### PR TITLE
feat(ns-8): surface a MemoryReview Needs-Me item per post-run candidate (FRIDAY_MEMORY_REVIEW_NEEDS_ME, default-OFF)

### DIFF
--- a/rust-core/crates/friday-hub/src/memory_extraction.rs
+++ b/rust-core/crates/friday-hub/src/memory_extraction.rs
@@ -411,7 +411,7 @@ pub fn filter_sensitive(
 /// just a `memory_item` row). DEFAULT-OFF: unset / empty / `"0"` / any value other than the
 /// exact opt-in `"1"` ⇒ OFF, and the extraction is BYTE-IDENTICAL to the pre-NS-8 baseline
 /// (no [`memory_review_needs_me`] call, NO activity row, no extra query). It is read ONCE in
-/// the public [`extract_inline`] (the chokepoint every production caller — the bin — goes
+/// the public [`extract_inline`] (the chokepoint every production extraction caller — the bin — goes
 /// through) and threaded as a pure bool to [`extract_inline_flagged`] — the "split env-read
 /// from pure logic" idiom (mirroring NS-7's `activity_needs_me_from`), so the behavioral tests
 /// inject the bool directly and never race `std::env`.
@@ -522,6 +522,19 @@ pub fn extract_inline<T: Transport>(
 /// (`let _`): a surfacing/duplicate error can NEVER roll back the committed candidates nor
 /// flip the run outcome. When FALSE the surfacing block is skipped entirely and the path is
 /// byte-identical to the pre-NS-8 baseline.
+///
+/// ### Seam boundary (what this surfacing covers — and what it does NOT)
+/// This is the only production EXTRACTION `record_candidate` loop, so NS-8's surfacing is
+/// wired here and here only (the `runtime.rs` `record_candidate` sites are test-only
+/// `seed_confirmed` helpers, not a production extraction path). Two OTHER production-API
+/// candidate-creators exist — [`friday_storage::memory::edit_candidate`] and
+/// [`friday_storage::memory::repropose_from_rejected`] (the memory-confirmation
+/// edit / re-propose actions, `07` §6/§7) — but both are currently DORMANT: their ONLY
+/// callers are tests, they are NOT wired to any runtime handler, and so they are OUTSIDE
+/// NS-8's seam. When either action IS wired into a runtime handler, that wiring MUST ALSO
+/// surface the freshly-created candidate as a [`ActivityType::MemoryReview`] Needs-Me item
+/// (calling [`memory_review_activity_row`] / the same surfacing step), else those candidates
+/// will record but never appear on the operator's review surface.
 ///
 /// ## Slice-3 ownership-binding (the store SCOPE is DERIVED from the SESSION)
 /// There is NO caller-supplied principal: the store scope (`principal_id`) is DERIVED
@@ -1807,5 +1820,90 @@ mod tests {
             1,
             "re-surfacing the same candidate must not duplicate the row"
         );
+    }
+
+    #[test]
+    fn ns8_only_freshly_recorded_candidates_surface_not_prior_run_pending() {
+        // PINS NS-8's core anti-nagging faithfulness: a review item surfaces ONLY for the
+        // candidates THIS extraction freshly recorded — a still-PENDING candidate that already
+        // existed (e.g. recorded by an EARLIER run, with NO surfaced row) is NOT re-surfaced.
+        //
+        // This is the DISCRIMINATING construction (the task's "minimal faithful equivalent"):
+        // a 2nd extraction over the SAME already-extracted session is NOT discriminating —
+        // it early-returns at the empty-pending guard and never reaches the surfacing loop, so
+        // it can't distinguish "surfacing iterates only fresh ids" from a (forbidden) re-query
+        // of `pending_review()`. Instead we (a) pre-seed a PENDING candidate X with NO surfaced
+        // row, then (b) run a flag-ON extraction over FRESH pending messages whose provider
+        // returns ZERO items — so the surfacing loop IS reached (messages non-empty ⇒ no early
+        // return) but `fresh_candidate_ids` is empty (0 candidates recorded this run). The
+        // correct impl (surface only freshly-recorded ids) leaves X UN-surfaced; a `pending_
+        // review()` re-query mutation would WRONGLY surface the pre-existing pending X. So this
+        // assertion kills that mutation.
+        let mut db = friday_storage::Db::open_hub(&tmp("ns8-fresh-only")).unwrap();
+
+        // (a) A still-PENDING candidate from an earlier run — recorded directly via the spine,
+        // with NO accompanying memory_review activity row (it was never surfaced).
+        // `pending_review` is principal-agnostic, so the namespace here is arbitrary.
+        record_candidate(
+            db.conn(),
+            &NewMemoryCandidate {
+                memory_id: "prior-run:c0",
+                scope: MemoryScope::Session,
+                content_ref: None,
+                content: Some("a leftover pending candidate from a prior run"),
+                principal_id: Some("prior-run-principal"),
+                sensitive: false,
+                created_at: 50,
+            },
+        )
+        .unwrap();
+        assert_eq!(
+            pending_review(db.conn()).unwrap().len(),
+            1,
+            "the pre-existing candidate is pending"
+        );
+        assert_eq!(
+            memory_review_rows(&db).len(),
+            0,
+            "the pre-existing pending candidate has NO surfaced review row"
+        );
+
+        // (b) A flag-ON extraction over FRESH pending messages whose provider returns ZERO
+        // items: messages are non-empty (no early return ⇒ the surfacing loop RUNS), but the
+        // record loop records 0 candidates ⇒ `fresh_candidate_ids` is empty ⇒ the surfacing
+        // loop is a no-op. Uses the normal mock client (the provider IS called).
+        let _ids = seed_session(&db, "s1", "alice");
+        let c = client(json!({ "items": [] }).to_string());
+        let out = extract_inline_flagged(
+            &mut db,
+            "s1",
+            &c,
+            DEFAULT_MAX_ITEMS,
+            "s1:ex:100",
+            "led-1",
+            100,
+            true, // flag ON
+        )
+        .unwrap();
+        assert!(
+            out.messages_read >= 1,
+            "the surfacing loop is reached (messages non-empty)"
+        );
+        assert_eq!(
+            out.candidates_created, 0,
+            "this extraction freshly records ZERO candidates"
+        );
+
+        // The pre-existing pending candidate X must NOT be surfaced: only THIS run's freshly-
+        // recorded ids surface, and this run recorded none. A `pending_review()` re-query would
+        // wrongly surface X here (count would become 1) — so this pins the freshly-recorded-only
+        // property, not merely "a re-run adds no rows".
+        assert_eq!(
+            memory_review_rows(&db).len(),
+            0,
+            "a pre-existing pending candidate (not freshly recorded this run) is NOT surfaced"
+        );
+        // X is still pending (untouched by the surfacing step).
+        assert_eq!(pending_review(db.conn()).unwrap().len(), 1);
     }
 }

--- a/rust-core/crates/friday-hub/src/memory_extraction.rs
+++ b/rust-core/crates/friday-hub/src/memory_extraction.rs
@@ -94,14 +94,16 @@
 //! path STAYS LIVE (queue/auto parity pending; this flips NO TS-retirement state).
 //! PROOF-ONLY — NOT a v1 GO.
 
-use friday_core::MemoryScope;
+use friday_core::{
+    memory_review_needs_me, ActivityState, ActivityType, MemoryScope, MemoryState, NeedsMeItem,
+};
 use friday_deepseek::{DeepSeekClient, DeepSeekError, Transport};
 use friday_storage::agent_session::{
     load_pending_session_messages, load_session_owner, mark_messages_extracted,
     StoredSessionMessage,
 };
 use friday_storage::memory::{record_candidate, NewMemoryCandidate};
-use friday_storage::StorageError;
+use friday_storage::{ActivityRow, StorageError};
 use serde_json::Value;
 use std::collections::HashSet;
 
@@ -402,8 +404,100 @@ pub fn filter_sensitive(
     (safe, dropped)
 }
 
-/// Run one INLINE manual extraction for a session: derive namespace → read messages →
-/// prompt → provider call (ledgered) → parse → sensitivity-filter → persist candidates.
+/// The `FRIDAY_MEMORY_REVIEW_NEEDS_ME` env var (NS-8 — the memory-confirm loop closure).
+/// When ON, a post-run extraction that records a fresh `Candidate` ALSO surfaces ONE
+/// [`ActivityType::MemoryReview`] activity row per candidate on the operator's Needs-Me /
+/// review surface (so a freshly-recorded pending candidate becomes visible review work, not
+/// just a `memory_item` row). DEFAULT-OFF: unset / empty / `"0"` / any value other than the
+/// exact opt-in `"1"` ⇒ OFF, and the extraction is BYTE-IDENTICAL to the pre-NS-8 baseline
+/// (no [`memory_review_needs_me`] call, NO activity row, no extra query). It is read ONCE in
+/// the public [`extract_inline`] (the chokepoint every production caller — the bin — goes
+/// through) and threaded as a pure bool to [`extract_inline_flagged`] — the "split env-read
+/// from pure logic" idiom (mirroring NS-7's `activity_needs_me_from`), so the behavioral tests
+/// inject the bool directly and never race `std::env`.
+pub const FRIDAY_MEMORY_REVIEW_NEEDS_ME: &str = "FRIDAY_MEMORY_REVIEW_NEEDS_ME";
+
+/// Pure flag-matcher for [`FRIDAY_MEMORY_REVIEW_NEEDS_ME`] (env read split out so it is
+/// unit-testable without `set_var` — the env-race-free idiom this codebase uses). DEFAULT-OFF:
+/// `None` (unset) ⇒ false; ON ONLY for the exact opt-in value `"1"` (after trim); everything
+/// else (empty, `"0"`, `"true"`, any other token) ⇒ false.
+fn memory_review_needs_me_from(raw: Option<&str>) -> bool {
+    matches!(raw.map(str::trim), Some("1"))
+}
+
+/// Pure projection: turn a freshly-recorded candidate into the ONE [`ActivityRow`] that
+/// surfaces it on the operator's Needs-Me / Memory-Review surface — or `None` when it must
+/// NOT surface. The candidate's [`MemoryState`] is threaded through the proven producer
+/// [`memory_review_needs_me`]: a pending `Candidate` ⇒ `Some(NeedsMeItem)` ⇒ a `Pending`
+/// [`ActivityType::MemoryReview`] row; a terminal `Confirmed`/`Rejected` candidate ⇒ `None`
+/// (the decision is made — it never re-surfaces, the terminal-is-final invariant). The
+/// row carries the producer's content-free `reason` as the `summary` and its
+/// `destination` (`memory/{scope}/{id}`, a refs-only label — never candidate content) in
+/// BOTH the `summary` (so the [`Db::list_activity`] projection, which drops `deep_link`,
+/// surfaces it) and `deep_link`. The `activity_id` is keyed on the candidate's `memory_id`
+/// (`activity_item.activity_id` is the PRIMARY KEY), so re-surfacing the SAME candidate is a
+/// fail-closed duplicate insert (idempotent — no duplicate row; mirrors NS-7's nonce key).
+fn memory_review_activity_row(
+    memory_id: &str,
+    state: MemoryState,
+    scope: MemoryScope,
+    summary: &str,
+    now_ms: i64,
+) -> Option<ActivityRow> {
+    let NeedsMeItem {
+        reason,
+        destination,
+        ..
+    } = memory_review_needs_me(memory_id, state, scope, summary)?;
+    Some(ActivityRow {
+        activity_id: format!("memory-review-needs-me-{memory_id}"),
+        // The candidate's memory id is the binding ref (a safe id, not a body).
+        session_id: None,
+        kind: ActivityType::MemoryReview,
+        state: ActivityState::Pending,
+        // The projection drops `deep_link`, so the destination lives in the summary too.
+        summary: format!("{reason} ({destination})"),
+        created_at: now_ms,
+        updated_at: now_ms,
+        deep_link: Some(destination),
+    })
+}
+
+/// Run one INLINE manual extraction for a session (public entrypoint; signature UNCHANGED
+/// so every existing caller — the `hub_extract_memory` bin and the in-crate tests — is
+/// untouched). Reads the NS-8 [`FRIDAY_MEMORY_REVIEW_NEEDS_ME`] flag ONCE here (the only env
+/// read; semantics in [`memory_review_needs_me_from`]) and delegates to
+/// [`extract_inline_flagged`]. The flag is **default-OFF**: when off the extraction is
+/// BYTE-IDENTICAL to the pre-NS-8 baseline (no `memory_review_needs_me` call, NO activity
+/// row, no extra query).
+#[allow(clippy::too_many_arguments)]
+pub fn extract_inline<T: Transport>(
+    db: &mut friday_storage::Db,
+    session_id: &str,
+    client: &DeepSeekClient<T>,
+    max_items: usize,
+    candidate_id_prefix: &str,
+    ledger_id: &str,
+    now_ms: i64,
+) -> Result<ExtractionOutcome, ExtractionError> {
+    // Read the NS-8 flag ONCE here; the body is pure on the resulting bool.
+    let memory_review =
+        memory_review_needs_me_from(std::env::var(FRIDAY_MEMORY_REVIEW_NEEDS_ME).ok().as_deref());
+    extract_inline_flagged(
+        db,
+        session_id,
+        client,
+        max_items,
+        candidate_id_prefix,
+        ledger_id,
+        now_ms,
+        memory_review,
+    )
+}
+
+/// The flag-parameterized extraction body: derive namespace → read messages → prompt →
+/// provider call (ledgered) → parse → sensitivity-filter → persist candidates → (NS-8,
+/// flag-gated) surface each freshly-recorded candidate on the Needs-Me surface.
 ///
 /// `client` is generic over [`Transport`] so tests inject a mock provider and the
 /// bin passes a live `DeepSeekClient::from_env()`. The call+ledger reuses
@@ -415,6 +509,19 @@ pub fn filter_sensitive(
 /// `"<session>:extract:<now_ms>"`). Slice-2 makes re-runs IDEMPOTENT at the source:
 /// only PENDING messages are read, and a successful run marks the processed messages
 /// `'extracted'`, so a second run reads no pending and creates no duplicate candidates.
+///
+/// ## NS-8 — flag-gated Memory-Review Needs-Me surfacing ([`FRIDAY_MEMORY_REVIEW_NEEDS_ME`])
+/// `memory_review` is supplied by the public [`extract_inline`] (from the env flag) and
+/// injected directly by the NS-8 behavioral tests (so they never mutate `std::env`). When
+/// TRUE, AFTER the candidates commit, each candidate FRESHLY recorded by THIS extraction is
+/// projected through [`memory_review_activity_row`] (the proven [`memory_review_needs_me`]
+/// producer) and persisted as ONE `Pending` [`ActivityType::MemoryReview`] activity row, so a
+/// pending candidate becomes visible review work. ONLY this run's freshly-recorded candidate
+/// ids are surfaced (collected inside the record loop — never a re-query of pending
+/// candidates, which would re-surface earlier runs' items). The write is best-effort
+/// (`let _`): a surfacing/duplicate error can NEVER roll back the committed candidates nor
+/// flip the run outcome. When FALSE the surfacing block is skipped entirely and the path is
+/// byte-identical to the pre-NS-8 baseline.
 ///
 /// ## Slice-3 ownership-binding (the store SCOPE is DERIVED from the SESSION)
 /// There is NO caller-supplied principal: the store scope (`principal_id`) is DERIVED
@@ -428,7 +535,7 @@ pub fn filter_sensitive(
 /// TS `MEMORY_NAMESPACE_UNRESOLVABLE`. The derived namespace is echoed in
 /// [`ExtractionOutcome::derived_namespace`].
 #[allow(clippy::too_many_arguments)]
-pub fn extract_inline<T: Transport>(
+pub fn extract_inline_flagged<T: Transport>(
     db: &mut friday_storage::Db,
     session_id: &str,
     client: &DeepSeekClient<T>,
@@ -436,6 +543,7 @@ pub fn extract_inline<T: Transport>(
     candidate_id_prefix: &str,
     ledger_id: &str,
     now_ms: i64,
+    memory_review: bool,
 ) -> Result<ExtractionOutcome, ExtractionError> {
     if session_id.trim().is_empty() {
         return Err(ExtractionError::BadInput("session_id"));
@@ -528,6 +636,12 @@ pub fn extract_inline<T: Transport>(
         .unchecked_transaction()
         .map_err(StorageError::from)?;
     let mut candidates_created = 0usize;
+    // NS-8: capture EXACTLY the candidate ids this extraction freshly records (the `Some`
+    // set surfaced below). Built INSIDE the record loop — never a re-query of pending
+    // candidates afterward, which could include earlier runs' pending items the task
+    // forbids re-surfacing. Each carries the candidate's `kind` (a fixed VALID_KINDS token,
+    // never content/PII) as the content-free card label. Empty + cheap when the flag is OFF.
+    let mut fresh_candidate_ids: Vec<(String, String)> = Vec::new();
     for (i, item) in safe_items.iter().enumerate() {
         let memory_id = format!("{candidate_id_prefix}:c{i}");
         record_candidate(
@@ -549,9 +663,34 @@ pub fn extract_inline<T: Transport>(
             },
         )?;
         candidates_created += 1;
+        if memory_review {
+            fresh_candidate_ids.push((memory_id, item.kind.clone()));
+        }
     }
     let messages_marked_extracted = mark_messages_extracted(&tx, &message_ids)?;
     tx.commit().map_err(StorageError::from)?;
+
+    // NS-8 (flag-gated, default-OFF): AFTER the candidates are durably committed, surface
+    // each freshly-recorded candidate as ONE Needs-Me / Memory-Review activity row. Each
+    // candidate was just written by `record_candidate` as `state = Candidate` (always — it
+    // has no other state), so it is threaded as `MemoryState::Candidate` through the proven
+    // `memory_review_needs_me` producer (terminal states yield `None`; that branch is
+    // exercised by the unit test, not reachable here by construction). Best-effort
+    // (`let _`): a duplicate insert (same candidate re-surfaced) or any activity-write error
+    // can NEVER roll back the committed candidates nor flip the run outcome — the candidates
+    // already persisted. When `memory_review` is FALSE this loop is empty and skipped, so the
+    // path is byte-identical to the pre-NS-8 baseline.
+    for (memory_id, label) in &fresh_candidate_ids {
+        if let Some(row) = memory_review_activity_row(
+            memory_id,
+            MemoryState::Candidate,
+            MemoryScope::Session,
+            label,
+            now_ms,
+        ) {
+            let _ = db.insert_activity(&row);
+        }
+    }
 
     Ok(ExtractionOutcome {
         messages_read,
@@ -1455,5 +1594,218 @@ mod tests {
             parse_items("{\"no_items_key\":true}", &valid),
             Err(ExtractionError::Parse)
         ));
+    }
+
+    // ── NS-8: surface a Memory-Review Needs-Me item per freshly-recorded candidate ──────
+    // (FRIDAY_MEMORY_REVIEW_NEEDS_ME, default-OFF). The flag bool is INJECTED into
+    // `extract_inline_flagged` directly so the tests never mutate `std::env` (no in-process
+    // race) — the codebase's split-env-read-from-pure-logic idiom (mirrors NS-7).
+
+    /// The `memory_review` activity rows on the surface, via the same `list_activity`
+    /// projection the operator's Needs-Me surface reads (drops `deep_link`/`session_id`).
+    fn memory_review_rows(db: &friday_storage::Db) -> Vec<friday_storage::ActivitySummary> {
+        db.list_activity()
+            .unwrap()
+            .into_iter()
+            .filter(|a| a.kind == ActivityType::MemoryReview.as_str())
+            .collect()
+    }
+
+    #[test]
+    fn ns8_pure_flag_matcher_is_default_off_and_only_exact_one_enables() {
+        assert!(
+            !memory_review_needs_me_from(None),
+            "unset ⇒ OFF (prod default)"
+        );
+        assert!(!memory_review_needs_me_from(Some("")), "empty ⇒ OFF");
+        assert!(!memory_review_needs_me_from(Some("0")), "0 ⇒ OFF");
+        assert!(!memory_review_needs_me_from(Some("off")), "off ⇒ OFF");
+        assert!(
+            !memory_review_needs_me_from(Some("true")),
+            "true ⇒ OFF (exact-1 only)"
+        );
+        assert!(memory_review_needs_me_from(Some("1")), "1 ⇒ ON");
+        assert!(memory_review_needs_me_from(Some("  1  ")), "trimmed 1 ⇒ ON");
+    }
+
+    #[test]
+    fn ns8_pure_row_builder_surfaces_candidate_and_skips_terminal() {
+        // A pending Candidate ⇒ ONE Pending memory_review row whose summary + deep_link carry
+        // the refs-only destination `memory/{scope}/{id}` (the `list_activity` projection
+        // drops `deep_link`, so the destination must also be in the summary).
+        let row = memory_review_activity_row(
+            "s1:ex:100:c0",
+            MemoryState::Candidate,
+            MemoryScope::Session,
+            "preference",
+            100,
+        )
+        .expect("a pending candidate surfaces");
+        assert_eq!(row.activity_id, "memory-review-needs-me-s1:ex:100:c0");
+        assert_eq!(row.kind.as_str(), "memory_review");
+        assert_eq!(row.state.as_str(), "pending");
+        assert_eq!(
+            row.deep_link.as_deref(),
+            Some("memory/session/s1:ex:100:c0")
+        );
+        assert!(
+            row.summary.contains("memory/session/s1:ex:100:c0"),
+            "destination must be in the (projection-surfaced) summary: {}",
+            row.summary
+        );
+        // TERMINAL candidate ⇒ None ⇒ never surfaced (terminal-is-final; producer's branch).
+        assert!(
+            memory_review_activity_row(
+                "s1:ex:100:c0",
+                MemoryState::Confirmed,
+                MemoryScope::Session,
+                "preference",
+                100,
+            )
+            .is_none(),
+            "a confirmed (terminal) candidate must NOT surface"
+        );
+        assert!(memory_review_activity_row(
+            "s1:ex:100:c0",
+            MemoryState::Rejected,
+            MemoryScope::Session,
+            "preference",
+            100,
+        )
+        .is_none());
+    }
+
+    #[test]
+    fn ns8_flag_on_surfaces_one_memory_review_row_per_fresh_candidate() {
+        let mut db = friday_storage::Db::open_hub(&tmp("ns8-on")).unwrap();
+        let ids = seed_session(&db, "s1", "alice");
+        let content = json!({
+            "items": [{
+                "kind": "preference",
+                "content": "User's project codename is Falcon.",
+                "sourceMessageIds": [ids[0]],
+                "tags": ["naming"]
+            }]
+        })
+        .to_string();
+        let c = client(content);
+
+        let out = extract_inline_flagged(
+            &mut db,
+            "s1",
+            &c,
+            DEFAULT_MAX_ITEMS,
+            "s1:ex:100",
+            "led-1",
+            100,
+            true, // flag ON
+        )
+        .unwrap();
+        assert_eq!(out.candidates_created, 1);
+
+        // EXACTLY one memory_review row, Pending, tied to THIS candidate via its destination
+        // `memory/{scope}/{id}` (scope = session; id = the freshly-minted candidate id).
+        let rows = memory_review_rows(&db);
+        assert_eq!(rows.len(), 1, "one row per freshly-recorded candidate");
+        assert_eq!(rows[0].activity_id, "memory-review-needs-me-s1:ex:100:c0");
+        assert_eq!(rows[0].state, "pending");
+        assert!(
+            rows[0].summary.contains("memory/session/s1:ex:100:c0"),
+            "row references the candidate's destination: {}",
+            rows[0].summary
+        );
+        // The candidate content must NEVER leak into the surfaced summary (PII-safe label).
+        assert!(
+            !rows[0].summary.contains("Falcon"),
+            "candidate content must not leak into the Needs-Me card: {}",
+            rows[0].summary
+        );
+    }
+
+    #[test]
+    fn ns8_flag_on_terminal_candidate_is_not_surfaced() {
+        // Drive the surfacing projection with a TERMINAL state directly (the proven producer
+        // returns None) — the honest exercise of terminal-is-final. `extract_inline` only ever
+        // freshly records `Candidate`s, so a terminal candidate cannot arise in that loop; the
+        // skip lives in `memory_review_activity_row` and is verified here end-to-end on the DB.
+        let db = friday_storage::Db::open_hub(&tmp("ns8-terminal")).unwrap();
+        for state in [MemoryState::Confirmed, MemoryState::Rejected] {
+            if let Some(row) =
+                memory_review_activity_row("m-terminal", state, MemoryScope::Session, "fact", 10)
+            {
+                db.insert_activity(&row).unwrap();
+            }
+        }
+        assert!(
+            memory_review_rows(&db).is_empty(),
+            "a terminal candidate yields no memory_review row"
+        );
+    }
+
+    #[test]
+    fn ns8_flag_off_is_byte_identical_no_review_row() {
+        let mut db = friday_storage::Db::open_hub(&tmp("ns8-off")).unwrap();
+        let ids = seed_session(&db, "s1", "alice");
+        let content = json!({
+            "items": [{
+                "kind": "preference",
+                "content": "User's project codename is Falcon.",
+                "sourceMessageIds": [ids[0]]
+            }]
+        })
+        .to_string();
+        let c = client(content);
+
+        let before = db.list_activity().unwrap();
+        let out = extract_inline_flagged(
+            &mut db,
+            "s1",
+            &c,
+            DEFAULT_MAX_ITEMS,
+            "s1:ex:100",
+            "led-1",
+            100,
+            false, // flag OFF (default)
+        )
+        .unwrap();
+        // The candidate still records exactly as today — the flag governs ONLY surfacing.
+        assert_eq!(out.candidates_created, 1);
+        assert_eq!(pending_review(db.conn()).unwrap().len(), 1);
+        // No memory_review row, and the activity surface is unchanged (byte-identical).
+        assert!(
+            memory_review_rows(&db).is_empty(),
+            "flag OFF ⇒ no review row"
+        );
+        assert_eq!(
+            db.list_activity().unwrap(),
+            before,
+            "flag OFF ⇒ activity surface byte-identical"
+        );
+    }
+
+    #[test]
+    fn ns8_re_surfacing_same_candidate_is_idempotent_one_row() {
+        // The activity_id is keyed on the candidate's memory_id (the PRIMARY KEY), so a
+        // second insert of the SAME candidate's row is a fail-closed duplicate — swallowed by
+        // the best-effort `let _` in the surfacing step, leaving exactly one row. `extract_inline`
+        // cannot naturally re-surface a candidate (unique `now_ms` prefix + message dedup), so
+        // this drives the insert path directly.
+        let db = friday_storage::Db::open_hub(&tmp("ns8-dedup")).unwrap();
+        let row = memory_review_activity_row(
+            "s1:ex:100:c0",
+            MemoryState::Candidate,
+            MemoryScope::Session,
+            "preference",
+            100,
+        )
+        .unwrap();
+        db.insert_activity(&row).unwrap();
+        // Re-surface the SAME candidate: best-effort swallow of the duplicate-PK error.
+        let _ = db.insert_activity(&row);
+        assert_eq!(
+            memory_review_rows(&db).len(),
+            1,
+            "re-surfacing the same candidate must not duplicate the row"
+        );
     }
 }


### PR DESCRIPTION
## NS-8 — close the memory-confirm loop (DARK, flag-gated, default-OFF)

The producer `friday_core::memory_review_needs_me` + `ActivityType::MemoryReview` were DARK: `memory_extraction.rs` recorded candidates (`record_candidate`, `state = Candidate`) but NOTHING turned a freshly-recorded pending candidate into a SURFACED Needs-Me item on the operator's review surface. NS-8 wires that last step behind a NEW env flag `FRIDAY_MEMORY_REVIEW_NEEDS_ME` (**DEFAULT-OFF**).

### Seam chosen + why faithful
`friday_hub::memory_extraction::extract_inline` is the **only production EXTRACTION `record_candidate` loop** — both `runtime.rs` `record_candidate` sites (4530, 5298) are inside `#[cfg(test)] mod tests` (`seed_confirmed` helpers), not a production extraction path. So the wiring lives entirely in `memory_extraction.rs`; **lib.rs and runtime.rs are NOT touched**. This is the faithful post-run extraction seam: it owns the extract → record loop and can enumerate exactly the candidates THIS extraction just recorded.

**Seam boundary (dormant candidate-creators out of scope).** Two OTHER production-API candidate-creators exist — `friday_storage::memory::edit_candidate` and `repropose_from_rejected` (the memory-confirmation edit / re-propose actions, `07` §6/§7) — but both are currently **DORMANT**: their ONLY callers are tests (`crates/friday-storage/tests/memory_persist.rs`), they are NOT wired to any runtime handler, and so they are **outside NS-8's seam**. When either action IS wired into a runtime handler, that wiring **must also** surface the freshly-created candidate as a `MemoryReview` Needs-Me item (call `memory_review_activity_row` / the same surfacing step), else those candidates will record but never appear on the operator's review surface. This boundary is now documented as a doc comment on `extract_inline_flagged` (the seam).

### Flag (default-OFF; flag-OFF byte-identical)
- New: `pub const FRIDAY_MEMORY_REVIEW_NEEDS_ME` + pure matcher `fn memory_review_needs_me_from(raw: Option<&str>) -> bool` — DEFAULT-OFF, ON **only for the exact opt-in `"1"`** (after trim), per the NS-8 spec.
- The public `extract_inline` **keeps its signature** (no live-caller break: the `hub_extract_memory` bin + every in-crate test compile untouched), reads the flag ONCE via the matcher (the NS-7 "split env-read from pure logic" idiom, mirroring `activity_needs_me_from`), and delegates to a new `pub fn extract_inline_flagged(..., memory_review: bool)`.
- **Flag OFF:** the surfacing loop is empty/skipped — no `memory_review_needs_me` call, NO activity row, no extra query — BYTE-IDENTICAL to the pre-NS-8 baseline (asserted: `list_activity` unchanged before/after).

### How only freshly-recorded candidates are enumerated
The candidate ids are collected **inside the existing `record_candidate` loop** (`fresh_candidate_ids`), not via a post-hoc re-query of pending candidates (which would re-surface earlier runs' pending items the task forbids). Dedup-via-extraction-status already guarantees each extraction records only NEW candidates, so the collected set is exactly this run's fresh candidates.

### Terminal-not-surfaced
Each candidate's `MemoryState` is threaded through the proven `memory_review_needs_me` producer: a pending `Candidate` ⇒ `Some(NeedsMeItem)` ⇒ a `Pending` `MemoryReview` row; a terminal `Confirmed`/`Rejected` ⇒ `None` ⇒ never surfaced (no nagging on a resolved item). `record_candidate` only ever writes `Candidate`, so a terminal candidate cannot arise in the loop by construction — the skip branch is exercised end-to-end by the terminal test + the pure row-builder test.

### Dedup approach
`activity_id = "memory-review-needs-me-{memory_id}"` and `activity_item.activity_id` is the PRIMARY KEY (verified in `schema.rs`), so re-surfacing the same candidate is a fail-closed duplicate insert — swallowed by the best-effort `let _` surface step, leaving exactly one row (mirrors NS-7's nonce key). The surface step runs **after `tx.commit()`** and is best-effort: a surfacing/duplicate error can never roll back the committed candidates nor flip the run outcome; it spends no model call and never blocks the run.

The destination `memory/{scope}/{id}` lives in BOTH the `summary` (the `list_activity` projection drops `deep_link`) and `deep_link`. The card label is the candidate's `kind` token (fixed `VALID_KINDS`, never content) — `item.content` (unredacted non-keyword PII) is never surfaced.

### Dark discipline
- Flag NET-NEW (grep-confirmed unused), default-OFF, no fake/fallback/degrade.
- No lib.rs / runtime.rs change. No live-caller public-signature change (`extract_inline` unchanged; `extract_inline_flagged` is new).
- Proven producer `memory_review_needs_me` and `record_candidate` only CALLED, never modified.
- Diff: 1 file (`memory_extraction.rs`) — the original feature (+357 / -5) plus the integrity-closure follow-up (+99 / -1: the freshly-recorded-only test + the seam-boundary doc note).

### Tests (real DB, no network, no key; bool injected directly — never `std::env`)
- `ns8_flag_on_surfaces_one_memory_review_row_per_fresh_candidate` — ON ⇒ exactly one `memory_review` Pending row tied to the candidate (destination `memory/session/{id}`), content not leaked.
- `ns8_flag_on_terminal_candidate_is_not_surfaced` — terminal ⇒ no row.
- `ns8_flag_off_is_byte_identical_no_review_row` — OFF ⇒ `list_activity` byte-identical.
- `ns8_re_surfacing_same_candidate_is_idempotent_one_row` — same candidate twice ⇒ one row.
- `ns8_only_freshly_recorded_candidates_surface_not_prior_run_pending` — **pins the freshly-recorded-only / anti-nagging property** with a DISCRIMINATING construction: pre-seed a still-PENDING candidate X with NO surfaced row, then run a flag-ON extraction over FRESH pending messages whose provider returns ZERO items — so the surfacing loop IS reached (messages non-empty ⇒ no early return) but records 0 fresh candidates. Assert X is NOT surfaced (0 `memory_review` rows). This **fails under a `pending_review()` re-query mutation** (verified locally) and passes only when surfacing iterates THIS run's freshly-recorded ids. (A plain 2nd-extraction-over-the-same-session is non-discriminating — it early-returns at the empty-pending guard and never reaches the surfacing loop.)
- `ns8_pure_flag_matcher_is_default_off_and_only_exact_one_enables` + `ns8_pure_row_builder_surfaces_candidate_and_skips_terminal` — pure unit tests.

### Local CI gate (rust-core.yml order, all green)
- `cargo fmt --all -- --check` ✅
- `cargo clippy --workspace --all-targets -- -D warnings` ✅ (exit 0)
- `cargo build -p friday-hub` ✅
- `cargo test -p friday-hub` ✅ (621 lib + all integration suites; all 7 NS-8 tests pass)
- `cargo test --workspace` ✅ (exit 0, 0 failed)

### Adversarial-review integrity closure (behavior unchanged)
A review passed NS-8 SAFE-TO-MERGE and surfaced two integrity items, both now closed in `511b8cf7` (touches ONLY `memory_extraction.rs`; no behavior change beyond +1 test):
1. **Pinned the freshly-recorded-only property** with `ns8_only_freshly_recorded_candidates_surface_not_prior_run_pending` (above) — the core anti-nagging claim previously had no shipped test. The test is mutation-verified: it FAILS under a `pending_review()` re-query of pending candidates and passes only for the correct fresh-ids-only surfacing.
2. **Corrected the seam doc** so it no longer reads as "the only production `record_candidate` loop": it is the only production **EXTRACTION** loop, and the dormant `edit_candidate` / `repropose_from_rejected` candidate-creators (test-only callers, not wired) are documented as out-of-seam with the must-also-surface requirement when wired.
