### PR TITLE
feat(c2-7): minimal owner-authed session FORK op (forked_from + copy-history + audit receipt)

### DIFF
--- a/rust-core/crates/friday-hub/src/runtime.rs
+++ b/rust-core/crates/friday-hub/src/runtime.rs
@@ -1090,6 +1090,33 @@ impl<T: Transport> HubRuntime<T> {
         )
     }
 
+    /// (C2-7) EXPLICIT owner-authed FORK of one routed session: create a NEW owned session
+    /// (fresh id, `forked_from` = the parent id, bound to the AUTHENTICATED `caller` — the SAME
+    /// `agent_session.user_id` axis as [`Self::open_session_for_owner`], NEVER a client-asserted
+    /// id) seeded with a COPY of the parent's messages, and write a hash-chained audit receipt.
+    /// Only the bound owner can fork — a non-owner / owner-less parent / absent parent id is
+    /// REFUSED fail-closed ([`friday_storage::ForkOutcome`] `accepted=false`, `status="not_owner"`)
+    /// with NO child created, NO message copied, and NO audit row.
+    ///
+    /// Metadata-only: the fork makes NO model call and writes NO `token_ledger` row (forking is
+    /// not a metered turn). A LATER turn on the forked session (via [`Self::run_session_task_pinned`])
+    /// routes + bills its OWN row exactly like any routed session, so the fork is a REAL branch of a
+    /// metered session — never a synthesized/mirror clone of a `provider_session_link` claude_control
+    /// link. ADDITIVE accessor.
+    pub fn fork_session_for_owner(
+        &self,
+        caller: &AuthedPrincipal,
+        parent_session_id: &str,
+        now_ms: i64,
+    ) -> Result<friday_storage::ForkOutcome, StorageError> {
+        friday_storage::fork_session_for_owner(
+            self.db.conn(),
+            caller.principal(),
+            parent_session_id,
+            now_ms,
+        )
+    }
+
     /// (C2-8) OWNER-GATED refs-only LINK-STATE projection for one routed session: the
     /// connectivity/staleness label (`fresh`/`stale`/`offline`) DERIVED from the session's
     /// last-activity timestamp (`agent_session.updated_at`, which the metered turn's folded
@@ -3229,6 +3256,275 @@ mod tests {
         assert_eq!(
             updated_after_rearchive, archive_at,
             "the idempotent re-archive does not bump updated_at"
+        );
+    }
+
+    #[test]
+    fn c2_7_owner_authed_fork_is_a_real_branch_of_a_metered_session() {
+        // C2-7 FAITHFUL DARK PROOF: drive ONE claude-pinned SESSIONED turn through the REAL
+        // `run_session_task_pinned` entry (billing one anthropic row — ASSERTED, so the PARENT
+        // is the REAL routed session that carries metered claude billing, never a mirror). Then
+        // FORK that parent as the BOUND owner and prove:
+        //   - a NEW session exists, distinct from the parent, with the parent's messages COPIED
+        //     (role/content/refs preserved verbatim — a copied turn legitimately still refs the
+        //     PARENT's run_id);
+        //   - the child's `forked_from` points back at the parent;
+        //   - the child is bound to the SAME owner (it appears in the owner's C2-4 active list);
+        //   - an audit receipt is written (action='session.forked') and the hash chain verifies;
+        //   - NO new ledger row at fork time (forking is metadata, not a model turn) — the whole
+        //     ledger stays at the 1 the parent turn wrote.
+        // THEN run ONE claude-pinned turn on the FORKED session and prove:
+        //   - it bills a NEW anthropic row on the CHILD run (the fork is a REAL branch of a
+        //     metered session, not a mirror clone) — the whole ledger is now 2;
+        //   - `forked_from` SURVIVES the child turn (the run-entry's ON CONFLICT bump never
+        //     names it).
+        // Owner MISMATCH: a DIFFERENT principal CANNOT fork (fail-closed refusal) — no child,
+        // no copy, no audit row, and the `agent_session` row count is unchanged.
+        // NO key, NO network — the claude stub bills the anthropic rows.
+        let (rt, _ws) = runtime_with_claude_wired(
+            "c2-7-fork-op",
+            vec![AgentStep::Finish {
+                message: "PONG".to_string(),
+            }],
+            Box::new(DenyAllApprovals),
+        );
+        let owner = authed_caller("principal:c2-7-owner");
+        let other = authed_caller("principal:c2-7-intruder");
+
+        // --- one claude-pinned sessioned turn → a REAL routed PARENT with a metered anthropic row ---
+        let parent_run = "run-c2-7-parent";
+        let parent_sess = "sess-c2-7-parent";
+        let (sel, _a) = rt
+            .run_session_task_pinned(
+                &owner,
+                parent_run,
+                parent_sess,
+                "first turn",
+                "claude",
+                5_000,
+            )
+            .expect("the claude-pinned sessioned turn runs");
+        assert_eq!(sel.provider_id, "claude", "the pin routed to claude");
+
+        // ASSERT the REAL anthropic ledger row on the PARENT run.
+        let parent_ledger = rt.db().list_run_token_usage(parent_run).unwrap();
+        assert_eq!(
+            parent_ledger.len(),
+            1,
+            "one anthropic row for the parent turn"
+        );
+        assert_eq!(parent_ledger[0].provider_kind, "anthropic");
+        assert_eq!(parent_ledger[0].base_url_host, "api.anthropic.com");
+        assert!(
+            !parent_ledger[0].fallback,
+            "the claude route is never a fallback"
+        );
+        assert_eq!(
+            rt.db().list_token_usage().unwrap().len(),
+            1,
+            "exactly one anthropic row exists before the fork"
+        );
+
+        // PRECONDITION: the parent has ≥1 message (else "messages COPIED" would prove nothing).
+        let parent_msgs = rt
+            .open_session_for_owner(&owner, parent_sess)
+            .unwrap()
+            .expect("the owner can open its own parent session");
+        assert!(
+            !parent_msgs.is_empty(),
+            "the metered turn folded ≥1 message into the parent (the copy source)"
+        );
+
+        let fork_receipts = |rt: &HubRuntime<ScriptTransport>| -> i64 {
+            rt.db()
+                .conn()
+                .query_row(
+                    "SELECT count(*) FROM audit_ledger WHERE action = 'session.forked'",
+                    [],
+                    |r| r.get(0),
+                )
+                .unwrap()
+        };
+        let session_count = |rt: &HubRuntime<ScriptTransport>| -> i64 {
+            rt.db()
+                .conn()
+                .query_row("SELECT count(*) FROM agent_session", [], |r| r.get(0))
+                .unwrap()
+        };
+        assert_eq!(fork_receipts(&rt), 0, "no fork receipt before the op");
+        let sessions_before_fork = session_count(&rt);
+
+        // --- OWNER-MISMATCH first: a DIFFERENT principal cannot fork (fail-closed refusal) -------
+        let refused = rt
+            .fork_session_for_owner(&other, parent_sess, 6_000)
+            .expect("the fork call itself does not error");
+        assert!(!refused.accepted, "a non-owner fork is refused");
+        assert_eq!(refused.status, "not_owner");
+        assert_eq!(
+            refused.child_session_id, None,
+            "a refused fork mints no child"
+        );
+        assert_eq!(refused.audit_ref, None, "a refused fork writes no receipt");
+        assert_eq!(
+            session_count(&rt),
+            sessions_before_fork,
+            "owner mismatch created NO child (agent_session count unchanged)"
+        );
+        assert_eq!(
+            fork_receipts(&rt),
+            0,
+            "a refused (non-owner) fork writes NO audit row (the real fail-closed proof)"
+        );
+
+        // --- the BOUND OWNER forks the parent ----------------------------------------------------
+        let fork_at = 7_000;
+        let outcome = rt
+            .fork_session_for_owner(&owner, parent_sess, fork_at)
+            .expect("the owner's fork runs");
+        assert!(outcome.accepted, "the bound owner's fork is accepted");
+        assert_eq!(outcome.status, "forked");
+        assert!(
+            outcome.audit_ref.is_some(),
+            "an accepted fork writes a receipt"
+        );
+        let child_sess = outcome
+            .child_session_id
+            .clone()
+            .expect("an accepted fork mints a child id");
+        assert_ne!(
+            child_sess, parent_sess,
+            "the child is a NEW, distinct session"
+        );
+
+        // A new session row exists (parent + child).
+        assert_eq!(
+            session_count(&rt),
+            sessions_before_fork + 1,
+            "the accepted fork created exactly one new session"
+        );
+
+        // The child's `forked_from` points back at the parent.
+        let child_forked_from: Option<String> = rt
+            .db()
+            .conn()
+            .query_row(
+                "SELECT forked_from FROM agent_session WHERE agent_session_id = ?1",
+                [&child_sess],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(
+            child_forked_from.as_deref(),
+            Some(parent_sess),
+            "the child's forked_from points at the parent"
+        );
+
+        // The child carries a COPY of the parent's messages (role/content/refs verbatim, in order).
+        let child_msgs = rt
+            .open_session_for_owner(&owner, &child_sess)
+            .unwrap()
+            .expect("the owner can open its own forked child session");
+        assert_eq!(
+            child_msgs.len(),
+            parent_msgs.len(),
+            "the child copied EVERY parent message"
+        );
+        for (c, pm) in child_msgs.iter().zip(parent_msgs.iter()) {
+            assert_eq!(c.role, pm.role, "copied role matches");
+            assert_eq!(c.content, pm.content, "copied content matches");
+            assert_eq!(
+                c.refs, pm.refs,
+                "copied refs match VERBATIM (a copied turn still refs the PARENT's run_id)"
+            );
+        }
+
+        // The child is bound to the SAME owner: it appears in the owner's C2-4 active list...
+        assert!(
+            rt.list_sessions_for_owner(&owner)
+                .unwrap()
+                .iter()
+                .any(|s| s.agent_session_id == child_sess),
+            "the forked child is listed under the SAME owner"
+        );
+        // ...and a DIFFERENT principal sees neither (owner-scoped empty for the intruder is the
+        // same fail-closed axis — the child was bound to the real owner, never the caller's claim).
+        assert!(
+            rt.open_session_for_owner(&other, &child_sess)
+                .unwrap()
+                .is_none(),
+            "a non-owner cannot open the forked child (bound to the real owner)"
+        );
+
+        // An audit receipt was written and the hash chain verifies.
+        assert_eq!(
+            fork_receipts(&rt),
+            1,
+            "exactly one session.forked receipt was recorded"
+        );
+        assert!(
+            friday_storage::audit::verify_audit_chain(rt.db().conn()).is_ok(),
+            "the fork receipt is on a verified hash chain"
+        );
+
+        // THE ANTI-FAKE (fork is metadata): NO new ledger row at fork time.
+        assert_eq!(
+            rt.db().list_token_usage().unwrap().len(),
+            1,
+            "the fork billed NO new ledger row (forking is not a model turn)"
+        );
+
+        // --- THEN: one claude-pinned turn on the FORKED CHILD bills a NEW anthropic row ----------
+        // The fork is a REAL branch of a metered session — a turn on the child meters its OWN row.
+        let child_run = "run-c2-7-child";
+        let (csel, _ca) = rt
+            .run_session_task_pinned(
+                &owner,
+                child_run,
+                &child_sess,
+                "branch turn",
+                "claude",
+                9_000,
+            )
+            .expect("the claude-pinned turn on the forked child runs");
+        assert_eq!(
+            csel.provider_id, "claude",
+            "the child turn routed to claude"
+        );
+
+        let child_ledger = rt.db().list_run_token_usage(child_run).unwrap();
+        assert_eq!(
+            child_ledger.len(),
+            1,
+            "ONE NEW anthropic row on the CHILD run (the fork is a real metered branch)"
+        );
+        assert_eq!(child_ledger[0].provider_kind, "anthropic");
+        assert_eq!(child_ledger[0].base_url_host, "api.anthropic.com");
+        assert!(
+            !child_ledger[0].fallback,
+            "the child claude route is never a fallback"
+        );
+
+        // The whole ledger is now 2: the parent row + the child's NEW row (no mis-attribution).
+        assert_eq!(
+            rt.db().list_token_usage().unwrap().len(),
+            2,
+            "two anthropic rows total: the parent turn + the child branch turn"
+        );
+
+        // `forked_from` SURVIVES the child turn (the run-entry's ON CONFLICT bump never names it).
+        let child_forked_from_after: Option<String> = rt
+            .db()
+            .conn()
+            .query_row(
+                "SELECT forked_from FROM agent_session WHERE agent_session_id = ?1",
+                [&child_sess],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(
+            child_forked_from_after.as_deref(),
+            Some(parent_sess),
+            "forked_from survives the child's metered turn (never erased by the run entry)"
         );
     }
 

--- a/rust-core/crates/friday-storage/src/agent_session.rs
+++ b/rust-core/crates/friday-storage/src/agent_session.rs
@@ -610,6 +610,167 @@ pub fn archive_session_for_owner(
     })
 }
 
+// --- C2-7 explicit owner-authed FORK op (a new branch of a metered session) -------
+//
+// An EXPLICIT, owner-authed FORK of one FRIDAY routed `agent_session`: the bound owner says
+// "branch this conversation" — create a NEW owned session seeded with a COPY of the parent's
+// messages, with `forked_from` pointing back at the parent, so a follow-up turn explores an
+// alternate branch WITHOUT mutating the parent's history. This is the metadata half ONLY:
+// the fork itself makes NO model call and writes NO `token_ledger` row (forking is not a
+// turn). A later turn on the FORKED session routes + bills exactly like any other routed
+// session (its OWN new `anthropic` row), so the fork is a real branch of a metered session —
+// NOT a synthesized/mirror clone of a `provider_session_link` claude_control link (that local
+// mirror has no owner axis and no real billing; this op never touches it).
+//
+// Owner-gated EXACTLY like the C2-4 read API and the C2-6 archive op: it reuses
+// [`owner_matches`] on the PARENT (the `agent_session.user_id` axis bound to the authenticated
+// caller by `run_session_task_pinned`), so a DIFFERENT principal — or a blank owner, an
+// owner-less (NULL `user_id`) parent, or an absent parent id — is REFUSED fail-closed with NO
+// child created, NO message copied, and NO audit row. Only the bound owner can fork, and the
+// child is bound to the SAME owner (NEVER a client-asserted id).
+//
+// The child session row + the copied messages + the hash-chained audit receipt are written in
+// ONE `unchecked_transaction` (atomic: a crash can never leave a half-copied child with no
+// receipt, nor a child with a partial transcript). The copies are INSERTed directly into the
+// child (the fork op holds the single tx, so it cannot call `append_session_message`, which
+// would open a nested transaction) preserving each turn's `role`/`content`/`refs` VERBATIM —
+// a fork is a faithful copy of the parent's history, so a copied message legitimately still
+// `refs` the PARENT's run_id (only the NEW follow-up turn on the child gets its own run_id).
+
+/// The body-free outcome of a [`fork_session_for_owner`] attempt. `accepted=false` is the
+/// fail-closed owner-mismatch refusal (no child, no copy, no receipt). Never a body.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ForkOutcome {
+    /// Whether the fork was accepted (`true`) or refused fail-closed (`false`).
+    pub accepted: bool,
+    /// Coarse, body-free outcome label (closed-vocab): `"forked"` (a child was created +
+    /// seeded) or `"not_owner"` (fail-closed refusal — a non-owner, an owner-less parent, a
+    /// blank owner, or an absent parent id).
+    pub status: String,
+    /// The minted child `agent_session_id`, present ONLY on an accepted fork. The caller uses
+    /// it to run the next (branched) turn on the child.
+    pub child_session_id: Option<String>,
+    /// Soft link to the hash-chained audit receipt, written ONLY on an accepted fork.
+    pub audit_ref: Option<String>,
+}
+
+impl ForkOutcome {
+    fn refused() -> Self {
+        ForkOutcome {
+            accepted: false,
+            status: "not_owner".to_string(),
+            child_session_id: None,
+            audit_ref: None,
+        }
+    }
+}
+
+/// Explicitly FORK a routed session as its BOUND owner: create a NEW owned `agent_session`
+/// (fresh id, `forked_from` = the parent id, `user_id` = the authenticated caller, `status`
+/// defaulting to `'active'`) seeded with a COPY of the parent's messages, and write a
+/// hash-chained audit receipt — all in ONE transaction.
+///
+/// Owner-gated fail-closed via [`owner_matches`] on the PARENT (the SAME `agent_session.user_id`
+/// axis as the C2-4 read API and the C2-6 archive op): a non-owner, an owner-less parent, a
+/// blank `user_id`, or an absent `parent_session_id` all return [`ForkOutcome::refused`]
+/// (`accepted=false`, `status="not_owner"`) with NO child, NO copied message, and NO audit row —
+/// a guessed parent id cannot fork another principal's session.
+///
+/// The child is bound to the SAME owner the parent check established (`caller == parent.user_id`),
+/// never a client-asserted id. The copied messages preserve each turn's `role`/`content`/`refs`
+/// verbatim in `seq` order (a copied message legitimately still `refs` the parent's run_id — a
+/// fork is a copy of history; only a NEW turn on the child gets its own run_id). The child's
+/// `seq` restarts at `0` (a fresh session).
+///
+/// Metadata-only: NO model call and NO `token_ledger` row (forking is not a metered turn). A
+/// LATER turn on the forked session routes + bills its OWN row exactly like any routed session,
+/// so the fork is a real branch of a metered session — never a synthesized/mirror clone.
+pub fn fork_session_for_owner(
+    conn: &Connection,
+    user_id: &str,
+    parent_session_id: &str,
+    now_ms: i64,
+) -> Result<ForkOutcome> {
+    // (1) Owner gate FIRST (fail-closed) on the PARENT: a non-owner / owner-less / absent /
+    //     blank-owner attempt is refused with no read leaked, no mint, and no write.
+    if !owner_matches(conn, user_id, parent_session_id)? {
+        return Ok(ForkOutcome::refused());
+    }
+
+    // (2) The owner matched the parent. Read its messages to copy (refs-only metadata is not
+    //     enough — a fork must carry the conversation, so the bodies are copied Hub-side, never
+    //     over the wire). A CSPRNG tag keys both the child id and the audit id so repeated forks
+    //     of the same parent never collide on the `agent_session` PK or the `audit_id` PK.
+    let parent_messages = load_session_messages(conn, parent_session_id)?;
+    let tag = friday_crypto::generate_approval_nonce();
+    let child_session_id = format!("{parent_session_id}:fork:{tag}");
+    let receipt_id = format!("{child_session_id}:fork:receipt");
+
+    // (3) Create the child + copy the messages + write the receipt in ONE transaction (atomic:
+    //     a crash can never leave a half-copied child or a child with no receipt). The child
+    //     names `forked_from` (the parent pointer, m0032) and `user_id` (the SAME owner the gate
+    //     established — never client-asserted); `status` takes its v28 DEFAULT 'active' so the
+    //     child appears in the owner's active list. The copies are INSERTed DIRECTLY (the op
+    //     holds the single tx; calling `append_session_message` would open a nested transaction).
+    let tx = conn.unchecked_transaction()?;
+    tx.execute(
+        "INSERT INTO agent_session (agent_session_id, created_at, updated_at, user_id, forked_from)
+         VALUES (?1, ?2, ?2, ?3, ?4)",
+        params![child_session_id, now_ms, user_id, parent_session_id],
+    )?;
+    for (seq, msg) in parent_messages.iter().enumerate() {
+        let seq = seq as i64;
+        let message_id = format!("{child_session_id}:m{seq}");
+        tx.execute(
+            "INSERT INTO agent_session_message
+                (message_id, agent_session_id, seq, role, content, refs, created_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+            params![
+                message_id,
+                child_session_id,
+                seq,
+                msg.role,
+                msg.content,
+                msg.refs,
+                now_ms,
+            ],
+        )?;
+    }
+    // The actor is the owner principal that authorized the fork (WHO forked); the payload_ref
+    // soft-links the NEW child session (the artifact this op produced).
+    audit::append_audit(
+        &tx,
+        &receipt_id,
+        user_id,
+        "session.forked",
+        Some(&child_session_id),
+        now_ms,
+    )?;
+    tx.commit()?;
+
+    Ok(ForkOutcome {
+        accepted: true,
+        status: "forked".to_string(),
+        child_session_id: Some(child_session_id),
+        audit_ref: Some(receipt_id),
+    })
+}
+
+/// Read a session's `forked_from` parent pointer (C2-7). `Some(parent_id)` for a forked
+/// session, `None` for a root session (or an absent one — both read back the same, no
+/// existence oracle is intended here; the owner-gated read API governs visibility). Pure read.
+pub fn session_forked_from(conn: &Connection, agent_session_id: &str) -> Result<Option<String>> {
+    let parent = conn
+        .query_row(
+            "SELECT forked_from FROM agent_session WHERE agent_session_id = ?1",
+            [agent_session_id],
+            |r| r.get::<_, Option<String>>(0),
+        )
+        .optional()?
+        .flatten();
+    Ok(parent)
+}
+
 // --- C2-8 offline/stale link-state (derived from last-activity vs now) --------
 //
 // A connectivity/staleness LABEL for a routed `agent_session`, derived purely from the

--- a/rust-core/crates/friday-storage/src/lib.rs
+++ b/rust-core/crates/friday-storage/src/lib.rs
@@ -41,9 +41,10 @@ pub mod workflow_read;
 
 pub use agent_session::{
     append_session_message, archive_session_for_owner, ensure_session, ensure_session_with_owner,
-    list_sessions_for_owner, load_session_messages, load_session_owner, open_session_for_owner,
-    session_exists, session_message_count, session_message_count_for_owner, ArchiveOutcome,
-    SessionListItem, SessionMessage, SessionOwner, StoredSessionMessage,
+    fork_session_for_owner, list_sessions_for_owner, load_session_messages, load_session_owner,
+    open_session_for_owner, session_exists, session_forked_from, session_message_count,
+    session_message_count_for_owner, ArchiveOutcome, ForkOutcome, SessionListItem, SessionMessage,
+    SessionOwner, StoredSessionMessage,
 };
 pub use authorize::authorize_mutating_action;
 pub use authorize_ed25519::{authorize_mutating_action_ed25519, Ed25519VerifyOnlyPolicy};

--- a/rust-core/crates/friday-storage/src/schema.rs
+++ b/rust-core/crates/friday-storage/src/schema.rs
@@ -537,6 +537,23 @@ pub fn hub_migrations() -> Vec<Migration> {
             destructive: false,
             up: m0031_trust_grant,
         },
+        // C2-7: additive NULLABLE `forked_from` column on the Hub-only `agent_session`
+        // table — a soft link (no FK, the `*_ref` convention) to the PARENT
+        // `agent_session_id` a fork descends from. This is the minimal Rust fork marker
+        // the TS path carries as `forked_from_message_id` / `root_session_key` (which the
+        // earlier Rust port deliberately OMITTED); C2-7 adds only the parent pointer the
+        // fork op needs. `ALTER TABLE ... ADD COLUMN` with no default is additive and
+        // forward-safe: every existing v31 `agent_session` row reads back `forked_from =
+        // NULL` (i.e. "not a fork" — a root session), so no pre-existing row is broken or
+        // mis-labelled and no existing session behavior changes. No CHECK (a NULL-or-id
+        // soft link needs none). Purely additive (ALTER only) — touches no other table, so
+        // v31 rows/queries are unaffected. Hub-only — `agent_session` is a Hub-only table.
+        Migration {
+            version: 32,
+            name: "agent_session_forked_from",
+            destructive: false,
+            up: m0032_agent_session_forked_from,
+        },
     ]
 }
 
@@ -2240,4 +2257,18 @@ fn m0030_context_passport(tx: &Transaction) -> rusqlite::Result<()> {
 /// query is unaffected.
 fn m0031_trust_grant(tx: &Transaction) -> rusqlite::Result<()> {
     tx.execute_batch(DDL_TRUST_GRANT)
+}
+
+// C2-7: additive NULLABLE `forked_from` soft-link column on the Hub-only `agent_session`
+// table — the PARENT `agent_session_id` a fork descends from (the minimal Rust fork
+// marker; the earlier port OMITTED the TS `forked_from_message_id`/`root_session_key`).
+// `ALTER TABLE ... ADD COLUMN` with no default is additive and FORWARD-SAFE: every existing
+// v31 row reads back `forked_from = NULL` (a root session, never mis-labelled as a fork),
+// no row is broken, and no existing session behavior changes. No CHECK — a NULL-or-id soft
+// link (the `*_ref` convention, no FK) needs none. The `agent_session` CREATE-DDL const
+// stays FROZEN at its pre-v32 shape, so a fresh install runs the base CREATE then this ALTER
+// (no duplicate-column on fresh install) — mirrors how m0021/m0028 added their columns.
+// Purely additive (ALTER only) — touches no other table, so v31 rows/queries are unaffected.
+fn m0032_agent_session_forked_from(tx: &Transaction) -> rusqlite::Result<()> {
+    tx.execute_batch("ALTER TABLE agent_session ADD COLUMN forked_from TEXT;")
 }

--- a/rust-core/crates/friday-storage/tests/migration.rs
+++ b/rust-core/crates/friday-storage/tests/migration.rs
@@ -556,6 +556,88 @@ fn forward_migration_v28_to_v29_adds_step_effect_table_and_preserves_v28_rows() 
 }
 
 #[test]
+fn forward_migration_v31_to_v32_adds_forked_from_to_null_and_fresh_has_column() {
+    // C2-7 additive migration v32: agent_session gains nullable `forked_from` (the parent
+    // pointer a fork descends from). This is the ALTER ADD COLUMN pattern (like m0021
+    // owner cols / m0028 lifecycle), NOT a new table. A PRE-EXISTING v31 session row
+    // (seeded before the column existed) must survive the forward ALTER reading back NULL
+    // (i.e. "not a fork" — a root session, never mis-labelled) so no existing session
+    // behavior changes. A FRESH install has the column, and the fork op then round-trips
+    // on the migrated DB (the child carries `forked_from` = the parent).
+    use friday_storage::agent_session::{
+        append_session_message, ensure_session_with_owner, fork_session_for_owner,
+        load_session_messages, session_forked_from, SessionMessage, SessionOwner,
+    };
+
+    let p = temp_db_path("agent-session-forked-from-mig");
+    {
+        let mut migs = hub_migrations();
+        migs.retain(|m| m.version <= 31);
+        let db = Db::open(&p, Profile::Hub, &migs, "v31").unwrap();
+        assert_eq!(db.version().unwrap(), 31);
+        assert!(
+            db.conn()
+                .prepare("SELECT forked_from FROM agent_session")
+                .is_err(),
+            "forked_from column must not exist before v32"
+        );
+        // Seed an OWNED session (v31 has the owner + lifecycle cols) with one message,
+        // using the v31 owner-bind API (which names only ≤v31 columns).
+        let owner = SessionOwner {
+            user_id: Some("user-fork".into()),
+            ..Default::default()
+        };
+        ensure_session_with_owner(db.conn(), "parent-31", &owner, 1).unwrap();
+        append_session_message(
+            db.conn(),
+            "parent-31",
+            &SessionMessage::new("user", "branch me", Some("run-31".to_string())),
+            2,
+        )
+        .unwrap();
+    }
+    // Reopen with the full set -> forward-migrate to v32 (the additive ALTER).
+    let db = Db::open_hub(&p).unwrap();
+    assert_eq!(db.version().unwrap(), hub_max_version());
+    assert_eq!(
+        db.count("agent_session").unwrap(),
+        1,
+        "pre-v32 session row survived the migration"
+    );
+    // The pre-existing row reads back `forked_from = NULL` (a root session, fail-safe).
+    assert_eq!(
+        session_forked_from(db.conn(), "parent-31").unwrap(),
+        None,
+        "pre-v32 row backfills `forked_from` to NULL (not a fork — forward-safe)"
+    );
+
+    // The fork op round-trips on the migrated DB: the bound owner forks the parent and the
+    // child carries `forked_from` = parent + a COPY of the parent's one message.
+    let out = fork_session_for_owner(db.conn(), "user-fork", "parent-31", 3).unwrap();
+    assert!(
+        out.accepted,
+        "the bound owner's fork is accepted on the migrated DB"
+    );
+    let child = out
+        .child_session_id
+        .expect("an accepted fork mints a child id");
+    assert_eq!(
+        session_forked_from(db.conn(), &child).unwrap(),
+        Some("parent-31".to_string()),
+        "the child's forked_from points back at the parent"
+    );
+    let copied = load_session_messages(db.conn(), &child).unwrap();
+    assert_eq!(copied.len(), 1, "the parent's one message was copied");
+    assert_eq!(copied[0].role, "user");
+    assert_eq!(copied[0].content, "branch me");
+    assert_eq!(
+        copied[0].refs.as_deref(),
+        Some("run-31"),
+        "a copied message keeps the parent's run ref verbatim (a fork is a copy of history)"
+    );
+}
+
+#[test]
 fn reopen_is_idempotent_and_preserves_rows() {
     let p = temp_db_path("seeded");
     {


### PR DESCRIPTION
**C2-7** of the C2 Claude-parity program: a minimal owner-authed FORK primitive for a routed `agent_session`. DARK (a deterministic test is the proof). NOT hot `lib.rs`. Builds on C2-4 (owner axis) + C2-6 (archive op + audit-receipt pattern).

## What it adds
- **forward-safe migration** (`schema.rs`, v32 `m0032_agent_session_forked_from`): additive nullable `ALTER TABLE agent_session ADD COLUMN forked_from TEXT;` — no CHECK, no FK. Every existing v31 row reads back `forked_from = NULL` (a root session, never mis-labelled); no row breaks and no existing session behavior changes.
- **copy-history fork op** (`agent_session.rs`, `fork_session_for_owner`): owner-gated (reuses C2-4 `owner_matches` on the parent) creation of a NEW owned session (fresh id, same authed owner, `forked_from` = parent id) seeded with a COPY of the parent's messages (role/content/refs verbatim, in `seq` order) + a hash-chained `session.forked` audit receipt — child row, copies, and receipt all written in ONE transaction. Adds `session_forked_from` reader + `ForkOutcome` (re-exported from `lib.rs`).
- **thin accessor** (`runtime.rs`, `HubRuntime::fork_session_for_owner`): scopes on `caller.principal()`.

## No model call at fork; the fork is a real branch of a metered session
The fork itself makes **no model call** and writes **no `token_ledger` row** (forking is metadata). A later turn on the forked session routes + bills its OWN `anthropic` row exactly like any routed session — so the fork is a REAL branch of a metered session, never a synthesized/mirror clone.

## Owner-gated fail-closed
A non-owner / owner-less parent / blank owner / absent parent id is REFUSED fail-closed (`accepted=false`, `status="not_owner"`) with NO child, NO copied message, and NO audit row.

## Faithful dark proofs
- `c2_7_owner_authed_fork_is_a_real_branch_of_a_metered_session` (`runtime.rs`): seed a claude-pinned PARENT via the REAL `run_session_task_pinned` (asserts the anthropic ledger row), fork as the bound owner → NEW session w/ copied history + `forked_from` + same owner (listed under the owner, intruder-open `None`) + audit receipt + chain verify + NO new ledger row at fork; THEN one claude turn on the FORKED session bills a NEW anthropic row on the child run (whole ledger 1→2) and `forked_from` survives the child turn; owner-mismatch → fail-closed (session count unchanged, no receipt).
- `forward_migration_v31_to_v32_adds_forked_from_to_null_and_fresh_has_column` (`tests/migration.rs`): pre-v31 row backfills `forked_from` to NULL; the fork op round-trips on the migrated DB.

## Local gates (all green, in rust-core.yml order)
- `cargo fmt --all --check`: clean
- `cargo clippy --workspace --all-targets -- -D warnings`: clean
- `cargo test --workspace`: 111 result-lines ok, 0 failed (the migration test file IS the migrations check; `scripts/quality/check-migrations.mjs` validates only the TS migration chain — untouched here — and still passes 92/92)

🤖 Generated with [Claude Code](https://claude.com/claude-code)