### PR TITLE
chore: standardize FRIDAY_MISSION_BOUND_RUN/MISSION_INTAKE/ACTIVITY_NEEDS_ME flag matchers to exact "1"

### DIFF
--- a/rust-core/crates/friday-hub/src/bin/hub_agent_run_server.rs
+++ b/rust-core/crates/friday-hub/src/bin/hub_agent_run_server.rs
@@ -445,7 +445,7 @@ fn agent_run_control_enabled_from(raw: Option<&str>) -> bool {
 /// (NS-4) The env flag that gates the MISSION-BOUND run seam. DEFAULT-OFF: a run is dispatched
 /// through the Mission-bound entry ([`friday_hub::run_authed_agent_loop_mission_bound`] — which
 /// mints the mission-birth + WorkItem bind) ONLY when `FRIDAY_MISSION_BOUND_RUN` is exactly
-/// `"1"`/`"true"` (case-insensitive). Unset — or any other value — leaves the seam DARK: every
+/// `"1"` (after trim). Unset — or any other value — leaves the seam DARK: every
 /// run takes the EXISTING unbound dispatch (`run_authed_agent_loop_with_policy` /
 /// `run_session_task_with_overrides`), BYTE-IDENTICAL to today, so deploying this binary changes
 /// NO live behavior until the operator flips this SEPARATE flag. Even with the flag ON, a run is
@@ -457,21 +457,18 @@ const MISSION_BOUND_RUN_ENABLED_ENV: &str = "FRIDAY_MISSION_BOUND_RUN";
 
 /// Pure flag-matcher for [`MISSION_BOUND_RUN_ENABLED_ENV`] (separated from the env read so it is
 /// testable without mutating the process-global environment). DEFAULT-OFF: `None` (unset) ⇒
-/// false; only the exact opt-in values `"1"`/`"true"` (case-insensitive, trimmed) ⇒ true;
-/// everything else ⇒ false.
+/// false; ON only for the exact opt-in value `"1"` (trimmed), matching the program's standard
+/// flag idiom; everything else (including `"true"`) ⇒ false.
 fn mission_bound_run_enabled_from(raw: Option<&str>) -> bool {
-    matches!(
-        raw.map(|v| v.trim().to_ascii_lowercase()).as_deref(),
-        Some("1") | Some("true")
-    )
+    matches!(raw.map(str::trim), Some("1"))
 }
 
 /// (NS-5) The env flag that gates the MISSION-INTAKE ingress arm. DEFAULT-OFF: an inbound
 /// [`Message::MissionIntakeRequest`] is HANDLED (birthing a Mission + WorkItem(Draft) +
 /// SurfaceThread + route_decision via the existing
 /// [`friday_hub::hub_server::mission_intake_result_for_db`] and replying with a
-/// [`Message::MissionIntakeResult`]) ONLY when `FRIDAY_MISSION_INTAKE` is exactly `"1"`/`"true"`
-/// (case-insensitive, trimmed). Unset — or any other value — leaves the arm DARK: the
+/// [`Message::MissionIntakeResult`]) ONLY when `FRIDAY_MISSION_INTAKE` is exactly `"1"`
+/// (after trim). Unset — or any other value — leaves the arm DARK: the
 /// `MissionIntakeRequest` falls through to the EXISTING catch-all keepalive echo, BYTE-IDENTICAL to
 /// today (the server has never had a MissionIntakeRequest arm, so the live behavior on this message
 /// is the benign echo), so deploying this binary changes NO live behavior until the operator flips
@@ -483,13 +480,10 @@ const MISSION_INTAKE_ENABLED_ENV: &str = "FRIDAY_MISSION_INTAKE";
 
 /// Pure flag-matcher for [`MISSION_INTAKE_ENABLED_ENV`] (separated from the env read so it is
 /// testable without mutating the process-global environment). DEFAULT-OFF: `None` (unset) ⇒
-/// false; only the exact opt-in values `"1"`/`"true"` (case-insensitive, trimmed) ⇒ true;
-/// everything else ⇒ false.
+/// false; ON only for the exact opt-in value `"1"` (trimmed), matching the program's standard
+/// flag idiom; everything else (including `"true"`) ⇒ false.
 fn mission_intake_enabled_from(raw: Option<&str>) -> bool {
-    matches!(
-        raw.map(|v| v.trim().to_ascii_lowercase()).as_deref(),
-        Some("1") | Some("true")
-    )
+    matches!(raw.map(str::trim), Some("1"))
 }
 
 /// Whether the operator has explicitly enabled the session-lifecycle reaper. Fail-closed:
@@ -1919,12 +1913,12 @@ mod tests {
         );
         assert!(mission_bound_run_enabled_from(Some("1")), "1 ⇒ enabled");
         assert!(
-            mission_bound_run_enabled_from(Some("true")),
-            "true ⇒ enabled"
+            !mission_bound_run_enabled_from(Some("true")),
+            "true ⇒ disabled (only exact 1)"
         );
         assert!(
-            mission_bound_run_enabled_from(Some("  TRUE  ")),
-            "padded TRUE ⇒ enabled"
+            !mission_bound_run_enabled_from(Some("  TRUE  ")),
+            "padded TRUE ⇒ disabled (only exact 1)"
         );
     }
 
@@ -1948,10 +1942,13 @@ mod tests {
             "garbage ⇒ disabled"
         );
         assert!(mission_intake_enabled_from(Some("1")), "1 ⇒ enabled");
-        assert!(mission_intake_enabled_from(Some("true")), "true ⇒ enabled");
         assert!(
-            mission_intake_enabled_from(Some("  TRUE  ")),
-            "padded TRUE ⇒ enabled"
+            !mission_intake_enabled_from(Some("true")),
+            "true ⇒ disabled (only exact 1)"
+        );
+        assert!(
+            !mission_intake_enabled_from(Some("  TRUE  ")),
+            "padded TRUE ⇒ disabled (only exact 1)"
         );
     }
 

--- a/rust-core/crates/friday-hub/src/lib.rs
+++ b/rust-core/crates/friday-hub/src/lib.rs
@@ -2924,13 +2924,10 @@ pub const FRIDAY_ACTIVITY_NEEDS_ME: &str = "FRIDAY_ACTIVITY_NEEDS_ME";
 
 /// Pure flag-matcher for [`FRIDAY_ACTIVITY_NEEDS_ME`] (env read split out so it is unit-
 /// testable without `set_var` — the env-race-free idiom this codebase uses everywhere).
-/// DEFAULT-OFF: `None` (unset) ⇒ false; only the exact opt-in values `"1"`/`"true"`
-/// (case-insensitive, trimmed) ⇒ true; everything else ⇒ false.
+/// DEFAULT-OFF: `None` (unset) ⇒ false; ON only for the exact opt-in value `"1"` (trimmed),
+/// matching the program's standard flag idiom; everything else (including `"true"`) ⇒ false.
 fn activity_needs_me_from(raw: Option<&str>) -> bool {
-    matches!(
-        raw.map(|v| v.trim().to_ascii_lowercase()).as_deref(),
-        Some("1") | Some("true")
-    )
+    matches!(raw.map(str::trim), Some("1"))
 }
 
 /// `cancel` (C2-1) is an OPTIONAL cooperative cancellation handle checked at the TOP of
@@ -4271,17 +4268,20 @@ mod tests {
 
     #[test]
     fn ns7_activity_needs_me_from_only_opt_in_enables() {
-        // The ONLY env-parse glue (the behavioral test bypasses env). Default-OFF; only the
-        // exact opt-in values `"1"`/`"true"` (case-insensitive, trimmed) enable.
+        // The ONLY env-parse glue (the behavioral test bypasses env). Default-OFF; ON only for
+        // the exact opt-in value `"1"` (trimmed) — the program's standard flag idiom.
         assert!(!activity_needs_me_from(None), "unset ⇒ OFF (prod default)");
         assert!(!activity_needs_me_from(Some("")), "empty ⇒ OFF");
         assert!(!activity_needs_me_from(Some("0")), "0 ⇒ OFF");
         assert!(!activity_needs_me_from(Some("off")), "off ⇒ OFF");
         assert!(activity_needs_me_from(Some("1")), "1 ⇒ ON");
-        assert!(activity_needs_me_from(Some("true")), "true ⇒ ON");
         assert!(
-            activity_needs_me_from(Some("  TRUE  ")),
-            "whitespace-padded TRUE ⇒ ON (trimmed, case-insensitive)"
+            !activity_needs_me_from(Some("true")),
+            "true ⇒ OFF (only exact 1)"
+        );
+        assert!(
+            !activity_needs_me_from(Some("  TRUE  ")),
+            "padded TRUE ⇒ OFF (only exact 1)"
         );
     }
 


### PR DESCRIPTION
Three default-OFF env-flag matchers accepted BOTH `"1"` and `"true"` (case-insensitively), while every other flag in the dark-build program accepts ONLY the exact `"1"` after trim (e.g. `passport_mint_from`, `codex_route_enabled_from_env`, `memory_review_needs_me_from`). This PR standardizes the three outliers to the program-standard exact-`"1"` idiom — for **consistency** with the rest of the flags and a **slightly stricter opt-in**.

Each matcher becomes `matches!(raw.map(str::trim), Some("1"))`: trim only, NO `to_ascii_lowercase`, accept ONLY `"1"`.

### Behavior
**DEFAULT-OFF semantics are UNCHANGED**: unset / empty / `"0"` / anything-else ⇒ `false`. The only behavioral delta is that `"true"` / `"TRUE"` / case-padded variants no longer enable the flag — only exactly `"1"` (after trim) does.

### Sites changed (3)
- `activity_needs_me_from` (`FRIDAY_ACTIVITY_NEEDS_ME`) — `rust-core/crates/friday-hub/src/lib.rs:2929`
- `mission_bound_run_enabled_from` (`FRIDAY_MISSION_BOUND_RUN`) — `rust-core/crates/friday-hub/src/bin/hub_agent_run_server.rs:462`
- `mission_intake_enabled_from` (`FRIDAY_MISSION_INTAKE`) — `rust-core/crates/friday-hub/src/bin/hub_agent_run_server.rs:488`

Each matcher’s doc-comment is updated from `"1"/"true" (case-insensitive)` to "exactly `1`" — dropping `to_ascii_lowercase` makes the flag case-sensitive, so the prior "case-insensitive" wording was no longer accurate.

### Tests updated (3 pure-matcher unit tests)
The `"true"` and `"  TRUE  "` cases flip from assert-true to assert-false; the `"1"` ⇒ true case is kept:
- `ns7_activity_needs_me_from_only_opt_in_enables` (lib.rs)
- `mission_bound_run_flag_is_default_off_and_fail_closed` (hub_agent_run_server.rs)
- `mission_intake_flag_is_default_off_and_fail_closed` (hub_agent_run_server.rs)

### Out of scope (intentionally not touched)
`reaper_enabled_from` and `agent_run_control_enabled_from` share the old `"1"`/`"true"` idiom but are deliberately left unchanged.

### Gate (rust-core, in order)
`cargo fmt --all -- --check` · `cargo clippy --workspace --all-targets -- -D warnings` · `cargo build -p friday-hub` · `cargo test -p friday-hub` — all green (621 lib tests + all integration bins, 0 failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)