### PR TITLE
docs(rust): batch doc-accuracy fixes (provider_doctor + R2 workflow run-state docs)

### DIFF
--- a/rust-core/crates/friday-hub/src/lib.rs
+++ b/rust-core/crates/friday-hub/src/lib.rs
@@ -83,7 +83,7 @@ pub mod diagnostics;
 /// R6 — onboarding provider capability-doctor (DARK). The providers analog of
 /// [`diagnostics::DiagnosticsSnapshot::collect`]: a hub-LIBRARY aggregate
 /// ([`provider_doctor::ProviderDoctor::run`]) that composes the EXISTING parsed
-/// per-provider [`friday_providers::ProviderAuthStatus`] (via [`provider_auth`] /
+/// per-provider [`friday_providers::ProviderAuthStatus`] (via
 /// [`friday_providers::detect`]) into one truth-labeled onboarding-readiness result —
 /// previously this multi-provider orchestration was inlined in the
 /// `hub_providers_detect` bin and callable by nothing else. No-fallback (per-provider

--- a/rust-core/crates/friday-hub/src/workflow_run_control.rs
+++ b/rust-core/crates/friday-hub/src/workflow_run_control.rs
@@ -273,7 +273,8 @@ pub fn retry(
 /// 2. Terminal run (no `-> Cancelled` edge) → [`RunControlError::InvalidTransition`]
 ///    (TS `INVALID_RUN_TRANSITION` from `assertTransition(status,"cancelled")`).
 ///
-/// Returns a [`WorkflowRunStatus::Cancelled`] outcome on success.
+/// On success the run is written to the terminal `Cancelled` state and `Ok(())`
+/// is returned (cancel produces no [`WorkflowOutcome`] — it does no node re-entry).
 pub fn cancel(conn: &Connection, run_id: &str, reason: Option<&str>, now_ms: i64) -> Result<()> {
     // (1) Unknown run → NotFound (the explicit not-found posture, before the
     // transition check, so a ghost run is a NotFound rather than a generic storage

--- a/rust-core/crates/friday-storage/src/workflow.rs
+++ b/rust-core/crates/friday-storage/src/workflow.rs
@@ -155,16 +155,16 @@ pub fn set_run_state(
 /// -> Running`, but that is a fresh START, not a resume, so `resumable` is NOT
 /// "any `-> Running` is legal"; it is precisely the `AwaitingCheckpoint` predicate
 /// the engine's [`crate::workflow`]-driven `resume_workflow` already enforces.
-/// `terminal` is the core `is_terminal()` (`Done`/`Failed`). This is purely
-/// additive read-only metadata; it performs NO write and changes no existing
-/// behavior.
+/// `terminal` is the core `is_terminal()` (`Done`/`Failed`/`Cancelled`). This is
+/// purely additive read-only metadata; it performs NO write and changes no
+/// existing behavior.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct RunControlState {
     pub state: WorkflowRunState,
     /// `true` iff a `-> Running` resume transition is permitted from `state`
     /// (i.e. `state == AwaitingCheckpoint`). Mirrors the `friday-core` machine.
     pub resumable: bool,
-    /// `true` iff `state` is a terminal run state (`Done`/`Failed`).
+    /// `true` iff `state` is a terminal run state (`Done`/`Failed`/`Cancelled`).
     pub terminal: bool,
 }
 


### PR DESCRIPTION
## Doc/comment-only batch — zero behavior change

Batches the accumulated Rust doc-accuracy nits. **Every changed line is a `///` doc comment** — no executable line is touched (verified via `git diff -U0`). Each comment was corrected to be ACCURATE to the current code (no new wrong statement introduced).

### R2 — stale run-state docs (flagged by the #645 review)

**`rust-core/crates/friday-storage/src/workflow.rs`** (two sites — same stale claim)

- L158
  - OLD: `/// terminal is the core is_terminal() (Done/Failed). ...`
  - NEW: `/// terminal is the core is_terminal() (Done/Failed/Cancelled). ...`
- L167
  - OLD: `/// true iff state is a terminal run state (Done/Failed).`
  - NEW: `/// true iff state is a terminal run state (Done/Failed/Cancelled).`
- Why: core `is_terminal()` returns `Done | Failed | Cancelled` (`rust-core/crates/friday-core/src/workflow.rs:51-57`); `Cancelled` was added additively in R2 slice-2. The two doc sites still said `(Done/Failed)`. Now matches the already-correct enumeration at `workflow_run_control.rs:260`.

**`rust-core/crates/friday-hub/src/workflow_run_control.rs`** — `cancel()` doc (L276)

- OLD: `/// Returns a [\`WorkflowRunStatus::Cancelled\`] outcome on success.`
- NEW: `/// On success the run is written to the terminal \`Cancelled\` state and \`Ok(())\` is returned (cancel produces no [\`WorkflowOutcome\`] — it does no node re-entry).`
- Why: `WorkflowRunStatus` has only `Completed | AwaitingCheckpoint | Failed` (no `Cancelled` variant — `workflow_exec.rs:86`), and `cancel()` returns `Result<()>`, not a `WorkflowRunStatus`. The old text also was a broken intra-doc link; the replacement uses plain/backticked text plus the in-scope `WorkflowOutcome` link (verified resolves).

### R6 — provider_doctor module doc

**`rust-core/crates/friday-hub/src/lib.rs`** — `provider_doctor` module doc (L86)

- OLD: `/// ... per-provider ProviderAuthStatus (via [\`provider_auth\`] / [\`friday_providers::detect\`]) into ...`
- NEW: `/// ... per-provider ProviderAuthStatus (via [\`friday_providers::detect\`]) into ...`
- Why: `ProviderDoctor::run_for` calls `friday_providers::detect` directly and never routes through `provider_auth` (a parallel single-provider wrapper at `lib.rs:774`). Subtractive fix — drops the inaccurate `provider_auth` mention so the doc exactly matches the call path. The `provider_doctor.rs` body and the `hub_providers_detect` bin doc headers were audited and are accurate — left unchanged.

### Verification (doc-only, still compiles)

- `git diff -U0`: every `+`/`-` line begins with `///` — confirmed doc-only across all 3 files / 4 sites.
- `cargo fmt --all -- --check`: clean.
- `cargo build -p friday-hub -p friday-storage -p friday-providers`: Finished OK.
- `cargo clippy -p friday-hub -p friday-storage -p friday-providers --all-targets -- -D warnings`: no warnings.
- Bonus: `cargo doc` confirmed none of the touched links are broken (the codebase has pre-existing unrelated broken intra-doc links, not gated in CI — which is why the `WorkflowRunStatus::Cancelled` nit survived).

🤖 Generated with [Claude Code](https://claude.com/claude-code)