### PR TITLE
feat(c2-6): explicit owner-authed session archive op + audit receipt

### DIFF
--- a/rust-core/crates/friday-hub/src/runtime.rs
+++ b/rust-core/crates/friday-hub/src/runtime.rs
@@ -1062,6 +1062,34 @@ impl<T: Transport> HubRuntime<T> {
         friday_storage::open_session_for_owner(self.db.conn(), caller.principal(), agent_session_id)
     }
 
+    /// (C2-6) EXPLICIT owner-authed ARCHIVE of one routed session: set `status='archived'` +
+    /// `archived_at` and write a hash-chained audit receipt, scoped to the AUTHENTICATED `caller`
+    /// (the SAME `agent_session.user_id` axis as [`Self::open_session_for_owner`], NEVER a
+    /// client-asserted id). Only the bound owner can archive — a non-owner / owner-less session /
+    /// absent id is REFUSED fail-closed ([`friday_storage::ArchiveOutcome`] `accepted=false`,
+    /// `status="not_owner"`) with NO state change and NO audit row. Idempotent: re-archiving an
+    /// already-archived session is an accepted no-op.
+    ///
+    /// This is the EXPLICIT counterpart to the time-based `session_lifecycle` sweep (which archives
+    /// only after the idle timeout) — it never invokes the sweep, and writes only the lifecycle
+    /// columns the sweep also uses, so an explicitly-archived session reads back identically to a
+    /// swept one. Metadata-only: NO model call and NO `token_ledger` row (archiving is not a metered
+    /// turn). After a successful archive the session no longer appears in
+    /// [`Self::list_sessions_for_owner`] (the active/owner list is archive-aware). ADDITIVE accessor.
+    pub fn archive_session_for_owner(
+        &self,
+        caller: &AuthedPrincipal,
+        agent_session_id: &str,
+        now_ms: i64,
+    ) -> Result<friday_storage::ArchiveOutcome, StorageError> {
+        friday_storage::archive_session_for_owner(
+            self.db.conn(),
+            caller.principal(),
+            agent_session_id,
+            now_ms,
+        )
+    }
+
     /// (C2-8) OWNER-GATED refs-only LINK-STATE projection for one routed session: the
     /// connectivity/staleness label (`fresh`/`stale`/`offline`) DERIVED from the session's
     /// last-activity timestamp (`agent_session.updated_at`, which the metered turn's folded
@@ -2994,6 +3022,213 @@ mod tests {
             rt.db().list_token_usage().unwrap().len(),
             ledger_baseline,
             "link-state reads are pure compute — no new ledger row across fresh/stale/offline"
+        );
+    }
+
+    #[test]
+    fn c2_6_owner_authed_archive_op_distinct_from_the_sweep() {
+        // C2-6 FAITHFUL DARK PROOF: drive ONE claude-pinned SESSIONED turn through the REAL
+        // `run_session_task_pinned` entry (billing one anthropic row — ASSERTED, so the archived
+        // session is the REAL routed session that carries metered claude rows, never a mirror).
+        // Then EXPLICITLY archive that session as the BOUND owner and prove:
+        //   - status transitions to 'archived' (+ archived_at set), distinct from the time-based
+        //     `session_lifecycle` sweep (which only archives after the 7d idle timeout);
+        //   - the session no longer appears in the C2-4 active/owner list (it was there before);
+        //   - an audit receipt is written and the hash chain verifies (action='session.archived');
+        //   - `list_run_token_usage` is UNCHANGED — archive is metadata, not a model turn;
+        //   - a DIFFERENT principal CANNOT archive it (owner mismatch → fail-closed refusal): no
+        //     state change, the session STILL listed, and NO new audit row.
+        // NO key, NO network — the claude stub bills the anthropic row.
+        let (rt, _ws) = runtime_with_claude_wired(
+            "c2-6-archive-op",
+            vec![AgentStep::Finish {
+                message: "PONG".to_string(),
+            }],
+            Box::new(DenyAllApprovals),
+        );
+        let owner = authed_caller("principal:c2-6-owner");
+        let other = authed_caller("principal:c2-6-intruder");
+
+        // --- one claude-pinned sessioned turn → a REAL routed session with a metered anthropic row ---
+        let run_id = "run-c2-6";
+        let sess = "sess-c2-6";
+        let (sel, _a) = rt
+            .run_session_task_pinned(&owner, run_id, sess, "first turn", "claude", 5_000)
+            .expect("the claude-pinned sessioned turn runs");
+        assert_eq!(sel.provider_id, "claude", "the pin routed to claude");
+
+        // ASSERT the REAL anthropic ledger row (the archived session carries metered claude billing).
+        let ledger_before = rt.db().list_run_token_usage(run_id).unwrap();
+        assert_eq!(
+            ledger_before.len(),
+            1,
+            "one anthropic row for the single claude turn"
+        );
+        assert_eq!(ledger_before[0].provider_kind, "anthropic");
+        assert_eq!(ledger_before[0].base_url_host, "api.anthropic.com");
+        assert!(
+            !ledger_before[0].fallback,
+            "the claude route is never a fallback"
+        );
+        let ledger_baseline = rt.db().list_token_usage().unwrap().len();
+        assert_eq!(
+            ledger_baseline, 1,
+            "one claude turn billed one anthropic row"
+        );
+
+        // No archive receipt exists yet (it is written only by the archive op).
+        let archive_receipts = |rt: &HubRuntime<ScriptTransport>| -> i64 {
+            rt.db()
+                .conn()
+                .query_row(
+                    "SELECT count(*) FROM audit_ledger WHERE action = 'session.archived'",
+                    [],
+                    |r| r.get(0),
+                )
+                .unwrap()
+        };
+        assert_eq!(archive_receipts(&rt), 0, "no archive receipt before the op");
+
+        // --- BEFORE archive: the session IS in the owner's active list, status is 'active' --------
+        assert_eq!(
+            rt.list_sessions_for_owner(&owner)
+                .unwrap()
+                .iter()
+                .map(|s| s.agent_session_id.as_str())
+                .collect::<Vec<_>>(),
+            vec![sess],
+            "the active session is listed before archiving"
+        );
+        let status_of = |rt: &HubRuntime<ScriptTransport>| -> String {
+            rt.db()
+                .conn()
+                .query_row(
+                    "SELECT status FROM agent_session WHERE agent_session_id = ?1",
+                    [sess],
+                    |r| r.get::<_, String>(0),
+                )
+                .unwrap()
+        };
+        assert_eq!(status_of(&rt), "active", "freshly-routed session is active");
+
+        // --- OWNER-MISMATCH first: a DIFFERENT principal cannot archive (fail-closed refusal) -----
+        let refused = rt
+            .archive_session_for_owner(&other, sess, 6_000)
+            .expect("the archive call itself does not error");
+        assert!(!refused.accepted, "a non-owner archive is refused");
+        assert_eq!(refused.status, "not_owner");
+        assert_eq!(
+            refused.audit_ref, None,
+            "a refused archive writes no receipt"
+        );
+        // The refusal changed NOTHING: still active, still listed, no audit row written.
+        assert_eq!(
+            status_of(&rt),
+            "active",
+            "owner mismatch left the status unchanged"
+        );
+        assert_eq!(
+            rt.list_sessions_for_owner(&owner).unwrap().len(),
+            1,
+            "owner mismatch left the session in the active list"
+        );
+        assert_eq!(
+            archive_receipts(&rt),
+            0,
+            "a refused (non-owner) archive writes NO audit row (the real fail-closed proof)"
+        );
+
+        // --- the BOUND OWNER archives the session -------------------------------------------------
+        let archive_at = 7_000;
+        let outcome = rt
+            .archive_session_for_owner(&owner, sess, archive_at)
+            .expect("the owner's archive runs");
+        assert!(outcome.accepted, "the bound owner's archive is accepted");
+        assert_eq!(outcome.status, "archived");
+        assert!(
+            outcome.audit_ref.is_some(),
+            "an accepted archive writes a receipt"
+        );
+
+        // status → 'archived' (+ archived_at = now); status_changed_at + updated_at bumped to now.
+        let (status, archived_at_col, status_changed_at, updated_at): (
+            String,
+            Option<i64>,
+            Option<i64>,
+            i64,
+        ) = rt
+            .db()
+            .conn()
+            .query_row(
+                "SELECT status, archived_at, status_changed_at, updated_at
+                 FROM agent_session WHERE agent_session_id = ?1",
+                [sess],
+                |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?, r.get(3)?)),
+            )
+            .unwrap();
+        assert_eq!(status, "archived", "status transitions to archived");
+        assert_eq!(
+            archived_at_col,
+            Some(archive_at),
+            "archived_at is stamped at now"
+        );
+        assert_eq!(status_changed_at, Some(archive_at));
+        assert_eq!(updated_at, archive_at);
+
+        // --- the session no longer appears in the C2-4 active/owner list --------------------------
+        assert!(
+            rt.list_sessions_for_owner(&owner).unwrap().is_empty(),
+            "an archived session is hidden from the active/owner list"
+        );
+
+        // --- an audit receipt was written and the hash chain verifies -----------------------------
+        assert_eq!(
+            archive_receipts(&rt),
+            1,
+            "exactly one session.archived receipt was recorded"
+        );
+        assert!(
+            friday_storage::audit::verify_audit_chain(rt.db().conn()).is_ok(),
+            "the archive receipt is on a verified hash chain"
+        );
+
+        // --- THE ANTI-FAKE: archive billed NO new ledger row (metadata, not a model turn) ---------
+        assert_eq!(
+            rt.db().list_run_token_usage(run_id).unwrap(),
+            ledger_before,
+            "archive is metadata: the run's token ledger is byte-identical (no new anthropic row)"
+        );
+        assert_eq!(
+            rt.db().list_token_usage().unwrap().len(),
+            ledger_baseline,
+            "archive wrote no new token_ledger row (no model call)"
+        );
+
+        // --- idempotent: re-archiving the owner's already-archived session is an accepted no-op ----
+        let again = rt
+            .archive_session_for_owner(&owner, sess, 8_000)
+            .expect("re-archive runs");
+        assert!(again.accepted, "re-archive is an accepted no-op");
+        assert_eq!(again.status, "already_archived");
+        assert_eq!(again.audit_ref, None, "re-archive writes no new receipt");
+        assert_eq!(
+            archive_receipts(&rt),
+            1,
+            "re-archive did not stack a second receipt"
+        );
+        // updated_at was NOT bumped by the no-op re-archive (it stays at the real archive time).
+        let updated_after_rearchive: i64 = rt
+            .db()
+            .conn()
+            .query_row(
+                "SELECT updated_at FROM agent_session WHERE agent_session_id = ?1",
+                [sess],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(
+            updated_after_rearchive, archive_at,
+            "the idempotent re-archive does not bump updated_at"
         );
     }
 

--- a/rust-core/crates/friday-storage/src/agent_session.rs
+++ b/rust-core/crates/friday-storage/src/agent_session.rs
@@ -23,6 +23,7 @@
 //! Truth label: minimal sessions/resume storage substrate + API + tests only.
 //! PROOF-ONLY; NOT a v1 GO.
 
+use crate::audit;
 use crate::error::{Result, StorageError};
 use rusqlite::{params, Connection, OptionalExtension};
 
@@ -392,10 +393,18 @@ pub struct SessionListItem {
 /// blank query never collapses to "all sessions"). A principal that owns no session gets an
 /// empty Vec (the load-bearing owner-scoping assertion: a DIFFERENT principal sees NOTHING).
 ///
+/// ## C2-6: archive-aware (the active/owner list hides archived + pruned sessions)
+/// The list excludes sessions whose `status` is `'archived'` or `'pruned'` (`status NOT IN ...`),
+/// so an explicitly-archived session ([`archive_session_for_owner`]) — or one the time-based
+/// `session_lifecycle` sweep advanced to `archived`/`pruned` — no longer appears in the owner's
+/// active list. `'active'` and `'idle'` sessions stay visible (an idle session is still a live,
+/// resumable conversation). The `status` column defaults to `'active'` (migration v28), so a
+/// never-swept session is included exactly as before. Pure read: no write, no schema change.
+///
 /// Ordering is `updated_at DESC, agent_session_id` — most-recent-first (the same convention
 /// as [`crate::provider_session::list_projections`]) with `agent_session_id` as a
 /// deterministic tiebreaker so two sessions touched at the same `updated_at` have a stable
-/// order. Pure read: no write, no schema change.
+/// order.
 pub fn list_sessions_for_owner(conn: &Connection, user_id: &str) -> Result<Vec<SessionListItem>> {
     // A blank owner must never match a NULL `user_id` row nor act as a wildcard — return
     // nothing without even querying (the `= ?1` bind already excludes NULL, but this makes
@@ -407,6 +416,7 @@ pub fn list_sessions_for_owner(conn: &Connection, user_id: &str) -> Result<Vec<S
         "SELECT agent_session_id, created_at, updated_at
          FROM agent_session
          WHERE user_id = ?1
+           AND status NOT IN ('archived', 'pruned')
          ORDER BY updated_at DESC, agent_session_id",
     )?;
     let rows = stmt.query_map([user_id], |r| {
@@ -476,6 +486,128 @@ fn owner_matches(conn: &Connection, user_id: &str, agent_session_id: &str) -> Re
         Some(owner) => Ok(owner.user_id.as_deref() == Some(user_id)),
         None => Ok(false),
     }
+}
+
+// --- C2-6 explicit owner-authed archive op (distinct from the time-based sweep) ---
+//
+// An EXPLICIT, owner-authed ARCHIVE of one FRIDAY routed `agent_session`: the owner says "archive
+// this session NOW" (e.g. a "close conversation" action), as opposed to the time-based
+// `session_lifecycle::sweep_lifecycle` reaper, which advances a session to `archived` only after
+// the 7-day idle timeout. The two are DISTINCT and complementary: this op never runs the sweep and
+// the sweep never runs this op — both simply write the SAME `agent_session` lifecycle columns
+// (`status='archived'` + `archived_at` + `status_changed_at` + `updated_at`), so a session archived
+// either way is read back identically (and continues down the sweep's archived→pruned path off its
+// `archived_at`).
+//
+// Owner-gated EXACTLY like the C2-4 read API: it reuses [`owner_matches`] (the `agent_session.user_id`
+// axis bound to the authenticated caller by `run_session_task_pinned`), so a DIFFERENT principal —
+// or a blank owner, an owner-less (NULL `user_id`) session, or an absent id — is REFUSED fail-closed
+// with NO state change and NO audit row. Only the bound owner can archive.
+//
+// The status transition + the hash-chained audit receipt are written in ONE `unchecked_transaction`
+// (atomic: a crash can never leave an archived session with no receipt, nor a receipt with no
+// transition). Metadata-only — NO model call, NO `token_ledger` row (archiving is not a turn).
+
+/// The body-free outcome of an [`archive_session_for_owner`] attempt. `accepted=false` is the
+/// fail-closed owner-mismatch refusal (no state change, no receipt). Never a body.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ArchiveOutcome {
+    /// Whether the archive was accepted (`true`) or refused fail-closed (`false`).
+    pub accepted: bool,
+    /// Coarse, body-free outcome label (closed-vocab): `"archived"` (the transition was written),
+    /// `"already_archived"` (idempotent accepted no-op), or `"not_owner"` (fail-closed refusal —
+    /// a non-owner, an owner-less session, a blank owner, or an absent id).
+    pub status: String,
+    /// Soft link to the hash-chained audit receipt, when one was written (only on a NEW archive
+    /// transition — an idempotent re-archive of an already-archived session writes none).
+    pub audit_ref: Option<String>,
+}
+
+impl ArchiveOutcome {
+    fn refused() -> Self {
+        ArchiveOutcome {
+            accepted: false,
+            status: "not_owner".to_string(),
+            audit_ref: None,
+        }
+    }
+}
+
+/// Explicitly ARCHIVE a routed session as its BOUND owner: set `status='archived'` + `archived_at`
+/// (plus `status_changed_at` + `updated_at`) and write a hash-chained audit receipt, in ONE
+/// transaction.
+///
+/// Owner-gated fail-closed via [`owner_matches`] (the SAME `agent_session.user_id` axis as the C2-4
+/// read API): a non-owner, an owner-less session, a blank `user_id`, or an absent `agent_session_id`
+/// all return [`ArchiveOutcome::refused`] (`accepted=false`, `status="not_owner"`) with NO state
+/// change and NO audit row — a guessed session id cannot archive another principal's session.
+///
+/// Idempotent: if the owner's session is ALREADY `'archived'`, this is an accepted no-op
+/// (`status="already_archived"`, no new receipt, no timestamp bump). An already-`'pruned'` session
+/// is treated the same (it is already past archive). Otherwise the transition fires and the receipt
+/// is written.
+///
+/// Metadata-only: NO model call and NO `token_ledger` row (archiving is not a metered turn). DISTINCT
+/// from [`crate::session_lifecycle::sweep_lifecycle`] — this never invokes the sweep and writes only
+/// the lifecycle columns the sweep also uses, so the two compose without either touching the other.
+pub fn archive_session_for_owner(
+    conn: &Connection,
+    user_id: &str,
+    agent_session_id: &str,
+    now_ms: i64,
+) -> Result<ArchiveOutcome> {
+    // (1) Owner gate FIRST (fail-closed): a non-owner / owner-less / absent / blank-owner attempt is
+    //     refused with no state read leaked and no write.
+    if !owner_matches(conn, user_id, agent_session_id)? {
+        return Ok(ArchiveOutcome::refused());
+    }
+
+    // (2) The owner matched, so the row exists — read its current status to make re-archive an
+    //     idempotent accepted no-op (and avoid stacking receipts on repeated archives).
+    let current_status: String = conn.query_row(
+        "SELECT status FROM agent_session WHERE agent_session_id = ?1",
+        [agent_session_id],
+        |r| r.get(0),
+    )?;
+    if current_status == "archived" || current_status == "pruned" {
+        return Ok(ArchiveOutcome {
+            accepted: true,
+            status: "already_archived".to_string(),
+            audit_ref: None,
+        });
+    }
+
+    // (3) Write the transition + the receipt in ONE transaction (atomic). The columns are EXACTLY
+    //     the ones the sweep's idle→archived step writes (status / archived_at / status_changed_at /
+    //     updated_at) — so an explicitly-archived session is read back identically to a swept one.
+    //     A CSPRNG tag keys the audit id so repeated archives of distinct sessions (or a re-archive
+    //     after a future un-archive) never PK-collide on the audit_id primary key.
+    let tag = friday_crypto::generate_approval_nonce();
+    let receipt_id = format!("{agent_session_id}:archive:{tag}:receipt");
+    let tx = conn.unchecked_transaction()?;
+    tx.execute(
+        "UPDATE agent_session
+            SET status = 'archived', archived_at = ?2, status_changed_at = ?2, updated_at = ?2
+          WHERE agent_session_id = ?1",
+        params![agent_session_id, now_ms],
+    )?;
+    // The actor is the owner principal that authorized the archive (WHO archived — more faithful
+    // for an owner-authed op than a fixed component name); the payload_ref soft-links the session.
+    audit::append_audit(
+        &tx,
+        &receipt_id,
+        user_id,
+        "session.archived",
+        Some(agent_session_id),
+        now_ms,
+    )?;
+    tx.commit()?;
+
+    Ok(ArchiveOutcome {
+        accepted: true,
+        status: "archived".to_string(),
+        audit_ref: Some(receipt_id),
+    })
 }
 
 // --- C2-8 offline/stale link-state (derived from last-activity vs now) --------
@@ -1205,6 +1337,220 @@ mod tests {
         assert_eq!(
             open_session_for_owner(db.conn(), "alice", "orphan").unwrap(),
             None
+        );
+    }
+
+    // --- C2-6 explicit owner-authed archive op -------------------------------
+
+    fn status_col(db: &Db, id: &str) -> String {
+        db.conn()
+            .query_row(
+                "SELECT status FROM agent_session WHERE agent_session_id = ?1",
+                [id],
+                |r| r.get::<_, String>(0),
+            )
+            .unwrap()
+    }
+
+    fn archive_receipt_count(db: &Db) -> i64 {
+        db.conn()
+            .query_row(
+                "SELECT count(*) FROM audit_ledger WHERE action = 'session.archived'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap()
+    }
+
+    #[test]
+    fn archive_session_for_owner_transitions_status_and_writes_receipt_and_hides_from_list() {
+        // SQL-level proof of the archive op (the friday-hub faithful proof — REAL routed session +
+        // metered anthropic row — lives in runtime.rs's in-crate tests). The BOUND owner archives
+        // her session: status → 'archived' (+ archived_at), an audit receipt is written, the chain
+        // verifies, and the session disappears from the C2-4 active list while a sibling active
+        // session stays listed.
+        let db = Db::open_hub(&tmp("c2-6-archive")).unwrap();
+        let alice = SessionOwner {
+            user_id: Some("alice".into()),
+            ..Default::default()
+        };
+        ensure_session_with_owner(db.conn(), "s1", &alice, 1_000).unwrap();
+        ensure_session_with_owner(db.conn(), "s2", &alice, 2_000).unwrap();
+        // Both start active and listed (most-recent-first).
+        assert_eq!(status_col(&db, "s1"), "active");
+        assert_eq!(
+            list_sessions_for_owner(db.conn(), "alice")
+                .unwrap()
+                .iter()
+                .map(|s| s.agent_session_id.clone())
+                .collect::<Vec<_>>(),
+            vec!["s2", "s1"]
+        );
+
+        // The owner archives s1.
+        let out = archive_session_for_owner(db.conn(), "alice", "s1", 3_000).unwrap();
+        assert!(out.accepted);
+        assert_eq!(out.status, "archived");
+        assert!(out.audit_ref.is_some());
+
+        // status → archived + archived_at = now; status_changed_at + updated_at bumped.
+        let (status, archived_at, sca, upd): (String, Option<i64>, Option<i64>, i64) = db
+            .conn()
+            .query_row(
+                "SELECT status, archived_at, status_changed_at, updated_at
+                 FROM agent_session WHERE agent_session_id = 's1'",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?, r.get(3)?)),
+            )
+            .unwrap();
+        assert_eq!(status, "archived");
+        assert_eq!(archived_at, Some(3_000));
+        assert_eq!(sca, Some(3_000));
+        assert_eq!(upd, 3_000);
+
+        // s1 is hidden from the active list; s2 (still active) remains.
+        assert_eq!(
+            list_sessions_for_owner(db.conn(), "alice")
+                .unwrap()
+                .iter()
+                .map(|s| s.agent_session_id.clone())
+                .collect::<Vec<_>>(),
+            vec!["s2"],
+            "the archived session is hidden; the active sibling remains listed"
+        );
+
+        // The receipt is written and the hash chain verifies.
+        assert_eq!(archive_receipt_count(&db), 1);
+        assert!(crate::audit::verify_audit_chain(db.conn()).is_ok());
+    }
+
+    #[test]
+    fn archive_owner_mismatch_is_fail_closed_no_state_change_no_receipt() {
+        // The load-bearing security assertion: a DIFFERENT principal (and a blank owner, an
+        // owner-less session, an absent id) CANNOT archive — refused fail-closed with NO state
+        // change and NO audit row. Only the bound owner can archive.
+        let db = Db::open_hub(&tmp("c2-6-mismatch")).unwrap();
+        ensure_session_with_owner(
+            db.conn(),
+            "s1",
+            &SessionOwner {
+                user_id: Some("alice".into()),
+                ..Default::default()
+            },
+            1_000,
+        )
+        .unwrap();
+
+        // A different principal's archive is refused, with no change and no receipt.
+        let bob = archive_session_for_owner(db.conn(), "bob", "s1", 2_000).unwrap();
+        assert_eq!(
+            bob,
+            ArchiveOutcome {
+                accepted: false,
+                status: "not_owner".into(),
+                audit_ref: None,
+            }
+        );
+        assert_eq!(
+            status_col(&db, "s1"),
+            "active",
+            "no state change on mismatch"
+        );
+        assert_eq!(
+            archive_receipt_count(&db),
+            0,
+            "no receipt on a refused archive"
+        );
+        // Still in alice's active list (untouched).
+        assert_eq!(
+            list_sessions_for_owner(db.conn(), "alice").unwrap().len(),
+            1
+        );
+
+        // A blank owner, an absent id, and an owner-less session are all refused too.
+        assert!(
+            !archive_session_for_owner(db.conn(), "", "s1", 2_000)
+                .unwrap()
+                .accepted
+        );
+        assert!(
+            !archive_session_for_owner(db.conn(), "alice", "ghost", 2_000)
+                .unwrap()
+                .accepted
+        );
+        ensure_session(db.conn(), "orphan", 1_500).unwrap();
+        assert!(
+            !archive_session_for_owner(db.conn(), "alice", "orphan", 2_000)
+                .unwrap()
+                .accepted
+        );
+        // None of those wrote a receipt or changed s1.
+        assert_eq!(archive_receipt_count(&db), 0);
+        assert_eq!(status_col(&db, "s1"), "active");
+    }
+
+    #[test]
+    fn re_archive_is_an_idempotent_accepted_noop() {
+        // Re-archiving an already-archived session is an accepted no-op: no new receipt, no
+        // timestamp bump. (A 'pruned' session — already past archive — is treated the same.)
+        let db = Db::open_hub(&tmp("c2-6-idem")).unwrap();
+        ensure_session_with_owner(
+            db.conn(),
+            "s1",
+            &SessionOwner {
+                user_id: Some("alice".into()),
+                ..Default::default()
+            },
+            1_000,
+        )
+        .unwrap();
+        let first = archive_session_for_owner(db.conn(), "alice", "s1", 3_000).unwrap();
+        assert_eq!(first.status, "archived");
+        assert_eq!(archive_receipt_count(&db), 1);
+
+        let again = archive_session_for_owner(db.conn(), "alice", "s1", 4_000).unwrap();
+        assert!(again.accepted);
+        assert_eq!(again.status, "already_archived");
+        assert_eq!(again.audit_ref, None);
+        assert_eq!(archive_receipt_count(&db), 1, "no second receipt");
+        // updated_at NOT bumped by the no-op.
+        let upd: i64 = db
+            .conn()
+            .query_row(
+                "SELECT updated_at FROM agent_session WHERE agent_session_id = 's1'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(
+            upd, 3_000,
+            "the idempotent re-archive does not bump updated_at"
+        );
+
+        // A 'pruned' session is likewise an accepted no-op (already past archive).
+        ensure_session_with_owner(
+            db.conn(),
+            "s2",
+            &SessionOwner {
+                user_id: Some("alice".into()),
+                ..Default::default()
+            },
+            1_000,
+        )
+        .unwrap();
+        db.conn()
+            .execute(
+                "UPDATE agent_session SET status = 'pruned' WHERE agent_session_id = 's2'",
+                [],
+            )
+            .unwrap();
+        let pruned = archive_session_for_owner(db.conn(), "alice", "s2", 5_000).unwrap();
+        assert!(pruned.accepted);
+        assert_eq!(pruned.status, "already_archived");
+        assert_eq!(
+            archive_receipt_count(&db),
+            1,
+            "pruned no-op writes no receipt"
         );
     }
 

--- a/rust-core/crates/friday-storage/src/lib.rs
+++ b/rust-core/crates/friday-storage/src/lib.rs
@@ -40,10 +40,10 @@ pub mod workflow_def;
 pub mod workflow_read;
 
 pub use agent_session::{
-    append_session_message, ensure_session, ensure_session_with_owner, list_sessions_for_owner,
-    load_session_messages, load_session_owner, open_session_for_owner, session_exists,
-    session_message_count, session_message_count_for_owner, SessionListItem, SessionMessage,
-    SessionOwner, StoredSessionMessage,
+    append_session_message, archive_session_for_owner, ensure_session, ensure_session_with_owner,
+    list_sessions_for_owner, load_session_messages, load_session_owner, open_session_for_owner,
+    session_exists, session_message_count, session_message_count_for_owner, ArchiveOutcome,
+    SessionListItem, SessionMessage, SessionOwner, StoredSessionMessage,
 };
 pub use authorize::authorize_mutating_action;
 pub use authorize_ed25519::{authorize_mutating_action_ed25519, Ed25519VerifyOnlyPolicy};


### PR DESCRIPTION
## C2-6 — explicit owner-authed session ARCHIVE op (DARK)

Adds an EXPLICIT, owner-authed ARCHIVE op for a FRIDAY routed `agent_session` — `status='archived'` + `archived_at` plus its hash-chained audit receipt — **distinct from the time-based `session_lifecycle` sweep**. Builds on C2-4 (owner-scoped session reads). DARK: deterministic tests are the proof; not a hot `lib.rs` path; no model call.

### What it does
- **`friday_storage::archive_session_for_owner`** (agent_session.rs): owner-gated via the **C2-4 owner axis** (`owner_matches` on `agent_session.user_id`, bound to the authenticated caller by `run_session_task_pinned`). Only the bound owner can archive; a non-owner / owner-less / blank-owner / absent-id attempt is **REFUSED fail-closed** (`accepted=false`, `status="not_owner"`) with NO state change and NO audit row. The status transition + the `session.archived` receipt are written in ONE `unchecked_transaction` (atomic). **Idempotent**: re-archiving an already-`archived`/`pruned` session is an accepted no-op (no new receipt, no timestamp bump). **Metadata-only** — no model call, no `token_ledger` row.
- **Thin runtime accessor** `HubRuntime::archive_session_for_owner` scoping on `caller.principal()` (mirrors `open_session_for_owner`).
- **C2-4 list is now archive-aware** — `list_sessions_for_owner` gains `AND status NOT IN ('archived','pruned')`, so an archived session no longer appears in the owner's active list (`active`+`idle` stay visible). The task didn't ask for this in words, but the "no longer appears in the list" assertion against the *actual* C2-4 function forces it; calling it out for honesty. Blast radius is contained: the only callers of `list_sessions_for_owner` are the storage def, this accessor, and tests (C2-4 is dark — no production consumer).

### Distinct from the sweep (NO-DEGRADE)
`session_lifecycle.rs` is **byte-untouched** (`git diff --quiet rust-core/crates/friday-storage/src/session_lifecycle.rs` ⇒ UNTOUCHED). This op never invokes the sweep and writes only the SAME lifecycle columns the sweep's idle→archived step uses (`status`/`archived_at`/`status_changed_at`/`updated_at`), so an explicitly-archived session reads back identically to a swept one and continues down the sweep's archived→pruned path.

### Faithful DARK proof (runtime.rs in-crate, real DB, no key/network)
A claude-pinned SESSIONED run through the REAL `run_session_task_pinned` entry bills a **REAL anthropic ledger row (asserted)** — so the archived session is the real routed session that carries metered claude rows, never a mirror. Then the BOUND owner archives that session and the test asserts: status → `archived` (+`archived_at`/`status_changed_at`/`updated_at` stamped), the session is **gone from the C2-4 active list** (it was there before), a `session.archived` audit receipt exists and **`verify_audit_chain` is Ok**, and `list_run_token_usage` is **byte-unchanged** (archive is metadata, not a model turn). Owner **MISMATCH** → fail-closed refusal: no state change, session STILL listed, NO new audit row. Idempotent re-archive proven. Plus SQL-level storage tests (transition+list-hide+chain, owner-mismatch fail-closed, idempotent no-op).

### Note for reviewers
The audit `actor` is the **owner principal** that authorized the archive (records WHO archived — faithful for an owner-authed op), with the session id in `payload_ref`. This diverges intentionally from C2-3's `write_control_receipt`, which uses a fixed `"agent-run-control"` actor. A principal id is an identity, not a secret.

### Local results (strict rust-core.yml order)
- `cargo fmt --all` + `--check`: clean
- `cargo clippy --workspace --all-targets -- -D warnings`: clean
- `cargo test -p friday-storage -p friday-hub`: all pass (4 new tests; existing C2-4/sweep tests green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)