### PR TITLE
feat(rust+ts): A1 transport-truth — carry turns/tools/tokens on the sealed-WS result (dark; live at DEPLOY GO)

### DIFF
--- a/rust-core/crates/friday-ffi/src/lib.rs
+++ b/rust-core/crates/friday-ffi/src/lib.rs
@@ -3368,6 +3368,10 @@ mod tests {
                 status: "completed".into(),
                 answer_sha256: None,
                 answer_len: None,
+                turns: None,
+                executed_tools: None,
+                prompt_tokens: None,
+                completion_tokens: None,
             },
         );
         match parse_hub_response(result.encode().unwrap()) {

--- a/rust-core/crates/friday-hub/src/bin/hub_agent_run_server.rs
+++ b/rust-core/crates/friday-hub/src/bin/hub_agent_run_server.rs
@@ -695,16 +695,23 @@ fn serve_sealed_session<S: Read + Write, T: Transport>(
                 let outcome = run_authed_agent_loop(runtime, &caller, &run_id, &task, now_ms);
 
                 // (refs) REFS-ONLY terminal receipt over the wire: status + answer FINGERPRINT
-                // (sha256/len) — NEVER the body. Mirrors `AuthedAnswer::proof_refs_json`.
-                let (status, answer_sha256, answer_len) = result_refs(&outcome);
+                // (sha256/len) + (A1) the run COUNTS (turns / executed_tools) — NEVER the body.
+                // Mirrors `AuthedAnswer::proof_refs_json`. Counts are metadata; token counts
+                // are DEFERRED (`None`) — not on `LoopOutcome`. An absent count is omitted from
+                // the wire (`skip_serializing_if`) ⇒ byte-identical to the pre-A1 result.
+                let refs = result_refs(&outcome);
                 let result = Envelope::new(
                     format!("agent-run-result-{run_id}"),
                     now_ms,
                     Message::AgentRunResult {
                         run_id: run_id.clone(),
-                        status,
-                        answer_sha256,
-                        answer_len,
+                        status: refs.status,
+                        answer_sha256: refs.answer_sha256,
+                        answer_len: refs.answer_len,
+                        turns: refs.turns,
+                        executed_tools: refs.executed_tools,
+                        prompt_tokens: None,
+                        completion_tokens: None,
                     },
                 )
                 .with_correlation(env.msg_id.clone());
@@ -754,12 +761,21 @@ fn now_ms() -> i64 {
         .unwrap_or(0)
 }
 
-/// Project a dispatch outcome to its REFS-ONLY terminal fields (status + answer sha256/len).
-/// NEVER returns the body. Derives the fingerprint from the `proof_refs_json` projection so the
-/// wire result and the proof surface agree.
-fn result_refs(
-    outcome: &friday_hub::hub_server::AuthedAnswer,
-) -> (String, Option<String>, Option<u64>) {
+/// The REFS-ONLY terminal projection of a dispatch outcome: status + answer sha256/len +
+/// (A1) the run COUNTS (turns / executed_tools). NEVER carries the body. Derived from the
+/// `proof_refs_json` projection so the wire result and the proof surface agree on the same
+/// numbers. Token counts are DEFERRED (not on `LoopOutcome`) ⇒ always `None` here.
+struct ResultRefs {
+    status: String,
+    answer_sha256: Option<String>,
+    answer_len: Option<u64>,
+    /// (A1) REFS-surface run COUNTS — a COUNT only, never a turn body / tool name / args.
+    turns: Option<u64>,
+    executed_tools: Option<u64>,
+}
+
+/// Project a dispatch outcome to its REFS-ONLY terminal fields. NEVER returns the body.
+fn result_refs(outcome: &friday_hub::hub_server::AuthedAnswer) -> ResultRefs {
     let refs = outcome.proof_refs_json();
     let status = refs
         .get("status")
@@ -775,7 +791,16 @@ fn result_refs(
         .and_then(|v| v.as_str())
         .map(str::to_string);
     let answer_len = refs.get("answer_len").and_then(|v| v.as_u64());
-    (status, answer_sha256, answer_len)
+    // (A1) The run COUNTS surface on `Delivered` only (null/absent otherwise).
+    let turns = refs.get("turns").and_then(|v| v.as_u64());
+    let executed_tools = refs.get("executed_tools").and_then(|v| v.as_u64());
+    ResultRefs {
+        status,
+        answer_sha256,
+        answer_len,
+        turns,
+        executed_tools,
+    }
 }
 
 /// On-wire form for a `Sealed`: `[nonce_len: u8][nonce][ciphertext]`. Mirrors the transport's
@@ -1422,22 +1447,36 @@ mod tests {
     #[test]
     fn refs_result_never_carries_body() {
         use friday_hub::hub_server::AuthedAnswer;
+        // (A1) Attach real run COUNTS — the refs result must surface the counts but STILL
+        // never carry the body.
         let delivered = AuthedAnswer::Delivered {
             run_id: "run-f".into(),
             status: "finished".into(),
             answer: BODY.into(),
             answer_sha256: sha256_hex(BODY.as_bytes()),
             answer_len: BODY.len() as i64,
+            turns: Some(3),
+            executed_tools: Some(2),
         };
-        let (status, sha, len) = result_refs(&delivered);
-        assert_eq!(status, "finished");
-        assert_eq!(sha.as_deref(), Some(sha256_hex(BODY.as_bytes()).as_str()));
-        assert_eq!(len, Some(BODY.len() as u64));
+        let refs = result_refs(&delivered);
+        assert_eq!(refs.status, "finished");
+        assert_eq!(
+            refs.answer_sha256.as_deref(),
+            Some(sha256_hex(BODY.as_bytes()).as_str())
+        );
+        assert_eq!(refs.answer_len, Some(BODY.len() as u64));
+        // (A1) The COUNTS rode through the refs projection.
+        assert_eq!(refs.turns, Some(3));
+        assert_eq!(refs.executed_tools, Some(2));
         let result = Message::AgentRunResult {
             run_id: "run-f".into(),
-            status,
-            answer_sha256: sha,
-            answer_len: len,
+            status: refs.status,
+            answer_sha256: refs.answer_sha256,
+            answer_len: refs.answer_len,
+            turns: refs.turns,
+            executed_tools: refs.executed_tools,
+            prompt_tokens: None,
+            completion_tokens: None,
         };
         assert!(
             !format!("{result:?}").contains(BODY),

--- a/rust-core/crates/friday-hub/src/bin/hub_authed_run.rs
+++ b/rust-core/crates/friday-hub/src/bin/hub_authed_run.rs
@@ -284,6 +284,8 @@ mod tests {
             answer: "THE-SECRET-BODY".into(),
             answer_sha256: "00".repeat(32),
             answer_len: 15,
+            turns: Some(2),
+            executed_tools: Some(1),
         };
         let mut payload = answer.proof_refs_json();
         let obj = payload.as_object_mut().unwrap();

--- a/rust-core/crates/friday-hub/src/hub_server.rs
+++ b/rust-core/crates/friday-hub/src/hub_server.rs
@@ -1164,6 +1164,16 @@ pub enum AuthedAnswer {
         answer: String,
         answer_sha256: String,
         answer_len: i64,
+        /// (A1 transport-truth) REFS-surface run METADATA carried from the
+        /// [`crate::LoopOutcome`]: the model-turn count. A COUNT only — never a turn
+        /// body. `None` until a caller attaches it via [`AuthedAnswer::with_counts`]
+        /// (e.g. [`run_authed_agent_loop`], which now has the outcome in hand). The
+        /// body-projection path that mints this variant leaves it `None` (it reads DB
+        /// state and has no outcome) — the loop entry attaches the real counts after.
+        turns: Option<u64>,
+        /// (A1) REFS-surface run METADATA: the executed-tool COUNT. Never a tool name
+        /// / args. Same `with_counts`-attached / `None`-by-default discipline as `turns`.
+        executed_tools: Option<u64>,
     },
     /// A stored answer exists but the authenticated caller is NOT its owner (or the run has no
     /// owner): the body is WITHHELD. Carries only the coarse deny reason + the refs-only
@@ -1189,6 +1199,8 @@ impl std::fmt::Debug for AuthedAnswer {
                 status,
                 answer_sha256,
                 answer_len,
+                turns,
+                executed_tools,
                 ..
             } => f
                 .debug_struct("AuthedAnswer::Delivered")
@@ -1196,6 +1208,8 @@ impl std::fmt::Debug for AuthedAnswer {
                 .field("status", status)
                 .field("answer_sha256", answer_sha256)
                 .field("answer_len", answer_len)
+                .field("turns", turns)
+                .field("executed_tools", executed_tools)
                 .field("answer", &"<redacted: owner-only body>")
                 .finish(),
             AuthedAnswer::Denied {
@@ -1226,6 +1240,37 @@ impl AuthedAnswer {
         }
     }
 
+    /// (A1 transport-truth) Attach the REFS-surface run COUNTS from the
+    /// [`crate::LoopOutcome`] to a `Delivered` answer. A NO-OP on `Denied` / `NoAnswer`
+    /// (a non-delivered outcome carries no counts) — so the loop entry can attach
+    /// unconditionally without re-matching. Counts are metadata only; this NEVER touches
+    /// the body, sha256, len, status, or owner. The body-release projection
+    /// ([`project_answer_for_authed`]) mints `Delivered` with `None` counts (it has no
+    /// outcome); the loop entry that holds the [`crate::LoopOutcome`] attaches the real
+    /// numbers here.
+    pub fn with_counts(self, turns: u64, executed_tools: u64) -> AuthedAnswer {
+        match self {
+            AuthedAnswer::Delivered {
+                run_id,
+                status,
+                answer,
+                answer_sha256,
+                answer_len,
+                ..
+            } => AuthedAnswer::Delivered {
+                run_id,
+                status,
+                answer,
+                answer_sha256,
+                answer_len,
+                turns: Some(turns),
+                executed_tools: Some(executed_tools),
+            },
+            // A non-delivered outcome carries no counts — unchanged.
+            other => other,
+        }
+    }
+
     /// The (d) REFS-ONLY proof projection: outcome label + status + the answer FINGERPRINT
     /// (sha256 + length) + run_id — and NEVER the answer body (and never an owner principal,
     /// raw provider/secret/channel id). This is what a proof/unauth surface (e.g. the bin's
@@ -1237,6 +1282,8 @@ impl AuthedAnswer {
                 status,
                 answer_sha256,
                 answer_len,
+                turns,
+                executed_tools,
                 ..
             } => json!({
                 "outcome": "delivered_to_authenticated_owner",
@@ -1244,6 +1291,10 @@ impl AuthedAnswer {
                 "status": status,
                 "answer_sha256": answer_sha256,
                 "answer_len": answer_len,
+                // (A1) REFS-surface run COUNTS (metadata, never a body). Absent ⇒ null
+                // (the proof surface and the wire result agree on the same numbers).
+                "turns": turns,
+                "executed_tools": executed_tools,
             }),
             AuthedAnswer::Denied {
                 run_id,
@@ -1282,6 +1333,11 @@ pub fn project_answer_for_authed(
             answer: stored.answer,
             answer_sha256: stored.answer_sha256,
             answer_len: stored.answer_len,
+            // (A1) This DB-projection path has no LoopOutcome in hand — counts default
+            // to `None`. The loop entry ([`run_authed_agent_loop`]) holds the outcome and
+            // attaches the real counts via [`AuthedAnswer::with_counts`].
+            turns: None,
+            executed_tools: None,
         },
         Ok(RunAnswerAccess::Denied(reason)) => AuthedAnswer::Denied {
             run_id: run_id.to_string(),
@@ -1318,13 +1374,28 @@ pub fn run_authed_agent_loop<T: Transport>(
 ) -> AuthedAnswer {
     // (a) the caller is already authenticated (typed proof). (b) run the loop as that
     // principal; a route/provider failure is a SAFE FAILURE (no body, no panic).
-    if runtime.run_task(run_id, task, now_ms).is_err() {
-        return AuthedAnswer::NoAnswer {
-            run_id: run_id.to_string(),
-        };
-    }
-    // (c) release the answer ONLY to the authenticated owner (owner-wiring + ownership gate).
+    //
+    // A1 transport-truth: `run_task` ALREADY returns the `LoopOutcome { turns,
+    // executed_tools, .. }` — this entry used to DISCARD it via `.is_err()`. Capture it so
+    // the REFS-surface run COUNTS can ride the result. This is a no-behavior-change edit:
+    // the `Err` arm still returns the identical body-free `NoAnswer`, and the `Ok` arm
+    // still projects the identical owner-gated body — counts are pure additive metadata.
+    let outcome = match runtime.run_task(run_id, task, now_ms) {
+        Ok((_selection, outcome)) => outcome,
+        Err(_) => {
+            return AuthedAnswer::NoAnswer {
+                run_id: run_id.to_string(),
+            };
+        }
+    };
+    // (c) release the answer ONLY to the authenticated owner (owner-wiring + ownership gate),
+    // then (A1) attach the loop's turn / executed-tool COUNTS to a `Delivered` answer
+    // (a NO-OP on Denied / NoAnswer). Counts are metadata — this never touches the body.
+    // Token counts stay `None` (DEFERRED): the per-turn usage is billed to the Rust
+    // `token_ledger`, not carried on `LoopOutcome`, so the wire field is reserved but
+    // unpopulated for now.
     project_answer_for_authed(runtime.db().conn(), run_id, caller)
+        .with_counts(outcome.turns, outcome.executed_tools)
 }
 
 fn work_item_timeline_wire(item: friday_core::WorkItem) -> MissionTimelineWorkItemWire {

--- a/rust-core/crates/friday-hub/src/hub_server.rs
+++ b/rust-core/crates/friday-hub/src/hub_server.rs
@@ -5823,6 +5823,66 @@ mod authed_route_tests {
         assert!(out.delivered_body().is_none());
     }
 
+    /// (A1 transport-truth) `with_counts` ATTACHES the run COUNTS to a `Delivered` answer
+    /// (the populated path `run_authed_agent_loop` drives) and is a NO-OP on a non-delivered
+    /// outcome. This is the regression guard for the PR's post-deploy value: without it, a
+    /// `with_counts` that silently dropped the counts (or a refactor that dropped the
+    /// `.with_counts(..)` call) would still pass every other test.
+    #[test]
+    fn a1_with_counts_populates_delivered_and_is_noop_otherwise() {
+        // A real owner-delivered projection (turns/tools default to None before attach).
+        let db = seed_owned("a1-owner", "run-c", "principal:P");
+        let owner = authed("principal:P");
+        let delivered = project_answer_for_authed(db.conn(), "run-c", &owner);
+        // Pre-attach: the DB-projection path has no outcome ⇒ no counts on the proof surface.
+        let pre = delivered.proof_refs_json();
+        assert!(pre.get("turns").unwrap().is_null());
+        assert!(pre.get("executed_tools").unwrap().is_null());
+
+        // ATTACH the loop's counts — the populated path. Counts now ride the proof surface as
+        // NUMBERS, and the body is STILL owner-only (never on the refs/proof surface).
+        let attached = delivered.with_counts(3, 2);
+        assert_eq!(
+            attached.delivered_body(),
+            Some(BODY),
+            "body still delivered"
+        );
+        let proof = attached.proof_refs_json();
+        assert_eq!(proof.get("turns").and_then(|v| v.as_u64()), Some(3));
+        assert_eq!(
+            proof.get("executed_tools").and_then(|v| v.as_u64()),
+            Some(2)
+        );
+        assert!(
+            !proof.to_string().contains(BODY),
+            "the count-bearing proof surface must still be body-free"
+        );
+
+        // NO-OP on a non-delivered outcome: a NoAnswer carries no counts and is unchanged.
+        let none = AuthedAnswer::NoAnswer {
+            run_id: "run-c".into(),
+        };
+        let none_after = none.with_counts(9, 9);
+        assert!(matches!(none_after, AuthedAnswer::NoAnswer { .. }));
+        let none_proof = none_after.proof_refs_json();
+        assert!(
+            none_proof.get("turns").is_none(),
+            "NoAnswer carries no turns"
+        );
+        assert!(
+            none_proof.get("executed_tools").is_none(),
+            "NoAnswer carries no executed_tools"
+        );
+
+        // NO-OP on a Denied outcome too (wrong principal): counts never appear.
+        let other = authed("principal:Q");
+        let denied = project_answer_for_authed(db.conn(), "run-c", &other).with_counts(9, 9);
+        assert!(matches!(denied, AuthedAnswer::Denied { .. }));
+        let denied_proof = denied.proof_refs_json();
+        assert!(denied_proof.get("turns").is_none());
+        assert!(denied_proof.get("executed_tools").is_none());
+    }
+
     // --- end-to-end through the real HubRuntime agent loop --------------------
 
     struct TempWs(PathBuf);

--- a/rust-core/crates/friday-protocol/src/lib.rs
+++ b/rust-core/crates/friday-protocol/src/lib.rs
@@ -903,6 +903,32 @@ pub enum Message {
         /// ref/fingerprint — never the body bytes.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         answer_len: Option<u64>,
+        /// (A1 transport-truth) REFS-surface run METADATA: the count of model turns
+        /// the loop took (`LoopOutcome::turns`). A COUNT only — never a turn body /
+        /// message / param. ADDITIVE + OPTIONAL: an OLD server omits it (deserializes
+        /// to `None` on a new client via `#[serde(default)]`); a NEW server's value is
+        /// ignored by an old client (serde ignores unknown fields — `Message` is not
+        /// `deny_unknown_fields`). `None` ⇒ byte-identical to the pre-A1 wire.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        turns: Option<u64>,
+        /// (A1) REFS-surface run METADATA: the count of tools that actually executed
+        /// (gate `Allow` + executor `Ok`; `LoopOutcome::executed_tools`). A COUNT only
+        /// — NEVER a tool name / args / receipt. Same additive/optional/byte-identical
+        /// discipline as `turns`.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        executed_tools: Option<u64>,
+        /// (A1) REFS-surface run METADATA: prompt-token total for the run, when known.
+        /// A COUNT only. **Wire-shape reserved; population is DEFERRED** — the per-turn
+        /// usage is billed to the Rust `token_ledger` (keyed by `run_id`) and is NOT on
+        /// `LoopOutcome`, so the emit path leaves this `None` for now (a later slice
+        /// folds the ledger total in). Carrying the field here completes the
+        /// wire-widening pattern so no second wire change is needed then.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        prompt_tokens: Option<u64>,
+        /// (A1) REFS-surface run METADATA: completion-token total for the run, when
+        /// known. A COUNT only. Same DEFERRED-population note as `prompt_tokens`.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        completion_tokens: Option<u64>,
     },
     /// either: explicit error code + message.
     Error { code: ErrorCode, message: String },
@@ -1882,6 +1908,10 @@ mod tests {
             status: "completed".into(),
             answer_sha256: Some("a".repeat(64)),
             answer_len: Some(4096),
+            turns: Some(3),
+            executed_tools: Some(2),
+            prompt_tokens: None,
+            completion_tokens: None,
         };
         let env = Envelope::new("m2", 2000, msg.clone()).with_correlation("c2");
         let json = env.encode().unwrap();
@@ -1892,33 +1922,143 @@ mod tests {
         assert_eq!(back.message, msg);
 
         // The fingerprint fields are optional: a no-answer result omits them, and
-        // `skip_serializing_if` keeps them off the wire entirely.
+        // `skip_serializing_if` keeps them off the wire entirely. The A1 count fields
+        // are optional on the SAME terms.
         let no_answer = Message::AgentRunResult {
             run_id: "run-2".into(),
             status: "no_answer".into(),
             answer_sha256: None,
             answer_len: None,
+            turns: None,
+            executed_tools: None,
+            prompt_tokens: None,
+            completion_tokens: None,
         };
         let env2 = Envelope::new("m3", 3000, no_answer.clone());
         let json2 = env2.encode().unwrap();
         assert!(!json2.contains("answer_sha256"));
         assert!(!json2.contains("answer_len"));
+        assert!(!json2.contains("turns"));
+        assert!(!json2.contains("executed_tools"));
+        assert!(!json2.contains("prompt_tokens"));
+        assert!(!json2.contains("completion_tokens"));
         assert_eq!(Envelope::decode(&json2).unwrap().message, no_answer);
+    }
+
+    /// (A1 transport-truth) Serde back-compat for the ADDITIVE count fields, BOTH
+    /// directions — the load-bearing wire-widening proof.
+    #[test]
+    fn agent_run_result_a1_counts_are_backward_and_forward_compatible() {
+        // (1) ABSENT ⇒ BYTE-IDENTICAL TO TODAY: a `None`-count result serializes with
+        // NO count keys at all (the pre-A1 wire shape, verbatim). This is the proof
+        // that a server which never populates counts emits exactly today's bytes.
+        let pre_a1_shape = Message::AgentRunResult {
+            run_id: "run-compat".into(),
+            status: "finished".into(),
+            answer_sha256: Some("c".repeat(64)),
+            answer_len: Some(42),
+            turns: None,
+            executed_tools: None,
+            prompt_tokens: None,
+            completion_tokens: None,
+        };
+        let pre_a1_json = Envelope::new("c1", 1, pre_a1_shape.clone())
+            .encode()
+            .unwrap();
+        for key in [
+            "turns",
+            "executed_tools",
+            "prompt_tokens",
+            "completion_tokens",
+        ] {
+            assert!(
+                !pre_a1_json.contains(key),
+                "an absent count must NOT appear on the wire (byte-identical to pre-A1): {key}"
+            );
+        }
+
+        // (2) FORWARD-COMPAT (new server → old client): a NEW server's JSON that
+        // CARRIES the count fields still deserializes on a client that does not know
+        // them — serde ignores unknown fields (`Message` is not `deny_unknown_fields`).
+        // We model "an old client" by an envelope JSON the running code can decode even
+        // with EXTRA keys present.
+        let new_server_json = r#"{"schema_version":1,"msg_id":"c2","sent_at":2,"message":{"kind":"AgentRunResult","run_id":"run-fwd","status":"finished","answer_sha256":"deadbeef","answer_len":10,"turns":4,"executed_tools":3,"prompt_tokens":111,"completion_tokens":22,"some_future_field":"ignored"}}"#;
+        let decoded = Envelope::decode(new_server_json).expect("forward-compat decode");
+        match decoded.message {
+            Message::AgentRunResult {
+                turns,
+                executed_tools,
+                prompt_tokens,
+                completion_tokens,
+                ..
+            } => {
+                assert_eq!(turns, Some(4));
+                assert_eq!(executed_tools, Some(3));
+                assert_eq!(prompt_tokens, Some(111));
+                assert_eq!(completion_tokens, Some(22));
+            }
+            other => panic!("expected AgentRunResult, got {other:?}"),
+        }
+
+        // (3) BACKWARD-COMPAT (old server → new client): a result JSON with NO count
+        // keys (today's server) deserializes to `None` on the new client via
+        // `#[serde(default)]` — never an error.
+        let old_server_json = r#"{"schema_version":1,"msg_id":"c3","sent_at":3,"message":{"kind":"AgentRunResult","run_id":"run-bwd","status":"finished","answer_sha256":"deadbeef","answer_len":10}}"#;
+        match Envelope::decode(old_server_json)
+            .expect("backward-compat decode")
+            .message
+        {
+            Message::AgentRunResult {
+                turns,
+                executed_tools,
+                prompt_tokens,
+                completion_tokens,
+                ..
+            } => {
+                assert_eq!(turns, None);
+                assert_eq!(executed_tools, None);
+                assert_eq!(prompt_tokens, None);
+                assert_eq!(completion_tokens, None);
+            }
+            other => panic!("expected AgentRunResult, got {other:?}"),
+        }
+
+        // (4) POPULATED round-trips intact (the new-server-to-new-client path).
+        let populated = Message::AgentRunResult {
+            run_id: "run-rt".into(),
+            status: "finished".into(),
+            answer_sha256: Some("a".repeat(64)),
+            answer_len: Some(7),
+            turns: Some(5),
+            executed_tools: Some(1),
+            prompt_tokens: Some(900),
+            completion_tokens: Some(80),
+        };
+        let env = Envelope::new("c4", 4, populated.clone());
+        assert_eq!(
+            Envelope::decode(&env.encode().unwrap()).unwrap().message,
+            populated
+        );
     }
 
     #[test]
     fn agent_run_result_is_refs_only_never_carries_the_body() {
         // STRUCTURAL refs-only proof (mirrors `AuthedAnswer::proof_refs_json` /
         // the `owner_sealed_body_len` discipline): the serialized AgentRunResult
-        // must contain ONLY the refs fields — run_id, status, and the answer
-        // FINGERPRINT — and NEVER the answer body or any `final_message` key. The
-        // body is sealed over the session by a later sub-slice, never here.
+        // must contain ONLY the refs fields — run_id, status, the answer FINGERPRINT,
+        // and (A1) the run COUNTS — and NEVER the answer body or any `final_message`
+        // key. The body is sealed over the session by a later sub-slice, never here.
         const BODY: &str = "TOP-SECRET ANSWER BODY THAT MUST NEVER HIT THE WIRE";
         let msg = Message::AgentRunResult {
             run_id: "run-1".into(),
             status: "completed".into(),
             answer_sha256: Some("b".repeat(64)),
             answer_len: Some(BODY.len() as u64),
+            // A1 counts: present but body-free (counts are metadata, never a body).
+            turns: Some(2),
+            executed_tools: Some(1),
+            prompt_tokens: None,
+            completion_tokens: None,
         };
         let json = Envelope::new("m1", 1000, msg).encode().unwrap();
 
@@ -1939,15 +2079,29 @@ mod tests {
             );
         }
 
-        // What IS allowed: exactly the refs/fingerprint keys.
+        // What IS allowed: exactly the refs/fingerprint keys PLUS the A1 run COUNTS
+        // (turns / executed_tools — present here; token counts are deferred ⇒ absent).
+        // No body-bearing key is in this set; every member is a ref/count, not a body.
         let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
         let m = parsed.get("message").unwrap().as_object().unwrap();
         let mut keys: Vec<&str> = m.keys().map(String::as_str).collect();
         keys.sort_unstable();
         assert_eq!(
             keys,
-            vec!["answer_len", "answer_sha256", "kind", "run_id", "status"]
+            vec![
+                "answer_len",
+                "answer_sha256",
+                "executed_tools",
+                "kind",
+                "run_id",
+                "status",
+                "turns",
+            ]
         );
+        // (A1) The counts are NUMBERS (metadata), not strings/objects that could smuggle
+        // a body — a structural guard that the count surface stays count-only.
+        assert!(m.get("turns").unwrap().is_number());
+        assert!(m.get("executed_tools").unwrap().is_number());
     }
 
     #[test]

--- a/src/api/mission-spine/friday-rust-hub-agent-run-sealed-client-service.ts
+++ b/src/api/mission-spine/friday-rust-hub-agent-run-sealed-client-service.ts
@@ -88,6 +88,15 @@ export interface FridayRustHubAgentRunSealedClientServiceResult {
   readonly answerSha256?: string;
   /** Byte length of the answer body — a measure, NEVER the body text. Absent when no answer. */
   readonly answerLen?: number;
+  /**
+   * (A1 transport-truth) REFS-surface run COUNTS — counts only, NEVER a body/turn/tool name.
+   * `undefined` when the server omits them (an OLD server that predates A1, or a non-delivered
+   * outcome). Token counts are DEFERRED server-side ⇒ currently always `undefined`.
+   */
+  readonly turns?: number;
+  readonly executedTools?: number;
+  readonly promptTokens?: number;
+  readonly completionTokens?: number;
 }
 
 export interface FridayRustHubAgentRunSealedClientService {
@@ -183,13 +192,20 @@ export function createFridayRustHubAgentRunSealedClientService(
       }
 
       // Map to the REFS-ONLY shape the composition consumes — DROP the in-band `body` (compose's
-      // authoritative body source is the slice-3 owner-gated DB readback).
+      // authoritative body source is the slice-3 owner-gated DB readback). (A1) Thread the run
+      // COUNTS through when present (absent ⇒ omitted, never 0-faked); these are counts, not body.
       return {
         truthLabel: "rust_wired",
         runId: sealed.runId,
         status: sealed.status,
         ...(sealed.answerSha256 !== undefined ? { answerSha256: sealed.answerSha256 } : {}),
         ...(sealed.answerLen !== undefined ? { answerLen: sealed.answerLen } : {}),
+        ...(sealed.turns !== undefined ? { turns: sealed.turns } : {}),
+        ...(sealed.executedTools !== undefined ? { executedTools: sealed.executedTools } : {}),
+        ...(sealed.promptTokens !== undefined ? { promptTokens: sealed.promptTokens } : {}),
+        ...(sealed.completionTokens !== undefined
+          ? { completionTokens: sealed.completionTokens }
+          : {}),
       };
     },
   };

--- a/src/api/mission-spine/friday-rust-hub-agent-run-ws-sealed-client.ts
+++ b/src/api/mission-spine/friday-rust-hub-agent-run-ws-sealed-client.ts
@@ -143,6 +143,25 @@ export interface FridayRustHubAgentRunSealedResult {
   /** Byte length of the answer body — a measure — when an answer exists. */
   readonly answerLen?: number;
   /**
+   * (A1 transport-truth) REFS-surface run METADATA: the model-turn COUNT the loop took.
+   * A COUNT only — never a turn body/message. `undefined` when the server omits it (an OLD
+   * server that predates A1, or a non-delivered outcome) — never fabricated.
+   */
+  readonly turns?: number;
+  /**
+   * (A1) REFS-surface run METADATA: the count of tools that actually executed. A COUNT only
+   * — never a tool name/args. `undefined` when absent (old server / non-delivered).
+   */
+  readonly executedTools?: number;
+  /**
+   * (A1) REFS-surface run METADATA: prompt-token total, when known. A COUNT only. Wire-shape
+   * reserved; population is DEFERRED server-side (the per-turn usage is billed to the Rust
+   * token_ledger, not carried on the loop outcome), so this is `undefined` for now.
+   */
+  readonly promptTokens?: number;
+  /** (A1) REFS-surface run METADATA: completion-token total, when known. DEFERRED ⇒ `undefined`. */
+  readonly completionTokens?: number;
+  /**
    * The OPENED answer body, when the run delivered one to this owner. Absent on a denied /
    * no-answer outcome. NOT a refs field — it arrived doubly-sealed over the owner channel.
    */
@@ -379,6 +398,12 @@ interface ResultRefs {
   status: string;
   answerSha256?: string;
   answerLen?: number;
+  // (A1 transport-truth) REFS-surface run COUNTS — counts only, never a body. Absent when the
+  // server omits them (old server / non-delivered / deferred token counts).
+  turns?: number;
+  executedTools?: number;
+  promptTokens?: number;
+  completionTokens?: number;
 }
 
 /**
@@ -408,6 +433,11 @@ function finishWithBody(ctx: InboundContext, body: string | undefined): void {
     status: refs.status,
     ...(refs.answerSha256 !== undefined ? { answerSha256: refs.answerSha256 } : {}),
     ...(refs.answerLen !== undefined ? { answerLen: refs.answerLen } : {}),
+    // (A1) Surface the run COUNTS when the server carried them (absent ⇒ omitted, not 0-faked).
+    ...(refs.turns !== undefined ? { turns: refs.turns } : {}),
+    ...(refs.executedTools !== undefined ? { executedTools: refs.executedTools } : {}),
+    ...(refs.promptTokens !== undefined ? { promptTokens: refs.promptTokens } : {}),
+    ...(refs.completionTokens !== undefined ? { completionTokens: refs.completionTokens } : {}),
     ...(body !== undefined ? { body } : {}),
   });
 }
@@ -422,11 +452,21 @@ function handleResult(ctx: InboundContext, fields: Record<string, unknown>): voi
   }
   const answerSha256 = asString(fields.answer_sha256);
   const answerLen = asNumber(fields.answer_len);
+  // (A1) REFS-surface run COUNTS — parse when present; `asNumber` yields `undefined` for an
+  // absent/non-numeric field (an OLD server omits them entirely ⇒ undefined, never 0-faked).
+  const turns = asNumber(fields.turns);
+  const executedTools = asNumber(fields.executed_tools);
+  const promptTokens = asNumber(fields.prompt_tokens);
+  const completionTokens = asNumber(fields.completion_tokens);
   ctx.refs = {
     runId,
     status,
     ...(answerSha256 !== undefined ? { answerSha256 } : {}),
     ...(answerLen !== undefined ? { answerLen } : {}),
+    ...(turns !== undefined ? { turns } : {}),
+    ...(executedTools !== undefined ? { executedTools } : {}),
+    ...(promptTokens !== undefined ? { promptTokens } : {}),
+    ...(completionTokens !== undefined ? { completionTokens } : {}),
   };
   // No fingerprint ⇒ no answer ⇒ no body envelope follows; settle now. Otherwise wait (bounded)
   // for the SECOND (body) envelope.

--- a/src/api/runtime/friday-api-runtime.ts
+++ b/src/api/runtime/friday-api-runtime.ts
@@ -1231,9 +1231,14 @@ async function composeRustReadOnlyAgentRun(args: {
   }
 
   // (4) Project the ONE TS continuity row (slice-2). SOLE TS usage writer; idempotent on
-  // run_id (re-projection adds no second row — the no-double-count contract). The refs-only
-  // WS result carries no token totals (S-D is refs-only and untouched), so usage is 0 here
-  // and `pricingResolved:false` stands — truth label dark, no fabricated numbers.
+  // run_id (re-projection adds no second row — the no-double-count contract).
+  //
+  // A1 transport-truth: the refs-only WS result now CARRIES the run COUNTS (turns /
+  // executedTools) when the server populated them — so we stop hardcoding turns:0 /
+  // executedTools:0 and use the carried values, falling back to 0 ONLY when absent (an OLD
+  // server that predates A1, byte-identically to today). TOKEN totals stay 0: the per-turn
+  // usage is billed to the Rust token_ledger and is NOT carried on the wire yet (deferred),
+  // so `pricingResolved:false` still stands — truth label dark, no fabricated numbers.
   const completedAtIso = args.nowIso();
   const projection = args.db.withWriteTransaction((db) => {
     const result = args.projector.project(db, {
@@ -1249,14 +1254,16 @@ async function composeRustReadOnlyAgentRun(args: {
       // asserted by hub_server.rs `status == "finished"`) — NOT "completed". A delivered readback
       // (gated above) implies the loop finished, so map "finished" → Finished, else Errored.
       loopStatus: wsResult.status === "finished" ? "Finished" : "Errored",
-      turns: 0,
-      executedTools: 0,
+      // (A1) carried run COUNTS (0 ONLY when the server omitted them — old server).
+      turns: wsResult.turns ?? 0,
+      executedTools: wsResult.executedTools ?? 0,
       finalMessageSha256: readbackReceipt.answerSha256,
       finalMessageLen: readbackReceipt.answerLen,
       auditChainVerified: false,
-      usagePromptTokens: 0,
-      usageCompletionTokens: 0,
-      usageTotalTokens: 0,
+      // Token totals stay 0 — DEFERRED (not on the wire yet); pricingResolved:false stands.
+      usagePromptTokens: wsResult.promptTokens ?? 0,
+      usageCompletionTokens: wsResult.completionTokens ?? 0,
+      usageTotalTokens: (wsResult.promptTokens ?? 0) + (wsResult.completionTokens ?? 0),
       completedAtIso,
     });
     // execrun S-F carry-forward (DARK): MERGE the apiRequest idempotency descriptor into the
@@ -1281,15 +1288,20 @@ async function composeRustReadOnlyAgentRun(args: {
     return result;
   });
 
-  // (5) Return the owner-released body as the run's final response.
+  // (5) Return the owner-released body as the run's final response. (A1) `toolCallCount` is the
+  // product-visible surface where "turns>0 with real tools" actually shows — use the carried
+  // executed-tool COUNT (0 ONLY when an old server omitted it). `usageInput`/`usageOutput` use the
+  // carried token counts (currently 0 — DEFERRED, not on the wire). `durationMs` stays 0: the
+  // refs-only result carries no start time, so a real duration is not derivable — honest 0, not
+  // invented.
   return {
     runId: args.runId,
     status: projection.status as FridayAgentRuntimeResult["status"],
     response: readbackReceipt.answer,
-    toolCallCount: 0,
+    toolCallCount: wsResult.executedTools ?? 0,
     durationMs: 0,
-    usageInput: 0,
-    usageOutput: 0,
+    usageInput: wsResult.promptTokens ?? 0,
+    usageOutput: wsResult.completionTokens ?? 0,
     finalResponse: readbackReceipt.answer,
   };
 }


### PR DESCRIPTION
## What & why (GATE-AGENT-REPLACE Phase 0 / A2 design §4)

The sealed-WS agent-run result carried **no per-run counts**, so `composeRustReadOnlyAgentRun` hardcoded `turns:0` / `executedTools:0` / `usage:0` — making **"turns>0 with real tools"** unprovable in the TS surface. The data **already exists** in `LoopOutcome { turns, executed_tools }` (`friday-hub/src/lib.rs`) and was **discarded** by `run_authed_agent_loop` (`.is_err()` threw away the `Ok((RoutedSelection, LoopOutcome))` payload). This carries it end-to-end as **additive, wire-compatible, refs-surface metadata (COUNTS only)**.

**DARK:** behavior is **byte-identical** until the rebuilt WS bin is deployed (DEPLOY GO). An old server omits the fields ⇒ TS falls back to `0` exactly as today.

## Additive wire fields

`Message::AgentRunResult` (`friday-protocol`) gains `turns` / `executed_tools` / `prompt_tokens` / `completion_tokens`, each `Option<u64>` with `#[serde(default, skip_serializing_if = "Option::is_none")]` — the **identical** back-compat discipline the existing `answer_sha256` / `answer_len` fields already use. `Message` is **not** `deny_unknown_fields` (verified: only `workflow_def.rs` uses it), so serde ignores a new server's fields on an old client.

## Serde back-compat proof (both directions)

New test `agent_run_result_a1_counts_are_backward_and_forward_compatible`:
1. **Absent ⇒ byte-identical to pre-A1:** a `None`-count result serializes with **no** count keys at all (the verbatim pre-A1 wire shape).
2. **Forward (new server → old client):** a JSON carrying the count fields **plus** an unknown `some_future_field` still deserializes — serde ignores unknowns.
3. **Backward (old server → new client):** today's JSON with **no** count keys deserializes to `None` via `#[serde(default)]` — never an error.
4. **Populated round-trips** intact.

The refs-only allowlist test (`agent_run_result_is_refs_only_never_carries_the_body`) was extended to include the counts and now also asserts they are **numbers** (a structural guard that the count surface can't smuggle a body). TS parses via `asNumber` ⇒ `undefined` when absent (never `0`-faked).

## LoopOutcome threading

`AuthedAnswer::Delivered` gains `turns` / `executed_tools` (`None` by default — the DB-body-projection path has no outcome in hand). `run_authed_agent_loop` now **captures** `run_task`'s already-returned `(RoutedSelection, LoopOutcome)` instead of discarding it, and attaches counts to the `Delivered` answer via a new `with_counts()` that is a **no-op on `Denied`/`NoAnswer`**. `proof_refs_json` + the server emit (`hub_agent_run_server` `result_refs` → struct) surface the counts so the wire result and the dev-bin proof agree on the same numbers.

**New test `a1_with_counts_populates_delivered_and_is_noop_otherwise`** covers the populated attach path directly (the PR's post-deploy value): pre-attach `Delivered` surfaces null counts; `with_counts(3,2)` puts 3/2 as numbers on the proof surface while the body stays owner-only; `with_counts` is a no-op on `NoAnswer` and on a `Denied` (wrong-principal) outcome. Without this, a `with_counts` that silently dropped the counts would still pass every other test.

## Compose de-hardcoding (TS)

The WS sealed-client result interface + the sealed-client-**service** result + the internal `ResultRefs` gain the four count fields. `composeRustReadOnlyAgentRun` stops hardcoding `turns:0` / `executedTools:0` — uses the carried counts, **falls back to 0 only when absent** (old server). `toolCallCount` on the product return maps to `executedTools` (the product-visible "turns>0 real tools" surface). `durationMs` stays `0` (the refs-only result carries no start time — honest, not invented).

## Hard rules upheld

- **Refs-surface, COUNTS only** — `u64` counts; `executed_tools` is a count, never tool names/args. No body/answer/param added to the wire.
- **No qualifier change. No routing/gating behavior change.** `pricingResolved` stays `false` (token totals unchanged at `0`).
- Backward + forward wire-compatible; the absent-field path is byte-identical to today (proven by test 1 + the passing 17-test compose suite which uses count-less mocks). The conditional-presence design — `skip_serializing_if` (Rust) + conditional object spreads (TS) — makes byte-identical-when-absent true **by construction**: with no counts, no key is added at runtime on either side.

## DARK / no-behavior-change

The change lands inert. Real counts only flow once the rebuilt WS bin is deployed (**DEPLOY GO**, C1). Until then every emit is `None` ⇒ omitted ⇒ identical bytes; TS `?? 0` ⇒ identical projection. This establishes the wire-widening pattern Phase 1/2 reuse.

## Honest deferrals

- **Token COUNTS are wire-reserved but UNPOPULATED.** Per-turn usage is billed to the Rust `token_ledger` (keyed by `run_id`), **not** carried on `LoopOutcome`. The task licensed this ("token counts *if available on the outcome/usage*"). A later slice folds the ledger total in with **no second wire change**. `turns` + `executed_tools` alone satisfy the stated goal.
- **Counts surface ONLY on a `Delivered` (finished + owner-matched) outcome.** A `Bounded`/`Paused`/`Errored`/non-owner run carries no counts even though the captured `LoopOutcome` now holds them (`with_counts` is a no-op on `NoAnswer`/`Denied`, and `NoAnswer` has no count fields). Defensible — owner-scoping; the goal targets finished runs — and named here so the honesty ledger stays clean.
- Wire-widening touched **8 files** (not the 4 in the write-set): adding fields to the struct literal compile-forces the FFI test + the `hub_authed_run` test, and the `sealed-client-service` adapter is the intermediary type the compose path actually consumes (the raw WS client alone wouldn't reach compose). All additive.

## Test evidence

- Rust: `cargo build` / `cargo test` (protocol 21, hub all bins 0-fail incl. 508-test lib, ffi) / `cargo fmt --check` / `cargo clippy -D warnings` — all green.
- TS: `tsc --noEmit` clean; `eslint` **0 errors** on the touched files (only pre-existing complexity/max-lines warnings on functions I didn't introduce); 36 relevant vitest pass (`rust-route-compose` 17, `sealed-client-service` 7, `ws-client` 12).

🤖 Generated with [Claude Code](https://claude.com/claude-code)