### PR TITLE
feat(a5): per-step-effect idempotency guard on the workflow retry frontier (DARK + DEPLOY-GO-gated)

### DIFF
--- a/rust-core/crates/friday-hub/src/workflow_exec.rs
+++ b/rust-core/crates/friday-hub/src/workflow_exec.rs
@@ -48,10 +48,119 @@ use friday_storage::{workflow, StorageError};
 use rusqlite::Connection;
 
 use crate::planner::{plan_step, StepDisposition, WorkflowDefinition};
-use crate::{gate_dispatch, GateDispatch, RawToolCall, ToolExecutor};
+use crate::{gate_dispatch, GateDispatch, RawToolCall, ToolExecutor, ToolReceipt};
 
 /// Priority of a workflow-checkpoint Needs-Me item (urgency-first ordering, `08` §1).
 const WORKFLOW_CHECKPOINT_PRIORITY: u8 = 7;
+
+/// A5: per-step-effect IDEMPOTENT dispatch — the single wrapper around the shared
+/// security chokepoint [`gate_dispatch`] that ALL three workflow drivers
+/// ([`advance_from`] auto-advance, [`resume_workflow`] force-dispatch, and
+/// [`retry_workflow`] force-dispatch) route their step dispatch through, so the
+/// retry frontier (`reopen_failed_step` → re-drive) never re-runs an
+/// already-committed side effect.
+///
+/// It does NOT touch / re-implement the gate (the `gate_dispatch` chokepoint is
+/// wrapped, never modified — the classify→authorize→execute-ONLY-on-`Allow`
+/// posture, the crypto authorize, and the executor-called-exactly-once invariant
+/// are all unchanged). It adds ONE thing on top:
+///
+/// - **Pre-dispatch SKIP (side-effect steps only):** for a step the persisted
+///   `has_side_effect` flag marks a side effect, it computes the STABLE idempotency
+///   key (`step_effect_idem_key(run_id, seq, action, params)` — NO attempt, so a
+///   retry of the SAME effect matches; WITH the action+params digest, so a changed
+///   effect at the same seq MISSES) and consults the m0029 ledger. A `Some` means
+///   the SAME effect already committed → the executor is NOT called and the RECORDED
+///   receipt is replayed as [`GateDispatch::Executed`]. The gate is also not consulted
+///   on the skip (the effect already passed it once when it committed).
+/// - **Post-dispatch RECORD (side-effect steps only):** on a real
+///   [`GateDispatch::Executed`], it RECORDS the committed effect under the same key
+///   BEFORE the caller's `complete_step`, so a subsequent re-drive can skip it. The
+///   key PK makes a re-record of the SAME effect a benign no-op.
+///
+/// A read-only step (`has_side_effect == false`) is NEVER skipped and NEVER recorded
+/// — re-running a read on retry is correct (skipping it would serve stale data), and
+/// reads are not a double-apply hazard.
+///
+/// PREDICATE CAVEAT (forward-only; documented, not narrowed here on purpose): the skip
+/// predicate is the persisted `has_side_effect` flag, which means "requires evidence
+/// to verify" — and the engine sets it `true` not only for mutating steps but also for
+/// a SENSITIVE-READ checkpoint and any `force_checkpoint` step. So in the FORWARD model
+/// (where the skip could fire) such a read would be REPLAYED from its recorded receipt
+/// rather than re-read — staleness, not a double-apply (benign for a read). This is
+/// inert in today's engine (a committed read is `Verified` and the frontier skips it,
+/// so its ledger row is never consulted), and is refined precisely when the
+/// executor-carried key lands (a key-aware tool decides re-run vs dedup per its own
+/// idempotency). For the same forward-only reason a SKIPPED step is still counted in
+/// `executed_steps` though the executor did not run. The predicate is deliberately NOT
+/// narrowed at this slice (narrowing it for zero current benefit is regression risk).
+///
+/// HONEST SCOPE (DARK defense-in-depth + forward-safety, NOT a live double-run fix):
+/// in today's LINEAR, SYNCHRONOUS engine a committed side-effect step is
+/// `complete_step`d `Verified`, and the retry frontier SKIPS `Verified` steps
+/// (`reopen_failed_step` REFUSES them) — so a committed effect is ALREADY never
+/// re-driven, and the SKIP branch here is REDUNDANT with that Verified-skip and is
+/// not reached by normal `run_workflow`/`retry_workflow` execution. The always-active,
+/// genuinely-new behavior is the RECORD (committed-effect provenance on every
+/// committed side-effect). The SKIP guards a FUTURE model where commit and `Verified`
+/// can diverge (a DAG frontier with a committed sibling, or an async/crash run). It
+/// does NOT make the current engine exactly-once against a partially-applied EXTERNAL
+/// tool — that needs the key CARRIED into `executor.execute` so a key-aware tool
+/// dedupes, a deferred sub-AC (the executor signature / gate code is untouched here).
+#[allow(clippy::too_many_arguments)]
+fn dispatch_step_idempotent(
+    conn: &Connection,
+    executor: &dyn ToolExecutor,
+    raw: &RawToolCall,
+    run_id: &str,
+    seq: usize,
+    step_id: &str,
+    secret: &[u8],
+    approve: &dyn Fn(&MutatingActionRequest) -> Option<CanonicalApproval>,
+    now_ms: i64,
+) -> Result<GateDispatch, StorageError> {
+    // The side-effect flag is the persisted truth (single-sourced with the
+    // run-completion gate / `complete_step`). A read-only step is never a re-run
+    // hazard, so it bypasses the ledger entirely (always dispatched, never recorded).
+    let is_side_effect = workflow::step_has_side_effect(conn, step_id)?.unwrap_or(false);
+    if !is_side_effect {
+        return gate_dispatch(conn, executor, raw, secret, approve, now_ms);
+    }
+
+    let idem_key = workflow::step_effect_idem_key(run_id, seq as i64, &raw.action, &raw.params);
+
+    // Pre-dispatch SKIP: the SAME effect already committed under this key → replay the
+    // recorded receipt WITHOUT calling the executor (and without re-consulting the
+    // gate — the effect already passed it when it committed). A DIFFERENT effect at the
+    // same seq computes a different key and misses, so this never replays the wrong one.
+    if let Some(committed) = workflow::committed_effect(conn, &idem_key)? {
+        return Ok(GateDispatch::Executed(ToolReceipt {
+            action: raw.action.clone(),
+            summary: committed.receipt_summary,
+            content: committed.receipt_content,
+        }));
+    }
+
+    // Not yet committed → the real gate-mandatory dispatch (unchanged).
+    let outcome = gate_dispatch(conn, executor, raw, secret, approve, now_ms)?;
+    // Post-dispatch RECORD: on a real commit, record the effect under the stable key
+    // BEFORE the caller's `complete_step`, so a later re-drive of the SAME effect skips
+    // it. The PK makes a re-record of the same key a benign no-op.
+    if let GateDispatch::Executed(receipt) = &outcome {
+        workflow::record_committed_effect(
+            conn,
+            &idem_key,
+            run_id,
+            step_id,
+            seq as i64,
+            &raw.action,
+            &receipt.summary,
+            receipt.content.as_deref(),
+            now_ms,
+        )?;
+    }
+    Ok(outcome)
+}
 
 /// The Needs-Me items for PAUSED workflows (`08` §2): every `AwaitingCheckpoint` run is
 /// surfaced as a cross-source action item the user must act on (approve/resume the
@@ -163,7 +272,9 @@ pub fn resume_workflow(
         action: step.action.clone(),
         params: step.params.clone(),
     };
-    match gate_dispatch(conn, executor, &raw, secret, approve, now_ms)? {
+    match dispatch_step_idempotent(
+        conn, executor, &raw, run_id, paused_seq, &step_id, secret, approve, now_ms,
+    )? {
         GateDispatch::Executed(receipt) => {
             workflow::complete_step(conn, &step_id, Some(&receipt.summary), true, now_ms)?;
         }
@@ -277,7 +388,9 @@ fn advance_from(
                     action: step.action.clone(),
                     params: step.params.clone(),
                 };
-                match gate_dispatch(conn, executor, &raw, secret, approve, now_ms)? {
+                match dispatch_step_idempotent(
+                    conn, executor, &raw, run_id, seq, &step_id, secret, approve, now_ms,
+                )? {
                     GateDispatch::Executed(receipt) => {
                         // Complete WITH the tool receipt as evidence (`08` §6).
                         workflow::complete_step(
@@ -412,11 +525,16 @@ fn find_retry_frontier_seq(
 /// frontier step then `advance_from(frontier + 1, ..)`. Already-`Verified` earlier
 /// steps are NEVER re-executed.
 ///
-/// HONEST LIMITATION (documented dark-substrate sub-AC): there are NO idempotency
-/// keys (TS `retryRun` has per-attempt idempotency keys). Re-driving the frontier
-/// step is correct for a TRANSIENT failure (the common retry case); a step whose
-/// side effect *partially* applied before failing could double-run on retry.
-/// Idempotency-keyed re-execution is a deferred follow-up — see the PR body.
+/// A5 IDEMPOTENCY: the frontier re-dispatch routes through
+/// [`dispatch_step_idempotent`] (the same wrapper as run/resume), so a side-effect
+/// step's COMMITTED effect is recorded under a stable per-effect key (m0029) and a
+/// re-drive of the SAME effect is skipped (the executor is not re-called). HONEST
+/// SCOPE: in this linear synchronous engine a committed side-effect step is
+/// `Verified` and the frontier already SKIPS `Verified` steps, so the skip is
+/// REDUNDANT defense-in-depth (forward-safe for a DAG/async model); the always-active
+/// behavior is the committed-effect RECORD. It does NOT make a partially-applied
+/// EXTERNAL tool exactly-once — that needs the key CARRIED into the executor (a
+/// deferred sub-AC). See [`dispatch_step_idempotent`] and the PR body.
 #[allow(clippy::too_many_arguments)]
 pub fn retry_workflow(
     def: &WorkflowDefinition,
@@ -451,7 +569,17 @@ pub fn retry_workflow(
         action: step.action.clone(),
         params: step.params.clone(),
     };
-    match gate_dispatch(conn, executor, &raw, secret, approve, now_ms)? {
+    match dispatch_step_idempotent(
+        conn,
+        executor,
+        &raw,
+        run_id,
+        frontier_seq,
+        &step_id,
+        secret,
+        approve,
+        now_ms,
+    )? {
         GateDispatch::Executed(receipt) => {
             workflow::complete_step(conn, &step_id, Some(&receipt.summary), true, now_ms)?;
         }
@@ -1002,5 +1130,323 @@ mod tests {
                 ),
             ],
         }
+    }
+
+    // --- A5: per-step-effect idempotency (m0029) -----------------------------
+
+    /// Executor that ERRS on its first call and SUCCEEDS thereafter (a transient
+    /// failure) — distinct from `CountingExec` so an A5 test can drive a real
+    /// engine-produced Failed run with a NON-Verified side-effect frontier.
+    struct TransientExec {
+        calls: Cell<usize>,
+    }
+    impl ToolExecutor for TransientExec {
+        fn execute(
+            &self,
+            action: &str,
+            _params: &[(String, String)],
+        ) -> Result<ToolReceipt, ExecError> {
+            let n = self.calls.get() + 1;
+            self.calls.set(n);
+            if n == 1 {
+                Err(ExecError::Unsupported("transient boom".to_string()))
+            } else {
+                Ok(ToolReceipt {
+                    action: action.to_string(),
+                    summary: format!("ran {action} (attempt {n})"),
+                    content: None,
+                })
+            }
+        }
+    }
+
+    /// A single SIDE-EFFECT (evidence_required) but gate-safe (`read_file`,
+    /// auto-advances) step. Its `has_side_effect` flag is true, so it is ledger-tracked,
+    /// yet it executes WITHOUT a checkpoint pause (the gate Allows a read), which is the
+    /// only synchronous shape in the linear engine where a side-effect step runs the
+    /// executor and is recorded.
+    fn single_side_effect_def() -> WorkflowDefinition {
+        WorkflowDefinition {
+            name: "probe".into(),
+            steps: vec![step("e", "read_file", &[("path", "log")], false, true)],
+        }
+    }
+
+    #[test]
+    fn a_committed_side_effect_records_its_effect_in_the_idempotency_ledger() {
+        // THE always-active, genuinely-new A5 behavior: when a side-effect step
+        // commits (executor Ok), the engine RECORDS the committed effect under its
+        // stable per-effect key (m0029). This is observable provenance regardless of
+        // whether the skip ever fires. A read-only step is NOT recorded (not a hazard).
+        let db = Db::open_hub(&tmp("a5-record")).unwrap();
+        let exec = CountingExec {
+            calls: Cell::new(0),
+        };
+        let def = WorkflowDefinition {
+            name: "mix".into(),
+            steps: vec![
+                step("read", "read_file", &[("path", "x")], false, false), // read-only s0
+                step("ev", "read_file", &[("path", "log")], false, true),  // side-effect s1
+            ],
+        };
+        let out = run_workflow(&def, &exec, db.conn(), "r1", SECRET, &deny_all, 100).unwrap();
+        assert_eq!(out.status, WorkflowRunStatus::Completed);
+
+        // The side-effect step (s1) recorded a committed effect under its stable key.
+        let key = workflow::step_effect_idem_key(
+            "r1",
+            1,
+            "read_file",
+            &[("path".to_string(), "log".to_string())],
+        );
+        let committed = workflow::committed_effect(db.conn(), &key).unwrap();
+        assert!(
+            committed.is_some(),
+            "the committed side-effect step recorded its effect"
+        );
+        let committed = committed.unwrap();
+        assert_eq!(committed.step_id, "r1:s1");
+        assert_eq!(committed.action, "read_file");
+
+        // The READ-ONLY step (s0) recorded NOTHING (not a re-run hazard).
+        let read_key = workflow::step_effect_idem_key(
+            "r1",
+            0,
+            "read_file",
+            &[("path".to_string(), "x".to_string())],
+        );
+        assert!(
+            workflow::committed_effect(db.conn(), &read_key)
+                .unwrap()
+                .is_none(),
+            "a read-only step is never ledger-recorded"
+        );
+    }
+
+    #[test]
+    fn idempotency_key_skips_a_non_verified_committed_side_effect_on_retry() {
+        // THE load-bearing GUARD-LOGIC test, isolating the idempotency KEY from
+        // Verified-skip. We construct a state the current linear engine does NOT
+        // produce on its own — a side-effect step left NON-Verified (ProofPending)
+        // that ALSO has a committed-effect ledger row — to prove the skip branch is
+        // the SOLE cause of the executor NOT being called.
+        //
+        // HONEST: this is a guard-logic test against an INJECTED ledger row, NOT a
+        // regression test of a prevented live double-run. In today's engine a committed
+        // side-effect step is Verified and the retry frontier skips Verified, so this
+        // exact (non-Verified + committed) combination is unreachable through normal
+        // run/retry; the skip is forward-safe defense-in-depth (see
+        // `dispatch_step_idempotent`). Verified-skip cannot cause this assertion: the
+        // step here is ProofPending, NOT Verified, so the frontier DOES reopen + re-drive
+        // it — only the ledger entry stops the executor.
+        let db = Db::open_hub(&tmp("a5-skip")).unwrap();
+        let exec = TransientExec {
+            calls: Cell::new(0),
+        };
+        let def = single_side_effect_def();
+
+        // First drive: gate Allows the read, executor ERRS → step ProofPending, run Failed.
+        let started = run_workflow(&def, &exec, db.conn(), "r1", SECRET, &mint_all, 100).unwrap();
+        assert!(matches!(started.status, WorkflowRunStatus::Failed { .. }));
+        assert_eq!(exec.calls.get(), 1);
+        assert_eq!(
+            workflow::step_status(db.conn(), "r1:s0").unwrap(),
+            Some(StepStatus::ProofPending),
+            "a side-effect exec-error leaves the step ProofPending (non-Verified frontier)"
+        );
+        // NB: no committed effect was recorded (the executor ERRED, never committed).
+        let key = workflow::step_effect_idem_key(
+            "r1",
+            0,
+            "read_file",
+            &[("path".to_string(), "log".to_string())],
+        );
+        assert!(workflow::committed_effect(db.conn(), &key)
+            .unwrap()
+            .is_none());
+
+        // INJECT a committed-effect ledger row for this exact effect (the synthetic
+        // state). On retry, the frontier reopens (ProofPending → Pending) and is
+        // re-driven through `dispatch_step_idempotent`, which now finds the recorded
+        // effect → SKIPS the executor and replays the recorded receipt.
+        workflow::record_committed_effect(
+            db.conn(),
+            &key,
+            "r1",
+            "r1:s0",
+            0,
+            "read_file",
+            "recorded-receipt-summary",
+            None,
+            150,
+        )
+        .unwrap();
+
+        let out = retry_workflow(&def, &exec, db.conn(), "r1", SECRET, &mint_all, 200).unwrap();
+        assert_eq!(out.status, WorkflowRunStatus::Completed);
+        assert_eq!(
+            exec.calls.get(),
+            1,
+            "the committed effect was SKIPPED on retry: the executor was NOT called again"
+        );
+        // The step completed from the recorded receipt → Verified.
+        assert_eq!(
+            workflow::step_status(db.conn(), "r1:s0").unwrap(),
+            Some(StepStatus::Verified)
+        );
+    }
+
+    #[test]
+    fn retry_without_a_ledger_entry_re_runs_the_frontier_the_negative_twin() {
+        // The NEGATIVE TWIN of the skip test: IDENTICAL setup but NO injected ledger
+        // row → the executor IS called again on retry. This isolates the key as the
+        // sole cause of the skip in the positive case (same engine path, same
+        // non-Verified frontier; the only difference is the ledger entry).
+        let db = Db::open_hub(&tmp("a5-noskip")).unwrap();
+        let exec = TransientExec {
+            calls: Cell::new(0),
+        };
+        let def = single_side_effect_def();
+
+        let started = run_workflow(&def, &exec, db.conn(), "r1", SECRET, &mint_all, 100).unwrap();
+        assert!(matches!(started.status, WorkflowRunStatus::Failed { .. }));
+        assert_eq!(exec.calls.get(), 1);
+
+        // NO ledger row injected → retry re-drives the frontier (executor called a 2nd time).
+        let out = retry_workflow(&def, &exec, db.conn(), "r1", SECRET, &mint_all, 200).unwrap();
+        assert_eq!(out.status, WorkflowRunStatus::Completed);
+        assert_eq!(
+            exec.calls.get(),
+            2,
+            "with NO committed-effect ledger entry the frontier is re-driven (executor re-called)"
+        );
+        assert_eq!(
+            workflow::step_status(db.conn(), "r1:s0").unwrap(),
+            Some(StepStatus::Verified)
+        );
+        // The re-drive committed the effect now (so a FURTHER re-drive would skip it).
+        let key = workflow::step_effect_idem_key(
+            "r1",
+            0,
+            "read_file",
+            &[("path".to_string(), "log".to_string())],
+        );
+        assert!(
+            workflow::committed_effect(db.conn(), &key)
+                .unwrap()
+                .is_some(),
+            "the successful re-drive recorded the committed effect"
+        );
+    }
+
+    #[test]
+    fn retry_after_partial_success_does_not_double_run_committed_steps_only_re_drives_frontier() {
+        // The required per-behavior retry test, driven END-TO-END (no injected state):
+        // a multi-step run where an EARLIER side-effect step COMMITS (Verified) and a
+        // LATER step is the failure frontier. Retry must re-drive ONLY the failed
+        // frontier — the already-committed earlier step's executor is NOT re-called.
+        //
+        // (In the linear engine this is enforced by Verified-skip; the A5 ledger ALSO
+        // recorded the earlier step's effect, so a future model that re-presented it at
+        // the frontier would skip it too. Both guards agree here.)
+        let db = Db::open_hub(&tmp("a5-partial")).unwrap();
+        // s0 = side-effect read (commits Verified on attempt 1); s1 = side-effect read
+        // that ERRS on its first execution (the frontier), succeeds on retry. A single
+        // TransientExec errs only on its FIRST call — which is s1 (s0 ran first, OK on
+        // call 1? no: call 1 is s0). So use a frontier-only-failing executor instead.
+        struct FrontierFailExec {
+            calls: Cell<usize>,
+            // step ids that have been executed, to prove no double-run.
+            ran: std::cell::RefCell<Vec<String>>,
+            fail_action_once: std::cell::RefCell<Option<String>>,
+        }
+        impl ToolExecutor for FrontierFailExec {
+            fn execute(
+                &self,
+                action: &str,
+                params: &[(String, String)],
+            ) -> Result<ToolReceipt, ExecError> {
+                self.calls.set(self.calls.get() + 1);
+                let path = params
+                    .iter()
+                    .find(|(k, _)| k == "path")
+                    .map(|(_, v)| v.clone())
+                    .unwrap_or_default();
+                self.ran.borrow_mut().push(format!("{action}:{path}"));
+                // Fail the frontier action exactly once (the first time it is seen).
+                let mut once = self.fail_action_once.borrow_mut();
+                if once.as_deref() == Some(path.as_str()) {
+                    *once = None;
+                    return Err(ExecError::Unsupported("frontier boom".to_string()));
+                }
+                Ok(ToolReceipt {
+                    action: action.to_string(),
+                    summary: format!("ran {action} {path}"),
+                    content: None,
+                })
+            }
+        }
+        let exec = FrontierFailExec {
+            calls: Cell::new(0),
+            ran: std::cell::RefCell::new(Vec::new()),
+            fail_action_once: std::cell::RefCell::new(Some("frontier".to_string())),
+        };
+        let def = WorkflowDefinition {
+            name: "twostep".into(),
+            steps: vec![
+                step("a", "read_file", &[("path", "committed")], false, true), // s0 side-effect
+                step("b", "read_file", &[("path", "frontier")], false, true), // s1 side-effect frontier
+            ],
+        };
+
+        // First drive: s0 commits (Verified), s1 errs → ProofPending, run Failed.
+        let started = run_workflow(&def, &exec, db.conn(), "r1", SECRET, &mint_all, 100).unwrap();
+        assert!(matches!(started.status, WorkflowRunStatus::Failed { .. }));
+        assert_eq!(
+            workflow::step_status(db.conn(), "r1:s0").unwrap(),
+            Some(StepStatus::Verified),
+            "the earlier side-effect step committed (Verified)"
+        );
+        assert_eq!(
+            workflow::step_status(db.conn(), "r1:s1").unwrap(),
+            Some(StepStatus::ProofPending),
+            "the frontier side-effect step failed (ProofPending)"
+        );
+        assert_eq!(
+            *exec.ran.borrow(),
+            vec!["read_file:committed", "read_file:frontier"]
+        );
+        let calls_after_first = exec.calls.get();
+        assert_eq!(calls_after_first, 2);
+        // s0's committed effect is recorded.
+        let s0_key = workflow::step_effect_idem_key(
+            "r1",
+            0,
+            "read_file",
+            &[("path".to_string(), "committed".to_string())],
+        );
+        assert!(workflow::committed_effect(db.conn(), &s0_key)
+            .unwrap()
+            .is_some());
+
+        // Retry: ONLY the frontier (s1) is re-driven; s0 is NOT re-executed.
+        let out = retry_workflow(&def, &exec, db.conn(), "r1", SECRET, &mint_all, 200).unwrap();
+        assert_eq!(out.status, WorkflowRunStatus::Completed);
+        assert_eq!(run_state(&db, "r1"), "done");
+        // Exactly ONE more executor call (the frontier re-drive); s0 not re-run.
+        assert_eq!(
+            exec.calls.get(),
+            calls_after_first + 1,
+            "retry re-drove ONLY the frontier — the committed earlier step was not double-run"
+        );
+        assert_eq!(
+            *exec.ran.borrow(),
+            vec![
+                "read_file:committed",
+                "read_file:frontier",
+                "read_file:frontier"
+            ],
+            "the committed step (committed) ran exactly once; only the frontier re-ran"
+        );
     }
 }

--- a/rust-core/crates/friday-hub/src/workflow_run_control.rs
+++ b/rust-core/crates/friday-hub/src/workflow_run_control.rs
@@ -43,8 +43,15 @@
 //!   m0027 column), transitions `Failed -> Running` (the new core edge), and
 //!   re-drives the frontier THROUGH THE SAME GATE then continues — REUSING the
 //!   engine path, not re-implementing it. A mutating frontier with no approval
-//!   re-pauses (never executes unapproved). HONEST: no idempotency keys yet (a
-//!   partial side-effect could double-run on retry) — a documented deferred sub-AC.
+//!   re-pauses (never executes unapproved). A5: the engine's re-drive now routes
+//!   through the per-step-effect idempotency guard (m0029 ledger) — a side-effect
+//!   step's COMMITTED effect is recorded under a stable per-effect key and a
+//!   re-drive of the SAME effect is skipped (executor not re-called). HONEST: in
+//!   this linear synchronous engine a committed step is `Verified` and the frontier
+//!   already skips `Verified`, so the SKIP is REDUNDANT defense-in-depth (forward-safe
+//!   for a DAG/async model); the always-active behavior is the committed-effect
+//!   RECORD. Exactly-once against a partially-applied EXTERNAL tool still needs the
+//!   key CARRIED into the executor — a documented deferred sub-AC.
 //! - **`cancel`** — the CANCEL control bridge (slice-2). Mirrors TS `cancelRun`
 //!   (terminal `cancelled`, distinct from `failed`, + a reason). [`cancel`]
 //!   prechecks the run exists and is non-terminal, then writes the terminal
@@ -199,9 +206,15 @@ pub fn resume(
 ///   other selection is a fail-closed [`RunControlError::InvalidTransition`] (we do
 ///   NOT silently ignore a caller's node selection). A future DAG engine would honor
 ///   arbitrary subsets — a deferred sub-AC.
-/// - **No idempotency keys** (TS has per-attempt idempotency keys). Re-driving the
-///   frontier is correct for a TRANSIENT failure; a partially-applied side effect
-///   could double-run. A documented deferred sub-AC (see the module docs / PR body).
+/// - **Per-step-effect idempotency (A5, m0029).** The frontier re-drive routes through
+///   the engine's idempotency guard ([`crate::workflow_exec`]'s `dispatch_step_idempotent`):
+///   a side-effect step's COMMITTED effect is recorded under a stable per-effect key (NOT
+///   the attempt) and a re-drive of the SAME effect is skipped (executor not re-called).
+///   HONEST: in this linear synchronous engine a committed step is `Verified` and the
+///   frontier already skips `Verified`, so the skip is REDUNDANT defense-in-depth
+///   (forward-safe for a DAG/async model); the always-active behavior is the committed-effect
+///   RECORD. Exactly-once against a partially-applied EXTERNAL tool still needs the key
+///   CARRIED into the executor — a deferred sub-AC (see the module docs / PR body).
 #[allow(clippy::too_many_arguments)]
 pub fn retry(
     conn: &Connection,

--- a/rust-core/crates/friday-storage/src/schema.rs
+++ b/rust-core/crates/friday-storage/src/schema.rs
@@ -111,6 +111,18 @@ pub const HUB_ONLY_TABLES: &[&str] = &[
     "system_intent_result",
     "system_control_lease",
     "system_intent_approval_record",
+    // A5: per-step-effect IDEMPOTENCY ledger (DARK substrate). Records the
+    // committed side-effect of a workflow step keyed by a STABLE idempotency key
+    // `sha256(run_id|seq|action|sorted-params)` (NOT the attempt — so it survives a
+    // `reopen_failed_step` retry and a re-drive of the SAME effect matches it). A
+    // separate table (not columns on `workflow_step`) so the record survives
+    // `reopen_failed_step` (which sets the step Pending / bumps attempt / clears
+    // evidence_ref) by construction. Hub-only: it hangs off the Hub-only workflow run
+    // engine and is created only where that engine runs. Holds NO secret/key material
+    // — the recorded receipt is the SAME bounded tool-summary (+ optional content) the
+    // step already persisted as evidence; the key is a digest, never raw approval/mint
+    // material. Nothing reads/writes it in production (DARK).
+    "workflow_step_effect",
 ];
 
 /// Tables present only on a phone (never created on the Hub).
@@ -461,6 +473,24 @@ pub fn hub_migrations() -> Vec<Migration> {
             destructive: false,
             up: m0028_agent_session_lifecycle,
         },
+        // A5: per-step-effect IDEMPOTENCY ledger (DARK substrate). A NEW Hub-only
+        // table `workflow_step_effect` recording the committed side-effect of a
+        // workflow step keyed by a STABLE idempotency key (the m0029 column
+        // `idem_key` = `sha256(run_id|seq|action|sorted-params)`, NOT the attempt —
+        // so a retry that re-drives the SAME effect matches the recorded commit and
+        // a CHANGED effect naturally misses). It is the NEW-TABLE pattern (like
+        // m0026 system_intent / m0005 agent_run), NOT an ALTER — so no existing
+        // table is touched and every pre-v29 row/query is unaffected. The table is
+        // separate (not columns on `workflow_step`) on purpose: the record must
+        // survive `reopen_failed_step` (which sets the step Pending / bumps attempt /
+        // clears evidence_ref), and a separate table survives-by-construction. DARK:
+        // nothing in production reads or writes it.
+        Migration {
+            version: 29,
+            name: "workflow_step_effect_idempotency",
+            destructive: false,
+            up: m0029_workflow_step_effect_idempotency,
+        },
     ]
 }
 
@@ -631,6 +661,32 @@ CREATE TABLE workflow_step (
     updated_at      INTEGER NOT NULL
 );
 CREATE INDEX idx_workflow_step_run ON workflow_step(run_id, seq);";
+
+// A5: per-step-effect IDEMPOTENCY ledger (Hub-only, DARK). One row per COMMITTED
+// side-effect of a workflow step. The PRIMARY KEY is the STABLE idempotency key
+// `idem_key` = `sha256(run_id|seq|action|sorted-params)` (NOT the attempt), so:
+//   * a retry that reopens + re-drives the SAME effect computes the SAME key and
+//     hits this row (the skip path), and
+//   * a re-drive of a DIFFERENT effect (changed action/params, e.g. a new def
+//     version at the same seq) computes a DIFFERENT key and naturally MISSES (it
+//     never skips the wrong effect).
+// `step_id`/`run_id`/`seq` are carried for projection/debug (and `run_id` is
+// indexed for a per-run sweep), but the key is the identity. The recorded
+// `receipt_summary` (+ optional `receipt_content`) is the SAME bounded tool
+// summary/content the step persisted as evidence — so a skip can return the
+// recorded receipt without re-running the executor. No secret/key material.
+const DDL_WORKFLOW_STEP_EFFECT: &str = "
+CREATE TABLE workflow_step_effect (
+    idem_key        TEXT PRIMARY KEY,
+    run_id          TEXT NOT NULL,
+    step_id         TEXT NOT NULL,
+    seq             INTEGER NOT NULL,
+    action          TEXT NOT NULL,
+    receipt_summary TEXT NOT NULL,
+    receipt_content TEXT,
+    committed_at    INTEGER NOT NULL
+);
+CREATE INDEX idx_workflow_step_effect_run ON workflow_step_effect(run_id, seq);";
 
 // --- PR-5 agent-loop fragments (Hub-only) -----------------------------------
 
@@ -2062,4 +2118,14 @@ fn m0028_agent_session_lifecycle(tx: &Transaction) -> rusqlite::Result<()> {
          ALTER TABLE agent_session ADD COLUMN status_changed_at INTEGER;
          ALTER TABLE agent_session ADD COLUMN last_activity_at INTEGER;",
     )
+}
+
+/// A5: per-step-effect IDEMPOTENCY ledger (DARK). One NEW Hub-only table
+/// (`DDL_WORKFLOW_STEP_EFFECT`) recording the committed side-effect of a workflow
+/// step keyed by a STABLE idempotency key. This is the NEW-TABLE migration pattern
+/// (like m0026 system_intent / m0005 agent_run), NOT an ALTER — touches no existing
+/// table, so every pre-v29 row and query is unaffected. Nothing in production reads
+/// or writes this table (DARK).
+fn m0029_workflow_step_effect_idempotency(tx: &Transaction) -> rusqlite::Result<()> {
+    tx.execute_batch(DDL_WORKFLOW_STEP_EFFECT)
 }

--- a/rust-core/crates/friday-storage/src/workflow.rs
+++ b/rust-core/crates/friday-storage/src/workflow.rs
@@ -227,6 +227,22 @@ pub fn step_status(conn: &Connection, step_id: &str) -> Result<Option<StepStatus
     Ok(s.map(|x| parse_step_status(&x)))
 }
 
+/// Whether a step carries a side effect (the persisted `has_side_effect` flag — the
+/// single source of truth the run-completion gate and `complete_step` already read).
+/// `None` for an unknown `step_id`. The A5 idempotency guard keys off this: ONLY a
+/// side-effect step is a re-run hazard, so only a side-effect step is ledger-checked
+/// (a read-only step always re-runs — skipping a read would serve stale data).
+pub fn step_has_side_effect(conn: &Connection, step_id: &str) -> Result<Option<bool>> {
+    let v: Option<i64> = conn
+        .query_row(
+            "SELECT has_side_effect FROM workflow_step WHERE step_id = ?1",
+            [step_id],
+            |r| r.get(0),
+        )
+        .optional()?;
+    Ok(v.map(|x| x != 0))
+}
+
 /// Resolve + persist a step's completion via the evidence-gating invariant. A
 /// side-effect step is persisted `Verified` only when deterministic evidence is
 /// supplied (`evidence_ref`); otherwise `ProofPending` (even if the model claimed
@@ -389,4 +405,145 @@ pub fn run_cancel_reason(conn: &Connection, run_id: &str) -> Result<Option<Strin
         )
         .optional()?;
     Ok(r.flatten())
+}
+
+// --- A5: per-step-effect IDEMPOTENCY ledger (DARK, m0029). Hub-only, additive. ---
+//
+// The retry frontier (`reopen_failed_step` -> Pending + `attempt += 1`) re-drives a
+// step's effect. These primitives let the engine RECORD a step's committed
+// side-effect under a STABLE idempotency key and CHECK that key on a re-drive so an
+// already-committed effect is NOT re-run. The key deliberately EXCLUDES the attempt
+// (so a retry of the SAME effect matches its prior commit) and INCLUDES the
+// action+params digest (so a re-drive of a DIFFERENT effect at the same seq — e.g. a
+// changed def version — naturally MISSES and never skips the wrong effect).
+//
+// HONEST SCOPE (the engine semantics, restated where the data lives): in today's
+// LINEAR, SYNCHRONOUS engine a committed side-effect step is `complete_step`d
+// `Verified`, and the retry frontier SKIPS `Verified` steps (`reopen_failed_step`
+// REFUSES them) — so a committed effect is already never re-driven. This ledger is
+// therefore DARK defense-in-depth + forward-safety: it always RECORDS committed-effect
+// provenance, and its SKIP guards a future model where commit and `Verified` can
+// diverge (a DAG frontier with a committed sibling, or an async/crash run). It does
+// NOT, by itself, make the current engine "exactly-once" against a partially-applied
+// external tool — that needs the key CARRIED into the executor so a key-aware tool
+// dedupes, an explicit deferred sub-AC (the executor signature / gate code is not
+// touched here).
+
+/// A committed per-step side-effect, recorded under its stable idempotency key.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CommittedEffect {
+    /// The stable idempotency key (`sha256(run_id|seq|action|sorted-params)` hex).
+    pub idem_key: String,
+    pub run_id: String,
+    pub step_id: String,
+    pub seq: i64,
+    pub action: String,
+    /// The committed tool-receipt summary (the SAME bounded text persisted as evidence).
+    pub receipt_summary: String,
+    /// The committed tool-receipt content (refs/body the engine threads back), or None.
+    pub receipt_content: Option<String>,
+    pub committed_at: i64,
+}
+
+/// Compute the STABLE per-step-effect idempotency key:
+/// `sha256(run_id "\0" seq "\0" action "\0" k1 "\0" v1 "\0" ...)` over the params
+/// SORTED by key (so param ORDER never changes the key — two semantically-identical
+/// effects share a key). It deliberately does NOT include the retry `attempt` (a
+/// retry of the SAME effect must match its prior commit) and DOES include
+/// action+params (a DIFFERENT effect at the same seq computes a different key, so a
+/// skip can never apply the wrong effect). `\0` separators + the explicit field
+/// order make the encoding unambiguous (no `"a"+"bc"` vs `"ab"+"c"` collision).
+pub fn step_effect_idem_key(
+    run_id: &str,
+    seq: i64,
+    action: &str,
+    params: &[(String, String)],
+) -> String {
+    use sha2::{Digest, Sha256};
+    let mut sorted: Vec<&(String, String)> = params.iter().collect();
+    sorted.sort_by(|a, b| a.0.cmp(&b.0).then_with(|| a.1.cmp(&b.1)));
+    let mut h = Sha256::new();
+    h.update(run_id.as_bytes());
+    h.update([0u8]);
+    h.update(seq.to_string().as_bytes());
+    h.update([0u8]);
+    h.update(action.as_bytes());
+    h.update([0u8]);
+    for (k, v) in sorted {
+        h.update(k.as_bytes());
+        h.update([0u8]);
+        h.update(v.as_bytes());
+        h.update([0u8]);
+    }
+    let digest = h.finalize();
+    let mut hex = String::with_capacity(64);
+    for b in digest {
+        use std::fmt::Write as _;
+        let _ = write!(hex, "{b:02x}");
+    }
+    hex
+}
+
+/// RECORD a step's committed side-effect under its stable idempotency key (the
+/// engine calls this immediately after a side-effect step's executor returns `Ok`,
+/// BEFORE `complete_step`). The `idem_key` PRIMARY KEY makes a re-record of the SAME
+/// effect a benign no-op (`INSERT OR IGNORE`) rather than a uniqueness error, so a
+/// re-drive that DID run the effect again (it was not skipped) does not fail closed
+/// on the record. Returns `true` if a NEW row was written, `false` if the key was
+/// already present (already-committed).
+#[allow(clippy::too_many_arguments)]
+pub fn record_committed_effect(
+    conn: &Connection,
+    idem_key: &str,
+    run_id: &str,
+    step_id: &str,
+    seq: i64,
+    action: &str,
+    receipt_summary: &str,
+    receipt_content: Option<&str>,
+    committed_at: i64,
+) -> Result<bool> {
+    let rows = conn.execute(
+        "INSERT OR IGNORE INTO workflow_step_effect
+            (idem_key, run_id, step_id, seq, action, receipt_summary, receipt_content, committed_at)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+        params![
+            idem_key,
+            run_id,
+            step_id,
+            seq,
+            action,
+            receipt_summary,
+            receipt_content,
+            committed_at
+        ],
+    )?;
+    Ok(rows == 1)
+}
+
+/// READ a committed effect by its stable idempotency key, or `None` if no effect was
+/// ever committed under that key. The engine consults this BEFORE dispatching a
+/// side-effect step on a re-drive: a `Some` means the SAME effect already committed
+/// (skip the executor, reuse the recorded receipt); a `None` means it never committed
+/// (dispatch through the gate). Never writes.
+pub fn committed_effect(conn: &Connection, idem_key: &str) -> Result<Option<CommittedEffect>> {
+    conn.query_row(
+        "SELECT idem_key, run_id, step_id, seq, action, receipt_summary, receipt_content, committed_at
+           FROM workflow_step_effect WHERE idem_key = ?1",
+        [idem_key],
+        |r| {
+            Ok(CommittedEffect {
+                idem_key: r.get(0)?,
+                run_id: r.get(1)?,
+                step_id: r.get(2)?,
+                seq: r.get(3)?,
+                action: r.get(4)?,
+                receipt_summary: r.get(5)?,
+                receipt_content: r.get(6)?,
+                committed_at: r.get(7)?,
+            })
+        },
+    )
+    .optional()
+    .map_err(StorageError::from)
 }

--- a/rust-core/crates/friday-storage/tests/migration.rs
+++ b/rust-core/crates/friday-storage/tests/migration.rs
@@ -475,6 +475,87 @@ fn forward_migration_v26_to_v27_adds_run_control_columns_and_preserves_v26_rows(
 }
 
 #[test]
+fn forward_migration_v28_to_v29_adds_step_effect_table_and_preserves_v28_rows() {
+    // A5 additive migration v29: ONE new Hub-only table `workflow_step_effect` (the
+    // per-step-effect idempotency ledger). This is the NEW-TABLE migration pattern
+    // (like m0026 system_intent / m0005 agent_run), NOT an ALTER — so it touches no
+    // existing table. A fresh v28 DB must NOT have the table; a v28 row seeded in a
+    // pre-existing table (workflow_step) must survive the forward migration untouched;
+    // and after reopen the schema reaches the current max version with the new table
+    // present + usable through the typed API.
+    use friday_storage::workflow;
+
+    let p = temp_db_path("wf-step-effect-mig");
+    {
+        let mut migs = hub_migrations();
+        migs.retain(|m| m.version <= 28);
+        let db = Db::open(&p, Profile::Hub, &migs, "v28").unwrap();
+        assert_eq!(db.version().unwrap(), 28);
+        // The table must not exist before v29.
+        assert!(
+            db.conn()
+                .prepare("SELECT 1 FROM workflow_step_effect LIMIT 1")
+                .is_err(),
+            "workflow_step_effect must not exist before v29"
+        );
+        // Seed a run + step (a pre-existing table) to prove the additive migration
+        // touches nothing.
+        workflow::create_run(db.conn(), "r-pre-v29", "ship", 10).unwrap();
+        workflow::add_step(db.conn(), "r-pre-v29:s0", "r-pre-v29", 0, true, 10).unwrap();
+    }
+    // Reopen with the full set -> forward-migrate to v29 (the additive CREATE TABLE).
+    let db = Db::open_hub(&p).unwrap();
+    assert_eq!(db.version().unwrap(), hub_max_version());
+    // The pre-existing v28 rows survived untouched.
+    assert_eq!(
+        db.count("workflow_run").unwrap(),
+        1,
+        "pre-v29 run row survived the migration"
+    );
+    assert_eq!(
+        db.count("workflow_step").unwrap(),
+        1,
+        "pre-v29 step survived"
+    );
+    // The new table is present and STARTS EMPTY.
+    assert_eq!(
+        db.count("workflow_step_effect").unwrap(),
+        0,
+        "new table starts empty"
+    );
+    // The typed idempotency API works against the migrated DB end-to-end: record a
+    // committed effect under its stable key and read it back.
+    let key = workflow::step_effect_idem_key(
+        "r-pre-v29",
+        0,
+        "write_file",
+        &[("path".to_string(), "o".to_string())],
+    );
+    assert!(workflow::committed_effect(db.conn(), &key)
+        .unwrap()
+        .is_none());
+    workflow::record_committed_effect(
+        db.conn(),
+        &key,
+        "r-pre-v29",
+        "r-pre-v29:s0",
+        0,
+        "write_file",
+        "committed on migrated db",
+        None,
+        11,
+    )
+    .unwrap();
+    assert_eq!(
+        workflow::committed_effect(db.conn(), &key)
+            .unwrap()
+            .unwrap()
+            .receipt_summary,
+        "committed on migrated db",
+    );
+}
+
+#[test]
 fn reopen_is_idempotent_and_preserves_rows() {
     let p = temp_db_path("seeded");
     {

--- a/rust-core/crates/friday-storage/tests/workflow_persist.rs
+++ b/rust-core/crates/friday-storage/tests/workflow_persist.rs
@@ -489,3 +489,191 @@ fn reopen_step_accepts_real_engine_frontier_states_and_refuses_verified() {
     // Unknown step -> fail-closed.
     assert!(workflow::reopen_failed_step(db.conn(), "ghost", 8).is_err());
 }
+
+// --- A5: per-step-effect idempotency ledger (m0029) --------------------------
+
+#[test]
+fn step_effect_idem_key_is_stable_and_param_order_insensitive_but_effect_sensitive() {
+    // The key must be STABLE across attempts (it excludes the attempt) so a retry of
+    // the SAME effect matches its prior commit, INSENSITIVE to param ORDER (two
+    // semantically-identical effects share a key), and SENSITIVE to the action/params
+    // (a DIFFERENT effect computes a different key, so a skip can never apply the
+    // wrong effect).
+    let p1 = vec![
+        ("path".to_string(), "out.txt".to_string()),
+        ("content".to_string(), "hello".to_string()),
+    ];
+    let p1_reordered = vec![
+        ("content".to_string(), "hello".to_string()),
+        ("path".to_string(), "out.txt".to_string()),
+    ];
+    let base = workflow::step_effect_idem_key("r1", 2, "write_file", &p1);
+
+    // Stable: same inputs -> same key (no attempt in the key).
+    assert_eq!(
+        base,
+        workflow::step_effect_idem_key("r1", 2, "write_file", &p1)
+    );
+    // Param-order-insensitive: reordering the same params -> same key.
+    assert_eq!(
+        base,
+        workflow::step_effect_idem_key("r1", 2, "write_file", &p1_reordered)
+    );
+
+    // Effect-sensitive: a changed action, a changed param value, a changed seq, or a
+    // changed run each produce a DIFFERENT key.
+    assert_ne!(
+        base,
+        workflow::step_effect_idem_key("r1", 2, "delete_file", &p1),
+        "a different action must miss"
+    );
+    let p_changed = vec![
+        ("path".to_string(), "out.txt".to_string()),
+        ("content".to_string(), "HELLO".to_string()),
+    ];
+    assert_ne!(
+        base,
+        workflow::step_effect_idem_key("r1", 2, "write_file", &p_changed),
+        "a different param value (changed effect at the same seq) must miss"
+    );
+    assert_ne!(
+        base,
+        workflow::step_effect_idem_key("r1", 3, "write_file", &p1),
+        "a different seq must miss"
+    );
+    assert_ne!(
+        base,
+        workflow::step_effect_idem_key("r2", 2, "write_file", &p1),
+        "a different run must miss"
+    );
+    // 64-hex sha256.
+    assert_eq!(base.len(), 64);
+    assert!(base.chars().all(|c| c.is_ascii_hexdigit()));
+}
+
+#[test]
+fn record_and_read_committed_effect_round_trips_and_re_record_is_a_no_op() {
+    let p = temp_db_path("wf-effect-rt");
+    let db = Db::open_hub(&p).unwrap();
+    let key = workflow::step_effect_idem_key(
+        "r1",
+        1,
+        "write_file",
+        &[("path".to_string(), "o".to_string())],
+    );
+    // No effect recorded yet.
+    assert_eq!(workflow::committed_effect(db.conn(), &key).unwrap(), None);
+
+    // First record returns true (a new row); reads back faithfully.
+    let wrote = workflow::record_committed_effect(
+        db.conn(),
+        &key,
+        "r1",
+        "r1:s1",
+        1,
+        "write_file",
+        "wrote out.txt",
+        Some("body-ref://abc"),
+        100,
+    )
+    .unwrap();
+    assert!(wrote, "first record writes a new row");
+    let got = workflow::committed_effect(db.conn(), &key)
+        .unwrap()
+        .unwrap();
+    assert_eq!(got.idem_key, key);
+    assert_eq!(got.run_id, "r1");
+    assert_eq!(got.step_id, "r1:s1");
+    assert_eq!(got.seq, 1);
+    assert_eq!(got.action, "write_file");
+    assert_eq!(got.receipt_summary, "wrote out.txt");
+    assert_eq!(got.receipt_content.as_deref(), Some("body-ref://abc"));
+    assert_eq!(got.committed_at, 100);
+
+    // A re-record of the SAME key is a benign no-op (INSERT OR IGNORE) returning false
+    // and NOT overwriting the original commit (it is the same effect).
+    let wrote_again = workflow::record_committed_effect(
+        db.conn(),
+        &key,
+        "r1",
+        "r1:s1",
+        1,
+        "write_file",
+        "DIFFERENT summary that must not clobber",
+        None,
+        200,
+    )
+    .unwrap();
+    assert!(!wrote_again, "re-record of the same key is a no-op");
+    let got2 = workflow::committed_effect(db.conn(), &key)
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        got2.receipt_summary, "wrote out.txt",
+        "the original committed receipt is preserved, never clobbered"
+    );
+    assert_eq!(got2.committed_at, 100);
+}
+
+#[test]
+fn committed_effect_survives_reopen_failed_step() {
+    // THE structural property the A5 design depends on: the idempotency ledger is a
+    // SEPARATE table, so a committed effect SURVIVES `reopen_failed_step` (which sets
+    // the step Pending, bumps attempt, clears the step's evidence_ref). If the ledger
+    // were columns on workflow_step, reopen would have to deliberately avoid them; a
+    // separate table survives by construction.
+    let p = temp_db_path("wf-effect-survives-reopen");
+    let db = Db::open_hub(&p).unwrap();
+    workflow::create_run(db.conn(), "r1", "ship", 1).unwrap();
+    workflow::add_step(db.conn(), "r1:s0", "r1", 0, true, 1).unwrap();
+    let params = [("path".to_string(), "o".to_string())];
+    let key = workflow::step_effect_idem_key("r1", 0, "write_file", &params);
+    workflow::record_committed_effect(
+        db.conn(),
+        &key,
+        "r1",
+        "r1:s0",
+        0,
+        "write_file",
+        "committed",
+        None,
+        2,
+    )
+    .unwrap();
+    // Put the step in a non-Verified frontier state, then reopen it (a retry would).
+    workflow::complete_step(db.conn(), "r1:s0", None, false, 3).unwrap(); // -> ProofPending
+    workflow::reopen_failed_step(db.conn(), "r1:s0", 4).unwrap();
+    assert_eq!(
+        workflow::step_attempt(db.conn(), "r1:s0").unwrap(),
+        Some(2),
+        "reopen bumped the attempt"
+    );
+    // The committed effect is STILL recorded under the SAME (attempt-free) key.
+    let got = workflow::committed_effect(db.conn(), &key).unwrap();
+    assert!(
+        got.is_some(),
+        "the committed effect survives reopen (attempt-free key, separate table)"
+    );
+    assert_eq!(got.unwrap().receipt_summary, "committed");
+}
+
+#[test]
+fn step_has_side_effect_reads_the_persisted_flag() {
+    let p = temp_db_path("wf-has-side-effect");
+    let db = Db::open_hub(&p).unwrap();
+    workflow::create_run(db.conn(), "r1", "x", 1).unwrap();
+    workflow::add_step(db.conn(), "r1:s0", "r1", 0, false, 1).unwrap(); // read-only
+    workflow::add_step(db.conn(), "r1:s1", "r1", 1, true, 1).unwrap(); // side-effect
+    assert_eq!(
+        workflow::step_has_side_effect(db.conn(), "r1:s0").unwrap(),
+        Some(false)
+    );
+    assert_eq!(
+        workflow::step_has_side_effect(db.conn(), "r1:s1").unwrap(),
+        Some(true)
+    );
+    assert_eq!(
+        workflow::step_has_side_effect(db.conn(), "ghost").unwrap(),
+        None
+    );
+}


### PR DESCRIPTION
## A5 — per-step-effect idempotency on the workflow retry frontier

Guards the Rust workflow retry frontier (`friday-hub` `workflow_run_control` retry path → `workflow_exec::retry_workflow`) so an **already-committed side-effect is not re-run** on a retry that re-drives the failure frontier. Each side-effect step's committed effect is recorded under a **stable per-effect idempotency key** and a re-drive of the **same** effect is skipped (the executor is not re-called).

### Design
- **Key** = `sha256(run_id | seq | action | sorted-params)` — **excludes** the retry `attempt` (so a retry of the SAME effect matches its prior commit) and **includes** the action+params digest (so a CHANGED effect at the same seq computes a different key and naturally **misses** — never replays the wrong effect). Param-order-insensitive.
- **Storage (m0029, additive, non-destructive; max was 28):** a NEW Hub-only table `workflow_step_effect` keyed on the `idem_key` PK. Registered in `HUB_ONLY_TABLES`. It is a **separate** table (not columns on `workflow_step`) so the record **survives `reopen_failed_step`** (which sets the step `Pending` / bumps `attempt` / clears `evidence_ref`) **by construction**. New primitives: `step_effect_idem_key`, `record_committed_effect` (`INSERT OR IGNORE` → no-op on re-record), `committed_effect`, `step_has_side_effect`.
- **Engine:** `dispatch_step_idempotent` **wraps** the shared `gate_dispatch` chokepoint (gate/crypto code **untouched** — classify→authorize→execute-only-on-Allow and the executor-called-exactly-once invariant are unchanged): for a side-effect step it checks the ledger (skip → replay the recorded receipt, executor not called) and records on commit. A **read-only step is never skipped/recorded** (re-running a read is correct, not a double-apply hazard). Wired into all three dispatch sites — `advance_from` (auto-advance), `resume_workflow`, `retry_workflow`.

### HONEST SCOPE (what this is, and is not)
In today's **linear, synchronous** engine a committed side-effect step is `complete_step`d **`Verified`**, and the retry frontier already **SKIPS** `Verified` steps (`reopen_failed_step` refuses them). So the **SKIP branch is REDUNDANT** with that Verified-skip and is **not reached** by normal `run_workflow`/`retry_workflow` execution — it is **DARK defense-in-depth + forward-safety** for a future model where commit and `Verified` can diverge (a DAG frontier with a committed sibling, or an async/crash run). The **always-active, genuinely-new behavior is the RECORD** (committed-effect provenance on every committed side-effect). The load-bearing skip test therefore uses an **injected** ledger row + a NON-`Verified` step and is labelled a **guard-logic test, not a regression test of a prevented live double-run**.

This does **NOT** make the current engine exactly-once against a **partially-applied EXTERNAL tool** — that needs the key **CARRIED into `ToolExecutor::execute`** so a key-aware tool dedupes (touches the gate/executor seam, deliberately untouched here).

**Predicate caveat (forward-only, documented not narrowed):** the skip/record predicate is the persisted `has_side_effect` flag = "requires evidence to verify", which the engine sets `true` for sensitive-read and `force_checkpoint` steps too. In the forward model those would be **replayed from a recorded receipt rather than re-read** (staleness, not double-apply — benign for a read); inert today (a committed read is `Verified`, frontier skips it). Same forward-only note: a skipped step is still counted in `executed_steps`. Refined when the executor-carried key lands.

### Tests (real, per-behavior)
- key stability / param-order-insensitivity / effect-sensitivity (action/value/seq/run each change the key)
- `record`/`read` round-trip + no-op re-record (PK)
- **committed effect survives `reopen_failed_step`** (the structural property)
- m0029 **v28→v29** migration (new table; preserves v28 rows; typed API on the migrated DB)
- schema_profile: hub HAS / phone OMITS `workflow_step_effect`
- the **always-active RECORD** on a committed side-effect (read-only NOT recorded)
- the **load-bearing GUARD-LOGIC skip test** (non-`Verified` + injected ledger → executor NOT re-called) + its **NEGATIVE TWIN** (no ledger → executor re-called) — isolating the key from Verified-skip
- end-to-end **partial-success retry**: re-drives ONLY the failed frontier; the committed earlier step is not double-run

`cargo test --workspace` green; `cargo clippy --workspace --all-targets -- -D warnings` clean; `cargo fmt` (pinned 1.95.0) applied.

### DARK + DEPLOY-GO-gated
No production route, no live wiring, no deploy, no scheduler/trigger; no TS runtime file changed. Purely additive over the existing dark Rust workflow substrate.

### What remains (deferred sub-ACs)
- **Carry the key into the executor** (`ToolExecutor::execute`) so a key-aware tool dedupes a partially-applied external effect — the only piece that prevents the *new* class of double-run. Touches the gate/executor seam; an **operator decision** (defer vs authorize).
- Refine the skip predicate from `has_side_effect` to "mutates external state" once the carried key lands (so a sensitive-read is never replay-instead-of-reread in the forward model).
- Selective-node / DAG retry (separate deferred sub-AC, pre-existing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)