### PR TITLE
NS-4: flag-gated mission-bound run seam (FRIDAY_MISSION_BOUND_RUN, default-OFF)

### DIFF
--- a/rust-core/crates/friday-hub/src/bin/hub_agent_run_server.rs
+++ b/rust-core/crates/friday-hub/src/bin/hub_agent_run_server.rs
@@ -360,6 +360,21 @@ fn run() -> Result<(), ServerError> {
         );
     }
 
+    // (NS-4) Read the MISSION-BOUND run seam flag ONCE at boot (default-off). When false the
+    // dispatch arm NEVER enters the bound-seam code — every run takes the EXACT pre-NS-4 unbound
+    // path, so deploying this binary changes NO live behavior until the operator flips this flag.
+    let mission_bound_run_enabled =
+        mission_bound_run_enabled_from(env::var(MISSION_BOUND_RUN_ENABLED_ENV).ok().as_deref());
+    if mission_bound_run_enabled {
+        eprintln!(
+            "hub_agent_run_server: MISSION-BOUND run seam ENABLED (FRIDAY_MISSION_BOUND_RUN) — a run whose session resolves to a live Mission is dispatched bound"
+        );
+    } else {
+        eprintln!(
+            "hub_agent_run_server: MISSION-BOUND run seam DISABLED (set FRIDAY_MISSION_BOUND_RUN=1 to enable) — all runs dispatch unbound"
+        );
+    }
+
     // (3) Long-lived accept loop. Each accepted connection: set the read timeout, read the peer
     // pubkey preamble, REJECT a non-allowlisted peer pubkey (S-F, the FIRST gate), reject low-order
     // points, run the WS handshake, derive the sealed session key, and serve sealed envelopes
@@ -371,6 +386,7 @@ fn run() -> Result<(), ServerError> {
             &owner_allowlist,
             &peer_allowlist,
             run_control_enabled,
+            mission_bound_run_enabled,
         ) {
             Ok(_served) => {}
             // A connection-level error ends THAT connection only; the server keeps listening.
@@ -402,6 +418,30 @@ const AGENT_RUN_CONTROL_ENABLED_ENV: &str = "FRIDAY_AGENT_RUN_CONTROL_VIA_RUST";
 /// Whether the operator has explicitly enabled the on-wire run-control plane. Fail-closed: only
 /// the exact opt-in values enable it; everything else (including unset) is OFF.
 fn agent_run_control_enabled_from(raw: Option<&str>) -> bool {
+    matches!(
+        raw.map(|v| v.trim().to_ascii_lowercase()).as_deref(),
+        Some("1") | Some("true")
+    )
+}
+
+/// (NS-4) The env flag that gates the MISSION-BOUND run seam. DEFAULT-OFF: a run is dispatched
+/// through the Mission-bound entry ([`friday_hub::run_authed_agent_loop_mission_bound`] — which
+/// mints the mission-birth + WorkItem bind) ONLY when `FRIDAY_MISSION_BOUND_RUN` is exactly
+/// `"1"`/`"true"` (case-insensitive). Unset — or any other value — leaves the seam DARK: every
+/// run takes the EXISTING unbound dispatch (`run_authed_agent_loop_with_policy` /
+/// `run_session_task_with_overrides`), BYTE-IDENTICAL to today, so deploying this binary changes
+/// NO live behavior until the operator flips this SEPARATE flag. Even with the flag ON, a run is
+/// bound only if a `MissionContextLookup` resolves (no prod surface-thread-keyed session exists
+/// yet); otherwise it falls through unbound. SEPARATE from `FRIDAY_ROUTE_AGENT_RUN_VIA_RUST`
+/// (run-START) and `FRIDAY_AGENT_RUN_CONTROL_VIA_RUST` (run-CONTROL); flipping THIS one is an
+/// operator cutover decision gated on organic Mission ingress.
+const MISSION_BOUND_RUN_ENABLED_ENV: &str = "FRIDAY_MISSION_BOUND_RUN";
+
+/// Pure flag-matcher for [`MISSION_BOUND_RUN_ENABLED_ENV`] (separated from the env read so it is
+/// testable without mutating the process-global environment). DEFAULT-OFF: `None` (unset) ⇒
+/// false; only the exact opt-in values `"1"`/`"true"` (case-insensitive, trimmed) ⇒ true;
+/// everything else ⇒ false.
+fn mission_bound_run_enabled_from(raw: Option<&str>) -> bool {
     matches!(
         raw.map(|v| v.trim().to_ascii_lowercase()).as_deref(),
         Some("1") | Some("true")
@@ -509,6 +549,7 @@ impl AgentRunWsListener {
         owner_allowlist: &[String],
         peer_allowlist: &[[u8; X25519_PUBKEY_LEN]],
         run_control_enabled: bool,
+        mission_bound_run_enabled: bool,
     ) -> Result<usize, TransportError> {
         let (stream, _peer) = self.listener.accept()?;
         // HARDENING: a per-connection read timeout BEFORE any read, so a stalled peer cannot
@@ -523,6 +564,7 @@ impl AgentRunWsListener {
             runtime,
             owner_allowlist,
             run_control_enabled,
+            mission_bound_run_enabled,
         )
     }
 }
@@ -560,6 +602,7 @@ fn serve_sealed_session<S: Read + Write, T: Transport>(
     runtime: &HubRuntime<T>,
     owner_allowlist: &[String],
     run_control_enabled: bool,
+    mission_bound_run_enabled: bool,
 ) -> Result<usize, TransportError> {
     let mut processed = 0usize;
     // S-E: per-session msg_id dedup. A reconnect mints a FRESH tracker (so it is not a
@@ -676,29 +719,56 @@ fn serve_sealed_session<S: Read + Write, T: Transport>(
                 };
                 let policy_override = effective_policy.as_ref();
 
-                let outcome = match session_id
-                    .as_deref()
-                    .map(str::trim)
-                    .filter(|s| !s.is_empty())
-                {
-                    Some(sid) => runtime.run_session_task_with_overrides(
-                        &caller,
-                        &run_id,
-                        sid,
-                        &task,
-                        policy_override,
-                        max_turns_override,
-                        now_ms,
-                    ),
-                    None => run_authed_agent_loop_with_policy(
+                // (NS-4) MISSION-BOUND seam — FLAG-GATED, the FIRST dispatch consulted. When
+                // `FRIDAY_MISSION_BOUND_RUN` is ON **and** this run's `session_id` resolves to a
+                // live DeepSeek-lane Mission surface, the run is dispatched BOUND (minting the
+                // mission-birth + WorkItem bind) and the seam returns `Some(answer)`. Otherwise it
+                // returns `None` and we fall through to the EXISTING unbound dispatch below —
+                // BYTE-IDENTICAL to the pre-NS-4 path. With the flag OFF the `else` arm binds
+                // `None` WITHOUT ever calling the seam, so a flag-off run takes the exact same
+                // `match session_id` it always has.
+                let mission_bound = if mission_bound_run_enabled {
+                    friday_hub::hub_server::run_authed_agent_loop_mission_bound(
                         runtime,
                         &caller,
                         &run_id,
                         &task,
+                        session_id.as_deref(),
                         policy_override,
                         max_turns_override,
                         now_ms,
-                    ),
+                    )
+                } else {
+                    None
+                };
+
+                let outcome = if let Some(answer) = mission_bound {
+                    answer
+                } else {
+                    match session_id
+                        .as_deref()
+                        .map(str::trim)
+                        .filter(|s| !s.is_empty())
+                    {
+                        Some(sid) => runtime.run_session_task_with_overrides(
+                            &caller,
+                            &run_id,
+                            sid,
+                            &task,
+                            policy_override,
+                            max_turns_override,
+                            now_ms,
+                        ),
+                        None => run_authed_agent_loop_with_policy(
+                            runtime,
+                            &caller,
+                            &run_id,
+                            &task,
+                            policy_override,
+                            max_turns_override,
+                            now_ms,
+                        ),
+                    }
                 };
 
                 // (refs) REFS-ONLY terminal receipt over the wire: status + answer FINGERPRINT
@@ -1423,7 +1493,7 @@ mod tests {
 
         // SERVER on the main thread (holds the non-Send runtime).
         let processed = listener
-            .accept_one(&server_kp, &rt, &allowlist, &peer_allowlist, false)
+            .accept_one(&server_kp, &rt, &allowlist, &peer_allowlist, false, false)
             .unwrap();
         assert_eq!(processed, 1, "one authed dispatch processed");
 
@@ -1533,6 +1603,7 @@ mod tests {
                 &allowlist,
                 &peer_allowlist,
                 run_control_enabled,
+                false, // (NS-4) mission-bound seam OFF for the run-control flag tests
             )
             .unwrap();
         assert_eq!(processed, 1, "[{tag}] the paused dispatch is processed");
@@ -1609,7 +1680,7 @@ mod tests {
             (req, session.clone(), session.clone())
         });
         let processed = listener
-            .accept_one(&server_kp, &rt, &allowlist, &peer_allowlist, false)
+            .accept_one(&server_kp, &rt, &allowlist, &peer_allowlist, false, false)
             .unwrap();
         assert_eq!(
             processed, 1,
@@ -1643,7 +1714,7 @@ mod tests {
         });
 
         let processed = listener
-            .accept_one(&server_kp, &rt, &allowlist, &peer_allowlist, false)
+            .accept_one(&server_kp, &rt, &allowlist, &peer_allowlist, false, false)
             .unwrap();
         assert_eq!(processed, 0, "[{tag}] rejected dispatch processes ZERO");
 
@@ -1710,6 +1781,39 @@ mod tests {
     }
 
     #[test]
+    fn mission_bound_run_flag_is_default_off_and_fail_closed() {
+        // (NS-4) The mission-bound run seam is DEFAULT-OFF: unset ⇒ disabled (deploy-safe, the
+        // dispatch arm never enters the bound-seam code). Only the exact opt-in values enable it;
+        // everything else is OFF.
+        assert!(
+            !mission_bound_run_enabled_from(None),
+            "unset ⇒ disabled (default-off, deploy-safe)"
+        );
+        assert!(
+            !mission_bound_run_enabled_from(Some("")),
+            "empty ⇒ disabled"
+        );
+        assert!(!mission_bound_run_enabled_from(Some("0")), "0 ⇒ disabled");
+        assert!(
+            !mission_bound_run_enabled_from(Some("false")),
+            "false ⇒ disabled"
+        );
+        assert!(
+            !mission_bound_run_enabled_from(Some("on")),
+            "garbage ⇒ disabled"
+        );
+        assert!(mission_bound_run_enabled_from(Some("1")), "1 ⇒ enabled");
+        assert!(
+            mission_bound_run_enabled_from(Some("true")),
+            "true ⇒ enabled"
+        );
+        assert!(
+            mission_bound_run_enabled_from(Some("  TRUE  ")),
+            "padded TRUE ⇒ enabled"
+        );
+    }
+
+    #[test]
     fn non_allowlisted_principal_is_rejected_no_run_no_body() {
         reject_case("rej-forged", "principal:attacker-not-allowlisted");
     }
@@ -1763,7 +1867,7 @@ mod tests {
         });
 
         let processed = listener
-            .accept_one(&server_kp, &rt, &allowlist, &peer_allowlist, false)
+            .accept_one(&server_kp, &rt, &allowlist, &peer_allowlist, false, false)
             .unwrap();
         assert_eq!(
             processed, 0,
@@ -1798,7 +1902,7 @@ mod tests {
         });
 
         let processed = listener
-            .accept_one(&server_kp, &rt, &allowlist, &peer_allowlist, false)
+            .accept_one(&server_kp, &rt, &allowlist, &peer_allowlist, false, false)
             .unwrap();
         assert_eq!(
             processed, 0,
@@ -1833,7 +1937,8 @@ mod tests {
             drop(stream);
         });
         // accept_one runs the REAL production path; a low-order key must make it return Err.
-        let outcome = listener.accept_one(&server_kp, &rt, &allowlist, &peer_allowlist, false);
+        let outcome =
+            listener.accept_one(&server_kp, &rt, &allowlist, &peer_allowlist, false, false);
         client.join().unwrap();
         assert!(
             outcome.is_err(),
@@ -2111,7 +2216,7 @@ mod tests {
             let _ = ws_recv_envelope(&mut ws, &sess_c1, SESSION_AAD);
         });
         let processed1 = listener
-            .accept_one(&server_kp, &rt1, &allowlist, &peer_allowlist, false)
+            .accept_one(&server_kp, &rt1, &allowlist, &peer_allowlist, false, false)
             .unwrap();
         assert_eq!(processed1, 1, "connection-1 is a VALID dispatch");
         let captured_proof = rx.recv().unwrap();
@@ -2144,7 +2249,7 @@ mod tests {
                 .map(|e| e.message)
         });
         let processed2 = listener
-            .accept_one(&server_kp, &rt2, &allowlist, &peer_allowlist, false)
+            .accept_one(&server_kp, &rt2, &allowlist, &peer_allowlist, false, false)
             .unwrap();
         assert_eq!(
             processed2, 0,
@@ -2195,7 +2300,7 @@ mod tests {
         });
 
         let processed = listener
-            .accept_one(&server_kp, &rt, &allowlist, &peer_allowlist, false)
+            .accept_one(&server_kp, &rt, &allowlist, &peer_allowlist, false, false)
             .unwrap();
         // The first keepalive was processed (echoed); the replayed msg_id ended the session.
         assert_eq!(
@@ -2263,8 +2368,14 @@ mod tests {
 
         let client = thread::spawn(move || try_preamble(addr, attacker_pub));
         // The server runs the REAL accept path; a non-allowlisted peer must make it FAIL CLOSED.
-        let outcome =
-            listener.accept_one(&server_kp, &rt, &owner_allowlist, &peer_allowlist, false);
+        let outcome = listener.accept_one(
+            &server_kp,
+            &rt,
+            &owner_allowlist,
+            &peer_allowlist,
+            false,
+            false,
+        );
         let obs = client.join().unwrap();
 
         assert!(
@@ -2313,7 +2424,14 @@ mod tests {
             (req, session.clone(), session.clone())
         });
         let processed = listener
-            .accept_one(&server_kp, &rt, &owner_allowlist, &peer_allowlist, false)
+            .accept_one(
+                &server_kp,
+                &rt,
+                &owner_allowlist,
+                &peer_allowlist,
+                false,
+                false,
+            )
             .unwrap();
         assert_eq!(
             processed, 1,
@@ -2714,7 +2832,14 @@ mod tests {
         // body send lands in the loopback send buffer, so `serve_sealed_session` returns Ok (no
         // error settle). (Large bodies can Err on the body send; see the NOTE on the test above.)
         let processed = listener
-            .accept_one(&server_kp, &rt, &owner_allowlist, &peer_allowlist, false)
+            .accept_one(
+                &server_kp,
+                &rt,
+                &owner_allowlist,
+                &peer_allowlist,
+                false,
+                false,
+            )
             .expect("server serves the interop session");
         assert_eq!(processed, 1, "one authed dispatch processed");
 
@@ -2761,7 +2886,14 @@ mod tests {
         // The TS client uses its fixed secret (whose pubkey is NOT enrolled) ⇒ rejected at preamble.
         let child = spawn_ts_client(addr.port(), &ts_client_secret_hex(), OWNER, "run-forged");
         // The server rejects the peer pubkey and returns an Err (no session established).
-        let served = listener.accept_one(&server_kp, &rt, &owner_allowlist, &peer_allowlist, false);
+        let served = listener.accept_one(
+            &server_kp,
+            &rt,
+            &owner_allowlist,
+            &peer_allowlist,
+            false,
+            false,
+        );
         assert!(
             served.is_err(),
             "a forged/non-allowlisted peer establishes NO session"
@@ -2803,7 +2935,14 @@ mod tests {
             "run-badprincipal",
         );
         let processed = listener
-            .accept_one(&server_kp, &rt, &owner_allowlist, &peer_allowlist, false)
+            .accept_one(
+                &server_kp,
+                &rt,
+                &owner_allowlist,
+                &peer_allowlist,
+                false,
+                false,
+            )
             .expect("server serves the session but runs nothing");
         assert_eq!(
             processed, 0,
@@ -2903,7 +3042,14 @@ mod tests {
             "run-compose-ok",
         );
         let processed = listener
-            .accept_one(&server_kp, &rt, &owner_allowlist, &peer_allowlist, false)
+            .accept_one(
+                &server_kp,
+                &rt,
+                &owner_allowlist,
+                &peer_allowlist,
+                false,
+                false,
+            )
             .expect("server serves the compose-adapter session");
         assert_eq!(processed, 1, "one authed dispatch processed");
 
@@ -2950,7 +3096,14 @@ mod tests {
             OWNER,
             "run-compose-forged",
         );
-        let served = listener.accept_one(&server_kp, &rt, &owner_allowlist, &peer_allowlist, false);
+        let served = listener.accept_one(
+            &server_kp,
+            &rt,
+            &owner_allowlist,
+            &peer_allowlist,
+            false,
+            false,
+        );
         assert!(
             served.is_err(),
             "an unenrolled derived pubkey establishes NO session"
@@ -3003,7 +3156,7 @@ mod tests {
         });
 
         let processed = listener
-            .accept_one(&server_kp, &rt, &allowlist, &peer_allowlist, false)
+            .accept_one(&server_kp, &rt, &allowlist, &peer_allowlist, false, false)
             .unwrap();
         assert_eq!(processed, 1, "one sessioned dispatch processed");
 
@@ -3104,7 +3257,7 @@ mod tests {
         });
         assert_eq!(
             listener
-                .accept_one(&server_kp, &rt, &allowlist, &peer1, false)
+                .accept_one(&server_kp, &rt, &allowlist, &peer1, false, false)
                 .unwrap(),
             1
         );
@@ -3121,7 +3274,7 @@ mod tests {
         });
         assert_eq!(
             listener
-                .accept_one(&server_kp, &rt, &allowlist, &peer2, false)
+                .accept_one(&server_kp, &rt, &allowlist, &peer2, false, false)
                 .unwrap(),
             1
         );
@@ -3166,7 +3319,7 @@ mod tests {
         });
         assert_eq!(
             listener
-                .accept_one(&server_kp, &rt, &allowlist, &peer_allowlist, false)
+                .accept_one(&server_kp, &rt, &allowlist, &peer_allowlist, false, false)
                 .unwrap(),
             1
         );

--- a/rust-core/crates/friday-hub/src/hub_server.rs
+++ b/rust-core/crates/friday-hub/src/hub_server.rs
@@ -1475,6 +1475,123 @@ pub fn run_authed_agent_loop_with_policy<T: Transport>(
         .with_counts(outcome.turns, outcome.executed_tools)
 }
 
+/// (NS-4) The FLAG-GATED Mission-BOUND dispatch seam — the live-reachable counterpart of the
+/// UNBOUND [`run_authed_agent_loop_with_policy`]. When the operator has flipped
+/// `FRIDAY_MISSION_BOUND_RUN` ON **and** a [`MissionContextLookup`] resolves to a live
+/// DeepSeek-lane Mission/WorkItem for this run, it dispatches the run through
+/// [`HubRuntime::run_agent_loop_for_mission_with_overrides`] — minting the mission-birth /
+/// WorkItem bind (a `MissionLink` + a WorkItem status transition + a `route_decision`) the
+/// unbound `run_task` path never produces. This is the seam mission-birth + passport-mint
+/// depend on to be live-reachable.
+///
+/// ## Return contract (the load-bearing NO-DEGRADE shape)
+/// - `Some(answer)` — the bound path was TAKEN (or fail-closed): the caller MUST use this and
+///   NOT run the unbound path. Two cases:
+///     * `MissionBoundLoopOutcome::Ran` ⇒ the owner-gated body, projected by
+///       [`project_answer_for_authed`] EXACTLY as the unbound entry does (same owner-wiring —
+///       both go through `run_with_request`), with the loop's COUNTS attached.
+///     * `Err(_)` ⇒ a body-free [`AuthedAnswer::NoAnswer`]. A SAFE FAILURE that MUST NOT fall
+///       through: by the time `run_agent_loop_for_mission` errors it has ALREADY created the
+///       `agent_run` row + may have spent model calls, so re-running the unbound path would
+///       conflict on `create_run` and double-bill. We stop here.
+/// - `None` — the bound path was NOT taken; the caller falls through to the EXISTING unbound
+///   dispatch BYTE-IDENTICALLY. Two cases, both write NOTHING:
+///     * the flag is OFF, or no `MissionContextLookup` was derivable (sessionless run); OR
+///     * `MissionBoundLoopOutcome::Blocked` — the preflight failed closed (the common case: the
+///       run's `session_id` is an ordinary chat session, not a Mission surface thread). The
+///       preflight returns Blocked BEFORE `upsert_route_decision` and BEFORE `create_run`, so a
+///       fall-through leaves NO stray `route_decision`/`agent_run`/`mission_link` row — the
+///       unbound run that follows is byte-identical to today.
+///
+/// ## FIX-Q2 owner gate (UNCHANGED invariant)
+/// The `caller == configured_principal` gate is asserted HERE, BEFORE any dispatch — the SAME
+/// fail-closed guard the unbound entry enforces. A non-owner caller (or an unconfigured `None`
+/// owner) returns a body-free `NoAnswer` and the loop NEVER runs (no row, no recall, no spend,
+/// no mission bind). The Mission-bound path must not be a way around the owner gate.
+///
+/// ## Provisional ingress (DARK; the deferred live-reachability)
+/// The wire `AgentRunRequest` carries NO Mission handle yet, so the ONLY run-scoped key
+/// available is the client-asserted `session_id`, mapped to a surface thread via
+/// [`MissionContextLookup::by_surface_thread`]. This conflates a chat-session id with a
+/// surface-thread id, which is SAFE only because resolution fails CLOSED (`Blocked` ⇒ `None` ⇒
+/// unbound). A first-class Mission handle on the wire (organic ingress) + the operator cutover
+/// plane are the DEFERRED prerequisites for this seam to move the live needle. Until then the
+/// flag is OFF and this returns `None` for every live request (no surface-thread-keyed session
+/// exists in prod), so the live run path is unchanged.
+///
+/// ## Semantics worth stating
+/// The bound path is SESSIONLESS (`run_task_with_overrides`, no history fold): a `session_id`
+/// that resolves to a Mission surface dispatches a bound WORK-run, not a sessioned chat — prior
+/// turns are not folded. The override threading matches the unbound arm so a peer-asserted
+/// tightening constraint is enforced identically (read-only / disabled-tools / max-turns).
+///
+/// The bound path is pinned to `WorkLane::DeepSeek` (the single live provider) by
+/// `run_agent_loop_for_mission_with_overrides` — expected, not a defect.
+#[allow(clippy::too_many_arguments)]
+pub fn run_authed_agent_loop_mission_bound<T: Transport>(
+    runtime: &HubRuntime<T>,
+    caller: &AuthedPrincipal,
+    run_id: &str,
+    task: &str,
+    session_id: Option<&str>,
+    policy_override: Option<&crate::RunPolicy>,
+    max_turns_override: Option<u64>,
+    now_ms: i64,
+) -> Option<AuthedAnswer> {
+    // Derive a MissionContextLookup from the only run-scoped key on the wire: the client-asserted
+    // `session_id` (treated as a surface-thread id). A sessionless run (or a blank session id) is
+    // NOT mission-resolvable ⇒ `None` ⇒ the caller falls through to the unbound path unchanged.
+    let lookup = session_id
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(MissionContextLookup::by_surface_thread)?;
+
+    // (FIX-Q2) caller == configured-owner, asserted BEFORE any dispatch — the SAME fail-closed
+    // guard the unbound entry enforces. A mismatch (or an unconfigured `None` owner) ⇒ a
+    // body-free `NoAnswer`, the loop NEVER runs, and we DO NOT fall through (returning `Some`
+    // closes the run as denied rather than silently re-trying the unbound owner-gated path).
+    match runtime.configured_principal() {
+        Some(owner) if owner == caller.principal() => {}
+        _ => {
+            return Some(AuthedAnswer::NoAnswer {
+                run_id: run_id.to_string(),
+            });
+        }
+    }
+
+    // The session id doubles as the provider-timeline session for the Mission bind. A non-empty
+    // value is guaranteed by the `filter`/`map` above.
+    let session = session_id.map(str::trim).filter(|s| !s.is_empty())?;
+
+    match runtime.run_agent_loop_for_mission_with_overrides(
+        lookup,
+        session,
+        run_id,
+        task,
+        policy_override,
+        max_turns_override,
+        now_ms,
+    ) {
+        // The Mission was valid: the composed loop ran and the run was bound to the Mission.
+        // Project the owner-gated body EXACTLY as the unbound entry does (both persist
+        // `run_result` with the same owner-wiring via `run_with_request`), then attach the
+        // loop's COUNTS. Token counts stay `None` (DEFERRED — billed to the token_ledger).
+        Ok(crate::runtime::MissionBoundLoopOutcome::Ran { outcome, .. }) => Some(
+            project_answer_for_authed(runtime.db().conn(), run_id, caller)
+                .with_counts(outcome.turns, outcome.executed_tools),
+        ),
+        // The preflight failed CLOSED (no resolvable/valid Mission for this run) — it wrote
+        // NOTHING (no `agent_run`, no `route_decision`, no `mission_link`). Fall through to the
+        // EXISTING unbound dispatch, BYTE-IDENTICAL to today.
+        Ok(crate::runtime::MissionBoundLoopOutcome::Blocked { .. }) => None,
+        // SAFE FAILURE: a route/storage error AFTER the run row exists. Body-free `NoAnswer`; we
+        // MUST NOT fall through (the unbound path would re-`create_run` and double-bill).
+        Err(_) => Some(AuthedAnswer::NoAnswer {
+            run_id: run_id.to_string(),
+        }),
+    }
+}
+
 fn work_item_timeline_wire(item: friday_core::WorkItem) -> MissionTimelineWorkItemWire {
     MissionTimelineWorkItemWire {
         work_item_id: item.work_item_id,
@@ -6493,5 +6610,403 @@ mod authed_route_tests {
             pause.summary.contains("write_file"),
             "the pause is for the mutating write_file action"
         );
+    }
+
+    // --- NS-4: the flag-gated MISSION-BOUND run seam --------------------------
+    //
+    // `run_authed_agent_loop_mission_bound` is the live-reachable counterpart of the unbound
+    // entry: when (in the bin) `FRIDAY_MISSION_BOUND_RUN` is ON and a `session_id` resolves to a
+    // live DeepSeek-lane Mission surface, a run is dispatched BOUND (minting the mission-birth +
+    // WorkItem bind). These tests drive the SEAM directly (the bin's flag plumbing is exercised by
+    // its own `*_enabled_from` matcher tests). The flag-on test proves REAL mission binding
+    // (MissionLink + WorkItem transition + route_decision); the flag-off/no-mission tests prove
+    // byte-identical fall-through.
+
+    use friday_core::{
+        ApprovalState as NsApprovalState, FridayConversation as NsFridayConversation,
+        HandoffJudgmentMemory as NsHandoffJudgmentMemory, Mission as NsMission,
+        MissionStatus as NsMissionStatus, Risk as NsRisk, SurfaceKind as NsSurfaceKind,
+        SurfaceThread as NsSurfaceThread, TruthStatus as NsTruthStatus,
+        VisibilityPolicy as NsVisibilityPolicy, WorkItem as NsWorkItem,
+        WorkItemStatus as NsWorkItemStatus, WorkLane as NsWorkLane,
+    };
+
+    /// Stage a `FridayConversation -> Mission -> WorkItem` graph the seam's preflight resolves,
+    /// with the SurfaceThread keyed by `surface_thread_id` — the SAME id the seam derives the
+    /// `MissionContextLookup` from (the run's `session_id`). A DeepSeek-lane / `deepseek`-target
+    /// active WorkItem makes the bound dispatch RESOLVABLE.
+    fn ns4_seed_mission<T: Transport>(rt: &HubRuntime<T>, surface_thread_id: &str) {
+        let now = 1_700_000_000_000;
+        let db = rt.db();
+        db.upsert_friday_conversation(&NsFridayConversation {
+            friday_conversation_id: "fconv_ns4".into(),
+            owner_principal: "principal:owner".into(),
+            title: "NS-4 mission".into(),
+            current_focus_summary: "Mission-bound run seam".into(),
+            active_mission_ids: vec!["mission-ns4".into()],
+            surface_thread_ids: vec![surface_thread_id.to_string()],
+            memory_scope_ref: None,
+            truth_status: NsTruthStatus::WiredRegistry,
+            proof_refs: vec!["proof://ns4-test".into()],
+            created_at_ms: now,
+            updated_at_ms: now,
+        })
+        .unwrap();
+        db.upsert_mission(&NsMission {
+            mission_id: "mission-ns4".into(),
+            friday_conversation_id: "fconv_ns4".into(),
+            title: "NS-4 mission".into(),
+            intent: "bind the live run to a mission".into(),
+            status: NsMissionStatus::Active,
+            why_now: "live runs must tie to a mission".into(),
+            decision_path_summary: "resolve mission context before the loop".into(),
+            considered_options: vec!["unbound run".into()],
+            deferred_options: vec!["multi-provider".into()],
+            known_pitfalls: vec!["unbound run looked bound".into()],
+            handoff_inheritance: vec!["preserve route judgment".into()],
+            work_item_ids: vec!["work-ns4".into()],
+            memory_candidate_refs: Vec::new(),
+            context_passport_refs: Vec::new(),
+            proof_refs: vec!["proof://ns4-test".into()],
+            created_at_ms: now,
+            updated_at_ms: now,
+        })
+        .unwrap();
+        db.upsert_surface_thread(&NsSurfaceThread {
+            surface_thread_id: surface_thread_id.to_string(),
+            friday_conversation_id: "fconv_ns4".into(),
+            mission_id: Some("mission-ns4".into()),
+            surface_kind: NsSurfaceKind::Mobile,
+            channel_binding_id: None,
+            delivery_route: "mobile".into(),
+            visibility_policy: NsVisibilityPolicy::Compact,
+            allowed_actions: vec!["open_mission".into()],
+            last_seen_at_ms: Some(now),
+            last_delivered_event_seq: Some(1),
+            created_at_ms: now,
+            updated_at_ms: now,
+        })
+        .unwrap();
+        db.upsert_work_item(&NsWorkItem {
+            work_item_id: "work-ns4".into(),
+            mission_id: "mission-ns4".into(),
+            lane: NsWorkLane::DeepSeek,
+            target_provider_or_agent: Some("deepseek".into()),
+            status: NsWorkItemStatus::ReadyToDispatch,
+            owner_claim_ids: Vec::new(),
+            workspace_refs: Vec::new(),
+            capability_id: Some("mission.ns4".into()),
+            risk_level: NsRisk::Medium,
+            approval_state: NsApprovalState::NotRequired,
+            blocking_reason: None,
+            input_refs: vec!["input://ns4".into()],
+            output_refs: Vec::new(),
+            proof_requirements: vec!["ns4 tests".into()],
+            proof_receipts: Vec::new(),
+            judgment_memory: ns4_judgment(),
+            created_at_ms: now,
+            updated_at_ms: now,
+        })
+        .unwrap();
+    }
+
+    fn ns4_judgment() -> NsHandoffJudgmentMemory {
+        NsHandoffJudgmentMemory {
+            task: "Run the Mission-bound agent loop".into(),
+            current_blocker: None,
+            target_lane_thread_agent_provider: NsWorkLane::DeepSeek.as_str().into(),
+            read_first_files: vec!["rust-core/crates/friday-hub/src/hub_server.rs".into()],
+            required_output: "Mission-bound run".into(),
+            done_criteria: vec!["run bound to mission".into()],
+            red_lines: vec!["do not run before mission context".into()],
+            why_this_route: "The WorkItem lane owns the agent loop.".into(),
+            considered_options: vec!["unbound run_task".into()],
+            deferred_options: vec!["multi-provider loop".into()],
+            previous_pitfalls: vec!["detached run looked bound".into()],
+            inheritable_context: vec!["Mission is product truth".into()],
+            proof_requirements: vec!["ns4 tests".into()],
+            ownership_claim_ids: Vec::new(),
+        }
+    }
+
+    fn table_count<T: Transport>(rt: &HubRuntime<T>, table: &str) -> i64 {
+        rt.db()
+            .conn()
+            .query_row(&format!("SELECT count(*) FROM {table}"), [], |r| r.get(0))
+            .unwrap()
+    }
+
+    fn agent_run_count<T: Transport>(rt: &HubRuntime<T>, run_id: &str) -> i64 {
+        rt.db()
+            .conn()
+            .query_row(
+                "SELECT count(*) FROM agent_run WHERE run_id = ?1",
+                [run_id],
+                |r| r.get(0),
+            )
+            .unwrap()
+    }
+
+    /// FLAG-ON happy path: a run whose `session_id` resolves to a live DeepSeek-lane Mission is
+    /// dispatched BOUND. The seam returns the owner-gated body AND mints REAL mission binding —
+    /// a `MissionLink` tied to THIS run_id, a `ReadyToDispatch -> CompletedWithProof` WorkItem
+    /// transition (the run as proof), and a `route_decision` row keyed to this run.
+    #[test]
+    fn mission_bound_seam_on_binds_run_to_mission_and_delivers_body_to_owner() {
+        let (rt, _ws) = runtime_with(
+            "ns4-bound",
+            FinishTransport {
+                answer: BODY.to_string(),
+            },
+            "principal:owner",
+        );
+        let surface = "surface-ns4-session";
+        ns4_seed_mission(&rt, surface);
+        let caller = authed("principal:owner");
+
+        // The seam is consulted (as the bin does when the flag is ON) with the run's session_id.
+        let out = run_authed_agent_loop_mission_bound(
+            &rt,
+            &caller,
+            "run-ns4-bound",
+            "do the mission work",
+            Some(surface),
+            None,
+            None,
+            1000,
+        )
+        .expect("the bound seam took the run (Some), not a fall-through");
+
+        // The authenticated owner is delivered the body via the SAME owner-gated projection the
+        // unbound path uses.
+        assert_eq!(
+            out.delivered_body(),
+            Some(BODY),
+            "the owner receives the bound run's answer body"
+        );
+        // The refs surface never leaks the body or a secret.
+        let proof = out.proof_refs_json().to_string();
+        assert!(
+            !proof.contains(BODY),
+            "proof surface leaked the body: {proof}"
+        );
+        assert!(!proof.contains("authed-route-test-secret"));
+
+        // REAL mission binding #1 — a MissionLink ties THIS run to the Mission/WorkItem.
+        let links = rt.db().list_mission_links("mission-ns4").unwrap();
+        assert!(
+            links.iter().any(|link| link.target_ref
+                == format!("friday://provider-timeline/{surface}#run-ns4-bound")
+                && link.work_item_id.as_deref() == Some("work-ns4")),
+            "a mission_link must bind THIS run to the mission: {links:?}"
+        );
+        // REAL mission binding #2 — the WorkItem transitioned ReadyToDispatch -> CompletedWithProof
+        // with the run as proof (the run actually completed the work).
+        let work_item = rt.db().get_work_item("work-ns4").unwrap().unwrap();
+        assert_eq!(work_item.status, NsWorkItemStatus::CompletedWithProof);
+        assert!(work_item
+            .proof_receipts
+            .contains(&"friday://agent-run/run-ns4-bound".to_string()));
+        // REAL mission binding #3 — a route_decision row keyed to THIS run exists.
+        let route_decisions: i64 = rt
+            .db()
+            .conn()
+            .query_row(
+                "SELECT count(*) FROM route_decision WHERE decision_id = ?1",
+                ["route-decision:agent-loop:run-ns4-bound"],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(
+            route_decisions, 1,
+            "a route_decision binds the run to the mission"
+        );
+        assert_eq!(agent_run_count(&rt, "run-ns4-bound"), 1, "the loop ran");
+        assert!(friday_storage::audit::verify_audit_chain(rt.db().conn()).is_ok());
+    }
+
+    /// FLAG-OFF byte-identical: when the flag is OFF, the bin NEVER calls the seam — every run
+    /// takes the EXACT unbound `run_authed_agent_loop_with_policy` path. This test pins that
+    /// unbound result, with the SAME Mission staged, produces ZERO mission binding (no
+    /// MissionLink, no WorkItem transition, no route_decision) and delivers the IDENTICAL body —
+    /// i.e. the run is byte-identical to today even though a resolvable Mission exists.
+    #[test]
+    fn mission_bound_flag_off_is_byte_identical_unbound_run_no_binding() {
+        let (rt, _ws) = runtime_with(
+            "ns4-off",
+            FinishTransport {
+                answer: BODY.to_string(),
+            },
+            "principal:owner",
+        );
+        ns4_seed_mission(&rt, "surface-ns4-session");
+        let caller = authed("principal:owner");
+
+        // The bin's flag-off path: the seam is NEVER consulted; the run goes straight through the
+        // unbound entry. We invoke EXACTLY that entry here (the same call the dispatch arm makes
+        // for a sessionless run with the flag off).
+        let out = run_authed_agent_loop_with_policy(
+            &rt,
+            &caller,
+            "run-ns4-off",
+            "do work",
+            None,
+            None,
+            1000,
+        );
+
+        // Same body delivered to the owner — unchanged behavior.
+        assert_eq!(
+            out.delivered_body(),
+            Some(BODY),
+            "flag-off run delivers the same body the pre-NS-4 unbound run did"
+        );
+        // ZERO mission binding — the unbound run touches no mission graph even though one resolves.
+        assert_eq!(
+            table_count(&rt, "mission_link"),
+            0,
+            "flag-off / unbound run must create NO mission_link"
+        );
+        assert_eq!(
+            table_count(&rt, "route_decision"),
+            0,
+            "flag-off / unbound run must create NO route_decision"
+        );
+        let work_item = rt.db().get_work_item("work-ns4").unwrap().unwrap();
+        assert_eq!(
+            work_item.status,
+            NsWorkItemStatus::ReadyToDispatch,
+            "flag-off / unbound run must NOT transition the WorkItem"
+        );
+        assert!(
+            work_item.proof_receipts.is_empty(),
+            "no proof attached unbound"
+        );
+        assert_eq!(
+            agent_run_count(&rt, "run-ns4-off"),
+            1,
+            "the unbound run still ran"
+        );
+    }
+
+    /// FLAG-ON but NO resolvable Mission: a `session_id` that is an ordinary chat session (no
+    /// surface-thread row / no bound mission) makes the seam fail CLOSED to `None` — the caller
+    /// falls through to the unbound path, byte-identical to today. The preflight wrote NOTHING.
+    #[test]
+    fn mission_bound_seam_on_unresolvable_falls_through_none_no_binding() {
+        let (rt, _ws) = runtime_with(
+            "ns4-fallthrough",
+            FinishTransport {
+                answer: BODY.to_string(),
+            },
+            "principal:owner",
+        );
+        // NO mission staged — the session_id does not resolve to a surface-thread-bound mission.
+        let caller = authed("principal:owner");
+
+        let out = run_authed_agent_loop_mission_bound(
+            &rt,
+            &caller,
+            "run-ns4-ft",
+            "do work",
+            Some("ordinary-chat-session"),
+            None,
+            None,
+            1000,
+        );
+
+        // The seam returned None ⇒ the caller falls through to the unbound dispatch.
+        assert!(
+            out.is_none(),
+            "an unresolvable mission must fall through (None), not bind"
+        );
+        // The fail-closed preflight wrote nothing: no run, no route_decision, no mission_link.
+        assert_eq!(
+            agent_run_count(&rt, "run-ns4-ft"),
+            0,
+            "no run on a blocked preflight"
+        );
+        assert_eq!(table_count(&rt, "route_decision"), 0);
+        assert_eq!(table_count(&rt, "mission_link"), 0);
+    }
+
+    /// FLAG-ON sessionless: a run with NO `session_id` is NOT mission-resolvable ⇒ the seam
+    /// returns `None` immediately (before any DB touch) and the caller falls through unbound.
+    #[test]
+    fn mission_bound_seam_on_sessionless_returns_none() {
+        let (rt, _ws) = runtime_with(
+            "ns4-sessionless",
+            FinishTransport {
+                answer: BODY.to_string(),
+            },
+            "principal:owner",
+        );
+        ns4_seed_mission(&rt, "surface-ns4-session");
+        let caller = authed("principal:owner");
+
+        let out = run_authed_agent_loop_mission_bound(
+            &rt,
+            &caller,
+            "run-ns4-none",
+            "do work",
+            None, // sessionless — no key to resolve a mission
+            None,
+            None,
+            1000,
+        );
+        assert!(out.is_none(), "a sessionless run is not mission-bound");
+        // No run was created by the seam (it returned None before any dispatch).
+        assert_eq!(agent_run_count(&rt, "run-ns4-none"), 0);
+        assert_eq!(table_count(&rt, "mission_link"), 0);
+    }
+
+    /// FIX-Q2 at the seam: a caller authenticated as a principal that is NOT the runtime's
+    /// configured owner must NEVER reach the bound dispatch — even with a resolvable Mission. The
+    /// seam returns `Some(NoAnswer)` (denied, not a fall-through) and the loop NEVER runs (no run
+    /// row, no mission binding). The mission-bound path must not be a way around the owner gate.
+    #[test]
+    fn mission_bound_seam_mismatched_caller_never_dispatches() {
+        let (rt, _ws) = runtime_with(
+            "ns4-q2",
+            FinishTransport {
+                answer: BODY.to_string(),
+            },
+            "principal:owner",
+        );
+        let surface = "surface-ns4-session";
+        ns4_seed_mission(&rt, surface);
+        let intruder = authed("principal:intruder");
+
+        let out = run_authed_agent_loop_mission_bound(
+            &rt,
+            &intruder,
+            "run-ns4-q2",
+            "do work",
+            Some(surface),
+            None,
+            None,
+            1000,
+        )
+        .expect("the owner gate returns Some(NoAnswer), not a fall-through");
+        assert!(
+            matches!(out, AuthedAnswer::NoAnswer { .. }),
+            "a mismatched caller must get the body-free NoAnswer"
+        );
+        // THE INVARIANT: no run row, no mission binding — the guard fired BEFORE any dispatch.
+        assert_eq!(
+            agent_run_count(&rt, "run-ns4-q2"),
+            0,
+            "FIX-Q2 at the seam: a mismatched caller must NOT dispatch a bound run"
+        );
+        assert_eq!(
+            table_count(&rt, "mission_link"),
+            0,
+            "no binding for a denied caller"
+        );
+        // The configured owner principal never leaks to the mismatched caller.
+        assert!(!out
+            .proof_refs_json()
+            .to_string()
+            .contains("principal:owner"));
     }
 }

--- a/rust-core/crates/friday-hub/src/runtime.rs
+++ b/rust-core/crates/friday-hub/src/runtime.rs
@@ -840,6 +840,42 @@ impl<T: Transport> HubRuntime<T> {
         task: &str,
         now_ms: i64,
     ) -> Result<MissionBoundLoopOutcome, RoutedLoopError> {
+        // Boot policy / ceiling (no per-run override) — the byte-identical pre-NS-4 body.
+        self.run_agent_loop_for_mission_with_overrides(
+            mission_lookup,
+            session_id,
+            run_id,
+            task,
+            None,
+            None,
+            now_ms,
+        )
+    }
+
+    /// (NS-4) [`Self::run_agent_loop_for_mission`] with an OPTIONAL per-run policy + max-turns
+    /// override threaded onto the composed loop — the Mission-bound parity of
+    /// [`Self::run_task_with_overrides`]. `None`/`None` ⇒ the boot policy/ceiling, byte-identical
+    /// to the pre-NS-4 entry. `Some(p)` ⇒ the COMPOSED only-tighten policy the live WS dispatch
+    /// arm built via [`crate::agent_run_control::effective_run_policy_over`].
+    ///
+    /// WHY this exists: the live mission-bound seam ([`crate::run_authed_agent_loop_mission_bound`])
+    /// is reached on the SAME dispatch arm that applies a peer's per-run CONSTRAINTS. The unbound
+    /// path threads those onto its loop; the Mission-bound loop MUST enforce the IDENTICAL
+    /// tightening (read-only / disabled-tools / max-turns) or a constraint asserted on a
+    /// mission-bound run would be silently dropped. The override CANNOT relax the run — it only
+    /// tightens — and it never re-binds the owner (the FIX-Q2 owner gate is orthogonal, enforced
+    /// at the seam before this is ever called).
+    #[allow(clippy::too_many_arguments)]
+    pub fn run_agent_loop_for_mission_with_overrides(
+        &self,
+        mission_lookup: MissionContextLookup,
+        session_id: &str,
+        run_id: &str,
+        task: &str,
+        policy_override: Option<&RunPolicy>,
+        max_turns_override: Option<u64>,
+        now_ms: i64,
+    ) -> Result<MissionBoundLoopOutcome, RoutedLoopError> {
         // PREFLIGHT (fail-closed): validate the Mission/work-item BEFORE any run exists. On
         // Blocked we return without ever calling `run_task`, so no `agent_run` row and no
         // model call happen for an invalid Mission — mirroring the ask path's preflight.
@@ -864,8 +900,16 @@ impl<T: Transport> HubRuntime<T> {
             }
         };
 
-        // Run the SAME composed loop as the unbound entry (no divergence).
-        let (selection, outcome) = self.run_task(run_id, task, now_ms)?;
+        // Run the SAME composed loop as the unbound entry (no divergence), threading the
+        // (effective) per-run policy + ceiling so a mission-bound run enforces the IDENTICAL
+        // tightening the unbound dispatch arm applies. Absent override ⇒ boot config unchanged.
+        let (selection, outcome) = self.run_task_with_overrides(
+            run_id,
+            task,
+            policy_override,
+            max_turns_override,
+            now_ms,
+        )?;
 
         // Bind the run to the Mission via the ask path's provider-timeline attachment.
         // Truth-honest: complete the WorkItem with the run as proof ONLY when the loop


### PR DESCRIPTION
NS-4 — a flag-gated seam that routes the live authed agent-run through `run_agent_loop_for_mission` (mission-birth + WorkItem bind) instead of the unbound `run_task`, behind **`FRIDAY_MISSION_BOUND_RUN`** (default-OFF). This is the seam mission-birth + passport-mint depend on to be live-reachable.

## What it does
- **`hub_server.rs` — `run_authed_agent_loop_mission_bound`**: the live-reachable counterpart of the unbound `run_authed_agent_loop_with_policy`. Returns `Option<AuthedAnswer>`:
  - `MissionBoundLoopOutcome::Ran` ⇒ `Some(owner-gated body)` (same `project_answer_for_authed` owner-wiring as the unbound path — both go through `run_with_request`).
  - `Blocked` ⇒ `None` ⇒ the caller falls through to the EXISTING unbound dispatch, **byte-identical** (the preflight fails closed BEFORE `upsert_route_decision`/`create_run`, so no stray rows).
  - `Err(_)` ⇒ `Some(NoAnswer)` (safe failure; MUST NOT fall through — the run row already exists, re-running would double-`create_run` / double-bill).
  - FIX-Q2 `caller == configured_principal` owner gate asserted at the seam BEFORE any dispatch.
- **`runtime.rs` — `run_agent_loop_for_mission_with_overrides`**: threads the per-run policy + max-turns override onto the bound loop so a peer-asserted tightening constraint (read-only / disabled-tools / max-turns) is enforced identically to the unbound arm. The existing 5-arg `run_agent_loop_for_mission` now delegates with `None`/`None` (byte-identical).
- **`bin/hub_agent_run_server.rs` — flag plumbing only**: read `FRIDAY_MISSION_BOUND_RUN` once at boot (default-off, pure `mission_bound_run_enabled_from` matcher), thread through `accept_one`/`serve_sealed_session`, consult the seam FIRST when the flag is ON, fall through to the unchanged `match session_id` otherwise.

## DARK
Flag off = byte-identical to today (the dispatch arm never enters the seam code). Live is gated on organic Mission **ingress** (the wire `AgentRunRequest` has no Mission handle yet — the lookup is provisionally derived from `session_id` via `by_surface_thread`, which fails closed to unbound) **+ the operator cutover plane**. Even with the flag flipped, a run binds only when a `MissionContextLookup` resolves to a live DeepSeek-lane Mission. The bound path is pinned to `WorkLane::DeepSeek` (the single live provider) — expected.

## NO-DEGRADE proof
- The **33 bin dispatch tests** stay green with the seam disabled (the actual flag-off routing path through `accept_one`/`serve_sealed_session`).
- A unit regression (`mission_bound_flag_off_is_byte_identical_unbound_run_no_binding`) pins that the unbound entry, with a resolvable Mission staged, produces ZERO binding and the identical body.
- Flag-ON test (`mission_bound_seam_on_binds_run_to_mission_and_delivers_body_to_owner`) proves REAL binding against a real DB: a MissionLink tied to THIS run, a `ReadyToDispatch -> CompletedWithProof` WorkItem transition (run as proof), and a `route_decision` row — not just that the branch was taken.

lib.rs untouched. `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test -p friday-hub` all green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)