### PR TITLE
fix(c2i-pr1): M-3 owner-gate project_run_readback + authenticate_read_request returns verified principal

### DIFF
--- a/rust-core/crates/friday-hub/src/bin/hub_read_projection_server.rs
+++ b/rust-core/crates/friday-hub/src/bin/hub_read_projection_server.rs
@@ -302,14 +302,19 @@ fn serve_read_session<S: Read + Write>(
         // across all three arms by construction (the substrate's whole reason for existing).
         let response = match env.message {
             Message::WorkbenchProjectionRequest { request } => {
-                if !authenticate_read_request(
+                // Auth-before-read. The workbench projection has NO per-run owner scope (it gates on
+                // `mission_id`), so we only need the pass/fail — the verified principal is not
+                // re-applied here. `None` ⇒ fail closed, END the session.
+                if authenticate_read_request(
                     session_key,
                     session_nonce,
                     &request.auth_proof,
                     &request.forwarded_principal,
                     &request.request_id,
                     owner_allowlist,
-                ) {
+                )
+                .is_none()
+                {
                     return Ok(processed);
                 }
                 let request_id = request.request_id.clone();
@@ -329,7 +334,10 @@ fn serve_read_session<S: Read + Write>(
                 )?
             }
             Message::RunReadbackRequest { request } => {
-                if !authenticate_read_request(
+                // Auth-before-read. The run-readback projection IS per-run owner-scoped (M-3), so we
+                // bind the VERIFIED `AuthedPrincipal` and scope the read on it — NEVER the raw wire
+                // `forwarded_principal`. `None` ⇒ fail closed, END the session.
+                let caller = match authenticate_read_request(
                     session_key,
                     session_nonce,
                     &request.auth_proof,
@@ -337,15 +345,27 @@ fn serve_read_session<S: Read + Write>(
                     &request.request_id,
                     owner_allowlist,
                 ) {
-                    return Ok(processed);
-                }
+                    Some(caller) => caller,
+                    None => return Ok(processed),
+                };
                 let request_id = request.request_id.clone();
+                // M-3 owner gate: `project_run_readback` returns `Ok(None)` when the verified caller
+                // is NOT the run's bound owner (or the run is absent/owner-less). Map that `Ok(None)`
+                // to the SAME `run_not_found` typed error a non-existent run produced before the
+                // gate, so not-owner is INDISTINGUISHABLE from unknown-run on the wire (no oracle)
+                // and the prior unknown-run frame is byte-identical in OUTCOME.
+                let projection = match project_run_readback(db, caller.principal(), &request.run_id)
+                {
+                    Ok(Some(value)) => Ok(value),
+                    Ok(None) => Err("run_not_found".to_string()),
+                    Err(reason) => Err(reason),
+                };
                 seal_and_frame(
                     session_key,
                     &env.msg_id,
                     &request_id,
                     now_ms,
-                    project_run_readback(db, &request.run_id),
+                    projection,
                     |sealed_hex| Message::RunReadbackSnapshot {
                         snapshot: RunReadbackSnapshotWire {
                             request_id: request_id.clone(),
@@ -356,14 +376,19 @@ fn serve_read_session<S: Read + Write>(
                 )?
             }
             Message::ProvidersDoctorRequest { request } => {
-                if !authenticate_read_request(
+                // Auth-before-read (auth runs BEFORE the provider CLIs are ever probed). The
+                // providers-doctor is NOT a per-run/DB read and has no owner scope, so we only need
+                // the pass/fail. `None` ⇒ fail closed, END the session.
+                if authenticate_read_request(
                     session_key,
                     session_nonce,
                     &request.auth_proof,
                     &request.forwarded_principal,
                     &request.request_id,
                     owner_allowlist,
-                ) {
+                )
+                .is_none()
+                {
                     return Ok(processed);
                 }
                 let request_id = request.request_id.clone();
@@ -409,8 +434,11 @@ fn serve_read_session<S: Read + Write>(
 
 /// Shared AUTH gate for every read arm. Verifies the forwarded principal against the sealed session
 /// (possession-of-session + per-handshake nonce + owner-allowlist), with the proof bound to THIS
-/// request's `request_id` (the read analog of `run_id`) + principal. Returns `true` iff the caller
-/// is the bound AUTHENTICATED owner; `false` (forged / empty / non-allowlisted principal, or an
+/// request's `request_id` (the read analog of `run_id`) + principal. Returns
+/// `Some(AuthedPrincipal)` iff the caller is the bound AUTHENTICATED owner — the VERIFIED principal
+/// minted ONLY from [`AuthedPrincipal::authenticate_forwarded`] (NEVER the raw wire
+/// `forwarded_principal` string). Each arm scopes its read on THIS authenticated principal, never on
+/// the client-asserted wire string. `None` (forged / empty / non-allowlisted principal, or an
 /// un-openable proof) means the caller MUST fail closed and END the session — never a partial
 /// release. Factored so the three arms share ONE auth path that cannot drift.
 fn authenticate_read_request(
@@ -420,7 +448,7 @@ fn authenticate_read_request(
     forwarded_principal: &str,
     request_id: &str,
     owner_allowlist: &[String],
-) -> bool {
+) -> Option<AuthedPrincipal> {
     let caller = decode_sealed_proof(auth_proof).and_then(|proof| {
         AuthedPrincipal::authenticate_forwarded(
             session_key,
@@ -440,7 +468,7 @@ fn authenticate_read_request(
             "hub_read_projection_server_read: request_id={request_id} leg=auth_failed (session ended)"
         );
     }
-    caller.is_some()
+    caller
 }
 
 /// Shared OWNER-SEAL + framing for every read arm (auth already passed). Takes the arm's projection
@@ -729,8 +757,15 @@ mod tests {
     /// Seed a probe hub DB with ONE `agent_run` + an ordered event log (through the WRITE path),
     /// then return its path. The S-R2 run-readback projection reads back this run's
     /// state/loop-status/event-kinds/counts refs-only. The task body is a body that must NEVER leak.
+    ///
+    /// M-3: the run also records a `run_result` whose `owner_principal == OWNER`, so the
+    /// owner-gated [`project_run_readback`] Grants the readback to OWNER (the bound owner the read
+    /// server authenticates as). Without a recorded owner the run is owner-less and the gate would
+    /// fail-close to `run_not_found`; the providers-doctor round-trips never read the run, so the
+    /// owner row is harmless for those callers.
     fn seed_run_db(tag: &str) -> String {
         use friday_storage::agent_run::{create_run, record_event};
+        use friday_storage::{persist_run_result, RunResult};
         let path = temp_db_path(tag);
         let db = Db::open_hub(&path).unwrap();
         let now = 1_780_640_000_000;
@@ -763,6 +798,20 @@ mod tests {
             "run_read_seam_probe",
             "agent.finished",
             now + 3,
+        )
+        .unwrap();
+        // M-3: bind OWNER as the run's owner so the owner-gated readback Grants the read server's
+        // authenticated owner (the run's answer body is owner-only and never rides the readback).
+        persist_run_result(
+            db.conn(),
+            "run_read_seam_probe",
+            &RunResult::new(
+                "finished",
+                "owner-only run answer body that must never leak",
+                None,
+            )
+            .with_owner_principal(OWNER),
+            now + 4,
         )
         .unwrap();
         path
@@ -1182,6 +1231,101 @@ mod tests {
         );
         let processed = server.join().unwrap();
         assert_eq!(processed, 0);
+    }
+
+    /// KAT (M-3) — the NEW per-run owner gate at the WIRE level. A VERIFIED, allowlisted caller
+    /// (authenticated as OWNER, exactly the proven happy path) requests a run that is owned by a
+    /// DIFFERENT principal. Before M-3 this would have read back ANY run by id (the cross-principal
+    /// existence/state oracle); now the owner gate collapses it to `Ok(None)`, which the server maps
+    /// to a `run_not_found` typed Error — INDISTINGUISHABLE from a non-existent run, so the
+    /// authenticated owner learns nothing about a run it does not own (no snapshot, no body, no
+    /// state). This is the ONE genuinely new denial: a verified caller reading another principal's
+    /// run. The session does NOT end (a benign typed Error keeps the link, unlike a failed auth).
+    #[test]
+    fn run_readback_read_server_owner_gate_denies_a_run_owned_by_another_principal() {
+        use friday_storage::agent_run::{create_run, record_event};
+        use friday_storage::{persist_run_result, RunResult};
+        // Seed a finished run OWNED BY A DIFFERENT principal (not OWNER, but the read server
+        // authenticates the caller as OWNER).
+        let db_path = temp_db_path("m3-cross-principal");
+        let db = Db::open_hub(&db_path).unwrap();
+        let now = 1_780_640_000_000;
+        create_run(
+            db.conn(),
+            "run_owned_by_someone_else",
+            "secret task body",
+            now,
+        )
+        .unwrap();
+        record_event(
+            db.conn(),
+            "ev-1",
+            "run_owned_by_someone_else",
+            "agent.finished",
+            now + 1,
+        )
+        .unwrap();
+        persist_run_result(
+            db.conn(),
+            "run_owned_by_someone_else",
+            &RunResult::new("finished", "the other principal's answer", None)
+                .with_owner_principal("principal:a-different-owner"),
+            now + 2,
+        )
+        .unwrap();
+        drop(db);
+
+        let server_kp = DeviceKeypair::generate();
+        let client_kp = DeviceKeypair::from_secret_bytes(CLIENT_SECRET);
+        let peer_allowlist = vec![client_kp.public_bytes()];
+        let owner_allowlist = vec![OWNER.to_string()];
+
+        let listener = ReadWsListener::bind_loopback(0).unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        let server = thread::spawn(move || {
+            let db = Db::open_hub_readonly(&db_path).unwrap();
+            let probe = null_probe();
+            listener
+                .accept_one(&server_kp, &db, &probe, &owner_allowlist, &peer_allowlist)
+                .unwrap()
+        });
+
+        let (mut ws, session_key, session_nonce) = client_handshake(addr, &client_kp);
+        let request_id = "req-m3-cross-principal-1";
+        // The caller authenticates as OWNER (the proven happy-path principal) — a VALID, allowlisted
+        // forwarded principal that DOES authenticate. Only the M-3 per-run owner gate denies it.
+        let req = Envelope::new(
+            "msg-m3-cross-principal-1",
+            1000,
+            Message::RunReadbackRequest {
+                request: RunReadbackRequestWire {
+                    run_id: "run_owned_by_someone_else".to_string(),
+                    forwarded_principal: OWNER.to_string(),
+                    auth_proof: read_auth_proof(&session_key, &session_nonce, OWNER, request_id),
+                    request_id: request_id.to_string(),
+                },
+            },
+        );
+        ws_send_envelope(&mut ws, &session_key, &req, SESSION_AAD).unwrap();
+
+        // The authenticated caller gets a typed `run_not_found` Error — NEVER a snapshot of a run it
+        // does not own. The link stays open (auth passed; only the per-run gate denied).
+        let resp = ws_recv_envelope(&mut ws, &session_key, SESSION_AAD).unwrap();
+        let Message::Error { code, message } = resp.message else {
+            panic!("expected a typed Error for a non-owned run, got a snapshot/other frame");
+        };
+        assert!(matches!(code, friday_protocol::ErrorCode::HubOffline));
+        assert_eq!(
+            message, "run_not_found",
+            "not-owner must be indistinguishable from unknown-run (no cross-principal oracle)"
+        );
+        drop(ws);
+        let processed = server.join().unwrap();
+        assert_eq!(
+            processed, 1,
+            "the server processed the request, then denied the read"
+        );
     }
 
     /// KAT (S-R3) — the providers-doctor projection round-trips through the read server: handshake →

--- a/rust-core/crates/friday-hub/src/bin/hub_run_readback.rs
+++ b/rust-core/crates/friday-hub/src/bin/hub_run_readback.rs
@@ -12,6 +12,16 @@
 //! refs-only boundary: that a Rust run's outcome can be projected to TS without
 //! ever transporting a body/secret/PII.
 //!
+//! ## M-3 OWNER GATE — the readback is now owner-scoped
+//! `project_run_readback` is owner-gated: it reads back a run ONLY for its bound
+//! owner principal (`resolve_run_owner`, the all-state owner axis). This bin
+//! supplies the asserted owner via `--owner <principal>` (the configured owner the
+//! run was bound to). The owner is NEVER resolved from the run's own row (that would
+//! re-open the cross-principal oracle M-3 closes). A missing/blank `--owner` ⇒ an
+//! empty caller ⇒ the gate fails closed; a not-owner / owner-less / unknown run all
+//! collapse to the bin's existing `run_not_found` error kind (indistinguishable, no
+//! existence/state oracle).
+//!
 //! ## Output contract — REFS ONLY (no bodies, no secrets, no PII)
 //! Emits a single JSON object to stdout carrying ONLY safe identifiers/labels:
 //! `truth_label="rust_wired_dev"`, `run_id`, the run `state` label (NOT the run
@@ -91,14 +101,27 @@ fn run() -> Result<String, ReadbackError> {
     }
     let run_id = arg_value(&args, "--run-id").ok_or(ReadbackError::new("bad_args"))?;
 
+    // M-3: the run-readback projection is now OWNER-GATED — it reads back a run ONLY for its bound
+    // owner principal. This operator-local readback supplies the owner principal via `--owner` (the
+    // configured owner the run was bound to). It is NEVER resolved from the run's own row (that would
+    // re-open the cross-principal oracle the M-3 gate closes); a caller asserts WHO it is, and the
+    // gate matches that against the run's bound owner. A missing/blank `--owner` ⇒ an empty caller
+    // ⇒ the gate fails closed (`Ok(None)` ⇒ `run_not_found`), mirroring the read server's
+    // blank-allowlist discipline (a readback with no asserted owner reads nothing).
+    let owner = arg_value(&args, "--owner").unwrap_or_default();
+
     // Read-only open: a readback can NEVER mutate an operator DB just because TS asks.
     let db = Db::open_hub_readonly(&db_path).map_err(|_| ReadbackError::new("open_failed"))?;
 
     // S-R2: the refs-only projection (state/loop-status/event-kinds/counts + DB-WIDE token totals,
     // with the forbidden-output guard run INSIDE) is the SHARED library fn so this bin and the DARK
     // read-projection server cannot drift. Map the projection's coarse error string back to this
-    // bin's exact error-kind vocabulary (so its stderr/exit contract is unchanged).
-    let snapshot = project_run_readback(&db, &run_id).map_err(map_projection_error)?;
+    // bin's exact error-kind vocabulary (so its stderr/exit contract is unchanged). M-3: a
+    // non-owner / owner-less / unknown run all yield `Ok(None)` from the owner gate — surface it as
+    // the bin's existing `run_not_found` so not-owner is indistinguishable from unknown-run.
+    let snapshot = project_run_readback(&db, &owner, &run_id)
+        .map_err(map_projection_error)?
+        .ok_or_else(|| ReadbackError::new("run_not_found"))?;
     serde_json::to_string(&snapshot).map_err(|_| ReadbackError::new("serialize_failed"))
 }
 
@@ -136,9 +159,16 @@ mod tests {
             "--db".to_string(),
             "/tmp/hub.sqlite".to_string(),
             "--run-id=run-xyz".to_string(),
+            "--owner".to_string(),
+            "principal:owner-x".to_string(),
         ];
         assert_eq!(arg_value(&args, "--db").as_deref(), Some("/tmp/hub.sqlite"));
         assert_eq!(arg_value(&args, "--run-id").as_deref(), Some("run-xyz"));
+        // M-3: the owner principal the readback gates on (space-form parse).
+        assert_eq!(
+            arg_value(&args, "--owner").as_deref(),
+            Some("principal:owner-x")
+        );
         assert_eq!(arg_value(&args, "--missing"), None);
     }
 

--- a/rust-core/crates/friday-hub/src/run_readback_projection.rs
+++ b/rust-core/crates/friday-hub/src/run_readback_projection.rs
@@ -43,14 +43,61 @@ use friday_storage::audit::verify_audit_chain;
 use friday_storage::Db;
 use serde_json::{json, Value};
 
-/// Project the refs-only run-readback snapshot for `run_id` from an already-opened read-only hub
-/// [`Db`]. Returns the refs-only snapshot `serde_json::Value` on success.
+/// (M-3) OWNER-GATED refs-only run-readback projection for `run_id` from an already-opened
+/// read-only hub [`Db`], scoped to `caller_principal`. `Ok(Some(snapshot))` ⇒ the caller IS the
+/// run's bound owner and gets the refs-only snapshot; `Ok(None)` ⇒ the caller is NOT the run's
+/// bound owner (or the run is owner-less / absent, or the caller is empty) — fail-closed, no
+/// existence/state oracle for a non-owner.
 ///
-/// Fail-closed: a read error, an unknown run, or a forbidden-marker leak all return `Err(String)`
-/// (the SAME coarse error-kind strings the bin surfaced) — never a partial or a raw body. The
-/// forbidden-output guard runs INSIDE this fn so both the bin and the read server inherit it.
-pub fn project_run_readback(db: &Db, run_id: &str) -> Result<Value, String> {
+/// ## M-3 owner gate — `resolve_run_owner` (the C2-9 owner axis)
+/// `project_run_readback` previously took only `run_id` with NO principal, so any authenticated
+/// caller could read back ANY run by guessing the id — a cross-principal existence/state ORACLE.
+/// The gate now resolves the run's bound owner via [`crate::agent_run_control::resolve_run_owner`]
+/// (the SAME owner resolution the owner-authed `reject`/`cancel` control ops and the C2-9
+/// `project_activity_needs_me` projection use). `resolve_run_owner` returns an owner ONLY for a
+/// PAUSED run (its pending-approval row's `principal_id`) or a FINISHED run that recorded a
+/// `run_result.owner_principal`; it returns `None` for every OTHER state — an in-progress / errored
+/// / bounded run with no `run_result` yet, and an owner-less finished run. An empty caller, an
+/// owner-less/no-resolvable-owner run, an unknown run, or a mismatch ALL collapse to `Ok(None)`, so
+/// a non-owner learns nothing (no body, no owner id, no run-existence/state oracle).
+///
+/// **Behavior change (honest scope):** because the gate requires a RESOLVABLE owner, even the legit
+/// owner can no longer read back a run that has not yet produced a `run_result` and is not paused
+/// (an in-progress / errored / bounded-without-result run, or an owner-less finished run) — those
+/// now return `Ok(None)`. This is the intended M-3 tightening (no resolvable owner ⇒ no readback,
+/// fail-closed — never an owner-less fallback, which would re-open the oracle). Pre-M-3 the
+/// projection returned a snapshot for ANY run with an `agent_run` row regardless of state.
+///
+/// `caller_principal` MUST be a principal the server already AUTHENTICATED against the sealed
+/// session (this fn does the OWNER-match on top; it never re-does session auth, and never trusts a
+/// client-asserted wire string — the read-projection server threads the verified
+/// `AuthedPrincipal::principal()` here).
+///
+/// Fail-closed: a read error or a forbidden-marker leak return `Err(String)` (the SAME coarse
+/// error-kind strings the bin surfaced) — never a partial or a raw body. The forbidden-output guard
+/// runs INSIDE this fn so both the bin and the read server inherit it.
+pub fn project_run_readback(
+    db: &Db,
+    caller_principal: &str,
+    run_id: &str,
+) -> Result<Option<Value>, String> {
     let conn = db.conn();
+
+    // OWNER GATE (fail-closed, M-3): the run's owner is resolved by `resolve_run_owner` (the
+    // pending-row principal for a paused run, or `run_result.owner_principal` for a finished one;
+    // `None` for any other state — see the fn docs). An empty caller, a run with no resolvable
+    // owner (absent / in-progress-without-result / owner-less), or a mismatch all collapse to
+    // `Ok(None)` — a non-owner gets no run-existence/state oracle (and never reaches the summary
+    // read below). This MIRRORS the C2-9 `project_activity_needs_me` gate exactly.
+    let caller = caller_principal.trim();
+    if caller.is_empty() {
+        return Ok(None);
+    }
+    let owner = crate::agent_run_control::resolve_run_owner(conn, run_id)
+        .map_err(|_| "read_failed".to_string())?;
+    if owner.as_deref() != Some(caller) {
+        return Ok(None);
+    }
 
     let summary = get_run_summary(conn, run_id)
         .map_err(|_| "read_failed".to_string())?
@@ -97,7 +144,7 @@ pub fn project_run_readback(db: &Db, run_id: &str) -> Result<Value, String> {
     // inherit refs-only. The guard renders to a string and rejects on any forbidden marker.
     let rendered = serde_json::to_string(&snapshot).map_err(|_| "serialize_failed".to_string())?;
     reject_forbidden_output(&rendered)?;
-    Ok(snapshot)
+    Ok(Some(snapshot))
 }
 
 /// Derive a coarse, refs-only loop-status LABEL from the ordered event kinds.
@@ -419,9 +466,12 @@ mod tests {
         .is_ok());
     }
 
+    const OWNER: &str = "principal:r2-proj-owner";
+
     #[test]
     fn project_run_readback_round_trips_a_seeded_run_refs_only() {
         use friday_storage::agent_run::{create_run, record_event};
+        use friday_storage::{persist_run_result, RunResult};
         // Seed a run with events through the WRITE path, then read it back through the projection.
         let path = std::env::temp_dir()
             .join(format!(
@@ -456,10 +506,22 @@ mod tests {
             now + 3,
         )
         .unwrap();
+        // M-3: a finished run records its bound OWNER principal via `run_result.owner_principal`
+        // (the all-state owner axis `resolve_run_owner` reads), so the owner gate Grants the owner.
+        persist_run_result(
+            db.conn(),
+            "run-r2-proj",
+            &RunResult::new("finished", "owner-only answer body", None).with_owner_principal(OWNER),
+            now + 4,
+        )
+        .unwrap();
         drop(db);
 
         let ro = Db::open_hub_readonly(&path).unwrap();
-        let snapshot = project_run_readback(&ro, "run-r2-proj").expect("projects");
+        // The OWNER reads its own run back — the happy path is preserved (a `Some` snapshot).
+        let snapshot = project_run_readback(&ro, OWNER, "run-r2-proj")
+            .expect("projects")
+            .expect("the owner gets a snapshot");
         let v: Value = from_str(&serde_json::to_string(&snapshot).unwrap()).unwrap();
 
         assert_eq!(v["run_id"], "run-r2-proj");
@@ -478,6 +540,8 @@ mod tests {
         let rendered = serde_json::to_string(&snapshot).unwrap();
         assert!(!rendered.contains("raw task body"));
         assert!(!rendered.contains("\"task\""));
+        // Refs-only: the owner-only answer body never rides the readback snapshot either.
+        assert!(!rendered.contains("owner-only answer body"));
     }
 
     #[test]
@@ -489,9 +553,105 @@ mod tests {
         let db = Db::open_hub(&path).unwrap();
         drop(db);
         let ro = Db::open_hub_readonly(&path).unwrap();
+        // M-3: an unknown run is owner-less, so the gate collapses it to `Ok(None)` BEFORE the
+        // summary read — fail-closed and INDISTINGUISHABLE from the not-owner case (the anti-oracle
+        // property). The wire outcome is unchanged: the server maps this `Ok(None)` to the same
+        // `run_not_found` typed error a non-existent run produced before.
         assert_eq!(
-            project_run_readback(&ro, "no-such-run").unwrap_err(),
-            "run_not_found"
+            project_run_readback(&ro, OWNER, "no-such-run").unwrap(),
+            None
+        );
+    }
+
+    #[test]
+    fn project_run_readback_non_owner_is_fail_closed_no_oracle() {
+        use friday_storage::agent_run::{create_run, record_event};
+        use friday_storage::{persist_run_result, RunResult};
+        // Seed a finished run OWNED by principal A.
+        let path = std::env::temp_dir()
+            .join(format!("friday-r2-nonowner-{}.sqlite", std::process::id()))
+            .to_string_lossy()
+            .into_owned();
+        let db = Db::open_hub(&path).unwrap();
+        let now = 1_780_640_000_000;
+        create_run(db.conn(), "run-r2-owned-by-a", "secret task body", now).unwrap();
+        record_event(
+            db.conn(),
+            "ev-a-1",
+            "run-r2-owned-by-a",
+            "agent.finished",
+            now + 1,
+        )
+        .unwrap();
+        persist_run_result(
+            db.conn(),
+            "run-r2-owned-by-a",
+            &RunResult::new("finished", "A's answer", None)
+                .with_owner_principal("principal:owner-A"),
+            now + 2,
+        )
+        .unwrap();
+        drop(db);
+
+        let ro = Db::open_hub_readonly(&path).unwrap();
+        // The OWNER (A) reads it back — `Some` (control: the run genuinely exists + is readable).
+        assert!(
+            project_run_readback(&ro, "principal:owner-A", "run-r2-owned-by-a")
+                .unwrap()
+                .is_some()
+        );
+        // A DIFFERENT verified caller (B) reading A's run → `Ok(None)` — the M-3 gate. B learns
+        // nothing: no body, no owner id, no existence/state oracle (identical to an unknown run).
+        assert_eq!(
+            project_run_readback(&ro, "principal:owner-B", "run-r2-owned-by-a").unwrap(),
+            None
+        );
+        // An EMPTY caller is never an owner (fail-closed) → `Ok(None)`.
+        assert_eq!(
+            project_run_readback(&ro, "", "run-r2-owned-by-a").unwrap(),
+            None
+        );
+    }
+
+    #[test]
+    fn project_run_readback_no_resolvable_owner_run_is_fail_closed_even_for_the_owner() {
+        use friday_storage::agent_run::{create_run, record_event};
+        // Seed an IN-PROGRESS run: an `agent_run` row + a non-terminal event, but NO pending
+        // approval row and NO `run_result` — so `resolve_run_owner` returns `None` (M-3 behavior
+        // change). Pre-M-3 this run read back a snapshot for anyone; now it fails closed.
+        let path = std::env::temp_dir()
+            .join(format!(
+                "friday-r2-inprogress-{}.sqlite",
+                std::process::id()
+            ))
+            .to_string_lossy()
+            .into_owned();
+        let db = Db::open_hub(&path).unwrap();
+        let now = 1_780_640_000_000;
+        create_run(db.conn(), "run-r2-in-progress", "task body", now).unwrap();
+        record_event(
+            db.conn(),
+            "ev-ip-1",
+            "run-r2-in-progress",
+            "plan.none",
+            now + 1,
+        )
+        .unwrap();
+        // No pending row, no run_result ⇒ no resolvable owner.
+        assert_eq!(
+            crate::agent_run_control::resolve_run_owner(db.conn(), "run-r2-in-progress").unwrap(),
+            None,
+            "a run with no pending row and no run_result has no resolvable owner"
+        );
+        drop(db);
+
+        let ro = Db::open_hub_readonly(&path).unwrap();
+        // Even a non-empty, plausible owner principal gets `Ok(None)` — the run has no resolvable
+        // owner, so NO caller is its owner (fail-closed; no owner-less fallback). This is the M-3
+        // tightening: a verified owner can no longer read back their own non-terminal run.
+        assert_eq!(
+            project_run_readback(&ro, "principal:some-owner", "run-r2-in-progress").unwrap(),
+            None
         );
     }
 }


### PR DESCRIPTION
## C2I-PR1 — M-3 read-auth tightening (Wave 1 pre-wire SECURITY fix)

Closes **M-3** from the V1 Dark-Program verification: `project_run_readback`
(`run_readback_projection.rs`) previously took **only `run_id`** with no
principal, so any authenticated caller of the dark read-projection server
could read back **any** run by guessing its id — a cross-principal
existence/state **ORACLE**. C2I-PR2 (Wave 3) adds five new read arms that
ride the SAME read server, so this oracle + the bool auth helper had to be
fixed **first** (per HARD-CONSTRAINT 3: pre-wire security same-or-earlier).

This is a pure **SECURITY TIGHTENING** of an already-gated, dark,
loopback-only surface — it adds **no new reachability**. It is the one
LIVE-WIRING PR that is intentionally **not flag-gated** (it only narrows
who may read an already-dark projection), which is acceptable and
documented in the program scope.

### The oracle, closed (`run_readback_projection.rs`)
`project_run_readback` now takes `caller_principal: &str` and returns
`Result<Option<Value>, String>`. Before any read it resolves the run's
bound owner via `crate::agent_run_control::resolve_run_owner` (the SAME
owner axis the owner-authed reject/cancel ops and the C2-9
`project_activity_needs_me` projection use) and returns `Ok(None)` unless
the resolved owner equals the trimmed, non-empty caller. A non-owner gets
no body, no owner id, and no run existence/state oracle (it never reaches
the summary read). `resolve_run_owner` / `authenticate_forwarded` are only
**called**, never modified.

### The auth refactor (`bin/hub_read_projection_server.rs`)
`authenticate_read_request` now returns **`Option<AuthedPrincipal>`** (was
`bool`) — the VERIFIED principal minted **only** from
`AuthedPrincipal::authenticate_forwarded` (nonce-bound, owner-allowlist-
ceilinged, possession-of-session proof), **never** the raw wire
`forwarded_principal` string. The RunReadback arm binds that verified
principal and scopes the projection on `caller.principal()` — not the wire
string — mapping `Ok(None)` to the `run_not_found` typed Error a
non-existent run already produced (so not-owner is **indistinguishable**
from unknown-run on the wire). The Workbench + ProvidersDoctor arms keep
their pass/fail check (`.is_none()` ⇒ END the session); they have no
per-run owner scope, so they don't bind the principal (no unused-var).

### `bin/hub_run_readback.rs`
The proof-only operator-local CLI gains an `--owner <principal>` arg
threaded as `caller_principal`. The owner is **asserted by the caller,
never resolved from the run's own row** (that would re-open the oracle); a
missing/blank `--owner` fails closed. `Ok(None)` maps to the bin's existing
`run_not_found` error kind.

## EXACTLY which requests newly fail-closed
(relative to the prior run-readback path)

- **(a) unverifiable forwarded principal** (forged / empty / non-allowlisted,
  or an un-openable proof) → session ends. **NOT new** — the old `bool`
  helper already enforced this; the refactor only threads the verified
  principal so the arm can scope on it.
- **(b) NEW** — a **verified, allowlisted caller reading a run owned by a
  DIFFERENT principal** → `run_not_found` (the M-3 gate). The core oracle
  closure.
- **(c) NEW** — a verified caller, **including the legit owner**, reading a
  run with **no resolvable owner**. `resolve_run_owner` returns an owner
  only for a PAUSED run (pending-row `principal_id`) or a FINISHED run that
  recorded `run_result.owner_principal`; it returns `None` for an
  in-progress / errored / bounded-without-result run and an owner-less
  finished run. Those now return `run_not_found`. Pre-M-3 the projection
  returned a snapshot for **any** run with an `agent_run` row regardless of
  state, so this is a real, documented tightening — **no owner-less
  fallback** (that would re-open the oracle).

## Happy-path preserved (⚠️ this server runs LIVE in prod on :48751)
A properly sealed+forwarded request from the **enrolled peer reading its
OWN** paused-or-finished-owner-recorded run authenticates and reads back the
exact same refs-only snapshot as today — **byte-identical in OUTCOME**. The
existing `run_readback_projection_round_trips_through_the_read_server` KAT
still passes; its `seed_run_db` now records the run's owner via
`persist_run_result(...).with_owner_principal(OWNER)` (the owner the read
server authenticates as). The honest scope of "preserved" is the paused /
finished-owner-recorded case (the case the dark seam was ever meant to read
back); the in-progress/owner-less case is the **(c)** tightening above.

## Known downstream behavior change (outside the 3-file scope, cannot edit)
The PROOF-ONLY TS dev bridge
`src/api/mission-spine/friday-rust-hub-run-readback-service.ts` spawns
`hub_run_readback` with only `--db`/`--run-id` (no `--owner`), so it will
now get `run_not_found` (fail-closed). That bridge is dev/proof-only
(registers no production route, no v1 GO); threading `--owner` through it is
a follow-up, not part of this Rust security fix.

## Scope + tests
**Touches ONLY the 3 files:** `run_readback_projection.rs`,
`bin/hub_read_projection_server.rs`, `bin/hub_run_readback.rs`. `lib.rs` /
`runtime.rs` / other bins untouched. No fake / degrade / loophole.

Tests (real DB, no network, no key):
- `run_readback_projection.rs`: owner reads own finished run → `Some`
  (happy path); a different verified principal reading A's run → `None`;
  empty caller → `None`; an in-progress no-resolvable-owner run → `None`
  even for a plausible owner (class **(c)**); unknown run → `None` (was `Err`).
- `hub_read_projection_server.rs`: the existing run-readback round-trip KAT
  (owner reads own run, refs-only, no body/secret); a **NEW** M-3 KAT
  proving a verified OWNER-authenticated caller reading a run owned by a
  DIFFERENT principal gets a `run_not_found` typed Error (no snapshot, link
  stays open); the mismatched-principal KAT (session ends) unchanged.
- `hub_run_readback.rs`: `--owner` arg parse.

## Gate (rust-core, in order — all green)
- `cargo fmt --all -- --check` ✅
- `cargo clippy --workspace --all-targets -- -D warnings` ✅
- `cargo build -p friday-hub` ✅
- `cargo test -p friday-hub` ✅ (623 lib tests + all bins + integration, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
