### PR TITLE
feat(hub): migrate codex gated-turn to Ed25519 verify-only authorization (dark, parity)

### DIFF
--- a/rust-core/crates/friday-hub/src/codex_gated_turn.rs
+++ b/rust-core/crates/friday-hub/src/codex_gated_turn.rs
@@ -12,10 +12,12 @@
 //!        │                                              │     Friday MutatingActionRequest,
 //!        │                                              │     deriving mutating/risk from the
 //!        │                                              │     TRUSTED registry — never the model
-//!        │                                              │ (2) GATE via the EXISTING stack:
-//!        │                                              │     friday_storage::authorize_agent_action
-//!        │                                              │     (trust-grant allowed_tools / risk
-//!        │                                              │      ceiling AND the mutating-action gate)
+//!        │                                              │ (2) GATE in two steps via the EXISTING
+//!        │                                              │     stack: friday_storage::authorize_agent_action
+//!        │                                              │     for the trust-grant check (allowed_tools /
+//!        │                                              │     risk ceiling) THEN the verify-only
+//!        │                                              │     friday_storage::authorize_mutating_action_ed25519
+//!        │                                              │     for the protected (mutating) gate
 //!        │  ◀── accept / cancel(deny) ──────────────────│ (3) MAP GateDecision → Codex decision
 //!        ▼                                                    Allow→accept, Deny/RequiresApproval→cancel
 //!  continues / aborts the turn                               and, on RequiresApproval, persist a
@@ -31,8 +33,10 @@
 //!   both need the connection, and threading it through the trait would force a borrow that
 //!   does not compose.
 //! - It REUSES, never reimplements: the trusted classifier ([`crate::trusted_classify`] via
-//!   [`crate::build_request_with_policy`]), the gate compose
-//!   ([`friday_storage::authorize_agent_action`]), the pending-approval persistence
+//!   [`crate::build_request_with_policy`]), the trust-grant check
+//!   ([`friday_storage::authorize_agent_action`]), the verify-only Ed25519 mutating-action gate
+//!   ([`friday_storage::authorize_mutating_action_ed25519`] — the IDENTICAL fn the
+//!   deepseek/claude routed loop uses), the pending-approval persistence
 //!   ([`friday_storage::PendingApprovalRequest`] / [`friday_storage::persist_pending_request`]),
 //!   the CSPRNG nonce ([`friday_crypto::generate_approval_nonce`]), and the billing map
 //!   ([`crate::BilledUsage::from_codex`]). It adds NO parallel gate, ledger, or pause
@@ -42,8 +46,21 @@
 //!   [`friday_providers::codex_appserver::CodexAppServerClient::run_turn_with_handler`]: with
 //!   the flag OFF, that surface fails closed on any mid-turn approval request WITHOUT
 //!   consulting our handler (byte-identical to the historical `interactive-approval-unsupported`),
-//!   so this path is effectively unused until the operator flips the flag. PR-B rewires
-//!   `runtime.rs` to CALL this and removes the in-process "brain"; this PR only builds the core.
+//!   so this path is effectively unused until the operator flips the flag. The runtime executor
+//!   seam ([`crate::CodexTurnExecutor`] / [`crate::LocalCodexGatedTurnExecutor`]) already CALLS
+//!   this fn, but passes `operator_vk = None` (DenyAll) until a follow-up threads a provisioned
+//!   operator verify key through the trait; the route flip is separately operator-gated.
+//!
+//! ## The HMAC → Ed25519 security upgrade (S6b/S6d parity)
+//! The protected (mutating-action) authorization is now **Ed25519 verify-only**: the Hub
+//! holds ONLY the operator's PUBLIC verify key ([`OperatorVerifyingKey`]) and can VERIFY an
+//! operator-signed approval but has NO path to MINT one. This brings the Codex gated turn to
+//! PARITY with the deepseek/claude routed loop (both call the same
+//! [`friday_storage::authorize_mutating_action_ed25519`]) and closes the latent self-Allow the
+//! old Hub-held HMAC secret left open (an HMAC-signed approval over the SAME canonical bytes is
+//! REJECTED — an HMAC hex is not a valid Ed25519 signature). With `operator_vk = None` (the
+//! triple-dark default) a protected action can NEVER be upgraded — it stays `RequiresApproval`
+//! and Pauses (DenyAll-equivalent).
 //!
 //! ## No-bypass / no-degrade invariants (the point of this PR)
 //! - **Mutating-ness is registry-derived, never the model's word.** Every Codex approval
@@ -67,11 +84,12 @@
 use std::cell::RefCell;
 
 use friday_core::gate::{CanonicalApproval, GateDecision, MutatingActionRequest};
+use friday_crypto::OperatorVerifyingKey;
 use friday_providers::codex_appserver::{
     CodexAppServerClient, CodexAppServerTransport, CodexApprovalDecision, CodexServerRequest,
     ModelTurnOutcome,
 };
-use friday_storage::AgentActionContext;
+use friday_storage::{authorize_mutating_action_ed25519, AgentActionContext};
 use rusqlite::Connection;
 
 use crate::{build_request_with_policy, BilledUsage, RawToolCall, RunPolicy, ToolError};
@@ -158,7 +176,7 @@ enum CapturedGate {
 /// Run ONE gated Codex model turn through the EXISTING Friday trust/approval stack and map
 /// the result onto a [`CodexTurnOutcome`].
 ///
-/// `codex_client` must already be on a started thread (the caller — PR-B — does
+/// `codex_client` must already be on a started thread (the caller does
 /// `initialize`/`thread/start`); this function drives exactly one turn via
 /// [`CodexAppServerClient::run_turn_with_handler`]. The Codex-transport gate flag
 /// ([`friday_providers::codex_appserver::FRIDAY_CODEX_MUTATING_GATE`]) governs whether the
@@ -174,22 +192,33 @@ enum CapturedGate {
 ///    [`crate::build_request_with_policy`] — so `mutating`/`risk`/`resource` are derived by
 ///    the trusted [`crate::trusted_classify`], NEVER from the model. An untranslatable
 ///    request (e.g. a command-execution with no command) fails closed.
-/// 2. **Gates** it via [`friday_storage::authorize_agent_action`] (the trust-grant
-///    `allowed_tools`/risk-ceiling AND-gate composed with the mutating-action gate) — reused
-///    verbatim. `approve_fn` supplies the (optional) [`CanonicalApproval`].
+/// 2. **Gates** it in TWO steps (NOT one composed call — preserving the trust check while
+///    swapping the protected authorize to Ed25519, mirroring the deepseek/claude loop's
+///    `gate_dispatch_with_policy_enforced`). Step 2a is the trust-grant check via
+///    [`friday_storage::authorize_agent_action`] with NO approval and NO secret — only a
+///    `denied_by == Some("trust_grant")` Deny (chat-only grant / risk-ceiling / no-active-grant)
+///    is consumed here, surfacing the grant's own reason. Step 2b is the protected (mutating)
+///    gate via [`friday_storage::authorize_mutating_action_ed25519`] — the IDENTICAL verify-only
+///    fn the routed loop uses — under the operator's PUBLIC `operator_vk`. With
+///    `operator_vk = None` (the triple-dark default) the base [`friday_core::gate::evaluate`]
+///    decision stands (DenyAll-equivalent): a protected action's `RequiresApproval` is never
+///    upgraded → it Pauses. `approve_fn` supplies the (optional) operator-signed
+///    [`CanonicalApproval`].
 /// 3. **Maps** the [`GateDecision`]: `Allow` → [`CodexApprovalDecision::Allow`]; `Deny` →
 ///    [`CodexApprovalDecision::Deny`] (captured as a hard deny); `RequiresApproval` →
 ///    [`CodexApprovalDecision::Deny`] (captured so the outer fn persists a pending request).
 ///
-/// `now_ms` timestamps the pending-approval row + its expiry. The `policy`'s
-/// `action_context` (the agent identity/workspace the trust grant is scoped to) is read back
-/// for the gate; if it carries none, the gate fails closed (`trust_no_active_grant`).
+/// `operator_vk` is the operator's PUBLIC Ed25519 verify key (the only half the Hub holds).
+/// `None` = unprovisioned = fail-closed DenyAll for protected actions. `now_ms` timestamps the
+/// pending-approval row + its expiry. The `policy`'s `action_context` (the agent
+/// identity/workspace the trust grant is scoped to) is read back for the trust check; if it
+/// carries none, the trust check fails closed (`trust_no_active_grant`).
 #[allow(clippy::too_many_arguments)]
 pub fn run_codex_gated_turn<T, F>(
     conn: &Connection,
     codex_client: &mut CodexAppServerClient<T>,
     policy: &RunPolicy,
-    secret: &[u8],
+    operator_vk: Option<&OperatorVerifyingKey>,
     approve_fn: &F,
     thread_id: &str,
     user_message_id: Option<&str>,
@@ -240,23 +269,61 @@ where
             }
         };
 
-        // (2) GATE via the EXISTING stack. Enrich the context's `.tool` dimension with the
-        // dispatched (registry) action so the trust grant's `allowed_tools` allowlist is
-        // actually checked (the same enrich the run-loop's TP-PR1 path does; without it the
-        // tool dimension is silently skipped = fail-open). This is restriction-only.
+        // (2) GATE in TWO steps (NOT one composed call). The pre-Ed25519 path called the
+        // composed `authorize_agent_action(.., approval, secret, ..)`, which ran the trust check
+        // THEN the inner HMAC mutating-action authorize. We SPLIT that so the protected gate is
+        // the verify-only Ed25519 fn (parity with the deepseek/claude loop) while the trust
+        // check is PRESERVED verbatim — dropping it would be a no-degrade trap (the Ed25519 fn
+        // has NO trust logic; it would never enforce a chat-only grant or the risk ceiling).
+        //
+        // (2a) TRUST-GRANT CHECK ONLY. Run `authorize_agent_action` with NO approval and NO
+        // secret so it cannot upgrade anything; we consume ONLY a `trust_grant` Deny (chat-only
+        // grant / risk-ceiling / no-active-grant), surfacing the grant's own reason. Any other
+        // outcome (Allow / a non-trust Deny / RequiresApproval) means trust did not object, so
+        // we fall through to the protected authorize in (2b). Enrich the context's `.tool`
+        // dimension with the dispatched (registry) action so the grant's `allowed_tools`
+        // allowlist is actually checked (the same enrich the run-loop's TP-PR1 path does;
+        // without it the tool dimension is silently skipped = fail-open). Restriction-only.
         let mut ctx = base_ctx.clone();
         ctx.tool = Some(raw.action.clone());
-        let record = match friday_storage::authorize_agent_action(
-            conn,
-            &request,
-            &ctx,
-            approve_fn(&request).as_ref(),
-            secret,
-            now_ms,
-        ) {
+        match friday_storage::authorize_agent_action(conn, &request, &ctx, None, &[], now_ms) {
+            // The trust grant objected — capture its own reason (Errored). The protected
+            // authorize is never reached (trust denies short-circuit).
+            Ok(r) if r.denied_by.as_deref() == Some("trust_grant") => {
+                *captured.borrow_mut() = Some(CapturedGate::Denied { reason: r.reason });
+                return Ok(CodexApprovalDecision::Deny);
+            }
+            // No trust objection — fall through to the protected (Ed25519) authorize below.
+            Ok(_) => {}
+            // A storage error during the trust check fails CLOSED.
+            Err(_) => {
+                *captured.borrow_mut() = Some(CapturedGate::Denied {
+                    reason: "codex_authorize_unavailable".to_string(),
+                });
+                return Ok(CodexApprovalDecision::Deny);
+            }
+        }
+
+        // (2b) PROTECTED MUTATING-ACTION GATE — verify-only Ed25519, the IDENTICAL fn the
+        // deepseek/claude routed loop uses. With `operator_vk = None` (triple-dark default) the
+        // pure base decision stands (DenyAll-equivalent): a `RequiresApproval` is never upgraded
+        // → Pause. With `Some(vk)`, only an operator-Ed25519-signed approval bound to THIS exact
+        // action can upgrade it; an HMAC-signed approval over the same bytes is rejected.
+        let record = match operator_vk {
+            Some(vk) => authorize_mutating_action_ed25519(
+                conn,
+                &request,
+                approve_fn(&request).as_ref(),
+                vk,
+                now_ms,
+            ),
+            None => Ok(friday_core::gate::evaluate(&request)),
+        };
+        let record = match record {
             Ok(r) => r,
-            // A storage error during authorize fails CLOSED: deny + capture so the turn
-            // aborts and the caller sees a typed reason (never auto-approve on a DB hiccup).
+            // A storage error during the protected authorize (e.g. the consumed_approval INSERT)
+            // fails CLOSED: deny + capture so the turn aborts and the caller sees a typed reason
+            // (never auto-approve on a DB hiccup).
             Err(_) => {
                 *captured.borrow_mut() = Some(CapturedGate::Denied {
                     reason: "codex_authorize_unavailable".to_string(),
@@ -565,17 +632,24 @@ mod tests {
         None
     }
 
+    /// Drive the gated turn with the offline-operator default (`no_approval`) and the given
+    /// `operator_vk`. NOTE: the `src` test module CANNOT name an operator *signing* key (the
+    /// `hub_crate_never_references_a_signing_key` structural guard scans this `src` tree for that
+    /// type), so the tests here only use `operator_vk = None` (the unprovisioned DenyAll path).
+    /// The provisioned positive-parity + HMAC-downgrade-defense KATs (which must MINT/SIGN
+    /// approvals with a real operator key) live in `tests/codex_gated_turn_ed25519.rs`.
     fn run<T: CodexAppServerTransport>(
         db: &Db,
         client: &mut CodexAppServerClient<T>,
         policy: &RunPolicy,
+        operator_vk: Option<&OperatorVerifyingKey>,
         text: &str,
     ) -> Result<CodexTurnOutcome, CodexGatedTurnError> {
         run_codex_gated_turn(
             db.conn(),
             client,
             policy,
-            b"test-secret",
+            operator_vk,
             &no_approval,
             "thread-1",
             None,
@@ -586,67 +660,19 @@ mod tests {
         )
     }
 
-    // ---- KAT (a): grant allows the tool → Allow → turn continues + Finishes ----
+    // ---- KAT (a) — RELOCATED to the integration tier ----
     //
-    // A grant whose `allowed_tools` includes `run_command` AND whose risk ceiling admits a
-    // High command: the gate composes trust-OK with the mutating gate. With no approval the
-    // mutating gate still RequiresApproval (a mutating action never auto-allows), so KAT (a)
-    // uses a READ-equivalent? No — every Codex approval request is a mutating action. The
-    // "turn continues + Finishes" Allow path is exercised by a grant that admits the tool AND
-    // an approval supplied by `approve_fn`. We prove the Allow→continue wire with an approval.
-    #[test]
-    fn kat_a_allowed_tool_with_approval_continues_and_finishes() {
-        let _gate = GateOn::on();
-        let db = Db::open_hub(&temp_path("kat-a")).unwrap();
-        let policy = policy_for("agent-1");
-        insert_grant(&db, "agent-1", &["run_command"], Risk::High);
-
-        // approve_fn mints a valid approval bound to the EXACT request → the mutating gate
-        // upgrades RequiresApproval to Allow → Codex `accept` → turn continues to completion.
-        let approve = |req: &MutatingActionRequest| -> Option<CanonicalApproval> {
-            Some(crate::mint_approval(
-                req,
-                "ap-allowed",
-                b"test-secret",
-                10_000,
-            ))
-        };
-        let mut client = client_over(Box::leak(
-            command_turn("cargo build", true).into_boxed_str(),
-        ));
-        let out = run_codex_gated_turn(
-            db.conn(),
-            &mut client,
-            &policy,
-            b"test-secret",
-            &approve,
-            "thread-1",
-            None,
-            "build it",
-            "gpt-5-codex",
-            "run-1",
-            1_000,
-        )
-        .unwrap();
-        match out {
-            CodexTurnOutcome::Finished { answer, usage } => {
-                assert_eq!(answer, "done");
-                assert_eq!(usage.provider_kind, friday_core::ProviderKind::Codex);
-                assert_eq!(usage.model, "gpt-5-codex");
-            }
-            other => panic!("expected Finished, got {other:?}"),
-        }
-        // The wire carries the `accept` decision (Allow), and the force-approval policy.
-        let written = String::from_utf8(client.into_transport().into_parts().1).unwrap();
-        assert!(
-            written.lines().any(|l| {
-                let v: serde_json::Value = serde_json::from_str(l).unwrap();
-                v.get("result").and_then(|r| r.get("decision"))
-                    == Some(&serde_json::json!("accept"))
-            }),
-            "expected an accept decision on the wire: {written}"
-        );
-    }
+    // The old HMAC KAT (a) is REPLACED by two tests that REQUIRE a real operator key (signing an
+    // Ed25519 approval for the positive-parity accept, and minting an HMAC approval to prove the
+    // downgrade defense rejects it). Both name an operator *signing* key, which the
+    // `operator_vk::tests::hub_crate_never_references_a_signing_key` structural guard FORBIDS
+    // anywhere under `friday-hub/src/` (a Hub that can name a signing key could self-mint). They
+    // therefore live in `tests/codex_gated_turn_ed25519.rs` (the integration tier is NOT scanned
+    // by that guard, mirroring `friday-storage/tests/authorize_ed25519.rs`):
+    //   - `ed25519_signed_approval_continues_and_finishes` (positive parity: accept → Finished)
+    //   - `hmac_signed_approval_is_rejected_downgrade_defense` (the anti-mock-green canary:
+    //     an HMAC-signed approval over the SAME bytes is REJECTED, not Allowed)
+    //   - `provisioned_but_unsigned_mutating_action_pauses` (Some(&vk) + no approval → Pause)
 
     // ---- KAT (b): chat-only grant (empty allowed_tools) → Deny → turn aborts ----
     #[test]
@@ -660,7 +686,9 @@ mod tests {
         let mut client = client_over(Box::leak(
             command_turn("cargo build", false).into_boxed_str(),
         ));
-        let out = run(&db, &mut client, &policy, "build it").unwrap();
+        // The trust check (step 2a) Denies a chat-only grant BEFORE the protected gate, so the
+        // `operator_vk` is irrelevant here — `None` proves the trust check survives the split.
+        let out = run(&db, &mut client, &policy, None, "build it").unwrap();
         match out {
             CodexTurnOutcome::Errored { reason } => {
                 assert!(
@@ -685,6 +713,7 @@ mod tests {
             &db,
             &mut client_over(Box::leak(command_turn("rm -rf /", false).into_boxed_str())),
             &policy,
+            None,
             "x",
         )
         .unwrap()
@@ -697,6 +726,12 @@ mod tests {
     }
 
     // ---- KAT (c): gate RequiresApproval → Deny + pending_approval_request persisted + Paused ----
+    //
+    // UNPROVISIONED (operator_vk = None — the triple-dark default / DenyAll): the protected gate's
+    // base `RequiresApproval` is NEVER upgraded (no approval can satisfy a None key), so a mutating
+    // Codex action Pauses + persists a pending row. (The provisioned-but-unsigned Pause variant —
+    // `Some(&vk)` + no approval → also Pause — lives in `tests/codex_gated_turn_ed25519.rs`, since
+    // naming an operator signing key / minting a key is forbidden under `friday-hub/src/`.)
     #[test]
     fn kat_c_requires_approval_persists_pending_and_pauses() {
         let _gate = GateOn::on();
@@ -709,7 +744,7 @@ mod tests {
         let mut client = client_over(Box::leak(
             command_turn("cargo build", false).into_boxed_str(),
         ));
-        let out = run(&db, &mut client, &policy, "build it").unwrap();
+        let out = run(&db, &mut client, &policy, None, "build it").unwrap();
         let nonce = match out {
             CodexTurnOutcome::Paused {
                 action,
@@ -758,7 +793,8 @@ mod tests {
         let mut client = client_over(Box::leak(
             command_turn("rm -rf /work/data", false).into_boxed_str(),
         ));
-        let out = run(&db, &mut client, &policy, "clean up").unwrap();
+        // Risk-ceiling deny is a trust-grant deny (step 2a), before the protected gate → vk N/A.
+        let out = run(&db, &mut client, &policy, None, "clean up").unwrap();
         match out {
             CodexTurnOutcome::Errored { reason } => {
                 assert!(
@@ -791,7 +827,8 @@ mod tests {
         let mut client = client_over(Box::leak(
             command_turn("cargo build", false).into_boxed_str(),
         ));
-        let out = run(&db, &mut client, &policy, "build it").unwrap();
+        // Flag OFF ⇒ the handler is never consulted, so the gate (and `operator_vk`) never runs.
+        let out = run(&db, &mut client, &policy, None, "build it").unwrap();
         match out {
             CodexTurnOutcome::Errored { reason } => {
                 assert_eq!(reason, "codex_protocol:interactive-approval-unsupported");
@@ -816,7 +853,7 @@ mod tests {
         let db = Db::open_hub(&temp_path("flag-off-text")).unwrap();
         let policy = policy_for("agent-1");
         let mut client = client_over(Box::leak(text_turn("hello").into_boxed_str()));
-        let out = run(&db, &mut client, &policy, "say hi").unwrap();
+        let out = run(&db, &mut client, &policy, None, "say hi").unwrap();
         match out {
             CodexTurnOutcome::Finished { answer, .. } => assert_eq!(answer, "hello"),
             other => panic!("text-only turn must Finish, got {other:?}"),
@@ -891,7 +928,11 @@ mod tests {
         let mut client = client_over(Box::leak(
             command_turn("cargo build", false).into_boxed_str(),
         ));
-        let out = run(&db, &mut client, &policy, "build it").unwrap();
+        // The trust check (step 2a) fails closed on a missing agent identity BEFORE the protected
+        // gate (step 2b), so `operator_vk` is irrelevant — `None` proves the trust check survives
+        // the split. The reason is the trust check's own `trust_no_active_grant`. (The
+        // ordering-with-a-key-provisioned nuance is asserted in `tests/codex_gated_turn_ed25519.rs`.)
+        let out = run(&db, &mut client, &policy, None, "build it").unwrap();
         match out {
             CodexTurnOutcome::Errored { reason } => {
                 assert!(reason.contains("trust_no_active_grant"), "got {reason}");

--- a/rust-core/crates/friday-hub/src/lib.rs
+++ b/rust-core/crates/friday-hub/src/lib.rs
@@ -857,9 +857,11 @@ impl<S: friday_providers::codex_appserver::CodexTurnSource> AgentLlmClient
 ///
 /// ## Why this is a separate seam from `AgentLlmClient`
 /// Codex is a coordinated AGENT in its own runtime: each pre-execution side effect it proposes
-/// must be routed through Friday's gate, which needs the `conn` (for `authorize_agent_action`
-/// and the pending-approval persist), the run `policy` (the trust-grant scope), the HMAC
-/// `secret`, and the operator `approve_fn`. The generic conn-less
+/// must be routed through Friday's gate, which needs the `conn` (for the trust check + the
+/// pending-approval persist), the run `policy` (the trust-grant scope), and the operator
+/// `approve_fn`. (The `secret` param is legacy — the live executor's `run_codex_gated_turn` is
+/// now Ed25519 verify-only and ignores it; see [`LocalCodexGatedTurnExecutor::run_gated_turn`].)
+/// The generic conn-less
 /// `AgentLlmClient::next_step_metered(&self, task, history)` carries NONE of those — which is
 /// exactly why the brain adapter was wrong (it treated Codex as a model-call and Friday-side
 /// re-executed). This seam takes them explicitly and returns a turn-level
@@ -930,7 +932,12 @@ impl CodexTurnExecutor for LocalCodexGatedTurnExecutor {
         &self,
         conn: &Connection,
         policy: &RunPolicy,
-        secret: &[u8],
+        // The HMAC `secret` is no longer consulted: `run_codex_gated_turn` is now Ed25519
+        // verify-only. The `CodexTurnExecutor` trait still carries it (deepseek/claude share
+        // the seam) — threading a provisioned `operator_vk` through the trait is a follow-up
+        // (see the `None` below). Until then this executor authorizes protected actions under
+        // DenyAll (the triple-dark default), so a mutating Codex turn always Pauses.
+        _secret: &[u8],
         approve: &dyn Fn(&MutatingActionRequest) -> Option<CanonicalApproval>,
         task: &str,
         run_id: &str,
@@ -962,7 +969,11 @@ impl CodexTurnExecutor for LocalCodexGatedTurnExecutor {
             conn,
             client,
             policy,
-            secret,
+            // TODO(follow-up): thread a provisioned `operator_vk` through `CodexTurnExecutor`
+            // so the live route can verify operator-signed approvals. Until then DenyAll: a
+            // protected (mutating) Codex action is never upgraded — it Pauses. This is the
+            // triple-dark default and keeps the route un-flippable without the key + flags.
+            None,
             &approve,
             &thread.thread_id,
             None,

--- a/rust-core/crates/friday-hub/tests/codex_gated_turn_ed25519.rs
+++ b/rust-core/crates/friday-hub/tests/codex_gated_turn_ed25519.rs
@@ -1,0 +1,318 @@
+//! Integration-tier KATs for the Ed25519 verify-only authorization of a gated Codex turn
+//! ([`friday_hub::codex_gated_turn::run_codex_gated_turn`]). These are the relocated KAT (a)
+//! tests: they REQUIRE a real operator key — signing an Ed25519 approval (positive parity) and
+//! minting an HMAC approval (the downgrade defense). Naming an operator *signing* key is FORBIDDEN
+//! anywhere under `friday-hub/src/` by the `hub_crate_never_references_a_signing_key` structural
+//! guard (a Hub that could name a signing key could self-mint the approvals it verifies). The
+//! integration tier (`tests/`) is a sibling of `src/` and is NOT scanned by that guard, so this is
+//! where signing must live — exactly mirroring `friday-storage/tests/authorize_ed25519.rs`.
+//!
+//! These prove, against the REAL `JsonLineTransport` over recorded Codex byte-streams (NO live
+//! codex), that the gated turn now authorizes protected actions via the IDENTICAL
+//! `friday_storage::authorize_mutating_action_ed25519` the deepseek/claude routed loop uses:
+//!   - an operator-Ed25519-signed approval Allows → the turn `accept`s → Finishes (parity);
+//!   - an HMAC-signed approval over the SAME canonical bytes is REJECTED (the anti-mock-green
+//!     downgrade canary — what the old Hub-held HMAC path WRONGLY accepted);
+//!   - a provisioned key with NO approval still Pauses (a mutating action never auto-allows).
+
+use std::sync::Mutex;
+
+use friday_core::gate::{
+    canonical_action_bytes, canonical_approval_signature_bytes, ApprovalDecision,
+    CanonicalApproval, MutatingActionRequest, CANONICAL_GATE_ISSUER,
+};
+use friday_core::Risk;
+use friday_crypto::{OperatorSigningKey, OperatorVerifyingKey};
+use friday_hub::codex_gated_turn::{run_codex_gated_turn, CodexTurnOutcome};
+use friday_hub::{mint_approval, RunPolicy};
+use friday_providers::codex_appserver::{
+    CodexAppServerClient, CodexAppServerTransport, JsonLineTransport, FRIDAY_CODEX_MUTATING_GATE,
+};
+use friday_storage::{AgentActionContext, Db};
+
+/// Serializes the gate-ON env mutation across this file's parallel test threads (cargo runs a
+/// test binary's `#[test]`s on multiple threads). The codex_appserver crate's gate is env-read
+/// (`FRIDAY_CODEX_MUTATING_GATE`); the `src` test module's `GATE_ENV_LOCK` is private, so we
+/// hold our own here. Held for each test body's lifetime and the var is cleared on the way out.
+static GATE_ENV_LOCK: Mutex<()> = Mutex::new(());
+
+/// RAII gate-ON guard: sets `FRIDAY_CODEX_MUTATING_GATE=1` while held (under the lock), clears
+/// it on drop. The flag-ON state is required for the handler (and thus the gate) to be consulted.
+struct GateOn(#[allow(dead_code)] std::sync::MutexGuard<'static, ()>);
+
+impl GateOn {
+    fn on() -> Self {
+        let guard = GATE_ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        std::env::set_var(FRIDAY_CODEX_MUTATING_GATE, "1");
+        GateOn(guard)
+    }
+}
+
+impl Drop for GateOn {
+    fn drop(&mut self) {
+        std::env::remove_var(FRIDAY_CODEX_MUTATING_GATE);
+    }
+}
+
+/// A fresh temp hub DB path, unique across runs AND processes.
+fn temp_path(tag: &str) -> String {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let dir = std::env::temp_dir();
+    let pid = std::process::id();
+    let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    dir.join(format!(
+        "friday-codex-ed25519-{pid}-{tag}-{n}-{nanos}.sqlite"
+    ))
+    .to_string_lossy()
+    .into_owned()
+}
+
+/// A `CodexAppServerClient` over a recorded `&[u8]` byte stream (the REAL `JsonLineTransport`) —
+/// NO live codex. Mirrors the `src` KATs' `client_over`.
+fn client_over(
+    stream: &'static str,
+) -> CodexAppServerClient<JsonLineTransport<&'static [u8], Vec<u8>>> {
+    CodexAppServerClient::new(JsonLineTransport::new(stream.as_bytes(), Vec::<u8>::new()))
+}
+
+/// A turn whose ONLY mid-turn event is the given commandExecution approval request, then (if
+/// `complete`) an agent message + turn/completed. Shaped per the codex_appserver recorded stream.
+fn command_turn(command: &str, complete: bool) -> String {
+    let mut s = String::new();
+    s.push_str(r#"{"id":1,"result":{"turn":{"id":"turn-1","status":"inProgress","items":[]}}}"#);
+    s.push('\n');
+    s.push_str(&format!(
+        r#"{{"id":77,"method":"item/commandExecution/requestApproval","params":{{"threadId":"thread-1","turnId":"turn-1","itemId":"i-1","approvalId":"ap-1","command":"{command}","cwd":"/work","startedAtMs":1}}}}"#
+    ));
+    s.push('\n');
+    if complete {
+        s.push_str(r#"{"method":"item/completed","params":{"threadId":"thread-1","turnId":"turn-1","completedAtMs":2,"item":{"id":"a-1","type":"agentMessage","text":"done"}}}"#);
+        s.push('\n');
+        s.push_str(r#"{"method":"turn/completed","params":{"threadId":"thread-1","turn":{"id":"turn-1","status":"completed","items":[]}}}"#);
+        s.push('\n');
+    }
+    s
+}
+
+/// Insert an ACTIVE trust grant for `agent_id` (the EXISTING `grant_trust` path).
+fn insert_grant(db: &Db, agent_id: &str, allowed_tools: &[&str], risk_ceiling: Risk) {
+    let grant = friday_core::TrustGrant {
+        grant_id: format!("g-{agent_id}"),
+        agent_id: agent_id.to_string(),
+        granted_at: 1,
+        expires_at: None,
+        revoked: false,
+        revoked_at: None,
+        boundaries: friday_core::TrustBoundaries {
+            workspace: None,
+            risk_ceiling,
+            token_ceiling: None,
+            max_runs: None,
+            allowed_channels: vec![],
+            allowed_providers: vec![],
+            allowed_tools: allowed_tools.iter().map(|s| s.to_string()).collect(),
+            allowed_workflow_families: vec![],
+            allowed_skill_families: vec![],
+        },
+    };
+    friday_storage::grant_trust(db.conn(), &grant, 1).expect("insert grant");
+}
+
+/// A policy bound to `agent_id` with an action-context (so the trust check finds the grant).
+fn policy_for(agent_id: &str) -> RunPolicy {
+    RunPolicy::new(Some(agent_id.to_string()), Vec::<String>::new(), false).with_action_context(
+        AgentActionContext {
+            agent_id: agent_id.to_string(),
+            ..Default::default()
+        },
+    )
+}
+
+/// Build a correctly-signed, digest-bound, future-dated **Ed25519** approval for THIS exact
+/// request — the operator's offline signature, the ONLY thing the verify-only gate accepts.
+/// Mirrors the proven pattern in `friday-storage/tests/authorize_ed25519.rs`.
+fn ed25519_approval(
+    request: &MutatingActionRequest,
+    sk: &OperatorSigningKey,
+    approval_id: &str,
+) -> CanonicalApproval {
+    let digest = friday_crypto::action_digest(&canonical_action_bytes(request));
+    let mut a = CanonicalApproval {
+        decision: ApprovalDecision::Approved,
+        approval_id: approval_id.to_string(),
+        action_digest: digest,
+        expires_at: Some(10_000),
+        issuer: Some(CANONICAL_GATE_ISSUER.to_string()),
+        signature: None,
+    };
+    a.signature = Some(sk.sign(&canonical_approval_signature_bytes(&a)).to_hex());
+    a
+}
+
+/// Drive ONE gated turn with the given `operator_vk` + `approve_fn`.
+#[allow(clippy::too_many_arguments)]
+fn run<T: CodexAppServerTransport, F: Fn(&MutatingActionRequest) -> Option<CanonicalApproval>>(
+    db: &Db,
+    client: &mut CodexAppServerClient<T>,
+    policy: &RunPolicy,
+    operator_vk: Option<&OperatorVerifyingKey>,
+    approve_fn: &F,
+    text: &str,
+) -> CodexTurnOutcome {
+    run_codex_gated_turn(
+        db.conn(),
+        client,
+        policy,
+        operator_vk,
+        approve_fn,
+        "thread-1",
+        None,
+        text,
+        "gpt-5-codex",
+        "run-1",
+        1_000,
+    )
+    .unwrap()
+}
+
+/// POSITIVE PARITY: an operator-Ed25519-signed approval bound to the EXACT request upgrades the
+/// verify-only mutating gate's RequiresApproval to Allow → Codex `accept` → the turn Finishes.
+/// This exercises the IDENTICAL `authorize_mutating_action_ed25519` the deepseek/claude loop uses.
+#[test]
+fn ed25519_signed_approval_continues_and_finishes() {
+    let _gate = GateOn::on();
+    let db = Db::open_hub(&temp_path("ed25519-pos")).unwrap();
+    let policy = policy_for("agent-1");
+    insert_grant(&db, "agent-1", &["run_command"], Risk::High);
+
+    // A freshly generated operator key; the Hub holds ONLY the verifying half.
+    let sk = OperatorSigningKey::generate();
+    let vk = sk.verifying_key();
+    let approve = |req: &MutatingActionRequest| -> Option<CanonicalApproval> {
+        Some(ed25519_approval(req, &sk, "ap-ed25519"))
+    };
+    let mut client = client_over(Box::leak(
+        command_turn("cargo build", true).into_boxed_str(),
+    ));
+    let out = run(&db, &mut client, &policy, Some(&vk), &approve, "build it");
+    match out {
+        CodexTurnOutcome::Finished { answer, usage } => {
+            assert_eq!(answer, "done");
+            assert_eq!(usage.provider_kind, friday_core::ProviderKind::Codex);
+            assert_eq!(usage.model, "gpt-5-codex");
+        }
+        other => panic!("expected Finished, got {other:?}"),
+    }
+    // The wire carries the `accept` decision (Allow).
+    let written = String::from_utf8(client.into_transport().into_parts().1).unwrap();
+    assert!(
+        written.lines().any(|l| {
+            let v: serde_json::Value = serde_json::from_str(l).unwrap();
+            v.get("result").and_then(|r| r.get("decision")) == Some(&serde_json::json!("accept"))
+        }),
+        "expected an accept decision on the wire: {written}"
+    );
+}
+
+/// NEGATIVE DOWNGRADE DEFENSE (the anti-mock-green canary): the OLD code accepted an HMAC-signed
+/// approval (the Hub-mintable `mint_approval`). The Ed25519 verify-only gate REJECTS it over the
+/// SAME canonical bytes — an HMAC hex is not a valid Ed25519 signature under `operator_vk`. The
+/// upgrade is Denied (`canonical_approval_signature_invalid`) → captured hard Deny → Errored. The
+/// turn NEVER `accept`s. An approval the Hub could self-mint can no longer Allow a protected action.
+#[test]
+fn hmac_signed_approval_is_rejected_downgrade_defense() {
+    let _gate = GateOn::on();
+    let db = Db::open_hub(&temp_path("ed25519-neg")).unwrap();
+    let policy = policy_for("agent-1");
+    insert_grant(&db, "agent-1", &["run_command"], Risk::High);
+
+    // A real operator key the gate verifies against; the approval below is NOT signed with it.
+    let sk = OperatorSigningKey::generate();
+    let vk = sk.verifying_key();
+    // approve_fn mints the OLD HMAC-style approval over the SAME action (what a self-minting Hub
+    // would produce). It is digest-bound and well-formed — only the SCHEME is wrong.
+    let approve = |req: &MutatingActionRequest| -> Option<CanonicalApproval> {
+        Some(mint_approval(req, "ap-hmac", b"test-secret", 10_000))
+    };
+    // `complete:false` — if (wrongly) accepted, the turn would continue; we assert it does NOT.
+    let mut client = client_over(Box::leak(
+        command_turn("cargo build", false).into_boxed_str(),
+    ));
+    let out = run(&db, &mut client, &policy, Some(&vk), &approve, "build it");
+    match out {
+        CodexTurnOutcome::Errored { reason } => {
+            assert_eq!(reason, "canonical_approval_signature_invalid");
+        }
+        other => panic!("expected Errored(signature_invalid), got {other:?}"),
+    }
+    // The wire carries `cancel` (deny), NEVER `accept`.
+    let written = String::from_utf8(client.into_transport().into_parts().1).unwrap();
+    assert!(
+        !written.lines().any(|l| {
+            serde_json::from_str::<serde_json::Value>(l)
+                .ok()
+                .and_then(|v| v.get("result").and_then(|r| r.get("decision")).cloned())
+                == Some(serde_json::json!("accept"))
+        }),
+        "an HMAC-signed approval must NEVER produce accept on the wire: {written}"
+    );
+    assert!(
+        written.contains(r#""decision":"cancel""#),
+        "expected cancel (deny) on the wire: {written}"
+    );
+}
+
+/// PROVISIONED but NO approval: a mutating action with `Some(&vk)` and no approval keeps the base
+/// RequiresApproval (a mutating action never auto-allows without a bound, signature-valid operator
+/// approval) → Pause + a persisted pending row. Complements the `None`-DenyAll Pause KAT in `src`.
+#[test]
+fn provisioned_but_unsigned_mutating_action_pauses() {
+    let _gate = GateOn::on();
+    let db = Db::open_hub(&temp_path("ed25519-pause")).unwrap();
+    let policy = policy_for("agent-1");
+    insert_grant(&db, "agent-1", &["run_command"], Risk::High);
+
+    let sk = OperatorSigningKey::generate();
+    let vk = sk.verifying_key();
+    let no_approval = |_req: &MutatingActionRequest| -> Option<CanonicalApproval> { None };
+    let mut client = client_over(Box::leak(
+        command_turn("cargo build", false).into_boxed_str(),
+    ));
+    let out = run(
+        &db,
+        &mut client,
+        &policy,
+        Some(&vk),
+        &no_approval,
+        "build it",
+    );
+    let nonce = match out {
+        CodexTurnOutcome::Paused {
+            action,
+            approval_nonce,
+        } => {
+            assert_eq!(action, "run_command");
+            approval_nonce
+        }
+        other => panic!("expected Paused, got {other:?}"),
+    };
+    let count: i64 = db
+        .conn()
+        .query_row(
+            "SELECT COUNT(*) FROM pending_approval_request WHERE run_id='run-1' AND approval_id=?1 AND action='run_command' AND status='pending'",
+            [&nonce],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(count, 1, "exactly one pending row under the run+nonce");
+    let written = String::from_utf8(client.into_transport().into_parts().1).unwrap();
+    assert!(
+        written.contains(r#""decision":"cancel""#),
+        "expected cancel on the wire: {written}"
+    );
+}


### PR DESCRIPTION
## Security upgrade: HMAC → Ed25519 verify-only for the Codex gated turn

Migrates the **protected (mutating-action) authorization** of `run_codex_gated_turn` from Hub-held **HMAC** — forgeable on Hub compromise, since the Hub holds the symmetric secret that both *mints* and *verifies* approvals — to **Ed25519 verify-only**. The Hub holds ONLY the operator's PUBLIC verify key (`OperatorVerifyingKey`): it can verify an operator-signed approval but has **no path to mint one**.

This brings the Codex gated turn to **PARITY** with the deepseek/claude routed loop: the function now calls the **IDENTICAL** `friday_storage::authorize_mutating_action_ed25519` that loop uses (which internally does `gate::canonical_approval_signature_bytes` + `friday_crypto::verify_ed25519_approval_hex`). No verification is reimplemented. This is a precondition for ever flipping the codex route live.

## The gate is a TWO-STEP SPLIT (the no-degrade point), not a wholesale swap

The pre-Ed25519 code called the composed `authorize_agent_action(.., approval, secret, ..)` — trust-grant check **then** the inner HMAC authorize. That is split so the protected gate becomes Ed25519 while the trust check is **preserved verbatim**:

- **(2a) trust-grant check** via `authorize_agent_action` with NO approval / NO secret — only a `denied_by == Some("trust_grant")` Deny (chat-only grant / risk-ceiling / no-active-grant) is consumed, surfacing the grant's own reason. The Ed25519 fn has **no** trust logic, so dropping this would silently stop enforcing chat-only grants and the risk ceiling — the no-degrade trap.
- **(2b) protected gate** via the verify-only `authorize_mutating_action_ed25519` under `operator_vk`. With `operator_vk = None` (the triple-dark default) the base `gate::evaluate` decision stands (DenyAll-equivalent): a protected action's `RequiresApproval` is never upgraded → it Pauses.

The `match record.decision { Allow / Deny / RequiresApproval }` mapping and the `RequiresApproval` → pending-persist → `Paused` path are **unchanged**.

Signature change: `secret: &[u8]` → `operator_vk: Option<&OperatorVerifyingKey>` (mirroring `run_session_loop` — `Option`, so unprovisioned = DenyAll).

## Triple-dark safety (unchanged)

No live caller flips this on. `FRIDAY_CODEX_ROUTE_ENABLED` / `FRIDAY_CODEX_MUTATING_GATE` stay OFF, and `operator_vk: None` → DenyAll. The handler is only consulted when the transport gate flag is ON.

## KAT(a) flip — the anti-mock-green canary

The old KAT(a) minted an **HMAC** approval and asserted `Finished` + `accept`. After this change an HMAC approval must be rejected. It is replaced by two tests:

- **Positive parity** — an operator-Ed25519-signed approval bound to the exact action → `accept` → `Finished`.
- **Negative downgrade defense** — an HMAC-signed approval over the **same** canonical bytes → **rejected** (`canonical_approval_signature_invalid`), `cancel` on the wire, **never** `accept`. Under the old code this exact input produced `Finished`+`accept` — a genuine flip, not mock-green.

Both REQUIRE a real operator key, and naming an operator **signing** key is forbidden anywhere under `friday-hub/src/` by the `operator_vk::tests::hub_crate_never_references_a_signing_key` structural guard (a Hub that can name a signing key could self-mint the approvals it verifies). So these live in the new integration-tier `tests/codex_gated_turn_ed25519.rs` (a sibling of `src/`, not scanned by the guard), mirroring `friday-storage/tests/authorize_ed25519.rs`. A third test there covers `Some(&vk)` + no approval → Pause.

The remaining `src` KATs are preserved and re-verified: (b) chat-only deny, (c) `RequiresApproval` → Pause + pending row (now exercised under the `None`-DenyAll path), (d) risk-ceiling deny, (e) flag-OFF unchanged.

## `runtime.rs` untouched; the runtime seam already exists in-tree

The runtime executor seam — `CodexTurnExecutor` / `LocalCodexGatedTurnExecutor` / `with_codex` / `run_codex_route_turn` — **already exists in-tree** and is the only direct caller of `run_codex_gated_turn` (in `lib.rs`). This PR stubs that one caller to pass `operator_vk = None` (renaming its now-unused `secret` param to `_secret`). **`runtime.rs` and the `CodexTurnExecutor` trait signature are not touched.**

Threading a provisioned `operator_vk` through the trait, and the live route flip, are **separate operator-gated follow-ups**.

## Deviations from the original spec (both git-verified, no-degrade)

1. The spec said the only file to change is `codex_gated_turn.rs` and "the only caller is the in-module KATs." The tree shows a **direct production caller** in `lib.rs` (`LocalCodexGatedTurnExecutor::run_gated_turn`), so the signature change requires the minimal `lib.rs` stub described above (pass `None`, `secret` → `_secret`).
2. The spec said to mint the Ed25519 approval in the in-module KAT. The `hub_crate_never_references_a_signing_key` guard forbids naming a signing key under `friday-hub/src/`, so the signing KATs are relocated to `tests/` (same pattern storage uses).

## Local verification

- `cargo build -p friday-hub` — ok
- `cargo clippy --workspace --all-targets` — **0 warnings**
- `cargo fmt -p friday-hub -- --check` — clean
- `cargo test -p friday-hub` — fully green (655 lib tests incl. the signing-key guard; all integration files incl. the 3 new Ed25519 KATs and `routed_codex_parity`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)