### PR TITLE
fix(rust-system): R4 slice-2 — verified approval AUTHORIZES system intent; effect deferred (Unavailable), no faked completion (dark)

### DIFF
--- a/rust-core/crates/friday-hub/src/system_intent.rs
+++ b/rust-core/crates/friday-hub/src/system_intent.rs
@@ -44,7 +44,7 @@
 //! `workflow_catalog`). The live TS system-intent path stays fail-closed; this is
 //! ADDITIVE substrate, not a product cutover. NOT v1 GO.
 //!
-//! ## The verified-approval → Allow → EXECUTE happy path (R4 slice-2, DARK)
+//! ## The verified-approval → Allow → AUTHORIZE (effect deferred) path (R4 slice-2, DARK)
 //! [`SystemIntentEntrypoint::dispatch_with_approval`] is the system-intent analogue
 //! of the in-product `friday-hub::resume::resume_with_approval` (S6d). It INGESTS a
 //! canonical Ed25519 operator approval bound to the intent's action digest and
@@ -59,21 +59,28 @@
 //! Single-use is the shared `consumed_approval` replay store (the `ed25519:` keyspace);
 //! a replay is refused by the nonce PK collision (no new migration).
 //!
-//! On `Allow` the execute split is honest:
-//! * a CONTROL-PLANE op (`resume_task` — the UNIQUE mutating intent with NO
-//!   companion/desktop/exec effect in the TS oracle; its sole effect there is an
-//!   in-memory `activeTask` pointer + event emissions) completes the control-plane
-//!   ENVELOPE: the m0026 lease auto-acquire (a DB op = "lease acquire bookkeeping") and
-//!   a `completed` result. Its in-memory `activeTask` domain state is OUTSIDE the m0026
-//!   substrate and is a documented deferral — the `completed` here fakes NO OS effect
-//!   because `resume_task` HAS no OS effect, so the result message reflects the
-//!   control-plane completion, NOT a claim that `activeTask` was set.
-//! * an OS-AFFECTING op (`launch_app`/`open_url`/`close_app`/…/`recover_ui`) is STILL
+//! On `Allow` the execute is honest: EVERY protected mutating intent records
+//! `unavailable` (the [`UnavailableExecutor`] seam) even on a valid `Allow` — the
+//! verified approval AUTHORIZES the action, but the actual domain effect is NOT faked.
+//! There is NO control-plane-completes path in this slice. In particular:
+//! * `resume_task` is NOT a pure control-plane / no-effect op: in the TS oracle its
+//!   handler sets an in-memory `activeTask` pointer AND emits `system.task.updated`
+//!   and `system.intent.completed` (`friday-system-service.ts`, `case "resume_task"`).
+//!   The `system.task.updated` event is READ BACK via `findLatestEventByName`
+//!   (`friday-system-service.ts:421`), so the un-emitted event is an OBSERVABLE,
+//!   load-bearing divergence — not cosmetic in-memory state. Recording `completed`
+//!   here while performing NONE of those three effects would be a faked-complete, so
+//!   `resume_task` records `unavailable` + the [`UNIMPLEMENTED_EXECUTION_MARKER`]
+//!   (its `activeTask` + the two event emissions are an HONEST deferred AC) until a
+//!   real executor models them.
+//! * an OS-AFFECTING op (`launch_app`/`open_url`/`close_app`/…/`recover_ui`) is likewise
 //!   routed to the [`UnavailableExecutor`] and records `unavailable` even on a valid
-//!   `Allow` — the verified approval authorizes the action, but the OS effect is not
-//!   faked. (`recover_ui`'s TS handler revokes the lease AND hides the companion
+//!   `Allow`. (`recover_ui`'s TS handler revokes the lease AND hides the companion
 //!   overlay + reads companion status, so it is OS-affecting; completing it after only
 //!   the lease-revoke would fake the overlay effect — it stays `unavailable`.)
+//! * In all cases the m0026 control-lease IS auto-acquired on the `Allow` path (the TS
+//!   `ensureControlLease` ordering, universal to every mutating intent) — that DB
+//!   bookkeeping is real and not faked; only the domain effect is deferred.
 //!
 //! ## DEFERRED / UNIMPLEMENTED seams (explicitly NOT faked green)
 //! * **The actual OS effect** of every "do something to the desktop" action
@@ -86,8 +93,13 @@
 //!   `unavailable` result with the coarse marker
 //!   [`UNIMPLEMENTED_EXECUTION_MARKER`] — it NEVER records `completed` for an
 //!   effect it did not perform, EVEN on a valid operator `Allow`.
-//! * **`resume_task`'s in-memory `activeTask` domain state** is not modeled in the
-//!   dark m0026 substrate — only its control-plane envelope (the lease) completes.
+//! * **`resume_task`'s domain effect** — its in-memory `activeTask` pointer AND the
+//!   two event emissions (`system.task.updated` / `system.intent.completed`) — is not
+//!   modeled in the dark m0026 substrate. Because `system.task.updated` is read back
+//!   (`findLatestEventByName`), this is an OBSERVABLE divergence, so `resume_task`
+//!   stays `unavailable` on a valid `Allow` (only its lease auto-acquire is real) —
+//!   exactly as the OS-affecting actions do. This is an HONEST deferred AC, NOT a
+//!   faked-`completed`.
 //! * **`target_ref` digest binding for a future REAL executor** — `dispatch_with_approval`
 //!   binds `target_ref` into the canonical action digest (via the gate request's
 //!   `parameters`), so a single-use approval is scoped to THIS exact target. The
@@ -174,11 +186,14 @@ pub struct DispatchOutcome {
     pub execution_deferred: bool,
 }
 
-/// The boundary to the actual OS effect of a desktop-affecting action. The TS
-/// equivalent is the `companionBridge` / `desktopSessionManager` / `execCommand`
-/// surface. The ONLY provided impl is [`UnavailableExecutor`] (precedent: the TS
-/// `createFridaySystemUnavailableCompanionBridge`); a real impl (companion/Swift
-/// app / AppleScript) is out of scope for this dark slice.
+/// The boundary to the actual EFFECT of a protected action — the OS effect of a
+/// desktop-affecting action (the TS `companionBridge` / `desktopSessionManager` /
+/// `execCommand` surface) AND `resume_task`'s non-OS DOMAIN effect (its `activeTask`
+/// pointer + the `system.task.updated` / `system.intent.completed` emissions). Both are
+/// deferred through this one seam. The ONLY provided impl is [`UnavailableExecutor`]
+/// (precedent: the TS `createFridaySystemUnavailableCompanionBridge`); a real impl
+/// (companion/Swift app / AppleScript + the task-event emission) is out of scope for
+/// this dark slice.
 pub trait SystemActionExecutor {
     /// Attempt to perform `action`'s OS effect on `target_ref`. Returns the coarse
     /// outcome the result row records. A real executor returns `Completed`; the
@@ -194,10 +209,10 @@ pub struct ExecOutcome {
     pub message: String,
 }
 
-/// The DEFAULT executor: every desktop-affecting action is reported `unavailable`
-/// with the unimplemented marker. This is the honest dark-slice seam — it never
-/// fakes a `completed` effect. Mirrors the TS unavailable companion bridge used in
-/// the retirement-guard test.
+/// The DEFAULT executor: every protected action (desktop-affecting OR `resume_task`'s
+/// domain effect) is reported `unavailable` with the unimplemented marker. This is the
+/// honest dark-slice seam — it never fakes a `completed` effect. Mirrors the TS
+/// unavailable companion bridge used in the retirement-guard test.
 #[derive(Clone, Copy, Debug, Default)]
 pub struct UnavailableExecutor;
 
@@ -394,13 +409,15 @@ impl<E: SystemActionExecutor> SystemIntentEntrypoint<E> {
     /// On the decision:
     /// * NOT `Allow` (`Deny` / `RequiresApproval` — replay/expired/forged/HMAC/owner-denied/
     ///   no-approval) → a `blocked` result; NOTHING is executed.
-    /// * `Allow` + a CONTROL-PLANE op ([`is_control_plane`] — `resume_task`) → the
-    ///   m0026 lease auto-acquire (a DB op) and a `completed` result. NO OS effect is
-    ///   faked (a control-plane op has none).
-    /// * `Allow` + an OS-AFFECTING op (everything else, incl. `recover_ui`) → routed to
-    ///   the [`SystemActionExecutor`] (the [`UnavailableExecutor`] by default) and records
-    ///   `unavailable` with the unimplemented marker — the approval authorizes the action,
-    ///   but the OS effect is NOT faked-`completed`.
+    /// * `Allow` → the m0026 lease auto-acquire (a real DB op) followed by the
+    ///   [`SystemActionExecutor`] (the [`UnavailableExecutor`] by default). EVERY protected
+    ///   intent — `resume_task` included — records `unavailable` with the unimplemented
+    ///   marker: the approval authorizes the action, but the domain effect is NOT
+    ///   faked-`completed`. There is NO control-plane-completes path in this slice.
+    ///   (`resume_task`'s `activeTask` pointer + the `system.task.updated` /
+    ///   `system.intent.completed` emissions — the latter read back via
+    ///   `findLatestEventByName` — are an HONEST deferred AC; recording `completed` while
+    ///   performing none of them would be a faked-complete.)
     ///
     /// `operator_vk` MUST come from an operator-controlled source — this function only
     /// ever VERIFIES with it. DARK: no production route/flag/caller wires it.
@@ -491,49 +508,17 @@ impl<E: SystemActionExecutor> SystemIntentEntrypoint<E> {
             return self.persist_blocked(conn, input, message, Some(evidence.reason), now_ms);
         }
 
-        // (7) Allow → the honest execute split.
-        if is_control_plane(input.action) {
-            // CONTROL-PLANE op (resume_task): complete the control-plane ENVELOPE — the
-            // m0026 lease auto-acquire (a DB op = "lease acquire bookkeeping"). The
-            // in-memory `activeTask` domain state is OUTSIDE the substrate (deferred), so
-            // the message reflects the control-plane completion, NOT a claim activeTask was
-            // set — `completed` here fakes NO OS effect (a control-plane op has none).
-            let lease_id = match self.ensure_lease(conn, input, now_ms) {
-                Ok(id) => id,
-                Err(LeaseAcquireError::Busy {
-                    owner_kind,
-                    owner_id,
-                }) => {
-                    return self.persist_blocked(
-                        conn,
-                        input,
-                        format!(
-                            "control lease is currently held by {}:{}",
-                            owner_kind.as_str(),
-                            owner_id
-                        ),
-                        Some("system_control_busy".to_string()),
-                        now_ms,
-                    );
-                }
-                Err(LeaseAcquireError::Storage(e)) => return Err(SystemIntentError::Storage(e)),
-            };
-            return self.persist_result(
-                conn,
-                input,
-                IntentStatus::Completed,
-                "Control-plane intent approved and completed (lease acquired)".to_string(),
-                lease_id,
-                None,
-                now_ms,
-            );
-        }
-
-        // OS-AFFECTING op (incl. recover_ui): the approval authorizes the action, but the
-        // OS effect is DEFERRED — route through the executor (the unavailable seam by
-        // default) and record `unavailable`, NEVER a faked `completed`. We still
-        // auto-acquire the lease (the TS `ensureControlLease` ordering) so the future real
-        // executor slots in unchanged.
+        // (7) Allow → the honest execute. EVERY protected mutating intent (resume_task
+        //     included) records `unavailable`: the approval AUTHORIZES the action, but the
+        //     domain effect is DEFERRED, never faked-`completed`. There is NO
+        //     control-plane-completes path in this slice. `resume_task` is NOT a pure
+        //     no-effect op — its TS handler sets `activeTask` AND emits
+        //     `system.task.updated` (read back via `findLatestEventByName`) +
+        //     `system.intent.completed`; recording `completed` while performing none of
+        //     those would be a faked-complete (an OBSERVABLE divergence). Those effects are
+        //     an HONEST deferred AC, exactly like `recover_ui`'s overlay effect. We still
+        //     auto-acquire the lease (the universal TS `ensureControlLease` ordering, real
+        //     DB bookkeeping) so the future real executor slots in unchanged.
         let lease_id = match self.ensure_lease(conn, input, now_ms) {
             Ok(id) => id,
             Err(LeaseAcquireError::Busy {
@@ -826,22 +811,6 @@ fn is_mutating(action: IntentAction) -> bool {
             | IntentAction::Approve
             | IntentAction::Deny
     )
-}
-
-/// True for a CONTROL-PLANE mutating intent: one whose execute effect is a pure
-/// DB / control-plane op (the m0026 lease bookkeeping), with NO OS / companion /
-/// desktop effect to fake. On a verified-approval `Allow` such an op may complete.
-///
-/// `resume_task` is the UNIQUE such intent: in the TS oracle its sole effect is an
-/// in-memory `activeTask` pointer + event emissions (`friday-system-service.ts`,
-/// `case "resume_task"`) — NO `companionBridge` / `execCommand` / `desktopSessionManager`
-/// call. Every other mutating intent is OS-affecting (launch_app/open_url/close_app/
-/// focus/clipboard*/notification_act/handoff*/recover_ui — recover_ui revokes the lease
-/// but ALSO hides the companion overlay + reads companion status, so it is OS-affecting)
-/// or reserved (approve/deny, hard-Denied by the gate). Those stay `unavailable` on a
-/// valid `Allow` — the approval authorizes the action, but the OS effect is not faked.
-fn is_control_plane(action: IntentAction) -> bool {
-    matches!(action, IntentAction::ResumeTask)
 }
 
 /// The TS `resolveRiskLevel`: close_app/notification_act/clipboard_read = high;
@@ -1196,34 +1165,5 @@ mod tests {
         assert!(!is_mutating(IntentAction::NotificationList));
         assert!(!is_mutating(IntentAction::RequestControl));
         assert!(!is_mutating(IntentAction::ReleaseControl));
-    }
-
-    /// `is_control_plane` is `resume_task`-ONLY: every OS-affecting / reserved mutating
-    /// intent is NOT control-plane (so it can never complete-fake an OS effect). The
-    /// verified-approval → execute happy path itself (which must construct an operator
-    /// SIGNING key to play the offline operator) lives in `tests/r4s2_approval_execute.rs`
-    /// — the Hub crate source tree is forbidden from ever naming the operator's signing-key
-    /// type (the key-substitution defense, the `operator_vk` hub-never-references guard).
-    #[test]
-    fn is_control_plane_is_resume_task_only() {
-        assert!(is_control_plane(IntentAction::ResumeTask));
-        for a in [
-            IntentAction::LaunchApp,
-            IntentAction::CloseApp,
-            IntentAction::OpenUrl,
-            IntentAction::Open,
-            IntentAction::Focus,
-            IntentAction::ArrangeWindows,
-            IntentAction::ClipboardRead,
-            IntentAction::ClipboardWrite,
-            IntentAction::NotificationAct,
-            IntentAction::HandoffToBrowser,
-            IntentAction::HandoffToTerminal,
-            IntentAction::RecoverUi,
-            IntentAction::Approve,
-            IntentAction::Deny,
-        ] {
-            assert!(!is_control_plane(a), "{a:?} must NOT be control-plane");
-        }
     }
 }

--- a/rust-core/crates/friday-hub/src/system_intent.rs
+++ b/rust-core/crates/friday-hub/src/system_intent.rs
@@ -44,26 +44,63 @@
 //! `workflow_catalog`). The live TS system-intent path stays fail-closed; this is
 //! ADDITIVE substrate, not a product cutover. NOT v1 GO.
 //!
+//! ## The verified-approval → Allow → EXECUTE happy path (R4 slice-2, DARK)
+//! [`SystemIntentEntrypoint::dispatch_with_approval`] is the system-intent analogue
+//! of the in-product `friday-hub::resume::resume_with_approval` (S6d). It INGESTS a
+//! canonical Ed25519 operator approval bound to the intent's action digest and
+//! COMPOSES (never re-implements) the proven verify-only policy
+//! `friday_storage::authorize_mutating_action_ed25519`: `friday_core::gate::evaluate`
+//! still cannot grant a mutating action, but a base `RequiresApproval` is upgraded to
+//! `Allow` ONLY by an operator-signed, digest-bound, unexpired, single-use approval.
+//! The Hub holds ONLY the operator's PUBLIC verify key (`OperatorVerifyingKey`), so
+//! agent/channel/remote can NEVER self-mint — and the reserved-action hard-`Deny`
+//! (an Agent/Channel doing `approve`/`deny`) is decided by the gate BEFORE any
+//! signature is examined, so it survives even a perfectly-valid operator approval.
+//! Single-use is the shared `consumed_approval` replay store (the `ed25519:` keyspace);
+//! a replay is refused by the nonce PK collision (no new migration).
+//!
+//! On `Allow` the execute split is honest:
+//! * a CONTROL-PLANE op (`resume_task` — the UNIQUE mutating intent with NO
+//!   companion/desktop/exec effect in the TS oracle; its sole effect there is an
+//!   in-memory `activeTask` pointer + event emissions) completes the control-plane
+//!   ENVELOPE: the m0026 lease auto-acquire (a DB op = "lease acquire bookkeeping") and
+//!   a `completed` result. Its in-memory `activeTask` domain state is OUTSIDE the m0026
+//!   substrate and is a documented deferral — the `completed` here fakes NO OS effect
+//!   because `resume_task` HAS no OS effect, so the result message reflects the
+//!   control-plane completion, NOT a claim that `activeTask` was set.
+//! * an OS-AFFECTING op (`launch_app`/`open_url`/`close_app`/…/`recover_ui`) is STILL
+//!   routed to the [`UnavailableExecutor`] and records `unavailable` even on a valid
+//!   `Allow` — the verified approval authorizes the action, but the OS effect is not
+//!   faked. (`recover_ui`'s TS handler revokes the lease AND hides the companion
+//!   overlay + reads companion status, so it is OS-affecting; completing it after only
+//!   the lease-revoke would fake the overlay effect — it stays `unavailable`.)
+//!
 //! ## DEFERRED / UNIMPLEMENTED seams (explicitly NOT faked green)
 //! * **The actual OS effect** of every "do something to the desktop" action
 //!   (launch_app/open_url/close_app/focus/clipboard*/notification*/handoff*/
-//!   arrange_windows/snapshot) — i.e. the TS `executeIntentInternal` switch
+//!   arrange_windows/recover_ui/snapshot) — i.e. the TS `executeIntentInternal` switch
 //!   bodies that call `execCommand` / `companionBridge` / `desktopSessionManager`.
 //!   Here those route to the [`SystemActionExecutor`] trait, whose only provided
 //!   impl is [`UnavailableExecutor`] (the precedent is the TS
 //!   `createFridaySystemUnavailableCompanionBridge`). A deferred action records a
 //!   `unavailable` result with the coarse marker
 //!   [`UNIMPLEMENTED_EXECUTION_MARKER`] — it NEVER records `completed` for an
-//!   effect it did not perform.
-//! * **The verified canonical approval → Allow → EXECUTE happy path** for a
-//!   mutating intent. `friday_core::gate::evaluate` cannot grant a mutating action;
-//!   the upgrade lives in `friday-storage::authorize_mutating_action` (PR-3b). This
-//!   module wires only the fail-closed BLOCK path (which is what "fail-closed"
-//!   requires); composing the verified-approval execute path is a documented
-//!   follow-on seam (an Allow would, today, hit the unavailable executor anyway).
+//!   effect it did not perform, EVEN on a valid operator `Allow`.
+//! * **`resume_task`'s in-memory `activeTask` domain state** is not modeled in the
+//!   dark m0026 substrate — only its control-plane envelope (the lease) completes.
+//! * **`target_ref` digest binding for a future REAL executor** — `dispatch_with_approval`
+//!   binds `target_ref` into the canonical action digest (via the gate request's
+//!   `parameters`), so a single-use approval is scoped to THIS exact target. The
+//!   `classify`-derived `Resource` (path/target/file) escalation is NOT exercised here
+//!   (a coarse `target_ref` is not a filesystem path); a real OS executor that needs
+//!   resource-scoped risk escalation is an explicit deferred AC.
 
-use friday_core::gate::{self, Actor, ActorKind, GateDecision, MutatingActionRequest};
+use friday_core::gate::{
+    self, Actor, ActorKind, CanonicalApproval, GateDecision, MutatingActionRequest,
+};
 use friday_core::Risk;
+use friday_crypto::OperatorVerifyingKey;
+use friday_storage::authorize_mutating_action_ed25519;
 use friday_storage::system_intent::{
     acquire_control_lease, insert_approval_record, insert_intent_request, insert_intent_result,
     normalize_active_lease, revoke_active_lease, ApprovalRecord, DecisionLabel, IntentAction,
@@ -339,6 +376,205 @@ impl<E: SystemActionExecutor> SystemIntentEntrypoint<E> {
         })
     }
 
+    /// Dispatch a system intent WITH a canonical Ed25519 operator approval — the
+    /// verified-approval → `Allow` → EXECUTE happy path (R4 slice-2, DARK). The
+    /// system-intent analogue of `friday-hub::resume::resume_with_approval` (S6d).
+    ///
+    /// It COMPOSES (never re-implements) the proven verify-only policy: the same
+    /// fail-closed front (flag, validate, persist REQUEST) as [`dispatch`], then
+    /// [`authorize_mutating_action_ed25519`] is the SOLE authority — `friday_core::gate`
+    /// is unchanged, and a base `Allow`/`Deny` (incl. the reserved-action hard-`Deny`
+    /// for an Agent/Channel doing `approve`/`deny`) is FINAL and never consults the
+    /// approval or the replay store. Only a base `RequiresApproval` (a mutating /
+    /// high-risk action) can be upgraded to `Allow`, and ONLY by an operator-signed,
+    /// digest-bound, unexpired, single-use approval verified under `operator_vk` (the
+    /// PUBLIC key the Hub holds — it can verify but never mint). The decision is
+    /// persisted as a durable approval-record.
+    ///
+    /// On the decision:
+    /// * NOT `Allow` (`Deny` / `RequiresApproval` — replay/expired/forged/HMAC/owner-denied/
+    ///   no-approval) → a `blocked` result; NOTHING is executed.
+    /// * `Allow` + a CONTROL-PLANE op ([`is_control_plane`] — `resume_task`) → the
+    ///   m0026 lease auto-acquire (a DB op) and a `completed` result. NO OS effect is
+    ///   faked (a control-plane op has none).
+    /// * `Allow` + an OS-AFFECTING op (everything else, incl. `recover_ui`) → routed to
+    ///   the [`SystemActionExecutor`] (the [`UnavailableExecutor`] by default) and records
+    ///   `unavailable` with the unimplemented marker — the approval authorizes the action,
+    ///   but the OS effect is NOT faked-`completed`.
+    ///
+    /// `operator_vk` MUST come from an operator-controlled source — this function only
+    /// ever VERIFIES with it. DARK: no production route/flag/caller wires it.
+    pub fn dispatch_with_approval(
+        &self,
+        conn: &Connection,
+        input: &IntentInput,
+        approval: &CanonicalApproval,
+        operator_vk: &OperatorVerifyingKey,
+        now_ms: i64,
+    ) -> Result<DispatchOutcome> {
+        // (1) Flag fail-closed — BEFORE any side effect, mirroring [`dispatch`] and the
+        //     TS method guard.
+        if !self.enabled {
+            return Err(SystemIntentError::FailClosed);
+        }
+
+        // (2) Validate (fail-closed) — never persist/execute an invalid input.
+        self.validate(input)?;
+
+        let mutating = is_mutating(input.action);
+        let risk = resolve_risk(input.action);
+
+        // (2b) Contract guard (fail-closed): the approval-ingestion entrypoint is ONLY for
+        //      a PROTECTED intent — one the gate would base-`RequiresApproval` (mutating, or
+        //      high-risk). A non-protected action (a would-base-`Allow` read-only/low-risk
+        //      op, or a lease-lifecycle `request_control`/`release_control`) does not belong
+        //      here: it is dispatched via [`dispatch`], not approved. Refusing it as `Invalid`
+        //      BEFORE any side effect keeps the contract tight and avoids the slice-1
+        //      divergence where a non-mutating action would auto-acquire a lease on this path.
+        if !(mutating || risk >= Risk::High) {
+            return Err(SystemIntentError::Invalid(format!(
+                "{} is not a protected intent; the approval-ingestion path is for mutating/high-risk intents only (use dispatch)",
+                input.action.as_str()
+            )));
+        }
+
+        // (3) Persist the immutable REQUEST record.
+        let request = IntentRequest {
+            intent_id: input.intent_id.clone(),
+            action: input.action,
+            actor_id: input.actor_id.clone(),
+            actor_kind: input.actor_kind,
+            target_ref: input.target_ref.clone(),
+            mutating,
+            risk: risk_label(risk),
+            created_at: now_ms,
+        };
+        insert_intent_request(conn, &request)?;
+
+        // (4) The verify-only policy is the SOLE authority. It runs `gate::evaluate`
+        //     internally (so the reserved-action hard-Deny for an Agent/Channel is decided
+        //     BEFORE the signature is examined), upgrades ONLY a base RequiresApproval to
+        //     Allow for an operator-signed/digest-bound/unexpired/single-use approval, and
+        //     CONSUMES the nonce on grant. `friday_core::gate` is unchanged.
+        let gate_request = build_gate_request(input, mutating, risk);
+        let evidence = authorize_mutating_action_ed25519(
+            conn,
+            &gate_request,
+            Some(approval),
+            operator_vk,
+            now_ms,
+        )?;
+
+        // (5) Persist the gate decision as durable approval-record evidence (refs-only).
+        insert_approval_record(
+            conn,
+            &ApprovalRecord {
+                record_id: format!("{}::approval", input.intent_id),
+                intent_id: input.intent_id.clone(),
+                action: input.action,
+                decision: decision_label(evidence.decision),
+                reason: evidence.reason.clone(),
+                risk: risk_label(evidence.risk),
+                approval_required: evidence.approval_required,
+                created_at: now_ms,
+            },
+        )?;
+
+        // (6) NOT Allow → blocked; NOTHING is executed (replay/expired/forged/HMAC/
+        //     owner-denied/reserved-action/no-approval all land here).
+        if evidence.decision != GateDecision::Allow {
+            let message = format!(
+                "Approval did not grant {}: {}",
+                input.action.as_str(),
+                evidence.reason
+            );
+            return self.persist_blocked(conn, input, message, Some(evidence.reason), now_ms);
+        }
+
+        // (7) Allow → the honest execute split.
+        if is_control_plane(input.action) {
+            // CONTROL-PLANE op (resume_task): complete the control-plane ENVELOPE — the
+            // m0026 lease auto-acquire (a DB op = "lease acquire bookkeeping"). The
+            // in-memory `activeTask` domain state is OUTSIDE the substrate (deferred), so
+            // the message reflects the control-plane completion, NOT a claim activeTask was
+            // set — `completed` here fakes NO OS effect (a control-plane op has none).
+            let lease_id = match self.ensure_lease(conn, input, now_ms) {
+                Ok(id) => id,
+                Err(LeaseAcquireError::Busy {
+                    owner_kind,
+                    owner_id,
+                }) => {
+                    return self.persist_blocked(
+                        conn,
+                        input,
+                        format!(
+                            "control lease is currently held by {}:{}",
+                            owner_kind.as_str(),
+                            owner_id
+                        ),
+                        Some("system_control_busy".to_string()),
+                        now_ms,
+                    );
+                }
+                Err(LeaseAcquireError::Storage(e)) => return Err(SystemIntentError::Storage(e)),
+            };
+            return self.persist_result(
+                conn,
+                input,
+                IntentStatus::Completed,
+                "Control-plane intent approved and completed (lease acquired)".to_string(),
+                lease_id,
+                None,
+                now_ms,
+            );
+        }
+
+        // OS-AFFECTING op (incl. recover_ui): the approval authorizes the action, but the
+        // OS effect is DEFERRED — route through the executor (the unavailable seam by
+        // default) and record `unavailable`, NEVER a faked `completed`. We still
+        // auto-acquire the lease (the TS `ensureControlLease` ordering) so the future real
+        // executor slots in unchanged.
+        let lease_id = match self.ensure_lease(conn, input, now_ms) {
+            Ok(id) => id,
+            Err(LeaseAcquireError::Busy {
+                owner_kind,
+                owner_id,
+            }) => {
+                return self.persist_blocked(
+                    conn,
+                    input,
+                    format!(
+                        "control lease is currently held by {}:{}",
+                        owner_kind.as_str(),
+                        owner_id
+                    ),
+                    Some("system_control_busy".to_string()),
+                    now_ms,
+                );
+            }
+            Err(LeaseAcquireError::Storage(e)) => return Err(SystemIntentError::Storage(e)),
+        };
+        let exec = self
+            .executor
+            .execute(input.action, input.target_ref.as_deref());
+        let execution_deferred = exec.status == IntentStatus::Unavailable
+            && exec.message == UNIMPLEMENTED_EXECUTION_MARKER;
+        let result = IntentResultRecord {
+            intent_id: input.intent_id.clone(),
+            action: input.action,
+            status: exec.status,
+            message: exec.message,
+            control_lease_id: lease_id,
+            gate_reason: None,
+            created_at: now_ms,
+        };
+        insert_intent_result(conn, &result)?;
+        Ok(DispatchOutcome {
+            result,
+            execution_deferred,
+        })
+    }
+
     // ─── internals ────────────────────────────────────────────────────────────
 
     fn validate(&self, input: &IntentInput) -> Result<()> {
@@ -592,6 +828,22 @@ fn is_mutating(action: IntentAction) -> bool {
     )
 }
 
+/// True for a CONTROL-PLANE mutating intent: one whose execute effect is a pure
+/// DB / control-plane op (the m0026 lease bookkeeping), with NO OS / companion /
+/// desktop effect to fake. On a verified-approval `Allow` such an op may complete.
+///
+/// `resume_task` is the UNIQUE such intent: in the TS oracle its sole effect is an
+/// in-memory `activeTask` pointer + event emissions (`friday-system-service.ts`,
+/// `case "resume_task"`) — NO `companionBridge` / `execCommand` / `desktopSessionManager`
+/// call. Every other mutating intent is OS-affecting (launch_app/open_url/close_app/
+/// focus/clipboard*/notification_act/handoff*/recover_ui — recover_ui revokes the lease
+/// but ALSO hides the companion overlay + reads companion status, so it is OS-affecting)
+/// or reserved (approve/deny, hard-Denied by the gate). Those stay `unavailable` on a
+/// valid `Allow` — the approval authorizes the action, but the OS effect is not faked.
+fn is_control_plane(action: IntentAction) -> bool {
+    matches!(action, IntentAction::ResumeTask)
+}
+
 /// The TS `resolveRiskLevel`: close_app/notification_act/clipboard_read = high;
 /// clipboard_write/launch_app = medium; everything else = low.
 fn resolve_risk(action: IntentAction) -> Risk {
@@ -648,19 +900,42 @@ fn build_gate_request(input: &IntentInput, mutating: bool, risk: Risk) -> Mutati
     };
     // The classification is sealed (built via `classify`), so the gate-decision trio
     // can only come from here — no struct-literal can assert `mutating: false` for a
-    // mutating action. We pass no params (the target is a coarse ref, not a path the
-    // classifier escalates on); the base risk carries the TS-resolved risk.
+    // mutating action. We pass no params to `classify` (the target is a coarse ref, not
+    // a filesystem path the classifier escalates risk on); the base risk carries the
+    // TS-resolved risk. The `target_ref` IS bound into the canonical action digest via
+    // the request's `parameters` (below) — separate from `classify`, so it scopes a
+    // single-use approval to THIS exact target WITHOUT changing the gate DECISION or
+    // risk (the digest distinguishes one authorized action from another).
     let classification = gate::classify(mutating, risk, input.action.as_str(), &[]);
+    let parameters = input
+        .target_ref
+        .as_deref()
+        .map(|t| format!("target_ref={t}"));
     MutatingActionRequest::from_classification(
         classification,
         input.action.as_str().to_string(),
         actor,
         "system".to_string(),
         Vec::new(),
-        None,
+        parameters,
         None,
         None,
     )
+}
+
+/// The canonical action DIGEST an operator must sign to approve `input` — the exact
+/// binding [`SystemIntentEntrypoint::dispatch_with_approval`] verifies against (the
+/// hex SHA-256 of the gate request's `canonical_action_bytes`, transitively binding
+/// action / actor / principal / surface / derived-risk / `target_ref`). This is the
+/// system-intent analogue of the `PendingApprovalRequest` binding an operator signs in
+/// S6: an off-Hub operator computes this digest, signs it with their OFFLINE private
+/// key, and the Hub (holding only the PUBLIC verify key) accepts the resulting approval
+/// for exactly this action. Exposed so the dark approval-ingestion seam can be exercised
+/// end-to-end from a `tests/` integration test WITHOUT the test naming any Hub internal
+/// (and without the Hub ever holding a signing key).
+pub fn intent_action_digest(input: &IntentInput) -> String {
+    let request = build_gate_request(input, is_mutating(input.action), resolve_risk(input.action));
+    friday_crypto::action_digest(&gate::canonical_action_bytes(&request))
 }
 
 #[cfg(test)]
@@ -921,5 +1196,34 @@ mod tests {
         assert!(!is_mutating(IntentAction::NotificationList));
         assert!(!is_mutating(IntentAction::RequestControl));
         assert!(!is_mutating(IntentAction::ReleaseControl));
+    }
+
+    /// `is_control_plane` is `resume_task`-ONLY: every OS-affecting / reserved mutating
+    /// intent is NOT control-plane (so it can never complete-fake an OS effect). The
+    /// verified-approval → execute happy path itself (which must construct an operator
+    /// SIGNING key to play the offline operator) lives in `tests/r4s2_approval_execute.rs`
+    /// — the Hub crate source tree is forbidden from ever naming the operator's signing-key
+    /// type (the key-substitution defense, the `operator_vk` hub-never-references guard).
+    #[test]
+    fn is_control_plane_is_resume_task_only() {
+        assert!(is_control_plane(IntentAction::ResumeTask));
+        for a in [
+            IntentAction::LaunchApp,
+            IntentAction::CloseApp,
+            IntentAction::OpenUrl,
+            IntentAction::Open,
+            IntentAction::Focus,
+            IntentAction::ArrangeWindows,
+            IntentAction::ClipboardRead,
+            IntentAction::ClipboardWrite,
+            IntentAction::NotificationAct,
+            IntentAction::HandoffToBrowser,
+            IntentAction::HandoffToTerminal,
+            IntentAction::RecoverUi,
+            IntentAction::Approve,
+            IntentAction::Deny,
+        ] {
+            assert!(!is_control_plane(a), "{a:?} must NOT be control-plane");
+        }
     }
 }

--- a/rust-core/crates/friday-hub/tests/r4s2_approval_execute.rs
+++ b/rust-core/crates/friday-hub/tests/r4s2_approval_execute.rs
@@ -1,0 +1,506 @@
+//! R4 slice-2 adversarial suite — the verified-approval → Allow → EXECUTE happy path
+//! for system-intent (DARK), the system-intent analogue of the S6d resume suite.
+//!
+//! This lives in `tests/` (NOT `src/`) for the SAME reason `s6d_resume_ingestion.rs`
+//! does: it must construct an operator SIGNING key to play the offline operator, and
+//! `friday-hub/src/**` is forbidden from ever naming `OperatorSigningKey` (the
+//! key-substitution defense, asserted by
+//! `operator_vk::tests::hub_crate_never_references_a_signing_key`). The Hub never holds
+//! a signing key; here the TEST holds it, exactly as the real operator does off-Hub.
+//!
+//! The security core proven here:
+//!   * a verified operator-Ed25519 approval is the ONLY path that upgrades a mutating
+//!     system intent to Allow → execute (the Hub holds only the PUBLIC verify key —
+//!     it can never self-mint);
+//!   * single-use: a replay of the same approval is refused (the `consumed_approval`
+//!     nonce PK collision), so a control-plane op does NOT complete twice;
+//!   * the DOWNGRADE defense: an HMAC-signed approval over the SAME canonical bytes
+//!     (what a self-minting Hub holding the symmetric secret would produce) is rejected;
+//!   * NEVER self-mintable: an Agent / Remote actor (the untrusted `OwnerKind`s this
+//!     entrypoint can produce — both map to the gate's bound `Agent`) doing a reserved
+//!     approve/deny is a hard-Deny EVEN with a perfectly-valid operator approval (the
+//!     reserved-action rule is decided before the signature is examined). The `Channel`
+//!     binding is a gate-LEVEL property (`OwnerKind` has no Channel variant, so it is not
+//!     representable here) and is covered by `friday-core::gate`'s own suite;
+//!   * the HONESTY split: a CONTROL-PLANE op (`resume_task`) completes; an OS-affecting
+//!     op (launch_app / recover_ui) stays `unavailable` even on a valid Allow — the OS
+//!     effect is NEVER faked-`completed`.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use friday_core::gate::{
+    canonical_approval_signature_bytes, ApprovalDecision, CanonicalApproval, CANONICAL_GATE_ISSUER,
+};
+use friday_crypto::{OperatorSigningKey, OperatorVerifyingKey};
+use friday_hub::system_intent::{
+    intent_action_digest, DispatchOutcome, IntentInput, SystemIntentEntrypoint,
+    UnavailableExecutor, UNIMPLEMENTED_EXECUTION_MARKER,
+};
+use friday_storage::system_intent::{
+    get_intent_result, get_lease, list_approval_records, DecisionLabel, IntentAction, IntentStatus,
+    OwnerKind,
+};
+use friday_storage::Db;
+
+/// The HMAC secret a self-minting Hub would hold (the symmetric mint==verify key). The
+/// verify-only Ed25519 path must make this irrelevant for a protected action.
+const HUB_HMAC_SECRET: &[u8] = b"hub-held-hmac-gate-secret-0123456789";
+const NOW: i64 = 1_000;
+const FUTURE: i64 = 2_000;
+
+static C: AtomicU64 = AtomicU64::new(0);
+fn tmp(tag: &str) -> String {
+    std::env::temp_dir()
+        .join(format!(
+            "friday-r4s2-{}-{}-{}.sqlite",
+            std::process::id(),
+            tag,
+            C.fetch_add(1, Ordering::Relaxed)
+        ))
+        .to_string_lossy()
+        .into_owned()
+}
+
+fn operator() -> (OperatorSigningKey, OperatorVerifyingKey) {
+    let sk = OperatorSigningKey::generate();
+    let vk = sk.verifying_key();
+    (sk, vk)
+}
+
+fn input(intent_id: &str, action: IntentAction, actor: &str, kind: OwnerKind) -> IntentInput {
+    IntentInput {
+        intent_id: intent_id.to_string(),
+        action,
+        actor_id: actor.to_string(),
+        actor_kind: kind,
+        target_ref: None,
+        reason: None,
+        lease_ttl_ms: None,
+    }
+}
+
+/// `resume_task` (the unique control-plane / OS-free mutating intent). It requires a
+/// `target_ref` (the task value), which is bound into the canonical action digest.
+fn resume_task_input(id: &str, value: &str) -> IntentInput {
+    let mut inp = input(id, IntentAction::ResumeTask, "api-1", OwnerKind::Api);
+    inp.target_ref = Some(value.to_string());
+    inp
+}
+
+/// A correctly-signed, digest-bound, future-dated operator Ed25519 approval for `inp`.
+/// The digest is the PUBLIC `intent_action_digest` binding — exactly what the dispatch
+/// path verifies — so the test never touches a Hub internal.
+fn ed25519_approval(
+    inp: &IntentInput,
+    sk: &OperatorSigningKey,
+    approval_id: &str,
+    expires_at: Option<i64>,
+) -> CanonicalApproval {
+    let mut a = CanonicalApproval {
+        decision: ApprovalDecision::Approved,
+        approval_id: approval_id.to_string(),
+        action_digest: intent_action_digest(inp),
+        expires_at,
+        issuer: Some(CANONICAL_GATE_ISSUER.to_string()),
+        signature: None,
+    };
+    a.signature = Some(sk.sign(&canonical_approval_signature_bytes(&a)).to_hex());
+    a
+}
+
+/// A digest-bound approval signed with the HUB-held HMAC secret — exactly what a
+/// self-minting Hub would produce over the SAME canonical bytes.
+fn hmac_approval(inp: &IntentInput, approval_id: &str) -> CanonicalApproval {
+    let mut a = CanonicalApproval {
+        decision: ApprovalDecision::Approved,
+        approval_id: approval_id.to_string(),
+        action_digest: intent_action_digest(inp),
+        expires_at: Some(FUTURE),
+        issuer: Some(CANONICAL_GATE_ISSUER.to_string()),
+        signature: None,
+    };
+    a.signature = Some(friday_crypto::sign_approval(
+        &canonical_approval_signature_bytes(&a),
+        HUB_HMAC_SECRET,
+    ));
+    a
+}
+
+fn consumed_count(db: &Db) -> i64 {
+    db.conn()
+        .query_row("SELECT count(*) FROM consumed_approval", [], |r| r.get(0))
+        .unwrap()
+}
+
+fn enabled_ep() -> SystemIntentEntrypoint<UnavailableExecutor> {
+    SystemIntentEntrypoint::with_execution_enabled(UnavailableExecutor)
+}
+
+/// THE HAPPY PATH: a control-plane intent (`resume_task`) + a valid operator Ed25519
+/// approval → Allow → `completed`, with the m0026 control-lease actually acquired and the
+/// approval-record decision = Allow. Exactly one nonce is consumed.
+#[test]
+fn control_plane_resume_task_with_valid_approval_completes() {
+    let db = Db::open_hub(&tmp("cp-happy")).unwrap();
+    let ep = enabled_ep();
+    let (sk, vk) = operator();
+    let inp = resume_task_input("i-rt", "follow_up_email");
+    let approval = ed25519_approval(&inp, &sk, "ap-rt-1", Some(FUTURE));
+
+    let outcome: DispatchOutcome = ep
+        .dispatch_with_approval(db.conn(), &inp, &approval, &vk, NOW)
+        .unwrap();
+    assert_eq!(
+        outcome.result.status,
+        IntentStatus::Completed,
+        "an approved control-plane intent completes"
+    );
+    assert!(
+        !outcome.execution_deferred,
+        "a control-plane completion is not the deferred-OS seam"
+    );
+    // The completion message reflects the control-plane envelope, NOT a claim that the
+    // (deferred) in-memory activeTask domain state was set.
+    assert!(outcome
+        .result
+        .message
+        .contains("Control-plane intent approved"));
+    assert!(!outcome.result.message.contains("Active task set"));
+    // The m0026 lease was actually acquired (the control-plane DB op).
+    let lease_id = outcome.result.control_lease_id.clone().unwrap();
+    let lease = get_lease(db.conn(), &lease_id).unwrap().unwrap();
+    assert_eq!(lease.owner_id, "api-1");
+    assert!(lease.revoked_at.is_none(), "the lease is active");
+    // The approval-record proves the verified Allow.
+    let trail = list_approval_records(db.conn(), "i-rt").unwrap();
+    assert_eq!(trail.len(), 1);
+    assert_eq!(trail[0].decision, DecisionLabel::Allow);
+    assert_eq!(trail[0].reason, "canonical_approval_granted");
+    assert_eq!(consumed_count(&db), 1);
+    assert_eq!(
+        get_intent_result(db.conn(), "i-rt")
+            .unwrap()
+            .unwrap()
+            .status,
+        IntentStatus::Completed
+    );
+}
+
+/// THE HONESTY CONTRAST: an OS-affecting intent (`launch_app`) + a *valid* operator
+/// approval → Allow, but the result is STILL `unavailable`, NOT `completed`. A legitimate
+/// Allow does NOT fake an OS effect.
+#[test]
+fn os_affecting_with_valid_approval_is_allowed_but_still_unavailable_not_completed() {
+    let db = Db::open_hub(&tmp("os-unavail")).unwrap();
+    let ep = enabled_ep();
+    let (sk, vk) = operator();
+    let mut inp = input("i-launch", IntentAction::LaunchApp, "api-1", OwnerKind::Api);
+    inp.target_ref = Some("com.apple.Safari".to_string());
+    let approval = ed25519_approval(&inp, &sk, "ap-launch-1", Some(FUTURE));
+
+    let outcome = ep
+        .dispatch_with_approval(db.conn(), &inp, &approval, &vk, NOW)
+        .unwrap();
+    assert_eq!(
+        outcome.result.status,
+        IntentStatus::Unavailable,
+        "a valid Allow does NOT fake the OS effect"
+    );
+    assert_ne!(outcome.result.status, IntentStatus::Completed);
+    assert_eq!(outcome.result.message, UNIMPLEMENTED_EXECUTION_MARKER);
+    assert!(outcome.execution_deferred);
+    // The approval WAS verified-Allow (the action was authorized) and the nonce WAS
+    // consumed — the deferral is the executor's, not the gate's.
+    let trail = list_approval_records(db.conn(), "i-launch").unwrap();
+    assert_eq!(trail[0].decision, DecisionLabel::Allow);
+    assert_eq!(consumed_count(&db), 1);
+}
+
+/// `recover_ui` is OS-affecting (its TS handler hides the companion overlay + reads
+/// companion status, beyond the lease-revoke) → even with a valid approval it stays
+/// `unavailable`, never faked-`completed` from only the lease leg.
+#[test]
+fn recover_ui_with_valid_approval_stays_unavailable_not_completed() {
+    let db = Db::open_hub(&tmp("recover-unavail")).unwrap();
+    let ep = enabled_ep();
+    let (sk, vk) = operator();
+    let inp = input(
+        "i-recover",
+        IntentAction::RecoverUi,
+        "api-1",
+        OwnerKind::Api,
+    );
+    let approval = ed25519_approval(&inp, &sk, "ap-recover-1", Some(FUTURE));
+
+    let outcome = ep
+        .dispatch_with_approval(db.conn(), &inp, &approval, &vk, NOW)
+        .unwrap();
+    assert_eq!(outcome.result.status, IntentStatus::Unavailable);
+    assert_ne!(outcome.result.status, IntentStatus::Completed);
+    assert!(outcome.execution_deferred);
+}
+
+/// Single-use: a second dispatch with the SAME approval is replay-refused (the nonce PK
+/// collision in consumed_approval), so the control-plane op does NOT complete twice.
+#[test]
+fn replay_of_same_approval_is_refused_and_does_not_complete_twice() {
+    let db = Db::open_hub(&tmp("replay")).unwrap();
+    let ep = enabled_ep();
+    let (sk, vk) = operator();
+    let inp1 = resume_task_input("i-r1", "task_a");
+    let approval = ed25519_approval(&inp1, &sk, "ap-replay", Some(FUTURE));
+
+    // First use: completes.
+    let o1 = ep
+        .dispatch_with_approval(db.conn(), &inp1, &approval, &vk, NOW)
+        .unwrap();
+    assert_eq!(o1.result.status, IntentStatus::Completed);
+    assert_eq!(consumed_count(&db), 1);
+
+    // Second use of the SAME approval nonce on a FRESH intent_id (same task value, so the
+    // digest still matches): replay-refused → blocked, NOT a second completion.
+    let inp2 = resume_task_input("i-r2", "task_a");
+    let o2 = ep
+        .dispatch_with_approval(db.conn(), &inp2, &approval, &vk, NOW)
+        .unwrap();
+    assert_eq!(
+        o2.result.status,
+        IntentStatus::Blocked,
+        "a replayed approval must not complete a second time"
+    );
+    assert_eq!(
+        o2.result.gate_reason.as_deref(),
+        Some("canonical_approval_replay_refused")
+    );
+    assert_eq!(consumed_count(&db), 1, "replay consumes no second nonce");
+}
+
+/// THE DOWNGRADE DEFENSE: an HMAC-signed approval over the SAME canonical bytes is
+/// REJECTED for the protected control-plane action — it does NOT complete. Non-vacuous:
+/// the same intent with a real operator Ed25519 signature DOES complete.
+#[test]
+fn hmac_signed_approval_is_rejected_downgrade_defense() {
+    let db = Db::open_hub(&tmp("downgrade")).unwrap();
+    let ep = enabled_ep();
+    let (sk, vk) = operator();
+    let inp = resume_task_input("i-hmac", "task_b");
+
+    // HMAC approval → rejected (no HMAC code path; verified as Ed25519 under vk).
+    let hmac = hmac_approval(&inp, "ap-hmac");
+    let blocked = ep
+        .dispatch_with_approval(db.conn(), &inp, &hmac, &vk, NOW)
+        .unwrap();
+    assert_eq!(
+        blocked.result.status,
+        IntentStatus::Blocked,
+        "an HMAC-signed approval must NOT Allow a protected action"
+    );
+    assert_eq!(
+        blocked.result.gate_reason.as_deref(),
+        Some("canonical_approval_signature_invalid")
+    );
+    assert_eq!(consumed_count(&db), 0, "a rejected approval burns no nonce");
+
+    // Non-vacuous: the SAME intent, properly Ed25519-signed by the operator, completes.
+    let inp2 = resume_task_input("i-hmac2", "task_b");
+    let good = ed25519_approval(&inp2, &sk, "ap-good", Some(FUTURE));
+    let ok = ep
+        .dispatch_with_approval(db.conn(), &inp2, &good, &vk, NOW)
+        .unwrap();
+    assert_eq!(ok.result.status, IntentStatus::Completed);
+    assert_eq!(consumed_count(&db), 1);
+}
+
+/// NEVER self-mintable: an Agent/remote actor doing a reserved action (`approve`/`deny`)
+/// is a hard-`Deny` EVEN with a perfectly-valid, digest-bound operator approval — the
+/// gate's reserved-action rule is decided before the signature is examined. NOTHING
+/// completes; no nonce is consumed.
+#[test]
+fn untrusted_actor_cannot_self_approve_reserved_action_even_with_valid_approval() {
+    let db = Db::open_hub(&tmp("self-approve")).unwrap();
+    let ep = enabled_ep();
+    let (sk, vk) = operator();
+
+    for (kind, tag) in [(OwnerKind::Agent, "ag"), (OwnerKind::Remote, "rm")] {
+        for action in [IntentAction::Approve, IntentAction::Deny] {
+            let id = format!("i-{tag}-{}", action.as_str());
+            let mut inp = input(&id, action, "untrusted-1", kind);
+            inp.target_ref = Some("close_app".to_string());
+            // A valid operator approval bound to THIS exact request.
+            let approval = ed25519_approval(&inp, &sk, &format!("ap-{id}"), Some(FUTURE));
+            let outcome = ep
+                .dispatch_with_approval(db.conn(), &inp, &approval, &vk, NOW)
+                .unwrap();
+            assert_eq!(
+                outcome.result.status,
+                IntentStatus::Blocked,
+                "{kind:?}/{action:?} must hard-Deny even with a valid operator approval"
+            );
+            assert_eq!(
+                outcome.result.gate_reason.as_deref(),
+                Some("agent_cannot_execute_reserved_approval_action")
+            );
+            let trail = list_approval_records(db.conn(), &id).unwrap();
+            assert_eq!(trail[0].decision, DecisionLabel::Deny);
+        }
+    }
+    // The reserved-action hard-Deny is a base decision — it consumes NO nonce.
+    assert_eq!(consumed_count(&db), 0);
+}
+
+/// A digest MISMATCH (an approval for a different task value) is denied — the approval
+/// does not authorize THIS action. No completion, no nonce consumed.
+#[test]
+fn digest_mismatch_approval_is_denied() {
+    let db = Db::open_hub(&tmp("digest-mismatch")).unwrap();
+    let ep = enabled_ep();
+    let (sk, vk) = operator();
+
+    // Sign an approval for a DIFFERENT task value, present it against this intent.
+    let other = resume_task_input("i-other", "DIFFERENT_TASK");
+    let cross = ed25519_approval(&other, &sk, "ap-cross", Some(FUTURE));
+    let inp = resume_task_input("i-dm", "task_c");
+    let outcome = ep
+        .dispatch_with_approval(db.conn(), &inp, &cross, &vk, NOW)
+        .unwrap();
+    assert_eq!(outcome.result.status, IntentStatus::Blocked);
+    assert_eq!(
+        outcome.result.gate_reason.as_deref(),
+        Some("canonical_approval_digest_mismatch")
+    );
+    assert_eq!(consumed_count(&db), 0);
+}
+
+/// An EXPIRED approval is denied fail-closed — the control-plane op does not complete.
+#[test]
+fn expired_approval_is_denied_fail_closed() {
+    let db = Db::open_hub(&tmp("expired")).unwrap();
+    let ep = enabled_ep();
+    let (sk, vk) = operator();
+    let inp = resume_task_input("i-exp", "task_d");
+    // expires_at in the past relative to NOW.
+    let past = ed25519_approval(&inp, &sk, "ap-past", Some(500));
+    let outcome = ep
+        .dispatch_with_approval(db.conn(), &inp, &past, &vk, NOW)
+        .unwrap();
+    assert_eq!(outcome.result.status, IntentStatus::Blocked);
+    assert_eq!(
+        outcome.result.gate_reason.as_deref(),
+        Some("canonical_approval_expired")
+    );
+    assert_eq!(consumed_count(&db), 0);
+}
+
+/// MINT-IMPOSSIBILITY: holding ONLY the operator's PUBLIC verify key, a signature from
+/// an UNRELATED (attacker) key cannot satisfy it. Nothing the Hub/attacker constructs
+/// Allows a protected action.
+#[test]
+fn forged_signature_from_unrelated_key_is_denied() {
+    let db = Db::open_hub(&tmp("forged")).unwrap();
+    let ep = enabled_ep();
+    let (_operator_sk, vk) = operator();
+    let attacker = OperatorSigningKey::generate();
+    let inp = resume_task_input("i-forge", "task_e");
+    let forged = ed25519_approval(&inp, &attacker, "ap-forge", Some(FUTURE));
+    let outcome = ep
+        .dispatch_with_approval(db.conn(), &inp, &forged, &vk, NOW)
+        .unwrap();
+    assert_eq!(outcome.result.status, IntentStatus::Blocked);
+    assert_eq!(
+        outcome.result.gate_reason.as_deref(),
+        Some("canonical_approval_signature_invalid")
+    );
+    assert_eq!(consumed_count(&db), 0);
+}
+
+/// The flag is fail-closed for the approval path too: a fail-closed entrypoint refuses
+/// `dispatch_with_approval` BEFORE any side effect, even with a valid operator approval.
+#[test]
+fn approval_path_is_fail_closed_when_flag_disabled() {
+    let db = Db::open_hub(&tmp("fc-approval")).unwrap();
+    let ep = SystemIntentEntrypoint::fail_closed();
+    let (sk, vk) = operator();
+    let inp = resume_task_input("i-fc", "task_f");
+    let approval = ed25519_approval(&inp, &sk, "ap-fc", Some(FUTURE));
+    let err = ep.dispatch_with_approval(db.conn(), &inp, &approval, &vk, NOW);
+    assert!(err.is_err(), "a disabled flag must fail-closed");
+    // No request/result/lease/approval-record/nonce side effect.
+    assert_eq!(db.count("system_intent_request").unwrap(), 0);
+    assert_eq!(db.count("system_intent_result").unwrap(), 0);
+    assert_eq!(db.count("system_control_lease").unwrap(), 0);
+    assert_eq!(db.count("system_intent_approval_record").unwrap(), 0);
+    assert_eq!(consumed_count(&db), 0);
+}
+
+/// A mutating intent dispatched WITHOUT any approval still Pauses (RequiresApproval →
+/// blocked) — the agent can never produce the operator's offline signature. (Covers the
+/// no-approval base of `dispatch_with_approval` vs the slice-1 `dispatch` block path.)
+#[test]
+fn explicit_owner_denial_and_missing_signature_are_denied() {
+    let db = Db::open_hub(&tmp("deny-paths")).unwrap();
+    let ep = enabled_ep();
+    let (sk, vk) = operator();
+    let inp = resume_task_input("i-deny", "task_g");
+
+    // Explicit owner Denied (re-signed so the signature is valid but decision is Denied).
+    let mut denied = ed25519_approval(&inp, &sk, "ap-d", Some(FUTURE));
+    denied.decision = ApprovalDecision::Denied;
+    denied.signature = Some(
+        sk.sign(&canonical_approval_signature_bytes(&denied))
+            .to_hex(),
+    );
+    let r = ep
+        .dispatch_with_approval(db.conn(), &inp, &denied, &vk, NOW)
+        .unwrap();
+    assert_eq!(r.result.status, IntentStatus::Blocked);
+    assert_eq!(
+        r.result.gate_reason.as_deref(),
+        Some("canonical_approval_denied")
+    );
+
+    // Missing signature → fail-closed Deny.
+    let inp2 = resume_task_input("i-nosig", "task_g");
+    let mut nosig = ed25519_approval(&inp2, &sk, "ap-n", Some(FUTURE));
+    nosig.signature = None;
+    let rn = ep
+        .dispatch_with_approval(db.conn(), &inp2, &nosig, &vk, NOW)
+        .unwrap();
+    assert_eq!(rn.result.status, IntentStatus::Blocked);
+    assert_eq!(
+        rn.result.gate_reason.as_deref(),
+        Some("canonical_approval_signature_missing")
+    );
+
+    assert_eq!(consumed_count(&db), 0);
+}
+
+/// CONTRACT GUARD: the approval-ingestion path is for PROTECTED (mutating/high-risk)
+/// intents only. A non-protected action (a read-only `snapshot`, a lease-lifecycle
+/// `request_control`) is refused fail-closed `Invalid` BEFORE any side effect — it does
+/// NOT silently auto-acquire a lease here (those go through `dispatch`). Even a valid
+/// operator approval cannot route a non-protected action through this path.
+#[test]
+fn non_protected_action_is_refused_on_the_approval_path() {
+    let db = Db::open_hub(&tmp("non-protected")).unwrap();
+    let ep = enabled_ep();
+    let (sk, vk) = operator();
+
+    for (action, target) in [
+        (IntentAction::Snapshot, None),
+        (IntentAction::RequestControl, None),
+        (IntentAction::SearchFile, Some("query")),
+    ] {
+        let mut inp = input("i-np", action, "api-1", OwnerKind::Api);
+        inp.target_ref = target.map(str::to_string);
+        let approval = ed25519_approval(&inp, &sk, "ap-np", Some(FUTURE));
+        let err = ep.dispatch_with_approval(db.conn(), &inp, &approval, &vk, NOW);
+        assert!(
+            err.is_err(),
+            "{action:?} must be refused on the approval path"
+        );
+    }
+    // Nothing was persisted and no nonce consumed (the guard is BEFORE the request insert).
+    assert_eq!(db.count("system_intent_request").unwrap(), 0);
+    assert_eq!(db.count("system_control_lease").unwrap(), 0);
+    assert_eq!(consumed_count(&db), 0);
+}

--- a/rust-core/crates/friday-hub/tests/r4s2_approval_execute.rs
+++ b/rust-core/crates/friday-hub/tests/r4s2_approval_execute.rs
@@ -13,7 +13,7 @@
 //!     system intent to Allow → execute (the Hub holds only the PUBLIC verify key —
 //!     it can never self-mint);
 //!   * single-use: a replay of the same approval is refused (the `consumed_approval`
-//!     nonce PK collision), so a control-plane op does NOT complete twice;
+//!     nonce PK collision), so an approved intent does NOT re-authorize twice;
 //!   * the DOWNGRADE defense: an HMAC-signed approval over the SAME canonical bytes
 //!     (what a self-minting Hub holding the symmetric secret would produce) is rejected;
 //!   * NEVER self-mintable: an Agent / Remote actor (the untrusted `OwnerKind`s this
@@ -22,9 +22,13 @@
 //!     reserved-action rule is decided before the signature is examined). The `Channel`
 //!     binding is a gate-LEVEL property (`OwnerKind` has no Channel variant, so it is not
 //!     representable here) and is covered by `friday-core::gate`'s own suite;
-//!   * the HONESTY split: a CONTROL-PLANE op (`resume_task`) completes; an OS-affecting
-//!     op (launch_app / recover_ui) stays `unavailable` even on a valid Allow — the OS
-//!     effect is NEVER faked-`completed`.
+//!   * the HONESTY posture: EVERY protected intent on a valid Allow — `resume_task`
+//!     (its `activeTask` pointer + `system.task.updated`/`system.intent.completed`
+//!     emissions are a deferred AC; `system.task.updated` is read back, so it is an
+//!     OBSERVABLE divergence) just as much as `launch_app` / `recover_ui` — stays
+//!     `unavailable` + `execution_deferred`. The approval AUTHORIZES the action and the
+//!     m0026 lease IS acquired, but the domain effect is NEVER faked-`completed`. There
+//!     is NO control-plane-completes path in this slice.
 
 use std::sync::atomic::{AtomicU64, Ordering};
 
@@ -79,8 +83,10 @@ fn input(intent_id: &str, action: IntentAction, actor: &str, kind: OwnerKind) ->
     }
 }
 
-/// `resume_task` (the unique control-plane / OS-free mutating intent). It requires a
-/// `target_ref` (the task value), which is bound into the canonical action digest.
+/// `resume_task` — a protected mutating intent whose domain effect (the `activeTask`
+/// pointer + the `system.task.updated`/`system.intent.completed` emissions) is a
+/// deferred AC, so on a valid Allow it stays `unavailable` like every other protected
+/// intent. It requires a `target_ref` (the task value), bound into the action digest.
 fn resume_task_input(id: &str, value: &str) -> IntentInput {
     let mut inp = input(id, IntentAction::ResumeTask, "api-1", OwnerKind::Api);
     inp.target_ref = Some(value.to_string());
@@ -136,11 +142,16 @@ fn enabled_ep() -> SystemIntentEntrypoint<UnavailableExecutor> {
     SystemIntentEntrypoint::with_execution_enabled(UnavailableExecutor)
 }
 
-/// THE HAPPY PATH: a control-plane intent (`resume_task`) + a valid operator Ed25519
-/// approval → Allow → `completed`, with the m0026 control-lease actually acquired and the
-/// approval-record decision = Allow. Exactly one nonce is consumed.
+/// THE HAPPY PATH (authorize, do not fake): `resume_task` + a valid operator Ed25519
+/// approval → Allow, with the m0026 control-lease actually acquired, the approval-record
+/// decision = Allow, and exactly one nonce consumed — BUT the result is `unavailable` +
+/// `execution_deferred`, NOT `completed`. The approval AUTHORIZES `resume_task`, but its
+/// domain effect (the `activeTask` pointer + the `system.task.updated` /
+/// `system.intent.completed` emissions, the former read back via `findLatestEventByName`,
+/// so an OBSERVABLE divergence) is a deferred AC — recording `completed` while performing
+/// none of those would be a faked-complete.
 #[test]
-fn control_plane_resume_task_with_valid_approval_completes() {
+fn resume_task_with_valid_approval_is_authorized_but_deferred_not_completed() {
     let db = Db::open_hub(&tmp("cp-happy")).unwrap();
     let ep = enabled_ep();
     let (sk, vk) = operator();
@@ -152,37 +163,36 @@ fn control_plane_resume_task_with_valid_approval_completes() {
         .unwrap();
     assert_eq!(
         outcome.result.status,
-        IntentStatus::Completed,
-        "an approved control-plane intent completes"
+        IntentStatus::Unavailable,
+        "an approved resume_task is authorized but its domain effect is deferred — never faked-completed"
     );
+    assert_ne!(outcome.result.status, IntentStatus::Completed);
     assert!(
-        !outcome.execution_deferred,
-        "a control-plane completion is not the deferred-OS seam"
+        outcome.execution_deferred,
+        "resume_task's domain effect is the deferred executor seam"
     );
-    // The completion message reflects the control-plane envelope, NOT a claim that the
-    // (deferred) in-memory activeTask domain state was set.
-    assert!(outcome
-        .result
-        .message
-        .contains("Control-plane intent approved"));
+    // The result message is the honest unimplemented marker — NOT a claim that activeTask
+    // was set or the events emitted.
+    assert_eq!(outcome.result.message, UNIMPLEMENTED_EXECUTION_MARKER);
     assert!(!outcome.result.message.contains("Active task set"));
-    // The m0026 lease was actually acquired (the control-plane DB op).
+    // The m0026 lease WAS actually acquired (the real, universal lease auto-acquire).
     let lease_id = outcome.result.control_lease_id.clone().unwrap();
     let lease = get_lease(db.conn(), &lease_id).unwrap().unwrap();
     assert_eq!(lease.owner_id, "api-1");
     assert!(lease.revoked_at.is_none(), "the lease is active");
-    // The approval-record proves the verified Allow.
+    // The approval-record proves the verified Allow (the approval WAS honored).
     let trail = list_approval_records(db.conn(), "i-rt").unwrap();
     assert_eq!(trail.len(), 1);
     assert_eq!(trail[0].decision, DecisionLabel::Allow);
     assert_eq!(trail[0].reason, "canonical_approval_granted");
+    // The nonce WAS consumed — the deferral is the executor's, not the gate's.
     assert_eq!(consumed_count(&db), 1);
     assert_eq!(
         get_intent_result(db.conn(), "i-rt")
             .unwrap()
             .unwrap()
             .status,
-        IntentStatus::Completed
+        IntentStatus::Unavailable
     );
 }
 
@@ -241,7 +251,7 @@ fn recover_ui_with_valid_approval_stays_unavailable_not_completed() {
 }
 
 /// Single-use: a second dispatch with the SAME approval is replay-refused (the nonce PK
-/// collision in consumed_approval), so the control-plane op does NOT complete twice.
+/// collision in consumed_approval), so the approval does NOT re-authorize a second time.
 #[test]
 fn replay_of_same_approval_is_refused_and_does_not_complete_twice() {
     let db = Db::open_hub(&tmp("replay")).unwrap();
@@ -250,11 +260,13 @@ fn replay_of_same_approval_is_refused_and_does_not_complete_twice() {
     let inp1 = resume_task_input("i-r1", "task_a");
     let approval = ed25519_approval(&inp1, &sk, "ap-replay", Some(FUTURE));
 
-    // First use: completes.
+    // First use: authorized (Allow) and the nonce is consumed; the domain effect is
+    // deferred, so the result is `unavailable` (NOT `completed`).
     let o1 = ep
         .dispatch_with_approval(db.conn(), &inp1, &approval, &vk, NOW)
         .unwrap();
-    assert_eq!(o1.result.status, IntentStatus::Completed);
+    assert_eq!(o1.result.status, IntentStatus::Unavailable);
+    assert!(o1.execution_deferred);
     assert_eq!(consumed_count(&db), 1);
 
     // Second use of the SAME approval nonce on a FRESH intent_id (same task value, so the
@@ -276,7 +288,7 @@ fn replay_of_same_approval_is_refused_and_does_not_complete_twice() {
 }
 
 /// THE DOWNGRADE DEFENSE: an HMAC-signed approval over the SAME canonical bytes is
-/// REJECTED for the protected control-plane action — it does NOT complete. Non-vacuous:
+/// REJECTED for the protected `resume_task` action — it does NOT authorize. Non-vacuous:
 /// the same intent with a real operator Ed25519 signature DOES complete.
 #[test]
 fn hmac_signed_approval_is_rejected_downgrade_defense() {
@@ -301,13 +313,18 @@ fn hmac_signed_approval_is_rejected_downgrade_defense() {
     );
     assert_eq!(consumed_count(&db), 0, "a rejected approval burns no nonce");
 
-    // Non-vacuous: the SAME intent, properly Ed25519-signed by the operator, completes.
+    // Non-vacuous: the SAME intent, properly Ed25519-signed by the operator, IS
+    // authorized (Allow) and consumes the nonce — its domain effect is deferred, so the
+    // result is `unavailable` (the Allow is real, distinguishing it from the HMAC block).
     let inp2 = resume_task_input("i-hmac2", "task_b");
     let good = ed25519_approval(&inp2, &sk, "ap-good", Some(FUTURE));
     let ok = ep
         .dispatch_with_approval(db.conn(), &inp2, &good, &vk, NOW)
         .unwrap();
-    assert_eq!(ok.result.status, IntentStatus::Completed);
+    assert_eq!(ok.result.status, IntentStatus::Unavailable);
+    assert!(ok.execution_deferred);
+    let trail = list_approval_records(db.conn(), "i-hmac2").unwrap();
+    assert_eq!(trail[0].decision, DecisionLabel::Allow);
     assert_eq!(consumed_count(&db), 1);
 }
 
@@ -371,7 +388,7 @@ fn digest_mismatch_approval_is_denied() {
     assert_eq!(consumed_count(&db), 0);
 }
 
-/// An EXPIRED approval is denied fail-closed — the control-plane op does not complete.
+/// An EXPIRED approval is denied fail-closed — `resume_task` is not authorized at all.
 #[test]
 fn expired_approval_is_denied_fail_closed() {
     let db = Db::open_hub(&tmp("expired")).unwrap();


### PR DESCRIPTION
## What this is

R4 slice-1 (#644) made every mutating system intent route through the canonical gate -> `RequiresApproval` -> `Blocked`, leaving `system_intent.rs`'s execute path UNREACHABLE. This slice builds the DARK path by which a VERIFIED operator Ed25519 approval AUTHORIZES a protected system intent — the system-intent analogue of the in-product `resume::resume_with_approval` (S6d), built by **composing** the proven verify-only policy. The approval grants `Allow`; the action's domain effect is then deferred (recorded `unavailable`), never faked-`completed`. `friday-core/gate.rs` and `friday-storage` are **unchanged**.

## Approval ingestion (`SystemIntentEntrypoint::dispatch_with_approval`)

- Same fail-closed front as `dispatch` (flag check -> validate -> persist immutable REQUEST), then a **contract guard** refusing any non-protected action (those go through `dispatch`), then `friday_storage::authorize_mutating_action_ed25519` is the **sole authority**:
  - `gate::evaluate` runs *inside* it, so the **reserved-action hard-`Deny`** (Agent/Channel doing `approve`/`deny`) is decided BEFORE any signature is examined;
  - only a base `RequiresApproval` is upgraded to `Allow`, and ONLY by an operator-signed, digest-bound, unexpired, single-use approval verified under the operator's **public** verify key (the Hub holds only `OperatorVerifyingKey` — it can verify but never mint);
  - the gate decision is persisted as a durable `approval_record` (refs-only).
- The canonical action digest now **binds `target_ref`** (via the gate request `parameters`), so a single-use approval is scoped to THIS exact target.
- **No new migration**: reuses the m0026 tables (request/result/approval_record/control_lease) + the shared `consumed_approval` replay store (the `ed25519:` keyspace). Consequence: a nonce is now globally single-use across `resume` and system-intent — conservative, intentional.

## Execute on `Allow` — authorize, do not fake (the honesty posture)

On a verified `Allow` the m0026 **control-lease is auto-acquired** (the universal TS `ensureControlLease` ordering — real DB bookkeeping), then EVERY protected mutating intent is routed through the `SystemActionExecutor` (the `UnavailableExecutor` by default) and records **`unavailable` + the unimplemented marker — never a faked `completed`**. **There is NO control-plane-completes path in this slice.**

This is a change from the first cut of this PR, which completed `resume_task` as a "control-plane envelope." That was WRONG: `resume_task` is NOT a pure no-effect op. Reading `friday-system-service.ts` `case "resume_task"` (lines 2290–2303), its handler does THREE things — sets the in-memory `activeTask` pointer, emits `system.task.updated`, and emits `system.intent.completed`. The Rust branch performed NONE of them (only the universal lease auto-acquire that TS runs for every action). Critically, `system.task.updated` is **read back** via `findLatestEventByName` (`friday-system-service.ts:421`), so the un-emitted event is an **observable, load-bearing divergence**, not cosmetic in-memory state — recording `completed` there was a faked-complete. So `resume_task` now sits with `launch_app` / `recover_ui`: its domain effect (the `activeTask` pointer + the two emissions) is an **HONEST deferred AC**, exactly mirroring how `recover_ui` already stayed `unavailable` despite the TS returning `'completed'` (it has the unperformed overlay effect). The approval AUTHORIZES the action and the lease IS acquired; the domain effect waits for a real executor.

(This was the *only* finding: a narrow MEDIUM honesty divergence. The security core — the gate, single-use replay-refusal, no-self-mint, downgrade defense, no-downgrade — was reviewed clean and is **untouched**.)

## Security invariants (adversarially tested in-suite)

`tests/r4s2_approval_execute.rs` (12 tests; needs the operator SIGNING key, so it lives in `tests/` per the `operator_vk` hub-never-references-a-signing-key defense) + 9 in-module lib tests:

- verified operator Ed25519 approval is the ONLY Allow path; the Hub never self-mints;
- **single-use**: replay refused on second use (nonce PK collision), an approval does NOT re-authorize twice;
- **downgrade defense**: an HMAC-signed approval over the SAME canonical bytes is rejected;
- **never self-mintable**: Agent/Remote reserved `approve`/`deny` hard-`Deny` EVEN with a perfectly-valid operator approval (the `Channel` binding is a gate-LEVEL property — `OwnerKind` has no Channel variant, so it isn't representable on this entrypoint — and is covered by `friday-core::gate`'s own suite);
- digest-mismatch / expired / forged-unrelated-key / missing-signature / owner-denied all denied (no nonce consumed);
- **the honesty posture**: `resume_task` AND `launch_app` AND `recover_ui` — each with a VALID operator approval -> `Allow` (nonce consumed, lease acquired, approval-record = Allow) but the result is STILL `unavailable`, NOT `completed`;
- flag fail-closed on the approval path too (no side effect when disabled);
- contract guard: a non-protected action (snapshot / request_control / search_file) is refused before any side effect.

### Nonce-consumed-on-non-completion (disclosure)

`authorize_mutating_action_ed25519` consumes the nonce as part of returning `Allow`, *before* the execute step — so a valid approval for `resume_task` / `launch_app` / any protected intent burns the nonce while recording `unavailable` (and an approved intent that hits a busy lease burns the nonce while recording `blocked`). This is correct (it mirrors `resume.rs`, which also consumes then can record `mutation_exec_failed`): the approval authorized the action; the deferral/contention is downstream of authorization.

## What stays `UnavailableExecutor` / deferred ACs

- The **real executor** for every protected action — the OS effect of every desktop-affecting action (companion/Swift/AppleScript) AND `resume_task`'s domain effect (the `activeTask` pointer + the `system.task.updated` / `system.intent.completed` emissions). The `UnavailableExecutor` is the only provided impl; all of these are explicit deferred ACs.
- **Resource-scoped risk escalation** for a future real executor (`classify`'s path/target/file `Resource`) is not exercised — a coarse `target_ref` is not a filesystem path.

## DARK / boundary

No production route, no flag, no runtime caller wires `dispatch_with_approval`; the chat A3 path is untouched. The live TS system-intent path stays fail-closed (`TS_RUNTIME_SYSTEM_INTENT_RETIRED`, 503). NOT a product cutover. NOT v1 GO.

## Test evidence

- `cargo build -p friday-hub -p friday-storage -p friday-core`: clean.
- `cargo test -p friday-hub -p friday-storage -p friday-core`: all `ok`, 0 failed (incl. `operator_vk::tests::hub_crate_never_references_a_signing_key` green; the new suite `r4s2_approval_execute` 12 passed; lib `system_intent::` 9 passed; `friday-storage` lib 73 passed + the migration/system_intent integration suites green).
- `cargo fmt --check`: clean.
- `cargo clippy -p friday-hub -p friday-storage -p friday-core --all-targets -- -D warnings`: clean.
- `git diff` confirms `friday-core/` and `friday-storage/` unchanged — the fix touches only `friday-hub/src/system_intent.rs` and `friday-hub/tests/r4s2_approval_execute.rs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
