### PR TITLE
test(c2-3): faithful control-op binding to a claude-pinned+metered run

### DIFF
--- a/rust-core/crates/friday-hub/src/runtime.rs
+++ b/rust-core/crates/friday-hub/src/runtime.rs
@@ -1788,6 +1788,231 @@ mod tests {
         assert_eq!(pending, 1, "one pending approval recorded for resume");
     }
 
+    // ---- C2-3: control-op binding to a claude-pinned+metered run (DARK, deterministic) -------
+    //
+    // A dedicated child module of `mod tests` so it inherits `super::*` (StubClaudeMeteredClient /
+    // tmp / TempDir / SECRET / DenyAllApprovals / the route-promotion helpers) while keeping the
+    // C2-3 binding tests cleanly grouped and `cargo test c2_control`-selectable.
+    mod c2_control {
+        use super::*;
+
+        // C2-3 closes the routed_claude_parity.rs "approve / reject / resume … WIRING NEEDED"
+        // DEFERRED note for the reject + cancel ops: it proves the EXISTING control substrate
+        // (`agent_run_control::{reject, cancel}`) acts on a genuinely CLAUDE-PINNED + METERED run
+        // (the one `claude_mutating_turn_bills_anthropic_row_then_pauses_for_approval` produces — a
+        // claude turn that bills EXACTLY ONE anthropic row, then Pauses on a pending approval) and
+        // that each control op records its OWN audit receipt while minting NO new model turn.
+        //
+        // THE ANTI-FAKE ("NO new anthropic row"). approve/reject/resume/cancel are Class-2 control
+        // mechanics layered on top of an ALREADY-metered claude turn — they are NEVER themselves
+        // metered. So after each control op these tests assert the run's token ledger is BYTE-FOR-BYTE
+        // (`RunTokenUsageRow` is `PartialEq`) the same single proposing-turn anthropic row it was
+        // BEFORE the op — not merely the same length — AND that the WHOLE ledger still has exactly one
+        // row (no hidden, non-run-scoped call). A control op that silently minted a model turn would
+        // add a row and fail here.
+        //
+        // SCOPE / honesty. reject (a) + cancel (c) are proven DETERMINISTICALLY here (no key, no
+        // network): they carry no operator signature, so they need only the run's bound OWNER. The
+        // RESUME leg (b) needs BOTH a test-minted operator Ed25519 approval (forbidden in `src/**` by
+        // the operator-signing-key self-mint source-scan — see `operator_vk.rs`) AND the crate-private
+        // `mark_route_*` claude route-promotion (no public no-key route-enable exists — the dark
+        // invariant), which cannot coexist in one file. Resume's faithful binding therefore lives as a
+        // LIVE `#[ignore]`'d test in `tests/routed_claude_parity.rs`
+        // (`resume_completes_claude_pinned_mutation_no_new_anthropic_row`), gated on the live model
+        // genuinely Pausing on a mutation. Resume's deterministic execute-and-receipt is already proven
+        // (just not on a metered run) by `tests/a1_run_control.rs::resume_executes_the_approved_mutation`.
+
+        /// Build a claude-wired runtime BOUND to `owner` (`principal_id: Some(owner)`) so the paused
+        /// run carries an owner principal — what the owner-authed control ops (`reject`/`cancel`)
+        /// require. Otherwise identical to [`runtime_with_claude_wired`] (DARK Claude client +
+        /// crate-private route promotion, no key/network). `operator_vk` stays `None` so a mutating
+        /// turn Pauses fail-closed (the metered claude turn + a pending approval — the substrate the
+        /// control op acts on).
+        fn runtime_with_owned_claude_wired(
+            tag: &str,
+            owner: &str,
+            steps: Vec<AgentStep>,
+        ) -> (HubRuntime<ScriptTransport>, TempDir) {
+            let ws = TempDir::new(tag);
+            let transport = ScriptTransport::new(&["{\"tool\":\"none\"}"]);
+            let client = DeepSeekClient::with_transport(transport, "k".into());
+            let agent = DeepSeekAgentLlmClient::new(client);
+            let mut rt = HubRuntime::new(
+                HubConfig {
+                    db_path: tmp(tag),
+                    workspace_root: ws.0.clone(),
+                    secret: SECRET.to_vec(),
+                    max_turns: 6,
+                    principal_id: Some(owner.to_string()),
+                    disabled_tools: vec![],
+                    read_only: false,
+                    operator_vk: None, // fail-closed Pause on a mutating action (no auto-approve)
+                },
+                agent,
+                Box::new(DenyAllApprovals),
+            )
+            .unwrap();
+            rt = rt.with_claude(Box::new(StubClaudeMeteredClient::new(steps, 11, 8)));
+            rt.mark_route_available("claude");
+            rt.mark_route_validated("claude");
+            (rt, ws)
+        }
+
+        /// Drive an OWNED, claude-pinned MUTATING turn to its Pause and assert the metered substrate the
+        /// control op acts on is genuinely there: routed to claude, status `Paused`, EXACTLY ONE
+        /// anthropic row, exactly one pending approval. Returns `(rt, ws, owner, nonce, ledger_before)`
+        /// — `ledger_before` is the proposing-turn row(s) the anti-fake compares against after the op.
+        fn paused_owned_claude_run(
+            tag: &str,
+            owner: &str,
+            run_id: &str,
+        ) -> (
+            HubRuntime<ScriptTransport>,
+            TempDir,
+            String,
+            Vec<friday_storage::RunTokenUsageRow>,
+        ) {
+            let (rt, ws) = runtime_with_owned_claude_wired(
+                tag,
+                owner,
+                vec![AgentStep::Tool(crate::RawToolCall {
+                    action: "write_file".to_string(),
+                    params: vec![
+                        ("path".to_string(), "out.txt".to_string()),
+                        ("content".to_string(), "C2".to_string()),
+                    ],
+                })],
+            );
+            let (selection, outcome) = rt
+                .run_task_pinned(run_id, "write a file", "claude", 2_000)
+                .expect("pinned claude runs through the runtime");
+            assert_eq!(selection.provider_id, "claude", "the pin routed to claude");
+            assert_eq!(
+                outcome.status,
+                LoopStatus::Paused,
+                "no operator key ⇒ the mutating action Pauses (RequiresApproval), never executes"
+            );
+
+            // The metered substrate: EXACTLY ONE anthropic row (the proposing claude turn was billed).
+            let ledger_before = rt.db().list_run_token_usage(run_id).unwrap();
+            assert_eq!(
+                ledger_before.len(),
+                1,
+                "the proposing claude turn was billed exactly one row"
+            );
+            assert_eq!(ledger_before[0].provider_kind, "anthropic");
+            assert_eq!(ledger_before[0].base_url_host, "api.anthropic.com");
+            assert_eq!(ledger_before[0].model, friday_anthropic::DEFAULT_MODEL);
+            assert!(!ledger_before[0].fallback);
+            // Whole-ledger agreement: no hidden, non-run-scoped row exists.
+            assert_eq!(rt.db().list_token_usage().unwrap().len(), 1);
+
+            // Exactly one pending approval (the nonce the control op targets / the run paused on).
+            let pending =
+                friday_storage::list_pending_requests_for_run(rt.db().conn(), run_id).unwrap();
+            assert_eq!(pending.len(), 1, "one pending approval recorded");
+            let nonce = pending[0].approval_id.clone();
+            assert_eq!(pending[0].status, "pending");
+
+            (rt, ws, nonce, ledger_before)
+        }
+
+        /// THE ANTI-FAKE assertion: after a Class-2 control op the run's token ledger is BYTE-FOR-BYTE
+        /// (`RunTokenUsageRow` is `PartialEq`) the `before` snapshot — the SAME single proposing-turn
+        /// anthropic row, NO new row — and the WHOLE ledger still has exactly that one row. A control
+        /// op that silently minted a model turn would add a row and fail here.
+        fn assert_no_new_anthropic_row(
+            rt: &HubRuntime<ScriptTransport>,
+            run_id: &str,
+            before: &[friday_storage::RunTokenUsageRow],
+        ) {
+            let after = rt.db().list_run_token_usage(run_id).unwrap();
+            assert_eq!(
+            after, before,
+            "NO new anthropic row: the control op is Class-2 (never a metered model turn) — the \
+             ledger must be byte-identical to the proposing-turn snapshot"
+        );
+            assert_eq!(
+                rt.db().list_token_usage().unwrap().len(),
+                1,
+                "the whole ledger still has exactly the one proposing-turn row (no hidden call)"
+            );
+        }
+
+        #[test]
+        fn reject_on_claude_pinned_paused_run_records_receipt_no_new_anthropic_row() {
+            // (a) REJECT a claude-pinned+metered paused run. The owner refuses the pending approval:
+            // status flips to 'rejected', a control receipt is written, and — the anti-fake — NO new
+            // anthropic row is billed (reject is Class-2 control mechanics, never a model turn).
+            const OWNER: &str = "owner:c2-3-reject";
+            const RUN: &str = "run-c2-3-reject";
+            let (rt, _ws, nonce, ledger_before) =
+                paused_owned_claude_run("c2-3-reject", OWNER, RUN);
+
+            let r = crate::agent_run_control::reject(rt.db().conn(), RUN, &nonce, OWNER, 3_000)
+                .unwrap();
+            assert!(r.accepted, "the owner's reject is accepted");
+            assert_eq!(r.status, "rejected", "the pending approval is now rejected");
+            assert!(r.audit_ref.is_some(), "an accepted reject writes a receipt");
+
+            // The pending row is genuinely 'rejected' (the substrate op ran, not a stub).
+            assert_eq!(
+                friday_storage::get_pending_request(rt.db().conn(), &nonce)
+                    .unwrap()
+                    .unwrap()
+                    .status,
+                "rejected"
+            );
+            // THE ANTI-FAKE: still EXACTLY the 1 proposing-turn anthropic row, byte-for-byte.
+            assert_no_new_anthropic_row(&rt, RUN, &ledger_before);
+        }
+
+        #[test]
+        fn cancel_on_claude_pinned_paused_run_records_receipt_no_new_anthropic_row() {
+            // (c) CANCEL a claude-pinned+metered paused run. The owner terminally stops the run:
+            // state='cancelled', a control receipt is written, and — the anti-fake — NO new anthropic
+            // row is billed (cancel is Class-2 control mechanics, never a model turn).
+            const OWNER: &str = "owner:c2-3-cancel";
+            const RUN: &str = "run-c2-3-cancel";
+            let (rt, _ws, _nonce, ledger_before) =
+                paused_owned_claude_run("c2-3-cancel", OWNER, RUN);
+
+            let r =
+                crate::agent_run_control::cancel(rt.db().conn(), RUN, OWNER, Some("done"), 3_000)
+                    .unwrap();
+            assert!(r.accepted, "the owner's cancel is accepted");
+            assert_eq!(r.status, "cancelled", "the run is terminally cancelled");
+            assert!(r.audit_ref.is_some(), "an accepted cancel writes a receipt");
+
+            // The run is genuinely cancelled (the substrate op ran, not a stub).
+            assert!(agent_run::is_cancelled(rt.db().conn(), RUN).unwrap());
+            // THE ANTI-FAKE: still EXACTLY the 1 proposing-turn anthropic row, byte-for-byte.
+            assert_no_new_anthropic_row(&rt, RUN, &ledger_before);
+        }
+
+        #[test]
+        fn reject_then_cancel_on_one_claude_pinned_run_never_bills_a_new_anthropic_row() {
+            // The two Class-2 ops applied to the SAME claude-pinned+metered run, in sequence: reject
+            // the pending approval, then cancel the run. After EACH op the ledger is re-asserted
+            // byte-for-byte — neither control op ever mints a model turn. This is the strongest single
+            // statement of the Class-2 invariant: a run accrues exactly the model rows its model turns
+            // produced, and control mechanics layered on top add NONE.
+            const OWNER: &str = "owner:c2-3-seq";
+            const RUN: &str = "run-c2-3-seq";
+            let (rt, _ws, nonce, ledger_before) = paused_owned_claude_run("c2-3-seq", OWNER, RUN);
+
+            let r = crate::agent_run_control::reject(rt.db().conn(), RUN, &nonce, OWNER, 3_000)
+                .unwrap();
+            assert!(r.accepted && r.status == "rejected");
+            assert_no_new_anthropic_row(&rt, RUN, &ledger_before);
+
+            let r =
+                crate::agent_run_control::cancel(rt.db().conn(), RUN, OWNER, None, 4_000).unwrap();
+            assert!(r.accepted && r.status == "cancelled");
+            assert_no_new_anthropic_row(&rt, RUN, &ledger_before);
+        }
+    } // mod c2_control
+
     #[test]
     fn claude_route_error_fails_run_closed_and_bills_nothing() {
         // ERROR HANDLING (§3): a claude turn whose model call FAILS (an OUTER AgentError — what

--- a/rust-core/crates/friday-hub/tests/routed_claude_parity.rs
+++ b/rust-core/crates/friday-hub/tests/routed_claude_parity.rs
@@ -85,17 +85,29 @@
 //                         IS the claude turn; the Pause is gate mechanics on top.
 //                         (Deterministically proven no-key in-crate; live here.)
 //
+// CONTROL-OP BINDING (C2-3) — Class-2 control mechanics on a claude-pinned+metered run (NO new
+// anthropic row; the control op is NEVER itself metered). These were the "approve / reject /
+// resume … WIRING NEEDED" DEFERRED entries; C2-3 binds the EXISTING control substrate
+// (`agent_run_control::{reject, cancel, resume}`) to a genuinely claude-pinned+metered run and
+// asserts the "NO new anthropic row" anti-fake after each op:
+//   - reject  -> DETERMINISTIC dark proof, runtime.rs `c2_control` module
+//                (`reject_on_claude_pinned_paused_run_records_receipt_no_new_anthropic_row`): the
+//                owner refuses the pending approval; status='rejected' + a control receipt; the
+//                ledger is byte-for-byte the proposing-turn snapshot (no new row).
+//   - cancel  -> DETERMINISTIC dark proof, runtime.rs `c2_control` module
+//                (`cancel_on_claude_pinned_paused_run_records_receipt_no_new_anthropic_row`):
+//                terminal cancel + receipt; ledger unchanged.
+//   - resume  -> the LIVE leg HERE (`resume_completes_claude_pinned_mutation_no_new_anthropic_row`):
+//                the operator signs an approval over the live paused action's digest; resume
+//                executes the ONE mutation + writes its resume receipt; the ledger is unchanged
+//                (the re-execution is NOT a routed Claude turn). LIVE because a deterministic
+//                resume needs BOTH a test-minted operator Ed25519 (forbidden in src by the
+//                self-mint scan) AND the crate-private route promotion — which cannot coexist in
+//                one file; the resume execute-and-receipt mechanics are also proven deterministically
+//                (off a metered run) by tests/a1_run_control.rs::resume_executes_the_approved_mutation.
+//
 // DEFERRED — session-control flows NOT expressible through the C2 route-pin/metering path
-// (~16 §3 entries; each needs a routed session-control surface the C2 atom does NOT build):
-//   - approve / reject -> the resume leg: an operator-signed approval re-executes the paused
-//                         mutation (s6d tests/s6d_resume_ingestion.rs /
-//                         tests/r4s2_approval_execute.rs substrate). The RE-EXECUTION is NOT
-//                         itself a routed Claude model turn, so it records no NEW anthropic
-//                         ledger row — it is approval/resume mechanics, not a metered Claude
-//                         flow. WIRING NEEDED: bind the resume entry to the run's pinned
-//                         provider + assert the resume's own audit receipt (no new model row).
-//   - resume           -> same s6d resume entry; same note. WIRING NEEDED: a provider-pinned
-//                         resume path + its receipt assertion.
+// (each needs a routed session-control surface the C2 atom does NOT build):
 //   - steer running turn -> mid-turn re-prompt; the loop is single-shot per run_task call with
 //                         no steer channel. WIRING NEEDED: a streaming/steer control method on
 //                         the routed session (a1_run_control.rs is the run-control substrate;
@@ -123,16 +135,22 @@
 //   - token ledger  -> the anthropic row itself — the core assertion of this harness.
 //
 // TALLY: 23 §3 flows = 4 chat-expressible (LIVE) + 1 session-control wired (approval-request)
-// + 2 cross-cutting (audit/ledger, side effects) + ~16 DEFERRED session-control.
-// session_control_wired = PARTIAL (only the approval-REQUEST half is routed+metered; the
-// approve/reject/resume completion half + all the list/open/read/steer/stop/fork/archive/
-// attach/diff/offline/activity surfaces are DEFERRED with the per-flow wiring notes above).
+// + 3 control-op binding (C2-3: reject/cancel deterministic in-crate, resume LIVE here)
+// + 2 cross-cutting (audit/ledger, side effects) + DEFERRED session-control (the
+// list/open/read/steer/stop/fork/archive/attach/diff/offline/activity surfaces). C2-3 closed the
+// approve/reject/resume completion half as Class-2 control-op binding with the "NO new anthropic
+// row" anti-fake (the control ops act on an already-metered claude turn, never themselves metered).
 
-use friday_crypto::{seal, DeviceKeypair};
+use friday_core::gate::{
+    canonical_approval_signature_bytes, ApprovalDecision, CanonicalApproval, CANONICAL_GATE_ISSUER,
+};
+use friday_crypto::{seal, DeviceKeypair, OperatorSigningKey, OperatorVerifyingKey};
+use friday_hub::agent_run_control::resume;
 use friday_hub::hub_server::AuthedPrincipal;
 use friday_hub::runtime::{HubConfig, HubRuntime, ENV_CLAUDE_ROUTE_ENABLED};
 use friday_hub::{CancelToken, LoopStatus, SteerHandle};
 use friday_providers::KeyValidationOutcome;
+use friday_storage::list_pending_requests_for_run;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicU64, Ordering};
 
@@ -609,5 +627,184 @@ fn steer_turn_folds_into_live_claude_loop_as_additional_metered_turn() {
     eprintln!(
         "LIVE OK: steer/inject → claude, status {:?}, {} billed anthropic turn(s) incl. the steered turn",
         outcome.status, outcome.turns
+    );
+}
+
+// ---- C2-3 resume (b): operator-signed resume of a claude-pinned mutation, LIVE ----------------
+//
+// The faithful RESUME binding (the "approve / resume" half of routed_claude_parity.rs's DEFERRED
+// "approve / reject / resume … WIRING NEEDED" note). It proves the EXISTING control substrate
+// (`agent_run_control::resume`, delegating verbatim to the S6 `resume_with_approval` spine) acts on
+// a genuinely CLAUDE-PINNED + METERED run and records its own resume audit_ref while minting NO new
+// model turn (Class-2: the re-execution of the approved mutation is NOT a routed Claude turn — it
+// bills NO new anthropic row).
+//
+// Why this is LIVE and `#[ignore]`'d, not deterministic (HONEST): a deterministic claude-pinned run
+// needs the crate-private `mark_route_*` route promotion (no public no-key route-enable exists —
+// the dark/default-off invariant), while minting a test operator Ed25519 approval needs
+// `OperatorSigningKey`, which `friday-hub/src/**` is FORBIDDEN to name (the self-mint source-scan in
+// `operator_vk.rs`). Those two cannot coexist in one file. So the deterministic dark proof covers
+// reject + cancel (runtime.rs `c2_control` module); resume's faithful binding is proven here, in
+// `tests/` (scan-exempt — the TEST holds the signing key exactly as the offline operator does),
+// against the LIVE routed claude run. The resume EXECUTE-and-receipt mechanics are ALSO proven
+// deterministically (just not on a metered run) by `tests/a1_run_control.rs::
+// resume_executes_the_approved_mutation`.
+//
+// Model-dependence: whether the live model proposes a mutation on a given prompt is model-dependent
+// (same caveat as `approval_request_claude_turn_bills_anthropic_then_pauses`). If it answers in chat
+// instead of pausing, the resume leg is skipped with a clear log — never a fake pass.
+
+fn operator_keypair() -> (OperatorSigningKey, OperatorVerifyingKey) {
+    let sk = OperatorSigningKey::generate();
+    let vk = sk.verifying_key();
+    (sk, vk)
+}
+
+/// A LIVE, claude-enabled runtime built with the operator's VERIFY key provisioned (so a presented
+/// signed approval can be verified at resume) — otherwise identical to [`live_claude_runtime`]. The
+/// run still PAUSES on a mutating action (the verify key is not an approval; the gate withholds
+/// until a signature is presented), persisting the pending approval the operator signs offline.
+fn live_claude_runtime_with_vk(
+    tag: &str,
+    vk: OperatorVerifyingKey,
+) -> (HubRuntime<friday_deepseek::UreqTransport>, TempWs) {
+    assert_eq!(
+        std::env::var(ENV_CLAUDE_ROUTE_ENABLED).ok().as_deref(),
+        Some("1"),
+        "set {ENV_CLAUDE_ROUTE_ENABLED}=1 to run the live routed-claude parity"
+    );
+    let ws = TempWs::new(tag);
+    let config = HubConfig {
+        db_path: ws.db_path(),
+        workspace_root: ws.0.clone(),
+        secret: b"routed-claude-parity-harness-secret-2".to_vec(),
+        max_turns: 6,
+        principal_id: None,
+        disabled_tools: vec![],
+        read_only: false,
+        operator_vk: Some(vk), // resume verifies a presented signature against THIS key
+    };
+    let mut rt = HubRuntime::live(config)
+        .expect("HubRuntime::live must assemble with the gate on + both provider keys present");
+    let outcome = rt.validate_and_enable_claude();
+    assert_eq!(
+        outcome,
+        KeyValidationOutcome::Valid,
+        "the live Anthropic key probe must be Valid to enable the claude route (got {outcome:?})"
+    );
+    (rt, ws)
+}
+
+#[test]
+#[ignore = "live: needs FRIDAY_CLAUDE_ROUTE_ENABLED=1 + both provider keys; spends Anthropic quota; model must propose a mutation; run with --ignored"]
+fn resume_completes_claude_pinned_mutation_no_new_anthropic_row() {
+    // The offline operator's keypair (the TEST holds the signing key; the Hub holds only the vk).
+    let (sk, vk) = operator_keypair();
+    let (rt, ws) = live_claude_runtime_with_vk("resume-complete", vk);
+    let run_id = "live-claude-resume";
+
+    // (1) A claude-pinned MUTATING turn: billed an anthropic row, then Paused on a pending approval.
+    let (selection, outcome) = rt
+        .run_task_pinned(
+            run_id,
+            "Create a file named out.txt containing the text RESUMED using the write_file tool.",
+            "claude",
+            2_000,
+        )
+        .expect("a live pinned-claude run that may propose a mutation completes its turn");
+    assert_eq!(selection.provider_id, "claude", "the pin routed to claude");
+    // The proposing turn(s) are billed regardless of the gate outcome.
+    assert_anthropic_rows(&rt, run_id, outcome.status, outcome.turns);
+
+    if outcome.status != LoopStatus::Paused {
+        eprintln!(
+            "LIVE SKIP(resume): claude turn billed (status {:?}); the model answered in chat \
+             rather than proposing a mutation — the resume leg needs a mutating proposal",
+            outcome.status
+        );
+        return;
+    }
+
+    // (2) Snapshot the metered ledger BEFORE resume — the anti-fake compares against this.
+    let ledger_before = rt.db().list_run_token_usage(run_id).unwrap();
+    assert!(
+        !ledger_before.is_empty(),
+        "the proposing claude turn was billed at least one anthropic row"
+    );
+
+    // (3) The offline operator signs an approval over the EXACT paused action's digest (read from
+    //     the persisted pending row — the same digest the loop authorized). The TEST mints the
+    //     Ed25519 signature; the Hub only ever verifies it.
+    let pending = list_pending_requests_for_run(rt.db().conn(), run_id).unwrap();
+    assert_eq!(pending.len(), 1, "one pending approval to resume");
+    let nonce = pending[0].approval_id.clone();
+    let action_digest = pending[0].action_digest.clone();
+    let mut approval = CanonicalApproval {
+        decision: ApprovalDecision::Approved,
+        approval_id: nonce.clone(),
+        action_digest,
+        expires_at: Some(5_000_000_000_000),
+        issuer: Some(CANONICAL_GATE_ISSUER.to_string()),
+        signature: None,
+    };
+    approval.signature = Some(
+        sk.sign(&canonical_approval_signature_bytes(&approval))
+            .to_hex(),
+    );
+    let signed_blob = serde_json::json!({
+        "decision": "approved",
+        "approval_id": approval.approval_id,
+        "action_digest": approval.action_digest,
+        "expires_at": approval.expires_at.unwrap(),
+        "issuer": approval.issuer,
+        "signature": approval.signature,
+    })
+    .to_string()
+    .into_bytes();
+
+    // (4) Resume through the EXISTING control substrate: verify → consume nonce → execute the ONE
+    //     approved mutation → write a resume audit receipt. NO new model turn. The verify key is the
+    //     one the RUNTIME was provisioned with (`rt.operator_vk()`), mirroring the wire path where
+    //     the server verifies against the Hub-held key — not a fresh key derived in the test.
+    let exec = friday_hub::FsToolExecutor::new(&ws.0);
+    let operator_vk = rt
+        .operator_vk()
+        .expect("the runtime was provisioned with the operator verify key");
+    let out = resume(
+        rt.db().conn(),
+        &exec,
+        operator_vk,
+        run_id,
+        &signed_blob,
+        3_000,
+    )
+    .unwrap();
+    assert!(
+        out.accepted,
+        "the operator-signed resume executed the mutation"
+    );
+    assert_eq!(out.status, "mutation_completed");
+    assert!(
+        out.audit_ref.is_some(),
+        "the resume wrote its own audit receipt"
+    );
+    assert_eq!(
+        std::fs::read_to_string(ws.0.join("out.txt")).unwrap(),
+        "RESUMED",
+        "the approved mutation actually executed"
+    );
+
+    // (5) THE ANTI-FAKE: the re-execution is Class-2 control mechanics, NOT a model turn — the
+    //     ledger is byte-for-byte the proposing-turn snapshot (NO new anthropic row).
+    let ledger_after = rt.db().list_run_token_usage(run_id).unwrap();
+    assert_eq!(
+        ledger_after, ledger_before,
+        "NO new anthropic row: resume re-executes the approved mutation, it is not a metered \
+         claude turn — the ledger must be byte-identical to the proposing-turn snapshot"
+    );
+    eprintln!(
+        "LIVE OK: resume → claude-pinned mutation completed via operator signature, resume \
+         receipt written, NO new anthropic row ({} billed turn(s) unchanged)",
+        ledger_after.len()
     );
 }


### PR DESCRIPTION
## C2-3 — faithful binding of approve/reject/resume/cancel to a claude-pinned metered run

A FAITHFUL test PR binding the EXISTING control substrate
(`agent_run_control::{reject, cancel, resume}` → `resume.rs`'s S6 spine) to a
genuinely **claude-PINNED + METERED** run, proving each control op records its
audit receipt **without minting a new model turn**. Class-2: control mechanics on
top of an already-metered claude turn, **never themselves metered**. DARK; not v1 GO.

**Reuses the existing substrate verbatim** — no new mutation path, no change to any
control op's behavior, **lib.rs untouched**. This is a test-only PR (+ a child
`c2_control` test module of `runtime.rs`'s `mod tests`; no new runtime accessor
was needed — `rt.db().conn()` and the pub-in-crate control ops suffice).

### The anti-fake — "NO new anthropic row" (asserted after EACH control op)
The run is first driven to the claude-pinned mutating Pause (reusing the
`claude_mutating_turn_bills_anthropic_row_then_pauses_for_approval` harness): one
anthropic row billed, status `Paused`, one pending approval. After each control op
the run's token ledger is asserted **byte-for-byte equal** (`RunTokenUsageRow` is
`PartialEq`) to that single proposing-turn anthropic row — not merely the same
length — **and** the whole ledger still has exactly one row (no hidden,
non-run-scoped call). A control op that silently minted a model turn would add a
row and fail. This is the anti-fake: approve/reject/resume/cancel are control
mechanics on top of an already-metered claude turn, never themselves metered.

### The three control-op assertions
- **(a) reject** — DETERMINISTIC dark proof (`runtime.rs` `c2_control`,
  `reject_on_claude_pinned_paused_run_records_receipt_no_new_anthropic_row`): owner
  refuses → pending status `'rejected'` + a control receipt (`audit_ref.is_some()`)
  → **NO new anthropic row** (ledger byte-identical).
- **(c) cancel** — DETERMINISTIC dark proof (`runtime.rs` `c2_control`,
  `cancel_on_claude_pinned_paused_run_records_receipt_no_new_anthropic_row`): owner
  cancels → terminal `cancelled` + a control receipt → **NO new anthropic row**.
  (Plus `reject_then_cancel_…` applies both to one run, re-asserting the anti-fake
  after each.)
- **(b) resume** — LIVE `#[ignore]`'d (`tests/routed_claude_parity.rs`,
  `resume_completes_claude_pinned_mutation_no_new_anthropic_row`): the test-minted
  operator Ed25519 approval over the live paused action's digest → `resume` executes
  the ONE mutation + writes a resume `audit_ref` → **NO new anthropic row** (the
  re-execution is not a routed Claude turn).

### Honesty — why resume (b) is LIVE, not deterministic
A deterministic resume-on-a-claude-metered-run cannot be built: it needs BOTH a
test-minted operator Ed25519 approval (forbidden in `src/**` by the operator-signing
-key self-mint source-scan in `operator_vk.rs`) AND the crate-private `mark_route_*`
claude route-promotion (no public no-key route-enable exists — the dark/default-off
invariant). These cannot coexist in one file. So reject + cancel are the deterministic
dark proof in-crate; resume's faithful binding is the LIVE leg (the test holds the
signing key exactly as the offline operator does), gated on the live model genuinely
Pausing on a mutation. Resume's execute-and-receipt mechanics are ALSO proven
deterministically (off a metered run) by
`tests/a1_run_control.rs::resume_executes_the_approved_mutation`.

### Local gates (rust-core.yml order, all green)
- `cargo fmt --all -- --check` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test -p friday-hub` — 597 lib + all integration tests pass; 0 failures
  (incl. the `hub_crate_never_references_a_signing_key` source-scan guard); the live
  resume test is correctly `#[ignore]`'d.

🤖 Generated with [Claude Code](https://claude.com/claude-code)