### PR TITLE
feat(f11 b1): friday-browser BrowserBackend trait + StubBrowserBackend + guards + handler mod stubs

### DIFF
--- a/rust-core/Cargo.lock
+++ b/rust-core/Cargo.lock
@@ -631,6 +631,11 @@ dependencies = [
 [[package]]
 name = "friday-browser"
 version = "0.0.1"
+dependencies = [
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+]
 
 [[package]]
 name = "friday-core"

--- a/rust-core/crates/friday-browser/Cargo.toml
+++ b/rust-core/crates/friday-browser/Cargo.toml
@@ -1,8 +1,23 @@
 [package]
 name = "friday-browser"
-description = "Friday F11 net-new media capability — browser crate skeleton. Empty compiling stub, no logic/deps/executors yet (Hub-only, heavy-binary → stays OUT of friday-ffi's phone dependency graph)."
+description = "Friday F11 net-new media capability — browser engine crate. Ships the BrowserBackend DI trait + the only-default-constructible StubBrowserBackend + the action/param schema + the SSRF/allowed-origins URL guard + the targetId resolver + the snapshot element-id cache + dom-lite types + the artifact-path helper. The real CDP backend lives behind the DEFAULT-OFF `browser-live-deploy-go` cargo feature (B4-LIVE). Hub-only, heavy-binary → stays OUT of friday-ffi's phone dependency graph. The `impl ToolExecutor` wrapper is a friday-hub module, not part of this crate (no hub dep → no cycle)."
 edition.workspace = true
 version.workspace = true
 license.workspace = true
 publish = false
 rust-version.workspace = true
+
+[features]
+# DEFAULT-OFF live-CDP deploy-go spine (mirrors friday-hub's `os-actuation-deploy-go`
+# precedent). With the feature OFF (the default, dark posture) the ONLY constructible
+# backend is `StubBrowserBackend` — no network, no Chromium, nothing real can be linked.
+# With the feature ON the real chromiumoxide CDP backend is an explicit UNBUILT seam
+# (`compile_error!` in lib.rs) until B4-LIVE supplies it via a deliberate, reviewable
+# RECOMPILED DEPLOY-GO cutover. So the default binary can never link a real browser
+# actuator by accident. NO dependency is pulled in by this empty feature here.
+browser-live-deploy-go = []
+
+[dependencies]
+thiserror = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }

--- a/rust-core/crates/friday-browser/src/action.rs
+++ b/rust-core/crates/friday-browser/src/action.rs
@@ -1,0 +1,702 @@
+//! The `browser` tool action/param schema — a faithful, strongly-typed port of the TS
+//! `friday-agent-browser-tool` parameter schema.
+//!
+//! The TS tool takes a single flat `params` object with an `action` discriminator (one of
+//! 16 actions) plus action-specific fields. This module parses that flat
+//! `serde_json::Value` into a [`BrowserAction`] enum so every handler (B2a-d) matches on a
+//! validated, typed value instead of re-reading raw params. The set of actions, `act`
+//! sub-kinds, `tabsAction` sub-kinds, and `screenshotMode` values are kept byte-identical
+//! to the oracle's `enum` lists.
+//!
+//! Pure parsing/validation only — no I/O, no backend call.
+
+use serde_json::Value;
+use thiserror::Error;
+
+/// Parse/validation failures for a `browser` tool param object. Coarse + payload-free
+/// (mirrors the provider-crate error discipline): a message names the offending field,
+/// never echoes a secret-bearing value.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum BrowserActionError {
+    /// The required `action` field is missing or not a string.
+    #[error("browser: required string param `action` is missing")]
+    MissingAction,
+    /// `action` was a string but not one of the 16 valid actions.
+    #[error("browser: invalid action `{0}`")]
+    InvalidAction(String),
+    /// `act` was a string but not one of the valid act sub-kinds.
+    #[error("browser: invalid act sub-action `{0}`")]
+    InvalidAct(String),
+    /// The `act` action requires an `act` sub-kind, which was missing.
+    #[error("browser: action `act` requires an `act` sub-action")]
+    MissingAct,
+    /// `tabsAction` was a string but not one of the valid tabs sub-kinds.
+    #[error("browser: invalid tabsAction `{0}`")]
+    InvalidTabsAction(String),
+    /// `screenshotMode` was a string but not `path` | `base64`.
+    #[error("browser: invalid screenshotMode `{0}`")]
+    InvalidScreenshotMode(String),
+    /// A field was present but had the wrong JSON type.
+    #[error("browser: param `{field}` has the wrong type (expected {expected})")]
+    WrongType {
+        /// The offending field name.
+        field: &'static str,
+        /// The expected JSON type.
+        expected: &'static str,
+    },
+    /// An action requires a field that was absent.
+    #[error("browser: action `{action}` requires param `{field}`")]
+    MissingField {
+        /// The action that needs the field.
+        action: &'static str,
+        /// The missing field name.
+        field: &'static str,
+    },
+}
+
+/// Screenshot output mode (oracle `screenshotMode` enum: `["path", "base64"]`).
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum ScreenshotMode {
+    /// Write the PNG to a workspace artifact path and return the path (the default).
+    #[default]
+    Path,
+    /// Return the PNG inline as base64.
+    Base64,
+}
+
+impl ScreenshotMode {
+    fn parse(s: &str) -> Result<Self, BrowserActionError> {
+        match s {
+            "path" => Ok(ScreenshotMode::Path),
+            "base64" => Ok(ScreenshotMode::Base64),
+            other => Err(BrowserActionError::InvalidScreenshotMode(other.to_string())),
+        }
+    }
+}
+
+/// The `tabs` sub-action (oracle `tabsAction` enum: `["list", "new", "switch", "close"]`).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum TabsAction {
+    List,
+    New,
+    Switch,
+    Close,
+}
+
+impl TabsAction {
+    fn parse(s: &str) -> Result<Self, BrowserActionError> {
+        match s {
+            "list" => Ok(TabsAction::List),
+            "new" => Ok(TabsAction::New),
+            "switch" => Ok(TabsAction::Switch),
+            "close" => Ok(TabsAction::Close),
+            other => Err(BrowserActionError::InvalidTabsAction(other.to_string())),
+        }
+    }
+}
+
+/// The `act` sub-kind (oracle `act` enum). Each carries the action-specific fields the
+/// oracle reads for that sub-kind. These are the MUTATING, external-effecting sub-actions
+/// — REGISTER's coarse `mutating=true/High` default gates the whole `browser` tool so
+/// none of these can fail-open.
+#[derive(Clone, Debug, PartialEq)]
+pub enum ActKind {
+    /// Click an element (by `elementId` from a snapshot or by `selector`).
+    Click,
+    /// Type text into the focused/targeted element (`text`).
+    Type { text: String },
+    /// Press a key (`key`, e.g. `"Enter"`, `"Tab"`).
+    Press { key: String },
+    /// Hover over an element.
+    Hover,
+    /// Drag from the targeted element to `endSelector` (drop target).
+    Drag { end_selector: Option<String> },
+    /// Select option values in a `<select>` (`values`).
+    Select { values: Vec<String> },
+    /// Fill an input with `text` (clears then types).
+    Fill { text: String },
+    /// Resize the viewport to `width` x `height`.
+    Resize {
+        width: Option<f64>,
+        height: Option<f64>,
+    },
+    /// Wait `time_ms` milliseconds.
+    Wait { time_ms: Option<f64> },
+    /// Evaluate JS (`text` is the script). Carries the oracle's 10s evaluate timeout.
+    Evaluate { script: String },
+    /// Close the targeted element/tab context.
+    Close,
+}
+
+/// The oracle's `act:evaluate` carries a fixed 10-second timeout.
+pub const ACT_EVALUATE_TIMEOUT_MS: u64 = 10_000;
+
+impl ActKind {
+    fn parse(sub: &str, p: &Params<'_>) -> Result<Self, BrowserActionError> {
+        match sub {
+            "click" => Ok(ActKind::Click),
+            "type" => Ok(ActKind::Type {
+                text: p.require_str("act:type", "text")?.to_string(),
+            }),
+            "press" => Ok(ActKind::Press {
+                key: p.require_str("act:press", "key")?.to_string(),
+            }),
+            "hover" => Ok(ActKind::Hover),
+            "drag" => Ok(ActKind::Drag {
+                end_selector: p.opt_str("endSelector")?.map(str::to_string),
+            }),
+            "select" => Ok(ActKind::Select {
+                values: p.opt_str_array("values")?,
+            }),
+            "fill" => Ok(ActKind::Fill {
+                text: p.require_str("act:fill", "text")?.to_string(),
+            }),
+            "resize" => Ok(ActKind::Resize {
+                width: p.opt_f64("width")?,
+                height: p.opt_f64("height")?,
+            }),
+            "wait" => Ok(ActKind::Wait {
+                time_ms: p.opt_f64("timeMs")?,
+            }),
+            // `text` holds the JS for evaluate (oracle: "or JS for act:evaluate").
+            "evaluate" => Ok(ActKind::Evaluate {
+                script: p.require_str("act:evaluate", "text")?.to_string(),
+            }),
+            "close" => Ok(ActKind::Close),
+            other => Err(BrowserActionError::InvalidAct(other.to_string())),
+        }
+    }
+}
+
+/// Common target-addressing fields shared by most actions (the oracle threads these
+/// through every action that touches a page).
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct TargetRef {
+    /// Explicit session id.
+    pub session_id: Option<String>,
+    /// `"sessionId"` or `"sessionId:tabId"` target id.
+    pub target_id: Option<String>,
+    /// Explicit tab id.
+    pub tab_id: Option<String>,
+    /// Profile name (for profile-based session disambiguation).
+    pub profile: Option<String>,
+    /// CSS selector (act target).
+    pub selector: Option<String>,
+    /// Cached element id from a prior snapshot (act target).
+    pub element_id: Option<String>,
+}
+
+/// A fully parsed, validated `browser` tool invocation. The 16 oracle actions, typed.
+#[derive(Clone, Debug, PartialEq)]
+pub enum BrowserAction {
+    /// Open a (new) session, optionally navigating to `url`, with an optional `profile`.
+    Open {
+        target: TargetRef,
+        url: Option<String>,
+    },
+    /// Navigate the targeted tab to `url`.
+    Navigate {
+        target: TargetRef,
+        url: Option<String>,
+    },
+    /// Screenshot the targeted page (`mode` = path|base64, `full_page`).
+    Screenshot {
+        target: TargetRef,
+        mode: ScreenshotMode,
+        full_page: bool,
+    },
+    /// AX-tree snapshot of the targeted page (populates the element-id cache).
+    Snapshot { target: TargetRef },
+    /// An interaction sub-action against the targeted element.
+    Act { target: TargetRef, kind: ActKind },
+    /// Tab operations on a session.
+    Tabs {
+        target: TargetRef,
+        sub: TabsAction,
+        tab_id: Option<String>,
+        url: Option<String>,
+    },
+    /// Close a session (or the targeted tab context).
+    Close { target: TargetRef },
+    /// Read engine/session status (no mutation).
+    Status { profile: Option<String> },
+    /// Start the engine / open a session (oracle: `start` is an alias for `open`).
+    Start {
+        target: TargetRef,
+        url: Option<String>,
+    },
+    /// Stop the engine / close sessions (optionally by `profile`).
+    Stop { profile: Option<String> },
+    /// List active profiles (read).
+    Profiles,
+    /// Focus the targeted tab and bring it to front.
+    Focus { target: TargetRef },
+    /// Read console output, or evaluate `text` as an expression when provided.
+    Console {
+        target: TargetRef,
+        text: Option<String>,
+    },
+    /// Render the targeted page to a PDF artifact.
+    Pdf { target: TargetRef },
+    /// Set files on the targeted file input (`file_paths`).
+    Upload {
+        target: TargetRef,
+        file_paths: Vec<String>,
+    },
+    /// Respond to a JS dialog (`accept` + optional `prompt_text`).
+    Dialog {
+        target: TargetRef,
+        accept: bool,
+        prompt_text: Option<String>,
+    },
+}
+
+/// All 16 valid `action` strings, in the oracle's declared order. Public so the hub /
+/// REGISTER reconciliation can cross-check the surface without re-deriving it.
+pub const VALID_ACTIONS: [&str; 16] = [
+    "open",
+    "navigate",
+    "screenshot",
+    "snapshot",
+    "act",
+    "tabs",
+    "close",
+    "status",
+    "start",
+    "stop",
+    "profiles",
+    "focus",
+    "console",
+    "pdf",
+    "upload",
+    "dialog",
+];
+
+/// A thin typed reader over the flat oracle param object.
+struct Params<'a> {
+    obj: &'a serde_json::Map<String, Value>,
+}
+
+impl<'a> Params<'a> {
+    fn opt_str(&self, field: &'static str) -> Result<Option<&'a str>, BrowserActionError> {
+        match self.obj.get(field) {
+            None | Some(Value::Null) => Ok(None),
+            Some(Value::String(s)) => Ok(Some(s.as_str())),
+            Some(_) => Err(BrowserActionError::WrongType {
+                field,
+                expected: "string",
+            }),
+        }
+    }
+
+    fn require_str(
+        &self,
+        action: &'static str,
+        field: &'static str,
+    ) -> Result<&'a str, BrowserActionError> {
+        self.opt_str(field)?
+            .ok_or(BrowserActionError::MissingField { action, field })
+    }
+
+    fn opt_bool(&self, field: &'static str) -> Result<Option<bool>, BrowserActionError> {
+        match self.obj.get(field) {
+            None | Some(Value::Null) => Ok(None),
+            Some(Value::Bool(b)) => Ok(Some(*b)),
+            Some(_) => Err(BrowserActionError::WrongType {
+                field,
+                expected: "boolean",
+            }),
+        }
+    }
+
+    fn opt_f64(&self, field: &'static str) -> Result<Option<f64>, BrowserActionError> {
+        match self.obj.get(field) {
+            None | Some(Value::Null) => Ok(None),
+            Some(Value::Number(n)) => n.as_f64().map(Some).ok_or(BrowserActionError::WrongType {
+                field,
+                expected: "number",
+            }),
+            Some(_) => Err(BrowserActionError::WrongType {
+                field,
+                expected: "number",
+            }),
+        }
+    }
+
+    fn opt_str_array(&self, field: &'static str) -> Result<Vec<String>, BrowserActionError> {
+        match self.obj.get(field) {
+            None | Some(Value::Null) => Ok(Vec::new()),
+            Some(Value::Array(items)) => items
+                .iter()
+                .map(|v| {
+                    v.as_str()
+                        .map(str::to_string)
+                        .ok_or(BrowserActionError::WrongType {
+                            field,
+                            expected: "array of strings",
+                        })
+                })
+                .collect(),
+            Some(_) => Err(BrowserActionError::WrongType {
+                field,
+                expected: "array of strings",
+            }),
+        }
+    }
+
+    fn target(&self) -> Result<TargetRef, BrowserActionError> {
+        Ok(TargetRef {
+            session_id: self.opt_str("sessionId")?.map(str::to_string),
+            target_id: self.opt_str("targetId")?.map(str::to_string),
+            tab_id: self.opt_str("tabId")?.map(str::to_string),
+            profile: self.opt_str("profile")?.map(str::to_string),
+            selector: self.opt_str("selector")?.map(str::to_string),
+            element_id: self.opt_str("elementId")?.map(str::to_string),
+        })
+    }
+}
+
+impl BrowserAction {
+    /// Parse a flat `params` object (the oracle tool's single argument) into a typed,
+    /// validated [`BrowserAction`]. Mirrors the oracle's `readStringParam("action",
+    /// {required:true})` + `VALID_ACTIONS` membership check, then reads the
+    /// action-specific fields.
+    pub fn parse(params: &Value) -> Result<Self, BrowserActionError> {
+        let obj = params
+            .as_object()
+            .ok_or(BrowserActionError::MissingAction)?;
+        let p = Params { obj };
+
+        let action = match obj.get("action") {
+            Some(Value::String(s)) => s.as_str(),
+            _ => return Err(BrowserActionError::MissingAction),
+        };
+
+        match action {
+            "open" => Ok(BrowserAction::Open {
+                target: p.target()?,
+                url: p.opt_str("url")?.map(str::to_string),
+            }),
+            "navigate" => Ok(BrowserAction::Navigate {
+                target: p.target()?,
+                url: p.opt_str("url")?.map(str::to_string),
+            }),
+            "screenshot" => Ok(BrowserAction::Screenshot {
+                target: p.target()?,
+                mode: match p.opt_str("screenshotMode")? {
+                    Some(s) => ScreenshotMode::parse(s)?,
+                    None => ScreenshotMode::default(),
+                },
+                full_page: p.opt_bool("fullPage")?.unwrap_or(false),
+            }),
+            "snapshot" => Ok(BrowserAction::Snapshot {
+                target: p.target()?,
+            }),
+            "act" => {
+                let sub = p.opt_str("act")?.ok_or(BrowserActionError::MissingAct)?;
+                Ok(BrowserAction::Act {
+                    target: p.target()?,
+                    kind: ActKind::parse(sub, &p)?,
+                })
+            }
+            "tabs" => {
+                let sub = match p.opt_str("tabsAction")? {
+                    Some(s) => TabsAction::parse(s)?,
+                    // The oracle defaults a tabs call with no sub to `list` (read).
+                    None => TabsAction::List,
+                };
+                Ok(BrowserAction::Tabs {
+                    target: p.target()?,
+                    sub,
+                    tab_id: p.opt_str("tabId")?.map(str::to_string),
+                    url: p.opt_str("url")?.map(str::to_string),
+                })
+            }
+            "close" => Ok(BrowserAction::Close {
+                target: p.target()?,
+            }),
+            "status" => Ok(BrowserAction::Status {
+                profile: p.opt_str("profile")?.map(str::to_string),
+            }),
+            "start" => Ok(BrowserAction::Start {
+                target: p.target()?,
+                url: p.opt_str("url")?.map(str::to_string),
+            }),
+            "stop" => Ok(BrowserAction::Stop {
+                profile: p.opt_str("profile")?.map(str::to_string),
+            }),
+            "profiles" => Ok(BrowserAction::Profiles),
+            "focus" => Ok(BrowserAction::Focus {
+                target: p.target()?,
+            }),
+            "console" => Ok(BrowserAction::Console {
+                target: p.target()?,
+                text: p.opt_str("text")?.map(str::to_string),
+            }),
+            "pdf" => Ok(BrowserAction::Pdf {
+                target: p.target()?,
+            }),
+            "upload" => {
+                let file_paths = p.opt_str_array("filePaths")?;
+                if file_paths.is_empty() {
+                    return Err(BrowserActionError::MissingField {
+                        action: "upload",
+                        field: "filePaths",
+                    });
+                }
+                Ok(BrowserAction::Upload {
+                    target: p.target()?,
+                    file_paths,
+                })
+            }
+            "dialog" => Ok(BrowserAction::Dialog {
+                target: p.target()?,
+                accept: p.opt_bool("accept")?.unwrap_or(false),
+                prompt_text: p.opt_str("promptText")?.map(str::to_string),
+            }),
+            other => Err(BrowserActionError::InvalidAction(other.to_string())),
+        }
+    }
+
+    /// Whether this action mutates browser/page state (vs a pure read). The hub's REGISTER
+    /// step gates the WHOLE `browser` tool coarsely (mutating=true/High) because the
+    /// single tool name mixes read + mutating sub-actions; this finer per-action bit is a
+    /// convenience for handler-level ledger hygiene (read sub-actions set `content`,
+    /// mutating sub-actions set refs-only summaries).
+    #[must_use]
+    pub fn is_mutating(&self) -> bool {
+        match self {
+            BrowserAction::Status { .. }
+            | BrowserAction::Profiles
+            | BrowserAction::Snapshot { .. } => false,
+            // `console` is a read UNLESS it carries an expression to evaluate.
+            BrowserAction::Console { text, .. } => text.is_some(),
+            // Everything else opens/navigates/acts/captures/closes/uploads → mutating.
+            _ => true,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn missing_action_is_rejected() {
+        assert_eq!(
+            BrowserAction::parse(&json!({})),
+            Err(BrowserActionError::MissingAction)
+        );
+        assert_eq!(
+            BrowserAction::parse(&json!({"action": 5})),
+            Err(BrowserActionError::MissingAction)
+        );
+        assert_eq!(
+            BrowserAction::parse(&json!("not an object")),
+            Err(BrowserActionError::MissingAction)
+        );
+    }
+
+    #[test]
+    fn invalid_action_is_rejected_with_the_name() {
+        assert_eq!(
+            BrowserAction::parse(&json!({"action": "teleport"})),
+            Err(BrowserActionError::InvalidAction("teleport".to_string()))
+        );
+    }
+
+    #[test]
+    fn all_sixteen_valid_actions_parse() {
+        // Drive each action with the minimal fields it needs so VALID_ACTIONS membership
+        // matches the parser arms exactly (no action silently unparseable).
+        for action in VALID_ACTIONS {
+            let mut obj = serde_json::Map::new();
+            obj.insert("action".to_string(), json!(action));
+            obj.insert("sessionId".to_string(), json!("s1"));
+            if action == "act" {
+                obj.insert("act".to_string(), json!("click"));
+            }
+            if action == "upload" {
+                obj.insert("filePaths".to_string(), json!(["/ws/a.txt"]));
+            }
+            if action == "navigate" || action == "open" || action == "start" {
+                obj.insert("url".to_string(), json!("https://example.com"));
+            }
+            let parsed = BrowserAction::parse(&Value::Object(obj));
+            assert!(
+                parsed.is_ok(),
+                "action {action} failed to parse: {parsed:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn navigate_carries_target_and_url() {
+        let parsed = BrowserAction::parse(&json!({
+            "action": "navigate",
+            "targetId": "s1:tab-1",
+            "url": "https://example.com"
+        }))
+        .expect("parse");
+        match parsed {
+            BrowserAction::Navigate { target, url } => {
+                assert_eq!(target.target_id.as_deref(), Some("s1:tab-1"));
+                assert_eq!(url.as_deref(), Some("https://example.com"));
+            }
+            other => panic!("expected Navigate, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn act_requires_a_sub_kind() {
+        assert_eq!(
+            BrowserAction::parse(&json!({"action": "act", "sessionId": "s1"})),
+            Err(BrowserActionError::MissingAct)
+        );
+        assert_eq!(
+            BrowserAction::parse(&json!({"action": "act", "act": "fly"})),
+            Err(BrowserActionError::InvalidAct("fly".to_string()))
+        );
+    }
+
+    #[test]
+    fn act_type_and_evaluate_read_the_text_field() {
+        let typed = BrowserAction::parse(&json!({
+            "action": "act", "act": "type", "text": "hello"
+        }))
+        .expect("parse type");
+        match typed {
+            BrowserAction::Act {
+                kind: ActKind::Type { text },
+                ..
+            } => assert_eq!(text, "hello"),
+            other => panic!("expected Act/Type, got {other:?}"),
+        }
+
+        let eval = BrowserAction::parse(&json!({
+            "action": "act", "act": "evaluate", "text": "1 + 1"
+        }))
+        .expect("parse evaluate");
+        match eval {
+            BrowserAction::Act {
+                kind: ActKind::Evaluate { script },
+                ..
+            } => {
+                assert_eq!(script, "1 + 1");
+            }
+            other => panic!("expected Act/Evaluate, got {other:?}"),
+        }
+        // The oracle's act:evaluate timeout is a fixed 10s.
+        assert_eq!(ACT_EVALUATE_TIMEOUT_MS, 10_000);
+    }
+
+    #[test]
+    fn act_type_missing_text_is_a_missing_field() {
+        assert_eq!(
+            BrowserAction::parse(&json!({"action": "act", "act": "type"})),
+            Err(BrowserActionError::MissingField {
+                action: "act:type",
+                field: "text"
+            })
+        );
+    }
+
+    #[test]
+    fn screenshot_mode_defaults_to_path_and_rejects_unknown() {
+        let def = BrowserAction::parse(&json!({"action": "screenshot", "sessionId": "s1"}))
+            .expect("parse");
+        match def {
+            BrowserAction::Screenshot {
+                mode, full_page, ..
+            } => {
+                assert_eq!(mode, ScreenshotMode::Path);
+                assert!(!full_page);
+            }
+            other => panic!("expected Screenshot, got {other:?}"),
+        }
+        assert_eq!(
+            BrowserAction::parse(&json!({"action": "screenshot", "screenshotMode": "gif"})),
+            Err(BrowserActionError::InvalidScreenshotMode("gif".to_string()))
+        );
+    }
+
+    #[test]
+    fn tabs_defaults_to_list_and_rejects_unknown_sub() {
+        let def =
+            BrowserAction::parse(&json!({"action": "tabs", "sessionId": "s1"})).expect("parse");
+        match def {
+            BrowserAction::Tabs { sub, .. } => assert_eq!(sub, TabsAction::List),
+            other => panic!("expected Tabs, got {other:?}"),
+        }
+        assert_eq!(
+            BrowserAction::parse(&json!({"action": "tabs", "tabsAction": "merge"})),
+            Err(BrowserActionError::InvalidTabsAction("merge".to_string()))
+        );
+    }
+
+    #[test]
+    fn upload_requires_non_empty_file_paths() {
+        assert_eq!(
+            BrowserAction::parse(&json!({"action": "upload", "sessionId": "s1"})),
+            Err(BrowserActionError::MissingField {
+                action: "upload",
+                field: "filePaths"
+            })
+        );
+        let ok = BrowserAction::parse(&json!({
+            "action": "upload", "filePaths": ["/ws/a.txt", "/ws/b.txt"]
+        }))
+        .expect("parse");
+        match ok {
+            BrowserAction::Upload { file_paths, .. } => assert_eq!(file_paths.len(), 2),
+            other => panic!("expected Upload, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn dialog_accept_defaults_false() {
+        let parsed =
+            BrowserAction::parse(&json!({"action": "dialog", "sessionId": "s1"})).expect("parse");
+        match parsed {
+            BrowserAction::Dialog {
+                accept,
+                prompt_text,
+                ..
+            } => {
+                assert!(!accept);
+                assert!(prompt_text.is_none());
+            }
+            other => panic!("expected Dialog, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn wrong_typed_field_is_rejected() {
+        assert_eq!(
+            BrowserAction::parse(&json!({"action": "navigate", "url": 42})),
+            Err(BrowserActionError::WrongType {
+                field: "url",
+                expected: "string"
+            })
+        );
+    }
+
+    #[test]
+    fn mutation_classification_matches_read_vs_write_sub_actions() {
+        let read = BrowserAction::parse(&json!({"action": "status"})).unwrap();
+        assert!(!read.is_mutating());
+        let snapshot = BrowserAction::parse(&json!({"action": "snapshot"})).unwrap();
+        assert!(!snapshot.is_mutating());
+        let console_read = BrowserAction::parse(&json!({"action": "console"})).unwrap();
+        assert!(!console_read.is_mutating());
+        let console_eval =
+            BrowserAction::parse(&json!({"action": "console", "text": "x"})).unwrap();
+        assert!(console_eval.is_mutating());
+        let nav =
+            BrowserAction::parse(&json!({"action": "navigate", "url": "https://e.com"})).unwrap();
+        assert!(nav.is_mutating());
+        let click = BrowserAction::parse(&json!({"action": "act", "act": "click"})).unwrap();
+        assert!(click.is_mutating());
+    }
+}

--- a/rust-core/crates/friday-browser/src/artifact.rs
+++ b/rust-core/crates/friday-browser/src/artifact.rs
@@ -1,0 +1,159 @@
+//! artifact — the browser artifact-path helper (pure path-string logic), ported from the
+//! TS `sanitizeArtifactPathSegment` / `browserArtifactDir`.
+//!
+//! Screenshot / PDF captures are written under
+//! `<workspaceRoot>/.friday/artifacts/browser/<sanitized-sessionId>/…`. This module
+//! computes that path and sanitizes the session-id segment so a hostile session id can't
+//! traverse out of the artifacts dir. It does NO filesystem I/O — the actual byte writes
+//! happen in the handler PRs (B2a) via the friday-fs root-containment primitives
+//! (`create_dir_all_within_root` / `write_file_within_root`), which apply the realpath /
+//! symlink-escape gate on top of this lexical sanitization. This crate carries no
+//! friday-fs dependency.
+
+use std::path::PathBuf;
+
+use thiserror::Error;
+
+/// A session-id (or other segment) that cannot be turned into a safe path component.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum ArtifactPathError {
+    /// The input was empty, was only separators, contained a `.`/`..` segment, or
+    /// sanitized down to nothing — i.e. it could not yield a safe single path component.
+    #[error("invalid artifact path segment \"{0}\"")]
+    InvalidSegment(String),
+}
+
+/// Sanitize an arbitrary string into a SINGLE safe path component (the oracle's
+/// `sanitizeArtifactPathSegment`):
+///
+/// 1. trim; split on any run of `/`/`\\`; drop empties;
+/// 2. reject if there are no segments OR any segment is `.`/`..` (no traversal);
+/// 3. join the surviving segments with `_`, replace any run of non-`[A-Za-z0-9._-]` with a
+///    single `_`, and strip leading/trailing `._-`;
+/// 4. reject if the result is empty.
+///
+/// The result NEVER contains a path separator — it is always one component.
+pub fn sanitize_artifact_path_segment(input: &str) -> Result<String, ArtifactPathError> {
+    let invalid = || ArtifactPathError::InvalidSegment(input.to_string());
+
+    let raw = input.trim();
+    let segments: Vec<&str> = raw.split(['/', '\\']).filter(|s| !s.is_empty()).collect();
+
+    if segments.is_empty() || segments.iter().any(|s| *s == "." || *s == "..") {
+        return Err(invalid());
+    }
+
+    // Join surviving segments with '_', then collapse non-allowed runs to a single '_'.
+    let joined = segments.join("_");
+    let mut collapsed = String::with_capacity(joined.len());
+    let mut prev_was_underscore_fill = false;
+    for ch in joined.chars() {
+        let allowed = ch.is_ascii_alphanumeric() || ch == '.' || ch == '_' || ch == '-';
+        if allowed {
+            collapsed.push(ch);
+            prev_was_underscore_fill = false;
+        } else if !prev_was_underscore_fill {
+            collapsed.push('_');
+            prev_was_underscore_fill = true;
+        }
+    }
+
+    // Strip leading/trailing `._-`.
+    let sanitized = collapsed.trim_matches(|c| c == '.' || c == '_' || c == '-');
+
+    if sanitized.is_empty() {
+        return Err(invalid());
+    }
+    Ok(sanitized.to_string())
+}
+
+/// Compute the per-session browser artifact directory RELATIVE to the workspace root:
+/// `.friday/artifacts/browser/<sanitized-sessionId>`. The returned path is relative — the
+/// handler joins it under the workspace root and writes through the friday-fs containment
+/// gate (which re-validates against traversal/symlink-escape). Returns the sanitization
+/// error if the session id is unsafe.
+pub fn browser_artifact_dir(session_id: &str) -> Result<PathBuf, ArtifactPathError> {
+    let safe = sanitize_artifact_path_segment(session_id)?;
+    let mut p = PathBuf::from(".friday");
+    p.push("artifacts");
+    p.push("browser");
+    p.push(safe);
+    Ok(p)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn simple_session_id_passes_through() {
+        assert_eq!(sanitize_artifact_path_segment("s1").unwrap(), "s1");
+        assert_eq!(
+            sanitize_artifact_path_segment("session-abc_123.v2").unwrap(),
+            "session-abc_123.v2"
+        );
+    }
+
+    #[test]
+    fn traversal_segments_are_rejected() {
+        // Any segment that is exactly "." or ".." rejects the whole input (no traversal).
+        assert!(sanitize_artifact_path_segment("..").is_err());
+        assert!(sanitize_artifact_path_segment("a/../b").is_err());
+        assert!(sanitize_artifact_path_segment("./x").is_err());
+        // NOTE: "/etc/passwd" has NO "."/".."" segment ([etc, passwd]) → it is NOT a
+        // traversal; it sanitizes to the single component "etc_passwd" (asserted in
+        // `path_separators_are_joined_with_underscore_not_kept`). The separators are
+        // dropped, so the result can never escape the artifacts dir lexically.
+    }
+
+    #[test]
+    fn path_separators_are_joined_with_underscore_not_kept() {
+        // "/etc/passwd" → segments [etc, passwd] → "etc_passwd" (NO separator survives).
+        let out = sanitize_artifact_path_segment("etc/passwd").unwrap();
+        assert_eq!(out, "etc_passwd");
+        assert!(!out.contains('/'));
+        let win = sanitize_artifact_path_segment("a\\b\\c").unwrap();
+        assert_eq!(win, "a_b_c");
+    }
+
+    #[test]
+    fn disallowed_chars_collapse_to_single_underscore() {
+        assert_eq!(sanitize_artifact_path_segment("a  b!!!c").unwrap(), "a_b_c");
+    }
+
+    #[test]
+    fn leading_trailing_punctuation_is_stripped() {
+        assert_eq!(sanitize_artifact_path_segment("__abc--").unwrap(), "abc");
+        assert_eq!(sanitize_artifact_path_segment("...x...").unwrap(), "x");
+    }
+
+    #[test]
+    fn empty_or_all_punctuation_is_rejected() {
+        assert!(sanitize_artifact_path_segment("").is_err());
+        assert!(sanitize_artifact_path_segment("   ").is_err());
+        assert!(sanitize_artifact_path_segment("///").is_err());
+        // Sanitizes down to empty after stripping → reject.
+        assert!(sanitize_artifact_path_segment("!!!").is_err());
+        assert!(sanitize_artifact_path_segment("___").is_err());
+    }
+
+    #[test]
+    fn artifact_dir_is_relative_and_under_friday_artifacts_browser() {
+        let dir = browser_artifact_dir("s1").unwrap();
+        assert_eq!(
+            dir,
+            PathBuf::from(".friday/artifacts/browser/s1"),
+            "got {dir:?}"
+        );
+        // Hostile session id is sanitized into one component.
+        let dir2 = browser_artifact_dir("../../escape").unwrap_or_else(|_| PathBuf::new());
+        // "../../escape" → segments contain ".." → rejected → empty fallback above.
+        assert_eq!(dir2, PathBuf::new());
+    }
+
+    #[test]
+    fn artifact_dir_rejects_unsafe_session_id() {
+        assert!(browser_artifact_dir("..").is_err());
+        assert!(browser_artifact_dir("").is_err());
+    }
+}

--- a/rust-core/crates/friday-browser/src/backend.rs
+++ b/rust-core/crates/friday-browser/src/backend.rs
@@ -1,0 +1,276 @@
+//! backend — the [`BrowserBackend`] dependency-injection trait: the seam between the
+//! action handlers (B2a-d) and the actual browser engine.
+//!
+//! This is the os-actuation `OsActuationBackend` analogue. The ONLY default-constructible
+//! impl is [`crate::stub::StubBrowserBackend`] (deterministic, in-memory, no network, no
+//! Chromium). The real Chrome-DevTools-Protocol impl is supplied by B4-LIVE behind the
+//! DEFAULT-OFF `browser-live-deploy-go` cargo feature; until then the feature-ON build does
+//! not compile (the `compile_error!` in `lib.rs`). So the default build cannot link a real
+//! actuator — this dark slice can never move a real browser.
+//!
+//! The trait carries NO `friday-hub` dependency: per the verified hub↔crate boundary, the
+//! `impl friday_hub::ToolExecutor` wrapper that calls these methods is a HUB module
+//! (B3-EXEC), not part of this crate (that would force a dependency cycle). The trait is
+//! synchronous and blocking, matching the provider-crate `Transport` seam — the hub adapts
+//! to async at its edge if needed.
+
+use thiserror::Error;
+
+use crate::dom_lite::{ConsoleEntry, PageInfo, PresentationMode, SnapshotResult, TabInfo};
+
+/// A backend operation failure. Coarse + payload-bounded (mirrors the provider-crate
+/// error discipline): names the failure class, never echoes page content or a secret.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum BackendError {
+    /// The engine is not running / could not be started.
+    #[error("browser engine unavailable: {0}")]
+    EngineUnavailable(String),
+    /// The named session does not exist.
+    #[error("browser session not found: {0}")]
+    SessionNotFound(String),
+    /// The named tab does not exist in its session.
+    #[error("browser tab not found: {0}")]
+    TabNotFound(String),
+    /// The requested element/selector could not be found on the page.
+    #[error("browser element not found: {0}")]
+    ElementNotFound(String),
+    /// A navigation was rejected by the URL guard (carries the guard message). The handler
+    /// runs the guard BEFORE calling the backend, so a real backend should never produce
+    /// this — but it lets the stub model a rejected navigation in tests.
+    #[error("browser navigation rejected: {0}")]
+    NavigationRejected(String),
+    /// The operation timed out (e.g. an `act:wait` / `act:evaluate` exceeded its budget).
+    #[error("browser operation timed out: {0}")]
+    Timeout(String),
+    /// The operation is not supported by this backend (the honest "not wired" marker —
+    /// the analogue of the os-actuation `Unavailable`).
+    #[error("browser operation unsupported: {0}")]
+    Unsupported(String),
+    /// Any other engine-side failure, classified coarsely.
+    #[error("browser engine error: {0}")]
+    Engine(String),
+}
+
+/// A handle to an open session + active tab returned by open/start/navigate.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct SessionHandle {
+    /// The session id.
+    pub session_id: String,
+    /// The active tab id.
+    pub tab_id: String,
+    /// Whether an existing session was reused (vs newly launched).
+    pub reused: bool,
+    /// How the session is presented (headless vs visible host Chrome).
+    pub presentation: PresentationMode,
+}
+
+/// A summary of one open session (for `status`).
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct SessionSummary {
+    /// The session id.
+    pub session_id: String,
+    /// The session's profile name, if any.
+    pub profile: Option<String>,
+    /// Number of open tabs.
+    pub tab_count: usize,
+    /// The active tab id.
+    pub active_tab_id: String,
+    /// Presentation mode.
+    pub presentation: PresentationMode,
+}
+
+/// An active profile summary (for `profiles`).
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct ProfileSummary {
+    /// The profile name (or `"(default)"` for sessions launched without a profile).
+    pub name: String,
+    /// Session ids using this profile.
+    pub session_ids: Vec<String>,
+}
+
+/// The result of a screenshot/pdf capture: either a workspace-relative artifact path or
+/// inline bytes (base64 mode for screenshots). The handler writes path-mode bytes via the
+/// friday-fs containment primitives; this carries what the backend produced.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum CaptureOutput {
+    /// Raw bytes the handler will persist (PNG/PDF) under the artifact dir, or return
+    /// inline (base64 screenshot mode).
+    Bytes(Vec<u8>),
+}
+
+/// The browser engine seam. Every method is fallible with a [`BackendError`]; a real
+/// backend MUST NOT report success for an effect it did not perform (the os-actuation
+/// "never report Completed for an unperformed effect" discipline).
+///
+/// Methods map to the 16 `browser` actions. `open`/`start` share `open_session`;
+/// `stop` is `close_session(None)` semantics threaded by the lifecycle handler.
+pub trait BrowserBackend {
+    // ── Engine / session lifecycle ──────────────────────────────────────────────────
+
+    /// Start the engine (idempotent; a no-op if already running). The lifecycle handler
+    /// (B2b) calls this for `start`.
+    fn start_engine(&self) -> Result<(), BackendError>;
+
+    /// Stop the engine and close all sessions (the `stop` action). Returns the number of
+    /// sessions closed.
+    fn stop_engine(&self) -> Result<usize, BackendError>;
+
+    /// Open (or reuse) a session for `profile`, optionally navigating to `url`. Backs both
+    /// `open` and `start` (alias). The URL guard has already run at the handler layer for
+    /// any `url`.
+    fn open_session(
+        &self,
+        session_id: Option<&str>,
+        profile: Option<&str>,
+        url: Option<&str>,
+    ) -> Result<SessionHandle, BackendError>;
+
+    /// Close a session (the `close` action); `None` closes the most-recent/all per the
+    /// handler's policy. Returns the number of sessions closed.
+    fn close_session(&self, session_id: Option<&str>) -> Result<usize, BackendError>;
+
+    /// Close all sessions matching `profile` (the `stop`-by-profile path). Returns the
+    /// count closed.
+    fn close_sessions_by_profile(&self, profile: &str) -> Result<usize, BackendError>;
+
+    /// Read engine status: the open sessions (optionally filtered by `profile`). A READ.
+    fn status(&self, profile: Option<&str>) -> Result<Vec<SessionSummary>, BackendError>;
+
+    /// List active profiles (the `profiles` action). A READ.
+    fn profiles(&self) -> Result<Vec<ProfileSummary>, BackendError>;
+
+    /// Focus a tab and bring it to front (the `focus` action).
+    fn focus(&self, session_id: &str, tab_id: &str) -> Result<(), BackendError>;
+
+    // ── Tabs ──────────────────────────────────────────────────────────────────────
+
+    /// List the tabs of a session (`tabs:list`). A READ.
+    fn list_tabs(&self, session_id: &str) -> Result<Vec<TabInfo>, BackendError>;
+
+    /// Open a new tab (`tabs:new`), optionally navigating to `url`. Returns the new tab id.
+    fn new_tab(&self, session_id: &str, url: Option<&str>) -> Result<String, BackendError>;
+
+    /// Switch the active tab (`tabs:switch`).
+    fn switch_tab(&self, session_id: &str, tab_id: &str) -> Result<(), BackendError>;
+
+    /// Close a tab (`tabs:close`).
+    fn close_tab(&self, session_id: &str, tab_id: &str) -> Result<(), BackendError>;
+
+    // ── Navigation / capture ────────────────────────────────────────────────────────
+
+    /// Navigate the targeted tab to `url` (the `navigate` action). The handler has ALREADY
+    /// validated `url` through the SSRF/origin guard before this is called.
+    fn navigate(&self, session_id: &str, tab_id: &str, url: &str)
+        -> Result<PageInfo, BackendError>;
+
+    /// Screenshot the targeted tab (`screenshot`). `full_page` requests a full-page
+    /// capture. Returns raw PNG bytes; the handler chooses path vs base64 presentation.
+    fn screenshot(
+        &self,
+        session_id: &str,
+        tab_id: &str,
+        full_page: bool,
+    ) -> Result<CaptureOutput, BackendError>;
+
+    /// AX-tree snapshot of the targeted tab (`snapshot`), assigning stable element ids the
+    /// handler caches. A READ.
+    fn snapshot(&self, session_id: &str, tab_id: &str) -> Result<SnapshotResult, BackendError>;
+
+    /// Read the targeted tab's console log lines (`console`, no expression). A READ.
+    fn console(&self, session_id: &str, tab_id: &str) -> Result<Vec<ConsoleEntry>, BackendError>;
+
+    /// Evaluate a JS expression in the targeted tab and return its stringified result
+    /// (`console` with text, and `act:evaluate`). Carries the caller-supplied
+    /// `timeout_ms` (the handler passes the oracle's 10s for act:evaluate).
+    fn evaluate(
+        &self,
+        session_id: &str,
+        tab_id: &str,
+        script: &str,
+        timeout_ms: u64,
+    ) -> Result<String, BackendError>;
+
+    /// Render the targeted tab to PDF (`pdf`). Returns raw PDF bytes.
+    fn print_pdf(&self, session_id: &str, tab_id: &str) -> Result<CaptureOutput, BackendError>;
+
+    // ── Interaction (the `act` family) ────────────────────────────────────────────
+
+    /// Click an element resolved by `selector` (the handler resolves a cached `elementId`
+    /// to a selector before calling).
+    fn click(&self, session_id: &str, tab_id: &str, selector: &str) -> Result<(), BackendError>;
+
+    /// Type `text` into the targeted element.
+    fn type_text(
+        &self,
+        session_id: &str,
+        tab_id: &str,
+        selector: Option<&str>,
+        text: &str,
+    ) -> Result<(), BackendError>;
+
+    /// Press a key in the targeted tab.
+    fn press_key(&self, session_id: &str, tab_id: &str, key: &str) -> Result<(), BackendError>;
+
+    /// Hover over an element.
+    fn hover(&self, session_id: &str, tab_id: &str, selector: &str) -> Result<(), BackendError>;
+
+    /// Drag from `selector` to `end_selector`.
+    fn drag(
+        &self,
+        session_id: &str,
+        tab_id: &str,
+        selector: &str,
+        end_selector: &str,
+    ) -> Result<(), BackendError>;
+
+    /// Select option `values` in a `<select>` addressed by `selector`.
+    fn select(
+        &self,
+        session_id: &str,
+        tab_id: &str,
+        selector: &str,
+        values: &[String],
+    ) -> Result<(), BackendError>;
+
+    /// Fill an input (clear + type) addressed by `selector` with `text`.
+    fn fill(
+        &self,
+        session_id: &str,
+        tab_id: &str,
+        selector: &str,
+        text: &str,
+    ) -> Result<(), BackendError>;
+
+    /// Resize the viewport.
+    fn resize(
+        &self,
+        session_id: &str,
+        tab_id: &str,
+        width: u32,
+        height: u32,
+    ) -> Result<(), BackendError>;
+
+    /// Wait `time_ms` milliseconds (the `act:wait` sub-action).
+    fn wait(&self, session_id: &str, tab_id: &str, time_ms: u64) -> Result<(), BackendError>;
+
+    // ── Upload / dialog ─────────────────────────────────────────────────────────────
+
+    /// Set `file_paths` on the targeted file input (the `upload` action). The handler has
+    /// already confined the paths to the workspace/tmp via friday-fs realpath containment.
+    fn upload(
+        &self,
+        session_id: &str,
+        tab_id: &str,
+        selector: Option<&str>,
+        file_paths: &[String],
+    ) -> Result<(), BackendError>;
+
+    /// Respond to a pending JS dialog (`dialog`): accept/dismiss with optional prompt text.
+    fn dialog(
+        &self,
+        session_id: &str,
+        tab_id: &str,
+        accept: bool,
+        prompt_text: Option<&str>,
+    ) -> Result<(), BackendError>;
+}

--- a/rust-core/crates/friday-browser/src/dom_lite.rs
+++ b/rust-core/crates/friday-browser/src/dom_lite.rs
@@ -1,0 +1,142 @@
+//! dom-lite — the lightweight, serializable page/AX/console types the [`BrowserBackend`]
+//! trait returns and the handlers consume.
+//!
+//! These mirror the TS browser-manager's snapshot/console/page shapes at a "lite" level:
+//! enough structure for the agent to reason about a page (accessibility tree nodes,
+//! console log lines, page metadata, tab listing) without the full live `Page` object.
+//! Pure data — no I/O, no network.
+//!
+//! [`BrowserBackend`]: crate::backend::BrowserBackend
+
+use serde::{Deserialize, Serialize};
+
+/// How a session is presented to the user — headless (no window) vs a visible host
+/// Chrome desktop window. Mirrors the TS presentation-mode metadata (the manager
+/// relaunches a headless session when a visible desktop session is requested).
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PresentationMode {
+    /// No visible window (the default automation mode).
+    #[default]
+    Headless,
+    /// A visible host-Chrome desktop window.
+    HostChromeVisible,
+}
+
+/// Page metadata (the "lite" view of a live page): the current URL + title.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PageInfo {
+    /// The page's current URL (post-redirect, as the engine reports it).
+    pub url: String,
+    /// The page title (`document.title` equivalent), if known.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+}
+
+/// A tab within a session.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TabInfo {
+    /// The tab id (the second component of a `sessionId:tabId` target id).
+    pub tab_id: String,
+    /// The tab's current page.
+    pub page: PageInfo,
+    /// Whether this is the session's active tab.
+    pub active: bool,
+}
+
+/// A node in the dom-lite accessibility tree (the snapshot result). One node per
+/// addressable element; `element_id` is the stable handle the [`ElementCache`] keys on so
+/// a later `act` can target an element discovered by a prior `snapshot`.
+///
+/// [`ElementCache`]: crate::element_cache::ElementCache
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DomNode {
+    /// The stable element id assigned by the snapshot (cached for later `act` targeting).
+    pub element_id: String,
+    /// The accessibility role (e.g. `"button"`, `"link"`, `"textbox"`).
+    pub role: String,
+    /// The accessible name / label, if any.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    /// A CSS selector that addresses this node, if the engine can supply one.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub selector: Option<String>,
+}
+
+/// The result of a `snapshot`: the AX-tree nodes (each with a freshly-assigned element id)
+/// plus the page they were captured from.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SnapshotResult {
+    /// The page the snapshot was taken from.
+    pub page: PageInfo,
+    /// The accessibility-tree nodes, each carrying a stable `element_id`.
+    pub nodes: Vec<DomNode>,
+}
+
+/// A console message log level.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ConsoleLevel {
+    #[default]
+    Log,
+    Info,
+    Warn,
+    Error,
+    Debug,
+}
+
+/// A single console log line read from the page.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ConsoleEntry {
+    /// The message level.
+    pub level: ConsoleLevel,
+    /// The message text.
+    pub text: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn presentation_mode_defaults_headless() {
+        assert_eq!(PresentationMode::default(), PresentationMode::Headless);
+    }
+
+    #[test]
+    fn console_level_defaults_log() {
+        assert_eq!(ConsoleLevel::default(), ConsoleLevel::Log);
+    }
+
+    #[test]
+    fn snapshot_roundtrips_through_serde_json() {
+        let snap = SnapshotResult {
+            page: PageInfo {
+                url: "https://example.com/".to_string(),
+                title: Some("Example".to_string()),
+            },
+            nodes: vec![DomNode {
+                element_id: "el-1".to_string(),
+                role: "button".to_string(),
+                name: Some("Submit".to_string()),
+                selector: Some("#submit".to_string()),
+            }],
+        };
+        let json = serde_json::to_string(&snap).expect("serialize");
+        let back: SnapshotResult = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(snap, back);
+    }
+
+    #[test]
+    fn optional_fields_are_omitted_when_none() {
+        let page = PageInfo {
+            url: "https://example.com/".to_string(),
+            title: None,
+        };
+        let json = serde_json::to_string(&page).expect("serialize");
+        assert!(
+            !json.contains("title"),
+            "None title must be skipped: {json}"
+        );
+    }
+}

--- a/rust-core/crates/friday-browser/src/element_cache.rs
+++ b/rust-core/crates/friday-browser/src/element_cache.rs
@@ -1,0 +1,126 @@
+//! element_cache — the snapshot-derived element-id cache.
+//!
+//! A `snapshot` assigns a stable `element_id` to each addressable node (see
+//! [`crate::dom_lite::DomNode`]). A later `act` can target an element by that id instead of
+//! a fresh CSS selector — but only ids from a PRIOR snapshot are valid. This cache is the
+//! lookup table: a snapshot populates it (per session/tab scope), an `act:click
+//! elementId=…` resolves through it to the node's selector (or fails closed if the id was
+//! never snapshotted / is stale).
+//!
+//! Pure in-memory map — no I/O. Scoped by a `scope` key (the handler passes
+//! `sessionId:tabId` so two tabs don't collide).
+
+use std::collections::HashMap;
+
+use crate::dom_lite::DomNode;
+
+/// A snapshot-derived element-id → node cache, keyed by a scope string (typically the
+/// resolved `sessionId:tabId`). Populating a scope REPLACES its prior contents (a fresh
+/// snapshot invalidates stale ids for that scope — matching the oracle, where a new
+/// snapshot supersedes the previous element handles).
+#[derive(Clone, Debug, Default)]
+pub struct ElementCache {
+    /// scope → (element_id → node)
+    by_scope: HashMap<String, HashMap<String, DomNode>>,
+}
+
+impl ElementCache {
+    /// A fresh, empty cache.
+    #[must_use]
+    pub fn new() -> Self {
+        ElementCache {
+            by_scope: HashMap::new(),
+        }
+    }
+
+    /// Populate a scope from a snapshot's nodes, REPLACING any prior entries for that
+    /// scope (a new snapshot invalidates stale element ids).
+    pub fn populate(&mut self, scope: &str, nodes: &[DomNode]) {
+        let map = nodes
+            .iter()
+            .map(|n| (n.element_id.clone(), n.clone()))
+            .collect();
+        self.by_scope.insert(scope.to_string(), map);
+    }
+
+    /// Resolve a cached element id within a scope to its node (e.g. for an `act` target).
+    /// Returns `None` if the scope was never snapshotted or the id is stale/unknown
+    /// (fail-closed: the handler then rejects the act rather than guessing).
+    #[must_use]
+    pub fn resolve<'a>(&'a self, scope: &str, element_id: &str) -> Option<&'a DomNode> {
+        self.by_scope.get(scope)?.get(element_id)
+    }
+
+    /// Whether a scope has a populated snapshot.
+    #[must_use]
+    pub fn has_scope(&self, scope: &str) -> bool {
+        self.by_scope.contains_key(scope)
+    }
+
+    /// Number of cached elements in a scope (0 if the scope is absent).
+    #[must_use]
+    pub fn len_in_scope(&self, scope: &str) -> usize {
+        self.by_scope.get(scope).map_or(0, HashMap::len)
+    }
+
+    /// Drop a scope's cache (e.g. when its tab/session closes).
+    pub fn clear_scope(&mut self, scope: &str) {
+        self.by_scope.remove(scope);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn node(id: &str, selector: &str) -> DomNode {
+        DomNode {
+            element_id: id.to_string(),
+            role: "button".to_string(),
+            name: None,
+            selector: Some(selector.to_string()),
+        }
+    }
+
+    #[test]
+    fn unknown_id_resolves_to_none_fail_closed() {
+        let cache = ElementCache::new();
+        assert!(cache.resolve("s1:tab-1", "el-1").is_none());
+        assert!(!cache.has_scope("s1:tab-1"));
+    }
+
+    #[test]
+    fn populate_then_resolve() {
+        let mut cache = ElementCache::new();
+        cache.populate("s1:tab-1", &[node("el-1", "#a"), node("el-2", "#b")]);
+        assert!(cache.has_scope("s1:tab-1"));
+        assert_eq!(cache.len_in_scope("s1:tab-1"), 2);
+        let resolved = cache.resolve("s1:tab-1", "el-2").expect("el-2 present");
+        assert_eq!(resolved.selector.as_deref(), Some("#b"));
+        // An id from another scope is not visible.
+        assert!(cache.resolve("s9:tab-9", "el-1").is_none());
+    }
+
+    #[test]
+    fn re_snapshot_replaces_stale_ids() {
+        let mut cache = ElementCache::new();
+        cache.populate("s1", &[node("el-1", "#a")]);
+        // A fresh snapshot of the same scope supersedes the old ids.
+        cache.populate("s1", &[node("el-9", "#z")]);
+        assert!(
+            cache.resolve("s1", "el-1").is_none(),
+            "stale id must be gone"
+        );
+        assert!(cache.resolve("s1", "el-9").is_some());
+        assert_eq!(cache.len_in_scope("s1"), 1);
+    }
+
+    #[test]
+    fn clear_scope_drops_the_cache() {
+        let mut cache = ElementCache::new();
+        cache.populate("s1", &[node("el-1", "#a")]);
+        cache.clear_scope("s1");
+        assert!(!cache.has_scope("s1"));
+        assert_eq!(cache.len_in_scope("s1"), 0);
+    }
+}

--- a/rust-core/crates/friday-browser/src/interaction.rs
+++ b/rust-core/crates/friday-browser/src/interaction.rs
@@ -1,0 +1,7 @@
+//! interaction — the `act` family handler (click/type/press/hover/drag/select/fill/
+//! resize/wait/evaluate/close) over [`crate::backend::BrowserBackend`], resolving targets
+//! through the [`crate::element_cache::ElementCache`] or a CSS selector.
+//!
+//! EMPTY COMPILING STUB (B1). This file exists so B1's `mod interaction;` declaration in
+//! `lib.rs` compiles standalone; the handler bodies are FILLED by B2c (which adds NO new
+//! `mod` line). Until B2c lands this module intentionally carries no items.

--- a/rust-core/crates/friday-browser/src/lib.rs
+++ b/rust-core/crates/friday-browser/src/lib.rs
@@ -1,7 +1,132 @@
-//! Friday F11 net-new media capability — browser crate.
+//! friday-browser — the Friday net-new `browser` capability ENGINE crate (Hub-only,
+//! heavy-binary, DARK).
 //!
-//! Skeleton placeholder only: this crate carries no logic, no dependencies, and
-//! no executor yet. The BrowserBackend trait, the StubBrowserBackend, the
-//! action/param schema, the security guards, and the cargo-feature spine for
-//! the live CDP backend land in later F11 crate-internal PRs (B1, B2a-d). The
-//! `impl ToolExecutor` wrapper is a `friday-hub` module, not part of this crate.
+//! This crate is the F11 browser foundation. It mirrors the os-actuation dark spine
+//! (`friday-hub::system_intent`): the only default-constructible backend is the
+//! [`StubBrowserBackend`] (a deterministic in-memory page/tab/session model — no
+//! network, no Chromium, no host effect), and the real Chrome-DevTools-Protocol backend
+//! is reachable ONLY through a deliberate, reviewable RECOMPILED cutover behind the
+//! DEFAULT-OFF `browser-live-deploy-go` cargo feature, whose feature-ON arm is an
+//! explicit `compile_error!` until B4-LIVE supplies the impl. So the default build cannot
+//! even LINK a real browser actuator — by construction, this dark slice can never move a
+//! real browser.
+//!
+//! # Scope (B1)
+//!
+//! - [`BrowserBackend`] — the dependency-injection trait every handler dispatches against
+//!   (the seam that B4-LIVE's CDP backend and the test stub both implement). It carries NO
+//!   `friday-hub` dependency: per the verified hub↔crate boundary (`friday-deepseek`/
+//!   `friday-anthropic`), the `impl friday_hub::ToolExecutor` wrapper is a HUB module
+//!   (B3-EXEC), never part of this crate — that would force a dependency cycle.
+//! - [`StubBrowserBackend`] — the only default-constructible backend.
+//! - [`action`] — the [`BrowserAction`] enum + `act` sub-kinds + the parsed param schema.
+//! - [`url_guard`] — the SSRF/allowed-origins `validate_url` guard (protocol + origin
+//!   allowlist), a faithful port of the TS `friday-browser-manager` guard.
+//! - [`target_id`] — the `sessionId` / `sessionId:tabId` / profile target-id resolver.
+//! - [`element_cache`] — the snapshot-derived element-id cache.
+//! - [`dom_lite`] — the dom-lite AX/console/page types.
+//! - [`artifact`] — the workspace-relative artifact-path helper (pure path-string logic;
+//!   the actual byte writes are done in the handler PRs via the friday-fs containment
+//!   primitives, never here).
+//!
+//! # Flags (consts only — the gate is enforced at the hub, NOT in this crate)
+//!
+//! The runtime dispatch flag [`ENV_ROUTE_ENABLED`] (`FRIDAY_BROWSER_ENABLED`) is declared
+//! here as a DEFAULT-OFF const + a [`route_enabled`] reader mirroring the
+//! `FRIDAY_CLAUDE_ROUTE_ENABLED` template (true iff the value is exactly `"1"`). This
+//! crate carries NO gate logic of its own — the hub's WIRE composite arm reads the flag.
+//!
+//! # Cargo feature
+//!
+//! `browser-live-deploy-go` (DEFAULT-OFF): the only path to a real browser actuator. The
+//! feature-ON arm is the `compile_error!` below until B4-LIVE; the default build links
+//! only the stub.
+//!
+//! Trust boundary: heavy-binary / live-external-effecting → stays OUT of `friday-ffi`'s
+//! (phone) dependency graph, the same boundary `friday-arch-tests` asserts for the
+//! provider-secret crates.
+
+// ── DEPLOY-GO compile-time gate on the real CDP backend ──────────────────────────────
+//
+// The DEFAULT build (feature OFF) ships ONLY `StubBrowserBackend`. Building with
+// `--features browser-live-deploy-go` intentionally fails to compile until B4-LIVE wires
+// the real chromiumoxide CDP backend (`src/live_cdp.rs`, owned by B4-LIVE — NOT created
+// here) behind this feature. So a default binary can never link a real browser actuator
+// by accident; flipping the feature is a deliberate, reviewable RECOMPILE. Exact mirror
+// of the `os-actuation-deploy-go` precedent (friday-hub/src/system_intent.rs).
+#[cfg(feature = "browser-live-deploy-go")]
+compile_error!(
+    "browser-live-deploy-go: no real CDP BrowserBackend is wired yet. The live Chrome-\
+     DevTools-Protocol backend over chromiumoxide is a DEPLOY-GO cutover (deliberate, \
+     reviewable recompile) — wire the real backend (src/live_cdp.rs) behind this arm in \
+     B4-LIVE before building with this feature. The default build links only \
+     StubBrowserBackend."
+);
+
+pub mod action;
+pub mod artifact;
+pub mod backend;
+pub mod dom_lite;
+pub mod element_cache;
+pub mod stub;
+pub mod target_id;
+pub mod url_guard;
+
+// ── Handler module spine (B2a-d FILL these; B1 pre-declares them so it compiles
+// standalone — empty compiling stubs live in the per-module files). B2a-d add NO new
+// `mod` line: they only fill the already-declared file, keeping each handler PR
+// file-disjoint from the others and from this declaration list. ───────────────────────
+mod interaction;
+mod lifecycle;
+mod nav_capture;
+mod upload_dialog;
+
+pub use action::{ActKind, BrowserAction, BrowserActionError, ScreenshotMode, TabsAction};
+pub use artifact::{browser_artifact_dir, sanitize_artifact_path_segment, ArtifactPathError};
+pub use backend::{BackendError, BrowserBackend};
+pub use dom_lite::{
+    ConsoleEntry, ConsoleLevel, DomNode, PageInfo, PresentationMode, SnapshotResult, TabInfo,
+};
+pub use element_cache::ElementCache;
+pub use stub::StubBrowserBackend;
+pub use target_id::{format_browser_target_id, parse_browser_target_id, ParsedTargetId};
+pub use url_guard::{matches_origin, validate_url, UrlGuardError, FRIDAY_BROWSER_ALLOW_ANY_ORIGIN};
+
+/// Hub-dispatch runtime flag (DEFAULT-OFF). The hub's WIRE composite arm reads this; the
+/// crate itself enforces no gate. Value semantics mirror the `FRIDAY_CLAUDE_ROUTE_ENABLED`
+/// template: enabled iff the env value is exactly `"1"`.
+pub const ENV_ROUTE_ENABLED: &str = "FRIDAY_BROWSER_ENABLED";
+
+/// Optional CDP attach endpoint env override (consumed only by the live B4-LIVE backend;
+/// declared here for one canonical home). Mirrors the TS `connectOverCDP` split.
+pub const ENV_WS_ENDPOINT: &str = "FRIDAY_BROWSER_WS_ENDPOINT";
+
+/// True iff the runtime dispatch flag is set to exactly `"1"`. Pure reader; the hub owns
+/// the actual gate decision — this is a convenience the hub may reuse.
+#[must_use]
+pub fn route_enabled() -> bool {
+    std::env::var(ENV_ROUTE_ENABLED)
+        .map(|v| v == "1")
+        .unwrap_or(false)
+}
+
+#[cfg(test)]
+mod lib_tests {
+    use super::*;
+
+    #[test]
+    fn flag_const_homes_are_stable() {
+        // The crate ships no live default: the dispatch flag lives here, DEFAULT-OFF,
+        // and the hub (not this crate) enforces the gate. Pin the canonical names so a
+        // rename can't silently desync the hub's WIRE arm.
+        assert_eq!(ENV_ROUTE_ENABLED, "FRIDAY_BROWSER_ENABLED");
+        assert_eq!(ENV_WS_ENDPOINT, "FRIDAY_BROWSER_WS_ENDPOINT");
+    }
+
+    #[test]
+    fn stub_is_the_default_constructible_backend() {
+        // The dark invariant: a default backend constructs and actuates nothing real.
+        let _backend = StubBrowserBackend::new();
+        let _backend_default = StubBrowserBackend::default();
+    }
+}

--- a/rust-core/crates/friday-browser/src/lifecycle.rs
+++ b/rust-core/crates/friday-browser/src/lifecycle.rs
@@ -1,0 +1,7 @@
+//! lifecycle — engine/session/tab lifecycle handlers (`start` / `stop` / `status` /
+//! `open` / `close` / `tabs` / `focus` / `profiles`) over
+//! [`crate::backend::BrowserBackend`].
+//!
+//! EMPTY COMPILING STUB (B1). This file exists so B1's `mod lifecycle;` declaration in
+//! `lib.rs` compiles standalone; the handler bodies are FILLED by B2b (which adds NO new
+//! `mod` line). Until B2b lands this module intentionally carries no items.

--- a/rust-core/crates/friday-browser/src/nav_capture.rs
+++ b/rust-core/crates/friday-browser/src/nav_capture.rs
@@ -1,0 +1,7 @@
+//! nav_capture — navigate + content-capture handlers (`navigate` / `screenshot` /
+//! `snapshot` / `console` / `pdf`) over [`crate::backend::BrowserBackend`].
+//!
+//! EMPTY COMPILING STUB (B1). This file exists so B1's `mod nav_capture;` declaration in
+//! `lib.rs` compiles standalone; the handler bodies are FILLED by B2a (which adds NO new
+//! `mod` line, keeping each handler PR file-disjoint). Until B2a lands this module
+//! intentionally carries no items.

--- a/rust-core/crates/friday-browser/src/stub.rs
+++ b/rust-core/crates/friday-browser/src/stub.rs
@@ -1,0 +1,703 @@
+//! stub — [`StubBrowserBackend`], the ONLY default-constructible [`BrowserBackend`].
+//!
+//! A deterministic, in-memory page/tab/session model. No network, no Chromium, no host
+//! effect — the os-actuation `UnavailableBackend` analogue, except this stub models real
+//! state so the handler logic (B2a-d) is fully testable WITHOUT a live browser. It NEVER
+//! reaches the network: a `navigate` records the URL it was handed (already guard-checked
+//! by the handler), a `screenshot` returns fixed deterministic bytes, an `evaluate`
+//! returns a fixed echo. Because this is the only constructible backend in the default
+//! build, the dark slice cannot move a real browser by construction.
+//!
+//! Interior mutability (`RefCell`) lets the `&self` trait methods mutate the in-memory
+//! session table — the live CDP backend will likewise present a `&self` interface over an
+//! interior connection.
+
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+
+use crate::backend::{
+    BackendError, BrowserBackend, CaptureOutput, ProfileSummary, SessionHandle, SessionSummary,
+};
+use crate::dom_lite::{
+    ConsoleEntry, ConsoleLevel, DomNode, PageInfo, PresentationMode, SnapshotResult, TabInfo,
+};
+
+/// Deterministic PNG-ish bytes a stub screenshot returns (a fixed marker, NOT a real
+/// image — enough for the handler to exercise path/base64 persistence deterministically).
+const STUB_SCREENSHOT_BYTES: &[u8] = b"FRIDAY-STUB-SCREENSHOT";
+/// Deterministic PDF-ish bytes a stub `print_pdf` returns.
+const STUB_PDF_BYTES: &[u8] = b"FRIDAY-STUB-PDF";
+/// Default profile name reported for sessions launched without an explicit profile.
+const DEFAULT_PROFILE_LABEL: &str = "(default)";
+
+#[derive(Clone, Debug)]
+struct StubTab {
+    tab_id: String,
+    page: PageInfo,
+}
+
+#[derive(Clone, Debug)]
+struct StubSession {
+    profile: Option<String>,
+    presentation: PresentationMode,
+    /// Insertion-ordered tabs (BTreeMap by a monotonic key would over-engineer; we keep a
+    /// Vec for order + the active index).
+    tabs: Vec<StubTab>,
+    active_tab: String,
+    console: Vec<ConsoleEntry>,
+}
+
+impl StubSession {
+    fn active_page_mut(&mut self, tab_id: &str) -> Option<&mut StubTab> {
+        self.tabs.iter_mut().find(|t| t.tab_id == tab_id)
+    }
+    fn has_tab(&self, tab_id: &str) -> bool {
+        self.tabs.iter().any(|t| t.tab_id == tab_id)
+    }
+}
+
+#[derive(Debug, Default)]
+struct State {
+    engine_running: bool,
+    /// session_id → session. BTreeMap so iteration order (e.g. status) is deterministic.
+    sessions: BTreeMap<String, StubSession>,
+    /// Monotonic counters so generated ids are deterministic within a process run.
+    next_session: u64,
+    next_tab: u64,
+}
+
+/// The deterministic in-memory browser backend. Default-constructible; the only backend
+/// the default build can link.
+#[derive(Debug, Default)]
+pub struct StubBrowserBackend {
+    state: RefCell<State>,
+}
+
+impl StubBrowserBackend {
+    /// A fresh stub with no engine running and no sessions.
+    #[must_use]
+    pub fn new() -> Self {
+        StubBrowserBackend {
+            state: RefCell::new(State::default()),
+        }
+    }
+
+    fn gen_session_id(state: &mut State) -> String {
+        state.next_session += 1;
+        format!("stub-session-{}", state.next_session)
+    }
+    fn gen_tab_id(state: &mut State) -> String {
+        state.next_tab += 1;
+        format!("stub-tab-{}", state.next_tab)
+    }
+
+    fn require_session<'a>(
+        sessions: &'a mut BTreeMap<String, StubSession>,
+        session_id: &str,
+    ) -> Result<&'a mut StubSession, BackendError> {
+        sessions
+            .get_mut(session_id)
+            .ok_or_else(|| BackendError::SessionNotFound(session_id.to_string()))
+    }
+}
+
+impl BrowserBackend for StubBrowserBackend {
+    fn start_engine(&self) -> Result<(), BackendError> {
+        self.state.borrow_mut().engine_running = true;
+        Ok(())
+    }
+
+    fn stop_engine(&self) -> Result<usize, BackendError> {
+        let mut st = self.state.borrow_mut();
+        let n = st.sessions.len();
+        st.sessions.clear();
+        st.engine_running = false;
+        Ok(n)
+    }
+
+    fn open_session(
+        &self,
+        session_id: Option<&str>,
+        profile: Option<&str>,
+        url: Option<&str>,
+    ) -> Result<SessionHandle, BackendError> {
+        let mut st = self.state.borrow_mut();
+        st.engine_running = true;
+
+        // Reuse an existing session if a known id was supplied.
+        if let Some(id) = session_id {
+            if let Some(existing) = st.sessions.get(id) {
+                let tab_id = existing.active_tab.clone();
+                let presentation = existing.presentation;
+                // Apply navigation to the active tab if requested.
+                if let Some(u) = url {
+                    if let Some(sess) = st.sessions.get_mut(id) {
+                        if let Some(tab) = sess.active_page_mut(&tab_id) {
+                            tab.page = PageInfo {
+                                url: u.to_string(),
+                                title: None,
+                            };
+                        }
+                    }
+                }
+                return Ok(SessionHandle {
+                    session_id: id.to_string(),
+                    tab_id,
+                    reused: true,
+                    presentation,
+                });
+            }
+        }
+
+        let new_session_id = match session_id {
+            Some(id) => id.to_string(),
+            None => Self::gen_session_id(&mut st),
+        };
+        let new_tab_id = Self::gen_tab_id(&mut st);
+        let page = PageInfo {
+            url: url.unwrap_or("about:blank").to_string(),
+            title: None,
+        };
+        let session = StubSession {
+            profile: profile.map(str::to_string),
+            presentation: PresentationMode::Headless,
+            tabs: vec![StubTab {
+                tab_id: new_tab_id.clone(),
+                page,
+            }],
+            active_tab: new_tab_id.clone(),
+            console: Vec::new(),
+        };
+        st.sessions.insert(new_session_id.clone(), session);
+        Ok(SessionHandle {
+            session_id: new_session_id,
+            tab_id: new_tab_id,
+            reused: false,
+            presentation: PresentationMode::Headless,
+        })
+    }
+
+    fn close_session(&self, session_id: Option<&str>) -> Result<usize, BackendError> {
+        let mut st = self.state.borrow_mut();
+        match session_id {
+            Some(id) => {
+                if st.sessions.remove(id).is_some() {
+                    Ok(1)
+                } else {
+                    Err(BackendError::SessionNotFound(id.to_string()))
+                }
+            }
+            None => {
+                let n = st.sessions.len();
+                st.sessions.clear();
+                Ok(n)
+            }
+        }
+    }
+
+    fn close_sessions_by_profile(&self, profile: &str) -> Result<usize, BackendError> {
+        let mut st = self.state.borrow_mut();
+        let to_remove: Vec<String> = st
+            .sessions
+            .iter()
+            .filter(|(_, s)| s.profile.as_deref() == Some(profile))
+            .map(|(id, _)| id.clone())
+            .collect();
+        let n = to_remove.len();
+        for id in to_remove {
+            st.sessions.remove(&id);
+        }
+        Ok(n)
+    }
+
+    fn status(&self, profile: Option<&str>) -> Result<Vec<SessionSummary>, BackendError> {
+        let st = self.state.borrow();
+        Ok(st
+            .sessions
+            .iter()
+            .filter(|(_, s)| match profile {
+                Some(p) => s.profile.as_deref() == Some(p),
+                None => true,
+            })
+            .map(|(id, s)| SessionSummary {
+                session_id: id.clone(),
+                profile: s.profile.clone(),
+                tab_count: s.tabs.len(),
+                active_tab_id: s.active_tab.clone(),
+                presentation: s.presentation,
+            })
+            .collect())
+    }
+
+    fn profiles(&self) -> Result<Vec<ProfileSummary>, BackendError> {
+        let st = self.state.borrow();
+        let mut by_profile: BTreeMap<String, Vec<String>> = BTreeMap::new();
+        for (id, s) in &st.sessions {
+            let name = s
+                .profile
+                .clone()
+                .unwrap_or_else(|| DEFAULT_PROFILE_LABEL.to_string());
+            by_profile.entry(name).or_default().push(id.clone());
+        }
+        Ok(by_profile
+            .into_iter()
+            .map(|(name, session_ids)| ProfileSummary { name, session_ids })
+            .collect())
+    }
+
+    fn focus(&self, session_id: &str, tab_id: &str) -> Result<(), BackendError> {
+        let mut st = self.state.borrow_mut();
+        let session = Self::require_session(&mut st.sessions, session_id)?;
+        if !session.has_tab(tab_id) {
+            return Err(BackendError::TabNotFound(tab_id.to_string()));
+        }
+        session.active_tab = tab_id.to_string();
+        Ok(())
+    }
+
+    fn list_tabs(&self, session_id: &str) -> Result<Vec<TabInfo>, BackendError> {
+        let st = self.state.borrow();
+        let session = st
+            .sessions
+            .get(session_id)
+            .ok_or_else(|| BackendError::SessionNotFound(session_id.to_string()))?;
+        Ok(session
+            .tabs
+            .iter()
+            .map(|t| TabInfo {
+                tab_id: t.tab_id.clone(),
+                page: t.page.clone(),
+                active: t.tab_id == session.active_tab,
+            })
+            .collect())
+    }
+
+    fn new_tab(&self, session_id: &str, url: Option<&str>) -> Result<String, BackendError> {
+        let mut st = self.state.borrow_mut();
+        let new_tab_id = Self::gen_tab_id(&mut st);
+        let session = Self::require_session(&mut st.sessions, session_id)?;
+        session.tabs.push(StubTab {
+            tab_id: new_tab_id.clone(),
+            page: PageInfo {
+                url: url.unwrap_or("about:blank").to_string(),
+                title: None,
+            },
+        });
+        Ok(new_tab_id)
+    }
+
+    fn switch_tab(&self, session_id: &str, tab_id: &str) -> Result<(), BackendError> {
+        self.focus(session_id, tab_id)
+    }
+
+    fn close_tab(&self, session_id: &str, tab_id: &str) -> Result<(), BackendError> {
+        let mut st = self.state.borrow_mut();
+        let session = Self::require_session(&mut st.sessions, session_id)?;
+        let before = session.tabs.len();
+        session.tabs.retain(|t| t.tab_id != tab_id);
+        if session.tabs.len() == before {
+            return Err(BackendError::TabNotFound(tab_id.to_string()));
+        }
+        // Re-point the active tab if we closed it.
+        if session.active_tab == tab_id {
+            session.active_tab = session
+                .tabs
+                .first()
+                .map(|t| t.tab_id.clone())
+                .unwrap_or_default();
+        }
+        Ok(())
+    }
+
+    fn navigate(
+        &self,
+        session_id: &str,
+        tab_id: &str,
+        url: &str,
+    ) -> Result<PageInfo, BackendError> {
+        let mut st = self.state.borrow_mut();
+        let session = Self::require_session(&mut st.sessions, session_id)?;
+        let tab = session
+            .active_page_mut(tab_id)
+            .ok_or_else(|| BackendError::TabNotFound(tab_id.to_string()))?;
+        tab.page = PageInfo {
+            url: url.to_string(),
+            title: Some("Stub Page".to_string()),
+        };
+        Ok(tab.page.clone())
+    }
+
+    fn screenshot(
+        &self,
+        session_id: &str,
+        tab_id: &str,
+        _full_page: bool,
+    ) -> Result<CaptureOutput, BackendError> {
+        let st = self.state.borrow();
+        let session = st
+            .sessions
+            .get(session_id)
+            .ok_or_else(|| BackendError::SessionNotFound(session_id.to_string()))?;
+        if !session.has_tab(tab_id) {
+            return Err(BackendError::TabNotFound(tab_id.to_string()));
+        }
+        Ok(CaptureOutput::Bytes(STUB_SCREENSHOT_BYTES.to_vec()))
+    }
+
+    fn snapshot(&self, session_id: &str, tab_id: &str) -> Result<SnapshotResult, BackendError> {
+        let st = self.state.borrow();
+        let session = st
+            .sessions
+            .get(session_id)
+            .ok_or_else(|| BackendError::SessionNotFound(session_id.to_string()))?;
+        let tab = session
+            .tabs
+            .iter()
+            .find(|t| t.tab_id == tab_id)
+            .ok_or_else(|| BackendError::TabNotFound(tab_id.to_string()))?;
+        // Deterministic two-node AX tree so the element cache + act-by-elementId path is
+        // exercisable without a real DOM.
+        Ok(SnapshotResult {
+            page: tab.page.clone(),
+            nodes: vec![
+                DomNode {
+                    element_id: "stub-el-1".to_string(),
+                    role: "link".to_string(),
+                    name: Some("Home".to_string()),
+                    selector: Some("a#home".to_string()),
+                },
+                DomNode {
+                    element_id: "stub-el-2".to_string(),
+                    role: "button".to_string(),
+                    name: Some("Submit".to_string()),
+                    selector: Some("button#submit".to_string()),
+                },
+            ],
+        })
+    }
+
+    fn console(&self, session_id: &str, tab_id: &str) -> Result<Vec<ConsoleEntry>, BackendError> {
+        let st = self.state.borrow();
+        let session = st
+            .sessions
+            .get(session_id)
+            .ok_or_else(|| BackendError::SessionNotFound(session_id.to_string()))?;
+        if !session.has_tab(tab_id) {
+            return Err(BackendError::TabNotFound(tab_id.to_string()));
+        }
+        Ok(session.console.clone())
+    }
+
+    fn evaluate(
+        &self,
+        session_id: &str,
+        tab_id: &str,
+        script: &str,
+        _timeout_ms: u64,
+    ) -> Result<String, BackendError> {
+        let mut st = self.state.borrow_mut();
+        let session = Self::require_session(&mut st.sessions, session_id)?;
+        if !session.has_tab(tab_id) {
+            return Err(BackendError::TabNotFound(tab_id.to_string()));
+        }
+        // Record the evaluation as a console line + return a deterministic echo (NEVER
+        // executes anything — the stub cannot run JS).
+        session.console.push(ConsoleEntry {
+            level: ConsoleLevel::Log,
+            text: format!("eval: {script}"),
+        });
+        Ok(format!("stub-eval-result: {script}"))
+    }
+
+    fn print_pdf(&self, session_id: &str, tab_id: &str) -> Result<CaptureOutput, BackendError> {
+        let st = self.state.borrow();
+        let session = st
+            .sessions
+            .get(session_id)
+            .ok_or_else(|| BackendError::SessionNotFound(session_id.to_string()))?;
+        if !session.has_tab(tab_id) {
+            return Err(BackendError::TabNotFound(tab_id.to_string()));
+        }
+        Ok(CaptureOutput::Bytes(STUB_PDF_BYTES.to_vec()))
+    }
+
+    fn click(&self, session_id: &str, tab_id: &str, _selector: &str) -> Result<(), BackendError> {
+        self.assert_tab(session_id, tab_id)
+    }
+
+    fn type_text(
+        &self,
+        session_id: &str,
+        tab_id: &str,
+        _selector: Option<&str>,
+        _text: &str,
+    ) -> Result<(), BackendError> {
+        self.assert_tab(session_id, tab_id)
+    }
+
+    fn press_key(&self, session_id: &str, tab_id: &str, _key: &str) -> Result<(), BackendError> {
+        self.assert_tab(session_id, tab_id)
+    }
+
+    fn hover(&self, session_id: &str, tab_id: &str, _selector: &str) -> Result<(), BackendError> {
+        self.assert_tab(session_id, tab_id)
+    }
+
+    fn drag(
+        &self,
+        session_id: &str,
+        tab_id: &str,
+        _selector: &str,
+        _end_selector: &str,
+    ) -> Result<(), BackendError> {
+        self.assert_tab(session_id, tab_id)
+    }
+
+    fn select(
+        &self,
+        session_id: &str,
+        tab_id: &str,
+        _selector: &str,
+        _values: &[String],
+    ) -> Result<(), BackendError> {
+        self.assert_tab(session_id, tab_id)
+    }
+
+    fn fill(
+        &self,
+        session_id: &str,
+        tab_id: &str,
+        _selector: &str,
+        _text: &str,
+    ) -> Result<(), BackendError> {
+        self.assert_tab(session_id, tab_id)
+    }
+
+    fn resize(
+        &self,
+        session_id: &str,
+        tab_id: &str,
+        _width: u32,
+        _height: u32,
+    ) -> Result<(), BackendError> {
+        self.assert_tab(session_id, tab_id)
+    }
+
+    fn wait(&self, session_id: &str, tab_id: &str, _time_ms: u64) -> Result<(), BackendError> {
+        // The stub does NOT actually sleep — it only validates the target (determinism +
+        // no real wall-clock dependence in tests).
+        self.assert_tab(session_id, tab_id)
+    }
+
+    fn upload(
+        &self,
+        session_id: &str,
+        tab_id: &str,
+        _selector: Option<&str>,
+        _file_paths: &[String],
+    ) -> Result<(), BackendError> {
+        self.assert_tab(session_id, tab_id)
+    }
+
+    fn dialog(
+        &self,
+        session_id: &str,
+        tab_id: &str,
+        _accept: bool,
+        _prompt_text: Option<&str>,
+    ) -> Result<(), BackendError> {
+        self.assert_tab(session_id, tab_id)
+    }
+}
+
+impl StubBrowserBackend {
+    /// Shared guard for the interaction methods: the session + tab must exist.
+    fn assert_tab(&self, session_id: &str, tab_id: &str) -> Result<(), BackendError> {
+        let st = self.state.borrow();
+        let session = st
+            .sessions
+            .get(session_id)
+            .ok_or_else(|| BackendError::SessionNotFound(session_id.to_string()))?;
+        if !session.has_tab(tab_id) {
+            return Err(BackendError::TabNotFound(tab_id.to_string()));
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn open(stub: &StubBrowserBackend, profile: Option<&str>) -> SessionHandle {
+        stub.open_session(None, profile, None).expect("open")
+    }
+
+    #[test]
+    fn open_creates_a_session_with_one_active_tab() {
+        let stub = StubBrowserBackend::new();
+        let h = open(&stub, Some("chrome"));
+        assert!(!h.reused);
+        assert_eq!(h.presentation, PresentationMode::Headless);
+        let tabs = stub.list_tabs(&h.session_id).expect("tabs");
+        assert_eq!(tabs.len(), 1);
+        assert!(tabs[0].active);
+    }
+
+    #[test]
+    fn open_with_known_id_reuses() {
+        let stub = StubBrowserBackend::new();
+        let h = stub.open_session(Some("s1"), None, None).expect("open");
+        assert!(!h.reused);
+        let again = stub.open_session(Some("s1"), None, None).expect("reopen");
+        assert!(again.reused);
+        assert_eq!(again.session_id, "s1");
+    }
+
+    #[test]
+    fn status_lists_and_filters_by_profile() {
+        let stub = StubBrowserBackend::new();
+        stub.open_session(Some("a"), Some("chrome"), None).unwrap();
+        stub.open_session(Some("b"), Some("openclaw"), None)
+            .unwrap();
+        assert_eq!(stub.status(None).unwrap().len(), 2);
+        let only_chrome = stub.status(Some("chrome")).unwrap();
+        assert_eq!(only_chrome.len(), 1);
+        assert_eq!(only_chrome[0].session_id, "a");
+    }
+
+    #[test]
+    fn profiles_groups_sessions_and_labels_default() {
+        let stub = StubBrowserBackend::new();
+        stub.open_session(Some("a"), Some("chrome"), None).unwrap();
+        stub.open_session(Some("b"), Some("chrome"), None).unwrap();
+        stub.open_session(Some("c"), None, None).unwrap();
+        let profiles = stub.profiles().unwrap();
+        // BTreeMap order: "(default)" < "chrome".
+        assert_eq!(profiles.len(), 2);
+        assert_eq!(profiles[0].name, "(default)");
+        assert_eq!(profiles[0].session_ids, vec!["c".to_string()]);
+        assert_eq!(profiles[1].name, "chrome");
+        assert_eq!(profiles[1].session_ids.len(), 2);
+    }
+
+    #[test]
+    fn stop_closes_all_sessions() {
+        let stub = StubBrowserBackend::new();
+        stub.open_session(Some("a"), None, None).unwrap();
+        stub.open_session(Some("b"), None, None).unwrap();
+        assert_eq!(stub.stop_engine().unwrap(), 2);
+        assert_eq!(stub.status(None).unwrap().len(), 0);
+    }
+
+    #[test]
+    fn stop_by_profile_closes_only_matching() {
+        let stub = StubBrowserBackend::new();
+        stub.open_session(Some("a"), Some("chrome"), None).unwrap();
+        stub.open_session(Some("b"), Some("other"), None).unwrap();
+        assert_eq!(stub.close_sessions_by_profile("chrome").unwrap(), 1);
+        assert_eq!(stub.status(None).unwrap().len(), 1);
+    }
+
+    #[test]
+    fn navigate_records_the_url() {
+        let stub = StubBrowserBackend::new();
+        let h = open(&stub, None);
+        let page = stub
+            .navigate(&h.session_id, &h.tab_id, "https://example.com/")
+            .expect("navigate");
+        assert_eq!(page.url, "https://example.com/");
+    }
+
+    #[test]
+    fn navigate_unknown_session_fails_closed() {
+        let stub = StubBrowserBackend::new();
+        let err = stub
+            .navigate("nope", "tab", "https://example.com/")
+            .unwrap_err();
+        assert_eq!(err, BackendError::SessionNotFound("nope".to_string()));
+    }
+
+    #[test]
+    fn tabs_lifecycle() {
+        let stub = StubBrowserBackend::new();
+        let h = open(&stub, None);
+        let t2 = stub.new_tab(&h.session_id, None).expect("new tab");
+        assert_eq!(stub.list_tabs(&h.session_id).unwrap().len(), 2);
+        stub.switch_tab(&h.session_id, &t2).expect("switch");
+        let tabs = stub.list_tabs(&h.session_id).unwrap();
+        assert!(tabs.iter().find(|t| t.tab_id == t2).unwrap().active);
+        stub.close_tab(&h.session_id, &t2).expect("close tab");
+        assert_eq!(stub.list_tabs(&h.session_id).unwrap().len(), 1);
+        // Closing a missing tab fails closed.
+        assert_eq!(
+            stub.close_tab(&h.session_id, "ghost").unwrap_err(),
+            BackendError::TabNotFound("ghost".to_string())
+        );
+    }
+
+    #[test]
+    fn screenshot_and_pdf_return_deterministic_bytes() {
+        let stub = StubBrowserBackend::new();
+        let h = open(&stub, None);
+        let CaptureOutput::Bytes(png) = stub.screenshot(&h.session_id, &h.tab_id, true).unwrap();
+        assert_eq!(png, STUB_SCREENSHOT_BYTES);
+        let CaptureOutput::Bytes(pdf) = stub.print_pdf(&h.session_id, &h.tab_id).unwrap();
+        assert_eq!(pdf, STUB_PDF_BYTES);
+    }
+
+    #[test]
+    fn snapshot_returns_stable_element_ids() {
+        let stub = StubBrowserBackend::new();
+        let h = open(&stub, None);
+        let snap = stub.snapshot(&h.session_id, &h.tab_id).unwrap();
+        assert_eq!(snap.nodes.len(), 2);
+        assert_eq!(snap.nodes[0].element_id, "stub-el-1");
+    }
+
+    #[test]
+    fn evaluate_echoes_and_logs_without_executing() {
+        let stub = StubBrowserBackend::new();
+        let h = open(&stub, None);
+        let out = stub
+            .evaluate(&h.session_id, &h.tab_id, "1+1", 10_000)
+            .unwrap();
+        assert_eq!(out, "stub-eval-result: 1+1");
+        let console = stub.console(&h.session_id, &h.tab_id).unwrap();
+        assert_eq!(console.len(), 1);
+        assert_eq!(console[0].text, "eval: 1+1");
+    }
+
+    #[test]
+    fn act_family_validates_target_and_succeeds_on_the_stub() {
+        let stub = StubBrowserBackend::new();
+        let h = open(&stub, None);
+        assert!(stub.click(&h.session_id, &h.tab_id, "#x").is_ok());
+        assert!(stub
+            .type_text(&h.session_id, &h.tab_id, Some("#x"), "hi")
+            .is_ok());
+        assert!(stub.press_key(&h.session_id, &h.tab_id, "Enter").is_ok());
+        assert!(stub.hover(&h.session_id, &h.tab_id, "#x").is_ok());
+        assert!(stub.drag(&h.session_id, &h.tab_id, "#a", "#b").is_ok());
+        assert!(stub
+            .select(&h.session_id, &h.tab_id, "#s", &["one".to_string()])
+            .is_ok());
+        assert!(stub.fill(&h.session_id, &h.tab_id, "#x", "v").is_ok());
+        assert!(stub.resize(&h.session_id, &h.tab_id, 800, 600).is_ok());
+        assert!(stub.wait(&h.session_id, &h.tab_id, 5).is_ok());
+        assert!(stub
+            .upload(
+                &h.session_id,
+                &h.tab_id,
+                Some("#f"),
+                &["/ws/a.txt".to_string()]
+            )
+            .is_ok());
+        assert!(stub.dialog(&h.session_id, &h.tab_id, true, None).is_ok());
+        // Every act against an unknown session fails closed.
+        assert_eq!(
+            stub.click("nope", "tab", "#x").unwrap_err(),
+            BackendError::SessionNotFound("nope".to_string())
+        );
+    }
+}

--- a/rust-core/crates/friday-browser/src/target_id.rs
+++ b/rust-core/crates/friday-browser/src/target_id.rs
@@ -1,0 +1,93 @@
+//! target_id — the `sessionId` / `sessionId:tabId` / profile target resolver, ported from
+//! the TS `friday-browser-target-id`.
+//!
+//! A target id is `"sessionId"` or `"sessionId:tabId"`. Parsing splits on the FIRST colon
+//! (so a session id may not itself contain a colon, matching `indexOf(":")`; everything
+//! after the first colon is the tab id, which MAY contain colons). The resolution
+//! priority (explicit sessionId/tabId > parsed targetId > profile lookup) is enforced at
+//! the hub/handler layer where a live session table exists; this crate ships the pure
+//! parse/format primitives + the parsed shape.
+
+/// A target id parsed into its components. `tab_id` is `None` when only a session was
+/// given (the active tab is then used by the resolver at dispatch time).
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct ParsedTargetId {
+    /// The session id (the part before the first colon).
+    pub session_id: String,
+    /// The tab id (everything after the first colon), if present.
+    pub tab_id: Option<String>,
+}
+
+/// Parse a `targetId` string into session + (optional) tab components, splitting on the
+/// FIRST colon (the oracle's `indexOf(":")`).
+#[must_use]
+pub fn parse_browser_target_id(target_id: &str) -> ParsedTargetId {
+    match target_id.find(':') {
+        None => ParsedTargetId {
+            session_id: target_id.to_string(),
+            tab_id: None,
+        },
+        Some(colon) => ParsedTargetId {
+            session_id: target_id[..colon].to_string(),
+            tab_id: Some(target_id[colon + 1..].to_string()),
+        },
+    }
+}
+
+/// Format a session/tab pair into a `targetId` string (the inverse of
+/// [`parse_browser_target_id`]). A `None`/empty tab id yields the bare session id.
+#[must_use]
+pub fn format_browser_target_id(session_id: &str, tab_id: Option<&str>) -> String {
+    match tab_id {
+        Some(t) if !t.is_empty() => format!("{session_id}:{t}"),
+        _ => session_id.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn session_only_has_no_tab() {
+        let p = parse_browser_target_id("s1");
+        assert_eq!(p.session_id, "s1");
+        assert_eq!(p.tab_id, None);
+    }
+
+    #[test]
+    fn session_and_tab_split_on_first_colon() {
+        let p = parse_browser_target_id("s1:tab-1");
+        assert_eq!(p.session_id, "s1");
+        assert_eq!(p.tab_id.as_deref(), Some("tab-1"));
+    }
+
+    #[test]
+    fn only_the_first_colon_splits_the_rest_stays_in_tab() {
+        // Everything after the first colon is the tab id (matches slice(colon+1)).
+        let p = parse_browser_target_id("s1:tab:weird:id");
+        assert_eq!(p.session_id, "s1");
+        assert_eq!(p.tab_id.as_deref(), Some("tab:weird:id"));
+    }
+
+    #[test]
+    fn empty_tab_after_trailing_colon() {
+        let p = parse_browser_target_id("s1:");
+        assert_eq!(p.session_id, "s1");
+        assert_eq!(p.tab_id.as_deref(), Some(""));
+    }
+
+    #[test]
+    fn format_roundtrips_parse() {
+        assert_eq!(format_browser_target_id("s1", Some("tab-1")), "s1:tab-1");
+        assert_eq!(format_browser_target_id("s1", None), "s1");
+        // Empty tab id formats to the bare session id (not "s1:").
+        assert_eq!(format_browser_target_id("s1", Some("")), "s1");
+
+        let p = parse_browser_target_id("s1:tab-1");
+        assert_eq!(
+            format_browser_target_id(&p.session_id, p.tab_id.as_deref()),
+            "s1:tab-1"
+        );
+    }
+}

--- a/rust-core/crates/friday-browser/src/upload_dialog.rs
+++ b/rust-core/crates/friday-browser/src/upload_dialog.rs
@@ -1,0 +1,8 @@
+//! upload_dialog — the `upload` + `dialog` handlers over
+//! [`crate::backend::BrowserBackend`], with upload paths confined to the workspace/tmp via
+//! the friday-fs realpath containment (applied in the handler, not this crate's pure
+//! types).
+//!
+//! EMPTY COMPILING STUB (B1). This file exists so B1's `mod upload_dialog;` declaration in
+//! `lib.rs` compiles standalone; the handler bodies are FILLED by B2d (which adds NO new
+//! `mod` line). Until B2d lands this module intentionally carries no items.

--- a/rust-core/crates/friday-browser/src/url_guard.rs
+++ b/rust-core/crates/friday-browser/src/url_guard.rs
@@ -1,0 +1,359 @@
+//! url_guard — the `browser` navigation security guard: protocol allow + origin-allowlist
+//! (`validateUrl` / `matchesOrigin` ported faithfully from the TS `friday-browser-manager`).
+//!
+//! This is the highest-value dark security unit. Every navigation flows through
+//! [`validate_url`] BEFORE any backend call:
+//!
+//! 1. The URL must parse and use `http:`/`https:` only (no `file:`/`data:`/`javascript:`…).
+//! 2. Its origin (scheme + lowercased host + non-default port) must match the
+//!    operator-curated `allowed_origins` list, with the oracle's DEFAULT-DENY semantics:
+//!    - empty list → DENY everything (the misconfiguration-trap fix);
+//!    - the single sentinel [`FRIDAY_BROWSER_ALLOW_ANY_ORIGIN`] (`"*"`) → allow any;
+//!    - exact origin match, OR a single-label wildcard subdomain (`https://*.example.com`)
+//!      whose `*` matches exactly ONE DNS label (no embedded dots → no
+//!      `evil.com.example.com` subdomain-confusion).
+//!
+//! There is intentionally NO private-IP/metadata-range blocker here: the oracle's guard is
+//! protocol + origin-allowlist, not IP-range SSRF, and adding one would diverge from the
+//! oracle's tested behavior. The allowlist IS the SSRF boundary (an operator who allows
+//! only their trusted origins cannot be steered to `169.254.169.254`).
+//!
+//! No `url` crate dependency: origin extraction is hand-rolled to exactly the precision
+//! the allowlist needs (scheme + host + port), pinned to the oracle's `new URL().origin`
+//! behavior by the test vectors below. Pure computation — no I/O.
+
+use thiserror::Error;
+
+/// The explicit opt-in sentinel that permits ANY origin (the oracle's `"*"`). Use only
+/// when the deployment cannot enumerate a trusted-origin allowlist; prefer an explicit
+/// list in production.
+pub const FRIDAY_BROWSER_ALLOW_ANY_ORIGIN: &str = "*";
+
+/// A navigation rejected by the guard. Coarse, payload-bounded messages mirroring the
+/// oracle's returned strings (kept stable so the hub/handlers can surface them verbatim).
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum UrlGuardError {
+    /// The URL did not parse into scheme + host.
+    #[error("Invalid URL: {0}")]
+    InvalidUrl(String),
+    /// The scheme is not `http:`/`https:`.
+    #[error("Protocol \"{0}:\" is not allowed. Only http: and https: are permitted.")]
+    DisallowedProtocol(String),
+    /// The origin is not in the allowlist (or the list is empty → default-deny).
+    #[error("Origin \"{0}\" is not in the allowed origins list.")]
+    OriginNotAllowed(String),
+}
+
+/// A minimally-parsed URL: scheme + origin, mirroring the subset of `new URL()` the guard
+/// reads. Hand-rolled (no `url` crate).
+struct ParsedUrl {
+    /// Lowercased scheme, WITHOUT the trailing colon (e.g. `"https"`).
+    scheme: String,
+    /// The origin string, exactly as the oracle's `URL.origin` would render it:
+    /// `scheme://host[:port]`, host lowercased, the scheme's DEFAULT port omitted.
+    origin: String,
+}
+
+/// Default ports the oracle's `URL.origin` omits.
+fn default_port_for(scheme: &str) -> Option<&'static str> {
+    match scheme {
+        "http" => Some("80"),
+        "https" => Some("443"),
+        _ => None,
+    }
+}
+
+/// Parse `url` far enough to read scheme + origin. Returns `None` for anything that does
+/// not look like an absolute `scheme://authority…` URL (the cases `new URL()` would throw
+/// on for our purposes — relative URLs, missing authority).
+fn parse_url(url: &str) -> Option<ParsedUrl> {
+    // Split scheme from the rest at the first "://" (we only handle authority-based
+    // http/https URLs; that is all the guard needs and all the oracle navigates).
+    let scheme_end = url.find("://")?;
+    let scheme = url[..scheme_end].to_ascii_lowercase();
+    if scheme.is_empty()
+        || !scheme
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || b == b'+' || b == b'-' || b == b'.')
+    {
+        return None;
+    }
+    let after_scheme = &url[scheme_end + 3..];
+
+    // The authority ends at the first '/', '?' or '#'.
+    let authority_end = after_scheme
+        .find(['/', '?', '#'])
+        .unwrap_or(after_scheme.len());
+    let authority = &after_scheme[..authority_end];
+
+    // Strip optional userinfo ("user:pass@host") — the oracle's origin excludes it.
+    let host_port = match authority.rfind('@') {
+        Some(at) => &authority[at + 1..],
+        None => authority,
+    };
+    if host_port.is_empty() {
+        return None;
+    }
+
+    // Split host and port. IPv6 literals are bracketed: "[::1]:8080".
+    let (host_raw, port) = if let Some(rest) = host_port.strip_prefix('[') {
+        // "[ipv6]" or "[ipv6]:port"
+        let close = rest.find(']')?;
+        let host = &rest[..close];
+        let after = &rest[close + 1..];
+        let port = after.strip_prefix(':').filter(|p| !p.is_empty());
+        (format!("[{host}]"), port)
+    } else {
+        match host_port.rfind(':') {
+            Some(colon) => {
+                let p = &host_port[colon + 1..];
+                // Treat a trailing ":" or a non-numeric tail as no port (defensive).
+                if !p.is_empty() && p.bytes().all(|b| b.is_ascii_digit()) {
+                    (host_port[..colon].to_string(), Some(p))
+                } else {
+                    (host_port.to_string(), None)
+                }
+            }
+            None => (host_port.to_string(), None),
+        }
+    };
+
+    let host = host_raw.to_ascii_lowercase();
+    if host.is_empty() || host == "[]" {
+        return None;
+    }
+
+    // Render origin like URL.origin: omit the scheme's default port.
+    let origin = match port {
+        Some(p) if Some(p) != default_port_for(&scheme) => format!("{scheme}://{host}:{p}"),
+        _ => format!("{scheme}://{host}"),
+    };
+
+    Some(ParsedUrl { scheme, origin })
+}
+
+/// Whether `origin` matches a single allowlist `pattern`. Exact match, or a single-label
+/// wildcard subdomain (`https://*.example.com`) where `*` matches exactly ONE DNS label
+/// (NO embedded dots — so `*.example.com` cannot match `evil.com.example.com`).
+fn origin_matches_pattern(origin: &str, pattern: &str) -> bool {
+    if pattern == FRIDAY_BROWSER_ALLOW_ANY_ORIGIN {
+        return true;
+    }
+    if !pattern.contains('*') {
+        return origin == pattern;
+    }
+    // Wildcard: the `*` stands for exactly one DNS label = [A-Za-z0-9-]+ (no dots). Split
+    // the pattern on the single `*` and require the origin to start/end with the literal
+    // parts and have a non-empty single-label middle.
+    let star = match pattern.find('*') {
+        Some(i) => i,
+        None => return false,
+    };
+    let prefix = &pattern[..star];
+    let suffix = &pattern[star + 1..];
+    // A second `*` is not a shape the oracle's regex produces a single-label match for;
+    // be conservative and reject (the oracle builds one regex per pattern, but a 2nd `*`
+    // would also become a single-label class — keeping to one `*` is the documented form).
+    if suffix.contains('*') {
+        return false;
+    }
+    if !origin.starts_with(prefix) || !origin.ends_with(suffix) {
+        return false;
+    }
+    if origin.len() < prefix.len() + suffix.len() {
+        return false;
+    }
+    let label = &origin[prefix.len()..origin.len() - suffix.len()];
+    !label.is_empty()
+        && label
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || b == b'-')
+}
+
+/// Whether `url`'s origin is permitted by `allowed_origins` (the oracle's `matchesOrigin`).
+/// DEFAULT-DENY: empty list → `false`; the sole `"*"` sentinel → `true`; otherwise an
+/// exact-origin or single-label-wildcard match.
+#[must_use]
+pub fn matches_origin(url: &str, allowed_origins: &[String]) -> bool {
+    // Empty → deny (the misconfiguration-trap fix). A lone "*" → allow any.
+    if allowed_origins.is_empty() {
+        return false;
+    }
+    if allowed_origins.len() == 1 && allowed_origins[0] == FRIDAY_BROWSER_ALLOW_ANY_ORIGIN {
+        return true;
+    }
+    let parsed = match parse_url(url) {
+        Some(p) => p,
+        None => return false,
+    };
+    allowed_origins
+        .iter()
+        .any(|pattern| origin_matches_pattern(&parsed.origin, pattern))
+}
+
+/// Validate a navigation URL against the protocol + origin-allowlist guard. Returns `Ok`
+/// to proceed, or the specific [`UrlGuardError`] to reject (the oracle's `validateUrl`,
+/// which returns `undefined` to allow or an error string to reject — here `Result`).
+pub fn validate_url(url: &str, allowed_origins: &[String]) -> Result<(), UrlGuardError> {
+    let parsed = parse_url(url).ok_or_else(|| UrlGuardError::InvalidUrl(url.to_string()))?;
+
+    if parsed.scheme != "http" && parsed.scheme != "https" {
+        return Err(UrlGuardError::DisallowedProtocol(parsed.scheme));
+    }
+
+    if !matches_origin(url, allowed_origins) {
+        return Err(UrlGuardError::OriginNotAllowed(parsed.origin));
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn list(items: &[&str]) -> Vec<String> {
+        items.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn empty_allowlist_denies_everything() {
+        // The default-deny misconfiguration-trap fix: empty list → reject any URL.
+        assert_eq!(
+            validate_url("https://example.com/", &[]),
+            Err(UrlGuardError::OriginNotAllowed(
+                "https://example.com".to_string()
+            ))
+        );
+        assert!(!matches_origin("https://example.com/", &[]));
+    }
+
+    #[test]
+    fn allow_any_sentinel_permits_any_origin() {
+        let any = list(&["*"]);
+        assert!(matches_origin("https://example.com/", &any));
+        assert!(matches_origin("http://other.test:8080/path", &any));
+        assert_eq!(validate_url("https://anything.example/", &any), Ok(()));
+    }
+
+    #[test]
+    fn non_http_protocol_is_rejected_even_with_allow_any() {
+        // Protocol is checked before/independent of the allowlist.
+        assert_eq!(
+            validate_url("file:///etc/passwd", &list(&["*"])),
+            Err(UrlGuardError::InvalidUrl("file:///etc/passwd".to_string()))
+        );
+        // A scheme with an authority but disallowed protocol → DisallowedProtocol.
+        assert_eq!(
+            validate_url("ftp://example.com/", &list(&["*"])),
+            Err(UrlGuardError::DisallowedProtocol("ftp".to_string()))
+        );
+    }
+
+    #[test]
+    fn invalid_url_is_rejected() {
+        assert_eq!(
+            validate_url("not a url", &list(&["*"])),
+            Err(UrlGuardError::InvalidUrl("not a url".to_string()))
+        );
+        assert_eq!(
+            validate_url("https://", &list(&["*"])),
+            Err(UrlGuardError::InvalidUrl("https://".to_string()))
+        );
+    }
+
+    #[test]
+    fn exact_origin_match() {
+        let allow = list(&["https://example.com"]);
+        assert_eq!(validate_url("https://example.com/page?q=1", &allow), Ok(()));
+        // Different host → denied.
+        assert_eq!(
+            validate_url("https://evil.com/", &allow),
+            Err(UrlGuardError::OriginNotAllowed(
+                "https://evil.com".to_string()
+            ))
+        );
+        // Different scheme is a different origin → denied.
+        assert_eq!(
+            validate_url("http://example.com/", &allow),
+            Err(UrlGuardError::OriginNotAllowed(
+                "http://example.com".to_string()
+            ))
+        );
+    }
+
+    #[test]
+    fn default_ports_are_normalized_out_of_the_origin() {
+        let allow = list(&["https://example.com", "http://example.com"]);
+        // :443 on https and :80 on http are the defaults → origin omits them → match.
+        assert_eq!(validate_url("https://example.com:443/", &allow), Ok(()));
+        assert_eq!(validate_url("http://example.com:80/", &allow), Ok(()));
+    }
+
+    #[test]
+    fn non_default_port_is_part_of_the_origin() {
+        let allow = list(&["https://example.com:8443"]);
+        assert_eq!(validate_url("https://example.com:8443/x", &allow), Ok(()));
+        // Without the port it is a different origin → denied.
+        assert_eq!(
+            validate_url("https://example.com/x", &allow),
+            Err(UrlGuardError::OriginNotAllowed(
+                "https://example.com".to_string()
+            ))
+        );
+    }
+
+    #[test]
+    fn host_is_lowercased() {
+        let allow = list(&["https://example.com"]);
+        assert_eq!(validate_url("https://EXAMPLE.com/", &allow), Ok(()));
+    }
+
+    #[test]
+    fn single_label_wildcard_subdomain_matches_one_label_only() {
+        let allow = list(&["https://*.example.com"]);
+        // One label → match.
+        assert!(matches_origin("https://api.example.com/", &allow));
+        assert!(matches_origin("https://www.example.com/path", &allow));
+        // Embedded dot in the wildcard region → NO match (subdomain-confusion guard).
+        assert!(!matches_origin("https://evil.com.example.com/", &allow));
+        // Different scheme → no match (origin includes scheme).
+        assert!(!matches_origin("http://api.example.com/", &allow));
+        // The bare apex (no label) → no match (label must be non-empty).
+        assert!(!matches_origin("https://.example.com/", &allow));
+    }
+
+    #[test]
+    fn userinfo_is_stripped_from_the_origin() {
+        let allow = list(&["https://example.com"]);
+        // "user:pass@host" — origin excludes userinfo, so this still matches the host.
+        assert_eq!(
+            validate_url("https://user:pass@example.com/", &allow),
+            Ok(())
+        );
+        // And a spoof attempt like "https://example.com@evil.com" resolves to evil.com.
+        assert_eq!(
+            validate_url("https://example.com@evil.com/", &allow),
+            Err(UrlGuardError::OriginNotAllowed(
+                "https://evil.com".to_string()
+            ))
+        );
+    }
+
+    #[test]
+    fn ipv6_literal_origin_is_handled() {
+        let allow = list(&["http://[::1]:8080"]);
+        assert!(matches_origin("http://[::1]:8080/json", &allow));
+        // Default-port omission still applies for bracketed hosts.
+        let allow_default = list(&["http://[::1]"]);
+        assert!(matches_origin("http://[::1]:80/", &allow_default));
+    }
+
+    #[test]
+    fn one_allowed_among_a_list() {
+        let allow = list(&["https://a.test", "https://b.test", "https://*.c.test"]);
+        assert!(matches_origin("https://b.test/x", &allow));
+        assert!(matches_origin("https://sub.c.test/", &allow));
+        assert!(!matches_origin("https://d.test/", &allow));
+    }
+}


### PR DESCRIPTION
## F11 Wave-2 — B1 (crate root for the net-new \`browser\` capability ENGINE crate)

Dark, Hub-only, heavy-binary foundation crate. Mirrors the os-actuation dark spine: the **only default-constructible backend is the deterministic in-memory `StubBrowserBackend`** (no network, no Chromium, no host effect). The real CDP backend lives behind the **DEFAULT-OFF `browser-live-deploy-go` cargo feature** whose feature-ON arm is `compile_error!` until B4-LIVE — so the default build cannot even link a real browser actuator.

### What this PR ships (`friday-browser` crate only)
- **`backend.rs`** — `trait BrowserBackend`, the DI seam covering all 16 `browser` actions (open/navigate/screenshot/snapshot/act-family/tabs/close/status/start/stop/profiles/focus/console/pdf/upload/dialog). **NO `friday-hub` dependency** — the `impl ToolExecutor` wrapper is a hub module (B3-EXEC) per the verified hub↔crate boundary (avoids a dependency cycle, matching the deepseek/anthropic precedent).
- **`stub.rs`** — `StubBrowserBackend`, the only default-constructible backend; every trait method returns deterministic in-memory values (no `todo!()`/`unimplemented!()`).
- **`action.rs`** — `BrowserAction` enum + `act` sub-kinds + tabs/screenshot sub-enums + the parsed param schema (faithful port of the TS browser-tool 16-action schema) + parse/validation.
- **`url_guard.rs`** — the SSRF/allowed-origins `validate_url` guard (protocol + origin-allowlist; default-DENY on empty list; `"*"` allow-any sentinel; single-label wildcard subdomain with no embedded-dot confusion). Hand-rolled origin extraction — **no new `url` crate dep**.
- **`target_id.rs`** — `sessionId` / `sessionId:tabId` parse+format (first-colon split). Profile→session resolution is deferred to the handler layer (B2b) where the live session table exists.
- **`element_cache.rs`** — snapshot-derived element-id cache (re-snapshot invalidates stale ids; unknown id → `None` fail-closed).
- **`dom_lite.rs`** — serializable AX/console/page/tab types.
- **`artifact.rs`** — pure path-string artifact-dir helper + segment sanitizer (no fs I/O; the real writes use friday-fs containment in B2a).
- **`lib.rs`** — `FRIDAY_BROWSER_ENABLED` flag const (DEFAULT-OFF, gate enforced at the hub, not in this crate) + the `browser-live-deploy-go` `compile_error!` spine + the handler `mod nav_capture; mod lifecycle; mod interaction; mod upload_dialog;` list.
- **Four handler files as EMPTY COMPILING STUBS** so B1 compiles standalone; B2a-d FILL them with no new `mod` line (file-disjoint).

### Dark discipline
Deps are `thiserror`/`serde`/`serde_json` (workspace). No hub dep, no `ToolExecutor`, no registry/capability change (later waves). No fake/degrade — the stub is a deterministic test double, not a runtime fallback.

### Gate (all green locally, from `rust-core`)
- `cargo fmt --all -- --check` ✅
- `cargo clippy --workspace --all-targets -- -D warnings` ✅
- `cargo build -p friday-browser` ✅ / `cargo build --workspace` ✅
- `cargo test -p friday-browser` ✅ (61 tests) / `cargo test --workspace` ✅
- `cargo build -p friday-browser --features browser-live-deploy-go` **fails with the `compile_error!`** (exit 101) — the deploy-go spine is proven to gate.

depends_on: SKEL (merged). Born off `9263779c`; the one commit that landed on main since (#733) touches friday-ffi/hub/protocol — disjoint from this crate, no conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)