### PR TITLE
feat(wi-1): route WorkItem status advance through guarded transition_work_item_status (FRIDAY_WORKITEM_GUARDED_TRANSITION, default-OFF)

### DIFF
--- a/rust-core/crates/friday-hub/src/mission_preflight.rs
+++ b/rust-core/crates/friday-hub/src/mission_preflight.rs
@@ -481,6 +481,42 @@ pub fn attach_provider_timeline_state(
     db: &Db,
     attachment: ProviderTimelineAttachment,
 ) -> Result<MissionAttachmentOutcome, StorageError> {
+    // Public seam preserved with its exact signature so every external caller compiles
+    // untouched. The guarded variant is the single behavioral knob (default-OFF), threaded
+    // in as a pure bool from the run-loop entrypoint's env read (the codebase's
+    // "split env-read from pure logic" idiom). `false` here = the pre-WI-1 path, byte-identical.
+    attach_provider_timeline_state_guarded(db, attachment, false)
+}
+
+/// (WI-1, M-6) [`attach_provider_timeline_state`] with the DARK WorkItem guarded-transition
+/// flag threaded in as a pure bool — the env read lives ONLY in the run-loop entrypoint
+/// ([`crate::runtime::HubRuntime::run_agent_loop_for_mission_with_overrides`]), so the
+/// behavioral tests drive this directly with `true`/`false` and never touch `std::env`.
+///
+/// `guarded = false` (the prod default) is BYTE-IDENTICAL to the pre-WI-1 body: the inline
+/// status-advance write runs unchanged — it sets `work_item.status`, bumps `updated_at_ms`,
+/// appends the completion proof receipt, and `upsert_work_item`s, writing NO `audit_ledger`
+/// row and making NO call to the guarded primitive.
+///
+/// `guarded = true` routes the SAME legal status advance through
+/// [`friday_storage::Db::transition_work_item_status`], which transitions the WorkItem AND
+/// writes ONE hash-chained `audit_ledger` lifecycle row in a single transaction. The SOLE
+/// behavioral delta vs OFF is that atomic audit row: the resulting status is identical, the
+/// MissionLink is identical, and the mission's `proof_refs`/`updated_at_ms` are updated on
+/// completion exactly as before (the primitive touches only the WorkItem, never the mission).
+///
+/// The legal-hop pre-check (`can_transition_to`) is SHARED and UNGUARDED across both paths and
+/// runs BEFORE the `guarded` fork, so an illegal hop returns the SAME `Ok(Blocked{illegal_...})`
+/// outcome on both paths (NOT an `Err` from the primitive's `try_transition`) — the run is never
+/// errored or blocked by routing through the primitive. Because the pre-check has already proven
+/// the hop legal (and is only entered when `work_item.status != next_status`), the primitive's
+/// `try_transition` can never fail inside the guarded branch. A same-status no-op falls into the
+/// OFF-equivalent else on BOTH paths (no transition ⇒ no audit row), preserving equivalence.
+pub fn attach_provider_timeline_state_guarded(
+    db: &Db,
+    attachment: ProviderTimelineAttachment,
+    guarded: bool,
+) -> Result<MissionAttachmentOutcome, StorageError> {
     let Some(mut mission) = db.get_mission(&attachment.mission_id)? else {
         return Ok(MissionAttachmentOutcome::blocked("unknown_mission"));
     };
@@ -500,6 +536,10 @@ pub fn attach_provider_timeline_state(
             attachment.proof_ref.as_deref(),
         )));
     };
+    // SHARED legal-hop pre-check (runs on BOTH paths, before the `guarded` fork). An illegal
+    // hop returns Ok(Blocked) here on both paths — so the guarded branch is only reached for a
+    // status CHANGE that is already proven legal, which is exactly the contract under which
+    // `transition_work_item_status`'s `try_transition` cannot error.
     if work_item.status != next_status && !work_item.status.can_transition_to(next_status) {
         return Ok(MissionAttachmentOutcome::blocked(format!(
             "illegal_work_item_transition:{}->{}",
@@ -508,17 +548,52 @@ pub fn attach_provider_timeline_state(
         )));
     }
 
-    work_item.status = next_status;
-    work_item.updated_at_ms = attachment.now_ms;
-    if next_status == WorkItemStatus::CompletedWithProof {
-        if let Some(proof_ref) = attachment.proof_ref.as_ref() {
-            push_unique(&mut work_item.proof_receipts, proof_ref.clone());
-            push_unique(&mut mission.proof_refs, proof_ref.clone());
-            mission.updated_at_ms = attachment.now_ms;
+    if guarded && work_item.status != next_status {
+        // ON path: route the (pre-checked legal) advance through the canonical guarded primitive
+        // so the status transition AND a hash-chained audit row commit in one transaction. The
+        // primitive pushes the completion proof receipt and upserts the WorkItem itself (it is the
+        // authoritative WorkItem writer on this path), so we do NOT upsert the WorkItem again and
+        // discard the returned row — the outcome below reports `next_status`. `proof_receipt` is
+        // passed ONLY for the CompletedWithProof hop (the primitive rejects a receipt for any other
+        // target and requires one for completion — matching this seam's contract exactly).
+        let actor_ref = format!("friday://agent-run/{}", attachment.request_id);
+        let reason = format!("provider_timeline:{}", attachment.state.as_str());
+        let proof_receipt = if next_status == WorkItemStatus::CompletedWithProof {
+            attachment.proof_ref.as_deref()
+        } else {
+            None
+        };
+        let (_updated, _previous) = db.transition_work_item_status(
+            &attachment.work_item_id,
+            next_status,
+            &actor_ref,
+            &reason,
+            proof_receipt,
+            attachment.now_ms,
+        )?;
+        // Mission side is NOT touched by the primitive — replicate the OFF path's mission update
+        // (append the completion proof ref + bump updated_at_ms) so the mission row is identical.
+        if next_status == WorkItemStatus::CompletedWithProof {
+            if let Some(proof_ref) = attachment.proof_ref.as_ref() {
+                push_unique(&mut mission.proof_refs, proof_ref.clone());
+                mission.updated_at_ms = attachment.now_ms;
+            }
         }
+        db.upsert_mission(&mission)?;
+    } else {
+        // OFF path (and same-status no-op on both paths): the pre-WI-1 inline write, verbatim.
+        work_item.status = next_status;
+        work_item.updated_at_ms = attachment.now_ms;
+        if next_status == WorkItemStatus::CompletedWithProof {
+            if let Some(proof_ref) = attachment.proof_ref.as_ref() {
+                push_unique(&mut work_item.proof_receipts, proof_ref.clone());
+                push_unique(&mut mission.proof_refs, proof_ref.clone());
+                mission.updated_at_ms = attachment.now_ms;
+            }
+        }
+        db.upsert_work_item(&work_item)?;
+        db.upsert_mission(&mission)?;
     }
-    db.upsert_work_item(&work_item)?;
-    db.upsert_mission(&mission)?;
 
     let target_ref = format!(
         "friday://provider-timeline/{}#{}",
@@ -766,6 +841,7 @@ mod tests {
         ApprovalState, ClaimState, HandoffJudgmentMemory, MemoryScope, MissionStatus, SurfaceKind,
         TruthStatus, VisibilityPolicy, WorkLane, WorkspaceClaim, WorkspaceClaimKind,
     };
+    use friday_storage::audit::verify_audit_chain;
     use friday_storage::{memory, workflow, Db};
     use std::sync::atomic::{AtomicU64, Ordering};
 
@@ -1814,5 +1890,290 @@ mod tests {
             proof_link.proof_ref.as_deref(),
             Some("proof://human-visible-receipt")
         );
+    }
+
+    // ===================== WI-1 (M-6) guarded WorkItem transition =====================
+
+    /// Count the hash-chained `audit_ledger` lifecycle rows the guarded primitive writes
+    /// (`work_item.lifecycle:from->to:reason`). Filters by the `action` prefix so unrelated
+    /// audit rows (e.g. from a model call) never inflate the count.
+    fn lifecycle_audit_rows(db: &Db) -> i64 {
+        db.conn()
+            .query_row(
+                "SELECT COUNT(*) FROM audit_ledger WHERE action LIKE 'work_item.lifecycle:%'",
+                [],
+                |r| r.get::<_, i64>(0),
+            )
+            .unwrap()
+    }
+
+    /// Stage a Mission/WorkItem to `ReadyToDispatch`, then drive it (guarded or not) through the
+    /// full provider progression up to `CompletedWithProof`. Returns the final attach outcome.
+    fn drive_to_completion(
+        db: &Db,
+        mission_id: &str,
+        work_item_id: &str,
+        guarded: bool,
+        now: i64,
+    ) -> MissionAttachmentOutcome {
+        let mut last = MissionAttachmentOutcome::blocked("unstarted");
+        for (i, state) in [
+            PendingState::SentToHub,         // ReadyToDispatch -> Dispatched
+            PendingState::AcceptedByHub,     // Dispatched -> HubAccepted
+            PendingState::RoutedToProvider,  // HubAccepted -> ProviderRouted
+            PendingState::WaitingProvider,   // ProviderRouted -> ProviderWaiting
+            PendingState::ProviderCompleted, // ProviderWaiting -> CompletedWithProof
+        ]
+        .into_iter()
+        .enumerate()
+        {
+            last = attach_provider_timeline_state_guarded(
+                db,
+                ProviderTimelineAttachment {
+                    mission_id: mission_id.to_string(),
+                    work_item_id: work_item_id.to_string(),
+                    friday_session_id: "friday-session-wi1".into(),
+                    request_id: "run-wi1".into(),
+                    state,
+                    proof_ref: (state == PendingState::ProviderCompleted)
+                        .then(|| "friday://agent-run/run-wi1".to_string()),
+                    now_ms: now + i as i64,
+                },
+                guarded,
+            )
+            .unwrap();
+            assert!(
+                matches!(last, MissionAttachmentOutcome::Attached { .. }),
+                "hop {state:?} should attach, got {last:?}"
+            );
+        }
+        last
+    }
+
+    #[test]
+    fn wi1_flag_on_advances_status_and_writes_hash_chained_audit_rows() {
+        let db = Db::open_hub(&tmp()).unwrap();
+        assert!(preflight_and_stage_work_item(
+            &db,
+            request(
+                "mission-wi1-on",
+                "work-wi1-on",
+                "guarded transition on",
+                WorkLane::DeepSeek,
+                Vec::new(),
+                false,
+                1,
+            ),
+        )
+        .unwrap()
+        .is_ready());
+
+        // Pre-condition: the staging path uses the inline upsert (no guarded primitive) so there
+        // are NO lifecycle audit rows before we drive the guarded progression.
+        assert_eq!(lifecycle_audit_rows(&db), 0);
+
+        let outcome = drive_to_completion(&db, "mission-wi1-on", "work-wi1-on", true, 10);
+
+        // (a) the status advanced correctly to completion-with-proof.
+        assert!(matches!(
+            outcome,
+            MissionAttachmentOutcome::Attached {
+                work_item_status: WorkItemStatus::CompletedWithProof,
+                ..
+            }
+        ));
+        let item = db.get_work_item("work-wi1-on").unwrap().unwrap();
+        assert_eq!(item.status, WorkItemStatus::CompletedWithProof);
+        assert_eq!(item.proof_receipts, vec!["friday://agent-run/run-wi1"]);
+        // Mission proof_refs updated on completion (the primitive does not touch the mission, so
+        // this seam replicates the OFF path's mission update — parity check).
+        assert!(db
+            .get_mission("mission-wi1-on")
+            .unwrap()
+            .unwrap()
+            .proof_refs
+            .contains(&"friday://agent-run/run-wi1".to_string()));
+
+        // (b) ONE hash-chained audit_ledger lifecycle row per legal hop (5 hops here), and the
+        // whole chain verifies (the guarded primitive's atomic-receipt invariant).
+        assert_eq!(lifecycle_audit_rows(&db), 5);
+        assert_eq!(
+            verify_audit_chain(db.conn()).unwrap(),
+            5,
+            "the WI-1 lifecycle rows are the only audit rows and the chain must verify"
+        );
+        // The MissionLink still binds the run (unchanged from the inline path).
+        let links = db.list_mission_links("mission-wi1-on").unwrap();
+        assert!(links
+            .iter()
+            .any(|link| link.link_kind == MissionLinkKind::ProviderTimeline));
+    }
+
+    #[test]
+    fn wi1_flag_off_is_byte_identical_and_writes_no_audit_row() {
+        let db = Db::open_hub(&tmp()).unwrap();
+        assert!(preflight_and_stage_work_item(
+            &db,
+            request(
+                "mission-wi1-off",
+                "work-wi1-off",
+                "guarded transition off",
+                WorkLane::DeepSeek,
+                Vec::new(),
+                false,
+                1,
+            ),
+        )
+        .unwrap()
+        .is_ready());
+
+        let outcome = drive_to_completion(&db, "mission-wi1-off", "work-wi1-off", false, 10);
+
+        // Same resulting status + proof as the ON path...
+        assert!(matches!(
+            outcome,
+            MissionAttachmentOutcome::Attached {
+                work_item_status: WorkItemStatus::CompletedWithProof,
+                ..
+            }
+        ));
+        let item = db.get_work_item("work-wi1-off").unwrap().unwrap();
+        assert_eq!(item.status, WorkItemStatus::CompletedWithProof);
+        assert_eq!(item.proof_receipts, vec!["friday://agent-run/run-wi1"]);
+        assert!(db
+            .get_mission("mission-wi1-off")
+            .unwrap()
+            .unwrap()
+            .proof_refs
+            .contains(&"friday://agent-run/run-wi1".to_string()));
+
+        // ...but NO lifecycle audit row from the guarded primitive (byte-identical to pre-WI-1).
+        assert_eq!(lifecycle_audit_rows(&db), 0);
+    }
+
+    #[test]
+    fn wi1_illegal_hop_is_rejected_the_same_way_on_both_paths_never_errors() {
+        // The legal-hop pre-check is SHARED and runs before the `guarded` fork: an illegal hop
+        // returns Ok(Blocked{illegal_...}) on BOTH paths (never an Err from the primitive's
+        // try_transition), so routing through the primitive never errors/blocks the run.
+        for guarded in [false, true] {
+            let db = Db::open_hub(&tmp()).unwrap();
+            assert!(preflight_and_stage_work_item(
+                &db,
+                request(
+                    "mission-wi1-illegal",
+                    "work-wi1-illegal",
+                    "illegal hop",
+                    WorkLane::DeepSeek,
+                    Vec::new(),
+                    false,
+                    1,
+                ),
+            )
+            .unwrap()
+            .is_ready());
+            // ReadyToDispatch -> CompletedWithProof is NOT a legal hop (must go through the
+            // provider states first). ProviderCompleted maps to CompletedWithProof.
+            let blocked = attach_provider_timeline_state_guarded(
+                &db,
+                ProviderTimelineAttachment {
+                    mission_id: "mission-wi1-illegal".into(),
+                    work_item_id: "work-wi1-illegal".into(),
+                    friday_session_id: "s".into(),
+                    request_id: "r".into(),
+                    state: PendingState::ProviderCompleted,
+                    proof_ref: Some("friday://agent-run/r".into()),
+                    now_ms: 10,
+                },
+                guarded,
+            )
+            .unwrap();
+            assert!(
+                matches!(
+                    &blocked,
+                    MissionAttachmentOutcome::Blocked { blockers }
+                        if blockers.iter().any(|b| b.starts_with("illegal_work_item_transition:ready_to_dispatch->completed_with_proof"))
+                ),
+                "guarded={guarded} expected illegal-hop block, got {blocked:?}"
+            );
+            // No status change and no audit row written on the rejected hop.
+            assert_eq!(
+                db.get_work_item("work-wi1-illegal")
+                    .unwrap()
+                    .unwrap()
+                    .status,
+                WorkItemStatus::ReadyToDispatch
+            );
+            assert_eq!(lifecycle_audit_rows(&db), 0);
+        }
+    }
+
+    #[test]
+    fn wi1_flag_on_same_status_is_a_noop_with_no_audit_row() {
+        // A re-attach at the SAME status (status == next_status) takes the OFF-equivalent else on
+        // BOTH paths — no guarded primitive call, no audit row, no spurious illegal-hop block.
+        let db = Db::open_hub(&tmp()).unwrap();
+        assert!(preflight_and_stage_work_item(
+            &db,
+            request(
+                "mission-wi1-noop",
+                "work-wi1-noop",
+                "same status noop",
+                WorkLane::DeepSeek,
+                Vec::new(),
+                false,
+                1,
+            ),
+        )
+        .unwrap()
+        .is_ready());
+        // Advance once (guarded) to Dispatched → one audit row.
+        let first = attach_provider_timeline_state_guarded(
+            &db,
+            ProviderTimelineAttachment {
+                mission_id: "mission-wi1-noop".into(),
+                work_item_id: "work-wi1-noop".into(),
+                friday_session_id: "s".into(),
+                request_id: "r".into(),
+                state: PendingState::SentToHub,
+                proof_ref: None,
+                now_ms: 10,
+            },
+            true,
+        )
+        .unwrap();
+        assert!(matches!(
+            first,
+            MissionAttachmentOutcome::Attached {
+                work_item_status: WorkItemStatus::Dispatched,
+                ..
+            }
+        ));
+        assert_eq!(lifecycle_audit_rows(&db), 1);
+
+        // Re-attach the SAME state (Dispatched again) under guarded=true → no-op, no new audit row.
+        let again = attach_provider_timeline_state_guarded(
+            &db,
+            ProviderTimelineAttachment {
+                mission_id: "mission-wi1-noop".into(),
+                work_item_id: "work-wi1-noop".into(),
+                friday_session_id: "s".into(),
+                request_id: "r".into(),
+                state: PendingState::SentToHub,
+                proof_ref: None,
+                now_ms: 11,
+            },
+            true,
+        )
+        .unwrap();
+        assert!(matches!(
+            again,
+            MissionAttachmentOutcome::Attached {
+                work_item_status: WorkItemStatus::Dispatched,
+                ..
+            }
+        ));
+        // Still exactly ONE lifecycle audit row — the same-status re-attach wrote none.
+        assert_eq!(lifecycle_audit_rows(&db), 1);
     }
 }

--- a/rust-core/crates/friday-hub/src/mission_preflight.rs
+++ b/rust-core/crates/friday-hub/src/mission_preflight.rs
@@ -500,10 +500,13 @@ pub fn attach_provider_timeline_state(
 ///
 /// `guarded = true` routes the SAME legal status advance through
 /// [`friday_storage::Db::transition_work_item_status`], which transitions the WorkItem AND
-/// writes ONE hash-chained `audit_ledger` lifecycle row in a single transaction. The SOLE
-/// behavioral delta vs OFF is that atomic audit row: the resulting status is identical, the
-/// MissionLink is identical, and the mission's `proof_refs`/`updated_at_ms` are updated on
-/// completion exactly as before (the primitive touches only the WorkItem, never the mission).
+/// writes ONE hash-chained `audit_ledger` lifecycle row in a single transaction. The ON path
+/// has TWO deltas vs OFF: (a) the hash-chained `audit_ledger` lifecycle rows, and (b) an ON-only
+/// `updated_at_ms` +offset (≤ +4ms, one per hop index — see the per-hop `now_ms` in
+/// [`crate::mission_runtime::attach_agent_loop_provider_state`]) on the WorkItem AND, on
+/// completion, the Mission row. The resulting status, `proof_refs`, and the MissionLink
+/// (`created_at_ms` is preserved from the first hop = base `now_ms`, identical to OFF) are the
+/// same on both paths. The OFF path is byte-identical to pre-WI-1.
 ///
 /// The legal-hop pre-check (`can_transition_to`) is SHARED and UNGUARDED across both paths and
 /// runs BEFORE the `guarded` fork, so an illegal hop returns the SAME `Ok(Blocked{illegal_...})`

--- a/rust-core/crates/friday-hub/src/mission_runtime.rs
+++ b/rust-core/crates/friday-hub/src/mission_runtime.rs
@@ -523,10 +523,14 @@ fn attach_completed_provider_state_for_ask(
 /// [`friday_storage::Db::transition_work_item_status`], writing one hash-chained `audit_ledger`
 /// lifecycle row per transition in its own transaction. A completed loop drives 5 legal hops
 /// (ReadyToDispatch → … → CompletedWithProof) ⇒ 5 lifecycle audit rows. The resulting WorkItem
-/// status and the MissionLink are unchanged either way. NOTE: ON-path only, each hop is given a
-/// distinct `now_ms` (a per-hop monotonic offset) so the per-hop audit_ids — derived from
-/// `(work_item_id, now_ms)`, the `audit_ledger` PRIMARY KEY — are unique across the multi-hop
-/// drive and the run never errors on a PK collision. OFF keeps the single caller-side `now_ms`.
+/// status and the MissionLink (its `created_at_ms` is preserved from the first hop = base
+/// `now_ms`) are unchanged either way. The ON path has TWO deltas vs OFF: (a) those hash-chained
+/// audit rows, and (b) an ON-only `updated_at_ms` +offset (≤ +4ms, one per hop index) on the
+/// WorkItem and, on completion, the Mission row — a direct consequence of the per-hop `now_ms`
+/// below. NOTE: ON-path only, each hop is given a distinct `now_ms` (a per-hop monotonic offset)
+/// so the per-hop audit_ids — derived from `(work_item_id, now_ms)`, the `audit_ledger` PRIMARY
+/// KEY — are unique across the multi-hop drive and the run never errors on a PK collision. OFF
+/// keeps the single caller-side `now_ms` (byte-identical to pre-WI-1).
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn attach_agent_loop_provider_state(
     db: &Db,
@@ -1437,6 +1441,18 @@ mod tests {
         assert!(item
             .proof_receipts
             .contains(&"friday://agent-run/run-loop-1".to_string()));
+
+        // WI-1 honesty pin: the ON-only `updated_at_ms` +offset is EXACTLY the documented value,
+        // not an arbitrary drift. 5 status-changing hops are driven (idx 0..=4); each enters the
+        // guarded branch and the primitive sets `updated_at_ms = base_now_ms + idx` (mission.rs).
+        // The final hop is the CompletedWithProof transition at idx=4, so the persisted WorkItem
+        // `updated_at_ms` MUST equal base_now_ms + 4. A future change can't silently widen it.
+        let final_hop_idx = 4;
+        assert_eq!(
+            item.updated_at_ms,
+            now + final_hop_idx,
+            "ON-path WorkItem updated_at_ms must be the base now_ms + final hop index, not a wider drift"
+        );
 
         // 5 legal hops (ReadyToDispatch → … → CompletedWithProof) ⇒ 5 lifecycle audit rows,
         // each with a DISTINCT audit_id despite the single caller-side now_ms, and the chain verifies.

--- a/rust-core/crates/friday-hub/src/mission_runtime.rs
+++ b/rust-core/crates/friday-hub/src/mission_runtime.rs
@@ -21,8 +21,9 @@ use crate::mission_context::{
     MissionContextResolution, ResolvedMissionContext,
 };
 use crate::mission_preflight::{
-    attach_channel_inbound_receipt, attach_provider_timeline_state, attach_workflow_run_ref,
-    MissionAttachmentOutcome, ProviderTimelineAttachment,
+    attach_channel_inbound_receipt, attach_provider_timeline_state,
+    attach_provider_timeline_state_guarded, attach_workflow_run_ref, MissionAttachmentOutcome,
+    ProviderTimelineAttachment,
 };
 use crate::planner::WorkflowDefinition;
 use crate::provider_timeline::PendingState;
@@ -512,6 +513,20 @@ fn attach_completed_provider_state_for_ask(
 ///   That is TRUE for every `Ok` loop outcome (the route was selected and the client was
 ///   called), and it deliberately does NOT claim `ProviderWaiting`/`CompletedWithProof` for
 ///   a paused or dead run. The binding link still exists, tied to the run.
+///
+/// (WI-1, M-6) `guarded` is the DARK WorkItem guarded-transition flag, threaded in as a pure
+/// bool from the run-loop entrypoint's single env read (see
+/// [`crate::runtime::HubRuntime::run_agent_loop_for_mission_with_overrides`]). It is forwarded
+/// verbatim to every per-state [`attach_provider_timeline_state_guarded`] call. `false` (the prod
+/// default): each legal status hop advances via the pre-WI-1 inline write — BYTE-IDENTICAL to
+/// before (no audit row, no primitive call). `true`: each legal hop advances through
+/// [`friday_storage::Db::transition_work_item_status`], writing one hash-chained `audit_ledger`
+/// lifecycle row per transition in its own transaction. A completed loop drives 5 legal hops
+/// (ReadyToDispatch → … → CompletedWithProof) ⇒ 5 lifecycle audit rows. The resulting WorkItem
+/// status and the MissionLink are unchanged either way. NOTE: ON-path only, each hop is given a
+/// distinct `now_ms` (a per-hop monotonic offset) so the per-hop audit_ids — derived from
+/// `(work_item_id, now_ms)`, the `audit_ledger` PRIMARY KEY — are unique across the multi-hop
+/// drive and the run never errors on a PK collision. OFF keeps the single caller-side `now_ms`.
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn attach_agent_loop_provider_state(
     db: &Db,
@@ -521,6 +536,7 @@ pub(crate) fn attach_agent_loop_provider_state(
     run_id: &str,
     completed: bool,
     proof_ref: &str,
+    guarded: bool,
     now_ms: i64,
 ) -> Result<MissionAttachmentOutcome, StorageError> {
     let mut states = vec![
@@ -535,8 +551,18 @@ pub(crate) fn attach_agent_loop_provider_state(
     let mut last = MissionAttachmentOutcome::Blocked {
         blockers: vec!["provider_state_not_attached".into()],
     };
-    for state in states {
-        last = attach_provider_timeline_state(
+    for (idx, state) in states.into_iter().enumerate() {
+        // WI-1 (M-6) audit_id uniqueness: the guarded primitive derives each lifecycle row's
+        // audit_id from `(work_item_id, now_ms)`, and that id is the `audit_ledger` PRIMARY KEY.
+        // This loop drives MULTIPLE hops for the SAME work_item, so reusing the single caller-side
+        // `now_ms` across hops would collide on the 2nd row's id and the primitive would return Err
+        // — erroring the run. ONLY on the guarded path we give each hop a distinct `now_ms` (the
+        // per-hop monotonic offset), so the audit_ids are unique and the chain extends cleanly.
+        // The OFF path is UNCHANGED — it keeps the single `now_ms`, so it stays BYTE-IDENTICAL to
+        // the pre-WI-1 inline write (which is PK-idempotent on `upsert_work_item` and never wrote
+        // an audit row, so it never had this constraint).
+        let hop_now_ms = if guarded { now_ms + idx as i64 } else { now_ms };
+        last = attach_provider_timeline_state_guarded(
             db,
             ProviderTimelineAttachment {
                 mission_id: mission_id.to_string(),
@@ -546,8 +572,9 @@ pub(crate) fn attach_agent_loop_provider_state(
                 state,
                 proof_ref: (state == PendingState::ProviderCompleted)
                     .then(|| proof_ref.to_string()),
-                now_ms,
+                now_ms: hop_now_ms,
             },
+            guarded,
         )?;
         if matches!(last, MissionAttachmentOutcome::Blocked { .. }) {
             return Ok(last);
@@ -566,6 +593,7 @@ mod tests {
         SurfaceKind, TruthStatus, VisibilityPolicy, WorkItem, WorkItemStatus,
     };
     use friday_crypto::InMemorySecureStore;
+    use friday_storage::audit::verify_audit_chain;
     use friday_storage::channel::ChannelKind;
     use friday_storage::{workflow, Db};
     use std::cell::Cell;
@@ -1350,5 +1378,113 @@ mod tests {
                 && link.target_ref == "friday://provider-timeline/friday-hub-session#ledger-ask-1"
                 && link.proof_ref.as_deref() == Some("friday://activity/activity-ask-1")
         }));
+    }
+
+    // ===================== WI-1 (M-6) guarded transition — PRODUCTION caller shape =============
+
+    /// Count the hash-chained `audit_ledger` lifecycle rows the guarded primitive writes.
+    fn lifecycle_audit_rows(db: &Db) -> i64 {
+        db.conn()
+            .query_row(
+                "SELECT COUNT(*) FROM audit_ledger WHERE action LIKE 'work_item.lifecycle:%'",
+                [],
+                |r| r.get::<_, i64>(0),
+            )
+            .unwrap()
+    }
+
+    /// The PRODUCTION caller shape: [`attach_agent_loop_provider_state`] drives ALL hops with a
+    /// SINGLE `now_ms` (the one threaded from `runtime.rs`'s agent-loop seam). Under `guarded=true`
+    /// this must NOT error/collide on the per-hop audit row — the run completes with proof AND the
+    /// expected number of hash-chained audit rows, and the chain verifies. (A regression here would
+    /// surface as an `Err` propagating out of the run, which is exactly what WI-1 must NOT do.)
+    #[test]
+    fn wi1_agent_loop_single_now_ms_completes_and_writes_chained_audit_rows() {
+        let db = Db::open_hub(&tmp("wi1-loop-on")).unwrap();
+        seed_work_item(
+            &db,
+            WorkLane::DeepSeek,
+            Some("deepseek"),
+            WorkItemStatus::ReadyToDispatch,
+        );
+        let now = 1_700_000_111_000;
+
+        let outcome = attach_agent_loop_provider_state(
+            &db,
+            "mission-runtime",
+            "work-runtime",
+            "friday-session-loop",
+            "run-loop-1",
+            /* completed = */ true,
+            "friday://agent-run/run-loop-1",
+            /* guarded = */ true,
+            now,
+        )
+        .unwrap();
+
+        assert!(
+            matches!(
+                outcome,
+                MissionAttachmentOutcome::Attached {
+                    work_item_status: WorkItemStatus::CompletedWithProof,
+                    ..
+                }
+            ),
+            "guarded agent-loop run must complete with proof, got {outcome:?}"
+        );
+        let item = db.get_work_item("work-runtime").unwrap().unwrap();
+        assert_eq!(item.status, WorkItemStatus::CompletedWithProof);
+        assert!(item
+            .proof_receipts
+            .contains(&"friday://agent-run/run-loop-1".to_string()));
+
+        // 5 legal hops (ReadyToDispatch → … → CompletedWithProof) ⇒ 5 lifecycle audit rows,
+        // each with a DISTINCT audit_id despite the single caller-side now_ms, and the chain verifies.
+        assert_eq!(lifecycle_audit_rows(&db), 5);
+        assert_eq!(
+            verify_audit_chain(db.conn()).unwrap(),
+            5,
+            "the WI-1 lifecycle rows are the only audit rows and the chain must verify"
+        );
+    }
+
+    /// Same production shape, flag OFF: byte-identical to pre-WI-1 — completes with proof and
+    /// writes NO lifecycle audit row from the guarded primitive.
+    #[test]
+    fn wi1_agent_loop_single_now_ms_flag_off_writes_no_audit_row() {
+        let db = Db::open_hub(&tmp("wi1-loop-off")).unwrap();
+        seed_work_item(
+            &db,
+            WorkLane::DeepSeek,
+            Some("deepseek"),
+            WorkItemStatus::ReadyToDispatch,
+        );
+        let now = 1_700_000_222_000;
+
+        let outcome = attach_agent_loop_provider_state(
+            &db,
+            "mission-runtime",
+            "work-runtime",
+            "friday-session-loop",
+            "run-loop-2",
+            /* completed = */ true,
+            "friday://agent-run/run-loop-2",
+            /* guarded = */ false,
+            now,
+        )
+        .unwrap();
+
+        assert!(matches!(
+            outcome,
+            MissionAttachmentOutcome::Attached {
+                work_item_status: WorkItemStatus::CompletedWithProof,
+                ..
+            }
+        ));
+        assert_eq!(
+            db.get_work_item("work-runtime").unwrap().unwrap().status,
+            WorkItemStatus::CompletedWithProof
+        );
+        assert_eq!(lifecycle_audit_rows(&db), 0);
     }
 }

--- a/rust-core/crates/friday-hub/src/runtime.rs
+++ b/rust-core/crates/friday-hub/src/runtime.rs
@@ -946,6 +946,15 @@ impl<T: Transport> HubRuntime<T> {
         // race `std::env`. DEFAULT-OFF: when off the body is BYTE-IDENTICAL to the pre-NS-6
         // baseline (no passport minted, no new query, normal `Ran`/`Blocked`).
         let passport_mint = passport_mint_from(std::env::var(ENV_PASSPORT_MINT).ok().as_deref());
+        // WI-1 (M-6): read the DARK WorkItem guarded-transition flag ONCE here (the only env read;
+        // semantics in [`workitem_guarded_transition_from`]) and thread the resulting bool into the
+        // private flagged inner fn — the same split-env-read idiom as `passport_mint`. DEFAULT-OFF:
+        // when off the WorkItem status advance is BYTE-IDENTICAL to the pre-WI-1 inline write.
+        let workitem_guarded = workitem_guarded_transition_from(
+            std::env::var(ENV_WORKITEM_GUARDED_TRANSITION)
+                .ok()
+                .as_deref(),
+        );
         self.run_agent_loop_for_mission_with_overrides_flagged(
             mission_lookup,
             session_id,
@@ -954,6 +963,7 @@ impl<T: Transport> HubRuntime<T> {
             policy_override,
             max_turns_override,
             passport_mint,
+            workitem_guarded,
             now_ms,
         )
     }
@@ -994,6 +1004,7 @@ impl<T: Transport> HubRuntime<T> {
         policy_override: Option<&RunPolicy>,
         max_turns_override: Option<u64>,
         passport_mint: bool,
+        workitem_guarded: bool,
         now_ms: i64,
     ) -> Result<MissionBoundLoopOutcome, RoutedLoopError> {
         // PREFLIGHT (fail-closed): validate the Mission/work-item BEFORE any run exists. On
@@ -1056,6 +1067,10 @@ impl<T: Transport> HubRuntime<T> {
             run_id,
             completed,
             &result_link,
+            // WI-1 (M-6): DARK-flag bool threaded from the entrypoint env read. OFF ⇒ the inline
+            // status-advance write (byte-identical); ON ⇒ each hop goes through the guarded
+            // `transition_work_item_status` primitive, adding the atomic hash-chained audit row.
+            workitem_guarded,
             now_ms,
         )?;
 
@@ -1540,6 +1555,21 @@ pub const ENV_PASSPORT_MINT: &str = "FRIDAY_PASSPORT_MINT";
 /// `activity_needs_me_from`). DEFAULT-OFF: `None` (unset) ⇒ false; ON only for the exact
 /// opt-in value `"1"` (trimmed); everything else ⇒ false.
 fn passport_mint_from(raw: Option<&str>) -> bool {
+    matches!(raw.map(str::trim), Some("1"))
+}
+
+/// (WI-1, M-6) Env var for the DARK WorkItem guarded-transition flag. Default-OFF. When ON, a
+/// mission-bound run's WorkItem status advance is routed through the canonical guarded primitive
+/// `friday_storage::Db::transition_work_item_status` so each transition also writes a
+/// hash-chained `audit_ledger` lifecycle row atomically. Flag-OFF is byte-identical to the
+/// pre-WI-1 inline status-advance write (no primitive call, no audit row).
+pub const ENV_WORKITEM_GUARDED_TRANSITION: &str = "FRIDAY_WORKITEM_GUARDED_TRANSITION";
+
+/// Pure flag-matcher for [`ENV_WORKITEM_GUARDED_TRANSITION`] (env read split out so it is
+/// unit-testable without `set_var` — the program-standard env-race-free idiom this file uses).
+/// DEFAULT-OFF: `None` (unset) ⇒ false; ON only for the exact opt-in value `"1"` (trimmed);
+/// everything else ⇒ false.
+fn workitem_guarded_transition_from(raw: Option<&str>) -> bool {
     matches!(raw.map(str::trim), Some("1"))
 }
 
@@ -5259,6 +5289,40 @@ mod tests {
         );
     }
 
+    /// (WI-1, M-6) The pure WorkItem-guarded-transition flag-matcher: DEFAULT-OFF, ON only for the
+    /// exact opt-in `"1"` (trimmed), everything else OFF. Driven directly (no `set_var`) — the
+    /// program-standard env-race-free idiom.
+    #[test]
+    fn workitem_guarded_transition_flag_is_off_by_default_and_on_only_for_exactly_1() {
+        assert!(
+            !workitem_guarded_transition_from(None),
+            "unset ⇒ OFF (prod default)"
+        );
+        assert!(
+            workitem_guarded_transition_from(Some("1")),
+            "exactly \"1\" ⇒ ON"
+        );
+        assert!(
+            workitem_guarded_transition_from(Some(" 1 ")),
+            "trimmed \"1\" ⇒ ON"
+        );
+        for off in ["", "0", "true", "yes", "01", "1 0", "enabled", "TRUE"] {
+            assert!(
+                !workitem_guarded_transition_from(Some(off)),
+                "{off:?} must NOT enable the guarded transition"
+            );
+        }
+        // Sanity: the live env var is unset in the test process ⇒ the real read reports OFF.
+        assert!(
+            !workitem_guarded_transition_from(
+                std::env::var(ENV_WORKITEM_GUARDED_TRANSITION)
+                    .ok()
+                    .as_deref()
+            ),
+            "FRIDAY_WORKITEM_GUARDED_TRANSITION must be unset/off in the test env (prod default)"
+        );
+    }
+
     /// A runtime whose run-owner principal is `principal` (so the confirmed-memory recall — the
     /// NS-6 real item source — is enabled and keyed on it). Mirrors `runtime_with` but sets the
     /// owner instead of `None`.
@@ -5360,6 +5424,7 @@ mod tests {
                 None,
                 None,
                 /* passport_mint = */ true,
+                /* workitem_guarded = */ false,
                 1000,
             )
             .unwrap();
@@ -5439,6 +5504,7 @@ mod tests {
                 None,
                 None,
                 /* passport_mint = */ true,
+                /* workitem_guarded = */ false,
                 1000,
             )
             .unwrap();
@@ -5537,6 +5603,7 @@ mod tests {
                 None,
                 None,
                 /* passport_mint = */ true,
+                /* workitem_guarded = */ false,
                 1000,
             )
             .unwrap();
@@ -5634,6 +5701,7 @@ mod tests {
                 None,
                 None,
                 /* passport_mint = */ false,
+                /* workitem_guarded = */ false,
                 1000,
             )
             .unwrap();


### PR DESCRIPTION
## WI-1 (M-6) — the LIVE-WIRING program's WorkItem guarded-transition loop

### The inline-bypass gap
On the mission-bound run path, a WorkItem's status is advanced by the inline write in `mission_preflight.rs::attach_provider_timeline_state` (sets `work_item.status`, bumps `updated_at_ms`, appends the completion proof receipt, `upsert_work_item`). That write produces **NO hash-chained `audit_ledger` row** — so a completed run's lifecycle hops leave no atomic, tamper-evident audit trail. The canonical primitive `friday_storage::Db::transition_work_item_status` does write that row (status transition + hash-chained audit receipt in ONE transaction), but the run path never went through it.

### The wiring
Behind a NEW flag `FRIDAY_WORKITEM_GUARDED_TRANSITION` (NET-NEW, **default-OFF**), route the (already-legal-hop-pre-checked) status advance through `transition_work_item_status` so the status transition AND a hash-chained audit row commit atomically. The primitive is **NOT modified** — only called.

Threading (split-env-read idiom, mirroring `passport_mint`):
- **Env read** once at the public entrypoint `runtime.rs::HubRuntime::run_agent_loop_for_mission_with_overrides` (~L948), via the pure matcher `workitem_guarded_transition_from(raw: Option<&str>)` that accepts EXACTLY `"1"` after trim.
- Threaded as a pure `bool` through the inner `..._flagged` fn → `mission_runtime.rs::attach_agent_loop_provider_state` → `mission_preflight.rs::attach_provider_timeline_state_guarded` (the fork).
- The public `attach_provider_timeline_state(db, attachment)` signature is preserved (delegates with `guarded=false`), so external callers compile untouched.

### Flag default-OFF + flag-OFF byte-identical
Default-OFF. When OFF the status advance takes the `else` branch which is the **verbatim** pre-WI-1 inline write — no `transition_work_item_status` call, no new audit row, single `now_ms`. Byte-identical to current prod.

### The audit-row-on test (real DB, no network)
- `wi1_agent_loop_single_now_ms_completes_and_writes_chained_audit_rows` — the **production caller shape** (a single `now_ms` driven through `attach_agent_loop_provider_state`): ON ⇒ completes with proof, status `CompletedWithProof`, **5 hash-chained lifecycle audit rows** (one per legal hop), `verify_audit_chain` passes, AND (honesty pin) the persisted WorkItem `updated_at_ms == base now_ms + final hop idx (4)` — locking the ON-only offset to exactly the documented value, not an arbitrary drift.
- `wi1_agent_loop_single_now_ms_flag_off_writes_no_audit_row` — same shape, OFF ⇒ completes with proof, **0** lifecycle audit rows.
- `wi1_flag_on_advances_status_and_writes_hash_chained_audit_rows` / `wi1_flag_off_is_byte_identical_and_writes_no_audit_row` — the `_guarded` seam directly, ON vs OFF.
- `wi1_flag_on_same_status_is_a_noop_with_no_audit_row` — same-status re-attach writes no row.
- `runtime::tests::workitem_guarded_transition_flag_is_off_by_default_and_on_only_for_exactly_1` — the pure flag-matcher (exact `"1"`).

### Legal-hop preserved
The legal-hop pre-check `work_item.status.can_transition_to(next_status)` is **SHARED and runs BEFORE** the `guarded` fork. An illegal hop therefore returns the SAME `Ok(Blocked{"illegal_work_item_transition:..."})` on BOTH paths — **never an `Err`** from the primitive's `try_transition` — so routing through the primitive never errors or blocks the run. Because the pre-check has already proven the hop legal (and the guarded branch is only entered on a status CHANGE), the primitive's `try_transition` cannot fail inside the guarded branch. Verified by `wi1_illegal_hop_is_rejected_the_same_way_on_both_paths_never_errors`.

### Honesty: the ON path has TWO deltas vs OFF (NOT a "drift" fix)
The inline `can_transition_to` pre-check is **deliberately retained** on both paths (it is what yields `Ok(Blocked)` instead of the primitive's `Err`). Both it and the primitive's `try_transition` delegate to the **same `friday_core` method**, so they cannot actually drift. WI-1 therefore does **not** remove the parallel hop logic. The concrete, honest delta of the ON path vs OFF is **exactly two things**:
1. the **atomic hash-chained `audit_ledger` lifecycle rows** (one per legal hop); and
2. an **ON-only `updated_at_ms` +offset** (≤ +4ms, one per hop index) on the **WorkItem** and, on completion, the **Mission** row — a direct consequence of the per-hop `now_ms` introduced below to keep `audit_id`s unique.

The resulting **status**, **proof_refs**, and the **MissionLink** are **identical** on both paths (the MissionLink's `created_at_ms` is preserved from the first hop = base `now_ms` by the `ON CONFLICT … DO UPDATE` clause, which does not overwrite `created_at_ms`). The OFF path is byte-identical to pre-WI-1. (No fake "fixes fake completion" claim — the inline path already enforces legal hops + proof-on-completion.)

### audit_id uniqueness fix (collision found and fixed)
`audit_id` is derived from `(work_item_id, now_ms)` and is the `audit_ledger` PRIMARY KEY. `attach_agent_loop_provider_state` drives MULTIPLE hops for the SAME work_item with a single caller-side `now_ms`. A first naive wiring reused that `now_ms` for every hop → the 2nd hop's audit insert hit `UNIQUE constraint failed: audit_ledger.audit_id`, the primitive returned `Err`, and **the run errored under flag-ON** (caught by the production-shape test, which failed before the fix). Fix: **ON-path only**, each hop gets a distinct `now_ms` (per-hop monotonic offset `now_ms + idx`) in the loop; OFF keeps the single `now_ms` (byte-identical). Trade-off (ON only): the ON-path WorkItem `updated_at_ms` and, on completion, the Mission `updated_at_ms` land at `now_ms+4` (the final hop, idx=4) rather than `now_ms`. The **MissionLink `created_at_ms` does NOT shift** — it is written on the first hop (idx=0 = base `now_ms`) and preserved across re-upserts. Acceptable: ON is the explicitly-differing path; status, proof_refs, and link identity are unchanged. Pinned by the ON test's `updated_at_ms == now_ms + 4` assertion.

### Out of WI-1's named scope (documented boundaries, not silent omissions)
- The in-process **ask dispatch** path (`mission_runtime.rs::attach_completed_provider_state_for_ask` → public `attach_provider_timeline_state`) stays `guarded=false` (byte-identical). WI-1's named target (scope §(c)) is the **agent-loop run path** (`attach_agent_loop_provider_state`). Wiring the ask path is a named follow-up.
- `preflight_and_stage_work_item` (mission_preflight.rs:148) advances `Draft → ReadyToDispatch` via a bare `upsert_work_item`, but that is the **initial persist** of the row (created alongside the mission/conversation), not a run-path advance — and the primitive requires a pre-existing row. Out of WI-1's named scope.

### Files touched
- `rust-core/crates/friday-hub/src/mission_preflight.rs` — `attach_provider_timeline_state_guarded` (the fork); public wrapper preserved.
- `rust-core/crates/friday-hub/src/mission_runtime.rs` — `attach_agent_loop_provider_state` gains `guarded: bool` + per-hop `now_ms` (ON-only); ON test pins `updated_at_ms`.
- `rust-core/crates/friday-hub/src/runtime.rs` — `ENV_WORKITEM_GUARDED_TRANSITION` + `workitem_guarded_transition_from` + env read at the entrypoint, threaded through `_flagged`.
- **NOT touched:** `hub_server.rs` (public entrypoint signature unchanged — not needed), `friday-storage/src/lib.rs` / `mission.rs` (**the primitive is only called, never modified**).

### Gate (from `rust-core`, in order)
`cargo fmt --all -- --check` ✓ · `cargo clippy --workspace --all-targets -- -D warnings` ✓ · `cargo build -p friday-hub` ✓ · `cargo test -p friday-hub` ✓ (lib 635 passed / 0 failed; all integration suites pass).

> Substrate/reachability only — every flag is default-OFF and dark; production behavior is unchanged until the operator-gated flip (`FRIDAY_WORKITEM_GUARDED_TRANSITION=1` on an already-live mission-bound path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
