### PR TITLE
feat(a1-run-controls): on-wire agent-run RUN-CONTROL protocol (pause/resume/cancel/reject) — DARK + DEPLOY-GO-gated

### DIFF
--- a/rust-core/crates/friday-ffi/src/lib.rs
+++ b/rust-core/crates/friday-ffi/src/lib.rs
@@ -1932,6 +1932,14 @@ fn message_kind_name(m: &friday_protocol::Message) -> &'static str {
         // it cannot silently fall through a wildcard.
         M::AgentRunRequest { .. } => "AgentRunRequest",
         M::AgentRunResult { .. } => "AgentRunResult",
+        // A1 run-controls (v13) — the on-wire control protocol. DARK on the FFI surface (nothing
+        // here constructs or dispatches them); NAMED so the truth label carries the real kind and
+        // this match stays exhaustive.
+        M::AgentRunPaused { .. } => "AgentRunPaused",
+        M::AgentRunResume { .. } => "AgentRunResume",
+        M::AgentRunCancel { .. } => "AgentRunCancel",
+        M::AgentRunReject { .. } => "AgentRunReject",
+        M::AgentRunControlResult { .. } => "AgentRunControlResult",
         M::Error { .. } => "Error",
     }
 }
@@ -3387,6 +3395,7 @@ mod tests {
                 forwarded_principal: "p".into(),
                 auth_proof: vec![],
                 session_id: None,
+                constraints: None,
             },
         );
         match parse_hub_response(request.encode().unwrap()) {

--- a/rust-core/crates/friday-hub/src/agent_run_control.rs
+++ b/rust-core/crates/friday-hub/src/agent_run_control.rs
@@ -1,0 +1,466 @@
+//! A1 — the Rust agent-run RUN-CONTROL plane (DARK).
+//!
+//! The on-wire control protocol for the live agent-run: PAUSE-surfacing, RESUME
+//! (operator-signed), CANCEL, and REJECT. This module is the pure, testable LOGIC behind the
+//! `friday-protocol` v13 control variants (`AgentRunPaused` / `AgentRunResume` /
+//! `AgentRunCancel` / `AgentRunReject` / `AgentRunControlResult`). The sealed-WS server bin
+//! ([`crate::bin::hub_agent_run_server`]) does the per-connection session AUTH (decode the
+//! `auth_proof`, [`crate::hub_server::AuthedPrincipal::authenticate_forwarded`]) and then calls
+//! into THIS module with the already-authenticated principal — so the control ops are unit
+//! testable against a `&Connection` without standing up a live session.
+//!
+//! ## What it builds (and what it deliberately does NOT)
+//! * **PAUSE-surfacing** ([`detect_pause`]). When a mutating tool Pauses, the live loop already
+//!   persists a `pending_approval_request` (CSPRNG nonce + the exact tool call + the digest)
+//!   BEFORE returning — but the server only sees an [`crate::hub_server::AuthedAnswer::NoAnswer`]
+//!   and today emits `AgentRunResult{status:"no_answer"}` (the "NoAnswer black hole"). This reads
+//!   the persisted pending row back so the server can emit a truth-labeled `AgentRunPaused`
+//!   instead. It is REFS-ONLY: nonce + digest + the action verb summary, never the tool body/args.
+//! * **CANCEL** ([`cancel`]). Owner-authed terminal stop: write the out-of-vocab terminal
+//!   `agent_run.state='cancelled'` (free-form TEXT — NO migration; see
+//!   [`friday_storage::agent_run::cancel_run`]), idempotent, refusing to clobber a run that
+//!   already produced a terminal `run_result`. It does NOT interrupt a synchronous in-flight loop
+//!   mid-turn — that is cooperative cancellation in the loop body (lib.rs), a DEFERRED sub-AC.
+//! * **REJECT** ([`reject`]). Owner-authed refusal of ONE pending tool-approval: mark
+//!   `pending_approval_request.status='rejected'` (reuses the existing m0014 status column — NO
+//!   migration).
+//! * **RESUME** ([`resume`]). Delegates VERBATIM to the S6 [`crate::resume::resume_with_approval`]
+//!   spine (decode the courier's `signed_blob` → `CanonicalApproval`, verify Ed25519 under the
+//!   OPERATOR's key, consume the nonce single-use, execute the ONE approved mutation, record the
+//!   owner). It does NOT re-implement verification/execution.
+//!
+//! ## The reject/cancel ↔ resume coupling (a REAL hole this module closes locally)
+//! The S6 spine's single-use guarantee is the gate's `consumed_approval` nonce store — NOT the
+//! `pending_approval_request.status` and NOT `agent_run.state`. [`resume_with_approval`] looks the
+//! pending row up by nonce and never reads either of those. So writing `status='rejected'` (reject)
+//! or `state='cancelled'` (cancel) ALONE does not block a later correctly-signed resume of the same
+//! approval — the mutation would still execute. To make reject/cancel REAL rather than cosmetic,
+//! [`resume`] PRE-CHECKS, before delegating: it refuses if the run is cancelled OR the pending row
+//! is rejected. This is a local, fail-closed bridge. A more robust spine-level fix (burn the nonce
+//! in `consumed_approval` on reject/cancel) needs a consumed-store insert API that does not exist
+//! yet, and the SAME pre-check is also absent from the existing `hub_resume_approval` dev bridge —
+//! both are surfaced as concerns.
+//!
+//! ## Auth model (HONEST)
+//! RESUME is self-authenticating: the AUTHORITY is the operator's Ed25519 signature over the
+//! nonce+digest (the Hub holds only a verify key — it can never mint it). CANCEL and REJECT carry
+//! NO operator signature, so they are OWNER-authed: the server authenticates the forwarded
+//! principal against the sealed session, and THIS module then requires that authenticated principal
+//! to equal the run's bound owner (resolved from the pending row's `principal_id` for a paused run,
+//! else the `run_result.owner_principal` for a finished one). A non-owner / ownerless-run control
+//! op fails closed. **OPEN QUESTION (surfaced):** whether trusted-peer + owner-match is sufficient,
+//! or whether cancel/reject should ALSO require an operator signature like resume.
+//!
+//! ## Truth label
+//! `rust_wired` at best. DARK + DEPLOY-GO-gated: the server emits/handles these ONLY behind the
+//! NEW default-off `FRIDAY_AGENT_RUN_CONTROL_VIA_RUST` flag; with the flag off the server emits
+//! exactly the pre-A1 bytes (a Paused run ⇒ `AgentRunResult{status:"no_answer"}`), so deploying a
+//! v13 binary changes NO live behavior. NOT `executeRun`-replaced; NOT v1 GO.
+
+use friday_core::gate::{ApprovalDecision, CanonicalApproval, CANONICAL_GATE_ISSUER};
+use friday_crypto::OperatorVerifyingKey;
+use friday_storage::{
+    agent_run::{self, CancelOutcome},
+    audit, get_pending_request, get_run_result, set_pending_status, StorageError,
+};
+use rusqlite::Connection;
+
+use friday_protocol::AgentRunConstraintsWire;
+
+use crate::resume::{resume_with_approval, ResumeError};
+use crate::{RunPolicy, ToolExecutor};
+
+/// Map a run's bound owner + the wire-asserted per-run [`AgentRunConstraintsWire`] onto an
+/// effective [`RunPolicy`] for THIS run — the policy the loop's gate consults (read-only /
+/// disabled-tool set / max-turns). A constraint can only ever TIGHTEN a run (a restriction, never
+/// a grant): `read_only` and the `disabled_tools` set are taken VERBATIM (both are restrictions),
+/// and `max_turns` is the caller's concern of the runtime ceiling — applied by the caller as
+/// `min(runtime_default, asserted)` (this fn returns the asserted cap; the caller floors it).
+///
+/// `constraints: None` ⇒ the UNCONSTRAINED policy for `owner_principal` (read-only off, no
+/// per-run disabled tools) — i.e. the run uses the runtime's normal gate discipline. So an absent
+/// constraints block maps to exactly the pre-A1 (no per-run-override) behavior.
+///
+/// **WIRED-SHAPE, application DEFERRED on the live dispatch.** This mapping is REAL and tested,
+/// but APPLYING it requires the runtime to accept a per-run policy OVERRIDE on its dispatch entry
+/// (today `HubRuntime::run_task` builds the gate request from its OWN constructed `self.policy`).
+/// Threading a per-run policy through the live run-START path touches the just-fixed real-call
+/// path, so it is a DEFERRED sub-AC (see the PR body / concerns) — this fn is the prerequisite
+/// logic, not a half-wired live path.
+pub fn effective_run_policy(
+    owner_principal: Option<&str>,
+    constraints: Option<&AgentRunConstraintsWire>,
+) -> RunPolicy {
+    let owner = owner_principal.map(|p| p.to_string());
+    match constraints {
+        None => RunPolicy::new(owner, Vec::<String>::new(), false),
+        Some(c) => RunPolicy::new(owner, c.disabled_tools.clone(), c.read_only),
+    }
+}
+
+/// The effective per-run `max_turns`: a wire-asserted cap can only ever LOWER the runtime ceiling
+/// (never raise it). `None`/absent ⇒ the runtime default unchanged.
+pub fn effective_max_turns(runtime_default: u64, constraints: Option<&AgentRunConstraintsWire>) -> u64 {
+    match constraints.and_then(|c| c.max_turns) {
+        Some(cap) => runtime_default.min(cap),
+        None => runtime_default,
+    }
+}
+
+/// The pending-approval status string a [`reject`] writes (reuses the m0014 status column).
+pub const PENDING_STATUS_REJECTED: &str = "rejected";
+
+/// REFS-ONLY pause info read back from a persisted `pending_approval_request` so the server can
+/// emit an [`friday_protocol::Message::AgentRunPaused`]. Carries the single-use nonce + the action
+/// digest + a coarse action-verb summary — NEVER the tool body/args/params.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PauseInfo {
+    /// The single-use approval nonce the operator signs over (= `pending_approval_request.approval_id`).
+    pub nonce: String,
+    /// Hex SHA-256 of the paused action's `canonical_action_bytes` (binds principal/scope/params).
+    pub action_digest: String,
+    /// A coarse, body-free summary of WHAT paused (the action verb). Never the args/params.
+    pub summary: String,
+}
+
+/// Detect whether `run_id` is PAUSED on a pending operator approval, returning REFS-ONLY
+/// [`PauseInfo`] when it is. This is how the server discriminates the NoAnswer black hole:
+/// `NoAnswer` + a pending row for this run ⇒ the run PAUSED (emit `AgentRunPaused`); `NoAnswer`
+/// + no pending row ⇒ a genuine no-answer (emit today's `AgentRunResult{no_answer}`).
+///
+/// Picks the OLDEST `pending` request for the run (the one the loop just paused on). A row whose
+/// status is no longer `pending` (already consumed/rejected) is NOT a live pause and is skipped.
+/// Returns `None` if the run is not paused (no pending row), so the server falls through to the
+/// unchanged no-answer path.
+pub fn detect_pause(conn: &Connection, run_id: &str) -> Result<Option<PauseInfo>, StorageError> {
+    let pendings = friday_storage::list_pending_requests_for_run(conn, run_id)?;
+    // Oldest-first (the storage list is ordered by created_at); the first still-`pending` row is
+    // the live pause. A `consumed`/`rejected` row is a resolved approval, not a live pause.
+    for p in pendings {
+        if p.status == "pending" {
+            return Ok(Some(PauseInfo {
+                nonce: p.approval_id,
+                action_digest: p.action_digest,
+                summary: format!("paused on {}", p.action),
+            }));
+        }
+    }
+    Ok(None)
+}
+
+/// The coarse, body-free outcome of a control op — the data the server projects into an
+/// [`friday_protocol::Message::AgentRunControlResult`]. `accepted=false` means the op was refused
+/// fail-closed; `status` says why at a coarse grain. Never a body.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ControlOutcome {
+    /// The control op (`resume` / `cancel` / `reject`).
+    pub op: &'static str,
+    /// Whether the op was accepted (`true`) or refused fail-closed (`false`).
+    pub accepted: bool,
+    /// Coarse, body-free outcome label (closed-vocab; see the per-op fns).
+    pub status: String,
+    /// Soft link to the hash-chained audit receipt, when one was written.
+    pub audit_ref: Option<String>,
+}
+
+impl ControlOutcome {
+    fn refused(op: &'static str, status: impl Into<String>) -> Self {
+        ControlOutcome {
+            op,
+            accepted: false,
+            status: status.into(),
+            audit_ref: None,
+        }
+    }
+}
+
+/// Resolve a run's bound OWNER principal for an owner-authed control op:
+///   1. a PAUSED run's owner is the pending row's `principal_id` (set from the gate request actor);
+///   2. a FINISHED run's owner is `run_result.owner_principal`;
+///   3. otherwise (no pending row, no result, or an empty/ownerless principal) ⇒ `None`
+///      (fail-closed: an ownerless run cannot be owner-authed and every control op refuses).
+///
+/// Returns the FIRST non-empty owner found. An empty/whitespace stored principal is treated as no
+/// owner (never matched), mirroring the body-read fail-closed discipline.
+pub fn resolve_run_owner(conn: &Connection, run_id: &str) -> Result<Option<String>, StorageError> {
+    for p in friday_storage::list_pending_requests_for_run(conn, run_id)? {
+        if let Some(pid) = p.principal_id.as_deref() {
+            if !pid.trim().is_empty() {
+                return Ok(Some(pid.to_string()));
+            }
+        }
+    }
+    if let Some(result) = get_run_result(conn, run_id)? {
+        if let Some(owner) = result.owner_principal.as_deref() {
+            if !owner.trim().is_empty() {
+                return Ok(Some(owner.to_string()));
+            }
+        }
+    }
+    Ok(None)
+}
+
+/// True iff `authed_principal` (an already session-authenticated principal) is the run's bound
+/// owner. Fail-closed: an ownerless run, or a mismatch, returns `false`. An empty authed principal
+/// is never an owner.
+fn is_run_owner(
+    conn: &Connection,
+    run_id: &str,
+    authed_principal: &str,
+) -> Result<bool, StorageError> {
+    let authed = authed_principal.trim();
+    if authed.is_empty() {
+        return Ok(false);
+    }
+    Ok(resolve_run_owner(conn, run_id)?.as_deref() == Some(authed))
+}
+
+/// CANCEL a run: owner-authed terminal stop.
+///
+/// `authed_principal` MUST be a principal the server already authenticated against the sealed
+/// session (this module does NOT re-do session auth — it does the OWNER-match on top). Fail-closed
+/// outcomes (`accepted=false`):
+///   - `not_owner` — the authed principal is not the run's bound owner (or the run is ownerless);
+///   - `unknown_run` — no `agent_run` row exists;
+///   - `already_completed` — the run already produced a terminal `run_result`; cancel refuses to
+///     touch a completed run (mirrors the resume.rs refusal-to-clobber discipline).
+///
+/// Accepted outcomes (`accepted=true`): `cancelled` (state written) / `already_cancelled`
+/// (idempotent no-op). An accepted cancel writes a hash-chained audit receipt.
+pub fn cancel(
+    conn: &Connection,
+    run_id: &str,
+    authed_principal: &str,
+    reason: Option<&str>,
+    now_ms: i64,
+) -> Result<ControlOutcome, StorageError> {
+    // (1) Owner gate FIRST (before any read of completion state leaks run existence to a
+    //     non-owner): a non-owner / ownerless run is refused with no state change.
+    if !is_run_owner(conn, run_id, authed_principal)? {
+        return Ok(ControlOutcome::refused("cancel", "not_owner"));
+    }
+    // (2) Refuse to cancel a COMPLETED run — its terminal result stands; cancel must not relabel
+    //     it. (A paused/live run has no result yet.)
+    if get_run_result(conn, run_id)?.is_some() {
+        return Ok(ControlOutcome::refused("cancel", "already_completed"));
+    }
+    // (3) Write the terminal cancelled state (idempotent; fail-closed on an unknown run, though
+    //     the owner gate above already implies the row exists for a non-ownerless run).
+    match agent_run::cancel_run(conn, run_id, now_ms)? {
+        CancelOutcome::UnknownRun => Ok(ControlOutcome::refused("cancel", "unknown_run")),
+        CancelOutcome::AlreadyCancelled => Ok(ControlOutcome {
+            op: "cancel",
+            accepted: true,
+            status: "already_cancelled".to_string(),
+            audit_ref: None,
+        }),
+        CancelOutcome::Cancelled => {
+            let summary = match reason {
+                Some(r) if !r.trim().is_empty() => format!("agent_run.cancelled:{}", r.trim()),
+                _ => "agent_run.cancelled".to_string(),
+            };
+            let audit_ref = write_control_receipt(conn, run_id, "cancel", &summary, now_ms)?;
+            Ok(ControlOutcome {
+                op: "cancel",
+                accepted: true,
+                status: "cancelled".to_string(),
+                audit_ref: Some(audit_ref),
+            })
+        }
+    }
+}
+
+/// REJECT one pending tool-approval on a run: owner-authed refusal.
+///
+/// `approval_id` identifies WHICH pending mutation to refuse (= the `AgentRunPaused::nonce`). Like
+/// [`cancel`], `authed_principal` is already session-authenticated; this does the owner-match.
+/// Fail-closed outcomes: `unknown_approval` (no pending row for this approval_id), `run_mismatch`
+/// (the pending row belongs to a different run than `run_id`), `not_owner`. Accepted outcome:
+/// `rejected` (status written + audit receipt). Idempotent: re-rejecting an already-rejected row
+/// is an accepted no-op (`already_rejected`).
+pub fn reject(
+    conn: &Connection,
+    run_id: &str,
+    approval_id: &str,
+    authed_principal: &str,
+    now_ms: i64,
+) -> Result<ControlOutcome, StorageError> {
+    let Some(pending) = get_pending_request(conn, approval_id)? else {
+        return Ok(ControlOutcome::refused("reject", "unknown_approval"));
+    };
+    // The pending row must belong to the run named in the message (a proof cannot be steered to a
+    // different run's approval).
+    if pending.run_id != run_id {
+        return Ok(ControlOutcome::refused("reject", "run_mismatch"));
+    }
+    // Owner gate: the authed principal must be the pending row's bound owner.
+    let owner_ok = matches!(
+        pending.principal_id.as_deref().map(str::trim),
+        Some(p) if !p.is_empty() && p == authed_principal.trim()
+    );
+    if !owner_ok {
+        return Ok(ControlOutcome::refused("reject", "not_owner"));
+    }
+    if pending.status == PENDING_STATUS_REJECTED {
+        return Ok(ControlOutcome {
+            op: "reject",
+            accepted: true,
+            status: "already_rejected".to_string(),
+            audit_ref: None,
+        });
+    }
+    // A consumed/resolved pending row cannot be rejected (the mutation already happened / the
+    // approval already resolved) — fail-closed rather than relabel a terminal row.
+    if pending.status != "pending" {
+        return Ok(ControlOutcome::refused("reject", "not_pending"));
+    }
+    set_pending_status(conn, approval_id, PENDING_STATUS_REJECTED)?;
+    let audit_ref = write_control_receipt(
+        conn,
+        run_id,
+        "reject",
+        &format!("pending_approval.rejected:{}", pending.action),
+        now_ms,
+    )?;
+    Ok(ControlOutcome {
+        op: "reject",
+        accepted: true,
+        status: "rejected".to_string(),
+        audit_ref: Some(audit_ref),
+    })
+}
+
+/// The operator-signed approval JSON the S6c CLI emits, carried as the courier's `signed_blob`.
+/// Mirrors `hub_resume_approval::SignedApprovalIn` (the existing dev-bridge decode) so the wire
+/// blob and the CLI output are the same shape. Unknown fields tolerated.
+#[derive(Debug, serde::Deserialize)]
+struct SignedApprovalIn {
+    decision: String,
+    approval_id: String,
+    action_digest: String,
+    expires_at: i64,
+    #[serde(default)]
+    issuer: Option<String>,
+    signature: String,
+}
+
+fn parse_decision(s: &str) -> Option<ApprovalDecision> {
+    match s {
+        "approved" => Some(ApprovalDecision::Approved),
+        "denied" => Some(ApprovalDecision::Denied),
+        _ => None,
+    }
+}
+
+/// RESUME a paused run from the operator's out-of-band signed approval (the courier's `signed_blob`).
+///
+/// The server decodes nothing; THIS fn decodes the blob → `CanonicalApproval` and delegates to the
+/// S6 [`resume_with_approval`] spine (verify Ed25519 under `operator_vk`, consume the nonce
+/// single-use, execute the ONE approved mutation, record the owner). It NEVER re-implements
+/// verification/execution.
+///
+/// **The reject/cancel coupling (REAL, not cosmetic).** BEFORE delegating, this PRE-CHECKS the run
+/// is not cancelled and the targeted pending row is not rejected — because the spine's single-use
+/// guard is the `consumed_approval` store, not `agent_run.state`/`pending.status`, so without this
+/// check a correctly-signed resume would still execute a rejected/cancelled run's mutation.
+/// Fail-closed outcomes: `malformed_blob`, `run_cancelled`, `approval_rejected`, and the bounded
+/// resume-error tokens. Accepted maps the gate decision: `mutation_completed` (executed) /
+/// `mutation_exec_failed` / `approval_refused` (gate Deny — replay/expired/bad-signature).
+pub fn resume(
+    conn: &Connection,
+    executor: &dyn ToolExecutor,
+    operator_vk: &OperatorVerifyingKey,
+    run_id: &str,
+    signed_blob: &[u8],
+    now_ms: i64,
+) -> Result<ControlOutcome, StorageError> {
+    // (1) Decode the courier blob (JSON of a SignedApproval). Malformed ⇒ fail-closed.
+    let signed: SignedApprovalIn = match std::str::from_utf8(signed_blob)
+        .ok()
+        .and_then(|s| serde_json::from_str(s.trim()).ok())
+    {
+        Some(s) => s,
+        None => return Ok(ControlOutcome::refused("resume", "malformed_blob")),
+    };
+    let Some(decision) = parse_decision(&signed.decision) else {
+        return Ok(ControlOutcome::refused("resume", "malformed_blob"));
+    };
+    let approval = CanonicalApproval {
+        decision,
+        approval_id: signed.approval_id.clone(),
+        action_digest: signed.action_digest.clone(),
+        expires_at: Some(signed.expires_at),
+        issuer: Some(
+            signed
+                .issuer
+                .clone()
+                .unwrap_or_else(|| CANONICAL_GATE_ISSUER.to_string()),
+        ),
+        signature: Some(signed.signature.clone()),
+    };
+
+    // (2) THE REJECT/CANCEL COUPLING. The spine does not read run/pending state, so enforce it
+    //     here: a cancelled run, or a rejected pending row, refuses the resume BEFORE the spine can
+    //     consume the nonce + execute. Fail-closed.
+    if agent_run::is_cancelled(conn, run_id)? {
+        return Ok(ControlOutcome::refused("resume", "run_cancelled"));
+    }
+    if let Some(pending) = get_pending_request(conn, &approval.approval_id)? {
+        if pending.status == PENDING_STATUS_REJECTED {
+            return Ok(ControlOutcome::refused("resume", "approval_rejected"));
+        }
+    }
+
+    // (3) Delegate VERBATIM to the S6 spine.
+    match resume_with_approval(conn, executor, operator_vk, &approval, now_ms) {
+        Ok(outcome) => Ok(ControlOutcome {
+            op: "resume",
+            // The spine PROCESSED it; `executed` reflects whether the mutation ran. A gate Deny
+            // (replay/expired/bad-signature) is a PROCESSED refusal — accepted=false at the wire
+            // (the control op did not effect a mutation), with the spine's coarse status.
+            accepted: outcome.executed,
+            status: outcome.result_status,
+            audit_ref: outcome.audit_ref,
+        }),
+        Err(e) => Ok(ControlOutcome::refused("resume", resume_error_kind(&e))),
+    }
+}
+
+/// Map a [`ResumeError`] to ONE bounded, refs-only category token (never embeds detail).
+fn resume_error_kind(err: &ResumeError) -> &'static str {
+    match err {
+        ResumeError::UnknownNonce => "unknown_nonce",
+        ResumeError::NoToolCall => "no_tool_call",
+        ResumeError::Unregistered(_) => "unregistered_tool",
+        ResumeError::DigestMismatch => "digest_mismatch",
+        ResumeError::Storage(_) => "storage_failed",
+    }
+}
+
+/// Write the event-log line + the hash-chained audit receipt for a control op in ONE transaction
+/// (the event log can never get ahead of the ledger on a partial commit) — mirrors
+/// [`crate::resume`]'s `write_receipt`. Returns the receipt id (the soft audit ref). A per-op
+/// CSPRNG tag keys the ids so repeated ops on the same run never PK-collide.
+fn write_control_receipt(
+    conn: &Connection,
+    run_id: &str,
+    op: &str,
+    summary: &str,
+    now_ms: i64,
+) -> Result<String, StorageError> {
+    let tag = friday_crypto::generate_approval_nonce();
+    let event_id = format!("{run_id}:control:{op}:{tag}:event");
+    let receipt_id = format!("{run_id}:control:{op}:{tag}:receipt");
+    let tx = conn.unchecked_transaction()?;
+    agent_run::record_event(&tx, &event_id, run_id, summary, now_ms)?;
+    audit::append_audit(
+        &tx,
+        &receipt_id,
+        "agent-run-control",
+        summary,
+        Some(run_id),
+        now_ms,
+    )?;
+    tx.commit()?;
+    Ok(receipt_id)
+}

--- a/rust-core/crates/friday-hub/src/agent_run_control.rs
+++ b/rust-core/crates/friday-hub/src/agent_run_control.rs
@@ -100,7 +100,10 @@ pub fn effective_run_policy(
 
 /// The effective per-run `max_turns`: a wire-asserted cap can only ever LOWER the runtime ceiling
 /// (never raise it). `None`/absent ⇒ the runtime default unchanged.
-pub fn effective_max_turns(runtime_default: u64, constraints: Option<&AgentRunConstraintsWire>) -> u64 {
+pub fn effective_max_turns(
+    runtime_default: u64,
+    constraints: Option<&AgentRunConstraintsWire>,
+) -> u64 {
     match constraints.and_then(|c| c.max_turns) {
         Some(cap) => runtime_default.min(cap),
         None => runtime_default,

--- a/rust-core/crates/friday-hub/src/bin/hub_agent_run_server.rs
+++ b/rust-core/crates/friday-hub/src/bin/hub_agent_run_server.rs
@@ -488,12 +488,34 @@ fn run() -> Result<(), ServerError> {
         );
     }
 
+    // (A1 run-controls) Read the run-control flag ONCE at boot (default-off). When false the
+    // server emits/handles EXACTLY the pre-A1 wire (a paused run ⇒ `AgentRunResult{no_answer}`;
+    // a control message ⇒ benign keepalive echo), so deploying a v13 binary changes NO live
+    // behavior until the operator flips this SEPARATE flag.
+    let run_control_enabled =
+        agent_run_control_enabled_from(env::var(AGENT_RUN_CONTROL_ENABLED_ENV).ok().as_deref());
+    if run_control_enabled {
+        eprintln!(
+            "hub_agent_run_server: on-wire run-CONTROL plane ENABLED (FRIDAY_AGENT_RUN_CONTROL_VIA_RUST)"
+        );
+    } else {
+        eprintln!(
+            "hub_agent_run_server: on-wire run-CONTROL plane DISABLED (set FRIDAY_AGENT_RUN_CONTROL_VIA_RUST=1 to enable)"
+        );
+    }
+
     // (3) Long-lived accept loop. Each accepted connection: set the read timeout, read the peer
     // pubkey preamble, REJECT a non-allowlisted peer pubkey (S-F, the FIRST gate), reject low-order
     // points, run the WS handshake, derive the sealed session key, and serve sealed envelopes
     // fail-closed — dispatching authed agent-runs.
     loop {
-        match listener.accept_one(&server_kp, &runtime, &owner_allowlist, &peer_allowlist) {
+        match listener.accept_one(
+            &server_kp,
+            &runtime,
+            &owner_allowlist,
+            &peer_allowlist,
+            run_control_enabled,
+        ) {
             Ok(_served) => {}
             // A connection-level error ends THAT connection only; the server keeps listening.
             Err(_e) => continue,
@@ -509,6 +531,26 @@ const SESSION_REAPER_ENABLED_ENV: &str = "FRIDAY_RUST_SESSION_REAPER_ENABLED";
 
 /// The reaper sweep cadence (120s), matching the old TS sweep's interval.
 const SESSION_REAPER_INTERVAL: Duration = Duration::from_secs(120);
+
+/// (A1 run-controls) The env flag that gates the on-wire RUN-CONTROL protocol. DEFAULT-OFF: the
+/// server emits `AgentRunPaused` (instead of the pre-A1 `AgentRunResult{no_answer}` for a paused
+/// run) and handles `AgentRunResume`/`AgentRunCancel`/`AgentRunReject` ONLY when
+/// `FRIDAY_AGENT_RUN_CONTROL_VIA_RUST` is exactly `"1"`/`"true"` (case-insensitive). Unset — or any
+/// other value — leaves the control plane DARK: a paused run emits EXACTLY the pre-A1
+/// `AgentRunResult{status:"no_answer"}` bytes, and a control message is treated as a benign
+/// keepalive (echoed), so deploying a v13 binary changes NO live behavior. SEPARATE from
+/// `FRIDAY_ROUTE_AGENT_RUN_VIA_RUST` (the run-START flag) — flipping THIS one is the run-CONTROL
+/// live-flip, an operator DEPLOY-GO decision.
+const AGENT_RUN_CONTROL_ENABLED_ENV: &str = "FRIDAY_AGENT_RUN_CONTROL_VIA_RUST";
+
+/// Whether the operator has explicitly enabled the on-wire run-control plane. Fail-closed: only
+/// the exact opt-in values enable it; everything else (including unset) is OFF.
+fn agent_run_control_enabled_from(raw: Option<&str>) -> bool {
+    matches!(
+        raw.map(|v| v.trim().to_ascii_lowercase()).as_deref(),
+        Some("1") | Some("true")
+    )
+}
 
 /// Whether the operator has explicitly enabled the session-lifecycle reaper. Fail-closed:
 /// only the exact opt-in values enable it; everything else (including unset) is OFF.
@@ -610,6 +652,7 @@ impl AgentRunWsListener {
         runtime: &HubRuntime<T>,
         owner_allowlist: &[String],
         peer_allowlist: &[[u8; X25519_PUBKEY_LEN]],
+        run_control_enabled: bool,
     ) -> Result<usize, TransportError> {
         let (stream, _peer) = self.listener.accept()?;
         // HARDENING: a per-connection read timeout BEFORE any read, so a stalled peer cannot
@@ -623,6 +666,7 @@ impl AgentRunWsListener {
             &session_nonce,
             runtime,
             owner_allowlist,
+            run_control_enabled,
         )
     }
 }
@@ -739,6 +783,7 @@ fn serve_sealed_session<S: Read + Write, T: Transport>(
     session_nonce: &[u8],
     runtime: &HubRuntime<T>,
     owner_allowlist: &[String],
+    run_control_enabled: bool,
 ) -> Result<usize, TransportError> {
     let mut processed = 0usize;
     // S-E: per-session msg_id dedup. A reconnect mints a FRESH tracker (so it is not a
@@ -764,6 +809,16 @@ fn serve_sealed_session<S: Read + Write, T: Transport>(
                 forwarded_principal,
                 auth_proof,
                 session_id,
+                // (A1 run-controls) The per-run CONSTRAINTS the peer asserts. The wire SHAPE +
+                // the pure mapping onto a per-run `RunPolicy`
+                // ([`friday_hub::agent_run_control::effective_run_policy`]) are built + tested,
+                // but APPLYING them on the live dispatch requires the runtime to accept a per-run
+                // policy OVERRIDE (today `run_task` uses its OWN constructed `self.policy`).
+                // Threading that through the just-fixed live run-START path is a DEFERRED sub-AC
+                // (see the PR body) — so this slice does NOT apply the constraints on dispatch.
+                // `_constraints` is captured (not `..`) so the destructure stays exhaustive and a
+                // future field addition is a compile error, not a silent drop.
+                constraints: _constraints,
             } => {
                 // The dispatch arm: AUTH BEFORE ANY RUN. The `auth_proof` is the peer-sealed
                 // challenge; reconstruct it as a `Sealed` for the session-key open. A malformed
@@ -834,21 +889,59 @@ fn serve_sealed_session<S: Read + Write, T: Transport>(
                     "hub_agent_run_server_dispatch: run_id={run_id} leg=refs status={} has_body={has_body}",
                     refs.status
                 );
-                let result = Envelope::new(
-                    format!("agent-run-result-{run_id}"),
-                    now_ms,
-                    Message::AgentRunResult {
-                        run_id: run_id.clone(),
-                        status: refs.status,
-                        answer_sha256: refs.answer_sha256,
-                        answer_len: refs.answer_len,
-                        turns: refs.turns,
-                        executed_tools: refs.executed_tools,
-                        prompt_tokens: None,
-                        completion_tokens: None,
-                    },
-                )
-                .with_correlation(env.msg_id.clone());
+                // (A1 run-controls) PAUSE-SURFACING — discriminate the NoAnswer black hole. When
+                // the run produced NO body, it is EITHER a genuine no-answer OR a PAUSE (the loop
+                // persisted a `pending_approval_request` before returning, and the server only
+                // sees `NoAnswer`). FLAG-GATED + DARK: only when the run-control flag is ON do we
+                // probe the DB for a live pending row and, if found, emit `AgentRunPaused` instead
+                // of `AgentRunResult{no_answer}`. With the flag OFF this branch is never taken, so
+                // a paused run emits EXACTLY the pre-A1 `AgentRunResult{status:"no_answer"}` bytes
+                // (the deploy-safety invariant). The pause frame is REFS-ONLY (nonce + digest +
+                // action-verb summary — never the tool body/args).
+                let result = if run_control_enabled && !has_body {
+                    match friday_hub::agent_run_control::detect_pause(runtime.db().conn(), &run_id)
+                    {
+                        Ok(Some(pause)) => {
+                            eprintln!(
+                                "hub_agent_run_server_dispatch: run_id={run_id} leg=paused (run-control enabled)"
+                            );
+                            Some(Envelope::new(
+                                format!("agent-run-paused-{run_id}"),
+                                now_ms,
+                                Message::AgentRunPaused {
+                                    run_id: run_id.clone(),
+                                    nonce: pause.nonce,
+                                    action_digest: pause.action_digest,
+                                    summary: pause.summary,
+                                },
+                            ))
+                        }
+                        // No live pending row (genuine no-answer) ⇒ fall through to the unchanged
+                        // refs result. A DB probe error is non-fatal: fail SAFE to the pre-A1 path
+                        // (never panic, never fabricate a pause).
+                        _ => None,
+                    }
+                } else {
+                    None
+                };
+                let result = result
+                    .unwrap_or_else(|| {
+                        Envelope::new(
+                            format!("agent-run-result-{run_id}"),
+                            now_ms,
+                            Message::AgentRunResult {
+                                run_id: run_id.clone(),
+                                status: refs.status,
+                                answer_sha256: refs.answer_sha256,
+                                answer_len: refs.answer_len,
+                                turns: refs.turns,
+                                executed_tools: refs.executed_tools,
+                                prompt_tokens: None,
+                                completion_tokens: None,
+                            },
+                        )
+                    })
+                    .with_correlation(env.msg_id.clone());
                 if let Err(err) = ws_send_envelope(ws, session_key, &result, SESSION_AAD) {
                     // The refs frame could not be sent (transport closed). Log which leg
                     // failed (run_id + leg) before ending the session — this is the leg-A
@@ -897,8 +990,134 @@ fn serve_sealed_session<S: Read + Write, T: Transport>(
                 }
                 processed += 1;
             }
+            // (A1 run-controls) RESUME — relay an operator's signed approval to the S6 spine.
+            // FLAG-GATED: when the flag is OFF this is a benign keepalive (echoed), so deploying a
+            // v13 binary changes no behavior; only when ON do we verify+execute. Resume is
+            // SELF-authenticating (the operator's Ed25519 signature is the authority); it uses the
+            // runtime's verify key + executor and pre-checks the reject/cancel coupling.
+            Message::AgentRunResume {
+                ref run_id,
+                ref signed_blob,
+            } if run_control_enabled => {
+                let now_ms = now_ms();
+                let outcome = match runtime.operator_vk() {
+                    Some(vk) => friday_hub::agent_run_control::resume(
+                        runtime.db().conn(),
+                        runtime.executor(),
+                        vk,
+                        run_id,
+                        signed_blob,
+                        now_ms,
+                    )
+                    .unwrap_or_else(|_| {
+                        // A storage error is a fail-closed refusal (never a panic / partial).
+                        friday_hub::agent_run_control::ControlOutcome {
+                            op: "resume",
+                            accepted: false,
+                            status: "storage_failed".to_string(),
+                            audit_ref: None,
+                        }
+                    }),
+                    // No operator key provisioned ⇒ cannot verify ⇒ fail-closed refusal.
+                    None => friday_hub::agent_run_control::ControlOutcome {
+                        op: "resume",
+                        accepted: false,
+                        status: "operator_vk_unprovisioned".to_string(),
+                        audit_ref: None,
+                    },
+                };
+                send_control_result(ws, session_key, &env.msg_id, run_id, &outcome, now_ms)?;
+                processed += 1;
+            }
+            // (A1 run-controls) CANCEL — owner-authed terminal stop. FLAG-GATED (keepalive when
+            // off). The forwarded principal is authenticated against the sealed session (the SAME
+            // possession proof an AgentRunRequest carries, bound to this run_id), then the control
+            // module requires that authenticated principal == the run's bound owner.
+            Message::AgentRunCancel {
+                ref run_id,
+                ref forwarded_principal,
+                ref auth_proof,
+                ref reason,
+            } if run_control_enabled => {
+                let now_ms = now_ms();
+                let outcome = match authenticate_control_caller(
+                    session_key,
+                    session_nonce,
+                    owner_allowlist,
+                    auth_proof,
+                    run_id,
+                    forwarded_principal,
+                ) {
+                    Some(caller) => friday_hub::agent_run_control::cancel(
+                        runtime.db().conn(),
+                        run_id,
+                        caller.principal(),
+                        reason.as_deref(),
+                        now_ms,
+                    )
+                    .unwrap_or_else(|_| friday_hub::agent_run_control::ControlOutcome {
+                        op: "cancel",
+                        accepted: false,
+                        status: "storage_failed".to_string(),
+                        audit_ref: None,
+                    }),
+                    // Session auth failed (forged / non-allowlisted / un-openable proof) ⇒
+                    // fail-closed refusal. We do NOT end the session (a control op is not a
+                    // dispatch); we answer the refusal and keep serving.
+                    None => friday_hub::agent_run_control::ControlOutcome {
+                        op: "cancel",
+                        accepted: false,
+                        status: "auth_failed".to_string(),
+                        audit_ref: None,
+                    },
+                };
+                send_control_result(ws, session_key, &env.msg_id, run_id, &outcome, now_ms)?;
+                processed += 1;
+            }
+            // (A1 run-controls) REJECT — owner-authed refusal of ONE pending tool-approval.
+            // FLAG-GATED (keepalive when off). Same owner-auth as cancel.
+            Message::AgentRunReject {
+                ref run_id,
+                ref approval_id,
+                ref forwarded_principal,
+                ref auth_proof,
+            } if run_control_enabled => {
+                let now_ms = now_ms();
+                let outcome = match authenticate_control_caller(
+                    session_key,
+                    session_nonce,
+                    owner_allowlist,
+                    auth_proof,
+                    run_id,
+                    forwarded_principal,
+                ) {
+                    Some(caller) => friday_hub::agent_run_control::reject(
+                        runtime.db().conn(),
+                        run_id,
+                        approval_id,
+                        caller.principal(),
+                        now_ms,
+                    )
+                    .unwrap_or_else(|_| friday_hub::agent_run_control::ControlOutcome {
+                        op: "reject",
+                        accepted: false,
+                        status: "storage_failed".to_string(),
+                        audit_ref: None,
+                    }),
+                    None => friday_hub::agent_run_control::ControlOutcome {
+                        op: "reject",
+                        accepted: false,
+                        status: "auth_failed".to_string(),
+                        audit_ref: None,
+                    },
+                };
+                send_control_result(ws, session_key, &env.msg_id, run_id, &outcome, now_ms)?;
+                processed += 1;
+            }
             // Benign keepalive (S-B behaviour): echo the opened envelope back, sealed under the
-            // SAME session key, correlated to the request. NO dispatch.
+            // SAME session key, correlated to the request. NO dispatch. This is ALSO where a
+            // control message lands when the run-control flag is OFF (the guards above are not
+            // met), so a v13 control message on a DARK server is a harmless echo — no handling.
             _ => {
                 let reply = Envelope::new(env.msg_id.clone(), env.sent_at, env.message)
                     .with_correlation(env.msg_id.clone());
@@ -915,6 +1134,65 @@ fn now_ms() -> i64 {
         .duration_since(UNIX_EPOCH)
         .map(|d| d.as_millis() as i64)
         .unwrap_or(0)
+}
+
+/// (A1 run-controls) Authenticate an owner-authed control op's forwarded principal against the
+/// sealed session — the SAME possession-of-session + nonce-bound-challenge + owner-allowlist chain
+/// the `AgentRunRequest` dispatch arm uses, bound to THIS control op's `run_id`. Returns the bound
+/// principal on success, `None` (fail-closed) on any failure (un-openable proof / forged / empty /
+/// anonymous / non-allowlisted). The caller then matches this principal to the run's bound owner.
+fn authenticate_control_caller(
+    session_key: &DataKey,
+    session_nonce: &[u8],
+    owner_allowlist: &[String],
+    auth_proof: &[u8],
+    run_id: &str,
+    forwarded_principal: &str,
+) -> Option<AuthedPrincipal> {
+    decode_sealed_proof(auth_proof).and_then(|proof| {
+        AuthedPrincipal::authenticate_forwarded(
+            session_key,
+            SESSION_AAD,
+            AUTH_CHALLENGE,
+            ForwardedAuth {
+                auth_proof: &proof,
+                session_nonce,
+                run_id,
+                forwarded_principal,
+            },
+            owner_allowlist,
+        )
+    })
+}
+
+/// (A1 run-controls) Send the REFS-ONLY [`Message::AgentRunControlResult`] receipt for a control
+/// op, sealed under the session and correlated to the request. Never a body — only the coarse
+/// op/accepted/status + a soft audit ref.
+fn send_control_result<S: Read + Write>(
+    ws: &mut WireWebSocket<S>,
+    session_key: &DataKey,
+    correlation_msg_id: &str,
+    run_id: &str,
+    outcome: &friday_hub::agent_run_control::ControlOutcome,
+    now_ms: i64,
+) -> Result<(), TransportError> {
+    eprintln!(
+        "hub_agent_run_server_control: run_id={run_id} op={} accepted={} status={}",
+        outcome.op, outcome.accepted, outcome.status
+    );
+    let result = Envelope::new(
+        format!("agent-run-control-result-{run_id}"),
+        now_ms,
+        Message::AgentRunControlResult {
+            run_id: run_id.to_string(),
+            op: outcome.op.to_string(),
+            accepted: outcome.accepted,
+            status: outcome.status.clone(),
+            audit_ref: outcome.audit_ref.clone(),
+        },
+    )
+    .with_correlation(correlation_msg_id.to_string());
+    ws_send_envelope(ws, session_key, &result, SESSION_AAD)
 }
 
 /// The REFS-ONLY terminal projection of a dispatch outcome: status + answer sha256/len +
@@ -1186,6 +1464,7 @@ mod tests {
                 forwarded_principal: principal.to_string(),
                 auth_proof: auth_proof_bytes(client_session, session_nonce, principal, run_id),
                 session_id: None,
+                constraints: None,
             },
         )
     }
@@ -1210,6 +1489,7 @@ mod tests {
                 forwarded_principal: principal.to_string(),
                 auth_proof: auth_proof_bytes(client_session, session_nonce, principal, run_id),
                 session_id: Some(session_id.to_string()),
+                constraints: None,
             },
         )
     }
@@ -1326,7 +1606,7 @@ mod tests {
 
         // SERVER on the main thread (holds the non-Send runtime).
         let processed = listener
-            .accept_one(&server_kp, &rt, &allowlist, &peer_allowlist)
+            .accept_one(&server_kp, &rt, &allowlist, &peer_allowlist, false)
             .unwrap();
         assert_eq!(processed, 1, "one authed dispatch processed");
 
@@ -1364,6 +1644,164 @@ mod tests {
         assert_eq!(opened, BODY.as_bytes(), "owner opens the sealed body");
     }
 
+    /// A MOCK transport that PROPOSES a mutating tool call (write_file) every turn. With the
+    /// runtime's `operator_vk: None` (DenyAll), the gate's `RequiresApproval` is never upgraded ⇒
+    /// the loop PAUSES and persists a `pending_approval_request` before returning the body-free
+    /// NoAnswer. Used by the deploy-safety pause-surfacing tests.
+    struct PauseTransport;
+    impl Transport for PauseTransport {
+        fn get_json(&self, _u: &str, _b: &str) -> Result<Value, DeepSeekError> {
+            Ok(json!({"data":[{"id":"deepseek-v4-flash"}]}))
+        }
+        fn post_json(&self, _u: &str, _b: &str, _body: &Value) -> Result<Value, DeepSeekError> {
+            // Propose a mutating write_file tool call (the gate Pauses it under DenyAll).
+            let content = r#"{"tool":"write_file","path":"out.txt","content":"X"}"#;
+            Ok(json!({
+                "model":"deepseek-v4-flash",
+                "choices":[{"message":{"content":content},"finish_reason":"stop"}],
+                "usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}
+            }))
+        }
+    }
+
+    /// Build a MOCK-transport runtime whose loop PAUSES on a mutating tool (operator_vk: None).
+    fn pausing_runtime(tag: &str, principal: &str) -> (HubRuntime<PauseTransport>, TempWs) {
+        let ws = TempWs::new(tag);
+        let client = DeepSeekClient::with_transport(PauseTransport, "k".into()); // pragma: allowlist secret
+        let agent = DeepSeekAgentLlmClient::new(client);
+        let rt = HubRuntime::new(
+            HubConfig {
+                db_path: std::env::temp_dir()
+                    .join(format!(
+                        "friday-execrun-pause-{}-{}-{}.sqlite",
+                        std::process::id(),
+                        tag,
+                        C.fetch_add(1, Ordering::Relaxed)
+                    ))
+                    .to_string_lossy()
+                    .into_owned(),
+                workspace_root: ws.0.clone(),
+                secret: b"execrun-pause-test-secret-0123456789".to_vec(), // pragma: allowlist secret
+                max_turns: 4,
+                principal_id: Some(principal.to_string()),
+                disabled_tools: vec![],
+                read_only: false,
+                operator_vk: None, // DenyAll ⇒ a mutating tool Pauses (never upgraded)
+            },
+            agent,
+            Box::new(DenyAllApprovals),
+        )
+        .unwrap();
+        (rt, ws)
+    }
+
+    /// Run ONE authed dispatch against a PAUSING runtime with the run-control flag set to
+    /// `run_control_enabled`, returning the client's first observed reply message.
+    fn dispatch_pausing_with_flag(tag: &str, run_control_enabled: bool) -> Message {
+        let (rt, _ws) = pausing_runtime(tag, OWNER);
+        let server_kp = DeviceKeypair::generate();
+        let listener = AgentRunWsListener::bind_loopback(0).unwrap();
+        let addr = listener.local_addr().unwrap();
+        let allowlist = vec![OWNER.to_string()];
+        let client_kp = DeviceKeypair::generate();
+        let peer_allowlist = allowlist_of(client_kp.public_bytes());
+        let client = spawn_client(addr, client_kp, |session, nonce| {
+            let req = agent_run_request("req-pause", "run-pause-1", OWNER, session, nonce);
+            (req, session.clone(), session.clone())
+        });
+        let processed = listener
+            .accept_one(
+                &server_kp,
+                &rt,
+                &allowlist,
+                &peer_allowlist,
+                run_control_enabled,
+            )
+            .unwrap();
+        assert_eq!(processed, 1, "[{tag}] the paused dispatch is processed");
+        client.join().unwrap().result.expect("a reply is sent")
+    }
+
+    /// DEPLOY-SAFETY (the load-bearing test): with the run-control flag OFF, a PAUSED run emits
+    /// EXACTLY the pre-A1 `AgentRunResult{status:"no_answer"}` — byte-for-byte the current live
+    /// behavior, so deploying a v13 binary changes nothing. With the flag ON, the SAME paused run
+    /// emits `AgentRunPaused` (refs-only: nonce + digest + summary) instead. ONE test, BOTH legs.
+    #[test]
+    fn paused_run_emits_no_answer_when_flag_off_and_paused_when_on() {
+        // FLAG OFF ⇒ pre-A1 no_answer result (unchanged live behavior). The exact pre-A1 status
+        // for a paused/no-body run is `no_answer_safe_failure` (the `AuthedAnswer::NoAnswer`
+        // projection) — this is the byte-for-byte current behavior that must be preserved.
+        match dispatch_pausing_with_flag("pause-off", false) {
+            Message::AgentRunResult { run_id, status, .. } => {
+                assert_eq!(run_id, "run-pause-1");
+                assert_eq!(
+                    status, "no_answer_safe_failure",
+                    "flag OFF: a paused run MUST emit the pre-A1 no_answer result (deploy-safe)"
+                );
+            }
+            other => panic!("flag OFF must emit AgentRunResult, got {other:?}"),
+        }
+
+        // FLAG ON ⇒ AgentRunPaused with refs-only pause info.
+        match dispatch_pausing_with_flag("pause-on", true) {
+            Message::AgentRunPaused {
+                run_id,
+                nonce,
+                action_digest,
+                summary,
+            } => {
+                assert_eq!(run_id, "run-pause-1");
+                assert_eq!(nonce.len(), 64, "the CSPRNG approval nonce is surfaced");
+                assert_eq!(action_digest.len(), 64);
+                assert!(
+                    summary.contains("write_file"),
+                    "the action-verb summary is surfaced (refs-only)"
+                );
+                // CANARY: the pause frame never carries the tool body/args.
+                let frame = format!("{run_id}{nonce}{action_digest}{summary}");
+                assert!(!frame.contains("\"content\""), "pause leaked tool params");
+            }
+            other => panic!("flag ON must emit AgentRunPaused, got {other:?}"),
+        }
+    }
+
+    /// DARK-when-OFF for control MESSAGES: a control message (e.g. AgentRunCancel) arriving with
+    /// the run-control flag OFF is treated as a benign keepalive (echoed back), NOT handled — so a
+    /// v13 control message on a dark server effects no state change. (Flag-ON handling is covered
+    /// by the `agent_run_control` unit suite in tests/a1_run_control.rs.)
+    #[test]
+    fn control_message_is_keepalive_echo_when_flag_off() {
+        let (rt, _ws) = mock_runtime("ctl-off", OWNER);
+        let server_kp = DeviceKeypair::generate();
+        let listener = AgentRunWsListener::bind_loopback(0).unwrap();
+        let addr = listener.local_addr().unwrap();
+        let allowlist = vec![OWNER.to_string()];
+        let client_kp = DeviceKeypair::generate();
+        let peer_allowlist = allowlist_of(client_kp.public_bytes());
+        let client = spawn_client(addr, client_kp, |session, _nonce| {
+            let req = Envelope::new(
+                "req-cancel",
+                1000,
+                Message::AgentRunCancel {
+                    run_id: "run-x".into(),
+                    forwarded_principal: OWNER.into(),
+                    auth_proof: vec![1, 2, 3],
+                    reason: None,
+                },
+            );
+            (req, session.clone(), session.clone())
+        });
+        let processed = listener
+            .accept_one(&server_kp, &rt, &allowlist, &peer_allowlist, false)
+            .unwrap();
+        assert_eq!(processed, 1, "the control message is processed as a keepalive");
+        // The flag is OFF ⇒ the message is ECHOED verbatim (keepalive), NOT a control result.
+        match client.join().unwrap().result.expect("an echo reply") {
+            Message::AgentRunCancel { run_id, .. } => assert_eq!(run_id, "run-x"),
+            other => panic!("flag OFF must echo the control message, got {other:?}"),
+        }
+    }
+
     // (b) THE PRECONDITION: a correct-handshake peer (real session key) with a NON-ALLOWLISTED /
     // forged / empty / anonymous forwarded principal is REJECTED — NO run, NO body. A session key
     // is NOT authorization.
@@ -1385,7 +1823,7 @@ mod tests {
         });
 
         let processed = listener
-            .accept_one(&server_kp, &rt, &allowlist, &peer_allowlist)
+            .accept_one(&server_kp, &rt, &allowlist, &peer_allowlist, false)
             .unwrap();
         assert_eq!(processed, 0, "[{tag}] rejected dispatch processes ZERO");
 
@@ -1417,6 +1855,35 @@ mod tests {
             "padded true ⇒ enabled"
         );
         assert!(reaper_enabled_from(Some(" 1 ")), "padded 1 ⇒ enabled");
+    }
+
+    #[test]
+    fn agent_run_control_flag_is_default_off_and_fail_closed() {
+        // The on-wire run-control plane is DEFAULT-OFF: unset ⇒ disabled (deploy-safe). Only the
+        // exact opt-in values enable it; everything else is OFF.
+        assert!(
+            !agent_run_control_enabled_from(None),
+            "unset ⇒ disabled (default-off, deploy-safe)"
+        );
+        assert!(!agent_run_control_enabled_from(Some("")), "empty ⇒ disabled");
+        assert!(!agent_run_control_enabled_from(Some("0")), "0 ⇒ disabled");
+        assert!(
+            !agent_run_control_enabled_from(Some("false")),
+            "false ⇒ disabled"
+        );
+        assert!(
+            !agent_run_control_enabled_from(Some("on")),
+            "garbage ⇒ disabled"
+        );
+        assert!(agent_run_control_enabled_from(Some("1")), "1 ⇒ enabled");
+        assert!(
+            agent_run_control_enabled_from(Some("true")),
+            "true ⇒ enabled"
+        );
+        assert!(
+            agent_run_control_enabled_from(Some("  TRUE  ")),
+            "padded TRUE ⇒ enabled"
+        );
     }
 
     #[test]
@@ -1466,13 +1933,14 @@ mod tests {
                     forwarded_principal: OWNER.to_string(),
                     auth_proof: bad_proof,
                     session_id: None,
+                    constraints: None,
                 },
             );
             (req, session.clone(), session.clone())
         });
 
         let processed = listener
-            .accept_one(&server_kp, &rt, &allowlist, &peer_allowlist)
+            .accept_one(&server_kp, &rt, &allowlist, &peer_allowlist, false)
             .unwrap();
         assert_eq!(
             processed, 0,
@@ -1507,7 +1975,7 @@ mod tests {
         });
 
         let processed = listener
-            .accept_one(&server_kp, &rt, &allowlist, &peer_allowlist)
+            .accept_one(&server_kp, &rt, &allowlist, &peer_allowlist, false)
             .unwrap();
         assert_eq!(
             processed, 0,
@@ -1542,7 +2010,7 @@ mod tests {
             drop(stream);
         });
         // accept_one runs the REAL production path; a low-order key must make it return Err.
-        let outcome = listener.accept_one(&server_kp, &rt, &allowlist, &peer_allowlist);
+        let outcome = listener.accept_one(&server_kp, &rt, &allowlist, &peer_allowlist, false);
         client.join().unwrap();
         assert!(
             outcome.is_err(),
@@ -1812,6 +2280,7 @@ mod tests {
                     forwarded_principal: OWNER.to_string(),
                     auth_proof: proof,
                     session_id: None,
+                    constraints: None,
                 },
             );
             ws_send_envelope(&mut ws, &sess_c1, &req, SESSION_AAD).unwrap();
@@ -1819,7 +2288,7 @@ mod tests {
             let _ = ws_recv_envelope(&mut ws, &sess_c1, SESSION_AAD);
         });
         let processed1 = listener
-            .accept_one(&server_kp, &rt1, &allowlist, &peer_allowlist)
+            .accept_one(&server_kp, &rt1, &allowlist, &peer_allowlist, false)
             .unwrap();
         assert_eq!(processed1, 1, "connection-1 is a VALID dispatch");
         let captured_proof = rx.recv().unwrap();
@@ -1842,6 +2311,7 @@ mod tests {
                     forwarded_principal: OWNER.to_string(),
                     auth_proof: captured_proof,
                     session_id: None,
+                    constraints: None,
                 },
             );
             ws_send_envelope(&mut ws, &sess_c2, &req, SESSION_AAD).unwrap();
@@ -1851,7 +2321,7 @@ mod tests {
                 .map(|e| e.message)
         });
         let processed2 = listener
-            .accept_one(&server_kp, &rt2, &allowlist, &peer_allowlist)
+            .accept_one(&server_kp, &rt2, &allowlist, &peer_allowlist, false)
             .unwrap();
         assert_eq!(
             processed2, 0,
@@ -1902,7 +2372,7 @@ mod tests {
         });
 
         let processed = listener
-            .accept_one(&server_kp, &rt, &allowlist, &peer_allowlist)
+            .accept_one(&server_kp, &rt, &allowlist, &peer_allowlist, false)
             .unwrap();
         // The first keepalive was processed (echoed); the replayed msg_id ended the session.
         assert_eq!(
@@ -1970,7 +2440,7 @@ mod tests {
 
         let client = thread::spawn(move || try_preamble(addr, attacker_pub));
         // The server runs the REAL accept path; a non-allowlisted peer must make it FAIL CLOSED.
-        let outcome = listener.accept_one(&server_kp, &rt, &owner_allowlist, &peer_allowlist);
+        let outcome = listener.accept_one(&server_kp, &rt, &owner_allowlist, &peer_allowlist, false);
         let obs = client.join().unwrap();
 
         assert!(
@@ -2019,7 +2489,7 @@ mod tests {
             (req, session.clone(), session.clone())
         });
         let processed = listener
-            .accept_one(&server_kp, &rt, &owner_allowlist, &peer_allowlist)
+            .accept_one(&server_kp, &rt, &owner_allowlist, &peer_allowlist, false)
             .unwrap();
         assert_eq!(
             processed, 1,
@@ -2404,7 +2874,7 @@ mod tests {
         );
         // SERVER serves on the main thread (non-Send runtime); the TS client drives the socket.
         let processed = listener
-            .accept_one(&server_kp, &rt, &owner_allowlist, &peer_allowlist)
+            .accept_one(&server_kp, &rt, &owner_allowlist, &peer_allowlist, false)
             .expect("server serves the interop session");
         assert_eq!(processed, 1, "one authed dispatch processed");
 
@@ -2450,7 +2920,7 @@ mod tests {
         // The TS client uses its fixed secret (whose pubkey is NOT enrolled) ⇒ rejected at preamble.
         let child = spawn_ts_client(addr.port(), &ts_client_secret_hex(), OWNER, "run-forged");
         // The server rejects the peer pubkey and returns an Err (no session established).
-        let served = listener.accept_one(&server_kp, &rt, &owner_allowlist, &peer_allowlist);
+        let served = listener.accept_one(&server_kp, &rt, &owner_allowlist, &peer_allowlist, false);
         assert!(
             served.is_err(),
             "a forged/non-allowlisted peer establishes NO session"
@@ -2492,7 +2962,7 @@ mod tests {
             "run-badprincipal",
         );
         let processed = listener
-            .accept_one(&server_kp, &rt, &owner_allowlist, &peer_allowlist)
+            .accept_one(&server_kp, &rt, &owner_allowlist, &peer_allowlist, false)
             .expect("server serves the session but runs nothing");
         assert_eq!(
             processed, 0,
@@ -2592,7 +3062,7 @@ mod tests {
             "run-compose-ok",
         );
         let processed = listener
-            .accept_one(&server_kp, &rt, &owner_allowlist, &peer_allowlist)
+            .accept_one(&server_kp, &rt, &owner_allowlist, &peer_allowlist, false)
             .expect("server serves the compose-adapter session");
         assert_eq!(processed, 1, "one authed dispatch processed");
 
@@ -2639,7 +3109,7 @@ mod tests {
             OWNER,
             "run-compose-forged",
         );
-        let served = listener.accept_one(&server_kp, &rt, &owner_allowlist, &peer_allowlist);
+        let served = listener.accept_one(&server_kp, &rt, &owner_allowlist, &peer_allowlist, false);
         assert!(
             served.is_err(),
             "an unenrolled derived pubkey establishes NO session"
@@ -2692,7 +3162,7 @@ mod tests {
         });
 
         let processed = listener
-            .accept_one(&server_kp, &rt, &allowlist, &peer_allowlist)
+            .accept_one(&server_kp, &rt, &allowlist, &peer_allowlist, false)
             .unwrap();
         assert_eq!(processed, 1, "one sessioned dispatch processed");
 
@@ -2793,7 +3263,7 @@ mod tests {
         });
         assert_eq!(
             listener
-                .accept_one(&server_kp, &rt, &allowlist, &peer1)
+                .accept_one(&server_kp, &rt, &allowlist, &peer1, false)
                 .unwrap(),
             1
         );
@@ -2810,7 +3280,7 @@ mod tests {
         });
         assert_eq!(
             listener
-                .accept_one(&server_kp, &rt, &allowlist, &peer2)
+                .accept_one(&server_kp, &rt, &allowlist, &peer2, false)
                 .unwrap(),
             1
         );
@@ -2855,7 +3325,7 @@ mod tests {
         });
         assert_eq!(
             listener
-                .accept_one(&server_kp, &rt, &allowlist, &peer_allowlist)
+                .accept_one(&server_kp, &rt, &allowlist, &peer_allowlist, false)
                 .unwrap(),
             1
         );

--- a/rust-core/crates/friday-hub/src/bin/hub_agent_run_server.rs
+++ b/rust-core/crates/friday-hub/src/bin/hub_agent_run_server.rs
@@ -1055,11 +1055,13 @@ fn serve_sealed_session<S: Read + Write, T: Transport>(
                         reason.as_deref(),
                         now_ms,
                     )
-                    .unwrap_or_else(|_| friday_hub::agent_run_control::ControlOutcome {
-                        op: "cancel",
-                        accepted: false,
-                        status: "storage_failed".to_string(),
-                        audit_ref: None,
+                    .unwrap_or_else(|_| {
+                        friday_hub::agent_run_control::ControlOutcome {
+                            op: "cancel",
+                            accepted: false,
+                            status: "storage_failed".to_string(),
+                            audit_ref: None,
+                        }
                     }),
                     // Session auth failed (forged / non-allowlisted / un-openable proof) ⇒
                     // fail-closed refusal. We do NOT end the session (a control op is not a
@@ -1098,11 +1100,13 @@ fn serve_sealed_session<S: Read + Write, T: Transport>(
                         caller.principal(),
                         now_ms,
                     )
-                    .unwrap_or_else(|_| friday_hub::agent_run_control::ControlOutcome {
-                        op: "reject",
-                        accepted: false,
-                        status: "storage_failed".to_string(),
-                        audit_ref: None,
+                    .unwrap_or_else(|_| {
+                        friday_hub::agent_run_control::ControlOutcome {
+                            op: "reject",
+                            accepted: false,
+                            status: "storage_failed".to_string(),
+                            audit_ref: None,
+                        }
                     }),
                     None => friday_hub::agent_run_control::ControlOutcome {
                         op: "reject",
@@ -1794,7 +1798,10 @@ mod tests {
         let processed = listener
             .accept_one(&server_kp, &rt, &allowlist, &peer_allowlist, false)
             .unwrap();
-        assert_eq!(processed, 1, "the control message is processed as a keepalive");
+        assert_eq!(
+            processed, 1,
+            "the control message is processed as a keepalive"
+        );
         // The flag is OFF ⇒ the message is ECHOED verbatim (keepalive), NOT a control result.
         match client.join().unwrap().result.expect("an echo reply") {
             Message::AgentRunCancel { run_id, .. } => assert_eq!(run_id, "run-x"),
@@ -1865,7 +1872,10 @@ mod tests {
             !agent_run_control_enabled_from(None),
             "unset ⇒ disabled (default-off, deploy-safe)"
         );
-        assert!(!agent_run_control_enabled_from(Some("")), "empty ⇒ disabled");
+        assert!(
+            !agent_run_control_enabled_from(Some("")),
+            "empty ⇒ disabled"
+        );
         assert!(!agent_run_control_enabled_from(Some("0")), "0 ⇒ disabled");
         assert!(
             !agent_run_control_enabled_from(Some("false")),
@@ -2440,7 +2450,8 @@ mod tests {
 
         let client = thread::spawn(move || try_preamble(addr, attacker_pub));
         // The server runs the REAL accept path; a non-allowlisted peer must make it FAIL CLOSED.
-        let outcome = listener.accept_one(&server_kp, &rt, &owner_allowlist, &peer_allowlist, false);
+        let outcome =
+            listener.accept_one(&server_kp, &rt, &owner_allowlist, &peer_allowlist, false);
         let obs = client.join().unwrap();
 
         assert!(

--- a/rust-core/crates/friday-hub/src/lib.rs
+++ b/rust-core/crates/friday-hub/src/lib.rs
@@ -37,6 +37,11 @@ pub mod operator_vk;
 
 pub mod resume;
 
+/// A1 — the Rust agent-run RUN-CONTROL plane (pause-surfacing / resume / cancel / reject). DARK +
+/// DEPLOY-GO-gated: the sealed-WS server emits/handles these ONLY behind the default-off
+/// `FRIDAY_AGENT_RUN_CONTROL_VIA_RUST` flag.
+pub mod agent_run_control;
+
 pub mod routing;
 
 /// UNW-004 — Hub composition root: wires the built graph (Db + RouteRegistry + live

--- a/rust-core/crates/friday-hub/src/runtime.rs
+++ b/rust-core/crates/friday-hub/src/runtime.rs
@@ -542,6 +542,23 @@ impl<T: Transport> HubRuntime<T> {
         &self.db
     }
 
+    /// (A1 run-controls) The composed `FsToolExecutor` (workspace-root-contained, gate-mandatory).
+    /// Exposed so the sealed-WS server's RESUME control handler can delegate to the S6
+    /// [`crate::resume::resume_with_approval`] spine (which executes the ONE approved mutation
+    /// through this executor). It is the SAME executor the live loop uses — no separate/forked
+    /// executor for control ops. ADDITIVE, read-only accessor: no live behavior change.
+    pub fn executor(&self) -> &FsToolExecutor {
+        &self.executor
+    }
+
+    /// (A1 run-controls) The operator's PUBLIC verify key, if provisioned. Exposed so the RESUME
+    /// control handler can verify an operator-signed approval (the Hub holds only a VERIFY key —
+    /// it can never mint one). `None` ⇒ fail-closed (resume cannot verify, so nothing is Allowed).
+    /// ADDITIVE, read-only accessor: no live behavior change.
+    pub fn operator_vk(&self) -> Option<&OperatorVerifyingKey> {
+        self.operator_vk.as_ref()
+    }
+
     /// FIX-Q2 (hardening) — the run-owner principal this runtime is CONFIGURED with (the
     /// `--owner` allowlist's single entry, threaded via [`HubConfig::principal_id`] into the
     /// [`RunPolicy`]). This is the principal `run_task` stamps as the run's owner, recalls

--- a/rust-core/crates/friday-hub/tests/a1_run_control.rs
+++ b/rust-core/crates/friday-hub/tests/a1_run_control.rs
@@ -17,8 +17,8 @@ use friday_core::gate::{
 };
 use friday_crypto::{OperatorSigningKey, OperatorVerifyingKey};
 use friday_hub::agent_run_control::{
-    cancel, detect_pause, effective_max_turns, effective_run_policy, reject, resume,
-    resolve_run_owner,
+    cancel, detect_pause, effective_max_turns, effective_run_policy, reject, resolve_run_owner,
+    resume,
 };
 use friday_hub::{
     build_request_with_policy, run_loop_with_policy, AgentError, AgentLlmClient, AgentStep,
@@ -148,7 +148,10 @@ const OWNER: &str = "owner:alice";
 /// Drive a run to a Pause BOUND to `OWNER`, returning (db, ws, nonce, request) so a test can
 /// sign + ingest an approval for the EXACT paused action. The pending row carries the owner
 /// principal (the digest binds it), so the reconstructed request used to sign uses the SAME policy.
-fn pause_owned_run(tag: &str, vk: &OperatorVerifyingKey) -> (Db, Workspace, String, MutatingActionRequest) {
+fn pause_owned_run(
+    tag: &str,
+    vk: &OperatorVerifyingKey,
+) -> (Db, Workspace, String, MutatingActionRequest) {
     let db = Db::open_hub(&temp_db(tag)).unwrap();
     let ws = Workspace::new(tag);
     let run_id = "run-ctl";
@@ -244,7 +247,10 @@ fn reject_refused_for_non_owner_run_mismatch_and_unknown_approval() {
     let r = reject(db.conn(), "run-ctl", &nonce, "mallory", NOW).unwrap();
     assert_eq!(r.status, "not_owner");
     assert_eq!(
-        get_pending_request(db.conn(), &nonce).unwrap().unwrap().status,
+        get_pending_request(db.conn(), &nonce)
+            .unwrap()
+            .unwrap()
+            .status,
         "pending"
     );
     // A reject naming a DIFFERENT run than the pending row's ⇒ run_mismatch.
@@ -256,7 +262,10 @@ fn reject_refused_for_non_owner_run_mismatch_and_unknown_approval() {
     assert!(r.accepted);
     assert_eq!(r.status, "rejected");
     assert_eq!(
-        get_pending_request(db.conn(), &nonce).unwrap().unwrap().status,
+        get_pending_request(db.conn(), &nonce)
+            .unwrap()
+            .unwrap()
+            .status,
         "rejected"
     );
     let r = reject(db.conn(), "run-ctl", &nonce, OWNER, NOW).unwrap();
@@ -281,7 +290,15 @@ fn rejected_approval_cannot_be_resumed_no_mutation() {
 
     // A correctly-signed resume for the SAME nonce is now REFUSED before the spine can execute.
     let approval = ed_approval(&request, &sk, &nonce, Some(FUTURE));
-    let out = resume(db.conn(), &exec, &vk, "run-ctl", &signed_blob(&approval), NOW).unwrap();
+    let out = resume(
+        db.conn(),
+        &exec,
+        &vk,
+        "run-ctl",
+        &signed_blob(&approval),
+        NOW,
+    )
+    .unwrap();
     assert!(!out.accepted, "a rejected approval must not resume");
     assert_eq!(out.status, "approval_rejected");
     assert!(
@@ -302,7 +319,15 @@ fn cancelled_run_cannot_be_resumed_no_mutation() {
     assert!(r.accepted);
 
     let approval = ed_approval(&request, &sk, &nonce, Some(FUTURE));
-    let out = resume(db.conn(), &exec, &vk, "run-ctl", &signed_blob(&approval), NOW).unwrap();
+    let out = resume(
+        db.conn(),
+        &exec,
+        &vk,
+        "run-ctl",
+        &signed_blob(&approval),
+        NOW,
+    )
+    .unwrap();
     assert!(!out.accepted, "a cancelled run must not resume");
     assert_eq!(out.status, "run_cancelled");
     assert!(
@@ -322,7 +347,15 @@ fn resume_executes_the_approved_mutation() {
     let exec = FsToolExecutor::new(&ws.0);
 
     let approval = ed_approval(&request, &sk, &nonce, Some(FUTURE));
-    let out = resume(db.conn(), &exec, &vk, "run-ctl", &signed_blob(&approval), NOW).unwrap();
+    let out = resume(
+        db.conn(),
+        &exec,
+        &vk,
+        "run-ctl",
+        &signed_blob(&approval),
+        NOW,
+    )
+    .unwrap();
     assert!(out.accepted);
     assert_eq!(out.status, "mutation_completed");
     assert!(out.audit_ref.is_some());

--- a/rust-core/crates/friday-hub/tests/a1_run_control.rs
+++ b/rust-core/crates/friday-hub/tests/a1_run_control.rs
@@ -1,0 +1,403 @@
+//! A1 run-controls adversarial suite — the Rust agent-run RUN-CONTROL plane
+//! ([`friday_hub::agent_run_control`]): pause-detection, owner-authed cancel/reject, the
+//! operator-signed resume bridge, and — the LOAD-BEARING test — the reject/cancel ↔ resume
+//! coupling that makes reject/cancel REAL rather than cosmetic.
+//!
+//! This lives in `tests/` (NOT `src/`) for the SAME reason as `s6d_resume_ingestion`: it
+//! constructs an operator SIGNING key to play the offline operator, and `friday-hub/src/**`
+//! is forbidden from ever referencing `OperatorSigningKey`. The Hub never holds a signing key;
+//! here the TEST holds it, exactly as the real operator does off-Hub.
+
+use std::cell::RefCell;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use friday_core::gate::{
+    canonical_action_bytes, canonical_approval_signature_bytes, ApprovalDecision,
+    CanonicalApproval, MutatingActionRequest, CANONICAL_GATE_ISSUER,
+};
+use friday_crypto::{OperatorSigningKey, OperatorVerifyingKey};
+use friday_hub::agent_run_control::{
+    cancel, detect_pause, effective_max_turns, effective_run_policy, reject, resume,
+    resolve_run_owner,
+};
+use friday_hub::{
+    build_request_with_policy, run_loop_with_policy, AgentError, AgentLlmClient, AgentStep,
+    FsToolExecutor, LoopStatus, RawToolCall, RunPolicy, TurnTrace,
+};
+use friday_protocol::AgentRunConstraintsWire;
+use friday_storage::{agent_run, get_pending_request, list_pending_requests_for_run, Db};
+
+static C: AtomicU64 = AtomicU64::new(0);
+
+fn unique(tag: &str) -> String {
+    format!(
+        "{}-{}-{}",
+        std::process::id(),
+        tag,
+        C.fetch_add(1, Ordering::Relaxed)
+    )
+}
+
+fn temp_db(tag: &str) -> String {
+    std::env::temp_dir()
+        .join(format!("friday-a1ctl-{}.sqlite", unique(tag)))
+        .to_string_lossy()
+        .into_owned()
+}
+
+struct Workspace(std::path::PathBuf);
+impl Workspace {
+    fn new(tag: &str) -> Self {
+        let p = std::env::temp_dir().join(format!("friday-a1ctl-ws-{}", unique(tag)));
+        std::fs::create_dir_all(&p).unwrap();
+        Workspace(p)
+    }
+    fn join(&self, n: &str) -> std::path::PathBuf {
+        self.0.join(n)
+    }
+}
+impl Drop for Workspace {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.0);
+    }
+}
+
+struct Script {
+    steps: RefCell<std::vec::IntoIter<AgentStep>>,
+}
+impl Script {
+    fn new(steps: Vec<AgentStep>) -> Self {
+        Script {
+            steps: RefCell::new(steps.into_iter()),
+        }
+    }
+}
+impl AgentLlmClient for Script {
+    fn propose_tool_call(&self, _task: &str) -> Result<RawToolCall, AgentError> {
+        Err(AgentError::Model("propose_tool_call unused".into()))
+    }
+    fn next_step(&self, _task: &str, _history: &[TurnTrace]) -> Result<AgentStep, AgentError> {
+        Ok(self.steps.borrow_mut().next().unwrap_or(AgentStep::Finish {
+            message: "done".into(),
+        }))
+    }
+}
+
+fn raw(action: &str, params: &[(&str, &str)]) -> RawToolCall {
+    RawToolCall {
+        action: action.to_string(),
+        params: params
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect(),
+    }
+}
+
+fn operator() -> (OperatorSigningKey, OperatorVerifyingKey) {
+    let sk = OperatorSigningKey::generate();
+    let vk = sk.verifying_key();
+    (sk, vk)
+}
+
+fn ed_approval(
+    req: &MutatingActionRequest,
+    sk: &OperatorSigningKey,
+    approval_id: &str,
+    expires_at: Option<i64>,
+) -> CanonicalApproval {
+    let digest = friday_crypto::action_digest(&canonical_action_bytes(req));
+    let mut a = CanonicalApproval {
+        decision: ApprovalDecision::Approved,
+        approval_id: approval_id.to_string(),
+        action_digest: digest,
+        expires_at,
+        issuer: Some(CANONICAL_GATE_ISSUER.to_string()),
+        signature: None,
+    };
+    a.signature = Some(sk.sign(&canonical_approval_signature_bytes(&a)).to_hex());
+    a
+}
+
+/// Encode a `CanonicalApproval` into the `signed_blob` JSON the courier carries (the SAME shape
+/// the S6c CLI emits / `hub_resume_approval` decodes).
+fn signed_blob(approval: &CanonicalApproval) -> Vec<u8> {
+    let decision = match approval.decision {
+        ApprovalDecision::Approved => "approved",
+        ApprovalDecision::Denied => "denied",
+    };
+    serde_json::json!({
+        "decision": decision,
+        "approval_id": approval.approval_id,
+        "action_digest": approval.action_digest,
+        "expires_at": approval.expires_at.unwrap(),
+        "issuer": approval.issuer,
+        "signature": approval.signature,
+    })
+    .to_string()
+    .into_bytes()
+}
+
+fn no_approval() -> impl Fn(&MutatingActionRequest) -> Option<CanonicalApproval> {
+    |_req| None
+}
+
+const NOW: i64 = 1_000;
+const FUTURE: i64 = 5_000_000_000_000;
+const OWNER: &str = "owner:alice";
+
+/// Drive a run to a Pause BOUND to `OWNER`, returning (db, ws, nonce, request) so a test can
+/// sign + ingest an approval for the EXACT paused action. The pending row carries the owner
+/// principal (the digest binds it), so the reconstructed request used to sign uses the SAME policy.
+fn pause_owned_run(tag: &str, vk: &OperatorVerifyingKey) -> (Db, Workspace, String, MutatingActionRequest) {
+    let db = Db::open_hub(&temp_db(tag)).unwrap();
+    let ws = Workspace::new(tag);
+    let run_id = "run-ctl";
+    agent_run::create_run(db.conn(), run_id, "write a file", 1).unwrap();
+    let policy = RunPolicy::new(Some(OWNER.to_string()), Vec::<String>::new(), false);
+    let call = raw("write_file", &[("path", "out.txt"), ("content", "RESUMED")]);
+    let client = Script::new(vec![AgentStep::Tool(call.clone())]);
+    let exec = FsToolExecutor::new(&ws.0);
+    let out = run_loop_with_policy(
+        &client,
+        &exec,
+        db.conn(),
+        run_id,
+        "write a file",
+        "",
+        Some(vk),
+        &no_approval(),
+        &policy,
+        5,
+        NOW,
+    )
+    .unwrap();
+    assert_eq!(out.status, LoopStatus::Paused);
+    let nonce = list_pending_requests_for_run(db.conn(), run_id).unwrap()[0]
+        .approval_id
+        .clone();
+    let request = build_request_with_policy(&call, &policy).unwrap();
+    (db, ws, nonce, request)
+}
+
+// ─────────────────────────── pause-detection ───────────────────────────
+
+#[test]
+fn detect_pause_reads_back_refs_only_on_a_paused_run() {
+    let (_sk, vk) = operator();
+    let (db, _ws, nonce, _req) = pause_owned_run("detect", &vk);
+    let info = detect_pause(db.conn(), "run-ctl").unwrap().unwrap();
+    assert_eq!(info.nonce, nonce);
+    assert_eq!(info.action_digest.len(), 64);
+    assert!(info.summary.contains("write_file"));
+    // A run with no pending row is NOT a pause.
+    agent_run::create_run(db.conn(), "run-other", "noop", 1).unwrap();
+    assert_eq!(detect_pause(db.conn(), "run-other").unwrap(), None);
+    assert_eq!(detect_pause(db.conn(), "ghost").unwrap(), None);
+}
+
+// ─────────────────────────── owner resolution + auth ───────────────────────────
+
+#[test]
+fn resolve_run_owner_anchors_on_pending_principal() {
+    let (_sk, vk) = operator();
+    let (db, _ws, _nonce, _req) = pause_owned_run("owner", &vk);
+    assert_eq!(
+        resolve_run_owner(db.conn(), "run-ctl").unwrap().as_deref(),
+        Some(OWNER)
+    );
+    assert_eq!(resolve_run_owner(db.conn(), "ghost").unwrap(), None);
+}
+
+#[test]
+fn cancel_refused_for_non_owner_and_accepted_for_owner() {
+    let (_sk, vk) = operator();
+    let (db, _ws, _nonce, _req) = pause_owned_run("cancel-auth", &vk);
+
+    // A non-owner cancel is refused with NO state change.
+    let r = cancel(db.conn(), "run-ctl", "mallory", None, NOW).unwrap();
+    assert!(!r.accepted);
+    assert_eq!(r.status, "not_owner");
+    assert!(!agent_run::is_cancelled(db.conn(), "run-ctl").unwrap());
+
+    // The owner cancels: terminal state written + audit ref.
+    let r = cancel(db.conn(), "run-ctl", OWNER, Some("changed mind"), NOW).unwrap();
+    assert!(r.accepted);
+    assert_eq!(r.status, "cancelled");
+    assert!(r.audit_ref.is_some());
+    assert!(agent_run::is_cancelled(db.conn(), "run-ctl").unwrap());
+
+    // Idempotent: a second owner cancel is an accepted no-op.
+    let r = cancel(db.conn(), "run-ctl", OWNER, None, NOW).unwrap();
+    assert!(r.accepted);
+    assert_eq!(r.status, "already_cancelled");
+}
+
+#[test]
+fn reject_refused_for_non_owner_run_mismatch_and_unknown_approval() {
+    let (_sk, vk) = operator();
+    let (db, _ws, nonce, _req) = pause_owned_run("reject-auth", &vk);
+
+    // Unknown approval id ⇒ refused.
+    let r = reject(db.conn(), "run-ctl", "no-such-nonce", OWNER, NOW).unwrap();
+    assert_eq!(r.status, "unknown_approval");
+    // A non-owner reject ⇒ refused, the pending row stays `pending`.
+    let r = reject(db.conn(), "run-ctl", &nonce, "mallory", NOW).unwrap();
+    assert_eq!(r.status, "not_owner");
+    assert_eq!(
+        get_pending_request(db.conn(), &nonce).unwrap().unwrap().status,
+        "pending"
+    );
+    // A reject naming a DIFFERENT run than the pending row's ⇒ run_mismatch.
+    let r = reject(db.conn(), "run-WRONG", &nonce, OWNER, NOW).unwrap();
+    assert_eq!(r.status, "run_mismatch");
+
+    // The owner rejects: status='rejected' + audit ref. Idempotent re-reject is accepted.
+    let r = reject(db.conn(), "run-ctl", &nonce, OWNER, NOW).unwrap();
+    assert!(r.accepted);
+    assert_eq!(r.status, "rejected");
+    assert_eq!(
+        get_pending_request(db.conn(), &nonce).unwrap().unwrap().status,
+        "rejected"
+    );
+    let r = reject(db.conn(), "run-ctl", &nonce, OWNER, NOW).unwrap();
+    assert_eq!(r.status, "already_rejected");
+}
+
+// ─────────────────────────── THE LOAD-BEARING COUPLING ───────────────────────────
+
+/// REAL, not cosmetic: after the owner REJECTS a pending approval, a LATER correctly-signed
+/// resume for that SAME approval_id must NOT execute the mutation. Without the resume handler's
+/// pre-check this would still run (the S6 spine only consults `consumed_approval`, not the
+/// pending status) — this is the bug the advisor flagged and the test that proves the fix.
+#[test]
+fn rejected_approval_cannot_be_resumed_no_mutation() {
+    let (sk, vk) = operator();
+    let (db, ws, nonce, request) = pause_owned_run("reject-resume", &vk);
+    let exec = FsToolExecutor::new(&ws.0);
+
+    // Owner rejects the pending approval.
+    let r = reject(db.conn(), "run-ctl", &nonce, OWNER, NOW).unwrap();
+    assert!(r.accepted);
+
+    // A correctly-signed resume for the SAME nonce is now REFUSED before the spine can execute.
+    let approval = ed_approval(&request, &sk, &nonce, Some(FUTURE));
+    let out = resume(db.conn(), &exec, &vk, "run-ctl", &signed_blob(&approval), NOW).unwrap();
+    assert!(!out.accepted, "a rejected approval must not resume");
+    assert_eq!(out.status, "approval_rejected");
+    assert!(
+        !ws.join("out.txt").exists(),
+        "the rejected mutation must NOT have executed"
+    );
+}
+
+/// Same coupling for CANCEL: after the owner cancels the run, a correctly-signed resume is
+/// refused and no mutation runs.
+#[test]
+fn cancelled_run_cannot_be_resumed_no_mutation() {
+    let (sk, vk) = operator();
+    let (db, ws, nonce, request) = pause_owned_run("cancel-resume", &vk);
+    let exec = FsToolExecutor::new(&ws.0);
+
+    let r = cancel(db.conn(), "run-ctl", OWNER, None, NOW).unwrap();
+    assert!(r.accepted);
+
+    let approval = ed_approval(&request, &sk, &nonce, Some(FUTURE));
+    let out = resume(db.conn(), &exec, &vk, "run-ctl", &signed_blob(&approval), NOW).unwrap();
+    assert!(!out.accepted, "a cancelled run must not resume");
+    assert_eq!(out.status, "run_cancelled");
+    assert!(
+        !ws.join("out.txt").exists(),
+        "the cancelled run's mutation must NOT have executed"
+    );
+}
+
+// ─────────────────────────── resume happy path + fail-closed ───────────────────────────
+
+/// The positive control: a correctly-signed resume of a non-cancelled/non-rejected paused run
+/// executes EXACTLY one mutation (delegating to the S6 spine).
+#[test]
+fn resume_executes_the_approved_mutation() {
+    let (sk, vk) = operator();
+    let (db, ws, nonce, request) = pause_owned_run("resume-ok", &vk);
+    let exec = FsToolExecutor::new(&ws.0);
+
+    let approval = ed_approval(&request, &sk, &nonce, Some(FUTURE));
+    let out = resume(db.conn(), &exec, &vk, "run-ctl", &signed_blob(&approval), NOW).unwrap();
+    assert!(out.accepted);
+    assert_eq!(out.status, "mutation_completed");
+    assert!(out.audit_ref.is_some());
+    assert_eq!(
+        std::fs::read_to_string(ws.join("out.txt")).unwrap(),
+        "RESUMED"
+    );
+}
+
+#[test]
+fn resume_malformed_blob_is_fail_closed() {
+    let (_sk, vk) = operator();
+    let (db, ws, _nonce, _req) = pause_owned_run("resume-bad", &vk);
+    let exec = FsToolExecutor::new(&ws.0);
+    let out = resume(db.conn(), &exec, &vk, "run-ctl", b"not json", NOW).unwrap();
+    assert!(!out.accepted);
+    assert_eq!(out.status, "malformed_blob");
+    assert!(!ws.join("out.txt").exists());
+}
+
+/// An HMAC-signed approval carried in the blob is refused by the spine (downgrade closed), and
+/// no mutation runs — the resume bridge does not weaken the S6 verification.
+#[test]
+fn resume_hmac_blob_is_refused() {
+    let (_sk, vk) = operator();
+    let (db, ws, nonce, request) = pause_owned_run("resume-hmac", &vk);
+    let exec = FsToolExecutor::new(&ws.0);
+    let digest = friday_crypto::action_digest(&canonical_action_bytes(&request));
+    let mut a = CanonicalApproval {
+        decision: ApprovalDecision::Approved,
+        approval_id: nonce,
+        action_digest: digest,
+        expires_at: Some(FUTURE),
+        issuer: Some(CANONICAL_GATE_ISSUER.to_string()),
+        signature: None,
+    };
+    a.signature = Some(friday_crypto::sign_approval(
+        &canonical_approval_signature_bytes(&a),
+        b"hub-held-hmac-secret-0123456789ab",
+    ));
+    let out = resume(db.conn(), &exec, &vk, "run-ctl", &signed_blob(&a), NOW).unwrap();
+    assert!(!out.accepted, "an HMAC blob is a gate Deny");
+    assert!(!ws.join("out.txt").exists());
+}
+
+// ─────────────────────────── constraints mapping (pure) ───────────────────────────
+
+#[test]
+fn effective_run_policy_maps_constraints_tightening_only() {
+    // None ⇒ unconstrained policy (read-only off, no disabled tools).
+    let p = effective_run_policy(Some(OWNER), None);
+    assert_eq!(p.principal_id(), Some(OWNER));
+    assert!(!p.is_read_only());
+    assert!(!p.is_tool_disabled("run_command"));
+
+    // A constraints block tightens: read_only on, the disabled set applied verbatim.
+    let c = AgentRunConstraintsWire {
+        read_only: true,
+        disabled_tools: vec!["run_command".into()],
+        max_turns: Some(2),
+    };
+    let p = effective_run_policy(Some(OWNER), Some(&c));
+    assert!(p.is_read_only());
+    assert!(p.is_tool_disabled("run_command"));
+
+    // max_turns can only LOWER the runtime ceiling, never raise it.
+    assert_eq!(effective_max_turns(8, Some(&c)), 2);
+    let raise = AgentRunConstraintsWire {
+        max_turns: Some(100),
+        ..Default::default()
+    };
+    assert_eq!(
+        effective_max_turns(8, Some(&raise)),
+        8,
+        "a higher asserted cap cannot raise the ceiling"
+    );
+    assert_eq!(effective_max_turns(8, None), 8, "None ⇒ runtime default");
+}

--- a/rust-core/crates/friday-protocol/src/lib.rs
+++ b/rust-core/crates/friday-protocol/src/lib.rs
@@ -35,9 +35,24 @@ use thiserror::Error;
 /// later sub-slices (S-B/S-C). Bumping the wire version here keeps wire-compat
 /// honest (a peer that speaks v12 advertises these kinds exist), even while no
 /// production route emits them.
-pub const CURRENT_SCHEMA_VERSION: u16 = 12;
+///
+/// v13 (A1 run-controls) adds the on-wire run-CONTROL protocol for the live
+/// agent-run: `AgentRunPaused` (emitted when the loop's gate Pauses a mutating
+/// tool — today a Paused run drops into the NoAnswer black hole), `AgentRunResume`
+/// (TS is a pure COURIER of the operator's out-of-band Ed25519 signature, never its
+/// author), `AgentRunCancel` (owner-authed terminal stop), `AgentRunReject`
+/// (owner-authed `pending_approval_request.status='rejected'`), and the
+/// `AgentRunControlResult` receipt. These also land DARK: the new variants append
+/// to the enum (a peer that speaks v13 advertises they exist), but NOTHING emits or
+/// handles them in production until the A1 server handlers are wired behind the
+/// NEW default-off `FRIDAY_AGENT_RUN_CONTROL_VIA_RUST` flag. With that flag OFF a
+/// Paused run emits exactly the pre-A1 `AgentRunResult{status:"no_answer"}` bytes —
+/// so deploying a v13 binary changes NO live behavior. The constraint fields added
+/// to `AgentRunRequest` are additive-optional (absent ⇒ byte-identical to the
+/// pre-A1 wire), so the live courier's current bytes still decode to no-constraints.
+pub const CURRENT_SCHEMA_VERSION: u16 = 13;
 /// The inclusive range of versions this build supports.
-pub const SUPPORTED: VersionRange = VersionRange { min: 1, max: 12 };
+pub const SUPPORTED: VersionRange = VersionRange { min: 1, max: 13 };
 
 /// A surface-safe Mission projection. This is the wire shape mobile, desktop, and
 /// channel surfaces may render. It intentionally has no raw provider ids, channel
@@ -754,6 +769,39 @@ pub enum ErrorCode {
     Internal,
 }
 
+/// (A1 run-controls) Per-run CONSTRAINTS carried on an `AgentRunRequest`. ADDITIVE +
+/// OPTIONAL on the wire: an absent field is `None` (`#[serde(default)]`) and a `None`
+/// constraints block is OMITTED from the wire (`skip_serializing_if`), so a request with
+/// no constraints is BYTE-IDENTICAL to the pre-A1 `AgentRunRequest`. This mirrors the
+/// `session_id` additive-optional discipline.
+///
+/// **SECURITY / TRUTH:** these are CLIENT-ASSERTED per-run restrictions the trusted-TS peer
+/// forwards; the server maps them onto the per-run `RunPolicy` (read-only / disabled-tool /
+/// max-turns) — they can only ever TIGHTEN a run (a constraint is a restriction, never a
+/// grant). Today the wire carries no constraints and read-only is enforced ONLY by the TS
+/// qualifier (per the A2 design doc); this is the wire shape that lets a run be constrained
+/// in Rust. A `None`/absent block ⇒ the server's existing default `RunPolicy` (unchanged
+/// live behavior). The server NEVER widens a run from these — an unknown/missing field
+/// fail-closes to the stricter interpretation.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AgentRunConstraintsWire {
+    /// When `true`, the run is constrained read-only: a mutating tool is blocked BEFORE
+    /// execution (strictly stricter than the gate's default Pause-pending-approval).
+    /// Absent ⇒ `false` (the run uses the gate's normal mutating-action discipline).
+    #[serde(default)]
+    pub read_only: bool,
+    /// Tools disabled for THIS run (an allowlist's complement, mirroring the TS oracle's
+    /// `disabledTools`). A disabled tool is rejected before classification/execution. Absent
+    /// ⇒ empty (no per-run disable beyond the gate). NEVER a grant — only a restriction.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub disabled_tools: Vec<String>,
+    /// A per-run `max_turns` cap, when the caller wants one tighter than the runtime default.
+    /// The server takes `min(runtime_default, this)` so a client-asserted value can only ever
+    /// LOWER the bound (never raise it past the runtime ceiling). Absent ⇒ the runtime default.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_turns: Option<u64>,
+}
+
 /// First-slice message kinds (gate §4.2). Tagged by `kind`.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "kind")]
@@ -898,6 +946,16 @@ pub enum Message {
         /// owner's history by guessing a `session_id`.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         session_id: Option<String>,
+        /// (A1 run-controls) Per-run CONSTRAINTS the server maps onto the run's `RunPolicy`
+        /// (read-only / disabled-tool / max-turns). ADDITIVE + OPTIONAL — an absent block
+        /// deserializes to `None` (`#[serde(default)]`) and a `None` value is OMITTED from
+        /// the wire (`skip_serializing_if`), so a constraint-free request is BYTE-IDENTICAL
+        /// to the pre-A1 wire and the live courier's current bytes decode to no-constraints.
+        /// SECURITY: a constraint can only TIGHTEN a run (a restriction, never a grant); see
+        /// [`AgentRunConstraintsWire`]. Threading these onto the per-run policy is the
+        /// prerequisite for any mutating run-control.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        constraints: Option<AgentRunConstraintsWire>,
     },
     /// hub->trusted-TS-peer: REFS-ONLY terminal receipt for an agent-run.
     /// **WS-transport substrate (S-A).** It carries a coarse loop-status label and
@@ -946,6 +1004,109 @@ pub enum Message {
         /// known. A COUNT only. Same DEFERRED-population note as `prompt_tokens`.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         completion_tokens: Option<u64>,
+    },
+    /// hub->trusted-TS-peer: (A1 run-controls) the loop's gate PAUSED a mutating tool on
+    /// `run_id` waiting for an operator approval. Today a Paused run writes no `run_result`
+    /// and drops into the NoAnswer black hole (the TS courier sees `AgentRunResult{status:
+    /// "no_answer"}` and cannot tell a pause from a dead run). This variant surfaces the
+    /// pause so the operator can be prompted to sign (out-of-band) and the courier can later
+    /// relay an `AgentRunResume`. It is REFS-ONLY: it carries the single-use approval `nonce`
+    /// (= the `pending_approval_request.approval_id` the operator signs over) and the
+    /// `action_digest` (which transitively binds principal/scope/params) — and a coarse,
+    /// body-free `summary` of what paused (the action verb). It NEVER carries the tool body,
+    /// args, or the answer. **DARK + FLAG-GATED:** the server emits this ONLY when the
+    /// default-off `FRIDAY_AGENT_RUN_CONTROL_VIA_RUST` flag is on; with the flag off the
+    /// server emits exactly the pre-A1 `AgentRunResult{status:"no_answer"}` bytes.
+    AgentRunPaused {
+        /// The run that paused (echoes `AgentRunRequest::run_id`).
+        run_id: String,
+        /// The single-use CSPRNG approval nonce the operator signs over (=
+        /// `pending_approval_request.approval_id`). It is a nonce, not a secret — it
+        /// identifies WHICH pause to resume; signing it requires the operator's private key.
+        nonce: String,
+        /// Hex SHA-256 of the request's `canonical_action_bytes` — binds the EXACT paused
+        /// action (and transitively principal/scope/params/derived-risk). A fingerprint, not
+        /// a body.
+        action_digest: String,
+        /// A coarse, body-free summary of WHAT paused (e.g. the action verb). NEVER the tool
+        /// args, the params, or any mutation body.
+        summary: String,
+    },
+    /// trusted-TS-peer->hub: (A1 run-controls) relay an operator's out-of-band approval to
+    /// RESUME a paused run. **The TS peer is a pure COURIER, never the author:** `signed_blob`
+    /// is the operator's canonical Ed25519-signed approval (the S6c CLI output), opaque to TS.
+    /// The server decodes it to a `CanonicalApproval` and delegates VERBATIM to the S6
+    /// `resume_with_approval` spine — which looks the pending row up by the approval's nonce,
+    /// cross-checks the action digest, Ed25519-verifies under the OPERATOR's public key,
+    /// CONSUMES the nonce (single-use), executes the ONE approved mutation, and records the
+    /// owner. The Hub holds only a VERIFY key — it can never mint this. A forged/replayed/
+    /// expired/HMAC blob is refused (no mutation). DARK + FLAG-GATED.
+    AgentRunResume {
+        /// The run to resume (echoes the paused `run_id`). Advisory context; the AUTHORITY is
+        /// the `signed_blob`'s nonce + digest, which the resume spine looks up independently.
+        run_id: String,
+        /// The operator's canonical Ed25519-signed approval bytes (JSON of a `CanonicalApproval`).
+        /// Opaque to the courier; verified by the server. Carries no secret (a signature +
+        /// public scope), and is single-use (the nonce is consumed on a successful verify).
+        signed_blob: Vec<u8>,
+    },
+    /// trusted-TS-peer->hub: (A1 run-controls) CANCEL a live agent-run — write a terminal
+    /// `cancelled` `agent_run.state` and stop the loop. **Owner-authed:** unlike resume (which
+    /// is self-authenticating via the operator signature), cancel carries a `forwarded_principal`
+    /// plus an `auth_proof` (the SAME sealed-session possession proof an `AgentRunRequest`
+    /// carries, bound to this `run_id`); the server verifies it against the session AND requires
+    /// the authenticated principal == the run's bound owner before writing the terminal state.
+    /// A non-owner / forged / ownerless-run cancel fails closed (no state change). DARK +
+    /// FLAG-GATED. Idempotent: cancelling an already-terminal run is a no-op success.
+    AgentRunCancel {
+        run_id: String,
+        /// The TS-token-resolved principal the trusted peer forwards. **A client assertion,
+        /// NOT an authority** — verified against the sealed session (`auth_proof`) and then
+        /// matched to the run's bound owner. Mirrors `AgentRunRequest::forwarded_principal`.
+        forwarded_principal: String,
+        /// The sealed possession proof (`AUTH_CHALLENGE || session_nonce`, AAD-bound to
+        /// `(principal, run_id)`). Mirrors `AgentRunRequest::auth_proof`. Opaque here.
+        auth_proof: Vec<u8>,
+        /// A coarse, body-free reason for the cancel (operator/audit context). NEVER a body.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        reason: Option<String>,
+    },
+    /// trusted-TS-peer->hub: (A1 run-controls) REJECT a pending tool-approval on a paused run —
+    /// mark `pending_approval_request.status='rejected'` (reuses the existing m0014 status
+    /// column; NO migration). **Owner-authed** on the SAME terms as `AgentRunCancel`: the
+    /// `forwarded_principal` + `auth_proof` are verified against the session, then the
+    /// authenticated principal must equal the pending row's bound owner (`principal_id`).
+    /// Reject is a SEPARATE leg from cancel: it refuses ONE pending mutation (the run stays
+    /// alive, just un-approved) rather than terminating the whole run. The load-bearing
+    /// single-use guarantee remains the gate's `consumed_approval` store; this status is
+    /// idempotent bookkeeping + the operator-facing "I said no" record. DARK + FLAG-GATED.
+    AgentRunReject {
+        run_id: String,
+        /// The pending approval to reject (= `pending_approval_request.approval_id` /
+        /// `AgentRunPaused::nonce`). Identifies WHICH pending mutation to refuse.
+        approval_id: String,
+        forwarded_principal: String,
+        auth_proof: Vec<u8>,
+    },
+    /// hub->trusted-TS-peer: (A1 run-controls) the body-free receipt for a control op
+    /// (`AgentRunResume` / `AgentRunCancel` / `AgentRunReject`). It carries a coarse outcome
+    /// status (e.g. `cancelled` / `already_terminal` / `rejected` / `mutation_completed` /
+    /// `denied` / `not_owner` / `unknown_run`) and a soft audit ref — NEVER a body, a tool
+    /// args, or an answer. `accepted=false` means the control op was refused (fail-closed);
+    /// the `status` says why at a coarse grain. Mirrors the refs-only discipline of
+    /// `AgentRunResult` and `MissionLifecycleResult`.
+    AgentRunControlResult {
+        run_id: String,
+        /// The control op this terminates (`resume` / `cancel` / `reject`).
+        op: String,
+        /// Whether the op was accepted (`true`) or refused fail-closed (`false`).
+        accepted: bool,
+        /// Coarse, body-free outcome label.
+        status: String,
+        /// Soft link to the hash-chained audit receipt for this control op, when one was
+        /// written. A ref, never a body.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        audit_ref: Option<String>,
     },
     /// either: explicit error code + message.
     Error { code: ErrorCode, message: String },
@@ -1909,6 +2070,8 @@ mod tests {
             auth_proof: vec![0xDE, 0xAD, 0xBE, 0xEF],
             // A2a Phase 1: a sessionless request (the pre-A2a shape) carries `None`.
             session_id: None,
+            // A1 run-controls: a constraint-free request carries `None`.
+            constraints: None,
         };
         let env = Envelope::new("m1", 1000, msg.clone()).with_correlation("c1");
         let json = env.encode().unwrap();
@@ -1931,11 +2094,19 @@ mod tests {
             forwarded_principal: "owner-1".into(),
             auth_proof: vec![0xDE, 0xAD, 0xBE, 0xEF],
             session_id: None,
+            constraints: None,
         };
         let json = Envelope::new("m1", 1000, msg).encode().unwrap();
         assert!(
             !json.contains("session_id"),
             "a sessionless AgentRunRequest must not carry a session_id key (byte-identical to pre-A2a): {json}"
+        );
+        // (A1 run-controls) absent constraints ⇒ NO `constraints` key on the wire
+        // (byte-identical to the pre-A1 AgentRunRequest, so the live courier's current
+        // bytes still decode to no-constraints).
+        assert!(
+            !json.contains("constraints"),
+            "a constraint-free AgentRunRequest must not carry a constraints key (byte-identical to pre-A1): {json}"
         );
     }
 
@@ -1952,6 +2123,7 @@ mod tests {
             forwarded_principal: "owner-1".into(),
             auth_proof: vec![0x01, 0x02],
             session_id: Some("sess-abc".into()),
+            constraints: None,
         };
         let env = Envelope::new("m2", 2000, msg.clone());
         let json = env.encode().unwrap();
@@ -2168,11 +2340,189 @@ mod tests {
     }
 
     #[test]
-    fn schema_version_bumped_to_twelve_for_ws_substrate() {
-        // S-A bumps the wire version so a v12 peer advertises these kinds exist
-        // (wire-compat honesty), even while nothing emits them yet (DARK).
-        assert_eq!(CURRENT_SCHEMA_VERSION, 12);
-        assert_eq!(SUPPORTED.max, 12);
+    fn schema_version_bumped_to_thirteen_for_run_controls() {
+        // A1 bumps the wire version so a v13 peer advertises the run-CONTROL kinds
+        // (Paused/Resume/Cancel/Reject/ControlResult) exist — wire-compat honesty — even
+        // while nothing emits them yet (DARK, behind the default-off flag). S-A's v12
+        // substrate kinds are still present and unchanged.
+        assert_eq!(CURRENT_SCHEMA_VERSION, 13);
+        assert_eq!(SUPPORTED.max, 13);
         assert_eq!(SUPPORTED.min, 1);
+    }
+
+    // --- A1 run-controls: the on-wire control protocol (v13) --------------------
+    // Per-behavior codec coverage for the NEW additive variants. These exercise ONLY
+    // the codec/shape — nothing here constructs a server or executes a control op
+    // (those are the friday-hub handlers, behind the default-off flag).
+
+    #[test]
+    fn agent_run_request_constraints_round_trip_and_are_additive_optional() {
+        // A constrained request round-trips its constraints; an absent block is byte-identical.
+        let constrained = Message::AgentRunRequest {
+            run_id: "run-c".into(),
+            task: "tidy the workspace".into(),
+            forwarded_principal: "owner-1".into(),
+            auth_proof: vec![0x01],
+            session_id: None,
+            constraints: Some(AgentRunConstraintsWire {
+                read_only: true,
+                disabled_tools: vec!["run_command".into(), "delete_file".into()],
+                max_turns: Some(3),
+            }),
+        };
+        let json = Envelope::new("m", 1, constrained.clone()).encode().unwrap();
+        assert!(json.contains("\"read_only\":true"));
+        assert!(json.contains("\"disabled_tools\":[\"run_command\",\"delete_file\"]"));
+        assert!(json.contains("\"max_turns\":3"));
+        assert_eq!(Envelope::decode(&json).unwrap().message, constrained);
+
+        // An empty-but-present constraints block omits the empty vec / None max_turns but keeps
+        // read_only (a bool always serializes) — still a tightening-only, body-free shape.
+        let empty = Message::AgentRunRequest {
+            run_id: "run-e".into(),
+            task: "go".into(),
+            forwarded_principal: "owner-1".into(),
+            auth_proof: vec![],
+            session_id: None,
+            constraints: Some(AgentRunConstraintsWire::default()),
+        };
+        let json = Envelope::new("m", 1, empty.clone()).encode().unwrap();
+        assert!(!json.contains("disabled_tools"));
+        assert!(!json.contains("max_turns"));
+        assert_eq!(Envelope::decode(&json).unwrap().message, empty);
+    }
+
+    #[test]
+    fn agent_run_paused_is_refs_only_and_round_trips() {
+        // Paused carries the nonce + digest + a coarse summary — NEVER a body/args.
+        const ARGS: &str = "rm -rf /Users/jarvis/private/secret";
+        let msg = Message::AgentRunPaused {
+            run_id: "run-1".into(),
+            nonce: "a".repeat(64),
+            action_digest: "b".repeat(64),
+            summary: "paused on delete_file".into(),
+        };
+        let env = Envelope::new("p1", 1000, msg.clone()).with_correlation("c1");
+        let json = env.encode().unwrap();
+        assert!(json.contains("\"kind\":\"AgentRunPaused\""));
+        assert!(json.contains(&format!("\"schema_version\":{CURRENT_SCHEMA_VERSION}")));
+        // Structural body-free guard: no args/params/body key can appear (the struct has none).
+        for forbidden in [ARGS, "params", "args", "tool_params", "body", "final_message"] {
+            assert!(
+                !json.contains(forbidden),
+                "AgentRunPaused leaked {forbidden}: {json}"
+            );
+        }
+        assert_eq!(Envelope::decode(&json).unwrap(), env);
+    }
+
+    #[test]
+    fn agent_run_resume_is_a_courier_blob_and_round_trips() {
+        // The TS peer carries an opaque signed_blob (the operator's signature) — the courier
+        // never authors it; the server verifies it. The codec just carries the bytes.
+        let msg = Message::AgentRunResume {
+            run_id: "run-1".into(),
+            signed_blob: vec![0xDE, 0xAD, 0xBE, 0xEF, 0x00, 0x01],
+        };
+        let env = Envelope::new("r1", 1001, msg.clone());
+        let json = env.encode().unwrap();
+        assert!(json.contains("\"kind\":\"AgentRunResume\""));
+        assert_eq!(Envelope::decode(&json).unwrap().message, msg);
+    }
+
+    #[test]
+    fn agent_run_cancel_carries_owner_auth_and_round_trips() {
+        // Cancel is owner-authed: it carries the forwarded principal + the sealed proof
+        // (mirroring AgentRunRequest) plus an optional coarse reason.
+        let msg = Message::AgentRunCancel {
+            run_id: "run-1".into(),
+            forwarded_principal: "owner-1".into(),
+            auth_proof: vec![0x01, 0x02, 0x03],
+            reason: Some("operator changed their mind".into()),
+        };
+        let env = Envelope::new("x1", 1002, msg.clone());
+        let json = env.encode().unwrap();
+        assert!(json.contains("\"kind\":\"AgentRunCancel\""));
+        assert!(json.contains("\"forwarded_principal\":\"owner-1\""));
+        assert_eq!(Envelope::decode(&json).unwrap().message, msg);
+
+        // Absent reason omits the key (additive-optional).
+        let no_reason = Message::AgentRunCancel {
+            run_id: "run-2".into(),
+            forwarded_principal: "owner-1".into(),
+            auth_proof: vec![],
+            reason: None,
+        };
+        let json = Envelope::new("x2", 1003, no_reason.clone()).encode().unwrap();
+        assert!(!json.contains("reason"));
+        assert_eq!(Envelope::decode(&json).unwrap().message, no_reason);
+    }
+
+    #[test]
+    fn agent_run_reject_carries_owner_auth_and_approval_id() {
+        let msg = Message::AgentRunReject {
+            run_id: "run-1".into(),
+            approval_id: "a".repeat(64),
+            forwarded_principal: "owner-1".into(),
+            auth_proof: vec![0x09],
+        };
+        let env = Envelope::new("j1", 1004, msg.clone());
+        let json = env.encode().unwrap();
+        assert!(json.contains("\"kind\":\"AgentRunReject\""));
+        assert!(json.contains("\"approval_id\""));
+        assert_eq!(Envelope::decode(&json).unwrap().message, msg);
+    }
+
+    #[test]
+    fn agent_run_control_result_is_refs_only_and_round_trips() {
+        let msg = Message::AgentRunControlResult {
+            run_id: "run-1".into(),
+            op: "cancel".into(),
+            accepted: true,
+            status: "cancelled".into(),
+            audit_ref: Some("audit://agent-run-control/run-1".into()),
+        };
+        let env = Envelope::new("k1", 1005, msg.clone());
+        let json = env.encode().unwrap();
+        assert!(json.contains("\"kind\":\"AgentRunControlResult\""));
+        assert!(json.contains("\"op\":\"cancel\""));
+        assert!(json.contains("\"accepted\":true"));
+        // Body-free guard.
+        for forbidden in ["body", "final_message", "answer\"", "params"] {
+            assert!(!json.contains(forbidden), "control result leaked {forbidden}");
+        }
+        assert_eq!(Envelope::decode(&json).unwrap().message, msg);
+
+        // A refused op (accepted=false) with no audit_ref omits the key.
+        let refused = Message::AgentRunControlResult {
+            run_id: "run-2".into(),
+            op: "reject".into(),
+            accepted: false,
+            status: "not_owner".into(),
+            audit_ref: None,
+        };
+        let json = Envelope::new("k2", 1006, refused.clone()).encode().unwrap();
+        assert!(!json.contains("audit_ref"));
+        assert_eq!(Envelope::decode(&json).unwrap().message, refused);
+    }
+
+    #[test]
+    fn pre_a1_agent_run_request_decodes_with_no_constraints() {
+        // FORWARD/BACKWARD-COMPAT: the live courier's CURRENT (pre-A1) AgentRunRequest JSON —
+        // which has no `constraints` key — still decodes on a v13 build to `constraints: None`
+        // (via `#[serde(default)]`). This is what makes deploying a v13 binary safe for the
+        // current peer.
+        let pre_a1 = r#"{"schema_version":12,"msg_id":"m","sent_at":1,"message":{"kind":"AgentRunRequest","run_id":"r","task":"t","forwarded_principal":"owner-1","auth_proof":[1,2]}}"#;
+        match Envelope::decode(pre_a1).expect("pre-A1 decode").message {
+            Message::AgentRunRequest {
+                session_id,
+                constraints,
+                ..
+            } => {
+                assert_eq!(session_id, None);
+                assert_eq!(constraints, None);
+            }
+            other => panic!("expected AgentRunRequest, got {other:?}"),
+        }
     }
 }

--- a/rust-core/crates/friday-protocol/src/lib.rs
+++ b/rust-core/crates/friday-protocol/src/lib.rs
@@ -2407,7 +2407,14 @@ mod tests {
         assert!(json.contains("\"kind\":\"AgentRunPaused\""));
         assert!(json.contains(&format!("\"schema_version\":{CURRENT_SCHEMA_VERSION}")));
         // Structural body-free guard: no args/params/body key can appear (the struct has none).
-        for forbidden in [ARGS, "params", "args", "tool_params", "body", "final_message"] {
+        for forbidden in [
+            ARGS,
+            "params",
+            "args",
+            "tool_params",
+            "body",
+            "final_message",
+        ] {
             assert!(
                 !json.contains(forbidden),
                 "AgentRunPaused leaked {forbidden}: {json}"
@@ -2453,7 +2460,9 @@ mod tests {
             auth_proof: vec![],
             reason: None,
         };
-        let json = Envelope::new("x2", 1003, no_reason.clone()).encode().unwrap();
+        let json = Envelope::new("x2", 1003, no_reason.clone())
+            .encode()
+            .unwrap();
         assert!(!json.contains("reason"));
         assert_eq!(Envelope::decode(&json).unwrap().message, no_reason);
     }
@@ -2489,7 +2498,10 @@ mod tests {
         assert!(json.contains("\"accepted\":true"));
         // Body-free guard.
         for forbidden in ["body", "final_message", "answer\"", "params"] {
-            assert!(!json.contains(forbidden), "control result leaked {forbidden}");
+            assert!(
+                !json.contains(forbidden),
+                "control result leaked {forbidden}"
+            );
         }
         assert_eq!(Envelope::decode(&json).unwrap().message, msg);
 

--- a/rust-core/crates/friday-storage/src/agent_run.rs
+++ b/rust-core/crates/friday-storage/src/agent_run.rs
@@ -11,6 +11,19 @@ use crate::error::{Result, StorageError};
 use friday_core::PlanState;
 use rusqlite::{params, Connection, OptionalExtension};
 
+/// (A1 run-controls) The terminal `agent_run.state` written when a run is CANCELLED. The
+/// `agent_run.state` column is free-form `TEXT` (no CHECK in [`crate::schema`] `DDL_AGENT_RUN`),
+/// so this string writes WITHOUT a migration. It is DELIBERATELY OUTSIDE the [`PlanState`]
+/// closed vocab ([`parse_plan_state`] returns `None` for it) so that:
+///   - a cancelled run can never be "re-decided" through the [`PlanState`] transition machine
+///     ([`set_run_state`] would reject any transition out of it, because the current state does
+///     not parse to a `PlanState` and that fn requires the current state to be a known one); and
+///   - any closed-vocab reader that round-trips through [`parse_plan_state`] sees `None` (run has
+///     no PlanState), distinct from a run that does not exist (the row read returns `None` too —
+///     see [`is_cancelled`] / [`run_state_string`] for the unambiguous distinguishers a control
+///     reader should use instead of conflating "no PlanState" with "no row").
+pub const STATE_CANCELLED: &str = "cancelled";
+
 fn parse_plan_state(s: &str) -> Option<PlanState> {
     match s {
         "awaiting_clarification" => Some(PlanState::AwaitingClarification),
@@ -94,4 +107,150 @@ pub fn record_event(
         params![event_id, run_id, seq, kind, created_at],
     )?;
     Ok(seq)
+}
+
+/// (A1 run-controls) Read a run's RAW `state` string (whatever is stored), or `None` if the run
+/// row does not exist. Unlike [`run_state`], this does NOT parse to a [`PlanState`], so it can
+/// observe the out-of-vocab terminal [`STATE_CANCELLED`] (which `run_state` would map to `None`,
+/// indistinguishable from a missing row). A control reader uses THIS to tell "cancelled run"
+/// (`Some("cancelled")`) apart from "no such run" (`None`).
+pub fn run_state_string(conn: &Connection, run_id: &str) -> Result<Option<String>> {
+    let s: Option<String> = conn
+        .query_row(
+            "SELECT state FROM agent_run WHERE run_id = ?1",
+            [run_id],
+            |r| r.get(0),
+        )
+        .optional()?;
+    Ok(s)
+}
+
+/// (A1 run-controls) True iff the run exists AND its `state` is the terminal [`STATE_CANCELLED`].
+/// `false` for a missing run or any non-cancelled state.
+pub fn is_cancelled(conn: &Connection, run_id: &str) -> Result<bool> {
+    Ok(run_state_string(conn, run_id)?.as_deref() == Some(STATE_CANCELLED))
+}
+
+/// The outcome of [`cancel_run`] — distinguishing the THREE fail-closed-safe cases the control
+/// plane must report differently (mirrors the workflow run-control vocabulary).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum CancelOutcome {
+    /// The run existed and was non-terminal: its `state` is now [`STATE_CANCELLED`].
+    Cancelled,
+    /// The run was ALREADY [`STATE_CANCELLED`]: idempotent no-op success (no second write).
+    AlreadyCancelled,
+    /// The run does not exist (no row to cancel): fail-closed, nothing written.
+    UnknownRun,
+}
+
+/// (A1 run-controls) CANCEL a run by writing the terminal [`STATE_CANCELLED`] `agent_run.state`,
+/// bypassing the [`PlanState`] transition machine (cancel is an out-of-band terminal stop, not a
+/// plan transition; the free-form TEXT column admits it with NO migration). Fail-closed and
+/// idempotent:
+///   - an UNKNOWN run writes nothing and returns [`CancelOutcome::UnknownRun`];
+///   - an ALREADY-cancelled run writes nothing and returns [`CancelOutcome::AlreadyCancelled`];
+///   - otherwise the state becomes `cancelled` and the fn returns [`CancelOutcome::Cancelled`].
+///
+/// **It NEVER touches `run_result`.** A run that already produced a terminal answer keeps it (the
+/// caller should refuse to cancel a completed run BEFORE calling this — see the control handler —
+/// but even if called, this only sets the `agent_run.state` flag and never clobbers a stored
+/// answer body/fingerprint). This is a state flag the LOOP and READERS can observe; it does not
+/// itself interrupt an in-flight loop mid-turn (the loop is synchronous per dispatch — cancel is
+/// observed between dispatches / on the next control read).
+pub fn cancel_run(conn: &Connection, run_id: &str, now: i64) -> Result<CancelOutcome> {
+    match run_state_string(conn, run_id)? {
+        None => Ok(CancelOutcome::UnknownRun),
+        Some(s) if s == STATE_CANCELLED => Ok(CancelOutcome::AlreadyCancelled),
+        Some(_) => {
+            conn.execute(
+                "UPDATE agent_run SET state = ?1, updated_at = ?2 WHERE run_id = ?3",
+                params![STATE_CANCELLED, now, run_id],
+            )?;
+            Ok(CancelOutcome::Cancelled)
+        }
+    }
+}
+
+#[cfg(test)]
+mod cancel_tests {
+    use super::*;
+    use crate::Db;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    static C: AtomicU64 = AtomicU64::new(0);
+    fn tmp(tag: &str) -> String {
+        std::env::temp_dir()
+            .join(format!(
+                "friday-agent-run-cancel-{}-{}-{}.sqlite",
+                std::process::id(),
+                tag,
+                C.fetch_add(1, Ordering::Relaxed)
+            ))
+            .to_string_lossy()
+            .into_owned()
+    }
+
+    #[test]
+    fn cancel_unknown_run_is_fail_closed_no_write() {
+        let db = Db::open_hub(&tmp("unknown")).unwrap();
+        assert_eq!(
+            cancel_run(db.conn(), "nope", 100).unwrap(),
+            CancelOutcome::UnknownRun
+        );
+        // Still no row (cancel never CREATES a run).
+        assert_eq!(run_state_string(db.conn(), "nope").unwrap(), None);
+        assert!(!is_cancelled(db.conn(), "nope").unwrap());
+    }
+
+    #[test]
+    fn cancel_live_run_writes_terminal_state_and_is_idempotent() {
+        let db = Db::open_hub(&tmp("live")).unwrap();
+        create_run(db.conn(), "r1", "do something", 1).unwrap();
+        // First cancel transitions the live run.
+        assert_eq!(
+            cancel_run(db.conn(), "r1", 2).unwrap(),
+            CancelOutcome::Cancelled
+        );
+        assert!(is_cancelled(db.conn(), "r1").unwrap());
+        assert_eq!(
+            run_state_string(db.conn(), "r1").unwrap().as_deref(),
+            Some(STATE_CANCELLED)
+        );
+        // Second cancel is an idempotent no-op success.
+        assert_eq!(
+            cancel_run(db.conn(), "r1", 3).unwrap(),
+            CancelOutcome::AlreadyCancelled
+        );
+        assert!(is_cancelled(db.conn(), "r1").unwrap());
+    }
+
+    #[test]
+    fn cancelled_state_is_outside_planstate_vocab_and_blocks_re_decide() {
+        // STATE_CANCELLED is NOT a PlanState ⇒ run_state() reads it back as None (no PlanState),
+        // and set_run_state can never transition out of it (the current state does not parse).
+        let db = Db::open_hub(&tmp("vocab")).unwrap();
+        create_run(db.conn(), "r1", "do something", 1).unwrap();
+        cancel_run(db.conn(), "r1", 2).unwrap();
+        assert_eq!(run_state(db.conn(), "r1").unwrap(), None);
+        // A re-decide attempt fails closed (current state unparseable ⇒ Unsupported), never
+        // resurrecting a cancelled run into the approval flow.
+        let err = set_run_state(db.conn(), "r1", PlanState::Approved, 4);
+        assert!(err.is_err(), "must not transition out of cancelled");
+        // The cancelled flag is intact after the refused transition.
+        assert!(is_cancelled(db.conn(), "r1").unwrap());
+    }
+
+    #[test]
+    fn run_state_string_distinguishes_cancelled_from_missing() {
+        let db = Db::open_hub(&tmp("distinguish")).unwrap();
+        create_run(db.conn(), "r1", "do something", 1).unwrap();
+        cancel_run(db.conn(), "r1", 2).unwrap();
+        // Cancelled run: Some("cancelled"); missing run: None — the control plane can tell them
+        // apart even though run_state() maps BOTH to None.
+        assert_eq!(
+            run_state_string(db.conn(), "r1").unwrap().as_deref(),
+            Some(STATE_CANCELLED)
+        );
+        assert_eq!(run_state_string(db.conn(), "ghost").unwrap(), None);
+    }
 }


### PR DESCRIPTION
## A1 / agent.runs run-controls — the on-wire control protocol (DARK + DEPLOY-GO-gated)

Builds the **real remaining Rust entrypoints** for A1: the on-wire run-CONTROL
protocol for the live agent-run. The run loop + dispatch transport + the S6
approve+execute leg already existed; what was missing (verified: the protocol
`Message` enum carried ONLY `AgentRunRequest`/`AgentRunResult`) was the wire protocol to
**surface a pause** and to drive **cancel / reject / resume** over the sealed WS session.

### DARK + DEPLOY-GO-gated (deploying this binary changes NO live behavior)
- A **NEW default-off flag `FRIDAY_AGENT_RUN_CONTROL_VIA_RUST`** (separate from the
  run-START flag `FRIDAY_ROUTE_AGENT_RUN_VIA_RUST`) gates all new emission/handling.
- **Flag OFF** (default): a paused run emits EXACTLY the pre-A1
  `AgentRunResult{status:"no_answer_safe_failure"}` bytes, and a v13 control message is a
  benign keepalive echo. Proven by a single deploy-safety test that exercises BOTH legs.
- The wire bump **v12 → v13** is additive (append-only variants + an additive-optional
  `constraints` field). Verified the production TS sealed-WS client
  (`src/api/mission-spine/friday-rust-hub-agent-run-ws-sealed-client.ts`) **ignores
  inbound `schema_version`** (it routes on `message.kind`), so the bump is safe for the
  live run-START leg too — consistent with the S-A 11→12 precedent.
- Extra care taken NOT to disturb the just-fixed live real-call path: the live dispatch
  arm is byte-identical when the flag is off; only additive accessors + a flag-gated
  branch were added.

### What is BUILT here (dark)
- `friday-protocol` (v13): `AgentRunPaused` / `AgentRunResume` / `AgentRunCancel` /
  `AgentRunReject` / `AgentRunControlResult` (refs-only — never a body/args), + an
  additive-optional `constraints` block on `AgentRunRequest`.
- `friday-storage` (**NO migration** — `agent_run.state` is free-form TEXT):
  `agent_run::cancel_run` writes the out-of-vocab terminal `cancelled` state (bypasses the
  `PlanState` machine, idempotent, never clobbers a completed `run_result`); reject reuses
  `pending_approval_request.status` (m0014).
- `friday-hub`:
  - `agent_run_control.rs` — pause-detection (DB read-back), owner-authed cancel/reject,
    resume (delegates VERBATIM to the S6 `resume_with_approval` spine — REUSE, not reimpl),
    and the `effective_run_policy`/`effective_max_turns` constraint mapping.
  - **THE LOAD-BEARING FIX:** reject/cancel were cosmetic — the S6 spine's single-use guard
    is the `consumed_approval` store, NOT `pending.status`/`agent_run.state`, so a later
    correctly-signed resume would STILL execute a rejected/cancelled mutation. `resume()`
    now pre-checks `is_cancelled` / `status=='rejected'` and refuses. Proven by two
    coupling tests.
  - Flag-gated server handlers in `hub_agent_run_server.rs` (owner-authed via the same
    `authenticate_forwarded` chain as dispatch) + additive `HubRuntime` accessors.

### Surface coverage (HONEST — ~3 net-new of 12 ops)
- **Built here (dark):** `agent.runs.cancel`, `agent.runs.reject(.tool)`,
  `agent.runs.approve(.tool)` (via resume), plus pause-surfacing.
- **Pre-existing:** `agent.runs.start`, `sessions.run`.
- **DEFERRED (not faked):** `agent.runs.rollback` (needs compensation/journaling design);
  `approve.plan`/`reject.plan` (the Rust loop never reaches `AwaitingPlanApproval` — there
  is NO plan-checkpoint to act on, so the plan-pause variant is NOT built);
  `agent.automations.{run,create,update,delete}` (not in Rust at all).
- **Constraints:** the wire shape + the pure `effective_run_policy`/`effective_max_turns`
  mapping are built + tested, but APPLYING them on the live dispatch is deferred (it would
  require threading a per-run policy override through the just-fixed run-START path).
  cancel/reject/resume do NOT depend on constraints being applied — they operate on the
  pending row / run state regardless — so the deferral does not hollow them out.

### Tests
`1371` workspace tests pass (`0` failed). `cargo clippy --workspace --all-targets -D
warnings` clean. New: 6 protocol codec tests, 4 storage cancel tests, 10 control-module
unit tests (incl. the two reject/cancel↔resume coupling tests), 3 server tests (incl. the
flag-off/flag-on deploy-safety test).

### Open questions for the operator
- Should `cancel`/`reject` ALSO require an operator signature (like resume), or is
  trusted-peer + owner-match sufficient? (They carry no operator signature today.)
- The reject/cancel↔resume coupling is fixed at the A1 handler, but the SAME hole persists
  at the S6 spine level (`consumed_approval` not burned on reject/cancel) and in the
  existing `hub_resume_approval.rs` dev bridge — harden the spine, or is the handler
  pre-check the intended boundary?
- Apply per-run constraints on the live run-START dispatch now (touches the just-fixed
  real-call path), or keep deferred?

**Do NOT merge.** Dark, unmerged, operator-gated. Flipping the flag (and any live
application of constraints) is a DEPLOY-GO decision. NOT `executeRun`-replaced; NOT v1 GO.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
