### PR TITLE
feat(j2): iOS sealed-WS write transport — NWConnection, master-derived peer (DARK, opt-in)

### DIFF
--- a/apps/friday-ios/Sources/FridayMobileShell/FridayApp.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayApp.swift
@@ -61,17 +61,16 @@ final class FridaySession: ObservableObject {
     // unavailable client — this PR does NOT flip the shipped default (that is the slice-6 gate).
     self.readClient = preview ? PreviewReadClient() : Self.defaultReadClient()
 
-    // The write client (Friday Chat read-WRITE / S6 surface) also has NO live transport wired
-    // (slice-6 deferred AC) ⇒ its default factory transport throws ⇒ honest-unavailable. Its
-    // transport keypair is an ephemeral X25519 SESSION key (transport identity only, NOT a
-    // signing key — INV-1) that NEVER reaches the live store because no socket is opened; it is
-    // confined to honest-unavailable construction. When slice-6 lands, inject a master-derived
-    // keypair + a live `NWConnection` transport here.
-    let writeKeypair = FridayCrypto.DeviceKeypair()
-    let endpoint = FridayClientFactory.Endpoint(
-      forwardedPrincipal: "principal:owner-device",
-      agentRunControlViaRust: runControlEnabled)
-    self.writeClient = FridayClientFactory.makeWriteClient(keypair: writeKeypair, endpoint: endpoint)
+    // The write client (Friday Chat read-WRITE / S6 surface). DEFAULT (gate OFF) = the throwing
+    // `liveTransportNotWired` factory transport ⇒ honest-unavailable, with an ephemeral X25519
+    // SESSION key (transport identity only, NOT a signing key — INV-1) that NEVER reaches the live
+    // store because no socket is opened. The master-derived LIVE write path (the iOS J2 mirror of
+    // the read seam's `RealReadClientFactory.makeLive`) is now BUILT and wired behind an OPT-IN
+    // env/arg gate (`FRIDAY_MOBILE_LIVE_WRITE=1` / `--live-write`, mirroring `FRIDAY_MOBILE_LIVE_READ`).
+    // This PR does NOT flip the shipped default (that, and the S6 control plane, are operator gates).
+    self.writeClient = preview
+      ? Self.honestUnavailableWriteClient()
+      : Self.defaultWriteClient(runControlEnabled: runControlEnabled)
     self.signer = MockOperatorSigner()
   }
 
@@ -98,6 +97,46 @@ final class FridaySession: ObservableObject {
     } catch {
       return RealReadClientFactory.makeHonestlyUnavailable(reason: "\(error)")
     }
+  }
+
+  /// The DEFAULT (non-preview) Friday Chat WRITE client. DEFAULT = the throwing
+  /// `liveTransportNotWired` factory transport (honest-unavailable, no socket, no SecureStore
+  /// touch); LIVE only when explicitly opted in via env `FRIDAY_MOBILE_LIVE_WRITE=1` or launch arg
+  /// `--live-write` (the WRITE-seam mirror of `--live-read`). This PR does NOT flip the shipped
+  /// default — the live write transport is opt-in, gated, and never on by default (slice-6 gate);
+  /// `runControlEnabled` (the S6 pause/approve/resume) is a SEPARATE operator gate, default-off.
+  ///
+  /// LIVE: derive the enrolled master-derived peer (`MasterKeyPeer`), target 48750 as `admin-001`,
+  /// over the real `SealedWSWriteClient` (`RealWriteClientFactory.makeLive`). If the host master key
+  /// is unavailable (e.g. a real phone — the J2 pairing problem), fall back to the throwing default
+  /// (honest unavailable) — NEVER fabricate a ready chat surface the live seam did not produce.
+  static func defaultWriteClient(runControlEnabled: Bool) -> FridayRustWriteClient {
+    let args = ProcessInfo.processInfo.arguments
+    let env = ProcessInfo.processInfo.environment
+    let useLive = args.contains("--live-write") || env["FRIDAY_MOBILE_LIVE_WRITE"] == "1"
+    guard useLive else {
+      // SHIPPED DEFAULT — unchanged: the throwing `liveTransportNotWired` factory transport, no
+      // socket, no SecureStore touch.
+      return honestUnavailableWriteClient(runControlEnabled: runControlEnabled)
+    }
+    do {
+      return try RealWriteClientFactory.makeLive(agentRunControlViaRust: runControlEnabled)
+    } catch {
+      // Master key unavailable (the J2 pairing problem on a real device): surface the truth via the
+      // throwing default transport (honest-unavailable) — never fabricate a ready chat surface.
+      return honestUnavailableWriteClient(runControlEnabled: runControlEnabled)
+    }
+  }
+
+  /// The honest-unavailable WRITE client: the shared `FridayClientFactory.makeWriteClient` with its
+  /// DEFAULT throwing `liveTransportNotWired` transport + an ephemeral session keypair that opens no
+  /// socket. This is the SHIPPED default and the preview/no-master-key fallback.
+  static func honestUnavailableWriteClient(runControlEnabled: Bool = false) -> FridayRustWriteClient {
+    let writeKeypair = FridayCrypto.DeviceKeypair()
+    let endpoint = FridayClientFactory.Endpoint(
+      forwardedPrincipal: "principal:owner-device",
+      agentRunControlViaRust: runControlEnabled)
+    return FridayClientFactory.makeWriteClient(keypair: writeKeypair, endpoint: endpoint)
   }
 
   #if DEBUG

--- a/apps/friday-ios/Sources/FridayMobileShellCore/RealWriteClientFactory.swift
+++ b/apps/friday-ios/Sources/FridayMobileShellCore/RealWriteClientFactory.swift
@@ -1,0 +1,128 @@
+import CryptoKit
+import Foundation
+import FridayRustClient
+import Network
+
+// MARK: - Real WRITE-client factory (the J2 device-pairing / Hub↔phone sync write seam)
+//
+// MIRRORS the iOS READ seam `RealReadClientFactory.makeLive` (#696) and the desktop NWConnection
+// sealed transport precedent, but for the sealed-WS WRITE / agent-run server
+// (`bin/hub_agent_run_server.rs`) on the loopback WRITE port. Builds the REAL `SealedWSWriteClient`
+// (the shared `FridayRustClient` package's sealed-WS WRITE client) configured for the agent-run
+// server's LOOPBACK host:port, driven over a concrete `NWConnection`-backed `SealedWSTransport`.
+//
+// REUSE, NO DIVERGENT IMPL: the network transport is the SAME `LoopbackSealedWSTransport` the read
+// seam uses (the socket plumbing + the cleartext length-prefixed preamble + the hand-rolled
+// RFC-6455 client upgrade + the masked Binary framing are byte-identical for read and write — the
+// Rust `establish_session` is the SHARED handshake for both servers). The crypto is the shared
+// package's X25519 ECDH → HKDF-SHA256 → XChaCha20-Poly1305; the master-derived peer is the SHARED
+// `MasterKeyPeer` from #696. This file adds NO fresh crypto and NO second transport class.
+//
+// SINGLE-PEER-TRAP SAFETY: the WRITE server reads the SAME `PEER_PUBKEY_ALLOWLIST_ID` single-peer
+// SecureStore the READ server reads (`~/.friday/agent-run-securestore`), enrolled to EXACTLY the
+// master-derived peer. We therefore derive — NEVER enroll — the master-derived keypair in memory
+// (`MasterKeyPeer.deriveKeypair`). A fresh enroll would EVICT that one peer and break BOTH seams.
+//
+// HONEST CEILING: against a DARK / un-flipped write server (nothing listening, or the peer not
+// enrolled) the connect / preamble / handshake fails honestly → the Friday Chat surface renders
+// honest-unavailable. The LIVE round-trip this enables is the sealed HANDSHAKE + peer-auth; a live
+// agent-run MUTATION (S6 control plane) is operator-gated and DARK — this seam does NOT dispatch
+// one, and the default shipped transport stays the throwing `liveTransportNotWired`.
+
+/// Configuration for the real WRITE client's connection to the agent-run server. A WRITE-side twin
+/// of `ReadProjectionServerConfig` (a distinct type so a read config can never be mis-pointed at the
+/// write port and vice-versa).
+public struct AgentRunServerConfig: Sendable, Equatable {
+  /// Loopback host the agent-run WRITE server listens on (default `127.0.0.1`).
+  public let host: String
+  /// TCP port the agent-run WRITE server listens on.
+  public let port: UInt16
+  /// Connect / preamble timeout. Past this, a dark server surfaces as honest unavailable.
+  public let connectTimeout: TimeInterval
+
+  public init(host: String = "127.0.0.1", port: UInt16, connectTimeout: TimeInterval = 4) {
+    self.host = host
+    self.port = port
+    self.connectTimeout = connectTimeout
+  }
+
+  /// The LIVE write seam: the loopback host:port the agent-run WRITE LaunchAgent
+  /// (`com.friday.rust-agent-run-ws-server`) listens on. The staged plist pins `--port 48750`
+  /// (distinct from the read-projection server on 48751 and the TS hub on 48060).
+  ///
+  /// HONEST NOTE: `48750` is the value the operator's LaunchAgent pins, NOT a bin default. If the
+  /// operator relaunches on a different port, update here / pass an explicit config. When nothing
+  /// listens on this port, the transport fails honestly → honest "unavailable".
+  public static let liveLoopback = AgentRunServerConfig(host: "127.0.0.1", port: 48750)
+}
+
+/// The owner principal the agent-run WRITE LaunchAgent enrolls in its owner-allowlist
+/// (`--owner admin-001` in `com.friday.rust-agent-run-ws-server.plist`). The live
+/// `forwarded_principal` MUST equal an owner-allowlist entry or a DISPATCHED run fails closed.
+/// (A handshake-only probe never asserts the principal — owner-auth is exercised only by a
+/// dispatch, which the live-write transport proof deliberately does NOT send.)
+public let liveAgentRunOwnerPrincipal = "admin-001"
+
+/// Builds the REAL `SealedWSWriteClient` for the agent-run WRITE server.
+public enum RealWriteClientFactory {
+  /// Construct the real write client over the `NWConnection` write transport.
+  ///
+  /// - Parameters:
+  ///   - config: the agent-run WRITE server's loopback host:port.
+  ///   - keypair: this client's X25519 keypair. Its public key MUST be the server's enrolled
+  ///     peer-allowlist entry (the master-derived peer) or the handshake is refused before the
+  ///     server sends its own pubkey. Defaults to a fresh ephemeral keypair (sufficient to drive
+  ///     the NEGATIVE control / honest-unavailable against the live server; the real enrolled path
+  ///     is `makeLive`, which derives the master peer).
+  ///   - forwardedPrincipal: the owner principal; MUST be in the server's owner-allowlist (only
+  ///     exercised by a DISPATCH — never by a handshake-only probe).
+  ///   - sessionId: optional session id for a sessioned (multi-turn chat) run.
+  ///   - agentRunControlViaRust: DEFAULT-OFF run-control flag (the S6 pause/approve/resume gate).
+  public static func make(
+    config: AgentRunServerConfig,
+    keypair: FridayCrypto.DeviceKeypair = FridayCrypto.DeviceKeypair(),
+    forwardedPrincipal: String,
+    sessionId: String? = nil,
+    agentRunControlViaRust: Bool = false
+  ) -> FridayRustWriteClient {
+    SealedWSWriteClient(
+      keypair: keypair,
+      forwardedPrincipal: forwardedPrincipal,
+      sessionId: sessionId,
+      agentRunControlViaRust: agentRunControlViaRust,
+      makeTransport: { try LoopbackSealedWSTransport(config: ReadProjectionServerConfig(
+        host: config.host, port: config.port, connectTimeout: config.connectTimeout)) }
+    )
+  }
+
+  /// Construct the LIVE write client — the enrolled master-derived peer connecting to the live
+  /// agent-run WRITE server.
+  ///
+  /// Derives the keypair from `~/.friday/master.key` (or `FRIDAY_MASTER_KEY`) the SAME way the
+  /// enroll CLI did (so its pubkey IS the allowlisted peer the WRITE server reads from the SHARED
+  /// single-peer SecureStore); targets `liveLoopback` (48750); authenticates as `admin-001`. Throws
+  /// (fail-closed) if the master key is missing/invalid — never substitutes an ephemeral key for the
+  /// live path, and NEVER enrolls a fresh key (single-peer-trap safe: `MasterKeyPeer.deriveKeypair`
+  /// only reads + derives in memory; enrolling would evict the desktop write-peer + break BOTH seams).
+  ///
+  /// This is the launch-mode the app selects under `FRIDAY_MOBILE_LIVE_WRITE=1` / `--live-write`.
+  /// The honest-unavailable (throwing `liveTransportNotWired`) client stays the shipped default;
+  /// this never runs without an enrolled host master key, and only on the env/arg opt-in.
+  ///
+  /// `agentRunControlViaRust` stays DEFAULT-OFF here (the S6 control plane is a separate operator
+  /// gate); wiring the live transport does NOT flip it on.
+  public static func makeLive(
+    config: AgentRunServerConfig = .liveLoopback,
+    forwardedPrincipal: String = liveAgentRunOwnerPrincipal,
+    sessionId: String? = nil,
+    agentRunControlViaRust: Bool = false
+  ) throws -> FridayRustWriteClient {
+    let keypair = try MasterKeyPeer.deriveKeypair()
+    return make(
+      config: config,
+      keypair: keypair,
+      forwardedPrincipal: forwardedPrincipal,
+      sessionId: sessionId,
+      agentRunControlViaRust: agentRunControlViaRust)
+  }
+}

--- a/apps/friday-ios/Tests/FridayMobileShellCoreTests/LiveWriteTransportIntegrationTests.swift
+++ b/apps/friday-ios/Tests/FridayMobileShellCoreTests/LiveWriteTransportIntegrationTests.swift
@@ -1,0 +1,117 @@
+import Foundation
+import Testing
+
+@testable import FridayMobileShellCore
+@testable import FridayRustClient
+
+// MARK: - LIVE write-transport sealed-handshake integration (MANUAL / env-gated — CI SKIPS)
+//
+// The J2 mirror of `LiveReadProjectionIntegrationTests` (#696), but for the sealed-WS WRITE /
+// agent-run server (`bin/hub_agent_run_server.rs`) on 127.0.0.1:48750. It drives the iOS
+// `LoopbackSealedWSTransport` (the SAME transport the read seam uses — no divergent impl) as the
+// enrolled MASTER-DERIVED peer (the SAME peer the read seam + the desktop derive, read from the
+// host `~/.friday/master.key`), and asserts the cleartext preamble + the RFC-6455 WS upgrade + the
+// ECDH session-key agreement COMPLETE — i.e. peer-auth passed at the SHARED `establish_session`
+// (`sealed_ws.rs`), which gates the SecureStore peer-allowlist FIRST, BEFORE the server writes back
+// its own pubkey + the 64-byte session nonce. So a peer that receives the server pubkey + a 64-byte
+// nonce HAS been peer-authenticated by the write server.
+//
+// These read a real host secret and require a live server, so they are GATED on
+// `FRIDAY_MOBILE_LIVE_WRITE_TEST=1` and are SKIPPED in CI (which has no such server and must never
+// read the host master key).
+//
+// Run locally (the agent-run WRITE server must already be listening — verify with
+// `lsof -nP -iTCP:48750 -sTCP:LISTEN`):
+//   FRIDAY_MOBILE_LIVE_WRITE_TEST=1 swift test --package-path apps/friday-ios \
+//     --filter LiveWriteTransport
+//
+// PROOF CEILING (honest — read it before trusting the green):
+//   * This proves the iOS WRITE-TRANSPORT sealed HANDSHAKE + peer-auth ONLY. It is deliberately
+//     NON-MUTATING: it sends ZERO `AgentRunRequest` envelopes. Dispatching a run would START A RUN
+//     (the S6 control plane is DARK + operator-gated) — so this test STOPS at the completed
+//     handshake and NEVER calls `dispatchAgentRun`.
+//   * It therefore does NOT prove a live agent-run, a live mutation, or owner-principal admission
+//     (the `forwarded_principal` owner-auth is exercised only by a DISPATCH, which we do not send).
+//     Those are slice-6 / operator gates.
+//   * SINGLE-PEER-TRAP: the master-derived path NEVER enrolls a fresh key — it only reads the
+//     master key and derives in memory. The negative control's ephemeral `DeviceKeypair()` opens a
+//     socket but writes NOTHING to the shared SecureStore.
+//   * SECRET DISCIPLINE: we print the PUBLIC key hex + handshake byte LENGTHS only — never the
+//     master key, the derived secret, or the session key.
+
+private let liveWriteTestEnabled =
+  ProcessInfo.processInfo.environment["FRIDAY_MOBILE_LIVE_WRITE_TEST"] == "1"
+
+/// Drive the sealed-WS handshake (preamble + WS upgrade + ECDH) over the live write transport as the
+/// enrolled master-derived peer, asserting peer-auth completes. NON-MUTATING: no envelope is sent.
+@Test(.enabled(if: liveWriteTestEnabled))
+func liveWriteTransportSealedHandshakeWithMasterDerivedPeer() throws {
+  // The enrolled peer: derive the keypair from the host master key the SAME way the enroll CLI did.
+  // Its pubkey is the allowlisted peer the WRITE server reads from the SHARED single-peer
+  // SecureStore (offline-proven byte-identical by `masterDerivedPubkeyMatchesRustKat`; here it is
+  // the REAL host key).
+  let keypair = try MasterKeyPeer.deriveKeypair()
+  print("[live-write] master-derived peer pubkey (PUBLIC) = \(Hex.encode(keypair.publicKey))")
+
+  // The SAME transport the read seam uses, pointed at the WRITE port (48750).
+  let transport = try LoopbackSealedWSTransport(config: ReadProjectionServerConfig(
+    host: AgentRunServerConfig.liveLoopback.host,
+    port: AgentRunServerConfig.liveLoopback.port))
+
+  // PHASE 1 — the cleartext preamble. Send our (enrolled) pubkey. The write server runs the
+  // peer-allowlist gate FIRST in `establish_session`; only an ALLOWLISTED peer then receives the
+  // server pubkey + the 64-byte session nonce. Receiving them IS the peer-auth proof.
+  try transport.writeFrame(keypair.publicKey)
+
+  let serverPub = try transport.readFrame()
+  print("[live-write] server pubkey bytes = \(serverPub.count)")
+  #expect(serverPub.count == FridayCrypto.x25519PublicKeyLen)
+
+  let sessionNonce = try transport.readFrame()
+  print("[live-write] session nonce bytes = \(sessionNonce.count)")
+  #expect(sessionNonce.count == 64)  // SESSION_NONCE_LEN — must match the write client's check.
+
+  // PHASE 1→2 — the RFC-6455 client WS upgrade over the (preamble-consumed) socket. The server is
+  // plain tungstenite over ws://; this validates 101 + Sec-WebSocket-Accept.
+  try transport.upgrade()
+
+  // The ECDH session-key agreement — the byte-exact shared substrate (X25519 → the per-session
+  // key the WRITE SESSION_AAD seals under). A 32-byte agreed key = the sealed channel is live.
+  let sessionKey = try keypair.agree(peerPublicKey: serverPub)
+  print("[live-write] AUTHENTICATED HANDSHAKE OK — agreed session key bytes = \(sessionKey.count)")
+  #expect(sessionKey.count == FridayCrypto.sessionKeyLen)
+
+  // STOP HERE. We do NOT send an AgentRunRequest — that would start a run (S6 is dark +
+  // operator-gated). The completed handshake + peer-auth is the transport proof.
+}
+
+/// NEGATIVE CONTROL — proves the master-derivation (peer-allowlist) is load-bearing. A FRESH
+/// ephemeral keypair is NOT the enrolled allowlist peer, so the write server's `establish_session`
+/// peer-allowlist gate fail-closes BEFORE writing back its pubkey — the session ends and the
+/// transport read fails. DISTINCT from the master-derived peer's completed handshake.
+@Test(.enabled(if: liveWriteTestEnabled))
+func liveWriteTransportRefusesFreshEphemeralPeer() throws {
+  let ephemeral = FridayCrypto.DeviceKeypair()
+  print("[live-write] ephemeral (NON-enrolled) pubkey = \(Hex.encode(ephemeral.publicKey))")
+
+  let transport = try LoopbackSealedWSTransport(config: ReadProjectionServerConfig(
+    host: AgentRunServerConfig.liveLoopback.host,
+    port: AgentRunServerConfig.liveLoopback.port))
+
+  do {
+    try transport.writeFrame(ephemeral.publicKey)
+    let serverPub = try transport.readFrame()
+    // If a server pubkey of the correct width comes back, a non-enrolled peer was admitted — a
+    // peer-auth bypass. Fail loudly.
+    if serverPub.count == FridayCrypto.x25519PublicKeyLen {
+      Issue.record(
+        "a non-enrolled ephemeral peer unexpectedly received a server pubkey (peer-auth bypass)")
+    } else {
+      // A short/empty frame is the server fail-closing — acceptable as a refusal signal.
+      print("[live-write] ephemeral peer REFUSED (short/empty frame, \(serverPub.count) bytes) as expected")
+    }
+  } catch {
+    // The expected outcome: the allowlist gate ended the session → the preamble read fails.
+    print("[live-write] ephemeral peer REFUSED (fail-closed) as expected: \(error)")
+  }
+}


### PR DESCRIPTION
## What
Ports the desktop / #696-read NWConnection sealed-WS transport onto the iOS WRITE client, so the mobile shell can do a sealed handshake + peer-auth to the live Rust write server (`:48750`). De-risks **J2** (Hub↔phone sync transport). DARK + opt-in; default unchanged.

- **Added:** `RealWriteClientFactory.swift` (`makeLive` → sealed-WS write client, reuses the shared `LoopbackSealedWSTransport` + `MasterKeyPeer.deriveKeypair` from #696 — no divergent crypto, no forked transport), `LiveWriteTransportIntegrationTests.swift` (env-gated `FRIDAY_MOBILE_LIVE_WRITE_TEST=1`, CI-skipped).
- **Changed:** `FridayApp.swift` — write-client seam → `Self.defaultWriteClient(...)`, which returns the existing throwing `liveTransportNotWired` honest-unavailable client **unless** `FRIDAY_MOBILE_LIVE_WRITE=1` / `--live-write` (mirror of #696's read gate).

## No-degrade / safety (verified)
- **Default UNCHANGED:** gate-off = the shipped throwing `liveTransportNotWired` transport; no slice-6 prod flip. Sim launch confirms default honest-unavailable + Hero Pet.
- **Single-peer trap respected:** master-derived peer ONLY; no enroll/SecureStore write in the new factory; shared SecureStore peer `6e92f094…` mtime UNCHANGED after all runs.
- **Non-mutating:** the integration test does a handshake-only sealed round-trip — zero `AgentRunRequest` envelopes; does NOT trigger S6 / any mutation (the S6 control plane stays dark, operator-gated).

## Proof (local; iOS not CI-covered, mirrors #696/desktop)
- `swift build` pass; sim build/launch on iPhone 17 Pro (default honest-unavailable, seam transparent).
- **LIVE sealed handshake against running :48750:** master-derived peer `532c48f3…` → server pubkey (32B) + session nonce (64B) + WS upgrade + agreed 32B session key (peer-allowlist auth complete, gated FIRST per `sealed_ws.rs establish_session`). Negative control: non-enrolled ephemeral peer REFUSED fail-closed.

## Honest ceiling
Proves the iOS write-transport sealed handshake + peer-allowlist auth — NOT a live agent-run, mutation, or owner-auth (those need the dark S6 control plane + a real device + operator). De-risk of J2's transport layer only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)