### PR TITLE
feat(c2-2): mid-loop steer as an additional metered claude turn

### DIFF
--- a/rust-core/crates/friday-hub/src/lib.rs
+++ b/rust-core/crates/friday-hub/src/lib.rs
@@ -2091,6 +2091,55 @@ impl CancelToken {
     }
 }
 
+/// (C2-2) A cooperative STEER handle for the routed run loop: an OPTIONAL slot holding at most
+/// ONE pending operator instruction. The loop [`SteerHandle::drain`]s it at the TOP of each turn
+/// (AFTER the [`CancelToken`] check, BEFORE the model call), and a drained instruction is folded
+/// into the prompt the model sees for that turn — so the NEXT `next_step_metered` carries it and
+/// produces a REAL extra billed turn whose chat is grounded on the steer. It is NOT a no-op
+/// mirror event and NOT a follow-up of its own: it changes the CONTENT of the turn the loop was
+/// already about to take. Cooperative/between-turns like the cancel: a turn already in flight is
+/// not re-prompted; the steer lands at the NEXT turn boundary the loop reaches. (It therefore
+/// cannot resurrect a loop that has already `Finish`ed — there is no next boundary.)
+///
+/// Clone-cheap (`Arc<Mutex<..>>`); the holder keeps a clone and calls [`SteerHandle::steer`] from
+/// another point (in a single-threaded test the stub injects it between scripted turns; the live
+/// test injects from a background thread, the same way the cancel is tripped). [`SteerHandle::drain`]
+/// returns `None` when empty — the no-op the no-steer path relies on. A drained instruction is
+/// consumed (`take`) so it is FOLDED IN exactly ONCE (the drain never re-fires on a later turn);
+/// having been folded into the prompt it then REMAINS in the model's context for the rest of the
+/// run, BY DESIGN — the loop's history (`TurnTrace`) has no slot to carry a free-form instruction,
+/// so dropping it after a single turn would make the model forget the operator's steer mid-task.
+///
+/// DARK: this is the steer substrate the routed-claude parity harness needs (the provider-workspace
+/// `SteerTurn=Unsupported` mirror is NOT a metered turn — this is). The no-key in-crate test, which
+/// asserts the stub OBSERVED the injected instruction in its `task` argument on the steered turn and
+/// NOT before, is its deterministic proof.
+#[derive(Clone, Debug, Default)]
+pub struct SteerHandle(std::sync::Arc<std::sync::Mutex<Option<String>>>);
+
+impl SteerHandle {
+    /// A fresh, empty steer handle (no pending instruction).
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Queue an operator instruction to fold into the model's NEXT turn. Replaces any prior
+    /// un-drained instruction (the slot holds at most one — the latest steer wins). Observed by
+    /// the loop at the next turn boundary; no effect on a turn already in flight.
+    pub fn steer(&self, instruction: impl Into<String>) {
+        if let Ok(mut slot) = self.0.lock() {
+            *slot = Some(instruction.into());
+        }
+    }
+
+    /// Take the pending instruction if any, leaving the slot empty. Returns `None` (a no-op)
+    /// when empty — the no-steer path. A poisoned lock is treated as empty (fail-closed: no
+    /// fabricated steer), never a panic in the hot loop.
+    pub fn drain(&self) -> Option<String> {
+        self.0.lock().ok().and_then(|mut slot| slot.take())
+    }
+}
+
 /// How a [`run_loop`] ended.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum LoopStatus {
@@ -2532,6 +2581,7 @@ pub fn run_loop(
         &RunPolicy::default(),
         max_turns,
         None, // cancel: no cancellation handle — pre-C2-1 behavior, byte-identical
+        None, // steer: no steer handle — pre-C2-2 behavior, byte-identical
         now_ms,
     )
 }
@@ -2592,6 +2642,18 @@ const RUN_LOOP_MAX_PROVIDER_ATTEMPTS: u32 = 3;
 /// pre-C2-1 behavior, BYTE-IDENTICAL — no check, no new stop. Cooperative/between-turns:
 /// a turn already in flight completes and is billed normally; the cancel takes effect at
 /// the NEXT turn boundary only.
+///
+/// `steer` (C2-2) is an OPTIONAL cooperative steer handle drained at the TOP of each turn,
+/// AFTER the cancel check and BEFORE the model call. When `Some` and holding a pending
+/// instruction at a turn boundary, the instruction is folded into the prompt for THIS turn —
+/// so the turn's `next_step_metered` carries it and produces a REAL billed model call grounded
+/// on the steer (an additional metered turn if the loop was continuing). `None`/empty (the
+/// default for every existing caller, and any turn with nothing pending) is BYTE-IDENTICAL to
+/// pre-C2-2: the drain is a no-op and `prompt_task` is unchanged. Cooperative/between-turns:
+/// a turn already in flight is not re-prompted; the steer lands at the next boundary. It folds
+/// into exactly one turn (the drain consumes it), and it cannot revive a `Finish`ed loop (there
+/// is no next boundary). It changes the prompt the model sees, never the run row / classification
+/// / billing attribution — the billed row is the ordinary per-turn anthropic/deepseek row.
 #[allow(clippy::too_many_arguments)]
 pub fn run_loop_with_policy(
     client: &dyn AgentLlmClient,
@@ -2605,6 +2667,7 @@ pub fn run_loop_with_policy(
     policy: &RunPolicy,
     max_turns: u64,
     cancel: Option<&CancelToken>,
+    steer: Option<&SteerHandle>,
     now_ms: i64,
 ) -> Result<LoopOutcome, StorageError> {
     // Plan classification recorded ONCE (it is a property of the task, constant across
@@ -2631,7 +2694,10 @@ pub fn run_loop_with_policy(
     // read file could contain adversarial instructions. The SAME backstop holds: that
     // content only ever reaches the prompt, and the gate still evaluates every subsequent
     // tool call regardless of what the file said; it is not a new mutation path.
-    let prompt_task = if recall_preamble.is_empty() {
+    // (C2-2) `mut` so a drained steer instruction can be folded in at a turn boundary below.
+    // Absent any steer (every pre-C2-2 caller, and any turn with nothing pending) this is never
+    // reassigned, so the prompt is byte-identical to before.
+    let mut prompt_task = if recall_preamble.is_empty() {
         task.to_string()
     } else {
         format!("{recall_preamble}{task}")
@@ -2674,6 +2740,31 @@ pub fn run_loop_with_policy(
                 final_message: None,
                 detail: format!("interrupted:turn={turn_index}"),
             });
+        }
+
+        // (C2-2) Cooperative steer, drained at the TOP of the turn — AFTER the cancel check
+        // (never re-prompt a turn an interrupt is about to cancel) and BEFORE the model call —
+        // so a pending operator instruction is folded into THIS turn's prompt and carried by
+        // `next_step_metered` below, producing a REAL billed model call grounded on the steer.
+        // The drain CONSUMES the instruction so it is folded in exactly ONCE (the drain never
+        // re-fires on a later turn). NOTE `prompt_task` is mutated IN PLACE and that mutation
+        // PERSISTS for the rest of the run — having been folded in, the steer REMAINS in the
+        // model's context on every subsequent turn, BY DESIGN (the loop's `history`/`TurnTrace`
+        // has no slot to carry a free-form instruction, so dropping it after one turn would make
+        // the model forget the operator's steer mid-task). When `steer` is `None` (every pre-C2-2
+        // caller) OR holds nothing, `drain()` returns `None`, `prompt_task` is left untouched, and
+        // this turn is byte-identical to before — billing/accounting/status unchanged (non-steered).
+        // The steer enters the agent's INSTRUCTION context (a prompt-injection-inward surface, like
+        // the recall preamble and the threaded-back tool-result content): the UNW-001 gate still
+        // evaluates EVERY subsequent tool call regardless of the steer text, so it is not a new
+        // mutation path. A refs-only `agent.steered` marker is recorded (NO ledger row — the
+        // billing is the ordinary per-turn row written below); this marker is evidence, NOT the
+        // metered turn itself.
+        if let Some(instruction) = steer.and_then(SteerHandle::drain) {
+            if !instruction.is_empty() {
+                prompt_task = format!("{prompt_task}\n\n[operator steer]: {instruction}");
+                agent_run::record_event(conn, &ev("steered"), run_id, "agent.steered", now_ms)?;
+            }
         }
 
         // S1.2 usage-parity: ONE metered model call per turn. An OUTER `Err` is a
@@ -3003,6 +3094,12 @@ pub fn run_loop_with_policy(
 /// turn is still appended (the operator asked it), but no `assistant` answer and no
 /// owner-wired `run_result` (those are gated on `Finished`). `None` (every existing
 /// caller) is byte-identical to the pre-C2-1 sessioned behavior.
+/// `steer` (C2-2) is the OPTIONAL cooperative steer handle, threaded VERBATIM into the inner
+/// [`run_loop_with_policy`] (drained at each turn boundary, folded into that turn's prompt). It
+/// affects only the model's PROMPT for the steered turn — the session's persisted `user`/`assistant`
+/// messages (the clean `task` and the loop's final answer) are unchanged, so the steer never
+/// rewrites the durable session transcript. `None` (every existing caller) is byte-identical to the
+/// pre-C2-2 sessioned behavior.
 #[allow(clippy::too_many_arguments)]
 pub fn run_session_loop(
     client: &dyn AgentLlmClient,
@@ -3018,6 +3115,7 @@ pub fn run_session_loop(
     policy: &RunPolicy,
     max_turns: u64,
     cancel: Option<&CancelToken>,
+    steer: Option<&SteerHandle>,
     now_ms: i64,
 ) -> Result<LoopOutcome, StorageError> {
     // 1. Ensure the session exists and LOAD its prior turns BEFORE persisting the
@@ -3036,7 +3134,7 @@ pub fn run_session_loop(
     let session_preamble = render_session_history(&prior);
     let combined_preamble = format!("{session_preamble}{recall_preamble}");
 
-    // 3. Run the SAME gate-mandatory loop (principal/scope/operator-key/cancel aware).
+    // 3. Run the SAME gate-mandatory loop (principal/scope/operator-key/cancel/steer aware).
     let outcome = run_loop_with_policy(
         client,
         executor,
@@ -3049,6 +3147,7 @@ pub fn run_session_loop(
         policy,
         max_turns,
         cancel,
+        steer,
         now_ms,
     )?;
 
@@ -4788,6 +4887,7 @@ mod tests {
             &RunPolicy::default(),
             5,
             None, // cancel: not exercised by this test
+            None, // steer: not exercised by this test
             1000,
         )
         .expect("routed claude loop runs");
@@ -5877,6 +5977,7 @@ mod tests {
                 &RunPolicy::new(None, Vec::<String>::new(), true), // read-only ⇒ Deny mutations
                 5,
                 None, // cancel: not exercised by this test
+                None, // steer: not exercised by this test
                 1000,
             )
             .unwrap();
@@ -6209,6 +6310,7 @@ mod tests {
             &RunPolicy::default(),
             10,
             None, // cancel: not exercised by this test
+            None, // steer: not exercised by this test
             10,
         )
         .unwrap();
@@ -6277,6 +6379,7 @@ mod tests {
             &RunPolicy::default(),
             5,
             None, // cancel: not exercised by this test
+            None, // steer: not exercised by this test
             10,
         )
         .unwrap();
@@ -6303,6 +6406,7 @@ mod tests {
             &RunPolicy::default(),
             5,
             None, // cancel: not exercised by this test
+            None, // steer: not exercised by this test
             20,
         )
         .unwrap();
@@ -6399,6 +6503,7 @@ mod tests {
             &RunPolicy::default(),
             5,
             None, // cancel: not exercised by this test
+            None, // steer: not exercised by this test
             100,
         )
         .unwrap();
@@ -6442,6 +6547,7 @@ mod tests {
             &policy,
             5,
             None, // cancel: not exercised by this test
+            None, // steer: not exercised by this test
             10,
         )
         .unwrap();
@@ -6503,6 +6609,7 @@ mod tests {
             &RunPolicy::default(), // no principal bound
             5,
             None, // cancel: not exercised by this test
+            None, // steer: not exercised by this test
             10,
         )
         .unwrap();
@@ -6550,6 +6657,7 @@ mod tests {
             &policy,
             5,
             None, // cancel: not exercised by this test
+            None, // steer: not exercised by this test
             10,
         )
         .unwrap();
@@ -6602,6 +6710,7 @@ mod tests {
             &RunPolicy::default(),
             5,
             None, // cancel: not exercised by this test
+            None, // steer: not exercised by this test
             10,
         )
         .unwrap();
@@ -6638,6 +6747,7 @@ mod tests {
             &RunPolicy::default(),
             5,
             None, // cancel: not exercised by this test
+            None, // steer: not exercised by this test
             20,
         )
         .unwrap();
@@ -6679,6 +6789,7 @@ mod tests {
             &RunPolicy::default(),
             5,
             None, // cancel: not exercised by this test
+            None, // steer: not exercised by this test
             10,
         )
         .unwrap();

--- a/rust-core/crates/friday-hub/src/routing.rs
+++ b/rust-core/crates/friday-hub/src/routing.rs
@@ -462,6 +462,7 @@ pub fn run_routed_loop(
         &crate::RunPolicy::default(),
         max_turns,
         None, // cancel: no cancellation handle — pre-C2-1 behavior, byte-identical
+        None, // steer: no steer handle — pre-C2-2 behavior, byte-identical
         now_ms,
     )
 }
@@ -485,6 +486,7 @@ pub fn run_routed_loop_with_policy(
     policy: &crate::RunPolicy,
     max_turns: u64,
     cancel: Option<&crate::CancelToken>,
+    steer: Option<&crate::SteerHandle>,
     now_ms: i64,
 ) -> Result<(RoutedSelection, LoopOutcome), RoutedLoopError> {
     let route = select_route(registry, request)?;
@@ -502,6 +504,8 @@ pub fn run_routed_loop_with_policy(
     // Ed25519 verify-only policy (never the HMAC authorize). `None` ⇒ fail-closed Pause.
     // C2-1: thread the cooperative cancellation handle VERBATIM (checked at each turn
     // boundary); `None` ⇒ no cancellation, byte-identical to the pre-C2-1 routed loop.
+    // C2-2: thread the cooperative steer handle VERBATIM (drained at each turn boundary,
+    // folded into that turn's prompt); `None` ⇒ no steer, byte-identical to before.
     let outcome = run_loop_with_policy(
         client,
         executor,
@@ -514,6 +518,7 @@ pub fn run_routed_loop_with_policy(
         policy,
         max_turns,
         cancel,
+        steer,
         now_ms,
     )?;
     Ok((selection, outcome))

--- a/rust-core/crates/friday-hub/src/runtime.rs
+++ b/rust-core/crates/friday-hub/src/runtime.rs
@@ -345,7 +345,8 @@ impl<T: Transport> HubRuntime<T> {
             &RouteRequest::any(),
             policy_override,
             max_turns_override,
-            None,
+            None, // cancel: not cancellable here (C2-1)
+            None, // steer: not steerable here (C2-2)
             now_ms,
         )
     }
@@ -369,7 +370,7 @@ impl<T: Transport> HubRuntime<T> {
             preferred_provider: Some(provider_id.to_string()),
             ..RouteRequest::any()
         };
-        self.run_with_request(run_id, task, &request, None, None, None, now_ms)
+        self.run_with_request(run_id, task, &request, None, None, None, None, now_ms)
     }
 
     /// (C2-1) [`Self::run_task_pinned`] with a cooperative [`CancelToken`] threaded into the
@@ -393,15 +394,60 @@ impl<T: Transport> HubRuntime<T> {
             preferred_provider: Some(provider_id.to_string()),
             ..RouteRequest::any()
         };
-        self.run_with_request(run_id, task, &request, None, None, Some(cancel), now_ms)
+        self.run_with_request(
+            run_id,
+            task,
+            &request,
+            None,
+            None,
+            Some(cancel),
+            None,
+            now_ms,
+        )
+    }
+
+    /// (C2-2) [`Self::run_task_pinned`] with a cooperative [`crate::SteerHandle`] threaded into
+    /// the routed loop — the mid-loop STEER entry the routed-claude parity harness needs. The
+    /// handle is drained at the TOP of each turn (AFTER the cancel check, BEFORE the model call):
+    /// a pending instruction is folded into THAT turn's prompt, so the turn's metered chat carries
+    /// it and produces a REAL billed model call grounded on the steer — an ADDITIONAL metered turn
+    /// when the loop was continuing, NOT a no-op mirror event. The holder keeps a clone of the same
+    /// `steer` to call [`crate::SteerHandle::steer`] from another point (in a single-threaded test
+    /// the steer is injected between scripted turns via a steer-on-call stub; the live test injects
+    /// it from a background thread). Identical to `run_task_pinned` in every other respect; an
+    /// EMPTY handle (nothing ever steered) reproduces `run_task_pinned` exactly. NOT cancellable
+    /// (steer and cancel are independent entries this slice; composing both is a later refinement).
+    pub fn run_task_pinned_steerable(
+        &self,
+        run_id: &str,
+        task: &str,
+        provider_id: &str,
+        steer: &crate::SteerHandle,
+        now_ms: i64,
+    ) -> Result<(RoutedSelection, LoopOutcome), RoutedLoopError> {
+        let request = RouteRequest {
+            preferred_provider: Some(provider_id.to_string()),
+            ..RouteRequest::any()
+        };
+        self.run_with_request(
+            run_id,
+            task,
+            &request,
+            None,
+            None,
+            None,
+            Some(steer),
+            now_ms,
+        )
     }
 
     /// (C2) The SHARED composed-loop body for [`Self::run_task_with_overrides`] (open request)
     /// and [`Self::run_task_pinned`] (provider-pinned request). Factored out so there is ONE
     /// composed loop — the ONLY variable between the two entries is `request` (C2-1 adds the
-    /// optional `cancel` handle, `None` for the default/pinned non-cancellable entries). The
-    /// default path remains byte-identical: `run_task_with_overrides` calls this with
-    /// `&RouteRequest::any()` and `cancel: None`.
+    /// optional `cancel` handle, C2-2 the optional `steer` handle, both `None` for the
+    /// default/pinned non-cancellable/non-steerable entries). The default path remains
+    /// byte-identical: `run_task_with_overrides` calls this with `&RouteRequest::any()`,
+    /// `cancel: None`, and `steer: None`.
     #[allow(clippy::too_many_arguments)]
     fn run_with_request(
         &self,
@@ -411,6 +457,7 @@ impl<T: Transport> HubRuntime<T> {
         policy_override: Option<&RunPolicy>,
         max_turns_override: Option<u64>,
         cancel: Option<&CancelToken>,
+        steer: Option<&crate::SteerHandle>,
         now_ms: i64,
     ) -> Result<(RoutedSelection, LoopOutcome), RoutedLoopError> {
         // The effective per-run policy + ceiling. Absent override ⇒ boot config unchanged.
@@ -449,6 +496,7 @@ impl<T: Transport> HubRuntime<T> {
             policy,
             max_turns,
             cancel,
+            steer,
             now_ms,
         )?;
 
@@ -601,6 +649,7 @@ impl<T: Transport> HubRuntime<T> {
             policy,
             max_turns,
             None, // cancel: the sessioned entry is not cancellable (C2-1 is sessionless)
+            None, // steer: the sessioned entry is not steerable (C2-2 is sessionless)
             now_ms,
         ) {
             Ok(outcome) => outcome,
@@ -739,6 +788,7 @@ impl<T: Transport> HubRuntime<T> {
             policy,
             max_turns,
             None, // cancel: the sessioned entry is not cancellable (C2-1 is sessionless)
+            None, // steer: the sessioned entry is not steerable (C2-2 is sessionless)
             now_ms,
         ) {
             Ok(outcome) => outcome,
@@ -1942,6 +1992,344 @@ mod tests {
             "one anthropic row for the single finished turn"
         );
         assert_eq!(rows[0].provider_kind, "anthropic");
+    }
+
+    // ---- C2-2 steer turn: mid-loop re-prompt as an additional metered turn --------------------
+    //
+    // The §3 "steer / inject mid-loop" flow: an operator instruction folded into the NEXT turn as
+    // a REAL additional metered claude turn (NOT the provider-workspace `SteerTurn=Unsupported`
+    // mirror, which is no metered turn at all). This is the DETERMINISTIC, no-key dark proof — it
+    // drives the REAL public `HubRuntime::run_task_pinned_steerable("claude", ..)` entry to a stub
+    // that (a) CAPTURES the prompt it is handed on every call into an externally-observable handle,
+    // and (b) injects the steer into the shared `SteerHandle` right after turn 1 — the same
+    // single-threaded determinism the C2-1 cancel stub uses. The make-or-break assertion is the
+    // DELTA: turn 1's captured prompt does NOT contain the steer; turn 2's DOES — proving the loop
+    // folded the injected instruction into the next metered turn, not that the string was always
+    // there. Paired with rows 1→2 (an extra billed anthropic row for the steered turn).
+
+    /// A steer-AWARE Claude stub: each metered step surfaces an Anthropic-kind [`BilledUsage`]
+    /// (the bits the live `ClaudeAgentLlmClient` maps from a real chat) plus the next scripted
+    /// step, CAPTURES the `task` (prompt) it is handed into a shared `Rc<RefCell<Vec<String>>>`
+    /// (so the test can assert what the model actually received on each turn), AND — to make a
+    /// single-threaded steer deterministic — INJECTS `steer_instruction` into the shared
+    /// [`crate::SteerHandle`] once it has served `steer_after_calls` steps. So after turn 1
+    /// returns, the handle holds the instruction; the loop drains it at the TOP of turn 2 and
+    /// folds it into turn 2's prompt BEFORE calling this stub again — which then captures the
+    /// steered prompt as `captured[1]`. MIRRORS the `CancelOnCallClaudeStub` shape; it does NOT
+    /// modify the existing stubs (other tests depend on them).
+    struct SteerOnCallClaudeStub {
+        steps: Vec<AgentStep>,
+        prompt_tokens: i64,
+        completion_tokens: i64,
+        model: String,
+        calls: Rc<Cell<usize>>,
+        captured: Rc<std::cell::RefCell<Vec<String>>>,
+        steer: crate::SteerHandle,
+        steer_after_calls: usize,
+        steer_instruction: String,
+    }
+    impl crate::AgentLlmClient for SteerOnCallClaudeStub {
+        fn propose_tool_call(&self, _task: &str) -> Result<crate::RawToolCall, crate::AgentError> {
+            unreachable!("routed loop uses next_step_metered")
+        }
+        fn next_step_metered(
+            &self,
+            task: &str,
+            _history: &[crate::TurnTrace],
+        ) -> Result<crate::MeteredStep, crate::AgentError> {
+            // Capture the EXACT prompt this turn was handed (the load-bearing observation: the
+            // steered turn's prompt must contain the injected instruction, the prior turn's must not).
+            self.captured.borrow_mut().push(task.to_string());
+            let i = self.calls.get();
+            self.calls.set(i + 1);
+            let step = self.steps.get(i).cloned().unwrap_or(AgentStep::Finish {
+                message: "done".to_string(),
+            });
+            let usage = crate::BilledUsage {
+                provider_kind: friday_core::ProviderKind::Anthropic,
+                model: self.model.clone(),
+                prompt_tokens: self.prompt_tokens,
+                completion_tokens: self.completion_tokens,
+            };
+            // Inject the steer AFTER serving the Nth step — so the just-served turn is NOT steered
+            // and the NEXT turn boundary drains + folds it. (`calls` was just incremented to `i+1`,
+            // the count of steps served.)
+            if self.calls.get() == self.steer_after_calls {
+                self.steer.steer(self.steer_instruction.clone());
+            }
+            Ok((Ok(step), Some(usage)))
+        }
+    }
+
+    /// Build a Claude-wired runtime around a [`SteerOnCallClaudeStub`] and hand back the SAME
+    /// flips `runtime_with_claude_wired` performs, plus the externally-observable `calls` and
+    /// `captured` handles and the shared [`crate::SteerHandle`]. Mirrors `cancellable_claude_runtime`.
+    /// Leaves `runtime_with_claude_wired` / the existing stubs untouched (NO-DEGRADE).
+    #[allow(clippy::type_complexity)]
+    fn steerable_claude_runtime(
+        tag: &str,
+        steps: Vec<AgentStep>,
+        steer_after_calls: usize,
+        steer_instruction: &str,
+    ) -> (
+        HubRuntime<ScriptTransport>,
+        TempDir,
+        crate::SteerHandle,
+        Rc<Cell<usize>>,
+        Rc<std::cell::RefCell<Vec<String>>>,
+    ) {
+        let ws = TempDir::new(tag);
+        let transport = ScriptTransport::new(&["{\"tool\":\"none\"}"]);
+        let client = DeepSeekClient::with_transport(transport, "k".into());
+        let agent = DeepSeekAgentLlmClient::new(client);
+        let mut rt = HubRuntime::new(
+            HubConfig {
+                db_path: tmp(tag),
+                workspace_root: ws.0.clone(),
+                secret: SECRET.to_vec(),
+                max_turns: 6,
+                principal_id: None,
+                disabled_tools: vec![],
+                read_only: false,
+                operator_vk: None,
+            },
+            agent,
+            Box::new(DenyAllApprovals),
+        )
+        .unwrap();
+        let calls = Rc::new(Cell::new(0usize));
+        let captured = Rc::new(std::cell::RefCell::new(Vec::new()));
+        let steer = crate::SteerHandle::new();
+        rt = rt.with_claude(Box::new(SteerOnCallClaudeStub {
+            steps,
+            prompt_tokens: 11,
+            completion_tokens: 8,
+            model: friday_anthropic::DEFAULT_MODEL.to_string(),
+            calls: calls.clone(),
+            captured: captured.clone(),
+            steer: steer.clone(),
+            steer_after_calls,
+            steer_instruction: steer_instruction.to_string(),
+        }));
+        rt.mark_route_available("claude");
+        rt.mark_route_validated("claude");
+        (rt, ws, steer, calls, captured)
+    }
+
+    #[test]
+    fn run_task_pinned_steerable_folds_steer_into_an_additional_metered_claude_turn() {
+        // STEER (routed + metered): a claude-pinned run with a MULTI-step script — turn 1 is a
+        // read-only tool that CONTINUES the loop (so a turn 2 is scripted), and the operator steer
+        // is injected right after turn 1 returns. At the TOP of turn 2 the loop DRAINS the steer
+        // and folds it into turn 2's prompt, so turn 2 is a REAL additional metered claude turn
+        // whose chat carries the injected instruction. This is the genuine steer — an extra billed
+        // claude turn grounded on the injection — NOT a `SteerTurn=Unsupported` mirror.
+        //
+        // The workspace has `notes.md` so turn 1's `read_file` is a clean Allowed+Executed CONTINUE
+        // (read-only needs no approval); turn 2's scripted `Finish` ends the run AFTER the steered
+        // metered call. Step 0 deliberately is NOT a Finish — a Finish would terminate before any
+        // turn-2 boundary, so the steer would have no next turn to fold into (an honest property:
+        // steer changes the CONTENT of an already-continuing turn, it does not resurrect a finished
+        // loop).
+        const STEER: &str = "ACTUALLY: also summarize the file in one line";
+        let (rt, ws, steer, calls, captured) = steerable_claude_runtime(
+            "c2-2-steer",
+            vec![
+                // turn 1: read-only tool → Allowed + Executed → loop CONTINUES to turn 2
+                AgentStep::Tool(crate::RawToolCall {
+                    action: "read_file".to_string(),
+                    params: vec![("path".to_string(), "notes.md".to_string())],
+                }),
+                // turn 2: Finish — this is the STEERED metered turn (its prompt carries the steer),
+                // then the loop ends with the answer.
+                AgentStep::Finish {
+                    message: "STEERED DONE".to_string(),
+                },
+            ],
+            1, // inject the steer after the stub has served 1 step (i.e. after turn 1)
+            STEER,
+        );
+        std::fs::write(ws.join("notes.md"), b"hello").unwrap();
+
+        let (selection, outcome) = rt
+            .run_task_pinned_steerable("run-c2-2-steer", "read the file", "claude", &steer, 1_000)
+            .expect("the steerable pinned claude run drives the routed loop");
+
+        // The pin really routed to claude (no reroute).
+        assert_eq!(selection.provider_id, "claude", "the pin routed to claude");
+        // The run ran the FULL two turns (turn 1 tool, turn 2 the steered Finish) — the steer added
+        // a real continuing turn, it did not interrupt.
+        assert_eq!(
+            outcome.status,
+            LoopStatus::Finished,
+            "the steered turn finished the run"
+        );
+        assert_eq!(
+            outcome.turns, 2,
+            "two model calls: turn 1 + the extra steered turn 2"
+        );
+        assert_eq!(
+            calls.get(),
+            2,
+            "the stub was called for BOTH turns — the steered turn is a REAL extra model call"
+        );
+        // The steer was consumed (drained) — it folds into exactly one turn, not silently re-applied.
+        assert!(
+            steer.drain().is_none(),
+            "the steer was consumed by the steered turn (the handle is empty after)"
+        );
+
+        // THE faithfulness proof — the DELTA: turn 1's prompt does NOT carry the steer, turn 2's
+        // DOES. This proves the loop FOLDED the injected instruction into the next metered turn,
+        // not that the string happened to be in the prompt all along. (Captured straight off the
+        // stub's `task` argument on each call — what the model actually received.)
+        let captured = captured.borrow();
+        assert_eq!(captured.len(), 2, "both turns' prompts were captured");
+        assert!(
+            !captured[0].contains(STEER),
+            "turn 1's prompt must NOT contain the steer (it was injected only AFTER turn 1): {:?}",
+            captured[0]
+        );
+        assert!(
+            captured[1].contains(STEER),
+            "turn 2's prompt MUST contain the folded steer — the stub OBSERVED the injection: {:?}",
+            captured[1]
+        );
+
+        // THE extra-billed-turn proof: rows grow 1→2, an ADDITIONAL anthropic row for the steered
+        // turn. BOTH rows are anthropic / api.anthropic.com / non-fallback — the steered turn is a
+        // real metered claude turn, never mis-attributed as deepseek and never a fallback.
+        let rows = rt.db().list_run_token_usage("run-c2-2-steer").unwrap();
+        assert_eq!(
+            rows.len(),
+            2,
+            "two anthropic rows: turn 1 + the EXTRA billed steered turn 2"
+        );
+        for row in &rows {
+            assert_eq!(
+                row.provider_kind, "anthropic",
+                "NOT mis-attributed as deepseek"
+            );
+            assert_eq!(row.base_url_host, "api.anthropic.com");
+            assert!(!row.fallback, "the claude route is never a fallback");
+        }
+        // Whole-ledger agrees: exactly the two anthropic rows exist (no hidden call).
+        let all = rt.db().list_token_usage().unwrap();
+        assert_eq!(all.len(), 2, "no hidden model call anywhere in the ledger");
+        assert!(all.iter().all(|r| r.provider_kind == "anthropic"));
+    }
+
+    #[test]
+    fn run_task_pinned_steerable_empty_handle_is_byte_identical_to_run_task_pinned() {
+        // NO-DEGRADE: an EMPTY steer handle (nothing ever steered) reproduces `run_task_pinned`
+        // EXACTLY — the run Finishes in one turn, billing one anthropic row, and the single
+        // captured prompt is UNchanged (no `[operator steer]` fold). The drain at each turn
+        // boundary is a pure no-op when nothing is pending (and `None`, the default path, skips
+        // it entirely — proven by the unchanged existing `run_task_pinned_*` claude tests).
+        let (rt, _ws, steer, calls, captured) = steerable_claude_runtime(
+            "c2-2-empty",
+            vec![AgentStep::Finish {
+                message: "PONG".to_string(),
+            }],
+            usize::MAX, // never inject a steer
+            "UNREACHED",
+        );
+        let (selection, outcome) = rt
+            .run_task_pinned_steerable("run-c2-2-empty", "say pong", "claude", &steer, 2_000)
+            .expect("an un-steered steerable run behaves like run_task_pinned");
+        assert_eq!(selection.provider_id, "claude");
+        assert_eq!(
+            outcome.status,
+            LoopStatus::Finished,
+            "an empty steer handle does not change the terminal status"
+        );
+        assert_eq!(outcome.turns, 1);
+        assert_eq!(calls.get(), 1, "the single Finish turn ran");
+        // The prompt the model saw is unchanged — no steer was folded in.
+        let captured = captured.borrow();
+        assert_eq!(captured.len(), 1);
+        assert!(
+            !captured[0].contains("[operator steer]"),
+            "no steer fold on the un-steered path: {:?}",
+            captured[0]
+        );
+        let rows = rt.db().list_run_token_usage("run-c2-2-empty").unwrap();
+        assert_eq!(
+            rows.len(),
+            1,
+            "one anthropic row for the single finished turn"
+        );
+        assert_eq!(rows[0].provider_kind, "anthropic");
+    }
+
+    #[test]
+    fn steer_is_folded_once_then_remains_in_context_for_the_rest_of_the_run() {
+        // The PERSISTS-IN-CONTEXT property (the corrected semantics): the steer is DRAINED/folded
+        // exactly ONCE, but having been folded into `prompt_task` it REMAINS in the model's context
+        // for every subsequent turn — BY DESIGN, since `TurnTrace` history has no slot to carry a
+        // free-form operator instruction (dropping it after one turn would make the model forget the
+        // steer mid-task). A 3-step script (tool, tool, Finish) with the steer injected after turn 1
+        // pins this: turn 1's prompt has NO steer; turns 2 AND 3 both carry it; and each carries
+        // EXACTLY ONE copy (not an accumulating re-append) — the drain fired once.
+        const STEER: &str = "ACTUALLY: number each step";
+        let (rt, ws, steer, calls, captured) = steerable_claude_runtime(
+            "c2-2-steer-persist",
+            vec![
+                // turn 1: read-only tool → CONTINUE
+                AgentStep::Tool(crate::RawToolCall {
+                    action: "read_file".to_string(),
+                    params: vec![("path".to_string(), "notes.md".to_string())],
+                }),
+                // turn 2: another read-only tool → CONTINUE (the steered turn)
+                AgentStep::Tool(crate::RawToolCall {
+                    action: "read_file".to_string(),
+                    params: vec![("path".to_string(), "notes.md".to_string())],
+                }),
+                // turn 3: Finish — the steer must STILL be in this turn's prompt.
+                AgentStep::Finish {
+                    message: "DONE".to_string(),
+                },
+            ],
+            1, // inject the steer after turn 1
+            STEER,
+        );
+        std::fs::write(ws.join("notes.md"), b"hello").unwrap();
+
+        let (_selection, outcome) = rt
+            .run_task_pinned_steerable("run-c2-2-persist", "read the file", "claude", &steer, 1_000)
+            .expect("the steerable pinned claude run drives the routed loop");
+        assert_eq!(outcome.status, LoopStatus::Finished);
+        assert_eq!(outcome.turns, 3, "three metered turns");
+        assert_eq!(calls.get(), 3, "the stub was called for all three turns");
+
+        let captured = captured.borrow();
+        assert_eq!(captured.len(), 3, "all three turns' prompts were captured");
+        assert!(
+            !captured[0].contains(STEER),
+            "turn 1 (pre-injection) has no steer"
+        );
+        assert!(
+            captured[1].contains(STEER),
+            "turn 2 (the steered turn) carries the folded steer"
+        );
+        assert!(
+            captured[2].contains(STEER),
+            "turn 3 STILL carries the steer — it remains in context for the rest of the run"
+        );
+        // Folded in exactly ONCE: each post-steer turn carries EXACTLY ONE copy of the instruction,
+        // never an accumulating re-append (which a per-turn re-fold would produce).
+        assert_eq!(
+            captured[1].matches(STEER).count(),
+            1,
+            "turn 2 carries exactly one copy of the steer"
+        );
+        assert_eq!(
+            captured[2].matches(STEER).count(),
+            1,
+            "turn 3 carries exactly one copy — the drain fired once, no re-append per turn"
+        );
+        // The handle is empty after — the steer was consumed (drained) exactly once.
+        assert!(steer.drain().is_none(), "the steer was consumed once");
     }
 
     // ---- PROOF-MEMORY-001 recall→inject wiring -------------------------------

--- a/rust-core/crates/friday-hub/tests/a1_run_control.rs
+++ b/rust-core/crates/friday-hub/tests/a1_run_control.rs
@@ -172,6 +172,7 @@ fn pause_owned_run(
         &policy,
         5,
         None, // cancel: not exercised by this test
+        None, // steer: not exercised by this test
         NOW,
     )
     .unwrap();

--- a/rust-core/crates/friday-hub/tests/routed_claude_parity.rs
+++ b/rust-core/crates/friday-hub/tests/routed_claude_parity.rs
@@ -131,7 +131,7 @@
 use friday_crypto::{seal, DeviceKeypair};
 use friday_hub::hub_server::AuthedPrincipal;
 use friday_hub::runtime::{HubConfig, HubRuntime, ENV_CLAUDE_ROUTE_ENABLED};
-use friday_hub::{CancelToken, LoopStatus};
+use friday_hub::{CancelToken, LoopStatus, SteerHandle};
 use friday_providers::KeyValidationOutcome;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -550,6 +550,64 @@ fn interrupt_stop_cancels_live_claude_loop_and_bills_nothing_after_trip() {
     }
     eprintln!(
         "LIVE OK: interrupt/stop → claude, status {:?}, {} billed anthropic turn(s), nothing after trip",
+        outcome.status, outcome.turns
+    );
+}
+
+// ---- C2-2 steer / inject mid-loop: cooperative steer, LIVE -----------------------------------
+//
+// The live mirror of the deterministic, no-key in-crate proof
+// (`runtime.rs::run_task_pinned_steerable_folds_steer_into_an_additional_metered_claude_turn`).
+// The in-crate test is the REAL dark proof (it forces the injection deterministically between two
+// scripted turns AND asserts the stub observed it in the steered turn's prompt). This LIVE test
+// exercises the SAME `run_task_pinned_steerable` entry against a real Anthropic key, injecting the
+// steer from a background thread shortly after the run starts (mirroring the C2-1 live interrupt's
+// background `cancel`). It is `#[ignore]`'d like every live test here — only the operator run
+// spends quota — and timing-dependent (a fast model may finish before the steer lands), so it
+// asserts only the metering invariants that hold regardless of WHEN the steer folds in:
+//   - the run terminates (no hang) routed to claude (no reroute);
+//   - EVERY recorded ledger row is anthropic / api.anthropic.com / non-fallback, and the row count
+//     equals `outcome.turns` for a finished run — each metered turn (incl. the steered one) billed
+//     exactly one anthropic row, the same "steer is an additional METERED turn" property the
+//     in-crate test pins deterministically (and which the `SteerTurn=Unsupported` mirror does NOT
+//     satisfy — a mirror produces NO metered turn).
+// Only the `SteerHandle` clone (Send + Sync via Arc<Mutex<..>>) crosses the thread boundary; the
+// runtime stays on this thread. A model that finished before the steer landed simply bills its
+// turns normally — the metering invariant still holds; the steer FOLD itself is what the
+// deterministic in-crate test proves.
+#[test]
+#[ignore = "live: needs FRIDAY_CLAUDE_ROUTE_ENABLED=1 + both provider keys; spends Anthropic quota; run with --ignored"]
+fn steer_turn_folds_into_live_claude_loop_as_additional_metered_turn() {
+    let (rt, _ws) = live_claude_runtime("steer-turn");
+    let steer = SteerHandle::new();
+    // Inject the steer shortly after the run begins, from a background thread (only the handle
+    // clone — Send + Sync — crosses the boundary; the runtime never leaves this thread).
+    let steerer = steer.clone();
+    let handle = std::thread::spawn(move || {
+        std::thread::sleep(std::time::Duration::from_millis(50));
+        steerer.steer("ACTUALLY: also state the current step number on each turn");
+    });
+    let (selection, outcome) = rt
+        .run_task_pinned_steerable(
+            "live-claude-steer",
+            // A deliberately multi-step task so the loop reaches a turn boundary where the
+            // (already-injected) steer folds into a real billed claude turn.
+            "Think step by step and use tools across several turns; do not finish immediately.",
+            "claude",
+            &steer,
+            1_000,
+        )
+        .expect("a steerable live pinned-claude run terminates (no hang, no reroute)");
+    handle.join().unwrap();
+    assert_eq!(
+        selection.provider_id, "claude",
+        "the pin routed to claude, no reroute"
+    );
+    // The steered turn is an ADDITIONAL METERED turn: one anthropic row per counted turn,
+    // all-anthropic (a mirror would bill nothing — this must bill the steered turn).
+    assert_anthropic_rows(&rt, "live-claude-steer", outcome.status, outcome.turns);
+    eprintln!(
+        "LIVE OK: steer/inject → claude, status {:?}, {} billed anthropic turn(s) incl. the steered turn",
         outcome.status, outcome.turns
     );
 }

--- a/rust-core/crates/friday-hub/tests/s6d_resume_ingestion.rs
+++ b/rust-core/crates/friday-hub/tests/s6d_resume_ingestion.rs
@@ -194,6 +194,7 @@ fn loop_protected_no_approval_pauses_and_persists_csprng_pending() {
         &RunPolicy::default(),
         5,
         None, // cancel: not exercised by this test
+        None, // steer: not exercised by this test
         NOW,
     )
     .unwrap();
@@ -256,6 +257,7 @@ fn loop_valid_ed25519_approval_executes_the_mutation() {
         &RunPolicy::default(),
         5,
         None, // cancel: not exercised by this test
+        None, // steer: not exercised by this test
         NOW,
     )
     .unwrap();
@@ -294,6 +296,7 @@ fn loop_hmac_approval_cannot_execute_even_with_operator_key() {
         &RunPolicy::default(),
         5,
         None, // cancel: not exercised by this test
+        None, // steer: not exercised by this test
         NOW,
     )
     .unwrap();
@@ -339,6 +342,7 @@ fn pause_a_run_with_policy(
         policy,
         5,
         None, // cancel: not exercised by this test
+        None, // steer: not exercised by this test
         NOW,
     )
     .unwrap();


### PR DESCRIPTION
**C2-2** steer: an operator instruction injected mid-loop, folded into the NEXT turn as a REAL additional metered claude turn — NOT the provider-workspace `SteerTurn=Unsupported` mirror (which is no metered turn at all). Builds directly on C2-1's per-turn checkpoint.

## Mechanism (surgical, hot file)
- New `SteerHandle(Arc<Mutex<Option<String>>>)` with `steer()` / `drain()` (mirrors `CancelToken`).
- Drained at the TOP of each loop iteration in `run_loop_with_policy`, AFTER the C2-1 cancel check and BEFORE `next_step_metered`. A pending instruction is folded into `prompt_task` for that turn, so the metered chat carries it and bills a real per-turn anthropic row.
- Threaded `steer: Option<&SteerHandle>` the same way C2-1 threaded `cancel`: `run_loop_with_policy` → `run_session_loop` → `run_routed_loop_with_policy` → `run_with_request`; exposed via new `HubRuntime::run_task_pinned_steerable` (mirrors `run_task_pinned_cancellable`).
- Drained/folded exactly ONCE; then REMAINS in context for the rest of the run by design (`TurnTrace` history has no slot for a free-form instruction).

## DARK
Live proof is anthropic-key-gated (`#[ignore]`'d live test in `tests/routed_claude_parity.rs`). The deterministic no-key in-crate tests are the dark proof:
- **faithful test**: injects the steer after turn 1, asserts the DELTA — turn 1's captured prompt does NOT contain the steer, turn 2's DOES (the stub OBSERVED the injection) — plus rows grow 1→2 (extra billed anthropic row, all `api.anthropic.com`/`fallback=false`), turns/calls==2, `provider_id==claude`.
- **persists-in-context (3-turn) test**: folded once, carried on every later turn, exactly one copy.

## NO-DEGRADE
The empty/`None` steer path is byte-identical to post-C2-1: `drain()` is a no-op, `prompt_task` untouched, billing/accounting/status unchanged (empty-handle test asserts no `[operator steer]` fold). No new `LoopStatus`.

Local gate (in order): `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test -p friday-hub` — all green (569 lib + integration, 3 new no-key steer tests pass, live test ignored).

🤖 Generated with [Claude Code](https://claude.com/claude-code)