### PR TITLE
fix(ns-hardening): close dot-join namespace collision (TS+Rust shared, F5.5) — TS LIVE / Rust DARK

### DIFF
--- a/rust-core/crates/friday-hub/src/session_namespace.rs
+++ b/rust-core/crates/friday-hub/src/session_namespace.rs
@@ -7,8 +7,9 @@
 //! user's memory is isolated PER (account, channel) instead of being shared across every
 //! channel for the same user.
 //!
-//! Format (byte-identical to the TS — including the Unicode-aware lowercasing; see the
-//! normalization note on the dot-join residual that is SHARED with the TS oracle):
+//! Format (byte-identical to the TS — including the Unicode-aware lowercasing; the dot-join
+//! collision is now CLOSED in BOTH halves by dropping `.` from the segment keep-set, see the
+//! normalization note on [`is_kept`]):
 //! ```text
 //! tenant.<accountId>.channel.<channel>.user.<normalizedUserId>.shared
 //! ```
@@ -284,7 +285,7 @@ fn falsy_or<'a>(value: Option<&'a str>, fallback: &'a str) -> &'a str {
 /// Byte-identical port of the TS `normalizeNamespaceSegment`:
 /// ```js
 /// value.toLowerCase()
-///   .replace(/[^a-z0-9._-]/g, "-")
+///   .replace(/[^a-z0-9_-]/g, "-")
 ///   .replace(/-+/g, "-")
 ///   .replace(/^-|-$/g, "");
 /// // empty result -> "default"
@@ -305,14 +306,19 @@ fn falsy_or<'a>(value: Option<&'a str>, fallback: &'a str) -> &'a str {
 /// they agree on the single-codepoint mappings relevant to the keep-set; this is now a
 /// faithful port, not a documented gap.
 ///
-/// Residual (genuinely shared with the TS, not a Rust divergence): the dot is in the
-/// keep-set and segments are `.`-joined, so an id literally containing the joiner/segment
-/// words could in principle collide with a different (account, channel, user) triple. This
-/// is byte-faithful to the TS oracle (same unescaped join + same keep-set), so it is NOT a
-/// Rust regression; closing it is a SHARED TS+Rust hardening follow-on (segment-escape /
-/// dot-reject), out of scope for this parity slice.
+/// Collision hardening (F5.5 — CLOSED, shared TS+Rust): the dot-join collision is now
+/// closed by DROPPING `.` from the keep-set (see [`is_kept`]). Previously `.` was kept AND
+/// used as the segment joiner, so an id literally containing the joiner/segment words (e.g.
+/// `alice.channel.evil.user.bob`) could forge a different (account, channel, user) triple's
+/// namespace string — the composite is the memory `principal_id` SCOPE, so that was a
+/// cross-scope read/write collision. With `.` mapped to `-` in every segment, the composite
+/// always splits into exactly the seven fixed-position parts, so the mapping is injective
+/// over NORMALIZED segment tuples — this closes the CROSS-POSITION joiner-injection. The
+/// WITHIN-position normalization stays lossy (`a.b` ≡ `a-b`, same accepted behavior as
+/// `@` → `-`), lower-severity and not exploitable under single-owner v1. The change is
+/// byte-identical to the LIVE TS oracle (`/[^a-z0-9_-]/g`), preserving the parity contract.
 pub fn normalize_namespace_segment(value: &str) -> String {
-    // Step 1: toLowerCase() then replace each char NOT in [a-z0-9._-] with '-'. Use the
+    // Step 1: toLowerCase() then replace each char NOT in [a-z0-9_-] with '-'. Use the
     // Unicode-aware `to_lowercase` (matches JS `.toLowerCase()`), NOT `to_ascii_lowercase`,
     // so a non-ASCII char JS folds into a kept ASCII char (e.g. Kelvin U+212A -> 'k') is
     // kept identically here instead of collapsing to '-'.
@@ -357,10 +363,21 @@ pub fn normalize_namespace_segment(value: &str) -> String {
     }
 }
 
-/// The TS keep-set `[a-z0-9._-]` (applied AFTER `toLowerCase`, so uppercase A-Z is already
+/// The TS keep-set `[a-z0-9_-]` (applied AFTER `toLowerCase`, so uppercase A-Z is already
 /// lowered and never reaches here as uppercase).
+///
+/// COLLISION HARDENING (F5.5): the literal `.` is DELIBERATELY EXCLUDED (it maps to `-` like
+/// any other punctuation). `.` is the SEGMENT JOINER used by
+/// [`resolve_session_memory_namespace`] (`.join(".")`), and that composite string becomes
+/// the memory `principal_id` SCOPE. Stripping `.` from every segment makes the composite
+/// always split into exactly the seven fixed-position parts, so the mapping is injective
+/// over NORMALIZED segment tuples — a userId literally containing `.` can no longer forge a
+/// different tuple's split (the CROSS-POSITION collision). The WITHIN-position normalization
+/// stays lossy (`a.b` ≡ `a-b`, same as the accepted `@` → `-`). This keep-set is
+/// byte-identical to the LIVE TS oracle `normalizeNamespaceSegment` (`/[^a-z0-9_-]/g`); the
+/// two MUST stay in lockstep.
 fn is_kept(ch: char) -> bool {
-    ch.is_ascii_lowercase() || ch.is_ascii_digit() || ch == '.' || ch == '_' || ch == '-'
+    ch.is_ascii_lowercase() || ch.is_ascii_digit() || ch == '_' || ch == '-'
 }
 
 #[cfg(test)]
@@ -413,6 +430,55 @@ mod tests {
     }
 
     #[test]
+    fn dot_join_collision_is_closed_distinct_tuples_never_collide() {
+        // F5.5 SHARED collision test (mirrored byte-for-byte in the TS test).
+        //
+        // The joiner-INJECTION vector: a userId / accountId literally containing the joiner
+        // word `.user.` (or `.channel.`) could, when `.` was kept intra-segment, forge a
+        // DIFFERENT (account, channel, user) tuple's composite string — and that string is
+        // the memory `principal_id` SCOPE, so distinct users would share one scope.
+        //
+        // Pre-fix these two DISTINCT tuples both produced
+        //   `tenant.a.channel.b.user.x.user.y.shared`  ← a real cross-tuple collision.
+        // Post-fix the embedded `.`s map to `-`, so they are DISTINCT.
+        let forged = resolve_session_memory_namespace(
+            Some("a"),
+            Some("b"),
+            Some("x.user.y"), // a userId that embeds the `.user.` joiner
+        )
+        .unwrap();
+        let victim = resolve_session_memory_namespace(
+            Some("a"),
+            Some("b.user.x"), // a channel that embeds the `.user.` joiner
+            Some("y"),
+        )
+        .unwrap();
+        assert_ne!(
+            forged, victim,
+            "distinct (account, channel, user) tuples must NEVER produce the same namespace"
+        );
+        assert_eq!(forged, "tenant.a.channel.b.user.x-user-y.shared");
+        assert_eq!(victim, "tenant.a.channel.b-user-x.user.y.shared");
+
+        // INJECTIVITY by construction: with `.` dropped from every segment, the composite
+        // splits into EXACTLY the seven fixed-position parts, so the parts (after the fixed
+        // tenant/channel/user/shared markers) round-trip the original normalized tuple.
+        let parts: Vec<&str> = forged.split('.').collect();
+        assert_eq!(parts.len(), 7, "namespace must be exactly 7 dot-parts");
+        assert_eq!(parts[0], "tenant");
+        assert_eq!(parts[2], "channel");
+        assert_eq!(parts[4], "user");
+        assert_eq!(parts[6], "shared");
+        // The account / channel / user payload positions never contain a `.`.
+        for payload in [parts[1], parts[3], parts[5]] {
+            assert!(
+                !payload.contains('.'),
+                "no segment may contain the joiner '.', got {payload:?}"
+            );
+        }
+    }
+
+    #[test]
     fn fails_closed_when_no_user_id() {
         // TS throws MEMORY_NAMESPACE_UNRESOLVABLE; we return the typed error. This is the
         // parity for the "no userId available" case (the DM/subagent fallbacks — now
@@ -431,7 +497,8 @@ mod tests {
 
     #[test]
     fn replaces_special_characters_in_user_id() {
-        // TS: "user@example.com" -> "user-example.com" ('@' -> '-', dots PRESERVED).
+        // F5.5 collision hardening: "user@example.com" -> "user-example-com" — '@' AND the
+        // literal '.' both map to '-' (the dot is no longer kept; it is the segment joiner).
         let ns = resolve_session_memory_namespace(
             Some("default"),
             Some("discord"),
@@ -440,7 +507,7 @@ mod tests {
         .unwrap();
         assert_eq!(
             ns,
-            "tenant.default.channel.discord.user.user-example.com.shared"
+            "tenant.default.channel.discord.user.user-example-com.shared"
         );
     }
 
@@ -486,13 +553,17 @@ mod tests {
         assert_eq!(normalize_namespace_segment(""), "default");
         // Runs of disallowed chars collapse to ONE '-'.
         assert_eq!(normalize_namespace_segment("a   b---c"), "a-b-c");
-        // Dots, underscores, hyphens are KEPT.
-        assert_eq!(normalize_namespace_segment("a.b_c-d"), "a.b_c-d");
-        // user@example.com (the segment-level vector).
+        // F5.5: underscores and hyphens are KEPT; the literal '.' is NOT (it maps to '-',
+        // then collapses with adjacent '-'). It is the segment joiner, never an intra-segment
+        // char.
+        assert_eq!(normalize_namespace_segment("a.b_c-d"), "a-b_c-d");
+        // user@example.com (the segment-level vector): '@' and '.' both -> '-'.
         assert_eq!(
             normalize_namespace_segment("user@example.com"),
-            "user-example.com"
+            "user-example-com"
         );
+        // A bare run of dots collapses to ONE '-' then trims to empty -> "default".
+        assert_eq!(normalize_namespace_segment("..."), "default");
         // Non-ASCII is outside the keep-set and becomes '-' (then collapses/trims).
         assert_eq!(normalize_namespace_segment("héllo"), "h-llo");
         assert_eq!(normalize_namespace_segment("名前"), "default");

--- a/src/sessions/services/friday-session-memory-namespace.ts
+++ b/src/sessions/services/friday-session-memory-namespace.ts
@@ -122,10 +122,33 @@ function resolveEffectiveUserId(
   return undefined;
 }
 
+/**
+ * Normalize a single namespace SEGMENT.
+ *
+ * Pipeline: lowercase → replace every char NOT in the keep-set `[a-z0-9_-]` with `-`
+ * → collapse runs of `-` → trim leading/trailing `-` → empty result becomes `default`.
+ *
+ * COLLISION HARDENING (F5.5): the literal `.` is DELIBERATELY EXCLUDED from the keep-set
+ * (it maps to `-` like any other punctuation). `.` is the SEGMENT JOINER used by
+ * {@link resolveFridaySessionMemoryNamespace} (`[...].join(".")`), and that composite string
+ * becomes the memory store SCOPE (the Rust `principal_id`). If a segment could itself
+ * contain a `.`, a userId such as `alice.channel.evil.user.bob` could FORGE a different
+ * (account, channel, user) tuple's namespace string — a cross-scope memory read/write
+ * collision. With `.` stripped from every segment, the composite ALWAYS splits into exactly
+ * the seven fixed-position parts, so the mapping is injective over NORMALIZED segment
+ * tuples: this closes the CROSS-POSITION joiner-injection (a segment can no longer forge a
+ * different account/channel/user split). The WITHIN-position normalization stays lossy
+ * (`a.b` ≡ `a-b`, the same accepted behavior as the pre-existing `@` → `-`); that is
+ * lower-severity and not exploitable under the single-owner v1 threat model.
+ *
+ * PARITY: this keep-set is byte-identical to the Rust port `normalize_namespace_segment`
+ * / `is_kept` in `rust-core/crates/friday-hub/src/session_namespace.rs`. The two MUST stay
+ * in lockstep (the Rust half binds the same composite string to its `principal_id` scope).
+ */
 function normalizeNamespaceSegment(value: string): string {
   const normalized = value
     .toLowerCase()
-    .replace(/[^a-z0-9._-]/g, "-")
+    .replace(/[^a-z0-9_-]/g, "-")
     .replace(/-+/g, "-")
     .replace(/^-|-$/g, "");
 

--- a/test/unit/sessions/services/friday-session-memory-namespace.test.ts
+++ b/test/unit/sessions/services/friday-session-memory-namespace.test.ts
@@ -95,10 +95,41 @@ describe("FridaySessionMemoryNamespace", () => {
       }
     });
 
-    it("replaces special characters in userId", () => {
+    it("replaces special characters in userId (including the dot — F5.5 hardening)", () => {
+      // F5.5 collision hardening: '@' AND the literal '.' both map to '-'. The dot is the
+      // segment joiner and is no longer kept inside a segment.
       const session = makeSession({ userId: "user@example.com" });
       const ns = resolveFridaySessionMemoryNamespace(session);
-      expect(ns).toBe("tenant.default.channel.discord.user.user-example.com.shared");
+      expect(ns).toBe("tenant.default.channel.discord.user.user-example-com.shared");
+    });
+
+    it("closes the dot-join collision: distinct tuples never collide (F5.5)", () => {
+      // The joiner-INJECTION vector: a userId / accountId literally containing the joiner
+      // word `.user.` could, when `.` was kept intra-segment, forge a DIFFERENT
+      // (account, channel, user) tuple's composite string — and that string IS the memory
+      // principal_id SCOPE, so distinct users would share one scope.
+      //
+      // Pre-fix both of these DISTINCT tuples produced
+      //   `tenant.a.channel.b.user.x.user.y.shared`  ← a real cross-tuple collision.
+      // Post-fix the embedded `.`s map to `-`, so they are DISTINCT.
+      const forged = resolveFridaySessionMemoryNamespace(
+        makeSession({ accountId: "a", channel: "b", userId: "x.user.y" }),
+      );
+      const victim = resolveFridaySessionMemoryNamespace(
+        makeSession({ accountId: "a", channel: "b.user.x", userId: "y" }),
+      );
+      expect(forged).not.toBe(victim);
+      expect(forged).toBe("tenant.a.channel.b.user.x-user-y.shared");
+      expect(victim).toBe("tenant.a.channel.b-user-x.user.y.shared");
+
+      // INJECTIVITY by construction: with `.` dropped from every segment, the composite
+      // splits into EXACTLY the seven fixed-position parts; no payload segment contains a dot.
+      const parts = forged.split(".");
+      expect(parts.length).toBe(7);
+      expect([parts[0], parts[2], parts[4], parts[6]]).toEqual(["tenant", "channel", "user", "shared"]);
+      for (const payload of [parts[1], parts[3], parts[5]]) {
+        expect(payload).not.toContain(".");
+      }
     });
 
     it("normalizes account and channel segments", () => {


### PR DESCRIPTION
## ns-hardening (F5.5): dot-join namespace collision hardening (TS+Rust shared)

### What this closes
The session-memory namespace is built by `.`-joining 7 segments
(`tenant.<account>.channel.<channel>.user.<user>.shared`) into a composite
string that becomes the memory **`principal_id` SCOPE** (Rust
`lib.rs:6161`, `memory_extraction.rs:456`). The segment normalizer **kept
the literal `.`** — TS `normalizeNamespaceSegment` regex `/[^a-z0-9._-]/g`
(`.` in the keep-class) and Rust `is_kept` returning `true` for `.`.

Because `.` was both a kept intra-segment char **and** the segment joiner,
a userId / accountId / channel literally containing the joiner word (e.g. a
userId `x.user.y`) could **forge a different (account, channel, user)
tuple's** namespace string → a cross-scope memory read/write collision.
Concretely, pre-fix both of these DISTINCT tuples produced the SAME string
`tenant.a.channel.b.user.x.user.y.shared`:
- `(a, b, "x.user.y")`
- `(a, "b.user.x", y)`

### Fix — drop-dot (chosen over escape-dot)
Drop `.` from the segment keep-set in **both** halves identically — `.` now
maps to `-` like any other punctuation. With no `.` inside any segment, the
composite always splits into exactly the seven fixed-position parts, so the
mapping is **injective over normalized segment tuples**: this closes the
**cross-position joiner-injection** (a segment can no longer forge a
different account/channel/user split). The **within-position** normalization
stays lossy (`a.b` ≡ `a-b`, the same accepted behavior as the pre-existing
`@` → `-`) — lower-severity and not exploitable under single-owner v1; this
is NOT a universal-injectivity claim.

This is a one-character, **byte-identical** TS↔Rust change that preserves
the parity contract. Escape-dot was rejected because the TS-regex /
Rust-char-loop escaping schemes diverge and the escape char itself needs
escaping — exactly what the byte-identical parity rule punishes.

A shared collision test (two distinct tuples must never produce the same
namespace + 7-part injectivity assertions) is added in both TS and Rust, and
the stale dotted-segment assertions + doc comments are updated (the residual
the Rust header previously documented as OPEN is now CLOSED).

### Status
- **Rust half = DARK + DEPLOY-GO-gated** — deploying the binary changes no
  live behavior (the Rust extraction path is dark; this is a parity port).
- **TS half = LIVE** — `normalizeNamespaceSegment` is on the live TS
  memory-namespace path. Deploying it **re-scopes** any EXISTING memory whose
  segment legitimately contained a `.` (an email-shaped userId, a dotted
  accountId/channel): that memory's `principal_id` derivation changes, so it
  is orphaned. Under the single-owner v1 threat model (enforce_single_peer,
  one configured owner) userIds are not adversarially controlled, so the
  collision itself is **defense-in-depth**, not an active exploit — but the
  re-scope is a real one-way data effect (see operator gate below).
- **No migration** (string-derivation change only; no schema). No backfill /
  dual-read mitigation is wired (the spec chose migration-free).

### Operator gate (live re-scope)
Before the **TS half** ships, the operator must confirm or accept that any
existing memory in the **prod store** whose `principal_id` has a dotted
segment (email-shaped userId, dotted account/channel) will be orphaned. The
blast radius cannot be verified from this repo — the audit found zero dotted
namespaces in *test expectations*, but the live risk is in the prod memory
store, which is not (and should not be) inspected here. Re-scoping is one-way
and there is no migration/backfill hook.

### What remains
- The operator confirmation/accept above (the only gate).
- This PR is intentionally SEPARATE (disjoint subsystem from the agent-run /
  workflow planes); the TS+Rust edits are in the SAME PR by parity-lockstep
  mandate.

### Tests (honest counts)
- TS: `friday-session-memory-namespace.test.ts` 15 tests pass (incl. new
  collision test); `friday-session-service.test.ts` 95 pass; memory-guard /
  agent-tools / session-routes consumer suites 153 pass. TS lint 0 errors.
- Rust: `session_namespace` lib unit tests 20/20 pass (incl. new
  `dot_join_collision_is_closed_distinct_tuples_never_collide`); full
  `friday-hub` lib 504/504 pass; `memory_extraction` 14, `hub_extract_memory`
  bin 6 pass. `cargo clippy -p friday-hub --all-targets -D warnings` clean (0).
  `cargo fmt` (pinned 1.95.0) applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
