### PR TITLE
fix(rust-agent-run): surface honest non-Finished terminal status instead of misleading readback_not_found 503

### DIFF
--- a/src/api/runtime/friday-api-runtime.ts
+++ b/src/api/runtime/friday-api-runtime.ts
@@ -993,6 +993,42 @@ export const RUST_ROUTE_READ_TOOL_ALLOWLIST = ["read_file", "list_dir", "stat_fi
 const RUST_ROUTE_DEEPSEEK_PROVIDER_ID = "deepseek";
 const RUST_ROUTE_DEEPSEEK_FLASH_MODEL = "deepseek-v4-flash";
 
+// (honest-non-finished) The well-known SHA-256 of the EMPTY byte string. A non-Finished terminal
+// run produced NO answer body, but the continuity-projector receipt requires a `finalMessageSha256`
+// string — we stamp this empty-body sentinel (with `finalMessageLen: 0`) so the body REF is
+// truthfully "zero bytes", NEVER an answer fingerprint. Refs-only — this is not a body.
+const EMPTY_BODY_SHA256 =
+  "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"; // pragma: allowlist secret
+
+// (honest-non-finished) The CLOSED allow-list of dispatch loop-status labels that mark a
+// NON-deliverable terminal run (the run ended without an answer to persist). The wire COLLAPSES
+// Blocked/Errored/Bounded/no-answer into ONE label: `AuthedAnswer::NoAnswer`'s refs carry no
+// `status` key, so the agent-run server falls back to the `outcome` → compose actually sees
+// `"no_answer_safe_failure"` for ALL non-Finished/no-body terminals (the raw loop-status tokens are
+// admitted too, for a server that surfaces them directly). EVERY OTHER status — notably `"finished"`
+// (a finished run SHOULD have a row) and any error status (`storage_failed`/`auth_failed`/
+// `operator_vk_unprovisioned`) — is NOT here, so it keeps today's fail-closed 503 (no gate-weakening).
+const RUST_ROUTE_NON_FINISHED_TERMINAL_STATUSES = new Set<string>([
+  "no_answer_safe_failure",
+  "no_answer",
+  "blocked",
+  "bounded",
+  "errored",
+]);
+
+// (honest-non-finished) Map a NON-Finished terminal wire status to the projector's `loopStatus`
+// token. The opaque collapsed labels (`no_answer_safe_failure`/`no_answer` — the only values the
+// LIVE wire emits, since `AuthedAnswer::NoAnswer` carries no status key) cannot recover which
+// non-Finished kind they were, so they map to "Errored". A raw loop-status token a server MIGHT
+// surface directly keeps its FAITHFUL capitalized form. ALL of these map to the SAME terminal
+// "failed" run status downstream (mapLoopStatusToTsStatus) — the distinction is metadata fidelity
+// only, never a different product-visible outcome, and is NEVER the resumable "Paused"/"cancelled".
+const RUST_ROUTE_NON_FINISHED_LOOP_STATUS: Record<string, string> = {
+  blocked: "Blocked",
+  bounded: "Bounded",
+  errored: "Errored",
+};
+
 // (A2b Phase 2, mutation-relax — DARK, default-off) The CLOSED, NAMED allow-list of mutating
 // Rust tools a gated chat run may carry. Clause 4's admitted tool set is the read set
 // (RUST_ROUTE_READ_TOOL_ALLOWLIST) UNION an EXPLICITLY-GRANTED subset of THIS list — only
@@ -1335,6 +1371,78 @@ function readRustAgentRunWsPort(raw: string | undefined): number {
   return Number.isFinite(parsed) && parsed >= 0 ? parsed : 0;
 }
 
+/**
+ * (honest-non-finished) Project + return an HONEST non-Finished terminal result for a run whose
+ * Rust loop terminated WITHOUT an answer (the persist guard skipped ⇒ the owner-gated readback
+ * legitimately `not_found`). Mirrors the Paused-branch projection pattern (write-transaction + the
+ * real projector) but maps to `loopStatus:"Errored"` (→ the projector's terminal "failed" status):
+ * the wire collapses Blocked/Errored/Bounded into one no-answer label and all three map to "failed"
+ * anyway, so "Errored" is the faithful coarse non-resumable terminal — NEVER "Paused" (resumable
+ * "cancelled", which a no-answer terminal is not). REFS-ONLY: empty body ref (len 0), empty
+ * response — we NEVER fabricate an answer body. We DELIBERATELY do NOT stamp the apiRequest
+ * idempotency descriptor (a failed/no-answer run must NOT replay on a retry).
+ */
+function projectHonestNonFinishedTerminal(input: {
+  readonly db: FridaySqliteLayer;
+  readonly projector: FridayRustHubRunContinuityProjectorService;
+  readonly runId: string;
+  readonly providerId: string;
+  readonly model: string;
+  readonly ownerPrincipal: string;
+  readonly wsStatus: string;
+  readonly turns: number;
+  readonly executedTools: number;
+  readonly completedAtIso: string;
+}): FridayAgentRuntimeResult {
+  const projection = input.db.withWriteTransaction((db) =>
+    input.projector.project(db, {
+      truthLabel: "rust_wired_dev",
+      proofOnly: true,
+      ok: true,
+      runId: input.runId,
+      routeId: `${input.providerId}:${input.model}`,
+      providerId: input.providerId,
+      model: input.model,
+      // The faithful non-Finished loop status (→ the projector's terminal "failed" run status —
+      // NEVER a fabricated "completed"/"finished", NEVER the resumable "Paused"/"cancelled"). The
+      // opaque collapsed labels fall back to "Errored". `errorCategory` is a bounded body-free label.
+      loopStatus: RUST_ROUTE_NON_FINISHED_LOOP_STATUS[input.wsStatus] ?? "Errored",
+      errorCategory: "rust_loop_non_finished",
+      // Carried run COUNTS when present (0 when omitted — old server / no-answer terminal).
+      turns: input.turns,
+      executedTools: input.executedTools,
+      // No body exists → an EMPTY body REF: the empty-string sha sentinel + len 0; NEVER an answer
+      // sha (the receipt type requires a sha string).
+      finalMessageSha256: EMPTY_BODY_SHA256,
+      finalMessageLen: 0,
+      auditChainVerified: false,
+      usagePromptTokens: 0,
+      usageCompletionTokens: 0,
+      usageTotalTokens: 0,
+      completedAtIso: input.completedAtIso,
+      // Stamp the BOUND OWNER (the authenticated caller, non-empty by the preflight) so the row is
+      // owner-scoped for the read routes — the same shape the delivered/paused branches use. A ref.
+      ...(input.ownerPrincipal ? { ownerPrincipalId: input.ownerPrincipal } : {}),
+    }),
+  );
+  // A non-Finished terminal settle is NOT a fail-closed 503 — it returns an HONEST terminal row.
+  // Logged body-free on its OWN line, never confused with a 503.
+  console.warn(
+    `[friday][rust-agent-run] non-finished-terminal run_id=${input.runId} leg=readback_not_found ws_status=${input.wsStatus} status=${projection.status}`,
+  );
+  return {
+    runId: input.runId,
+    // The HONEST terminal mapping ("failed") — NOT Finished. No body → empty response (INV-5).
+    status: projection.status as FridayAgentRuntimeResult["status"],
+    response: "",
+    toolCallCount: input.executedTools,
+    durationMs: 0,
+    usageInput: 0,
+    usageOutput: 0,
+    finalResponse: "",
+  };
+}
+
 async function composeRustReadOnlyAgentRun(args: {
   readonly runId: string;
   readonly task: string;
@@ -1541,6 +1649,37 @@ async function composeRustReadOnlyAgentRun(args: {
   }
   if (readbackReceipt.outcome !== "delivered") {
     // leg C: the readback succeeded but returned a non-delivered outcome (denied / not_found).
+    //
+    // (honest-non-finished) A run that terminated NON-Finished (the Rust loop ended Blocked /
+    // Errored / Bounded, or fail-closed-to-no-answer) DELIBERATELY skips the Rust-side persist guard
+    // (`if outcome.status == Finished { persist_run_result }`), so NO `run_result` row is written and
+    // the owner-gated body readback LEGITIMATELY returns `not_found` — there was never an answer to
+    // store. Throwing the `readback_not_found` 503 for that case MISREPORTS an honest terminal settle
+    // as a transport/storage failure (the hourly self-probe + S6 saw exactly this). We carve out ONLY
+    // that one honest case — `not_found` (NOT `denied`: an ownership-gate refusal MUST still 503; a
+    // missing-row read is the only honest-terminal signal) AND a non-deliverable terminal wire status
+    // (RUST_ROUTE_NON_FINISHED_TERMINAL_STATUSES) — and keep TODAY's 503 for everything else.
+    if (
+      readbackReceipt.outcome === "not_found" &&
+      RUST_ROUTE_NON_FINISHED_TERMINAL_STATUSES.has(wsResult.status)
+    ) {
+      // HONEST non-Finished terminal: project a refs-only "failed" continuity row + return it instead
+      // of throwing (see {@link projectHonestNonFinishedTerminal} for the full no-body rationale).
+      return projectHonestNonFinishedTerminal({
+        db: args.db,
+        projector: args.projector,
+        runId: args.runId,
+        providerId: args.providerId,
+        model: args.model,
+        ownerPrincipal: callerPrincipal,
+        wsStatus: wsResult.status,
+        turns: wsResult.turns ?? 0,
+        executedTools: wsResult.executedTools ?? 0,
+        completedAtIso: args.nowIso(),
+      });
+    }
+    // Every OTHER non-delivered case (denied, finished-but-missing-row, any error status) keeps
+    // TODAY's fail-closed 503 EXACTLY — body-free observability then the unchanged 503.
     logFailClosed(`readback_${readbackReceipt.outcome}`);
     throw failClosed();
   }

--- a/test/unit/api/runtime/friday-api-runtime-rust-route-compose.test.ts
+++ b/test/unit/api/runtime/friday-api-runtime-rust-route-compose.test.ts
@@ -158,6 +158,53 @@ function makeStubPausedWsClient() {
   return { service, calls };
 }
 
+/**
+ * (honest-non-finished) A scripted-stub sealed WS client that settles every dispatch with a
+ * caller-chosen loop `status` and NO answer refs (the refs-only result a NON-deliverable terminal
+ * carries). Used to drive the readback-not_found compose branch with a specific wire status.
+ */
+function makeStubStatusWsClient(status: string) {
+  const calls: FridayRustHubAgentRunSealedClientServiceRequest[] = [];
+  const service: FridayRustHubAgentRunSealedClientService = {
+    dispatchRun: vi.fn(async (request: FridayRustHubAgentRunSealedClientServiceRequest) => {
+      calls.push(request);
+      return {
+        truthLabel: "rust_wired" as const,
+        runId: request.runId,
+        status,
+        // A non-deliverable terminal carries NO answer refs (no sha / no len).
+      };
+    }),
+    resumeWithApproval: vi.fn(async () => {
+      throw new Error("resumeWithApproval not used by this status-dispatch test");
+    }),
+  };
+  return { service, calls };
+}
+
+/**
+ * (honest-non-finished) A stub readback that always returns the body-free `not_found` outcome —
+ * the LEGITIMATE outcome for a run whose Rust loop terminated NON-Finished (it skipped the persist
+ * guard, so no `run_result` row exists). Records each call so the path can be asserted.
+ */
+function makeNotFoundReadback() {
+  const calls: FridayRustHubRunAnswerReadbackInput[] = [];
+  const service: FridayRustHubRunAnswerReadbackService = {
+    readAnswer: vi.fn(
+      async (input: FridayRustHubRunAnswerReadbackInput): Promise<FridayRustHubRunAnswerReadbackReceipt> => {
+        calls.push(input);
+        return {
+          truthLabel: "rust_wired_dev",
+          proofOnly: true,
+          outcome: "not_found",
+          runId: input.runId,
+        };
+      },
+    ),
+  };
+  return { service, calls };
+}
+
 /** A stub readback that returns the owner-gated body to the matching owner principal. */
 function makeStubReadback(owner: string) {
   const calls: FridayRustHubRunAnswerReadbackInput[] = [];
@@ -388,6 +435,184 @@ describe("FridayApiRuntime — execrun S-F-compose (DARK) Rust-route composition
     );
     const parsedMetadata = JSON.parse(rowMetadata) as { apiRequest?: { principalId?: string } };
     expect(parsedMetadata.apiRequest?.principalId).toBe(OWNER_PRINCIPAL);
+  });
+
+  // ── (honest-non-finished) the readback_not_found 503 defect fix ──
+  //
+  // THE DEFECT: a run whose Rust loop terminated NON-Finished (Blocked/Errored/Bounded → the
+  // no-answer terminal) DELIBERATELY skips the Rust-side persist guard, so NO `run_result` row is
+  // written and the owner-gated body readback LEGITIMATELY returns `not_found`. Compose used to throw
+  // the `readback_not_found` 503 for that case — MISREPORTING an honest terminal settle as a
+  // transport failure (the hourly self-probe + S6 saw exactly this). THE FIX: a strict allowlist
+  // (not_found AND a non-Finished terminal wire status) projects an HONEST "failed" continuity row
+  // instead of the 503 — while EVERY other not-delivered case (denied, finished-but-missing-row, any
+  // error status) keeps today's 503 EXACTLY (no gate-weakening).
+
+  /** Read the projected continuity-row's stored loop-status label off `metadata_json`. */
+  function readProjectedLoopStatus(database: FridaySqliteLayer, runId: string): string | undefined {
+    const meta = database.withReadConnection((d) =>
+      (d.prepare("SELECT metadata_json FROM friday_agent_runs WHERE id = ?").get(runId) as
+        | { metadata_json: string | null }
+        | undefined)?.metadata_json ?? "{}",
+    );
+    return (JSON.parse(meta) as { rustContinuity?: { loopStatus?: string } }).rustContinuity?.loopStatus;
+  }
+
+  it("(nf-a) non-Finished wire status (no_answer_safe_failure) + readback not_found → NO 503; honest failed row, NO body", async () => {
+    db = createTestDb();
+    // The PRODUCTION wire value: a NON-deliverable terminal collapses to AuthedAnswer::NoAnswer →
+    // compose sees the `no_answer_safe_failure` status (the value the live server actually emits).
+    const ws = makeStubStatusWsClient("no_answer_safe_failure");
+    const readback = makeNotFoundReadback();
+    const runtime = makeRuntime(db, {
+      routeAgentRunViaRust: true,
+      wsClient: ws.service,
+      readback: readback.service,
+    });
+
+    const result = (await callStartRoute(runtime, { ...QUALIFYING_BODY })) as {
+      runId: string;
+      response: string;
+      finalResponse?: string;
+      status: string;
+      toolCallCount: number;
+    };
+
+    // The dispatch ran AND the readback ran (not_found is a real read, not a skip).
+    expect(ws.calls).toHaveLength(1);
+    expect(readback.calls).toHaveLength(1);
+
+    // NO 503: the honest non-Finished terminal is surfaced as the projector's "failed" status —
+    // NEVER "completed", NEVER "cancelled" (cancelled is the resumable Paused mapping; this is not).
+    expect(result.status).toBe("failed");
+    // NO fabricated body — the response is empty and the route omits the empty finalResponse.
+    expect(result.response).toBe("");
+    expect(result.finalResponse).toBeUndefined();
+    expect(result.toolCallCount).toBe(0);
+
+    // Exactly ONE continuity row, mapped to the failed status with the Errored loop-status label.
+    expect(countRows(db, "friday_agent_runs", RUN_ID)).toBe(1);
+    const rowStatus = db.withReadConnection((d) =>
+      (d.prepare("SELECT status FROM friday_agent_runs WHERE id = ?").get(RUN_ID) as { status: string }).status,
+    );
+    expect(rowStatus).toBe("failed");
+    expect(readProjectedLoopStatus(db, RUN_ID)).toBe("Errored");
+
+    // REFS-ONLY: the row stores an empty-body ref (len 0) — NEVER the owner body.
+    const rowResponse = db.withReadConnection((d) =>
+      (d.prepare("SELECT response_text FROM friday_agent_runs WHERE id = ?").get(RUN_ID) as
+        | { response_text: string | null }
+        | undefined)?.response_text ?? "",
+    );
+    expect(rowResponse).toContain("rust-run-body-ref:");
+    expect(rowResponse).toContain("len=0");
+    expect(rowResponse).not.toBe(OWNER_BODY);
+
+    // The owner is stamped so the row is owner-scoped for the read routes (a ref, never a body).
+    const rowMetadata = db.withReadConnection((d) =>
+      (d.prepare("SELECT metadata_json FROM friday_agent_runs WHERE id = ?").get(RUN_ID) as
+        | { metadata_json: string | null }
+        | undefined)?.metadata_json ?? "{}",
+    );
+    expect((JSON.parse(rowMetadata) as { apiRequest?: { principalId?: string } }).apiRequest?.principalId).toBe(
+      OWNER_PRINCIPAL,
+    );
+  });
+
+  it("(nf-b) the task's case — wire status \"blocked\" + readback not_found → NO 503; honest failed row", async () => {
+    db = createTestDb();
+    // A raw loop-status token a server MIGHT surface directly (the allowlist admits it too).
+    const ws = makeStubStatusWsClient("blocked");
+    const readback = makeNotFoundReadback();
+    const runtime = makeRuntime(db, {
+      routeAgentRunViaRust: true,
+      wsClient: ws.service,
+      readback: readback.service,
+    });
+
+    const result = (await callStartRoute(runtime, { ...QUALIFYING_BODY })) as { status: string; response: string };
+
+    expect(ws.calls).toHaveLength(1);
+    expect(readback.calls).toHaveLength(1);
+    expect(result.status).toBe("failed");
+    expect(result.response).toBe("");
+    expect(countRows(db, "friday_agent_runs", RUN_ID)).toBe(1);
+    // A RAW loop-status token keeps its FAITHFUL capitalized label in metadata — but the
+    // product-visible status is STILL "failed" (mapLoopStatusToTsStatus maps Blocked → failed).
+    expect(readProjectedLoopStatus(db, RUN_ID)).toBe("Blocked");
+  });
+
+  it("(nf-c) Case A — wire status \"finished\" + readback not_found → STILL 503 (a finished run's missing row is a REAL failure; gate preserved)", async () => {
+    db = createTestDb();
+    // status "finished" ⇒ a body SHOULD exist; a missing row is a genuine readback failure → 503.
+    const ws = makeStubStatusWsClient("finished");
+    const readback = makeNotFoundReadback();
+    const runtime = makeRuntime(db, {
+      routeAgentRunViaRust: true,
+      wsClient: ws.service,
+      readback: readback.service,
+    });
+
+    await expect(callStartRoute(runtime, { ...QUALIFYING_BODY })).rejects.toMatchObject({
+      code: "TS_RUNTIME_AGENT_RUNS_RETIRED",
+      httpStatus: 503,
+    });
+    // The dispatch + readback both ran, and NO honest row was projected — the 503 is preserved.
+    expect(ws.calls).toHaveLength(1);
+    expect(readback.calls).toHaveLength(1);
+    expect(countRows(db, "friday_agent_runs", RUN_ID)).toBe(0);
+  });
+
+  it("(nf-d) no-weakening guard — an ERROR wire status (storage_failed) + not_found → STILL 503 (not an honest terminal)", async () => {
+    db = createTestDb();
+    // An ERROR status is NOT in the non-Finished-terminal allowlist → it must fall through to the
+    // unchanged 503. This is the strongest no-gate-weakening proof: a real storage failure (which
+    // could otherwise leak through a naive binary as a "failed" row) still fails closed.
+    const ws = makeStubStatusWsClient("storage_failed");
+    const readback = makeNotFoundReadback();
+    const runtime = makeRuntime(db, {
+      routeAgentRunViaRust: true,
+      wsClient: ws.service,
+      readback: readback.service,
+    });
+
+    await expect(callStartRoute(runtime, { ...QUALIFYING_BODY })).rejects.toMatchObject({
+      code: "TS_RUNTIME_AGENT_RUNS_RETIRED",
+      httpStatus: 503,
+    });
+    expect(ws.calls).toHaveLength(1);
+    expect(readback.calls).toHaveLength(1);
+    expect(countRows(db, "friday_agent_runs", RUN_ID)).toBe(0);
+  });
+
+  it("(nf-e) no-weakening guard — a DENIED ownership refusal (even with a non-Finished status) → STILL 503", async () => {
+    db = createTestDb();
+    // `denied` is an OWNERSHIP-GATE refusal — it MUST stay 503 even if the loop status is a
+    // non-Finished terminal. Only `not_found` (a genuinely missing row) is the honest-terminal signal.
+    const ws = makeStubStatusWsClient("no_answer_safe_failure");
+    const deniedReadback: FridayRustHubRunAnswerReadbackService = {
+      readAnswer: vi.fn(
+        async (input: FridayRustHubRunAnswerReadbackInput): Promise<FridayRustHubRunAnswerReadbackReceipt> => ({
+          truthLabel: "rust_wired_dev",
+          proofOnly: true,
+          outcome: "denied",
+          runId: input.runId,
+          denyReason: "principal_mismatch",
+        }),
+      ),
+    };
+    const runtime = makeRuntime(db, {
+      routeAgentRunViaRust: true,
+      wsClient: ws.service,
+      readback: deniedReadback,
+    });
+
+    await expect(callStartRoute(runtime, { ...QUALIFYING_BODY })).rejects.toMatchObject({
+      code: "TS_RUNTIME_AGENT_RUNS_RETIRED",
+      httpStatus: 503,
+    });
+    expect(ws.calls).toHaveLength(1);
+    expect(countRows(db, "friday_agent_runs", RUN_ID)).toBe(0);
   });
 
   it("(b) flag OFF (default) → byte-identical 503; the WS path is NEVER touched", async () => {


### PR DESCRIPTION
## Root cause

In `composeRustReadOnlyAgentRun` (`src/api/runtime/friday-api-runtime.ts`), the owner-gated answer readback's `outcome !== "delivered"` branch ALWAYS threw `failClosed()` → 503 `readback_not_found`.

But a run whose Rust loop terminates **NON-Finished** (LoopStatus Blocked / Errored / Bounded, or fail-closed-to-no-answer) **deliberately skips the Rust-side persist guard** (`if outcome.status == Finished { persist_run_result }` in the hub runtime). No `run_result` row is ever written, so the owner-gated body readback **legitimately** returns `not_found` — there was never an answer to store. Throwing the 503 for that case **misreports an honest terminal settle as a transport/storage failure**. This hit the hourly self-probe and S6.

The dispatch loop-status label (`wsResult.status`) is already in scope at the readback decision point.

## The fix — Case-A / Case-B split (no gate-weakening)

At the `outcome !== "delivered"` branch we now carve out **only** the honest non-Finished terminal case with a **strict allowlist**, and otherwise keep today's 503 exactly:

- **Case B — honest non-Finished terminal (NO 503):** `outcome === "not_found"` **AND** `wsResult.status ∈ { no_answer_safe_failure, no_answer, blocked, bounded, errored }`. The wire collapses Blocked/Errored/Bounded/no-answer into one label (`AuthedAnswer::NoAnswer`'s `proof_refs_json` carries no `status` key → the agent-run server falls back to the `outcome`, so compose actually sees `"no_answer_safe_failure"` for all non-Finished/no-body terminals; the raw loop-status tokens are admitted too). We project an HONEST refs-only continuity row via the **same write-transaction + projector pattern the Paused branch uses**, mapped to `loopStatus:"Errored"` → the projector's terminal **"failed"** status (never `"Paused"`/`"cancelled"` — a no-answer terminal is not resumable). Refs-only: empty body ref (empty-string sha sentinel + `len 0`), empty response — **never a fabricated answer body**. Owner is stamped so the row is owner-scoped for the read routes. We deliberately do **not** stamp the apiRequest idempotency descriptor (a failed/no-answer run must not replay on a retry).

- **Case A — genuine error (KEEP 503):** every other non-delivered case falls through to the unchanged `logFailClosed()` + `throw failClosed()`:
  - `wsResult.status === "finished"` + `not_found` → a finished run **should** have a row, so a missing row is a real failure → **still 503**.
  - `outcome === "denied"` (an ownership-gate refusal) → **still 503** even with a non-Finished status.
  - any error status (`storage_failed` / `auth_failed` / `operator_vk_unprovisioned`) → not in the allowlist → **still 503**.

### No-degrade argument

The carve-out is a strict allowlist requiring **both** conjuncts; everything else defaults to today's fail-closed 503. A finished run with a missing row still 503s; `denied` still 503s; any storage/auth error still 503s. We never fabricate an answer body. The read-only delivered path and the Paused path are untouched.

## KAT (colocated, `friday-api-runtime-rust-route-compose.test.ts`)

- `(nf-a)` `no_answer_safe_failure` (the value the live wire emits) + `not_found` → **NO 503**; status `"failed"`, one continuity row with `loopStatus "Errored"`, empty body ref `len=0`, no body, owner stamped.
- `(nf-b)` `blocked` + `not_found` → same (the task's named case).
- `(nf-c)` Case A: `finished` + `not_found` → **STILL 503**, no row.
- `(nf-d)` no-weakening: `storage_failed` + `not_found` → **STILL 503**, no row.
- `(nf-e)` no-weakening: `denied` (with a non-Finished status) → **STILL 503**, no row.

## Constraints / hygiene

- **TS-only**: touches only the compose source + its colocated test. No Rust, no other hot files.
- Born-current on `origin/main` `70b458ca`.
- Local green: `npm run lint` (0 errors), `npm run typecheck` (0 errors), `npm test` for this file (**34/34 pass**). Both `secrets`-job gates pass (detect-secrets-hook + provider-key-pattern denylist); the empty-string SHA constant is a public well-known hash with an allowlist marker.
- The honest-terminal projection is extracted to a module-level helper so the compose function stays under the per-function line limit.

## Deploy note

This changes **source only**. Making it live on prod needs a `dist` rebuild + hub restart — a **separate operator-gated deploy**, not attempted here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)