### PR TITLE
feat(mission-spine): wire dispatch adapter into bootstrap so organic routes are callable (FRIDAY_MISSION_SPINE_ROUTES_VIA_RUST, dark)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -905,14 +905,14 @@
         "filename": "test/unit/hub/friday-hub-bootstrap-env.test.ts",
         "hashed_secret": "5c5a15a8b0b3e154d77746945e563ba40100681b",
         "is_verified": false,
-        "line_number": 134
+        "line_number": 135
       },
       {
         "type": "Secret Keyword",
         "filename": "test/unit/hub/friday-hub-bootstrap-env.test.ts",
         "hashed_secret": "8a8281cec699f5e51330e21dd7fab3531af6ef0c",
         "is_verified": false,
-        "line_number": 135
+        "line_number": 136
       }
     ],
     "test/unit/media-understanding/friday-openai-vision-provider.test.ts": [
@@ -1124,5 +1124,5 @@
       }
     ]
   },
-  "generated_at": "2026-06-11T23:19:56Z"
+  "generated_at": "2026-06-14T05:43:03Z"
 }

--- a/src/api/mission-spine/friday-mission-spine-dispatch-adapter.ts
+++ b/src/api/mission-spine/friday-mission-spine-dispatch-adapter.ts
@@ -1,0 +1,188 @@
+import { FridayDomainError } from "#errors";
+
+import type { FridayMissionSpineDispatchService } from "../http/routes/friday-mission-spine-routes.js";
+import {
+  createFridayRustHubAgentRunSealedClient,
+  type CreateFridayRustHubAgentRunSealedClientOptions,
+  type FridayRustHubAgentRunSealedClient,
+  type FridayRustHubMissionIntakeRequest,
+  type FridayRustHubMissionIntakeResult,
+  type FridayRustHubMissionLifecycleRequest,
+  type FridayRustHubMissionLifecycleResult,
+  type FridayRustHubWorkItemStatusRequest,
+  type FridayRustHubWorkItemStatusResult,
+} from "./friday-rust-hub-agent-run-ws-sealed-client.js";
+import type { FridayRustAgentRunWsClientX25519SecretResolver } from "./friday-rust-hub-agent-run-ws-client-x25519-secret.js";
+
+/**
+ * (Lane B-2) The bootstrap-side ADAPTER that makes the three ORGANIC mission-spine POST routes
+ * (`/v1/mission-spine/intake|lifecycle|work-item-status`) CALLABLE — by satisfying the routes'
+ * `deps.dispatch` ({@link FridayMissionSpineDispatchService}). Until something provides that
+ * dispatcher, every POST route is PERMANENTLY 503 (`MISSION_SPINE_DISPATCH_UNAVAILABLE`); this
+ * adapter is what an operator flag (`FRIDAY_MISSION_SPINE_ROUTES_VIA_RUST`) wires in to flip them
+ * from honest-unavailable to live.
+ *
+ * ## Why a separate adapter (and not the agent-run Service wrapper)
+ * The agent-run `createFridayRustHubAgentRunSealedClientService` takes a per-DISPATCH `clientSecret`
+ * (compose resolves it from SecureStore per qualifying run) and exposes `dispatchRun`/`resumeWithApproval`.
+ * The mission-spine route interface instead exposes `intakeMission`/`transitionMission`/`transitionWorkItem`
+ * — the THREE PURE-Hub mutations the low-level sealed client (`createFridayRustHubAgentRunSealedClient`)
+ * already implements (`runMissionRoundTrip`: connect → ECDH preamble → WS upgrade → seal+send → await the
+ * FIRST matching `*Result`, refs-only, NO DB). This adapter bridges those: it resolves the X25519 SECRET,
+ * constructs the underlying sealed client, and delegates each method 1:1.
+ *
+ * ## Construction seam (load-bearing for flag-OFF byte-identical)
+ * The factory captures ONLY host/port/timeout + the injectable resolver/createClient seams. It does NOT
+ * resolve a secret and does NOT construct the underlying client at construction time — that happens LAZILY,
+ * INSIDE each method (mirrors the agent-run Service wrapper's per-dispatch `buildClient` idiom). So the
+ * factory is SIDE-EFFECT-FREE: bootstrap can construct it eagerly when the flag is ON with NO key
+ * resolution, NO socket, and NO synchronous `RangeError` from a not-yet-provisioned secret — a flag-ON
+ * but unprovisioned host FAILS CLOSED (503) per call rather than crashing boot. When the flag is OFF the
+ * adapter is never constructed at all and `missionSpine.dispatch` stays unset (null) → byte-identical to
+ * today.
+ *
+ * ## Fail-closed contract (never a fake success)
+ * - The X25519 secret resolver returns `null` (missing / disabled / non-32-byte / SecureStore misconfig)
+ *   ⇒ this throws a typed 503 BEFORE any socket is opened.
+ * - The underlying client constructor throws (e.g. a malformed secret slipped past the resolver) ⇒ caught
+ *   and surfaced as a typed 503.
+ * - The underlying mission round-trip rejects (connect error / closed session / timeout / wrong inbound
+ *   kind / the server's `Error` envelope / unparseable result) ⇒ its `FridayDomainError` (503) surfaces
+ *   UNCHANGED; any non-domain throw is wrapped as a typed 503. There is NO new success path — a result is
+ *   the refs-only `*Result` the low-level client already returns, passed through verbatim.
+ *
+ * ## Truth labels (read before trusting this)
+ * - `rust_wired` ceiling: confers NO v1 GO. End-to-end Loop1 closure ALSO needs the SERVER flags
+ *   (`FRIDAY_MISSION_INTAKE` for intake, `FRIDAY_MISSION_SPINE_DISPATCH` for lifecycle/work-item) + a
+ *   deploy + a real test mission (operator-gated). This adapter only makes the TS routes callable.
+ */
+
+/**
+ * Factory seam for the underlying sealed client. Defaults to the real
+ * {@link createFridayRustHubAgentRunSealedClient}; tests inject a fake to delegate/fail-closed
+ * WITHOUT a socket (and without re-proving the already-proven interop).
+ */
+export type CreateMissionSpineSealedClientFn = (
+  options: CreateFridayRustHubAgentRunSealedClientOptions,
+) => FridayRustHubAgentRunSealedClient;
+
+export interface CreateFridayMissionSpineDispatchAdapterOptions {
+  /** Loopback host for the Rust agent-run WS server. Defaults to `127.0.0.1` (in the client). */
+  readonly host?: string;
+  /** Port the Rust agent-run WS server listens on (the SAME server the agent-run path dials). */
+  readonly port: number;
+  /** Bounded await (ms) for one mission round-trip before failing closed. */
+  readonly timeoutMs?: number;
+  /**
+   * SecureStore resolver for the sealed WS client's X25519 SECRET — the SAME ECDH-model resolver the
+   * agent-run path uses. A `null`/short resolve fails closed → no WS call, today's 503. Tests inject a
+   * fixture secret. NEVER logs it.
+   */
+  readonly secretResolver: FridayRustAgentRunWsClientX25519SecretResolver;
+  /**
+   * Injectable factory for the underlying sealed client (test seam). Default = the real sealed client.
+   * Constructed LAZILY per-call so this factory itself is side-effect-free.
+   */
+  readonly createClient?: CreateMissionSpineSealedClientFn;
+}
+
+function unavailable(message: string): FridayDomainError {
+  return new FridayDomainError("MISSION_SPINE_DISPATCH_RUST_UNAVAILABLE", message, {
+    httpStatus: 503,
+    details: {
+      surface: "service:mission_spine_dispatch_adapter",
+      bridge: "rust_wired",
+      proofOnly: true,
+      proofReady: false,
+    },
+  });
+}
+
+/**
+ * Build the mission-spine dispatch ADAPTER the bootstrap injects into `missionSpine.dispatch` when
+ * `FRIDAY_MISSION_SPINE_ROUTES_VIA_RUST` is on. SIDE-EFFECT-FREE: captures host/port/timeout +
+ * resolver/createClient seams only; resolves no secret and opens no socket until a route actually
+ * calls one of the three methods on a real request.
+ */
+export function createFridayMissionSpineDispatchAdapter(
+  options: CreateFridayMissionSpineDispatchAdapterOptions,
+): FridayMissionSpineDispatchService {
+  const { host, port, timeoutMs } = options;
+  const createClient = options.createClient ?? createFridayRustHubAgentRunSealedClient;
+  const secretResolver = options.secretResolver;
+
+  /**
+   * Resolve the X25519 secret + construct the underlying sealed client — shared by all three methods.
+   * Fail-closed (503): a `null`/short resolve → no client; a constructor throw (non-32-byte secret) →
+   * mapped to 503 so a malformed resolve surfaces as today's 503 rather than an unhandled throw.
+   */
+  function buildClient(): FridayRustHubAgentRunSealedClient {
+    const clientSecret = secretResolver();
+    if (!clientSecret) {
+      throw unavailable("Mission-spine dispatch could not resolve the sealed-WS client secret.");
+    }
+    try {
+      return createClient({
+        ...(host !== undefined ? { host } : {}),
+        port,
+        clientSecret,
+        ...(timeoutMs !== undefined ? { timeoutMs } : {}),
+      });
+    } catch {
+      throw unavailable("Mission-spine dispatch could not construct the sealed-WS client.");
+    }
+  }
+
+  return {
+    async intakeMission(
+      request: FridayRustHubMissionIntakeRequest,
+    ): Promise<FridayRustHubMissionIntakeResult> {
+      const client = buildClient();
+      try {
+        return await client.intakeMission(request);
+      } catch (error) {
+        throw error instanceof FridayDomainError
+          ? error
+          : unavailable("Mission-spine intake dispatch failed.");
+      }
+    },
+
+    async transitionMission(
+      request: FridayRustHubMissionLifecycleRequest,
+    ): Promise<FridayRustHubMissionLifecycleResult> {
+      const client = buildClient();
+      try {
+        return await client.transitionMission(request);
+      } catch (error) {
+        throw error instanceof FridayDomainError
+          ? error
+          : unavailable("Mission-spine lifecycle dispatch failed.");
+      }
+    },
+
+    async transitionWorkItem(
+      request: FridayRustHubWorkItemStatusRequest,
+    ): Promise<FridayRustHubWorkItemStatusResult> {
+      const client = buildClient();
+      try {
+        return await client.transitionWorkItem(request);
+      } catch (error) {
+        throw error instanceof FridayDomainError
+          ? error
+          : unavailable("Mission-spine work-item dispatch failed.");
+      }
+    },
+  };
+}
+
+/**
+ * Parse the Rust agent-run WS port from a raw env string — REPLICATES `readRustAgentRunWsPort` in
+ * friday-api-runtime.ts EXACTLY so the mission-spine adapter dials the SAME port as the agent-run
+ * path: absent/blank/non-finite/negative ⇒ `0` (with the flag off this port is never dialed; 6b
+ * provisions the real port via `FRIDAY_HUB_AGENT_RUN_WS_PORT`).
+ */
+export function readMissionSpineRustWsPort(raw: string | undefined): number {
+  if (!raw) return 0;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : 0;
+}

--- a/src/hub/bootstrap/hub-helpers.ts
+++ b/src/hub/bootstrap/hub-helpers.ts
@@ -1977,6 +1977,18 @@ export interface FridayHubConfig {
    * `FRIDAY_ROUTE_WORKFLOWS_VIA_RUST` env knob).
    */
   routeWorkflowsViaRust?: boolean;
+  /**
+   * (Lane B-2) ORGANIC mission-spine POST routes bridge (DARK): "wire a real dispatch adapter into
+   * `missionSpine.dispatch` so `/v1/mission-spine/intake|lifecycle|work-item-status` become CALLABLE"
+   * flag. DEFAULT-FALSE — production hub creation must leave this unset so `missionSpine.dispatch`
+   * stays unset (null) and each POST route returns today's fail-closed 503
+   * (`MISSION_SPINE_DISPATCH_UNAVAILABLE`) → byte-identical. When true, bootstrap builds the sealed-WS
+   * dispatch adapter (mirroring the agent-run sealed-WS config) and injects it. End-to-end Loop1
+   * closure ALSO needs the SERVER flags (`FRIDAY_MISSION_INTAKE`, `FRIDAY_MISSION_SPINE_DISPATCH`) + a
+   * deploy + a real mission (operator-gated). Resolution: `resolveRouteMissionSpineViaRust` (explicit
+   * config wins; otherwise the `FRIDAY_MISSION_SPINE_ROUTES_VIA_RUST` env knob).
+   */
+  routeMissionSpineViaRust?: boolean;
 }
 
 // ─── Resolved Hub Config ───

--- a/src/hub/friday-hub-bootstrap.ts
+++ b/src/hub/friday-hub-bootstrap.ts
@@ -120,6 +120,11 @@ import {
 import { createFridaySocialImportService } from "#skills/social-import";
 import { parseFridaySecretInput, resolveFridaySecretInput } from "../security/friday-secret-ref.js";
 import { createFridayRustHubWorkbenchProjectionService } from "../api/mission-spine/friday-rust-hub-workbench-projection-service.js";
+import {
+  createFridayMissionSpineDispatchAdapter,
+  readMissionSpineRustWsPort,
+} from "../api/mission-spine/friday-mission-spine-dispatch-adapter.js";
+import { resolveRustAgentRunWsClientX25519Secret } from "../api/mission-spine/friday-rust-hub-agent-run-ws-client-x25519-secret.js";
 import type { FridayChannelPersonaConfig, FridayGuideLensRoutesDeps, FridaySystemRoutesDeps } from "#api";
 import type { FridayPackagingRoutesDeps } from "../api/http/routes/friday-packaging-routes.js";
 import {
@@ -1015,6 +1020,38 @@ export function resolveRouteWorkflowsViaRust(
     return configValue;
   }
   const raw = (env.FRIDAY_ROUTE_WORKFLOWS_VIA_RUST ?? "").trim().toLowerCase();
+  return raw === "1" || raw === "true";
+}
+
+/**
+ * (Lane B-2) ORGANIC mission-spine POST routes bridge (DARK): single source of truth resolving the
+ * `routeMissionSpineViaRust` flag from (1) an EXPLICIT {@link FridayHubConfig.routeMissionSpineViaRust}
+ * and, only as a fallback, (2) the `FRIDAY_MISSION_SPINE_ROUTES_VIA_RUST` env var — the operator knob
+ * that flips the three organic POST routes (`/v1/mission-spine/intake|lifecycle|work-item-status`)
+ * from PERMANENTLY fail-closed (503 `MISSION_SPINE_DISPATCH_UNAVAILABLE`, because `missionSpine.dispatch`
+ * is never injected) to LIVE — by wiring a real dispatch adapter over the sealed-WS client.
+ *
+ * PRECEDENCE + PARSE mirror {@link resolveRouteAgentRunViaRust} exactly: an explicit config boolean
+ * (true OR false) ALWAYS wins; the env is consulted ONLY when config does not specify. Case-insensitive,
+ * trimmed `"1"` or `"true"` ⇒ true; ABSENT / `""` / `"0"` / `"false"` / ANY other value ⇒ false.
+ * DEFAULT (both unset) ⇒ false, so `missionSpine.dispatch` stays unset (null) and the POST routes are
+ * byte-identical to today's fail-closed 503.
+ *
+ * NOTE: the env var name deliberately deviates from the `FRIDAY_ROUTE_*_VIA_RUST` sibling convention
+ * (it is `FRIDAY_MISSION_SPINE_ROUTES_VIA_RUST`) to read clearly as "the mission-spine ROUTES knob".
+ * End-to-end Loop1 closure ALSO needs the SERVER flags (`FRIDAY_MISSION_INTAKE` for intake,
+ * `FRIDAY_MISSION_SPINE_DISPATCH` for lifecycle/work-item) + a deploy + a real mission (operator-gated);
+ * this client-side knob only makes the TS routes CALLABLE.
+ */
+export function resolveRouteMissionSpineViaRust(
+  configValue: boolean | undefined,
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  // Config explicit (true OR false) wins — env is the fallback for the unset gap only.
+  if (typeof configValue === "boolean") {
+    return configValue;
+  }
+  const raw = (env.FRIDAY_MISSION_SPINE_ROUTES_VIA_RUST ?? "").trim().toLowerCase();
   return raw === "1" || raw === "true";
 }
 
@@ -6976,6 +7013,29 @@ export async function createFridayHub(
     stateDir: stateRuntime.stateDir,
   });
 
+  // (Lane B-2) ORGANIC mission-spine POST routes (DARK): construct the dispatch adapter that makes
+  // `/v1/mission-spine/intake|lifecycle|work-item-status` CALLABLE — but ONLY when the operator flag is
+  // on. SINGLE SOURCE OF TRUTH = `resolveRouteMissionSpineViaRust` (explicit config wins; else the
+  // `FRIDAY_MISSION_SPINE_ROUTES_VIA_RUST` env knob, case-insensitive "1"/"true" → true; anything else,
+  // incl. unset → false). With nothing set (the default) this is `false`, so the adapter is NOT built,
+  // `missionSpine.dispatch` stays unset (the conditional spread below omits the key entirely), and each
+  // POST route returns today's fail-closed 503 (`MISSION_SPINE_DISPATCH_UNAVAILABLE`) → byte-identical.
+  //
+  // SIDE-EFFECT-FREE construction: the adapter factory captures host/port/timeout + the SecureStore
+  // X25519 secret resolver only — it resolves NO secret and opens NO socket here. The secret is resolved
+  // + the sealed client built LAZILY, per route call, so a flag-ON-but-unprovisioned host FAILS CLOSED
+  // (503) per call rather than crashing boot. Config (endpoint + ECDH secret resolver) MIRRORS the
+  // agent-run sealed-WS path (friday-api-runtime.ts ~:4816); the DB path is intentionally NOT carried
+  // (the mission round-trips are refs-only WS, no DB readback).
+  const routeMissionSpineViaRust = resolveRouteMissionSpineViaRust(config.routeMissionSpineViaRust);
+  const missionSpineDispatch = routeMissionSpineViaRust
+    ? createFridayMissionSpineDispatchAdapter({
+      host: process.env.FRIDAY_HUB_AGENT_RUN_WS_HOST ?? "127.0.0.1",
+      port: readMissionSpineRustWsPort(process.env.FRIDAY_HUB_AGENT_RUN_WS_PORT),
+      secretResolver: resolveRustAgentRunWsClientX25519Secret,
+    })
+    : null;
+
   const runtimeSupportedChannelKinds = FRIDAY_SUPPORTED_CHANNEL_KINDS.filter(isFridayChannelKindSupported);
 
   const apiRuntime = createFridayApiRuntime({
@@ -7056,6 +7116,10 @@ export async function createFridayHub(
     canonicalMutatingActionGate: canonicalMutatingActionGateEnabled,
     missionSpine: {
       workbench: missionSpineWorkbenchProjectionService,
+      // (Lane B-2) DARK: `dispatch` is spread in ONLY when the route flag is on (above). With the flag
+      // off the key is OMITTED entirely → the `missionSpine` deps object is structurally IDENTICAL to
+      // today, the routes see `deps.dispatch === undefined`, and each POST route is fail-closed 503.
+      ...(missionSpineDispatch ? { dispatch: missionSpineDispatch } : {}),
       disabledReason: null,
     },
     uix: {

--- a/src/hub/index.ts
+++ b/src/hub/index.ts
@@ -39,6 +39,7 @@ export {
   resolveFridayHubConfig,
   resolveAgentRunControlViaRust,
   resolveRouteAgentRunViaRust,
+  resolveRouteMissionSpineViaRust,
   resolveRouteProvidersViaRust,
   resolveRouteWorkflowsViaRust,
   sanitizeFridayChannelVisibleReply,

--- a/test/unit/api/mission-spine/friday-mission-spine-dispatch-adapter.test.ts
+++ b/test/unit/api/mission-spine/friday-mission-spine-dispatch-adapter.test.ts
@@ -1,0 +1,247 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { FridayDomainError } from "../../../../src/errors/friday-domain-error.js";
+import {
+  createFridayMissionSpineDispatchAdapter,
+  readMissionSpineRustWsPort,
+} from "../../../../src/api/mission-spine/friday-mission-spine-dispatch-adapter.js";
+import type {
+  CreateFridayRustHubAgentRunSealedClientOptions,
+  FridayRustHubAgentRunSealedClient,
+  FridayRustHubMissionIntakeRequest,
+  FridayRustHubMissionIntakeResult,
+  FridayRustHubMissionLifecycleRequest,
+  FridayRustHubMissionLifecycleResult,
+  FridayRustHubWorkItemStatusRequest,
+  FridayRustHubWorkItemStatusResult,
+} from "../../../../src/api/mission-spine/friday-rust-hub-agent-run-ws-sealed-client.js";
+
+// (Lane B-2) The bootstrap-side ADAPTER that satisfies `missionSpine.dispatch` so the three organic
+// POST routes become callable. These tests mock the underlying sealed client at the `createClient`
+// seam + the secret resolver — so we exercise the adapter's lazy-build / delegation / fail-closed
+// WITHOUT a socket and WITHOUT re-proving the (already-proven) ECDH interop.
+
+const SECRET = new Uint8Array(32).fill(7);
+
+const INTAKE_REQ: FridayRustHubMissionIntakeRequest = {
+  fridayConversationId: "conv-1",
+  ownerPrincipal: "principal-owner",
+  surfaceThreadId: "thread-1",
+  surfaceKind: "mobile",
+  deliveryRoute: "mobile",
+  visibilityPolicy: "owner_only",
+  missionId: "mission-1",
+  workItemId: "wi-1",
+  title: "title",
+  intent: "intent",
+  lane: "lane",
+};
+
+const INTAKE_RESULT: FridayRustHubMissionIntakeResult = {
+  truthLabel: "rust_wired",
+  fridayConversationId: "conv-1",
+  missionId: "mission-1",
+  surfaceThreadId: "thread-1",
+  status: "ready",
+  blockers: [],
+  createdOrReady: true,
+};
+
+const LIFECYCLE_REQ: FridayRustHubMissionLifecycleRequest = {
+  fridayConversationId: "conv-1",
+  missionId: "mission-1",
+  targetStatus: "queued",
+  actorRef: "actor-1",
+  reason: "advance",
+};
+
+const LIFECYCLE_RESULT: FridayRustHubMissionLifecycleResult = {
+  truthLabel: "rust_wired",
+  fridayConversationId: "conv-1",
+  missionId: "mission-1",
+  previousStatus: "ready",
+  status: "queued",
+  actorRef: "actor-1",
+  reason: "advance",
+  activeMissionIds: ["mission-1"],
+  updatedAtMs: 1,
+};
+
+const WORKITEM_REQ: FridayRustHubWorkItemStatusRequest = {
+  workItemId: "wi-1",
+  targetStatus: "in_progress",
+  actorRef: "actor-1",
+  reason: "start",
+};
+
+const WORKITEM_RESULT: FridayRustHubWorkItemStatusResult = {
+  truthLabel: "rust_wired",
+  workItemId: "wi-1",
+  missionId: "mission-1",
+  previousStatus: "ready",
+  status: "in_progress",
+  actorRef: "actor-1",
+  reason: "start",
+  proofReceiptCount: 0,
+  updatedAtMs: 1,
+};
+
+/** A fake underlying sealed client + a recorder of how it was constructed/called. */
+function makeFakeClient(behavior: {
+  intake?: FridayRustHubMissionIntakeResult;
+  lifecycle?: FridayRustHubMissionLifecycleResult;
+  workItem?: FridayRustHubWorkItemStatusResult;
+  reject?: unknown;
+}) {
+  const constructed: CreateFridayRustHubAgentRunSealedClientOptions[] = [];
+  const intakeCalls: FridayRustHubMissionIntakeRequest[] = [];
+  const lifecycleCalls: FridayRustHubMissionLifecycleRequest[] = [];
+  const workItemCalls: FridayRustHubWorkItemStatusRequest[] = [];
+  const createClient = vi.fn(
+    (options: CreateFridayRustHubAgentRunSealedClientOptions): FridayRustHubAgentRunSealedClient => {
+      constructed.push(options);
+      return {
+        dispatchRun: vi.fn(async () => {
+          throw new Error("dispatchRun not used by the mission adapter");
+        }),
+        resumeWithApproval: vi.fn(async () => {
+          throw new Error("resumeWithApproval not used by the mission adapter");
+        }),
+        intakeMission: vi.fn(async (req: FridayRustHubMissionIntakeRequest) => {
+          intakeCalls.push(req);
+          if (behavior.reject !== undefined) throw behavior.reject;
+          return behavior.intake!;
+        }),
+        transitionMission: vi.fn(async (req: FridayRustHubMissionLifecycleRequest) => {
+          lifecycleCalls.push(req);
+          if (behavior.reject !== undefined) throw behavior.reject;
+          return behavior.lifecycle!;
+        }),
+        transitionWorkItem: vi.fn(async (req: FridayRustHubWorkItemStatusRequest) => {
+          workItemCalls.push(req);
+          if (behavior.reject !== undefined) throw behavior.reject;
+          return behavior.workItem!;
+        }),
+      };
+    },
+  );
+  return { createClient, constructed, intakeCalls, lifecycleCalls, workItemCalls };
+}
+
+describe("createFridayMissionSpineDispatchAdapter (Lane B-2, dark, adapter)", () => {
+  describe("happy path — delegates to the (mocked) sealed client", () => {
+    it("intakeMission builds the client lazily with the resolved secret + delegates the request", async () => {
+      const fake = makeFakeClient({ intake: INTAKE_RESULT });
+      const secretResolver = vi.fn(() => SECRET);
+      const adapter = createFridayMissionSpineDispatchAdapter({
+        host: "127.0.0.1",
+        port: 48750,
+        secretResolver,
+        createClient: fake.createClient,
+      });
+
+      // Side-effect-free construction: NO secret resolved, NO client built until the first call.
+      expect(secretResolver).not.toHaveBeenCalled();
+      expect(fake.createClient).not.toHaveBeenCalled();
+
+      const result = await adapter.intakeMission(INTAKE_REQ);
+
+      expect(result).toBe(INTAKE_RESULT);
+      expect(secretResolver).toHaveBeenCalledTimes(1);
+      expect(fake.createClient).toHaveBeenCalledTimes(1);
+      expect(fake.constructed[0]).toMatchObject({ host: "127.0.0.1", port: 48750, clientSecret: SECRET });
+      expect(fake.intakeCalls).toEqual([INTAKE_REQ]);
+    });
+
+    it("transitionMission + transitionWorkItem delegate verbatim", async () => {
+      const fake = makeFakeClient({ lifecycle: LIFECYCLE_RESULT, workItem: WORKITEM_RESULT });
+      const adapter = createFridayMissionSpineDispatchAdapter({
+        port: 48750,
+        secretResolver: () => SECRET,
+        createClient: fake.createClient,
+      });
+
+      expect(await adapter.transitionMission(LIFECYCLE_REQ)).toBe(LIFECYCLE_RESULT);
+      expect(await adapter.transitionWorkItem(WORKITEM_REQ)).toBe(WORKITEM_RESULT);
+      expect(fake.lifecycleCalls).toEqual([LIFECYCLE_REQ]);
+      expect(fake.workItemCalls).toEqual([WORKITEM_REQ]);
+    });
+  });
+
+  describe("fail-closed — never a fake success", () => {
+    it("a null secret resolve → typed 503, no client built", async () => {
+      const fake = makeFakeClient({ intake: INTAKE_RESULT });
+      const adapter = createFridayMissionSpineDispatchAdapter({
+        port: 48750,
+        secretResolver: () => null,
+        createClient: fake.createClient,
+      });
+
+      await expect(adapter.intakeMission(INTAKE_REQ)).rejects.toMatchObject({
+        code: "MISSION_SPINE_DISPATCH_RUST_UNAVAILABLE",
+        httpStatus: 503,
+      });
+      expect(fake.createClient).not.toHaveBeenCalled();
+      expect(fake.intakeCalls).toEqual([]);
+    });
+
+    it("the underlying client constructor throwing → typed 503", async () => {
+      const adapter = createFridayMissionSpineDispatchAdapter({
+        port: 48750,
+        secretResolver: () => SECRET,
+        createClient: () => {
+          throw new RangeError("clientSecret must be 32 bytes");
+        },
+      });
+
+      const error = await adapter.transitionMission(LIFECYCLE_REQ).catch((e) => e);
+      expect(error).toBeInstanceOf(FridayDomainError);
+      expect((error as FridayDomainError).code).toBe("MISSION_SPINE_DISPATCH_RUST_UNAVAILABLE");
+      expect((error as FridayDomainError).httpStatus).toBe(503);
+    });
+
+    it("an inner FridayDomainError (e.g. a WS error / server Error envelope) surfaces UNCHANGED", async () => {
+      const innerWsError = new FridayDomainError(
+        "MISSION_SPINE_RUST_AGENT_RUN_SEALED_WS_CLIENT_UNAVAILABLE",
+        "sealed session closed before a result",
+        { httpStatus: 503, details: { surface: "ws" } },
+      );
+      const fake = makeFakeClient({ reject: innerWsError });
+      const adapter = createFridayMissionSpineDispatchAdapter({
+        port: 48750,
+        secretResolver: () => SECRET,
+        createClient: fake.createClient,
+      });
+
+      const error = await adapter.transitionWorkItem(WORKITEM_REQ).catch((e) => e);
+      // Surfaced unchanged → the route returns this exact 503 (never a fake-ready result).
+      expect(error).toBe(innerWsError);
+      expect((error as FridayDomainError).httpStatus).toBe(503);
+    });
+
+    it("a NON-domain inner throw is wrapped as a typed 503 (never leaks as an unhandled throw)", async () => {
+      const fake = makeFakeClient({ reject: new Error("socket ECONNREFUSED") });
+      const adapter = createFridayMissionSpineDispatchAdapter({
+        port: 48750,
+        secretResolver: () => SECRET,
+        createClient: fake.createClient,
+      });
+
+      const error = await adapter.intakeMission(INTAKE_REQ).catch((e) => e);
+      expect(error).toBeInstanceOf(FridayDomainError);
+      expect((error as FridayDomainError).code).toBe("MISSION_SPINE_DISPATCH_RUST_UNAVAILABLE");
+      expect((error as FridayDomainError).httpStatus).toBe(503);
+    });
+  });
+
+  describe("readMissionSpineRustWsPort — replicates the agent-run port parse exactly", () => {
+    it("absent / blank / non-finite / negative ⇒ 0; a valid port parses", () => {
+      expect(readMissionSpineRustWsPort(undefined)).toBe(0);
+      expect(readMissionSpineRustWsPort("")).toBe(0);
+      expect(readMissionSpineRustWsPort("not-a-number")).toBe(0);
+      expect(readMissionSpineRustWsPort("-5")).toBe(0);
+      expect(readMissionSpineRustWsPort("48750")).toBe(48750);
+      expect(readMissionSpineRustWsPort("0")).toBe(0);
+    });
+  });
+});

--- a/test/unit/hub/friday-hub-bootstrap-env.test.ts
+++ b/test/unit/hub/friday-hub-bootstrap-env.test.ts
@@ -5,6 +5,7 @@ import {
   resolveFridayCanonicalMutatingActionGate,
   resolveFridayHubConfig,
   resolveRouteAgentRunViaRust,
+  resolveRouteMissionSpineViaRust,
   resolveRouteProvidersViaRust,
   resolveRouteWorkflowsViaRust,
 } from "#hub";
@@ -496,5 +497,38 @@ describe("resolveRouteWorkflowsViaRust", () => {
     expect(resolveRouteWorkflowsViaRust(true, emptyEnv())).toBe(true);
     expect(resolveRouteWorkflowsViaRust(false, { FRIDAY_ROUTE_WORKFLOWS_VIA_RUST: "1" })).toBe(false);
     expect(resolveRouteWorkflowsViaRust(false, { FRIDAY_ROUTE_WORKFLOWS_VIA_RUST: "true" })).toBe(false);
+  });
+});
+
+describe("resolveRouteMissionSpineViaRust (Lane B-2 organic POST routes flag)", () => {
+  // DEFAULT-OFF: nothing set → false → missionSpine.dispatch stays null → byte-identical 503.
+  it("defaults to false when neither config nor env is set", () => {
+    expect(resolveRouteMissionSpineViaRust(undefined, emptyEnv())).toBe(false);
+  });
+
+  it("parses FRIDAY_MISSION_SPINE_ROUTES_VIA_RUST 1/true (case-insensitive, trimmed) as true", () => {
+    expect(resolveRouteMissionSpineViaRust(undefined, { FRIDAY_MISSION_SPINE_ROUTES_VIA_RUST: "1" })).toBe(true);
+    expect(resolveRouteMissionSpineViaRust(undefined, { FRIDAY_MISSION_SPINE_ROUTES_VIA_RUST: "true" })).toBe(true);
+    expect(resolveRouteMissionSpineViaRust(undefined, { FRIDAY_MISSION_SPINE_ROUTES_VIA_RUST: "TRUE" })).toBe(true);
+    expect(resolveRouteMissionSpineViaRust(undefined, { FRIDAY_MISSION_SPINE_ROUTES_VIA_RUST: "  1  " })).toBe(true);
+    expect(resolveRouteMissionSpineViaRust(undefined, { FRIDAY_MISSION_SPINE_ROUTES_VIA_RUST: " true " })).toBe(true);
+  });
+
+  // Fail-safe OFF: everything that is not exactly "1"/"true" → false.
+  it("treats 0, false, empty, and garbage env values as false (fail-safe off)", () => {
+    expect(resolveRouteMissionSpineViaRust(undefined, { FRIDAY_MISSION_SPINE_ROUTES_VIA_RUST: "0" })).toBe(false);
+    expect(resolveRouteMissionSpineViaRust(undefined, { FRIDAY_MISSION_SPINE_ROUTES_VIA_RUST: "false" })).toBe(false);
+    expect(resolveRouteMissionSpineViaRust(undefined, { FRIDAY_MISSION_SPINE_ROUTES_VIA_RUST: "" })).toBe(false);
+    expect(resolveRouteMissionSpineViaRust(undefined, { FRIDAY_MISSION_SPINE_ROUTES_VIA_RUST: "yes" })).toBe(false);
+    expect(resolveRouteMissionSpineViaRust(undefined, { FRIDAY_MISSION_SPINE_ROUTES_VIA_RUST: "on" })).toBe(false);
+    expect(resolveRouteMissionSpineViaRust(undefined, { FRIDAY_MISSION_SPINE_ROUTES_VIA_RUST: "2" })).toBe(false);
+  });
+
+  // PRECEDENCE: explicit config wins over env (true wins, AND the discriminating false-beats-env-true).
+  it("uses explicit config over the env (true wins; false beats env true)", () => {
+    expect(resolveRouteMissionSpineViaRust(true, { FRIDAY_MISSION_SPINE_ROUTES_VIA_RUST: "0" })).toBe(true);
+    expect(resolveRouteMissionSpineViaRust(true, emptyEnv())).toBe(true);
+    expect(resolveRouteMissionSpineViaRust(false, { FRIDAY_MISSION_SPINE_ROUTES_VIA_RUST: "1" })).toBe(false);
+    expect(resolveRouteMissionSpineViaRust(false, { FRIDAY_MISSION_SPINE_ROUTES_VIA_RUST: "true" })).toBe(false);
   });
 });


### PR DESCRIPTION
## The gap

The three organic mission-spine POST routes — `POST /v1/mission-spine/intake`, `POST /v1/mission-spine/:missionId/lifecycle`, `POST /v1/mission-spine/work-items/:workItemId/status` (in `src/api/http/routes/friday-mission-spine-routes.ts`) — gate on `deps.dispatch`. When it is null/undefined each route returns a **permanent 503** (`MISSION_SPINE_DISPATCH_UNAVAILABLE`).

The hub bootstrap (`src/hub/friday-hub-bootstrap.ts`) set `missionSpine: { workbench, disabledReason: null }` and **never set `dispatch`** — so the routes could never fire, regardless of any server-side configuration. This PR closes that wiring gap behind a default-off flag.

## The flag (dark by default)

`FRIDAY_MISSION_SPINE_ROUTES_VIA_RUST` — resolved by `resolveRouteMissionSpineViaRust(config.routeMissionSpineViaRust)`:
- explicit `FridayHubConfig.routeMissionSpineViaRust` (true OR false) ALWAYS wins;
- else the env var, trimmed + lowercased, `"1"`/`"true"` ⇒ true; absent / `""` / `"0"` / `"false"` / anything else ⇒ false.

This mirrors the `resolveRouteAgentRunViaRust` matcher idiom exactly (config-wins-else-env; narrow true-set). DEFAULT (both unset) ⇒ `false`.

## The adapter wiring (mirrors the agent-run pattern)

New `createFridayMissionSpineDispatchAdapter` (`src/api/mission-spine/friday-mission-spine-dispatch-adapter.ts`) wraps the low-level proven sealed-WS client (`createFridayRustHubAgentRunSealedClient`) and exposes `{ intakeMission, transitionMission, transitionWorkItem }` — the exact `FridayMissionSpineDispatchService` the routes consume.

- Config **mirrors the agent-run sealed-WS path** (`friday-api-runtime.ts` ~:4816): the same WS endpoint (`FRIDAY_HUB_AGENT_RUN_WS_HOST` / `FRIDAY_HUB_AGENT_RUN_WS_PORT`, port-parse replicated verbatim) and the same X25519 SecureStore secret resolver (`resolveRustAgentRunWsClientX25519Secret`).
- **No DB path** is carried — the mission round-trips are refs-only WS (`runMissionRoundTrip`), with no owner-gated DB readback (unlike the agent-run answer readback).
- **Side-effect-free construction**: the factory captures only host/port/timeout + the resolver; it resolves no secret and opens no socket at build time. The secret is resolved and the sealed client built **lazily, per route call** — so a flag-ON-but-unprovisioned host fails closed (503) per call rather than crashing boot.

Bootstrap injects it at the `missionSpine` deps block via a conditional spread:
```ts
const routeMissionSpineViaRust = resolveRouteMissionSpineViaRust(config.routeMissionSpineViaRust);
const missionSpineDispatch = routeMissionSpineViaRust ? createFridayMissionSpineDispatchAdapter({ ... }) : null;
// ...
missionSpine: {
  workbench: missionSpineWorkbenchProjectionService,
  ...(missionSpineDispatch ? { dispatch: missionSpineDispatch } : {}),
  disabledReason: null,
},
```

## Flag-OFF byte-identical

With the flag off (the default), the adapter is **not constructed**, the `dispatch` key is **omitted entirely** from the `missionSpine` deps object (conditional spread), the routes see `deps.dispatch === undefined`, and each POST route returns today's fail-closed 503. The deps object is structurally identical to before this PR. No existing route's behavior changes.

## Fail-closed behavior (never a fake success)

- secret resolver returns `null` (missing / disabled / non-32-byte / SecureStore misconfig) ⇒ typed 503 **before any socket**;
- the underlying client constructor throws (malformed secret) ⇒ caught ⇒ typed 503;
- the underlying mission round-trip rejects (connect error / closed session / 30s timeout / wrong inbound kind / the server's `Error` envelope incl. a proofless completion / unparseable result) ⇒ its `FridayDomainError` (503) surfaces unchanged; any non-domain throw is wrapped as a typed 503.

There is no new success path: a result is the refs-only `*Result` the low-level client already returns, passed through verbatim. The routes' owner-gating (`assertBoundPrincipalForOperation`) and the Rust-side proof-on-completion remain the enforcers — this PR only makes `dispatch` non-null when the flag is on.

## KATs

- `resolveRouteMissionSpineViaRust`: default-off, parse (`1`/`true`/case/trim), fail-safe-off (`0`/`false`/`yes`/`on`/`2`/`""`), config-wins precedence (incl. false-beats-env-true).
- adapter: lazy side-effect-free construction (no resolve/build until first call); delegates `intakeMission`/`transitionMission`/`transitionWorkItem` to the mocked sealed client; constructs with the resolved secret + endpoint.
- fail-closed: null secret ⇒ 503 (no client built); constructor throw ⇒ 503; inner `FridayDomainError` surfaces unchanged; non-domain throw wrapped ⇒ 503.
- `readMissionSpineRustWsPort` parity with the agent-run port parse.
- Existing route tests already cover dispatch-present vs null (503) at the route layer.

## Scope / untouched

TS-only. Touches bootstrap (injection + flag resolver + config field + barrel re-export) + a new adapter file + tests. The routes file (Lane B is done), the agent-run `dispatchRun` wiring (`friday-api-runtime.ts`), and all Rust are **untouched**.

## NOTE — this is NOT end-to-end Loop1 closure

This PR only makes the TS routes **callable**. Real organic Loop1 closure ALSO needs the **SERVER flags** (`FRIDAY_MISSION_INTAKE` for intake, `FRIDAY_MISSION_SPINE_DISPATCH` for lifecycle/work-item) + a deploy + a real test mission — all operator-gated. Do not read this as "the mission-spine routes are now live." `rust_wired` ceiling; confers no v1 GO.

## Local gates

- `npm run typecheck` — clean
- `npm run lint` — 0 errors (adapter source lints clean)
- mission-spine + bootstrap-env vitest suites — pass (adapter 7, routes 22, bootstrap-env 65; full mission-spine dir 170; hub bootstrap unit+integration 75)
- `npm run test:contracts` — pass
- `secrets` job (both gates: `detect-secrets-hook` + `check-provider-key-patterns.mjs`) — pass (baseline refreshed for line-number drift only; no new secret)
- Born-current on `origin/main` (rebased onto the latest after #745 merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)