### PR TITLE
fix(security): close OF6 latent method-level skill-run hole at 2 non-route callers

### DIFF
--- a/src/agent/tools/friday-agent-skill-tool.ts
+++ b/src/agent/tools/friday-agent-skill-tool.ts
@@ -1,4 +1,5 @@
 import type { FridayAgentToolDefinition, FridayAgentToolResult } from "../model/friday-agent.types.js";
+import { FridayDomainError } from "#errors";
 import {
   canRunFridayBundledSystemNodeSkillWithoutGate,
   evaluateFridaySkillExecutionReadiness,
@@ -26,6 +27,19 @@ export interface CreateFridayAgentSkillToolDeps {
   skillRegistry?: FridaySkillRegistry;
   listMcpServerReadiness?: () => readonly FridayMcpServerReadiness[];
   getSkillLifecycleStatus?: (skillId: string) => SkillLifecycleStatus | null | undefined;
+  /**
+   * TS Runtime Retirement — OF6 method-level fail-closed guard. The agent
+   * `skill_run` tool is a NON-route caller that reaches the shared
+   * `skillExecutor.execute` arbitrary-code sink (shell/python/node) keyed by an
+   * ARBITRARY caller-supplied skillId. The public skill route is already fenced
+   * by `allowTestOnlySkillRunExecution` at friday-skill-routes.ts; this is the
+   * SAME flag for the whole skill-run retirement surface. Default-undefined →
+   * OFF → skill runs fail closed (the intended retired state in production).
+   * Only the test oracle (or a future Rust-owned entrypoint flip) sets it true.
+   * The `ai-inference` BYOK shortcut is exempt below (it short-circuits to the
+   * provider service inside the executor and never reaches the code sink).
+   */
+  allowTestOnlySkillRunExecution?: boolean;
 }
 
 // ─── Factory ───
@@ -50,6 +64,33 @@ export function createFridayAgentSkillTool(
       signal: AbortSignal,
     ): Promise<FridayAgentToolResult> {
       const skillId = readStringParam(args, "skillId", { required: true });
+
+      // ─── TS Runtime Retirement — OF6 method-level fail-closed guard ───
+      // This NON-route caller reaches the shared `skillExecutor.execute`
+      // arbitrary-code sink with a caller-supplied skillId. Fail closed unless
+      // the test oracle (or a future Rust-owned entrypoint) opts in via the same
+      // flag the skill route uses. EXEMPT `ai-inference`: that skillId
+      // short-circuits to the provider service inside the executor
+      // (friday-skill-executor.ts ai-inference shortcut) and returns BEFORE any
+      // shell/python/node sink — it is a fixed (non-arbitrary) BYOK path that
+      // must stay live, so guarding it would wrongly retire provider inference.
+      if (
+        skillId !== "ai-inference"
+        && deps.allowTestOnlySkillRunExecution !== true
+      ) {
+        throw new FridayDomainError(
+          "TS_RUNTIME_SKILL_RUNS_RETIRED",
+          "Skill run execution is fail-closed while runtime ownership is being moved out of TypeScript.",
+          {
+            httpStatus: 503,
+            details: {
+              classification: "fail_closed",
+              replacement: "rust_owned_skill_run_entrypoint_required",
+            },
+          },
+        );
+      }
+
       const timeoutMs =
         readNumberParam(args, "timeoutMs", { integer: true }) ??
         FRIDAY_AGENT_TOOL_TIMEOUT_MS;

--- a/src/agent/tools/friday-agent-tool-registry.ts
+++ b/src/agent/tools/friday-agent-tool-registry.ts
@@ -75,6 +75,13 @@ export interface CreateFridayAgentToolRegistryOptions {
   skillExecutor?: FridaySkillExecutor;
   skillRegistry?: FridaySkillRegistry;
   getSkillLifecycleStatus?: (skillId: string) => SkillLifecycleStatus | null | undefined;
+  /**
+   * TS Runtime Retirement — OF6 method-level guard for the agent `skill_run`
+   * tool (a NON-route caller of the arbitrary-code skill sink). Threaded into
+   * the skill tool's deps; default-undefined → OFF → fail-closed. Same flag as
+   * the skill route. See createFridayAgentSkillTool for the exemption details.
+   */
+  allowTestOnlySkillRunExecution?: boolean;
   workflowCrudService?: FridayWorkflowCrudService;
   workflowExecutionService?: FridayWorkflowExecutionService;
   memoryService?: FridayMemoryService;
@@ -203,6 +210,7 @@ export function createFridayAgentToolRegistry(
         skillRegistry: options.skillRegistry,
         listMcpServerReadiness,
         getSkillLifecycleStatus: options?.getSkillLifecycleStatus,
+        allowTestOnlySkillRunExecution: options?.allowTestOnlySkillRunExecution,
       }),
     );
   }

--- a/src/hub/friday-hub-bootstrap.ts
+++ b/src/hub/friday-hub-bootstrap.ts
@@ -1461,6 +1461,35 @@ export async function createFridayHub(
       );
     }
 
+    // ─── TS Runtime Retirement — OF6 method-level fail-closed guard ───
+    // `invokeSkillForWorkflow` is a NON-route caller that reaches the shared
+    // `executor.execute` arbitrary-code sink (shell/python/node) keyed by an
+    // ARBITRARY workflow-supplied skillId. Fail closed unless the test oracle
+    // (or a future Rust-owned entrypoint) opts in via the SAME skill-run
+    // retirement flag the route + agent tool use (default-undefined → OFF →
+    // skill runs fail closed in production). EXEMPT `ai-inference`: that fixed
+    // (non-arbitrary) skillId short-circuits to the provider service inside the
+    // executor (friday-skill-executor.ts ai-inference shortcut) and returns
+    // BEFORE any code sink — it is the live BYOK path for the workflow AI node
+    // (workflow-ai-adapter.ts invokes "ai-inference" through this same fn), so
+    // guarding it would wrongly retire provider inference for workflows.
+    if (
+      skillId !== "ai-inference"
+      && config.allowTestOnlySkillRunExecution !== true
+    ) {
+      throw new FridayDomainError(
+        "TS_RUNTIME_SKILL_RUNS_RETIRED",
+        "Skill run execution is fail-closed while runtime ownership is being moved out of TypeScript.",
+        {
+          httpStatus: 503,
+          details: {
+            classification: "fail_closed",
+            replacement: "rust_owned_skill_run_entrypoint_required",
+          },
+        },
+      );
+    }
+
     const handle = executor.execute({
       skillId,
       input: payload,
@@ -3053,6 +3082,9 @@ export async function createFridayHub(
     skillExecutor: executor,
     skillRegistry: registry,
     getSkillLifecycleStatus: getPersistedSkillLifecycleStatus,
+    // OF6: fence the agent skill_run tool's arbitrary-code sink with the same
+    // skill-run retirement flag the route uses (default-off → fail-closed).
+    allowTestOnlySkillRunExecution: config.allowTestOnlySkillRunExecution,
     workflowCrudService: workflowRuntime.crud,
     workflowExecutionService: workflowRuntime.execution,
     memoryService,
@@ -5235,6 +5267,8 @@ export async function createFridayHub(
         skillExecutor: executor,
         skillRegistry: registry,
         getSkillLifecycleStatus: getPersistedSkillLifecycleStatus,
+        // OF6: same skill-run retirement fence on subagent child tools.
+        allowTestOnlySkillRunExecution: config.allowTestOnlySkillRunExecution,
         workflowCrudService: workflowRuntime.crud,
         workflowExecutionService: workflowRuntime.execution,
         memoryService,

--- a/test/unit/agent/tools/friday-agent-skill-tool.test.ts
+++ b/test/unit/agent/tools/friday-agent-skill-tool.test.ts
@@ -93,7 +93,7 @@ describe("FridayAgentSkillTool", () => {
 
   it("has correct name and parameters", () => {
     const executor = mockExecutor(makeResult());
-    const tool = createFridayAgentSkillTool({ skillExecutor: executor });
+    const tool = createFridayAgentSkillTool({ skillExecutor: executor, allowTestOnlySkillRunExecution: true });
 
     expect(tool.name).toBe("skill_run");
     expect(tool.description).toBeTruthy();
@@ -104,7 +104,7 @@ describe("FridayAgentSkillTool", () => {
 
   it("returns skill output on success", async () => {
     const executor = mockExecutor(makeResult());
-    const tool = createFridayAgentSkillTool({ skillExecutor: executor });
+    const tool = createFridayAgentSkillTool({ skillExecutor: executor, allowTestOnlySkillRunExecution: true });
 
     const result = await tool.execute(
       { skillId: "weather", input: { city: "Seattle" } },
@@ -125,7 +125,7 @@ describe("FridayAgentSkillTool", () => {
 
   it("passes correct parameters to executor", async () => {
     const executor = mockExecutor(makeResult());
-    const tool = createFridayAgentSkillTool({ skillExecutor: executor });
+    const tool = createFridayAgentSkillTool({ skillExecutor: executor, allowTestOnlySkillRunExecution: true });
 
     await tool.execute(
       { skillId: "my-skill", input: { key: "value" }, timeoutMs: 5000 },
@@ -150,7 +150,7 @@ describe("FridayAgentSkillTool", () => {
     const executor = mockExecutor(
       makeResult({ status: "failed", stderr: "skill not found" }),
     );
-    const tool = createFridayAgentSkillTool({ skillExecutor: executor });
+    const tool = createFridayAgentSkillTool({ skillExecutor: executor, allowTestOnlySkillRunExecution: true });
 
     const result = await tool.execute(
       { skillId: "bad-skill", input: {} },
@@ -168,7 +168,7 @@ describe("FridayAgentSkillTool", () => {
     const executor = mockExecutor(
       makeResult({ status: "timeout", stderr: "" }),
     );
-    const tool = createFridayAgentSkillTool({ skillExecutor: executor });
+    const tool = createFridayAgentSkillTool({ skillExecutor: executor, allowTestOnlySkillRunExecution: true });
 
     const result = await tool.execute(
       { skillId: "slow-skill", input: {} },
@@ -185,7 +185,7 @@ describe("FridayAgentSkillTool", () => {
     const executor = mockExecutor(
       makeResult({ status: "cancelled", stderr: "" }),
     );
-    const tool = createFridayAgentSkillTool({ skillExecutor: executor });
+    const tool = createFridayAgentSkillTool({ skillExecutor: executor, allowTestOnlySkillRunExecution: true });
 
     const result = await tool.execute(
       { skillId: "cancelled-skill", input: {} },
@@ -200,6 +200,7 @@ describe("FridayAgentSkillTool", () => {
     const executor = mockExecutor(makeResult());
     const tool = createFridayAgentSkillTool({
       skillExecutor: executor,
+      allowTestOnlySkillRunExecution: true,
       skillRegistry: mockRegistry({
         requirements: {
           bins: [],
@@ -266,6 +267,7 @@ describe("FridayAgentSkillTool", () => {
     });
     const tool = createFridayAgentSkillTool({
       skillExecutor: executor,
+      allowTestOnlySkillRunExecution: true,
       skillRegistry: registry,
     });
 
@@ -288,6 +290,7 @@ describe("FridayAgentSkillTool", () => {
     const executor = mockExecutor(makeResult());
     const tool = createFridayAgentSkillTool({
       skillExecutor: executor,
+      allowTestOnlySkillRunExecution: true,
       skillRegistry: mockRegistry(),
       getSkillLifecycleStatus: (skillId) =>
         skillId === "secure-skill" ? "not_installed" : undefined,
@@ -313,6 +316,7 @@ describe("FridayAgentSkillTool", () => {
     const executor = mockExecutor(makeResult());
     const tool = createFridayAgentSkillTool({
       skillExecutor: executor,
+      allowTestOnlySkillRunExecution: true,
       skillRegistry: {
         ...mockRegistry(),
         get: vi.fn((skillId: string) => {
@@ -368,6 +372,7 @@ describe("FridayAgentSkillTool", () => {
       const executor = mockExecutor(makeResult());
       const tool = createFridayAgentSkillTool({
         skillExecutor: executor,
+        allowTestOnlySkillRunExecution: true,
         skillRegistry: {
           ...mockRegistry(),
           get: vi.fn((skillId: string) => {
@@ -438,6 +443,7 @@ describe("FridayAgentSkillTool", () => {
     const executor = mockExecutor(makeResult());
     const tool = createFridayAgentSkillTool({
       skillExecutor: executor,
+      allowTestOnlySkillRunExecution: true,
       skillRegistry: {
         ...mockRegistry(),
         get: vi.fn((skillId: string) => {
@@ -494,7 +500,7 @@ describe("FridayAgentSkillTool", () => {
 
   it("throws on missing skillId", async () => {
     const executor = mockExecutor(makeResult());
-    const tool = createFridayAgentSkillTool({ skillExecutor: executor });
+    const tool = createFridayAgentSkillTool({ skillExecutor: executor, allowTestOnlySkillRunExecution: true });
 
     await expect(
       tool.execute({ skillId: "", input: {} }, signal()),
@@ -505,7 +511,7 @@ describe("FridayAgentSkillTool", () => {
 
   it("defaults to empty object for non-object input", async () => {
     const executor = mockExecutor(makeResult());
-    const tool = createFridayAgentSkillTool({ skillExecutor: executor });
+    const tool = createFridayAgentSkillTool({ skillExecutor: executor, allowTestOnlySkillRunExecution: true });
 
     await tool.execute(
       { skillId: "test", input: "not-an-object" },
@@ -531,7 +537,7 @@ describe("FridayAgentSkillTool", () => {
       cancel: vi.fn(),
     };
 
-    const tool = createFridayAgentSkillTool({ skillExecutor: executor });
+    const tool = createFridayAgentSkillTool({ skillExecutor: executor, allowTestOnlySkillRunExecution: true });
 
     const promise = tool.execute(
       { skillId: "long-skill", input: {} },
@@ -543,5 +549,63 @@ describe("FridayAgentSkillTool", () => {
 
     await expect(promise).rejects.toThrow("aborted");
     expect(executor.cancel).toHaveBeenCalledWith("run-abort");
+  });
+
+  // ─── TS Runtime Retirement — OF6 method-level fail-closed guard ───
+
+  it("fails closed with TS_RUNTIME_SKILL_RUNS_RETIRED when the skill-run flag is UNSET (default-off, no reliance on transitive upstream containment)", async () => {
+    const executor = mockExecutor(makeResult());
+    // Flag deliberately UNSET — mirrors production. The arbitrary-code skill
+    // sink must NOT be reachable via the agent tool just because an upstream
+    // agent/workflow flag happens to be on.
+    const tool = createFridayAgentSkillTool({ skillExecutor: executor });
+
+    await expect(
+      tool.execute({ skillId: "weather", input: { city: "Seattle" } }, signal()),
+    ).rejects.toMatchObject({
+      code: "TS_RUNTIME_SKILL_RUNS_RETIRED",
+      httpStatus: 503,
+      details: {
+        classification: "fail_closed",
+        replacement: "rust_owned_skill_run_entrypoint_required",
+      },
+    });
+    expect(executor.execute).not.toHaveBeenCalled();
+  });
+
+  it("PRESERVES the ai-inference BYOK shortcut even when the skill-run flag is UNSET (the guard must not retire provider inference)", async () => {
+    const executor = mockExecutor(makeResult());
+    const tool = createFridayAgentSkillTool({ skillExecutor: executor });
+
+    const result = await tool.execute(
+      { skillId: "ai-inference", input: { prompt: "hi" } },
+      signal(),
+    );
+
+    // ai-inference is exempt — it reaches the executor (which short-circuits to
+    // the provider service before any shell/python/node sink), so the guard does
+    // not 503 it.
+    expect(result.isError).toBeUndefined();
+    expect(executor.execute).toHaveBeenCalledWith(
+      expect.objectContaining({ skillId: "ai-inference" }),
+    );
+  });
+
+  it("proceeds past the guard for an arbitrary skill when the test-oracle flag is set true (guard is flag-gated, not a hard block)", async () => {
+    const executor = mockExecutor(makeResult());
+    const tool = createFridayAgentSkillTool({
+      skillExecutor: executor,
+      allowTestOnlySkillRunExecution: true,
+    });
+
+    const result = await tool.execute(
+      { skillId: "weather", input: { city: "Seattle" } },
+      signal(),
+    );
+
+    expect(result.isError).toBeUndefined();
+    expect(executor.execute).toHaveBeenCalledWith(
+      expect.objectContaining({ skillId: "weather" }),
+    );
   });
 });

--- a/test/unit/agent/tools/friday-agent-tool-registry.test.ts
+++ b/test/unit/agent/tools/friday-agent-tool-registry.test.ts
@@ -281,6 +281,7 @@ describe("createFridayAgentToolRegistry", () => {
         execute,
         cancel: vi.fn(),
       } as never,
+      allowTestOnlySkillRunExecution: true,
       skillRegistry: stubMcpRequiredSkillRegistry(),
       mcpAdapter: stubMcpAdapter(),
       getMcpServerAvailability: () => ({ available: false, promotionChannel: "shadow" }),
@@ -319,6 +320,7 @@ describe("createFridayAgentToolRegistry", () => {
         execute,
         cancel: vi.fn(),
       } as never,
+      allowTestOnlySkillRunExecution: true,
       skillRegistry: stubMcpRequiredSkillRegistry(),
       getSkillLifecycleStatus: (skillId) =>
         skillId === "mcp-skill" ? "not_installed" : undefined,

--- a/test/unit/hub/friday-hub-bootstrap.test.ts
+++ b/test/unit/hub/friday-hub-bootstrap.test.ts
@@ -2,6 +2,7 @@ import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import * as crypto from "node:crypto";
+import { fileURLToPath } from "node:url";
 
 import Database from "better-sqlite3";
 import { beforeEach, describe, it, expect, afterEach, vi } from "vitest";
@@ -47,6 +48,18 @@ function createTestChannelPlugin(kind = "testchannel"): {
   };
 }
 
+// Absolute path to the repo's real bundled skills dir (test file lives at
+// test/unit/hub/, so the repo root is three levels up). Used by the OF6 guard
+// proofs to register a REAL bundled shell skill (audit-shell-env-presence-probe)
+// so it RESOLVES through the workflow node executor and reaches the guarded
+// `invokeSkillForWorkflow` caller — an unregistered skillId would die at skill
+// resolution before the guard, proving nothing.
+const REPO_SKILLS_DIR = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../../../skills",
+);
+const OF6_RESOLVABLE_SKILL_ID = "audit-shell-env-presence-probe";
+
 function sha256(content: string): string {
   return crypto.createHash("sha256").update(content).digest("hex");
 }
@@ -76,6 +89,43 @@ function makeChannelApprovedWorkflowGraph(
         },
       ],
       edges: [{ id: "edge-trigger-receipt", sourceNodeId: "trigger", targetNodeId: "receipt" }],
+    },
+    failurePolicy: { onFailure: "fail_fast", notifyUser: false },
+    tests: [],
+    checksum: "placeholder-checksum",
+  };
+  return {
+    ...graph,
+    checksum: sha256(JSON.stringify({ ...graph, checksum: "" })),
+  };
+}
+
+// OF6 method-level guard proof: a minimal published workflow whose single
+// post-trigger node is an `action` (skill) node. Running it drives the hub's
+// `invokeSkillForWorkflow` NON-route caller into the shared skill executor — the
+// path the OF6 guard fences. The skillId is ARBITRARY (not `ai-inference`), so
+// the guard must fail it closed when the skill-run flag is unset.
+function makeSingleSkillNodeWorkflowGraph(
+  skillId: string,
+  workflowId = "wf-placeholder",
+  versionId = "wv-placeholder",
+): FridayCompiledWorkflowGraphV2 {
+  const graph: FridayCompiledWorkflowGraphV2 = {
+    schemaVersion: "2.0",
+    workflowId,
+    workflowVersionId: versionId,
+    sourceSpecSchemaVersion: "1.0",
+    graph: {
+      nodes: [
+        { id: "trigger", type: "trigger", label: "Manual trigger", config: {} },
+        {
+          id: "skill-action",
+          type: "action",
+          label: "Run a skill via the workflow invoke path",
+          config: { skillId, args: {} },
+        },
+      ],
+      edges: [{ id: "edge-trigger-skill", sourceNodeId: "trigger", targetNodeId: "skill-action" }],
     },
     failurePolicy: { onFailure: "fail_fast", notifyUser: false },
     tests: [],
@@ -1372,5 +1422,100 @@ describe("createFridayHub", () => {
       }
     }
   }, 60_000);
+
+  // ─── TS Runtime Retirement — OF6 method-level fail-closed guard (Caller 2) ───
+  // Proves the workflow skill-invoke NON-route caller (invokeSkillForWorkflow)
+  // no longer relies on transitive upstream containment: with BOTH upstream
+  // run-execution flags ON but the skill-run flag UNSET, a workflow skill-node
+  // fails closed with TS_RUNTIME_SKILL_RUNS_RETIRED before reaching the shared
+  // arbitrary-code skill sink. A separate positive case proves the guard is
+  // flag-gated (test-oracle ON → past the guard).
+  it("OF6: a workflow skill-node fails closed (TS_RUNTIME_SKILL_RUNS_RETIRED) when the skill-run flag is UNSET even with the workflow + agent run flags ON", async () => {
+    hub = await createIsolatedHub({
+      // Point the bundled-skills root at the repo's real skills dir so the shell
+      // skill auto-installs (bundled origin) and RESOLVES through node execution.
+      skillDirs: [REPO_SKILLS_DIR, path.join(os.tmpdir(), "of6-managed-empty")],
+      allowTestOnlyWorkflowRunExecution: true,
+      allowTestOnlyAgentRunExecution: true,
+      // allowTestOnlySkillRunExecution intentionally UNSET → fail-closed.
+    });
+    await hub.start();
+
+    // owner/createdBy/startedBy left NULL — workflows.owner_user_id etc. are
+    // nullable FKs to users(id); no user row is needed for this guard proof.
+    const { workflow, version } = hub.workflowRuntime.crud.createWorkflowWithVersion(
+      {
+        slug: "of6-skill-node-failclosed",
+        name: "OF6 skill-node fail-closed proof",
+        description: "Single resolvable shell skill node to exercise the OF6 guard.",
+        tags: ["of6-skill-run-retirement"],
+      },
+      makeSingleSkillNodeWorkflowGraph(OF6_RESOLVABLE_SKILL_ID),
+      undefined,
+      "OF6 method-level guard local proof.",
+    );
+    const published = hub.workflowRuntime.crud.publishVersion(workflow.id, version.versionNumber);
+
+    const run = await hub.workflowRuntime.execution.startRun({
+      workflowId: workflow.id,
+      workflowVersionId: published.id,
+      triggerType: "manual",
+      triggerPayload: {},
+    });
+    const finalStatus = await waitForWorkflowRunStable(hub, run.id);
+    expect(finalStatus).not.toBe("completed");
+
+    const nodes = hub.workflowRuntime.execution.getRunNodes(run.id);
+    const skillNode = nodes.find((node) => node.nodeId === "skill-action");
+    expect(skillNode).toBeTruthy();
+    const errorBlob = JSON.stringify(skillNode?.error ?? {});
+    // The guard fired (the skill RESOLVED, then failed CLOSED) — proven by the
+    // verbatim retirement message, NOT a generic "not found". The node executor
+    // re-codes the thrown FridayDomainError as NODE_EXECUTION_FAILED but preserves
+    // the original fail-closed message, which is the load-bearing signature here.
+    expect(errorBlob).toContain("fail-closed");
+    expect(errorBlob).toContain("runtime ownership is being moved out of TypeScript");
+  }, 30_000);
+
+  it("OF6: a workflow skill-node proceeds past the guard when the test-oracle skill-run flag is set true", async () => {
+    hub = await createIsolatedHub({
+      skillDirs: [REPO_SKILLS_DIR, path.join(os.tmpdir(), "of6-managed-empty-on")],
+      allowTestOnlyWorkflowRunExecution: true,
+      allowTestOnlySkillRunExecution: true,
+    });
+    await hub.start();
+
+    const { workflow, version } = hub.workflowRuntime.crud.createWorkflowWithVersion(
+      {
+        slug: "of6-skill-node-flag-on",
+        name: "OF6 skill-node flag-on proof",
+        description: "Single resolvable shell skill node with the skill-run flag on.",
+        tags: ["of6-skill-run-retirement"],
+      },
+      makeSingleSkillNodeWorkflowGraph(OF6_RESOLVABLE_SKILL_ID),
+      undefined,
+      "OF6 method-level guard flag-on local proof.",
+    );
+    const published = hub.workflowRuntime.crud.publishVersion(workflow.id, version.versionNumber);
+
+    const run = await hub.workflowRuntime.execution.startRun({
+      workflowId: workflow.id,
+      workflowVersionId: published.id,
+      triggerType: "manual",
+      triggerPayload: {},
+    });
+    await waitForWorkflowRunStable(hub, run.id);
+
+    // With the flag on, the guard is BYPASSED: the node reaches the real shell
+    // executor (whatever its execution outcome). The retirement signature must
+    // be ABSENT — that distinguishes "guard bypassed" from "guard fired", proving
+    // the guard is flag-gated rather than a hard block.
+    const nodes = hub.workflowRuntime.execution.getRunNodes(run.id);
+    const skillNode = nodes.find((node) => node.nodeId === "skill-action");
+    expect(skillNode).toBeTruthy();
+    const errorBlob = JSON.stringify(skillNode?.error ?? {});
+    expect(errorBlob).not.toContain("TS_RUNTIME_SKILL_RUNS_RETIRED");
+    expect(errorBlob).not.toContain("runtime ownership is being moved out of TypeScript");
+  }, 30_000);
 
 });


### PR DESCRIPTION
## What this closes

The skill **EXECUTOR** (`src/skills/executor/friday-skill-executor.ts` `execute`→`executeInternal`→ shell/python/node = arbitrary code) was **ROUTE-only-guarded** by `allowTestOnlySkillRunExecution` (at `friday-skill-routes.ts:861`). Two **NON-route** callers reached that arbitrary-code sink with **no method-level retirement guard**, contained ONLY transitively by default-off upstream flags. The slice-6 Rust cutover flips exactly those upstream flags — so this is the **OF6 latent method-level hole**, closed here with defense-in-depth **at the sink callers**.

## Scope — exactly the 2 non-route callers

1. **Caller 1 — agent `skill_run` tool** (`src/agent/tools/friday-agent-skill-tool.ts`): guard at the **top of `execute`** (before it reaches `skillExecutor.execute`). The flag is threaded into the tool deps → tool registry options (`friday-agent-tool-registry.ts`) → both hub-bootstrap registry call sites (main + subagent children).
2. **Caller 2 — workflow invoke** (`src/hub/friday-hub-bootstrap.ts` `invokeSkillForWorkflow`): guard **before `executor.execute(...)`**, keyed to `config.allowTestOnlySkillRunExecution`.

Both reuse the **SAME** flag (one flag for the whole skill-run retirement surface) and throw the same `FridayDomainError("TS_RUNTIME_SKILL_RUNS_RETIRED", …, { httpStatus: 503, details: { classification: "fail_closed", replacement: "rust_owned_skill_run_entrypoint_required" } })` as the route guard (inline-replicated, matching the existing UIX-surface precedent — no cross-layer import of the route helper).

## Default-OFF (NO degrade)

The flag stays **unset in prod** → skill runs **fail closed**, which is the intended retired state. This PR only **adds** a fail-closed guard; it weakens nothing. Verified there is no `?? true` / default-true for `allowTestOnlySkillRunExecution` anywhere in prod config.

## Preserves (MUST NOT retire) — verified

- **`ai-inference` BYOK shortcut**: **exempt at BOTH callers** (`skillId !== "ai-inference"`). It short-circuits to the provider service inside the executor (`friday-skill-executor.ts` ai-inference shortcut) and returns **before any shell/python/node sink** — a fixed (non-arbitrary) path. For workflows it is the live AI-node BYOK path (`workflow-ai-adapter.ts` invokes `"ai-inference"` through `invokeSkillForWorkflow`). The exemption mirrors the **executor's own** `request.skillId === "ai-inference"` check (NOT the route guard, which 503s ai-inference unconditionally — the route has other provider-inference entrypoints; the workflow AI-node does not).
- **Curated UIX starter-template lane**: untouched. It is gated by its **own** `enforceUixSkillExecRetirement` flag (DEC-3a accepted-live) and is not one of these two callers. UIX surface tests stay green.

## Tests (behavioral, defense-in-depth)

- Agent `skill_run`: **503s** `TS_RUNTIME_SKILL_RUNS_RETIRED` when the skill flag is UNSET; **ai-inference proceeds** (positively asserts `executor.execute` was called) with the flag UNSET; proceeds for an arbitrary skill when the test-oracle flag is `true`.
- Workflow skill-node: with BOTH `allowTestOnlyWorkflowRunExecution=true` AND `allowTestOnlyAgentRunExecution=true` but `allowTestOnlySkillRunExecution` UNSET, a skill action node (a **resolvable real bundled shell skill**) **fails closed** with the verbatim retirement message (proving it no longer relies on transitive upstream containment); with the skill flag `true` it proceeds past the guard.
- Threaded `allowTestOnlySkillRunExecution: true` (test-oracle) into the existing skill-tool / tool-registry tests that expect execution to proceed, so they stay green.

## Local gate results (all green)

- `npm run build` (tsc): **0 errors** ✓
- `npm run lint`: **0 errors** (1554 pre-existing warnings, none in touched files) ✓
- Touched-area vitest: agent skill-tool + registry + hub-bootstrap (incl. new OF6 tests) ✓; plus full `test/unit/agent`, both `test/integration/{hub,node-runner}`, sessions/classifier, channel-trigger, hub-helpers, skill-run-checkpoint — **all pass** (no fail-close regressions) ✓
- `node scripts/quality/check-ts-runtime-retirement.mjs` → **passed**, then `assert-ts-runtime-blocker-zero.mjs` → **ts_runtime_blocker == 0** ✓ (routeCount **unchanged by this PR** — guards are at non-route callers)
- `node scripts/quality/assert-ts-runtime-method-guards.mjs` → **passed** (no new unregistered mutators; no floors changed)
- `npm run test:contracts` → **passed** (unaffected) ✓
- secrets: `check-provider-key-patterns.mjs` clean + `detect-secrets-hook` clean ✓
- No Rust touched → no cargo build/test needed.

## Honest caveats

- **Third raw `.execute()` caller NOT guarded — intentionally**: `src/cli/friday-cli.ts:1605` (local operator `friday skill run`). It is operator-local, **outside** the OF6 transitive-containment surface (not contained by the slice-6 upstream flags), and guarding it would **degrade an operator capability** (violates the NO-degrade constraint). Documented, not changed.
- `executeLifecycleCanary` (`friday-skill-executor.ts:631`) is a **different method** (gated promotion/canary path), untouched.
- The two guard sites are **NOT registered in `methodRetiredSurfaces`** — they are a tool-factory `execute` and a `const`-arrow, not public `…Service` methods, so the structural method-guard gate's scan does not apply to them. The anti-regression protection here is the **behavioral tests** (run in the `test` job), not `assert-ts-runtime-method-guards.mjs`. A future removal of these guards would be caught by the behavioral tests, not by the structural gate.
- **Caller 2 ai-inference exemption is covered by code symmetry + AI-adapter routing, not a dedicated test.** The workflow flag-off test uses an *action*-node shell skill (which exercises the guard for that path). ai-inference reaches `invokeSkillForWorkflow` only via the *AI-node* → `WorkflowAiAdapter` path (which bypasses `resolveSkill` and needs a provider mock), so an action-node test cannot cover it. The Caller 1 ai-inference exemption **is** positively tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)