### PR TITLE
feat(c2-4): owner-scoped routed-session list/open/read (NOT the mirror)

### DIFF
--- a/rust-core/crates/friday-hub/src/runtime.rs
+++ b/rust-core/crates/friday-hub/src/runtime.rs
@@ -925,6 +925,36 @@ impl<T: Transport> HubRuntime<T> {
         &self.db
     }
 
+    /// (C2-4) OWNER-SCOPED list of the FRIDAY routed agent_sessions owned by `caller` —
+    /// the sessions [`Self::run_session_task_pinned`] populates (which carry REAL provider
+    /// `token_ledger` rows, e.g. an `anthropic` row per Claude turn). Scopes on the SAME
+    /// authenticated principal the sessioned entry binds the session owner to (NEVER a
+    /// client-asserted id), so a caller sees ONLY their own sessions — a different principal's
+    /// list is EMPTY (INV-5/INV-7 fail-closed). Most-recently-active first.
+    ///
+    /// This reads the routed sessions DELIBERATELY, NOT the `provider_session_link`
+    /// claude_control mirror (`Db::list_provider_session_projections`) — that local mirror
+    /// has no owner axis and no real billing, so surfacing it here would be a fake. ADDITIVE,
+    /// read-only accessor: no write, no live behavior change.
+    pub fn list_sessions_for_owner(
+        &self,
+        caller: &AuthedPrincipal,
+    ) -> Result<Vec<friday_storage::SessionListItem>, StorageError> {
+        friday_storage::list_sessions_for_owner(self.db.conn(), caller.principal())
+    }
+
+    /// (C2-4) OWNER-SCOPED open/read of one routed session's folded user/assistant transcript:
+    /// `Some(messages)` ONLY when `caller` owns `agent_session_id`, else `None`. The
+    /// fail-closed open half — a guessed session id cannot bypass the owner check (a non-owner,
+    /// an owner-less session, and an absent id all read back `None`). ADDITIVE, read-only.
+    pub fn open_session_for_owner(
+        &self,
+        caller: &AuthedPrincipal,
+        agent_session_id: &str,
+    ) -> Result<Option<Vec<friday_storage::StoredSessionMessage>>, StorageError> {
+        friday_storage::open_session_for_owner(self.db.conn(), caller.principal(), agent_session_id)
+    }
+
     /// (A1 run-controls) The composed `FsToolExecutor` (workspace-root-contained, gate-mandatory).
     /// Exposed so the sealed-WS server's RESUME control handler can delegate to the S6
     /// [`crate::resume::resume_with_approval`] spine (which executes the ONE approved mutation
@@ -1704,6 +1734,172 @@ mod tests {
         let all = rt.db().list_token_usage().unwrap();
         assert_eq!(all.len(), 1);
         assert_eq!(all[0].provider_kind, "anthropic");
+    }
+
+    #[test]
+    fn c2_4_owner_scoped_list_open_read_of_routed_sessions() {
+        // C2-4 FAITHFUL DARK PROOF: run TWO claude-pinned SESSIONED turns through the REAL
+        // `run_session_task_pinned` entry (each billing one anthropic row — ASSERTED), then prove
+        // the owner-scoped read API over the FRIDAY ROUTED `agent_session` rows:
+        //   - `list_sessions_for_owner(owner)` returns BOTH sessions, bound to the authed owner,
+        //     most-recently-active first;
+        //   - open returns the right session's folded user/assistant transcript;
+        //   - a DIFFERENT principal's list is owner-scoped EMPTY and its open is None
+        //     (INV-5/INV-7 fail-closed — the load-bearing security assertion);
+        //   - list/open/read write NO new ledger row (pure read; the count stays at the 2 the runs
+        //     wrote);
+        //   - the NOT-A-MIRROR / two-session trap: each listed session's message `refs` is its
+        //     run_id, and that run_id carries the REAL anthropic ledger rows — never a
+        //     claude_control mirror link.
+        // NO key, NO network — the claude stub bills the anthropic rows.
+        let (rt, _ws) = runtime_with_claude_wired(
+            "c2-4-owner-scoped-read",
+            // Each `run_session_task_pinned` call drives a FRESH single-shot loop on a fresh stub
+            // (the stub's `calls` counter resets per runtime build is not needed — both turns reuse
+            // THIS runtime's single stub, whose script is `[Finish]`, so every call Finishes).
+            vec![AgentStep::Finish {
+                message: "PONG".to_string(),
+            }],
+            Box::new(DenyAllApprovals),
+        );
+        let owner = authed_caller("principal:c2-4-owner");
+        let other = authed_caller("principal:c2-4-intruder");
+
+        // --- two claude-pinned sessioned turns (two DISTINCT sessions, DISTINCT now_ms) ---------
+        let (sel1, _a1) = rt
+            .run_session_task_pinned(
+                &owner,
+                "run-c2-4-a",
+                "sess-c2-4-a",
+                "first turn",
+                "claude",
+                3_000,
+            )
+            .expect("first claude sessioned turn runs");
+        assert_eq!(sel1.provider_id, "claude");
+        let (sel2, _a2) = rt
+            .run_session_task_pinned(
+                &owner,
+                "run-c2-4-b",
+                "sess-c2-4-b",
+                "second turn",
+                "claude",
+                4_000,
+            )
+            .expect("second claude sessioned turn runs");
+        assert_eq!(sel2.provider_id, "claude");
+
+        // ASSERT the REAL anthropic rows: one per run, billed to anthropic / api.anthropic.com.
+        for run_id in ["run-c2-4-a", "run-c2-4-b"] {
+            let rows = rt.db().list_run_token_usage(run_id).unwrap();
+            assert_eq!(
+                rows.len(),
+                1,
+                "{run_id}: one anthropic row for the single claude turn"
+            );
+            assert_eq!(
+                rows[0].provider_kind, "anthropic",
+                "{run_id}: NOT mis-attributed as deepseek"
+            );
+            assert_eq!(rows[0].base_url_host, "api.anthropic.com");
+            assert!(!rows[0].fallback, "the claude route is never a fallback");
+        }
+        // The no-new-ledger BASELINE is 2 (the two runs already billed two anthropic rows).
+        let ledger_baseline = rt.db().list_token_usage().unwrap().len();
+        assert_eq!(
+            ledger_baseline, 2,
+            "two claude turns billed two anthropic rows"
+        );
+
+        // --- list: the owner sees BOTH, most-recently-updated first (sess-b @4000 before -a @3000) ---
+        let listed = rt.list_sessions_for_owner(&owner).unwrap();
+        assert_eq!(
+            listed
+                .iter()
+                .map(|s| s.agent_session_id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["sess-c2-4-b", "sess-c2-4-a"],
+            "owner list returns both routed sessions, most-recently-active first"
+        );
+
+        // --- the DIFFERENT principal's list is owner-scoped EMPTY (the load-bearing assertion) ---
+        assert!(
+            rt.list_sessions_for_owner(&other).unwrap().is_empty(),
+            "a different principal sees NONE of the owner's sessions (INV-5/INV-7 fail-closed)"
+        );
+
+        // --- open: the owner reads the right session's folded user/assistant transcript ----------
+        let msgs_a = rt
+            .open_session_for_owner(&owner, "sess-c2-4-a")
+            .unwrap()
+            .expect("the owner can open her own session");
+        // run_session_loop folds a "user" turn (the task, refs=run_id) + an "assistant" turn on
+        // Finished (refs=run_id).
+        assert_eq!(
+            msgs_a.len(),
+            2,
+            "user task + assistant answer folded into the session"
+        );
+        assert_eq!(msgs_a[0].role, "user");
+        assert_eq!(msgs_a[0].content, "first turn");
+        assert_eq!(msgs_a[1].role, "assistant");
+
+        // --- the DIFFERENT principal cannot open a guessed session id (fail-closed open) ---------
+        assert_eq!(
+            rt.open_session_for_owner(&other, "sess-c2-4-a").unwrap(),
+            None,
+            "a guessed session id does not bypass owner-scoping"
+        );
+
+        // --- NOT-A-MIRROR / two-session trap: the listed session's message refs IS the run_id ----
+        // that carries the REAL anthropic rows — never a claude_control mirror link. Prove it for
+        // each listed session.
+        for item in &listed {
+            let msgs = rt
+                .open_session_for_owner(&owner, &item.agent_session_id)
+                .unwrap()
+                .expect("owner opens her listed session");
+            let run_id = msgs[0]
+                .refs
+                .as_deref()
+                .expect("the folded turn soft-links its producing run_id");
+            let rows = rt.db().list_run_token_usage(run_id).unwrap();
+            assert_eq!(
+                rows.len(),
+                1,
+                "the listed session's run carries a REAL anthropic row"
+            );
+            assert_eq!(
+                rows[0].provider_kind, "anthropic",
+                "the listed session ties to anthropic billing, never a mirror link"
+            );
+            assert_eq!(rows[0].base_url_host, "api.anthropic.com");
+        }
+        // The two sessions map to the two DISTINCT billed runs (no session points at the wrong run).
+        let run_a = rt
+            .open_session_for_owner(&owner, "sess-c2-4-a")
+            .unwrap()
+            .unwrap()[0]
+            .refs
+            .clone()
+            .unwrap();
+        let run_b = rt
+            .open_session_for_owner(&owner, "sess-c2-4-b")
+            .unwrap()
+            .unwrap()[0]
+            .refs
+            .clone()
+            .unwrap();
+        assert_eq!(run_a, "run-c2-4-a");
+        assert_eq!(run_b, "run-c2-4-b");
+        assert_ne!(run_a, run_b, "the two sessions carry DISTINCT billed runs");
+
+        // --- PURE READ: list/open/read wrote NO new ledger row (count unchanged from baseline) ---
+        assert_eq!(
+            rt.db().list_token_usage().unwrap().len(),
+            ledger_baseline,
+            "list/open/read are pure reads — no new ledger row"
+        );
     }
 
     #[test]

--- a/rust-core/crates/friday-storage/src/agent_session.rs
+++ b/rust-core/crates/friday-storage/src/agent_session.rs
@@ -357,6 +357,127 @@ pub fn session_message_count(conn: &Connection, agent_session_id: &str) -> Resul
     Ok(n)
 }
 
+// --- C2-4 owner-scoped routed-session list/open/read --------------------------
+//
+// An OWNER-SCOPED read view over the FRIDAY routed `agent_session` rows — the ones
+// `friday_hub::HubRuntime::run_session_task_pinned` populates (and which carry REAL
+// `token_ledger` rows attributed to the answering provider, e.g. an `anthropic` row per
+// Claude turn). These read the routed sessions DELIBERATELY, NOT the
+// `provider_session::list_projections` `provider_session_link` claude_control mirror — a
+// `FridayLocalMirror` link is a CRUD projection, has no `user_id` to scope on, and carries
+// no real billing, so surfacing it here would be a fake. This view never touches that
+// table.
+//
+// The scope axis is the `agent_session.user_id` column (m0021), bound to the AUTHENTICATED
+// caller's principal by `run_session_task_pinned` (NEVER a client-asserted id). Scoping is
+// genuinely FAIL-CLOSED (INV-5/INV-7): a DIFFERENT principal's list is EMPTY and an open of
+// another owner's session returns `None` — a guessed `agent_session_id` cannot bypass the
+// owner check, so the WHOLE read API (list AND open/read) is owner-scoped, not best-effort.
+
+/// One row of an owner's routed-session list ([`list_sessions_for_owner`]). Refs-only
+/// metadata — id + timestamps, NEVER any message body (the bodies are read separately and
+/// owner-gated via [`open_session_for_owner`]).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SessionListItem {
+    pub agent_session_id: String,
+    pub created_at: i64,
+    pub updated_at: i64,
+}
+
+/// List the FRIDAY routed sessions OWNED by `user_id`, most-recently-active first.
+///
+/// Scopes on `agent_session.user_id = ?1` (the column `run_session_task_pinned` binds to the
+/// authenticated caller). A blank/empty `user_id` matches NOTHING (fail-closed: an unbound /
+/// owner-less session — whose `user_id` is NULL — is never listed under any owner, and a
+/// blank query never collapses to "all sessions"). A principal that owns no session gets an
+/// empty Vec (the load-bearing owner-scoping assertion: a DIFFERENT principal sees NOTHING).
+///
+/// Ordering is `updated_at DESC, agent_session_id` — most-recent-first (the same convention
+/// as [`crate::provider_session::list_projections`]) with `agent_session_id` as a
+/// deterministic tiebreaker so two sessions touched at the same `updated_at` have a stable
+/// order. Pure read: no write, no schema change.
+pub fn list_sessions_for_owner(conn: &Connection, user_id: &str) -> Result<Vec<SessionListItem>> {
+    // A blank owner must never match a NULL `user_id` row nor act as a wildcard — return
+    // nothing without even querying (the `= ?1` bind already excludes NULL, but this makes
+    // the fail-closed explicit and skips the round-trip).
+    if user_id.is_empty() {
+        return Ok(Vec::new());
+    }
+    let mut stmt = conn.prepare(
+        "SELECT agent_session_id, created_at, updated_at
+         FROM agent_session
+         WHERE user_id = ?1
+         ORDER BY updated_at DESC, agent_session_id",
+    )?;
+    let rows = stmt.query_map([user_id], |r| {
+        Ok(SessionListItem {
+            agent_session_id: r.get(0)?,
+            created_at: r.get(1)?,
+            updated_at: r.get(2)?,
+        })
+    })?;
+    let mut out = Vec::new();
+    for row in rows {
+        out.push(row?);
+    }
+    Ok(out)
+}
+
+/// OWNER-SCOPED open of one routed session's conversation: returns the folded
+/// user/assistant messages (via the existing [`load_session_messages`]) ONLY when the
+/// session is owned by `user_id`; otherwise `None`.
+///
+/// This is the FAIL-CLOSED open half of the C2-4 read API: a caller cannot read another
+/// principal's session by guessing its `agent_session_id` — the owner is checked FIRST (via
+/// [`load_session_owner`], scoping on the SAME `user_id` axis as [`list_sessions_for_owner`])
+/// and a mismatch (or an absent session, or an owner-less NULL `user_id`) returns `None` with
+/// no message read at all. A blank `user_id` matches nothing. Pure read: no write.
+///
+/// `None` therefore covers three fail-closed cases uniformly — "no such session", "session
+/// has no owner", and "session owned by someone else" — none of which a non-owner may
+/// distinguish from the others (no existence oracle). `Some(vec)` (possibly empty for a
+/// brand-new owned session with no turns yet) is returned ONLY to the matching owner.
+pub fn open_session_for_owner(
+    conn: &Connection,
+    user_id: &str,
+    agent_session_id: &str,
+) -> Result<Option<Vec<StoredSessionMessage>>> {
+    if !owner_matches(conn, user_id, agent_session_id)? {
+        return Ok(None);
+    }
+    Ok(Some(load_session_messages(conn, agent_session_id)?))
+}
+
+/// OWNER-SCOPED message count for one routed session (refs-only — no body): `Some(n)` ONLY
+/// when `user_id` owns the session, else `None`. The owner-gated counterpart of
+/// [`session_message_count`], scoped identically to [`open_session_for_owner`] so a
+/// non-owner gets no count (and thus no existence/size oracle). Pure read.
+pub fn session_message_count_for_owner(
+    conn: &Connection,
+    user_id: &str,
+    agent_session_id: &str,
+) -> Result<Option<i64>> {
+    if !owner_matches(conn, user_id, agent_session_id)? {
+        return Ok(None);
+    }
+    Ok(Some(session_message_count(conn, agent_session_id)?))
+}
+
+/// Whether the session exists AND is owned by exactly `user_id`. The single fail-closed
+/// owner check the owner-scoped open/read functions share: a blank `user_id`, an absent
+/// session, an owner-less (NULL `user_id`) session, or a different owner all return `false`.
+fn owner_matches(conn: &Connection, user_id: &str, agent_session_id: &str) -> Result<bool> {
+    if user_id.is_empty() {
+        return Ok(false);
+    }
+    // `load_session_owner` returns `None` for an absent session and `Some(owner)` with a
+    // `None` `user_id` for an owner-less one — both fail the match closed.
+    match load_session_owner(conn, agent_session_id)? {
+        Some(owner) => Ok(owner.user_id.as_deref() == Some(user_id)),
+        None => Ok(false),
+    }
+}
+
 /// Load only the messages NOT yet consumed by a memory extraction
 /// (`memory_extract_status = 'pending'`), in `seq` order (oldest first). This is the
 /// dedup half of session-memory slice-2: the inline extraction reads PENDING messages
@@ -842,5 +963,146 @@ mod tests {
     fn load_owner_of_absent_session_is_none() {
         let db = Db::open_hub(&tmp("absent")).unwrap();
         assert_eq!(load_session_owner(db.conn(), "ghost").unwrap(), None);
+    }
+
+    // --- C2-4 owner-scoped routed-session list/open/read ---------------------
+
+    #[test]
+    fn list_sessions_for_owner_scopes_to_owner_and_orders_by_updated_at_desc() {
+        // SQL-level proof of the owner-scoping + ordering contract (the friday-hub
+        // `run_session_task_pinned` e2e proof lives in runtime.rs's in-crate tests, where
+        // the claude stub harness is reachable). Two sessions for `alice` at DISTINCT
+        // updated_at, one for `bob`.
+        let db = Db::open_hub(&tmp("c2-4-list")).unwrap();
+        let alice = SessionOwner {
+            user_id: Some("alice".into()),
+            ..Default::default()
+        };
+        let bob = SessionOwner {
+            user_id: Some("bob".into()),
+            ..Default::default()
+        };
+        // alice/s1 created first (older updated_at), alice/s2 second (newer), bob/s3.
+        ensure_session_with_owner(db.conn(), "s1", &alice, 3_000).unwrap();
+        ensure_session_with_owner(db.conn(), "s2", &alice, 4_000).unwrap();
+        ensure_session_with_owner(db.conn(), "s3", &bob, 5_000).unwrap();
+
+        // alice sees exactly her two, most-recently-updated FIRST (s2 @4000 before s1 @3000).
+        let alice_list = list_sessions_for_owner(db.conn(), "alice").unwrap();
+        assert_eq!(
+            alice_list
+                .iter()
+                .map(|s| &s.agent_session_id)
+                .collect::<Vec<_>>(),
+            vec!["s2", "s1"],
+            "owner list is most-recently-updated first"
+        );
+        assert_eq!(alice_list[0].updated_at, 4_000);
+        assert_eq!(alice_list[1].updated_at, 3_000);
+
+        // bob sees only his — owner-scoped, never alice's (the load-bearing assertion).
+        let bob_list = list_sessions_for_owner(db.conn(), "bob").unwrap();
+        assert_eq!(bob_list.len(), 1);
+        assert_eq!(bob_list[0].agent_session_id, "s3");
+
+        // A principal that owns NOTHING gets an EMPTY list (fail-closed, not all-sessions).
+        assert!(list_sessions_for_owner(db.conn(), "carol")
+            .unwrap()
+            .is_empty());
+    }
+
+    #[test]
+    fn list_excludes_owner_less_sessions_and_blank_query_matches_nothing() {
+        // An owner-less session (NULL user_id, e.g. created via the no-owner `ensure_session`)
+        // is never listed under any owner, and a blank/empty owner query never collapses to a
+        // wildcard that would surface every session (fail-closed).
+        let db = Db::open_hub(&tmp("c2-4-noowner")).unwrap();
+        ensure_session(db.conn(), "owner-less", 1_000).unwrap();
+        ensure_session_with_owner(
+            db.conn(),
+            "owned",
+            &SessionOwner {
+                user_id: Some("alice".into()),
+                ..Default::default()
+            },
+            2_000,
+        )
+        .unwrap();
+        // Blank query → nothing (must NOT match the NULL-user_id owner-less row nor wildcard).
+        assert!(list_sessions_for_owner(db.conn(), "").unwrap().is_empty());
+        // alice sees only her owned session, never the owner-less one.
+        let alice = list_sessions_for_owner(db.conn(), "alice").unwrap();
+        assert_eq!(alice.len(), 1);
+        assert_eq!(alice[0].agent_session_id, "owned");
+    }
+
+    #[test]
+    fn open_and_count_are_owner_scoped_fail_closed() {
+        // Open/read of a session is gated by the SAME owner axis as the list: a guessed
+        // agent_session_id cannot bypass scoping. A DIFFERENT principal — and an owner-less
+        // session, and an absent id — all read back None (no existence/size oracle).
+        let db = Db::open_hub(&tmp("c2-4-open")).unwrap();
+        ensure_session_with_owner(
+            db.conn(),
+            "s1",
+            &SessionOwner {
+                user_id: Some("alice".into()),
+                ..Default::default()
+            },
+            1_000,
+        )
+        .unwrap();
+        append_session_message(
+            db.conn(),
+            "s1",
+            &SessionMessage::new("user", "remember 47", Some("run-1".into())),
+            1_010,
+        )
+        .unwrap();
+        append_session_message(
+            db.conn(),
+            "s1",
+            &SessionMessage::new("assistant", "noted 47", Some("run-1".into())),
+            1_020,
+        )
+        .unwrap();
+
+        // The OWNER opens + reads the folded transcript.
+        let msgs = open_session_for_owner(db.conn(), "alice", "s1")
+            .unwrap()
+            .expect("the owner can open her own session");
+        assert_eq!(msgs.len(), 2);
+        assert_eq!(
+            (msgs[0].role.as_str(), msgs[1].role.as_str()),
+            ("user", "assistant")
+        );
+        assert_eq!(msgs[0].content, "remember 47");
+        assert_eq!(
+            session_message_count_for_owner(db.conn(), "alice", "s1").unwrap(),
+            Some(2)
+        );
+
+        // A DIFFERENT principal guessing the same id reads NOTHING (fail-closed open).
+        assert_eq!(
+            open_session_for_owner(db.conn(), "bob", "s1").unwrap(),
+            None
+        );
+        assert_eq!(
+            session_message_count_for_owner(db.conn(), "bob", "s1").unwrap(),
+            None
+        );
+        // A blank owner and an absent id are also fail-closed.
+        assert_eq!(open_session_for_owner(db.conn(), "", "s1").unwrap(), None);
+        assert_eq!(
+            open_session_for_owner(db.conn(), "alice", "ghost").unwrap(),
+            None
+        );
+
+        // An owner-less session is not openable by anyone (NULL user_id never matches).
+        ensure_session(db.conn(), "orphan", 1_100).unwrap();
+        assert_eq!(
+            open_session_for_owner(db.conn(), "alice", "orphan").unwrap(),
+            None
+        );
     }
 }

--- a/rust-core/crates/friday-storage/src/lib.rs
+++ b/rust-core/crates/friday-storage/src/lib.rs
@@ -40,9 +40,10 @@ pub mod workflow_def;
 pub mod workflow_read;
 
 pub use agent_session::{
-    append_session_message, ensure_session, ensure_session_with_owner, load_session_messages,
-    load_session_owner, session_exists, session_message_count, SessionMessage, SessionOwner,
-    StoredSessionMessage,
+    append_session_message, ensure_session, ensure_session_with_owner, list_sessions_for_owner,
+    load_session_messages, load_session_owner, open_session_for_owner, session_exists,
+    session_message_count, session_message_count_for_owner, SessionListItem, SessionMessage,
+    SessionOwner, StoredSessionMessage,
 };
 pub use authorize::authorize_mutating_action;
 pub use authorize_ed25519::{authorize_mutating_action_ed25519, Ed25519VerifyOnlyPolicy};


### PR DESCRIPTION
## C2-4 — owner-scoped routed-session list/open/read

An owner-scoped READ API over the FRIDAY **routed** `agent_session` rows — the
sessions `HubRuntime::run_session_task_pinned` populates, which carry **REAL**
`token_ledger` rows (an `anthropic` row per Claude turn). This reads the routed
sessions DELIBERATELY, **NOT** `provider_session::list_projections` (the
`provider_session_link` claude_control **FridayLocalMirror**) — that local mirror
has no owner axis and no real billing, so surfacing it here would be a fake. This
view never touches that table.

### API surface
Storage (`friday-storage/src/agent_session.rs`, exported via `lib.rs`):
- `list_sessions_for_owner(conn, user_id) -> Vec<SessionListItem>` — `agent_session`
  rows `WHERE user_id = ?`, `ORDER BY updated_at DESC, agent_session_id`
  (most-recent-first, deterministic tiebreak). A blank owner matches NOTHING.
- `open_session_for_owner(conn, user_id, id) -> Option<Vec<StoredSessionMessage>>` —
  owner-checked FIRST, then delegates to the existing `load_session_messages`.
- `session_message_count_for_owner(conn, user_id, id) -> Option<i64>` — owner-gated
  counterpart of `session_message_count`.

Thin runtime accessors (`friday-hub/src/runtime.rs`): `HubRuntime::list_sessions_for_owner` /
`open_session_for_owner`, scoped on the AUTHENTICATED `caller.principal()` — the SAME
axis `run_session_task_pinned` binds the session owner to (never a client-asserted id).

### Owner-scoping is genuinely FAIL-CLOSED (INV-5/INV-7), not best-effort
- **list** of a DIFFERENT principal is **owner-scoped EMPTY** (the load-bearing
  security assertion). A blank owner matches nothing; an owner-less (NULL `user_id`)
  session is never listed under any owner.
- **open/read** is gated by the SAME owner axis: a guessed `agent_session_id` by a
  non-owner returns `None` — the whole read API is scoped, not just the list.

### DARK
The deterministic in-crate proof is the evidence (the claude stub bills the anthropic
rows; **no key, no network**). Live only needs a key to seed a session.

### NO-DEGRADE
Additive read-only — no write, **no schema change, no index/migration**;
`run_session_task_pinned` behavior is untouched; `friday-hub/src/lib.rs` is untouched.

### Faithful proof (the dark test)
`runtime.rs::tests::c2_4_owner_scoped_list_open_read_of_routed_sessions`: two
claude-pinned sessioned turns via `run_session_task_pinned` (each billing an **asserted**
anthropic row, `provider_kind=anthropic` / `api.anthropic.com` / `fallback=false`) →
- list returns BOTH sessions bound to the authed owner, most-recent-first;
- open returns the right session's folded user/assistant transcript;
- a DIFFERENT principal's list is **owner-scoped EMPTY** and its open is `None`;
- list/open/read write **NO new ledger row** (count stays at the 2 the runs wrote);
- **two-session trap / not-a-mirror**: each listed session's message `refs` IS its
  `run_id`, and that `run_id` carries the REAL anthropic ledger rows — never a
  claude_control mirror link; the two sessions map to two DISTINCT billed runs.

Plus SQL-level storage tests in `agent_session.rs` for the scoping + ordering contract.

### Gate (local, in order)
- `cargo fmt --all --check` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test -p friday-storage -p friday-hub` — 0 failed (incl. 4 new tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)