### PR TITLE
feat(diagnostics): headless Rust-route self-probe (F1.5 organic-traffic landing; DEFAULT-OFF, weakly-organic, recurring real spend when enabled)

### DIFF
--- a/src/diagnostics/friday-rust-route-self-probe.ts
+++ b/src/diagnostics/friday-rust-route-self-probe.ts
@@ -1,0 +1,398 @@
+// ─── F1.5 — Headless in-product Rust-route self-probe diagnostic (DARK, DEFAULT-OFF) ───
+//
+// WHAT THIS IS (read this before the reviewer reads anything else):
+//   A read-only, product-purposed *self-probe* diagnostic. WHEN — and only when — an
+//   operator explicitly enables it via the kill-switch env flag, it periodically lands ONE
+//   qualifying read-only agent-run through the LIVE Rust read-only agent-run route, which
+//   produces a REAL `token_ledger` row in rust-hub.sqlite (provider_kind='deepseek',
+//   fallback=0, total_tokens>0, session_id=run_id). Its purpose is a real in-product health
+//   signal: "does a non-synthetic product component still reach Rust end-to-end?" — its last
+//   outcome is surfaced as a diagnostic, not discarded into a bare cron.
+//
+// HONEST LABELING (DO NOT upgrade this):
+//   This is the OPTION-1 / H-b mechanism from TRUE_TRAFFIC_INGRESS_OPTIONS_20260610.md. It
+//   earns a "recurring REAL token_ledger row" — real DeepSeek spend, real tokens — but it is
+//   **WEAKLY organic (system-initiated)**, NOT strictly organic. It is the harness shape
+//   reframed as a product diagnostic; it does NOT move the qualifier-breadth / transport / S6
+//   gaps. NEVER report it as "organic" unqualified. (Design FACT/HONESTY-CRUX, file lines 36-52.)
+//
+// INGRESS = H-b ONLY (design lines 45-46, 11):
+//   In-process loopback `POST http://127.0.0.1:<hubPort>/v1/agent/runs` with a self-minted
+//   `admin-001` bearer — the EXACT slice6 path. It goes through the REAL HTTP + auth +
+//   route-wrapper chain (clause-1 `invokedFromHttpStartRunRoute` is hardcoded-true inside
+//   `routeStartRun`, reachable ONLY from this HTTP handler). It does NOT import/call
+//   `routeStartRun` directly and opens NO new trust surface. H-a (a direct in-process caller
+//   that asserts admin without a token) was REJECTED by the design (line 46) because it
+//   creates an "assert admin without a token" surface; we do not build it.
+//
+// SECURITY — the self-mint is the sensitive part (scope it tightly; flag it for review):
+//   `mintDiagnosticAdminBearer` hand-constructs an access-token claim set with
+//   `principalId:"admin-001"` and HMAC-signs it with the hub's EXISTING `tokenSecret` via the
+//   already-shipped `encodeToken` (no new secret, no new un-authed admin path). The token is:
+//     • SESSIONLESS (no `sid`) — so the validator's `lookupSessionTokenState` short-circuits to
+//       "active" with NO DB lookup and the mint persists NOTHING (no session row, no issued-
+//       token row). This is what makes it single-use + never-persisted by construction. We do
+//       NOT use the auth-service login/`generateTokenPair` path precisely because that DOES
+//       persist a session + issued-token row.
+//     • SHORT-LIVED (smallest viable TTL — default 60s; auth validates once at request receipt,
+//       not mid-run, so 60s covers loopback + validation with margin).
+//     • MINIMALLY SCOPED — only `["agent.run"]`, NOT the full admin scope set. GAP A (the Rust
+//       owner-allowlist) is satisfied by `principalId==="admin-001"` ALONE; the Rust server only
+//       checks principalId, never scopes. The probe never reads the ledger (the operator does,
+//       via SQL), so no `agent.read`. If this token ever leaked it cannot perform admin writes.
+//     • NEVER LOGGED — not in success, not in error paths, not in the last-outcome holder.
+//   REVIEWER: scrutinize that this self-mint cannot be reached except from the scheduler job it
+//   is colocated with — `mintDiagnosticAdminBearer` is intentionally NOT re-exported from any
+//   barrel; only the bootstrap wiring + the colocated test import it. A broadly-importable
+//   sessionless admin minter would re-create the H-a trust surface through a side door.
+//
+// KILL-SWITCH (DEFAULT-OFF):
+//   The ENTIRE scheduler registration + firing is gated behind `FRIDAY_RUST_ROUTE_DIAGNOSTIC_ENABLED`.
+//   Unset / anything-but-"true" ⇒ the job is NEVER built, NEVER registered, NEVER fires (mirrors
+//   the `envEqualsTrue` posture in friday-capability-gates.ts). Enabling = recurring REAL DeepSeek
+//   spend (operator gate; pick a low cadence). Interval is configurable via
+//   `FRIDAY_RUST_ROUTE_DIAGNOSTIC_INTERVAL_MS` (default hourly, clamped to a 5-min floor); it only
+//   matters when the flag is on.
+
+import * as crypto from "node:crypto";
+
+import { encodeToken } from "#api";
+import type { FridayProviderService } from "#providers";
+
+// The qualifying body's read-tool grant must be EXACTLY these four (clause-4). We re-declare the
+// literal here (rather than import the runtime constant) to keep the diagnostic module free of a
+// heavy runtime import; the colocated test asserts this set is byte-identical to the predicate's
+// `RUST_ROUTE_READ_TOOL_ALLOWLIST` AND that the produced body satisfies `qualifiesForRustReadOnlyRoute`.
+export const RUST_ROUTE_DIAGNOSTIC_READ_TOOLS = [
+  "read_file",
+  "list_dir",
+  "stat_file",
+  "search",
+] as const;
+
+/** DeepSeek-flash model literal — clause-3 (`model:"deepseek-v4-flash"`). */
+export const RUST_ROUTE_DIAGNOSTIC_MODEL = "deepseek-v4-flash";
+
+/** The seeded admin owner the Rust server's `--owner admin-001` allowlist requires (GAP A). */
+export const RUST_ROUTE_DIAGNOSTIC_PRINCIPAL_ID = "admin-001";
+
+/** Env flag names (documented in the module header). */
+export const RUST_ROUTE_DIAGNOSTIC_ENABLED_ENV = "FRIDAY_RUST_ROUTE_DIAGNOSTIC_ENABLED";
+export const RUST_ROUTE_DIAGNOSTIC_INTERVAL_ENV = "FRIDAY_RUST_ROUTE_DIAGNOSTIC_INTERVAL_MS";
+
+/** Default cadence when enabled: hourly (low cadence per the spend heads-up). */
+export const RUST_ROUTE_DIAGNOSTIC_DEFAULT_INTERVAL_MS = 3_600_000;
+/** Floor on the interval so a mis-set env can never busy-spend (5 min). */
+export const RUST_ROUTE_DIAGNOSTIC_MIN_INTERVAL_MS = 300_000;
+/** Smallest viable bearer TTL in SECONDS (validated once at receipt; 60s covers loopback). */
+export const RUST_ROUTE_DIAGNOSTIC_BEARER_TTL_SEC = 60;
+/** The stable scheduler job id. */
+export const RUST_ROUTE_DIAGNOSTIC_JOB_ID = "rust-route-self-probe";
+
+// ─── Config resolution (pure) ───
+
+export interface RustRouteDiagnosticConfig {
+  enabled: boolean;
+  intervalMs: number;
+}
+
+/**
+ * Resolve the diagnostic's enable + interval from the environment. DEFAULT-OFF: `enabled` is
+ * true ONLY when the flag is exactly the string "true" (mirrors `envEqualsTrue`). The interval
+ * is clamped to a 5-min floor and is only consulted when enabled.
+ */
+export function resolveRustRouteDiagnosticConfig(
+  env: NodeJS.ProcessEnv = process.env,
+): RustRouteDiagnosticConfig {
+  const enabled = env[RUST_ROUTE_DIAGNOSTIC_ENABLED_ENV] === "true";
+  const raw = Number(env[RUST_ROUTE_DIAGNOSTIC_INTERVAL_ENV] ?? String(RUST_ROUTE_DIAGNOSTIC_DEFAULT_INTERVAL_MS));
+  const intervalMs = Math.max(
+    RUST_ROUTE_DIAGNOSTIC_MIN_INTERVAL_MS,
+    Number.isFinite(raw) ? Math.trunc(raw) : RUST_ROUTE_DIAGNOSTIC_DEFAULT_INTERVAL_MS,
+  );
+  return { enabled, intervalMs };
+}
+
+// ─── Bearer self-mint (security-sensitive; module-private by convention) ───
+
+/**
+ * Hand-mint a SESSIONLESS, SHORT-LIVED, MINIMALLY-SCOPED `admin-001` access token signed with
+ * the hub's existing `tokenSecret`. Reuses the shipped `encodeToken` (HMAC-SHA256). Persists
+ * NOTHING. See the module header for the full security rationale.
+ *
+ * NOT re-exported from any barrel — importing this broadly would re-create the rejected H-a
+ * "assert admin without a token" trust surface. Only the bootstrap wiring + the colocated test
+ * import it.
+ *
+ * @returns the raw `Bearer`-ready token string. NEVER log it.
+ */
+export function mintDiagnosticAdminBearer(deps: {
+  tokenSecret: string;
+  nowMs: () => number;
+  idGenerator: () => string;
+  ttlSec?: number;
+}): string {
+  const ttlSec = deps.ttlSec ?? RUST_ROUTE_DIAGNOSTIC_BEARER_TTL_SEC;
+  const nowSec = Math.floor(deps.nowMs() / 1000);
+  // Minimal claims: admin-001 principal (GAP A), ONLY agent.run scope, sessionless (no `sid`),
+  // short exp. `tokenId` is a fresh uuid never inserted into the revocation table ⇒ not revoked.
+  const claims = {
+    tokenId: deps.idGenerator(),
+    principalType: "user" as const,
+    principalId: RUST_ROUTE_DIAGNOSTIC_PRINCIPAL_ID,
+    userId: RUST_ROUTE_DIAGNOSTIC_PRINCIPAL_ID,
+    role: "admin" as const,
+    scopes: ["agent.run" as const],
+    iat: nowSec,
+    exp: nowSec + ttlSec,
+    // intentionally NO `sid` — keeps `lookupSessionTokenState` short-circuited to "active"
+    // (no DB lookup, no persistence).
+  };
+  return encodeToken(claims, deps.tokenSecret);
+}
+
+// ─── Qualifying body (the FIXED slice6 shape) ───
+
+export interface RustRouteSelfProbeBody {
+  task: string;
+  providerId: string;
+  model: string;
+  constraints: { readOnly: true };
+  allowedRustRouteTools: string[];
+}
+
+/**
+ * Build the EXACT qualifying body for the Rust read-only route. `providerId` MUST be the
+ * RESOLVED enabled-deepseek provider id (a prod UUID; slice6 proved the literal "deepseek" is a
+ * test/RGG seed shape only — on prod the row carries a UUID whose kind==="deepseek"). The caller
+ * resolves it at probe time via {@link resolveEnabledDeepseekProviderId}.
+ *
+ * Sends NONE of: sessionKey, requireReview, planReviewOverride, taskProfile.* — every one of
+ * those disqualifies. A read-only repo/config self-probe prompt; the run only reads.
+ */
+export function buildRustRouteSelfProbeBody(providerId: string): RustRouteSelfProbeBody {
+  return {
+    task:
+      "Read-only self-probe: confirm the repository is reachable. "
+      + "Use a read tool (e.g. list the working directory or stat a file) to confirm you can "
+      + "read the repo, then reply with exactly: PROBE_OK",
+    providerId,
+    model: RUST_ROUTE_DIAGNOSTIC_MODEL,
+    constraints: { readOnly: true },
+    allowedRustRouteTools: [...RUST_ROUTE_DIAGNOSTIC_READ_TOOLS],
+  };
+}
+
+/**
+ * Resolve the id of the single enabled provider whose kind is "deepseek". Returns undefined when
+ * none is enabled (the probe then no-ops with a clear outcome rather than firing a doomed call).
+ */
+export async function resolveEnabledDeepseekProviderId(
+  providerService: Pick<FridayProviderService, "listProviders">,
+): Promise<string | undefined> {
+  const providers = await providerService.listProviders();
+  return providers.find((p) => p.kind === "deepseek" && p.enabled === true)?.id;
+}
+
+// ─── Loopback transport (injected for testability — never a real call in CI) ───
+
+export interface RustRouteLoopbackTransport {
+  /**
+   * Perform the loopback `POST /v1/agent/runs`. Returns the HTTP status + (optional) parsed runId.
+   * The implementation MUST attach `Authorization: Bearer <bearer>` and `Content-Type:
+   * application/json`. Injected so unit tests can mock it (no network in CI).
+   */
+  postAgentRun(input: {
+    bearer: string;
+    body: RustRouteSelfProbeBody;
+  }): Promise<{ httpStatus: number; runId?: string }>;
+}
+
+/** Build the default loopback transport that hits the hub's bound loopback port via `fetch`. */
+export function createRustRouteLoopbackTransport(deps: {
+  host: string;
+  port: number;
+  fetchImpl?: typeof fetch;
+  timeoutMs?: number;
+}): RustRouteLoopbackTransport {
+  const fetchImpl = deps.fetchImpl ?? fetch;
+  const timeoutMs = deps.timeoutMs ?? 120_000;
+  return {
+    async postAgentRun({ bearer, body }) {
+      const controller = new AbortController();
+      const timer = setTimeout(() => controller.abort(), timeoutMs);
+      try {
+        const res = await fetchImpl(`http://${deps.host}:${deps.port}/v1/agent/runs`, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            // Bearer is attached here and ONLY here; never logged.
+            Authorization: `Bearer ${bearer}`,
+          },
+          body: JSON.stringify(body),
+          signal: controller.signal,
+        });
+        let runId: string | undefined;
+        try {
+          const json = (await res.json()) as { runId?: unknown; id?: unknown };
+          if (typeof json.runId === "string") {
+            runId = json.runId;
+          } else if (typeof json.id === "string") {
+            runId = json.id;
+          }
+        } catch {
+          // Non-JSON / empty body — status alone is the outcome signal.
+        }
+        return { httpStatus: res.status, runId };
+      } finally {
+        clearTimeout(timer);
+      }
+    },
+  };
+}
+
+// ─── Last-probe outcome (the in-product diagnostic surface) ───
+
+export interface RustRouteProbeOutcome {
+  /** "ok" = loopback returned 2xx; "skipped" = no enabled deepseek provider; "error" = threw / non-2xx. */
+  status: "ok" | "skipped" | "error";
+  /** ISO timestamp of the probe attempt. */
+  at: string;
+  /** HTTP status when the loopback call was made (undefined for skipped). */
+  httpStatus?: number;
+  /** runId echoed by the route (acceptance is the rust-hub.sqlite token_ledger row, not this). */
+  runId?: string;
+  /** Short human reason (never contains the bearer). */
+  detail?: string;
+}
+
+/** A tiny, documented holder for the last-probe outcome (the diagnostic readback surface). */
+export interface RustRouteProbeOutcomeHolder {
+  get(): RustRouteProbeOutcome | undefined;
+  set(outcome: RustRouteProbeOutcome): void;
+}
+
+export function createRustRouteProbeOutcomeHolder(): RustRouteProbeOutcomeHolder {
+  let last: RustRouteProbeOutcome | undefined;
+  return {
+    get: () => last,
+    set: (outcome) => {
+      last = outcome;
+    },
+  };
+}
+
+// ─── The probe runner (one tick) ───
+
+export interface RustRouteSelfProbeDeps {
+  tokenSecret: string;
+  nowIso: () => string;
+  idGenerator: () => string;
+  providerService: Pick<FridayProviderService, "listProviders">;
+  transport: RustRouteLoopbackTransport;
+  outcomeHolder: RustRouteProbeOutcomeHolder;
+  /** Injected logger (defaults to console). NEVER receives the bearer. */
+  logger?: Pick<Console, "warn" | "info">;
+  ttlSec?: number;
+}
+
+/**
+ * Run ONE probe tick: resolve the enabled deepseek provider → mint a fresh short-lived bearer →
+ * loopback POST the fixed qualifying body → record the outcome. LOG-AND-CONTINUE on any failure
+ * (never throws) so the recurring scheduler job cannot become a crash/fail-loop. The terminal
+ * acceptance (a real token_ledger row) is verified out-of-band by the operator via SQL.
+ */
+export async function runRustRouteSelfProbe(deps: RustRouteSelfProbeDeps): Promise<RustRouteProbeOutcome> {
+  const logger = deps.logger ?? console;
+  const at = deps.nowIso();
+  try {
+    const providerId = await resolveEnabledDeepseekProviderId(deps.providerService);
+    if (!providerId) {
+      const outcome: RustRouteProbeOutcome = {
+        status: "skipped",
+        at,
+        detail: "no enabled deepseek provider; probe skipped",
+      };
+      deps.outcomeHolder.set(outcome);
+      logger.info?.(`[friday][rust-route-self-probe] ${outcome.detail}`);
+      return outcome;
+    }
+
+    // Mint a fresh bearer PER PROBE (single-use). Never logged.
+    const bearer = mintDiagnosticAdminBearer({
+      tokenSecret: deps.tokenSecret,
+      nowMs: () => new Date(deps.nowIso()).getTime(),
+      idGenerator: deps.idGenerator,
+      ttlSec: deps.ttlSec,
+    });
+    const body = buildRustRouteSelfProbeBody(providerId);
+    const { httpStatus, runId } = await deps.transport.postAgentRun({ bearer, body });
+
+    const ok = httpStatus >= 200 && httpStatus < 300;
+    const outcome: RustRouteProbeOutcome = {
+      status: ok ? "ok" : "error",
+      at,
+      httpStatus,
+      runId,
+      detail: ok
+        ? "loopback agent-run accepted; verify the real token_ledger row in rust-hub.sqlite"
+        : `loopback agent-run returned HTTP ${httpStatus}`,
+    };
+    deps.outcomeHolder.set(outcome);
+    if (ok) {
+      logger.info?.(
+        `[friday][rust-route-self-probe] ${outcome.detail}${runId ? ` (runId=${runId})` : ""}`,
+      );
+    } else {
+      logger.warn?.(`[friday][rust-route-self-probe] ${outcome.detail}`);
+    }
+    return outcome;
+  } catch (err) {
+    // LOG-AND-CONTINUE: never crash the scheduler loop. Error message is from our own code /
+    // fetch, never the bearer.
+    const detail = err instanceof Error ? err.message : String(err);
+    const outcome: RustRouteProbeOutcome = { status: "error", at, detail };
+    deps.outcomeHolder.set(outcome);
+    logger.warn?.(`[friday][rust-route-self-probe] probe failed (log-and-continue): ${detail}`);
+    return outcome;
+  }
+}
+
+// ─── Scheduler job builder (pure; off ⇒ null) ───
+
+export interface RustRouteSelfProbeJob {
+  id: string;
+  intervalMs: number;
+  timeoutMs: number;
+  catchUpRuns: number;
+  run: () => Promise<unknown>;
+}
+
+/**
+ * Build the scheduler job definition for the self-probe — or `null` when the kill-switch is off.
+ * Pure + DI'd so the bootstrap wiring stays a one-liner and the off→null / on→def behavior is
+ * unit-testable without booting the hub.
+ *
+ * IMPORTANT: when `config.enabled` is false this returns `null` ⇒ the bootstrap never pushes a
+ * job ⇒ the scheduler never registers it ⇒ it NEVER fires. DEFAULT-OFF by construction.
+ */
+export function maybeBuildRustRouteSelfProbeJob(
+  config: RustRouteDiagnosticConfig,
+  probeDeps: RustRouteSelfProbeDeps,
+): RustRouteSelfProbeJob | null {
+  if (!config.enabled) {
+    return null;
+  }
+  return {
+    id: RUST_ROUTE_DIAGNOSTIC_JOB_ID,
+    intervalMs: config.intervalMs,
+    // The real run can take ~20s (slice6: 19s). Generous timeout; still well under the
+    // scheduler default. catchUpRuns:1 — never burst multiple real (spending) runs on startup.
+    timeoutMs: 120_000,
+    catchUpRuns: 1,
+    // log-and-continue: runRustRouteSelfProbe never throws, so a failed probe is recorded and the
+    // recurring job survives (no crash/fail-loop). Reuses the scheduler's own backoff for the
+    // pathological case where the run handler itself somehow rejects.
+    run: async () => runRustRouteSelfProbe(probeDeps),
+  };
+}

--- a/src/diagnostics/friday-rust-route-self-probe.ts
+++ b/src/diagnostics/friday-rust-route-self-probe.ts
@@ -136,12 +136,14 @@ export function mintDiagnosticAdminBearer(deps: {
   const nowSec = Math.floor(deps.nowMs() / 1000);
   // Minimal claims: admin-001 principal (GAP A), ONLY agent.run scope, sessionless (no `sid`),
   // short exp. `tokenId` is a fresh uuid never inserted into the revocation table ⇒ not revoked.
+  // NO `role`: principalId alone satisfies the Rust owner allowlist (GAP A) and the happy path,
+  // so `role` is omitted to remove a latent admin-path escalation (the `principal.role==="admin"` /
+  // principalHasAnyRole authz paths would otherwise grant full admin within the 60s TTL if reached).
   const claims = {
     tokenId: deps.idGenerator(),
     principalType: "user" as const,
     principalId: RUST_ROUTE_DIAGNOSTIC_PRINCIPAL_ID,
     userId: RUST_ROUTE_DIAGNOSTIC_PRINCIPAL_ID,
-    role: "admin" as const,
     scopes: ["agent.run" as const],
     iat: nowSec,
     exp: nowSec + ttlSec,

--- a/src/hub/bootstrap/hub-helpers.ts
+++ b/src/hub/bootstrap/hub-helpers.ts
@@ -60,6 +60,7 @@ import type { FridayBrowserPresentationMode } from "#browser";
 import type { FridayAutonomousEngine } from "../../agent/autonomous/friday-autonomous.types.js";
 import type { FridayMcpAdapter } from "../../agent/mcp/friday-mcp-adapter.types.js";
 import { parseFridaySecretInput } from "../../security/friday-secret-ref.js";
+import type { RustRouteProbeOutcome } from "../../diagnostics/friday-rust-route-self-probe.js";
 
 // ─── Constants ───
 
@@ -1825,6 +1826,14 @@ export interface FridayHub {
   satelliteRuntime: FridaySatelliteRuntime;
   mcpAdapter?: FridayMcpAdapter;
   webchatWsService?: WebchatWsService;
+  /**
+   * F1.5 — Headless Rust-route self-probe diagnostic readback (DARK, DEFAULT-OFF). `lastProbeOutcome`
+   * returns the most recent probe result, or `undefined` when the FRIDAY_RUST_ROUTE_DIAGNOSTIC_ENABLED
+   * flag is unset (the diagnostic never ran). Read-only; never carries the self-minted bearer.
+   */
+  rustRouteDiagnostic: {
+    lastProbeOutcome(): RustRouteProbeOutcome | undefined;
+  };
 }
 
 export interface FridayHubStatus {

--- a/src/hub/friday-hub-bootstrap.ts
+++ b/src/hub/friday-hub-bootstrap.ts
@@ -364,6 +364,17 @@ import { appendFridayAuditLog, resolveFridayAuditLogPath } from "./services/frid
 import { createFridayGatewayService } from "./services/friday-gateway-service.js";
 import { createFridayProviderBackedTtsService } from "../media/friday-provider-backed-tts-service.js";
 import { createFridayChannelNaturalTriggerResolver } from "./bootstrap/friday-channel-natural-trigger-resolver.js";
+// F1.5 — Headless Rust-route self-probe diagnostic (DARK, DEFAULT-OFF). The `mintDiagnosticAdminBearer`
+// self-mint is intentionally module-scoped (NOT re-exported from a barrel) to avoid re-creating the
+// rejected H-a "assert admin without a token" trust surface; only this wiring + its test import it.
+import {
+  createRustRouteLoopbackTransport,
+  createRustRouteProbeOutcomeHolder,
+  maybeBuildRustRouteSelfProbeJob,
+  resolveRustRouteDiagnosticConfig,
+  RUST_ROUTE_DIAGNOSTIC_JOB_ID,
+  type RustRouteProbeOutcomeHolder,
+} from "../diagnostics/friday-rust-route-self-probe.js";
 
 // ─── Extracted helpers, types, and stubs ───
 
@@ -7380,6 +7391,10 @@ export async function createFridayHub(
 
   let jobScheduler: FridayJobSchedulerService | undefined;
   let schedulerRepo: FridayJobSchedulerRepository | undefined;
+  // F1.5 self-probe last-outcome holder — the in-product diagnostic readback surface. Only
+  // assigned when the default-OFF FRIDAY_RUST_ROUTE_DIAGNOSTIC_ENABLED flag is on; stays
+  // undefined (no diagnostic) otherwise. Read-only outcome; NEVER holds the bearer.
+  let rustRouteProbeOutcomeHolder: RustRouteProbeOutcomeHolder | undefined;
   if (stateRuntime) {
     schedulerRepo = createFridayJobSchedulerRepository({ db: stateRuntime.sqlite });
     const schedulerRepoRef = schedulerRepo;
@@ -7585,6 +7600,43 @@ export async function createFridayHub(
       },
     });
 
+    // F1.5 — Headless Rust-route self-probe diagnostic (DARK, DEFAULT-OFF; OPTION-1 / H-b).
+    // WHEN ENABLED by the operator via FRIDAY_RUST_ROUTE_DIAGNOSTIC_ENABLED=true ONLY, this
+    // recurring read-only self-probe lands ONE qualifying agent-run through the LIVE Rust
+    // read-only route (in-process loopback POST /v1/agent/runs with a self-minted, sessionless,
+    // short-lived, agent.run-only admin-001 bearer — the EXACT slice6 H-b path; no new trust
+    // surface, no direct routeStartRun caller). Each successful tick produces a REAL
+    // token_ledger row in rust-hub.sqlite. HONEST LABEL: "recurring REAL row, WEAKLY organic
+    // (system-initiated)" — NOT strictly organic. ENABLING = recurring REAL DeepSeek spend
+    // (operator gate; default cadence hourly, 5-min floor). Default-OFF by construction: when
+    // the flag is unset/anything-but-"true", maybeBuildRustRouteSelfProbeJob returns null ⇒ the
+    // job is never pushed ⇒ never registered ⇒ never fires. A failed probe is log-and-continue
+    // (runRustRouteSelfProbe never throws) so the recurring job cannot become a crash/fail-loop.
+    {
+      const diagnosticConfig = resolveRustRouteDiagnosticConfig(process.env);
+      if (diagnosticConfig.enabled) {
+        const probeHost = config.host ?? process.env.FRIDAY_HOST ?? "127.0.0.1";
+        const probePort = config.port ?? parseFridayHubPort(process.env.FRIDAY_PORT) ?? 3141;
+        rustRouteProbeOutcomeHolder = createRustRouteProbeOutcomeHolder();
+        const probeJob = maybeBuildRustRouteSelfProbeJob(diagnosticConfig, {
+          tokenSecret,
+          nowIso,
+          idGenerator,
+          providerService,
+          transport: createRustRouteLoopbackTransport({ host: probeHost, port: probePort }),
+          outcomeHolder: rustRouteProbeOutcomeHolder,
+        });
+        if (probeJob) {
+          schedulerJobs.push(probeJob);
+          console.warn(
+            `[friday][rust-route-self-probe] ENABLED — recurring REAL DeepSeek spend every `
+            + `${Math.round(diagnosticConfig.intervalMs / 1000)}s (weakly organic, system-initiated). `
+            + `Verify landings via token_ledger in rust-hub.sqlite (fallback=0, total_tokens>0).`,
+          );
+        }
+      }
+    }
+
     jobScheduler = createFridayJobSchedulerService({
       repository: schedulerRepoRef,
       nowIso,
@@ -7606,6 +7658,17 @@ export async function createFridayHub(
     // Runs before jobScheduler.start(), so start()'s seed loop will not re-create them.
     schedulerRepoRef.disableJob("session-lifecycle-sweep", nowIso());
     schedulerRepoRef.disableJob("agent-loop-cooldown-sweep", nowIso());
+
+    // F1.5 stop-the-spin: if the Rust-route self-probe is NOT enabled this boot, disable any row
+    // a PRIOR enabled boot persisted (enabled=1, next_run_at set). Enable→disable is the expected
+    // operator lifecycle (turn it on to land rows, off to stop spend). Without this, a disabled
+    // boot leaves the row enabled=1 with NO in-memory def → the exact orphan busy-spin trap
+    // described above (run loop skips it, but min-wake still sees it → armTimer(0) spins once
+    // next_run_at passes). disableJob clears enabled + next_run_at; harmless no-op on a fresh DB.
+    // Runs before start() so its seed loop will not re-create the row.
+    if (!resolveRustRouteDiagnosticConfig(process.env).enabled) {
+      schedulerRepoRef.disableJob(RUST_ROUTE_DIAGNOSTIC_JOB_ID, nowIso());
+    }
 
     // Link agent automations to the unified scheduler.
     if (apiRuntime.agentAutomationService) {
@@ -9604,6 +9667,11 @@ export async function createFridayHub(
     satelliteRuntime,
     mcpAdapter,
     webchatWsService,
+    // F1.5 diagnostic readback surface — the last self-probe outcome (undefined when the
+    // default-OFF flag is unset, i.e. the diagnostic never ran). Read-only; never holds the bearer.
+    rustRouteDiagnostic: {
+      lastProbeOutcome: () => rustRouteProbeOutcomeHolder?.get(),
+    },
   };
 
   return hub;

--- a/test/unit/diagnostics/friday-rust-route-self-probe.test.ts
+++ b/test/unit/diagnostics/friday-rust-route-self-probe.test.ts
@@ -178,6 +178,12 @@ describe("mintDiagnosticAdminBearer (security-sensitive self-mint)", () => {
     const { principal, claims } = makeValidator().validate(token);
     expect(principal.principalId).toBe("admin-001");
     expect(claims?.principalType).toBe("user");
+    // MUST-FIX (review): no `role` is minted — principalId alone satisfies GAP A and the happy
+    // path. `role` is omitted so the latent `principal.role==="admin"` / principalHasAnyRole
+    // authz paths cannot grant full admin within the bearer's TTL. Assert it is absent on BOTH
+    // the raw claims AND the validator-projected principal (the load-bearing one for authz).
+    expect(claims?.role).toBeUndefined();
+    expect(principal.role).toBeUndefined();
   });
 
   it("is short-lived (exp - iat === the smallest viable TTL) and sessionless (no sid)", () => {

--- a/test/unit/diagnostics/friday-rust-route-self-probe.test.ts
+++ b/test/unit/diagnostics/friday-rust-route-self-probe.test.ts
@@ -1,0 +1,340 @@
+import * as crypto from "node:crypto";
+
+import { describe, expect, it, vi } from "vitest";
+
+import { createFridayTokenValidator } from "#api";
+import type { FridayProviderProfile } from "#providers";
+
+import {
+  buildRustRouteSelfProbeBody,
+  createRustRouteProbeOutcomeHolder,
+  maybeBuildRustRouteSelfProbeJob,
+  mintDiagnosticAdminBearer,
+  resolveEnabledDeepseekProviderId,
+  resolveRustRouteDiagnosticConfig,
+  runRustRouteSelfProbe,
+  RUST_ROUTE_DIAGNOSTIC_BEARER_TTL_SEC,
+  RUST_ROUTE_DIAGNOSTIC_DEFAULT_INTERVAL_MS,
+  RUST_ROUTE_DIAGNOSTIC_JOB_ID,
+  RUST_ROUTE_DIAGNOSTIC_MIN_INTERVAL_MS,
+  RUST_ROUTE_DIAGNOSTIC_READ_TOOLS,
+  type RustRouteLoopbackTransport,
+} from "../../../src/diagnostics/friday-rust-route-self-probe.js";
+import {
+  qualifiesForRustReadOnlyRoute,
+  RUST_ROUTE_READ_TOOL_ALLOWLIST,
+} from "../../../src/api/runtime/friday-api-runtime.js";
+
+// F1.5 — Headless Rust-route self-probe diagnostic (DARK, DEFAULT-OFF; OPTION-1 / H-b).
+// These tests pin the security-sensitive + correctness-critical behaviors WITHOUT any network:
+//   • DEFAULT-OFF: flag unset/anything-but-"true" ⇒ job is NOT built (null) ⇒ never fires.
+//   • Flag ON ⇒ job built with the correct interval, and the produced body EXACTLY satisfies
+//     the real `qualifiesForRustReadOnlyRoute` predicate (clause-by-clause).
+//   • The self-minted bearer decodes (through the REAL token validator) to principalId
+//     'admin-001', is short-lived, sessionless, minimally-scoped, and single-use (fresh tokenId).
+//   • The probe loopback POST is mocked — the real landing is proven at enable-time on prod.
+
+const SECRET = "test-token-secret-at-least-32-bytes-long-aaaa";
+const FIXED_NOW_ISO = "2026-06-10T12:00:00.000Z";
+const FIXED_NOW_MS = new Date(FIXED_NOW_ISO).getTime();
+
+function deepseekProfile(overrides: Partial<FridayProviderProfile> = {}): FridayProviderProfile {
+  return {
+    id: "fa15f1fe-a0b6-4f79-96c3-4ae8e1be28a4",
+    kind: "deepseek",
+    enabled: true,
+    // The predicate + probe only read id/kind/enabled; the rest is filler for the type.
+    ...(overrides as object),
+  } as FridayProviderProfile;
+}
+
+// ─── Config (DEFAULT-OFF kill-switch) ───
+
+describe("resolveRustRouteDiagnosticConfig (DEFAULT-OFF kill-switch)", () => {
+  it("is DISABLED when the flag is unset", () => {
+    expect(resolveRustRouteDiagnosticConfig({}).enabled).toBe(false);
+  });
+
+  it("is DISABLED for anything other than the exact string 'true'", () => {
+    for (const raw of ["1", "TRUE", "yes", "on", "false", ""]) {
+      expect(resolveRustRouteDiagnosticConfig({ FRIDAY_RUST_ROUTE_DIAGNOSTIC_ENABLED: raw }).enabled).toBe(false);
+    }
+  });
+
+  it("is ENABLED only for exactly 'true'", () => {
+    expect(resolveRustRouteDiagnosticConfig({ FRIDAY_RUST_ROUTE_DIAGNOSTIC_ENABLED: "true" }).enabled).toBe(true);
+  });
+
+  it("defaults the interval to hourly and clamps to the 5-min floor", () => {
+    expect(resolveRustRouteDiagnosticConfig({}).intervalMs).toBe(RUST_ROUTE_DIAGNOSTIC_DEFAULT_INTERVAL_MS);
+    // below the floor → clamped up
+    expect(
+      resolveRustRouteDiagnosticConfig({ FRIDAY_RUST_ROUTE_DIAGNOSTIC_INTERVAL_MS: "1000" }).intervalMs,
+    ).toBe(RUST_ROUTE_DIAGNOSTIC_MIN_INTERVAL_MS);
+    // above the floor → honored
+    expect(
+      resolveRustRouteDiagnosticConfig({ FRIDAY_RUST_ROUTE_DIAGNOSTIC_INTERVAL_MS: "900000" }).intervalMs,
+    ).toBe(900_000);
+    // garbage → default
+    expect(
+      resolveRustRouteDiagnosticConfig({ FRIDAY_RUST_ROUTE_DIAGNOSTIC_INTERVAL_MS: "not-a-number" }).intervalMs,
+    ).toBe(RUST_ROUTE_DIAGNOSTIC_DEFAULT_INTERVAL_MS);
+  });
+});
+
+// ─── Scheduler job builder: OFF ⇒ null, ON ⇒ correct shape ───
+
+function probeDepsStub() {
+  return {
+    tokenSecret: SECRET,
+    nowIso: () => FIXED_NOW_ISO,
+    idGenerator: () => crypto.randomUUID(),
+    providerService: { listProviders: async () => [deepseekProfile()] },
+    transport: { postAgentRun: vi.fn(async () => ({ httpStatus: 200, runId: "run-1" })) },
+    outcomeHolder: createRustRouteProbeOutcomeHolder(),
+  };
+}
+
+describe("maybeBuildRustRouteSelfProbeJob (default-OFF ⇒ never registered)", () => {
+  it("returns null when disabled ⇒ the bootstrap never pushes a job ⇒ it NEVER fires", () => {
+    const job = maybeBuildRustRouteSelfProbeJob({ enabled: false, intervalMs: 3_600_000 }, probeDepsStub());
+    expect(job).toBeNull();
+  });
+
+  it("builds a job with the correct id + interval when enabled", () => {
+    const job = maybeBuildRustRouteSelfProbeJob({ enabled: true, intervalMs: 3_600_000 }, probeDepsStub());
+    expect(job).not.toBeNull();
+    expect(job?.id).toBe(RUST_ROUTE_DIAGNOSTIC_JOB_ID);
+    expect(job?.intervalMs).toBe(3_600_000);
+    expect(job?.catchUpRuns).toBe(1);
+  });
+
+  it("the built job, when run, makes EXACTLY one loopback call (no burst) and never throws", async () => {
+    const deps = probeDepsStub();
+    const job = maybeBuildRustRouteSelfProbeJob({ enabled: true, intervalMs: 3_600_000 }, deps);
+    await expect(job!.run()).resolves.toBeDefined();
+    expect(deps.transport.postAgentRun).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ─── The qualifying body EXACTLY satisfies the real predicate ───
+
+describe("buildRustRouteSelfProbeBody (the FIXED slice6 qualifying shape)", () => {
+  it("uses EXACTLY the four read tools and the same set as the predicate's allowlist", () => {
+    const body = buildRustRouteSelfProbeBody("fa15f1fe-a0b6-4f79-96c3-4ae8e1be28a4");
+    expect(body.allowedRustRouteTools).toEqual([...RUST_ROUTE_DIAGNOSTIC_READ_TOOLS]);
+    expect([...RUST_ROUTE_DIAGNOSTIC_READ_TOOLS].sort()).toEqual([...RUST_ROUTE_READ_TOOL_ALLOWLIST].sort());
+  });
+
+  it("produces a body that QUALIFIES for the live Rust read-only route (clause-by-clause)", () => {
+    const providerId = "fa15f1fe-a0b6-4f79-96c3-4ae8e1be28a4"; // prod UUID, kind=deepseek
+    const body = buildRustRouteSelfProbeBody(providerId);
+    // Mirror the route wrapper: clause-1 marker is hardcoded-true inside routeStartRun, and the
+    // wrapper resolves the provider record (kind=deepseek, enabled). The diagnostic carries
+    // principalId admin-001 (GAP A), but the body itself is sessionless so the predicate's
+    // session sub-clause does not even engage.
+    expect(
+      qualifiesForRustReadOnlyRoute({
+        invokedFromHttpStartRunRoute: true,
+        providerId: body.providerId,
+        resolvedProvider: { kind: "deepseek", enabled: true },
+        model: body.model,
+        constraints: body.constraints,
+        allowedRustRouteTools: body.allowedRustRouteTools,
+        principalId: "admin-001",
+      }),
+    ).toBe(true);
+  });
+
+  it("sends NONE of the disqualifying fields (sessionKey/requireReview/planReviewOverride/taskProfile)", () => {
+    const body = buildRustRouteSelfProbeBody("fa15f1fe");
+    const keys = Object.keys(body);
+    expect(keys).not.toContain("sessionKey");
+    expect(keys).not.toContain("requireReview");
+    expect(keys).not.toContain("planReviewOverride");
+    expect(keys).not.toContain("taskProfile");
+  });
+});
+
+// ─── Bearer self-mint: principalId=admin-001, short-lived, sessionless, minimal scope, single-use ───
+
+describe("mintDiagnosticAdminBearer (security-sensitive self-mint)", () => {
+  function makeValidator() {
+    // Real validator, fresh tokenId is never revoked. Sessionless ⇒ lookupSessionTokenState
+    // short-circuits to "active" without a DB read; we stub it to prove no DB dependency.
+    return createFridayTokenValidator({
+      tokenSecret: SECRET,
+      nowMs: () => FIXED_NOW_MS,
+      lookupTokenRevocation: () => false,
+    });
+  }
+
+  it("decodes (through the REAL validator) to principalId === 'admin-001'", () => {
+    const token = mintDiagnosticAdminBearer({
+      tokenSecret: SECRET,
+      nowMs: () => FIXED_NOW_MS,
+      idGenerator: () => crypto.randomUUID(),
+    });
+    const { principal, claims } = makeValidator().validate(token);
+    expect(principal.principalId).toBe("admin-001");
+    expect(claims?.principalType).toBe("user");
+  });
+
+  it("is short-lived (exp - iat === the smallest viable TTL) and sessionless (no sid)", () => {
+    const token = mintDiagnosticAdminBearer({
+      tokenSecret: SECRET,
+      nowMs: () => FIXED_NOW_MS,
+      idGenerator: () => crypto.randomUUID(),
+    });
+    const { claims } = makeValidator().validate(token);
+    expect(claims!.exp - claims!.iat).toBe(RUST_ROUTE_DIAGNOSTIC_BEARER_TTL_SEC);
+    expect(claims!.sid).toBeUndefined();
+  });
+
+  it("is rejected by the validator once expired (TTL is actually enforced)", () => {
+    const token = mintDiagnosticAdminBearer({
+      tokenSecret: SECRET,
+      nowMs: () => FIXED_NOW_MS,
+      idGenerator: () => crypto.randomUUID(),
+      ttlSec: 5,
+    });
+    // A validator whose clock is well past exp must reject it.
+    const lateValidator = createFridayTokenValidator({
+      tokenSecret: SECRET,
+      nowMs: () => FIXED_NOW_MS + 10_000,
+      lookupTokenRevocation: () => false,
+    });
+    expect(() => lateValidator.validate(token)).toThrow();
+  });
+
+  it("mints ONLY the agent.run scope (minimal — not the full admin set)", () => {
+    const token = mintDiagnosticAdminBearer({
+      tokenSecret: SECRET,
+      nowMs: () => FIXED_NOW_MS,
+      idGenerator: () => crypto.randomUUID(),
+    });
+    const { claims } = makeValidator().validate(token);
+    expect(claims!.scopes).toEqual(["agent.run"]);
+    expect(claims!.scopes).not.toContain("hub.admin");
+    expect(claims!.scopes).not.toContain("desktop.execute");
+  });
+
+  it("is single-use: each mint carries a fresh tokenId", () => {
+    let n = 0;
+    const idGenerator = () => `token-${n++}`;
+    const a = makeValidator().validate(
+      mintDiagnosticAdminBearer({ tokenSecret: SECRET, nowMs: () => FIXED_NOW_MS, idGenerator }),
+    );
+    const b = makeValidator().validate(
+      mintDiagnosticAdminBearer({ tokenSecret: SECRET, nowMs: () => FIXED_NOW_MS, idGenerator }),
+    );
+    expect(a.claims!.tokenId).not.toBe(b.claims!.tokenId);
+  });
+});
+
+// ─── Provider resolution: prod UUID, not the literal "deepseek" ───
+
+describe("resolveEnabledDeepseekProviderId", () => {
+  it("returns the enabled deepseek provider's (UUID) id", async () => {
+    const id = await resolveEnabledDeepseekProviderId({
+      listProviders: async () => [
+        deepseekProfile({ id: "uuid-deepseek", enabled: true }),
+        deepseekProfile({ id: "uuid-anthropic", kind: "anthropic" as FridayProviderProfile["kind"] }),
+      ],
+    });
+    expect(id).toBe("uuid-deepseek");
+  });
+
+  it("returns undefined when no enabled deepseek provider exists", async () => {
+    const id = await resolveEnabledDeepseekProviderId({
+      listProviders: async () => [deepseekProfile({ enabled: false })],
+    });
+    expect(id).toBeUndefined();
+  });
+});
+
+// ─── Probe runner: mocked transport, log-and-continue ───
+
+describe("runRustRouteSelfProbe (no network in CI; the real landing is proven at enable-time on prod)", () => {
+  const baseDeps = () => ({
+    tokenSecret: SECRET,
+    nowIso: () => FIXED_NOW_ISO,
+    idGenerator: () => crypto.randomUUID(),
+    providerService: { listProviders: async () => [deepseekProfile()] },
+    outcomeHolder: createRustRouteProbeOutcomeHolder(),
+    logger: { warn: vi.fn(), info: vi.fn() },
+  });
+
+  it("posts the qualifying body with a bearer and records an 'ok' outcome on 2xx", async () => {
+    const postAgentRun = vi.fn(async () => ({ httpStatus: 200, runId: "run-xyz" }));
+    const transport: RustRouteLoopbackTransport = { postAgentRun };
+    const deps = { ...baseDeps(), transport };
+    const outcome = await runRustRouteSelfProbe(deps);
+
+    expect(outcome.status).toBe("ok");
+    expect(outcome.httpStatus).toBe(200);
+    expect(outcome.runId).toBe("run-xyz");
+    expect(deps.outcomeHolder.get()?.status).toBe("ok");
+
+    // body shape forwarded to the transport is the fixed qualifying shape
+    const call = postAgentRun.mock.calls[0][0];
+    expect(call.body.model).toBe("deepseek-v4-flash");
+    expect(call.body.providerId).toBe("fa15f1fe-a0b6-4f79-96c3-4ae8e1be28a4");
+    expect(call.body.allowedRustRouteTools).toEqual([...RUST_ROUTE_DIAGNOSTIC_READ_TOOLS]);
+    // a bearer was attached; we never assert its literal value (and it is never logged)
+    expect(typeof call.bearer).toBe("string");
+    expect(call.bearer.length).toBeGreaterThan(0);
+  });
+
+  it("records 'skipped' (no call) when no enabled deepseek provider exists", async () => {
+    const postAgentRun = vi.fn();
+    const deps = {
+      ...baseDeps(),
+      providerService: { listProviders: async () => [] },
+      transport: { postAgentRun },
+    };
+    const outcome = await runRustRouteSelfProbe(deps);
+    expect(outcome.status).toBe("skipped");
+    expect(postAgentRun).not.toHaveBeenCalled();
+  });
+
+  it("LOG-AND-CONTINUEs (never throws) when the loopback rejects — no crash-loop", async () => {
+    const deps = {
+      ...baseDeps(),
+      transport: { postAgentRun: vi.fn(async () => { throw new Error("ECONNREFUSED"); }) },
+    };
+    const outcome = await runRustRouteSelfProbe(deps);
+    expect(outcome.status).toBe("error");
+    expect(deps.outcomeHolder.get()?.status).toBe("error");
+  });
+
+  it("records 'error' on a non-2xx loopback status", async () => {
+    const deps = {
+      ...baseDeps(),
+      transport: { postAgentRun: vi.fn(async () => ({ httpStatus: 503 })) },
+    };
+    const outcome = await runRustRouteSelfProbe(deps);
+    expect(outcome.status).toBe("error");
+    expect(outcome.httpStatus).toBe(503);
+  });
+
+  it("never includes the self-minted bearer in any recorded outcome detail", async () => {
+    let capturedBearer = "";
+    const deps = {
+      ...baseDeps(),
+      transport: {
+        postAgentRun: vi.fn(async ({ bearer }: { bearer: string }) => {
+          capturedBearer = bearer;
+          return { httpStatus: 200, runId: "r" };
+        }),
+      },
+    };
+    await runRustRouteSelfProbe(deps);
+    const detail = deps.outcomeHolder.get()?.detail ?? "";
+    expect(detail.length).toBeGreaterThan(0);
+    expect(capturedBearer.length).toBeGreaterThan(0);
+    // The recorded diagnostic outcome must NOT leak the bearer (nor its signature half).
+    expect(detail).not.toContain(capturedBearer);
+    expect(detail).not.toContain(capturedBearer.split(".")[1] ?? "__none__");
+  });
+});

--- a/test/unit/diagnostics/friday-rust-route-self-probe.test.ts
+++ b/test/unit/diagnostics/friday-rust-route-self-probe.test.ts
@@ -34,7 +34,7 @@ import {
 //     'admin-001', is short-lived, sessionless, minimally-scoped, and single-use (fresh tokenId).
 //   • The probe loopback POST is mocked — the real landing is proven at enable-time on prod.
 
-const SECRET = "test-token-secret-at-least-32-bytes-long-aaaa";
+const SECRET = "test-token-secret-at-least-32-bytes-long-aaaa"; // pragma: allowlist secret
 const FIXED_NOW_ISO = "2026-06-10T12:00:00.000Z";
 const FIXED_NOW_MS = new Date(FIXED_NOW_ISO).getTime();
 


### PR DESCRIPTION
## What this is

**F1.5 OPTION-1 / H-b** from `TRUE_TRAFFIC_INGRESS_OPTIONS_20260610.md`. A read-only, product-purposed **self-probe diagnostic** that — **only when an operator explicitly enables it** — periodically lands ONE qualifying read-only agent-run through the **LIVE Rust read-only agent-run route**, producing a **REAL `token_ledger` row** in `rust-hub.sqlite`. Its last outcome is surfaced as an in-product diagnostic (`FridayHub.rustRouteDiagnostic.lastProbeOutcome()`), so it is a real capability — not a naked cron.

DARK + DEFAULT-OFF. No prod tree touched, nothing deployed, nothing enabled by default, not merged.

## DEFAULT-OFF kill-switch (the exact flag)

- **`FRIDAY_RUST_ROUTE_DIAGNOSTIC_ENABLED`** — gates the **entire** scheduler registration + firing. `=='true'` is the ONLY enable value (mirrors `envEqualsTrue` in `friday-capability-gates.ts`). Unset / anything-else ⇒ `maybeBuildRustRouteSelfProbeJob` returns `null` ⇒ the job is **never built, never registered, never fires**.
- **`FRIDAY_RUST_ROUTE_DIAGNOSTIC_INTERVAL_MS`** — cadence when enabled. Default **hourly** (`3_600_000`), clamped to a **5-min floor**. Only matters when enabled.

## ⚠️ ENABLING = recurring REAL DeepSeek spend (operator gate)

Each successful tick is a real agent-run that calls DeepSeek and writes real tokens. Enabling this flag establishes a **recurring real-spend posture** (F5.2 "recurring provider spend"). Pick a low cadence. The default-off flag keeps it operator-controlled. On enable, the hub logs a one-line REAL-spend warning.

## Honest labeling — DO NOT upgrade

This earns a **recurring REAL `token_ledger` row** (real spend, real tokens), but it is **WEAKLY organic (system-initiated)** — the harness shape reframed as a product diagnostic. It is **NOT strictly organic** and moves **none** of the qualifier-breadth / transport / S6 gaps. Never report it as "organic" unqualified. (Design HONESTY-CRUX, file lines 36-52.)

## Ingress = H-b ONLY (no new trust surface); H-a rejected

- **H-b (chosen):** in-process loopback `POST http://127.0.0.1:<hubPort>/v1/agent/runs` with a self-minted `admin-001` bearer — the EXACT slice6 path. Goes through the **real** HTTP + auth + route-wrapper chain; clause-1 `invokedFromHttpStartRunRoute` is hardcoded-true *inside* `routeStartRun`, reachable ONLY from this HTTP handler. **Does NOT import/call `routeStartRun` directly. Opens NO new trust surface.**
- **H-a (rejected, design line 46):** a direct in-process caller that asserts admin without a token. That creates an "assert admin without a token" surface — any code reaching it routes as admin. **Not built.**

## Bearer self-mint — the security-sensitive part (please scrutinize)

`mintDiagnosticAdminBearer` hand-constructs access-token claims and HMAC-signs them with the hub's **existing** `tokenSecret` via the already-shipped `encodeToken`. **No new secret, no new un-authed admin path.** The token is:

- **Sessionless** (no `sid`) ⇒ the validator's `lookupSessionTokenState` short-circuits to `"active"` with **no DB lookup**, and the mint **persists nothing** (no session row, no issued-token row). We deliberately do **not** use the auth-service login / `generateTokenPair` path precisely because that persists a session + issued-token row.
- **Short-lived** — smallest viable TTL, **60s** (auth validates once at request receipt, not mid-run).
- **Minimally scoped** — only `["agent.run"]`, **NOT** the full admin scope set (no `hub.admin`, no `desktop.execute`, no `*.write`). GAP A (the Rust `--owner admin-001` allowlist) is satisfied by `principalId === "admin-001"` **alone**; the Rust server checks principalId, never scopes.
- **Single-use** — a fresh `tokenId` per probe; minted fresh each tick.
- **Never logged** — not on success, not in error paths, not in the last-outcome holder.

**Reviewer asks — please rule on these two explicitly:**
1. **The capability:** a sessionless, unregistered, self-signed token bearing `principalId:"admin-001"` that fully validates with no persistence. Its safety rests on `mintDiagnosticAdminBearer` staying **module-private** (not re-exported from any barrel — only the bootstrap wiring + the colocated test import it). A broadly-importable version *would be* H-a through a side door. Please confirm no re-export creeps in.
2. **`role:"admin"` is still carried in claims** (truthful — admin-001 is an admin), even though `scopes` is minimized to `["agent.run"]`. The target public route gates on neither, so it's fine here — but any **future** consumer that authorizes via `roleHasScope(principal.role, …)` instead of `principal.scopes` would see full admin. Flagging so you rule on it rather than discover it.

## SEV-1 guards (learned from this session's fail-loop)

- A failed probe is **log-and-continue** (`runRustRouteSelfProbe` never throws) ⇒ the recurring job cannot crash/fail-loop.
- On a **disabled boot**, the bootstrap `disableJob()`s any scheduler row a **prior enabled boot** persisted — enable→disable is the expected operator lifecycle. Without this, a disabled boot leaves the row `enabled=1` with no in-memory def ⇒ the **orphan busy-spin trap** (the exact pattern the neighboring retired-sweep guard prevents).

## Acceptance — the REAL row (proven at enable-time on prod, NOT in CI)

```sql
-- against rust-hub.sqlite, NOT the TS DB
SELECT ledger_id, session_id, provider_kind, model, prompt_tokens, completion_tokens,
       total_tokens, fallback, created_at
FROM token_ledger
WHERE provider_kind='deepseek' AND fallback=0 AND total_tokens>0
ORDER BY created_at DESC LIMIT 5;
```

A real landing = a fresh row with `session_id=<run_id>`, `prompt_tokens>0`, `completion_tokens>0`, `fallback=0`. The TS `llm_usage_records` projection is **NOT** acceptance. The probe resolves the **enabled deepseek provider's real (UUID) id at probe time** — slice6 proved the literal `"deepseek"` is a test/RGG seed shape only; prod rows carry a UUID whose `kind==="deepseek"`.

## Tests (22 new; no network)

- DEFAULT-OFF: flag unset/non-`"true"` ⇒ job not built (`null`) ⇒ never fires; interval default + 5-min-floor clamp.
- Flag ON ⇒ job with correct id + interval; the produced body **exactly satisfies the real `qualifiesForRustReadOnlyRoute` predicate**; sends none of the disqualifiers.
- Self-mint decoded through the **real** `createFridayTokenValidator`: `principalId === "admin-001"`, short-lived (TTL enforced — rejected once expired), sessionless (no `sid`), minimal scope (`["agent.run"]`, not admin set), single-use (distinct tokenIds).
- Provider UUID resolution; probe runner with **mocked** loopback (ok / skipped / error / non-2xx / log-and-continue / bearer never in outcome).

`npm run typecheck` clean; `npm run lint` 0 errors; hub bootstrap unit + integration green (the integration test boots `createFridayHub` flag-OFF, exercising the wiring + disable guard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)