### PR TITLE
feat(ui): integrate real FridayRustClient → desktop Console (live read, honest-unavailable when dark)

### DIFF
--- a/apps/macos/FridayHubConsole/Package.resolved
+++ b/apps/macos/FridayHubConsole/Package.resolved
@@ -1,0 +1,15 @@
+{
+  "originHash" : "e2083dc2300e2f900a51180d6ad3bfe0f150b8b3c1b2d08333d4264e4a22a669",
+  "pins" : [
+    {
+      "identity" : "swift-sodium",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/jedisct1/swift-sodium.git",
+      "state" : {
+        "revision" : "4f9164a0a2c9a6a7ff53a2833d54a5c79c957342",
+        "version" : "0.9.1"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/apps/macos/FridayHubConsole/Package.swift
+++ b/apps/macos/FridayHubConsole/Package.swift
@@ -10,11 +10,22 @@ let package = Package(
     .executable(name: "FridayHubConsole", targets: ["FridayHubConsole"]),
     .library(name: "FridayHubConsoleCore", targets: ["FridayHubConsoleCore"]),
   ],
+  dependencies: [
+    // The REAL sealed-WS read client package (PR #677 read + #680 write, crypto-parity
+    // PASS). The Console's `FridayRustReadClient` protocol + `SealedWSReadClient` live
+    // there; the Core target adapts the package's refs-only `WorkbenchProjectionSnapshot`
+    // into the Console's rich display `WorkbenchSnapshot`.
+    .package(path: "../FridayRustClient"),
+  ],
   targets: [
-    // Core: snapshot truth model + read-only client protocol + mock + view models.
-    // Kept UI-free so view-model truth rules are unit-testable via `swift test`.
+    // Core: rich display snapshot model + mock + view models + the real-client adapter/factory.
+    // Kept UI-free so view-model truth rules (incl. honest-unavailable) are unit-testable via
+    // `swift test`. Depends on FridayRustClient for the read-client protocol + SealedWSReadClient.
     .target(
       name: "FridayHubConsoleCore",
+      dependencies: [
+        .product(name: "FridayRustClient", package: "FridayRustClient"),
+      ],
       path: "Sources/FridayHubConsoleCore"
     ),
     // Executable: the SwiftUI shell (three-pane Hub Console + Operations Overview).
@@ -25,7 +36,10 @@ let package = Package(
     ),
     .testTarget(
       name: "FridayHubConsoleCoreTests",
-      dependencies: ["FridayHubConsoleCore"],
+      dependencies: [
+        "FridayHubConsoleCore",
+        .product(name: "FridayRustClient", package: "FridayRustClient"),
+      ],
       path: "Tests/FridayHubConsoleCoreTests"
     ),
   ]

--- a/apps/macos/FridayHubConsole/Sources/FridayHubConsole/FridayHubConsoleApp.swift
+++ b/apps/macos/FridayHubConsole/Sources/FridayHubConsole/FridayHubConsoleApp.swift
@@ -3,16 +3,41 @@ import SwiftUI
 
 /// Friday Hub Console — the v1 desktop UI shell (D-PR1).
 ///
-/// A read-only operator workbench over Rust Hub Mission truth. D-PR1 wires the
-/// shell to a `MockReadClient`; the real `FridayRustClient` package is integrated
-/// in a later PR via the same `FridayRustReadClient` protocol.
+/// A read-only operator workbench over Rust Hub Mission truth. This build wires the shell to
+/// the REAL `SealedWSReadClient` (the `FridayRustClient` package) over the read-projection
+/// server's loopback seam — "the app actually reads the live Rust core".
+///
+/// Pre-slice-6 the Rust read-projection server is DARK / not flipped, so the real client
+/// cannot connect and the Console renders the HONEST "unavailable" state (never fake-ready,
+/// never a crash) — the correct behavior until the operator flips the server (slice-6 gate).
+///
+/// The in-memory `MockReadClient` is kept ONLY behind a debug/launch flag (and for previews).
 @main
 struct FridayHubConsoleApp: App {
   var body: some Scene {
     WindowGroup("Friday Hub Console") {
-      HubConsoleShell(client: MockReadClient(behavior: .loaded))
+      HubConsoleShell(client: Self.readClient)
     }
     .windowStyle(.titleBar)
     .defaultSize(width: 1180, height: 720)
+  }
+
+  /// The read client the live shell uses.
+  ///
+  /// DEFAULT = the REAL `SealedWSReadClient`. Set the launch arg `--use-mock-read-client`
+  /// (or env `FRIDAY_HUB_CONSOLE_USE_MOCK=1`) to fall back to the in-memory mock for local
+  /// design/demo work without a running read-projection server. The mock is NEVER the default.
+  static var readClient: FridayRustReadClient {
+    let args = ProcessInfo.processInfo.arguments
+    let env = ProcessInfo.processInfo.environment
+    let useMock =
+      args.contains("--use-mock-read-client") || env["FRIDAY_HUB_CONSOLE_USE_MOCK"] == "1"
+    if useMock {
+      return MockReadClient(behavior: .loaded)
+    }
+    return RealReadClientFactory.make(
+      config: .slice6LoopbackPlaceholder,
+      forwardedPrincipal: "owner:hub-console-desktop"
+    )
   }
 }

--- a/apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/FridayRustReadClient.swift
+++ b/apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/FridayRustReadClient.swift
@@ -1,26 +1,33 @@
 import Foundation
 
-/// Read-only client over hub truth.
-///
-/// The real implementation lives in a separate `FridayRustClient` package
-/// (integrated later) and decodes the Rust Hub Mission Workbench projection JSON
-/// into `WorkbenchSnapshot`. This protocol is deliberately READ-ONLY: there is no
-/// mutate / dispatch / provider-admin entry point. The Hub Console consumes truth;
-/// it does not author it.
-///
-/// `Sendable` so a concurrent/actor-backed real client conforms cleanly under
-/// Swift 6 strict concurrency.
-public protocol FridayRustReadClient: Sendable {
-  /// Fetch the current Mission Workbench projection.
-  ///
-  /// Throws on transport / hub unavailability (e.g. a 503, offline, or stale-read
-  /// failure). Callers must render that throw AS an honest "unavailable" state —
-  /// never as a fake-ready snapshot.
-  func fetchWorkbench() async throws -> WorkbenchSnapshot
-}
+// The READ-ONLY client protocol the Console consumes is now the SINGLE source of truth
+// from the `FridayRustClient` package (`FridayRustReadClient` — re-exported below). The
+// Console's former duplicate protocol + its rich `WorkbenchSnapshot` are reconciled like
+// so:
+//   - PROTOCOL: deleted here; the package's `FridayRustReadClient` (now `: Sendable`,
+//     aligned with the Console's old constraint) is the survivor. `import FridayRustClient`
+//     makes the bare name resolve to it across Core.
+//   - SNAPSHOT: the package's `WorkbenchSnapshot` is a THIN refs-only wire type
+//     (workItemIds/routeDecisionSummary/raw). The Console's rich, fully-typed
+//     `WorkbenchSnapshot` (the whole UI consumes its work-items/capabilities/transcript
+//     tree) is KEPT as the display model. The local declaration shadows the imported one
+//     within Core, so bare `WorkbenchSnapshot` stays the rich type; the wire type is
+//     qualified `FridayRustClient.WorkbenchSnapshot` in the adapter + real-client factory.
+//   - ADAPTER: `WorkbenchSnapshotAdapter` bridges the wire snapshot's `raw` JSON into the
+//     rich display model (see WorkbenchSnapshotAdapter.swift).
 
-/// Errors a read client surfaces. Each maps to an honest UI "unavailable" reason;
-/// none of them is recoverable by the UI pretending the hub is ready.
+// Re-export ONLY the protocol so the executable can name `FridayRustReadClient` without
+// importing FridayRustClient directly. The package's thin `WorkbenchSnapshot` is deliberately
+// NOT re-exported: within Core the local rich `WorkbenchSnapshot` declaration shadows it, and
+// re-exporting the wire type would make the bare name ambiguous downstream. The adapter +
+// factory qualify the wire type as `FridayRustClient.WorkbenchSnapshot` where they need it.
+@_exported import protocol FridayRustClient.FridayRustReadClient
+
+/// Errors the Console's MOCK read client surfaces (and the view model maps to an honest UI
+/// "unavailable" reason). Kept Console-local on purpose: it is the mock/preview/test error
+/// vocabulary (503 / offline / projection-unavailable). The REAL client throws the package's
+/// `FridayReadClientError`; the view model's `reason(for:)` maps BOTH to honest unavailable.
+/// None of these is recoverable by the UI pretending the hub is ready.
 public enum FridayRustReadClientError: Error, Sendable, Equatable, CustomStringConvertible {
   /// Hub responded but with a service-unavailable status (e.g. 503).
   case hubUnavailable(statusCode: Int)

--- a/apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/MockReadClient.swift
+++ b/apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/MockReadClient.swift
@@ -1,7 +1,9 @@
 import Foundation
+import FridayRustClient
 
-/// In-memory `FridayRustReadClient` used so the app builds, previews, and
-/// view-model tests run without the real `FridayRustClient` package.
+/// In-memory `FridayRustReadClient` used for SwiftUI previews and view-model truth-rule
+/// tests, so the app builds + previews + `swift test` run without a live read-projection
+/// server. The REAL path is `SealedWSReadClient` (see RealReadClientFactory).
 ///
 /// The representative snapshot mirrors the Rust `mission_workbench_probe` fixture
 /// and intentionally exercises every honest-rendering rule:
@@ -24,13 +26,28 @@ public struct MockReadClient: FridayRustReadClient {
     self.behavior = behavior
   }
 
-  public func fetchWorkbench() async throws -> WorkbenchSnapshot {
+  /// Conform to the unified `FridayRustReadClient` protocol: it returns the package's THIN
+  /// refs-only wire snapshot (`FridayRustClient.WorkbenchSnapshot`). The mock encodes its rich
+  /// `representativeSnapshot` to the camelCase contract JSON and wraps it as the wire snapshot
+  /// (its `raw` then carries the full projection), so the view model's adapter re-decodes it
+  /// back to the rich display model — exercising the SAME wire→display path the real client uses.
+  public func fetchWorkbench() async throws -> FridayRustClient.WorkbenchSnapshot {
     switch behavior {
     case .loaded:
-      return MockReadClient.representativeSnapshot
+      return try MockReadClient.representativeWireSnapshot()
     case let .unavailable(error):
       throw error
     }
+  }
+
+  /// The rich representative snapshot, encoded to contract JSON and wrapped as the package's
+  /// thin wire snapshot (so its `raw` carries the full projection for the adapter to re-decode).
+  ///
+  /// A throwing factory (not a stored `let`): the package's wire `WorkbenchSnapshot` carries an
+  /// `[String: Any] raw` and is intentionally NOT `Sendable`, so it cannot be a global `let`.
+  public static func representativeWireSnapshot() throws -> FridayRustClient.WorkbenchSnapshot {
+    let json = try JSONEncoder().encode(representativeSnapshot)
+    return try FridayRustClient.WorkbenchSnapshot(projectionJSON: json, generatedAtMs: 0)
   }
 
   /// Representative sample projection (refs are already-redacted `proof://` fingerprints,

--- a/apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/OperationsOverviewViewModel.swift
+++ b/apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/OperationsOverviewViewModel.swift
@@ -1,4 +1,5 @@
 import Foundation
+import FridayRustClient
 
 /// What the right-docked proof inspector is currently focused on.
 /// Each case carries only refs/labels — never a body to load.
@@ -51,10 +52,16 @@ public final class OperationsOverviewViewModel: ObservableObject {
 
   /// Re-fetch the Workbench projection. The only mutating-looking action — and it
   /// only re-reads truth; it never writes.
+  ///
+  /// `client.fetchWorkbench()` returns the package's THIN refs-only wire snapshot; the
+  /// adapter re-decodes its `raw` projection JSON into the rich display model. A transport
+  /// throw (the dark/un-flipped read server — the NORMAL pre-slice-6 state) OR an adapter
+  /// decode failure both land in `.unavailable`, rendered AS truth — never a fake-ready snapshot.
   public func refresh() async {
     state = .loading
     do {
-      let snapshot = try await client.fetchWorkbench()
+      let wire = try await client.fetchWorkbench()
+      let snapshot = try WorkbenchSnapshotAdapter.display(from: wire)
       state = .loaded(snapshot)
     } catch {
       // Render the failure AS truth. Never fall back to a fake-ready snapshot.
@@ -68,10 +75,35 @@ public final class OperationsOverviewViewModel: ObservableObject {
   }
 
   private static func reason(for error: Error) -> String {
+    // Mock / preview / adapter vocabulary (503 / offline / projection-unavailable).
     if let clientError = error as? FridayRustReadClientError {
       return clientError.description
     }
+    // The REAL `SealedWSReadClient` throws the package's error type. Each variant maps to an
+    // honest "unavailable" reason — including a closed/refused transport, which is exactly the
+    // dark/un-flipped read server (the NORMAL state until the slice-6 operator flip).
+    if let readError = error as? FridayReadClientError {
+      return Self.reason(for: readError)
+    }
     return "Hub unavailable — \(error)"
+  }
+
+  /// Map the package read client's typed error to an honest unavailable reason string.
+  private static func reason(for error: FridayReadClientError) -> String {
+    switch error {
+    case let .transport(detail):
+      return "Hub offline — no connection (\(detail))"
+    case .badServerPubkey:
+      return "Hub unavailable — invalid server identity"
+    case .badSessionNonce:
+      return "Hub unavailable — invalid session handshake"
+    case let .serverError(code, message):
+      return "Hub unavailable — server error \(code): \(message)"
+    case let .unexpectedResponse(kind):
+      return "Hub unavailable — unexpected response (\(kind))"
+    case let .malformedProjection(detail):
+      return "Projection unavailable: \(detail)"
+    }
   }
 
   // MARK: - Derived inspector content (refs only)

--- a/apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/RealReadClientFactory.swift
+++ b/apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/RealReadClientFactory.swift
@@ -1,0 +1,255 @@
+import Foundation
+import FridayRustClient
+import Network
+
+// MARK: - Real read-client factory + loopback transport
+//
+// Builds the REAL `SealedWSReadClient` (the package's sealed-WS read client) configured for
+// the read-projection server's LOOPBACK host:port, with a concrete `NWConnection`-backed
+// `SealedWSTransport`. This is the "the app actually reads the live Rust core" seam.
+//
+// STATUS (pre-slice-6): the Rust read-projection server (#675/#678) is DARK / not yet flipped.
+// So this client CANNOT connect yet — that is EXPECTED. The loopback transport genuinely
+// attempts host:port; against the dark server it fails at connect / preamble-read, throwing
+// `FridayReadClientError.transport(...)`. The view model maps that to the honest "unavailable"
+// state — the CORRECT pre-slice-6 behavior. The live round-trip (real WS upgrade + sealed
+// exchange against a RUNNING server with the UI peer pubkey enrolled) is the DEFERRED slice-6
+// acceptance criterion; this factory does not claim it.
+
+/// Configuration for the real read client's connection to the read-projection server.
+public struct ReadProjectionServerConfig: Sendable, Equatable {
+  /// Loopback host the read-projection server listens on (default `127.0.0.1`).
+  public let host: String
+  /// TCP port the read-projection server listens on.
+  public let port: UInt16
+  /// Connect / preamble timeout. Past this, a dark server surfaces as honest unavailable.
+  public let connectTimeout: TimeInterval
+
+  public init(host: String = "127.0.0.1", port: UInt16, connectTimeout: TimeInterval = 4) {
+    self.host = host
+    self.port = port
+    self.connectTimeout = connectTimeout
+  }
+
+  /// A PLACEHOLDER loopback config for pre-slice-6.
+  ///
+  /// HONEST NOTE: the read-projection server (`hub_read_projection_server.rs`) takes its port
+  /// from an operator `--port` CLI arg and DEFAULTS to `0` (OS-assigned) — there is NO fixed
+  /// well-known port to point at yet. This placeholder is intentionally a port the dark server
+  /// is NOT listening on, so it surfaces as honest-unavailable. The ACTUAL host:port is wired
+  /// from the operator's launch config at the slice-6 flip — confirm it there, do not trust
+  /// this constant as the live endpoint.
+  public static let slice6LoopbackPlaceholder = ReadProjectionServerConfig(
+    host: "127.0.0.1", port: 8799)
+}
+
+/// Builds the REAL `SealedWSReadClient` for the read-projection server.
+public enum RealReadClientFactory {
+  /// Construct the real read client.
+  ///
+  /// - Parameters:
+  ///   - config: the read-projection server's loopback host:port.
+  ///   - keypair: this client's X25519 keypair. Its public key MUST be enrolled in the
+  ///     server's SecureStore peer-allowlist (the slice-6 operator step) or the handshake is
+  ///     refused. Defaults to a fresh ephemeral keypair (sufficient to PROVE honest-unavailable
+  ///     against the dark server; real enrollment is the slice-6 gate).
+  ///   - forwardedPrincipal: the owner principal; MUST be in the server's owner-allowlist.
+  ///   - missionId: optional Mission id; `nil` ⇒ the server's first active Mission.
+  public static func make(
+    config: ReadProjectionServerConfig,
+    keypair: FridayCrypto.DeviceKeypair = FridayCrypto.DeviceKeypair(),
+    forwardedPrincipal: String,
+    missionId: String? = nil
+  ) -> FridayRustReadClient {
+    SealedWSReadClient(
+      keypair: keypair,
+      forwardedPrincipal: forwardedPrincipal,
+      missionId: missionId,
+      makeTransport: { try LoopbackSealedWSTransport(config: config) }
+    )
+  }
+}
+
+// MARK: - NWConnection-backed loopback transport
+
+/// A concrete `SealedWSTransport` over an `NWConnection` TCP loopback socket. It genuinely
+/// attempts the connection + cleartext preamble framing. Against the DARK read-projection
+/// server (the normal pre-slice-6 state) the connect fails / the preamble read returns no
+/// bytes, surfaced as `FridayReadClientError.transport(...)` → honest unavailable.
+///
+/// SCOPE: this carries the byte-exact preamble framing (`BE32(len) || payload`, mirroring
+/// `friday_transport::write_frame`/`read_frame`) so a connect against a LIVE server makes
+/// real progress. The `upgrade()` (real RFC-6455 WS handshake) + WS message framing are
+/// the DEFERRED slice-6 live-round-trip work and throw `transport("...deferred...")` here —
+/// reached ONLY after a successful connect+preamble, which the dark server never grants.
+final class LoopbackSealedWSTransport: SealedWSTransport {
+  private let connection: NWConnection
+  private let timeout: TimeInterval
+  private var started = false
+
+  init(config: ReadProjectionServerConfig) throws {
+    guard let port = NWEndpoint.Port(rawValue: config.port) else {
+      throw FridayReadClientError.transport("invalid read-projection port \(config.port)")
+    }
+    self.timeout = config.connectTimeout
+    self.connection = NWConnection(
+      host: NWEndpoint.Host(config.host),
+      port: port,
+      using: .tcp
+    )
+  }
+
+  /// Bring the connection to `.ready`, or throw on failure/timeout. Against the dark server
+  /// this is where we fail honestly (connection refused / timed out).
+  private func ensureStarted() throws {
+    guard !started else { return }
+    started = true
+    let semaphore = DispatchSemaphore(value: 0)
+    let outcome = OutcomeBox()
+    connection.stateUpdateHandler = { state in
+      switch state {
+      case .ready:
+        outcome.set(nil)
+        semaphore.signal()
+      case let .failed(error):
+        outcome.set(FridayReadClientError.transport("connect failed: \(error)"))
+        semaphore.signal()
+      case let .waiting(error):
+        // No listener (refused) keeps NWConnection in `.waiting`; treat as offline, do not hang.
+        outcome.set(FridayReadClientError.transport("connect waiting (no server): \(error)"))
+        semaphore.signal()
+      case .cancelled:
+        outcome.set(FridayReadClientError.transport("connection cancelled"))
+        semaphore.signal()
+      default:
+        break
+      }
+    }
+    connection.start(queue: .global())
+    if semaphore.wait(timeout: .now() + timeout) == .timedOut {
+      connection.cancel()
+      throw FridayReadClientError.transport("connect timed out after \(timeout)s (server dark?)")
+    }
+    if let error = outcome.take() { throw error }
+  }
+
+  func writeFrame(_ payload: [UInt8]) throws {
+    try ensureStarted()
+    var frame = [UInt8]()
+    let len = UInt32(payload.count)
+    frame.append(UInt8((len >> 24) & 0xff))
+    frame.append(UInt8((len >> 16) & 0xff))
+    frame.append(UInt8((len >> 8) & 0xff))
+    frame.append(UInt8(len & 0xff))
+    frame.append(contentsOf: payload)
+    try send(Data(frame))
+  }
+
+  func readFrame() throws -> [UInt8] {
+    try ensureStarted()
+    let header = try receiveExactly(4)
+    let len =
+      (UInt32(header[0]) << 24) | (UInt32(header[1]) << 16)
+      | (UInt32(header[2]) << 8) | UInt32(header[3])
+    if len == 0 { return [] }
+    return try receiveExactly(Int(len))
+  }
+
+  func upgrade() throws {
+    // The real RFC-6455 WebSocket upgrade is the DEFERRED slice-6 live-round-trip work. It is
+    // only ever reached AFTER a successful connect + preamble, which the dark read-projection
+    // server never grants — so the honest-unavailable path is exercised long before here.
+    throw FridayReadClientError.transport(
+      "WS upgrade is the deferred slice-6 live-round-trip step (not wired pre-flip)")
+  }
+
+  func sendMessage(_ body: [UInt8]) throws {
+    throw FridayReadClientError.transport("WS messaging deferred to slice-6 (not reached pre-flip)")
+  }
+
+  func recvMessage() throws -> [UInt8] {
+    throw FridayReadClientError.transport("WS messaging deferred to slice-6 (not reached pre-flip)")
+  }
+
+  // MARK: NWConnection send/receive bridged to the synchronous transport contract.
+
+  private func send(_ data: Data) throws {
+    let semaphore = DispatchSemaphore(value: 0)
+    let outcome = OutcomeBox()
+    connection.send(
+      content: data,
+      completion: .contentProcessed { error in
+        if let error { outcome.set(FridayReadClientError.transport("send failed: \(error)")) }
+        semaphore.signal()
+      })
+    if semaphore.wait(timeout: .now() + timeout) == .timedOut {
+      throw FridayReadClientError.transport("send timed out (server dark?)")
+    }
+    if let error = outcome.take() { throw error }
+  }
+
+  private func receiveExactly(_ count: Int) throws -> [UInt8] {
+    var collected = [UInt8]()
+    collected.reserveCapacity(count)
+    while collected.count < count {
+      let chunk = try receiveSome(min: 1, max: count - collected.count)
+      if chunk.isEmpty {
+        throw FridayReadClientError.transport("connection closed mid-frame (server dark?)")
+      }
+      collected.append(contentsOf: chunk)
+    }
+    return collected
+  }
+
+  private func receiveSome(min: Int, max: Int) throws -> [UInt8] {
+    let semaphore = DispatchSemaphore(value: 0)
+    let outcome = OutcomeBox()
+    let dataBox = DataBox()
+    connection.receive(minimumIncompleteLength: min, maximumLength: max) {
+      content, _, isComplete, error in
+      if let content { dataBox.set([UInt8](content)) }
+      if let error {
+        outcome.set(FridayReadClientError.transport("receive failed: \(error)"))
+      } else if (content == nil || content!.isEmpty) && isComplete {
+        // EOF with no bytes — the dark server never wrote a preamble.
+        outcome.set(FridayReadClientError.transport("connection closed (server dark?)"))
+      }
+      semaphore.signal()
+    }
+    if semaphore.wait(timeout: .now() + timeout) == .timedOut {
+      throw FridayReadClientError.transport("receive timed out (server dark?)")
+    }
+    if let error = outcome.take() { throw error }
+    return dataBox.take()
+  }
+
+  deinit { connection.cancel() }
+}
+
+// Small thread-safe boxes so the NWConnection callbacks (on a global queue) can hand a
+// result back to the waiting synchronous caller without data races.
+private final class OutcomeBox: @unchecked Sendable {
+  private let lock = NSLock()
+  private var error: Error?
+  func set(_ error: Error?) {
+    lock.lock(); defer { lock.unlock() }
+    if self.error == nil { self.error = error }
+  }
+  func take() -> Error? {
+    lock.lock(); defer { lock.unlock() }
+    return error
+  }
+}
+
+private final class DataBox: @unchecked Sendable {
+  private let lock = NSLock()
+  private var bytes: [UInt8] = []
+  func set(_ bytes: [UInt8]) {
+    lock.lock(); defer { lock.unlock() }
+    self.bytes = bytes
+  }
+  func take() -> [UInt8] {
+    lock.lock(); defer { lock.unlock() }
+    return bytes
+  }
+}

--- a/apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/WorkbenchSnapshotAdapter.swift
+++ b/apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/WorkbenchSnapshotAdapter.swift
@@ -1,0 +1,46 @@
+import Foundation
+import FridayRustClient
+
+// MARK: - Wire → display adapter
+//
+// The `FridayRustClient` package returns a THIN refs-only wire snapshot
+// (`FridayRustClient.WorkbenchSnapshot`: missionId / runtimeFeedStatus(String) /
+// statusLabels([String]) / routeDecisionSummary / workItemIds([String]) / generatedAtMs /
+// `raw`). The Console UI consumes the RICH, fully-typed `WorkbenchSnapshot` (work-items with
+// state/owner/done, capability states, transcript sections, receipt arrays, memory
+// candidates, the typed route decision). The thin model cannot feed the UI, so we bridge.
+//
+// The bridge is the wire snapshot's `raw` field — the FULL decoded refs-only projection JSON
+// the package kept precisely "so a UI can read fields this typed view does not surface". We
+// re-serialize `raw` and Codable-decode it into the rich display model. The rich model's
+// camelCase contract is wire-identical to the Rust projection JSON the package decoded, so
+// this is a clean re-decode, not a lossy mapping.
+//
+// TRUTH RULE: a serialize/decode failure must surface as honest UNAVAILABLE (the caller maps
+// the throw to `.unavailable`). We never make rich fields optional to force a partial decode —
+// that would fabricate a ready-looking snapshot from an unparseable projection.
+
+public enum WorkbenchSnapshotAdapter {
+  /// Adapt the package's refs-only wire snapshot into the Console's rich display snapshot by
+  /// re-decoding its retained `raw` projection JSON.
+  ///
+  /// Throws `FridayRustReadClientError.projectionUnavailable` on a serialize/decode failure —
+  /// which the view model renders AS truth ("unavailable"), never as a fabricated snapshot.
+  public static func display(
+    from wire: FridayRustClient.WorkbenchSnapshot
+  ) throws -> WorkbenchSnapshot {
+    let data: Data
+    do {
+      data = try JSONSerialization.data(withJSONObject: wire.raw)
+    } catch {
+      throw FridayRustReadClientError.projectionUnavailable(
+        reason: "projection JSON could not be re-serialized: \(error)")
+    }
+    do {
+      return try JSONDecoder().decode(WorkbenchSnapshot.self, from: data)
+    } catch {
+      throw FridayRustReadClientError.projectionUnavailable(
+        reason: "projection JSON did not match the Workbench contract: \(error)")
+    }
+  }
+}

--- a/apps/macos/FridayHubConsole/Tests/FridayHubConsoleCoreTests/OperationsOverviewViewModelTests.swift
+++ b/apps/macos/FridayHubConsole/Tests/FridayHubConsoleCoreTests/OperationsOverviewViewModelTests.swift
@@ -2,6 +2,7 @@ import Foundation
 import Testing
 
 @testable import FridayHubConsoleCore
+@testable import FridayRustClient
 
 @Test
 @MainActor
@@ -166,4 +167,99 @@ func decodesRustProjectionShapedJSON() throws {
   #expect(snapshot.statusLabels == [.stale, .offline, .error])
   #expect(snapshot.workItems.first?.state == .providerAck)
   #expect(snapshot.transcriptSections.first?.events.first?.evidenceRefs.timelineRef != nil)
+}
+
+// MARK: - Real FridayRustClient integration (wire → display reconciliation)
+
+@Test
+func mockWireSnapshotRoundTripsThroughAdapterToRichDisplay() throws {
+  // The reconciliation keystone: the package returns a THIN refs-only wire snapshot
+  // (`FridayRustClient.WorkbenchSnapshot`); the Console's `WorkbenchSnapshotAdapter` re-decodes
+  // its `raw` projection JSON into the rich display model. Adapting the representative wire
+  // snapshot must reproduce an EQUAL rich snapshot — proving the bridge is lossless for the
+  // fields the UI consumes (this is the same path the REAL client's response takes).
+  let wire = try MockReadClient.representativeWireSnapshot()
+  let display = try WorkbenchSnapshotAdapter.display(from: wire)
+  #expect(display == MockReadClient.representativeSnapshot)
+}
+
+@Test
+func adapterSurfacesMalformedProjectionAsUnavailableNotReady() throws {
+  // A wire snapshot whose `raw` is NOT a valid Workbench projection must throw (→ honest
+  // unavailable), never a partial-but-ready snapshot. We never fabricate readiness from
+  // unparseable JSON.
+  let junk = try FridayRustClient.WorkbenchSnapshot(
+    projectionJSON: #"{"missionId":"m"}"#.data(using: .utf8)!,
+    generatedAtMs: 0)
+  #expect(throws: FridayRustReadClientError.self) {
+    _ = try WorkbenchSnapshotAdapter.display(from: junk)
+  }
+}
+
+@Test
+@MainActor
+func realClientConnectionFailureRendersHonestUnavailable() async {
+  // THE REQUIRED TRUTH TEST — exercises the REAL `SealedWSReadClient`, not the mock.
+  //
+  // Pre-slice-6 the Rust read-projection server is DARK / not flipped, so the real client
+  // CANNOT connect — the EXPECTED normal state. We inject a transport that fails exactly as a
+  // dark/refused server does (`makeTransport` throws, which `fetchWorkbench()` calls FIRST,
+  // before any socket I/O — deterministic, no flaky real network). The view model MUST render
+  // this as the honest `.unavailable` state, never a fake-ready snapshot and never a crash.
+  let realClient = SealedWSReadClient(
+    keypair: FridayCrypto.DeviceKeypair(),
+    forwardedPrincipal: "owner:hub-console-desktop",
+    makeTransport: {
+      throw FridayReadClientError.transport("connection refused (read-projection server dark)")
+    })
+  let vm = OperationsOverviewViewModel(client: realClient)
+  await vm.refresh()
+
+  guard case let .unavailable(reason) = vm.state else {
+    Issue.record("real-client connect failure must render .unavailable, got \(vm.state)")
+    return
+  }
+  // The package error maps to an honest offline reason, and NO snapshot is fabricated.
+  #expect(reason.contains("offline") || reason.contains("connection"))
+  #expect(vm.state.snapshot == nil)
+}
+
+@Test
+@MainActor
+func loopbackTransportAgainstDarkServerRendersHonestUnavailable() async {
+  // THE PRODUCTION HONEST-UNAVAILABLE PATH — drives the REAL `LoopbackSealedWSTransport`
+  // (NWConnection + the synchronous bridge), NOT an injected throwing closure.
+  //
+  // Pre-slice-6 the read-projection server is DARK; nothing listens on the loopback port. The
+  // transport must fail at connect (refused / `.waiting` / bounded timeout) and the view model
+  // must render `.unavailable` — never fake-ready, never a hang, never a crash. We use a high
+  // loopback port nothing listens on + a short connectTimeout so the bound is observable.
+  let start = Date()
+  let client = RealReadClientFactory.make(
+    config: ReadProjectionServerConfig(host: "127.0.0.1", port: 49231, connectTimeout: 3),
+    forwardedPrincipal: "owner:hub-console-desktop")
+  let vm = OperationsOverviewViewModel(client: client)
+  await vm.refresh()
+  let elapsed = Date().timeIntervalSince(start)
+
+  guard case .unavailable = vm.state else {
+    Issue.record("dark loopback server must render .unavailable, got \(vm.state)")
+    return
+  }
+  // No fabricated snapshot, and the failure is BOUNDED (did not hang) — well under the timeout
+  // ceiling for a refused connect; comfortably under the test wall even if it times out.
+  #expect(vm.state.snapshot == nil)
+  #expect(elapsed < 10)
+}
+
+@Test
+func realClientFactoryBuildsAgainstLoopbackConfig() {
+  // The factory builds a real `SealedWSReadClient` (conforming to the unified protocol) for the
+  // read-projection server's loopback seam. This is wiring-only; the live round-trip against a
+  // RUNNING server is the deferred slice-6 acceptance criterion.
+  let client = RealReadClientFactory.make(
+    config: .slice6LoopbackPlaceholder,
+    forwardedPrincipal: "owner:hub-console-desktop")
+  #expect(client is SealedWSReadClient)
+  #expect(ReadProjectionServerConfig.slice6LoopbackPlaceholder.host == "127.0.0.1")
 }

--- a/apps/macos/FridayRustClient/Sources/FridayRustClient/ReadClient.swift
+++ b/apps/macos/FridayRustClient/Sources/FridayRustClient/ReadClient.swift
@@ -85,7 +85,11 @@ public protocol SealedWSTransport {
 
 /// The clean product-facing read client. A UI depends on THIS, not the transport. Returns
 /// the refs-only typed `WorkbenchSnapshot` mirroring the Rust `WorkbenchProjectionSnapshot`.
-public protocol FridayRustReadClient {
+///
+/// `Sendable` so a concurrent/actor-backed real client (and the SwiftUI view model that
+/// stores one) conforms cleanly under Swift 6 strict concurrency. (This was the Console's
+/// duplicate-protocol constraint; the two protocols are reconciled to this single one.)
+public protocol FridayRustReadClient: Sendable {
   /// Fetch the Mission Workbench refs-only projection over the sealed-WS read seam:
   /// handshake → owner-authed request → open the owner-sealed snapshot → typed result.
   func fetchWorkbench() async throws -> WorkbenchSnapshot
@@ -95,7 +99,12 @@ public protocol FridayRustReadClient {
 
 /// The sealed-WS read client. Drives the full handshake + request/response LOGIC over an
 /// injected `SealedWSTransport`. Pure byte-exact logic; the network is the injected pipe.
-public final class SealedWSReadClient: FridayRustReadClient {
+///
+/// `@unchecked Sendable`: every stored property is an immutable `let` (the keypair, the
+/// principal, the injected `@escaping` factory/closures). The closures are not statically
+/// `@Sendable` (so the protocol's `Sendable` is not auto-satisfied), but the instance carries
+/// no mutable shared state across the `await`, so it is safe to send. Asserted, not derived.
+public final class SealedWSReadClient: FridayRustReadClient, @unchecked Sendable {
   private let keypair: FridayCrypto.DeviceKeypair
   private let forwardedPrincipal: String
   private let missionId: String?


### PR DESCRIPTION
## What

Wires the **real** sealed-WS read client (`SealedWSReadClient` from the `FridayRustClient` package, #677) into the SwiftUI desktop **Hub Console** (`apps/macos/FridayHubConsole`), **replacing the `MockReadClient`** — the core "the app actually reads the live Rust core" integration step.

> **Stacking:** base = `ui-swift-sealed-ws-client-20260611`, so this **stacks on #677** and **merges after #677**. The branch already carries the merged Console (#676) + mobile (#679) via main.

Pre-slice-6 the Rust read-projection server (#675/#678, `hub_read_projection_server.rs`) is **DARK / not flipped**, so the real client **cannot connect** — that is EXPECTED. The Console renders the **honest "unavailable"** state (never fake-ready, never a crash) per the truth rules.

## Reconciling the two `WorkbenchSnapshot` / `FridayRustReadClient` definitions

The Console and the package each defined a `FridayRustReadClient` protocol and a `WorkbenchSnapshot` — but they are **not substitutable** (the package's snapshot is thin/refs-only; the Console's is the rich typed tree the whole UI consumes). Reconciled as:

- **Protocol → package wins.** Deleted the Console's duplicate `FridayRustReadClient`; the package's is the single source of truth (`import FridayRustClient` resolves the bare name across Core).
- **Snapshot → keep the Console's rich display model, bridge via an adapter.** The package's `WorkbenchSnapshot` is thin (`workItemIds:[String]`, `routeDecisionSummary:String?`, `runtimeFeedStatus:String`, + `raw`) and cannot feed the UI (work-items with state/owner/done, capability states, transcript sections, receipt arrays, the typed route decision, the `.chip`/`.isHealthy` enum extensions). So the Console's rich `WorkbenchSnapshot` is kept as the **display model** — the local declaration shadows the imported wire type within Core, so bare `WorkbenchSnapshot` stays the rich type; the wire type is qualified `FridayRustClient.WorkbenchSnapshot` only in the adapter + factory. **Did not** enrich the package's wire type or rewrite the UI to the thin type.
- **Adapter = the `raw` bridge.** `WorkbenchSnapshotAdapter.display(from:)` re-serializes the wire snapshot's retained `raw` projection JSON and Codable-decodes it into the rich display model (the rich model's camelCase contract is wire-identical to the Rust projection). A serialize/decode failure throws → honest `.unavailable`; rich fields are **not** made optional to force a partial-but-ready decode.

## `: Sendable` resolution

#677's package protocol omitted `: Sendable`; the Console's had it (so a concurrent/actor-backed client + the `@MainActor` view model conform under Swift 6 strict concurrency). Reconciled to the package's protocol **with `: Sendable` added**. `SealedWSReadClient` cannot auto-conform (its `@escaping` closures), so it is now `final class … FridayRustReadClient, @unchecked Sendable` with a justification (all stored state is `let`; no mutable shared state across the `await`). **This edit lands in `apps/macos/FridayRustClient/Sources/FridayRustClient/ReadClient.swift` in this PR's diff — it is the directed Sendable reconciliation, the correct home, not stray churn on #677's surface.**

## Honest-unavailable wiring + test

- The executable **defaults to the real client** (`RealReadClientFactory.make` over an `NWConnection` loopback `SealedWSReadClient`); the `MockReadClient` is kept **only** behind a launch flag (`--use-mock-read-client` / `FRIDAY_HUB_CONSOLE_USE_MOCK=1`) and for SwiftUI previews.
- A throw from the real client (dark/refused/timed-out server, OR an adapter decode failure) → the view model's `.unavailable` state, rendered AS truth via the existing `UnavailableView`. `reason(for:)` now maps **both** the package's `FridayReadClientError` and the Console's `FridayRustReadClientError`.
- **Tests** (13 green, +5 new):
  - `realClientConnectionFailureRendersHonestUnavailable` — exercises the **REAL** `SealedWSReadClient` (injected failing transport) → honest `.unavailable`, no snapshot (deterministic; `makeTransport()` is called first).
  - `loopbackTransportAgainstDarkServerRendersHonestUnavailable` — drives the **PRODUCTION** `LoopbackSealedWSTransport` (NWConnection) against a dark loopback port → honest `.unavailable` in **~0.003s** (bounded; no hang/crash/fake-ready). This proves the actual ship path, not just the VM mapping.
  - `mockWireSnapshotRoundTripsThroughAdapterToRichDisplay` — the wire→display bridge is **lossless** (the reconciliation keystone).
  - `adapterSurfacesMalformedProjectionAsUnavailableNotReady` — bad projection → throw, never partial-ready.
  - `realClientFactoryBuildsAgainstLoopbackConfig` — factory wiring.

## Local checks

- `swift build` (FridayHubConsole) — clean from-scratch build: **green**.
- `swift test` (FridayHubConsole) — **13/13 green** (8 original + 5 new).
- `swift build` + `swift test` (FridayRustClient) — **43/43 green** (the `: Sendable` / `@unchecked Sendable` changes don't regress the package or its KATs).
- SwiftUI Previews unchanged — still use the mock (loaded / 503 / offline).
- swift-sodium resolves from cache (no network wall); `Package.resolved` committed (revision matches the package's pin), per repo convention.

## Deferred

- **Placeholder owner principal**: `forwardedPrincipal: "owner:hub-console-desktop"` is also a placeholder (never validated pre-flip — connect refuses before auth). Reconcile it with the read-projection server's owner-allowlist at the slice-6 flip, same as the host:port.
- **Adapter strictness watch (slice-6)**: the wire→display adapter requires the FULL rich Workbench contract to decode from `raw`, while the package's thin wire snapshot only requires `missionId`. So a live projection the package accepts but that omits a rich-required field renders honest-unavailable *even with the server up* — the correct fail-safe (rich fields are deliberately NOT made optional; unknown enums already degrade to `.unknown`). The live `raw`→rich path is only truly proven at the flip; verify it there.
- **LIVE read round-trip = slice-6 operator gate**: the real WS upgrade + sealed exchange against a RUNNING read-projection server with the UI peer pubkey enrolled. `LoopbackSealedWSTransport.upgrade()/sendMessage()/recvMessage()` are explicit deferred stubs reached only after a successful connect+preamble (which the dark server never grants). The server's actual host:port is operator-supplied (`--port`, defaults to OS-assigned `0`) — the placeholder loopback config (`slice6LoopbackPlaceholder`) is intentionally a dark port and is **not** an asserted live endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
