### PR TITLE
S6: complete the mutating-chat PRODUCT path (DARK, default-off)

### DIFF
--- a/docs/ops/ts-runtime-retirement-manifest.json
+++ b/docs/ops/ts-runtime-retirement-manifest.json
@@ -562,6 +562,19 @@
       "next_action": "Replace fail-closed response with a Rust-owned agent run control entrypoint when available."
     },
     {
+      "id": "agent_runs_resume",
+      "route": {
+        "method": "POST",
+        "path": "/v1/agent/runs/:runId/resume",
+        "operationId": "agent.runs.resume"
+      },
+      "classification": "fail_closed",
+      "user_triggerable": true,
+      "executes_product_logic": false,
+      "proof": "src/api/http/routes/friday-agent-routes.ts gates agent.runs.resume on FRIDAY_AGENT_RUN_CONTROL_VIA_RUST (default-off): flag-off short-circuits to the byte-identical TS_RUNTIME_AGENT_RUNS_RETIRED 503 BEFORE any run lookup (no run-existence leak). Flag-on enforces caller==the wire run's bound owner, then relays the OPAQUE operator-signed Ed25519 approval blob verbatim to the Rust sealed-WS resumeWithApproval (INV-1: TS never parses/validates/inspects the signature/digest); the wire runId is bound to the executed run (pending.run_id==run_id, the s6-687 fix). TS performs NO agent/mutation execution — signature verification and the single approved mutation are Rust-owned under the operator Ed25519 verify key.",
+      "next_action": "Replace the flag-gated TS courier relay with a Rust-owned resume entrypoint when the UI connects the Rust hub directly (slice-6 end-state)."
+    },
+    {
       "id": "agent_runs_rollback",
       "route": {
         "method": "POST",

--- a/rust-core/crates/friday-hub/src/agent_run_control.rs
+++ b/rust-core/crates/friday-hub/src/agent_run_control.rs
@@ -29,17 +29,25 @@
 //!   OPERATOR's key, consume the nonce single-use, execute the ONE approved mutation, record the
 //!   owner). It does NOT re-implement verification/execution.
 //!
-//! ## The reject/cancel ↔ resume coupling (a REAL hole this module closes locally)
-//! The S6 spine's single-use guarantee is the gate's `consumed_approval` nonce store — NOT the
-//! `pending_approval_request.status` and NOT `agent_run.state`. [`resume_with_approval`] looks the
-//! pending row up by nonce and never reads either of those. So writing `status='rejected'` (reject)
-//! or `state='cancelled'` (cancel) ALONE does not block a later correctly-signed resume of the same
-//! approval — the mutation would still execute. To make reject/cancel REAL rather than cosmetic,
-//! [`resume`] PRE-CHECKS, before delegating: it refuses if the run is cancelled OR the pending row
-//! is rejected. This is a local, fail-closed bridge. A more robust spine-level fix (burn the nonce
-//! in `consumed_approval` on reject/cancel) needs a consumed-store insert API that does not exist
-//! yet, and the SAME pre-check is also absent from the existing `hub_resume_approval` dev bridge —
-//! both are surfaced as concerns.
+//! ## The wire-run binding + reject/cancel ↔ resume coupling (REAL holes this module closes locally)
+//! [`resume_with_approval`] takes NO `run_id`: it looks the pending row up by the blob's nonce and
+//! executes whatever run that pending row names (`pending.run_id`). It also never reads
+//! `pending_approval_request.status` or `agent_run.state` (the spine's single-use guarantee is the
+//! gate's `consumed_approval` nonce store ALONE). So [`resume`] must enforce three things against
+//! the WIRE `run_id` before delegating, all fail-closed:
+//!   1. **Wire-run binding (security).** `pending.run_id == run_id`, else `run_mismatch`. The TS
+//!      resume route owner-gates the run named by the wire `run_id`; without this the owner-gated
+//!      run and the executed (nonce-selected) run could differ — an attacker owning run A could
+//!      resume A on the wire while carrying a nonce belonging to victim run B, executing B's
+//!      mutation past A's owner gate. Mirrors [`reject`]'s existing `run_mismatch` binding.
+//!   2. **Cancel coupling.** Refuse if the run is cancelled (`state='cancelled'`) — else a
+//!      correctly-signed resume would still execute a cancelled run's mutation.
+//!   3. **Reject coupling.** Refuse if the pending row is rejected (`status='rejected'`).
+//! Binding (1) also makes the cancel pre-check (2) CONSISTENT: every path that proceeds has
+//! `run_id == pending.run_id`, so `is_cancelled(run_id)` keys on the SAME run the spine executes.
+//! A more robust spine-level fix (burn the nonce in `consumed_approval` on reject/cancel) needs a
+//! consumed-store insert API that does not exist yet, and the SAME pre-checks are also absent from
+//! the existing `hub_resume_approval` dev bridge — both are surfaced as concerns.
 //!
 //! ## Auth model (HONEST)
 //! RESUME is self-authenticating: the AUTHORITY is the operator's Ed25519 signature over the
@@ -381,13 +389,19 @@ fn parse_decision(s: &str) -> Option<ApprovalDecision> {
 /// single-use, execute the ONE approved mutation, record the owner). It NEVER re-implements
 /// verification/execution.
 ///
-/// **The reject/cancel coupling (REAL, not cosmetic).** BEFORE delegating, this PRE-CHECKS the run
-/// is not cancelled and the targeted pending row is not rejected — because the spine's single-use
-/// guard is the `consumed_approval` store, not `agent_run.state`/`pending.status`, so without this
-/// check a correctly-signed resume would still execute a rejected/cancelled run's mutation.
-/// Fail-closed outcomes: `malformed_blob`, `run_cancelled`, `approval_rejected`, and the bounded
-/// resume-error tokens. Accepted maps the gate decision: `mutation_completed` (executed) /
-/// `mutation_exec_failed` / `approval_refused` (gate Deny — replay/expired/bad-signature).
+/// **The wire-run binding (security MUST-FIX) + reject/cancel coupling (REAL, not cosmetic).**
+/// BEFORE delegating, this PRE-CHECKS, against the WIRE `run_id`: (a) that the nonce's pending row
+/// belongs to the SAME run as the wire `run_id` (`pending.run_id == run_id`) — the spine selects
+/// the run to execute SOLELY from the nonce, so without this the route's owner gate (keyed on the
+/// wire `run_id`) and the executed run could differ (`run_mismatch`); (b) that the run is not
+/// cancelled; and (c) that the targeted pending row is not rejected. (b)/(c) are needed because the
+/// spine's single-use guard is the `consumed_approval` store, not `agent_run.state`/`pending.status`,
+/// so without them a correctly-signed resume would still execute a rejected/cancelled run's
+/// mutation. The (a) binding ALSO makes the (b) `is_cancelled` pre-check consistent (it keys on the
+/// same run the spine executes). Fail-closed outcomes: `malformed_blob`, `run_mismatch`,
+/// `run_cancelled`, `approval_rejected`, and the bounded resume-error tokens. Accepted maps the gate
+/// decision: `mutation_completed` (executed) / `mutation_exec_failed` / `approval_refused` (gate
+/// Deny — replay/expired/bad-signature).
 pub fn resume(
     conn: &Connection,
     executor: &dyn ToolExecutor,
@@ -428,6 +442,21 @@ pub fn resume(
         return Ok(ControlOutcome::refused("resume", "run_cancelled"));
     }
     if let Some(pending) = get_pending_request(conn, &approval.approval_id)? {
+        // (2a) WIRE-RUN ↔ EXECUTED-RUN BINDING (security MUST-FIX). The TS resume route owner-gates
+        //      the run named by the WIRE `run_id` (it 403s unless the authed caller owns THAT run),
+        //      but the spine selects the run to execute SOLELY from the blob's nonce
+        //      (`pending.run_id`) and takes no `run_id`. Without this check the owner-gated run and
+        //      the executed run could DIFFER: an attacker who owns run A could resume A on the wire
+        //      while carrying a nonce whose pending row belongs to victim run B, executing B's
+        //      mutation past A's owner gate. Refuse fail-closed unless the wire run is the SAME run
+        //      the nonce will execute (mirrors `reject`'s `run_mismatch` binding — same wire vocab,
+        //      no protocol change). This ALSO makes the `is_cancelled(conn, run_id)` pre-check above
+        //      consistent: every path that proceeds now has `run_id == pending.run_id`, so the
+        //      cancel pre-check keys on the SAME run the spine will execute (the latent coupling the
+        //      review flagged is closed by this one binding).
+        if pending.run_id != run_id {
+            return Ok(ControlOutcome::refused("resume", "run_mismatch"));
+        }
         if pending.status == PENDING_STATUS_REJECTED {
             return Ok(ControlOutcome::refused("resume", "approval_rejected"));
         }

--- a/rust-core/crates/friday-hub/src/hub_server.rs
+++ b/rust-core/crates/friday-hub/src/hub_server.rs
@@ -6406,4 +6406,92 @@ mod authed_route_tests {
             "with no override + non-read-only boot, the run is NOT read-only-blocked (the override is what blocks)"
         );
     }
+
+    /// A non-read-only per-run constraint (`read_only:false`) composing onto a non-read-only boot
+    /// policy.
+    fn mutating_override(rt_principal: &str) -> crate::RunPolicy {
+        let c = friday_protocol::AgentRunConstraintsWire {
+            read_only: false,
+            disabled_tools: vec![],
+            max_turns: None,
+        };
+        let boot =
+            crate::RunPolicy::new(Some(rt_principal.to_string()), Vec::<String>::new(), false);
+        crate::agent_run_control::effective_run_policy_over(&boot, Some(&c))
+    }
+
+    /// (S6 mutating-chat — THE B#3 LOAD-BEARING TEST) A mutating run admitted under the LIVE
+    /// dispatch entry with a per-run `read_only:false` constraint composed onto the server's
+    /// `read_only:false` boot policy (exactly what the WS server's flag-on dispatch arm builds via
+    /// `effective_run_policy_over(runtime.policy(), constraints)`) must **PAUSE** the mutating tool
+    /// pending an operator-signed approval — NOT Deny it (that would force the read-only path), and
+    /// NOT silently Allow it (the catastrophic escalation the whole S6 model rests on NOT happening).
+    ///
+    /// This is the complement to `a1_sessionless_override_read_only_blocks_mutating_tool` (the
+    /// `read_only:true → BLOCK` case): together they pin both arms of the composed-policy gate. The
+    /// `read_only:false` composition is the ACTUAL mutating-chat dispatch — the existing test only
+    /// proved the tightening direction; this proves a permitted-but-ungated mutation HALTS, so the
+    /// only path to execution is the operator's Ed25519 signature (proven end-to-end by
+    /// `s6d_resume_ingestion.rs` / `a1_run_control.rs`).
+    #[test]
+    fn s6_mutating_override_read_only_false_pauses_not_allows_not_denies() {
+        let (rt, ws) = runtime_with("s6-mutate-pause", MutateTransport, "principal:owner");
+        let caller = authed("principal:owner");
+        let policy = mutating_override("principal:owner");
+
+        // The composed policy is NOT read-only (no escalation, no silent loosening did NOT happen)
+        // — a `read_only:false` constraint over a `read_only:false` boot stays mutating-CAPABLE.
+        assert!(
+            !policy.is_read_only(),
+            "read_only:false over read_only:false boot stays non-read-only (mutating-capable)"
+        );
+
+        let out = run_authed_agent_loop_with_policy(
+            &rt,
+            &caller,
+            "s6-mut-ro-false",
+            "write a file",
+            Some(&policy),
+            None,
+            1000,
+        );
+
+        // PAUSE ⇒ no body delivered, NO file written (the mutation did NOT execute).
+        assert!(
+            out.delivered_body().is_none(),
+            "a paused (ungated) mutating run delivers no body"
+        );
+        assert!(
+            !ws.0.join("out.txt").exists(),
+            "the mutating tool PAUSED — it must NOT have executed without an operator signature"
+        );
+
+        // It is NOT a read-only Deny (that would be the wrong, over-restrictive outcome): there is
+        // NO `run_is_read_only:*` block event for this run.
+        let ro_blocked: i64 = rt
+            .db()
+            .conn()
+            .query_row(
+                "SELECT count(*) FROM agent_run_event WHERE run_id = 's6-mut-ro-false' AND kind LIKE 'tool.blocked:deny:run_is_read_only:%'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(
+            ro_blocked, 0,
+            "a read_only:false mutating run must NOT be read-only-denied (it pauses, not denies)"
+        );
+
+        // It DID pause: a live `pending` approval row (CSPRNG nonce + the exact tool call + digest)
+        // was persisted — the single thing an operator signature later authorizes. This is the gate
+        // standing between an admitted mutating run and an unsigned mutation executing.
+        let pause = crate::agent_run_control::detect_pause(rt.db().conn(), "s6-mut-ro-false")
+            .unwrap();
+        let pause = pause.expect("an ungated mutating run must PAUSE pending approval");
+        assert_eq!(pause.nonce.len(), 64, "CSPRNG nonce is 32 bytes => 64 hex");
+        assert!(
+            pause.summary.contains("write_file"),
+            "the pause is for the mutating write_file action"
+        );
+    }
 }

--- a/rust-core/crates/friday-hub/src/hub_server.rs
+++ b/rust-core/crates/friday-hub/src/hub_server.rs
@@ -6485,8 +6485,8 @@ mod authed_route_tests {
         // It DID pause: a live `pending` approval row (CSPRNG nonce + the exact tool call + digest)
         // was persisted — the single thing an operator signature later authorizes. This is the gate
         // standing between an admitted mutating run and an unsigned mutation executing.
-        let pause = crate::agent_run_control::detect_pause(rt.db().conn(), "s6-mut-ro-false")
-            .unwrap();
+        let pause =
+            crate::agent_run_control::detect_pause(rt.db().conn(), "s6-mut-ro-false").unwrap();
         let pause = pause.expect("an ungated mutating run must PAUSE pending approval");
         assert_eq!(pause.nonce.len(), 64, "CSPRNG nonce is 32 bytes => 64 hex");
         assert!(

--- a/rust-core/crates/friday-hub/tests/a1_run_control.rs
+++ b/rust-core/crates/friday-hub/tests/a1_run_control.rs
@@ -336,6 +336,80 @@ fn cancelled_run_cannot_be_resumed_no_mutation() {
     );
 }
 
+/// THE WIRE-RUN BINDING (security MUST-FIX). The spine selects the run to execute SOLELY from the
+/// blob's nonce (`pending.run_id`) and takes no run_id, while the TS route owner-gates the run named
+/// by the WIRE run_id. Without the resume handler's `pending.run_id == run_id` pre-check, an
+/// attacker who owns run A could resume A on the wire while carrying a nonce whose pending row
+/// belongs to victim run B — executing B's mutation past A's owner gate. This proves the binding:
+/// a resume whose wire run_id != the blob's `pending.run_id` is REFUSED (`run_mismatch`) and NO
+/// mutation runs. (The wire run here is a real, non-cancelled run, so the check lands on the binding
+/// — not on the cancel pre-check.)
+#[test]
+fn resume_wire_run_mismatch_is_refused_no_mutation() {
+    let (sk, vk) = operator();
+    // The victim run is paused on a mutation; `nonce`/`request` describe THAT pending action.
+    let (db, ws, nonce, request) = pause_owned_run("wire-mismatch", &vk);
+    let exec = FsToolExecutor::new(&ws.0);
+
+    // A SECOND, real, non-cancelled run the attacker controls on the wire (NOT the run the nonce
+    // belongs to). It exists so the resume passes the `is_cancelled` pre-check and lands squarely on
+    // the wire-run binding rather than failing for an unrelated reason.
+    agent_run::create_run(db.conn(), "run-attacker", "attacker run", 1).unwrap();
+
+    // A correctly-signed approval for the VICTIM's paused action, but the resume names the ATTACKER's
+    // wire run_id. The binding must refuse before the spine can consume the nonce + execute.
+    let approval = ed_approval(&request, &sk, &nonce, Some(FUTURE));
+    let out = resume(
+        db.conn(),
+        &exec,
+        &vk,
+        "run-attacker",
+        &signed_blob(&approval),
+        NOW,
+    )
+    .unwrap();
+    assert!(
+        !out.accepted,
+        "a resume whose wire run_id != the nonce's pending.run_id must be refused"
+    );
+    assert_eq!(out.status, "run_mismatch");
+    assert!(
+        out.audit_ref.is_none(),
+        "a refused-before-spine resume writes no receipt"
+    );
+    assert!(
+        !ws.join("out.txt").exists(),
+        "the mismatched resume must NOT have executed the victim's mutation"
+    );
+    // The victim's pending row is untouched (still `pending`, nonce NOT consumed) — so the legitimate
+    // owner can still resume it on the correct wire run_id.
+    assert_eq!(
+        get_pending_request(db.conn(), &nonce)
+            .unwrap()
+            .unwrap()
+            .status,
+        "pending"
+    );
+
+    // POSITIVE CONTROL: the SAME approval on the CORRECT wire run_id (the victim's) executes — the
+    // binding refuses only the mismatch, never a legitimate resume.
+    let out = resume(
+        db.conn(),
+        &exec,
+        &vk,
+        "run-ctl",
+        &signed_blob(&approval),
+        NOW,
+    )
+    .unwrap();
+    assert!(out.accepted, "the matching wire run_id resumes normally");
+    assert_eq!(out.status, "mutation_completed");
+    assert_eq!(
+        std::fs::read_to_string(ws.join("out.txt")).unwrap(),
+        "RESUMED"
+    );
+}
+
 // ─────────────────────────── resume happy path + fail-closed ───────────────────────────
 
 /// The positive control: a correctly-signed resume of a non-cancelled/non-rejected paused run

--- a/src/api/http/routes/friday-agent-routes.ts
+++ b/src/api/http/routes/friday-agent-routes.ts
@@ -1670,10 +1670,15 @@ export function createFridayAgentRoutes(
     //   * FLAG OFF (the default) ⇒ SHORT-CIRCUIT to the byte-identical retired 503 BEFORE any run
     //     lookup — a DARK host's `/resume` is indistinguishable from the retired path (no run
     //     existence leak, byte-identical to today).
-    //   * FLAG ON ⇒ require a bound owner principal, fetch the run, enforce the authenticated
-    //     principal === the run's bound owner (the run's `metadata.apiRequest.principalId`) — reject
-    //     fail-closed otherwise (this TS gate is LOAD-BEARING: Rust resume is signature-authed and
-    //     does NOT re-check the owner) — then relay the OPAQUE signed blob VERBATIM to Rust.
+    //   * FLAG ON ⇒ require a bound owner principal, fetch the run named by the WIRE `runId`, and
+    //     enforce the authenticated principal === THAT run's bound owner (its
+    //     `metadata.apiRequest.principalId`) — reject fail-closed otherwise — then relay the OPAQUE
+    //     signed blob VERBATIM to Rust. This TS gate checks the owner of the WIRE `runId`; Rust
+    //     resume is signature-authed and does NOT re-check the owner, but (since the s6-687 fix) the
+    //     Rust side BINDS `pending.run_id == run_id`, so the owner-gated run (wire `runId`) and the
+    //     run the nonce actually executes are guaranteed to be the SAME run — a resume whose wire
+    //     `runId` mismatches the nonce's pending row is refused in Rust (`run_mismatch`) and runs
+    //     nothing.
     // INV-1 (opaque relay): the route NEVER parses/validates/inspects the signature/digest; it
     // base64-decodes the operator's `signedApproval` to bytes and hands them through unchanged.
     // Verification happens ONLY in Rust under the operator verify key (the hub holds no signing key).
@@ -1695,10 +1700,14 @@ export function createFridayAgentRoutes(
         // (b) BOUND OWNER required. The synthetic public principal can never own/resume a run.
         const bound = assertBoundPrincipalForOperation(ctx.principal, "agent.run.resume", "api");
 
-        // (c) Fetch the run; enforce the authenticated principal === the run's BOUND OWNER. An
-        // ownerless run (no stamped owner) is resumable by NOBODY (fail-closed). Any mismatch ⇒
-        // 403, never executing the mutation under the wrong principal. (Rust does NOT re-check the
-        // owner on resume — it is signature-authed — so this gate is the owner boundary.)
+        // (c) Fetch the run named by the WIRE `runId`; enforce the authenticated principal === THAT
+        // run's BOUND OWNER. An ownerless run (no stamped owner) is resumable by NOBODY
+        // (fail-closed). Any mismatch ⇒ 403, never executing the mutation under the wrong principal.
+        // Rust does NOT re-check the owner on resume (it is signature-authed), but it DOES bind
+        // `pending.run_id == run_id` (the s6-687 wire-run binding) — so the run this gate owner-checks
+        // (the wire `runId`) and the run the nonce executes are the SAME run; a wire/nonce run
+        // mismatch is refused in Rust before any execution. This gate is thus the owner boundary for
+        // the run that actually resumes.
         const run = getVisibleRunOrThrow(runId);
         const ownerPrincipalId = readRunOwnerPrincipalId(run);
         if (!ownerPrincipalId || ownerPrincipalId !== bound.principalId) {

--- a/src/api/http/routes/friday-agent-routes.ts
+++ b/src/api/http/routes/friday-agent-routes.ts
@@ -6,6 +6,7 @@ import type {
   FridayGetAgentRunResponse,
   FridayListAgentRunsQuery,
   FridayListAgentRunsResponse,
+  FridayResumeAgentRunResponse,
   FridayStartAgentRunRequest,
   FridayStartAgentRunResponse,
 } from "../../model/friday-api-agent.types.js";
@@ -914,6 +915,14 @@ export interface FridayAgentRoutesDeps {
     // unchanged 503). Forwarded RAW — presence-only, never coerced/injected (route-not-method
     // pin: it may only DISQUALIFY, never grant). Absent for every existing caller.
     planReviewOverride?: unknown;
+    // (A2b Phase 2, mutation-relax — DARK, default-off) the explicit POSITIVE grant of mutating
+    // Rust tools + the operator-signed gate opt-in marker. Additive + optional; forwarded straight
+    // to the route-bound startRun wrapper, which (ONLY when the default-OFF
+    // `FRIDAY_AGENT_RUN_CONTROL_VIA_RUST` flag is on) lets the qualifier admit a `readOnly:false`
+    // run. Absent for every existing caller (→ the mutating branch never opens → byte-identical
+    // 503). NEVER infers mutation-permission from `readOnly` flipping — both are explicit gates.
+    mutatingToolGrant?: string[];
+    mutationGate?: string;
   }) => Promise<FridayAgentRuntimeResult>;
   getRun: (runId: string) => FridayAgentRunRecord | null;
   listRuns: (query: {
@@ -939,6 +948,31 @@ export interface FridayAgentRoutesDeps {
   rollbackRun?: (runId: string) => { restoredCount: number; errors: Array<{ filePath: string; error: string }> } | null;
   eventEmitter: FridayAgentEventEmitter;
   automationService: FridayAgentAutomationService;
+  /**
+   * (S6 mutating-chat — DARK, default-off) The resolved on/off state of the Rust run-CONTROL plane
+   * flag (`FRIDAY_AGENT_RUN_CONTROL_VIA_RUST`). The resume route is gated on this being EXACTLY
+   * `true`; absent / `undefined` / `false` (the default) ⇒ the resume route SHORT-CIRCUITS to the
+   * SAME fail-closed 503 a non-routed (retired) run raises — BEFORE any run lookup, so a dark host
+   * leaks no run existence and is byte-identical to today. Sourced from the SAME
+   * `resolveAgentRunControlViaRust` boolean the Rust server + sealed client gate on, so the TS
+   * control surface and the Rust control plane flip together.
+   */
+  agentRunControlViaRust?: boolean;
+  /**
+   * (S6 mutating-chat — DARK, default-off) Relay an operator's OPAQUE Ed25519-signed approval to
+   * RESUME a paused mutating run. The route is a PURE COURIER: it relays `opaqueSignedBlob` VERBATIM
+   * to the Rust sealed-WS resume (INV-1 — TS NEVER parses/validates/inspects the signature/digest;
+   * verification happens ONLY in Rust under the operator verify key). The route enforces, BEFORE
+   * calling this, that the authenticated caller equals the run's bound owner. This fn resolves the
+   * WS client X25519 secret + dials the sealed resume; it fails CLOSED (the byte-identical 503) on a
+   * missing secret / WS error / flag-off. Returns the refs-only resume outcome. Provided ONLY by the
+   * runtime; absent ⇒ the route is unreachable (its flag gate has already 503'd).
+   */
+  resumeRun?: (
+    runId: string,
+    opaqueSignedBlob: Uint8Array,
+    principal: FridayAuthPrincipal | null,
+  ) => Promise<FridayResumeAgentRunResponse>;
 }
 
 interface FridayAgentPlanControlInput {
@@ -1166,6 +1200,34 @@ export function createFridayAgentRoutes(
       );
     }
     return run;
+  }
+
+  // (S6 mutating-chat) The byte-IDENTICAL fail-closed 503 a non-routed (retired) agent-run raises
+  // (same code/message/status/classification/replacement as the runtime's `failClosedRustAgentRun`
+  // + the retired `startRun`). The resume route throws this on the flag-OFF short-circuit — BEFORE
+  // any run lookup — so a DARK host's `/resume` is INDISTINGUISHABLE from the retired path: it leaks
+  // no run existence and is byte-identical to today.
+  function failClosedResumeRoute(): FridayDomainError {
+    return new FridayDomainError(
+      "TS_RUNTIME_AGENT_RUNS_RETIRED",
+      "Agent run execution is fail-closed while runtime ownership is being moved out of TypeScript.",
+      {
+        httpStatus: 503,
+        details: {
+          classification: "fail_closed",
+          replacement: "rust_owned_agent_run_entrypoint_required",
+        },
+      },
+    );
+  }
+
+  // (S6 mutating-chat) Read a run's BOUND OWNER principal from `metadata.apiRequest.principalId`
+  // (the SAME shape the compose paused/delivered projection stamps + the idempotency reads use).
+  // A blank/whitespace/absent value ⇒ `undefined` (fail-closed: an ownerless run can be resumed by
+  // NOBODY — every caller mismatches). NEVER the body — a principal id is a ref.
+  function readRunOwnerPrincipalId(run: FridayAgentRunRecord): string | undefined {
+    const owner = run.metadata?.apiRequest?.principalId;
+    return typeof owner === "string" && owner.trim().length > 0 ? owner.trim() : undefined;
   }
 
   function buildTenantContext(principal: unknown): FridayProviderTenantContext | undefined {
@@ -1417,6 +1479,28 @@ export function createFridayAgentRoutes(
         // disqualified instead of (incorrectly) qualifying.
         const hasPlanReviewOverride = "planReviewOverride" in body;
 
+        // (A2b Phase 2, mutation-relax — DARK, default-off) parse the explicit, optional per-run
+        // mutating-tool grant + the operator-signed gate marker. Mirrors the `allowedRustRouteTools`
+        // extraction EXACTLY: accepted ONLY as an array of non-empty strings (grant) / a non-empty
+        // string (gate); any other shape (or absence) ⇒ undefined. ADDITIVE: no existing caller sends
+        // either, so behavior is unchanged (→ the qualifier's mutating branch stays closed → today's
+        // 503). The gate is enforced downstream by the qualifier (closed allow-list + the
+        // `operator_signed_ed25519` marker) ONLY behind the default-off `FRIDAY_AGENT_RUN_CONTROL_VIA_RUST`
+        // flag — these fields can ONLY make a `readOnly:false` run a CANDIDATE, never AUTHORIZE the
+        // mutation (the Rust gate Pauses every mutating tool pending an operator-signed Ed25519
+        // approval; this route never carries the signature). Mutation-permission is NEVER inferred
+        // from `readOnly` flipping — both the grant and the marker are explicit, required gates.
+        const mutatingToolGrant = Array.isArray(body.mutatingToolGrant)
+          && body.mutatingToolGrant.every(
+            (t): t is string => typeof t === "string" && t.length > 0,
+          )
+          ? body.mutatingToolGrant
+          : undefined;
+        const mutationGate =
+          typeof body.mutationGate === "string" && body.mutationGate.length > 0
+            ? body.mutationGate
+            : undefined;
+
         const result = await deps.startRun({
           task: body.task,
           taskPrompt,
@@ -1435,6 +1519,8 @@ export function createFridayAgentRoutes(
           ...(hasPlanReviewOverride
             ? { planReviewOverride: (body as Record<string, unknown>).planReviewOverride }
             : {}),
+          ...(mutatingToolGrant ? { mutatingToolGrant } : {}),
+          ...(mutationGate ? { mutationGate } : {}),
           ...(apiIdempotencyKey
             ? {
               apiIdempotencyKey,
@@ -1575,6 +1661,88 @@ export function createFridayAgentRoutes(
         deps.cancelRun(runId);
         const response: FridayCancelAgentRunResponse = { cancelled: true, runId };
         return response;
+      },
+    },
+
+    // ─── POST /v1/agent/runs/:runId/resume ───
+    // (S6 mutating-chat — DARK, default-off) Relay an operator's OPAQUE Ed25519-signed approval to
+    // RESUME a paused mutating run. GATED on `FRIDAY_AGENT_RUN_CONTROL_VIA_RUST`:
+    //   * FLAG OFF (the default) ⇒ SHORT-CIRCUIT to the byte-identical retired 503 BEFORE any run
+    //     lookup — a DARK host's `/resume` is indistinguishable from the retired path (no run
+    //     existence leak, byte-identical to today).
+    //   * FLAG ON ⇒ require a bound owner principal, fetch the run, enforce the authenticated
+    //     principal === the run's bound owner (the run's `metadata.apiRequest.principalId`) — reject
+    //     fail-closed otherwise (this TS gate is LOAD-BEARING: Rust resume is signature-authed and
+    //     does NOT re-check the owner) — then relay the OPAQUE signed blob VERBATIM to Rust.
+    // INV-1 (opaque relay): the route NEVER parses/validates/inspects the signature/digest; it
+    // base64-decodes the operator's `signedApproval` to bytes and hands them through unchanged.
+    // Verification happens ONLY in Rust under the operator verify key (the hub holds no signing key).
+    {
+      operationId: "agent.runs.resume",
+      method: "POST",
+      path: "/v1/agent/runs/:runId/resume",
+      auth: { public: true },
+      async handler(ctx) {
+        const { runId } = ctx.params as { runId: string };
+
+        // (a) FLAG GATE — checked FIRST, BEFORE any run lookup. Flag off / resume fn absent ⇒ the
+        // byte-identical retired 503 (DARK: no run existence leak). `resumeRun` is provided ONLY by
+        // the runtime; its absence is treated identically to flag-off (defense-in-depth).
+        if (deps.agentRunControlViaRust !== true || !deps.resumeRun) {
+          throw failClosedResumeRoute();
+        }
+
+        // (b) BOUND OWNER required. The synthetic public principal can never own/resume a run.
+        const bound = assertBoundPrincipalForOperation(ctx.principal, "agent.run.resume", "api");
+
+        // (c) Fetch the run; enforce the authenticated principal === the run's BOUND OWNER. An
+        // ownerless run (no stamped owner) is resumable by NOBODY (fail-closed). Any mismatch ⇒
+        // 403, never executing the mutation under the wrong principal. (Rust does NOT re-check the
+        // owner on resume — it is signature-authed — so this gate is the owner boundary.)
+        const run = getVisibleRunOrThrow(runId);
+        const ownerPrincipalId = readRunOwnerPrincipalId(run);
+        if (!ownerPrincipalId || ownerPrincipalId !== bound.principalId) {
+          throw new FridayDomainError(
+            "AGENT_RUN_RESUME_PRINCIPAL_MISMATCH",
+            "The authenticated principal is not the bound owner of this run.",
+            { httpStatus: 403 },
+          );
+        }
+
+        // (d) OPAQUE relay. The operator's signed CanonicalApproval rides the body as a base64
+        // string (`signedApproval`); decode it to bytes VERBATIM and relay — NEVER parse/inspect the
+        // signature/digest (INV-1). A missing/non-string/undecodable value is a 400 (no relay, no
+        // mutation). We do NOT validate JSON-ness or any inner field — Rust owns verification.
+        const body = ctx.body as { signedApproval?: unknown } | null | undefined;
+        const signedApprovalB64 = body?.signedApproval;
+        if (typeof signedApprovalB64 !== "string" || signedApprovalB64.length === 0) {
+          throw new FridayDomainError(
+            "AGENT_RUN_RESUME_SIGNED_APPROVAL_REQUIRED",
+            "signedApproval (base64-encoded operator-signed approval) is required in the request body.",
+            { httpStatus: 400 },
+          );
+        }
+        let opaqueSignedBlob: Uint8Array;
+        try {
+          opaqueSignedBlob = new Uint8Array(Buffer.from(signedApprovalB64, "base64"));
+        } catch {
+          throw new FridayDomainError(
+            "AGENT_RUN_RESUME_SIGNED_APPROVAL_MALFORMED",
+            "signedApproval could not be base64-decoded.",
+            { httpStatus: 400 },
+          );
+        }
+        if (opaqueSignedBlob.length === 0) {
+          throw new FridayDomainError(
+            "AGENT_RUN_RESUME_SIGNED_APPROVAL_MALFORMED",
+            "signedApproval decoded to an empty blob.",
+            { httpStatus: 400 },
+          );
+        }
+
+        // (e) Relay VERBATIM to the runtime resume (which resolves the WS secret + dials the sealed
+        // resume; fails closed on any error). Returns the refs-only outcome (NEVER a body).
+        return await deps.resumeRun(runId, opaqueSignedBlob, ctx.principal);
       },
     },
 

--- a/src/api/mission-spine/friday-rust-hub-run-continuity-projector-service.ts
+++ b/src/api/mission-spine/friday-rust-hub-run-continuity-projector-service.ts
@@ -108,6 +108,17 @@ export interface FridayRustHubRunReceipt {
   readonly usageTotalTokens: number;
   /** ISO timestamp the Rust run completed (drives the TS continuity timestamps). */
   readonly completedAtIso: string;
+  /**
+   * (S6 mutating-chat) The run's BOUND OWNER principal — stamped onto the projected row's
+   * `metadata.apiRequest.principalId` (the SAME shape the delivered idempotency stamp + the read
+   * routes use) so a LATER owner-gated control op (the resume route) can match the authenticated
+   * caller to the run's owner. OPTIONAL + additive: absent ⇒ no owner stamp (byte-identical to
+   * today — the delivered-finished branch still stamps owner via its own idempotency merge, and a
+   * sessionless/ownerless run stays ownerless). Set by the PAUSED compose branch (which previously
+   * returned BEFORE any owner stamp, leaving a paused row ownerless) so a paused mutating run has a
+   * real owner to authorize its resume against. NEVER the body — a principal id is a ref.
+   */
+  readonly ownerPrincipalId?: string;
 }
 
 /** What the projector wrote/found (refs-only — no body). */
@@ -245,6 +256,13 @@ export function createFridayRustHubRunContinuityProjectorService(): FridayRustHu
           finalMessageLen: receipt.finalMessageLen,
           ...(receipt.errorCategory ? { errorCategory: receipt.errorCategory } : {}),
         },
+        // (S6 mutating-chat) Stamp the bound OWNER under the SAME `apiRequest.principalId` shape
+        // the delivered-finished idempotency merge + the read routes use, so the resume route can
+        // authorize an owner-gated control op against the run's owner. Conditional ⇒ omitted when
+        // absent (byte-identical to the pre-S6 row). A principal id is a ref, never a body.
+        ...(receipt.ownerPrincipalId
+          ? { apiRequest: { principalId: receipt.ownerPrincipalId } }
+          : {}),
       });
 
       // NOTE: `context_cost_summary_json` is left UNSET. That column is read via

--- a/src/api/model/friday-api-agent.types.ts
+++ b/src/api/model/friday-api-agent.types.ts
@@ -34,6 +34,19 @@ export interface FridayStartAgentRunRequest {
    * readOnly — this is the independent clause-4 gate.
    */
   allowedRustRouteTools?: string[];
+  /**
+   * (A2b Phase 2, mutation-relax — DARK, default-off) the explicit POSITIVE grant of mutating
+   * Rust tools (a subset of write_file/append_file/edit_file/delete_file/move_file/run_command)
+   * and the REQUIRED operator-signed gate opt-in marker (`"operator_signed_ed25519"`). Additive +
+   * optional — every existing caller omits BOTH. A `readOnly:false` run is admitted to the Rust
+   * route ONLY when the default-OFF `FRIDAY_AGENT_RUN_CONTROL_VIA_RUST` flag is on AND it carries a
+   * non-empty grant ⊆ the closed mutating allow-list AND `mutationGate === "operator_signed_ed25519"`
+   * AND a bound owner principal. These admit CANDIDACY only — the Rust runtime gate Pauses every
+   * mutating tool pending an operator-signed Ed25519 approval (the signature, NOT this field, is the
+   * authority). Absent / flag-off ⇒ a `readOnly:false` run stays disqualified ⇒ today's 503.
+   */
+  mutatingToolGrant?: string[];
+  mutationGate?: string;
 }
 
 export interface FridayAgentRunExecutionResponse {
@@ -73,4 +86,21 @@ export interface FridayGetAgentRunResponse {
 export interface FridayCancelAgentRunResponse {
   cancelled: boolean;
   runId: string;
+}
+
+/**
+ * (S6 mutating-chat — DARK, default-off) The REFS-ONLY outcome of relaying an operator-signed
+ * approval to RESUME a paused mutating run. Mirrors the Rust `AgentRunControlResult` the sealed-WS
+ * resume returns: the coarse op/accepted/status + an optional soft audit ref — NEVER the mutation
+ * body, args, or answer. `accepted=false` is a fail-closed refusal (forged/replayed/expired
+ * signature, unprovisioned verify key, or a rejected/cancelled run); `status` says why at a coarse
+ * grain. The TS route is a pure courier — it relays the OPAQUE signed blob verbatim and NEVER
+ * inspects the signature/digest (INV-1: verification happens ONLY in Rust under the operator key).
+ */
+export interface FridayResumeAgentRunResponse {
+  runId: string;
+  op: string;
+  accepted: boolean;
+  status: string;
+  auditRef?: string;
 }

--- a/src/api/runtime/friday-api-runtime.ts
+++ b/src/api/runtime/friday-api-runtime.ts
@@ -147,7 +147,11 @@ import type {
   FridayRustHubAgentRunSealedClientService,
   FridayRustHubAgentRunSealedClientServiceDispatchOutcome,
 } from "../mission-spine/friday-rust-hub-agent-run-sealed-client-service.js";
-import type { FridayRustHubAgentRunConstraints } from "../mission-spine/friday-rust-hub-agent-run-ws-sealed-client.js";
+import type {
+  FridayRustHubAgentRunConstraints,
+  FridayRustHubAgentRunResumeResult,
+} from "../mission-spine/friday-rust-hub-agent-run-ws-sealed-client.js";
+import type { FridayResumeAgentRunResponse } from "../model/friday-api-agent.types.js";
 import { createFridayRustHubRunContinuityProjectorService } from "../mission-spine/friday-rust-hub-run-continuity-projector-service.js";
 import type { FridayRustHubRunContinuityProjectorService } from "../mission-spine/friday-rust-hub-run-continuity-projector-service.js";
 import { createFridayRustHubRunAnswerReadbackService } from "../mission-spine/friday-rust-hub-run-answer-readback-service.js";
@@ -1461,6 +1465,16 @@ async function composeRustReadOnlyAgentRun(args: {
         usageCompletionTokens: 0,
         usageTotalTokens: 0,
         completedAtIso: pausedAtIso,
+        // (S6 mutating-chat) Stamp the run's BOUND OWNER onto the paused row's
+        // `metadata.apiRequest.principalId`. The paused branch previously returned BEFORE any
+        // owner stamp (the delivered branch's idempotency merge below is unreached for a pause),
+        // leaving a paused row ownerless — so the resume route's owner-binding gate would reject
+        // EVERY resume, including the legitimate owner. `callerPrincipal` is the same bound owner
+        // the readback/qualifier require (clause `hasBoundOwnerPrincipal` already guaranteed it is
+        // non-empty for a gated mutating run). Safe for the flag-off invariant: the paused outcome
+        // is reachable ONLY flag-on (the courier never returns a pause when off), so this never
+        // changes byte-identical-when-off behavior.
+        ...(callerPrincipal ? { ownerPrincipalId: callerPrincipal } : {}),
       }),
     );
     // A pause is NOT a fail-closed 503 — it is an honest non-Finished settle that returns a row.
@@ -4830,6 +4844,53 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
       return startRun(input);
     };
 
+    // (S6 mutating-chat — DARK, default-off) Runtime-level RESUME relay handed to the resume HTTP
+    // route. The route already (1) flag-gated on `deps.agentRunControlViaRust` BEFORE any run lookup
+    // and (2) enforced caller == the run's bound owner, so this fn is reached ONLY for an
+    // owner-authorized resume on a flag-on host. It is the pure courier's transport half: resolve
+    // the SecureStore X25519 client secret (the SAME ECDH secret the dispatch path uses), then dial
+    // the sealed-WS `resumeWithApproval`, relaying the OPAQUE blob VERBATIM (INV-1: it inspects
+    // NOTHING inside the blob; verification happens ONLY in Rust under the operator verify key).
+    // Fails CLOSED to the byte-identical retired 503 on a missing/short secret OR any WS error — it
+    // NEVER falls through to a TS-side resume (there is none). Returns the refs-only outcome.
+    const routeResumeRun = async (
+      runId: string,
+      opaqueSignedBlob: Uint8Array,
+      _principal: FridayAuthPrincipal | null,
+    ): Promise<FridayResumeAgentRunResponse> => {
+      // Defense-in-depth: even though the route flag-gated already, re-check here so this fn can
+      // NEVER relay while the control plane is off (a future caller can't bypass the dark posture).
+      if (deps.agentRunControlViaRust !== true) {
+        throw failClosedRustAgentRun();
+      }
+      // Resolve the X25519 client SECRET fail-closed BEFORE any WS connection (a non-32-byte secret
+      // ⇒ the byte-identical 503; never open an unauthenticated WS, never log the key).
+      const clientSecret = rustWsClientSecretResolver();
+      if (!clientSecret || clientSecret.length !== 32) {
+        throw failClosedRustAgentRun();
+      }
+      let outcome: FridayRustHubAgentRunResumeResult;
+      try {
+        outcome = await rustWsClient.resumeWithApproval({
+          runId,
+          clientSecret,
+          // INV-1: the OPAQUE operator-signed blob is relayed VERBATIM — the courier authors nothing.
+          opaqueSignedBlob,
+        });
+      } catch {
+        // Any sealed-WS failure (flag-off inner client, transport, refused) ⇒ the byte-identical
+        // 503; never a partial / TS-side resume.
+        throw failClosedRustAgentRun();
+      }
+      return {
+        runId: outcome.runId,
+        op: outcome.op,
+        accepted: outcome.accepted,
+        status: outcome.status,
+        ...(outcome.auditRef !== undefined ? { auditRef: outcome.auditRef } : {}),
+      };
+    };
+
     for (const route of createFridayAgentRoutes({
       validateRequestedRoute: async (providerId, model, tenantContext) => {
         await deps.providerService.resolveRoute(model, providerId, {
@@ -4955,6 +5016,11 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
       },
       eventEmitter: deps.agentEventEmitter,
       automationService: routeAutomationService,
+      // (S6 mutating-chat — DARK, default-off) the SAME resolved control-plane flag the Rust server
+      // + sealed client gate on. With it off (the default), the resume route SHORT-CIRCUITS to the
+      // byte-identical retired 503 before any run lookup; on, it relays an owner-authorized resume.
+      agentRunControlViaRust: deps.agentRunControlViaRust,
+      resumeRun: routeResumeRun,
     })) {
       routes.register(route);
     }

--- a/src/security/friday-owner-session-channel-capability.ts
+++ b/src/security/friday-owner-session-channel-capability.ts
@@ -50,6 +50,7 @@ export type FridayPublicMutationOperation =
   | "agent.plan.reject"
   | "agent.tool.approve"
   | "agent.tool.reject"
+  | "agent.run.resume"
   | "satellite.pairing.approve"
   | "satellite.pairing.reject"
   | "satellite.revoke"

--- a/test/contracts/api/__snapshots__/friday-api-route-contract.snapshot.test.ts.snap
+++ b/test/contracts/api/__snapshots__/friday-api-route-contract.snapshot.test.ts.snap
@@ -8,9 +8,9 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > Phase 14.5A WP-001: eve
     "hmac_or_bearer_opt_in": 1,
     "public_low_risk": 2,
     "rate_limited_pending": 4,
-    "unclassified": 250,
+    "unclassified": 251,
   },
-  "total_public_mutating": 320,
+  "total_public_mutating": 321,
   "unclassified_sample_max_5": [
     "capabilities.acquisition.runs.create",
     "capabilities.acquisition.runs.approve",
@@ -21,7 +21,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > Phase 14.5A WP-001: eve
 }
 `;
 
-exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures route count to detect accidental additions/removals 1`] = `419`;
+exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures route count to detect accidental additions/removals 1`] = `420`;
 
 exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route surface as a stable contract 1`] = `
 [
@@ -4048,6 +4048,16 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   {
     "authKind": "public",
     "index": 402,
+    "method": "POST",
+    "operationId": "agent.runs.resume",
+    "path": "/v1/agent/runs/:runId/resume",
+    "rateLimitPolicyId": null,
+    "roles": [],
+    "scopes": [],
+  },
+  {
+    "authKind": "public",
+    "index": 403,
     "method": "GET",
     "operationId": "agent.runs.audit",
     "path": "/v1/agent/runs/:runId/audit",
@@ -4057,7 +4067,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 403,
+    "index": 404,
     "method": "POST",
     "operationId": "agent.runs.rollback",
     "path": "/v1/agent/runs/:runId/rollback",
@@ -4067,7 +4077,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 404,
+    "index": 405,
     "method": "POST",
     "operationId": "agent.runs.approve.plan",
     "path": "/v1/agent/runs/:runId/approve-plan",
@@ -4077,7 +4087,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 405,
+    "index": 406,
     "method": "POST",
     "operationId": "agent.runs.reject.plan",
     "path": "/v1/agent/runs/:runId/reject-plan",
@@ -4087,7 +4097,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 406,
+    "index": 407,
     "method": "POST",
     "operationId": "agent.runs.approve.tool",
     "path": "/v1/agent/runs/:runId/approve-tool",
@@ -4097,7 +4107,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 407,
+    "index": 408,
     "method": "POST",
     "operationId": "agent.runs.reject.tool",
     "path": "/v1/agent/runs/:runId/reject-tool",
@@ -4107,7 +4117,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 408,
+    "index": 409,
     "method": "GET",
     "operationId": "agent.runs.events",
     "path": "/v1/agent/runs/:runId/events",
@@ -4117,7 +4127,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 409,
+    "index": 410,
     "method": "POST",
     "operationId": "agent.automations.create",
     "path": "/v1/agent/automations",
@@ -4127,7 +4137,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 410,
+    "index": 411,
     "method": "GET",
     "operationId": "agent.automations.list",
     "path": "/v1/agent/automations",
@@ -4137,7 +4147,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 411,
+    "index": 412,
     "method": "GET",
     "operationId": "agent.automations.get",
     "path": "/v1/agent/automations/:automationId",
@@ -4147,7 +4157,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 412,
+    "index": 413,
     "method": "PATCH",
     "operationId": "agent.automations.update",
     "path": "/v1/agent/automations/:automationId",
@@ -4157,7 +4167,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 413,
+    "index": 414,
     "method": "DELETE",
     "operationId": "agent.automations.delete",
     "path": "/v1/agent/automations/:automationId",
@@ -4167,7 +4177,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 414,
+    "index": 415,
     "method": "POST",
     "operationId": "agent.automations.run",
     "path": "/v1/agent/automations/:automationId/run",
@@ -4177,7 +4187,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 415,
+    "index": 416,
     "method": "GET",
     "operationId": "agent.subagents.list",
     "path": "/v1/agent/subagents",
@@ -4187,7 +4197,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 416,
+    "index": 417,
     "method": "GET",
     "operationId": "agent.subagents.get",
     "path": "/v1/agent/subagents/:subagentId",
@@ -4197,7 +4207,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 417,
+    "index": 418,
     "method": "GET",
     "operationId": "agent.runs.subagents.list",
     "path": "/v1/agent/runs/:runId/subagents",
@@ -4207,7 +4217,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 418,
+    "index": 419,
     "method": "GET",
     "operationId": "assets.inventory.list",
     "path": "/v1/assets/inventory",

--- a/test/unit/api/http/routes/friday-agent-routes.test.ts
+++ b/test/unit/api/http/routes/friday-agent-routes.test.ts
@@ -96,9 +96,9 @@ describe("FridayAgentRoutes", () => {
     };
   });
 
-  it("registers 18 agent routes", () => {
+  it("registers 19 agent routes", () => {
     const routes = createFridayAgentRoutes(stubDeps);
-    expect(routes).toHaveLength(18);
+    expect(routes).toHaveLength(19);
   });
 
   it("POST /v1/agent/runs requires agent.run scope with workflow.run compatibility", () => {
@@ -261,6 +261,217 @@ describe("FridayAgentRoutes", () => {
       },
       disabledToolNames: undefined,
     }));
+  });
+
+  // ─── B#1: mutating-tool grant + gate marker body-field extraction (DARK) ───
+
+  it("POST /v1/agent/runs FORWARDS a valid mutatingToolGrant + mutationGate from the body (B#1)", async () => {
+    const routes = createFridayAgentRoutes(stubDeps);
+    const route = routes.find((r) => r.operationId === "agent.runs.start")!;
+
+    await route.handler({
+      body: {
+        task: "edit a file",
+        constraints: { readOnly: false },
+        mutatingToolGrant: ["write_file", "edit_file"],
+        mutationGate: "operator_signed_ed25519",
+      },
+      params: {},
+      query: {},
+      headers: {},
+      principal: createStubPrincipal(),
+      requestId: "req-1",
+      receivedAt: "2026-01-01T00:00:00.000Z",
+    });
+
+    expect(stubDeps.startRun).toHaveBeenCalledWith(expect.objectContaining({
+      mutatingToolGrant: ["write_file", "edit_file"],
+      mutationGate: "operator_signed_ed25519",
+    }));
+  });
+
+  it("POST /v1/agent/runs OMITS mutatingToolGrant/mutationGate when absent or malformed (byte-identical when off)", async () => {
+    const routes = createFridayAgentRoutes(stubDeps);
+    const route = routes.find((r) => r.operationId === "agent.runs.start")!;
+
+    // No mutating fields at all → neither key is forwarded (every existing caller's shape).
+    await route.handler({
+      body: { task: "just a read" },
+      params: {},
+      query: {},
+      headers: {},
+      principal: createStubPrincipal(),
+      requestId: "req-1",
+      receivedAt: "2026-01-01T00:00:00.000Z",
+    });
+    const firstCall = (stubDeps.startRun as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(firstCall).not.toHaveProperty("mutatingToolGrant");
+    expect(firstCall).not.toHaveProperty("mutationGate");
+
+    // Malformed shapes (empty array, non-string element, empty/non-string gate) → undefined → omitted.
+    await route.handler({
+      body: {
+        task: "malformed grant",
+        mutatingToolGrant: [123, ""],
+        mutationGate: 42,
+      } as unknown as { task: string },
+      params: {},
+      query: {},
+      headers: {},
+      principal: createStubPrincipal(),
+      requestId: "req-1",
+      receivedAt: "2026-01-01T00:00:00.000Z",
+    });
+    const secondCall = (stubDeps.startRun as ReturnType<typeof vi.fn>).mock.calls[1][0];
+    expect(secondCall).not.toHaveProperty("mutatingToolGrant");
+    expect(secondCall).not.toHaveProperty("mutationGate");
+  });
+
+  // ─── B#2: the resume route (POST /v1/agent/runs/:runId/resume) — DARK, default-off ───
+
+  it("POST /v1/agent/runs/:runId/resume is registered with the right method/path/auth", () => {
+    const routes = createFridayAgentRoutes(stubDeps);
+    const route = routes.find((r) => r.operationId === "agent.runs.resume");
+    expect(route).toBeDefined();
+    expect(route!.method).toBe("POST");
+    expect(route!.path).toBe("/v1/agent/runs/:runId/resume");
+    expect(route!.auth).toEqual({ public: true });
+  });
+
+  it("resume FLAG-OFF short-circuits to the byte-identical retired 503 BEFORE any run lookup (DARK)", async () => {
+    // Default stubDeps has no agentRunControlViaRust + no resumeRun ⇒ flag-off.
+    const routes = createFridayAgentRoutes(stubDeps);
+    const route = routes.find((r) => r.operationId === "agent.runs.resume")!;
+
+    await expect(route.handler({
+      body: { signedApproval: Buffer.from("anything").toString("base64") },
+      params: { runId: "run-1" },
+      query: {},
+      headers: {},
+      principal: createStubPrincipal(),
+      requestId: "req-1",
+      receivedAt: "2026-01-01T00:00:00.000Z",
+    })).rejects.toMatchObject({
+      code: "TS_RUNTIME_AGENT_RUNS_RETIRED",
+      httpStatus: 503,
+      details: {
+        classification: "fail_closed",
+        replacement: "rust_owned_agent_run_entrypoint_required",
+      },
+    });
+    // The flag-off short-circuit happens BEFORE any run lookup → no run-existence leak.
+    expect(stubDeps.getRun).not.toHaveBeenCalled();
+    expect(stubDeps.resumeRun).toBeUndefined();
+  });
+
+  it("resume FLAG-ON rejects a caller who is NOT the run's bound owner (fail-closed 403)", async () => {
+    const resumeRun = vi.fn();
+    stubDeps.agentRunControlViaRust = true;
+    stubDeps.resumeRun = resumeRun;
+    // The run is owned by "owner:alice" (stamped at metadata.apiRequest.principalId).
+    stubDeps.getRun = vi.fn().mockReturnValue(createStubRun({
+      metadata: { apiRequest: { operationId: "agent.runs.start", idempotencyKey: "k", payloadHash: "h", receivedAt: "t", principalId: "owner:alice" } },
+    }));
+    const routes = createFridayAgentRoutes(stubDeps);
+    const route = routes.find((r) => r.operationId === "agent.runs.resume")!;
+
+    await expect(route.handler({
+      body: { signedApproval: Buffer.from("blob").toString("base64") },
+      params: { runId: "run-1" },
+      query: {},
+      headers: {},
+      // A DIFFERENT, bound principal (mallory) — authenticated but not the owner.
+      principal: createStubPrincipal({ principalId: "owner:mallory" }),
+      requestId: "req-1",
+      receivedAt: "2026-01-01T00:00:00.000Z",
+    })).rejects.toMatchObject({
+      code: "AGENT_RUN_RESUME_PRINCIPAL_MISMATCH",
+      httpStatus: 403,
+    });
+    expect(resumeRun).not.toHaveBeenCalled();
+  });
+
+  it("resume FLAG-ON rejects an OWNERLESS run (no stamped owner ⇒ resumable by nobody)", async () => {
+    const resumeRun = vi.fn();
+    stubDeps.agentRunControlViaRust = true;
+    stubDeps.resumeRun = resumeRun;
+    stubDeps.getRun = vi.fn().mockReturnValue(createStubRun()); // no metadata.apiRequest.principalId
+    const routes = createFridayAgentRoutes(stubDeps);
+    const route = routes.find((r) => r.operationId === "agent.runs.resume")!;
+
+    await expect(route.handler({
+      body: { signedApproval: Buffer.from("blob").toString("base64") },
+      params: { runId: "run-1" },
+      query: {},
+      headers: {},
+      principal: createStubPrincipal({ principalId: "owner:alice" }),
+      requestId: "req-1",
+      receivedAt: "2026-01-01T00:00:00.000Z",
+    })).rejects.toMatchObject({
+      code: "AGENT_RUN_RESUME_PRINCIPAL_MISMATCH",
+      httpStatus: 403,
+    });
+    expect(resumeRun).not.toHaveBeenCalled();
+  });
+
+  it("resume FLAG-ON relays the OPAQUE base64 blob VERBATIM to deps.resumeRun for the bound owner", async () => {
+    const resumeRun = vi.fn().mockResolvedValue({
+      runId: "run-1",
+      op: "resume",
+      accepted: true,
+      status: "mutation_completed",
+      auditRef: "audit-1",
+    });
+    stubDeps.agentRunControlViaRust = true;
+    stubDeps.resumeRun = resumeRun;
+    stubDeps.getRun = vi.fn().mockReturnValue(createStubRun({
+      metadata: { apiRequest: { operationId: "agent.runs.start", idempotencyKey: "k", payloadHash: "h", receivedAt: "t", principalId: "owner:alice" } },
+    }));
+    const routes = createFridayAgentRoutes(stubDeps);
+    const route = routes.find((r) => r.operationId === "agent.runs.resume")!;
+
+    const rawBlob = new Uint8Array([1, 2, 3, 250, 251, 0]);
+    const principal = createStubPrincipal({ principalId: "owner:alice" });
+    const response = await route.handler({
+      body: { signedApproval: Buffer.from(rawBlob).toString("base64") },
+      params: { runId: "run-1" },
+      query: {},
+      headers: {},
+      principal,
+      requestId: "req-1",
+      receivedAt: "2026-01-01T00:00:00.000Z",
+    });
+
+    expect(resumeRun).toHaveBeenCalledTimes(1);
+    const [relayedRunId, relayedBlob, relayedPrincipal] = resumeRun.mock.calls[0];
+    expect(relayedRunId).toBe("run-1");
+    // VERBATIM: the relayed bytes equal the decoded base64 exactly (no parse, no re-encode).
+    expect(Array.from(relayedBlob as Uint8Array)).toEqual(Array.from(rawBlob));
+    expect(relayedPrincipal).toBe(principal);
+    expect(response).toMatchObject({ accepted: true, status: "mutation_completed", auditRef: "audit-1" });
+  });
+
+  it("resume FLAG-ON 400s a missing/non-string/undecodable signedApproval (no relay)", async () => {
+    const resumeRun = vi.fn();
+    stubDeps.agentRunControlViaRust = true;
+    stubDeps.resumeRun = resumeRun;
+    stubDeps.getRun = vi.fn().mockReturnValue(createStubRun({
+      metadata: { apiRequest: { operationId: "agent.runs.start", idempotencyKey: "k", payloadHash: "h", receivedAt: "t", principalId: "owner:alice" } },
+    }));
+    const routes = createFridayAgentRoutes(stubDeps);
+    const route = routes.find((r) => r.operationId === "agent.runs.resume")!;
+    const principal = createStubPrincipal({ principalId: "owner:alice" });
+
+    await expect(route.handler({
+      body: {},
+      params: { runId: "run-1" },
+      query: {},
+      headers: {},
+      principal,
+      requestId: "req-1",
+      receivedAt: "2026-01-01T00:00:00.000Z",
+    })).rejects.toMatchObject({ code: "AGENT_RUN_RESUME_SIGNED_APPROVAL_REQUIRED", httpStatus: 400 });
+    expect(resumeRun).not.toHaveBeenCalled();
   });
 
   it("GET /v1/agent/runs requires agent.read scope with workflow.run compatibility", () => {

--- a/test/unit/api/mission-spine/friday-rust-hub-run-continuity-projector-service.test.ts
+++ b/test/unit/api/mission-spine/friday-rust-hub-run-continuity-projector-service.test.ts
@@ -203,6 +203,28 @@ describe("FridayRustHubRunContinuityProjector (executeRun-replace slice 2, fork 
     expect(listed.some((r) => r.id === FIXTURE_RECEIPT.runId)).toBe(true);
   });
 
+  it("(S6 mutating-chat) an ownerPrincipalId receipt round-trips to metadata.apiRequest.principalId through the REAL read path", () => {
+    // This pins the seam the resume route's owner-binding gate depends on: a paused projection
+    // stamps the bound owner, and the SAME repository read the route uses (getById → rowToRecord →
+    // parseRunMetadata) must deserialize it back to `record.metadata.apiRequest.principalId`. A
+    // PARTIAL `apiRequest` (only `principalId`) must survive — `parseRunMetadata` does no schema
+    // strip — so the route has a real owner to authorize the resume against (a regression here would
+    // 403 EVERY legitimate resume in prod while every mocked test stayed green).
+    const db = freshDb();
+    const projector = createFridayRustHubRunContinuityProjectorService();
+    projector.project(db, { ...FIXTURE_RECEIPT, runId: "owned-paused-run", ownerPrincipalId: "owner:alice" });
+
+    const repo = createFridayAgentRunRepository();
+    const got = repo.getById(db, "owned-paused-run");
+    expect(got).not.toBeNull();
+    expect(got?.metadata?.apiRequest?.principalId).toBe("owner:alice");
+
+    // A receipt WITHOUT an owner stamps NO apiRequest (byte-identical to the pre-S6 row).
+    projector.project(db, { ...FIXTURE_RECEIPT, runId: "unowned-run" });
+    const unowned = repo.getById(db, "unowned-run");
+    expect(unowned?.metadata?.apiRequest).toBeUndefined();
+  });
+
   it("the projected row carries NO answer body — responseText is a ref, never the body", () => {
     const db = freshDb();
     const projector = createFridayRustHubRunContinuityProjectorService();

--- a/test/unit/api/runtime/friday-api-runtime-rust-route-compose.test.ts
+++ b/test/unit/api/runtime/friday-api-runtime-rust-route-compose.test.ts
@@ -192,6 +192,7 @@ function makeStubReadback(owner: string) {
 
 interface ComposeDeps {
   routeAgentRunViaRust?: boolean;
+  agentRunControlViaRust?: boolean;
   wsClient?: FridayRustHubAgentRunSealedClientService;
   readback?: FridayRustHubRunAnswerReadbackService;
   clientSecretResolver?: () => Uint8Array | null;
@@ -215,6 +216,7 @@ function makeRuntime(db: FridaySqliteLayer, opts: ComposeDeps) {
     // allowTestOnlyAgentRunStartExecution intentionally UNSET → production fail-closed 503
     // on the disqualified / flag-off path (matches production + slice-4).
     ...(opts.routeAgentRunViaRust === undefined ? {} : { routeAgentRunViaRust: opts.routeAgentRunViaRust }),
+    ...(opts.agentRunControlViaRust === undefined ? {} : { agentRunControlViaRust: opts.agentRunControlViaRust }),
     ...(opts.wsClient ? { rustAgentRunWsClient: opts.wsClient } : {}),
     ...(opts.readback ? { rustAgentRunAnswerReadback: opts.readback } : {}),
     // The REAL projector is used so the no-double-count contract is exercised against a db.
@@ -373,6 +375,19 @@ describe("FridayApiRuntime — execrun S-F-compose (DARK) Rust-route composition
     );
     expect(rowResponse).toContain("rust-run-body-ref:");
     expect(rowResponse).not.toBe(OWNER_BODY);
+
+    // (S6 mutating-chat) The paused row now STAMPS the run's BOUND OWNER at
+    // `metadata.apiRequest.principalId` — so the resume route's owner-binding gate has a real owner
+    // to authorize against. Before the fix the paused branch returned BEFORE any owner stamp, so the
+    // resume route would have rejected EVERY resume (including the legitimate owner). The owner is a
+    // ref, never the body.
+    const rowMetadata = db.withReadConnection((d) =>
+      (d.prepare("SELECT metadata_json FROM friday_agent_runs WHERE id = ?").get(RUN_ID) as
+        | { metadata_json: string | null }
+        | undefined)?.metadata_json ?? "{}",
+    );
+    const parsedMetadata = JSON.parse(rowMetadata) as { apiRequest?: { principalId?: string } };
+    expect(parsedMetadata.apiRequest?.principalId).toBe(OWNER_PRINCIPAL);
   });
 
   it("(b) flag OFF (default) → byte-identical 503; the WS path is NEVER touched", async () => {
@@ -807,5 +822,191 @@ describe("FridayApiRuntime — execrun S-F-compose (DARK) Rust-route composition
     expect(ws.calls).toHaveLength(0);
     expect(readback.calls).toHaveLength(0);
     expect(countRows(db, "friday_agent_runs", RUN_ID)).toBe(0);
+  });
+
+  // ─── (S6 mutating-chat) routeResumeRun — the runtime resume relay's fail-closed branches ───
+  //
+  // These exercise the RUNTIME function the resume route delegates to (NOT a mocked deps.resumeRun):
+  // the defense-in-depth flag check, the X25519-secret preflight, the WS-error fail-closed, and the
+  // success mapping. We drive a paused MUTATING run to the DB first (so the owner is stamped + the
+  // resume route's owner-binding passes), then call the resume route on that run.
+
+  // A mutating body that pauses on the gate: readOnly:false + the operator-signed gate marker + a
+  // grant ⊆ the closed mutating allow-list. The owner is OWNER_PRINCIPAL (stamped on the paused row).
+  const MUTATING_PAUSING_BODY = {
+    ...QUALIFYING_BODY,
+    constraints: { readOnly: false },
+    mutatingToolGrant: ["write_file"],
+    mutationGate: "operator_signed_ed25519",
+  };
+
+  /** Make a stub WS client whose resume returns/throws a scripted control outcome. */
+  function makeResumeWsClient(
+    resume: (req: { runId: string; clientSecret: Uint8Array; opaqueSignedBlob: Uint8Array }) =>
+      | Promise<{ truthLabel: "rust_wired"; runId: string; op: string; accepted: boolean; status: string; auditRef?: string }>,
+  ) {
+    const paused = makeStubPausedWsClient();
+    const resumeCalls: Array<{ runId: string; opaqueSignedBlob: Uint8Array }> = [];
+    const service: FridayRustHubAgentRunSealedClientService = {
+      dispatchRun: paused.service.dispatchRun,
+      resumeWithApproval: vi.fn(async (req: { runId: string; clientSecret: Uint8Array; opaqueSignedBlob: Uint8Array }) => {
+        resumeCalls.push({ runId: req.runId, opaqueSignedBlob: req.opaqueSignedBlob });
+        return resume(req);
+      }),
+    };
+    return { service, resumeCalls };
+  }
+
+  async function pauseAMutatingRun(
+    runtime: ReturnType<typeof createFridayApiRuntime>,
+  ): Promise<void> {
+    // Flag-on + mutating body ⇒ the paused dispatch ⇒ a continuity row stamped with OWNER_PRINCIPAL.
+    await callStartRoute(runtime, { ...MUTATING_PAUSING_BODY });
+  }
+
+  function resumeRoute(runtime: ReturnType<typeof createFridayApiRuntime>) {
+    const route = runtime.routes.getRoutes().find((r) => r.operationId === "agent.runs.resume");
+    expect(route).toBeDefined();
+    return route!;
+  }
+
+  async function callResume(
+    runtime: ReturnType<typeof createFridayApiRuntime>,
+    opts: { blob?: Uint8Array; principalId?: string } = {},
+  ) {
+    return resumeRoute(runtime).handler({
+      body: { signedApproval: Buffer.from(opts.blob ?? new Uint8Array([9, 9, 9])).toString("base64") },
+      params: { runId: RUN_ID },
+      principal: makeBoundPrincipal(opts.principalId ?? OWNER_PRINCIPAL),
+      receivedAt: NOW,
+    } as never);
+  }
+
+  it("(resume-ok) flag ON + owner + valid secret → relays the opaque blob VERBATIM and maps the outcome", async () => {
+    db = createTestDb();
+    const blob = new Uint8Array([1, 2, 3, 200, 0, 255]);
+    const ws = makeResumeWsClient(async (req) => ({
+      truthLabel: "rust_wired" as const,
+      runId: req.runId,
+      op: "resume",
+      accepted: true,
+      status: "mutation_completed",
+      auditRef: "audit-xyz",
+    }));
+    const runtime = makeRuntime(db, {
+      routeAgentRunViaRust: true,
+      agentRunControlViaRust: true,
+      wsClient: ws.service,
+    });
+    await pauseAMutatingRun(runtime);
+
+    const res = (await callResume(runtime, { blob })) as { accepted: boolean; status: string; auditRef?: string; op: string };
+    expect(res).toMatchObject({ op: "resume", accepted: true, status: "mutation_completed", auditRef: "audit-xyz" });
+    // The opaque blob was relayed VERBATIM (no parse / re-encode).
+    expect(ws.resumeCalls).toHaveLength(1);
+    expect(Array.from(ws.resumeCalls[0].opaqueSignedBlob)).toEqual(Array.from(blob));
+  });
+
+  it("(resume-deny) flag ON + a Rust REFUSAL (forged/expired/replayed) → accepted:false, no throw", async () => {
+    db = createTestDb();
+    const ws = makeResumeWsClient(async (req) => ({
+      truthLabel: "rust_wired" as const,
+      runId: req.runId,
+      op: "resume",
+      accepted: false,
+      status: "approval_refused",
+    }));
+    const runtime = makeRuntime(db, {
+      routeAgentRunViaRust: true,
+      agentRunControlViaRust: true,
+      wsClient: ws.service,
+    });
+    await pauseAMutatingRun(runtime);
+
+    const res = (await callResume(runtime)) as { accepted: boolean; status: string };
+    expect(res).toMatchObject({ accepted: false, status: "approval_refused" });
+  });
+
+  it("(resume-secret) flag ON but the X25519 secret is MISSING → byte-identical 503; WS resume NEVER called", async () => {
+    db = createTestDb();
+    const ws = makeResumeWsClient(async () => {
+      throw new Error("resume must not be reached when the secret is missing");
+    });
+    // Pre-seed an OWNED paused row DIRECTLY via the projector (so the owner-binding passes) — we
+    // cannot use the dispatch pause here because the dispatch preflight ALSO resolves the (null)
+    // secret and would 503 before pausing. This isolates the RESUME secret-preflight branch.
+    db.withWriteTransaction((d) =>
+      createFridayRustHubRunContinuityProjectorService().project(d, {
+        truthLabel: "rust_wired_dev",
+        proofOnly: true,
+        ok: true,
+        runId: RUN_ID,
+        routeId: "deepseek:deepseek-v4-flash",
+        providerId: "deepseek",
+        model: "deepseek-v4-flash",
+        loopStatus: "Paused",
+        turns: 0,
+        executedTools: 0,
+        finalMessageSha256: "d".repeat(64),
+        finalMessageLen: 0,
+        auditChainVerified: false,
+        usagePromptTokens: 0,
+        usageCompletionTokens: 0,
+        usageTotalTokens: 0,
+        completedAtIso: NOW,
+        ownerPrincipalId: OWNER_PRINCIPAL,
+      }),
+    );
+    const runtime = makeRuntime(db, {
+      routeAgentRunViaRust: true,
+      agentRunControlViaRust: true,
+      wsClient: ws.service,
+      clientSecretResolver: () => null, // no SecureStore secret
+    });
+
+    await expect(callResume(runtime)).rejects.toMatchObject({
+      code: "TS_RUNTIME_AGENT_RUNS_RETIRED",
+      httpStatus: 503,
+    });
+    expect(ws.resumeCalls).toHaveLength(0);
+  });
+
+  it("(resume-wserror) flag ON but the sealed-WS resume THROWS → byte-identical 503 (fail-closed)", async () => {
+    db = createTestDb();
+    const ws = makeResumeWsClient(async () => {
+      throw new Error("transport closed");
+    });
+    const runtime = makeRuntime(db, {
+      routeAgentRunViaRust: true,
+      agentRunControlViaRust: true,
+      wsClient: ws.service,
+    });
+    await pauseAMutatingRun(runtime);
+
+    await expect(callResume(runtime)).rejects.toMatchObject({
+      code: "TS_RUNTIME_AGENT_RUNS_RETIRED",
+      httpStatus: 503,
+    });
+  });
+
+  it("(resume-flagoff) flag OFF → the resume route short-circuits to the retired 503 BEFORE any run lookup", async () => {
+    db = createTestDb();
+    const ws = makeResumeWsClient(async () => {
+      throw new Error("resume must not be reached with the control flag off");
+    });
+    // routeAgentRunViaRust on (so we could pause) but agentRunControlViaRust OFF — except with the
+    // control flag off the dispatch never pauses; so just assert the resume route is 503 on a
+    // flag-off runtime regardless of run state.
+    const runtime = makeRuntime(db, {
+      routeAgentRunViaRust: true,
+      // agentRunControlViaRust omitted → default off.
+      wsClient: ws.service,
+    });
+
+    await expect(callResume(runtime)).rejects.toMatchObject({
+      code: "TS_RUNTIME_AGENT_RUNS_RETIRED",
+      httpStatus: 503,
+    });
+    expect(ws.resumeCalls).toHaveLength(0);
   });
 });

--- a/test/unit/api/runtime/friday-api-runtime-rust-route-flag.test.ts
+++ b/test/unit/api/runtime/friday-api-runtime-rust-route-flag.test.ts
@@ -104,6 +104,20 @@ const QUALIFYING_SHAPED_BODY = {
   constraints: { readOnly: true },
 };
 
+// A MUTATING-shaped request body: readOnly:false + an explicit positive mutatingToolGrant (a member
+// of RUST_ROUTE_MUTATING_TOOL_ALLOWLIST) + the operator-signed gate marker. This is the shape the
+// isGatedMutatingRun qualifier inspects. With the route's Rust-route flag OFF the qualifier's FIRST
+// conjunct (agentRunControlViaRust === true) is false, so the mutating branch is dead code and the
+// run disqualifies to the SAME retired 503 as a read-only run does — byte-identical when off.
+const MUTATING_SHAPED_BODY = {
+  task: "Write the result to out.txt in the workspace.",
+  providerId: "deepseek",
+  model: "deepseek-v4-flash",
+  constraints: { readOnly: false },
+  mutatingToolGrant: ["write_file"],
+  mutationGate: "operator_signed_ed25519",
+};
+
 async function callStartRoute(
   runtime: ReturnType<typeof createFridayApiRuntime>,
   body: Record<string, unknown>,
@@ -151,5 +165,18 @@ describe("FridayApiRuntime — execrun slice 4 per-run Rust-route flag (dark)", 
     db = createTestDb();
     const runtime = makeRuntime(db, true);
     await expectByteIdentical503(callStartRoute(runtime, { ...QUALIFYING_SHAPED_BODY }));
+  });
+
+  it("flag OFF: a MUTATING body (readOnly:false + grant + ed25519 gate) is byte-identical 503", async () => {
+    // Coverage complement to the read-only flag-off test: a fully mutating-shaped body (an explicit
+    // mutatingToolGrant + mutationGate:"operator_signed_ed25519" + readOnly:false) disqualifies to
+    // the EXACT same retired 503 (TS_RUNTIME_AGENT_RUNS_RETIRED / 503) when the route's Rust-route
+    // flag is off. The makeRuntime flag here is the START-route flag (routeAgentRunViaRust); the
+    // qualifier's mutating branch keys on agentRunControlViaRust, which is unset here — so the
+    // mutating branch is dead code and the body is admitted/disqualified identically to today. No
+    // run is created, executeRun is never reached, no mutating surface is opened.
+    db = createTestDb();
+    const runtime = makeRuntime(db, false);
+    await expectByteIdentical503(callStartRoute(runtime, { ...MUTATING_SHAPED_BODY }));
   });
 });


### PR DESCRIPTION
## S6 mutating-chat PRODUCT path — DARK, default-off

Completes the TS-side blockers so an operator-signed mutating agent-run can flow end-to-end through the product path, behind the default-OFF `FRIDAY_AGENT_RUN_CONTROL_VIA_RUST` flag. **Both flags (`FRIDAY_ROUTE_AGENT_RUN_VIA_RUST` + `FRIDAY_AGENT_RUN_CONTROL_VIA_RUST`) stay default-off. With them off, behavior is byte-identical to today** (proven by a flag-off test that 503s before any run lookup). No gate weakening, no loophole, no degrade — the Ed25519 signature is the only thing that authorizes a mutation; the hub holds a verify key only.

### What's wired

**B#1 — request-field extraction** (`src/api/http/routes/friday-agent-routes.ts`)
The start-run handler now parses `mutatingToolGrant` (string[]) + `mutationGate` (string) from the body — mirroring the existing `allowedRustRouteTools` extraction exactly — and forwards them into the route-bound `startRun` wrapper additively. The runtime qualifier (`isGatedMutatingRun`) already expected + threaded these; the only gap was the HTTP parse. Added both to `FridayStartAgentRunRequest` (model) + the route `deps.startRun` interface. The qualifier's predicate logic is **unchanged**. Malformed/absent shapes ⇒ omitted ⇒ byte-identical 503.

**B#2 — resume HTTP route** (`POST /v1/agent/runs/:runId/resume`, `friday-agent-routes.ts` + runtime `routeResumeRun` in `friday-api-runtime.ts`)
- (a) Flag-off ⇒ **short-circuits to the byte-identical retired 503 BEFORE any run lookup** (`failClosedResumeRoute`, same code/message/status/details as the retired `startRun`) — a dark host leaks no run existence.
- (b) Flag-on ⇒ requires a bound owner principal and enforces it **== the owner of the run named by the WIRE `runId`** (that run's `metadata.apiRequest.principalId`), fail-closed 403 otherwise. Rust resume is signature-authed and does NOT re-check the owner — so on its own this route would only owner-gate the *wire* `runId`, NOT necessarily the run the nonce executes. **Closed by the Rust-side `pending.run_id == run_id` binding** (`agent_run_control::resume`, see below): the Rust resume now refuses (`run_mismatch`, executing nothing) unless the nonce's pending row belongs to the SAME run as the wire `runId`. With that binding, the owner-gated run (wire `runId`) and the run the nonce actually resumes/executes are guaranteed to be the **same run** — so the route's owner check is the owner boundary for the run that actually mutates.
- (c) Relays the signed `CanonicalApproval` as an **OPAQUE base64 blob VERBATIM** to the sealed-WS `resumeWithApproval` — the route NEVER parses/validates/inspects the signature/digest (INV-1). Verification happens ONLY in Rust under the operator verify key.
- (d) Returns the refs-only resume outcome. The runtime `routeResumeRun` resolves the X25519 secret + dials the sealed resume, failing closed (byte-identical 503) on missing secret / WS error / flag-off.

**B#2 owner-population fix** (`friday-rust-hub-run-continuity-projector-service.ts` + the paused compose branch in `friday-api-runtime.ts`)
The PAUSED compose branch returned **before** any owner stamp (the delivered branch's idempotency merge is unreached for a pause), leaving a paused row **ownerless** ⇒ the B#2 owner-binding gate would have 403'd **every legitimate resume**. The projector now optionally stamps the bound owner at `metadata.apiRequest.principalId` (the same shape the read routes + idempotency reads use); the paused compose branch sets it from the already-validated `callerPrincipal`. Safe for the flag-off invariant: the paused outcome is reachable only flag-on (the courier never returns a pause when off), so this never changes byte-identical-when-off behavior. Proven to round-trip through the **real repository read path** (`getById` → `rowToRecord` → `parseRunMetadata`), not just raw SQL.

**S6-687 fix-pass — wire-run ↔ executed-run binding (security MUST-FIX), owner-gate honesty, mutating flag-off coverage**
An adversarial review found the owner gate above was **described as stronger than it was**: the TS route owner-gates the owner of the **WIRE `runId`**, but the Rust spine `resume_with_approval` takes **no `run_id`** and selects the run to execute SOLELY from the blob's nonce (`get_pending_request(approval_id)` → `run_id = pending.run_id`). There was NO `pending.run_id == run_id` binding — so the owner-gated run (wire `runId`) and the run the nonce executes could be **different runs** (e.g. an attacker who owns run A resumes A on the wire while carrying a nonce whose pending row belongs to victim run B, executing B's mutation past A's owner gate).
- **Fix (Rust):** `agent_run_control::resume` now refuses fail-closed with `run_mismatch` (executing nothing, consuming no nonce, writing no receipt) unless `pending.run_id == run_id` — mirroring the existing `reject` `run_mismatch` binding (same wire vocab, no protocol change). This ties the owner-gated wire `runId` to the run that actually resumes/executes: they are now guaranteed the **same run**. The same binding ALSO closes a **latent coupling**: the existing `is_cancelled(conn, run_id)` pre-check keyed on the *wire* `runId`, which could differ from the executed run; now every path that proceeds has `run_id == pending.run_id`, so the cancel pre-check is consistent (keys on the same run the spine executes). New Rust test `resume_wire_run_mismatch_is_refused_no_mutation` (in `a1_run_control.rs`, real test Ed25519 key) asserts a wire-`runId`≠nonce-`pending.run_id` resume is `run_mismatch` + no file written + the victim's pending row untouched, with a positive control that the matching wire `runId` resumes normally.
- **Honesty (comments + this body):** the route doc-comment and inline `(c)` comment previously over-stated the gate as "== the run's bound owner / LOAD-BEARING"; they now accurately state it checks the owner of the **wire** `runId`, and that the Rust `pending.run_id == run_id` binding makes the owner-gated run and the executed run the same run.
- **Coverage (TS):** one new flag-off test (`friday-api-runtime-rust-route-flag.test.ts`) asserts a **mutating** body (`constraints.readOnly:false` + a valid `mutatingToolGrant` + `mutationGate:"operator_signed_ed25519"`) disqualifies to the **exact same** retired 503 (`TS_RUNTIME_AGENT_RUNS_RETIRED`/503) as the read-only flag-off test — closing the gap that only the read-only flag-off direction was previously asserted.

### B#3 — per-run constraint at dispatch: NO Rust production change was needed

Re-verification of the live tree (not the scout's stale notes) found B#3 **already implemented**:
- The WS server boots `read_only: false` (`hub_agent_run_server.rs:314`).
- It **already composes** the peer's per-run `constraints` onto the boot `RunPolicy` via `agent_run_control::effective_run_policy_over` (only-tighten: `read_only` is logical-OR, disabled-tools UNION — a per-run constraint can never escalate beyond the boot grant) and threads the override through **both** live dispatch arms (`run_authed_agent_loop_with_policy` + `run_session_task_with_overrides`), gated on the run-control flag (`hub_server.rs:664-702`).
- It already surfaces `AgentRunPaused` and already verifies + executes `AgentRunResume` under the operator verify key.

So the gate the whole model rests on already holds: under `read_only:false`, a mutating tool is **not** read-only-denied; it reaches the gate, which **Pauses** (RequiresApproval) by default — the executor is reached only on `Allow`, which requires the operator's Ed25519 signature. The **deliverable for B#3 is the missing complement test** (the existing suite only proved the `read_only:true → BLOCK` tightening direction): a mutating run under a per-run `read_only:false` constraint composed onto the `read_only:false` boot, dispatched through the live entry, asserts it **PAUSES** (persists a pending approval, writes no file) — NOT Allow (no silent escalation) and NOT Deny (not over-restrictive).

### E2E proof — proven in two layers, NOT one single test (honest)

The prompt's "MANDATORY E2E PROOF TEST" specified ONE test flowing `POST /v1/agent/runs` → pause → sign → **resume route** → `mutation_completed` through a real WS. **That single full-chain test does not exist here**, and there is no harness in this repo that boots `hub_agent_run_server` and drives the TS sealed client against it (searched). The full HTTP→real-WS→execute chain is the deferred **operator live-proof**. Instead the mechanism is proven in two layers (legitimate: the sealed-WS seam is already 6a-LIVE-PROVEN, so a mock-boundary TS test is not a brand-new unproven seam):

- **Crypto / signature heart (Rust integration, REAL test Ed25519 key)** — `s6d_resume_ingestion.rs` + `a1_run_control.rs` (cited, pre-existing, re-run green) prove the prompt's steps (3)–(7): pause → operator (test key) signs the pending nonce's exact digest → `resume()` → `mutation_completed` + the mutation file is written + the owner-scoped readback Grants only the owner. The **negative case** (forged/absent/replayed/expired/HMAC/key-substitution/wrong-digest/unknown-nonce → Deny/refusal, `executed=false`, no file) is proven there too. The production proof later uses the real operator key.
- **B#3 gate (Rust, new)** — `read_only:false → PAUSE` through the live dispatch entry (above).
- **HTTP boundary (TS, new)** — B#1 admits the candidate; the resume route's flag-off 503-before-lookup, owner-binding (mismatch + ownerless → 403), opaque-verbatim relay, and 400 on a malformed blob; `routeResumeRun`'s ok / deny / missing-secret-503 / WS-error-503 / flag-off-503 branches; and the paused-projection owner stamp round-tripping through the real repo read path. The sealed client is mocked at the boundary (it returns a paused outcome / a control result).

### Build / lint / test status
- `npm run build` (tsc + ui): clean
- `npm run lint`: **0 errors** (1553 pre-existing warnings, none new in touched files)
- vitest (touched areas): 846 tests green, 0 type errors — incl. the new B#1/B#2/routeResumeRun/owner-round-trip tests
- `cargo build --release` (full workspace): clean
- `cargo test -p friday-hub`: all green (lib 550 + integration suites; incl. the new `read_only:false→PAUSE` test, the new `resume_wire_run_mismatch_is_refused_no_mutation` binding test, and the resume/control integration suites — `a1_run_control` now 13 tests)
- `cargo fmt --all -- --check` + `cargo clippy -p friday-hub --all-targets -- -D warnings`: clean
- detect-secrets: clean (no baseline refresh needed)

### Caveats / deferred (honest)
- **No single full-chain HTTP→real-WS e2e** (see above) — that is the operator live-proof; this PR proves the mechanism in two layers with a TEST key.
- `truth_status` remains **rust_wired / DARK** — both flags default-off, no production caller, no real operator-key proof. NOT v1 GO.
- B#3 required **no Rust production change** — it was already wired. This PR's only Rust change is the one complement test (`+88` lines in `hub_server.rs` tests).
- Token totals on the projected paused row stay 0 (deferred — per the existing dark-slice posture).
- The S6-687 wire-run binding is added in `agent_run_control::resume` only. The **separate `hub_resume_approval` dev bridge** has the same structural shape (the module doc already surfaces it) and was deliberately left untouched (out of scope for this fix-pass) — surfaced as a follow-up concern, not fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

