### PR TITLE
feat(a1): apply per-run constraints onto the run-START RunPolicy (DARK + DEPLOY-GO-gated)

### DIFF
--- a/rust-core/crates/friday-hub/src/agent_run_control.rs
+++ b/rust-core/crates/friday-hub/src/agent_run_control.rs
@@ -98,6 +98,25 @@ pub fn effective_run_policy(
     }
 }
 
+/// (A1 — APPLICATION) Compose a per-run [`AgentRunConstraintsWire`] ONTO an existing boot
+/// [`RunPolicy`], returning the effective per-run policy the loop's gate must consult. Unlike
+/// [`effective_run_policy`] (which REBUILDS a policy from owner+constraints and is correct only
+/// when the boot policy is unconstrained), this COMPOSES via [`RunPolicy::tightened_by`] so the
+/// only-tighten invariant holds UNCONDITIONALLY — a boot-configured `read_only`/`disabled_tools`
+/// can NEVER be loosened by a constraint that omits it (defense-in-depth against any future
+/// non-unconstrained boot config). `constraints: None` ⇒ a CLONE of the boot policy unchanged
+/// (the absent-constraint case = byte-identical pre-A1 behavior). This is the live-dispatch entry
+/// the runtime threads as a per-run override.
+pub fn effective_run_policy_over(
+    boot: &RunPolicy,
+    constraints: Option<&AgentRunConstraintsWire>,
+) -> RunPolicy {
+    match constraints {
+        None => boot.clone(),
+        Some(c) => boot.tightened_by(c.read_only, &c.disabled_tools),
+    }
+}
+
 /// The effective per-run `max_turns`: a wire-asserted cap can only ever LOWER the runtime ceiling
 /// (never raise it). `None`/absent ⇒ the runtime default unchanged.
 pub fn effective_max_turns(

--- a/rust-core/crates/friday-hub/src/bin/hub_agent_run_server.rs
+++ b/rust-core/crates/friday-hub/src/bin/hub_agent_run_server.rs
@@ -131,7 +131,7 @@ use friday_crypto::{
     generate_approval_nonce, seal, DataKey, DeviceKeypair, FileSecureStore, Sealed, SecureStore,
 };
 use friday_deepseek::Transport;
-use friday_hub::hub_server::{run_authed_agent_loop, AuthedPrincipal, ForwardedAuth};
+use friday_hub::hub_server::{run_authed_agent_loop_with_policy, AuthedPrincipal, ForwardedAuth};
 use friday_hub::key_source::{PEER_PUBKEY_ALLOWLIST_ID, X25519_PUBKEY_LEN};
 use friday_hub::runtime::{HubConfig, HubRuntime};
 use friday_protocol::{Envelope, IdempotencyTracker, Message, Seen};
@@ -809,16 +809,13 @@ fn serve_sealed_session<S: Read + Write, T: Transport>(
                 forwarded_principal,
                 auth_proof,
                 session_id,
-                // (A1 run-controls) The per-run CONSTRAINTS the peer asserts. The wire SHAPE +
-                // the pure mapping onto a per-run `RunPolicy`
-                // ([`friday_hub::agent_run_control::effective_run_policy`]) are built + tested,
-                // but APPLYING them on the live dispatch requires the runtime to accept a per-run
-                // policy OVERRIDE (today `run_task` uses its OWN constructed `self.policy`).
-                // Threading that through the just-fixed live run-START path is a DEFERRED sub-AC
-                // (see the PR body) — so this slice does NOT apply the constraints on dispatch.
-                // `_constraints` is captured (not `..`) so the destructure stays exhaustive and a
-                // future field addition is a compile error, not a silent drop.
-                constraints: _constraints,
+                // (A1 run-controls — APPLICATION) The per-run CONSTRAINTS the peer asserts. The
+                // wire SHAPE + the pure mapping landed in #660; THIS slice APPLIES them on the live
+                // dispatch by COMPOSING them onto the runtime's boot policy
+                // ([`friday_hub::agent_run_control::effective_run_policy_over`]) and threading the
+                // result through the per-run policy override the runtime now accepts. ABSENT
+                // (`None`) ⇒ NO override ⇒ the boot policy/ceiling, byte-identical to pre-A1.
+                constraints,
             } => {
                 // The dispatch arm: AUTH BEFORE ANY RUN. The `auth_proof` is the peer-sealed
                 // challenge; reconstruct it as a `Sealed` for the session-key open. A malformed
@@ -861,13 +858,68 @@ fn serve_sealed_session<S: Read + Write, T: Transport>(
                 // share the IDENTICAL refs + owner-sealed-body emit below (the body is owner-gated
                 // by `project_answer_for_authed` in BOTH), so the only difference is which loop ran.
                 let now_ms = now_ms();
+
+                // (A1 run-controls — APPLICATION) Compute the per-run policy + max-turns OVERRIDE
+                // ONCE (before the session/sessionless branch) so BOTH arms apply the SAME
+                // effective gate. The override COMPOSES the peer's asserted `constraints` onto the
+                // runtime's boot policy ([`effective_run_policy_over`]) so it can ONLY TIGHTEN
+                // (read-only OR, disabled-tools UNION; the bound owner is unchanged).
+                //
+                // DARK + DEPLOY-GO-gated, TWO independent reasons it changes NO live behavior:
+                //   (1) FLAG: the override is built ONLY when `run_control_enabled`
+                //       (`FRIDAY_AGENT_RUN_CONTROL_VIA_RUST`, default-off). Flag OFF ⇒ `None`
+                //       override ⇒ the boot policy/ceiling, byte-identical to pre-A1 — even if a
+                //       peer somehow asserted constraints, they are IGNORED with the flag off.
+                //   (2) ABSENT: even with the flag on, a request that carries NO `constraints`
+                //       block (every live courier today) yields `effective_run_policy_over(boot,
+                //       None) == boot.clone()` ⇒ `Some(boot-equal)` which gates identically to the
+                //       boot policy, and `effective_max_turns(default, None) == default`. So the
+                //       only behavior change is for a request that EXPLICITLY asserts a TIGHTER
+                //       constraint while the flag is on — strictly a restriction.
+                //
+                // We pass the override as `Some(&effective_policy)` whenever the flag is on (even
+                // for absent constraints, where it equals boot) so the application path is
+                // exercised uniformly; absent + flag-on stays byte-equivalent because the composed
+                // policy equals boot. With the flag off we pass `None` so the runtime takes its
+                // own `self.policy` reference (no clone, the exact pre-A1 object).
+                let effective_policy = if run_control_enabled {
+                    Some(friday_hub::agent_run_control::effective_run_policy_over(
+                        runtime.policy(),
+                        constraints.as_ref(),
+                    ))
+                } else {
+                    None
+                };
+                let max_turns_override = if run_control_enabled {
+                    constraints.as_ref().and_then(|c| c.max_turns)
+                } else {
+                    None
+                };
+                let policy_override = effective_policy.as_ref();
+
                 let outcome = match session_id
                     .as_deref()
                     .map(str::trim)
                     .filter(|s| !s.is_empty())
                 {
-                    Some(sid) => runtime.run_session_task(&caller, &run_id, sid, &task, now_ms),
-                    None => run_authed_agent_loop(runtime, &caller, &run_id, &task, now_ms),
+                    Some(sid) => runtime.run_session_task_with_overrides(
+                        &caller,
+                        &run_id,
+                        sid,
+                        &task,
+                        policy_override,
+                        max_turns_override,
+                        now_ms,
+                    ),
+                    None => run_authed_agent_loop_with_policy(
+                        runtime,
+                        &caller,
+                        &run_id,
+                        &task,
+                        policy_override,
+                        max_turns_override,
+                        now_ms,
+                    ),
                 };
 
                 // (refs) REFS-ONLY terminal receipt over the wire: status + answer FINGERPRINT

--- a/rust-core/crates/friday-hub/src/hub_server.rs
+++ b/rust-core/crates/friday-hub/src/hub_server.rs
@@ -1393,10 +1393,37 @@ pub fn run_authed_agent_loop<T: Transport>(
     task: &str,
     now_ms: i64,
 ) -> AuthedAnswer {
+    // Pre-A1 entry: NO per-run override ⇒ the boot policy / ceiling (byte-identical). Every
+    // pre-A1 caller (dev bin, tests) stays on this path; only the WS dispatch arm opts into an
+    // override via `run_authed_agent_loop_with_policy`.
+    run_authed_agent_loop_with_policy(runtime, caller, run_id, task, None, None, now_ms)
+}
+
+/// (A1) [`run_authed_agent_loop`] with an OPTIONAL per-run policy + max-turns override applied at
+/// run-START — the SESSIONLESS dispatch entry that APPLIES a peer's
+/// [`friday_protocol::AgentRunConstraintsWire`]. `None`/`None` ⇒ the boot policy/ceiling
+/// (byte-identical pre-A1 path). `Some(p)` ⇒ the COMPOSED only-tighten policy the dispatch arm
+/// built via [`crate::agent_run_control::effective_run_policy_over`].
+///
+/// The FIX-Q2 `caller == configured_principal` guard is UNCHANGED and still precedes any dispatch:
+/// a per-run CONSTRAINT tightens WHAT the run may do, it does NOT change WHO it runs as — the owner
+/// gate is orthogonal and a constraint can never relax it. A non-owner caller still fails closed to
+/// a body-free `NoAnswer` regardless of the override.
+#[allow(clippy::too_many_arguments)]
+pub fn run_authed_agent_loop_with_policy<T: Transport>(
+    runtime: &HubRuntime<T>,
+    caller: &AuthedPrincipal,
+    run_id: &str,
+    task: &str,
+    policy_override: Option<&crate::RunPolicy>,
+    max_turns_override: Option<u64>,
+    now_ms: i64,
+) -> AuthedAnswer {
     // (FIX-Q2) caller == configured-owner, asserted BEFORE any dispatch. A mismatch — or an
     // unconfigured (`None`) owner — fails CLOSED to a body-free `NoAnswer`: the loop never runs,
     // so nothing is created/recalled/billed/owner-stamped under the wrong principal. On live
     // (single owner) this is unreachable (caller is always the configured owner by construction).
+    // The override does NOT touch this gate — a constraint cannot relax the owner check.
     match runtime.configured_principal() {
         Some(owner) if owner == caller.principal() => {}
         _ => {
@@ -1406,14 +1433,21 @@ pub fn run_authed_agent_loop<T: Transport>(
         }
     }
     // (a) the caller is already authenticated (typed proof). (b) run the loop as that
-    // principal; a route/provider failure is a SAFE FAILURE (no body, no panic).
+    // principal under the (effective) per-run policy; a route/provider failure is a SAFE FAILURE
+    // (no body, no panic).
     //
-    // A1 transport-truth: `run_task` ALREADY returns the `LoopOutcome { turns,
+    // A1 transport-truth: `run_task_with_overrides` ALREADY returns the `LoopOutcome { turns,
     // executed_tools, .. }` — this entry used to DISCARD it via `.is_err()`. Capture it so
     // the REFS-surface run COUNTS can ride the result. This is a no-behavior-change edit:
     // the `Err` arm still returns the identical body-free `NoAnswer`, and the `Ok` arm
     // still projects the identical owner-gated body — counts are pure additive metadata.
-    let outcome = match runtime.run_task(run_id, task, now_ms) {
+    let outcome = match runtime.run_task_with_overrides(
+        run_id,
+        task,
+        policy_override,
+        max_turns_override,
+        now_ms,
+    ) {
         Ok((_selection, outcome)) => outcome,
         Err(_) => {
             return AuthedAnswer::NoAnswer {
@@ -6182,6 +6216,151 @@ mod authed_route_tests {
                 )
                 .unwrap(),
             0
+        );
+    }
+
+    // ---- A1: per-run-constraints override on the LIVE dispatch entries -------
+    //
+    // These pin the override THREADING through the two hot dispatch entries the WS server
+    // calls: the SESSIONLESS `run_authed_agent_loop_with_policy` and the SESSIONED
+    // `run_session_task_with_overrides`. The spec's risk-flag names this path explicitly; the
+    // tests prove a `read_only:true` override actually BLOCKS a mutating tool (not just that the
+    // mapping is pure).
+
+    /// A transport that proposes ONE mutating `write_file` tool call on the first turn.
+    struct MutateTransport;
+    impl Transport for MutateTransport {
+        fn get_json(&self, _u: &str, _b: &str) -> Result<Value, DeepSeekError> {
+            Ok(serde_json::json!({"data":[{"id":"deepseek-v4-flash"}]}))
+        }
+        fn post_json(&self, _u: &str, _b: &str, _body: &Value) -> Result<Value, DeepSeekError> {
+            let content =
+                "{\"tool\":\"write_file\",\"parameters\":{\"path\":\"out.txt\",\"content\":\"X\"}}";
+            Ok(serde_json::json!({
+                "model":"deepseek-v4-flash",
+                "choices":[{"message":{"content":content},"finish_reason":"stop"}],
+                "usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}
+            }))
+        }
+    }
+
+    fn read_only_override(rt_principal: &str) -> crate::RunPolicy {
+        let c = friday_protocol::AgentRunConstraintsWire {
+            read_only: true,
+            disabled_tools: vec![],
+            max_turns: None,
+        };
+        // Compose onto the boot policy of a runtime configured with `rt_principal` (unconstrained
+        // boot) — exactly what the dispatch arm does with `runtime.policy()`.
+        let boot =
+            crate::RunPolicy::new(Some(rt_principal.to_string()), Vec::<String>::new(), false);
+        crate::agent_run_control::effective_run_policy_over(&boot, Some(&c))
+    }
+
+    /// (A1) SESSIONLESS dispatch entry: a `read_only:true` policy override BLOCKS a mutating tool
+    /// through `run_authed_agent_loop_with_policy`, writing no file. The override is APPLIED, not
+    /// dropped, on the hub_server live entry.
+    #[test]
+    fn a1_sessionless_override_read_only_blocks_mutating_tool() {
+        let (rt, ws) = runtime_with("a1-sessionless-ro", MutateTransport, "principal:owner");
+        let caller = authed("principal:owner");
+        let policy = read_only_override("principal:owner");
+        let out = run_authed_agent_loop_with_policy(
+            &rt,
+            &caller,
+            "a1-sl-ro",
+            "write a file",
+            Some(&policy),
+            None,
+            1000,
+        );
+        // Read-only Deny ⇒ non-Finished ⇒ body-free NoAnswer; nothing executed, no file written.
+        assert!(out.delivered_body().is_none(), "read-only blocks the body");
+        assert!(
+            !ws.0.join("out.txt").exists(),
+            "the read-only override withheld the write (no file)"
+        );
+        let blocked: i64 = rt
+            .db()
+            .conn()
+            .query_row(
+                "SELECT count(*) FROM agent_run_event WHERE run_id = 'a1-sl-ro' AND kind LIKE 'tool.blocked:deny:run_is_read_only:write_file%'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(blocked, 1, "the read-only block is recorded for the run");
+    }
+
+    /// (A1) SESSIONED dispatch entry (the hot, live-reachable path the risk-flag names): a
+    /// `read_only:true` override BLOCKS a mutating tool through `run_session_task_with_overrides`
+    /// — proving the override threads symmetrically into `run_session_loop`, not just the
+    /// sessionless loop.
+    #[test]
+    fn a1_sessioned_override_read_only_blocks_mutating_tool() {
+        let (rt, ws) = runtime_with("a1-sessioned-ro", MutateTransport, "principal:owner");
+        let caller = authed("principal:owner");
+        let policy = read_only_override("principal:owner");
+        let out = rt.run_session_task_with_overrides(
+            &caller,
+            "a1-se-ro",
+            "chat-session-1",
+            "write a file",
+            Some(&policy),
+            None,
+            1000,
+        );
+        assert!(
+            out.delivered_body().is_none(),
+            "read-only blocks the body on the sessioned path too"
+        );
+        assert!(
+            !ws.0.join("out.txt").exists(),
+            "the read-only override withheld the write on the sessioned path (no file)"
+        );
+        let blocked: i64 = rt
+            .db()
+            .conn()
+            .query_row(
+                "SELECT count(*) FROM agent_run_event WHERE run_id = 'a1-se-ro' AND kind LIKE 'tool.blocked:deny:run_is_read_only:write_file%'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(
+            blocked, 1,
+            "the read-only block is recorded for the sessioned run"
+        );
+    }
+
+    /// (A1) Control: with NO override on the sessioned entry (the `run_session_task` path) and a
+    /// boot policy that is NOT read-only, the SAME mutating tool is NOT read-only-blocked (it
+    /// Pauses pending approval instead) — proving the block in the test above is the OVERRIDE, not
+    /// a broken loop.
+    #[test]
+    fn a1_sessioned_absent_override_is_not_read_only_blocked() {
+        let (rt, _ws) = runtime_with("a1-sessioned-noov", MutateTransport, "principal:owner");
+        let caller = authed("principal:owner");
+        // `run_session_task` = the absent-override path.
+        let _out = rt.run_session_task(
+            &caller,
+            "a1-se-noov",
+            "chat-session-2",
+            "write a file",
+            1000,
+        );
+        let ro_blocked: i64 = rt
+            .db()
+            .conn()
+            .query_row(
+                "SELECT count(*) FROM agent_run_event WHERE run_id = 'a1-se-noov' AND kind LIKE 'tool.blocked:deny:run_is_read_only:%'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(
+            ro_blocked, 0,
+            "with no override + non-read-only boot, the run is NOT read-only-blocked (the override is what blocks)"
         );
     }
 }

--- a/rust-core/crates/friday-hub/src/lib.rs
+++ b/rust-core/crates/friday-hub/src/lib.rs
@@ -1074,6 +1074,38 @@ impl RunPolicy {
         self.read_only
     }
 
+    /// (A1) Return a NEW policy that is THIS policy TIGHTENED by per-run constraints — never
+    /// loosened. It is the COMPOSITION (not a replacement) of the boot policy with a wire-
+    /// asserted per-run restriction, so the only-tighten invariant holds UNCONDITIONALLY,
+    /// independent of whether the boot config is itself unconstrained:
+    ///   - `read_only` is the LOGICAL-OR (`self || constraint`) — a read-only run can never be
+    ///     un-read-onlied by a constraint that omits the flag;
+    ///   - `disabled_tools` is the UNION (`self ∪ constraint`) — a tool the boot policy disables
+    ///     STAYS disabled even when the per-run constraint does not name it;
+    ///   - the bound `principal_id` is taken VERBATIM from `self` (a constraint is a restriction
+    ///     of WHAT the run may do, NEVER a re-binding of WHO it runs as — the owner is the
+    ///     authenticated caller the runtime is configured with, unchanged by any constraint).
+    ///
+    /// The `disabled_tools` arg is normalized exactly as [`RunPolicy::new`] (trim, drop empties),
+    /// so an empty/whitespace entry can never widen the set. Passing `read_only:false` + an empty
+    /// list yields a policy EQUAL to `self` (no widening) — the absent-constraint case the caller
+    /// instead represents as `None` (no override at all), but this still composes safely.
+    pub fn tightened_by(&self, read_only: bool, disabled_tools: &[String]) -> RunPolicy {
+        let mut merged: std::collections::BTreeSet<String> = self.disabled_tools.clone();
+        for n in disabled_tools {
+            let trimmed = n.trim();
+            if !trimmed.is_empty() {
+                merged.insert(trimmed.to_string());
+            }
+        }
+        RunPolicy {
+            principal_id: self.principal_id.clone(),
+            disabled_tools: merged,
+            // OR: a constraint can only ADD read-only, never remove a boot-configured one.
+            read_only: self.read_only || read_only,
+        }
+    }
+
     /// Fail-closed, name-reconciled resolution of a tool action against this run's
     /// disabled-set (executeRun-replacement slice 1 — security pre-req).
     ///

--- a/rust-core/crates/friday-hub/src/runtime.rs
+++ b/rust-core/crates/friday-hub/src/runtime.rs
@@ -253,6 +253,45 @@ impl<T: Transport> HubRuntime<T> {
         task: &str,
         now_ms: i64,
     ) -> Result<(RoutedSelection, LoopOutcome), RoutedLoopError> {
+        // Pre-A1 entry: NO per-run override ⇒ the run uses the runtime's boot `self.policy` +
+        // `self.max_turns`. BYTE-IDENTICAL to the pre-A1 behavior (every existing caller — dev
+        // bins, tests, the mission-bound entry — stays on this path unchanged).
+        self.run_task_with_overrides(run_id, task, None, None, now_ms)
+    }
+
+    /// (A1) [`Self::run_task`] with an OPTIONAL per-run policy + max-turns override applied at
+    /// run-START. This is the live-dispatch entry the WS server uses to APPLY a peer's
+    /// [`friday_protocol::AgentRunConstraintsWire`] (read-only / disabled-tools / max-turns) onto
+    /// the gate the loop consults — closing the A1 deferral.
+    ///
+    /// ## The override semantics (only-tighten, fail-safe)
+    ///   - `policy_override: None` ⇒ the run uses the boot `self.policy` VERBATIM (the
+    ///     `run_task` path) — byte-identical pre-A1 behavior. The dispatch arm passes `None`
+    ///     precisely when the request carried NO `constraints` block.
+    ///   - `policy_override: Some(p)` ⇒ the run uses `p`, which the caller MUST have built by
+    ///     COMPOSING the boot policy with the constraint
+    ///     ([`crate::agent_run_control::effective_run_policy_over`]) so it can only ever TIGHTEN.
+    ///     The override REPLACES `self.policy` for THIS run's gate requests AND the owner-stamp —
+    ///     so this fn is internally consistent on ONE policy object (`p.principal_id()` is the
+    ///     stamped owner, which `effective_run_policy_over` preserves verbatim from boot, so the
+    ///     owner is UNCHANGED by any constraint).
+    ///   - `max_turns_override: None` ⇒ `self.max_turns`. `Some(cap)` ⇒ `self.max_turns.min(cap)`
+    ///     (a cap can only LOWER the ceiling, never raise it past the runtime default — the floor
+    ///     is applied HERE so a caller can pass the raw asserted cap).
+    pub fn run_task_with_overrides(
+        &self,
+        run_id: &str,
+        task: &str,
+        policy_override: Option<&RunPolicy>,
+        max_turns_override: Option<u64>,
+        now_ms: i64,
+    ) -> Result<(RoutedSelection, LoopOutcome), RoutedLoopError> {
+        // The effective per-run policy + ceiling. Absent override ⇒ boot config unchanged.
+        let policy = policy_override.unwrap_or(&self.policy);
+        let max_turns = match max_turns_override {
+            Some(cap) => self.max_turns.min(cap),
+            None => self.max_turns,
+        };
         agent_run::create_run(self.db.conn(), run_id, task, now_ms)?;
         // PROOF-MEMORY-001: recall this owner's confirmed memory, gate it through the
         // Context Passport, and inject it as a prompt PREAMBLE (the run's `task` stays
@@ -265,8 +304,8 @@ impl<T: Transport> HubRuntime<T> {
         // selection here.
         let request = RouteRequest::any();
         let approve = |req: &MutatingActionRequest| self.approval.approve(req);
-        // S4: thread the run policy so the bound principal reaches every gate request's
-        // Actor (and the action digest) and the disabled/read-only restrictions are
+        // S4: thread the (effective) run policy so the bound principal reaches every gate
+        // request's Actor (and the action digest) and the disabled/read-only restrictions are
         // enforced before any tool executes. S6d: thread the provisioned operator verify
         // key so a protected action authorizes via the Ed25519 verify-only policy (never
         // HMAC); `None` ⇒ fail-closed Pause.
@@ -281,14 +320,15 @@ impl<T: Transport> HubRuntime<T> {
             &recall_preamble,
             self.operator_vk.as_ref(),
             &approve,
-            &self.policy,
-            self.max_turns,
+            policy,
+            max_turns,
             now_ms,
         )?;
 
         // D1 OWNER-WIRING: a FINISHED run produced a deliverable ANSWER; persist it Hub-side
         // keyed by `run_id` with the run's BOUND OWNER principal recorded
-        // (`self.policy.principal_id()` — the SAME principal S4 binds into the gate Actor), so
+        // (`policy.principal_id()` — the SAME principal S4 binds into the gate Actor; the
+        // override preserves boot's principal verbatim, so this is the configured owner), so
         // the authenticated body projection [`friday_storage::get_run_answer_for_principal`]
         // releases the answer body ONLY to that owner. A run with NO bound principal records
         // NO owner ⇒ the body stays unreadable to everyone (fail-closed, correct).
@@ -304,7 +344,7 @@ impl<T: Transport> HubRuntime<T> {
                 outcome.final_message.clone().unwrap_or_default(),
                 None,
             );
-            if let Some(principal) = self.policy.principal_id() {
+            if let Some(principal) = policy.principal_id() {
                 result = result.with_owner_principal(principal);
             }
             persist_run_result(self.db.conn(), run_id, &result, now_ms)?;
@@ -357,6 +397,35 @@ impl<T: Transport> HubRuntime<T> {
         task: &str,
         now_ms: i64,
     ) -> AuthedAnswer {
+        // Pre-A1 sessioned entry: NO per-run override ⇒ boot policy + ceiling (byte-identical).
+        self.run_session_task_with_overrides(caller, run_id, session_id, task, None, None, now_ms)
+    }
+
+    /// (A1) [`Self::run_session_task`] with an OPTIONAL per-run policy + max-turns override —
+    /// the SESSIONED parity of [`Self::run_task_with_overrides`]. Same only-tighten semantics:
+    /// `None` ⇒ boot `self.policy`/`self.max_turns` verbatim (the `run_session_task` path);
+    /// `Some(p)` ⇒ the COMPOSED (only-tighten) per-run policy the dispatch arm built. The
+    /// override drives the SAME existing [`run_session_loop`] (no new loop code) — read-only /
+    /// disabled-tools are enforced by the loop's gate exactly as the sessionless entry, and a
+    /// constraint can never re-bind the session owner (`p`'s principal == boot's, the
+    /// authenticated `caller`).
+    #[allow(clippy::too_many_arguments)]
+    pub fn run_session_task_with_overrides(
+        &self,
+        caller: &AuthedPrincipal,
+        run_id: &str,
+        session_id: &str,
+        task: &str,
+        policy_override: Option<&RunPolicy>,
+        max_turns_override: Option<u64>,
+        now_ms: i64,
+    ) -> AuthedAnswer {
+        // The effective per-run policy + ceiling. Absent override ⇒ boot config unchanged.
+        let policy = policy_override.unwrap_or(&self.policy);
+        let max_turns = match max_turns_override {
+            Some(cap) => self.max_turns.min(cap),
+            None => self.max_turns,
+        };
         // Create the run row FIRST — `run_session_loop` only `ensure_session`s the session
         // row; it does NOT create the `agent_run` row (its step-5 `persist_run_result`
         // would orphan without one). `run_task` does this too. A create failure is a SAFE
@@ -402,8 +471,8 @@ impl<T: Transport> HubRuntime<T> {
             &recall_preamble,
             self.operator_vk.as_ref(),
             &approve,
-            &self.policy,
-            self.max_turns,
+            policy,
+            max_turns,
             now_ms,
         ) {
             Ok(outcome) => outcome,
@@ -571,6 +640,22 @@ impl<T: Transport> HubRuntime<T> {
     /// identity, not a secret, but it is never logged/printed by this accessor's callers).
     pub(crate) fn configured_principal(&self) -> Option<&str> {
         self.policy.principal_id()
+    }
+
+    /// (A1) The runtime's BOOT [`RunPolicy`] (the `--owner` principal + boot disabled-tools /
+    /// read-only, built ONCE at [`HubRuntime::live`]). Exposed so the WS dispatch arm can COMPOSE
+    /// a peer's per-run constraints ONTO it ([`crate::agent_run_control::effective_run_policy_over`])
+    /// — the override can only ever TIGHTEN this boot policy, never loosen it. Read-only accessor;
+    /// it returns the SAME object the no-override `run_task` path uses, so an absent-constraint
+    /// run composed off this is byte-equivalent to the boot path.
+    pub fn policy(&self) -> &RunPolicy {
+        &self.policy
+    }
+
+    /// (A1) The runtime's BOOT `max_turns` ceiling. A per-run cap can only LOWER this (never
+    /// raise it past the runtime default); the floor is applied inside the run entries.
+    pub fn max_turns(&self) -> u64 {
+        self.max_turns
     }
 }
 
@@ -1804,5 +1889,343 @@ mod tests {
         if out.executed_tools > 0 {
             assert!(friday_storage::audit::verify_audit_chain(rt.db().conn()).is_ok());
         }
+    }
+
+    // ---- A1: per-run-constraints application (override threading) ------------
+    //
+    // These prove the live application of `AgentRunConstraintsWire` onto the per-run
+    // `RunPolicy` — the deferral #660 left open. The discriminating no-regression test (the
+    // one the advisor flagged) is `boot read_only/disabled + ABSENT or non-tightening
+    // override ⇒ STILL constrained` — it fails if the override REPLACES rather than COMPOSES
+    // the boot policy.
+
+    /// Build a runtime with EXPLICIT boot policy + max_turns (the parts `runtime_with` fixes).
+    fn runtime_with_boot(
+        tag: &str,
+        contents: &[&str],
+        principal_id: Option<String>,
+        disabled_tools: Vec<String>,
+        read_only: bool,
+        max_turns: u64,
+    ) -> (HubRuntime<ScriptTransport>, TempDir) {
+        let ws = TempDir::new(tag);
+        let transport = ScriptTransport::new(contents);
+        let client = DeepSeekClient::with_transport(transport, "k".into());
+        let agent = DeepSeekAgentLlmClient::new(client);
+        let rt = HubRuntime::new(
+            HubConfig {
+                db_path: tmp(tag),
+                workspace_root: ws.0.clone(),
+                secret: SECRET.to_vec(),
+                max_turns,
+                principal_id,
+                disabled_tools,
+                read_only,
+                operator_vk: None,
+            },
+            agent,
+            Box::new(DenyAllApprovals),
+        )
+        .unwrap();
+        (rt, ws)
+    }
+
+    fn constraints(
+        read_only: bool,
+        disabled_tools: &[&str],
+        max_turns: Option<u64>,
+    ) -> friday_protocol::AgentRunConstraintsWire {
+        friday_protocol::AgentRunConstraintsWire {
+            read_only,
+            disabled_tools: disabled_tools.iter().map(|s| s.to_string()).collect(),
+            max_turns,
+        }
+    }
+
+    /// Count the `tool.blocked:deny:run_is_read_only:<tool>` events for a run.
+    fn read_only_blocks(rt: &HubRuntime<ScriptTransport>, tool: &str) -> i64 {
+        rt.db()
+            .conn()
+            .query_row(
+                &format!(
+                    "SELECT count(*) FROM agent_run_event WHERE kind LIKE 'tool.blocked:deny:run_is_read_only:{tool}%'"
+                ),
+                [],
+                |r| r.get(0),
+            )
+            .unwrap()
+    }
+
+    /// Count the `tool.blocked:deny:tool_disabled_for_run:<tool>` events for a run.
+    fn disabled_blocks(rt: &HubRuntime<ScriptTransport>, tool: &str) -> i64 {
+        rt.db()
+            .conn()
+            .query_row(
+                &format!(
+                    "SELECT count(*) FROM agent_run_event WHERE kind LIKE 'tool.blocked:deny:tool_disabled_for_run:{tool}%'"
+                ),
+                [],
+                |r| r.get(0),
+            )
+            .unwrap()
+    }
+
+    /// TIGHTEN (the spec's named test): boot is read_only:FALSE, but an asserted
+    /// `read_only:true` constraint forces a gate-DENY of a mutating tool — even though boot
+    /// would have Paused-pending-approval. Proves the override is APPLIED, not dropped.
+    #[test]
+    fn a1_override_read_only_true_forces_block_though_boot_is_not_read_only() {
+        let (rt, root) = runtime_with_boot(
+            "a1-tighten-ro",
+            &["{\"tool\":\"write_file\",\"parameters\":{\"path\":\"out.txt\",\"content\":\"X\"}}"],
+            None,
+            vec![],
+            false, // boot: NOT read-only
+            6,
+        );
+        let c = constraints(true, &[], None); // per-run: read-only
+        let policy = crate::agent_run_control::effective_run_policy_over(rt.policy(), Some(&c));
+        let (_sel, out) = rt
+            .run_task_with_overrides("a1-ro", "write a file", Some(&policy), c.max_turns, 1000)
+            .unwrap();
+        assert_eq!(
+            out.status,
+            LoopStatus::Blocked,
+            "read_only:true override must BLOCK the mutating tool"
+        );
+        assert_eq!(out.executed_tools, 0, "nothing executes under read-only");
+        assert!(!root.join("out.txt").exists(), "no file written");
+        assert_eq!(
+            read_only_blocks(&rt, "write_file"),
+            1,
+            "the block is recorded with the run_is_read_only reason"
+        );
+    }
+
+    /// TIGHTEN: boot has NO disabled tools; an asserted `disabled_tools:[read_file]` constraint
+    /// blocks the read through the override.
+    #[test]
+    fn a1_override_disabled_tool_blocks_though_boot_disables_none() {
+        let (rt, root) = runtime_with_boot(
+            "a1-tighten-dis",
+            &[
+                "{\"tool\":\"read_file\",\"parameters\":{\"path\":\"notes.md\"}}",
+                "{\"tool\":\"none\"}",
+            ],
+            None,
+            vec![], // boot: nothing disabled
+            false,
+            6,
+        );
+        std::fs::write(root.join("notes.md"), b"secret").unwrap();
+        let c = constraints(false, &["read_file"], None);
+        let policy = crate::agent_run_control::effective_run_policy_over(rt.policy(), Some(&c));
+        let (_sel, out) = rt
+            .run_task_with_overrides("a1-dis", "read the notes", Some(&policy), None, 1000)
+            .unwrap();
+        assert_eq!(out.status, LoopStatus::Blocked, "disabled tool blocks");
+        assert_eq!(out.executed_tools, 0);
+        assert_eq!(disabled_blocks(&rt, "read_file"), 1);
+    }
+
+    /// NO-REGRESSION (the discriminating one): boot is read_only:TRUE, and the override is
+    /// ABSENT (`None`). The run MUST stay read-only. A REPLACE-the-boot-policy mistake would
+    /// pass `run_task`'s default unconstrained policy and let the write through — this catches
+    /// it. (`run_task` itself = the absent-override path.)
+    #[test]
+    fn a1_absent_override_preserves_boot_read_only() {
+        let (rt, root) = runtime_with_boot(
+            "a1-noreg-ro",
+            &["{\"tool\":\"write_file\",\"parameters\":{\"path\":\"out.txt\",\"content\":\"X\"}}"],
+            None,
+            vec![],
+            true, // boot: read-only
+            6,
+        );
+        // Absent override = the `run_task` path (delegates `(None, None)`).
+        let (_sel, out) = rt
+            .run_task("a1-noreg-ro-run", "write a file", 1000)
+            .unwrap();
+        assert_eq!(
+            out.status,
+            LoopStatus::Blocked,
+            "boot read-only must persist with NO override"
+        );
+        assert_eq!(out.executed_tools, 0);
+        assert!(!root.join("out.txt").exists());
+        assert_eq!(read_only_blocks(&rt, "write_file"), 1);
+    }
+
+    /// NO-REGRESSION (compose, not replace): boot is read_only:TRUE, and a PRESENT override
+    /// asserts read_only:FALSE (+ a max_turns cap). The OR semantics mean the run STAYS
+    /// read-only — a constraint can never UN-read-only a boot-configured read-only run. A
+    /// replace-mistake (taking the constraint verbatim) would loosen it.
+    #[test]
+    fn a1_override_cannot_loosen_boot_read_only() {
+        let (rt, root) = runtime_with_boot(
+            "a1-noloose-ro",
+            &["{\"tool\":\"write_file\",\"parameters\":{\"path\":\"out.txt\",\"content\":\"X\"}}"],
+            None,
+            vec![],
+            true, // boot: read-only
+            6,
+        );
+        let c = constraints(false, &[], Some(2)); // tries to turn read-only OFF
+        let policy = crate::agent_run_control::effective_run_policy_over(rt.policy(), Some(&c));
+        assert!(
+            policy.is_read_only(),
+            "composed policy stays read-only (boot OR constraint)"
+        );
+        let (_sel, out) = rt
+            .run_task_with_overrides(
+                "a1-noloose-ro-run",
+                "write a file",
+                Some(&policy),
+                c.max_turns,
+                1000,
+            )
+            .unwrap();
+        assert_eq!(out.status, LoopStatus::Blocked, "still read-only");
+        assert_eq!(out.executed_tools, 0);
+        assert!(!root.join("out.txt").exists());
+    }
+
+    /// NO-REGRESSION (union, not replace): boot disables `read_file`; a PRESENT override that
+    /// does NOT name `read_file` (disables something else) must STILL keep read_file disabled.
+    #[test]
+    fn a1_override_cannot_re_enable_boot_disabled_tool() {
+        let (rt, root) = runtime_with_boot(
+            "a1-noloose-dis",
+            &[
+                "{\"tool\":\"read_file\",\"parameters\":{\"path\":\"notes.md\"}}",
+                "{\"tool\":\"none\"}",
+            ],
+            None,
+            vec!["read_file".to_string()], // boot disables read_file
+            false,
+            6,
+        );
+        std::fs::write(root.join("notes.md"), b"secret").unwrap();
+        // Override names a DIFFERENT tool — does not mention read_file.
+        let c = constraints(false, &["delete_file"], None);
+        let policy = crate::agent_run_control::effective_run_policy_over(rt.policy(), Some(&c));
+        assert!(
+            policy.is_tool_disabled("read_file"),
+            "boot-disabled read_file stays disabled after compose"
+        );
+        let (_sel, out) = rt
+            .run_task_with_overrides(
+                "a1-noloose-dis-run",
+                "read the notes",
+                Some(&policy),
+                None,
+                1000,
+            )
+            .unwrap();
+        assert_eq!(out.status, LoopStatus::Blocked, "read_file still blocked");
+        assert_eq!(out.executed_tools, 0);
+        assert_eq!(disabled_blocks(&rt, "read_file"), 1);
+    }
+
+    /// max_turns: a per-run cap LOWERS the ceiling (cannot raise it). Boot ceiling = 6; an
+    /// override cap of 1 means the loop bounds after a single turn. (The floor is applied
+    /// inside `run_task_with_overrides` as `self.max_turns.min(cap)`.)
+    #[test]
+    fn a1_override_max_turns_cap_lowers_ceiling() {
+        // A script that keeps proposing a read (never "none") — without a cap it would run to
+        // the boot ceiling; the cap forces a Bounded outcome sooner.
+        let (rt, root) = runtime_with_boot(
+            "a1-maxturns",
+            &[
+                "{\"tool\":\"read_file\",\"parameters\":{\"path\":\"notes.md\"}}",
+                "{\"tool\":\"read_file\",\"parameters\":{\"path\":\"notes.md\"}}",
+                "{\"tool\":\"read_file\",\"parameters\":{\"path\":\"notes.md\"}}",
+                "{\"tool\":\"read_file\",\"parameters\":{\"path\":\"notes.md\"}}",
+                "{\"tool\":\"read_file\",\"parameters\":{\"path\":\"notes.md\"}}",
+                "{\"tool\":\"read_file\",\"parameters\":{\"path\":\"notes.md\"}}",
+            ],
+            None,
+            vec![],
+            false,
+            6, // boot ceiling
+        );
+        std::fs::write(root.join("notes.md"), b"hello").unwrap();
+        // cap=1: a cap can only lower; min(6,1)=1.
+        let c = constraints(false, &[], Some(1));
+        let policy = crate::agent_run_control::effective_run_policy_over(rt.policy(), Some(&c));
+        let (_sel, out) = rt
+            .run_task_with_overrides("a1-maxturns-run", "read", Some(&policy), c.max_turns, 1000)
+            .unwrap();
+        assert!(
+            out.turns <= 1,
+            "the max_turns cap (1) lowered the boot ceiling (6); got {} turns",
+            out.turns
+        );
+        // A cap of 1 cannot RAISE past boot: passing 100 must still floor to boot (6) — the loop
+        // never runs more than the boot ceiling.
+        let c_high = constraints(false, &[], Some(100));
+        let policy_high =
+            crate::agent_run_control::effective_run_policy_over(rt.policy(), Some(&c_high));
+        let (_sel2, out2) = rt
+            .run_task_with_overrides(
+                "a1-maxturns-high",
+                "read",
+                Some(&policy_high),
+                c_high.max_turns,
+                2000,
+            )
+            .unwrap();
+        assert!(
+            out2.turns <= 6,
+            "a cap above boot cannot raise the ceiling; got {} turns",
+            out2.turns
+        );
+    }
+
+    /// The override preserves the bound OWNER (a constraint restricts WHAT, never WHO). A
+    /// Finished run under a constraint still owner-stamps the boot principal — so the body is
+    /// releasable to that owner exactly as the no-override path.
+    #[test]
+    fn a1_override_preserves_bound_owner_on_finished_run() {
+        let (rt, _root) = runtime_with_boot(
+            "a1-owner",
+            &["{\"tool\":\"none\"}"], // finish immediately
+            Some("principal:owner-a1".to_string()),
+            vec![],
+            false,
+            6,
+        );
+        let c = constraints(true, &["delete_file"], Some(3)); // a tightening constraint
+        let policy = crate::agent_run_control::effective_run_policy_over(rt.policy(), Some(&c));
+        assert_eq!(
+            policy.principal_id(),
+            Some("principal:owner-a1"),
+            "compose preserves the boot principal verbatim"
+        );
+        let (_sel, out) = rt
+            .run_task_with_overrides(
+                "a1-owner-run",
+                "answer me",
+                Some(&policy),
+                c.max_turns,
+                1000,
+            )
+            .unwrap();
+        assert_eq!(out.status, LoopStatus::Finished);
+        // The owner was stamped: the result row records the boot owner.
+        let owner: Option<String> = rt
+            .db()
+            .conn()
+            .query_row(
+                "SELECT owner_principal FROM run_result WHERE run_id = 'a1-owner-run'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(
+            owner.as_deref(),
+            Some("principal:owner-a1"),
+            "the constrained run still owner-stamps the boot principal"
+        );
     }
 }

--- a/rust-core/crates/friday-hub/tests/a1_run_control.rs
+++ b/rust-core/crates/friday-hub/tests/a1_run_control.rs
@@ -17,8 +17,8 @@ use friday_core::gate::{
 };
 use friday_crypto::{OperatorSigningKey, OperatorVerifyingKey};
 use friday_hub::agent_run_control::{
-    cancel, detect_pause, effective_max_turns, effective_run_policy, reject, resolve_run_owner,
-    resume,
+    cancel, detect_pause, effective_max_turns, effective_run_policy, effective_run_policy_over,
+    reject, resolve_run_owner, resume,
 };
 use friday_hub::{
     build_request_with_policy, run_loop_with_policy, AgentError, AgentLlmClient, AgentStep,
@@ -433,4 +433,76 @@ fn effective_run_policy_maps_constraints_tightening_only() {
         "a higher asserted cap cannot raise the ceiling"
     );
     assert_eq!(effective_max_turns(8, None), 8, "None ⇒ runtime default");
+}
+
+/// (A1 APPLICATION) `effective_run_policy_over` COMPOSES onto an arbitrary boot policy so the
+/// only-tighten invariant holds UNCONDITIONALLY — the load-bearing property the live dispatch
+/// relies on (a constraint can NEVER loosen a boot-configured restriction).
+#[test]
+fn effective_run_policy_over_composes_only_tightens() {
+    // None over ANY boot ⇒ the boot policy unchanged (the absent-constraint path).
+    let boot_unconstrained = RunPolicy::new(Some(OWNER.into()), Vec::<String>::new(), false);
+    let p = effective_run_policy_over(&boot_unconstrained, None);
+    assert_eq!(p.principal_id(), Some(OWNER));
+    assert!(!p.is_read_only());
+
+    // A boot policy that is ITSELF read-only + disables `delete_file`.
+    let boot_strict = RunPolicy::new(Some(OWNER.into()), vec!["delete_file".to_string()], true);
+
+    // (1) None ⇒ boot strictness preserved (NOT reset to unconstrained — the REPLACE bug).
+    let p = effective_run_policy_over(&boot_strict, None);
+    assert!(p.is_read_only(), "None must NOT loosen a read-only boot");
+    assert!(
+        p.is_tool_disabled("delete_file"),
+        "None must NOT re-enable a boot-disabled tool"
+    );
+
+    // (2) A constraint that tries to LOOSEN (read_only:false + a DIFFERENT disabled set) cannot:
+    //     read_only stays true (OR), and the boot-disabled tool stays disabled (UNION).
+    let loosen = AgentRunConstraintsWire {
+        read_only: false,
+        disabled_tools: vec!["run_command".into()],
+        max_turns: None,
+    };
+    let p = effective_run_policy_over(&boot_strict, Some(&loosen));
+    assert!(p.is_read_only(), "OR: boot read-only cannot be turned off");
+    assert!(
+        p.is_tool_disabled("delete_file"),
+        "UNION: boot-disabled delete_file stays disabled"
+    );
+    assert!(
+        p.is_tool_disabled("run_command"),
+        "UNION: the constraint ADDS run_command to the disabled set"
+    );
+    assert_eq!(p.principal_id(), Some(OWNER), "owner is preserved verbatim");
+
+    // (3) A constraint TIGHTENS an unconstrained boot: read_only on, tool disabled.
+    let tighten = AgentRunConstraintsWire {
+        read_only: true,
+        disabled_tools: vec!["write_file".into()],
+        max_turns: Some(1),
+    };
+    let p = effective_run_policy_over(&boot_unconstrained, Some(&tighten));
+    assert!(p.is_read_only());
+    assert!(p.is_tool_disabled("write_file"));
+}
+
+/// `RunPolicy::tightened_by` directly: empty/whitespace entries are dropped (cannot widen), and
+/// composing with `(false, [])` is a NO-OP equal to the receiver.
+#[test]
+fn tightened_by_drops_empties_and_noop_on_empty_constraint() {
+    let boot = RunPolicy::new(Some(OWNER.into()), vec!["delete_file".to_string()], false);
+
+    // (false, []) over a non-read-only boot ⇒ equal to boot (no widening, no narrowing).
+    let same = boot.tightened_by(false, &[]);
+    assert!(!same.is_read_only());
+    assert!(same.is_tool_disabled("delete_file"));
+    assert!(!same.is_tool_disabled("write_file"));
+
+    // Empty / whitespace entries are normalized away (cannot pollute the disabled set).
+    let p = boot.tightened_by(true, &["".into(), "   ".into(), "write_file".into()]);
+    assert!(p.is_read_only());
+    assert!(p.is_tool_disabled("delete_file"));
+    assert!(p.is_tool_disabled("write_file"));
+    assert!(!p.is_tool_disabled(""), "empty entry never disables");
 }

--- a/src/api/mission-spine/friday-rust-hub-agent-run-sealed-client-service.ts
+++ b/src/api/mission-spine/friday-rust-hub-agent-run-sealed-client-service.ts
@@ -3,6 +3,7 @@ import { FridayDomainError } from "#errors";
 import {
   createFridayRustHubAgentRunSealedClient,
   type CreateFridayRustHubAgentRunSealedClientOptions,
+  type FridayRustHubAgentRunConstraints,
   type FridayRustHubAgentRunSealedClient,
 } from "./friday-rust-hub-agent-run-ws-sealed-client.js";
 
@@ -76,6 +77,13 @@ export interface FridayRustHubAgentRunSealedClientServiceRequest {
    * `forwardedPrincipal`, never this key.
    */
   readonly sessionKey?: string;
+  /**
+   * (A1 run-controls) Per-run CONSTRAINTS forwarded UNCHANGED to the underlying sealed client,
+   * which emits the snake_case `constraints` wire block ONLY when something tightens (else OMITS
+   * it ⇒ byte-identical pre-A1 wire). The Rust server COMPOSES them onto the run policy (read-only
+   * / disabled-tools / max-turns), tightening only, behind its default-off run-control flag.
+   */
+  readonly constraints?: FridayRustHubAgentRunConstraints;
 }
 
 /**
@@ -194,6 +202,9 @@ export function createFridayRustHubAgentRunSealedClientService(
           // (A2a Phase 1) forward the session key; the inner client emits `session_id` only when
           // non-empty (absent/blank ⇒ byte-identical sessionless wire).
           ...(request.sessionKey !== undefined ? { sessionKey: request.sessionKey } : {}),
+          // (A1 run-controls) forward the per-run constraints; the inner client emits the
+          // `constraints` wire block only when something tightens (absent ⇒ byte-identical wire).
+          ...(request.constraints !== undefined ? { constraints: request.constraints } : {}),
         });
       } catch (error) {
         throw error instanceof FridayDomainError

--- a/src/api/mission-spine/friday-rust-hub-agent-run-ws-sealed-client.ts
+++ b/src/api/mission-spine/friday-rust-hub-agent-run-ws-sealed-client.ts
@@ -137,6 +137,32 @@ export interface FridayRustHubAgentRunSealedRequest {
    * owner is the authenticated `forwardedPrincipal`, verified server-side — never this key.**
    */
   readonly sessionKey?: string;
+  /**
+   * (A1 run-controls) Per-run CONSTRAINTS the trusted peer asserts; the Rust server COMPOSES
+   * them onto the run's `RunPolicy` (read-only / disabled-tools / max-turns) so they can ONLY
+   * ever TIGHTEN a run (a restriction, never a grant). ABSENT (`undefined`) ⇒ the `constraints`
+   * field is OMITTED from the wire entirely, so the envelope is BYTE-IDENTICAL to the pre-A1
+   * request and the server applies NO override (boot policy unchanged). DARK + DEPLOY-GO-gated:
+   * the server APPLIES these only behind its default-off `FRIDAY_AGENT_RUN_CONTROL_VIA_RUST`
+   * flag, so emitting them changes no live behavior until that flag is on. Mirrors the
+   * `sessionKey` additive-optional discipline.
+   */
+  readonly constraints?: FridayRustHubAgentRunConstraints;
+}
+
+/**
+ * (A1 run-controls) The TS-side per-run constraint shape (camelCase; mapped to the snake_case
+ * `AgentRunConstraintsWire`). Every field is OPTIONAL and a RESTRICTION only — there is no field
+ * that can WIDEN a run. An all-absent object serializes to no wire field at all (see the emit
+ * site), preserving byte-identity.
+ */
+export interface FridayRustHubAgentRunConstraints {
+  /** When `true`, the run is read-only: a mutating tool is blocked before execution. */
+  readonly readOnly?: boolean;
+  /** Tools disabled for THIS run (the TS oracle's `disabledTools`); a restriction, never a grant. */
+  readonly disabledTools?: readonly string[];
+  /** A per-run `max_turns` cap; the server takes `min(runtime_default, this)` (can only LOWER). */
+  readonly maxTurns?: number;
 }
 
 /**
@@ -382,6 +408,58 @@ function sealAndSend(sender: WsSender, sessionKey: Uint8Array, envelope: unknown
   // CLIENT frames MUST be masked (tungstenite rejects unmasked client frames). The Sender was
   // constructed with a mask generator, so mask:true uses it.
   sender.send(Buffer.from(wire), { binary: true, mask: true, fin: true });
+}
+
+/**
+ * (A1 run-controls) Map the TS-side per-run constraints onto the snake_case
+ * `AgentRunConstraintsWire` shape — or `undefined` when NOTHING is asserted, so the caller OMITS
+ * the whole `constraints` key (byte-identity with the pre-A1 request).
+ *
+ * The emitted object MIRRORS the Rust serde discipline EXACTLY so the round-trip is faithful:
+ *   - `read_only` is emitted as a bool ONLY when the caller asserts `readOnly === true` (the Rust
+ *     field has `#[serde(default)]`, so an absent `read_only` deserializes to `false` — we never
+ *     emit `read_only: false`, keeping the block minimal and a read-only-off run byte-clean);
+ *   - `disabled_tools` is emitted ONLY when the normalized (trimmed, de-duped, non-empty) set is
+ *     non-empty (Rust `skip_serializing_if = "Vec::is_empty"`);
+ *   - `max_turns` is emitted ONLY when a finite positive integer cap is given (Rust
+ *     `skip_serializing_if = "Option::is_none"`).
+ * If, after normalization, NONE of the three is present, the run asserts no tightening at all and
+ * this returns `undefined` (no wire block). A constraint can ONLY tighten — there is no field that
+ * widens — so a hostile/garbled value at worst under-restricts to "no constraint", never a grant.
+ */
+export function buildConstraintsWire(
+  constraints: FridayRustHubAgentRunConstraints | undefined,
+): Record<string, unknown> | undefined {
+  if (constraints === undefined) {
+    return undefined;
+  }
+  const wire: Record<string, unknown> = {};
+  if (constraints.readOnly === true) {
+    wire.read_only = true;
+  }
+  if (Array.isArray(constraints.disabledTools)) {
+    // Normalize like the Rust `RunPolicy::new` / the TS oracle's `normalizeToolNameSet`: trim,
+    // drop empties, de-dup — so a whitespace/duplicate entry can never bloat or weaken the set.
+    const normalized = Array.from(
+      new Set(
+        constraints.disabledTools
+          .filter((t): t is string => typeof t === "string")
+          .map((t) => t.trim())
+          .filter((t) => t.length > 0),
+      ),
+    );
+    if (normalized.length > 0) {
+      wire.disabled_tools = normalized;
+    }
+  }
+  if (
+    typeof constraints.maxTurns === "number" &&
+    Number.isInteger(constraints.maxTurns) &&
+    constraints.maxTurns > 0
+  ) {
+    wire.max_turns = constraints.maxTurns;
+  }
+  return Object.keys(wire).length > 0 ? wire : undefined;
 }
 
 /** Open + decode one inbound sealed WS Binary payload into its inner message. */
@@ -692,6 +770,13 @@ export function createFridayRustHubAgentRunSealedClient(
               typeof request.sessionKey === "string" && request.sessionKey.trim().length > 0
                 ? request.sessionKey.trim()
                 : undefined;
+            // (A1 run-controls) Derive the snake_case `constraints` wire block from the request's
+            // per-run constraints, emitting it ONLY when the caller actually asserts a TIGHTENING
+            // (read-only, a non-empty disabled-tool set, or a max-turns cap). When NOTHING is
+            // asserted the whole `constraints` key is OMITTED, so the serialized envelope is
+            // BYTE-IDENTICAL to the pre-A1 request and the server applies no override. This
+            // mirrors the `session_id` conditional-spread discipline.
+            const constraintsWire = buildConstraintsWire(request.constraints);
             const envelope = {
               schema_version: SCHEMA_VERSION,
               msg_id: `agent-run-${request.runId}`,
@@ -706,6 +791,8 @@ export function createFridayRustHubAgentRunSealedClient(
                 auth_proof: Array.from(authProof),
                 // Conditional spread: present ⇒ `session_id` rides the wire; absent ⇒ no key.
                 ...(sessionId !== undefined ? { session_id: sessionId } : {}),
+                // Conditional spread: present ⇒ `constraints` rides the wire; absent ⇒ no key.
+                ...(constraintsWire !== undefined ? { constraints: constraintsWire } : {}),
               },
             };
             sealAndSend(sender, sessionKey, envelope);

--- a/src/api/runtime/friday-api-runtime.ts
+++ b/src/api/runtime/friday-api-runtime.ts
@@ -141,6 +141,7 @@ import { createFridayCloudWorkerSetupService } from "#cloud-workers";
 // (the ECDH model — REPLACES #612's symmetric session-key resolver, which was the wrong shape).
 import { createFridayRustHubAgentRunSealedClientService } from "../mission-spine/friday-rust-hub-agent-run-sealed-client-service.js";
 import type { FridayRustHubAgentRunSealedClientService } from "../mission-spine/friday-rust-hub-agent-run-sealed-client-service.js";
+import type { FridayRustHubAgentRunConstraints } from "../mission-spine/friday-rust-hub-agent-run-ws-sealed-client.js";
 import { createFridayRustHubRunContinuityProjectorService } from "../mission-spine/friday-rust-hub-run-continuity-projector-service.js";
 import type { FridayRustHubRunContinuityProjectorService } from "../mission-spine/friday-rust-hub-run-continuity-projector-service.js";
 import { createFridayRustHubRunAnswerReadbackService } from "../mission-spine/friday-rust-hub-run-answer-readback-service.js";
@@ -1200,6 +1201,17 @@ async function composeRustReadOnlyAgentRun(args: {
    * scopes the session to the authenticated owner principal, never this key.
    */
   readonly sessionKey: string | undefined;
+  /**
+   * (A1 run-controls) The per-run CONSTRAINTS to forward on the sealed-WS dispatch so the Rust
+   * server COMPOSES them onto the run's `RunPolicy` (read-only / disabled-tools / max-turns) —
+   * they can only ever TIGHTEN. For a qualifying read-only Rust run this is `{ readOnly: true }`
+   * (clause 2 of {@link qualifiesForRustReadOnlyRoute} already REQUIRES `readOnly === true`, so
+   * forwarding it makes the read-only guarantee travel on the WIRE + be enforced in RUST, not
+   * only by the TS qualifier — the defense-in-depth A1 closes). ABSENT (`undefined`) ⇒ no
+   * `constraints` on the wire, byte-identical to the pre-A1 dispatch, server applies no override
+   * (gated additionally by the server's default-off run-control flag).
+   */
+  readonly constraints: FridayRustHubAgentRunConstraints | undefined;
   readonly providerId: string;
   readonly model: string;
   readonly wsClient: FridayRustHubAgentRunSealedClientService;
@@ -1273,6 +1285,10 @@ async function composeRustReadOnlyAgentRun(args: {
       // non-empty (absent/blank ⇒ byte-identical sessionless wire, today's behavior). The server
       // owner-scopes the session to `callerPrincipal` (the authenticated owner), never this key.
       ...(args.sessionKey !== undefined ? { sessionKey: args.sessionKey } : {}),
+      // (A1 run-controls) forward the per-run constraints; the WS client emits `constraints` only
+      // when something tightens (here `{ readOnly: true }`), else OMITS the field (byte-identical
+      // pre-A1 wire). The server composes them onto the run policy behind its default-off flag.
+      ...(args.constraints !== undefined ? { constraints: args.constraints } : {}),
     });
   } catch (err) {
     logFailClosed(
@@ -4541,6 +4557,15 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
             // (A2a Phase 1) forward the session key so a SESSIONED qualifying run dispatches
             // `session_id`; absent/blank ⇒ byte-identical sessionless dispatch (today's behavior).
             sessionKey: input.sessionKey,
+            // (A1 run-controls) Derive the per-run constraints to forward on the wire. A run only
+            // reaches here when it QUALIFIED, which (clause 2) REQUIRES `constraints.readOnly ===
+            // true` — so forward `{ readOnly: true }`, making the read-only guarantee travel on
+            // the wire + be enforced in Rust (defense-in-depth), not only by this TS qualifier.
+            // We forward ONLY the verified-true `readOnly` (the qualifier's own contract); the
+            // disabled-tool / max-turns axes are not asserted by the read-only route today, so
+            // they stay absent (omitted on the wire). The server gates application behind its
+            // default-off run-control flag, so this remains DARK + DEPLOY-GO-gated.
+            constraints: { readOnly: true },
             providerId: input.providerId ?? RUST_ROUTE_DEEPSEEK_PROVIDER_ID,
             model: input.model ?? RUST_ROUTE_DEEPSEEK_FLASH_MODEL,
             wsClient: rustWsClient,

--- a/test/unit/api/mission-spine/friday-rust-hub-agent-run-sealed-client-service.test.ts
+++ b/test/unit/api/mission-spine/friday-rust-hub-agent-run-sealed-client-service.test.ts
@@ -27,6 +27,7 @@ function makeFakeClient(behavior: {
     task: string;
     forwardedPrincipal: string;
     sessionKey?: string;
+    constraints?: { readOnly?: boolean; disabledTools?: readonly string[]; maxTurns?: number };
   }> = [];
   const createClient = vi.fn(
     (options: CreateFridayRustHubAgentRunSealedClientOptions): FridayRustHubAgentRunSealedClient => {
@@ -214,6 +215,38 @@ describe("createFridayRustHubAgentRunSealedClientService (B1-compose, dark, adap
       // no sessionKey
     });
     expect("sessionKey" in fake.dispatched[0]).toBe(false);
+  });
+
+  it("(A1 run-controls) forwards per-run constraints to the underlying client", async () => {
+    const fake = makeFakeClient({ result: deliveredResult() });
+    const service = createFridayRustHubAgentRunSealedClientService({
+      port: 4123,
+      createClient: fake.createClient,
+    });
+    await service.dispatchRun({
+      runId: "run-1",
+      task: "read README.md",
+      forwardedPrincipal: "owner-1",
+      clientSecret: SECRET,
+      constraints: { readOnly: true },
+    });
+    expect(fake.dispatched[0].constraints).toEqual({ readOnly: true });
+  });
+
+  it("(A1 run-controls) does NOT set constraints on the inner dispatch when absent (byte-identical)", async () => {
+    const fake = makeFakeClient({ result: deliveredResult() });
+    const service = createFridayRustHubAgentRunSealedClientService({
+      port: 4123,
+      createClient: fake.createClient,
+    });
+    await service.dispatchRun({
+      runId: "run-1",
+      task: "read README.md",
+      forwardedPrincipal: "owner-1",
+      clientSecret: SECRET,
+      // no constraints
+    });
+    expect("constraints" in fake.dispatched[0]).toBe(false);
   });
 
   it("fails closed (503) when the underlying client construction throws (e.g. a non-32-byte secret)", async () => {

--- a/test/unit/api/mission-spine/friday-rust-hub-agent-run-ws-constraints-wire.test.ts
+++ b/test/unit/api/mission-spine/friday-rust-hub-agent-run-ws-constraints-wire.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+
+import { buildConstraintsWire } from "../../../../src/api/mission-spine/friday-rust-hub-agent-run-ws-sealed-client.js";
+
+// (A1 run-controls) `buildConstraintsWire` maps the TS-side per-run constraints onto the
+// snake_case `AgentRunConstraintsWire` shape the Rust server decodes — or `undefined` when
+// NOTHING tightens, so the caller OMITS the whole `constraints` key (byte-identity with the
+// pre-A1 request). The Rust serde discipline is mirrored EXACTLY:
+//   - `read_only` emitted ONLY when true (Rust `#[serde(default)]` ⇒ absent deserializes false);
+//   - `disabled_tools` emitted ONLY when the normalized set is non-empty (Rust skip-if-empty);
+//   - `max_turns` emitted ONLY when a finite positive integer cap is given (Rust skip-if-none).
+describe("buildConstraintsWire (A1 run-controls, snake_case wire mapping)", () => {
+  it("undefined input ⇒ undefined (no wire block — byte-identical pre-A1)", () => {
+    expect(buildConstraintsWire(undefined)).toBeUndefined();
+  });
+
+  it("an all-absent / non-tightening object ⇒ undefined (no wire key emitted)", () => {
+    expect(buildConstraintsWire({})).toBeUndefined();
+    expect(buildConstraintsWire({ readOnly: false })).toBeUndefined();
+    expect(buildConstraintsWire({ disabledTools: [] })).toBeUndefined();
+    // whitespace/empty entries normalize away to an empty set ⇒ no wire key
+    expect(buildConstraintsWire({ disabledTools: ["", "   "] })).toBeUndefined();
+    // a non-positive / non-integer cap is not a real tightening ⇒ no wire key
+    expect(buildConstraintsWire({ maxTurns: 0 })).toBeUndefined();
+    expect(buildConstraintsWire({ maxTurns: -3 })).toBeUndefined();
+    expect(buildConstraintsWire({ maxTurns: 1.5 })).toBeUndefined();
+  });
+
+  it("readOnly:true ⇒ { read_only: true } only", () => {
+    expect(buildConstraintsWire({ readOnly: true })).toEqual({ read_only: true });
+  });
+
+  it("readOnly:false is NEVER emitted (kept minimal; matches the Rust default)", () => {
+    // false alone ⇒ undefined; false alongside a real tightening ⇒ the false is dropped.
+    expect(buildConstraintsWire({ readOnly: false, maxTurns: 2 })).toEqual({ max_turns: 2 });
+    expect("read_only" in (buildConstraintsWire({ readOnly: false, maxTurns: 2 }) ?? {})).toBe(
+      false,
+    );
+  });
+
+  it("disabledTools ⇒ trimmed, de-duped, empties dropped (cannot bloat/weaken the set)", () => {
+    expect(
+      buildConstraintsWire({ disabledTools: [" write_file ", "write_file", "", "delete_file"] }),
+    ).toEqual({ disabled_tools: ["write_file", "delete_file"] });
+  });
+
+  it("maxTurns positive integer ⇒ { max_turns }", () => {
+    expect(buildConstraintsWire({ maxTurns: 3 })).toEqual({ max_turns: 3 });
+  });
+
+  it("all three tightenings compose into one snake_case block", () => {
+    expect(
+      buildConstraintsWire({ readOnly: true, disabledTools: ["delete_file"], maxTurns: 2 }),
+    ).toEqual({ read_only: true, disabled_tools: ["delete_file"], max_turns: 2 });
+  });
+});

--- a/test/unit/api/runtime/friday-api-runtime-rust-route-compose.test.ts
+++ b/test/unit/api/runtime/friday-api-runtime-rust-route-compose.test.ts
@@ -277,6 +277,10 @@ describe("FridayApiRuntime — execrun S-F-compose (DARK) Rust-route composition
     expect(ws.calls).toHaveLength(1);
     expect(ws.calls[0].runId).toBe(RUN_ID);
     expect(ws.calls[0].forwardedPrincipal).toBe(OWNER_PRINCIPAL);
+    // (A1 run-controls) compose forwards the per-run read-only constraint on the dispatch — the
+    // qualifier (clause 2) already REQUIRES readOnly:true, so the guarantee now travels on the
+    // wire + is enforced in Rust (defense-in-depth), not only by this TS qualifier.
+    expect(ws.calls[0].constraints).toEqual({ readOnly: true });
     // The sealed client receives the resolved 32-byte X25519 SECRET (NOT a pre-built authProof).
     expect(ws.calls[0].clientSecret.length).toBe(32);
     expect(readback.calls).toHaveLength(1);


### PR DESCRIPTION
## A1 — per-run-constraints threading (the prerequisite before any mutating run-control)

Closes the EXPLICIT deferral #660 (b638e37f) left open: *"live application of constraints onto the run-START policy"*. #660 landed the on-wire `constraints` field, the `AgentRunConstraintsWire` struct, and the pure mapping helpers. This PR **APPLIES** them — threading the per-run `AgentRunConstraintsWire` (read-only / disabled-tools / max-turns) onto the **live run-START `RunPolicy`** the loop's gate consults, instead of the boot config.

### DARK + DEPLOY-GO-gated (changes NO live behavior on deploy)
Two independent reasons:
1. **Absent override = boot policy.** When a request carries no `constraints` (every live courier today before this PR's TS leg, and the `run_task`/`run_session_task` delegating wrappers), the override is `None` ⇒ the runtime uses its own `self.policy`/`self.max_turns` reference — **byte-identical** to pre-A1.
2. **Flag-gated application.** The dispatch arm builds the override ONLY behind the default-off `FRIDAY_AGENT_RUN_CONTROL_VIA_RUST` flag (the same flag governing the A1 run-control plane). Flag off ⇒ `None` override ⇒ boot policy, even if a peer asserted constraints.

A constraint can **ONLY TIGHTEN** (read_only logical-OR, disabled_tools UNION via `RunPolicy::tightened_by`) — composed onto the boot policy, so the only-tighten invariant holds **unconditionally**, independent of whether boot is itself unconstrained. Not crypto/handshake-adjacent (operates on `RunPolicy`/gate, never the seal/auth_proof). NOT `executeRun`-replaced; **NOT v1 GO**.

### What changed
- **runtime.rs** — `run_task_with_overrides` / `run_session_task_with_overrides` accept `Option<&RunPolicy>` + `Option<max_turns>`; the existing `run_task`/`run_session_task` delegate with `(None, None)` (every pre-A1 caller untouched). Owner-stamp + the max_turns floor (`self.max_turns.min(cap)`) use the EFFECTIVE policy.
- **hub_server.rs** — `run_authed_agent_loop_with_policy` (sessionless dispatch entry); the FIX-Q2 `caller == configured_owner` guard is unchanged (a constraint tightens WHAT, never WHO).
- **lib.rs** — `RunPolicy::tightened_by(read_only, disabled_tools)` composing helper (full field access; protocol-free).
- **agent_run_control.rs** — `effective_run_policy_over(boot, constraints)` (composes onto boot; `None ⇒ boot.clone()`). The merged `effective_run_policy` is left untouched (its contract + tests stay green).
- **hub_agent_run_server.rs** — dispatch arm computes the override ONCE (flag-gated) and passes it to BOTH dispatch arms (sessioned + sessionless).
- **TS courier** (`friday-rust-hub-agent-run-ws-sealed-client.ts` + `-sealed-client-service.ts`) — `AgentRunRequest` builder emits `constraints` ONLY when something tightens (else omits the key ⇒ byte-identical wire); `buildConstraintsWire` mirrors the Rust serde discipline exactly.
- **friday-api-runtime.ts** — `composeRustReadOnlyAgentRun` derives `{ readOnly: true }` (clause 2 of the qualifier already REQUIRES `readOnly === true`), so the read-only guarantee now travels on the **wire** + is enforced in **Rust** — the defense-in-depth the A2 GATE-AGENT-REPLACE design §1a/§4 names (today read-only is enforced ONLY by the TS qualifier).

### Tests (real per-behavior; honest counts)
- **Rust** — 11 `a1_` tests: sessionless AND **sessioned** read-only block (the hot path the risk-flag names), absent-override no-regression (boot read-only/disabled persists), compose-not-replace no-loosen (a constraint can't un-read-only or re-enable a boot-disabled tool), tighten (read_only:true blocks though boot is read_only:false), max_turns floor (lowers, never raises), owner preserved; + `effective_run_policy_over` / `tightened_by` composing unit tests. **friday-hub: 696 passed / 0 failed**. `clippy -D warnings` clean; `cargo fmt` (pinned 1.95.0) clean.
- **TS** — `buildConstraintsWire` mapping (7) + service forwarding (2) + compose forwards `{readOnly:true}` (1). 248 tests across `test/unit/api/runtime` + `test/unit/api/mission-spine` pass; `typecheck:src` clean; touched-file lint 0 errors.

### What remains / for the operator
- **Flag coupling (ratify):** constraint application reuses `FRIDAY_AGENT_RUN_CONTROL_VIA_RUST`, so enabling pause/cancel/resume also enables constraint-tightening. Defensible (only-tighten; qualifying runs are read-tool-only) but worth a decision vs a dedicated flag.
- **Deploy ordering = NON-issue:** the `Message` enum is NOT `#[serde(deny_unknown_fields)]`, so even a pre-#660 server tolerates (ignores) the new `constraints` field. No server-first ordering is load-bearing.
- Batch note: per the spec this is a SEPARATE PR sequenced SECOND (after leg-A); it shares the TS file `friday-rust-hub-agent-run-ws-sealed-client.ts` with leg-A but a DIFFERENT function (AgentRunRequest builder vs settle handlers). Coordinator handles batching/rebase at merge. Do NOT merge from here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)