### PR TITLE
feat(rust): R5 slice-2 — friday-system-remote (address #635 review LOWs, dark)

### DIFF
--- a/rust-core/crates/friday-system-remote/src/device.rs
+++ b/rust-core/crates/friday-system-remote/src/device.rs
@@ -22,7 +22,7 @@
 //! so no device can be registered yet — fail closed.
 
 use crate::error::{RemoteError, Result};
-use crate::webauthn::VerifiedAttestation;
+use crate::webauthn::{VerifiedAssertion, VerifiedAttestation};
 use std::collections::HashMap;
 
 /// A registered WebAuthn device row.
@@ -79,6 +79,22 @@ impl DeviceStore {
         }
         if self.by_id.contains_key(device_id) {
             return Err(RemoteError::DeviceAlreadyRegistered(device_id.to_string()));
+        }
+        // Credential ids are minted unique by the authenticator. Enforce that
+        // uniqueness in the store too, so the credential-id reverse lookup
+        // ([`Self::get_by_credential_for_owner`]) is unambiguous (this is the
+        // invariant a future persistence slice expresses as a UNIQUE index on the
+        // credential column). A second device claiming an already-registered
+        // credential id is REFUSED — fail-closed.
+        let new_credential_id = attestation.credential_id();
+        if self
+            .by_id
+            .values()
+            .any(|d| d.credential_id == new_credential_id)
+        {
+            return Err(RemoteError::DeviceAlreadyRegistered(format!(
+                "credential already registered for device '{device_id}'"
+            )));
         }
         let device = RegisteredDevice {
             device_id: device_id.to_string(),
@@ -148,6 +164,77 @@ impl DeviceStore {
         Ok(())
     }
 
+    /// Resolve the registered device for a WebAuthn `credential_id`, owner-scoped.
+    /// A WebAuthn assertion identifies the authenticator by credential id (not by
+    /// our internal `device_id`), so the assert path needs this reverse lookup.
+    ///
+    /// Returns:
+    /// * [`RemoteError::UnknownCredential`] if NO device with that credential id
+    ///   is registered — fail-closed, and the `UnknownCredential` variant (already
+    ///   in the taxonomy) is exactly the right "no such credential" signal;
+    /// * [`RemoteError::OwnerMismatch`] if a device with that credential id exists
+    ///   but is owned by a different principal — cross-owner resolution is refused
+    ///   (existence is revealed only after the owner check passes).
+    ///
+    /// Credential ids are unique within the store ([`Self::register`] refuses a
+    /// duplicate live credential id), so the in-memory scan's first match is
+    /// unambiguous.
+    pub fn get_by_credential_for_owner(
+        &self,
+        credential_id: &[u8],
+        owner: &str,
+    ) -> Result<&RegisteredDevice> {
+        let device = self
+            .by_id
+            .values()
+            .find(|d| d.credential_id == credential_id)
+            .ok_or(RemoteError::UnknownCredential)?;
+        if device.owner != owner {
+            return Err(RemoteError::OwnerMismatch);
+        }
+        Ok(device)
+    }
+
+    /// Apply a VERIFIED assertion: advance the matching device's `last_seen_at`
+    /// (forward-only) and return the device. This is the assert-path counterpart
+    /// of [`DeviceStore::register`]'s verify→register: only a successful
+    /// [`crate::webauthn::WebAuthnVerifier::verify_assertion`] can mint a
+    /// [`VerifiedAssertion`] (no public constructor), so an unverified assertion
+    /// can never reach here — the same typestate fail-closed guarantee as
+    /// registration.
+    ///
+    /// Resolution is by the assertion's `credential_id`, scoped to the assertion's
+    /// own `owner`. If no device matches the credential id the call fails closed
+    /// ([`RemoteError::UnknownCredential`]); a credential owned by a different
+    /// principal is [`RemoteError::OwnerMismatch`]. The owner is taken from the
+    /// verified assertion itself, NOT from caller free-input, so a caller cannot
+    /// smuggle a different owner past verification.
+    pub fn apply_assertion(
+        &mut self,
+        assertion: &VerifiedAssertion,
+        now: i64,
+    ) -> Result<RegisteredDevice> {
+        // Locate the device id under an owner-scoped, fail-closed lookup first so
+        // we never touch a cross-owner device. (An immutable borrow that ends
+        // before the mutation below.)
+        let device_id = self
+            .get_by_credential_for_owner(assertion.credential_id(), assertion.owner())?
+            .device_id
+            .clone();
+        // We just resolved this id under the assertion's owner, so the mutable
+        // re-borrow is guaranteed present and owner-matched. Advance last_seen_at
+        // forward-only (a stale/replayed assertion timestamp cannot rewind it),
+        // then return the updated row — no `expect`/`unwrap` on any path.
+        let device = self
+            .by_id
+            .get_mut(&device_id)
+            .ok_or_else(|| RemoteError::DeviceNotFound(device_id.clone()))?;
+        if now > device.last_seen_at {
+            device.last_seen_at = now;
+        }
+        Ok(device.clone())
+    }
+
     /// Delete a device, owner-scoped. A missing device is
     /// [`RemoteError::DeviceNotFound`]; another owner's device is
     /// [`RemoteError::OwnerMismatch`] and is NOT deleted.
@@ -176,8 +263,25 @@ impl DeviceStore {
 mod tests {
     use super::*;
     use crate::webauthn::{
-        begin_registration, AcceptingTestVerifier, AttestationResponse, WebAuthnVerifier,
+        begin_assertion, begin_registration, AcceptingTestVerifier, AssertionResponse,
+        AttestationResponse, WebAuthnVerifier,
     };
+
+    /// Mint a VerifiedAssertion for `owner`/`cred` via the test verifier (the only
+    /// in-crate path to a verified token). The verifier enforces the credential-id
+    /// binding, so this mirrors a real successful assertion.
+    fn verified_assertion(owner: &str, cred: Vec<u8>) -> VerifiedAssertion {
+        let chal = begin_assertion(owner, "friday.local", cred.clone(), vec![5, 6, 7]).unwrap();
+        let resp = AssertionResponse {
+            credential_id: cred,
+            authenticator_data: vec![1],
+            client_data_json: br#"{"type":"webauthn.get"}"#.to_vec(),
+            signature: vec![0xde, 0xad],
+        };
+        AcceptingTestVerifier
+            .verify_assertion(&chal, &resp, &[0x04, 0x01, 0x02])
+            .expect("test verifier accepts a matching credential")
+    }
 
     fn verified_attestation(owner: &str, cred: Vec<u8>) -> VerifiedAttestation {
         let chal = begin_registration(owner, "friday.local", vec![1, 2, 3]).unwrap();
@@ -216,6 +320,21 @@ mod tests {
             store.register("dev-1", &att2, "", 2),
             Err(RemoteError::DeviceAlreadyRegistered("dev-1".into()))
         );
+    }
+
+    #[test]
+    fn register_rejects_duplicate_credential_id() {
+        let mut store = DeviceStore::new();
+        let att = verified_attestation("owner-1", vec![7, 7, 7]);
+        store.register("dev-1", &att, "", 1).unwrap();
+        // A different device_id but the SAME credential id is refused — credential
+        // ids are unique within the store (fail-closed), even across owners.
+        let att_same_cred = verified_attestation("owner-2", vec![7, 7, 7]);
+        assert!(matches!(
+            store.register("dev-2", &att_same_cred, "", 2),
+            Err(RemoteError::DeviceAlreadyRegistered(_))
+        ));
+        assert_eq!(store.len(), 1);
     }
 
     #[test]
@@ -313,5 +432,106 @@ mod tests {
         assert!(o1.iter().all(|d| d.owner == "owner-1"));
         assert_eq!(store.list_for_owner("owner-2").len(), 1);
         assert_eq!(store.list_for_owner("owner-3").len(), 0);
+    }
+
+    // ---- slice-2: assert-path linkage (credential resolve + apply_assertion) ----
+
+    #[test]
+    fn get_by_credential_for_owner_resolves_and_scopes() {
+        let mut store = DeviceStore::new();
+        store
+            .register(
+                "dev-1",
+                &verified_attestation("owner-1", vec![7, 7, 7]),
+                "",
+                1,
+            )
+            .unwrap();
+        // Correct owner + credential ⇒ resolves to the device.
+        let d = store
+            .get_by_credential_for_owner(&[7, 7, 7], "owner-1")
+            .unwrap();
+        assert_eq!(d.device_id, "dev-1");
+        // Unknown credential ⇒ UnknownCredential (fail-closed).
+        assert_eq!(
+            store.get_by_credential_for_owner(&[0, 0, 0], "owner-1"),
+            Err(RemoteError::UnknownCredential)
+        );
+        // Right credential, WRONG owner ⇒ OwnerMismatch (cross-owner refused).
+        assert_eq!(
+            store.get_by_credential_for_owner(&[7, 7, 7], "owner-2"),
+            Err(RemoteError::OwnerMismatch)
+        );
+    }
+
+    #[test]
+    fn apply_assertion_touches_matching_device_forward_only() {
+        let mut store = DeviceStore::new();
+        store
+            .register(
+                "dev-1",
+                &verified_attestation("owner-1", vec![7, 7, 7]),
+                "",
+                100,
+            )
+            .unwrap();
+        // A verified assertion for the registered credential advances last_seen_at.
+        let assertion = verified_assertion("owner-1", vec![7, 7, 7]);
+        let touched = store.apply_assertion(&assertion, 500).unwrap();
+        assert_eq!(touched.device_id, "dev-1");
+        assert_eq!(touched.last_seen_at, 500);
+        // Forward-only: a stale/replayed assertion timestamp cannot rewind it.
+        let stale = verified_assertion("owner-1", vec![7, 7, 7]);
+        let again = store.apply_assertion(&stale, 200).unwrap();
+        assert_eq!(again.last_seen_at, 500);
+    }
+
+    #[test]
+    fn apply_assertion_for_unregistered_credential_fails_closed() {
+        let mut store = DeviceStore::new();
+        store
+            .register(
+                "dev-1",
+                &verified_attestation("owner-1", vec![7, 7, 7]),
+                "",
+                1,
+            )
+            .unwrap();
+        // Verified assertion, but for a credential that is NOT registered.
+        let assertion = verified_assertion("owner-1", vec![9, 9, 9]);
+        assert_eq!(
+            store.apply_assertion(&assertion, 10),
+            Err(RemoteError::UnknownCredential)
+        );
+    }
+
+    #[test]
+    fn apply_assertion_cannot_touch_another_owners_device() {
+        let mut store = DeviceStore::new();
+        // Device with credential [7,7,7] is owned by owner-1.
+        store
+            .register(
+                "dev-1",
+                &verified_attestation("owner-1", vec![7, 7, 7]),
+                "",
+                1,
+            )
+            .unwrap();
+        // A (verified) assertion that claims owner-2 for the SAME credential id is
+        // refused — the owner is bound into the verified assertion, and the device
+        // belongs to owner-1, so resolution fails closed with OwnerMismatch. The
+        // device is NOT touched.
+        let assertion = verified_assertion("owner-2", vec![7, 7, 7]);
+        assert_eq!(
+            store.apply_assertion(&assertion, 999),
+            Err(RemoteError::OwnerMismatch)
+        );
+        assert_eq!(
+            store
+                .get_for_owner("dev-1", "owner-1")
+                .unwrap()
+                .last_seen_at,
+            1
+        );
     }
 }

--- a/rust-core/crates/friday-system-remote/src/lib.rs
+++ b/rust-core/crates/friday-system-remote/src/lib.rs
@@ -22,6 +22,27 @@
 //! * [`session`] — `RemoteSession` model + in-memory `SessionStore`
 //!   (create/heartbeat/delete) with monotonic-expiry, fail-closed lifecycle.
 //!
+//! # slice-2 additions (DARK, additive, fail-closed)
+//! Slice-2 addresses the slice-1-deferred LOWs that are in-crate / additive /
+//! schema-free (the others — real crypto, persistence migration, hub route/FFI,
+//! passkey flows — stay deferred for the reasons below):
+//! * **Assert path ASSEMBLED.** Slice-1 defined [`webauthn::VerifiedAssertion`]
+//!   but left it UNCONSUMED. Slice-2 wires the verify→apply counterpart of
+//!   verify→register: [`device::DeviceStore::apply_assertion`] takes a
+//!   `&VerifiedAssertion` (mintable ONLY via the verifier seam) and advances the
+//!   resolved device's `last_seen_at` (forward-only), via the new owner-scoped
+//!   [`device::DeviceStore::get_by_credential_for_owner`] reverse lookup. With the
+//!   default [`webauthn::DeferredVerifier`] no `VerifiedAssertion` exists, so the
+//!   assert path is unreachable end-to-end (same fail-closed guarantee as
+//!   registration).
+//! * **Heartbeat re-validates the bound device (slice-1 fail-closed hole).**
+//!   Slice-1 [`session::SessionStore::heartbeat`] never consulted the
+//!   `DeviceStore`, so a deleted/re-owned device left its sessions
+//!   heartbeatable-alive indefinitely. Slice-2 makes `heartbeat` take a
+//!   `&DeviceStore` and REFUSE if the bound device is gone or no longer
+//!   owner-matched — a revoked device severs its sessions' liveness on the next
+//!   heartbeat. A refused heartbeat leaves the session row unmutated.
+//!
 //! # What is STUB / DEFERRED (explicit)
 //! 1. **Real WebAuthn cryptographic verification.** [`webauthn::DeferredVerifier`]
 //!    FAILS CLOSED (`Err(WebAuthnVerifierNotWired)`) for every ceremony. COSE key

--- a/rust-core/crates/friday-system-remote/src/session.rs
+++ b/rust-core/crates/friday-system-remote/src/session.rs
@@ -148,9 +148,18 @@ impl SessionStore {
     /// * the owner does not match ([`RemoteError::OwnerMismatch`]);
     /// * `ttl_ms` is non-positive;
     /// * the session is ALREADY EXPIRED at `now` ([`RemoteError::SessionExpired`])
-    ///   — an expired session is dead and cannot be revived by heartbeat.
+    ///   — an expired session is dead and cannot be revived by heartbeat;
+    /// * the BOUND DEVICE is no longer registered or no longer owner-matched
+    ///   ([`RemoteError::DeviceNotFound`] / [`RemoteError::OwnerMismatch`]) — a
+    ///   session must not outlive the device it controls. Without this check a
+    ///   deleted/revoked device left its sessions heartbeatable-alive forever
+    ///   (slice-1 gap). Revoking the device now severs liveness on the next
+    ///   heartbeat — fail-closed. The session row itself is NOT mutated when the
+    ///   device check fails, so a refused heartbeat leaves the prior expiry intact
+    ///   (the session still expires on its own clock and can be deleted).
     pub fn heartbeat(
         &mut self,
+        devices: &DeviceStore,
         session_id: &str,
         owner: &str,
         now: i64,
@@ -159,9 +168,11 @@ impl SessionStore {
         if ttl_ms <= 0 {
             return Err(RemoteError::InvalidInput("ttl_ms must be positive".into()));
         }
+        // Read-phase: validate owner, liveness, and the bound device WITHOUT
+        // mutating, so any refusal leaves the session row untouched.
         let s = self
             .by_id
-            .get_mut(session_id)
+            .get(session_id)
             .ok_or_else(|| RemoteError::SessionNotFound(session_id.to_string()))?;
         if s.owner != owner {
             return Err(RemoteError::OwnerMismatch);
@@ -170,6 +181,16 @@ impl SessionStore {
             // Dead. Do not revive. Fail closed.
             return Err(RemoteError::SessionExpired);
         }
+        // Re-validate the bound device: it must still be registered AND still
+        // owner-matched. A device deleted or re-owned out from under the session
+        // severs the session's liveness here (fail-closed) rather than letting an
+        // orphaned session be heartbeated indefinitely.
+        devices.get_for_owner(&s.device_id, owner)?;
+        // Mutate-phase: all checks passed; refresh.
+        let s = self
+            .by_id
+            .get_mut(session_id)
+            .ok_or_else(|| RemoteError::SessionNotFound(session_id.to_string()))?;
         s.heartbeat_at = now;
         s.expires_at = now.saturating_add(ttl_ms);
         Ok(s.clone())
@@ -252,7 +273,9 @@ mod tests {
         assert_eq!(s.state_at(1_400), SessionState::Active);
 
         // heartbeat while live: refresh expiry forward, bump heartbeat_at.
-        let s2 = sessions.heartbeat("sess-1", "owner-1", 1_400, 500).unwrap();
+        let s2 = sessions
+            .heartbeat(&devices, "sess-1", "owner-1", 1_400, 500)
+            .unwrap();
         assert_eq!(s2.heartbeat_at, 1_400);
         assert_eq!(s2.expires_at, 1_900);
 
@@ -275,12 +298,12 @@ mod tests {
             .unwrap();
         // expires_at = 1_100; heartbeat at exactly 1_100 (>=) ⇒ expired, refused.
         assert_eq!(
-            sessions.heartbeat("sess-1", "owner-1", 1_100, 100),
+            sessions.heartbeat(&devices, "sess-1", "owner-1", 1_100, 100),
             Err(RemoteError::SessionExpired)
         );
         // and well past expiry too.
         assert_eq!(
-            sessions.heartbeat("sess-1", "owner-1", 5_000, 100),
+            sessions.heartbeat(&devices, "sess-1", "owner-1", 5_000, 100),
             Err(RemoteError::SessionExpired)
         );
         // An expired session can still be DELETED (valid terminal op).
@@ -346,7 +369,7 @@ mod tests {
             Err(RemoteError::OwnerMismatch)
         );
         assert_eq!(
-            sessions.heartbeat("sess-1", "owner-2", 1_100, 1_000),
+            sessions.heartbeat(&devices, "sess-1", "owner-2", 1_100, 1_000),
             Err(RemoteError::OwnerMismatch)
         );
         assert_eq!(
@@ -359,9 +382,10 @@ mod tests {
 
     #[test]
     fn heartbeat_and_delete_missing_session_fail_closed() {
+        let devices = DeviceStore::new();
         let mut sessions = SessionStore::new();
         assert!(matches!(
-            sessions.heartbeat("ghost", "owner-1", 1, 10),
+            sessions.heartbeat(&devices, "ghost", "owner-1", 1, 10),
             Err(RemoteError::SessionNotFound(_))
         ));
         assert!(matches!(
@@ -398,5 +422,63 @@ mod tests {
             .list_for_owner("owner-1")
             .iter()
             .all(|s| s.owner == "owner-1"));
+    }
+
+    // ---- slice-2: heartbeat re-validates the bound device (fail-closed) ----
+
+    #[test]
+    fn heartbeat_refused_after_bound_device_is_deleted() {
+        let mut devices = store_with_device("owner-1", "dev-1");
+        let mut sessions = SessionStore::new();
+        sessions
+            .create(&devices, "sess-1", "dev-1", "owner-1", 1_000, 1_000)
+            .unwrap();
+        // While the device is live, heartbeat works.
+        sessions
+            .heartbeat(&devices, "sess-1", "owner-1", 1_100, 1_000)
+            .unwrap();
+        // Revoke (delete) the device the session controls.
+        devices.delete_for_owner("dev-1", "owner-1").unwrap();
+        // The session is still within its own expiry window, but its bound device
+        // is gone ⇒ heartbeat is now REFUSED (fail-closed); a revoked device must
+        // not keep its sessions alive.
+        assert!(matches!(
+            sessions.heartbeat(&devices, "sess-1", "owner-1", 1_200, 1_000),
+            Err(RemoteError::DeviceNotFound(_))
+        ));
+        // The refused heartbeat did NOT mutate the session; it still expires on
+        // its prior clock and can be deleted (the valid terminal op).
+        let s = sessions.get_for_owner("sess-1", "owner-1").unwrap();
+        assert_eq!(s.expires_at, 2_100); // from the 1_100 heartbeat, unchanged
+        sessions.delete_for_owner("sess-1", "owner-1").unwrap();
+    }
+
+    #[test]
+    fn heartbeat_refused_when_device_reowned() {
+        // Device re-owned out from under a session ⇒ OwnerMismatch on heartbeat.
+        // (Modelled by deleting dev-1 and re-registering the same device_id to a
+        // different owner; the session still references owner-1.)
+        let mut devices = store_with_device("owner-1", "dev-1");
+        let mut sessions = SessionStore::new();
+        sessions
+            .create(&devices, "sess-1", "dev-1", "owner-1", 1_000, 1_000)
+            .unwrap();
+        devices.delete_for_owner("dev-1", "owner-1").unwrap();
+        // Re-register the same device_id under owner-2.
+        let chal = begin_registration("owner-2", "friday.local", vec![1, 2, 3]).unwrap();
+        let resp = AttestationResponse {
+            credential_id: vec![7, 7, 7],
+            attestation_object: vec![0xa0],
+            client_data_json: b"{}".to_vec(),
+        };
+        let att = AcceptingTestVerifier
+            .verify_registration(&chal, &resp)
+            .unwrap();
+        devices.register("dev-1", &att, "", 0).unwrap();
+        // owner-1's session can no longer heartbeat the now-owner-2 device.
+        assert_eq!(
+            sessions.heartbeat(&devices, "sess-1", "owner-1", 1_200, 1_000),
+            Err(RemoteError::OwnerMismatch)
+        );
     }
 }

--- a/rust-core/crates/friday-system-remote/tests/fail_closed.rs
+++ b/rust-core/crates/friday-system-remote/tests/fail_closed.rs
@@ -76,3 +76,29 @@ fn session_store_is_empty_without_a_device() {
     assert!(matches!(out, Err(RemoteError::DeviceNotFound(_))));
     assert!(sessions.is_empty());
 }
+
+#[test]
+fn assert_path_is_unreachable_through_the_default_path() {
+    // slice-2: DeviceStore::apply_assertion advances a device's last_seen on a
+    // VERIFIED assertion. But — exactly like registration — an external caller
+    // cannot mint a VerifiedAssertion: the only verifier they can reach is the
+    // shipped DeferredVerifier, which fails closed. So with no real verifier wired
+    // the assert path is unreachable end to end (we cannot even construct the
+    // argument to apply_assertion), and credential resolution over an empty store
+    // also fails closed.
+    let chal = begin_assertion("owner-1", "friday.local", vec![7, 7, 7], vec![4, 5, 6]).unwrap();
+    let resp = AssertionResponse {
+        credential_id: vec![7, 7, 7],
+        authenticator_data: vec![1],
+        client_data_json: b"{}".to_vec(),
+        signature: vec![0xde, 0xad],
+    };
+    let out = DeferredVerifier.verify_assertion(&chal, &resp, &[0x04, 0x01]);
+    assert_eq!(out, Err(RemoteError::WebAuthnVerifierNotWired));
+    // And the by-credential resolver over an empty store fails closed too.
+    let devices = DeviceStore::new();
+    assert_eq!(
+        devices.get_by_credential_for_owner(&[7, 7, 7], "owner-1"),
+        Err(RemoteError::UnknownCredential)
+    );
+}


### PR DESCRIPTION
## R5 slice-2 — `system.remote.*` foundation, address #635 deferred LOWs (DARK)

Slice-2 of R5. Slice-1 = #635 (merged: "friday-system-remote device + remote-session foundation, dark, WebAuthn seam fail-closed, no hub wiring"). This slice addresses the deferred LOW acceptance-criteria that are **in-crate / additive / schema-free**; the rest stay deferred for the reasons #635 gave.

### Truth label — DARK, NOT v1 GO
- **No friday-hub wiring.** No production caller, no route, no FFI export. `friday-hub` untouched.
- **No new dependency, no `Cargo.toml`/`Cargo.lock` change.** Only the 4 crate src/test files changed (purely additive within the dark crate).
- The crate still does not exist in production; this neither replaces a TS surface nor moves the live product. It is foundation hardening, **not** a v1 GO of device/sync.

### Provenance of the "LOWs" — honesty note
**There is NO GitHub review on #635** (its `reviews`, inline review comments, and issue comments are all empty — verified via `gh`). The slice-1 adversarial review happened out-of-band. So the "deferred LOWs" addressed here are reconstructed from:
1. #635's own **"Explicitly DEFERRED"** section, and
2. the slice brief's named LOW categories (additional fail-closed coverage, session lifecycle edge cases, WebAuthn seam completeness).

Triage of #635's 5 deferrals for in-crate/dark/additive feasibility:

| #635 deferral | Slice-2? | Why |
|---|---|---|
| 3. Assert→session/presence linkage (`VerifiedAssertion` defined but UNCONSUMED) | ✅ **closed** | in-crate, additive, schema-free; symmetric to slice-1 verify→register |
| 1. Real WebAuthn crypto verification | ⏸ deferred | needs `webauthn-rs`; not a clean LOW |
| 2. Persistence migration | ⏸ deferred | edits shared `friday-storage::schema` (highest-contention merge point) — kept in-crate by design |
| 4. Hub route / FFI / CSPRNG / gate+principal | ⏸ deferred | operator-gated |
| 5. Passkey-specific flows | ⏸ deferred | needs real crypto |

### What this slice BUILDS

**1. Assert path ASSEMBLED (the literal #635 deferred LOW #3).**
Slice-1 defined `webauthn::VerifiedAssertion` but its only consumer was *nothing* (`grep` confirmed: no non-test caller). Slice-2 wires the verify→apply counterpart of slice-1's verify→register:
- `DeviceStore::get_by_credential_for_owner(credential_id, owner)` — owner-scoped reverse lookup (a WebAuthn assertion identifies the authenticator by *credential id*, not our internal `device_id`). Unknown credential ⇒ `UnknownCredential`; cross-owner ⇒ `OwnerMismatch` (existence revealed only after the owner check).
- `DeviceStore::apply_assertion(&VerifiedAssertion, now)` — advances the resolved device's `last_seen_at` (forward-only; a stale/replayed timestamp cannot rewind it). The owner is taken from the *verified assertion*, not caller free-input, so a caller cannot smuggle a different owner past verification.
- A `VerifiedAssertion` is mintable **only** via the `WebAuthnVerifier` seam (no public constructor). With the default `DeferredVerifier`, none exists ⇒ the assert path is unreachable end-to-end — the **same fail-closed guarantee as registration**.

**2. `heartbeat` re-validates the bound device — disclosed hardening (NOT one of #635's 5 literal deferrals).**
This is an adjacent **fail-closed hole** found while assembling the assert path, in the "session lifecycle / additional fail-closed coverage" category. Slice-1 `SessionStore::heartbeat` never consulted the `DeviceStore`, so a **deleted or re-owned device left its sessions heartbeatable-alive indefinitely**. `heartbeat` now takes `&DeviceStore` and **REFUSES** if the bound device is gone (`DeviceNotFound`) or no longer owner-matched (`OwnerMismatch`). A refused heartbeat leaves the session row **unmutated** (it still expires on its own clock and can be deleted).
- **Invariant established:** ops that *extend* a session's life/control (`create`, `heartbeat`) require a live owner-matched device; terminal/read ops (`delete_for_owner`, `get_for_owner`) do not. (Pre-empts "why does heartbeat need the store but delete doesn't?")

**3. `register` enforces credential-id uniqueness.**
A second device claiming an already-registered credential id is refused (`DeviceAlreadyRegistered`). This makes the by-credential resolver's first-match **unambiguous** — the invariant a future persistence slice expresses as a UNIQUE index on the credential column. (`register` previously enforced only `device_id` uniqueness.)

### Fail-closed coverage added (tests)
- `apply_assertion` for an unregistered credential ⇒ `UnknownCredential`; for another owner's credential ⇒ `OwnerMismatch` (device NOT touched).
- `get_by_credential_for_owner` resolve + unknown + cross-owner.
- `heartbeat` refused after the bound device is deleted (session row left unmutated, verified `expires_at` unchanged) and after the device is re-owned.
- `register` rejects a duplicate live credential id (even across owners).
- Public-surface KAT: the assert path is unreachable through the default `DeferredVerifier` (cannot even construct the `apply_assertion` argument).

### Verification
```
cargo build -p friday-system-remote      ✅ Finished
cargo test  -p friday-system-remote      ✅ 26 unit + 6 integration, 0 failed
cargo fmt   -p friday-system-remote --check  ✅ no diff
cargo clippy -p friday-system-remote --all-targets -- -D warnings  ✅ 0 warnings
cargo test --workspace                   ✅ 0 failures across the workspace
```
Changed files: only `device.rs`, `session.rs`, `lib.rs`, `tests/fail_closed.rs`. **Zero friday-hub touch; zero `Cargo.toml`/`Cargo.lock` change; zero new deps.** The `heartbeat` signature change is in-crate only (the crate has no production caller); all in-crate callers (tests) updated.

### Still DEFERRED (unchanged from #635, by design)
Real WebAuthn cryptographic verification (COSE/attestation/signature/sign-count/origin/rp-id/challenge binding — needs a real `WebAuthnVerifier`, e.g. over `webauthn-rs`); persistence migration; hub route wiring / FFI / CSPRNG challenge issuance / gate+principal integration (operator-gated); passkey-specific flows. The forward-looking error variants (`WebAuthnRejected`/`CeremonyOutOfOrder`) remain unproduced by the default path — intentional seam vocabulary for the real verifier, not dead code to tidy away.

🤖 Generated with [Claude Code](https://claude.com/claude-code)