### PR TITLE
feat(a8-system-remote): REAL WebAuthn/FIDO2 passkey verifier over webauthn-rs (DARK + flag-gated-off)

### DIFF
--- a/rust-core/Cargo.lock
+++ b/rust-core/Cargo.lock
@@ -94,10 +94,88 @@ dependencies = [
 ]
 
 [[package]]
+name = "asn1-rs"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5493c3bedbacf7fd7382c6346bbd66687d12bbaad3a89a2d2c303ee6cf20b048"
+dependencies = [
+ "asn1-rs-derive",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror 1.0.69",
+ "time",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "965c2d33e53cb6b267e148a4cb0760bc01f4904c1cd4bb4002a085bb016d1490"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "asn1-rs-impl"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
+name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "base64"
@@ -112,6 +190,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
+name = "base64urlsafedata"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b08e33815c87d8cadcddb1e74ac307368a3751fbe40c961538afa21a1899f21c"
+dependencies = [
+ "base64 0.21.7",
+ "pastey",
+ "serde",
+]
+
+[[package]]
 name = "basic-toml"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -119,6 +208,12 @@ checksum = "ba62675e8242a4c4e806d12f11d136e626e6c8361d6b829310732241652a178a"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -134,6 +229,12 @@ checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
 ]
+
+[[package]]
+name = "bumpalo"
+version = "3.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "byteorder"
@@ -294,13 +395,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
- "rand_core",
+ "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -348,6 +455,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "der-parser"
+version = "9.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cd0a5c643689626bec213c4d8bd4d96acc8ffdb4ad4bb6bc16abf27d5f4b553"
+dependencies = [
+ "asn1-rs",
+ "displaydoc",
+ "nom",
+ "num-bigint",
+ "num-traits",
+ "rusticata-macros",
+]
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -387,7 +517,7 @@ checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
- "rand_core",
+ "rand_core 0.6.4",
  "serde",
  "sha2",
  "subtle",
@@ -407,7 +537,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -455,6 +585,21 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -610,7 +755,12 @@ dependencies = [
 name = "friday-system-remote"
 version = "0.0.1"
 dependencies = [
+ "openssl-sys",
+ "serde_json",
+ "sha2",
  "thiserror 1.0.69",
+ "webauthn-authenticator-rs",
+ "webauthn-rs",
 ]
 
 [[package]]
@@ -631,6 +781,94 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88a41f105fe1d5b6b34b2055e3dc59bb79b46b48b2040b9e6c7b4b5de097aa41"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "slab",
 ]
 
 [[package]]
@@ -656,13 +894,25 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "wasip2",
  "wasip3",
 ]
@@ -682,6 +932,17 @@ dependencies = [
  "log",
  "plain",
  "scroll",
+]
+
+[[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
 ]
 
 [[package]]
@@ -722,6 +983,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hkdf"
@@ -894,6 +1161,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "js-sys"
+version = "0.3.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2025f20d7a4fa7785846e7b63d10a76d3f1cee98ee5cb79ea59703f95e42162"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -957,6 +1241,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "mio"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -964,6 +1259,60 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-conv"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+
+[[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "oid-registry"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8d8034d9489cdaf79228eb9f6a3b8d7bb32ba00d6645ebd48eef4077ceb5bd9"
+dependencies = [
+ "asn1-rs",
 ]
 
 [[package]]
@@ -979,10 +1328,69 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
+name = "openssl"
+version = "0.10.80"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
+dependencies = [
+ "bitflags 2.11.1",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "openssl-src"
+version = "300.6.1+3.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46eb8fb9fb3b61ce1c0f8a026c4c1a0714d3a9e138e7fbde78753ce2babc3846"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.116"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28a22dc7140cda5f096e5e7724a6962ca81a7f8bfd2979f9b18c11af56318c4"
+dependencies = [
+ "cc",
+ "libc",
+ "openssl-src",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "pastey"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pkcs8"
@@ -1027,6 +1435,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1065,6 +1479,12 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
@@ -1076,8 +1496,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1087,7 +1517,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1097,6 +1537,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -1139,7 +1588,7 @@ dependencies = [
  "getrandom 0.2.17",
  "libc",
  "untrusted",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1148,7 +1597,7 @@ version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b838eba278d213a8beaf485bd313fd580ca4505a00d5871caeb1457c55322cae"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "fallible-iterator",
  "fallible-streaming-iterator",
  "hashlink",
@@ -1172,16 +1621,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusticata-macros"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1218,6 +1676,12 @@ dependencies = [
  "rustls-pki-types",
  "untrusted",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "scroll"
@@ -1257,6 +1721,26 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
+]
+
+[[package]]
+name = "serde_bytes"
+version = "0.11.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
+dependencies = [
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "serde_cbor_2"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aec2709de9078e077090abd848e967abab63c9fb3fdb5d4799ad359d8d482c"
+dependencies = [
+ "half",
+ "serde",
 ]
 
 [[package]]
@@ -1335,7 +1819,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -1351,6 +1835,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1361,6 +1851,16 @@ name = "smawk"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
+
+[[package]]
+name = "socket2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "spki"
@@ -1428,7 +1928,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1481,6 +1981,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1488,6 +2019,71 @@ checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
+]
+
+[[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tokio"
+version = "1.52.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
+dependencies = [
+ "libc",
+ "mio",
+ "pin-project-lite",
+ "socket2",
+ "tokio-macros",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -1532,6 +2128,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
 name = "tungstenite"
 version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1543,7 +2170,7 @@ dependencies = [
  "http",
  "httparse",
  "log",
- "rand",
+ "rand 0.8.6",
  "sha1",
  "thiserror 1.0.69",
  "utf-8",
@@ -1560,6 +2187,15 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
 
 [[package]]
 name = "unicode-xid"
@@ -1710,7 +2346,7 @@ version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "flate2",
  "log",
  "once_cell",
@@ -1732,6 +2368,7 @@ dependencies = [
  "idna",
  "percent-encoding",
  "serde",
+ "serde_derive",
 ]
 
 [[package]]
@@ -1745,6 +2382,18 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "uuid"
+version = "1.23.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "144d6b123cef80b301b8f72a9e2ca4370ddec21950d0a103dd22c437006d2db7"
+dependencies = [
+ "getrandom 0.4.2",
+ "js-sys",
+ "serde_core",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "vcpkg"
@@ -1783,6 +2432,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen"
+version = "0.2.123"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a254a4b10c19a76f09a27640e7ffbf9bc30bf67e16a3bf28aaefa4920fe81563"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.123"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24a40fc75b0ec6f3746ceb10d36f53a93dcd68a93b11b6445983945d79eba0dc"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.123"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "908f34bd9b9ce3d4caf07b72dfab63d61504d156856c6bd3cd87fa350cf3985b"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.123"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7acbf7616c27b194bbb550bf77ed0c2c3e5b7fd1260a93082b95fb7f47959b92"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
 name = "wasm-encoder"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1810,10 +2504,111 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
+]
+
+[[package]]
+name = "webauthn-attestation-ca"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6475c0bbd1a3f04afaa3e98880408c5be61680c5e6bd3c6f8c250990d5d3e18e"
+dependencies = [
+ "base64urlsafedata",
+ "openssl",
+ "openssl-sys",
+ "serde",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "webauthn-authenticator-rs"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "779e9c80ff248c7e12ea967f909249101f6e86f70fccd742d4b66c490c1710b4"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "base64 0.21.7",
+ "base64urlsafedata",
+ "bitflags 1.3.2",
+ "futures",
+ "hex",
+ "nom",
+ "num-derive",
+ "num-traits",
+ "openssl",
+ "openssl-sys",
+ "serde",
+ "serde_bytes",
+ "serde_cbor_2",
+ "serde_json",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+ "unicode-normalization",
+ "url",
+ "uuid",
+ "webauthn-rs-core",
+ "webauthn-rs-proto",
+]
+
+[[package]]
+name = "webauthn-rs"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c548915e0e92ee946bbf2aecf01ea21bef53d974b0793cc6732ba81a03fc422"
+dependencies = [
+ "base64urlsafedata",
+ "serde",
+ "tracing",
+ "url",
+ "uuid",
+ "webauthn-rs-core",
+]
+
+[[package]]
+name = "webauthn-rs-core"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "296d2d501feb715d80b8e186fb88bab1073bca17f460303a1013d17b673bea6a"
+dependencies = [
+ "base64 0.21.7",
+ "base64urlsafedata",
+ "der-parser",
+ "hex",
+ "nom",
+ "openssl",
+ "openssl-sys",
+ "rand 0.9.4",
+ "rand_chacha 0.9.0",
+ "serde",
+ "serde_cbor_2",
+ "serde_json",
+ "thiserror 1.0.69",
+ "tracing",
+ "url",
+ "uuid",
+ "webauthn-attestation-ca",
+ "webauthn-rs-proto",
+ "x509-parser",
+]
+
+[[package]]
+name = "webauthn-rs-proto"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c37393beac9c1ed1ca6dbb30b1e01783fb316ab3a45d90ecd48c99052dd7ef1e"
+dependencies = [
+ "base64 0.21.7",
+ "base64urlsafedata",
+ "serde",
+ "serde_json",
+ "url",
 ]
 
 [[package]]
@@ -1844,12 +2639,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
 name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
  "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -1989,7 +2799,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags",
+ "bitflags 2.11.1",
  "indexmap",
  "log",
  "serde",
@@ -2032,9 +2842,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
 dependencies = [
  "curve25519-dalek",
- "rand_core",
+ "rand_core 0.6.4",
  "serde",
  "zeroize",
+]
+
+[[package]]
+name = "x509-parser"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcbc162f30700d6f3f82a24bf7cc62ffe7caea42c0b2cba8bf7f3ae50cf51f69"
+dependencies = [
+ "asn1-rs",
+ "data-encoding",
+ "der-parser",
+ "lazy_static",
+ "nom",
+ "oid-registry",
+ "rusticata-macros",
+ "thiserror 1.0.69",
+ "time",
 ]
 
 [[package]]

--- a/rust-core/crates/friday-system-remote/Cargo.toml
+++ b/rust-core/crates/friday-system-remote/Cargo.toml
@@ -8,9 +8,40 @@ publish = false
 rust-version.workspace = true
 
 # DARK crate. No production caller, no hub route, no FFI exposure. It is a
-# self-contained R5 slice-1 foundation; it deliberately depends on NOTHING in the
-# workspace (not even friday-core) so it cannot contend with concurrent lanes and
-# carries no migration / schema coupling. Persistence is an explicit deferred
-# slice (see lib.rs) — there is no rusqlite dependency by design this slice.
+# self-contained R5 slice foundation; aside from the real WebAuthn verifier
+# (webauthn-rs, A8) it deliberately depends on NOTHING else in the workspace (not
+# even friday-core) so it cannot contend with concurrent lanes and carries no
+# migration / schema coupling. Persistence (pending-ceremony state + the stored
+# Passkey credential) is an explicit deferred slice (see lib.rs) — there is no
+# rusqlite dependency by design this slice; the credential + pending challenge
+# state are held IN-MEMORY.
 [dependencies]
 thiserror.workspace = true
+# Serialize the public `Passkey` credential blob (public key + credential id +
+# sign-count; NO private key) for the device row, and read its sign-count.
+serde_json.workspace = true
+# Derive a deterministic per-owner WebAuthn user handle (uuid bytes) from the
+# owner principal, without pulling the uuid `v5` feature into the graph.
+sha2.workspace = true
+# A8: real WebAuthn/FIDO2 passkey verification. Pinned to 0.5.5 (matches Cargo.lock).
+# We do NOT enable any origin/rp-id-weakening feature and we do NOT enable
+# `danger-allow-state-serialisation`: the pending ceremony state is held in-memory
+# and consumed single-use this DARK slice (serializing it for persistence is the
+# deferred persistence slice). `attestation` is left at its default-off: passkey
+# registration uses AttestationConveyancePreference::None (no attestation-CA trust
+# anchor configured), faithful to the consumer-passkey posture.
+webauthn-rs = "=0.5.5"
+# Force a statically-linked, vendored OpenSSL so the workspace compiles
+# reproducibly without a system libssl. webauthn-rs-core depends on openssl-sys
+# (^0.9.111) WITHOUT the vendored feature; declaring it here with `vendored`
+# unifies the feature across the whole dependency graph (Cargo feature
+# unification), so CI never depends on the runner having libssl-dev.
+openssl-sys = { version = "0.9.116", features = ["vendored"] }
+
+[dev-dependencies]
+# A8 round-trip PROOF: a pure-software FIDO2 authenticator that performs REAL
+# ES256 key generation + signing, driven entirely in-process (no USB/NFC/CTAP
+# transport). This lets the KATs exercise the genuine register→assert crypto path
+# end-to-end — NOT the cfg(test) AcceptingTestVerifier (which proves only the
+# device store, never the cryptography). Pinned to match the verifier crate.
+webauthn-authenticator-rs = { version = "=0.5.5", features = ["softpasskey"] }

--- a/rust-core/crates/friday-system-remote/src/device.rs
+++ b/rust-core/crates/friday-system-remote/src/device.rs
@@ -39,6 +39,14 @@ pub struct RegisteredDevice {
     /// Credential public key (from the verified attestation). A real verifier
     /// extracts this from the COSE key in `authData`.
     pub public_key: Vec<u8>,
+    /// The authenticator sign-count regression baseline (A8). Seeded from the
+    /// verified attestation at registration and advanced (forward-only) on each
+    /// verified assertion. A real verifier (see [`crate::real`]) rejects an
+    /// assertion whose presented sign-count does not strictly increase over this
+    /// stored value (a cloned-authenticator signal); this field is that stored
+    /// value. Many synced passkeys keep it 0 forever (spec-legal; see
+    /// [`crate::real`]).
+    pub sign_count: u32,
     /// Optional human label (e.g. "Jarvis's iPhone").
     pub label: String,
     /// Creation timestamp (ms since epoch; caller-supplied clock).
@@ -102,6 +110,8 @@ impl DeviceStore {
             rp_id: attestation.rp_id().to_string(),
             credential_id: attestation.credential_id().to_vec(),
             public_key: attestation.public_key().to_vec(),
+            // Seed the sign-count regression baseline from the verified attestation.
+            sign_count: attestation.sign_count(),
             label: label.to_string(),
             created_at: now,
             last_seen_at: now,
@@ -231,6 +241,16 @@ impl DeviceStore {
             .ok_or_else(|| RemoteError::DeviceNotFound(device_id.clone()))?;
         if now > device.last_seen_at {
             device.last_seen_at = now;
+        }
+        // Advance the sign-count regression baseline (forward-only). The verifier
+        // (crate::real) already proved this assertion's count strictly increased
+        // over the prior baseline; persisting it here is what makes a later REPLAY
+        // of an older assertion (re-verified against this stored baseline) trip the
+        // cloned-authenticator check. Forward-only as belt-and-braces against a
+        // verifier that returned a stale value.
+        let asserted = assertion.new_sign_count();
+        if asserted > device.sign_count {
+            device.sign_count = asserted;
         }
         Ok(device.clone())
     }
@@ -484,6 +504,41 @@ mod tests {
         let stale = verified_assertion("owner-1", vec![7, 7, 7]);
         let again = store.apply_assertion(&stale, 200).unwrap();
         assert_eq!(again.last_seen_at, 500);
+    }
+
+    #[test]
+    fn apply_assertion_advances_sign_count_forward_only() {
+        // A8: the store advances its sign-count regression baseline to the
+        // verified assertion's value (forward-only). The verifier (crate::real)
+        // already proved the strict increase; this pins the store's persistence of
+        // it. We mint VerifiedAssertions directly via the pub(crate) constructor to
+        // control the sign-count (the AcceptingTestVerifier always emits 0).
+        let mut store = DeviceStore::new();
+        store
+            .register(
+                "dev-1",
+                &verified_attestation("owner-1", vec![7, 7, 7]),
+                "",
+                100,
+            )
+            .unwrap();
+        assert_eq!(
+            store.get_for_owner("dev-1", "owner-1").unwrap().sign_count,
+            0
+        );
+
+        // Assertion presenting sign-count 5 advances the baseline to 5.
+        let a5 = VerifiedAssertion::new_verified("owner-1".into(), vec![7, 7, 7], 5);
+        let d = store.apply_assertion(&a5, 200).unwrap();
+        assert_eq!(d.sign_count, 5);
+
+        // A later assertion presenting a LOWER count (3) does NOT rewind the stored
+        // baseline (forward-only, belt-and-braces). (The real verifier would have
+        // rejected such an assertion outright as a clone before it ever reached
+        // here; this guards a verifier that returned a stale value.)
+        let a3 = VerifiedAssertion::new_verified("owner-1".into(), vec![7, 7, 7], 3);
+        let d = store.apply_assertion(&a3, 300).unwrap();
+        assert_eq!(d.sign_count, 5, "stored sign-count must not rewind");
     }
 
     #[test]

--- a/rust-core/crates/friday-system-remote/src/device.rs
+++ b/rust-core/crates/friday-system-remote/src/device.rs
@@ -242,12 +242,18 @@ impl DeviceStore {
         if now > device.last_seen_at {
             device.last_seen_at = now;
         }
-        // Advance the sign-count regression baseline (forward-only). The verifier
-        // (crate::real) already proved this assertion's count strictly increased
-        // over the prior baseline; persisting it here is what makes a later REPLAY
-        // of an older assertion (re-verified against this stored baseline) trip the
-        // cloned-authenticator check. Forward-only as belt-and-braces against a
-        // verifier that returned a stale value.
+        // Advance this row's sign-count PROJECTION (forward-only). IMPORTANT: this
+        // `RegisteredDevice.sign_count` is a human-/audit-facing projection, NOT
+        // the value the real verifier compares against. The verifier
+        // (crate::real::RealWebAuthn) checks the counter inside the credential blob
+        // (`StoredCredential` / the serialized `Passkey`) it is handed at
+        // `begin_assertion`; the loop that actually enforces regression across
+        // ceremonies is "persist the updated `StoredCredential` that
+        // `finish_assertion` returns, then re-derive the next baseline from it".
+        // Where the authoritative blob lives in a device row (and whether this
+        // `u32` is folded into it or dropped) is a deferred persistence-schema
+        // decision — see this crate's open questions. Forward-only here so a stale
+        // value cannot rewind the projection.
         let asserted = assertion.new_sign_count();
         if asserted > device.sign_count {
             device.sign_count = asserted;

--- a/rust-core/crates/friday-system-remote/src/error.rs
+++ b/rust-core/crates/friday-system-remote/src/error.rs
@@ -22,6 +22,36 @@ pub enum RemoteError {
     #[error("webauthn verification failed: {0}")]
     WebAuthnRejected(String),
 
+    /// A WebAuthn assertion verified cryptographically but its authenticator
+    /// sign-count did NOT strictly increase over the stored value. A
+    /// non-increasing (≤) sign-count is the W3C-defined signal that the
+    /// authenticator may be CLONED — at least two copies of the credential
+    /// private key in parallel use. We REJECT (fail-closed) rather than score-
+    /// and-continue. (Synced passkeys legitimately keep a 0 counter and are
+    /// exempt from this check by spec; see [`crate::real`].)
+    #[error("possible cloned authenticator: sign-count regression (non-increasing)")]
+    ClonedAuthenticator,
+
+    /// A WebAuthn ceremony challenge id was presented that the server never
+    /// issued, or was already consumed. Challenges are single-use and server-
+    /// issued; an unknown/replayed challenge is REFUSED (fail-closed).
+    #[error("unknown or already-consumed ceremony challenge: {0}")]
+    UnknownCeremony(String),
+
+    /// Registration was attempted without an operator-authorized owner trust
+    /// root. The first-device bootstrap posture is "an already-trusted operator
+    /// authorizes the registration" — registration is NOT self-authorizing. A
+    /// registration whose owner principal is not in the authorized set is
+    /// REFUSED. See [`crate::real`] (FLAGGED bootstrap posture).
+    #[error("registration not authorized for owner '{0}' (no operator trust root)")]
+    RegistrationNotAuthorized(String),
+
+    /// The relying-party identity (rp_id / origin) supplied to build the real
+    /// verifier was malformed (e.g. origin is not a valid URL). Fail-closed: a
+    /// verifier with an ambiguous RP identity is never constructed.
+    #[error("invalid relying-party identity: {0}")]
+    InvalidRelyingParty(String),
+
     /// The presented credential id does not match the challenge's expected
     /// credential, or the device for an assertion is not registered.
     #[error("unknown or mismatched credential")]

--- a/rust-core/crates/friday-system-remote/src/lib.rs
+++ b/rust-core/crates/friday-system-remote/src/lib.rs
@@ -43,13 +43,39 @@
 //!   owner-matched — a revoked device severs its sessions' liveness on the next
 //!   heartbeat. A refused heartbeat leaves the session row unmutated.
 //!
+//! # slice-3 / A8 addition (DARK, flag-gated-OFF, no route flip)
+//! [`real`] is the REAL WebAuthn/FIDO2 passkey engine over `webauthn-rs`,
+//! replacing the slice-1 cryptographic gap:
+//! * registration: attestation parse + COSE public-key extraction + strict
+//!   RP-ID-hash / origin / type / challenge binding;
+//! * assertion: real ES256/RS256/EdDSA signature verification over
+//!   `authenticatorData || sha256(clientDataJSON)` + the **sign-count regression
+//!   check** (non-increasing ⇒ possible cloned authenticator ⇒ REJECT);
+//! * stores ONLY public material ([`real::StoredCredential`] = a serialized
+//!   `Passkey`: public key + credential id + sign-count; NO private key);
+//! * single-use in-memory ceremony challenges (consumed on finish);
+//! * a FLAGGED first-device bootstrap posture: registration is authorized by an
+//!   already-trusted operator (an authorized-owner set), never self-authorizing.
+//!
+//! The engine is the privileged minter of the existing
+//! [`webauthn::VerifiedAttestation`]/[`webauthn::VerifiedAssertion`] typestate
+//! tokens — same fail-closed guarantee, now backed by real crypto. It is FULLY
+//! DARK and flag-gated-OFF: nothing constructs a [`real::RealWebAuthn`] in
+//! production; the shipped default verifier the public API exposes is STILL
+//! [`webauthn::DeferredVerifier`], and the `fail_closed` KATs continue to prove
+//! that default path rejects. Flipping the real verifier on is a later, operator-
+//! gated, DEPLOY-GO step.
+//!
 //! # What is STUB / DEFERRED (explicit)
-//! 1. **Real WebAuthn cryptographic verification.** [`webauthn::DeferredVerifier`]
-//!    FAILS CLOSED (`Err(WebAuthnVerifierNotWired)`) for every ceremony. COSE key
-//!    parsing, attestation-statement validation, signature/sign-count/origin/
-//!    rp-id/challenge checks are NOT implemented — a future slice wires a real
-//!    `WebAuthnVerifier` (e.g. over `webauthn-rs`). Until then NO device can be
-//!    registered and NO verified-path session can be opened.
+//! 1. **Hub wiring / route flip of the real verifier.** [`real::RealWebAuthn`]
+//!    EXISTS and performs genuine cryptography, but no production code constructs
+//!    it: the shipped default remains [`webauthn::DeferredVerifier`], which FAILS
+//!    CLOSED (`Err(WebAuthnVerifierNotWired)`). Binding the real engine to the 11
+//!    `system.remote.*` routes, CSPRNG challenge/ceremony-id issuance, the
+//!    deploy-gated relying-party identity, and the operator-seeded authorized-
+//!    owner trust root are all DEFERRED (operator-gated). Until that flip, NO
+//!    device is registered through the default path and NO verified-path session
+//!    opens — fail closed.
 //! 2. **Persistence.** Both stores are IN-MEMORY. A `friday-storage` migration
 //!    (`m00NN`) registering `remote_device` / `remote_session` in
 //!    `HUB_ONLY_TABLES` + a forward-migration KAT is DEFERRED. Rationale: that
@@ -74,11 +100,13 @@
 
 pub mod device;
 pub mod error;
+pub mod real;
 pub mod session;
 pub mod webauthn;
 
 pub use device::{DeviceStore, RegisteredDevice};
 pub use error::{RemoteError, Result};
+pub use real::{CeremonyId, RealWebAuthn, StoredCredential};
 pub use session::{RemoteSession, SessionState, SessionStore};
 pub use webauthn::{
     begin_assertion, begin_registration, AssertionChallenge, AssertionResponse,

--- a/rust-core/crates/friday-system-remote/src/real.rs
+++ b/rust-core/crates/friday-system-remote/src/real.rs
@@ -1,0 +1,430 @@
+//! A8 — REAL WebAuthn/FIDO2 passkey verification over `webauthn-rs`.
+//!
+//! This module replaces the cryptographic gap the slice-1 [`crate::webauthn`]
+//! seam deliberately left open. Where the shipped [`crate::webauthn::DeferredVerifier`]
+//! REJECTS every ceremony (`WebAuthnVerifierNotWired`), this module performs the
+//! genuine ceremonies via the `webauthn-rs` crate:
+//!
+//! * **registration** (`navigator.credentials.create`): attestation-object CBOR
+//!   parse, COSE credential-public-key extraction, RP-ID hash + origin + type +
+//!   challenge binding, and (because passkeys use
+//!   `AttestationConveyancePreference::None`) no attestation-CA trust anchor.
+//! * **assertion** (`navigator.credentials.get`): ES256/RS256/EdDSA signature
+//!   verification over `authenticatorData || sha256(clientDataJSON)`, the
+//!   RP-ID-hash / origin / type / challenge binding, AND the **sign-count
+//!   regression check** (a non-increasing counter ⇒ possible cloned
+//!   authenticator ⇒ REJECT).
+//!
+//! # DARK + flag-gated-OFF, NO route flip (A8 posture)
+//! Nothing here is wired to `friday-hub`, any route, or the FFI. The shipped
+//! default verifier the public API exposes is STILL [`crate::webauthn::DeferredVerifier`]
+//! — the `fail_closed` KATs continue to prove the default production path
+//! rejects. A [`RealWebAuthn`] engine only exists if a caller *constructs* one
+//! with an explicit relying-party identity; no production code does this yet.
+//! This is the gate: the real verifier now EXISTS, but flipping it on is a later,
+//! operator-gated, DEPLOY-GO step.
+//!
+//! # Hub stores ONLY public material (never private keys)
+//! By WebAuthn construction the private key never leaves the authenticator — the
+//! server never sees it. What this engine surfaces for storage is the
+//! [`StoredCredential`] blob: a serialized `webauthn-rs` `Passkey`, which holds
+//! the credential id, the COSE *public* key, the sign-count, and registration
+//! flags — and nothing secret. A device row persists exactly that.
+//!
+//! # Strict RP-ID / origin / challenge binding
+//! The engine is built from an injected `rp_id` + `rp_origin` (the hub identity —
+//! NOT hardcoded; a deploy-gated config). We deliberately do NOT enable
+//! `allow_subdomains`, `allow_any_port`, or any extra allowed origin: those
+//! relax exactly the origin/`rpIdHash` binding A8 is required to enforce. A
+//! `clientDataJSON` whose `origin` or whose authenticator-data `rpIdHash` does
+//! not match the configured identity is rejected by `webauthn-rs`.
+//!
+//! # Challenge handling — single-use, in-memory (this DARK slice)
+//! `webauthn-rs` is a two-phase, stateful ceremony: `start_*` returns a pending
+//! state the server MUST hold and pair to the `finish_*` call. We hold the
+//! pending state in an in-memory [`std::collections::HashMap`] keyed by a
+//! server-issued `ceremony_id`, and **consume it on finish (single-use)** — a
+//! replayed or unknown `ceremony_id` is [`RemoteError::UnknownCeremony`]. We do
+//! NOT enable `webauthn-rs`'s `danger-allow-state-serialisation`: persisting the
+//! pending state across process restarts is the deferred persistence slice.
+//!
+//! # FLAGGED: first-device bootstrap posture
+//! Per the A8 brief, the first-device bootstrap path is ambiguous, so we
+//! implement the SOUNDEST posture and flag it: **registration is authorized by an
+//! already-trusted operator, never self-authorizing.** [`RealWebAuthn::begin_registration`]
+//! refuses (`RegistrationNotAuthorized`) unless the target owner principal is in
+//! an operator-supplied authorized set. This is the trust root; how the operator
+//! seeds that set (CLI, a bootstrap secret, an existing trusted device) is a
+//! deploy-gated decision left to the operator — see the PR body's open questions.
+//!
+//! # FLAGGED: synced-passkey counter exemption (faithful to spec)
+//! W3C §verifying-assertion only requires the strictly-increasing check when the
+//! counter is nonzero. Many platform/synced passkeys (iCloud Keychain, Google
+//! Password Manager) report a counter of 0 forever — they CANNOT be clone-
+//! detected by counter, by design. `webauthn-rs` applies the check exactly when
+//! `presented > 0 || stored > 0`; we do NOT re-implement or tighten it at the
+//! store layer (that would false-reject legitimate synced passkeys). The
+//! regression check is therefore real but, for 0/0 passkeys, a no-op — flagged so
+//! a reviewer does not read "no rejection for a synced passkey" as a hole.
+
+use crate::error::{RemoteError, Result};
+use crate::webauthn::{VerifiedAssertion, VerifiedAttestation};
+use std::collections::HashMap;
+use webauthn_rs::prelude::{
+    CreationChallengeResponse, Passkey, PasskeyAuthentication, PasskeyRegistration,
+    PublicKeyCredential, RegisterPublicKeyCredential, RequestChallengeResponse, Url, Uuid,
+    Webauthn, WebauthnBuilder, WebauthnError,
+};
+
+/// The opaque, server-issued id that pairs a `start_*` ceremony to its `finish_*`
+/// call. Single-use: consumed (removed) on finish.
+pub type CeremonyId = String;
+
+/// A credential record fit for a device row: the serialized `webauthn-rs`
+/// `Passkey`. It carries the credential id, the COSE PUBLIC key, the current
+/// sign-count and registration flags — NO private key (the private key never
+/// leaves the authenticator). A future persistence slice stores this blob's
+/// bytes; the engine reconstructs the `Passkey` from it to verify assertions.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct StoredCredential {
+    /// The WebAuthn credential id (raw bytes) — the device-row key.
+    credential_id: Vec<u8>,
+    /// The serialized `Passkey` (JSON). Public material only.
+    passkey_json: String,
+    /// The COSE public key bytes (serialized), surfaced for the device row's
+    /// `public_key` column. Derived from the same `Passkey`.
+    public_key: Vec<u8>,
+    /// The current stored sign-count (the regression baseline).
+    sign_count: u32,
+}
+
+impl StoredCredential {
+    pub fn credential_id(&self) -> &[u8] {
+        &self.credential_id
+    }
+    /// The serialized public credential blob (no secret material) for persistence.
+    pub fn passkey_json(&self) -> &str {
+        &self.passkey_json
+    }
+    pub fn public_key(&self) -> &[u8] {
+        &self.public_key
+    }
+    pub fn sign_count(&self) -> u32 {
+        self.sign_count
+    }
+
+    /// Rehydrate a stored credential from its serialized `Passkey` JSON blob —
+    /// the inverse of [`StoredCredential::passkey_json`]. A persistence slice
+    /// loads a device row's stored credential bytes back into a verifiable
+    /// credential through this; the engine's [`RealWebAuthn::begin_assertion`]
+    /// then reconstructs the `Passkey` from it. Fail-closed: malformed JSON or a
+    /// blob that is not a valid public credential is [`RemoteError::WebAuthnRejected`].
+    pub fn from_passkey_json(passkey_json: &str) -> Result<Self> {
+        let passkey: Passkey = serde_json::from_str(passkey_json)
+            .map_err(|e| RemoteError::WebAuthnRejected(format!("deserialize passkey: {e}")))?;
+        Self::from_passkey(&passkey)
+    }
+
+    fn from_passkey(passkey: &Passkey) -> Result<Self> {
+        let passkey_json = serde_json::to_string(passkey)
+            .map_err(|e| RemoteError::WebAuthnRejected(format!("serialize passkey: {e}")))?;
+        let public_key = serde_json::to_vec(passkey.get_public_key())
+            .map_err(|e| RemoteError::WebAuthnRejected(format!("serialize COSE key: {e}")))?;
+        Ok(Self {
+            credential_id: passkey.cred_id().as_ref().to_vec(),
+            passkey_json,
+            public_key,
+            sign_count: counter_of(passkey),
+        })
+    }
+
+    fn to_passkey(&self) -> Result<Passkey> {
+        serde_json::from_str(&self.passkey_json)
+            .map_err(|e| RemoteError::WebAuthnRejected(format!("deserialize passkey: {e}")))
+    }
+}
+
+/// The pending registration challenge state (held server-side between
+/// `begin_registration` and `finish_registration`). Bound to the target owner so
+/// the finished credential is attributed to the operator-authorized principal,
+/// not to free caller input.
+struct PendingReg {
+    owner: String,
+    state: PasskeyRegistration,
+}
+
+/// The pending assertion challenge state, bound to the stored credential it
+/// authenticates and its owner.
+struct PendingAuth {
+    owner: String,
+    credential_id: Vec<u8>,
+    state: PasskeyAuthentication,
+}
+
+/// The real WebAuthn engine: a configured relying party + the in-memory pending
+/// ceremony state + the operator-authorized owner trust root.
+///
+/// NOTE: this is NOT a [`crate::webauthn::WebAuthnVerifier`] implementation. That
+/// trait is single-shot (`verify(challenge, response)`) and cannot carry the
+/// two-phase pending state `webauthn-rs` requires; forcing it through that seam
+/// would have meant smuggling the challenge state out-of-band. Instead this
+/// engine is the privileged MINTER of the existing typestate tokens
+/// ([`VerifiedAttestation`]/[`VerifiedAssertion`]) — the same fail-closed
+/// guarantee (only a verifier can mint one) holds, now backed by real crypto.
+/// The `WebAuthnVerifier` trait + [`crate::webauthn::DeferredVerifier`] remain as
+/// the shipped fail-closed default seam.
+pub struct RealWebAuthn {
+    webauthn: Webauthn,
+    rp_id: String,
+    /// Owner principals an operator has authorized to register a device. The
+    /// first-device bootstrap trust root (FLAGGED — see module docs).
+    authorized_owners: Vec<String>,
+    pending_reg: HashMap<CeremonyId, PendingReg>,
+    pending_auth: HashMap<CeremonyId, PendingAuth>,
+    /// Monotonic ceremony-id source (in-memory; a real deployment uses a CSPRNG
+    /// token — deferred with the rest of the hub wiring).
+    next_id: u64,
+}
+
+impl RealWebAuthn {
+    /// Construct the engine for a relying party. `rp_id` is the effective domain
+    /// (e.g. `friday.local`); `rp_origin` is the full origin the client is served
+    /// from (e.g. `https://friday.local`). Both come from the hub identity — a
+    /// deploy-gated config, never hardcoded. `authorized_owners` is the operator-
+    /// supplied registration trust root (may start with exactly the operator's
+    /// own principal for the first-device bootstrap).
+    ///
+    /// Fails closed ([`RemoteError::InvalidRelyingParty`]) if the origin is not a
+    /// valid URL or the builder rejects the identity. We do NOT relax any origin
+    /// binding (no subdomains, no any-port, no extra origins).
+    pub fn new(rp_id: &str, rp_origin: &str, authorized_owners: Vec<String>) -> Result<Self> {
+        if rp_id.trim().is_empty() {
+            return Err(RemoteError::InvalidRelyingParty("rp_id is empty".into()));
+        }
+        let origin = Url::parse(rp_origin)
+            .map_err(|e| RemoteError::InvalidRelyingParty(format!("rp_origin not a URL: {e}")))?;
+        let webauthn = WebauthnBuilder::new(rp_id, &origin)
+            .map_err(map_webauthn_err)?
+            // STRICT: no allow_subdomains / allow_any_port / append_allowed_origin.
+            .rp_name("Friday")
+            .build()
+            .map_err(map_webauthn_err)?;
+        Ok(Self {
+            webauthn,
+            rp_id: rp_id.to_string(),
+            authorized_owners,
+            pending_reg: HashMap::new(),
+            pending_auth: HashMap::new(),
+            next_id: 0,
+        })
+    }
+
+    fn issue_ceremony_id(&mut self) -> CeremonyId {
+        self.next_id = self.next_id.wrapping_add(1);
+        format!("ceremony-{}", self.next_id)
+    }
+
+    fn is_authorized(&self, owner: &str) -> bool {
+        self.authorized_owners.iter().any(|o| o == owner)
+    }
+
+    /// Begin a registration ceremony for an operator-authorized owner. Returns a
+    /// single-use `ceremony_id` and the `CreationChallengeResponse` to hand to the
+    /// client (`navigator.credentials.create`).
+    ///
+    /// Fail-closed: an owner not in the operator-authorized set is REFUSED
+    /// ([`RemoteError::RegistrationNotAuthorized`]) — registration is never self-
+    /// authorizing (FLAGGED bootstrap posture).
+    ///
+    /// `exclude_credential_ids` is the set of credential ids already registered to
+    /// this owner; passing them prevents the authenticator from minting a second
+    /// credential for an already-registered device.
+    pub fn begin_registration(
+        &mut self,
+        owner: &str,
+        user_display_name: &str,
+        exclude_credential_ids: &[Vec<u8>],
+    ) -> Result<(CeremonyId, CreationChallengeResponse)> {
+        if owner.trim().is_empty() {
+            return Err(RemoteError::InvalidInput("owner is empty".into()));
+        }
+        if !self.is_authorized(owner) {
+            return Err(RemoteError::RegistrationNotAuthorized(owner.to_string()));
+        }
+        // Deterministic per-owner user handle (a real deployment maps owner→stable
+        // uuid; here we derive one from the owner principal so re-registration is
+        // consistent within a run). SHA-256 the owner and take the first 16 bytes
+        // as the uuid — avoids pulling the uuid `v5` feature into the graph.
+        let user_unique_id = owner_user_handle(owner);
+        let exclude = if exclude_credential_ids.is_empty() {
+            None
+        } else {
+            Some(
+                exclude_credential_ids
+                    .iter()
+                    .map(|id| id.clone().into())
+                    .collect(),
+            )
+        };
+        let (ccr, state) = self
+            .webauthn
+            .start_passkey_registration(user_unique_id, owner, user_display_name, exclude)
+            .map_err(map_webauthn_err)?;
+        let ceremony_id = self.issue_ceremony_id();
+        self.pending_reg.insert(
+            ceremony_id.clone(),
+            PendingReg {
+                owner: owner.to_string(),
+                state,
+            },
+        );
+        Ok((ceremony_id, ccr))
+    }
+
+    /// Finish a registration ceremony. Consumes the pending state (single-use),
+    /// verifies the attestation cryptographically (RP-ID hash / origin / type /
+    /// challenge binding; COSE key extraction), and mints a [`VerifiedAttestation`]
+    /// — the typestate token a [`crate::device::DeviceStore::register`] accepts —
+    /// plus the [`StoredCredential`] blob to persist.
+    ///
+    /// Fail-closed: an unknown/already-consumed `ceremony_id` is
+    /// [`RemoteError::UnknownCeremony`]; any cryptographic failure is
+    /// [`RemoteError::WebAuthnRejected`].
+    pub fn finish_registration(
+        &mut self,
+        ceremony_id: &str,
+        credential: &RegisterPublicKeyCredential,
+    ) -> Result<(VerifiedAttestation, StoredCredential)> {
+        // Consume the pending state (single-use). Unknown/replayed ⇒ fail-closed.
+        let pending = self
+            .pending_reg
+            .remove(ceremony_id)
+            .ok_or_else(|| RemoteError::UnknownCeremony(ceremony_id.to_string()))?;
+        let passkey = self
+            .webauthn
+            .finish_passkey_registration(credential, &pending.state)
+            .map_err(map_webauthn_err)?;
+        let stored = StoredCredential::from_passkey(&passkey)?;
+        let attestation = VerifiedAttestation::new_verified(
+            pending.owner,
+            self.rp_id.clone(),
+            stored.credential_id.clone(),
+            stored.public_key.clone(),
+            stored.sign_count,
+        );
+        Ok((attestation, stored))
+    }
+
+    /// Begin an assertion ceremony against a previously-stored credential. Returns
+    /// a single-use `ceremony_id` and the `RequestChallengeResponse` for the
+    /// client (`navigator.credentials.get`).
+    pub fn begin_assertion(
+        &mut self,
+        owner: &str,
+        stored: &StoredCredential,
+    ) -> Result<(CeremonyId, RequestChallengeResponse)> {
+        if owner.trim().is_empty() {
+            return Err(RemoteError::InvalidInput("owner is empty".into()));
+        }
+        let passkey = stored.to_passkey()?;
+        let (rcr, state) = self
+            .webauthn
+            .start_passkey_authentication(&[passkey])
+            .map_err(map_webauthn_err)?;
+        let ceremony_id = self.issue_ceremony_id();
+        self.pending_auth.insert(
+            ceremony_id.clone(),
+            PendingAuth {
+                owner: owner.to_string(),
+                credential_id: stored.credential_id.clone(),
+                state,
+            },
+        );
+        Ok((ceremony_id, rcr))
+    }
+
+    /// Finish an assertion ceremony. Consumes the pending state (single-use),
+    /// verifies the signature + RP-ID/origin/challenge binding, AND enforces the
+    /// sign-count regression check.
+    ///
+    /// Returns the minted [`VerifiedAssertion`] (carrying the verified, strictly-
+    /// advanced sign-count to persist) and the new sign-count value.
+    ///
+    /// Fail-closed:
+    /// * unknown/already-consumed `ceremony_id` ⇒ [`RemoteError::UnknownCeremony`];
+    /// * sign-count regression (non-increasing, nonzero) ⇒
+    ///   [`RemoteError::ClonedAuthenticator`] — the W3C cloned-authenticator signal
+    ///   (`webauthn-rs` raises `CredentialPossibleCompromise`);
+    /// * any other cryptographic failure ⇒ [`RemoteError::WebAuthnRejected`].
+    pub fn finish_assertion(
+        &mut self,
+        ceremony_id: &str,
+        credential: &PublicKeyCredential,
+    ) -> Result<(VerifiedAssertion, u32)> {
+        let pending = self
+            .pending_auth
+            .remove(ceremony_id)
+            .ok_or_else(|| RemoteError::UnknownCeremony(ceremony_id.to_string()))?;
+        let auth_result = self
+            .webauthn
+            .finish_passkey_authentication(credential, &pending.state)
+            .map_err(map_webauthn_err)?;
+        // Defense-in-depth: the credential the assertion authenticated must be the
+        // one this ceremony was issued for. (webauthn-rs scopes the allow-list to
+        // the single credential we passed at start, so this is belt-and-braces.)
+        if auth_result.cred_id().as_ref() != pending.credential_id.as_slice() {
+            return Err(RemoteError::WebAuthnRejected(
+                "assertion credential id does not match ceremony".into(),
+            ));
+        }
+        let new_sign_count = auth_result.counter();
+        let assertion =
+            VerifiedAssertion::new_verified(pending.owner, pending.credential_id, new_sign_count);
+        Ok((assertion, new_sign_count))
+    }
+
+    /// Number of currently-pending registration ceremonies (test/introspection).
+    pub fn pending_registration_count(&self) -> usize {
+        self.pending_reg.len()
+    }
+
+    /// Number of currently-pending assertion ceremonies (test/introspection).
+    pub fn pending_assertion_count(&self) -> usize {
+        self.pending_auth.len()
+    }
+}
+
+/// Derive a deterministic per-owner WebAuthn user handle from the owner
+/// principal: SHA-256(owner) truncated to the 16 uuid bytes. Deterministic so a
+/// re-registration for the same owner uses a stable handle.
+fn owner_user_handle(owner: &str) -> Uuid {
+    use sha2::{Digest, Sha256};
+    let digest = Sha256::digest(owner.as_bytes());
+    let mut bytes = [0u8; 16];
+    bytes.copy_from_slice(&digest[..16]);
+    Uuid::from_bytes(bytes)
+}
+
+/// Read a `Passkey`'s current sign-count by round-tripping its public JSON. We
+/// avoid depending on `webauthn-rs`'s `danger-credential-internals` feature
+/// (which would expose the inner `Credential`); the serialized form has a
+/// top-level `counter` field that is exactly the stored sign-count.
+fn counter_of(passkey: &Passkey) -> u32 {
+    // The serialized Passkey is `{ "cred": { ... "counter": N ... } }`.
+    serde_json::to_value(passkey)
+        .ok()
+        .and_then(|v| v.get("cred").and_then(|c| c.get("counter")).cloned())
+        .and_then(|c| c.as_u64())
+        .map(|c| c as u32)
+        .unwrap_or(0)
+}
+
+/// Map a `webauthn-rs` error to a closed [`RemoteError`]. The cloned-authenticator
+/// signal gets its own dedicated variant; everything else is a generic rejection
+/// carrying the upstream reason (never an accept, never a panic).
+fn map_webauthn_err(e: WebauthnError) -> RemoteError {
+    match e {
+        WebauthnError::CredentialPossibleCompromise => RemoteError::ClonedAuthenticator,
+        other => RemoteError::WebAuthnRejected(format!("{other:?}")),
+    }
+}

--- a/rust-core/crates/friday-system-remote/src/real.rs
+++ b/rust-core/crates/friday-system-remote/src/real.rs
@@ -154,10 +154,16 @@ struct PendingReg {
 }
 
 /// The pending assertion challenge state, bound to the stored credential it
-/// authenticates and its owner.
+/// authenticates and its owner. Carries the `Passkey` whose counter was the
+/// regression baseline for THIS ceremony, so `finish_assertion` can fold the
+/// verified advance back into an updated [`StoredCredential`] (the credential's
+/// system of record) and the caller can persist it.
 struct PendingAuth {
     owner: String,
     credential_id: Vec<u8>,
+    /// The baseline passkey (counter = the value the regression check compared
+    /// against). Advanced via `Passkey::update_credential` on a verified result.
+    baseline_passkey: Passkey,
     state: PasskeyAuthentication,
 }
 
@@ -329,7 +335,7 @@ impl RealWebAuthn {
         let passkey = stored.to_passkey()?;
         let (rcr, state) = self
             .webauthn
-            .start_passkey_authentication(&[passkey])
+            .start_passkey_authentication(std::slice::from_ref(&passkey))
             .map_err(map_webauthn_err)?;
         let ceremony_id = self.issue_ceremony_id();
         self.pending_auth.insert(
@@ -337,6 +343,7 @@ impl RealWebAuthn {
             PendingAuth {
                 owner: owner.to_string(),
                 credential_id: stored.credential_id.clone(),
+                baseline_passkey: passkey,
                 state,
             },
         );
@@ -347,8 +354,16 @@ impl RealWebAuthn {
     /// verifies the signature + RP-ID/origin/challenge binding, AND enforces the
     /// sign-count regression check.
     ///
-    /// Returns the minted [`VerifiedAssertion`] (carrying the verified, strictly-
-    /// advanced sign-count to persist) and the new sign-count value.
+    /// Returns the minted [`VerifiedAssertion`] (carrying the verified,
+    /// monotonically-advanced sign-count) AND the **updated [`StoredCredential`]**
+    /// — the baseline `Passkey`'s counter (and backup-state flags) folded forward
+    /// via `Passkey::update_credential`. The caller MUST persist this updated
+    /// credential as the credential's system of record: it is what a SUBSEQUENT
+    /// [`RealWebAuthn::begin_assertion`] uses as the next regression baseline, so
+    /// persisting it is exactly what makes a later REPLAY of an older (lower-count)
+    /// assertion trip [`RemoteError::ClonedAuthenticator`]. Without persisting it,
+    /// the baseline never advances across calls and the regression check is
+    /// toothless between ceremonies.
     ///
     /// Fail-closed:
     /// * unknown/already-consumed `ceremony_id` ⇒ [`RemoteError::UnknownCeremony`];
@@ -360,7 +375,7 @@ impl RealWebAuthn {
         &mut self,
         ceremony_id: &str,
         credential: &PublicKeyCredential,
-    ) -> Result<(VerifiedAssertion, u32)> {
+    ) -> Result<(VerifiedAssertion, StoredCredential)> {
         let pending = self
             .pending_auth
             .remove(ceremony_id)
@@ -377,10 +392,21 @@ impl RealWebAuthn {
                 "assertion credential id does not match ceremony".into(),
             ));
         }
-        let new_sign_count = auth_result.counter();
-        let assertion =
-            VerifiedAssertion::new_verified(pending.owner, pending.credential_id, new_sign_count);
-        Ok((assertion, new_sign_count))
+        // Fold the verified advance back into the baseline passkey (counter +
+        // backup-state). `update_credential` only moves the counter forward and
+        // returns None only on a cred-id mismatch (impossible here — we just
+        // asserted equality). This produces the credential's NEW system-of-record
+        // blob that the caller persists and a later begin_assertion re-derives its
+        // baseline from.
+        let mut advanced = pending.baseline_passkey;
+        let _ = advanced.update_credential(&auth_result);
+        let updated_stored = StoredCredential::from_passkey(&advanced)?;
+        let assertion = VerifiedAssertion::new_verified(
+            pending.owner,
+            pending.credential_id,
+            updated_stored.sign_count,
+        );
+        Ok((assertion, updated_stored))
     }
 
     /// Number of currently-pending registration ceremonies (test/introspection).

--- a/rust-core/crates/friday-system-remote/src/webauthn.rs
+++ b/rust-core/crates/friday-system-remote/src/webauthn.rs
@@ -74,6 +74,11 @@ pub struct VerifiedAttestation {
     /// verifier fills this from the COSE key in `authData`; the stub never
     /// reaches here.
     public_key: Bytes,
+    /// The authenticator's initial sign-count at registration time. A real
+    /// verifier reads this from the attestation `authData`; it seeds the
+    /// monotonic regression baseline a device row stores. Many platform/synced
+    /// passkeys report 0 here (and stay 0) — that is spec-legal.
+    sign_count: u32,
 }
 
 impl VerifiedAttestation {
@@ -88,6 +93,33 @@ impl VerifiedAttestation {
     }
     pub fn public_key(&self) -> &[u8] {
         &self.public_key
+    }
+    /// Initial sign-count established at registration (the regression baseline).
+    pub fn sign_count(&self) -> u32 {
+        self.sign_count
+    }
+
+    /// Crate-internal constructor — the SINGLE choke point through which a
+    /// `VerifiedAttestation` comes into existence. It is `pub(crate)`, so only
+    /// the in-crate verifiers can call it: the real [`crate::real`] engine (after
+    /// genuine cryptographic verification) and the `cfg(test)`
+    /// [`AcceptingTestVerifier`]. An external caller (e.g. a future hub) has NO
+    /// path to it — they can only obtain a `VerifiedAttestation` as the `Ok`
+    /// result of a verifier, preserving the fail-closed typestate guarantee.
+    pub(crate) fn new_verified(
+        owner: String,
+        rp_id: String,
+        credential_id: Bytes,
+        public_key: Bytes,
+        sign_count: u32,
+    ) -> Self {
+        Self {
+            owner,
+            rp_id,
+            credential_id,
+            public_key,
+            sign_count,
+        }
     }
 }
 
@@ -118,6 +150,13 @@ pub struct AssertionResponse {
 pub struct VerifiedAssertion {
     owner: String,
     credential_id: Bytes,
+    /// The authenticator sign-count this assertion presented, AFTER the real
+    /// verifier confirmed it strictly increased over the stored baseline (or is
+    /// the spec-legal 0/0 synced-passkey case). The device row advances its
+    /// stored sign-count to this value — that advance is what makes a later
+    /// REPLAY of an older assertion trip the regression check. The test verifier
+    /// leaves it 0 (it performs no counter logic).
+    new_sign_count: u32,
 }
 
 impl VerifiedAssertion {
@@ -126,6 +165,21 @@ impl VerifiedAssertion {
     }
     pub fn credential_id(&self) -> &[u8] {
         &self.credential_id
+    }
+    /// The verified, strictly-advanced sign-count to persist on the device row.
+    pub fn new_sign_count(&self) -> u32 {
+        self.new_sign_count
+    }
+
+    /// Crate-internal constructor — the SINGLE choke point through which a
+    /// `VerifiedAssertion` comes into existence (`pub(crate)`; same fail-closed
+    /// rationale as [`VerifiedAttestation::new_verified`]).
+    pub(crate) fn new_verified(owner: String, credential_id: Bytes, new_sign_count: u32) -> Self {
+        Self {
+            owner,
+            credential_id,
+            new_sign_count,
+        }
     }
 }
 
@@ -261,14 +315,16 @@ impl WebAuthnVerifier for AcceptingTestVerifier {
         challenge: &RegistrationChallenge,
         response: &AttestationResponse,
     ) -> Result<VerifiedAttestation> {
-        Ok(VerifiedAttestation {
-            owner: challenge.owner.clone(),
-            rp_id: challenge.rp_id.clone(),
-            credential_id: response.credential_id.clone(),
+        Ok(VerifiedAttestation::new_verified(
+            challenge.owner.clone(),
+            challenge.rp_id.clone(),
+            response.credential_id.clone(),
             // A real verifier extracts this from the COSE key in authData; the
             // test verifier fabricates a deterministic placeholder.
-            public_key: vec![0x04, 0xAA, 0xBB, 0xCC],
-        })
+            vec![0x04, 0xAA, 0xBB, 0xCC],
+            // No counter logic in the test verifier: seed the baseline at 0.
+            0,
+        ))
     }
 
     fn verify_assertion(
@@ -282,10 +338,12 @@ impl WebAuthnVerifier for AcceptingTestVerifier {
         if response.credential_id != challenge.expected_credential_id {
             return Err(RemoteError::UnknownCredential);
         }
-        Ok(VerifiedAssertion {
-            owner: challenge.owner.clone(),
-            credential_id: response.credential_id.clone(),
-        })
+        Ok(VerifiedAssertion::new_verified(
+            challenge.owner.clone(),
+            response.credential_id.clone(),
+            // No counter logic in the test verifier.
+            0,
+        ))
     }
 }
 

--- a/rust-core/crates/friday-system-remote/tests/real_crypto.rs
+++ b/rust-core/crates/friday-system-remote/tests/real_crypto.rs
@@ -51,19 +51,23 @@ fn real_register(
     stored
 }
 
-/// Drive a full REAL assertion round-trip; returns the new sign-count.
+/// Drive a full REAL assertion round-trip; returns the verified new sign-count
+/// and the UPDATED stored credential (counter folded forward) the caller would
+/// persist as the next baseline.
 fn real_assert(
     engine: &mut RealWebAuthn,
     authenticator: &mut WebauthnAuthenticator<SoftPasskey>,
     owner: &str,
     stored: &StoredCredential,
-) -> Result<u32, RemoteError> {
+) -> Result<(u32, StoredCredential), RemoteError> {
     let (ceremony_id, rcr) = engine.begin_assertion(owner, stored)?;
     let origin = Url::parse(RP_ORIGIN).unwrap();
     let pkc = authenticator
         .do_authentication(origin, rcr)
         .expect("software authenticator performs assertion");
-    engine.finish_assertion(&ceremony_id, &pkc).map(|(_, c)| c)
+    engine
+        .finish_assertion(&ceremony_id, &pkc)
+        .map(|(_, updated)| (updated.sign_count(), updated))
 }
 
 #[test]
@@ -89,11 +93,50 @@ fn real_registration_then_assertion_round_trip() {
 
     // REAL assertion: the same authenticator signs a fresh challenge; the
     // signature is verified over authenticatorData || sha256(clientDataJSON).
-    let count =
+    let (count, _updated) =
         real_assert(&mut engine, &mut auth, OWNER, &stored).expect("a genuine assertion verifies");
     // SoftPasskey increments its counter per auth: first auth ⇒ 1 (> the stored 0).
     assert_eq!(count, 1);
     assert_eq!(engine.pending_assertion_count(), 0);
+}
+
+#[test]
+fn persisted_baseline_advances_across_real_assertions_and_catches_a_lagging_clone() {
+    // Closes the persistence loop the apply/persist contract claims: each real
+    // assertion returns an UPDATED StoredCredential whose counter has advanced;
+    // persisting it and re-deriving the next baseline from it advances the
+    // regression baseline ACROSS ceremonies (0 → 1 → 2 here, all real). Then a
+    // cloned/lagging authenticator (its counter behind the persisted baseline)
+    // producing a fresh, challenge-valid assertion is rejected on the COUNTER.
+    let mut engine = engine();
+    let mut auth = WebauthnAuthenticator::new(SoftPasskey::new(true));
+    let stored0 = real_register(&mut engine, &mut auth, OWNER); // baseline counter 0
+    assert_eq!(stored0.sign_count(), 0);
+
+    // First real assertion: counter 0 → 1; persist the advanced blob.
+    let (c1, stored1) = real_assert(&mut engine, &mut auth, OWNER, &stored0).unwrap();
+    assert_eq!(c1, 1);
+    assert_eq!(stored1.sign_count(), 1);
+
+    // Second real assertion AGAINST THE PERSISTED blob: counter 1 → 2. This is the
+    // proof the baseline genuinely advanced across calls — webauthn-rs accepted
+    // 2 > 1 only because the baseline it compared against was the persisted 1.
+    let (c2, stored2) = real_assert(&mut engine, &mut auth, OWNER, &stored1).unwrap();
+    assert_eq!(c2, 2);
+    assert_eq!(stored2.sign_count(), 2);
+
+    // Now model a CLONE that lags the persisted baseline: a credential blob at the
+    // advanced baseline (2) is what the server holds, but a cloned authenticator
+    // presents a LOWER counter. We drive a fresh, challenge-valid assertion whose
+    // baseline blob is bumped ABOVE what the authenticator will present, so the
+    // genuine signature is rejected purely on the sign-count regression.
+    let lagging_view = bump_stored_counter(&stored2, 50);
+    let cloned = real_assert(&mut engine, &mut auth, OWNER, &lagging_view);
+    assert_eq!(
+        cloned,
+        Err(RemoteError::ClonedAuthenticator),
+        "an assertion whose counter lags the persisted baseline must be rejected as a clone"
+    );
 }
 
 #[test]

--- a/rust-core/crates/friday-system-remote/tests/real_crypto.rs
+++ b/rust-core/crates/friday-system-remote/tests/real_crypto.rs
@@ -1,0 +1,269 @@
+//! A8 REAL-crypto round-trip KATs over [`friday_system_remote::RealWebAuthn`].
+//!
+//! These do NOT use the `cfg(test)` `AcceptingTestVerifier` (which proves only
+//! the device store, never the cryptography). They drive a PURE-SOFTWARE FIDO2
+//! authenticator (`webauthn-authenticator-rs`'s `SoftPasskey`, which performs
+//! real ES256 key generation + signing) through the genuine ceremony:
+//!
+//!   start_passkey_registration → SoftPasskey.do_registration → finish_registration
+//!   start_passkey_authentication → SoftPasskey.do_authentication → finish_assertion
+//!
+//! This is the proof that the real path verifies real cryptography end-to-end —
+//! the "prove a new integration seam end-to-end" discipline (a mocked verifier
+//! proves nothing about the real default path).
+
+use friday_system_remote::{
+    DeviceStore, RealWebAuthn, RemoteError, SessionStore, StoredCredential,
+};
+use webauthn_authenticator_rs::softpasskey::SoftPasskey;
+use webauthn_authenticator_rs::WebauthnAuthenticator;
+use webauthn_rs::prelude::Url;
+
+const RP_ID: &str = "friday.local";
+const RP_ORIGIN: &str = "https://friday.local";
+const OWNER: &str = "operator-1";
+
+/// Build an engine whose ONLY operator-authorized owner is `OWNER` (the
+/// first-device bootstrap trust root).
+fn engine() -> RealWebAuthn {
+    RealWebAuthn::new(RP_ID, RP_ORIGIN, vec![OWNER.to_string()]).expect("valid RP identity")
+}
+
+/// Drive a full REAL registration round-trip with the software authenticator,
+/// returning the verified attestation's stored credential + the (still-live)
+/// authenticator so the same key can authenticate later.
+fn real_register(
+    engine: &mut RealWebAuthn,
+    authenticator: &mut WebauthnAuthenticator<SoftPasskey>,
+    owner: &str,
+) -> StoredCredential {
+    let (ceremony_id, ccr) = engine
+        .begin_registration(owner, "Operator Device", &[])
+        .expect("authorized owner begins registration");
+    let origin = Url::parse(RP_ORIGIN).unwrap();
+    // The authenticator mints a real credential + attestation over the challenge.
+    let reg = authenticator
+        .do_registration(origin, ccr)
+        .expect("software authenticator performs registration");
+    let (_attestation, stored) = engine
+        .finish_registration(&ceremony_id, &reg)
+        .expect("real attestation verifies");
+    stored
+}
+
+/// Drive a full REAL assertion round-trip; returns the new sign-count.
+fn real_assert(
+    engine: &mut RealWebAuthn,
+    authenticator: &mut WebauthnAuthenticator<SoftPasskey>,
+    owner: &str,
+    stored: &StoredCredential,
+) -> Result<u32, RemoteError> {
+    let (ceremony_id, rcr) = engine.begin_assertion(owner, stored)?;
+    let origin = Url::parse(RP_ORIGIN).unwrap();
+    let pkc = authenticator
+        .do_authentication(origin, rcr)
+        .expect("software authenticator performs assertion");
+    engine.finish_assertion(&ceremony_id, &pkc).map(|(_, c)| c)
+}
+
+#[test]
+fn real_registration_then_assertion_round_trip() {
+    let mut engine = engine();
+    let mut auth = WebauthnAuthenticator::new(SoftPasskey::new(true));
+
+    // REAL registration: a genuine ES256 credential is minted and the attestation
+    // is cryptographically verified (RP-ID/origin/challenge binding all checked
+    // by webauthn-rs). The stored blob carries public material only.
+    let stored = real_register(&mut engine, &mut auth, OWNER);
+    assert!(!stored.credential_id().is_empty());
+    assert!(!stored.public_key().is_empty());
+    // No private key leaks into the stored public credential JSON.
+    let json = stored.passkey_json();
+    assert!(
+        !json.to_lowercase().contains("private") && !json.contains("\"d\""),
+        "stored credential must hold no private-key material: {json}"
+    );
+
+    // The ceremony state was consumed (single-use): no pending registrations left.
+    assert_eq!(engine.pending_registration_count(), 0);
+
+    // REAL assertion: the same authenticator signs a fresh challenge; the
+    // signature is verified over authenticatorData || sha256(clientDataJSON).
+    let count =
+        real_assert(&mut engine, &mut auth, OWNER, &stored).expect("a genuine assertion verifies");
+    // SoftPasskey increments its counter per auth: first auth ⇒ 1 (> the stored 0).
+    assert_eq!(count, 1);
+    assert_eq!(engine.pending_assertion_count(), 0);
+}
+
+#[test]
+fn real_attestation_drives_device_store_registration() {
+    // The real verifier mints the SAME VerifiedAttestation typestate token the
+    // DeviceStore::register accepts — so the real path registers a device, and the
+    // store seeds its sign-count regression baseline from the attestation.
+    let mut engine = engine();
+    let mut auth = WebauthnAuthenticator::new(SoftPasskey::new(true));
+
+    let (ceremony_id, ccr) = engine
+        .begin_registration(OWNER, "Operator Device", &[])
+        .unwrap();
+    let reg = auth
+        .do_registration(Url::parse(RP_ORIGIN).unwrap(), ccr)
+        .unwrap();
+    let (attestation, _stored) = engine.finish_registration(&ceremony_id, &reg).unwrap();
+
+    let mut devices = DeviceStore::new();
+    let dev = devices
+        .register("dev-1", &attestation, "Operator Phone", 1_000)
+        .expect("real attestation registers a device");
+    assert_eq!(dev.owner, OWNER);
+    assert_eq!(dev.rp_id, RP_ID);
+    assert_eq!(dev.sign_count, 0); // baseline at registration
+    assert_eq!(dev.credential_id, attestation.credential_id());
+
+    // And a remote session can be opened against the now-registered real device.
+    let mut sessions = SessionStore::new();
+    let s = sessions
+        .create(&devices, "sess-1", "dev-1", OWNER, 2_000, 1_000)
+        .expect("session opens against a real registered device");
+    assert_eq!(s.device_id, "dev-1");
+}
+
+#[test]
+fn cloned_authenticator_sign_count_regression_is_rejected() {
+    // THE A8 hardening KAT, with REAL crypto. A cryptographically-valid assertion
+    // whose sign-count does NOT strictly increase over the stored value is the
+    // W3C cloned-authenticator signal and MUST be rejected.
+    let mut engine = engine();
+    let mut auth = WebauthnAuthenticator::new(SoftPasskey::new(true));
+    let stored = real_register(&mut engine, &mut auth, OWNER);
+
+    // Forge a stored credential whose sign-count is artificially HIGH (as if the
+    // server had already observed a higher counter from this credential — the
+    // genuine authenticator). The next REAL assertion the authenticator produces
+    // will present a LOWER counter (its own in-memory counter, starting at 1),
+    // exactly modelling a cloned/lagging authenticator. The signature itself is
+    // valid; the rejection is purely the sign-count regression check.
+    let bumped = bump_stored_counter(&stored, 100);
+
+    let result = real_assert(&mut engine, &mut auth, OWNER, &bumped);
+    assert_eq!(
+        result,
+        Err(RemoteError::ClonedAuthenticator),
+        "a valid signature with a regressed (<=) sign-count must be rejected as a possible clone"
+    );
+    // The ceremony state was still consumed (single-use), so a retry cannot replay.
+    assert_eq!(engine.pending_assertion_count(), 0);
+}
+
+#[test]
+fn unknown_or_replayed_ceremony_id_is_rejected() {
+    let mut engine = engine();
+    let mut auth = WebauthnAuthenticator::new(SoftPasskey::new(true));
+    let stored = real_register(&mut engine, &mut auth, OWNER);
+
+    // A finish against a ceremony id that was never issued ⇒ fail-closed.
+    let (ceremony_id, rcr) = engine.begin_assertion(OWNER, &stored).unwrap();
+    let pkc = auth
+        .do_authentication(Url::parse(RP_ORIGIN).unwrap(), rcr)
+        .unwrap();
+    // First finish consumes the ceremony (succeeds).
+    engine
+        .finish_assertion(&ceremony_id, &pkc)
+        .expect("first finish succeeds");
+    // Replaying the SAME ceremony id ⇒ UnknownCeremony (single-use).
+    let replay = engine.finish_assertion(&ceremony_id, &pkc);
+    assert!(matches!(replay, Err(RemoteError::UnknownCeremony(_))));
+    // A wholly unknown ceremony id ⇒ UnknownCeremony.
+    let bogus = engine.finish_assertion("ceremony-99999", &pkc);
+    assert!(matches!(bogus, Err(RemoteError::UnknownCeremony(_))));
+}
+
+#[test]
+fn registration_for_unauthorized_owner_is_refused() {
+    // First-device bootstrap posture (FLAGGED): registration is authorized by an
+    // already-trusted operator, NEVER self-authorizing. An owner not in the
+    // authorized set cannot even begin a registration ceremony.
+    let mut engine = engine(); // only OWNER is authorized
+    let out = engine.begin_registration("intruder", "Rogue Device", &[]);
+    assert!(matches!(
+        out,
+        Err(RemoteError::RegistrationNotAuthorized(_))
+    ));
+    assert_eq!(engine.pending_registration_count(), 0);
+}
+
+#[test]
+fn cross_origin_ceremony_fails_closed() {
+    // The engine is bound to https://friday.local (rp_id friday.local). A ceremony
+    // driven for a DIFFERENT origin must NOT yield a verifiable credential: the
+    // origin/rp-id binding is enforced. (Here the SoftPasskey itself refuses to
+    // sign for an origin that is not a registrable-domain-suffix of the
+    // challenge's rp_id — a real layer of the binding; the server-side
+    // clientDataJSON-origin comparison in webauthn-rs is the second layer, covered
+    // by webauthn-rs's own suite. Either way the chain fails closed.)
+    let mut engine = engine(); // rp_id = friday.local, origin = https://friday.local
+    let mut auth = WebauthnAuthenticator::new(SoftPasskey::new(true));
+
+    let (_ceremony_id, ccr) = engine
+        .begin_registration(OWNER, "Operator Device", &[])
+        .unwrap();
+    // Drive the authenticator at an attacker-controlled origin that is NOT a
+    // suffix of the challenge rp_id.
+    let evil_origin = Url::parse("https://evil.example").unwrap();
+    let reg = auth.do_registration(evil_origin, ccr);
+    assert!(
+        reg.is_err(),
+        "a cross-origin ceremony must not produce a verifiable credential (origin binding)"
+    );
+}
+
+#[test]
+fn tampered_assertion_client_data_is_rejected() {
+    // Server-side integrity: the signature covers authenticatorData ||
+    // sha256(clientDataJSON). Tampering the clientDataJSON (e.g. to substitute a
+    // different origin/type/challenge) after signing breaks the signature, and
+    // webauthn-rs rejects it. This proves the engine does NOT accept a
+    // clientDataJSON that was not the one signed over.
+    let mut engine = engine();
+    let mut auth = WebauthnAuthenticator::new(SoftPasskey::new(true));
+    let stored = real_register(&mut engine, &mut auth, OWNER);
+
+    let (ceremony_id, rcr) = engine.begin_assertion(OWNER, &stored).unwrap();
+    let mut pkc = auth
+        .do_authentication(Url::parse(RP_ORIGIN).unwrap(), rcr)
+        .unwrap();
+    // Tamper: flip a byte of the signed clientDataJSON. The stored signature no
+    // longer validates over the (now-different) data.
+    if let Some(first) = pkc.response.client_data_json.as_mut().first_mut() {
+        *first ^= 0xFF;
+    }
+    let out = engine.finish_assertion(&ceremony_id, &pkc);
+    assert!(
+        matches!(out, Err(RemoteError::WebAuthnRejected(_))),
+        "a tampered clientDataJSON must be rejected, got {out:?}"
+    );
+}
+
+#[test]
+fn invalid_relying_party_origin_is_refused() {
+    // A malformed origin never yields a verifier (fail-closed construction).
+    let out = RealWebAuthn::new(RP_ID, "not a url", vec![OWNER.to_string()]);
+    assert!(matches!(out, Err(RemoteError::InvalidRelyingParty(_))));
+    let empty_rp = RealWebAuthn::new("", RP_ORIGIN, vec![OWNER.to_string()]);
+    assert!(matches!(empty_rp, Err(RemoteError::InvalidRelyingParty(_))));
+}
+
+/// Forge a [`StoredCredential`] copy whose serialized `Passkey` carries a higher
+/// sign-count. Used to model a server that has already observed a higher counter
+/// for this credential than a (cloned/lagging) authenticator will next present.
+fn bump_stored_counter(stored: &StoredCredential, new_counter: u64) -> StoredCredential {
+    // The serialized Passkey is `{ "cred": { ... "counter": N ... } }`.
+    let mut v: serde_json::Value = serde_json::from_str(stored.passkey_json()).unwrap();
+    v["cred"]["counter"] = serde_json::json!(new_counter);
+    let bumped_json = serde_json::to_string(&v).unwrap();
+    // Rehydrate through the public persistence API (the same path a future
+    // storage slice uses to load a stored credential blob back into a verifiable
+    // credential).
+    StoredCredential::from_passkey_json(&bumped_json).unwrap()
+}


### PR DESCRIPTION
## A8 — `system.remote` device-pairing: real WebAuthn/FIDO2 passkeys

Replaces the slice-1/2 cryptographic gap (the fail-closed `DeferredVerifier` stub) with a **real** WebAuthn/FIDO2 passkey engine, `friday_system_remote::real::RealWebAuthn`, backed by `webauthn-rs` 0.5.5. Builds directly on the merged #635 (slice-1) / #648 (slice-2) foundation.

### What is REAL now
- **Registration** (`navigator.credentials.create`): attestation parse + COSE public-key extraction + strict RP-ID-hash / origin / type / challenge binding. Passkeys use `AttestationConveyancePreference::None` (no attestation-CA trust anchor — consumer-passkey posture).
- **Assertion** (`navigator.credentials.get`): real ES256/RS256/EdDSA signature verification over `authenticatorData || sha256(clientDataJSON)`, the same RP-ID/origin/challenge binding, AND the **sign-count regression check** — a non-increasing (≤) counter ⇒ possible cloned authenticator ⇒ `RemoteError::ClonedAuthenticator` (webauthn-rs raises `CredentialPossibleCompromise`).
- **Hub stores ONLY public material**: `StoredCredential` is a serialized `Passkey` (public key + credential id + sign-count + flags). The private key never leaves the authenticator — there is no path for it to reach the server.
- **Strict binding**: built from injected `rp_id` + `rp_origin`; we deliberately do NOT enable `allow_subdomains` / `allow_any_port` / extra origins, and do NOT enable `danger-allow-state-serialisation`.
- **Single-use ceremonies**: pending challenge state held in-memory keyed by a server-issued `ceremony_id`, consumed on finish; unknown/replayed ⇒ `UnknownCeremony`.
- **Sign-count persistence loop closed**: `finish_assertion` returns the advanced `StoredCredential` (counter folded forward via `Passkey::update_credential`); persisting it and re-deriving the next baseline is what enforces regression across ceremonies.

### FLAGGED decisions (operator, see below)
- **First-device bootstrap**: the path was ambiguous; implemented the soundest posture — registration is authorized by an **already-trusted operator** (an `authorized_owners` trust root), NEVER self-authorizing (`RegistrationNotAuthorized` otherwise).
- **Synced-passkey counter exemption**: faithful to W3C — the strictly-increasing check only applies when a counter is nonzero. Synced passkeys (iCloud/Google) report 0 forever and cannot be clone-detected by counter, by design. Not re-implemented/tightened at the store layer (would false-reject legit passkeys).

### Proof (genuine crypto, not the test verifier)
`tests/real_crypto.rs` (9 KATs) drives a **pure-software FIDO2 authenticator** (`webauthn-authenticator-rs` `SoftPasskey`, real ES256 signing) — NOT the `cfg(test)` `AcceptingTestVerifier` — through: register→assert round-trip; real attestation → DeviceStore registration → session open; baseline advances 0→1→2 across real assertions and a lagging clone is rejected; the forged-baseline clone rejection; single-use/replayed ceremony; cross-origin refusal; tampered-clientData rejection; unauthorized-owner refusal; invalid-RP refusal.

### DARK + flag-gated-OFF, no route flip
- Nothing constructs `RealWebAuthn` in production. The shipped default verifier the public API exposes is **still `DeferredVerifier`** (intentionally retained as the fail-closed default) — the `fail_closed.rs` KATs continue to prove the default path rejects.
- No `friday-hub` wiring, no route, no FFI export. Flipping the real verifier on is a later, operator-gated, DEPLOY-GO step.

### Migration
None. Storage stays in-memory (consistent with #635/#648 and the m0024-contention note). No shared schema file touched. "Migration if needed" resolves to not-needed for an unwired in-memory slice.

### What remains (deferred, operator-gated)
- Hub route wiring of the 11 `system.remote.*` routes + CSPRNG ceremony-id/challenge issuance + FFI exposure.
- Persistence slice: the pending-ceremony state and the `StoredCredential` blob (and reconciling `RegisteredDevice.sign_count` — an audit projection — with the authoritative blob in a device-row schema).
- Deploy-gated relying-party identity (`rp_id`/`rp_origin`) and operator-seeded `authorized_owners` trust root.

### Build/CI notes
- `webauthn-rs` pulls `openssl`; `openssl-sys` pinned with the `vendored` feature so CI builds statically without a system libssl. `webauthn-rs` pinned `=0.5.5`; `Cargo.lock` committed. Residual: vendored OpenSSL compiles from source (build-time under the 25-min `rust-core.yml` cap).

Tests: 27 unit + 6 fail_closed + 9 real_crypto, all green. Workspace `cargo clippy --all-targets -D warnings` + `cargo fmt --check` clean (pinned 1.95.0). NOT v1 GO.

🤖 Generated with [Claude Code](https://claude.com/claude-code)