### PR TITLE
feat(c2-5): owner-gated file-view bound to a claude run's read_file receipt

### DIFF
--- a/rust-core/crates/friday-hub/src/run_readback_projection.rs
+++ b/rust-core/crates/friday-hub/src/run_readback_projection.rs
@@ -186,6 +186,76 @@ pub fn project_session_link_state(
     Ok(Some(snapshot))
 }
 
+/// (C2-5) OWNER-GATED refs-only FILE-VIEW of the workspace files a run actually READ — the
+/// file refs of the run's `read_file` tool receipts, keyed to `run_id`. `Ok(None)` ⇒ the caller
+/// is NOT the run's bound owner (or the run has no stored result / no real owner) — fail-closed,
+/// no existence/state oracle for a non-owner (the SAME owner axis as the C2-4 read API and the
+/// in-file [`project_session_link_state`]). `Ok(Some(snapshot))` ⇒ the owner's file-view.
+///
+/// ## Anchored to the REAL read_file receipt of a metered turn (NOT a mirror)
+/// `read_file` is a read-type tool the gate Allows directly inside the run loop, so a claude turn
+/// that proposes it bills a REAL `anthropic` token-ledger row AND records a
+/// `tool.executed:read {n} bytes from {path}` event in the SAME transaction as the hash-chained
+/// `tool.executed:read_file` audit receipt. [`friday_storage::agent_run_read::list_read_file_refs`]
+/// reads THOSE run-keyed receipt events, so the file-view is the co-committed witness of the
+/// genuine metered turn's receipt — never a synthesized / mirror file event.
+///
+/// ## Owner gate — reuses the C2-4 / D1-Q1 axis, body-free
+/// The gate is [`friday_storage::get_run_answer_for_principal`] (the proven fail-closed
+/// `Granted` / `Denied` / `NotFound` ownership match on the run's bound `owner_principal` — the
+/// SAME principal `run_session_loop` records). On a `Granted` the answer BODY is discarded (bound
+/// to `_`); this projection NEVER carries the answer — only the file refs + run id. Every denying
+/// outcome collapses to `Ok(None)` so a non-owner learns nothing (no body, no owner id, no
+/// existence oracle). HONEST scope: the file-view is a readback of a COMPLETED run (the owner axis
+/// is only recorded once the run persists its `run_result`, on `Finished`).
+///
+/// ## Class-2 read: no model call, no new ledger row, no mutation
+/// Pure reads + JSON shaping over already-persisted events — it never touches a provider
+/// credential, the model path, or any write. The shared [`reject_forbidden_output`] guard runs
+/// INSIDE this fn so the file refs (relative workspace paths) inherit the refs-only discipline
+/// (an absolute-path / secret marker would fail it closed).
+pub fn project_run_file_view(
+    db: &Db,
+    caller_principal: &str,
+    run_id: &str,
+) -> Result<Option<Value>, String> {
+    let conn = db.conn();
+
+    // OWNER GATE (fail-closed): reuse the D1-Q1 / C2-4 ownership match. Any non-Granted outcome
+    // (NotFound / NoOwnerPrincipal / AnonymousCaller / PrincipalMismatch) collapses to `Ok(None)`
+    // — a non-owner gets no body, no owner id, and no existence/state oracle for the file-view.
+    // The answer body in `Granted` is DISCARDED here (`_`); this projection never carries it.
+    match friday_storage::get_run_answer_for_principal(conn, run_id, caller_principal)
+        .map_err(|_| "read_failed".to_string())?
+    {
+        friday_storage::RunAnswerAccess::Granted(_) => {}
+        friday_storage::RunAnswerAccess::Denied(_) | friday_storage::RunAnswerAccess::NotFound => {
+            return Ok(None)
+        }
+    }
+
+    // The owner is entitled: read the run's `read_file` receipt refs (run-keyed; the co-committed
+    // witness of the real metered turn's receipt). This is a pure read — no new ledger row.
+    let file_refs = friday_storage::agent_run_read::list_read_file_refs(conn, run_id)
+        .map_err(|_| "read_failed".to_string())?;
+
+    let snapshot = json!({
+        "truth_label": "rust_wired_dev",
+        "proof_only": true,
+        "ok": true,
+        "run_id": run_id,
+        // The relative workspace paths the run's `read_file` receipts recorded, in receipt order.
+        "file_refs": file_refs,
+        "file_view_count": file_refs.len(),
+    });
+
+    // Inherit the refs-only guard: a relative path passes; an absolute-path / secret marker that
+    // somehow reached a receipt summary fails the projection closed (never leaks).
+    let rendered = serde_json::to_string(&snapshot).map_err(|_| "serialize_failed".to_string())?;
+    reject_forbidden_output(&rendered)?;
+    Ok(Some(snapshot))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/rust-core/crates/friday-hub/src/runtime.rs
+++ b/rust-core/crates/friday-hub/src/runtime.rs
@@ -1085,6 +1085,22 @@ impl<T: Transport> HubRuntime<T> {
         )
     }
 
+    /// (C2-5) OWNER-GATED refs-only FILE-VIEW for one run: the workspace file refs the run's
+    /// `read_file` tool receipts recorded, keyed to `run_id`. `Some(snapshot)` ONLY when `caller`
+    /// is the run's bound OWNER, else `None` (fail-closed — a non-owner cannot read another's
+    /// file-view by guessing the run_id; the SAME owner axis as [`Self::open_session_for_owner`]
+    /// and the D1-Q1 answer-body projection). The file refs are anchored to the REAL
+    /// `read_file` receipt of a metered turn (a claude turn proposing `read_file` bills an
+    /// `anthropic` row AND co-commits the receipt event) — never a synthesized/mirror file event.
+    /// Class-2 read: no model call, no ledger row, no write. ADDITIVE, read-only accessor.
+    pub fn file_view_for_owner(
+        &self,
+        caller: &AuthedPrincipal,
+        run_id: &str,
+    ) -> Result<Option<serde_json::Value>, String> {
+        crate::run_readback_projection::project_run_file_view(&self.db, caller.principal(), run_id)
+    }
+
     /// (A1 run-controls) The composed `FsToolExecutor` (workspace-root-contained, gate-mandatory).
     /// Exposed so the sealed-WS server's RESUME control handler can delegate to the S6
     /// [`crate::resume::resume_with_approval`] spine (which executes the ONE approved mutation
@@ -2010,6 +2026,126 @@ mod tests {
                 crate::agent_run_control::cancel(rt.db().conn(), RUN, OWNER, None, 4_000).unwrap();
             assert!(r.accepted && r.status == "cancelled");
             assert_no_new_anthropic_row(&rt, RUN, &ledger_before);
+        }
+
+        // ---- C2-5: owner-gated file-view bound to a claude run's read_file receipt ------------
+        #[test]
+        fn c2_5_file_view_bound_to_a_claude_read_file_receipt_owner_gated() {
+            // C2-5 FAITHFUL DARK PROOF. A claude-pinned SESSIONED run whose stub script proposes
+            // `read_file` (a read-type tool the gate Allows directly inside the loop) → finish.
+            //   - the read_file turn bills a REAL anthropic row (provider_kind=anthropic,
+            //     api.anthropic.com, fallback=false) AND co-commits a `tool.executed:read_file`
+            //     audit receipt + its run-keyed `tool.executed:read N bytes from <ref>` event;
+            //   - the owner's file-view returns that file ref KEYED to the run;
+            //   - reading the view writes NO new ledger row (it reads existing receipts);
+            //   - a DIFFERENT principal's view is fail-closed `None` (owner-gated).
+            // The file-view is anchored to the REAL receipt of the metered turn, NOT a mirror.
+            // NO key, NO network — the claude stub bills the anthropic rows.
+            const OWNER: &str = "principal:c2-5-owner";
+            const RUN: &str = "run-c2-5";
+            const SESS: &str = "sess-c2-5";
+
+            // Build with HubConfig.principal_id = OWNER so the run's `run_result.owner_principal`
+            // (set from `policy.principal_id()`) equals OWNER — the file-view's owner axis. The
+            // authed caller below uses the SAME principal, so every owner axis agrees.
+            let (rt, ws) = runtime_with_owned_claude_wired(
+                "c2-5-file-view",
+                OWNER,
+                vec![
+                    AgentStep::Tool(crate::RawToolCall {
+                        action: "read_file".to_string(),
+                        params: vec![("path".to_string(), "notes.md".to_string())],
+                    }),
+                    AgentStep::Finish {
+                        message: "PONG".to_string(),
+                    },
+                ],
+            );
+            // Seed the workspace file so the gate-Allowed read_file EXECUTES (a missing path would
+            // record `tool.exec_error`, not a receipt — see the storage parse contract).
+            std::fs::write(ws.0.join("notes.md"), b"composed e2e note").unwrap();
+
+            let owner = authed_caller(OWNER);
+            let other = authed_caller("principal:c2-5-intruder");
+
+            let (selection, _answer) = rt
+                .run_session_task_pinned(&owner, RUN, SESS, "read the notes", "claude", 5_000)
+                .expect("the claude-pinned sessioned read_file run executes");
+            assert_eq!(selection.provider_id, "claude", "the pin routed to claude");
+
+            // --- the read_file turn billed a REAL anthropic row -------------------------------
+            // `[read_file, Finish]` is TWO metered claude turns (the read_file proposal bills +
+            // executes, then Finish bills) ⇒ exactly two anthropic rows.
+            let rows = rt.db().list_run_token_usage(RUN).unwrap();
+            assert_eq!(
+                rows.len(),
+                2,
+                "two metered claude turns: read_file then finish"
+            );
+            for row in &rows {
+                assert_eq!(row.provider_kind, "anthropic", "NOT mis-attributed");
+                assert_eq!(row.base_url_host, "api.anthropic.com");
+                assert_eq!(row.model, friday_anthropic::DEFAULT_MODEL);
+                assert!(!row.fallback, "the claude route is never a fallback");
+            }
+            // The no-new-ledger BASELINE is the two rows the metered turns billed.
+            let ledger_baseline = rt.db().list_token_usage().unwrap().len();
+            assert_eq!(ledger_baseline, 2);
+
+            // --- the run recorded a REAL read_file receipt (the anchor, not a mirror) ----------
+            // The Allowed+executed read_file co-commits a hash-chained audit receipt
+            // (action='tool.executed:read_file') in the SAME tx as its run-keyed event. Assert the
+            // receipt exists and the chain verifies — proving it's the genuine metered turn's
+            // receipt the file-view anchors to.
+            let receipt_rows: i64 = rt
+                .db()
+                .conn()
+                .query_row(
+                    "SELECT count(*) FROM audit_ledger WHERE action = 'tool.executed:read_file'",
+                    [],
+                    |r| r.get(0),
+                )
+                .unwrap();
+            assert_eq!(
+                receipt_rows, 1,
+                "exactly one read_file receipt was recorded"
+            );
+            assert!(
+                friday_storage::audit::verify_audit_chain(rt.db().conn()).is_ok(),
+                "the read_file receipt is on a verified hash chain"
+            );
+
+            // --- the OWNER's file-view returns that file ref, keyed to the run -----------------
+            let view = rt
+                .file_view_for_owner(&owner, RUN)
+                .unwrap()
+                .expect("the owner reads her own file-view");
+            assert_eq!(view["run_id"], RUN, "the view is keyed to the run");
+            assert_eq!(
+                view["file_refs"],
+                serde_json::json!(["notes.md"]),
+                "the file-view surfaces the read_file receipt's file ref"
+            );
+            assert_eq!(view["file_view_count"], 1);
+            // Refs-only: the view never carries the run task body or the answer.
+            let rendered = serde_json::to_string(&view).unwrap();
+            assert!(!rendered.contains("read the notes"), "no run task body");
+            assert!(!rendered.contains("PONG"), "no answer body");
+
+            // --- a DIFFERENT principal's view is fail-closed None (owner-gated) ----------------
+            assert_eq!(
+                rt.file_view_for_owner(&other, RUN).unwrap(),
+                None,
+                "a non-owner cannot read another's file-view (fail-closed, no oracle)"
+            );
+
+            // --- THE ANTI-FAKE: reading the file-view wrote NO new ledger row ------------------
+            // (twice — once per principal — it is a pure read over existing receipts).
+            assert_eq!(
+                rt.db().list_token_usage().unwrap().len(),
+                ledger_baseline,
+                "the file-view is a Class-2 read: no new ledger row from the view"
+            );
         }
     } // mod c2_control
 

--- a/rust-core/crates/friday-storage/src/agent_run_read.rs
+++ b/rust-core/crates/friday-storage/src/agent_run_read.rs
@@ -78,6 +78,51 @@ pub fn list_event_kinds(conn: &Connection, run_id: &str) -> Result<Vec<String>> 
     Ok(out)
 }
 
+/// (C2-5) The ordered (by `seq` ascending) list of the FILE REFS a run's `read_file`
+/// executions actually read, parsed out of the run's `tool.executed:read … bytes from <ref>`
+/// event kinds.
+///
+/// ## Anchored to the REAL receipt, never a mirror
+/// A `read_file` is a read-type tool the gate Allows directly inside the run loop, so an
+/// Allowed+executed `read_file` records ONE `tool.executed:read {n} bytes from {path}` event
+/// (`crate::agent_run::record_event`) in the SAME transaction as the hash-chained
+/// `tool.executed:read_file` audit receipt. This fn reads THOSE run-keyed events — it is the
+/// co-committed witness of the genuine receipt, not a synthesized/mirror file event. A
+/// `read_file` that FAILED records `tool.exec_error:*` (not `tool.executed:`) and so is correctly
+/// absent here (no receipt ⇒ no file ref).
+///
+/// ## Parsing
+/// The receipt summary is `read {n} bytes from {path}`, so the file ref is the substring AFTER
+/// the FIRST ` bytes from ` separator (split on that exact marker, not a bare ` from `, so a path
+/// that itself contains ` from ` survives intact). Only `read_file`'s `read …` summary matches;
+/// other read-type executions (`listed …`, `stat …`, `search matched …`) do NOT, so they never
+/// leak in.
+///
+/// ## Refs-only
+/// The returned strings are the RELATIVE workspace paths the model proposed (the loop's executor
+/// never embeds an absolute path in the summary). The caller is still expected to run them through
+/// an output guard before emitting them off-process — same discipline as [`list_event_kinds`].
+pub fn list_read_file_refs(conn: &Connection, run_id: &str) -> Result<Vec<String>> {
+    const READ_PREFIX: &str = "tool.executed:read ";
+    const FROM_SEP: &str = " bytes from ";
+    let mut out = Vec::new();
+    for kind in list_event_kinds(conn, run_id)? {
+        // Only `read_file`'s `read {n} bytes from {path}` receipt summary qualifies. A
+        // `tool.executed:` event whose summary is NOT a `read …` line (a write/list/stat/etc.)
+        // is skipped; an exec_error event never carries the `tool.executed:` prefix at all.
+        if let Some(tail) = kind.strip_prefix(READ_PREFIX) {
+            // `tail` = `{n} bytes from {path}`. Split on the FIRST ` bytes from ` only, so a
+            // path containing the separator text survives in the ref.
+            if let Some((_count, path)) = tail.split_once(FROM_SEP) {
+                if !path.is_empty() {
+                    out.push(path.to_string());
+                }
+            }
+        }
+    }
+    Ok(out)
+}
+
 /// DB-wide token totals over `token_ledger` (see [`DbWideTokenTotals`] for the
 /// honest-scope caveat). `COALESCE(..., 0)` so an empty ledger reads `0`, not NULL.
 pub fn db_wide_token_totals(conn: &Connection) -> Result<DbWideTokenTotals> {
@@ -194,6 +239,81 @@ mod tests {
         let db = Db::open_hub(&tmp("noevents")).unwrap();
         create_run(db.conn(), "run-3", "task", 1).unwrap();
         assert!(list_event_kinds(db.conn(), "run-3").unwrap().is_empty());
+    }
+
+    #[test]
+    fn list_read_file_refs_parses_only_read_file_receipts_run_scoped() {
+        let db = Db::open_hub(&tmp("readrefs")).unwrap();
+        create_run(db.conn(), "run-rf", "task", 1).unwrap();
+        // A read_file receipt (qualifies) + a path that itself contains " from " (must survive).
+        record_event(
+            db.conn(),
+            "run-rf:e0",
+            "run-rf",
+            "tool.executed:read 15 bytes from notes.md",
+            2,
+        )
+        .unwrap();
+        record_event(
+            db.conn(),
+            "run-rf:e1",
+            "run-rf",
+            "tool.executed:read 7 bytes from a from b.md",
+            3,
+        )
+        .unwrap();
+        // Non-read tool.executed events must NOT be parsed as file refs.
+        record_event(
+            db.conn(),
+            "run-rf:e2",
+            "run-rf",
+            "tool.executed:wrote 4 bytes to out.txt",
+            4,
+        )
+        .unwrap();
+        record_event(
+            db.conn(),
+            "run-rf:e3",
+            "run-rf",
+            "tool.executed:listed 3 entries in .",
+            5,
+        )
+        .unwrap();
+        // A FAILED read records exec_error (no `tool.executed:` prefix) ⇒ no ref.
+        record_event(
+            db.conn(),
+            "run-rf:e4",
+            "run-rf",
+            "tool.exec_error:not found: missing.md",
+            6,
+        )
+        .unwrap();
+        // A different run's read_file must never leak into this run's refs (run-scoped).
+        create_run(db.conn(), "run-other", "task", 1).unwrap();
+        record_event(
+            db.conn(),
+            "run-other:e0",
+            "run-other",
+            "tool.executed:read 9 bytes from other.md",
+            7,
+        )
+        .unwrap();
+
+        let refs = list_read_file_refs(db.conn(), "run-rf").unwrap();
+        assert_eq!(
+            refs,
+            vec!["notes.md".to_string(), "a from b.md".to_string()],
+            "only read_file receipts of THIS run, parsed on the FIRST ` bytes from ` separator"
+        );
+    }
+
+    #[test]
+    fn list_read_file_refs_is_empty_for_run_with_no_reads() {
+        let db = Db::open_hub(&tmp("noreadrefs")).unwrap();
+        create_run(db.conn(), "run-nr", "task", 1).unwrap();
+        record_event(db.conn(), "run-nr:e0", "run-nr", "plan.none", 2).unwrap();
+        record_event(db.conn(), "run-nr:e1", "run-nr", "agent.finished", 3).unwrap();
+        assert!(list_read_file_refs(db.conn(), "run-nr").unwrap().is_empty());
     }
 
     #[test]


### PR DESCRIPTION
C2-5 owner-gated file-view bound to a claude run's read_file receipt; Class-2 read (no model call, no new ledger row); anchored to the real metered turn.

## What
An owner-gated, refs-only FILE-VIEW projection that surfaces the workspace file refs a run actually READ — the file refs of the run's `read_file` tool receipts, keyed to `run_id`. DARK (the deterministic in-crate test is the proof; no key, no network).

## Anchored to a REAL receipt, never a mirror
`read_file` is a read-type tool the gate Allows directly inside the run loop, so a claude turn proposing it bills a REAL `anthropic` token-ledger row AND co-commits — in ONE transaction — the hash-chained `tool.executed:read_file` audit receipt + its run-keyed `tool.executed:read N bytes from <ref>` event. The file-view reads THOSE run-keyed receipt events: the co-committed witness of the genuine metered turn's receipt, NOT a synthesized / `provider_session_link` mirror file event. A `read_file` that FAILED records `tool.exec_error:*` (no receipt) and is correctly absent.

## Surfaces (all additive, read-only)
- **Storage** (`friday-storage/agent_run_read.rs`): `list_read_file_refs(conn, run_id)` — parses the file ref out of the run's `tool.executed:read … bytes from <ref>` events, run-scoped, ordered by `seq`; splits on the FIRST ` bytes from ` so a path containing that text survives; non-read `tool.executed` events (write/list/stat) never match.
- **Projection** (`friday-hub/run_readback_projection.rs`): `project_run_file_view(db, caller_principal, run_id)` — owner-gates via the proven D1-Q1 / C2-4 axis (`get_run_answer_for_principal`; the answer BODY is discarded — the view never carries it). Any non-Granted outcome collapses to `Ok(None)` (fail-closed, no existence/state oracle for a non-owner). The refs-only guard runs inside.
- **Runtime accessor** (`friday-hub/runtime.rs`): `file_view_for_owner(caller, run_id)` — scopes on the authenticated `caller.principal()`.

## NO-DEGRADE
Class-2 read: no model call, no new ledger row, no run-path change, no write, no schema/migration. `friday-hub/lib.rs` is UNTOUCHED (diff stat = 0 for lib.rs).

## Honest scope
The file-view is a readback of a **COMPLETED (Finished) run** — `run_result.owner_principal` (the only clean per-run owner axis; `agent_session.user_id` was deliberately ruled out as it has no run→session path for non-sessioned runs) is recorded only on `Finished`. A run that reads then Pauses persists no `run_result`, so the owner reads `None`. Inherent to the owner axis, documented in the doc comment.

## Faithful proof (DARK, `runtime.rs` `c2_control::c2_5_file_view_bound_to_a_claude_read_file_receipt_owner_gated`)
A claude-pinned SESSIONED run (`run_session_task_pinned`) built with `HubConfig.principal_id = OWNER` and an authed caller of the SAME principal, stub scripts `[read_file, Finish]`:
- the read_file turn bills a REAL anthropic row (`provider_kind=anthropic`, `api.anthropic.com`, `fallback=false`) — two metered turns => two rows;
- a `tool.executed:read_file` receipt exists in `audit_ledger` and `verify_audit_chain` passes (the real-receipt anchor);
- the OWNER's file-view returns `file_refs == ["notes.md"]` keyed to the run (and never the task body / answer);
- a DIFFERENT principal's view is fail-closed `None` (owner-gated, PrincipalMismatch);
- reading the view writes NO new ledger row (count stays at the 2 the metered turns billed).

Plus storage unit tests for `list_read_file_refs` (parse-only-read_file + run-scoped + ` from ` in path survives; empty for no-reads).

## Local gate (rust-core.yml order)
- `cargo fmt --all` then `--check`: clean
- `cargo clippy --workspace --all-targets -- -D warnings`: clean
- `cargo test -p friday-hub`: 603 unit + all integration green (new C2-5 test passes)
- `cargo test -p friday-storage`: 110 + 2 new green

🤖 Generated with [Claude Code](https://claude.com/claude-code)