### PR TITLE
feat(loop): memory-confirmation reversibility + MemoryReview Needs-Me projection — DARK

### DIFF
--- a/rust-core/crates/friday-core/src/activity.rs
+++ b/rust-core/crates/friday-core/src/activity.rs
@@ -11,6 +11,11 @@ pub enum ActivityType {
     OfflineResult,
     /// A verified channel-origin inbound recorded as a Hub event (Channels track A-PR4).
     ChannelInbound,
+    /// A pending memory candidate surfaced for the user's explicit review
+    /// (confirm/reject/edit) — the Memory-confirmation loop (`07` §6/§7). A
+    /// candidate is never auto-confirmed; surfacing it for review is how the
+    /// "no silent long-term write" invariant reaches the user.
+    MemoryReview,
 }
 
 impl ActivityType {
@@ -21,6 +26,7 @@ impl ActivityType {
             ActivityType::OfflineQueued => "offline_queued",
             ActivityType::OfflineResult => "offline_result",
             ActivityType::ChannelInbound => "channel_inbound",
+            ActivityType::MemoryReview => "memory_review",
         }
     }
 }
@@ -83,6 +89,7 @@ mod tests {
         assert_eq!(ActivityType::AskReceipt.as_str(), "ask_receipt");
         assert_eq!(ActivityType::OfflineResult.as_str(), "offline_result");
         assert_eq!(ActivityType::ChannelInbound.as_str(), "channel_inbound");
+        assert_eq!(ActivityType::MemoryReview.as_str(), "memory_review");
     }
 
     #[test]

--- a/rust-core/crates/friday-core/src/lib.rs
+++ b/rust-core/crates/friday-core/src/lib.rs
@@ -52,9 +52,9 @@ pub use mechanism_matrix::{
     MechanismStatus,
 };
 pub use memory::{
-    decide_candidate, gate_transfer, redact_passport_for_projection, resolve_conflict, Confidence,
-    ConflictResolution, MemoryScope, MemoryState, PassportItem, PassportItemKind,
-    RedactedPassportItem,
+    decide_candidate, gate_transfer, memory_review_needs_me, redact_passport_for_projection,
+    resolve_conflict, Confidence, ConflictResolution, MemoryScope, MemoryState, PassportItem,
+    PassportItemKind, RedactedPassportItem, MEMORY_REVIEW_PRIORITY,
 };
 pub use mission::{
     find_duplicate_mission, find_duplicate_work_item, requires_context_passport,

--- a/rust-core/crates/friday-core/src/memory.rs
+++ b/rust-core/crates/friday-core/src/memory.rs
@@ -12,7 +12,9 @@
 //!   secrets / raw tokens never transfer; a sensitive included item needs
 //!   explicit approval; only included items transfer.
 
+use crate::activity::ActivityType;
 use crate::error::CoreError;
+use crate::workflow::NeedsMeItem;
 
 /// Layer/scope of a memory item (`02` §11).
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -100,6 +102,56 @@ pub fn decide_candidate(state: MemoryState, user_confirmed: Option<bool>) -> Mem
         (MemoryState::Candidate, Some(false)) => MemoryState::Rejected,
         (MemoryState::Candidate, None) => MemoryState::Candidate, // still pending; not written
         (other, _) => other,
+    }
+}
+
+/// Default urgency of a Memory-Review Needs-Me item. A pending memory candidate
+/// is a low-noise review nudge (the user decides confirm/reject/edit at their
+/// pace), so it sits below action items that block live work — but it is still
+/// surfaced (never silently dropped or auto-confirmed). Kept a named constant so
+/// the projection's priority is auditable in one place.
+pub const MEMORY_REVIEW_PRIORITY: u8 = 1;
+
+/// Project a single memory candidate into a [`NeedsMeItem`] for the Needs-Me /
+/// Memory-Review surface — the pure half of the Memory-confirmation loop
+/// (`07` §6/§7, `08` §2). A memory becomes durable ONLY by explicit user
+/// decision, so a pending `Candidate` is the ONLY state that needs the user:
+///
+/// - `Candidate` (pending) -> `Some(NeedsMeItem)` of [`ActivityType::MemoryReview`]
+///   kind (its `source` is the activity-type wire string, keeping the surface and
+///   the activity taxonomy in lockstep).
+/// - `Confirmed` / `Rejected` (terminal) -> `None`: the decision is already made,
+///   so it does NOT need the user and must not re-surface (no nagging on a
+///   resolved item, mirroring the terminal-is-final lifecycle invariant).
+///
+/// Pure + total over `MemoryState`; takes primitives (no storage row dependency)
+/// so it composes with either an in-memory candidate or a persisted `MemoryRow`.
+/// `summary` is a short, already-redaction-safe label for the card (the caller is
+/// responsible for not passing secret material — the Context Passport gate governs
+/// what content may leave the Hub; see [`redact_passport_for_projection`]).
+pub fn memory_review_needs_me(
+    memory_id: &str,
+    state: MemoryState,
+    scope: MemoryScope,
+    summary: &str,
+) -> Option<NeedsMeItem> {
+    match state {
+        // Only a pending candidate needs the user's review.
+        MemoryState::Candidate => Some(NeedsMeItem {
+            source: ActivityType::MemoryReview.as_str().to_string(),
+            id: memory_id.to_string(),
+            reason: if summary.is_empty() {
+                "Review a new memory candidate".to_string()
+            } else {
+                format!("Review memory candidate: {summary}")
+            },
+            priority: MEMORY_REVIEW_PRIORITY,
+            // Where the user acts on it: the memory item's review entry.
+            destination: format!("memory/{}/{}", scope.as_str(), memory_id),
+        }),
+        // A confirmed or rejected memory is terminal — the decision is made; it
+        // never re-surfaces for review.
+        MemoryState::Confirmed | MemoryState::Rejected => None,
     }
 }
 
@@ -261,6 +313,45 @@ mod tests {
             MemoryState::Rejected
         );
         assert!(!MemoryState::Rejected.is_durable());
+    }
+
+    // k5 — Memory-Review Needs-Me projection.
+    #[test]
+    fn memory_review_needs_me_projects_only_pending_candidates() {
+        // A pending Candidate -> a MemoryReview Needs-Me item.
+        let pending = memory_review_needs_me(
+            "m1",
+            MemoryState::Candidate,
+            MemoryScope::Global,
+            "likes rust",
+        )
+        .expect("a pending candidate must surface for review");
+        assert_eq!(pending.id, "m1");
+        // Source is wired to the ActivityType wire string (surface <-> taxonomy lockstep).
+        assert_eq!(pending.source, ActivityType::MemoryReview.as_str());
+        assert_eq!(pending.source, "memory_review");
+        assert_eq!(pending.priority, MEMORY_REVIEW_PRIORITY);
+        assert!(pending.reason.contains("likes rust"));
+        assert_eq!(pending.destination, "memory/global/m1");
+
+        // A Confirmed or Rejected (terminal) memory does NOT surface — the decision
+        // is already made; it must not re-nag the user.
+        assert!(
+            memory_review_needs_me("m1", MemoryState::Confirmed, MemoryScope::Global, "x")
+                .is_none(),
+            "a confirmed memory is terminal and never needs review"
+        );
+        assert!(
+            memory_review_needs_me("m1", MemoryState::Rejected, MemoryScope::Session, "x")
+                .is_none(),
+            "a rejected memory is terminal and never needs review"
+        );
+
+        // Empty summary still yields a usable, non-empty reason (no blank card).
+        let blank =
+            memory_review_needs_me("m2", MemoryState::Candidate, MemoryScope::Project, "").unwrap();
+        assert!(!blank.reason.is_empty());
+        assert_eq!(blank.destination, "memory/project/m2");
     }
 
     #[test]

--- a/rust-core/crates/friday-storage/src/memory.rs
+++ b/rust-core/crates/friday-storage/src/memory.rs
@@ -196,6 +196,85 @@ pub fn reject(conn: &Connection, memory_id: &str, now: i64) -> Result<MemoryStat
     decide(conn, memory_id, false, now)
 }
 
+/// Edit a PENDING memory candidate (the Memory-confirmation loop's "edit"
+/// action, `07` §6/§7). The edit is modeled as a SUCCESSOR, never an in-place
+/// mutation: the old candidate is `reject`-ed (becomes a terminal `Rejected`
+/// row, untouched thereafter) and the edited content is recorded as a NEW
+/// `Candidate` row. The two rows COEXIST — the prior content is preserved as a
+/// terminal Rejected record, so the edit is reversible by a SUCCESSOR
+/// (re-propose / a future re-edit) without ever rewriting or resurrecting a
+/// terminal row. There is no provenance column (that would need a migration);
+/// reversibility lives in the coexisting rows, not a stored edge.
+///
+/// **PENDING-only by construction.** The edit composes `reject` first, and
+/// `reject`/`decide` already refuse a terminal row — so editing a `Confirmed`
+/// memory ERRORS (and inserts nothing), which is the EXPLICIT deferred AC
+/// (revising a confirmed memory = retire-on-confirm, NOT built here); editing an
+/// already-`Rejected` source also errors (use [`repropose_from_rejected`]). No
+/// separate state guard is needed — the lifecycle enforces the scope.
+///
+/// **Atomic.** Both writes run in one transaction: if recording the new
+/// candidate fails (e.g. a colliding `new_memory_id`), the rejection of the old
+/// candidate is rolled back too — there is never a half-edit that leaves the old
+/// candidate Rejected with no replacement.
+///
+/// Returns the id of the new candidate on success.
+pub fn edit_candidate(
+    conn: &Connection,
+    old_memory_id: &str,
+    edited: &NewMemoryCandidate,
+    now: i64,
+) -> Result<String> {
+    let tx = conn.unchecked_transaction()?;
+    // Reject the old candidate FIRST: `reject`/`decide` errors on a terminal
+    // (Confirmed/Rejected) row, so a Confirmed source is refused here (deferred
+    // AC) and a Rejected source is refused (use repropose) — PENDING-only scope
+    // falls out of the lifecycle, no extra guard.
+    reject(&tx, old_memory_id, now)?;
+    // Record the edited content as a brand-new candidate (NEVER durable).
+    record_candidate(&tx, edited)?;
+    tx.commit()?;
+    Ok(edited.memory_id.to_string())
+}
+
+/// Re-propose a NEW candidate sourced from a previously-`Rejected` memory (the
+/// Memory-confirmation loop's "re-propose" action, `07` §6/§7). This records a
+/// fresh `Candidate` row and leaves the source `Rejected` row ENTIRELY UNTOUCHED
+/// — the rejection stays terminal and final (re-asserting `decide` on it still
+/// errors; a re-propose does NOT resurrect or rewrite the old row). Reversibility
+/// is forward-only: a successor candidate is created; the historical Rejected
+/// record is preserved as-is.
+///
+/// A light guard confirms the source exists and is `Rejected` (symmetry with
+/// [`edit_candidate`]'s PENDING-only scope: re-propose is the path FROM a
+/// terminal Rejected, edit is the path FROM a pending Candidate). The source is
+/// only READ, never written. Returns the id of the new candidate.
+pub fn repropose_from_rejected(
+    conn: &Connection,
+    source_memory_id: &str,
+    reproposed: &NewMemoryCandidate,
+    // Reserved for API symmetry with `edit_candidate(.., now)`. Unused here: the
+    // new candidate's timestamp comes from `reproposed.created_at`, and the source
+    // Rejected row is never re-stamped (it stays terminal/untouched).
+    _now: i64,
+) -> Result<String> {
+    let src = current_state(conn, source_memory_id)?.ok_or_else(|| {
+        StorageError::Unsupported(format!(
+            "memory_item '{source_memory_id}' not found; nothing to re-propose"
+        ))
+    })?;
+    if src != MemoryState::Rejected {
+        return Err(StorageError::Unsupported(format!(
+            "memory_item '{source_memory_id}' is {} (not rejected); re-propose only applies to a \
+             rejected memory — edit a pending candidate with edit_candidate instead",
+            src.as_str()
+        )));
+    }
+    // Record-only: the source Rejected row is never written here.
+    record_candidate(conn, reproposed)?;
+    Ok(reproposed.memory_id.to_string())
+}
+
 /// Candidates awaiting the user's decision, oldest first (`07` §6/§7) — the
 /// data-layer query that **backs** the Memory Review schedule (the schedule's
 /// settings/cron/morning-card UI is deferred, `07` §7). These are surfaced for

--- a/rust-core/crates/friday-storage/tests/memory_persist.rs
+++ b/rust-core/crates/friday-storage/tests/memory_persist.rs
@@ -361,6 +361,186 @@ fn memory_review_queue_is_oldest_first_and_only_candidates() {
     assert_eq!(queue, vec!["old".to_string(), "new".to_string()]);
 }
 
+// --- Memory-confirmation loop: edit / re-propose (successor, not mutation) ---
+
+#[test]
+fn k3_edit_candidate_rejects_old_and_creates_new_candidate() {
+    let p = temp_db_path("mem-edit");
+    let db = Db::open_hub(&p).unwrap();
+    // A pending candidate the user wants to revise.
+    memory::record_candidate(
+        db.conn(),
+        &cand("orig", MemoryScope::Global, Some("typo: lieks rust"), 1),
+    )
+    .unwrap();
+    assert_eq!(state_of(&db, "orig"), "candidate");
+
+    // Edit it: the edit is a NEW candidate; the old becomes Rejected (reversible
+    // by a successor, NOT an in-place row mutation).
+    let new_id = memory::edit_candidate(
+        db.conn(),
+        "orig",
+        &cand("edited", MemoryScope::Global, Some("likes rust"), 2),
+        100,
+    )
+    .unwrap();
+    assert_eq!(new_id, "edited");
+
+    // The OLD candidate is now a terminal Rejected row (still present, untouched
+    // content) — reversibility = coexisting rows, not a rewrite.
+    let old = memory::get(db.conn(), "orig").unwrap().unwrap();
+    assert_eq!(old.state, MemoryState::Rejected);
+    assert_eq!(old.content_ref.as_deref(), Some("typo: lieks rust"));
+    assert!(!old.state.is_durable());
+
+    // A NEW Candidate row exists with the edited content, pending the user's decision.
+    let new = memory::get(db.conn(), "edited").unwrap().unwrap();
+    assert_eq!(new.state, MemoryState::Candidate);
+    assert_eq!(new.content_ref.as_deref(), Some("likes rust"));
+    // The new candidate is in the review queue; the old rejected one is not.
+    let queue: Vec<String> = memory::pending_review(db.conn())
+        .unwrap()
+        .into_iter()
+        .map(|m| m.memory_id)
+        .collect();
+    assert_eq!(queue, vec!["edited".to_string()]);
+}
+
+#[test]
+fn k3_edit_is_pending_only_confirmed_edit_is_refused_deferred_ac() {
+    // Editing a CONFIRMED memory (retire-on-confirm) is the EXPLICIT deferred AC —
+    // it must be refused, and refused ATOMICALLY (no new row leaks in).
+    let p = temp_db_path("mem-edit-confirmed");
+    let db = Db::open_hub(&p).unwrap();
+    memory::record_candidate(db.conn(), &cand("c", MemoryScope::Global, Some("fact"), 1)).unwrap();
+    memory::confirm(db.conn(), "c", 10).unwrap();
+    assert_eq!(state_of(&db, "c"), "confirmed");
+
+    let res = memory::edit_candidate(
+        db.conn(),
+        "c",
+        &cand("c_edited", MemoryScope::Global, Some("revised fact"), 2),
+        20,
+    );
+    assert!(
+        res.is_err(),
+        "editing a CONFIRMED memory must be refused (deferred AC)"
+    );
+    // Atomicity: the confirmed source is untouched AND the would-be new row never landed.
+    assert_eq!(state_of(&db, "c"), "confirmed");
+    assert!(memory::get(db.conn(), "c_edited").unwrap().is_none());
+    // The confirmed memory is still auto-usable (not collaterally rejected).
+    assert!(memory::auto_usable(db.conn())
+        .unwrap()
+        .iter()
+        .any(|m| m.memory_id == "c"));
+}
+
+#[test]
+fn k3_edit_is_atomic_no_half_edit_on_new_id_collision() {
+    // If recording the new candidate fails (PK collision on the new id), the
+    // rejection of the old candidate must roll back — never a half-edit.
+    let p = temp_db_path("mem-edit-atomic");
+    let db = Db::open_hub(&p).unwrap();
+    memory::record_candidate(db.conn(), &cand("orig", MemoryScope::Global, Some("a"), 1)).unwrap();
+    // A pre-existing row that will collide with the edit's new id.
+    memory::record_candidate(db.conn(), &cand("taken", MemoryScope::Global, Some("b"), 2)).unwrap();
+
+    let res = memory::edit_candidate(
+        db.conn(),
+        "orig",
+        &cand("taken", MemoryScope::Global, Some("c"), 3), // collides
+        50,
+    );
+    assert!(res.is_err(), "colliding new id must error");
+    // ATOMIC: the old candidate was NOT left rejected — the whole edit rolled back.
+    assert_eq!(
+        state_of(&db, "orig"),
+        "candidate",
+        "a failed edit must not leave the old candidate Rejected (no half-edit)"
+    );
+    // The pre-existing "taken" row is unchanged (still its own candidate).
+    let taken = memory::get(db.conn(), "taken").unwrap().unwrap();
+    assert_eq!(taken.content_ref.as_deref(), Some("b"));
+}
+
+#[test]
+fn k4_repropose_from_rejected_creates_new_candidate_source_stays_terminal() {
+    let p = temp_db_path("mem-repropose");
+    let db = Db::open_hub(&p).unwrap();
+    // A rejected memory the user changed their mind about.
+    memory::record_candidate(
+        db.conn(),
+        &cand("src", MemoryScope::Global, Some("plays guitar"), 1),
+    )
+    .unwrap();
+    memory::reject(db.conn(), "src", 10).unwrap();
+    assert_eq!(state_of(&db, "src"), "rejected");
+
+    // Re-propose: a NEW candidate; the source Rejected row is left UNTOUCHED.
+    let new_id = memory::repropose_from_rejected(
+        db.conn(),
+        "src",
+        &cand("repro", MemoryScope::Global, Some("plays guitar"), 2),
+        100,
+    )
+    .unwrap();
+    assert_eq!(new_id, "repro");
+
+    // The NEW candidate exists and is pending.
+    let new = memory::get(db.conn(), "repro").unwrap().unwrap();
+    assert_eq!(new.state, MemoryState::Candidate);
+
+    // THE k4 invariant: the source Rejected row is STILL terminal — re-asserting
+    // a decision on it STILL errors (reversibility does NOT resurrect the old row).
+    assert_eq!(state_of(&db, "src"), "rejected");
+    assert!(
+        memory::confirm(db.conn(), "src", 200).is_err(),
+        "the source Rejected row must stay terminal (no resurrection)"
+    );
+    assert!(memory::reject(db.conn(), "src", 200).is_err());
+    assert_eq!(state_of(&db, "src"), "rejected");
+}
+
+#[test]
+fn k4_repropose_only_from_a_rejected_source() {
+    let p = temp_db_path("mem-repropose-guard");
+    let db = Db::open_hub(&p).unwrap();
+    // From a non-existent source: error, no silent create.
+    assert!(memory::repropose_from_rejected(
+        db.conn(),
+        "ghost",
+        &cand("x", MemoryScope::Global, None, 1),
+        10
+    )
+    .is_err());
+    assert!(memory::get(db.conn(), "x").unwrap().is_none());
+
+    // From a still-PENDING candidate: refused (use edit_candidate, not re-propose).
+    memory::record_candidate(db.conn(), &cand("pend", MemoryScope::Global, Some("p"), 1)).unwrap();
+    assert!(memory::repropose_from_rejected(
+        db.conn(),
+        "pend",
+        &cand("y", MemoryScope::Global, None, 2),
+        10
+    )
+    .is_err());
+    assert!(memory::get(db.conn(), "y").unwrap().is_none());
+    assert_eq!(state_of(&db, "pend"), "candidate"); // source untouched
+
+    // From a CONFIRMED memory: also refused (re-propose is from a Rejected source only).
+    memory::record_candidate(db.conn(), &cand("conf", MemoryScope::Global, Some("c"), 1)).unwrap();
+    memory::confirm(db.conn(), "conf", 5).unwrap();
+    assert!(memory::repropose_from_rejected(
+        db.conn(),
+        "conf",
+        &cand("z", MemoryScope::Global, None, 3),
+        10
+    )
+    .is_err());
+    assert!(memory::get(db.conn(), "z").unwrap().is_none());
+}
+
 #[test]
 fn memory_item_is_hub_only_absent_on_phone() {
     let p = temp_db_path("mem-phone");


### PR DESCRIPTION
North-star loop-closure: the memory candidate → confirm/edit/reject reversible loop + an Activity/Needs-Me surface for pending review. Builds ON the existing memory.rs MemoryState machine + storage decide/reject/pending_review. **DARK** (no live wiring). NO schema.rs/migration (kept disjoint from the parallel passport/trust lane's v30/v31).

- **Reversibility = successor creation, NEVER in-place mutation of a terminal row.** `edit_candidate` = reject(old) + record_candidate(new) in one transaction (old becomes a terminal `Rejected` row with content intact; the edit is a brand-new `Candidate`). `repropose_from_rejected` = record_candidate(new) leaving the source `Rejected` row untouched. The two rows coexist (no provenance column = no migration). Atomic: a colliding new id rolls back the rejection (no half-edit).
- **PENDING-only scope falls out for free** (reject-first ordering): editing a `Confirmed` memory errors (retire-on-confirm = explicit DEFERRED AC, not built); editing a `Rejected` source errors.
- `ActivityType::MemoryReview` + pure `memory_review_needs_me(...)` projection (reuses shared `workflow::NeedsMeItem`): a pending `Candidate` → `Some(NeedsMeItem)`; terminal `Confirmed`/`Rejected` → `None`.

## Validated (CI-exact, dark)
`cargo fmt --all -- --check` clean; `cargo clippy --workspace --all-targets -- -D warnings` clean; `cargo test -p friday-core memory/activity` (14+3 pass, incl k5) + `-p friday-storage --test memory_persist` (23 pass, k3+k4 + 4 adversarial siblings: deferred-AC refusal, atomicity/no-half-edit, repropose source-state guard); `cargo test --workspace` 0 failures.

## Honest ceiling
DARK mechanism only (lifecycle + persistence + Needs-Me projection, in-crate/storage-validated). DEFERRED AC (NOT built): live round-trip into the hub, mobile review sheet, scheduled Memory Review, CONFIRMED-edit (retire-on-confirm). Not wired to any live caller. **NOT v1-GO.** (Live-wiring note: use an Immediate tx for the edit under concurrent writers, per Friday's SQLITE_BUSY history.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)