### PR TITLE
feat(a7-hardening): Phase-A — cargo-feature gate real OS backend + sever guideLens/setupAssistant companion bypasses (dark)

### DIFF
--- a/rust-core/crates/friday-hub/Cargo.toml
+++ b/rust-core/crates/friday-hub/Cargo.toml
@@ -7,6 +7,19 @@ license.workspace = true
 publish = false
 rust-version.workspace = true
 
+[features]
+# DEPLOY-GO actuation gate (Barrier 3). DEFAULT-OFF. The default build has NO real,
+# host-effecting `OsActuationBackend` compiled in: `OsIntentExecutor::production_default`
+# is `#[cfg(not(feature = "os-actuation-deploy-go"))]` and returns a
+# `OsIntentExecutor<UnavailableBackend>` — the only constructible production backend is
+# `UnavailableBackend`, which actuates NOTHING (compile-time property). A REAL backend can
+# only ship via a deliberate, reviewable, RECOMPILED DEPLOY-GO cutover that enables this
+# feature and supplies the impl — it can NEVER be flipped on at runtime (there is no
+# `env::var` that selects a backend; the selection is `#[cfg(feature = ...)]`-only). Until
+# that cutover the feature-ON arm is an explicit unbuilt seam (`compile_error!`), so the
+# default build cannot even link a real actuator. KEEP DEFAULT-OFF.
+os-actuation-deploy-go = []
+
 [dependencies]
 friday-core.workspace = true
 friday-crypto.workspace = true

--- a/rust-core/crates/friday-hub/src/system_intent.rs
+++ b/rust-core/crates/friday-hub/src/system_intent.rs
@@ -372,6 +372,54 @@ impl OsIntentExecutor<UnavailableBackend> {
     }
 }
 
+// ─── Barrier 3: DEPLOY-GO compile-time gate on any real OS-actuation backend ──────
+//
+// `production_default` is THE production selector seam — the single function a runtime
+// composition root may call to obtain the OS executor without naming a backend. Its
+// return TYPE is the compile-time enforcement of the audited "a real backend can never be
+// flipped on at runtime" property:
+//
+//   * DEFAULT build (feature OFF) — the selector is concretely typed
+//     `OsIntentExecutor<UnavailableBackend>`. The ONLY constructible production backend is
+//     `UnavailableBackend`, which actuates NOTHING. There is NO `env::var` (or any runtime
+//     input) that could swap in a real backend: the choice is `#[cfg(feature = ...)]`-only.
+//   * DEPLOY-GO build (feature ON) — the arm is an explicit unbuilt seam. Shipping a real
+//     host-effecting backend requires a deliberate, reviewable, RECOMPILED cutover that
+//     both enables the feature AND supplies the impl here. Until then the feature-ON build
+//     does not compile, so the default binary can never link a real actuator by accident.
+//
+// This preserves the dark posture: the default build is byte-identical in behavior to
+// today (UnavailableBackend only, nothing actuates), and adds a compile-time barrier
+// against a runtime flip.
+impl OsIntentExecutor<UnavailableBackend> {
+    /// The production OS-executor selector (Barrier 3). On the DEFAULT build the return
+    /// type is pinned to `OsIntentExecutor<UnavailableBackend>` — the only constructible
+    /// production backend, which actuates NOTHING. A real backend is reachable ONLY via a
+    /// recompiled DEPLOY-GO cutover (the `os-actuation-deploy-go` feature), never a runtime
+    /// flag. The default-build executor is dry-run/observe + empty allowlist + unavailable
+    /// backend — identical to [`dry_run_default`](Self::dry_run_default) — so calling this
+    /// can never move the host on a default build.
+    #[cfg(not(feature = "os-actuation-deploy-go"))]
+    pub fn production_default() -> OsIntentExecutor<UnavailableBackend> {
+        // The default build offers EXACTLY ONE production backend: UnavailableBackend.
+        // No `env::var`, no runtime selection — the backend is fixed at compile time.
+        OsIntentExecutor::dry_run_default()
+    }
+}
+
+// DEPLOY-GO arm: the real, host-effecting backend selector is an explicit UNBUILT seam.
+// A real `OsActuationBackend` (a signed companion/Swift helper / least-privilege OS
+// process) is provisioned here ONLY at the DEPLOY-GO cutover, which is a deliberate,
+// reviewable RECOMPILE. Until that lands the feature-ON build intentionally does not
+// compile, so a real actuator can never be linked into a default binary.
+#[cfg(feature = "os-actuation-deploy-go")]
+compile_error!(
+    "os-actuation-deploy-go: no real OsActuationBackend is wired yet. Provisioning a \
+     host-effecting backend is a DEPLOY-GO cutover (deliberate, reviewable recompile) — \
+     wire the real backend + an `OsIntentExecutor::production_default` selector for this \
+     arm here before building with this feature."
+);
+
 impl<B: OsActuationBackend> OsIntentExecutor<B> {
     /// Build an executor with the actuate flag set EXPLICITLY, an operator-curated
     /// allowlist, and a backend. NEVER set `actuate = true` on a production path until
@@ -1532,6 +1580,57 @@ mod tests {
             assert_eq!(out.message, DRY_RUN_OBSERVED_MARKER, "{a:?}");
             assert_ne!(out.status, IntentStatus::Completed);
         }
+    }
+
+    #[test]
+    #[cfg(not(feature = "os-actuation-deploy-go"))]
+    fn barrier3_production_default_selector_cannot_actuate_on_default_build() {
+        // Barrier 3 (compile-time DEPLOY-GO gate): on the DEFAULT build the production
+        // selector `production_default()` returns an `OsIntentExecutor<UnavailableBackend>`
+        // — the backend type is PINNED at compile time, so the only constructible
+        // production backend is the one that actuates NOTHING. There is no runtime/env
+        // input that could swap in a real backend. Behaviorally: every action (mutating or
+        // observe) short-circuits to a refs-only dry-run, `would_actuate` is false for all,
+        // and nothing is ever `Completed`.
+        //
+        // The `let ex: OsIntentExecutor<UnavailableBackend>` annotation is itself part of
+        // the proof: it would FAIL TO COMPILE on the default build if the selector could
+        // return any other (e.g. real, host-effecting) backend.
+        let ex: OsIntentExecutor<UnavailableBackend> = OsIntentExecutor::production_default();
+        for a in [
+            IntentAction::Snapshot,
+            IntentAction::SearchFile,
+            IntentAction::NotificationList,
+            IntentAction::LaunchApp,
+            IntentAction::CloseApp,
+            IntentAction::OpenUrl,
+            IntentAction::OpenProject,
+            IntentAction::Focus,
+            IntentAction::ArrangeWindows,
+            IntentAction::ClipboardRead,
+            IntentAction::ClipboardWrite,
+            IntentAction::NotificationAct,
+        ] {
+            assert!(
+                !ex.would_actuate(a),
+                "{a:?} must never actuate on the default build"
+            );
+            let out = ex.execute(a, Some("ref"));
+            assert_eq!(out.status, IntentStatus::Unavailable, "{a:?}");
+            assert_eq!(out.message, DRY_RUN_OBSERVED_MARKER, "{a:?}");
+            assert_ne!(
+                out.status,
+                IntentStatus::Completed,
+                "{a:?} must never report Completed"
+            );
+        }
+        // Pin the equivalence to the dry-run ship default: the production selector is the
+        // unavailable-backend dry-run posture on the default build, by construction.
+        let baseline = OsIntentExecutor::dry_run_default();
+        assert_eq!(
+            ex.would_actuate(IntentAction::LaunchApp),
+            baseline.would_actuate(IntentAction::LaunchApp)
+        );
     }
 
     #[test]

--- a/src/hub/friday-hub-bootstrap.ts
+++ b/src/hub/friday-hub-bootstrap.ts
@@ -988,6 +988,40 @@ export function resolveRouteWorkflowsViaRust(
   return raw === "1" || raw === "true";
 }
 
+/**
+ * Barrier 5 (companion hardening): gate the live system companion bridge for
+ * AGENT-REACHABLE consumers behind the SAME test-only flag that fences
+ * `friday-system-service.executeIntent` (the `TS_RUNTIME_SYSTEM_INTENT_RETIRED`
+ * guard at `friday-system-service.ts`, opened only by
+ * `allowTestOnlySystemIntentExecution === true`).
+ *
+ * The `guide_lens` agent tool and the setup assistant reach the live Swift
+ * companion daemon via `companionBridge` WITHOUT passing through that
+ * `executeIntent` retirement guard, so on the default/production path they were a
+ * bypass: an agent run could drive overlay draws and a `captureSnapshot`
+ * screen-read at the daemon even though the executeIntent route is 503.
+ *
+ * This helper SEVERS that bypass by default: unless the explicit test-only flag is
+ * set, agent-reachable consumers receive `undefined` instead of the live bridge.
+ * Both consumers already null-check `companionBridge` (`friday-guide-lens-service.ts`
+ * `showNativeOverlay`/`clearNativeOverlay`/`captureSnapshot`;
+ * `friday-setup-assistant.ts` `setOverlayVisible`), so an absent bridge degrades
+ * them to fail-closed no-ops — no daemon call, no overlay, no screen read. NEVER
+ * default the flag on in production; the flag is the test-oracle escape hatch only.
+ *
+ * NOTE: the `systemService` consumer is NOT routed through this helper — it keeps
+ * the live bridge and is fenced separately at the method level by
+ * `executeIntent`'s own guard (it threads the same flag through
+ * `createFridaySystemService`). Severing the agent-reachable bypasses here mirrors
+ * that method-level fail-closed posture for the two consumers that lacked it.
+ */
+function resolveAgentReachableCompanionBridge<TBridge>(
+  liveBridge: TBridge,
+  allowTestOnlySystemIntentExecution: boolean | undefined,
+): TBridge | undefined {
+  return allowTestOnlySystemIntentExecution === true ? liveBridge : undefined;
+}
+
 function normalizeFridayHubPort(value: number | undefined): number | undefined {
   if (typeof value !== "number" || !Number.isInteger(value) || value < 1 || value > 65535) {
     return undefined;
@@ -2381,7 +2415,16 @@ export async function createFridayHub(
       idGenerator,
       nowIso,
       systemService,
-      companionBridge: systemCompanionBridge,
+      // Barrier 5: the guide_lens agent tool bypasses the executeIntent retirement
+      // guard, so on the default/prod path it must NOT receive the live companion
+      // bridge (it would let an agent drive overlay draws + a captureSnapshot
+      // screen-read at the daemon). Fail closed to `undefined` unless the same
+      // test-only flag that opens executeIntent is set; the service null-checks the
+      // bridge and degrades overlay/snapshot to no-ops when absent.
+      companionBridge: resolveAgentReachableCompanionBridge(
+        systemCompanionBridge,
+        config.allowTestOnlySystemIntentExecution,
+      ),
       parserAdapter: guideLensParserAdapter,
       defaultPreferences: {
         defaultSurface: "native_desktop",
@@ -8167,7 +8210,15 @@ export async function createFridayHub(
       environmentScanner,
       coordinator: setupCoordinator,
       prerequisiteInstaller,
-      companionBridge: systemCompanionBridge,
+      // Barrier 5: the setup assistant is a SECOND agent-reachable token-holder of
+      // the live companion bridge that bypasses the executeIntent retirement guard.
+      // Fail closed to `undefined` on the default/prod path (it null-checks the
+      // bridge and degrades setOverlayVisible to a no-op when absent), opened only
+      // by the same test-only flag that fences executeIntent.
+      companionBridge: resolveAgentReachableCompanionBridge(
+        systemCompanionBridge,
+        config.allowTestOnlySystemIntentExecution,
+      ),
       eventEmitter: {
         emit: (event, payload) => {
           agentEventEmitter.emit(event as never, payload as never);

--- a/test/unit/hub/friday-hub-companion-bypass-sever.test.ts
+++ b/test/unit/hub/friday-hub-companion-bypass-sever.test.ts
@@ -1,0 +1,185 @@
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  clearAutoDetectProviderEnv,
+  restoreAutoDetectProviderEnv,
+  type FridayAutoDetectProviderEnvSnapshot,
+} from "../../_helpers/auto-detect-provider-env.js";
+
+// Barrier 5 (companion OS-actuation hardening): the `guide_lens` agent tool and the
+// setup assistant reach the live Swift companion daemon via `companionBridge` WITHOUT
+// passing through the `executeIntent` retirement guard
+// (`TS_RUNTIME_SYSTEM_INTENT_RETIRED`). On the default/production path that is a bypass:
+// an agent run could drive overlay draws and a `captureSnapshot` screen-read at the
+// daemon even though `executeIntent` is 503. The bootstrap now severs both bypasses —
+// `guideLensService` and `setupAssistant` receive the live companion bridge ONLY when the
+// same test-only flag (`allowTestOnlySystemIntentExecution === true`) that opens
+// `executeIntent` is set; otherwise they receive `undefined` (fail-closed no-op). The
+// `systemService` consumer is NOT severed here — it keeps the live bridge and is fenced
+// separately by `executeIntent`'s own method-level guard.
+//
+// This test mocks the THREE leaf factory modules (the barrels re-export them by
+// reference, so the mock is picked up through `../<area>/index.js`) and captures the
+// `companionBridge` argument each factory actually receives when a full hub is built. It
+// discriminates the three-way wiring: gate-off → guideLens/setup undefined,
+// systemService live; gate-on → all three live.
+
+const captured = vi.hoisted(() => ({
+  guideLensBridge: undefined as unknown,
+  setupBridge: undefined as unknown,
+  systemBridge: undefined as unknown,
+  guideLensCalled: false,
+  setupCalled: false,
+  systemCalled: false,
+}));
+
+vi.mock("../../../src/guide-lens/engine/friday-guide-lens-service.js", async (orig) => {
+  const actual = (await orig()) as typeof import("../../../src/guide-lens/engine/friday-guide-lens-service.js");
+  return {
+    ...actual,
+    createFridayGuideLensService: vi.fn((deps: Parameters<typeof actual.createFridayGuideLensService>[0]) => {
+      captured.guideLensCalled = true;
+      captured.guideLensBridge = deps.companionBridge;
+      return actual.createFridayGuideLensService(deps);
+    }),
+  };
+});
+
+vi.mock("../../../src/setup/friday-setup-assistant.js", async (orig) => {
+  const actual = (await orig()) as typeof import("../../../src/setup/friday-setup-assistant.js");
+  return {
+    ...actual,
+    createFridaySetupAssistant: vi.fn((deps: Parameters<typeof actual.createFridaySetupAssistant>[0]) => {
+      captured.setupCalled = true;
+      captured.setupBridge = deps.companionBridge;
+      return actual.createFridaySetupAssistant(deps);
+    }),
+  };
+});
+
+vi.mock("../../../src/system/engine/friday-system-service.js", async (orig) => {
+  const actual = (await orig()) as typeof import("../../../src/system/engine/friday-system-service.js");
+  return {
+    ...actual,
+    createFridaySystemService: vi.fn((deps: Parameters<typeof actual.createFridaySystemService>[0]) => {
+      captured.systemCalled = true;
+      captured.systemBridge = deps.companionBridge;
+      return actual.createFridaySystemService(deps);
+    }),
+  };
+});
+
+// Imported AFTER the mocks are declared (vi.mock is hoisted above, so the SUT picks up the
+// mocked leaf modules through the barrel re-exports).
+const { createFridayHub } = await import("#hub");
+type FridayHub = Awaited<ReturnType<typeof createFridayHub>>;
+
+describe("Barrier 5: sever guideLens/setupAssistant companion bypasses", () => {
+  let hub: FridayHub | null = null;
+  let stateDir: string | null = null;
+  let bundledSkillsDir: string | null = null;
+  let managedSkillsDir: string | null = null;
+  let autoDetectEnvSnapshot: FridayAutoDetectProviderEnvSnapshot | null = null;
+  const originalSuppression = process.env.FRIDAY_SUPPRESS_TEST_ENV_SECURITY_WARNINGS;
+  const originalTransport = process.env.FRIDAY_SYSTEM_COMPANION_TRANSPORT;
+
+  beforeEach(() => {
+    process.env.FRIDAY_SUPPRESS_TEST_ENV_SECURITY_WARNINGS = "1";
+    // Use the local in-process companion bridge so the bridge is constructed
+    // (non-undefined — proving the gate, not a vacuous undefined-everywhere pass) WITHOUT
+    // starting a unix-socket server. FRIDAY_SYSTEM_ENABLED is unset → systemEnabled true →
+    // the bridge IS built.
+    process.env.FRIDAY_SYSTEM_COMPANION_TRANSPORT = "in_process";
+    autoDetectEnvSnapshot = clearAutoDetectProviderEnv();
+    captured.guideLensBridge = undefined;
+    captured.setupBridge = undefined;
+    captured.systemBridge = undefined;
+    captured.guideLensCalled = false;
+    captured.setupCalled = false;
+    captured.systemCalled = false;
+  });
+
+  afterEach(async () => {
+    if (originalSuppression === undefined) {
+      delete process.env.FRIDAY_SUPPRESS_TEST_ENV_SECURITY_WARNINGS;
+    } else {
+      process.env.FRIDAY_SUPPRESS_TEST_ENV_SECURITY_WARNINGS = originalSuppression;
+    }
+    if (originalTransport === undefined) {
+      delete process.env.FRIDAY_SYSTEM_COMPANION_TRANSPORT;
+    } else {
+      process.env.FRIDAY_SYSTEM_COMPANION_TRANSPORT = originalTransport;
+    }
+    if (hub) {
+      await hub.stop();
+      hub = null;
+    }
+    if (stateDir) {
+      await fs.rm(stateDir, { recursive: true, force: true });
+      stateDir = null;
+    }
+    bundledSkillsDir = null;
+    managedSkillsDir = null;
+    if (autoDetectEnvSnapshot) {
+      restoreAutoDetectProviderEnv(autoDetectEnvSnapshot);
+      autoDetectEnvSnapshot = null;
+    }
+  });
+
+  async function buildHub(
+    overrides: Partial<Parameters<typeof createFridayHub>[0]> = {},
+  ): Promise<FridayHub> {
+    stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "friday-hub-companion-sever-"));
+    bundledSkillsDir = path.join(stateDir, "skills-empty");
+    managedSkillsDir = path.join(stateDir, "managed-skills-empty");
+    await fs.mkdir(bundledSkillsDir, { recursive: true });
+    await fs.mkdir(managedSkillsDir, { recursive: true });
+    hub = await createFridayHub({
+      skillDirs: [bundledSkillsDir, managedSkillsDir],
+      stateDir,
+      ...overrides,
+    });
+    return hub;
+  }
+
+  it("gate OFF (prod default): guideLens + setupAssistant get NO live companion bridge; systemService unchanged", async () => {
+    // No allowTestOnlySystemIntentExecution → the production default.
+    await buildHub();
+
+    // Sanity: all three factories ran AND the live bridge was actually constructed (the
+    // systemService consumer received a non-undefined bridge), so an undefined elsewhere is
+    // a SEVER, not a vacuous undefined-everywhere pass.
+    expect(captured.guideLensCalled).toBe(true);
+    expect(captured.setupCalled).toBe(true);
+    expect(captured.systemCalled).toBe(true);
+    expect(captured.systemBridge).toBeDefined();
+
+    // The two agent-reachable bypasses are severed: no live bridge.
+    expect(captured.guideLensBridge).toBeUndefined();
+    expect(captured.setupBridge).toBeUndefined();
+
+    // systemService keeps the live bridge (byte-identical to today; fenced separately by
+    // executeIntent's own method-level guard). The two severed consumers did NOT receive
+    // that live instance.
+    expect(captured.guideLensBridge).not.toBe(captured.systemBridge);
+    expect(captured.setupBridge).not.toBe(captured.systemBridge);
+  });
+
+  it("gate ON (test-only flag): all three consumers receive the SAME live companion bridge", async () => {
+    await buildHub({ allowTestOnlySystemIntentExecution: true });
+
+    expect(captured.guideLensCalled).toBe(true);
+    expect(captured.setupCalled).toBe(true);
+    expect(captured.systemCalled).toBe(true);
+
+    // The live bridge is present and is the SAME instance handed to systemService — the
+    // test-only escape hatch restores the legacy wiring for all three.
+    expect(captured.systemBridge).toBeDefined();
+    expect(captured.guideLensBridge).toBe(captured.systemBridge);
+    expect(captured.setupBridge).toBe(captured.systemBridge);
+  });
+});


### PR DESCRIPTION
## Summary

Two Phase-A companion OS-actuation hardening barriers in ONE PR. Design of record: `COMPANION_HARDENING_DESIGN_20260611.md`. Both **DARK + DEFAULT-OFF / FAIL-CLOSED**: byte-identical to today on the live default path; no flag flipped; no prod mutation; no Swift rebuild.

### Barrier 3 (Rust) — compile-time DEPLOY-GO gate on any real OS-actuation backend
- New cargo feature `os-actuation-deploy-go` (**DEFAULT-OFF**) in `friday-hub`.
- New `OsIntentExecutor::production_default()` production selector seam. On the default build its return type is pinned to `OsIntentExecutor<UnavailableBackend>` — the **only constructible production backend**, which actuates NOTHING (a compile-time property). Selection is `#[cfg(feature = ...)]`-only; there is **no `env::var`** that can swap in a real backend, preserving the audited no-runtime-flip property.
- The feature-ON arm is an explicit unbuilt seam (`compile_error!`): a real host-effecting backend ships ONLY via a deliberate, reviewable **recompiled DEPLOY-GO cutover**, never a runtime flag. Verified: building `--features os-actuation-deploy-go` fails with the DEPLOY-GO message.
- Default-features test `barrier3_production_default_selector_cannot_actuate_on_default_build`: the selector returns `UnavailableBackend` (type-pinned by an explicit annotation that would fail to compile if any other backend could be returned) and actuates nothing across every action.

### Barrier 5 (TS) — sever both agent-reachable companion bypasses behind the SAME guard as `executeIntent`
The `guide_lens` agent tool and the setup assistant reached the live Swift companion daemon via `companionBridge` **without** passing through the `executeIntent` retirement guard (`TS_RUNTIME_SYSTEM_INTENT_RETIRED`) — a default/prod bypass (overlay draws + a `captureSnapshot` screen-read at the daemon, even though `executeIntent` is 503).
- New `resolveAgentReachableCompanionBridge` helper: returns the live companion bridge only when `allowTestOnlySystemIntentExecution === true`, else `undefined`.
- Applied at the **two** agent-reachable consumers (`createFridayGuideLensService` :2384, `createFridaySetupAssistant` :8170). Both null-check `companionBridge`, so an absent bridge degrades overlay/snapshot to **fail-closed no-ops** (no daemon call, no overlay, no screen-read).
- `systemService` (:2197) left **byte-identical** — it keeps the live bridge and is fenced separately at the method level by `executeIntent`'s own guard.
- New vitest `friday-hub-companion-bypass-sever.test.ts` discriminates the three-way wiring via leaf-module arg-capture (a real, non-undefined bridge is constructed, so the test is not a vacuous undefined-everywhere pass): **gate-off → guideLens/setup `undefined`, systemService live; gate-on → all three the same live bridge**.

## Byte-identical-when-off argument
- **Rust**: the default build can link no real `OsActuationBackend` *type* (the feature arm is `compile_error!`), so `OsIntentExecutor::new` staying generic is harmless — there is no real backend to name or pass. Default behavior is `UnavailableBackend`-only, exactly as today. CI uses `cargo test --workspace` / `clippy --workspace --all-targets` (no `--all-features`), so the `compile_error!` is never tripped.
- **TS**: `mock-env` defaults `allowTestOnlySystemIntentExecution = true`, so mock e2e/CI runs already get the live bridge through the test-only path — unchanged. Only true production (flag unset) severs the two bypasses, which is strictly *more* fail-closed and is the intended default.

## Local checks (all green)
- `cargo +1.95.0 fmt --all`; `cargo +1.95.0 build` + `test --workspace` (default features); `clippy --all-targets -D warnings` clean; feature-ON `compile_error!` verified firing.
- `npm run lint` → **0 errors**; `npm run typecheck` → no errors.
- New + regression vitest green: `friday-hub-companion-bypass-sever` (2/2), `friday-hub-bootstrap` (20), guide-lens / system-service / agent-guide-lens-tool / agent-setup-assistant-tool (71 total), `friday-system-native-companion` + `friday-hub-bootstrap` integration (38).

🤖 Generated with [Claude Code](https://claude.com/claude-code)