### PR TITLE
feat(f11-skel): add friday-vision/ocr/tts/pdf/browser crate skeletons + workspace members/deps (no logic)

### DIFF
--- a/rust-core/Cargo.lock
+++ b/rust-core/Cargo.lock
@@ -629,6 +629,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "friday-browser"
+version = "0.0.1"
+
+[[package]]
 name = "friday-core"
 version = "0.0.1"
 dependencies = [
@@ -707,6 +711,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "friday-ocr"
+version = "0.0.1"
+
+[[package]]
 name = "friday-operator-cli"
 version = "0.0.1"
 dependencies = [
@@ -733,6 +741,10 @@ dependencies = [
  "thiserror 1.0.69",
  "zeroize",
 ]
+
+[[package]]
+name = "friday-pdf"
+version = "0.0.1"
 
 [[package]]
 name = "friday-protocol"
@@ -789,6 +801,14 @@ dependencies = [
  "thiserror 1.0.69",
  "tungstenite",
 ]
+
+[[package]]
+name = "friday-tts"
+version = "0.0.1"
+
+[[package]]
+name = "friday-vision"
+version = "0.0.1"
 
 [[package]]
 name = "fs-err"

--- a/rust-core/Cargo.toml
+++ b/rust-core/Cargo.toml
@@ -29,6 +29,12 @@ members = [
     "crates/friday-operator-cli",
     "crates/friday-operator-signer",
     "crates/friday-arch-tests",
+    # F11 net-new media-capability crates (skeleton stubs; no logic/deps/executors yet).
+    "crates/friday-vision",
+    "crates/friday-ocr",
+    "crates/friday-tts",
+    "crates/friday-pdf",
+    "crates/friday-browser",
 ]
 
 [workspace.package]
@@ -71,6 +77,12 @@ friday-fs = { path = "crates/friday-fs" }
 friday-hub = { path = "crates/friday-hub" }
 friday-ffi = { path = "crates/friday-ffi" }
 friday-operator-cli = { path = "crates/friday-operator-cli" }
+# F11 net-new media-capability crates (skeleton stubs; no logic/deps/executors yet).
+friday-vision = { path = "crates/friday-vision" }
+friday-ocr = { path = "crates/friday-ocr" }
+friday-tts = { path = "crates/friday-tts" }
+friday-pdf = { path = "crates/friday-pdf" }
+friday-browser = { path = "crates/friday-browser" }
 
 [profile.dev]
 # bundled SQLite compiles faster with some opt; keep debug assertions on.

--- a/rust-core/crates/friday-browser/Cargo.toml
+++ b/rust-core/crates/friday-browser/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "friday-browser"
+description = "Friday F11 net-new media capability — browser crate skeleton. Empty compiling stub, no logic/deps/executors yet (Hub-only, heavy-binary → stays OUT of friday-ffi's phone dependency graph)."
+edition.workspace = true
+version.workspace = true
+license.workspace = true
+publish = false
+rust-version.workspace = true

--- a/rust-core/crates/friday-browser/src/lib.rs
+++ b/rust-core/crates/friday-browser/src/lib.rs
@@ -1,0 +1,7 @@
+//! Friday F11 net-new media capability — browser crate.
+//!
+//! Skeleton placeholder only: this crate carries no logic, no dependencies, and
+//! no executor yet. The BrowserBackend trait, the StubBrowserBackend, the
+//! action/param schema, the security guards, and the cargo-feature spine for
+//! the live CDP backend land in later F11 crate-internal PRs (B1, B2a-d). The
+//! `impl ToolExecutor` wrapper is a `friday-hub` module, not part of this crate.

--- a/rust-core/crates/friday-ocr/Cargo.toml
+++ b/rust-core/crates/friday-ocr/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "friday-ocr"
+description = "Friday F11 net-new media capability — ocr crate skeleton. Empty compiling stub, no logic/deps/executors yet (Hub-only, provider-secret-bearing → stays OUT of friday-ffi's phone dependency graph)."
+edition.workspace = true
+version.workspace = true
+license.workspace = true
+publish = false
+rust-version.workspace = true

--- a/rust-core/crates/friday-ocr/src/lib.rs
+++ b/rust-core/crates/friday-ocr/src/lib.rs
@@ -1,0 +1,7 @@
+//! Friday F11 net-new media capability — ocr crate.
+//!
+//! Skeleton placeholder only: this crate carries no logic, no dependencies, and
+//! no executor yet. The OcrProvider DI trait, the live vision-LLM `ureq`
+//! transport, and the deterministic stub land in a later F11 crate-internal PR
+//! (OCR-1). The `impl ToolExecutor` wrapper is a `friday-hub` module, not part
+//! of this crate.

--- a/rust-core/crates/friday-pdf/Cargo.toml
+++ b/rust-core/crates/friday-pdf/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "friday-pdf"
+description = "Friday F11 net-new media capability — pdf_parse crate skeleton. Empty compiling stub, no logic/deps/executors yet (Hub-only, no phone surface → stays OUT of friday-ffi's dependency graph)."
+edition.workspace = true
+version.workspace = true
+license.workspace = true
+publish = false
+rust-version.workspace = true

--- a/rust-core/crates/friday-pdf/src/lib.rs
+++ b/rust-core/crates/friday-pdf/src/lib.rs
@@ -1,0 +1,8 @@
+//! Friday F11 net-new media capability — pdf_parse crate.
+//!
+//! Skeleton placeholder only: this crate carries no logic, no dependencies, and
+//! no executor yet. The PdfTextExtractor trait, the deterministic stub, and the
+//! clamp/page-window/truncate logic land in a later F11 crate-internal PR
+//! (PDF-1); the real embedded-text extractor lands behind a default-OFF cargo
+//! feature (PDF-2). The `impl ToolExecutor` wrapper is a `friday-hub` module,
+//! not part of this crate.

--- a/rust-core/crates/friday-tts/Cargo.toml
+++ b/rust-core/crates/friday-tts/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "friday-tts"
+description = "Friday F11 net-new media capability — tts crate skeleton. Empty compiling stub, no logic/deps/executors yet (Hub-only, provider-secret-bearing → stays OUT of friday-ffi's phone dependency graph)."
+edition.workspace = true
+version.workspace = true
+license.workspace = true
+publish = false
+rust-version.workspace = true

--- a/rust-core/crates/friday-tts/src/lib.rs
+++ b/rust-core/crates/friday-tts/src/lib.rs
@@ -1,0 +1,7 @@
+//! Friday F11 net-new media capability — tts crate.
+//!
+//! Skeleton placeholder only: this crate carries no logic, no dependencies, and
+//! no executor yet. The TtsTransport DI seam, the live `ureq` transport, the
+//! UnavailableTransport default, and the test stub land in a later F11
+//! crate-internal PR (TTS-2). The `impl ToolExecutor` wrapper is a `friday-hub`
+//! module, not part of this crate.

--- a/rust-core/crates/friday-vision/Cargo.toml
+++ b/rust-core/crates/friday-vision/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "friday-vision"
+description = "Friday F11 net-new media capability — vision (image_analysis) crate skeleton. Empty compiling stub, no logic/deps/executors yet (Hub-only, provider-secret-bearing → stays OUT of friday-ffi's phone dependency graph)."
+edition.workspace = true
+version.workspace = true
+license.workspace = true
+publish = false
+rust-version.workspace = true

--- a/rust-core/crates/friday-vision/src/lib.rs
+++ b/rust-core/crates/friday-vision/src/lib.rs
@@ -1,0 +1,6 @@
+//! Friday F11 net-new media capability — vision (image_analysis) crate.
+//!
+//! Skeleton placeholder only: this crate carries no logic, no dependencies, and
+//! no executor yet. The VisionModelClient DI trait, the live `ureq` transport,
+//! and the deterministic stub land in a later F11 crate-internal PR (VIS-1). The
+//! `impl ToolExecutor` wrapper is a `friday-hub` module, not part of this crate.


### PR DESCRIPTION
## F11 net-new media capabilities — Wave 1 (SKEL)

The sole `rust-core/Cargo.toml` PR for the F11 program: lands all five net-new media-capability crates as compiling **empty stubs** plus the single manifest serialize edit, so every later F11 crate-internal PR is file-disjoint inside its own crate (no 5-deep "add-crate-to-Cargo.toml + logic" chain).

### The five net-new crates (empty stubs, no logic)
- `rust-core/crates/friday-vision/` (`Cargo.toml` + `src/lib.rs`) — image_analysis
- `rust-core/crates/friday-ocr/` (`Cargo.toml` + `src/lib.rs`)
- `rust-core/crates/friday-tts/` (`Cargo.toml` + `src/lib.rs`)
- `rust-core/crates/friday-pdf/` (`Cargo.toml` + `src/lib.rs`)
- `rust-core/crates/friday-browser/` (`Cargo.toml` + `src/lib.rs`)

Each crate is just a `//!` doc-commented empty `lib.rs` + a minimal `Cargo.toml` (`version` 0.0.1 via `version.workspace`, workspace edition, matching the existing small-crate shape). No `[dependencies]`, no `[lints]` (the workspace defines no `[workspace.lints]`).

### The single Cargo.toml edit
`rust-core/Cargo.toml`: all five crates added to the EXPLICIT `members` list AND `[workspace.dependencies]` (`friday-<name> = { path = "crates/friday-<name>" }`), matching the existing entries' format. `Cargo.lock` updated with the five new zero-dep package entries.

### Carries no logic / deps / executors — and outside the ffi graph
NO `ToolExecutor` impl, NO registry change, NO `tool_name_map`/`capability` change, NO `friday-hub` dep, NO external deps. The crates declare zero internal deps, so they stay **OUTSIDE `friday-ffi`'s phone dependency graph** — the `friday-arch-tests` dependency-boundary test (`tests/dep_boundary.rs`) stays green (the five crates are isolated nodes, never reachable from the ffi closure). The DI traits, transports, stubs, and the hub-side `impl ToolExecutor` wrappers land in later F11 PRs.

### rust-core workspace gate — all green (in order)
- `cargo fmt --all -- --check` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean (all 5 stubs compile clippy-clean)
- `cargo build --workspace` — clean
- `cargo test --workspace` — green, including the `friday-arch-tests` dependency-boundary tests (`ffi_dependency_closure_excludes_deepseek`, `hub_is_the_secret_bearing_composition_root_and_phone_is_not`, +2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)