### PR TITLE
feat(ts-retirement): method-guard hardening for orphan off-route surfaces + validator registration (defense-in-depth, no current leak)

### DIFF
--- a/docs/ops/ts-runtime-retirement-manifest.json
+++ b/docs/ops/ts-runtime-retirement-manifest.json
@@ -56,17 +56,27 @@
       "doc": "Anti-shrinkage floor: a CI-comparable baseline of manifest entry counts + per-surface method-guard counts. The assertion fails if any count drops BELOW its baseline, forcing a conscious, reviewable baseline edit in the same PR when a surface is legitimately removed/reclassified or a guard is intentionally retired. perSurfaceMethodsMin floors EACH registered surface (present + >= its method count) so 'drop a surface + add filler' cannot hold the grand total. behavioralTestsMin floors the count of surfaces backed by an existing behavioral test so one documented missing-test gap cannot be copied to null out the others. byClassification is EMITTED for review but NOT floored: fail_closed legitimately shrinks as surfaces move to Rust ownership.",
       "surfacesMin": 279,
       "routeFamiliesMin": 18,
-      "guardedMethodsMin": 12,
+      "guardedMethodsMin": 34,
       "perSurfaceMethodsMin": {
         "capability_acquisition": 3,
         "workflow_generator": 5,
         "system_intent": 1,
         "workflow_deploy": 2,
-        "autonomy_policy": 1
+        "autonomy_policy": 1,
+        "satellite_registration": 1,
+        "satellite_pairing": 4,
+        "satellite_capability": 1,
+        "satellite_heartbeat": 1,
+        "satellite_sync": 2,
+        "fleet_remediation": 1,
+        "realtime_ack": 1,
+        "autonomy_mcp_lifecycle": 4,
+        "node_runner_execution": 1,
+        "retry_pipeline": 6
       },
-      "behavioralTestsMin": 5,
+      "behavioralTestsMin": 15,
       "baselineCommit": "e6b39186",
-      "baselineNote": "Set from origin/main e6b39186 (post-#628 TS-R1 4-surface mirror + #597 autonomy-policy). Lower a *Min / drop a perSurfaceMethodsMin entry only in a PR that also removes the corresponding entry/guard, so the reviewer sees the de-retirement."
+      "baselineNote": "Set from origin/main e6b39186 (post-#628 TS-R1 4-surface mirror + #597 autonomy-policy), then RAISED for the orphan off-route leak audit (2026-06-10) defense-in-depth wave: guardedMethodsMin 12->34, behavioralTestsMin 5->15 with the 10 new method-guarded orphan surfaces (satellite registration/pairing/capability/heartbeat/sync, fleet remediation, realtime ack, autonomy MCP lifecycle, node-runner execution, retry pipeline). Lower a *Min / drop a perSurfaceMethodsMin entry only in a PR that also removes the corresponding entry/guard, so the reviewer sees the de-retirement."
     },
     "surfaces": [
       {
@@ -126,6 +136,129 @@
         "behavioralTest": "test/unit/autonomy/friday-controlled-autonomy-services.test.ts",
         "off_route_callers": "agent controlled-autonomy tool (policy_update)",
         "note": "Inline guard; synchronous (non-async) method. Reads getPolicy/evaluateRisks stay live. Guard added in #597. behavioralTest points to friday-controlled-autonomy-services.test.ts (its 'updatePolicy METHOD-level fail-closed' describe block) rather than a `*-retirement-guard*` file because the naming convention is non-uniform here."
+      },
+      {
+        "id": "satellite_registration",
+        "family_code": "TS_RUNTIME_SATELLITE_PAIRING_RETIRED",
+        "serviceFile": "src/satellites/services/friday-satellite-registration-service.ts",
+        "flag": "allowTestOnlySatellitePairingExecution",
+        "guardHelper": "assertSatelliteRegistrationExecutionAllowed",
+        "mutatingMethods": ["register"],
+        "behavioralTest": "test/unit/satellites/services/friday-satellite-registration-retirement-guard.test.ts",
+        "off_route_callers": "none today (route-deps-only via friday-satellite-pairing-routes); future auto-pairing loop would bypass the route fence",
+        "note": "Orphan off-route leak audit (2026-06-10) defense-in-depth: register was ROUTE-only-guarded (TS_RUNTIME_SATELLITE_PAIRING_RETIRED at the pairing route). Method-head guard fails closed before any satellite/pairing-request row write. The runtime composition (createFridaySatelliteRuntime) forwards allowTestOnlySatellitePairingExecution; the live hub never sets it, so the method 503s by default. Verb `register` is not in mutatorVerbs (declared explicitly)."
+      },
+      {
+        "id": "satellite_pairing",
+        "family_code": "TS_RUNTIME_SATELLITE_PAIRING_RETIRED",
+        "serviceFile": "src/satellites/services/friday-satellite-pairing-service.ts",
+        "flag": "allowTestOnlySatellitePairingExecution",
+        "guardHelper": "assertSatellitePairingExecutionAllowed",
+        "mutatingMethods": ["approvePairing", "rejectPairing", "completeHandshake", "revokeSatellite"],
+        "behavioralTest": "test/unit/satellites/services/friday-satellite-pairing-retirement-guard.test.ts",
+        "off_route_callers": "none today (route-deps-only via friday-satellite-pairing-routes; the TUI calls the guarded HTTP route over the wire, not the method)",
+        "note": "Orphan off-route leak audit (2026-06-10) defense-in-depth: the four pairing mutations were ROUTE-only-guarded. Each method-head guard fails closed before any pairing/token/satellite row write. Only `approvePairing` is verb-prefixed (approve); the other three (reject/complete/revoke) are declared explicitly. No live mutator-verb sibling on this file to allowlist."
+      },
+      {
+        "id": "satellite_capability",
+        "family_code": "TS_RUNTIME_SATELLITE_RUNTIME_RETIRED",
+        "serviceFile": "src/satellites/services/friday-satellite-capability-service.ts",
+        "flag": "allowTestOnlySatelliteRuntimeExecution",
+        "guardHelper": "assertSatelliteRuntimeExecutionAllowed",
+        "mutatingMethods": ["updateCapabilities"],
+        "behavioralTest": "test/unit/satellites/services/friday-satellite-capability-retirement-guard.test.ts",
+        "off_route_callers": "none today (route-deps-only via friday-satellite-runtime-routes)",
+        "note": "Orphan off-route leak audit (2026-06-10) defense-in-depth: updateCapabilities was ROUTE-only-guarded (TS_RUNTIME_SATELLITE_RUNTIME_RETIRED). Method-head guard fails closed before the capability/revision write. `update` is a mutatorVerb (auto-flagged, declared)."
+      },
+      {
+        "id": "satellite_heartbeat",
+        "family_code": "TS_RUNTIME_SATELLITE_RUNTIME_RETIRED",
+        "serviceFile": "src/satellites/services/friday-satellite-heartbeat-service.ts",
+        "flag": "allowTestOnlySatelliteRuntimeExecution",
+        "guardHelper": "assertSatelliteRuntimeExecutionAllowed",
+        "mutatingMethods": ["recordHeartbeat"],
+        "behavioralTest": "test/unit/satellites/services/friday-satellite-heartbeat-retirement-guard.test.ts",
+        "off_route_callers": "none today (route-deps-only via friday-satellite-runtime-routes). NOTE: the live `heartbeat-runner` scheduler job is OBSERVABILITY, not this satellite heartbeat — different service.",
+        "note": "Orphan off-route leak audit (2026-06-10) defense-in-depth: recordHeartbeat was ROUTE-only-guarded. Method-head guard fails closed before the heartbeat/status-transition write. Verb `record` is not in mutatorVerbs (declared explicitly)."
+      },
+      {
+        "id": "satellite_sync",
+        "family_code": "TS_RUNTIME_SATELLITE_RUNTIME_RETIRED",
+        "serviceFile": "src/satellites/services/friday-satellite-sync-service.ts",
+        "flag": "allowTestOnlySatelliteRuntimeExecution",
+        "guardHelper": "assertSatelliteRuntimeExecutionAllowed",
+        "mutatingMethods": ["pull", "push"],
+        "behavioralTest": "test/unit/satellites/services/friday-satellite-sync-retirement-guard.test.ts",
+        "off_route_callers": "none in the hub (route-deps-only via friday-satellite-runtime-routes pushSync/pullSync); the off-hub local-runner uses an injected API-client, not this engine, and is not wired in bootstrap",
+        "note": "Orphan off-route leak audit (2026-06-10) defense-in-depth: the inbound sync mutations (pull leases the outbox command-queue + signs a cursor; push persists acks/node-results) were ROUTE-only-guarded. Guards the INBOUND sync engine only — the hub->satellite outbox command-queue (outbox.enqueue) and retention GC are SEPARATE non-retired services and are NOT fenced. Verbs `pull`/`push` are not in mutatorVerbs (declared explicitly)."
+      },
+      {
+        "id": "fleet_remediation",
+        "family_code": "TS_RUNTIME_FLEET_REMEDIATION_RETIRED",
+        "serviceFile": "src/api/fleet/friday-fleet-dashboard-service.ts",
+        "flag": "allowTestOnlyFleetRemediationExecution",
+        "guardHelper": "assertFleetRemediationExecutionAllowed",
+        "mutatingMethods": ["executeSatelliteRemediationAction"],
+        "behavioralTest": "test/unit/api/fleet/friday-fleet-remediation-retirement-guard.test.ts",
+        "off_route_callers": "none today (route-deps-only via friday-fleet-routes, after the canonical-approval gate)",
+        "note": "Orphan off-route leak audit (2026-06-10) defense-in-depth: executeSatelliteRemediationAction was ROUTE-only-guarded (TS_RUNTIME_FLEET_REMEDIATION_RETIRED, asserted after the canonical-approval gate). Method-head guard fails closed before the remediation effect. Reads (getOverview/listSatellites/getSatelliteDetail/getSatelliteRemediationPlan/getSecurityCenter) stay live (verb `get`/`list`). Flag plumbed from api-runtime (same source the route uses)."
+      },
+      {
+        "id": "realtime_ack",
+        "family_code": "TS_RUNTIME_REALTIME_RETIRED",
+        "serviceFile": "src/api/realtime/friday-realtime-subscription-service.ts",
+        "flag": "allowTestOnlyRealtimeExecution",
+        "guardHelper": "assertRealtimeAckExecutionAllowed",
+        "mutatingMethods": ["ackEvent"],
+        "allowlistMutators": [
+          { "method": "generateCursor", "reason": "Read-only HMAC cursor generator (returns computeCursorHmac(...)); verb-prefix 'generate' is a false match, not a state mutation. No DB write, no retirement boundary. Left live." }
+        ],
+        "behavioralTest": "test/unit/api/realtime/friday-realtime-ack-retirement-guard.test.ts",
+        "off_route_callers": "TWO live ingress points already gate this flag BEFORE calling ackEvent: the HTTP /v1/realtime/ack route AND the WS `ack` frame. This method-head guard registers that de-facto two-site fence as a single method guard so a future THIRD caller cannot bypass it.",
+        "note": "Orphan off-route leak audit (2026-06-10): formalizes the already-double-guarded realtime ackEvent as a registered method guard. Fails closed before the checkpoint upsert. Reads (validateSubscriptions/pullEvents/getCheckpoint/cursor helpers) stay live. Verb `ack` is not in mutatorVerbs (declared explicitly). Flag plumbed from api-runtime (same source the route + WS gateway use)."
+      },
+      {
+        "id": "autonomy_mcp_lifecycle",
+        "family_code": "TS_RUNTIME_AUTONOMY_LIFECYCLE_RETIRED",
+        "serviceFile": "src/autonomy/services/friday-mcp-server-upgrade-lifecycle-service.ts",
+        "flag": "allowTestOnlyAutonomyLifecycleExecution",
+        "guardHelper": "assertAutonomyLifecycleExecutionAllowed",
+        "mutatingMethods": ["registerShadowVersion", "recordCanaryResult", "promote", "rollback"],
+        "behavioralTest": "test/unit/autonomy/friday-mcp-server-upgrade-lifecycle-retirement-guard.test.ts",
+        "off_route_callers": "none today (route-deps-only via friday-autonomy-routes mcpServerActions; no autonomy self-upgrade scheduler is wired)",
+        "note": "Orphan off-route leak audit (2026-06-10) defense-in-depth: the MCP-server upgrade-lifecycle mutations were ROUTE-only-guarded (assertAutonomyLifecycleTestOracleAllowed). Each method-head guard fails closed before the canonical-ticket check and any state write. Only `rollback` is verb-prefixed; the others are declared explicitly. getLifecycleEvidence stays live (verb `get`). NOTE: the sibling skill/channel-adapter/plugin upgrade-lifecycle services share this method SHAPE and the same route guard but are OUT of the audit's named scope (autonomy.mcp.servers.* only) — left for a follow-up parallel-family audit, not a missed surface."
+      },
+      {
+        "id": "node_runner_execution",
+        "family_code": "TS_RUNTIME_NODE_RUNNER_EXECUTION_RETIRED",
+        "serviceFile": "src/api/runtime/friday-deterministic-pipeline-runtime.ts",
+        "flag": "allowTestOnlyNodeRunnerExecution",
+        "guardHelper": "assertNodeRunnerExecutionAllowed",
+        "mutatingMethods": ["executeNode"],
+        "allowlistMutators": [
+          { "method": "createPolicy", "reason": "TWO-SURFACES-ONE-FILE: declared AND guarded under the retry_pipeline surface (same serviceFile, flag allowTestOnlyRetryPipelineExecution, guardHelper assertRetryPipelineExecutionAllowed). Its fail-closed guard IS enforced by retry_pipeline's Phase A.1; this allowlist only suppresses the cross-surface A.2 noise on the shared file. NOT a hole." },
+          { "method": "updatePolicy", "reason": "Same as createPolicy: declared+guarded under retry_pipeline (shared file)." },
+          { "method": "deletePolicy", "reason": "Same as createPolicy: declared+guarded under retry_pipeline (shared file)." },
+          { "method": "execute", "reason": "Internal class method `async execute(...)` on `class DataNodeAdapter implements FridayNodeAdapter` (a transform-node handler), NOT a route-deps mutator on the returned object. Verb-prefix 'execute' false-matches the textual scan. Not reachable as a retired surface." }
+        ],
+        "behavioralTest": "test/unit/api/runtime/friday-deterministic-pipeline-retirement-guard.test.ts",
+        "off_route_callers": "none today (the runtime is route-deps-only in the hub: bootstrap passes it to the route factory + a no-op health-check; no scheduler/event-bus/workflow consumer)",
+        "note": "Orphan off-route leak audit (2026-06-10), F3.4 top-priority: node.runner.execute was ROUTE-only-guarded. This guards the route-deps WRAPPER `nodeRunner.executeNode` that the runtime returns — NOT the shared `createNodeRunnerPipeline` engine, which the LIVE workflow runtime uses as a SEPARATE instance (verified: workflow-runtime calls its own createNodeRunnerPipeline().execute; this wrapper calls this runtime's own instance). Converted from an arrow-property closure to object-method shorthand so the textual validator can locate the method head. `execute` is a mutatorVerb (auto-flagged, declared). Reads (getExecution/listExecutions) stay arrow closures (=>-excluded from the unregistered-mutator scan)."
+      },
+      {
+        "id": "retry_pipeline",
+        "family_code": "TS_RUNTIME_RETRY_PIPELINE_RETIRED",
+        "serviceFile": "src/api/runtime/friday-deterministic-pipeline-runtime.ts",
+        "flag": "allowTestOnlyRetryPipelineExecution",
+        "guardHelper": "assertRetryPipelineExecutionAllowed",
+        "mutatingMethods": ["createPolicy", "updatePolicy", "deletePolicy", "classifyFailure", "decideRetry", "acknowledgeEscalation"],
+        "allowlistMutators": [
+          { "method": "executeNode", "reason": "TWO-SURFACES-ONE-FILE: declared AND guarded under the node_runner_execution surface (same serviceFile, flag allowTestOnlyNodeRunnerExecution, guardHelper assertNodeRunnerExecutionAllowed). Its fail-closed guard IS enforced by node_runner_execution's Phase A.1; this allowlist only suppresses the cross-surface A.2 noise. NOT a hole." },
+          { "method": "execute", "reason": "Internal class method `async execute(...)` on `class DataNodeAdapter implements FridayNodeAdapter`, NOT a route-deps mutator. Verb-prefix 'execute' false-matches. Same internal-class entry as node_runner_execution." }
+        ],
+        "behavioralTest": "test/unit/api/runtime/friday-deterministic-pipeline-retirement-guard.test.ts",
+        "off_route_callers": "none today (route-deps-only, same as node_runner_execution)",
+        "note": "Orphan off-route leak audit (2026-06-10), F3.4 top-priority: retry.* mutations were ROUTE-only-guarded. Guards the route-deps WRAPPERS (retry.createPolicy/updatePolicy/deletePolicy/classifyFailure/decideRetry/acknowledgeEscalation) — local retryRepository/failureClassifier, not the shared engine. Converted from arrow-property closures to object-method shorthand for the validator. create/update/delete are mutatorVerbs (auto-flagged); classify/decide/acknowledge are declared explicitly. Reads (getPolicy/listPolicies/getTrace/listTraces/getCostSummary/listEscalations/listCircuitBreakers) stay arrow closures. Same serviceFile as node_runner_execution; the validator scans the file once and both surfaces' declared methods are located by name."
       }
     ]
   },

--- a/src/api/fleet/friday-fleet-dashboard-service.ts
+++ b/src/api/fleet/friday-fleet-dashboard-service.ts
@@ -415,6 +415,31 @@ export function createFridayFleetDashboardService(
 ): FridayFleetDashboardService {
   const repo = createFridayFleetDashboardRepository();
 
+  // ─── TS Runtime Retirement: METHOD-level fail-closed guard ───
+  // Defense-in-depth (orphan off-route leak audit, 2026-06-10): fleet satellite
+  // remediation was ROUTE-only-guarded (friday-fleet-routes asserts the test-
+  // oracle flag after the canonical-approval gate and before this method). No
+  // non-route caller reaches `executeSatelliteRemediationAction` today, but a
+  // future internal wiring would bypass the route fence. Fails closed BEFORE the
+  // remediation effect unless the explicit test-oracle flag is set. Mirrors the
+  // route's advertised 503 code (TS_RUNTIME_FLEET_REMEDIATION_RETIRED). Reads
+  // stay live (no guard on getOverview/listSatellites/getSatelliteDetail/etc.).
+  function assertFleetRemediationExecutionAllowed(): void {
+    if (deps.allowTestOnlyFleetRemediationExecution !== true) {
+      throw new FridayDomainError(
+        "TS_RUNTIME_FLEET_REMEDIATION_RETIRED",
+        "TypeScript fleet satellite remediation is fail-closed in default/live runtime; use the Rust-owned fleet remediation entrypoint.",
+        {
+          httpStatus: 503,
+          details: {
+            classification: "fail_closed",
+            replacement: "rust_owned_fleet_remediation_entrypoint_required",
+          },
+        },
+      );
+    }
+  }
+
   return {
     getOverview() {
       const now = deps.nowIso();
@@ -693,6 +718,7 @@ export function createFridayFleetDashboardService(
     },
 
     async executeSatelliteRemediationAction(input) {
+      assertFleetRemediationExecutionAllowed();
       const detail = this.getSatelliteDetail(input.satelliteId);
       if (!detail) {
         throw new FridayDomainError(

--- a/src/api/fleet/friday-fleet-dashboard-service.types.ts
+++ b/src/api/fleet/friday-fleet-dashboard-service.types.ts
@@ -28,4 +28,13 @@ export interface CreateFridayFleetDashboardServiceDeps {
   nowIso: () => string;
   idGenerator: () => string;
   outboxQueueService?: FridayOutboxQueueService;
+  /**
+   * Test-oracle only: allows the legacy TypeScript fleet satellite-remediation
+   * mutation (`executeSatelliteRemediationAction`) in isolated test/validation
+   * harnesses. Default/live runtime must leave this unset so the method fails
+   * closed for ALL callers (the HTTP fleet route guard is bypassed by a direct
+   * method call). Reads (getOverview/listSatellites/getSatelliteDetail/
+   * getSatelliteRemediationPlan/getSecurityCenter) stay live. Never default on.
+   */
+  allowTestOnlyFleetRemediationExecution?: boolean;
 }

--- a/src/api/realtime/friday-realtime-subscription-service.ts
+++ b/src/api/realtime/friday-realtime-subscription-service.ts
@@ -1,4 +1,5 @@
 import * as crypto from "node:crypto";
+import { FridayDomainError } from "#errors";
 import type { FridaySqliteLayer } from "#state";
 import type {
   FridayRealtimeEventEnvelope,
@@ -125,6 +126,17 @@ export interface CreateFridayRealtimeSubscriptionServiceDeps {
   nowIso: () => string;
   currentEpoch: number;
   cursorSecret?: string;
+  /**
+   * Test-oracle only: allows the legacy TypeScript realtime checkpoint-ack
+   * mutation (`ackEvent`) in isolated test/validation harnesses. Default/live
+   * runtime must leave this unset so the method fails closed for ALL ingress
+   * (the HTTP /v1/realtime/ack route AND the WS `ack` frame both already gate on
+   * the same flag BEFORE calling ackEvent; this method-head guard formalizes
+   * that two-site fence as a registered method guard). Reads
+   * (validateSubscriptions/pullEvents/getCheckpoint/cursor helpers) stay live.
+   * Never default this flag on in production.
+   */
+  allowTestOnlyRealtimeExecution?: boolean;
 }
 
 // ─── Factory ───
@@ -133,6 +145,31 @@ export function createFridayRealtimeSubscriptionService(
   deps: CreateFridayRealtimeSubscriptionServiceDeps,
 ): FridayRealtimeSubscriptionService {
   const cursorSecret = deps.cursorSecret ?? crypto.randomBytes(16).toString("hex");
+
+  // ─── TS Runtime Retirement: METHOD-level fail-closed guard ───
+  // Defense-in-depth (orphan off-route leak audit, 2026-06-10): the realtime
+  // checkpoint-ack mutation has TWO live ingress points — the HTTP /v1/realtime/
+  // ack route and the WS `ack` frame — and both already gate on
+  // allowTestOnlyRealtimeExecution before calling ackEvent. This method-head
+  // guard registers that de-facto two-site fence as a single method guard, so a
+  // future THIRD caller of ackEvent cannot bypass it. Fails closed BEFORE the
+  // checkpoint upsert unless the explicit test-oracle flag is set. Mirrors the
+  // ingress 503 code (TS_RUNTIME_REALTIME_RETIRED).
+  function assertRealtimeAckExecutionAllowed(): void {
+    if (deps.allowTestOnlyRealtimeExecution !== true) {
+      throw new FridayDomainError(
+        "TS_RUNTIME_REALTIME_RETIRED",
+        "TypeScript realtime checkpoint-ack is fail-closed in default/live runtime; use the Rust-owned realtime delivery entrypoint.",
+        {
+          httpStatus: 503,
+          details: {
+            classification: "fail_closed",
+            replacement: "rust_owned_realtime_entrypoint_required",
+          },
+        },
+      );
+    }
+  }
 
   /** Check if a streamId is valid for the given topic based on prefix rules. */
   function isStreamValidForTopic(topic: FridayRealtimeTopic, streamId: string): boolean {
@@ -210,6 +247,7 @@ export function createFridayRealtimeSubscriptionService(
     },
 
     ackEvent(principalId, streamId, seq, epoch, cursor) {
+      assertRealtimeAckExecutionAllowed();
       if (epoch !== deps.currentEpoch) {
         return { accepted: false };
       }

--- a/src/api/runtime/friday-api-runtime.ts
+++ b/src/api/runtime/friday-api-runtime.ts
@@ -1510,6 +1510,12 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
     nowIso: deps.nowIso,
     currentEpoch: CURRENT_EPOCH,
     cursorSecret: deps.tokenSecret,
+    // TS-runtime-retirement (method-level guard): same top-level flag the HTTP
+    // realtime route + WS ack frame use, so ackEvent fail-closes by default in
+    // live (all three sites fenced) and the legacy path is reachable only under
+    // the test oracle. Both ingress points already pre-check this flag, so live
+    // test-oracle mode passes the ingress gate AND this method guard together.
+    allowTestOnlyRealtimeExecution: deps.allowTestOnlyRealtimeExecution,
   });
 
   const wsGateway = createFridayRealtimeWsGateway({
@@ -1547,6 +1553,10 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
     nowIso: deps.nowIso,
     idGenerator: deps.idGenerator,
     outboxQueueService: deps.outboxQueueService,
+    // TS-runtime-retirement (method-level guard): same top-level flag the fleet
+    // route uses, so the method fail-closes by default in live (route + method
+    // both fenced) and the legacy path is reachable only under the test oracle.
+    allowTestOnlyFleetRemediationExecution: deps.allowTestOnlyFleetRemediationExecution,
   });
 
   // Conflicts
@@ -1919,6 +1929,11 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
         nowIso: deps.nowIso,
         stateDir,
         canonicalMutationGate,
+        // TS-runtime-retirement (method-level guard): same top-level flag the
+        // autonomy route uses, so the lifecycle mutations fail-close by default
+        // in live (route + method both fenced) and the legacy path is reachable
+        // only under the test oracle.
+        allowTestOnlyAutonomyLifecycleExecution: deps.allowTestOnlyAutonomyLifecycleExecution,
       })
     : undefined;
   const channelAdapterUpgradeLifecycle = deps.channels?.registry

--- a/src/api/runtime/friday-deterministic-pipeline-runtime.ts
+++ b/src/api/runtime/friday-deterministic-pipeline-runtime.ts
@@ -91,6 +91,26 @@ export interface CreateFridayDeterministicPipelineRuntimeDeps {
     nodeId: string,
     payload: Record<string, unknown>,
   ) => Promise<unknown>;
+  /**
+   * Test-oracle only: allows the legacy TypeScript node-runner EXECUTION
+   * (`nodeRunner.executeNode`) in isolated test/validation harnesses.
+   * Default/live runtime must leave this unset so the method fails closed for
+   * ALL callers (the HTTP node-runner route guard is bypassed by a direct method
+   * call on this route-deps wrapper). This guards ONLY the route-deps wrapper —
+   * NOT the shared `createNodeRunnerPipeline` engine that the live workflow
+   * runtime also uses (a separate instance). Never default this flag on in prod.
+   */
+  allowTestOnlyNodeRunnerExecution?: boolean;
+  /**
+   * Test-oracle only: allows the legacy TypeScript retry-pipeline mutations
+   * (`retry.createPolicy`/`updatePolicy`/`deletePolicy`/`classifyFailure`/
+   * `decideRetry`/`acknowledgeEscalation`) in isolated test/validation harnesses.
+   * Default/live runtime must leave this unset so the methods fail closed for ALL
+   * callers (the HTTP retry route guard is bypassed by a direct method call on
+   * these route-deps wrappers). Guards ONLY the route-deps wrappers, not the
+   * shared failure-classifier/retry repos. Never default this flag on in prod.
+   */
+  allowTestOnlyRetryPipelineExecution?: boolean;
 }
 
 const RULES_EVALUATE_SCOPE = "rules:evaluate";
@@ -459,6 +479,49 @@ export function createFridayDeterministicPipelineRuntime(
   );
   const pipelineEnabled = pipelineConfig.enabled;
   const pipelineEnforceMode = pipelineConfig.mode === "enforce";
+
+  // ─── TS Runtime Retirement: METHOD-level fail-closed guards ───
+  // Defense-in-depth (orphan off-route leak audit, 2026-06-10): node-runner
+  // execution and retry-pipeline mutations were ROUTE-only-guarded (friday-
+  // deterministic-pipeline-routes asserts the test-oracle flags before the
+  // engine call). These guards fence the route-deps WRAPPERS that this runtime
+  // returns (node.runner.execute, retry.*) — NOT the shared `createNodeRunner
+  // Pipeline`/classifier engines, which the LIVE workflow runtime uses as
+  // separate instances. The runtime is route-deps-only in the hub (bootstrap
+  // passes it to the route factory + a no-op health-check; no scheduler/event-bus
+  // consumer), so guarding the wrapper fails any future non-route caller closed
+  // BEFORE the engine call, with NO effect on the live workflow pipeline. Mirror
+  // the route's advertised 503 codes. Reads (get*/list*) stay live (un-guarded).
+  function assertNodeRunnerExecutionAllowed(): void {
+    if (deps.allowTestOnlyNodeRunnerExecution !== true) {
+      throw new FridayDomainError(
+        "TS_RUNTIME_NODE_RUNNER_EXECUTION_RETIRED",
+        "TypeScript node-runner execution is fail-closed in default/live runtime; use the Rust-owned node-runner entrypoint.",
+        {
+          httpStatus: 503,
+          details: {
+            classification: "fail_closed",
+            replacement: "rust_owned_node_runner_entrypoint_required",
+          },
+        },
+      );
+    }
+  }
+  function assertRetryPipelineExecutionAllowed(): void {
+    if (deps.allowTestOnlyRetryPipelineExecution !== true) {
+      throw new FridayDomainError(
+        "TS_RUNTIME_RETRY_PIPELINE_RETIRED",
+        "TypeScript retry-pipeline mutation is fail-closed in default/live runtime; use the Rust-owned retry entrypoint.",
+        {
+          httpStatus: 503,
+          details: {
+            classification: "fail_closed",
+            replacement: "rust_owned_retry_pipeline_entrypoint_required",
+          },
+        },
+      );
+    }
+  }
 
   const rulesRepository = createFridayRulesRepository();
   const policyBundleRepository = createFridayPolicyBundleRepository();
@@ -1080,7 +1143,8 @@ export function createFridayDeterministicPipelineRuntime(
     },
 
     nodeRunner: {
-      executeNode: async (body) => {
+      async executeNode(body) {
+        assertNodeRunnerExecutionAllowed();
         const payload = asRecord(body);
         const nodeId = asString(payload.nodeId) ?? deps.idGenerator();
         const nodeType = asString(payload.nodeType) ?? "action";
@@ -1493,7 +1557,8 @@ export function createFridayDeterministicPipelineRuntime(
         return { items, total: items.length };
       },
 
-      createPolicy: (body) => {
+      createPolicy(body) {
+        assertRetryPipelineExecutionAllowed();
         const payload = asRecord(body);
         const now = deps.nowIso();
         const policy: FridayRetryPolicy = {
@@ -1545,7 +1610,8 @@ export function createFridayDeterministicPipelineRuntime(
         return { policy };
       },
 
-      updatePolicy: (policyId, body) => {
+      updatePolicy(policyId, body) {
+        assertRetryPipelineExecutionAllowed();
         const payload = asRecord(body);
         const current = retryPersistenceAvailable
           ? deps.db.withReadConnection((db) => retryRepository.getPolicyById(db, policyId))
@@ -1606,7 +1672,8 @@ export function createFridayDeterministicPipelineRuntime(
         return { policy: updated };
       },
 
-      deletePolicy: (policyId, body) => {
+      deletePolicy(policyId, body) {
+        assertRetryPipelineExecutionAllowed();
         const payload = asRecord(body);
         const current = retryPersistenceAvailable
           ? deps.db.withReadConnection((db) => retryRepository.getPolicyById(db, policyId))
@@ -1655,7 +1722,8 @@ export function createFridayDeterministicPipelineRuntime(
         return { items: runId ? retryTraces.filter((trace) => trace.runId === runId) : [...retryTraces] };
       },
 
-      classifyFailure: (body) => {
+      classifyFailure(body) {
+        assertRetryPipelineExecutionAllowed();
         const payload = asRecord(body);
         const error = toClassifyFailureError(payload.error);
         if (!error) {
@@ -1668,7 +1736,8 @@ export function createFridayDeterministicPipelineRuntime(
         return { classifiedFailure };
       },
 
-      decideRetry: (body) => {
+      decideRetry(body) {
+        assertRetryPipelineExecutionAllowed();
         const payload = asRecord(body);
         const classifiedFailure = payload.classifiedFailure
           ? payload.classifiedFailure as FridayClassifiedFailure
@@ -1884,7 +1953,8 @@ export function createFridayDeterministicPipelineRuntime(
         return { items, total: items.length };
       },
 
-      acknowledgeEscalation: (escalationId) => {
+      acknowledgeEscalation(escalationId) {
+        assertRetryPipelineExecutionAllowed();
         if (!retryPersistenceAvailable) {
           throw new FridayDomainError("RETRY_ESCALATION_NOT_FOUND", "Retry escalation not found", { httpStatus: 404 });
         }

--- a/src/autonomy/services/friday-mcp-server-upgrade-lifecycle-service.ts
+++ b/src/autonomy/services/friday-mcp-server-upgrade-lifecycle-service.ts
@@ -100,6 +100,15 @@ export interface CreateFridayMcpServerUpgradeLifecycleServiceDeps {
   nowIso: () => string;
   stateDir?: string;
   canonicalMutationGate?: FridayMutatingActionGate;
+  /**
+   * Test-oracle only: allows the legacy TypeScript MCP-server upgrade-lifecycle
+   * mutations (`registerShadowVersion`/`recordCanaryResult`/`promote`/`rollback`)
+   * in isolated test/validation harnesses. Default/live runtime must leave this
+   * unset so the methods fail closed for ALL callers (the autonomy route guard,
+   * assertAutonomyLifecycleTestOracleAllowed, is bypassed by a direct method
+   * call). Reads (getLifecycleEvidence) stay live. Never default on in prod.
+   */
+  allowTestOnlyAutonomyLifecycleExecution?: boolean;
 }
 
 interface McpServerLifecycleSnapshot {
@@ -198,6 +207,31 @@ export function createFridayMcpServerLifecycleMutatingActionRequest(
 export function createFridayMcpServerUpgradeLifecycleService(
   deps: CreateFridayMcpServerUpgradeLifecycleServiceDeps,
 ): FridayMcpServerUpgradeLifecycleService {
+  // ─── TS Runtime Retirement: METHOD-level fail-closed guard ───
+  // Defense-in-depth (orphan off-route leak audit, 2026-06-10): the autonomy MCP-
+  // server upgrade-lifecycle mutations were ROUTE-only-guarded (friday-autonomy-
+  // routes asserts allowTestOnlyAutonomyLifecycleExecution before the mcpServer-
+  // Actions handlers). No autonomy self-upgrade scheduler is wired today (these
+  // are route-deps-only), but a future auto-promotion loop would bypass the route
+  // fence. Each lifecycle mutation fails closed BEFORE the canonical-ticket check
+  // and any state write unless the explicit test-oracle flag is set. Mirrors the
+  // route's advertised 503 code (TS_RUNTIME_AUTONOMY_LIFECYCLE_RETIRED).
+  function assertAutonomyLifecycleExecutionAllowed(): void {
+    if (deps.allowTestOnlyAutonomyLifecycleExecution !== true) {
+      throw new FridayDomainError(
+        "TS_RUNTIME_AUTONOMY_LIFECYCLE_RETIRED",
+        "TypeScript MCP-server upgrade lifecycle is fail-closed in default/live runtime; use the Rust-owned autonomy lifecycle entrypoint.",
+        {
+          httpStatus: 503,
+          details: {
+            classification: "fail_closed",
+            replacement: "rust_owned_autonomy_lifecycle_entrypoint_required",
+          },
+        },
+      );
+    }
+  }
+
   function getServer(serverId: string): ReturnType<FridayMcpAdapter["listServers"]>[number] {
     const found = deps.mcpAdapter.listServers().find((server) => server.id === serverId);
     if (!found) {
@@ -361,6 +395,7 @@ export function createFridayMcpServerUpgradeLifecycleService(
 
   return {
     registerShadowVersion(input) {
+      assertAutonomyLifecycleExecutionAllowed();
       const ticket = requireCanonicalLifecycleTicket({
         action: "shadow",
         serverId: input.serverId,
@@ -404,6 +439,7 @@ export function createFridayMcpServerUpgradeLifecycleService(
     },
 
     async recordCanaryResult(input) {
+      assertAutonomyLifecycleExecutionAllowed();
       const state = getState(input.serverId);
       const shadowVersionId = state?.shadowVersionId;
       if (state?.promotionChannel !== "shadow" && state?.promotionChannel !== "canary") {
@@ -512,6 +548,7 @@ export function createFridayMcpServerUpgradeLifecycleService(
     },
 
     promote(input) {
+      assertAutonomyLifecycleExecutionAllowed();
       const current = getState(input.serverId);
       const evidence = readEvidence(input.serverId);
       if (current?.promotionChannel !== "canary") {
@@ -575,6 +612,7 @@ export function createFridayMcpServerUpgradeLifecycleService(
     },
 
     rollback(input) {
+      assertAutonomyLifecycleExecutionAllowed();
       const current = getCanaryStats(input.serverId);
       const evidence = readEvidence(input.serverId);
       const rollbackTarget = evidence.shadow?.previous;

--- a/src/hub/bootstrap/hub-helpers.ts
+++ b/src/hub/bootstrap/hub-helpers.ts
@@ -1894,6 +1894,10 @@ export interface FridayHubConfig {
   allowTestOnlyDiagnosisExecution?: boolean;
   /** Test-oracle only; production hub creation must leave the realtime checkpoint-ack mutation fail-closed. */
   allowTestOnlyRealtimeExecution?: boolean;
+  /** Test-oracle only; production hub creation must leave inbound satellite runtime mutations (heartbeat/capabilities/sync) fail-closed. */
+  allowTestOnlySatelliteRuntimeExecution?: boolean;
+  /** Test-oracle only; production hub creation must leave satellite registration/pairing mutations fail-closed. */
+  allowTestOnlySatellitePairingExecution?: boolean;
   /** Test-oracle only; production hub creation must leave skill-converter convert/import/pack mutations fail-closed. */
   allowTestOnlySkillConverterExecution?: boolean;
   /** Test-oracle only; production hub creation must leave scan-migrate local-scan + batch-convert product logic fail-closed. */

--- a/src/hub/friday-hub-bootstrap.ts
+++ b/src/hub/friday-hub-bootstrap.ts
@@ -6268,6 +6268,13 @@ export async function createFridayHub(
         },
       });
     },
+    // TS-runtime-retirement (method-level guards): same top-level flags the
+    // satellite-runtime + pairing ROUTES use, so the inbound satellite mutations
+    // (register/pairing/heartbeat/capabilities/sync) fail-close by default in
+    // live (route + method both fenced) and are reachable only under the test
+    // oracle. Live/prod config leaves these unset.
+    allowTestOnlySatelliteRuntimeExecution: config.allowTestOnlySatelliteRuntimeExecution,
+    allowTestOnlySatellitePairingExecution: config.allowTestOnlySatellitePairingExecution,
   });
 
   const workflowSatelliteDispatcher = createFridayWorkflowSatelliteDispatchService({

--- a/src/satellites/runtime/friday-satellite-runtime.ts
+++ b/src/satellites/runtime/friday-satellite-runtime.ts
@@ -46,6 +46,21 @@ export interface CreateFridaySatelliteRuntimeOptions {
     explicitDisconnect?: boolean;
   }) => void;
   onSatelliteResumeEligible?: (signal: FridaySatelliteResumeSignal) => void;
+  /**
+   * Test-oracle only (TS Runtime Retirement, method-level guards): forwarded to
+   * the inbound satellite-runtime services (heartbeat/capabilities/sync) so the
+   * legacy TypeScript mutations remain reachable in test/validation harnesses.
+   * Default/live hub leaves this unset so the methods fail closed (mirroring the
+   * route fence). See the per-service guard for behavior.
+   */
+  allowTestOnlySatelliteRuntimeExecution?: boolean;
+  /**
+   * Test-oracle only (TS Runtime Retirement, method-level guards): forwarded to
+   * the inbound satellite-pairing services (registration/pairing) so the legacy
+   * TypeScript mutations remain reachable in test/validation harnesses.
+   * Default/live hub leaves this unset so the methods fail closed.
+   */
+  allowTestOnlySatellitePairingExecution?: boolean;
 }
 
 /**
@@ -68,6 +83,8 @@ export function createFridaySatelliteRuntime(
     remoteNodeResultWriter,
     onStatusTransition,
     onSatelliteResumeEligible,
+    allowTestOnlySatelliteRuntimeExecution,
+    allowTestOnlySatellitePairingExecution,
   } = options;
 
   // Repositories
@@ -117,6 +134,7 @@ export function createFridaySatelliteRuntime(
     idGenerator,
     nowIso,
     pairingTtlMs,
+    allowTestOnlySatellitePairingExecution,
   });
 
   const pairing = createFridaySatellitePairingService({
@@ -128,6 +146,7 @@ export function createFridaySatelliteRuntime(
     idGenerator,
     nowIso,
     tokenSecret,
+    allowTestOnlySatellitePairingExecution,
   });
 
   const capabilities = createFridaySatelliteCapabilityService({
@@ -137,6 +156,7 @@ export function createFridaySatelliteRuntime(
     idGenerator,
     nowIso,
     revisionCache: new Map(),
+    allowTestOnlySatelliteRuntimeExecution,
   });
 
   const heartbeat = createFridaySatelliteHeartbeatService({
@@ -147,6 +167,7 @@ export function createFridaySatelliteRuntime(
     nowIso,
     expectedIntervalMs: expectedHeartbeatIntervalMs,
     onStatusTransition: chainedStatusTransition,
+    allowTestOnlySatelliteRuntimeExecution,
   });
 
   const offlineSweeper = createFridaySatelliteOfflineSweeper({
@@ -176,6 +197,7 @@ export function createFridaySatelliteRuntime(
       learningLedger.appendBatch(events);
     }),
     remoteNodeResultWriter,
+    allowTestOnlySatelliteRuntimeExecution,
   });
   const localRunner = createFridaySatelliteLocalRunnerService({ sync });
 

--- a/src/satellites/services/friday-satellite-capability-service.ts
+++ b/src/satellites/services/friday-satellite-capability-service.ts
@@ -1,3 +1,4 @@
+import { FridayDomainError } from "#errors";
 import type { FridaySqliteLayer } from "#state";
 import type { FridaySatelliteCapabilityReport } from "../model/friday-satellite.types.js";
 import type { FridaySatelliteRepository } from "../persistence/friday-satellite-repository.js";
@@ -18,6 +19,14 @@ export interface CreateCapabilityServiceDeps {
   nowIso: () => string;
   /** @deprecated Kept for API compatibility; revision is now persisted in hub_settings. */
   revisionCache?: Map<string, number>;
+  /**
+   * Test-oracle only: allows the legacy TypeScript satellite-capability
+   * mutation (`updateCapabilities`) in isolated test/validation harnesses.
+   * Default/live runtime must leave this unset so the method fails closed for
+   * ALL callers (the HTTP satellite-runtime route guard is bypassed by a direct
+   * method call). Never default this flag on in production.
+   */
+  allowTestOnlySatelliteRuntimeExecution?: boolean;
 }
 
 const REVISION_KEY_PREFIX = "capability_revision:";
@@ -25,8 +34,32 @@ const REVISION_KEY_PREFIX = "capability_revision:";
 export function createFridaySatelliteCapabilityService(
   deps: CreateCapabilityServiceDeps,
 ): FridaySatelliteCapabilityService {
+  // ─── TS Runtime Retirement: METHOD-level fail-closed guard ───
+  // Defense-in-depth (orphan off-route leak audit, 2026-06-10): the satellite
+  // capability mutation was ROUTE-only-guarded (friday-satellite-runtime-routes).
+  // No non-route caller reaches `updateCapabilities` today, but a future inbound
+  // wiring would bypass the route fence. Fails closed BEFORE the capability/
+  // revision write unless the explicit test-oracle flag is set. Mirrors the
+  // route's advertised 503 code (TS_RUNTIME_SATELLITE_RUNTIME_RETIRED).
+  function assertSatelliteRuntimeExecutionAllowed(): void {
+    if (deps.allowTestOnlySatelliteRuntimeExecution !== true) {
+      throw new FridayDomainError(
+        "TS_RUNTIME_SATELLITE_RUNTIME_RETIRED",
+        "TypeScript satellite capability update is fail-closed in default/live runtime; use the Rust-owned satellite runtime entrypoint.",
+        {
+          httpStatus: 503,
+          details: {
+            classification: "fail_closed",
+            replacement: "rust_owned_satellite_runtime_entrypoint_required",
+          },
+        },
+      );
+    }
+  }
+
   return {
     updateCapabilities(report) {
+      assertSatelliteRuntimeExecutionAllowed();
       return deps.db.withWriteTransaction((db) => {
         // Enforce monotonic revision from persisted state
         const revisionKey = `${REVISION_KEY_PREFIX}${report.satelliteId}`;

--- a/src/satellites/services/friday-satellite-heartbeat-service.ts
+++ b/src/satellites/services/friday-satellite-heartbeat-service.ts
@@ -34,6 +34,14 @@ export interface CreateHeartbeatServiceDeps {
     failureRate1m?: number;
     explicitDisconnect?: boolean;
   }) => void;
+  /**
+   * Test-oracle only: allows the legacy TypeScript satellite-heartbeat mutation
+   * (`recordHeartbeat`) in isolated test/validation harnesses. Default/live
+   * runtime must leave this unset so the method fails closed for ALL callers
+   * (the HTTP satellite-runtime route guard is bypassed by a direct method
+   * call). Never default this flag on in production.
+   */
+  allowTestOnlySatelliteRuntimeExecution?: boolean;
 }
 
 /** Default expected heartbeat interval: 15 seconds. */
@@ -44,8 +52,32 @@ export function createFridaySatelliteHeartbeatService(
 ): FridaySatelliteHeartbeatService {
   const expectedIntervalMs = deps.expectedIntervalMs ?? DEFAULT_EXPECTED_INTERVAL_MS;
 
+  // ─── TS Runtime Retirement: METHOD-level fail-closed guard ───
+  // Defense-in-depth (orphan off-route leak audit, 2026-06-10): the satellite
+  // heartbeat mutation was ROUTE-only-guarded (friday-satellite-runtime-routes).
+  // No non-route caller reaches `recordHeartbeat` today, but a future inbound
+  // wiring would bypass the route fence. Fails closed BEFORE the heartbeat/
+  // status-transition write unless the explicit test-oracle flag is set. Mirrors
+  // the route's advertised 503 code (TS_RUNTIME_SATELLITE_RUNTIME_RETIRED).
+  function assertSatelliteRuntimeExecutionAllowed(): void {
+    if (deps.allowTestOnlySatelliteRuntimeExecution !== true) {
+      throw new FridayDomainError(
+        "TS_RUNTIME_SATELLITE_RUNTIME_RETIRED",
+        "TypeScript satellite heartbeat is fail-closed in default/live runtime; use the Rust-owned satellite runtime entrypoint.",
+        {
+          httpStatus: 503,
+          details: {
+            classification: "fail_closed",
+            replacement: "rust_owned_satellite_runtime_entrypoint_required",
+          },
+        },
+      );
+    }
+  }
+
   return {
     recordHeartbeat(input) {
+      assertSatelliteRuntimeExecutionAllowed();
       let transition:
         | {
           satelliteId: string;

--- a/src/satellites/services/friday-satellite-pairing-service.ts
+++ b/src/satellites/services/friday-satellite-pairing-service.ts
@@ -75,6 +75,14 @@ export interface CreatePairingServiceDeps {
   tokenSecret: string;
   /** Optional override for ephemeral key generation (testing). */
   generateEphemeralKeyPair?: () => { publicKey: string; privateKey: string };
+  /**
+   * Test-oracle only: allows the legacy TypeScript satellite-pairing mutations
+   * (`approvePairing`/`rejectPairing`/`completeHandshake`/`revokeSatellite`) in
+   * isolated test/validation harnesses. Default/live runtime must leave this
+   * unset so the methods fail closed for ALL callers (the HTTP pairing route
+   * guard is bypassed by a direct method call). Never default this on in prod.
+   */
+  allowTestOnlySatellitePairingExecution?: boolean;
 }
 
 function hashToken(token: string): string {
@@ -131,8 +139,34 @@ function extractTokenVersionFromLabel(label: string): number | undefined {
 export function createFridaySatellitePairingService(
   deps: CreatePairingServiceDeps,
 ): FridaySatellitePairingService {
+  // ─── TS Runtime Retirement: METHOD-level fail-closed guard ───
+  // Defense-in-depth (orphan off-route leak audit, 2026-06-10): the satellite
+  // pairing mutations were ROUTE-only-guarded (friday-satellite-pairing-routes).
+  // No non-route caller reaches these methods today (route-deps-only; the TUI
+  // hits the guarded HTTP route over the wire), but a future inbound wiring (an
+  // auto-pairing/handshake loop) would bypass the route fence and reopen a
+  // G4-class leak. Each pairing mutation fails closed BEFORE any pairing/token/
+  // satellite row write unless the explicit test-oracle flag is set. Mirrors the
+  // route's advertised 503 code (TS_RUNTIME_SATELLITE_PAIRING_RETIRED).
+  function assertSatellitePairingExecutionAllowed(): void {
+    if (deps.allowTestOnlySatellitePairingExecution !== true) {
+      throw new FridayDomainError(
+        "TS_RUNTIME_SATELLITE_PAIRING_RETIRED",
+        "TypeScript satellite pairing is fail-closed in default/live runtime; use the Rust-owned satellite pairing entrypoint.",
+        {
+          httpStatus: 503,
+          details: {
+            classification: "fail_closed",
+            replacement: "rust_owned_satellite_pairing_entrypoint_required",
+          },
+        },
+      );
+    }
+  }
+
   return {
     approvePairing(input) {
+      assertSatellitePairingExecutionAllowed();
       return deps.db.withWriteTransaction((db) => {
         const nowIso = deps.nowIso();
 
@@ -203,6 +237,7 @@ export function createFridaySatellitePairingService(
     },
 
     rejectPairing(input) {
+      assertSatellitePairingExecutionAllowed();
       deps.db.withWriteTransaction((db) => {
         const nowIso = deps.nowIso();
         const request = deps.pairingRequestRepo.getRequest(db, input.requestId);
@@ -221,6 +256,7 @@ export function createFridaySatellitePairingService(
     },
 
     completeHandshake(input) {
+      assertSatellitePairingExecutionAllowed();
       return deps.db.withWriteTransaction((db) => {
         const nowIso = deps.nowIso();
 
@@ -304,6 +340,7 @@ export function createFridaySatellitePairingService(
     },
 
     revokeSatellite(input) {
+      assertSatellitePairingExecutionAllowed();
       deps.db.withWriteTransaction((db) => {
         const nowIso = deps.nowIso();
 

--- a/src/satellites/services/friday-satellite-registration-service.ts
+++ b/src/satellites/services/friday-satellite-registration-service.ts
@@ -1,4 +1,5 @@
 import { randomBytes } from "node:crypto";
+import { FridayDomainError } from "#errors";
 import type { FridaySqliteLayer } from "#state";
 import type { FridaySatelliteRegistrationInput } from "../model/friday-satellite.types.js";
 import type { FridaySatelliteRepository } from "../persistence/friday-satellite-repository.js";
@@ -27,6 +28,14 @@ export interface CreateRegistrationServiceDeps {
   idGenerator: () => string;
   nowIso: () => string;
   pairingTtlMs?: number;
+  /**
+   * Test-oracle only: allows the legacy TypeScript satellite-registration
+   * mutation (`register`) in isolated test/validation harnesses. Default/live
+   * runtime must leave this unset so the method fails closed for ALL callers,
+   * including any non-route caller (the HTTP pairing route guard is bypassed by
+   * a direct method call). Never default this flag on in production.
+   */
+  allowTestOnlySatellitePairingExecution?: boolean;
 }
 
 /** Default pairing request TTL: 10 minutes. */
@@ -37,8 +46,33 @@ export function createFridaySatelliteRegistrationService(
 ): FridaySatelliteRegistrationService {
   const pairingTtlMs = deps.pairingTtlMs ?? DEFAULT_PAIRING_TTL_MS;
 
+  // ─── TS Runtime Retirement: METHOD-level fail-closed guard ───
+  // Defense-in-depth (orphan off-route leak audit, 2026-06-10): satellite
+  // registration was ROUTE-only-guarded (friday-satellite-pairing-routes asserts
+  // the test-oracle flag before the register route). Today no non-route caller
+  // reaches `register` — it is route-deps-only — but a FUTURE wiring (e.g. an
+  // auto-pairing loop) would silently reopen a G4-class leak. Guarding here fails
+  // ALL non-route callers closed BEFORE any satellite/pairing row write, unless
+  // the explicit test-oracle flag is set. Mirrors the route's advertised 503 code.
+  function assertSatelliteRegistrationExecutionAllowed(): void {
+    if (deps.allowTestOnlySatellitePairingExecution !== true) {
+      throw new FridayDomainError(
+        "TS_RUNTIME_SATELLITE_PAIRING_RETIRED",
+        "TypeScript satellite registration is fail-closed in default/live runtime; use the Rust-owned satellite pairing entrypoint.",
+        {
+          httpStatus: 503,
+          details: {
+            classification: "fail_closed",
+            replacement: "rust_owned_satellite_pairing_entrypoint_required",
+          },
+        },
+      );
+    }
+  }
+
   return {
     register(input) {
+      assertSatelliteRegistrationExecutionAllowed();
       return deps.db.withWriteTransaction((db) => {
         const satelliteId = deps.idGenerator();
         const requestId = deps.idGenerator();

--- a/src/satellites/services/friday-satellite-sync-service.ts
+++ b/src/satellites/services/friday-satellite-sync-service.ts
@@ -1,3 +1,4 @@
+import { FridayDomainError } from "#errors";
 import type { FridaySqliteLayer } from "#state";
 import type { FridayLearningEventAppendInput } from "#ledger";
 import type { FridayResumeValidationResult } from "../model/friday-satellite-protocol.types.js";
@@ -66,13 +67,50 @@ export interface CreateSyncServiceDeps {
   nowIso: () => string;
   learningEventWriter?: (events: FridayLearningEventAppendInput[]) => void;
   remoteNodeResultWriter?: (input: FridaySyncNodeResultInput & { satelliteId: string }) => Promise<void>;
+  /**
+   * Test-oracle only: allows the legacy TypeScript satellite-sync mutations
+   * (`pull`/`push`) in isolated test/validation harnesses. Default/live runtime
+   * must leave this unset so the methods fail closed for ALL callers (the HTTP
+   * satellite-runtime route guard is bypassed by a direct method call). The
+   * satellite-side local runner is a different object (an injected API-client)
+   * that is not wired in the hub. Never default this flag on in production.
+   */
+  allowTestOnlySatelliteRuntimeExecution?: boolean;
 }
 
 export function createFridaySatelliteSyncService(
   deps: CreateSyncServiceDeps,
 ): FridaySatelliteSyncService {
+  // ─── TS Runtime Retirement: METHOD-level fail-closed guard ───
+  // Defense-in-depth (orphan off-route leak audit, 2026-06-10): the inbound
+  // satellite sync mutations (pull leases the outbox command-queue + signs a
+  // cursor; push persists acks/node-results) were ROUTE-only-guarded
+  // (friday-satellite-runtime-routes pushSync/pullSync). No non-route caller
+  // reaches these in the hub today (the off-hub local-runner uses an injected
+  // API-client, not this engine), but a future inbound wiring would bypass the
+  // route fence. Fails closed BEFORE any checkpoint/outbox/result write unless
+  // the explicit test-oracle flag is set. Note: this guards the inbound sync
+  // engine only; the hub→satellite outbox command-queue (outbox.enqueue) and the
+  // retention GC are SEPARATE non-retired services and are NOT fenced here.
+  function assertSatelliteRuntimeExecutionAllowed(): void {
+    if (deps.allowTestOnlySatelliteRuntimeExecution !== true) {
+      throw new FridayDomainError(
+        "TS_RUNTIME_SATELLITE_RUNTIME_RETIRED",
+        "TypeScript satellite sync is fail-closed in default/live runtime; use the Rust-owned satellite runtime entrypoint.",
+        {
+          httpStatus: 503,
+          details: {
+            classification: "fail_closed",
+            replacement: "rust_owned_satellite_runtime_entrypoint_required",
+          },
+        },
+      );
+    }
+  }
+
   return {
     pull(input) {
+      assertSatelliteRuntimeExecutionAllowed();
       return deps.db.withWriteTransaction((db) => {
         const nowIso = deps.nowIso();
         const currentEpoch = deps.checkpointRepo.getEpoch(db);
@@ -147,6 +185,7 @@ export function createFridaySatelliteSyncService(
     },
 
     async push(input) {
+      assertSatelliteRuntimeExecutionAllowed();
       const acceptedNodeResults: FridaySyncPushResult["acceptedNodeResults"] = [];
       const nodeResultConflicts: FridaySyncPushResult["conflicts"] = [];
 

--- a/test/integration/hub/friday-hub-bootstrap-integration.test.ts
+++ b/test/integration/hub/friday-hub-bootstrap-integration.test.ts
@@ -200,6 +200,12 @@ describe("FridayHub Bootstrap Integration", () => {
   ): Promise<FridayHub> {
     const hub = await createFridayHub({
       allowTestOnlyWorkflowRunExecution: true, // TS-retirement method guard: test-oracle opt-in
+      // TS-retirement method guards (orphan off-route leak audit): these hub
+      // integration tests exercise the legacy TypeScript inbound satellite paths
+      // (sync/register/heartbeat) as part of self-learning/self-healing scenarios.
+      // Production hub creation leaves these unset so the methods fail closed.
+      allowTestOnlySatelliteRuntimeExecution: true,
+      allowTestOnlySatellitePairingExecution: true,
       stateDir,
       skillDirs: [bundledSkillsDir, managedSkillsDir],
     });

--- a/test/integration/satellites/friday-satellite-runtime-resume.test.ts
+++ b/test/integration/satellites/friday-satellite-runtime-resume.test.ts
@@ -77,6 +77,11 @@ describe("FridaySatelliteRuntime offline -> resume integration", () => {
       nowIso: () => nowIso,
       onStatusTransition,
       onSatelliteResumeEligible,
+      // TS-runtime-retirement: exercise the legacy TypeScript inbound satellite
+      // mutations (heartbeat/sync) in this integration test; default/live hub
+      // leaves these unset so the methods fail closed.
+      allowTestOnlySatelliteRuntimeExecution: true,
+      allowTestOnlySatellitePairingExecution: true,
     });
 
     expect(runtime.resumeCoordinator).toBeDefined();

--- a/test/unit/api/fleet/friday-fleet-dashboard-service.test.ts
+++ b/test/unit/api/fleet/friday-fleet-dashboard-service.test.ts
@@ -146,6 +146,10 @@ describe("FridayFleetDashboardService", () => {
       nowIso: () => NOW,
       idGenerator: createTestIdGenerator(),
       outboxQueueService,
+      // TS-runtime-retirement: exercise the legacy TypeScript remediation path in
+      // these unit tests; default/live runtime leaves this unset so it fails
+      // closed (the 503-by-default behavior is asserted in the dedicated guard test).
+      allowTestOnlyFleetRemediationExecution: true,
     });
   });
 

--- a/test/unit/api/fleet/friday-fleet-remediation-retirement-guard.test.ts
+++ b/test/unit/api/fleet/friday-fleet-remediation-retirement-guard.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import type { FridaySqliteLayer } from "#state";
+import { FridayDomainError } from "#errors";
+import { createFridayFleetDashboardService } from "#api";
+import { createTestDb, createTestIdGenerator } from "../../satellites/_helpers/create-test-db.helper.js";
+
+/**
+ * TS Runtime Retirement — METHOD-level guard for fleet satellite remediation
+ * (orphan off-route leak audit, 2026-06-10 defense-in-depth).
+ *
+ * `executeSatelliteRemediationAction` was ROUTE-only-guarded (friday-fleet-routes
+ * asserts the flag after the canonical-approval gate). This proves it fails closed
+ * by default (flag unset) BEFORE the remediation effect, and that reads stay live.
+ */
+
+const RETIRED_CODE = "TS_RUNTIME_FLEET_REMEDIATION_RETIRED";
+const NOW = "2026-06-10T10:00:00.000Z";
+
+describe("FridayFleetDashboardService TS-retirement method guard", () => {
+  let db: FridaySqliteLayer;
+
+  beforeEach(() => {
+    db = createTestDb();
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  function buildService(allowTestOnlyFleetRemediationExecution?: boolean) {
+    return createFridayFleetDashboardService({
+      db,
+      nowIso: () => NOW,
+      idGenerator: createTestIdGenerator(),
+      outboxQueueService: {
+        requeueExpiredLeases: async () => 0,
+        expireByTtl: async () => 0,
+      },
+      ...(allowTestOnlyFleetRemediationExecution === undefined
+        ? {}
+        : { allowTestOnlyFleetRemediationExecution }),
+    });
+  }
+
+  it("executeSatelliteRemediationAction fails closed by default: rejects with 503 fail_closed", async () => {
+    const service = buildService();
+    await expect(
+      service.executeSatelliteRemediationAction({ satelliteId: "sat-x", actionId: "requeue_expired_leases" }),
+    ).rejects.toMatchObject({ code: RETIRED_CODE, httpStatus: 503 });
+  });
+
+  it("also fails closed when the flag is explicitly false", async () => {
+    const service = buildService(false);
+    await expect(
+      service.executeSatelliteRemediationAction({ satelliteId: "sat-x", actionId: "requeue_expired_leases" }),
+    ).rejects.toMatchObject({ code: RETIRED_CODE, httpStatus: 503 });
+  });
+
+  it("read surfaces (getOverview) stay live without the flag", () => {
+    const service = buildService();
+    const overview = service.getOverview();
+    expect(overview).toBeDefined();
+  });
+
+  it("passes the guard when the test-oracle flag is enabled (reaches not-found, not the 503)", async () => {
+    const service = buildService(true);
+    // Guard open: reaches real logic; with no satellite it throws the domain
+    // SATELLITE_NOT_FOUND (NOT the retirement 503), proving the guard no longer blocks.
+    await expect(
+      service.executeSatelliteRemediationAction({ satelliteId: "sat-missing", actionId: "requeue_expired_leases" }),
+    ).rejects.toMatchObject({ code: "SATELLITE_NOT_FOUND" });
+  });
+});

--- a/test/unit/api/http/routes/friday-fleet-routes.test.ts
+++ b/test/unit/api/http/routes/friday-fleet-routes.test.ts
@@ -134,6 +134,11 @@ describe("FridayFleetRoutes", () => {
       nowIso: () => NOW,
       idGenerator: createTestIdGenerator(),
       outboxQueueService,
+      // Method-level test-oracle: let the shared service run the legacy path so the
+      // success case works. The "TS-runtime retirement" describe below builds routes
+      // WITHOUT the route flag and asserts the ROUTE guard 503s before the service is
+      // ever reached, so this method flag does not weaken that fail-close assertion.
+      allowTestOnlyFleetRemediationExecution: true,
     });
     routes = createFridayFleetRoutes({
       fleetService,

--- a/test/unit/api/http/routes/friday-realtime-routes.test.ts
+++ b/test/unit/api/http/routes/friday-realtime-routes.test.ts
@@ -171,6 +171,10 @@ describe("FridayRealtimeRoutes", () => {
         nowIso: () => NOW,
         currentEpoch: EPOCH,
         cursorSecret: "test-secret",
+        // Mirror production (api-runtime passes the same flag to the route AND the
+        // subscription service): when the route flag is on, ackEvent's method
+        // guard must also be open so the live test-oracle path reaches the ack.
+        allowTestOnlyRealtimeExecution: allow,
       });
       return createFridayRealtimeRoutes({ subscriptionService, currentEpoch: EPOCH, allowTestOnlyRealtimeExecution: allow })
         .find((r) => r.operationId === "realtime.ack")!;

--- a/test/unit/api/realtime/friday-realtime-ack-retirement-guard.test.ts
+++ b/test/unit/api/realtime/friday-realtime-ack-retirement-guard.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import type { FridaySqliteLayer } from "#state";
+import { FridayDomainError } from "#errors";
+import {
+  createFridayRealtimeCheckpointRepository,
+  createFridayRealtimeEventRepository,
+  createFridayRealtimeSubscriptionService,
+} from "#api";
+import { createTestDb } from "../../satellites/_helpers/create-test-db.helper.js";
+
+/**
+ * TS Runtime Retirement — METHOD-level guard for realtime checkpoint-ack
+ * (orphan off-route leak audit, 2026-06-10). `ackEvent` has TWO live ingress
+ * points (HTTP /v1/realtime/ack route + WS `ack` frame), both already gating the
+ * same flag. This registers that de-facto two-site fence as a single method guard:
+ * in default/live config `ackEvent` fails closed BEFORE the checkpoint upsert.
+ */
+
+const RETIRED_CODE = "TS_RUNTIME_REALTIME_RETIRED";
+const NOW = "2026-06-10T10:00:00.000Z";
+const EPOCH = 1;
+
+describe("FridayRealtimeSubscriptionService.ackEvent TS-retirement method guard", () => {
+  let db: FridaySqliteLayer;
+
+  beforeEach(() => {
+    db = createTestDb();
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  function buildService(allowTestOnlyRealtimeExecution?: boolean) {
+    return createFridayRealtimeSubscriptionService({
+      db,
+      eventRepo: createFridayRealtimeEventRepository(),
+      checkpointRepo: createFridayRealtimeCheckpointRepository(),
+      nowIso: () => NOW,
+      currentEpoch: EPOCH,
+      cursorSecret: "test-secret", // pragma: allowlist secret
+      ...(allowTestOnlyRealtimeExecution === undefined ? {} : { allowTestOnlyRealtimeExecution }),
+    });
+  }
+
+  function checkpointExists(): boolean {
+    return (
+      db.withReadConnection((reader) =>
+        (reader
+          .prepare("SELECT COUNT(*) AS c FROM realtime_checkpoints")
+          .get() as { c: number }).c,
+      ) > 0
+    );
+  }
+
+  it("ackEvent fails closed by default: throws 503 fail_closed and persists no checkpoint", () => {
+    const service = buildService();
+    let caught: unknown;
+    try {
+      service.ackEvent("user-1", "workflow:wf-1", 5, EPOCH);
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toBeInstanceOf(FridayDomainError);
+    expect((caught as FridayDomainError).code).toBe(RETIRED_CODE);
+    expect((caught as FridayDomainError).httpStatus).toBe(503);
+    expect(checkpointExists()).toBe(false);
+  });
+
+  it("also fails closed when the flag is explicitly false", () => {
+    const service = buildService(false);
+    expect(() => service.ackEvent("user-1", "workflow:wf-1", 5, EPOCH)).toThrow(
+      expect.objectContaining({ code: RETIRED_CODE, httpStatus: 503 }),
+    );
+    expect(checkpointExists()).toBe(false);
+  });
+
+  it("getCheckpoint (read) stays live without the flag", () => {
+    const service = buildService();
+    expect(service.getCheckpoint("user-1", "workflow:wf-1")).toBeNull();
+  });
+
+  it("ackEvent accepts and persists when the test-oracle flag is enabled (legacy path preserved)", () => {
+    const service = buildService(true);
+    const result = service.ackEvent("user-1", "workflow:wf-1", 5, EPOCH);
+    expect(result.accepted).toBe(true);
+    expect(checkpointExists()).toBe(true);
+  });
+});

--- a/test/unit/api/realtime/friday-realtime-subscription-service.test.ts
+++ b/test/unit/api/realtime/friday-realtime-subscription-service.test.ts
@@ -69,6 +69,10 @@ describe("FridayRealtimeSubscriptionService", () => {
       checkpointRepo,
       nowIso: () => NOW,
       currentEpoch: EPOCH,
+      // TS-runtime-retirement: exercise the legacy ackEvent path in these unit
+      // tests (ack acceptance/epoch/cursor logic). Default/live runtime leaves
+      // this unset so ackEvent fails closed (asserted in the dedicated guard test).
+      allowTestOnlyRealtimeExecution: true,
     });
   });
 

--- a/test/unit/api/realtime/friday-realtime-ws-gateway.test.ts
+++ b/test/unit/api/realtime/friday-realtime-ws-gateway.test.ts
@@ -69,6 +69,11 @@ describe("FridayRealtimeWsGateway", () => {
       checkpointRepo,
       nowIso: () => NOW,
       currentEpoch: EPOCH,
+      // TS-runtime-retirement (method guard): the shared service must allow the
+      // legacy ackEvent path so flag-enabled gateways below can succeed. The
+      // retirement test builds a gateway WITHOUT the gateway flag and asserts the
+      // WS ack frame fail-closes at the gateway BEFORE reaching ackEvent.
+      allowTestOnlyRealtimeExecution: true,
     });
     eventBus = createFridayRealtimeEventBus({
       idGenerator: () => "bus-evt-1",
@@ -140,6 +145,7 @@ describe("FridayRealtimeWsGateway", () => {
       checkpointRepo,
       nowIso: () => NOW,
       currentEpoch: EPOCH,
+      allowTestOnlyRealtimeExecution: true,
     });
     const wsFrameKeyMaterial = ["ws", "frame", "secret"].join("-");
     const frameCrypto = createFridayRealtimeFrameCrypto({

--- a/test/unit/api/runtime/friday-deterministic-pipeline-retirement-guard.test.ts
+++ b/test/unit/api/runtime/friday-deterministic-pipeline-retirement-guard.test.ts
@@ -1,0 +1,107 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import { FridayDomainError } from "#errors";
+import { createFridayDeterministicPipelineRuntime } from "../../../../src/api/runtime/friday-deterministic-pipeline-runtime.js";
+import { createTestDb, createTestIdGenerator } from "../../../helpers/friday-test-db.helper.js";
+
+/**
+ * TS Runtime Retirement — METHOD-level guards for the deterministic-pipeline
+ * route-deps wrappers (orphan off-route leak audit, 2026-06-10; F3.4 top-priority
+ * node.runner.execute + retry.*).
+ *
+ * These guard the route-deps WRAPPERS (`nodeRunner.executeNode`, `retry.*`) that
+ * this runtime returns — NOT the shared engine the live workflow runtime uses.
+ * In default/live config (flags unset) the wrappers fail closed; with the test-
+ * oracle flags they run the legacy path. Reads (get/list wrappers) stay live.
+ */
+
+const NODE_RETIRED = "TS_RUNTIME_NODE_RUNNER_EXECUTION_RETIRED";
+const RETRY_RETIRED = "TS_RUNTIME_RETRY_PIPELINE_RETIRED";
+
+function clearRulesState(db: ReturnType<typeof createTestDb>): void {
+  db.withWriteTransaction((conn) => {
+    conn.prepare("DELETE FROM rule_evaluation_log").run();
+    conn.prepare("DELETE FROM rule_versions").run();
+    conn.prepare("DELETE FROM rules").run();
+    conn.prepare("DELETE FROM rule_policy_bundles").run();
+  });
+}
+
+describe("Friday deterministic pipeline runtime TS-retirement method guards", () => {
+  let openDbs: Array<ReturnType<typeof createTestDb>> = [];
+
+  afterEach(() => {
+    for (const db of openDbs) db.close();
+    openDbs = [];
+  });
+
+  function buildRuntime(flags?: {
+    allowTestOnlyNodeRunnerExecution?: boolean;
+    allowTestOnlyRetryPipelineExecution?: boolean;
+  }) {
+    const db = createTestDb();
+    clearRulesState(db);
+    openDbs.push(db);
+    return createFridayDeterministicPipelineRuntime({
+      db,
+      idGenerator: createTestIdGenerator(),
+      nowIso: () => "2026-06-10T00:00:00.000Z",
+      invokeSkill: async () => ({ ok: true }),
+      ...(flags ?? {}),
+    });
+  }
+
+  it("node.runner.execute fails closed by default: rejects with 503 fail_closed", async () => {
+    const runtime = buildRuntime();
+    await expect(
+      runtime.nodeRunner.executeNode({ nodeId: "n-1", nodeType: "action", nodeConfig: {}, inputData: {} }),
+    ).rejects.toMatchObject({ code: NODE_RETIRED, httpStatus: 503 });
+  });
+
+  it("retry.* mutations fail closed by default: 503 fail_closed", () => {
+    const runtime = buildRuntime();
+    const calls: Array<() => unknown> = [
+      () => runtime.retry.createPolicy({ name: "p" }),
+      () => runtime.retry.updatePolicy("p-1", { etag: "e" }),
+      () => runtime.retry.deletePolicy("p-1", { etag: "e" }),
+      () => runtime.retry.classifyFailure({ error: { errorCode: "X" } }),
+      () => runtime.retry.decideRetry({ error: { errorCode: "X" } }),
+      () => runtime.retry.acknowledgeEscalation("esc-1"),
+    ];
+    for (const call of calls) {
+      expect(call).toThrow(expect.objectContaining({ code: RETRY_RETIRED, httpStatus: 503 }));
+    }
+  });
+
+  it("node-runner and retry guards are independent (a retry flag does not open node-runner)", async () => {
+    const runtime = buildRuntime({ allowTestOnlyRetryPipelineExecution: true });
+    // retry classify is reachable now...
+    expect(() => runtime.retry.classifyFailure({ error: { errorCode: "X" } })).not.toThrow();
+    // ...but node-runner still fails closed (its own flag is unset).
+    await expect(
+      runtime.nodeRunner.executeNode({ nodeId: "n-1", nodeType: "action", nodeConfig: {}, inputData: {} }),
+    ).rejects.toMatchObject({ code: NODE_RETIRED, httpStatus: 503 });
+  });
+
+  it("reads (retry.listPolicies) stay live without any flag", () => {
+    const runtime = buildRuntime();
+    const listed = runtime.retry.listPolicies({}) as { items: unknown[] };
+    expect(Array.isArray(listed.items)).toBe(true);
+  });
+
+  it("wrappers run when the test-oracle flags are enabled (legacy path preserved)", async () => {
+    const runtime = buildRuntime({
+      allowTestOnlyNodeRunnerExecution: true,
+      allowTestOnlyRetryPipelineExecution: true,
+    });
+    const created = runtime.retry.createPolicy({ name: "p" }) as { policy: { id: string } };
+    expect(created.policy.id).toBeTruthy();
+    const executed = (await runtime.nodeRunner.executeNode({
+      nodeId: "n-1",
+      nodeType: "data",
+      nodeConfig: {},
+      inputData: { value: 1 },
+    })) as { execution: { status: string } };
+    expect(executed.execution.status).toBeTruthy();
+  });
+});

--- a/test/unit/api/runtime/friday-deterministic-pipeline-runtime.test.ts
+++ b/test/unit/api/runtime/friday-deterministic-pipeline-runtime.test.ts
@@ -48,6 +48,12 @@ describe("Friday deterministic pipeline runtime wiring", () => {
       idGenerator,
       nowIso: () => "2026-02-27T00:00:00.000Z",
       invokeSkill: async () => ({ ok: true }),
+      // TS-runtime-retirement: exercise the legacy node-runner/retry paths in
+      // these unit tests; default/live runtime leaves these unset so the route-
+      // deps wrappers fail closed (the 503-by-default behavior is asserted in the
+      // dedicated guard test).
+      allowTestOnlyNodeRunnerExecution: true,
+      allowTestOnlyRetryPipelineExecution: true,
     });
 
     const created = runtime.rules.createBundle({
@@ -84,6 +90,12 @@ describe("Friday deterministic pipeline runtime wiring", () => {
       idGenerator: createTestIdGenerator(),
       nowIso: () => "2026-02-27T00:00:00.000Z",
       invokeSkill: async () => ({ ok: true }),
+      // TS-runtime-retirement: exercise the legacy node-runner/retry paths in
+      // these unit tests; default/live runtime leaves these unset so the route-
+      // deps wrappers fail closed (the 503-by-default behavior is asserted in the
+      // dedicated guard test).
+      allowTestOnlyNodeRunnerExecution: true,
+      allowTestOnlyRetryPipelineExecution: true,
     });
 
     expect(() =>
@@ -108,6 +120,12 @@ describe("Friday deterministic pipeline runtime wiring", () => {
       idGenerator: createTestIdGenerator(),
       nowIso: () => "2026-02-27T00:00:00.000Z",
       invokeSkill: async () => ({ ok: true }),
+      // TS-runtime-retirement: exercise the legacy node-runner/retry paths in
+      // these unit tests; default/live runtime leaves these unset so the route-
+      // deps wrappers fail closed (the 503-by-default behavior is asserted in the
+      // dedicated guard test).
+      allowTestOnlyNodeRunnerExecution: true,
+      allowTestOnlyRetryPipelineExecution: true,
     });
 
     const created = runtime.rules.createBundle({
@@ -145,6 +163,8 @@ describe("Friday deterministic pipeline runtime wiring", () => {
       invokeSkill: async (_skillId, _runId, _nodeId, payload) => ({
         echoed: payload,
       }),
+      allowTestOnlyNodeRunnerExecution: true,
+      allowTestOnlyRetryPipelineExecution: true,
     });
 
     const executed = await runtime.nodeRunner.executeNode({
@@ -180,6 +200,12 @@ describe("Friday deterministic pipeline runtime wiring", () => {
       idGenerator,
       nowIso: () => "2026-02-27T00:00:00.000Z",
       invokeSkill: async () => ({ ok: true }),
+      // TS-runtime-retirement: exercise the legacy node-runner/retry paths in
+      // these unit tests; default/live runtime leaves these unset so the route-
+      // deps wrappers fail closed (the 503-by-default behavior is asserted in the
+      // dedicated guard test).
+      allowTestOnlyNodeRunnerExecution: true,
+      allowTestOnlyRetryPipelineExecution: true,
     });
 
     async function executeEvidenceRun(runId: string, inputData: Record<string, unknown>) {
@@ -276,6 +302,12 @@ describe("Friday deterministic pipeline runtime wiring", () => {
       idGenerator,
       nowIso: () => "2026-02-27T00:00:00.000Z",
       invokeSkill: async () => ({ ok: true }),
+      // TS-runtime-retirement: exercise the legacy node-runner/retry paths in
+      // these unit tests; default/live runtime leaves these unset so the route-
+      // deps wrappers fail closed (the 503-by-default behavior is asserted in the
+      // dedicated guard test).
+      allowTestOnlyNodeRunnerExecution: true,
+      allowTestOnlyRetryPipelineExecution: true,
     });
 
     const run = await runtime.acceptance.runChecks({
@@ -303,6 +335,12 @@ describe("Friday deterministic pipeline runtime wiring", () => {
       idGenerator: createTestIdGenerator(),
       nowIso: () => "2026-02-27T00:00:00.000Z",
       invokeSkill: async () => ({ ok: true }),
+      // TS-runtime-retirement: exercise the legacy node-runner/retry paths in
+      // these unit tests; default/live runtime leaves these unset so the route-
+      // deps wrappers fail closed (the 503-by-default behavior is asserted in the
+      // dedicated guard test).
+      allowTestOnlyNodeRunnerExecution: true,
+      allowTestOnlyRetryPipelineExecution: true,
     });
 
     const decided = runtime.retry.decideRetry({
@@ -333,6 +371,12 @@ describe("Friday deterministic pipeline runtime wiring", () => {
       idGenerator: createTestIdGenerator(),
       nowIso: () => "2026-02-27T00:00:00.000Z",
       invokeSkill: async () => ({ ok: true }),
+      // TS-runtime-retirement: exercise the legacy node-runner/retry paths in
+      // these unit tests; default/live runtime leaves these unset so the route-
+      // deps wrappers fail closed (the 503-by-default behavior is asserted in the
+      // dedicated guard test).
+      allowTestOnlyNodeRunnerExecution: true,
+      allowTestOnlyRetryPipelineExecution: true,
     });
 
     for (let index = 0; index < 3; index += 1) {
@@ -384,6 +428,12 @@ describe("Friday deterministic pipeline runtime wiring", () => {
       idGenerator: createTestIdGenerator(),
       nowIso: () => "2026-02-27T00:00:00.000Z",
       invokeSkill: async () => ({ ok: true }),
+      // TS-runtime-retirement: exercise the legacy node-runner/retry paths in
+      // these unit tests; default/live runtime leaves these unset so the route-
+      // deps wrappers fail closed (the 503-by-default behavior is asserted in the
+      // dedicated guard test).
+      allowTestOnlyNodeRunnerExecution: true,
+      allowTestOnlyRetryPipelineExecution: true,
     });
 
     const created = runtime.rules.createBundle({

--- a/test/unit/autonomy/friday-mcp-server-upgrade-lifecycle-retirement-guard.test.ts
+++ b/test/unit/autonomy/friday-mcp-server-upgrade-lifecycle-retirement-guard.test.ts
@@ -1,0 +1,122 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import type { FridaySqliteLayer } from "#state";
+import { FridayDomainError } from "#errors";
+import { createFridayAutonomySubjectUpgradeStateRepository } from "../../../src/autonomy/persistence/friday-autonomy-subject-upgrade-state-repository.js";
+import { createFridayMcpServerUpgradeLifecycleService } from "../../../src/autonomy/services/friday-mcp-server-upgrade-lifecycle-service.js";
+import { createFridayMutatingActionGate } from "../../../src/security/friday-mutating-action-gate.js";
+import { createTestDb } from "../satellites/_helpers/create-test-db.helper.js";
+
+/**
+ * TS Runtime Retirement — METHOD-level guard for the autonomy MCP-server
+ * upgrade-lifecycle (orphan off-route leak audit, 2026-06-10 defense-in-depth).
+ *
+ * registerShadowVersion/recordCanaryResult/promote/rollback were ROUTE-only-
+ * guarded (assertAutonomyLifecycleTestOracleAllowed). This proves each method
+ * fail-closes by default (flag unset) BEFORE the canonical-ticket check and any
+ * state write. With the test-oracle flag the guard is open (and the method then
+ * reaches its canonical-ticket requirement instead of the retirement 503).
+ */
+
+const RETIRED_CODE = "TS_RUNTIME_AUTONOMY_LIFECYCLE_RETIRED";
+
+describe("FridayMcpServerUpgradeLifecycleService TS-retirement method guard", () => {
+  let db: FridaySqliteLayer;
+  let stateDir: string;
+
+  beforeEach(() => {
+    db = createTestDb();
+    stateDir = mkdtempSync(join(tmpdir(), "friday-mcp-lifecycle-guard-"));
+  });
+
+  afterEach(() => {
+    db.close();
+    rmSync(stateDir, { recursive: true, force: true });
+  });
+
+  function buildService(allowTestOnlyAutonomyLifecycleExecution?: boolean) {
+    return createFridayMcpServerUpgradeLifecycleService({
+      db,
+      stateRepo: createFridayAutonomySubjectUpgradeStateRepository(),
+      mcpAdapter: {
+        listServers: () => [{ id: "stdio-echo", transport: "stdio", command: "node", args: ["server.js"] }],
+        listTools: async () => [{ serverId: "stdio-echo", name: "echo", inputSchema: { type: "object" } }],
+      },
+      nowIso: () => "2026-06-10T00:00:00.000Z",
+      stateDir,
+      canonicalMutationGate: createFridayMutatingActionGate({
+        nowIso: () => "2026-06-10T00:00:00.000Z",
+        ticketIdGenerator: () => "ticket-1",
+      }),
+      ...(allowTestOnlyAutonomyLifecycleExecution === undefined
+        ? {}
+        : { allowTestOnlyAutonomyLifecycleExecution }),
+    });
+  }
+
+  const shadowInput = {
+    serverId: "stdio-echo",
+    shadowVersionId: "stdio-echo@shadow",
+    runtimeVersion: "f27377c",
+    providerModel: "claude-sonnet-4-20250514",
+    actor: { kind: "user" as const, id: "user-1", principalId: "user-1" },
+    surface: "api:/v1/autonomy/mcp-servers/shadow",
+    planDigest: "mcp-plan-1",
+  };
+
+  it("registerShadowVersion fails closed by default: throws 503 fail_closed", () => {
+    const service = buildService();
+    let caught: unknown;
+    try {
+      service.registerShadowVersion(shadowInput);
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toBeInstanceOf(FridayDomainError);
+    expect((caught as FridayDomainError).code).toBe(RETIRED_CODE);
+    expect((caught as FridayDomainError).httpStatus).toBe(503);
+  });
+
+  it("promote and rollback also fail closed by default", async () => {
+    const service = buildService();
+    expect(() =>
+      service.promote({ ...shadowInput, surface: "api:/v1/autonomy/mcp-servers/promote" }),
+    ).toThrow(expect.objectContaining({ code: RETIRED_CODE, httpStatus: 503 }));
+    expect(() =>
+      service.rollback({ ...shadowInput, surface: "api:/v1/autonomy/mcp-servers/rollback" }),
+    ).toThrow(expect.objectContaining({ code: RETIRED_CODE, httpStatus: 503 }));
+    await expect(
+      service.recordCanaryResult({ ...shadowInput, surface: "api:/v1/autonomy/mcp-servers/canary" }),
+    ).rejects.toMatchObject({ code: RETIRED_CODE, httpStatus: 503 });
+  });
+
+  it("also fails closed when the flag is explicitly false", () => {
+    const service = buildService(false);
+    expect(() => service.registerShadowVersion(shadowInput)).toThrow(
+      expect.objectContaining({ code: RETIRED_CODE, httpStatus: 503 }),
+    );
+  });
+
+  it("getLifecycleEvidence (read) stays live without the flag", () => {
+    const service = buildService();
+    expect(service.getLifecycleEvidence({ serverId: "stdio-echo" })).toBeNull();
+  });
+
+  it("passes the guard when the flag is enabled (reaches the canonical-ticket requirement, not the 503)", () => {
+    const service = buildService(true);
+    // Guard open: registerShadowVersion now reaches its canonical-ticket check and
+    // throws a DIFFERENT error (no valid canonical approval), NOT the retirement 503,
+    // proving the method guard no longer blocks the legacy path.
+    let caught: unknown;
+    try {
+      service.registerShadowVersion(shadowInput);
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toBeInstanceOf(FridayDomainError);
+    expect((caught as FridayDomainError).code).not.toBe(RETIRED_CODE);
+  });
+});

--- a/test/unit/autonomy/friday-mcp-server-upgrade-lifecycle-service.test.ts
+++ b/test/unit/autonomy/friday-mcp-server-upgrade-lifecycle-service.test.ts
@@ -83,6 +83,10 @@ describe("createFridayMcpServerUpgradeLifecycleService", () => {
       nowIso: () => "2026-04-17T22:15:00.000Z",
       stateDir,
       canonicalMutationGate,
+      // TS-runtime-retirement: exercise the legacy lifecycle mutations in these
+      // unit tests; default/live runtime leaves this unset so they fail closed
+      // (the 503-by-default behavior is asserted in the dedicated guard test).
+      allowTestOnlyAutonomyLifecycleExecution: true,
     });
     return { repo, service };
   }

--- a/test/unit/satellites/services/friday-satellite-capability-retirement-guard.test.ts
+++ b/test/unit/satellites/services/friday-satellite-capability-retirement-guard.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import type { FridaySqliteLayer } from "#state";
+import { FridayDomainError } from "#errors";
+import type { FridaySatelliteCapabilityReport } from "#satellites";
+import {
+  createFridaySatelliteCapabilityRepository,
+  createFridaySatelliteCapabilityService,
+  createFridaySatelliteRepository,
+} from "#satellites";
+import { createTestDb, createTestIdGenerator } from "../_helpers/create-test-db.helper.js";
+
+/**
+ * TS Runtime Retirement — METHOD-level guard for satellite capability update
+ * (orphan off-route leak audit, 2026-06-10 defense-in-depth). `updateCapabilities`
+ * was ROUTE-only-guarded; this proves it fails closed by default BEFORE the
+ * capability/revision write.
+ */
+
+const RETIRED_CODE = "TS_RUNTIME_SATELLITE_RUNTIME_RETIRED";
+const NOW = "2026-06-10T00:00:00.000Z";
+
+const report: FridaySatelliteCapabilityReport = {
+  satelliteId: "sat-1",
+  revision: 5,
+  generatedAt: NOW,
+  runtime: { os: "darwin", arch: "arm64", appVersion: "1.0.0", nodeVersion: "22.0.0" },
+  capabilities: [{ key: "camera", available: true }],
+};
+
+describe("FridaySatelliteCapabilityService TS-retirement method guard", () => {
+  let db: FridaySqliteLayer;
+
+  beforeEach(() => {
+    db = createTestDb();
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  function buildService(allowTestOnlySatelliteRuntimeExecution?: boolean) {
+    return createFridaySatelliteCapabilityService({
+      db,
+      satelliteRepo: createFridaySatelliteRepository(),
+      capabilityRepo: createFridaySatelliteCapabilityRepository(),
+      idGenerator: createTestIdGenerator(),
+      nowIso: () => NOW,
+      ...(allowTestOnlySatelliteRuntimeExecution === undefined
+        ? {}
+        : { allowTestOnlySatelliteRuntimeExecution }),
+    });
+  }
+
+  function countCapabilityRows(): number {
+    return db.withReadConnection((reader) =>
+      (reader.prepare("SELECT COUNT(*) AS c FROM satellite_capabilities").get() as { c: number }).c,
+    );
+  }
+
+  it("updateCapabilities fails closed by default: throws 503 and writes no capability row", () => {
+    const service = buildService();
+    let caught: unknown;
+    try {
+      service.updateCapabilities(report);
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toBeInstanceOf(FridayDomainError);
+    expect((caught as FridayDomainError).code).toBe(RETIRED_CODE);
+    expect((caught as FridayDomainError).httpStatus).toBe(503);
+    expect(countCapabilityRows()).toBe(0);
+  });
+
+  it("also fails closed when the flag is explicitly false", () => {
+    const service = buildService(false);
+    expect(() => service.updateCapabilities(report)).toThrow(
+      expect.objectContaining({ code: RETIRED_CODE, httpStatus: 503 }),
+    );
+    expect(countCapabilityRows()).toBe(0);
+  });
+
+  it("passes the guard when the test-oracle flag is enabled (reaches not-found, not the 503)", () => {
+    const service = buildService(true);
+    // Guard open: reaches real logic; with no satellite row it returns accepted=false
+    // (NOT a retirement 503), proving the guard no longer blocks the legacy path.
+    const result = service.updateCapabilities(report);
+    expect(result.accepted).toBe(false);
+  });
+});

--- a/test/unit/satellites/services/friday-satellite-capability-service.test.ts
+++ b/test/unit/satellites/services/friday-satellite-capability-service.test.ts
@@ -36,6 +36,9 @@ describe("FridaySatelliteCapabilityService", () => {
       idGenerator: createTestIdGenerator(),
       nowIso: () => NOW,
       revisionCache: revisionCache ?? new Map(),
+      // TS-runtime-retirement: exercise the legacy TypeScript updateCapabilities
+      // path here; default/live hub leaves this unset so it fails closed.
+      allowTestOnlySatelliteRuntimeExecution: true,
     });
   }
 

--- a/test/unit/satellites/services/friday-satellite-heartbeat-retirement-guard.test.ts
+++ b/test/unit/satellites/services/friday-satellite-heartbeat-retirement-guard.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import type { FridaySqliteLayer } from "#state";
+import { FridayDomainError } from "#errors";
+import {
+  createFridaySatelliteHeartbeatRepository,
+  createFridaySatelliteHeartbeatService,
+  createFridaySatelliteRepository,
+} from "#satellites";
+import { createTestDb, createTestIdGenerator } from "../_helpers/create-test-db.helper.js";
+
+/**
+ * TS Runtime Retirement — METHOD-level guard for satellite heartbeat
+ * (orphan off-route leak audit, 2026-06-10 defense-in-depth). `recordHeartbeat`
+ * was ROUTE-only-guarded; this proves it fails closed by default BEFORE the
+ * heartbeat/status-transition write. (The live `heartbeat-runner` scheduler is
+ * observability, a different service, and is unaffected.)
+ */
+
+const RETIRED_CODE = "TS_RUNTIME_SATELLITE_RUNTIME_RETIRED";
+const NOW = "2026-06-10T00:00:00.000Z";
+
+describe("FridaySatelliteHeartbeatService TS-retirement method guard", () => {
+  let db: FridaySqliteLayer;
+
+  beforeEach(() => {
+    db = createTestDb();
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  function buildService(allowTestOnlySatelliteRuntimeExecution?: boolean) {
+    return createFridaySatelliteHeartbeatService({
+      db,
+      satelliteRepo: createFridaySatelliteRepository(),
+      heartbeatRepo: createFridaySatelliteHeartbeatRepository(),
+      idGenerator: createTestIdGenerator(),
+      nowIso: () => NOW,
+      ...(allowTestOnlySatelliteRuntimeExecution === undefined
+        ? {}
+        : { allowTestOnlySatelliteRuntimeExecution }),
+    });
+  }
+
+  function countHeartbeatRows(): number {
+    return db.withReadConnection((reader) =>
+      (reader.prepare("SELECT COUNT(*) AS c FROM satellite_heartbeats").get() as { c: number }).c,
+    );
+  }
+
+  it("recordHeartbeat fails closed by default: throws 503 and writes no heartbeat row", () => {
+    const service = buildService();
+    let caught: unknown;
+    try {
+      service.recordHeartbeat({ satelliteId: "sat-1", ts: NOW });
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toBeInstanceOf(FridayDomainError);
+    expect((caught as FridayDomainError).code).toBe(RETIRED_CODE);
+    expect((caught as FridayDomainError).httpStatus).toBe(503);
+    expect(countHeartbeatRows()).toBe(0);
+  });
+
+  it("also fails closed when the flag is explicitly false", () => {
+    const service = buildService(false);
+    expect(() => service.recordHeartbeat({ satelliteId: "sat-1", ts: NOW })).toThrow(
+      expect.objectContaining({ code: RETIRED_CODE, httpStatus: 503 }),
+    );
+    expect(countHeartbeatRows()).toBe(0);
+  });
+
+  it("passes the guard when the test-oracle flag is enabled (reaches not-found, not the 503)", () => {
+    const service = buildService(true);
+    // Guard open: reaches real logic; with no satellite row it throws the domain
+    // SATELLITE_NOT_FOUND (NOT the retirement 503), proving the guard no longer blocks.
+    expect(() => service.recordHeartbeat({ satelliteId: "sat-1", ts: NOW })).toThrow(
+      expect.objectContaining({ code: "SATELLITE_NOT_FOUND" }),
+    );
+  });
+});

--- a/test/unit/satellites/services/friday-satellite-heartbeat-service.test.ts
+++ b/test/unit/satellites/services/friday-satellite-heartbeat-service.test.ts
@@ -40,6 +40,7 @@ describe("FridaySatelliteHeartbeatService", () => {
       heartbeatRepo,
       idGenerator: createTestIdGenerator(),
       nowIso: () => NOW,
+      allowTestOnlySatelliteRuntimeExecution: true,
     });
 
     const result = service.recordHeartbeat({
@@ -61,6 +62,7 @@ describe("FridaySatelliteHeartbeatService", () => {
       heartbeatRepo,
       idGenerator: createTestIdGenerator(),
       nowIso: () => NOW,
+      allowTestOnlySatelliteRuntimeExecution: true,
     });
 
     const result = service.recordHeartbeat({
@@ -81,6 +83,7 @@ describe("FridaySatelliteHeartbeatService", () => {
       heartbeatRepo,
       idGenerator: createTestIdGenerator(),
       nowIso: () => NOW,
+      allowTestOnlySatelliteRuntimeExecution: true,
     });
 
     const result = service.recordHeartbeat({
@@ -102,6 +105,7 @@ describe("FridaySatelliteHeartbeatService", () => {
       heartbeatRepo,
       idGenerator: createTestIdGenerator(),
       nowIso: () => NOW,
+      allowTestOnlySatelliteRuntimeExecution: true,
       onStatusTransition,
     });
 
@@ -132,6 +136,7 @@ describe("FridaySatelliteHeartbeatService", () => {
       heartbeatRepo,
       idGenerator: createTestIdGenerator(),
       nowIso: () => NOW,
+      allowTestOnlySatelliteRuntimeExecution: true,
     });
 
     const result = service.recordHeartbeat({
@@ -153,6 +158,7 @@ describe("FridaySatelliteHeartbeatService", () => {
       heartbeatRepo,
       idGenerator: createTestIdGenerator(),
       nowIso: () => NOW,
+      allowTestOnlySatelliteRuntimeExecution: true,
     });
 
     const result = service.recordHeartbeat({
@@ -174,6 +180,7 @@ describe("FridaySatelliteHeartbeatService", () => {
       heartbeatRepo,
       idGenerator: createTestIdGenerator(),
       nowIso: () => NOW,
+      allowTestOnlySatelliteRuntimeExecution: true,
       onStatusTransition,
     });
 
@@ -195,6 +202,7 @@ describe("FridaySatelliteHeartbeatService", () => {
       heartbeatRepo,
       idGenerator: createTestIdGenerator(),
       nowIso: () => NOW,
+      allowTestOnlySatelliteRuntimeExecution: true,
     });
 
     service.recordHeartbeat({
@@ -225,6 +233,7 @@ describe("FridaySatelliteHeartbeatService", () => {
       heartbeatRepo,
       idGenerator: createTestIdGenerator(),
       nowIso: () => NOW,
+      allowTestOnlySatelliteRuntimeExecution: true,
     });
 
     expect(() =>

--- a/test/unit/satellites/services/friday-satellite-pairing-retirement-guard.test.ts
+++ b/test/unit/satellites/services/friday-satellite-pairing-retirement-guard.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import type { FridaySqliteLayer } from "#state";
+import { FridayDomainError } from "#errors";
+import {
+  createFridayApiTokenRepository,
+  createFridaySatelliteCapabilityRepository,
+  createFridaySatellitePairingRequestRepository,
+  createFridaySatellitePairingService,
+  createFridaySatelliteRepository,
+  createFridayStreamCheckpointRepository,
+} from "#satellites";
+import { createTestDb, createTestIdGenerator } from "../_helpers/create-test-db.helper.js";
+
+/**
+ * TS Runtime Retirement — METHOD-level guard for satellite pairing
+ * (orphan off-route leak audit, 2026-06-10 defense-in-depth).
+ *
+ * approvePairing/rejectPairing/completeHandshake/revokeSatellite were ROUTE-only-
+ * guarded. These prove each method now fail-closes by default (flag unset) BEFORE
+ * reading or mutating any pairing/token/satellite state. With the test-oracle flag
+ * the guard is open (the methods then reach their normal not-found path).
+ */
+
+const RETIRED_CODE = "TS_RUNTIME_SATELLITE_PAIRING_RETIRED";
+const NOW = "2026-06-10T00:00:00.000Z";
+
+describe("FridaySatellitePairingService TS-retirement method guard", () => {
+  let db: FridaySqliteLayer;
+
+  beforeEach(() => {
+    db = createTestDb();
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  function buildService(allowTestOnlySatellitePairingExecution?: boolean) {
+    return createFridaySatellitePairingService({
+      db,
+      satelliteRepo: createFridaySatelliteRepository(),
+      pairingRequestRepo: createFridaySatellitePairingRequestRepository(),
+      apiTokenRepo: createFridayApiTokenRepository(),
+      checkpointRepo: createFridayStreamCheckpointRepository(),
+      idGenerator: createTestIdGenerator(),
+      nowIso: () => NOW,
+      tokenSecret: "test-token-secret", // pragma: allowlist secret
+      ...(allowTestOnlySatellitePairingExecution === undefined
+        ? {}
+        : { allowTestOnlySatellitePairingExecution }),
+    });
+  }
+
+  it("all four pairing mutations fail closed by default with 503 fail_closed", () => {
+    const service = buildService();
+    const calls: Array<() => unknown> = [
+      () => service.approvePairing({ requestId: "r-1", satelliteId: "s-1", resolverUserId: "u-1", scopes: ["satellite.write"] }),
+      () => service.rejectPairing({ requestId: "r-1", satelliteId: "s-1", resolverUserId: "u-1" }),
+      () => service.completeHandshake({
+        satelliteId: "s-1",
+        token: "tok",
+        signedChallenge: "sig",
+        challengeNonce: "nonce",
+        clientEphemeralPublicKey: "pub",
+        supportedAlgorithms: [],
+      }),
+      () => service.revokeSatellite({ satelliteId: "s-1" }),
+    ];
+    for (const call of calls) {
+      let caught: unknown;
+      try {
+        call();
+      } catch (error) {
+        caught = error;
+      }
+      expect(caught).toBeInstanceOf(FridayDomainError);
+      expect((caught as FridayDomainError).code).toBe(RETIRED_CODE);
+      expect((caught as FridayDomainError).httpStatus).toBe(503);
+    }
+  });
+
+  it("also fails closed when the flag is explicitly false", () => {
+    const service = buildService(false);
+    expect(() => service.revokeSatellite({ satelliteId: "s-1" })).toThrow(
+      expect.objectContaining({ code: RETIRED_CODE, httpStatus: 503 }),
+    );
+  });
+
+  it("passes the guard (reaches the normal not-found path) when the test-oracle flag is enabled", () => {
+    const service = buildService(true);
+    // The guard is open; approvePairing now reaches its real logic and fails with
+    // the domain not-found error (NOT the retirement 503), proving the guard no
+    // longer blocks the legacy path.
+    expect(() =>
+      service.approvePairing({ requestId: "missing", satelliteId: "s-1", resolverUserId: "u-1", scopes: ["satellite.write"] }),
+    ).toThrow(expect.objectContaining({ code: "PAIRING_REQUEST_NOT_FOUND" }));
+  });
+});

--- a/test/unit/satellites/services/friday-satellite-pairing-service.test.ts
+++ b/test/unit/satellites/services/friday-satellite-pairing-service.test.ts
@@ -64,6 +64,7 @@ describe("FridaySatellitePairingService", () => {
       idGenerator: idGen,
       nowIso: () => NOW,
       pairingTtlMs: 10 * 60 * 1000,
+      allowTestOnlySatellitePairingExecution: true,
     });
     return regService.register({
       type: "phone",
@@ -85,6 +86,9 @@ describe("FridaySatellitePairingService", () => {
       nowIso: () => nowIso,
       tokenSecret: "test-token-secret", // pragma: allowlist secret
       generateEphemeralKeyPair: () => EPHEMERAL_KEY,
+      // TS-runtime-retirement: exercise the legacy TypeScript pairing path here;
+      // default/live hub leaves this unset so the methods fail closed.
+      allowTestOnlySatellitePairingExecution: true,
     });
   }
 

--- a/test/unit/satellites/services/friday-satellite-registration-retirement-guard.test.ts
+++ b/test/unit/satellites/services/friday-satellite-registration-retirement-guard.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import type { FridaySqliteLayer } from "#state";
+import { FridayDomainError } from "#errors";
+import type { FridaySatelliteRegistrationInput } from "#satellites";
+import {
+  createFridaySatelliteCapabilityRepository,
+  createFridaySatellitePairingRequestRepository,
+  createFridaySatelliteRegistrationService,
+  createFridaySatelliteRepository,
+} from "#satellites";
+import { createTestDb, createTestIdGenerator } from "../_helpers/create-test-db.helper.js";
+
+/**
+ * TS Runtime Retirement — METHOD-level guard for satellite registration
+ * (orphan off-route leak audit, 2026-06-10 defense-in-depth).
+ *
+ * `register` was ROUTE-only-guarded (friday-satellite-pairing-routes asserts
+ * `allowTestOnlySatellitePairingExecution` before the register route). This
+ * proves the guard now lives on the METHOD: in default/live config (flag unset)
+ * `register` fails closed BEFORE any satellite/pairing-request row write; with
+ * the explicit test-oracle flag it still works.
+ */
+
+const RETIRED_CODE = "TS_RUNTIME_SATELLITE_PAIRING_RETIRED";
+const NOW = "2026-06-10T00:00:00.000Z";
+
+const baseInput: FridaySatelliteRegistrationInput = {
+  type: "phone",
+  displayName: "My Phone",
+  publicKey: "pk-abc123",
+  runtime: { platform: "darwin", arch: "arm64", appVersion: "1.0.0", nodeVersion: "22.0.0" },
+  transport: "ws",
+};
+
+describe("FridaySatelliteRegistrationService TS-retirement method guard", () => {
+  let db: FridaySqliteLayer;
+
+  beforeEach(() => {
+    db = createTestDb();
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  function buildService(allowTestOnlySatellitePairingExecution?: boolean) {
+    return createFridaySatelliteRegistrationService({
+      db,
+      satelliteRepo: createFridaySatelliteRepository(),
+      pairingRequestRepo: createFridaySatellitePairingRequestRepository(),
+      capabilityRepo: createFridaySatelliteCapabilityRepository(),
+      idGenerator: createTestIdGenerator(),
+      nowIso: () => NOW,
+      ...(allowTestOnlySatellitePairingExecution === undefined
+        ? {}
+        : { allowTestOnlySatellitePairingExecution }),
+    });
+  }
+
+  function countSatelliteRows(): number {
+    return db.withReadConnection((reader) =>
+      (reader.prepare("SELECT COUNT(*) AS c FROM satellites").get() as { c: number }).c,
+    );
+  }
+
+  it("register fails closed by default: throws 503 fail_closed and writes no satellite row", () => {
+    const service = buildService();
+    let caught: unknown;
+    try {
+      service.register(baseInput);
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toBeInstanceOf(FridayDomainError);
+    const domainError = caught as FridayDomainError;
+    expect(domainError.code).toBe(RETIRED_CODE);
+    expect(domainError.httpStatus).toBe(503);
+    expect(domainError.details).toMatchObject({ classification: "fail_closed" });
+    expect(countSatelliteRows()).toBe(0);
+  });
+
+  it("register also fails closed when the flag is explicitly false", () => {
+    const service = buildService(false);
+    expect(() => service.register(baseInput)).toThrow(
+      expect.objectContaining({ code: RETIRED_CODE, httpStatus: 503 }),
+    );
+    expect(countSatelliteRows()).toBe(0);
+  });
+
+  it("register runs when the test-oracle flag is enabled (legacy path preserved)", () => {
+    const service = buildService(true);
+    const result = service.register(baseInput);
+    expect(result.pairingStatus).toBe("pending");
+    expect(countSatelliteRows()).toBe(1);
+  });
+});

--- a/test/unit/satellites/services/friday-satellite-registration-service.test.ts
+++ b/test/unit/satellites/services/friday-satellite-registration-service.test.ts
@@ -41,6 +41,9 @@ describe("FridaySatelliteRegistrationService", () => {
       capabilityRepo: createFridaySatelliteCapabilityRepository(),
       idGenerator: createTestIdGenerator(),
       nowIso: () => NOW,
+      // TS-runtime-retirement: exercise the legacy TypeScript register path in
+      // these unit tests; default/live hub leaves this unset so it fails closed.
+      allowTestOnlySatellitePairingExecution: true,
     });
   }
 
@@ -107,6 +110,7 @@ describe("FridaySatelliteRegistrationService", () => {
       idGenerator: createTestIdGenerator(),
       nowIso: () => NOW,
       pairingTtlMs: 5 * 60 * 1000, // 5 minutes
+      allowTestOnlySatellitePairingExecution: true,
     });
 
     const result = service.register(baseInput);

--- a/test/unit/satellites/services/friday-satellite-sync-retirement-guard.test.ts
+++ b/test/unit/satellites/services/friday-satellite-sync-retirement-guard.test.ts
@@ -1,0 +1,93 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import type { FridaySqliteLayer } from "#state";
+import { FridayDomainError } from "#errors";
+import {
+  createFridayAckResumeValidator,
+  createFridayOutboxMessageRepository,
+  createFridayResumeCursorSigner,
+  createFridaySatelliteSyncService,
+  createFridayStreamCheckpointRepository,
+} from "#satellites";
+import { createTestDb } from "../_helpers/create-test-db.helper.js";
+
+/**
+ * TS Runtime Retirement — METHOD-level guard for the inbound satellite sync
+ * engine (orphan off-route leak audit, 2026-06-10 defense-in-depth). `pull`
+ * (leases the outbox command-queue + signs a cursor) and `push` (persists acks/
+ * node-results) were ROUTE-only-guarded; this proves both fail closed by default
+ * BEFORE any checkpoint/outbox/result write. Guards the INBOUND sync engine only
+ * — the hub->satellite outbox command-queue and retention GC are separate
+ * non-retired services and are unaffected.
+ */
+
+const RETIRED_CODE = "TS_RUNTIME_SATELLITE_RUNTIME_RETIRED";
+const NOW = "2026-06-10T00:00:00.000Z";
+const SECRET = "test-sync-secret"; // pragma: allowlist secret
+
+describe("FridaySatelliteSyncService TS-retirement method guard", () => {
+  let db: FridaySqliteLayer;
+  const cursorSigner = createFridayResumeCursorSigner(SECRET);
+  const ackValidator = createFridayAckResumeValidator(cursorSigner);
+  const checkpointRepo = createFridayStreamCheckpointRepository();
+  const outboxRepo = createFridayOutboxMessageRepository();
+
+  beforeEach(() => {
+    db = createTestDb();
+    db.withWriteTransaction((d) => {
+      checkpointRepo.bumpEpoch(d, NOW);
+    });
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  function buildService(allowTestOnlySatelliteRuntimeExecution?: boolean) {
+    return createFridaySatelliteSyncService({
+      db,
+      checkpointRepo,
+      outboxRepo,
+      cursorSigner,
+      ackValidator,
+      nowIso: () => NOW,
+      ...(allowTestOnlySatelliteRuntimeExecution === undefined
+        ? {}
+        : { allowTestOnlySatelliteRuntimeExecution }),
+    });
+  }
+
+  it("pull fails closed by default: throws 503 fail_closed", () => {
+    const service = buildService();
+    let caught: unknown;
+    try {
+      service.pull({ satelliteId: "sat-1", streamId: "fleet.x", lastAckedSeq: 0, subscriptions: [] });
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toBeInstanceOf(FridayDomainError);
+    expect((caught as FridayDomainError).code).toBe(RETIRED_CODE);
+    expect((caught as FridayDomainError).httpStatus).toBe(503);
+  });
+
+  it("push fails closed by default: rejects with 503 fail_closed", async () => {
+    const service = buildService();
+    await expect(service.push({ satelliteId: "sat-1", acks: [] })).rejects.toMatchObject({
+      code: RETIRED_CODE,
+      httpStatus: 503,
+    });
+  });
+
+  it("pull also fails closed when the flag is explicitly false", () => {
+    const service = buildService(false);
+    expect(() =>
+      service.pull({ satelliteId: "sat-1", streamId: "fleet.x", lastAckedSeq: 0, subscriptions: [] }),
+    ).toThrow(expect.objectContaining({ code: RETIRED_CODE, httpStatus: 503 }));
+  });
+
+  it("pull passes the guard when the test-oracle flag is enabled (returns a result, not the 503)", () => {
+    const service = buildService(true);
+    const result = service.pull({ satelliteId: "sat-1", streamId: "fleet.x", lastAckedSeq: 0, subscriptions: [] });
+    expect(result.streamId).toBe("fleet.x");
+  });
+});

--- a/test/unit/satellites/services/friday-satellite-sync-service.test.ts
+++ b/test/unit/satellites/services/friday-satellite-sync-service.test.ts
@@ -48,6 +48,7 @@ describe("FridaySatelliteSyncService", () => {
       cursorSigner,
       ackValidator,
       nowIso: () => NOW,
+      allowTestOnlySatelliteRuntimeExecution: true,
     });
   }
 
@@ -60,6 +61,7 @@ describe("FridaySatelliteSyncService", () => {
       cursorSigner,
       ackValidator,
       nowIso: () => NOW,
+      allowTestOnlySatelliteRuntimeExecution: true,
       learningEventWriter: writer,
     });
 
@@ -241,6 +243,7 @@ describe("FridaySatelliteSyncService", () => {
       cursorSigner,
       ackValidator,
       nowIso: () => NOW,
+      allowTestOnlySatelliteRuntimeExecution: true,
       remoteNodeResultWriter: writer,
     });
 
@@ -302,6 +305,7 @@ describe("FridaySatelliteSyncService", () => {
       cursorSigner,
       ackValidator,
       nowIso: () => NOW,
+      allowTestOnlySatelliteRuntimeExecution: true,
       remoteNodeResultWriter: writer,
     });
     const pulled = service.pull({


### PR DESCRIPTION
## What & why

The **orphan off-route leak audit** (`ORPHAN_OFFROUTE_LEAK_AUDIT_20260610.md`) found **0 current leaks** across ~45 orphan surfaces, but they are SAFE only by off-route **unreachability** — they are route-only-guarded, **not** method-guarded, and absent from the #631-extended `methodRetiredSurfaces` validator (which covered only 5 seed surfaces). A FUTURE PR wiring a non-route caller into one of these live engines would silently reopen a **G4-class leak** while the route validator stays `blocker=0`.

This PR implements the audit's recommendation: promote the named retired mutators to **METHOD-level fail-closed guards** (default 503), **register** each in the validator's `methodRetiredSurfaces`, and add a **503-by-default behavioral test** per surface. This is **defense-in-depth — no current leak is being closed**, the fence is being locked against a future regression.

## Per-surface: OLD (route-only) → NEW (method-guarded)

Each method-head guard is `if (deps.<flag> !== true) throw 503 <ROUTE_CODE>`, placed **before any state read/write**, mirroring the route's advertised 503 code. Each `<flag>` is plumbed from the **same source the route uses** (api-runtime / satellite-runtime composition) and is **unset in live** (fail-closed by default).

| Surface | serviceFile | Methods | Route code (mirrored) |
|---|---|---|---|
| satellite_registration | friday-satellite-registration-service.ts | `register` | TS_RUNTIME_SATELLITE_PAIRING_RETIRED |
| satellite_pairing | friday-satellite-pairing-service.ts | `approvePairing`,`rejectPairing`,`completeHandshake`,`revokeSatellite` | TS_RUNTIME_SATELLITE_PAIRING_RETIRED |
| satellite_capability | friday-satellite-capability-service.ts | `updateCapabilities` | TS_RUNTIME_SATELLITE_RUNTIME_RETIRED |
| satellite_heartbeat | friday-satellite-heartbeat-service.ts | `recordHeartbeat` | TS_RUNTIME_SATELLITE_RUNTIME_RETIRED |
| satellite_sync | friday-satellite-sync-service.ts | `pull`,`push` (inbound engine only) | TS_RUNTIME_SATELLITE_RUNTIME_RETIRED |
| fleet_remediation | friday-fleet-dashboard-service.ts | `executeSatelliteRemediationAction` | TS_RUNTIME_FLEET_REMEDIATION_RETIRED |
| realtime_ack | friday-realtime-subscription-service.ts | `ackEvent` | TS_RUNTIME_REALTIME_RETIRED |
| autonomy_mcp_lifecycle | friday-mcp-server-upgrade-lifecycle-service.ts | `registerShadowVersion`,`recordCanaryResult`,`promote`,`rollback` | TS_RUNTIME_AUTONOMY_LIFECYCLE_RETIRED |
| node_runner_execution | friday-deterministic-pipeline-runtime.ts | `executeNode` | TS_RUNTIME_NODE_RUNNER_EXECUTION_RETIRED |
| retry_pipeline | friday-deterministic-pipeline-runtime.ts | `createPolicy`,`updatePolicy`,`deletePolicy`,`classifyFailure`,`decideRetry`,`acknowledgeEscalation` | TS_RUNTIME_RETRY_PIPELINE_RETIRED |

**Notes on the two subtle ones:**
- **realtime_ack** already had a *de-facto* two-site method guard (HTTP `/v1/realtime/ack` route + WS `ack` frame both pre-gate the flag before calling `ackEvent`). This **registers** that fence as a single method guard so a future THIRD caller cannot bypass it.
- **node_runner_execution / retry_pipeline** guard the route-deps **WRAPPERS** the runtime returns (converted from arrow-property closures to object-method shorthand so the textual validator can locate them) — **NOT** the shared `createNodeRunnerPipeline` / `FridayRuleEngine` engines, which the **live workflow runtime uses as separate instances** (verified: workflow-runtime constructs its own `createNodeRunnerPipeline().execute`; the wrapper calls *this* runtime's instance). The runtime is route-deps-only in the hub (route factory + a verified **no-op** health-check at bootstrap:7087).

## methodRetiredSurfaces registration + anti-shrinkage floors

- 10 new surface entries added (satellite ×5, fleet, realtime, mcp-lifecycle, node-runner, retry).
- `guardedMethodsMin` **12 → 34**, `behavioralTestsMin` **5 → 15**, plus a `perSurfaceMethodsMin` entry per new surface — so a future PR cannot silently drop these guards without tripping anti-shrinkage.
- **Novel two-surfaces-one-file pattern** (`node_runner_execution` + `retry_pipeline` share `friday-deterministic-pipeline-runtime.ts`): the A.2 unregistered-mutator scan runs over the whole file per surface, so each surface **cross-allowlists** the other's methods (e.g. `node_runner_execution` allowlists `createPolicy`/`updatePolicy`/`deletePolicy` "declared+guarded under retry_pipeline, same file") — **no blind spot**: each method's guard is still enforced by its own surface's Phase A.1. `execute` (an internal `class DataNodeAdapter` method, not a route-deps mutator) is allowlisted in both with that reason. `generateCursor` (read-only HMAC helper, verb 'generate' false-match) is allowlisted on realtime_ack.

## 503-by-default behavioral tests (one per surface, 9 files)

Each constructs the service **WITHOUT** the flag and asserts the method throws `FridayDomainError` / `code` / `httpStatus: 503` and writes no row, **AND** that the legacy path works with the flag enabled, **AND** that reads stay live. (node-runner + retry share one test file per the manifest.)

## Live non-retired paths — explicitly UNTOUCHED (HARD RULE)

- satellite **retention GC** (`retention.run`), **outbox command-queue enqueue** (`outbox.enqueue`, hub→satellite), **remote-result writer** — NOT fenced (separate non-retired internal surfaces; the sync guard fences only the INBOUND `pull`/`push` engine).
- the agent's **OUTBOUND** MCP client `callTool` (`friday-agent-mcp-tool.ts` → `mcpAdapter.callTool`) — different object/direction, NOT fenced.
- deterministic-pipeline **route-deps health-check** (bootstrap:7087, verified no-op) and the live **workflow runtime** pipeline (separate shared-engine instances) — NOT fenced.
- Every guard fail-closes **only** when its test-oracle flag is unset, which is the live default; the existing route tests (mocked deps) and all edited service/integration tests pass with the flag set in the test-oracle path.

## Documented-not-guarded (no clean seam / over-guard risk)

- **mcp inbound `mcpServer.callTool`** — an inline IIFE in `friday-hub-bootstrap.ts`, **no serviceFile** to register, and already guarded **at the JSON-RPC dispatcher**; route-deps-only. No clean method seam.
- **media-understanding `processAttachments`** — the service exposes a single read-orchestration method (verb 'process', not a mutator), no off-route caller; the `analyze`/`doctor` route surfaces have no underlying mutator method.
- **deterministic-pipeline rules / acceptance / playbook** (~remaining surfaces) — arrow-property route-deps wrappers; converting all would be a large, risky refactor of the live return object, and the family's SAFE verdict already rests on the **#637-method-guarded `executeRun`** (the embedded pipeline's sole live driver). Deferred.
- **Sibling skill/channel-adapter/plugin upgrade-lifecycle services** share the MCP-lifecycle method shape and the same route guard but are **out of the audit's named scope** (`autonomy.mcp.servers.*` only) — left for a follow-up parallel-family audit, **not** a missed surface.

## Verification (local)

- `assert-ts-runtime-method-guards.mjs`: **PASS** (15 surfaces, 34 declared methods, 15 behavioral tests present, no shrinkage; every method `guarded`).
- `check-ts-runtime-retirement.mjs` (route validator): **PASS** (`blocker=0`, `blockerFamilies: []`).
- `typecheck:src` (tsc): **PASS** (0 errors). `lint`: **0 errors** (warnings pre-existing).
- vitest: **9 new guard suites (34 tests)** + **16 edited existing suites** green; api-runtime/satellite/realtime/fleet/autonomy dirs + route-contract snapshot green.
- secrets: `check-provider-key-patterns.mjs` clean; `detect-secrets-hook` clean on changed files (test secrets carry `pragma: allowlist secret`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)