### PR TITLE
feat(mission-spine): emit mission_context on AgentRunRequest envelope (dark, additive-optional)

### DIFF
--- a/src/api/mission-spine/friday-rust-hub-agent-run-sealed-client-service.ts
+++ b/src/api/mission-spine/friday-rust-hub-agent-run-sealed-client-service.ts
@@ -4,6 +4,7 @@ import {
   createFridayRustHubAgentRunSealedClient,
   type CreateFridayRustHubAgentRunSealedClientOptions,
   type FridayRustHubAgentRunConstraints,
+  type FridayRustHubAgentRunMissionContext,
   type FridayRustHubAgentRunPausedOutcome,
   type FridayRustHubAgentRunResumeResult,
   type FridayRustHubAgentRunSealedClient,
@@ -87,6 +88,14 @@ export interface FridayRustHubAgentRunSealedClientServiceRequest {
    * / disabled-tools / max-turns), tightening only, behind its default-off run-control flag.
    */
   readonly constraints?: FridayRustHubAgentRunConstraints;
+  /**
+   * (NS45-PR1 / M-4) The first-class Mission handle forwarded UNCHANGED to the underlying sealed
+   * client, which emits the snake_case `mission_context` wire block ONLY when a handle is present
+   * (absent ⇒ OMITTED ⇒ byte-identical pre-NS45 wire). The Rust server resolves the handle and
+   * walks the mission-bound run path behind its default-off `FRIDAY_MISSION_BOUND_RUN` flag; the
+   * bound owner is the authenticated `forwardedPrincipal`, gated server-side, never this handle.
+   */
+  readonly missionContext?: FridayRustHubAgentRunMissionContext;
 }
 
 /**
@@ -277,6 +286,9 @@ export function createFridayRustHubAgentRunSealedClientService(
           // (A1 run-controls) forward the per-run constraints; the inner client emits the
           // `constraints` wire block only when something tightens (absent ⇒ byte-identical wire).
           ...(request.constraints !== undefined ? { constraints: request.constraints } : {}),
+          // (NS45-PR1 / M-4) forward the first-class Mission handle; the inner client emits the
+          // `mission_context` wire block only when a handle is present (absent ⇒ byte-identical wire).
+          ...(request.missionContext !== undefined ? { missionContext: request.missionContext } : {}),
         });
       } catch (error) {
         throw error instanceof FridayDomainError

--- a/src/api/mission-spine/friday-rust-hub-agent-run-ws-sealed-client.ts
+++ b/src/api/mission-spine/friday-rust-hub-agent-run-ws-sealed-client.ts
@@ -148,6 +148,37 @@ export interface FridayRustHubAgentRunSealedRequest {
    * `sessionKey` additive-optional discipline.
    */
   readonly constraints?: FridayRustHubAgentRunConstraints;
+  /**
+   * (NS45-PR1 / M-4) The FIRST-CLASS Mission handle this run participates in. A real handle
+   * `{fridayConversationId, missionId, workItemId}` (from the NS-5 `MissionIntakeResult`) is
+   * emitted on the wire as the snake_case `mission_context` block, which lets the Rust dispatch
+   * resolve the Mission via `MissionContextLookup::by_mission_work_item` and route through the
+   * mission-bound run path (`run_authed_agent_loop_mission_bound`). ABSENT (`undefined`) ⇒ the
+   * `mission_context` field is OMITTED from the wire entirely, so the envelope is BYTE-IDENTICAL
+   * to the pre-NS45 request and routes through the UNCHANGED unbound dispatch path. DARK + gated:
+   * the server walks the bound path only behind its default-off `FRIDAY_MISSION_BOUND_RUN` flag,
+   * so emitting the handle changes no live behavior until that flag is on. **SECURITY: this only
+   * SELECTS which Mission/WorkItem the run binds to; it confers NO authority — the run's bound
+   * owner is the authenticated `forwardedPrincipal`, gated server-side, never this handle.**
+   * Mirrors the `sessionKey`/`constraints` additive-optional discipline.
+   */
+  readonly missionContext?: FridayRustHubAgentRunMissionContext;
+}
+
+/**
+ * (NS45-PR1 / M-4) The TS-side first-class Mission handle (camelCase; mapped to the snake_case
+ * `MissionWorkItemContextWire` the Rust server decodes). All three fields are REQUIRED on the wire
+ * struct (`friday_protocol::MissionWorkItemContextWire` — `friday_conversation_id` / `mission_id` /
+ * `work_item_id`, none `Option`), so this TS shape REQUIRES all three too (no collapse-to-absent on
+ * an individual field). Presence of the whole object is what is optional, mirroring `sessionKey`.
+ */
+export interface FridayRustHubAgentRunMissionContext {
+  /** The canonical Friday conversation this run belongs to (Rust `friday_conversation_id`). */
+  readonly fridayConversationId: string;
+  /** The Mission this run binds to (Rust `mission_id`). */
+  readonly missionId: string;
+  /** The WorkItem this run advances (Rust `work_item_id`). */
+  readonly workItemId: string;
 }
 
 /**
@@ -710,6 +741,31 @@ export function buildConstraintsWire(
     wire.max_turns = constraints.maxTurns;
   }
   return Object.keys(wire).length > 0 ? wire : undefined;
+}
+
+/**
+ * (NS45-PR1 / M-4) Map the TS-side first-class Mission handle onto the snake_case
+ * `MissionWorkItemContextWire` shape the Rust server decodes — or `undefined` when NO handle is
+ * given, so the caller OMITS the whole `mission_context` key (byte-identity with the pre-NS45
+ * request). Unlike `buildConstraintsWire` there is NO tightening/collapse logic: the Rust struct's
+ * three fields are ALL required (`friday_conversation_id` / `mission_id` / `work_item_id`, none
+ * `Option`), so a defined handle ALWAYS emits the full three-field object. This is presence-based
+ * (mirrors `session_id`), NOT value-collapsing. The handle is a client ASSERTION of which Mission
+ * the run binds to — it confers no authority; the bound owner is the authenticated principal,
+ * gated server-side. EXPORTED + pure so the precise wire shape is unit-testable without a socket
+ * (mirrors {@link buildConstraintsWire}).
+ */
+export function buildMissionContextWire(
+  missionContext: FridayRustHubAgentRunMissionContext | undefined,
+): Record<string, unknown> | undefined {
+  if (missionContext === undefined) {
+    return undefined;
+  }
+  return {
+    friday_conversation_id: missionContext.fridayConversationId,
+    mission_id: missionContext.missionId,
+    work_item_id: missionContext.workItemId,
+  };
 }
 
 /**
@@ -1621,6 +1677,12 @@ export function createFridayRustHubAgentRunSealedClient(
             // BYTE-IDENTICAL to the pre-A1 request and the server applies no override. This
             // mirrors the `session_id` conditional-spread discipline.
             const constraintsWire = buildConstraintsWire(request.constraints);
+            // (NS45-PR1 / M-4) Derive the snake_case `mission_context` wire block from the request's
+            // first-class Mission handle, emitting it ONLY when a handle is present. When NO handle is
+            // given the whole `mission_context` key is OMITTED, so the serialized envelope is
+            // BYTE-IDENTICAL to the pre-NS45 request and the server routes through the unchanged
+            // unbound dispatch path. This mirrors the `session_id` conditional-spread discipline.
+            const missionContextWire = buildMissionContextWire(request.missionContext);
             const envelope = {
               schema_version: SCHEMA_VERSION,
               msg_id: `agent-run-${request.runId}`,
@@ -1637,6 +1699,8 @@ export function createFridayRustHubAgentRunSealedClient(
                 ...(sessionId !== undefined ? { session_id: sessionId } : {}),
                 // Conditional spread: present ⇒ `constraints` rides the wire; absent ⇒ no key.
                 ...(constraintsWire !== undefined ? { constraints: constraintsWire } : {}),
+                // Conditional spread: present ⇒ `mission_context` rides the wire; absent ⇒ no key.
+                ...(missionContextWire !== undefined ? { mission_context: missionContextWire } : {}),
               },
             };
             sealAndSend(sender, sessionKey, envelope);

--- a/test/unit/api/mission-spine/friday-rust-hub-agent-run-ws-mission-context-wire.test.ts
+++ b/test/unit/api/mission-spine/friday-rust-hub-agent-run-ws-mission-context-wire.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+
+import { buildMissionContextWire } from "../../../../src/api/mission-spine/friday-rust-hub-agent-run-ws-sealed-client.js";
+
+// (NS45-PR1 / M-4) `buildMissionContextWire` maps the TS-side first-class Mission handle onto the
+// snake_case `MissionWorkItemContextWire` shape the Rust server decodes — or `undefined` when NO
+// handle is given, so the AgentRunRequest envelope OMITS the whole `mission_context` key
+// (byte-identity with the pre-NS45 request). Unlike `buildConstraintsWire` there is NO
+// tightening/collapse: the Rust struct's three fields are ALL required, so a defined handle ALWAYS
+// emits the full three-field object. This is presence-based (mirrors `session_id`).
+//
+// GOLDEN cross-check against the REAL Rust wire struct
+// (rust-core/crates/friday-protocol/src/lib.rs):
+//   - `pub struct MissionWorkItemContextWire` (lib.rs:294), `#[serde(... Serialize, Deserialize)]`
+//     with NO `#[serde(rename_all)]` ⇒ field names serialize VERBATIM (already snake_case);
+//   - `pub friday_conversation_id: String` (lib.rs:295)  — REQUIRED (not Option, no serde default);
+//   - `pub mission_id: String`            (lib.rs:296)  — REQUIRED;
+//   - `pub work_item_id: String`          (lib.rs:297)  — REQUIRED.
+// The seam reads exactly these three off the handle:
+//   - hub_server.rs:1696 `handle.friday_conversation_id`
+//   - hub_server.rs:1697 `handle.mission_id`
+//   - hub_server.rs:1698 `handle.work_item_id`
+// The `AgentRunRequest` variant carries it as `mission_context: Option<MissionWorkItemContextWire>`
+// (lib.rs:1383) with `#[serde(default, skip_serializing_if = "Option::is_none")]` (lib.rs:1382), so
+// `None` ⇒ NO `mission_context` key on the wire (lib.rs round-trip asserts this at lib.rs:2590).
+describe("buildMissionContextWire (NS45-PR1, snake_case wire mapping — golden cross-check)", () => {
+  it("undefined input ⇒ undefined (no wire block — byte-identical pre-NS45 envelope)", () => {
+    // ABSENT case: a handle-free request omits the whole `mission_context` key. The envelope
+    // builder spreads `...(missionContextWire !== undefined ? { mission_context } : {})`, so an
+    // `undefined` here produces NO key ⇒ the serialized envelope is byte-identical to today's.
+    expect(buildMissionContextWire(undefined)).toBeUndefined();
+  });
+
+  it("a defined handle ⇒ the EXACT three-field snake_case golden wire object", () => {
+    // PRESENT case: the emitted object must deep-equal this hand-written golden fixture, whose
+    // keys + required set were cross-checked field-for-field against MissionWorkItemContextWire
+    // (lib.rs:294-297) above. No extra keys, no missing keys, snake_case verbatim.
+    const golden = {
+      friday_conversation_id: "conv-7",
+      mission_id: "mission-42",
+      work_item_id: "work-item-9",
+    };
+    const wire = buildMissionContextWire({
+      fridayConversationId: "conv-7",
+      missionId: "mission-42",
+      workItemId: "work-item-9",
+    });
+    expect(wire).toEqual(golden);
+    // EXACT key set — no fabricated/extra fields, none of the three dropped (all are REQUIRED).
+    expect(Object.keys(wire ?? {}).sort()).toEqual([
+      "friday_conversation_id",
+      "mission_id",
+      "work_item_id",
+    ]);
+  });
+
+  it("all three fields are emitted VERBATIM (no normalization the Rust side does not do)", () => {
+    // Unlike constraints (trim/de-dup/drop-empty), the Mission handle is passed through verbatim:
+    // the Rust struct does no normalization, so neither does TS. Values ride exactly as given.
+    const wire = buildMissionContextWire({
+      fridayConversationId: "  spaced-conv  ",
+      missionId: "Mission-MixedCase",
+      workItemId: "wi/with/slashes",
+    });
+    expect(wire).toEqual({
+      friday_conversation_id: "  spaced-conv  ",
+      mission_id: "Mission-MixedCase",
+      work_item_id: "wi/with/slashes",
+    });
+  });
+});


### PR DESCRIPTION
## The gap
Friday's Rust hub already has a fully-built mission-bound run path (`run_authed_agent_loop_mission_bound`) that walks a WorkItem `ReadyToDispatch -> Dispatched -> HubAccepted -> ProviderRouted -> ProviderWaiting -> CompletedWithProof` with a real provider call + proof receipt. It is wired into the live bin (`hub_agent_run_server.rs:840-853`) behind the default-off `FRIDAY_MISSION_BOUND_RUN` flag.

But the TS sealed-WS client that builds the `AgentRunRequest` envelope (`friday-rust-hub-agent-run-ws-sealed-client.ts`) emitted `run_id`, `task`, `forwarded_principal`, `auth_proof`, and conditional `session_id`/`constraints` — **never a `mission_context` key**. So every live run arrived with `mission_context = None` and could never dispatch bound. The bound path was unreachable from the wire.

## What this does (envelope plumbing ONLY)
Threads an OPTIONAL first-class Mission handle through the run-start path and emits `mission_context`, mirroring the proven `session_id`/`constraints` additive-optional discipline:

- **Inner client** (`friday-rust-hub-agent-run-ws-sealed-client.ts`): adds an optional `missionContext` field (`FridayRustHubAgentRunMissionContext` = `fridayConversationId` / `missionId` / `workItemId`) to `FridayRustHubAgentRunSealedRequest`; adds an exported pure `buildMissionContextWire` that maps it onto the snake_case `MissionWorkItemContextWire` shape; emits it via conditional-spread on the envelope `message` object.
- **Service** (`friday-rust-hub-agent-run-sealed-client-service.ts`): adds the optional `missionContext` field and forwards it UNCHANGED to the inner client, mirroring the `constraints` spread.

Threading stops at the service boundary — the explicitly-deferred handle-producing driver is the natural next caller. `composeRustReadOnlyAgentRun` is the read-only path (a mission-bound run is work-doing, not read-only), so binding does not belong there.

## Dark-safety (flag OFF = inert, verified byte-identical)
Presence-based conditional-spread: `...(missionContextWire !== undefined ? { mission_context: missionContextWire } : {})`. With no handle (today's prod state, `FRIDAY_MISSION_BOUND_RUN` OFF) ⇒ **NO `mission_context` key** ⇒ the serialized envelope is **byte-identical** to the pre-change wire and routes through the unchanged unbound dispatch path. No Rust touched, no defaults changed, no flag flipped, no driver/poller/intake added.

## Golden cross-check (anti-mock-green)
`buildMissionContextWire` emits exactly the three REQUIRED snake_case fields of the real Rust wire struct `friday_protocol::MissionWorkItemContextWire`:
- `friday_conversation_id: String` — `lib.rs:295` (required, no `Option`, no serde default)
- `mission_id: String` — `lib.rs:296` (required)
- `work_item_id: String` — `lib.rs:297` (required)

Struct has NO `#[serde(rename_all)]` ⇒ field names serialize verbatim. The bound seam reads exactly these three off the handle: `handle.friday_conversation_id` / `handle.mission_id` / `handle.work_item_id` (`hub_server.rs:1696-1698`). The `AgentRunRequest` variant carries it as `mission_context: Option<MissionWorkItemContextWire>` with `#[serde(default, skip_serializing_if = "Option::is_none")]` (`lib.rs:1382-1383`), so `None` ⇒ no key (asserted in the Rust round-trip at `lib.rs:2590`).

New test (`friday-rust-hub-agent-run-ws-mission-context-wire.test.ts`) asserts the golden wire object (PRESENT) and `undefined ⇒ undefined` (ABSENT byte-identity). The existing sealed-client + service tests pass untouched as the regression guard.

## Local verification
- `eslint .` → 0 errors (warnings are repo-wide pre-existing baseline; the `max-lines-per-function` on the sealed-client factory pre-existed at 348 lines before this PR)
- `npm run typecheck` (src + contracts) → 0 errors
- vitest: 49/49 pass (3 new golden + 46 existing sealed-client/service/constraints regression)
- detect-secrets-hook + `check-provider-key-patterns.mjs` → clean

## Follow-ups (operator-gated, NOT in this PR)
- Live proof of a bound dispatch end-to-end.
- The `FRIDAY_MISSION_BOUND_RUN=1` flag flip on prod.
- The handle-producing driver that supplies a real `{fridayConversationId, missionId, workItemId}` from a `MissionIntakeResult` (separate slice).

🤖 Generated with [Claude Code](https://claude.com/claude-code)