### PR TITLE
feat(mission-spine): live dispatch entry for Mission/WorkItem/lifecycle (FRIDAY_MISSION_SPINE_DISPATCH, default-OFF)

### DIFF
--- a/rust-core/crates/friday-ffi/src/lib.rs
+++ b/rust-core/crates/friday-ffi/src/lib.rs
@@ -1925,6 +1925,8 @@ fn message_kind_name(m: &friday_protocol::Message) -> &'static str {
         M::MissionTimelineSnapshot { .. } => "MissionTimelineSnapshot",
         M::MissionLifecycleRequest { .. } => "MissionLifecycleRequest",
         M::MissionLifecycleResult { .. } => "MissionLifecycleResult",
+        M::WorkItemStatusRequest { .. } => "WorkItemStatusRequest",
+        M::WorkItemStatusResult { .. } => "WorkItemStatusResult",
         // S-R1 — the DARK sealed-WS READ-seam projection kinds. NAMED here so the exhaustive match
         // holds and the truth label carries the real kind; nothing on the FFI surface constructs or
         // dispatches them (the UI reads them directly over the sealed-WS read server, not via FFI).

--- a/rust-core/crates/friday-hub/src/bin/hub_agent_run_server.rs
+++ b/rust-core/crates/friday-hub/src/bin/hub_agent_run_server.rs
@@ -392,6 +392,24 @@ fn run() -> Result<(), ServerError> {
         );
     }
 
+    // (KEYSTONE) Read the MISSION-SPINE DISPATCH flag ONCE at boot (default-off). When false the
+    // dispatch arms NEVER handle a `MissionLifecycleRequest` / `WorkItemStatusRequest` — each falls
+    // through to the EXISTING catch-all keepalive echo (byte-identical to today, since the server
+    // has never had these arms), so deploying this binary changes NO live behavior until the
+    // operator flips this flag.
+    let mission_spine_dispatch_enabled = mission_spine_dispatch_enabled_from(
+        env::var(MISSION_SPINE_DISPATCH_ENABLED_ENV).ok().as_deref(),
+    );
+    if mission_spine_dispatch_enabled {
+        eprintln!(
+            "hub_agent_run_server: MISSION-SPINE dispatch ENABLED (FRIDAY_MISSION_SPINE_DISPATCH) — Mission/WorkItem lifecycle requests transition the Hub state machine (no model call)"
+        );
+    } else {
+        eprintln!(
+            "hub_agent_run_server: MISSION-SPINE dispatch DISABLED (set FRIDAY_MISSION_SPINE_DISPATCH=1 to enable) — Mission/WorkItem lifecycle requests are benign keepalive echoes"
+        );
+    }
+
     // (3) Long-lived accept loop. Each accepted connection: set the read timeout, read the peer
     // pubkey preamble, REJECT a non-allowlisted peer pubkey (S-F, the FIRST gate), reject low-order
     // points, run the WS handshake, derive the sealed session key, and serve sealed envelopes
@@ -405,6 +423,7 @@ fn run() -> Result<(), ServerError> {
             run_control_enabled,
             mission_bound_run_enabled,
             mission_intake_enabled,
+            mission_spine_dispatch_enabled,
         ) {
             Ok(_served) => {}
             // A connection-level error ends THAT connection only; the server keeps listening.
@@ -485,6 +504,35 @@ const MISSION_INTAKE_ENABLED_ENV: &str = "FRIDAY_MISSION_INTAKE";
 /// false; ON only for the exact opt-in value `"1"` (trimmed), matching the program's standard
 /// flag idiom; everything else (including `"true"`) ⇒ false.
 fn mission_intake_enabled_from(raw: Option<&str>) -> bool {
+    matches!(raw.map(str::trim), Some("1"))
+}
+
+/// The env flag that gates the MISSION-SPINE DISPATCH arms (the keystone that makes the
+/// operating-layer mission-spine REACHABLE). DEFAULT-OFF: a [`Message::MissionLifecycleRequest`]
+/// (advance one canonical Mission's lifecycle through the Hub state machine) and a
+/// [`Message::WorkItemStatusRequest`] (advance one WorkItem's lifecycle, with the
+/// proof-on-completion invariant enforced at the persistence boundary) are HANDLED — birthing the
+/// status transition + audit row via the existing
+/// [`friday_hub::hub_server::mission_lifecycle_result_for_db`] /
+/// [`friday_hub::hub_server::work_item_status_result_for_db`] and replying with the matching
+/// `*Result` — ONLY when `FRIDAY_MISSION_SPINE_DISPATCH` is exactly `"1"` (after trim). Unset — or
+/// any other value — leaves the arms DARK: each request falls through to the EXISTING catch-all
+/// keepalive echo, BYTE-IDENTICAL to today (the server has never had these arms), so deploying this
+/// binary changes NO live behavior until the operator flips this SEPARATE flag. No model call is
+/// made (a pure `&Db` mutation ⇒ ZERO `token_ledger` rows). SEPARATE from
+/// `FRIDAY_ROUTE_AGENT_RUN_VIA_RUST` (run-START), `FRIDAY_AGENT_RUN_CONTROL_VIA_RUST` (run-CONTROL),
+/// `FRIDAY_MISSION_BOUND_RUN` (the bound-run seam), and `FRIDAY_MISSION_INTAKE` (Mission birth);
+/// flipping THIS one is an operator cutover decision. The sealed session IS the channel auth (the
+/// single-peer/single-owner SERVER invariant `enforce_single_peer` upholds at boot — a non-owner
+/// peer can never open a session), mirroring the merged `FRIDAY_MISSION_INTAKE` arm; these wire
+/// shapes carry no per-request `auth_proof`.
+const MISSION_SPINE_DISPATCH_ENABLED_ENV: &str = "FRIDAY_MISSION_SPINE_DISPATCH";
+
+/// Pure flag-matcher for [`MISSION_SPINE_DISPATCH_ENABLED_ENV`] (separated from the env read so it
+/// is testable without mutating the process-global environment). DEFAULT-OFF: `None` (unset) ⇒
+/// false; ON only for the exact opt-in value `"1"` (trimmed), matching the program's standard flag
+/// idiom; everything else (including `"true"`) ⇒ false.
+fn mission_spine_dispatch_enabled_from(raw: Option<&str>) -> bool {
     matches!(raw.map(str::trim), Some("1"))
 }
 
@@ -594,6 +642,7 @@ impl AgentRunWsListener {
         run_control_enabled: bool,
         mission_bound_run_enabled: bool,
         mission_intake_enabled: bool,
+        mission_spine_dispatch_enabled: bool,
     ) -> Result<usize, TransportError> {
         let (stream, _peer) = self.listener.accept()?;
         // HARDENING: a per-connection read timeout BEFORE any read, so a stalled peer cannot
@@ -610,6 +659,7 @@ impl AgentRunWsListener {
             run_control_enabled,
             mission_bound_run_enabled,
             mission_intake_enabled,
+            mission_spine_dispatch_enabled,
         )
     }
 }
@@ -652,6 +702,7 @@ fn serve_sealed_session<S: Read + Write, T: Transport>(
     run_control_enabled: bool,
     mission_bound_run_enabled: bool,
     mission_intake_enabled: bool,
+    mission_spine_dispatch_enabled: bool,
 ) -> Result<usize, TransportError> {
     let mut processed = 0usize;
     // S-E: per-session msg_id dedup. A reconnect mints a FRESH tracker (so it is not a
@@ -1105,6 +1156,66 @@ fn serve_sealed_session<S: Read + Write, T: Transport>(
                 );
                 // Correlate the reply to the inbound request (consistent with every other bin
                 // reply + the `mission_intake_result` dispatch caller's `.with_correlation`).
+                ws_send_envelope(
+                    ws,
+                    session_key,
+                    &result.with_correlation(env.msg_id.clone()),
+                    SESSION_AAD,
+                )?;
+                processed += 1;
+            }
+            // (KEYSTONE) MISSION-LIFECYCLE dispatch — FLAG-GATED. When `FRIDAY_MISSION_SPINE_DISPATCH`
+            // is ON, an inbound `MissionLifecycleRequest` advances ONE canonical Mission through the
+            // Hub state machine via the EXISTING `friday_hub::hub_server::mission_lifecycle_result_for_db`
+            // — the SAME transition the `HubServer::dispatch` arm uses — and replies with a
+            // `MissionLifecycleResult` (or an `Error` on an unknown status / illegal hop / missing
+            // Mission). PURE `&Db` mutation: NO provider/model call, ZERO `token_ledger` rows. The
+            // sealed session IS the channel auth (single-peer/single-owner SERVER invariant; this wire
+            // shape carries no per-request `auth_proof`), mirroring the merged mission-intake arm. When
+            // the flag is OFF this guard FAILS and the request falls through to the catch-all keepalive
+            // echo below — BYTE-IDENTICAL to today (the server has never had this arm).
+            Message::MissionLifecycleRequest { request } if mission_spine_dispatch_enabled => {
+                let now_ms = now_ms();
+                let result = friday_hub::hub_server::mission_lifecycle_result_for_db(
+                    runtime.db(),
+                    &env.msg_id,
+                    request,
+                    now_ms,
+                );
+                eprintln!(
+                    "hub_agent_run_server_dispatch: msg_id={} leg=mission_lifecycle (mission-spine enabled)",
+                    env.msg_id
+                );
+                ws_send_envelope(
+                    ws,
+                    session_key,
+                    &result.with_correlation(env.msg_id.clone()),
+                    SESSION_AAD,
+                )?;
+                processed += 1;
+            }
+            // (KEYSTONE) WORK-ITEM-STATUS dispatch — FLAG-GATED. When `FRIDAY_MISSION_SPINE_DISPATCH`
+            // is ON, an inbound `WorkItemStatusRequest` advances ONE WorkItem through the Hub state
+            // machine via the EXISTING `friday_hub::hub_server::work_item_status_result_for_db` and
+            // replies with a `WorkItemStatusResult` (or an `Error`). **Proof-on-completion is
+            // ENFORCED at the persistence boundary:** a `completed_with_proof` target with no
+            // (or empty/whitespace) `proof_receipt` is REJECTED as a typed `Error` — "done" can
+            // never be claimed without proof. PURE `&Db` mutation: NO provider/model call, ZERO
+            // `token_ledger` rows; the sealed session is the channel auth. When the flag is OFF this
+            // guard FAILS and the request falls through to the catch-all keepalive echo below —
+            // BYTE-IDENTICAL to today.
+            Message::WorkItemStatusRequest { request } if mission_spine_dispatch_enabled => {
+                let now_ms = now_ms();
+                let result = friday_hub::hub_server::work_item_status_result_for_db(
+                    runtime.db(),
+                    &env.msg_id,
+                    request,
+                    now_ms,
+                );
+                eprintln!(
+                    "hub_agent_run_server_dispatch: msg_id={} leg=work_item_status (mission-spine enabled)",
+                    env.msg_id
+                );
                 ws_send_envelope(
                     ws,
                     session_key,
@@ -1599,6 +1710,7 @@ mod tests {
                 false,
                 false,
                 false,
+                false, // (KEYSTONE) mission-spine dispatch OFF — byte-identical to today
             )
             .unwrap();
         assert_eq!(processed, 1, "one authed dispatch processed");
@@ -1711,6 +1823,7 @@ mod tests {
                 run_control_enabled,
                 false, // (NS-4) mission-bound seam OFF for the run-control flag tests
                 false, // (NS-5) mission-intake ingress OFF for the run-control flag tests
+                false, // (KEYSTONE) mission-spine dispatch OFF for the run-control flag tests
             )
             .unwrap();
         assert_eq!(processed, 1, "[{tag}] the paused dispatch is processed");
@@ -1795,6 +1908,7 @@ mod tests {
                 false,
                 false,
                 false,
+                false, // (KEYSTONE) mission-spine dispatch OFF — byte-identical to today
             )
             .unwrap();
         assert_eq!(
@@ -1837,6 +1951,7 @@ mod tests {
                 false,
                 false,
                 false,
+                false, // (KEYSTONE) mission-spine dispatch OFF — byte-identical to today
             )
             .unwrap();
         assert_eq!(processed, 0, "[{tag}] rejected dispatch processes ZERO");
@@ -2026,6 +2141,7 @@ mod tests {
                 false, // run-control OFF
                 false, // mission-bound seam OFF
                 true,  // (NS-5) mission-intake ingress ON
+                false, // (KEYSTONE) mission-spine dispatch OFF for the mission-intake test
             )
             .unwrap();
         assert_eq!(processed, 1, "one mission-intake request processed");
@@ -2126,6 +2242,7 @@ mod tests {
                 false, // run-control OFF
                 false, // mission-bound seam OFF
                 false, // (NS-5) mission-intake ingress OFF — byte-identical to today
+                false, // (KEYSTONE) mission-spine dispatch OFF — byte-identical to today
             )
             .unwrap();
         assert_eq!(
@@ -2166,6 +2283,481 @@ mod tests {
                 .is_empty(),
             "flag OFF writes NO route_decision"
         );
+    }
+
+    // =======================================================================
+    // (KEYSTONE) FRIDAY_MISSION_SPINE_DISPATCH — Mission/WorkItem lifecycle arms
+    // =======================================================================
+
+    #[test]
+    fn mission_spine_dispatch_flag_is_default_off_and_fail_closed() {
+        // The mission-spine dispatch arms are DEFAULT-OFF: unset ⇒ disabled (deploy-safe, each
+        // arm falls through to the keepalive echo). Only the exact opt-in value enables it.
+        assert!(
+            !mission_spine_dispatch_enabled_from(None),
+            "unset ⇒ disabled (default-off, deploy-safe)"
+        );
+        assert!(
+            !mission_spine_dispatch_enabled_from(Some("")),
+            "empty ⇒ disabled"
+        );
+        assert!(
+            !mission_spine_dispatch_enabled_from(Some("0")),
+            "0 ⇒ disabled"
+        );
+        assert!(
+            !mission_spine_dispatch_enabled_from(Some("false")),
+            "false ⇒ disabled"
+        );
+        assert!(
+            !mission_spine_dispatch_enabled_from(Some("on")),
+            "garbage ⇒ disabled"
+        );
+        assert!(
+            mission_spine_dispatch_enabled_from(Some("1")),
+            "1 ⇒ enabled"
+        );
+        assert!(
+            !mission_spine_dispatch_enabled_from(Some("true")),
+            "true ⇒ disabled (only exact 1)"
+        );
+        assert!(
+            !mission_spine_dispatch_enabled_from(Some("  TRUE  ")),
+            "padded TRUE ⇒ disabled (only exact 1)"
+        );
+    }
+
+    /// (KEYSTONE) Seed a real Mission + WorkItem(ReadyToDispatch) into the runtime's DB by driving
+    /// the PROVEN intake free-fn directly (no session needed — it is a pure `&Db` mutation). Returns
+    /// the canonical ids so the lifecycle/status KATs have a real target. Uses the SAME shape the
+    /// `mission_intake_request` builder produces.
+    fn seed_mission_and_work_item<T: Transport>(rt: &HubRuntime<T>) {
+        let req = match mission_intake_request("seed").message {
+            Message::MissionIntakeRequest { request } => request,
+            _ => unreachable!("the seed builder produces a MissionIntakeRequest"),
+        };
+        let env = friday_hub::hub_server::mission_intake_result_for_db(rt.db(), "seed", req, 1_000);
+        match env.message {
+            Message::MissionIntakeResult { result } => {
+                assert_eq!(
+                    result.status, "ready",
+                    "seed births a ready Mission/WorkItem"
+                );
+            }
+            other => panic!("seed intake must succeed, got {other:?}"),
+        }
+    }
+
+    /// (KEYSTONE) A `MissionLifecycleRequest` envelope. No `auth_proof`: the sealed session IS the
+    /// channel auth (mirroring the merged mission-intake arm).
+    fn mission_lifecycle_request(msg_id: &str, target_status: &str) -> Envelope {
+        Envelope::new(
+            msg_id,
+            1000,
+            Message::MissionLifecycleRequest {
+                request: friday_protocol::MissionLifecycleRequestWire {
+                    friday_conversation_id: "fconv_ns5_intake".into(),
+                    mission_id: "mission-ns5".into(),
+                    target_status: target_status.into(),
+                    actor_ref: OWNER.into(),
+                    reason: "operator advances the Mission".into(),
+                    proof_ref: None,
+                    merged_into_mission_id: None,
+                },
+            },
+        )
+    }
+
+    /// (KEYSTONE) A `WorkItemStatusRequest` envelope for `work_item_id` → `target_status`, carrying
+    /// `proof_receipt`. No `auth_proof`: the sealed session is the channel auth.
+    fn work_item_status_request(
+        msg_id: &str,
+        work_item_id: &str,
+        target_status: &str,
+        proof_receipt: Option<&str>,
+    ) -> Envelope {
+        Envelope::new(
+            msg_id,
+            1000,
+            Message::WorkItemStatusRequest {
+                request: friday_protocol::WorkItemStatusRequestWire {
+                    work_item_id: work_item_id.into(),
+                    target_status: target_status.into(),
+                    actor_ref: OWNER.into(),
+                    reason: "operator advances the WorkItem".into(),
+                    proof_receipt: proof_receipt.map(str::to_string),
+                },
+            },
+        )
+    }
+
+    /// (KEYSTONE / KAT a) FLAG-ON: a `MissionLifecycleRequest` driven through the REAL dispatch path
+    /// (`accept_one` → `serve_sealed_session`) advances the canonical Mission's status through the
+    /// Hub state machine, returns a `MissionLifecycleResult`, and writes ZERO `token_ledger` rows.
+    #[test]
+    fn flag_on_mission_lifecycle_transitions_through_dispatch() {
+        let (rt, _ws) = mock_runtime("spine-lifecycle-on", OWNER);
+        seed_mission_and_work_item(&rt);
+        let server_kp = DeviceKeypair::generate();
+        let listener = AgentRunWsListener::bind_loopback(0).unwrap();
+        let addr = listener.local_addr().unwrap();
+        let allowlist = vec![OWNER.to_string()];
+        let client_kp = DeviceKeypair::generate();
+        let peer_allowlist = allowlist_of(client_kp.public_bytes());
+        let client = spawn_client(addr, client_kp, |session, _nonce| {
+            let req = mission_lifecycle_request("req-lifecycle-on", "paused");
+            (req, session.clone(), session.clone())
+        });
+
+        let processed = listener
+            .accept_one(
+                &server_kp,
+                &rt,
+                &allowlist,
+                &peer_allowlist,
+                false, // run-control OFF
+                false, // mission-bound seam OFF
+                false, // mission-intake ingress OFF
+                true,  // (KEYSTONE) mission-spine dispatch ON
+            )
+            .unwrap();
+        assert_eq!(processed, 1, "one mission-lifecycle request processed");
+
+        let obs = client.join().unwrap();
+        let Some(Message::MissionLifecycleResult { result }) = obs.result.clone() else {
+            panic!(
+                "flag ON must reply with MissionLifecycleResult, got {:?}",
+                obs.result
+            );
+        };
+        assert_eq!(result.mission_id, "mission-ns5");
+        assert_eq!(result.previous_status, "active");
+        assert_eq!(result.status, "paused", "the Mission was transitioned");
+
+        // The DB row reflects the transition.
+        let mission = rt
+            .db()
+            .get_mission("mission-ns5")
+            .unwrap()
+            .expect("Mission row persisted");
+        assert_eq!(mission.status, friday_core::MissionStatus::Paused);
+
+        // ZERO model call: a lifecycle transition is a pure &Db mutation.
+        let ledger_rows: i64 = rt
+            .db()
+            .conn()
+            .query_row("SELECT COUNT(*) FROM token_ledger", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(
+            ledger_rows, 0,
+            "lifecycle makes NO model call ⇒ ZERO ledger rows"
+        );
+    }
+
+    /// (KEYSTONE / KAT a) FLAG-ON: a `WorkItemStatusRequest` with a VALID proof_receipt completes
+    /// the WorkItem with proof through the REAL dispatch path, returning a `WorkItemStatusResult`
+    /// whose status is `completed_with_proof` and whose receipt COUNT is 1.
+    #[test]
+    fn flag_on_work_item_status_completes_with_proof_through_dispatch() {
+        let (rt, _ws) = mock_runtime("spine-workitem-on", OWNER);
+        seed_mission_and_work_item(&rt);
+        // The seeded WorkItem is ReadyToDispatch; walk it to ProviderWaiting (the only legal
+        // pre-completion state) so the completion hop is valid — exercising the state machine.
+        for (i, next) in [
+            friday_core::WorkItemStatus::Dispatched,
+            friday_core::WorkItemStatus::HubAccepted,
+            friday_core::WorkItemStatus::ProviderRouted,
+            friday_core::WorkItemStatus::ProviderWaiting,
+        ]
+        .into_iter()
+        .enumerate()
+        {
+            // DISTINCT now_ms per hop: the audit_id is `workitem_lifecycle:{id}:{now_ms}`, so a
+            // shared timestamp would collide on the audit_ledger UNIQUE key.
+            let now = 2_000 + i as i64;
+            rt.db()
+                .transition_work_item_status("work-ns5", next, OWNER, "advance", None, now)
+                .unwrap();
+        }
+        let server_kp = DeviceKeypair::generate();
+        let listener = AgentRunWsListener::bind_loopback(0).unwrap();
+        let addr = listener.local_addr().unwrap();
+        let allowlist = vec![OWNER.to_string()];
+        let client_kp = DeviceKeypair::generate();
+        let peer_allowlist = allowlist_of(client_kp.public_bytes());
+        let client = spawn_client(addr, client_kp, |session, _nonce| {
+            let req = work_item_status_request(
+                "req-workitem-on",
+                "work-ns5",
+                "completed_with_proof",
+                Some("proof://work-ns5/verified-result"),
+            );
+            (req, session.clone(), session.clone())
+        });
+
+        let processed = listener
+            .accept_one(
+                &server_kp,
+                &rt,
+                &allowlist,
+                &peer_allowlist,
+                false,
+                false,
+                false,
+                true, // (KEYSTONE) mission-spine dispatch ON
+            )
+            .unwrap();
+        assert_eq!(processed, 1, "one work-item-status request processed");
+
+        let obs = client.join().unwrap();
+        let Some(Message::WorkItemStatusResult { result }) = obs.result.clone() else {
+            panic!(
+                "flag ON must reply with WorkItemStatusResult, got {:?}",
+                obs.result
+            );
+        };
+        assert_eq!(result.work_item_id, "work-ns5");
+        assert_eq!(result.mission_id, "mission-ns5");
+        assert_eq!(result.previous_status, "provider_waiting");
+        assert_eq!(result.status, "completed_with_proof");
+        assert_eq!(
+            result.proof_receipt_count, 1,
+            "exactly one receipt persisted"
+        );
+
+        let work = rt
+            .db()
+            .get_work_item("work-ns5")
+            .unwrap()
+            .expect("WorkItem row persisted");
+        assert_eq!(work.status, friday_core::WorkItemStatus::CompletedWithProof);
+        assert_eq!(work.proof_receipts.len(), 1);
+    }
+
+    /// (KEYSTONE / KAT b) PROOF-ON-COMPLETION: a `completed_with_proof` WorkItemStatusRequest with an
+    /// EMPTY proof_receipt is REJECTED — the dispatch arm returns a typed `Error`, NOT a fake-ready
+    /// completion, and the WorkItem is NOT advanced. This is the load-bearing safety invariant.
+    #[test]
+    fn flag_on_work_item_completion_with_empty_proof_is_rejected() {
+        let (rt, _ws) = mock_runtime("spine-workitem-emptyproof", OWNER);
+        seed_mission_and_work_item(&rt);
+        for (i, next) in [
+            friday_core::WorkItemStatus::Dispatched,
+            friday_core::WorkItemStatus::HubAccepted,
+            friday_core::WorkItemStatus::ProviderRouted,
+            friday_core::WorkItemStatus::ProviderWaiting,
+        ]
+        .into_iter()
+        .enumerate()
+        {
+            // DISTINCT now_ms per hop: the audit_id is `workitem_lifecycle:{id}:{now_ms}`, so a
+            // shared timestamp would collide on the audit_ledger UNIQUE key.
+            let now = 2_000 + i as i64;
+            rt.db()
+                .transition_work_item_status("work-ns5", next, OWNER, "advance", None, now)
+                .unwrap();
+        }
+        let server_kp = DeviceKeypair::generate();
+        let listener = AgentRunWsListener::bind_loopback(0).unwrap();
+        let addr = listener.local_addr().unwrap();
+        let allowlist = vec![OWNER.to_string()];
+        let client_kp = DeviceKeypair::generate();
+        let peer_allowlist = allowlist_of(client_kp.public_bytes());
+        let client = spawn_client(addr, client_kp, |session, _nonce| {
+            // EMPTY (whitespace-only) receipt — must be treated as NO receipt and rejected.
+            let req = work_item_status_request(
+                "req-workitem-emptyproof",
+                "work-ns5",
+                "completed_with_proof",
+                Some("   "),
+            );
+            (req, session.clone(), session.clone())
+        });
+
+        let processed = listener
+            .accept_one(
+                &server_kp,
+                &rt,
+                &allowlist,
+                &peer_allowlist,
+                false,
+                false,
+                false,
+                true, // (KEYSTONE) mission-spine dispatch ON
+            )
+            .unwrap();
+        assert_eq!(processed, 1, "the request is processed (then rejected)");
+
+        // FAIL-CLOSED: a typed Error, never a WorkItemStatusResult.
+        match client.join().unwrap().result.expect("a reply is sent") {
+            Message::Error { message, .. } => {
+                assert!(
+                    message.contains("work item lifecycle blocked"),
+                    "the proofless completion is a typed error: {message}"
+                );
+            }
+            other => panic!("empty-proof completion must be REJECTED, got {other:?}"),
+        }
+
+        // The WorkItem was NOT completed — it stays at ProviderWaiting, no fake-ready write.
+        let work = rt
+            .db()
+            .get_work_item("work-ns5")
+            .unwrap()
+            .expect("WorkItem row persisted");
+        assert_eq!(
+            work.status,
+            friday_core::WorkItemStatus::ProviderWaiting,
+            "a proofless completion never advances the WorkItem"
+        );
+        assert!(
+            work.proof_receipts.is_empty(),
+            "no receipt was appended for the rejected completion"
+        );
+    }
+
+    /// (KEYSTONE / KAT c) CROSS-OWNER / NOT-FOUND: a WorkItemStatusRequest for a work_item_id that
+    /// does NOT exist in this owner's DB is denied (typed `not found` Error). Under the single-peer/
+    /// single-owner session-auth model, an unknown id IS the cross-owner denial (a non-owner could
+    /// never open this session, and an id outside this DB is not found). No partial write.
+    #[test]
+    fn flag_on_work_item_status_unknown_id_is_denied_not_found() {
+        let (rt, _ws) = mock_runtime("spine-workitem-notfound", OWNER);
+        seed_mission_and_work_item(&rt);
+        let server_kp = DeviceKeypair::generate();
+        let listener = AgentRunWsListener::bind_loopback(0).unwrap();
+        let addr = listener.local_addr().unwrap();
+        let allowlist = vec![OWNER.to_string()];
+        let client_kp = DeviceKeypair::generate();
+        let peer_allowlist = allowlist_of(client_kp.public_bytes());
+        let client = spawn_client(addr, client_kp, |session, _nonce| {
+            let req = work_item_status_request(
+                "req-workitem-notfound",
+                "work-belonging-to-another-owner",
+                "ready_to_dispatch",
+                None,
+            );
+            (req, session.clone(), session.clone())
+        });
+
+        let processed = listener
+            .accept_one(
+                &server_kp,
+                &rt,
+                &allowlist,
+                &peer_allowlist,
+                false,
+                false,
+                false,
+                true, // (KEYSTONE) mission-spine dispatch ON
+            )
+            .unwrap();
+        assert_eq!(processed, 1, "the request is processed (then denied)");
+
+        match client.join().unwrap().result.expect("a reply is sent") {
+            Message::Error { message, .. } => {
+                assert!(
+                    message.contains("not found"),
+                    "an unknown WorkItem is a not-found denial: {message}"
+                );
+            }
+            other => panic!("unknown WorkItem must be denied, got {other:?}"),
+        }
+        // The seeded (owner's own) WorkItem is untouched — no cross-bleed write.
+        let work = rt.db().get_work_item("work-ns5").unwrap().unwrap();
+        assert_eq!(work.status, friday_core::WorkItemStatus::ReadyToDispatch);
+    }
+
+    /// (KEYSTONE / KAT d) DEPLOY-SAFETY: with the flag OFF, BOTH a MissionLifecycleRequest and a
+    /// WorkItemStatusRequest are treated as benign keepalive ECHOES — BYTE-IDENTICAL to today (the
+    /// server has never had these arms). No transition, no write.
+    #[test]
+    fn flag_off_mission_spine_requests_are_keepalive_echoes_and_change_nothing() {
+        let (rt, _ws) = mock_runtime("spine-off", OWNER);
+        seed_mission_and_work_item(&rt);
+
+        // (1) MissionLifecycleRequest with the flag OFF ⇒ echoed verbatim, Mission NOT transitioned.
+        {
+            let server_kp = DeviceKeypair::generate();
+            let listener = AgentRunWsListener::bind_loopback(0).unwrap();
+            let addr = listener.local_addr().unwrap();
+            let allowlist = vec![OWNER.to_string()];
+            let client_kp = DeviceKeypair::generate();
+            let peer_allowlist = allowlist_of(client_kp.public_bytes());
+            let client = spawn_client(addr, client_kp, |session, _nonce| {
+                let req = mission_lifecycle_request("req-lifecycle-off", "paused");
+                (req, session.clone(), session.clone())
+            });
+            let processed = listener
+                .accept_one(
+                    &server_kp,
+                    &rt,
+                    &allowlist,
+                    &peer_allowlist,
+                    false,
+                    false,
+                    false,
+                    false, // (KEYSTONE) mission-spine dispatch OFF
+                )
+                .unwrap();
+            assert_eq!(
+                processed, 1,
+                "the lifecycle request is processed as a keepalive"
+            );
+            match client.join().unwrap().result.expect("an echo reply") {
+                Message::MissionLifecycleRequest { request } => {
+                    assert_eq!(request.target_status, "paused", "echoed verbatim");
+                }
+                other => panic!("flag OFF must echo the MissionLifecycleRequest, got {other:?}"),
+            }
+            assert_eq!(
+                rt.db().get_mission("mission-ns5").unwrap().unwrap().status,
+                friday_core::MissionStatus::Active,
+                "flag OFF transitions NOTHING (the seeded Mission stays Active)"
+            );
+        }
+
+        // (2) WorkItemStatusRequest with the flag OFF ⇒ echoed verbatim, WorkItem NOT transitioned.
+        {
+            let server_kp = DeviceKeypair::generate();
+            let listener = AgentRunWsListener::bind_loopback(0).unwrap();
+            let addr = listener.local_addr().unwrap();
+            let allowlist = vec![OWNER.to_string()];
+            let client_kp = DeviceKeypair::generate();
+            let peer_allowlist = allowlist_of(client_kp.public_bytes());
+            let client = spawn_client(addr, client_kp, |session, _nonce| {
+                let req =
+                    work_item_status_request("req-workitem-off", "work-ns5", "dispatched", None);
+                (req, session.clone(), session.clone())
+            });
+            let processed = listener
+                .accept_one(
+                    &server_kp,
+                    &rt,
+                    &allowlist,
+                    &peer_allowlist,
+                    false,
+                    false,
+                    false,
+                    false, // (KEYSTONE) mission-spine dispatch OFF
+                )
+                .unwrap();
+            assert_eq!(
+                processed, 1,
+                "the work-item-status request is processed as a keepalive"
+            );
+            match client.join().unwrap().result.expect("an echo reply") {
+                Message::WorkItemStatusRequest { request } => {
+                    assert_eq!(request.work_item_id, "work-ns5", "echoed verbatim");
+                }
+                other => panic!("flag OFF must echo the WorkItemStatusRequest, got {other:?}"),
+            }
+            assert_eq!(
+                rt.db().get_work_item("work-ns5").unwrap().unwrap().status,
+                friday_core::WorkItemStatus::ReadyToDispatch,
+                "flag OFF transitions NOTHING (the seeded WorkItem stays ReadyToDispatch)"
+            );
+        }
     }
 
     #[test]
@@ -2231,6 +2823,7 @@ mod tests {
                 false,
                 false,
                 false,
+                false, // (KEYSTONE) mission-spine dispatch OFF — byte-identical to today
             )
             .unwrap();
         assert_eq!(
@@ -2274,6 +2867,7 @@ mod tests {
                 false,
                 false,
                 false,
+                false, // (KEYSTONE) mission-spine dispatch OFF — byte-identical to today
             )
             .unwrap();
         assert_eq!(
@@ -2317,6 +2911,7 @@ mod tests {
             false,
             false,
             false,
+            false, // (KEYSTONE) mission-spine dispatch OFF — byte-identical to today
         );
         client.join().unwrap();
         assert!(
@@ -2604,6 +3199,7 @@ mod tests {
                 false,
                 false,
                 false,
+                false, // (KEYSTONE) mission-spine dispatch OFF — byte-identical to today
             )
             .unwrap();
         assert_eq!(processed1, 1, "connection-1 is a VALID dispatch");
@@ -2646,6 +3242,7 @@ mod tests {
                 false,
                 false,
                 false,
+                false, // (KEYSTONE) mission-spine dispatch OFF — byte-identical to today
             )
             .unwrap();
         assert_eq!(
@@ -2705,6 +3302,7 @@ mod tests {
                 false,
                 false,
                 false,
+                false, // (KEYSTONE) mission-spine dispatch OFF — byte-identical to today
             )
             .unwrap();
         // The first keepalive was processed (echoed); the replayed msg_id ended the session.
@@ -2781,6 +3379,7 @@ mod tests {
             false,
             false,
             false,
+            false, // (KEYSTONE) mission-spine dispatch OFF — byte-identical to today
         );
         let obs = client.join().unwrap();
 
@@ -2838,6 +3437,7 @@ mod tests {
                 false,
                 false,
                 false,
+                false, // (KEYSTONE) mission-spine dispatch OFF — byte-identical to today
             )
             .unwrap();
         assert_eq!(
@@ -3247,6 +3847,7 @@ mod tests {
                 false,
                 false,
                 false,
+                false, // (KEYSTONE) mission-spine dispatch OFF — byte-identical to today
             )
             .expect("server serves the interop session");
         assert_eq!(processed, 1, "one authed dispatch processed");
@@ -3302,6 +3903,7 @@ mod tests {
             false,
             false,
             false,
+            false, // (KEYSTONE) mission-spine dispatch OFF — byte-identical to today
         );
         assert!(
             served.is_err(),
@@ -3352,6 +3954,7 @@ mod tests {
                 false,
                 false,
                 false,
+                false, // (KEYSTONE) mission-spine dispatch OFF — byte-identical to today
             )
             .expect("server serves the session but runs nothing");
         assert_eq!(
@@ -3460,6 +4063,7 @@ mod tests {
                 false,
                 false,
                 false,
+                false, // (KEYSTONE) mission-spine dispatch OFF — byte-identical to today
             )
             .expect("server serves the compose-adapter session");
         assert_eq!(processed, 1, "one authed dispatch processed");
@@ -3515,6 +4119,7 @@ mod tests {
             false,
             false,
             false,
+            false, // (KEYSTONE) mission-spine dispatch OFF — byte-identical to today
         );
         assert!(
             served.is_err(),
@@ -3576,6 +4181,7 @@ mod tests {
                 false,
                 false,
                 false,
+                false, // (KEYSTONE) mission-spine dispatch OFF — byte-identical to today
             )
             .unwrap();
         assert_eq!(processed, 1, "one sessioned dispatch processed");
@@ -3677,7 +4283,7 @@ mod tests {
         });
         assert_eq!(
             listener
-                .accept_one(&server_kp, &rt, &allowlist, &peer1, false, false, false)
+                .accept_one(&server_kp, &rt, &allowlist, &peer1, false, false, false, false)
                 .unwrap(),
             1
         );
@@ -3694,7 +4300,7 @@ mod tests {
         });
         assert_eq!(
             listener
-                .accept_one(&server_kp, &rt, &allowlist, &peer2, false, false, false)
+                .accept_one(&server_kp, &rt, &allowlist, &peer2, false, false, false, false)
                 .unwrap(),
             1
         );
@@ -3746,7 +4352,8 @@ mod tests {
                     &peer_allowlist,
                     false,
                     false,
-                    false
+                    false,
+                    false, // (KEYSTONE) mission-spine dispatch OFF — byte-identical to today
                 )
                 .unwrap(),
             1

--- a/rust-core/crates/friday-hub/src/hub_server.rs
+++ b/rust-core/crates/friday-hub/src/hub_server.rs
@@ -27,7 +27,8 @@ use friday_protocol::{
     MissionTimelineLinkWire, MissionTimelineMissionWire, MissionTimelineRequestWire,
     MissionTimelineSnapshotWire, MissionTimelineSurfaceEventWire, MissionTimelineWorkItemWire,
     MissionWorkItemContextWire, ProviderWorkspaceActionRequestWire,
-    ProviderWorkspaceActionResultWire, RouteDecisionProjectionWire, SUPPORTED,
+    ProviderWorkspaceActionResultWire, RouteDecisionProjectionWire, WorkItemStatusRequestWire,
+    WorkItemStatusResultWire, SUPPORTED,
 };
 use friday_providers::unified::{FallbackStatus, PlatformProvider, ProviderSession, SessionStatus};
 use friday_storage::{
@@ -475,6 +476,138 @@ fn mission_intake_error(msg_id: &str, now_ms: i64, code: ErrorCode, message: &st
     .with_correlation(msg_id.to_string())
 }
 
+/// The Mission lifecycle-transition mutation, parameterized over `&Db` so BOTH the
+/// [`HubServer::dispatch`] path AND the live agent-run server bin's flag-gated dispatch arm reuse
+/// the EXACT same Hub state-machine transition and the same [`MissionLifecycleResultWire`] reply.
+/// It touches ONLY the DB (status-transition validation + audit + write) and makes NO
+/// provider/model call — so it writes ZERO `token_ledger` rows.
+///
+/// Returns a [`Message::MissionLifecycleResult`] envelope on success, or a [`Message::Error`]
+/// envelope on an unknown target status / invalid transition / missing Mission, correlated to
+/// `msg_id`. A status change here is a Mission-management fact, NOT provider completion unless the
+/// command carried and persisted valid proof.
+pub fn mission_lifecycle_result_for_db(
+    db: &Db,
+    msg_id: &str,
+    request: MissionLifecycleRequestWire,
+    now_ms: i64,
+) -> Envelope {
+    let next_status = match mission_status_from_wire(&request.target_status) {
+        Ok(status) => status,
+        Err(message) => {
+            return mission_intake_error(msg_id, now_ms, ErrorCode::Internal, message);
+        }
+    };
+
+    match db.transition_mission_status(
+        &request.friday_conversation_id,
+        &request.mission_id,
+        next_status,
+        &request.actor_ref,
+        &request.reason,
+        request.proof_ref.as_deref(),
+        request.merged_into_mission_id.as_deref(),
+        now_ms,
+    ) {
+        Ok((mission, previous_status, active_mission_ids)) => Envelope::new(
+            format!("{msg_id}-mission-lifecycle"),
+            now_ms,
+            Message::MissionLifecycleResult {
+                result: MissionLifecycleResultWire {
+                    friday_conversation_id: mission.friday_conversation_id,
+                    mission_id: mission.mission_id,
+                    previous_status: previous_status.as_str().to_string(),
+                    status: mission.status.as_str().to_string(),
+                    actor_ref: request.actor_ref,
+                    reason: request.reason,
+                    proof_ref: request.proof_ref,
+                    merged_into_mission_id: request.merged_into_mission_id,
+                    active_mission_ids,
+                    updated_at_ms: mission.updated_at_ms,
+                },
+            },
+        ),
+        // FAIL-CLOSED: any transition error (unknown Mission, illegal hop, conflicting merge) is a
+        // typed Error envelope — never a partial write (the storage transition is one transaction).
+        Err(err) => mission_intake_error(
+            msg_id,
+            now_ms,
+            ErrorCode::Internal,
+            &format!("mission lifecycle blocked: {err}"),
+        ),
+    }
+}
+
+/// The WorkItem lifecycle-transition mutation, parameterized over `&Db` so the live agent-run
+/// server bin's flag-gated dispatch arm can advance a WorkItem through the Hub state machine
+/// WITHOUT a `HubServer`. It touches ONLY the DB (status-transition validation + the
+/// proof-on-completion invariant + audit + write) and makes NO provider/model call — so it writes
+/// ZERO `token_ledger` rows.
+///
+/// **Proof-on-completion is ENFORCED, not advisory:** the underlying
+/// [`Db::transition_work_item_status`] REJECTS a `completed_with_proof` target that carries no
+/// `proof_receipt` (or an empty one), so "done" can never be claimed without proof. This function
+/// surfaces that rejection as a typed [`Message::Error`] — it never fakes a completion. Returns a
+/// [`Message::WorkItemStatusResult`] on success, correlated to `msg_id`.
+pub fn work_item_status_result_for_db(
+    db: &Db,
+    msg_id: &str,
+    request: WorkItemStatusRequestWire,
+    now_ms: i64,
+) -> Envelope {
+    let next_status = match work_item_status_from_wire(&request.target_status) {
+        Ok(status) => status,
+        Err(message) => {
+            return mission_intake_error(msg_id, now_ms, ErrorCode::Internal, message);
+        }
+    };
+
+    // A blank proof_receipt is normalized to `None` BEFORE the call so the storage layer's
+    // (CompletedWithProof, None) rejection fires for an all-whitespace receipt too — a
+    // whitespace-only "proof" must never satisfy the proof-on-completion invariant.
+    let proof_receipt = request
+        .proof_receipt
+        .as_deref()
+        .map(str::trim)
+        .filter(|receipt| !receipt.is_empty());
+
+    match db.transition_work_item_status(
+        &request.work_item_id,
+        next_status,
+        &request.actor_ref,
+        &request.reason,
+        proof_receipt,
+        now_ms,
+    ) {
+        Ok((work_item, previous_status)) => Envelope::new(
+            format!("{msg_id}-work-item-status"),
+            now_ms,
+            Message::WorkItemStatusResult {
+                result: WorkItemStatusResultWire {
+                    work_item_id: work_item.work_item_id,
+                    mission_id: work_item.mission_id,
+                    previous_status: previous_status.as_str().to_string(),
+                    status: work_item.status.as_str().to_string(),
+                    actor_ref: request.actor_ref,
+                    reason: request.reason,
+                    // COUNT only — never the raw receipt refs (they can carry provider/channel ids).
+                    proof_receipt_count: work_item.proof_receipts.len() as u64,
+                    updated_at_ms: work_item.updated_at_ms,
+                },
+            },
+        ),
+        // FAIL-CLOSED: a proofless `completed_with_proof`, an illegal hop, an unknown WorkItem, or a
+        // receipt on a non-completion target is a typed Error — never a partial / fake-ready write
+        // (the storage transition is one transaction: audit row + upsert commit together).
+        Err(err) => mission_intake_error(
+            msg_id,
+            now_ms,
+            ErrorCode::Internal,
+            &format!("work item lifecycle blocked: {err}"),
+        ),
+    }
+}
+
 impl<T: Transport> HubServer<T> {
     fn ask(
         &mut self,
@@ -850,48 +983,11 @@ impl<T: Transport> HubServer<T> {
         request: MissionLifecycleRequestWire,
         now_ms: i64,
     ) -> Envelope {
-        let next_status = match mission_status_from_wire(&request.target_status) {
-            Ok(status) => status,
-            Err(message) => {
-                return Self::error(msg_id, now_ms, ErrorCode::Internal, message);
-            }
-        };
-
-        match self.db.transition_mission_status(
-            &request.friday_conversation_id,
-            &request.mission_id,
-            next_status,
-            &request.actor_ref,
-            &request.reason,
-            request.proof_ref.as_deref(),
-            request.merged_into_mission_id.as_deref(),
-            now_ms,
-        ) {
-            Ok((mission, previous_status, active_mission_ids)) => Envelope::new(
-                format!("{msg_id}-mission-lifecycle"),
-                now_ms,
-                Message::MissionLifecycleResult {
-                    result: MissionLifecycleResultWire {
-                        friday_conversation_id: mission.friday_conversation_id,
-                        mission_id: mission.mission_id,
-                        previous_status: previous_status.as_str().to_string(),
-                        status: mission.status.as_str().to_string(),
-                        actor_ref: request.actor_ref,
-                        reason: request.reason,
-                        proof_ref: request.proof_ref,
-                        merged_into_mission_id: request.merged_into_mission_id,
-                        active_mission_ids,
-                        updated_at_ms: mission.updated_at_ms,
-                    },
-                },
-            ),
-            Err(err) => Self::error(
-                msg_id,
-                now_ms,
-                ErrorCode::Internal,
-                &format!("mission lifecycle blocked: {err}"),
-            ),
-        }
+        // The lifecycle body is a pure `&Db` mutation (no `deepseek`/`next_ask`), so it is
+        // extracted to the free `mission_lifecycle_result_for_db` — letting the LIVE agent-run
+        // server bin (which holds a `HubRuntime`, not a `HubServer`) REUSE the exact same Hub
+        // state-machine transition through its flag-gated dispatch arm WITHOUT reimplementing it.
+        mission_lifecycle_result_for_db(&self.db, msg_id, request, now_ms)
     }
 
     fn error(msg_id: &str, now_ms: i64, code: ErrorCode, message: &str) -> Envelope {
@@ -1926,6 +2022,30 @@ fn mission_status_from_wire(value: &str) -> Result<friday_core::MissionStatus, &
         "archived" => Ok(friday_core::MissionStatus::Archived),
         "merged" => Ok(friday_core::MissionStatus::Merged),
         _ => Err("mission lifecycle target_status is unknown"),
+    }
+}
+
+/// Map a WorkItem `target_status` wire string to the canonical [`friday_core::WorkItemStatus`].
+/// Mirrors the (private) storage-side `parse_work_item_status` vocabulary so the bin's flag-gated
+/// dispatch arm validates the target BEFORE the transition; an unknown value is a typed error,
+/// never a silent default.
+fn work_item_status_from_wire(value: &str) -> Result<friday_core::WorkItemStatus, &'static str> {
+    match value {
+        "draft" => Ok(friday_core::WorkItemStatus::Draft),
+        "preflight_blocked" => Ok(friday_core::WorkItemStatus::PreflightBlocked),
+        "waiting_for_user" => Ok(friday_core::WorkItemStatus::WaitingForUser),
+        "ready_to_dispatch" => Ok(friday_core::WorkItemStatus::ReadyToDispatch),
+        "dispatched" => Ok(friday_core::WorkItemStatus::Dispatched),
+        "hub_accepted" => Ok(friday_core::WorkItemStatus::HubAccepted),
+        "provider_routed" => Ok(friday_core::WorkItemStatus::ProviderRouted),
+        "provider_waiting" => Ok(friday_core::WorkItemStatus::ProviderWaiting),
+        "completed_with_proof" => Ok(friday_core::WorkItemStatus::CompletedWithProof),
+        "failed_retryable" => Ok(friday_core::WorkItemStatus::FailedRetryable),
+        "failed_terminal" => Ok(friday_core::WorkItemStatus::FailedTerminal),
+        "cancelled" => Ok(friday_core::WorkItemStatus::Cancelled),
+        "merged" => Ok(friday_core::WorkItemStatus::Merged),
+        "archived" => Ok(friday_core::WorkItemStatus::Archived),
+        _ => Err("work item lifecycle target_status is unknown"),
     }
 }
 

--- a/rust-core/crates/friday-protocol/src/lib.rs
+++ b/rust-core/crates/friday-protocol/src/lib.rs
@@ -207,6 +207,40 @@ pub struct MissionLifecycleResultWire {
     pub updated_at_ms: i64,
 }
 
+/// Client request to advance ONE WorkItem's lifecycle through the Hub state
+/// machine. This is a Hub-owned mutation, not a provider/model call. A
+/// `target_status` of `completed_with_proof` MUST carry a non-empty
+/// `proof_receipt` — the persistence layer rejects a proofless completion so
+/// "done" can never be claimed without proof (the proof-on-completion invariant).
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WorkItemStatusRequestWire {
+    pub work_item_id: String,
+    pub target_status: String,
+    pub actor_ref: String,
+    pub reason: String,
+    /// REQUIRED when `target_status == "completed_with_proof"` (non-empty), and
+    /// REJECTED for any other target. Absent ⇒ no receipt is appended.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub proof_receipt: Option<String>,
+}
+
+/// Hub response after a WorkItem lifecycle command. It returns the changed
+/// WorkItem's previous/current status and the redacted proof-receipt count; a
+/// status of `completed_with_proof` here is only honest because the persistence
+/// layer enforced a non-empty receipt before writing it.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WorkItemStatusResultWire {
+    pub work_item_id: String,
+    pub mission_id: String,
+    pub previous_status: String,
+    pub status: String,
+    pub actor_ref: String,
+    pub reason: String,
+    /// COUNT of persisted proof receipts (never the raw receipt refs themselves).
+    pub proof_receipt_count: u64,
+    pub updated_at_ms: i64,
+}
+
 /// Client request to resolve/create a Mission from one mobile/desktop/channel
 /// surface input. This is a Hub-owned preflight mutation, not a provider/model
 /// call. Duplicate/conflict outcomes must be surfaced instead of silently
@@ -1197,6 +1231,15 @@ pub enum Message {
     /// hub->client: lifecycle mutation receipt. Status changes here are Mission
     /// management facts, not provider completion unless proof_ref says so.
     MissionLifecycleResult { result: MissionLifecycleResultWire },
+    /// client->hub: advance ONE WorkItem's lifecycle through the Hub state
+    /// machine. Never a provider/model call. A `completed_with_proof` target
+    /// MUST carry a non-empty `proof_receipt` (the persistence layer rejects a
+    /// proofless completion).
+    WorkItemStatusRequest { request: WorkItemStatusRequestWire },
+    /// hub->client: WorkItem lifecycle mutation receipt. A `completed_with_proof`
+    /// status here is honest precisely because the proof-on-completion invariant
+    /// was enforced before the write.
+    WorkItemStatusResult { result: WorkItemStatusResultWire },
     /// **S-R1** — UI→DARK read-server: request the Mission Workbench read projection over the
     /// sealed-WS READ seam. PURE READ — no model/provider call. Owner-scoped: the read server
     /// authenticates `forwarded_principal`/`auth_proof` against the sealed session (the SAME chain a
@@ -2002,6 +2045,27 @@ mod tests {
                 },
             },
             mission_lifecycle_result(),
+            Message::WorkItemStatusRequest {
+                request: WorkItemStatusRequestWire {
+                    work_item_id: "work-1".into(),
+                    target_status: "completed_with_proof".into(),
+                    actor_ref: "operator:jarvis".into(),
+                    reason: "provider returned a verified result".into(),
+                    proof_receipt: Some("proof://work-item/1".into()),
+                },
+            },
+            Message::WorkItemStatusResult {
+                result: WorkItemStatusResultWire {
+                    work_item_id: "work-1".into(),
+                    mission_id: "mission-1".into(),
+                    previous_status: "provider_waiting".into(),
+                    status: "completed_with_proof".into(),
+                    actor_ref: "operator:jarvis".into(),
+                    reason: "provider returned a verified result".into(),
+                    proof_receipt_count: 1,
+                    updated_at_ms: 1_700_000_000_007,
+                },
+            },
         ];
         for msg in cases {
             let env = Envelope::new("m1", 1000, msg).with_correlation("c1");
@@ -2218,6 +2282,33 @@ mod tests {
                 "mission lifecycle wire leaked {forbidden}: {json}"
             );
         }
+        assert_eq!(Envelope::decode(&json).unwrap(), env);
+    }
+
+    #[test]
+    fn work_item_status_request_omits_proof_receipt_when_absent_and_round_trips() {
+        // A non-completion transition carries NO proof_receipt — the key must be ABSENT on the
+        // wire (additive-optional), so an older peer's decode is unaffected and the shape stays
+        // honest (a receipt is only valid for a completed_with_proof transition).
+        let env = Envelope::new(
+            "work-item-status-1",
+            1000,
+            Message::WorkItemStatusRequest {
+                request: WorkItemStatusRequestWire {
+                    work_item_id: "work-1".into(),
+                    target_status: "ready_to_dispatch".into(),
+                    actor_ref: "operator:jarvis".into(),
+                    reason: "preflight cleared".into(),
+                    proof_receipt: None,
+                },
+            },
+        );
+        let json = env.encode().unwrap();
+        assert!(json.contains("\"kind\":\"WorkItemStatusRequest\""));
+        assert!(
+            !json.contains("proof_receipt"),
+            "a receipt-free WorkItemStatusRequest must not carry a proof_receipt key: {json}"
+        );
         assert_eq!(Envelope::decode(&json).unwrap(), env);
     }
 


### PR DESCRIPTION
## What & why (the keystone)

The Mission/WorkItem lifecycle domain logic is fully built and proven in Rust, but it was only reachable through `HubServer::dispatch` — which is **never instantiated in production**. The running `hub_agent_run_server` only dispatched `AgentRunRequest/Resume/Cancel/Reject` + (dark) `MissionIntakeRequest`. This PR is the keystone that makes the operating-layer mission-spine **reachable** over the live sealed-WS agent-run server: it wires **Mission-lifecycle** and **WorkItem-status** transitions into the running server, behind a NEW default-OFF flag.

## Files changed (4)

| File | Change | +/- |
|---|---|---|
| `rust-core/crates/friday-protocol/src/lib.rs` | add `WorkItemStatusRequestWire` / `WorkItemStatusResultWire` structs + `WorkItemStatusRequest` / `WorkItemStatusResult` `Message` variants (additive; the `Message` enum is **not** `deny_unknown_fields`). `MissionIntake*`/`MissionLifecycle*` variants + wire types **already existed** on `main`. | +91 |
| `rust-core/crates/friday-ffi/src/lib.rs` | add the two `WorkItemStatus` arms to the **exhaustive** `message_kind_name` match (no wildcard — it would not compile otherwise). `From<Message> for AskResponseFfi` has an `Unsupported` fallback, so the new variants are safe there (no change needed). | +2 |
| `rust-core/crates/friday-hub/src/hub_server.rs` | extract `mission_lifecycle_result_for_db` + add `work_item_status_result_for_db` free fns (parameterized over `&Db`, mirroring the existing `mission_intake_result_for_db`) so the bin reuses the **exact** transition without a `HubServer`; add `work_item_status_from_wire` helper. The `mission_lifecycle_result` method now delegates to the free fn — a byte-identical extraction (same `{msg_id}-mission-lifecycle` success id + correlation; error path same `{msg_id}-error` / `ErrorCode::Internal` / `.with_correlation`). | +206/-46 |
| `rust-core/crates/friday-hub/src/bin/hub_agent_run_server.rs` | add `FRIDAY_MISSION_SPINE_DISPATCH` flag + matcher + plumbing (`main` → `accept_one` → `serve_sealed_session`) and two flag-gated dispatch arms (`MissionLifecycleRequest`, `WorkItemStatusRequest`) + 6 KATs. | +613 |

`friday-hub/src/runtime.rs` is **NOT touched** (it is a serialization binding-axis — deliberately avoided).

## The flag

`FRIDAY_MISSION_SPINE_DISPATCH` — default-OFF (enabled only on exact `"1"` after trim; everything else, incl. unset and `"true"`, is OFF). Read once at boot.

## Dark-safety argument (flag-OFF byte-identical)

- The two new arms are `Message::… if mission_spine_dispatch_enabled =>`. With the flag OFF the guards fail and both message kinds fall through to the **unchanged catch-all keepalive echo** (`_ =>`) — byte-identical to today (the server has never had these arms).
- Additive `Message` variants do not perturb the bytes of any existing variant; there are no variant-count assertions anywhere in the workspace.
- Proven by KAT `flag_off_mission_spine_requests_are_keepalive_echoes_and_change_nothing`: both kinds echo verbatim and transition nothing in the DB.
- Pure `&Db` mutations: NO provider/model call ⇒ ZERO `token_ledger` rows (asserted in the lifecycle KAT).

## Proof-on-completion enforcement

A `completed_with_proof` WorkItem transition with an **empty / whitespace-only / absent** `proof_receipt` is **rejected** at the persistence boundary (`transition_work_item_status`, mission.rs) and surfaced as a typed `Error` — never a fake-ready write. The dispatch arm normalizes a whitespace-only receipt to `None` before the call so the rejection fires for that too. Proven by KAT `flag_on_work_item_completion_with_empty_proof_is_rejected` (WorkItem stays `ProviderWaiting`, no receipt appended).

## KATs (bin test module, real `accept_one` → `serve_sealed_session` path)

- `mission_spine_dispatch_flag_is_default_off_and_fail_closed`
- (a) `flag_on_mission_lifecycle_transitions_through_dispatch` — Mission `active`→`paused`, ZERO ledger rows
- (a) `flag_on_work_item_status_completes_with_proof_through_dispatch` — `provider_waiting`→`completed_with_proof`, receipt count = 1
- (b) `flag_on_work_item_completion_with_empty_proof_is_rejected` — typed error, WorkItem unchanged
- (c) `flag_on_work_item_status_unknown_id_is_denied_not_found`
- (d) `flag_off_mission_spine_requests_are_keepalive_echoes_and_change_nothing`

## ⚠️ Two deliberate deviations from the literal task (coordinator: please review)

**1. Auth model — session-auth, NOT `authenticate_forwarded`.** The task said "owner-gate (authenticate_forwarded principal)". The Mission/WorkItem wire shapes carry **no** `auth_proof`/`forwarded_principal` field, so `authenticate_forwarded` is impossible without adding required wire fields (breaking the reuse/additive constraint + every existing literal construction). I instead mirrored the **already-merged `FRIDAY_MISSION_INTAKE` arm**, which uses **session-as-auth**. This is sound because `enforce_single_peer` is a boot-time SERVER invariant (>1 enrolled peer refused) and the runtime is single-owner (v1) — a non-owner can never open the session.
   - **Consequence to see plainly:** there is **no per-request owner check in the dispatch layer** — `transition_work_item_status` looks up by id and transitions, with no owner scoping. Owner-isolation rests entirely on the session layer. KAT (c) is therefore a **not-found** test, not a cross-owner-isolation proof (under single-owner there is no other owner's row in the DB to deny). If you want defense-in-depth, requiring `authenticate_forwarded` (which needs new wire fields) is a clean follow-up.

**2. MissionIntake is NOT under this new flag.** The task listed three arms under `FRIDAY_MISSION_SPINE_DISPATCH`; this PR wires **two** (lifecycle + work-item). Intake **already** dispatches under the pre-existing `FRIDAY_MISSION_INTAKE` flag (merged). You cannot have two match arms for `Message::MissionIntakeRequest`, and re-gating merged code would break its byte-identical contract. **Net:** all three message kinds are reachable — **intake** via `FRIDAY_MISSION_INTAKE`, **lifecycle + work-item** via the new `FRIDAY_MISSION_SPINE_DISPATCH`.

**Minor:** `mission_intake_error` (a correlated-`Error` helper) is reused by the new lifecycle/work-item free fns; name kept for diff minimality (it is generic, not intake-specific).

## Local gates (all PASS)

- `cargo fmt --all -- --check` — PASS
- `cargo clippy --workspace --all-targets -- -D warnings` — PASS
- `cargo build --workspace --all-targets` — PASS
- `cargo test --workspace` — PASS (exit 0, zero failures; incl. friday-protocol 32, friday-ffi 26, friday-hub lib 641, hub_agent_run_server bin 42 with the 6 new KATs)

Born-current on `origin/main` `70b458ca` (re-verified at push time; no concurrent commit touched any of the 4 files). Not merged — coordinator reviews + merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)