### PR TITLE
feat(c2-8): offline/stale routed-session link-state keyed off real metered-turn timestamps

### DIFF
--- a/rust-core/crates/friday-hub/src/run_readback_projection.rs
+++ b/rust-core/crates/friday-hub/src/run_readback_projection.rs
@@ -33,6 +33,9 @@
 //! does pure reads + JSON shaping. It never touches a provider credential or the model path.
 
 use friday_storage::agent_run_read::{db_wide_token_totals, get_run_summary, list_event_kinds};
+use friday_storage::agent_session::{
+    link_state_for_owner, LINK_OFFLINE_AFTER_MS, LINK_STALE_AFTER_MS,
+};
 use friday_storage::audit::verify_audit_chain;
 use friday_storage::Db;
 use serde_json::{json, Value};
@@ -126,6 +129,61 @@ pub fn derive_loop_status(kinds: &[String]) -> &'static str {
 pub fn reject_forbidden_output(rendered: &str) -> Result<(), String> {
     crate::refs_guard::reject_forbidden_output(rendered, &["\"task\""])
         .map_err(|marker| format!("forbidden marker in projection: {marker}"))
+}
+
+/// (C2-8) OWNER-GATED refs-only projection of a routed session's offline/stale LINK-STATE,
+/// derived from the session's last-activity timestamp (`agent_session.updated_at`) vs the
+/// injected `now_ms`. `Ok(None)` ⇒ the caller does not own the session (or it is absent /
+/// owner-less) — fail-closed, no existence/state oracle for a non-owner (the SAME owner axis
+/// as the C2-4 read API). `Ok(Some(snapshot))` ⇒ the owner's link-state label
+/// (`fresh`/`stale`/`offline`) plus the thresholds it was derived against.
+///
+/// DARK / pure clock-driven compute: the state is DERIVED on read from `updated_at + now_ms`
+/// — nothing is persisted, no model call, no ledger row, no mutation of the run path. The
+/// timestamp keys off the REAL routed session's activity (the metered turn's folded
+/// `append_session_message` bumps `updated_at`), NOT a `provider_session_link` claude_control
+/// mirror heartbeat. `now_ms` is INJECTED (never a wall clock) so transitions are
+/// deterministically testable.
+///
+/// Refs-only by construction: the snapshot carries only the session id, the closed-vocabulary
+/// state label, the last-activity timestamp, and the static thresholds — never a message body
+/// or the run `task`. The shared [`reject_forbidden_output`] guard runs INSIDE this fn, so it
+/// inherits the same refs-only discipline as [`project_run_readback`].
+pub fn project_session_link_state(
+    db: &Db,
+    user_id: &str,
+    agent_session_id: &str,
+    now_ms: i64,
+) -> Result<Option<Value>, String> {
+    let conn = db.conn();
+
+    let state = match link_state_for_owner(conn, user_id, agent_session_id, now_ms)
+        .map_err(|_| "read_failed".to_string())?
+    {
+        // Fail-closed: a non-owner / absent / owner-less session reads back None — never a
+        // distinguishable error, so a non-owner gets no existence/state oracle.
+        None => return Ok(None),
+        Some(state) => state,
+    };
+
+    let snapshot = json!({
+        "truth_label": "rust_wired_dev",
+        "proof_only": true,
+        "ok": true,
+        "agent_session_id": agent_session_id,
+        // Closed-vocabulary label only (never any session text): fresh | stale | offline.
+        "link_state": state.as_str(),
+        "now_ms": now_ms,
+        // The static thresholds the state was derived against (so a UI can render the bands).
+        "stale_after_ms": LINK_STALE_AFTER_MS,
+        "offline_after_ms": LINK_OFFLINE_AFTER_MS,
+    });
+
+    // Inherit the refs-only guard (the payload is body-free, so it passes — but run it so this
+    // projection matches the file's discipline and can never regress to carrying a body).
+    let rendered = serde_json::to_string(&snapshot).map_err(|_| "serialize_failed".to_string())?;
+    reject_forbidden_output(&rendered)?;
+    Ok(Some(snapshot))
 }
 
 #[cfg(test)]

--- a/rust-core/crates/friday-hub/src/runtime.rs
+++ b/rust-core/crates/friday-hub/src/runtime.rs
@@ -955,6 +955,29 @@ impl<T: Transport> HubRuntime<T> {
         friday_storage::open_session_for_owner(self.db.conn(), caller.principal(), agent_session_id)
     }
 
+    /// (C2-8) OWNER-GATED refs-only LINK-STATE projection for one routed session: the
+    /// connectivity/staleness label (`fresh`/`stale`/`offline`) DERIVED from the session's
+    /// last-activity timestamp (`agent_session.updated_at`, which the metered turn's folded
+    /// `append_session_message` bumps) vs the injected `now_ms`. `Some(snapshot)` ONLY when
+    /// `caller` owns `agent_session_id`, else `None` (fail-closed — a non-owner cannot read
+    /// another's link-state by guessing the id; the SAME owner axis as
+    /// [`Self::open_session_for_owner`]). DARK / pure clock-driven compute: no model call, no
+    /// ledger row, no write — the state keys off the REAL routed session's activity, never a
+    /// claude_control mirror heartbeat. ADDITIVE, read-only accessor.
+    pub fn project_session_link_state(
+        &self,
+        caller: &AuthedPrincipal,
+        agent_session_id: &str,
+        now_ms: i64,
+    ) -> Result<Option<serde_json::Value>, String> {
+        crate::run_readback_projection::project_session_link_state(
+            &self.db,
+            caller.principal(),
+            agent_session_id,
+            now_ms,
+        )
+    }
+
     /// (A1 run-controls) The composed `FsToolExecutor` (workspace-root-contained, gate-mandatory).
     /// Exposed so the sealed-WS server's RESUME control handler can delegate to the S6
     /// [`crate::resume::resume_with_approval`] spine (which executes the ONE approved mutation
@@ -1899,6 +1922,112 @@ mod tests {
             rt.db().list_token_usage().unwrap().len(),
             ledger_baseline,
             "list/open/read are pure reads — no new ledger row"
+        );
+    }
+
+    #[test]
+    fn c2_8_offline_stale_link_state_keys_off_the_real_metered_turn() {
+        // C2-8 FAITHFUL DARK PROOF: drive ONE claude-pinned SESSIONED turn through the REAL
+        // `run_session_task_pinned` entry at a recorded last-turn time T. The metered turn folds
+        // its `append_session_message`, bumping `agent_session.updated_at = T`, AND bills the
+        // anthropic ledger row (ASSERTED) — so the link-state keys off the REAL routed session's
+        // metered-turn activity, NOT a synthesized mirror heartbeat.
+        //
+        // Then compute the owner-gated link-state at three INJECTED `now`s and prove the pure
+        // clock-driven transitions:
+        //   - now just after the turn          → fresh
+        //   - now past the stale threshold      → stale
+        //   - now past the offline bound        → offline
+        // Assert NO new ledger row across all three reads (the state is computed, never a model
+        // call), and that a DIFFERENT principal cannot read the link-state (fail-closed).
+        // NO key, NO network — the claude stub bills the anthropic row.
+        use friday_storage::agent_session::{LINK_OFFLINE_AFTER_MS, LINK_STALE_AFTER_MS};
+
+        let (rt, _ws) = runtime_with_claude_wired(
+            "c2-8-link-state",
+            vec![AgentStep::Finish {
+                message: "PONG".to_string(),
+            }],
+            Box::new(DenyAllApprovals),
+        );
+        let owner = authed_caller("principal:c2-8-owner");
+        let other = authed_caller("principal:c2-8-intruder");
+
+        let last_turn = 2_000_000_i64;
+        let (sel, _a) = rt
+            .run_session_task_pinned(
+                &owner,
+                "run-c2-8",
+                "sess-c2-8",
+                "first turn",
+                "claude",
+                last_turn,
+            )
+            .expect("claude sessioned turn runs");
+        assert_eq!(sel.provider_id, "claude");
+
+        // ASSERT the REAL anthropic ledger row exists (the session is genuinely metered — this is
+        // what makes the link-state's timestamp the REAL routed turn's, not a synthesized one).
+        let rows = rt.db().list_run_token_usage("run-c2-8").unwrap();
+        assert_eq!(
+            rows.len(),
+            1,
+            "one anthropic row for the single claude turn"
+        );
+        assert_eq!(
+            rows[0].provider_kind, "anthropic",
+            "the session ties to a REAL anthropic turn, never a mirror link"
+        );
+        assert_eq!(rows[0].base_url_host, "api.anthropic.com");
+        assert!(!rows[0].fallback, "the claude route is never a fallback");
+
+        // The no-new-ledger BASELINE is 1 (the one metered turn billed one anthropic row).
+        let ledger_baseline = rt.db().list_token_usage().unwrap().len();
+        assert_eq!(
+            ledger_baseline, 1,
+            "one claude turn billed one anthropic row"
+        );
+
+        // --- fresh → stale → offline on the injected clock (the metered turn set updated_at=T) ---
+        let fresh = rt
+            .project_session_link_state(&owner, "sess-c2-8", last_turn + 1)
+            .unwrap()
+            .expect("the owner reads her own link-state");
+        assert_eq!(fresh["link_state"], "fresh", "just after the turn → fresh");
+        assert_eq!(fresh["stale_after_ms"], LINK_STALE_AFTER_MS);
+        assert_eq!(fresh["offline_after_ms"], LINK_OFFLINE_AFTER_MS);
+
+        let stale = rt
+            .project_session_link_state(&owner, "sess-c2-8", last_turn + LINK_STALE_AFTER_MS)
+            .unwrap()
+            .expect("owner read");
+        assert_eq!(
+            stale["link_state"], "stale",
+            "past the stale threshold → stale"
+        );
+
+        let offline = rt
+            .project_session_link_state(&owner, "sess-c2-8", last_turn + LINK_OFFLINE_AFTER_MS)
+            .unwrap()
+            .expect("owner read");
+        assert_eq!(
+            offline["link_state"], "offline",
+            "past the offline bound → offline"
+        );
+
+        // --- a DIFFERENT principal cannot read the link-state (fail-closed, no state oracle) -----
+        assert_eq!(
+            rt.project_session_link_state(&other, "sess-c2-8", last_turn + 1)
+                .unwrap(),
+            None,
+            "a guessed session id does not let a non-owner read the link-state"
+        );
+
+        // --- NO new ledger row across ALL transitions (state is computed, never a model call) ----
+        assert_eq!(
+            rt.db().list_token_usage().unwrap().len(),
+            ledger_baseline,
+            "link-state reads are pure compute — no new ledger row across fresh/stale/offline"
         );
     }
 

--- a/rust-core/crates/friday-storage/src/agent_session.rs
+++ b/rust-core/crates/friday-storage/src/agent_session.rs
@@ -478,6 +478,108 @@ fn owner_matches(conn: &Connection, user_id: &str, agent_session_id: &str) -> Re
     }
 }
 
+// --- C2-8 offline/stale link-state (derived from last-activity vs now) --------
+//
+// A connectivity/staleness LABEL for a routed `agent_session`, derived purely from the
+// session's last-activity timestamp (`agent_session.updated_at`) vs an injected `now_ms`.
+// This is the SAME column `run_session_task_pinned`'s folded metered turn bumps (the
+// `append_session_message` after a real provider-billed turn advances `updated_at`), so the
+// staleness keys off the REAL routed session's activity — NOT a synthesized
+// `provider_session_link` claude_control mirror heartbeat (that local mirror has no owner
+// axis and no real billing, so reading it here would be a fake; this never touches it).
+//
+// DARK / pure compute: the state is DERIVED on read from `updated_at + now_ms`. Nothing is
+// persisted — there is no `link_state` column, no migration, no write, and no model call.
+// It is deterministically testable by injecting `now_ms` (never a wall clock).
+//
+// HONESTY SEAM (documented, not papered over): `updated_at` is the session's LAST-ACTIVITY
+// timestamp. A metered turn bumps it (via the folded `append_session_message`), and the
+// owner-less `ensure_session` at run-START also bumps it — so it is "last session activity",
+// a SUPERSET of "last metered turn", not strictly the last billed turn. The faithful hub
+// test drives the REAL `run_session_task_pinned` path so the metered turn IS what sets the
+// timestamp the state keys off, and ASSERTS the anthropic ledger row to prove the session is
+// genuinely metered (not a synthesized row).
+
+/// Idle threshold (ms): a link with NO activity for AT LEAST this long is no longer
+/// [`LinkState::Fresh`] — it becomes [`LinkState::Stale`]. 60s.
+pub const LINK_STALE_AFTER_MS: i64 = 60_000;
+
+/// Offline bound (ms): a link whose last activity is AT LEAST this old is
+/// [`LinkState::Offline`] (the longer bound — the last metered turn is well past stale). 5m.
+pub const LINK_OFFLINE_AFTER_MS: i64 = 300_000;
+
+/// The connectivity/staleness state of a routed session link, derived from last-activity vs
+/// now. A CLOSED vocabulary (like [`crate::run_readback_projection`]'s loop-status label) —
+/// the only values are these three, so no session-embedded text can leak through it.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum LinkState {
+    /// Active within the idle threshold (`elapsed < LINK_STALE_AFTER_MS`).
+    Fresh,
+    /// Idle for at least the stale threshold but less than the offline bound.
+    Stale,
+    /// Last activity is at least the offline bound old (`elapsed >= LINK_OFFLINE_AFTER_MS`).
+    Offline,
+}
+
+impl LinkState {
+    /// The stable, refs-only label — a fixed `&'static str` from the closed vocabulary
+    /// (never any session text), suitable for an off-process projection.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            LinkState::Fresh => "fresh",
+            LinkState::Stale => "stale",
+            LinkState::Offline => "offline",
+        }
+    }
+}
+
+/// Derive the [`LinkState`] from a session's `last_activity_ms` and an injected `now_ms`.
+///
+/// Pure clock-driven transition on `elapsed = now_ms - last_activity_ms`:
+/// `elapsed < LINK_STALE_AFTER_MS` ⇒ `Fresh`; `>= LINK_STALE_AFTER_MS` and
+/// `< LINK_OFFLINE_AFTER_MS` ⇒ `Stale`; `>= LINK_OFFLINE_AFTER_MS` ⇒ `Offline`. A `now_ms`
+/// BEFORE `last_activity_ms` (clock skew / a future timestamp) clamps elapsed to 0 ⇒ `Fresh`
+/// (never an underflow). No wall clock — `now_ms` is injected so the transitions are
+/// deterministically testable.
+pub fn derive_link_state(last_activity_ms: i64, now_ms: i64) -> LinkState {
+    let elapsed = now_ms.saturating_sub(last_activity_ms).max(0);
+    if elapsed >= LINK_OFFLINE_AFTER_MS {
+        LinkState::Offline
+    } else if elapsed >= LINK_STALE_AFTER_MS {
+        LinkState::Stale
+    } else {
+        LinkState::Fresh
+    }
+}
+
+/// OWNER-SCOPED link-state of one routed session: `Some(state)` derived from the session's
+/// `updated_at` (its last-activity timestamp) vs `now_ms`, ONLY when `user_id` owns the
+/// session; otherwise `None`.
+///
+/// Fail-closed exactly like [`open_session_for_owner`] / [`session_message_count_for_owner`]:
+/// a blank `user_id`, an absent session, an owner-less (NULL `user_id`) session, or a
+/// DIFFERENT owner all return `None` — a non-owner cannot read another principal's link-state
+/// by guessing its `agent_session_id` (no existence/state oracle). Pure read + compute: no
+/// write, no schema change, no model call. The timestamp is the REAL routed session's
+/// activity (`updated_at`), not a mirror heartbeat.
+pub fn link_state_for_owner(
+    conn: &Connection,
+    user_id: &str,
+    agent_session_id: &str,
+    now_ms: i64,
+) -> Result<Option<LinkState>> {
+    if !owner_matches(conn, user_id, agent_session_id)? {
+        return Ok(None);
+    }
+    // The owner check passed, so the row exists — read its last-activity timestamp.
+    let last_activity_ms: i64 = conn.query_row(
+        "SELECT updated_at FROM agent_session WHERE agent_session_id = ?1",
+        [agent_session_id],
+        |r| r.get(0),
+    )?;
+    Ok(Some(derive_link_state(last_activity_ms, now_ms)))
+}
+
 /// Load only the messages NOT yet consumed by a memory extraction
 /// (`memory_extract_status = 'pending'`), in `seq` order (oldest first). This is the
 /// dedup half of session-memory slice-2: the inline extraction reads PENDING messages
@@ -1102,6 +1204,153 @@ mod tests {
         ensure_session(db.conn(), "orphan", 1_100).unwrap();
         assert_eq!(
             open_session_for_owner(db.conn(), "alice", "orphan").unwrap(),
+            None
+        );
+    }
+
+    // --- C2-8 offline/stale link-state ---------------------------------------
+
+    #[test]
+    fn derive_link_state_transitions_fresh_stale_offline_on_the_injected_clock() {
+        // Pure clock-driven transitions on elapsed = now - last_activity. The boundaries are
+        // inclusive at the threshold (>=), so a now exactly AT a threshold is the harsher state.
+        let t = 1_000_000;
+        // Just after the turn → fresh.
+        assert_eq!(derive_link_state(t, t + 1), LinkState::Fresh);
+        assert_eq!(
+            derive_link_state(t, t + LINK_STALE_AFTER_MS - 1),
+            LinkState::Fresh,
+            "one ms before the stale threshold is still fresh"
+        );
+        // At / past the stale threshold (but before offline) → stale.
+        assert_eq!(
+            derive_link_state(t, t + LINK_STALE_AFTER_MS),
+            LinkState::Stale,
+            "exactly at the stale threshold is stale (inclusive boundary)"
+        );
+        assert_eq!(
+            derive_link_state(t, t + LINK_OFFLINE_AFTER_MS - 1),
+            LinkState::Stale,
+            "one ms before the offline bound is still stale"
+        );
+        // At / past the offline bound → offline.
+        assert_eq!(
+            derive_link_state(t, t + LINK_OFFLINE_AFTER_MS),
+            LinkState::Offline,
+            "exactly at the offline bound is offline (inclusive boundary)"
+        );
+        assert_eq!(
+            derive_link_state(t, t + LINK_OFFLINE_AFTER_MS * 10),
+            LinkState::Offline
+        );
+        // The label vocabulary is closed/stable.
+        assert_eq!(LinkState::Fresh.as_str(), "fresh");
+        assert_eq!(LinkState::Stale.as_str(), "stale");
+        assert_eq!(LinkState::Offline.as_str(), "offline");
+    }
+
+    #[test]
+    fn derive_link_state_clamps_clock_skew_to_fresh_not_underflow() {
+        // A now BEFORE last_activity (clock skew / a future timestamp) clamps elapsed to 0 →
+        // fresh, never an underflow/offline. Also robust at i64 extremes (saturating_sub).
+        assert_eq!(derive_link_state(5_000, 1_000), LinkState::Fresh);
+        assert_eq!(derive_link_state(i64::MAX, i64::MIN), LinkState::Fresh);
+    }
+
+    #[test]
+    fn link_state_for_owner_keys_off_updated_at_and_advances_with_the_clock() {
+        // SQL-level proof of the owner-gated read over the REAL agent_session.updated_at (the
+        // claude-stub/anthropic-ledger faithful proof lives in friday-hub runtime.rs, where the
+        // harness is reachable). Here updated_at stands in for the last-activity timestamp.
+        let db = Db::open_hub(&tmp("c2-8-state")).unwrap();
+        let last_turn = 2_000_000;
+        ensure_session_with_owner(
+            db.conn(),
+            "s1",
+            &SessionOwner {
+                user_id: Some("alice".into()),
+                ..Default::default()
+            },
+            last_turn,
+        )
+        .unwrap();
+
+        // now just after the turn → fresh; past the stale threshold → stale; past offline → offline.
+        assert_eq!(
+            link_state_for_owner(db.conn(), "alice", "s1", last_turn + 1).unwrap(),
+            Some(LinkState::Fresh)
+        );
+        assert_eq!(
+            link_state_for_owner(db.conn(), "alice", "s1", last_turn + LINK_STALE_AFTER_MS)
+                .unwrap(),
+            Some(LinkState::Stale)
+        );
+        assert_eq!(
+            link_state_for_owner(db.conn(), "alice", "s1", last_turn + LINK_OFFLINE_AFTER_MS)
+                .unwrap(),
+            Some(LinkState::Offline)
+        );
+
+        // A later metered turn bumps updated_at, so the link goes fresh again at the same `now`
+        // (proving the state keys off the LIVE last-activity timestamp, not a fixed creation time).
+        let stale_now = last_turn + LINK_STALE_AFTER_MS;
+        assert_eq!(
+            link_state_for_owner(db.conn(), "alice", "s1", stale_now).unwrap(),
+            Some(LinkState::Stale)
+        );
+        append_session_message(
+            db.conn(),
+            "s1",
+            &SessionMessage::new("assistant", "noted", Some("run-1".into())),
+            stale_now,
+        )
+        .unwrap();
+        assert_eq!(
+            link_state_for_owner(db.conn(), "alice", "s1", stale_now + 1).unwrap(),
+            Some(LinkState::Fresh),
+            "a fresh metered turn (bumping updated_at) returns the link to fresh"
+        );
+    }
+
+    #[test]
+    fn link_state_for_owner_is_owner_scoped_fail_closed() {
+        // The link-state read is gated by the SAME owner axis as open/count: a different
+        // principal, an owner-less session, a blank owner, and an absent id all read back None
+        // (no existence/state oracle — a non-owner cannot read another's link-state).
+        let db = Db::open_hub(&tmp("c2-8-owner")).unwrap();
+        ensure_session_with_owner(
+            db.conn(),
+            "s1",
+            &SessionOwner {
+                user_id: Some("alice".into()),
+                ..Default::default()
+            },
+            10_000,
+        )
+        .unwrap();
+        // The owner reads her own link-state.
+        assert_eq!(
+            link_state_for_owner(db.conn(), "alice", "s1", 10_000).unwrap(),
+            Some(LinkState::Fresh)
+        );
+        // A DIFFERENT principal guessing the id reads NOTHING (fail-closed — the load-bearing one).
+        assert_eq!(
+            link_state_for_owner(db.conn(), "bob", "s1", 10_000).unwrap(),
+            None
+        );
+        // A blank owner and an absent id are also fail-closed.
+        assert_eq!(
+            link_state_for_owner(db.conn(), "", "s1", 10_000).unwrap(),
+            None
+        );
+        assert_eq!(
+            link_state_for_owner(db.conn(), "alice", "ghost", 10_000).unwrap(),
+            None
+        );
+        // An owner-less session (NULL user_id) is not readable by anyone.
+        ensure_session(db.conn(), "orphan", 10_000).unwrap();
+        assert_eq!(
+            link_state_for_owner(db.conn(), "alice", "orphan", 10_000).unwrap(),
             None
         );
     }


### PR DESCRIPTION
## C2-8 — offline/stale routed-session link-state (DARK)

Adds a connectivity/staleness state on the routed session link, derived from **last-activity vs now**, keyed off the **REAL** routed `agent_session`'s metered-turn timestamps — **not** a synthesized mirror heartbeat. Builds on C2-4 (owner-scoped routed-session read).

### State derivation (pure, clock-driven)
`elapsed = now_ms - agent_session.updated_at` (saturating; a future/skewed `now` clamps to 0 → fresh):
- `elapsed < 60_000ms` (`LINK_STALE_AFTER_MS`) → **fresh**
- `60_000ms <= elapsed < 300_000ms` (`LINK_OFFLINE_AFTER_MS`) → **stale**
- `elapsed >= 300_000ms` → **offline**

`updated_at` is the column the metered turn's folded `append_session_message` bumps, so the staleness keys off the real routed session's activity. `now_ms` is **injected** (never a wall clock) so transitions are deterministically testable.

### NO-DEGRADE
Additive read/compute only. **No model call, no new ledger row, no mutation of the run path, no migration/new column.** Owner-gated via the C2-4 owner axis: a non-owner cannot read another's link-state (fail-closed `None` — no existence/state oracle). Does **NOT** touch lib.rs.

### Files
- `friday-storage/src/agent_session.rs` — `LinkState` (closed vocab) + thresholds + `derive_link_state` + owner-gated `link_state_for_owner`; SQL-level fresh/stale/offline + boundary + clock-skew + owner-fail-closed tests.
- `friday-hub/src/run_readback_projection.rs` — owner-gated refs-only `project_session_link_state` (closed-vocabulary label; runs the shared forbidden-output guard).
- `friday-hub/src/runtime.rs` — `HubRuntime::project_session_link_state` accessor + faithful DARK test.

### Faithful test (DARK, injected clock)
`c2_8_offline_stale_link_state_keys_off_the_real_metered_turn` drives the REAL `run_session_task_pinned` claude-pinned turn (reusing the claude-stub harness), **asserts the anthropic ledger row exists**, then at injected `now`: `T+1` → fresh, `T+STALE` → stale, `T+OFFLINE` → offline; a different principal's read is `None` (fail-closed); and **NO new ledger row** across all transitions (state is computed, never a model call).

🤖 Generated with [Claude Code](https://claude.com/claude-code)