### PR TITLE
feat(substrate): J2 read-seam multi-peer (no-evict) + C2 session-control routing — DARK

### DIFF
--- a/rust-core/crates/friday-hub/src/bin/hub_read_projection_server.rs
+++ b/rust-core/crates/friday-hub/src/bin/hub_read_projection_server.rs
@@ -40,11 +40,23 @@
 //! the slice-6 operator gate (G2, the FREEZE tripwire) — NOT this slice. Built ≠ flipped; this moves
 //! NO UI needle. NOT v1 GO.
 //!
-//! ## Single-owner v1 (DEFERRED cross-owner isolation — see PR body acceptance criteria)
-//! The owner-allowlist ceiling is the SAME single-configured-owner model the write path uses today.
-//! Per-conversation owner-principal matching (so peer A cannot read peer B's mission even with a
-//! valid session) is tied to the write path's own unbuilt FIX-Q2/FIX-Q3b multi-principal bindings
-//! and is DEFERRED as an explicit acceptance criterion — NOT silently skipped.
+//! ## Multi-peer read seam (J2) — single-OWNER v1, multi-DEVICE
+//! (J2) The read seam admits a NON-EMPTY MULTI-peer pubkey allowlist (boots on the DISTINCT
+//! [`friday_hub::key_source::READ_SEAM_PEER_PUBKEY_ALLOWLIST_ID`], enforcing
+//! [`friday_hub::sealed_ws::enforce_peer_allowlist_nonempty`], NOT `enforce_single_peer`). This
+//! REMOVES the single-peer eviction trap for the READ seam: a desktop master-derived peer AND a
+//! distinct mobile device key can BOTH be enrolled and read CONCURRENTLY, with no fresh-key
+//! eviction — the per-handshake S-F gate (`peer_is_allowlisted`) checks the presented key against
+//! EVERY enrolled key. The live WRITE server is BYTE-UNTOUCHED: it still boots on
+//! `PEER_PUBKEY_ALLOWLIST_ID` and still enforces single-peer.
+//!
+//! ## Single-OWNER v1 (DEFERRED per-PRINCIPAL isolation — see PR body acceptance criteria)
+//! Multi-DEVICE is NOT multi-tenant. The owner-allowlist ceiling is the SAME single-configured-owner
+//! model the write path uses today: every enrolled read peer/device authenticates as the SAME
+//! owner. Per-conversation owner-principal matching (so peer A cannot read peer B's mission even with
+//! a valid session) is tied to the write path's own unbuilt FIX-Q2/FIX-Q3b multi-principal bindings
+//! (the tamper-evident pubkey→principal binding) and is DEFERRED as an explicit acceptance criterion
+//! — NOT silently skipped. Multi-peer here = "more than one DEVICE for the one owner".
 
 use std::env;
 use std::io::{Read, Write};
@@ -54,11 +66,11 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use friday_crypto::{seal, DataKey, DeviceKeypair, FileSecureStore};
 use friday_hub::hub_server::{AuthedPrincipal, ForwardedAuth};
-use friday_hub::key_source::{PEER_PUBKEY_ALLOWLIST_ID, X25519_PUBKEY_LEN};
+use friday_hub::key_source::{READ_SEAM_PEER_PUBKEY_ALLOWLIST_ID, X25519_PUBKEY_LEN};
 use friday_hub::providers_doctor_projection::{parse_provider_selection, project_providers_doctor};
 use friday_hub::run_readback_projection::project_run_readback;
 use friday_hub::sealed_ws::{
-    decode_sealed_proof, enforce_single_peer, establish_session, load_peer_allowlist,
+    decode_sealed_proof, enforce_peer_allowlist_nonempty, establish_session, load_peer_allowlist,
 };
 use friday_hub::workbench_projection::project_workbench;
 use friday_protocol::{
@@ -95,11 +107,10 @@ enum ServerError {
     /// The read-only hub DB could not be opened ⇒ the server refuses to start (no projection
     /// surface). The category only — never the db path.
     DbUnavailable,
-    /// The SecureStore peer-pubkey allowlist is MISSING or INVALID ⇒ FAIL CLOSED.
+    /// The SecureStore peer-pubkey allowlist is MISSING, INVALID, or EMPTY ⇒ FAIL CLOSED. (J2: the
+    /// read seam admits a NON-EMPTY MULTI-peer list, so there is no longer a multi-peer refusal —
+    /// only the missing/empty/corrupt fail-closed remains.)
     PeerAllowlist,
-    /// More than one enrolled peer pubkey ⇒ refused (single-peer is a code invariant until the
-    /// multi-principal bindings land). The count is NOT surfaced.
-    MultiPeerUnsupported,
     /// The master key is absent/unreadable ⇒ the server REFUSES TO BOOT (never auto-generated).
     MasterKeyUnavailable,
     /// The persistent FileSecureStore cannot be resolved/opened ⇒ FAIL CLOSED. Never the path.
@@ -113,7 +124,6 @@ fn main() {
             ServerError::Bind => "bind_failed",
             ServerError::DbUnavailable => "db_unavailable",
             ServerError::PeerAllowlist => "peer_allowlist_unavailable",
-            ServerError::MultiPeerUnsupported => "peer_allowlist_multi_peer_unsupported",
             ServerError::MasterKeyUnavailable => "master_key_unavailable",
             ServerError::StoreUnavailable => "secure_store_unavailable",
         };
@@ -157,9 +167,15 @@ fn run() -> Result<(), ServerError> {
     };
     let secure_store =
         FileSecureStore::open(&store_dir, kek).map_err(|_| ServerError::StoreUnavailable)?;
-    let peer_allowlist = load_peer_allowlist(&secure_store, PEER_PUBKEY_ALLOWLIST_ID)
+    // (J2) MULTI-PEER read seam: load from the READ-SEAM id (DISTINCT from the live write server's
+    // `PEER_PUBKEY_ALLOWLIST_ID`, which is byte-untouched) and enforce only that the allowlist is
+    // NON-EMPTY — NOT single-peer. This removes the single-peer eviction trap for the READ seam: a
+    // desktop master-derived peer AND a distinct mobile device key can BOTH be enrolled and BOTH
+    // read, with no fresh-key eviction (the per-handshake S-F gate checks the presented key against
+    // EVERY enrolled key). The write server is unaffected (own id + own single-peer guard).
+    let peer_allowlist = load_peer_allowlist(&secure_store, READ_SEAM_PEER_PUBKEY_ALLOWLIST_ID)
         .map_err(|_| ServerError::PeerAllowlist)?;
-    enforce_single_peer(&peer_allowlist).map_err(|_| ServerError::MultiPeerUnsupported)?;
+    enforce_peer_allowlist_nonempty(&peer_allowlist).map_err(|_| ServerError::PeerAllowlist)?;
     eprintln!(
         "hub_read_projection_server: peer-pubkey allowlist loaded from SecureStore (count={})",
         peer_allowlist.len()
@@ -846,6 +862,140 @@ mod tests {
         drop(ws);
         let processed = server.join().unwrap();
         assert_eq!(processed, 1);
+    }
+
+    /// A SECOND fixed non-secret test client secret scalar, DISTINCT from [`CLIENT_SECRET`] (so it
+    /// derives a different X25519 pubkey). Used by the J2 multi-peer KAT to enroll a second peer.
+    /// TEST FIXTURE, not real key material.
+    const CLIENT_SECRET_B: [u8; 32] = [
+        // pragma: allowlist secret
+        151, 157, 163, 167, 173, 179, 181, 191, 193, 197, 199, 211, 223, 227, 229, 233, 239, 241,
+        251, 3, 5, 7, 9, 11, 13, 15, 17, 19, 21, 23, 25, 27,
+    ];
+
+    /// Drive ONE full sealed read round-trip (workbench projection) for the peer built from
+    /// `client_secret` against the listener: handshake → owner auth → owner-sealed refs-only
+    /// snapshot. The server accepts inline (using a FIXED `server_secret` so each accept derives a
+    /// stable key); the client runs in a spawned thread (`DeviceKeypair` is neither Clone nor Send,
+    /// so the secret bytes — which ARE Copy — cross the thread boundary and the keypair is rebuilt
+    /// inside). Asserts the canonical mission id is in the owner-opened body and exactly ONE
+    /// envelope was served. Reused by the J2 multi-peer KAT so each peer's round-trip is identical.
+    #[allow(clippy::too_many_arguments)]
+    fn one_read_round_trip(
+        listener: &ReadWsListener,
+        addr: SocketAddr,
+        server_secret: [u8; 32],
+        client_secret: [u8; 32],
+        owner_allowlist: &[String],
+        peer_allowlist: &[[u8; X25519_PUBKEY_LEN]],
+        db_path: &str,
+        request_id: &str,
+    ) {
+        let req_id = request_id.to_string();
+        let client = thread::spawn(move || {
+            let client_kp = DeviceKeypair::from_secret_bytes(client_secret);
+            let (mut ws, session_key, session_nonce) = client_handshake(addr, &client_kp);
+            let req = Envelope::new(
+                format!("msg-{req_id}"),
+                1000,
+                Message::WorkbenchProjectionRequest {
+                    request: WorkbenchProjectionRequestWire {
+                        mission_id: None,
+                        forwarded_principal: OWNER.to_string(),
+                        auth_proof: read_auth_proof(&session_key, &session_nonce, OWNER, &req_id),
+                        request_id: req_id.clone(),
+                    },
+                },
+            );
+            ws_send_envelope(&mut ws, &session_key, &req, SESSION_AAD).unwrap();
+            let resp = ws_recv_envelope(&mut ws, &session_key, SESSION_AAD).unwrap();
+            let Message::WorkbenchProjectionSnapshot { snapshot } = resp.message else {
+                panic!("expected a WorkbenchProjectionSnapshot");
+            };
+            assert_eq!(snapshot.request_id, req_id);
+            let sealed_bytes = hex_decode(&snapshot.projection_json);
+            let opened =
+                crypto_open(&session_key, &decode_sealed(&sealed_bytes), SESSION_AAD).unwrap();
+            let json = String::from_utf8(opened).unwrap();
+            assert!(
+                json.contains("mission_read_seam_probe_20260611"),
+                "the owner-opened snapshot carries the canonical mission id"
+            );
+            drop(ws);
+        });
+        let server_kp = DeviceKeypair::from_secret_bytes(server_secret);
+        let db = Db::open_hub_readonly(db_path).unwrap();
+        let probe = null_probe();
+        let processed = listener
+            .accept_one(&server_kp, &db, &probe, owner_allowlist, peer_allowlist)
+            .unwrap();
+        assert_eq!(processed, 1, "the server served exactly one read envelope");
+        client.join().unwrap();
+    }
+
+    /// (J2 KAT) MULTI-PEER read seam, NO eviction. TWO distinct real `DeviceKeypair`s are enrolled
+    /// under the read-seam allowlist; the server runs `accept_one` THREE times. Peer A completes a
+    /// full sealed read round-trip, THEN peer B completes one, THEN peer A AGAIN — proving B did NOT
+    /// evict A (the single-peer trap is gone for the read seam). The server uses a FIXED keypair
+    /// across the three accepts so each peer derives a stable session key.
+    #[test]
+    fn read_server_admits_two_distinct_peers_with_no_eviction() {
+        let db_path = seed_probe_db("j2-multipeer");
+        const SERVER_SECRET: [u8; 32] = [
+            // pragma: allowlist secret
+            2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83,
+            89, 97, 101, 103, 107, 109, 113, 127, 131,
+        ];
+        let kp_a = DeviceKeypair::from_secret_bytes(CLIENT_SECRET);
+        let kp_b = DeviceKeypair::from_secret_bytes(CLIENT_SECRET_B);
+        // The two peers are genuinely DISTINCT (different pubkeys) — a real multi-device allowlist.
+        assert_ne!(kp_a.public_bytes(), kp_b.public_bytes());
+        let peer_allowlist = vec![kp_a.public_bytes(), kp_b.public_bytes()];
+        // The read seam admits this 2-key list (nonempty), where the write seam would refuse it.
+        assert!(
+            friday_hub::sealed_ws::enforce_peer_allowlist_nonempty(&peer_allowlist).is_ok(),
+            "read seam admits a 2-peer allowlist"
+        );
+        assert!(
+            friday_hub::sealed_ws::enforce_single_peer(&peer_allowlist).is_err(),
+            "the write seam guard still refuses the SAME 2-peer list (untouched)"
+        );
+        let owner_allowlist = vec![OWNER.to_string()];
+
+        let listener = ReadWsListener::bind_loopback(0).unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        // Peer A → Peer B → Peer A again. All three succeed: B did NOT evict A.
+        one_read_round_trip(
+            &listener,
+            addr,
+            SERVER_SECRET,
+            CLIENT_SECRET,
+            &owner_allowlist,
+            &peer_allowlist,
+            &db_path,
+            "j2-A-1",
+        );
+        one_read_round_trip(
+            &listener,
+            addr,
+            SERVER_SECRET,
+            CLIENT_SECRET_B,
+            &owner_allowlist,
+            &peer_allowlist,
+            &db_path,
+            "j2-B-1",
+        );
+        one_read_round_trip(
+            &listener,
+            addr,
+            SERVER_SECRET,
+            CLIENT_SECRET,
+            &owner_allowlist,
+            &peer_allowlist,
+            &db_path,
+            "j2-A-2-after-B",
+        );
     }
 
     /// KAT — owner-scoping: a MISMATCHED forwarded principal (well-formed, but NOT in the owner

--- a/rust-core/crates/friday-hub/src/bin/hub_read_seam_enroll.rs
+++ b/rust-core/crates/friday-hub/src/bin/hub_read_seam_enroll.rs
@@ -2,11 +2,12 @@
 //! infra, DARK/staged).
 //!
 //! Enrolls a UI peer's X25519 PUBLIC key into the **read-projection** server's
-//! [`friday_hub::key_source::PEER_PUBKEY_ALLOWLIST_ID`] SecureStore allowlist so the
+//! [`friday_hub::key_source::READ_SEAM_PEER_PUBKEY_ALLOWLIST_ID`] SecureStore allowlist so the
 //! [`hub_read_projection_server`] (slice S-R1) will admit that UI client's sealed-WS handshake.
 //! It is the read-seam analog of [`hub_agent_run_enroll`] (the write-server enroll CLI) and shares
-//! the SAME key source, the SAME store layout, and the SAME on-disk allowlist format — so the two
-//! servers cannot drift in how the allowlist is provisioned.
+//! the SAME key source, the SAME store layout, and the SAME on-disk allowlist format — but a
+//! DISTINCT SecureStore id (the read-seam id, NOT the write server's `PEER_PUBKEY_ALLOWLIST_ID`),
+//! so the read multi-peer set never contaminates the write single-peer entry.
 //!
 //! ## DARK / staged — NOT a live flip
 //! Running this CLI only writes the peer allowlist entry into a SecureStore dir; it does NOT install
@@ -14,36 +15,34 @@
 //! (install the read-projection LaunchAgent + flip the prod flag) is the slice-6 OPERATOR gate
 //! (G2, the FREEZE tripwire) — NOT this CLI. Built ≠ flipped.
 //!
-//! ## The two enrollment sources (one peer at a time — single-peer v1)
-//! The read-projection server enforces [`friday_hub::sealed_ws::enforce_single_peer`] at boot, so
-//! the allowlist v1 holds EXACTLY ONE peer pubkey. This CLI therefore enrolls ONE peer, REPLACING
-//! whatever was there (idempotent — never appends a second key). Choose the source:
+//! ## The two enrollment sources (REPLACE one peer, or `--add` to build a multi-peer set)
+//! The read-projection server enforces [`friday_hub::sealed_ws::enforce_peer_allowlist_nonempty`]
+//! at boot, so the read allowlist may hold ONE OR MORE peer pubkeys. Without `--add` this CLI
+//! REPLACES the allowlist with the single resolved peer (idempotent); with `--add` it APPENDS to
+//! build a multi-peer set. Choose the source:
 //!
 //! * **`--from-master` (DEFAULT)** — derive the peer pubkey from THIS host's master key, exactly as
 //!   [`hub_agent_run_enroll`] does (the same [`friday_hub::key_source::derive_client_x25519_pubkey`]
 //!   parity). This is the **desktop UI** path: the SwiftUI console runs as the same OS user with
 //!   `~/.friday/master.key` access, derives the SAME X25519 key, and is therefore already the
-//!   write-peer — so a desktop UI pointed at its own master needs NO separate device key. (If the
-//!   read store IS the shared `~/.friday/agent-run-securestore`, the value written equals the
-//!   already-enrolled write peer; idempotent.)
+//!   write-peer — so a desktop UI pointed at its own master needs NO separate device key.
 //! * **`--pubkey <64-hex>`** — enroll an EXTERNALLY-generated X25519 public key (32 bytes / 64 hex).
 //!   This is the path a **distinct device** (e.g. a paired mobile device that does NOT share the
 //!   host master key) uses: the device generates its own keypair off-box and the operator enrolls
-//!   its PUBLIC key here. Because the server is single-peer, this REPLACES the prior peer — the
-//!   enrolled device becomes the SOLE allowlisted reader.
+//!   its PUBLIC key here. With `--add` it joins the existing reader(s); without `--add` it REPLACES.
 //!
-//! ## Multi-peer (DESKTOP + a distinct mobile device CONCURRENTLY) — DEFERRED, not skipped
+//! ## Multi-peer (DESKTOP + a distinct mobile device CONCURRENTLY) — BUILT (J2)
 //! Admitting MORE THAN ONE peer at once (so a desktop master-derived peer AND a distinct mobile
-//! device key are BOTH allowlisted) is gated by the read server's [`enforce_single_peer`] boot
-//! invariant, which exists precisely because a multi-key allowlist needs the (currently UNBUILT)
-//! tamper-evident pubkey→principal bindings that bind the AUTHENTICATED caller to the MATCHED
-//! pubkey. The on-disk allowlist FORMAT already supports a concatenation of 32-byte keys (the
-//! server parses it with `chunks_exact(32)`), so this CLI CAN write a multi-key value via
-//! `--add` — but the server would refuse to boot on it today. So `--add` is gated behind an
-//! explicit `--allow-multi-peer-unsupported-by-server` acknowledgment flag and prints a loud
-//! warning. This is the EXPLICIT acceptance-criterion deferral the slice-6 runbook (B-2) names:
-//! single-peer works now; concurrent multi-peer is a separate build-first lane (relax
-//! `enforce_single_peer` for the read server + the principal bindings).
+//! device key are BOTH allowlisted) is now SUPPORTED for the read seam: the read-projection server
+//! boots on the DISTINCT read-seam id and enforces `enforce_peer_allowlist_nonempty` (NOT
+//! `enforce_single_peer`), so a non-empty multi-peer allowlist is admitted with NO eviction (the
+//! per-handshake S-F gate checks the presented key against EVERY enrolled key). The on-disk
+//! allowlist FORMAT is a concatenation of 32-byte keys (parsed with `chunks_exact(32)`); `--add`
+//! writes that multi-key value (idempotent-append). HONEST CEILING: per-PRINCIPAL isolation — the
+//! tamper-evident pubkey→principal binding that ties the AUTHENTICATED caller to the MATCHED
+//! pubkey — is still UNBUILT/DEFERRED, so v1 is single-OWNER: multi-peer = "more than one DEVICE
+//! for the one configured owner", NOT multi-tenant. The WRITE server is BYTE-UNTOUCHED (own id +
+//! own single-peer guard).
 //!
 //! ## Usage
 //! ```text
@@ -60,8 +59,9 @@
 //!   device generates its OWN keypair OFF-BOX and hands over only its PUBLIC key — the private key
 //!   never touches this host (and [`friday_crypto::DeviceKeypair`] deliberately never exposes a
 //!   secret, so this CLI cannot and does not mint device secrets — that is the device's job).
-//! * `--add` — APPEND the pubkey to the existing allowlist (multi-peer) instead of REPLACING.
-//!   Requires `--allow-multi-peer-unsupported-by-server` (the read server will refuse a >1 list).
+//! * `--add` — APPEND the pubkey to the existing allowlist (build a multi-peer set) instead of
+//!   REPLACING. SUPPORTED (J2): the read server admits a non-empty multi-peer allowlist. The legacy
+//!   `--allow-multi-peer-unsupported-by-server` ack is a deprecated NO-OP (accepted, ignored).
 //! * `--print-pubkey` — print the resolved pubkey hex and EXIT WITHOUT enrolling (verification).
 //! * `--dry-run` — report what WOULD be enrolled and exit 0 WITHOUT touching the filesystem.
 //!
@@ -76,7 +76,7 @@ use std::process::ExitCode;
 use friday_crypto::FileSecureStore;
 use friday_hub::key_source::{
     default_store_dir, derive_client_x25519_pubkey, derive_file_store_kek, read_master_key,
-    PEER_PUBKEY_ALLOWLIST_ID, X25519_PUBKEY_LEN,
+    READ_SEAM_PEER_PUBKEY_ALLOWLIST_ID, X25519_PUBKEY_LEN,
 };
 
 /// A coarse, non-leaking error category. Its `Display` never carries a key, a secret-bearing path,
@@ -133,7 +133,6 @@ struct Opts {
     store_dir: Option<PathBuf>,
     source: Source,
     add: bool,
-    allow_multi_peer: bool,
     print_pubkey: bool,
     dry_run: bool,
 }
@@ -168,7 +167,6 @@ fn parse_args(args: impl Iterator<Item = String>) -> Result<Opts, EnrollError> {
     let mut from_master = false;
     let mut pubkey: Option<[u8; X25519_PUBKEY_LEN]> = None;
     let mut add = false;
-    let mut allow_multi_peer = false;
     let mut print_pubkey = false;
     let mut dry_run = false;
     let mut it = args;
@@ -188,7 +186,9 @@ fn parse_args(args: impl Iterator<Item = String>) -> Result<Opts, EnrollError> {
                 pubkey = Some(decode_pubkey_hex(&v).ok_or(EnrollError::BadPubkey)?);
             }
             "--add" => add = true,
-            "--allow-multi-peer-unsupported-by-server" => allow_multi_peer = true,
+            // (J2) Deprecated NO-OP: the read seam now SUPPORTS a multi-peer allowlist, so this ack
+            // is no longer required. Accepted (not an "unknown argument" error) for back-compat.
+            "--allow-multi-peer-unsupported-by-server" => {}
             "--print-pubkey" => print_pubkey = true,
             "--dry-run" => dry_run = true,
             "-h" | "--help" => {
@@ -216,22 +216,17 @@ fn parse_args(args: impl Iterator<Item = String>) -> Result<Opts, EnrollError> {
         Source::FromMaster
     };
 
-    // --add (multi-peer) is gated: the read server refuses a >1 allowlist (enforce_single_peer).
-    if add && !allow_multi_peer {
-        return Err(EnrollError::BadArgs(
-            "--add builds a MULTI-PEER allowlist, which the read-projection server REFUSES at boot \
-             (enforce_single_peer). Pass --allow-multi-peer-unsupported-by-server to acknowledge \
-             this is for a future server that relaxes that invariant, or drop --add to REPLACE \
-             (single-peer)."
-                .into(),
-        ));
-    }
+    // (J2) --add (multi-peer) is NO LONGER gated for the read seam: the read-projection server now
+    // boots on the READ-SEAM id and enforces `enforce_peer_allowlist_nonempty` (NOT
+    // `enforce_single_peer`), so a MULTI-peer allowlist is SUPPORTED — a desktop master-derived
+    // peer AND a distinct mobile device can both be enrolled and read concurrently, with no
+    // eviction. The legacy `--allow-multi-peer-unsupported-by-server` ack is accepted as a
+    // deprecated NO-OP (so an existing invocation does not break), but is no longer required.
 
     Ok(Opts {
         store_dir,
         source,
         add,
-        allow_multi_peer,
         print_pubkey,
         dry_run,
     })
@@ -281,7 +276,8 @@ fn run() -> Result<(), EnrollError> {
         let mode = if opts.add { "APPEND" } else { "REPLACE" };
         println!(
             "DRY-RUN: would {mode} peer pubkey {pubkey_hex} (32 bytes) under id \
-             '{PEER_PUBKEY_ALLOWLIST_ID}' in store dir {} — NOT written (store not opened)",
+             '{READ_SEAM_PEER_PUBKEY_ALLOWLIST_ID}' in store dir {} — NOT written \
+             (store not opened)",
             store_dir.display()
         );
         return Ok(());
@@ -300,7 +296,7 @@ fn run() -> Result<(), EnrollError> {
     // only when the new key is not already present (idempotent), and with a LOUD warning.
     let value: Vec<u8> = if opts.add {
         let mut existing = store
-            .try_get(PEER_PUBKEY_ALLOWLIST_ID)
+            .try_get(READ_SEAM_PEER_PUBKEY_ALLOWLIST_ID)
             .map_err(|_| EnrollError::StoreRead)?
             .unwrap_or_default();
         // Idempotent: if the new pubkey is already an aligned 32-byte chunk, do not duplicate it.
@@ -312,10 +308,12 @@ fn run() -> Result<(), EnrollError> {
             existing.extend_from_slice(&pubkey);
         }
         eprintln!(
-            "hub_read_seam_enroll: WARNING — APPEND mode wrote a MULTI-PEER allowlist \
-             ({} peer(s)). The read-projection server enforces single-peer at boot and will \
-             REFUSE to start on this allowlist until enforce_single_peer is relaxed + the \
-             pubkey->principal bindings are built (DEFERRED, see runbook B-2).",
+            "hub_read_seam_enroll: APPEND mode wrote a MULTI-PEER read-seam allowlist \
+             ({} peer(s)). The read-projection server enforces enforce_peer_allowlist_nonempty at \
+             boot, so it ADMITS this multi-peer list (no eviction). HONEST CEILING: per-PRINCIPAL \
+             isolation (binding the authed caller to the matched pubkey) is still the deferred \
+             pubkey->principal binding — v1 is single-OWNER, so multi-peer = multi-DEVICE for the \
+             one owner.",
             existing.len() / X25519_PUBKEY_LEN
         );
         existing
@@ -325,7 +323,7 @@ fn run() -> Result<(), EnrollError> {
 
     // (7) CHECKED enrollment write — the CLI must KNOW it landed.
     store
-        .try_put(PEER_PUBKEY_ALLOWLIST_ID, &value)
+        .try_put(READ_SEAM_PEER_PUBKEY_ALLOWLIST_ID, &value)
         .map_err(|_| EnrollError::EnrollWrite)?;
 
     let mode = if opts.add {
@@ -334,14 +332,14 @@ fn run() -> Result<(), EnrollError> {
         "enrolled (REPLACE)"
     };
     let peers = value.len() / X25519_PUBKEY_LEN;
-    let multi_note = if opts.allow_multi_peer && opts.add {
-        " [SERVER-UNSUPPORTED multi-peer: read server will refuse >1 at boot]"
+    let multi_note = if opts.add && peers > 1 {
+        " [multi-peer SUPPORTED: read server admits a non-empty multi-peer allowlist — no eviction]"
     } else {
         ""
     };
     println!(
-        "OK: {mode} read-seam peer pubkey {pubkey_hex} under id '{PEER_PUBKEY_ALLOWLIST_ID}' \
-         in store dir {} ({peers} peer(s) total){multi_note}",
+        "OK: {mode} read-seam peer pubkey {pubkey_hex} under id \
+         '{READ_SEAM_PEER_PUBKEY_ALLOWLIST_ID}' in store dir {} ({peers} peer(s) total){multi_note}",
         store_dir.display()
     );
     Ok(())
@@ -421,14 +419,13 @@ mod tests {
     }
 
     #[test]
-    fn add_without_ack_is_rejected() {
+    fn add_no_longer_requires_an_ack() {
+        // (J2) The read seam now SUPPORTS multi-peer, so `--add` ALONE parses (no ack gate).
         let hex = "22".repeat(32);
-        assert!(matches!(
-            parse_args(["--pubkey", &hex, "--add"].into_iter().map(String::from)),
-            Err(EnrollError::BadArgs(_))
-        ));
-        // with the ack flag it parses
-        let o = parse_args(
+        let o = parse_args(["--pubkey", &hex, "--add"].into_iter().map(String::from)).unwrap();
+        assert!(o.add, "--add parses with no ack flag now");
+        // The legacy ack flag is still accepted (deprecated NO-OP), not an "unknown argument".
+        let o2 = parse_args(
             [
                 "--pubkey",
                 &hex,
@@ -439,7 +436,7 @@ mod tests {
             .map(String::from),
         )
         .unwrap();
-        assert!(o.add && o.allow_multi_peer);
+        assert!(o2.add, "the deprecated ack flag is accepted as a no-op");
     }
 
     #[test]
@@ -450,7 +447,7 @@ mod tests {
         ));
     }
 
-    // ── enroll round-trip (REPLACE, single-peer): the external pubkey is the sole 32-byte chunk ─
+    // ── enroll round-trip (REPLACE): the external pubkey is the sole 32-byte chunk ───────────────
     #[test]
     fn external_pubkey_replace_round_trips_single_peer() {
         let master = [0x42u8; 32];
@@ -461,24 +458,30 @@ mod tests {
         // Mirror run()'s REPLACE path: open store under master KEK, try_put exactly the 32 bytes.
         let kek = derive_file_store_kek(&master);
         let mut store = FileSecureStore::open(&dir, kek).unwrap();
-        store.try_put(PEER_PUBKEY_ALLOWLIST_ID, &external).unwrap();
+        store
+            .try_put(READ_SEAM_PEER_PUBKEY_ALLOWLIST_ID, &external)
+            .unwrap();
 
         let store2 = FileSecureStore::open(&dir, derive_file_store_kek(&master)).unwrap();
-        let stored = store2.try_get(PEER_PUBKEY_ALLOWLIST_ID).unwrap().unwrap();
+        let stored = store2
+            .try_get(READ_SEAM_PEER_PUBKEY_ALLOWLIST_ID)
+            .unwrap()
+            .unwrap();
         assert_eq!(stored.len(), X25519_PUBKEY_LEN, "single-peer = 32 bytes");
         assert_eq!(&stored[..], &external[..]);
-        // The read server's load_peer_allowlist + enforce_single_peer would accept this (len==1).
+        // The read server's load_peer_allowlist + enforce_peer_allowlist_nonempty accepts this.
         let allowlist =
-            friday_hub::sealed_ws::load_peer_allowlist(&store2, PEER_PUBKEY_ALLOWLIST_ID).unwrap();
-        assert!(friday_hub::sealed_ws::enforce_single_peer(&allowlist).is_ok());
+            friday_hub::sealed_ws::load_peer_allowlist(&store2, READ_SEAM_PEER_PUBKEY_ALLOWLIST_ID)
+                .unwrap();
+        assert!(friday_hub::sealed_ws::enforce_peer_allowlist_nonempty(&allowlist).is_ok());
         assert!(friday_hub::sealed_ws::peer_is_allowlisted(
             &allowlist, &external
         ));
     }
 
-    // ── --add APPEND idempotency + multi-peer is REFUSED by the server invariant ──────────────
+    // ── (J2 KAT) --add A then B → stored len == 2*32, idempotent, and the read server ADMITS it ──
     #[test]
-    fn add_appends_then_idempotent_and_server_refuses_multi() {
+    fn add_appends_two_peers_idempotent_and_read_server_admits_multi() {
         let master = [0x07u8; 32];
         let td = TempDir::new("add-multi");
         let dir = td.child("store");
@@ -488,11 +491,14 @@ mod tests {
         let kek = derive_file_store_kek(&master);
         let mut store = FileSecureStore::open(&dir, kek).unwrap();
         // enroll A (replace), then append B, then append B again (idempotent).
-        store.try_put(PEER_PUBKEY_ALLOWLIST_ID, &pk_a).unwrap();
+        store
+            .try_put(READ_SEAM_PEER_PUBKEY_ALLOWLIST_ID, &pk_a)
+            .unwrap();
 
+        // Mirror run()'s --add APPEND path exactly (idempotent on an already-present aligned chunk).
         let append = |store: &mut FileSecureStore, pk: &[u8; 32]| {
             let mut existing = store
-                .try_get(PEER_PUBKEY_ALLOWLIST_ID)
+                .try_get(READ_SEAM_PEER_PUBKEY_ALLOWLIST_ID)
                 .unwrap()
                 .unwrap_or_default();
             let already = existing.len() % X25519_PUBKEY_LEN == 0
@@ -500,23 +506,36 @@ mod tests {
             if !already {
                 existing.extend_from_slice(pk);
             }
-            store.try_put(PEER_PUBKEY_ALLOWLIST_ID, &existing).unwrap();
+            store
+                .try_put(READ_SEAM_PEER_PUBKEY_ALLOWLIST_ID, &existing)
+                .unwrap();
         };
         append(&mut store, &pk_b);
         append(&mut store, &pk_b); // idempotent: still 2 peers, not 3
 
         let store2 = FileSecureStore::open(&dir, derive_file_store_kek(&master)).unwrap();
-        let stored = store2.try_get(PEER_PUBKEY_ALLOWLIST_ID).unwrap().unwrap();
+        let stored = store2
+            .try_get(READ_SEAM_PEER_PUBKEY_ALLOWLIST_ID)
+            .unwrap()
+            .unwrap();
         assert_eq!(stored.len(), 2 * X25519_PUBKEY_LEN, "two peers, idempotent");
 
-        // The server parses 2 keys but enforce_single_peer REFUSES it (the deferred lane).
+        // (J2) The read server parses 2 keys and ADMITS them (enforce_peer_allowlist_nonempty Ok) —
+        // the single-peer eviction trap is GONE. Both peers are allowlisted (no eviction).
         let allowlist =
-            friday_hub::sealed_ws::load_peer_allowlist(&store2, PEER_PUBKEY_ALLOWLIST_ID).unwrap();
+            friday_hub::sealed_ws::load_peer_allowlist(&store2, READ_SEAM_PEER_PUBKEY_ALLOWLIST_ID)
+                .unwrap();
         assert_eq!(allowlist.len(), 2);
         assert!(
-            friday_hub::sealed_ws::enforce_single_peer(&allowlist).is_err(),
-            "multi-peer is REFUSED by the read server boot invariant (deferred lane)"
+            friday_hub::sealed_ws::enforce_peer_allowlist_nonempty(&allowlist).is_ok(),
+            "the read server ADMITS a 2-peer allowlist (J2 multi-peer, no eviction)"
         );
+        assert!(friday_hub::sealed_ws::peer_is_allowlisted(
+            &allowlist, &pk_a
+        ));
+        assert!(friday_hub::sealed_ws::peer_is_allowlisted(
+            &allowlist, &pk_b
+        ));
     }
 
     // ── --from-master derives the SAME pubkey the write enroll CLI + the handshake use ─────────

--- a/rust-core/crates/friday-hub/src/key_source.rs
+++ b/rust-core/crates/friday-hub/src/key_source.rs
@@ -82,6 +82,19 @@ const WS_X25519_SECRET_PURPOSE: &[u8] = b"friday.rust.agent_run.ws.x25519_secret
 /// 32-byte X25519 public keys (the server parses it with `chunks_exact(32)`).
 pub const PEER_PUBKEY_ALLOWLIST_ID: &str = "friday:execrun:ws:s-f:peer-pubkey-allowlist:v1";
 
+/// (J2) The SecureStore id under which the **READ-SEAM** peer X25519 pubkey allowlist lives —
+/// DISTINCT from [`PEER_PUBKEY_ALLOWLIST_ID`] (the live WRITE server's id, byte-untouched). The
+/// read-projection server (`hub_read_projection_server`) boots on THIS id and admits a NON-EMPTY
+/// multi-peer allowlist (it enforces `enforce_peer_allowlist_nonempty`, NOT `enforce_single_peer`),
+/// so a desktop master-derived peer AND a distinct mobile device key can BOTH be enrolled
+/// concurrently for the READ seam. The write server is unaffected: it still boots on
+/// `PEER_PUBKEY_ALLOWLIST_ID` and still enforces single-peer. The stored value is the SAME on-disk
+/// format — a concatenation of one-or-more raw 32-byte X25519 public keys (parsed with
+/// `chunks_exact(32)`). The two ids live in the SAME store dir (`agent-run-securestore`); a distinct
+/// id keeps the read multi-peer set from contaminating the write single-peer entry.
+pub const READ_SEAM_PEER_PUBKEY_ALLOWLIST_ID: &str =
+    "friday:read-seam:ws:s-r1:peer-pubkey-allowlist:v1";
+
 /// The default FileSecureStore directory RELATIVE to `$HOME` (`~/.friday/agent-run-securestore`).
 /// The enroll bin's `--store-dir` defaults to this; the SERVER slice will reuse the SAME default
 /// (via [`default_store_dir`]) so the CLI and the server agree on where the allowlist lives.

--- a/rust-core/crates/friday-hub/src/runtime.rs
+++ b/rust-core/crates/friday-hub/src/runtime.rs
@@ -591,6 +591,139 @@ impl<T: Transport> HubRuntime<T> {
             .with_counts(outcome.turns, outcome.executed_tools)
     }
 
+    /// (C2) Pin a SPECIFIC provider for a SESSIONED follow-up/steer turn (no-fallback) — the
+    /// SESSIONED parity of [`Self::run_task_pinned`]. A session steer turn (e.g. a follow-up
+    /// "make it shorter" or an approval-resume continuation on an already-bound session) routes
+    /// to + BILLS the pinned provider, instead of the deepseek-hardcoded
+    /// [`Self::run_session_task_with_overrides`].
+    ///
+    /// ## Routing — the SAME resolve() chokepoint as the sessionless pinned entry
+    /// It builds a pinned [`RouteRequest`] (`preferred_provider: Some(provider_id)`), selects the
+    /// route via [`crate::routing::select_route`], and resolves the live client through the SAME
+    /// [`ProviderClientResolver::resolve`] chokepoint the routed loop uses. A non-dispatchable pin
+    /// (e.g. `claude` while DARK) FAILS CLOSED at `resolve()` with
+    /// [`RoutedLoopError::NoClientForProvider`] — NEVER a silent reroute, and (critically) BEFORE
+    /// any `agent_run` row is created or any token is billed, so a dark pin bills NOTHING. A pin to
+    /// an UNREGISTERED/unavailable provider surfaces [`RoutedLoopError::Route`] from `select_route`,
+    /// also before any write.
+    ///
+    /// ## Everything else is byte-identical to [`Self::run_session_task_with_overrides`]
+    /// Once the client is resolved, this drives the EXISTING [`run_session_loop`] with the RESOLVED
+    /// `&dyn AgentLlmClient` in place of `&self.deepseek` — owner-binding (the authenticated
+    /// `caller`, NEVER the client-asserted `session_id`), the memory-recall preamble, the session
+    /// history fold, the gate-mandatory loop, and the owner-gated body projection are all
+    /// UNCHANGED. The sessionless-overrides body is left byte-untouched (additive).
+    ///
+    /// Returns the [`RoutedSelection`] (so the caller can assert WHO answered — `provider_id`)
+    /// alongside the owner-gated [`AuthedAnswer`]. A storage failure inside the loop is a SAFE
+    /// FAILURE: `Ok((selection, AuthedAnswer::NoAnswer))` — never a panic, never a partial body.
+    ///
+    /// DARK: like the rest of C2, the live Claude leg needs `FRIDAY_CLAUDE_ROUTE_ENABLED` + a live
+    /// Anthropic key (the gated `live()` path); the deterministic in-crate proof wires the route +
+    /// a stub metered client with NO key. NOT v1 GO.
+    #[allow(clippy::too_many_arguments)]
+    pub fn run_session_task_pinned(
+        &self,
+        caller: &AuthedPrincipal,
+        run_id: &str,
+        session_id: &str,
+        task: &str,
+        provider_id: &str,
+        now_ms: i64,
+    ) -> Result<(RoutedSelection, AuthedAnswer), RoutedLoopError> {
+        // (1) ROUTE + RESOLVE FIRST — the same chokepoint as the routed loop, BEFORE any write.
+        // A dark/unavailable pin fails closed here (NoClientForProvider / Route), so a dark Claude
+        // pin creates NO run row and bills NOTHING.
+        let request = RouteRequest {
+            preferred_provider: Some(provider_id.to_string()),
+            ..RouteRequest::any()
+        };
+        let route = crate::routing::select_route(&self.routes, &request)?;
+        let selection = RoutedSelection {
+            provider_id: route.provider_id.clone(),
+            model: route.model.clone(),
+            model_size: route.model_size,
+            backend_kind: route.backend_kind,
+        };
+        let client = self
+            .resolve(route)
+            .ok_or_else(|| RoutedLoopError::NoClientForProvider(route.provider_id.clone()))?;
+
+        // (2) From here this is byte-identical to `run_session_task_with_overrides` (the pre-C2
+        // sessioned body) EXCEPT the loop runs on the RESOLVED `client` instead of `&self.deepseek`.
+        // No per-run policy/max-turns override (the boot config applies, like `run_task_pinned`).
+        let policy = &self.policy;
+        let max_turns = self.max_turns;
+
+        // Create the run row FIRST (run_session_loop only ensure_sessions). A create failure is a
+        // SAFE FAILURE (body-free NoAnswer). The route is already resolved, so this only runs for a
+        // dispatchable pin — a dark pin already returned above without creating a row.
+        if agent_run::create_run(self.db.conn(), run_id, task, now_ms).is_err() {
+            return Ok((
+                selection,
+                AuthedAnswer::NoAnswer {
+                    run_id: run_id.to_string(),
+                },
+            ));
+        }
+
+        // Owner-scoping: bind the session owner to the AUTHENTICATED caller (INV-5/INV-7), NEVER
+        // the client-asserted session_id.
+        let owner = SessionOwner {
+            user_id: Some(caller.principal().to_string()),
+            ..SessionOwner::default()
+        };
+
+        // The owner's confirmed-memory recall preamble (same source as the unpinned entry).
+        let recall_preamble = match self.recall_preamble(run_id, now_ms) {
+            Ok(p) => p,
+            Err(_) => {
+                return Ok((
+                    selection,
+                    AuthedAnswer::NoAnswer {
+                        run_id: run_id.to_string(),
+                    },
+                ));
+            }
+        };
+
+        // Drive the EXISTING session loop AS the bound owner on the RESOLVED client (the ONLY
+        // change from the deepseek-hardcoded entry). The billing — a token_ledger row attributed to
+        // the client's own provider_kind/host — happens INSIDE the loop from the client's metered
+        // step, so a Claude client bills an anthropic row with NO extra wiring.
+        let approve = |req: &MutatingActionRequest| self.approval.approve(req);
+        let outcome = match run_session_loop(
+            client,
+            &self.executor,
+            self.db.conn(),
+            run_id,
+            session_id,
+            Some(&owner),
+            task,
+            &recall_preamble,
+            self.operator_vk.as_ref(),
+            &approve,
+            policy,
+            max_turns,
+            now_ms,
+        ) {
+            Ok(outcome) => outcome,
+            Err(_) => {
+                return Ok((
+                    selection,
+                    AuthedAnswer::NoAnswer {
+                        run_id: run_id.to_string(),
+                    },
+                ));
+            }
+        };
+
+        // Release the body ONLY to the authenticated owner, then attach the loop's counts.
+        let answer = project_answer_for_authed(self.db.conn(), run_id, caller)
+            .with_counts(outcome.turns, outcome.executed_tools);
+        Ok((selection, answer))
+    }
+
     /// S1.3 — the Mission-BOUND agent-loop entry (the `executeRun` Mission-context parity,
     /// deferred from S1.2). Mirrors [`crate::mission_runtime::ask_friday_for_mission`]'s
     /// preflight for the loop:
@@ -1406,6 +1539,140 @@ mod tests {
                 .is_empty(),
             "a route error bills nothing"
         );
+    }
+
+    // ---- C2 session-control routing: a SESSIONED follow-up/steer turn routes + bills ----------
+
+    /// Build an authenticated caller bound to `principal` over a freshly paired sealed session —
+    /// the SAME mechanism `hub_server`'s own tests use (ECDH-pair two DeviceKeypairs, seal the
+    /// agreed challenge, `AuthedPrincipal::authenticate`). The runtime treats this `caller` exactly
+    /// as the WS dispatch arm's authenticated principal.
+    fn authed_caller(principal: &str) -> AuthedPrincipal {
+        use friday_crypto::{seal, DeviceKeypair};
+        const AAD: &[u8] = b"c2-session-pinned-test-aad";
+        const CHALLENGE: &[u8] = b"c2-session-pinned-test-challenge";
+        let hub = DeviceKeypair::generate();
+        let phone = DeviceKeypair::generate();
+        let hub_session = hub.agree(&phone.public_bytes());
+        let caller_session = phone.agree(&hub.public_bytes());
+        let sealed = seal(&caller_session, CHALLENGE, AAD).unwrap();
+        AuthedPrincipal::authenticate(&hub_session, &sealed, AAD, CHALLENGE, principal).unwrap()
+    }
+
+    #[test]
+    fn session_followup_turn_routes_to_claude_and_bills_anthropic() {
+        // POSITIVE: a SESSIONED follow-up/steer turn pinned to "claude" routes through the REAL
+        // `run_session_task_pinned` entry to the wired Claude stub, finishes, and records EXACTLY
+        // ONE token_ledger row attributed to Anthropic (host api.anthropic.com, fallback=false) —
+        // NOT mis-attributed as deepseek. NO key, NO network. The sessioned parity of
+        // `run_task_pinned_claude_routes_through_runtime_and_writes_anthropic_row`.
+        let (rt, _ws) = runtime_with_claude_wired(
+            "c2-session-pinned-claude",
+            vec![AgentStep::Finish {
+                message: "PONG (follow-up)".to_string(),
+            }],
+            Box::new(DenyAllApprovals),
+        );
+        let caller = authed_caller("principal:session-owner");
+        let (selection, _answer) = rt
+            .run_session_task_pinned(
+                &caller,
+                "run-c2-session",
+                "sess-c2-1",
+                "make it shorter", // a session steer turn
+                "claude",
+                3_000,
+            )
+            .expect("a dispatchable claude pin runs through the sessioned entry");
+        assert_eq!(
+            selection.provider_id, "claude",
+            "the session steer turn resolved to claude"
+        );
+        // NOTE on the answer: `runtime_with_claude_wired` configures `principal_id: None`, so
+        // `run_session_loop`'s owner-wiring records NO owner ⇒ the body projection releases nothing
+        // (single-owner-v1 fail-closed: a run with no bound owner is unreadable). That is the
+        // CORRECT documented behavior and is ORTHOGONAL to the C2 routing+billing claim, which is
+        // what this KAT asserts: the run reached the wired CLAUDE client and billed an anthropic
+        // row. (Body delivery to a matching owner is covered by the sessionless owner-gating tests.)
+
+        // EXACTLY ONE anthropic row for the single claude turn — billed to anthropic, not deepseek.
+        let rows = rt.db().list_run_token_usage("run-c2-session").unwrap();
+        assert_eq!(
+            rows.len(),
+            1,
+            "one anthropic row for the single claude turn"
+        );
+        let row = &rows[0];
+        assert_eq!(
+            row.provider_kind, "anthropic",
+            "session turn billed to anthropic (NOT mis-attributed as deepseek)"
+        );
+        assert_eq!(row.base_url_host, "api.anthropic.com");
+        assert_eq!(row.model, friday_anthropic::DEFAULT_MODEL);
+        assert!(!row.fallback, "the claude route is never a fallback");
+        // Whole-ledger agrees: only this one anthropic row exists (no hidden deepseek call).
+        let all = rt.db().list_token_usage().unwrap();
+        assert_eq!(all.len(), 1);
+        assert_eq!(all[0].provider_kind, "anthropic");
+    }
+
+    #[test]
+    fn session_pinned_claude_dark_fails_closed_and_bills_nothing() {
+        // NEGATIVE: the `claude` route is DISPATCHABLE (available+validated, as the gated `live()`
+        // path promotes it) but the Claude CLIENT is NOT wired (no `with_claude` — the resolver's
+        // documented dark backstop). A sessioned pin to "claude" then FAILS CLOSED at the resolve()
+        // chokepoint with NoClientForProvider — NEVER a silent reroute to deepseek — and bills
+        // NOTHING (no run row, no ledger row), because the failure is BEFORE any write. This is the
+        // sessioned mirror of the resolver's dark backstop; NO key, NO network.
+        let (mut rt, _ws, post_calls) = runtime_with(
+            "c2-session-dark",
+            &["{\"tool\":\"none\"}"],
+            Box::new(DenyAllApprovals),
+        );
+        // Promote the route to dispatchable WITHOUT wiring the client (claude stays None) — so the
+        // fail-closed is at resolve() (NoClientForProvider), not at select_route.
+        rt.mark_route_available("claude");
+        rt.mark_route_validated("claude");
+        let caller = authed_caller("principal:session-owner");
+        let err = rt
+            .run_session_task_pinned(
+                &caller,
+                "run-c2-session-dark",
+                "sess-c2-dark-1",
+                "make it shorter",
+                "claude",
+                4_000,
+            )
+            .expect_err("a dark claude pin must fail closed, never reroute");
+        match err {
+            RoutedLoopError::NoClientForProvider(p) => {
+                assert_eq!(
+                    p, "claude",
+                    "fail-closed names the dark provider, no reroute"
+                )
+            }
+            other => panic!("expected NoClientForProvider(claude), got {other:?}"),
+        }
+        // No reroute to deepseek: the deepseek transport was never called.
+        assert_eq!(post_calls.get(), 0, "no reroute — deepseek never called");
+        // Nothing was billed AND no run row was created (the fail-closed happened before any write).
+        assert!(
+            rt.db()
+                .list_run_token_usage("run-c2-session-dark")
+                .unwrap()
+                .is_empty(),
+            "a dark pin bills nothing"
+        );
+        let run_rows: i64 = rt
+            .db()
+            .conn()
+            .query_row(
+                "SELECT count(*) FROM agent_run WHERE run_id = 'run-c2-session-dark'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(run_rows, 0, "no agent_run row was created for the dark pin");
     }
 
     // ---- PROOF-MEMORY-001 recall→inject wiring -------------------------------

--- a/rust-core/crates/friday-hub/src/sealed_ws.rs
+++ b/rust-core/crates/friday-hub/src/sealed_ws.rs
@@ -191,6 +191,36 @@ pub fn enforce_single_peer(
     Ok(())
 }
 
+/// (J2) Fail closed unless the allowlist holds AT LEAST ONE peer pubkey — the MULTI-PEER sibling of
+/// [`enforce_single_peer`], for the READ seam ONLY.
+///
+/// The read-projection server removes the single-peer eviction trap: a desktop master-derived peer
+/// AND a distinct mobile device key can BOTH be enrolled concurrently, so the read server admits a
+/// non-empty multi-peer allowlist. The per-handshake S-F PEER gate ([`peer_is_allowlisted`]) already
+/// checks the presented pubkey against EVERY enrolled key (`contains`), so a 2-key allowlist admits
+/// either real peer with no eviction — that is the whole point of this guard.
+///
+/// [`load_peer_allowlist`] already rejects a MISSING (`Missing`) or non-32-multiple/empty
+/// (`Invalid`) value, so by the time this guard runs the only residual fail-closed case is
+/// `len() == 0` (defensive — `load_peer_allowlist` cannot return it, but assert it rather than trust
+/// it). `len() >= 1` ⇒ `Ok`. This guard does NOT, and must not, touch the WRITE server: the live
+/// write bin still calls [`enforce_single_peer`] on `PEER_PUBKEY_ALLOWLIST_ID` and still refuses a
+/// >1 list — the two guards + two ids keep the seams independent.
+///
+/// HONEST CEILING (the same as the write path's): per-PRINCIPAL isolation — binding the
+/// AUTHENTICATED caller to the MATCHED pubkey so peer A cannot read peer B's owner-scoped data via a
+/// valid session — is the (still UNBUILT) tamper-evident pubkey→principal binding, DEFERRED. v1
+/// remains single-configured-owner: every enrolled read peer authenticates as the SAME owner, so
+/// multi-peer here means "more than one DEVICE for the one owner", not multi-tenant.
+pub fn enforce_peer_allowlist_nonempty(
+    allowlist: &[[u8; X25519_PUBKEY_LEN]],
+) -> Result<(), PeerAllowlistError> {
+    if allowlist.is_empty() {
+        return Err(PeerAllowlistError::Invalid);
+    }
+    Ok(())
+}
+
 /// On-wire form for a `Sealed`: `[nonce_len: u8][nonce][ciphertext]`. Mirrors the transport's
 /// internal `encode_sealed` (kept here — the transport does not expose it). Carries no key. Shared
 /// so the read server's owner-sealed body and the write server's auth_proof / owner-sealed body use
@@ -330,6 +360,36 @@ mod tests {
     #[test]
     fn enforce_single_peer_refuses_two_keys() {
         let two = vec![[1u8; X25519_PUBKEY_LEN], [2u8; X25519_PUBKEY_LEN]];
+        assert_eq!(
+            enforce_single_peer(&two),
+            Err(PeerAllowlistError::MultiPeer)
+        );
+    }
+
+    /// (J2 KAT) The READ-seam nonempty guard accepts ONE or TWO peers (Ok) and refuses only an
+    /// EMPTY list (Err::Invalid) — removing the single-peer eviction trap for the read seam.
+    #[test]
+    fn enforce_peer_allowlist_nonempty_accepts_one_and_two_refuses_zero() {
+        let one = vec![[1u8; X25519_PUBKEY_LEN]];
+        let two = vec![[1u8; X25519_PUBKEY_LEN], [2u8; X25519_PUBKEY_LEN]];
+        let none: Vec<[u8; X25519_PUBKEY_LEN]> = vec![];
+        assert!(enforce_peer_allowlist_nonempty(&one).is_ok());
+        assert!(enforce_peer_allowlist_nonempty(&two).is_ok());
+        assert_eq!(
+            enforce_peer_allowlist_nonempty(&none),
+            Err(PeerAllowlistError::Invalid)
+        );
+    }
+
+    /// (J2 KAT — anti-regression) The WRITE-seam guard [`enforce_single_peer`] is BYTE-UNCHANGED: it
+    /// MUST still reject a 2-key list. The read seam relaxing single-peer must NOT relax the write
+    /// seam — proven side-by-side on the SAME two-key list the read guard now accepts.
+    #[test]
+    fn enforce_single_peer_still_refuses_two_keys_after_read_seam_relax() {
+        let two = vec![[3u8; X25519_PUBKEY_LEN], [4u8; X25519_PUBKEY_LEN]];
+        // The read seam admits this list…
+        assert!(enforce_peer_allowlist_nonempty(&two).is_ok());
+        // …but the WRITE seam still refuses it, unchanged.
         assert_eq!(
             enforce_single_peer(&two),
             Err(PeerAllowlistError::MultiPeer)


### PR DESCRIPTION
Two disjoint friday-hub substrate slices, DARK/additive/no-degrade.

## Slice 1 — J2 read-seam multi-peer (removes the single-peer eviction trap, READ seam only)
- New `READ_SEAM_PEER_PUBKEY_ALLOWLIST_ID` (read seam stops sharing the write server's single-peer id) + `enforce_peer_allowlist_nonempty` sibling (Err only on len 0). The read-projection server + read-enroll CLI target the new id; `--add` multi-peer works for the read seam.
- **Live WRITE seam BYTE-UNTOUCHED:** `hub_agent_run_server.rs` / `hub_server.rs` / write-enroll = EMPTY diff; `PEER_PUBKEY_ALLOWLIST_ID` + `enforce_single_peer` unchanged (zero deletions). `MultiPeerUnsupported` is a PER-BIN enum — the write server keeps its copy + `enforce_single_peer`; only the read bin's now-unused copy was removed.
- KATs: `enforce_peer_allowlist_nonempty` (Ok 1&2, Err 0) + `enforce_single_peer` anti-regression (still Err on 2) + **2 distinct real DeviceKeypairs both complete full sealed read round-trips with NO eviction (A→B→A)** + enroll `--add` A then B idempotent.

## Slice 2 — C2 session-control routing (additive runtime.rs; no lib.rs change)
- New `run_session_task_pinned(.., provider_id, ..)` resolves the client via the route-pin `resolve()` chokepoint + passes the resolved `&dyn AgentLlmClient` into the EXISTING `run_session_loop` (which already takes a trait object). Makes a session follow-up/steer turn route to + bill Claude. `run_session_task_with_overrides` body byte-untouched.
- KATs: `session_followup_turn_routes_to_claude_and_bills_anthropic` (resolved=claude, 1 anthropic row, host=api.anthropic.com, fallback=false) + negative `session_pinned_claude_dark_fails_closed_and_bills_nothing` (NoClientForProvider, no run row, no ledger row, no reroute).

## Validated (CI-exact, dark)
`cargo fmt --all -- --check` clean; `cargo clippy --workspace --all-targets -- -D warnings` clean; full workspace 1534 passed / 0 failed / 34 ignored.

## Honest ceiling
J2 = transport/enroll multi-peer only — NOT a real paired device, NO per-principal isolation (single-OWNER multi-DEVICE; tamper-evident pubkey→principal binding stays deferred). Read server stays DARK (no LaunchAgent / no prod caller; slice-6 flip is a separate operator gate). C2 = DARK — the live Claude leg needs `FRIDAY_CLAUDE_ROUTE_ENABLED` + a live Anthropic key. Neither slice moves a v1 needle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)