### PR TITLE
feat(ns45-pr1): bind AgentRunRequest to a first-class mission_context handle, retire surface_thread shim (FRIDAY_MISSION_BOUND_RUN, default-OFF)

### DIFF
--- a/rust-core/crates/friday-ffi/src/lib.rs
+++ b/rust-core/crates/friday-ffi/src/lib.rs
@@ -3409,6 +3409,7 @@ mod tests {
                 auth_proof: vec![],
                 session_id: None,
                 constraints: None,
+                mission_context: None,
             },
         );
         match parse_hub_response(request.encode().unwrap()) {

--- a/rust-core/crates/friday-hub/src/bin/hub_agent_run_server.rs
+++ b/rust-core/crates/friday-hub/src/bin/hub_agent_run_server.rs
@@ -449,10 +449,12 @@ fn agent_run_control_enabled_from(raw: Option<&str>) -> bool {
 /// run takes the EXISTING unbound dispatch (`run_authed_agent_loop_with_policy` /
 /// `run_session_task_with_overrides`), BYTE-IDENTICAL to today, so deploying this binary changes
 /// NO live behavior until the operator flips this SEPARATE flag. Even with the flag ON, a run is
-/// bound only if a `MissionContextLookup` resolves (no prod surface-thread-keyed session exists
-/// yet); otherwise it falls through unbound. SEPARATE from `FRIDAY_ROUTE_AGENT_RUN_VIA_RUST`
-/// (run-START) and `FRIDAY_AGENT_RUN_CONTROL_VIA_RUST` (run-CONTROL); flipping THIS one is an
-/// operator cutover decision gated on organic Mission ingress.
+/// bound only if it carries a FIRST-CLASS `mission_context` handle (NS45-PR1 / M-4) that resolves
+/// to a live Mission/WorkItem via `MissionContextLookup::by_mission_work_item`; a run with no
+/// handle (every live courier today) falls through unbound. SEPARATE from
+/// `FRIDAY_ROUTE_AGENT_RUN_VIA_RUST` (run-START) and `FRIDAY_AGENT_RUN_CONTROL_VIA_RUST`
+/// (run-CONTROL); flipping THIS one is an operator cutover decision gated on organic Mission
+/// ingress (the courier populating `AgentRunRequest.mission_context`).
 const MISSION_BOUND_RUN_ENABLED_ENV: &str = "FRIDAY_MISSION_BOUND_RUN";
 
 /// Pure flag-matcher for [`MISSION_BOUND_RUN_ENABLED_ENV`] (separated from the env read so it is
@@ -682,6 +684,12 @@ fn serve_sealed_session<S: Read + Write, T: Transport>(
                 // result through the per-run policy override the runtime now accepts. ABSENT
                 // (`None`) ⇒ NO override ⇒ the boot policy/ceiling, byte-identical to pre-A1.
                 constraints,
+                // (NS45-PR1 / M-4) The FIRST-CLASS Mission handle this run binds to, retiring the
+                // `session_id`-as-surface-thread shim NS-4 used for mission resolution. ABSENT
+                // (`None`) ⇒ NO handle ⇒ the run is NOT mission-resolvable ⇒ the unbound path,
+                // byte-identical to today. PRESENT ⇒ the mission-bound seam (when the flag is ON)
+                // resolves the Mission via `by_mission_work_item` from this handle.
+                mission_context,
             } => {
                 // The dispatch arm: AUTH BEFORE ANY RUN. The `auth_proof` is the peer-sealed
                 // challenge; reconstruct it as a `Sealed` for the session-key open. A malformed
@@ -766,21 +774,25 @@ fn serve_sealed_session<S: Read + Write, T: Transport>(
                 };
                 let policy_override = effective_policy.as_ref();
 
-                // (NS-4) MISSION-BOUND seam — FLAG-GATED, the FIRST dispatch consulted. When
-                // `FRIDAY_MISSION_BOUND_RUN` is ON **and** this run's `session_id` resolves to a
-                // live DeepSeek-lane Mission surface, the run is dispatched BOUND (minting the
-                // mission-birth + WorkItem bind) and the seam returns `Some(answer)`. Otherwise it
-                // returns `None` and we fall through to the EXISTING unbound dispatch below —
-                // BYTE-IDENTICAL to the pre-NS-4 path. With the flag OFF the `else` arm binds
-                // `None` WITHOUT ever calling the seam, so a flag-off run takes the exact same
-                // `match session_id` it always has.
+                // (NS45-PR1 / M-4) MISSION-BOUND seam — FLAG-GATED, the FIRST dispatch consulted.
+                // When `FRIDAY_MISSION_BOUND_RUN` is ON **and** this run carries a FIRST-CLASS
+                // `mission_context` handle that resolves to a live DeepSeek-lane Mission/WorkItem,
+                // the run is dispatched BOUND (minting the mission-birth + WorkItem bind) and the
+                // seam returns `Some(answer)`. Otherwise it returns `None` and we fall through to
+                // the EXISTING unbound dispatch below — BYTE-IDENTICAL to the pre-NS-4 path.
+                //
+                // The mission handle, NOT the `session_id` shim, is now the resolution source
+                // (M-4: the provisional surface-thread conflation is retired). With the flag OFF
+                // the `else` arm binds `None` WITHOUT ever calling the seam; and with the flag ON
+                // but NO handle the seam returns `None` immediately — in BOTH cases the run takes
+                // the exact same `match session_id` unbound dispatch it always has, byte-identical.
                 let mission_bound = if mission_bound_run_enabled {
                     friday_hub::hub_server::run_authed_agent_loop_mission_bound(
                         runtime,
                         &caller,
                         &run_id,
                         &task,
-                        session_id.as_deref(),
+                        mission_context.as_ref(),
                         policy_override,
                         max_turns_override,
                         now_ms,
@@ -1436,6 +1448,7 @@ mod tests {
                 auth_proof: auth_proof_bytes(client_session, session_nonce, principal, run_id),
                 session_id: None,
                 constraints: None,
+                mission_context: None,
             },
         )
     }
@@ -1461,6 +1474,7 @@ mod tests {
                 auth_proof: auth_proof_bytes(client_session, session_nonce, principal, run_id),
                 session_id: Some(session_id.to_string()),
                 constraints: None,
+                mission_context: None,
             },
         )
     }
@@ -2202,6 +2216,7 @@ mod tests {
                     auth_proof: bad_proof,
                     session_id: None,
                     constraints: None,
+                    mission_context: None,
                 },
             );
             (req, session.clone(), session.clone())
@@ -2573,6 +2588,7 @@ mod tests {
                     auth_proof: proof,
                     session_id: None,
                     constraints: None,
+                    mission_context: None,
                 },
             );
             ws_send_envelope(&mut ws, &sess_c1, &req, SESSION_AAD).unwrap();
@@ -2612,6 +2628,7 @@ mod tests {
                     auth_proof: captured_proof,
                     session_id: None,
                     constraints: None,
+                    mission_context: None,
                 },
             );
             ws_send_envelope(&mut ws, &sess_c2, &req, SESSION_AAD).unwrap();

--- a/rust-core/crates/friday-hub/src/hub_server.rs
+++ b/rust-core/crates/friday-hub/src/hub_server.rs
@@ -1547,21 +1547,35 @@ pub fn run_authed_agent_loop_with_policy<T: Transport>(
 /// owner) returns a body-free `NoAnswer` and the loop NEVER runs (no row, no recall, no spend,
 /// no mission bind). The Mission-bound path must not be a way around the owner gate.
 ///
-/// ## Provisional ingress (DARK; the deferred live-reachability)
-/// The wire `AgentRunRequest` carries NO Mission handle yet, so the ONLY run-scoped key
-/// available is the client-asserted `session_id`, mapped to a surface thread via
-/// [`MissionContextLookup::by_surface_thread`]. This conflates a chat-session id with a
-/// surface-thread id, which is SAFE only because resolution fails CLOSED (`Blocked` ⇒ `None` ⇒
-/// unbound). A first-class Mission handle on the wire (organic ingress) + the operator cutover
-/// plane are the DEFERRED prerequisites for this seam to move the live needle. Until then the
-/// flag is OFF and this returns `None` for every live request (no surface-thread-keyed session
-/// exists in prod), so the live run path is unchanged.
+/// ## First-class Mission-handle ingress (NS45-PR1 / M-4)
+/// Resolution now keys off the FIRST-CLASS `mission_context` handle the wire `AgentRunRequest`
+/// carries — `{friday_conversation_id, mission_id, work_item_id}` — mapped via
+/// [`MissionContextLookup::by_mission_work_item`]. This RETIRES the provisional NS-4 shim that
+/// conflated the client-asserted `session_id` with a surface-thread id for mission resolution
+/// (the `session_id` field stays on the wire for the sessioned-chat unbound path, but it is NO
+/// LONGER the mission-resolution key). A run with NO handle (`None`) is NOT mission-resolvable ⇒
+/// `None` ⇒ the caller falls through to the unbound path, BYTE-IDENTICAL to today. The handle is
+/// a CLIENT ASSERTION that selects WHICH Mission to bind to; it is never an authority — the
+/// FIX-Q2 owner gate below is the authority.
+///
+/// The handle is populated by organic ingress (the native client / courier from the NS-5
+/// `MissionIntakeResult`) + the operator flips the flag; until both exist the flag is OFF and
+/// this returns `None` for every live request, so the live run path is unchanged.
+///
+/// ## Go-live caveat (DEFERRED — a named gate, NOT added here)
+/// A client-asserted `mission_id` under an `owner_allowlist > 1` is a cross-principal resolution
+/// surface (the same deferred class as M-3/M-5). It is SAFE under single-owner v1 + the FIX-Q2
+/// owner gate (the single configured owner is the only principal that can dispatch a bound run).
+/// Enforcing that a multi-owner caller actually OWNS the asserted `mission_id` is a NAMED go-live
+/// gate — this PR resolves the handle but does NOT add that multi-owner ownership check.
 ///
 /// ## Semantics worth stating
-/// The bound path is SESSIONLESS (`run_task_with_overrides`, no history fold): a `session_id`
-/// that resolves to a Mission surface dispatches a bound WORK-run, not a sessioned chat — prior
-/// turns are not folded. The override threading matches the unbound arm so a peer-asserted
-/// tightening constraint is enforced identically (read-only / disabled-tools / max-turns).
+/// The bound path is SESSIONLESS (`run_task_with_overrides`, no history fold): a handle dispatches
+/// a bound WORK-run, not a sessioned chat — prior turns are not folded. The provider-timeline
+/// session label for the Mission bind is derived from the handle's `friday_conversation_id` (the
+/// canonical conversation the run belongs to), NOT the `session_id` shim. The override threading
+/// matches the unbound arm so a peer-asserted tightening constraint is enforced identically
+/// (read-only / disabled-tools / max-turns).
 ///
 /// The bound path is pinned to `WorkLane::DeepSeek` (the single live provider) by
 /// `run_agent_loop_for_mission_with_overrides` — expected, not a defect.
@@ -1571,18 +1585,22 @@ pub fn run_authed_agent_loop_mission_bound<T: Transport>(
     caller: &AuthedPrincipal,
     run_id: &str,
     task: &str,
-    session_id: Option<&str>,
+    mission_context: Option<&MissionWorkItemContextWire>,
     policy_override: Option<&crate::RunPolicy>,
     max_turns_override: Option<u64>,
     now_ms: i64,
 ) -> Option<AuthedAnswer> {
-    // Derive a MissionContextLookup from the only run-scoped key on the wire: the client-asserted
-    // `session_id` (treated as a surface-thread id). A sessionless run (or a blank session id) is
-    // NOT mission-resolvable ⇒ `None` ⇒ the caller falls through to the unbound path unchanged.
-    let lookup = session_id
-        .map(str::trim)
-        .filter(|s| !s.is_empty())
-        .map(MissionContextLookup::by_surface_thread)?;
+    // (NS45-PR1 / M-4) Derive the MissionContextLookup from the FIRST-CLASS handle on the wire —
+    // NOT the `session_id` surface-thread shim. A run with NO handle (`None`) is NOT
+    // mission-resolvable ⇒ `None` ⇒ the caller falls through to the unbound path unchanged. This
+    // is the retirement point of the provisional shim: a flag-ON run with no handle takes the
+    // exact same unbound dispatch as a flag-OFF run.
+    let handle = mission_context?;
+    let lookup = MissionContextLookup::by_mission_work_item(
+        handle.friday_conversation_id.clone(),
+        handle.mission_id.clone(),
+        handle.work_item_id.clone(),
+    );
 
     // (FIX-Q2) caller == configured-owner, asserted BEFORE any dispatch — the SAME fail-closed
     // guard the unbound entry enforces. A mismatch (or an unconfigured `None` owner) ⇒ a
@@ -1597,9 +1615,12 @@ pub fn run_authed_agent_loop_mission_bound<T: Transport>(
         }
     }
 
-    // The session id doubles as the provider-timeline session for the Mission bind. A non-empty
-    // value is guaranteed by the `filter`/`map` above.
-    let session = session_id.map(str::trim).filter(|s| !s.is_empty())?;
+    // The provider-timeline session label for the Mission bind (the `friday_session_id` baked into
+    // the MissionLink `target_ref`). NS45-PR1 derives it from the handle's `friday_conversation_id`
+    // — the canonical conversation this run belongs to — instead of the retired surface-thread
+    // shim. It is a label; the preflight has already resolved+validated the handle, so this id
+    // matches the Mission's conversation by the time the bind runs.
+    let session = handle.friday_conversation_id.as_str();
 
     match runtime.run_agent_loop_for_mission_with_overrides(
         lookup,
@@ -6650,14 +6671,17 @@ mod authed_route_tests {
         );
     }
 
-    // --- NS-4: the flag-gated MISSION-BOUND run seam --------------------------
+    // --- NS-4 / NS45-PR1: the flag-gated MISSION-BOUND run seam ---------------
     //
     // `run_authed_agent_loop_mission_bound` is the live-reachable counterpart of the unbound
-    // entry: when (in the bin) `FRIDAY_MISSION_BOUND_RUN` is ON and a `session_id` resolves to a
-    // live DeepSeek-lane Mission surface, a run is dispatched BOUND (minting the mission-birth +
-    // WorkItem bind). These tests drive the SEAM directly (the bin's flag plumbing is exercised by
-    // its own `*_enabled_from` matcher tests). The flag-on test proves REAL mission binding
-    // (MissionLink + WorkItem transition + route_decision); the flag-off/no-mission tests prove
+    // entry: when (in the bin) `FRIDAY_MISSION_BOUND_RUN` is ON and the run carries a FIRST-CLASS
+    // `mission_context` handle that resolves to a live DeepSeek-lane Mission/WorkItem, a run is
+    // dispatched BOUND (minting the mission-birth + WorkItem bind). NS45-PR1 (M-4) retired the
+    // `session_id`-as-surface-thread shim: resolution now keys off the handle
+    // `{friday_conversation_id, mission_id, work_item_id}` via `by_mission_work_item`. These tests
+    // drive the SEAM directly (the bin's flag plumbing is exercised by its own `*_enabled_from`
+    // matcher tests). The flag-on test proves REAL mission binding (MissionLink + WorkItem
+    // transition + route_decision); the flag-off / no-handle / unresolvable tests prove
     // byte-identical fall-through.
 
     use friday_core::{
@@ -6669,10 +6693,22 @@ mod authed_route_tests {
         WorkItemStatus as NsWorkItemStatus, WorkLane as NsWorkLane,
     };
 
-    /// Stage a `FridayConversation -> Mission -> WorkItem` graph the seam's preflight resolves,
-    /// with the SurfaceThread keyed by `surface_thread_id` — the SAME id the seam derives the
-    /// `MissionContextLookup` from (the run's `session_id`). A DeepSeek-lane / `deepseek`-target
-    /// active WorkItem makes the bound dispatch RESOLVABLE.
+    /// The FIRST-CLASS Mission handle (NS45-PR1) that resolves against the graph
+    /// [`ns4_seed_mission`] stages — the three ids match the seeded
+    /// `FridayConversation`/`Mission`/`WorkItem` rows, so `by_mission_work_item` resolves Ready.
+    fn ns4_handle() -> MissionWorkItemContextWire {
+        MissionWorkItemContextWire {
+            friday_conversation_id: "fconv_ns4".into(),
+            mission_id: "mission-ns4".into(),
+            work_item_id: "work-ns4".into(),
+        }
+    }
+
+    /// Stage a `FridayConversation -> Mission -> WorkItem` graph the seam's preflight resolves via
+    /// the FIRST-CLASS handle (`{fconv_ns4, mission-ns4, work-ns4}` — see [`ns4_handle`]). The
+    /// `surface_thread_id` arg is seeded for graph realism but is NO LONGER the resolution key
+    /// (NS45-PR1 retired the surface-thread shim). A DeepSeek-lane / `deepseek`-target active
+    /// WorkItem makes the bound dispatch RESOLVABLE.
     fn ns4_seed_mission<T: Transport>(rt: &HubRuntime<T>, surface_thread_id: &str) {
         let now = 1_700_000_000_000;
         let db = rt.db();
@@ -6802,13 +6838,15 @@ mod authed_route_tests {
         ns4_seed_mission(&rt, surface);
         let caller = authed("principal:owner");
 
-        // The seam is consulted (as the bin does when the flag is ON) with the run's session_id.
+        // The seam is consulted (as the bin does when the flag is ON) with the run's FIRST-CLASS
+        // mission_context handle (NS45-PR1) — NOT the session_id surface-thread shim.
+        let handle = ns4_handle();
         let out = run_authed_agent_loop_mission_bound(
             &rt,
             &caller,
             "run-ns4-bound",
             "do the mission work",
-            Some(surface),
+            Some(&handle),
             None,
             None,
             1000,
@@ -6830,11 +6868,16 @@ mod authed_route_tests {
         );
         assert!(!proof.contains("authed-route-test-secret"));
 
-        // REAL mission binding #1 — a MissionLink ties THIS run to the Mission/WorkItem.
+        // REAL mission binding #1 — a MissionLink ties THIS run to the Mission/WorkItem. NS45-PR1:
+        // the provider-timeline session label is derived from the handle's friday_conversation_id
+        // (the retired surface-thread shim is no longer the label source).
         let links = rt.db().list_mission_links("mission-ns4").unwrap();
         assert!(
             links.iter().any(|link| link.target_ref
-                == format!("friday://provider-timeline/{surface}#run-ns4-bound")
+                == format!(
+                    "friday://provider-timeline/{}#run-ns4-bound",
+                    handle.friday_conversation_id
+                )
                 && link.work_item_id.as_deref() == Some("work-ns4")),
             "a mission_link must bind THIS run to the mission: {links:?}"
         );
@@ -6863,11 +6906,13 @@ mod authed_route_tests {
         assert!(friday_storage::audit::verify_audit_chain(rt.db().conn()).is_ok());
     }
 
-    /// FLAG-OFF byte-identical: when the flag is OFF, the bin NEVER calls the seam — every run
-    /// takes the EXACT unbound `run_authed_agent_loop_with_policy` path. This test pins that
-    /// unbound result, with the SAME Mission staged, produces ZERO mission binding (no
-    /// MissionLink, no WorkItem transition, no route_decision) and delivers the IDENTICAL body —
-    /// i.e. the run is byte-identical to today even though a resolvable Mission exists.
+    /// FLAG-OFF byte-identical: when the flag is OFF, the bin NEVER calls the seam (the
+    /// `if mission_bound_run_enabled { seam } else { None }` else-arm) — every run takes the EXACT
+    /// unbound `run_authed_agent_loop_with_policy` path, even one carrying a resolvable
+    /// `mission_context` handle. This test pins that unbound result, with the SAME Mission staged,
+    /// produces ZERO mission binding (no MissionLink, no WorkItem transition, no route_decision)
+    /// and delivers the IDENTICAL body — i.e. the run is byte-identical to today even though a
+    /// resolvable Mission exists.
     #[test]
     fn mission_bound_flag_off_is_byte_identical_unbound_run_no_binding() {
         let (rt, _ws) = runtime_with(
@@ -6927,11 +6972,12 @@ mod authed_route_tests {
         );
     }
 
-    /// FLAG-ON but NO resolvable Mission: a `session_id` that is an ordinary chat session (no
-    /// surface-thread row / no bound mission) makes the seam fail CLOSED to `None` — the caller
-    /// falls through to the unbound path, byte-identical to today. The preflight wrote NOTHING.
+    /// FLAG-ON but UNRESOLVABLE handle: a `mission_context` handle pointing at a Mission/WorkItem
+    /// that does NOT exist (no graph staged) makes the seam fail CLOSED to `None` — the caller
+    /// falls through to the unbound path, byte-identical to today, with NO crash. The preflight
+    /// blocked BEFORE `create_run`, so it wrote NOTHING.
     #[test]
-    fn mission_bound_seam_on_unresolvable_falls_through_none_no_binding() {
+    fn mission_bound_seam_on_unresolvable_handle_falls_through_none_no_binding() {
         let (rt, _ws) = runtime_with(
             "ns4-fallthrough",
             FinishTransport {
@@ -6939,24 +6985,29 @@ mod authed_route_tests {
             },
             "principal:owner",
         );
-        // NO mission staged — the session_id does not resolve to a surface-thread-bound mission.
+        // NO mission staged — the handle's ids do not resolve to a real Mission/WorkItem.
         let caller = authed("principal:owner");
+        let unresolvable = MissionWorkItemContextWire {
+            friday_conversation_id: "fconv_does_not_exist".into(),
+            mission_id: "mission_does_not_exist".into(),
+            work_item_id: "work_does_not_exist".into(),
+        };
 
         let out = run_authed_agent_loop_mission_bound(
             &rt,
             &caller,
             "run-ns4-ft",
             "do work",
-            Some("ordinary-chat-session"),
+            Some(&unresolvable),
             None,
             None,
             1000,
         );
 
-        // The seam returned None ⇒ the caller falls through to the unbound dispatch.
+        // The seam returned None ⇒ the caller falls through to the unbound dispatch (no crash).
         assert!(
             out.is_none(),
-            "an unresolvable mission must fall through (None), not bind"
+            "an unresolvable handle must fall through (None), not bind / not crash"
         );
         // The fail-closed preflight wrote nothing: no run, no route_decision, no mission_link.
         assert_eq!(
@@ -6968,12 +7019,14 @@ mod authed_route_tests {
         assert_eq!(table_count(&rt, "mission_link"), 0);
     }
 
-    /// FLAG-ON sessionless: a run with NO `session_id` is NOT mission-resolvable ⇒ the seam
-    /// returns `None` immediately (before any DB touch) and the caller falls through unbound.
+    /// FLAG-ON no-handle: a run with NO `mission_context` handle is NOT mission-resolvable ⇒ the
+    /// seam returns `None` immediately (before any DB touch / owner-gate) and the caller falls
+    /// through unbound — the retirement point of the surface-thread shim (a `session_id` alone no
+    /// longer makes a run mission-bound).
     #[test]
-    fn mission_bound_seam_on_sessionless_returns_none() {
+    fn mission_bound_seam_on_no_handle_returns_none() {
         let (rt, _ws) = runtime_with(
-            "ns4-sessionless",
+            "ns4-no-handle",
             FinishTransport {
                 answer: BODY.to_string(),
             },
@@ -6987,12 +7040,12 @@ mod authed_route_tests {
             &caller,
             "run-ns4-none",
             "do work",
-            None, // sessionless — no key to resolve a mission
+            None, // no handle — no key to resolve a mission
             None,
             None,
             1000,
         );
-        assert!(out.is_none(), "a sessionless run is not mission-bound");
+        assert!(out.is_none(), "a run with no handle is not mission-bound");
         // No run was created by the seam (it returned None before any dispatch).
         assert_eq!(agent_run_count(&rt, "run-ns4-none"), 0);
         assert_eq!(table_count(&rt, "mission_link"), 0);
@@ -7014,13 +7067,14 @@ mod authed_route_tests {
         let surface = "surface-ns4-session";
         ns4_seed_mission(&rt, surface);
         let intruder = authed("principal:intruder");
+        let handle = ns4_handle();
 
         let out = run_authed_agent_loop_mission_bound(
             &rt,
             &intruder,
             "run-ns4-q2",
             "do work",
-            Some(surface),
+            Some(&handle),
             None,
             None,
             1000,

--- a/rust-core/crates/friday-hub/src/mission_context.rs
+++ b/rust-core/crates/friday-hub/src/mission_context.rs
@@ -17,7 +17,11 @@ pub struct MissionContextLookup {
 }
 
 impl MissionContextLookup {
-    pub fn by_work_item(
+    /// Build a lookup from a FIRST-CLASS Mission handle `{friday_conversation_id, mission_id,
+    /// work_item_id}` (NS45-PR1 / M-4: the canonical resolution source, replacing the provisional
+    /// surface-thread shim for run mission resolution). The three ids are the SAME shape the
+    /// `MissionWorkItemContextWire` carries on the wire and the `MissionIntakeResult` emits.
+    pub fn by_mission_work_item(
         friday_conversation_id: impl Into<String>,
         mission_id: impl Into<String>,
         work_item_id: impl Into<String>,
@@ -28,6 +32,19 @@ impl MissionContextLookup {
             work_item_id: Some(work_item_id.into()),
             surface_thread_id: None,
         }
+    }
+
+    /// Back-compat alias for [`Self::by_mission_work_item`], retained so the existing in-crate
+    /// call sites (`provider_dispatch` + the runtime/mission_runtime tests) compile UNCHANGED —
+    /// NS45-PR1 only needed to NAME the first-class handle constructor, not churn callers in
+    /// files outside its scope (keeping `runtime.rs` untouched preserves the Wave-2 file
+    /// disjointness with TP-PR2). Delegates verbatim.
+    pub fn by_work_item(
+        friday_conversation_id: impl Into<String>,
+        mission_id: impl Into<String>,
+        work_item_id: impl Into<String>,
+    ) -> Self {
+        Self::by_mission_work_item(friday_conversation_id, mission_id, work_item_id)
     }
 
     pub fn by_surface_thread(surface_thread_id: impl Into<String>) -> Self {

--- a/rust-core/crates/friday-protocol/src/lib.rs
+++ b/rust-core/crates/friday-protocol/src/lib.rs
@@ -1105,6 +1105,27 @@ pub enum Message {
         /// prerequisite for any mutating run-control.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         constraints: Option<AgentRunConstraintsWire>,
+        /// (NS45-PR1 / M-4) The FIRST-CLASS Mission handle this run participates in, retiring the
+        /// provisional `session_id`-as-surface-thread shim that NS-4 used for mission resolution.
+        /// A real handle `{friday_conversation_id, mission_id, work_item_id}` from the NS-5
+        /// `MissionIntakeResult` lets the dispatch resolve the Mission via
+        /// `MissionContextLookup::by_mission_work_item` and route through the mission-bound run
+        /// path, INSTEAD of conflating a chat-session id with a surface-thread id.
+        ///
+        /// ADDITIVE + OPTIONAL — an absent field deserializes to `None` (`#[serde(default)]`) and
+        /// a `None` value is OMITTED from the wire (`skip_serializing_if`), so a request WITHOUT a
+        /// handle is BYTE-IDENTICAL to the pre-NS45 wire and routes through the UNCHANGED unbound
+        /// dispatch path. Mirrors the `session_id`/`constraints` additive-optional pattern.
+        ///
+        /// **SECURITY (INV-5/INV-7): this is a CLIENT ASSERTION, NOT an authority.** It selects
+        /// WHICH Mission/WorkItem the run binds to — it does NOT grant access. The run's bound
+        /// OWNER is the AUTHENTICATED forwarded principal (the FIX-Q2 `configured_principal` owner
+        /// gate at the mission-bound seam), NEVER this handle. A client-asserted `mission_id` is
+        /// safe under single-owner v1 + that owner gate; enforcing ownership of a client-asserted
+        /// `mission_id` under a multi-owner (`owner_allowlist > 1`) allowlist is a NAMED go-live
+        /// gate, not added here (see the NS45-PR1 scope).
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        mission_context: Option<MissionWorkItemContextWire>,
     },
     /// hub->trusted-TS-peer: REFS-ONLY terminal receipt for an agent-run.
     /// **WS-transport substrate (S-A).** It carries a coarse loop-status label and
@@ -2221,6 +2242,8 @@ mod tests {
             session_id: None,
             // A1 run-controls: a constraint-free request carries `None`.
             constraints: None,
+            // NS45-PR1: a request with no Mission handle carries `None`.
+            mission_context: None,
         };
         let env = Envelope::new("m1", 1000, msg.clone()).with_correlation("c1");
         let json = env.encode().unwrap();
@@ -2244,6 +2267,7 @@ mod tests {
             auth_proof: vec![0xDE, 0xAD, 0xBE, 0xEF],
             session_id: None,
             constraints: None,
+            mission_context: None,
         };
         let json = Envelope::new("m1", 1000, msg).encode().unwrap();
         assert!(
@@ -2256,6 +2280,13 @@ mod tests {
         assert!(
             !json.contains("constraints"),
             "a constraint-free AgentRunRequest must not carry a constraints key (byte-identical to pre-A1): {json}"
+        );
+        // (NS45-PR1) absent mission_context ⇒ NO `mission_context` key on the wire
+        // (byte-identical to the pre-NS45 AgentRunRequest, so a handle-free request decodes
+        // unchanged and routes through the unbound path).
+        assert!(
+            !json.contains("mission_context"),
+            "a handle-free AgentRunRequest must not carry a mission_context key (byte-identical to pre-NS45): {json}"
         );
     }
 
@@ -2273,6 +2304,7 @@ mod tests {
             auth_proof: vec![0x01, 0x02],
             session_id: Some("sess-abc".into()),
             constraints: None,
+            mission_context: None,
         };
         let env = Envelope::new("m2", 2000, msg.clone());
         let json = env.encode().unwrap();
@@ -2518,6 +2550,7 @@ mod tests {
                 disabled_tools: vec!["run_command".into(), "delete_file".into()],
                 max_turns: Some(3),
             }),
+            mission_context: None,
         };
         let json = Envelope::new("m", 1, constrained.clone()).encode().unwrap();
         assert!(json.contains("\"read_only\":true"));
@@ -2534,6 +2567,7 @@ mod tests {
             auth_proof: vec![],
             session_id: None,
             constraints: Some(AgentRunConstraintsWire::default()),
+            mission_context: None,
         };
         let json = Envelope::new("m", 1, empty.clone()).encode().unwrap();
         assert!(!json.contains("disabled_tools"));
@@ -2678,10 +2712,15 @@ mod tests {
             Message::AgentRunRequest {
                 session_id,
                 constraints,
+                mission_context,
                 ..
             } => {
                 assert_eq!(session_id, None);
                 assert_eq!(constraints, None);
+                // (NS45-PR1) the pre-NS45 wire (no `mission_context` key) decodes to `None`
+                // via `#[serde(default)]` — the additive-optional guarantee that makes
+                // deploying a build with this field safe for the current courier.
+                assert_eq!(mission_context, None);
             }
             other => panic!("expected AgentRunRequest, got {other:?}"),
         }


### PR DESCRIPTION
## NS45-PR1 / M-4 — Mission-handle ingress (Wave 2 of the LIVE-WIRING program)

Binds an `AgentRunRequest` to a **first-class Mission handle**, retiring the provisional `session_id`-as-surface-thread shim that NS-4 used for mission resolution. Behind the **pre-existing** `FRIDAY_MISSION_BOUND_RUN` flag (default-OFF, exact-`"1"` matcher — unchanged). **Dark + flag-gated: production behavior is UNCHANGED until the operator flips the flag AND organic ingress populates the handle.**

### Wire addition (Option, back-compat)
Adds an **ADDITIVE + OPTIONAL** field to the `Message::AgentRunRequest` variant:

```rust
#[serde(default, skip_serializing_if = "Option::is_none")]
mission_context: Option<MissionWorkItemContextWire>,   // { friday_conversation_id, mission_id, work_item_id }
```

Mirrors the `session_id`/`constraints` additive-optional discipline. Absent (`None`) ⇒ **no `mission_context` key on the wire** ⇒ byte-identical to the pre-NS45 request; an old courier's current bytes decode to `None` (proven by the pre-existing-wire decode test). `mission_context` is additive-optional within schema **v13** — same convention as the A2a `session_id` field (a new *field* on an existing variant, not a new *kind*) ⇒ **no version bump**; `Message` is not `deny_unknown_fields`, so forward/back-compat holds both directions.

### Resolve + route
- `run_authed_agent_loop_mission_bound` now takes `mission_context: Option<&MissionWorkItemContextWire>` **instead of** the `session_id` shim.
- A present handle resolves the Mission via `MissionContextLookup::by_mission_work_item` (the renamed first-class constructor; `by_work_item` is kept as a thin delegating back-compat alias so out-of-scope callers — `provider_dispatch` + `runtime`/`mission_runtime` tests — compile unchanged, which keeps `runtime.rs` **untouched** and preserves Wave-2 file disjointness with TP-PR2).
- The provider-timeline session label (the `friday_session_id` baked into the `MissionLink` target_ref) is derived from the handle's `friday_conversation_id`, **not** the retired surface-thread shim.
- The **FIX-Q2 owner gate** (`caller == configured_principal`) stays asserted BEFORE any dispatch; the `Blocked ⇒ None` / `Err ⇒ NoAnswer (no fall-through)` contract is verbatim.

### Flag-OFF byte-identical guarantee
Proven **by composition**, matching the NS-4 discipline (no literal flag-OFF+handle-through-dispatch test):
1. the flag matcher `mission_bound_run_enabled_from(None) == false` (exact-`"1"`, existing matcher tests unchanged), **plus**
2. the bin's `if mission_bound_run_enabled { seam } else { None }` else-arm never calls the seam when the flag is off, **plus**
3. with the flag ON but **no handle**, the seam returns `None` immediately (before any DB touch / owner-gate).

In all three cases the run takes the exact pre-NS-4 unbound `match session_id` dispatch — byte-identical (no Mission bind, no MissionLink, no WorkItem transition, no route_decision). The flag-OFF unbound-no-binding test pins this with a resolvable Mission staged.

### Unresolvable handle ⇒ fail-closed
A flag-ON run with a handle that points at a non-existent Mission/WorkItem: the preflight blocks BEFORE `create_run`, the seam returns `None`, the run falls through unbound — **no crash, no `agent_run`/`route_decision`/`mission_link` rows**.

### Go-live caveat (DEFERRED — a named gate, NOT added here)
A client-asserted `mission_id` under an `owner_allowlist > 1` is a cross-principal resolution surface (same deferred class as M-3/M-5). It is **safe under single-owner v1 + the FIX-Q2 owner gate** (the single configured owner is the only principal that can dispatch a bound run). Enforcing that a multi-owner caller actually OWNS the asserted `mission_id` is a **named go-live gate** — this PR resolves the handle but does NOT add that multi-owner ownership check.

### TS/contract impact
None reds on the Rust gate. The TS courier (`src/api/mission-spine/…`) and Swift `AgentRunRequestWire` are independent producer codebases (not compiled by the Rust gate); they omit `mission_context` ⇒ byte-identical JSON the Rust server decodes to `None`. The Swift WriteKATs only assert producer-side key omission, not the Rust struct's field set. **Forward work at go-live:** the courier + Swift wire types gain a `mission_context` field when organic ingress is wired — no current test reds.

### Files touched
- `rust-core/crates/friday-protocol/src/lib.rs` — the wire field + codec tests
- `rust-core/crates/friday-hub/src/mission_context.rs` — `by_mission_work_item` + `by_work_item` back-compat alias
- `rust-core/crates/friday-hub/src/hub_server.rs` — the seam rewrite (handle-keyed resolution) + the 5 NS-4/NS45 seam tests
- `rust-core/crates/friday-hub/src/bin/hub_agent_run_server.rs` — the dispatch arm destructure + seam call (the routing site)
- `rust-core/crates/friday-ffi/src/lib.rs` — one `mission_context: None` in a test construction (the **required** build fix from the wire widening; disjoint from TP-PR2's `runtime.rs`)

### Gate (rust-core, in order — all green)
- `cargo fmt --all -- --check` ✅
- `cargo clippy --workspace --all-targets -- -D warnings` ✅
- `cargo build -p friday-hub` ✅
- `cargo test -p friday-hub` ✅ (635 lib + integration; 0 failed) · `cargo test -p friday-protocol -p friday-ffi` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)