### PR TITLE
feat(f11 vis-1): friday-vision VisionModelClient DI trait + UreqVision transport + deterministic stub

### DIFF
--- a/rust-core/Cargo.lock
+++ b/rust-core/Cargo.lock
@@ -809,6 +809,12 @@ version = "0.0.1"
 [[package]]
 name = "friday-vision"
 version = "0.0.1"
+dependencies = [
+ "base64 0.22.1",
+ "serde_json",
+ "thiserror 1.0.69",
+ "ureq",
+]
 
 [[package]]
 name = "fs-err"

--- a/rust-core/crates/friday-vision/Cargo.toml
+++ b/rust-core/crates/friday-vision/Cargo.toml
@@ -1,8 +1,27 @@
 [package]
 name = "friday-vision"
-description = "Friday F11 net-new media capability — vision (image_analysis) crate skeleton. Empty compiling stub, no logic/deps/executors yet (Hub-only, provider-secret-bearing → stays OUT of friday-ffi's phone dependency graph)."
+description = "Friday F11 net-new media capability — vision (image_analysis) crate: the VisionModelClient DI trait + a real ureq multimodal HTTP transport + a deterministic test stub. Hub-only, provider-secret-bearing (BYOK vision LLM) → stays OUT of friday-ffi's phone dependency graph."
 edition.workspace = true
 version.workspace = true
 license.workspace = true
 publish = false
 rust-version.workspace = true
+
+# Hub-only, provider-secret-bearing crate. The live leg reads a BYOK vision-LLM
+# key (operator-gated, supplied at the hub only) and must stay OUT of
+# friday-ffi's dependency graph (same trust boundary as friday-deepseek /
+# friday-anthropic; asserted by friday-arch-tests). DARK by default: the runtime
+# flag FRIDAY_VISION_TOOL_ENABLED is a default-OFF const here; the gate is
+# enforced later at the hub, not in this crate.
+[dependencies]
+serde_json = "1"
+thiserror.workspace = true
+# Blocking HTTP client (rustls/webpki-roots; no async runtime, no system certs).
+# ALREADY a workspace dep (friday-deepseek / friday-anthropic / friday-hub); NOT a
+# new external crate. The live multimodal POST reuses it; the dark path uses the
+# deterministic stub and makes no call.
+ureq = { version = "2", features = ["json"] }
+# base64-encode local image bytes into the multimodal data-URI part. ALREADY in
+# the workspace lock (0.22.1, transitive); promoting to a direct dep does not add
+# a new external crate or change Cargo.lock.
+base64 = "0.22"

--- a/rust-core/crates/friday-vision/src/client.rs
+++ b/rust-core/crates/friday-vision/src/client.rs
@@ -1,0 +1,430 @@
+//! [`VisionModelClient`] implementations.
+//!
+//! - [`HttpVisionModelClient`] — the real client: validate → build multimodal body
+//!   → POST via an injected [`VisionTransport`] → strict-parse. **No fallback.**
+//! - [`StubVisionModelClient`] — a deterministic test stub (fixed analysis + token
+//!   counts) so all upstream dispatch/validation logic is unit-testable offline.
+//!   NEVER a runtime fallback — it is constructed only by tests / the dark dispatch
+//!   path that explicitly wants determinism, never silently substituted for a
+//!   failed live route.
+
+use crate::transport::{build_request_body, parse_response, UreqVisionTransport, VisionTransport};
+use crate::{VisionError, VisionModelClient, VisionRequest, VisionResponse};
+
+/// The default vision model used when a [`VisionRequest`] supplies none. The hub
+/// wiring can override at construction; this is only the fallback id sent on the
+/// wire (the REPORTED model is what gets ledgered).
+pub const DEFAULT_MODEL: &str = "gpt-4o-mini";
+
+/// The real vision client: an injected [`VisionTransport`] + a BYOK bearer key +
+/// the provider base URL + a default model. Production construction supplies the
+/// real [`UreqVisionTransport`]; tests inject a mock transport.
+pub struct HttpVisionModelClient<T: VisionTransport> {
+    transport: T,
+    api_key: String,
+    base_url: String,
+    default_model: String,
+}
+
+impl HttpVisionModelClient<UreqVisionTransport> {
+    /// Construct the real client from an explicit base URL + BYOK key. (The key is
+    /// never logged; the hub reads it from [`crate::ENV_KEY`] at the WIRE arm and
+    /// passes it here — this crate never reads the process environment itself.)
+    pub fn new(api_key: impl Into<String>, base_url: impl Into<String>) -> Self {
+        Self::with_transport(UreqVisionTransport::new(), api_key, base_url)
+    }
+}
+
+impl<T: VisionTransport> HttpVisionModelClient<T> {
+    /// For tests / alternate transports. (`api_key` is never logged.)
+    pub fn with_transport(
+        transport: T,
+        api_key: impl Into<String>,
+        base_url: impl Into<String>,
+    ) -> Self {
+        HttpVisionModelClient {
+            transport,
+            api_key: api_key.into(),
+            base_url: base_url.into().trim_end_matches('/').to_string(),
+            default_model: DEFAULT_MODEL.to_string(),
+        }
+    }
+
+    /// Override the default model id sent when a request omits one.
+    pub fn with_default_model(mut self, model: impl Into<String>) -> Self {
+        self.default_model = model.into();
+        self
+    }
+
+    fn endpoint(&self) -> String {
+        format!(
+            "{}{}",
+            self.base_url,
+            crate::transport::CHAT_COMPLETIONS_PATH
+        )
+    }
+}
+
+impl<T: VisionTransport> VisionModelClient for HttpVisionModelClient<T> {
+    fn analyze(&self, req: &VisionRequest) -> Result<VisionResponse, VisionError> {
+        // 1. Validate WITHOUT any I/O — refuses an unresolved workspace path, bad
+        //    detail (already an enum), no/too-many images, oversized payload.
+        let image_count = req.validate()?;
+        // 2. Build the multimodal body (the shape the plain-string providers lack).
+        let model = req.model.as_deref().unwrap_or(&self.default_model);
+        let body = build_request_body(req, model)?;
+        // 3. The ONLY network call. No retry, no second provider, no fallback.
+        let v = self
+            .transport
+            .post_json(&self.endpoint(), &self.api_key, &body)?;
+        // 4. Strict parse; ledger the reported model.
+        parse_response(&v, model, image_count)
+    }
+}
+
+/// A deterministic stub client. Returns a fixed analysis + token counts so the
+/// hub executor's param-validation / receipt-shape / no-fallback logic is provable
+/// offline. It STILL runs [`VisionRequest::validate`] first, so the stub exercises
+/// the same adverse-path errors as the real client (it is NOT a yes-machine).
+/// It makes NO network call and is NEVER a silent substitute for a failed live
+/// route.
+#[derive(Clone, Debug)]
+pub struct StubVisionModelClient {
+    pub analysis: String,
+    pub model: String,
+    pub input_tokens: i64,
+    pub output_tokens: i64,
+}
+
+impl Default for StubVisionModelClient {
+    fn default() -> Self {
+        StubVisionModelClient {
+            analysis: "stub vision analysis: a deterministic placeholder description".into(),
+            model: "stub-vision-model".into(),
+            input_tokens: 100,
+            output_tokens: 20,
+        }
+    }
+}
+
+impl StubVisionModelClient {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl VisionModelClient for StubVisionModelClient {
+    fn analyze(&self, req: &VisionRequest) -> Result<VisionResponse, VisionError> {
+        // Same validation as the real path — a malformed request still fails,
+        // proving the stub does not paper over adverse inputs.
+        let image_count = req.validate()?;
+        Ok(VisionResponse {
+            analysis: self.analysis.clone(),
+            model: self.model.clone(),
+            image_count,
+            input_tokens: Some(self.input_tokens),
+            output_tokens: Some(self.output_tokens),
+            extracted_text: None,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::transport::map_ureq_err;
+    use crate::{ImageDetail, VisionImage};
+    use serde_json::{json, Value};
+    use std::cell::Cell;
+    use std::io::{Read, Write};
+    use std::net::TcpListener;
+    use std::thread;
+
+    /// Mock transport: counts POSTs and returns a canned result or a canned error.
+    struct MockTransport {
+        post_calls: Cell<u32>,
+        result: Result<Value, VisionError>,
+    }
+
+    impl MockTransport {
+        fn ok(v: Value) -> Self {
+            MockTransport {
+                post_calls: Cell::new(0),
+                result: Ok(v),
+            }
+        }
+        fn err(e: VisionError) -> Self {
+            MockTransport {
+                post_calls: Cell::new(0),
+                result: Err(e),
+            }
+        }
+    }
+
+    impl VisionTransport for MockTransport {
+        fn post_json(
+            &self,
+            _url: &str,
+            _bearer: &str,
+            _body: &Value,
+        ) -> Result<Value, VisionError> {
+            self.post_calls.set(self.post_calls.get() + 1);
+            self.result.clone()
+        }
+    }
+
+    fn good_reply() -> Value {
+        json!({
+            "model": "vis-pro-0613",
+            "choices": [{"message": {"role": "assistant", "content": "a red bicycle"}}],
+            "usage": {"prompt_tokens": 1500, "completion_tokens": 12}
+        })
+    }
+
+    fn req() -> VisionRequest {
+        VisionRequest {
+            prompt: "what is in the image?".into(),
+            images: vec![VisionImage::Url("https://x/a.png".into())],
+            model: Some("vis-pro".into()),
+            detail: ImageDetail::Auto,
+            max_tokens: Some(128),
+        }
+    }
+
+    #[test]
+    fn http_client_happy_path_one_call_reported_model() {
+        let c = HttpVisionModelClient::with_transport(
+            MockTransport::ok(good_reply()),
+            "key-not-real",
+            "https://vis.example.com",
+        );
+        let resp = c.analyze(&req()).unwrap();
+        assert_eq!(resp.analysis, "a red bicycle");
+        assert_eq!(resp.model, "vis-pro-0613");
+        assert_eq!(resp.image_count, 1);
+        assert_eq!(resp.input_tokens, Some(1500));
+        assert_eq!(resp.output_tokens, Some(12));
+        // Exactly ONE network call — no retry/fallback.
+        assert_eq!(c.transport.post_calls.get(), 1);
+    }
+
+    #[test]
+    fn http_client_validation_failure_makes_zero_calls() {
+        // An invalid request never reaches the transport.
+        let bad = VisionRequest {
+            prompt: "x".into(),
+            images: vec![],
+            model: None,
+            detail: ImageDetail::Auto,
+            max_tokens: None,
+        };
+        let c = HttpVisionModelClient::with_transport(
+            MockTransport::ok(good_reply()),
+            "k",
+            "https://vis.example.com",
+        );
+        assert!(matches!(
+            c.analyze(&bad).unwrap_err(),
+            VisionError::Validation(_)
+        ));
+        assert_eq!(
+            c.transport.post_calls.get(),
+            0,
+            "must not call on invalid input"
+        );
+    }
+
+    #[test]
+    fn http_client_provider_error_does_not_fallback() {
+        let c = HttpVisionModelClient::with_transport(
+            MockTransport::err(VisionError::ProviderUnavailable("HTTP 503".into())),
+            "k",
+            "https://vis.example.com",
+        );
+        let err = c.analyze(&req()).unwrap_err();
+        assert!(matches!(err, VisionError::ProviderUnavailable(_)));
+        // One attempt, then surfaced — no second provider/stub substitution.
+        assert_eq!(c.transport.post_calls.get(), 1);
+    }
+
+    #[test]
+    fn http_client_auth_error_surfaces() {
+        let c = HttpVisionModelClient::with_transport(
+            MockTransport::err(VisionError::Auth(401)),
+            "k",
+            "https://vis.example.com",
+        );
+        assert!(matches!(
+            c.analyze(&req()).unwrap_err(),
+            VisionError::Auth(401)
+        ));
+    }
+
+    #[test]
+    fn http_client_uses_default_model_when_request_omits_one() {
+        let mut r = req();
+        r.model = None;
+        let c = HttpVisionModelClient::with_transport(
+            // reply omits `model` so parse falls back to the requested (default) id
+            MockTransport::ok(json!({"choices": [{"message": {"content": "x"}}]})),
+            "k",
+            "https://vis.example.com",
+        )
+        .with_default_model("my-default-vis");
+        let resp = c.analyze(&r).unwrap();
+        assert_eq!(resp.model, "my-default-vis");
+    }
+
+    #[test]
+    fn stub_returns_deterministic_result_and_validates() {
+        let stub = StubVisionModelClient::new();
+        let resp = stub.analyze(&req()).unwrap();
+        assert_eq!(resp.analysis, StubVisionModelClient::default().analysis);
+        assert_eq!(resp.model, "stub-vision-model");
+        assert_eq!(resp.input_tokens, Some(100));
+        assert_eq!(resp.output_tokens, Some(20));
+        assert_eq!(resp.image_count, 1);
+        assert!(resp.extracted_text.is_none());
+    }
+
+    #[test]
+    fn stub_still_rejects_invalid_request() {
+        // The stub is not a yes-machine: it runs the same validation.
+        let stub = StubVisionModelClient::new();
+        let bad = VisionRequest {
+            prompt: "".into(),
+            images: vec![VisionImage::Url("https://x/a.png".into())],
+            model: None,
+            detail: ImageDetail::Auto,
+            max_tokens: None,
+        };
+        assert!(matches!(
+            stub.analyze(&bad).unwrap_err(),
+            VisionError::Validation(_)
+        ));
+    }
+
+    /// A one-shot HTTP server to drive the REAL UreqVisionTransport end-to-end:
+    /// proves the full validate→build→POST→parse path against a local socket and
+    /// that a 4xx body carrying a secret is NOT echoed into the error.
+    ///
+    /// The POST request carries a JSON body, so the server must DRAIN the full
+    /// request (request line + headers + the `Content-Length` body) before
+    /// replying — otherwise replying-then-closing while ureq is still flushing the
+    /// request body breaks the connection (os error 22 on the client read). We
+    /// parse `Content-Length` from the headers and read exactly that many body
+    /// bytes, then write the response.
+    fn serve_http_once(
+        status: u16,
+        reason: &'static str,
+        body: &'static str,
+    ) -> (String, thread::JoinHandle<()>) {
+        use std::io::BufRead;
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        let handle = thread::spawn(move || {
+            let (stream, _) = listener.accept().unwrap();
+            let mut reader = std::io::BufReader::new(stream);
+            // Read headers line-by-line until the blank line; capture Content-Length.
+            let mut content_length = 0usize;
+            loop {
+                let mut line = String::new();
+                if reader.read_line(&mut line).unwrap() == 0 {
+                    break;
+                }
+                let trimmed = line.trim_end();
+                if trimmed.is_empty() {
+                    break; // end of headers
+                }
+                if let Some(rest) = trimmed.to_ascii_lowercase().strip_prefix("content-length:") {
+                    content_length = rest.trim().parse().unwrap_or(0);
+                }
+            }
+            // Drain exactly the declared body so the client finishes flushing.
+            if content_length > 0 {
+                let mut body_buf = vec![0u8; content_length];
+                reader.read_exact(&mut body_buf).unwrap();
+            }
+            let mut stream = reader.into_inner();
+            let response = format!(
+                "HTTP/1.1 {status} {reason}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                body.len()
+            );
+            stream.write_all(response.as_bytes()).unwrap();
+            let _ = stream.flush();
+        });
+        (format!("http://{addr}"), handle)
+    }
+
+    #[test]
+    fn real_transport_full_path_against_local_server() {
+        let (base_url, handle) = serve_http_once(
+            200,
+            "OK",
+            r#"{"model":"vis-pro-0613","choices":[{"message":{"content":"a dog"}}],"usage":{"prompt_tokens":900,"completion_tokens":5}}"#,
+        );
+        let c = HttpVisionModelClient::new("key-not-real", base_url);
+        let resp = c.analyze(&req()).unwrap();
+        handle.join().unwrap();
+        assert_eq!(resp.analysis, "a dog");
+        assert_eq!(resp.model, "vis-pro-0613");
+        assert_eq!(resp.input_tokens, Some(900));
+    }
+
+    #[test]
+    fn real_transport_4xx_is_coarse_and_secret_free() {
+        let (base_url, handle) = serve_http_once(
+            429,
+            "Too Many Requests",
+            r#"{"error":"quota hit for SECRET-QUOTA-BODY"}"#,
+        );
+        let c = HttpVisionModelClient::new("test-key-not-real", base_url);
+        let err = c.analyze(&req()).unwrap_err();
+        handle.join().unwrap();
+        assert!(matches!(err, VisionError::ClientError { status: 429 }));
+        for rendered in [format!("{err:?}"), format!("{err}")] {
+            for forbidden in [
+                "SECRET-QUOTA-BODY",
+                "test-key-not-real",
+                "Authorization",
+                "Bearer",
+            ] {
+                assert!(
+                    !rendered.contains(forbidden),
+                    "render leaked {forbidden}: {rendered}"
+                );
+            }
+            assert!(rendered.contains("429"), "status code missing: {rendered}");
+        }
+    }
+
+    #[test]
+    fn real_transport_network_fail_without_secret() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        drop(listener);
+        let c = HttpVisionModelClient::new("test-key-not-real", format!("http://{addr}"));
+        let err = c.analyze(&req()).unwrap_err();
+        assert!(matches!(
+            err,
+            VisionError::ProviderUnavailable(ref r) if r.starts_with("transport:")
+        ));
+        let rendered = format!("{err:?}");
+        for forbidden in ["test-key-not-real", "Authorization", "Bearer"] {
+            assert!(
+                !rendered.contains(forbidden),
+                "leaked {forbidden}: {rendered}"
+            );
+        }
+    }
+
+    #[test]
+    fn map_ureq_err_is_reachable_from_client_module() {
+        // Sanity: the transport error mapper is the shared classifier.
+        let resp = ureq::Response::new(503, "x", "{}").unwrap();
+        assert!(matches!(
+            map_ureq_err(ureq::Error::Status(503, resp)),
+            VisionError::ProviderUnavailable(_)
+        ));
+    }
+}

--- a/rust-core/crates/friday-vision/src/lib.rs
+++ b/rust-core/crates/friday-vision/src/lib.rs
@@ -1,6 +1,407 @@
-//! Friday F11 net-new media capability — vision (image_analysis) crate.
+//! friday-vision — the `image_analysis` vision route (Hub-only, secret-bearing).
 //!
-//! Skeleton placeholder only: this crate carries no logic, no dependencies, and
-//! no executor yet. The VisionModelClient DI trait, the live `ureq` transport,
-//! and the deterministic stub land in a later F11 crate-internal PR (VIS-1). The
-//! `impl ToolExecutor` wrapper is a `friday-hub` module, not part of this crate.
+//! Net-new F11 media capability. Mirrors the Friday TS `image_analysis` tool
+//! (`src/agent/tools/friday-agent-image-analysis-tool.ts` + helpers): analyze one
+//! or more images with a vision-capable, OpenAI-compatible `/chat/completions`
+//! endpoint that accepts multimodal message content (text + `image_url` parts).
+//!
+//! **Critical gap this crate fills:** `friday-deepseek` / `friday-anthropic`
+//! `chat()` send `"content": prompt` as a PLAIN STRING — there is NO multimodal
+//! message shape in Rust today. This crate defines the multimodal request/response
+//! contract behind a DI seam so the dispatch/validation logic is testable WITHOUT
+//! a live provider.
+//!
+//! Shape (matching the existing `friday-deepseek` provider boundary, §0.1 of the
+//! F11 plan):
+//! - [`VisionModelClient`] — the DI trait the hub executor dispatches to (the
+//!   `impl ToolExecutor` wrapper is a `friday-hub` module, NOT in this crate — a
+//!   capability crate cannot depend on `friday-hub` without a cycle).
+//! - [`transport::UreqVisionTransport`] — the real blocking `ureq` leg: base64-
+//!   encodes local image bytes, POSTs the multimodal body, strict-parses the
+//!   reply. **No fallback** — a failed route is a [`VisionError`], never a silent
+//!   substitute or canned answer.
+//! - [`client::HttpVisionModelClient`] — wires a transport + BYOK key into the
+//!   trait.
+//! - [`client::StubVisionModelClient`] — deterministic test stub with a fixed
+//!   analysis and fixed token counts so all upstream logic is unit-testable
+//!   offline. NEVER a runtime fallback.
+//!
+//! **DARK by default.** [`ENV_ROUTE_ENABLED`] / [`route_enabled`] are consts/pure
+//! helpers only; the gate is enforced later at the hub (this crate ships no hub
+//! dep, no `ToolExecutor`, no registry/capability change).
+//!
+//! Trust boundary: provider-secret-bearing (BYOK vision-LLM key) → stays OUT of
+//! `friday-ffi`'s phone dependency graph (same boundary as friday-deepseek /
+//! friday-anthropic; asserted by `friday-arch-tests`).
+
+use thiserror::Error;
+
+pub mod client;
+pub mod transport;
+
+pub use client::{HttpVisionModelClient, StubVisionModelClient};
+pub use transport::{UreqVisionTransport, VisionTransport};
+
+/// Hub-only environment variable holding the BYOK vision-LLM API key. Read on the
+/// Hub only at the operator-gated live wiring (WIRE); never read in this crate's
+/// dark path.
+pub const ENV_KEY: &str = "FRIDAY_VISION_API_KEY";
+
+/// Default-OFF runtime flag governing hub dispatch of the `image_analysis` tool.
+/// CONST ONLY here — the gate is enforced later at the hub (runtime.rs WIRE arm),
+/// mirroring the `FRIDAY_CLAUDE_ROUTE_ENABLED` template. The crate carries no
+/// gate logic; this const is the single source of the flag's name.
+pub const ENV_ROUTE_ENABLED: &str = "FRIDAY_VISION_TOOL_ENABLED";
+
+/// Maximum number of images per analysis request (mirrors the TS oracle's
+/// `MAX_IMAGES = 10`).
+pub const MAX_IMAGES: usize = 10;
+
+/// Maximum byte size of a base64-source data URI / inline payload (mirrors the
+/// TS oracle's `MAX_DATA_URI_BYTES = 20 MiB`). Enforced on `Base64` parts.
+pub const MAX_DATA_URI_BYTES: usize = 20 * 1024 * 1024;
+
+/// True iff the route flag is EXACTLY `"1"` — the same default-OFF semantics as
+/// the `FRIDAY_CLAUDE_ROUTE_ENABLED` template (`runtime.rs:948`). Pure read of
+/// the supplied value; this crate NEVER reads the process environment itself nor
+/// enforces the gate (that is the hub's job at WIRE). Provided so the hub wiring
+/// has one canonical predicate.
+pub fn route_enabled(flag_value: Option<&str>) -> bool {
+    flag_value == Some("1")
+}
+
+/// Image-detail hint, mirroring the TS oracle's `ImageDetail` (`low | high |
+/// auto`, default `auto`). Serializes to the OpenAI-compatible `image_url.detail`
+/// field.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
+pub enum ImageDetail {
+    Low,
+    High,
+    #[default]
+    Auto,
+}
+
+impl ImageDetail {
+    /// Parse the TS oracle's accepted detail strings. `None`/empty → `Auto`
+    /// (matching `validateDetail`); any other value is a [`VisionError::Validation`].
+    pub fn parse(value: Option<&str>) -> Result<Self, VisionError> {
+        match value {
+            None => Ok(ImageDetail::Auto),
+            Some(s) => match s {
+                "" => Ok(ImageDetail::Auto),
+                "low" => Ok(ImageDetail::Low),
+                "high" => Ok(ImageDetail::High),
+                "auto" => Ok(ImageDetail::Auto),
+                other => Err(VisionError::Validation(format!(
+                    "invalid detail \"{other}\". Valid: low, high, auto"
+                ))),
+            },
+        }
+    }
+
+    /// The wire value for the OpenAI-compatible `image_url.detail` field.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            ImageDetail::Low => "low",
+            ImageDetail::High => "high",
+            ImageDetail::Auto => "auto",
+        }
+    }
+}
+
+/// One image source for a [`VisionRequest`]. Mirrors the TS oracle's normalized
+/// image inputs (`type: "base64" | "url"`), plus a `WorkspacePath` variant for a
+/// local file that the HUB executor resolves+reads through
+/// `friday_fs::open_read_within_root` BEFORE constructing the request — so this
+/// crate never touches the filesystem and the workspace-containment gate stays in
+/// the hub executor (VISOCR-EXEC), exactly where `read_file` enforces it.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum VisionImage {
+    /// An HTTP(S) URL passed straight through as an `image_url`. (SSRF/allowed-origin
+    /// guarding, if any, is the hub executor's concern; this crate transmits.)
+    Url(String),
+    /// Already-decoded image bytes + MIME, encoded by the transport into a
+    /// `data:<mime>;base64,<...>` `image_url`. Used for both data-URI inputs and
+    /// local files the hub already read.
+    Base64 { mime: String, data_base64: String },
+    /// A workspace-relative path the hub executor will read into `Base64` BEFORE
+    /// the live call. This crate does NOT read it (no filesystem dep); a transport
+    /// that is handed an unresolved `WorkspacePath` returns a [`VisionError`]
+    /// rather than reaching outside its boundary.
+    WorkspacePath(String),
+}
+
+/// A multimodal vision request. Built by the hub executor from validated tool
+/// params and dispatched to a [`VisionModelClient`].
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct VisionRequest {
+    /// The analysis prompt / question about the image(s).
+    pub prompt: String,
+    /// 1..=[`MAX_IMAGES`] image sources.
+    pub images: Vec<VisionImage>,
+    /// Vision model id (`None` → the transport/caller's default).
+    pub model: Option<String>,
+    /// Detail hint (default [`ImageDetail::Auto`]).
+    pub detail: ImageDetail,
+    /// Max response tokens (`None` → provider default).
+    pub max_tokens: Option<u32>,
+}
+
+impl VisionRequest {
+    /// Validate the request shape WITHOUT any I/O (no file read, no network).
+    /// Mirrors the TS oracle: at least one image, at most [`MAX_IMAGES`], a
+    /// non-empty prompt, and each `Base64` payload within [`MAX_DATA_URI_BYTES`].
+    /// Returns the (validated) image count so the hub executor can ledger a
+    /// refs-only `image_count`.
+    pub fn validate(&self) -> Result<usize, VisionError> {
+        if self.prompt.trim().is_empty() {
+            return Err(VisionError::Validation("prompt is required".into()));
+        }
+        if self.images.is_empty() {
+            return Err(VisionError::Validation(
+                "at least one image is required".into(),
+            ));
+        }
+        if self.images.len() > MAX_IMAGES {
+            return Err(VisionError::Validation(format!(
+                "too many images ({}). Maximum: {MAX_IMAGES}",
+                self.images.len()
+            )));
+        }
+        for img in &self.images {
+            match img {
+                VisionImage::Base64 { data_base64, mime } => {
+                    if mime.trim().is_empty() {
+                        return Err(VisionError::Validation(
+                            "base64 image missing MIME type".into(),
+                        ));
+                    }
+                    if data_base64.len() > MAX_DATA_URI_BYTES {
+                        return Err(VisionError::Validation(format!(
+                            "image data exceeds maximum size of {MAX_DATA_URI_BYTES} bytes"
+                        )));
+                    }
+                }
+                VisionImage::Url(u) => {
+                    if u.trim().is_empty() {
+                        return Err(VisionError::Validation("image URL is empty".into()));
+                    }
+                }
+                VisionImage::WorkspacePath(p) => {
+                    // The hub executor MUST resolve+read this into Base64 before the
+                    // call. Reaching the client with an unresolved path is a caller
+                    // bug, never a silent file read from inside this crate.
+                    return Err(VisionError::UnresolvedImage(p.clone()));
+                }
+            }
+        }
+        Ok(self.images.len())
+    }
+}
+
+/// A vision analysis result (the bits Friday surfaces + ledgers).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct VisionResponse {
+    /// The model's analysis text (read-type, model-facing `content`).
+    pub analysis: String,
+    /// The model id the response reported (ledger the reported model, not the
+    /// requested one, to avoid stale-model claims — same discipline as
+    /// `friday-deepseek`).
+    pub model: String,
+    /// Number of images in the request (refs-only ledger field).
+    pub image_count: usize,
+    /// Prompt/input tokens, if the provider reported usage.
+    pub input_tokens: Option<i64>,
+    /// Completion/output tokens, if the provider reported usage.
+    pub output_tokens: Option<i64>,
+    /// OCR latent-field mirror: the Friday TS oracle has a never-written
+    /// `extractedText?` field (zero writers; the actual text mechanism is the
+    /// vision LLM). Mirrored here as a latent `None` — this crate is NOT an OCR
+    /// engine; the dedicated `ocr` route (friday-ocr) uses an extract-text prompt.
+    pub extracted_text: Option<String>,
+}
+
+// `Clone + PartialEq + Eq` so the structured error can be carried (not stringified)
+// into the hub error site and classified. Messages stay COARSE and secret-free
+// (status code / kind only — see `transport::map_ureq_err`), so carrying the
+// variant leaks no more than a stringified form would.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum VisionError {
+    /// Env var unset/empty at the hub. Adverse path: a blocker, never a fallback.
+    #[error("vision credential missing or empty (env {ENV_KEY})")]
+    CredentialMissing,
+    /// Request shape invalid (bad detail, no/too-many images, oversized payload).
+    /// Mirrors the TS oracle's `VALIDATION_ERROR` (HTTP 400 class).
+    #[error("vision request invalid: {0}")]
+    Validation(String),
+    /// A [`VisionImage::WorkspacePath`] reached the client unresolved — the hub
+    /// executor must read it into `Base64` first. This crate never reads files.
+    #[error("unresolved workspace image path reached the vision client: {0}")]
+    UnresolvedImage(String),
+    /// Authentication rejected (HTTP 401/403). Never a fallback.
+    #[error("vision authentication failed (HTTP {0})")]
+    Auth(u16),
+    /// TRANSIENT failure that retrying the SAME route may fix — network/transport
+    /// error, request-timeout (408), or a server-side 5xx. Never a fallback.
+    #[error("vision provider unavailable: {0}")]
+    ProviderUnavailable(String),
+    /// A TERMINAL client-side HTTP error (other 4xx: 400/404/422 and 429 rate-limit
+    /// — no backoff mechanism, so 429 is terminal). Display is COARSE: status code
+    /// only, never the response body. Never a fallback.
+    #[error("vision client error (HTTP {status})")]
+    ClientError { status: u16 },
+    /// Response did not match the documented multimodal-completion shape.
+    #[error("vision response shape unexpected: {0}")]
+    BadResponse(String),
+}
+
+/// The dependency-injection seam the hub `VisionToolExecutor` dispatches to. The
+/// real impl is [`HttpVisionModelClient`]; tests inject [`StubVisionModelClient`]
+/// so the no-hidden-call, no-fallback, and validation logic are provable offline.
+pub trait VisionModelClient {
+    /// Analyze the images per the prompt. The ONLY call-making method.
+    /// **No fallback** — a failed route is a [`VisionError`], never a substitute.
+    fn analyze(&self, req: &VisionRequest) -> Result<VisionResponse, VisionError>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detail_parses_oracle_values_and_defaults_to_auto() {
+        assert_eq!(ImageDetail::parse(None).unwrap(), ImageDetail::Auto);
+        assert_eq!(ImageDetail::parse(Some("")).unwrap(), ImageDetail::Auto);
+        assert_eq!(ImageDetail::parse(Some("low")).unwrap(), ImageDetail::Low);
+        assert_eq!(ImageDetail::parse(Some("high")).unwrap(), ImageDetail::High);
+        assert_eq!(ImageDetail::parse(Some("auto")).unwrap(), ImageDetail::Auto);
+        assert_eq!(ImageDetail::default(), ImageDetail::Auto);
+    }
+
+    #[test]
+    fn detail_rejects_unknown_without_leaking() {
+        let err = ImageDetail::parse(Some("ultra")).unwrap_err();
+        assert!(matches!(err, VisionError::Validation(_)));
+        assert!(format!("{err}").contains("ultra"));
+    }
+
+    #[test]
+    fn detail_wire_strings() {
+        assert_eq!(ImageDetail::Low.as_str(), "low");
+        assert_eq!(ImageDetail::High.as_str(), "high");
+        assert_eq!(ImageDetail::Auto.as_str(), "auto");
+    }
+
+    #[test]
+    fn route_enabled_only_for_exact_one() {
+        assert!(route_enabled(Some("1")));
+        assert!(!route_enabled(Some("0")));
+        assert!(!route_enabled(Some("true")));
+        assert!(!route_enabled(Some(" 1")));
+        assert!(!route_enabled(Some("")));
+        assert!(!route_enabled(None));
+    }
+
+    fn req_with(images: Vec<VisionImage>) -> VisionRequest {
+        VisionRequest {
+            prompt: "what is in this image?".into(),
+            images,
+            model: None,
+            detail: ImageDetail::Auto,
+            max_tokens: None,
+        }
+    }
+
+    #[test]
+    fn validate_accepts_url_and_base64() {
+        let r = req_with(vec![
+            VisionImage::Url("https://example.com/a.png".into()),
+            VisionImage::Base64 {
+                mime: "image/png".into(),
+                data_base64: "aGVsbG8=".into(),
+            },
+        ]);
+        assert_eq!(r.validate().unwrap(), 2);
+    }
+
+    #[test]
+    fn validate_rejects_empty_prompt() {
+        let mut r = req_with(vec![VisionImage::Url("https://x/a.png".into())]);
+        r.prompt = "   ".into();
+        assert!(matches!(
+            r.validate().unwrap_err(),
+            VisionError::Validation(_)
+        ));
+    }
+
+    #[test]
+    fn validate_rejects_zero_images() {
+        let r = req_with(vec![]);
+        assert!(matches!(
+            r.validate().unwrap_err(),
+            VisionError::Validation(_)
+        ));
+    }
+
+    #[test]
+    fn validate_rejects_too_many_images() {
+        let imgs = (0..MAX_IMAGES + 1)
+            .map(|i| VisionImage::Url(format!("https://x/{i}.png")))
+            .collect();
+        let r = req_with(imgs);
+        let err = r.validate().unwrap_err();
+        assert!(matches!(err, VisionError::Validation(_)));
+        assert!(format!("{err}").contains(&MAX_IMAGES.to_string()));
+    }
+
+    #[test]
+    fn validate_rejects_oversized_base64() {
+        let r = req_with(vec![VisionImage::Base64 {
+            mime: "image/png".into(),
+            data_base64: "a".repeat(MAX_DATA_URI_BYTES + 1),
+        }]);
+        assert!(matches!(
+            r.validate().unwrap_err(),
+            VisionError::Validation(_)
+        ));
+    }
+
+    #[test]
+    fn validate_rejects_base64_missing_mime() {
+        let r = req_with(vec![VisionImage::Base64 {
+            mime: "  ".into(),
+            data_base64: "aGVsbG8=".into(),
+        }]);
+        assert!(matches!(
+            r.validate().unwrap_err(),
+            VisionError::Validation(_)
+        ));
+    }
+
+    #[test]
+    fn validate_rejects_unresolved_workspace_path() {
+        // A WorkspacePath must be read into Base64 by the hub executor BEFORE the
+        // call. Reaching the client with it is a caller bug, surfaced as a clean
+        // error — this crate never reads the filesystem.
+        let r = req_with(vec![VisionImage::WorkspacePath(".friday/img/a.png".into())]);
+        assert!(matches!(
+            r.validate().unwrap_err(),
+            VisionError::UnresolvedImage(_)
+        ));
+    }
+
+    #[test]
+    fn extracted_text_is_a_latent_none_mirror_not_an_ocr_engine() {
+        // The oracle's extractedText is never written; this crate mirrors it as a
+        // latent None. The vision response carries analysis, not OCR text.
+        let resp = VisionResponse {
+            analysis: "a cat".into(),
+            model: "vis-1".into(),
+            image_count: 1,
+            input_tokens: Some(10),
+            output_tokens: Some(4),
+            extracted_text: None,
+        };
+        assert!(resp.extracted_text.is_none());
+    }
+}

--- a/rust-core/crates/friday-vision/src/transport.rs
+++ b/rust-core/crates/friday-vision/src/transport.rs
@@ -1,0 +1,357 @@
+//! HTTP transport seam for the vision route.
+//!
+//! [`VisionTransport`] is the low-level POST seam (mirrors `friday-deepseek`'s
+//! `Transport`); the real impl is [`UreqVisionTransport`]. The multimodal-body
+//! construction and the strict reply parse are pure functions ([`build_request_body`],
+//! [`parse_response`]) so the OpenAI-compatible message shape is testable WITHOUT a
+//! live provider. **No fallback** — every adverse path is a [`VisionError`].
+
+use crate::{ImageDetail, VisionError, VisionImage, VisionRequest, VisionResponse};
+use base64::engine::general_purpose::STANDARD as BASE64;
+use base64::Engine as _;
+use serde_json::{json, Value};
+
+/// The default vision-completions path appended to the BYOK base URL. Mirrors the
+/// OpenAI-compatible `/chat/completions` convention the TS oracle targets.
+pub const CHAT_COMPLETIONS_PATH: &str = "/v1/chat/completions";
+
+/// Low-level HTTP POST seam. The real impl is [`UreqVisionTransport`]; tests
+/// inject a deterministic mock so the multimodal-body and no-fallback logic are
+/// provable offline.
+pub trait VisionTransport {
+    /// POST a JSON body with a bearer credential, returning the parsed JSON reply.
+    /// MUST NEVER format the request (which carries the `Authorization` header) or
+    /// the response body into an error string.
+    fn post_json(&self, url: &str, bearer: &str, body: &Value) -> Result<Value, VisionError>;
+}
+
+/// Real blocking HTTP transport (ureq + rustls). Maps errors to controlled
+/// [`VisionError`] messages — it never formats the request (which carries the
+/// `Authorization` header) into an error string.
+pub struct UreqVisionTransport;
+
+impl UreqVisionTransport {
+    pub fn new() -> Self {
+        UreqVisionTransport
+    }
+}
+
+impl Default for UreqVisionTransport {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Map a `ureq::Error` to a controlled, secret-free [`VisionError`] — classify by
+/// status code ONLY; never read/echo the response body or the request headers.
+/// Same partition as `friday-deepseek::map_ureq_err` (401/403→Auth; 408+5xx→
+/// transient ProviderUnavailable; other 4xx + 429→terminal ClientError).
+pub fn map_ureq_err(e: ureq::Error) -> VisionError {
+    match e {
+        ureq::Error::Status(code, _resp) => {
+            if code == 401 || code == 403 {
+                VisionError::Auth(code)
+            } else if code == 408 || (500..=599).contains(&code) {
+                VisionError::ProviderUnavailable(format!("HTTP {code}"))
+            } else {
+                VisionError::ClientError { status: code }
+            }
+        }
+        ureq::Error::Transport(t) => {
+            VisionError::ProviderUnavailable(format!("transport: {}", t.kind()))
+        }
+    }
+}
+
+impl VisionTransport for UreqVisionTransport {
+    fn post_json(&self, url: &str, bearer: &str, body: &Value) -> Result<Value, VisionError> {
+        let resp = ureq::post(url)
+            .set("Authorization", &format!("Bearer {bearer}"))
+            .set("Accept", "application/json")
+            .send_json(body.clone())
+            .map_err(map_ureq_err)?;
+        resp.into_json::<Value>()
+            .map_err(|e| VisionError::BadResponse(format!("invalid JSON: {e}")))
+    }
+}
+
+/// Render one [`VisionImage`] into its OpenAI-compatible `image_url` part value.
+/// A `Base64` image becomes a `data:<mime>;base64,<...>` URI. An unresolved
+/// [`VisionImage::WorkspacePath`] is a caller bug — this crate never reads files,
+/// so it is surfaced as a clean [`VisionError::UnresolvedImage`].
+fn image_url_value(img: &VisionImage, detail: ImageDetail) -> Result<Value, VisionError> {
+    let url = match img {
+        VisionImage::Url(u) => u.clone(),
+        VisionImage::Base64 { mime, data_base64 } => {
+            format!("data:{mime};base64,{data_base64}")
+        }
+        VisionImage::WorkspacePath(p) => return Err(VisionError::UnresolvedImage(p.clone())),
+    };
+    Ok(json!({
+        "type": "image_url",
+        "image_url": { "url": url, "detail": detail.as_str() },
+    }))
+}
+
+/// Build the OpenAI-compatible multimodal `/chat/completions` request body for a
+/// validated [`VisionRequest`]. The single user message's `content` is an ARRAY
+/// of parts: one `{type:"text"}` prompt part followed by one `{type:"image_url"}`
+/// part per image. This is the multimodal shape that `friday-deepseek` /
+/// `friday-anthropic` lack (they send a plain-string `content`).
+///
+/// Pure — no I/O. Assumes the caller already ran [`VisionRequest::validate`]
+/// (so images are non-empty, within bounds, and have no unresolved paths); a
+/// stray unresolved path is still defended here.
+pub fn build_request_body(req: &VisionRequest, model: &str) -> Result<Value, VisionError> {
+    let mut content: Vec<Value> = Vec::with_capacity(req.images.len() + 1);
+    content.push(json!({ "type": "text", "text": req.prompt }));
+    for img in &req.images {
+        content.push(image_url_value(img, req.detail)?);
+    }
+    let mut body = json!({
+        "model": model,
+        "messages": [{ "role": "user", "content": content }],
+        "stream": false,
+    });
+    if let Some(max) = req.max_tokens {
+        body["max_tokens"] = json!(max);
+    }
+    Ok(body)
+}
+
+/// Strict-parse an OpenAI-compatible chat-completion reply into a
+/// [`VisionResponse`]. Ledgers the REPORTED model id (avoids stale-model claims).
+/// Usage tokens are optional (vision providers vary); a missing usage object is
+/// NOT an error. `image_count` is supplied by the caller (the validated count).
+/// **No fallback** — a malformed body is a clean [`VisionError::BadResponse`].
+pub fn parse_response(
+    v: &Value,
+    requested_model: &str,
+    image_count: usize,
+) -> Result<VisionResponse, VisionError> {
+    let choice0 = v
+        .get("choices")
+        .and_then(Value::as_array)
+        .and_then(|a| a.first())
+        .ok_or_else(|| VisionError::BadResponse("missing `choices[0]`".into()))?;
+
+    // content may be a plain string OR a parts array (providers differ); accept
+    // both, join text parts. A reply with no extractable text is a BadResponse —
+    // never a silent empty analysis passed off as success.
+    let message = choice0
+        .get("message")
+        .ok_or_else(|| VisionError::BadResponse("missing `choices[0].message`".into()))?;
+    let analysis = extract_text(message.get("content"))
+        .ok_or_else(|| VisionError::BadResponse("missing analysis text in message".into()))?;
+
+    let reported_model = v
+        .get("model")
+        .and_then(Value::as_str)
+        .unwrap_or(requested_model)
+        .to_string();
+
+    let usage = v.get("usage");
+    let input_tokens = usage
+        .and_then(|u| u.get("prompt_tokens"))
+        .and_then(Value::as_i64);
+    let output_tokens = usage
+        .and_then(|u| u.get("completion_tokens"))
+        .and_then(Value::as_i64);
+
+    Ok(VisionResponse {
+        analysis,
+        model: reported_model,
+        image_count,
+        input_tokens,
+        output_tokens,
+        // OCR latent mirror: the vision route never writes it (see lib.rs).
+        extracted_text: None,
+    })
+}
+
+/// Extract the assistant text from a `content` value that may be either a plain
+/// string or an array of `{type:"text",text}` parts. Returns `None` only when
+/// there is no text at all.
+fn extract_text(content: Option<&Value>) -> Option<String> {
+    match content {
+        Some(Value::String(s)) => Some(s.clone()),
+        Some(Value::Array(parts)) => {
+            let mut out = String::new();
+            for p in parts {
+                if let Some(t) = p.get("text").and_then(Value::as_str) {
+                    out.push_str(t);
+                }
+            }
+            // Distinguish "no text parts" (None) from "empty string content"
+            // (Some("")) — an array with zero text parts is treated as missing.
+            if parts
+                .iter()
+                .any(|p| p.get("text").and_then(Value::as_str).is_some())
+            {
+                Some(out)
+            } else {
+                None
+            }
+        }
+        _ => None,
+    }
+}
+
+/// Encode raw image bytes to standard base64 (for building a [`VisionImage::Base64`]
+/// from bytes the hub executor read via `friday_fs::open_read_within_root`). Pure.
+pub fn encode_image_bytes(bytes: &[u8]) -> String {
+    BASE64.encode(bytes)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn req() -> VisionRequest {
+        VisionRequest {
+            prompt: "describe".into(),
+            images: vec![
+                VisionImage::Url("https://x/a.png".into()),
+                VisionImage::Base64 {
+                    mime: "image/png".into(),
+                    data_base64: "QUJD".into(),
+                },
+            ],
+            model: None,
+            detail: ImageDetail::High,
+            max_tokens: Some(256),
+        }
+    }
+
+    #[test]
+    fn body_has_multimodal_content_array_one_text_plus_one_per_image() {
+        let body = build_request_body(&req(), "vis-pro").unwrap();
+        assert_eq!(body["model"], "vis-pro");
+        assert_eq!(body["stream"], false);
+        assert_eq!(body["max_tokens"], 256);
+        let content = body["messages"][0]["content"].as_array().unwrap();
+        // 1 text part + 2 image parts.
+        assert_eq!(content.len(), 3);
+        assert_eq!(content[0]["type"], "text");
+        assert_eq!(content[0]["text"], "describe");
+        assert_eq!(content[1]["type"], "image_url");
+        assert_eq!(content[1]["image_url"]["url"], "https://x/a.png");
+        assert_eq!(content[1]["image_url"]["detail"], "high");
+        // base64 image becomes a data URI.
+        assert_eq!(content[2]["image_url"]["url"], "data:image/png;base64,QUJD");
+    }
+
+    #[test]
+    fn body_omits_max_tokens_when_none() {
+        let mut r = req();
+        r.max_tokens = None;
+        let body = build_request_body(&r, "m").unwrap();
+        assert!(body.get("max_tokens").is_none());
+    }
+
+    #[test]
+    fn body_build_rejects_unresolved_workspace_path() {
+        let r = VisionRequest {
+            prompt: "x".into(),
+            images: vec![VisionImage::WorkspacePath("a.png".into())],
+            model: None,
+            detail: ImageDetail::Auto,
+            max_tokens: None,
+        };
+        assert!(matches!(
+            build_request_body(&r, "m").unwrap_err(),
+            VisionError::UnresolvedImage(_)
+        ));
+    }
+
+    #[test]
+    fn parse_response_reads_string_content_and_reported_model() {
+        let v = json!({
+            "model": "vis-pro-0613",
+            "choices": [{"message": {"role": "assistant", "content": "a tabby cat"}}],
+            "usage": {"prompt_tokens": 1200, "completion_tokens": 18}
+        });
+        let r = parse_response(&v, "vis-pro", 2).unwrap();
+        assert_eq!(r.analysis, "a tabby cat");
+        assert_eq!(r.model, "vis-pro-0613");
+        assert_eq!(r.image_count, 2);
+        assert_eq!(r.input_tokens, Some(1200));
+        assert_eq!(r.output_tokens, Some(18));
+        assert!(r.extracted_text.is_none());
+    }
+
+    #[test]
+    fn parse_response_reads_parts_array_content() {
+        let v = json!({
+            "model": "m",
+            "choices": [{"message": {"content": [
+                {"type": "text", "text": "hello "},
+                {"type": "text", "text": "world"}
+            ]}}]
+        });
+        let r = parse_response(&v, "m", 1).unwrap();
+        assert_eq!(r.analysis, "hello world");
+        // usage absent → tokens None (not an error).
+        assert_eq!(r.input_tokens, None);
+        assert_eq!(r.output_tokens, None);
+    }
+
+    #[test]
+    fn parse_response_falls_back_to_requested_model_when_unreported() {
+        let v = json!({
+            "choices": [{"message": {"content": "x"}}]
+        });
+        let r = parse_response(&v, "requested-m", 1).unwrap();
+        assert_eq!(r.model, "requested-m");
+    }
+
+    #[test]
+    fn parse_response_missing_choices_is_bad_response() {
+        let v = json!({"model": "m"});
+        assert!(matches!(
+            parse_response(&v, "m", 1).unwrap_err(),
+            VisionError::BadResponse(_)
+        ));
+    }
+
+    #[test]
+    fn parse_response_missing_text_is_bad_response_not_silent_empty() {
+        // A reply with no text content is an error — never a silent empty analysis
+        // passed off as a successful vision result.
+        let v = json!({
+            "model": "m",
+            "choices": [{"message": {"content": [{"type": "image_url"}]}}]
+        });
+        assert!(matches!(
+            parse_response(&v, "m", 1).unwrap_err(),
+            VisionError::BadResponse(_)
+        ));
+    }
+
+    #[test]
+    fn map_ureq_status_partition_matches_deepseek_boundary() {
+        let status_err = |code: u16| {
+            let resp = ureq::Response::new(code, "x", "{}").unwrap();
+            map_ureq_err(ureq::Error::Status(code, resp))
+        };
+        for code in [500u16, 502, 503, 504, 599, 408] {
+            assert!(matches!(
+                status_err(code),
+                VisionError::ProviderUnavailable(ref r) if r == &format!("HTTP {code}")
+            ));
+        }
+        for code in [400u16, 404, 409, 422, 429] {
+            assert!(
+                matches!(status_err(code), VisionError::ClientError { status } if status == code)
+            );
+        }
+        assert!(matches!(status_err(401), VisionError::Auth(401)));
+        assert!(matches!(status_err(403), VisionError::Auth(403)));
+    }
+
+    #[test]
+    fn encode_image_bytes_is_standard_base64() {
+        assert_eq!(encode_image_bytes(b"ABC"), "QUJD");
+        assert_eq!(encode_image_bytes(b""), "");
+    }
+}


### PR DESCRIPTION
## VIS-1 (F11 Wave-2 crate root)

Net-new `friday-vision` crate — the `image_analysis` (vision) client seam. Fills the multimodal-message gap: `friday-deepseek`/`friday-anthropic` `chat()` send `"content"` as a PLAIN STRING; there is no multimodal (text + `image_url` parts) message shape in Rust today.

Per F11 plan §0.1 / §3 (VIS-1), the capability crate ships ONLY the DI trait + a real `ureq` transport + a deterministic stub. The `impl ToolExecutor` wrapper is a later `friday-hub` module (VISOCR-EXEC) — a capability crate cannot depend on `friday-hub` without a cycle.

### What landed
- **`lib.rs`** — `VisionModelClient` DI trait + `VisionRequest`/`VisionResponse`/`VisionImage`(`Url`|`Base64`|`WorkspacePath`)/`ImageDetail`(low|high|auto, default auto)/`VisionError`, mirroring the TS `image_analysis` tool (`MAX_IMAGES=10`, `MAX_DATA_URI_BYTES=20MiB`, pure `validate()` with no I/O). `extracted_text` is a latent `None` mirror of the oracle's never-written field — this crate is NOT an OCR engine.
- **`transport.rs`** — `VisionTransport` seam + real `UreqVisionTransport` (base64 multimodal POST; coarse, secret-free status→error mapping matching deepseek's partition: 401/403→Auth, 408+5xx→transient, other-4xx+429→terminal); pure `build_request_body`/`parse_response` (no I/O, accepts string- or parts-array content; ledgers the reported model). **No fallback** — a failed route is a `VisionError`, never a substitute or canned answer.
- **`client.rs`** — `HttpVisionModelClient` (validate→build→POST→parse) and the deterministic `StubVisionModelClient` (fixed analysis + token counts; still runs validation — not a yes-machine; never a runtime fallback).

### Dark discipline
- Flag `FRIDAY_VISION_TOOL_ENABLED` is a **const-only name**; `route_enabled` is a pure predicate. The crate reads NO environment and enforces NO gate — the gate is enforced later at the hub.
- No `friday-hub`/`friday-ffi` dep, no `ToolExecutor`/`ToolRegistry`/capability change.
- Provider-secret-bearing → stays OUT of `friday-ffi`'s phone dependency graph. Live BYOK vision-LLM proof is operator-gated.
- `Cargo.lock` delta is only the `friday-vision` dep-edge (`base64 0.22.1`/`serde_json`/`thiserror`/`ureq` all already locked — no new external crate).

### Gate (all green, from the worktree's `rust-core`)
- `cargo fmt --all -- --check`
- `cargo clippy -p friday-vision --all-targets -- -D warnings`
- `cargo build -p friday-vision`
- `cargo test -p friday-vision` — 33 tests pass (incl. real-`ureq` end-to-end against a local socket + coarse/secret-free 4xx + network-fail rendering)
- `cargo build --workspace`

🤖 Generated with [Claude Code](https://claude.com/claude-code)