### PR TITLE
feat(c2i-pr2): 5 owner-gated C2 read-plane ops (SessionList/Open[M-2 seal]/LinkState/FileView/ActivityNeedsMe)

### DIFF
--- a/rust-core/crates/friday-ffi/src/lib.rs
+++ b/rust-core/crates/friday-ffi/src/lib.rs
@@ -1938,6 +1938,20 @@ fn message_kind_name(m: &friday_protocol::Message) -> &'static str {
         M::RunReadbackSnapshot { .. } => "RunReadbackSnapshot",
         M::ProvidersDoctorRequest { .. } => "ProvidersDoctorRequest",
         M::ProvidersDoctorSnapshot { .. } => "ProvidersDoctorSnapshot",
+        // C2I-PR2 — the 5 DARK sealed-WS READ-seam owner-gated C2 read-plane kinds. NAMED here for
+        // the same reason as S-R1/S-R2/S-R3: nothing on the FFI surface constructs/dispatches them
+        // (the UI reads them directly over the sealed-WS read server), but naming them keeps this
+        // match exhaustive and carries the real kind in the truth label.
+        M::SessionListRequest { .. } => "SessionListRequest",
+        M::SessionListSnapshot { .. } => "SessionListSnapshot",
+        M::SessionOpenRequest { .. } => "SessionOpenRequest",
+        M::SessionOpenSnapshot { .. } => "SessionOpenSnapshot",
+        M::SessionLinkStateRequest { .. } => "SessionLinkStateRequest",
+        M::SessionLinkStateSnapshot { .. } => "SessionLinkStateSnapshot",
+        M::RunFileViewRequest { .. } => "RunFileViewRequest",
+        M::RunFileViewSnapshot { .. } => "RunFileViewSnapshot",
+        M::ActivityNeedsMeRequest { .. } => "ActivityNeedsMeRequest",
+        M::ActivityNeedsMeSnapshot { .. } => "ActivityNeedsMeSnapshot",
         // WS-transport substrate (S-A..S-F) message kinds. Still DARK on the FFI
         // surface (nothing here constructs or dispatches them), but they are
         // NAMED so the truth label carries the real kind — and so this match

--- a/rust-core/crates/friday-hub/src/bin/hub_read_projection_server.rs
+++ b/rust-core/crates/friday-hub/src/bin/hub_read_projection_server.rs
@@ -68,14 +68,19 @@ use friday_crypto::{seal, DataKey, DeviceKeypair, FileSecureStore};
 use friday_hub::hub_server::{AuthedPrincipal, ForwardedAuth};
 use friday_hub::key_source::{READ_SEAM_PEER_PUBKEY_ALLOWLIST_ID, X25519_PUBKEY_LEN};
 use friday_hub::providers_doctor_projection::{parse_provider_selection, project_providers_doctor};
-use friday_hub::run_readback_projection::project_run_readback;
+use friday_hub::run_readback_projection::{
+    project_activity_needs_me, project_run_file_view, project_run_readback,
+    project_session_link_state,
+};
 use friday_hub::sealed_ws::{
     decode_sealed_proof, enforce_peer_allowlist_nonempty, establish_session, load_peer_allowlist,
 };
 use friday_hub::workbench_projection::project_workbench;
 use friday_protocol::{
-    Envelope, IdempotencyTracker, Message, ProvidersDoctorSnapshotWire, RunReadbackSnapshotWire,
-    Seen, WorkbenchProjectionSnapshotWire,
+    ActivityNeedsMeSnapshotWire, Envelope, IdempotencyTracker, Message,
+    ProvidersDoctorSnapshotWire, RunFileViewSnapshotWire, RunReadbackSnapshotWire, Seen,
+    SessionLinkStateSnapshotWire, SessionListSnapshotWire, SessionOpenSnapshotWire,
+    WorkbenchProjectionSnapshotWire,
 };
 use friday_providers::{CliProbe, ProviderProbe};
 use friday_storage::Db;
@@ -258,10 +263,13 @@ impl ReadWsListener {
 /// Serve sealed read-projection envelopes over ONE established session until the peer disconnects,
 /// sends an envelope that fails to open, OR fails auth.
 ///
-/// **S-R1/S-R2/S-R3 read arms.** A sealed envelope that opens to one of the three read requests
-/// ([`Message::WorkbenchProjectionRequest`], [`Message::RunReadbackRequest`],
-/// [`Message::ProvidersDoctorRequest`]) takes the IDENTICAL read path, factored into two shared
-/// helpers so the three arms cannot drift:
+/// **Read arms (S-R1/S-R2/S-R3 + C2I-PR2).** A sealed envelope that opens to one of the read
+/// requests — the original three ([`Message::WorkbenchProjectionRequest`],
+/// [`Message::RunReadbackRequest`], [`Message::ProvidersDoctorRequest`]) PLUS the five C2I-PR2
+/// owner-gated C2 read-plane ops ([`Message::SessionListRequest`], [`Message::SessionOpenRequest`]
+/// (the M-2 sealed-body carve-out), [`Message::SessionLinkStateRequest`],
+/// [`Message::RunFileViewRequest`], [`Message::ActivityNeedsMeRequest`]) — takes the IDENTICAL read
+/// path, factored into two shared helpers so the arms cannot drift:
 /// 1. [`authenticate_read_request`] — [`AuthedPrincipal::authenticate_forwarded`] verifies the
 ///    forwarded principal against the session (possession-of-session + per-handshake nonce +
 ///    owner-allowlist), with the proof bound to the request's `request_id` (the read analog of
@@ -412,6 +420,258 @@ fn serve_read_session<S: Read + Write>(
                     },
                 )?
             }
+            // ===== C2I-PR2: the 5 OWNER-GATED C2 read-plane arms ==========================
+            // Each rides the IDENTICAL auth-before-read path the RunReadbackRequest arm proved
+            // (C2I-PR1): authenticate via the shared helper (a `None` ENDS the session, fail-
+            // closed), call the EXISTING owner-scoped accessor with the VERIFIED principal
+            // (`caller.principal()`, NEVER the raw wire `forwarded_principal`), then `seal_and_frame`
+            // the result. For the 4 resource-keyed ops a per-resource owner denial collapses to the
+            // SAME typed `*_not_found` Error a non-existent resource produced — INDISTINGUISHABLE on
+            // the wire (no cross-principal existence/state oracle), exactly the M-3 discipline.
+            //
+            // **C2-4 SessionList** — the OWNER-SCOPED routed-session list. No resource key: a
+            // different principal's list is naturally EMPTY, so there is no per-resource gate (the
+            // `user_id = ?1` scope IS the gate). An owned-but-empty list is a real `Ok([])` snapshot,
+            // not an error. The `SessionListItem`s are refs-only (id + timestamps, never a body).
+            Message::SessionListRequest { request } => {
+                let caller = match authenticate_read_request(
+                    session_key,
+                    session_nonce,
+                    &request.auth_proof,
+                    &request.forwarded_principal,
+                    &request.request_id,
+                    owner_allowlist,
+                ) {
+                    Some(caller) => caller,
+                    None => return Ok(processed),
+                };
+                let request_id = request.request_id.clone();
+                // Owner-scoped list (the SAME `friday_storage::list_sessions_for_owner` the
+                // HubRuntime accessor wraps). A blank/non-owner principal matches NOTHING.
+                let projection =
+                    friday_storage::list_sessions_for_owner(db.conn(), caller.principal())
+                        .map(|items| {
+                            serde_json::json!({
+                                "truth_label": "rust_wired_dev",
+                                "proof_only": true,
+                                "ok": true,
+                                "session_count": items.len(),
+                                "sessions": items
+                                    .iter()
+                                    .map(|item| serde_json::json!({
+                                        "agent_session_id": item.agent_session_id,
+                                        "created_at": item.created_at,
+                                        "updated_at": item.updated_at,
+                                    }))
+                                    .collect::<Vec<_>>(),
+                            })
+                        })
+                        .map_err(|_| "read_failed".to_string());
+                seal_and_frame(
+                    session_key,
+                    &env.msg_id,
+                    &request_id,
+                    now_ms,
+                    projection,
+                    |sealed_hex| Message::SessionListSnapshot {
+                        snapshot: SessionListSnapshotWire {
+                            request_id: request_id.clone(),
+                            projection_json: sealed_hex,
+                            generated_at_ms: now_ms,
+                        },
+                    },
+                )?
+            }
+            // **C2-4 / M-2 SessionOpen** — the ONE DELIBERATE BODY-DELIVERY CARVE-OUT. The owner gate
+            // is `owner_matches(caller.principal())` (INSIDE `open_session_for_owner` — a non-owner /
+            // owner-less / absent session all read back `None`, never a client-asserted user_id). The
+            // full transcript bodies are delivered ONLY when the gate passes, and ONLY OWNER-SEALED
+            // via `seal_and_frame` (so the body never leaves the process unsealed). We DO NOT run
+            // `reject_forbidden_output` on this body — that guard would false-reject legitimate
+            // transcript text; the owner gate + the owner-sealing ARE the protection (M-2). A `None`
+            // (non-owner / absent / owner-less) collapses to `session_not_found` — INDISTINGUISHABLE,
+            // so the verified caller learns nothing about a session it does not own (no body, no
+            // existence oracle). An owned-but-empty session is a real `Some(vec![])` snapshot.
+            Message::SessionOpenRequest { request } => {
+                let caller = match authenticate_read_request(
+                    session_key,
+                    session_nonce,
+                    &request.auth_proof,
+                    &request.forwarded_principal,
+                    &request.request_id,
+                    owner_allowlist,
+                ) {
+                    Some(caller) => caller,
+                    None => return Ok(processed),
+                };
+                let request_id = request.request_id.clone();
+                let projection = match friday_storage::open_session_for_owner(
+                    db.conn(),
+                    caller.principal(),
+                    &request.agent_session_id,
+                ) {
+                    // M-2 carve-out: the owner is entitled to the FULL bodies. Serialize the folded
+                    // transcript (role/content/refs/seq) — this DOES carry message text, delivered
+                    // ONLY here, ONLY to the gated owner, and ONLY sealed by `seal_and_frame`. NO
+                    // `reject_forbidden_output` (it would false-reject legit transcript text).
+                    Ok(Some(messages)) => Ok(serde_json::json!({
+                        "truth_label": "rust_wired_dev",
+                        "proof_only": true,
+                        "ok": true,
+                        "agent_session_id": request.agent_session_id,
+                        "message_count": messages.len(),
+                        // The DELIBERATE body carve-out: the owner's own transcript bodies.
+                        "messages": messages
+                            .iter()
+                            .map(|m| serde_json::json!({
+                                "message_id": m.message_id,
+                                "seq": m.seq,
+                                "role": m.role,
+                                "content": m.content,
+                                "refs": m.refs,
+                                "created_at": m.created_at,
+                            }))
+                            .collect::<Vec<_>>(),
+                    })),
+                    // Fail-closed: a non-owner / owner-less / absent session is INDISTINGUISHABLE.
+                    Ok(None) => Err("session_not_found".to_string()),
+                    Err(_) => Err("read_failed".to_string()),
+                };
+                seal_and_frame(
+                    session_key,
+                    &env.msg_id,
+                    &request_id,
+                    now_ms,
+                    projection,
+                    |sealed_hex| Message::SessionOpenSnapshot {
+                        snapshot: SessionOpenSnapshotWire {
+                            request_id: request_id.clone(),
+                            projection_json: sealed_hex,
+                            generated_at_ms: now_ms,
+                        },
+                    },
+                )?
+            }
+            // **C2-8 SessionLinkState** — the refs-only connectivity/staleness label. OWNER-GATED
+            // inside `project_session_link_state` (`Ok(None)` for a non-owner / absent / owner-less
+            // session). The staleness is derived against the SERVER's own clock (`now_ms`, NOT a
+            // client-supplied field — a caller cannot paint their own session fresh). A non-owner
+            // `Ok(None)` collapses to `session_not_found` (INDISTINGUISHABLE).
+            Message::SessionLinkStateRequest { request } => {
+                let caller = match authenticate_read_request(
+                    session_key,
+                    session_nonce,
+                    &request.auth_proof,
+                    &request.forwarded_principal,
+                    &request.request_id,
+                    owner_allowlist,
+                ) {
+                    Some(caller) => caller,
+                    None => return Ok(processed),
+                };
+                let request_id = request.request_id.clone();
+                let projection = match project_session_link_state(
+                    db,
+                    caller.principal(),
+                    &request.agent_session_id,
+                    now_ms,
+                ) {
+                    Ok(Some(value)) => Ok(value),
+                    Ok(None) => Err("session_not_found".to_string()),
+                    Err(reason) => Err(reason),
+                };
+                seal_and_frame(
+                    session_key,
+                    &env.msg_id,
+                    &request_id,
+                    now_ms,
+                    projection,
+                    |sealed_hex| Message::SessionLinkStateSnapshot {
+                        snapshot: SessionLinkStateSnapshotWire {
+                            request_id: request_id.clone(),
+                            projection_json: sealed_hex,
+                            generated_at_ms: now_ms,
+                        },
+                    },
+                )?
+            }
+            // **C2-5 RunFileView** — the refs-only workspace file refs the run's `read_file` receipts
+            // recorded. OWNER-GATED inside `project_run_file_view` (the C2-4/D1-Q1
+            // `get_run_answer_for_principal` axis; `Ok(None)` for a non-owner / owner-less / absent
+            // run). A non-owner `Ok(None)` collapses to `run_not_found` (INDISTINGUISHABLE — the SAME
+            // shape the RunReadback arm uses).
+            Message::RunFileViewRequest { request } => {
+                let caller = match authenticate_read_request(
+                    session_key,
+                    session_nonce,
+                    &request.auth_proof,
+                    &request.forwarded_principal,
+                    &request.request_id,
+                    owner_allowlist,
+                ) {
+                    Some(caller) => caller,
+                    None => return Ok(processed),
+                };
+                let request_id = request.request_id.clone();
+                let projection =
+                    match project_run_file_view(db, caller.principal(), &request.run_id) {
+                        Ok(Some(value)) => Ok(value),
+                        Ok(None) => Err("run_not_found".to_string()),
+                        Err(reason) => Err(reason),
+                    };
+                seal_and_frame(
+                    session_key,
+                    &env.msg_id,
+                    &request_id,
+                    now_ms,
+                    projection,
+                    |sealed_hex| Message::RunFileViewSnapshot {
+                        snapshot: RunFileViewSnapshotWire {
+                            request_id: request_id.clone(),
+                            projection_json: sealed_hex,
+                            generated_at_ms: now_ms,
+                        },
+                    },
+                )?
+            }
+            // **C2-9 ActivityNeedsMe** — the refs-only Activity / Needs-Me projection for a PAUSED
+            // run. OWNER-GATED inside `project_activity_needs_me` (the paused run's pending-row owner
+            // via `resolve_run_owner`; `Ok(None)` for a non-owner / not-paused / owner-less run). A
+            // non-owner `Ok(None)` collapses to `run_not_found` (INDISTINGUISHABLE).
+            Message::ActivityNeedsMeRequest { request } => {
+                let caller = match authenticate_read_request(
+                    session_key,
+                    session_nonce,
+                    &request.auth_proof,
+                    &request.forwarded_principal,
+                    &request.request_id,
+                    owner_allowlist,
+                ) {
+                    Some(caller) => caller,
+                    None => return Ok(processed),
+                };
+                let request_id = request.request_id.clone();
+                let projection =
+                    match project_activity_needs_me(db, caller.principal(), &request.run_id) {
+                        Ok(Some(value)) => Ok(value),
+                        Ok(None) => Err("run_not_found".to_string()),
+                        Err(reason) => Err(reason),
+                    };
+                seal_and_frame(
+                    session_key,
+                    &env.msg_id,
+                    &request_id,
+                    now_ms,
+                    projection,
+                    |sealed_hex| Message::ActivityNeedsMeSnapshot {
+                        snapshot: ActivityNeedsMeSnapshotWire {
+                            request_id: request_id.clone(),
+                            projection_json: sealed_hex,
+                            generated_at_ms: now_ms,
+                        },
+                    },
+                )?
+            }
             // Any other opened envelope is NOT a read projection. The read server has no write/
             // control surface — refuse it with a typed Error (never an echo of an unknown message,
             // never a dispatch). The session continues so a benign keepalive does not drop the link.
@@ -421,7 +681,9 @@ fn serve_read_session<S: Read + Write>(
                 Message::Error {
                     code: friday_protocol::ErrorCode::SchemaVersionUnsupported,
                     message: "read server accepts only WorkbenchProjectionRequest, \
-                              RunReadbackRequest, or ProvidersDoctorRequest"
+                              RunReadbackRequest, ProvidersDoctorRequest, SessionListRequest, \
+                              SessionOpenRequest, SessionLinkStateRequest, RunFileViewRequest, \
+                              or ActivityNeedsMeRequest"
                         .into(),
                 },
             )
@@ -815,6 +1077,159 @@ mod tests {
         )
         .unwrap();
         path
+    }
+
+    // ===== C2I-PR2 seeders (real DB, no network) =====================================
+    // Each seeds the EXACT rows the corresponding owner-scoped accessor reads — bound to
+    // `owner` so a verified caller authenticating AS that principal Grants, and any other
+    // principal is fail-closed. The bodies (session transcript text, run answer) are seeded
+    // verbatim so the round-trip can assert they (a) reach the gated owner sealed and (b)
+    // NEVER appear for a non-owner.
+
+    /// Seed an owned `agent_session` + two folded transcript messages (`user` then
+    /// `assistant`), bound to `owner` via `user_id`. The contents are bodies that must reach
+    /// ONLY the gated owner, ONLY sealed (the M-2 carve-out). Returns the session id.
+    fn seed_owned_session(path: &str, owner: &str, session_id: &str) {
+        use friday_storage::agent_session::{
+            append_session_message, ensure_session_with_owner, SessionMessage, SessionOwner,
+        };
+        let db = Db::open_hub(path).unwrap();
+        let now = 1_780_640_000_000;
+        ensure_session_with_owner(
+            db.conn(),
+            session_id,
+            &SessionOwner {
+                user_id: Some(owner.to_string()),
+                ..SessionOwner::default()
+            },
+            now,
+        )
+        .unwrap();
+        append_session_message(
+            db.conn(),
+            session_id,
+            &SessionMessage::new("user", "TRANSCRIPT-BODY-user-says-hello", None),
+            now + 1,
+        )
+        .unwrap();
+        append_session_message(
+            db.conn(),
+            session_id,
+            &SessionMessage::new("assistant", "TRANSCRIPT-BODY-assistant-replies", None),
+            now + 2,
+        )
+        .unwrap();
+    }
+
+    /// Seed an owned `agent_session` with NO messages (the owned-but-empty edge): a real owned
+    /// session that opens to `Some(vec![])`, NOT `session_not_found`.
+    fn seed_owned_empty_session(path: &str, owner: &str, session_id: &str) {
+        use friday_storage::agent_session::{ensure_session_with_owner, SessionOwner};
+        let db = Db::open_hub(path).unwrap();
+        ensure_session_with_owner(
+            db.conn(),
+            session_id,
+            &SessionOwner {
+                user_id: Some(owner.to_string()),
+                ..SessionOwner::default()
+            },
+            1_780_640_000_000,
+        )
+        .unwrap();
+    }
+
+    /// Seed a session bound to `owner` whose `updated_at` is far in the past, so its link-state
+    /// derives to `offline` against any plausible wall clock (the band transitions themselves are
+    /// unit-tested in runtime.rs c2_8; this wire KAT only needs round-trip + owner-gating).
+    fn seed_owned_stale_session(path: &str, owner: &str, session_id: &str) {
+        use friday_storage::agent_session::{ensure_session_with_owner, SessionOwner};
+        let db = Db::open_hub(path).unwrap();
+        ensure_session_with_owner(
+            db.conn(),
+            session_id,
+            &SessionOwner {
+                user_id: Some(owner.to_string()),
+                ..SessionOwner::default()
+            },
+            // A fixed epoch-millis in 2020 — far enough past that `now - updated_at` exceeds the
+            // offline threshold under any real wall clock the test runs at.
+            1_577_836_800_000,
+        )
+        .unwrap();
+    }
+
+    /// Seed a FINISHED run owned by `owner` (via `run_result.owner_principal`) plus a `read_file`
+    /// receipt event (the exact `tool.executed:read {n} bytes from {path}` shape
+    /// `list_read_file_refs` parses). The file-view of this run reads back `["notes.md"]` for the
+    /// gated owner, `run_not_found` for anyone else.
+    fn seed_owned_filed_run(path: &str, owner: &str, run_id: &str) {
+        use friday_storage::agent_run::{create_run, record_event};
+        use friday_storage::{persist_run_result, RunResult};
+        let db = Db::open_hub(path).unwrap();
+        let now = 1_780_640_000_000;
+        create_run(db.conn(), run_id, "RUN-TASK-BODY-must-never-leak", now).unwrap();
+        record_event(
+            db.conn(),
+            &format!("{run_id}-ev-read"),
+            run_id,
+            "tool.executed:read 15 bytes from notes.md",
+            now + 1,
+        )
+        .unwrap();
+        record_event(
+            db.conn(),
+            &format!("{run_id}-ev-fin"),
+            run_id,
+            "agent.finished",
+            now + 2,
+        )
+        .unwrap();
+        persist_run_result(
+            db.conn(),
+            run_id,
+            &RunResult::new("finished", "RUN-ANSWER-BODY-must-never-leak", None)
+                .with_owner_principal(owner),
+            now + 3,
+        )
+        .unwrap();
+    }
+
+    /// Seed a PAUSED run owned by `owner` (the pending approval row's `principal_id`), so
+    /// `resolve_run_owner` (the C2-9 owner axis) Grants the gated owner. Returns the approval
+    /// nonce the Needs-Me item anchors to.
+    fn seed_owned_paused_run(path: &str, owner: &str, run_id: &str) -> String {
+        use friday_storage::agent_run::create_run;
+        use friday_storage::pending_request::{persist_pending_request, PendingApprovalRequest};
+        let db = Db::open_hub(path).unwrap();
+        let now = 1_780_640_000_000;
+        create_run(
+            db.conn(),
+            run_id,
+            "PAUSED-RUN-TASK-BODY-must-never-leak",
+            now,
+        )
+        .unwrap();
+        let nonce = format!("approval-nonce-{run_id}");
+        persist_pending_request(
+            db.conn(),
+            &PendingApprovalRequest {
+                approval_id: nonce.clone(),
+                run_id: run_id.to_string(),
+                action: "write_file".to_string(),
+                action_digest: "0".repeat(64),
+                principal_id: Some(owner.to_string()),
+                surface: "test".to_string(),
+                resource_type: None,
+                resource_id: None,
+                expires_at: now + 1_000_000,
+                issuer: friday_core::gate::CANONICAL_GATE_ISSUER.to_string(),
+                status: "pending".to_string(),
+                created_at: now + 1,
+                tool_params: None,
+            },
+        )
+        .unwrap();
+        nonce
     }
 
     /// Drive the client half of the handshake (mirrors the write-bin test client + the TS reference
@@ -1451,6 +1866,603 @@ mod tests {
         );
         let processed = server.join().unwrap();
         assert_eq!(processed, 0);
+    }
+
+    // ===== C2I-PR2 KATs — the 5 owner-gated C2 read-plane ops over the read server ============
+    //
+    // Two distinct fail-closed layers are covered (per op):
+    //   (A) AUTH layer — an unverified / non-allowlisted forwarded principal ⇒
+    //       `authenticate_read_request` returns None ⇒ the session ENDS, `processed == 0`, NO frame.
+    //   (B) OWNER-GATE layer (the 4 resource-keyed ops) — a VERIFIED caller (authenticates fine AS
+    //       OWNER) requests a resource owned by a DIFFERENT principal ⇒ a typed `*_not_found` Error,
+    //       the link STAYS OPEN (`processed == 1`), NO body.
+    // SessionList has no per-resource gate (its scope-to-empty IS the gate), so it has only an
+    // (A) test + a happy-path round-trip. The M-2 crux is SessionOpen's (B) test: a verified
+    // non-owner gets `session_not_found` and NO transcript byte appears in ANY frame.
+
+    /// The single peer secret every C2I-PR2 KAT enrolls (reusing the proven [`CLIENT_SECRET`]).
+    /// Drive ONE C2I-PR2 read request over a fresh sealed session against `db_path`. The closure
+    /// builds the request `Message` from the freshly-sealed `auth_proof` (bound to
+    /// `forwarded_principal` + `request_id`). Returns `(opened_response, processed)` where
+    /// `opened_response` is `None` iff the session ended fail-closed before any frame arrived (the
+    /// AUTH-layer denial), else `Some(envelope)` (a snapshot OR a typed Error — the OWNER-GATE
+    /// layer / happy path). The OWNER allowlist is fixed to `[OWNER]`.
+    fn c2_read_request(
+        db_path: &str,
+        forwarded_principal: &str,
+        request_id: &str,
+        build: impl FnOnce(Vec<u8>) -> Message + Send + 'static,
+    ) -> (Option<Envelope>, usize) {
+        let server_kp = DeviceKeypair::generate();
+        let client_kp = DeviceKeypair::from_secret_bytes(CLIENT_SECRET);
+        let peer_allowlist = vec![client_kp.public_bytes()];
+        let owner_allowlist = vec![OWNER.to_string()];
+        let db_path = db_path.to_string();
+
+        let listener = ReadWsListener::bind_loopback(0).unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        let server = thread::spawn(move || {
+            let db = Db::open_hub_readonly(&db_path).unwrap();
+            let probe = null_probe();
+            listener
+                .accept_one(&server_kp, &db, &probe, &owner_allowlist, &peer_allowlist)
+                .unwrap()
+        });
+
+        let (mut ws, session_key, session_nonce) = client_handshake(addr, &client_kp);
+        let auth_proof = read_auth_proof(
+            &session_key,
+            &session_nonce,
+            forwarded_principal,
+            request_id,
+        );
+        let req = Envelope::new(format!("msg-{request_id}"), 1000, build(auth_proof));
+        ws_send_envelope(&mut ws, &session_key, &req, SESSION_AAD).unwrap();
+        // A snapshot/typed-Error arrives (processed==1) OR the session ends fail-closed (the recv
+        // errors with EOF and processed==0 — the AUTH-layer denial).
+        let opened = ws_recv_envelope(&mut ws, &session_key, SESSION_AAD).ok();
+        drop(ws);
+        let processed = server.join().unwrap();
+        (opened, processed)
+    }
+
+    /// Open a snapshot's OWNER-SEALED `projection_json` (hex of `[nonce_len][nonce][ciphertext]`)
+    /// under the session key — only the bound owner can — and return the JSON string. Re-derives
+    /// the client session key from the FIXED test secrets (the helper above used a fresh server
+    /// keypair, so a snapshot test instead asserts on the wire shape + that the body is sealed;
+    /// see each test). This thin opener is used by the happy-path tests that retain the key.
+    fn open_sealed_projection(session_key: &DataKey, projection_json: &str) -> String {
+        let sealed_bytes = hex_decode(projection_json);
+        let opened =
+            friday_crypto::open(session_key, &decode_sealed(&sealed_bytes), SESSION_AAD).unwrap();
+        String::from_utf8(opened).unwrap()
+    }
+
+    /// (A-layer, ALL 5) An unverified / non-allowlisted forwarded principal is refused fail-closed
+    /// for EVERY one of the 5 ops: NO frame, the session ends, `processed == 0`. This is the auth
+    /// gate the 5 arms inherit verbatim from C2I-PR1 — table-driven so a new arm cannot skip it.
+    #[test]
+    fn c2i_pr2_all_five_ops_reject_an_unverified_principal_fail_closed() {
+        let attacker = "principal:not-the-owner";
+        // Each op, built against a DB seeded so the resource EXISTS for OWNER — proving the denial
+        // is the AUTH gate (attacker not allowlisted), not a missing resource.
+        // 1. SessionList
+        {
+            let db = seed_run_db("a-list");
+            let rid = "req-a-list";
+            let (resp, processed) = c2_read_request(&db, attacker, rid, |auth_proof| {
+                Message::SessionListRequest {
+                    request: friday_protocol::SessionListRequestWire {
+                        forwarded_principal: attacker.to_string(),
+                        auth_proof,
+                        request_id: rid.to_string(),
+                    },
+                }
+            });
+            assert!(
+                resp.is_none() && processed == 0,
+                "SessionList: auth-fail ends the session"
+            );
+        }
+        // 2. SessionOpen (M-2)
+        {
+            let db = seed_run_db("a-open");
+            seed_owned_session(&db, OWNER, "sess-a");
+            let rid = "req-a-open";
+            let (resp, processed) = c2_read_request(&db, attacker, rid, |auth_proof| {
+                Message::SessionOpenRequest {
+                    request: friday_protocol::SessionOpenRequestWire {
+                        agent_session_id: "sess-a".to_string(),
+                        forwarded_principal: attacker.to_string(),
+                        auth_proof,
+                        request_id: rid.to_string(),
+                    },
+                }
+            });
+            assert!(
+                resp.is_none() && processed == 0,
+                "SessionOpen: auth-fail ends the session"
+            );
+        }
+        // 3. SessionLinkState
+        {
+            let db = seed_run_db("a-link");
+            seed_owned_session(&db, OWNER, "sess-a");
+            let rid = "req-a-link";
+            let (resp, processed) = c2_read_request(&db, attacker, rid, |auth_proof| {
+                Message::SessionLinkStateRequest {
+                    request: friday_protocol::SessionLinkStateRequestWire {
+                        agent_session_id: "sess-a".to_string(),
+                        forwarded_principal: attacker.to_string(),
+                        auth_proof,
+                        request_id: rid.to_string(),
+                    },
+                }
+            });
+            assert!(
+                resp.is_none() && processed == 0,
+                "SessionLinkState: auth-fail ends the session"
+            );
+        }
+        // 4. RunFileView
+        {
+            let db = seed_run_db("a-fv");
+            seed_owned_filed_run(&db, OWNER, "run-a");
+            let rid = "req-a-fv";
+            let (resp, processed) = c2_read_request(&db, attacker, rid, |auth_proof| {
+                Message::RunFileViewRequest {
+                    request: friday_protocol::RunFileViewRequestWire {
+                        run_id: "run-a".to_string(),
+                        forwarded_principal: attacker.to_string(),
+                        auth_proof,
+                        request_id: rid.to_string(),
+                    },
+                }
+            });
+            assert!(
+                resp.is_none() && processed == 0,
+                "RunFileView: auth-fail ends the session"
+            );
+        }
+        // 5. ActivityNeedsMe
+        {
+            let db = seed_run_db("a-anm");
+            seed_owned_paused_run(&db, OWNER, "run-a");
+            let rid = "req-a-anm";
+            let (resp, processed) = c2_read_request(&db, attacker, rid, |auth_proof| {
+                Message::ActivityNeedsMeRequest {
+                    request: friday_protocol::ActivityNeedsMeRequestWire {
+                        run_id: "run-a".to_string(),
+                        forwarded_principal: attacker.to_string(),
+                        auth_proof,
+                        request_id: rid.to_string(),
+                    },
+                }
+            });
+            assert!(
+                resp.is_none() && processed == 0,
+                "ActivityNeedsMe: auth-fail ends the session"
+            );
+        }
+    }
+
+    /// (C2-4) SessionList happy path: the gated OWNER reads back their own sessions, OWNER-SEALED
+    /// refs-only (id + timestamps, never a body). The full sealed round-trip retains the client key
+    /// so the opened body can be asserted.
+    #[test]
+    fn c2i_pr2_session_list_owner_reads_own_sessions_sealed_refs_only() {
+        let db_path = seed_run_db("list-ok");
+        seed_owned_session(&db_path, OWNER, "sess-list-1");
+        let server_kp = DeviceKeypair::generate();
+        let client_kp = DeviceKeypair::from_secret_bytes(CLIENT_SECRET);
+        let peer_allowlist = vec![client_kp.public_bytes()];
+        let owner_allowlist = vec![OWNER.to_string()];
+        let listener = ReadWsListener::bind_loopback(0).unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = thread::spawn(move || {
+            let db = Db::open_hub_readonly(&db_path).unwrap();
+            let probe = null_probe();
+            listener
+                .accept_one(&server_kp, &db, &probe, &owner_allowlist, &peer_allowlist)
+                .unwrap()
+        });
+        let (mut ws, session_key, session_nonce) = client_handshake(addr, &client_kp);
+        let rid = "req-list-ok";
+        let req = Envelope::new(
+            "msg-list-ok",
+            1000,
+            Message::SessionListRequest {
+                request: friday_protocol::SessionListRequestWire {
+                    forwarded_principal: OWNER.to_string(),
+                    auth_proof: read_auth_proof(&session_key, &session_nonce, OWNER, rid),
+                    request_id: rid.to_string(),
+                },
+            },
+        );
+        ws_send_envelope(&mut ws, &session_key, &req, SESSION_AAD).unwrap();
+        let resp = ws_recv_envelope(&mut ws, &session_key, SESSION_AAD).unwrap();
+        let Message::SessionListSnapshot { snapshot } = resp.message else {
+            panic!("expected a SessionListSnapshot");
+        };
+        assert_eq!(snapshot.request_id, rid);
+        let json = open_sealed_projection(&session_key, &snapshot.projection_json);
+        assert!(
+            json.contains("sess-list-1"),
+            "the owner sees her own session id"
+        );
+        assert!(json.contains("\"session_count\":1"));
+        // Refs-only: no transcript body in the LIST (bodies ride SessionOpen only).
+        assert!(
+            !json.contains("TRANSCRIPT-BODY"),
+            "list is refs-only — no body"
+        );
+        drop(ws);
+        assert_eq!(server.join().unwrap(), 1);
+    }
+
+    /// (C2-4 / M-2) SessionOpen happy path — THE CARVE-OUT: the gated OWNER reads back the FULL
+    /// transcript bodies, but ONLY OWNER-SEALED. The body is delivered (the deliberate carve-out)
+    /// AND it is sealed (open it under the session key to read it).
+    #[test]
+    fn c2i_pr2_session_open_owner_reads_full_transcript_only_sealed_m2() {
+        let db_path = seed_run_db("open-ok");
+        seed_owned_session(&db_path, OWNER, "sess-open-1");
+        let server_kp = DeviceKeypair::generate();
+        let client_kp = DeviceKeypair::from_secret_bytes(CLIENT_SECRET);
+        let peer_allowlist = vec![client_kp.public_bytes()];
+        let owner_allowlist = vec![OWNER.to_string()];
+        let listener = ReadWsListener::bind_loopback(0).unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = thread::spawn(move || {
+            let db = Db::open_hub_readonly(&db_path).unwrap();
+            let probe = null_probe();
+            listener
+                .accept_one(&server_kp, &db, &probe, &owner_allowlist, &peer_allowlist)
+                .unwrap()
+        });
+        let (mut ws, session_key, session_nonce) = client_handshake(addr, &client_kp);
+        let rid = "req-open-ok";
+        let req = Envelope::new(
+            "msg-open-ok",
+            1000,
+            Message::SessionOpenRequest {
+                request: friday_protocol::SessionOpenRequestWire {
+                    agent_session_id: "sess-open-1".to_string(),
+                    forwarded_principal: OWNER.to_string(),
+                    auth_proof: read_auth_proof(&session_key, &session_nonce, OWNER, rid),
+                    request_id: rid.to_string(),
+                },
+            },
+        );
+        ws_send_envelope(&mut ws, &session_key, &req, SESSION_AAD).unwrap();
+        let resp = ws_recv_envelope(&mut ws, &session_key, SESSION_AAD).unwrap();
+        let Message::SessionOpenSnapshot { snapshot } = resp.message else {
+            panic!("expected a SessionOpenSnapshot");
+        };
+        assert_eq!(snapshot.request_id, rid);
+        // M-2: the body NEVER appears unsealed on the wire — the sealed hex must NOT contain the
+        // plaintext transcript marker.
+        assert!(
+            !snapshot.projection_json.contains("TRANSCRIPT-BODY"),
+            "the transcript body is SEALED — never plaintext on the wire"
+        );
+        // The gated OWNER opens it under the session key and DOES get the full bodies (the carve-out).
+        let json = open_sealed_projection(&session_key, &snapshot.projection_json);
+        assert!(
+            json.contains("TRANSCRIPT-BODY-user-says-hello"),
+            "owner gets the user body"
+        );
+        assert!(
+            json.contains("TRANSCRIPT-BODY-assistant-replies"),
+            "owner gets the assistant body"
+        );
+        assert!(json.contains("\"message_count\":2"));
+        drop(ws);
+        assert_eq!(server.join().unwrap(), 1);
+    }
+
+    /// (C2-4 / M-2 CRUX) SessionOpen owner-gate: a VERIFIED caller (authenticates AS OWNER) opens a
+    /// session owned by a DIFFERENT principal. The owner gate (`owner_matches`) collapses it to
+    /// `session_not_found` — INDISTINGUISHABLE from an absent session — and NO transcript byte
+    /// appears in ANY frame. The link stays open (auth passed; only the per-resource gate denied).
+    #[test]
+    fn c2i_pr2_session_open_owner_gate_denies_a_session_owned_by_another_principal_m2() {
+        let db_path = seed_run_db("open-cross");
+        // The session is owned by SOMEONE ELSE; the caller authenticates as OWNER.
+        seed_owned_session(&db_path, "principal:a-different-owner", "sess-other");
+        let rid = "req-open-cross";
+        let (resp, processed) = c2_read_request(&db_path, OWNER, rid, |auth_proof| {
+            Message::SessionOpenRequest {
+                request: friday_protocol::SessionOpenRequestWire {
+                    agent_session_id: "sess-other".to_string(),
+                    forwarded_principal: OWNER.to_string(),
+                    auth_proof,
+                    request_id: rid.to_string(),
+                },
+            }
+        });
+        assert_eq!(
+            processed, 1,
+            "auth passed; the per-resource gate denied (link stays open)"
+        );
+        let resp = resp.expect("a typed Error frame (not a session-end)");
+        // Belt + suspenders: serialize the WHOLE frame FIRST — no transcript byte rides it at all.
+        let rendered = serde_json::to_string(&resp).unwrap();
+        assert!(
+            !rendered.contains("TRANSCRIPT-BODY"),
+            "M-2: a non-owner gets NO body byte in any frame"
+        );
+        let Message::Error { code, message } = resp.message else {
+            panic!("a verified non-owner must get a typed Error, never a SessionOpenSnapshot");
+        };
+        assert!(matches!(code, friday_protocol::ErrorCode::HubOffline));
+        assert_eq!(
+            message, "session_not_found",
+            "not-owner is INDISTINGUISHABLE from unknown-session (no oracle)"
+        );
+    }
+
+    /// (C2-4) SessionOpen owned-but-EMPTY edge: an owned session with no turns opens to a real
+    /// (sealed) snapshot with `message_count == 0`, NOT `session_not_found`. Proves the `Some(vec![])`
+    /// vs `None` split treats empty as a real owned read.
+    #[test]
+    fn c2i_pr2_session_open_owned_empty_session_is_a_real_snapshot_not_not_found() {
+        let db_path = seed_run_db("open-empty");
+        seed_owned_empty_session(&db_path, OWNER, "sess-empty");
+        let rid = "req-open-empty";
+        let (resp, processed) = c2_read_request(&db_path, OWNER, rid, |auth_proof| {
+            Message::SessionOpenRequest {
+                request: friday_protocol::SessionOpenRequestWire {
+                    agent_session_id: "sess-empty".to_string(),
+                    forwarded_principal: OWNER.to_string(),
+                    auth_proof,
+                    request_id: rid.to_string(),
+                },
+            }
+        });
+        assert_eq!(processed, 1);
+        let resp = resp.expect("a snapshot frame");
+        let Message::SessionOpenSnapshot { snapshot } = resp.message else {
+            panic!("an owned-but-empty session must be a real snapshot, never session_not_found");
+        };
+        assert_eq!(snapshot.request_id, rid);
+        // The sealed body is a real (empty-transcript) snapshot — assert on the wire shape (the
+        // fresh-server helper does not retain the key, so we cannot open it here; the open-ok test
+        // proves the opening). The presence of the snapshot variant (not an Error) is the assertion.
+    }
+
+    /// (C2-8) SessionLinkState owner-gate: a VERIFIED caller opens a link-state for a session owned
+    /// by a DIFFERENT principal ⇒ `session_not_found` (INDISTINGUISHABLE), link stays open, no text.
+    #[test]
+    fn c2i_pr2_link_state_owner_gate_denies_a_session_owned_by_another_principal() {
+        let db_path = seed_run_db("link-cross");
+        seed_owned_stale_session(&db_path, "principal:a-different-owner", "sess-other");
+        let rid = "req-link-cross";
+        let (resp, processed) = c2_read_request(&db_path, OWNER, rid, |auth_proof| {
+            Message::SessionLinkStateRequest {
+                request: friday_protocol::SessionLinkStateRequestWire {
+                    agent_session_id: "sess-other".to_string(),
+                    forwarded_principal: OWNER.to_string(),
+                    auth_proof,
+                    request_id: rid.to_string(),
+                },
+            }
+        });
+        assert_eq!(processed, 1);
+        let resp = resp.expect("a typed Error frame");
+        let Message::Error { message, .. } = resp.message else {
+            panic!("a verified non-owner must get a typed Error");
+        };
+        assert_eq!(
+            message, "session_not_found",
+            "no cross-principal link-state oracle"
+        );
+    }
+
+    /// (C2-8) SessionLinkState happy path: the gated OWNER reads back the (sealed) link-state label
+    /// for her own session. The far-past `updated_at` derives to `offline`.
+    #[test]
+    fn c2i_pr2_link_state_owner_reads_own_session_sealed() {
+        let db_path = seed_run_db("link-ok");
+        seed_owned_stale_session(&db_path, OWNER, "sess-link");
+        let server_kp = DeviceKeypair::generate();
+        let client_kp = DeviceKeypair::from_secret_bytes(CLIENT_SECRET);
+        let peer_allowlist = vec![client_kp.public_bytes()];
+        let owner_allowlist = vec![OWNER.to_string()];
+        let listener = ReadWsListener::bind_loopback(0).unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = thread::spawn(move || {
+            let db = Db::open_hub_readonly(&db_path).unwrap();
+            let probe = null_probe();
+            listener
+                .accept_one(&server_kp, &db, &probe, &owner_allowlist, &peer_allowlist)
+                .unwrap()
+        });
+        let (mut ws, session_key, session_nonce) = client_handshake(addr, &client_kp);
+        let rid = "req-link-ok";
+        let req = Envelope::new(
+            "msg-link-ok",
+            1000,
+            Message::SessionLinkStateRequest {
+                request: friday_protocol::SessionLinkStateRequestWire {
+                    agent_session_id: "sess-link".to_string(),
+                    forwarded_principal: OWNER.to_string(),
+                    auth_proof: read_auth_proof(&session_key, &session_nonce, OWNER, rid),
+                    request_id: rid.to_string(),
+                },
+            },
+        );
+        ws_send_envelope(&mut ws, &session_key, &req, SESSION_AAD).unwrap();
+        let resp = ws_recv_envelope(&mut ws, &session_key, SESSION_AAD).unwrap();
+        let Message::SessionLinkStateSnapshot { snapshot } = resp.message else {
+            panic!("expected a SessionLinkStateSnapshot");
+        };
+        let json = open_sealed_projection(&session_key, &snapshot.projection_json);
+        assert!(
+            json.contains("\"link_state\":\"offline\""),
+            "far-past session derives offline"
+        );
+        assert!(json.contains("sess-link"));
+        drop(ws);
+        assert_eq!(server.join().unwrap(), 1);
+    }
+
+    /// (C2-5) RunFileView owner-gate: a VERIFIED caller reads a file-view for a run owned by a
+    /// DIFFERENT principal ⇒ `run_not_found` (INDISTINGUISHABLE), link stays open, no body.
+    #[test]
+    fn c2i_pr2_file_view_owner_gate_denies_a_run_owned_by_another_principal() {
+        let db_path = seed_run_db("fv-cross");
+        seed_owned_filed_run(&db_path, "principal:a-different-owner", "run-other");
+        let rid = "req-fv-cross";
+        let (resp, processed) = c2_read_request(&db_path, OWNER, rid, |auth_proof| {
+            Message::RunFileViewRequest {
+                request: friday_protocol::RunFileViewRequestWire {
+                    run_id: "run-other".to_string(),
+                    forwarded_principal: OWNER.to_string(),
+                    auth_proof,
+                    request_id: rid.to_string(),
+                },
+            }
+        });
+        assert_eq!(processed, 1);
+        let resp = resp.expect("a typed Error frame");
+        let Message::Error { message, .. } = resp.message else {
+            panic!("a verified non-owner must get a typed Error");
+        };
+        assert_eq!(
+            message, "run_not_found",
+            "no cross-principal file-view oracle"
+        );
+    }
+
+    /// (C2-5) RunFileView happy path: the gated OWNER reads back the (sealed) refs-only file-view of
+    /// her own run — the `read_file` receipt path ref, never the run task/answer body.
+    #[test]
+    fn c2i_pr2_file_view_owner_reads_own_run_sealed_refs_only() {
+        let db_path = seed_run_db("fv-ok");
+        seed_owned_filed_run(&db_path, OWNER, "run-fv");
+        let server_kp = DeviceKeypair::generate();
+        let client_kp = DeviceKeypair::from_secret_bytes(CLIENT_SECRET);
+        let peer_allowlist = vec![client_kp.public_bytes()];
+        let owner_allowlist = vec![OWNER.to_string()];
+        let listener = ReadWsListener::bind_loopback(0).unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = thread::spawn(move || {
+            let db = Db::open_hub_readonly(&db_path).unwrap();
+            let probe = null_probe();
+            listener
+                .accept_one(&server_kp, &db, &probe, &owner_allowlist, &peer_allowlist)
+                .unwrap()
+        });
+        let (mut ws, session_key, session_nonce) = client_handshake(addr, &client_kp);
+        let rid = "req-fv-ok";
+        let req = Envelope::new(
+            "msg-fv-ok",
+            1000,
+            Message::RunFileViewRequest {
+                request: friday_protocol::RunFileViewRequestWire {
+                    run_id: "run-fv".to_string(),
+                    forwarded_principal: OWNER.to_string(),
+                    auth_proof: read_auth_proof(&session_key, &session_nonce, OWNER, rid),
+                    request_id: rid.to_string(),
+                },
+            },
+        );
+        ws_send_envelope(&mut ws, &session_key, &req, SESSION_AAD).unwrap();
+        let resp = ws_recv_envelope(&mut ws, &session_key, SESSION_AAD).unwrap();
+        let Message::RunFileViewSnapshot { snapshot } = resp.message else {
+            panic!("expected a RunFileViewSnapshot");
+        };
+        let json = open_sealed_projection(&session_key, &snapshot.projection_json);
+        assert!(
+            json.contains("notes.md"),
+            "the file-view surfaces the read_file receipt ref"
+        );
+        assert!(json.contains("\"file_view_count\":1"));
+        // Refs-only: the run task / answer body never appears.
+        assert!(!json.contains("RUN-TASK-BODY"), "no run task body");
+        assert!(!json.contains("RUN-ANSWER-BODY"), "no run answer body");
+        drop(ws);
+        assert_eq!(server.join().unwrap(), 1);
+    }
+
+    /// (C2-9) ActivityNeedsMe owner-gate: a VERIFIED caller reads Activity/Needs-Me for a paused run
+    /// owned by a DIFFERENT principal ⇒ `run_not_found` (INDISTINGUISHABLE), link stays open.
+    #[test]
+    fn c2i_pr2_activity_needs_me_owner_gate_denies_a_run_owned_by_another_principal() {
+        let db_path = seed_run_db("anm-cross");
+        seed_owned_paused_run(&db_path, "principal:a-different-owner", "run-other");
+        let rid = "req-anm-cross";
+        let (resp, processed) = c2_read_request(&db_path, OWNER, rid, |auth_proof| {
+            Message::ActivityNeedsMeRequest {
+                request: friday_protocol::ActivityNeedsMeRequestWire {
+                    run_id: "run-other".to_string(),
+                    forwarded_principal: OWNER.to_string(),
+                    auth_proof,
+                    request_id: rid.to_string(),
+                },
+            }
+        });
+        assert_eq!(processed, 1);
+        let resp = resp.expect("a typed Error frame");
+        let Message::Error { message, .. } = resp.message else {
+            panic!("a verified non-owner must get a typed Error");
+        };
+        assert_eq!(
+            message, "run_not_found",
+            "no cross-principal activity oracle"
+        );
+    }
+
+    /// (C2-9) ActivityNeedsMe happy path: the gated OWNER reads back the (sealed) Needs-Me item
+    /// anchored to the REAL pending-approval nonce of her own paused run.
+    #[test]
+    fn c2i_pr2_activity_needs_me_owner_reads_own_paused_run_sealed() {
+        let db_path = seed_run_db("anm-ok");
+        let nonce = seed_owned_paused_run(&db_path, OWNER, "run-anm");
+        let server_kp = DeviceKeypair::generate();
+        let client_kp = DeviceKeypair::from_secret_bytes(CLIENT_SECRET);
+        let peer_allowlist = vec![client_kp.public_bytes()];
+        let owner_allowlist = vec![OWNER.to_string()];
+        let listener = ReadWsListener::bind_loopback(0).unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = thread::spawn(move || {
+            let db = Db::open_hub_readonly(&db_path).unwrap();
+            let probe = null_probe();
+            listener
+                .accept_one(&server_kp, &db, &probe, &owner_allowlist, &peer_allowlist)
+                .unwrap()
+        });
+        let (mut ws, session_key, session_nonce) = client_handshake(addr, &client_kp);
+        let rid = "req-anm-ok";
+        let req = Envelope::new(
+            "msg-anm-ok",
+            1000,
+            Message::ActivityNeedsMeRequest {
+                request: friday_protocol::ActivityNeedsMeRequestWire {
+                    run_id: "run-anm".to_string(),
+                    forwarded_principal: OWNER.to_string(),
+                    auth_proof: read_auth_proof(&session_key, &session_nonce, OWNER, rid),
+                    request_id: rid.to_string(),
+                },
+            },
+        );
+        ws_send_envelope(&mut ws, &session_key, &req, SESSION_AAD).unwrap();
+        let resp = ws_recv_envelope(&mut ws, &session_key, SESSION_AAD).unwrap();
+        let Message::ActivityNeedsMeSnapshot { snapshot } = resp.message else {
+            panic!("expected an ActivityNeedsMeSnapshot");
+        };
+        let json = open_sealed_projection(&session_key, &snapshot.projection_json);
+        assert!(json.contains("run-anm"), "keyed to the run");
+        assert!(
+            json.contains(&nonce),
+            "the Needs-Me item points at the REAL approval nonce"
+        );
+        // Refs-only: the paused run task body never appears.
+        assert!(!json.contains("PAUSED-RUN-TASK-BODY"), "no run task body");
+        drop(ws);
+        assert_eq!(server.join().unwrap(), 1);
     }
 
     /// Lowercase-hex decode helper for the test (mirror of the bin's `hex_encode`).

--- a/rust-core/crates/friday-protocol/src/lib.rs
+++ b/rust-core/crates/friday-protocol/src/lib.rs
@@ -919,6 +919,177 @@ pub struct ProvidersDoctorSnapshotWire {
     pub generated_at_ms: i64,
 }
 
+// ----------------------------------------------------------------------------------------------
+// **C2I-PR2** — the 5 OWNER-GATED C2 READ-PLANE request/snapshot wire shapes for the DARK read
+// server. Every one is the EXACT sibling of [`RunReadbackRequestWire`] / [`RunReadbackSnapshotWire`]:
+// a PURE READ (never a model/provider call) that runs the SAME owner-auth chain —
+// `forwarded_principal` + `auth_proof` are VERIFIED against the sealed session
+// (possession-of-session + per-handshake nonce + owner-allowlist), the proof bound to `request_id`
+// (the read analog of `run_id`). Each snapshot is released ONLY to the bound AUTHENTICATED principal
+// and the body rides `projection_json` OWNER-SEALED by the transport. DARK / additive: `Message` is
+// NOT `deny_unknown_fields`, so these new variants are byte-identical to current prod when nothing
+// constructs them. Nothing in production constructs or dispatches any of these yet (the C2 lane is
+// gated behind `FRIDAY_CLAUDE_ROUTE_ENABLED` + the slice-6 operator cutover).
+// ----------------------------------------------------------------------------------------------
+
+/// **C2I-PR2 (C2-4)** — client→read-server request for the OWNER-SCOPED routed-session LIST. No
+/// resource key (it lists every session the AUTHENTICATED owner owns; a different principal's list
+/// is naturally empty). Sibling of [`RunReadbackRequestWire`].
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SessionListRequestWire {
+    /// The device-resolved principal conveyed by the peer. VERIFIED against the sealed session
+    /// before release — never trusted as an authority on its own.
+    pub forwarded_principal: String,
+    /// The sealed possession-of-session proof, bound to `request_id` + `forwarded_principal` in its
+    /// AAD (the read analog of the write `auth_proof`). Opaque bytes here.
+    pub auth_proof: Vec<u8>,
+    /// The opaque per-request id the `auth_proof` is bound to (the read analog of `run_id`).
+    pub request_id: String,
+}
+
+/// **C2I-PR2 (C2-4)** — read-server→client refs-only routed-session LIST snapshot. The session list
+/// (id + timestamps, NEVER a message body) rides `projection_json` OWNER-SEALED.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SessionListSnapshotWire {
+    /// Echoes the request id this snapshot answers (correlation).
+    pub request_id: String,
+    /// The refs-only session-list JSON, OWNER-SEALED (the owner's `SessionListItem`s: id +
+    /// timestamps only — never a body). A non-owner reads back an empty list, never an oracle.
+    pub projection_json: String,
+    /// Hub epoch-millis at which the snapshot was generated (lets the UI flag a stale snapshot).
+    pub generated_at_ms: i64,
+}
+
+/// **C2I-PR2 (C2-4 / M-2)** — client→read-server request to OPEN one routed session's full
+/// conversation transcript. `agent_session_id` is the resource key; the read is OWNER-GATED
+/// (`owner_matches`) — a non-owner / owner-less / absent session is INDISTINGUISHABLE
+/// (`session_not_found`). Sibling of [`RunReadbackRequestWire`].
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SessionOpenRequestWire {
+    /// The routed session id to open. REQUIRED — open has no "first active" default.
+    pub agent_session_id: String,
+    /// The device-resolved principal conveyed by the peer. VERIFIED against the sealed session
+    /// before release — never trusted as an authority on its own.
+    pub forwarded_principal: String,
+    /// The sealed possession-of-session proof, bound to `request_id` + `forwarded_principal` in its
+    /// AAD (the read analog of the write `auth_proof`). Opaque bytes here.
+    pub auth_proof: Vec<u8>,
+    /// The opaque per-request id the `auth_proof` is bound to (the read analog of `run_id`).
+    pub request_id: String,
+}
+
+/// **C2I-PR2 (C2-4 / M-2)** — read-server→client routed-session transcript snapshot. THE ONE
+/// DELIBERATE BODY-DELIVERY CARVE-OUT on the read seam: unlike the refs-only reads, this carries the
+/// session's FULL conversation messages. They are protected by the SAME two mechanisms every read
+/// uses — (1) the owner gate (`owner_matches` on the VERIFIED principal; a non-owner gets
+/// `session_not_found`, never bytes) and (2) OWNER-SEALING (`projection_json` is sealed under the
+/// owner-authed session key, so the body never leaves the process unsealed). The read server does
+/// NOT run `reject_forbidden_output` on this body — that guard would false-reject legitimate
+/// transcript text; the owner gate + sealing ARE the protection (documented carve-out, M-2).
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SessionOpenSnapshotWire {
+    /// Echoes the request id this snapshot answers (correlation).
+    pub request_id: String,
+    /// The session's folded conversation messages JSON, OWNER-SEALED. The M-2 carve-out: this DOES
+    /// carry message bodies (owner-only, sealed) — never released to a non-owner, never unsealed.
+    pub projection_json: String,
+    /// Hub epoch-millis at which the snapshot was generated.
+    pub generated_at_ms: i64,
+}
+
+/// **C2I-PR2 (C2-8)** — client→read-server request for one routed session's refs-only LINK-STATE
+/// (`fresh`/`stale`/`offline`). `agent_session_id` is the resource key; OWNER-GATED. The staleness
+/// is derived against the SERVER's clock (never a client-supplied timestamp), so a caller cannot
+/// paint their own session fresh. Sibling of [`RunReadbackRequestWire`].
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SessionLinkStateRequestWire {
+    /// The routed session id whose link-state to project. REQUIRED.
+    pub agent_session_id: String,
+    /// The device-resolved principal conveyed by the peer. VERIFIED against the sealed session
+    /// before release — never trusted as an authority on its own.
+    pub forwarded_principal: String,
+    /// The sealed possession-of-session proof, bound to `request_id` + `forwarded_principal` in its
+    /// AAD (the read analog of the write `auth_proof`). Opaque bytes here.
+    pub auth_proof: Vec<u8>,
+    /// The opaque per-request id the `auth_proof` is bound to (the read analog of `run_id`).
+    pub request_id: String,
+}
+
+/// **C2I-PR2 (C2-8)** — read-server→client refs-only LINK-STATE snapshot. Carries the
+/// closed-vocabulary connectivity label + the static thresholds it was derived against, OWNER-SEALED
+/// — never any session text (the shared `project_session_link_state` guard ran before sealing).
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SessionLinkStateSnapshotWire {
+    /// Echoes the request id this snapshot answers (correlation).
+    pub request_id: String,
+    /// The refs-only link-state JSON, OWNER-SEALED (state label + thresholds only — never a body).
+    pub projection_json: String,
+    /// Hub epoch-millis at which the snapshot was generated.
+    pub generated_at_ms: i64,
+}
+
+/// **C2I-PR2 (C2-5)** — client→read-server request for one run's refs-only FILE-VIEW (the workspace
+/// file refs the run's `read_file` receipts recorded). `run_id` is the resource key; OWNER-GATED on
+/// the run's bound owner (a non-owner gets `run_not_found`). Sibling of [`RunReadbackRequestWire`].
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RunFileViewRequestWire {
+    /// The run id whose file-view to read back. REQUIRED.
+    pub run_id: String,
+    /// The device-resolved principal conveyed by the peer. VERIFIED against the sealed session
+    /// before release — never trusted as an authority on its own.
+    pub forwarded_principal: String,
+    /// The sealed possession-of-session proof, bound to `request_id` + `forwarded_principal` in its
+    /// AAD (the read analog of the write `auth_proof`). Opaque bytes here.
+    pub auth_proof: Vec<u8>,
+    /// The opaque per-request id the `auth_proof` is bound to (the read analog of `run_id`).
+    pub request_id: String,
+}
+
+/// **C2I-PR2 (C2-5)** — read-server→client refs-only FILE-VIEW snapshot. Carries the relative
+/// workspace path refs (in receipt order) + the count, OWNER-SEALED — never a file body, never the
+/// run `task` (the shared `project_run_file_view` guard ran before sealing).
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RunFileViewSnapshotWire {
+    /// Echoes the request id this snapshot answers (correlation).
+    pub request_id: String,
+    /// The refs-only file-view JSON, OWNER-SEALED (relative path refs + count only — never a body).
+    pub projection_json: String,
+    /// Hub epoch-millis at which the snapshot was generated.
+    pub generated_at_ms: i64,
+}
+
+/// **C2I-PR2 (C2-9)** — client→read-server request for one PAUSED run's Activity / Needs-Me
+/// projection (the metered-turn AskReceipt rows + the pending-approval Needs-Me item). `run_id` is
+/// the resource key; OWNER-GATED on the paused run's pending-row owner (`resolve_run_owner`; a
+/// non-owner gets `run_not_found`). Sibling of [`RunReadbackRequestWire`].
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ActivityNeedsMeRequestWire {
+    /// The run id whose Activity / Needs-Me to project. REQUIRED.
+    pub run_id: String,
+    /// The device-resolved principal conveyed by the peer. VERIFIED against the sealed session
+    /// before release — never trusted as an authority on its own.
+    pub forwarded_principal: String,
+    /// The sealed possession-of-session proof, bound to `request_id` + `forwarded_principal` in its
+    /// AAD (the read analog of the write `auth_proof`). Opaque bytes here.
+    pub auth_proof: Vec<u8>,
+    /// The opaque per-request id the `auth_proof` is bound to (the read analog of `run_id`).
+    pub request_id: String,
+}
+
+/// **C2I-PR2 (C2-9)** — read-server→client refs-only Activity / Needs-Me snapshot. Carries the
+/// body-free AskReceipt rows ("{n} tokens via {model}") + the Needs-Me item anchored to the REAL
+/// pending-approval nonce, OWNER-SEALED — never the run `task` (the shared `project_activity_needs_me`
+/// guard ran before sealing).
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ActivityNeedsMeSnapshotWire {
+    /// Echoes the request id this snapshot answers (correlation).
+    pub request_id: String,
+    /// The refs-only Activity / Needs-Me JSON, OWNER-SEALED (receipt summaries + Needs-Me ref only).
+    pub projection_json: String,
+    /// Hub epoch-millis at which the snapshot was generated.
+    pub generated_at_ms: i64,
+}
+
 /// First-slice message kinds (gate §4.2). Tagged by `kind`.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "kind")]
@@ -1057,6 +1228,47 @@ pub enum Message {
     /// `linked_only` — never upgraded, never raw account info). Guard ran before sealing.
     ProvidersDoctorSnapshot {
         snapshot: ProvidersDoctorSnapshotWire,
+    },
+    /// **C2I-PR2 (C2-4)** — UI→DARK read-server: request the OWNER-SCOPED routed-session LIST over
+    /// the sealed-WS READ seam. PURE READ — no model/provider call. Owner-scoped (the SAME chain a
+    /// write uses, proof bound to `request_id`); a non-owner's list is naturally empty. DARK.
+    SessionListRequest { request: SessionListRequestWire },
+    /// **C2I-PR2 (C2-4)** — DARK read-server→UI: owner-sealed refs-only routed-session LIST
+    /// (id + timestamps only, never a body). DARK.
+    SessionListSnapshot { snapshot: SessionListSnapshotWire },
+    /// **C2I-PR2 (C2-4 / M-2)** — UI→DARK read-server: OPEN one routed session's full conversation
+    /// transcript. PURE READ — no model/provider call. Owner-GATED (`owner_matches` on the VERIFIED
+    /// principal); a non-owner gets `session_not_found` (no body, no oracle). DARK.
+    SessionOpenRequest { request: SessionOpenRequestWire },
+    /// **C2I-PR2 (C2-4 / M-2)** — DARK read-server→UI: the routed-session transcript snapshot. THE
+    /// deliberate body-delivery carve-out: it DOES carry message bodies, OWNER-SEALED + owner-gated
+    /// (never `reject_forbidden_output`, which would false-reject legit transcript text). DARK.
+    SessionOpenSnapshot { snapshot: SessionOpenSnapshotWire },
+    /// **C2I-PR2 (C2-8)** — UI→DARK read-server: request one routed session's refs-only LINK-STATE.
+    /// PURE READ. Owner-GATED; staleness derived against the SERVER clock (never a client field). DARK.
+    SessionLinkStateRequest {
+        request: SessionLinkStateRequestWire,
+    },
+    /// **C2I-PR2 (C2-8)** — DARK read-server→UI: owner-sealed refs-only LINK-STATE snapshot
+    /// (closed-vocab state label + thresholds, never any session text). DARK.
+    SessionLinkStateSnapshot {
+        snapshot: SessionLinkStateSnapshotWire,
+    },
+    /// **C2I-PR2 (C2-5)** — UI→DARK read-server: request one run's refs-only FILE-VIEW (the
+    /// `read_file` receipt path refs). PURE READ. Owner-GATED on the run's bound owner; a non-owner
+    /// gets `run_not_found`. DARK.
+    RunFileViewRequest { request: RunFileViewRequestWire },
+    /// **C2I-PR2 (C2-5)** — DARK read-server→UI: owner-sealed refs-only FILE-VIEW snapshot
+    /// (relative path refs + count, never a file body, never the run `task`). DARK.
+    RunFileViewSnapshot { snapshot: RunFileViewSnapshotWire },
+    /// **C2I-PR2 (C2-9)** — UI→DARK read-server: request one PAUSED run's Activity / Needs-Me
+    /// projection. PURE READ. Owner-GATED on the paused run's pending-row owner; a non-owner gets
+    /// `run_not_found`. DARK.
+    ActivityNeedsMeRequest { request: ActivityNeedsMeRequestWire },
+    /// **C2I-PR2 (C2-9)** — DARK read-server→UI: owner-sealed refs-only Activity / Needs-Me snapshot
+    /// (body-free AskReceipt summaries + the Needs-Me item anchored to the real approval nonce). DARK.
+    ActivityNeedsMeSnapshot {
+        snapshot: ActivityNeedsMeSnapshotWire,
     },
     /// trusted-TS-peer->hub: dispatch one production agent-run to the Rust loop
     /// over the long-lived sealed WS session. **WS-transport substrate (S-A) for
@@ -2723,6 +2935,135 @@ mod tests {
                 assert_eq!(mission_context, None);
             }
             other => panic!("expected AgentRunRequest, got {other:?}"),
+        }
+    }
+
+    /// **C2I-PR2** — the 5 owner-gated C2 read-plane request + snapshot wire shapes round-trip
+    /// over the envelope codec (the read-server arms the bin dispatches them to). Mirrors the
+    /// `agent_run_request_round_trips_over_envelope` style: encode → assert the `kind` tag →
+    /// decode → byte-equal. Pure codec/shape — nothing here constructs a server or auth path.
+    #[test]
+    fn c2i_pr2_read_plane_wire_shapes_round_trip_over_envelope() {
+        let cases: Vec<(Message, &str)> = vec![
+            (
+                Message::SessionListRequest {
+                    request: SessionListRequestWire {
+                        forwarded_principal: "owner-1".into(),
+                        auth_proof: vec![1, 2, 3],
+                        request_id: "req-list".into(),
+                    },
+                },
+                "SessionListRequest",
+            ),
+            (
+                Message::SessionListSnapshot {
+                    snapshot: SessionListSnapshotWire {
+                        request_id: "req-list".into(),
+                        projection_json: "deadbeef".into(),
+                        generated_at_ms: 1000,
+                    },
+                },
+                "SessionListSnapshot",
+            ),
+            (
+                Message::SessionOpenRequest {
+                    request: SessionOpenRequestWire {
+                        agent_session_id: "sess-1".into(),
+                        forwarded_principal: "owner-1".into(),
+                        auth_proof: vec![4, 5],
+                        request_id: "req-open".into(),
+                    },
+                },
+                "SessionOpenRequest",
+            ),
+            (
+                Message::SessionOpenSnapshot {
+                    snapshot: SessionOpenSnapshotWire {
+                        request_id: "req-open".into(),
+                        projection_json: "cafe".into(),
+                        generated_at_ms: 1001,
+                    },
+                },
+                "SessionOpenSnapshot",
+            ),
+            (
+                Message::SessionLinkStateRequest {
+                    request: SessionLinkStateRequestWire {
+                        agent_session_id: "sess-1".into(),
+                        forwarded_principal: "owner-1".into(),
+                        auth_proof: vec![6],
+                        request_id: "req-link".into(),
+                    },
+                },
+                "SessionLinkStateRequest",
+            ),
+            (
+                Message::SessionLinkStateSnapshot {
+                    snapshot: SessionLinkStateSnapshotWire {
+                        request_id: "req-link".into(),
+                        projection_json: "01".into(),
+                        generated_at_ms: 1002,
+                    },
+                },
+                "SessionLinkStateSnapshot",
+            ),
+            (
+                Message::RunFileViewRequest {
+                    request: RunFileViewRequestWire {
+                        run_id: "run-1".into(),
+                        forwarded_principal: "owner-1".into(),
+                        auth_proof: vec![7, 8],
+                        request_id: "req-fv".into(),
+                    },
+                },
+                "RunFileViewRequest",
+            ),
+            (
+                Message::RunFileViewSnapshot {
+                    snapshot: RunFileViewSnapshotWire {
+                        request_id: "req-fv".into(),
+                        projection_json: "02".into(),
+                        generated_at_ms: 1003,
+                    },
+                },
+                "RunFileViewSnapshot",
+            ),
+            (
+                Message::ActivityNeedsMeRequest {
+                    request: ActivityNeedsMeRequestWire {
+                        run_id: "run-1".into(),
+                        forwarded_principal: "owner-1".into(),
+                        auth_proof: vec![9],
+                        request_id: "req-anm".into(),
+                    },
+                },
+                "ActivityNeedsMeRequest",
+            ),
+            (
+                Message::ActivityNeedsMeSnapshot {
+                    snapshot: ActivityNeedsMeSnapshotWire {
+                        request_id: "req-anm".into(),
+                        projection_json: "03".into(),
+                        generated_at_ms: 1004,
+                    },
+                },
+                "ActivityNeedsMeSnapshot",
+            ),
+        ];
+        for (msg, kind) in cases {
+            let env = Envelope::new("m1", 1000, msg.clone()).with_correlation("c1");
+            let json = env.encode().unwrap();
+            assert!(
+                json.contains(&format!("\"schema_version\":{CURRENT_SCHEMA_VERSION}")),
+                "carries the current schema version: {json}"
+            );
+            assert!(
+                json.contains(&format!("\"kind\":\"{kind}\"")),
+                "carries the {kind} tag: {json}"
+            );
+            let back = Envelope::decode(&json).unwrap();
+            assert_eq!(back, env, "{kind} round-trips byte-equal");
+            assert_eq!(back.message, msg);
         }
     }
 }


### PR DESCRIPTION
## What

Wave-3 of the LIVE-WIRING program (depends_on C2I-PR1, merged at `59bdb837`). Wires **5 OWNER-GATED C2 read ops** onto the DARK read-projection server (`hub_read_projection_server`), each reusing C2I-PR1's verified-principal auth + owner-scoping + sealed framing. **Born-current on `59bdb837`** so the new arms reuse the principal-aware `authenticate_read_request`.

### The 5 ops + their existing owner-scoped accessors

| Op | Accessor (reached as a free fn — runtime.rs NOT touched) | Shape |
|----|----|----|
| **SessionList** | `friday_storage::list_sessions_for_owner` | refs-only (id + timestamps) |
| **SessionOpen** | `friday_storage::open_session_for_owner` | **M-2 sealed-body carve-out** (full transcript) |
| **SessionLinkState** | `run_readback_projection::project_session_link_state` | refs-only (state label + thresholds) |
| **RunFileView** | `run_readback_projection::project_run_file_view` | refs-only (`read_file` path refs) |
| **ActivityNeedsMe** | `run_readback_projection::project_activity_needs_me` | refs-only (AskReceipts + Needs-Me) |

Each arm: authenticate via `authenticate_read_request` (`None` ⇒ session ends, fail-closed) → call the accessor with `caller.principal()` (the **VERIFIED** principal from `authenticate_forwarded`, **never** the wire `forwarded_principal`) → `seal_and_frame` the result. This is the EXACT C2I-PR1 `RunReadbackRequest` pattern.

### C2I-PR1 verified-principal auth reuse
All 5 arms call the shared `authenticate_read_request` helper (returns `Option<AuthedPrincipal>`, minted ONLY from `AuthedPrincipal::authenticate_forwarded`). A forged / empty / non-allowlisted principal (or un-openable proof) ⇒ `None` ⇒ NO snapshot, the session ENDS. The accessor is always scoped on `caller.principal()`.

### M-2 — the one security carve-out (SessionOpen)
`open_session_for_owner` returns the FULL conversation transcript bodies. The SessionOpen arm:
- **owner-gates** via `owner_matches(caller.principal())` (inside the accessor — a non-owner / owner-less / absent session all read back `None`; never a client-asserted `user_id`);
- delivers the body **ONLY sealed** under the owner-authed session key via the same `seal_and_frame` the other arms use (the body never leaves the process unsealed);
- **deliberately does NOT run `reject_forbidden_output` on the body** — that guard would false-reject legitimate transcript text. The owner-gate + the owner-sealing ARE the protection. This is the named, documented exception (M-2).

A non-owner `Ok(None)` collapses to `session_not_found` — indistinguishable from an absent session (no existence/state oracle).

### Fail-closed for non-owners (per op)
Two distinct layers, both proven by KATs:
- **Auth layer (ALL 5)** — `c2i_pr2_all_five_ops_reject_an_unverified_principal_fail_closed`: an unverified / non-allowlisted principal ⇒ session ends, `processed==0`, NO frame, for every one of the 5 (table-driven, against DBs seeded so the resource EXISTS for the owner — proving the denial is auth, not a missing resource).
- **Owner-gate layer (the 4 resource-keyed ops)** — a VERIFIED caller (authenticates AS owner) requesting a resource owned by `principal:a-different-owner` ⇒ typed `*_not_found` Error (`session_not_found` for SessionOpen/LinkState; `run_not_found` for FileView/ActivityNeedsMe), link stays open (`processed==1`), no body:
  - `c2i_pr2_session_open_owner_gate_denies_a_session_owned_by_another_principal_m2` (**the M-2 crux**: also asserts the sealed `projection_json` carries no plaintext `TRANSCRIPT-BODY` and no body byte rides any frame),
  - `c2i_pr2_link_state_owner_gate_denies_a_session_owned_by_another_principal`,
  - `c2i_pr2_file_view_owner_gate_denies_a_run_owned_by_another_principal`,
  - `c2i_pr2_activity_needs_me_owner_gate_denies_a_run_owned_by_another_principal`.
- **Happy-path + sealing (each op)** — `..._owner_reads_own_*_sealed*`: the gated owner reads back the correct OWNER-SEALED result (the M-2 SessionOpen test opens the seal under the session key and confirms the full bodies arrive; the refs-only tests confirm no run task/answer body leaks).
- **Owned-but-empty edge** — `c2i_pr2_session_open_owned_empty_session_is_a_real_snapshot_not_not_found`: `Some(vec![])` ⇒ a real snapshot, NOT `session_not_found`.

`SessionLinkState` uses the **server's own clock** (`now_ms` computed in the serve loop), never a client-supplied timestamp, so a caller cannot paint their own session fresh. `SessionList` is refs-only by construction (`SessionListItem` = opaque id + timestamps), so `reject_forbidden_output` is not needed on it (conscious choice; the other three projections guard internally).

### Flag / dark / no-prod-caller guarantee
The C2 lane rides the REUSED `FRIDAY_CLAUDE_ROUTE_ENABLED` flag + the slice-6 operator cutover. Per the read-server discipline, darkness is **STRUCTURAL** — the server is loopback-only with no LaunchAgent and no production caller, and the new arms read NO env flag (exactly like the existing 3 read arms). Flag-OFF / no-prod-caller leaves prod byte-identical: `Message` is NOT `deny_unknown_fields`, so the additive variants are inert until something constructs them, which nothing in production does.

## Files touched
- **`friday-protocol/src/lib.rs`** — 10 additive wire types (5 request + 5 snapshot, exact siblings of `RunReadbackRequestWire`/`RunReadbackSnapshotWire`) + 10 additive `Message` variants + a round-trip test (`c2i_pr2_read_plane_wire_shapes_round_trip_over_envelope`).
- **`bin/hub_read_projection_server.rs`** — the 5 handler arms + 10 KATs + seeders.
- **`friday-ffi/src/lib.rs`** — mechanical exhaustiveness fix: the existing `message_kind` match already names every read-seam variant (the next variant is a deliberate compile error there), so the 10 additive variants get label-only arms. No downstream FFI behavior change.
- **`runtime.rs` — UNTOUCHED.** The accessors are reached via the existing `friday_storage::*` storage fns and `run_readback_projection::project_*` free fns (proven crate-root `pub` by the cross-crate calls the HubRuntime methods already make, e.g. runtime.rs:1296). The proven accessors' owner-gating logic is only CALLED, never modified.

## Contract-test impact
None. There is no golden Message-kind-list contract test in the workspace — the only exhaustive consumer is `friday-ffi`'s `message_kind` match (updated). The existing read wire types have no dedicated protocol round-trip test; this PR adds one for the 5 new shapes.

## CI gate (run from `rust-core`)
- `cargo fmt --all -- --check` ✅
- `cargo clippy --workspace --all-targets -- -D warnings` ✅
- `cargo build -p friday-hub` ✅
- `cargo test -p friday-hub` ✅ (641 lib + 19 read-server bin + all integration suites, 0 failed)
- `cargo test -p friday-protocol` ✅ (31 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)