### PR TITLE
fix(b4): transport-B organic mutating dispatch — forward readOnly:false for gated-mutating runs

### DIFF
--- a/src/api/runtime/friday-api-runtime.ts
+++ b/src/api/runtime/friday-api-runtime.ts
@@ -1102,6 +1102,41 @@ export interface RustRouteQualificationInput {
 }
 
 /**
+ * (A2b Phase 2, mutation-relax — DARK, default-off) The SINGLE source of truth for whether an
+ * agent-run is a VALID GATED MUTATING run. Extracted from {@link qualifiesForRustReadOnlyRoute}'s
+ * clause-2 computation so the qualifier (admission) AND the route's compose call site (the
+ * `constraints.readOnly` it forwards on the wire) consult the EXACT same predicate — they can
+ * never diverge (no guard-divergence hole). Side-effect-free; returns a bool.
+ *
+ * Every conjunct must hold; any uncertainty ⇒ false ⇒ the run is treated as read-only-only (the
+ * compose path forwards `{ readOnly: true }`, byte-identical to today). The FIRST conjunct is
+ * `agentRunControlViaRust === true`, which is default-off, so OFF ⇒ this is always false ⇒
+ * BYTE-IDENTICAL-WHEN-OFF. The compensating tightenings (an explicit positive `mutatingToolGrant`
+ * ⊆ the closed allow-list, an explicit `mutationGate` marker, and a non-empty bound owner
+ * principal) keep the admitted UNGATED-mutation surface EXACTLY ZERO. This admits CANDIDACY only:
+ * the Rust runtime gate remains the real enforcer and PAUSES every mutating tool pending an
+ * operator-signed Ed25519 approval.
+ */
+export function isGatedMutatingRustRouteRun(input: RustRouteQualificationInput): boolean {
+  const mutatingGrant = input.mutatingToolGrant;
+  const mutatingGrantWithinAllowList =
+    Array.isArray(mutatingGrant)
+    && mutatingGrant.length > 0
+    && mutatingGrant.every((tool) =>
+      (RUST_ROUTE_MUTATING_TOOL_ALLOWLIST as readonly string[]).includes(tool),
+    );
+  const hasBoundOwnerPrincipal =
+    typeof input.principalId === "string" && input.principalId.trim().length > 0;
+  return (
+    input.agentRunControlViaRust === true
+    && input.constraints?.readOnly === false
+    && mutatingGrantWithinAllowList
+    && input.mutationGate === RUST_ROUTE_MUTATION_GATE_MARKER
+    && hasBoundOwnerPrincipal
+  );
+}
+
+/**
  * Fail-closed qualifying predicate for the future Rust read-only route (DARK).
  * TOTAL + side-effect-free: returns `true` only when EVERY clause holds; any missing /
  * uncertain field → `false`. Computes a bool; routes nothing.
@@ -1136,21 +1171,10 @@ export function qualifiesForRustReadOnlyRoute(input: RustRouteQualificationInput
   //         mutating run, independent of any session sub-clause below).
   // The Rust runtime gate remains the REAL enforcer: each granted mutating tool still Pauses
   // pending an operator-signed Ed25519 approval. This admits CANDIDACY only, never EXECUTION.
-  const mutatingGrant = input.mutatingToolGrant;
-  const mutatingGrantWithinAllowList =
-    Array.isArray(mutatingGrant)
-    && mutatingGrant.length > 0
-    && mutatingGrant.every((tool) =>
-      (RUST_ROUTE_MUTATING_TOOL_ALLOWLIST as readonly string[]).includes(tool),
-    );
-  const hasBoundOwnerPrincipal =
-    typeof input.principalId === "string" && input.principalId.trim().length > 0;
-  const isGatedMutatingRun =
-    input.agentRunControlViaRust === true
-    && input.constraints?.readOnly === false
-    && mutatingGrantWithinAllowList
-    && input.mutationGate === RUST_ROUTE_MUTATION_GATE_MARKER
-    && hasBoundOwnerPrincipal;
+  // The SINGLE source of truth, shared VERBATIM with the route's compose call site (which forwards
+  // `constraints.readOnly: false` ONLY for this verdict) via {@link isGatedMutatingRustRouteRun} —
+  // so admission (here) and the on-the-wire constraint can NEVER diverge.
+  const isGatedMutatingRun = isGatedMutatingRustRouteRun(input);
 
   // Clause 2 — readOnly (hard-blocks mutating tools in the runtime) OR a VALID gated mutating
   // run (the only way `readOnly:false` is ever admitted; flag-off ⇒ this OR-arm is dead code).
@@ -4708,7 +4732,12 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
             // Unresolvable ⇒ resolvedProvider stays undefined ⇒ clause 3 disqualifies.
           }
         }
-        const qualifies = qualifiesForRustReadOnlyRoute({
+        // The ONE qualification input, built ONCE and reused for BOTH the admission predicate
+        // (`qualifiesForRustReadOnlyRoute`) AND the gated-mutating verdict
+        // (`isGatedMutatingRustRouteRun`, which decides the `constraints.readOnly` we forward on
+        // the wire). Sharing one object guarantees the two predicates see byte-identical inputs —
+        // no field can drift between admission and the on-the-wire constraint.
+        const rustRouteQualificationInput: RustRouteQualificationInput = {
           invokedFromHttpStartRunRoute: true,
           providerId: input.providerId,
           resolvedProvider,
@@ -4731,7 +4760,8 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
           // existing caller (→ the mutating branch never opens). Consulted only behind the flag.
           mutatingToolGrant: input.mutatingToolGrant,
           mutationGate: input.mutationGate,
-        });
+        };
+        const qualifies = qualifiesForRustReadOnlyRoute(rustRouteQualificationInput);
         if (qualifies) {
           // execrun S-F carry-forward (DARK) — apiRequestIdempotencyKey REPLAY precedence.
           // The compose path mints a FRESH runId; without this guard two requests sharing
@@ -4808,15 +4838,26 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
             // (A2a Phase 1) forward the session key so a SESSIONED qualifying run dispatches
             // `session_id`; absent/blank ⇒ byte-identical sessionless dispatch (today's behavior).
             sessionKey: input.sessionKey,
-            // (A1 run-controls) Derive the per-run constraints to forward on the wire. A run only
-            // reaches here when it QUALIFIED, which (clause 2) REQUIRES `constraints.readOnly ===
-            // true` — so forward `{ readOnly: true }`, making the read-only guarantee travel on
-            // the wire + be enforced in Rust (defense-in-depth), not only by this TS qualifier.
-            // We forward ONLY the verified-true `readOnly` (the qualifier's own contract); the
-            // disabled-tool / max-turns axes are not asserted by the read-only route today, so
-            // they stay absent (omitted on the wire). The server gates application behind its
-            // default-off run-control flag, so this remains DARK + DEPLOY-GO-gated.
-            constraints: { readOnly: true },
+            // (A1 run-controls + A2b mutation-relax) Derive the per-run `readOnly` constraint to
+            // forward on the wire from the SAME verdict the qualifier validated (one shared
+            // predicate — `isGatedMutatingRustRouteRun` — so admission + the wire constraint can
+            // NEVER diverge):
+            //   • READ-ONLY run (today's behavior, byte-identical): clause 2 REQUIRED
+            //     `constraints.readOnly === true`, so forward `{ readOnly: true }` — the read-only
+            //     guarantee travels on the wire + is enforced in Rust (defense-in-depth), not only
+            //     by this TS qualifier. UNCHANGED — no degrade.
+            //   • GATED MUTATING run (A2b, dark/default-off): forward `{ readOnly: false }` — the
+            //     REAL constraint the qualifier validated. The wire `read_only` is then OMITTED
+            //     (`buildConstraintsWire` never emits `read_only:false`), so the Rust RunPolicy is
+            //     NOT read-only and the granted mutating tool FIRES → the runtime gate evaluates it
+            //     → withholds the (default-absent) approval → PAUSES, surfacing the courier's
+            //     paused outcome. The `mutatingToolGrant` is NOT a wire field (the constraints/wire
+            //     are restriction-only by design); it is the TS-side ADMISSION gate the qualifier
+            //     enforces, and the Rust gate pauses every mutating action regardless.
+            // The disabled-tool / max-turns axes are not asserted by this route, so they stay
+            // absent (omitted on the wire). The server gates application behind its default-off
+            // run-control flag, so this remains DARK + DEPLOY-GO-gated.
+            constraints: { readOnly: !isGatedMutatingRustRouteRun(rustRouteQualificationInput) },
             providerId: input.providerId ?? RUST_ROUTE_DEEPSEEK_PROVIDER_ID,
             model: input.model ?? RUST_ROUTE_DEEPSEEK_FLASH_MODEL,
             wsClient: rustWsClient,

--- a/test/unit/api/runtime/friday-api-runtime-rust-route-compose.test.ts
+++ b/test/unit/api/runtime/friday-api-runtime-rust-route-compose.test.ts
@@ -824,6 +824,164 @@ describe("FridayApiRuntime — execrun S-F-compose (DARK) Rust-route composition
     expect(countRows(db, "friday_agent_runs", RUN_ID)).toBe(0);
   });
 
+  // ─── (B4 organic mutating dispatch) the readOnly the courier FORWARDS on the wire ───
+  //
+  // THE DEFECT this fixes: a gated-mutating run the qualifier ADMITS used to dispatch the
+  // HARDCODED `constraints: { readOnly: true }` — so the real Rust server blocked the write
+  // tool BEFORE execution → no pause → awaiting_clarification → 503. The fix forwards the REAL
+  // constraint the qualifier validated (`readOnly:false` for a gated-mutating run; unchanged
+  // `readOnly:true` for a read-only run), so a genuinely-organic HTTP mutating chat reaches the
+  // Rust gate and PAUSES. We capture the dispatched `constraints` off the stub to assert this
+  // WITHOUT a real server, and prove the read-only path is unchanged + the qualifier unweakened.
+  //
+  // A gated-mutating body that QUALIFIES: agentRunControlViaRust on (set on the runtime),
+  // readOnly:false, a grant ⊆ the closed mutating allow-list, the operator-signed gate marker,
+  // a bound owner principal (the route's authenticated principal), deepseek-flash, the 4-read grant.
+  const GATED_MUTATING_BODY = {
+    ...QUALIFYING_BODY,
+    constraints: { readOnly: false },
+    mutatingToolGrant: ["write_file"],
+    mutationGate: "operator_signed_ed25519",
+  };
+
+  it("(b4-a) gated-mutating qualifying run → compose dispatches constraints.readOnly:FALSE (the real verdict, not hardcoded true)", async () => {
+    db = createTestDb();
+    // The dispatch PAUSES (a mutating tool hit the gate) — the realistic organic outcome.
+    const ws = makeStubPausedWsClient();
+    const readback = makeStubReadback(OWNER_PRINCIPAL);
+    const runtime = makeRuntime(db, {
+      routeAgentRunViaRust: true,
+      // The SAME default-off flag the qualifier's mutating verdict + the courier's pause both gate on.
+      agentRunControlViaRust: true,
+      wsClient: ws.service,
+      readback: readback.service,
+    });
+
+    const result = (await callStartRoute(runtime, { ...GATED_MUTATING_BODY })) as { status: string };
+
+    // The run was ADMITTED and the courier was dispatched (NOT 503'd at the qualifier).
+    expect(ws.calls).toHaveLength(1);
+    // THE FIX: the courier forwards readOnly:FALSE — the real constraint the qualifier validated.
+    // Before the fix this was the hardcoded { readOnly: true }, which would block the write tool in
+    // Rust before it could pause. (No disabled-tools / max-turns asserted on this route → absent.)
+    expect(ws.calls[0].constraints).toEqual({ readOnly: false });
+    // And the organic outcome is the operator-gated PAUSE (projected as the terminal "cancelled"),
+    // never a 503 — which is the whole point of the B4 fix.
+    expect(result.status).toBe("cancelled");
+  });
+
+  it("(b4-b) read-only qualifying run → compose STILL dispatches constraints.readOnly:TRUE (no degrade)", async () => {
+    db = createTestDb();
+    const ws = makeStubWsClient();
+    const readback = makeStubReadback(OWNER_PRINCIPAL);
+    const runtime = makeRuntime(db, {
+      routeAgentRunViaRust: true,
+      // Flag ON to prove the read-only path is byte-identical even when the mutating branch is live.
+      agentRunControlViaRust: true,
+      wsClient: ws.service,
+      readback: readback.service,
+    });
+
+    const result = (await callStartRoute(runtime, { ...QUALIFYING_BODY })) as { response: string };
+
+    expect(ws.calls).toHaveLength(1);
+    // UNCHANGED: a read-only run forwards exactly { readOnly: true } — the read-only path does not
+    // degrade now that the mutating branch can forward { readOnly: false }.
+    expect(ws.calls[0].constraints).toEqual({ readOnly: true });
+    expect(result.response).toBe(OWNER_BODY);
+  });
+
+  it("(b4-c) mutating run MISSING the gate marker → qualifier REJECTS → byte-identical 503; courier NEVER dispatched (no new hole)", async () => {
+    db = createTestDb();
+    const ws = makeStubPausedWsClient();
+    const readback = makeStubReadback(OWNER_PRINCIPAL);
+    const runtime = makeRuntime(db, {
+      routeAgentRunViaRust: true,
+      agentRunControlViaRust: true,
+      wsClient: ws.service,
+      readback: readback.service,
+    });
+
+    // readOnly:false + a valid grant + a bound principal, but NO operator-signed gate marker →
+    // the qualifier's gated-mutating verdict is false → clause-2 disqualifies → 503. A mutating run
+    // without the full gate can NEVER dispatch.
+    const { mutationGate: _omitted, ...noGateBody } = GATED_MUTATING_BODY;
+    await expect(callStartRoute(runtime, { ...noGateBody })).rejects.toMatchObject({
+      code: "TS_RUNTIME_AGENT_RUNS_RETIRED",
+      httpStatus: 503,
+    });
+    // The "no new hole" check: the courier was NEVER dispatched (the run never even reached compose).
+    expect(ws.calls).toHaveLength(0);
+    expect(readback.calls).toHaveLength(0);
+    expect(countRows(db, "friday_agent_runs", RUN_ID)).toBe(0);
+  });
+
+  it("(b4-d) mutating run with the gate but NO grant → qualifier REJECTS → 503; courier NEVER dispatched", async () => {
+    db = createTestDb();
+    const ws = makeStubPausedWsClient();
+    const readback = makeStubReadback(OWNER_PRINCIPAL);
+    const runtime = makeRuntime(db, {
+      routeAgentRunViaRust: true,
+      agentRunControlViaRust: true,
+      wsClient: ws.service,
+      readback: readback.service,
+    });
+
+    // readOnly:false + the gate marker + a bound principal, but the mutatingToolGrant is OMITTED →
+    // the gated-mutating verdict is false → 503. A mutating run with no positive grant fails closed.
+    const { mutatingToolGrant: _omitted, ...noGrantBody } = GATED_MUTATING_BODY;
+    await expect(callStartRoute(runtime, { ...noGrantBody })).rejects.toMatchObject({
+      code: "TS_RUNTIME_AGENT_RUNS_RETIRED",
+      httpStatus: 503,
+    });
+    expect(ws.calls).toHaveLength(0);
+    expect(readback.calls).toHaveLength(0);
+  });
+
+  it("(b4-f) gated-mutating body but a BLANK owner principal → qualifier REJECTS → 503; courier NEVER dispatched", async () => {
+    db = createTestDb();
+    const ws = makeStubPausedWsClient();
+    const readback = makeStubReadback(OWNER_PRINCIPAL);
+    const runtime = makeRuntime(db, {
+      routeAgentRunViaRust: true,
+      agentRunControlViaRust: true,
+      wsClient: ws.service,
+      readback: readback.service,
+    });
+
+    // readOnly:false + the gate marker + a valid grant, but a BLANK/whitespace owner principal →
+    // the `hasBoundOwnerPrincipal` conjunct fails → the gated-mutating verdict is false → 503. An
+    // ownerless mutating run can never own a gated run (the body readback could not be owner-scoped).
+    await expect(
+      callStartRoute(runtime, { ...GATED_MUTATING_BODY }, { principalId: "   " }),
+    ).rejects.toMatchObject({
+      code: "TS_RUNTIME_AGENT_RUNS_RETIRED",
+      httpStatus: 503,
+    });
+    expect(ws.calls).toHaveLength(0);
+    expect(readback.calls).toHaveLength(0);
+  });
+
+  it("(b4-e) gated-mutating body but the run-control FLAG is OFF → qualifier REJECTS → 503; courier NEVER dispatched (byte-identical-when-off)", async () => {
+    db = createTestDb();
+    const ws = makeStubPausedWsClient();
+    const readback = makeStubReadback(OWNER_PRINCIPAL);
+    const runtime = makeRuntime(db, {
+      routeAgentRunViaRust: true,
+      // agentRunControlViaRust OMITTED → default off. The mutating verdict's FIRST conjunct is this
+      // flag, so off ⇒ a readOnly:false run stays disqualified EXACTLY as today (no behavior change).
+      wsClient: ws.service,
+      readback: readback.service,
+    });
+
+    await expect(callStartRoute(runtime, { ...GATED_MUTATING_BODY })).rejects.toMatchObject({
+      code: "TS_RUNTIME_AGENT_RUNS_RETIRED",
+      httpStatus: 503,
+    });
+    expect(ws.calls).toHaveLength(0);
+    expect(readback.calls).toHaveLength(0);
+  });
+
   // ─── (S6 mutating-chat) routeResumeRun — the runtime resume relay's fail-closed branches ───
   //
   // These exercise the RUNTIME function the resume route delegates to (NOT a mocked deps.resumeRun):


### PR DESCRIPTION
## What
Fixes the transport-B (in-product TS-HTTP courier) MUTATING DISPATCH leg so a genuinely-organic `POST /v1/agent/runs` chat that the qualifier admits as a **gated mutating run** dispatches with `readOnly:false` (and thus PAUSEs for operator approval) instead of being forced read-only → 503.

- **The defect:** `routeStartRun`'s compose call HARDCODED `constraints:{readOnly:true}`, so a run the qualifier admitted (`agentRunControlViaRust && readOnly===false && grant⊆allowlist && mutationGate===marker && bound principal`) still dispatched read-only → write denied → `awaiting_clarification` → 503.
- **The fix:** extracted the qualifier's gated-mutating predicate **verbatim** into one exported helper `isGatedMutatingRustRouteRun(input)` (single source of truth for both admission and compose), and changed the compose constraint to `{ readOnly: !isGatedMutatingRustRouteRun(input) }`.
- **Correction on the wire-grant:** the constraints/WS envelope is restriction-only **by design** (`buildConstraintsWire` never emits `read_only:false`); the Rust runtime gate PAUSEs every mutating action by default. So `mutatingToolGrant` is purely the TS-side admission gate — no wire-grant field was needed or added. Forwarding `readOnly:false` is the whole fix.

## No-degrade / no-new-hole (tested)
- **Read-only path byte-identical:** `!false = true` → `{ readOnly: true }` exactly as before (test b4-b asserts this even with the flag ON; the pre-existing compose test still passes).
- **Qualifier UNWEAKENED:** the 5 conjuncts are extracted verbatim (same conjuncts, same order); the 45 predicate unit tests pass unchanged.
- **4 negative tests** prove no new hole: a mutating run missing the gate marker (b4-c) / the grant (b4-d) / the run-control flag (b4-e) / a bound principal (b4-f) each → 503 with the courier NEVER dispatched.
- typecheck 0 errors; `npm run lint` 0 errors (1554 pre-existing warnings unchanged); `vitest test/unit/api/runtime/` 190 passed (incl 6 new) + 45 predicate + 141 mission-spine.

## Honest scope
This is the **transport-B in-product HTTP courier** — it enables a genuinely-ORGANIC mutating dispatch + operator-gated PAUSE via HTTP. It is **NOT** the v1-locked UI→sealed-WS-direct path (transport-A), and **confers no v1 GO**. The b4-a PAUSE assertion is stub-driven (load-bearing assertion = the captured `constraints.readOnly===false`); the Rust gate's pause behavior is proven in the Rust hub, not re-proven here. The operator's organic proof (re-arm control plane + POST a mutating chat + Ed25519 sign + resume) is the needle-moving step this unblocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)