### PR TITLE
feat(gate-agent-replace): desktop Ed25519 signing helper (D3 key-custody bridge, dark)

### DIFF
--- a/rust-core/Cargo.lock
+++ b/rust-core/Cargo.lock
@@ -574,6 +574,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "friday-operator-signer"
+version = "0.0.1"
+dependencies = [
+ "friday-core",
+ "friday-crypto",
+ "friday-hub",
+ "friday-operator-cli",
+ "serde",
+ "serde_json",
+ "sha2",
+ "thiserror 1.0.69",
+ "zeroize",
+]
+
+[[package]]
 name = "friday-protocol"
 version = "0.0.1"
 dependencies = [

--- a/rust-core/Cargo.toml
+++ b/rust-core/Cargo.toml
@@ -27,6 +27,7 @@ members = [
     "crates/friday-hub",
     "crates/friday-ffi",
     "crates/friday-operator-cli",
+    "crates/friday-operator-signer",
     "crates/friday-arch-tests",
 ]
 
@@ -69,6 +70,7 @@ friday-providers = { path = "crates/friday-providers" }
 friday-fs = { path = "crates/friday-fs" }
 friday-hub = { path = "crates/friday-hub" }
 friday-ffi = { path = "crates/friday-ffi" }
+friday-operator-cli = { path = "crates/friday-operator-cli" }
 
 [profile.dev]
 # bundled SQLite compiles faster with some opt; keep debug assertions on.

--- a/rust-core/crates/friday-operator-cli/src/lib.rs
+++ b/rust-core/crates/friday-operator-cli/src/lib.rs
@@ -277,6 +277,29 @@ pub fn keygen_to_path(key_path: &Path) -> Result<String, CliError> {
 /// reconstruct the canonical bytes, Ed25519-sign them, and return the signed
 /// approval. Fail-closed on every malformed input; never panics; never leaks the key.
 pub fn sign_request(key_path: &Path, req: &PendingRequest) -> Result<SignedApproval, CliError> {
+    let sk = read_signing_key(key_path)?;
+    sign_request_with_key(&sk, req)
+}
+
+/// sign with an ALREADY-LOADED operator signing key: validate the pending request,
+/// reconstruct the canonical bytes, Ed25519-sign them, and return the signed approval.
+///
+/// This is the byte-producing core that [`sign_request`] (file-sourced key) and any
+/// OTHER operator-controlled key source (e.g. a KEK-wrapped `SecureStore` seed) MUST
+/// both route through, so every signature is produced over the IDENTICAL
+/// [`canonical_bytes`] the Hub recomputes at verify time
+/// (`friday_core::gate::canonical_approval_signature_bytes`). Producing the bytes any
+/// other way is the one error that silently yields a signature the Hub rejects; reusing
+/// this function makes byte-identity true by construction.
+///
+/// The caller owns key custody (how the [`OperatorSigningKey`] was obtained); this
+/// function never reads a key source and never leaks key material (the signature is the
+/// only key-derived output, and a signature is public by construction). Fail-closed on
+/// every malformed field; never panics.
+pub fn sign_request_with_key(
+    sk: &OperatorSigningKey,
+    req: &PendingRequest,
+) -> Result<SignedApproval, CliError> {
     let decision = parse_decision(&req.decision)?;
     if req.approval_id.trim().is_empty() {
         return Err(CliError::BadRequest(
@@ -297,7 +320,6 @@ pub fn sign_request(key_path: &Path, req: &PendingRequest) -> Result<SignedAppro
         return Err(CliError::BadRequest("issuer must not be empty".to_string()));
     }
 
-    let sk = read_signing_key(key_path)?;
     let bytes = canonical_bytes(
         decision,
         &req.approval_id,
@@ -376,6 +398,34 @@ mod tests {
         );
         // Default issuer is the canonical gate issuer.
         assert_eq!(signed.issuer, CANONICAL_GATE_ISSUER);
+        std::fs::remove_file(&key_path).ok();
+    }
+
+    #[test]
+    fn sign_request_and_with_key_are_byte_identical() {
+        // The file-sourced `sign_request` and the already-loaded-key
+        // `sign_request_with_key` MUST produce the IDENTICAL signed approval for the
+        // same key + request — i.e. the split is a pure refactor and any other key
+        // source (e.g. a KEK-wrapped SecureStore seed) that routes through
+        // `sign_request_with_key` signs the same canonical bytes the Hub verifies.
+        let dir = std::env::temp_dir().join(format!("op-cli-unit-eq-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let key_path = dir.join("operator.key");
+        let _ = std::fs::remove_file(&key_path);
+        keygen_to_path(&key_path).unwrap();
+
+        let req = sample_request();
+        let from_file = sign_request(&key_path, &req).unwrap();
+        let sk = read_signing_key(&key_path).unwrap();
+        let from_key = sign_request_with_key(&sk, &req).unwrap();
+
+        assert_eq!(from_file.signature, from_key.signature);
+        assert_eq!(from_file.action_digest, from_key.action_digest);
+        assert_eq!(from_file.approval_id, from_key.approval_id);
+        assert_eq!(from_file.issuer, from_key.issuer);
+        assert_eq!(from_file.decision, from_key.decision);
+        assert_eq!(from_file.scheme, from_key.scheme);
+        assert_eq!(from_file.expires_at, from_key.expires_at);
         std::fs::remove_file(&key_path).ok();
     }
 

--- a/rust-core/crates/friday-operator-signer/Cargo.toml
+++ b/rust-core/crates/friday-operator-signer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "friday-operator-signer"
-description = "Friday Rust Core — DESKTOP operator-signing helper (GATE-AGENT-REPLACE D3 key-custody bridge). Like the S6c offline CLI, but reads the operator's PRIVATE Ed25519 signing seed from the KEK-wrapped SecureStore the WS server already uses (option (c) of the A2 design key-custody decision), and produces an Ed25519 SignedApproval over the Hub-computed canonical action digest — EXACTLY what resume_with_approval verifies under OperatorVerifyingKey. DARK: a standalone helper, NOT wired into prod, NEVER auto-run by the hub/coordinator. Deliberately depends on friday-core + friday-crypto + friday-operator-cli (the operator side) and NEVER friday-hub at runtime (the hub holds ONLY the verify key; the signer is the operator). PROOF-ONLY; NOT v1 GO."
+description = "Friday Rust Core — DESKTOP operator-signing helper (GATE-AGENT-REPLACE D3 key-custody bridge). Like the S6c offline CLI, but reads the operator's PRIVATE Ed25519 signing seed from an ISOLATED KEK-wrapped SecureStore the HUB CANNOT OPEN — a separate store directory sealed under a KEK derived from a separate operator-only master (FRIDAY_OPERATOR_SIGNER_MASTER) with a distinct purpose tag (option (c) of the A2 design key-custody decision, isolated per the operator 'isolate now' decision) — and produces an Ed25519 SignedApproval over the Hub-computed canonical action digest — EXACTLY what resume_with_approval verifies under OperatorVerifyingKey. ISOLATION upholds INV-1/INV-6: the seed is no longer co-resident with the Hub's store and the Hub cannot derive the unwrapping KEK. DARK: a standalone helper, NOT wired into prod, NEVER auto-run by the hub/coordinator. Deliberately depends on friday-core + friday-crypto + friday-operator-cli (the operator side) and NEVER friday-hub at runtime (the hub holds ONLY the verify key; the signer is the operator). PROOF-ONLY; NOT v1 GO."
 edition.workspace = true
 version.workspace = true
 license.workspace = true
@@ -10,9 +10,9 @@ rust-version.workspace = true
 [dependencies]
 # CanonicalApproval issuer / ApprovalDecision shapes echoed for operator review.
 friday-core.workspace = true
-# OperatorSigningKey (S6a Ed25519 primitive) + the KEK-wrapped FileSecureStore the WS
-# server reads. This crate is the OPERATOR side that holds the PRIVATE key; the Hub
-# holds only OperatorVerifyingKey.
+# OperatorSigningKey (S6a Ed25519 primitive) + the KEK-wrapped FileSecureStore. This
+# crate is the OPERATOR side that holds the PRIVATE key in an ISOLATED store the Hub
+# cannot open; the Hub holds only OperatorVerifyingKey.
 friday-crypto.workspace = true
 # Reuse the EXACT byte-producing signer (`sign_request_with_key`) + the
 # PendingRequest / SignedApproval shapes the S6c CLI defines, so the signature is
@@ -28,10 +28,12 @@ thiserror.workspace = true
 zeroize.workspace = true
 
 [dev-dependencies]
-# TEST-ONLY: pin this crate's KEK derivation to be byte-identical to the WS server's
-# (`friday_hub::key_source::derive_file_store_kek`) via a round-trip KAT — so a seed
-# the desktop helper writes/reads under its KEK opens the SAME FileSecureStore the
-# server boots from. friday-hub is a DEV dependency ONLY; it is NOT compiled into the
+# TEST-ONLY: prove ISOLATION — the inverted KAT
+# (`hub_kek_cannot_open_the_operator_signer_seed`) asserts the Hub's own
+# `friday_hub::key_source::derive_file_store_kek` CANNOT open a store this crate sealed
+# the seed into (distinct purpose tag + separate operator-only master + separate dir),
+# and `signer_store_dir_differs_from_hub_store_dir` asserts the dirs differ via the Hub's
+# pub `default_store_dir`. friday-hub is a DEV dependency ONLY; it is NOT compiled into the
 # shipped `friday-operator-sign` binary (which must stay decoupled from the Hub's
 # secret-bearing graph).
 friday-hub.workspace = true

--- a/rust-core/crates/friday-operator-signer/Cargo.toml
+++ b/rust-core/crates/friday-operator-signer/Cargo.toml
@@ -1,0 +1,41 @@
+[package]
+name = "friday-operator-signer"
+description = "Friday Rust Core — DESKTOP operator-signing helper (GATE-AGENT-REPLACE D3 key-custody bridge). Like the S6c offline CLI, but reads the operator's PRIVATE Ed25519 signing seed from the KEK-wrapped SecureStore the WS server already uses (option (c) of the A2 design key-custody decision), and produces an Ed25519 SignedApproval over the Hub-computed canonical action digest — EXACTLY what resume_with_approval verifies under OperatorVerifyingKey. DARK: a standalone helper, NOT wired into prod, NEVER auto-run by the hub/coordinator. Deliberately depends on friday-core + friday-crypto + friday-operator-cli (the operator side) and NEVER friday-hub at runtime (the hub holds ONLY the verify key; the signer is the operator). PROOF-ONLY; NOT v1 GO."
+edition.workspace = true
+version.workspace = true
+license.workspace = true
+publish = false
+rust-version.workspace = true
+
+[dependencies]
+# CanonicalApproval issuer / ApprovalDecision shapes echoed for operator review.
+friday-core.workspace = true
+# OperatorSigningKey (S6a Ed25519 primitive) + the KEK-wrapped FileSecureStore the WS
+# server reads. This crate is the OPERATOR side that holds the PRIVATE key; the Hub
+# holds only OperatorVerifyingKey.
+friday-crypto.workspace = true
+# Reuse the EXACT byte-producing signer (`sign_request_with_key`) + the
+# PendingRequest / SignedApproval shapes the S6c CLI defines, so the signature is
+# produced over the IDENTICAL canonical bytes the Hub recomputes at verify time —
+# byte-identity by construction, not re-implemented.
+friday-operator-cli.workspace = true
+# Master-key-derived KEK derivation (sha256(purpose || master)).
+sha2.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+thiserror.workspace = true
+# Wipe transient secret buffers (decoded seed / master key) after use.
+zeroize.workspace = true
+
+[dev-dependencies]
+# TEST-ONLY: pin this crate's KEK derivation to be byte-identical to the WS server's
+# (`friday_hub::key_source::derive_file_store_kek`) via a round-trip KAT — so a seed
+# the desktop helper writes/reads under its KEK opens the SAME FileSecureStore the
+# server boots from. friday-hub is a DEV dependency ONLY; it is NOT compiled into the
+# shipped `friday-operator-sign` binary (which must stay decoupled from the Hub's
+# secret-bearing graph).
+friday-hub.workspace = true
+
+[[bin]]
+name = "friday-operator-sign"
+path = "src/main.rs"

--- a/rust-core/crates/friday-operator-signer/src/lib.rs
+++ b/rust-core/crates/friday-operator-signer/src/lib.rs
@@ -1,0 +1,571 @@
+//! Desktop operator-signing helper — library half (GATE-AGENT-REPLACE D3 key-custody
+//! bridge, the operator-chosen **desktop helper** option of the A2 key-custody decision).
+//!
+//! ## Truth label — OPERATOR SIDE, dark, proof-only
+//!
+//! This is the OFFLINE OPERATOR signer, like the S6c CLI ([`friday_operator_cli`]), with
+//! exactly ONE thing swapped: the PRIVATE Ed25519 signing seed is sourced from the
+//! **KEK-wrapped [`SecureStore`] the WS server already uses** (a 32-byte raw seed under a
+//! namespaced id), instead of a plaintext hex file. The A2 design (decision 3c) chose this
+//! desktop helper as the bridge for the first live S6-in-product proof precisely BECAUSE it
+//! reuses the existing KEK plumbing and stays Ed25519-native — so the Hub's verify side
+//! (`OperatorVerifyingKey`) needs no scheme change.
+//!
+//! It loads the seed, builds an [`OperatorSigningKey`], and produces an Ed25519
+//! [`SignedApproval`] over the Hub-computed canonical action bytes — EXACTLY what
+//! `friday_hub::resume::resume_with_approval` verifies. It NEVER mints out of thin air: it
+//! signs the digest the Hub already computed (carried in the pending request), the operator
+//! reviews the human-readable context, and the bytes are produced by the SAME
+//! [`friday_operator_cli::sign_request_with_key`] path the file-based CLI uses, so the bytes
+//! are byte-identical to what the Hub recomputes at verify time.
+//!
+//! ## Why the Hub holds only the verify key still holds (INV-1 / INV-6)
+//!
+//! This crate is the OPERATOR side. It deliberately depends on `friday-core` +
+//! `friday-crypto` + `friday-operator-cli` and NEVER on `friday-hub` at runtime — the Hub
+//! crate holds ONLY [`friday_crypto::OperatorVerifyingKey`] and (by the structural
+//! `hub_crate_never_references_a_signing_key` test) contains NO code that turns the stored
+//! seed bytes into a signer. The seed living in the KEK-wrapped SecureStore is safe FOR
+//! THAT REASON: the Hub can read the bytes but has no `OperatorSigningKey` path to sign
+//! with them; only this separate operator-run helper does.
+//!
+//! ## NEVER auto-invoked
+//!
+//! This helper is the operator's signer; it runs on the OPERATOR's machine, attended, and
+//! is NEVER invoked automatically by the hub or any coordinator process. There is no
+//! production route, no scheduler hook, no in-process caller — it is a one-shot CLI the
+//! operator runs by hand to approve ONE specific paused mutation. PROOF-ONLY; NOT v1 GO.
+
+use friday_core::gate::ApprovalDecision;
+use friday_crypto::{FileSecureStore, Kek, OperatorSigningKey, SecureStore};
+use friday_operator_cli::{sign_request_with_key, CliError, PendingRequest, SignedApproval};
+use sha2::{Digest, Sha256};
+use thiserror::Error;
+use zeroize::Zeroize;
+
+/// Length of the operator's Ed25519 secret seed, in raw bytes (the value stored under
+/// [`OPERATOR_SIGNING_SEED_SECURE_STORE_ID`]).
+pub const SIGNING_SEED_LEN: usize = 32;
+
+/// Master-key width in bytes — MUST equal `friday_hub::key_source::MASTER_KEY_LEN`. The
+/// dev-dep KAT pins the whole KEK derivation to the server's, so a divergence here is
+/// caught at test time.
+pub const MASTER_KEY_LEN: usize = 32;
+
+/// The `SecureStore` id under which the operator provisions their 32-byte RAW Ed25519
+/// **signing seed**. Namespaced so it can NEVER collide with the verify-key id
+/// (`friday_hub::operator_vk::OPERATOR_VK_SECURE_STORE_ID`), the KEK, or the peer-pubkey
+/// allowlist (`friday_hub::key_source::PEER_PUBKEY_ALLOWLIST_ID`). The seed is the SECRET
+/// half; it lives ONLY with the operator (this store, on the operator's machine), never on
+/// the Hub.
+pub const OPERATOR_SIGNING_SEED_SECURE_STORE_ID: &str =
+    "friday.operator.approval.signing_seed.ed25519";
+
+/// Env var carrying the hex-encoded master key (highest-priority source). MUST match
+/// `friday_hub::key_source::MASTER_KEY_ENV` — the helper derives the SAME KEK the server
+/// boots from, so it opens the SAME `FileSecureStore`.
+pub const MASTER_KEY_ENV: &str = "FRIDAY_MASTER_KEY"; // pragma: allowlist secret
+
+/// Path of the persisted master key file RELATIVE to `$HOME`. MUST match
+/// `friday_hub::key_source`'s `MASTER_KEY_FILE_REL` (private there; re-derived here as the
+/// operator side). RESIDUAL: this constant is hand-copied, not pinned by a KAT — but any
+/// drift is FAIL-CLOSED, not silent-wrong-key: a different file path yields a different
+/// master ⇒ a different KEK ⇒ `get()` returns `None` ⇒ `SeedUnprovisioned` (the helper
+/// refuses to sign), exactly as `wrong_master_key_fails_closed` proves. It can never make
+/// the helper sign the wrong thing.
+const MASTER_KEY_FILE_REL: &str = ".friday/master.key";
+
+/// The default `FileSecureStore` directory RELATIVE to `$HOME`. MUST match
+/// `friday_hub::key_source::default_store_dir`'s `DEFAULT_STORE_DIR_REL` so the helper
+/// reads the SAME store the server enrolled into. RESIDUAL (fail-closed, as above): a wrong
+/// dir simply finds no seed entry ⇒ `SeedUnprovisioned`, never a wrong signature.
+const DEFAULT_STORE_DIR_REL: &str = ".friday/agent-run-securestore";
+
+/// Domain-separation tag for the `FileSecureStore` KEK derivation. MUST be byte-identical
+/// to `friday_hub::key_source`'s `FILE_STORE_KEK_PURPOSE` (private there) so the derived
+/// KEK opens the SAME store. This one IS pinned: a round-trip KAT
+/// (`kek_derivation_matches_the_ws_server`) seals under the server's KEK and opens under
+/// ours (Kek has no `Eq`), so a divergence is caught at test time. (And even unpinned it
+/// would be fail-closed: a wrong tag ⇒ wrong KEK ⇒ `None` ⇒ `SeedUnprovisioned`.)
+const FILE_STORE_KEK_PURPOSE: &[u8] = b"friday.rust.securestore.file.kek.v1";
+
+/// A fail-closed error. **Carries no key bytes, no master key, no seed, no plaintext** —
+/// only a structural category — so it is always safe to surface/log. The seed/master are
+/// the secrets; they never appear in any variant.
+#[derive(Debug, Error)]
+pub enum SignerError {
+    /// `$HOME` is unset and no explicit store dir / master path was given, so the default
+    /// `~/.friday/...` locations cannot be resolved.
+    #[error("HOME is not set; pass --store-dir and a master key explicitly")]
+    HomeUnset,
+    /// Neither `FRIDAY_MASTER_KEY` nor `~/.friday/master.key` is present. FAIL CLOSED — the
+    /// helper NEVER auto-generates a master key (it must match the host's existing one).
+    #[error("no master key: set FRIDAY_MASTER_KEY (hex) or provision ~/.friday/master.key")]
+    MasterKeyMissing,
+    /// The master key source was present but not valid 32-byte hex.
+    #[error("master key is malformed (expected 64 hex chars = 32 bytes)")]
+    MasterKeyMalformed,
+    /// The SecureStore could not be opened (path/permissions). No secret content.
+    #[error("secure store is unavailable")]
+    StoreUnavailable,
+    /// No operator signing seed is provisioned in the SecureStore under
+    /// [`OPERATOR_SIGNING_SEED_SECURE_STORE_ID`] (absent, or present-but-unreadable —
+    /// the fail-closed `SecureStore::get` collapses both to absent). FAIL CLOSED: with no
+    /// operator key the helper signs NOTHING.
+    #[error("operator signing seed is not provisioned in the secure store")]
+    SeedUnprovisioned,
+    /// The provisioned seed is not exactly [`SIGNING_SEED_LEN`] raw bytes.
+    #[error("operator signing seed is malformed (expected 32 raw bytes)")]
+    SeedMalformed,
+    /// The pending request was malformed (bad decision / digest / approval_id / expiry).
+    /// Wraps the S6c CLI's secret-free validation error.
+    #[error("invalid pending request: {0}")]
+    BadRequest(#[from] CliError),
+}
+
+/// Decode a 64-char hex string into exactly [`MASTER_KEY_LEN`] bytes. `None` for any
+/// non-hex / odd-length / wrong-length input (fail-closed; never panics).
+fn decode_master_hex(s: &str) -> Option<[u8; MASTER_KEY_LEN]> {
+    let b = s.trim().as_bytes();
+    if b.len() != MASTER_KEY_LEN * 2 {
+        return None;
+    }
+    let mut out = [0u8; MASTER_KEY_LEN];
+    for (i, pair) in b.chunks_exact(2).enumerate() {
+        out[i] = (hex_nibble(pair[0])? << 4) | hex_nibble(pair[1])?;
+    }
+    Some(out)
+}
+
+fn hex_nibble(b: u8) -> Option<u8> {
+    match b {
+        b'0'..=b'9' => Some(b - b'0'),
+        b'a'..=b'f' => Some(b - b'a' + 10),
+        b'A'..=b'F' => Some(b - b'A' + 10),
+        _ => None,
+    }
+}
+
+/// `$HOME`-relative path, or [`SignerError::HomeUnset`] when `$HOME` is unset.
+fn home_relative(rel: &str) -> Result<std::path::PathBuf, SignerError> {
+    let home = std::env::var_os("HOME").ok_or(SignerError::HomeUnset)?;
+    if home.is_empty() {
+        return Err(SignerError::HomeUnset);
+    }
+    Ok(std::path::Path::new(&home).join(rel))
+}
+
+/// The default `FileSecureStore` directory (`~/.friday/agent-run-securestore`), matching
+/// the WS server's `default_store_dir`.
+pub fn default_store_dir() -> Result<std::path::PathBuf, SignerError> {
+    home_relative(DEFAULT_STORE_DIR_REL)
+}
+
+/// Read the 32-byte master key, FAIL-CLOSED, mirroring the WS server's
+/// `friday_hub::key_source::read_master_key` SOURCE order MINUS auto-generation:
+///   1. `FRIDAY_MASTER_KEY` env (hex), if non-empty.
+///   2. `~/.friday/master.key` (bytes -> UTF-8 -> trim -> hex-decode).
+///   3. Neither present -> [`SignerError::MasterKeyMissing`]. NEVER creates the file.
+///
+/// The returned key is wrapped so it is wiped on drop; it never appears in any error.
+fn read_master_key() -> Result<MasterKey, SignerError> {
+    if let Some(env_val) = std::env::var_os(MASTER_KEY_ENV) {
+        let env_str = env_val.to_string_lossy();
+        if !env_str.is_empty() {
+            return decode_master_hex(&env_str)
+                .map(MasterKey)
+                .ok_or(SignerError::MasterKeyMalformed);
+        }
+    }
+    let path = home_relative(MASTER_KEY_FILE_REL)?;
+    match std::fs::read(&path) {
+        Ok(bytes) => {
+            let text = String::from_utf8_lossy(&bytes);
+            decode_master_hex(text.trim())
+                .map(MasterKey)
+                .ok_or(SignerError::MasterKeyMalformed)
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Err(SignerError::MasterKeyMissing),
+        // Any other IO error (e.g. EACCES on a present-but-unreadable file) is reported as
+        // a malformed-source failure (secret-free), never silently "missing".
+        Err(_) => Err(SignerError::MasterKeyMalformed),
+    }
+}
+
+/// A master key that wipes its bytes on drop. The bytes are secret (they derive the KEK
+/// that unwraps the signing seed); they are never printed, logged, or returned.
+struct MasterKey([u8; MASTER_KEY_LEN]);
+
+impl Drop for MasterKey {
+    fn drop(&mut self) {
+        self.0.zeroize();
+    }
+}
+
+/// Derive the `FileSecureStore` KEK from the master key:
+/// `Kek::from_bytes(sha256(FILE_STORE_KEK_PURPOSE || master))`.
+///
+/// Byte-identical to `friday_hub::key_source::derive_file_store_kek` (pinned by the
+/// dev-dep round-trip KAT in this crate's tests), so a store the WS server opens and a
+/// store this helper opens use the SAME KEK and thus see the SAME entries.
+fn derive_file_store_kek(master: &[u8; MASTER_KEY_LEN]) -> Kek {
+    let mut hasher = Sha256::new();
+    hasher.update(FILE_STORE_KEK_PURPOSE);
+    hasher.update(master);
+    let digest = hasher.finalize();
+    let mut bytes = [0u8; 32];
+    bytes.copy_from_slice(&digest);
+    Kek::from_bytes(bytes)
+}
+
+/// Load the operator's PRIVATE [`OperatorSigningKey`] from the KEK-wrapped SecureStore at
+/// `store_dir`, using the host master key to derive the KEK. The 32 raw seed bytes are
+/// read from [`OPERATOR_SIGNING_SEED_SECURE_STORE_ID`], built into a signing key, then the
+/// transient seed buffer is zeroized.
+///
+/// Fail-closed: a missing master key, an unreadable store, an absent/unreadable seed entry,
+/// or a wrong-length seed each return an `Err` and the helper signs nothing. The seed bytes
+/// never appear in any error or log.
+pub fn load_signing_key_from_store(
+    store_dir: &std::path::Path,
+) -> Result<OperatorSigningKey, SignerError> {
+    let master = read_master_key()?;
+    let kek = derive_file_store_kek(&master.0);
+    drop(master); // wipe the master key as soon as the KEK is derived.
+
+    let store = FileSecureStore::open(store_dir, kek).map_err(|_| SignerError::StoreUnavailable)?;
+    // Fail-closed read: `SecureStore::get` collapses absent AND present-but-unreadable
+    // (wrong KEK / tampered / malformed) to `None` — either way there is no operator key
+    // and the helper refuses to sign.
+    let mut seed_bytes = store
+        .get(OPERATOR_SIGNING_SEED_SECURE_STORE_ID)
+        .ok_or(SignerError::SeedUnprovisioned)?;
+
+    // `mut` so the ORIGINAL binding is zeroized below (a shadowing `let mut x = x` would
+    // COPY the `[u8; 32]` (it is `Copy`) and leave the original live + un-wiped).
+    let mut seed_arr: [u8; SIGNING_SEED_LEN] = match seed_bytes.as_slice().try_into() {
+        Ok(a) => a,
+        Err(_) => {
+            seed_bytes.zeroize();
+            return Err(SignerError::SeedMalformed);
+        }
+    };
+    let sk = OperatorSigningKey::from_seed_bytes(&seed_arr);
+    // Wipe the secret seed: the stack array we decoded AND the heap buffer it came from.
+    // (`from_seed_bytes` copied the seed into the key, which zeroizes on drop.)
+    seed_arr.zeroize();
+    seed_bytes.zeroize();
+    Ok(sk)
+}
+
+/// End-to-end: load the operator signing key from the SecureStore at `store_dir` and
+/// produce an Ed25519 [`SignedApproval`] over the pending request's canonical bytes.
+///
+/// The signature is produced by [`friday_operator_cli::sign_request_with_key`] — the SAME
+/// byte-producing path the file-based S6c CLI uses — so it is byte-identical to what the
+/// Hub recomputes at verify time (`friday_hub::resume::resume_with_approval` ->
+/// `authorize_mutating_action_ed25519` -> `canonical_approval_signature_bytes`). The
+/// operator owns the digest semantics: the request's `action_digest` is the one the Hub
+/// already computed and persisted; this helper only signs it.
+pub fn sign_pending_from_store(
+    store_dir: &std::path::Path,
+    req: &PendingRequest,
+) -> Result<SignedApproval, SignerError> {
+    let sk = load_signing_key_from_store(store_dir)?;
+    Ok(sign_request_with_key(&sk, req)?)
+}
+
+/// Provision (enroll) a 32-byte operator signing seed into the SecureStore at `store_dir`,
+/// under the host master-key-derived KEK. OPERATOR-side only — used so the operator can put
+/// their seed into the same KEK-wrapped store the helper later reads. The seed bytes are
+/// wiped from the caller-supplied slice's responsibility (this fn does not retain them);
+/// the value the SecureStore seals is the secret.
+///
+/// FAIL-CLOSED on a wrong-length seed (must be exactly [`SIGNING_SEED_LEN`]) so a truncated
+/// seed is never enrolled. Returns `Ok(())` only after the entry is durably written.
+pub fn provision_signing_seed_into_store(
+    store_dir: &std::path::Path,
+    seed: &[u8],
+) -> Result<(), SignerError> {
+    if seed.len() != SIGNING_SEED_LEN {
+        return Err(SignerError::SeedMalformed);
+    }
+    let master = read_master_key()?;
+    let kek = derive_file_store_kek(&master.0);
+    drop(master);
+    let mut store =
+        FileSecureStore::open(store_dir, kek).map_err(|_| SignerError::StoreUnavailable)?;
+    store
+        .try_put(OPERATOR_SIGNING_SEED_SECURE_STORE_ID, seed)
+        .map_err(|_| SignerError::StoreUnavailable)
+}
+
+/// Map a human decision string to the gate enum, for echoing the operator's choice in
+/// context. Fail-closed: only the two exact spellings are accepted.
+pub fn parse_decision(s: &str) -> Option<ApprovalDecision> {
+    match s {
+        "approved" => Some(ApprovalDecision::Approved),
+        "denied" => Some(ApprovalDecision::Denied),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use friday_crypto::OperatorVerifyingKey;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    struct TempDir {
+        path: std::path::PathBuf,
+    }
+    impl TempDir {
+        fn new(tag: &str) -> Self {
+            static CTR: AtomicU64 = AtomicU64::new(0);
+            let n = CTR.fetch_add(1, Ordering::Relaxed);
+            let mut path = std::env::temp_dir();
+            path.push(format!(
+                "friday-operator-signer-test-{tag}-{}-{n}",
+                std::process::id()
+            ));
+            std::fs::create_dir_all(&path).unwrap();
+            Self { path }
+        }
+        fn child(&self, name: &str) -> std::path::PathBuf {
+            self.path.join(name)
+        }
+    }
+    impl Drop for TempDir {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.path);
+        }
+    }
+
+    const KAT_MASTER: [u8; MASTER_KEY_LEN] = [0x42u8; MASTER_KEY_LEN];
+
+    fn sample_request(action_digest: &str) -> PendingRequest {
+        PendingRequest {
+            approval_id: "ap-nonce-signer-001".to_string(),
+            action_digest: action_digest.to_string(),
+            expires_at: 1_900_000_000_000,
+            decision: "approved".to_string(),
+            issuer: None,
+            principal: Some("owner:operator".to_string()),
+            action: Some("fs.write_file".to_string()),
+            surface: Some("desktop".to_string()),
+        }
+    }
+
+    /// LOAD-BEARING KAT: this crate's KEK derivation MUST be byte-identical to the WS
+    /// server's (`friday_hub::key_source::derive_file_store_kek`). `Kek` has no `Eq`, so
+    /// we prove equality by sealing under the SERVER's KEK and opening under OURS (and
+    /// vice-versa) through a real `FileSecureStore`. A divergence here would mean the
+    /// helper reads a DIFFERENT store than the server enrolled into — a silent
+    /// fail-closed at the D3 proof.
+    #[test]
+    fn kek_derivation_matches_the_ws_server() {
+        let td = TempDir::new("kek-parity");
+        let dir = td.child("store");
+        // Seal under the HUB/server's KEK derivation.
+        {
+            let server_kek = friday_hub::key_source::derive_file_store_kek(&KAT_MASTER);
+            let mut s = FileSecureStore::open(&dir, server_kek).unwrap();
+            s.try_put(
+                OPERATOR_SIGNING_SEED_SECURE_STORE_ID,
+                &[0x07u8; SIGNING_SEED_LEN],
+            )
+            .unwrap();
+        }
+        // Open under OUR KEK derivation — must read the same bytes.
+        let our_kek = derive_file_store_kek(&KAT_MASTER);
+        let s = FileSecureStore::open(&dir, our_kek).unwrap();
+        assert_eq!(
+            s.try_get(OPERATOR_SIGNING_SEED_SECURE_STORE_ID)
+                .unwrap()
+                .as_deref(),
+            Some(&[0x07u8; SIGNING_SEED_LEN][..]),
+            "the desktop signer's KEK must open a store the WS server sealed — a mismatch \
+             means the helper reads a different store than the server enrolled into"
+        );
+        // And the symmetric direction: our seal opens under the server's KEK.
+        let our_kek2 = derive_file_store_kek(&KAT_MASTER);
+        let mut s2 = FileSecureStore::open(&dir, our_kek2).unwrap();
+        s2.try_put(
+            OPERATOR_SIGNING_SEED_SECURE_STORE_ID,
+            &[0x09u8; SIGNING_SEED_LEN],
+        )
+        .unwrap();
+        let server_kek2 = friday_hub::key_source::derive_file_store_kek(&KAT_MASTER);
+        let s3 = FileSecureStore::open(&dir, server_kek2).unwrap();
+        assert_eq!(
+            s3.try_get(OPERATOR_SIGNING_SEED_SECURE_STORE_ID)
+                .unwrap()
+                .as_deref(),
+            Some(&[0x09u8; SIGNING_SEED_LEN][..]),
+        );
+    }
+
+    /// The seed id MUST be distinct from every other SecureStore id the system uses, so
+    /// the signing seed can never collide with the verify key or the peer allowlist.
+    #[test]
+    fn signing_seed_id_is_distinct_from_other_secure_store_ids() {
+        assert_ne!(
+            OPERATOR_SIGNING_SEED_SECURE_STORE_ID,
+            friday_hub::operator_vk::OPERATOR_VK_SECURE_STORE_ID
+        );
+        assert_ne!(
+            OPERATOR_SIGNING_SEED_SECURE_STORE_ID,
+            friday_hub::key_source::PEER_PUBKEY_ALLOWLIST_ID
+        );
+    }
+
+    /// END-TO-END: provision a seed into the KEK-wrapped store, sign a pending request
+    /// from it, and prove the emitted Ed25519 signature VERIFIES under the matching
+    /// verify key over the EXACT canonical bytes — i.e. the Hub would accept it.
+    #[test]
+    fn store_sourced_signature_verifies_under_the_matching_verify_key() {
+        use friday_core::gate::{CanonicalApproval, CANONICAL_GATE_ISSUER};
+        let td = TempDir::new("e2e");
+        let dir = td.child("store");
+
+        // The operator generates a keypair off-Hub and provisions ONLY the private seed
+        // into the KEK-wrapped store (the verify key would be provisioned into the Hub).
+        let operator = OperatorSigningKey::generate();
+        let vk = operator.verifying_key();
+        let seed = operator.to_seed_bytes();
+
+        // Provision under a known master (KAT_MASTER) by sealing with the server's KEK.
+        {
+            let kek = derive_file_store_kek(&KAT_MASTER);
+            let mut s = FileSecureStore::open(&dir, kek).unwrap();
+            s.try_put(OPERATOR_SIGNING_SEED_SECURE_STORE_ID, &seed)
+                .unwrap();
+        }
+
+        // The helper loads the seed from the store (master via env) and signs.
+        let digest = "b".repeat(64);
+        let req = sample_request(&digest);
+        let signed = with_master_env(&KAT_MASTER, || sign_pending_from_store(&dir, &req)).unwrap();
+
+        // Reconstruct the EXACT bytes the Hub verifies over and check the signature.
+        let approval = CanonicalApproval {
+            decision: parse_decision(&signed.decision).unwrap(),
+            approval_id: signed.approval_id.clone(),
+            action_digest: signed.action_digest.clone(),
+            expires_at: Some(signed.expires_at),
+            issuer: Some(signed.issuer.clone()),
+            signature: None,
+        };
+        let bytes = friday_core::gate::canonical_approval_signature_bytes(&approval);
+        assert!(
+            verify_signature(&bytes, &vk, &signed.signature),
+            "the store-sourced signature must verify under the matching verify key over \
+             the canonical approval bytes the Hub recomputes"
+        );
+        assert_eq!(signed.scheme, "ed25519");
+        assert_eq!(signed.action_digest, digest);
+        assert_eq!(signed.issuer, CANONICAL_GATE_ISSUER);
+    }
+
+    /// FAIL-CLOSED: an empty store (no seed provisioned) refuses to sign.
+    #[test]
+    fn unprovisioned_seed_fails_closed() {
+        let td = TempDir::new("unprov");
+        let dir = td.child("store");
+        // Create the store dir (with the right KEK) but provision NO seed.
+        {
+            let kek = derive_file_store_kek(&KAT_MASTER);
+            let _ = FileSecureStore::open(&dir, kek).unwrap();
+        }
+        let req = sample_request(&"c".repeat(64));
+        let err = with_master_env(&KAT_MASTER, || sign_pending_from_store(&dir, &req)).unwrap_err();
+        assert!(matches!(err, SignerError::SeedUnprovisioned));
+    }
+
+    /// FAIL-CLOSED: a wrong-length seed in the store is rejected (never built into a key).
+    #[test]
+    fn malformed_seed_fails_closed() {
+        let td = TempDir::new("malformed");
+        let dir = td.child("store");
+        {
+            let kek = derive_file_store_kek(&KAT_MASTER);
+            let mut s = FileSecureStore::open(&dir, kek).unwrap();
+            s.try_put(OPERATOR_SIGNING_SEED_SECURE_STORE_ID, &[0x01u8; 16]) // too short
+                .unwrap();
+        }
+        // NB: `OperatorSigningKey` has no Debug (key bytes are never logged), so the Ok
+        // arm cannot be unwrapped/printed — `matches!` the Err arm directly.
+        let result = with_master_env(&KAT_MASTER, || load_signing_key_from_store(&dir));
+        assert!(matches!(result, Err(SignerError::SeedMalformed)));
+    }
+
+    /// FAIL-CLOSED: a store opened under the WRONG master key (wrong KEK) cannot read the
+    /// seed — the AEAD unwrap fails and `get` returns None → SeedUnprovisioned (never a
+    /// silently-wrong key).
+    #[test]
+    fn wrong_master_key_fails_closed() {
+        let td = TempDir::new("wrongkek");
+        let dir = td.child("store");
+        // Provision under master A.
+        let master_a = [0x11u8; MASTER_KEY_LEN];
+        {
+            let kek = derive_file_store_kek(&master_a);
+            let mut s = FileSecureStore::open(&dir, kek).unwrap();
+            s.try_put(
+                OPERATOR_SIGNING_SEED_SECURE_STORE_ID,
+                &[0x05u8; SIGNING_SEED_LEN],
+            )
+            .unwrap();
+        }
+        // Try to load under master B (different KEK) → fail closed.
+        let master_b = [0x22u8; MASTER_KEY_LEN];
+        let result = with_master_env(&master_b, || load_signing_key_from_store(&dir));
+        assert!(matches!(result, Err(SignerError::SeedUnprovisioned)));
+    }
+
+    #[test]
+    fn provision_rejects_wrong_length_seed() {
+        let td = TempDir::new("provlen");
+        let dir = td.child("store");
+        let err = with_master_env(&KAT_MASTER, || {
+            provision_signing_seed_into_store(&dir, &[0u8; 31])
+        })
+        .unwrap_err();
+        assert!(matches!(err, SignerError::SeedMalformed));
+    }
+
+    #[test]
+    fn parse_decision_is_fail_closed() {
+        assert_eq!(parse_decision("approved"), Some(ApprovalDecision::Approved));
+        assert_eq!(parse_decision("denied"), Some(ApprovalDecision::Denied));
+        assert_eq!(parse_decision("maybe"), None);
+        assert_eq!(parse_decision(""), None);
+    }
+
+    fn verify_signature(bytes: &[u8], vk: &OperatorVerifyingKey, sig_hex: &str) -> bool {
+        friday_crypto::verify_ed25519_approval_hex(bytes, &vk.to_bytes(), sig_hex)
+    }
+
+    /// Run `f` with `FRIDAY_MASTER_KEY` set to the hex of `master`, restoring the prior
+    /// env afterward. These tests mutate process-global env, so they are serialized by
+    /// running them all through this one helper under a single mutex.
+    fn with_master_env<T>(master: &[u8; MASTER_KEY_LEN], f: impl FnOnce() -> T) -> T {
+        use std::sync::Mutex;
+        static ENV_LOCK: Mutex<()> = Mutex::new(());
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let saved = std::env::var_os(MASTER_KEY_ENV);
+        let hex: String = master.iter().map(|b| format!("{b:02x}")).collect();
+        // SAFETY: serialized by ENV_LOCK; restored before the guard drops.
+        unsafe {
+            std::env::set_var(MASTER_KEY_ENV, &hex);
+        }
+        let out = f();
+        unsafe {
+            match saved {
+                Some(v) => std::env::set_var(MASTER_KEY_ENV, v),
+                None => std::env::remove_var(MASTER_KEY_ENV),
+            }
+        }
+        out
+    }
+}

--- a/rust-core/crates/friday-operator-signer/src/lib.rs
+++ b/rust-core/crates/friday-operator-signer/src/lib.rs
@@ -1,15 +1,54 @@
 //! Desktop operator-signing helper — library half (GATE-AGENT-REPLACE D3 key-custody
 //! bridge, the operator-chosen **desktop helper** option of the A2 key-custody decision).
 //!
-//! ## Truth label — OPERATOR SIDE, dark, proof-only
+//! ## Truth label — OPERATOR SIDE, ISOLATED key custody, dark, proof-only
 //!
 //! This is the OFFLINE OPERATOR signer, like the S6c CLI ([`friday_operator_cli`]), with
-//! exactly ONE thing swapped: the PRIVATE Ed25519 signing seed is sourced from the
-//! **KEK-wrapped [`SecureStore`] the WS server already uses** (a 32-byte raw seed under a
+//! exactly ONE thing swapped: the PRIVATE Ed25519 signing seed is sourced from a
+//! **KEK-wrapped [`SecureStore`] the Hub CANNOT open** (a 32-byte raw seed under a
 //! namespaced id), instead of a plaintext hex file. The A2 design (decision 3c) chose this
 //! desktop helper as the bridge for the first live S6-in-product proof precisely BECAUSE it
-//! reuses the existing KEK plumbing and stays Ed25519-native — so the Hub's verify side
-//! (`OperatorVerifyingKey`) needs no scheme change.
+//! stays Ed25519-native — so the Hub's verify side (`OperatorVerifyingKey`) needs no scheme
+//! change.
+//!
+//! ### ISOLATION (operator decision "isolate now"): the seed is NOT co-resident with the Hub
+//!
+//! A security audit found that sealing the operator seed under the Hub's OWN store KEK
+//! (same `FILE_STORE_KEK_PURPOSE`, same `DEFAULT_STORE_DIR_REL`, same master key) WEAKENED
+//! INV-6: the Hub process could derive that KEK via
+//! `friday_hub::key_source::derive_file_store_kek(master)` and open the seed store. This
+//! crate now seals the seed under a KEK the Hub's existing derivation CANNOT produce,
+//! achieving true isolation even on one box, by stacking THREE independent separations.
+//!
+//! ### Unconditional + KAT-proven: the Hub's existing `derive_file_store_kek` cannot open it
+//!
+//!   1. **Distinct KEK purpose tag** — [`SIGNER_SEED_KEK_PURPOSE`] is byte-DIFFERENT from
+//!      the Hub's `FILE_STORE_KEK_PURPOSE`, so the Hub's hardcoded `derive_file_store_kek`
+//!      cannot produce the seed KEK **even if it were fed the signer master** (the inverted
+//!      KAT proves exactly this worst case).
+//!   2. **Distinct store directory** — [`SIGNER_STORE_DIR_REL`] is NOT the Hub's
+//!      `DEFAULT_STORE_DIR_REL`, so the seed never lands in the store the Hub enrolls into.
+//!
+//! These two hold REGARDLESS of the master values; the inverted KAT
+//! [`hub_kek_cannot_open_the_operator_signer_seed`] PROVES the Hub's `derive_file_store_kek`
+//! cannot unwrap the seed (asserting both the runtime `get()` → `None` and the explicit
+//! `try_get()` → `Err(Crypto(Open))`).
+//!
+//! ### Operational (default-true, NOT KAT-covered): hub-underivable even with NEW hub code
+//!
+//!   3. **Distinct master/secret source** — the signer's KEK is derived from a SEPARATE
+//!      operator-only master ([`SIGNER_MASTER_ENV`] / [`signer_master_file`]), NOT the Hub's
+//!      `FRIDAY_MASTER_KEY` / `~/.friday/master.key`. The Hub never reads this source.
+//!
+//! Separation (3) is what would let the seed KEK stay hub-*underivable* even against ADDED
+//! hub code (not just the existing derivation): such code would still need the signer
+//! master VALUE, which the Hub never holds. This property is CONDITIONAL on the signer
+//! master value DIFFERING from the Hub's master — which the separate source/file provides by
+//! DEFAULT (distinct env + distinct file, each provisioned by the operator out of band). It
+//! is NOT KAT-covered (no test exercises a hypothetical hub that hashes
+//! `SIGNER_SEED_KEK_PURPOSE` with the signer master) and it DOES degrade if the operator
+//! deliberately points both masters at the same bytes. The unconditional guarantee above
+//! does not depend on it.
 //!
 //! It loads the seed, builds an [`OperatorSigningKey`], and produces an Ed25519
 //! [`SignedApproval`] over the Hub-computed canonical action bytes — EXACTLY what
@@ -25,9 +64,9 @@
 //! `friday-crypto` + `friday-operator-cli` and NEVER on `friday-hub` at runtime — the Hub
 //! crate holds ONLY [`friday_crypto::OperatorVerifyingKey`] and (by the structural
 //! `hub_crate_never_references_a_signing_key` test) contains NO code that turns the stored
-//! seed bytes into a signer. The seed living in the KEK-wrapped SecureStore is safe FOR
-//! THAT REASON: the Hub can read the bytes but has no `OperatorSigningKey` path to sign
-//! with them; only this separate operator-run helper does.
+//! seed bytes into a signer. With the ISOLATION above the seed is doubly safe: the Hub has
+//! no `OperatorSigningKey` path to sign with AND cannot even open the store the seed lives
+//! in. Only this separate operator-run helper, with the operator-only master, can.
 //!
 //! ## NEVER auto-invoked
 //!
@@ -47,9 +86,9 @@ use zeroize::Zeroize;
 /// [`OPERATOR_SIGNING_SEED_SECURE_STORE_ID`]).
 pub const SIGNING_SEED_LEN: usize = 32;
 
-/// Master-key width in bytes — MUST equal `friday_hub::key_source::MASTER_KEY_LEN`. The
-/// dev-dep KAT pins the whole KEK derivation to the server's, so a divergence here is
-/// caught at test time.
+/// Master-key width in bytes. The signer's master is a SEPARATE 32-byte secret from the
+/// Hub's (see [`SIGNER_MASTER_ENV`]); the width matches because both are 32-byte keys, but
+/// the VALUE differs and the Hub never reads the signer's source.
 pub const MASTER_KEY_LEN: usize = 32;
 
 /// The `SecureStore` id under which the operator provisions their 32-byte RAW Ed25519
@@ -61,33 +100,39 @@ pub const MASTER_KEY_LEN: usize = 32;
 pub const OPERATOR_SIGNING_SEED_SECURE_STORE_ID: &str =
     "friday.operator.approval.signing_seed.ed25519";
 
-/// Env var carrying the hex-encoded master key (highest-priority source). MUST match
-/// `friday_hub::key_source::MASTER_KEY_ENV` — the helper derives the SAME KEK the server
-/// boots from, so it opens the SAME `FileSecureStore`.
-pub const MASTER_KEY_ENV: &str = "FRIDAY_MASTER_KEY"; // pragma: allowlist secret
+/// Env var carrying the hex-encoded **operator-signer master key** (highest-priority
+/// source). DELIBERATELY DISTINCT from the Hub's `friday_hub::key_source::MASTER_KEY_ENV`
+/// (`FRIDAY_MASTER_KEY`): this is the operator-only secret that derives the seed-store KEK.
+/// The Hub process never reads this var. When its VALUE also differs from the Hub's master
+/// (the default — a separate env/file the operator provisions out of band), the seed KEK
+/// stays hub-underivable even against ADDED hub code, since such code would still lack the
+/// signer master value. (The unconditional, KAT-proven isolation from the distinct purpose
+/// tag + store dir does not depend on this.)
+pub const SIGNER_MASTER_ENV: &str = "FRIDAY_OPERATOR_SIGNER_MASTER"; // pragma: allowlist secret
 
-/// Path of the persisted master key file RELATIVE to `$HOME`. MUST match
-/// `friday_hub::key_source`'s `MASTER_KEY_FILE_REL` (private there; re-derived here as the
-/// operator side). RESIDUAL: this constant is hand-copied, not pinned by a KAT — but any
-/// drift is FAIL-CLOSED, not silent-wrong-key: a different file path yields a different
-/// master ⇒ a different KEK ⇒ `get()` returns `None` ⇒ `SeedUnprovisioned` (the helper
-/// refuses to sign), exactly as `wrong_master_key_fails_closed` proves. It can never make
-/// the helper sign the wrong thing.
-const MASTER_KEY_FILE_REL: &str = ".friday/master.key";
+/// Path of the persisted **operator-signer master key** file RELATIVE to `$HOME`.
+/// DELIBERATELY DISTINCT from the Hub's `~/.friday/master.key` so the two masters never
+/// collide on disk. The Hub's `key_source` reads ONLY `~/.friday/master.key`; it never
+/// reads this file — so even a Hub running as the same user, reading its own configured
+/// sources, never obtains the signer master. (A missing source ⇒ fail-closed
+/// `MasterKeyMissing`; the helper NEVER auto-generates a master.)
+const SIGNER_MASTER_FILE_REL: &str = ".friday/operator-signer.key";
 
-/// The default `FileSecureStore` directory RELATIVE to `$HOME`. MUST match
-/// `friday_hub::key_source::default_store_dir`'s `DEFAULT_STORE_DIR_REL` so the helper
-/// reads the SAME store the server enrolled into. RESIDUAL (fail-closed, as above): a wrong
-/// dir simply finds no seed entry ⇒ `SeedUnprovisioned`, never a wrong signature.
-const DEFAULT_STORE_DIR_REL: &str = ".friday/agent-run-securestore";
+/// The signer's `FileSecureStore` directory RELATIVE to `$HOME`. DELIBERATELY DISTINCT from
+/// `friday_hub::key_source::default_store_dir`'s `DEFAULT_STORE_DIR_REL`
+/// (`~/.friday/agent-run-securestore`) so the operator seed NEVER lands in the store the Hub
+/// enrolls into. The inverted KAT asserts `signer::default_store_dir() !=
+/// friday_hub::key_source::default_store_dir()`.
+const SIGNER_STORE_DIR_REL: &str = ".friday/operator-signer-securestore";
 
-/// Domain-separation tag for the `FileSecureStore` KEK derivation. MUST be byte-identical
-/// to `friday_hub::key_source`'s `FILE_STORE_KEK_PURPOSE` (private there) so the derived
-/// KEK opens the SAME store. This one IS pinned: a round-trip KAT
-/// (`kek_derivation_matches_the_ws_server`) seals under the server's KEK and opens under
-/// ours (Kek has no `Eq`), so a divergence is caught at test time. (And even unpinned it
-/// would be fail-closed: a wrong tag ⇒ wrong KEK ⇒ `None` ⇒ `SeedUnprovisioned`.)
-const FILE_STORE_KEK_PURPOSE: &[u8] = b"friday.rust.securestore.file.kek.v1";
+/// Domain-separation tag for the signer's seed-store KEK derivation. DELIBERATELY
+/// BYTE-DIFFERENT from `friday_hub::key_source`'s `FILE_STORE_KEK_PURPOSE`
+/// (`b"friday.rust.securestore.file.kek.v1"`), so the Hub's hardcoded `derive_file_store_kek`
+/// CANNOT produce this KEK even if it were somehow fed the signer master. Pinned by the
+/// inverted KAT (`hub_kek_cannot_open_the_operator_signer_seed`): a seed sealed under the
+/// signer's KEK is UNOPENABLE under the Hub's KEK derivation (different tag AND, in practice,
+/// a different master).
+const SIGNER_SEED_KEK_PURPOSE: &[u8] = b"friday.operator.signer.seed.kek.v1"; // pragma: allowlist secret
 
 /// A fail-closed error. **Carries no key bytes, no master key, no seed, no plaintext** —
 /// only a structural category — so it is always safe to surface/log. The seed/master are
@@ -98,9 +143,12 @@ pub enum SignerError {
     /// `~/.friday/...` locations cannot be resolved.
     #[error("HOME is not set; pass --store-dir and a master key explicitly")]
     HomeUnset,
-    /// Neither `FRIDAY_MASTER_KEY` nor `~/.friday/master.key` is present. FAIL CLOSED — the
-    /// helper NEVER auto-generates a master key (it must match the host's existing one).
-    #[error("no master key: set FRIDAY_MASTER_KEY (hex) or provision ~/.friday/master.key")]
+    /// Neither `FRIDAY_OPERATOR_SIGNER_MASTER` nor `~/.friday/operator-signer.key` is
+    /// present. FAIL CLOSED — the helper NEVER auto-generates a master key (the operator must
+    /// provision their isolated signer master out of band).
+    #[error(
+        "no signer master: set FRIDAY_OPERATOR_SIGNER_MASTER (hex) or provision ~/.friday/operator-signer.key"
+    )]
     MasterKeyMissing,
     /// The master key source was present but not valid 32-byte hex.
     #[error("master key is malformed (expected 64 hex chars = 32 bytes)")]
@@ -155,21 +203,31 @@ fn home_relative(rel: &str) -> Result<std::path::PathBuf, SignerError> {
     Ok(std::path::Path::new(&home).join(rel))
 }
 
-/// The default `FileSecureStore` directory (`~/.friday/agent-run-securestore`), matching
-/// the WS server's `default_store_dir`.
+/// The signer's `FileSecureStore` directory (`~/.friday/operator-signer-securestore`),
+/// DELIBERATELY DISTINCT from the Hub's `default_store_dir`
+/// (`~/.friday/agent-run-securestore`) so the operator seed is never co-resident with the
+/// Hub's store.
 pub fn default_store_dir() -> Result<std::path::PathBuf, SignerError> {
-    home_relative(DEFAULT_STORE_DIR_REL)
+    home_relative(SIGNER_STORE_DIR_REL)
 }
 
-/// Read the 32-byte master key, FAIL-CLOSED, mirroring the WS server's
-/// `friday_hub::key_source::read_master_key` SOURCE order MINUS auto-generation:
-///   1. `FRIDAY_MASTER_KEY` env (hex), if non-empty.
-///   2. `~/.friday/master.key` (bytes -> UTF-8 -> trim -> hex-decode).
+/// The `$HOME`-relative path of the operator-signer master key file. Exposed (test-visible)
+/// only to assert it differs from the Hub's master path; the file CONTENT is never read by
+/// the Hub.
+pub fn signer_master_file() -> Result<std::path::PathBuf, SignerError> {
+    home_relative(SIGNER_MASTER_FILE_REL)
+}
+
+/// Read the 32-byte **operator-signer** master key, FAIL-CLOSED. This is the OPERATOR-ONLY
+/// secret that derives the seed-store KEK; it is DISTINCT from the Hub's master and the Hub
+/// never reads either of these sources:
+///   1. `FRIDAY_OPERATOR_SIGNER_MASTER` env (hex), if non-empty.
+///   2. `~/.friday/operator-signer.key` (bytes -> UTF-8 -> trim -> hex-decode).
 ///   3. Neither present -> [`SignerError::MasterKeyMissing`]. NEVER creates the file.
 ///
 /// The returned key is wrapped so it is wiped on drop; it never appears in any error.
 fn read_master_key() -> Result<MasterKey, SignerError> {
-    if let Some(env_val) = std::env::var_os(MASTER_KEY_ENV) {
+    if let Some(env_val) = std::env::var_os(SIGNER_MASTER_ENV) {
         let env_str = env_val.to_string_lossy();
         if !env_str.is_empty() {
             return decode_master_hex(&env_str)
@@ -177,7 +235,7 @@ fn read_master_key() -> Result<MasterKey, SignerError> {
                 .ok_or(SignerError::MasterKeyMalformed);
         }
     }
-    let path = home_relative(MASTER_KEY_FILE_REL)?;
+    let path = home_relative(SIGNER_MASTER_FILE_REL)?;
     match std::fs::read(&path) {
         Ok(bytes) => {
             let text = String::from_utf8_lossy(&bytes);
@@ -202,15 +260,17 @@ impl Drop for MasterKey {
     }
 }
 
-/// Derive the `FileSecureStore` KEK from the master key:
-/// `Kek::from_bytes(sha256(FILE_STORE_KEK_PURPOSE || master))`.
+/// Derive the SIGNER's seed-store KEK from the **signer master key**:
+/// `Kek::from_bytes(sha256(SIGNER_SEED_KEK_PURPOSE || master))`.
 ///
-/// Byte-identical to `friday_hub::key_source::derive_file_store_kek` (pinned by the
-/// dev-dep round-trip KAT in this crate's tests), so a store the WS server opens and a
-/// store this helper opens use the SAME KEK and thus see the SAME entries.
-fn derive_file_store_kek(master: &[u8; MASTER_KEY_LEN]) -> Kek {
+/// DELIBERATELY NOT byte-identical to `friday_hub::key_source::derive_file_store_kek`: the
+/// purpose tag differs ([`SIGNER_SEED_KEK_PURPOSE`] vs the Hub's `FILE_STORE_KEK_PURPOSE`)
+/// AND the master differs (the operator-only [`SIGNER_MASTER_ENV`]). The inverted KAT
+/// `hub_kek_cannot_open_the_operator_signer_seed` proves the Hub's derivation cannot open a
+/// store sealed under this KEK — true isolation even on one box.
+fn derive_signer_seed_kek(master: &[u8; MASTER_KEY_LEN]) -> Kek {
     let mut hasher = Sha256::new();
-    hasher.update(FILE_STORE_KEK_PURPOSE);
+    hasher.update(SIGNER_SEED_KEK_PURPOSE);
     hasher.update(master);
     let digest = hasher.finalize();
     let mut bytes = [0u8; 32];
@@ -218,10 +278,11 @@ fn derive_file_store_kek(master: &[u8; MASTER_KEY_LEN]) -> Kek {
     Kek::from_bytes(bytes)
 }
 
-/// Load the operator's PRIVATE [`OperatorSigningKey`] from the KEK-wrapped SecureStore at
-/// `store_dir`, using the host master key to derive the KEK. The 32 raw seed bytes are
-/// read from [`OPERATOR_SIGNING_SEED_SECURE_STORE_ID`], built into a signing key, then the
-/// transient seed buffer is zeroized.
+/// Load the operator's PRIVATE [`OperatorSigningKey`] from the ISOLATED KEK-wrapped
+/// SecureStore at `store_dir`, using the OPERATOR-ONLY signer master key (the one the Hub
+/// never reads) to derive the seed KEK. The 32 raw seed bytes are read from
+/// [`OPERATOR_SIGNING_SEED_SECURE_STORE_ID`], built into a signing key, then the transient
+/// seed buffer is zeroized.
 ///
 /// Fail-closed: a missing master key, an unreadable store, an absent/unreadable seed entry,
 /// or a wrong-length seed each return an `Err` and the helper signs nothing. The seed bytes
@@ -230,7 +291,7 @@ pub fn load_signing_key_from_store(
     store_dir: &std::path::Path,
 ) -> Result<OperatorSigningKey, SignerError> {
     let master = read_master_key()?;
-    let kek = derive_file_store_kek(&master.0);
+    let kek = derive_signer_seed_kek(&master.0);
     drop(master); // wipe the master key as soon as the KEK is derived.
 
     let store = FileSecureStore::open(store_dir, kek).map_err(|_| SignerError::StoreUnavailable)?;
@@ -276,10 +337,10 @@ pub fn sign_pending_from_store(
 }
 
 /// Provision (enroll) a 32-byte operator signing seed into the SecureStore at `store_dir`,
-/// under the host master-key-derived KEK. OPERATOR-side only — used so the operator can put
-/// their seed into the same KEK-wrapped store the helper later reads. The seed bytes are
-/// wiped from the caller-supplied slice's responsibility (this fn does not retain them);
-/// the value the SecureStore seals is the secret.
+/// under the ISOLATED **signer-master-derived KEK** (a KEK the Hub cannot derive). OPERATOR-
+/// side only — the operator puts their seed into the isolated KEK-wrapped store the helper
+/// later reads. The seed bytes are wiped from the caller-supplied slice's responsibility
+/// (this fn does not retain them); the value the SecureStore seals is the secret.
 ///
 /// FAIL-CLOSED on a wrong-length seed (must be exactly [`SIGNING_SEED_LEN`]) so a truncated
 /// seed is never enrolled. Returns `Ok(())` only after the entry is durably written.
@@ -291,7 +352,7 @@ pub fn provision_signing_seed_into_store(
         return Err(SignerError::SeedMalformed);
     }
     let master = read_master_key()?;
-    let kek = derive_file_store_kek(&master.0);
+    let kek = derive_signer_seed_kek(&master.0);
     drop(master);
     let mut store =
         FileSecureStore::open(store_dir, kek).map_err(|_| SignerError::StoreUnavailable)?;
@@ -341,7 +402,24 @@ mod tests {
         }
     }
 
+    /// The operator-signer master used in the KATs (all 0x42). This is the SIGNER's master;
+    /// it is what `read_master_key()` reads from `SIGNER_MASTER_ENV` in these tests.
     const KAT_MASTER: [u8; MASTER_KEY_LEN] = [0x42u8; MASTER_KEY_LEN];
+
+    /// Seal the seed into a store at `dir` under the SIGNER's real seed-store KEK derivation
+    /// (the SAME `derive_signer_seed_kek` the helper uses). This replaces the previous tests'
+    /// habit of sealing under `friday_hub::key_source::derive_file_store_kek` — which is now
+    /// exactly the derivation the seed must be UNopenable under.
+    fn seal_seed_under_signer_kek(
+        dir: &std::path::Path,
+        master: &[u8; MASTER_KEY_LEN],
+        seed: &[u8],
+    ) {
+        let kek = derive_signer_seed_kek(master);
+        let mut s = FileSecureStore::open(dir, kek).unwrap();
+        s.try_put(OPERATOR_SIGNING_SEED_SECURE_STORE_ID, seed)
+            .unwrap();
+    }
 
     fn sample_request(action_digest: &str) -> PendingRequest {
         PendingRequest {
@@ -356,53 +434,112 @@ mod tests {
         }
     }
 
-    /// LOAD-BEARING KAT: this crate's KEK derivation MUST be byte-identical to the WS
-    /// server's (`friday_hub::key_source::derive_file_store_kek`). `Kek` has no `Eq`, so
-    /// we prove equality by sealing under the SERVER's KEK and opening under OURS (and
-    /// vice-versa) through a real `FileSecureStore`. A divergence here would mean the
-    /// helper reads a DIFFERENT store than the server enrolled into — a silent
-    /// fail-closed at the D3 proof.
+    /// INVERTED LOAD-BEARING KAT (the isolation smoking gun): the Hub's KEK derivation
+    /// (`friday_hub::key_source::derive_file_store_kek`) MUST NOT be able to open a store the
+    /// signer sealed the operator seed into. This is the EXACT OPPOSITE of the old
+    /// `kek_derivation_matches_the_ws_server`, which proved the two KEKs were the same (the
+    /// INV-6-weakening co-residency the audit flagged).
+    ///
+    /// We isolate the right variable: we give the Hub derivation BOTH masters it could
+    /// plausibly hold — its OWN master AND (worst case) the signer master — and prove that in
+    /// EITHER case its `derive_file_store_kek` (which hardcodes the Hub's `FILE_STORE_KEK_PURPOSE`)
+    /// cannot unwrap the seed. The seed is sealed under the signer's real
+    /// `derive_signer_seed_kek` (distinct purpose tag + operator-only master).
+    ///
+    /// `FileSecureStore::open` with a wrong KEK SUCCEEDS to open the dir, but the per-entry
+    /// DataKey unwrap then fails the AEAD. We assert BOTH faces of that failure:
+    ///   * the runtime-relevant infallible `SecureStore::get` (the method the Hub actually
+    ///     calls through the trait) FAIL-CLOSES to `None` — the Hub sees NO seed; and
+    ///   * the explicit `try_get` surfaces `Err(Crypto(Open))` — a cryptographic REFUSAL, not
+    ///     a merely-absent entry — so the failure is unambiguously "could not decrypt", which
+    ///     is the whole isolation claim.
     #[test]
-    fn kek_derivation_matches_the_ws_server() {
-        let td = TempDir::new("kek-parity");
+    fn hub_kek_cannot_open_the_operator_signer_seed() {
+        use friday_crypto::{CryptoError, FileStoreError};
+
+        let td = TempDir::new("isolation");
         let dir = td.child("store");
-        // Seal under the HUB/server's KEK derivation.
-        {
-            let server_kek = friday_hub::key_source::derive_file_store_kek(&KAT_MASTER);
-            let mut s = FileSecureStore::open(&dir, server_kek).unwrap();
-            s.try_put(
-                OPERATOR_SIGNING_SEED_SECURE_STORE_ID,
-                &[0x07u8; SIGNING_SEED_LEN],
-            )
-            .unwrap();
-        }
-        // Open under OUR KEK derivation — must read the same bytes.
-        let our_kek = derive_file_store_kek(&KAT_MASTER);
-        let s = FileSecureStore::open(&dir, our_kek).unwrap();
+        // The operator seals the seed under the SIGNER's KEK (signer master + distinct tag).
+        let signer_master = KAT_MASTER;
+        seal_seed_under_signer_kek(&dir, &signer_master, &[0x07u8; SIGNING_SEED_LEN]);
+
+        // (1) The Hub holds its OWN master (which is a DIFFERENT secret from the signer's).
+        //     Even if that master happened to equal the signer's (it does NOT in prod), the
+        //     Hub's derivation uses a DIFFERENT purpose tag → a different KEK → cannot open.
+        let hub_master = [0xABu8; MASTER_KEY_LEN];
+        let hub_kek_own = friday_hub::key_source::derive_file_store_kek(&hub_master);
+        let s_own = FileSecureStore::open(&dir, hub_kek_own).unwrap();
+        // Runtime path: the infallible trait read fail-closes to None (the Hub sees no seed).
         assert_eq!(
-            s.try_get(OPERATOR_SIGNING_SEED_SECURE_STORE_ID)
+            SecureStore::get(&s_own, OPERATOR_SIGNING_SEED_SECURE_STORE_ID),
+            None,
+            "the Hub's KEK (its own master) MUST NOT open the operator-signer seed store"
+        );
+        // Explicit path: the failure is a cryptographic OPEN failure (could not decrypt),
+        // proving the Hub's KEK genuinely cannot unwrap the seed — not that it is absent.
+        assert!(
+            matches!(
+                s_own.try_get(OPERATOR_SIGNING_SEED_SECURE_STORE_ID),
+                Err(FileStoreError::Crypto(CryptoError::Open))
+            ),
+            "the Hub's KEK must FAIL the AEAD unwrap (Crypto(Open)), not find an absent entry"
+        );
+
+        // (2) WORST CASE — even if the Hub were somehow fed the SIGNER's master, its hardcoded
+        //     `FILE_STORE_KEK_PURPOSE` (!= SIGNER_SEED_KEK_PURPOSE) yields a different KEK that
+        //     STILL cannot open the seed. This isolates the PURPOSE-TAG separation specifically
+        //     (so the test cannot pass merely because the masters differ — that is already
+        //     covered by `wrong_master_key_fails_closed`).
+        let hub_kek_signer_master = friday_hub::key_source::derive_file_store_kek(&signer_master);
+        let s_worst = FileSecureStore::open(&dir, hub_kek_signer_master).unwrap();
+        assert_eq!(
+            SecureStore::get(&s_worst, OPERATOR_SIGNING_SEED_SECURE_STORE_ID),
+            None,
+            "even fed the SIGNER master, the Hub's distinct-purpose-tag KEK MUST NOT open the seed"
+        );
+        assert!(
+            matches!(
+                s_worst.try_get(OPERATOR_SIGNING_SEED_SECURE_STORE_ID),
+                Err(FileStoreError::Crypto(CryptoError::Open))
+            ),
+            "fed the SIGNER master, the Hub's distinct-tag KEK must still FAIL the AEAD unwrap"
+        );
+
+        // (3) Positive control: the SIGNER's own KEK (same master + tag) DOES open it, proving
+        //     the seed really is there and (1)/(2) failed for the RIGHT reason (wrong KEK),
+        //     not because the store was empty.
+        let signer_kek = derive_signer_seed_kek(&signer_master);
+        let s_ok = FileSecureStore::open(&dir, signer_kek).unwrap();
+        assert_eq!(
+            s_ok.try_get(OPERATOR_SIGNING_SEED_SECURE_STORE_ID)
                 .unwrap()
                 .as_deref(),
             Some(&[0x07u8; SIGNING_SEED_LEN][..]),
-            "the desktop signer's KEK must open a store the WS server sealed — a mismatch \
-             means the helper reads a different store than the server enrolled into"
+            "the signer's own KEK must open the seed (control: the seed is present)"
         );
-        // And the symmetric direction: our seal opens under the server's KEK.
-        let our_kek2 = derive_file_store_kek(&KAT_MASTER);
-        let mut s2 = FileSecureStore::open(&dir, our_kek2).unwrap();
-        s2.try_put(
-            OPERATOR_SIGNING_SEED_SECURE_STORE_ID,
-            &[0x09u8; SIGNING_SEED_LEN],
-        )
-        .unwrap();
-        let server_kek2 = friday_hub::key_source::derive_file_store_kek(&KAT_MASTER);
-        let s3 = FileSecureStore::open(&dir, server_kek2).unwrap();
-        assert_eq!(
-            s3.try_get(OPERATOR_SIGNING_SEED_SECURE_STORE_ID)
-                .unwrap()
-                .as_deref(),
-            Some(&[0x09u8; SIGNING_SEED_LEN][..]),
-        );
+    }
+
+    /// STRUCTURAL ISOLATION: the signer's default store directory MUST differ from the Hub's,
+    /// so the operator seed is never co-resident with the Hub's enrolled store. (Uses the Hub's
+    /// PUBLIC `default_store_dir`; `DEFAULT_STORE_DIR_REL` is private there.)
+    #[test]
+    fn signer_store_dir_differs_from_hub_store_dir() {
+        // Both resolve `$HOME`-relative; run under a fixed HOME so the assertion is about the
+        // RELATIVE component, not a transient env.
+        with_home_env("/tmp/friday-isolation-home", || {
+            let signer = default_store_dir().unwrap();
+            let hub = friday_hub::key_source::default_store_dir().unwrap();
+            assert_ne!(
+                signer, hub,
+                "the operator-signer store dir must NOT equal the Hub's default store dir"
+            );
+            // And the master sources differ too.
+            let signer_master_path = signer_master_file().unwrap();
+            assert!(
+                signer_master_path.ends_with(".friday/operator-signer.key"),
+                "the signer master file must be the isolated operator-signer.key, not the Hub's master.key"
+            );
+        });
     }
 
     /// The seed id MUST be distinct from every other SecureStore id the system uses, so
@@ -434,15 +571,10 @@ mod tests {
         let vk = operator.verifying_key();
         let seed = operator.to_seed_bytes();
 
-        // Provision under a known master (KAT_MASTER) by sealing with the server's KEK.
-        {
-            let kek = derive_file_store_kek(&KAT_MASTER);
-            let mut s = FileSecureStore::open(&dir, kek).unwrap();
-            s.try_put(OPERATOR_SIGNING_SEED_SECURE_STORE_ID, &seed)
-                .unwrap();
-        }
+        // Provision under a known signer master (KAT_MASTER) by sealing with the SIGNER's KEK.
+        seal_seed_under_signer_kek(&dir, &KAT_MASTER, &seed);
 
-        // The helper loads the seed from the store (master via env) and signs.
+        // The helper loads the seed from the store (signer master via env) and signs.
         let digest = "b".repeat(64);
         let req = sample_request(&digest);
         let signed = with_master_env(&KAT_MASTER, || sign_pending_from_store(&dir, &req)).unwrap();
@@ -472,9 +604,9 @@ mod tests {
     fn unprovisioned_seed_fails_closed() {
         let td = TempDir::new("unprov");
         let dir = td.child("store");
-        // Create the store dir (with the right KEK) but provision NO seed.
+        // Create the store dir (with the right signer KEK) but provision NO seed.
         {
-            let kek = derive_file_store_kek(&KAT_MASTER);
+            let kek = derive_signer_seed_kek(&KAT_MASTER);
             let _ = FileSecureStore::open(&dir, kek).unwrap();
         }
         let req = sample_request(&"c".repeat(64));
@@ -487,14 +619,9 @@ mod tests {
     fn malformed_seed_fails_closed() {
         let td = TempDir::new("malformed");
         let dir = td.child("store");
-        {
-            let kek = derive_file_store_kek(&KAT_MASTER);
-            let mut s = FileSecureStore::open(&dir, kek).unwrap();
-            s.try_put(OPERATOR_SIGNING_SEED_SECURE_STORE_ID, &[0x01u8; 16]) // too short
-                .unwrap();
-        }
-        // NB: `OperatorSigningKey` has no Debug (key bytes are never logged), so the Ok
-        // arm cannot be unwrapped/printed — `matches!` the Err arm directly.
+        seal_seed_under_signer_kek(&dir, &KAT_MASTER, &[0x01u8; 16]); // too short
+                                                                      // NB: `OperatorSigningKey` has no Debug (key bytes are never logged), so the Ok
+                                                                      // arm cannot be unwrapped/printed — `matches!` the Err arm directly.
         let result = with_master_env(&KAT_MASTER, || load_signing_key_from_store(&dir));
         assert!(matches!(result, Err(SignerError::SeedMalformed)));
     }
@@ -506,18 +633,10 @@ mod tests {
     fn wrong_master_key_fails_closed() {
         let td = TempDir::new("wrongkek");
         let dir = td.child("store");
-        // Provision under master A.
+        // Provision under signer master A.
         let master_a = [0x11u8; MASTER_KEY_LEN];
-        {
-            let kek = derive_file_store_kek(&master_a);
-            let mut s = FileSecureStore::open(&dir, kek).unwrap();
-            s.try_put(
-                OPERATOR_SIGNING_SEED_SECURE_STORE_ID,
-                &[0x05u8; SIGNING_SEED_LEN],
-            )
-            .unwrap();
-        }
-        // Try to load under master B (different KEK) → fail closed.
+        seal_seed_under_signer_kek(&dir, &master_a, &[0x05u8; SIGNING_SEED_LEN]);
+        // Try to load under signer master B (different KEK) → fail closed.
         let master_b = [0x22u8; MASTER_KEY_LEN];
         let result = with_master_env(&master_b, || load_signing_key_from_store(&dir));
         assert!(matches!(result, Err(SignerError::SeedUnprovisioned)));
@@ -546,24 +665,50 @@ mod tests {
         friday_crypto::verify_ed25519_approval_hex(bytes, &vk.to_bytes(), sig_hex)
     }
 
-    /// Run `f` with `FRIDAY_MASTER_KEY` set to the hex of `master`, restoring the prior
-    /// env afterward. These tests mutate process-global env, so they are serialized by
-    /// running them all through this one helper under a single mutex.
-    fn with_master_env<T>(master: &[u8; MASTER_KEY_LEN], f: impl FnOnce() -> T) -> T {
+    /// A single process-global env lock shared by EVERY env-mutating test helper in this
+    /// module (`with_master_env` + `with_home_env`), so two of them can never race on env
+    /// (which is UB) regardless of which threads cargo runs them on.
+    fn env_lock() -> std::sync::MutexGuard<'static, ()> {
         use std::sync::Mutex;
         static ENV_LOCK: Mutex<()> = Mutex::new(());
-        let _guard = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
-        let saved = std::env::var_os(MASTER_KEY_ENV);
+        ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner())
+    }
+
+    /// Run `f` with the SIGNER master env (`FRIDAY_OPERATOR_SIGNER_MASTER`) set to the hex of
+    /// `master`, restoring the prior env afterward. (The helper reads the SIGNER master, NOT
+    /// the Hub's `FRIDAY_MASTER_KEY`.) Serialized under the shared [`env_lock`].
+    fn with_master_env<T>(master: &[u8; MASTER_KEY_LEN], f: impl FnOnce() -> T) -> T {
+        let _guard = env_lock();
+        let saved = std::env::var_os(SIGNER_MASTER_ENV);
         let hex: String = master.iter().map(|b| format!("{b:02x}")).collect();
-        // SAFETY: serialized by ENV_LOCK; restored before the guard drops.
+        // SAFETY: serialized by the shared env lock; restored before the guard drops.
         unsafe {
-            std::env::set_var(MASTER_KEY_ENV, &hex);
+            std::env::set_var(SIGNER_MASTER_ENV, &hex);
         }
         let out = f();
         unsafe {
             match saved {
-                Some(v) => std::env::set_var(MASTER_KEY_ENV, v),
-                None => std::env::remove_var(MASTER_KEY_ENV),
+                Some(v) => std::env::set_var(SIGNER_MASTER_ENV, v),
+                None => std::env::remove_var(SIGNER_MASTER_ENV),
+            }
+        }
+        out
+    }
+
+    /// Run `f` with `HOME` set to `home`, restoring the prior value afterward. Serialized
+    /// under the shared [`env_lock`] (HOME is process-global like the master env).
+    fn with_home_env<T>(home: &str, f: impl FnOnce() -> T) -> T {
+        let _guard = env_lock();
+        let saved = std::env::var_os("HOME");
+        // SAFETY: serialized by the shared env lock; restored before the guard drops.
+        unsafe {
+            std::env::set_var("HOME", home);
+        }
+        let out = f();
+        unsafe {
+            match saved {
+                Some(v) => std::env::set_var("HOME", v),
+                None => std::env::remove_var("HOME"),
             }
         }
         out

--- a/rust-core/crates/friday-operator-signer/src/main.rs
+++ b/rust-core/crates/friday-operator-signer/src/main.rs
@@ -7,8 +7,9 @@
 //! The OFFLINE OPERATOR signer. Like the S6c CLI (`friday-operator-approve`) it produces an
 //! Ed25519-signed `CanonicalApproval` over the Hub-computed canonical action digest — EXACTLY
 //! what `friday_hub::resume::resume_with_approval` verifies under `OperatorVerifyingKey`. The
-//! ONE difference: the operator's PRIVATE signing seed is read from the **KEK-wrapped
-//! `FileSecureStore` the WS server already uses** (KEK derived from the host master key),
+//! ONE difference: the operator's PRIVATE signing seed is read from a **KEK-wrapped
+//! `FileSecureStore` the Hub CANNOT open** — an ISOLATED store, in a SEPARATE directory,
+//! sealed under a KEK derived from a SEPARATE operator-only master key the Hub never reads —
 //! instead of a plaintext hex file. Ed25519-native, so the Hub verify side needs no scheme
 //! change.
 //!
@@ -24,32 +25,41 @@
 //! - INV-1 (no self-mint): the HUB crate holds ONLY `OperatorVerifyingKey` and (by the
 //!   structural `hub_crate_never_references_a_signing_key` test) has NO code that turns the
 //!   stored seed bytes into a signer. This helper lives in a SEPARATE crate
-//!   (`friday-operator-signer`) on the operator side; it adds NO signing path to the hub. The
-//!   seed living in the KEK-wrapped SecureStore is safe FOR THAT REASON.
-//! - INV-6 (real operator key, off-box): the SIGNING seed lives with the operator, in the
-//!   operator's SecureStore on the operator's machine; this helper is the operator's signer
-//!   and is never run by the hub/coordinator.
+//!   (`friday-operator-signer`) on the operator side; it adds NO signing path to the hub.
+//! - INV-6 (real operator key, ISOLATED): the SIGNING seed lives with the operator in an
+//!   ISOLATED KEK-wrapped SecureStore the HUB's existing derivation CANNOT OPEN — a separate
+//!   store directory, sealed under a KEK with a DISTINCT purpose tag. Unconditionally (any
+//!   master values), the Hub's own `derive_file_store_kek` cannot unwrap the seed; the
+//!   inverted KAT `hub_kek_cannot_open_the_operator_signer_seed` proves exactly that (even
+//!   fed the signer master). The KEK is also derived from a separate operator-only master
+//!   (`FRIDAY_OPERATOR_SIGNER_MASTER` / `~/.friday/operator-signer.key`) the Hub never reads,
+//!   so by default (distinct master VALUE) the seed KEK stays hub-underivable even against
+//!   added hub code — a conditional, not-KAT-covered property that degrades only if the
+//!   operator deliberately reuses the same master bytes. Either way the seed is NO LONGER
+//!   co-resident with the Hub's store (the audit's INV-6-weakening co-residency is removed).
 //!
 //! ## Subcommands
 //!
 //! ```text
 //! friday-operator-sign provision --seed-hex <64-hex> [--store-dir <dir>]
-//!     Enroll the operator's 32-byte Ed25519 signing seed (hex) into the KEK-wrapped
-//!     SecureStore (KEK derived from the host master key). The seed is the SECRET; it is
-//!     never printed. Run ONCE on the operator's machine. (Prefer feeding the seed via
-//!     --seed-stdin so it never appears in argv / shell history.)
+//!     Enroll the operator's 32-byte Ed25519 signing seed (hex) into the ISOLATED
+//!     KEK-wrapped SecureStore (KEK derived from the operator-only signer master). The seed
+//!     is the SECRET; it is never printed. Run ONCE on the operator's machine. (Prefer
+//!     feeding the seed via --seed-stdin so it never appears in argv / shell history.)
 //!
 //! friday-operator-sign sign --request <pending.json> [--store-dir <dir>]
 //!     Read a pending request (the fields the Hub persists when a mutating action Pauses:
 //!     approval_id nonce + the Hub-computed action_digest + expiry + decision), load the
-//!     PRIVATE seed from the SecureStore, and emit an Ed25519-signed CanonicalApproval (JSON)
-//!     to stdout. The seed never appears in the output; the SignedApproval is what the Hub's
-//!     resume ingestion verifies.
+//!     PRIVATE seed from the ISOLATED SecureStore, and emit an Ed25519-signed
+//!     CanonicalApproval (JSON) to stdout. The seed never appears in the output; the
+//!     SignedApproval is what the Hub's resume ingestion verifies.
 //! ```
 //!
-//! The master key is sourced exactly as the WS server sources it: `FRIDAY_MASTER_KEY` (hex)
-//! or `~/.friday/master.key`. NEVER auto-generated. The store dir defaults to
-//! `~/.friday/agent-run-securestore` (the server's default).
+//! The signer master key is an OPERATOR-ONLY secret, DISTINCT from the Hub's: it is sourced
+//! from `FRIDAY_OPERATOR_SIGNER_MASTER` (hex) or `~/.friday/operator-signer.key`. NEVER
+//! auto-generated, and NEVER the Hub's `FRIDAY_MASTER_KEY` / `~/.friday/master.key`. The
+//! store dir defaults to `~/.friday/operator-signer-securestore` (NOT the Hub's
+//! `~/.friday/agent-run-securestore`), so the seed is never co-resident with the Hub's store.
 
 use std::process::ExitCode;
 
@@ -66,16 +76,18 @@ USAGE:
     friday-operator-sign provision --seed-stdin        [--store-dir <dir>]
     friday-operator-sign sign --request <pending-request.json> [--store-dir <dir>]
 
-provision enrolls the operator's 32-byte Ed25519 signing seed into the KEK-wrapped
-SecureStore (KEK derived from the host master key). The seed is the SECRET and is never
-printed. Prefer --seed-stdin so the seed never appears in argv / shell history.
+provision enrolls the operator's 32-byte Ed25519 signing seed into the ISOLATED KEK-wrapped
+SecureStore (KEK derived from the operator-only signer master). The seed is the SECRET and
+is never printed. Prefer --seed-stdin so the seed never appears in argv / shell history.
 
-sign reads a pending request JSON, loads the PRIVATE seed from the SecureStore, and emits
-an Ed25519-signed CanonicalApproval (JSON) to stdout for the Hub's resume ingestion. The
-private seed never appears in the output.
+sign reads a pending request JSON, loads the PRIVATE seed from the ISOLATED SecureStore, and
+emits an Ed25519-signed CanonicalApproval (JSON) to stdout for the Hub's resume ingestion.
+The private seed never appears in the output.
 
-The master key is sourced from FRIDAY_MASTER_KEY (hex) or ~/.friday/master.key (never
-auto-generated). --store-dir defaults to ~/.friday/agent-run-securestore.
+The signer master key is sourced from FRIDAY_OPERATOR_SIGNER_MASTER (hex) or
+~/.friday/operator-signer.key (never auto-generated) — an OPERATOR-ONLY secret, DISTINCT
+from the Hub's master so the Hub cannot derive the seed KEK. --store-dir defaults to
+~/.friday/operator-signer-securestore (NOT the Hub's store).
 
 DARK / PROOF-ONLY: this helper is NOT wired into prod, registers no route, and is NEVER
 invoked automatically by the hub or any coordinator process. The operator runs it by hand.";
@@ -140,7 +152,7 @@ fn cmd_provision(args: &[String]) -> Result<(), String> {
 
     // The seed bytes never appear here — only a non-secret confirmation to stderr.
     eprintln!(
-        "operator signing seed provisioned into the SecureStore at {} (KEK-wrapped under the host master key).",
+        "operator signing seed provisioned into the ISOLATED SecureStore at {} (KEK-wrapped under the operator-only signer master; the Hub cannot derive this KEK).",
         store_dir.display()
     );
     Ok(())

--- a/rust-core/crates/friday-operator-signer/src/main.rs
+++ b/rust-core/crates/friday-operator-signer/src/main.rs
@@ -1,0 +1,237 @@
+//! `friday-operator-sign` — the DESKTOP operator-signing helper (GATE-AGENT-REPLACE D3
+//! key-custody bridge; the operator-chosen desktop-helper option of the A2 key-custody
+//! decision). This REPLACES the file-key dev path for real operator custody.
+//!
+//! ## What it is
+//!
+//! The OFFLINE OPERATOR signer. Like the S6c CLI (`friday-operator-approve`) it produces an
+//! Ed25519-signed `CanonicalApproval` over the Hub-computed canonical action digest — EXACTLY
+//! what `friday_hub::resume::resume_with_approval` verifies under `OperatorVerifyingKey`. The
+//! ONE difference: the operator's PRIVATE signing seed is read from the **KEK-wrapped
+//! `FileSecureStore` the WS server already uses** (KEK derived from the host master key),
+//! instead of a plaintext hex file. Ed25519-native, so the Hub verify side needs no scheme
+//! change.
+//!
+//! ## DARK — NOT wired into prod, NEVER auto-run
+//!
+//! This is a standalone helper. It registers NO production route, has NO scheduler hook, and
+//! is NEVER invoked automatically by the hub or any coordinator process. It runs ON THE
+//! OPERATOR'S MACHINE, ATTENDED — the operator runs it by hand to approve ONE specific paused
+//! mutation for the D3 live proof. PROOF-ONLY; NOT a v1 GO.
+//!
+//! ## Key-custody invariants this helper upholds
+//!
+//! - INV-1 (no self-mint): the HUB crate holds ONLY `OperatorVerifyingKey` and (by the
+//!   structural `hub_crate_never_references_a_signing_key` test) has NO code that turns the
+//!   stored seed bytes into a signer. This helper lives in a SEPARATE crate
+//!   (`friday-operator-signer`) on the operator side; it adds NO signing path to the hub. The
+//!   seed living in the KEK-wrapped SecureStore is safe FOR THAT REASON.
+//! - INV-6 (real operator key, off-box): the SIGNING seed lives with the operator, in the
+//!   operator's SecureStore on the operator's machine; this helper is the operator's signer
+//!   and is never run by the hub/coordinator.
+//!
+//! ## Subcommands
+//!
+//! ```text
+//! friday-operator-sign provision --seed-hex <64-hex> [--store-dir <dir>]
+//!     Enroll the operator's 32-byte Ed25519 signing seed (hex) into the KEK-wrapped
+//!     SecureStore (KEK derived from the host master key). The seed is the SECRET; it is
+//!     never printed. Run ONCE on the operator's machine. (Prefer feeding the seed via
+//!     --seed-stdin so it never appears in argv / shell history.)
+//!
+//! friday-operator-sign sign --request <pending.json> [--store-dir <dir>]
+//!     Read a pending request (the fields the Hub persists when a mutating action Pauses:
+//!     approval_id nonce + the Hub-computed action_digest + expiry + decision), load the
+//!     PRIVATE seed from the SecureStore, and emit an Ed25519-signed CanonicalApproval (JSON)
+//!     to stdout. The seed never appears in the output; the SignedApproval is what the Hub's
+//!     resume ingestion verifies.
+//! ```
+//!
+//! The master key is sourced exactly as the WS server sources it: `FRIDAY_MASTER_KEY` (hex)
+//! or `~/.friday/master.key`. NEVER auto-generated. The store dir defaults to
+//! `~/.friday/agent-run-securestore` (the server's default).
+
+use std::process::ExitCode;
+
+use friday_operator_cli::PendingRequest;
+use friday_operator_signer::{
+    default_store_dir, provision_signing_seed_into_store, sign_pending_from_store, SIGNING_SEED_LEN,
+};
+
+const USAGE: &str = "\
+friday-operator-sign — desktop operator-signing helper (GATE-AGENT-REPLACE D3 bridge)
+
+USAGE:
+    friday-operator-sign provision --seed-hex <64-hex> [--store-dir <dir>]
+    friday-operator-sign provision --seed-stdin        [--store-dir <dir>]
+    friday-operator-sign sign --request <pending-request.json> [--store-dir <dir>]
+
+provision enrolls the operator's 32-byte Ed25519 signing seed into the KEK-wrapped
+SecureStore (KEK derived from the host master key). The seed is the SECRET and is never
+printed. Prefer --seed-stdin so the seed never appears in argv / shell history.
+
+sign reads a pending request JSON, loads the PRIVATE seed from the SecureStore, and emits
+an Ed25519-signed CanonicalApproval (JSON) to stdout for the Hub's resume ingestion. The
+private seed never appears in the output.
+
+The master key is sourced from FRIDAY_MASTER_KEY (hex) or ~/.friday/master.key (never
+auto-generated). --store-dir defaults to ~/.friday/agent-run-securestore.
+
+DARK / PROOF-ONLY: this helper is NOT wired into prod, registers no route, and is NEVER
+invoked automatically by the hub or any coordinator process. The operator runs it by hand.";
+
+fn main() -> ExitCode {
+    match run() {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(message) => {
+            // The error category is secret-free by construction (SignerError / CliError
+            // carry no seed / master / plaintext); safe to print.
+            eprintln!("friday-operator-sign: {message}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+fn run() -> Result<(), String> {
+    let args: Vec<String> = std::env::args().collect();
+    match args.get(1).map(String::as_str) {
+        Some("provision") => cmd_provision(&args[2..]),
+        Some("sign") => cmd_sign(&args[2..]),
+        Some("help") | Some("--help") | Some("-h") | None => {
+            println!("{USAGE}");
+            Ok(())
+        }
+        Some(other) => Err(format!("unknown subcommand {other:?}\n\n{USAGE}")),
+    }
+}
+
+fn resolve_store_dir(args: &[String]) -> Result<std::path::PathBuf, String> {
+    match arg_value(args, "--store-dir") {
+        Some(p) => Ok(std::path::PathBuf::from(p)),
+        None => default_store_dir().map_err(|e| e.to_string()),
+    }
+}
+
+fn cmd_provision(args: &[String]) -> Result<(), String> {
+    let store_dir = resolve_store_dir(args)?;
+
+    // The seed is the SECRET. Prefer stdin (never in argv / shell history); --seed-hex is
+    // a convenience that DOES land in argv, so it is flagged in the usage text.
+    let seed_hex = if args.iter().any(|a| a == "--seed-stdin") {
+        use std::io::Read;
+        let mut buf = String::new();
+        std::io::stdin()
+            .read_to_string(&mut buf)
+            .map_err(|_| "could not read seed from stdin".to_string())?;
+        buf.trim().to_string()
+    } else {
+        arg_value(args, "--seed-hex").ok_or_else(|| {
+            format!("provision requires --seed-hex <64-hex> or --seed-stdin\n\n{USAGE}")
+        })?
+    };
+
+    let seed = decode_seed_hex(&seed_hex)
+        .ok_or_else(|| "seed must be exactly 64 hex chars (32 bytes)".to_string())?;
+    let result = provision_signing_seed_into_store(&store_dir, &seed).map_err(|e| e.to_string());
+    // Wipe the decoded seed copy regardless of outcome.
+    let mut seed = seed;
+    zeroize_vec(&mut seed);
+    result?;
+
+    // The seed bytes never appear here — only a non-secret confirmation to stderr.
+    eprintln!(
+        "operator signing seed provisioned into the SecureStore at {} (KEK-wrapped under the host master key).",
+        store_dir.display()
+    );
+    Ok(())
+}
+
+fn cmd_sign(args: &[String]) -> Result<(), String> {
+    let store_dir = resolve_store_dir(args)?;
+    let request = arg_value(args, "--request")
+        .ok_or_else(|| format!("sign requires --request <pending-request.json>\n\n{USAGE}"))?;
+    let json = std::fs::read_to_string(&request)
+        .map_err(|_| format!("could not read request file {request}"))?;
+    let req: PendingRequest =
+        serde_json::from_str(&json).map_err(|e| format!("invalid request JSON: {e}"))?;
+
+    let signed = sign_pending_from_store(&store_dir, &req).map_err(|e| e.to_string())?;
+    // The signed approval -> stdout. The private seed is never part of this output (it is
+    // the OPERATOR side's secret; only the public signature + the Hub-computed digest the
+    // operator signed are emitted).
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&signed).map_err(|e| e.to_string())?
+    );
+    Ok(())
+}
+
+/// Decode exactly [`SIGNING_SEED_LEN`] bytes of hex. `None` for any non-hex / wrong-length
+/// input (fail-closed; never panics).
+fn decode_seed_hex(s: &str) -> Option<Vec<u8>> {
+    let b = s.trim().as_bytes();
+    if b.len() != SIGNING_SEED_LEN * 2 {
+        return None;
+    }
+    let mut out = Vec::with_capacity(SIGNING_SEED_LEN);
+    for pair in b.chunks_exact(2) {
+        out.push((hex_nibble(pair[0])? << 4) | hex_nibble(pair[1])?);
+    }
+    Some(out)
+}
+
+fn hex_nibble(b: u8) -> Option<u8> {
+    match b {
+        b'0'..=b'9' => Some(b - b'0'),
+        b'a'..=b'f' => Some(b - b'a' + 10),
+        b'A'..=b'F' => Some(b - b'A' + 10),
+        _ => None,
+    }
+}
+
+/// Best-effort wipe of a secret byte buffer (the decoded seed) before it drops.
+fn zeroize_vec(v: &mut [u8]) {
+    use zeroize::Zeroize;
+    v.zeroize();
+}
+
+/// `--name value` or `--name=value`. Mirrors the existing Hub / operator-cli bins.
+fn arg_value(args: &[String], name: &str) -> Option<String> {
+    args.windows(2)
+        .find_map(|pair| (pair[0] == name).then(|| pair[1].clone()))
+        .or_else(|| {
+            let prefix = format!("{name}=");
+            args.iter()
+                .find_map(|arg| arg.strip_prefix(&prefix).map(str::to_string))
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn decode_seed_hex_is_fail_closed() {
+        assert!(decode_seed_hex(&"a".repeat(64)).is_some());
+        assert!(decode_seed_hex(&"A".repeat(64)).is_some()); // uppercase ok
+        assert!(decode_seed_hex(&"a".repeat(62)).is_none()); // too short
+        assert!(decode_seed_hex(&"a".repeat(66)).is_none()); // too long
+        assert!(decode_seed_hex(&"z".repeat(64)).is_none()); // non-hex
+        assert!(decode_seed_hex("").is_none());
+    }
+
+    #[test]
+    fn arg_value_supports_both_forms() {
+        let args = vec![
+            "--store-dir".to_string(),
+            "/tmp/x".to_string(),
+            "--request=/tmp/r.json".to_string(),
+        ];
+        assert_eq!(arg_value(&args, "--store-dir"), Some("/tmp/x".to_string()));
+        assert_eq!(
+            arg_value(&args, "--request"),
+            Some("/tmp/r.json".to_string())
+        );
+        assert_eq!(arg_value(&args, "--missing"), None);
+    }
+}


### PR DESCRIPTION
## What

Adds **`friday-operator-signer`** — a standalone, OPERATOR-side desktop helper (binary `friday-operator-sign`) that:

1. reads the operator's PRIVATE Ed25519 signing seed from an **ISOLATED KEK-wrapped `FileSecureStore` the Hub CANNOT open**, and
2. produces an Ed25519 `SignedApproval` over the **Hub-computed canonical action digest** — EXACTLY what `friday_hub::resume::resume_with_approval` verifies under `OperatorVerifyingKey`.

This is the operator-chosen **desktop-helper** key-custody option (A2 design decision 3c) — the D3 key-custody bridge that lets the attended operator produce the Ed25519 `SignedApproval` for the first live S6-in-product proof, replacing the `hub_resume_approval` / coordinator-held-key dev path with real operator custody. Ed25519-native, so the Hub verify side (`OperatorVerifyingKey`) needs **no scheme change**.

## ISOLATION (operator decision: "isolate now")

A security audit found the original design **weakened INV-6**: it sealed the operator seed under the Hub's OWN store KEK — same `FILE_STORE_KEK_PURPOSE`, same `DEFAULT_STORE_DIR_REL`, same master key — so the hub process could derive that KEK via `friday_hub::key_source::derive_file_store_kek(master)` and open the signer seed. The seed was **co-resident** with the hub's store.

This is now fixed with **isolation even on one box**, stacking three separations. They split into an **unconditional, KAT-proven** guarantee and a **conditional, default-true operational** one:

**Unconditional (any master values) — the hub's existing derivation cannot open the seed:**

1. **Distinct KEK purpose tag** — `SIGNER_SEED_KEK_PURPOSE = b"friday.operator.signer.seed.kek.v1"` is byte-different from the hub's `FILE_STORE_KEK_PURPOSE`, so the hub's hardcoded `derive_file_store_kek` cannot produce the seed KEK **even if fed the signer master** (the inverted KAT proves this exact worst case).
2. **Distinct store directory** — `~/.friday/operator-signer-securestore` (not the hub's `~/.friday/agent-run-securestore`), so the seed never lands in the store the hub enrolls into.

**Conditional (default-true, NOT KAT-covered) — hub-underivable even against NEW hub code:**

3. **Distinct master / secret source** — the signer's KEK is derived from a SEPARATE operator-only master `FRIDAY_OPERATOR_SIGNER_MASTER` / `~/.friday/operator-signer.key`, **NOT** the hub's `FRIDAY_MASTER_KEY` / `~/.friday/master.key`. The hub never reads this source. When the master **VALUE** also differs (the default — separate env + separate file, provisioned out of band), even ADDED hub code cannot derive the seed KEK because it would still lack the signer master value. This property is NOT KAT-covered and degrades only if the operator deliberately points both masters at the same bytes; the unconditional guarantee above does not depend on it.

**Truth label:** the operator signing seed is sealed under a KEK the **hub's existing derivation cannot produce** (distinct purpose tag, KAT-proven) in an **isolated, non-co-resident store** (distinct dir). With the default distinct master value it is additionally **hub-underivable against added code**. This upholds **INV-1** (the hub still holds only the verify key and has no signing path) and **INV-6** (the seed lives only with the operator, in a store the hub cannot open). The seed is NO LONGER co-resident with the hub's store.

## DARK / default-off

A one-shot CLI (`friday-operator-sign provision|sign`) the operator runs **by hand**. It registers **NO production route**, has **no scheduler hook**, and is **NEVER invoked automatically** by the hub or any coordinator process. No existing runtime path changes; not-run = byte-identical to today.

## Invariants

- **INV-1 (no self-mint):** the helper lives in a **separate crate** (NOT `friday-hub/src/`), so the structural `hub_crate_never_references_a_signing_key` test stays green (verified). The hub still holds **only** `OperatorVerifyingKey` and has no code to sign with the stored seed.
- **INV-6 (real operator key, isolated):** the signing seed lives only with the operator, in an **isolated SecureStore the hub cannot open** (separate dir + separate operator-only master + distinct purpose tag), on the operator's machine; the helper is the operator signer. The inverted KAT `hub_kek_cannot_open_the_operator_signer_seed` proves the hub's own `derive_file_store_kek` cannot unwrap the seed.
- **Ed25519-native byte-identity:** the signature is produced by the **same** `friday_operator_cli::sign_request_with_key` byte path the file-based S6c CLI uses, so it is byte-identical to what the Hub recomputes at verify time (`canonical_approval_signature_bytes`). The e2e KAT reconstructs those exact bytes and calls `verify_ed25519_approval_hex` — i.e. it exercises the **real** hub verify, not a proxy.

## KATs (the isolation proof)

- **`hub_kek_cannot_open_the_operator_signer_seed`** (NEW — inverts the old `kek_derivation_matches_the_ws_server`): seals the seed under the signer's real KEK, then proves the **hub's** `derive_file_store_kek` cannot open it — both when fed the hub's own master AND, worst-case, when fed the signer master (isolating the purpose-tag separation specifically, so it can't pass merely because masters differ). Asserts the runtime infallible `SecureStore::get` → `None` AND the explicit `try_get` → `Err(Crypto(Open))` (a cryptographic refusal, not an absent entry). A positive control proves the seed really is present (so the negatives fail for the right reason).
- **`signer_store_dir_differs_from_hub_store_dir`** (NEW): asserts `signer::default_store_dir() != friday_hub::key_source::default_store_dir()` (via the hub's pub fn) and that the signer master file is the isolated `operator-signer.key`, never the hub's `master.key`.
- **`store_sourced_signature_verifies_under_the_matching_verify_key`** (POSITIVE, retained): provision a seed into the isolated store under the signer's own KEK, sign, and prove the emitted Ed25519 signature verifies under the operator public key over the exact canonical bytes (`verify_ed25519_approval_hex`) — i.e. the hub would accept it. Signer-own-KEK round-trip + verify.
- Fail-closed KATs retained (now rewired to the signer KEK + signer master env): `unprovisioned_seed_fails_closed`, `malformed_seed_fails_closed`, `wrong_master_key_fails_closed`, `provision_rejects_wrong_length_seed`, `signing_seed_id_is_distinct_from_other_secure_store_ids`.

## The one pre-existing-code change (no flag, by design)

`friday-operator-cli`'s `sign_request(path, req)` was split into `sign_request_with_key(&sk, req)` (the byte-producing core) + a thin file-loading wrapper. This is a **pure behavior-preserving refactor** — there is no flag because nothing behaves differently. Evidence: test `sign_request_and_with_key_are_byte_identical` (Ed25519 is deterministic ⇒ identical key+bytes ⇒ identical signature).

## Key-source decoupling (dev-dep posture)

The KEK is derived in this crate from `friday-crypto` primitives + the **distinct** signer purpose tag. A **test-only** inverted KAT consumes the hub's pub `derive_file_store_kek` + `default_store_dir` to PROVE the hub cannot open the seed store (`friday-hub` is a **dev-dependency only**). The shipped binary's runtime closure does **NOT** include `friday-hub` (verified: `cargo tree -p friday-operator-signer --edges normal,build -i friday-hub` → "nothing to print"), keeping the operator tool decoupled from the hub's secret-bearing graph.

**Residual (explicitly fail-closed):** the signer's master-read path constants are independent of the hub's. A missing/mismatched signer master makes `get()` return `None` → `SeedUnprovisioned` (the helper refuses to sign), as `wrong_master_key_fails_closed` proves. It can never sign the wrong thing.

## Fail-closed + secret hygiene

Missing signer master / unopenable store / absent or wrong-length seed each refuse to sign. Errors are secret-free (no seed/master/plaintext in any variant). Seed + master key are zeroized after use. Namespaced SecureStore id distinct from the verify-key and peer-allowlist ids (asserted by test).

## Scope (out of this PR)

Driving the signed blob through the full `resume_with_approval` (DB + pending row + executor) is the D3 **live** proof — operator-gated and out of scope here. This PR is the (now isolated) signing helper only. PROOF-ONLY; NOT v1 GO.

## Local checks (pinned toolchain)

- `cargo +1.95.0 fmt --all --check` — clean
- `cargo +1.95.0 test -p friday-operator-signer` — green (lib 9 incl. the inverted isolation KAT + dir-inequality + positive verify; main 2)
- `cargo +1.95.0 test -p friday-hub --lib hub_crate_never_references_a_signing_key` — green (INV-1)
- `cargo +1.95.0 clippy -p friday-operator-signer --all-targets` — clean
- `cargo +1.95.0 build` (workspace) — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
