### PR TITLE
feat(loop): Context-Passport gate + Trust-grant baseline + WorkItem transition — DARK (v30/v31)

### DIFF
--- a/rust-core/crates/friday-core/src/lib.rs
+++ b/rust-core/crates/friday-core/src/lib.rs
@@ -26,6 +26,7 @@ mod memory;
 mod mission;
 mod offline;
 mod pairing;
+mod passport;
 mod pathsafe;
 mod planning;
 mod process_registry;
@@ -69,6 +70,7 @@ pub use pairing::{
     FridayPairPayload, FridayPairProjection, PairAuthority, PairTransportHint, PairTransportKind,
     PairingSecret, TrustedDeviceProjection, CURRENT_PAIR_PAYLOAD_VERSION,
 };
+pub use passport::{build_context_passport, ContextPassport};
 pub use pathsafe::{contained, PathError};
 pub use planning::{classify_kind, PlanState, PlanningKind};
 pub use process_registry::{

--- a/rust-core/crates/friday-core/src/lib.rs
+++ b/rust-core/crates/friday-core/src/lib.rs
@@ -35,6 +35,7 @@ mod session;
 mod skill;
 mod skill_catalog;
 mod tool_policy;
+mod trust;
 mod workflow;
 
 pub use activity::{ActivityState, ActivityType};
@@ -90,6 +91,7 @@ pub use tool_policy::{
     contains_blocked_shell_char, contains_sensitive_assignment, contains_sensitive_material,
     is_destructive_request, shell_risk, touches_protected_artifact, Risk, ShellRisk,
 };
+pub use trust::{check_grant, GrantCheck, TrustBoundaries, TrustGrant};
 pub use workflow::{
     aggregate_needs_me, resolve_step_completion, run_is_complete, NeedsMeItem, StepStatus,
     StepView, WorkflowRunState,

--- a/rust-core/crates/friday-core/src/passport.rs
+++ b/rust-core/crates/friday-core/src/passport.rs
@@ -1,0 +1,225 @@
+//! Context Passport object — the destination-bound, fail-closed-by-construction
+//! carrier for an external context transfer (`07` §10, `02` §7/§12; north-star
+//! loop closure, commit 2).
+//!
+//! The pure transfer gate already lives in [`crate::memory::gate_transfer`] (it blocks
+//! a never-transferable secret/token item and requires explicit approval for a
+//! sensitive item). What was MISSING is the *object* that binds those cleared items to
+//! a SPECIFIC destination — so the Hub preflight can ask "does THIS passport authorize
+//! THIS transfer to THIS lane/target?" rather than only "is a passport ref present?"
+//! (the hollow check this object exists to replace).
+//!
+//! Fail-closed BY CONSTRUCTION: [`build_context_passport`] runs `gate_transfer`
+//! internally, so a [`ContextPassport`] that clears a secret/raw-token item or an
+//! unapproved sensitive item simply CANNOT be constructed — there is no struct-literal
+//! escape (the fields are public for read, but the only constructor is the gated
+//! builder, and the preflight rebuilds through it on load rather than trusting a stored
+//! row).
+
+use crate::error::CoreError;
+use crate::memory::{gate_transfer, PassportItem};
+use crate::mission::WorkLane;
+
+/// A built, destination-bound Context Passport. Existence is proof that
+/// [`gate_transfer`] cleared every included item for transfer (no secret/raw-token
+/// content; sensitive items only with explicit approval).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ContextPassport {
+    pub passport_id: String,
+    pub mission_id: String,
+    /// Optional: a passport may be scoped to one WorkItem, or to the Mission's transfer.
+    pub work_item_id: Option<String>,
+    /// The lane this passport authorizes a transfer TO.
+    pub destination_lane: WorkLane,
+    /// Optional concrete target (provider/agent/channel id). When present, a transfer
+    /// must match it exactly; when `None`, the passport authorizes the whole lane.
+    pub destination_target: Option<String>,
+    /// The full item set (including non-included items) so a reload re-gates identically.
+    pub items: Vec<PassportItem>,
+    /// Whether sensitive items were explicitly approved when the passport was built.
+    pub approved_sensitive: bool,
+    pub created_at_ms: i64,
+}
+
+/// Build a Context Passport, GATING the item set by construction. Returns
+/// [`CoreError::BlockedTransfer`] (the same error `gate_transfer` raises) if any
+/// included item is a never-transferable secret/raw-token kind, or a sensitive item
+/// without `approved_sensitive` — so a passport that would leak a secret can never
+/// exist as a value.
+#[allow(clippy::too_many_arguments)]
+pub fn build_context_passport(
+    passport_id: impl Into<String>,
+    mission_id: impl Into<String>,
+    work_item_id: Option<String>,
+    destination_lane: WorkLane,
+    destination_target: Option<String>,
+    items: Vec<PassportItem>,
+    approved_sensitive: bool,
+    created_at_ms: i64,
+) -> Result<ContextPassport, CoreError> {
+    // The fail-closed core: if this errors, no ContextPassport value is produced.
+    gate_transfer(&items, approved_sensitive)?;
+    Ok(ContextPassport {
+        passport_id: passport_id.into(),
+        mission_id: mission_id.into(),
+        work_item_id,
+        destination_lane,
+        destination_target,
+        items,
+        approved_sensitive,
+        created_at_ms,
+    })
+}
+
+impl ContextPassport {
+    /// Whether this passport authorizes a transfer to `lane` (+ `target`). The
+    /// destination BINDING the hollow ref-presence check could not see: the lane must
+    /// match exactly, and if the passport carries a concrete target the request target
+    /// must equal it. A passport with no target authorizes the whole lane.
+    pub fn authorizes_transfer(&self, lane: WorkLane, target: Option<&str>) -> bool {
+        if self.destination_lane != lane {
+            return false;
+        }
+        match self.destination_target.as_deref() {
+            Some(bound) => target == Some(bound),
+            None => true,
+        }
+    }
+
+    /// The included items this passport actually carries across the boundary — the
+    /// record of WHAT was shared (so an audit can show the cleared payload, never the
+    /// blocked/secret items, which `gate_transfer` already proved absent on build).
+    pub fn shared_items(&self) -> Vec<&PassportItem> {
+        self.items.iter().filter(|i| i.included).collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::memory::PassportItemKind;
+
+    fn item(kind: PassportItemKind, label: &str, included: bool, sensitive: bool) -> PassportItem {
+        PassportItem {
+            kind,
+            label: label.into(),
+            included,
+            sensitive,
+        }
+    }
+
+    fn ok_items() -> Vec<PassportItem> {
+        vec![
+            item(PassportItemKind::Summary, "weekly plan", true, false),
+            item(PassportItemKind::File, "design.md", true, false),
+        ]
+    }
+
+    #[test]
+    fn a_provider_secret_item_cannot_be_built_into_a_passport() {
+        let items = vec![item(
+            PassportItemKind::ProviderSecret,
+            "deepseek key",
+            true,
+            true,
+        )];
+        let err = build_context_passport(
+            "p1",
+            "m1",
+            None,
+            WorkLane::Codex,
+            Some("codex".into()),
+            items,
+            true,
+            1,
+        )
+        .unwrap_err();
+        assert!(matches!(err, CoreError::BlockedTransfer(_)));
+    }
+
+    #[test]
+    fn a_raw_token_item_cannot_be_built_into_a_passport() {
+        let items = vec![item(PassportItemKind::RawToken, "bearer", true, false)];
+        let err = build_context_passport("p1", "m1", None, WorkLane::Claude, None, items, false, 1)
+            .unwrap_err();
+        assert!(matches!(err, CoreError::BlockedTransfer(_)));
+    }
+
+    #[test]
+    fn an_unapproved_sensitive_item_cannot_be_built_into_a_passport() {
+        let items = vec![item(
+            PassportItemKind::Summary,
+            "salary figures",
+            true,
+            true,
+        )];
+        // approved_sensitive = false -> blocked by construction.
+        let err = build_context_passport("p1", "m1", None, WorkLane::Codex, None, items, false, 1)
+            .unwrap_err();
+        assert!(matches!(err, CoreError::BlockedTransfer(_)));
+
+        // The SAME item with explicit approval builds.
+        let items = vec![item(
+            PassportItemKind::Summary,
+            "salary figures",
+            true,
+            true,
+        )];
+        let ok = build_context_passport("p1", "m1", None, WorkLane::Codex, None, items, true, 1);
+        assert!(ok.is_ok());
+    }
+
+    #[test]
+    fn authorizes_only_the_bound_lane_and_target() {
+        let p = build_context_passport(
+            "p1",
+            "m1",
+            None,
+            WorkLane::Codex,
+            Some("codex".into()),
+            ok_items(),
+            false,
+            1,
+        )
+        .unwrap();
+
+        assert!(p.authorizes_transfer(WorkLane::Codex, Some("codex")));
+        // Wrong lane.
+        assert!(!p.authorizes_transfer(WorkLane::Claude, Some("codex")));
+        // Wrong target.
+        assert!(!p.authorizes_transfer(WorkLane::Codex, Some("claude")));
+        // Missing target where one is bound.
+        assert!(!p.authorizes_transfer(WorkLane::Codex, None));
+    }
+
+    #[test]
+    fn an_untargeted_passport_authorizes_the_whole_lane() {
+        let p = build_context_passport(
+            "p1",
+            "m1",
+            None,
+            WorkLane::Channel,
+            None,
+            ok_items(),
+            false,
+            1,
+        )
+        .unwrap();
+        assert!(p.authorizes_transfer(WorkLane::Channel, Some("telegram:1")));
+        assert!(p.authorizes_transfer(WorkLane::Channel, None));
+        assert!(!p.authorizes_transfer(WorkLane::Codex, None));
+    }
+
+    #[test]
+    fn shared_items_are_only_the_included_ones() {
+        let items = vec![
+            item(PassportItemKind::Summary, "included", true, false),
+            item(PassportItemKind::File, "excluded", false, false),
+        ];
+        let p = build_context_passport("p1", "m1", None, WorkLane::Codex, None, items, false, 1)
+            .unwrap();
+        let shared = p.shared_items();
+        assert_eq!(shared.len(), 1);
+        assert_eq!(shared[0].label, "included");
+    }
+}

--- a/rust-core/crates/friday-core/src/tool_policy.rs
+++ b/rust-core/crates/friday-core/src/tool_policy.rs
@@ -39,6 +39,14 @@ impl Risk {
     }
 }
 
+/// The most-restrictive risk is the default: anything unclassified is treated as the
+/// lowest privilege, never escalated by omission (fail-safe for trust boundaries).
+impl Default for Risk {
+    fn default() -> Self {
+        Risk::ReadOnly
+    }
+}
+
 /// Shell-command risk class (TS `safe | guarded | destructive | blocked`).
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum ShellRisk {

--- a/rust-core/crates/friday-core/src/trust.rs
+++ b/rust-core/crates/friday-core/src/trust.rs
@@ -1,0 +1,286 @@
+//! Trust-grant baseline — the per-agent capability envelope (north-star doc 55 §4,
+//! the 9 boundaries; loop closure commit 3).
+//!
+//! A [`TrustGrant`] is a scoped, revocable, expiring authorization for ONE agent
+//! ("friday" | "codex" | "claude" | "workflow:<id>" | "skill:<id>") to act WITHIN a
+//! set of [`TrustBoundaries`]. This is PURE policy (no I/O): [`check_grant`] decides
+//! whether a single requested action falls inside the grant's envelope. Persistence
+//! (issue/revoke/active-lookup) and the restrictive compose with the mutating-action
+//! gate live in `friday-storage`.
+//!
+//! Fail-closed posture:
+//! - an EMPTY allowlist is DENY-ALL for the dimension it scopes (a grant must
+//!   explicitly enumerate what it permits — "no tools listed" never means "all tools");
+//! - a deny on revoked / expired / agent-mismatch / risk-over-ceiling /
+//!   workspace-prefix-miss / out-of-allowlist short-circuits;
+//! - the only `Allow` is `"trust_grant_within_boundaries"`, and it means "no trust
+//!   objection" — it is NEVER an upgrade (the storage compose feeds it to the mutating
+//!   gate, which can still require approval).
+//!
+//! DEFERRED (stored, NOT enforced — honest): `token_ceiling` / `max_runs` need a live
+//! token-ledger / run-state counter; this baseline stores them but does not enforce
+//! them (no fake counter). The check ignores them.
+
+use crate::gate::GateDecision;
+use crate::tool_policy::Risk;
+
+/// The scoping envelope of a trust grant — north-star doc 55 §4's boundaries.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TrustBoundaries {
+    /// Workspace path PREFIX the grant is confined to. `None` = unscoped (any path).
+    pub workspace: Option<String>,
+    /// The maximum risk an action may carry. An effective risk ABOVE this is denied.
+    pub risk_ceiling: Risk,
+    /// DEFERRED (stored, not enforced): token spend ceiling.
+    pub token_ceiling: Option<i64>,
+    /// DEFERRED (stored, not enforced): max runs under this grant.
+    pub max_runs: Option<i64>,
+    /// Allowlists. EMPTY = DENY-ALL for that dimension (fail-closed).
+    pub allowed_channels: Vec<String>,
+    pub allowed_providers: Vec<String>,
+    pub allowed_tools: Vec<String>,
+    pub allowed_workflow_families: Vec<String>,
+    pub allowed_skill_families: Vec<String>,
+}
+
+/// A scoped, revocable, expiring authorization for one agent.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TrustGrant {
+    pub grant_id: String,
+    /// "friday" | "codex" | "claude" | "workflow:<id>" | "skill:<id>".
+    pub agent_id: String,
+    pub granted_at: i64,
+    /// `None` = no expiry. Otherwise the grant is dead once `now >= expires_at`.
+    pub expires_at: Option<i64>,
+    pub revoked: bool,
+    pub revoked_at: Option<i64>,
+    pub boundaries: TrustBoundaries,
+}
+
+/// One action's request dimensions, checked against a grant. A dimension carried as
+/// `Some(..)` is checked against its allowlist; a `None` dimension is not part of this
+/// action and is not checked (so a tool-only grant does not deny a tool-only request
+/// just because `allowed_providers` is empty).
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct GrantCheck {
+    pub agent_id: String,
+    pub now: i64,
+    /// The action's EFFECTIVE risk (the gate's derived `.risk`, not a re-derivation).
+    pub effective_risk: Risk,
+    /// The workspace path the action touches (checked against the prefix boundary).
+    pub workspace: Option<String>,
+    pub tool: Option<String>,
+    pub provider: Option<String>,
+    pub channel: Option<String>,
+    pub workflow_family: Option<String>,
+    pub skill_family: Option<String>,
+}
+
+/// Whether `value` is permitted by `allowlist`. EMPTY allowlist = DENY-ALL.
+fn allowed(allowlist: &[String], value: &str) -> bool {
+    allowlist.iter().any(|a| a == value)
+}
+
+/// Decide whether `check`'s action falls inside `grant`'s envelope. Returns the
+/// decision plus a stable reason label. The ONLY `Allow` reason is
+/// `"trust_grant_within_boundaries"`; every other branch is a `Deny` with a
+/// dimension-specific reason. Pure — no clock, no I/O (the caller supplies `now`).
+pub fn check_grant(grant: &TrustGrant, check: &GrantCheck) -> (GateDecision, &'static str) {
+    let deny = |reason: &'static str| (GateDecision::Deny, reason);
+
+    if grant.revoked {
+        return deny("trust_grant_revoked");
+    }
+    if let Some(expires_at) = grant.expires_at {
+        if check.now >= expires_at {
+            return deny("trust_grant_expired");
+        }
+    }
+    if grant.agent_id != check.agent_id {
+        return deny("trust_grant_agent_mismatch");
+    }
+
+    // Risk ceiling: an effective risk ABOVE the ceiling is denied.
+    if check.effective_risk > grant.boundaries.risk_ceiling {
+        return deny("trust_grant_risk_over_ceiling");
+    }
+
+    // Workspace prefix. A bounded grant confines actions to a path prefix; an action
+    // that touches a path outside it (or omits a path when the grant is workspace-
+    // scoped) is denied. An unscoped grant (`None`) skips this.
+    if let Some(prefix) = grant.boundaries.workspace.as_deref() {
+        match check.workspace.as_deref() {
+            Some(path) if path.starts_with(prefix) => {}
+            _ => return deny("trust_grant_workspace_out_of_scope"),
+        }
+    }
+
+    // Per-dimension allowlists — checked ONLY for the dimensions this action carries.
+    if let Some(tool) = check.tool.as_deref() {
+        if !allowed(&grant.boundaries.allowed_tools, tool) {
+            return deny("trust_grant_tool_not_allowed");
+        }
+    }
+    if let Some(provider) = check.provider.as_deref() {
+        if !allowed(&grant.boundaries.allowed_providers, provider) {
+            return deny("trust_grant_provider_not_allowed");
+        }
+    }
+    if let Some(channel) = check.channel.as_deref() {
+        if !allowed(&grant.boundaries.allowed_channels, channel) {
+            return deny("trust_grant_channel_not_allowed");
+        }
+    }
+    if let Some(family) = check.workflow_family.as_deref() {
+        if !allowed(&grant.boundaries.allowed_workflow_families, family) {
+            return deny("trust_grant_workflow_family_not_allowed");
+        }
+    }
+    if let Some(family) = check.skill_family.as_deref() {
+        if !allowed(&grant.boundaries.allowed_skill_families, family) {
+            return deny("trust_grant_skill_family_not_allowed");
+        }
+    }
+
+    (GateDecision::Allow, "trust_grant_within_boundaries")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn boundaries() -> TrustBoundaries {
+        TrustBoundaries {
+            workspace: Some("/work/friday".into()),
+            risk_ceiling: Risk::Medium,
+            token_ceiling: Some(1000),
+            max_runs: Some(5),
+            allowed_channels: vec!["telegram".into()],
+            allowed_providers: vec!["deepseek".into()],
+            allowed_tools: vec!["read_file".into()],
+            allowed_workflow_families: vec![],
+            allowed_skill_families: vec![],
+        }
+    }
+
+    fn grant() -> TrustGrant {
+        TrustGrant {
+            grant_id: "g1".into(),
+            agent_id: "friday".into(),
+            granted_at: 1,
+            expires_at: Some(1_000),
+            revoked: false,
+            revoked_at: None,
+            boundaries: boundaries(),
+        }
+    }
+
+    fn check() -> GrantCheck {
+        GrantCheck {
+            agent_id: "friday".into(),
+            now: 100,
+            effective_risk: Risk::ReadOnly,
+            workspace: Some("/work/friday/src".into()),
+            tool: Some("read_file".into()),
+            provider: None,
+            channel: None,
+            workflow_family: None,
+            skill_family: None,
+        }
+    }
+
+    #[test]
+    fn within_boundaries_allows() {
+        let (d, r) = check_grant(&grant(), &check());
+        assert_eq!(d, GateDecision::Allow);
+        assert_eq!(r, "trust_grant_within_boundaries");
+    }
+
+    #[test]
+    fn revoked_denies() {
+        let mut g = grant();
+        g.revoked = true;
+        let (d, r) = check_grant(&g, &check());
+        assert_eq!(d, GateDecision::Deny);
+        assert_eq!(r, "trust_grant_revoked");
+    }
+
+    #[test]
+    fn expired_denies() {
+        let mut c = check();
+        c.now = 1_000; // now >= expires_at
+        let (d, r) = check_grant(&grant(), &c);
+        assert_eq!(d, GateDecision::Deny);
+        assert_eq!(r, "trust_grant_expired");
+    }
+
+    #[test]
+    fn agent_mismatch_denies() {
+        let mut c = check();
+        c.agent_id = "codex".into();
+        let (d, r) = check_grant(&grant(), &c);
+        assert_eq!(d, GateDecision::Deny);
+        assert_eq!(r, "trust_grant_agent_mismatch");
+    }
+
+    #[test]
+    fn risk_over_ceiling_denies() {
+        let mut c = check();
+        c.effective_risk = Risk::High; // > Medium ceiling
+        let (d, r) = check_grant(&grant(), &c);
+        assert_eq!(d, GateDecision::Deny);
+        assert_eq!(r, "trust_grant_risk_over_ceiling");
+    }
+
+    #[test]
+    fn workspace_outside_prefix_denies() {
+        let mut c = check();
+        c.workspace = Some("/etc/passwd".into());
+        let (d, r) = check_grant(&grant(), &c);
+        assert_eq!(d, GateDecision::Deny);
+        assert_eq!(r, "trust_grant_workspace_out_of_scope");
+    }
+
+    #[test]
+    fn tool_not_in_allowlist_denies() {
+        let mut c = check();
+        c.tool = Some("delete_file".into());
+        let (d, r) = check_grant(&grant(), &c);
+        assert_eq!(d, GateDecision::Deny);
+        assert_eq!(r, "trust_grant_tool_not_allowed");
+    }
+
+    #[test]
+    fn empty_allowlist_is_deny_all_for_a_checked_dimension() {
+        // allowed_workflow_families is empty -> ANY workflow-family action denies.
+        let mut c = check();
+        c.workflow_family = Some("nightly".into());
+        let (d, r) = check_grant(&grant(), &c);
+        assert_eq!(d, GateDecision::Deny);
+        assert_eq!(r, "trust_grant_workflow_family_not_allowed");
+    }
+
+    #[test]
+    fn empty_allowlist_does_not_deny_an_unchecked_dimension() {
+        // allowed_providers is non-empty but the request carries NO provider; a
+        // tool-only request must NOT be denied for the absent provider dimension.
+        let c = check(); // provider = None, tool = read_file (allowed)
+        let (d, _) = check_grant(&grant(), &c);
+        assert_eq!(d, GateDecision::Allow);
+
+        // And an empty allowlist on an UN-checked dimension is still a non-issue: a
+        // grant with empty allowed_skill_families allows a non-skill action.
+        let (d2, _) = check_grant(&grant(), &c);
+        assert_eq!(d2, GateDecision::Allow);
+    }
+
+    #[test]
+    fn unscoped_workspace_grant_skips_the_prefix_check() {
+        let mut g = grant();
+        g.boundaries.workspace = None;
+        let mut c = check();
+        c.workspace = Some("/anywhere".into());
+        let (d, _) = check_grant(&g, &c);
+        assert_eq!(d, GateDecision::Allow);
+    }
+}

--- a/rust-core/crates/friday-core/src/trust.rs
+++ b/rust-core/crates/friday-core/src/trust.rs
@@ -108,9 +108,16 @@ pub fn check_grant(grant: &TrustGrant, check: &GrantCheck) -> (GateDecision, &'s
     // Workspace prefix. A bounded grant confines actions to a path prefix; an action
     // that touches a path outside it (or omits a path when the grant is workspace-
     // scoped) is denied. An unscoped grant (`None`) skips this.
+    //
+    // BOUNDARY-AWARE prefix (NOT a raw `starts_with`): a grant for `/work/friday`
+    // authorizes `/work/friday` itself and any path under `/work/friday/...`, but
+    // MUST NOT authorize a sibling like `/work/friday-secret` (a raw starts_with
+    // would fail OPEN there). The trailing-slash compare enforces a path-component
+    // boundary; `trim_end_matches('/')` normalizes a prefix that already ends in `/`.
     if let Some(prefix) = grant.boundaries.workspace.as_deref() {
+        let prefix_norm = prefix.trim_end_matches('/');
         match check.workspace.as_deref() {
-            Some(path) if path.starts_with(prefix) => {}
+            Some(path) if path == prefix_norm || path.starts_with(&format!("{prefix_norm}/")) => {}
             _ => return deny("trust_grant_workspace_out_of_scope"),
         }
     }
@@ -239,6 +246,36 @@ mod tests {
         let (d, r) = check_grant(&grant(), &c);
         assert_eq!(d, GateDecision::Deny);
         assert_eq!(r, "trust_grant_workspace_out_of_scope");
+    }
+
+    #[test]
+    fn workspace_sibling_prefix_does_not_fail_open() {
+        // grant() is scoped to "/work/friday". A raw starts_with would FAIL OPEN on
+        // the sibling "/work/friday-secret"; the boundary-aware check must DENY it,
+        // while still allowing the exact dir and any path under it.
+        let g = grant();
+
+        let mut sibling = check();
+        sibling.workspace = Some("/work/friday-secret/leak".into());
+        let (d, r) = check_grant(&g, &sibling);
+        assert_eq!(d, GateDecision::Deny, "sibling prefix must NOT fail open");
+        assert_eq!(r, "trust_grant_workspace_out_of_scope");
+
+        let mut exact = check();
+        exact.workspace = Some("/work/friday".into());
+        assert_eq!(
+            check_grant(&g, &exact).0,
+            GateDecision::Allow,
+            "exact dir allowed"
+        );
+
+        let mut child = check();
+        child.workspace = Some("/work/friday/src/main.rs".into());
+        assert_eq!(
+            check_grant(&g, &child).0,
+            GateDecision::Allow,
+            "sub-path allowed"
+        );
     }
 
     #[test]

--- a/rust-core/crates/friday-hub/src/mission_preflight.rs
+++ b/rust-core/crates/friday-hub/src/mission_preflight.rs
@@ -87,7 +87,12 @@ pub fn preflight_and_stage_work_item(
     db: &Db,
     request: MissionPreflightRequest,
 ) -> Result<MissionPreflightOutcome, StorageError> {
-    let blockers = validate_preflight_request(&request);
+    let mut blockers = validate_preflight_request(&request);
+    // Db-backed Context Passport gate (destination-binding; appended to the SAME vec so
+    // collect-all-then-block semantics hold — never reordered ahead of the pure checks).
+    if let Some(passport_blocker) = context_passport_blocker(db, &request)? {
+        blockers.push(passport_blocker);
+    }
     if !blockers.is_empty() {
         return Ok(MissionPreflightOutcome::Blocked {
             blockers,
@@ -304,25 +309,61 @@ pub fn attach_memory_decision_ref(
     )
 }
 
+/// Mint + attach a destination-bound Context Passport OBJECT (loop closure commit 2).
+///
+/// Evolved from the old ref-only version: instead of pushing an arbitrary string into
+/// `context_passport_refs` (which the hollow gate trusted), this BUILDS a real
+/// [`ContextPassport`] (`build_context_passport` runs `gate_transfer` — a secret/
+/// raw-token item or an unapproved sensitive item makes the build fail, so the passport
+/// is never minted), PERSISTS the object, links it by `passport_id`, and pushes the
+/// `passport_id` as the ref. The strengthened preflight gate then re-loads + re-gates +
+/// destination-checks THIS object. A build failure returns a `passport_blocked_*`
+/// outcome (the secret never persists).
+#[allow(clippy::too_many_arguments)]
 pub fn attach_context_passport_ref(
     db: &Db,
     mission_id: &str,
-    passport_ref: &str,
+    passport_id: &str,
+    work_item_id: Option<&str>,
+    destination_lane: friday_core::WorkLane,
+    destination_target: Option<&str>,
+    items: Vec<friday_core::PassportItem>,
+    approved_sensitive: bool,
     now_ms: i64,
 ) -> Result<MissionAttachmentOutcome, StorageError> {
-    if passport_ref.trim().is_empty() {
+    if passport_id.trim().is_empty() {
         return Ok(MissionAttachmentOutcome::blocked(
-            "context_passport_ref_required",
+            "context_passport_id_required",
         ));
     }
+
+    // Fail-closed by construction: a passport that would carry a secret / unapproved
+    // sensitive item cannot be built, so it is never persisted or linked.
+    let passport = match friday_core::build_context_passport(
+        passport_id.to_string(),
+        mission_id.to_string(),
+        work_item_id.map(|s| s.to_string()),
+        destination_lane,
+        destination_target.map(|s| s.to_string()),
+        items,
+        approved_sensitive,
+        now_ms,
+    ) {
+        Ok(p) => p,
+        Err(e) => {
+            return Ok(MissionAttachmentOutcome::blocked(format!(
+                "context_passport_blocked:{e}"
+            )));
+        }
+    };
 
     let outcome = attach_mission_link_ref(
         db,
         mission_id,
-        None,
+        work_item_id,
         MissionLinkKind::ContextPassport,
-        passport_ref.to_string(),
-        Some(passport_ref.to_string()),
+        format!("friday://context-passport/{passport_id}"),
+        Some(passport_id.to_string()),
         now_ms,
     )?;
     if matches!(
@@ -332,7 +373,9 @@ pub fn attach_context_passport_ref(
         let Some(mut mission) = db.get_mission(mission_id)? else {
             return Ok(MissionAttachmentOutcome::blocked("unknown_mission"));
         };
-        push_unique(&mut mission.context_passport_refs, passport_ref.to_string());
+        // Persist the gated object, then record its id as the ref the gate resolves.
+        db.upsert_context_passport(&passport)?;
+        push_unique(&mut mission.context_passport_refs, passport_id.to_string());
         mission.updated_at_ms = now_ms;
         db.upsert_mission(&mission)?;
     }
@@ -525,12 +568,45 @@ fn validate_preflight_request(request: &MissionPreflightRequest) -> Vec<String> 
             request.work_item.approval_state.as_str()
         ));
     }
-    if requires_context_passport(request.work_item.lane, request.includes_sensitive_context)
-        && request.mission.context_passport_refs.is_empty()
-    {
-        blockers.push("context_passport_required_before_sensitive_external_transfer".into());
-    }
+    // NOTE: the Context Passport check is NO LONGER a pure ref-presence test (that was
+    // the hollow gate — a non-empty refs list of any string satisfied it). It now LOADS
+    // the referenced passport object(s) and requires one that re-clears the transfer
+    // gate AND authorizes THIS destination, which needs `db` — so it lives in the
+    // db-backed `context_passport_blocker` called from `preflight_and_stage_work_item`,
+    // appended to the SAME blockers vec (collect-all-then-block semantics preserved).
     blockers
+}
+
+/// The strengthened, destination-binding Context Passport gate (replaces the hollow
+/// ref-presence check). When a sensitive external transfer requires a passport, this
+/// LOADS the Mission's referenced passport objects and requires one that BOTH (a)
+/// rebuilds-and-re-gates via `build_context_passport` on load — a tampered/secret row
+/// fails to load, fail-closed — AND (b) `authorizes_transfer(work_item.lane, target)`
+/// for THIS destination. Returns the identical blocker string the hollow check used
+/// (so existing negative assertions are unchanged) when no authorizing passport is
+/// found, else `None`.
+fn context_passport_blocker(
+    db: &Db,
+    request: &MissionPreflightRequest,
+) -> Result<Option<String>, StorageError> {
+    if !requires_context_passport(request.work_item.lane, request.includes_sensitive_context) {
+        return Ok(None);
+    }
+    let lane = request.work_item.lane;
+    let target = request.work_item.target_provider_or_agent.as_deref();
+    for passport_id in &request.mission.context_passport_refs {
+        // A row that does not rebuild-and-re-gate surfaces a load error; treat ANY
+        // non-authorizing / unloadable ref as "not satisfied" and keep scanning. The
+        // gate only passes on a passport that loaded cleanly AND authorizes this hop.
+        if let Ok(Some(passport)) = db.get_context_passport(passport_id) {
+            if passport.authorizes_transfer(lane, target) {
+                return Ok(None);
+            }
+        }
+    }
+    Ok(Some(
+        "context_passport_required_before_sensitive_external_transfer".into(),
+    ))
 }
 
 fn bind_surface_to_existing_mission(
@@ -1067,6 +1143,48 @@ mod tests {
         ));
         assert_eq!(db.count("work_item").unwrap(), 0);
 
+        // A BOGUS ref (a string the gate cannot resolve to a real authorizing passport)
+        // must NOT satisfy the strengthened gate — this is the hollow bug being closed.
+        let still_blocked = preflight_and_stage_work_item(
+            &db,
+            request(
+                "mission-ctx",
+                "work-ctx",
+                "handoff sensitive context",
+                WorkLane::Codex,
+                vec!["ctxp://not-a-real-passport".into()],
+                true,
+                2,
+            ),
+        )
+        .unwrap();
+        assert!(matches!(
+            still_blocked,
+            MissionPreflightOutcome::Blocked { blockers, .. }
+                if blockers.contains(&"context_passport_required_before_sensitive_external_transfer".to_string())
+        ));
+        assert_eq!(db.count("work_item").unwrap(), 0);
+
+        // Mint a REAL passport bound to the destination (Codex/codex), then stage: the
+        // gate loads + re-gates + destination-checks the object and passes.
+        let passport = friday_core::build_context_passport(
+            "passport-ctx",
+            "mission-ctx",
+            Some("work-ctx".to_string()),
+            WorkLane::Codex,
+            Some("codex".to_string()),
+            vec![friday_core::PassportItem {
+                kind: friday_core::PassportItemKind::Summary,
+                label: "handoff summary".into(),
+                included: true,
+                sensitive: true,
+            }],
+            true, // sensitive item explicitly approved
+            2,
+        )
+        .unwrap();
+        db.upsert_context_passport(&passport).unwrap();
+
         let ready = preflight_and_stage_work_item(
             &db,
             request(
@@ -1074,9 +1192,9 @@ mod tests {
                 "work-ctx",
                 "handoff sensitive context",
                 WorkLane::Codex,
-                vec!["ctxp://approved-transfer".into()],
+                vec!["passport-ctx".into()],
                 true,
-                2,
+                3,
             ),
         )
         .unwrap();
@@ -1085,6 +1203,50 @@ mod tests {
             db.get_work_item("work-ctx").unwrap().unwrap().status,
             WorkItemStatus::ReadyToDispatch
         );
+    }
+
+    #[test]
+    fn passport_for_the_wrong_destination_fails_closed() {
+        let db = Db::open_hub(&tmp()).unwrap();
+        // Mint a passport bound to Claude, but request a transfer to Codex.
+        let passport = friday_core::build_context_passport(
+            "passport-claude",
+            "mission-dest",
+            None,
+            WorkLane::Claude,
+            None,
+            vec![friday_core::PassportItem {
+                kind: friday_core::PassportItemKind::Summary,
+                label: "claude-bound summary".into(),
+                included: true,
+                sensitive: false,
+            }],
+            false,
+            1,
+        )
+        .unwrap();
+        db.upsert_context_passport(&passport).unwrap();
+
+        // The Codex transfer cites the Claude passport — destination mismatch must block.
+        let blocked = preflight_and_stage_work_item(
+            &db,
+            request(
+                "mission-dest",
+                "work-dest",
+                "destination-mismatch transfer",
+                WorkLane::Codex,
+                vec!["passport-claude".into()],
+                true,
+                2,
+            ),
+        )
+        .unwrap();
+        assert!(matches!(
+            blocked,
+            MissionPreflightOutcome::Blocked { blockers, .. }
+                if blockers.contains(&"context_passport_required_before_sensitive_external_transfer".to_string())
+        ));
+        assert_eq!(db.count("work_item").unwrap(), 0);
     }
 
     #[test]
@@ -1590,14 +1752,32 @@ mod tests {
         .unwrap()
         .is_ready());
 
-        let passport =
-            attach_context_passport_ref(&db, "mission-proof", "ctxp://approved-share", 2).unwrap();
+        let passport = attach_context_passport_ref(
+            &db,
+            "mission-proof",
+            "passport-share",
+            None,
+            WorkLane::FridayHub,
+            None,
+            vec![friday_core::PassportItem {
+                kind: friday_core::PassportItemKind::Summary,
+                label: "approved share".into(),
+                included: true,
+                sensitive: false,
+            }],
+            false,
+            2,
+        )
+        .unwrap();
         assert!(matches!(
             passport,
             MissionAttachmentOutcome::MissionLinked { .. }
         ));
+        // The ref pushed is now the passport_id (resolving to the persisted object),
+        // and the object itself is retrievable + re-gates on load.
         let mission = db.get_mission("mission-proof").unwrap().unwrap();
-        assert_eq!(mission.context_passport_refs, vec!["ctxp://approved-share"]);
+        assert_eq!(mission.context_passport_refs, vec!["passport-share"]);
+        assert!(db.get_context_passport("passport-share").unwrap().is_some());
 
         let proof = attach_proof_receipt_ref(
             &db,

--- a/rust-core/crates/friday-storage/src/lib.rs
+++ b/rust-core/crates/friday-storage/src/lib.rs
@@ -33,6 +33,7 @@ pub mod schedule;
 mod schema;
 pub mod session_lifecycle;
 pub mod system_intent;
+pub mod trust_grant;
 pub mod workflow;
 pub mod workflow_catalog;
 pub mod workflow_def;
@@ -66,6 +67,10 @@ pub use run_result::{
 };
 pub use schema::{hub_migrations, phone_migrations, HUB_ONLY_TABLES, PHONE_ONLY_TABLES};
 pub use session_lifecycle::{sweep_lifecycle, SweepOutcome};
+pub use trust_grant::{
+    active_grant, authorize_agent_action, grant_trust, latest_grant_any_state, revoke_trust,
+    AgentActionContext,
+};
 
 use friday_core::{
     ActivityState, ActivityType, ContextPassport, DeviceIdentity, FridayConversation,

--- a/rust-core/crates/friday-storage/src/lib.rs
+++ b/rust-core/crates/friday-storage/src/lib.rs
@@ -684,6 +684,30 @@ impl Db {
         mission::get_work_item(&self.conn, work_item_id)
     }
 
+    #[allow(clippy::too_many_arguments)]
+    pub fn transition_work_item_status(
+        &self,
+        work_item_id: &str,
+        next_status: friday_core::WorkItemStatus,
+        actor_ref: &str,
+        reason: &str,
+        proof_receipt: Option<&str>,
+        now_ms: i64,
+    ) -> Result<(WorkItem, friday_core::WorkItemStatus)> {
+        if self.profile != Profile::Hub {
+            return Err(StorageError::Unsupported("WorkItems are Hub-only".into()));
+        }
+        mission::transition_work_item_status(
+            &self.conn,
+            work_item_id,
+            next_status,
+            actor_ref,
+            reason,
+            proof_receipt,
+            now_ms,
+        )
+    }
+
     pub fn list_work_items_for_mission(&self, mission_id: &str) -> Result<Vec<WorkItem>> {
         if self.profile != Profile::Hub {
             return Err(StorageError::Unsupported("WorkItems are Hub-only".into()));

--- a/rust-core/crates/friday-storage/src/lib.rs
+++ b/rust-core/crates/friday-storage/src/lib.rs
@@ -23,6 +23,7 @@ mod migrate;
 pub mod mission;
 pub mod offline;
 pub mod pairing;
+pub mod passport;
 pub mod pending_request;
 pub mod process_registry;
 pub mod provider_session;
@@ -48,6 +49,7 @@ pub use error::{Result, StorageError};
 pub use migrate::{
     apply_migrations, current_version, now_ms, Migration, MigrationFn, MigrationReport,
 };
+pub use passport::{get_context_passport, list_for_mission, upsert_context_passport};
 pub use pending_request::{
     get_pending_request, list_pending_requests_for_run, persist_pending_request,
     set_pending_status, PendingApprovalRequest,
@@ -66,10 +68,11 @@ pub use schema::{hub_migrations, phone_migrations, HUB_ONLY_TABLES, PHONE_ONLY_T
 pub use session_lifecycle::{sweep_lifecycle, SweepOutcome};
 
 use friday_core::{
-    ActivityState, ActivityType, DeviceIdentity, FridayConversation, FridayPairPayload,
-    LedgerEntry, Mission, MissionLink, MissionSurfaceProjection, ProviderSessionEvent,
-    ProviderSessionLink, ProviderSessionProjection, RouteDecisionCard, RouteDecisionProjection,
-    SessionState, SurfaceEvent, SurfaceThread, TrustedDeviceProjection, WorkItem,
+    ActivityState, ActivityType, ContextPassport, DeviceIdentity, FridayConversation,
+    FridayPairPayload, LedgerEntry, Mission, MissionLink, MissionSurfaceProjection,
+    ProviderSessionEvent, ProviderSessionLink, ProviderSessionProjection, RouteDecisionCard,
+    RouteDecisionProjection, SessionState, SurfaceEvent, SurfaceThread, TrustedDeviceProjection,
+    WorkItem,
 };
 use friday_core::{ProcessLease, ProcessObservation, WorkspaceClaim};
 use rusqlite::{Connection, ErrorCode, OpenFlags};
@@ -727,6 +730,36 @@ impl Db {
             return Err(StorageError::Unsupported("WorkItems are Hub-only".into()));
         }
         mission::find_duplicate_work_item(&self.conn, candidate)
+    }
+
+    pub fn upsert_context_passport(&self, passport: &ContextPassport) -> Result<()> {
+        if self.profile != Profile::Hub {
+            return Err(StorageError::Unsupported(
+                "Context Passports are Hub-only".into(),
+            ));
+        }
+        passport::upsert_context_passport(&self.conn, passport)
+    }
+
+    pub fn get_context_passport(&self, passport_id: &str) -> Result<Option<ContextPassport>> {
+        if self.profile != Profile::Hub {
+            return Err(StorageError::Unsupported(
+                "Context Passports are Hub-only".into(),
+            ));
+        }
+        passport::get_context_passport(&self.conn, passport_id)
+    }
+
+    pub fn list_context_passports_for_mission(
+        &self,
+        mission_id: &str,
+    ) -> Result<Vec<ContextPassport>> {
+        if self.profile != Profile::Hub {
+            return Err(StorageError::Unsupported(
+                "Context Passports are Hub-only".into(),
+            ));
+        }
+        passport::list_for_mission(&self.conn, mission_id)
     }
 
     pub fn upsert_surface_thread(&self, surface_thread: &SurfaceThread) -> Result<()> {

--- a/rust-core/crates/friday-storage/src/mission.rs
+++ b/rust-core/crates/friday-storage/src/mission.rs
@@ -630,6 +630,98 @@ pub fn transition_mission_status(
     Ok((mission, previous_status, conversation.active_mission_ids))
 }
 
+/// Transition a WorkItem's lifecycle status at the persistence boundary — the
+/// WorkItem parity of [`transition_mission_status`].
+///
+/// Enforces the domain's `try_transition` (an illegal hop is rejected here, not
+/// silently upserted), and REQUIRES a `proof_receipt` when the next status is
+/// `CompletedWithProof` — so "completed" can never be claimed without proof (the
+/// `completion_is_proven` invariant is true at write time, not just at validate
+/// time). The transition is recorded in the hash-chained audit ledger (a WorkItem
+/// has no `decision_path_summary` text field, so the lifecycle entry IS the audit
+/// row), and the loaded WorkItem is upserted — both inside ONE transaction (the
+/// audit-read and the state write are atomic, per the audit-ledger invariant). On
+/// `CompletedWithProof` the new receipt is appended to `proof_receipts` so the
+/// stored row satisfies [`WorkItem::completion_is_proven`].
+#[allow(clippy::too_many_arguments)]
+pub fn transition_work_item_status(
+    conn: &Connection,
+    work_item_id: &str,
+    next_status: WorkItemStatus,
+    actor_ref: &str,
+    reason: &str,
+    proof_receipt: Option<&str>,
+    now_ms: i64,
+) -> Result<(WorkItem, WorkItemStatus)> {
+    require_non_empty(work_item_id, "work_item_lifecycle.work_item_id")?;
+    require_non_empty(actor_ref, "work_item_lifecycle.actor_ref")?;
+    require_non_empty(reason, "work_item_lifecycle.reason")?;
+
+    // Fail-completion: a CompletedWithProof transition MUST carry a proof receipt, so
+    // a fake-ready completion is rejected at the persistence boundary (before any of
+    // the lower validate/upsert checks). A receipt presented for any OTHER target is
+    // rejected too — it would be silently dropped and misrepresent the transition.
+    match (next_status, proof_receipt) {
+        (WorkItemStatus::CompletedWithProof, None) => {
+            return Err(unsupported(
+                "work_item_lifecycle completed_with_proof requires a proof_receipt so completion is not fake-ready",
+            ));
+        }
+        (WorkItemStatus::CompletedWithProof, Some(receipt)) => {
+            require_non_empty(receipt, "work_item_lifecycle.proof_receipt")?;
+        }
+        (_, Some(_)) => {
+            return Err(unsupported(
+                "work_item_lifecycle proof_receipt is only valid for a completed_with_proof transition",
+            ));
+        }
+        (_, None) => {}
+    }
+
+    let mut item = get_work_item(conn, work_item_id)?.ok_or_else(|| {
+        unsupported(format!(
+            "work_item_lifecycle WorkItem '{work_item_id}' not found"
+        ))
+    })?;
+
+    let previous_status = item.status;
+    item.status = previous_status
+        .try_transition(next_status)
+        .map_err(|e| unsupported(e.to_string()))?;
+    item.updated_at_ms = now_ms;
+    if let Some(receipt) = proof_receipt {
+        let receipt = receipt.to_string();
+        if !item.proof_receipts.contains(&receipt) {
+            item.proof_receipts.push(receipt);
+        }
+    }
+
+    // One transaction: the lifecycle audit row (the hash-chain read + insert) and the
+    // upsert commit together, so a recorded transition always has a persisted state.
+    // The audit row IS the WorkItem's lifecycle entry — it carries actor, the
+    // from->to hop, and the reason (a WorkItem has no decision_path_summary column).
+    let tx = conn.unchecked_transaction()?;
+    let audit_id = format!("workitem_lifecycle:{work_item_id}:{now_ms}");
+    let action = format!(
+        "work_item.lifecycle:{}->{}:{}",
+        previous_status.as_str(),
+        item.status.as_str(),
+        reason
+    );
+    crate::audit::append_audit(
+        &tx,
+        &audit_id,
+        actor_ref,
+        &action,
+        Some(work_item_id),
+        now_ms,
+    )?;
+    upsert_work_item(&tx, &item)?;
+    tx.commit()?;
+
+    Ok((item, previous_status))
+}
+
 pub fn list_missions_for_conversation(
     conn: &Connection,
     friday_conversation_id: &str,

--- a/rust-core/crates/friday-storage/src/passport.rs
+++ b/rust-core/crates/friday-storage/src/passport.rs
@@ -1,0 +1,223 @@
+//! Context Passport persistence (Hub-only; loop closure commit 2).
+//!
+//! Persists the destination-bound [`ContextPassport`] object + its item set, and
+//! reloads it by REBUILDING through [`build_context_passport`] — so a stored row only
+//! becomes a usable passport if it RE-CLEARS the transfer gate. A directly-INSERTed
+//! secret/raw-token item (bypassing the typed `upsert`) therefore fails to rebuild and
+//! the loader returns the gate error / treats the passport as absent: the gate is
+//! never satisfied by trusting a raw DB row.
+//!
+//! `PassportItem` / `PassportItemKind` live in the FROZEN parallel memory lane
+//! (`friday-core::memory`), which is serde-free and has no string conversion for the
+//! kind. So the kind<->string map lives HERE (the storage boundary), not in core.
+
+use crate::error::{Result, StorageError};
+use friday_core::{
+    build_context_passport, ContextPassport, PassportItem, PassportItemKind, WorkLane,
+};
+use rusqlite::{params, Connection, OptionalExtension};
+
+fn unsupported(message: impl Into<String>) -> StorageError {
+    StorageError::Unsupported(message.into())
+}
+
+fn lane_as_str(lane: WorkLane) -> &'static str {
+    lane.as_str()
+}
+
+fn parse_lane(value: &str) -> Result<WorkLane> {
+    match value {
+        "friday_hub" => Ok(WorkLane::FridayHub),
+        "codex" => Ok(WorkLane::Codex),
+        "claude" => Ok(WorkLane::Claude),
+        "deepseek" => Ok(WorkLane::DeepSeek),
+        "workflow" => Ok(WorkLane::Workflow),
+        "channel" => Ok(WorkLane::Channel),
+        "human" => Ok(WorkLane::Human),
+        "future_api" => Ok(WorkLane::FutureApi),
+        other => Err(unsupported(format!("unknown work lane '{other}'"))),
+    }
+}
+
+fn kind_as_str(kind: PassportItemKind) -> &'static str {
+    match kind {
+        PassportItemKind::MemorySnippet => "memory_snippet",
+        PassportItemKind::Summary => "summary",
+        PassportItemKind::File => "file",
+        PassportItemKind::Screenshot => "screenshot",
+        PassportItemKind::Attachment => "attachment",
+        PassportItemKind::ProviderSecret => "provider_secret",
+        PassportItemKind::RawToken => "raw_token",
+    }
+}
+
+fn parse_kind(value: &str) -> Result<PassportItemKind> {
+    match value {
+        "memory_snippet" => Ok(PassportItemKind::MemorySnippet),
+        "summary" => Ok(PassportItemKind::Summary),
+        "file" => Ok(PassportItemKind::File),
+        "screenshot" => Ok(PassportItemKind::Screenshot),
+        "attachment" => Ok(PassportItemKind::Attachment),
+        "provider_secret" => Ok(PassportItemKind::ProviderSecret),
+        "raw_token" => Ok(PassportItemKind::RawToken),
+        other => Err(unsupported(format!("unknown passport item kind '{other}'"))),
+    }
+}
+
+/// Persist a built Context Passport + its item set in ONE transaction (parent +
+/// children commit together). The passport is ALREADY gated by construction (it is a
+/// [`ContextPassport`] value, which only `build_context_passport` produces), so the
+/// upsert does not re-gate — but the loader does, defending against a direct INSERT.
+pub fn upsert_context_passport(conn: &Connection, passport: &ContextPassport) -> Result<()> {
+    if passport.passport_id.trim().is_empty() {
+        return Err(unsupported(
+            "context_passport passport_id must not be empty",
+        ));
+    }
+    if passport.mission_id.trim().is_empty() {
+        return Err(unsupported("context_passport mission_id must not be empty"));
+    }
+    let tx = conn.unchecked_transaction()?;
+    tx.execute(
+        "INSERT INTO context_passport
+            (passport_id, mission_id, work_item_id, destination_lane, destination_target,
+             approved_sensitive, created_at_ms)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
+         ON CONFLICT(passport_id) DO UPDATE SET
+            mission_id = excluded.mission_id,
+            work_item_id = excluded.work_item_id,
+            destination_lane = excluded.destination_lane,
+            destination_target = excluded.destination_target,
+            approved_sensitive = excluded.approved_sensitive,
+            created_at_ms = excluded.created_at_ms",
+        params![
+            passport.passport_id,
+            passport.mission_id,
+            passport.work_item_id,
+            lane_as_str(passport.destination_lane),
+            passport.destination_target,
+            i64::from(passport.approved_sensitive),
+            passport.created_at_ms,
+        ],
+    )?;
+    // Replace the child item set wholesale (an upsert of the parent re-states all items).
+    tx.execute(
+        "DELETE FROM context_passport_item WHERE passport_id = ?1",
+        params![passport.passport_id],
+    )?;
+    for (seq, item) in passport.items.iter().enumerate() {
+        tx.execute(
+            "INSERT INTO context_passport_item
+                (passport_id, seq, kind, label, included, sensitive)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+            params![
+                passport.passport_id,
+                seq as i64,
+                kind_as_str(item.kind),
+                item.label,
+                i64::from(item.included),
+                i64::from(item.sensitive),
+            ],
+        )?;
+    }
+    tx.commit()?;
+    Ok(())
+}
+
+/// The raw (pre-rebuild) parent row of a Context Passport.
+struct ParentRow {
+    mission_id: String,
+    work_item_id: Option<String>,
+    lane: String,
+    target: Option<String>,
+    approved_sensitive: i64,
+    created_at_ms: i64,
+}
+
+/// Load a Context Passport BY REBUILDING through `build_context_passport`. A row whose
+/// item set no longer clears the transfer gate (e.g. a directly-INSERTed secret item)
+/// returns `Err(BlockedTransfer)` — it never silently becomes a usable passport. A
+/// missing parent row returns `Ok(None)`.
+pub fn get_context_passport(
+    conn: &Connection,
+    passport_id: &str,
+) -> Result<Option<ContextPassport>> {
+    let parent: Option<ParentRow> = conn
+        .query_row(
+            "SELECT mission_id, work_item_id, destination_lane, destination_target,
+                    approved_sensitive, created_at_ms
+             FROM context_passport WHERE passport_id = ?1",
+            params![passport_id],
+            |r| {
+                Ok(ParentRow {
+                    mission_id: r.get(0)?,
+                    work_item_id: r.get(1)?,
+                    lane: r.get(2)?,
+                    target: r.get(3)?,
+                    approved_sensitive: r.get(4)?,
+                    created_at_ms: r.get(5)?,
+                })
+            },
+        )
+        .optional()?;
+    let Some(parent) = parent else {
+        return Ok(None);
+    };
+
+    let mut stmt = conn.prepare(
+        "SELECT kind, label, included, sensitive
+         FROM context_passport_item WHERE passport_id = ?1 ORDER BY seq",
+    )?;
+    let rows = stmt.query_map(params![passport_id], |r| {
+        Ok((
+            r.get::<_, String>(0)?,
+            r.get::<_, String>(1)?,
+            r.get::<_, i64>(2)?,
+            r.get::<_, i64>(3)?,
+        ))
+    })?;
+    let mut items = Vec::new();
+    for row in rows {
+        let (kind, label, included, sensitive) = row?;
+        items.push(PassportItem {
+            kind: parse_kind(&kind)?,
+            label,
+            included: included != 0,
+            sensitive: sensitive != 0,
+        });
+    }
+
+    // REBUILD through the gated constructor: this re-runs `gate_transfer`, so a tampered
+    // row (secret content / unapproved sensitive) fails closed here.
+    let passport = build_context_passport(
+        passport_id.to_string(),
+        parent.mission_id,
+        parent.work_item_id,
+        parse_lane(&parent.lane)?,
+        parent.target,
+        items,
+        parent.approved_sensitive != 0,
+        parent.created_at_ms,
+    )
+    .map_err(|e| unsupported(e.to_string()))?;
+    Ok(Some(passport))
+}
+
+/// List the passports minted for a Mission, newest first. Each is rebuilt-and-re-gated
+/// (a tampered row surfaces its `BlockedTransfer` error rather than loading).
+pub fn list_for_mission(conn: &Connection, mission_id: &str) -> Result<Vec<ContextPassport>> {
+    let mut stmt = conn.prepare(
+        "SELECT passport_id FROM context_passport
+         WHERE mission_id = ?1 ORDER BY created_at_ms DESC, passport_id",
+    )?;
+    let ids: Vec<String> = stmt
+        .query_map(params![mission_id], |r| r.get::<_, String>(0))?
+        .collect::<rusqlite::Result<_>>()?;
+    let mut out = Vec::with_capacity(ids.len());
+    for id in ids {
+        if let Some(p) = get_context_passport(conn, &id)? {
+            out.push(p);
+        }
+    }
+    Ok(out)
+}

--- a/rust-core/crates/friday-storage/src/passport.rs
+++ b/rust-core/crates/friday-storage/src/passport.rs
@@ -46,7 +46,7 @@ fn kind_as_str(kind: PassportItemKind) -> &'static str {
         PassportItemKind::File => "file",
         PassportItemKind::Screenshot => "screenshot",
         PassportItemKind::Attachment => "attachment",
-        PassportItemKind::ProviderSecret => "provider_secret",
+        PassportItemKind::ProviderSecret => "provider_secret", // pragma: allowlist secret
         PassportItemKind::RawToken => "raw_token",
     }
 }

--- a/rust-core/crates/friday-storage/src/schema.rs
+++ b/rust-core/crates/friday-storage/src/schema.rs
@@ -123,6 +123,19 @@ pub const HUB_ONLY_TABLES: &[&str] = &[
     // step already persisted as evidence; the key is a digest, never raw approval/mint
     // material. Nothing reads/writes it in production (DARK).
     "workflow_step_effect",
+    // Loop closure (v30): the Context Passport OBJECT store — the destination-bound
+    // carrier the Hub preflight checks before a sensitive external transfer (replacing
+    // the hollow ref-presence check). The parent `context_passport` row binds a built
+    // passport to its destination lane/target; `context_passport_item` is the child item
+    // set (one row per included/excluded item) kept in a separate table so the parent
+    // memory-lane `PassportItem` type stays serde-free / untouched. Hub-only: the
+    // passport mediates a transfer OUT of the Hub and is created only where the Hub
+    // preflight runs (never on a phone). Holds NO secret/key material BY CONSTRUCTION —
+    // `build_context_passport` runs `gate_transfer` so a never-transferable secret/token
+    // item can never be persisted; the stored item rows are non-secret labels/flags and
+    // the passport is rebuilt-and-re-gated on load, never trusted raw.
+    "context_passport",
+    "context_passport_item",
 ];
 
 /// Tables present only on a phone (never created on the Hub).
@@ -491,6 +504,20 @@ pub fn hub_migrations() -> Vec<Migration> {
             destructive: false,
             up: m0029_workflow_step_effect_idempotency,
         },
+        // Loop closure v30: TWO new Hub-only tables — `context_passport` (the built,
+        // destination-bound passport object) + its `context_passport_item` child set.
+        // This is the NEW-TABLE migration pattern (like m0026 system_intent / m0005
+        // agent_run), NOT an ALTER — so it touches no existing table and every pre-v30
+        // row/query is unaffected. The passport object is the destination binding the
+        // strengthened Hub preflight checks (replacing the hollow ref-presence gate);
+        // a row that does not rebuild-and-re-gate via `build_context_passport` on load
+        // fails closed (the gate treats it as absent).
+        Migration {
+            version: 30,
+            name: "context_passport",
+            destructive: false,
+            up: m0030_context_passport,
+        },
     ]
 }
 
@@ -687,6 +714,39 @@ CREATE TABLE workflow_step_effect (
     committed_at    INTEGER NOT NULL
 );
 CREATE INDEX idx_workflow_step_effect_run ON workflow_step_effect(run_id, seq);";
+
+// --- Loop closure v30: Context Passport object store (Hub-only) -------------
+
+// The built passport object + its item child set. `mission_id` / `work_item_id` are
+// PLAIN TEXT SOFT-LINKS (no FK, house style like `run_result.audit_ref`) so a passport
+// can be MINTED before its Mission/WorkItem row exists (the preflight gate mints, then
+// stages — the staging write is what the gate guards). `destination_lane` is the
+// `WorkLane::as_str` value; `destination_target` is the optional concrete provider/
+// agent/channel id. Items are stored as non-secret label/kind/flag rows (one per item):
+// `build_context_passport` ran `gate_transfer` BEFORE persist so a never-transferable
+// secret/token item can never reach this table, and the storage reader rebuilds-and-
+// re-gates through `build_context_passport` on load (a directly-INSERTed secret row
+// fails to rebuild => the gate treats the passport as absent => fail-closed).
+const DDL_CONTEXT_PASSPORT: &str = "
+CREATE TABLE context_passport (
+    passport_id        TEXT PRIMARY KEY,
+    mission_id         TEXT NOT NULL,
+    work_item_id       TEXT,
+    destination_lane   TEXT NOT NULL,
+    destination_target TEXT,
+    approved_sensitive INTEGER NOT NULL DEFAULT 0,
+    created_at_ms      INTEGER NOT NULL
+);
+CREATE INDEX idx_context_passport_mission ON context_passport(mission_id, created_at_ms);
+CREATE TABLE context_passport_item (
+    passport_id TEXT NOT NULL,
+    seq         INTEGER NOT NULL,
+    kind        TEXT NOT NULL,
+    label       TEXT NOT NULL,
+    included    INTEGER NOT NULL DEFAULT 1,
+    sensitive   INTEGER NOT NULL DEFAULT 0,
+    PRIMARY KEY (passport_id, seq)
+);";
 
 // --- PR-5 agent-loop fragments (Hub-only) -----------------------------------
 
@@ -2128,4 +2188,11 @@ fn m0028_agent_session_lifecycle(tx: &Transaction) -> rusqlite::Result<()> {
 /// or writes this table (DARK).
 fn m0029_workflow_step_effect_idempotency(tx: &Transaction) -> rusqlite::Result<()> {
     tx.execute_batch(DDL_WORKFLOW_STEP_EFFECT)
+}
+
+/// Loop closure v30: the two NEW Hub-only Context Passport tables
+/// (`DDL_CONTEXT_PASSPORT`). NEW-TABLE migration pattern (like m0029 / m0026), NOT an
+/// ALTER — touches no existing table, so every pre-v30 row and query is unaffected.
+fn m0030_context_passport(tx: &Transaction) -> rusqlite::Result<()> {
+    tx.execute_batch(DDL_CONTEXT_PASSPORT)
 }

--- a/rust-core/crates/friday-storage/src/schema.rs
+++ b/rust-core/crates/friday-storage/src/schema.rs
@@ -136,6 +136,14 @@ pub const HUB_ONLY_TABLES: &[&str] = &[
     // the passport is rebuilt-and-re-gated on load, never trusted raw.
     "context_passport",
     "context_passport_item",
+    // Loop closure (v31): the trust-grant baseline — a per-agent, revocable, expiring
+    // capability envelope (north-star doc 55 §4's boundaries). Hub-only: a grant is the
+    // Hub-coordinated authorization an agent acts within, and `authorize_agent_action`
+    // composes it AHEAD of the mutating-action gate (it can only ADD a restriction, never
+    // upgrade RequiresApproval). Holds NO secret/key material — the row is the agent id,
+    // lifecycle timestamps, and a JSON boundaries blob (path prefix / risk ceiling /
+    // allowlists; token/run ceilings are STORED but DEFERRED-not-enforced).
+    "trust_grant",
 ];
 
 /// Tables present only on a phone (never created on the Hub).
@@ -518,6 +526,17 @@ pub fn hub_migrations() -> Vec<Migration> {
             destructive: false,
             up: m0030_context_passport,
         },
+        // Loop closure v31: ONE new Hub-only table `trust_grant` — the per-agent
+        // capability envelope. NEW-TABLE pattern (like m0030 / m0029); touches no
+        // existing table, so every pre-v31 row/query is unaffected. The boundaries are a
+        // JSON TEXT blob; the partial-ish active-lookup index keys on the columns
+        // `active_grant` filters/orders by.
+        Migration {
+            version: 31,
+            name: "trust_grant",
+            destructive: false,
+            up: m0031_trust_grant,
+        },
     ]
 }
 
@@ -747,6 +766,25 @@ CREATE TABLE context_passport_item (
     sensitive   INTEGER NOT NULL DEFAULT 0,
     PRIMARY KEY (passport_id, seq)
 );";
+
+// --- Loop closure v31: trust-grant baseline (Hub-only) ----------------------
+
+// The per-agent capability envelope. `boundaries` is a JSON blob (path prefix / risk
+// ceiling / token+run ceilings (DEFERRED) / the five allowlists). `revoked` /
+// `revoked_at` / `expires_at` drive the active-grant lifecycle; the index covers the
+// `active_grant(agent_id, now)` lookup (`revoked = 0 AND (expires_at IS NULL OR
+// expires_at > now) ORDER BY granted_at DESC`). Holds NO secret/key material.
+const DDL_TRUST_GRANT: &str = "
+CREATE TABLE trust_grant (
+    grant_id   TEXT PRIMARY KEY,
+    agent_id   TEXT NOT NULL,
+    granted_at INTEGER NOT NULL,
+    expires_at INTEGER,
+    revoked    INTEGER NOT NULL DEFAULT 0,
+    revoked_at INTEGER,
+    boundaries TEXT NOT NULL
+);
+CREATE INDEX idx_trust_grant_agent_active ON trust_grant(agent_id, revoked, expires_at);";
 
 // --- PR-5 agent-loop fragments (Hub-only) -----------------------------------
 
@@ -2195,4 +2233,11 @@ fn m0029_workflow_step_effect_idempotency(tx: &Transaction) -> rusqlite::Result<
 /// ALTER — touches no existing table, so every pre-v30 row and query is unaffected.
 fn m0030_context_passport(tx: &Transaction) -> rusqlite::Result<()> {
     tx.execute_batch(DDL_CONTEXT_PASSPORT)
+}
+
+/// Loop closure v31: the NEW Hub-only `trust_grant` table (`DDL_TRUST_GRANT`).
+/// NEW-TABLE migration pattern; touches no existing table, so every pre-v31 row and
+/// query is unaffected.
+fn m0031_trust_grant(tx: &Transaction) -> rusqlite::Result<()> {
+    tx.execute_batch(DDL_TRUST_GRANT)
 }

--- a/rust-core/crates/friday-storage/src/trust_grant.rs
+++ b/rust-core/crates/friday-storage/src/trust_grant.rs
@@ -1,0 +1,376 @@
+//! Trust-grant persistence + the restrictive agent-action compose (loop closure
+//! commit 3; Hub-only).
+//!
+//! Persists a [`TrustGrant`] (issue/revoke, each in ONE transaction with a
+//! hash-chained audit row) and looks up the active grant for an agent. The composing
+//! [`authorize_agent_action`] is the KEY correctness surface: it AND-gates the trust
+//! grant with the existing mutating-action gate, and is RESTRICTIVE-ONLY — a grant
+//! `Allow` means "no trust objection", never an upgrade, so a mutating action that the
+//! gate would make `RequiresApproval` STAYS `RequiresApproval`.
+//!
+//! Boundaries are stored as a JSON TEXT blob. `friday-core` is serde-free (its domain
+//! types use manual `as_str`), so the `TrustBoundaries` <-> JSON map lives HERE (the
+//! storage boundary), hand-built with `serde_json`.
+//!
+//! DEFERRED (honest): `token_ceiling` / `max_runs` are STORED but NOT enforced (no live
+//! ledger/run-state counter — no fake counter). Nothing in production CALLS
+//! `authorize_agent_action` yet (the runtime call-site wiring is a deferred AC).
+
+use crate::error::{Result, StorageError};
+use friday_core::gate::{
+    self, CanonicalApproval, GateDecision, GateEvidenceRecord, MutatingActionRequest,
+};
+use friday_core::{check_grant, GrantCheck, Risk, TrustBoundaries, TrustGrant};
+use rusqlite::{params, Connection, OptionalExtension};
+use serde_json::{json, Value};
+
+fn unsupported(message: impl Into<String>) -> StorageError {
+    StorageError::Unsupported(message.into())
+}
+
+fn risk_as_str(risk: Risk) -> &'static str {
+    risk.as_str()
+}
+
+fn parse_risk(value: &str) -> Result<Risk> {
+    match value {
+        "read_only" => Ok(Risk::ReadOnly),
+        "low" => Ok(Risk::Low),
+        "medium" => Ok(Risk::Medium),
+        "high" => Ok(Risk::High),
+        "critical" => Ok(Risk::Critical),
+        other => Err(unsupported(format!("unknown risk '{other}'"))),
+    }
+}
+
+fn encode_boundaries(b: &TrustBoundaries) -> Result<String> {
+    let v = json!({
+        "workspace": b.workspace,
+        "risk_ceiling": risk_as_str(b.risk_ceiling),
+        "token_ceiling": b.token_ceiling,
+        "max_runs": b.max_runs,
+        "allowed_channels": b.allowed_channels,
+        "allowed_providers": b.allowed_providers,
+        "allowed_tools": b.allowed_tools,
+        "allowed_workflow_families": b.allowed_workflow_families,
+        "allowed_skill_families": b.allowed_skill_families,
+    });
+    serde_json::to_string(&v).map_err(|e| unsupported(format!("encode boundaries: {e}")))
+}
+
+fn decode_string_vec(v: &Value, field: &str) -> Result<Vec<String>> {
+    match v {
+        Value::Array(items) => items
+            .iter()
+            .map(|i| {
+                i.as_str()
+                    .map(str::to_string)
+                    .ok_or_else(|| unsupported(format!("{field} entry not a string")))
+            })
+            .collect(),
+        Value::Null => Ok(Vec::new()),
+        _ => Err(unsupported(format!("{field} not an array"))),
+    }
+}
+
+fn decode_opt_i64(v: &Value, field: &str) -> Result<Option<i64>> {
+    match v {
+        Value::Null => Ok(None),
+        Value::Number(n) => n
+            .as_i64()
+            .map(Some)
+            .ok_or_else(|| unsupported(format!("{field} not an i64"))),
+        _ => Err(unsupported(format!("{field} not a number/null"))),
+    }
+}
+
+fn decode_opt_string(v: &Value, field: &str) -> Result<Option<String>> {
+    match v {
+        Value::Null => Ok(None),
+        Value::String(s) => Ok(Some(s.clone())),
+        _ => Err(unsupported(format!("{field} not a string/null"))),
+    }
+}
+
+fn decode_boundaries(blob: &str) -> Result<TrustBoundaries> {
+    let v: Value =
+        serde_json::from_str(blob).map_err(|e| unsupported(format!("decode boundaries: {e}")))?;
+    let risk_ceiling = v
+        .get("risk_ceiling")
+        .and_then(Value::as_str)
+        .ok_or_else(|| unsupported("boundaries.risk_ceiling missing"))?;
+    Ok(TrustBoundaries {
+        workspace: decode_opt_string(v.get("workspace").unwrap_or(&Value::Null), "workspace")?,
+        risk_ceiling: parse_risk(risk_ceiling)?,
+        token_ceiling: decode_opt_i64(
+            v.get("token_ceiling").unwrap_or(&Value::Null),
+            "token_ceiling",
+        )?,
+        max_runs: decode_opt_i64(v.get("max_runs").unwrap_or(&Value::Null), "max_runs")?,
+        allowed_channels: decode_string_vec(
+            v.get("allowed_channels").unwrap_or(&Value::Null),
+            "allowed_channels",
+        )?,
+        allowed_providers: decode_string_vec(
+            v.get("allowed_providers").unwrap_or(&Value::Null),
+            "allowed_providers",
+        )?,
+        allowed_tools: decode_string_vec(
+            v.get("allowed_tools").unwrap_or(&Value::Null),
+            "allowed_tools",
+        )?,
+        allowed_workflow_families: decode_string_vec(
+            v.get("allowed_workflow_families").unwrap_or(&Value::Null),
+            "allowed_workflow_families",
+        )?,
+        allowed_skill_families: decode_string_vec(
+            v.get("allowed_skill_families").unwrap_or(&Value::Null),
+            "allowed_skill_families",
+        )?,
+    })
+}
+
+/// Issue a trust grant. ONE transaction: the insert + the `trust.grant` audit row
+/// (payload_ref = grant_id) commit together so a granted authority always has its
+/// hash-chained receipt.
+pub fn grant_trust(conn: &Connection, grant: &TrustGrant, now_ms: i64) -> Result<()> {
+    if grant.grant_id.trim().is_empty() {
+        return Err(unsupported("trust_grant grant_id must not be empty"));
+    }
+    if grant.agent_id.trim().is_empty() {
+        return Err(unsupported("trust_grant agent_id must not be empty"));
+    }
+    let boundaries = encode_boundaries(&grant.boundaries)?;
+    let tx = conn.unchecked_transaction()?;
+    tx.execute(
+        "INSERT INTO trust_grant
+            (grant_id, agent_id, granted_at, expires_at, revoked, revoked_at, boundaries)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
+         ON CONFLICT(grant_id) DO UPDATE SET
+            agent_id = excluded.agent_id,
+            granted_at = excluded.granted_at,
+            expires_at = excluded.expires_at,
+            revoked = excluded.revoked,
+            revoked_at = excluded.revoked_at,
+            boundaries = excluded.boundaries",
+        params![
+            grant.grant_id,
+            grant.agent_id,
+            grant.granted_at,
+            grant.expires_at,
+            i64::from(grant.revoked),
+            grant.revoked_at,
+            boundaries,
+        ],
+    )?;
+    crate::audit::append_audit(
+        &tx,
+        &format!("trust_grant:{}:{now_ms}", grant.grant_id),
+        &grant.agent_id,
+        "trust.grant",
+        Some(&grant.grant_id),
+        now_ms,
+    )?;
+    tx.commit()?;
+    Ok(())
+}
+
+/// Revoke a trust grant. ONE transaction: the `revoked = 1` update + the `trust.revoke`
+/// audit row commit together. Revoking a missing grant errors (fail-closed — there is
+/// no silent no-op that would look like a successful revoke).
+pub fn revoke_trust(conn: &Connection, grant_id: &str, now_ms: i64) -> Result<()> {
+    if grant_id.trim().is_empty() {
+        return Err(unsupported("trust_grant grant_id must not be empty"));
+    }
+    let agent_id: Option<String> = conn
+        .query_row(
+            "SELECT agent_id FROM trust_grant WHERE grant_id = ?1",
+            params![grant_id],
+            |r| r.get(0),
+        )
+        .optional()?;
+    let Some(agent_id) = agent_id else {
+        return Err(unsupported(format!(
+            "trust_grant '{grant_id}' not found for revoke"
+        )));
+    };
+    let tx = conn.unchecked_transaction()?;
+    tx.execute(
+        "UPDATE trust_grant SET revoked = 1, revoked_at = ?2 WHERE grant_id = ?1",
+        params![grant_id, now_ms],
+    )?;
+    crate::audit::append_audit(
+        &tx,
+        &format!("trust_revoke:{grant_id}:{now_ms}"),
+        &agent_id,
+        "trust.revoke",
+        Some(grant_id),
+        now_ms,
+    )?;
+    tx.commit()?;
+    Ok(())
+}
+
+/// The raw `trust_grant` row (pre-boundaries-decode).
+struct GrantRow {
+    grant_id: String,
+    granted_at: i64,
+    expires_at: Option<i64>,
+    revoked: i64,
+    revoked_at: Option<i64>,
+    boundaries: String,
+}
+
+fn row_to_grant(agent_id: &str, row: GrantRow) -> Result<TrustGrant> {
+    Ok(TrustGrant {
+        grant_id: row.grant_id,
+        agent_id: agent_id.to_string(),
+        granted_at: row.granted_at,
+        expires_at: row.expires_at,
+        revoked: row.revoked != 0,
+        revoked_at: row.revoked_at,
+        boundaries: decode_boundaries(&row.boundaries)?,
+    })
+}
+
+fn read_grant_row(r: &rusqlite::Row<'_>) -> rusqlite::Result<GrantRow> {
+    Ok(GrantRow {
+        grant_id: r.get(0)?,
+        granted_at: r.get(1)?,
+        expires_at: r.get(2)?,
+        revoked: r.get(3)?,
+        revoked_at: r.get(4)?,
+        boundaries: r.get(5)?,
+    })
+}
+
+/// The newest currently-active grant for `agent_id` (`revoked = 0` AND not expired at
+/// `now`), or `None`. A `None` is the caller's signal to fail closed (no active grant
+/// => no agent authority).
+pub fn active_grant(conn: &Connection, agent_id: &str, now: i64) -> Result<Option<TrustGrant>> {
+    let row: Option<GrantRow> = conn
+        .query_row(
+            "SELECT grant_id, granted_at, expires_at, revoked, revoked_at, boundaries
+             FROM trust_grant
+             WHERE agent_id = ?1 AND revoked = 0 AND (expires_at IS NULL OR expires_at > ?2)
+             ORDER BY granted_at DESC LIMIT 1",
+            params![agent_id, now],
+            read_grant_row,
+        )
+        .optional()?;
+    row.map(|row| row_to_grant(agent_id, row)).transpose()
+}
+
+/// The newest grant for `agent_id` regardless of revoked/expired state, or `None` when
+/// the agent has NO grant row at all. Used by `authorize_agent_action` to distinguish a
+/// REVOKED/EXPIRED authority (a meaningful audit signal — `check_grant` then reports
+/// `trust_grant_revoked` / `trust_grant_expired`) from one that was NEVER granted
+/// (`trust_no_active_grant`).
+pub fn latest_grant_any_state(conn: &Connection, agent_id: &str) -> Result<Option<TrustGrant>> {
+    let row: Option<GrantRow> = conn
+        .query_row(
+            "SELECT grant_id, granted_at, expires_at, revoked, revoked_at, boundaries
+             FROM trust_grant
+             WHERE agent_id = ?1
+             ORDER BY granted_at DESC LIMIT 1",
+            params![agent_id],
+            read_grant_row,
+        )
+        .optional()?;
+    row.map(|row| row_to_grant(agent_id, row)).transpose()
+}
+
+/// The non-risk action dimensions for the trust check. `effective_risk` is NOT here —
+/// it is taken from the gate's derived `.risk` inside `authorize_agent_action` (never
+/// re-derived).
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct AgentActionContext {
+    pub agent_id: String,
+    pub workspace: Option<String>,
+    pub tool: Option<String>,
+    pub provider: Option<String>,
+    pub channel: Option<String>,
+    pub workflow_family: Option<String>,
+    pub skill_family: Option<String>,
+}
+
+/// Compose the trust grant with the mutating-action gate — RESTRICTIVE AND-gate (the
+/// KEY correctness surface). Order: (1) load the active grant; if NONE, distinguish a
+/// REVOKED/EXPIRED authority (run `check_grant` on the latest grant row so the audit
+/// reason is `trust_grant_revoked` / `trust_grant_expired`) from one that was NEVER
+/// granted (`trust_no_active_grant`) — both fail closed. (2) `gate::evaluate(request)`
+/// for the PUBLIC effective `.risk`. (3) a `check_grant` `Deny` short-circuits with the
+/// grant's reason. (4) grant OK => fall through to `authorize_mutating_action`
+/// UNCHANGED, which may still return `RequiresApproval`/`Deny`. A grant `Allow` NEVER
+/// upgrades `RequiresApproval` to `Allow`: step 4 never sees the grant decision, it just
+/// runs the existing gate compose.
+pub fn authorize_agent_action(
+    conn: &Connection,
+    request: &MutatingActionRequest,
+    ctx: &AgentActionContext,
+    approval: Option<&CanonicalApproval>,
+    secret: &[u8],
+    now: i64,
+) -> Result<GateEvidenceRecord> {
+    let denied = |reason: String, base: &GateEvidenceRecord| GateEvidenceRecord {
+        decision: GateDecision::Deny,
+        reason,
+        risk: base.risk,
+        approval_required: base.approval_required,
+        denied_by: Some("trust_grant".to_string()),
+    };
+
+    // (1) No ACTIVE grant => deny (fail-closed). But surface WHY: a latest grant that is
+    // revoked/expired reports its own `check_grant` reason (the operator-meaningful
+    // "authority revoked/expired" signal); only a total absence of any grant row reports
+    // `trust_no_active_grant`. An agent with no authority acts on nothing either way.
+    let Some(grant) = active_grant(conn, &ctx.agent_id, now)? else {
+        let base = gate::evaluate(request);
+        return match latest_grant_any_state(conn, &ctx.agent_id)? {
+            Some(stale) => {
+                let check = grant_check(ctx, now, base.risk);
+                let (_decision, reason) = check_grant(&stale, &check);
+                // The stale grant is revoked or expired (active_grant excluded it), so
+                // `check_grant` denies with that reason; defend with a fallback label if a
+                // future state ever slips through.
+                let reason = if reason == "trust_grant_within_boundaries" {
+                    "trust_no_active_grant"
+                } else {
+                    reason
+                };
+                Ok(denied(reason.to_string(), &base))
+            }
+            None => Ok(denied("trust_no_active_grant".to_string(), &base)),
+        };
+    };
+
+    // (2) The gate's derived effective risk is the trust check's risk input.
+    let base = gate::evaluate(request);
+    let check = grant_check(ctx, now, base.risk);
+
+    // (3) A trust deny short-circuits with the grant's reason.
+    let (decision, reason) = check_grant(&grant, &check);
+    if decision == GateDecision::Deny {
+        return Ok(denied(reason.to_string(), &base));
+    }
+
+    // (4) Grant OK ("no trust objection") => run the EXISTING mutating-action compose
+    // verbatim. It alone decides Allow/RequiresApproval/Deny — the grant cannot upgrade
+    // a RequiresApproval here (this branch never passes the grant decision down).
+    crate::authorize::authorize_mutating_action(conn, request, approval, secret, now)
+}
+
+/// Build the `GrantCheck` from the action context + the gate's derived effective risk.
+fn grant_check(ctx: &AgentActionContext, now: i64, effective_risk: Risk) -> GrantCheck {
+    GrantCheck {
+        agent_id: ctx.agent_id.clone(),
+        now,
+        effective_risk,
+        workspace: ctx.workspace.clone(),
+        tool: ctx.tool.clone(),
+        provider: ctx.provider.clone(),
+        channel: ctx.channel.clone(),
+        workflow_family: ctx.workflow_family.clone(),
+        skill_family: ctx.skill_family.clone(),
+    }
+}

--- a/rust-core/crates/friday-storage/tests/context_passport.rs
+++ b/rust-core/crates/friday-storage/tests/context_passport.rs
@@ -1,0 +1,137 @@
+//! Context Passport persistence KATs (loop closure, commit 2; migration v30).
+//!
+//! Proves the v30 tables are Hub-only + forward-migrated, a built passport
+//! round-trips through persist/reload, and — the load-time fail-closed invariant —
+//! a directly-INSERTed secret/raw-token item makes the reload REBUILD fail (the
+//! stored row is never silently trusted as a usable passport). Real SQLite, no creds.
+
+mod common;
+
+use common::temp_db_path;
+use friday_core::{
+    build_context_passport, ContextPassport, PassportItem, PassportItemKind, WorkLane,
+};
+use friday_storage::{hub_migrations, Db, Profile, StorageError, HUB_ONLY_TABLES};
+
+fn hub_max_version() -> i64 {
+    hub_migrations().iter().map(|m| m.version).max().unwrap()
+}
+
+fn item(kind: PassportItemKind, label: &str, included: bool, sensitive: bool) -> PassportItem {
+    PassportItem {
+        kind,
+        label: label.into(),
+        included,
+        sensitive,
+    }
+}
+
+fn ok_passport(id: &str) -> ContextPassport {
+    build_context_passport(
+        id,
+        "mission-cp",
+        Some("work-cp".to_string()),
+        WorkLane::Codex,
+        Some("codex".to_string()),
+        vec![
+            item(PassportItemKind::Summary, "weekly plan", true, false),
+            item(PassportItemKind::File, "design.md", false, false),
+        ],
+        false,
+        100,
+    )
+    .unwrap()
+}
+
+#[test]
+fn v30_tables_are_hub_only_and_forward_migrated() {
+    for table in ["context_passport", "context_passport_item"] {
+        assert!(HUB_ONLY_TABLES.contains(&table));
+    }
+
+    let p = temp_db_path("context-passport-mig");
+    {
+        let mut migs = hub_migrations();
+        migs.retain(|m| m.version <= 29);
+        let db = Db::open(&p, Profile::Hub, &migs, "v29").unwrap();
+        assert_eq!(db.version().unwrap(), 29);
+        for t in ["context_passport", "context_passport_item"] {
+            assert!(
+                db.conn()
+                    .prepare(&format!("SELECT 1 FROM {t} LIMIT 1"))
+                    .is_err(),
+                "table {t} must not exist before v30"
+            );
+        }
+    }
+    // Reopen with the full set -> forward-migrate to v30 (the two additive CREATE TABLEs).
+    let db = Db::open_hub(&p).unwrap();
+    assert_eq!(db.version().unwrap(), hub_max_version());
+    for t in ["context_passport", "context_passport_item"] {
+        assert_eq!(
+            db.count(t).unwrap(),
+            0,
+            "new table {t} exists and starts empty"
+        );
+    }
+}
+
+#[test]
+fn passport_round_trips_through_persist_and_reload() {
+    let db = Db::open_hub(&temp_db_path("cp-roundtrip")).unwrap();
+    let passport = ok_passport("p-rt");
+    db.upsert_context_passport(&passport).unwrap();
+
+    let loaded = db.get_context_passport("p-rt").unwrap().unwrap();
+    assert_eq!(loaded.passport_id, "p-rt");
+    assert_eq!(loaded.mission_id, "mission-cp");
+    assert_eq!(loaded.work_item_id.as_deref(), Some("work-cp"));
+    assert_eq!(loaded.destination_lane, WorkLane::Codex);
+    assert_eq!(loaded.destination_target.as_deref(), Some("codex"));
+    assert_eq!(loaded.items.len(), 2);
+    // The destination binding survives the round-trip.
+    assert!(loaded.authorizes_transfer(WorkLane::Codex, Some("codex")));
+    assert!(!loaded.authorizes_transfer(WorkLane::Claude, Some("codex")));
+    // Only the included item is "shared".
+    assert_eq!(loaded.shared_items().len(), 1);
+
+    // list_for_mission surfaces it too.
+    let listed = db.list_context_passports_for_mission("mission-cp").unwrap();
+    assert_eq!(listed.len(), 1);
+    assert_eq!(listed[0].passport_id, "p-rt");
+
+    // A missing id is None (not an error).
+    assert!(db.get_context_passport("nope").unwrap().is_none());
+}
+
+#[test]
+fn a_directly_inserted_secret_item_fails_closed_on_reload() {
+    // The persist API can never store a secret item (build_context_passport gates it),
+    // so simulate a TAMPERED row by inserting the parent + a ProviderSecret child
+    // directly. The reload REBUILDS through build_context_passport, which re-runs
+    // gate_transfer and refuses — the stored row never becomes a usable passport.
+    let db = Db::open_hub(&temp_db_path("cp-tamper")).unwrap();
+    db.conn()
+        .execute(
+            "INSERT INTO context_passport
+                (passport_id, mission_id, work_item_id, destination_lane, destination_target,
+                 approved_sensitive, created_at_ms)
+             VALUES ('p-tamper', 'mission-cp', NULL, 'codex', 'codex', 1, 100)",
+            [],
+        )
+        .unwrap();
+    db.conn()
+        .execute(
+            "INSERT INTO context_passport_item
+                (passport_id, seq, kind, label, included, sensitive)
+             VALUES ('p-tamper', 0, 'provider_secret', 'leaked key', 1, 1)",
+            [],
+        )
+        .unwrap();
+
+    let err = db.get_context_passport("p-tamper").unwrap_err();
+    assert!(
+        matches!(err, StorageError::Unsupported(_)),
+        "a secret-bearing row must fail the rebuild gate on load, got {err:?}"
+    );
+}

--- a/rust-core/crates/friday-storage/tests/trust_grant.rs
+++ b/rust-core/crates/friday-storage/tests/trust_grant.rs
@@ -1,0 +1,287 @@
+//! Trust-grant baseline KATs (loop closure, commit 3; migration v31). Real SQLite.
+//!
+//! Proves the per-agent capability envelope and — the KEY correctness surface — that
+//! `authorize_agent_action` is a RESTRICTIVE AND-gate: it can only ADD a trust denial
+//! ahead of the existing mutating-action gate, and a grant `Allow` NEVER upgrades a
+//! `RequiresApproval` action to `Allow`. No creds.
+
+mod common;
+
+use common::temp_db_path;
+use friday_core::gate::{classify, Actor, ActorKind, GateDecision, MutatingActionRequest};
+use friday_core::{Risk, TrustBoundaries, TrustGrant};
+use friday_storage::{
+    active_grant, authorize_agent_action, grant_trust, revoke_trust, AgentActionContext, Db,
+};
+
+const SECRET: &[u8] = b"gate-signing-secret";
+
+fn req(action: &str, mutating: bool, base_risk: Risk) -> MutatingActionRequest {
+    MutatingActionRequest::from_classification(
+        classify(mutating, base_risk, action, &[]),
+        action.to_string(),
+        Actor {
+            kind: ActorKind::Agent,
+            id: "friday".to_string(),
+            principal_id: Some("p1".to_string()),
+        },
+        "system".to_string(),
+        vec![],
+        None,
+        Some("idem-1".to_string()),
+        None,
+    )
+}
+
+fn boundaries(tools: &[&str], risk_ceiling: Risk) -> TrustBoundaries {
+    TrustBoundaries {
+        workspace: None,
+        risk_ceiling,
+        token_ceiling: Some(1000), // STORED, DEFERRED-not-enforced
+        max_runs: Some(5),         // STORED, DEFERRED-not-enforced
+        allowed_channels: vec![],
+        allowed_providers: vec![],
+        allowed_tools: tools.iter().map(|s| s.to_string()).collect(),
+        allowed_workflow_families: vec![],
+        allowed_skill_families: vec![],
+    }
+}
+
+fn grant_for(tools: &[&str], risk_ceiling: Risk, expires_at: Option<i64>) -> TrustGrant {
+    TrustGrant {
+        grant_id: "g-friday".into(),
+        agent_id: "friday".into(),
+        granted_at: 1,
+        expires_at,
+        revoked: false,
+        revoked_at: None,
+        boundaries: boundaries(tools, risk_ceiling),
+    }
+}
+
+fn ctx(tool: &str) -> AgentActionContext {
+    AgentActionContext {
+        agent_id: "friday".into(),
+        workspace: None,
+        tool: Some(tool.into()),
+        provider: None,
+        channel: None,
+        workflow_family: None,
+        skill_family: None,
+    }
+}
+
+fn audit_count(db: &Db) -> i64 {
+    db.conn()
+        .query_row("SELECT count(*) FROM audit_ledger", [], |r| r.get(0))
+        .unwrap()
+}
+
+#[test]
+fn read_only_in_allowlist_within_risk_ceiling_allows() {
+    let db = Db::open_hub(&temp_db_path("trust-allow")).unwrap();
+    grant_trust(db.conn(), &grant_for(&["read_file"], Risk::Medium, None), 1).unwrap();
+
+    // read_file is a non-mutating, read-only action -> the gate Allows, and the grant
+    // permits the tool within the risk ceiling.
+    let r = authorize_agent_action(
+        db.conn(),
+        &req("read_file", false, Risk::ReadOnly),
+        &ctx("read_file"),
+        None,
+        SECRET,
+        100,
+    )
+    .unwrap();
+    assert_eq!(r.decision, GateDecision::Allow);
+}
+
+#[test]
+fn tool_not_in_allowlist_denies() {
+    let db = Db::open_hub(&temp_db_path("trust-tool")).unwrap();
+    grant_trust(db.conn(), &grant_for(&["read_file"], Risk::Medium, None), 1).unwrap();
+
+    let r = authorize_agent_action(
+        db.conn(),
+        &req("delete_file", true, Risk::Medium),
+        &ctx("delete_file"),
+        None,
+        SECRET,
+        100,
+    )
+    .unwrap();
+    assert_eq!(r.decision, GateDecision::Deny);
+    assert_eq!(r.reason, "trust_grant_tool_not_allowed");
+}
+
+#[test]
+fn grant_allow_never_upgrades_requires_approval() {
+    // THE invariant: a mutating action that the gate makes RequiresApproval, whose tool
+    // IS in the allowlist and whose risk is UNDER the ceiling, must STAY RequiresApproval
+    // (the grant is restrictive-only; no canonical approval presented).
+    let db = Db::open_hub(&temp_db_path("trust-no-upgrade")).unwrap();
+    grant_trust(
+        db.conn(),
+        &grant_for(&["write_file"], Risk::Medium, None),
+        1,
+    )
+    .unwrap();
+
+    let r = authorize_agent_action(
+        db.conn(),
+        &req("write_file", true, Risk::Medium), // mutating -> gate RequiresApproval
+        &ctx("write_file"),
+        None, // no approval
+        SECRET,
+        100,
+    )
+    .unwrap();
+    assert_eq!(
+        r.decision,
+        GateDecision::RequiresApproval,
+        "a grant Allow must NEVER upgrade RequiresApproval to Allow"
+    );
+}
+
+#[test]
+fn revoked_grant_denies_and_no_grant_denies() {
+    let db = Db::open_hub(&temp_db_path("trust-revoke")).unwrap();
+
+    // No grant at all -> fail closed.
+    let r = authorize_agent_action(
+        db.conn(),
+        &req("read_file", false, Risk::ReadOnly),
+        &ctx("read_file"),
+        None,
+        SECRET,
+        100,
+    )
+    .unwrap();
+    assert_eq!(r.decision, GateDecision::Deny);
+    assert_eq!(r.reason, "trust_no_active_grant");
+
+    // Grant then revoke -> revoked grant is not ACTIVE, but the compose DISTINGUISHES a
+    // revoked authority from a never-granted one: it reports trust_grant_revoked (the
+    // operator-meaningful "authority revoked" audit signal), NOT trust_no_active_grant.
+    grant_trust(db.conn(), &grant_for(&["read_file"], Risk::Medium, None), 1).unwrap();
+    revoke_trust(db.conn(), "g-friday", 50).unwrap();
+    assert!(active_grant(db.conn(), "friday", 100).unwrap().is_none());
+
+    let r = authorize_agent_action(
+        db.conn(),
+        &req("read_file", false, Risk::ReadOnly),
+        &ctx("read_file"),
+        None,
+        SECRET,
+        100,
+    )
+    .unwrap();
+    assert_eq!(r.decision, GateDecision::Deny);
+    assert_eq!(
+        r.reason, "trust_grant_revoked",
+        "a revoked authority must report trust_grant_revoked, not the never-granted reason"
+    );
+}
+
+#[test]
+fn expired_grant_reports_expired_reason_through_the_real_path() {
+    // The expired-authority audit distinction: an expired grant is not ACTIVE, but the
+    // compose reports trust_grant_expired (via check_grant on the latest grant row), not
+    // the never-granted reason.
+    let db = Db::open_hub(&temp_db_path("trust-expired-reason")).unwrap();
+    grant_trust(
+        db.conn(),
+        &grant_for(&["read_file"], Risk::Medium, Some(50)),
+        1,
+    )
+    .unwrap();
+
+    let r = authorize_agent_action(
+        db.conn(),
+        &req("read_file", false, Risk::ReadOnly),
+        &ctx("read_file"),
+        None,
+        SECRET,
+        100, // now >= expires_at(50)
+    )
+    .unwrap();
+    assert_eq!(r.decision, GateDecision::Deny);
+    assert_eq!(r.reason, "trust_grant_expired");
+}
+
+#[test]
+fn risk_over_ceiling_denies() {
+    let db = Db::open_hub(&temp_db_path("trust-risk")).unwrap();
+    // Ceiling is Low, but the action is a destructive run_command -> escalated to High.
+    grant_trust(db.conn(), &grant_for(&["run_command"], Risk::Low, None), 1).unwrap();
+
+    // A run_command whose base risk already exceeds the ceiling.
+    let r = authorize_agent_action(
+        db.conn(),
+        &req("run_command", true, Risk::High),
+        &ctx("run_command"),
+        None,
+        SECRET,
+        100,
+    )
+    .unwrap();
+    assert_eq!(r.decision, GateDecision::Deny);
+    assert_eq!(r.reason, "trust_grant_risk_over_ceiling");
+}
+
+#[test]
+fn expired_grant_denies() {
+    let db = Db::open_hub(&temp_db_path("trust-expired")).unwrap();
+    grant_trust(
+        db.conn(),
+        &grant_for(&["read_file"], Risk::Medium, Some(50)),
+        1,
+    )
+    .unwrap();
+
+    // active_grant excludes the expired grant -> no ACTIVE grant at now=100, and the
+    // compose denies (reporting the expired-authority reason via the latest-grant lookup).
+    assert!(active_grant(db.conn(), "friday", 100).unwrap().is_none());
+    let r = authorize_agent_action(
+        db.conn(),
+        &req("read_file", false, Risk::ReadOnly),
+        &ctx("read_file"),
+        None,
+        SECRET,
+        100,
+    )
+    .unwrap();
+    assert_eq!(r.decision, GateDecision::Deny);
+    assert_eq!(r.reason, "trust_grant_expired");
+}
+
+#[test]
+fn grant_then_revoke_writes_exactly_two_audit_rows_and_chain_verifies() {
+    let db = Db::open_hub(&temp_db_path("trust-audit")).unwrap();
+    assert_eq!(audit_count(&db), 0);
+
+    grant_trust(db.conn(), &grant_for(&["read_file"], Risk::Medium, None), 1).unwrap();
+    revoke_trust(db.conn(), "g-friday", 50).unwrap();
+
+    // Exactly two audit rows: trust.grant + trust.revoke.
+    assert_eq!(audit_count(&db), 2);
+    let actions: Vec<String> = {
+        let mut stmt = db
+            .conn()
+            .prepare("SELECT action FROM audit_ledger ORDER BY rowid")
+            .unwrap();
+        let rows = stmt
+            .query_map([], |r| r.get::<_, String>(0))
+            .unwrap()
+            .map(|r| r.unwrap())
+            .collect();
+        rows
+    };
+    assert_eq!(actions, vec!["trust.grant", "trust.revoke"]);
+
+    // The hash chain verifies (both rows appended inside their own tx).
+    assert_eq!(
+        friday_storage::audit::verify_audit_chain(db.conn()).unwrap(),
+        2
+    );
+}

--- a/rust-core/crates/friday-storage/tests/work_item_lifecycle.rs
+++ b/rust-core/crates/friday-storage/tests/work_item_lifecycle.rs
@@ -1,0 +1,231 @@
+//! WorkItem transition-primitive KATs (loop closure, commit 1).
+//!
+//! `transition_work_item_status` is the WorkItem parity of
+//! `transition_mission_status`: it enforces the domain's legal transition graph at
+//! the persistence boundary (an illegal hop errors instead of silently upserting),
+//! REQUIRES a proof_receipt for a `CompletedWithProof` transition (so completion can
+//! never be fake-claimed), and records the hop in the hash-chained audit ledger.
+//! Real SQLite; no creds.
+
+mod common;
+
+use common::temp_db_path;
+use friday_core::{
+    ApprovalState, FridayConversation, HandoffJudgmentMemory, Mission, MissionStatus, Risk,
+    TruthStatus, WorkItem, WorkItemStatus, WorkLane,
+};
+use friday_storage::{Db, StorageError};
+
+fn conversation() -> FridayConversation {
+    FridayConversation {
+        friday_conversation_id: "fconv_wi_lifecycle".into(),
+        owner_principal: "owner-1".into(),
+        title: "WorkItem lifecycle".into(),
+        current_focus_summary: "transition primitive".into(),
+        active_mission_ids: vec!["mission-wi".into()],
+        surface_thread_ids: Vec::new(),
+        memory_scope_ref: None,
+        truth_status: TruthStatus::WiredRegistry,
+        proof_refs: vec!["proof://wi".into()],
+        created_at_ms: 1,
+        updated_at_ms: 1,
+    }
+}
+
+fn mission() -> Mission {
+    Mission {
+        mission_id: "mission-wi".into(),
+        friday_conversation_id: "fconv_wi_lifecycle".into(),
+        title: "WorkItem lifecycle mission".into(),
+        intent: "exercise the WorkItem transition primitive".into(),
+        status: MissionStatus::Active,
+        why_now: "loop closure".into(),
+        decision_path_summary: "enforce transitions at persistence".into(),
+        considered_options: vec!["validate-only".into()],
+        deferred_options: vec!["ui".into()],
+        known_pitfalls: vec!["ack is not completion".into()],
+        handoff_inheritance: vec!["carry judgment".into()],
+        work_item_ids: vec!["work-wi".into()],
+        memory_candidate_refs: Vec::new(),
+        context_passport_refs: Vec::new(),
+        proof_refs: vec!["proof://wi".into()],
+        created_at_ms: 1,
+        updated_at_ms: 1,
+    }
+}
+
+fn judgment() -> HandoffJudgmentMemory {
+    HandoffJudgmentMemory {
+        task: "drive a WorkItem to completion".into(),
+        current_blocker: None,
+        target_lane_thread_agent_provider: "codex/backend".into(),
+        read_first_files: vec!["rust-core/crates/friday-storage/src/mission.rs".into()],
+        required_output: "transition KATs".into(),
+        done_criteria: vec!["legal chain advances".into()],
+        red_lines: vec!["no fake completion".into()],
+        why_this_route: "Hub owns lifecycle truth".into(),
+        considered_options: vec!["validate-only".into()],
+        deferred_options: vec!["native ui".into()],
+        previous_pitfalls: vec!["completed without proof".into()],
+        inheritable_context: vec!["proof receipts are the only completion evidence".into()],
+        proof_requirements: vec!["cargo test -p friday-storage work_item_lifecycle".into()],
+        ownership_claim_ids: vec!["own-wi".into()],
+    }
+}
+
+/// A read-only-shaped WorkItem (no workspace refs) so ownership is not required and
+/// the test focuses purely on the lifecycle transition rules.
+fn work_item(status: WorkItemStatus) -> WorkItem {
+    WorkItem {
+        work_item_id: "work-wi".into(),
+        mission_id: "mission-wi".into(),
+        lane: WorkLane::Codex,
+        target_provider_or_agent: Some("codex".into()),
+        status,
+        owner_claim_ids: Vec::new(),
+        workspace_refs: Vec::new(),
+        capability_id: Some("provider.codex.turn".into()),
+        risk_level: Risk::Medium,
+        approval_state: ApprovalState::NotRequired,
+        blocking_reason: None,
+        input_refs: vec!["input://handoff".into()],
+        output_refs: Vec::new(),
+        proof_requirements: vec!["provider completion receipt".into()],
+        proof_receipts: Vec::new(),
+        judgment_memory: judgment(),
+        created_at_ms: 1,
+        updated_at_ms: 1,
+    }
+}
+
+fn seed(db: &Db, status: WorkItemStatus) {
+    db.upsert_friday_conversation(&conversation()).unwrap();
+    db.upsert_mission(&mission()).unwrap();
+    db.upsert_work_item(&work_item(status)).unwrap();
+}
+
+#[test]
+fn legal_chain_advances_to_completed_with_proof() {
+    let db = Db::open_hub(&temp_db_path("wi-legal")).unwrap();
+    seed(&db, WorkItemStatus::Draft);
+
+    // Draft -> ReadyToDispatch -> Dispatched -> HubAccepted -> ProviderRouted ->
+    // ProviderWaiting -> CompletedWithProof. Each hop is a legal edge.
+    let chain = [
+        (WorkItemStatus::ReadyToDispatch, None),
+        (WorkItemStatus::Dispatched, None),
+        (WorkItemStatus::HubAccepted, None),
+        (WorkItemStatus::ProviderRouted, None),
+        (WorkItemStatus::ProviderWaiting, None),
+        (
+            WorkItemStatus::CompletedWithProof,
+            Some("proof://provider-completed"),
+        ),
+    ];
+    for (now, (next, receipt)) in (10..).zip(chain) {
+        let (item, _prev) = db
+            .transition_work_item_status("work-wi", next, "agent:friday", "advance", receipt, now)
+            .unwrap();
+        assert_eq!(item.status, next);
+    }
+
+    let stored = db.get_work_item("work-wi").unwrap().unwrap();
+    assert_eq!(stored.status, WorkItemStatus::CompletedWithProof);
+    assert!(
+        stored.completion_is_proven(),
+        "completed WorkItem carries the proof receipt"
+    );
+    assert!(stored
+        .proof_receipts
+        .contains(&"proof://provider-completed".to_string()));
+}
+
+#[test]
+fn illegal_hop_is_rejected_at_persistence_boundary() {
+    let db = Db::open_hub(&temp_db_path("wi-illegal")).unwrap();
+    seed(&db, WorkItemStatus::Draft);
+
+    // Draft -> Dispatched is NOT a legal edge (Draft can only go to PreflightBlocked /
+    // WaitingForUser / ReadyToDispatch / Merged).
+    let err = db
+        .transition_work_item_status(
+            "work-wi",
+            WorkItemStatus::Dispatched,
+            "agent:friday",
+            "skip the queue",
+            None,
+            10,
+        )
+        .unwrap_err();
+    assert!(matches!(err, StorageError::Unsupported(_)));
+
+    // The illegal hop persisted nothing: the WorkItem is still Draft.
+    assert_eq!(
+        db.get_work_item("work-wi").unwrap().unwrap().status,
+        WorkItemStatus::Draft
+    );
+}
+
+#[test]
+fn completed_with_proof_without_a_receipt_is_rejected() {
+    let db = Db::open_hub(&temp_db_path("wi-fake-done")).unwrap();
+    seed(&db, WorkItemStatus::ProviderWaiting);
+
+    // ProviderWaiting -> CompletedWithProof is a LEGAL edge, but completion without a
+    // proof receipt is a fake-ready completion and must be rejected.
+    let err = db
+        .transition_work_item_status(
+            "work-wi",
+            WorkItemStatus::CompletedWithProof,
+            "agent:friday",
+            "claim done",
+            None,
+            10,
+        )
+        .unwrap_err();
+    assert!(matches!(err, StorageError::Unsupported(_)));
+
+    // Nothing advanced: the WorkItem is still ProviderWaiting (not fake-completed).
+    let stored = db.get_work_item("work-wi").unwrap().unwrap();
+    assert_eq!(stored.status, WorkItemStatus::ProviderWaiting);
+    assert!(!stored.completion_is_proven());
+
+    // The SAME transition WITH a receipt now succeeds (proven completion).
+    let (item, prev) = db
+        .transition_work_item_status(
+            "work-wi",
+            WorkItemStatus::CompletedWithProof,
+            "agent:friday",
+            "claim done with proof",
+            Some("proof://real-receipt"),
+            11,
+        )
+        .unwrap();
+    assert_eq!(prev, WorkItemStatus::ProviderWaiting);
+    assert_eq!(item.status, WorkItemStatus::CompletedWithProof);
+    assert!(item.completion_is_proven());
+}
+
+#[test]
+fn proof_receipt_on_a_non_completion_transition_is_rejected() {
+    let db = Db::open_hub(&temp_db_path("wi-stray-receipt")).unwrap();
+    seed(&db, WorkItemStatus::Draft);
+
+    // A receipt presented for a non-completion hop would be silently dropped and
+    // misrepresent the transition — reject it.
+    let err = db
+        .transition_work_item_status(
+            "work-wi",
+            WorkItemStatus::ReadyToDispatch,
+            "agent:friday",
+            "advance with a stray receipt",
+            Some("proof://stray"),
+            10,
+        )
+        .unwrap_err();
+    assert!(matches!(err, StorageError::Unsupported(_)));
+    assert_eq!(
+        db.get_work_item("work-wi").unwrap().unwrap().status,
+        WorkItemStatus::Draft
+    );
+}


### PR DESCRIPTION
Three north-star loop-closure slices (one branch, sequential commits to keep migrations v30/v31 collision-free). All DARK + unit/KAT-validated, no creds/device. `gate.rs` + `memory.rs` UNTOUCHED (verified absent from diff).

## Commit 1 — WorkItem transition primitive (friday-storage/mission.rs)
`transition_work_item_status` (parity of `transition_mission_status`): enforces `try_transition` at the persistence boundary, REQUIRES a proof_receipt for CompletedWithProof (rejects fake-completion), rejects a stray receipt on a non-completion hop; audit + upsert in ONE transaction. 4 KATs.

## Commit 2 — Context-Passport object + NON-HOLLOW gate (migration v30)
Closes the HOLLOW gate at `mission_preflight.rs` (which only checked `refs.is_empty()` — any string passed, blind to destination/content). NEW `passport.rs`: `build_context_passport` runs `gate_transfer` INTERNALLY so a passport clearing a secret/unapproved-sensitive item **cannot be constructed** (fail-closed BY CONSTRUCTION); `authorizes_transfer(lane,target)` is the destination binding the hollow check couldn't see. NEW `context_passport`(+item) tables (v30, hub-only) + storage with **rebuild-on-load** (a directly-INSERTed secret row fails closed on reload — gate_transfer re-runs). Strengthened gate loads the passport + requires build-success AND destination-match. 3 KATs (incl wrong-destination + directly-inserted-secret-reload). memory.rs untouched.

## Commit 3 — Trust-grant baseline (migration v31)
NEW `trust.rs`: `TrustGrant` + `TrustBoundaries` (the 9 doc-55§4 boundaries) + `check_grant`. **Empty allowlist = DENY-ALL** for a checked dimension (per-dimension; an absent dimension isn't denied). NEW `trust_grant.rs` storage: grant/revoke each in ONE tx + `append_audit`; `active_grant` lookup. `authorize_agent_action` = **restrictive AND-gate**: no grant → Deny; check_grant Deny → short-circuit; Allow → falls through to `authorize_mutating_action` UNCHANGED — **a grant Allow NEVER upgrades RequiresApproval→Allow** (proven by KAT). 8 storage KATs + 10 pure units. (v31 trust_grant table, hub-only.)

## Commit 4 — workspace boundary hardening (no fail-open)
The workspace check used a raw `starts_with` (a `/work/friday` grant would FAIL OPEN on the sibling `/work/friday-secret`). Made boundary-aware (exact dir + `/work/friday/...` children only). + KAT.

## Validated (CI-exact, dark)
`cargo fmt --all -- --check` clean; `cargo clippy --workspace --all-targets -- -D warnings` clean; core passport/trust/mission + storage trust_grant/context_passport/work_item_lifecycle/mission_spine/migration/schema_profile + hub mission_preflight all pass; full workspace 1561+ pass (only failure = the pre-existing non-deterministic friday-anthropic loopback sandbox flake, not in this diff).

## Honest ceiling
All DARK. `authorize_agent_action` is fully tested but **nothing in production calls it** (the runtime.rs call-site wiring is the explicit DEFERRED AC — same posture as gate.rs's `evaluate`). Live passport-mint into a real dispatch, `token_ceiling`/`max_runs` enforcement (STORED only — no fake counter), grant-issuance authority + Trust Center UI = deferred/operator-UI-gated. **NOT v1-GO** — this is the north-star loop substrate, dark + unit-proven.

🤖 Generated with [Claude Code](https://claude.com/claude-code)