### PR TITLE
feat(mission-spine): organic POST routes (intake/lifecycle/work-item-status) via sealed-WS, flag-gated dark

### DIFF
--- a/src/api/http/routes/friday-mission-spine-routes.ts
+++ b/src/api/http/routes/friday-mission-spine-routes.ts
@@ -1,10 +1,19 @@
 import { FridayDomainError } from "#errors";
+import { assertBoundPrincipalForOperation } from "../../../security/friday-owner-session-channel-capability.js";
 import type { FridayRouteDefinition } from "../../model/friday-api-common.types.js";
 import type {
   FridayMissionSpineLifecycleState,
   FridayMissionSpineWorkbenchResponse,
   FridayMissionSpineWorkbenchSnapshot,
 } from "../../model/friday-api-mission-spine.types.js";
+import type {
+  FridayRustHubMissionIntakeRequest,
+  FridayRustHubMissionIntakeResult,
+  FridayRustHubMissionLifecycleRequest,
+  FridayRustHubMissionLifecycleResult,
+  FridayRustHubWorkItemStatusRequest,
+  FridayRustHubWorkItemStatusResult,
+} from "../../mission-spine/friday-rust-hub-agent-run-ws-sealed-client.js";
 
 export interface FridayMissionSpineWorkbenchProjectionInput {
   missionId?: string;
@@ -17,9 +26,48 @@ export interface FridayMissionSpineWorkbenchProjectionService {
   getSnapshot(input: FridayMissionSpineWorkbenchProjectionInput): Promise<FridayMissionSpineWorkbenchSnapshot>;
 }
 
+/**
+ * (Lane B) The ORGANIC mutation seam: a thin service that drives the (flag-gated) Rust sealed-WS
+ * dispatch arms for the three Hub-owned mission-spine mutations. The route handlers validate the
+ * body, then hand a typed request to this service, which seals + sends over the sealed-WS client
+ * and returns the refs-only result. When this service is `null` (the DEFAULT — the route flag is
+ * off / no client wired), the POST routes return honest-unavailable (503), byte-identical to the
+ * read route's unavailable path. PROVIDING it is what makes the routes LIVE — and live closure
+ * ALSO needs the SERVER flags (`FRIDAY_MISSION_INTAKE` for intake, `FRIDAY_MISSION_SPINE_DISPATCH`
+ * for lifecycle/work-item), which are a separate operator-gated flip.
+ */
+export interface FridayMissionSpineDispatchService {
+  intakeMission(request: FridayRustHubMissionIntakeRequest): Promise<FridayRustHubMissionIntakeResult>;
+  transitionMission(
+    request: FridayRustHubMissionLifecycleRequest,
+  ): Promise<FridayRustHubMissionLifecycleResult>;
+  transitionWorkItem(
+    request: FridayRustHubWorkItemStatusRequest,
+  ): Promise<FridayRustHubWorkItemStatusResult>;
+}
+
 export interface FridayMissionSpineRoutesDeps {
   readonly workbench: FridayMissionSpineWorkbenchProjectionService | null;
+  /**
+   * (Lane B) The organic mutation dispatcher, DEFAULT-OFF (`null`). `null` ⇒ the three POST routes
+   * are honest-unavailable (503); a real adapter ⇒ they seal + dispatch over the sealed-WS client.
+   * Adding the routes with this `null` is byte-identical to today for existing traffic.
+   */
+  readonly dispatch?: FridayMissionSpineDispatchService | null;
+  /** (Lane B) Optional reason for the dispatch-unavailable 503; falls back to a default message. */
+  readonly dispatchDisabledReason?: string | null;
   readonly disabledReason: string | null;
+}
+
+/** (Lane B) Response envelope for each organic mutation route — refs-only result passthrough. */
+export interface FridayMissionSpineIntakeResponse {
+  readonly result: FridayRustHubMissionIntakeResult;
+}
+export interface FridayMissionSpineLifecycleResponse {
+  readonly result: FridayRustHubMissionLifecycleResult;
+}
+export interface FridayMissionSpineWorkItemStatusResponse {
+  readonly result: FridayRustHubWorkItemStatusResult;
 }
 
 const DEFAULT_DISABLED_MESSAGE =
@@ -85,6 +133,200 @@ function readMissionId(query: unknown): string | undefined {
   if (typeof value !== "string") return undefined;
   const trimmed = value.trim();
   return trimmed.length > 0 ? trimmed : undefined;
+}
+
+// ─── (Lane B) Organic mutation body validation ──────────────────────────────
+
+const DEFAULT_DISPATCH_DISABLED_MESSAGE =
+  "Mission Spine organic mutation dispatch is unavailable in this runtime; the Rust Hub sealed-WS dispatch seam has not been wired.";
+
+/** Throw a typed 400 for an invalid organic-mutation body. Never echoes the raw body. */
+function throwInvalidBody(surface: string, failures: readonly string[]): never {
+  throw new FridayDomainError(
+    "MISSION_SPINE_DISPATCH_REQUEST_INVALID",
+    "Mission Spine organic mutation request body did not satisfy the dispatch contract.",
+    {
+      httpStatus: 400,
+      details: { surface, failures },
+    },
+  );
+}
+
+function asBody(body: unknown): Record<string, unknown> {
+  return body && typeof body === "object" && !Array.isArray(body) ? (body as Record<string, unknown>) : {};
+}
+
+/** A required, trimmed, non-empty string field — or `undefined` (pushes a failure code). */
+function readRequiredString(
+  body: Record<string, unknown>,
+  field: string,
+  failures: string[],
+): string | undefined {
+  const value = body[field];
+  if (typeof value !== "string" || value.trim().length === 0) {
+    failures.push(`${field}_missing_or_empty`);
+    return undefined;
+  }
+  return value.trim();
+}
+
+/** An optional, trimmed, non-empty string field — or `undefined` (a present-but-non-string is a failure). */
+function readOptionalString(
+  body: Record<string, unknown>,
+  field: string,
+  failures: string[],
+): string | undefined {
+  const value = body[field];
+  if (value === undefined || value === null) return undefined;
+  if (typeof value !== "string" || value.trim().length === 0) {
+    failures.push(`${field}_invalid`);
+    return undefined;
+  }
+  return value.trim();
+}
+
+function readOptionalBoolean(
+  body: Record<string, unknown>,
+  field: string,
+  failures: string[],
+): boolean | undefined {
+  const value = body[field];
+  if (value === undefined || value === null) return undefined;
+  if (typeof value !== "boolean") {
+    failures.push(`${field}_invalid`);
+    return undefined;
+  }
+  return value;
+}
+
+const WORK_ITEM_COMPLETED_WITH_PROOF = "completed_with_proof";
+
+/** Validate a Mission intake body into the typed request (or throw a typed 400). */
+function validateIntakeBody(body: unknown): FridayRustHubMissionIntakeRequest {
+  const surface = "api:/v1/mission-spine/intake";
+  const b = asBody(body);
+  const failures: string[] = [];
+  const fridayConversationId = readRequiredString(b, "fridayConversationId", failures);
+  const ownerPrincipal = readRequiredString(b, "ownerPrincipal", failures);
+  const surfaceThreadId = readRequiredString(b, "surfaceThreadId", failures);
+  const surfaceKind = readRequiredString(b, "surfaceKind", failures);
+  const deliveryRoute = readRequiredString(b, "deliveryRoute", failures);
+  const visibilityPolicy = readRequiredString(b, "visibilityPolicy", failures);
+  const missionId = readRequiredString(b, "missionId", failures);
+  const workItemId = readRequiredString(b, "workItemId", failures);
+  const title = readRequiredString(b, "title", failures);
+  const intent = readRequiredString(b, "intent", failures);
+  const lane = readRequiredString(b, "lane", failures);
+  const targetProviderOrAgent = readOptionalString(b, "targetProviderOrAgent", failures);
+  const capabilityId = readOptionalString(b, "capabilityId", failures);
+  const bodyRef = readOptionalString(b, "bodyRef", failures);
+  const includesSensitiveContext = readOptionalBoolean(b, "includesSensitiveContext", failures);
+  if (
+    failures.length > 0 ||
+    fridayConversationId === undefined ||
+    ownerPrincipal === undefined ||
+    surfaceThreadId === undefined ||
+    surfaceKind === undefined ||
+    deliveryRoute === undefined ||
+    visibilityPolicy === undefined ||
+    missionId === undefined ||
+    workItemId === undefined ||
+    title === undefined ||
+    intent === undefined ||
+    lane === undefined
+  ) {
+    throwInvalidBody(surface, failures);
+  }
+  return {
+    fridayConversationId,
+    ownerPrincipal,
+    surfaceThreadId,
+    surfaceKind,
+    deliveryRoute,
+    visibilityPolicy,
+    missionId,
+    workItemId,
+    title,
+    intent,
+    lane,
+    ...(targetProviderOrAgent !== undefined ? { targetProviderOrAgent } : {}),
+    ...(capabilityId !== undefined ? { capabilityId } : {}),
+    ...(bodyRef !== undefined ? { bodyRef } : {}),
+    ...(includesSensitiveContext !== undefined ? { includesSensitiveContext } : {}),
+  };
+}
+
+/** Validate a Mission lifecycle body + path missionId into the typed request (or throw a typed 400). */
+function validateLifecycleBody(missionId: string, body: unknown): FridayRustHubMissionLifecycleRequest {
+  const surface = "api:/v1/mission-spine/:missionId/lifecycle";
+  const b = asBody(body);
+  const failures: string[] = [];
+  const trimmedMissionId = typeof missionId === "string" ? missionId.trim() : "";
+  if (trimmedMissionId.length === 0) failures.push("missionId_missing_or_empty");
+  const fridayConversationId = readRequiredString(b, "fridayConversationId", failures);
+  const targetStatus = readRequiredString(b, "targetStatus", failures);
+  const actorRef = readRequiredString(b, "actorRef", failures);
+  const reason = readRequiredString(b, "reason", failures);
+  const proofRef = readOptionalString(b, "proofRef", failures);
+  const mergedIntoMissionId = readOptionalString(b, "mergedIntoMissionId", failures);
+  if (
+    failures.length > 0 ||
+    fridayConversationId === undefined ||
+    targetStatus === undefined ||
+    actorRef === undefined ||
+    reason === undefined
+  ) {
+    throwInvalidBody(surface, failures);
+  }
+  return {
+    fridayConversationId,
+    missionId: trimmedMissionId,
+    targetStatus,
+    actorRef,
+    reason,
+    ...(proofRef !== undefined ? { proofRef } : {}),
+    ...(mergedIntoMissionId !== undefined ? { mergedIntoMissionId } : {}),
+  };
+}
+
+/** Validate a WorkItem status body + path workItemId into the typed request (or throw a typed 400). */
+function validateWorkItemStatusBody(workItemId: string, body: unknown): FridayRustHubWorkItemStatusRequest {
+  const surface = "api:/v1/mission-spine/work-items/:workItemId/status";
+  const b = asBody(body);
+  const failures: string[] = [];
+  const trimmedWorkItemId = typeof workItemId === "string" ? workItemId.trim() : "";
+  if (trimmedWorkItemId.length === 0) failures.push("workItemId_missing_or_empty");
+  const targetStatus = readRequiredString(b, "targetStatus", failures);
+  const actorRef = readRequiredString(b, "actorRef", failures);
+  const reason = readRequiredString(b, "reason", failures);
+  const proofReceipt = readOptionalString(b, "proofReceipt", failures);
+  // Mirror the SERVER proof-on-completion invariant at the edge so a proofless completion is a
+  // typed 400 here (the Rust persistence boundary ALSO rejects it as the load-bearing guard; this
+  // is a fail-fast convenience, NOT a replacement for the server enforcement).
+  if (targetStatus === WORK_ITEM_COMPLETED_WITH_PROOF && proofReceipt === undefined) {
+    failures.push("proof_receipt_required_for_completion");
+  }
+  if (
+    failures.length > 0 ||
+    targetStatus === undefined ||
+    actorRef === undefined ||
+    reason === undefined
+  ) {
+    throwInvalidBody(surface, failures);
+  }
+  return {
+    workItemId: trimmedWorkItemId,
+    targetStatus,
+    actorRef,
+    reason,
+    ...(proofReceipt !== undefined ? { proofReceipt } : {}),
+  };
+}
+
+function readPathParam(params: unknown, key: string): string {
+  if (!params || typeof params !== "object") return "";
+  const value = (params as Record<string, unknown>)[key];
+  return typeof value === "string" ? value : "";
 }
 
 function hasText(value: string | undefined): boolean {
@@ -361,6 +603,28 @@ export function createFridayMissionSpineRoutes(
     );
   }
 
+  // (Lane B) DEFAULT-OFF: `deps.dispatch` is null/undefined unless an adapter is wired, so each
+  // POST route is honest-unavailable (503) by default — byte-identical to today for existing
+  // traffic (a new route that's flag-OFF never alters any existing route's behavior).
+  const dispatch = deps.dispatch ?? null;
+
+  function dispatchDisabledMessage(): string {
+    return deps.dispatchDisabledReason && deps.dispatchDisabledReason.trim().length > 0
+      ? deps.dispatchDisabledReason
+      : DEFAULT_DISPATCH_DISABLED_MESSAGE;
+  }
+
+  function throwDispatchDisabled(surface: string): never {
+    throw new FridayDomainError(
+      "MISSION_SPINE_DISPATCH_UNAVAILABLE",
+      dispatchDisabledMessage(),
+      {
+        httpStatus: 503,
+        details: { surface, dispatch: "rust_hub_unavailable", proofReady: false },
+      },
+    );
+  }
+
   return [
     {
       operationId: "mission.spine.workbench.get",
@@ -383,6 +647,63 @@ export function createFridayMissionSpineRoutes(
           throwInvalidSnapshot(failures);
         }
         return { snapshot };
+      },
+    },
+    // (Lane B) ORGANIC MISSION INTAKE — POST. Order of guards: (1) dispatch-disabled (flag-OFF)
+    // → 503 FIRST regardless of caller, so a flag-OFF route is a uniform honest-unavailable;
+    // (2) bound-principal (refuse the synthetic public principal) → 401; (3) body validation
+    // → 400; (4) seal + dispatch over the sealed-WS client. Refs-only result passthrough.
+    {
+      operationId: "mission.spine.intake.create",
+      method: "POST",
+      path: "/v1/mission-spine/intake",
+      auth: { public: true },
+      async handler(ctx): Promise<FridayMissionSpineIntakeResponse> {
+        if (!dispatch) {
+          throwDispatchDisabled("api:/v1/mission-spine/intake");
+        }
+        assertBoundPrincipalForOperation(ctx.principal ?? null, "mission.spine.intake", "api");
+        const request = validateIntakeBody(ctx.body);
+        const result = await dispatch.intakeMission(request);
+        return { result };
+      },
+    },
+    // (Lane B) ORGANIC MISSION LIFECYCLE — POST. Same guard order; the canonical missionId rides
+    // the path. A `status` in the result is a Mission-management fact, not provider completion.
+    {
+      operationId: "mission.spine.lifecycle.transition",
+      method: "POST",
+      path: "/v1/mission-spine/:missionId/lifecycle",
+      auth: { public: true },
+      async handler(ctx): Promise<FridayMissionSpineLifecycleResponse> {
+        if (!dispatch) {
+          throwDispatchDisabled("api:/v1/mission-spine/:missionId/lifecycle");
+        }
+        assertBoundPrincipalForOperation(ctx.principal ?? null, "mission.spine.lifecycle", "api");
+        const missionId = readPathParam(ctx.params, "missionId");
+        const request = validateLifecycleBody(missionId, ctx.body);
+        const result = await dispatch.transitionMission(request);
+        return { result };
+      },
+    },
+    // (Lane B) ORGANIC WORK-ITEM STATUS — POST. Same guard order; the workItemId rides the path
+    // and the optional `proofReceipt` is a passthrough. Proof-on-completion is ENFORCED SERVER-
+    // side (a proofless `completed_with_proof` is a typed `Error` ⇒ the client fails closed); the
+    // edge validation rejects it as a 400 as a fail-fast convenience, never the load-bearing guard.
+    {
+      operationId: "mission.spine.workitem.status.transition",
+      method: "POST",
+      path: "/v1/mission-spine/work-items/:workItemId/status",
+      auth: { public: true },
+      async handler(ctx): Promise<FridayMissionSpineWorkItemStatusResponse> {
+        if (!dispatch) {
+          throwDispatchDisabled("api:/v1/mission-spine/work-items/:workItemId/status");
+        }
+        assertBoundPrincipalForOperation(ctx.principal ?? null, "mission.spine.workitem.status", "api");
+        const workItemId = readPathParam(ctx.params, "workItemId");
+        const request = validateWorkItemStatusBody(workItemId, ctx.body);
+        const result = await dispatch.transitionWorkItem(request);
+        return { result };
       },
     },
   ];

--- a/src/api/mission-spine/friday-rust-hub-agent-run-ws-sealed-client.ts
+++ b/src/api/mission-spine/friday-rust-hub-agent-run-ws-sealed-client.ts
@@ -740,8 +740,16 @@ export function buildResumeEnvelope(
 
 /**
  * (Lane B) Wrap a built inner message in the standard Envelope shape (mirrors the dispatch +
- * resume envelopes). `msgId`/`correlationId` are derived from a stable per-request key so the
+ * resume envelopes). `msgId`/`correlationId` are derived from a stable per-entity key so the
  * server's `with_correlation(msg_id)` round-trips deterministically.
+ *
+ * **msg_id collision is a NON-ISSUE here (verified):** each mission call (`runMissionRoundTrip`)
+ * opens a FRESH sealed session and sends EXACTLY ONE envelope. The server's `IdempotencyTracker`
+ * is constructed FRESH per connection (`serve_sealed_session` stack-local, `hub_agent_run_server`),
+ * so it only dedupes WITHIN a session — it never sees a second envelope on the same session. A
+ * stable per-entity key therefore cannot be misread as a within-session replay even when the same
+ * mission/work-item transitions repeatedly (each transition is its own connection). No per-call
+ * suffix is needed; cross-handshake replay is defeated by the per-handshake `session_nonce`.
  */
 function buildMissionEnvelope(key: string, message: Record<string, unknown>): Record<string, unknown> {
   return {
@@ -764,8 +772,13 @@ function buildMissionEnvelope(key: string, message: Record<string, unknown>): Re
 export function buildMissionIntakeEnvelope(
   request: FridayRustHubMissionIntakeRequest,
 ): Record<string, unknown> {
-  const message: Record<string, unknown> = {
-    kind: "MissionIntakeRequest",
+  // WIRE NESTING (HOLE-1 fix): `Message::MissionIntakeRequest { request: MissionIntakeRequestWire }`
+  // is a SINGLE-FIELD wrapper, and `Message` is `#[serde(tag = "kind")]` (internally tagged). serde
+  // therefore emits the inner wire fields NESTED under a `request` key, NOT flat under `message`:
+  //   {"kind":"MissionIntakeRequest","request":{ …fields… }}
+  // The pre-fix flat shape failed `Envelope::decode` server-side (missing `request` key) ⇒ 503. The
+  // byte-exact nesting is pinned by the Rust-emitted golden cross-check in the wire test.
+  const inner: Record<string, unknown> = {
     friday_conversation_id: request.fridayConversationId,
     owner_principal: request.ownerPrincipal,
     surface_thread_id: request.surfaceThreadId,
@@ -782,9 +795,15 @@ export function buildMissionIntakeEnvelope(
       : {}),
     ...(request.capabilityId !== undefined ? { capability_id: request.capabilityId } : {}),
     ...(request.bodyRef !== undefined ? { body_ref: request.bodyRef } : {}),
+    // `includes_sensitive_context` is `#[serde(default)]` WITHOUT `skip_serializing_if` Rust-side,
+    // so an absent key deserializes to `false` (interop-safe). We OMIT it when false to keep the
+    // outbound minimal; serde's `default` accepts the omission. We only EMIT it when true.
     ...(request.includesSensitiveContext === true ? { includes_sensitive_context: true } : {}),
   };
-  return buildMissionEnvelope(`mission-intake-${request.missionId}`, message);
+  return buildMissionEnvelope(`mission-intake-${request.missionId}`, {
+    kind: "MissionIntakeRequest",
+    request: inner,
+  });
 }
 
 /**
@@ -795,8 +814,9 @@ export function buildMissionIntakeEnvelope(
 export function buildMissionLifecycleEnvelope(
   request: FridayRustHubMissionLifecycleRequest,
 ): Record<string, unknown> {
-  const message: Record<string, unknown> = {
-    kind: "MissionLifecycleRequest",
+  // WIRE NESTING (HOLE-1 fix): inner fields nest under `request` (single-field wrapper +
+  // internally-tagged `Message`); see {@link buildMissionIntakeEnvelope}.
+  const inner: Record<string, unknown> = {
     friday_conversation_id: request.fridayConversationId,
     mission_id: request.missionId,
     target_status: request.targetStatus,
@@ -807,7 +827,10 @@ export function buildMissionLifecycleEnvelope(
       ? { merged_into_mission_id: request.mergedIntoMissionId }
       : {}),
   };
-  return buildMissionEnvelope(`mission-lifecycle-${request.missionId}`, message);
+  return buildMissionEnvelope(`mission-lifecycle-${request.missionId}`, {
+    kind: "MissionLifecycleRequest",
+    request: inner,
+  });
 }
 
 /**
@@ -819,15 +842,19 @@ export function buildMissionLifecycleEnvelope(
 export function buildWorkItemStatusEnvelope(
   request: FridayRustHubWorkItemStatusRequest,
 ): Record<string, unknown> {
-  const message: Record<string, unknown> = {
-    kind: "WorkItemStatusRequest",
+  // WIRE NESTING (HOLE-1 fix): inner fields nest under `request` (single-field wrapper +
+  // internally-tagged `Message`); see {@link buildMissionIntakeEnvelope}.
+  const inner: Record<string, unknown> = {
     work_item_id: request.workItemId,
     target_status: request.targetStatus,
     actor_ref: request.actorRef,
     reason: request.reason,
     ...(request.proofReceipt !== undefined ? { proof_receipt: request.proofReceipt } : {}),
   };
-  return buildMissionEnvelope(`work-item-status-${request.workItemId}`, message);
+  return buildMissionEnvelope(`work-item-status-${request.workItemId}`, {
+    kind: "WorkItemStatusRequest",
+    request: inner,
+  });
 }
 
 /**
@@ -838,12 +865,17 @@ export function buildWorkItemStatusEnvelope(
 export function parseMissionIntakeResult(
   fields: Record<string, unknown>,
 ): FridayRustHubMissionIntakeResult | undefined {
-  const fridayConversationId = asString(fields.friday_conversation_id);
-  const missionId = asString(fields.mission_id);
-  const surfaceThreadId = asString(fields.surface_thread_id);
-  const status = asString(fields.status);
-  const blockers = fields.blockers;
-  const createdOrReady = fields.created_or_ready;
+  // HOLE-1 fix: the refs live NESTED under `result` (single-field wrapper); unwrap fail-closed.
+  const r = unwrapResult(fields);
+  if (r === undefined) {
+    return undefined;
+  }
+  const fridayConversationId = asString(r.friday_conversation_id);
+  const missionId = asString(r.mission_id);
+  const surfaceThreadId = asString(r.surface_thread_id);
+  const status = asString(r.status);
+  const blockers = r.blockers;
+  const createdOrReady = r.created_or_ready;
   if (
     !fridayConversationId ||
     !missionId ||
@@ -855,10 +887,13 @@ export function parseMissionIntakeResult(
   ) {
     return undefined;
   }
-  const workItemId = asString(fields.work_item_id);
-  const duplicateMissionId = asString(fields.duplicate_mission_id);
-  const duplicateWorkItemId = asString(fields.duplicate_work_item_id);
+  const workItemId = asString(r.work_item_id);
+  const duplicateMissionId = asString(r.duplicate_mission_id);
+  const duplicateWorkItemId = asString(r.duplicate_work_item_id);
   return {
+    // `MissionIntakeResultWire` carries NO `truth_label` field (verified in friday-protocol), so the
+    // server cannot send one — this `rust_wired` label is the TS-side ceiling for a Rust-served refs
+    // result, asserted by construction (not read from the wire). It confers no v1 GO.
     truthLabel: "rust_wired",
     fridayConversationId,
     missionId,
@@ -879,14 +914,19 @@ export function parseMissionIntakeResult(
 export function parseMissionLifecycleResult(
   fields: Record<string, unknown>,
 ): FridayRustHubMissionLifecycleResult | undefined {
-  const fridayConversationId = asString(fields.friday_conversation_id);
-  const missionId = asString(fields.mission_id);
-  const previousStatus = asString(fields.previous_status);
-  const status = asString(fields.status);
-  const actorRef = asString(fields.actor_ref);
-  const reason = asString(fields.reason);
-  const activeMissionIds = fields.active_mission_ids;
-  const updatedAtMs = asNumber(fields.updated_at_ms);
+  // HOLE-1 fix: the refs live NESTED under `result` (single-field wrapper); unwrap fail-closed.
+  const r = unwrapResult(fields);
+  if (r === undefined) {
+    return undefined;
+  }
+  const fridayConversationId = asString(r.friday_conversation_id);
+  const missionId = asString(r.mission_id);
+  const previousStatus = asString(r.previous_status);
+  const status = asString(r.status);
+  const actorRef = asString(r.actor_ref);
+  const reason = asString(r.reason);
+  const activeMissionIds = r.active_mission_ids;
+  const updatedAtMs = asNumber(r.updated_at_ms);
   if (
     !fridayConversationId ||
     !missionId ||
@@ -900,9 +940,10 @@ export function parseMissionLifecycleResult(
   ) {
     return undefined;
   }
-  const proofRef = asString(fields.proof_ref);
-  const mergedIntoMissionId = asString(fields.merged_into_mission_id);
+  const proofRef = asString(r.proof_ref);
+  const mergedIntoMissionId = asString(r.merged_into_mission_id);
   return {
+    // No `truth_label` on `MissionLifecycleResultWire`; TS-side ceiling label (see intake parser).
     truthLabel: "rust_wired",
     fridayConversationId,
     missionId,
@@ -925,14 +966,19 @@ export function parseMissionLifecycleResult(
 export function parseWorkItemStatusResult(
   fields: Record<string, unknown>,
 ): FridayRustHubWorkItemStatusResult | undefined {
-  const workItemId = asString(fields.work_item_id);
-  const missionId = asString(fields.mission_id);
-  const previousStatus = asString(fields.previous_status);
-  const status = asString(fields.status);
-  const actorRef = asString(fields.actor_ref);
-  const reason = asString(fields.reason);
-  const proofReceiptCount = asNumber(fields.proof_receipt_count);
-  const updatedAtMs = asNumber(fields.updated_at_ms);
+  // HOLE-1 fix: the refs live NESTED under `result` (single-field wrapper); unwrap fail-closed.
+  const r = unwrapResult(fields);
+  if (r === undefined) {
+    return undefined;
+  }
+  const workItemId = asString(r.work_item_id);
+  const missionId = asString(r.mission_id);
+  const previousStatus = asString(r.previous_status);
+  const status = asString(r.status);
+  const actorRef = asString(r.actor_ref);
+  const reason = asString(r.reason);
+  const proofReceiptCount = asNumber(r.proof_receipt_count);
+  const updatedAtMs = asNumber(r.updated_at_ms);
   if (
     !workItemId ||
     !missionId ||
@@ -946,6 +992,7 @@ export function parseWorkItemStatusResult(
     return undefined;
   }
   return {
+    // No `truth_label` on `WorkItemStatusResultWire`; TS-side ceiling label (see intake parser).
     truthLabel: "rust_wired",
     workItemId,
     missionId,
@@ -977,6 +1024,23 @@ function asString(value: unknown): string | undefined {
 }
 function asNumber(value: unknown): number | undefined {
   return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+/**
+ * (Lane B, HOLE-1 fix) Unwrap the NESTED `result` sub-object from a mission `*Result` inbound's
+ * fields. `Message::Mission*Result { result: …Wire }` is a SINGLE-FIELD wrapper on an internally-
+ * tagged (`#[serde(tag = "kind")]`) enum, so the wire nests the result fields under a `result` key:
+ *   {"kind":"Mission*Result","result":{ …refs… }}
+ * The `inbound.fields` handed to a parser is the whole `message` object (`{kind, result:{…}}`), NOT
+ * the inner refs. Returns `undefined` (caller fails closed 503) when `result` is missing/ill-typed —
+ * this MUST not throw, because `parse()` runs OUTSIDE the inbound try/catch in `runMissionRoundTrip`.
+ */
+function unwrapResult(fields: Record<string, unknown>): Record<string, unknown> | undefined {
+  const result = fields.result;
+  if (!result || typeof result !== "object" || Array.isArray(result)) {
+    return undefined;
+  }
+  return result as Record<string, unknown>;
 }
 
 /** The refs accumulated from the FIRST inbound envelope (the refs-only `AgentRunResult`). */

--- a/src/api/mission-spine/friday-rust-hub-agent-run-ws-sealed-client.ts
+++ b/src/api/mission-spine/friday-rust-hub-agent-run-ws-sealed-client.ts
@@ -341,6 +341,35 @@ export interface FridayRustHubAgentRunSealedClient {
   resumeWithApproval(
     request: FridayRustHubAgentRunResumeRequest,
   ): Promise<FridayRustHubAgentRunResumeResult>;
+  /**
+   * (Lane B) Resolve/create a Mission from one surface input over a sealed session —
+   * `Message::MissionIntakeRequest`. PURE Hub mutation (no model/provider call). Opens a fresh
+   * sealed session (the channel auth), sends the intake envelope, and awaits the FIRST
+   * `MissionIntakeResult`. Fails closed (503) on any non-clean settle or any other inbound
+   * (including the server's `Error` envelope), never a partial.
+   */
+  intakeMission(
+    request: FridayRustHubMissionIntakeRequest,
+  ): Promise<FridayRustHubMissionIntakeResult>;
+  /**
+   * (Lane B) Advance ONE Mission's lifecycle over a sealed session —
+   * `Message::MissionLifecycleRequest`. PURE Hub mutation. Awaits the FIRST
+   * `MissionLifecycleResult`; fails closed on any other inbound. A `status` here is a Mission-
+   * management fact, NOT provider completion unless `proofRef` says so.
+   */
+  transitionMission(
+    request: FridayRustHubMissionLifecycleRequest,
+  ): Promise<FridayRustHubMissionLifecycleResult>;
+  /**
+   * (Lane B) Advance ONE WorkItem's status over a sealed session —
+   * `Message::WorkItemStatusRequest`. PURE Hub mutation. Awaits the FIRST `WorkItemStatusResult`;
+   * fails closed on any other inbound. **Proof-on-completion is enforced SERVER-side:** a
+   * `completed_with_proof` target with an empty/absent `proofReceipt` is rejected as a typed
+   * `Error` ⇒ this fails closed (never a fake-ready result).
+   */
+  transitionWorkItem(
+    request: FridayRustHubWorkItemStatusRequest,
+  ): Promise<FridayRustHubWorkItemStatusResult>;
 }
 
 /** (A3 courier) A resume relay: the run to resume + the operator's OPAQUE signed approval blob. */
@@ -352,6 +381,106 @@ export interface FridayRustHubAgentRunResumeRequest {
    * courier — relayed VERBATIM as the wire `signed_blob`; TS inspects/derives/authors NOTHING.
    */
   readonly opaqueSignedBlob: Uint8Array;
+}
+
+// ─── (Lane B) Mission-spine organic mutation requests/results ───────────────
+//
+// The keystone (#741) wired three Hub-owned, PURE-`&Db` mutations into the live
+// `hub_agent_run_server` behind a SERVER flag (`FRIDAY_MISSION_INTAKE` for intake,
+// `FRIDAY_MISSION_SPINE_DISPATCH` for lifecycle/work-item), each replying with the
+// matching `*Result` (or a typed `Error` on an illegal hop / missing entity /
+// proofless completion). These wire shapes carry NO per-request `auth_proof`/
+// `forwarded_principal` — the sealed session IS the channel auth (single-peer/
+// single-owner SERVER invariant), mirroring the merged mission-intake arm. These
+// methods build the EXACT `friday-protocol` wire shapes and settle on the FIRST
+// matching Result; ANY other inbound (including the server's `Error` envelope) is
+// a typed fail-closed (503), never a partial.
+
+/** (Lane B) A Mission intake/preflight request — `MissionIntakeRequestWire`. */
+export interface FridayRustHubMissionIntakeRequest {
+  readonly fridayConversationId: string;
+  readonly ownerPrincipal: string;
+  readonly surfaceThreadId: string;
+  readonly surfaceKind: string;
+  readonly deliveryRoute: string;
+  readonly visibilityPolicy: string;
+  readonly missionId: string;
+  readonly workItemId: string;
+  readonly title: string;
+  readonly intent: string;
+  readonly lane: string;
+  readonly targetProviderOrAgent?: string;
+  readonly capabilityId?: string;
+  readonly bodyRef?: string;
+  readonly includesSensitiveContext?: boolean;
+}
+
+/** (Lane B) Refs-only Mission intake result — `MissionIntakeResultWire`. */
+export interface FridayRustHubMissionIntakeResult {
+  readonly truthLabel: "rust_wired";
+  readonly fridayConversationId: string;
+  readonly missionId: string;
+  readonly workItemId?: string;
+  readonly surfaceThreadId: string;
+  readonly status: string;
+  readonly blockers: readonly string[];
+  readonly duplicateMissionId?: string;
+  readonly duplicateWorkItemId?: string;
+  readonly createdOrReady: boolean;
+}
+
+/** (Lane B) A Mission lifecycle transition request — `MissionLifecycleRequestWire`. */
+export interface FridayRustHubMissionLifecycleRequest {
+  readonly fridayConversationId: string;
+  readonly missionId: string;
+  readonly targetStatus: string;
+  readonly actorRef: string;
+  readonly reason: string;
+  readonly proofRef?: string;
+  readonly mergedIntoMissionId?: string;
+}
+
+/** (Lane B) Refs-only Mission lifecycle result — `MissionLifecycleResultWire`. */
+export interface FridayRustHubMissionLifecycleResult {
+  readonly truthLabel: "rust_wired";
+  readonly fridayConversationId: string;
+  readonly missionId: string;
+  readonly previousStatus: string;
+  readonly status: string;
+  readonly actorRef: string;
+  readonly reason: string;
+  readonly proofRef?: string;
+  readonly mergedIntoMissionId?: string;
+  readonly activeMissionIds: readonly string[];
+  readonly updatedAtMs: number;
+}
+
+/** (Lane B) A WorkItem status transition request — `WorkItemStatusRequestWire`. */
+export interface FridayRustHubWorkItemStatusRequest {
+  readonly workItemId: string;
+  readonly targetStatus: string;
+  readonly actorRef: string;
+  readonly reason: string;
+  /**
+   * REQUIRED (non-empty) when `targetStatus === "completed_with_proof"`; the Rust persistence
+   * boundary REJECTS a proofless completion as a typed `Error` (the proof-on-completion invariant).
+   * Absent ⇒ no receipt is appended (the key is OMITTED from the wire, byte-clean).
+   */
+  readonly proofReceipt?: string;
+}
+
+/** (Lane B) Refs-only WorkItem status result — `WorkItemStatusResultWire`. */
+export interface FridayRustHubWorkItemStatusResult {
+  readonly truthLabel: "rust_wired";
+  readonly workItemId: string;
+  readonly missionId: string;
+  readonly previousStatus: string;
+  readonly status: string;
+  readonly actorRef: string;
+  readonly reason: string;
+  /** COUNT of persisted proof receipts (never the raw receipt refs themselves). */
+  readonly proofReceiptCount: number;
+  readonly updatedAtMs: number;
 }
 
 function unavailable(message: string): FridayDomainError {
@@ -609,6 +738,226 @@ export function buildResumeEnvelope(
   };
 }
 
+/**
+ * (Lane B) Wrap a built inner message in the standard Envelope shape (mirrors the dispatch +
+ * resume envelopes). `msgId`/`correlationId` are derived from a stable per-request key so the
+ * server's `with_correlation(msg_id)` round-trips deterministically.
+ */
+function buildMissionEnvelope(key: string, message: Record<string, unknown>): Record<string, unknown> {
+  return {
+    schema_version: SCHEMA_VERSION,
+    msg_id: key,
+    correlation_id: key,
+    sent_at: Date.now(),
+    message,
+  };
+}
+
+/**
+ * (Lane B) Build the `MissionIntakeRequest` inner message — the EXACT `MissionIntakeRequestWire`
+ * shape. Required string fields ride verbatim; the four Option fields use the same conditional-
+ * spread discipline as {@link buildConstraintsWire} (absent ⇒ key OMITTED, byte-clean). The bool
+ * `includes_sensitive_context` has `#[serde(default)]` Rust-side, so we emit it ONLY when the
+ * caller asserts `true` (an absent/false value deserializes to `false`). EXPORTED + pure so the
+ * precise wire shape is unit-testable without a socket.
+ */
+export function buildMissionIntakeEnvelope(
+  request: FridayRustHubMissionIntakeRequest,
+): Record<string, unknown> {
+  const message: Record<string, unknown> = {
+    kind: "MissionIntakeRequest",
+    friday_conversation_id: request.fridayConversationId,
+    owner_principal: request.ownerPrincipal,
+    surface_thread_id: request.surfaceThreadId,
+    surface_kind: request.surfaceKind,
+    delivery_route: request.deliveryRoute,
+    visibility_policy: request.visibilityPolicy,
+    mission_id: request.missionId,
+    work_item_id: request.workItemId,
+    title: request.title,
+    intent: request.intent,
+    lane: request.lane,
+    ...(request.targetProviderOrAgent !== undefined
+      ? { target_provider_or_agent: request.targetProviderOrAgent }
+      : {}),
+    ...(request.capabilityId !== undefined ? { capability_id: request.capabilityId } : {}),
+    ...(request.bodyRef !== undefined ? { body_ref: request.bodyRef } : {}),
+    ...(request.includesSensitiveContext === true ? { includes_sensitive_context: true } : {}),
+  };
+  return buildMissionEnvelope(`mission-intake-${request.missionId}`, message);
+}
+
+/**
+ * (Lane B) Build the `MissionLifecycleRequest` inner message — the EXACT
+ * `MissionLifecycleRequestWire` shape. `proof_ref`/`merged_into_mission_id` use conditional-spread
+ * (absent ⇒ key OMITTED). EXPORTED + pure for socket-free wire testing.
+ */
+export function buildMissionLifecycleEnvelope(
+  request: FridayRustHubMissionLifecycleRequest,
+): Record<string, unknown> {
+  const message: Record<string, unknown> = {
+    kind: "MissionLifecycleRequest",
+    friday_conversation_id: request.fridayConversationId,
+    mission_id: request.missionId,
+    target_status: request.targetStatus,
+    actor_ref: request.actorRef,
+    reason: request.reason,
+    ...(request.proofRef !== undefined ? { proof_ref: request.proofRef } : {}),
+    ...(request.mergedIntoMissionId !== undefined
+      ? { merged_into_mission_id: request.mergedIntoMissionId }
+      : {}),
+  };
+  return buildMissionEnvelope(`mission-lifecycle-${request.missionId}`, message);
+}
+
+/**
+ * (Lane B) Build the `WorkItemStatusRequest` inner message — the EXACT `WorkItemStatusRequestWire`
+ * shape. `proof_receipt` uses conditional-spread (absent ⇒ key OMITTED). The proof-on-completion
+ * invariant is enforced SERVER-side (a proofless `completed_with_proof` is a typed `Error`); this
+ * builder never fabricates a receipt. EXPORTED + pure for socket-free wire testing.
+ */
+export function buildWorkItemStatusEnvelope(
+  request: FridayRustHubWorkItemStatusRequest,
+): Record<string, unknown> {
+  const message: Record<string, unknown> = {
+    kind: "WorkItemStatusRequest",
+    work_item_id: request.workItemId,
+    target_status: request.targetStatus,
+    actor_ref: request.actorRef,
+    reason: request.reason,
+    ...(request.proofReceipt !== undefined ? { proof_receipt: request.proofReceipt } : {}),
+  };
+  return buildMissionEnvelope(`work-item-status-${request.workItemId}`, message);
+}
+
+/**
+ * (Lane B) Parse a `MissionIntakeResult` inbound into the refs-only TS result. Returns `undefined`
+ * (caller fails closed) when a REQUIRED ref is missing/ill-typed. The optional refs are surfaced
+ * only when present (absent ⇒ omitted, never fabricated). EXPORTED + pure for socket-free testing.
+ */
+export function parseMissionIntakeResult(
+  fields: Record<string, unknown>,
+): FridayRustHubMissionIntakeResult | undefined {
+  const fridayConversationId = asString(fields.friday_conversation_id);
+  const missionId = asString(fields.mission_id);
+  const surfaceThreadId = asString(fields.surface_thread_id);
+  const status = asString(fields.status);
+  const blockers = fields.blockers;
+  const createdOrReady = fields.created_or_ready;
+  if (
+    !fridayConversationId ||
+    !missionId ||
+    !surfaceThreadId ||
+    !status ||
+    !Array.isArray(blockers) ||
+    !blockers.every((b): b is string => typeof b === "string") ||
+    typeof createdOrReady !== "boolean"
+  ) {
+    return undefined;
+  }
+  const workItemId = asString(fields.work_item_id);
+  const duplicateMissionId = asString(fields.duplicate_mission_id);
+  const duplicateWorkItemId = asString(fields.duplicate_work_item_id);
+  return {
+    truthLabel: "rust_wired",
+    fridayConversationId,
+    missionId,
+    surfaceThreadId,
+    status,
+    blockers,
+    createdOrReady,
+    ...(workItemId !== undefined ? { workItemId } : {}),
+    ...(duplicateMissionId !== undefined ? { duplicateMissionId } : {}),
+    ...(duplicateWorkItemId !== undefined ? { duplicateWorkItemId } : {}),
+  };
+}
+
+/**
+ * (Lane B) Parse a `MissionLifecycleResult` inbound into the refs-only TS result. Returns
+ * `undefined` when a REQUIRED ref is missing/ill-typed. EXPORTED + pure for socket-free testing.
+ */
+export function parseMissionLifecycleResult(
+  fields: Record<string, unknown>,
+): FridayRustHubMissionLifecycleResult | undefined {
+  const fridayConversationId = asString(fields.friday_conversation_id);
+  const missionId = asString(fields.mission_id);
+  const previousStatus = asString(fields.previous_status);
+  const status = asString(fields.status);
+  const actorRef = asString(fields.actor_ref);
+  const reason = asString(fields.reason);
+  const activeMissionIds = fields.active_mission_ids;
+  const updatedAtMs = asNumber(fields.updated_at_ms);
+  if (
+    !fridayConversationId ||
+    !missionId ||
+    !previousStatus ||
+    !status ||
+    !actorRef ||
+    !reason ||
+    !Array.isArray(activeMissionIds) ||
+    !activeMissionIds.every((m): m is string => typeof m === "string") ||
+    updatedAtMs === undefined
+  ) {
+    return undefined;
+  }
+  const proofRef = asString(fields.proof_ref);
+  const mergedIntoMissionId = asString(fields.merged_into_mission_id);
+  return {
+    truthLabel: "rust_wired",
+    fridayConversationId,
+    missionId,
+    previousStatus,
+    status,
+    actorRef,
+    reason,
+    activeMissionIds,
+    updatedAtMs,
+    ...(proofRef !== undefined ? { proofRef } : {}),
+    ...(mergedIntoMissionId !== undefined ? { mergedIntoMissionId } : {}),
+  };
+}
+
+/**
+ * (Lane B) Parse a `WorkItemStatusResult` inbound into the refs-only TS result. Returns `undefined`
+ * when a REQUIRED ref is missing/ill-typed. `proof_receipt_count` is a COUNT (never raw refs).
+ * EXPORTED + pure for socket-free testing.
+ */
+export function parseWorkItemStatusResult(
+  fields: Record<string, unknown>,
+): FridayRustHubWorkItemStatusResult | undefined {
+  const workItemId = asString(fields.work_item_id);
+  const missionId = asString(fields.mission_id);
+  const previousStatus = asString(fields.previous_status);
+  const status = asString(fields.status);
+  const actorRef = asString(fields.actor_ref);
+  const reason = asString(fields.reason);
+  const proofReceiptCount = asNumber(fields.proof_receipt_count);
+  const updatedAtMs = asNumber(fields.updated_at_ms);
+  if (
+    !workItemId ||
+    !missionId ||
+    !previousStatus ||
+    !status ||
+    !actorRef ||
+    !reason ||
+    proofReceiptCount === undefined ||
+    updatedAtMs === undefined
+  ) {
+    return undefined;
+  }
+  return {
+    truthLabel: "rust_wired",
+    workItemId,
+    missionId,
+    previousStatus,
+    status,
+    actorRef,
+    reason,
+    proofReceiptCount,
+    updatedAtMs,
+  };
+}
+
 /** Open + decode one inbound sealed WS Binary payload into its inner message. */
 function openInbound(sessionKey: Uint8Array, payload: Buffer): InboundEnvelope {
   const sealed = decodeSealed(new Uint8Array(payload));
@@ -856,6 +1205,182 @@ export function handleServerClose(ctx: InboundContext): void {
     return;
   }
   finishFromRefs(ctx);
+}
+
+/**
+ * (Lane B) Parameters for the generic sealed mission round-trip — the connect/preamble/derive-key/
+ * upgrade machinery, factored from {@link FridayRustHubAgentRunResumeRequest}'s handshake.
+ */
+interface MissionRoundTripParams<TResult> {
+  readonly host: string;
+  readonly port: number;
+  readonly timeoutMs: number;
+  readonly keypair: { readonly publicKey: Uint8Array; readonly secret: Uint8Array };
+  /** The pre-built Envelope to seal + send (one of the `build*Envelope` outputs). */
+  readonly envelope: Record<string, unknown>;
+  /** The ONLY inbound message kind accepted; any other kind fails closed. */
+  readonly expectedKind: string;
+  /** Parse the accepted inbound's fields into the refs-only result, or `undefined` ⇒ fail closed. */
+  readonly parse: (fields: Record<string, unknown>) => TResult | undefined;
+  /** A short label for the fail-closed messages (e.g. "mission-intake"). */
+  readonly leg: string;
+}
+
+/**
+ * (Lane B) Run ONE sealed request→response round-trip for a mission-spine mutation. Mirrors the
+ * `resumeWithApproval` handshake EXACTLY (connect → length-prefixed preamble → X25519+HKDF session
+ * key → RFC6455 upgrade → seal+send → await the FIRST matching Result → settle), reusing the SAME
+ * module-level helpers. FAIL-CLOSED (503) contract:
+ *   - any non-clean settle (connect error / socket close before a result / timeout / wrong-width
+ *     preamble / un-openable envelope) → fail closed;
+ *   - ANY inbound whose kind != `expectedKind` — INCLUDING the server's `Error` envelope (illegal
+ *     hop / missing entity / proofless completion) — → fail closed, never a partial;
+ *   - a matching kind that fails to parse (missing required ref) → fail closed.
+ * Never logs/returns secrets or raw bodies; the result is refs-only by construction.
+ */
+function runMissionRoundTrip<TResult>(params: MissionRoundTripParams<TResult>): Promise<TResult> {
+  const { host, port, timeoutMs, keypair, envelope, expectedKind, parse, leg } = params;
+  return new Promise<TResult>((resolve, reject) => {
+    let settled = false;
+    let socket: Socket | null = null;
+    let receiver: WsReceiver | null = null;
+    let sessionKey: Uint8Array = new Uint8Array(0);
+
+    const timer = setTimeout(() => {
+      fail(unavailable(`Sealed mission-spine client (${leg}) timed out awaiting a result.`));
+    }, timeoutMs);
+    if (typeof timer.unref === "function") timer.unref();
+
+    function teardown(): void {
+      clearTimeout(timer);
+      if (receiver) {
+        receiver.removeAllListeners();
+      }
+      if (socket) {
+        socket.removeAllListeners();
+        socket.on("error", () => {});
+        try {
+          socket.destroy();
+        } catch {
+          // best-effort; the result is already decided.
+        }
+      }
+    }
+    function succeed(result: TResult): void {
+      if (settled) return;
+      settled = true;
+      teardown();
+      resolve(result);
+    }
+    function fail(error: FridayDomainError): void {
+      if (settled) return;
+      settled = true;
+      teardown();
+      reject(error);
+    }
+    // The server ending the session BEFORE a result is the fail-closed path (forged peer / the
+    // server ran nothing). A result already settled ⇒ this is a guarded no-op.
+    function onClose(): void {
+      fail(unavailable(`Sealed mission-spine client (${leg}) connection closed before a result.`));
+    }
+    function onInbound(payload: Buffer): void {
+      let inbound: InboundEnvelope;
+      try {
+        inbound = openInbound(sessionKey, payload);
+      } catch {
+        fail(unavailable(`Sealed mission-spine client (${leg}) could not open an inbound envelope.`));
+        return;
+      }
+      // STRICT: only the matching Result kind is accepted. A server `Error` envelope (or any other
+      // kind) is a typed fail-closed — never coerced to a result, never a partial.
+      if (inbound.kind !== expectedKind) {
+        fail(unavailable(`Sealed mission-spine client (${leg}) received an unknown message shape.`));
+        return;
+      }
+      const parsed = parse(inbound.fields);
+      if (parsed === undefined) {
+        fail(unavailable(`Sealed mission-spine client (${leg}) result is missing a required ref.`));
+        return;
+      }
+      succeed(parsed);
+    }
+
+    void (async () => {
+      // (1) RAW TCP connect (NOT new WebSocket(url)) — preamble first, like dispatch/resume.
+      let connected: Socket;
+      try {
+        connected = await new Promise<Socket>((res, rej) => {
+          const s = connect({ host, port }, () => res(s));
+          socket = s;
+          s.once("error", rej);
+        });
+      } catch {
+        fail(unavailable(`Sealed mission-spine client (${leg}) could not open a connection.`));
+        return;
+      }
+      socket = connected;
+      socket.setNoDelay(true);
+
+      const reader = createPreambleReader(socket);
+      try {
+        // (2) preamble: write client pubkey → read server pubkey (32B) → read nonce (64B).
+        socket.write(frameBytes(keypair.publicKey));
+        const serverPub = await reader.readFrame();
+        if (serverPub.length !== X25519_PUBKEY_LEN) {
+          throw new Error("server pubkey wrong width");
+        }
+        const sessionNonce = await reader.readFrame();
+        if (sessionNonce.length !== SESSION_NONCE_LEN) {
+          throw new Error("session nonce wrong width");
+        }
+
+        // (3) derive the session key (X25519 + HKDF) over the agreed peer pubkey. The mission wire
+        // shapes carry NO per-request `auth_proof` — the sealed session IS the channel auth (the
+        // server enforces single-peer/single-owner), so this leg builds no possession proof.
+        const derived = agree(keypair.secret, serverPub);
+        sessionKey = derived;
+
+        // (4) hand off to the WS layer over the SAME socket: manual RFC6455 upgrade, then
+        // Sender/Receiver. (`sessionNonce` is consumed only to validate preamble width here.)
+        void sessionNonce;
+        const { socket: sock, leftover: preambleLeftover } = reader.takeover();
+        if (preambleLeftover.length > 0) {
+          throw new Error("unexpected buffered bytes before ws upgrade");
+        }
+        const leftover = await wsClientUpgrade(sock, host, port);
+
+        const sender = new wsRuntime.Sender(sock, undefined, () => randomBytes(4));
+        const recv = new wsRuntime.Receiver({ isServer: false, binaryType: "nodebuffer", skipUTF8Validation: true });
+        receiver = recv;
+
+        recv.on("message", (data: Buffer, isBinary: boolean) => {
+          if (!isBinary) {
+            fail(unavailable(`Sealed mission-spine client (${leg}) received a non-binary frame.`));
+            return;
+          }
+          onInbound(data);
+        });
+        recv.on("conclude", onClose);
+        recv.on("error", () => {
+          fail(unavailable(`Sealed mission-spine client (${leg}) received a malformed WS frame.`));
+        });
+
+        sock.on("data", (chunk: Buffer) => recv.write(chunk));
+        sock.on("error", () => {
+          fail(unavailable(`Sealed mission-spine client (${leg}) connection error.`));
+        });
+        sock.on("close", onClose);
+        if (leftover.length > 0) {
+          recv.write(leftover);
+        }
+
+        // (5) seal + send the pre-built mission envelope.
+        sealAndSend(sender, derived, envelope);
+      } catch {
+        fail(unavailable(`Sealed mission-spine client (${leg}) handshake failed.`));
+      }
+    })();
+  });
 }
 
 export function createFridayRustHubAgentRunSealedClient(
@@ -1231,6 +1756,66 @@ export function createFridayRustHubAgentRunSealedClient(
             fail(unavailable("Sealed agent-run client resume handshake failed."));
           }
         })();
+      });
+    },
+
+    intakeMission(
+      request: FridayRustHubMissionIntakeRequest,
+    ): Promise<FridayRustHubMissionIntakeResult> {
+      if (!request.missionId || !request.fridayConversationId) {
+        return Promise.reject(
+          unavailable("Sealed mission-spine client intake requires a mission id and conversation id."),
+        );
+      }
+      return runMissionRoundTrip<FridayRustHubMissionIntakeResult>({
+        host,
+        port,
+        timeoutMs,
+        keypair,
+        envelope: buildMissionIntakeEnvelope(request),
+        expectedKind: "MissionIntakeResult",
+        parse: parseMissionIntakeResult,
+        leg: "mission-intake",
+      });
+    },
+
+    transitionMission(
+      request: FridayRustHubMissionLifecycleRequest,
+    ): Promise<FridayRustHubMissionLifecycleResult> {
+      if (!request.missionId || !request.targetStatus) {
+        return Promise.reject(
+          unavailable("Sealed mission-spine client lifecycle requires a mission id and target status."),
+        );
+      }
+      return runMissionRoundTrip<FridayRustHubMissionLifecycleResult>({
+        host,
+        port,
+        timeoutMs,
+        keypair,
+        envelope: buildMissionLifecycleEnvelope(request),
+        expectedKind: "MissionLifecycleResult",
+        parse: parseMissionLifecycleResult,
+        leg: "mission-lifecycle",
+      });
+    },
+
+    transitionWorkItem(
+      request: FridayRustHubWorkItemStatusRequest,
+    ): Promise<FridayRustHubWorkItemStatusResult> {
+      if (!request.workItemId || !request.targetStatus) {
+        return Promise.reject(
+          unavailable("Sealed mission-spine client work-item requires a work-item id and target status."),
+        );
+      }
+      return runMissionRoundTrip<FridayRustHubWorkItemStatusResult>({
+        host,
+        port,
+        timeoutMs,
+        keypair,
+        envelope: buildWorkItemStatusEnvelope(request),
+        expectedKind: "WorkItemStatusResult",
+        parse: parseWorkItemStatusResult,
+        leg: "work-item-status",
       });
     },
   };

--- a/src/security/friday-owner-session-channel-capability.ts
+++ b/src/security/friday-owner-session-channel-capability.ts
@@ -85,7 +85,14 @@ export type FridayPublicMutationOperation =
   // Phase 17A — user-owned cloud worker setup UX bound-principal ops.
   | "cloud.worker.dns.validate"
   | "cloud.worker.package.generate"
-  | "cloud.worker.teardown.receipt";
+  | "cloud.worker.teardown.receipt"
+  // Lane B — organic mission-spine mutations driven over the sealed-WS dispatch
+  // arms (Mission intake / Mission lifecycle / WorkItem status). Public mutating
+  // routes: refuse the synthetic public principal; only a bound owner drives a
+  // Mission/WorkItem transition.
+  | "mission.spine.intake"
+  | "mission.spine.lifecycle"
+  | "mission.spine.workitem.status";
 
 export type FridayBoundPrincipalSource = "api" | "session" | "channel" | "satellite";
 

--- a/test/contracts/api/__snapshots__/friday-api-route-contract.snapshot.test.ts.snap
+++ b/test/contracts/api/__snapshots__/friday-api-route-contract.snapshot.test.ts.snap
@@ -3,14 +3,14 @@
 exports[`MECHANISM-4 — API Route Contract (Snapshot) > Phase 14.5A WP-001: every public mutating route maps to an accepted gate family 1`] = `
 {
   "classified": {
-    "bound_principal": 59,
+    "bound_principal": 62,
     "channel_signature": 4,
     "hmac_or_bearer_opt_in": 1,
     "public_low_risk": 2,
     "rate_limited_pending": 4,
     "unclassified": 251,
   },
-  "total_public_mutating": 321,
+  "total_public_mutating": 324,
   "unclassified_sample_max_5": [
     "capabilities.acquisition.runs.create",
     "capabilities.acquisition.runs.approve",
@@ -21,7 +21,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > Phase 14.5A WP-001: eve
 }
 `;
 
-exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures route count to detect accidental additions/removals 1`] = `420`;
+exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures route count to detect accidental additions/removals 1`] = `423`;
 
 exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route surface as a stable contract 1`] = `
 [
@@ -1809,6 +1809,36 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
     "authKind": "public",
     "index": 178,
     "method": "POST",
+    "operationId": "mission.spine.intake.create",
+    "path": "/v1/mission-spine/intake",
+    "rateLimitPolicyId": null,
+    "roles": [],
+    "scopes": [],
+  },
+  {
+    "authKind": "public",
+    "index": 179,
+    "method": "POST",
+    "operationId": "mission.spine.lifecycle.transition",
+    "path": "/v1/mission-spine/:missionId/lifecycle",
+    "rateLimitPolicyId": null,
+    "roles": [],
+    "scopes": [],
+  },
+  {
+    "authKind": "public",
+    "index": 180,
+    "method": "POST",
+    "operationId": "mission.spine.workitem.status.transition",
+    "path": "/v1/mission-spine/work-items/:workItemId/status",
+    "rateLimitPolicyId": null,
+    "roles": [],
+    "scopes": [],
+  },
+  {
+    "authKind": "public",
+    "index": 181,
+    "method": "POST",
     "operationId": "realtime.subscribe",
     "path": "/v1/realtime/subscriptions",
     "rateLimitPolicyId": "realtime.subscribe",
@@ -1817,7 +1847,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 179,
+    "index": 182,
     "method": "POST",
     "operationId": "realtime.pull",
     "path": "/v1/realtime/pull",
@@ -1827,7 +1857,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 180,
+    "index": 183,
     "method": "POST",
     "operationId": "realtime.ack",
     "path": "/v1/realtime/ack",
@@ -1837,7 +1867,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 181,
+    "index": 184,
     "method": "GET",
     "operationId": "providers.usage.get",
     "path": "/v1/providers/usage",
@@ -1847,7 +1877,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 182,
+    "index": 185,
     "method": "GET",
     "operationId": "providers.budget.get",
     "path": "/v1/providers/budget",
@@ -1857,7 +1887,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 183,
+    "index": 186,
     "method": "PUT",
     "operationId": "providers.budget.set",
     "path": "/v1/providers/budget",
@@ -1867,7 +1897,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 184,
+    "index": 187,
     "method": "GET",
     "operationId": "providers.templates.list",
     "path": "/v1/providers/templates",
@@ -1877,7 +1907,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 185,
+    "index": 188,
     "method": "GET",
     "operationId": "providers.templates.get",
     "path": "/v1/providers/templates/:templateId",
@@ -1887,7 +1917,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 186,
+    "index": 189,
     "method": "GET",
     "operationId": "providers.list",
     "path": "/v1/providers",
@@ -1897,7 +1927,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 187,
+    "index": 190,
     "method": "GET",
     "operationId": "providers.health.list",
     "path": "/v1/providers/health",
@@ -1907,7 +1937,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 188,
+    "index": 191,
     "method": "GET",
     "operationId": "providers.capability.health.list",
     "path": "/v1/providers/capability-health",
@@ -1917,7 +1947,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 189,
+    "index": 192,
     "method": "POST",
     "operationId": "capabilities.doctor",
     "path": "/v1/capabilities/doctor",
@@ -1927,7 +1957,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 190,
+    "index": 193,
     "method": "GET",
     "operationId": "providers.get",
     "path": "/v1/providers/:providerId",
@@ -1937,7 +1967,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 191,
+    "index": 194,
     "method": "POST",
     "operationId": "providers.create",
     "path": "/v1/providers",
@@ -1947,7 +1977,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 192,
+    "index": 195,
     "method": "PATCH",
     "operationId": "providers.update",
     "path": "/v1/providers/:providerId",
@@ -1957,7 +1987,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 193,
+    "index": 196,
     "method": "DELETE",
     "operationId": "providers.delete",
     "path": "/v1/providers/:providerId",
@@ -1967,7 +1997,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 194,
+    "index": 197,
     "method": "POST",
     "operationId": "providers.validate",
     "path": "/v1/providers/:providerId/validate",
@@ -1977,7 +2007,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 195,
+    "index": 198,
     "method": "GET",
     "operationId": "providers.doctor",
     "path": "/v1/providers/:providerId/doctor",
@@ -1987,7 +2017,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 196,
+    "index": 199,
     "method": "GET",
     "operationId": "providers.routing.explain",
     "path": "/v1/providers/routing/explain",
@@ -1997,7 +2027,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 197,
+    "index": 200,
     "method": "POST",
     "operationId": "providers.routing.pin",
     "path": "/v1/providers/routing/pin",
@@ -2007,7 +2037,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 198,
+    "index": 201,
     "method": "POST",
     "operationId": "providers.routing.penalty.clear",
     "path": "/v1/providers/routing/penalties/clear",
@@ -2017,7 +2047,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 199,
+    "index": 202,
     "method": "GET",
     "operationId": "providers.auth.profiles.list",
     "path": "/v1/providers/:providerId/auth-profiles",
@@ -2027,7 +2057,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 200,
+    "index": 203,
     "method": "POST",
     "operationId": "providers.auth.profiles.activate",
     "path": "/v1/providers/:providerId/auth-profiles/:profileKey/activate",
@@ -2037,7 +2067,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 201,
+    "index": 204,
     "method": "GET",
     "operationId": "providers.routing.get",
     "path": "/v1/model-routing",
@@ -2047,7 +2077,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 202,
+    "index": 205,
     "method": "PUT",
     "operationId": "providers.routing.set",
     "path": "/v1/model-routing",
@@ -2057,7 +2087,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 203,
+    "index": 206,
     "method": "POST",
     "operationId": "auth.oauth.anthropic.initiate",
     "path": "/v1/auth/oauth/anthropic/initiate",
@@ -2067,7 +2097,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 204,
+    "index": 207,
     "method": "POST",
     "operationId": "auth.oauth.anthropic.callback",
     "path": "/v1/auth/oauth/anthropic/callback",
@@ -2077,7 +2107,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 205,
+    "index": 208,
     "method": "POST",
     "operationId": "auth.oauth.openai.codex.device.initiate",
     "path": "/v1/auth/oauth/openai-codex/device/initiate",
@@ -2087,7 +2117,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 206,
+    "index": 209,
     "method": "POST",
     "operationId": "auth.oauth.openai.codex.device.complete",
     "path": "/v1/auth/oauth/openai-codex/device/complete",
@@ -2097,7 +2127,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 207,
+    "index": 210,
     "method": "POST",
     "operationId": "media.understanding.doctor",
     "path": "/v1/media-understanding/doctor",
@@ -2107,7 +2137,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 208,
+    "index": 211,
     "method": "POST",
     "operationId": "media.understanding.analyze",
     "path": "/v1/media-understanding/analyze",
@@ -2117,7 +2147,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 209,
+    "index": 212,
     "method": "GET",
     "operationId": "task.workflows.boundaries.list",
     "path": "/v1/task-workflows/boundaries",
@@ -2127,7 +2157,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 210,
+    "index": 213,
     "method": "GET",
     "operationId": "task.workflows.gates.list",
     "path": "/v1/task-workflows/gates",
@@ -2137,7 +2167,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 211,
+    "index": 214,
     "method": "POST",
     "operationId": "task.workflows.preview",
     "path": "/v1/task-workflows/preview",
@@ -2147,7 +2177,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 212,
+    "index": 215,
     "method": "POST",
     "operationId": "task.workflows.create",
     "path": "/v1/task-workflows",
@@ -2157,7 +2187,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 213,
+    "index": 216,
     "method": "GET",
     "operationId": "task.workflows.list",
     "path": "/v1/task-workflows",
@@ -2167,7 +2197,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 214,
+    "index": 217,
     "method": "GET",
     "operationId": "task.workflows.get",
     "path": "/v1/task-workflows/:workflowId",
@@ -2177,7 +2207,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 215,
+    "index": 218,
     "method": "POST",
     "operationId": "task.workflows.revise",
     "path": "/v1/task-workflows/:workflowId/revisions",
@@ -2187,7 +2217,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 216,
+    "index": 219,
     "method": "GET",
     "operationId": "task.workflows.revisions.list",
     "path": "/v1/task-workflows/:workflowId/revisions",
@@ -2197,7 +2227,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 217,
+    "index": 220,
     "method": "POST",
     "operationId": "task.workflows.claims.create",
     "path": "/v1/task-workflows/:workflowId/claims",
@@ -2207,7 +2237,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 218,
+    "index": 221,
     "method": "GET",
     "operationId": "task.workflows.claims.list",
     "path": "/v1/task-workflows/:workflowId/claims",
@@ -2217,7 +2247,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 219,
+    "index": 222,
     "method": "GET",
     "operationId": "task.workflows.claims.get",
     "path": "/v1/task-workflows/:workflowId/claims/:claimId",
@@ -2227,7 +2257,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 220,
+    "index": 223,
     "method": "POST",
     "operationId": "task.workflows.claims.evidence.attach",
     "path": "/v1/task-workflows/:workflowId/claims/:claimId/evidence-ref",
@@ -2237,7 +2267,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 221,
+    "index": 224,
     "method": "GET",
     "operationId": "task.workflows.claims.evidence.list",
     "path": "/v1/task-workflows/:workflowId/claims/:claimId/evidence-refs",
@@ -2247,7 +2277,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 222,
+    "index": 225,
     "method": "POST",
     "operationId": "task.workflows.claims.verify",
     "path": "/v1/task-workflows/:workflowId/claims/:claimId/verify",
@@ -2257,7 +2287,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 223,
+    "index": 226,
     "method": "POST",
     "operationId": "task.workflows.claims.block",
     "path": "/v1/task-workflows/:workflowId/claims/:claimId/block",
@@ -2267,7 +2297,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 224,
+    "index": 227,
     "method": "POST",
     "operationId": "task.workflows.closeout",
     "path": "/v1/task-workflows/:workflowId/closeout",
@@ -2277,7 +2307,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 225,
+    "index": 228,
     "method": "POST",
     "operationId": "task.workflows.lanes.executor.open",
     "path": "/v1/task-workflows/:workflowId/lanes/executor",
@@ -2287,7 +2317,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 226,
+    "index": 229,
     "method": "POST",
     "operationId": "task.workflows.lanes.verifier.open",
     "path": "/v1/task-workflows/:workflowId/lanes/verifier",
@@ -2297,7 +2327,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 227,
+    "index": 230,
     "method": "POST",
     "operationId": "task.workflows.lanes.complete",
     "path": "/v1/task-workflows/:workflowId/lanes/:laneId/complete",
@@ -2307,7 +2337,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 228,
+    "index": 231,
     "method": "POST",
     "operationId": "task.workflows.lanes.verdict",
     "path": "/v1/task-workflows/:workflowId/lanes/:laneId/verdict",
@@ -2317,7 +2347,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 229,
+    "index": 232,
     "method": "GET",
     "operationId": "task.workflows.lanes.list",
     "path": "/v1/task-workflows/:workflowId/lanes",
@@ -2327,7 +2357,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 230,
+    "index": 233,
     "method": "GET",
     "operationId": "task.workflows.lanes.get",
     "path": "/v1/task-workflows/:workflowId/lanes/:laneId",
@@ -2337,7 +2367,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 231,
+    "index": 234,
     "method": "POST",
     "operationId": "task.workflows.lanes.cli.handoff.record",
     "path": "/v1/task-workflows/:workflowId/lanes/:laneId/cli-handoffs",
@@ -2347,7 +2377,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 232,
+    "index": 235,
     "method": "GET",
     "operationId": "task.workflows.lanes.cli.handoffs.list",
     "path": "/v1/task-workflows/:workflowId/lanes/:laneId/cli-handoffs",
@@ -2357,7 +2387,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 233,
+    "index": 236,
     "method": "GET",
     "operationId": "task.workflows.cli.handoffs.list",
     "path": "/v1/task-workflows/:workflowId/cli-handoffs",
@@ -2367,7 +2397,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 234,
+    "index": 237,
     "method": "GET",
     "operationId": "task.workflows.supervisor.read",
     "path": "/v1/task-workflows/:workflowId/supervisor",
@@ -2377,7 +2407,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 235,
+    "index": 238,
     "method": "POST",
     "operationId": "task.workflows.channel.command.issue",
     "path": "/v1/task-workflows/:workflowId/channel-commands",
@@ -2387,7 +2417,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 236,
+    "index": 239,
     "method": "GET",
     "operationId": "task.workflows.channel.command.list",
     "path": "/v1/task-workflows/:workflowId/channel-commands",
@@ -2397,7 +2427,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 237,
+    "index": 240,
     "method": "POST",
     "operationId": "task.workflows.channel.command.confirm",
     "path": "/v1/task-workflows/:workflowId/channel-commands/confirm",
@@ -2407,7 +2437,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 238,
+    "index": 241,
     "method": "GET",
     "operationId": "task.workflows.evidence.explorer.query",
     "path": "/v1/task-workflows/evidence",
@@ -2417,7 +2447,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 239,
+    "index": 242,
     "method": "GET",
     "operationId": "task.workflows.evidence.explorer.raw",
     "path": "/v1/task-workflows/evidence/:evidenceRefId/raw",
@@ -2427,7 +2457,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 240,
+    "index": 243,
     "method": "POST",
     "operationId": "skills.social.import",
     "path": "/v1/skills/social-import",
@@ -2437,7 +2467,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 241,
+    "index": 244,
     "method": "GET",
     "operationId": "setup.status",
     "path": "/v1/setup/status",
@@ -2447,7 +2477,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 242,
+    "index": 245,
     "method": "POST",
     "operationId": "providers.detect",
     "path": "/v1/providers/detect",
@@ -2457,7 +2487,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 243,
+    "index": 246,
     "method": "GET",
     "operationId": "setup.network.get",
     "path": "/v1/setup/network",
@@ -2467,7 +2497,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 244,
+    "index": 247,
     "method": "POST",
     "operationId": "setup.network.save",
     "path": "/v1/setup/network",
@@ -2477,7 +2507,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 245,
+    "index": 248,
     "method": "POST",
     "operationId": "setup.channels.feishu.registration.begin",
     "path": "/v1/setup/channels/feishu/registration/begin",
@@ -2487,7 +2517,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 246,
+    "index": 249,
     "method": "POST",
     "operationId": "setup.channels.feishu.registration.poll",
     "path": "/v1/setup/channels/feishu/registration/poll",
@@ -2497,7 +2527,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 247,
+    "index": 250,
     "method": "POST",
     "operationId": "setup.channels.telegram.verification.begin",
     "path": "/v1/setup/channels/telegram/verification/begin",
@@ -2507,7 +2537,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 248,
+    "index": 251,
     "method": "POST",
     "operationId": "setup.channels.telegram.verification.poll",
     "path": "/v1/setup/channels/telegram/verification/poll",
@@ -2517,7 +2547,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 249,
+    "index": 252,
     "method": "POST",
     "operationId": "setup.channels.discord.verification.begin",
     "path": "/v1/setup/channels/discord/verification/begin",
@@ -2527,7 +2557,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 250,
+    "index": 253,
     "method": "POST",
     "operationId": "setup.channels.discord.verification.complete",
     "path": "/v1/setup/channels/discord/verification/complete",
@@ -2537,7 +2567,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 251,
+    "index": 254,
     "method": "POST",
     "operationId": "setup.channels.test",
     "path": "/v1/setup/channels/test",
@@ -2547,7 +2577,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 252,
+    "index": 255,
     "method": "POST",
     "operationId": "setup.channels.save",
     "path": "/v1/setup/channels",
@@ -2557,7 +2587,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 253,
+    "index": 256,
     "method": "POST",
     "operationId": "setup.complete",
     "path": "/v1/setup/complete",
@@ -2567,7 +2597,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 254,
+    "index": 257,
     "method": "GET",
     "operationId": "skills.list",
     "path": "/v1/skills",
@@ -2577,7 +2607,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 255,
+    "index": 258,
     "method": "GET",
     "operationId": "skills.catalog.list",
     "path": "/v1/skills/catalog",
@@ -2587,7 +2617,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 256,
+    "index": 259,
     "method": "GET",
     "operationId": "skills.get",
     "path": "/v1/skills/:skillId",
@@ -2597,7 +2627,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 257,
+    "index": 260,
     "method": "POST",
     "operationId": "skills.install",
     "path": "/v1/skills/install",
@@ -2607,7 +2637,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 258,
+    "index": 261,
     "method": "POST",
     "operationId": "skills.update",
     "path": "/v1/skills/:skillId/update",
@@ -2617,7 +2647,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 259,
+    "index": 262,
     "method": "DELETE",
     "operationId": "skills.delete",
     "path": "/v1/skills/:skillId",
@@ -2627,7 +2657,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 260,
+    "index": 263,
     "method": "POST",
     "operationId": "skills.manifest.validate",
     "path": "/v1/skills/validate-manifest",
@@ -2637,7 +2667,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 261,
+    "index": 264,
     "method": "POST",
     "operationId": "skills.verify",
     "path": "/v1/skills/:skillId/verify",
@@ -2647,7 +2677,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 262,
+    "index": 265,
     "method": "POST",
     "operationId": "skills.upgrade.analyze",
     "path": "/v1/skills/:skillId/upgrade/analyze",
@@ -2657,7 +2687,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 263,
+    "index": 266,
     "method": "POST",
     "operationId": "skills.upgrade.decide",
     "path": "/v1/skills/:skillId/upgrade/decide",
@@ -2667,7 +2697,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 264,
+    "index": 267,
     "method": "POST",
     "operationId": "skills.run",
     "path": "/v1/skills/:skillId/run",
@@ -2677,7 +2707,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 265,
+    "index": 268,
     "method": "POST",
     "operationId": "skills.generator.sessions.create",
     "path": "/v1/skills/generator/sessions",
@@ -2687,7 +2717,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 266,
+    "index": 269,
     "method": "GET",
     "operationId": "skills.generator.sessions.get",
     "path": "/v1/skills/generator/sessions/:sessionId",
@@ -2697,7 +2727,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 267,
+    "index": 270,
     "method": "POST",
     "operationId": "skills.generator.sessions.messages.create",
     "path": "/v1/skills/generator/sessions/:sessionId/messages",
@@ -2707,7 +2737,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 268,
+    "index": 271,
     "method": "POST",
     "operationId": "skills.generator.sessions.generate",
     "path": "/v1/skills/generator/sessions/:sessionId/generate",
@@ -2717,7 +2747,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 269,
+    "index": 272,
     "method": "POST",
     "operationId": "skills.generator.sessions.test",
     "path": "/v1/skills/generator/sessions/:sessionId/test",
@@ -2727,7 +2757,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 270,
+    "index": 273,
     "method": "GET",
     "operationId": "skills.generator.sessions.evidence.get",
     "path": "/v1/skills/generator/sessions/:sessionId/evidence",
@@ -2737,7 +2767,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 271,
+    "index": 274,
     "method": "POST",
     "operationId": "skills.generator.sessions.approve",
     "path": "/v1/skills/generator/sessions/:sessionId/approve",
@@ -2747,7 +2777,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 272,
+    "index": 275,
     "method": "DELETE",
     "operationId": "skills.generator.sessions.cancel",
     "path": "/v1/skills/generator/sessions/:sessionId",
@@ -2757,7 +2787,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 273,
+    "index": 276,
     "method": "GET",
     "operationId": "skills.ui.get",
     "path": "/v1/skills/:skillId/ui",
@@ -2767,7 +2797,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 274,
+    "index": 277,
     "method": "POST",
     "operationId": "uix.intents.resolve",
     "path": "/v1/uix/intents/resolve",
@@ -2777,7 +2807,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 275,
+    "index": 278,
     "method": "GET",
     "operationId": "uix.templates.list",
     "path": "/v1/uix/templates",
@@ -2787,7 +2817,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 276,
+    "index": 279,
     "method": "GET",
     "operationId": "uix.home.snapshot.get",
     "path": "/v1/uix/home-snapshot",
@@ -2797,7 +2827,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 277,
+    "index": 280,
     "method": "GET",
     "operationId": "uix.assistant.inbox.snapshot.get",
     "path": "/v1/uix/assistant-inbox-snapshot",
@@ -2807,7 +2837,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 278,
+    "index": 281,
     "method": "GET",
     "operationId": "uix.diagnostics.get",
     "path": "/v1/uix/diagnostics",
@@ -2817,7 +2847,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 279,
+    "index": 282,
     "method": "GET",
     "operationId": "uix.preferences.list",
     "path": "/v1/uix/preferences",
@@ -2827,7 +2857,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 280,
+    "index": 283,
     "method": "PUT",
     "operationId": "uix.preferences.update",
     "path": "/v1/uix/preferences",
@@ -2837,7 +2867,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 281,
+    "index": 284,
     "method": "DELETE",
     "operationId": "uix.preferences.delete",
     "path": "/v1/uix/preferences/:preferenceId",
@@ -2847,7 +2877,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 282,
+    "index": 285,
     "method": "GET",
     "operationId": "uix.persona.get",
     "path": "/v1/uix/persona",
@@ -2857,7 +2887,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 283,
+    "index": 286,
     "method": "PUT",
     "operationId": "uix.persona.update",
     "path": "/v1/uix/persona",
@@ -2867,7 +2897,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 284,
+    "index": 287,
     "method": "POST",
     "operationId": "uix.templates.execute",
     "path": "/v1/uix/templates/:templateId/execute",
@@ -2877,7 +2907,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 285,
+    "index": 288,
     "method": "POST",
     "operationId": "uix.wizards.start",
     "path": "/v1/uix/wizards/:wizardId/start",
@@ -2887,7 +2917,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 286,
+    "index": 289,
     "method": "POST",
     "operationId": "uix.wizards.continue",
     "path": "/v1/uix/wizards/:wizardId/continue",
@@ -2897,7 +2927,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 287,
+    "index": 290,
     "method": "GET",
     "operationId": "uix.issues.list",
     "path": "/v1/uix/issues",
@@ -2907,7 +2937,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 288,
+    "index": 291,
     "method": "GET",
     "operationId": "uix.user.profile.get",
     "path": "/v1/uix/user-profile",
@@ -2917,7 +2947,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 289,
+    "index": 292,
     "method": "PUT",
     "operationId": "uix.user.profile.update",
     "path": "/v1/uix/user-profile",
@@ -2927,7 +2957,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 290,
+    "index": 293,
     "method": "POST",
     "operationId": "uix.investigate",
     "path": "/v1/uix/investigate",
@@ -2937,7 +2967,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 291,
+    "index": 294,
     "method": "GET",
     "operationId": "uix.learnedfacts.list",
     "path": "/v1/uix/learned-facts",
@@ -2947,7 +2977,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 292,
+    "index": 295,
     "method": "DELETE",
     "operationId": "uix.learnedfacts.clear",
     "path": "/v1/uix/learned-facts",
@@ -2957,7 +2987,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 293,
+    "index": 296,
     "method": "PATCH",
     "operationId": "uix.learnedfacts.update",
     "path": "/v1/uix/learned-facts/:factKey",
@@ -2967,7 +2997,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 294,
+    "index": 297,
     "method": "DELETE",
     "operationId": "uix.learnedfacts.delete",
     "path": "/v1/uix/learned-facts/:factKey",
@@ -2977,7 +3007,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 295,
+    "index": 298,
     "method": "GET",
     "operationId": "packs.cross.border.profile.get",
     "path": "/v1/packs/cross-border/profile",
@@ -2987,7 +3017,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 296,
+    "index": 299,
     "method": "PUT",
     "operationId": "packs.cross.border.profile.put",
     "path": "/v1/packs/cross-border/profile",
@@ -2997,7 +3027,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 297,
+    "index": 300,
     "method": "GET",
     "operationId": "packs.cross.border.snapshot.get",
     "path": "/v1/packs/cross-border/snapshot",
@@ -3007,7 +3037,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 298,
+    "index": 301,
     "method": "POST",
     "operationId": "packs.cross.border.import.post",
     "path": "/v1/packs/cross-border/import",
@@ -3017,7 +3047,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 299,
+    "index": 302,
     "method": "POST",
     "operationId": "packs.cross.border.workflow.presets.apply",
     "path": "/v1/packs/cross-border/workflow-presets/apply",
@@ -3027,7 +3057,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 300,
+    "index": 303,
     "method": "PATCH",
     "operationId": "packs.cross.border.workflow.presets.toggle",
     "path": "/v1/packs/cross-border/workflow-presets/:workflowId",
@@ -3037,7 +3067,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 301,
+    "index": 304,
     "method": "POST",
     "operationId": "packs.cross.border.run.evidence.capture",
     "path": "/v1/packs/cross-border/run-evidence",
@@ -3047,7 +3077,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 302,
+    "index": 305,
     "method": "PATCH",
     "operationId": "packs.cross.border.import.stale",
     "path": "/v1/packs/cross-border/imports/:importBatchId/stale",
@@ -3057,7 +3087,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 303,
+    "index": 306,
     "method": "POST",
     "operationId": "packs.cross.border.workflows.disable.all",
     "path": "/v1/packs/cross-border/workflows/disable-all",
@@ -3067,7 +3097,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 304,
+    "index": 307,
     "method": "GET",
     "operationId": "skills.converters.list",
     "path": "/v1/skills/converters",
@@ -3077,7 +3107,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 305,
+    "index": 308,
     "method": "POST",
     "operationId": "skills.convert",
     "path": "/v1/skills/convert",
@@ -3087,7 +3117,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 306,
+    "index": 309,
     "method": "POST",
     "operationId": "skills.import",
     "path": "/v1/skills/import",
@@ -3097,7 +3127,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 307,
+    "index": 310,
     "method": "POST",
     "operationId": "skills.pack",
     "path": "/v1/skills/pack",
@@ -3107,7 +3137,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 308,
+    "index": 311,
     "method": "POST",
     "operationId": "workflows.generator.sessions.create",
     "path": "/v1/workflows/generator/sessions",
@@ -3117,7 +3147,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 309,
+    "index": 312,
     "method": "GET",
     "operationId": "workflows.generator.sessions.get",
     "path": "/v1/workflows/generator/sessions/:sessionId",
@@ -3127,7 +3157,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 310,
+    "index": 313,
     "method": "POST",
     "operationId": "workflows.generator.sessions.messages.create",
     "path": "/v1/workflows/generator/sessions/:sessionId/messages",
@@ -3137,7 +3167,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 311,
+    "index": 314,
     "method": "POST",
     "operationId": "workflows.generator.sessions.generate",
     "path": "/v1/workflows/generator/sessions/:sessionId/generate",
@@ -3147,7 +3177,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 312,
+    "index": 315,
     "method": "GET",
     "operationId": "workflows.generator.sessions.evidence.get",
     "path": "/v1/workflows/generator/sessions/:sessionId/evidence",
@@ -3157,7 +3187,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 313,
+    "index": 316,
     "method": "POST",
     "operationId": "workflows.generator.sessions.approve",
     "path": "/v1/workflows/generator/sessions/:sessionId/approve",
@@ -3167,7 +3197,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 314,
+    "index": 317,
     "method": "DELETE",
     "operationId": "workflows.generator.sessions.cancel",
     "path": "/v1/workflows/generator/sessions/:sessionId",
@@ -3177,7 +3207,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 315,
+    "index": 318,
     "method": "GET",
     "operationId": "rules.bundles.list",
     "path": "/v1/rules/bundles",
@@ -3187,7 +3217,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 316,
+    "index": 319,
     "method": "GET",
     "operationId": "rules.bundles.get",
     "path": "/v1/rules/bundles/:bundleId",
@@ -3197,7 +3227,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 317,
+    "index": 320,
     "method": "POST",
     "operationId": "rules.bundles.create",
     "path": "/v1/rules/bundles",
@@ -3207,7 +3237,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 318,
+    "index": 321,
     "method": "PATCH",
     "operationId": "rules.bundles.update",
     "path": "/v1/rules/bundles/:bundleId",
@@ -3217,7 +3247,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 319,
+    "index": 322,
     "method": "GET",
     "operationId": "rules.bundles.versions.list",
     "path": "/v1/rules/bundles/:bundleId/versions",
@@ -3227,7 +3257,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 320,
+    "index": 323,
     "method": "GET",
     "operationId": "rules.list",
     "path": "/v1/rules/bundles/:bundleId/rules",
@@ -3237,7 +3267,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 321,
+    "index": 324,
     "method": "POST",
     "operationId": "rules.evaluate",
     "path": "/v1/rules/evaluate",
@@ -3247,7 +3277,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 322,
+    "index": 325,
     "method": "POST",
     "operationId": "rules.simulate",
     "path": "/v1/rules/simulate",
@@ -3257,7 +3287,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 323,
+    "index": 326,
     "method": "GET",
     "operationId": "rules.versions.list",
     "path": "/v1/rules/:ruleId/versions",
@@ -3267,7 +3297,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 324,
+    "index": 327,
     "method": "GET",
     "operationId": "rules.audit.log.list",
     "path": "/v1/rules/audit-log",
@@ -3277,7 +3307,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 325,
+    "index": 328,
     "method": "POST",
     "operationId": "node.runner.execute",
     "path": "/v1/node-runner/execute",
@@ -3287,7 +3317,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 326,
+    "index": 329,
     "method": "GET",
     "operationId": "node.runner.executions.get",
     "path": "/v1/node-runner/executions/:executionId",
@@ -3297,7 +3327,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 327,
+    "index": 330,
     "method": "GET",
     "operationId": "node.runner.executions.list",
     "path": "/v1/node-runner/executions",
@@ -3307,7 +3337,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 328,
+    "index": 331,
     "method": "POST",
     "operationId": "acceptance.run",
     "path": "/v1/acceptance/run",
@@ -3317,7 +3347,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 329,
+    "index": 332,
     "method": "GET",
     "operationId": "acceptance.results.get",
     "path": "/v1/acceptance/results/:resultId",
@@ -3327,7 +3357,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 330,
+    "index": 333,
     "method": "GET",
     "operationId": "acceptance.results.list",
     "path": "/v1/acceptance/results",
@@ -3337,7 +3367,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 331,
+    "index": 334,
     "method": "GET",
     "operationId": "acceptance.runs.get",
     "path": "/v1/acceptance/runs/:runId",
@@ -3347,7 +3377,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 332,
+    "index": 335,
     "method": "GET",
     "operationId": "acceptance.tests.list",
     "path": "/v1/acceptance/tests",
@@ -3357,7 +3387,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 333,
+    "index": 336,
     "method": "GET",
     "operationId": "acceptance.tests.get",
     "path": "/v1/acceptance/tests/:testId",
@@ -3367,7 +3397,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 334,
+    "index": 337,
     "method": "POST",
     "operationId": "acceptance.tests.create",
     "path": "/v1/acceptance/tests",
@@ -3377,7 +3407,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 335,
+    "index": 338,
     "method": "PUT",
     "operationId": "acceptance.tests.update",
     "path": "/v1/acceptance/tests/:testId",
@@ -3387,7 +3417,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 336,
+    "index": 339,
     "method": "DELETE",
     "operationId": "acceptance.tests.delete",
     "path": "/v1/acceptance/tests/:testId",
@@ -3397,7 +3427,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 337,
+    "index": 340,
     "method": "GET",
     "operationId": "acceptance.tests.versions.list",
     "path": "/v1/acceptance/tests/:testId/versions",
@@ -3407,7 +3437,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 338,
+    "index": 341,
     "method": "GET",
     "operationId": "acceptance.artifacts.history",
     "path": "/v1/acceptance/artifacts/history",
@@ -3417,7 +3447,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 339,
+    "index": 342,
     "method": "GET",
     "operationId": "retry.policies.list",
     "path": "/v1/retry/policies",
@@ -3427,7 +3457,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 340,
+    "index": 343,
     "method": "GET",
     "operationId": "retry.policies.get",
     "path": "/v1/retry/policies/:policyId",
@@ -3437,7 +3467,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 341,
+    "index": 344,
     "method": "POST",
     "operationId": "retry.policies.create",
     "path": "/v1/retry/policies",
@@ -3447,7 +3477,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 342,
+    "index": 345,
     "method": "PUT",
     "operationId": "retry.policies.update",
     "path": "/v1/retry/policies/:policyId",
@@ -3457,7 +3487,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 343,
+    "index": 346,
     "method": "DELETE",
     "operationId": "retry.policies.delete",
     "path": "/v1/retry/policies/:policyId",
@@ -3467,7 +3497,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 344,
+    "index": 347,
     "method": "POST",
     "operationId": "retry.classify",
     "path": "/v1/retry/classify",
@@ -3477,7 +3507,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 345,
+    "index": 348,
     "method": "POST",
     "operationId": "retry.decide",
     "path": "/v1/retry/decide",
@@ -3487,7 +3517,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 346,
+    "index": 349,
     "method": "GET",
     "operationId": "retry.traces.list",
     "path": "/v1/retry/traces",
@@ -3497,7 +3527,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 347,
+    "index": 350,
     "method": "GET",
     "operationId": "retry.traces.get",
     "path": "/v1/retry/traces/:traceId",
@@ -3507,7 +3537,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 348,
+    "index": 351,
     "method": "GET",
     "operationId": "retry.costs.summary",
     "path": "/v1/retry/costs",
@@ -3517,7 +3547,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 349,
+    "index": 352,
     "method": "GET",
     "operationId": "retry.escalations.list",
     "path": "/v1/retry/escalations",
@@ -3527,7 +3557,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 350,
+    "index": 353,
     "method": "POST",
     "operationId": "retry.escalations.acknowledge",
     "path": "/v1/retry/escalations/:escalationId/acknowledge",
@@ -3537,7 +3567,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 351,
+    "index": 354,
     "method": "GET",
     "operationId": "retry.circuit.breakers.list",
     "path": "/v1/retry/circuit-breakers",
@@ -3547,7 +3577,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 352,
+    "index": 355,
     "method": "GET",
     "operationId": "playbook.list",
     "path": "/v1/playbooks",
@@ -3557,7 +3587,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 353,
+    "index": 356,
     "method": "GET",
     "operationId": "playbook.get",
     "path": "/v1/playbooks/:playbookId",
@@ -3567,7 +3597,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 354,
+    "index": 357,
     "method": "POST",
     "operationId": "playbook.select",
     "path": "/v1/playbooks/select",
@@ -3577,7 +3607,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 355,
+    "index": 358,
     "method": "GET",
     "operationId": "playbook.candidates.list",
     "path": "/v1/playbooks/candidates",
@@ -3587,7 +3617,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 356,
+    "index": 359,
     "method": "POST",
     "operationId": "playbook.candidates.promote",
     "path": "/v1/playbooks/candidates/:candidateId/promote",
@@ -3597,7 +3627,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 357,
+    "index": 360,
     "method": "POST",
     "operationId": "playbook.rollback",
     "path": "/v1/playbooks/:playbookId/rollback",
@@ -3607,7 +3637,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 358,
+    "index": 361,
     "method": "GET",
     "operationId": "playbook.scores",
     "path": "/v1/playbooks/:playbookId/scores",
@@ -3617,7 +3647,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 359,
+    "index": 362,
     "method": "POST",
     "operationId": "memory.store",
     "path": "/v1/memory/store",
@@ -3627,7 +3657,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 360,
+    "index": 363,
     "method": "POST",
     "operationId": "memory.items.create",
     "path": "/v1/memory/items",
@@ -3637,7 +3667,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 361,
+    "index": 364,
     "method": "POST",
     "operationId": "memory.search",
     "path": "/v1/memory/search",
@@ -3647,7 +3677,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 362,
+    "index": 365,
     "method": "GET",
     "operationId": "memory.get",
     "path": "/v1/memory/items/:id",
@@ -3657,7 +3687,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 363,
+    "index": 366,
     "method": "GET",
     "operationId": "memory.list",
     "path": "/v1/memory/items",
@@ -3667,7 +3697,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 364,
+    "index": 367,
     "method": "DELETE",
     "operationId": "memory.delete",
     "path": "/v1/memory/items/:id",
@@ -3677,7 +3707,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 365,
+    "index": 368,
     "method": "POST",
     "operationId": "memory.prune",
     "path": "/v1/memory/prune",
@@ -3687,7 +3717,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 366,
+    "index": 369,
     "method": "GET",
     "operationId": "sessions.usage.get",
     "path": "/v1/sessions/:sessionKey/usage",
@@ -3697,7 +3727,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 367,
+    "index": 370,
     "method": "GET",
     "operationId": "sessions.usage.list",
     "path": "/v1/sessions/usage",
@@ -3707,7 +3737,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 368,
+    "index": 371,
     "method": "GET",
     "operationId": "sessions.list",
     "path": "/v1/sessions",
@@ -3717,7 +3747,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 369,
+    "index": 372,
     "method": "POST",
     "operationId": "sessions.create",
     "path": "/v1/sessions",
@@ -3727,7 +3757,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 370,
+    "index": 373,
     "method": "GET",
     "operationId": "sessions.get",
     "path": "/v1/sessions/:sessionKey",
@@ -3737,7 +3767,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 371,
+    "index": 374,
     "method": "DELETE",
     "operationId": "sessions.delete",
     "path": "/v1/sessions/:sessionKey",
@@ -3747,7 +3777,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 372,
+    "index": 375,
     "method": "POST",
     "operationId": "sessions.archive",
     "path": "/v1/sessions/:sessionKey/archive",
@@ -3757,7 +3787,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 373,
+    "index": 376,
     "method": "POST",
     "operationId": "sessions.reset",
     "path": "/v1/sessions/:sessionKey/reset",
@@ -3767,7 +3797,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 374,
+    "index": 377,
     "method": "POST",
     "operationId": "sessions.prune",
     "path": "/v1/sessions/prune",
@@ -3777,7 +3807,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 375,
+    "index": 378,
     "method": "POST",
     "operationId": "sessions.sweep",
     "path": "/v1/sessions/sweep",
@@ -3787,7 +3817,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 376,
+    "index": 379,
     "method": "POST",
     "operationId": "sessions.compact",
     "path": "/v1/sessions/:sessionKey/compact",
@@ -3797,7 +3827,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 377,
+    "index": 380,
     "method": "GET",
     "operationId": "sessions.messages.list",
     "path": "/v1/sessions/:sessionKey/messages",
@@ -3807,7 +3837,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 378,
+    "index": 381,
     "method": "GET",
     "operationId": "sessions.export",
     "path": "/v1/sessions/:sessionKey/export",
@@ -3817,7 +3847,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 379,
+    "index": 382,
     "method": "POST",
     "operationId": "sessions.messages.create",
     "path": "/v1/sessions/:sessionKey/messages",
@@ -3827,7 +3857,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 380,
+    "index": 383,
     "method": "POST",
     "operationId": "sessions.outbound.send",
     "path": "/v1/sessions/:sessionKey/outbound",
@@ -3837,7 +3867,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 381,
+    "index": 384,
     "method": "POST",
     "operationId": "sessions.run",
     "path": "/v1/sessions/:sessionKey/run",
@@ -3847,7 +3877,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 382,
+    "index": 385,
     "method": "GET",
     "operationId": "sessions.memory.namespace.get",
     "path": "/v1/sessions/:sessionKey/memory-namespace",
@@ -3857,7 +3887,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 383,
+    "index": 386,
     "method": "POST",
     "operationId": "sessions.forks.create",
     "path": "/v1/sessions/:sessionKey/fork",
@@ -3867,7 +3897,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 384,
+    "index": 387,
     "method": "GET",
     "operationId": "sessions.forks.list",
     "path": "/v1/sessions/:sessionKey/forks",
@@ -3877,7 +3907,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 385,
+    "index": 388,
     "method": "POST",
     "operationId": "sessions.forks.merge",
     "path": "/v1/sessions/:sessionKey/merge",
@@ -3887,7 +3917,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 386,
+    "index": 389,
     "method": "POST",
     "operationId": "sessions.memory.extract",
     "path": "/v1/sessions/:sessionKey/memory/extract",
@@ -3897,7 +3927,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 387,
+    "index": 390,
     "method": "POST",
     "operationId": "sessions.memory.remember",
     "path": "/v1/sessions/:sessionKey/memory/remember",
@@ -3907,7 +3937,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 388,
+    "index": 391,
     "method": "GET",
     "operationId": "sessions.memory.extraction.get",
     "path": "/v1/sessions/:sessionKey/memory/extraction",
@@ -3917,7 +3947,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 389,
+    "index": 392,
     "method": "POST",
     "operationId": "sessions.memory.extraction.retry",
     "path": "/v1/sessions/memory/extraction/retry",
@@ -3927,7 +3957,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 390,
+    "index": 393,
     "method": "GET",
     "operationId": "plugins.list",
     "path": "/v1/plugins",
@@ -3937,7 +3967,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 391,
+    "index": 394,
     "method": "GET",
     "operationId": "plugins.get",
     "path": "/v1/plugins/:id",
@@ -3947,7 +3977,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 392,
+    "index": 395,
     "method": "GET",
     "operationId": "plugins.versions.list",
     "path": "/v1/plugins/:id/versions",
@@ -3957,7 +3987,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 393,
+    "index": 396,
     "method": "POST",
     "operationId": "plugins.install",
     "path": "/v1/plugins/:id/install",
@@ -3967,7 +3997,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 394,
+    "index": 397,
     "method": "POST",
     "operationId": "plugins.enable",
     "path": "/v1/plugins/:id/enable",
@@ -3977,7 +4007,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 395,
+    "index": 398,
     "method": "POST",
     "operationId": "plugins.disable",
     "path": "/v1/plugins/:id/disable",
@@ -3987,7 +4017,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 396,
+    "index": 399,
     "method": "DELETE",
     "operationId": "plugins.uninstall",
     "path": "/v1/plugins/:id",
@@ -3997,7 +4027,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 397,
+    "index": 400,
     "method": "POST",
     "operationId": "agent.runs.start",
     "path": "/v1/agent/runs",
@@ -4007,7 +4037,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 398,
+    "index": 401,
     "method": "GET",
     "operationId": "agent.runs.list",
     "path": "/v1/agent/runs",
@@ -4017,7 +4047,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 399,
+    "index": 402,
     "method": "GET",
     "operationId": "agent.runs.summary",
     "path": "/v1/agent/runs/summary",
@@ -4027,7 +4057,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 400,
+    "index": 403,
     "method": "GET",
     "operationId": "agent.runs.get",
     "path": "/v1/agent/runs/:runId",
@@ -4037,7 +4067,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 401,
+    "index": 404,
     "method": "POST",
     "operationId": "agent.runs.cancel",
     "path": "/v1/agent/runs/:runId/cancel",
@@ -4047,7 +4077,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 402,
+    "index": 405,
     "method": "POST",
     "operationId": "agent.runs.resume",
     "path": "/v1/agent/runs/:runId/resume",
@@ -4057,7 +4087,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 403,
+    "index": 406,
     "method": "GET",
     "operationId": "agent.runs.audit",
     "path": "/v1/agent/runs/:runId/audit",
@@ -4067,7 +4097,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 404,
+    "index": 407,
     "method": "POST",
     "operationId": "agent.runs.rollback",
     "path": "/v1/agent/runs/:runId/rollback",
@@ -4077,7 +4107,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 405,
+    "index": 408,
     "method": "POST",
     "operationId": "agent.runs.approve.plan",
     "path": "/v1/agent/runs/:runId/approve-plan",
@@ -4087,7 +4117,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 406,
+    "index": 409,
     "method": "POST",
     "operationId": "agent.runs.reject.plan",
     "path": "/v1/agent/runs/:runId/reject-plan",
@@ -4097,7 +4127,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 407,
+    "index": 410,
     "method": "POST",
     "operationId": "agent.runs.approve.tool",
     "path": "/v1/agent/runs/:runId/approve-tool",
@@ -4107,7 +4137,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 408,
+    "index": 411,
     "method": "POST",
     "operationId": "agent.runs.reject.tool",
     "path": "/v1/agent/runs/:runId/reject-tool",
@@ -4117,7 +4147,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 409,
+    "index": 412,
     "method": "GET",
     "operationId": "agent.runs.events",
     "path": "/v1/agent/runs/:runId/events",
@@ -4127,7 +4157,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 410,
+    "index": 413,
     "method": "POST",
     "operationId": "agent.automations.create",
     "path": "/v1/agent/automations",
@@ -4137,7 +4167,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 411,
+    "index": 414,
     "method": "GET",
     "operationId": "agent.automations.list",
     "path": "/v1/agent/automations",
@@ -4147,7 +4177,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 412,
+    "index": 415,
     "method": "GET",
     "operationId": "agent.automations.get",
     "path": "/v1/agent/automations/:automationId",
@@ -4157,7 +4187,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 413,
+    "index": 416,
     "method": "PATCH",
     "operationId": "agent.automations.update",
     "path": "/v1/agent/automations/:automationId",
@@ -4167,7 +4197,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 414,
+    "index": 417,
     "method": "DELETE",
     "operationId": "agent.automations.delete",
     "path": "/v1/agent/automations/:automationId",
@@ -4177,7 +4207,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 415,
+    "index": 418,
     "method": "POST",
     "operationId": "agent.automations.run",
     "path": "/v1/agent/automations/:automationId/run",
@@ -4187,7 +4217,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 416,
+    "index": 419,
     "method": "GET",
     "operationId": "agent.subagents.list",
     "path": "/v1/agent/subagents",
@@ -4197,7 +4227,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 417,
+    "index": 420,
     "method": "GET",
     "operationId": "agent.subagents.get",
     "path": "/v1/agent/subagents/:subagentId",
@@ -4207,7 +4237,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 418,
+    "index": 421,
     "method": "GET",
     "operationId": "agent.runs.subagents.list",
     "path": "/v1/agent/runs/:runId/subagents",
@@ -4217,7 +4247,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 419,
+    "index": 422,
     "method": "GET",
     "operationId": "assets.inventory.list",
     "path": "/v1/assets/inventory",

--- a/test/contracts/api/friday-api-route-contract.snapshot.test.ts
+++ b/test/contracts/api/friday-api-route-contract.snapshot.test.ts
@@ -859,6 +859,12 @@ describe("MECHANISM-4 — API Route Contract (Snapshot)", () => {
         "cloud.workers.dns.validate",
         "cloud.workers.package.generate",
         "cloud.workers.teardown.receipt",
+        // Lane B: organic mission-spine mutations driven over the sealed-WS dispatch arms.
+        // Each handler refuses the synthetic public principal via
+        // assertBoundPrincipalForOperation before any dispatch (and is flag-OFF/503 by default).
+        "mission.spine.intake.create",
+        "mission.spine.lifecycle.transition",
+        "mission.spine.workitem.status.transition",
       ]);
       // rate_limited_pending
       const RATE_LIMITED_PENDING: ReadonlySet<string> = new Set([

--- a/test/unit/api/mission-spine/friday-rust-hub-mission-spine-wire.test.ts
+++ b/test/unit/api/mission-spine/friday-rust-hub-mission-spine-wire.test.ts
@@ -1,0 +1,255 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildMissionIntakeEnvelope,
+  buildMissionLifecycleEnvelope,
+  buildWorkItemStatusEnvelope,
+  parseMissionIntakeResult,
+  parseMissionLifecycleResult,
+  parseWorkItemStatusResult,
+  type FridayRustHubMissionIntakeRequest,
+  type FridayRustHubMissionLifecycleRequest,
+  type FridayRustHubWorkItemStatusRequest,
+} from "../../../../src/api/mission-spine/friday-rust-hub-agent-run-ws-sealed-client.js";
+
+// (Lane B) The mission-spine wire builders map the TS-side requests onto the EXACT snake_case
+// `friday-protocol` wire shapes (`MissionIntakeRequestWire` / `MissionLifecycleRequestWire` /
+// `WorkItemStatusRequestWire`). Option fields use conditional-spread (absent ⇒ key OMITTED,
+// byte-clean), mirroring `buildConstraintsWire`. The parsers are fail-closed: a missing/ill-typed
+// REQUIRED ref ⇒ `undefined` (the round-trip then fails closed). These carry NO `auth_proof` /
+// `forwarded_principal` — the sealed session is the channel auth.
+
+const FULL_INTAKE: FridayRustHubMissionIntakeRequest = {
+  fridayConversationId: "conversation_x",
+  ownerPrincipal: "owner_x",
+  surfaceThreadId: "surface_x",
+  surfaceKind: "mobile",
+  deliveryRoute: "in_app",
+  visibilityPolicy: "owner_only",
+  missionId: "mission_x",
+  workItemId: "work_x",
+  title: "Title",
+  intent: "Intent",
+  lane: "deepseek",
+};
+
+describe("buildMissionIntakeEnvelope (MissionIntakeRequestWire wire mapping)", () => {
+  it("emits the required fields + kind, omitting all four optionals when absent", () => {
+    const env = buildMissionIntakeEnvelope(FULL_INTAKE);
+    expect(env.schema_version).toBe(12);
+    expect(env.msg_id).toBe("mission-intake-mission_x");
+    expect(env.correlation_id).toBe("mission-intake-mission_x");
+    const message = env.message as Record<string, unknown>;
+    expect(message).toEqual({
+      kind: "MissionIntakeRequest",
+      friday_conversation_id: "conversation_x",
+      owner_principal: "owner_x",
+      surface_thread_id: "surface_x",
+      surface_kind: "mobile",
+      delivery_route: "in_app",
+      visibility_policy: "owner_only",
+      mission_id: "mission_x",
+      work_item_id: "work_x",
+      title: "Title",
+      intent: "Intent",
+      lane: "deepseek",
+    });
+    // Optionals OMITTED entirely (not null/undefined).
+    expect("target_provider_or_agent" in message).toBe(false);
+    expect("capability_id" in message).toBe(false);
+    expect("body_ref" in message).toBe(false);
+    expect("includes_sensitive_context" in message).toBe(false);
+  });
+
+  it("emits the optionals (snake_case) when present; bool only when true", () => {
+    const message = buildMissionIntakeEnvelope({
+      ...FULL_INTAKE,
+      targetProviderOrAgent: "deepseek-v4",
+      capabilityId: "cap_x",
+      bodyRef: "body://ref",
+      includesSensitiveContext: true,
+    }).message as Record<string, unknown>;
+    expect(message.target_provider_or_agent).toBe("deepseek-v4");
+    expect(message.capability_id).toBe("cap_x");
+    expect(message.body_ref).toBe("body://ref");
+    expect(message.includes_sensitive_context).toBe(true);
+  });
+
+  it("never emits includes_sensitive_context when false (matches the Rust serde default)", () => {
+    const message = buildMissionIntakeEnvelope({
+      ...FULL_INTAKE,
+      includesSensitiveContext: false,
+    }).message as Record<string, unknown>;
+    expect("includes_sensitive_context" in message).toBe(false);
+  });
+});
+
+const FULL_LIFECYCLE: FridayRustHubMissionLifecycleRequest = {
+  fridayConversationId: "conversation_x",
+  missionId: "mission_x",
+  targetStatus: "queued",
+  actorRef: "actor_x",
+  reason: "advance",
+};
+
+describe("buildMissionLifecycleEnvelope (MissionLifecycleRequestWire wire mapping)", () => {
+  it("emits the required fields, omitting proof_ref / merged_into_mission_id when absent", () => {
+    const env = buildMissionLifecycleEnvelope(FULL_LIFECYCLE);
+    expect(env.msg_id).toBe("mission-lifecycle-mission_x");
+    const message = env.message as Record<string, unknown>;
+    expect(message).toEqual({
+      kind: "MissionLifecycleRequest",
+      friday_conversation_id: "conversation_x",
+      mission_id: "mission_x",
+      target_status: "queued",
+      actor_ref: "actor_x",
+      reason: "advance",
+    });
+    expect("proof_ref" in message).toBe(false);
+    expect("merged_into_mission_id" in message).toBe(false);
+  });
+
+  it("emits proof_ref + merged_into_mission_id when present", () => {
+    const message = buildMissionLifecycleEnvelope({
+      ...FULL_LIFECYCLE,
+      proofRef: "proof://ref",
+      mergedIntoMissionId: "mission_y",
+    }).message as Record<string, unknown>;
+    expect(message.proof_ref).toBe("proof://ref");
+    expect(message.merged_into_mission_id).toBe("mission_y");
+  });
+});
+
+const FULL_WORK_ITEM: FridayRustHubWorkItemStatusRequest = {
+  workItemId: "work_x",
+  targetStatus: "ready_to_dispatch",
+  actorRef: "actor_x",
+  reason: "stage",
+};
+
+describe("buildWorkItemStatusEnvelope (WorkItemStatusRequestWire wire mapping)", () => {
+  it("emits the required fields, omitting proof_receipt when absent", () => {
+    const env = buildWorkItemStatusEnvelope(FULL_WORK_ITEM);
+    expect(env.msg_id).toBe("work-item-status-work_x");
+    const message = env.message as Record<string, unknown>;
+    expect(message).toEqual({
+      kind: "WorkItemStatusRequest",
+      work_item_id: "work_x",
+      target_status: "ready_to_dispatch",
+      actor_ref: "actor_x",
+      reason: "stage",
+    });
+    expect("proof_receipt" in message).toBe(false);
+  });
+
+  it("emits proof_receipt when present (the completion path)", () => {
+    const message = buildWorkItemStatusEnvelope({
+      ...FULL_WORK_ITEM,
+      targetStatus: "completed_with_proof",
+      proofReceipt: "proof://receipt",
+    }).message as Record<string, unknown>;
+    expect(message.proof_receipt).toBe("proof://receipt");
+  });
+});
+
+describe("parseMissionIntakeResult (fail-closed refs-only)", () => {
+  const valid = {
+    friday_conversation_id: "conversation_x",
+    mission_id: "mission_x",
+    surface_thread_id: "surface_x",
+    status: "ready",
+    blockers: [],
+    created_or_ready: true,
+  };
+
+  it("parses a valid result, surfacing only present optionals", () => {
+    expect(parseMissionIntakeResult(valid)).toEqual({
+      truthLabel: "rust_wired",
+      fridayConversationId: "conversation_x",
+      missionId: "mission_x",
+      surfaceThreadId: "surface_x",
+      status: "ready",
+      blockers: [],
+      createdOrReady: true,
+    });
+    const withOptionals = parseMissionIntakeResult({
+      ...valid,
+      work_item_id: "work_x",
+      duplicate_mission_id: "mission_dup",
+      duplicate_work_item_id: "work_dup",
+    });
+    expect(withOptionals?.workItemId).toBe("work_x");
+    expect(withOptionals?.duplicateMissionId).toBe("mission_dup");
+    expect(withOptionals?.duplicateWorkItemId).toBe("work_dup");
+  });
+
+  it("fails closed (undefined) on a missing required ref or ill-typed fields", () => {
+    expect(parseMissionIntakeResult({ ...valid, mission_id: "" })).toBeUndefined();
+    expect(parseMissionIntakeResult({ ...valid, created_or_ready: "yes" })).toBeUndefined();
+    expect(parseMissionIntakeResult({ ...valid, blockers: [1, 2] })).toBeUndefined();
+    expect(parseMissionIntakeResult({})).toBeUndefined();
+  });
+});
+
+describe("parseMissionLifecycleResult (fail-closed refs-only)", () => {
+  const valid = {
+    friday_conversation_id: "conversation_x",
+    mission_id: "mission_x",
+    previous_status: "ready",
+    status: "queued",
+    actor_ref: "actor_x",
+    reason: "advance",
+    active_mission_ids: ["mission_x"],
+    updated_at_ms: 1700000000000,
+  };
+
+  it("parses a valid result + present optionals", () => {
+    const parsed = parseMissionLifecycleResult({ ...valid, proof_ref: "proof://r", merged_into_mission_id: "mission_y" });
+    expect(parsed?.status).toBe("queued");
+    expect(parsed?.activeMissionIds).toEqual(["mission_x"]);
+    expect(parsed?.updatedAtMs).toBe(1700000000000);
+    expect(parsed?.proofRef).toBe("proof://r");
+    expect(parsed?.mergedIntoMissionId).toBe("mission_y");
+  });
+
+  it("fails closed on a missing required ref or ill-typed updated_at_ms / list", () => {
+    expect(parseMissionLifecycleResult({ ...valid, status: "" })).toBeUndefined();
+    expect(parseMissionLifecycleResult({ ...valid, updated_at_ms: "x" })).toBeUndefined();
+    expect(parseMissionLifecycleResult({ ...valid, active_mission_ids: "nope" })).toBeUndefined();
+  });
+});
+
+describe("parseWorkItemStatusResult (fail-closed refs-only, count not raw refs)", () => {
+  const valid = {
+    work_item_id: "work_x",
+    mission_id: "mission_x",
+    previous_status: "ready_to_dispatch",
+    status: "completed_with_proof",
+    actor_ref: "actor_x",
+    reason: "done",
+    proof_receipt_count: 2,
+    updated_at_ms: 1700000000000,
+  };
+
+  it("parses a valid result, surfacing the proof RECEIPT COUNT (never raw refs)", () => {
+    const parsed = parseWorkItemStatusResult(valid);
+    expect(parsed).toEqual({
+      truthLabel: "rust_wired",
+      workItemId: "work_x",
+      missionId: "mission_x",
+      previousStatus: "ready_to_dispatch",
+      status: "completed_with_proof",
+      actorRef: "actor_x",
+      reason: "done",
+      proofReceiptCount: 2,
+      updatedAtMs: 1700000000000,
+    });
+  });
+
+  it("fails closed on a missing required ref or ill-typed count", () => {
+    expect(parseWorkItemStatusResult({ ...valid, work_item_id: "" })).toBeUndefined();
+    expect(parseWorkItemStatusResult({ ...valid, reason: "" })).toBeUndefined();
+    expect(parseWorkItemStatusResult({ ...valid, proof_receipt_count: "two" })).toBeUndefined();
+    expect(parseWorkItemStatusResult({ ...valid, updated_at_ms: undefined })).toBeUndefined();
+  });
+});

--- a/test/unit/api/mission-spine/friday-rust-hub-mission-spine-wire.test.ts
+++ b/test/unit/api/mission-spine/friday-rust-hub-mission-spine-wire.test.ts
@@ -13,11 +13,16 @@ import {
 } from "../../../../src/api/mission-spine/friday-rust-hub-agent-run-ws-sealed-client.js";
 
 // (Lane B) The mission-spine wire builders map the TS-side requests onto the EXACT snake_case
-// `friday-protocol` wire shapes (`MissionIntakeRequestWire` / `MissionLifecycleRequestWire` /
-// `WorkItemStatusRequestWire`). Option fields use conditional-spread (absent ⇒ key OMITTED,
-// byte-clean), mirroring `buildConstraintsWire`. The parsers are fail-closed: a missing/ill-typed
-// REQUIRED ref ⇒ `undefined` (the round-trip then fails closed). These carry NO `auth_proof` /
-// `forwarded_principal` — the sealed session is the channel auth.
+// `friday-protocol` wire shapes. CRITICAL (HOLE-1): each `Message::Mission*Request`/`*Result`
+// variant is a SINGLE-FIELD WRAPPER (`{ request: …Wire }` / `{ result: …Wire }`) on an
+// internally-tagged (`#[serde(tag = "kind")]`) enum, so serde NESTS the inner wire fields under a
+// `request`/`result` key — they are NOT flat under `message`. A flat shape fails `Envelope::decode`
+// server-side (missing `request`) and `parse*Result` reading `fields.X` instead of `fields.result.X`
+// ⇒ undefined ⇒ 503. Option fields use conditional-spread (absent ⇒ key OMITTED, byte-clean). The
+// parsers are fail-closed: a missing/ill-typed `result` wrapper OR a missing required ref ⇒
+// `undefined`. These carry NO `auth_proof`/`forwarded_principal` — the sealed session is the channel
+// auth. The TS↔Rust nesting is PINNED by the golden cross-check at the bottom of this file (the
+// EXACT bytes the Rust `Envelope::encode` round-trip test emits for these messages).
 
 const FULL_INTAKE: FridayRustHubMissionIntakeRequest = {
   fridayConversationId: "conversation_x",
@@ -34,14 +39,17 @@ const FULL_INTAKE: FridayRustHubMissionIntakeRequest = {
 };
 
 describe("buildMissionIntakeEnvelope (MissionIntakeRequestWire wire mapping)", () => {
-  it("emits the required fields + kind, omitting all four optionals when absent", () => {
+  it("nests the required fields under `request` + kind, omitting all four optionals when absent", () => {
     const env = buildMissionIntakeEnvelope(FULL_INTAKE);
     expect(env.schema_version).toBe(12);
     expect(env.msg_id).toBe("mission-intake-mission_x");
     expect(env.correlation_id).toBe("mission-intake-mission_x");
     const message = env.message as Record<string, unknown>;
-    expect(message).toEqual({
-      kind: "MissionIntakeRequest",
+    expect(message.kind).toBe("MissionIntakeRequest");
+    // The wrapper key is `request` (NOT flat fields under `message`).
+    expect(Object.keys(message).sort()).toEqual(["kind", "request"]);
+    const request = message.request as Record<string, unknown>;
+    expect(request).toEqual({
       friday_conversation_id: "conversation_x",
       owner_principal: "owner_x",
       surface_thread_id: "surface_x",
@@ -55,13 +63,13 @@ describe("buildMissionIntakeEnvelope (MissionIntakeRequestWire wire mapping)", (
       lane: "deepseek",
     });
     // Optionals OMITTED entirely (not null/undefined).
-    expect("target_provider_or_agent" in message).toBe(false);
-    expect("capability_id" in message).toBe(false);
-    expect("body_ref" in message).toBe(false);
-    expect("includes_sensitive_context" in message).toBe(false);
+    expect("target_provider_or_agent" in request).toBe(false);
+    expect("capability_id" in request).toBe(false);
+    expect("body_ref" in request).toBe(false);
+    expect("includes_sensitive_context" in request).toBe(false);
   });
 
-  it("emits the optionals (snake_case) when present; bool only when true", () => {
+  it("emits the optionals (snake_case, nested under request) when present; bool only when true", () => {
     const message = buildMissionIntakeEnvelope({
       ...FULL_INTAKE,
       targetProviderOrAgent: "deepseek-v4",
@@ -69,10 +77,11 @@ describe("buildMissionIntakeEnvelope (MissionIntakeRequestWire wire mapping)", (
       bodyRef: "body://ref",
       includesSensitiveContext: true,
     }).message as Record<string, unknown>;
-    expect(message.target_provider_or_agent).toBe("deepseek-v4");
-    expect(message.capability_id).toBe("cap_x");
-    expect(message.body_ref).toBe("body://ref");
-    expect(message.includes_sensitive_context).toBe(true);
+    const request = message.request as Record<string, unknown>;
+    expect(request.target_provider_or_agent).toBe("deepseek-v4");
+    expect(request.capability_id).toBe("cap_x");
+    expect(request.body_ref).toBe("body://ref");
+    expect(request.includes_sensitive_context).toBe(true);
   });
 
   it("never emits includes_sensitive_context when false (matches the Rust serde default)", () => {
@@ -80,7 +89,8 @@ describe("buildMissionIntakeEnvelope (MissionIntakeRequestWire wire mapping)", (
       ...FULL_INTAKE,
       includesSensitiveContext: false,
     }).message as Record<string, unknown>;
-    expect("includes_sensitive_context" in message).toBe(false);
+    const request = message.request as Record<string, unknown>;
+    expect("includes_sensitive_context" in request).toBe(false);
   });
 });
 
@@ -93,30 +103,33 @@ const FULL_LIFECYCLE: FridayRustHubMissionLifecycleRequest = {
 };
 
 describe("buildMissionLifecycleEnvelope (MissionLifecycleRequestWire wire mapping)", () => {
-  it("emits the required fields, omitting proof_ref / merged_into_mission_id when absent", () => {
+  it("nests the required fields under `request`, omitting proof_ref / merged_into_mission_id when absent", () => {
     const env = buildMissionLifecycleEnvelope(FULL_LIFECYCLE);
     expect(env.msg_id).toBe("mission-lifecycle-mission_x");
     const message = env.message as Record<string, unknown>;
-    expect(message).toEqual({
-      kind: "MissionLifecycleRequest",
+    expect(message.kind).toBe("MissionLifecycleRequest");
+    expect(Object.keys(message).sort()).toEqual(["kind", "request"]);
+    const request = message.request as Record<string, unknown>;
+    expect(request).toEqual({
       friday_conversation_id: "conversation_x",
       mission_id: "mission_x",
       target_status: "queued",
       actor_ref: "actor_x",
       reason: "advance",
     });
-    expect("proof_ref" in message).toBe(false);
-    expect("merged_into_mission_id" in message).toBe(false);
+    expect("proof_ref" in request).toBe(false);
+    expect("merged_into_mission_id" in request).toBe(false);
   });
 
-  it("emits proof_ref + merged_into_mission_id when present", () => {
+  it("emits proof_ref + merged_into_mission_id (nested) when present", () => {
     const message = buildMissionLifecycleEnvelope({
       ...FULL_LIFECYCLE,
       proofRef: "proof://ref",
       mergedIntoMissionId: "mission_y",
     }).message as Record<string, unknown>;
-    expect(message.proof_ref).toBe("proof://ref");
-    expect(message.merged_into_mission_id).toBe("mission_y");
+    const request = message.request as Record<string, unknown>;
+    expect(request.proof_ref).toBe("proof://ref");
+    expect(request.merged_into_mission_id).toBe("mission_y");
   });
 });
 
@@ -128,38 +141,44 @@ const FULL_WORK_ITEM: FridayRustHubWorkItemStatusRequest = {
 };
 
 describe("buildWorkItemStatusEnvelope (WorkItemStatusRequestWire wire mapping)", () => {
-  it("emits the required fields, omitting proof_receipt when absent", () => {
+  it("nests the required fields under `request`, omitting proof_receipt when absent", () => {
     const env = buildWorkItemStatusEnvelope(FULL_WORK_ITEM);
     expect(env.msg_id).toBe("work-item-status-work_x");
     const message = env.message as Record<string, unknown>;
-    expect(message).toEqual({
-      kind: "WorkItemStatusRequest",
+    expect(message.kind).toBe("WorkItemStatusRequest");
+    expect(Object.keys(message).sort()).toEqual(["kind", "request"]);
+    const request = message.request as Record<string, unknown>;
+    expect(request).toEqual({
       work_item_id: "work_x",
       target_status: "ready_to_dispatch",
       actor_ref: "actor_x",
       reason: "stage",
     });
-    expect("proof_receipt" in message).toBe(false);
+    expect("proof_receipt" in request).toBe(false);
   });
 
-  it("emits proof_receipt when present (the completion path)", () => {
+  it("emits proof_receipt (nested) when present (the completion path)", () => {
     const message = buildWorkItemStatusEnvelope({
       ...FULL_WORK_ITEM,
       targetStatus: "completed_with_proof",
       proofReceipt: "proof://receipt",
     }).message as Record<string, unknown>;
-    expect(message.proof_receipt).toBe("proof://receipt");
+    const request = message.request as Record<string, unknown>;
+    expect(request.proof_receipt).toBe("proof://receipt");
   });
 });
 
-describe("parseMissionIntakeResult (fail-closed refs-only)", () => {
+describe("parseMissionIntakeResult (fail-closed refs-only, NESTED result)", () => {
+  // The parser is handed the whole `message` object: `{kind, result:{…refs…}}`.
   const valid = {
-    friday_conversation_id: "conversation_x",
-    mission_id: "mission_x",
-    surface_thread_id: "surface_x",
-    status: "ready",
-    blockers: [],
-    created_or_ready: true,
+    result: {
+      friday_conversation_id: "conversation_x",
+      mission_id: "mission_x",
+      surface_thread_id: "surface_x",
+      status: "ready",
+      blockers: [],
+      created_or_ready: true,
+    },
   };
 
   it("parses a valid result, surfacing only present optionals", () => {
@@ -173,10 +192,12 @@ describe("parseMissionIntakeResult (fail-closed refs-only)", () => {
       createdOrReady: true,
     });
     const withOptionals = parseMissionIntakeResult({
-      ...valid,
-      work_item_id: "work_x",
-      duplicate_mission_id: "mission_dup",
-      duplicate_work_item_id: "work_dup",
+      result: {
+        ...valid.result,
+        work_item_id: "work_x",
+        duplicate_mission_id: "mission_dup",
+        duplicate_work_item_id: "work_dup",
+      },
     });
     expect(withOptionals?.workItemId).toBe("work_x");
     expect(withOptionals?.duplicateMissionId).toBe("mission_dup");
@@ -184,27 +205,40 @@ describe("parseMissionIntakeResult (fail-closed refs-only)", () => {
   });
 
   it("fails closed (undefined) on a missing required ref or ill-typed fields", () => {
-    expect(parseMissionIntakeResult({ ...valid, mission_id: "" })).toBeUndefined();
-    expect(parseMissionIntakeResult({ ...valid, created_or_ready: "yes" })).toBeUndefined();
-    expect(parseMissionIntakeResult({ ...valid, blockers: [1, 2] })).toBeUndefined();
+    expect(parseMissionIntakeResult({ result: { ...valid.result, mission_id: "" } })).toBeUndefined();
+    expect(parseMissionIntakeResult({ result: { ...valid.result, created_or_ready: "yes" } })).toBeUndefined();
+    expect(parseMissionIntakeResult({ result: { ...valid.result, blockers: [1, 2] } })).toBeUndefined();
+    expect(parseMissionIntakeResult({ result: {} })).toBeUndefined();
+  });
+
+  it("fails closed (no throw) on a missing/ill-typed `result` wrapper — the flat (pre-fix) shape", () => {
+    // The flat pre-fix shape (refs directly under message) MUST fail closed, never throw — parse()
+    // runs OUTSIDE the inbound try/catch, so a thrown TypeError would not be a clean 503.
+    expect(parseMissionIntakeResult(valid.result)).toBeUndefined();
     expect(parseMissionIntakeResult({})).toBeUndefined();
+    expect(parseMissionIntakeResult({ result: null as unknown as Record<string, unknown> })).toBeUndefined();
+    expect(parseMissionIntakeResult({ result: [] as unknown as Record<string, unknown> })).toBeUndefined();
   });
 });
 
-describe("parseMissionLifecycleResult (fail-closed refs-only)", () => {
+describe("parseMissionLifecycleResult (fail-closed refs-only, NESTED result)", () => {
   const valid = {
-    friday_conversation_id: "conversation_x",
-    mission_id: "mission_x",
-    previous_status: "ready",
-    status: "queued",
-    actor_ref: "actor_x",
-    reason: "advance",
-    active_mission_ids: ["mission_x"],
-    updated_at_ms: 1700000000000,
+    result: {
+      friday_conversation_id: "conversation_x",
+      mission_id: "mission_x",
+      previous_status: "ready",
+      status: "queued",
+      actor_ref: "actor_x",
+      reason: "advance",
+      active_mission_ids: ["mission_x"],
+      updated_at_ms: 1700000000000,
+    },
   };
 
   it("parses a valid result + present optionals", () => {
-    const parsed = parseMissionLifecycleResult({ ...valid, proof_ref: "proof://r", merged_into_mission_id: "mission_y" });
+    const parsed = parseMissionLifecycleResult({
+      result: { ...valid.result, proof_ref: "proof://r", merged_into_mission_id: "mission_y" },
+    });
     expect(parsed?.status).toBe("queued");
     expect(parsed?.activeMissionIds).toEqual(["mission_x"]);
     expect(parsed?.updatedAtMs).toBe(1700000000000);
@@ -213,22 +247,29 @@ describe("parseMissionLifecycleResult (fail-closed refs-only)", () => {
   });
 
   it("fails closed on a missing required ref or ill-typed updated_at_ms / list", () => {
-    expect(parseMissionLifecycleResult({ ...valid, status: "" })).toBeUndefined();
-    expect(parseMissionLifecycleResult({ ...valid, updated_at_ms: "x" })).toBeUndefined();
-    expect(parseMissionLifecycleResult({ ...valid, active_mission_ids: "nope" })).toBeUndefined();
+    expect(parseMissionLifecycleResult({ result: { ...valid.result, status: "" } })).toBeUndefined();
+    expect(parseMissionLifecycleResult({ result: { ...valid.result, updated_at_ms: "x" } })).toBeUndefined();
+    expect(parseMissionLifecycleResult({ result: { ...valid.result, active_mission_ids: "nope" } })).toBeUndefined();
+  });
+
+  it("fails closed (no throw) on a missing `result` wrapper (the flat pre-fix shape)", () => {
+    expect(parseMissionLifecycleResult(valid.result)).toBeUndefined();
+    expect(parseMissionLifecycleResult({})).toBeUndefined();
   });
 });
 
-describe("parseWorkItemStatusResult (fail-closed refs-only, count not raw refs)", () => {
+describe("parseWorkItemStatusResult (fail-closed refs-only, count not raw refs, NESTED result)", () => {
   const valid = {
-    work_item_id: "work_x",
-    mission_id: "mission_x",
-    previous_status: "ready_to_dispatch",
-    status: "completed_with_proof",
-    actor_ref: "actor_x",
-    reason: "done",
-    proof_receipt_count: 2,
-    updated_at_ms: 1700000000000,
+    result: {
+      work_item_id: "work_x",
+      mission_id: "mission_x",
+      previous_status: "ready_to_dispatch",
+      status: "completed_with_proof",
+      actor_ref: "actor_x",
+      reason: "done",
+      proof_receipt_count: 2,
+      updated_at_ms: 1700000000000,
+    },
   };
 
   it("parses a valid result, surfacing the proof RECEIPT COUNT (never raw refs)", () => {
@@ -247,9 +288,146 @@ describe("parseWorkItemStatusResult (fail-closed refs-only, count not raw refs)"
   });
 
   it("fails closed on a missing required ref or ill-typed count", () => {
-    expect(parseWorkItemStatusResult({ ...valid, work_item_id: "" })).toBeUndefined();
-    expect(parseWorkItemStatusResult({ ...valid, reason: "" })).toBeUndefined();
-    expect(parseWorkItemStatusResult({ ...valid, proof_receipt_count: "two" })).toBeUndefined();
-    expect(parseWorkItemStatusResult({ ...valid, updated_at_ms: undefined })).toBeUndefined();
+    expect(parseWorkItemStatusResult({ result: { ...valid.result, work_item_id: "" } })).toBeUndefined();
+    expect(parseWorkItemStatusResult({ result: { ...valid.result, reason: "" } })).toBeUndefined();
+    expect(parseWorkItemStatusResult({ result: { ...valid.result, proof_receipt_count: "two" } })).toBeUndefined();
+    expect(parseWorkItemStatusResult({ result: { ...valid.result, updated_at_ms: undefined } })).toBeUndefined();
+  });
+
+  it("fails closed (no throw) on a missing `result` wrapper (the flat pre-fix shape)", () => {
+    expect(parseWorkItemStatusResult(valid.result)).toBeUndefined();
+    expect(parseWorkItemStatusResult({})).toBeUndefined();
+  });
+});
+
+// ─── TS↔Rust GOLDEN CROSS-CHECK (the real fix for the mock-green trap) ───────
+//
+// These are the EXACT bytes the Rust `Envelope::encode` round-trip emits for the three Mission
+// `*Request`/`*Result` variants, captured VERBATIM from `friday-protocol`'s round-trip test data
+// (`rust-core/crates/friday-protocol/src/lib.rs`, via `Envelope::new("m1", 1000, msg)
+// .with_correlation("c1").encode()`). They prove the on-wire NESTING + key names that a pure
+// TS-side unit test (mock both halves) cannot — if the Rust enum shape changes, the cross-check
+// breaks and forces a re-capture.
+//
+// What is asserted (and what is NOT):
+//  - We `JSON.parse` the Rust JSON and `toEqual` the `message.request`/`message.result` SUB-OBJECT
+//    against what the TS builder emits / what the TS parser consumes. SUB-OBJECT (not full-envelope
+//    byte) comparison is deliberate: the outer envelope cannot be byte-equal (`sent_at = Date.now()`,
+//    `msg_id` is per-entity not "m1", and TS `SCHEMA_VERSION` is 12 vs the current Rust 13 — all
+//    orthogonal to the wire-NESTING bug under repair). The sub-object equality is exactly the bug's
+//    surface: nesting depth + key names + types.
+//  - `includes_sensitive_context`: Rust has `#[serde(default)]` WITHOUT `skip_serializing_if`, so it
+//    is ALWAYS emitted (`false` when unset); TS omits-when-false (serde `default` accepts the
+//    omission — interop-safe). To keep the BUILD cross-check a clean deep-equal we capture the intake
+//    fixture with the bool TRUE, so both sides emit it. (The omit↔false asymmetry for the false case
+//    is covered by the dedicated build unit test above.)
+
+const RUST_INTAKE_REQUEST_JSON =
+  '{"schema_version":13,"msg_id":"m1","correlation_id":"c1","sent_at":1000,"message":{"kind":"MissionIntakeRequest","request":{"friday_conversation_id":"conversation_x","owner_principal":"owner_x","surface_thread_id":"surface_x","surface_kind":"mobile","delivery_route":"in_app","visibility_policy":"owner_only","mission_id":"mission_x","work_item_id":"work_x","title":"Title","intent":"Intent","lane":"deepseek","target_provider_or_agent":"deepseek-v4","capability_id":"cap_x","body_ref":"body://ref","includes_sensitive_context":true}}}';
+const RUST_INTAKE_RESULT_JSON =
+  '{"schema_version":13,"msg_id":"m1","correlation_id":"c1","sent_at":1000,"message":{"kind":"MissionIntakeResult","result":{"friday_conversation_id":"conversation_x","mission_id":"mission_x","work_item_id":"work_x","surface_thread_id":"surface_x","status":"ready","blockers":[],"duplicate_mission_id":"mission_dup","duplicate_work_item_id":"work_dup","created_or_ready":true}}}';
+const RUST_LIFECYCLE_REQUEST_JSON =
+  '{"schema_version":13,"msg_id":"m1","correlation_id":"c1","sent_at":1000,"message":{"kind":"MissionLifecycleRequest","request":{"friday_conversation_id":"conversation_x","mission_id":"mission_x","target_status":"queued","actor_ref":"actor_x","reason":"advance","proof_ref":"proof://ref","merged_into_mission_id":"mission_y"}}}';
+const RUST_LIFECYCLE_RESULT_JSON =
+  '{"schema_version":13,"msg_id":"m1","correlation_id":"c1","sent_at":1000,"message":{"kind":"MissionLifecycleResult","result":{"friday_conversation_id":"conversation_x","mission_id":"mission_x","previous_status":"ready","status":"queued","actor_ref":"actor_x","reason":"advance","proof_ref":"proof://r","merged_into_mission_id":"mission_y","active_mission_ids":["mission_x"],"updated_at_ms":1700000000000}}}';
+const RUST_WORK_ITEM_REQUEST_JSON =
+  '{"schema_version":13,"msg_id":"m1","correlation_id":"c1","sent_at":1000,"message":{"kind":"WorkItemStatusRequest","request":{"work_item_id":"work_x","target_status":"completed_with_proof","actor_ref":"actor_x","reason":"stage","proof_receipt":"proof://receipt"}}}';
+const RUST_WORK_ITEM_RESULT_JSON =
+  '{"schema_version":13,"msg_id":"m1","correlation_id":"c1","sent_at":1000,"message":{"kind":"WorkItemStatusResult","result":{"work_item_id":"work_x","mission_id":"mission_x","previous_status":"ready_to_dispatch","status":"completed_with_proof","actor_ref":"actor_x","reason":"done","proof_receipt_count":2,"updated_at_ms":1700000000000}}}';
+
+/** Pull the inner `message.<key>` sub-object out of a captured Rust envelope JSON string. */
+function rustInner(json: string, key: "request" | "result"): Record<string, unknown> {
+  const env = JSON.parse(json) as { message: Record<string, unknown> };
+  return env.message[key] as Record<string, unknown>;
+}
+
+describe("TS↔Rust golden cross-check: build* emits BYTE-COMPATIBLE nesting the Rust server decodes", () => {
+  it("MissionIntakeRequest: TS `message.request` deep-equals the Rust-emitted `request`", () => {
+    const tsRequest = (
+      buildMissionIntakeEnvelope({
+        ...FULL_INTAKE,
+        targetProviderOrAgent: "deepseek-v4",
+        capabilityId: "cap_x",
+        bodyRef: "body://ref",
+        includesSensitiveContext: true, // emit the bool so both sides carry it (see header note).
+      }).message as Record<string, unknown>
+    ).request;
+    expect(tsRequest).toEqual(rustInner(RUST_INTAKE_REQUEST_JSON, "request"));
+  });
+
+  it("MissionLifecycleRequest: TS `message.request` deep-equals the Rust-emitted `request`", () => {
+    const tsRequest = (
+      buildMissionLifecycleEnvelope({
+        ...FULL_LIFECYCLE,
+        proofRef: "proof://ref",
+        mergedIntoMissionId: "mission_y",
+      }).message as Record<string, unknown>
+    ).request;
+    expect(tsRequest).toEqual(rustInner(RUST_LIFECYCLE_REQUEST_JSON, "request"));
+  });
+
+  it("WorkItemStatusRequest: TS `message.request` deep-equals the Rust-emitted `request`", () => {
+    const tsRequest = (
+      buildWorkItemStatusEnvelope({
+        ...FULL_WORK_ITEM,
+        targetStatus: "completed_with_proof",
+        reason: "stage",
+        proofReceipt: "proof://receipt",
+      }).message as Record<string, unknown>
+    ).request;
+    expect(tsRequest).toEqual(rustInner(RUST_WORK_ITEM_REQUEST_JSON, "request"));
+  });
+});
+
+describe("TS↔Rust golden cross-check: parse*Result CONSUMES the exact Rust-emitted result JSON", () => {
+  it("parseMissionIntakeResult consumes the Rust `MissionIntakeResult` envelope's `message`", () => {
+    const message = (JSON.parse(RUST_INTAKE_RESULT_JSON) as { message: Record<string, unknown> }).message;
+    const parsed = parseMissionIntakeResult(message);
+    expect(parsed).toEqual({
+      truthLabel: "rust_wired",
+      fridayConversationId: "conversation_x",
+      missionId: "mission_x",
+      workItemId: "work_x",
+      surfaceThreadId: "surface_x",
+      status: "ready",
+      blockers: [],
+      duplicateMissionId: "mission_dup",
+      duplicateWorkItemId: "work_dup",
+      createdOrReady: true,
+    });
+  });
+
+  it("parseMissionLifecycleResult consumes the Rust `MissionLifecycleResult` envelope's `message`", () => {
+    const message = (JSON.parse(RUST_LIFECYCLE_RESULT_JSON) as { message: Record<string, unknown> }).message;
+    const parsed = parseMissionLifecycleResult(message);
+    expect(parsed).toEqual({
+      truthLabel: "rust_wired",
+      fridayConversationId: "conversation_x",
+      missionId: "mission_x",
+      previousStatus: "ready",
+      status: "queued",
+      actorRef: "actor_x",
+      reason: "advance",
+      proofRef: "proof://r",
+      mergedIntoMissionId: "mission_y",
+      activeMissionIds: ["mission_x"],
+      updatedAtMs: 1700000000000,
+    });
+  });
+
+  it("parseWorkItemStatusResult consumes the Rust `WorkItemStatusResult` envelope's `message`", () => {
+    const message = (JSON.parse(RUST_WORK_ITEM_RESULT_JSON) as { message: Record<string, unknown> }).message;
+    const parsed = parseWorkItemStatusResult(message);
+    expect(parsed).toEqual({
+      truthLabel: "rust_wired",
+      workItemId: "work_x",
+      missionId: "mission_x",
+      previousStatus: "ready_to_dispatch",
+      status: "completed_with_proof",
+      actorRef: "actor_x",
+      reason: "done",
+      proofReceiptCount: 2,
+      updatedAtMs: 1700000000000,
+    });
   });
 });

--- a/test/unit/api/routes/friday-mission-spine-routes.test.ts
+++ b/test/unit/api/routes/friday-mission-spine-routes.test.ts
@@ -546,3 +546,295 @@ describe("createFridayMissionSpineRoutes", () => {
     expect(JSON.stringify(error.details)).toContain("transcript_event_truth_label_invalid");
   });
 });
+
+// ─── (Lane B) Organic mutation POST routes ──────────────────────────────────
+
+import type { FridayMissionSpineDispatchService } from "../../../../src/api/http/routes/friday-mission-spine-routes.js";
+
+function makeDispatch(overrides: Partial<FridayMissionSpineDispatchService> = {}): {
+  dispatch: FridayMissionSpineDispatchService;
+  intake: ReturnType<typeof vi.fn>;
+  lifecycle: ReturnType<typeof vi.fn>;
+  workItem: ReturnType<typeof vi.fn>;
+} {
+  const intake = vi.fn(async () => ({
+    truthLabel: "rust_wired" as const,
+    fridayConversationId: "conversation_lane_b",
+    missionId: "mission_lane_b",
+    workItemId: "work_lane_b",
+    surfaceThreadId: "surface_lane_b",
+    status: "ready",
+    blockers: [] as string[],
+    createdOrReady: true,
+  }));
+  const lifecycle = vi.fn(async () => ({
+    truthLabel: "rust_wired" as const,
+    fridayConversationId: "conversation_lane_b",
+    missionId: "mission_lane_b",
+    previousStatus: "ready",
+    status: "queued",
+    actorRef: "actor_lane_b",
+    reason: "advance",
+    activeMissionIds: ["mission_lane_b"],
+    updatedAtMs: 1_700_000_000_000,
+  }));
+  const workItem = vi.fn(async () => ({
+    truthLabel: "rust_wired" as const,
+    workItemId: "work_lane_b",
+    missionId: "mission_lane_b",
+    previousStatus: "ready_to_dispatch",
+    status: "completed_with_proof",
+    actorRef: "actor_lane_b",
+    reason: "done",
+    proofReceiptCount: 1,
+    updatedAtMs: 1_700_000_000_000,
+  }));
+  return {
+    dispatch: {
+      intakeMission: intake,
+      transitionMission: lifecycle,
+      transitionWorkItem: workItem,
+      ...overrides,
+    } as FridayMissionSpineDispatchService,
+    intake,
+    lifecycle,
+    workItem,
+  };
+}
+
+function findPost(routes: ReturnType<typeof createFridayMissionSpineRoutes>, operationId: string) {
+  const route = routes.find((candidate) => candidate.operationId === operationId);
+  if (!route) throw new Error(`${operationId} route missing`);
+  return route;
+}
+
+const BOUND_PRINCIPAL = {
+  principalId: "principal-1",
+  userId: "user-1",
+  principalType: "user",
+  role: "admin",
+  scopes: ["hub.admin"],
+};
+
+const VALID_INTAKE_BODY = {
+  fridayConversationId: "conversation_lane_b",
+  ownerPrincipal: "owner_lane_b",
+  surfaceThreadId: "surface_lane_b",
+  surfaceKind: "mobile",
+  deliveryRoute: "in_app",
+  visibilityPolicy: "owner_only",
+  missionId: "mission_lane_b",
+  workItemId: "work_lane_b",
+  title: "Lane B organic intake",
+  intent: "create mission",
+  lane: "deepseek",
+};
+
+const VALID_LIFECYCLE_BODY = {
+  fridayConversationId: "conversation_lane_b",
+  targetStatus: "queued",
+  actorRef: "actor_lane_b",
+  reason: "advance",
+};
+
+const VALID_WORK_ITEM_BODY = {
+  targetStatus: "ready_to_dispatch",
+  actorRef: "actor_lane_b",
+  reason: "stage",
+};
+
+describe("createFridayMissionSpineRoutes — Lane B organic mutation routes", () => {
+  it("registers the three POST routes as public, byte-additive to the GET route", () => {
+    const { dispatch } = makeDispatch();
+    const routes = createFridayMissionSpineRoutes({ workbench: null, disabledReason: null, dispatch });
+    const intake = findPost(routes, "mission.spine.intake.create");
+    const lifecycle = findPost(routes, "mission.spine.lifecycle.transition");
+    const workItem = findPost(routes, "mission.spine.workitem.status.transition");
+    expect(intake.method).toBe("POST");
+    expect(intake.path).toBe("/v1/mission-spine/intake");
+    expect(intake.auth).toEqual({ public: true });
+    expect(lifecycle.path).toBe("/v1/mission-spine/:missionId/lifecycle");
+    expect(workItem.path).toBe("/v1/mission-spine/work-items/:workItemId/status");
+    // The GET route is unchanged and still present.
+    expect(findRoute(routes).method).toBe("GET");
+  });
+
+  describe("flag-OFF (no dispatch service) → honest-unavailable", () => {
+    it("intake returns 503 without invoking any client", async () => {
+      const { intake } = makeDispatch();
+      const routes = createFridayMissionSpineRoutes({ workbench: null, disabledReason: null });
+      const route = findPost(routes, "mission.spine.intake.create");
+      let thrown: unknown = null;
+      try {
+        await route.handler(makeCtx({ body: VALID_INTAKE_BODY }) as never);
+      } catch (err) {
+        thrown = err;
+      }
+      expect(thrown).toBeInstanceOf(FridayDomainError);
+      const error = thrown as FridayDomainError;
+      expect(error.code).toBe("MISSION_SPINE_DISPATCH_UNAVAILABLE");
+      expect(error.httpStatus).toBe(503);
+      expect(intake).not.toHaveBeenCalled();
+    });
+
+    it("lifecycle and work-item also 503 when dispatch is null", async () => {
+      const routes = createFridayMissionSpineRoutes({ workbench: null, disabledReason: null, dispatch: null });
+      const lifecycle = findPost(routes, "mission.spine.lifecycle.transition");
+      const workItem = findPost(routes, "mission.spine.workitem.status.transition");
+      for (const [route, params, body] of [
+        [lifecycle, { missionId: "mission_lane_b" }, VALID_LIFECYCLE_BODY],
+        [workItem, { workItemId: "work_lane_b" }, VALID_WORK_ITEM_BODY],
+      ] as const) {
+        let thrown: unknown = null;
+        try {
+          await route.handler(makeCtx({ params, body }) as never);
+        } catch (err) {
+          thrown = err;
+        }
+        expect((thrown as FridayDomainError).code).toBe("MISSION_SPINE_DISPATCH_UNAVAILABLE");
+        expect((thrown as FridayDomainError).httpStatus).toBe(503);
+      }
+    });
+
+    it("503-unavailable fires FIRST — even for a null (unauthenticated) principal", async () => {
+      const routes = createFridayMissionSpineRoutes({ workbench: null, disabledReason: null });
+      const route = findPost(routes, "mission.spine.intake.create");
+      let thrown: unknown = null;
+      try {
+        await route.handler(makeCtx({ principal: null, body: VALID_INTAKE_BODY }) as never);
+      } catch (err) {
+        thrown = err;
+      }
+      // Flag-OFF is a uniform honest-unavailable, NOT a principal refusal.
+      expect((thrown as FridayDomainError).code).toBe("MISSION_SPINE_DISPATCH_UNAVAILABLE");
+    });
+  });
+
+  describe("flag-ON: bound-principal gate", () => {
+    it("refuses the synthetic public (null) principal with a bound-principal 401, no dispatch", async () => {
+      const { dispatch, intake } = makeDispatch();
+      const routes = createFridayMissionSpineRoutes({ workbench: null, disabledReason: null, dispatch });
+      const route = findPost(routes, "mission.spine.intake.create");
+      let thrown: unknown = null;
+      try {
+        await route.handler(makeCtx({ principal: null, body: VALID_INTAKE_BODY }) as never);
+      } catch (err) {
+        thrown = err;
+      }
+      expect(thrown).toBeInstanceOf(FridayDomainError);
+      expect((thrown as FridayDomainError).httpStatus).toBe(401);
+      expect(intake).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("flag-ON: builds the correct wire + returns the refs-only result", () => {
+    it("intake maps the body to the typed request and passes through the result", async () => {
+      const { dispatch, intake } = makeDispatch();
+      const routes = createFridayMissionSpineRoutes({ workbench: null, disabledReason: null, dispatch });
+      const route = findPost(routes, "mission.spine.intake.create");
+      const response = await route.handler(
+        makeCtx({ principal: BOUND_PRINCIPAL, body: { ...VALID_INTAKE_BODY, includesSensitiveContext: true } }) as never,
+      );
+      expect(intake).toHaveBeenCalledTimes(1);
+      expect(intake).toHaveBeenCalledWith({
+        ...VALID_INTAKE_BODY,
+        includesSensitiveContext: true,
+      });
+      expect((response as { result: { status: string } }).result.status).toBe("ready");
+    });
+
+    it("lifecycle takes the missionId from the path, omitting absent optionals", async () => {
+      const { dispatch, lifecycle } = makeDispatch();
+      const routes = createFridayMissionSpineRoutes({ workbench: null, disabledReason: null, dispatch });
+      const route = findPost(routes, "mission.spine.lifecycle.transition");
+      await route.handler(
+        makeCtx({ principal: BOUND_PRINCIPAL, params: { missionId: "mission_from_path" }, body: VALID_LIFECYCLE_BODY }) as never,
+      );
+      expect(lifecycle).toHaveBeenCalledWith({
+        fridayConversationId: "conversation_lane_b",
+        missionId: "mission_from_path",
+        targetStatus: "queued",
+        actorRef: "actor_lane_b",
+        reason: "advance",
+      });
+    });
+
+    it("work-item takes the workItemId from the path and passes proofReceipt through", async () => {
+      const { dispatch, workItem } = makeDispatch();
+      const routes = createFridayMissionSpineRoutes({ workbench: null, disabledReason: null, dispatch });
+      const route = findPost(routes, "mission.spine.workitem.status.transition");
+      const response = await route.handler(
+        makeCtx({
+          principal: BOUND_PRINCIPAL,
+          params: { workItemId: "work_from_path" },
+          body: { targetStatus: "completed_with_proof", actorRef: "actor_lane_b", reason: "done", proofReceipt: "proof://receipt/ref" },
+        }) as never,
+      );
+      expect(workItem).toHaveBeenCalledWith({
+        workItemId: "work_from_path",
+        targetStatus: "completed_with_proof",
+        actorRef: "actor_lane_b",
+        reason: "done",
+        proofReceipt: "proof://receipt/ref",
+      });
+      expect((response as { result: { proofReceiptCount: number } }).result.proofReceiptCount).toBe(1);
+    });
+  });
+
+  describe("flag-ON: invalid body → typed 400, fail-closed (no dispatch)", () => {
+    it("intake rejects a missing required field", async () => {
+      const { dispatch, intake } = makeDispatch();
+      const routes = createFridayMissionSpineRoutes({ workbench: null, disabledReason: null, dispatch });
+      const route = findPost(routes, "mission.spine.intake.create");
+      const { missionId: _omit, ...withoutMission } = VALID_INTAKE_BODY;
+      let thrown: unknown = null;
+      try {
+        await route.handler(makeCtx({ principal: BOUND_PRINCIPAL, body: withoutMission }) as never);
+      } catch (err) {
+        thrown = err;
+      }
+      expect((thrown as FridayDomainError).code).toBe("MISSION_SPINE_DISPATCH_REQUEST_INVALID");
+      expect((thrown as FridayDomainError).httpStatus).toBe(400);
+      expect(JSON.stringify((thrown as FridayDomainError).details)).toContain("missionId_missing_or_empty");
+      expect(intake).not.toHaveBeenCalled();
+    });
+
+    it("lifecycle rejects a missing path missionId", async () => {
+      const { dispatch, lifecycle } = makeDispatch();
+      const routes = createFridayMissionSpineRoutes({ workbench: null, disabledReason: null, dispatch });
+      const route = findPost(routes, "mission.spine.lifecycle.transition");
+      let thrown: unknown = null;
+      try {
+        await route.handler(makeCtx({ principal: BOUND_PRINCIPAL, params: {}, body: VALID_LIFECYCLE_BODY }) as never);
+      } catch (err) {
+        thrown = err;
+      }
+      expect((thrown as FridayDomainError).httpStatus).toBe(400);
+      expect(JSON.stringify((thrown as FridayDomainError).details)).toContain("missionId_missing_or_empty");
+      expect(lifecycle).not.toHaveBeenCalled();
+    });
+
+    it("work-item rejects a proofless completed_with_proof at the edge (mirrors server invariant)", async () => {
+      const { dispatch, workItem } = makeDispatch();
+      const routes = createFridayMissionSpineRoutes({ workbench: null, disabledReason: null, dispatch });
+      const route = findPost(routes, "mission.spine.workitem.status.transition");
+      let thrown: unknown = null;
+      try {
+        await route.handler(
+          makeCtx({
+            principal: BOUND_PRINCIPAL,
+            params: { workItemId: "work_from_path" },
+            body: { targetStatus: "completed_with_proof", actorRef: "a", reason: "r" },
+          }) as never,
+        );
+      } catch (err) {
+        thrown = err;
+      }
+      expect((thrown as FridayDomainError).httpStatus).toBe(400);
+      expect(JSON.stringify((thrown as FridayDomainError).details)).toContain(
+        "proof_receipt_required_for_completion",
+      );
+      expect(workItem).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
## What & why (Lane B)

The **organic caller** for the mission-spine. The keystone #741 wired the Rust `hub_agent_run_server` sealed-WS **dispatch arms** for Mission intake / Mission lifecycle / WorkItem status (gated behind server flags, default-OFF), but nothing in the product reaches them. This PR adds the TS half — sealed-WS client methods + flag-gated POST routes — so the UI/API can actually **create + transition** Missions/WorkItems and **Loop1 can close live** (once the operator flips the server flags + deploys dist).

## The 3 routes (mirror the GET `/v1/mission-spine/workbench` contract)
| Method | Path | operationId | Client method → wire |
|---|---|---|---|
| POST | `/v1/mission-spine/intake` | `mission.spine.intake.create` | `intakeMission` → `MissionIntakeRequest` |
| POST | `/v1/mission-spine/:missionId/lifecycle` | `mission.spine.lifecycle.transition` | `transitionMission` → `MissionLifecycleRequest` |
| POST | `/v1/mission-spine/work-items/:workItemId/status` | `mission.spine.workitem.status.transition` | `transitionWorkItem` → `WorkItemStatusRequest` |

**Handler guard order (per route):** (1) dispatch-disabled (flag-OFF) → **503 honest-unavailable FIRST**, uniform regardless of caller; (2) **bound-principal** (`assertBoundPrincipalForOperation`) → refuse the synthetic public principal (401); (3) body validation → typed **400**; (4) seal + dispatch over the sealed-WS client; refs-only result passthrough. `proof_receipt` is a passthrough on the work-item route (Rust enforces proof-on-completion).

## Client methods (`friday-rust-hub-agent-run-ws-sealed-client.ts`)
- `intakeMission` / `transitionMission` / `transitionWorkItem` mirror `resumeWithApproval`'s handshake (RAW connect → length-prefixed preamble → X25519+HKDF session key → manual RFC6455 upgrade → seal+send → await the FIRST matching `*Result` → settle) via one shared `runMissionRoundTrip` helper, reusing the existing module-level helpers. **`dispatchRun` is untouched** (its `AgentRunRequest` byte-identity is preserved).
- Pure, exported, **socket-free-testable** builders/parsers that map to the **EXACT** `friday-protocol` wire shapes. Option fields use conditional-spread (absent ⇒ key omitted), mirroring `buildConstraintsWire`. These carry **no `auth_proof`/`forwarded_principal`** — the sealed session **is** the channel auth (single-peer/single-owner SERVER invariant), as the keystone arms document.
- **Refs-only + fail-closed:** ANY non-matching inbound — **including the server's `Error` envelope** (illegal hop / missing entity / proofless completion) — is a typed fail-closed (503), never a partial. (Granular 4xx mapping of a server-side domain rejection is deferred; today it's a clean fail-closed 503.)

## The flag & dark-safety (flag-OFF byte-identical / honest-unavailable)
- The route flag lives as `deps.dispatch` on `FridayMissionSpineRoutesDeps`, **default `null`**. `null` ⇒ each POST route is honest-unavailable (503), the **same pattern** as the read route's unavailable path. The base/contract runtime (no `deps.missionSpine.dispatch`) keeps it `null` automatically, so **adding these routes is byte-identical to today for existing traffic** — no live-by-default mutating route, no runtime DI change needed.
- **LIVE closure additionally needs the SERVER flags** (operator-gated flip) + a **dist deploy**. Note the two-flag nuance from #741: intake rides **`FRIDAY_MISSION_INTAKE`**, while lifecycle + work-item ride **`FRIDAY_MISSION_SPINE_DISPATCH`** (the task statement collapsed these into one).

## Gate family (no gate-weakening)
The 3 public mutating routes are classified **`bound_principal`** (NOT dropped into the `unclassified` debt bucket — that would be a new ungated mutating surface). Each handler calls `assertBoundPrincipalForOperation` before any dispatch; 3 new members were added to the `FridayPublicMutationOperation` union and the WP-001 contract `BOUND_PRINCIPAL` set. The contract snapshot was regenerated and the diff is **verifiably additive**: 3 new entries + index renumber + route count 420→423; `bound_principal` 59→62, `total_public_mutating` 321→324; **no existing route's auth/path/method changed**.

## KATs
- **flag-OFF** → routes honest-unavailable 503, **no client call** (incl. for a `null` principal — 503 fires before the principal check).
- **bound-principal** → a `null`/synthetic public principal is refused with 401, **no dispatch**.
- **flag-ON** → each route builds the correct wire + calls the (mocked) client + returns the refs-only result; path id (`missionId`/`workItemId`) is taken from the path; optional fields omitted when absent.
- **invalid body / missing path id / proofless `completed_with_proof`** → typed 400, fail-closed (no dispatch).
- builder optional-omission (snake_case, bool only when true) + parser **fail-closed on missing/ill-typed required refs** (all `*Result` fields verified field-for-field against the origin/main wire structs, incl. the required `reason` on `WorkItemStatusResult`).

## Local gates
- `npm run lint` — **0 errors** (warnings only, matching existing codebase patterns).
- `npm run typecheck` — clean (src + contracts).
- `npx vitest run` mission-spine + routes — **35 new tests** green; full mission-spine suite (214) green.
- `npm run test:contracts` / `test:contracts:routes` — green (snapshot updated, additive).
- `npm run check:secret-patterns` — clean.

## Scope
TS-only. Touches the mission-spine routes file, the sealed-WS client, the public-mutation-op union (1 line family), and the WP-001 contract test set. **No Rust, no unrelated hot files, no runtime DI change.** Born current on the latest `origin/main` at branch time. Do **not** merge — this lands DARK; the product needle moves only on the operator's server-flag flip + dist deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)