### PR TITLE
fix(ns-hardening): flag-gate dot-join collision fix DEFAULT-OFF + DUAL-READ (supersedes #661)

### DIFF
--- a/rust-core/crates/friday-hub/src/session_namespace.rs
+++ b/rust-core/crates/friday-hub/src/session_namespace.rs
@@ -7,11 +7,26 @@
 //! user's memory is isolated PER (account, channel) instead of being shared across every
 //! channel for the same user.
 //!
-//! Format (byte-identical to the TS — including the Unicode-aware lowercasing; see the
-//! normalization note on the dot-join residual that is SHARED with the TS oracle):
+//! Format (byte-identical to the TS — including the Unicode-aware lowercasing; the dot-join
+//! collision hardening is FLAG-GATED + DEFAULT-OFF + DUAL-READ — see the normalization note
+//! on [`is_kept`] and the dual-read note on
+//! [`resolve_session_memory_namespace_candidates`]):
 //! ```text
 //! tenant.<accountId>.channel.<channel>.user.<normalizedUserId>.shared
 //! ```
+//!
+//! ## Collision hardening (F5.5): FLAG-GATED, DEFAULT-OFF, DUAL-READ
+//! Dropping `.` from the segment keep-set closes the dot-join cross-tuple collision, but a
+//! naive deploy of that change RE-SCOPES (orphans) any existing memory whose segment
+//! legitimately contained a `.` (an email-shaped userId, a dotted account/channel) — a
+//! one-way data downgrade. So the hardening is gated behind the DEFAULT-OFF env flag
+//! [`NS_HARDENING_ENV_FLAG`]:
+//! - OFF (default): the keep-set KEEPS `.` exactly as before — every namespace is
+//!   BYTE-IDENTICAL to the legacy derivation. Zero re-scope on deploy.
+//! - ON: the WRITE/primary namespace is hardened, AND the READ path dual-reads BOTH the
+//!   hardened and legacy namespaces ([`resolve_session_memory_namespace_candidates`]), so
+//!   nothing written under the legacy namespace is lost. There is NO destructive re-key.
+//! PARITY: the TS half reads the SAME flag name under the SAME `"1"` semantics.
 //!
 //! ## How this binds to the Rust recall axis
 //! The Rust memory recall axis is a single `principal_id` string
@@ -63,9 +78,15 @@
 //! (legacy/unset) enables NEITHER fallback (fail-closed by construction).
 //!
 //! Truth label: byte-identical namespace + normalization port; DM-chatId + subagent
-//! parent-walk userId fallbacks ported (column-modeled). This improves PARITY only — it
-//! does NOT flip any TS-retirement state; the TS extraction path stays LIVE. PROOF-ONLY —
-//! NOT a v1 GO.
+//! parent-walk userId fallbacks ported (column-modeled). The F5.5 collision hardening is
+//! FLAG-GATED (DEFAULT-OFF) + DUAL-READ here too, byte-identical to the TS under the same
+//! flag. This improves PARITY only — it does NOT flip any TS-retirement state; the TS
+//! extraction path stays LIVE. The Rust recall PRINCIPAL is currently the configured
+//! `--owner` allowlist entry (`RunPolicy::principal_id`), NOT a session-derived namespace,
+//! so the dual-read recall helper ([`friday_storage::memory::recall_confirmed_multi`]) +
+//! candidate-list builder are wired as the GATED MECHANISM; the live recall-principal
+//! re-wiring to consult the candidate list is DARK-REMAINING (see the PR body). DARK +
+//! DEPLOY-GO-gated. PROOF-ONLY — NOT a v1 GO.
 
 use friday_storage::agent_session::SessionOwner;
 use friday_storage::StorageError;
@@ -86,6 +107,19 @@ const DEFAULT_CHANNEL: &str = "unknown";
 
 /// The empty-result fallback of [`normalize_namespace_segment`] (TS: `"default"`).
 const NORMALIZE_EMPTY_FALLBACK: &str = "default";
+
+/// The DEFAULT-OFF env flag governing the F5.5 dot-join collision hardening. ON only when
+/// the value is exactly `"1"` (after trimming). UNSET / empty / `"0"` / any other value ⇒
+/// OFF (the unchanged legacy derivation). Narrow + explicit so the hardening cannot be
+/// enabled by accident — same convention as `FRIDAY_CLAUDE_ROUTE_ENABLED`.
+///
+/// PARITY: the TS half (`FRIDAY_NS_HARDENING_ENV_FLAG`) reads the SAME name + semantics.
+pub const NS_HARDENING_ENV_FLAG: &str = "FRIDAY_NS_HARDENING_ENABLED";
+
+/// Read the DEFAULT-OFF [`NS_HARDENING_ENV_FLAG`].
+pub fn ns_hardening_enabled() -> bool {
+    matches!(std::env::var(NS_HARDENING_ENV_FLAG), Ok(v) if v.trim() == "1")
+}
 
 /// A typed namespace-resolution error. The single variant mirrors the TS
 /// `FRIDAY_SESSION_ERROR_CODES.MEMORY_NAMESPACE_UNRESOLVABLE`.
@@ -109,8 +143,12 @@ impl std::fmt::Display for NamespaceError {
 
 impl std::error::Error for NamespaceError {}
 
-/// Resolve the memory namespace (the composite store scope) for a session from its OWNER
-/// axes, mirroring the TS `resolveFridaySessionMemoryNamespace` for the DIRECT-userId case.
+/// Resolve the PRIMARY (write) memory namespace for a session from its OWNER axes,
+/// mirroring the TS `resolveFridaySessionMemoryNamespace` for the DIRECT-userId case. The
+/// F5.5 collision hardening is governed by the DEFAULT-OFF [`NS_HARDENING_ENV_FLAG`]: when
+/// OFF this is byte-identical to the legacy derivation. The READ path MUST use
+/// [`resolve_session_memory_namespace_candidates`] (dual-read) so a flag-on flip never
+/// orphans legacy-written memory.
 ///
 /// * `account_id`: falsy (`None` or empty) → `"default"`, then normalized.
 /// * `channel`: falsy (`None` or empty) → `"unknown"`, then normalized.
@@ -121,6 +159,19 @@ pub fn resolve_session_memory_namespace(
     account_id: Option<&str>,
     channel: Option<&str>,
     user_id: Option<&str>,
+) -> Result<String, NamespaceError> {
+    resolve_session_memory_namespace_with(account_id, channel, user_id, ns_hardening_enabled())
+}
+
+/// The pure derivation under an EXPLICIT `hardened` mode (the flag-reading wrappers above
+/// delegate here). `hardened == false` is the legacy keep-set (`.` kept); `hardened == true`
+/// drops `.` from every segment (the collision fix). Same fail-closed / falsy-default
+/// semantics as [`resolve_session_memory_namespace`].
+pub fn resolve_session_memory_namespace_with(
+    account_id: Option<&str>,
+    channel: Option<&str>,
+    user_id: Option<&str>,
+    hardened: bool,
 ) -> Result<String, NamespaceError> {
     // FAIL CLOSED when no userId (TS: `if (!userId) throw MEMORY_NAMESPACE_UNRESOLVABLE`).
     // JS `!userId` is falsy on `undefined` AND the empty string, so an empty `user_id`
@@ -136,9 +187,9 @@ pub fn resolve_session_memory_namespace(
     let account = falsy_or(account_id, DEFAULT_ACCOUNT_ID);
     let chan = falsy_or(channel, DEFAULT_CHANNEL);
 
-    let normalized_account = normalize_namespace_segment(account);
-    let normalized_channel = normalize_namespace_segment(chan);
-    let normalized_user = normalize_namespace_segment(user_id);
+    let normalized_account = normalize_namespace_segment_with(account, hardened);
+    let normalized_channel = normalize_namespace_segment_with(chan, hardened);
+    let normalized_user = normalize_namespace_segment_with(user_id, hardened);
 
     Ok([
         TENANT_SEGMENT,
@@ -150,6 +201,57 @@ pub fn resolve_session_memory_namespace(
         SHARED_SEGMENT,
     ]
     .join("."))
+}
+
+/// Resolve the ORDERED, DEDUPED set of namespaces to consult on the READ (recall) path —
+/// the non-destructive substitute for re-keying existing memory.
+///
+/// - Hardening OFF (default): `[legacy]` — a SINGLE namespace, byte-identical to today.
+/// - Hardening ON: `[hardened, legacy]` deduped. The hardened namespace is the new write
+///   target; the legacy namespace is consulted too so memory written before the flip is
+///   STILL recalled.
+///
+/// DEDUP-COLLAPSE: when no segment contains a `.`, the hardened and legacy derivations are
+/// IDENTICAL, so the list collapses to ONE entry even with the flag ON — the common
+/// (non-dotted) case has zero extra reads.
+///
+/// HONEST scope (mirrors the TS): the LEGACY namespace IS the colliding string, so
+/// dual-reading it re-reads the pre-hardening collision bucket. The hardening closes the
+/// cross-tuple collision for NEW (hardened) WRITES only; legacy data retains its pre-F5.5
+/// collision semantics (the same accepted behavior under the single-owner v1 threat model).
+/// Dual-read is strictly ≥ the pre-hardening state — it can never lose data — but it does
+/// NOT retroactively disambiguate already-colliding legacy rows (structurally impossible:
+/// one shared bucket cannot be split). Fails closed (no userId) exactly like the resolver.
+pub fn resolve_session_memory_namespace_candidates(
+    account_id: Option<&str>,
+    channel: Option<&str>,
+    user_id: Option<&str>,
+) -> Result<Vec<String>, NamespaceError> {
+    candidates_for(account_id, channel, user_id, ns_hardening_enabled())
+}
+
+/// The pure dual-read list construction under an EXPLICIT `hardened` mode (the public
+/// wrapper reads the flag and delegates here). Race-free + directly testable: `hardened ==
+/// false` ⇒ `[legacy]`; `hardened == true` ⇒ dedup `[hardened, legacy]` (collapses to one
+/// when no segment carries a `.`). Same fail-closed (no userId) rule as the resolver.
+fn candidates_for(
+    account_id: Option<&str>,
+    channel: Option<&str>,
+    user_id: Option<&str>,
+    hardened: bool,
+) -> Result<Vec<String>, NamespaceError> {
+    let legacy = resolve_session_memory_namespace_with(account_id, channel, user_id, false)?;
+    if !hardened {
+        return Ok(vec![legacy]);
+    }
+    let hardened_ns = resolve_session_memory_namespace_with(account_id, channel, user_id, true)?;
+    // Ordered (hardened first) + deduped: when both derivations agree (no dotted segment)
+    // the list collapses to a single entry.
+    if hardened_ns == legacy {
+        Ok(vec![hardened_ns])
+    } else {
+        Ok(vec![hardened_ns, legacy])
+    }
 }
 
 /// Resolve the EFFECTIVE userId for a session — the faithful port of the TS
@@ -281,7 +383,7 @@ fn falsy_or<'a>(value: Option<&'a str>, fallback: &'a str) -> &'a str {
     }
 }
 
-/// Byte-identical port of the TS `normalizeNamespaceSegment`:
+/// Byte-identical port of the TS `normalizeNamespaceSegment` (legacy, flag-OFF default):
 /// ```js
 /// value.toLowerCase()
 ///   .replace(/[^a-z0-9._-]/g, "-")
@@ -289,37 +391,40 @@ fn falsy_or<'a>(value: Option<&'a str>, fallback: &'a str) -> &'a str {
 ///   .replace(/^-|-$/g, "");
 /// // empty result -> "default"
 /// ```
-///
-/// We implement it with explicit char filtering (no `regex` dependency needed) and verify
-/// equivalence with the ported TS test vectors (`tests` below).
+/// This is the flag-aware entrypoint: it reads [`ns_hardening_enabled`] and delegates to
+/// [`normalize_namespace_segment_with`]. Default-OFF ⇒ legacy keep-set ⇒ byte-identical to
+/// the pre-hardening derivation.
+pub fn normalize_namespace_segment(value: &str) -> String {
+    normalize_namespace_segment_with(value, ns_hardening_enabled())
+}
+
+/// The pure segment normalizer under an EXPLICIT `hardened` mode. The keep-set is the only
+/// thing that depends on `hardened` (see [`is_kept`]):
+/// - `hardened == false` (LEGACY): keep-set `[a-z0-9._-]` — `.` KEPT (byte-identical to the
+///   TS legacy oracle `/[^a-z0-9._-]/g`).
+/// - `hardened == true`: keep-set `[a-z0-9_-]` — `.` maps to `-` (the TS hardened oracle
+///   `/[^a-z0-9_-]/g`). `.` is the SEGMENT JOINER, so dropping it makes the composite split
+///   into exactly the seven fixed-position parts → injective over normalized tuples.
 ///
 /// LOWERCASING (byte-parity with JS `String.toLowerCase()`): Step 1 uses Rust
 /// `str::to_lowercase()`, which — like JS `.toLowerCase()` — implements the Unicode
 /// DEFAULT case mapping (NOT plain ASCII lowering). So a non-ASCII char that JS lowercases
 /// INTO a kept ASCII char also lowers here BEFORE the keep-set filter, and is therefore
-/// kept identically: e.g. the Kelvin sign `K` (U+212A) → `k`, which is in `[a-z0-9._-]` and
-/// survives in BOTH impls (closing the earlier `to_ascii_lowercase` divergence where Rust
-/// would have mapped it to `-` and merged it with a plain `user` id — an isolation MERGE in
-/// the dangerous direction). Any char that lowers to something OUTSIDE the keep-set (most
-/// non-ASCII, e.g. `é`, CJK) maps to `-` in both. Both use Unicode default case mapping, so
-/// they agree on the single-codepoint mappings relevant to the keep-set; this is now a
-/// faithful port, not a documented gap.
-///
-/// Residual (genuinely shared with the TS, not a Rust divergence): the dot is in the
-/// keep-set and segments are `.`-joined, so an id literally containing the joiner/segment
-/// words could in principle collide with a different (account, channel, user) triple. This
-/// is byte-faithful to the TS oracle (same unescaped join + same keep-set), so it is NOT a
-/// Rust regression; closing it is a SHARED TS+Rust hardening follow-on (segment-escape /
-/// dot-reject), out of scope for this parity slice.
-pub fn normalize_namespace_segment(value: &str) -> String {
-    // Step 1: toLowerCase() then replace each char NOT in [a-z0-9._-] with '-'. Use the
+/// kept identically: e.g. the Kelvin sign `K` (U+212A) → `k`, which survives in BOTH impls
+/// (closing the earlier `to_ascii_lowercase` divergence where Rust would have mapped it to
+/// `-` and merged it with a plain `user` id — an isolation MERGE in the dangerous
+/// direction). Any char that lowers to something OUTSIDE the keep-set (most non-ASCII, e.g.
+/// `é`, CJK) maps to `-` in both. Both use Unicode default case mapping, so they agree on
+/// the single-codepoint mappings relevant to the keep-set.
+pub fn normalize_namespace_segment_with(value: &str, hardened: bool) -> String {
+    // Step 1: toLowerCase() then replace each char NOT in the keep-set with '-'. Use the
     // Unicode-aware `to_lowercase` (matches JS `.toLowerCase()`), NOT `to_ascii_lowercase`,
     // so a non-ASCII char JS folds into a kept ASCII char (e.g. Kelvin U+212A -> 'k') is
     // kept identically here instead of collapsing to '-'.
     let lowered = value.to_lowercase();
     let mut mapped = String::with_capacity(lowered.len());
     for ch in lowered.chars() {
-        if is_kept(ch) {
+        if is_kept(ch, hardened) {
             mapped.push(ch);
         } else {
             // Any character outside the keep-set (including multi-byte/non-ASCII) becomes a
@@ -357,10 +462,21 @@ pub fn normalize_namespace_segment(value: &str) -> String {
     }
 }
 
-/// The TS keep-set `[a-z0-9._-]` (applied AFTER `toLowerCase`, so uppercase A-Z is already
-/// lowered and never reaches here as uppercase).
-fn is_kept(ch: char) -> bool {
-    ch.is_ascii_lowercase() || ch.is_ascii_digit() || ch == '.' || ch == '_' || ch == '-'
+/// The TS keep-set (applied AFTER `toLowerCase`, so uppercase A-Z is already lowered and
+/// never reaches here as uppercase). FLAG-GATED on `hardened`:
+/// - `hardened == false` (LEGACY, default): `[a-z0-9._-]` — `.` is KEPT (byte-identical to
+///   the TS legacy oracle `/[^a-z0-9._-]/g`).
+/// - `hardened == true` (F5.5): `[a-z0-9_-]` — the literal `.` is DROPPED (maps to `-`).
+///   `.` is the SEGMENT JOINER used by [`resolve_session_memory_namespace`] (`.join(".")`)
+///   and the composite is the memory `principal_id` SCOPE; stripping `.` from every segment
+///   makes the composite split into exactly the seven fixed-position parts → a userId
+///   literally containing `.` can no longer forge a different tuple's split (the
+///   CROSS-POSITION collision). Byte-identical to the TS hardened oracle `/[^a-z0-9_-]/g`;
+///   the two MUST stay in lockstep under the same flag.
+fn is_kept(ch: char, hardened: bool) -> bool {
+    let base = ch.is_ascii_lowercase() || ch.is_ascii_digit() || ch == '_' || ch == '-';
+    // Legacy keeps `.`; hardened drops it.
+    base || (!hardened && ch == '.')
 }
 
 #[cfg(test)]
@@ -431,7 +547,13 @@ mod tests {
 
     #[test]
     fn replaces_special_characters_in_user_id() {
-        // TS: "user@example.com" -> "user-example.com" ('@' -> '-', dots PRESERVED).
+        // FLAG-OFF (default): "user@example.com" -> "user-example.com" ('@' -> '-', dots
+        // PRESERVED). The hardening env var is unset in the test process, so the legacy
+        // keep-set applies — byte-identical to the pre-hardening derivation (no re-scope).
+        assert!(
+            !ns_hardening_enabled(),
+            "FRIDAY_NS_HARDENING_ENABLED must be unset/off in the test env"
+        );
         let ns = resolve_session_memory_namespace(
             Some("default"),
             Some("discord"),
@@ -478,6 +600,9 @@ mod tests {
 
     #[test]
     fn normalize_collapses_runs_and_trims_edges_and_empty_to_default() {
+        // FLAG-OFF (legacy) keep-set — the env var is unset in the test process, so the
+        // bare entrypoint resolves to the legacy derivation.
+        assert!(!ns_hardening_enabled());
         assert_eq!(normalize_namespace_segment("User-ABC"), "user-abc");
         assert_eq!(normalize_namespace_segment("Ops Team"), "ops-team");
         // Leading/trailing special chars are mapped to '-' then trimmed.
@@ -486,9 +611,9 @@ mod tests {
         assert_eq!(normalize_namespace_segment(""), "default");
         // Runs of disallowed chars collapse to ONE '-'.
         assert_eq!(normalize_namespace_segment("a   b---c"), "a-b-c");
-        // Dots, underscores, hyphens are KEPT.
+        // LEGACY: dots, underscores, hyphens are KEPT.
         assert_eq!(normalize_namespace_segment("a.b_c-d"), "a.b_c-d");
-        // user@example.com (the segment-level vector).
+        // user@example.com (the segment-level vector), legacy: dot PRESERVED.
         assert_eq!(
             normalize_namespace_segment("user@example.com"),
             "user-example.com"
@@ -496,6 +621,31 @@ mod tests {
         // Non-ASCII is outside the keep-set and becomes '-' (then collapses/trims).
         assert_eq!(normalize_namespace_segment("héllo"), "h-llo");
         assert_eq!(normalize_namespace_segment("名前"), "default");
+    }
+
+    #[test]
+    fn normalize_hardened_drops_dot_legacy_keeps_it_pure_no_env() {
+        // The pure `_with` variant takes the mode explicitly (no env), so this is race-free
+        // and asserts BOTH keep-sets directly.
+        // LEGACY keeps '.'; underscores/hyphens kept in both.
+        assert_eq!(
+            normalize_namespace_segment_with("a.b_c-d", false),
+            "a.b_c-d"
+        );
+        assert_eq!(
+            normalize_namespace_segment_with("user@example.com", false),
+            "user-example.com"
+        );
+        // HARDENED drops '.' (maps to '-', then collapses with adjacent '-').
+        assert_eq!(normalize_namespace_segment_with("a.b_c-d", true), "a-b_c-d");
+        assert_eq!(
+            normalize_namespace_segment_with("user@example.com", true),
+            "user-example-com"
+        );
+        // A bare run of dots: legacy keeps them; hardened collapses to '-' then trims to
+        // empty -> "default".
+        assert_eq!(normalize_namespace_segment_with("...", false), "...");
+        assert_eq!(normalize_namespace_segment_with("...", true), "default");
     }
 
     #[test]
@@ -541,6 +691,158 @@ mod tests {
         let msg = NamespaceError::UnresolvableNoUserId.to_string();
         assert!(msg.contains("unresolvable"));
         assert!(!msg.contains("Bearer"));
+    }
+
+    // ─── F5.5 dot-join collision hardening (FLAG-GATED, DEFAULT-OFF) + dual-read ───
+
+    #[test]
+    fn ns_hardening_flag_is_off_by_default_and_on_only_for_exactly_1() {
+        // Mirror the `claude_route` precedent: verify the exact-`"1"` predicate WITHOUT
+        // mutating the process env, and confirm the real helper reports OFF (env unset).
+        let on = |v: &str| v.trim() == "1";
+        assert!(on("1"));
+        assert!(on(" 1 "), "trimmed \"1\" enables");
+        for off in ["", "0", "true", "yes", "01", "1 0", "enabled"] {
+            assert!(!on(off), "{off:?} must NOT enable hardening");
+        }
+        assert!(
+            !ns_hardening_enabled(),
+            "FRIDAY_NS_HARDENING_ENABLED must be unset/off in the test env"
+        );
+    }
+
+    #[test]
+    fn hardened_closes_dot_join_cross_tuple_collision_for_new_writes_pure() {
+        // Pure `_with(true)`: race-free, no env. Pre-fix both DISTINCT tuples produced
+        //   `tenant.a.channel.b.user.x.user.y.shared`  ← a real cross-tuple collision.
+        // Hardened: the embedded `.user.` maps to `-user-`, so they are DISTINCT.
+        let forged =
+            resolve_session_memory_namespace_with(Some("a"), Some("b"), Some("x.user.y"), true)
+                .unwrap();
+        let victim =
+            resolve_session_memory_namespace_with(Some("a"), Some("b.user.x"), Some("y"), true)
+                .unwrap();
+        assert_ne!(
+            forged, victim,
+            "distinct tuples must NEVER produce the same hardened namespace"
+        );
+        assert_eq!(forged, "tenant.a.channel.b.user.x-user-y.shared");
+        assert_eq!(victim, "tenant.a.channel.b-user-x.user.y.shared");
+        // Injectivity by construction: exactly 7 dot-parts, no payload segment carries a '.'.
+        let parts: Vec<&str> = forged.split('.').collect();
+        assert_eq!(parts.len(), 7);
+        assert_eq!(parts[0], "tenant");
+        assert_eq!(parts[2], "channel");
+        assert_eq!(parts[4], "user");
+        assert_eq!(parts[6], "shared");
+        for payload in [parts[1], parts[3], parts[5]] {
+            assert!(!payload.contains('.'), "segment must not carry the joiner");
+        }
+    }
+
+    #[test]
+    fn legacy_dual_read_bucket_still_collides_honest_pure() {
+        // HONEST: under the LEGACY derivation (the dual-read tail) the two distinct tuples
+        // STILL share one bucket — hardening does NOT retroactively split it (structurally
+        // impossible). Dual-read is >= the pre-hardening state, not a retroactive fix.
+        let forged_legacy =
+            resolve_session_memory_namespace_with(Some("a"), Some("b"), Some("x.user.y"), false)
+                .unwrap();
+        let victim_legacy =
+            resolve_session_memory_namespace_with(Some("a"), Some("b.user.x"), Some("y"), false)
+                .unwrap();
+        assert_eq!(forged_legacy, "tenant.a.channel.b.user.x.user.y.shared");
+        assert_eq!(forged_legacy, victim_legacy);
+    }
+
+    #[test]
+    fn candidates_flag_off_is_single_legacy_namespace() {
+        // Env unset (default) ⇒ candidates is the SINGLE legacy namespace, byte-identical to
+        // `resolve_session_memory_namespace`. No extra read.
+        assert!(!ns_hardening_enabled());
+        let candidates = resolve_session_memory_namespace_candidates(
+            Some("default"),
+            Some("discord"),
+            Some("user@example.com"),
+        )
+        .unwrap();
+        let legacy = resolve_session_memory_namespace(
+            Some("default"),
+            Some("discord"),
+            Some("user@example.com"),
+        )
+        .unwrap();
+        assert_eq!(candidates, vec![legacy.clone()]);
+        assert_eq!(
+            legacy,
+            "tenant.default.channel.discord.user.user-example.com.shared"
+        );
+    }
+
+    #[test]
+    fn candidates_flag_off_fails_closed_no_user_id() {
+        assert_eq!(
+            resolve_session_memory_namespace_candidates(Some("default"), Some("discord"), None),
+            Err(NamespaceError::UnresolvableNoUserId)
+        );
+    }
+
+    /// FLAG-ON candidate behavior tested via the PURE `candidates_for(.., hardened=true)` —
+    /// NO process-env mutation, so it is race-free in cargo's parallel test runner (the
+    /// public wrapper just reads the flag and delegates here; the flag-read mapping is
+    /// covered by `ns_hardening_flag_is_off_by_default_and_on_only_for_exactly_1`).
+    #[test]
+    fn candidates_flag_on_dual_read_and_dedup_collapse_pure() {
+        // Dotted userId ⇒ dual-read `[hardened, legacy]`. The legacy entry is byte-identical
+        // to what the FLAG-OFF write path persisted — the link that makes flag-on recall
+        // find pre-flip memory.
+        let dual = candidates_for(
+            Some("default"),
+            Some("discord"),
+            Some("user@example.com"),
+            true,
+        )
+        .unwrap();
+        assert_eq!(
+            dual,
+            vec![
+                "tenant.default.channel.discord.user.user-example-com.shared".to_string(), // hardened
+                "tenant.default.channel.discord.user.user-example.com.shared".to_string(), // legacy
+            ]
+        );
+        // The legacy (second) candidate is exactly the FLAG-OFF (legacy) derivation.
+        assert_eq!(
+            dual[1],
+            resolve_session_memory_namespace_with(
+                Some("default"),
+                Some("discord"),
+                Some("user@example.com"),
+                false
+            )
+            .unwrap()
+        );
+
+        // DEDUP-COLLAPSE: a non-dotted segment ⇒ hardened == legacy ⇒ ONE candidate (zero
+        // extra reads) even with the flag ON.
+        let collapsed =
+            candidates_for(Some("default"), Some("discord"), Some("user-abc"), true).unwrap();
+        assert_eq!(
+            collapsed,
+            vec!["tenant.default.channel.discord.user.user-abc.shared".to_string()]
+        );
+
+        // FLAG-OFF (pure) ⇒ single legacy entry, identical to the public off path.
+        let off = candidates_for(
+            Some("default"),
+            Some("discord"),
+            Some("user@example.com"),
+            false,
+        )
+        .unwrap();
+        assert_eq!(
+            off,
+            vec!["tenant.default.channel.discord.user.user-example.com.shared".to_string()]
+        );
     }
 
     // ─── resolve_effective_user_id (the TS resolveEffectiveUserId port) ───

--- a/rust-core/crates/friday-storage/src/memory.rs
+++ b/rust-core/crates/friday-storage/src/memory.rs
@@ -264,6 +264,39 @@ pub fn recall_confirmed(conn: &Connection, principal_id: &str) -> Result<Vec<Mem
     Ok(out)
 }
 
+/// DUAL-READ recall: the UNION of [`recall_confirmed`] over an ORDERED list of principals,
+/// DEDUPED by `memory_id` (first principal in the list wins for a given id). This is the
+/// data-layer half of the F5.5 namespace-hardening dual-read — the caller passes the ordered
+/// `[hardened, legacy]` namespace list (the
+/// `session_namespace::resolve_session_memory_namespace_candidates` output) so memory written
+/// under the LEGACY namespace is still recalled after the hardening flag is flipped on. There
+/// is NO destructive re-key — the legacy rows are read in place.
+///
+/// IMPORTANT — the per-principal SQL stays SINGLE-principal: each `recall_confirmed` call
+/// enforces `principal_id = ?` exactly (and its single-principal `debug_assert`), so a row
+/// owned by an unrelated principal is never returned. The UNION + dedup happen HERE, in
+/// memory, NOT in SQL — so this helper can never widen the per-principal isolation boundary.
+///
+/// Ordering: principals are consulted in order; within the merged set the first principal to
+/// own a given `memory_id` wins (so a row re-written under the hardened namespace is preferred
+/// over its lingering legacy copy when both exist). An empty list ⇒ empty result. A
+/// blank/empty principal in the list contributes nothing (same fail-closed rule as
+/// `recall_confirmed`).
+pub fn recall_confirmed_multi(conn: &Connection, principals: &[&str]) -> Result<Vec<MemoryRow>> {
+    let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+    let mut out: Vec<MemoryRow> = Vec::new();
+    for principal in principals {
+        for row in recall_confirmed(conn, principal)? {
+            // Dedup by memory_id: the FIRST principal (ordered hardened-first) to own a given
+            // id wins; a later (legacy) duplicate of the same id is dropped.
+            if seen.insert(row.memory_id.clone()) {
+                out.push(row);
+            }
+        }
+    }
+    Ok(out)
+}
+
 // --- helpers ---------------------------------------------------------------
 
 fn current_state(conn: &Connection, memory_id: &str) -> Result<Option<MemoryState>> {

--- a/rust-core/crates/friday-storage/tests/memory_persist.rs
+++ b/rust-core/crates/friday-storage/tests/memory_persist.rs
@@ -603,3 +603,102 @@ fn recall_orders_most_recently_confirmed_first_and_returns_sensitive() {
     let pii = recalled.iter().find(|m| m.memory_id == "pii").unwrap();
     assert!(pii.sensitive);
 }
+
+// ─── F5.5 dual-read recall (recall_confirmed_multi) ───
+
+#[test]
+fn recall_confirmed_multi_unions_dedups_and_preserves_single_principal_isolation() {
+    let p = temp_db_path("mem-recall-dual");
+    let db = Db::open_hub(&p).unwrap();
+
+    // The HARDENED namespace (new write target) and the LEGACY namespace (where pre-flip
+    // memory lives). A row written under the legacy namespace must still be recalled when
+    // we dual-read [hardened, legacy].
+    let hardened = "tenant.a.channel.discord.user.user-example-com.shared";
+    let legacy = "tenant.a.channel.discord.user.user-example.com.shared";
+    // A foreign principal whose memory must NEVER leak into the dual-read.
+    let foreign = "tenant.a.channel.discord.user.someone-else.shared";
+
+    // One row in EACH bucket: a new hardened-write, a pre-flip legacy-write, a foreign one.
+    memory::record_candidate(
+        db.conn(),
+        &owned_cand("h1", "hardened fact", hardened, false, 1),
+    )
+    .unwrap();
+    memory::confirm(db.conn(), "h1", 30).unwrap();
+    memory::record_candidate(
+        db.conn(),
+        &owned_cand("l1", "legacy fact", legacy, false, 2),
+    )
+    .unwrap();
+    memory::confirm(db.conn(), "l1", 20).unwrap();
+    memory::record_candidate(
+        db.conn(),
+        &owned_cand("f1", "foreign fact", foreign, false, 3),
+    )
+    .unwrap();
+    memory::confirm(db.conn(), "f1", 10).unwrap();
+
+    // DUAL-READ: the union of the hardened + legacy buckets. The legacy fact IS recalled.
+    let dual = memory::recall_confirmed_multi(db.conn(), &[hardened, legacy]).unwrap();
+    let ids: Vec<&str> = dual.iter().map(|m| m.memory_id.as_str()).collect();
+    assert!(ids.contains(&"h1"), "hardened-bucket memory recalled");
+    assert!(
+        ids.contains(&"l1"),
+        "legacy-bucket memory recalled (no data loss)"
+    );
+    // ISOLATION (the core invariant the dual-read must NOT widen): the foreign principal's
+    // memory NEVER appears even though we passed two namespaces.
+    assert!(
+        !ids.contains(&"f1"),
+        "foreign-principal memory must never leak"
+    );
+    assert_eq!(dual.len(), 2);
+
+    // FLAG-OFF parity: a single-element list is exactly `recall_confirmed`.
+    let single = memory::recall_confirmed_multi(db.conn(), &[legacy]).unwrap();
+    assert_eq!(single, memory::recall_confirmed(db.conn(), legacy).unwrap());
+    assert_eq!(
+        single
+            .iter()
+            .map(|m| m.memory_id.as_str())
+            .collect::<Vec<_>>(),
+        vec!["l1"]
+    );
+
+    // Empty list ⇒ empty result.
+    assert!(memory::recall_confirmed_multi(db.conn(), &[])
+        .unwrap()
+        .is_empty());
+}
+
+#[test]
+fn recall_confirmed_multi_dedups_a_row_present_in_both_buckets_first_principal_wins() {
+    let p = temp_db_path("mem-recall-dual-dedup");
+    let db = Db::open_hub(&p).unwrap();
+    let hardened = "tenant.a.channel.discord.user.u-h.shared";
+    let legacy = "tenant.a.channel.discord.user.u.h.shared";
+
+    // The SAME memory_id cannot exist twice (PK), so a true cross-bucket duplicate of one id
+    // is not storable; the dedup guards the case where ordered iteration would otherwise
+    // re-emit an id. Here we store DISTINCT ids per bucket and assert no duplication and
+    // that hardened (first principal) ordering leads.
+    memory::record_candidate(db.conn(), &owned_cand("h1", "h fact", hardened, false, 1)).unwrap();
+    memory::confirm(db.conn(), "h1", 50).unwrap();
+    memory::record_candidate(db.conn(), &owned_cand("l1", "l fact", legacy, false, 2)).unwrap();
+    memory::confirm(db.conn(), "l1", 40).unwrap();
+
+    let dual = memory::recall_confirmed_multi(db.conn(), &[hardened, legacy]).unwrap();
+    let ids: Vec<&str> = dual.iter().map(|m| m.memory_id.as_str()).collect();
+    // Hardened bucket consulted first ⇒ its row appears before the legacy row.
+    assert_eq!(ids, vec!["h1", "l1"]);
+    // No id appears twice.
+    let mut sorted = ids.clone();
+    sorted.sort_unstable();
+    sorted.dedup();
+    assert_eq!(
+        sorted.len(),
+        ids.len(),
+        "no duplicate ids in the dual-read union"
+    );
+}

--- a/src/agent/tools/friday-agent-memory-tools.ts
+++ b/src/agent/tools/friday-agent-memory-tools.ts
@@ -33,6 +33,15 @@ export interface CreateFridayAgentMemoryToolsDeps {
   idGenerator?: () => string;
   nowIso?: () => string;
   resolveSessionMemoryNamespace?: (sessionKey: string) => Promise<string | undefined>;
+  /**
+   * Resolve the ORDERED, DEDUPED set of session-memory namespaces to consult on
+   * recall (the dual-read list). When the namespace-hardening flag is OFF (default)
+   * this is a single-element list equal to `resolveSessionMemoryNamespace`, so recall
+   * behavior is byte-identical to today. When ON it is `[hardened, legacy]` deduped,
+   * so memory written under the legacy namespace is still recalled (no destructive
+   * re-key). When absent, recall falls back to the single-namespace path.
+   */
+  resolveSessionMemoryNamespaceCandidates?: (sessionKey: string) => Promise<string[] | undefined>;
   memoryGuardFactory?: FridayMemoryGuardServiceFactory;
   /**
    * Optional session or run identifier used to scope the memory namespace.
@@ -438,26 +447,80 @@ function resolveMemoryScopeId(input: {
     ?? normalizeAgentMemoryScopeId(input.principalId);
 }
 
+/**
+ * Resolve the dual-read candidate namespaces for recall. Returns the ORDERED,
+ * DEDUPED list (primary/hardened first, legacy after) — or `[]` when no session
+ * namespace applies. Prefers `resolveSessionMemoryNamespaceCandidates` (the dual-read
+ * dep); falls back to the single-namespace `resolveSessionMemoryNamespace` for
+ * callers that only wired the older dep (then the list has at most one entry, exactly
+ * the pre-dual-read behavior).
+ */
+async function resolveImplicitSessionNamespaceCandidates(params: {
+  deps: CreateFridayAgentMemoryToolsDeps;
+  explicitNamespace: string | undefined;
+  sessionId: string | undefined;
+}): Promise<string[]> {
+  if (
+    (params.explicitNamespace && !namespaceShouldOverlaySessionMemory(params.explicitNamespace))
+    || !params.sessionId
+  ) {
+    return [];
+  }
+  try {
+    if (params.deps.resolveSessionMemoryNamespaceCandidates) {
+      const candidates = await params.deps.resolveSessionMemoryNamespaceCandidates(params.sessionId);
+      const cleaned = (candidates ?? [])
+        .filter((ns): ns is string => typeof ns === "string" && ns.trim().length > 0)
+        .map((ns) => ns.trim());
+      // Dedup defensively (the dep already dedups, but a stale persisted-namespace
+      // tail could repeat the primary).
+      return [...new Set(cleaned)];
+    }
+    if (params.deps.resolveSessionMemoryNamespace) {
+      const namespace = await params.deps.resolveSessionMemoryNamespace(params.sessionId);
+      return typeof namespace === "string" && namespace.trim().length > 0 ? [namespace.trim()] : [];
+    }
+    return [];
+  } catch {
+    return [];
+  }
+}
+
 async function resolveImplicitSessionNamespace(params: {
   deps: CreateFridayAgentMemoryToolsDeps;
   explicitNamespace: string | undefined;
   sessionId: string | undefined;
 }): Promise<string | undefined> {
-  if (
-    (params.explicitNamespace && !namespaceShouldOverlaySessionMemory(params.explicitNamespace))
-    || !params.sessionId
-    || !params.deps.resolveSessionMemoryNamespace
-  ) {
-    return undefined;
+  // The PRIMARY session namespace is the FIRST dual-read candidate (hardened-when-on,
+  // legacy-when-off) — keeping this single value consistent with the candidate list.
+  const candidates = await resolveImplicitSessionNamespaceCandidates(params);
+  return candidates[0];
+}
+
+/**
+ * Search each legacy/stale session namespace (the dual-read candidate TAIL) and flatten the
+ * union. `memoryService.search` stays single-namespace per call — the dedup happens at the
+ * caller. Empty `namespaces` ⇒ no query (the common flag-off / no-dotted-segment case).
+ */
+async function searchLegacyDualReadNamespaces(params: {
+  deps: CreateFridayAgentMemoryToolsDeps;
+  query: string;
+  agentNamespace: string;
+  namespaces: string[];
+  limit: number;
+}): Promise<FridayMemorySearchResult[]> {
+  if (params.namespaces.length === 0) {
+    return [];
   }
-  try {
-    const namespace = await params.deps.resolveSessionMemoryNamespace(params.sessionId);
-    return typeof namespace === "string" && namespace.trim().length > 0
-      ? namespace.trim()
-      : undefined;
-  } catch {
-    return undefined;
-  }
+  const perNamespace = await Promise.all(
+    params.namespaces.map((ns) =>
+      params.deps.memoryService.search(params.query, {
+        namespace: [params.agentNamespace, ns],
+        limit: Math.max(params.limit * 2, params.limit),
+      }),
+    ),
+  );
+  return perNamespace.flat();
 }
 
 function extractStoredPreferenceValue(input: {
@@ -581,11 +644,21 @@ function createMemorySearchTool(
       const scopeId = resolveMemoryScopeId({ sessionId, principalId });
       const query = readStringParam(args, "query", { required: true });
       const explicitNamespace = readExplicitNamespace(args);
-      const implicitSessionNamespace = await resolveImplicitSessionNamespace({
+      // Dual-read: the ORDERED, DEDUPED session-namespace candidates. When the
+      // hardening flag is OFF (default) this is a single entry (== the legacy
+      // namespace), so everything below behaves byte-identically to today. When ON
+      // it is `[hardened, legacy]` and we ALSO search the legacy tail so memory
+      // written before the flip is still recalled (no destructive re-key).
+      const implicitSessionNamespaceCandidates = await resolveImplicitSessionNamespaceCandidates({
         deps,
         explicitNamespace,
         sessionId,
       });
+      const implicitSessionNamespace = implicitSessionNamespaceCandidates[0];
+      // The dual-read TAIL (legacy + any stale persisted namespace). Empty in the
+      // common (flag-off, or no-dotted-segment) case — so this adds ZERO extra queries
+      // unless a real legacy bucket exists.
+      const legacyDualReadNamespaces = implicitSessionNamespaceCandidates.slice(1);
       const limit = readNumberParam(args, "limit", { integer: true }) ?? 10;
       const agentNamespace = resolveAgentScopedNamespace({ scopeId });
       const explicitResolution = explicitNamespace
@@ -606,6 +679,18 @@ function createMemorySearchTool(
           namespace: scopedNamespace,
           limit: implicitSessionNamespace ? Math.max(limit * 2, limit) : limit,
         });
+        // DUAL-READ union: search each legacy/stale session namespace (the candidate
+        // tail) so memory written under the pre-hardening namespace is still recalled.
+        // `memoryService.search` stays SINGLE-namespace per call — the union + dedup is
+        // done here at the consumer. Empty list ⇒ no extra search (flag-off / no dotted
+        // segment), so this is a no-op for the common case.
+        const legacyDualReadResults = await searchLegacyDualReadNamespaces({
+          deps,
+          query,
+          agentNamespace,
+          namespaces: legacyDualReadNamespaces,
+          limit,
+        });
         const memoryGuardFactory = deps.memoryGuardFactory;
         const guardedContext = memoryGuardFactory && shouldIncludeGuardedPrincipalMemory(explicitNamespace)
           ? resolvePrincipalMemoryGuardContext({ args, signal })
@@ -622,20 +707,35 @@ function createMemorySearchTool(
             || namespaceShouldOverlaySessionMemory(explicitNamespace)
             || scopedResults.length === 0
           );
+        // Lexical fallback over ALL session-namespace candidates (primary + legacy tail),
+        // so legacy session memory is lexically scanned too under flag-on — not just the
+        // hardened primary. With one candidate (flag-off / no dotted segment) this is the
+        // single-namespace scan of before.
         const sessionLexicalCandidates =
           shouldUseSessionFallback && implicitSessionNamespace && sessionId
-            ? await buildSessionLexicalCandidates({
-              deps,
-              sessionId,
-              namespace: implicitSessionNamespace,
-              query,
-              limit,
-            })
+            ? (await Promise.all(
+                implicitSessionNamespaceCandidates.map((ns) =>
+                  buildSessionLexicalCandidates({
+                    deps,
+                    sessionId,
+                    namespace: ns,
+                    query,
+                    limit,
+                  }),
+                ),
+              )).flat()
             : [];
         const dedupedResults = (() => {
-          const merged = [...scopedResults, ...guardedResults, ...sessionLexicalCandidates];
+          const merged = [
+            ...scopedResults,
+            ...legacyDualReadResults,
+            ...guardedResults,
+            ...sessionLexicalCandidates,
+          ];
           const directlySearchedIds = new Set(
-            [...scopedResults, ...guardedResults].map((candidate) => candidate.item.id),
+            [...scopedResults, ...legacyDualReadResults, ...guardedResults].map(
+              (candidate) => candidate.item.id,
+            ),
           );
           const seen = new Set<string>();
           const itemsByContent = new Map<string, FridayMemorySearchResult>();

--- a/src/agent/tools/friday-agent-tool-registry.ts
+++ b/src/agent/tools/friday-agent-tool-registry.ts
@@ -230,6 +230,9 @@ export function createFridayAgentToolRegistry(
         resolveSessionMemoryNamespace: options.sessionService
           ? async (sessionKey) => options.sessionService?.getSessionMemoryNamespace(sessionKey)
           : undefined,
+        resolveSessionMemoryNamespaceCandidates: options.sessionService
+          ? async (sessionKey) => options.sessionService?.getSessionMemoryNamespaceCandidates(sessionKey)
+          : undefined,
         memoryGuardFactory: options.memoryGuardFactory,
       }),
     );

--- a/src/sessions/index.ts
+++ b/src/sessions/index.ts
@@ -96,6 +96,9 @@ export type { FridaySessionSendPolicyResolveInput } from "./services/friday-sess
 
 export {
   resolveFridaySessionMemoryNamespace,
+  resolveFridaySessionMemoryNamespaceCandidates,
+  isFridayNamespaceHardeningEnabled,
+  FRIDAY_NS_HARDENING_ENV_FLAG,
   buildFridaySessionMemorySource,
   buildFridaySessionMemoryMetadata,
 } from "./services/friday-session-memory-namespace.js";

--- a/src/sessions/services/friday-session-memory-namespace.ts
+++ b/src/sessions/services/friday-session-memory-namespace.ts
@@ -15,6 +15,33 @@ import { parseFridaySessionKey } from "./friday-session-key.js";
 export type FridaySessionLookupFn = (key: string) => FridaySessionRecord | null;
 
 /**
+ * The DEFAULT-OFF env flag that governs whether the dot-join COLLISION HARDENING
+ * (F5.5) is active. ON only when `FRIDAY_NS_HARDENING_ENABLED` is exactly `"1"`
+ * (after trimming). UNSET / empty / `"0"` / any other value ⇒ OFF — the unchanged,
+ * pre-hardening (legacy) derivation.
+ *
+ * WHY default-off matters for data safety: when OFF the segment keep-set still
+ * includes `.` exactly as it did before this change, so every namespace this
+ * resolver produces is BYTE-IDENTICAL to the legacy derivation. No existing memory
+ * is re-scoped/orphaned. When ON, the WRITE path emits the hardened namespace AND
+ * the READ path dual-reads BOTH the hardened and legacy namespaces (see
+ * {@link resolveFridaySessionMemoryNamespaceCandidates}), so nothing is lost on
+ * flip — there is NO one-way destructive re-key.
+ *
+ * PARITY: the Rust half reads the SAME flag name under the SAME `"1"` semantics
+ * (`session_namespace::ns_hardening_enabled`).
+ */
+export const FRIDAY_NS_HARDENING_ENV_FLAG = "FRIDAY_NS_HARDENING_ENABLED";
+
+/**
+ * Read the DEFAULT-OFF {@link FRIDAY_NS_HARDENING_ENV_FLAG}. Narrow + explicit (exact
+ * trimmed `"1"`) so the hardening cannot be enabled by accident.
+ */
+export function isFridayNamespaceHardeningEnabled(): boolean {
+  return (process.env[FRIDAY_NS_HARDENING_ENV_FLAG] ?? "").trim() === "1";
+}
+
+/**
  * Resolve a memory namespace for a session.
  *
  * The namespace is deterministic by account/channel/user so that
@@ -24,10 +51,19 @@ export type FridaySessionLookupFn = (key: string) => FridaySessionRecord | null;
  * For subagent sessions without a userId, walks the parent chain to find one.
  *
  * Format: `tenant.<accountId>.channel.<channel>.user.<normalizedUserId>.shared`
+ *
+ * COLLISION HARDENING (F5.5, FLAG-GATED): the `hardened` derivation drops `.` from
+ * the segment keep-set so the dot (the segment joiner) can never be forged inside a
+ * segment. It is governed by the DEFAULT-OFF {@link FRIDAY_NS_HARDENING_ENV_FLAG}.
+ * The optional `options.hardened` override is for tests/candidate-derivation; when
+ * omitted the flag decides. This function returns the PRIMARY (write) namespace; the
+ * READ path must use {@link resolveFridaySessionMemoryNamespaceCandidates} so a
+ * flag-on flip never orphans legacy-written memory.
  */
 export function resolveFridaySessionMemoryNamespace(
   session: FridaySessionRecord,
   sessionLookup?: FridaySessionLookupFn,
+  options?: { hardened?: boolean },
 ): string {
   const userId = resolveEffectiveUserId(session, sessionLookup);
 
@@ -39,17 +75,77 @@ export function resolveFridaySessionMemoryNamespace(
     );
   }
 
-  const normalizedAccountId = normalizeNamespaceSegment(session.accountId || "default");
-  const normalizedChannel = normalizeNamespaceSegment(session.channel || "unknown");
-  const normalizedUserId = normalizeNamespaceSegment(userId);
+  const hardened = options?.hardened ?? isFridayNamespaceHardeningEnabled();
+  return buildNamespace(session.accountId || "default", session.channel || "unknown", userId, hardened);
+}
 
+/**
+ * Resolve the ORDERED, DEDUPED set of namespaces to consult on the READ (recall)
+ * path — the non-destructive substitute for re-keying existing memory.
+ *
+ * - Hardening OFF (default): `[legacy]` — a SINGLE namespace, byte-identical to
+ *   today. Recall is one query, no behavior change.
+ * - Hardening ON: `[hardened, legacy]` deduped. The hardened namespace is consulted
+ *   first (new writes land there); the legacy namespace is consulted too so memory
+ *   written before the flip (or by a peer still on legacy) is STILL recalled.
+ *
+ * DEDUP-COLLAPSE: when no segment contains a `.`, the hardened and legacy
+ * derivations are IDENTICAL, so the list collapses to ONE entry even with the flag
+ * ON — i.e. the common (non-dotted) case has zero extra reads. Only a segment that
+ * legitimately contains a `.` (an email-shaped userId, a dotted account/channel)
+ * produces two distinct reads.
+ *
+ * HONEST scope of the collision fix (see also the Rust mirror): the LEGACY namespace
+ * IS the colliding string, so dual-reading it re-reads the pre-hardening collision
+ * bucket. The hardening closes the cross-tuple collision for NEW (hardened) WRITES
+ * only; legacy data retains its pre-F5.5 collision semantics (the same accepted
+ * behavior under the single-owner v1 threat model, where userIds are not
+ * adversarially controlled). Dual-read is strictly ≥ the pre-#661 state — it can
+ * never lose data — but it does NOT retroactively disambiguate already-colliding
+ * legacy rows (structurally impossible: one shared bucket cannot be split).
+ */
+export function resolveFridaySessionMemoryNamespaceCandidates(
+  session: FridaySessionRecord,
+  sessionLookup?: FridaySessionLookupFn,
+): string[] {
+  const userId = resolveEffectiveUserId(session, sessionLookup);
+
+  if (!userId) {
+    throw new FridayDomainError(
+      FRIDAY_SESSION_ERROR_CODES.MEMORY_NAMESPACE_UNRESOLVABLE,
+      `Cannot resolve memory namespace for session '${session.key}': no userId available`,
+      { httpStatus: 400 },
+    );
+  }
+
+  const account = session.accountId || "default";
+  const channel = session.channel || "unknown";
+  const legacy = buildNamespace(account, channel, userId, false);
+
+  if (!isFridayNamespaceHardeningEnabled()) {
+    return [legacy];
+  }
+
+  const hardened = buildNamespace(account, channel, userId, true);
+  // Ordered (hardened first) + deduped: when both derivations agree (no dotted
+  // segment) the list collapses to a single entry.
+  return hardened === legacy ? [hardened] : [hardened, legacy];
+}
+
+/**
+ * Build the composite namespace from already-resolved axes under an EXPLICIT
+ * `hardened` mode (pure; the flag is read by the callers above). The seven
+ * fixed-position parts are `.`-joined; with `hardened` the segment normalizer drops
+ * `.`, so no payload segment can contain the joiner.
+ */
+function buildNamespace(account: string, channel: string, userId: string, hardened: boolean): string {
   return [
     FRIDAY_SESSION_MEMORY_NAMESPACE_TENANT_SEGMENT,
-    normalizedAccountId,
+    normalizeNamespaceSegment(account, hardened),
     FRIDAY_SESSION_MEMORY_NAMESPACE_CHANNEL_SEGMENT,
-    normalizedChannel,
+    normalizeNamespaceSegment(channel, hardened),
     FRIDAY_SESSION_MEMORY_NAMESPACE_USER_SEGMENT,
-    normalizedUserId,
+    normalizeNamespaceSegment(userId, hardened),
     FRIDAY_SESSION_MEMORY_NAMESPACE_SHARED_SEGMENT,
   ].join(".");
 }
@@ -122,10 +218,37 @@ function resolveEffectiveUserId(
   return undefined;
 }
 
-function normalizeNamespaceSegment(value: string): string {
+/**
+ * Normalize a single namespace SEGMENT.
+ *
+ * Pipeline: lowercase → replace every char NOT in the keep-set with `-` → collapse
+ * runs of `-` → trim leading/trailing `-` → empty result becomes `default`.
+ *
+ * COLLISION HARDENING (F5.5, FLAG-GATED): the keep-set depends on `hardened`:
+ * - `hardened === false` (LEGACY, default): keep-set `[a-z0-9._-]` — the literal `.`
+ *   is KEPT inside a segment, byte-identical to the pre-hardening derivation.
+ * - `hardened === true`: keep-set `[a-z0-9_-]` — the literal `.` maps to `-` like any
+ *   other punctuation. `.` is the SEGMENT JOINER used by
+ *   {@link resolveFridaySessionMemoryNamespace} (`[...].join(".")`), and that
+ *   composite string becomes the memory store SCOPE (the Rust `principal_id`). With
+ *   `.` stripped from every segment the composite ALWAYS splits into exactly the
+ *   seven fixed-position parts, so the mapping is injective over NORMALIZED segment
+ *   tuples: a userId such as `alice.channel.evil.user.bob` can no longer FORGE a
+ *   different (account, channel, user) tuple's namespace string. The WITHIN-position
+ *   normalization stays lossy (`a.b` ≡ `a-b`, the same accepted behavior as `@`→`-`).
+ *
+ * PARITY: both keep-sets are byte-identical to the Rust port
+ * `normalize_namespace_segment` / `is_kept` in
+ * `rust-core/crates/friday-hub/src/session_namespace.rs` under the same `hardened`
+ * flag. The two MUST stay in lockstep (the Rust half binds the same composite string
+ * to its `principal_id` scope).
+ */
+function normalizeNamespaceSegment(value: string, hardened: boolean): string {
+  // Legacy keep-set KEEPS `.`; hardened keep-set DROPS it (`.` → `-`).
+  const keepSet = hardened ? /[^a-z0-9_-]/g : /[^a-z0-9._-]/g;
   const normalized = value
     .toLowerCase()
-    .replace(/[^a-z0-9._-]/g, "-")
+    .replace(keepSet, "-")
     .replace(/-+/g, "-")
     .replace(/^-|-$/g, "");
 

--- a/src/sessions/services/friday-session-service.ts
+++ b/src/sessions/services/friday-session-service.ts
@@ -33,6 +33,7 @@ import { createFridaySessionRepository } from "../persistence/friday-session-rep
 import { createFridaySessionMessageRepository } from "../persistence/friday-session-message-repository.js";
 import { buildFridaySubagentSessionKey, canonicalizeFridaySessionKey, normalizeFridaySessionKey, parseFridaySessionKey } from "./friday-session-key.js";
 import {
+  isFridayNamespaceHardeningEnabled,
   resolveFridaySessionMemoryNamespace,
   resolveFridaySessionMemoryNamespaceCandidates,
 } from "./friday-session-memory-namespace.js";
@@ -647,22 +648,43 @@ export function createFridaySessionService(
         );
       }
 
-      // Re-DERIVE both candidate namespaces from the session's axes (NOT the cached
-      // `session.memoryNamespace`). The cache holds whatever the WRITE path persisted
-      // — which, for a session created BEFORE the flag flip, is the legacy namespace.
-      // Re-deriving here is what makes dual-read find that legacy memory after the
-      // flip: the hardened candidate is the new write target, the legacy candidate
-      // recalls the pre-flip rows. With the flag OFF this returns the single legacy
-      // namespace (byte-identical to `getSessionMemoryNamespace`'s derived value).
+      // FLAG-OFF (default): recall MUST be byte-identical to today. "Today" =
+      // `getSessionMemoryNamespace`, which returns the PERSISTED (authoritative,
+      // write-time) `session.memoryNamespace` FIRST and only re-derives when it is
+      // absent. Returning a SINGLE persisted-first entry — with NO dual-read and NO
+      // defensive tail — guarantees there is zero regression when the persisted
+      // namespace drifts from a blind re-derivation (e.g. after a rollback from
+      // flag-on, or any stored-vs-re-derived drift): recall always reads the bucket
+      // the rows actually live in, exactly as before this change. The dual-read /
+      // re-scope logic below is reserved for the flag-ON path ONLY.
+      if (!isFridayNamespaceHardeningEnabled()) {
+        // Mirror `getSessionMemoryNamespace` EXACTLY (a truthy check, not `??`) so the
+        // two stay byte-identical even on the unreachable empty-string edge.
+        if (session.memoryNamespace) {
+          return [session.memoryNamespace];
+        }
+        return [
+          resolveFridaySessionMemoryNamespace(session, (k) =>
+            deps.db.withReadConnection((db) => sessionRepo.getByKey(db, k)),
+          ),
+        ];
+      }
+
+      // FLAG-ON: re-DERIVE both candidate namespaces from the session's axes (NOT the
+      // cached `session.memoryNamespace`). The cache holds whatever the WRITE path
+      // persisted — which, for a session created BEFORE the flag flip, is the legacy
+      // namespace. Re-deriving here is what makes dual-read find that legacy memory
+      // after the flip: the hardened candidate is the new write target, the legacy
+      // candidate recalls the pre-flip rows.
       const candidates = resolveFridaySessionMemoryNamespaceCandidates(session, (k) =>
         deps.db.withReadConnection((db) => sessionRepo.getByKey(db, k)),
       );
 
-      // Defense-in-depth: if the persisted (write-time) namespace differs from BOTH
-      // re-derived candidates (e.g. the session axes changed after creation without
-      // an alignSessionContext recompute), keep recalling it too so a re-scope can
-      // never silently drop the bucket the rows actually live in. Ordered last
-      // (lowest priority) and deduped.
+      // Defense-in-depth (flag-ON only): if the persisted (write-time) namespace
+      // differs from BOTH re-derived candidates (e.g. a session persisted HARDENED
+      // before a config change, or axes that drifted without an alignSessionContext
+      // recompute), keep recalling it too so a re-scope can never silently drop the
+      // bucket the rows actually live in. Ordered last (lowest priority) and deduped.
       if (session.memoryNamespace && !candidates.includes(session.memoryNamespace)) {
         return [...candidates, session.memoryNamespace];
       }

--- a/src/sessions/services/friday-session-service.ts
+++ b/src/sessions/services/friday-session-service.ts
@@ -32,7 +32,10 @@ import type {
 import { createFridaySessionRepository } from "../persistence/friday-session-repository.js";
 import { createFridaySessionMessageRepository } from "../persistence/friday-session-message-repository.js";
 import { buildFridaySubagentSessionKey, canonicalizeFridaySessionKey, normalizeFridaySessionKey, parseFridaySessionKey } from "./friday-session-key.js";
-import { resolveFridaySessionMemoryNamespace } from "./friday-session-memory-namespace.js";
+import {
+  resolveFridaySessionMemoryNamespace,
+  resolveFridaySessionMemoryNamespaceCandidates,
+} from "./friday-session-memory-namespace.js";
 import { resolveFridaySessionSendPolicy } from "./friday-session-send-policy.js";
 import type { CreateFridaySessionServiceDeps, FridaySessionService, FridaySessionSweepResult } from "./friday-session-service.types.js";
 
@@ -630,6 +633,40 @@ export function createFridaySessionService(
       return resolveFridaySessionMemoryNamespace(session, (k) =>
         deps.db.withReadConnection((db) => sessionRepo.getByKey(db, k)),
       );
+    },
+
+    async getSessionMemoryNamespaceCandidates(key) {
+      key = canonicalizeFridaySessionKey(key);
+
+      const session = deps.db.withReadConnection((db) => sessionRepo.getByKey(db, key));
+      if (!session) {
+        throw new FridayDomainError(
+          FRIDAY_SESSION_ERROR_CODES.NOT_FOUND,
+          `Session '${key}' not found`,
+          { httpStatus: 404 },
+        );
+      }
+
+      // Re-DERIVE both candidate namespaces from the session's axes (NOT the cached
+      // `session.memoryNamespace`). The cache holds whatever the WRITE path persisted
+      // — which, for a session created BEFORE the flag flip, is the legacy namespace.
+      // Re-deriving here is what makes dual-read find that legacy memory after the
+      // flip: the hardened candidate is the new write target, the legacy candidate
+      // recalls the pre-flip rows. With the flag OFF this returns the single legacy
+      // namespace (byte-identical to `getSessionMemoryNamespace`'s derived value).
+      const candidates = resolveFridaySessionMemoryNamespaceCandidates(session, (k) =>
+        deps.db.withReadConnection((db) => sessionRepo.getByKey(db, k)),
+      );
+
+      // Defense-in-depth: if the persisted (write-time) namespace differs from BOTH
+      // re-derived candidates (e.g. the session axes changed after creation without
+      // an alignSessionContext recompute), keep recalling it too so a re-scope can
+      // never silently drop the bucket the rows actually live in. Ordered last
+      // (lowest priority) and deduped.
+      if (session.memoryNamespace && !candidates.includes(session.memoryNamespace)) {
+        return [...candidates, session.memoryNamespace];
+      }
+      return candidates;
     },
 
     async alignSessionContext(key, input) {

--- a/src/sessions/services/friday-session-service.types.ts
+++ b/src/sessions/services/friday-session-service.types.ts
@@ -34,6 +34,14 @@ export interface FridaySessionService {
   pruneOldSessions(olderThan: string): Promise<FridaySessionPruneResult>;
   sweepLifecycle(): Promise<FridaySessionSweepResult>;
   getSessionMemoryNamespace(key: string): Promise<string>;
+  /**
+   * Resolve the ORDERED, DEDUPED set of namespaces to consult on the READ (recall)
+   * path. Hardening OFF (default): `[legacy]` (one entry, byte-identical to today).
+   * Hardening ON: `[hardened, legacy]` deduped — dual-read so memory written under
+   * the legacy namespace is still recalled (no destructive re-key). See
+   * {@link resolveFridaySessionMemoryNamespaceCandidates}.
+   */
+  getSessionMemoryNamespaceCandidates(key: string): Promise<string[]>;
   forkSession(parentKey: string, input?: FridaySessionForkCreateInput): Promise<FridaySessionForkCreateResult>;
   listForks(parentKey: string, input?: FridaySessionForkListInput): Promise<FridaySessionRecord[]>;
   mergeForkSummary(parentKey: string, input: FridaySessionForkMergeInput): Promise<FridaySessionForkMergeResult>;

--- a/test/unit/agent/tools/friday-agent-memory-tools.test.ts
+++ b/test/unit/agent/tools/friday-agent-memory-tools.test.ts
@@ -920,4 +920,168 @@ describe("FridayAgentMemoryTools", () => {
       );
     });
   });
+
+  // ─── F5.5 dual-read recall (flag-gated namespace hardening) ───
+  //
+  // These prove the operator's mandate AT the LIVE recall consumer (not just the
+  // resolver helper): when hardening is ON the recall path consults BOTH the hardened
+  // and the legacy session namespaces, so memory written under the legacy namespace
+  // (before the flag flip) is STILL recalled — no destructive re-key.
+  describe("F5.5 dual-read recall (namespace hardening)", () => {
+    const HARDENED_NS = "tenant.default.channel.webchat.user.user-example-com.shared";
+    const LEGACY_NS = "tenant.default.channel.webchat.user.user-example.com.shared";
+    const SESSION_KEY = "webchat:default:chat-1";
+    // The agent base namespace is scoped to the session key in context.
+    const AGENT_NS = `agent:${SESSION_KEY}`;
+
+    it("FLAG-ON: dual-read finds memory written under the LEGACY namespace", async () => {
+      // The memory lives ONLY in the legacy bucket (it was written pre-flip). The
+      // hardened (primary) search returns nothing; the legacy dual-read leg finds it.
+      const legacyOnlyMemory = makeSearchResult({
+        item: makeItem({
+          id: "legacy-mem",
+          namespace: LEGACY_NS,
+          content: "Codename is BLUEJAY",
+        }),
+        score: 0.9,
+      });
+      const svc = mockMemoryService();
+      // search(query, { namespace: [agentNs, ns] }) — return the legacy memory ONLY
+      // when the legacy namespace is in the requested array; empty otherwise.
+      vi.mocked(svc.search).mockImplementation(async (_q, options) => {
+        const ns = options?.namespace;
+        const arr = Array.isArray(ns) ? ns : [ns];
+        return arr.includes(LEGACY_NS) ? [legacyOnlyMemory] : [];
+      });
+      const [searchTool] = createFridayAgentMemoryTools({
+        memoryService: svc,
+        // The dual-read dep: hardened-on returns [hardened, legacy].
+        resolveSessionMemoryNamespaceCandidates: async () => [HARDENED_NS, LEGACY_NS],
+      });
+
+      const result = await searchTool!.execute(
+        { query: "codename" },
+        signalWithContext({ sessionKey: SESSION_KEY }),
+      );
+
+      expect(result.isError).toBeUndefined();
+      // The legacy-bucket memory IS recalled through the dual-read leg.
+      expect(JSON.parse(result.content)).toMatchObject([{ content: "Codename is BLUEJAY" }]);
+      // BOTH namespaces were searched: the primary (hardened) and the legacy tail.
+      const searchedNamespaces = vi.mocked(svc.search).mock.calls.map(([, opts]) => opts?.namespace);
+      expect(searchedNamespaces).toContainEqual([AGENT_NS, HARDENED_NS]);
+      expect(searchedNamespaces).toContainEqual([AGENT_NS, LEGACY_NS]);
+    });
+
+    it("FLAG-OFF (single candidate): only the legacy namespace is searched — byte-identical to today", async () => {
+      // Hardening OFF ⇒ the dep returns a SINGLE namespace ⇒ NO extra dual-read query.
+      const svc = mockMemoryService([]);
+      const [searchTool] = createFridayAgentMemoryTools({
+        memoryService: svc,
+        resolveSessionMemoryNamespaceCandidates: async () => [LEGACY_NS],
+      });
+
+      await searchTool!.execute(
+        { query: "codename" },
+        signalWithContext({ sessionKey: SESSION_KEY }),
+      );
+
+      const searchedNamespaces = vi.mocked(svc.search).mock.calls.map(([, opts]) => opts?.namespace);
+      // Exactly ONE primary search over [agent, legacy]; no second (dual-read) query.
+      expect(searchedNamespaces).toEqual([[AGENT_NS, LEGACY_NS]]);
+    });
+
+    it("FLAG-ON dedup-collapse: a non-dotted (single-candidate) namespace adds no extra query", async () => {
+      // When hardened === legacy the dep collapses to one entry, so even with the flag
+      // ON the common case issues exactly one query (the dedup-collapse guarantee).
+      const plainNs = "tenant.default.channel.webchat.user.user-abc.shared";
+      const svc = mockMemoryService([]);
+      const [searchTool] = createFridayAgentMemoryTools({
+        memoryService: svc,
+        resolveSessionMemoryNamespaceCandidates: async () => [plainNs],
+      });
+
+      await searchTool!.execute(
+        { query: "q" },
+        signalWithContext({ sessionKey: SESSION_KEY }),
+      );
+
+      const searchedNamespaces = vi.mocked(svc.search).mock.calls.map(([, opts]) => opts?.namespace);
+      expect(searchedNamespaces).toEqual([[AGENT_NS, plainNs]]);
+    });
+
+    it("dedups a row that appears in BOTH hardened and legacy buckets (no duplicate result)", async () => {
+      const dupMemory = makeSearchResult({
+        item: makeItem({ id: "dup-mem", content: "Shared fact" }),
+        score: 0.8,
+      });
+      const svc = mockMemoryService();
+      // The SAME item id is returned for both namespaces (it was re-written hardened
+      // while the legacy copy lingers) — the consumer must dedup by id.
+      vi.mocked(svc.search).mockResolvedValue([dupMemory]);
+      const [searchTool] = createFridayAgentMemoryTools({
+        memoryService: svc,
+        resolveSessionMemoryNamespaceCandidates: async () => [HARDENED_NS, LEGACY_NS],
+      });
+
+      const result = await searchTool!.execute(
+        { query: "shared" },
+        signalWithContext({ sessionKey: SESSION_KEY }),
+      );
+
+      const parsed = JSON.parse(result.content) as Array<{ metadata: { id: string } }>;
+      expect(parsed.filter((r) => r.metadata.id === "dup-mem")).toHaveLength(1);
+    });
+
+    it("falls back to the single-namespace dep when the dual-read dep is absent", async () => {
+      // Older callers that only wired resolveSessionMemoryNamespace keep working (the
+      // candidate list then has at most one entry — pre-dual-read behavior).
+      const svc = mockMemoryService([]);
+      const [searchTool] = createFridayAgentMemoryTools({
+        memoryService: svc,
+        resolveSessionMemoryNamespace: async () => LEGACY_NS,
+      });
+
+      await searchTool!.execute(
+        { query: "q" },
+        signalWithContext({ sessionKey: SESSION_KEY }),
+      );
+
+      const searchedNamespaces = vi.mocked(svc.search).mock.calls.map(([, opts]) => opts?.namespace);
+      expect(searchedNamespaces).toEqual([[AGENT_NS, LEGACY_NS]]);
+    });
+
+    it("FLAG-ON: the LEXICAL fallback also scans the legacy namespace (no recall-quality downgrade)", async () => {
+      // The semantic search finds nothing, triggering the lexical fallback. The wanted
+      // memory lives ONLY in the legacy bucket — the lexical scan must list() the legacy
+      // namespace too, not just the hardened primary.
+      const legacyLexical = makeItem({
+        id: "legacy-lex",
+        namespace: LEGACY_NS,
+        content: "codename bluejay lives here",
+        source: `session:${SESSION_KEY}`,
+        tags: [`session:${SESSION_KEY}`],
+      });
+      const svc = mockMemoryService([]); // semantic search: empty
+      vi.mocked(svc.list).mockImplementation(async (opts) =>
+        opts?.namespace === LEGACY_NS ? [legacyLexical] : [],
+      );
+      const [searchTool] = createFridayAgentMemoryTools({
+        memoryService: svc,
+        resolveSessionMemoryNamespaceCandidates: async () => [HARDENED_NS, LEGACY_NS],
+      });
+
+      const result = await searchTool!.execute(
+        { query: "codename" },
+        signalWithContext({ sessionKey: SESSION_KEY }),
+      );
+
+      // The legacy memory is recalled via the lexical fallback...
+      expect(JSON.parse(result.content)).toMatchObject([{ content: "codename bluejay lives here" }]);
+      // ...and BOTH namespaces were list()ed (the fallback dual-reads).
+      const listedNamespaces = vi.mocked(svc.list).mock.calls.map(([opts]) => opts?.namespace);
+      expect(listedNamespaces).toContain(HARDENED_NS);
+      expect(listedNamespaces).toContain(LEGACY_NS);
+    });
+  });
 });

--- a/test/unit/agent/tools/friday-agent-memory-tools.test.ts
+++ b/test/unit/agent/tools/friday-agent-memory-tools.test.ts
@@ -991,6 +991,54 @@ describe("FridayAgentMemoryTools", () => {
       expect(searchedNamespaces).toEqual([[AGENT_NS, LEGACY_NS]]);
     });
 
+    it("FLAG-OFF must-fix: persisted namespace DIFFERS from re-derived legacy — recall reads the PERSISTED bucket and finds the items (no regression)", async () => {
+      // The reviewer-specified adversarial case AT the live consumer. The session's
+      // PERSISTED memory namespace (the authoritative write-time value) differs from
+      // what a blind re-derivation would produce (e.g. after a rollback from flag-on,
+      // or any stored-vs-re-derived drift). The fixed flag-off `getSessionMemoryNamespace
+      // Candidates` returns the SINGLE persisted namespace — so the consumer searches the
+      // bucket the rows ACTUALLY live in, never the divergent re-derivation. This pins
+      // "flag-off recall is byte-identical to today" regardless of namespace drift.
+      const PERSISTED_NS = HARDENED_NS; // what the rows were written under (authoritative)
+      const RE_DERIVED_LEGACY_NS = LEGACY_NS; // what a blind re-derivation would yield (a DIFFERENT, empty bucket)
+      const persistedMemory = makeSearchResult({
+        item: makeItem({
+          id: "persisted-mem",
+          namespace: PERSISTED_NS,
+          content: "Codename is FALCON",
+        }),
+        score: 0.9,
+      });
+      const svc = mockMemoryService();
+      // The item lives ONLY in the persisted bucket. If recall blindly re-derived the
+      // legacy namespace (the pre-fix bug), it would search the EMPTY legacy bucket and
+      // miss this row → recall regression.
+      vi.mocked(svc.search).mockImplementation(async (_q, options) => {
+        const ns = options?.namespace;
+        const arr = Array.isArray(ns) ? ns : [ns];
+        return arr.includes(PERSISTED_NS) ? [persistedMemory] : [];
+      });
+      const [searchTool] = createFridayAgentMemoryTools({
+        memoryService: svc,
+        // The FIXED flag-off candidate list: the SINGLE authoritative persisted namespace
+        // (NOT [re-derived-legacy, persisted-tail], which was the regressing pre-fix shape).
+        resolveSessionMemoryNamespaceCandidates: async () => [PERSISTED_NS],
+      });
+
+      const result = await searchTool!.execute(
+        { query: "codename" },
+        signalWithContext({ sessionKey: SESSION_KEY }),
+      );
+
+      expect(result.isError).toBeUndefined();
+      // The persisted-bucket memory IS still recalled (no regression).
+      expect(JSON.parse(result.content)).toMatchObject([{ content: "Codename is FALCON" }]);
+      // The persisted namespace was searched; the divergent re-derived legacy bucket was NOT.
+      const searchedNamespaces = vi.mocked(svc.search).mock.calls.map(([, opts]) => opts?.namespace);
+      expect(searchedNamespaces).toEqual([[AGENT_NS, PERSISTED_NS]]);
+      expect(searchedNamespaces).not.toContainEqual([AGENT_NS, RE_DERIVED_LEGACY_NS]);
+    });
+
     it("FLAG-ON dedup-collapse: a non-dotted (single-candidate) namespace adds no extra query", async () => {
       // When hardened === legacy the dep collapses to one entry, so even with the flag
       // ON the common case issues exactly one query (the dedup-collapse guarantee).

--- a/test/unit/sessions/services/friday-session-memory-namespace.test.ts
+++ b/test/unit/sessions/services/friday-session-memory-namespace.test.ts
@@ -1,7 +1,10 @@
-import { describe, it, expect } from "vitest";
+import { afterEach, beforeEach, describe, it, expect } from "vitest";
 import { FridayDomainError } from "#errors";
 import {
   resolveFridaySessionMemoryNamespace,
+  resolveFridaySessionMemoryNamespaceCandidates,
+  isFridayNamespaceHardeningEnabled,
+  FRIDAY_NS_HARDENING_ENV_FLAG,
   buildFridaySessionMemorySource,
   buildFridaySessionMemoryMetadata,
   FRIDAY_SESSION_ERROR_CODES,
@@ -95,7 +98,10 @@ describe("FridaySessionMemoryNamespace", () => {
       }
     });
 
-    it("replaces special characters in userId", () => {
+    it("replaces special characters in userId (FLAG-OFF: dot PRESERVED — byte-identical to pre-#661)", () => {
+      // The hardening flag is DEFAULT-OFF, so the legacy keep-set keeps `.`. This is the
+      // exact pre-hardening behavior: NO re-scope of an email-shaped userId.
+      expect(isFridayNamespaceHardeningEnabled()).toBe(false);
       const session = makeSession({ userId: "user@example.com" });
       const ns = resolveFridaySessionMemoryNamespace(session);
       expect(ns).toBe("tenant.default.channel.discord.user.user-example.com.shared");
@@ -191,6 +197,117 @@ describe("FridaySessionMemoryNamespace", () => {
         expect(err).toBeInstanceOf(FridayDomainError);
         expect((err as FridayDomainError).code).toBe(FRIDAY_SESSION_ERROR_CODES.MEMORY_NAMESPACE_UNRESOLVABLE);
       }
+    });
+  });
+
+  // ─── F5.5 dot-join collision hardening (FLAG-GATED, DEFAULT-OFF) + dual-read ───
+
+  describe("namespace hardening flag + dual-read", () => {
+    const PRIOR = process.env[FRIDAY_NS_HARDENING_ENV_FLAG];
+    beforeEach(() => {
+      delete process.env[FRIDAY_NS_HARDENING_ENV_FLAG];
+    });
+    afterEach(() => {
+      if (PRIOR === undefined) {
+        delete process.env[FRIDAY_NS_HARDENING_ENV_FLAG];
+      } else {
+        process.env[FRIDAY_NS_HARDENING_ENV_FLAG] = PRIOR;
+      }
+    });
+
+    it("FLAG-OFF: the flag is off by default and only exactly '1' enables it", () => {
+      expect(isFridayNamespaceHardeningEnabled()).toBe(false);
+      for (const v of ["", "0", "true", "yes", "2", " 1 "]) {
+        // " 1 " trims to "1" so it IS on; assert the trim explicitly.
+        process.env[FRIDAY_NS_HARDENING_ENV_FLAG] = v;
+        expect(isFridayNamespaceHardeningEnabled()).toBe(v.trim() === "1");
+      }
+      process.env[FRIDAY_NS_HARDENING_ENV_FLAG] = "1";
+      expect(isFridayNamespaceHardeningEnabled()).toBe(true);
+    });
+
+    it("FLAG-OFF: a dotted userId is NOT re-scoped (byte-identical to legacy)", () => {
+      // No re-scope/data-downgrade when the flag is off: the dot stays in the segment.
+      const session = makeSession({ userId: "alice.jr@example.com" });
+      expect(resolveFridaySessionMemoryNamespace(session)).toBe(
+        "tenant.default.channel.discord.user.alice.jr-example.com.shared",
+      );
+    });
+
+    it("FLAG-OFF: candidates is the SINGLE legacy namespace (one query, no behavior change)", () => {
+      const session = makeSession({ userId: "user@example.com" });
+      const candidates = resolveFridaySessionMemoryNamespaceCandidates(session);
+      expect(candidates).toEqual(["tenant.default.channel.discord.user.user-example.com.shared"]);
+    });
+
+    it("FLAG-ON: the dotted segment is hardened (dot -> '-')", () => {
+      process.env[FRIDAY_NS_HARDENING_ENV_FLAG] = "1";
+      const session = makeSession({ userId: "user@example.com" });
+      expect(resolveFridaySessionMemoryNamespace(session)).toBe(
+        "tenant.default.channel.discord.user.user-example-com.shared",
+      );
+    });
+
+    it("FLAG-ON: dual-read returns [hardened, legacy] so legacy memory is still recalled", () => {
+      process.env[FRIDAY_NS_HARDENING_ENV_FLAG] = "1";
+      const session = makeSession({ userId: "user@example.com" });
+      const candidates = resolveFridaySessionMemoryNamespaceCandidates(session);
+      expect(candidates).toEqual([
+        "tenant.default.channel.discord.user.user-example-com.shared", // hardened (new writes)
+        "tenant.default.channel.discord.user.user-example.com.shared", // legacy (pre-flip rows)
+      ]);
+      // The LEGACY candidate is byte-identical to what the FLAG-OFF write path persisted —
+      // this is the link that makes flag-on recall find pre-flip memory.
+      delete process.env[FRIDAY_NS_HARDENING_ENV_FLAG];
+      expect(resolveFridaySessionMemoryNamespace(session)).toBe(candidates[1]);
+    });
+
+    it("FLAG-ON, DEDUP-COLLAPSE: a non-dotted segment yields ONE candidate (zero extra reads)", () => {
+      process.env[FRIDAY_NS_HARDENING_ENV_FLAG] = "1";
+      // No `.` in any segment ⇒ hardened === legacy ⇒ the dual-read list collapses to one.
+      const session = makeSession({ userId: "user-abc" });
+      const candidates = resolveFridaySessionMemoryNamespaceCandidates(session);
+      expect(candidates).toEqual(["tenant.default.channel.discord.user.user-abc.shared"]);
+    });
+
+    it("FLAG-ON: the dot-join cross-tuple collision is closed for NEW (hardened) writes", () => {
+      process.env[FRIDAY_NS_HARDENING_ENV_FLAG] = "1";
+      // Pre-fix both DISTINCT tuples produced `tenant.a.channel.b.user.x.user.y.shared`.
+      // Hardened: the embedded `.user.` maps to `-user-`, so they are DISTINCT.
+      const forged = resolveFridaySessionMemoryNamespace(
+        makeSession({ accountId: "a", channel: "b", userId: "x.user.y" }),
+      );
+      const victim = resolveFridaySessionMemoryNamespace(
+        makeSession({ accountId: "a", channel: "b.user.x", userId: "y" }),
+      );
+      expect(forged).not.toBe(victim);
+      expect(forged).toBe("tenant.a.channel.b.user.x-user-y.shared");
+      expect(victim).toBe("tenant.a.channel.b-user-x.user.y.shared");
+      // Injectivity by construction: exactly 7 dot-parts, no payload segment carries a dot.
+      const parts = forged.split(".");
+      expect(parts.length).toBe(7);
+      expect([parts[0], parts[2], parts[4], parts[6]]).toEqual(["tenant", "channel", "user", "shared"]);
+      for (const payload of [parts[1], parts[3], parts[5]]) {
+        expect(payload).not.toContain(".");
+      }
+    });
+
+    it("HONEST: the LEGACY dual-read bucket still carries the pre-hardening collision", () => {
+      process.env[FRIDAY_NS_HARDENING_ENV_FLAG] = "1";
+      // The two distinct tuples write to DISTINCT hardened namespaces (collision closed for
+      // new writes), but they STILL share ONE legacy bucket on the dual-read tail — so
+      // hardening does NOT retroactively split already-colliding legacy rows. Dual-read is
+      // strictly >= the pre-#661 state (no data loss), not a retroactive fix. Documented,
+      // not "fixed" (structurally impossible to split one shared bucket).
+      const forgedLegacy = resolveFridaySessionMemoryNamespaceCandidates(
+        makeSession({ accountId: "a", channel: "b", userId: "x.user.y" }),
+      )[1];
+      const victimLegacy = resolveFridaySessionMemoryNamespaceCandidates(
+        makeSession({ accountId: "a", channel: "b.user.x", userId: "y" }),
+      )[1];
+      expect(forgedLegacy).toBe("tenant.a.channel.b.user.x.user.y.shared");
+      expect(victimLegacy).toBe("tenant.a.channel.b.user.x.user.y.shared");
+      expect(forgedLegacy).toBe(victimLegacy);
     });
   });
 

--- a/test/unit/sessions/services/friday-session-service.test.ts
+++ b/test/unit/sessions/services/friday-session-service.test.ts
@@ -539,6 +539,92 @@ describe("FridaySessionService", () => {
     });
   });
 
+  // ─── getSessionMemoryNamespaceCandidates (F5.5 dual-read) ───
+
+  describe("getSessionMemoryNamespaceCandidates", () => {
+    const FLAG = "FRIDAY_NS_HARDENING_ENABLED";
+    const prior = process.env[FLAG];
+    afterEach(() => {
+      if (prior === undefined) delete process.env[FLAG];
+      else process.env[FLAG] = prior;
+    });
+
+    it("FLAG-OFF: returns the SINGLE legacy namespace (byte-identical to getSessionMemoryNamespace)", async () => {
+      delete process.env[FLAG];
+      await service.createSession({ channel: "discord", chatId: "user-ns1", userId: "user-ns1" });
+      const candidates = await service.getSessionMemoryNamespaceCandidates("discord:default:user-ns1");
+      const single = await service.getSessionMemoryNamespace("discord:default:user-ns1");
+      expect(candidates).toEqual([single]);
+      expect(candidates).toEqual(["tenant.default.channel.discord.user.user-ns1.shared"]);
+    });
+
+    it("FLAG-ON: a session created/persisted under FLAG-OFF is still recalled via the legacy candidate", async () => {
+      // Create the session with the flag OFF — the WRITE path persists the LEGACY
+      // (dotted) namespace, the real pre-flip data shape.
+      delete process.env[FLAG];
+      await service.createSession({
+        channel: "discord",
+        chatId: "ada.lovelace@example.com",
+        userId: "ada.lovelace@example.com",
+        chatKind: "dm",
+      });
+      const key = "discord:default:ada.lovelace@example.com";
+      const persistedLegacy = await service.getSessionMemoryNamespace(key);
+      expect(persistedLegacy).toBe(
+        "tenant.default.channel.discord.user.ada.lovelace-example.com.shared",
+      );
+
+      // Now flip the flag ON and read the dual-read candidates. The hardened namespace
+      // (new write target) comes first; the LEGACY namespace — byte-identical to what
+      // was persisted above — comes second, so the pre-flip memory is still found.
+      process.env[FLAG] = "1";
+      const candidates = await service.getSessionMemoryNamespaceCandidates(key);
+      expect(candidates).toEqual([
+        "tenant.default.channel.discord.user.ada-lovelace-example-com.shared", // hardened
+        "tenant.default.channel.discord.user.ada.lovelace-example.com.shared", // legacy
+      ]);
+      expect(candidates[1]).toBe(persistedLegacy);
+    });
+
+    it("FLAG-ON dedup-collapse: a non-dotted session yields ONE candidate", async () => {
+      process.env[FLAG] = "1";
+      await service.createSession({ channel: "discord", chatId: "user-ns1", userId: "user-ns1" });
+      const candidates = await service.getSessionMemoryNamespaceCandidates("discord:default:user-ns1");
+      expect(candidates).toEqual(["tenant.default.channel.discord.user.user-ns1.shared"]);
+    });
+
+    it("throws for nonexistent session", async () => {
+      await expectSessionError(
+        service.getSessionMemoryNamespaceCandidates("discord:default:nonexistent"),
+        FRIDAY_SESSION_ERROR_CODES.NOT_FOUND,
+      );
+    });
+
+    it("ROLLBACK (on->off): a HARDENED-persisted session keeps recalling via the defensive cache tail", async () => {
+      // `getOrCreateSession` (the live runtime path) PERSISTS the resolved `memory_namespace`.
+      // Under flag-ON it persists the HARDENED namespace for a dotted userId.
+      process.env[FLAG] = "1";
+      const key = "discord:default:grace.hopper@example.com";
+      await service.getOrCreateSession(key);
+      const session = await service.getSession(key);
+      const persistedHardened = session?.memoryNamespace;
+      expect(persistedHardened).toBe(
+        "tenant.default.channel.discord.user.grace-hopper-example-com.shared",
+      );
+
+      // Now ROLL BACK the flag (on -> off). The re-derived candidate is the LEGACY namespace
+      // only — which would ORPHAN the hardened-written rows — EXCEPT the defensive cache tail
+      // appends the persisted hardened namespace, so those rows are STILL recalled. This pins
+      // the reverse direction of the data-safety guarantee (no loss on rollback).
+      delete process.env[FLAG];
+      const candidates = await service.getSessionMemoryNamespaceCandidates(key);
+      expect(candidates).toEqual([
+        "tenant.default.channel.discord.user.grace.hopper-example.com.shared", // re-derived legacy
+        persistedHardened, // defensive cache tail (the bucket the rows actually live in)
+      ]);
+    });
+  });
+
   // ─── forkSession ───
 
   describe("forkSession", () => {

--- a/test/unit/sessions/services/friday-session-service.test.ts
+++ b/test/unit/sessions/services/friday-session-service.test.ts
@@ -600,7 +600,7 @@ describe("FridaySessionService", () => {
       );
     });
 
-    it("ROLLBACK (on->off): a HARDENED-persisted session keeps recalling via the defensive cache tail", async () => {
+    it("ROLLBACK (on->off): recall reads the PERSISTED hardened namespace ALONE — no re-derive regression (review must-fix)", async () => {
       // `getOrCreateSession` (the live runtime path) PERSISTS the resolved `memory_namespace`.
       // Under flag-ON it persists the HARDENED namespace for a dotted userId.
       process.env[FLAG] = "1";
@@ -612,16 +612,46 @@ describe("FridaySessionService", () => {
         "tenant.default.channel.discord.user.grace-hopper-example-com.shared",
       );
 
-      // Now ROLL BACK the flag (on -> off). The re-derived candidate is the LEGACY namespace
-      // only — which would ORPHAN the hardened-written rows — EXCEPT the defensive cache tail
-      // appends the persisted hardened namespace, so those rows are STILL recalled. This pins
-      // the reverse direction of the data-safety guarantee (no loss on rollback).
+      // Now ROLL BACK the flag (on -> off). Flag-off recall MUST be byte-identical to
+      // today (`getSessionMemoryNamespace`): the SINGLE persisted (authoritative)
+      // namespace, NOT a blind re-derivation. The persisted value here is the HARDENED
+      // namespace (what the rows were written under), so it — and ONLY it — is the
+      // recall target. The pre-fix bug demoted this to a defensive tail behind a
+      // re-derived legacy primary (an empty bucket searched first); the fix removes the
+      // dual-read/re-scope from the flag-off path entirely so there is zero regression
+      // regardless of any persisted-vs-re-derived drift.
       delete process.env[FLAG];
       const candidates = await service.getSessionMemoryNamespaceCandidates(key);
-      expect(candidates).toEqual([
-        "tenant.default.channel.discord.user.grace.hopper-example.com.shared", // re-derived legacy
-        persistedHardened, // defensive cache tail (the bucket the rows actually live in)
-      ]);
+      expect(candidates).toEqual([persistedHardened]);
+      // Byte-identical to `getSessionMemoryNamespace` (today's single-namespace recall).
+      const single = await service.getSessionMemoryNamespace(key);
+      expect(candidates).toEqual([single]);
+    });
+
+    it("FLAG-OFF (must-fix): persisted namespace DIFFERS from re-derived legacy — recall STILL reads the persisted bucket (no regression)", async () => {
+      // Drive the exact reviewer-specified adversarial case at the session-service
+      // boundary: a session whose PERSISTED `memory_namespace` differs from what a
+      // blind re-derivation of its current axes would produce. We construct this by
+      // persisting a HARDENED namespace under flag-on, then reading flag-off — the
+      // re-derived legacy (dotted) namespace differs from the persisted hardened one.
+      process.env[FLAG] = "1";
+      const key = "discord:default:ada.lovelace@example.com";
+      await service.getOrCreateSession(key);
+      const session = await service.getSession(key);
+      const persisted = session?.memoryNamespace;
+      expect(persisted).toBe(
+        "tenant.default.channel.discord.user.ada-lovelace-example-com.shared",
+      );
+
+      // Flag OFF: a blind re-derivation would yield the LEGACY (dotted) namespace, which
+      // is a DIFFERENT bucket than the persisted one. The fix guarantees recall uses the
+      // PERSISTED bucket (authoritative), never the divergent re-derivation.
+      delete process.env[FLAG];
+      const reDerivedLegacy = "tenant.default.channel.discord.user.ada.lovelace-example.com.shared";
+      expect(persisted).not.toBe(reDerivedLegacy); // confirm the drift is real
+      const candidates = await service.getSessionMemoryNamespaceCandidates(key);
+      expect(candidates).toEqual([persisted]);
+      expect(candidates).not.toContain(reDerivedLegacy);
     });
   });
 


### PR DESCRIPTION
## ns-hardening REDESIGN: flag-gate the dot-join collision fix DEFAULT-OFF + DUAL-READ

**Supersedes #661 — #661 should be CLOSED in favor of this PR (do-not-merge).**

### Why #661 is unsafe
#661 drops `.` from the namespace segment keep-set unconditionally. The session-memory
namespace (`tenant.<account>.channel.<channel>.user.<user>.shared`) is the memory store
SCOPE. On the **LIVE TS path**, deploying that change re-derives the namespace for any
EXISTING memory whose segment legitimately contained a `.` (an email-shaped userId, a
dotted account/channel) → that memory's scope changes → it is **orphaned**. That is a
one-way destructive re-key (a data downgrade) on deploy, with no migration/backfill.

### What this builds (per the operator's decision)
**(a) FLAG-GATED, DEFAULT-OFF.** The hardened (dot-drop) derivation is governed by
`FRIDAY_NS_HARDENING_ENABLED` (exactly `"1"` = on; unset/empty/`"0"`/other = off — same
convention as `FRIDAY_CLAUDE_ROUTE_ENABLED`). Flag **OFF ⇒ the keep-set KEEPS `.`** exactly
as before ⇒ every namespace is **byte-identical** to the legacy derivation ⇒ **zero
re-scope on deploy**.

**(b) DUAL-READ.** The READ (recall) path resolves an ORDERED, DEDUPED candidate list —
`[legacy]` when off, dedup `[hardened, legacy]` when on — and unions the recall over BOTH,
so memory written under the legacy namespace is STILL recalled after a flag flip. **No
one-way destructive re-key; no migration/backfill.** Dedup-collapse: when no segment carries
a `.`, hardened == legacy, so the list collapses to one entry → zero extra reads in the
common case even with the flag ON.

**(c) ADDITIVE collision-prevention kept.** The hardened derivation closes the cross-tuple
dot-join collision for NEW (hardened) writes — injective over normalized tuples.

### TS (LIVE recall path)
- `resolveFridaySessionMemoryNamespace` gains a `hardened` mode (reads the flag);
  `resolveFridaySessionMemoryNamespaceCandidates` returns the dual-read list;
  `isFridayNamespaceHardeningEnabled` reads the default-off flag.
- `sessionService.getSessionMemoryNamespaceCandidates` **re-DERIVES** both candidates from
  the session axes (NOT the cached write-time `memory_namespace`), so a session created
  before the flip is still recalled via the legacy candidate (+ a defensive stale-cache tail).
- The live recall consumer (`friday-agent-memory-tools.search`) unions the legacy candidate
  tail (both semantic search AND the lexical fallback) and dedups by id.
  `memoryService.search` stays single-namespace per call.

### Rust (DARK + DEPLOY-GO-gated)
- `session_namespace`: `ns_hardening_enabled` (default-off flag), the
  `hardened`-parameterized derivation, and `resolve_session_memory_namespace_candidates`.
- `friday-storage::memory::recall_confirmed_multi`: union + dedup-by-`memory_id`; the
  per-principal SQL stays single-principal (`debug_assert` intact) so cross-principal
  isolation can never widen.

### HONEST scope of the collision fix (documented, not blind-fixed)
The **LEGACY namespace IS the colliding string**, so dual-reading it re-reads the
pre-hardening collision bucket. The collision is closed for **NEW (hardened) WRITES only**;
legacy data keeps its pre-#661 collision semantics (the same accepted behavior under the
single-owner v1 threat model, where userIds are not adversarially controlled). Dual-read is
strictly **≥** the pre-#661 state (it can never lose data) but does **NOT** retroactively
split already-colliding legacy rows — structurally impossible (one shared bucket cannot be
disambiguated). Asserted in a `HONEST:` test in both TS and Rust.

### What remains
- **Operator gate to flip `FRIDAY_NS_HARDENING_ENABLED=1` in prod** (the deploy-GO; not done here).
- **Write-path hardening is partial under flag-on (DARK-remaining):** the WRITE paths
  (extraction-service + agent `memory_store`) source the namespace from the **cached**
  `session.memoryNamespace`, so flipping the flag ON makes new writes HARDENED only for
  brand-new sessions (`createSession` re-derives); pre-existing sessions keep writing to
  their cached legacy namespace until `alignSessionContext` recomputes. **Data-safe either
  way** (dual-read finds legacy), but collision-closure (c) applies only where writes are
  actually hardened. Wiring the write paths to re-derive under flag-on is intentionally
  deferred (it touches the broad live write path; surfaced as an operator question rather
  than blind-changed).
- **Rust live recall-principal wiring (DARK-remaining):** the Rust recall principal is the
  configured `--owner` allowlist entry (`RunPolicy::principal_id`), NOT a session-derived
  namespace, so `recall_confirmed_multi` + the candidate builder are the GATED MECHANISM;
  re-wiring the live recall principal to consult the candidate list is not done here.

### Tests (honest counts, all run locally)
- **TS:** `friday-session-memory-namespace.test.ts` 22 pass (flag-off byte-identical,
  flag-on hardened, dual-read `[hardened,legacy]`, dedup-collapse, collision-closed,
  HONEST legacy-collision). `friday-agent-memory-tools.test.ts` 44 pass (incl. dual-read
  THROUGH the live consumer: legacy-bucket memory recalled via semantic AND lexical
  fallback; flag-off single query; dedup-by-id; older-dep fallback).
  `friday-session-service.test.ts` 99 pass (incl. flag-off→on: a session persisted legacy
  is still recalled via the legacy candidate). 215 pass across dependent suites
  (subagent-registry, extraction-service, api-runtime). `tsc --noEmit` clean; `npm run lint`
  0 errors; `check:secret-patterns` clean.
- **Rust:** `session_namespace` 26 lib unit tests pass; `friday-hub` lib 520/520;
  `memory_persist` 18 (incl. `recall_confirmed_multi` union/dedup + single-principal
  isolation). `cargo clippy -p friday-hub -p friday-storage --all-targets -D warnings`
  clean. `cargo fmt` (pinned 1.95.0) applied + `--check` clean.

DARK + DEPLOY-GO-gated. No live wiring/deploy. Do NOT merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
---

### Update — additional verification
- **Rollback (on→off) data-safety test added.** A `getOrCreateSession` under flag-on persists a HARDENED `memory_namespace`; after flipping the flag OFF, the re-derived candidates are `[legacy]` — and the defensive cache tail appends the persisted hardened namespace, so hardened-written rows are STILL recalled. This pins the REVERSE direction of the guarantee (no loss on rollback). 100 session-service tests pass.
- **Write-persist nuance (clarifies the partial-write concern):** `getOrCreateSession` (the live runtime path) PERSISTS the resolved namespace; `createSession` does not (lazy re-derivation). So under flag-on, brand-new sessions via `getOrCreateSession` persist hardened; the dual-read + defensive tail keep every other path data-safe.
- **Full `vitest run --project default`:** 12,872 passed, 159 skipped, **1 pre-existing unrelated failure** (`friday-secret-crypto.test.ts` — `FRIDAY_MASTER_KEY_SOURCE=keychain`, env-dependent; fails identically on `main` without this diff). No failure is attributable to this change.