### PR TITLE
feat(rust-storage): Rust-owned session-lifecycle reaper on agent_session (v28 + flag-gated tick; dark, replaces retired TS sweep)

### DIFF
--- a/rust-core/crates/friday-hub/src/bin/hub_agent_run_server.rs
+++ b/rust-core/crates/friday-hub/src/bin/hub_agent_run_server.rs
@@ -1412,7 +1412,10 @@ mod tests {
         assert!(reaper_enabled_from(Some("1")), "1 ⇒ enabled");
         assert!(reaper_enabled_from(Some("true")), "true ⇒ enabled");
         assert!(reaper_enabled_from(Some("TRUE")), "TRUE ⇒ enabled");
-        assert!(reaper_enabled_from(Some("  true  ")), "padded true ⇒ enabled");
+        assert!(
+            reaper_enabled_from(Some("  true  ")),
+            "padded true ⇒ enabled"
+        );
         assert!(reaper_enabled_from(Some(" 1 ")), "padded 1 ⇒ enabled");
     }
 

--- a/rust-core/crates/friday-hub/src/bin/hub_agent_run_server.rs
+++ b/rust-core/crates/friday-hub/src/bin/hub_agent_run_server.rs
@@ -124,6 +124,7 @@ use std::env;
 use std::io::{Read, Write};
 use std::net::{Ipv4Addr, SocketAddr, TcpListener};
 use std::path::PathBuf;
+use std::thread;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use friday_crypto::{
@@ -445,7 +446,10 @@ fn run() -> Result<(), ServerError> {
     // them. `HubRuntime::live` only CONSTRUCTS the provider client (no network call); an actual
     // run needs the env key — the separate operator live-proof.
     let runtime = HubRuntime::live(HubConfig {
-        db_path,
+        // Clone here so the `db_path` binding stays alive for the session-reaper tick below,
+        // which opens its OWN connection to the SAME path (the accept-loop's runtime
+        // connection is never shared across threads).
+        db_path: db_path.clone(),
         workspace_root: PathBuf::from(&workspace_root),
         secret: ephemeral_dev_secret(pid, nanos),
         max_turns: 6,
@@ -467,6 +471,23 @@ fn run() -> Result<(), ServerError> {
         "hub_agent_run_server: listening (loopback-only) on {addr} — DARK (S-C: authed dispatch arm, no production caller)"
     );
 
+    // (2b) Rust-owned session-lifecycle REAPER tick (DARK, DEFAULT-OFF). Spawn a background
+    // thread that opens its OWN DB connection and runs `sweep_lifecycle` on an interval —
+    // BUT ONLY when the operator has explicitly enabled it. The thread is spawned ONLY when
+    // `FRIDAY_RUST_SESSION_REAPER_ENABLED` is "1"/"true"; unset/anything-else ⇒ NOT spawned
+    // ⇒ no second DB connection, no reaping. This is what makes deploying the new binary
+    // SAFE: the destructive reaper (it HARD-DELETES rows) does nothing until the flag is
+    // flipped — wire-live = (rebuild bin + deploy + set the env flag) is a SEPARATE
+    // operator-gated step. The reaper owns lifecycle on `agent_session` (the retired TS
+    // `session-lifecycle-sweep` replacement).
+    if reaper_enabled() {
+        spawn_session_reaper(db_path.clone());
+    } else {
+        eprintln!(
+            "hub_agent_run_server: session-lifecycle reaper DISABLED (set FRIDAY_RUST_SESSION_REAPER_ENABLED=1 to enable)"
+        );
+    }
+
     // (3) Long-lived accept loop. Each accepted connection: set the read timeout, read the peer
     // pubkey preamble, REJECT a non-allowlisted peer pubkey (S-F, the FIRST gate), reject low-order
     // points, run the WS handshake, derive the sealed session key, and serve sealed envelopes
@@ -478,6 +499,86 @@ fn run() -> Result<(), ServerError> {
             Err(_e) => continue,
         }
     }
+}
+
+/// The env flag that gates the session-lifecycle reaper tick. DEFAULT-OFF: the tick is
+/// spawned ONLY when `FRIDAY_RUST_SESSION_REAPER_ENABLED` is exactly `"1"` or `"true"`
+/// (case-insensitive). Unset — or any other value — leaves the reaper DISABLED, so the
+/// new binary deploys DARK (the destructive sweep never runs until the operator flips it).
+const SESSION_REAPER_ENABLED_ENV: &str = "FRIDAY_RUST_SESSION_REAPER_ENABLED";
+
+/// The reaper sweep cadence (120s), matching the old TS sweep's interval.
+const SESSION_REAPER_INTERVAL: Duration = Duration::from_secs(120);
+
+/// Whether the operator has explicitly enabled the session-lifecycle reaper. Fail-closed:
+/// only the exact opt-in values enable it; everything else (including unset) is OFF.
+fn reaper_enabled() -> bool {
+    reaper_enabled_from(env::var(SESSION_REAPER_ENABLED_ENV).ok().as_deref())
+}
+
+/// Pure flag-matcher (separated from the env read so it is testable without mutating the
+/// process-global environment). DEFAULT-OFF: `None` (unset) ⇒ false; only the exact opt-in
+/// values `"1"`/`"true"` (case-insensitive, trimmed) ⇒ true; everything else ⇒ false.
+fn reaper_enabled_from(raw: Option<&str>) -> bool {
+    matches!(
+        raw.map(|v| v.trim().to_ascii_lowercase()).as_deref(),
+        Some("1") | Some("true")
+    )
+}
+
+/// Spawn the DARK session-lifecycle reaper tick on its OWN thread + OWN DB connection.
+///
+/// The thread opens a SEPARATE `Db::open_hub` connection (NOT the accept-loop's, never
+/// shared across threads, and deliberately NOT `open_hub_concurrent` — that flips the prod
+/// DB to WAL persistently, which is an operator live-flip, not a dark deploy) and calls
+/// `sweep_lifecycle` every [`SESSION_REAPER_INTERVAL`]. Errors (a failed open, or a failed
+/// sweep) are LOGGED and the loop continues — the reaper never panics the daemon. A
+/// non-empty sweep logs its per-transition counts (refs-only: counts, never session bodies).
+fn spawn_session_reaper(db_path: String) {
+    thread::spawn(move || {
+        // Open this thread's OWN connection. A failed open is logged and the reaper exits
+        // (the daemon keeps serving); it does NOT crash the process.
+        let db = match friday_storage::Db::open_hub(&db_path) {
+            Ok(db) => db,
+            Err(_e) => {
+                // Category only — never the db_path (it can carry the operator's home/username).
+                eprintln!(
+                    "hub_agent_run_server: session reaper could not open its DB connection — reaper not running"
+                );
+                return;
+            }
+        };
+        eprintln!(
+            "hub_agent_run_server: session-lifecycle reaper ENABLED (interval={}s)",
+            SESSION_REAPER_INTERVAL.as_secs()
+        );
+        loop {
+            thread::sleep(SESSION_REAPER_INTERVAL);
+            let now_ms = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .map(|d| d.as_millis() as i64)
+                .unwrap_or(0);
+            match friday_storage::sweep_lifecycle(db.conn(), now_ms) {
+                Ok(outcome) if !outcome.is_empty() => {
+                    eprintln!(
+                        "hub_agent_run_server: session sweep idled={} archived={} pruned={} hard_deleted={} messages_deleted={}",
+                        outcome.idled,
+                        outcome.archived,
+                        outcome.pruned,
+                        outcome.hard_deleted,
+                        outcome.messages_deleted,
+                    );
+                }
+                // An empty sweep is the common case — stay quiet to avoid log spam.
+                Ok(_) => {}
+                // A sweep error (e.g. a transient lock) is logged and the loop continues; the
+                // reaper never crashes the daemon. Category only — never row contents.
+                Err(_e) => {
+                    eprintln!("hub_agent_run_server: session sweep failed (continuing)");
+                }
+            }
+        }
+    });
 }
 
 /// The loopback-only S-C WS listener. Owns the socket lifecycle; the session/serve/dispatch
@@ -1295,6 +1396,24 @@ mod tests {
             "[{tag}] a rejected dispatch must end the session with no reply (no run, no body)"
         );
         assert!(obs.body_chunk.is_none(), "[{tag}] no body on rejection");
+    }
+
+    #[test]
+    fn session_reaper_flag_is_default_off_and_fail_closed() {
+        // The reaper tick is DEFAULT-OFF: unset ⇒ disabled. Only the exact opt-in values
+        // enable it; everything else (empty, "0", "yes", "false", garbage) is OFF.
+        assert!(!reaper_enabled_from(None), "unset ⇒ disabled (default-off)");
+        assert!(!reaper_enabled_from(Some("")), "empty ⇒ disabled");
+        assert!(!reaper_enabled_from(Some("0")), "0 ⇒ disabled");
+        assert!(!reaper_enabled_from(Some("false")), "false ⇒ disabled");
+        assert!(!reaper_enabled_from(Some("no")), "no ⇒ disabled");
+        assert!(!reaper_enabled_from(Some("enabled")), "garbage ⇒ disabled");
+        // Only the exact opt-in values enable it (case-insensitive, trimmed).
+        assert!(reaper_enabled_from(Some("1")), "1 ⇒ enabled");
+        assert!(reaper_enabled_from(Some("true")), "true ⇒ enabled");
+        assert!(reaper_enabled_from(Some("TRUE")), "TRUE ⇒ enabled");
+        assert!(reaper_enabled_from(Some("  true  ")), "padded true ⇒ enabled");
+        assert!(reaper_enabled_from(Some(" 1 ")), "padded 1 ⇒ enabled");
     }
 
     #[test]

--- a/rust-core/crates/friday-storage/src/lib.rs
+++ b/rust-core/crates/friday-storage/src/lib.rs
@@ -30,6 +30,7 @@ pub mod provider_timeline_store;
 pub mod run_result;
 pub mod schedule;
 mod schema;
+pub mod session_lifecycle;
 pub mod system_intent;
 pub mod workflow;
 pub mod workflow_catalog;
@@ -62,6 +63,7 @@ pub use run_result::{
     StoredRunResult,
 };
 pub use schema::{hub_migrations, phone_migrations, HUB_ONLY_TABLES, PHONE_ONLY_TABLES};
+pub use session_lifecycle::{sweep_lifecycle, SweepOutcome};
 
 use friday_core::{
     ActivityState, ActivityType, DeviceIdentity, FridayConversation, FridayPairPayload,

--- a/rust-core/crates/friday-storage/src/schema.rs
+++ b/rust-core/crates/friday-storage/src/schema.rs
@@ -434,6 +434,33 @@ pub fn hub_migrations() -> Vec<Migration> {
             destructive: false,
             up: m0027_workflow_run_control_columns,
         },
+        // Rust-owned session lifecycle (DARK substrate + reaper): add the lifecycle
+        // status + per-transition timestamp columns to the Hub-only `agent_session`
+        // table, mirroring the TS `sessions` lifecycle axes the retired
+        // `session-lifecycle-sweep` operated over (`status`, `idle_at`, `archived_at`,
+        // `pruned_at`, `status_changed_at`, `last_activity_at`). This is the storage
+        // half of the Rust-owned reaper that REPLACES the retired (fail-closed) TS
+        // sweep: Rust now OWNS lifecycle on `agent_session` (the TS `sessions` table's
+        // historical lifecycle data is abandoned per operator decision, NOT migrated).
+        //
+        // All columns are additive (`status` NOT NULL DEFAULT 'active' with a
+        // vocabulary CHECK; the four timestamp columns NULLABLE epoch-ms). Every
+        // existing v27 row reads back `status = 'active'` with all lifecycle
+        // timestamps NULL — i.e. a freshly-active session, exactly the at-rest state
+        // a never-swept session should have. `last_activity_at` is a NULLABLE forward
+        // hook with NO writer yet (the hot `ensure_session`/`append_session_message`
+        // paths keep bumping only `updated_at`); the reaper drives active→idle off
+        // `COALESCE(last_activity_at, updated_at)` so the predicate fires off the
+        // genuinely-maintained `updated_at` until a future slice wires a dedicated
+        // last-activity writer. Purely additive (ALTER only) — touches no other table.
+        // The reaper TICK that consumes these is DEFAULT-OFF (env-gated), so this
+        // migration is dark on deploy. Hub-only — `agent_session` is a Hub-only table.
+        Migration {
+            version: 28,
+            name: "agent_session_lifecycle",
+            destructive: false,
+            up: m0028_agent_session_lifecycle,
+        },
     ]
 }
 
@@ -1989,5 +2016,50 @@ fn m0027_workflow_run_control_columns(tx: &Transaction) -> rusqlite::Result<()> 
     tx.execute_batch(
         "ALTER TABLE workflow_step ADD COLUMN attempt INTEGER NOT NULL DEFAULT 1;
          ALTER TABLE workflow_run ADD COLUMN cancel_reason TEXT;",
+    )
+}
+
+// Rust-owned session lifecycle: additive lifecycle columns on the Hub-only
+// `agent_session` table, mirroring the TS `sessions` lifecycle axes the retired
+// `session-lifecycle-sweep` operated over. This is the storage half of the
+// Rust-owned reaper (`crate::session_lifecycle::sweep_lifecycle`) that REPLACES
+// the retired TS sweep.
+//
+//   * `status` — the lifecycle phase. NOT NULL DEFAULT 'active' so every existing
+//     v27 row reads back as a freshly-active session; the CHECK admits ONLY the TS
+//     vocabulary ('active' | 'idle' | 'archived' | 'pruned') so an unknown status
+//     cannot be stored to LOOK like a phase the reaper would (or would not) advance
+//     (matches the house chat_kind/session_kind CHECK style).
+//   * `idle_at` / `archived_at` / `pruned_at` — the epoch-ms transition timestamps
+//     the SUBSEQUENT transition's predicate reads (idle→archived reads `idle_at`,
+//     archived→pruned reads `archived_at`, pruned→hard-delete reads `pruned_at`),
+//     exactly as the TS repo drives each step off its own per-phase timestamp.
+//     NULLABLE: a never-transitioned (active) session has all three NULL.
+//   * `status_changed_at` — bumped on EVERY transition (parity with the TS sweep,
+//     which always writes it); it is an observability axis, NOT a predicate driver.
+//   * `last_activity_at` — a NULLABLE FORWARD HOOK that mirrors the TS
+//     `sessions.last_activity_at` the active→idle predicate keys on. It has NO writer
+//     yet (the hot `ensure_session`/`append_session_message` paths keep bumping only
+//     `updated_at`, unchanged here), so it reads back NULL on every row. The reaper
+//     therefore drives active→idle off `COALESCE(last_activity_at, updated_at)` — the
+//     genuinely-maintained `updated_at` is the live signal until a future slice wires
+//     a dedicated last-activity writer; this column is added now so that wiring is a
+//     pure data change with no schema change. It is intentionally NOT backfilled to
+//     `updated_at` (a frozen snapshot would wrongly idle sessions that are still
+//     active after the migration runs).
+//
+// `agent_session`'s CREATE-DDL const stays FROZEN at its pre-v28 shape, so a fresh
+// install runs the base CREATE then these ALTERs (no duplicate-column on fresh
+// install) — mirrors how m0021/m0023 added their columns. Purely additive (ALTER
+// only) — touches no other table, so v27 rows/queries are unaffected. Hub-only.
+fn m0028_agent_session_lifecycle(tx: &Transaction) -> rusqlite::Result<()> {
+    tx.execute_batch(
+        "ALTER TABLE agent_session ADD COLUMN status TEXT NOT NULL DEFAULT 'active'
+            CHECK(status IN ('active', 'idle', 'archived', 'pruned'));
+         ALTER TABLE agent_session ADD COLUMN idle_at INTEGER;
+         ALTER TABLE agent_session ADD COLUMN archived_at INTEGER;
+         ALTER TABLE agent_session ADD COLUMN pruned_at INTEGER;
+         ALTER TABLE agent_session ADD COLUMN status_changed_at INTEGER;
+         ALTER TABLE agent_session ADD COLUMN last_activity_at INTEGER;",
     )
 }

--- a/rust-core/crates/friday-storage/src/session_lifecycle.rs
+++ b/rust-core/crates/friday-storage/src/session_lifecycle.rs
@@ -282,15 +282,7 @@ mod tests {
                 "SELECT status, idle_at, archived_at, pruned_at, last_activity_at
                  FROM agent_session WHERE agent_session_id = 's1'",
                 [],
-                |r| {
-                    Ok((
-                        r.get(0)?,
-                        r.get(1)?,
-                        r.get(2)?,
-                        r.get(3)?,
-                        r.get(4)?,
-                    ))
-                },
+                |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?, r.get(3)?, r.get(4)?)),
             )
             .unwrap();
         assert_eq!(status, "active");
@@ -338,13 +330,19 @@ mod tests {
         // Just UNDER the idle timeout: now = created + IDLE_TIMEOUT (not strictly greater).
         let just_under = created + IDLE_TIMEOUT_MS;
         let out = sweep_lifecycle(db.conn(), just_under).unwrap();
-        assert_eq!(out.idled, 0, "at-exactly-threshold does not fire (strict <)");
+        assert_eq!(
+            out.idled, 0,
+            "at-exactly-threshold does not fire (strict <)"
+        );
         assert_eq!(status_of(&db, "s1"), "active");
 
         // Just OVER: now = created + IDLE_TIMEOUT + 1.
         let just_over = created + IDLE_TIMEOUT_MS + 1;
         let out = sweep_lifecycle(db.conn(), just_over).unwrap();
-        assert_eq!(out.idled, 1, "past-threshold idles via COALESCE(updated_at)");
+        assert_eq!(
+            out.idled, 1,
+            "past-threshold idles via COALESCE(updated_at)"
+        );
         assert_eq!(status_of(&db, "s1"), "idle");
         // The transition wrote idle_at + status_changed_at + updated_at = now.
         let (idle_at, sca, upd): (i64, i64, i64) = db
@@ -389,7 +387,15 @@ mod tests {
         let db = Db::open_hub(&tmp("archive")).unwrap();
         let now = 100_000_000_000_i64;
         // idle_at just UNDER the archive timeout (not strictly past) → not archived.
-        seed(&db, "under", "idle", Some(now - ARCHIVE_TIMEOUT_MS), None, None, 1);
+        seed(
+            &db,
+            "under",
+            "idle",
+            Some(now - ARCHIVE_TIMEOUT_MS),
+            None,
+            None,
+            1,
+        );
         // idle_at just OVER → archived.
         seed(
             &db,
@@ -478,8 +484,14 @@ mod tests {
         );
         let out = sweep_lifecycle(db.conn(), now).unwrap();
         assert_eq!(out.hard_deleted, 1);
-        assert!(exists(&db, "keep"), "not-yet-expired pruned session is kept");
-        assert!(!exists(&db, "gone"), "past-timeout pruned session is removed");
+        assert!(
+            exists(&db, "keep"),
+            "not-yet-expired pruned session is kept"
+        );
+        assert!(
+            !exists(&db, "gone"),
+            "past-timeout pruned session is removed"
+        );
     }
 
     // --- hard-delete safety: only past-timeout pruned rows go -------------------
@@ -494,15 +506,7 @@ mod tests {
         seed(&db, "idl", "idle", Some(1), None, None, 1);
         seed(&db, "arc", "archived", None, Some(1), None, 1);
         // A pruned row NOT yet past the hard-delete timeout.
-        seed(
-            &db,
-            "fresh-pruned",
-            "pruned",
-            None,
-            None,
-            Some(now - 1),
-            1,
-        );
+        seed(&db, "fresh-pruned", "pruned", None, None, Some(now - 1), 1);
         // A pruned row past the timeout.
         seed(
             &db,
@@ -514,7 +518,10 @@ mod tests {
             1,
         );
         let out = sweep_lifecycle(db.conn(), now).unwrap();
-        assert_eq!(out.hard_deleted, 1, "only the expired pruned row is deleted");
+        assert_eq!(
+            out.hard_deleted, 1,
+            "only the expired pruned row is deleted"
+        );
         assert!(exists(&db, "fresh-pruned"));
         assert!(!exists(&db, "old-pruned"));
         // The other-phase rows DID advance (they were aged), but none was DELETED.
@@ -568,7 +575,10 @@ mod tests {
 
         let out = sweep_lifecycle(db.conn(), now).unwrap();
         assert_eq!(out.hard_deleted, 1);
-        assert_eq!(out.messages_deleted, 2, "both child messages of 'gone' removed");
+        assert_eq!(
+            out.messages_deleted, 2,
+            "both child messages of 'gone' removed"
+        );
         assert!(!exists(&db, "gone"));
         // No orphan messages for the deleted session.
         let orphans: i64 = db
@@ -600,7 +610,15 @@ mod tests {
         let db = Db::open_hub(&tmp("idem")).unwrap();
         let now = 100_000_000_000_i64;
         // One row per phase, each just-eligible to advance exactly one step.
-        seed(&db, "a", "active", None, None, None, now - IDLE_TIMEOUT_MS - 1);
+        seed(
+            &db,
+            "a",
+            "active",
+            None,
+            None,
+            None,
+            now - IDLE_TIMEOUT_MS - 1,
+        );
         seed(
             &db,
             "i",
@@ -639,7 +657,10 @@ mod tests {
 
         // Second sweep at the SAME now: nothing is newly eligible → no-op.
         let second = sweep_lifecycle(db.conn(), now).unwrap();
-        assert!(second.is_empty(), "second back-to-back sweep changes nothing");
+        assert!(
+            second.is_empty(),
+            "second back-to-back sweep changes nothing"
+        );
     }
 
     // --- fresh-DB / all-active no-op -------------------------------------------
@@ -654,7 +675,10 @@ mod tests {
         ensure_session(db.conn(), "s2", now - 1).unwrap();
         ensure_session(db.conn(), "s3", now - IDLE_TIMEOUT_MS).unwrap(); // exactly at boundary
         let out = sweep_lifecycle(db.conn(), now).unwrap();
-        assert!(out.is_empty(), "fresh all-active DB → zero transitions, zero deletes");
+        assert!(
+            out.is_empty(),
+            "fresh all-active DB → zero transitions, zero deletes"
+        );
         assert_eq!(status_of(&db, "s1"), "active");
         assert_eq!(status_of(&db, "s2"), "active");
         assert_eq!(status_of(&db, "s3"), "active");

--- a/rust-core/crates/friday-storage/src/session_lifecycle.rs
+++ b/rust-core/crates/friday-storage/src/session_lifecycle.rs
@@ -1,0 +1,698 @@
+//! Rust-owned session-lifecycle REAPER (DARK substrate).
+//!
+//! This is the Rust replacement for the retired TypeScript `session-lifecycle-sweep`
+//! (`src/sessions/services/friday-session-service.ts` `sweepLifecycle`, now fail-closed;
+//! its scheduler job was removed in PR #652). The operator's chosen architecture is that
+//! **Rust OWNS session lifecycle, writing to the Hub-only `agent_session` table** — the TS
+//! `sessions` table's historical lifecycle data is ABANDONED (not migrated).
+//!
+//! ## The four transitions (ported from the TS sweep, ONE write transaction)
+//! With the ported timeout constants below (mirroring `src/sessions/friday-session.constants.ts`):
+//!   1. `active`   → `idle`     when no activity for > [`IDLE_TIMEOUT_MS`]   (30m)
+//!   2. `idle`     → `archived` when idle for     > [`ARCHIVE_TIMEOUT_MS`]  (7d)
+//!   3. `archived` → `pruned`   when archived for > [`PRUNE_TIMEOUT_MS`]    (30d)
+//!   4. `pruned`   → hard-delete when pruned for  > [`HARD_DELETE_TIMEOUT_MS`] (7d after pruned)
+//!
+//! Each transition uses a STRICT `<` boundary (faithful to the TS repo's
+//! `... < beforeIso` predicates), advances `status`, writes the relevant per-phase
+//! timestamp + `status_changed_at` + `updated_at`, and runs INSIDE one transaction
+//! (all-or-nothing). Because a freshly-idled row gets `idle_at = now`, it cannot also
+//! archive in the SAME tick (the 7d archive boundary is not met) — a session advances at
+//! most ONE phase per sweep, which is exactly what gives the sweep its free idempotency:
+//! a second back-to-back sweep finds nothing newly-eligible and is a no-op.
+//!
+//! ## active→idle drives off `COALESCE(last_activity_at, updated_at)`
+//! The TS predicate keys on `sessions.last_activity_at`. The Rust `agent_session` gains a
+//! `last_activity_at` column (migration v28) but it has NO writer yet — the hot
+//! `ensure_session`/`append_session_message` paths bump only `updated_at`. So the reaper
+//! coalesces to the genuinely-maintained `updated_at`, which is semantically the TS
+//! last-activity (it advances on every ensure + every appended message). When a future
+//! slice wires a dedicated last-activity writer, `last_activity_at` simply takes precedence
+//! with no change here.
+//!
+//! ## Hard-delete handles the FK child (no orphans)
+//! `agent_session_message` has a `FOREIGN KEY(agent_session_id) REFERENCES agent_session`
+//! with NO `ON DELETE CASCADE`, and `foreign_keys` is ON on every connection. So a parent
+//! DELETE while children exist would FAIL the FK constraint. The hard-delete therefore
+//! DELETEs the doomed sessions' child messages FIRST, then the parent rows — same
+//! transaction, no orphan rows.
+//!
+//! ## OMISSIONS vs the TS sweep (documented, intentional)
+//!   * **Fork-archive.** The TS sweep had a 5th step that archived inactive FORK sessions
+//!     (`parent_session_key IS NOT NULL`). The Rust `agent_session` has a `parent_session_id`
+//!     (the subagent chain pointer, v23) but NONE of the TS FORK markers
+//!     (`forked_from_message_id` / `root_session_key` / a fork timeout) — there is no fork
+//!     CONCEPT in the Rust schema. So fork-archive is OMITTED (there is nothing to archive
+//!     as a fork).
+//!   * **Memory-extraction-on-idle.** The TS sweep enqueued memory extraction when a session
+//!     went idle. That responsibility is owned by the SEPARATE Rust session-memory surface
+//!     (#599–601, `agent_session_message.memory_extract_status` + the inline extractor), NOT
+//!     by this reaper — so it is NOT duplicated here.
+//!
+//! ## Status / wiring
+//! DARK: the reaper TICK that calls [`sweep_lifecycle`] on an interval lives in the Hub WS
+//! server bin behind a DEFAULT-OFF env flag (`FRIDAY_RUST_SESSION_REAPER_ENABLED`), so
+//! deploying the new binary reaps NOTHING until the operator explicitly flips the flag.
+//! Wire-live = (rebuild bin + deploy + flip flag) is a SEPARATE operator-gated step.
+//! NOT a v1 GO.
+
+use crate::error::Result;
+use rusqlite::params;
+use rusqlite::Connection;
+
+// ─── Ported timeout constants (mirror src/sessions/friday-session.constants.ts) ───
+
+/// active → idle: no activity for longer than 30 minutes.
+pub const IDLE_TIMEOUT_MS: i64 = 30 * 60 * 1000;
+/// idle → archived: idle for longer than 7 days.
+pub const ARCHIVE_TIMEOUT_MS: i64 = 7 * 24 * 60 * 60 * 1000;
+/// archived → pruned: archived for longer than 30 days.
+pub const PRUNE_TIMEOUT_MS: i64 = 30 * 24 * 60 * 60 * 1000;
+/// pruned → hard-delete: pruned for longer than 7 days.
+pub const HARD_DELETE_TIMEOUT_MS: i64 = 7 * 24 * 60 * 60 * 1000;
+
+/// Per-transition counts from one [`sweep_lifecycle`] call, for observability. The
+/// `hard_deleted` count is the number of `agent_session` ROWS removed (each may have
+/// taken child messages with it).
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct SweepOutcome {
+    /// active → idle
+    pub idled: usize,
+    /// idle → archived
+    pub archived: usize,
+    /// archived → pruned
+    pub pruned: usize,
+    /// pruned → hard-deleted (rows removed)
+    pub hard_deleted: usize,
+    /// child `agent_session_message` rows removed alongside hard-deleted sessions.
+    pub messages_deleted: usize,
+}
+
+impl SweepOutcome {
+    /// Whether this sweep changed anything (any transition fired). Useful for a tick that
+    /// only wants to log on a non-empty sweep.
+    pub fn is_empty(&self) -> bool {
+        self.idled == 0
+            && self.archived == 0
+            && self.pruned == 0
+            && self.hard_deleted == 0
+            && self.messages_deleted == 0
+    }
+}
+
+/// Run the four lifecycle transitions over `agent_session` in ONE transaction at logical
+/// time `now_ms` (epoch ms). Returns the per-transition [`SweepOutcome`] counts.
+///
+/// The four steps run in order (active→idle→archived→pruned→hard-delete); each reads the
+/// timestamp the PRIOR step wrote, but a strict `<` boundary plus the per-phase timeouts
+/// mean a row advances at most one phase per call (a just-idled row's `idle_at = now` is
+/// not `< now - ARCHIVE_TIMEOUT`). The whole sweep is all-or-nothing: any error rolls back
+/// every transition (no partial sweep).
+pub fn sweep_lifecycle(conn: &Connection, now_ms: i64) -> Result<SweepOutcome> {
+    let tx = conn.unchecked_transaction()?;
+
+    // 1. active → idle: no activity for > IDLE_TIMEOUT. Drive off
+    //    COALESCE(last_activity_at, updated_at) — last_activity_at has no writer yet, so
+    //    updated_at (genuinely maintained) is the live signal. STRICT `<` boundary.
+    let idle_before = now_ms - IDLE_TIMEOUT_MS;
+    let idled = tx.execute(
+        "UPDATE agent_session
+            SET status = 'idle', idle_at = ?1, status_changed_at = ?1, updated_at = ?1
+          WHERE status = 'active'
+            AND COALESCE(last_activity_at, updated_at) < ?2",
+        params![now_ms, idle_before],
+    )?;
+
+    // 2. idle → archived: idle for > ARCHIVE_TIMEOUT (drives off idle_at). STRICT `<`.
+    let archive_before = now_ms - ARCHIVE_TIMEOUT_MS;
+    let archived = tx.execute(
+        "UPDATE agent_session
+            SET status = 'archived', archived_at = ?1, status_changed_at = ?1, updated_at = ?1
+          WHERE status = 'idle'
+            AND idle_at IS NOT NULL
+            AND idle_at < ?2",
+        params![now_ms, archive_before],
+    )?;
+
+    // 3. archived → pruned: archived for > PRUNE_TIMEOUT (drives off archived_at). STRICT `<`.
+    let prune_before = now_ms - PRUNE_TIMEOUT_MS;
+    let pruned = tx.execute(
+        "UPDATE agent_session
+            SET status = 'pruned', pruned_at = ?1, status_changed_at = ?1, updated_at = ?1
+          WHERE status = 'archived'
+            AND archived_at IS NOT NULL
+            AND archived_at < ?2",
+        params![now_ms, prune_before],
+    )?;
+
+    // 4. pruned → hard-delete: pruned for > HARD_DELETE_TIMEOUT (drives off pruned_at).
+    //    STRICT `<`. Delete child messages FIRST (FK has no ON DELETE CASCADE and
+    //    foreign_keys is ON), then the parent rows — same txn, no orphans.
+    let hard_delete_before = now_ms - HARD_DELETE_TIMEOUT_MS;
+    let messages_deleted = tx.execute(
+        "DELETE FROM agent_session_message
+          WHERE agent_session_id IN (
+              SELECT agent_session_id FROM agent_session
+               WHERE status = 'pruned'
+                 AND pruned_at IS NOT NULL
+                 AND pruned_at < ?1
+          )",
+        params![hard_delete_before],
+    )?;
+    let hard_deleted = tx.execute(
+        "DELETE FROM agent_session
+          WHERE status = 'pruned'
+            AND pruned_at IS NOT NULL
+            AND pruned_at < ?1",
+        params![hard_delete_before],
+    )?;
+
+    tx.commit()?;
+
+    Ok(SweepOutcome {
+        idled,
+        archived,
+        pruned,
+        hard_deleted,
+        messages_deleted,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::agent_session::{append_session_message, ensure_session, SessionMessage};
+    use crate::Db;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    static C: AtomicU64 = AtomicU64::new(0);
+    fn tmp(tag: &str) -> String {
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        std::env::temp_dir()
+            .join(format!(
+                "friday-session-lifecycle-{}-{}-{}-{nanos}.sqlite",
+                std::process::id(),
+                tag,
+                C.fetch_add(1, Ordering::Relaxed),
+            ))
+            .to_string_lossy()
+            .into_owned()
+    }
+
+    fn status_of(db: &Db, id: &str) -> String {
+        db.conn()
+            .query_row(
+                "SELECT status FROM agent_session WHERE agent_session_id = ?1",
+                [id],
+                |r| r.get::<_, String>(0),
+            )
+            .unwrap()
+    }
+
+    fn exists(db: &Db, id: &str) -> bool {
+        db.conn()
+            .query_row(
+                "SELECT EXISTS(SELECT 1 FROM agent_session WHERE agent_session_id = ?1)",
+                [id],
+                |r| r.get::<_, bool>(0),
+            )
+            .unwrap()
+    }
+
+    /// Hand-place a session in a given phase with explicit timestamps so a boundary test can
+    /// pin the exact per-phase timestamp the next transition reads. (active→idle is ALSO
+    /// covered via the real `ensure_session` path in its own test so the dead-predicate bug
+    /// — a NULL `last_activity_at` with no COALESCE — would be caught.)
+    fn seed(
+        db: &Db,
+        id: &str,
+        status: &str,
+        idle_at: Option<i64>,
+        archived_at: Option<i64>,
+        pruned_at: Option<i64>,
+        updated_at: i64,
+    ) {
+        db.conn()
+            .execute(
+                "INSERT INTO agent_session
+                    (agent_session_id, created_at, updated_at, status,
+                     idle_at, archived_at, pruned_at, status_changed_at, last_activity_at)
+                 VALUES (?1, ?2, ?2, ?3, ?4, ?5, ?6, ?2, NULL)",
+                params![id, updated_at, status, idle_at, archived_at, pruned_at],
+            )
+            .unwrap();
+    }
+
+    // --- migration v28 ---------------------------------------------------------
+
+    #[test]
+    fn migration_v28_reaches_latest_and_adds_lifecycle_columns() {
+        let db = Db::open_hub(&tmp("v28")).unwrap();
+        // The fresh chain reaches the code's max version (derived, so a later additive
+        // migration does not break this).
+        let v: i64 = db
+            .conn()
+            .query_row("SELECT version FROM schema_version WHERE id = 1", [], |r| {
+                r.get(0)
+            })
+            .unwrap();
+        let expected = crate::hub_migrations()
+            .iter()
+            .map(|m| m.version)
+            .max()
+            .unwrap();
+        assert_eq!(v, expected, "fresh migration reaches the latest version");
+        assert!(v >= 28, "the v28 lifecycle columns exist");
+
+        // A freshly-ensured session defaults to status 'active' with all lifecycle
+        // timestamps NULL — the at-rest never-swept state.
+        ensure_session(db.conn(), "s1", 1000).unwrap();
+        let (status, idle_at, archived_at, pruned_at, last_activity_at): (
+            String,
+            Option<i64>,
+            Option<i64>,
+            Option<i64>,
+            Option<i64>,
+        ) = db
+            .conn()
+            .query_row(
+                "SELECT status, idle_at, archived_at, pruned_at, last_activity_at
+                 FROM agent_session WHERE agent_session_id = 's1'",
+                [],
+                |r| {
+                    Ok((
+                        r.get(0)?,
+                        r.get(1)?,
+                        r.get(2)?,
+                        r.get(3)?,
+                        r.get(4)?,
+                    ))
+                },
+            )
+            .unwrap();
+        assert_eq!(status, "active");
+        assert_eq!(idle_at, None);
+        assert_eq!(archived_at, None);
+        assert_eq!(pruned_at, None);
+        assert_eq!(
+            last_activity_at, None,
+            "last_activity_at is a NULL forward hook with no writer"
+        );
+    }
+
+    #[test]
+    fn status_check_rejects_unknown_phase() {
+        let db = Db::open_hub(&tmp("statuscheck")).unwrap();
+        ensure_session(db.conn(), "s1", 1000).unwrap();
+        // The CHECK admits only the TS vocabulary.
+        let bad = db.conn().execute(
+            "UPDATE agent_session SET status = 'zombie' WHERE agent_session_id = 's1'",
+            [],
+        );
+        assert!(bad.is_err(), "an out-of-vocabulary status is rejected");
+        for ok in ["active", "idle", "archived", "pruned"] {
+            db.conn()
+                .execute(
+                    "UPDATE agent_session SET status = ?1 WHERE agent_session_id = 's1'",
+                    [ok],
+                )
+                .unwrap();
+        }
+    }
+
+    // --- per-transition boundary: just-under vs just-over ----------------------
+
+    #[test]
+    fn active_to_idle_boundary_via_real_ensure_path() {
+        // CRITICAL: build the row via the REAL `ensure_session` path (which writes ONLY
+        // updated_at, leaving last_activity_at NULL) and age it via updated_at. If the
+        // predicate keyed on a bare `last_activity_at < ?` (NULL ⇒ never matches), this row
+        // would NEVER idle and this test would FAIL — catching the dead-predicate bug.
+        let db = Db::open_hub(&tmp("idle-real")).unwrap();
+        let created = 1_000_000;
+        ensure_session(db.conn(), "s1", created).unwrap();
+
+        // Just UNDER the idle timeout: now = created + IDLE_TIMEOUT (not strictly greater).
+        let just_under = created + IDLE_TIMEOUT_MS;
+        let out = sweep_lifecycle(db.conn(), just_under).unwrap();
+        assert_eq!(out.idled, 0, "at-exactly-threshold does not fire (strict <)");
+        assert_eq!(status_of(&db, "s1"), "active");
+
+        // Just OVER: now = created + IDLE_TIMEOUT + 1.
+        let just_over = created + IDLE_TIMEOUT_MS + 1;
+        let out = sweep_lifecycle(db.conn(), just_over).unwrap();
+        assert_eq!(out.idled, 1, "past-threshold idles via COALESCE(updated_at)");
+        assert_eq!(status_of(&db, "s1"), "idle");
+        // The transition wrote idle_at + status_changed_at + updated_at = now.
+        let (idle_at, sca, upd): (i64, i64, i64) = db
+            .conn()
+            .query_row(
+                "SELECT idle_at, status_changed_at, updated_at
+                 FROM agent_session WHERE agent_session_id = 's1'",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)),
+            )
+            .unwrap();
+        assert_eq!((idle_at, sca, upd), (just_over, just_over, just_over));
+    }
+
+    #[test]
+    fn last_activity_at_takes_precedence_when_set() {
+        // When last_activity_at IS set, it (not updated_at) drives the idle predicate —
+        // proving the COALESCE precedence. updated_at is OLD (would idle) but last_activity_at
+        // is RECENT, so the session stays active.
+        let db = Db::open_hub(&tmp("idle-precedence")).unwrap();
+        let old = 1_000_000;
+        ensure_session(db.conn(), "s1", old).unwrap();
+        let recent = old + IDLE_TIMEOUT_MS; // recent activity
+        db.conn()
+            .execute(
+                "UPDATE agent_session SET last_activity_at = ?1 WHERE agent_session_id = 's1'",
+                [recent],
+            )
+            .unwrap();
+        // Sweep just past the OLD updated_at's idle boundary but within the recent activity's.
+        let now = old + IDLE_TIMEOUT_MS + 1;
+        let out = sweep_lifecycle(db.conn(), now).unwrap();
+        assert_eq!(
+            out.idled, 0,
+            "recent last_activity_at keeps the session active despite old updated_at"
+        );
+        assert_eq!(status_of(&db, "s1"), "active");
+    }
+
+    #[test]
+    fn idle_to_archived_boundary() {
+        let db = Db::open_hub(&tmp("archive")).unwrap();
+        let now = 100_000_000_000_i64;
+        // idle_at just UNDER the archive timeout (not strictly past) → not archived.
+        seed(&db, "under", "idle", Some(now - ARCHIVE_TIMEOUT_MS), None, None, 1);
+        // idle_at just OVER → archived.
+        seed(
+            &db,
+            "over",
+            "idle",
+            Some(now - ARCHIVE_TIMEOUT_MS - 1),
+            None,
+            None,
+            1,
+        );
+        let out = sweep_lifecycle(db.conn(), now).unwrap();
+        assert_eq!(out.archived, 1);
+        assert_eq!(status_of(&db, "under"), "idle");
+        assert_eq!(status_of(&db, "over"), "archived");
+        let archived_at: i64 = db
+            .conn()
+            .query_row(
+                "SELECT archived_at FROM agent_session WHERE agent_session_id = 'over'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(archived_at, now, "archived_at stamped at now");
+    }
+
+    #[test]
+    fn archived_to_pruned_boundary() {
+        let db = Db::open_hub(&tmp("prune")).unwrap();
+        let now = 100_000_000_000_i64;
+        seed(
+            &db,
+            "under",
+            "archived",
+            None,
+            Some(now - PRUNE_TIMEOUT_MS),
+            None,
+            1,
+        );
+        seed(
+            &db,
+            "over",
+            "archived",
+            None,
+            Some(now - PRUNE_TIMEOUT_MS - 1),
+            None,
+            1,
+        );
+        let out = sweep_lifecycle(db.conn(), now).unwrap();
+        assert_eq!(out.pruned, 1);
+        assert_eq!(status_of(&db, "under"), "archived");
+        assert_eq!(status_of(&db, "over"), "pruned");
+        let pruned_at: i64 = db
+            .conn()
+            .query_row(
+                "SELECT pruned_at FROM agent_session WHERE agent_session_id = 'over'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(pruned_at, now, "pruned_at stamped at now");
+    }
+
+    #[test]
+    fn pruned_to_hard_delete_boundary() {
+        let db = Db::open_hub(&tmp("harddelete")).unwrap();
+        let now = 100_000_000_000_i64;
+        // pruned_at just UNDER the hard-delete timeout → NOT deleted.
+        seed(
+            &db,
+            "keep",
+            "pruned",
+            None,
+            None,
+            Some(now - HARD_DELETE_TIMEOUT_MS),
+            1,
+        );
+        // pruned_at just OVER → hard-deleted.
+        seed(
+            &db,
+            "gone",
+            "pruned",
+            None,
+            None,
+            Some(now - HARD_DELETE_TIMEOUT_MS - 1),
+            1,
+        );
+        let out = sweep_lifecycle(db.conn(), now).unwrap();
+        assert_eq!(out.hard_deleted, 1);
+        assert!(exists(&db, "keep"), "not-yet-expired pruned session is kept");
+        assert!(!exists(&db, "gone"), "past-timeout pruned session is removed");
+    }
+
+    // --- hard-delete safety: only past-timeout pruned rows go -------------------
+
+    #[test]
+    fn hard_delete_only_removes_expired_pruned_not_other_phases() {
+        let db = Db::open_hub(&tmp("hd-safety")).unwrap();
+        let now = 100_000_000_000_i64;
+        // A row in each non-pruned phase, all old enough to be deleted IF the predicate were
+        // wrong — none should be touched by hard-delete (they advance at most one phase).
+        seed(&db, "act", "active", None, None, None, 1);
+        seed(&db, "idl", "idle", Some(1), None, None, 1);
+        seed(&db, "arc", "archived", None, Some(1), None, 1);
+        // A pruned row NOT yet past the hard-delete timeout.
+        seed(
+            &db,
+            "fresh-pruned",
+            "pruned",
+            None,
+            None,
+            Some(now - 1),
+            1,
+        );
+        // A pruned row past the timeout.
+        seed(
+            &db,
+            "old-pruned",
+            "pruned",
+            None,
+            None,
+            Some(now - HARD_DELETE_TIMEOUT_MS - 1),
+            1,
+        );
+        let out = sweep_lifecycle(db.conn(), now).unwrap();
+        assert_eq!(out.hard_deleted, 1, "only the expired pruned row is deleted");
+        assert!(exists(&db, "fresh-pruned"));
+        assert!(!exists(&db, "old-pruned"));
+        // The other-phase rows DID advance (they were aged), but none was DELETED.
+        assert!(exists(&db, "act"));
+        assert!(exists(&db, "idl"));
+        assert!(exists(&db, "arc"));
+    }
+
+    // --- hard-delete cleans child messages (no orphans) ------------------------
+
+    #[test]
+    fn hard_delete_removes_child_messages_no_orphan() {
+        let db = Db::open_hub(&tmp("hd-children")).unwrap();
+        let now = 100_000_000_000_i64;
+        // A pruned-and-expired session WITH child messages, and a sibling pruned session
+        // that is NOT yet expired (its messages must survive).
+        seed(
+            &db,
+            "gone",
+            "pruned",
+            None,
+            None,
+            Some(now - HARD_DELETE_TIMEOUT_MS - 1),
+            1,
+        );
+        seed(&db, "keep", "pruned", None, None, Some(now - 1), 1);
+        append_session_message(
+            db.conn(),
+            "gone",
+            &SessionMessage::new("user", "secret", None),
+            10,
+        )
+        .unwrap();
+        append_session_message(
+            db.conn(),
+            "gone",
+            &SessionMessage::new("assistant", "reply", None),
+            11,
+        )
+        .unwrap();
+        append_session_message(
+            db.conn(),
+            "keep",
+            &SessionMessage::new("user", "still here", None),
+            10,
+        )
+        .unwrap();
+        // NOTE: append bumps updated_at to 11; that does not matter for hard-delete
+        // (it keys on pruned_at), and the pre-set pruned_at survives the append's
+        // updated_at bump.
+
+        let out = sweep_lifecycle(db.conn(), now).unwrap();
+        assert_eq!(out.hard_deleted, 1);
+        assert_eq!(out.messages_deleted, 2, "both child messages of 'gone' removed");
+        assert!(!exists(&db, "gone"));
+        // No orphan messages for the deleted session.
+        let orphans: i64 = db
+            .conn()
+            .query_row(
+                "SELECT COUNT(*) FROM agent_session_message WHERE agent_session_id = 'gone'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(orphans, 0, "no orphaned child rows for the deleted session");
+        // The kept session's message survives.
+        assert!(exists(&db, "keep"));
+        let kept: i64 = db
+            .conn()
+            .query_row(
+                "SELECT COUNT(*) FROM agent_session_message WHERE agent_session_id = 'keep'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(kept, 1, "the non-expired session keeps its message");
+    }
+
+    // --- idempotency: second back-to-back sweep is a no-op ---------------------
+
+    #[test]
+    fn second_sweep_is_a_noop() {
+        let db = Db::open_hub(&tmp("idem")).unwrap();
+        let now = 100_000_000_000_i64;
+        // One row per phase, each just-eligible to advance exactly one step.
+        seed(&db, "a", "active", None, None, None, now - IDLE_TIMEOUT_MS - 1);
+        seed(
+            &db,
+            "i",
+            "idle",
+            Some(now - ARCHIVE_TIMEOUT_MS - 1),
+            None,
+            None,
+            1,
+        );
+        seed(
+            &db,
+            "r",
+            "archived",
+            None,
+            Some(now - PRUNE_TIMEOUT_MS - 1),
+            None,
+            1,
+        );
+        seed(
+            &db,
+            "p",
+            "pruned",
+            None,
+            None,
+            Some(now - HARD_DELETE_TIMEOUT_MS - 1),
+            1,
+        );
+
+        let first = sweep_lifecycle(db.conn(), now).unwrap();
+        assert_eq!(first.idled, 1);
+        assert_eq!(first.archived, 1);
+        assert_eq!(first.pruned, 1);
+        assert_eq!(first.hard_deleted, 1);
+        // 'a' idled (idle_at = now); it cannot ALSO archive this tick (7d boundary unmet).
+        assert_eq!(status_of(&db, "a"), "idle");
+
+        // Second sweep at the SAME now: nothing is newly eligible → no-op.
+        let second = sweep_lifecycle(db.conn(), now).unwrap();
+        assert!(second.is_empty(), "second back-to-back sweep changes nothing");
+    }
+
+    // --- fresh-DB / all-active no-op -------------------------------------------
+
+    #[test]
+    fn all_active_fresh_db_is_a_noop() {
+        let db = Db::open_hub(&tmp("fresh")).unwrap();
+        let now = 100_000_000_000_i64;
+        // Three freshly-ensured active sessions whose updated_at is RECENT (within the idle
+        // window) → no transition fires.
+        ensure_session(db.conn(), "s1", now).unwrap();
+        ensure_session(db.conn(), "s2", now - 1).unwrap();
+        ensure_session(db.conn(), "s3", now - IDLE_TIMEOUT_MS).unwrap(); // exactly at boundary
+        let out = sweep_lifecycle(db.conn(), now).unwrap();
+        assert!(out.is_empty(), "fresh all-active DB → zero transitions, zero deletes");
+        assert_eq!(status_of(&db, "s1"), "active");
+        assert_eq!(status_of(&db, "s2"), "active");
+        assert_eq!(status_of(&db, "s3"), "active");
+    }
+
+    #[test]
+    fn empty_db_sweep_is_a_noop() {
+        let db = Db::open_hub(&tmp("emptydb")).unwrap();
+        let out = sweep_lifecycle(db.conn(), 100_000_000_000).unwrap();
+        assert!(out.is_empty());
+    }
+
+    // --- full lifecycle across ticks (single-step-per-tick) --------------------
+
+    #[test]
+    fn one_session_walks_the_whole_lifecycle_one_phase_per_tick() {
+        let db = Db::open_hub(&tmp("walk")).unwrap();
+        let t0 = 1_000_000_000_i64;
+        ensure_session(db.conn(), "s", t0).unwrap();
+
+        // Tick 1: past idle → idle.
+        let t1 = t0 + IDLE_TIMEOUT_MS + 1;
+        assert_eq!(sweep_lifecycle(db.conn(), t1).unwrap().idled, 1);
+        assert_eq!(status_of(&db, "s"), "idle");
+
+        // Tick 2: past archive (idle_at was t1) → archived.
+        let t2 = t1 + ARCHIVE_TIMEOUT_MS + 1;
+        assert_eq!(sweep_lifecycle(db.conn(), t2).unwrap().archived, 1);
+        assert_eq!(status_of(&db, "s"), "archived");
+
+        // Tick 3: past prune (archived_at was t2) → pruned.
+        let t3 = t2 + PRUNE_TIMEOUT_MS + 1;
+        assert_eq!(sweep_lifecycle(db.conn(), t3).unwrap().pruned, 1);
+        assert_eq!(status_of(&db, "s"), "pruned");
+
+        // Tick 4: past hard-delete (pruned_at was t3) → gone.
+        let t4 = t3 + HARD_DELETE_TIMEOUT_MS + 1;
+        assert_eq!(sweep_lifecycle(db.conn(), t4).unwrap().hard_deleted, 1);
+        assert!(!exists(&db, "s"));
+    }
+}


### PR DESCRIPTION
## Architecture: Rust owns session lifecycle on `agent_session`

The TypeScript `session-lifecycle-sweep` was retired (fail-closed) and its scheduler job was removed in #652. Per the operator's chosen architecture, **Rust now OWNS session lifecycle, writing to the Hub-only `agent_session` table**. The TS `sessions` table's historical lifecycle data is **abandoned (NOT migrated)** per that decision. This PR is the Rust-owned replacement reaper — the "most thorough" real replacement for the retired sweep.

It is **DARK**: a default-off env flag gates the reaper tick, so deploying the new binary reaps nothing. Wire-live is a separate operator-gated step (below). **NOT a v1 GO.**

## The four transitions (ported from the TS sweep, ONE write transaction)

Ported timeout constants mirror `src/sessions/friday-session.constants.ts`; predicates use a **strict `<`** boundary, faithful to the TS repo's `... < beforeIso` predicates (`src/sessions/persistence/friday-session-repository.ts`):

| # | Transition | Fires when | Drives off |
|---|------------|-----------|------------|
| 1 | `active` → `idle` | no activity > **30m** (`IDLE_TIMEOUT_MS`) | `COALESCE(last_activity_at, updated_at)` |
| 2 | `idle` → `archived` | idle > **7d** (`ARCHIVE_TIMEOUT_MS`) | `idle_at` |
| 3 | `archived` → `pruned` | archived > **30d** (`PRUNE_TIMEOUT_MS`) | `archived_at` |
| 4 | `pruned` → hard-delete | pruned > **7d** (`HARD_DELETE_TIMEOUT_MS`) | `pruned_at` |

Each transition advances `status`, writes the per-phase timestamp + `status_changed_at` + `updated_at`, all in one transaction (all-or-nothing). A freshly-idled row gets `idle_at = now`, so it cannot also archive in the same tick (the 7d boundary is unmet) — a session advances **at most one phase per sweep**, which is exactly what makes a back-to-back second sweep a no-op (free idempotency).

### `last_activity_at` is a forward hook with no writer yet
The TS predicate keys on `sessions.last_activity_at`. Migration v28 adds a nullable `last_activity_at` column to `agent_session`, but **it has no writer yet** — the hot `ensure_session`/`append_session_message` paths (deliberately untouched) bump only `updated_at`. So the reaper coalesces to the genuinely-maintained `updated_at`, which is semantically the TS last-activity (it advances on every ensure + appended message). When a future slice wires a dedicated last-activity writer, it simply takes precedence with no change here. The column is intentionally **not** backfilled to `updated_at` (a frozen snapshot would wrongly idle sessions still active after the migration runs). A boundary test builds the row via the **real `ensure_session` path** so the NULL-`last_activity_at` dead-predicate (a bare `last_activity_at < ?` would match nothing in prod) is caught.

### Hard-delete handles the FK child (no orphans)
`agent_session_message` has `FOREIGN KEY(agent_session_id) REFERENCES agent_session` with **no `ON DELETE CASCADE`**, and `PRAGMA foreign_keys` is ON on every connection. So a parent DELETE while children exist would fail the FK constraint and roll the whole sweep back every cycle. The hard-delete therefore deletes the doomed sessions' child messages **first**, then the parent rows, in the same transaction. I enumerated all FK children of `agent_session` (`grep REFERENCES agent_session`): `agent_session_message` is the **only** one. The session-memory `memory_item` surface (#599–601) links by *namespace*, not an FK, so it neither blocks the delete nor is cleaned by it (correct scope).

## Parts

1. **Migration v28** (`agent_session_lifecycle`): additive ALTERs adding `status` (NOT NULL DEFAULT `'active'`, vocabulary CHECK `active|idle|archived|pruned`) + `idle_at`/`archived_at`/`pruned_at`/`status_changed_at`/`last_activity_at` (nullable epoch-ms). Frozen base CREATE-DDL + ALTER, mirroring m0021/m0023. **Note:** the task brief said "v25", but the worktree's max migration was already **v27** (`workflow_run_control_columns`) and v25/v26 are taken (`workflow_catalog`/`system_intent_substrate`), so this is correctly **v28**. No existing migration was changed.
2. **Reaper module** (`session_lifecycle.rs`): `sweep_lifecycle(conn, now_ms) -> SweepOutcome` (per-transition counts incl. `messages_deleted`), exported from storage `lib.rs`.
3. **Flag-gated tick-thread** in `hub_agent_run_server.rs`: a background `std::thread` that opens its **own** `Db::open_hub` connection (never shares the accept-loop's connection across threads) and sweeps every **120s** (matching the old TS cadence). Spawned **only** when `FRIDAY_RUST_SESSION_REAPER_ENABLED` is `"1"`/`"true"`. Errors (failed open, failed sweep) log-and-continue — never panics the daemon. Non-empty sweeps log refs-only counts.
4. **Tests**: per-transition boundary (just-under vs just-over), active→idle via the real `ensure_session` path, COALESCE precedence, idempotency, fresh/empty no-op, hard-delete safety, child-message cleanup (no orphans), full-lifecycle walk across ticks, status CHECK, migration-reaches-latest, and the default-off flag matcher (`None`/empty/`0`/`false`/garbage ⇒ off; `1`/`true`/`TRUE`/padded ⇒ on).

## DEFAULT-OFF: deploying the binary is safe

The reaper hard-deletes rows, so the tick is gated behind `FRIDAY_RUST_SESSION_REAPER_ENABLED` (default-off, fail-closed — only exact opt-in values enable it). **Unset = thread not spawned = no second DB connection = no reaping.** Deploying the new binary is therefore safe; it does nothing destructive until the operator explicitly flips the flag.

**Wire-live = (rebuild Rust bin + deploy + flip flag) is a separate operator-gated step.**

### Live-flip prerequisite (operator decision, surfaced)

I deliberately use `Db::open_hub` (NOT `open_hub_concurrent`) for the reaper's connection: `open_hub_concurrent` flips the prod DB to WAL **persistently** the instant it connects, which is itself an operator live-flip — not a dark deploy. With the flag OFF there is no second connection and zero contention. **But when the operator flips the flag live**, the reaper's separate connection under the default rollback-journal mode can hit `SQLITE_BUSY` against the WS server's connection, and a reaper write holding the lock can stall the *serving* path. So **enabling the flag in production should be paired with the busy_timeout/WAL concurrent-open path** (`open_hub_concurrent`, which itself is the operator-gated WAL file-mode flip). This is the surface where the flag can degrade live runs — flagged here for the operator.

## Omissions vs the TS sweep (intentional)

- **Fork-archive** — the TS sweep had a 5th step archiving inactive *fork* sessions (`parent_session_key IS NOT NULL`). The Rust `agent_session` has `parent_session_id` (the *subagent* chain pointer, v23) but **none** of the TS fork markers (`forked_from_message_id` / `root_session_key` / a fork timeout) — there is no fork *concept* in the Rust schema, so fork-archive is omitted (nothing to archive as a fork).
- **Memory-extraction-on-idle** — the TS sweep enqueued memory extraction when a session went idle. That responsibility is owned by the **separate** Rust session-memory surface (#599–601: `agent_session_message.memory_extract_status` + the inline extractor), so it is **not** duplicated in this reaper.

## Verification

- `cargo build --workspace` ✅
- `cargo clippy --workspace --all-targets -- -D warnings` ✅ (0 warnings; this is the `rust-core.yml` CI gate)
- `cargo test --workspace` ✅ (0 failures; `friday-storage` lib 86 incl. 13 new session_lifecycle tests, `friday-hub` lib 500 incl. the flag test, `friday-arch-tests` green — the 6 new columns trip no arch invariant)
- No existing migration changed (v28 added only); no WS/auth/crypto path altered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)