### PR TITLE
feat(c1-1): Codex ledger identity (provider attribution)

### DIFF
--- a/rust-core/crates/friday-core/src/ledger.rs
+++ b/rust-core/crates/friday-core/src/ledger.rs
@@ -15,6 +15,12 @@ pub enum ProviderKind {
     /// mis-attributed as DeepSeek; reachable only through the gated, dark Claude
     /// path (the DeepSeek route is unchanged).
     Anthropic,
+    /// (C1) The Codex app-server route. Recorded so a routed Codex model turn is
+    /// NEVER mis-attributed as DeepSeek/Anthropic. The Codex turn runs through the
+    /// LOCAL app-server (`provider_app_server_local`), not a remote API — see
+    /// [`LedgerEntry::codex_route`] for the local host label. Identity only in C1-1
+    /// (no routing wired yet); not produced by any existing path.
+    Codex,
 }
 
 impl ProviderKind {
@@ -22,6 +28,7 @@ impl ProviderKind {
         match self {
             ProviderKind::DeepSeek => "deepseek",
             ProviderKind::Anthropic => "anthropic",
+            ProviderKind::Codex => "codex",
         }
     }
 }
@@ -150,6 +157,45 @@ impl LedgerEntry {
             created_at,
         )
     }
+
+    /// (C1) A Codex app-server route entry, mirroring [`LedgerEntry::anthropic_route`]
+    /// but with [`ProviderKind::Codex`]. The routed Codex turn runs through Friday's
+    /// LOCAL app-server (the `provider_app_server_local` sync mode), so the host label is
+    /// the local-app-server label `"provider_app_server_local"` — NOT `api.openai.com`:
+    /// recording a remote API host that the routed path never calls would be a FAKE.
+    /// `fallback` is hard-wired to `false` (the Codex route is a no-fallback route, like
+    /// DeepSeek/Claude). This is what keeps a Codex model turn from being recorded as
+    /// DeepSeek or Anthropic.
+    #[allow(clippy::too_many_arguments)]
+    pub fn codex_route(
+        ledger_id: impl Into<String>,
+        session_id: impl Into<String>,
+        activity_id: impl Into<String>,
+        model: impl Into<String>,
+        prompt_tokens: i64,
+        completion_tokens: i64,
+        cost_estimate: Option<f64>,
+        result_link: Option<String>,
+        created_at: i64,
+    ) -> Result<LedgerEntry, CoreError> {
+        LedgerEntry::new(
+            ledger_id,
+            session_id,
+            activity_id,
+            ProviderKind::Codex,
+            model,
+            // LOCAL app-server label (`friday_core::SyncMode::ProviderAppServerLocal`
+            // mints this same string); the routed Codex path is the local app-server,
+            // so a remote-API host here would be a fake.
+            "provider_app_server_local",
+            prompt_tokens,
+            completion_tokens,
+            cost_estimate,
+            false, // fallback: never true on the Codex route either
+            result_link,
+            created_at,
+        )
+    }
 }
 
 #[cfg(test)]
@@ -235,6 +281,23 @@ mod tests {
         assert_eq!(e.provider_kind, ProviderKind::Anthropic);
         assert_eq!(e.provider_kind.as_str(), "anthropic");
         assert_eq!(e.base_url_host, "api.anthropic.com");
+        assert!(!e.fallback);
+        assert_eq!(e.total_tokens, 19);
+        assert_eq!(e.cost_estimate, None);
+    }
+
+    #[test]
+    fn codex_route_ledger_entry_shape() {
+        // (C1) The Codex route entry records the Codex provider kind + the LOCAL
+        // app-server host label (NOT a remote API), never fallback, with the total
+        // computed from the parts.
+        let e = LedgerEntry::codex_route("l4", "s1", "a1", "gpt-5-codex", 11, 8, None, None, 4000)
+            .unwrap();
+        assert_eq!(e.provider_kind, ProviderKind::Codex);
+        assert_eq!(e.provider_kind.as_str(), "codex");
+        // LOCAL app-server label, never a remote API the routed path never calls.
+        assert_eq!(e.base_url_host, "provider_app_server_local");
+        assert_ne!(e.base_url_host, "api.openai.com");
         assert!(!e.fallback);
         assert_eq!(e.total_tokens, 19);
         assert_eq!(e.cost_estimate, None);

--- a/rust-core/crates/friday-hub/src/lib.rs
+++ b/rust-core/crates/friday-hub/src/lib.rs
@@ -482,6 +482,32 @@ impl BilledUsage {
             completion_tokens: outcome.output_tokens,
         }
     }
+
+    /// (C1) Map a Codex app-server `ModelTurnOutcome` into the neutral billed-usage
+    /// shape, tagged [`friday_core::ProviderKind::Codex`] so a routed Codex turn is never
+    /// mis-attributed as DeepSeek/Anthropic.
+    ///
+    /// Unlike the DeepSeek/Anthropic outcomes, [`friday_providers::codex_appserver::ModelTurnOutcome`]
+    /// carries NO model field (the app-server's `turn/completed` does not report it), so the
+    /// `route_model` is supplied SEPARATELY by the caller (the requested route model). Usage is
+    /// `Option`: the `thread/tokenUsage/updated` notification is not guaranteed every turn, so a
+    /// turn with no usage bills 0/0 (honest absence — its `total_tokens` is dropped, the ledger
+    /// recomputes the total from the parts).
+    pub fn from_codex(
+        outcome: &friday_providers::codex_appserver::ModelTurnOutcome,
+        route_model: &str,
+    ) -> Self {
+        let (prompt_tokens, completion_tokens) = match &outcome.usage {
+            Some(u) => (u.input_tokens, u.output_tokens),
+            None => (0, 0),
+        };
+        Self {
+            provider_kind: friday_core::ProviderKind::Codex,
+            model: route_model.to_string(),
+            prompt_tokens,
+            completion_tokens,
+        }
+    }
 }
 
 /// The model-client seam (mirrors `friday-deepseek`'s `Transport` DI pattern). The
@@ -2515,6 +2541,19 @@ fn bill_model_call(
             now_ms,
         ),
         friday_core::ProviderKind::Anthropic => friday_core::LedgerEntry::anthropic_route(
+            ledger_id.as_str(),
+            run_id,
+            activity_id.as_str(),
+            &outcome.model,
+            outcome.prompt_tokens,
+            outcome.completion_tokens,
+            None,
+            None,
+            now_ms,
+        ),
+        // (C1) A Codex turn records `provider_kind="codex"` + the LOCAL app-server host
+        // label via `codex_route`, so it is never mis-attributed as DeepSeek/Anthropic.
+        friday_core::ProviderKind::Codex => friday_core::LedgerEntry::codex_route(
             ledger_id.as_str(),
             run_id,
             activity_id.as_str(),
@@ -4783,6 +4822,50 @@ mod tests {
             "loop biller passes no cost estimate (unchanged)"
         );
         assert_eq!(fallback, 0, "Friday route is never a fallback (unchanged)");
+    }
+
+    #[test]
+    fn billed_usage_from_codex_maps_outcome_and_route_model() {
+        // (C1-1) `BilledUsage::from_codex` maps a Codex app-server `ModelTurnOutcome`
+        // (which has NO model field) plus a SEPARATELY-supplied route model into the
+        // neutral billed-usage shape, tagged ProviderKind::Codex (never DeepSeek/Anthropic).
+        // The `tokenUsage.last` breakdown maps input/output -> prompt/completion; the
+        // outcome's own `total_tokens` is dropped (the ledger recomputes from the parts).
+        let outcome = friday_providers::codex_appserver::ModelTurnOutcome {
+            thread_id: "thr-1".to_string(),
+            turn_id: "turn-1".to_string(),
+            status: "completed".to_string(),
+            content: "hi".to_string(),
+            usage: Some(friday_providers::codex_appserver::CodexTokenUsage {
+                input_tokens: 11,
+                output_tokens: 8,
+                total_tokens: 19,
+            }),
+        };
+        let billed = BilledUsage::from_codex(&outcome, "gpt-5-codex");
+        assert_eq!(billed.provider_kind, friday_core::ProviderKind::Codex);
+        assert_eq!(billed.model, "gpt-5-codex"); // taken from the route, not the outcome
+        assert_eq!(billed.prompt_tokens, 11);
+        assert_eq!(billed.completion_tokens, 8);
+    }
+
+    #[test]
+    fn billed_usage_from_codex_no_usage_bills_zero() {
+        // (C1-1) A turn with no `thread/tokenUsage/updated` notification (usage == None) is
+        // NOT a failure — it bills 0/0 (honest absence), still tagged ProviderKind::Codex with
+        // the supplied route model.
+        let outcome = friday_providers::codex_appserver::ModelTurnOutcome {
+            thread_id: "thr-2".to_string(),
+            turn_id: "turn-2".to_string(),
+            status: "completed".to_string(),
+            content: "ok".to_string(),
+            usage: None,
+        };
+        let billed = BilledUsage::from_codex(&outcome, "gpt-5-codex");
+        assert_eq!(billed.provider_kind, friday_core::ProviderKind::Codex);
+        assert_eq!(billed.model, "gpt-5-codex");
+        assert_eq!(billed.prompt_tokens, 0);
+        assert_eq!(billed.completion_tokens, 0);
     }
 
     #[test]


### PR DESCRIPTION
## C1-1 — Codex ledger identity (provider attribution)

Adds the Codex provider identity to the ONE biller so a routed Codex turn is **never mis-attributed as DeepSeek/Anthropic**. First PR of the C1 Codex-parity program.

### What changed (purely additive)
- **`rust-core/crates/friday-core/src/ledger.rs`**
  - New `ProviderKind::Codex` variant (extends the exhaustive `as_str` match with `=> "codex"`).
  - New `LedgerEntry::codex_route(..)` ctor, mirroring `anthropic_route` but `provider_kind = Codex`, `fallback` hard-wired `false`, and `base_url_host = "provider_app_server_local"`.
- **`rust-core/crates/friday-hub/src/lib.rs`**
  - New `BilledUsage::from_codex(outcome, route_model)` — the model is taken **separately** (`ModelTurnOutcome` has no model field); `usage: Option`, so a turn with no `tokenUsage` notification bills `0/0`.
  - New `ProviderKind::Codex` arm in the exhaustive `bill_model_call` match (no wildcard).

### DARK / identity-only
No routing wired yet — the new variant is produced by **no existing path**. Existing DeepSeek/Anthropic arms, ctors, and `bill_model_call` behavior are unchanged (0 deletions in the diff).

### Local host label, not a remote API
The routed Codex path runs through Friday's **local app-server** (the `provider_app_server_local` sync mode), so `codex_route`'s `base_url_host` is the local label `"provider_app_server_local"` — **NOT** `api.openai.com`. Recording a remote API host the routed path never calls would be a fake.

### Proof (deterministic, no creds)
- `codex_route_ledger_entry_shape`: `provider_kind == Codex`, host == local label (and `!= api.openai.com`), `fallback == false`, `total == prompt + completion`.
- `billed_usage_from_codex_maps_outcome_and_route_model`: `Some(usage)` + separate route model maps to the neutral shape (provider_kind/model/tokens).
- `billed_usage_from_codex_no_usage_bills_zero`: `None`-usage maps to `0/0`.

Local gate (rust-core.yml order): `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test -p friday-core -p friday-hub` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)