### PR TITLE
feat(ui): Android mock shell — Home + device-pairing + sync flow (Compose, minimal, emulator proof)

### DIFF
--- a/apps/friday-android/README.md
+++ b/apps/friday-android/README.md
@@ -1,5 +1,18 @@
 # Friday — native Android shell (Unit 5c, emulator)
 
+This directory holds **two** Gradle modules:
+
+- **`:app`** (this file) — the **real-UniFFI Unit-5c** shell (Android Views) that
+  renders values from the all-Rust core via generated Kotlin bindings; built and
+  screenshotted by `build-emu.sh` (NDK cross-compile).
+- **`:mock`** ([`mock/README.md`](mock/README.md)) — a minimal **Jetpack Compose**
+  shell that proves the **device-pairing + Hub↔phone sync FLOW** on the emulator.
+  It is a self-contained MOCK (no UniFFI, no NDK, no sealed-WS client) and builds
+  with `gradle :mock:assembleDebug` (Maven only). The `:app` module below is left
+  fully intact — `:mock` is added alongside it, not in place of it.
+
+## `:app` — real-UniFFI bridge proof (Unit 5c)
+
 A minimal Activity that renders values computed by the **all-Rust core**
 (`friday-ffi`) through the generated **UniFFI Kotlin** bindings — the Android
 mirror of `apps/friday-ios`. It proves the Kotlin ↔ Rust bridge runs on the

--- a/apps/friday-android/build.gradle.kts
+++ b/apps/friday-android/build.gradle.kts
@@ -3,4 +3,7 @@
 // plugin is applied (see apps/friday-android/README.md).
 plugins {
     id("com.android.application") version "9.2.1" apply false
+    // Compose compiler plugin for the :mock module. AGP 9 ships built-in Kotlin;
+    // the standalone compose plugin must match that bundled Kotlin version.
+    id("org.jetbrains.kotlin.plugin.compose") version "2.2.0" apply false
 }

--- a/apps/friday-android/mock/README.md
+++ b/apps/friday-android/mock/README.md
@@ -1,0 +1,64 @@
+# Friday — Android MOCK shell (`:mock`)
+
+A minimal **Jetpack Compose** app whose only job for v1 is to prove the
+**device-pairing + Hub↔phone sync FLOW** runs on the Android **emulator**. It
+mirrors the design intent of `apps/friday-ios` (PR #679) at a minimal level:
+Cyan + Coral palette, warm off-white background, glass cards, light theme, a
+small retro-LCD pet, Home = Status + a chat-entry affordance.
+
+## This is a MOCK — read this before trusting anything it shows
+
+- **Pairing (QR / passkey) is MOCKED.** `PairingState.kt` is a deterministic
+  in-memory state machine (`UNPAIRED → SCANNING → PASSKEY → PAIRING → PAIRED`).
+  There is **no camera**, **no WebAuthn/passkey**, and the "QR" is a decorative
+  pixel grid, not a scannable code.
+- **Hub↔phone sync is MOCKED.** The sync indicator (`OFFLINE/STALE/SYNCING/SYNCED`)
+  is driven by scripted delays, not a transport.
+- **No real Hub connectivity.** There is **no sealed-WS client**. The real
+  Kotlin sealed-WS Hub client is a **DEFERRED** acceptance criterion (post-v1;
+  v1 ships **iOS** as the real client).
+- **refs-only · read-only.** The shell renders state and shows references; it
+  performs **no mutating action** against any Hub. (Contrast the sibling `:app`,
+  which has a real `markActivityDone` write over UniFFI.)
+
+## Relationship to the existing `:app` module (coexistence, nothing destroyed)
+
+`apps/friday-android` already contains `:app` — the **real-UniFFI Unit-5c**
+shell that renders values from the all-Rust core via generated Kotlin bindings
+and is built/screenshotted by `build-emu.sh` (NDK cross-compile). That module is
+**left fully intact**. This `:mock` module is added **alongside** it as a
+separate, self-contained Gradle module so the two never interfere:
+
+| | `:app` (Unit-5c) | `:mock` (this) |
+|---|---|---|
+| UI | Android Views | Jetpack Compose |
+| Data | real Rust core via UniFFI | in-memory MOCK |
+| Build | `build-emu.sh` (NDK cross-compile) | `gradle :mock:assembleDebug` (Maven only) |
+| Purpose | Kotlin↔Rust bridge proof | pairing + sync FLOW proof |
+
+## Build
+
+```sh
+cd apps/friday-android
+gradle :mock:assembleDebug    # -> mock/build/outputs/apk/debug/mock-debug.apk
+```
+
+No Rust, no NDK, no UniFFI — dependencies come from Google Maven + Maven Central.
+Verified green with **AGP 9.2.1 / Gradle 9.5.1 / Kotlin compose plugin 2.2.0 /
+Compose BOM 2024.09.03 / compileSdk 36**.
+
+## Emulator run + screenshot
+
+Emulator screenshot capture is a **follow-up** (the coordinator runs the
+emulator). To install + launch on a running emulator:
+
+```sh
+adb install -r mock/build/outputs/apk/debug/mock-debug.apk
+adb shell am start -n com.friday.mock/.MainActivity
+```
+
+## Honest status
+
+Emulator-level FLOW proof of the pairing + sync **shape** only. Overall Friday
+v1 is **NO-GO**. Real pairing ceremony, real sync transport, and the Kotlin
+sealed-WS Hub client are all post-v1.

--- a/apps/friday-android/mock/build.gradle.kts
+++ b/apps/friday-android/mock/build.gradle.kts
@@ -1,0 +1,62 @@
+// Friday Android MOCK shell (:mock) — v1 device-proof surface.
+//
+// A self-contained Jetpack Compose app proving the device-pairing + Hub↔phone
+// sync FLOW on the Android emulator. It is a MOCK: no UniFFI, no NDK, no real
+// sealed-WS Hub client — all pairing/sync state is a deterministic in-memory
+// stub (see PairingViewModel). This keeps `gradle :mock:assembleDebug` building
+// from public Maven repos with NO Rust cross-compile, unlike the sibling :app
+// (the real-UniFFI Unit-5c bridge proof, which needs build-emu.sh).
+//
+// AGP 9 has built-in Kotlin; Compose is enabled via the standalone
+// `org.jetbrains.kotlin.plugin.compose` plugin + `buildFeatures.compose`.
+plugins {
+    id("com.android.application")
+    id("org.jetbrains.kotlin.plugin.compose")
+}
+
+android {
+    namespace = "com.friday.mock"
+    compileSdk = 36
+
+    defaultConfig {
+        applicationId = "com.friday.mock"
+        minSdk = 24
+        targetSdk = 36
+        versionCode = 1
+        versionName = "0.0.1"
+    }
+
+    buildTypes {
+        getByName("debug") {
+            isMinifyEnabled = false
+        }
+    }
+
+    buildFeatures {
+        compose = true
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+}
+
+dependencies {
+    val composeBom = platform("androidx.compose:compose-bom:2024.09.03")
+    implementation(composeBom)
+
+    implementation("androidx.core:core-ktx:1.13.1")
+    implementation("androidx.activity:activity-compose:1.9.2")
+    implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.8.6")
+    implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:2.8.6")
+    implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.8.6")
+
+    implementation("androidx.compose.ui:ui")
+    implementation("androidx.compose.ui:ui-graphics")
+    implementation("androidx.compose.ui:ui-tooling-preview")
+    implementation("androidx.compose.foundation:foundation")
+    implementation("androidx.compose.material3:material3")
+
+    debugImplementation("androidx.compose.ui:ui-tooling")
+}

--- a/apps/friday-android/mock/src/main/AndroidManifest.xml
+++ b/apps/friday-android/mock/src/main/AndroidManifest.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <application
+        android:label="Friday (mock)"
+        android:allowBackup="false"
+        android:theme="@android:style/Theme.Material.Light.NoActionBar">
+        <activity
+            android:name=".MainActivity"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+</manifest>

--- a/apps/friday-android/mock/src/main/kotlin/com/friday/mock/MainActivity.kt
+++ b/apps/friday-android/mock/src/main/kotlin/com/friday/mock/MainActivity.kt
@@ -1,0 +1,470 @@
+// Friday — Android MOCK shell (Compose), v1 device-proof surface.
+//
+// Goal: prove the device-pairing + Hub<->phone sync FLOW runs on the Android
+// emulator. It mirrors the design intent of apps/friday-ios at a MINIMAL level:
+// Cyan+Coral palette, warm off-white bg, glass cards, light theme, a small
+// retro-LCD pet, Home = Status + a chat-entry affordance.
+//
+// HONEST SCOPE (do not mistake this for the real app):
+//  - Pairing (QR/passkey) and Hub<->phone sync are MOCKED — a deterministic
+//    in-memory state machine (PairingViewModel), not a real ceremony / WS.
+//  - refs-only + read-only: the phone renders state and shows references; it
+//    performs NO mutating action against any Hub (unlike the sibling :app,
+//    which has a real markActivityDone write over UniFFI).
+//  - The real Kotlin sealed-WS Hub client is DEFERRED (post-v1; iOS is the v1
+//    real client). See README + PR body.
+package com.friday.mock
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.compose.foundation.Canvas
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+
+class MainActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent { RootScreen() }
+    }
+}
+
+private enum class Tab(val title: String) {
+    HOME("Friday"), PAIR("Pair"), SYNC("Sync")
+}
+
+@Composable
+fun RootScreen(vm: PairingViewModel = viewModel()) {
+    var tab by remember { mutableStateOf(Tab.HOME) }
+    Column(
+        Modifier
+            .fillMaxSize()
+            .background(Theme.bg)
+            .padding(top = 36.dp),
+    ) {
+        TopBar(tab) { tab = it }
+        Column(
+            Modifier
+                .fillMaxWidth()
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = 18.dp)
+                .padding(bottom = 28.dp),
+            verticalArrangement = Arrangement.spacedBy(14.dp),
+        ) {
+            when (tab) {
+                Tab.HOME -> HomeScreen(vm) { tab = Tab.PAIR }
+                Tab.PAIR -> PairScreen(vm)
+                Tab.SYNC -> SyncScreen(vm)
+            }
+            Footer()
+        }
+    }
+}
+
+// Top bar: brand mark + the three minimal destinations (command-sheet direction).
+@Composable
+private fun TopBar(tab: Tab, onSelect: (Tab) -> Unit) {
+    Row(
+        Modifier.fillMaxWidth().padding(horizontal = 18.dp, vertical = 6.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Box(Modifier.size(12.dp).clip(CircleShape).background(Theme.coral)) // Small Mark
+        Spacer(Modifier.width(10.dp))
+        Text("Friday", color = Theme.ink, fontSize = 20.sp, fontWeight = FontWeight.SemiBold)
+        Text("  mock", color = Theme.cyan, fontSize = 12.sp, fontFamily = FontFamily.Monospace)
+        Spacer(Modifier.weight(1f))
+        Tab.entries.forEach { t ->
+            val sel = t == tab
+            Text(
+                t.title,
+                color = if (sel) Theme.cyan else Theme.sub,
+                fontSize = 14.sp,
+                fontWeight = if (sel) FontWeight.Bold else FontWeight.Normal,
+                modifier = Modifier
+                    .padding(start = 12.dp)
+                    .clip(RoundedCornerShape(8.dp))
+                    .background(if (sel) Theme.cyan.copy(alpha = 0.12f) else Color.Transparent)
+                    .padding(horizontal = 8.dp, vertical = 4.dp)
+                    .clickableNoRipple { onSelect(t) },
+            )
+        }
+    }
+}
+
+// --- Home: Status + a chat-entry affordance (minimal) --------------------------
+
+@Composable
+private fun HomeScreen(vm: PairingViewModel, onPair: () -> Unit) {
+    val online = vm.online
+
+    HeroPet(online)
+
+    GlassCard {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Text("Status", color = Theme.ink, fontSize = 17.sp, fontWeight = FontWeight.SemiBold)
+            Spacer(Modifier.weight(1f))
+            Chip(connectionLabel(vm), Theme.risk(connectionLabel(vm)))
+        }
+        Spacer(Modifier.height(8.dp))
+        StatusRow(if (online) "online · paired" else pairHint(vm), Theme.risk(connectionLabel(vm)))
+        StatusRow("hub: ${vm.mockHubName}", Theme.sub)
+        StatusRow("sync: ${syncLabel(vm.sync)}", Theme.risk(syncLabel(vm.sync)))
+    }
+
+    // Chat-entry affordance (honest: real chat needs a connected Hub).
+    GlassCard {
+        Text("Chat", color = Theme.ink, fontSize = 17.sp, fontWeight = FontWeight.SemiBold)
+        Spacer(Modifier.height(8.dp))
+        Row(
+            Modifier
+                .fillMaxWidth()
+                .clip(RoundedCornerShape(12.dp))
+                .background(Color(0x14808080))
+                .padding(12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text("Ask Friday…", color = Theme.sub, fontSize = 15.sp)
+            Spacer(Modifier.weight(1f))
+            Box(Modifier.size(22.dp).clip(CircleShape).background(Theme.cyan.copy(alpha = 0.4f)))
+        }
+        Spacer(Modifier.height(6.dp))
+        Text(
+            "connect a Hub to chat — pairing + Hub↔phone sync are MOCKED in this shell",
+            color = Theme.sub, fontSize = 12.sp,
+        )
+    }
+
+    GlassCard {
+        Text("Device", color = Theme.ink, fontSize = 17.sp, fontWeight = FontWeight.SemiBold)
+        Spacer(Modifier.height(6.dp))
+        Text(
+            if (online) "Paired to the mock Hub. Open Sync to re-run the (mock) sync."
+            else "Not paired. Pair this phone to a Hub to demonstrate the flow.",
+            color = Theme.sub, fontSize = 13.sp,
+        )
+        Spacer(Modifier.height(10.dp))
+        Button(
+            onClick = onPair,
+            colors = ButtonDefaults.buttonColors(containerColor = Theme.cyan),
+        ) { Text(if (online) "View pairing" else "Pair a device") }
+    }
+}
+
+// --- Pairing ceremony (QR / passkey), MOCKED ----------------------------------
+
+@Composable
+private fun PairScreen(vm: PairingViewModel) {
+    SectionTitle("Device pairing", "QR + passkey ceremony — MOCKED (no camera, no WebAuthn)")
+
+    // Step indicator.
+    GlassCard {
+        StepDots(vm.step)
+        Spacer(Modifier.height(12.dp))
+        when (vm.step) {
+            PairStep.UNPAIRED -> {
+                Text("Pair this phone to a Hub", color = Theme.ink, fontSize = 16.sp, fontWeight = FontWeight.SemiBold)
+                Spacer(Modifier.height(6.dp))
+                Text("On the Hub, open Settings → Devices → Add phone to show a QR. (Mock: tap below.)",
+                    color = Theme.sub, fontSize = 13.sp)
+                Spacer(Modifier.height(12.dp))
+                Button(onClick = { vm.beginScan() }, colors = ButtonDefaults.buttonColors(containerColor = Theme.cyan)) {
+                    Text("Scan QR")
+                }
+            }
+            PairStep.SCANNING -> {
+                Text("Scan the Hub QR", color = Theme.ink, fontSize = 16.sp, fontWeight = FontWeight.SemiBold)
+                Spacer(Modifier.height(10.dp))
+                QrPlaceholder()
+                Spacer(Modifier.height(10.dp))
+                Text("MOCK camera frame — no real scanning. Tap to simulate a detected QR.",
+                    color = Theme.sub, fontSize = 12.sp)
+                Spacer(Modifier.height(12.dp))
+                Button(onClick = { vm.qrDetected() }, colors = ButtonDefaults.buttonColors(containerColor = Theme.cyan)) {
+                    Text("Simulate QR detected")
+                }
+            }
+            PairStep.PASSKEY -> {
+                Text("Confirm passkey", color = Theme.ink, fontSize = 16.sp, fontWeight = FontWeight.SemiBold)
+                Spacer(Modifier.height(8.dp))
+                Text("Pairing code from the Hub:", color = Theme.sub, fontSize = 13.sp)
+                Spacer(Modifier.height(6.dp))
+                Text(vm.mockPairingCode, color = Theme.cyan, fontSize = 26.sp,
+                    fontFamily = FontFamily.Monospace, fontWeight = FontWeight.Bold)
+                Spacer(Modifier.height(8.dp))
+                Text("MOCK passkey prompt — a real build uses WebAuthn/platform passkey. " +
+                    "Confirm that this code matches the Hub.", color = Theme.sub, fontSize = 12.sp)
+                Spacer(Modifier.height(12.dp))
+                Button(onClick = { vm.confirmPasskey() }, colors = ButtonDefaults.buttonColors(containerColor = Theme.cyan)) {
+                    Text("Confirm passkey & pair")
+                }
+            }
+            PairStep.PAIRING -> {
+                Text("Pairing…", color = Theme.ink, fontSize = 16.sp, fontWeight = FontWeight.SemiBold)
+                Spacer(Modifier.height(8.dp))
+                Text("MOCK handshake (no sealed-WS). Establishing the (mock) session…",
+                    color = Theme.sub, fontSize = 13.sp)
+            }
+            PairStep.PAIRED -> {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Box(Modifier.size(14.dp).clip(CircleShape).background(Theme.cyan))
+                    Spacer(Modifier.width(10.dp))
+                    Text("Paired", color = Theme.cyan, fontSize = 18.sp, fontWeight = FontWeight.Bold)
+                }
+                Spacer(Modifier.height(8.dp))
+                Text("Paired to ${vm.mockHubName} (mock). The phone holds a device ref only — " +
+                    "no provider secret on the phone.", color = Theme.sub, fontSize = 13.sp)
+                Spacer(Modifier.height(12.dp))
+                OutlinedButton(onClick = { vm.unpair() }) { Text("Unpair", color = Theme.coral) }
+            }
+        }
+    }
+
+    GlassCard {
+        Text("Trust boundary", color = Theme.ink, fontSize = 15.sp, fontWeight = FontWeight.SemiBold)
+        Spacer(Modifier.height(6.dp))
+        Text("refs-only · read-only · no mutating action from this shell. The real " +
+            "Kotlin sealed-WS Hub client is DEFERRED (post-v1; iOS is the v1 real client).",
+            color = Theme.sub, fontSize = 12.sp)
+    }
+}
+
+// --- Sync indicator (Hub<->phone), MOCKED -------------------------------------
+
+@Composable
+private fun SyncScreen(vm: PairingViewModel) {
+    SectionTitle("Hub ↔ phone sync", "sync indicator — MOCKED (no real transport)")
+
+    GlassCard {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Box(Modifier.size(14.dp).clip(CircleShape).background(Theme.risk(syncLabel(vm.sync))))
+            Spacer(Modifier.width(10.dp))
+            Text(syncLabel(vm.sync).replaceFirstChar { it.uppercase() },
+                color = Theme.risk(syncLabel(vm.sync)), fontSize = 18.sp, fontWeight = FontWeight.Bold)
+            Spacer(Modifier.weight(1f))
+            Chip(syncLabel(vm.sync), Theme.risk(syncLabel(vm.sync)))
+        }
+        Spacer(Modifier.height(10.dp))
+        StatusRow("last sync: ${vm.lastSync ?: "—"}", Theme.sub)
+        StatusRow(
+            when (vm.sync) {
+                SyncState.SYNCED -> "Phone state is up to date with the Hub (mock)."
+                SyncState.SYNCING -> "Pulling the latest Hub state (mock)…"
+                SyncState.STALE -> "Phone state is stale — reconnect to refresh."
+                SyncState.OFFLINE -> "Offline — pair a device first."
+            },
+            Theme.sub,
+        )
+    }
+
+    GlassCard {
+        Text("Sync actions", color = Theme.ink, fontSize = 15.sp, fontWeight = FontWeight.SemiBold)
+        Spacer(Modifier.height(8.dp))
+        if (vm.step != PairStep.PAIRED) {
+            Text("Pair a device (Pair tab) to enable the (mock) sync.", color = Theme.sub, fontSize = 13.sp)
+        } else {
+            Text("Re-run a mock sync to see the indicator cycle syncing → synced.",
+                color = Theme.sub, fontSize = 13.sp)
+            Spacer(Modifier.height(10.dp))
+            Button(
+                onClick = { vm.resync() },
+                enabled = vm.sync != SyncState.SYNCING,
+                colors = ButtonDefaults.buttonColors(containerColor = Theme.cyan),
+            ) { Text(if (vm.sync == SyncState.SYNCING) "Syncing…" else "Sync now") }
+        }
+    }
+}
+
+// --- shared bits --------------------------------------------------------------
+
+private fun connectionLabel(vm: PairingViewModel): String = when {
+    vm.online -> "online"
+    vm.step == PairStep.PAIRED -> syncLabel(vm.sync)
+    vm.step == PairStep.UNPAIRED -> "offline"
+    else -> "pairing"
+}
+
+private fun pairHint(vm: PairingViewModel): String = when (vm.step) {
+    PairStep.UNPAIRED -> "offline · not paired"
+    PairStep.PAIRED -> "paired · ${syncLabel(vm.sync)}"
+    else -> "pairing in progress"
+}
+
+private fun syncLabel(s: SyncState): String = when (s) {
+    SyncState.OFFLINE -> "offline"
+    SyncState.STALE -> "stale"
+    SyncState.SYNCING -> "syncing"
+    SyncState.SYNCED -> "synced"
+}
+
+@Composable
+private fun StatusRow(text: String, color: Color) {
+    Text(text, color = color, fontSize = 14.sp, modifier = Modifier.padding(vertical = 3.dp))
+}
+
+@Composable
+private fun SectionTitle(title: String, sub: String) {
+    Column(Modifier.padding(top = 8.dp, bottom = 2.dp)) {
+        Text(title, color = Theme.ink, fontSize = 20.sp, fontWeight = FontWeight.Bold)
+        Text(sub, color = Theme.sub, fontSize = 12.sp)
+    }
+}
+
+@Composable
+private fun Footer() {
+    Text(
+        "MOCK device-proof shell · pairing + sync stubbed · refs-only · v1 NO-GO (greenfield)",
+        color = Theme.sub, fontSize = 11.sp, modifier = Modifier.padding(top = 18.dp),
+    )
+}
+
+// Step dots for the pairing ceremony (1=scan, 2=passkey, 3=paired).
+@Composable
+private fun StepDots(step: PairStep) {
+    val active = when (step) {
+        PairStep.UNPAIRED -> 0
+        PairStep.SCANNING -> 1
+        PairStep.PASSKEY -> 2
+        PairStep.PAIRING, PairStep.PAIRED -> 3
+    }
+    Row(verticalAlignment = Alignment.CenterVertically) {
+        listOf("Scan", "Passkey", "Paired").forEachIndexed { i, label ->
+            val done = active >= i + 1
+            Box(Modifier.size(12.dp).clip(CircleShape).background(if (done) Theme.cyan else Theme.sub.copy(alpha = 0.3f)))
+            Spacer(Modifier.width(6.dp))
+            Text(label, color = if (done) Theme.cyan else Theme.sub, fontSize = 12.sp)
+            if (i < 2) { Spacer(Modifier.width(8.dp)); Text("›", color = Theme.sub, fontSize = 14.sp); Spacer(Modifier.width(8.dp)) }
+        }
+    }
+}
+
+// A MOCK QR frame — decorative pixel grid, NOT a real/scannable QR code.
+@Composable
+private fun QrPlaceholder() {
+    Box(
+        Modifier
+            .size(160.dp)
+            .clip(RoundedCornerShape(12.dp))
+            .background(Color.White)
+            .border(1.dp, Theme.cyan.copy(alpha = 0.25f), RoundedCornerShape(12.dp))
+            .padding(12.dp),
+        contentAlignment = Alignment.Center,
+    ) {
+        Canvas(Modifier.fillMaxSize()) { drawMockQr() }
+    }
+}
+
+private fun DrawScope.drawMockQr() {
+    val n = 11
+    val cell = size.minDimension / n
+    // Deterministic checker-ish pattern + finder squares (purely decorative).
+    for (r in 0 until n) for (c in 0 until n) {
+        val finder = (r < 3 && c < 3) || (r < 3 && c >= n - 3) || (r >= n - 3 && c < 3)
+        val on = finder || ((r * 7 + c * 3) % 5 == 0)
+        if (on) drawRectAt(r, c, cell)
+    }
+}
+
+private fun DrawScope.drawRectAt(r: Int, c: Int, cell: Float) {
+    drawRect(
+        color = Color(0xFF1C1E22),
+        topLeft = Offset(c * cell, r * cell),
+        size = Size(cell * 0.9f, cell * 0.9f),
+    )
+}
+
+// Retro-LCD Hero Pet — minimal pixel cat face on an LCD panel (mood companion,
+// not a status source of truth). Mirrors the iOS HeroPet at a minimal level.
+@Composable
+private fun HeroPet(online: Boolean) {
+    Column(Modifier.fillMaxWidth(), horizontalAlignment = Alignment.CenterHorizontally) {
+        Box(
+            Modifier
+                .padding(top = 6.dp)
+                .size(width = 150.dp, height = 110.dp)
+                .clip(RoundedCornerShape(14.dp))
+                .background(Theme.lcdBg)
+                .border(1.dp, Theme.lcd.copy(alpha = 0.25f), RoundedCornerShape(14.dp))
+                .padding(12.dp),
+        ) {
+            Canvas(Modifier.fillMaxSize()) { drawPet() }
+        }
+        Spacer(Modifier.height(6.dp))
+        Text(if (online) "Friday is here" else "Friday is offline", color = Theme.sub, fontSize = 12.sp)
+    }
+}
+
+private val petFace = listOf(
+    "X..XX..X", ".XXXXXX.", "X.XOXO.X", "X.XXXX.X", "X.X..X.X", ".XXXXXX.",
+)
+
+private fun DrawScope.drawPet() {
+    val cols = 8
+    val rows = petFace.size
+    val cell = minOf(size.width / cols, size.height / rows)
+    petFace.forEachIndexed { r, line ->
+        line.forEachIndexed { c, ch ->
+            if (ch == '.') return@forEachIndexed
+            val on = ch == 'X'
+            drawRect(
+                color = if (on) Theme.lcd else Theme.lcd.copy(alpha = 0.35f),
+                topLeft = Offset(c * cell + 1f, r * cell + 1f),
+                size = Size(cell - 2f, cell - 2f),
+            )
+        }
+    }
+}
+
+// A tiny no-ripple clickable for the top-bar tabs (keeps deps minimal).
+private fun Modifier.clickableNoRipple(onClick: () -> Unit): Modifier =
+    this.clickable(
+        interactionSource = MutableInteractionSource(),
+        indication = null,
+        onClick = onClick,
+    )
+
+// Preview renders against a directly-constructed VM (no ViewModelStoreOwner needed
+// in the preview pane, unlike the viewModel() default used at runtime).
+@Preview(showBackground = true)
+@Composable
+private fun HomePreview() {
+    RootScreen(vm = PairingViewModel())
+}

--- a/apps/friday-android/mock/src/main/kotlin/com/friday/mock/PairingState.kt
+++ b/apps/friday-android/mock/src/main/kotlin/com/friday/mock/PairingState.kt
@@ -1,0 +1,86 @@
+// MOCK device-pairing + Hub<->phone sync state machine.
+//
+// HONEST LABEL: this is a deterministic in-memory STUB. There is no real Hub,
+// no QR camera, no passkey/WebAuthn ceremony, and NO sealed-WS client. It exists
+// only to demonstrate the SHAPE of the pairing + sync flow on the emulator for
+// the v1 device-proof. Every transition is a scripted delay, not a network call.
+// The real Kotlin sealed-WS Hub client is a DEFERRED acceptance criterion
+// (post-v1; v1 ships iOS as the real client — see README / PR body).
+package com.friday.mock
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+
+// The pairing ceremony states (refs-only; the phone never holds a provider secret).
+enum class PairStep { UNPAIRED, SCANNING, PASSKEY, PAIRING, PAIRED }
+
+// The Hub<->phone sync indicator states (honest: offline/stale/syncing/synced).
+enum class SyncState { OFFLINE, STALE, SYNCING, SYNCED }
+
+class PairingViewModel : ViewModel() {
+    // --- device-pairing ceremony (mocked) ---
+    var step by mutableStateOf(PairStep.UNPAIRED)
+        private set
+
+    // A fixed, non-secret demo pairing code — illustrative only, not a real token.
+    val mockPairingCode = "FRDY-EMU-7Q2K"
+    val mockHubName = "Friday Hub (mock)"
+
+    // --- Hub<->phone sync indicator (mocked) ---
+    var sync by mutableStateOf(SyncState.OFFLINE)
+        private set
+    var lastSync by mutableStateOf<String?>(null)
+        private set
+
+    // Step 1: user taps "Scan QR" — show the (mock) scan surface.
+    fun beginScan() {
+        if (step != PairStep.UNPAIRED) return
+        step = PairStep.SCANNING
+    }
+
+    // Step 2: a QR is "detected" → advance to the passkey confirmation prompt.
+    fun qrDetected() {
+        if (step != PairStep.SCANNING) return
+        step = PairStep.PASSKEY
+    }
+
+    // Step 3: user confirms the passkey prompt → run the (mock) pairing handshake.
+    fun confirmPasskey() {
+        if (step != PairStep.PASSKEY) return
+        step = PairStep.PAIRING
+        viewModelScope.launch {
+            delay(900)              // mock handshake latency (no real WS)
+            step = PairStep.PAIRED
+            sync = SyncState.SYNCING
+            delay(900)              // mock first sync
+            sync = SyncState.SYNCED
+            lastSync = "just now (mock)"
+        }
+    }
+
+    // Re-run a (mock) sync from the paired state — demonstrates the sync indicator.
+    fun resync() {
+        if (step != PairStep.PAIRED || sync == SyncState.SYNCING) return
+        viewModelScope.launch {
+            sync = SyncState.SYNCING
+            delay(900)
+            sync = SyncState.SYNCED
+            lastSync = "just now (mock)"
+        }
+    }
+
+    // Tear the pairing down (back to the unpaired/offline state).
+    fun unpair() {
+        step = PairStep.UNPAIRED
+        sync = SyncState.OFFLINE
+        lastSync = null
+    }
+
+    // Honest connection label for the Home status card.
+    val online: Boolean get() = step == PairStep.PAIRED && sync == SyncState.SYNCED
+}

--- a/apps/friday-android/mock/src/main/kotlin/com/friday/mock/Theme.kt
+++ b/apps/friday-android/mock/src/main/kotlin/com/friday/mock/Theme.kt
@@ -1,0 +1,70 @@
+// Friday mobile design tokens — minimal Compose port of the operator-locked
+// baseline (friday-design-handoff-20260602/saved/mobile-selection.json):
+// palette = Cyan + Coral (locked), background = Warm off-white, theme = Light,
+// form = Glass Native (translucent rounded panels), pet = Retro LCD.
+//
+// This is the Android mirror of apps/friday-ios Theme; applied at a MINIMAL
+// level (a glass-ish card + the two brand colors + warm bg), not pixel-perfect.
+package com.friday.mock
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+object Theme {
+    val cyan = Color(0xFF1AB0C2)    // action / online / direct (locked)
+    val coral = Color(0xFFF2735B)   // urgency / accent / danger (locked)
+    val lcd = Color(0xFF8CF2B2)     // retro-LCD phosphor
+    val lcdBg = Color(0xFF0F1A17)
+    val ink = Color(0xFF1C1E22)
+    val sub = Color(0xFF788086)
+    val bg = Color(0xFFF7F6F2)      // warm off-white (locked)
+    val card = Color(0xCCFFFFFF)    // glass-ish translucent white panel
+
+    // Risk semantics via color (mirrors iOS Theme.risk): success/warning/danger.
+    fun risk(kind: String): Color = when (kind) {
+        "online", "paired", "success", "synced", "direct" -> cyan
+        "syncing", "pairing", "stale", "warning", "pending" -> Color(0xFFE6961E)
+        "offline", "failed", "danger", "fallback" -> coral
+        else -> sub
+    }
+}
+
+// Glass Native card surface — translucent rounded panel with a faint cyan hairline.
+@Composable
+fun GlassCard(modifier: Modifier = Modifier, content: @Composable () -> Unit) {
+    androidx.compose.foundation.layout.Column(
+        modifier
+            .clip(RoundedCornerShape(18.dp))
+            .background(Theme.card)
+            .border(BorderStroke(1.dp, Theme.cyan.copy(alpha = 0.18f)), RoundedCornerShape(18.dp))
+            .padding(18.dp)
+    ) { content() }
+}
+
+// Status chip: monospaced uppercase pill (locked status-label style).
+@Composable
+fun Chip(text: String, color: Color) {
+    Text(
+        text = text.uppercase(),
+        color = color,
+        fontSize = 11.sp,
+        fontWeight = FontWeight.Bold,
+        fontFamily = FontFamily.Monospace,
+        modifier = Modifier
+            .clip(RoundedCornerShape(20.dp))
+            .background(color.copy(alpha = 0.14f))
+            .padding(horizontal = 10.dp, vertical = 4.dp),
+    )
+}

--- a/apps/friday-android/settings.gradle.kts
+++ b/apps/friday-android/settings.gradle.kts
@@ -13,3 +13,5 @@ dependencyResolutionManagement {
 }
 rootProject.name = "friday-android"
 include(":app")
+// :mock — the self-contained Compose device-proof shell (no UniFFI/NDK).
+include(":mock")


### PR DESCRIPTION
## What

A minimal **Jetpack Compose** Android module (`:mock`, under `apps/friday-android/`) whose only v1 job is to prove the **device-pairing + Hub↔phone sync FLOW** runs on the Android **emulator**. It mirrors the design intent of `apps/friday-ios` (PR #679) at a minimal level.

This is the Android side of the v1 device-proof. Per operator scope it is a **MOCK / minimal shell**, not a full-feature app — iOS is the primary surface.

## What renders (build-verified; not yet visually verified)

`gradle :mock:assembleDebug` is **green** — this proves compile + package, **not** render. Emulator screenshot capture is a **coordinator follow-up**. The three Compose surfaces the APK contains:

- **Home** — Status card (honest `offline / stale / pairing / paired` + sync state, via `Theme.risk`), a **chat-entry affordance** ("Ask Friday…", honest "connect a Hub to chat"), a retro-LCD Hero Pet, and a pair CTA.
- **Pair** — the device-pairing ceremony with a step indicator: `UNPAIRED → SCANNING → PASSKEY → PAIRING → PAIRED`. Shows a (decorative) QR frame, a passkey-confirm prompt with a non-secret demo code, then a "Paired" state.
- **Sync** — the Hub↔phone **sync indicator** (`offline / stale / syncing / synced`) with a "Sync now" action that cycles `syncing → synced`.

Design tokens applied minimally per `friday-design-handoff-20260602/saved/mobile-selection.json`: cyanCoral palette, warm off-white bg (`#F7F6F2`), glass-ish translucent cards, light theme, retro-LCD pet.

## Honest mock-labeling (do not over-read)

- **Pairing (QR/passkey) is MOCKED** — `PairingState.kt` is a deterministic in-memory state machine. **No camera**, **no WebAuthn/passkey**; the "QR" is a decorative pixel grid, not a scannable code. Every pairing step is labeled MOCK in-UI.
- **Hub↔phone sync is MOCKED** — driven by scripted delays, not a transport.
- **No real Hub connectivity** — there is **no sealed-WS client**.
- **refs-only · read-only** — the shell renders state and shows references; it performs **no mutating action** against any Hub (contrast the sibling `:app`, which has a real `markActivityDone` write over UniFFI).

## Coexistence (nothing destroyed)

`apps/friday-android` already contains `:app` — the **real-UniFFI Unit-5c** shell (Android Views) that renders values from the all-Rust core via generated Kotlin bindings, built/screenshotted by `build-emu.sh` (NDK cross-compile). **That module is left fully intact.** This `:mock` module is added **alongside** it as a separate, self-contained Gradle module (no UniFFI, no NDK) so the two never interfere. Rationale: wiring real bindings would drag the whole NDK cross-compile pipeline in for zero task benefit, and the operator scope explicitly authorizes a mock.

| | `:app` (Unit-5c) | `:mock` (this PR) |
|---|---|---|
| UI | Android Views | Jetpack Compose |
| Data | real Rust core via UniFFI | in-memory MOCK |
| Build | `build-emu.sh` (NDK cross-compile) | `gradle :mock:assembleDebug` (Maven only) |
| Purpose | Kotlin↔Rust bridge proof | pairing + sync FLOW proof |

## Build approach

`gradle :mock:assembleDebug` (real Android build, not a kotlinc compile-verify — the SDK is present). Verified **green** with **AGP 9.2.1 / Gradle 9.5.1 / Kotlin compose plugin 2.2.0 / Compose BOM 2024.09.03 / compileSdk 36**. AGP 9 ships built-in Kotlin; Compose is enabled via the standalone `org.jetbrains.kotlin.plugin.compose` plugin + `buildFeatures.compose`. Dependencies resolve from Google Maven + Maven Central — **no Rust cross-compile**. The Android gradle build is not wired into any CI workflow (consistent with `:app`), so this module is inert for CI.

## Deferred acceptance criteria (explicit, post-v1)

- **Real Kotlin sealed-WS Hub client** — DEFERRED. v1 ships **iOS** as the real client; the Android real client is post-v1.
- Real QR camera scanning (vs. the mock frame).
- Real WebAuthn / platform-passkey pairing ceremony (vs. the mock prompt).
- Real Hub↔phone sync transport (vs. scripted delays).
- Emulator screenshot capture (coordinator runs the emulator).
- Physical-device proof + Play Store release (operator-gated).

Overall Friday **v1 is NO-GO** (greenfield). This is an emulator-level FLOW proof of the pairing + sync **shape** only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)