### PR TITLE
feat(c2-9): owner-scoped Activity/Needs-Me projection over a paused metered claude run

### DIFF
--- a/rust-core/crates/friday-hub/src/run_readback_projection.rs
+++ b/rust-core/crates/friday-hub/src/run_readback_projection.rs
@@ -32,6 +32,9 @@
 //! This fn takes an ALREADY-OPENED [`Db`] (the bin and the server open it `open_hub_readonly`) and
 //! does pure reads + JSON shaping. It never touches a provider credential or the model path.
 
+use friday_providers::unified::{
+    NeedsMeItem, NeedsMeKind, NeedsMePriority, PlatformProvider, SessionStatus,
+};
 use friday_storage::agent_run_read::{db_wide_token_totals, get_run_summary, list_event_kinds};
 use friday_storage::agent_session::{
     link_state_for_owner, LINK_OFFLINE_AFTER_MS, LINK_STALE_AFTER_MS,
@@ -251,6 +254,114 @@ pub fn project_run_file_view(
 
     // Inherit the refs-only guard: a relative path passes; an absolute-path / secret marker that
     // somehow reached a receipt summary fails the projection closed (never leaks).
+    let rendered = serde_json::to_string(&snapshot).map_err(|_| "serialize_failed".to_string())?;
+    reject_forbidden_output(&rendered)?;
+    Ok(Some(snapshot))
+}
+
+/// (C2-9) OWNER-SCOPED Activity / Needs-Me projection for ONE paused, claude-pinned run: the
+/// run's `AskReceipt` activity rows (one per metered turn) PLUS a single Needs-Me item surfacing
+/// the pending operator approval the run Paused on. `Ok(None)` ⇒ the caller is NOT the run's bound
+/// owner (or the run is not paused / owner-less / the caller is empty) — fail-closed, no
+/// existence/state oracle for a non-owner. `Ok(Some(snapshot))` ⇒ the owner's Activity/Needs-Me
+/// view.
+///
+/// ## Owner axis — `resolve_run_owner`, NOT the literal C2-4/C2-5 gate (deliberate, documented)
+/// The C2-4/C2-5 read APIs gate on [`friday_storage::get_run_answer_for_principal`], which keys on
+/// `run_result.owner_principal` — a row that only exists once a run is *Finished*. THIS run is
+/// *Paused* (it has no `run_result` yet), so the literal gate would deny every caller. The SAME
+/// owner concept for a paused run lives on the pending approval row's `principal_id`, which
+/// [`crate::agent_run_control::resolve_run_owner`] returns (the SAME source the owner-authed
+/// `reject`/`cancel` control ops gate on). So the owner axis here is `resolve_run_owner` —
+/// fail-closed identically: an empty caller, an owner-less run, or a mismatch all read back `None`.
+///
+/// ## Built over the EXISTING substrate, refs-only (NOT a synthesized inbox)
+/// * The Needs-Me item is anchored to a REAL pending approval via [`crate::agent_run_control::detect_pause`]
+///   (`ref_id` = the live CSPRNG approval nonce; `kind` = Approval; `status` = AwaitingApproval) —
+///   so it points at a run with a real `pending_approval_request`, never a fabricated entry. A run
+///   that is not paused (no pending row) yields `needs_me: None`.
+/// * The AskReceipt rows are read from [`friday_storage::Db::list_activity`] filtered to THIS run:
+///   `kind == "ask_receipt"` AND `activity_id` carries the run prefix `"{run_id}:"` — matching the
+///   `bill_model_call` scheme (`{run_id}:t{turn_index}:askreceipt`). Each row is the body-free
+///   `"{n} tokens via {model}"` receipt of a real metered turn.
+///
+/// ## Class-2 read: no model call, no new ledger row, no mutation
+/// Pure reads over already-persisted activity + pending rows — it never touches a provider
+/// credential, the model path, or any write, and writes NO `token_ledger` row (it is not a metered
+/// turn). It is INDEPENDENT of the ns-7 `FRIDAY_ACTIVITY_NEEDS_ME` persisted-activity flag: the
+/// Needs-Me item is COMPUTED from `detect_pause` at read time, not read from a persisted row. The
+/// shared [`reject_forbidden_output`] guard runs INSIDE this fn so the snapshot inherits the
+/// refs-only discipline.
+pub fn project_activity_needs_me(
+    db: &Db,
+    caller_principal: &str,
+    run_id: &str,
+) -> Result<Option<Value>, String> {
+    let conn = db.conn();
+
+    // OWNER GATE (fail-closed): the paused run's owner is the pending row's `principal_id`
+    // (`resolve_run_owner`). An empty caller, an owner-less run, or a mismatch all collapse to
+    // `Ok(None)` — a non-owner gets no existence/state oracle for the run's activity.
+    let caller = caller_principal.trim();
+    if caller.is_empty() {
+        return Ok(None);
+    }
+    let owner = crate::agent_run_control::resolve_run_owner(conn, run_id)
+        .map_err(|_| "read_failed".to_string())?;
+    if owner.as_deref() != Some(caller) {
+        return Ok(None);
+    }
+
+    // The run's AskReceipt activity rows: filter the DB-wide activity list to THIS run by the
+    // `bill_model_call` id scheme (`{run_id}:t{turn_index}:askreceipt`). The trailing colon makes
+    // the prefix unambiguous (`run-c2-9:` never matches `run-c2-90:`).
+    let run_prefix = format!("{run_id}:");
+    let ask_receipts: Vec<Value> = db
+        .list_activity()
+        .map_err(|_| "read_failed".to_string())?
+        .into_iter()
+        .filter(|row| row.kind == "ask_receipt" && row.activity_id.starts_with(&run_prefix))
+        .map(|row| {
+            json!({
+                "activity_id": row.activity_id,
+                "kind": row.kind,
+                "state": row.state,
+                // The metered-turn receipt summary ("{n} tokens via {model}") — body-free.
+                "summary": row.summary,
+                "created_at": row.created_at,
+            })
+        })
+        .collect();
+
+    // The Needs-Me item: anchored to the REAL pending approval the run paused on (`detect_pause`).
+    // A run not paused yields `None` (no synthesized inbox entry). The run is claude-pinned, so the
+    // provider is Claude; the sessionless run's `friday_session_id` is the run id.
+    let needs_me = crate::agent_run_control::detect_pause(conn, run_id)
+        .map_err(|_| "read_failed".to_string())?
+        .map(|pause| NeedsMeItem {
+            item_id: format!("needs-me:{run_id}:{}", pause.nonce),
+            provider: PlatformProvider::Claude,
+            friday_session_id: run_id.to_string(),
+            kind: NeedsMeKind::Approval,
+            priority: NeedsMePriority::High,
+            // The live approval nonce — the real `pending_approval_request.approval_id`.
+            ref_id: pause.nonce,
+            status: SessionStatus::AwaitingApproval,
+        });
+
+    let ask_receipt_count = ask_receipts.len();
+    let snapshot = json!({
+        "truth_label": "rust_wired_dev",
+        "proof_only": true,
+        "ok": true,
+        "run_id": run_id,
+        "ask_receipts": ask_receipts,
+        "ask_receipt_count": ask_receipt_count,
+        "needs_me": needs_me,
+    });
+
+    // Inherit the refs-only guard (the AskReceipt summary + the nonce-only Needs-Me item are
+    // body-free, so it passes — but run it so this projection matches the file's discipline).
     let rendered = serde_json::to_string(&snapshot).map_err(|_| "serialize_failed".to_string())?;
     reject_forbidden_output(&rendered)?;
     Ok(Some(snapshot))

--- a/rust-core/crates/friday-hub/src/runtime.rs
+++ b/rust-core/crates/friday-hub/src/runtime.rs
@@ -1156,6 +1156,31 @@ impl<T: Transport> HubRuntime<T> {
         crate::run_readback_projection::project_run_file_view(&self.db, caller.principal(), run_id)
     }
 
+    /// (C2-9) OWNER-SCOPED Activity / Needs-Me projection for one PAUSED, claude-pinned run: the
+    /// run's `AskReceipt` activity rows (one per metered turn) PLUS a Needs-Me item surfacing the
+    /// pending operator approval the run Paused on. `Some(snapshot)` ONLY when `caller` is the
+    /// paused run's bound OWNER, else `None` (fail-closed — a non-owner cannot read another's
+    /// activity by guessing the run_id). Scopes on `caller.principal()`, NEVER a client-asserted id.
+    ///
+    /// The owner axis is the paused run's pending-row principal (`resolve_run_owner`), NOT the
+    /// C2-4/C2-5 `get_run_answer_for_principal` gate — a paused run has no `run_result` for that
+    /// gate to key on, so the SAME owner concept is taken from the pending approval row (the SAME
+    /// source the owner-authed `reject`/`cancel` control ops gate on). The Needs-Me item is anchored
+    /// to a REAL `pending_approval_request` via `detect_pause` and the AskReceipts to REAL metered
+    /// turns via `Db::list_activity` — never a synthesized inbox entry. Class-2 read: no model call,
+    /// no ledger row, no write. ADDITIVE, read-only accessor.
+    pub fn activity_needs_me_for_owner(
+        &self,
+        caller: &AuthedPrincipal,
+        run_id: &str,
+    ) -> Result<Option<serde_json::Value>, String> {
+        crate::run_readback_projection::project_activity_needs_me(
+            &self.db,
+            caller.principal(),
+            run_id,
+        )
+    }
+
     /// (A1 run-controls) The composed `FsToolExecutor` (workspace-root-contained, gate-mandatory).
     /// Exposed so the sealed-WS server's RESUME control handler can delegate to the S6
     /// [`crate::resume::resume_with_approval`] spine (which executes the ONE approved mutation
@@ -2201,6 +2226,88 @@ mod tests {
                 ledger_baseline,
                 "the file-view is a Class-2 read: no new ledger row from the view"
             );
+        }
+
+        // ---- C2-9: owner-scoped Activity / Needs-Me projection over a paused metered run -------
+        #[test]
+        fn c2_9_activity_needs_me_surfaces_paused_claude_run_owner_scoped_no_new_ledger_row() {
+            // C2-9 FAITHFUL DARK PROOF. Reuse the C2-3 setup (`paused_owned_claude_run`): a
+            // claude-pinned MUTATING turn that bills EXACTLY ONE anthropic row then Pauses on a real
+            // pending approval. The Activity/Needs-Me projection then surfaces, OWNER-SCOPED:
+            //   - the AskReceipt activity row of the metered turn (`{RUN}:t0:askreceipt`,
+            //     "{n} tokens via {model}" — the real metered turn, never synthesized);
+            //   - a Needs-Me item for the pending approval, anchored to the REAL nonce
+            //     (`detect_pause`) — provider=claude, kind=approval, status=awaiting_approval,
+            //     `ref_id` = the live `pending_approval_request.approval_id`;
+            //   - a DIFFERENT principal's projection is fail-closed `None` (owner-gated);
+            //   - reading the projection writes NO new ledger row (Class-2 read).
+            // NO key, NO network — the claude stub bills the anthropic row; NO ns-7
+            // FRIDAY_ACTIVITY_NEEDS_ME flag is set (the Needs-Me item is COMPUTED from detect_pause
+            // at read time, decoupled from the persisted-activity path).
+            const OWNER: &str = "principal:c2-9-owner";
+            const RUN: &str = "run-c2-9";
+            let (rt, _ws, nonce, ledger_before) = paused_owned_claude_run("c2-9", OWNER, RUN);
+
+            let owner = authed_caller(OWNER);
+            let other = authed_caller("principal:c2-9-intruder");
+
+            // --- the OWNER's projection surfaces the AskReceipt + the Needs-Me item ------------
+            let view = rt
+                .activity_needs_me_for_owner(&owner, RUN)
+                .unwrap()
+                .expect("the owner reads her own paused-run Activity/Needs-Me projection");
+            assert_eq!(view["run_id"], RUN, "the projection is keyed to the run");
+
+            // The AskReceipt of the ONE metered claude turn, keyed by the bill_model_call scheme.
+            assert_eq!(
+                view["ask_receipt_count"], 1,
+                "exactly one metered-turn receipt"
+            );
+            let receipts = view["ask_receipts"].as_array().expect("ask_receipts array");
+            assert_eq!(receipts.len(), 1);
+            assert_eq!(
+                receipts[0]["activity_id"],
+                format!("{RUN}:t0:askreceipt"),
+                "the receipt is the proposing metered turn's real AskReceipt row"
+            );
+            assert_eq!(receipts[0]["kind"], "ask_receipt");
+            assert_eq!(receipts[0]["state"], "done");
+            assert!(
+                receipts[0]["summary"]
+                    .as_str()
+                    .unwrap()
+                    .contains("tokens via"),
+                "the AskReceipt summary is the metered turn's body-free token receipt"
+            );
+
+            // The Needs-Me item, anchored to the REAL pending approval (the detect_pause nonce).
+            let needs_me = &view["needs_me"];
+            assert!(!needs_me.is_null(), "a paused run surfaces a Needs-Me item");
+            assert_eq!(
+                needs_me["ref_id"], nonce,
+                "the Needs-Me item points at the REAL pending_approval_request nonce, not a \
+                 synthesized inbox entry"
+            );
+            assert_eq!(needs_me["provider"], "claude", "the run is claude-pinned");
+            assert_eq!(needs_me["kind"], "approval");
+            assert_eq!(needs_me["priority"], "high");
+            assert_eq!(needs_me["status"], "awaiting_approval");
+            assert_eq!(needs_me["friday_session_id"], RUN);
+
+            // Refs-only: the projection never carries the run task body or any answer.
+            let rendered = serde_json::to_string(&view).unwrap();
+            assert!(!rendered.contains("write a file"), "no run task body");
+
+            // --- a DIFFERENT principal's projection is fail-closed None (owner-gated) ----------
+            assert_eq!(
+                rt.activity_needs_me_for_owner(&other, RUN).unwrap(),
+                None,
+                "a non-owner cannot read another's Activity/Needs-Me (fail-closed, no oracle)"
+            );
+
+            // --- THE ANTI-FAKE: the projection wrote NO new ledger row (projection-only) -------
+            // (read once per principal — a pure compute over existing activity + pending rows).
+            assert_no_new_anthropic_row(&rt, RUN, &ledger_before);
         }
     } // mod c2_control
 


### PR DESCRIPTION
## C2-9 — owner-scoped Activity/Needs-Me projection over a paused metered claude run

Surfaces a PAUSED, claude-pinned run (`GateDispatch::RequiresApproval`) as an **owner-scoped Needs-Me item + the run's AskReceipt activity rows**. DARK (deterministic test is the proof, projection-only). Builds on C2-3 (merged).

### What it does
- **Additive projection** `project_activity_needs_me` in `run_readback_projection.rs` + a thin **accessor** `activity_needs_me_for_owner` in `runtime.rs` scoping on `caller.principal()` (NEVER a client-asserted id).
- **Pure read/compute over the EXISTING substrate:**
  - AskReceipts from `Db::list_activity()`, filtered to this run by the `bill_model_call` id scheme (`{run_id}:t{turn_index}:askreceipt`).
  - The Needs-Me item from `detect_pause(run_id)` — `ref_id` = the **real** `pending_approval_request` nonce. Reuses `NeedsMeItem`/`NeedsMeKind`/`NeedsMePriority` from `friday_providers::unified` (provider=Claude, kind=Approval, priority=High, status=AwaitingApproval).
- **Points at a REAL run** with a real `anthropic` ledger row + a real `pending_approval_request` — never a synthesized inbox entry. Independent of the ns-7 `FRIDAY_ACTIVITY_NEEDS_ME` persisted-activity flag (the Needs-Me item is computed from `detect_pause` at read time).

### Owner axis (deliberate deviation from the literal spec — flagged)
The owner axis is **`resolve_run_owner`** (the paused run's pending-row `principal_id`), **not** the literal C2-4/C2-5 `get_run_answer_for_principal` gate — a paused run has **no `run_result`** for that gate to key on, so the literal gate would deny every caller. Same owner concept, correct source for a paused run (the SAME source the owner-authed `reject`/`cancel` control ops gate on). Fail-closed identically: an empty caller / owner-less run / mismatch all read back `None`.

### NO-DEGRADE
Projection-only, read-only. **No model call, no new ledger row, no run-path change.** Owner-gated fail-closed. Class-2 read.

### Faithful dark proof (`runtime.rs` `c2_control`, reusing the C2-3 `paused_owned_claude_run` setup; no key/network)
A claude-pinned mutating turn bills exactly one anthropic row then Pauses on a real pending approval. Then:
- the owner's projection lists the `{RUN}:t0:askreceipt` **AskReceipt** ("tokens via {model}") AND a **Needs-Me item** (`ref_id` == the real `detect_pause` nonce, provider=claude, kind=approval, status=awaiting_approval, friday_session_id=run);
- a **different principal** reads back `None` (owner-gated fail-closed, no oracle);
- the projection writes **NO new ledger row** (byte-for-byte ledger snapshot via `assert_no_new_anthropic_row`).

### Local checks (in rust-core.yml order)
- `cargo fmt --all --check` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test -p friday-hub` — 609 lib tests pass, 0 failures (incl. `c2_9_activity_needs_me_surfaces_paused_claude_run_owner_scoped_no_new_ledger_row`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)