### PR TITLE
fix(rust-hub): leg-A answer-return decouple — sealed-WS client settles on refs ALONE (#655 Part 4)

### DIFF
--- a/rust-core/crates/friday-hub/src/bin/hub_agent_run_server.rs
+++ b/rust-core/crates/friday-hub/src/bin/hub_agent_run_server.rs
@@ -2862,9 +2862,21 @@ mod tests {
     }
 
     // (1) FULL ROUND-TRIP: the real TS sealed client ↔ the real server. The allowlisted client +
-    // allowlisted principal ⇒ the loop runs, a REFS-ONLY result is returned, AND the TS client opens
-    // the owner-sealed body back to "PONG". Proves TS-seal → Rust-open (auth_proof accepted) AND
-    // Rust-seal → TS-open (owner body) over the REAL protocol.
+    // allowlisted principal ⇒ the loop runs and a REFS-ONLY result is returned. (leg-A decouple,
+    // #655 Part 4) The TS client now SETTLES on the refs envelope ALONE — it no longer awaits or
+    // surfaces the owner-sealed body frame (compose sources the body from the owner-gated DB
+    // readback). So we assert the REFS the client surfaces (status/sha256/len from the FIRST
+    // envelope); proving TS-seal → Rust-open (auth_proof accepted) + refs settle over the REAL
+    // protocol. The server STILL persists the body to the DB + STILL emits the body frame after
+    // the refs frame. For a SMALL body (this "PONG") `accept_one` returns Ok(1): the post-refs
+    // body send lands in the loopback send buffer before the client's teardown RST is processed.
+    // NOTE (characterized, flagged to the operator — NOT fixed here, server-logic is out of
+    // leg-A scope): for a LARGE answer (empirically ~256KB) the body write is still pending when
+    // the client's RST arrives, so `ws_send_envelope(body)` returns Err → `serve_sealed_session`
+    // returns Err → `accept_one` is Err and logs `leg=body_send error=transport_closed`. This is
+    // a benign log (the answer is committed in the DB and the client already settled on refs), but
+    // it fires on otherwise-healthy large-answer runs. Making the body send non-fatal is a
+    // follow-up server change.
     #[test]
     #[ignore = "needs `node` + the prebuilt interop bundle; opt in with --ignored"]
     fn interop_ts_client_full_round_trip_pong() {
@@ -2884,6 +2896,10 @@ mod tests {
             "run-interop-ok",
         );
         // SERVER serves on the main thread (non-Send runtime); the TS client drives the socket.
+        // (leg-A decouple) The dispatch still processes ONE authed run even though the client
+        // settles on refs and tears down before draining the body frame — for this SMALL body the
+        // body send lands in the loopback send buffer, so `serve_sealed_session` returns Ok (no
+        // error settle). (Large bodies can Err on the body send; see the NOTE on the test above.)
         let processed = listener
             .accept_one(&server_kp, &rt, &owner_allowlist, &peer_allowlist, false)
             .expect("server serves the interop session");
@@ -2895,13 +2911,14 @@ mod tests {
             serde_json::json!(true),
             "TS client reports success: {v:?}"
         );
-        assert_eq!(
-            v["body"],
-            serde_json::json!(ANSWER),
-            "TS client opened the owner-sealed body"
+        // (leg-A decouple) The client no longer surfaces a body — it settles on the refs alone.
+        assert!(
+            v.get("body").is_none(),
+            "leg-A decouple: the client surfaces NO body (refs-only settle): {v:?}"
         );
         assert_eq!(v["runId"], serde_json::json!("run-interop-ok"));
-        // The refs fingerprint matches the body (TS surfaces sha256/len from the refs result).
+        // The refs fingerprint is surfaced from the FIRST (refs) envelope — sha256/len of the answer
+        // the server persisted (and which the owner-gated DB readback will return to compose).
         assert_eq!(
             v["answerSha256"],
             serde_json::json!(sha256_hex(ANSWER.as_bytes())),

--- a/src/api/mission-spine/friday-rust-hub-agent-run-ws-sealed-client.ts
+++ b/src/api/mission-spine/friday-rust-hub-agent-run-ws-sealed-client.ts
@@ -11,10 +11,8 @@ import {
   decodeSealed,
   deviceKeypairFromSecret,
   encodeSealed,
-  hexDecode,
   open,
   seal,
-  sha256Hex,
   X25519_PUBKEY_LEN,
 } from "./friday-rust-hub-agent-run-ws-sealed-crypto.js";
 
@@ -41,9 +39,13 @@ import {
  *   4. `session_key = HKDF(X25519(client_priv, server_pub))`.
  *   5. Send an `AgentRunRequest` Envelope sealed under the session key (XChaCha20-Poly1305),
  *      with a per-request `auth_proof` sealed over `AUTH_CHALLENGE || session_nonce`.
- *   6. Read TWO inbound sealed envelopes: the refs-only `AgentRunResult` FIRST, then (only if
- *      a body was delivered) a SECOND `AskFridayStream{seq:0, chunk:hex}` carrying the
- *      DOUBLY-sealed body. A denied/no-answer outcome sends NO body envelope.
+ *   6. (leg-A decouple, #655 Part 4) SETTLE on the FIRST inbound sealed envelope — the refs-only
+ *      `AgentRunResult` (status + answer fingerprint + A1 counts) — ALONE. The client no longer
+ *      awaits the SECOND owner-sealed body frame: the authoritative answer body is sourced by
+ *      compose from the owner-gated DB readback, not from the WS frame. The server still emits the
+ *      body frame after the refs frame, and still persists the body to the Hub DB BEFORE emitting
+ *      refs (so the readback always finds a committed row when refs arrive — no not_found race);
+ *      this client simply settles on refs and tears down without draining the body frame.
  *
  * ## Threat model (HONEST — loopback only)
  * The server binds 127.0.0.1 only; this client connects only to loopback. The client
@@ -138,9 +140,13 @@ export interface FridayRustHubAgentRunSealedRequest {
 }
 
 /**
- * The result of a sealed dispatch: the REFS-ONLY receipt PLUS the opened owner-sealed body,
- * when the run delivered one. The body is surfaced ONLY to the authed in-process caller (it
- * arrived doubly-sealed over the owner-only channel); it is NEVER on the refs receipt itself.
+ * The result of a sealed dispatch: the REFS-ONLY receipt (status + answer fingerprint +
+ * A1 counts). (leg-A decouple, #655 Part 4) The dispatch now SETTLES on the refs envelope
+ * ALONE — it no longer awaits or surfaces the owner-sealed body frame. The authoritative
+ * answer body is sourced by compose from the owner-gated DB readback
+ * (`FridayRustHubRunAnswerReadbackService.readAnswer`), never from the WS body frame, so the
+ * client carries NO `body` field. (The Rust server still PERSISTS the body to the Hub DB and
+ * still emits the body frame after the refs frame; this client simply does not wait for it.)
  */
 export interface FridayRustHubAgentRunSealedResult {
   readonly truthLabel: "rust_wired";
@@ -171,11 +177,6 @@ export interface FridayRustHubAgentRunSealedResult {
   readonly promptTokens?: number;
   /** (A1) REFS-surface run METADATA: completion-token total, when known. DEFERRED ⇒ `undefined`. */
   readonly completionTokens?: number;
-  /**
-   * The OPENED answer body, when the run delivered one to this owner. Absent on a denied /
-   * no-answer outcome. NOT a refs field — it arrived doubly-sealed over the owner channel.
-   */
-  readonly body?: string;
 }
 
 export interface CreateFridayRustHubAgentRunSealedClientOptions {
@@ -195,9 +196,11 @@ export interface CreateFridayRustHubAgentRunSealedClientOptions {
 
 export interface FridayRustHubAgentRunSealedClient {
   /**
-   * Dispatch one agent-run over a sealed session and await its result. Connects, runs the
-   * preamble + WS upgrade, seals the request, reads the refs result + optional owner-sealed
-   * body, then closes. Fails closed (503) on any non-clean settle.
+   * Dispatch one agent-run over a sealed session and await its REFS-ONLY result. Connects, runs
+   * the preamble + WS upgrade, seals the request, reads the FIRST (refs) result envelope, then
+   * settles and closes — it does NOT await the owner-sealed body frame (leg-A decouple, #655 Part
+   * 4; compose sources the body from the owner-gated DB readback). Fails closed (503) on any
+   * non-clean settle, including a session that closes BEFORE any refs arrive.
    */
   dispatchRun(
     request: FridayRustHubAgentRunSealedRequest,
@@ -417,11 +420,18 @@ interface ResultRefs {
 }
 
 /**
- * The two-envelope read state + settlement callbacks, shared between the inbound-message handler
- * and the server-close handler. Extracted to a module-level factory so the dispatch closure stays
- * small and the read-loop logic is testable in isolation.
+ * The refs read state + settlement callbacks, shared between the inbound-message handler and the
+ * server-close handler. Extracted to a module-level factory so the dispatch closure stays small
+ * and the settle logic is testable in isolation.
+ *
+ * (leg-A decouple, #655 Part 4) The dispatch settles on the FIRST (refs) envelope alone; `refs`
+ * is the only accumulated state, read by the close handler to distinguish a clean settle from a
+ * close-before-any-refs fail-closed.
+ *
+ * EXPORTED (with {@link handleResult} / {@link handleServerClose}) ONLY so the settle-branch logic
+ * is unit-testable against a fake ctx without a socket; not part of the public dispatch surface.
  */
-interface InboundContext {
+export interface InboundContext {
   /** Set once the handshake derives the session key (mutated in the async setup). */
   sessionKey: Uint8Array;
   /** Mutable refs slot — set by the result handler, read by the close handler. */
@@ -430,8 +440,8 @@ interface InboundContext {
   fail(error: FridayDomainError): void;
 }
 
-/** Settle from the accumulated refs + the (optional) opened body. */
-function finishWithBody(ctx: InboundContext, body: string | undefined): void {
+/** Settle from the accumulated refs (status + answer fingerprint + A1 counts). */
+function finishFromRefs(ctx: InboundContext): void {
   const { refs } = ctx;
   if (!refs) {
     ctx.fail(unavailable("Sealed agent-run client never received a result ref."));
@@ -448,12 +458,20 @@ function finishWithBody(ctx: InboundContext, body: string | undefined): void {
     ...(refs.executedTools !== undefined ? { executedTools: refs.executedTools } : {}),
     ...(refs.promptTokens !== undefined ? { promptTokens: refs.promptTokens } : {}),
     ...(refs.completionTokens !== undefined ? { completionTokens: refs.completionTokens } : {}),
-    ...(body !== undefined ? { body } : {}),
   });
 }
 
-/** Handle the refs-only `AgentRunResult` envelope (the FIRST inbound). */
-function handleResult(ctx: InboundContext, fields: Record<string, unknown>): void {
+/**
+ * Handle the refs-only `AgentRunResult` envelope (the FIRST and ONLY inbound the client awaits).
+ *
+ * (leg-A decouple, #655 Part 4) SETTLE IMMEDIATELY on the refs — whether or not a fingerprint is
+ * present. Previously, a result carrying `answer_sha256`/`answer_len` made the client WAIT for a
+ * SECOND owner-sealed body frame; that wait is removed. The body is sourced by compose from the
+ * owner-gated DB readback, and the server persists the body BEFORE emitting these refs, so a
+ * committed row is guaranteed to exist when this settles (no not_found race). A missing required
+ * ref (`run_id`/`status`) still fails closed — the refs-surface contract is preserved.
+ */
+export function handleResult(ctx: InboundContext, fields: Record<string, unknown>): void {
   const runId = asString(fields.run_id);
   const status = asString(fields.status);
   if (!runId || !status) {
@@ -478,51 +496,17 @@ function handleResult(ctx: InboundContext, fields: Record<string, unknown>): voi
     ...(promptTokens !== undefined ? { promptTokens } : {}),
     ...(completionTokens !== undefined ? { completionTokens } : {}),
   };
-  // No fingerprint ⇒ no answer ⇒ no body envelope follows; settle now. Otherwise wait (bounded)
-  // for the SECOND (body) envelope.
-  if (answerSha256 === undefined && answerLen === undefined) {
-    finishWithBody(ctx, undefined);
-  }
+  // (leg-A decouple) Settle on the refs ALONE — the body frame (if any) is no longer awaited.
+  finishFromRefs(ctx);
 }
 
-/** Handle the owner-sealed body envelope (`AskFridayStream`, the optional SECOND inbound). */
-function handleBody(ctx: InboundContext, fields: Record<string, unknown>): void {
-  // chunk = hex(encode_sealed(seal(session_key, body, SESSION_AAD))). DOUBLY sealed: the
-  // transport already opened the OUTER seal; the chunk hex-decodes to a SECOND sealed blob we
-  // open again under the session key.
-  const chunk = asString(fields.chunk);
-  if (chunk === undefined) {
-    ctx.fail(unavailable("Sealed agent-run client body chunk missing."));
-    return;
-  }
-  let body: string;
-  try {
-    const innerSealed = decodeSealed(hexDecode(chunk));
-    body = Buffer.from(open(ctx.sessionKey, innerSealed, SESSION_AAD)).toString("utf8");
-  } catch {
-    ctx.fail(unavailable("Sealed agent-run client could not open the owner-sealed body."));
-    return;
-  }
-  // Defensive: a DELIVERED body MUST carry a refs fingerprint, and that fingerprint MUST match the
-  // opened body — on BOTH sha256 AND byte length. The server always emits sha256+len together with a
-  // body; a body with no sha256 ref, a sha256 mismatch, or a len mismatch is fail-closed (never
-  // surfaced unverified). This holds the integrity check independent of the loopback trust model.
-  if (ctx.refs?.answerSha256 === undefined) {
-    ctx.fail(unavailable("Sealed agent-run client received a body with no fingerprint ref."));
-    return;
-  }
-  if (ctx.refs.answerSha256 !== sha256Hex(Buffer.from(body, "utf8"))) {
-    ctx.fail(unavailable("Sealed agent-run client body fingerprint mismatch."));
-    return;
-  }
-  if (ctx.refs.answerLen !== undefined && ctx.refs.answerLen !== Buffer.byteLength(body, "utf8")) {
-    ctx.fail(unavailable("Sealed agent-run client body length mismatch."));
-    return;
-  }
-  finishWithBody(ctx, body);
-}
-
-/** Dispatch one opened inbound envelope to its handler (result / body / unknown ⇒ fail-closed). */
+/**
+ * Dispatch one opened inbound envelope to its handler. (leg-A decouple, #655 Part 4) The client
+ * settles synchronously on the FIRST `AgentRunResult`, so any later frame (e.g. the now-ignored
+ * owner-sealed body `AskFridayStream`) arrives after teardown removed the listeners and after the
+ * `settled` guard is set — a no-op. We keep the kind dispatch narrow: only `AgentRunResult` is a
+ * recognized inbound; anything else BEFORE a result is fail-closed.
+ */
 function handleInbound(ctx: InboundContext, payload: Buffer): void {
   let inbound: InboundEnvelope;
   try {
@@ -535,28 +519,21 @@ function handleInbound(ctx: InboundContext, payload: Buffer): void {
     handleResult(ctx, inbound.fields);
     return;
   }
-  if (inbound.kind === "AskFridayStream") {
-    handleBody(ctx, inbound.fields);
-    return;
-  }
   ctx.fail(unavailable("Sealed agent-run client received an unknown message shape."));
 }
 
 /**
  * Handle the server ending the session. A close BEFORE any refs is the FAIL-CLOSED path (forged
- * peer / bad principal — the server established no session or ran nothing). With refs present, a
- * missing body is fail-closed only when the refs indicated an answer exists.
+ * peer / bad principal — the server established no session or ran nothing) and stays a 503. With
+ * refs present the client already settled on them, so `succeed`'s `settled` guard makes this a
+ * no-op; `finishFromRefs` is a defensive backstop for the (unreached) refs-present close.
  */
-function handleServerClose(ctx: InboundContext): void {
+export function handleServerClose(ctx: InboundContext): void {
   if (!ctx.refs) {
     ctx.fail(unavailable("Sealed agent-run client connection closed before a result."));
     return;
   }
-  if (ctx.refs.answerSha256 !== undefined || ctx.refs.answerLen !== undefined) {
-    ctx.fail(unavailable("Sealed agent-run client connection closed before the body."));
-    return;
-  }
-  finishWithBody(ctx, undefined);
+  finishFromRefs(ctx);
 }
 
 export function createFridayRustHubAgentRunSealedClient(
@@ -681,7 +658,8 @@ export function createFridayRustHubAgentRunSealedClient(
               handleInbound(ctx, data);
             });
             // The server closed the session. Before any refs ⇒ fail-closed (forged peer / bad
-            // principal); after refs ⇒ settle (or fail if a promised body never arrived).
+            // principal). After refs the client already settled, so this is a guarded no-op
+            // (leg-A decouple: a body-frame-less close is no longer a failure).
             recv.on("conclude", () => handleServerClose(ctx));
             recv.on("error", () => {
               fail(unavailable("Sealed agent-run client received a malformed WS frame."));

--- a/test/interop/friday-rust-hub-agent-run-sealed-client-runner.ts
+++ b/test/interop/friday-rust-hub-agent-run-sealed-client-runner.ts
@@ -7,10 +7,13 @@
  *
  * This drives `createFridayRustHubAgentRunSealedClient` UNCHANGED — the e2e proof is that the
  * REAL client speaks the REAL Rust server's sealed protocol (TS-seal → Rust-open, auth_proof
- * accepted, owner-sealed body opened). A reimplementation here would prove nothing.
+ * accepted, refs-only result settled). (leg-A decouple, #655 Part 4) The client now SETTLES on
+ * the refs envelope ALONE and no longer surfaces the owner-sealed body frame, so this runner
+ * reports the REFS (status/sha256/len) — NOT a body. The answer body is sourced by compose from
+ * the owner-gated DB readback, proven separately.
  *
  * Output contract (stdout, exactly one JSON line):
- *   success: {"ok":true,"status":"…","runId":"…","answerSha256":"…","answerLen":…,"body":"PONG"}
+ *   success: {"ok":true,"status":"…","runId":"…","answerSha256":"…","answerLen":…}
  *   fail-closed: {"ok":false,"code":"…","httpStatus":503}
  */
 import { createFridayRustHubAgentRunSealedClient } from "../../src/api/mission-spine/friday-rust-hub-agent-run-ws-sealed-client.js";
@@ -51,7 +54,6 @@ async function main(): Promise<void> {
         runId: result.runId,
         answerSha256: result.answerSha256 ?? null,
         answerLen: result.answerLen ?? null,
-        body: result.body ?? null,
       }) + "\n",
     );
     process.exit(0);

--- a/test/unit/api/mission-spine/friday-rust-hub-agent-run-sealed-client-service.test.ts
+++ b/test/unit/api/mission-spine/friday-rust-hub-agent-run-sealed-client-service.test.ts
@@ -88,7 +88,10 @@ describe("createFridayRustHubAgentRunSealedClientService (B1-compose, dark, adap
     });
   });
 
-  it("maps the sealed result to REFS-ONLY and DROPS the in-band body", async () => {
+  it("maps the sealed result to REFS-ONLY (the client no longer carries an in-band body)", async () => {
+    // (leg-A decouple, #655 Part 4) The underlying sealed client now SETTLES on the refs envelope
+    // alone and surfaces NO `body` — so the adapter receives refs-only and maps refs-only. (The
+    // adapter already dropped any body; this asserts the post-decouple shape end-to-end.)
     const fake = makeFakeClient({
       result: {
         truthLabel: "rust_wired",
@@ -96,7 +99,6 @@ describe("createFridayRustHubAgentRunSealedClientService (B1-compose, dark, adap
         status: "finished",
         answerSha256: "a".repeat(64),
         answerLen: 4,
-        body: "PONG", // the sealed client's belt-and-suspenders in-band body — must be DROPPED.
       },
     });
     const service = createFridayRustHubAgentRunSealedClientService({
@@ -118,7 +120,7 @@ describe("createFridayRustHubAgentRunSealedClientService (B1-compose, dark, adap
       answerSha256: "a".repeat(64),
       answerLen: 4,
     });
-    // The in-band body is NOT surfaced (compose's body source is the slice-3 DB readback).
+    // No body is surfaced (compose's body source is the slice-3 owner-gated DB readback).
     expect("body" in result).toBe(false);
   });
 
@@ -236,12 +238,13 @@ describe("createFridayRustHubAgentRunSealedClientService (B1-compose, dark, adap
 });
 
 function deliveredResult(): FridayRustHubAgentRunSealedResult {
+  // (leg-A decouple, #655 Part 4) A delivered result is REFS-ONLY — the client no longer surfaces
+  // an in-band body; the owner-gated DB readback supplies the answer to compose.
   return {
     truthLabel: "rust_wired",
     runId: "run-1",
     status: "finished",
     answerSha256: "a".repeat(64),
     answerLen: 4,
-    body: "PONG",
   };
 }

--- a/test/unit/api/mission-spine/friday-rust-hub-agent-run-ws-sealed-client.test.ts
+++ b/test/unit/api/mission-spine/friday-rust-hub-agent-run-ws-sealed-client.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it } from "vitest";
+
+import { FridayDomainError } from "../../../../src/errors/friday-domain-error.js";
+import {
+  handleResult,
+  handleServerClose,
+  type FridayRustHubAgentRunSealedResult,
+  type InboundContext,
+} from "../../../../src/api/mission-spine/friday-rust-hub-agent-run-ws-sealed-client.js";
+
+// (leg-A decouple, #655 Part 4) The sealed WS client now SETTLES on the FIRST (refs) envelope
+// ALONE — it no longer awaits or surfaces the SECOND owner-sealed body frame. compose sources the
+// authoritative answer body from the owner-gated DB readback, and the Rust server persists the
+// body to the Hub DB BEFORE emitting refs (so a committed row always exists when refs arrive).
+//
+// These tests drive the EXPORTED settle handlers against a fake InboundContext — proving the
+// settle-branch logic WITHOUT a socket. The REAL socket round-trip (TS-seal → Rust-open over the
+// genuine sealed protocol, refs settle, body send still lands server-side) is proven by the Rust
+// `#[ignore]` interop test `interop_ts_client_full_round_trip_pong` (run with --ignored), which
+// also asserts the client surfaces NO body and the server still serves Ok(1).
+
+/** A fake InboundContext that records exactly one terminal settle (succeed XOR fail). */
+function makeCtx(): {
+  ctx: InboundContext;
+  succeeded: () => FridayRustHubAgentRunSealedResult | undefined;
+  failed: () => FridayDomainError | undefined;
+} {
+  let succeededWith: FridayRustHubAgentRunSealedResult | undefined;
+  let failedWith: FridayDomainError | undefined;
+  let settled = false;
+  const ctx: InboundContext = {
+    sessionKey: new Uint8Array(0),
+    refs: null,
+    succeed(result) {
+      if (settled) return;
+      settled = true;
+      succeededWith = result;
+    },
+    fail(error) {
+      if (settled) return;
+      settled = true;
+      failedWith = error;
+    },
+  };
+  return { ctx, succeeded: () => succeededWith, failed: () => failedWith };
+}
+
+describe("friday-rust-hub-agent-run-ws-sealed-client settle handlers (leg-A decouple)", () => {
+  it("(a) settles on a DELIVERED refs envelope ALONE — no body frame awaited, no body surfaced", () => {
+    const { ctx, succeeded, failed } = makeCtx();
+    handleResult(ctx, {
+      kind: "AgentRunResult",
+      run_id: "run-1",
+      status: "finished",
+      answer_sha256: "a".repeat(64),
+      answer_len: 4,
+      turns: 2,
+      executed_tools: 1,
+    });
+
+    // Settled SYNCHRONOUSLY on the refs — even though a fingerprint (sha256/len) is present, the
+    // client no longer waits for the SECOND (body) envelope.
+    expect(failed()).toBeUndefined();
+    const result = succeeded();
+    expect(result).toEqual({
+      truthLabel: "rust_wired",
+      runId: "run-1",
+      status: "finished",
+      answerSha256: "a".repeat(64),
+      answerLen: 4,
+      turns: 2,
+      executedTools: 1,
+    });
+    // The decoupled client carries NO body — compose's body source is the owner-gated DB readback.
+    expect(result && "body" in result).toBe(false);
+  });
+
+  it("(a') settles on a NO-ANSWER refs envelope (no fingerprint) — refs-only, bare status", () => {
+    const { ctx, succeeded, failed } = makeCtx();
+    handleResult(ctx, { kind: "AgentRunResult", run_id: "run-1", status: "no_answer" });
+
+    expect(failed()).toBeUndefined();
+    expect(succeeded()).toEqual({
+      truthLabel: "rust_wired",
+      runId: "run-1",
+      status: "no_answer",
+    });
+  });
+
+  it("(b) a server close BEFORE any refs stays FAIL-CLOSED (503) — forged peer / bad principal", () => {
+    const { ctx, succeeded, failed } = makeCtx();
+    // No refs accumulated (the server established no session / ran nothing) → close → 503.
+    handleServerClose(ctx);
+
+    expect(succeeded()).toBeUndefined();
+    const err = failed();
+    expect(err).toBeInstanceOf(FridayDomainError);
+    expect(err?.httpStatus).toBe(503);
+    expect(err?.message).toContain("closed before a result");
+  });
+
+  it("(b') a server close AFTER the client already settled on refs is a guarded no-op (no double-settle)", () => {
+    const { ctx, succeeded, failed } = makeCtx();
+    handleResult(ctx, {
+      kind: "AgentRunResult",
+      run_id: "run-1",
+      status: "finished",
+      answer_sha256: "a".repeat(64),
+      answer_len: 4,
+    });
+    // The client settled on refs; the later session close must NOT flip the result to a 503.
+    handleServerClose(ctx);
+
+    expect(failed()).toBeUndefined();
+    expect(succeeded()?.status).toBe("finished");
+  });
+
+  it("(c) a refs envelope MISSING a required ref (run_id) fails closed (503) — refs-surface contract preserved", () => {
+    const { ctx, succeeded, failed } = makeCtx();
+    handleResult(ctx, { kind: "AgentRunResult", status: "finished" });
+
+    expect(succeeded()).toBeUndefined();
+    const err = failed();
+    expect(err?.httpStatus).toBe(503);
+    expect(err?.message).toContain("missing a required ref");
+  });
+
+  it("(c') a refs envelope MISSING status fails closed (503)", () => {
+    const { ctx, succeeded, failed } = makeCtx();
+    handleResult(ctx, { kind: "AgentRunResult", run_id: "run-1" });
+
+    expect(succeeded()).toBeUndefined();
+    expect(failed()?.httpStatus).toBe(503);
+  });
+
+  it("(c'') an ABSENT fingerprint with a non-numeric answer_len is treated as no-answer (no 0-fake, no body)", () => {
+    const { ctx, succeeded, failed } = makeCtx();
+    handleResult(ctx, {
+      kind: "AgentRunResult",
+      run_id: "run-1",
+      status: "no_answer",
+      // Non-numeric / absent counts must be OMITTED (undefined), never coerced to 0.
+      answer_len: "not-a-number",
+      turns: null,
+    });
+
+    expect(failed()).toBeUndefined();
+    const result = succeeded();
+    expect(result?.answerLen).toBeUndefined();
+    expect(result?.turns).toBeUndefined();
+    expect(result && "body" in result).toBe(false);
+  });
+
+  it("surfaces the A1 run COUNTS from the refs when the server carried them (counts only, never a body)", () => {
+    const { ctx, succeeded } = makeCtx();
+    handleResult(ctx, {
+      kind: "AgentRunResult",
+      run_id: "run-1",
+      status: "finished",
+      answer_sha256: "b".repeat(64),
+      answer_len: 7,
+      turns: 5,
+      executed_tools: 3,
+    });
+
+    const result = succeeded();
+    expect(result?.turns).toBe(5);
+    expect(result?.executedTools).toBe(3);
+    // Token counts are DEFERRED server-side ⇒ omitted (never 0-faked).
+    expect(result?.promptTokens).toBeUndefined();
+    expect(result?.completionTokens).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## What

Completes the **explicitly deferred** "Part 4, leg-A decouple" from #655 (commit `a5e1d5c5`). #655 fixed leg B (WAL + `busy_timeout` on the hub-DB openers, fixing the intermittent `SQLITE_BUSY` readback 503-after-billing) and added body-free `{run_id, leg, code}` fail-closed logging — but left leg-A as a named follow-up.

**The rare 503 residual:** the TS sealed-WS client, on a *delivered* run, additionally **waited for and opened the second owner-sealed body frame** after the refs frame. A dropped/late body frame (the leg-A "closed-before-the-body" surface) 503'd a run whose answer was already billed **and** already persisted to the Hub DB.

The body frame is **redundant**: compose (`composeRustReadOnlyAgentRun` in `friday-api-runtime.ts`) sources the answer from the **owner-gated DB readback** (`FridayRustHubRunAnswerReadbackService.readAnswer` → `friday_storage::get_run_answer_for_principal`, the `owner == caller` gate), **not** from the WS body frame. `wsResult.body` is dispatched then never referenced.

## Change (TS — the live read-only Rust route, gated DEFAULT-OFF behind `FRIDAY_ROUTE_AGENT_RUN_VIA_RUST`)

- `handleResult` settles **immediately** on the refs envelope (status + answer fingerprint + A1 counts), whether or not a fingerprint is present — it no longer waits for the body frame.
- `handleServerClose` drops the "closed before the body" fail-closed branch; a body-frame-less close after refs is no longer a failure.
- `handleBody` (the inner-seal `open()` + sha256/len verify) is **deleted as dead code**, with its now-unused `hexDecode`/`sha256Hex` imports and the `AskFridayStream` inbound branch.
- The vestigial `body` field is removed from `FridayRustHubAgentRunSealedResult` + `finishFromRefs` (formerly `finishWithBody`), cascading coherently to the service-adapter test + the interop-runner output contract.

## Preserved (verified by test)

- Fail-closed-**before-any-refs** path (forged peer / bad principal → no session → close-before-refs stays a **503**).
- Refs-surface contract (missing `run_id`/`status` still **503**).
- The owner-gate in the DB readback (untouched).

## Verified safe-against-race + end-to-end

The Rust server persists `run_result` **before** emitting refs (`run_authed_agent_loop`/`run_session_task` → `persist_run_result`, then `result_refs(&outcome)`, then the refs frame), so a committed row always exists when refs arrive (no `not_found` race). The `#[ignore]` interop test `interop_ts_client_full_round_trip_pong` was re-run with the decoupled client and the small `PONG` body: `accept_one` returns `Ok(1)` and `leg=body_send status=delivered` still logs. The test now asserts the client surfaces **no body** (refs-only) + the refs sha256/len.

## ⚠️ Known, characterized, flagged (NOT fixed — out of leg-A scope)

For a **large** answer (empirically ~256KB), the server's post-refs body send `Err`s ("Broken pipe") because the client already tore down → `serve_sealed_session` returns `Err` and logs `leg=body_send error=transport_closed` on an otherwise-healthy run. This is **benign for correctness** (the answer is committed in the DB and compose reads it; the client already settled on refs), but it fires the #655-Part-2 diagnostic line **on success**. Making the body send non-fatal is a follow-up **server** change, intentionally not done here (server-logic is out of leg-A scope per the build mandate). See the NOTE on the test and the operator question below.

## DARK + DEPLOY-GO-gated

TS-only logic change on a route gated DEFAULT-OFF; going live requires the operator to flip `FRIDAY_ROUTE_AGENT_RUN_VIA_RUST`. The change only **relaxes** a redundant client-side wait (fails *more*-available, never less); the X25519 handshake, peer-auth, `auth_proof`, session-key seal, and the owner-gated DB readback are all untouched. Deploying the binary changes no live behavior.

## What remains

- Operator cutover (`FRIDAY_ROUTE_AGENT_RUN_VIA_RUST`) is unchanged; **this PR does not move the live needle.**
- The large-body `body_send` log interaction above (server follow-up if the operator wants the diagnostic line suppressed on healthy large-answer runs).

## Batching note

Sibling item **A1 (constraints emit)** shares this file but touches **different** functions (the `sealAndSend` `AgentRunRequest` builder, not the settle handlers). **Sequence leg-A → A1** to avoid a merge conflict on this file. Do **not** combine — a live bugfix and a dark prerequisite should not share a deploy.

## Tests (honest counts)

- `tsc` 0 errors; `eslint` 0 errors.
- vitest: 8 new WS-client settle tests + 9 service-adapter + 82 mission-spine + 187 runtime/diagnostics — all green.
- `cargo build` + `cargo clippy --all-targets -D warnings` clean (friday-hub); `cargo fmt --check` clean (pinned 1.95.0).
- `cargo test -p friday-hub`: 503 unit tests green; the 3 `#[ignore]` interop tests (`--ignored`, small body) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)