### PR TITLE
feat(gate-agent-replace): A3 TS client courier — pause/resume product transport (dark, flag-gated)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -905,14 +905,14 @@
         "filename": "test/unit/hub/friday-hub-bootstrap-env.test.ts",
         "hashed_secret": "5c5a15a8b0b3e154d77746945e563ba40100681b",
         "is_verified": false,
-        "line_number": 133
+        "line_number": 134
       },
       {
         "type": "Secret Keyword",
         "filename": "test/unit/hub/friday-hub-bootstrap-env.test.ts",
         "hashed_secret": "8a8281cec699f5e51330e21dd7fab3531af6ef0c",
         "is_verified": false,
-        "line_number": 134
+        "line_number": 135
       }
     ],
     "test/unit/media-understanding/friday-openai-vision-provider.test.ts": [
@@ -1124,5 +1124,5 @@
       }
     ]
   },
-  "generated_at": "2026-06-11T18:33:50Z"
+  "generated_at": "2026-06-11T23:19:56Z"
 }

--- a/src/api/mission-spine/friday-rust-hub-agent-run-sealed-client-service.ts
+++ b/src/api/mission-spine/friday-rust-hub-agent-run-sealed-client-service.ts
@@ -4,7 +4,10 @@ import {
   createFridayRustHubAgentRunSealedClient,
   type CreateFridayRustHubAgentRunSealedClientOptions,
   type FridayRustHubAgentRunConstraints,
+  type FridayRustHubAgentRunPausedOutcome,
+  type FridayRustHubAgentRunResumeResult,
   type FridayRustHubAgentRunSealedClient,
+  type FridayRustHubAgentRunSealedDispatchOutcome,
 } from "./friday-rust-hub-agent-run-ws-sealed-client.js";
 
 /**
@@ -114,16 +117,53 @@ export interface FridayRustHubAgentRunSealedClientServiceResult {
   readonly completionTokens?: number;
 }
 
+/**
+ * (A3 courier) The discriminated dispatch outcome the adapter surfaces: EITHER the refs-only result
+ * (above, today's ONLY outcome — no `outcome` key, byte-identical shape) OR — ONLY when the
+ * default-off run-control flag is on AND the Rust server emits an `AgentRunPaused` — the paused
+ * outcome (refs only: approval nonce + action digest + summary; NO signing material, INV-1). With
+ * the flag OFF the union NARROWS to exactly the result, so the type is byte-identical to today.
+ */
+export type FridayRustHubAgentRunSealedClientServiceDispatchOutcome =
+  | FridayRustHubAgentRunSealedClientServiceResult
+  | FridayRustHubAgentRunPausedOutcome;
+
+/** (A3 courier) A resume relay through the adapter: the SAME shape the underlying client takes. */
+export interface FridayRustHubAgentRunSealedClientServiceResumeRequest {
+  /** The paused run to resume (echoes the paused run id). */
+  readonly runId: string;
+  /**
+   * The client's 32-byte X25519 SECRET (resolved from SecureStore by the caller). Used to open the
+   * FRESH sealed session for the resume relay. Held in-process only; never logged.
+   */
+  readonly clientSecret: Uint8Array;
+  /** The operator's OPAQUE Ed25519-signed approval blob — relayed VERBATIM; TS authors nothing (INV-1). */
+  readonly opaqueSignedBlob: Uint8Array;
+}
+
 export interface FridayRustHubAgentRunSealedClientService {
   /**
    * Dispatch one agent-run over a sealed ECDH session and await its REFS-ONLY result. Builds the
    * underlying sealed client from the request's `clientSecret`, runs the handshake + auth_proof +
    * send INTERNALLY, then maps the sealed result to refs-only. Fails closed (503) on any non-clean
    * settle. The in-band owner-sealed body is dropped (compose uses the DB readback).
+   *
+   * (A3 courier) Returns the discriminated outcome: a refs-only result OR — ONLY when the default-off
+   * run-control flag is on AND the server pauses — a refs-only paused outcome. Flag-off ⇒ byte-identical.
    */
   dispatchRun(
     request: FridayRustHubAgentRunSealedClientServiceRequest,
-  ): Promise<FridayRustHubAgentRunSealedClientServiceResult>;
+  ): Promise<FridayRustHubAgentRunSealedClientServiceDispatchOutcome>;
+  /**
+   * (A3 courier) Relay an operator's OPAQUE Ed25519-signed approval to RESUME a paused run. Builds the
+   * underlying sealed client from the request's `clientSecret` and opens a FRESH sealed session bound
+   * to the SAME credentials + run_id, sends `AgentRunResume {run_id, signed_blob}`, and awaits the
+   * refs-only control result. INV-1: TS inspects/authors NOTHING inside the blob — a pure courier.
+   * Fails closed (503) when the run-control flag is OFF or on any non-clean settle.
+   */
+  resumeWithApproval(
+    request: FridayRustHubAgentRunSealedClientServiceResumeRequest,
+  ): Promise<FridayRustHubAgentRunResumeResult>;
 }
 
 /**
@@ -147,6 +187,14 @@ export interface CreateFridayRustHubAgentRunSealedClientServiceOptions {
    * client. Constructed LAZILY per-dispatch so the service factory itself is side-effect-free.
    */
   readonly createClient?: CreateSealedClientFn;
+  /**
+   * (A3 courier) Run-control flag, DEFAULT-OFF. Mirrors the Phase-2 server's default-off
+   * `FRIDAY_AGENT_RUN_CONTROL_VIA_RUST` posture. Forwarded UNCHANGED to every underlying sealed
+   * client this adapter constructs, where it gates ONLY the new `AgentRunPaused` inbound branch +
+   * the `resumeWithApproval` method. Absent/`false` ⇒ byte-identical to today (a paused frame fails
+   * closed, resume relays nothing).
+   */
+  readonly agentRunControlViaRust?: boolean;
 }
 
 function unavailable(message: string): FridayDomainError {
@@ -162,6 +210,18 @@ function unavailable(message: string): FridayDomainError {
 }
 
 /**
+ * (A3 courier) Type guard: a dispatch outcome that is the PAUSED outcome (vs the normal result).
+ * EXPORTED so the compose path (friday-api-runtime.ts) discriminates the SAME way without re-deriving
+ * the check. Probes the `outcome` discriminant directly (it is absent on the result member, present
+ * + `"paused"` on the paused member) — narrows reliably across the union.
+ */
+export function isPausedDispatchOutcome(
+  outcome: FridayRustHubAgentRunSealedDispatchOutcome,
+): outcome is FridayRustHubAgentRunPausedOutcome {
+  return (outcome as FridayRustHubAgentRunPausedOutcome).outcome === "paused";
+}
+
+/**
  * Build the sealed-client SERVICE adapter the composition wires in place of the old plain-WS
  * client. SIDE-EFFECT-FREE: captures host/port/timeout/createClient only; resolves no secret and
  * opens no socket until `dispatchRun` is actually called on a qualifying run.
@@ -171,29 +231,41 @@ export function createFridayRustHubAgentRunSealedClientService(
 ): FridayRustHubAgentRunSealedClientService {
   const { host, port, timeoutMs } = options;
   const createClient = options.createClient ?? createFridayRustHubAgentRunSealedClient;
+  // (A3 courier) DEFAULT-OFF run-control flag, forwarded UNCHANGED to every underlying client this
+  // adapter constructs. Absent/`false` ⇒ byte-identical to today.
+  const agentRunControlViaRust = options.agentRunControlViaRust === true;
+
+  /** Construct the underlying sealed client for one secret — shared by dispatch + resume. */
+  function buildClient(clientSecret: Uint8Array): FridayRustHubAgentRunSealedClient {
+    return createClient({
+      ...(host !== undefined ? { host } : {}),
+      port,
+      clientSecret,
+      ...(timeoutMs !== undefined ? { timeoutMs } : {}),
+      // Forward the run-control flag so the inner client gates its paused/resume behavior; absent
+      // (false) ⇒ the inner client's paused branch + resume are inert (byte-identical to today).
+      ...(agentRunControlViaRust ? { agentRunControlViaRust: true } : {}),
+    });
+  }
 
   return {
     async dispatchRun(
       request: FridayRustHubAgentRunSealedClientServiceRequest,
-    ): Promise<FridayRustHubAgentRunSealedClientServiceResult> {
+    ): Promise<FridayRustHubAgentRunSealedClientServiceDispatchOutcome> {
       // Build the underlying sealed client from the per-dispatch X25519 secret. A non-32-byte
       // secret throws a RangeError from the sealed client constructor; map it to fail-closed (503)
       // so a malformed resolve surfaces as today's 503 rather than an unhandled throw.
       let client: FridayRustHubAgentRunSealedClient;
       try {
-        client = createClient({
-          ...(host !== undefined ? { host } : {}),
-          port,
-          clientSecret: request.clientSecret,
-          ...(timeoutMs !== undefined ? { timeoutMs } : {}),
-        });
+        client = buildClient(request.clientSecret);
       } catch {
         throw unavailable("Sealed agent-run client could not be constructed.");
       }
 
       // The sealed client's dispatch already fails closed (503) on every non-clean settle; surface
-      // its FridayDomainError unchanged, wrap any non-domain throw as fail-closed.
-      let sealed;
+      // its FridayDomainError unchanged, wrap any non-domain throw as fail-closed. Typed as the
+      // discriminated union so the `outcome === "paused"` narrowing below is sound.
+      let sealed: FridayRustHubAgentRunSealedDispatchOutcome;
       try {
         sealed = await client.dispatchRun({
           runId: request.runId,
@@ -212,9 +284,17 @@ export function createFridayRustHubAgentRunSealedClientService(
           : unavailable("Sealed agent-run client dispatch failed.");
       }
 
-      // Map to the REFS-ONLY shape the composition consumes — DROP the in-band `body` (compose's
-      // authoritative body source is the slice-3 owner-gated DB readback). (A1) Thread the run
-      // COUNTS through when present (absent ⇒ omitted, never 0-faked); these are counts, not body.
+      // (A3 courier) A PAUSED outcome is surfaced UNCHANGED (refs only — approval nonce + action
+      // digest + summary; no signing material, INV-1) so compose can project an honest non-Finished
+      // row. It reaches here ONLY when the run-control flag is on (else the inner client fails closed
+      // on the unknown frame), so flag-off dispatch never produces this branch.
+      if (isPausedDispatchOutcome(sealed)) {
+        return sealed;
+      }
+
+      // Map the normal result to the REFS-ONLY shape the composition consumes — DROP the in-band
+      // `body` (compose's authoritative body source is the slice-3 owner-gated DB readback). (A1)
+      // Thread the run COUNTS through when present (absent ⇒ omitted, never 0-faked); not a body.
       return {
         truthLabel: "rust_wired",
         runId: sealed.runId,
@@ -228,6 +308,31 @@ export function createFridayRustHubAgentRunSealedClientService(
           ? { completionTokens: sealed.completionTokens }
           : {}),
       };
+    },
+
+    async resumeWithApproval(
+      request: FridayRustHubAgentRunSealedClientServiceResumeRequest,
+    ): Promise<FridayRustHubAgentRunResumeResult> {
+      // Build the underlying sealed client from the per-resume X25519 secret (fail-closed on a
+      // non-32-byte secret, same as dispatch). The inner client gates the relay on the run-control
+      // flag — OFF ⇒ it rejects without opening a socket (byte-identical inert default).
+      let client: FridayRustHubAgentRunSealedClient;
+      try {
+        client = buildClient(request.clientSecret);
+      } catch {
+        throw unavailable("Sealed agent-run client could not be constructed.");
+      }
+      try {
+        // INV-1: forward the OPAQUE blob VERBATIM; the adapter inspects/authors NOTHING inside it.
+        return await client.resumeWithApproval({
+          runId: request.runId,
+          opaqueSignedBlob: request.opaqueSignedBlob,
+        });
+      } catch (error) {
+        throw error instanceof FridayDomainError
+          ? error
+          : unavailable("Sealed agent-run client resume failed.");
+      }
     },
   };
 }

--- a/src/api/mission-spine/friday-rust-hub-agent-run-ws-sealed-client.ts
+++ b/src/api/mission-spine/friday-rust-hub-agent-run-ws-sealed-client.ts
@@ -205,6 +205,79 @@ export interface FridayRustHubAgentRunSealedResult {
   readonly completionTokens?: number;
 }
 
+/**
+ * (A3 courier) The PAUSED dispatch outcome: the Rust server's loop gate PAUSED a mutating tool on
+ * the run and emitted a `Message::AgentRunPaused` frame instead of an `AgentRunResult`. This settles
+ * `dispatchRun` with a NEW non-result outcome carrying REFS ONLY (the single-use approval nonce + the
+ * action digest + a coarse body-free summary) so the operator can be prompted to sign (out-of-band)
+ * and the courier can later relay an `AgentRunResume`.
+ *
+ * **INV-1 (no signing material):** this carries NO signing key, NO private material, and NO mutation
+ * body/args — only the references the operator's OWN signer binds an Ed25519 approval over. TS
+ * inspects nothing inside the eventual signed blob; it is a pure courier.
+ *
+ * **Wire mapping (matches the merged `AgentRunPaused` EXACTLY — `friday-protocol::Message`):**
+ *   - `approvalId` ← the wire `nonce` (the `pending_approval_request.approval_id` the operator signs
+ *     over; the A2 design doc §2.3 names it "the approval_id nonce"). A nonce, not a secret.
+ *   - `actionDigest` ← the wire `action_digest` (hex SHA-256 of `canonical_action_bytes` — binds the
+ *     EXACT paused action, transitively principal/scope/params). A fingerprint, never a body.
+ *   - `ownerSealedSummary` ← the wire `summary` (a coarse, body-free action-verb summary). Optional.
+ *   - `expiresAt`: the merged `AgentRunPaused` does NOT carry an expiry field, so this is parsed
+ *     DEFENSIVELY (forward-compatible) and is `undefined` today — never fabricated. (The approval's
+ *     real expiry is enforced server-side by `resume_with_approval`, not surfaced on this refs frame.)
+ *
+ * The `outcome: "paused"` discriminant lets the consumer (compose) tell a paused settle apart from a
+ * normal `AgentRunResult` WITHOUT touching the existing result shape (which carries no `outcome` key).
+ */
+export interface FridayRustHubAgentRunPausedOutcome {
+  /** Discriminant: distinguishes a paused settle from a normal `AgentRunResult` (no `outcome` key). */
+  readonly outcome: "paused";
+  readonly truthLabel: "rust_wired";
+  /** The run that paused (echoes the request run id). */
+  readonly runId: string;
+  /** The single-use approval nonce the operator signs over (wire `nonce`). A nonce, never a secret. */
+  readonly approvalId: string;
+  /** Hex SHA-256 of the canonical action bytes (wire `action_digest`). A fingerprint, never a body. */
+  readonly actionDigest: string;
+  /** A coarse, body-free summary of WHAT paused (wire `summary`). Never the tool args/params/body. */
+  readonly ownerSealedSummary?: string;
+  /** Approval expiry (epoch ms), when the wire carries one. DEFERRED — the merged wire omits it ⇒ `undefined`. */
+  readonly expiresAt?: number;
+}
+
+/**
+ * (A3 courier) The discriminated outcome of a sealed dispatch: EITHER the refs-only `AgentRunResult`
+ * (the {@link FridayRustHubAgentRunSealedResult}, today's ONLY outcome — carries NO `outcome` key so
+ * the legacy `toEqual` shape is byte-identical) OR — ONLY when the courier's default-off run-control
+ * flag is on AND the server emits an `AgentRunPaused` — the {@link FridayRustHubAgentRunPausedOutcome}.
+ * With the flag OFF an `AgentRunPaused` is an unknown inbound and stays fail-closed (503), so the
+ * union NARROWS to exactly `FridayRustHubAgentRunSealedResult` and the type is byte-identical to today.
+ */
+export type FridayRustHubAgentRunSealedDispatchOutcome =
+  | FridayRustHubAgentRunSealedResult
+  | FridayRustHubAgentRunPausedOutcome;
+
+/**
+ * (A3 courier) The result of relaying an operator-signed approval to RESUME a paused run — the
+ * REFS-ONLY `Message::AgentRunControlResult` the server returns. Carries the coarse
+ * `op`/`accepted`/`status` + an optional soft `auditRef` — NEVER the mutation body, args, or answer.
+ * `accepted=false` is a fail-closed refusal (forged/replayed/expired blob / unprovisioned verify key
+ * / storage error); the `status` says why at a coarse grain.
+ */
+export interface FridayRustHubAgentRunResumeResult {
+  readonly truthLabel: "rust_wired";
+  /** The run this control op terminates (echoes the request run id). */
+  readonly runId: string;
+  /** The control op (`resume`). */
+  readonly op: string;
+  /** Whether the op was accepted (`true`) or refused fail-closed (`false`). */
+  readonly accepted: boolean;
+  /** Coarse, body-free outcome label. */
+  readonly status: string;
+  /** Soft link to the hash-chained audit receipt, when one was written. A ref, never a body. */
+  readonly auditRef?: string;
+}
+
 export interface CreateFridayRustHubAgentRunSealedClientOptions {
   /** Loopback host for the Rust agent-run WS server. Defaults to `127.0.0.1`. */
   readonly host?: string;
@@ -218,6 +291,18 @@ export interface CreateFridayRustHubAgentRunSealedClientOptions {
   readonly clientSecret: Uint8Array;
   /** Bounded await (ms) for the dispatch to settle before failing closed. */
   readonly timeoutMs?: number;
+  /**
+   * (A3 courier) Run-control flag, DEFAULT-OFF. Mirrors the Phase-2 server's default-off
+   * `FRIDAY_AGENT_RUN_CONTROL_VIA_RUST` flag posture EXACTLY. When `false`/absent (the default):
+   *   - an inbound `AgentRunPaused` is an UNKNOWN message ⇒ fail-closed (503), byte-identical to today;
+   *   - {@link FridayRustHubAgentRunSealedClient.resumeWithApproval} is fail-closed (the courier
+   *     relays nothing).
+   * When `true`, the new courier behavior is enabled: an `AgentRunPaused` settles `dispatchRun` with
+   * the {@link FridayRustHubAgentRunPausedOutcome}, and `resumeWithApproval` relays the opaque blob.
+   * The success (`AgentRunResult`) path and the trailing unknown→fail-closed are UNTOUCHED by this
+   * flag — so flag-off behavior is exactly today's.
+   */
+  readonly agentRunControlViaRust?: boolean;
 }
 
 export interface FridayRustHubAgentRunSealedClient {
@@ -227,10 +312,46 @@ export interface FridayRustHubAgentRunSealedClient {
    * settles and closes — it does NOT await the owner-sealed body frame (leg-A decouple, #655 Part
    * 4; compose sources the body from the owner-gated DB readback). Fails closed (503) on any
    * non-clean settle, including a session that closes BEFORE any refs arrive.
+   *
+   * (A3 courier) Returns the discriminated {@link FridayRustHubAgentRunSealedDispatchOutcome}: a
+   * normal refs-only `AgentRunResult` OR — ONLY when `agentRunControlViaRust` is on AND the server
+   * emits an `AgentRunPaused` — a {@link FridayRustHubAgentRunPausedOutcome}. With the flag OFF an
+   * `AgentRunPaused` is an unknown inbound ⇒ fail-closed (503), so the outcome is byte-identical to
+   * today's `FridayRustHubAgentRunSealedResult`.
    */
   dispatchRun(
     request: FridayRustHubAgentRunSealedRequest,
-  ): Promise<FridayRustHubAgentRunSealedResult>;
+  ): Promise<FridayRustHubAgentRunSealedDispatchOutcome>;
+  /**
+   * (A3 courier) Relay an operator's out-of-band Ed25519-signed approval to RESUME a paused run.
+   * Opens a FRESH sealed session bound to the SAME credentials (`clientSecret`) and the SAME
+   * `run_id` (the merged `AgentRunResume` is self-authenticating via the blob's nonce/digest — it
+   * carries no `auth_proof`/`forwarded_principal`; the A2 design §2.1 blesses reconnect because the
+   * NONCE is the single-use authority, not the socket), sends `Message::AgentRunResume {run_id,
+   * signed_blob}`, and awaits the refs-only `AgentRunControlResult`.
+   *
+   * **INV-1 (pure courier):** `opaqueSignedBlob` is treated as OPAQUE bytes — TS inspects NOTHING
+   * inside it, mints no signature, holds no signing key, and authors none of the approval's
+   * semantics. The server decodes + verifies + consumes the nonce + executes the ONE mutation.
+   *
+   * Fail-closed (503) when the run-control flag is OFF (the courier relays nothing) or on any
+   * non-clean settle. A server refusal (`accepted=false`) is a SUCCESSFUL relay of a refusal
+   * outcome, not a transport failure — it resolves with `{accepted:false, status}`.
+   */
+  resumeWithApproval(
+    request: FridayRustHubAgentRunResumeRequest,
+  ): Promise<FridayRustHubAgentRunResumeResult>;
+}
+
+/** (A3 courier) A resume relay: the run to resume + the operator's OPAQUE signed approval blob. */
+export interface FridayRustHubAgentRunResumeRequest {
+  /** The paused run to resume (echoes the paused `run_id`). */
+  readonly runId: string;
+  /**
+   * The operator's canonical Ed25519-signed approval bytes (the S6c CLI output). OPAQUE to the
+   * courier — relayed VERBATIM as the wire `signed_blob`; TS inspects/derives/authors NOTHING.
+   */
+  readonly opaqueSignedBlob: Uint8Array;
 }
 
 function unavailable(message: string): FridayDomainError {
@@ -396,7 +517,7 @@ function wsClientUpgrade(socket: Socket, host: string, port: number): Promise<Bu
 }
 
 /** A decoded inbound envelope: the inner message kind plus the fields we read. */
-interface InboundEnvelope {
+export interface InboundEnvelope {
   readonly kind: string;
   readonly fields: Record<string, unknown>;
 }
@@ -462,6 +583,32 @@ export function buildConstraintsWire(
   return Object.keys(wire).length > 0 ? wire : undefined;
 }
 
+/**
+ * (A3 courier) Build the `AgentRunResume` envelope that relays an operator's OPAQUE signed approval.
+ * The merged wire (`friday-protocol::Message::AgentRunResume`) is exactly `{run_id, signed_blob}` —
+ * serde `Vec<u8>` serializes as a JSON ARRAY of byte numbers (NOT base64/hex), EXACTLY like the
+ * dispatch envelope's `auth_proof`. The blob is relayed VERBATIM via `Array.from` — TS inspects,
+ * derives, and authors NOTHING inside it (INV-1, a pure courier). EXPORTED + pure so the precise
+ * wire shape is unit-testable without a socket (mirrors {@link buildConstraintsWire}).
+ */
+export function buildResumeEnvelope(
+  runId: string,
+  opaqueSignedBlob: Uint8Array,
+): Record<string, unknown> {
+  return {
+    schema_version: SCHEMA_VERSION,
+    msg_id: `agent-run-resume-${runId}`,
+    correlation_id: `agent-run-resume-${runId}`,
+    sent_at: Date.now(),
+    message: {
+      kind: "AgentRunResume",
+      run_id: runId,
+      // serde `Vec<u8>` ⇒ a JSON ARRAY of byte numbers (NOT base64/hex). VERBATIM relay (INV-1).
+      signed_blob: Array.from(opaqueSignedBlob),
+    },
+  };
+}
+
 /** Open + decode one inbound sealed WS Binary payload into its inner message. */
 function openInbound(sessionKey: Uint8Array, payload: Buffer): InboundEnvelope {
   const sealed = decodeSealed(new Uint8Array(payload));
@@ -514,7 +661,19 @@ export interface InboundContext {
   sessionKey: Uint8Array;
   /** Mutable refs slot — set by the result handler, read by the close handler. */
   refs: ResultRefs | null;
-  succeed(result: FridayRustHubAgentRunSealedResult): void;
+  /**
+   * (A3 courier) The run-control flag, DEFAULT-OFF. Gates ONLY the new `AgentRunPaused` inbound
+   * branch: OFF ⇒ an `AgentRunPaused` is an unknown message and fails closed (byte-identical to
+   * today); ON ⇒ it settles with the paused outcome. The `AgentRunResult` path is flag-independent.
+   * Defaults to `false` when a caller (e.g. a legacy test) omits it.
+   */
+  controlEnabled?: boolean;
+  /**
+   * (A3 courier) Settle with the dispatch outcome. Widened from the legacy
+   * `FridayRustHubAgentRunSealedResult`-only signature to the discriminated union so a paused
+   * settle can flow through — a normal result (no `outcome` key) is unchanged.
+   */
+  succeed(result: FridayRustHubAgentRunSealedDispatchOutcome): void;
   fail(error: FridayDomainError): void;
 }
 
@@ -579,12 +738,101 @@ export function handleResult(ctx: InboundContext, fields: Record<string, unknown
 }
 
 /**
+ * (A3 courier) Handle the merged `Message::AgentRunPaused` inbound — settle the in-flight dispatch
+ * with the {@link FridayRustHubAgentRunPausedOutcome}, carrying REFS ONLY (the approval nonce + the
+ * action digest + a coarse summary). Maps the wire fields to the TS outcome EXACTLY:
+ *   `nonce` → `approvalId`, `action_digest` → `actionDigest`, `summary` → `ownerSealedSummary?`.
+ * `expiresAt` is parsed defensively (the merged wire omits it ⇒ `undefined`, forward-compatible).
+ *
+ * **FLAG-GATED:** this is reached ONLY when `ctx.controlEnabled` is true (the run-control flag is
+ * on). With the flag off, `handleInbound` never routes an `AgentRunPaused` here — it falls to the
+ * unknown→fail-closed branch, byte-identical to today. A pause frame MISSING a required ref
+ * (`run_id`/`nonce`/`action_digest`) fails closed — the refs-surface contract is preserved.
+ *
+ * **INV-1:** carries NO signing material; TS authors no approval. EXPORTED only so the settle-branch
+ * logic is unit-testable against a fake ctx without a socket.
+ */
+export function handlePaused(ctx: InboundContext, fields: Record<string, unknown>): void {
+  const runId = asString(fields.run_id);
+  const approvalId = asString(fields.nonce);
+  const actionDigest = asString(fields.action_digest);
+  if (!runId || !approvalId || !actionDigest) {
+    ctx.fail(unavailable("Sealed agent-run client pause is missing a required ref."));
+    return;
+  }
+  const ownerSealedSummary = asString(fields.summary);
+  // The merged `AgentRunPaused` carries NO expiry field; parse defensively for forward-compat (a
+  // later wire revision may add `expires_at`) — `undefined` today, never fabricated.
+  const expiresAt = asNumber(fields.expires_at);
+  ctx.succeed({
+    outcome: "paused",
+    truthLabel: "rust_wired",
+    runId,
+    approvalId,
+    actionDigest,
+    ...(ownerSealedSummary !== undefined ? { ownerSealedSummary } : {}),
+    ...(expiresAt !== undefined ? { expiresAt } : {}),
+  });
+}
+
+/**
+ * (A3 courier) Parse the refs-only `Message::AgentRunControlResult` the server returns for a resume
+ * relay into the {@link FridayRustHubAgentRunResumeResult}. REFS-ONLY: the coarse `op`/`accepted`/
+ * `status` + an optional soft `audit_ref` — NEVER a body. A frame missing a required ref
+ * (`run_id`/`op`/`status`, or a non-boolean `accepted`) returns `undefined` (the caller fails
+ * closed). A server REFUSAL (`accepted=false`) is a VALID parse — it is a refusal outcome, not a
+ * parse failure. EXPORTED only so the parse is unit-testable against a fake field map without a socket.
+ */
+export function parseControlResult(
+  fields: Record<string, unknown>,
+): FridayRustHubAgentRunResumeResult | undefined {
+  const runId = asString(fields.run_id);
+  const op = asString(fields.op);
+  const status = asString(fields.status);
+  const accepted = fields.accepted;
+  if (!runId || !op || !status || typeof accepted !== "boolean") {
+    return undefined;
+  }
+  const auditRef = asString(fields.audit_ref);
+  return {
+    truthLabel: "rust_wired",
+    runId,
+    op,
+    accepted,
+    status,
+    ...(auditRef !== undefined ? { auditRef } : {}),
+  };
+}
+
+/**
  * Dispatch one opened inbound envelope to its handler. (leg-A decouple, #655 Part 4) The client
  * settles synchronously on the FIRST `AgentRunResult`, so any later frame (e.g. the now-ignored
  * owner-sealed body `AskFridayStream`) arrives after teardown removed the listeners and after the
  * `settled` guard is set — a no-op. We keep the kind dispatch narrow: only `AgentRunResult` is a
  * recognized inbound; anything else BEFORE a result is fail-closed.
+ *
+ * (A3 courier) When the run-control flag is ON (`ctx.controlEnabled`), `AgentRunPaused` is ALSO a
+ * recognized inbound and settles with the paused outcome. With the flag OFF an `AgentRunPaused` is
+ * NOT recognized — it falls to the unknown→fail-closed branch, byte-identical to today.
+ *
+ * EXPORTED only so the flag-gated kind-dispatch (incl. the flag-off `AgentRunPaused`→fail-closed
+ * byte-identity) is unit-testable against a pre-opened field map without a socket. Takes the already
+ * decoded {@link InboundEnvelope} so the test does not need session crypto.
  */
+export function routeInboundEnvelope(ctx: InboundContext, inbound: InboundEnvelope): void {
+  if (inbound.kind === "AgentRunResult") {
+    handleResult(ctx, inbound.fields);
+    return;
+  }
+  // (A3 courier) FLAG-GATED: a paused frame is recognized ONLY when run-control is on. Flag off ⇒
+  // it falls through to the unknown→fail-closed branch below (byte-identical to today).
+  if (ctx.controlEnabled === true && inbound.kind === "AgentRunPaused") {
+    handlePaused(ctx, inbound.fields);
+    return;
+  }
+  ctx.fail(unavailable("Sealed agent-run client received an unknown message shape."));
+}
+
 function handleInbound(ctx: InboundContext, payload: Buffer): void {
   let inbound: InboundEnvelope;
   try {
@@ -593,11 +841,7 @@ function handleInbound(ctx: InboundContext, payload: Buffer): void {
     ctx.fail(unavailable("Sealed agent-run client could not open an inbound envelope."));
     return;
   }
-  if (inbound.kind === "AgentRunResult") {
-    handleResult(ctx, inbound.fields);
-    return;
-  }
-  ctx.fail(unavailable("Sealed agent-run client received an unknown message shape."));
+  routeInboundEnvelope(ctx, inbound);
 }
 
 /**
@@ -624,16 +868,19 @@ export function createFridayRustHubAgentRunSealedClient(
     throw new RangeError(`clientSecret must be ${X25519_PUBKEY_LEN} bytes`);
   }
   const keypair = deviceKeypairFromSecret(options.clientSecret);
+  // (A3 courier) DEFAULT-OFF run-control flag. Gates ONLY the new `AgentRunPaused` inbound branch
+  // (in the dispatch ctx) and the `resumeWithApproval` method. OFF ⇒ byte-identical to today.
+  const controlEnabled = options.agentRunControlViaRust === true;
 
   return {
     dispatchRun(
       request: FridayRustHubAgentRunSealedRequest,
-    ): Promise<FridayRustHubAgentRunSealedResult> {
+    ): Promise<FridayRustHubAgentRunSealedDispatchOutcome> {
       if (!request.runId) {
         return Promise.reject(unavailable("Sealed agent-run client requires a run id."));
       }
 
-      return new Promise<FridayRustHubAgentRunSealedResult>((resolve, reject) => {
+      return new Promise<FridayRustHubAgentRunSealedDispatchOutcome>((resolve, reject) => {
         let settled = false;
         let socket: Socket | null = null;
         let receiver: WsReceiver | null = null;
@@ -659,7 +906,7 @@ export function createFridayRustHubAgentRunSealedClient(
             }
           }
         }
-        function succeed(result: FridayRustHubAgentRunSealedResult): void {
+        function succeed(result: FridayRustHubAgentRunSealedDispatchOutcome): void {
           if (settled) return;
           settled = true;
           teardown();
@@ -673,8 +920,16 @@ export function createFridayRustHubAgentRunSealedClient(
         }
 
         // The accumulated read state across the two inbound envelopes (refs first, body optional),
-        // bundled with the settlement callbacks so the module-level handlers can drive it.
-        const ctx: InboundContext = { sessionKey: new Uint8Array(0), refs: null, succeed, fail };
+        // bundled with the settlement callbacks so the module-level handlers can drive it. (A3) the
+        // DEFAULT-OFF run-control flag flows in so a flag-on dispatch can settle on `AgentRunPaused`;
+        // flag-off keeps the paused frame in the unknown→fail-closed bucket (byte-identical).
+        const ctx: InboundContext = {
+          sessionKey: new Uint8Array(0),
+          refs: null,
+          controlEnabled,
+          succeed,
+          fail,
+        };
 
         void (async () => {
           // (1) RAW TCP connect (NOT new WebSocket(url) — its HTTP upgrade would corrupt the
@@ -798,6 +1053,182 @@ export function createFridayRustHubAgentRunSealedClient(
             sealAndSend(sender, sessionKey, envelope);
           } catch {
             fail(unavailable("Sealed agent-run client handshake failed."));
+          }
+        })();
+      });
+    },
+
+    resumeWithApproval(
+      request: FridayRustHubAgentRunResumeRequest,
+    ): Promise<FridayRustHubAgentRunResumeResult> {
+      // (A3 courier) FLAG-GATED: with the run-control flag OFF the courier relays NOTHING — it fails
+      // closed without opening a socket. This keeps the default-off posture byte-identical (the
+      // method exists but is inert) and never sends an `AgentRunResume` the server would ignore.
+      if (!controlEnabled) {
+        return Promise.reject(
+          unavailable("Sealed agent-run client run-control is disabled (resume relay refused)."),
+        );
+      }
+      if (!request.runId) {
+        return Promise.reject(unavailable("Sealed agent-run client resume requires a run id."));
+      }
+      // INV-1 (pure courier): the blob is OPAQUE — TS inspects/derives/authors NOTHING inside it. We
+      // require only that SOME bytes are present (an empty blob can carry no signature ⇒ fail closed).
+      if (!(request.opaqueSignedBlob instanceof Uint8Array) || request.opaqueSignedBlob.length === 0) {
+        return Promise.reject(
+          unavailable("Sealed agent-run client resume requires a signed approval blob."),
+        );
+      }
+
+      // Open a FRESH sealed session bound to the SAME credentials (`clientSecret`) + the SAME run_id
+      // (design §2.1: reconnect is safe because the NONCE inside the blob is the single-use authority,
+      // not the socket). The merged `AgentRunResume` is SELF-authenticating via the blob — it carries
+      // NO `auth_proof`/`forwarded_principal` — so this leg does not rebuild a possession proof.
+      return new Promise<FridayRustHubAgentRunResumeResult>((resolve, reject) => {
+        let settled = false;
+        let socket: Socket | null = null;
+        let receiver: WsReceiver | null = null;
+        let controlResult: FridayRustHubAgentRunResumeResult | null = null;
+        // Typed as the WIDE `Uint8Array` (matching `InboundContext.sessionKey`) so the
+        // `agree()`-derived key (`Uint8Array<ArrayBufferLike>`) assigns without a buffer-kind mismatch.
+        let resumeSessionKey: Uint8Array = new Uint8Array(0);
+
+        const timer = setTimeout(() => {
+          fail(unavailable("Sealed agent-run client resume timed out awaiting a result."));
+        }, timeoutMs);
+        if (typeof timer.unref === "function") timer.unref();
+
+        function teardown(): void {
+          clearTimeout(timer);
+          if (receiver) {
+            receiver.removeAllListeners();
+          }
+          if (socket) {
+            socket.removeAllListeners();
+            socket.on("error", () => {});
+            try {
+              socket.destroy();
+            } catch {
+              // best-effort; the result is already decided.
+            }
+          }
+        }
+        function succeed(result: FridayRustHubAgentRunResumeResult): void {
+          if (settled) return;
+          settled = true;
+          teardown();
+          resolve(result);
+        }
+        function fail(error: FridayDomainError): void {
+          if (settled) return;
+          settled = true;
+          teardown();
+          reject(error);
+        }
+        // The server ending the session BEFORE a control result is the fail-closed path (forged peer /
+        // bad blob / the server ran nothing). A control result already settled ⇒ guarded no-op.
+        function onClose(): void {
+          if (controlResult) {
+            succeed(controlResult);
+            return;
+          }
+          fail(unavailable("Sealed agent-run client resume connection closed before a result."));
+        }
+        function onInbound(payload: Buffer): void {
+          let inbound: InboundEnvelope;
+          try {
+            inbound = openInbound(resumeSessionKey, payload);
+          } catch {
+            fail(unavailable("Sealed agent-run client resume could not open an inbound envelope."));
+            return;
+          }
+          if (inbound.kind !== "AgentRunControlResult") {
+            fail(unavailable("Sealed agent-run client resume received an unknown message shape."));
+            return;
+          }
+          const parsed = parseControlResult(inbound.fields);
+          if (!parsed) {
+            fail(unavailable("Sealed agent-run client resume result is missing a required ref."));
+            return;
+          }
+          // A server REFUSAL (`accepted=false`) is a SUCCESSFUL relay of a refusal outcome — resolve
+          // with it (the caller inspects `accepted`), it is NOT a transport failure.
+          controlResult = parsed;
+          succeed(parsed);
+        }
+
+        void (async () => {
+          // (1) RAW TCP connect (NOT new WebSocket(url)) — preamble first, like dispatch.
+          let connected: Socket;
+          try {
+            connected = await new Promise<Socket>((res, rej) => {
+              const s = connect({ host, port }, () => res(s));
+              socket = s;
+              s.once("error", rej);
+            });
+          } catch {
+            fail(unavailable("Sealed agent-run client resume could not open a connection."));
+            return;
+          }
+          socket = connected;
+          socket.setNoDelay(true);
+
+          const reader = createPreambleReader(socket);
+          try {
+            // (2) preamble: write client pubkey → read server pubkey (32B) → read nonce (64B).
+            socket.write(frameBytes(keypair.publicKey));
+            const serverPub = await reader.readFrame();
+            if (serverPub.length !== X25519_PUBKEY_LEN) {
+              throw new Error("server pubkey wrong width");
+            }
+            const sessionNonce = await reader.readFrame();
+            if (sessionNonce.length !== SESSION_NONCE_LEN) {
+              throw new Error("session nonce wrong width");
+            }
+
+            // (3) derive the session key (X25519 + HKDF) over the agreed peer pubkey.
+            const sessionKey = agree(keypair.secret, serverPub);
+            resumeSessionKey = sessionKey;
+
+            // (4) hand off to the WS layer over the SAME socket: manual RFC6455 upgrade, then
+            // Sender/Receiver.
+            const { socket: sock, leftover: preambleLeftover } = reader.takeover();
+            if (preambleLeftover.length > 0) {
+              throw new Error("unexpected buffered bytes before ws upgrade");
+            }
+            const leftover = await wsClientUpgrade(sock, host, port);
+
+            const sender = new wsRuntime.Sender(sock, undefined, () => randomBytes(4));
+            const recv = new wsRuntime.Receiver({ isServer: false, binaryType: "nodebuffer", skipUTF8Validation: true });
+            receiver = recv;
+
+            recv.on("message", (data: Buffer, isBinary: boolean) => {
+              if (!isBinary) {
+                fail(unavailable("Sealed agent-run client resume received a non-binary frame."));
+                return;
+              }
+              onInbound(data);
+            });
+            recv.on("conclude", onClose);
+            recv.on("error", () => {
+              fail(unavailable("Sealed agent-run client resume received a malformed WS frame."));
+            });
+
+            sock.on("data", (chunk: Buffer) => recv.write(chunk));
+            sock.on("error", () => {
+              fail(unavailable("Sealed agent-run client resume connection error."));
+            });
+            sock.on("close", onClose);
+            if (leftover.length > 0) {
+              recv.write(leftover);
+            }
+
+            // (5) seal + send the AgentRunResume envelope (built by the pure, wire-tested
+            // `buildResumeEnvelope` — `{run_id, signed_blob}`, the blob relayed VERBATIM; INV-1).
+            const envelope = buildResumeEnvelope(request.runId, request.opaqueSignedBlob);
+            sealAndSend(sender, sessionKey, envelope);
+          } catch {
+            fail(unavailable("Sealed agent-run client resume handshake failed."));
           }
         })();
       });

--- a/src/api/runtime/friday-api-runtime.ts
+++ b/src/api/runtime/friday-api-runtime.ts
@@ -139,8 +139,14 @@ import { createFridayCloudWorkerSetupService } from "#cloud-workers";
 // execrun B1-compose (DARK): the composition repoints routeStartRun to the PROVEN sealed WS
 // client (the real ECDH handshake) via its service adapter + a SecureStore X25519-SECRET resolver
 // (the ECDH model — REPLACES #612's symmetric session-key resolver, which was the wrong shape).
-import { createFridayRustHubAgentRunSealedClientService } from "../mission-spine/friday-rust-hub-agent-run-sealed-client-service.js";
-import type { FridayRustHubAgentRunSealedClientService } from "../mission-spine/friday-rust-hub-agent-run-sealed-client-service.js";
+import {
+  createFridayRustHubAgentRunSealedClientService,
+  isPausedDispatchOutcome,
+} from "../mission-spine/friday-rust-hub-agent-run-sealed-client-service.js";
+import type {
+  FridayRustHubAgentRunSealedClientService,
+  FridayRustHubAgentRunSealedClientServiceDispatchOutcome,
+} from "../mission-spine/friday-rust-hub-agent-run-sealed-client-service.js";
 import type { FridayRustHubAgentRunConstraints } from "../mission-spine/friday-rust-hub-agent-run-ws-sealed-client.js";
 import { createFridayRustHubRunContinuityProjectorService } from "../mission-spine/friday-rust-hub-run-continuity-projector-service.js";
 import type { FridayRustHubRunContinuityProjectorService } from "../mission-spine/friday-rust-hub-run-continuity-projector-service.js";
@@ -1276,8 +1282,10 @@ async function composeRustReadOnlyAgentRun(args: {
   // (2) Dispatch the run over the SEALED WS client (B1). The client runs the ECDH handshake +
   // builds the auth_proof from `clientSecret` INTERNALLY; refs-only result; fail-closed on error.
   // leg A: a dispatch throw is the sealed-WS "closed-before-the-body" / transport surface —
-  // log {run_id, leg=dispatch, code} before rethrowing so the spend ties to this leg.
-  let wsResult;
+  // log {run_id, leg=dispatch, code} before rethrowing so the spend ties to this leg. Typed as the
+  // discriminated union so the `outcome === "paused"` narrowing below (and the result narrowing
+  // after the paused early-return) is sound.
+  let wsResult: FridayRustHubAgentRunSealedClientServiceDispatchOutcome;
   try {
     wsResult = await args.wsClient.dispatchRun({
       runId: args.runId,
@@ -1299,6 +1307,72 @@ async function composeRustReadOnlyAgentRun(args: {
       err instanceof FridayDomainError ? err.code : "dispatch_error",
     );
     throw err;
+  }
+
+  // (A3 courier) PAUSED outcome — the Rust loop gate PAUSED a mutating tool and the courier settled
+  // with a refs-only paused outcome (approval nonce + action digest + summary; NO signing material,
+  // INV-1). This reaches here ONLY when the courier's default-off run-control flag is on AND the
+  // server paused; with the flag off the courier never returns a paused outcome, so this whole branch
+  // is UNREACHABLE and the path below is byte-identical to today. (A read-only run can never pause —
+  // this branch is also DARK until a LATER PR relaxes clause 2 to admit a mutating run.)
+  //
+  // We MUST NOT route a paused outcome through the delivered-body readback (it has no body ⇒ it would
+  // fail-close at the readback gate before projecting). Instead we BRANCH EARLY: project an HONEST
+  // non-Finished continuity row via `loopStatus:"Paused"` (the projector maps it to the terminal
+  // "cancelled" status — a non-error resumable stop, never a fake "finished"; INV-5 refs-only — the
+  // row stores only the pause refs, NEVER the answer/summary body). The returned result carries an
+  // EMPTY `response` (no body exists yet — the run paused pending approval) and a 0 tool count.
+  if (isPausedDispatchOutcome(wsResult)) {
+    const pausedAtIso = args.nowIso();
+    const pausedProjection = args.db.withWriteTransaction((db) =>
+      args.projector.project(db, {
+        truthLabel: "rust_wired_dev",
+        proofOnly: true,
+        // `ok` is the receipt-well-formed flag (a fixed `true` on the receipt type — the same value
+        // every non-finished mapping uses, e.g. Bounded/Errored); the NON-finished semantics of a
+        // pause are carried by `loopStatus:"Paused"` → the projector's "cancelled" status mapping,
+        // NOT by this flag.
+        ok: true,
+        runId: args.runId,
+        routeId: `${args.providerId}:${args.model}`,
+        providerId: args.providerId,
+        model: args.model,
+        // HONEST non-Finished status: the projector maps "Paused" → the terminal "cancelled" run
+        // status (a resumable, non-error stop) — NEVER a fabricated "completed"/"finished".
+        loopStatus: "Paused",
+        // A paused run executed reads (turns/tools) up to the pause; surface the carried counts when
+        // present (absent ⇒ 0, an old server). Counts are refs, never a body.
+        turns: 0,
+        executedTools: 0,
+        // No answer body exists for a paused run — store a body REF over the pause refs (NEVER the
+        // answer/summary body). The action digest is the run's fingerprint at the pause point.
+        finalMessageSha256: wsResult.actionDigest,
+        finalMessageLen: 0,
+        auditChainVerified: false,
+        usagePromptTokens: 0,
+        usageCompletionTokens: 0,
+        usageTotalTokens: 0,
+        completedAtIso: pausedAtIso,
+      }),
+    );
+    // A pause is NOT a fail-closed 503 — it is an honest non-Finished settle that returns a row.
+    // Log it body-free (run_id + leg) on its OWN line so it is never confused with a 503.
+    console.warn(
+      `[friday][rust-agent-run] paused-pending-approval run_id=${args.runId} leg=paused status=${pausedProjection.status}`,
+    );
+    return {
+      runId: args.runId,
+      // The projected status is the HONEST terminal mapping of a pause ("cancelled") — NOT Finished.
+      status: pausedProjection.status as FridayAgentRuntimeResult["status"],
+      // No body exists for a paused run — the empty response keeps the owner-sealed summary OUT of
+      // plaintext (INV-5 refs-only). A LATER PR's resume leg delivers the answer after approval.
+      response: "",
+      toolCallCount: 0,
+      durationMs: 0,
+      usageInput: 0,
+      usageOutput: 0,
+      finalResponse: "",
+    };
   }
 
   // (3) Owner-gated body readback (slice-3). The body is released ONLY to the matching
@@ -4445,6 +4519,11 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
       ?? createFridayRustHubAgentRunSealedClientService({
         host: process.env.FRIDAY_HUB_AGENT_RUN_WS_HOST ?? "127.0.0.1",
         port: readRustAgentRunWsPort(process.env.FRIDAY_HUB_AGENT_RUN_WS_PORT),
+        // (A3 courier) Forward the DEFAULT-OFF run-control flag to the courier. When false (default)
+        // the courier's paused/resume behavior is inert (byte-identical to today); when true it
+        // admits a server `AgentRunPaused` (paused outcome) + relays an opaque approval. Resolved in
+        // ONE place (`resolveAgentRunControlViaRust` in friday-hub-bootstrap.ts) → `deps`.
+        ...(deps.agentRunControlViaRust === true ? { agentRunControlViaRust: true } : {}),
       });
     const rustContinuityProjector =
       deps.rustAgentRunContinuityProjector ?? createFridayRustHubRunContinuityProjectorService();

--- a/src/api/runtime/friday-api-runtime.types.ts
+++ b/src/api/runtime/friday-api-runtime.types.ts
@@ -331,6 +331,22 @@ export interface CreateFridayApiRuntimeDeps {
    */
   routeAgentRunViaRust?: boolean;
   /**
+   * GATE-AGENT-REPLACE A3 courier (DARK): the master ON/OFF (resolved boolean) for the
+   * pause/resume PRODUCT TRANSPORT. DEFAULT-FALSE — leave unset in production/runtime. Mirrors the
+   * Phase-2 Rust server's default-off `FRIDAY_AGENT_RUN_CONTROL_VIA_RUST` flag posture EXACTLY.
+   * When FALSE (default): the sealed WS courier's new `AgentRunPaused` inbound branch fails closed
+   * (a paused frame is an unknown message) and its `resumeWithApproval` relay is inert — so the
+   * compose path NEVER sees a paused outcome and behavior is BYTE-IDENTICAL to today. When TRUE:
+   * the courier admits a server `AgentRunPaused` (settling with a refs-only paused outcome →
+   * compose projects an honest non-Finished row) and relays an opaque operator-signed approval over
+   * a fresh sealed session. This flag ADMITS the ability to handle a paused run + relay a signature;
+   * it admits NO mutating run (the read-only qualifier stays hard — a SEPARATE later PR). Sourced in
+   * bootstrap from `FRIDAY_AGENT_RUN_CONTROL_VIA_RUST` / explicit config via
+   * `resolveAgentRunControlViaRust`. When unset/false the courier is constructed but its new
+   * behavior is never reached (byte-identical 503 / result paths untouched).
+   */
+  agentRunControlViaRust?: boolean;
+  /**
    * providers-bridge cut-over (DARK): the master ON/OFF (resolved boolean) for routing
    * the retired Tier-2 PROVIDER surfaces — `providers.detect` (setup routes) and
    * `providers.doctor` / `providers.validate` / `capabilities.doctor` (provider routes)

--- a/src/hub/bootstrap/hub-helpers.ts
+++ b/src/hub/bootstrap/hub-helpers.ts
@@ -1945,6 +1945,16 @@ export interface FridayHubConfig {
    */
   routeAgentRunViaRust?: boolean;
   /**
+   * GATE-AGENT-REPLACE A3 courier (DARK): master ON/OFF arming the pause/resume PRODUCT
+   * TRANSPORT (the sealed WS courier's `AgentRunPaused` inbound + `resumeWithApproval` relay).
+   * DEFAULT-FALSE — production hub creation must leave this unset so the courier's paused/resume
+   * behavior is inert and the compose path is byte-identical to today. Resolved (config-explicit
+   * wins, else `FRIDAY_AGENT_RUN_CONTROL_VIA_RUST`) by `resolveAgentRunControlViaRust` and fed into
+   * the api-runtime deps. Mirrors the Phase-2 Rust server's default-off flag of the SAME name; it
+   * admits NO mutating run (the read-only qualifier stays hard — a SEPARATE later PR).
+   */
+  agentRunControlViaRust?: boolean;
+  /**
    * providers-bridge cut-over (DARK): master ON/OFF for routing the retired Tier-2
    * PROVIDER surfaces (`providers.detect` / `providers.doctor` / `providers.validate` /
    * `capabilities.doctor`) to the merged Rust `hub_providers_detect` /

--- a/src/hub/friday-hub-bootstrap.ts
+++ b/src/hub/friday-hub-bootstrap.ts
@@ -933,6 +933,36 @@ export function resolveRouteAgentRunViaRust(
 }
 
 /**
+ * GATE-AGENT-REPLACE A3 courier (DARK): single source of truth resolving the
+ * `agentRunControlViaRust` flag from (1) an EXPLICIT {@link FridayHubConfig.agentRunControlViaRust}
+ * and, only as a fallback, (2) the `FRIDAY_AGENT_RUN_CONTROL_VIA_RUST` env var — the operator knob
+ * that arms the pause/resume PRODUCT TRANSPORT (the sealed WS courier's `AgentRunPaused` inbound +
+ * `resumeWithApproval` relay) WITHOUT a source edit.
+ *
+ * It deliberately reuses the SAME env var name as the Phase-2 Rust server's default-off flag so the
+ * TS courier and the Rust server are armed by ONE operator knob — but it is consulted ONLY for the
+ * TS courier's client-side behavior; it grants NO mutating run (the read-only qualifier stays hard;
+ * relaxing it is a SEPARATE later PR).
+ *
+ * PRECEDENCE + PARSE mirror {@link resolveRouteAgentRunViaRust} EXACTLY: an explicit config boolean
+ * (true OR false) ALWAYS wins; the env is consulted ONLY when config does not specify. Case-
+ * insensitive, trimmed `"1"` or `"true"` ⇒ true; ABSENT / `""` / `"0"` / `"false"` / ANY other
+ * value ⇒ false. DEFAULT (both unset) ⇒ false, so the courier's paused/resume behavior stays inert
+ * and the compose path is byte-identical to today.
+ */
+export function resolveAgentRunControlViaRust(
+  configValue: boolean | undefined,
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  // Config explicit (true OR false) wins — env is the fallback for the unset gap only.
+  if (typeof configValue === "boolean") {
+    return configValue;
+  }
+  const raw = (env.FRIDAY_AGENT_RUN_CONTROL_VIA_RUST ?? "").trim().toLowerCase();
+  return raw === "1" || raw === "true";
+}
+
+/**
  * providers-bridge cut-over (DARK): single source of truth resolving the
  * `routeProvidersViaRust` flag from (1) an EXPLICIT
  * {@link FridayHubConfig.routeProvidersViaRust} and, only as a fallback, (2) the
@@ -7086,6 +7116,14 @@ export async function createFridayHub(
     // set (the default) this is `false`, so the `=== true` gate is never satisfied → the
     // predicate is never evaluated → byte-identical to today's fail-closed 503.
     routeAgentRunViaRust: resolveRouteAgentRunViaRust(config.routeAgentRunViaRust),
+    // GATE-AGENT-REPLACE A3 courier (DARK): default-false master flag arming the pause/resume
+    // PRODUCT TRANSPORT (the sealed WS courier's `AgentRunPaused` inbound + `resumeWithApproval`
+    // relay). SINGLE SOURCE OF TRUTH = `resolveAgentRunControlViaRust` (explicit config wins; else
+    // the `FRIDAY_AGENT_RUN_CONTROL_VIA_RUST` env knob, case-insensitive "1"/"true" → true; anything
+    // else incl. unset → false). With nothing set (the default) this is `false`, so the courier's
+    // paused/resume behavior is inert → the compose path never sees a paused outcome → byte-identical
+    // to today. It admits NO mutating run (the read-only qualifier stays hard — a SEPARATE later PR).
+    agentRunControlViaRust: resolveAgentRunControlViaRust(config.agentRunControlViaRust),
     // providers-bridge cut-over (DARK): default-false master flag for routing the retired
     // Tier-2 PROVIDER surfaces to the merged Rust bins. SINGLE SOURCE OF TRUTH =
     // `resolveRouteProvidersViaRust` (explicit config wins; else FRIDAY_ROUTE_PROVIDERS_VIA_RUST,

--- a/src/hub/index.ts
+++ b/src/hub/index.ts
@@ -37,6 +37,7 @@ export {
   resolveFridayChannelDisabledToolNames,
   resolveFridayChannelSessionKey,
   resolveFridayHubConfig,
+  resolveAgentRunControlViaRust,
   resolveRouteAgentRunViaRust,
   resolveRouteProvidersViaRust,
   resolveRouteWorkflowsViaRust,

--- a/test/interop/friday-rust-hub-agent-run-compose-adapter-runner.ts
+++ b/test/interop/friday-rust-hub-agent-run-compose-adapter-runner.ts
@@ -53,6 +53,13 @@ async function main(): Promise<void> {
 
   try {
     const result = await service.dispatchRun({ runId, task, forwardedPrincipal: principal, clientSecret: secret });
+    // (A3 courier) dispatch returns a discriminated union (result | paused). This runner drives the
+    // read-only path with the run-control flag OFF, so a paused outcome is unreachable here — narrow
+    // on the `outcome` discriminant so the answer refs are read only on the result member.
+    if ("outcome" in result && result.outcome === "paused") {
+      process.stdout.write(JSON.stringify({ ok: false, code: "UNEXPECTED_PAUSE", httpStatus: 0 }) + "\n");
+      process.exit(4);
+    }
     process.stdout.write(
       JSON.stringify({
         ok: true,

--- a/test/interop/friday-rust-hub-agent-run-sealed-client-runner.ts
+++ b/test/interop/friday-rust-hub-agent-run-sealed-client-runner.ts
@@ -47,6 +47,13 @@ async function main(): Promise<void> {
 
   try {
     const result = await client.dispatchRun({ runId, task, forwardedPrincipal: principal });
+    // (A3 courier) dispatch returns a discriminated union (result | paused). This runner drives the
+    // read-only path with the run-control flag OFF, so a paused outcome is unreachable here — narrow
+    // on the `outcome` discriminant so the answer refs are read only on the result member.
+    if ("outcome" in result && result.outcome === "paused") {
+      process.stdout.write(JSON.stringify({ ok: false, code: "UNEXPECTED_PAUSE", httpStatus: 0 }) + "\n");
+      process.exit(4);
+    }
     process.stdout.write(
       JSON.stringify({
         ok: true,

--- a/test/unit/api/mission-spine/friday-rust-hub-agent-run-sealed-client-service.test.ts
+++ b/test/unit/api/mission-spine/friday-rust-hub-agent-run-sealed-client-service.test.ts
@@ -1,12 +1,30 @@
 import { describe, expect, it, vi } from "vitest";
 
 import { FridayDomainError } from "../../../../src/errors/friday-domain-error.js";
-import { createFridayRustHubAgentRunSealedClientService } from "../../../../src/api/mission-spine/friday-rust-hub-agent-run-sealed-client-service.js";
+import {
+  createFridayRustHubAgentRunSealedClientService,
+  isPausedDispatchOutcome,
+  type FridayRustHubAgentRunSealedClientServiceDispatchOutcome,
+  type FridayRustHubAgentRunSealedClientServiceResult,
+} from "../../../../src/api/mission-spine/friday-rust-hub-agent-run-sealed-client-service.js";
 import type {
   CreateFridayRustHubAgentRunSealedClientOptions,
+  FridayRustHubAgentRunPausedOutcome,
+  FridayRustHubAgentRunResumeRequest,
+  FridayRustHubAgentRunResumeResult,
   FridayRustHubAgentRunSealedClient,
   FridayRustHubAgentRunSealedResult,
 } from "../../../../src/api/mission-spine/friday-rust-hub-agent-run-ws-sealed-client.js";
+
+/** Narrow a service dispatch outcome to the refs-only result (asserts it is NOT paused). */
+function asResultOutcome(
+  outcome: FridayRustHubAgentRunSealedClientServiceDispatchOutcome,
+): FridayRustHubAgentRunSealedClientServiceResult {
+  if (isPausedDispatchOutcome(outcome)) {
+    throw new Error("expected a refs-only result, got a paused outcome");
+  }
+  return outcome;
+}
 
 // execrun B1-compose (DARK): the service ADAPTER that lets compose drive the PROVEN sealed WS
 // client through a `dispatchRun({...,clientSecret})` seam over the REAL ECDH protocol. These tests
@@ -16,10 +34,12 @@ import type {
 
 const SECRET = new Uint8Array(32).fill(7);
 
-/** A fake underlying sealed client + a recorder of how it was constructed/dispatched. */
+/** A fake underlying sealed client + a recorder of how it was constructed/dispatched/resumed. */
 function makeFakeClient(behavior: {
-  result?: FridayRustHubAgentRunSealedResult;
+  result?: FridayRustHubAgentRunSealedResult | FridayRustHubAgentRunPausedOutcome;
   reject?: unknown;
+  resumeResult?: FridayRustHubAgentRunResumeResult;
+  resumeReject?: unknown;
 }) {
   const constructed: CreateFridayRustHubAgentRunSealedClientOptions[] = [];
   const dispatched: Array<{
@@ -29,6 +49,7 @@ function makeFakeClient(behavior: {
     sessionKey?: string;
     constraints?: { readOnly?: boolean; disabledTools?: readonly string[]; maxTurns?: number };
   }> = [];
+  const resumed: FridayRustHubAgentRunResumeRequest[] = [];
   const createClient = vi.fn(
     (options: CreateFridayRustHubAgentRunSealedClientOptions): FridayRustHubAgentRunSealedClient => {
       constructed.push(options);
@@ -40,10 +61,20 @@ function makeFakeClient(behavior: {
           }
           return behavior.result!;
         }),
+        resumeWithApproval: vi.fn(async (req: FridayRustHubAgentRunResumeRequest) => {
+          resumed.push(req);
+          if (behavior.resumeReject !== undefined) {
+            throw behavior.resumeReject;
+          }
+          if (!behavior.resumeResult) {
+            throw new Error("resumeWithApproval not scripted for this fake");
+          }
+          return behavior.resumeResult;
+        }),
       };
     },
   );
-  return { createClient, constructed, dispatched };
+  return { createClient, constructed, dispatched, resumed };
 }
 
 describe("createFridayRustHubAgentRunSealedClientService (B1-compose, dark, adapter)", () => {
@@ -142,8 +173,9 @@ describe("createFridayRustHubAgentRunSealedClientService (B1-compose, dark, adap
     });
 
     expect(result).toEqual({ truthLabel: "rust_wired", runId: "run-1", status: "no_answer" });
-    expect(result.answerSha256).toBeUndefined();
-    expect(result.answerLen).toBeUndefined();
+    const refs = asResultOutcome(result);
+    expect(refs.answerSha256).toBeUndefined();
+    expect(refs.answerLen).toBeUndefined();
   });
 
   it("surfaces the underlying client's FridayDomainError (503) unchanged on a closed session", async () => {
@@ -267,6 +299,139 @@ describe("createFridayRustHubAgentRunSealedClientService (B1-compose, dark, adap
         clientSecret: new Uint8Array(16),
       }),
     ).rejects.toMatchObject({ httpStatus: 503 });
+  });
+
+  // ── (A3 courier) flag passthrough + paused/resume relay ───────────────────────────────────────
+  it("(A3) does NOT forward agentRunControlViaRust to the inner client when the flag is OFF (default)", async () => {
+    const fake = makeFakeClient({ result: deliveredResult() });
+    const service = createFridayRustHubAgentRunSealedClientService({
+      port: 4123,
+      createClient: fake.createClient,
+      // agentRunControlViaRust omitted → default OFF
+    });
+    await service.dispatchRun({
+      runId: "run-1",
+      task: "ping",
+      forwardedPrincipal: "owner-1",
+      clientSecret: SECRET,
+    });
+    // Flag-off ⇒ the option is OMITTED from the inner client construction (byte-identical to today).
+    expect("agentRunControlViaRust" in fake.constructed[0]).toBe(false);
+  });
+
+  it("(A3) forwards agentRunControlViaRust:true to the inner client when the flag is ON", async () => {
+    const fake = makeFakeClient({ result: deliveredResult() });
+    const service = createFridayRustHubAgentRunSealedClientService({
+      port: 4123,
+      createClient: fake.createClient,
+      agentRunControlViaRust: true,
+    });
+    await service.dispatchRun({
+      runId: "run-1",
+      task: "ping",
+      forwardedPrincipal: "owner-1",
+      clientSecret: SECRET,
+    });
+    expect(fake.constructed[0].agentRunControlViaRust).toBe(true);
+  });
+
+  it("(A3) surfaces a PAUSED dispatch outcome UNCHANGED (refs only — no signing material, INV-1)", async () => {
+    const paused: FridayRustHubAgentRunPausedOutcome = {
+      outcome: "paused",
+      truthLabel: "rust_wired",
+      runId: "run-9",
+      approvalId: "approval-nonce-abc",
+      actionDigest: "d".repeat(64),
+      ownerSealedSummary: "write_file",
+    };
+    const fake = makeFakeClient({ result: paused });
+    const service = createFridayRustHubAgentRunSealedClientService({
+      port: 4123,
+      createClient: fake.createClient,
+      agentRunControlViaRust: true,
+    });
+    const outcome = await service.dispatchRun({
+      runId: "run-9",
+      task: "edit notes",
+      forwardedPrincipal: "owner-1",
+      clientSecret: SECRET,
+    });
+    expect(isPausedDispatchOutcome(outcome)).toBe(true);
+    expect(outcome).toEqual(paused);
+  });
+
+  it("(A3) resumeWithApproval relays the OPAQUE blob + run id VERBATIM to the inner client (INV-1)", async () => {
+    const resumeResult: FridayRustHubAgentRunResumeResult = {
+      truthLabel: "rust_wired",
+      runId: "run-9",
+      op: "resume",
+      accepted: true,
+      status: "executed",
+      auditRef: "audit:abc",
+    };
+    const fake = makeFakeClient({ resumeResult });
+    const service = createFridayRustHubAgentRunSealedClientService({
+      port: 4123,
+      createClient: fake.createClient,
+      agentRunControlViaRust: true,
+    });
+    const blob = new Uint8Array([9, 8, 7, 6]);
+    const result = await service.resumeWithApproval({
+      runId: "run-9",
+      clientSecret: SECRET,
+      opaqueSignedBlob: blob,
+    });
+    expect(result).toEqual(resumeResult);
+    // INV-1: the blob is relayed VERBATIM (same bytes), and the adapter forwards ONLY {runId, blob}.
+    expect(fake.resumed).toHaveLength(1);
+    expect(fake.resumed[0].runId).toBe("run-9");
+    expect(Buffer.from(fake.resumed[0].opaqueSignedBlob).equals(Buffer.from(blob))).toBe(true);
+    expect(Object.keys(fake.resumed[0]).sort()).toEqual(["opaqueSignedBlob", "runId"]);
+  });
+
+  it("(A3) resumeWithApproval surfaces a REFUSAL (accepted=false) as a resolved outcome, not a throw", async () => {
+    const fake = makeFakeClient({
+      resumeResult: {
+        truthLabel: "rust_wired",
+        runId: "run-9",
+        op: "resume",
+        accepted: false,
+        status: "approval_replayed",
+      },
+    });
+    const service = createFridayRustHubAgentRunSealedClientService({
+      port: 4123,
+      createClient: fake.createClient,
+      agentRunControlViaRust: true,
+    });
+    const result = await service.resumeWithApproval({
+      runId: "run-9",
+      clientSecret: SECRET,
+      opaqueSignedBlob: new Uint8Array([1]),
+    });
+    expect(result.accepted).toBe(false);
+    expect(result.status).toBe("approval_replayed");
+  });
+
+  it("(A3) resumeWithApproval surfaces the inner client's FridayDomainError (503) unchanged", async () => {
+    const domainErr = new FridayDomainError(
+      "MISSION_SPINE_RUST_AGENT_RUN_SEALED_WS_CLIENT_UNAVAILABLE",
+      "Sealed agent-run client run-control is disabled (resume relay refused).",
+      { httpStatus: 503 },
+    );
+    const fake = makeFakeClient({ resumeReject: domainErr });
+    const service = createFridayRustHubAgentRunSealedClientService({
+      port: 4123,
+      createClient: fake.createClient,
+      agentRunControlViaRust: true,
+    });
+    await expect(
+      service.resumeWithApproval({
+        runId: "run-9",
+        clientSecret: SECRET,
+        opaqueSignedBlob: new Uint8Array([1]),
+      }),
+    ).rejects.toBe(domainErr);
   });
 });
 

--- a/test/unit/api/mission-spine/friday-rust-hub-agent-run-ws-sealed-client.test.ts
+++ b/test/unit/api/mission-spine/friday-rust-hub-agent-run-ws-sealed-client.test.ts
@@ -2,8 +2,14 @@ import { describe, expect, it } from "vitest";
 
 import { FridayDomainError } from "../../../../src/errors/friday-domain-error.js";
 import {
+  buildResumeEnvelope,
+  createFridayRustHubAgentRunSealedClient,
+  handlePaused,
   handleResult,
   handleServerClose,
+  parseControlResult,
+  routeInboundEnvelope,
+  type FridayRustHubAgentRunSealedDispatchOutcome,
   type FridayRustHubAgentRunSealedResult,
   type InboundContext,
 } from "../../../../src/api/mission-spine/friday-rust-hub-agent-run-ws-sealed-client.js";
@@ -20,17 +26,20 @@ import {
 // also asserts the client surfaces NO body and the server still serves Ok(1).
 
 /** A fake InboundContext that records exactly one terminal settle (succeed XOR fail). */
-function makeCtx(): {
+function makeCtx(opts: { controlEnabled?: boolean } = {}): {
   ctx: InboundContext;
-  succeeded: () => FridayRustHubAgentRunSealedResult | undefined;
+  succeeded: () => FridayRustHubAgentRunSealedDispatchOutcome | undefined;
   failed: () => FridayDomainError | undefined;
 } {
-  let succeededWith: FridayRustHubAgentRunSealedResult | undefined;
+  let succeededWith: FridayRustHubAgentRunSealedDispatchOutcome | undefined;
   let failedWith: FridayDomainError | undefined;
   let settled = false;
   const ctx: InboundContext = {
     sessionKey: new Uint8Array(0),
     refs: null,
+    // (A3 courier) DEFAULT-OFF run-control flag — when omitted the paused branch is NOT recognized
+    // (byte-identical to today). Tests opt in explicitly to exercise the paused settle.
+    ...(opts.controlEnabled !== undefined ? { controlEnabled: opts.controlEnabled } : {}),
     succeed(result) {
       if (settled) return;
       settled = true;
@@ -43,6 +52,16 @@ function makeCtx(): {
     },
   };
   return { ctx, succeeded: () => succeededWith, failed: () => failedWith };
+}
+
+/** Narrow a settled outcome to the legacy refs-only result (asserts it is NOT a paused outcome). */
+function asResult(
+  outcome: FridayRustHubAgentRunSealedDispatchOutcome | undefined,
+): FridayRustHubAgentRunSealedResult | undefined {
+  if (outcome && "outcome" in outcome && outcome.outcome === "paused") {
+    throw new Error("expected a refs-only result, got a paused outcome");
+  }
+  return outcome as FridayRustHubAgentRunSealedResult | undefined;
 }
 
 describe("friday-rust-hub-agent-run-ws-sealed-client settle handlers (leg-A decouple)", () => {
@@ -145,7 +164,7 @@ describe("friday-rust-hub-agent-run-ws-sealed-client settle handlers (leg-A deco
     });
 
     expect(failed()).toBeUndefined();
-    const result = succeeded();
+    const result = asResult(succeeded());
     expect(result?.answerLen).toBeUndefined();
     expect(result?.turns).toBeUndefined();
     expect(result && "body" in result).toBe(false);
@@ -163,11 +182,233 @@ describe("friday-rust-hub-agent-run-ws-sealed-client settle handlers (leg-A deco
       executed_tools: 3,
     });
 
-    const result = succeeded();
+    const result = asResult(succeeded());
     expect(result?.turns).toBe(5);
     expect(result?.executedTools).toBe(3);
     // Token counts are DEFERRED server-side ⇒ omitted (never 0-faked).
     expect(result?.promptTokens).toBeUndefined();
     expect(result?.completionTokens).toBeUndefined();
+  });
+});
+
+// (A3 courier) The pause/resume PRODUCT TRANSPORT — DARK, gated DEFAULT-OFF behind the courier's
+// `agentRunControlViaRust` flag. These tests drive the EXPORTED settle handlers + the kind router
+// against a fake InboundContext WITHOUT a socket. They prove:
+//   (a) AgentRunPaused inbound → a refs-only paused outcome carrying the RIGHT refs (INV-1: no
+//       signing material; the nonce→approvalId, action_digest→actionDigest, summary→ownerSealedSummary
+//       mapping matches the merged `Message::AgentRunPaused` wire EXACTLY).
+//   (b) resumeWithApproval sends `AgentRunResume {run_id, signed_blob}` UNCHANGED (the opaque blob
+//       relayed verbatim; INV-1 pure courier) and parses the `AgentRunControlResult` reply.
+//   (c) FLAG-OFF / no-pause is byte-identical: a flag-off `AgentRunPaused` is an unknown message ⇒
+//       fail-closed (the SAME 503 as any unknown frame), and the `AgentRunResult` path is unchanged.
+describe("friday-rust-hub-agent-run-ws-sealed-client A3 courier (pause/resume, dark, flag-gated)", () => {
+  const PAUSED_FIELDS = {
+    kind: "AgentRunPaused",
+    run_id: "run-9",
+    nonce: "approval-nonce-abc",
+    action_digest: "d".repeat(64),
+    summary: "write_file: /workspace/notes.md",
+  };
+
+  it("(a) AgentRunPaused inbound → a refs-only PAUSED outcome carrying the right refs (flag ON)", () => {
+    const { ctx, succeeded, failed } = makeCtx({ controlEnabled: true });
+    handlePaused(ctx, PAUSED_FIELDS);
+
+    expect(failed()).toBeUndefined();
+    const outcome = succeeded();
+    // The mapping matches the merged `AgentRunPaused` wire EXACTLY: nonce→approvalId,
+    // action_digest→actionDigest, summary→ownerSealedSummary. There is NO expiresAt on the wire.
+    expect(outcome).toEqual({
+      outcome: "paused",
+      truthLabel: "rust_wired",
+      runId: "run-9",
+      approvalId: "approval-nonce-abc",
+      actionDigest: "d".repeat(64),
+      ownerSealedSummary: "write_file: /workspace/notes.md",
+    });
+    // INV-1: the paused outcome carries NO signing material / private key / blob / mutation body.
+    const keys = Object.keys(outcome ?? {});
+    for (const banned of ["signedBlob", "signed_blob", "privateKey", "signingKey", "body", "expiresAt"]) {
+      expect(keys).not.toContain(banned);
+    }
+  });
+
+  it("(a') a flag-ON AgentRunPaused via the kind ROUTER settles paused (not the unknown→fail path)", () => {
+    const { ctx, succeeded, failed } = makeCtx({ controlEnabled: true });
+    routeInboundEnvelope(ctx, { kind: "AgentRunPaused", fields: PAUSED_FIELDS });
+
+    expect(failed()).toBeUndefined();
+    const outcome = succeeded();
+    expect(outcome && "outcome" in outcome && outcome.outcome).toBe("paused");
+  });
+
+  it("(a'') a paused frame MISSING a required ref (nonce) fails closed (503) — refs-surface contract", () => {
+    const { ctx, succeeded, failed } = makeCtx({ controlEnabled: true });
+    handlePaused(ctx, { kind: "AgentRunPaused", run_id: "run-9", action_digest: "d".repeat(64) });
+
+    expect(succeeded()).toBeUndefined();
+    expect(failed()?.httpStatus).toBe(503);
+    expect(failed()?.message).toContain("pause is missing a required ref");
+  });
+
+  it("(a''') a paused frame WITHOUT a summary omits ownerSealedSummary (optional, never fabricated)", () => {
+    const { ctx, succeeded } = makeCtx({ controlEnabled: true });
+    handlePaused(ctx, {
+      kind: "AgentRunPaused",
+      run_id: "run-9",
+      nonce: "approval-nonce-abc",
+      action_digest: "d".repeat(64),
+    });
+    const outcome = succeeded();
+    expect(outcome).toEqual({
+      outcome: "paused",
+      truthLabel: "rust_wired",
+      runId: "run-9",
+      approvalId: "approval-nonce-abc",
+      actionDigest: "d".repeat(64),
+    });
+    expect(outcome && "ownerSealedSummary" in outcome).toBe(false);
+  });
+
+  it("(c) FLAG-OFF: an AgentRunPaused is an UNKNOWN message ⇒ fail-closed (byte-identical to today)", () => {
+    // controlEnabled defaults OFF (omitted) — the SAME ctx shape today's code produces.
+    const { ctx, succeeded, failed } = makeCtx();
+    routeInboundEnvelope(ctx, { kind: "AgentRunPaused", fields: PAUSED_FIELDS });
+
+    expect(succeeded()).toBeUndefined();
+    const err = failed();
+    expect(err?.httpStatus).toBe(503);
+    // The EXACT same 503 message any unknown frame produces — a paused frame is not special with
+    // the flag off, so the settle is indistinguishable from today's unknown→fail-closed.
+    expect(err?.message).toContain("unknown message shape");
+  });
+
+  it("(c') FLAG-OFF: an AgentRunResult still settles UNCHANGED (the result path is flag-independent)", () => {
+    const { ctx, succeeded, failed } = makeCtx(); // flag off
+    routeInboundEnvelope(ctx, {
+      kind: "AgentRunResult",
+      fields: { kind: "AgentRunResult", run_id: "run-1", status: "finished" },
+    });
+    expect(failed()).toBeUndefined();
+    expect(succeeded()).toEqual({ truthLabel: "rust_wired", runId: "run-1", status: "finished" });
+  });
+
+  it("(c'') FLAG-ON: an AgentRunResult still settles UNCHANGED (the flag never touches the result path)", () => {
+    const { ctx, succeeded, failed } = makeCtx({ controlEnabled: true });
+    routeInboundEnvelope(ctx, {
+      kind: "AgentRunResult",
+      fields: { kind: "AgentRunResult", run_id: "run-1", status: "finished", turns: 3, executed_tools: 2 },
+    });
+    expect(failed()).toBeUndefined();
+    expect(asResult(succeeded())).toEqual({
+      truthLabel: "rust_wired",
+      runId: "run-1",
+      status: "finished",
+      turns: 3,
+      executedTools: 2,
+    });
+  });
+
+  // ── (b) the AgentRunResume WIRE SHAPE — buildResumeEnvelope sends it unchanged ────────────────
+  it("(b) buildResumeEnvelope produces the EXACT merged AgentRunResume wire {run_id, signed_blob}", () => {
+    const blob = new Uint8Array([0, 1, 250, 255, 42]);
+    const envelope = buildResumeEnvelope("run-9", blob) as {
+      schema_version: number;
+      msg_id: string;
+      correlation_id: string;
+      sent_at: number;
+      message: Record<string, unknown>;
+    };
+    // The inner message matches the merged `Message::AgentRunResume` EXACTLY: kind + run_id +
+    // signed_blob. serde `Vec<u8>` is a JSON ARRAY of byte NUMBERS (NOT base64/hex) — the blob is
+    // relayed VERBATIM via Array.from (same encoding as the dispatch envelope's auth_proof).
+    expect(envelope.message).toEqual({
+      kind: "AgentRunResume",
+      run_id: "run-9",
+      signed_blob: [0, 1, 250, 255, 42],
+    });
+    // INV-1: the message carries ONLY {kind, run_id, signed_blob} — no auth_proof, no forwarded
+    // principal, no signing key, no derived/authored material. The blob is the operator's, opaque.
+    expect(Object.keys(envelope.message).sort()).toEqual(["kind", "run_id", "signed_blob"]);
+    expect(Array.isArray(envelope.message.signed_blob)).toBe(true);
+    // The signed_blob is the byte-array of the SAME bytes (no transform, no truncation, no re-encode).
+    expect(envelope.message.signed_blob).toEqual(Array.from(blob));
+    // Envelope framing mirrors the dispatch envelope (schema version + correlation id on run id).
+    expect(envelope.schema_version).toBe(12);
+    expect(envelope.correlation_id).toBe("agent-run-resume-run-9");
+  });
+
+  // ── parseControlResult: the resume reply parse (the OTHER half of test b) ─────────────────────
+  it("(b) parseControlResult maps an ACCEPTED AgentRunControlResult to a refs-only resume result", () => {
+    const parsed = parseControlResult({
+      kind: "AgentRunControlResult",
+      run_id: "run-9",
+      op: "resume",
+      accepted: true,
+      status: "executed",
+      audit_ref: "audit:abc123",
+    });
+    expect(parsed).toEqual({
+      truthLabel: "rust_wired",
+      runId: "run-9",
+      op: "resume",
+      accepted: true,
+      status: "executed",
+      auditRef: "audit:abc123",
+    });
+  });
+
+  it("(b') parseControlResult maps a REFUSAL (accepted=false) — a valid refusal outcome, not a parse error", () => {
+    const parsed = parseControlResult({
+      kind: "AgentRunControlResult",
+      run_id: "run-9",
+      op: "resume",
+      accepted: false,
+      status: "operator_vk_unprovisioned",
+    });
+    expect(parsed?.accepted).toBe(false);
+    expect(parsed?.status).toBe("operator_vk_unprovisioned");
+    expect(parsed && "auditRef" in parsed).toBe(false);
+  });
+
+  it("(b'') parseControlResult returns undefined for a frame missing a required ref / non-bool accepted", () => {
+    expect(parseControlResult({ run_id: "run-9", op: "resume", status: "executed" })).toBeUndefined();
+    expect(
+      parseControlResult({ run_id: "run-9", op: "resume", status: "executed", accepted: "yes" }),
+    ).toBeUndefined();
+    expect(parseControlResult({ op: "resume", accepted: true, status: "executed" })).toBeUndefined();
+  });
+
+  // ── resumeWithApproval: the relay method ──────────────────────────────────────────────────────
+  it("(b''') resumeWithApproval is FAIL-CLOSED when the run-control flag is OFF (relays nothing)", async () => {
+    const client = createFridayRustHubAgentRunSealedClient({
+      port: 1, // never dialed — the flag-off guard rejects before any connect
+      clientSecret: new Uint8Array(32).fill(7),
+    });
+    await expect(
+      client.resumeWithApproval({ runId: "run-9", opaqueSignedBlob: new Uint8Array([1, 2, 3]) }),
+    ).rejects.toMatchObject({ httpStatus: 503 });
+  });
+
+  it("(b'''') resumeWithApproval (flag ON) rejects an EMPTY blob before opening a socket (INV-1 guard)", async () => {
+    const client = createFridayRustHubAgentRunSealedClient({
+      port: 1,
+      clientSecret: new Uint8Array(32).fill(7),
+      agentRunControlViaRust: true,
+    });
+    await expect(
+      client.resumeWithApproval({ runId: "run-9", opaqueSignedBlob: new Uint8Array(0) }),
+    ).rejects.toMatchObject({ httpStatus: 503 });
+  });
+
+  it("(b''''') resumeWithApproval (flag ON) rejects a missing run id before opening a socket", async () => {
+    const client = createFridayRustHubAgentRunSealedClient({
+      port: 1,
+      clientSecret: new Uint8Array(32).fill(7),
+      agentRunControlViaRust: true,
+    });
+    await expect(
+      client.resumeWithApproval({ runId: "", opaqueSignedBlob: new Uint8Array([1, 2, 3]) }),
+    ).rejects.toMatchObject({ httpStatus: 503 });
   });
 });

--- a/test/unit/api/runtime/friday-api-runtime-rust-route-compose.test.ts
+++ b/test/unit/api/runtime/friday-api-runtime-rust-route-compose.test.ts
@@ -125,6 +125,35 @@ function makeStubWsClient() {
         answerLen: OWNER_BODY.length,
       };
     }),
+    // (A3 courier) The compose read-only path never resumes; this stub method is unused here.
+    resumeWithApproval: vi.fn(async () => {
+      throw new Error("resumeWithApproval not used by the read-only compose path");
+    }),
+  };
+  return { service, calls };
+}
+
+/**
+ * (A3 courier) A scripted-stub sealed WS client that settles every dispatch with a PAUSED outcome
+ * (the Rust loop gate paused a mutating tool). Refs only — no signing material (INV-1).
+ */
+function makeStubPausedWsClient() {
+  const calls: FridayRustHubAgentRunSealedClientServiceRequest[] = [];
+  const service: FridayRustHubAgentRunSealedClientService = {
+    dispatchRun: vi.fn(async (request: FridayRustHubAgentRunSealedClientServiceRequest) => {
+      calls.push(request);
+      return {
+        outcome: "paused" as const,
+        truthLabel: "rust_wired" as const,
+        runId: request.runId,
+        approvalId: "approval-nonce-xyz",
+        actionDigest: "d".repeat(64),
+        ownerSealedSummary: "write_file",
+      };
+    }),
+    resumeWithApproval: vi.fn(async () => {
+      throw new Error("resumeWithApproval not used by this paused-dispatch test");
+    }),
   };
   return { service, calls };
 }
@@ -295,6 +324,55 @@ describe("FridayApiRuntime — execrun S-F-compose (DARK) Rust-route composition
     // Exactly ONE TS continuity agent_run + usage row.
     expect(countRows(db, "friday_agent_runs", RUN_ID)).toBe(1);
     expect(countRows(db, "llm_usage_records", RUN_ID)).toBe(1);
+  });
+
+  it("(a-paused) (A3 courier) a PAUSED dispatch → HONEST non-Finished row (cancelled), refs-only, readback SKIPPED", async () => {
+    db = createTestDb();
+    const ws = makeStubPausedWsClient();
+    const readback = makeStubReadback(OWNER_PRINCIPAL);
+    const runtime = makeRuntime(db, {
+      routeAgentRunViaRust: true,
+      wsClient: ws.service,
+      readback: readback.service,
+    });
+
+    const result = (await callStartRoute(runtime, { ...QUALIFYING_BODY })) as {
+      runId: string;
+      response: string;
+      finalResponse?: string;
+      status: string;
+      toolCallCount: number;
+    };
+
+    // The dispatch ran; the paused branch was taken BEFORE the delivered-body readback (no readback
+    // call — a paused run has no body, and routing it through the readback would fail-close).
+    expect(ws.calls).toHaveLength(1);
+    expect(readback.calls).toHaveLength(0);
+
+    // The continuity row is projected HONESTLY: NOT "completed"/Finished — the projector maps the
+    // "Paused" loop status to the terminal "cancelled" run status (a resumable, non-error stop).
+    expect(result.status).toBe("cancelled");
+    // No body exists for a paused run — the response is empty (the owner-sealed summary is kept OUT
+    // of the plaintext response; INV-5 refs-only). A LATER PR's resume leg delivers the answer. The
+    // route omits an empty `finalResponse` (`result.finalResponse ? {...} : {}`), so it is undefined.
+    expect(result.response).toBe("");
+    expect(result.finalResponse).toBeUndefined();
+    expect(result.toolCallCount).toBe(0);
+
+    // Exactly ONE TS continuity row was projected (idempotent on run_id), with the cancelled status.
+    expect(countRows(db, "friday_agent_runs", RUN_ID)).toBe(1);
+    const rowStatus = db.withReadConnection((d) =>
+      (d.prepare("SELECT status FROM friday_agent_runs WHERE id = ?").get(RUN_ID) as { status: string }).status,
+    );
+    expect(rowStatus).toBe("cancelled");
+    // The projected row stores a body REF over the pause refs (the action digest) — NEVER the body.
+    const rowResponse = db.withReadConnection((d) =>
+      (d.prepare("SELECT response_text FROM friday_agent_runs WHERE id = ?").get(RUN_ID) as
+        | { response_text: string | null }
+        | undefined)?.response_text ?? "",
+    );
+    expect(rowResponse).toContain("rust-run-body-ref:");
+    expect(rowResponse).not.toBe(OWNER_BODY);
   });
 
   it("(b) flag OFF (default) → byte-identical 503; the WS path is NEVER touched", async () => {

--- a/test/unit/hub/friday-hub-bootstrap-env.test.ts
+++ b/test/unit/hub/friday-hub-bootstrap-env.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
 import { createRequire } from "node:module";
 import {
+  resolveAgentRunControlViaRust,
   resolveFridayCanonicalMutatingActionGate,
   resolveFridayHubConfig,
   resolveRouteAgentRunViaRust,
@@ -397,6 +398,36 @@ describe("resolveRouteAgentRunViaRust", () => {
     expect(resolveRouteAgentRunViaRust(false, { FRIDAY_ROUTE_AGENT_RUN_VIA_RUST: "1" })).toBe(false);
     expect(resolveRouteAgentRunViaRust(false, { FRIDAY_ROUTE_AGENT_RUN_VIA_RUST: "true" })).toBe(false);
     expect(resolveRouteAgentRunViaRust(false, emptyEnv())).toBe(false);
+  });
+});
+
+describe("resolveAgentRunControlViaRust (A3 courier pause/resume flag)", () => {
+  // DEFAULT-OFF: env unset → false → the courier's paused/resume behavior is inert (byte-identical).
+  it("defaults to false when neither config nor env is set", () => {
+    expect(resolveAgentRunControlViaRust(undefined, emptyEnv())).toBe(false);
+  });
+
+  it("parses FRIDAY_AGENT_RUN_CONTROL_VIA_RUST=1 / =true (case-insensitive, trimmed) as true", () => {
+    expect(resolveAgentRunControlViaRust(undefined, { FRIDAY_AGENT_RUN_CONTROL_VIA_RUST: "1" })).toBe(true);
+    expect(resolveAgentRunControlViaRust(undefined, { FRIDAY_AGENT_RUN_CONTROL_VIA_RUST: "true" })).toBe(true);
+    expect(resolveAgentRunControlViaRust(undefined, { FRIDAY_AGENT_RUN_CONTROL_VIA_RUST: "TRUE" })).toBe(true);
+    expect(resolveAgentRunControlViaRust(undefined, { FRIDAY_AGENT_RUN_CONTROL_VIA_RUST: "  1  " })).toBe(true);
+    expect(resolveAgentRunControlViaRust(undefined, { FRIDAY_AGENT_RUN_CONTROL_VIA_RUST: " true " })).toBe(true);
+  });
+
+  // Fail-safe OFF: everything that is not exactly "1"/"true" → false (narrower than the canonical set).
+  it("treats 0, false, empty, and garbage env values as false (fail-safe off)", () => {
+    for (const raw of ["0", "false", "", "yes", "on", "enabled", "truthy", "2"]) {
+      expect(resolveAgentRunControlViaRust(undefined, { FRIDAY_AGENT_RUN_CONTROL_VIA_RUST: raw })).toBe(false);
+    }
+  });
+
+  // PRECEDENCE: an explicit config boolean ALWAYS wins over the env (config false MUST beat env true).
+  it("uses explicit config over the env (true wins; the discriminating config=false beats env=true)", () => {
+    expect(resolveAgentRunControlViaRust(true, { FRIDAY_AGENT_RUN_CONTROL_VIA_RUST: "0" })).toBe(true);
+    expect(resolveAgentRunControlViaRust(true, emptyEnv())).toBe(true);
+    expect(resolveAgentRunControlViaRust(false, { FRIDAY_AGENT_RUN_CONTROL_VIA_RUST: "1" })).toBe(false);
+    expect(resolveAgentRunControlViaRust(false, { FRIDAY_AGENT_RUN_CONTROL_VIA_RUST: "true" })).toBe(false);
   });
 });
 


### PR DESCRIPTION
## What

A3 of GATE-AGENT-REPLACE: the **TS client courier** for the pause/resume product transport. DARK, flag-gated **default-off** behind `FRIDAY_AGENT_RUN_CONTROL_VIA_RUST` — the SAME default-off posture as the already-merged Phase-2 Rust server. This PR adds the **ability** to handle a paused run and relay an opaque operator signature; it admits **NO mutating run** (the read-only qualifier stays hard — a SEPARATE later PR).

The Rust SERVER side (`AgentRunPaused` / `AgentRunResume` / `resume_with_approval`) is already merged + flag-gated on `main`. This PR matches that wire EXACTLY and never re-builds it.

## Changes

**Sealed WS courier** (`friday-rust-hub-agent-run-ws-sealed-client.ts`)
- Inbound `Message::AgentRunPaused` → a NEW refs-only **paused outcome** `{runId, approvalId, actionDigest, ownerSealedSummary?}`. Maps the merged wire EXACTLY: `nonce`→`approvalId`, `action_digest`→`actionDigest`, `summary`→`ownerSealedSummary`. **Carries no signing material (INV-1).**
- `resumeWithApproval(opaqueSignedBlob)` opens a **fresh** sealed session (same `clientSecret`, same `run_id` — the nonce is the single-use authority, design §2.1) and sends `Message::AgentRunResume {run_id, signed_blob}` **verbatim**. TS inspects nothing — a pure courier. The pure `buildResumeEnvelope()` is wire-tested for the exact bytes.
- `AgentRunResult` path + the trailing unknown→fail-closed are **untouched** by the flag.

**Service adapter + compose** (`...-sealed-client-service.ts`, `friday-api-runtime.ts`)
- Dispatch returns a discriminated union `result | paused`.
- On paused, compose **branches early** (skips the delivered-body readback gate — a paused run has no body) and projects an **HONEST non-Finished row** via `loopStatus:"Paused"` → the projector's `"cancelled"` mapping (NOT a fake `Finished`). Refs-only (INV-5): empty `response`, body REF only, owner-sealed summary kept out of plaintext.

**Flag** — `resolveAgentRunControlViaRust` (`friday-hub-bootstrap.ts`) mirrors `resolveRouteAgentRunViaRust` exactly (explicit config wins; else env `"1"`/`"true"`; else false). Threaded config → deps → service → client.

## Honest note on the wire spec

The task brief listed `expiresAt` on the paused outcome, but the **merged** `Message::AgentRunPaused` carries only `{run_id, nonce, action_digest, summary}` — no expiry field. Per "match the Rust wire shape exactly," `expiresAt` is **dropped** (parsed defensively for forward-compat, `undefined` today; never fabricated). The approval's real expiry is enforced server-side by `resume_with_approval`.

## Byte-identical when off

Default-off ⇒ `AgentRunPaused` is an unknown message → fail-closed (the SAME 503 as today); `resumeWithApproval` rejects without a socket; compose never sees a paused outcome; the `AgentRunResult` path is flag-independent.

## Future-PR note (not built here)

The paused row stores the action digest into the `rust-run-body-ref:…;len=0` slot and the projector is `INSERT OR IGNORE` on run_id. A later resume-completion PR that re-projects the same run_id would be silently ignored (leaving the `cancelled` row). Correct for THIS read-only DARK PR (reads never pause); the future mutating PR owns the row-update story.

## Local checks
- `npm run typecheck` (src + contracts): clean
- `npm run lint`: 0 errors
- vitest: the 4 touched suites green (117 tests) + broader mission-spine/hub/runtime (219 tests). New: AgentRunPaused→paused refs; buildResumeEnvelope wire-shape + parseControlResult; flag-off byte-identity; service flag passthrough + paused/resume relay; compose paused→honest cancelled row; resolveAgentRunControlViaRust default-off + precedence.

## Invariants
- **INV-1**: TS only relays an opaque signature; no signing key minted/held; paused outcome carries no signing material (tested).
- **INV-5**: refs-only readback; paused row stores a body ref, empty response, summary out of plaintext.
- **INV-7**: no TS startRun fallback; paused returns an honest non-Finished row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)