### PR TITLE
feat(c2-1): cooperative cancellation token for interrupt/stop in routed loop

### DIFF
--- a/rust-core/crates/friday-hub/src/lib.rs
+++ b/rust-core/crates/friday-hub/src/lib.rs
@@ -2058,6 +2058,39 @@ pub fn run_one_turn_with_executor(
 
 // --- the multi-turn run loop -------------------------------------------------
 
+/// (C2-1) A cooperative cancellation handle for the routed run loop. The loop checks
+/// [`CancelToken::is_cancelled`] at the TOP of each turn (BEFORE the model call), so a
+/// tripped token stops the loop cleanly with [`LoopStatus::Interrupted`] — making NO
+/// further model call and billing NOTHING after the trip. Cooperative (between-turns),
+/// NOT a mid-turn abort: a turn already in flight runs to completion; the cancel takes
+/// effect at the next turn boundary. Clone-cheap (`Arc`); holder and loop share the SAME
+/// flag, so [`CancelToken::cancel`] from any holder is observed by the loop.
+///
+/// DARK: this is the interrupt/stop substrate the routed-claude parity harness's
+/// `interrupt / stop` flow needs (see `tests/routed_claude_parity.rs`'s DEFERRED note —
+/// "there is no cancel handle on run_task_pinned. WIRING NEEDED: a cancellation token
+/// threaded into the routed loop"). The no-key in-crate test is its deterministic proof.
+#[derive(Clone, Debug, Default)]
+pub struct CancelToken(std::sync::Arc<std::sync::atomic::AtomicBool>);
+
+impl CancelToken {
+    /// A fresh, un-tripped token.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Request cancellation. Idempotent — observed by the loop at the next turn boundary
+    /// (no effect on a turn already in flight; that turn completes and is billed normally).
+    pub fn cancel(&self) {
+        self.0.store(true, std::sync::atomic::Ordering::SeqCst);
+    }
+
+    /// Whether cancellation has been requested.
+    pub fn is_cancelled(&self) -> bool {
+        self.0.load(std::sync::atomic::Ordering::SeqCst)
+    }
+}
+
 /// How a [`run_loop`] ended.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum LoopStatus {
@@ -2072,6 +2105,11 @@ pub enum LoopStatus {
     Bounded,
     /// The model client errored (transport/parse) — fail-closed stop.
     Errored,
+    /// (C2-1) A cooperative [`CancelToken`] was tripped at a turn boundary — the loop
+    /// stopped BEFORE the next model call. Terminal: no further model call is made and
+    /// NOTHING is billed after the trip. Carries no deliverable answer (like `Bounded`),
+    /// so the post-loop owner-wiring tail (which persists only on `Finished`) skips it.
+    Interrupted,
 }
 
 /// The outcome of a whole [`run_loop`]. `executed_tools` is the count of tools that
@@ -2493,6 +2531,7 @@ pub fn run_loop(
         approve,
         &RunPolicy::default(),
         max_turns,
+        None, // cancel: no cancellation handle — pre-C2-1 behavior, byte-identical
         now_ms,
     )
 }
@@ -2546,6 +2585,13 @@ pub fn run_loop(
 /// attempt (or the final exhausted failure) is recorded once, OUTSIDE this inner loop.
 const RUN_LOOP_MAX_PROVIDER_ATTEMPTS: u32 = 3;
 
+/// `cancel` (C2-1) is an OPTIONAL cooperative cancellation handle checked at the TOP of
+/// each turn, BEFORE the model call. When `Some` and already tripped at a turn boundary,
+/// the loop stops with [`LoopStatus::Interrupted`]: it makes NO further model call and
+/// bills NOTHING after the trip. `None` (the default for every existing caller) is the
+/// pre-C2-1 behavior, BYTE-IDENTICAL — no check, no new stop. Cooperative/between-turns:
+/// a turn already in flight completes and is billed normally; the cancel takes effect at
+/// the NEXT turn boundary only.
 #[allow(clippy::too_many_arguments)]
 pub fn run_loop_with_policy(
     client: &dyn AgentLlmClient,
@@ -2558,6 +2604,7 @@ pub fn run_loop_with_policy(
     approve: &dyn Fn(&MutatingActionRequest) -> Option<CanonicalApproval>,
     policy: &RunPolicy,
     max_turns: u64,
+    cancel: Option<&CancelToken>,
     now_ms: i64,
 ) -> Result<LoopOutcome, StorageError> {
     // Plan classification recorded ONCE (it is a property of the task, constant across
@@ -2603,6 +2650,31 @@ pub fn run_loop_with_policy(
 
     for turn_index in 0..max_turns {
         let ev = |suffix: &str| format!("{run_id}:t{turn_index}:{suffix}");
+
+        // (C2-1) Cooperative cancellation, checked at the TOP of the turn — BEFORE the
+        // model call below — so a tripped token stops the loop with NO further model call
+        // and NOTHING billed after the trip. `turns: turn_index` (NOT `+1`): this turn's
+        // `next_step_metered` has NOT happened, so it must NOT count toward the
+        // turns==model-calls invariant (the previous turn's call is `turn_index`). When
+        // `cancel` is `None` (every pre-C2-1 caller) this is a no-op and the loop is
+        // byte-identical to before. Records a refs-only audit event (no ledger row),
+        // mirroring the `agent.loop_bounded` terminal marker.
+        if cancel.is_some_and(CancelToken::is_cancelled) {
+            agent_run::record_event(
+                conn,
+                &ev("interrupted"),
+                run_id,
+                "agent.interrupted",
+                now_ms,
+            )?;
+            return Ok(LoopOutcome {
+                status: LoopStatus::Interrupted,
+                turns: turn_index,
+                executed_tools,
+                final_message: None,
+                detail: format!("interrupted:turn={turn_index}"),
+            });
+        }
 
         // S1.2 usage-parity: ONE metered model call per turn. An OUTER `Err` is a
         // route/transport/discovery failure — the chat produced no usage, so NOTHING is
@@ -2925,6 +2997,12 @@ pub fn run_loop_with_policy(
 ///
 /// Truth label: parity wiring inside the Rust loop (dev-bridge/test-provable). It does
 /// NOT flip any TS-retirement state and is NOT a v1 GO.
+/// `cancel` (C2-1) is the OPTIONAL cooperative cancellation handle, threaded VERBATIM into
+/// the inner [`run_loop_with_policy`] (checked at each turn boundary). An `Interrupted`
+/// outcome is treated EXACTLY like the other non-`Finished` terminals here: the `user`
+/// turn is still appended (the operator asked it), but no `assistant` answer and no
+/// owner-wired `run_result` (those are gated on `Finished`). `None` (every existing
+/// caller) is byte-identical to the pre-C2-1 sessioned behavior.
 #[allow(clippy::too_many_arguments)]
 pub fn run_session_loop(
     client: &dyn AgentLlmClient,
@@ -2939,6 +3017,7 @@ pub fn run_session_loop(
     approve: &dyn Fn(&MutatingActionRequest) -> Option<CanonicalApproval>,
     policy: &RunPolicy,
     max_turns: u64,
+    cancel: Option<&CancelToken>,
     now_ms: i64,
 ) -> Result<LoopOutcome, StorageError> {
     // 1. Ensure the session exists and LOAD its prior turns BEFORE persisting the
@@ -2957,7 +3036,7 @@ pub fn run_session_loop(
     let session_preamble = render_session_history(&prior);
     let combined_preamble = format!("{session_preamble}{recall_preamble}");
 
-    // 3. Run the SAME gate-mandatory loop (principal/scope/operator-key aware).
+    // 3. Run the SAME gate-mandatory loop (principal/scope/operator-key/cancel aware).
     let outcome = run_loop_with_policy(
         client,
         executor,
@@ -2969,6 +3048,7 @@ pub fn run_session_loop(
         approve,
         policy,
         max_turns,
+        cancel,
         now_ms,
     )?;
 
@@ -4707,6 +4787,7 @@ mod tests {
             &no_approval(),
             &RunPolicy::default(),
             5,
+            None, // cancel: not exercised by this test
             1000,
         )
         .expect("routed claude loop runs");
@@ -5795,6 +5876,7 @@ mod tests {
                 &no_approval(),
                 &RunPolicy::new(None, Vec::<String>::new(), true), // read-only ⇒ Deny mutations
                 5,
+                None, // cancel: not exercised by this test
                 1000,
             )
             .unwrap();
@@ -6126,6 +6208,7 @@ mod tests {
             &no_approval(),
             &RunPolicy::default(),
             10,
+            None, // cancel: not exercised by this test
             10,
         )
         .unwrap();
@@ -6193,6 +6276,7 @@ mod tests {
             &no_approval(),
             &RunPolicy::default(),
             5,
+            None, // cancel: not exercised by this test
             10,
         )
         .unwrap();
@@ -6218,6 +6302,7 @@ mod tests {
             &no_approval(),
             &RunPolicy::default(),
             5,
+            None, // cancel: not exercised by this test
             20,
         )
         .unwrap();
@@ -6313,6 +6398,7 @@ mod tests {
             &no_approval(),
             &RunPolicy::default(),
             5,
+            None, // cancel: not exercised by this test
             100,
         )
         .unwrap();
@@ -6355,6 +6441,7 @@ mod tests {
             &no_approval(),
             &policy,
             5,
+            None, // cancel: not exercised by this test
             10,
         )
         .unwrap();
@@ -6415,6 +6502,7 @@ mod tests {
             &no_approval(),
             &RunPolicy::default(), // no principal bound
             5,
+            None, // cancel: not exercised by this test
             10,
         )
         .unwrap();
@@ -6461,6 +6549,7 @@ mod tests {
             &no_approval(),
             &policy,
             5,
+            None, // cancel: not exercised by this test
             10,
         )
         .unwrap();
@@ -6512,6 +6601,7 @@ mod tests {
             &no_approval(),
             &RunPolicy::default(),
             5,
+            None, // cancel: not exercised by this test
             10,
         )
         .unwrap();
@@ -6547,6 +6637,7 @@ mod tests {
             &no_approval(),
             &RunPolicy::default(),
             5,
+            None, // cancel: not exercised by this test
             20,
         )
         .unwrap();
@@ -6587,6 +6678,7 @@ mod tests {
             &no_approval(),
             &RunPolicy::default(),
             5,
+            None, // cancel: not exercised by this test
             10,
         )
         .unwrap();

--- a/rust-core/crates/friday-hub/src/routing.rs
+++ b/rust-core/crates/friday-hub/src/routing.rs
@@ -461,6 +461,7 @@ pub fn run_routed_loop(
         approve,
         &crate::RunPolicy::default(),
         max_turns,
+        None, // cancel: no cancellation handle — pre-C2-1 behavior, byte-identical
         now_ms,
     )
 }
@@ -483,6 +484,7 @@ pub fn run_routed_loop_with_policy(
     approve: &dyn Fn(&MutatingActionRequest) -> Option<CanonicalApproval>,
     policy: &crate::RunPolicy,
     max_turns: u64,
+    cancel: Option<&crate::CancelToken>,
     now_ms: i64,
 ) -> Result<(RoutedSelection, LoopOutcome), RoutedLoopError> {
     let route = select_route(registry, request)?;
@@ -498,6 +500,8 @@ pub fn run_routed_loop_with_policy(
 
     // S6d: thread the operator verify key so the loop authorizes a protected action via the
     // Ed25519 verify-only policy (never the HMAC authorize). `None` ⇒ fail-closed Pause.
+    // C2-1: thread the cooperative cancellation handle VERBATIM (checked at each turn
+    // boundary); `None` ⇒ no cancellation, byte-identical to the pre-C2-1 routed loop.
     let outcome = run_loop_with_policy(
         client,
         executor,
@@ -509,6 +513,7 @@ pub fn run_routed_loop_with_policy(
         approve,
         policy,
         max_turns,
+        cancel,
         now_ms,
     )?;
     Ok((selection, outcome))

--- a/rust-core/crates/friday-hub/src/runtime.rs
+++ b/rust-core/crates/friday-hub/src/runtime.rs
@@ -44,8 +44,8 @@ use crate::routing::{
     RouteRequest, RoutedLoopError, RoutedSelection,
 };
 use crate::{
-    run_session_loop, AgentLlmClient, DeepSeekAgentLlmClient, FsToolExecutor, LoopOutcome,
-    LoopStatus, RunPolicy,
+    run_session_loop, AgentLlmClient, CancelToken, DeepSeekAgentLlmClient, FsToolExecutor,
+    LoopOutcome, LoopStatus, RunPolicy,
 };
 
 /// S1.3 — the outcome of [`HubRuntime::run_agent_loop_for_mission`], mirroring
@@ -345,6 +345,7 @@ impl<T: Transport> HubRuntime<T> {
             &RouteRequest::any(),
             policy_override,
             max_turns_override,
+            None,
             now_ms,
         )
     }
@@ -368,13 +369,40 @@ impl<T: Transport> HubRuntime<T> {
             preferred_provider: Some(provider_id.to_string()),
             ..RouteRequest::any()
         };
-        self.run_with_request(run_id, task, &request, None, None, now_ms)
+        self.run_with_request(run_id, task, &request, None, None, None, now_ms)
+    }
+
+    /// (C2-1) [`Self::run_task_pinned`] with a cooperative [`CancelToken`] threaded into the
+    /// routed loop — the interrupt/stop entry the routed-claude parity harness's `interrupt /
+    /// stop` flow needs. The token is checked at the TOP of each turn (BEFORE the model call):
+    /// when tripped at a turn boundary the loop stops with [`LoopStatus::Interrupted`], makes
+    /// NO further model call, and bills NOTHING after the trip. The holder keeps a clone of the
+    /// same `cancel` to call [`CancelToken::cancel`] from another point (in a single-threaded
+    /// test it is tripped between scripted turns via a cancel-on-call stub). Identical to
+    /// `run_task_pinned` in every other respect; passing a fresh/un-tripped token reproduces
+    /// `run_task_pinned` exactly.
+    pub fn run_task_pinned_cancellable(
+        &self,
+        run_id: &str,
+        task: &str,
+        provider_id: &str,
+        cancel: &CancelToken,
+        now_ms: i64,
+    ) -> Result<(RoutedSelection, LoopOutcome), RoutedLoopError> {
+        let request = RouteRequest {
+            preferred_provider: Some(provider_id.to_string()),
+            ..RouteRequest::any()
+        };
+        self.run_with_request(run_id, task, &request, None, None, Some(cancel), now_ms)
     }
 
     /// (C2) The SHARED composed-loop body for [`Self::run_task_with_overrides`] (open request)
     /// and [`Self::run_task_pinned`] (provider-pinned request). Factored out so there is ONE
-    /// composed loop — the ONLY variable between the two entries is `request`. The default path
-    /// remains byte-identical: `run_task_with_overrides` calls this with `&RouteRequest::any()`.
+    /// composed loop — the ONLY variable between the two entries is `request` (C2-1 adds the
+    /// optional `cancel` handle, `None` for the default/pinned non-cancellable entries). The
+    /// default path remains byte-identical: `run_task_with_overrides` calls this with
+    /// `&RouteRequest::any()` and `cancel: None`.
+    #[allow(clippy::too_many_arguments)]
     fn run_with_request(
         &self,
         run_id: &str,
@@ -382,6 +410,7 @@ impl<T: Transport> HubRuntime<T> {
         request: &RouteRequest,
         policy_override: Option<&RunPolicy>,
         max_turns_override: Option<u64>,
+        cancel: Option<&CancelToken>,
         now_ms: i64,
     ) -> Result<(RoutedSelection, LoopOutcome), RoutedLoopError> {
         // The effective per-run policy + ceiling. Absent override ⇒ boot config unchanged.
@@ -419,6 +448,7 @@ impl<T: Transport> HubRuntime<T> {
             &approve,
             policy,
             max_turns,
+            cancel,
             now_ms,
         )?;
 
@@ -570,6 +600,7 @@ impl<T: Transport> HubRuntime<T> {
             &approve,
             policy,
             max_turns,
+            None, // cancel: the sessioned entry is not cancellable (C2-1 is sessionless)
             now_ms,
         ) {
             Ok(outcome) => outcome,
@@ -707,6 +738,7 @@ impl<T: Transport> HubRuntime<T> {
             &approve,
             policy,
             max_turns,
+            None, // cancel: the sessioned entry is not cancellable (C2-1 is sessionless)
             now_ms,
         ) {
             Ok(outcome) => outcome,
@@ -1681,6 +1713,235 @@ mod tests {
             )
             .unwrap();
         assert_eq!(run_rows, 0, "no agent_run row was created for the dark pin");
+    }
+
+    // ---- C2-1 interrupt / stop: cooperative cancellation in the routed loop ----------------
+    //
+    // The §3 "interrupt / stop" flow the routed-claude parity harness lists as DEFERRED
+    // ("there is no cancel handle on run_task_pinned. WIRING NEEDED: a cancellation token
+    // threaded into the routed loop"). This is the GENUINE interrupt: a real metered claude
+    // turn is billed, then a hard cancel trips at the turn boundary and the loop stops with NO
+    // further model call and NOTHING billed after the trip — NOT a claude_control mirror event,
+    // NOT a follow-up turn. NO key, NO network. The `#[ignore]`'d live mirror lives in
+    // `tests/routed_claude_parity.rs`.
+
+    /// A cancel-AWARE Claude stub: each metered step surfaces an Anthropic-kind [`BilledUsage`]
+    /// (the bits the live `ClaudeAgentLlmClient` maps from a real chat) plus the next scripted
+    /// step, AND — to make a single-threaded interrupt deterministic — TRIPS the shared
+    /// [`CancelToken`] once it has served `trip_after_calls` steps. So after turn 1 returns, the
+    /// token is set; the loop checks it at the TOP of turn 2 and stops BEFORE calling this stub
+    /// again. `calls` is an externally-observable `Rc<Cell<usize>>` so the test can assert the
+    /// stub was NEVER called for turn 2 (no model call after the trip). This MIRRORS the
+    /// existing `StubClaudeMeteredClient` shape; it does NOT modify it (other tests depend on it).
+    struct CancelOnCallClaudeStub {
+        steps: Vec<AgentStep>,
+        prompt_tokens: i64,
+        completion_tokens: i64,
+        model: String,
+        calls: Rc<Cell<usize>>,
+        cancel: CancelToken,
+        trip_after_calls: usize,
+    }
+    impl crate::AgentLlmClient for CancelOnCallClaudeStub {
+        fn propose_tool_call(&self, _task: &str) -> Result<crate::RawToolCall, crate::AgentError> {
+            unreachable!("routed loop uses next_step_metered")
+        }
+        fn next_step_metered(
+            &self,
+            _task: &str,
+            _history: &[crate::TurnTrace],
+        ) -> Result<crate::MeteredStep, crate::AgentError> {
+            let i = self.calls.get();
+            self.calls.set(i + 1);
+            let step = self.steps.get(i).cloned().unwrap_or(AgentStep::Finish {
+                message: "done".to_string(),
+            });
+            let usage = crate::BilledUsage {
+                provider_kind: friday_core::ProviderKind::Anthropic,
+                model: self.model.clone(),
+                prompt_tokens: self.prompt_tokens,
+                completion_tokens: self.completion_tokens,
+            };
+            // Trip the token AFTER serving the Nth step — so the just-served turn completes and
+            // is billed normally, and the NEXT turn boundary observes the cancel. (`calls` was
+            // just incremented to `i+1`, the count of steps served.)
+            if self.calls.get() == self.trip_after_calls {
+                self.cancel.cancel();
+            }
+            Ok((Ok(step), Some(usage)))
+        }
+    }
+
+    /// Build a Claude-wired runtime around a [`CancelOnCallClaudeStub`] and hand back the SAME
+    /// flips `runtime_with_claude_wired` performs, plus the externally-observable `calls` handle
+    /// and the shared [`CancelToken`]. Mirrors how `runtime_with` returns `post_calls`. Leaves
+    /// `runtime_with_claude_wired` / `StubClaudeMeteredClient` untouched (NO-DEGRADE for the
+    /// existing harness).
+    fn cancellable_claude_runtime(
+        tag: &str,
+        steps: Vec<AgentStep>,
+        trip_after_calls: usize,
+    ) -> (
+        HubRuntime<ScriptTransport>,
+        TempDir,
+        CancelToken,
+        Rc<Cell<usize>>,
+    ) {
+        let ws = TempDir::new(tag);
+        let transport = ScriptTransport::new(&["{\"tool\":\"none\"}"]);
+        let client = DeepSeekClient::with_transport(transport, "k".into());
+        let agent = DeepSeekAgentLlmClient::new(client);
+        let mut rt = HubRuntime::new(
+            HubConfig {
+                db_path: tmp(tag),
+                workspace_root: ws.0.clone(),
+                secret: SECRET.to_vec(),
+                max_turns: 6,
+                principal_id: None,
+                disabled_tools: vec![],
+                read_only: false,
+                operator_vk: None,
+            },
+            agent,
+            Box::new(DenyAllApprovals),
+        )
+        .unwrap();
+        let calls = Rc::new(Cell::new(0usize));
+        let cancel = CancelToken::new();
+        rt = rt.with_claude(Box::new(CancelOnCallClaudeStub {
+            steps,
+            prompt_tokens: 11,
+            completion_tokens: 8,
+            model: friday_anthropic::DEFAULT_MODEL.to_string(),
+            calls: calls.clone(),
+            cancel: cancel.clone(),
+            trip_after_calls,
+        }));
+        rt.mark_route_available("claude");
+        rt.mark_route_validated("claude");
+        (rt, ws, cancel, calls)
+    }
+
+    #[test]
+    fn run_task_pinned_cancellable_interrupts_claude_loop_after_one_billed_turn() {
+        // INTERRUPT / STOP (routed + metered): a claude-pinned run with a MULTI-step script —
+        // turn 1 is a read-only tool that CONTINUES the loop (so a turn 2 is scripted), and the
+        // cancel token trips right after turn 1 returns. At the TOP of turn 2 the loop observes
+        // the cancel and stops with `Interrupted`: it makes NO turn-2 model call and bills
+        // NOTHING after the trip. This is the genuine interrupt — a real metered claude turn,
+        // then a hard cancel — NOT a claude_control mirror, NOT a follow-up turn.
+        //
+        // The workspace has `notes.md` so turn 1's `read_file` is a clean Allowed+Executed
+        // CONTINUE (read-only needs no approval); turn 2's scripted `Finish` must NEVER be
+        // consumed (calls == 1). Step 0 deliberately is NOT a Finish — a Finish would terminate
+        // before the turn-2 cancel check ever ran.
+        let (rt, ws, cancel, calls) = cancellable_claude_runtime(
+            "c2-1-interrupt",
+            vec![
+                // turn 1: read-only tool → Allowed + Executed → loop CONTINUES to turn 2
+                AgentStep::Tool(crate::RawToolCall {
+                    action: "read_file".to_string(),
+                    params: vec![("path".to_string(), "notes.md".to_string())],
+                }),
+                // turn 2: would Finish — but the cancel (tripped after turn 1) stops the loop
+                // at the turn-2 boundary BEFORE this step is ever requested.
+                AgentStep::Finish {
+                    message: "SHOULD NEVER BE REACHED".to_string(),
+                },
+            ],
+            1, // trip the cancel after the stub has served 1 step (i.e. after turn 1)
+        );
+        std::fs::write(ws.join("notes.md"), b"hello").unwrap();
+
+        let (selection, outcome) = rt
+            .run_task_pinned_cancellable(
+                "run-c2-1-int",
+                "do a thing then stop",
+                "claude",
+                &cancel,
+                1_000,
+            )
+            .expect("the cancellable pinned claude run drives the routed loop");
+
+        // The pin really routed to claude (no reroute).
+        assert_eq!(selection.provider_id, "claude", "the pin routed to claude");
+        // Terminal status is the NEW Interrupted variant — stopped at the turn-2 boundary.
+        assert_eq!(
+            outcome.status,
+            LoopStatus::Interrupted,
+            "the tripped cancel stops the loop with Interrupted"
+        );
+        // turns == 1: turn 1's model call happened (counted); turn 2's did NOT (the cancel
+        // check is BEFORE the model call, so it does not count) — the honest turns==model-calls
+        // accounting.
+        assert_eq!(outcome.turns, 1, "exactly one model call was made (turn 1)");
+        assert_eq!(
+            outcome.executed_tools, 1,
+            "turn 1's read_file executed before the cancel"
+        );
+
+        // THE no-model-call-after-trip proof: the stub was called EXACTLY ONCE. Turn 2's
+        // scripted Finish step was NEVER consumed.
+        assert_eq!(
+            calls.get(),
+            1,
+            "no model call after the trip — turn 2's scripted step was never consumed"
+        );
+
+        // THE bill-nothing-after-trip proof: EXACTLY ONE anthropic ledger row — turn 1's billed
+        // claude turn — and nothing after. (provider_kind anthropic, api.anthropic.com,
+        // fallback=false: a real metered claude turn, never mis-attributed as deepseek.)
+        let rows = rt.db().list_run_token_usage("run-c2-1-int").unwrap();
+        assert_eq!(
+            rows.len(),
+            1,
+            "exactly one anthropic row (turn 1); nothing billed after the cancel trip"
+        );
+        let row = &rows[0];
+        assert_eq!(
+            row.provider_kind, "anthropic",
+            "NOT mis-attributed as deepseek"
+        );
+        assert_eq!(row.base_url_host, "api.anthropic.com");
+        assert!(!row.fallback, "the claude route is never a fallback");
+        // Whole-ledger agrees: only the one anthropic row exists (no hidden call).
+        let all = rt.db().list_token_usage().unwrap();
+        assert_eq!(all.len(), 1, "no hidden model call anywhere in the ledger");
+        assert_eq!(all[0].provider_kind, "anthropic");
+    }
+
+    #[test]
+    fn run_task_pinned_cancellable_untripped_token_is_byte_identical_to_run_task_pinned() {
+        // NO-DEGRADE: an un-tripped cancel token reproduces `run_task_pinned` EXACTLY — the run
+        // Finishes, billing one anthropic row. The cancel check at each turn boundary is a pure
+        // no-op when the token is never tripped (and `None`, the default path, skips it
+        // entirely — proven by the unchanged existing `run_task_pinned_*` claude tests).
+        let (rt, _ws, cancel, calls) = cancellable_claude_runtime(
+            "c2-1-untripped",
+            vec![AgentStep::Finish {
+                message: "PONG".to_string(),
+            }],
+            usize::MAX, // never trip
+        );
+        let (selection, outcome) = rt
+            .run_task_pinned_cancellable("run-c2-1-noop", "say pong", "claude", &cancel, 2_000)
+            .expect("an un-tripped cancellable run behaves like run_task_pinned");
+        assert_eq!(selection.provider_id, "claude");
+        assert_eq!(
+            outcome.status,
+            LoopStatus::Finished,
+            "an un-tripped token does not change the terminal status"
+        );
+        assert_eq!(outcome.turns, 1);
+        assert_eq!(calls.get(), 1, "the single Finish turn ran");
+        assert!(!cancel.is_cancelled(), "the token was never tripped");
+        let rows = rt.db().list_run_token_usage("run-c2-1-noop").unwrap();
+        assert_eq!(
+            rows.len(),
+            1,
+            "one anthropic row for the single finished turn"
+        );
+        assert_eq!(rows[0].provider_kind, "anthropic");
     }
 
     // ---- PROOF-MEMORY-001 recall→inject wiring -------------------------------

--- a/rust-core/crates/friday-hub/tests/a1_run_control.rs
+++ b/rust-core/crates/friday-hub/tests/a1_run_control.rs
@@ -171,6 +171,7 @@ fn pause_owned_run(
         &no_approval(),
         &policy,
         5,
+        None, // cancel: not exercised by this test
         NOW,
     )
     .unwrap();

--- a/rust-core/crates/friday-hub/tests/routed_claude_parity.rs
+++ b/rust-core/crates/friday-hub/tests/routed_claude_parity.rs
@@ -131,7 +131,7 @@
 use friday_crypto::{seal, DeviceKeypair};
 use friday_hub::hub_server::AuthedPrincipal;
 use friday_hub::runtime::{HubConfig, HubRuntime, ENV_CLAUDE_ROUTE_ENABLED};
-use friday_hub::LoopStatus;
+use friday_hub::{CancelToken, LoopStatus};
 use friday_providers::KeyValidationOutcome;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -471,4 +471,85 @@ fn auth_failure_keeps_claude_undispatchable_no_reroute() {
         .run_task_pinned("live-claude-authfail", "say pong", "claude", 1_000)
         .expect_err("an unvalidated claude route must fail the pin closed, never reroute");
     eprintln!("LIVE OK: auth failure → claude undispatchable, pin failed closed: {err:?}");
+}
+
+// ---- C2-1 interrupt / stop: cooperative cancellation, LIVE -----------------------------------
+//
+// The live mirror of the deterministic, no-key in-crate proof
+// (`runtime.rs::run_task_pinned_cancellable_interrupts_claude_loop_after_one_billed_turn`).
+// The in-crate test is the REAL dark proof (it forces the trip deterministically between two
+// scripted turns); this LIVE test exercises the SAME `run_task_pinned_cancellable` entry against
+// a real Anthropic key, tripping the shared `CancelToken` from a background thread shortly after
+// the run starts. It is `#[ignore]`'d like every live test here — only the operator run spends
+// quota — and timing-dependent (a fast/slow model may interrupt at turn 0 vs. a later boundary),
+// so it asserts only the COOPERATIVE-STOP invariants that hold regardless of WHEN the trip lands:
+//   - the run terminates (no hang) routed to claude (no reroute);
+//   - the terminal status is `Interrupted` whenever the trip lands at or before a turn boundary
+//     the loop reaches (the common case for a multi-turn task);
+//   - EVERY recorded ledger row is anthropic / api.anthropic.com / non-fallback, and the row
+//     count equals `outcome.turns` (each counted turn billed exactly once; NOTHING billed after
+//     the trip — the same no-bill-after-trip property the in-crate test pins deterministically).
+// Only the `CancelToken` clone (Send) crosses the thread boundary; the runtime stays on this
+// thread.
+#[test]
+#[ignore = "live: needs FRIDAY_CLAUDE_ROUTE_ENABLED=1 + both provider keys; spends Anthropic quota; run with --ignored"]
+fn interrupt_stop_cancels_live_claude_loop_and_bills_nothing_after_trip() {
+    let (rt, _ws) = live_claude_runtime("interrupt-stop");
+    let cancel = CancelToken::new();
+    // Trip the cancel shortly after the run begins, from a background thread (only the token
+    // clone — which is Send — crosses the boundary; the runtime never leaves this thread).
+    let canceller = cancel.clone();
+    let handle = std::thread::spawn(move || {
+        std::thread::sleep(std::time::Duration::from_millis(50));
+        canceller.cancel();
+    });
+    let (selection, outcome) = rt
+        .run_task_pinned_cancellable(
+            "live-claude-interrupt",
+            // A deliberately multi-step task so the loop reaches a turn boundary where the
+            // (already-tripped) cancel can stop it after a real billed claude turn.
+            "Think step by step and use tools across several turns; do not finish immediately.",
+            "claude",
+            &cancel,
+            1_000,
+        )
+        .expect("a cancellable live pinned-claude run terminates (no hang, no reroute)");
+    handle.join().unwrap();
+    assert_eq!(
+        selection.provider_id, "claude",
+        "the pin routed to claude, no reroute"
+    );
+    // Whenever the loop reached a boundary after the trip, the status is Interrupted; a model
+    // that finished within the first turn before the trip landed would be Finished/Bounded —
+    // either way the metering invariant below must hold.
+    assert!(
+        matches!(
+            outcome.status,
+            LoopStatus::Interrupted | LoopStatus::Finished | LoopStatus::Bounded
+        ),
+        "cooperative stop or a fast finish; got {:?}",
+        outcome.status
+    );
+    // No-bill-after-trip + all-anthropic: one anthropic row per counted turn, nothing after.
+    let rows = rt
+        .db()
+        .list_run_token_usage("live-claude-interrupt")
+        .unwrap();
+    assert_eq!(
+        rows.len(),
+        outcome.turns as usize,
+        "exactly one anthropic row per counted turn; nothing billed after the cancel trip"
+    );
+    for row in &rows {
+        assert_eq!(
+            row.provider_kind, "anthropic",
+            "NOT mis-attributed as deepseek"
+        );
+        assert_eq!(row.base_url_host, "api.anthropic.com");
+        assert!(!row.fallback, "the claude route is never a fallback");
+    }
+    eprintln!(
+        "LIVE OK: interrupt/stop → claude, status {:?}, {} billed anthropic turn(s), nothing after trip",
+        outcome.status, outcome.turns
+    );
 }

--- a/rust-core/crates/friday-hub/tests/s6d_resume_ingestion.rs
+++ b/rust-core/crates/friday-hub/tests/s6d_resume_ingestion.rs
@@ -193,6 +193,7 @@ fn loop_protected_no_approval_pauses_and_persists_csprng_pending() {
         &no_approval(),
         &RunPolicy::default(),
         5,
+        None, // cancel: not exercised by this test
         NOW,
     )
     .unwrap();
@@ -254,6 +255,7 @@ fn loop_valid_ed25519_approval_executes_the_mutation() {
         &approve,
         &RunPolicy::default(),
         5,
+        None, // cancel: not exercised by this test
         NOW,
     )
     .unwrap();
@@ -291,6 +293,7 @@ fn loop_hmac_approval_cannot_execute_even_with_operator_key() {
         &approve,
         &RunPolicy::default(),
         5,
+        None, // cancel: not exercised by this test
         NOW,
     )
     .unwrap();
@@ -335,6 +338,7 @@ fn pause_a_run_with_policy(
         &no_approval(),
         policy,
         5,
+        None, // cancel: not exercised by this test
         NOW,
     )
     .unwrap();


### PR DESCRIPTION
## C2-1 — interrupt/stop via cooperative cancellation token

Adds a cooperative `CancelToken` (`Arc<AtomicBool>`) threaded into the routed run loop, so a claude-pinned run can be interrupted/stopped mid-loop. Closes the `tests/routed_claude_parity.rs` DEFERRED "interrupt / stop" flow ("there is no cancel handle on run_task_pinned. WIRING NEEDED: a cancellation token threaded into the routed loop").

### What it does
- New `CancelToken` type + new terminal `LoopStatus::Interrupted`.
- Checked at the **TOP** of each `for turn_index` iteration in `run_loop_with_policy`, **BEFORE** `next_step_metered`. A tripped token at a turn boundary stops the loop with `Interrupted`: **NO** further model call, **NOTHING** billed after the trip. `turns: turn_index` (not `+1`) — this turn's model call hasn't happened, preserving the turns==model-calls invariant.
- Threaded `Option<&CancelToken>` through `run_loop_with_policy → run_session_loop`, `run_routed_loop_with_policy`, and `run_with_request`; new public entry `run_task_pinned_cancellable` on `HubRuntime`.
- Cooperative/between-turns: a turn already in flight completes and is billed normally; the cancel takes effect at the next turn boundary.

### DARK
Live proof is anthropic-key-gated. The `#[ignore]`'d live test (`interrupt_stop_cancels_live_claude_loop_and_bills_nothing_after_trip`) mirrors the existing live tests. The **deterministic no-key in-crate test IS the dark proof**: a claude-pinned multi-step run, cancel tripped after turn 1, asserting `provider_id==claude`, EXACTLY 1 anthropic row (`api.anthropic.com`, `fallback==false`), `status==Interrupted`, `turns==1`, and the stub called EXACTLY ONCE (turn 2's `Finish` never consumed — genuine no-call/no-bill after the trip, never a claude_control mirror).

### NO-DEGRADE
The token is `Option<&CancelToken>` defaulted to `None`; every existing call-site passes `None` and is byte-identical to before. No exhaustive `match` on `LoopStatus` exists (verified by the green `clippy --workspace --all-targets -D warnings` + full test build — E0004 would have fired otherwise), so the new variant needs no arm changes. Post-loop owner-wiring tails gate on `Finished`, so `Interrupted` falls through like `Bounded`/`Errored` (user turn appended, no `run_result` persisted). A NO-DEGRADE test confirms an un-tripped token reproduces `run_task_pinned` exactly.

### Local gate (all green, in order)
`cargo fmt --all -- --check` · `cargo clippy --workspace --all-targets -- -D warnings` · `cargo test -p friday-hub` (566 lib + all integration; 2 new tests pass; live test stays ignored).

🤖 Generated with [Claude Code](https://claude.com/claude-code)