### PR TITLE
fix(ts-retirement): SEV-1 stop fail-loop — gate off retired recurring sweeps (session-lifecycle + agent-loop-cooldown) + disableJob persisted rows

### DIFF
--- a/src/hub/friday-hub-bootstrap.ts
+++ b/src/hub/friday-hub-bootstrap.ts
@@ -299,7 +299,6 @@ import {
 } from "#learning";
 import {
   createFridayObservabilityApiService,
-  FRIDAY_BUILT_IN_SELF_HEALING_ALERT_RULE_ID,
 } from "../observability/services/friday-observability-api-service.js";
 import { createFridaySatelliteRuntimeRoutes } from "../api/http/routes/friday-satellite-runtime-routes.js";
 import { scanLocalSkills } from "../skills/converter/discovery/friday-local-skill-scanner.js";
@@ -312,7 +311,6 @@ import {
   createFridayJobSchedulerRepository,
   createFridayJobSchedulerService,
   createFridayLearningMetricsJob,
-  createFridaySessionLifecycleJob,
   createFridaySessionMemoryExtractionWorkerJob,
   createFridayWorkflowCronTriggerJob,
   createFridayWorkflowTimeoutJob,
@@ -7409,22 +7407,16 @@ export async function createFridayHub(
       },
     ];
 
-    // Session lifecycle sweep
-    if (sessionExtractionService) {
-      const lifecycleJob = createFridaySessionLifecycleJob({
-        db: stateRuntime.sqlite,
-        sessionService: hubSessionService,
-        extractionService: sessionExtractionService,
-        nowIso,
-      });
-      schedulerJobs.push({
-        id: "session-lifecycle-sweep",
-        intervalMs: 120_000, // every 2 min
-        timeoutMs: 300_000, // 5 min
-        catchUpRuns: 1,
-        run: async () => { await lifecycleJob.run(); },
-      });
-    }
+    // Session lifecycle sweep — RETIRED (SEV-1 stop-the-fail-loop).
+    // The `session-lifecycle-sweep` job's handler called sessionService.sweepLifecycle(),
+    // which is fail-closed (TS_RUNTIME_SESSION_RETIRED, 503) in default/live runtime.
+    // A recurring sweep against a retired method fail-loops forever (the scheduler
+    // never auto-disables a recurring failer; it markFailed → reschedule with capped
+    // backoff). The job is no longer registered here so start() does not re-seed its
+    // row enabled=1; the persisted row (if any) is disabled below via
+    // schedulerRepoRef.disableJob so it is excluded from BOTH due-selection and the
+    // min-wake computation (no busy-spin). The Rust-owned session_lifecycle entrypoint
+    // is a separate operator-gated Phase-1/2 replacement.
 
     // Session memory extraction worker
     if (sessionExtractionService) {
@@ -7541,21 +7533,18 @@ export async function createFridayHub(
       }
     }
 
-    schedulerJobs.push({
-      id: "agent-loop-cooldown-sweep",
-      intervalMs: 60_000,
-      timeoutMs: 120_000,
-      catchUpRuns: 1,
-      run: async () => {
-        const hasRepeatedFailureAlert = observabilityService.alerts.getActiveEvents().some(
-          (event) => event.ruleId === FRIDAY_BUILT_IN_SELF_HEALING_ALERT_RULE_ID && event.status !== "resolved",
-        );
-        await agentLoopService?.resumeCooldownRuns({
-          limit: 10,
-          trigger: hasRepeatedFailureAlert ? "repeated_failure_alert" : "cooldown_elapsed",
-        });
-      },
-    });
+    // Agent-loop cooldown sweep — RETIRED (SEV-1 stop-the-fail-loop, latent twin).
+    // The `agent-loop-cooldown-sweep` job's handler called
+    // agentLoopService.resumeCooldownRuns() → executeRun → executionService.execute(),
+    // which is fail-closed (TS_RUNTIME_AUTOFIX_EXECUTION_RETIRED, 503) in default/live
+    // runtime. It does not fire today only because it queries cooldown rows first and
+    // there are none — but its terminal action is already retired, so it can never do
+    // work and becomes an infinite fail-loop the instant any cooldown loop-run row
+    // exists. The job is no longer registered here so start() does not re-seed its row
+    // enabled=1; the persisted row (if any) is disabled below via
+    // schedulerRepoRef.disableJob so it is excluded from BOTH due-selection and the
+    // min-wake computation (no busy-spin). The Rust-owned auto-fix execution entrypoint
+    // is a separate operator-gated Phase-1/2 replacement.
 
     // System self-health monitor: periodic diagnose-only checks; maintenance cleanup requires an explicit gate.
     schedulerJobs.push({
@@ -7595,6 +7584,21 @@ export async function createFridayHub(
       jobs: schedulerJobs,
     });
     const schedulerService = jobScheduler;
+
+    // SEV-1 stop-the-fail-loop: disable the two retired recurring sweeps' persisted
+    // rows. Removing the registration alone is NOT enough — the rows are already
+    // persisted enabled=1 with a next_run_at, and start() does not re-enable existing
+    // rows, but a row left enabled=1 with a def absent from the in-memory map is the
+    // busy-spin trap: the run loop skips it (no jobDef) yet the min-wake computation
+    // still sees it (enabled + nextRunAt), so once next_run_at is in the past,
+    // delayMs=max(0,past)=0 → armTimer(0) spins every event-loop turn (STRICTLY worse
+    // than the original 120s/60s fail-loop). disableJob sets enabled=0 AND
+    // next_run_at=NULL, excluding the row from BOTH listDue (WHERE enabled=1) and the
+    // min-wake (skips !enabled || !nextRunAt) → loop stops, no spin, no orphaned state
+    // (the guarded write-txn never ran). On a fresh DB these are harmless no-op UPDATEs.
+    // Runs before jobScheduler.start(), so start()'s seed loop will not re-create them.
+    schedulerRepoRef.disableJob("session-lifecycle-sweep", nowIso());
+    schedulerRepoRef.disableJob("agent-loop-cooldown-sweep", nowIso());
 
     // Link agent automations to the unified scheduler.
     if (apiRuntime.agentAutomationService) {

--- a/test/integration/hub/friday-hub-bootstrap-integration.test.ts
+++ b/test/integration/hub/friday-hub-bootstrap-integration.test.ts
@@ -1499,7 +1499,13 @@ describe("FridayHub Bootstrap Integration", () => {
     });
   });
 
-  it("registers the agent-loop cooldown sweep job on startup", async () => {
+  it("does NOT register the retired agent-loop cooldown sweep job on startup (SEV-1 stop-the-fail-loop)", async () => {
+    // The `agent-loop-cooldown-sweep` job's terminal action (executionService.execute)
+    // is fail-closed (TS_RUNTIME_AUTOFIX_EXECUTION_RETIRED). It is no longer registered,
+    // and bootstrap calls schedulerRepoRef.disableJob("agent-loop-cooldown-sweep") so any
+    // persisted row is excluded from due-selection and min-wake. On a fresh DB the
+    // disableJob is a no-op UPDATE, so the row never exists; if a legacy row were present
+    // it would be enabled=0 with next_run_at=NULL. Either way it must not be enabled.
     const hub = await createIsolatedHub();
     await hub.start();
 
@@ -1507,12 +1513,14 @@ describe("FridayHub Bootstrap Integration", () => {
     const db = new Database(dbPath);
     try {
       const row = db
-        .prepare("SELECT id, interval_ms, enabled FROM friday_scheduler_jobs WHERE id = 'agent-loop-cooldown-sweep'")
-        .get() as { id: string; interval_ms: number; enabled: number } | undefined;
-      expect(row).toBeDefined();
-      expect(row!.id).toBe("agent-loop-cooldown-sweep");
-      expect(row!.interval_ms).toBe(60_000);
-      expect(row!.enabled).toBe(1);
+        .prepare("SELECT id, interval_ms, enabled, next_run_at FROM friday_scheduler_jobs WHERE id = 'agent-loop-cooldown-sweep'")
+        .get() as { id: string; interval_ms: number; enabled: number; next_run_at: string | null } | undefined;
+      // Fresh DB: the retired job is never seeded, so no row exists.
+      if (row !== undefined) {
+        // Legacy/pre-existing row: bootstrap's disableJob must have disabled it.
+        expect(row.enabled).toBe(0);
+        expect(row.next_run_at).toBeNull();
+      }
     } finally {
       db.close();
     }
@@ -1557,10 +1565,10 @@ describe("FridayHub Bootstrap Integration", () => {
         jobId: "autofix-dispatch",
         status: expect.stringMatching(/^(scheduled|pending|idle)$/),
       });
-      expect(jobById.get("agent-loop-cooldown-sweep")).toMatchObject({
-        jobId: "agent-loop-cooldown-sweep",
-        status: expect.stringMatching(/^(scheduled|pending|idle)$/),
-      });
+      // SEV-1 stop-the-fail-loop: the retired `agent-loop-cooldown-sweep` job is no
+      // longer registered (its terminal action is fail-closed), so it does not appear
+      // in the /v1/jobs listing on a fresh hub.
+      expect(jobById.get("agent-loop-cooldown-sweep")).toBeUndefined();
     });
   });
 

--- a/test/unit/jobs/scheduler/friday-job-scheduler-service.test.ts
+++ b/test/unit/jobs/scheduler/friday-job-scheduler-service.test.ts
@@ -498,4 +498,124 @@ describe("FridayJobSchedulerService", () => {
 
     await scheduler.stop();
   });
+
+  // ─── SEV-1 stop-the-fail-loop: retired recurring sweep deregistration + disableJob ───
+  //
+  // A retired recurring job (e.g. session-lifecycle-sweep / agent-loop-cooldown-sweep)
+  // whose handler calls a fail-closed (503) method fail-loops forever: the scheduler
+  // markFailed → reschedules with capped backoff and never auto-disables a recurring
+  // failer. The fix removes the in-memory registration AND calls disableJob on the
+  // persisted row. Removing registration ALONE is the busy-spin trap: an enabled row
+  // with its def absent from the in-memory map is skipped by the run loop (no jobDef)
+  // but is still seen by the min-wake computation; once its next_run_at is in the past,
+  // delayMs = max(0, past) = 0 → armTimer(0) spins every event-loop turn (STRICTLY
+  // worse). disableJob sets enabled=0 AND next_run_at=NULL, excluding the row from BOTH
+  // listDue (WHERE enabled=1) and the min-wake (skips !enabled || !nextRunAt).
+
+  it("SEV-1: NEGATIVE CONTROL — an ENABLED ghost row with an absent job def busy-spins (armTimer(0))", async () => {
+    // This proves the bug is real: without disableJob, deregistration alone leaves the
+    // row enabled=1 with a past next_run_at, and the min-wake computes a wake ~now
+    // (the armTimer(0) signature observable via status().nextWakeAt).
+    const repo = createFridayJobSchedulerRepository({ db });
+
+    // Persisted ghost row: enabled=1, next_run_at in the past — but NO matching job def.
+    const pastDate = new Date(Date.now() - 120_000).toISOString();
+    repo.upsert({ id: "retired-ghost", intervalMs: 120_000, timeoutMs: 300_000, catchUpRuns: 1, nowIso: pastDate });
+    repo.setNextRunAt("retired-ghost", pastDate, pastDate);
+
+    const runLog: string[] = [];
+    // Job map deliberately does NOT contain "retired-ghost".
+    const scheduler = createFridayJobSchedulerService({ repository: repo, jobs: [] });
+
+    await scheduler.start();
+    // Read the wake state immediately on the post-await continuation, BEFORE the
+    // setTimeout(0) macrotask fires, then stop promptly (stop() synchronously cancels
+    // the timer) so the control does not actually spin.
+    const status = await scheduler.status();
+    await scheduler.stop();
+
+    // The run loop never executed the ghost (no jobDef) ...
+    expect(runLog).toEqual([]);
+    // ... but min-wake DID see the enabled row → a wake was armed ≈ now (the trap).
+    expect(status.nextWakeAt).toBeDefined();
+    const wakeMs = new Date(status.nextWakeAt!).getTime();
+    expect(wakeMs - Date.now()).toBeLessThanOrEqual(1_000); // ≈0 delay = busy-spin signature
+
+    // The row is still enabled (deregistration alone did not disable it).
+    const ghost = repo.getById("retired-ghost");
+    expect(ghost?.enabled).toBe(true);
+  });
+
+  it("SEV-1: FIX — disableJob on a deregistered ghost row stops the loop with no busy-spin", async () => {
+    const repo = createFridayJobSchedulerRepository({ db });
+
+    // Same persisted ghost row as the negative control.
+    const pastDate = new Date(Date.now() - 120_000).toISOString();
+    repo.upsert({ id: "retired-ghost", intervalMs: 120_000, timeoutMs: 300_000, catchUpRuns: 1, nowIso: pastDate });
+    repo.setNextRunAt("retired-ghost", pastDate, pastDate);
+
+    // The fix: disable the persisted row (mirrors bootstrap's schedulerRepoRef.disableJob
+    // call) — this is what bootstrap does in addition to removing the registration.
+    const nowIso = new Date().toISOString();
+    repo.disableJob("retired-ghost", nowIso);
+
+    // (3) disableJob sets enabled=0 AND next_run_at=NULL.
+    const afterDisable = repo.getById("retired-ghost");
+    expect(afterDisable?.enabled).toBe(false);
+    expect(afterDisable?.nextRunAt).toBeNull();
+    // Excluded from due-selection (WHERE enabled=1).
+    expect(repo.listDue(new Date().toISOString()).some((j) => j.id === "retired-ghost")).toBe(false);
+
+    const runLog: string[] = [];
+    // Job map deliberately does NOT contain "retired-ghost".
+    const scheduler = createFridayJobSchedulerService({ repository: repo, jobs: [] });
+
+    await scheduler.start();
+    const status = await scheduler.status();
+    await scheduler.stop();
+
+    // (1) no executeJob runs for the disabled ghost.
+    expect(runLog).toEqual([]);
+    // (2) NO busy-spin: the disabled row is excluded from min-wake (earliestMs stays
+    // Infinity), so armTimer is never called and no wake is scheduled.
+    expect(status.nextWakeAt).toBeUndefined();
+    // The row remains disabled across the scheduler start() (start() does not re-enable
+    // existing rows; upsert's ON CONFLICT never touches `enabled`).
+    const afterStart = repo.getById("retired-ghost");
+    expect(afterStart?.enabled).toBe(false);
+    expect(afterStart?.nextRunAt).toBeNull();
+  });
+
+  it("SEV-1: disabled ghost row stays excluded alongside a healthy live job (no spin from the ghost)", async () => {
+    const repo = createFridayJobSchedulerRepository({ db });
+
+    // A retired ghost row (disabled) coexisting with a real future-scheduled job.
+    const pastDate = new Date(Date.now() - 120_000).toISOString();
+    repo.upsert({ id: "retired-ghost", intervalMs: 120_000, timeoutMs: 300_000, catchUpRuns: 1, nowIso: pastDate });
+    repo.setNextRunAt("retired-ghost", pastDate, pastDate);
+    repo.disableJob("retired-ghost", new Date().toISOString());
+
+    const runLog: string[] = [];
+    const jobs: FridayScheduledJobDefinition[] = [
+      {
+        id: "healthy-job",
+        // Anchored far in the future so it neither runs now nor pulls min-wake to ~0.
+        schedule: { kind: "every", everyMs: 600_000, anchorMs: Date.now() + 600_000 },
+        run: async () => { runLog.push("healthy"); },
+      },
+    ];
+
+    const scheduler = createFridayJobSchedulerService({ repository: repo, jobs });
+
+    await scheduler.start();
+    const status = await scheduler.status();
+    await scheduler.stop();
+
+    // The ghost neither ran nor contributed a ~now wake.
+    expect(runLog).toEqual([]);
+    // Min-wake reflects the healthy future job (~10min out), NOT a 0ms ghost spin.
+    expect(status.nextWakeAt).toBeDefined();
+    const wakeMs = new Date(status.nextWakeAt!).getTime();
+    expect(wakeMs - Date.now()).toBeGreaterThan(1_000);
+  });
 });


### PR DESCRIPTION
## SEV-1: recurring scheduler jobs fail-loop against TS-retired methods

Friday retired its TS runtime by fencing mutating methods with fail-closed guards (`throw FridayDomainError("TS_RUNTIME_*_RETIRED", … httpStatus:503, classification:"fail_closed")`). Two **recurring** scheduler jobs call retired methods, so they fail-loop forever.

### Fail-loop mechanism
The unified job scheduler (`src/jobs/scheduler/friday-job-scheduler-service.ts`) **never auto-disables a recurring failer**. On a job throw, `executeJob` calls `repository.markFailed` → increments `consecutive_failures` → reschedules with exponential backoff **capped at 60min**. A recurring job whose terminal call is permanently retired therefore retries forever. Observed `consecutive_failures=10` in prod for `session-lifecycle-sweep` — concrete evidence the SEV-1 is firing.

### The two jobs fixed
Both registered in `src/hub/friday-hub-bootstrap.ts`:

1. **`session-lifecycle-sweep`** (interval 120s, the **confirmed-firing SEV-1**)
   handler `src/jobs/sessions/friday-session-lifecycle-job.ts` → `sessionService.sweepLifecycle()`, fenced at `src/sessions/services/friday-session-service.ts` with `TS_RUNTIME_SESSION_RETIRED`. Flag unset in prod → throws every 120s.

2. **`agent-loop-cooldown-sweep`** (interval 60s, the **latent twin**, always registered with no env gate)
   handler → `agentLoopService.resumeCooldownRuns()` → `executeRun` → `executionService.execute()`, fenced at `src/learning/services/friday-auto-fix-execution-service.ts` with `TS_RUNTIME_AUTOFIX_EXECUTION_RETIRED`. It does not fire **today** only because `resumeCooldownRuns` queries cooldown rows first and there are none — but its terminal action is already retired, so it becomes an infinite fail-loop the instant any cooldown loop-run row exists. (`executeRun`'s `finalizeRunOnExecutionThrow` marks the run `failed` and **re-throws**, so the scheduler sees the throw.)

### The fix — two changes per job
For each job:
- **(a)** Remove the registration `push` block so `start()` never re-seeds the persisted row `enabled=1`.
- **(b)** After the scheduler is constructed (before `start()`), call `schedulerRepoRef.disableJob("<job-id>", nowIso())`.

### The busy-spin trap — why deregistration ALONE is STRICTLY WORSE
The job row is already persisted `enabled=1` with a `next_run_at` in `friday_scheduler_jobs`. If the def is removed but the row stays `enabled=1`:
- the run loop **skips** it at `if (!jobDef) continue` (no execution), **but**
- the min-wake computation (`~line 251-262`) still sees it: `if (!job.enabled || !job.nextRunAt) continue` does **not** skip an enabled row with a `next_run_at`. So `earliestMs = next_run_at`; once that time is in the past, `delayMs = max(0, past - now) = 0` → `armTimer(0)` → a continuous busy-spin every event-loop turn.

That is **strictly worse** than the original 120s/60s fail-loop. `disableJob` (`~line 248-254`) sets `enabled=0` **AND** `next_run_at=NULL`, which excludes the row from **both**:
- `listDue` (`WHERE enabled=1 … next_run_at IS NOT NULL`) → never selected for execution, and
- the min-wake (`skip !enabled || !nextRunAt`) → never contributes a 0ms wake.

Result: the loop stops, no busy-spin, and **no orphaned state** (the guarded write-txn never ran). `consecutive_failures` simply freezes (cosmetic/historical). On a fresh DB the two `disableJob` calls are harmless no-op `UPDATE`s. The calls run before `jobScheduler.start()`, and `start()` does not re-enable existing rows (`upsert`'s `ON CONFLICT DO UPDATE` never touches `enabled`), so the disable persists across restarts.

### NOTED third job — autofix-dispatch (NOT fixed here, per task scope)
`autofix-dispatch` (`src/hub/friday-hub-bootstrap.ts`) calls `autoFixDispatcher.runReadyActions(...)` → `executionService.execute()` — the **same** `TS_RUNTIME_AUTOFIX_EXECUTION_RETIRED` fence. It is a latent fail-loop the instant a planned, auto-approvable, data-preserving action exists. **Difference from the twin:** it is **env/capability-gated off by default** (registered only when `capabilityGates.autoFixDispatchEnabled` is true). Per task instructions this is a NOTE, not a fix — a follow-up should apply the same deregistration + `disableJob` treatment if/when that gate is enabled.

For completeness, the other recurring jobs whose terminal calls touch a retirement fence were audited and are **not** scheduler-level fail-loops:
- `session-memory-extraction` — its worker (`src/jobs/sessions/friday-session-memory-extraction-job.ts`) catches the per-row throw internally and returns a result (no re-throw); per-row retries are bounded by `maxAttempts` then go terminal `failed`.
- `workflow-cron-trigger` — `fireCronRegistration` wraps `startRun` in a try/catch that swallows the throw (logs a warning, returns false); `tickCron`/the scheduler job returns normally. Also latent (no cron trigger registrations).

### Tests
- New unit tests in `test/unit/jobs/scheduler/friday-job-scheduler-service.test.ts`:
  - **NEGATIVE CONTROL** — an *enabled* ghost row whose def is absent from the in-memory map: no execution, but `status().nextWakeAt ≈ now` (the `armTimer(0)` busy-spin signature). This proves the bug is real and that `disableJob`, not deregistration, is the fix.
  - **FIX** — after `disableJob`: no execution, `status().nextWakeAt === undefined` (excluded from min-wake), and the row is `enabled=0` / `next_run_at=NULL` and excluded from `listDue` — and stays disabled across `start()`.
  - **Coexistence** — a disabled ghost row alongside a healthy future-scheduled job: the ghost neither runs nor pulls min-wake to ~0.
- Updated the two `test/integration/hub/friday-hub-bootstrap-integration.test.ts` assertions that previously asserted `agent-loop-cooldown-sweep` is registered (`enabled=1`) / listed in `/v1/jobs`; they now assert it is not registered/listed (and that any legacy row would be disabled).

### Verification (run locally in the worktree)
- `npm run lint` → **0 errors** (1546 pre-existing warnings, none from this change; removed both now-orphaned imports cleanly).
- `npm run typecheck` (src + operator-client + ui + contract types) → **clean**.
- `test/unit/jobs/scheduler/friday-job-scheduler-service.test.ts` → **20 passed** (3 new).
- `test/integration/hub/friday-hub-bootstrap-integration.test.ts` → **36 passed**.
- Adjacent: session-lifecycle-job, session-memory-retirement-guard, scheduler multi-schedule, v024 schema, session-lifecycle integration → all green.

### Scope / non-goals
- Does **NOT** un-fence the retired guards (re-opening a deliberately-retired mutating surface — rejected).
- Does **NOT** build the Rust replacement — `session_lifecycle` / auto-fix execution ownership move to Rust is a **separate operator-gated Phase-1/2**.
- Does **NOT** change any guard behavior or any `allowTestOnly*` flag default. (Side note: the comment in `friday-session-service.ts` describing the scheduler catching the throw and rescheduling is now partially moot for this path, since the job no longer fires; the guard itself is correct defense-in-depth and is left untouched.)

### DEPLOY-GATED
Prod is at `e8f92070`. **This PR does not deploy** and does not restart services. The fail-loop stops only once a build carrying this change is deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)