### PR TITLE
feat(ns-3): operator-CLI trust-grant issuance/revoke call-site

### DIFF
--- a/rust-core/Cargo.lock
+++ b/rust-core/Cargo.lock
@@ -712,6 +712,7 @@ version = "0.0.1"
 dependencies = [
  "friday-core",
  "friday-crypto",
+ "friday-storage",
  "serde",
  "serde_json",
  "thiserror 1.0.69",

--- a/rust-core/crates/friday-operator-cli/Cargo.toml
+++ b/rust-core/crates/friday-operator-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "friday-operator-cli"
-description = "Friday Rust Core — OFFLINE operator-signing CLI (slice S6c). Holds the operator's PRIVATE Ed25519 key and emits operator-signed CanonicalApprovals; the Hub holds ONLY the public verify key. Deliberately depends on just friday-core + friday-crypto (NOT the Hub's secret-bearing graph), so the operator tool is decoupled from the Hub at compile time. Not wired to a live resume (S6d). PROOF-ONLY."
+description = "Friday Rust Core — operator CLI. (1) OFFLINE operator-signing (slice S6c): holds the operator's PRIVATE Ed25519 key and emits operator-signed CanonicalApprovals (the Hub holds ONLY the public verify key); this half links just friday-core + friday-crypto. (2) NS-3 Hub-side trust-grant issuance/revoke: mints/revokes a TrustGrant in the Hub DB via friday_storage (the operator POLICY action that makes NS-2's enforce flag satisfiable); this half links friday-storage. Not wired to a live resume (S6d). PROOF-ONLY."
 edition.workspace = true
 version.workspace = true
 license.workspace = true
@@ -14,6 +14,11 @@ friday-core.workspace = true
 # OperatorSigningKey (S6a Ed25519 primitive). This crate is the OPERATOR side that
 # holds the PRIVATE key; the Hub holds only OperatorVerifyingKey.
 friday-crypto.workspace = true
+# NS-3: the Hub-side trust-grant issuance/revoke subcommand calls
+# friday_storage::grant_trust / revoke_trust against the Hub DB. This is the operator
+# POLICY action that mints a TrustGrant; it is what makes NS-2's (separate, default-OFF)
+# enforce flag ever satisfiable. The keygen/sign path stays storage-free.
+friday-storage.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true

--- a/rust-core/crates/friday-operator-cli/src/lib.rs
+++ b/rust-core/crates/friday-operator-cli/src/lib.rs
@@ -8,11 +8,28 @@
 //! can VERIFY an approval but can NEVER MINT one. This is the cryptographic half of
 //! the operator's hard rule "the agent must never self-approve."
 //!
-//! Scope: this crate adds the keygen + sign tool ONLY. It does NOT wire into the
-//! live gate/resume (that is S6d), does NOT edit `friday-core::gate` or
-//! `friday-storage` (S6b owns them), and does NOT decide key CUSTODY (who generates
-//! / holds the operator key for the S6e proof — a Directive-0d operator gate). It
-//! merely loads a key from a path and signs. No network. PROOF-ONLY; NOT v1 GO.
+//! Scope: the operator-signing half of this crate adds the keygen + sign tool ONLY.
+//! It does NOT wire into the live gate/resume (that is S6d), does NOT edit
+//! `friday-core::gate` or `friday-storage` (S6b owns them), and does NOT decide key
+//! CUSTODY (who generates / holds the operator key for the S6e proof — a Directive-0d
+//! operator gate). It merely loads a key from a path and signs. No network.
+//! PROOF-ONLY; NOT v1 GO.
+//!
+//! ## NS-3: Hub-side trust-grant issuance/revoke (the OTHER half — see [`trust_grant`])
+//!
+//! `friday_storage::grant_trust` / `revoke_trust` had ZERO callers — so an enforced
+//! trust check (NS-2, a separate PR, default-OFF) would deny EVERY mutating action
+//! closed (`trust_no_active_grant`) because no issuance path could ever mint a
+//! `TrustGrant`. NS-3 adds that issuance path as an OPERATOR POLICY action: the
+//! [`trust_grant`] module mints / revokes a `TrustGrant` for an `agent_id` with its
+//! boundaries (risk ceiling, workspace / tool / provider / channel / family scopes,
+//! expiry) by calling `friday_storage::grant_trust` / `revoke_trust` against the Hub DB.
+//!
+//! This half links `friday-storage` (the only reason this crate now touches the Hub's
+//! storage graph; the keygen/sign path above stays storage-free). It is DARK: issuance
+//! is an operator action invoked from the CLI, NOT wired into the live run loop, and it
+//! does NOT enable enforcement (NS-2 owns the enforce flag, default-OFF). It is purely
+//! ADDITIVE — the keygen/sign behavior and output are unchanged.
 //!
 //! ## The crypto contract (why the Hub will accept what this emits)
 //!
@@ -69,6 +86,13 @@ pub enum CliError {
     BadDecision(String),
     #[error("invalid action_digest: expected 64 lowercase hex chars (a SHA-256 digest)")]
     BadActionDigest,
+    // ---- NS-3 trust-grant issuance/revoke ----
+    #[error("invalid trust grant: {0}")]
+    BadGrant(String),
+    #[error("could not open Hub database at {0}")]
+    OpenDb(String),
+    #[error("trust-grant storage error: {0}")]
+    Storage(String),
 }
 
 /// The pending-request the operator signs. Shaped to match what S6b persists when a
@@ -350,6 +374,180 @@ pub fn decode_verifying_key_hex(hex: &str) -> Option<[u8; VERIFYING_KEY_LEN]> {
 /// Decode a 64-byte hex signature emitted in [`SignedApproval::signature`].
 pub fn decode_signature_hex(hex: &str) -> Option<Vec<u8>> {
     from_hex(hex.trim())
+}
+
+/// NS-3 — Hub-side trust-grant issuance/revoke (the operator POLICY action).
+///
+/// This module is the call-site that mints / revokes a `friday_core::TrustGrant`
+/// through `friday_storage::grant_trust` / `revoke_trust` — the storage functions that
+/// otherwise had ZERO callers, so NS-2's enforced trust check could never be satisfied
+/// (it would deny every mutating action closed with `trust_no_active_grant`). It links
+/// `friday-storage` (the only Hub-storage coupling in this crate). It is DARK: invoked
+/// from the operator CLI, NOT from the live run loop, and it does NOT enable enforcement
+/// (NS-2 owns the enforce flag, default-OFF).
+pub mod trust_grant {
+    use super::CliError;
+    use friday_core::{Risk, TrustBoundaries, TrustGrant};
+    use friday_storage::Db;
+
+    /// Operator-supplied parameters for an issuance. Bundled into ONE struct (rather
+    /// than a wide function signature) so the boundary fields stay grouped and the
+    /// issuance call does not trip `clippy::too_many_arguments`. Every `Vec` allowlist
+    /// is fail-closed: EMPTY = DENY-ALL for that dimension (mirrors `check_grant`).
+    #[derive(Debug, Clone, Default)]
+    pub struct TrustGrantSpec {
+        /// Stable id for the grant row (e.g. `g-friday-2026`). Required, non-empty.
+        pub grant_id: String,
+        /// The agent the grant authorizes: `friday` | `codex` | `claude` |
+        /// `workflow:<id>` | `skill:<id>`. Required, non-empty.
+        pub agent_id: String,
+        /// Maximum effective risk an action may carry under this grant.
+        pub risk_ceiling: Risk,
+        /// `None` = no expiry; otherwise epoch-ms after which the grant is dead.
+        pub expires_at: Option<i64>,
+        /// Optional workspace path PREFIX the grant is confined to (`None` = any path).
+        pub workspace: Option<String>,
+        /// DEFERRED in storage (stored, NOT enforced — no live ledger/run counter).
+        pub token_ceiling: Option<i64>,
+        /// DEFERRED in storage (stored, NOT enforced).
+        pub max_runs: Option<i64>,
+        pub allowed_channels: Vec<String>,
+        pub allowed_providers: Vec<String>,
+        pub allowed_tools: Vec<String>,
+        pub allowed_workflow_families: Vec<String>,
+        pub allowed_skill_families: Vec<String>,
+    }
+
+    impl TrustGrantSpec {
+        /// Compose the `TrustGrant` this spec describes, granted at `now_ms`. Pure (no
+        /// I/O) — the persistence is done by [`issue`].
+        fn to_grant(&self, now_ms: i64) -> TrustGrant {
+            TrustGrant {
+                grant_id: self.grant_id.clone(),
+                agent_id: self.agent_id.clone(),
+                granted_at: now_ms,
+                expires_at: self.expires_at,
+                revoked: false,
+                revoked_at: None,
+                boundaries: TrustBoundaries {
+                    workspace: self.workspace.clone(),
+                    risk_ceiling: self.risk_ceiling,
+                    token_ceiling: self.token_ceiling,
+                    max_runs: self.max_runs,
+                    allowed_channels: self.allowed_channels.clone(),
+                    allowed_providers: self.allowed_providers.clone(),
+                    allowed_tools: self.allowed_tools.clone(),
+                    allowed_workflow_families: self.allowed_workflow_families.clone(),
+                    allowed_skill_families: self.allowed_skill_families.clone(),
+                },
+            }
+        }
+    }
+
+    /// Parse an operator-supplied risk string into the gate enum. Fail-closed: only the
+    /// five canonical spellings are accepted (matches `Risk::as_str`).
+    pub fn parse_risk(s: &str) -> Result<Risk, CliError> {
+        match s {
+            "read_only" => Ok(Risk::ReadOnly),
+            "low" => Ok(Risk::Low),
+            "medium" => Ok(Risk::Medium),
+            "high" => Ok(Risk::High),
+            "critical" => Ok(Risk::Critical),
+            other => Err(CliError::BadGrant(format!(
+                "unknown risk_ceiling {other:?}: expected one of \
+                 read_only|low|medium|high|critical"
+            ))),
+        }
+    }
+
+    /// Parse a comma-separated allowlist (e.g. `--tools read_file,write_file`) into a
+    /// `Vec<String>`. `None`/empty input yields an EMPTY vec — which `check_grant`
+    /// treats as DENY-ALL for that dimension (fail-closed). Surrounding whitespace is
+    /// trimmed; empty segments (e.g. a trailing comma) are dropped.
+    pub fn parse_csv(value: Option<&str>) -> Vec<String> {
+        match value {
+            None => Vec::new(),
+            Some(raw) => raw
+                .split(',')
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .map(str::to_string)
+                .collect(),
+        }
+    }
+
+    /// Build the issuance spec from already-parsed parts. Validates the two required
+    /// non-empty identifiers (fail-closed) so an empty `grant_id`/`agent_id` is caught
+    /// here rather than as an opaque storage error.
+    #[allow(clippy::too_many_arguments)]
+    pub fn build_spec(
+        grant_id: String,
+        agent_id: String,
+        risk_ceiling: Risk,
+        expires_at: Option<i64>,
+        workspace: Option<String>,
+        token_ceiling: Option<i64>,
+        max_runs: Option<i64>,
+        allowed_channels: Vec<String>,
+        allowed_providers: Vec<String>,
+        allowed_tools: Vec<String>,
+        allowed_workflow_families: Vec<String>,
+        allowed_skill_families: Vec<String>,
+    ) -> Result<TrustGrantSpec, CliError> {
+        if grant_id.trim().is_empty() {
+            return Err(CliError::BadGrant("grant_id must not be empty".to_string()));
+        }
+        if agent_id.trim().is_empty() {
+            return Err(CliError::BadGrant("agent_id must not be empty".to_string()));
+        }
+        Ok(TrustGrantSpec {
+            grant_id,
+            agent_id,
+            risk_ceiling,
+            expires_at,
+            workspace,
+            token_ceiling,
+            max_runs,
+            allowed_channels,
+            allowed_providers,
+            allowed_tools,
+            allowed_workflow_families,
+            allowed_skill_families,
+        })
+    }
+
+    /// Issue (mint) the trust grant `spec` describes against the OPEN Hub `db`, granted
+    /// at `now_ms`. Routes through `friday_storage::grant_trust`, so the grant + its
+    /// hash-chained `trust.grant` audit row commit together. Returns the persisted
+    /// `TrustGrant` (so the caller can echo it / a test can assert the round-trip).
+    ///
+    /// `now_ms` is an argument (not read from a clock here) so a test can pin it; the
+    /// CLI supplies `SystemTime::now`.
+    pub fn issue(db: &Db, spec: &TrustGrantSpec, now_ms: i64) -> Result<TrustGrant, CliError> {
+        let grant = spec.to_grant(now_ms);
+        friday_storage::grant_trust(db.conn(), &grant, now_ms)
+            .map_err(|e| CliError::Storage(e.to_string()))?;
+        Ok(grant)
+    }
+
+    /// Revoke the grant `grant_id` against the OPEN Hub `db` at `now_ms`. Routes through
+    /// `friday_storage::revoke_trust`, so the `revoked=1` update + its `trust.revoke`
+    /// audit row commit together. Revoking a missing grant is a fail-closed error (the
+    /// storage layer returns one — no silent no-op that would look like a revoke).
+    pub fn revoke(db: &Db, grant_id: &str, now_ms: i64) -> Result<(), CliError> {
+        if grant_id.trim().is_empty() {
+            return Err(CliError::BadGrant("grant_id must not be empty".to_string()));
+        }
+        friday_storage::revoke_trust(db.conn(), grant_id, now_ms)
+            .map_err(|e| CliError::Storage(e.to_string()))
+    }
+
+    /// Open the Hub DB at `path` for an issuance/revoke. Wraps `Db::open_hub` so the
+    /// error is a clean `CliError::OpenDb` (the path is not secret; this never echoes
+    /// DB contents).
+    pub fn open_hub(path: &str) -> Result<Db, CliError> {
+        Db::open_hub(path).map_err(|_| CliError::OpenDb(path.to_string()))
+    }
 }
 
 #[cfg(test)]

--- a/rust-core/crates/friday-operator-cli/src/main.rs
+++ b/rust-core/crates/friday-operator-cli/src/main.rs
@@ -17,24 +17,43 @@
 //!
 //! Truth label: offline operator-signing tool (operator-held private key; the Hub
 //! holds only the public key). NOT wired to a live resume (S6d). PROOF-ONLY.
+//!
+//! NS-3 adds two MORE subcommands — `grant` and `revoke` — the operator POLICY action
+//! that mints / revokes a TrustGrant in the Hub DB (via `friday_storage`). They are
+//! what make NS-2's (separate, default-OFF) enforced trust check satisfiable. DARK:
+//! invoked from the CLI, NOT wired into the live run loop, enforcement stays OFF.
 
 use std::path::Path;
 use std::process::ExitCode;
+use std::time::{SystemTime, UNIX_EPOCH};
 
+use friday_operator_cli::trust_grant;
 use friday_operator_cli::{keygen_to_path, sign_request, PendingRequest};
 
 const USAGE: &str = "\
-friday-operator-approve — offline operator-signing CLI (S6c)
+friday-operator-approve — operator CLI (S6c signing + NS-3 trust-grant issuance)
 
 USAGE:
     friday-operator-approve keygen --out <private-key-path>
     friday-operator-approve sign  --key <private-key-path> --request <pending-request.json>
+    friday-operator-approve grant  --db <hub.sqlite> --grant-id <id> --agent <agent-id> \\
+                                    --risk-ceiling <read_only|low|medium|high|critical> \\
+                                    [--expires-at <epoch-ms>] [--workspace <path-prefix>] \\
+                                    [--token-ceiling <n>] [--max-runs <n>] \\
+                                    [--tools a,b] [--providers a,b] [--channels a,b] \\
+                                    [--workflow-families a,b] [--skill-families a,b]
+    friday-operator-approve revoke --db <hub.sqlite> --grant-id <id>
 
 keygen writes the operator PRIVATE key (mode 0600) to --out and prints the PUBLIC
 verifying key (JSON) to stdout for Hub provisioning. The private key is never printed.
 
 sign reads a pending request JSON and emits an Ed25519-signed CanonicalApproval (JSON)
-to stdout. The private key never appears in the output.";
+to stdout. The private key never appears in the output.
+
+grant mints a TrustGrant for --agent with the given boundaries (operator POLICY action;
+the allowlists are fail-closed — an omitted dimension is DENY-ALL) and prints the
+persisted grant (JSON). revoke marks the grant --grant-id revoked. Both write a
+hash-chained audit row. DARK: this does NOT enable enforcement (NS-2 owns that flag).";
 
 fn main() -> ExitCode {
     match run() {
@@ -51,6 +70,8 @@ fn run() -> Result<(), String> {
     match args.get(1).map(String::as_str) {
         Some("keygen") => cmd_keygen(&args[2..]),
         Some("sign") => cmd_sign(&args[2..]),
+        Some("grant") => cmd_grant(&args[2..]),
+        Some("revoke") => cmd_revoke(&args[2..]),
         Some("help") | Some("--help") | Some("-h") | None => {
             println!("{USAGE}");
             Ok(())
@@ -93,6 +114,111 @@ fn cmd_sign(args: &[String]) -> Result<(), String> {
         serde_json::to_string_pretty(&signed).map_err(|e| e.to_string())?
     );
     Ok(())
+}
+
+/// NS-3 `grant`: mint a TrustGrant for --agent with the supplied boundaries against the
+/// Hub DB. Operator POLICY action. Prints the persisted grant as JSON to stdout. DARK —
+/// does NOT enable enforcement (NS-2 owns that flag).
+fn cmd_grant(args: &[String]) -> Result<(), String> {
+    let db_path = arg_value(args, "--db")
+        .ok_or_else(|| format!("grant requires --db <hub.sqlite>\n\n{USAGE}"))?;
+    let grant_id = arg_value(args, "--grant-id")
+        .ok_or_else(|| format!("grant requires --grant-id <id>\n\n{USAGE}"))?;
+    let agent_id = arg_value(args, "--agent")
+        .ok_or_else(|| format!("grant requires --agent <agent-id>\n\n{USAGE}"))?;
+    let risk_str = arg_value(args, "--risk-ceiling").ok_or_else(|| {
+        format!("grant requires --risk-ceiling <read_only|low|medium|high|critical>\n\n{USAGE}")
+    })?;
+    let risk_ceiling = trust_grant::parse_risk(&risk_str).map_err(|e| e.to_string())?;
+
+    let spec = trust_grant::build_spec(
+        grant_id,
+        agent_id,
+        risk_ceiling,
+        arg_i64(args, "--expires-at")?,
+        arg_value(args, "--workspace"),
+        arg_i64(args, "--token-ceiling")?,
+        arg_i64(args, "--max-runs")?,
+        trust_grant::parse_csv(arg_value(args, "--channels").as_deref()),
+        trust_grant::parse_csv(arg_value(args, "--providers").as_deref()),
+        trust_grant::parse_csv(arg_value(args, "--tools").as_deref()),
+        trust_grant::parse_csv(arg_value(args, "--workflow-families").as_deref()),
+        trust_grant::parse_csv(arg_value(args, "--skill-families").as_deref()),
+    )
+    .map_err(|e| e.to_string())?;
+
+    let db = trust_grant::open_hub(&db_path).map_err(|e| e.to_string())?;
+    let grant = trust_grant::issue(&db, &spec, now_ms()?).map_err(|e| e.to_string())?;
+
+    // Echo the persisted grant (JSON) for operator review + machine parsing. The
+    // boundaries are flattened from the stored TrustGrant so the round-trip is visible.
+    let b = &grant.boundaries;
+    let out = serde_json::json!({
+        "result": "granted",
+        "grant_id": grant.grant_id,
+        "agent_id": grant.agent_id,
+        "granted_at": grant.granted_at,
+        "expires_at": grant.expires_at,
+        "boundaries": {
+            "workspace": b.workspace,
+            "risk_ceiling": b.risk_ceiling.as_str(),
+            "token_ceiling": b.token_ceiling,
+            "max_runs": b.max_runs,
+            "allowed_channels": b.allowed_channels,
+            "allowed_providers": b.allowed_providers,
+            "allowed_tools": b.allowed_tools,
+            "allowed_workflow_families": b.allowed_workflow_families,
+            "allowed_skill_families": b.allowed_skill_families,
+        },
+    });
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&out).map_err(|e| e.to_string())?
+    );
+    Ok(())
+}
+
+/// NS-3 `revoke`: mark --grant-id revoked in the Hub DB. Prints a small JSON receipt.
+fn cmd_revoke(args: &[String]) -> Result<(), String> {
+    let db_path = arg_value(args, "--db")
+        .ok_or_else(|| format!("revoke requires --db <hub.sqlite>\n\n{USAGE}"))?;
+    let grant_id = arg_value(args, "--grant-id")
+        .ok_or_else(|| format!("revoke requires --grant-id <id>\n\n{USAGE}"))?;
+    let now = now_ms()?;
+    let db = trust_grant::open_hub(&db_path).map_err(|e| e.to_string())?;
+    trust_grant::revoke(&db, &grant_id, now).map_err(|e| e.to_string())?;
+    let out = serde_json::json!({
+        "result": "revoked",
+        "grant_id": grant_id,
+        "revoked_at": now,
+    });
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&out).map_err(|e| e.to_string())?
+    );
+    Ok(())
+}
+
+/// Current wall-clock as epoch-ms. The CLI supplies the clock; the library issuance fn
+/// takes `now` as an argument so a test can pin it.
+fn now_ms() -> Result<i64, String> {
+    let ms = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_err(|_| "system clock is before the unix epoch".to_string())?
+        .as_millis();
+    i64::try_from(ms).map_err(|_| "system clock overflows i64 epoch-ms".to_string())
+}
+
+/// Parse an OPTIONAL `--name <i64>` flag. Absent => `None`; present-but-unparseable =>
+/// a clean error (fail-closed — never silently treated as absent).
+fn arg_i64(args: &[String], name: &str) -> Result<Option<i64>, String> {
+    match arg_value(args, name) {
+        None => Ok(None),
+        Some(v) => v
+            .parse::<i64>()
+            .map(Some)
+            .map_err(|_| format!("{name} must be an integer, got {v:?}")),
+    }
 }
 
 /// `--name value` or `--name=value`. Mirrors the existing Hub bins' arg parsing.

--- a/rust-core/crates/friday-operator-cli/tests/trust_grant_issuance.rs
+++ b/rust-core/crates/friday-operator-cli/tests/trust_grant_issuance.rs
@@ -1,0 +1,290 @@
+//! NS-3 — the DARK proof for the operator-CLI trust-grant issuance/revoke call-site.
+//!
+//! `friday_storage::grant_trust` / `revoke_trust` had ZERO callers, so NS-2's enforced
+//! trust check (a separate PR, default-OFF) would deny EVERY mutating action closed
+//! (`trust_no_active_grant`) because no path could ever mint a `TrustGrant`. NS-3 adds
+//! that issuance path. This test is the dark proof: it drives the NEW call-site
+//! (`friday_operator_cli::trust_grant::issue` / `revoke`) against a REAL temp SQLite Hub
+//! DB and proves issuance ACTUALLY satisfies the check — not merely that a row was
+//! written:
+//!
+//! 1. BEFORE issuance: `authorize_agent_action` for an in-boundary mutating action
+//!    Denies with `trust_no_active_grant` (the check is unsatisfiable).
+//! 2. issue via the new path -> `active_grant` returns the grant AND the boundary fields
+//!    (risk ceiling / tool scope / workspace / expiry) round-trip.
+//! 3. AFTER issuance: the SAME in-boundary mutating action NO LONGER returns
+//!    `trust_no_active_grant`; the trust layer is transparent (`denied_by` is NOT
+//!    `trust_grant`) and the result is the base gate's `RequiresApproval` — i.e. the
+//!    grant is RESTRICTIVE-only and the check is now satisfiable (the safety prerequisite
+//!    that lets NS-2's flag be turned on without bricking the run path).
+//! 4. revoke via the new path -> `authorize_agent_action` reports `trust_grant_revoked`.
+//!
+//! DARK: this exercises the operator POLICY action; it does NOT enable enforcement
+//! (NS-2 owns the enforce flag, default-OFF) and does NOT touch the live run loop.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use friday_core::gate::{classify, Actor, ActorKind, GateDecision, MutatingActionRequest};
+use friday_core::Risk;
+use friday_operator_cli::trust_grant::{self, TrustGrantSpec};
+use friday_storage::{active_grant, authorize_agent_action, AgentActionContext, Db};
+
+const SECRET: &[u8] = b"gate-signing-secret";
+const AGENT: &str = "friday";
+const GRANT_ID: &str = "g-friday-ns3";
+const TOOL: &str = "write_file";
+const WORKSPACE: &str = "/work/friday";
+
+static COUNTER: AtomicU64 = AtomicU64::new(0);
+
+/// A fresh on-disk SQLite path (a real file — the migration backup guard copies it).
+fn temp_db_path(tag: &str) -> String {
+    let n = COUNTER.fetch_add(1, Ordering::SeqCst);
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let mut dir = std::env::temp_dir();
+    dir.push(format!(
+        "friday-ns3-cli-test-{tag}-{}-{nanos}-{n}",
+        std::process::id()
+    ));
+    std::fs::create_dir_all(&dir).unwrap();
+    dir.push("db.sqlite");
+    dir.to_string_lossy().to_string()
+}
+
+/// The spec the operator CLI would build for an in-boundary `write_file` grant:
+/// risk_ceiling Medium, tool allowlisted, workspace-scoped, with an expiry far in the
+/// future. Mirrors the comma-separated CLI parse via `parse_csv`.
+fn in_boundary_spec(expires_at: Option<i64>) -> TrustGrantSpec {
+    trust_grant::build_spec(
+        GRANT_ID.to_string(),
+        AGENT.to_string(),
+        Risk::Medium,
+        expires_at,
+        Some(WORKSPACE.to_string()),
+        Some(1000), // token_ceiling — stored, DEFERRED-not-enforced
+        Some(5),    // max_runs — stored, DEFERRED-not-enforced
+        trust_grant::parse_csv(Some("telegram")),
+        trust_grant::parse_csv(Some("deepseek")),
+        trust_grant::parse_csv(Some("read_file,write_file")),
+        Vec::new(),
+        Vec::new(),
+    )
+    .expect("spec with non-empty ids is valid")
+}
+
+/// An in-boundary MUTATING `write_file` request + its action context: tool allowlisted,
+/// effective risk (Medium) at/under the ceiling, workspace under the grant's prefix.
+fn in_boundary_request() -> MutatingActionRequest {
+    MutatingActionRequest::from_classification(
+        classify(true, Risk::Medium, TOOL, &[]),
+        TOOL.to_string(),
+        Actor {
+            kind: ActorKind::Agent,
+            id: AGENT.to_string(),
+            principal_id: Some("p1".to_string()),
+        },
+        "system".to_string(),
+        vec![],
+        None,
+        Some("idem-ns3".to_string()),
+        None,
+    )
+}
+
+fn in_boundary_ctx() -> AgentActionContext {
+    AgentActionContext {
+        agent_id: AGENT.to_string(),
+        workspace: Some(format!("{WORKSPACE}/src/main.rs")),
+        tool: Some(TOOL.to_string()),
+        provider: None,
+        channel: None,
+        workflow_family: None,
+        skill_family: None,
+    }
+}
+
+#[test]
+fn issued_grant_satisfies_the_trust_check_then_revoke_reports_revoked() {
+    let db = Db::open_hub(&temp_db_path("issue-revoke")).unwrap();
+    let now = 100i64;
+
+    // (1) BEFORE issuance: the check is UNSATISFIABLE — no active grant -> Deny with
+    //     trust_no_active_grant. This is exactly the state that would brick every
+    //     mutating action if NS-2's enforce flag were on with no issuance path.
+    let before = authorize_agent_action(
+        db.conn(),
+        &in_boundary_request(),
+        &in_boundary_ctx(),
+        None,
+        SECRET,
+        now,
+    )
+    .unwrap();
+    assert_eq!(before.decision, GateDecision::Deny);
+    assert_eq!(before.reason, "trust_no_active_grant");
+    assert_eq!(before.denied_by.as_deref(), Some("trust_grant"));
+
+    // (2) Issue via the NEW operator-CLI call-site (NOT grant_trust directly).
+    let issued = trust_grant::issue(&db, &in_boundary_spec(None), now).unwrap();
+    assert_eq!(issued.grant_id, GRANT_ID);
+    assert_eq!(issued.agent_id, AGENT);
+    assert_eq!(issued.granted_at, now);
+
+    // active_grant returns it, and the boundary fields ROUND-TRIP through storage.
+    let active = active_grant(db.conn(), AGENT, now)
+        .unwrap()
+        .expect("active grant present after issuance");
+    assert_eq!(active.grant_id, GRANT_ID);
+    assert_eq!(active.expires_at, None);
+    assert_eq!(active.boundaries.risk_ceiling, Risk::Medium);
+    assert_eq!(active.boundaries.workspace.as_deref(), Some(WORKSPACE));
+    assert_eq!(active.boundaries.token_ceiling, Some(1000));
+    assert_eq!(active.boundaries.max_runs, Some(5));
+    assert_eq!(
+        active.boundaries.allowed_tools,
+        vec!["read_file".to_string(), "write_file".to_string()]
+    );
+    assert_eq!(active.boundaries.allowed_providers, vec!["deepseek"]);
+    assert_eq!(active.boundaries.allowed_channels, vec!["telegram"]);
+
+    // (3) AFTER issuance: the SAME in-boundary mutating action no longer returns
+    //     trust_no_active_grant. The grant is RESTRICTIVE-only — it does NOT upgrade the
+    //     base gate's RequiresApproval to Allow; it just stops objecting (the trust layer
+    //     is transparent: denied_by is NOT trust_grant). This is the proof that issuance
+    //     ACTUALLY satisfies the check (the request falls through to the base gate),
+    //     not merely that a row was written.
+    let after = authorize_agent_action(
+        db.conn(),
+        &in_boundary_request(),
+        &in_boundary_ctx(),
+        None, // no canonical approval presented
+        SECRET,
+        now,
+    )
+    .unwrap();
+    assert_ne!(
+        after.reason, "trust_no_active_grant",
+        "issuance must make the trust check satisfiable"
+    );
+    assert_ne!(
+        after.denied_by.as_deref(),
+        Some("trust_grant"),
+        "an in-boundary action must not be denied BY the trust layer after issuance"
+    );
+    assert_eq!(
+        after.decision,
+        GateDecision::RequiresApproval,
+        "a mutating action falls through to the base gate's RequiresApproval (the grant \
+         is restrictive-only and never upgrades it to Allow)"
+    );
+
+    // (4) Revoke via the NEW operator-CLI call-site (NOT revoke_trust directly). The
+    //     grant is no longer ACTIVE, and the compose reports the operator-meaningful
+    //     trust_grant_revoked (NOT the never-granted reason).
+    trust_grant::revoke(&db, GRANT_ID, 200).unwrap();
+    assert!(active_grant(db.conn(), AGENT, 300).unwrap().is_none());
+
+    let after_revoke = authorize_agent_action(
+        db.conn(),
+        &in_boundary_request(),
+        &in_boundary_ctx(),
+        None,
+        SECRET,
+        300,
+    )
+    .unwrap();
+    assert_eq!(after_revoke.decision, GateDecision::Deny);
+    assert_eq!(
+        after_revoke.reason, "trust_grant_revoked",
+        "a revoked authority must report trust_grant_revoked, not the never-granted reason"
+    );
+}
+
+#[test]
+fn expiry_round_trips_and_an_expired_grant_is_not_active() {
+    // The expiry boundary round-trips through the issuance path: an issued grant with an
+    // expiry is ACTIVE before it and not active at/after it.
+    let db = Db::open_hub(&temp_db_path("expiry")).unwrap();
+    let expires_at = 500i64;
+    let issued = trust_grant::issue(&db, &in_boundary_spec(Some(expires_at)), 100).unwrap();
+    assert_eq!(issued.expires_at, Some(expires_at));
+
+    assert!(
+        active_grant(db.conn(), AGENT, 100).unwrap().is_some(),
+        "active before expiry"
+    );
+    assert!(
+        active_grant(db.conn(), AGENT, expires_at)
+            .unwrap()
+            .is_none(),
+        "not active at/after expiry"
+    );
+}
+
+#[test]
+fn empty_grant_id_and_empty_agent_fail_closed() {
+    // The issuance call-site validates the required identifiers — an empty id is a clean
+    // BadGrant error, never an opaque storage failure or a silent no-op.
+    assert!(trust_grant::build_spec(
+        String::new(),
+        AGENT.to_string(),
+        Risk::Low,
+        None,
+        None,
+        None,
+        None,
+        Vec::new(),
+        Vec::new(),
+        Vec::new(),
+        Vec::new(),
+        Vec::new(),
+    )
+    .is_err());
+    assert!(trust_grant::build_spec(
+        GRANT_ID.to_string(),
+        String::new(),
+        Risk::Low,
+        None,
+        None,
+        None,
+        None,
+        Vec::new(),
+        Vec::new(),
+        Vec::new(),
+        Vec::new(),
+        Vec::new(),
+    )
+    .is_err());
+
+    let db = Db::open_hub(&temp_db_path("revoke-empty")).unwrap();
+    assert!(
+        trust_grant::revoke(&db, "  ", 1).is_err(),
+        "revoking an empty grant_id is fail-closed"
+    );
+}
+
+#[test]
+fn parse_risk_and_csv_are_fail_closed() {
+    assert_eq!(trust_grant::parse_risk("medium").unwrap(), Risk::Medium);
+    assert_eq!(trust_grant::parse_risk("critical").unwrap(), Risk::Critical);
+    assert!(
+        trust_grant::parse_risk("MEDIUM").is_err(),
+        "uppercase rejected"
+    );
+    assert!(
+        trust_grant::parse_risk("severe").is_err(),
+        "unknown rejected"
+    );
+
+    // CSV: trims, drops empty segments, None => empty (DENY-ALL for that dimension).
+    assert_eq!(
+        trust_grant::parse_csv(Some(" read_file , write_file ,")),
+        vec!["read_file".to_string(), "write_file".to_string()]
+    );
+    assert!(trust_grant::parse_csv(None).is_empty());
+    assert!(trust_grant::parse_csv(Some("")).is_empty());
+}


### PR DESCRIPTION
## NS-3 — operator-CLI trust-grant issuance/revoke

`friday_storage::grant_trust` / `revoke_trust` had **ZERO callers**, so NS-2's enforced trust check (separate PR, default-OFF) would deny **every** mutating action closed (`trust_no_active_grant`) — there was no path to ever mint a `TrustGrant`. NS-3 adds that issuance path so the check is satisfiable.

This is the **safety prerequisite for NS-2**: it lets NS-2's enforce flag be turned on without bricking the run path.

### What
Two new `friday-operator-approve` subcommands (operator POLICY action):
- `grant --db <hub.sqlite> --grant-id <id> --agent <agent-id> --risk-ceiling <read_only|low|medium|high|critical> [--expires-at <epoch-ms>] [--workspace <prefix>] [--token-ceiling <n>] [--max-runs <n>] [--tools a,b] [--providers a,b] [--channels a,b] [--workflow-families a,b] [--skill-families a,b]` — mints a `TrustGrant` via `friday_storage::grant_trust`. Allowlists are fail-closed (omitted dimension = DENY-ALL). Prints the persisted grant as JSON.
- `revoke --db <hub.sqlite> --grant-id <id>` — marks the grant revoked via `friday_storage::revoke_trust`.

Both write a hash-chained audit row (the storage layer's existing one-transaction guarantee).

### NO-DEGRADE
Purely **ADDITIVE** — the `keygen`/`sign` subcommands are byte-for-byte unchanged (6 existing `cli_roundtrip` tests still green). Does **not** flip any default flag and does **not** enable enforcement (NS-2 owns the enforce flag, default-OFF).

### DARK
Invoked from the CLI only; **not** wired into the live run loop and does **not** touch the Hub runtime `lib.rs`. Source changes are confined to the `friday-operator-cli` crate.

### Dependency surface (reviewer note)
This crate now links **`friday-storage`** for the issuance half (the `keygen`/`sign` half stays storage-free). The crate's old "storage-free" doc/description are updated to reflect the two halves. **arch-tests still pass** — no new edge into the phone (`friday-ffi`) closure, so the no-secret-on-phone boundary is intact.

### Dark proof (`tests/trust_grant_issuance.rs`, real temp sqlite)
- **Before** issuance: an in-boundary mutating action Denies with `trust_no_active_grant`.
- **After** issuing via the new path: `active_grant` returns the grant with all boundary fields (risk ceiling / tool scope / workspace / expiry / token_ceiling / max_runs / allowlists) round-tripped, **and** `authorize_agent_action` no longer returns `trust_no_active_grant` — it falls through to the base gate (`decision = RequiresApproval`, `denied_by != "trust_grant"`), proving issuance **actually satisfies** the check (restrictive-only; never upgrades RequiresApproval to Allow).
- **After** revoke via the new path: `authorize_agent_action` reports `trust_grant_revoked`.

### Local gate (in order, all green)
`cargo fmt --all` + `--check` clean · `cargo clippy --workspace --all-targets -- -D warnings` clean · `cargo test -p friday-operator-cli -p friday-storage` all pass (4 new tests + 6 existing roundtrip + storage suite) · arch-tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)