### PR TITLE
feat(ts-rust-bridge): WORKFLOW catalog-mutation route bridge → hub_workflow_catalog bin (DARK, flag-off)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -905,14 +905,14 @@
         "filename": "test/unit/hub/friday-hub-bootstrap-env.test.ts",
         "hashed_secret": "5c5a15a8b0b3e154d77746945e563ba40100681b",
         "is_verified": false,
-        "line_number": 132
+        "line_number": 133
       },
       {
         "type": "Secret Keyword",
         "filename": "test/unit/hub/friday-hub-bootstrap-env.test.ts",
         "hashed_secret": "8a8281cec699f5e51330e21dd7fab3531af6ef0c",
         "is_verified": false,
-        "line_number": 133
+        "line_number": 134
       }
     ],
     "test/unit/media-understanding/friday-openai-vision-provider.test.ts": [
@@ -1124,5 +1124,5 @@
       }
     ]
   },
-  "generated_at": "2026-06-11T17:49:22Z"
+  "generated_at": "2026-06-11T18:33:50Z"
 }

--- a/src/api/http/routes/friday-workflow-routes.ts
+++ b/src/api/http/routes/friday-workflow-routes.ts
@@ -5,6 +5,10 @@ import {
   assertBoundPrincipalAuthorityForOperation,
   type FridayPublicMutationOperation,
 } from "../../../security/friday-owner-session-channel-capability.js";
+import type {
+  FridayRustHubWorkflowCatalogBridgeService,
+  FridayRustHubWorkflowCatalogReceipt,
+} from "../../mission-spine/friday-rust-hub-workflow-catalog-bridge-service.js";
 
 /** Maximum value for list endpoint limit query parameters. */
 const WORKFLOW_MAX_LIST_LIMIT = 100;
@@ -39,6 +43,73 @@ export interface FridayWorkflowRoutesDeps {
    * surfaces fail-closed until Rust owns workflow catalog write truth.
    */
   allowTestOnlyWorkflowCatalogMutationExecution?: boolean;
+  /**
+   * Tier-2 WORKFLOW catalog-mutation route bridge (DARK), DEFAULT-OFF. When `true`, the
+   * catalog-mutation handlers route `update` / `publish` / `archive` to the Rust
+   * `hub_workflow_catalog` bin (#657) via {@link rustWorkflowCatalogBridge} (after auth)
+   * instead of the retired TS path, returning a refs-only receipt. DEFAULT/unset ⇒
+   * byte-identical to today's fail-closed `TS_RUNTIME_WORKFLOW_CATALOG_MUTATION_RETIRED`
+   * 503 (this flag's branch is never entered). `create` (graph→def compiler out of scope)
+   * and the catalog pointer-`deploy` (semantic mismatch with the richer draft-deploy route)
+   * are intentionally NOT route-wired — they remain fail-closed/retired even with the flag on.
+   */
+  routeWorkflowsViaRust?: boolean;
+  /**
+   * The refs-only TS→Rust catalog-mutation bridge, consulted ONLY on the
+   * {@link routeWorkflowsViaRust}-on branch. Absent + flag-on ⇒ fail closed (503). Never
+   * consulted while the flag is off.
+   */
+  rustWorkflowCatalogBridge?: FridayRustHubWorkflowCatalogBridgeService;
+}
+
+/**
+ * Refs-only response returned by the catalog-mutation routes when
+ * {@link FridayWorkflowRoutesDeps.routeWorkflowsViaRust} is on. This is DELIBERATELY NOT the
+ * verbatim {@link FridayUpdateWorkflowResponse}/etc. shape: the Rust bin withholds the
+ * verbatim slug/name/description/tags (refs-only — bounded sha256+len projections) and never
+ * emits the definition body, so the full TS response cannot be honestly reconstructed. The
+ * production cut-over either enriches the response server-side from a verbatim-allowed read or
+ * moves the client onto this refs-only contract (see the PR body).
+ */
+export interface FridayWorkflowCatalogRustRouteResponse {
+  readonly routedVia: "rust_hub_workflow_catalog";
+  readonly receipt: FridayRustHubWorkflowCatalogReceipt;
+}
+
+function rustWorkflowBridgeUnavailable(): never {
+  throw new FridayDomainError(
+    "TS_RUNTIME_WORKFLOW_CATALOG_RUST_BRIDGE_UNAVAILABLE",
+    "Rust workflow catalog route bridge is enabled but no bridge service is configured.",
+    {
+      httpStatus: 503,
+      details: {
+        classification: "fail_closed",
+        replacement: "rust_owned_workflow_catalog_write_entrypoint_required",
+      },
+    },
+  );
+}
+
+function requireRustWorkflowBridge(
+  deps: FridayWorkflowRoutesDeps,
+): FridayRustHubWorkflowCatalogBridgeService {
+  if (!deps.rustWorkflowCatalogBridge) {
+    rustWorkflowBridgeUnavailable();
+  }
+  return deps.rustWorkflowCatalogBridge;
+}
+
+/** Require a positive-integer field on a flag-on request body, failing closed otherwise. */
+function requirePositiveIntField(body: Record<string, unknown> | null, field: string): number {
+  const value = body ? body[field] : undefined;
+  if (typeof value !== "number" || !Number.isInteger(value) || value < 1) {
+    throw new FridayDomainError(
+      "VALIDATION_ERROR",
+      `${field} is required and must be a positive integer`,
+      { httpStatus: 400 },
+    );
+  }
+  return value;
 }
 
 function throwRetiredWorkflowCatalogMutation(): never {
@@ -69,6 +140,69 @@ function assertWorkflowWritePrincipal(
     anyOfScopes: ["hub.admin", "workflow.write"],
     anyOfRoles: ["owner", "admin", "operator"],
   });
+}
+
+/**
+ * Flag-on (DARK) `workflows.update` → Rust `hub_workflow_catalog update`. Auth has ALREADY
+ * run in the handler. Fail-closed divergences: a `graph` (definition) change is rejected (the
+ * catalog `update` cannot change the definition); `etag` is accepted but not honored (the bin
+ * gates on `--expected-revision`, the authoritative token). See the PR body's divergence note.
+ */
+async function routeUpdateViaRust(
+  bridge: FridayRustHubWorkflowCatalogBridgeService,
+  workflowId: UUID,
+  body: Record<string, unknown> | null,
+): Promise<FridayWorkflowCatalogRustRouteResponse> {
+  const expectedRevision = requirePositiveIntField(body, "expectedRevision");
+  if (body && body.graph !== undefined) {
+    throw new FridayDomainError(
+      "VALIDATION_ERROR",
+      "graph (definition) change is not supported on the Rust workflow catalog update route; use a versioning op",
+      { httpStatus: 400 },
+    );
+  }
+  const receipt = await bridge.mutateCatalog({
+    op: "update",
+    workflowId,
+    expectedRevision,
+    name: body && typeof body.name === "string" ? body.name : undefined,
+    description: body && typeof body.description === "string" ? body.description : undefined,
+    tagsJson: body && Array.isArray(body.tags) ? JSON.stringify(body.tags) : undefined,
+  });
+  return { routedVia: "rust_hub_workflow_catalog", receipt };
+}
+
+/**
+ * Flag-on (DARK) `workflows.archive` → Rust `hub_workflow_catalog archive`. Auth has ALREADY
+ * run. NEW dark contract (fail-closed): the catalog `archive` REQUIRES `--expected-revision`
+ * (optimistic concurrency), which the retired DELETE contract does not carry — so the flag-on
+ * route REQUIRES `expectedRevision` in the body rather than read-then-archive (a TOCTOU that
+ * would defeat the very concurrency check). See the PR body.
+ */
+async function routeArchiveViaRust(
+  bridge: FridayRustHubWorkflowCatalogBridgeService,
+  workflowId: UUID,
+  body: Record<string, unknown> | null,
+): Promise<FridayWorkflowCatalogRustRouteResponse> {
+  const expectedRevision = requirePositiveIntField(body, "expectedRevision");
+  const receipt = await bridge.mutateCatalog({ op: "archive", workflowId, expectedRevision });
+  return { routedVia: "rust_hub_workflow_catalog", receipt };
+}
+
+/**
+ * Flag-on (DARK) `workflows.publish` → Rust `hub_workflow_catalog publish`. Auth has ALREADY
+ * run. NEW dark contract (fail-closed): the catalog `publish` REQUIRES `--version`, but the TS
+ * `versionNumber` is OPTIONAL — so the flag-on route REQUIRES `versionNumber` in the body (no
+ * "publish the latest" guess). See the PR body.
+ */
+async function routePublishViaRust(
+  bridge: FridayRustHubWorkflowCatalogBridgeService,
+  workflowId: UUID,
+  body: Record<string, unknown> | null,
+): Promise<FridayWorkflowCatalogRustRouteResponse> {
+  const version = requirePositiveIntField(body, "versionNumber");
+  const receipt = await bridge.mutateCatalog({ op: "publish", workflowId, version });
+  return { routedVia: "rust_hub_workflow_catalog", receipt };
 }
 
 export function createFridayWorkflowRoutes(
@@ -158,6 +292,17 @@ export function createFridayWorkflowRoutes(
       path: "/v1/workflows/:workflowId",
       auth: { public: true },
       async handler(ctx) {
+        // DARK Rust route (flag-on): auth THEN bridge. Flag-off falls through to today's
+        // exact retirement path below (byte-identical).
+        if (deps.routeWorkflowsViaRust === true) {
+          assertWorkflowWritePrincipal(ctx.principal ?? null, "workflow.update");
+          const { workflowId } = ctx.params as { workflowId: UUID };
+          return routeUpdateViaRust(
+            requireRustWorkflowBridge(deps),
+            workflowId,
+            ctx.body as Record<string, unknown> | null,
+          );
+        }
         assertWorkflowCatalogMutationTestOracleAllowed(deps);
         assertWorkflowWritePrincipal(ctx.principal ?? null, "workflow.update");
         const { workflowId } = ctx.params as { workflowId: UUID };
@@ -190,6 +335,17 @@ export function createFridayWorkflowRoutes(
       path: "/v1/workflows/:workflowId",
       auth: { public: true },
       async handler(ctx) {
+        // DARK Rust route (flag-on): auth THEN bridge. Flag-off falls through to today's
+        // exact retirement path below (byte-identical).
+        if (deps.routeWorkflowsViaRust === true) {
+          assertWorkflowWritePrincipal(ctx.principal ?? null, "workflow.archive");
+          const { workflowId } = ctx.params as { workflowId: UUID };
+          return routeArchiveViaRust(
+            requireRustWorkflowBridge(deps),
+            workflowId,
+            ctx.body as Record<string, unknown> | null,
+          );
+        }
         assertWorkflowCatalogMutationTestOracleAllowed(deps);
         assertWorkflowWritePrincipal(ctx.principal ?? null, "workflow.archive");
         const { workflowId } = ctx.params as { workflowId: UUID };
@@ -203,6 +359,17 @@ export function createFridayWorkflowRoutes(
       auth: { public: true },
       rateLimitPolicyId: "workflow.publish",
       async handler(ctx) {
+        // DARK Rust route (flag-on): auth THEN bridge. Flag-off falls through to today's
+        // exact retirement path below (byte-identical).
+        if (deps.routeWorkflowsViaRust === true) {
+          assertWorkflowWritePrincipal(ctx.principal ?? null, "workflow.publish");
+          const { workflowId } = ctx.params as { workflowId: UUID };
+          return routePublishViaRust(
+            requireRustWorkflowBridge(deps),
+            workflowId,
+            ctx.body as Record<string, unknown> | null,
+          );
+        }
         assertWorkflowCatalogMutationTestOracleAllowed(deps);
         assertWorkflowWritePrincipal(ctx.principal ?? null, "workflow.publish");
         const { workflowId } = ctx.params as { workflowId: UUID };

--- a/src/api/mission-spine/friday-rust-hub-workflow-catalog-bridge-service.ts
+++ b/src/api/mission-spine/friday-rust-hub-workflow-catalog-bridge-service.ts
@@ -1,0 +1,471 @@
+import { execFile } from "node:child_process";
+import { existsSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+
+import { FridayDomainError } from "#errors";
+
+/**
+ * TS->Rust bridge for the A6/R3 `hub_workflow_catalog` dev bin (#657) — the Tier-2
+ * WORKFLOW catalog-MUTATION surface.
+ *
+ * It clones the execFile shape of `friday-rust-hub-run-task-bridge-service.ts`: it spawns
+ * the prebuilt `hub_workflow_catalog` binary (or falls back to `cargo run --bin`), drives
+ * the five catalog ops the retired TS `workflows.*` mutation surface maps to —
+ * `create / update / archive / publish / deploy` — and validates the bin's REFS-ONLY
+ * stdout into a receipt. The bin emits ONLY safe identifiers/labels/counts and a BOUNDED
+ * projection (`<field>_sha256` + `<field>_len`) of the free-form caller strings; the
+ * verbatim `slug` / `name` / `description` / `tags_json` columns and the definition
+ * BODIES (`definition_json` / `source_meta`) are NEVER emitted by the bin — and this
+ * bridge's `parseReceipt` REJECTS them as defense-in-depth (a body field that ever
+ * appeared would fail the receipt closed, 503).
+ *
+ * DARK / `rust_wired_dev` ceiling — confers no v1 GO. This bridge is consulted ONLY on the
+ * flag-on branch of the workflow catalog-mutation routes, gated DEFAULT-OFF behind
+ * `FRIDAY_ROUTE_WORKFLOWS_VIA_RUST` (operator cutover pending). With the flag OFF (default)
+ * the routes stay byte-identical to today's fail-closed/retired behavior
+ * (`TS_RUNTIME_WORKFLOW_CATALOG_MUTATION_RETIRED`, 503) and this bridge is never built/consulted.
+ *
+ * ## DEV-DB CEILING (a load-bearing cut-over caveat)
+ * `hub_workflow_catalog` opens the target DB with `Db::open_hub`, which MIGRATES on open and
+ * is documented "dev/temp DBs ONLY — NEVER the production hub DB." So flipping the flag on
+ * with the bin pointed at a DEV DB proves the TS->Rust catalog path end-to-end, but it does
+ * NOT (and must not) write the production catalog. The production cut-over therefore needs a
+ * separate answer to the prod-DB-vs-migrate-on-open question (see the PR body). The DB path is
+ * supplied via `FRIDAY_HUB_WORKFLOW_CATALOG_DB_PATH` (mirroring `FRIDAY_HUB_AGENT_RUN_DB_PATH`);
+ * absent ⇒ the bridge fails closed (503) — it NEVER guesses/creates a DB.
+ *
+ * The bridge fails CLOSED (503) on any non-zero exit, timeout, parse failure, invalid shape,
+ * `ok:false` receipt, or any payload that carries a forbidden body/verbatim field.
+ */
+const execFileAsync = promisify(execFile);
+
+/** The catalog mutation ops the retired TS `workflows.*` surface maps to. */
+export type FridayRustHubWorkflowCatalogOp =
+  | "create"
+  | "update"
+  | "archive"
+  | "publish"
+  | "deploy";
+
+/**
+ * Refs-only catalog-mutation receipt — no definition bodies, no verbatim free-form strings,
+ * no secrets, no PII. The free-form caller strings are present ONLY as a bounded
+ * sha256+length projection (the bin's contract). `description` is nullable: a NULL
+ * description yields `descriptionSha256: null` / `descriptionLen: null`.
+ */
+export interface FridayRustHubWorkflowCatalogReceipt {
+  /** Always the dev tier — this is NOT a product/proven receipt. */
+  readonly truthLabel: "rust_wired_dev";
+  /** Always true — a loud reminder this is a dev bridge, not a product path. */
+  readonly proofOnly: true;
+  /** Which catalog op produced this receipt (echoed by the bin). */
+  readonly op: string;
+  readonly workflowId: string;
+  /** Bounded projection of the free-form caller strings (never the verbatim value). */
+  readonly slugSha256: string;
+  readonly slugLen: number;
+  readonly nameSha256: string;
+  readonly nameLen: number;
+  readonly descriptionSha256: string | null;
+  readonly descriptionLen: number | null;
+  readonly tagsJsonSha256: string;
+  readonly tagsJsonLen: number;
+  /** Safe identity/state/concurrency refs (emitted verbatim by the bin). */
+  readonly isArchived: boolean;
+  readonly revision: number;
+  /** sha256 etag — the optimistic-concurrency token for the next mutation. */
+  readonly etag: string;
+  /** The deployed version pointer, or null when nothing is deployed. */
+  readonly deployedVersion: number | null;
+  readonly createdAtMs: number;
+  readonly updatedAtMs: number;
+  /** Present only on `publish` (the just-published version). */
+  readonly publishedVersion?: number;
+}
+
+export interface FridayRustHubWorkflowCatalogCreateInput {
+  readonly op: "create";
+  readonly workflowId: string;
+  readonly slug: string;
+  readonly name: string;
+  readonly description?: string;
+  readonly tagsJson?: string;
+  /** The workflow definition body JSON, passed through to the bin as `--def-json`. */
+  readonly defJson: string;
+  readonly nowMs?: number;
+}
+
+export interface FridayRustHubWorkflowCatalogUpdateInput {
+  readonly op: "update";
+  readonly workflowId: string;
+  /** Optimistic-concurrency token — the bin's `--expected-revision`. */
+  readonly expectedRevision: number;
+  readonly name?: string;
+  /**
+   * Tri-state description: a string SETS it, `null` CLEARS it (`--clear-description`),
+   * `undefined` leaves it unchanged. SET and CLEAR are mutually exclusive in the bin.
+   */
+  readonly description?: string | null;
+  readonly tagsJson?: string;
+  readonly nowMs?: number;
+}
+
+export interface FridayRustHubWorkflowCatalogArchiveInput {
+  readonly op: "archive";
+  readonly workflowId: string;
+  readonly expectedRevision: number;
+  readonly nowMs?: number;
+}
+
+export interface FridayRustHubWorkflowCatalogPublishInput {
+  readonly op: "publish";
+  readonly workflowId: string;
+  readonly version: number;
+}
+
+export interface FridayRustHubWorkflowCatalogDeployInput {
+  readonly op: "deploy";
+  readonly workflowId: string;
+  readonly expectedRevision: number;
+  readonly nowMs?: number;
+}
+
+export type FridayRustHubWorkflowCatalogInput =
+  | FridayRustHubWorkflowCatalogCreateInput
+  | FridayRustHubWorkflowCatalogUpdateInput
+  | FridayRustHubWorkflowCatalogArchiveInput
+  | FridayRustHubWorkflowCatalogPublishInput
+  | FridayRustHubWorkflowCatalogDeployInput;
+
+export interface CreateFridayRustHubWorkflowCatalogBridgeServiceOptions {
+  readonly repoRoot?: string;
+  /**
+   * Path to the DEV hub DB the bin mutates (must exist). Default =
+   * `process.env.FRIDAY_HUB_WORKFLOW_CATALOG_DB_PATH`. NEVER the production hub DB — the
+   * bin migrates on open (see the file header). Absent ⇒ the bridge fails closed.
+   */
+  readonly dbPath?: string;
+  /** Path to a prebuilt `hub_workflow_catalog` binary; falls back to `cargo run --bin` when absent. */
+  readonly adapterBin?: string;
+  readonly timeoutMs?: number;
+}
+
+export interface FridayRustHubWorkflowCatalogBridgeService {
+  mutateCatalog(
+    input: FridayRustHubWorkflowCatalogInput,
+  ): Promise<FridayRustHubWorkflowCatalogReceipt>;
+}
+
+function unavailable(message: string): FridayDomainError {
+  return new FridayDomainError("MISSION_SPINE_RUST_WORKFLOW_CATALOG_BRIDGE_UNAVAILABLE", message, {
+    httpStatus: 503,
+    details: {
+      surface: "service:rust_hub_workflow_catalog_bridge",
+      bridge: "rust_wired_dev",
+      proofOnly: true,
+      proofReady: false,
+    },
+  });
+}
+
+function readTimeoutMs(raw: string | undefined, fallback: number): number {
+  if (!raw) return fallback;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function resolveDefaultRepoRoot(): string {
+  const moduleDir = dirname(fileURLToPath(import.meta.url));
+  return resolve(moduleDir, "../../..");
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function asNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+/**
+ * A `<field>_sha256` projection: a non-empty string (a present projection) OR `null` (an
+ * explicitly-absent nullable field, e.g. a NULL description). Any other value is a shape
+ * violation. Returns `{ ok, value }` so the caller can fail closed on a missing pair.
+ */
+function asNullableShaProjection(value: unknown): { ok: boolean; value: string | null } {
+  if (value === null) return { ok: true, value: null };
+  const s = asString(value);
+  if (s !== undefined) return { ok: true, value: s };
+  return { ok: false, value: null };
+}
+
+function asNullableLenProjection(value: unknown): { ok: boolean; value: number | null } {
+  if (value === null) return { ok: true, value: null };
+  const n = asNumber(value);
+  if (n !== undefined) return { ok: true, value: n };
+  return { ok: false, value: null };
+}
+
+/** The forbidden VERBATIM / BODY keys the bin never emits — a body-leak boundary. */
+const FORBIDDEN_RECEIPT_KEYS: readonly string[] = [
+  "slug",
+  "name",
+  "description",
+  "tags_json",
+  "definition_json",
+  "source_meta",
+];
+
+/** A required non-empty string ref, or fail closed with a missing-refs message. */
+function reqString(value: unknown, what: string): string {
+  const s = asString(value);
+  if (s === undefined) {
+    throw unavailable(`Rust hub_workflow_catalog bridge payload is missing ${what}.`);
+  }
+  return s;
+}
+
+/** A required finite-number ref, or fail closed with a missing-refs message. */
+function reqNumber(value: unknown, what: string): number {
+  const n = asNumber(value);
+  if (n === undefined) {
+    throw unavailable(`Rust hub_workflow_catalog bridge payload is missing ${what}.`);
+  }
+  return n;
+}
+
+/**
+ * Guard the receipt-LEVEL boundaries (object shape, the no-verbatim/no-body field boundary,
+ * the truth label, and `ok:false`). Extracted from {@link parseReceipt} to keep its complexity
+ * bounded. Returns the validated root record.
+ */
+function guardReceiptEnvelope(payload: unknown): Record<string, unknown> {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    throw unavailable("Rust hub_workflow_catalog bridge returned a non-object payload.");
+  }
+  const root = payload as Record<string, unknown>;
+  // Hard boundary: the verbatim free-form columns + definition bodies must NEVER cross
+  // the bridge — only the bounded `_sha256`/`_len` projections + safe refs may.
+  for (const key of FORBIDDEN_RECEIPT_KEYS) {
+    if (key in root) {
+      throw unavailable(
+        "Rust hub_workflow_catalog bridge payload carried a forbidden verbatim/body field (rejected).",
+      );
+    }
+  }
+  if (root.truth_label !== "rust_wired_dev") {
+    throw unavailable("Rust hub_workflow_catalog bridge payload is not labeled rust_wired_dev.");
+  }
+  if (root.ok === false) {
+    throw unavailable("Rust hub_workflow_catalog bridge reported a fail-closed mutation.");
+  }
+  return root;
+}
+
+/** The nullable `deployed_version` pointer (null = no deploy pointer yet). */
+function parseDeployedVersion(value: unknown): number | null {
+  if (value === null || value === undefined) return null;
+  const dv = asNumber(value);
+  if (dv === undefined) {
+    throw unavailable("Rust hub_workflow_catalog bridge payload has an invalid deployed_version.");
+  }
+  return dv;
+}
+
+/**
+ * Validate + normalize the Rust bin's refs-only stdout into a receipt. Fails closed on any
+ * shape violation AND on any attempt to carry a verbatim free-form string or a definition
+ * body (the boundary this bridge enforces, mirroring the bin's own output guard).
+ */
+function parseReceipt(payload: unknown): FridayRustHubWorkflowCatalogReceipt {
+  const root = guardReceiptEnvelope(payload);
+
+  const isArchived = root.is_archived;
+  if (typeof isArchived !== "boolean") {
+    throw unavailable("Rust hub_workflow_catalog bridge payload is missing is_archived.");
+  }
+
+  // The nullable description projection (NULL distinguishable from empty-string).
+  const descSha = asNullableShaProjection(root.description_sha256);
+  const descLen = asNullableLenProjection(root.description_len);
+  if (!descSha.ok || !descLen.ok) {
+    throw unavailable("Rust hub_workflow_catalog bridge payload has an invalid description projection.");
+  }
+
+  return {
+    truthLabel: "rust_wired_dev",
+    proofOnly: true,
+    op: reqString(root.op, "the op"),
+    workflowId: reqString(root.workflow_id, "the workflow id"),
+    slugSha256: reqString(root.slug_sha256, "slug_sha256"),
+    slugLen: reqNumber(root.slug_len, "slug_len"),
+    nameSha256: reqString(root.name_sha256, "name_sha256"),
+    nameLen: reqNumber(root.name_len, "name_len"),
+    descriptionSha256: descSha.value,
+    descriptionLen: descLen.value,
+    tagsJsonSha256: reqString(root.tags_json_sha256, "tags_json_sha256"),
+    tagsJsonLen: reqNumber(root.tags_json_len, "tags_json_len"),
+    isArchived,
+    revision: reqNumber(root.revision, "revision"),
+    etag: reqString(root.etag, "etag"),
+    deployedVersion: parseDeployedVersion(root.deployed_version),
+    createdAtMs: reqNumber(root.created_at_ms, "created_at_ms"),
+    updatedAtMs: reqNumber(root.updated_at_ms, "updated_at_ms"),
+    publishedVersion: asNumber(root.published_version),
+  };
+}
+
+/** Build the bin argv for a given catalog op (fail-closed: never synthesize a missing required arg). */
+function buildAdapterArgs(dbPath: string, input: FridayRustHubWorkflowCatalogInput): string[] {
+  const args = ["--db", dbPath, "--op", input.op, "--workflow-id", input.workflowId];
+  switch (input.op) {
+    case "create": {
+      args.push("--slug", input.slug, "--name", input.name, "--def-json", input.defJson);
+      if (input.description !== undefined) {
+        args.push("--description", input.description);
+      }
+      if (input.tagsJson !== undefined) {
+        args.push("--tags-json", input.tagsJson);
+      }
+      if (typeof input.nowMs === "number") {
+        args.push("--now-ms", String(input.nowMs));
+      }
+      break;
+    }
+    case "update": {
+      args.push("--expected-revision", String(input.expectedRevision));
+      if (input.name !== undefined) {
+        args.push("--name", input.name);
+      }
+      // Tri-state description: string SETS, null CLEARS, undefined unchanged.
+      if (input.description === null) {
+        args.push("--clear-description");
+      } else if (input.description !== undefined) {
+        args.push("--description", input.description);
+      }
+      if (input.tagsJson !== undefined) {
+        args.push("--tags-json", input.tagsJson);
+      }
+      if (typeof input.nowMs === "number") {
+        args.push("--now-ms", String(input.nowMs));
+      }
+      break;
+    }
+    case "archive": {
+      args.push("--expected-revision", String(input.expectedRevision));
+      if (typeof input.nowMs === "number") {
+        args.push("--now-ms", String(input.nowMs));
+      }
+      break;
+    }
+    case "publish": {
+      args.push("--version", String(input.version));
+      break;
+    }
+    case "deploy": {
+      args.push("--expected-revision", String(input.expectedRevision));
+      if (typeof input.nowMs === "number") {
+        args.push("--now-ms", String(input.nowMs));
+      }
+      break;
+    }
+  }
+  return args;
+}
+
+export function createFridayRustHubWorkflowCatalogBridgeService(
+  options: CreateFridayRustHubWorkflowCatalogBridgeServiceOptions = {},
+): FridayRustHubWorkflowCatalogBridgeService {
+  const repoRoot = resolve(
+    options.repoRoot ?? process.env.FRIDAY_REPO_ROOT ?? resolveDefaultRepoRoot(),
+  );
+  const rustCoreRoot = resolve(
+    process.env.FRIDAY_MISSION_SPINE_RUST_CORE_ROOT ?? join(repoRoot, "rust-core"),
+  );
+  const adapterBin = options.adapterBin ?? process.env.FRIDAY_HUB_WORKFLOW_CATALOG_BIN;
+  const dbPathRaw = options.dbPath ?? process.env.FRIDAY_HUB_WORKFLOW_CATALOG_DB_PATH;
+  const timeoutMs =
+    options.timeoutMs ??
+    readTimeoutMs(process.env.FRIDAY_HUB_WORKFLOW_CATALOG_TIMEOUT_MS, 120_000);
+
+  // One-time guard so the (loud) cargo-run-fallback warning is logged once per service
+  // instance, not on every mutation. Flipped true the first time the fallback is taken.
+  let warnedCargoFallback = false;
+
+  return {
+    async mutateCatalog(
+      input: FridayRustHubWorkflowCatalogInput,
+    ): Promise<FridayRustHubWorkflowCatalogReceipt> {
+      // A missing/empty DB path FAILS CLOSED — the bridge never guesses or creates a DB.
+      if (!dbPathRaw) {
+        throw unavailable("Rust hub_workflow_catalog bridge requires a DB path.");
+      }
+      const dbPath = resolve(dbPathRaw);
+      // The dev hub DB must ALREADY exist — a missing DB is fail-closed (the bin would
+      // also refuse, but we refuse before spawning).
+      if (!existsSync(dbPath)) {
+        throw unavailable("Rust hub_workflow_catalog DB is not present for this runtime.");
+      }
+      if (!input.workflowId) {
+        throw unavailable("Rust hub_workflow_catalog bridge requires a workflow id.");
+      }
+
+      const adapterArgs = buildAdapterArgs(dbPath, input);
+
+      // Prefer the PREBUILT binary (`FRIDAY_HUB_WORKFLOW_CATALOG_BIN` / `adapterBin`). The
+      // `cargo run` fallback COMPILES the bin in the request hot path (latency + a
+      // non-JSON-stdout failure surface), so emit a LOUD one-time warning when it is taken.
+      const command = adapterBin ?? "cargo";
+      const args = adapterBin
+        ? adapterArgs
+        : [
+            "run",
+            "--quiet",
+            "--manifest-path",
+            join(rustCoreRoot, "Cargo.toml"),
+            "-p",
+            "friday-hub",
+            "--bin",
+            "hub_workflow_catalog",
+            "--",
+            ...adapterArgs,
+          ];
+      if (!adapterBin && !warnedCargoFallback) {
+        warnedCargoFallback = true;
+        console.warn(
+          "[friday][rust-workflow-catalog] FRIDAY_HUB_WORKFLOW_CATALOG_BIN is not set — " +
+            "falling back to `cargo run` in the request hot path (compiles per cold start; " +
+            "adds latency and a failure surface). Set it to a prebuilt hub_workflow_catalog " +
+            "binary at deploy time.",
+        );
+      }
+
+      let stdout = "";
+      try {
+        const result = await execFileAsync(command, args, {
+          cwd: repoRoot,
+          timeout: timeoutMs,
+          maxBuffer: 2 * 1024 * 1024,
+          env: {
+            ...process.env,
+            RUST_BACKTRACE: "0",
+          },
+        });
+        stdout = result.stdout;
+      } catch {
+        // Non-zero exit, timeout, or spawn failure → fail closed (no detail surfaced).
+        throw unavailable("Rust hub_workflow_catalog bridge could not produce a refs-only receipt.");
+      }
+
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(stdout);
+      } catch {
+        throw unavailable("Rust hub_workflow_catalog bridge returned invalid JSON.");
+      }
+      return parseReceipt(parsed);
+    },
+  };
+}

--- a/src/api/runtime/friday-api-runtime.ts
+++ b/src/api/runtime/friday-api-runtime.ts
@@ -148,6 +148,7 @@ import { createFridayRustHubRunAnswerReadbackService } from "../mission-spine/fr
 import type { FridayRustHubRunAnswerReadbackService } from "../mission-spine/friday-rust-hub-run-answer-readback-service.js";
 import { createFridayRustHubProvidersDetectService } from "../mission-spine/friday-rust-hub-providers-detect-bridge-service.js";
 import { createFridayRustHubCapabilityDoctorService } from "../mission-spine/friday-rust-hub-capability-doctor-bridge-service.js";
+import { createFridayRustHubWorkflowCatalogBridgeService } from "../mission-spine/friday-rust-hub-workflow-catalog-bridge-service.js";
 import { resolveRustAgentRunWsClientX25519Secret } from "../mission-spine/friday-rust-hub-agent-run-ws-client-x25519-secret.js";
 import type { FridayRustAgentRunWsClientX25519SecretResolver } from "../mission-spine/friday-rust-hub-agent-run-ws-client-x25519-secret.js";
 import { createFridayStudioService } from "../../studio/index.js";
@@ -2581,9 +2582,21 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
     routes.register(route);
   }
 
+  // Tier-2 WORKFLOW catalog-mutation route bridge (DARK): the refs-only TS→Rust bridge for the
+  // `hub_workflow_catalog` bin, consulted ONLY on the `routeWorkflowsViaRust`-on branch of the
+  // catalog-mutation handlers. Constructed lazily ONLY when the flag is on (default-off ⇒ the
+  // bridge is never built and the routes stay byte-identical to today's retirement 503). Tests
+  // inject a scripted-mock adapterBin bridge via `deps.rustWorkflowCatalogBridge`.
+  const routeWorkflowsViaRust = deps.routeWorkflowsViaRust === true;
+  const rustWorkflowCatalogBridge = routeWorkflowsViaRust
+    ? deps.rustWorkflowCatalogBridge ?? createFridayRustHubWorkflowCatalogBridgeService()
+    : undefined;
+
   // Register workflow routes (real service wiring)
   for (const route of createFridayWorkflowRoutes({
     allowTestOnlyWorkflowCatalogMutationExecution: deps.allowTestOnlyWorkflowCatalogMutationExecution,
+    routeWorkflowsViaRust,
+    rustWorkflowCatalogBridge,
     listWorkflows: (query) => {
       const workflows = workflowRuntime.crud.listWorkflows({
         tag: query.tag,

--- a/src/api/runtime/friday-api-runtime.types.ts
+++ b/src/api/runtime/friday-api-runtime.types.ts
@@ -33,6 +33,7 @@ import type { FridayRustHubRunAnswerReadbackService } from "../mission-spine/fri
 import type { FridayRustHubProvidersDetectService } from "../mission-spine/friday-rust-hub-providers-detect-bridge-service.js";
 import type { FridayRustHubCapabilityDoctorService } from "../mission-spine/friday-rust-hub-capability-doctor-bridge-service.js";
 import type { FridayRustAgentRunWsClientX25519SecretResolver } from "../mission-spine/friday-rust-hub-agent-run-ws-client-x25519-secret.js";
+import type { FridayRustHubWorkflowCatalogBridgeService } from "../mission-spine/friday-rust-hub-workflow-catalog-bridge-service.js";
 import type { FridayMediaUnderstandingRoutesDeps } from "../http/routes/friday-media-understanding-routes.js";
 import type { FridaySocialImportRoutesDeps } from "../http/routes/friday-social-import-routes.js";
 import type { FridayTaskWorkflowRoutesDeps } from "../http/routes/friday-task-workflow-routes.js";
@@ -383,6 +384,28 @@ export interface CreateFridayApiRuntimeDeps {
    * fails closed (no body) → 503. Tests point this at a hermetic fixture DB / stub readback.
    */
   rustAgentRunHubDbPath?: string;
+  /**
+   * Tier-2 WORKFLOW catalog-mutation route bridge (DARK): the master ON/OFF for routing the
+   * `workflows.create/update/archive/publish/deploy` mutations to the Rust `hub_workflow_catalog`
+   * bin (#657). DEFAULT-FALSE — leave unset in production/runtime so the catalog-mutation routes
+   * stay byte-identical to today's fail-closed `TS_RUNTIME_WORKFLOW_CATALOG_MUTATION_RETIRED` 503.
+   * When set true, each catalog-mutation route handler runs auth, then routes to the refs-only
+   * bridge ({@link rustWorkflowCatalogBridge}) and returns a refs-only receipt (a `rust_wired_dev`
+   * DEV-DB ceiling — the bin migrates the target DB on open and must NOT point at the production
+   * hub DB, so the production cut-over is a separate operator decision). Its resolution +
+   * precedence live in `resolveRouteWorkflowsViaRust` (explicit config wins; the
+   * `FRIDAY_ROUTE_WORKFLOWS_VIA_RUST` env knob fills the unset gap).
+   */
+  routeWorkflowsViaRust?: boolean;
+  /**
+   * Tier-2 WORKFLOW catalog-mutation route bridge (DARK): the refs-only TS→Rust catalog-mutation
+   * bridge consulted ONLY on the {@link routeWorkflowsViaRust}-on branch. OPTIONAL — when omitted
+   * the runtime lazily constructs the real bridge (reads the `FRIDAY_HUB_WORKFLOW_CATALOG_*`
+   * knobs: bin path + DEV DB path + timeout). NEVER consulted while the flag is off → byte-identical
+   * 503 path is untouched. Tests inject a scripted-mock `.mjs` adapterBin bridge so the flag-on
+   * path is mock-proven (no real Rust bin, no compile).
+   */
+  rustWorkflowCatalogBridge?: FridayRustHubWorkflowCatalogBridgeService;
   /**
    * Test-oracle only: allows legacy TypeScript agent run controls in isolated
    * mock/unit validation. Production/runtime callers must leave this unset so

--- a/src/hub/bootstrap/hub-helpers.ts
+++ b/src/hub/bootstrap/hub-helpers.ts
@@ -1954,6 +1954,17 @@ export interface FridayHubConfig {
    * `resolveRouteProvidersViaRust` and fed into the api-runtime deps.
    */
   routeProvidersViaRust?: boolean;
+  /**
+   * Tier-2 WORKFLOW catalog-mutation route bridge (DARK): "route create/update/archive/
+   * publish/deploy via the Rust `hub_workflow_catalog` bin (#657)" flag. DEFAULT-FALSE —
+   * production hub creation must leave this unset so the catalog-mutation routes stay
+   * byte-identical to today's fail-closed `TS_RUNTIME_WORKFLOW_CATALOG_MUTATION_RETIRED`
+   * 503. When true, the catalog-mutation route handlers run auth then route to the
+   * refs-only Rust bridge (a `rust_wired_dev` DEV-DB ceiling — see the bridge service).
+   * Resolution: `resolveRouteWorkflowsViaRust` (explicit config wins; otherwise the
+   * `FRIDAY_ROUTE_WORKFLOWS_VIA_RUST` env knob).
+   */
+  routeWorkflowsViaRust?: boolean;
 }
 
 // ─── Resolved Hub Config ───

--- a/src/hub/friday-hub-bootstrap.ts
+++ b/src/hub/friday-hub-bootstrap.ts
@@ -959,6 +959,35 @@ export function resolveRouteProvidersViaRust(
   return raw === "1" || raw === "true";
 }
 
+/**
+ * Tier-2 WORKFLOW catalog-mutation route bridge (DARK): single source of truth resolving the
+ * `routeWorkflowsViaRust` flag from (1) an EXPLICIT {@link FridayHubConfig.routeWorkflowsViaRust}
+ * and, only as a fallback, (2) the `FRIDAY_ROUTE_WORKFLOWS_VIA_RUST` env var — the operator knob
+ * that flips the Rust-owned workflow catalog-mutation route (`create/update/archive/publish/
+ * deploy` → the `hub_workflow_catalog` bin, #657) WITHOUT a source edit.
+ *
+ * MIRRORS {@link resolveRouteAgentRunViaRust} exactly: an explicit config boolean (true OR false)
+ * ALWAYS wins; the env is consulted ONLY when config does not specify. PARSE (fail-safe OFF):
+ * case-insensitive, trimmed `"1"` or `"true"` ⇒ true; ABSENT, `""`, `"0"`, `"false"`, or ANY
+ * other value ⇒ false. DEFAULT (both unset) ⇒ false, so the downstream
+ * `deps.routeWorkflowsViaRust === true` gate stays off and the catalog-mutation routes stay
+ * byte-identical to today's fail-closed `TS_RUNTIME_WORKFLOW_CATALOG_MUTATION_RETIRED` 503.
+ *
+ * The sibling `FRIDAY_HUB_WORKFLOW_CATALOG_*` knobs (bin path, DEV DB path, timeout) are read +
+ * documented at the bridge construction point in `friday-rust-hub-workflow-catalog-bridge-service.ts`.
+ */
+export function resolveRouteWorkflowsViaRust(
+  configValue: boolean | undefined,
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  // Config explicit (true OR false) wins — env is the fallback for the unset gap only.
+  if (typeof configValue === "boolean") {
+    return configValue;
+  }
+  const raw = (env.FRIDAY_ROUTE_WORKFLOWS_VIA_RUST ?? "").trim().toLowerCase();
+  return raw === "1" || raw === "true";
+}
+
 function normalizeFridayHubPort(value: number | undefined): number | undefined {
   if (typeof value !== "number" || !Number.isInteger(value) || value < 1 || value > 65535) {
     return undefined;
@@ -7064,6 +7093,13 @@ export async function createFridayHub(
     // (the default) this is `false` → the route handlers' `=== true` gate is never satisfied →
     // byte-identical to today's fail-closed 503.
     routeProvidersViaRust: resolveRouteProvidersViaRust(config.routeProvidersViaRust),
+    // Tier-2 WORKFLOW catalog-mutation route bridge (DARK): default-false flag routing
+    // create/update/archive/publish/deploy → the Rust `hub_workflow_catalog` bin. SINGLE
+    // SOURCE OF TRUTH = `resolveRouteWorkflowsViaRust` (explicit config wins; otherwise the
+    // `FRIDAY_ROUTE_WORKFLOWS_VIA_RUST` env knob fills the gap, "1"/"true" → true; anything
+    // else incl. unset → false). With nothing set (the default) this is `false`, so the
+    // `=== true` gate is never satisfied → byte-identical to today's fail-closed retirement 503.
+    routeWorkflowsViaRust: resolveRouteWorkflowsViaRust(config.routeWorkflowsViaRust),
     allowTestOnlyAgentRunControlExecution: config.allowTestOnlyAgentRunControlExecution,
     allowTestOnlyAutonomyLifecycleExecution: config.allowTestOnlyAutonomyLifecycleExecution,
     allowTestOnlyStandingAgendaExecution: config.allowTestOnlyStandingAgendaExecution,

--- a/src/hub/index.ts
+++ b/src/hub/index.ts
@@ -39,6 +39,7 @@ export {
   resolveFridayHubConfig,
   resolveRouteAgentRunViaRust,
   resolveRouteProvidersViaRust,
+  resolveRouteWorkflowsViaRust,
   sanitizeFridayChannelVisibleReply,
   shouldFailClosedForFridayWorkspaceContext,
   resolveTokenSecret,

--- a/test/unit/api/http/routes/friday-workflow-routes.test.ts
+++ b/test/unit/api/http/routes/friday-workflow-routes.test.ts
@@ -159,4 +159,158 @@ describe("FridayWorkflowRoutes", () => {
     });
     expect(createWorkflow).not.toHaveBeenCalled();
   });
+
+  describe("DARK Rust catalog-mutation route bridge (routeWorkflowsViaRust)", () => {
+    /** A scripted-stub bridge that records the mutate call + returns a fixed refs-only receipt. */
+    function makeStubBridge() {
+      const calls: unknown[] = [];
+      return {
+        calls,
+        mutateCatalog: vi.fn(async (input: unknown) => {
+          calls.push(input);
+          return {
+            truthLabel: "rust_wired_dev" as const,
+            proofOnly: true as const,
+            op: (input as { op: string }).op,
+            workflowId: (input as { workflowId: string }).workflowId,
+            slugSha256: "00",
+            slugLen: 2,
+            nameSha256: "11",
+            nameLen: 3,
+            descriptionSha256: null,
+            descriptionLen: null,
+            tagsJsonSha256: "22",
+            tagsJsonLen: 2,
+            isArchived: false,
+            revision: 2,
+            etag: "e".repeat(64),
+            deployedVersion: null,
+            createdAtMs: 100,
+            updatedAtMs: 200,
+          };
+        }),
+      };
+    }
+
+    function flagOnRoutes(bridge: ReturnType<typeof makeStubBridge>) {
+      return createFridayWorkflowRoutes({
+        ...stubDeps,
+        // The test-oracle stays OFF: the Rust branch must be a SEPARATE path, not the oracle.
+        routeWorkflowsViaRust: true,
+        rustWorkflowCatalogBridge: bridge,
+      });
+    }
+
+    it("flag-OFF is byte-identical to today's retirement 503 (bridge never consulted)", async () => {
+      const bridge = makeStubBridge();
+      // Flag unset entirely → today's path: retirement 503 BEFORE any bridge call.
+      const routes = createFridayWorkflowRoutes({
+        ...stubDeps,
+        rustWorkflowCatalogBridge: bridge, // present but must NOT be consulted
+      });
+      for (const op of ["workflows.update", "workflows.archive", "workflows.publish"]) {
+        const route = routes.find((r) => r.operationId === op)!;
+        await expect(
+          route.handler(makeCtx({ params: { workflowId: "wf-1" }, body: { expectedRevision: 1, versionNumber: 1 } })),
+        ).rejects.toMatchObject({
+          code: "TS_RUNTIME_WORKFLOW_CATALOG_MUTATION_RETIRED",
+          httpStatus: 503,
+        });
+      }
+      expect(bridge.mutateCatalog).not.toHaveBeenCalled();
+    });
+
+    it("flag-ON still enforces auth BEFORE routing to the bridge", async () => {
+      const bridge = makeStubBridge();
+      const route = flagOnRoutes(bridge).find((r) => r.operationId === "workflows.update")!;
+      await expect(
+        route.handler(makeCtx({
+          principal: makePrincipal({ role: "viewer", scopes: ["workflow.read"] }),
+          params: { workflowId: "wf-1" },
+          body: { expectedRevision: 1 },
+        })),
+      ).rejects.toMatchObject({ httpStatus: 403 });
+      // Auth rejected → the bridge was NEVER consulted.
+      expect(bridge.mutateCatalog).not.toHaveBeenCalled();
+    });
+
+    it("flag-ON update routes an authorized request to the bridge (refs-only response)", async () => {
+      const bridge = makeStubBridge();
+      const route = flagOnRoutes(bridge).find((r) => r.operationId === "workflows.update")!;
+      const res = await route.handler(makeCtx({
+        params: { workflowId: "wf-1" },
+        body: { expectedRevision: 1, name: "Renamed", tags: ["a", "b"] },
+      }));
+      expect(res).toMatchObject({ routedVia: "rust_hub_workflow_catalog" });
+      expect(bridge.mutateCatalog).toHaveBeenCalledTimes(1);
+      expect(bridge.calls[0]).toMatchObject({
+        op: "update",
+        workflowId: "wf-1",
+        expectedRevision: 1,
+        name: "Renamed",
+        tagsJson: JSON.stringify(["a", "b"]),
+      });
+    });
+
+    it("flag-ON update REJECTS a graph (definition) change (fail-closed divergence)", async () => {
+      const bridge = makeStubBridge();
+      const route = flagOnRoutes(bridge).find((r) => r.operationId === "workflows.update")!;
+      await expect(
+        route.handler(makeCtx({
+          params: { workflowId: "wf-1" },
+          body: { expectedRevision: 1, graph: { nodes: [], edges: [] } },
+        })),
+      ).rejects.toMatchObject({ code: "VALIDATION_ERROR", httpStatus: 400 });
+      expect(bridge.mutateCatalog).not.toHaveBeenCalled();
+    });
+
+    it("flag-ON archive REQUIRES expectedRevision in the body (fail-closed contract)", async () => {
+      const bridge = makeStubBridge();
+      const route = flagOnRoutes(bridge).find((r) => r.operationId === "workflows.archive")!;
+      await expect(
+        route.handler(makeCtx({ params: { workflowId: "wf-1" }, body: {} })),
+      ).rejects.toMatchObject({ code: "VALIDATION_ERROR", httpStatus: 400 });
+      expect(bridge.mutateCatalog).not.toHaveBeenCalled();
+      // With expectedRevision present it routes through.
+      const res = await route.handler(makeCtx({ params: { workflowId: "wf-1" }, body: { expectedRevision: 3 } }));
+      expect(res).toMatchObject({ routedVia: "rust_hub_workflow_catalog" });
+      expect(bridge.calls.at(-1)).toMatchObject({ op: "archive", workflowId: "wf-1", expectedRevision: 3 });
+    });
+
+    it("flag-ON publish REQUIRES versionNumber in the body (fail-closed contract)", async () => {
+      const bridge = makeStubBridge();
+      const route = flagOnRoutes(bridge).find((r) => r.operationId === "workflows.publish")!;
+      await expect(
+        route.handler(makeCtx({ params: { workflowId: "wf-1" }, body: {} })),
+      ).rejects.toMatchObject({ code: "VALIDATION_ERROR", httpStatus: 400 });
+      expect(bridge.mutateCatalog).not.toHaveBeenCalled();
+      const res = await route.handler(makeCtx({ params: { workflowId: "wf-1" }, body: { versionNumber: 2 } }));
+      expect(res).toMatchObject({ routedVia: "rust_hub_workflow_catalog" });
+      expect(bridge.calls.at(-1)).toMatchObject({ op: "publish", workflowId: "wf-1", version: 2 });
+    });
+
+    it("flag-ON with NO bridge configured fails closed (503)", async () => {
+      const routes = createFridayWorkflowRoutes({ ...stubDeps, routeWorkflowsViaRust: true });
+      const route = routes.find((r) => r.operationId === "workflows.publish")!;
+      await expect(
+        route.handler(makeCtx({ params: { workflowId: "wf-1" }, body: { versionNumber: 1 } })),
+      ).rejects.toMatchObject({
+        code: "TS_RUNTIME_WORKFLOW_CATALOG_RUST_BRIDGE_UNAVAILABLE",
+        httpStatus: 503,
+      });
+    });
+
+    it("flag-ON does NOT route create or deploy (they stay retired/fail-closed)", async () => {
+      const bridge = makeStubBridge();
+      const route = flagOnRoutes(bridge).find((r) => r.operationId === "workflows.create")!;
+      // create is NOT route-wired (graph→def compiler out of scope) → today's retirement 503.
+      await expect(
+        route.handler(makeCtx({ body: { slug: "wf", name: "Workflow", graph: {} } })),
+      ).rejects.toMatchObject({
+        code: "TS_RUNTIME_WORKFLOW_CATALOG_MUTATION_RETIRED",
+        httpStatus: 503,
+      });
+      expect(bridge.mutateCatalog).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/test/unit/api/mission-spine/friday-rust-hub-workflow-catalog-bridge-service.test.ts
+++ b/test/unit/api/mission-spine/friday-rust-hub-workflow-catalog-bridge-service.test.ts
@@ -1,0 +1,338 @@
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { createFridayRustHubWorkflowCatalogBridgeService } from "../../../../src/api/mission-spine/friday-rust-hub-workflow-catalog-bridge-service.js";
+
+/**
+ * DARK (Rust-wired-DEV) bridge test for the `hub_workflow_catalog` bin (#657). Spawns a
+ * SCRIPTED MOCK bin (no real Rust compile, no SQLite, hermetic in CI) via `adapterBin`,
+ * mirroring the chmod-0o755 shebang-mock idiom from the run-task-bridge test. Covers each of
+ * the five catalog ops the retired TS `workflows.*` surface maps to, plus the fail-closed
+ * cases: non-zero exit, malformed JSON, timeout, `ok:false`, and the verbatim/body-leak
+ * rejection that mirrors the bin's own output guard.
+ */
+describe("friday-rust-hub-workflow-catalog-bridge-service (Tier-2 workflow catalog mutation bridge)", () => {
+  let scratch: string | undefined;
+
+  afterEach(() => {
+    if (scratch) {
+      rmSync(scratch, { recursive: true, force: true });
+      scratch = undefined;
+    }
+  });
+
+  /**
+   * Write a scripted-mock bin + an empty DB file (the bridge checks the DB path EXISTS before
+   * spawning), returning both paths. The mock echoes back parts of argv it received so a test
+   * can assert the argv mapping (op + flags) when it wants to.
+   */
+  function setup(mockSource: string): { binPath: string; dbPath: string } {
+    scratch = mkdtempSync(join(tmpdir(), "friday-hub-workflow-catalog-bridge-"));
+    const binPath = join(scratch, "hub_workflow_catalog_mock.mjs");
+    writeFileSync(binPath, `#!/usr/bin/env node\n${mockSource}`);
+    chmodSync(binPath, 0o755);
+    const dbPath = join(scratch, "hub.sqlite");
+    writeFileSync(dbPath, "");
+    return { binPath, dbPath };
+  }
+
+  /** A scripted mock that emits a valid refs-only receipt echoing the op + any extra fields. */
+  function okMock(extraJson = "{}"): string {
+    return `
+      const argv = process.argv.slice(2);
+      const get = (n) => { const i = argv.indexOf(n); return i >= 0 ? argv[i + 1] : undefined; };
+      const out = {
+        truth_label: "rust_wired_dev",
+        proof_only: true,
+        ok: true,
+        op: get("--op"),
+        workflow_id: get("--workflow-id"),
+        slug_sha256: "00",
+        slug_len: 2,
+        name_sha256: "11",
+        name_len: 3,
+        description_sha256: null,
+        description_len: null,
+        tags_json_sha256: "22",
+        tags_json_len: 2,
+        is_archived: false,
+        revision: 1,
+        etag: "${"e".repeat(64)}",
+        deployed_version: null,
+        created_at_ms: 100,
+        updated_at_ms: 100,
+        ...${extraJson},
+      };
+      process.stdout.write(JSON.stringify(out));
+    `;
+  }
+
+  it("create: maps fields to argv and parses a refs-only receipt", async () => {
+    const { binPath, dbPath } = setup(`
+      const argv = process.argv.slice(2);
+      const get = (n) => { const i = argv.indexOf(n); return i >= 0 ? argv[i + 1] : undefined; };
+      process.stdout.write(JSON.stringify({
+        truth_label: "rust_wired_dev",
+        proof_only: true,
+        ok: true,
+        op: get("--op"),
+        workflow_id: get("--workflow-id"),
+        // Echo the def-json presence + tags so the test asserts argv mapping.
+        slug_sha256: get("--slug") ? "aa" : "00",
+        slug_len: 2,
+        name_sha256: get("--name") ? "bb" : "00",
+        name_len: 3,
+        description_sha256: get("--description") ? "cc" : null,
+        description_len: get("--description") ? 4 : null,
+        tags_json_sha256: get("--tags-json") ? "dd" : "00",
+        tags_json_len: 2,
+        is_archived: false,
+        revision: 1,
+        etag: "${"e".repeat(64)}",
+        deployed_version: null,
+        created_at_ms: 100,
+        updated_at_ms: 100,
+        _def_present: get("--def-json") !== undefined,
+      }));
+    `);
+    const service = createFridayRustHubWorkflowCatalogBridgeService({ adapterBin: binPath, dbPath });
+
+    const receipt = await service.mutateCatalog({
+      op: "create",
+      workflowId: "wf1",
+      slug: "research-wf",
+      name: "Research",
+      description: "a research workflow",
+      tagsJson: JSON.stringify(["ai"]),
+      defJson: JSON.stringify({ schema_version: 1, name: "Research", steps: [] }),
+      nowMs: 100,
+    });
+
+    expect(receipt).toMatchObject({
+      truthLabel: "rust_wired_dev",
+      proofOnly: true,
+      op: "create",
+      workflowId: "wf1",
+      slugSha256: "aa",
+      nameSha256: "bb",
+      descriptionSha256: "cc",
+      tagsJsonSha256: "dd",
+      revision: 1,
+      isArchived: false,
+      deployedVersion: null,
+    });
+  });
+
+  it("update: passes --expected-revision and the tri-state clear, never a verbatim body", async () => {
+    const { binPath, dbPath } = setup(`
+      const argv = process.argv.slice(2);
+      const has = (n) => argv.includes(n);
+      const get = (n) => { const i = argv.indexOf(n); return i >= 0 ? argv[i + 1] : undefined; };
+      process.stdout.write(JSON.stringify({
+        truth_label: "rust_wired_dev", proof_only: true, ok: true,
+        op: get("--op"), workflow_id: get("--workflow-id"),
+        slug_sha256: "00", slug_len: 2, name_sha256: "11", name_len: 3,
+        // CLEAR: --clear-description present → description null.
+        description_sha256: has("--clear-description") ? null : "cc",
+        description_len: has("--clear-description") ? null : 4,
+        tags_json_sha256: "22", tags_json_len: 2, is_archived: false,
+        revision: Number(get("--expected-revision")) + 1,
+        etag: "${"e".repeat(64)}", deployed_version: null,
+        created_at_ms: 100, updated_at_ms: 200,
+      }));
+    `);
+    const service = createFridayRustHubWorkflowCatalogBridgeService({ adapterBin: binPath, dbPath });
+
+    const receipt = await service.mutateCatalog({
+      op: "update",
+      workflowId: "wf1",
+      expectedRevision: 1,
+      name: "Research v2",
+      description: null, // clear
+    });
+
+    expect(receipt.op).toBe("update");
+    expect(receipt.revision).toBe(2);
+    expect(receipt.descriptionSha256).toBeNull();
+    expect(receipt.descriptionLen).toBeNull();
+  });
+
+  it("publish: carries the just-published version", async () => {
+    const { binPath, dbPath } = setup(okMock(`{ op: get("--op"), published_version: Number(get("--version")) }`));
+    const service = createFridayRustHubWorkflowCatalogBridgeService({ adapterBin: binPath, dbPath });
+
+    const receipt = await service.mutateCatalog({ op: "publish", workflowId: "wf1", version: 2 });
+
+    expect(receipt.op).toBe("publish");
+    expect(receipt.publishedVersion).toBe(2);
+  });
+
+  it("deploy: carries the deployed_version pointer", async () => {
+    const { binPath, dbPath } = setup(okMock(`{ op: get("--op"), deployed_version: 2 }`));
+    const service = createFridayRustHubWorkflowCatalogBridgeService({ adapterBin: binPath, dbPath });
+
+    const receipt = await service.mutateCatalog({
+      op: "deploy",
+      workflowId: "wf1",
+      expectedRevision: 2,
+    });
+
+    expect(receipt.op).toBe("deploy");
+    expect(receipt.deployedVersion).toBe(2);
+  });
+
+  it("archive: parses the archived receipt", async () => {
+    const { binPath, dbPath } = setup(okMock(`{ op: get("--op"), is_archived: true }`));
+    const service = createFridayRustHubWorkflowCatalogBridgeService({ adapterBin: binPath, dbPath });
+
+    const receipt = await service.mutateCatalog({
+      op: "archive",
+      workflowId: "wf1",
+      expectedRevision: 3,
+    });
+
+    expect(receipt.op).toBe("archive");
+    expect(receipt.isArchived).toBe(true);
+  });
+
+  it("fails closed (503) when no DB path is configured", async () => {
+    const { binPath } = setup(okMock());
+    const service = createFridayRustHubWorkflowCatalogBridgeService({ adapterBin: binPath });
+
+    await expect(
+      service.mutateCatalog({ op: "publish", workflowId: "wf1", version: 1 }),
+    ).rejects.toMatchObject({
+      code: "MISSION_SPINE_RUST_WORKFLOW_CATALOG_BRIDGE_UNAVAILABLE",
+      httpStatus: 503,
+    });
+  });
+
+  it("fails closed (503) when the DB path does not exist", async () => {
+    const { binPath } = setup(okMock());
+    const service = createFridayRustHubWorkflowCatalogBridgeService({
+      adapterBin: binPath,
+      dbPath: join(tmpdir(), "friday-nonexistent-hub-db-xyz.sqlite"),
+    });
+
+    await expect(
+      service.mutateCatalog({ op: "publish", workflowId: "wf1", version: 1 }),
+    ).rejects.toMatchObject({
+      code: "MISSION_SPINE_RUST_WORKFLOW_CATALOG_BRIDGE_UNAVAILABLE",
+      httpStatus: 503,
+    });
+  });
+
+  it("fails closed (503) on a non-zero exit", async () => {
+    const { binPath, dbPath } = setup(`
+      process.stderr.write("hub_workflow_catalog_unavailable: conflict");
+      process.exit(2);
+    `);
+    const service = createFridayRustHubWorkflowCatalogBridgeService({ adapterBin: binPath, dbPath });
+
+    await expect(
+      service.mutateCatalog({ op: "publish", workflowId: "wf1", version: 1 }),
+    ).rejects.toMatchObject({
+      code: "MISSION_SPINE_RUST_WORKFLOW_CATALOG_BRIDGE_UNAVAILABLE",
+      httpStatus: 503,
+    });
+  });
+
+  it("fails closed on malformed JSON", async () => {
+    const { binPath, dbPath } = setup(`process.stdout.write("not json {");`);
+    const service = createFridayRustHubWorkflowCatalogBridgeService({ adapterBin: binPath, dbPath });
+
+    await expect(
+      service.mutateCatalog({ op: "publish", workflowId: "wf1", version: 1 }),
+    ).rejects.toMatchObject({
+      code: "MISSION_SPINE_RUST_WORKFLOW_CATALOG_BRIDGE_UNAVAILABLE",
+      httpStatus: 503,
+    });
+  });
+
+  it("fails closed on timeout", async () => {
+    const { binPath, dbPath } = setup(`setTimeout(() => process.stdout.write("late"), 5000);`);
+    const service = createFridayRustHubWorkflowCatalogBridgeService({
+      adapterBin: binPath,
+      dbPath,
+      timeoutMs: 200,
+    });
+
+    await expect(
+      service.mutateCatalog({ op: "publish", workflowId: "wf1", version: 1 }),
+    ).rejects.toMatchObject({
+      code: "MISSION_SPINE_RUST_WORKFLOW_CATALOG_BRIDGE_UNAVAILABLE",
+      httpStatus: 503,
+    });
+  });
+
+  it("fails closed on an ok:false receipt", async () => {
+    const { binPath, dbPath } = setup(`
+      process.stdout.write(JSON.stringify({
+        truth_label: "rust_wired_dev", proof_only: true, ok: false, error_kind: "conflict",
+      }));
+    `);
+    const service = createFridayRustHubWorkflowCatalogBridgeService({ adapterBin: binPath, dbPath });
+
+    await expect(
+      service.mutateCatalog({ op: "publish", workflowId: "wf1", version: 1 }),
+    ).rejects.toMatchObject({
+      code: "MISSION_SPINE_RUST_WORKFLOW_CATALOG_BRIDGE_UNAVAILABLE",
+      httpStatus: 503,
+    });
+  });
+
+  it("rejects a payload that carries a verbatim free-form field (no-body boundary)", async () => {
+    const { binPath, dbPath } = setup(`
+      process.stdout.write(JSON.stringify({
+        truth_label: "rust_wired_dev", proof_only: true, ok: true,
+        op: "create", workflow_id: "wf1",
+        // A verbatim free-form column must NEVER cross the bridge.
+        name: "the raw workflow name that must never cross",
+        slug_sha256: "00", slug_len: 2, name_sha256: "11", name_len: 3,
+        description_sha256: null, description_len: null,
+        tags_json_sha256: "22", tags_json_len: 2, is_archived: false,
+        revision: 1, etag: "${"e".repeat(64)}", deployed_version: null,
+        created_at_ms: 100, updated_at_ms: 100,
+      }));
+    `);
+    const service = createFridayRustHubWorkflowCatalogBridgeService({ adapterBin: binPath, dbPath });
+
+    await expect(
+      service.mutateCatalog({
+        op: "create",
+        workflowId: "wf1",
+        slug: "s",
+        name: "n",
+        defJson: "{}",
+      }),
+    ).rejects.toMatchObject({
+      code: "MISSION_SPINE_RUST_WORKFLOW_CATALOG_BRIDGE_UNAVAILABLE",
+      httpStatus: 503,
+    });
+  });
+
+  it("rejects a payload that carries a definition body field (no-body boundary)", async () => {
+    const { binPath, dbPath } = setup(`
+      process.stdout.write(JSON.stringify({
+        truth_label: "rust_wired_dev", proof_only: true, ok: true,
+        op: "create", workflow_id: "wf1",
+        definition_json: "{\\"schema_version\\":1}",
+        slug_sha256: "00", slug_len: 2, name_sha256: "11", name_len: 3,
+        description_sha256: null, description_len: null,
+        tags_json_sha256: "22", tags_json_len: 2, is_archived: false,
+        revision: 1, etag: "${"e".repeat(64)}", deployed_version: null,
+        created_at_ms: 100, updated_at_ms: 100,
+      }));
+    `);
+    const service = createFridayRustHubWorkflowCatalogBridgeService({ adapterBin: binPath, dbPath });
+
+    await expect(
+      service.mutateCatalog({ op: "create", workflowId: "wf1", slug: "s", name: "n", defJson: "{}" }),
+    ).rejects.toMatchObject({
+      code: "MISSION_SPINE_RUST_WORKFLOW_CATALOG_BRIDGE_UNAVAILABLE",
+      httpStatus: 503,
+    });
+  });
+});

--- a/test/unit/hub/friday-hub-bootstrap-env.test.ts
+++ b/test/unit/hub/friday-hub-bootstrap-env.test.ts
@@ -5,6 +5,7 @@ import {
   resolveFridayHubConfig,
   resolveRouteAgentRunViaRust,
   resolveRouteProvidersViaRust,
+  resolveRouteWorkflowsViaRust,
 } from "#hub";
 import type { FridayHubConfig } from "#hub";
 
@@ -429,5 +430,40 @@ describe("resolveRouteProvidersViaRust", () => {
   it("uses explicit config false over the env (config false beats env true)", () => {
     expect(resolveRouteProvidersViaRust(false, { FRIDAY_ROUTE_PROVIDERS_VIA_RUST: "1" })).toBe(false);
     expect(resolveRouteProvidersViaRust(false, emptyEnv())).toBe(false);
+  });
+});
+
+// ─── Tier-2 workflow catalog-mutation route bridge: routeWorkflowsViaRust (DARK, default-off) ───
+
+describe("resolveRouteWorkflowsViaRust", () => {
+  // DEFAULT-OFF: nothing set → false → byte-identical to today's retirement 503.
+  it("defaults to false when neither config nor env is set", () => {
+    expect(resolveRouteWorkflowsViaRust(undefined, emptyEnv())).toBe(false);
+  });
+
+  it("parses FRIDAY_ROUTE_WORKFLOWS_VIA_RUST 1/true (case-insensitive, trimmed) as true", () => {
+    expect(resolveRouteWorkflowsViaRust(undefined, { FRIDAY_ROUTE_WORKFLOWS_VIA_RUST: "1" })).toBe(true);
+    expect(resolveRouteWorkflowsViaRust(undefined, { FRIDAY_ROUTE_WORKFLOWS_VIA_RUST: "true" })).toBe(true);
+    expect(resolveRouteWorkflowsViaRust(undefined, { FRIDAY_ROUTE_WORKFLOWS_VIA_RUST: "TRUE" })).toBe(true);
+    expect(resolveRouteWorkflowsViaRust(undefined, { FRIDAY_ROUTE_WORKFLOWS_VIA_RUST: "  1  " })).toBe(true);
+    expect(resolveRouteWorkflowsViaRust(undefined, { FRIDAY_ROUTE_WORKFLOWS_VIA_RUST: " true " })).toBe(true);
+  });
+
+  // Fail-safe OFF: everything that is not exactly "1"/"true" → false.
+  it("treats 0, false, empty, and garbage env values as false (fail-safe off)", () => {
+    expect(resolveRouteWorkflowsViaRust(undefined, { FRIDAY_ROUTE_WORKFLOWS_VIA_RUST: "0" })).toBe(false);
+    expect(resolveRouteWorkflowsViaRust(undefined, { FRIDAY_ROUTE_WORKFLOWS_VIA_RUST: "false" })).toBe(false);
+    expect(resolveRouteWorkflowsViaRust(undefined, { FRIDAY_ROUTE_WORKFLOWS_VIA_RUST: "" })).toBe(false);
+    expect(resolveRouteWorkflowsViaRust(undefined, { FRIDAY_ROUTE_WORKFLOWS_VIA_RUST: "yes" })).toBe(false);
+    expect(resolveRouteWorkflowsViaRust(undefined, { FRIDAY_ROUTE_WORKFLOWS_VIA_RUST: "on" })).toBe(false);
+    expect(resolveRouteWorkflowsViaRust(undefined, { FRIDAY_ROUTE_WORKFLOWS_VIA_RUST: "2" })).toBe(false);
+  });
+
+  // PRECEDENCE: explicit config wins over env (true wins, AND the discriminating false-beats-env-true).
+  it("uses explicit config over the env (true wins; false beats env true)", () => {
+    expect(resolveRouteWorkflowsViaRust(true, { FRIDAY_ROUTE_WORKFLOWS_VIA_RUST: "0" })).toBe(true);
+    expect(resolveRouteWorkflowsViaRust(true, emptyEnv())).toBe(true);
+    expect(resolveRouteWorkflowsViaRust(false, { FRIDAY_ROUTE_WORKFLOWS_VIA_RUST: "1" })).toBe(false);
+    expect(resolveRouteWorkflowsViaRust(false, { FRIDAY_ROUTE_WORKFLOWS_VIA_RUST: "true" })).toBe(false);
   });
 });


### PR DESCRIPTION
## DARK / flag-off

Wires the **Tier-2 WORKFLOW catalog-mutation** surface to the Rust `hub_workflow_catalog` bin (#657) behind a **DEFAULT-OFF** flag. With the flag absent (default), the catalog-mutation routes stay **byte-identical** to today's fail-closed/retired behavior (`TS_RUNTIME_WORKFLOW_CATALOG_MUTATION_RETIRED`, 503) — the flag branch is never entered, and the bridge is never even constructed. The wiring exists but does NOT auto-activate; the cut-over deploy flips it.

**Exact flag:** `FRIDAY_ROUTE_WORKFLOWS_VIA_RUST` (case-insensitive trimmed `"1"`/`"true"` → on; anything else, incl. unset → off). An explicit `routeWorkflowsViaRust` HubConfig boolean wins over the env (`resolveRouteWorkflowsViaRust`, mirroring `resolveRouteAgentRunViaRust`).

**What the cut-over flips:** the `workflows.update` / `workflows.publish` / `workflows.archive` route handlers run auth (`assertWorkflowWritePrincipal`) **then** route to the refs-only Rust bridge (instead of the retired TS path), against the configured **DEV** hub DB (`FRIDAY_HUB_WORKFLOW_CATALOG_DB_PATH`), returning a refs-only receipt.

## The bridge (REAL, no stub/mock/fallback/downgrade)

`src/api/mission-spine/friday-rust-hub-workflow-catalog-bridge-service.ts` — spawns the prebuilt `hub_workflow_catalog` bin (`FRIDAY_HUB_WORKFLOW_CATALOG_BIN`) or falls back to `cargo run --bin` (loud one-time warning), parses the bin's **refs-only** JSON (bounded `<field>_sha256`+`<field>_len` projections of slug/name/description/tags + safe identity/state/concurrency refs), and **fails CLOSED (503)** on: non-zero exit, timeout, malformed JSON, `ok:false`, or any payload that carries a forbidden **verbatim free-form column** (`slug`/`name`/`description`/`tags_json`) or **definition body** (`definition_json`/`source_meta`). Follows the `friday-rust-hub-run-task-bridge-service` pattern. **Rust untouched** (bin already merged in #657).

## Per-op route-wiring status (all 5 proven at the bridge-service layer against the REAL bin)

| op | route-wired? | notes |
|---|---|---|
| **update** | ✅ wired | rejects a `graph` (definition) change **fail-closed** (catalog update can't change the def); `etag` accepted but **not honored** — the bin gates on `--expected-revision`, the authoritative token. |
| **publish** | ✅ wired | NEW dark contract: requires `versionNumber` in the body **fail-closed** (the bin needs `--version`; the TS field is optional — no "publish the latest" guess). |
| **archive** | ✅ wired | NEW dark contract: requires `expectedRevision` in the body **fail-closed** (the bin needs `--expected-revision`; the DELETE route doesn't carry it — no read-then-archive TOCTOU). |
| **create** | ⏸ deferred | TS `graph` (nodes/edges DAG) ≠ Rust `StoredWorkflowDefV1` (linear `schema_version`/`name`/`steps`). A faithful wiring needs a graph→def compiler — out of scope for a dark bridge. Flag-on create stays retired/fail-closed; **the flag-on surface therefore mutates EXISTING workflows only.** |
| **deploy** | ⏸ not wired | the catalog bin's pointer-`deploy` (sets `deployed_version`) ≠ the richer `workflows.deploy` draft-deploy product route (triggers/export/run-now/lock). Wiring it would be a silent downgrade. Flag-on deploy stays retired/fail-closed. |

## Caveats / cut-over blockers (honest)

- **`rust_wired_dev` DEV-DB ceiling.** The bin opens the target DB with `Db::open_hub`, which **migrates on open** and is documented "dev/temp DBs ONLY — NEVER the production hub DB." So flipping the flag on (pointed at a dev DB) proves the TS→Rust catalog path end-to-end but does **not** write the production catalog. The production cut-over needs the prod-DB-vs-migrate-on-open question answered first.
- **Refs-only response-shape divergence.** The flag-on routes return a `{ routedVia, receipt }` refs-only response, NOT the verbatim `FridayUpdateWorkflowResponse` shape — the bin withholds the verbatim slug/name/description/tags and never emits the def body, so the full TS response can't be honestly reconstructed. Cut-over either enriches server-side from a verbatim-allowed read, or moves the client onto the refs-only contract.

## NOT in this PR (separate concerns / not delivered)

- **S10 scheduler/trigger ingress** — single-owner-vs-double-fire, deploy-gated. NOT built here (request-driven route bridges only).
- **`workflows.runs.resume/retry/cancel` run-control bridge — NOT delivered.** There is no callable `workflow_run_control` bin or wire seam: only the in-process `friday_hub::workflow_run_control` domain module, consumed solely by its own tests (`hub_agent_run_server.rs`/#660 uses the SEPARATE `agent_run_control` plane). The cheapest unblock differs per op:
  - **cancel** — a pure state write (no executor/secret/approve). Bridgeable via one small NEW bin analogous to `hub_workflow_catalog`; blocked here only by "Rust untouched."
  - **resume/retry** — take `&dyn ToolExecutor` + secret + an `approve` gate-callback and drive the engine. A one-shot refs-only bin structurally can't carry an executor + gate-callback across a process boundary — these need the sealed-WS run-control seam (the #660 model extended to workflow runs) or in-process Rust (a different architecture than the catalog bridge).

## Tests

- **flag-off**: byte-identical retirement 503, bridge never consulted (update/archive/publish).
- **flag-on**: auth enforced BEFORE the bridge (unauthorized → 403, bridge not called); each wired op routes through; the fail-closed divergences (update rejects `graph`; archive requires `expectedRevision`; publish requires `versionNumber`); flag-on + no bridge configured → 503; flag-on does NOT route create/deploy (stay retired).
- **bridge service**: all 5 ops + non-zero-exit / malformed-JSON / timeout / `ok:false` / verbatim-field + body-field rejection (scripted-mock bin).
- **resolveRouteWorkflowsViaRust**: default-off, parse, fail-safe-off, config-over-env precedence.
- **real-bin e2e** (manual proof, not committed): built `hub_workflow_catalog`, created a dev DB, and round-tripped `create→update→publish→deploy→archive` through the real compiled bridge — refs-only receipts parsed, tri-state description-clear worked, deploy pointer followed the published version, and NO verbatim free-form value leaked into any receipt.

Local gates: `tsc --noEmit` clean, `eslint .` 0 errors, vitest (routes/mission-spine/hub/runtime/e2e-workflows/route-contract-snapshot) all green, provider-key denylist + detect-secrets clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
