### PR TITLE
feat(memory): fire post-run extraction from the live run loop (FRIDAY_RUN_LOOP_MEMORY_EXTRACTION, dark)

### DIFF
--- a/rust-core/crates/friday-hub/src/bin/hub_extract_memory.rs
+++ b/rust-core/crates/friday-hub/src/bin/hub_extract_memory.rs
@@ -105,14 +105,16 @@ fn run() -> Result<String, ExtractError> {
     let client = DeepSeekClient::from_env().map_err(|_| ExtractError::new("credential_missing"))?;
 
     // A write bin: open the hub DB read-write (it records candidates + a ledger row).
-    let mut db = Db::open_hub(&db_path).map_err(|_| ExtractError::new("open_failed"))?;
+    // `extract_inline` takes a SHARED `&Db` (it uses only `&self`/`&Connection` storage ops),
+    // so no `mut` binding is needed.
+    let db = Db::open_hub(&db_path).map_err(|_| ExtractError::new("open_failed"))?;
 
     let now_ms = now_ms();
     let id_prefix = format!("{session_id}:extract:{now_ms}");
     let ledger_id = format!("led:{session_id}:{now_ms}");
 
     let outcome = extract_inline(
-        &mut db,
+        &db,
         &session_id,
         &client,
         DEFAULT_MAX_ITEMS,

--- a/rust-core/crates/friday-hub/src/lib.rs
+++ b/rust-core/crates/friday-hub/src/lib.rs
@@ -584,6 +584,14 @@ impl<T: friday_deepseek::Transport> DeepSeekAgentLlmClient<T> {
     pub fn discover_models(&self) -> Result<Vec<String>, friday_deepseek::DeepSeekError> {
         self.client.discover_models()
     }
+    /// (NS8-WIRE-1) Borrow the underlying structured-inference [`friday_deepseek::DeepSeekClient`].
+    /// The agent-loop adapter wraps the raw client; the post-run memory-extraction trigger
+    /// ([`crate::memory_extraction::extract_inline`]) needs the raw client (it issues ONE
+    /// structured `run_friday_ask` call, not the agent-loop step API). This is a read-only
+    /// borrow — it grants no new capability the adapter did not already wrap.
+    pub(crate) fn inner(&self) -> &friday_deepseek::DeepSeekClient<T> {
+        &self.client
+    }
 }
 
 /// Completion-token budget for the agent-loop reasoning calls (`propose_tool_call` and

--- a/rust-core/crates/friday-hub/src/memory_extraction.rs
+++ b/rust-core/crates/friday-hub/src/memory_extraction.rs
@@ -463,16 +463,24 @@ fn memory_review_activity_row(
     })
 }
 
-/// Run one INLINE manual extraction for a session (public entrypoint; signature UNCHANGED
-/// so every existing caller — the `hub_extract_memory` bin and the in-crate tests — is
-/// untouched). Reads the NS-8 [`FRIDAY_MEMORY_REVIEW_NEEDS_ME`] flag ONCE here (the only env
-/// read; semantics in [`memory_review_needs_me_from`]) and delegates to
-/// [`extract_inline_flagged`]. The flag is **default-OFF**: when off the extraction is
-/// BYTE-IDENTICAL to the pre-NS-8 baseline (no `memory_review_needs_me` call, NO activity
-/// row, no extra query).
+/// Run one INLINE manual extraction for a session (public entrypoint). Reads the NS-8
+/// [`FRIDAY_MEMORY_REVIEW_NEEDS_ME`] flag ONCE here (the only env read; semantics in
+/// [`memory_review_needs_me_from`]) and delegates to [`extract_inline_flagged`]. The flag is
+/// **default-OFF**: when off the extraction is BYTE-IDENTICAL to the pre-NS-8 baseline (no
+/// `memory_review_needs_me` call, NO activity row, no extra query).
+///
+/// ## `db: &Db` (NS8-WIRE-1 — relaxed from `&mut Db`, behavior unchanged)
+/// The `db` handle is a SHARED `&Db`. This entire extraction path uses ONLY `&self` storage
+/// operations — `db.conn()` (a `&Connection`), the `&Connection`-based
+/// `unchecked_transaction`, and `db.insert_token_ledger` / `db.insert_activity` (both `&self`)
+/// — so the previous `&mut Db` receiver was gratuitous. It is relaxed to `&Db` so the live
+/// sessioned run loop's `&self` runtime caller can fire this post-run (NS8-WIRE-1) WITHOUT a
+/// `&mut self` rewrite. Pre-existing `&mut db` call sites (the `hub_extract_memory` bin + the
+/// in-crate tests) reborrow `&mut Db → &Db` at the call automatically, so they are untouched
+/// and behavior is byte-identical.
 #[allow(clippy::too_many_arguments)]
 pub fn extract_inline<T: Transport>(
-    db: &mut friday_storage::Db,
+    db: &friday_storage::Db,
     session_id: &str,
     client: &DeepSeekClient<T>,
     max_items: usize,
@@ -549,7 +557,7 @@ pub fn extract_inline<T: Transport>(
 /// [`ExtractionOutcome::derived_namespace`].
 #[allow(clippy::too_many_arguments)]
 pub fn extract_inline_flagged<T: Transport>(
-    db: &mut friday_storage::Db,
+    db: &friday_storage::Db,
     session_id: &str,
     client: &DeepSeekClient<T>,
     max_items: usize,
@@ -832,7 +840,7 @@ mod tests {
 
     #[test]
     fn extract_persists_candidates_and_recall_reads_them_back_after_confirm() {
-        let mut db = friday_storage::Db::open_hub(&tmp("consistency")).unwrap();
+        let db = friday_storage::Db::open_hub(&tmp("consistency")).unwrap();
         let ids = seed_session(&db, "s1", "alice");
         // Slice-3: the store scope is the SESSION-DERIVED namespace, not a caller principal.
         let ns = ns_for("alice");
@@ -848,16 +856,8 @@ mod tests {
         .to_string();
         let c = client(content);
 
-        let out = extract_inline(
-            &mut db,
-            "s1",
-            &c,
-            DEFAULT_MAX_ITEMS,
-            "s1:ex:100",
-            "led-1",
-            100,
-        )
-        .unwrap();
+        let out =
+            extract_inline(&db, "s1", &c, DEFAULT_MAX_ITEMS, "s1:ex:100", "led-1", 100).unwrap();
         assert_eq!(out.messages_read, 2);
         assert_eq!(out.items_parsed, 1);
         assert_eq!(out.sensitive_dropped, 0);
@@ -899,7 +899,7 @@ mod tests {
 
     #[test]
     fn sensitive_item_is_dropped_not_stored() {
-        let mut db = friday_storage::Db::open_hub(&tmp("sensitive")).unwrap();
+        let db = friday_storage::Db::open_hub(&tmp("sensitive")).unwrap();
         let ids = seed_session(&db, "s2", "bob");
         // Two items: one benign, one whose content carries a sensitive KEYWORD.
         let content = json!({
@@ -911,16 +911,8 @@ mod tests {
         .to_string();
         let c = client(content);
 
-        let out = extract_inline(
-            &mut db,
-            "s2",
-            &c,
-            DEFAULT_MAX_ITEMS,
-            "s2:ex:100",
-            "led-2",
-            100,
-        )
-        .unwrap();
+        let out =
+            extract_inline(&db, "s2", &c, DEFAULT_MAX_ITEMS, "s2:ex:100", "led-2", 100).unwrap();
         assert_eq!(out.items_parsed, 2);
         assert_eq!(out.sensitive_dropped, 1, "the API-key item must be dropped");
         assert_eq!(out.candidates_created, 1);
@@ -947,7 +939,7 @@ mod tests {
         // it IS stored raw (parity with the TS) — and the EXISTING recall path redacts
         // it via cognition::rank_recall. This proves the store→confirm→recall→redact
         // loop is consistent end-to-end with no new store-time redaction.
-        let mut db = friday_storage::Db::open_hub(&tmp("pii")).unwrap();
+        let db = friday_storage::Db::open_hub(&tmp("pii")).unwrap();
         let ids = seed_session(&db, "s3", "carol");
         let ns = ns_for("carol");
         let content = json!({
@@ -960,16 +952,8 @@ mod tests {
         .to_string();
         let c = client(content);
 
-        let out = extract_inline(
-            &mut db,
-            "s3",
-            &c,
-            DEFAULT_MAX_ITEMS,
-            "s3:ex:100",
-            "led-3",
-            100,
-        )
-        .unwrap();
+        let out =
+            extract_inline(&db, "s3", &c, DEFAULT_MAX_ITEMS, "s3:ex:100", "led-3", 100).unwrap();
         assert_eq!(out.candidates_created, 1);
         // The email keyword guard does NOT match a bare email, so it is stored.
         assert_eq!(out.sensitive_dropped, 0);
@@ -990,7 +974,7 @@ mod tests {
 
     #[test]
     fn empty_session_extracts_nothing_without_calling_provider() {
-        let mut db = friday_storage::Db::open_hub(&tmp("empty")).unwrap();
+        let db = friday_storage::Db::open_hub(&tmp("empty")).unwrap();
         // Slice-3: the session must have a RESOLVABLE owner (else it fails closed BEFORE
         // the empty-message early-return). Bind an owner, then leave the session message-less.
         ensure_session_with_owner(
@@ -1017,16 +1001,8 @@ mod tests {
             }
         }
         let c = DeepSeekClient::with_transport(PanicTransport, "test-key-not-real".into());
-        let out = extract_inline(
-            &mut db,
-            "s4",
-            &c,
-            DEFAULT_MAX_ITEMS,
-            "s4:ex:100",
-            "led-4",
-            100,
-        )
-        .unwrap();
+        let out =
+            extract_inline(&db, "s4", &c, DEFAULT_MAX_ITEMS, "s4:ex:100", "led-4", 100).unwrap();
         assert_eq!(out.messages_read, 0);
         assert_eq!(out.candidates_created, 0);
         assert_eq!(out.messages_marked_extracted, 0);
@@ -1040,7 +1016,7 @@ mod tests {
         // Slice-3 PARITY: a session with NO owner user_id has an UNRESOLVABLE memory
         // namespace, so extraction FAILS CLOSED (mirrors the TS MEMORY_NAMESPACE_UNRESOLVABLE
         // throw) BEFORE the provider is ever contacted — even though the session has messages.
-        let mut db = friday_storage::Db::open_hub(&tmp("nouser")).unwrap();
+        let db = friday_storage::Db::open_hub(&tmp("nouser")).unwrap();
         // Owner-less session (account/channel set but user_id absent) WITH a message.
         ensure_session_with_owner(
             db.conn(),
@@ -1072,16 +1048,8 @@ mod tests {
             }
         }
         let c = DeepSeekClient::with_transport(PanicTransport, "test-key-not-real".into());
-        let err = extract_inline(
-            &mut db,
-            "s1",
-            &c,
-            DEFAULT_MAX_ITEMS,
-            "s1:ex:100",
-            "led-1",
-            100,
-        )
-        .unwrap_err();
+        let err = extract_inline(&db, "s1", &c, DEFAULT_MAX_ITEMS, "s1:ex:100", "led-1", 100)
+            .unwrap_err();
         assert!(
             matches!(
                 err,
@@ -1103,7 +1071,7 @@ mod tests {
         // DM fallback e2e: a `chat_kind == "dm"` conversation with NO user_id stores its
         // candidates under the chat-id-derived namespace (TS: parts.chatId), end-to-end
         // through the real extraction path.
-        let mut db = friday_storage::Db::open_hub(&tmp("dm-fallback")).unwrap();
+        let db = friday_storage::Db::open_hub(&tmp("dm-fallback")).unwrap();
         ensure_session_with_owner(
             db.conn(),
             "dm-s",
@@ -1138,7 +1106,7 @@ mod tests {
         .to_string();
         let c = client(content);
         let out = extract_inline(
-            &mut db,
+            &db,
             "dm-s",
             &c,
             DEFAULT_MAX_ITEMS,
@@ -1165,7 +1133,7 @@ mod tests {
         // Subagent fallback e2e: a child session with NO user_id walks `parent_session_id`
         // to the parent's user — and the namespace keeps the CHILD's own account/channel
         // (only the userId comes from the parent, faithful to the TS resolver).
-        let mut db = friday_storage::Db::open_hub(&tmp("subagent-fallback")).unwrap();
+        let db = friday_storage::Db::open_hub(&tmp("subagent-fallback")).unwrap();
         // The parent session (a normal owned conversation).
         ensure_session_with_owner(
             db.conn(),
@@ -1214,7 +1182,7 @@ mod tests {
         .to_string();
         let c = client(content);
         let out = extract_inline(
-            &mut db,
+            &db,
             "child-s",
             &c,
             DEFAULT_MAX_ITEMS,
@@ -1247,7 +1215,7 @@ mod tests {
             }
         }
 
-        let mut db = friday_storage::Db::open_hub(&tmp("underivable")).unwrap();
+        let db = friday_storage::Db::open_hub(&tmp("underivable")).unwrap();
         // (a) A GROUP chat: multi-user — attributing it to the chat id would merge users.
         ensure_session_with_owner(
             db.conn(),
@@ -1300,7 +1268,7 @@ mod tests {
         for sid in ["group-s", "orphan-s"] {
             let c = DeepSeekClient::with_transport(PanicTransport, "test-key-not-real".into());
             let err = extract_inline(
-                &mut db,
+                &db,
                 sid,
                 &c,
                 DEFAULT_MAX_ITEMS,
@@ -1342,7 +1310,7 @@ mod tests {
         // After run 1 BOTH must be marked extracted (so run 2 sees zero pending and never
         // calls the provider). seed_session gives a referenced + an unreferenced message,
         // so the unchanged-ledger assertion catches "marked only the referenced id".
-        let mut db = friday_storage::Db::open_hub(&tmp("dedup")).unwrap();
+        let db = friday_storage::Db::open_hub(&tmp("dedup")).unwrap();
         let ids = seed_session(&db, "s1", "alice");
         let content = json!({
             "items": [{
@@ -1356,16 +1324,8 @@ mod tests {
         let c = client(content);
 
         // Run 1: reads both pending, creates 1 candidate, marks BOTH messages extracted.
-        let out1 = extract_inline(
-            &mut db,
-            "s1",
-            &c,
-            DEFAULT_MAX_ITEMS,
-            "s1:ex:100",
-            "led-1",
-            100,
-        )
-        .unwrap();
+        let out1 =
+            extract_inline(&db, "s1", &c, DEFAULT_MAX_ITEMS, "s1:ex:100", "led-1", 100).unwrap();
         assert_eq!(out1.messages_read, 2);
         assert_eq!(out1.candidates_created, 1);
         assert_eq!(out1.messages_marked_extracted, 2, "both messages consumed");
@@ -1390,16 +1350,8 @@ mod tests {
             }
         }
         let c2 = DeepSeekClient::with_transport(PanicTransport, "test-key-not-real".into());
-        let out2 = extract_inline(
-            &mut db,
-            "s1",
-            &c2,
-            DEFAULT_MAX_ITEMS,
-            "s1:ex:200",
-            "led-2",
-            200,
-        )
-        .unwrap();
+        let out2 =
+            extract_inline(&db, "s1", &c2, DEFAULT_MAX_ITEMS, "s1:ex:200", "led-2", 200).unwrap();
         assert_eq!(out2.messages_read, 0, "no pending messages on re-run");
         assert_eq!(out2.candidates_created, 0, "no duplicate candidates");
         assert_eq!(out2.messages_marked_extracted, 0);
@@ -1423,7 +1375,7 @@ mod tests {
         // then `:c1`. We pre-insert a memory_item at `:c1` so the c1 INSERT collides on
         // the PRIMARY KEY mid-loop → the whole tx drops → BOTH the c0 candidate AND the
         // extracted-marks roll back (all-or-nothing). No test seam in `extract_inline`.
-        let mut db = friday_storage::Db::open_hub(&tmp("rollback")).unwrap();
+        let db = friday_storage::Db::open_hub(&tmp("rollback")).unwrap();
         let ids = seed_session(&db, "s1", "alice");
         let content = json!({
             "items": [
@@ -1450,16 +1402,8 @@ mod tests {
         )
         .unwrap();
 
-        let err = extract_inline(
-            &mut db,
-            "s1",
-            &c,
-            DEFAULT_MAX_ITEMS,
-            "s1:ex:100",
-            "led-1",
-            100,
-        )
-        .unwrap_err();
+        let err = extract_inline(&db, "s1", &c, DEFAULT_MAX_ITEMS, "s1:ex:100", "led-1", 100)
+            .unwrap_err();
         assert!(
             matches!(err, ExtractionError::Storage(_)),
             "PK collision is a storage error"
@@ -1498,7 +1442,7 @@ mod tests {
         // A session whose ONLY extracted item is sensitivity-DROPPED still consumes its
         // source messages: they are marked extracted so a re-run does not re-extract them
         // (matches the TS — a dropped item still leaves the pending set).
-        let mut db = friday_storage::Db::open_hub(&tmp("dropped")).unwrap();
+        let db = friday_storage::Db::open_hub(&tmp("dropped")).unwrap();
         let ids = seed_session(&db, "s1", "bob");
         let content = json!({
             "items": [
@@ -1508,16 +1452,8 @@ mod tests {
         .to_string();
         let c = client(content);
 
-        let out = extract_inline(
-            &mut db,
-            "s1",
-            &c,
-            DEFAULT_MAX_ITEMS,
-            "s1:ex:100",
-            "led-1",
-            100,
-        )
-        .unwrap();
+        let out =
+            extract_inline(&db, "s1", &c, DEFAULT_MAX_ITEMS, "s1:ex:100", "led-1", 100).unwrap();
         assert_eq!(out.items_parsed, 1);
         assert_eq!(out.sensitive_dropped, 1, "the API-key item is dropped");
         assert_eq!(out.candidates_created, 0, "nothing safe to persist");
@@ -1542,16 +1478,8 @@ mod tests {
             }
         }
         let c2 = DeepSeekClient::with_transport(PanicTransport, "test-key-not-real".into());
-        let out2 = extract_inline(
-            &mut db,
-            "s1",
-            &c2,
-            DEFAULT_MAX_ITEMS,
-            "s1:ex:200",
-            "led-2",
-            200,
-        )
-        .unwrap();
+        let out2 =
+            extract_inline(&db, "s1", &c2, DEFAULT_MAX_ITEMS, "s1:ex:200", "led-2", 200).unwrap();
         assert_eq!(out2.messages_read, 0, "dropped source is not re-extracted");
     }
 
@@ -1559,10 +1487,10 @@ mod tests {
     fn blank_session_is_bad_input() {
         // Slice-3 removed the caller `principal_id` arg (the store scope is now session-
         // derived), so only the blank-session-id bad-input remains.
-        let mut db = friday_storage::Db::open_hub(&tmp("blank")).unwrap();
+        let db = friday_storage::Db::open_hub(&tmp("blank")).unwrap();
         let c = client(r#"{"items":[]}"#);
         assert!(matches!(
-            extract_inline(&mut db, "  ", &c, DEFAULT_MAX_ITEMS, "p", "l", 1),
+            extract_inline(&db, "  ", &c, DEFAULT_MAX_ITEMS, "p", "l", 1),
             Err(ExtractionError::BadInput("session_id"))
         ));
     }
@@ -1690,7 +1618,7 @@ mod tests {
 
     #[test]
     fn ns8_flag_on_surfaces_one_memory_review_row_per_fresh_candidate() {
-        let mut db = friday_storage::Db::open_hub(&tmp("ns8-on")).unwrap();
+        let db = friday_storage::Db::open_hub(&tmp("ns8-on")).unwrap();
         let ids = seed_session(&db, "s1", "alice");
         let content = json!({
             "items": [{
@@ -1704,7 +1632,7 @@ mod tests {
         let c = client(content);
 
         let out = extract_inline_flagged(
-            &mut db,
+            &db,
             "s1",
             &c,
             DEFAULT_MAX_ITEMS,
@@ -1757,7 +1685,7 @@ mod tests {
 
     #[test]
     fn ns8_flag_off_is_byte_identical_no_review_row() {
-        let mut db = friday_storage::Db::open_hub(&tmp("ns8-off")).unwrap();
+        let db = friday_storage::Db::open_hub(&tmp("ns8-off")).unwrap();
         let ids = seed_session(&db, "s1", "alice");
         let content = json!({
             "items": [{
@@ -1771,7 +1699,7 @@ mod tests {
 
         let before = db.list_activity().unwrap();
         let out = extract_inline_flagged(
-            &mut db,
+            &db,
             "s1",
             &c,
             DEFAULT_MAX_ITEMS,
@@ -1839,7 +1767,7 @@ mod tests {
         // correct impl (surface only freshly-recorded ids) leaves X UN-surfaced; a `pending_
         // review()` re-query mutation would WRONGLY surface the pre-existing pending X. So this
         // assertion kills that mutation.
-        let mut db = friday_storage::Db::open_hub(&tmp("ns8-fresh-only")).unwrap();
+        let db = friday_storage::Db::open_hub(&tmp("ns8-fresh-only")).unwrap();
 
         // (a) A still-PENDING candidate from an earlier run — recorded directly via the spine,
         // with NO accompanying memory_review activity row (it was never surfaced).
@@ -1875,7 +1803,7 @@ mod tests {
         let _ids = seed_session(&db, "s1", "alice");
         let c = client(json!({ "items": [] }).to_string());
         let out = extract_inline_flagged(
-            &mut db,
+            &db,
             "s1",
             &c,
             DEFAULT_MAX_ITEMS,

--- a/rust-core/crates/friday-hub/src/runtime.rs
+++ b/rust-core/crates/friday-hub/src/runtime.rs
@@ -1001,8 +1001,13 @@ impl<T: Transport> HubRuntime<T> {
         // (a no-op on Denied/NoAnswer). This is byte-shared with `run_authed_agent_loop`'s
         // tail, so the only difference between the two dispatch arms is which loop ran. Token
         // counts stay `None` (DEFERRED — billed to the Rust token_ledger, not on LoopOutcome).
-        project_answer_for_authed(self.db.conn(), run_id, caller)
-            .with_counts(outcome.turns, outcome.executed_tools)
+        let answer = project_answer_for_authed(self.db.conn(), run_id, caller)
+            .with_counts(outcome.turns, outcome.executed_tools);
+        // (NS8-WIRE-1, Loop5) Fire post-run memory extraction (flag-gated, default-OFF; only on
+        // Finished; result discarded; failure-isolated) AFTER the owner-gated answer is bound +
+        // projected. See `maybe_extract_memory_post_run`.
+        self.maybe_extract_memory_post_run(session_id, run_id, &outcome, now_ms);
+        answer
     }
 
     /// (C2) Pin a SPECIFIC provider for a SESSIONED FOLLOW-UP turn (no-fallback) — the
@@ -1139,7 +1144,100 @@ impl<T: Transport> HubRuntime<T> {
         // Release the body ONLY to the authenticated owner, then attach the loop's counts.
         let answer = project_answer_for_authed(self.db.conn(), run_id, caller)
             .with_counts(outcome.turns, outcome.executed_tools);
+        // (NS8-WIRE-1, Loop5) Fire post-run memory extraction (flag-gated, default-OFF; only on
+        // Finished; result discarded; failure-isolated) AFTER the owner-gated answer is bound +
+        // projected. See `maybe_extract_memory_post_run`.
+        self.maybe_extract_memory_post_run(session_id, run_id, &outcome, now_ms);
         Ok((selection, answer))
+    }
+
+    /// (NS8-WIRE-1, Loop5) Fire POST-RUN session-memory extraction from the LIVE sessioned run
+    /// loop — the missing TRIGGER that closes the Memory loop. This is the CALLER for the already
+    /// merged producer [`crate::memory_extraction::extract_inline`] (#726); it does NOT reimplement
+    /// extraction.
+    ///
+    /// ## When it fires (and when it does NOT)
+    /// - **Flag-gated, default-OFF.** Reads [`ENV_RUN_LOOP_MEMORY_EXTRACTION`] ONCE here. OFF (the
+    ///   prod default — unset / empty / `"0"` / anything but the exact `"1"`) ⇒ this returns
+    ///   IMMEDIATELY before any work: NO extraction call, NO query, NO provider call. The run is
+    ///   BYTE-IDENTICAL to today.
+    /// - **Only on `Finished`.** A `Paused` / `Errored` / `Bounded` / `Blocked` / `Interrupted`
+    ///   outcome returns without firing (those carry no deliverable answer; `Paused` belongs to the
+    ///   resume completion leg). This mirrors the owner-wiring `persist_run_result` gate.
+    ///
+    /// ## Why it can NEVER change the run's outcome/status/answer
+    /// - **Sequenced AFTER the answer is bound + projected.** Both call sites invoke this only after
+    ///   `persist_run_result` (the owner-gated answer bind, inside `run_session_loop`) AND
+    ///   `project_answer_for_authed` have materialized the [`AuthedAnswer`]. The answer the caller
+    ///   returns is already in hand; this runs purely for its candidate side effect.
+    /// - **Result DISCARDED via `let _`.** The [`crate::memory_extraction::ExtractionOutcome`] (and
+    ///   any [`crate::memory_extraction::ExtractionError`]) is dropped. It is never inspected, never
+    ///   propagated, and never folded into the answer — so it CANNOT flip Delivered→NoAnswer.
+    /// - **Failure-isolated.** Extraction writes ONLY `token_ledger` / `memory_item` (candidate) /
+    ///   (NS-8-flag-gated) `activity` rows — NEVER the `run_result` row the answer projection reads.
+    ///   An extraction ERROR (provider failure, unresolvable namespace, parse, storage) is swallowed
+    ///   by the `let _`: the run already succeeded and stays `Finished`; the answer/status/ledger of
+    ///   the RUN are unchanged. The candidates it records are NON-DURABLE `Candidate` rows, gated on
+    ///   a separate operator confirm (Needs-Me) surface — NOT this trigger.
+    ///
+    /// `&self` is sufficient: the producer takes a SHARED `&Db` (NS8-WIRE-1 relaxed it from
+    /// `&mut Db`; the whole path uses only `&self`/`&Connection` storage ops), and the raw
+    /// structured-inference client comes from `self.deepseek.inner()`. The id-prefix / ledger-id
+    /// mirror the `hub_extract_memory` bin.
+    ///
+    /// Reads [`ENV_RUN_LOOP_MEMORY_EXTRACTION`] ONCE here and threads the resulting bool into the
+    /// pure-on-the-bool inner [`Self::maybe_extract_memory_post_run_flagged`] — the program-standard
+    /// "split env-read from pure logic" idiom (mirroring `passport_mint` / `workitem_guarded`), so
+    /// behavioral tests inject the bool directly and never race `std::env`.
+    fn maybe_extract_memory_post_run(
+        &self,
+        session_id: &str,
+        run_id: &str,
+        outcome: &LoopOutcome,
+        now_ms: i64,
+    ) {
+        let enabled = run_loop_memory_extraction_from(
+            std::env::var(ENV_RUN_LOOP_MEMORY_EXTRACTION)
+                .ok()
+                .as_deref(),
+        );
+        self.maybe_extract_memory_post_run_flagged(session_id, run_id, outcome, now_ms, enabled);
+    }
+
+    /// The flag-parameterized inner (pure on `enabled`, env-race-free for tests). DEFAULT-OFF:
+    /// `enabled == false` ⇒ return before ANY work, byte-identical to the pre-NS8-WIRE-1 baseline
+    /// (no extraction call, no query, no provider call). Only fires on
+    /// [`LoopStatus::Finished`]. The result is DISCARDED + the call is failure-isolated via `let _`
+    /// (see the parent doc): it can NEVER flip the run's answer/status or break the run.
+    fn maybe_extract_memory_post_run_flagged(
+        &self,
+        session_id: &str,
+        run_id: &str,
+        outcome: &LoopOutcome,
+        now_ms: i64,
+        enabled: bool,
+    ) {
+        // Flag-gated, default-OFF: OFF ⇒ return before ANY work (byte-identical to today).
+        if !enabled {
+            return;
+        }
+        // Only on Finished (NOT Paused / Errored / Bounded / Blocked / Interrupted).
+        if outcome.status != LoopStatus::Finished {
+            return;
+        }
+        let id_prefix = format!("{session_id}:extract:{now_ms}");
+        let ledger_id = format!("led:{run_id}:{now_ms}");
+        // Result DISCARDED + failure-isolated: `let _` drops the Ok(outcome) AND swallows any
+        // Err — extraction can NEVER flip the run's answer/status or break the run.
+        let _ = crate::memory_extraction::extract_inline(
+            &self.db,
+            session_id,
+            self.deepseek.inner(),
+            crate::memory_extraction::DEFAULT_MAX_ITEMS,
+            &id_prefix,
+            &ledger_id,
+            now_ms,
+        );
     }
 
     /// S1.3 — the Mission-BOUND agent-loop entry (the `executeRun` Mission-context parity,
@@ -1843,6 +1941,25 @@ pub const ENV_WORKITEM_GUARDED_TRANSITION: &str = "FRIDAY_WORKITEM_GUARDED_TRANS
 /// DEFAULT-OFF: `None` (unset) ⇒ false; ON only for the exact opt-in value `"1"` (trimmed);
 /// everything else ⇒ false.
 fn workitem_guarded_transition_from(raw: Option<&str>) -> bool {
+    matches!(raw.map(str::trim), Some("1"))
+}
+
+/// (NS8-WIRE-1, Loop5) The default-OFF env gate that fires POST-RUN session-memory extraction
+/// from the LIVE sessioned run loop — the missing TRIGGER for the Memory closed loop. When ON,
+/// a `Finished` sessioned run, AFTER its owner-gated answer is bound + projected, fires the
+/// existing producer [`crate::memory_extraction::extract_inline`] for the session (the result is
+/// DISCARDED — see [`HubRuntime::maybe_extract_memory_post_run`]). ON only when
+/// `FRIDAY_RUN_LOOP_MEMORY_EXTRACTION` is exactly `"1"` (after trimming). UNSET / empty / `"0"` /
+/// any other value ⇒ OFF (unchanged prod default: the run is BYTE-IDENTICAL to today — no
+/// extraction call, no extra query, no provider call). Kept narrow + explicit so this run-path
+/// change cannot be enabled by accident.
+pub const ENV_RUN_LOOP_MEMORY_EXTRACTION: &str = "FRIDAY_RUN_LOOP_MEMORY_EXTRACTION";
+
+/// Pure flag-matcher for [`ENV_RUN_LOOP_MEMORY_EXTRACTION`] (env read split out so it is
+/// unit-testable without `set_var` — the program-standard env-race-free idiom this file uses).
+/// DEFAULT-OFF: `None` (unset) ⇒ false; ON only for the exact opt-in value `"1"` (trimmed);
+/// everything else ⇒ false.
+fn run_loop_memory_extraction_from(raw: Option<&str>) -> bool {
     matches!(raw.map(str::trim), Some("1"))
 }
 
@@ -5999,6 +6116,381 @@ mod tests {
             ),
             "FRIDAY_WORKITEM_GUARDED_TRANSITION must be unset/off in the test env (prod default)"
         );
+    }
+
+    // ── NS8-WIRE-1 (Loop5): post-run memory-extraction TRIGGER from the live sessioned loop ──
+
+    #[test]
+    fn run_loop_memory_extraction_flag_matcher_is_exact_one_default_off() {
+        // The DEFAULT-OFF exact-"1" matcher idiom (mirrors the claude/passport/workitem gates).
+        assert!(
+            !run_loop_memory_extraction_from(None),
+            "unset ⇒ OFF (prod default)"
+        );
+        assert!(
+            run_loop_memory_extraction_from(Some("1")),
+            "exactly \"1\" ⇒ ON"
+        );
+        assert!(
+            run_loop_memory_extraction_from(Some(" 1 ")),
+            "trimmed \"1\" ⇒ ON"
+        );
+        for off in ["", "0", "true", "yes", "01", "1 0", "enabled", "TRUE"] {
+            assert!(
+                !run_loop_memory_extraction_from(Some(off)),
+                "{off:?} must NOT enable post-run extraction"
+            );
+        }
+        // Sanity: the live env var is unset in the test process ⇒ the real read reports OFF.
+        assert!(
+            !run_loop_memory_extraction_from(
+                std::env::var(ENV_RUN_LOOP_MEMORY_EXTRACTION)
+                    .ok()
+                    .as_deref()
+            ),
+            "FRIDAY_RUN_LOOP_MEMORY_EXTRACTION must be unset/off in the test env (prod default)"
+        );
+    }
+
+    /// The extraction JSON the producer's `run_friday_ask` chat returns (one valid candidate
+    /// referencing the session's user turn id `<run>:m0`). A safe (non-sensitive) item.
+    fn extraction_items_json(source_msg_id: &str) -> String {
+        serde_json::json!({
+            "items": [{
+                "kind": "preference",
+                "content": "User wants concise answers.",
+                "sourceMessageIds": [source_msg_id],
+            }]
+        })
+        .to_string()
+    }
+
+    #[test]
+    fn post_run_extraction_flag_on_finished_fires_and_never_changes_the_run() {
+        // KAT (flag-ON + Finished): the post-run extraction TRIGGER fires the existing producer,
+        // its result is DISCARDED, and the RUN's answer/status/run_result row are UNCHANGED.
+        //
+        // Sequence on ONE up-front-scripted transport: post[0] = the agent loop's Finish; post[1]
+        // = the extraction `run_friday_ask` chat (the candidate JSON, referencing the session's
+        // user turn `sess-ns8wire:m0` — `append_session_message` mints `<session>:m<seq>`). The
+        // session owner is the authenticated caller (user_id set ⇒ a resolvable memory namespace),
+        // so extraction does NOT fail closed on namespace.
+        let owner = "owner-ns8wire";
+        let items = extraction_items_json("sess-ns8wire:m0");
+        let (rt, _ws, _c) = runtime_with_owner(
+            "ns8wire-on",
+            owner,
+            &["{\"tool\":\"none\",\"answer\":\"PONG\"}", &items],
+        );
+        // The first run drives the loop to Finish (post[0]); the test process env is OFF, so the
+        // run's OWN internal `maybe_extract_memory_post_run` is a no-op (verified: zero extraction).
+        let caller = authed_caller(owner);
+        let answer = rt.run_session_task(&caller, "run-ns8wire", "sess-ns8wire", "say pong", 5_000);
+        // The run Delivered an owned answer.
+        let delivered_body = match &answer {
+            AuthedAnswer::Delivered { answer, status, .. } => {
+                assert_eq!(status, "finished", "the run finished");
+                answer.clone()
+            }
+            other => panic!("expected a Delivered answer, got {other:?}"),
+        };
+        // Snapshot the run_result row + DB counts BEFORE the (flag-ON) extraction step.
+        let before = friday_storage::get_run_result(rt.db().conn(), "run-ns8wire")
+            .unwrap()
+            .expect("a finished run has a run_result row");
+        assert_eq!(before.status, "finished");
+        let ledger_before = rt.db().count("token_ledger").unwrap();
+        let mem_before = rt.db().count("memory_item").unwrap();
+        assert_eq!(
+            mem_before, 0,
+            "flag-OFF internal call created NO candidate (byte-identical baseline)"
+        );
+
+        // Fire the flagged inner directly with a Finished outcome (the env-race-free idiom — no
+        // set_var). The extraction is the NEXT chat POST → the transport serves post[1] (items).
+        let outcome = LoopOutcome {
+            status: LoopStatus::Finished,
+            turns: 1,
+            executed_tools: 0,
+            final_message: Some(delivered_body.clone()),
+            detail: String::new(),
+        };
+        rt.maybe_extract_memory_post_run_flagged(
+            "sess-ns8wire",
+            "run-ns8wire",
+            &outcome,
+            6_000,
+            true, // flag ON
+        );
+
+        // PROOF extraction FIRED: it billed a token_ledger row AND recorded a Candidate.
+        assert_eq!(
+            rt.db().count("token_ledger").unwrap(),
+            ledger_before + 1,
+            "the extraction call was ledgered (it fired)"
+        );
+        assert_eq!(
+            rt.db().count("memory_item").unwrap(),
+            mem_before + 1,
+            "the extraction recorded a Candidate (it fired)"
+        );
+        // PROOF the RUN is UNCHANGED: the run_result row (status + answer body) is byte-identical;
+        // extraction writes token_ledger/memory_item only, NEVER run_result, so it cannot flip
+        // Delivered→NoAnswer.
+        let after = friday_storage::get_run_result(rt.db().conn(), "run-ns8wire")
+            .unwrap()
+            .expect("the run_result row still exists");
+        assert_eq!(
+            after.status, before.status,
+            "status unchanged (still finished)"
+        );
+        assert_eq!(after.answer, before.answer, "answer body unchanged");
+        assert_eq!(
+            after.answer, delivered_body,
+            "the delivered answer is exactly the persisted answer (unaffected by extraction)"
+        );
+    }
+
+    #[test]
+    fn post_run_extraction_not_fired_on_non_finished_outcomes() {
+        // KAT (flag-ON + Paused/Errored/etc.): extraction is gated on Finished ONLY. A non-Finished
+        // outcome fires NOTHING — no provider call, no ledger row, no candidate.
+        let owner = "owner-ns8wire-np";
+        let (rt, _ws, _c) =
+            runtime_with_owner("ns8wire-nonfinished", owner, &["{\"tool\":\"none\"}"]);
+        // Seed an owned session WITH a pending message so extraction COULD fire if it were not
+        // gated — proving the gate (not an empty session) is what blocks it.
+        friday_storage::ensure_session_with_owner(
+            rt.db().conn(),
+            "sess-np",
+            &SessionOwner {
+                user_id: Some(owner.to_string()),
+                ..SessionOwner::default()
+            },
+            1,
+        )
+        .unwrap();
+        friday_storage::append_session_message(
+            rt.db().conn(),
+            "sess-np",
+            &friday_storage::SessionMessage::new("user", "remember this", None),
+            2,
+        )
+        .unwrap();
+        let ledger_before = rt.db().count("token_ledger").unwrap();
+        let mem_before = rt.db().count("memory_item").unwrap();
+
+        for status in [
+            LoopStatus::Paused,
+            LoopStatus::Errored,
+            LoopStatus::Bounded,
+            LoopStatus::Blocked,
+            LoopStatus::Interrupted,
+        ] {
+            let outcome = LoopOutcome {
+                status,
+                turns: 1,
+                executed_tools: 0,
+                final_message: None,
+                detail: String::new(),
+            };
+            rt.maybe_extract_memory_post_run_flagged("sess-np", "run-np", &outcome, 3_000, true);
+        }
+        assert_eq!(
+            rt.db().count("token_ledger").unwrap(),
+            ledger_before,
+            "no non-Finished outcome may fire extraction (no ledger row)"
+        );
+        assert_eq!(
+            rt.db().count("memory_item").unwrap(),
+            mem_before,
+            "no non-Finished outcome may record a candidate"
+        );
+    }
+
+    #[test]
+    fn post_run_extraction_flag_off_is_byte_identical_even_on_finished() {
+        // KAT (flag-OFF): the DEFAULT. Even on a Finished outcome with a pending-message,
+        // owned (namespace-resolvable) session — i.e. extraction WOULD fire were the flag on —
+        // the OFF path returns before ANY work: no provider call, no token_ledger row, no
+        // candidate. Byte-identical to the pre-NS8-WIRE-1 baseline. A PanicTransport proves zero
+        // provider contact.
+        struct PanicTransport;
+        impl Transport for PanicTransport {
+            fn get_json(&self, _u: &str, _b: &str) -> Result<Value, DeepSeekError> {
+                panic!("flag-OFF must make NO provider call (discover)");
+            }
+            fn post_json(&self, _u: &str, _b: &str, _body: &Value) -> Result<Value, DeepSeekError> {
+                panic!("flag-OFF must make NO provider call (chat)");
+            }
+        }
+        let owner = "owner-ns8wire-off";
+        let tag = "ns8wire-off";
+        let ws = TempDir::new(tag);
+        let client = DeepSeekClient::with_transport(PanicTransport, "k".into());
+        let agent = DeepSeekAgentLlmClient::new(client);
+        let rt = HubRuntime::new(
+            HubConfig {
+                db_path: tmp(tag),
+                workspace_root: ws.0.clone(),
+                secret: SECRET.to_vec(),
+                max_turns: 6,
+                principal_id: Some(owner.to_string()),
+                disabled_tools: vec![],
+                read_only: false,
+                operator_vk: None,
+            },
+            agent,
+            Box::new(DenyAllApprovals),
+        )
+        .unwrap();
+        // An owned session WITH a pending message (extraction would fire if the flag were on).
+        friday_storage::ensure_session_with_owner(
+            rt.db().conn(),
+            "sess-off",
+            &SessionOwner {
+                user_id: Some(owner.to_string()),
+                ..SessionOwner::default()
+            },
+            1,
+        )
+        .unwrap();
+        friday_storage::append_session_message(
+            rt.db().conn(),
+            "sess-off",
+            &friday_storage::SessionMessage::new("user", "remember this", None),
+            2,
+        )
+        .unwrap();
+        let ledger_before = rt.db().count("token_ledger").unwrap();
+        let mem_before = rt.db().count("memory_item").unwrap();
+
+        let outcome = LoopOutcome {
+            status: LoopStatus::Finished,
+            turns: 1,
+            executed_tools: 0,
+            final_message: Some("PONG".to_string()),
+            detail: String::new(),
+        };
+        // enabled = false ⇒ the OFF path. The PanicTransport guarantees it never touches the
+        // provider; the counts prove it never touched storage either.
+        rt.maybe_extract_memory_post_run_flagged("sess-off", "run-off", &outcome, 3_000, false);
+
+        assert_eq!(
+            rt.db().count("token_ledger").unwrap(),
+            ledger_before,
+            "flag-OFF fires NO extraction (no ledger row) — byte-identical baseline"
+        );
+        assert_eq!(
+            rt.db().count("memory_item").unwrap(),
+            mem_before,
+            "flag-OFF records NO candidate — byte-identical baseline"
+        );
+    }
+
+    /// A transport that serves a Finish on the FIRST chat POST (the agent loop) but FAILS every
+    /// later chat POST (the extraction `run_friday_ask` call) with a transient provider error —
+    /// the failure-isolation probe. `/models` (GET) always succeeds (discovery is not the failure).
+    struct FailExtractionTransport {
+        post_calls: Rc<Cell<usize>>,
+    }
+    impl FailExtractionTransport {
+        fn new() -> Self {
+            Self {
+                post_calls: Rc::new(Cell::new(0)),
+            }
+        }
+    }
+    impl Transport for FailExtractionTransport {
+        fn get_json(&self, _url: &str, _bearer: &str) -> Result<Value, DeepSeekError> {
+            Ok(serde_json::json!({"data":[{"id":"deepseek-v4-flash"}]}))
+        }
+        fn post_json(
+            &self,
+            _url: &str,
+            _bearer: &str,
+            _body: &Value,
+        ) -> Result<Value, DeepSeekError> {
+            let n = self.post_calls.get();
+            self.post_calls.set(n + 1);
+            if n == 0 {
+                // The agent loop's turn: Finish with an answer.
+                Ok(serde_json::json!({
+                    "model":"deepseek-v4-flash",
+                    "choices":[{"message":{"content":"{\"tool\":\"none\",\"answer\":\"PONG\"}"},"finish_reason":"stop"}],
+                    "usage":{"prompt_tokens":10,"completion_tokens":5,"total_tokens":15}
+                }))
+            } else {
+                // The extraction call FAILS — a transient provider-unavailable error.
+                Err(DeepSeekError::ProviderUnavailable("extraction down".into()))
+            }
+        }
+    }
+
+    #[test]
+    fn post_run_extraction_failure_is_isolated_run_stays_finished() {
+        // KAT (failure-isolation): the extraction call ERRORS (provider unavailable on the
+        // extraction POST). The `let _` swallows it — the RUN already Finished and its run_result
+        // row is UNCHANGED; no candidate is recorded. An extraction error can NEVER break the run.
+        let owner = "owner-ns8wire-fail";
+        let tag = "ns8wire-fail";
+        let ws = TempDir::new(tag);
+        let transport = FailExtractionTransport::new();
+        let client = DeepSeekClient::with_transport(transport, "k".into());
+        let agent = DeepSeekAgentLlmClient::new(client);
+        let rt = HubRuntime::new(
+            HubConfig {
+                db_path: tmp(tag),
+                workspace_root: ws.0.clone(),
+                secret: SECRET.to_vec(),
+                max_turns: 6,
+                principal_id: Some(owner.to_string()),
+                disabled_tools: vec![],
+                read_only: false,
+                operator_vk: None,
+            },
+            agent,
+            Box::new(DenyAllApprovals),
+        )
+        .unwrap();
+
+        let caller = authed_caller(owner);
+        let answer = rt.run_session_task(&caller, "run-fail", "sess-fail", "say pong", 5_000);
+        let delivered_body = match &answer {
+            AuthedAnswer::Delivered { answer, status, .. } => {
+                assert_eq!(status, "finished");
+                answer.clone()
+            }
+            other => panic!("expected Delivered, got {other:?}"),
+        };
+        let before = friday_storage::get_run_result(rt.db().conn(), "run-fail")
+            .unwrap()
+            .expect("finished run has a result");
+        let mem_before = rt.db().count("memory_item").unwrap();
+
+        let outcome = LoopOutcome {
+            status: LoopStatus::Finished,
+            turns: 1,
+            executed_tools: 0,
+            final_message: Some(delivered_body.clone()),
+            detail: String::new(),
+        };
+        // The extraction call (post[1]) returns Err — this MUST NOT panic / propagate / break.
+        // The `let _` in `maybe_extract_memory_post_run_flagged` isolates the failure.
+        rt.maybe_extract_memory_post_run_flagged("sess-fail", "run-fail", &outcome, 6_000, true);
+
+        // The extraction failed BEFORE recording any candidate (no partial state).
+        assert_eq!(
+            rt.db().count("memory_item").unwrap(),
+            mem_before,
+            "a failed extraction records NO candidate"
+        );
+        // The RUN is UNCHANGED: still finished, same answer body. Failure isolated.
+        let after = friday_storage::get_run_result(rt.db().conn(), "run-fail")
+            .unwrap()
+            .expect("the run_result row survives a failed extraction");
+        assert_eq!(after.status, "finished", "the run stays Finished");
+        assert_eq!(after.answer, before.answer, "the answer body is unchanged");
     }
 
     /// A runtime whose run-owner principal is `principal` (so the confirmed-memory recall — the


### PR DESCRIPTION
## NS8-WIRE-1 / Loop5 — the missing TRIGGER for the Memory closed loop

The memory-extraction **PRODUCER** (`extract_inline` / `memory_extraction.rs`, #726) is already merged. What was missing is the **CALLER**: nothing fired post-run extraction from the live sessioned run loop. This PR adds that trigger, flag-gated **DARK** (default-OFF). It does NOT reimplement extraction — it reuses the existing producer.

### Trigger site (file:line)
- `crates/friday-hub/src/runtime.rs:1232` — the discarded producer call `let _ = crate::memory_extraction::extract_inline(&self.db, session_id, self.deepseek.inner(), …)`, inside the private helper `maybe_extract_memory_post_run_flagged` (`runtime.rs:1212`).
- Invoked from **both** live sessioned run-loop call sites, AFTER the owner-gated answer is bound (`run_session_loop` step-5 `persist_run_result`) AND projected (`project_answer_for_authed`):
  - `runtime.rs:1009` in `run_session_task_with_overrides` (the live `run_session_task` path)
  - `runtime.rs:1150` in `run_session_task_pinned` (C2 sessioned pinned path)

### Gated on Finished only
Fires ONLY when `outcome.status == LoopStatus::Finished`. `Paused` / `Errored` / `Bounded` / `Blocked` / `Interrupted` fire nothing (they carry no deliverable answer; `Paused` belongs to the resume completion leg) — mirrors the owner-wiring `persist_run_result` gate.

### Result discarded — never flips Delivered→NoAnswer
The `ExtractionOutcome` (and any `ExtractionError`) is dropped via `let _`. It is never inspected, propagated, or folded into the answer. The answer is already bound in `let answer = …;` before the trigger runs, then returned unchanged. The decisive structural discriminator: **extraction writes only `token_ledger` / `memory_item` (candidate) / (NS-8-flag) `activity` rows — NEVER the `run_result` row**, which is the only thing the answer projection reads. So it cannot change the run's answer/status/`run_result`.

### Failure-isolated
An extraction error (provider failure, unresolvable namespace, parse, storage) is swallowed by the `let _`. The run already succeeded and stays `Finished`; its answer/status are unchanged. KAT `post_run_extraction_failure_is_isolated_run_stays_finished` proves this with a transport whose extraction POST returns `Err` — the run_result row is byte-identical and no candidate is recorded.

### Flag-OFF byte-identical
New flag **`FRIDAY_RUN_LOOP_MEMORY_EXTRACTION`** (`runtime.rs:1956`), exact-"1" matcher mirroring the `claude_route_enabled_from_env` / `passport_mint_from` idiom; default-OFF (unset / empty / `0` / anything but `1`). OFF ⇒ the helper returns before any work: no extraction call, no query, no provider call. The run is byte-identical to today. The producer reads its own NS-8 `FRIDAY_MEMORY_REVIEW_NEEDS_ME` flag separately (unchanged, also default-OFF).

## "Ledger UNCHANGED" — read this precisely
The success KAT asserts `token_ledger +1` and `memory_item +1` when the flag is ON. That is the **expected, in-scope producer side effect** of reusing `extract_inline`: the extraction's own provider-call cost is ledgered (a row keyed `led:{run_id}:{now_ms}`) and the recorded candidate is a non-durable `memory_item` (`state = Candidate`). The charter's "the run's … ledger UNCHANGED" applies to the **run's answer / status / `run_result` row** — which both the success and failure KATs prove byte-identical. The extraction's ledger/candidate rows are a *new, intended* effect of the trigger, not a change to the run.

## Design facts (deliberate, in-scope)
- **Synchronous inline.** When ON, the answer is held until the extraction provider call returns (`let answer = …; self.maybe_extract…(); answer`). Errors are isolated, but a slow extraction delays answer delivery. Async / background firing is explicitly out of scope (a future slice).
- **DeepSeek-only extraction.** The trigger always uses `self.deepseek.inner()` even when a `run_session_task_pinned` run answered via Claude — matching the producer / the `hub_extract_memory` bin (extraction is DeepSeek-only by design). `self.deepseek` is non-optional, so there is no nil path.
- **Producer signature relaxation** (the one change outside `lib.rs`/`runtime.rs`): `extract_inline` / `extract_inline_flagged` go from `&mut Db` → `&Db`. The whole extraction path uses only `&self`/`&Connection` storage ops, so the `&mut` was gratuitous — clippy's `unnecessary_mut_passed` flagged the old `&mut db` arguments. All pre-existing call sites coerce; behavior is byte-identical. The mechanical `&mut db → &db` / `let mut db → let db` test fixups in `memory_extraction.rs` follow from this.

## KATs (no live needed; mock/temp DB)
- `run_loop_memory_extraction_flag_matcher_is_exact_one_default_off` — exact-"1", default-OFF.
- `post_run_extraction_flag_on_finished_fires_and_never_changes_the_run` — ON+Finished: extraction fired (token_ledger +1, memory_item +1) AND the run_result row (status + answer body) is byte-identical to the delivered answer.
- `post_run_extraction_not_fired_on_non_finished_outcomes` — Paused/Errored/Bounded/Blocked/Interrupted (with a pending-message session) fire nothing.
- `post_run_extraction_failure_is_isolated_run_stays_finished` — extraction POST errors → swallowed; run stays Finished, answer unchanged, no candidate.
- `post_run_extraction_flag_off_is_byte_identical_even_on_finished` — OFF on a Finished, pending-message, owned session (would fire if ON): a PanicTransport proves zero provider contact; counts unchanged.

## Local gates (worktree, born-current on origin/main `3bf1560b`)
- `cargo fmt --all -- --check` ✅
- `cargo clippy --workspace --all-targets -- -D warnings` ✅
- `cargo build --workspace --all-targets` ✅
- `cargo test --workspace` ✅ (friday-hub lib: 655 passed / 0 failed)

## Scope / honesty
Confirmation (Needs-Me UI) and the recall side are **separate** surfaces (operator-gated / later). The candidates this trigger lands are non-durable `Candidate` rows requiring an explicit confirm. DARK, proof-only — NOT a v1 GO. No gate-weakening, no admin, no panic/unwrap; flag-OFF dark-safe; extraction failure-isolated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)