### PR TITLE
feat(providers-bridge): DARK TS->Rust route wiring for Tier-2 PROVIDER surfaces (DEFAULT-OFF)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -332,7 +332,7 @@
         "filename": "src/api/http/routes/friday-provider-routes.ts",
         "hashed_secret": "ecb252044b5ea0f679ee78ec1a12904739e2904d",
         "is_verified": false,
-        "line_number": 278
+        "line_number": 282
       }
     ],
     "src/api/http/routes/friday-setup-routes.ts": [
@@ -341,7 +341,7 @@
         "filename": "src/api/http/routes/friday-setup-routes.ts",
         "hashed_secret": "ecb252044b5ea0f679ee78ec1a12904739e2904d",
         "is_verified": false,
-        "line_number": 2130
+        "line_number": 2193
       }
     ],
     "src/media-understanding/friday-media-doctor.ts": [
@@ -905,14 +905,14 @@
         "filename": "test/unit/hub/friday-hub-bootstrap-env.test.ts",
         "hashed_secret": "5c5a15a8b0b3e154d77746945e563ba40100681b",
         "is_verified": false,
-        "line_number": 131
+        "line_number": 132
       },
       {
         "type": "Secret Keyword",
         "filename": "test/unit/hub/friday-hub-bootstrap-env.test.ts",
         "hashed_secret": "8a8281cec699f5e51330e21dd7fab3531af6ef0c",
         "is_verified": false,
-        "line_number": 132
+        "line_number": 133
       }
     ],
     "test/unit/media-understanding/friday-openai-vision-provider.test.ts": [
@@ -1124,5 +1124,5 @@
       }
     ]
   },
-  "generated_at": "2026-06-09T17:28:28Z"
+  "generated_at": "2026-06-11T17:49:22Z"
 }

--- a/src/api/http/routes/friday-provider-routes.ts
+++ b/src/api/http/routes/friday-provider-routes.ts
@@ -54,6 +54,10 @@ import {
   listFridayProviderTemplates,
 } from "#providers";
 import { FridayDomainError } from "#errors";
+import type {
+  FridayRustCapabilityDoctorReceipt,
+  FridayRustHubCapabilityDoctorService,
+} from "../../mission-spine/friday-rust-hub-capability-doctor-bridge-service.js";
 import {
   resolveExistingOAuthProvider,
   resolveOrProvisionOAuthProvider,
@@ -414,6 +418,34 @@ export interface FridayProviderRoutesDeps {
    * surfaces (GET/PUT /v1/model-routing), which remain operator_external_adapter.
    */
   allowTestOnlyProviderRoutingControlsExecution?: boolean;
+  /**
+   * DARK cut-over flag (DEFAULT-OFF). When `true`, the retired provider-probe routes
+   * (`providers.validate` / `providers.doctor` / `capabilities.doctor`) — instead of
+   * fail-closing with 503 — bridge to the merged Rust `hub_capability_doctor` bin
+   * (#658) via {@link rustCapabilityDoctor} and return its REFS-ONLY composite payload.
+   * When falsy (the default) those routes are byte-identical to today: they fail-close
+   * (503 TS_RUNTIME_PROVIDER_PROBE_RETIRED) unless the test-oracle flag re-enables the
+   * legacy probe.
+   *
+   * SURFACE-SHAPE: the Rust bin is a fixed codex/claude (CLI) + deepseek/anthropic
+   * (key) doctor with NO providerId input — it does NOT reproduce the legacy
+   * per-`:providerId` validate/doctor shapes. Flipping this flag CHANGES the response
+   * contract for clients — see the PR / operator note.
+   *
+   * QUOTA: only `capabilities.doctor` may opt into the bin's LIVE key-validation arm
+   * (~1-2 Anthropic tokens), and ONLY on an explicit `validateKeys: true` request body
+   * field; `providers.validate` / `providers.doctor` never pass `--validate-keys`. The
+   * resolved boolean is supplied by the runtime (sourced from
+   * `FRIDAY_ROUTE_PROVIDERS_VIA_RUST` / explicit config); this factory does NOT read
+   * the env itself.
+   */
+  routeProvidersViaRust?: boolean;
+  /**
+   * The Rust capability-doctor bridge service consulted ONLY when
+   * {@link routeProvidersViaRust} is `true`. Injected by the runtime (and by tests).
+   * When the flag is on but this is absent, those routes fail closed.
+   */
+  rustCapabilityDoctor?: FridayRustHubCapabilityDoctorService;
 }
 
 export function createFridayProviderSetupMutatingActionRequest(input: {
@@ -801,6 +833,26 @@ export function createFridayProviderRoutes(
     };
   }
 
+  /**
+   * DARK cut-over bridge for the retired provider-probe routes. Returns the Rust
+   * `hub_capability_doctor` refs-only payload. Fails closed (503) when the flag is on
+   * but the bridge was not wired. `validateKeys` is forwarded ONLY where an explicit
+   * request opts in (capabilities.doctor); the other probe routes pass false → the
+   * bin's zero-quota CLI-detect-only default.
+   */
+  async function bridgeCapabilityDoctorViaRust(
+    validateKeys: boolean,
+  ): Promise<FridayRustCapabilityDoctorReceipt> {
+    if (!deps.rustCapabilityDoctor) {
+      throwRetiredProviderRuntime(
+        "TS_RUNTIME_PROVIDER_PROBE_RETIRED",
+        "TypeScript provider probe execution (Rust route enabled but capability-doctor bridge not wired)",
+        "provider_probe",
+      );
+    }
+    return deps.rustCapabilityDoctor.doctor({ validateKeys });
+  }
+
   return [
     {
       operationId: "providers.templates.list",
@@ -865,7 +917,7 @@ export function createFridayProviderRoutes(
       path: "/v1/capabilities/doctor",
       auth: { public: true },
       rateLimitPolicyId: "provider.validate",
-      async handler(ctx): Promise<FridayRunCapabilityDoctorResponse> {
+      async handler(ctx): Promise<FridayRunCapabilityDoctorResponse | FridayRustCapabilityDoctorReceipt> {
         const raw = ctx.body as Record<string, unknown> | null;
         const providerIds = parseCapabilityDoctorProviderIds(raw);
         const ticket = maybeRequireProviderMutationTicket({
@@ -876,6 +928,17 @@ export function createFridayProviderRoutes(
           parameters: { providerIds: providerIds ?? "all-providers" },
           surface: "api:/v1/capabilities/doctor",
         });
+        // DARK cut-over (DEFAULT-OFF): bridge to the Rust hub_capability_doctor bin
+        // instead of fail-closing. The canonical mutation gate above still runs first
+        // (byte-identical gate ordering). QUOTA: this is the ONLY probe route that may
+        // request the bin's LIVE key-validation arm (~1-2 Anthropic tokens), and ONLY
+        // when the request body explicitly sets `validateKeys: true`; absent/false runs
+        // the bin's zero-quota CLI-detect-only default.
+        if (deps.routeProvidersViaRust === true) {
+          const validateKeys = raw?.validateKeys === true;
+          const receipt = await bridgeCapabilityDoctorViaRust(validateKeys);
+          return withCanonicalGate(receipt, ticket);
+        }
         assertProviderProbeTestOracleAllowed(deps);
         const report = await deps.providerService.runCapabilityDoctor({
           ownerUserId: ctx.principal?.userId,
@@ -1008,7 +1071,7 @@ export function createFridayProviderRoutes(
       path: "/v1/providers/:providerId/validate",
       auth: { public: true },
       rateLimitPolicyId: "provider.validate",
-      async handler(ctx): Promise<FridayValidateProviderResponse> {
+      async handler(ctx): Promise<FridayValidateProviderResponse | FridayRustCapabilityDoctorReceipt> {
         const { providerId } = ctx.params as { providerId: string };
         const body = (ctx.body ?? {}) as Record<string, unknown>;
         const ticket = maybeRequireProviderMutationTicket({
@@ -1019,6 +1082,16 @@ export function createFridayProviderRoutes(
           parameters: { providerId },
           surface: "api:/v1/providers/validate",
         });
+        // DARK cut-over (DEFAULT-OFF): bridge to the Rust hub_capability_doctor bin
+        // instead of fail-closing. The canonical mutation gate above still runs first.
+        // QUOTA: validate NEVER opts into the live key-validation arm (validateKeys
+        // false) — zero quota. SURFACE-SHAPE: the bin has no providerId input, so the
+        // returned doctor is the fixed codex/claude+deepseek/anthropic composite, not a
+        // per-`:providerId` validation result (see the deps doc + PR).
+        if (deps.routeProvidersViaRust === true) {
+          const receipt = await bridgeCapabilityDoctorViaRust(false);
+          return withCanonicalGate(receipt, ticket);
+        }
         assertProviderProbeTestOracleAllowed(deps);
         const validation =
           await deps.providerService.validateProvider(providerId, {
@@ -1033,8 +1106,17 @@ export function createFridayProviderRoutes(
       method: "GET",
       path: "/v1/providers/:providerId/doctor",
       auth: { public: true },
-      async handler(ctx): Promise<FridayGetProviderDoctorResponse> {
+      async handler(ctx): Promise<FridayGetProviderDoctorResponse | FridayRustCapabilityDoctorReceipt> {
         const { providerId } = ctx.params as { providerId: string };
+        // DARK cut-over (DEFAULT-OFF): bridge to the Rust hub_capability_doctor bin
+        // instead of fail-closing. QUOTA: doctor NEVER opts into the live key-validation
+        // arm (validateKeys false) — zero quota. SURFACE-SHAPE: the bin has no
+        // providerId input, so the returned doctor is the fixed
+        // codex/claude+deepseek/anthropic composite, not a per-`:providerId` health
+        // diagnostic (see the deps doc + PR).
+        if (deps.routeProvidersViaRust === true) {
+          return bridgeCapabilityDoctorViaRust(false);
+        }
         assertProviderProbeTestOracleAllowed(deps);
         const doctor = await deps.providerService.doctorProvider(providerId);
         return { doctor };

--- a/src/api/http/routes/friday-setup-routes.ts
+++ b/src/api/http/routes/friday-setup-routes.ts
@@ -41,6 +41,10 @@ import { parseFridaySecretInput } from "../../../security/friday-secret-ref.js";
 import { isFridayLoopbackAddress } from "../friday-http-client-ip.js";
 import { isUnauthenticatedPublicPrincipal } from "../../../security/friday-owner-session-channel-capability.js";
 import type { FridayAuthPrincipal } from "../../model/friday-api-auth.types.js";
+import type {
+  FridayRustHubProvidersDetectService,
+  FridayRustProvidersDetectReceipt,
+} from "../../mission-spine/friday-rust-hub-providers-detect-bridge-service.js";
 
 // ─── Types ───
 
@@ -1922,6 +1926,28 @@ export interface FridaySetupRoutesDeps {
    * reconciliation note.
    */
   allowTestOnlyProviderDetectExecution?: boolean;
+  /**
+   * DARK cut-over flag (DEFAULT-OFF). When `true`, the retired `providers.detect`
+   * route — instead of fail-closing with 503 — bridges to the merged Rust
+   * `hub_providers_detect` bin (#591/#639) via {@link rustProvidersDetect} and returns
+   * its REFS-ONLY CLI-login-status payload. When falsy (the default) the route is
+   * byte-identical to today: it fail-closes (503 TS_RUNTIME_PROVIDERS_DETECT_RETIRED)
+   * unless the test-oracle flag re-enables the legacy BYOK probe.
+   *
+   * SURFACE-SHAPE: the Rust bin answers the codex/claude CLI-login question (input
+   * `--probe`), NOT the legacy BYOK probe (apiKey/kind/baseUrl -> /v1/models). Flipping
+   * this flag CHANGES the response contract for clients — see the PR / operator note.
+   * The resolved boolean is supplied by the runtime (sourced from
+   * `FRIDAY_ROUTE_PROVIDERS_VIA_RUST` / explicit config); this factory does NOT read
+   * the env itself.
+   */
+  routeProvidersViaRust?: boolean;
+  /**
+   * The Rust providers-detect bridge service consulted ONLY when
+   * {@link routeProvidersViaRust} is `true`. Injected by the runtime (and by tests).
+   * When the flag is on but this is absent, the route fails closed.
+   */
+  rustProvidersDetect?: FridayRustHubProvidersDetectService;
 }
 
 // ─── Factory ───
@@ -2120,8 +2146,45 @@ export function createFridaySetupRoutes(
       path: "/v1/providers/detect",
       auth: { public: true, allowUnauthenticatedMutation: true },
       rateLimitPolicyId: "provider.validate",
-      async handler(ctx): Promise<DetectProviderResponse> {
+      async handler(ctx): Promise<DetectProviderResponse | FridayRustProvidersDetectReceipt> {
         assertSetupBootstrapBoundary(ctx);
+
+        // DARK cut-over (DEFAULT-OFF): when FRIDAY_ROUTE_PROVIDERS_VIA_RUST is on
+        // (resolved into deps.routeProvidersViaRust), bridge to the Rust
+        // hub_providers_detect bin and return its REFS-ONLY CLI-login-status payload
+        // instead of fail-closing. The bootstrap boundary above still runs first
+        // (byte-identical to today's gate ordering). The legacy BYOK input validation
+        // below does NOT apply to the Rust surface — the bin validates its own argv —
+        // so it is intentionally bypassed on this branch. SURFACE-SHAPE differs from
+        // the legacy BYOK probe; see the deps doc + PR.
+        if (deps.routeProvidersViaRust === true) {
+          if (!deps.rustProvidersDetect) {
+            throw new FridayDomainError(
+              "TS_RUNTIME_PROVIDERS_DETECT_RETIRED",
+              "Provider detection is fail-closed: the Rust route is enabled but the providers-detect bridge is not wired.",
+              {
+                httpStatus: 503,
+                details: {
+                  classification: "fail_closed",
+                  replacement: "rust_owned_provider_detect_entrypoint_required",
+                },
+              },
+            );
+          }
+          const detectBody = ctx.body as DetectProviderRequest | null;
+          // Optional `probe` selector (`codex` | `claude` | `both`); default `both`.
+          // The legacy BYOK kind/apiKey/baseUrl fields are NOT consumed here.
+          const requestedProbe =
+            detectBody && typeof (detectBody as Record<string, unknown>).probe === "string"
+              ? ((detectBody as Record<string, unknown>).probe as string)
+              : undefined;
+          const probe =
+            requestedProbe === "codex" || requestedProbe === "claude" || requestedProbe === "both"
+              ? requestedProbe
+              : "both";
+          return deps.rustProvidersDetect.detect({ probe });
+        }
+
         const body = ctx.body as DetectProviderRequest | null;
         if (!body || typeof body !== "object") {
           throw new FridayDomainError("VALIDATION_ERROR", "Request body is required", { httpStatus: 400 });

--- a/src/api/mission-spine/friday-rust-hub-capability-doctor-bridge-service.ts
+++ b/src/api/mission-spine/friday-rust-hub-capability-doctor-bridge-service.ts
@@ -1,0 +1,347 @@
+import { execFile } from "node:child_process";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+
+import { FridayDomainError } from "#errors";
+
+/**
+ * TS->Rust REFS-ONLY bridge for the merged `hub_capability_doctor` bin (#658). It
+ * surfaces the (now 503) `providers.doctor` / `providers.validate` / `capabilities.doctor`
+ * surfaces at the Rust layer by spawning the bin and parsing its refs-only JSON.
+ *
+ * It clones the read-only execFile shape from the run-readback siblings. It is DARK:
+ * the routes that drive it (`providers.doctor`/`providers.validate`/`capabilities.doctor`
+ * in friday-provider-routes.ts) consult this bridge ONLY when the cut-over flag
+ * `FRIDAY_ROUTE_PROVIDERS_VIA_RUST` is ON; with the flag OFF those routes stay
+ * byte-identical to today's fail-closed 503. It registers no production route on its
+ * own and confers no v1 GO.
+ *
+ * ## QUOTA SAFETY — the key posture
+ * The bin's live key-validation arm spends LIVE Anthropic quota (~1-2 tokens) on a
+ * minimal `POST /v1/messages max_tokens=1`. That arm runs ONLY when the bin is passed
+ * `--validate-keys`. This bridge passes `--validate-keys` ONLY when the caller sets
+ * `input.validateKeys === true` (operator-gated). The DEFAULT (`validateKeys`
+ * unset/false) runs the ZERO-quota CLI-detect-only path; the key section comes back
+ * honestly `null` / not-probed (NOT a fabricated all-missing).
+ *
+ * ## SURFACE-SHAPE NOTE (deliberate, not a fabrication)
+ * The legacy TS `providers.validate`/`providers.doctor` are per-`:providerId` probes;
+ * `capabilities.doctor` accepts a providerIds filter. `hub_capability_doctor` has NO
+ * providerId input — it is a fixed codex/claude (CLI) + deepseek/anthropic (key)
+ * doctor. When the flag is ON the routes return THIS refs-only composite — they do NOT
+ * synthesize the old per-providerId shapes. That contract change is surfaced (PR body +
+ * operator question), not blind-filled.
+ *
+ * ## Output contract — REFS ONLY (no bodies, no secrets, no account info)
+ * The bin emits ONLY secret-safe fields (strips raw CLI stdout/stderr; the key
+ * outcomes are already coarse label/status; runs its own `reject_forbidden_output`
+ * guard before printing). This bridge re-validates the shape and fails CLOSED (503) on
+ * any non-zero exit, timeout, parse failure, wrong truth label, `ok:false`, or invalid
+ * shape.
+ *
+ * NEITHER bin takes `--db` — this bridge spawns with (at most) `--validate-keys` only.
+ */
+const execFileAsync = promisify(execFile);
+
+/** One per-CLI-provider refs-only detection entry — the four safe fields ONLY. */
+export interface FridayRustCapabilityCliEntry {
+  /** Safe provider label (`codex` | `claude`). */
+  readonly provider: string;
+  readonly installed: boolean;
+  readonly authenticated: boolean;
+  /** Coarse static detail: `logged_in` | `not_logged_in` | `not_installed`. */
+  readonly detail: string;
+}
+
+/** One per-credential refs-only key-validation entry — the coarse safe fields ONLY. */
+export interface FridayRustCapabilityKeyEntry {
+  /** Safe credential label (`deepseek` | `anthropic`). */
+  readonly provider: string;
+  /** Coarse outcome label: `valid` | `invalid` | `unavailable` | `credential_missing`. */
+  readonly label: string;
+  /** Coarse HTTP status (present only for `invalid`); otherwise null. */
+  readonly status: number | null;
+  /** Coarse static detail (present only for `unavailable`); otherwise null. */
+  readonly detail: string | null;
+}
+
+/** Refs-only capability-doctor receipt — no bodies, no secrets, no account info. */
+export interface FridayRustCapabilityDoctorReceipt {
+  /** The bin's truth label — proof/dev tier, NOT a product/proven receipt. */
+  readonly truthLabel: "rust_capability_doctor";
+  /** Always true — a loud reminder this is a dev bridge, not a product path. */
+  readonly proofOnly: true;
+  /** CLI-detect section: per-provider entries (the codex/claude login question). */
+  readonly cliDetected: readonly FridayRustCapabilityCliEntry[];
+  /** Safe labels of the CLI providers reporting logged-in (no fallback). */
+  readonly cliLoggedIn: readonly string[];
+  /** True iff `--validate-keys` was passed (the live, quota-spending arm ran). */
+  readonly keyValidationProbed: boolean;
+  /**
+   * Live key-validation section, present ONLY when probed; `null` (honest absence)
+   * when the zero-quota default path ran.
+   */
+  readonly keyValidation: readonly FridayRustCapabilityKeyEntry[] | null;
+  /**
+   * Credentials a live round-trip CONFIRMED valid (only `valid` counts); `null` when
+   * not probed.
+   */
+  readonly confirmedValidKeys: readonly string[] | null;
+}
+
+export interface FridayRustCapabilityDoctorInput {
+  /**
+   * Run the LIVE key-validation arm (`--validate-keys`). DEFAULT false (zero quota).
+   * Setting true spends ~1-2 live Anthropic tokens — operator-gated at the call site.
+   */
+  readonly validateKeys?: boolean;
+}
+
+export interface CreateFridayRustHubCapabilityDoctorServiceOptions {
+  readonly repoRoot?: string;
+  /** Path to a prebuilt `hub_capability_doctor` binary; falls back to `cargo run --bin` when absent. */
+  readonly adapterBin?: string;
+  readonly timeoutMs?: number;
+}
+
+export interface FridayRustHubCapabilityDoctorService {
+  doctor(input?: FridayRustCapabilityDoctorInput): Promise<FridayRustCapabilityDoctorReceipt>;
+}
+
+function unavailable(message: string): FridayDomainError {
+  return new FridayDomainError("MISSION_SPINE_RUST_CAPABILITY_DOCTOR_UNAVAILABLE", message, {
+    httpStatus: 503,
+    details: {
+      surface: "service:rust_hub_capability_doctor",
+      bridge: "rust_capability_doctor",
+      proofOnly: true,
+      proofReady: false,
+    },
+  });
+}
+
+function readTimeoutMs(raw: string | undefined, fallback: number): number {
+  if (!raw) return fallback;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function resolveDefaultRepoRoot(): string {
+  const moduleDir = dirname(fileURLToPath(import.meta.url));
+  return resolve(moduleDir, "../../..");
+}
+
+const KEY_LABELS: ReadonlySet<string> = new Set([
+  "valid",
+  "invalid",
+  "unavailable",
+  "credential_missing",
+]);
+
+/** Validate + normalize one CLI-detect entry. Fails closed on any shape violation. */
+function parseCliEntry(value: unknown): FridayRustCapabilityCliEntry {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw unavailable("Rust hub_capability_doctor cli entry is not an object.");
+  }
+  const entry = value as Record<string, unknown>;
+  if ("stdout" in entry || "stderr" in entry) {
+    throw unavailable("Rust hub_capability_doctor cli entry carried a raw CLI stream field (rejected).");
+  }
+  const provider = entry.provider;
+  const installed = entry.installed;
+  const authenticated = entry.authenticated;
+  const detail = entry.detail;
+  if (
+    typeof provider !== "string" ||
+    provider.length === 0 ||
+    typeof installed !== "boolean" ||
+    typeof authenticated !== "boolean" ||
+    typeof detail !== "string" ||
+    detail.length === 0
+  ) {
+    throw unavailable("Rust hub_capability_doctor cli entry has an invalid shape.");
+  }
+  return { provider, installed, authenticated, detail };
+}
+
+/** Validate + normalize one key-validation entry. Fails closed on any shape violation. */
+function parseKeyEntry(value: unknown): FridayRustCapabilityKeyEntry {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw unavailable("Rust hub_capability_doctor key entry is not an object.");
+  }
+  const entry = value as Record<string, unknown>;
+  const provider = entry.provider;
+  const label = entry.label;
+  if (
+    typeof provider !== "string" ||
+    provider.length === 0 ||
+    typeof label !== "string" ||
+    !KEY_LABELS.has(label)
+  ) {
+    throw unavailable("Rust hub_capability_doctor key entry has an invalid shape.");
+  }
+  // `status` is a coarse HTTP code on `invalid`, else null/absent; `detail` is a coarse
+  // static label on `unavailable`, else null/absent. Both validated permissively as
+  // (number|null) / (string|null) — never a body.
+  const statusRaw = entry.status;
+  const status =
+    typeof statusRaw === "number" && Number.isFinite(statusRaw) ? statusRaw : null;
+  const detailRaw = entry.detail;
+  const detail = typeof detailRaw === "string" && detailRaw.length > 0 ? detailRaw : null;
+  return { provider, label, status, detail };
+}
+
+/**
+ * Validate + normalize the bin's refs-only stdout into a receipt. Fails closed on any
+ * shape violation. Enforces the bin's honesty contract: the key section is present iff
+ * `key_validation_probed` is true (and `null` otherwise).
+ */
+function parseReceipt(payload: unknown): FridayRustCapabilityDoctorReceipt {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    throw unavailable("Rust hub_capability_doctor bridge returned a non-object payload.");
+  }
+  const root = payload as Record<string, unknown>;
+
+  if (root.truth_label !== "rust_capability_doctor") {
+    throw unavailable("Rust hub_capability_doctor bridge payload is not labeled rust_capability_doctor.");
+  }
+  if (root.ok === false) {
+    throw unavailable("Rust hub_capability_doctor bridge reported a fail-closed doctor.");
+  }
+
+  const cliRaw = root.cli_detected;
+  if (!Array.isArray(cliRaw)) {
+    throw unavailable("Rust hub_capability_doctor bridge payload is missing the cli_detected array.");
+  }
+  const cliDetected = cliRaw.map(parseCliEntry);
+
+  const loggedInRaw = root.cli_logged_in;
+  if (!Array.isArray(loggedInRaw) || !loggedInRaw.every((p) => typeof p === "string")) {
+    throw unavailable("Rust hub_capability_doctor bridge payload has an invalid cli_logged_in list.");
+  }
+  const cliLoggedIn = loggedInRaw as string[];
+
+  const keyValidationProbed = root.key_validation_probed;
+  if (typeof keyValidationProbed !== "boolean") {
+    throw unavailable("Rust hub_capability_doctor bridge payload is missing key_validation_probed.");
+  }
+
+  if (keyValidationProbed) {
+    const keyRaw = root.key_validation;
+    if (!Array.isArray(keyRaw)) {
+      throw unavailable(
+        "Rust hub_capability_doctor bridge claimed probed keys but is missing the key_validation array.",
+      );
+    }
+    const keyValidation = keyRaw.map(parseKeyEntry);
+    const confirmedRaw = root.confirmed_valid_keys;
+    if (!Array.isArray(confirmedRaw) || !confirmedRaw.every((p) => typeof p === "string")) {
+      throw unavailable(
+        "Rust hub_capability_doctor bridge probed keys but has an invalid confirmed_valid_keys list.",
+      );
+    }
+    return {
+      truthLabel: "rust_capability_doctor",
+      proofOnly: true,
+      cliDetected,
+      cliLoggedIn,
+      keyValidationProbed: true,
+      keyValidation,
+      confirmedValidKeys: confirmedRaw as string[],
+    };
+  }
+
+  // NOT probed: the key section MUST be the honest null (never a fabricated array).
+  if (root.key_validation !== null && root.key_validation !== undefined) {
+    throw unavailable(
+      "Rust hub_capability_doctor reported not-probed but carried a non-null key section (rejected).",
+    );
+  }
+  return {
+    truthLabel: "rust_capability_doctor",
+    proofOnly: true,
+    cliDetected,
+    cliLoggedIn,
+    keyValidationProbed: false,
+    keyValidation: null,
+    confirmedValidKeys: null,
+  };
+}
+
+export function createFridayRustHubCapabilityDoctorService(
+  options: CreateFridayRustHubCapabilityDoctorServiceOptions = {},
+): FridayRustHubCapabilityDoctorService {
+  const repoRoot = resolve(
+    options.repoRoot ?? process.env.FRIDAY_REPO_ROOT ?? resolveDefaultRepoRoot(),
+  );
+  const rustCoreRoot = resolve(
+    process.env.FRIDAY_MISSION_SPINE_RUST_CORE_ROOT ?? join(repoRoot, "rust-core"),
+  );
+  const adapterBin = options.adapterBin ?? process.env.FRIDAY_HUB_CAPABILITY_DOCTOR_BIN;
+  const timeoutMs =
+    options.timeoutMs ?? readTimeoutMs(process.env.FRIDAY_HUB_CAPABILITY_DOCTOR_TIMEOUT_MS, 120_000);
+
+  let warnedCargoFallback = false;
+
+  return {
+    async doctor(
+      input: FridayRustCapabilityDoctorInput = {},
+    ): Promise<FridayRustCapabilityDoctorReceipt> {
+      // QUOTA GATE: pass `--validate-keys` ONLY on an explicit true. Any other value
+      // (false/undefined) runs the bin's zero-quota CLI-detect-only default.
+      const validateKeys = input.validateKeys === true;
+      const adapterArgs = validateKeys ? ["--validate-keys"] : [];
+
+      const command = adapterBin ?? "cargo";
+      const args = adapterBin
+        ? adapterArgs
+        : [
+            "run",
+            "--quiet",
+            "--manifest-path",
+            join(rustCoreRoot, "Cargo.toml"),
+            "-p",
+            "friday-hub",
+            "--bin",
+            "hub_capability_doctor",
+            "--",
+            ...adapterArgs,
+          ];
+      if (!adapterBin && !warnedCargoFallback) {
+        warnedCargoFallback = true;
+        console.warn(
+          "[friday][rust-capability-doctor] FRIDAY_HUB_CAPABILITY_DOCTOR_BIN is not set — " +
+            "falling back to `cargo run` in the request hot path (compiles per cold start; " +
+            "adds latency and a failure surface). Set it to a prebuilt hub_capability_doctor " +
+            "binary at deploy time.",
+        );
+      }
+
+      let stdout = "";
+      try {
+        const result = await execFileAsync(command, args, {
+          cwd: repoRoot,
+          timeout: timeoutMs,
+          maxBuffer: 2 * 1024 * 1024,
+          env: {
+            ...process.env,
+            RUST_BACKTRACE: "0",
+          },
+        });
+        stdout = result.stdout;
+      } catch {
+        // Non-zero exit, timeout, or spawn failure → fail closed (no detail surfaced).
+        throw unavailable("Rust hub_capability_doctor bridge could not produce a refs-only doctor.");
+      }
+
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(stdout);
+      } catch {
+        throw unavailable("Rust hub_capability_doctor bridge returned invalid JSON.");
+      }
+      return parseReceipt(parsed);
+    },
+  };
+}

--- a/src/api/mission-spine/friday-rust-hub-providers-detect-bridge-service.ts
+++ b/src/api/mission-spine/friday-rust-hub-providers-detect-bridge-service.ts
@@ -1,0 +1,263 @@
+import { execFile } from "node:child_process";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+
+import { FridayDomainError } from "#errors";
+
+/**
+ * TS->Rust REFS-ONLY bridge for the merged `hub_providers_detect` bin (#591/#639).
+ * It surfaces the (now 503) `providers.detect` onboarding question — "which provider
+ * CLIs report themselves installed + logged-in?" — at the Rust layer by spawning the
+ * bin and parsing its refs-only JSON.
+ *
+ * It clones the read-only execFile shape from
+ * `friday-rust-hub-run-readback-service` / `friday-rust-hub-run-answer-readback-service`.
+ * It is DARK: the route that drives it (`providers.detect` in friday-setup-routes.ts)
+ * only consults this bridge when the cut-over flag `FRIDAY_ROUTE_PROVIDERS_VIA_RUST`
+ * is ON; with the flag OFF the route stays byte-identical to today's fail-closed 503.
+ * It registers no production route on its own and confers no v1 GO.
+ *
+ * ## SURFACE-SHAPE NOTE (deliberate, not a fabrication)
+ * The legacy TS `providers.detect` is a BYOK probe (apiKey/kind/baseUrl ->
+ * provider /v1/models -> availableModels/validated). `hub_providers_detect` answers
+ * a DIFFERENT question: the codex/claude CLI login status, with input `--probe
+ * codex|claude|both` (default `both`). When the flag is ON the route returns THIS
+ * refs-only payload — it does NOT synthesize the old BYOK fields. That contract change
+ * is surfaced (PR body + operator question), not blind-filled.
+ *
+ * ## Output contract — REFS ONLY (no bodies, no secrets, no account info)
+ * The bin emits ONLY secret-safe fields (it strips raw CLI stdout/stderr and runs its
+ * own `reject_forbidden_output` guard before printing). This bridge re-validates the
+ * shape and fails CLOSED (503) on any non-zero exit, timeout, parse failure, wrong
+ * truth label, `ok:false`, or invalid shape.
+ *
+ * NEITHER bin takes `--db` — this bridge spawns with `--probe <selection>` only (no
+ * `existsSync(dbPath)` guard, unlike the run-readback siblings which read a hub DB).
+ */
+const execFileAsync = promisify(execFile);
+
+/** Provider selection the bin understands (`--probe` value). Default `both`. */
+export type FridayRustProvidersDetectProbe = "codex" | "claude" | "both";
+
+/** One per-provider refs-only detection entry — the four safe fields ONLY. */
+export interface FridayRustProvidersDetectEntry {
+  /** Safe provider label (`codex` | `claude`). */
+  readonly provider: string;
+  readonly installed: boolean;
+  readonly authenticated: boolean;
+  /** Coarse static detail: `logged_in` | `not_logged_in` | `not_installed`. */
+  readonly detail: string;
+}
+
+/** Refs-only providers-detect receipt — no bodies, no secrets, no account info. */
+export interface FridayRustProvidersDetectReceipt {
+  /** The bin's truth label — proof/dev tier, NOT a product/proven receipt. */
+  readonly truthLabel: "rust_providers_detect";
+  /** Always true — a loud reminder this is a dev bridge, not a product path. */
+  readonly proofOnly: true;
+  /** Per-provider detection entries (provider label + booleans + static detail). */
+  readonly detected: readonly FridayRustProvidersDetectEntry[];
+  /** Safe labels of providers that are installed AND authenticated (no fallback). */
+  readonly readyProviders: readonly string[];
+  /** Aggregate onboarding-readiness booleans (provider labels + booleans only). */
+  readonly anyAuthenticated: boolean;
+  readonly allAuthenticated: boolean;
+}
+
+export interface FridayRustProvidersDetectInput {
+  /** Which provider CLIs to probe. Defaults to `both` when omitted. */
+  readonly probe?: FridayRustProvidersDetectProbe;
+}
+
+export interface CreateFridayRustHubProvidersDetectServiceOptions {
+  readonly repoRoot?: string;
+  /** Path to a prebuilt `hub_providers_detect` binary; falls back to `cargo run --bin` when absent. */
+  readonly adapterBin?: string;
+  readonly timeoutMs?: number;
+}
+
+export interface FridayRustHubProvidersDetectService {
+  detect(input?: FridayRustProvidersDetectInput): Promise<FridayRustProvidersDetectReceipt>;
+}
+
+function unavailable(message: string): FridayDomainError {
+  return new FridayDomainError("MISSION_SPINE_RUST_PROVIDERS_DETECT_UNAVAILABLE", message, {
+    httpStatus: 503,
+    details: {
+      surface: "service:rust_hub_providers_detect",
+      bridge: "rust_providers_detect",
+      proofOnly: true,
+      proofReady: false,
+    },
+  });
+}
+
+function readTimeoutMs(raw: string | undefined, fallback: number): number {
+  if (!raw) return fallback;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function resolveDefaultRepoRoot(): string {
+  const moduleDir = dirname(fileURLToPath(import.meta.url));
+  return resolve(moduleDir, "../../..");
+}
+
+const VALID_PROBES: ReadonlySet<string> = new Set(["codex", "claude", "both"]);
+
+/**
+ * Validate + normalize one per-provider entry. Accepts ONLY the four safe fields,
+ * fails closed on a missing/mis-typed field, and rejects any raw-stream field name as
+ * a defensive backstop (the bin already strips them).
+ */
+function parseEntry(value: unknown): FridayRustProvidersDetectEntry {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw unavailable("Rust hub_providers_detect entry is not an object.");
+  }
+  const entry = value as Record<string, unknown>;
+  if ("stdout" in entry || "stderr" in entry) {
+    throw unavailable("Rust hub_providers_detect entry carried a raw CLI stream field (rejected).");
+  }
+  const provider = entry.provider;
+  const installed = entry.installed;
+  const authenticated = entry.authenticated;
+  const detail = entry.detail;
+  if (
+    typeof provider !== "string" ||
+    provider.length === 0 ||
+    typeof installed !== "boolean" ||
+    typeof authenticated !== "boolean" ||
+    typeof detail !== "string" ||
+    detail.length === 0
+  ) {
+    throw unavailable("Rust hub_providers_detect entry has an invalid shape.");
+  }
+  return { provider, installed, authenticated, detail };
+}
+
+/**
+ * Validate + normalize the bin's refs-only stdout into a receipt. Fails closed on any
+ * shape violation. Mirrors the readback siblings' defensive parsing.
+ */
+function parseReceipt(payload: unknown): FridayRustProvidersDetectReceipt {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    throw unavailable("Rust hub_providers_detect bridge returned a non-object payload.");
+  }
+  const root = payload as Record<string, unknown>;
+
+  if (root.truth_label !== "rust_providers_detect") {
+    throw unavailable("Rust hub_providers_detect bridge payload is not labeled rust_providers_detect.");
+  }
+  if (root.ok === false) {
+    throw unavailable("Rust hub_providers_detect bridge reported a fail-closed detect.");
+  }
+
+  const detectedRaw = root.detected;
+  if (!Array.isArray(detectedRaw)) {
+    throw unavailable("Rust hub_providers_detect bridge payload is missing the detected array.");
+  }
+  const detected = detectedRaw.map(parseEntry);
+
+  const readyRaw = root.ready_providers;
+  if (!Array.isArray(readyRaw) || !readyRaw.every((p) => typeof p === "string")) {
+    throw unavailable("Rust hub_providers_detect bridge payload has an invalid ready_providers list.");
+  }
+  const readyProviders = readyRaw as string[];
+
+  if (typeof root.any_authenticated !== "boolean" || typeof root.all_authenticated !== "boolean") {
+    throw unavailable("Rust hub_providers_detect bridge payload is missing the readiness booleans.");
+  }
+
+  return {
+    truthLabel: "rust_providers_detect",
+    proofOnly: true,
+    detected,
+    readyProviders,
+    anyAuthenticated: root.any_authenticated,
+    allAuthenticated: root.all_authenticated,
+  };
+}
+
+export function createFridayRustHubProvidersDetectService(
+  options: CreateFridayRustHubProvidersDetectServiceOptions = {},
+): FridayRustHubProvidersDetectService {
+  const repoRoot = resolve(
+    options.repoRoot ?? process.env.FRIDAY_REPO_ROOT ?? resolveDefaultRepoRoot(),
+  );
+  const rustCoreRoot = resolve(
+    process.env.FRIDAY_MISSION_SPINE_RUST_CORE_ROOT ?? join(repoRoot, "rust-core"),
+  );
+  const adapterBin = options.adapterBin ?? process.env.FRIDAY_HUB_PROVIDERS_DETECT_BIN;
+  const timeoutMs =
+    options.timeoutMs ?? readTimeoutMs(process.env.FRIDAY_HUB_PROVIDERS_DETECT_TIMEOUT_MS, 120_000);
+
+  // One-time loud warning when the cargo-run fallback (compiles in the request hot
+  // path) is taken — mirrors the run-answer-readback sibling.
+  let warnedCargoFallback = false;
+
+  return {
+    async detect(
+      input: FridayRustProvidersDetectInput = {},
+    ): Promise<FridayRustProvidersDetectReceipt> {
+      const probe = input.probe ?? "both";
+      // Defensive: only the closed vocabulary the bin accepts may be passed; anything
+      // else would `bad_args`/exit 2 the bin anyway → fail closed before spawning.
+      if (!VALID_PROBES.has(probe)) {
+        throw unavailable("Rust hub_providers_detect received an unsupported probe selection.");
+      }
+
+      const adapterArgs = ["--probe", probe];
+
+      const command = adapterBin ?? "cargo";
+      const args = adapterBin
+        ? adapterArgs
+        : [
+            "run",
+            "--quiet",
+            "--manifest-path",
+            join(rustCoreRoot, "Cargo.toml"),
+            "-p",
+            "friday-hub",
+            "--bin",
+            "hub_providers_detect",
+            "--",
+            ...adapterArgs,
+          ];
+      if (!adapterBin && !warnedCargoFallback) {
+        warnedCargoFallback = true;
+        console.warn(
+          "[friday][rust-providers-detect] FRIDAY_HUB_PROVIDERS_DETECT_BIN is not set — " +
+            "falling back to `cargo run` in the request hot path (compiles per cold start; " +
+            "adds latency and a failure surface). Set it to a prebuilt hub_providers_detect " +
+            "binary at deploy time.",
+        );
+      }
+
+      let stdout = "";
+      try {
+        const result = await execFileAsync(command, args, {
+          cwd: repoRoot,
+          timeout: timeoutMs,
+          maxBuffer: 2 * 1024 * 1024,
+          env: {
+            ...process.env,
+            RUST_BACKTRACE: "0",
+          },
+        });
+        stdout = result.stdout;
+      } catch {
+        // Non-zero exit, timeout, or spawn failure → fail closed (no detail surfaced).
+        throw unavailable("Rust hub_providers_detect bridge could not produce a refs-only detect.");
+      }
+
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(stdout);
+      } catch {
+        throw unavailable("Rust hub_providers_detect bridge returned invalid JSON.");
+      }
+      return parseReceipt(parsed);
+    },
+  };
+}

--- a/src/api/runtime/friday-api-runtime.ts
+++ b/src/api/runtime/friday-api-runtime.ts
@@ -146,6 +146,8 @@ import { createFridayRustHubRunContinuityProjectorService } from "../mission-spi
 import type { FridayRustHubRunContinuityProjectorService } from "../mission-spine/friday-rust-hub-run-continuity-projector-service.js";
 import { createFridayRustHubRunAnswerReadbackService } from "../mission-spine/friday-rust-hub-run-answer-readback-service.js";
 import type { FridayRustHubRunAnswerReadbackService } from "../mission-spine/friday-rust-hub-run-answer-readback-service.js";
+import { createFridayRustHubProvidersDetectService } from "../mission-spine/friday-rust-hub-providers-detect-bridge-service.js";
+import { createFridayRustHubCapabilityDoctorService } from "../mission-spine/friday-rust-hub-capability-doctor-bridge-service.js";
 import { resolveRustAgentRunWsClientX25519Secret } from "../mission-spine/friday-rust-hub-agent-run-ws-client-x25519-secret.js";
 import type { FridayRustAgentRunWsClientX25519SecretResolver } from "../mission-spine/friday-rust-hub-agent-run-ws-client-x25519-secret.js";
 import { createFridayStudioService } from "../../studio/index.js";
@@ -3636,6 +3638,17 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
     routes.register(route);
   }
 
+  // providers-bridge cut-over (DARK, DEFAULT-OFF): the TS->Rust bridge services for the
+  // retired Tier-2 PROVIDER surfaces. They are constructed unconditionally (cheap; no
+  // spawn until consulted) but are consulted ONLY when deps.routeProvidersViaRust is
+  // true — the route handlers gate on that flag and otherwise fail-close exactly as
+  // today. Shared by the provider routes (doctor/validate/capabilities.doctor) and the
+  // setup routes (providers.detect). Tests inject scripted-fake-bin bridges via deps.
+  const rustProvidersDetectService =
+    deps.rustProvidersDetect ?? createFridayRustHubProvidersDetectService();
+  const rustCapabilityDoctorService =
+    deps.rustCapabilityDoctor ?? createFridayRustHubCapabilityDoctorService();
+
   // Register provider routes (BYOK)
   for (const route of createFridayProviderRoutes({
     providerService: deps.providerService,
@@ -3643,6 +3656,8 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
     providerMutationGateRequired,
     allowTestOnlyProviderProbeExecution: deps.allowTestOnlyProviderProbeExecution,
     allowTestOnlyProviderRoutingControlsExecution: deps.allowTestOnlyProviderRoutingControlsExecution,
+    routeProvidersViaRust: deps.routeProvidersViaRust,
+    rustCapabilityDoctor: rustCapabilityDoctorService,
   })) {
     routes.register(route);
   }
@@ -3728,6 +3743,8 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
       onChannelsSaved: deps.onSetupChannelsSaved,
       onSetupCompleted: deps.onSetupCompleted,
       allowTestOnlyProviderDetectExecution: deps.allowTestOnlyProviderDetectExecution,
+      routeProvidersViaRust: deps.routeProvidersViaRust,
+      rustProvidersDetect: rustProvidersDetectService,
     })) {
       routes.register(route);
     }

--- a/src/api/runtime/friday-api-runtime.types.ts
+++ b/src/api/runtime/friday-api-runtime.types.ts
@@ -30,6 +30,8 @@ import type { FridayProviderService } from "#providers";
 import type { FridayRustHubAgentRunSealedClientService } from "../mission-spine/friday-rust-hub-agent-run-sealed-client-service.js";
 import type { FridayRustHubRunContinuityProjectorService } from "../mission-spine/friday-rust-hub-run-continuity-projector-service.js";
 import type { FridayRustHubRunAnswerReadbackService } from "../mission-spine/friday-rust-hub-run-answer-readback-service.js";
+import type { FridayRustHubProvidersDetectService } from "../mission-spine/friday-rust-hub-providers-detect-bridge-service.js";
+import type { FridayRustHubCapabilityDoctorService } from "../mission-spine/friday-rust-hub-capability-doctor-bridge-service.js";
 import type { FridayRustAgentRunWsClientX25519SecretResolver } from "../mission-spine/friday-rust-hub-agent-run-ws-client-x25519-secret.js";
 import type { FridayMediaUnderstandingRoutesDeps } from "../http/routes/friday-media-understanding-routes.js";
 import type { FridaySocialImportRoutesDeps } from "../http/routes/friday-social-import-routes.js";
@@ -327,6 +329,32 @@ export interface CreateFridayApiRuntimeDeps {
    * flag holds the gate; it does not turn anything on.
    */
   routeAgentRunViaRust?: boolean;
+  /**
+   * providers-bridge cut-over (DARK): the master ON/OFF (resolved boolean) for routing
+   * the retired Tier-2 PROVIDER surfaces — `providers.detect` (setup routes) and
+   * `providers.doctor` / `providers.validate` / `capabilities.doctor` (provider routes)
+   * — to the merged Rust `hub_providers_detect` / `hub_capability_doctor` bins instead
+   * of fail-closing with 503. DEFAULT-FALSE — leave unset in production/runtime so those
+   * routes stay byte-identical to today. Sourced (in bootstrap) from
+   * `FRIDAY_ROUTE_PROVIDERS_VIA_RUST` / explicit config via `resolveRouteProvidersViaRust`.
+   * When unset/false the bridge services below are constructed but NEVER consulted.
+   */
+  routeProvidersViaRust?: boolean;
+  /**
+   * providers-bridge cut-over (DARK): the providers-detect bridge service consulted by
+   * the `providers.detect` route ONLY when {@link routeProvidersViaRust} is true. OPTIONAL
+   * — when omitted the runtime lazily constructs the real service. Tests inject a bridge
+   * pointed at a scripted fake bin (no real cargo/provider, no spend, no network).
+   */
+  rustProvidersDetect?: FridayRustHubProvidersDetectService;
+  /**
+   * providers-bridge cut-over (DARK): the capability-doctor bridge service consulted by
+   * the `providers.doctor` / `providers.validate` / `capabilities.doctor` routes ONLY when
+   * {@link routeProvidersViaRust} is true. OPTIONAL — when omitted the runtime lazily
+   * constructs the real service. The bin's LIVE key-validation arm (~1-2 Anthropic tokens)
+   * runs ONLY when a caller explicitly opts in (capabilities.doctor `validateKeys: true`).
+   */
+  rustCapabilityDoctor?: FridayRustHubCapabilityDoctorService;
   /**
    * execrun-replacement slice S-F-compose (DARK): the three dark-substrate services the
    * composition wires together when {@link routeAgentRunViaRust} is on AND a run qualifies.

--- a/src/hub/bootstrap/hub-helpers.ts
+++ b/src/hub/bootstrap/hub-helpers.ts
@@ -1944,6 +1944,16 @@ export interface FridayHubConfig {
    * in this slice (the later composition slice consumes it).
    */
   routeAgentRunViaRust?: boolean;
+  /**
+   * providers-bridge cut-over (DARK): master ON/OFF for routing the retired Tier-2
+   * PROVIDER surfaces (`providers.detect` / `providers.doctor` / `providers.validate` /
+   * `capabilities.doctor`) to the merged Rust `hub_providers_detect` /
+   * `hub_capability_doctor` bins instead of fail-closing with 503. DEFAULT-FALSE —
+   * production hub creation must leave this unset so the routes stay byte-identical to
+   * today. Resolved (config-explicit wins, else `FRIDAY_ROUTE_PROVIDERS_VIA_RUST`) by
+   * `resolveRouteProvidersViaRust` and fed into the api-runtime deps.
+   */
+  routeProvidersViaRust?: boolean;
 }
 
 // ─── Resolved Hub Config ───

--- a/src/hub/friday-hub-bootstrap.ts
+++ b/src/hub/friday-hub-bootstrap.ts
@@ -932,6 +932,33 @@ export function resolveRouteAgentRunViaRust(
   return raw === "1" || raw === "true";
 }
 
+/**
+ * providers-bridge cut-over (DARK): single source of truth resolving the
+ * `routeProvidersViaRust` flag from (1) an EXPLICIT
+ * {@link FridayHubConfig.routeProvidersViaRust} and, only as a fallback, (2) the
+ * `FRIDAY_ROUTE_PROVIDERS_VIA_RUST` env var — the operator knob that flips the retired
+ * Tier-2 PROVIDER surfaces (`providers.detect` / `providers.doctor` /
+ * `providers.validate` / `capabilities.doctor`) from fail-closed (503) to bridging the
+ * merged Rust `hub_providers_detect` / `hub_capability_doctor` bins, WITHOUT a source
+ * edit.
+ *
+ * PRECEDENCE + PARSE mirror {@link resolveRouteAgentRunViaRust} exactly: an explicit
+ * config boolean (true OR false) ALWAYS wins; the env is consulted only for the unset
+ * gap. Case-insensitive, trimmed `"1"` or `"true"` ⇒ true; ABSENT / `""` / `"0"` /
+ * `"false"` / ANY other value ⇒ false. DEFAULT (env unset, config unset) ⇒ false, so
+ * the routes stay byte-identical to today's fail-closed 503.
+ */
+export function resolveRouteProvidersViaRust(
+  configValue: boolean | undefined,
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  if (typeof configValue === "boolean") {
+    return configValue;
+  }
+  const raw = (env.FRIDAY_ROUTE_PROVIDERS_VIA_RUST ?? "").trim().toLowerCase();
+  return raw === "1" || raw === "true";
+}
+
 function normalizeFridayHubPort(value: number | undefined): number | undefined {
   if (typeof value !== "number" || !Number.isInteger(value) || value < 1 || value > 65535) {
     return undefined;
@@ -7030,6 +7057,13 @@ export async function createFridayHub(
     // set (the default) this is `false`, so the `=== true` gate is never satisfied → the
     // predicate is never evaluated → byte-identical to today's fail-closed 503.
     routeAgentRunViaRust: resolveRouteAgentRunViaRust(config.routeAgentRunViaRust),
+    // providers-bridge cut-over (DARK): default-false master flag for routing the retired
+    // Tier-2 PROVIDER surfaces to the merged Rust bins. SINGLE SOURCE OF TRUTH =
+    // `resolveRouteProvidersViaRust` (explicit config wins; else FRIDAY_ROUTE_PROVIDERS_VIA_RUST,
+    // case-insensitive "1"/"true" → true; anything else incl. unset → false). With nothing set
+    // (the default) this is `false` → the route handlers' `=== true` gate is never satisfied →
+    // byte-identical to today's fail-closed 503.
+    routeProvidersViaRust: resolveRouteProvidersViaRust(config.routeProvidersViaRust),
     allowTestOnlyAgentRunControlExecution: config.allowTestOnlyAgentRunControlExecution,
     allowTestOnlyAutonomyLifecycleExecution: config.allowTestOnlyAutonomyLifecycleExecution,
     allowTestOnlyStandingAgendaExecution: config.allowTestOnlyStandingAgendaExecution,

--- a/src/hub/index.ts
+++ b/src/hub/index.ts
@@ -38,6 +38,7 @@ export {
   resolveFridayChannelSessionKey,
   resolveFridayHubConfig,
   resolveRouteAgentRunViaRust,
+  resolveRouteProvidersViaRust,
   sanitizeFridayChannelVisibleReply,
   shouldFailClosedForFridayWorkspaceContext,
   resolveTokenSecret,

--- a/test/unit/api/http/routes/friday-setup-routes.test.ts
+++ b/test/unit/api/http/routes/friday-setup-routes.test.ts
@@ -604,3 +604,111 @@ describe("createFridaySetupRoutes — providers.detect TS-runtime retirement", (
     await expect(route.handler(makeCtx({ body: {}, ip: "127.0.0.1" }))).rejects.toMatchObject({ httpStatus: 400 });
   });
 });
+
+describe("createFridaySetupRoutes — providers.detect DARK Rust cut-over (FRIDAY_ROUTE_PROVIDERS_VIA_RUST)", () => {
+  // A scripted bridge stub standing in for the real Rust hub_providers_detect bin (no
+  // spawn, no cargo, no CLI, no quota). It records the probe it was asked for.
+  function makeDetectBridge() {
+    const calls: Array<{ probe?: string }> = [];
+    const detect = vi.fn(async (input?: { probe?: string }) => {
+      calls.push({ probe: input?.probe });
+      return {
+        truthLabel: "rust_providers_detect" as const,
+        proofOnly: true as const,
+        detected: [{ provider: "codex", installed: true, authenticated: true, detail: "logged_in" }],
+        readyProviders: ["codex"],
+        anyAuthenticated: true,
+        allAuthenticated: false,
+      };
+    });
+    return { rustProvidersDetect: { detect }, calls, detect };
+  }
+
+  it("flag OFF (default) stays byte-identical: 503 TS_RUNTIME_PROVIDERS_DETECT_RETIRED even with the bridge wired", async () => {
+    const { deps } = makeDeps({ setupCompletedAt: null });
+    const bridge = makeDetectBridge();
+    // Bridge present, flag absent (default OFF), legacy probe also retired.
+    const routes = createFridaySetupRoutes({
+      ...deps,
+      allowTestOnlyProviderDetectExecution: false,
+      rustProvidersDetect: bridge.rustProvidersDetect,
+    } as unknown as FridaySetupRoutesDeps);
+    const route = findMutatingRoute(routes, "providers.detect");
+
+    await expect(route.handler(makeCtx({ body: { kind: "ollama" }, ip: "127.0.0.1" }))).rejects.toMatchObject({
+      code: "TS_RUNTIME_PROVIDERS_DETECT_RETIRED",
+      httpStatus: 503,
+    });
+    // Flag off ⇒ the bridge is NEVER consulted.
+    expect(bridge.detect).not.toHaveBeenCalled();
+  });
+
+  it("flag ON bridges to the Rust providers-detect bin and returns its refs-only payload", async () => {
+    const { deps } = makeDeps({ setupCompletedAt: null });
+    const bridge = makeDetectBridge();
+    const routes = createFridaySetupRoutes({
+      ...deps,
+      allowTestOnlyProviderDetectExecution: false,
+      routeProvidersViaRust: true,
+      rustProvidersDetect: bridge.rustProvidersDetect,
+    } as unknown as FridaySetupRoutesDeps);
+    const route = findMutatingRoute(routes, "providers.detect");
+
+    const result = await route.handler(makeCtx({ body: {}, ip: "127.0.0.1" }));
+
+    expect(result).toMatchObject({
+      truthLabel: "rust_providers_detect",
+      proofOnly: true,
+      readyProviders: ["codex"],
+    });
+    // Default probe selection is `both` when the body omits it.
+    expect(bridge.calls).toEqual([{ probe: "both" }]);
+  });
+
+  it("flag ON forwards an explicit probe selection", async () => {
+    const { deps } = makeDeps({ setupCompletedAt: null });
+    const bridge = makeDetectBridge();
+    const routes = createFridaySetupRoutes({
+      ...deps,
+      routeProvidersViaRust: true,
+      rustProvidersDetect: bridge.rustProvidersDetect,
+    } as unknown as FridaySetupRoutesDeps);
+    const route = findMutatingRoute(routes, "providers.detect");
+
+    await route.handler(makeCtx({ body: { probe: "claude" }, ip: "127.0.0.1" }));
+
+    expect(bridge.calls).toEqual([{ probe: "claude" }]);
+  });
+
+  it("flag ON still enforces the bootstrap boundary FIRST (non-localhost 403, bridge untouched)", async () => {
+    const { deps } = makeDeps({ setupCompletedAt: null });
+    const bridge = makeDetectBridge();
+    const routes = createFridaySetupRoutes({
+      ...deps,
+      routeProvidersViaRust: true,
+      rustProvidersDetect: bridge.rustProvidersDetect,
+    } as unknown as FridaySetupRoutesDeps);
+    const route = findMutatingRoute(routes, "providers.detect");
+
+    await expect(route.handler(makeCtx({ body: {}, ip: "10.0.0.5" }))).rejects.toMatchObject({
+      code: "SETUP_BOOTSTRAP_NOT_ALLOWED_NON_LOCALHOST",
+      httpStatus: 403,
+    });
+    expect(bridge.detect).not.toHaveBeenCalled();
+  });
+
+  it("flag ON but bridge missing fails closed (503), never silently passing", async () => {
+    const { deps } = makeDeps({ setupCompletedAt: null });
+    const routes = createFridaySetupRoutes({
+      ...deps,
+      routeProvidersViaRust: true,
+      // no rustProvidersDetect wired
+    } as unknown as FridaySetupRoutesDeps);
+    const route = findMutatingRoute(routes, "providers.detect");
+
+    await expect(route.handler(makeCtx({ body: {}, ip: "127.0.0.1" }))).rejects.toMatchObject({
+      code: "TS_RUNTIME_PROVIDERS_DETECT_RETIRED",
+      httpStatus: 503,
+    });
+  });
+});

--- a/test/unit/api/mission-spine/friday-rust-hub-capability-doctor-bridge-service.test.ts
+++ b/test/unit/api/mission-spine/friday-rust-hub-capability-doctor-bridge-service.test.ts
@@ -1,0 +1,194 @@
+import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { createFridayRustHubCapabilityDoctorService } from "../../../../src/api/mission-spine/friday-rust-hub-capability-doctor-bridge-service.js";
+
+/**
+ * REFS-ONLY capability-doctor bridge test. Spawns a SCRIPTED MOCK bin (no real cargo, no
+ * provider CLI, no live Anthropic round-trip, no quota, no secret) supplied as
+ * `adapterBin`. The mock records its argv to a sidecar file so the test can assert that
+ * `--validate-keys` is passed ONLY when the caller explicitly requests it (the quota
+ * gate). NO test here ever runs the real live key-validation arm.
+ */
+describe("friday-rust-hub-capability-doctor-bridge-service (DARK refs-only bridge)", () => {
+  let scratch: string | undefined;
+
+  afterEach(() => {
+    if (scratch) {
+      rmSync(scratch, { recursive: true, force: true });
+      scratch = undefined;
+    }
+  });
+
+  function setup(mockBody: string): { binPath: string; argvPath: string } {
+    scratch = mkdtempSync(join(tmpdir(), "friday-hub-capability-doctor-"));
+    const argvPath = join(scratch, "argv.json");
+    const binPath = join(scratch, "hub_capability_doctor_mock.mjs");
+    writeFileSync(
+      binPath,
+      `#!/usr/bin/env node
+import { writeFileSync } from "node:fs";
+writeFileSync(${JSON.stringify(argvPath)}, JSON.stringify(process.argv.slice(2)));
+${mockBody}
+`,
+    );
+    chmodSync(binPath, 0o755);
+    return { binPath, argvPath };
+  }
+
+  function readArgv(argvPath: string): string[] {
+    return JSON.parse(readFileSync(argvPath, "utf8")) as string[];
+  }
+
+  const CLI_ONLY_BODY = `
+    process.stdout.write(JSON.stringify({
+      truth_label: "rust_capability_doctor",
+      proof_only: true,
+      ok: true,
+      cli_detected: [
+        { provider: "codex", installed: true, authenticated: true, detail: "logged_in" },
+        { provider: "claude", installed: true, authenticated: false, detail: "not_logged_in" },
+      ],
+      cli_logged_in: ["codex"],
+      key_validation_probed: false,
+      key_validation: null,
+      confirmed_valid_keys: null,
+    }));
+  `;
+
+  it("default (validateKeys unset) runs CLI-only and NEVER passes --validate-keys (quota gate)", async () => {
+    const { binPath, argvPath } = setup(CLI_ONLY_BODY);
+    const service = createFridayRustHubCapabilityDoctorService({ adapterBin: binPath });
+
+    const receipt = await service.doctor();
+
+    expect(receipt).toMatchObject({
+      truthLabel: "rust_capability_doctor",
+      proofOnly: true,
+      cliLoggedIn: ["codex"],
+      keyValidationProbed: false,
+      keyValidation: null,
+      confirmedValidKeys: null,
+    });
+    // The zero-quota default MUST NOT pass --validate-keys.
+    expect(readArgv(argvPath)).toEqual([]);
+  });
+
+  it("validateKeys:false also never passes --validate-keys", async () => {
+    const { binPath, argvPath } = setup(CLI_ONLY_BODY);
+    const service = createFridayRustHubCapabilityDoctorService({ adapterBin: binPath });
+
+    await service.doctor({ validateKeys: false });
+
+    expect(readArgv(argvPath)).toEqual([]);
+  });
+
+  it("validateKeys:true passes --validate-keys and parses the live key section", async () => {
+    const { binPath, argvPath } = setup(`
+      process.stdout.write(JSON.stringify({
+        truth_label: "rust_capability_doctor",
+        proof_only: true,
+        ok: true,
+        cli_detected: [
+          { provider: "codex", installed: true, authenticated: true, detail: "logged_in" },
+          { provider: "claude", installed: true, authenticated: false, detail: "not_logged_in" },
+        ],
+        cli_logged_in: ["codex"],
+        key_validation_probed: true,
+        key_validation: [
+          { provider: "deepseek", label: "valid", status: null, detail: null },
+          { provider: "anthropic", label: "invalid", status: 401, detail: null },
+        ],
+        confirmed_valid_keys: ["deepseek"],
+      }));
+    `);
+    const service = createFridayRustHubCapabilityDoctorService({ adapterBin: binPath });
+
+    const receipt = await service.doctor({ validateKeys: true });
+
+    // The ONLY way --validate-keys crosses the bridge is an explicit true.
+    expect(readArgv(argvPath)).toEqual(["--validate-keys"]);
+    expect(receipt.keyValidationProbed).toBe(true);
+    expect(receipt.keyValidation).toEqual([
+      { provider: "deepseek", label: "valid", status: null, detail: null },
+      { provider: "anthropic", label: "invalid", status: 401, detail: null },
+    ]);
+    expect(receipt.confirmedValidKeys).toEqual(["deepseek"]);
+  });
+
+  it("rejects a not-probed payload that carries a non-null key section (honesty contract)", async () => {
+    const { binPath } = setup(`
+      process.stdout.write(JSON.stringify({
+        truth_label: "rust_capability_doctor",
+        proof_only: true,
+        ok: true,
+        cli_detected: [{ provider: "codex", installed: true, authenticated: true, detail: "logged_in" }],
+        cli_logged_in: ["codex"],
+        key_validation_probed: false,
+        key_validation: [{ provider: "anthropic", label: "credential_missing", status: null, detail: null }],
+        confirmed_valid_keys: null,
+      }));
+    `);
+    const service = createFridayRustHubCapabilityDoctorService({ adapterBin: binPath });
+
+    await expect(service.doctor()).rejects.toMatchObject({
+      code: "MISSION_SPINE_RUST_CAPABILITY_DOCTOR_UNAVAILABLE",
+      httpStatus: 503,
+    });
+  });
+
+  it("fails closed (503) on a non-zero exit", async () => {
+    const { binPath } = setup(`
+      process.stderr.write("hub_capability_doctor_unavailable: bad_args");
+      process.exit(2);
+    `);
+    const service = createFridayRustHubCapabilityDoctorService({ adapterBin: binPath });
+
+    await expect(service.doctor()).rejects.toMatchObject({
+      code: "MISSION_SPINE_RUST_CAPABILITY_DOCTOR_UNAVAILABLE",
+      httpStatus: 503,
+    });
+  });
+
+  it("fails closed on malformed JSON", async () => {
+    const { binPath } = setup(`process.stdout.write("not json {");`);
+    const service = createFridayRustHubCapabilityDoctorService({ adapterBin: binPath });
+
+    await expect(service.doctor()).rejects.toMatchObject({
+      code: "MISSION_SPINE_RUST_CAPABILITY_DOCTOR_UNAVAILABLE",
+      httpStatus: 503,
+    });
+  });
+
+  it("fails closed on the wrong truth label (copy-paste guard)", async () => {
+    const { binPath } = setup(`
+      process.stdout.write(JSON.stringify({
+        truth_label: "rust_wired_dev",
+        ok: true,
+        cli_detected: [],
+        cli_logged_in: [],
+        key_validation_probed: false,
+        key_validation: null,
+        confirmed_valid_keys: null,
+      }));
+    `);
+    const service = createFridayRustHubCapabilityDoctorService({ adapterBin: binPath });
+
+    await expect(service.doctor()).rejects.toMatchObject({
+      code: "MISSION_SPINE_RUST_CAPABILITY_DOCTOR_UNAVAILABLE",
+      httpStatus: 503,
+    });
+  });
+
+  it("fails closed on timeout", async () => {
+    const { binPath } = setup(`setTimeout(() => process.stdout.write("late"), 5000);`);
+    const service = createFridayRustHubCapabilityDoctorService({ adapterBin: binPath, timeoutMs: 200 });
+
+    await expect(service.doctor()).rejects.toMatchObject({
+      code: "MISSION_SPINE_RUST_CAPABILITY_DOCTOR_UNAVAILABLE",
+      httpStatus: 503,
+    });
+  });
+});

--- a/test/unit/api/mission-spine/friday-rust-hub-providers-detect-bridge-service.test.ts
+++ b/test/unit/api/mission-spine/friday-rust-hub-providers-detect-bridge-service.test.ts
@@ -1,0 +1,188 @@
+import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { createFridayRustHubProvidersDetectService } from "../../../../src/api/mission-spine/friday-rust-hub-providers-detect-bridge-service.js";
+
+/**
+ * REFS-ONLY providers-detect bridge test. Spawns a SCRIPTED MOCK bin (no real cargo, no
+ * provider CLI, no quota, no secret) supplied as `adapterBin`, mirroring the chmod-0o755
+ * shebang-mock idiom from the run-readback sibling. The mock records its argv to a sidecar
+ * file so the test can assert the exact `--probe` selection that crossed the bridge.
+ */
+describe("friday-rust-hub-providers-detect-bridge-service (DARK refs-only bridge)", () => {
+  let scratch: string | undefined;
+
+  afterEach(() => {
+    if (scratch) {
+      rmSync(scratch, { recursive: true, force: true });
+      scratch = undefined;
+    }
+  });
+
+  function setup(mockBody: string): { binPath: string; argvPath: string } {
+    scratch = mkdtempSync(join(tmpdir(), "friday-hub-providers-detect-"));
+    const argvPath = join(scratch, "argv.json");
+    const binPath = join(scratch, "hub_providers_detect_mock.mjs");
+    // The mock records the args it received (minus node + script path) then runs the body.
+    writeFileSync(
+      binPath,
+      `#!/usr/bin/env node
+import { writeFileSync } from "node:fs";
+writeFileSync(${JSON.stringify(argvPath)}, JSON.stringify(process.argv.slice(2)));
+${mockBody}
+`,
+    );
+    chmodSync(binPath, 0o755);
+    return { binPath, argvPath };
+  }
+
+  function readArgv(argvPath: string): string[] {
+    return JSON.parse(readFileSync(argvPath, "utf8")) as string[];
+  }
+
+  it("parses a valid refs-only detect on the happy path and defaults to --probe both", async () => {
+    const { binPath, argvPath } = setup(`
+      process.stdout.write(JSON.stringify({
+        truth_label: "rust_providers_detect",
+        proof_only: true,
+        ok: true,
+        detected: [
+          { provider: "codex", installed: true, authenticated: true, detail: "logged_in" },
+          { provider: "claude", installed: true, authenticated: false, detail: "not_logged_in" },
+        ],
+        ready_providers: ["codex"],
+        any_authenticated: true,
+        all_authenticated: false,
+      }));
+    `);
+    const service = createFridayRustHubProvidersDetectService({ adapterBin: binPath });
+
+    const receipt = await service.detect();
+
+    expect(receipt).toMatchObject({
+      truthLabel: "rust_providers_detect",
+      proofOnly: true,
+      readyProviders: ["codex"],
+      anyAuthenticated: true,
+      allAuthenticated: false,
+    });
+    expect(receipt.detected).toEqual([
+      { provider: "codex", installed: true, authenticated: true, detail: "logged_in" },
+      { provider: "claude", installed: true, authenticated: false, detail: "not_logged_in" },
+    ]);
+    // Default selection is `both`.
+    expect(readArgv(argvPath)).toEqual(["--probe", "both"]);
+  });
+
+  it("passes the requested probe selection through to the bin", async () => {
+    const { binPath, argvPath } = setup(`
+      process.stdout.write(JSON.stringify({
+        truth_label: "rust_providers_detect",
+        proof_only: true,
+        ok: true,
+        detected: [{ provider: "claude", installed: false, authenticated: false, detail: "not_installed" }],
+        ready_providers: [],
+        any_authenticated: false,
+        all_authenticated: false,
+      }));
+    `);
+    const service = createFridayRustHubProvidersDetectService({ adapterBin: binPath });
+
+    await service.detect({ probe: "claude" });
+
+    expect(readArgv(argvPath)).toEqual(["--probe", "claude"]);
+  });
+
+  it("fails closed (503) on a non-zero exit", async () => {
+    const { binPath } = setup(`
+      process.stderr.write("hub_providers_detect_unavailable: bad_args");
+      process.exit(2);
+    `);
+    const service = createFridayRustHubProvidersDetectService({ adapterBin: binPath });
+
+    await expect(service.detect()).rejects.toMatchObject({
+      code: "MISSION_SPINE_RUST_PROVIDERS_DETECT_UNAVAILABLE",
+      httpStatus: 503,
+    });
+  });
+
+  it("fails closed on malformed JSON", async () => {
+    const { binPath } = setup(`process.stdout.write("not json {");`);
+    const service = createFridayRustHubProvidersDetectService({ adapterBin: binPath });
+
+    await expect(service.detect()).rejects.toMatchObject({
+      code: "MISSION_SPINE_RUST_PROVIDERS_DETECT_UNAVAILABLE",
+      httpStatus: 503,
+    });
+  });
+
+  it("fails closed on the wrong truth label (copy-paste guard)", async () => {
+    const { binPath } = setup(`
+      process.stdout.write(JSON.stringify({
+        truth_label: "rust_wired_dev",
+        ok: true,
+        detected: [],
+        ready_providers: [],
+        any_authenticated: false,
+        all_authenticated: false,
+      }));
+    `);
+    const service = createFridayRustHubProvidersDetectService({ adapterBin: binPath });
+
+    await expect(service.detect()).rejects.toMatchObject({
+      code: "MISSION_SPINE_RUST_PROVIDERS_DETECT_UNAVAILABLE",
+      httpStatus: 503,
+    });
+  });
+
+  it("fails closed when the bin reports ok:false", async () => {
+    const { binPath } = setup(`
+      process.stdout.write(JSON.stringify({
+        truth_label: "rust_providers_detect",
+        proof_only: true,
+        ok: false,
+        error_kind: "bad_args",
+      }));
+    `);
+    const service = createFridayRustHubProvidersDetectService({ adapterBin: binPath });
+
+    await expect(service.detect()).rejects.toMatchObject({
+      code: "MISSION_SPINE_RUST_PROVIDERS_DETECT_UNAVAILABLE",
+      httpStatus: 503,
+    });
+  });
+
+  it("rejects an entry carrying a raw CLI stream field", async () => {
+    const { binPath } = setup(`
+      process.stdout.write(JSON.stringify({
+        truth_label: "rust_providers_detect",
+        proof_only: true,
+        ok: true,
+        detected: [
+          { provider: "codex", installed: true, authenticated: true, detail: "logged_in", stdout: "raw cli text" },
+        ],
+        ready_providers: ["codex"],
+        any_authenticated: true,
+        all_authenticated: false,
+      }));
+    `);
+    const service = createFridayRustHubProvidersDetectService({ adapterBin: binPath });
+
+    await expect(service.detect()).rejects.toMatchObject({
+      code: "MISSION_SPINE_RUST_PROVIDERS_DETECT_UNAVAILABLE",
+      httpStatus: 503,
+    });
+  });
+
+  it("fails closed on timeout", async () => {
+    const { binPath } = setup(`setTimeout(() => process.stdout.write("late"), 5000);`);
+    const service = createFridayRustHubProvidersDetectService({ adapterBin: binPath, timeoutMs: 200 });
+
+    await expect(service.detect()).rejects.toMatchObject({
+      code: "MISSION_SPINE_RUST_PROVIDERS_DETECT_UNAVAILABLE",
+      httpStatus: 503,
+    });
+  });
+});

--- a/test/unit/hub/friday-hub-bootstrap-env.test.ts
+++ b/test/unit/hub/friday-hub-bootstrap-env.test.ts
@@ -4,6 +4,7 @@ import {
   resolveFridayCanonicalMutatingActionGate,
   resolveFridayHubConfig,
   resolveRouteAgentRunViaRust,
+  resolveRouteProvidersViaRust,
 } from "#hub";
 import type { FridayHubConfig } from "#hub";
 
@@ -395,5 +396,38 @@ describe("resolveRouteAgentRunViaRust", () => {
     expect(resolveRouteAgentRunViaRust(false, { FRIDAY_ROUTE_AGENT_RUN_VIA_RUST: "1" })).toBe(false);
     expect(resolveRouteAgentRunViaRust(false, { FRIDAY_ROUTE_AGENT_RUN_VIA_RUST: "true" })).toBe(false);
     expect(resolveRouteAgentRunViaRust(false, emptyEnv())).toBe(false);
+  });
+});
+
+describe("resolveRouteProvidersViaRust", () => {
+  // DEFAULT-OFF: env unset (nothing set) → false → byte-identical to today's gated-off 503.
+  it("defaults to false when neither config nor env is set", () => {
+    expect(resolveRouteProvidersViaRust(undefined, emptyEnv())).toBe(false);
+  });
+
+  it("parses FRIDAY_ROUTE_PROVIDERS_VIA_RUST=1 / =true (case-insensitive, trimmed) as true", () => {
+    expect(resolveRouteProvidersViaRust(undefined, { FRIDAY_ROUTE_PROVIDERS_VIA_RUST: "1" })).toBe(true);
+    expect(resolveRouteProvidersViaRust(undefined, { FRIDAY_ROUTE_PROVIDERS_VIA_RUST: "true" })).toBe(true);
+    expect(resolveRouteProvidersViaRust(undefined, { FRIDAY_ROUTE_PROVIDERS_VIA_RUST: "TRUE" })).toBe(true);
+    expect(resolveRouteProvidersViaRust(undefined, { FRIDAY_ROUTE_PROVIDERS_VIA_RUST: " true " })).toBe(true);
+  });
+
+  // Fail-safe OFF: everything that is not exactly "1"/"true" → false.
+  it("treats 0, false, empty, and garbage env values as false (fail-safe off)", () => {
+    for (const raw of ["0", "false", "", "yes", "on", "enabled", "truthy", "2"]) {
+      expect(resolveRouteProvidersViaRust(undefined, { FRIDAY_ROUTE_PROVIDERS_VIA_RUST: raw })).toBe(false);
+    }
+  });
+
+  // PRECEDENCE: an explicit config boolean ALWAYS wins over the env.
+  it("uses explicit config true over the env (even when env says false)", () => {
+    expect(resolveRouteProvidersViaRust(true, { FRIDAY_ROUTE_PROVIDERS_VIA_RUST: "false" })).toBe(true);
+    expect(resolveRouteProvidersViaRust(true, emptyEnv())).toBe(true);
+  });
+
+  // The discriminating case: config=false MUST beat env=true (a `||` would wrongly return true here).
+  it("uses explicit config false over the env (config false beats env true)", () => {
+    expect(resolveRouteProvidersViaRust(false, { FRIDAY_ROUTE_PROVIDERS_VIA_RUST: "1" })).toBe(false);
+    expect(resolveRouteProvidersViaRust(false, emptyEnv())).toBe(false);
   });
 });

--- a/test/unit/providers/api/friday-provider-routes.test.ts
+++ b/test/unit/providers/api/friday-provider-routes.test.ts
@@ -1493,4 +1493,115 @@ describe("FridayProviderRoutes", () => {
       ).resolves.toBeDefined();
     });
   });
+
+  describe("DARK Rust cut-over for the probe surfaces (FRIDAY_ROUTE_PROVIDERS_VIA_RUST)", () => {
+    // A scripted capability-doctor bridge stub (no spawn, no cargo, no CLI, no live
+    // Anthropic round-trip, no quota). It records whether --validate-keys was requested.
+    function makeDoctorBridge() {
+      const calls: Array<{ validateKeys?: boolean }> = [];
+      const doctor = vi.fn(async (input?: { validateKeys?: boolean }) => {
+        calls.push({ validateKeys: input?.validateKeys });
+        return {
+          truthLabel: "rust_capability_doctor" as const,
+          proofOnly: true as const,
+          cliDetected: [{ provider: "codex", installed: true, authenticated: true, detail: "logged_in" }],
+          cliLoggedIn: ["codex"],
+          keyValidationProbed: input?.validateKeys === true,
+          keyValidation: input?.validateKeys === true ? [] : null,
+          confirmedValidKeys: input?.validateKeys === true ? [] : null,
+        };
+      });
+      return { rustCapabilityDoctor: { doctor }, calls, doctor };
+    }
+
+    function findRoute(operationId: string, extraDeps: Record<string, unknown>) {
+      const mockService = makeMockService();
+      const route = createFridayProviderRoutes({
+        providerService: mockService,
+        ...extraDeps,
+      } as never).find((entry) => entry.operationId === operationId);
+      if (!route) throw new Error(`route not found: ${operationId}`);
+      return { route, mockService };
+    }
+
+    it("flag OFF (default) stays byte-identical: providers.validate 503 even with the bridge wired", async () => {
+      const bridge = makeDoctorBridge();
+      const { route, mockService } = findRoute("providers.validate", {
+        rustCapabilityDoctor: bridge.rustCapabilityDoctor,
+      });
+      await expect(
+        route.handler(makeCtx({ params: { providerId: "prov-001" } })),
+      ).rejects.toMatchObject({ code: "TS_RUNTIME_PROVIDER_PROBE_RETIRED", httpStatus: 503 });
+      expect(bridge.doctor).not.toHaveBeenCalled();
+      expect(mockService.validateProvider).not.toHaveBeenCalled();
+    });
+
+    it("flag ON bridges providers.validate to the Rust capability-doctor and NEVER passes validateKeys", async () => {
+      const bridge = makeDoctorBridge();
+      const { route, mockService } = findRoute("providers.validate", {
+        routeProvidersViaRust: true,
+        rustCapabilityDoctor: bridge.rustCapabilityDoctor,
+      });
+      const result = await route.handler(makeCtx({ params: { providerId: "prov-001" } }));
+      expect(result).toMatchObject({ truthLabel: "rust_capability_doctor", proofOnly: true });
+      // validate is zero-quota: it must request validateKeys=false.
+      expect(bridge.calls).toEqual([{ validateKeys: false }]);
+      expect(mockService.validateProvider).not.toHaveBeenCalled();
+    });
+
+    it("flag ON bridges providers.doctor to the Rust capability-doctor and NEVER passes validateKeys", async () => {
+      const bridge = makeDoctorBridge();
+      const { route, mockService } = findRoute("providers.doctor", {
+        routeProvidersViaRust: true,
+        rustCapabilityDoctor: bridge.rustCapabilityDoctor,
+      });
+      const result = await route.handler(makeCtx({ params: { providerId: "prov-001" } }));
+      expect(result).toMatchObject({ truthLabel: "rust_capability_doctor", proofOnly: true });
+      expect(bridge.calls).toEqual([{ validateKeys: false }]);
+      expect(mockService.doctorProvider).not.toHaveBeenCalled();
+    });
+
+    it("flag ON bridges capabilities.doctor; validateKeys is OFF by default (quota gate)", async () => {
+      const bridge = makeDoctorBridge();
+      const { route } = findRoute("capabilities.doctor", {
+        routeProvidersViaRust: true,
+        rustCapabilityDoctor: bridge.rustCapabilityDoctor,
+      });
+      const result = await route.handler(makeCtx({ body: {} }));
+      expect(result).toMatchObject({ truthLabel: "rust_capability_doctor", keyValidationProbed: false });
+      // No explicit opt-in ⇒ zero quota.
+      expect(bridge.calls).toEqual([{ validateKeys: false }]);
+    });
+
+    it("flag ON capabilities.doctor opts into the LIVE key-validation arm ONLY on explicit validateKeys:true", async () => {
+      const bridge = makeDoctorBridge();
+      const { route } = findRoute("capabilities.doctor", {
+        routeProvidersViaRust: true,
+        rustCapabilityDoctor: bridge.rustCapabilityDoctor,
+      });
+      const result = await route.handler(makeCtx({ body: { validateKeys: true } }));
+      expect(result).toMatchObject({ truthLabel: "rust_capability_doctor", keyValidationProbed: true });
+      expect(bridge.calls).toEqual([{ validateKeys: true }]);
+    });
+
+    it("flag ON but bridge missing fails closed (503), never silently passing", async () => {
+      const { route } = findRoute("capabilities.doctor", { routeProvidersViaRust: true });
+      await expect(route.handler(makeCtx({ body: {} }))).rejects.toMatchObject({
+        code: "TS_RUNTIME_PROVIDER_PROBE_RETIRED",
+        httpStatus: 503,
+      });
+    });
+
+    it("flag ON still validates the capabilities.doctor body (400) before bridging", async () => {
+      const bridge = makeDoctorBridge();
+      const { route } = findRoute("capabilities.doctor", {
+        routeProvidersViaRust: true,
+        rustCapabilityDoctor: bridge.rustCapabilityDoctor,
+      });
+      await expect(
+        route.handler(makeCtx({ body: { providerIds: [] } })),
+      ).rejects.toMatchObject({ code: "VALIDATION_ERROR", httpStatus: 400 });
+      expect(bridge.doctor).not.toHaveBeenCalled();
+    });
+  });
 });


### PR DESCRIPTION
## DARK / flag-off — deploying this changes NOTHING

Wires the retired Tier-2 PROVIDER TS surfaces to the already-merged Rust bins, but the
un-fence stays behind a **DEFAULT-OFF** cut-over flag. Absent the flag, every route is
**byte-identical to today** (503 `TS_RUNTIME_PROVIDERS_DETECT_RETIRED` /
`TS_RUNTIME_PROVIDER_PROBE_RETIRED`). No production route auto-activates.

### The exact flag
`FRIDAY_ROUTE_PROVIDERS_VIA_RUST` (resolved by `resolveRouteProvidersViaRust`, mirroring
the proven `resolveRouteAgentRunViaRust`): explicit `HubConfig.routeProvidersViaRust`
wins; otherwise the env — case-insensitive, trimmed `"1"`/`"true"` → on; absent / `""` /
`"0"` / `"false"` / anything else → **OFF**.

### What the cut-over flips (flag ON)
- `providers.detect` (setup routes) → spawns **`hub_providers_detect`** (#591/#639) and
  returns its refs-only codex/claude CLI-login-status payload. The setup **bootstrap
  boundary still runs first**.
- `providers.doctor` / `providers.validate` / `capabilities.doctor` (provider routes) →
  spawn **`hub_capability_doctor`** (#658) and return its refs-only composite. The
  **canonical mutation gate still runs first**.
- **Quota:** only `capabilities.doctor` may opt into the bin's LIVE key-validation arm
  (~1-2 Anthropic tokens), and **only** on an explicit `validateKeys: true` request body
  field. `providers.validate` / `providers.doctor` never pass `--validate-keys`. Default
  is the bin's zero-quota CLI-detect-only path.
- Flag-on but bridge missing → fail closed (503), never silently passing.

### ⚠️ CONTRACT CHANGE at cut-over (surfaced, not blind-filled)
The Rust bins answer a **different question** than the legacy routes — flipping the flag
changes the response shape for clients:
- `providers.detect`: legacy BYOK probe (`apiKey`/`kind`/`baseUrl` → provider `/v1/models`
  → `availableModels`/`validated`) → Rust `--probe codex|claude|both` CLI-login refs.
- `providers.validate` / `providers.doctor`: legacy per-`:providerId` result → fixed
  codex/claude (CLI) + deepseek/anthropic (key) composite with **no providerId input**.
The legacy fields are NOT synthesized (truth-label discipline). The HTTP layer applies no
response-schema validation (`route.handler` result is serialized directly), so the new
shape reaches clients verbatim at cut-over.

## Implementation
Two refs-only spawn+parse bridge services (pattern:
`friday-rust-hub-run-answer-readback-service.ts`), fail-closed (503) on non-zero exit /
timeout / bad JSON / wrong truth label (`rust_providers_detect` /
`rust_capability_doctor`) / invalid shape. Neither bin takes `--db`. Flag plumbed
end-to-end: hub-helpers config → bootstrap (`resolveRouteProvidersViaRust`) →
runtime types deps → runtime (both factories) → route factories (which receive the
resolved boolean; they do not read env).

## Tests
- 16 bridge unit tests (scripted fake-bin, argv recorded): happy path, default `--probe
  both`, explicit probe, validateKeys gate (off by default; on only for `true`),
  wrong-truth-label, `ok:false`, raw-stream-field reject, not-probed-non-null reject,
  non-zero exit, malformed JSON, timeout.
- Route tests: flag-off = 503 (today) even with the bridge wired (bridge untouched);
  flag-on bridges + parses refs; bootstrap boundary / body-validation still run first;
  flag-on + bridge-missing = 503; the `validateKeys` quota gate.
- `resolveRouteProvidersViaRust` precedence/parse parity tests.
- **Strong proof (uncommitted, run locally):** both REAL bins spawned through the bridges
  (zero quota, no `--validate-keys`) parse correctly. Not committed so CI/RGG never build
  the Rust bins or hit Anthropic.

Rust untouched (bins already merged). `typecheck` + `lint` (0 errors) + `build:api` clean.

## NOT a v1 GO
`rust_wired_dev` / proof-only tier; DARK. Confers no v1 GO. Do NOT merge — operator gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
