### PR TITLE
feat(rust+ts): A2a Phase 1 — session read-only route (qualifier clause-5 relax + session_id wire + conditional run_session_loop dispatch, owner-scoped; dark, DEPLOY-GO-only)

### DIFF
--- a/rust-core/crates/friday-ffi/src/lib.rs
+++ b/rust-core/crates/friday-ffi/src/lib.rs
@@ -3386,6 +3386,7 @@ mod tests {
                 task: "t".into(),
                 forwarded_principal: "p".into(),
                 auth_proof: vec![],
+                session_id: None,
             },
         );
         match parse_hub_response(request.encode().unwrap()) {

--- a/rust-core/crates/friday-hub/src/bin/hub_agent_run_server.rs
+++ b/rust-core/crates/friday-hub/src/bin/hub_agent_run_server.rs
@@ -662,6 +662,7 @@ fn serve_sealed_session<S: Read + Write, T: Transport>(
                 task,
                 forwarded_principal,
                 auth_proof,
+                session_id,
             } => {
                 // The dispatch arm: AUTH BEFORE ANY RUN. The `auth_proof` is the peer-sealed
                 // challenge; reconstruct it as a `Sealed` for the session-key open. A malformed
@@ -691,8 +692,27 @@ fn serve_sealed_session<S: Read + Write, T: Transport>(
 
                 // AUTHENTICATED: run the Rust loop AS the bound owner. A route/provider failure
                 // is a SAFE FAILURE (body-free NoAnswer) — never a panic, never a partial body.
+                //
+                // (A2a Phase 1) CONDITIONAL dispatch swap on the client-asserted `session_id`:
+                //   * PRESENT (non-empty) ⇒ the SESSIONED entry [`HubRuntime::run_session_task`]
+                //     (the EXISTING `run_session_loop` — reloads history, appends this turn), with
+                //     the session OWNER = the AUTHENTICATED `caller` (NEVER `session_id`).
+                //   * ABSENT (or blank) ⇒ the UNCHANGED sessionless [`run_authed_agent_loop`].
+                // The swap is CONDITIONAL by design: `run_session_loop` runs ensure_session/
+                // load_session_messages, so routing today's sessionless live path through it would
+                // NOT be byte-identical. A blank/whitespace `session_id` is treated as ABSENT so a
+                // degenerate value can never silently divert the sessionless path. Both arms then
+                // share the IDENTICAL refs + owner-sealed-body emit below (the body is owner-gated
+                // by `project_answer_for_authed` in BOTH), so the only difference is which loop ran.
                 let now_ms = now_ms();
-                let outcome = run_authed_agent_loop(runtime, &caller, &run_id, &task, now_ms);
+                let outcome = match session_id
+                    .as_deref()
+                    .map(str::trim)
+                    .filter(|s| !s.is_empty())
+                {
+                    Some(sid) => runtime.run_session_task(&caller, &run_id, sid, &task, now_ms),
+                    None => run_authed_agent_loop(runtime, &caller, &run_id, &task, now_ms),
+                };
 
                 // (refs) REFS-ONLY terminal receipt over the wire: status + answer FINGERPRINT
                 // (sha256/len) + (A1) the run COUNTS (turns / executed_tools) — NEVER the body.
@@ -1029,6 +1049,31 @@ mod tests {
                 task: "answer me".into(),
                 forwarded_principal: principal.to_string(),
                 auth_proof: auth_proof_bytes(client_session, session_nonce, principal, run_id),
+                session_id: None,
+            },
+        )
+    }
+
+    /// (A2a Phase 1) A SESSIONED `AgentRunRequest` — identical to [`agent_run_request`] but
+    /// carrying a non-empty `session_id`, so the server's dispatch arm branches into
+    /// `run_session_task` (the existing `run_session_loop`) instead of `run_authed_agent_loop`.
+    fn sessioned_agent_run_request(
+        msg_id: &str,
+        run_id: &str,
+        principal: &str,
+        session_id: &str,
+        client_session: &DataKey,
+        session_nonce: &[u8],
+    ) -> Envelope {
+        Envelope::new(
+            msg_id,
+            1000,
+            Message::AgentRunRequest {
+                run_id: run_id.to_string(),
+                task: "answer me".into(),
+                forwarded_principal: principal.to_string(),
+                auth_proof: auth_proof_bytes(client_session, session_nonce, principal, run_id),
+                session_id: Some(session_id.to_string()),
             },
         )
     }
@@ -1263,6 +1308,7 @@ mod tests {
                     task: "answer me".into(),
                     forwarded_principal: OWNER.to_string(),
                     auth_proof: bad_proof,
+                    session_id: None,
                 },
             );
             (req, session.clone(), session.clone())
@@ -1608,6 +1654,7 @@ mod tests {
                     task: "answer me".into(),
                     forwarded_principal: OWNER.to_string(),
                     auth_proof: proof,
+                    session_id: None,
                 },
             );
             ws_send_envelope(&mut ws, &sess_c1, &req, SESSION_AAD).unwrap();
@@ -1637,6 +1684,7 @@ mod tests {
                     task: "answer me".into(),
                     forwarded_principal: OWNER.to_string(),
                     auth_proof: captured_proof,
+                    session_id: None,
                 },
             );
             ws_send_envelope(&mut ws, &sess_c2, &req, SESSION_AAD).unwrap();
@@ -2450,6 +2498,233 @@ mod tests {
             v["httpStatus"],
             serde_json::json!(503),
             "fail-closed surfaces a 503"
+        );
+    }
+
+    // ────────────────────────────────────────────────────────────────────────────────────
+    // (A2a Phase 1) SESSIONED read-only dispatch — the CONDITIONAL swap on `session_id`.
+    // ────────────────────────────────────────────────────────────────────────────────────
+
+    // OWNER-SCOPING: a sessioned request (non-empty `session_id`) routes through
+    // `run_session_task` → `run_session_loop`. The session row is created OWNED by the
+    // AUTHENTICATED forwarded principal (the `caller`), NOT the client-asserted `session_id`,
+    // and the body is delivered owner-sealed to that owner EXACTLY like the sessionless path.
+    #[test]
+    fn sessioned_dispatch_creates_owner_scoped_session_and_delivers_body_to_owner() {
+        let (rt, _ws) = mock_runtime("sess-owner", OWNER);
+        let server_kp = DeviceKeypair::generate();
+        let listener = AgentRunWsListener::bind_loopback(0).unwrap();
+        let addr = listener.local_addr().unwrap();
+        let allowlist = vec![OWNER.to_string()];
+
+        let client_kp = DeviceKeypair::generate();
+        let client_session = client_kp.agree(&server_kp.public_bytes());
+        let peer_allowlist = allowlist_of(client_kp.public_bytes());
+        let client = spawn_client(addr, client_kp, |session, nonce| {
+            // CLIENT-ASSERTED session id — deliberately NOT the principal. The owner binding
+            // must come from the authenticated `caller`, never this value.
+            let req = sessioned_agent_run_request(
+                "req-s1",
+                "run-sess-1",
+                OWNER,
+                "chat-session-xyz",
+                session,
+                nonce,
+            );
+            (req, session.clone(), session.clone())
+        });
+
+        let processed = listener
+            .accept_one(&server_kp, &rt, &allowlist, &peer_allowlist)
+            .unwrap();
+        assert_eq!(processed, 1, "one sessioned dispatch processed");
+
+        let obs = client.join().unwrap();
+        // The refs result + owner-sealed body are delivered EXACTLY as the sessionless path
+        // (the two dispatch arms share the identical emit tail).
+        let Some(Message::AgentRunResult {
+            run_id,
+            answer_sha256,
+            answer_len,
+            ..
+        }) = obs.result.clone()
+        else {
+            panic!("expected AgentRunResult, got {:?}", obs.result);
+        };
+        assert_eq!(run_id, "run-sess-1");
+        assert_eq!(
+            answer_sha256.as_deref(),
+            Some(sha256_hex(BODY.as_bytes()).as_str())
+        );
+        assert_eq!(answer_len, Some(BODY.len() as u64));
+        assert!(
+            !format!("{:?}", obs.result).contains(BODY),
+            "refs result leaked the body"
+        );
+        let chunk = obs
+            .body_chunk
+            .expect("owner-sealed body delivered for the sessioned run");
+        let inner_bytes = hex_decode(&chunk).expect("body chunk is hex");
+        let inner = decode_sealed_proof(&inner_bytes).expect("owner-sealed body decodes");
+        let opened = friday_crypto::open(&client_session, &inner, SESSION_AAD).unwrap();
+        assert_eq!(
+            opened,
+            BODY.as_bytes(),
+            "owner opens the sealed sessioned body"
+        );
+
+        // OWNER-SCOPING (the load-bearing assertion): the session row was created OWNED by the
+        // AUTHENTICATED principal (`OWNER`), NEVER the client-asserted `session_id`.
+        let owner = friday_storage::load_session_owner(rt.db().conn(), "chat-session-xyz")
+            .unwrap()
+            .expect("the sessioned run created the session row");
+        assert_eq!(
+            owner.user_id.as_deref(),
+            Some(OWNER),
+            "the session owner MUST be the authenticated principal, never the client-asserted session_id"
+        );
+        assert_ne!(
+            owner.user_id.as_deref(),
+            Some("chat-session-xyz"),
+            "the client-asserted session_id must NEVER become the owner"
+        );
+
+        // The run's turn was appended to THIS session (history is now persisted for the next turn).
+        assert!(
+            friday_storage::session_message_count(rt.db().conn(), "chat-session-xyz").unwrap() >= 1,
+            "the sessioned run appended at least the user turn"
+        );
+
+        // BODY is releasable ONLY to the bound owner (a guessed/other principal is denied).
+        use friday_storage::{AnswerDenyReason, RunAnswerAccess};
+        match friday_storage::get_run_answer_for_principal(rt.db().conn(), "run-sess-1", OWNER)
+            .unwrap()
+        {
+            RunAnswerAccess::Granted(stored) => assert_eq!(stored.answer, BODY),
+            other => panic!("owner must be Granted the sessioned body, got {other:?}"),
+        }
+        assert_eq!(
+            friday_storage::get_run_answer_for_principal(
+                rt.db().conn(),
+                "run-sess-1",
+                "principal:not-the-owner"
+            )
+            .unwrap(),
+            RunAnswerAccess::Denied(AnswerDenyReason::PrincipalMismatch),
+            "a non-owner (even one who guessed the session_id) must be DENIED the body"
+        );
+    }
+
+    // SESSION THREADING: a SECOND turn on the SAME session id reloads + extends the SAME
+    // session row — proving multi-turn history accumulates on one session (the Phase-1
+    // capability). Two separate sealed connections (transport-stateless, DB-stateful).
+    #[test]
+    fn second_sessioned_turn_threads_into_the_same_session_history() {
+        let (rt, _ws) = mock_runtime("sess-thread", OWNER);
+        let server_kp = DeviceKeypair::generate();
+        let listener = AgentRunWsListener::bind_loopback(0).unwrap();
+        let addr = listener.local_addr().unwrap();
+        let allowlist = vec![OWNER.to_string()];
+        let sid = "chat-thread-1";
+
+        // ── Turn 1 (fresh sealed connection) ──
+        let kp1 = DeviceKeypair::generate();
+        let peer1 = allowlist_of(kp1.public_bytes());
+        let c1 = spawn_client(addr, kp1, move |s, n| {
+            let req = sessioned_agent_run_request("req-t1", "run-t1", OWNER, "chat-thread-1", s, n);
+            (req, s.clone(), s.clone())
+        });
+        assert_eq!(
+            listener
+                .accept_one(&server_kp, &rt, &allowlist, &peer1)
+                .unwrap(),
+            1
+        );
+        c1.join().unwrap();
+        let after_turn1 = friday_storage::session_message_count(rt.db().conn(), sid).unwrap();
+        assert!(after_turn1 >= 1, "turn 1 appended history");
+
+        // ── Turn 2 (a SEPARATE sealed connection, SAME session id) ──
+        let kp2 = DeviceKeypair::generate();
+        let peer2 = allowlist_of(kp2.public_bytes());
+        let c2 = spawn_client(addr, kp2, move |s, n| {
+            let req = sessioned_agent_run_request("req-t2", "run-t2", OWNER, "chat-thread-1", s, n);
+            (req, s.clone(), s.clone())
+        });
+        assert_eq!(
+            listener
+                .accept_one(&server_kp, &rt, &allowlist, &peer2)
+                .unwrap(),
+            1
+        );
+        c2.join().unwrap();
+
+        // Turn 2 reloaded the SAME session and appended ON TOP of turn 1's history — the count
+        // STRICTLY grew (it did not start a fresh session), and both runs' turns are present.
+        let after_turn2 = friday_storage::session_message_count(rt.db().conn(), sid).unwrap();
+        assert!(
+            after_turn2 > after_turn1,
+            "turn 2 must extend the SAME session history (got {after_turn1} → {after_turn2})"
+        );
+        let msgs = friday_storage::load_session_messages(rt.db().conn(), sid).unwrap();
+        assert!(
+            msgs.iter().any(|m| m.refs.as_deref() == Some("run-t1")),
+            "turn 1's message persists in the shared session"
+        );
+        assert!(
+            msgs.iter().any(|m| m.refs.as_deref() == Some("run-t2")),
+            "turn 2's message was appended to the SAME session"
+        );
+    }
+
+    // BYTE-IDENTICAL SESSIONLESS: a request with NO `session_id` (the pre-A2a shape) still
+    // routes through the UNCHANGED `run_authed_agent_loop` and creates NO session row — the
+    // sessioned path is not silently entered. This is the regression fence for the one
+    // currently-live, operator-fed sessionless path.
+    #[test]
+    fn sessionless_dispatch_uses_unchanged_path_and_creates_no_session_row() {
+        let (rt, _ws) = mock_runtime("sess-none", OWNER);
+        let server_kp = DeviceKeypair::generate();
+        let listener = AgentRunWsListener::bind_loopback(0).unwrap();
+        let addr = listener.local_addr().unwrap();
+        let allowlist = vec![OWNER.to_string()];
+
+        let client_kp = DeviceKeypair::generate();
+        let peer_allowlist = allowlist_of(client_kp.public_bytes());
+        let client = spawn_client(addr, client_kp, |session, nonce| {
+            // The EXACT sessionless helper today's live path uses (session_id: None).
+            let req = agent_run_request("req-none", "run-none", OWNER, session, nonce);
+            (req, session.clone(), session.clone())
+        });
+        assert_eq!(
+            listener
+                .accept_one(&server_kp, &rt, &allowlist, &peer_allowlist)
+                .unwrap(),
+            1
+        );
+        let obs = client.join().unwrap();
+        // The result is delivered (the unchanged sessionless path still works).
+        assert!(
+            matches!(obs.result, Some(Message::AgentRunResult { .. })),
+            "sessionless dispatch still returns a refs result"
+        );
+        // CRITICAL: NO session row was created for the sessionless run — `run_session_loop`
+        // (which ensure_session's) was NEVER entered. The run's own id is never a session id.
+        assert!(
+            friday_storage::load_session_owner(rt.db().conn(), "run-none")
+                .unwrap()
+                .is_none(),
+            "the sessionless path must NOT create a session row (byte-identical to today)"
+        );
+        // And the agent_session table has NO rows at all from this run.
+        let n: i64 = rt
+            .db()
+            .conn()
+            .query_row("SELECT count(*) FROM agent_session", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(
+            n, 0,
+            "the sessionless dispatch created ZERO session rows (the session loop was never reached)"
         );
     }
 }

--- a/rust-core/crates/friday-hub/src/runtime.rs
+++ b/rust-core/crates/friday-hub/src/runtime.rs
@@ -30,8 +30,9 @@ use friday_core::gate::{CanonicalApproval, MutatingActionRequest};
 use friday_core::WorkLane;
 use friday_crypto::OperatorVerifyingKey;
 use friday_deepseek::{DeepSeekClient, DeepSeekError, Transport, UreqTransport};
-use friday_storage::{agent_run, persist_run_result, Db, RunResult, StorageError};
+use friday_storage::{agent_run, persist_run_result, Db, RunResult, SessionOwner, StorageError};
 
+use crate::hub_server::{project_answer_for_authed, AuthedAnswer, AuthedPrincipal};
 use crate::mission_context::MissionContextLookup;
 use crate::mission_preflight::MissionAttachmentOutcome;
 use crate::mission_runtime::{
@@ -43,7 +44,8 @@ use crate::routing::{
     RouteRequest, RoutedLoopError, RoutedSelection,
 };
 use crate::{
-    AgentLlmClient, DeepSeekAgentLlmClient, FsToolExecutor, LoopOutcome, LoopStatus, RunPolicy,
+    run_session_loop, AgentLlmClient, DeepSeekAgentLlmClient, FsToolExecutor, LoopOutcome,
+    LoopStatus, RunPolicy,
 };
 
 /// S1.3 — the outcome of [`HubRuntime::run_agent_loop_for_mission`], mirroring
@@ -309,6 +311,118 @@ impl<T: Transport> HubRuntime<T> {
         }
 
         Ok((selection, outcome))
+    }
+
+    /// (A2a Phase 1) The SESSIONED authenticated agent-loop entry — the read-only chat
+    /// parity of [`run_authed_agent_loop`](crate::hub_server::run_authed_agent_loop) for a
+    /// MULTI-TURN session. It drives the EXISTING, already-verified
+    /// [`run_session_loop`] (no new loop code) so a run reloads its session history and
+    /// appends this turn, then projects the answer body owner-gated EXACTLY as the
+    /// sessionless entry does. The dispatch arm calls this ONLY when the client carried a
+    /// non-empty `session_id`; a sessionless run stays on [`run_authed_agent_loop`]
+    /// unchanged (byte-identical).
+    ///
+    /// ## Owner-scoping (INV-5/INV-7 — the load-bearing security property)
+    /// The session OWNER is the AUTHENTICATED forwarded principal (`caller`, produced ONLY
+    /// by [`AuthedPrincipal::authenticate_forwarded`] against the owner allowlist), NEVER
+    /// the client-asserted `session_id`. We bind `SessionOwner { user_id:
+    /// caller.principal(), .. }` at session creation, and the body is released via
+    /// [`project_answer_for_authed`] to that SAME authenticated `caller` — so a peer can
+    /// never read another owner's session history/body by guessing a `session_id`. Single-
+    /// owner v1: the runtime's `self.policy.principal_id()` is the SAME configured owner the
+    /// allowlist admits, so `run_session_loop`'s owner-wiring records `owner == caller` and
+    /// the body is releasable to them. If they ever diverged (a multi-entry allowlist, NOT
+    /// v1), `project_answer_for_authed` would DENY → fail-closed (the body stays withheld),
+    /// which is the correct safe behavior, not a leak.
+    ///
+    /// SAFE FAILURE: a storage failure (the session loop's `Err`) OR a non-Finished run
+    /// returns a body-free [`AuthedAnswer::NoAnswer`] — no panic, no partial/false success
+    /// — mirroring [`run_authed_agent_loop`]. The body, when delivered, is carried ONLY in
+    /// [`AuthedAnswer::Delivered`] for in-process hand-off to the authed owner; it is NEVER
+    /// placed on a refs surface and NEVER logged.
+    ///
+    /// Recall: like [`Self::run_task`], the run still folds this owner's confirmed-memory
+    /// recall preamble (keyed by `self.policy.principal_id()`) AHEAD of the session history
+    /// — consistent with the sessionless entry; the session loop adds prior-turn history on
+    /// top, it does not replace recall.
+    ///
+    /// Truth label: DARK Phase 1 (read-only sessioned chat). Reachable only when the WS
+    /// server's dispatch arm branches on a client `session_id`; live only at DEPLOY GO.
+    /// Read-only sessioned chat on Rust is an HONEST PARTIAL — it is NOT GATE-AGENT-REPLACE.
+    pub fn run_session_task(
+        &self,
+        caller: &AuthedPrincipal,
+        run_id: &str,
+        session_id: &str,
+        task: &str,
+        now_ms: i64,
+    ) -> AuthedAnswer {
+        // Create the run row FIRST — `run_session_loop` only `ensure_session`s the session
+        // row; it does NOT create the `agent_run` row (its step-5 `persist_run_result`
+        // would orphan without one). `run_task` does this too. A create failure is a SAFE
+        // FAILURE (body-free NoAnswer; no panic, no partial body).
+        if agent_run::create_run(self.db.conn(), run_id, task, now_ms).is_err() {
+            return AuthedAnswer::NoAnswer {
+                run_id: run_id.to_string(),
+            };
+        }
+
+        // Owner-scoping: bind the session's owner to the AUTHENTICATED caller principal —
+        // NEVER the client-asserted `session_id` (INV-5/INV-7). The `user_id` axis is what
+        // the memory namespace + owner-wiring derive from.
+        let owner = SessionOwner {
+            user_id: Some(caller.principal().to_string()),
+            ..SessionOwner::default()
+        };
+
+        // The owner's confirmed-memory recall preamble (same source as `run_task`). A recall
+        // failure is a SAFE FAILURE (body-free NoAnswer) — never a panic.
+        let recall_preamble = match self.recall_preamble(run_id, now_ms) {
+            Ok(p) => p,
+            Err(_) => {
+                return AuthedAnswer::NoAnswer {
+                    run_id: run_id.to_string(),
+                };
+            }
+        };
+
+        // Drive the EXISTING session loop AS the bound owner: it ensures the OWNED session,
+        // loads + folds prior history, runs the SAME gate-mandatory loop (read-only stays
+        // gate-enforced; a mutating tool would Pause — Phase 1 admits none), appends this
+        // turn, and owner-wires a Finished answer's `run_result`. NO new loop code.
+        let approve = |req: &MutatingActionRequest| self.approval.approve(req);
+        let outcome = match run_session_loop(
+            &self.deepseek,
+            &self.executor,
+            self.db.conn(),
+            run_id,
+            session_id,
+            Some(&owner),
+            task,
+            &recall_preamble,
+            self.operator_vk.as_ref(),
+            &approve,
+            &self.policy,
+            self.max_turns,
+            now_ms,
+        ) {
+            Ok(outcome) => outcome,
+            // A storage failure is a SAFE FAILURE: body-free NoAnswer (mirrors the
+            // sessionless entry's route/provider-failure handling). No panic, no partial.
+            Err(_) => {
+                return AuthedAnswer::NoAnswer {
+                    run_id: run_id.to_string(),
+                };
+            }
+        };
+
+        // Release the body ONLY to the authenticated owner (the SAME owner-gated projection
+        // the sessionless entry uses), then attach the loop's COUNTS to a Delivered answer
+        // (a no-op on Denied/NoAnswer). This is byte-shared with `run_authed_agent_loop`'s
+        // tail, so the only difference between the two dispatch arms is which loop ran. Token
+        // counts stay `None` (DEFERRED — billed to the Rust token_ledger, not on LoopOutcome).
+        project_answer_for_authed(self.db.conn(), run_id, caller)
+            .with_counts(outcome.turns, outcome.executed_tools)
     }
 
     /// S1.3 — the Mission-BOUND agent-loop entry (the `executeRun` Mission-context parity,

--- a/rust-core/crates/friday-protocol/src/lib.rs
+++ b/rust-core/crates/friday-protocol/src/lib.rs
@@ -881,6 +881,23 @@ pub enum Message {
         /// The sealed proof bytes the dispatch arm will later verify against the
         /// session (S-C). **SHAPE-ONLY here** — opaque, unverified at this layer.
         auth_proof: Vec<u8>,
+        /// (A2a Phase 1) The CLIENT-ASSERTED session id this run participates in,
+        /// when the run is a sessioned (multi-turn) chat. ADDITIVE + OPTIONAL — an
+        /// absent field deserializes to `None` (`#[serde(default)]`) and a `None`
+        /// value is OMITTED from the wire (`skip_serializing_if`), so a sessionless
+        /// request is BYTE-IDENTICAL to the pre-A2a wire and routes through the
+        /// unchanged sessionless dispatch path. **Mirrors the A1 additive-optional
+        /// pattern.**
+        ///
+        /// **SECURITY (INV-5/INV-7): this is a CLIENT ASSERTION, NOT an authority.**
+        /// It selects WHICH session row to load/append — it does NOT grant access to
+        /// it. The run's bound OWNER is the AUTHENTICATED forwarded principal
+        /// (verified by [`crate`]-external `authenticate_forwarded` against the owner
+        /// allowlist), NEVER this `session_id`. Session history + the answer body are
+        /// releasable only to that authenticated owner — so a peer cannot read another
+        /// owner's history by guessing a `session_id`.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        session_id: Option<String>,
     },
     /// hub->trusted-TS-peer: REFS-ONLY terminal receipt for an agent-run.
     /// **WS-transport substrate (S-A).** It carries a coarse loop-status label and
@@ -1890,6 +1907,8 @@ mod tests {
             // sealed session; the codec just carries them.
             forwarded_principal: "owner-1".into(),
             auth_proof: vec![0xDE, 0xAD, 0xBE, 0xEF],
+            // A2a Phase 1: a sessionless request (the pre-A2a shape) carries `None`.
+            session_id: None,
         };
         let env = Envelope::new("m1", 1000, msg.clone()).with_correlation("c1");
         let json = env.encode().unwrap();
@@ -1897,6 +1916,50 @@ mod tests {
         assert!(json.contains("\"kind\":\"AgentRunRequest\""));
         let back = Envelope::decode(&json).unwrap();
         assert_eq!(back, env);
+        assert_eq!(back.message, msg);
+    }
+
+    #[test]
+    fn agent_run_request_sessionless_is_byte_identical_no_session_id_key() {
+        // (A2a Phase 1) BYTE-IDENTICAL proof: a `session_id: None` request serializes
+        // with NO `session_id` key at all (`skip_serializing_if = "Option::is_none"`),
+        // so the sessionless wire is exactly the pre-A2a wire. This is the additive-
+        // optional discipline A1 established; absent ⇒ unchanged on the wire.
+        let msg = Message::AgentRunRequest {
+            run_id: "run-1".into(),
+            task: "summarize the inbox".into(),
+            forwarded_principal: "owner-1".into(),
+            auth_proof: vec![0xDE, 0xAD, 0xBE, 0xEF],
+            session_id: None,
+        };
+        let json = Envelope::new("m1", 1000, msg).encode().unwrap();
+        assert!(
+            !json.contains("session_id"),
+            "a sessionless AgentRunRequest must not carry a session_id key (byte-identical to pre-A2a): {json}"
+        );
+    }
+
+    #[test]
+    fn agent_run_request_sessioned_round_trips_with_session_id() {
+        // (A2a Phase 1) A sessioned request carries `session_id` on the wire and
+        // round-trips it. An OLD decoder (pre-A2a) ignores the unknown field (the
+        // `Message` enum is NOT `deny_unknown_fields`), so a new client talking to an
+        // old server degrades to sessionless rather than failing — same forward/back
+        // compatibility A1 relies on.
+        let msg = Message::AgentRunRequest {
+            run_id: "run-2".into(),
+            task: "compare it to the other file".into(),
+            forwarded_principal: "owner-1".into(),
+            auth_proof: vec![0x01, 0x02],
+            session_id: Some("sess-abc".into()),
+        };
+        let env = Envelope::new("m2", 2000, msg.clone());
+        let json = env.encode().unwrap();
+        assert!(
+            json.contains("\"session_id\":\"sess-abc\""),
+            "a sessioned request must carry session_id on the wire: {json}"
+        );
+        let back = Envelope::decode(&json).unwrap();
         assert_eq!(back.message, msg);
     }
 

--- a/src/api/mission-spine/friday-rust-hub-agent-run-sealed-client-service.ts
+++ b/src/api/mission-spine/friday-rust-hub-agent-run-sealed-client-service.ts
@@ -69,6 +69,13 @@ export interface FridayRustHubAgentRunSealedClientServiceRequest {
    * (fail-closed). Held in-process only; never logged. A non-32-byte secret fails closed (503).
    */
   readonly clientSecret: Uint8Array;
+  /**
+   * (A2a Phase 1) The session key for a MULTI-TURN read-only chat run. Forwarded UNCHANGED to the
+   * underlying sealed client, which emits it as `session_id` ONLY when non-empty (absent/blank ⇒
+   * byte-identical sessionless wire). The Rust server scopes the session to the authenticated
+   * `forwardedPrincipal`, never this key.
+   */
+  readonly sessionKey?: string;
 }
 
 /**
@@ -184,6 +191,9 @@ export function createFridayRustHubAgentRunSealedClientService(
           runId: request.runId,
           task: request.task,
           forwardedPrincipal: request.forwardedPrincipal,
+          // (A2a Phase 1) forward the session key; the inner client emits `session_id` only when
+          // non-empty (absent/blank ⇒ byte-identical sessionless wire).
+          ...(request.sessionKey !== undefined ? { sessionKey: request.sessionKey } : {}),
         });
       } catch (error) {
         throw error instanceof FridayDomainError

--- a/src/api/mission-spine/friday-rust-hub-agent-run-ws-sealed-client.ts
+++ b/src/api/mission-spine/friday-rust-hub-agent-run-ws-sealed-client.ts
@@ -125,6 +125,16 @@ export interface FridayRustHubAgentRunSealedRequest {
   readonly task: string;
   /** The TS-token-resolved principal the trusted peer forwards (allowlist-checked by the server). */
   readonly forwardedPrincipal: string;
+  /**
+   * (A2a Phase 1) The session key for a MULTI-TURN (sessioned) read-only chat run. When
+   * NON-EMPTY it is forwarded on the wire as `session_id`, which makes the Rust server's
+   * dispatch arm branch into the sessioned loop (history reload/append). ABSENT or BLANK ⇒
+   * the `session_id` field is OMITTED from the wire entirely, so the envelope is
+   * BYTE-IDENTICAL to the pre-A2a sessionless request and routes through the unchanged
+   * sessionless dispatch path. **SECURITY: this only SELECTS the session row; the run's
+   * owner is the authenticated `forwardedPrincipal`, verified server-side — never this key.**
+   */
+  readonly sessionKey?: string;
 }
 
 /**
@@ -696,6 +706,14 @@ export function createFridayRustHubAgentRunSealedClient(
               forwardedPrincipal: request.forwardedPrincipal,
               runId: request.runId,
             });
+            // (A2a Phase 1) Forward `session_id` ONLY when the run carries a non-empty session
+            // key. A blank/absent key OMITS the field entirely (it is NOT set to null/undefined),
+            // so the serialized envelope is BYTE-IDENTICAL to the pre-A2a sessionless request —
+            // the Rust server then routes it through the unchanged sessionless dispatch path.
+            const sessionId =
+              typeof request.sessionKey === "string" && request.sessionKey.trim().length > 0
+                ? request.sessionKey.trim()
+                : undefined;
             const envelope = {
               schema_version: SCHEMA_VERSION,
               msg_id: `agent-run-${request.runId}`,
@@ -708,6 +726,8 @@ export function createFridayRustHubAgentRunSealedClient(
                 forwarded_principal: request.forwardedPrincipal,
                 // serde `Vec<u8>` serializes as a JSON ARRAY of byte numbers (NOT base64/hex).
                 auth_proof: Array.from(authProof),
+                // Conditional spread: present ⇒ `session_id` rides the wire; absent ⇒ no key.
+                ...(sessionId !== undefined ? { session_id: sessionId } : {}),
               },
             };
             sealAndSend(sender, sessionKey, envelope);

--- a/src/api/runtime/friday-api-runtime.ts
+++ b/src/api/runtime/friday-api-runtime.ts
@@ -1002,6 +1002,15 @@ export interface RustRouteQualificationInput {
   };
   model?: string;
   sessionKey?: string;
+  /**
+   * (A2a Phase 1) The OWNER principal for the run. Used ONLY by the relaxed clause-5 session
+   * sub-clause: a sessioned run (`sessionKey` non-empty) is admitted ONLY with a non-empty
+   * `principalId` (the bound owner the Rust server scopes the session history + body to). A
+   * blank/whitespace/absent principal disqualifies a SESSIONED run (fail-closed). It has NO
+   * effect on a sessionless run (that path is unchanged). The route wrapper populates this
+   * from the SAME normalized `principalId` it already threads to compose/idempotency.
+   */
+  principalId?: string;
   requireReview?: boolean;
   constraints?: FridayAgentRunConstraints;
   taskProfile?: FridayAgentTaskProfileInput;
@@ -1094,9 +1103,28 @@ export function qualifiesForRustReadOnlyRoute(input: RustRouteQualificationInput
     return false;
   }
 
-  // Clause 5 — no session-mirror dependency (a sessioned run participates in mirroring).
+  // Clause 5 — session sub-clause (A2a Phase 1 RELAX, owner-scoped).
+  //
+  // A non-empty `sessionKey` NO LONGER disqualifies — a read-only sessioned (multi-turn)
+  // chat run may now route to Rust, where the server reloads + threads the session history
+  // via the already-built `run_session_loop`. This is the ONLY relaxation in Phase 1: clause
+  // 2 (readOnly), clause 3 (deepseek-flash), clause 4 (exactly the 4 read tools), and the
+  // plan-review sub-clauses above all stay intact and fail-closed.
+  //
+  // COMPENSATING REQUIREMENT (the matched tightening): a sessioned run is admitted ONLY with
+  // a NON-EMPTY owner `principalId`. The session history + answer body are releasable only to
+  // the run's bound OWNER = the authenticated forwarded principal; an anonymous / blank
+  // principal cannot own a session, so it MUST still disqualify (fail-closed) — otherwise an
+  // ownerless sessioned run could not be safely owner-scoped. A blank/whitespace principalId
+  // counts as absent. SCOPE: this requirement is checked ONLY when a sessionKey is present —
+  // the SESSIONLESS path is UNTOUCHED (a sessionless run with a blank principal stays exactly
+  // as today: it qualifies here and fail-closes downstream in compose, byte-identical).
   if (typeof input.sessionKey === "string" && input.sessionKey.trim().length > 0) {
-    return false;
+    const hasOwnerPrincipal =
+      typeof input.principalId === "string" && input.principalId.trim().length > 0;
+    if (!hasOwnerPrincipal) {
+      return false;
+    }
   }
 
   // Subagents + Pause-able/mutating-approval actions are precluded structurally
@@ -1165,6 +1193,13 @@ async function composeRustReadOnlyAgentRun(args: {
   readonly runId: string;
   readonly task: string;
   readonly principalId: string | undefined;
+  /**
+   * (A2a Phase 1) The session key for a MULTI-TURN read-only chat run, forwarded to the sealed
+   * WS dispatch as `session_id` ONLY when non-empty. Absent/blank ⇒ the dispatch is byte-
+   * identical to today's sessionless request (no `session_id` on the wire). The Rust server
+   * scopes the session to the authenticated owner principal, never this key.
+   */
+  readonly sessionKey: string | undefined;
   readonly providerId: string;
   readonly model: string;
   readonly wsClient: FridayRustHubAgentRunSealedClientService;
@@ -1217,6 +1252,10 @@ async function composeRustReadOnlyAgentRun(args: {
     task: args.task,
     forwardedPrincipal: callerPrincipal,
     clientSecret,
+    // (A2a Phase 1) forward the session key; the WS client emits `session_id` only when it is
+    // non-empty (absent/blank ⇒ byte-identical sessionless wire, today's behavior). The server
+    // owner-scopes the session to `callerPrincipal` (the authenticated owner), never this key.
+    ...(args.sessionKey !== undefined ? { sessionKey: args.sessionKey } : {}),
   });
 
   // (3) Owner-gated body readback (slice-3). The body is released ONLY to the matching
@@ -4364,6 +4403,10 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
           resolvedProvider,
           model: input.model,
           sessionKey: input.sessionKey,
+          // (A2a Phase 1) the owner principal the relaxed clause-5 session sub-clause requires
+          // for a SESSIONED run. The qualifier trims it; a blank/absent principal disqualifies
+          // a sessioned run (fail-closed) and is a no-op for a sessionless run.
+          principalId: input.principalId,
           requireReview: input.requireReview,
           constraints: input.constraints,
           taskProfile: input.taskProfile,
@@ -4443,6 +4486,9 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
             // matching the bare startRun which normalizes throughout). Robust to future auth
             // issuance even if a principalId ever arrives non-canonical.
             principalId: normalizedPrincipalId,
+            // (A2a Phase 1) forward the session key so a SESSIONED qualifying run dispatches
+            // `session_id`; absent/blank ⇒ byte-identical sessionless dispatch (today's behavior).
+            sessionKey: input.sessionKey,
             providerId: input.providerId ?? RUST_ROUTE_DEEPSEEK_PROVIDER_ID,
             model: input.model ?? RUST_ROUTE_DEEPSEEK_FLASH_MODEL,
             wsClient: rustWsClient,

--- a/test/unit/api/mission-spine/friday-rust-hub-agent-run-sealed-client-service.test.ts
+++ b/test/unit/api/mission-spine/friday-rust-hub-agent-run-sealed-client-service.test.ts
@@ -22,7 +22,12 @@ function makeFakeClient(behavior: {
   reject?: unknown;
 }) {
   const constructed: CreateFridayRustHubAgentRunSealedClientOptions[] = [];
-  const dispatched: Array<{ runId: string; task: string; forwardedPrincipal: string }> = [];
+  const dispatched: Array<{
+    runId: string;
+    task: string;
+    forwardedPrincipal: string;
+    sessionKey?: string;
+  }> = [];
   const createClient = vi.fn(
     (options: CreateFridayRustHubAgentRunSealedClientOptions): FridayRustHubAgentRunSealedClient => {
       constructed.push(options);
@@ -175,6 +180,38 @@ describe("createFridayRustHubAgentRunSealedClientService (B1-compose, dark, adap
         clientSecret: SECRET,
       }),
     ).rejects.toMatchObject({ httpStatus: 503 });
+  });
+
+  it("(A2a Phase 1) forwards a NON-EMPTY sessionKey to the underlying client", async () => {
+    const fake = makeFakeClient({ result: deliveredResult() });
+    const service = createFridayRustHubAgentRunSealedClientService({
+      port: 4123,
+      createClient: fake.createClient,
+    });
+    await service.dispatchRun({
+      runId: "run-1",
+      task: "compare it to the other file",
+      forwardedPrincipal: "owner-1",
+      clientSecret: SECRET,
+      sessionKey: "chat-session-xyz",
+    });
+    expect(fake.dispatched[0].sessionKey).toBe("chat-session-xyz");
+  });
+
+  it("(A2a Phase 1) does NOT set sessionKey on the inner dispatch when it is absent (byte-identical sessionless)", async () => {
+    const fake = makeFakeClient({ result: deliveredResult() });
+    const service = createFridayRustHubAgentRunSealedClientService({
+      port: 4123,
+      createClient: fake.createClient,
+    });
+    await service.dispatchRun({
+      runId: "run-1",
+      task: "read README.md",
+      forwardedPrincipal: "owner-1",
+      clientSecret: SECRET,
+      // no sessionKey
+    });
+    expect("sessionKey" in fake.dispatched[0]).toBe(false);
   });
 
   it("fails closed (503) when the underlying client construction throws (e.g. a non-32-byte secret)", async () => {

--- a/test/unit/api/runtime/friday-api-runtime-rust-route-predicate.test.ts
+++ b/test/unit/api/runtime/friday-api-runtime-rust-route-predicate.test.ts
@@ -184,7 +184,9 @@ describe("qualifiesForRustReadOnlyRoute (execrun slice 4, dark predicate)", () =
     ).toBe(false);
   });
 
-  it("a valid resolved record does NOT bypass the no-session clause", () => {
+  it("a valid resolved record does NOT bypass the session OWNER requirement (sessioned + no principal)", () => {
+    // (A2a Phase 1) a sessioned run with NO owner principal stays disqualified (fail-closed),
+    // even with an otherwise fully-qualifying prod-resolved input.
     expect(
       qualifiesForRustReadOnlyRoute({ ...prodResolvedQualifyingInput(), sessionKey: "some-session" }),
     ).toBe(false);
@@ -265,10 +267,62 @@ describe("qualifiesForRustReadOnlyRoute (execrun slice 4, dark predicate)", () =
     expect(qualifiesForRustReadOnlyRoute({ ...qualifyingInput(), planReviewOverride: {} })).toBe(false);
   });
 
-  // ── Clause 5: no session-mirror dependency ──────────────────────────────────
-  it("disqualifies a sessioned run (session-mirror dependency)", () => {
+  // ── Clause 5 session sub-clause (A2a Phase 1 RELAX, owner-scoped) ────────────
+  // A sessioned run is NOW admitted — but ONLY with a non-empty owner principalId. The
+  // sessionLESS path is unchanged (the owner requirement is checked only when a sessionKey
+  // is present). A blank/whitespace sessionKey is treated as absent (no session).
+  it("admits a sessioned run when an owner principalId is present (A2a Phase 1 relax)", () => {
+    expect(
+      qualifiesForRustReadOnlyRoute({
+        ...qualifyingInput(),
+        sessionKey: "sess-123",
+        principalId: "principal:owner-1",
+      }),
+    ).toBe(true);
+  });
+
+  it("disqualifies a sessioned run with a MISSING owner principalId (fail-closed)", () => {
     expect(qualifiesForRustReadOnlyRoute({ ...qualifyingInput(), sessionKey: "sess-123" })).toBe(false);
-    // whitespace-only sessionKey is treated as absent (still qualifies)
+  });
+
+  it("disqualifies a sessioned run with a BLANK / whitespace owner principalId (fail-closed)", () => {
+    expect(
+      qualifiesForRustReadOnlyRoute({ ...qualifyingInput(), sessionKey: "sess-123", principalId: "" }),
+    ).toBe(false);
+    expect(
+      qualifiesForRustReadOnlyRoute({ ...qualifyingInput(), sessionKey: "sess-123", principalId: "   " }),
+    ).toBe(false);
+  });
+
+  it("admits a sessioned run that ALSO meets every other clause (a real read-only sessioned chat)", () => {
+    expect(
+      qualifiesForRustReadOnlyRoute({
+        ...prodResolvedQualifyingInput(),
+        sessionKey: "chat-session-xyz",
+        principalId: "principal:owner-1",
+        allowedRustRouteTools: ["search", "stat_file", "list_dir", "read_file"],
+      }),
+    ).toBe(true);
+  });
+
+  it("a sessioned run is STILL bound by every other clause (sessioned ∧ readOnly:false ⇒ disqualified)", () => {
+    expect(
+      qualifiesForRustReadOnlyRoute({
+        ...qualifyingInput(),
+        sessionKey: "sess-123",
+        principalId: "principal:owner-1",
+        constraints: { readOnly: false },
+      }),
+    ).toBe(false);
+  });
+
+  it("the session OWNER requirement does NOT affect the SESSIONLESS path (blank principal still qualifies)", () => {
+    // A sessionless run with a blank/absent principal qualifies HERE exactly as before
+    // (it fail-closes downstream in compose). The owner requirement is session-scoped only —
+    // this preserves the byte-identical sessionless behavior.
+    expect(qualifiesForRustReadOnlyRoute({ ...qualifyingInput(), principalId: "" })).toBe(true);
+    expect(qualifiesForRustReadOnlyRoute({ ...qualifyingInput(), principalId: undefined })).toBe(true);
+    // whitespace-only sessionKey is treated as absent (no session ⇒ no owner needed ⇒ qualifies)
     expect(qualifiesForRustReadOnlyRoute({ ...qualifyingInput(), sessionKey: "   " })).toBe(true);
   });
 


### PR DESCRIPTION
## A2a Phase 1 — session, still read-only (GATE-AGENT-REPLACE A-path)

**DARK build.** No live behavior change until DEPLOY GO + WS bin rebuild. This de-risks the **session seam** WITHOUT touching the mutation/S6 surface at all. It is an **honest PARTIAL** — read-only sessioned chat on Rust is **NOT** GATE-AGENT-REPLACE (the gate closes only at D4).

Design of record: `GATE_AGENT_REPLACE_A2_DESIGN_20260610.md` §1(b), §2.1, §3 Change 1, §4 Phase 1. Base: A1 transport-truth (#649, merged).

---

### THE THREE PARTS (all preserve the byte-identical sessionless live path)

**1. Qualifier Change 1** (`src/api/runtime/friday-api-runtime.ts`, `qualifiesForRustReadOnlyRoute`)
Relax the clause-5 **session sub-clause** so a non-empty `sessionKey` NO LONGER disqualifies. **Kept intact:** clause 2 (`readOnly===true`), clause 3 (deepseek-flash), clause 4 (exactly the 4 read tools), the plan-review sub-clauses. **Compensating tightening:** a sessioned run is admitted **ONLY** with a non-empty owner `principalId` (anonymous/blank ⇒ disqualify, fail-closed). The owner requirement is **session-scoped** — checked only when a `sessionKey` is present — so the **sessionless path is unchanged** (a blank-principal sessionless run still qualifies here and fail-closes downstream in compose, exactly as today).

**2. Wire** (`rust-core/crates/friday-protocol/src/lib.rs` + TS courier)
Add `session_id: Option<String>` to `AgentRunRequest` as an **ADDITIVE OPTIONAL** field — `#[serde(default, skip_serializing_if = "Option::is_none")]`, mirroring the A1 pattern (**no `SCHEMA_VERSION` bump**). Absent ⇒ byte-identical wire. TS threads `sessionKey` from the route wrapper → `composeRustReadOnlyAgentRun` → sealed-client service → sealed WS client, which emits `session_id` **only when non-empty** (conditional spread; absent ⇒ no key on the wire).

**3. Server CONDITIONAL dispatch swap** (`rust-core/crates/friday-hub/src/bin/hub_agent_run_server.rs`, `serve_sealed_session`)
Branch on `session_id`: **PRESENT** (non-empty, trimmed) ⇒ the **EXISTING** `run_session_loop` via a new `HubRuntime::run_session_task`; **ABSENT/blank** ⇒ the **UNCHANGED** `run_authed_agent_loop`. **NO new loop code.** The swap is **CONDITIONAL by design** — `run_session_loop` runs `ensure_session`/`load_session_messages`, so routing today's sessionless live path through it would NOT be byte-identical and would silently change the one currently-live operator-fed path.

---

### OWNER-SCOPING GUARANTEE (INV-5 / INV-7)

`HubRuntime::run_session_task` binds the session owner = **`caller.principal()`** — the **AUTHENTICATED forwarded principal** from `authenticate_forwarded` (owner-allowlist-checked) — **NEVER the client-asserted `session_id`**. The answer body is released via the **same** owner-gated `project_answer_for_authed` the sessionless entry uses; the two dispatch arms share the **identical** refs + owner-sealed-body emit tail, so the only difference is which loop ran. `run_session_task` returns **`AuthedAnswer`** (not `LoopOutcome`), so body release stays owner-gated.

Single-owner v1: `caller.principal() == policy.principal_id()` (boot config sets `principal_id: owner_allowlist.first()`, and `authenticate_forwarded` checks the same allowlist), so `run_session_loop`'s owner-wiring records `owner == caller` and the body is releasable. If they ever diverged (a multi-entry allowlist — NOT v1), `project_answer_for_authed` **DENIES** → fail-closed (body withheld), the correct safe behavior.

**Tested:** `sessioned_dispatch_creates_owner_scoped_session_and_delivers_body_to_owner` proves the session row is owned by the authenticated principal (never the `session_id`), the body is delivered owner-sealed, and a non-owner (even one who guessed the `session_id`) is **DENIED** the body.

---

### BYTE-IDENTICAL-SESSIONLESS PROOF

- **protocol serde golden** (`agent_run_request_sessionless_is_byte_identical_no_session_id_key`): a `session_id: None` request serializes with **NO `session_id` key**.
- **server test** (`sessionless_dispatch_uses_unchanged_path_and_creates_no_session_row`): a sessionless dispatch routes the **UNCHANGED** `run_authed_agent_loop` and creates **ZERO** session rows (`run_session_loop` never reached).
- **TS**: conditional spread omits the key when `sessionKey` is absent/blank (identical object ⇒ identical JSON); the service-adapter test asserts the `sessionKey` boundary **both ways** (forwarded when present, absent when omitted). *Note (honest):* there is no direct byte-assertion on the envelope the sealed client emits post-handshake — the chain is conditional-spread → identical object → identical JSON, plus the serde golden on the Rust decode side.

---

### READ-ONLY PRESERVED

`readOnly` stays enforced by qualifier clause 2 **AND** the Rust gate — **NOT loosened**. Mutation still Pauses (the gate is unchanged); Phase 1 admits **no** mutating tools anyway (clause 4 still requires exactly the 4 read tools). **No mutation / S6 / pause-resume code in this slice.** No TS fallback — the qualifying path still fail-closes (503) and routes to Rust, never re-enters TS `startRun`.

---

### DARK STATEMENT

Reversible/inert until live-flipped: the route is gated DEFAULT-OFF behind `FRIDAY_ROUTE_AGENT_RUN_VIA_RUST`, and the server-side conditional swap lives only in the WS bin, which goes live **only at DEPLOY GO + WS bin rebuild**. No prod mutation, no flag flip, no restart. Loopback-only.

---

### TEST EVIDENCE

- `cargo build` (protocol+hub+ffi, `--all-targets`) OK; `cargo fmt --check` **CLEAN**; `cargo clippy -p friday-protocol -p friday-hub -p friday-ffi --all-targets -- -D warnings` **CLEAN**.
- `cargo test` protocol+hub+ffi: **all green** — protocol 23 (incl. 3 new serde tests), hub bin 28 (incl. 3 new sessioned/sessionless dispatch tests), hub lib + integration all pass, ffi pass.
- `tsc --noEmit` OK; `eslint` touched files **0 errors**; vitest (predicate 32, sealed-client-service 9, compose 17, flag 3) = **61 passed**.

---

### HONEST DEFERRALS

- **Read-only sessioned chat on Rust != GATE-AGENT-REPLACE.** The gate's own words (chat read-write loop including S6 signing + organic traffic) close only when **D4** lands.
- **Cross-owner session-HISTORY-CONTENT isolation rests on single-owner v1.** `load_session_messages` is `session_id`-keyed (not owner-filtered). Only one principal can authenticate (`enforce_single_peer` + a single `owner_allowlist`), so **no cross-owner history read is reachable today** — but that safety comes from single-owner v1, NOT from the `SessionOwner` binding. The binding scopes **owner + body-release**; history-content isolation is the v1 single-owner bound. FIX-Q2/Q3b (multi-user) are unbuilt (design §5.5/§6).
- The session path passes `&self.deepseek` directly (clause 3 pins flash), so it persists **no** `RoutedSelection`/`route_decision` row (per-turn usage is still ledgered). Acceptable for dark Phase 1.
- Token totals stay `0` on the wire (DEFERRED — billed to the Rust `token_ledger`), unchanged from A1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)