### PR TITLE
feat(mission-spine): thread missionContext driver from agent-run route to sealed client (dark, additive-optional)

### DIFF
--- a/src/api/http/routes/friday-agent-routes.ts
+++ b/src/api/http/routes/friday-agent-routes.ts
@@ -923,6 +923,16 @@ export interface FridayAgentRoutesDeps {
     // 503). NEVER infers mutation-permission from `readOnly` flipping — both are explicit gates.
     mutatingToolGrant?: string[];
     mutationGate?: string;
+    // (NS45-PR2 mission-bound driver — DARK) the first-class Mission handle this run binds to.
+    // Additive + optional; forwarded straight to the route-bound startRun wrapper, which threads
+    // it (UNCHANGED, camelCase) onto the sealed-WS dispatch ONLY when present. Absent for every
+    // existing caller (→ omitted on the wire → byte-identical unbound run). Does NOT change
+    // Rust-route qualification; the bound owner stays the authenticated principal, never this handle.
+    missionContext?: {
+      fridayConversationId: string;
+      missionId: string;
+      workItemId: string;
+    };
   }) => Promise<FridayAgentRuntimeResult>;
   getRun: (runId: string) => FridayAgentRunRecord | null;
   listRuns: (query: {
@@ -1501,6 +1511,42 @@ export function createFridayAgentRoutes(
             ? body.mutationGate
             : undefined;
 
+        // (NS45-PR2 mission-bound driver — DARK) parse the optional first-class Mission handle.
+        // ALL-OR-NOTHING (mirrors the executionContext/taskProfile structured-body discipline):
+        // accepted ONLY as an object carrying all THREE required, non-empty string fields
+        // (fridayConversationId/missionId/workItemId — the exact 3 the Rust `MissionWorkItemContextWire`
+        // requires). Any other shape — absence, non-object, or a MISSING/blank field — ⇒ undefined ⇒
+        // the conditional spread below OMITS the key ⇒ a byte-identical unbound dispatch (today's
+        // behavior). PRESENCE-ONLY: never fabricate a field, never crash on a partial body. This
+        // handle ONLY SELECTS the Mission/WorkItem to bind; the run's owner stays the authenticated
+        // principal (forwarded below via `principalInput`), never this handle.
+        let missionContext:
+          | { fridayConversationId: string; missionId: string; workItemId: string }
+          | undefined;
+        if (
+          body.missionContext !== undefined
+          && typeof body.missionContext === "object"
+          && body.missionContext !== null
+          && !Array.isArray(body.missionContext)
+        ) {
+          const mc = body.missionContext as Record<string, unknown>;
+          const fridayConversationId =
+            typeof mc.fridayConversationId === "string" && mc.fridayConversationId.trim().length > 0
+              ? mc.fridayConversationId.trim()
+              : undefined;
+          const missionId =
+            typeof mc.missionId === "string" && mc.missionId.trim().length > 0
+              ? mc.missionId.trim()
+              : undefined;
+          const workItemId =
+            typeof mc.workItemId === "string" && mc.workItemId.trim().length > 0
+              ? mc.workItemId.trim()
+              : undefined;
+          if (fridayConversationId && missionId && workItemId) {
+            missionContext = { fridayConversationId, missionId, workItemId };
+          }
+        }
+
         const result = await deps.startRun({
           task: body.task,
           taskPrompt,
@@ -1521,6 +1567,9 @@ export function createFridayAgentRoutes(
             : {}),
           ...(mutatingToolGrant ? { mutatingToolGrant } : {}),
           ...(mutationGate ? { mutationGate } : {}),
+          // (NS45-PR2 mission-bound driver — DARK) forward the validated Mission handle UNCHANGED
+          // (camelCase). Absent ⇒ key OMITTED ⇒ byte-identical unbound run.
+          ...(missionContext ? { missionContext } : {}),
           ...(apiIdempotencyKey
             ? {
               apiIdempotencyKey,

--- a/src/api/model/friday-api-agent.types.ts
+++ b/src/api/model/friday-api-agent.types.ts
@@ -47,6 +47,25 @@ export interface FridayStartAgentRunRequest {
    */
   mutatingToolGrant?: string[];
   mutationGate?: string;
+  /**
+   * (NS45-PR2 / mission-bound driver — DARK, additive-optional) the FIRST-CLASS Mission handle this
+   * run is BOUND to. A real handle `{fridayConversationId, missionId, workItemId}` (all three
+   * REQUIRED, non-empty — matching the Rust `MissionWorkItemContextWire`) is threaded UNCHANGED down
+   * the route→compose→dispatch chain to the sealed client (#750), which emits the snake_case
+   * `mission_context` wire block ONLY when present. ABSENT (or any field missing/blank ⇒ treated as
+   * absent at the route) ⇒ the field is OMITTED end-to-end and the dispatch is BYTE-IDENTICAL to
+   * today's unbound run. The Rust server walks the mission-bound run path behind its default-off
+   * `FRIDAY_MISSION_BOUND_RUN` flag, so carrying the handle changes no live behavior until that flag
+   * is on. **SECURITY: this only SELECTS which Mission/WorkItem the run binds to; it confers NO
+   * authority — the bound owner is the authenticated `forwarded_principal`, gated server-side, never
+   * this handle.** Does NOT change Rust-route QUALIFICATION (it rides ALONGSIDE the qualifying
+   * fields). Mirrors the `allowedRustRouteTools`/`mutatingToolGrant` additive-optional discipline.
+   */
+  missionContext?: {
+    fridayConversationId: string;
+    missionId: string;
+    workItemId: string;
+  };
 }
 
 export interface FridayAgentRunExecutionResponse {

--- a/src/api/runtime/friday-api-runtime.ts
+++ b/src/api/runtime/friday-api-runtime.ts
@@ -149,6 +149,7 @@ import type {
 } from "../mission-spine/friday-rust-hub-agent-run-sealed-client-service.js";
 import type {
   FridayRustHubAgentRunConstraints,
+  FridayRustHubAgentRunMissionContext,
   FridayRustHubAgentRunResumeResult,
 } from "../mission-spine/friday-rust-hub-agent-run-ws-sealed-client.js";
 import type { FridayResumeAgentRunResponse } from "../model/friday-api-agent.types.js";
@@ -1465,6 +1466,15 @@ async function composeRustReadOnlyAgentRun(args: {
    * (gated additionally by the server's default-off run-control flag).
    */
   readonly constraints: FridayRustHubAgentRunConstraints | undefined;
+  /**
+   * (NS45-PR2 mission-bound driver — DARK) The first-class Mission handle to forward on the sealed-WS
+   * dispatch so the Rust server resolves the Mission/WorkItem and (behind its default-off
+   * `FRIDAY_MISSION_BOUND_RUN` flag) walks the bound run path. The WS client emits the snake_case
+   * `mission_context` block ONLY when this is present; ABSENT (`undefined`) ⇒ no `mission_context` on
+   * the wire, byte-identical to the pre-NS45 unbound dispatch. SECURITY: the bound owner is the
+   * authenticated `principalId` (forwarded as `forwardedPrincipal`), never this handle.
+   */
+  readonly missionContext?: FridayRustHubAgentRunMissionContext;
   readonly providerId: string;
   readonly model: string;
   readonly wsClient: FridayRustHubAgentRunSealedClientService;
@@ -1544,6 +1554,11 @@ async function composeRustReadOnlyAgentRun(args: {
       // when something tightens (here `{ readOnly: true }`), else OMITS the field (byte-identical
       // pre-A1 wire). The server composes them onto the run policy behind its default-off flag.
       ...(args.constraints !== undefined ? { constraints: args.constraints } : {}),
+      // (NS45-PR2 mission-bound driver — DARK) forward the Mission handle; the WS client emits the
+      // `mission_context` wire block ONLY when present (absent ⇒ OMITTED ⇒ byte-identical unbound
+      // wire). The server walks the bound run path behind its default-off `FRIDAY_MISSION_BOUND_RUN`
+      // flag; the bound owner is `forwardedPrincipal`, never this handle.
+      ...(args.missionContext !== undefined ? { missionContext: args.missionContext } : {}),
     });
   } catch (err) {
     logFailClosed(
@@ -4688,6 +4703,12 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
       // Consulted by the qualifier ONLY behind the default-off `agentRunControlViaRust` flag.
       mutatingToolGrant?: string[];
       mutationGate?: string;
+      // (NS45-PR2 mission-bound driver — DARK) the first-class Mission handle this run binds to.
+      // Purely additive + optional — every existing caller omits it. The HTTP route forwards the
+      // validated `body.missionContext`. Carried in this shared type so `routeStartRun` (typeof
+      // startRun) can thread it onto the sealed-WS dispatch; the BARE fail-closed `startRun` below
+      // never reaches the wire, so it only carries the field. NEVER overrides principal/owner.
+      missionContext?: FridayRustHubAgentRunMissionContext;
     }) => {
       if (deps.allowTestOnlyAgentRunStartExecution !== true) {
         void input;
@@ -5006,6 +5027,13 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
             hubDbPath: rustHubDbPath,
             db: deps.db,
             nowIso: deps.nowIso,
+            // (NS45-PR2 mission-bound driver — DARK) forward the Mission handle so the sealed-WS
+            // dispatch emits the `mission_context` wire block when present (absent ⇒ omitted ⇒
+            // byte-identical unbound dispatch). This rides ALONGSIDE the qualifying fields — it is
+            // deliberately NOT part of `rustRouteQualificationInput` above, so it does NOT change
+            // Rust-route QUALIFICATION. SECURITY: it does not touch `principalId` — the bound owner
+            // stays the authenticated `normalizedPrincipal`; this handle only SELECTS the binding.
+            ...(input.missionContext !== undefined ? { missionContext: input.missionContext } : {}),
             // Stamp the apiRequest idempotency descriptor onto the projected row so a
             // SUBSEQUENT request sharing this key REPLAYS this run (the lookup above) rather
             // than minting a second runId. Mirrors the EXACT shape the bare startRun persists

--- a/test/unit/api/runtime/friday-api-runtime-rust-route-compose.test.ts
+++ b/test/unit/api/runtime/friday-api-runtime-rust-route-compose.test.ts
@@ -1393,3 +1393,119 @@ describe("FridayApiRuntime — execrun S-F-compose (DARK) Rust-route composition
     expect(ws.resumeCalls).toHaveLength(0);
   });
 });
+
+// (NS45-PR2 mission-bound driver — DARK) The route now threads an optional first-class Mission
+// handle (`{fridayConversationId, missionId, workItemId}`) from `POST /v1/agent/runs` down the
+// route→routeStartRun→compose→dispatch chain to the sealed-WS client (#750), which emits the
+// snake_case `mission_context` wire block ONLY when the handle is present. These tests assert the
+// THREADING (the handle reaches `dispatchRun` unchanged when present, is ABSENT on the dispatch
+// when omitted, and a PARTIAL body is treated as absent — never forwarded, never a crash). The
+// camelCase→snake_case wire conversion + the bound run path are #750's / Rust's tested job and are
+// NOT re-asserted here.
+describe("FridayApiRuntime — NS45-PR2 mission-bound run driver (DARK, additive-optional)", () => {
+  let db: FridaySqliteLayer;
+
+  afterEach(() => {
+    db?.close();
+  });
+
+  const VALID_MISSION_CONTEXT = {
+    fridayConversationId: "conv-abc-123",
+    missionId: "mission-def-456",
+    workItemId: "workitem-ghi-789",
+  };
+
+  it("ABSENT: a qualifying run WITHOUT missionContext → the dispatch carries NO missionContext key (byte-identical)", async () => {
+    db = createTestDb();
+    const ws = makeStubWsClient();
+    const readback = makeStubReadback(OWNER_PRINCIPAL);
+    const runtime = makeRuntime(db, {
+      routeAgentRunViaRust: true,
+      wsClient: ws.service,
+      readback: readback.service,
+    });
+
+    await callStartRoute(runtime, { ...QUALIFYING_BODY });
+
+    expect(ws.calls).toHaveLength(1);
+    // The OMITTED-key guarantee: not merely `undefined`, but the KEY is absent on the dispatch
+    // request — so the sealed client's `request.missionContext !== undefined` check fails and the
+    // `mission_context` wire block is never emitted (byte-identical to the pre-NS45 unbound wire).
+    expect("missionContext" in ws.calls[0]).toBe(false);
+    expect(ws.calls[0].missionContext).toBeUndefined();
+  });
+
+  it("PRESENT: a valid 3-field missionContext → threaded UNCHANGED (camelCase) to dispatchRun", async () => {
+    db = createTestDb();
+    const ws = makeStubWsClient();
+    const readback = makeStubReadback(OWNER_PRINCIPAL);
+    const runtime = makeRuntime(db, {
+      routeAgentRunViaRust: true,
+      wsClient: ws.service,
+      readback: readback.service,
+    });
+
+    await callStartRoute(runtime, {
+      ...QUALIFYING_BODY,
+      missionContext: { ...VALID_MISSION_CONTEXT },
+    });
+
+    expect(ws.calls).toHaveLength(1);
+    // Threaded UNCHANGED, camelCase preserved — the sealed client converts to snake_case (#750).
+    expect(ws.calls[0].missionContext).toEqual(VALID_MISSION_CONTEXT);
+    // Auth UNCHANGED: the bound owner is the authenticated forwarded principal, NEVER the handle.
+    expect(ws.calls[0].forwardedPrincipal).toBe(OWNER_PRINCIPAL);
+    // Qualification UNCHANGED: a missionContext-bearing run still qualifies via the SAME read-only
+    // clauses (it routed to the sealed dispatch + the read-only constraint is forwarded as before).
+    expect(ws.calls[0].constraints).toEqual({ readOnly: true });
+  });
+
+  it("PARTIAL: a missionContext missing workItemId → treated as UNDEFINED (NOT forwarded, no crash)", async () => {
+    db = createTestDb();
+    const ws = makeStubWsClient();
+    const readback = makeStubReadback(OWNER_PRINCIPAL);
+    const runtime = makeRuntime(db, {
+      routeAgentRunViaRust: true,
+      wsClient: ws.service,
+      readback: readback.service,
+    });
+
+    // No throw (the run still completes) AND the partial handle is dropped at the route.
+    const result = (await callStartRoute(runtime, {
+      ...QUALIFYING_BODY,
+      missionContext: {
+        fridayConversationId: "conv-abc-123",
+        missionId: "mission-def-456",
+        // workItemId intentionally OMITTED → the whole handle collapses to undefined.
+      },
+    })) as { status: string };
+
+    expect(result.status).toBe("completed");
+    expect(ws.calls).toHaveLength(1);
+    expect("missionContext" in ws.calls[0]).toBe(false);
+    expect(ws.calls[0].missionContext).toBeUndefined();
+  });
+
+  it("PARTIAL: a missionContext with a BLANK field → treated as UNDEFINED (not fabricated, not forwarded)", async () => {
+    db = createTestDb();
+    const ws = makeStubWsClient();
+    const readback = makeStubReadback(OWNER_PRINCIPAL);
+    const runtime = makeRuntime(db, {
+      routeAgentRunViaRust: true,
+      wsClient: ws.service,
+      readback: readback.service,
+    });
+
+    await callStartRoute(runtime, {
+      ...QUALIFYING_BODY,
+      missionContext: {
+        fridayConversationId: "conv-abc-123",
+        missionId: "   ", // blank/whitespace → not a valid handle field
+        workItemId: "workitem-ghi-789",
+      },
+    });
+
+    expect(ws.calls).toHaveLength(1);
+    expect(ws.calls[0].missionContext).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Gap closed

#750 extended the **sealed-client service** with an optional `missionContext` field (and `buildMissionContextWire`) but nothing upstream ever *populates* it — the run-start HTTP route had no way to bind a run to a Mission/WorkItem. This PR adds the **DRIVER**: it threads an optional first-class Mission handle `{ fridayConversationId, missionId, workItemId }` from `POST /v1/agent/runs` down the chain

```
route handler (deps.startRun)
  -> routeStartRun
    -> composeRustReadOnlyAgentRun(args)
      -> wsClient.dispatchRun({ ... })   // the #750 service field
```

so an operator can trigger a run **bound** to a Mission/WorkItem. When `FRIDAY_MISSION_BOUND_RUN=1` the Rust hub resolves the handle and walks the WorkItem `ReadyToDispatch -> CompletedWithProof`.

## Additive-optional dark-safety

Every change is a **new optional field + a conditional spread**, mirroring the existing `allowedRustRouteTools` / `mutatingToolGrant` discipline verbatim:

- route handler parse + `...(missionContext ? { missionContext } : {})` into `deps.startRun({...})`
- `routeStartRun` -> `...(input.missionContext !== undefined ? { missionContext: input.missionContext } : {})` into the `composeRustReadOnlyAgentRun({...})` call
- compose -> `...(args.missionContext !== undefined ? { missionContext: args.missionContext } : {})` into `dispatchRun({...})`

When `missionContext` is **absent — or any of the 3 fields is missing/blank, which the route treats as absent** — every spread **omits the key**, so the dispatch is **byte-identical to today's unbound run** (#750's `buildMissionContextWire(undefined)` already omits `mission_context` on the wire). Verified by the ABSENT/PARTIAL tests asserting `"missionContext" in dispatchedRequest === false`.

## Does NOT change qualification or auth

- **Qualification unchanged.** `missionContext` is deliberately **NOT** added to `rustRouteQualificationInput` — it rides *alongside* the read-only qualifying fields and does not affect `qualifiesForRustReadOnlyRoute`. A bound run qualifies via the same read-only clauses.
- **Auth unchanged.** The bound run's owner stays the authenticated `forwarded_principal` (`normalizedPrincipal` at the compose call — untouched). The handle only **SELECTS** the Mission/WorkItem; it confers no authority. The Rust server gates the bound owner server-side, never from this handle.
- **Idempotency unchanged.** `hashIdempotencyPayload` is untouched (matches the precedent — `allowedRustRouteTools` / `mutatingToolGrant` are also absent from that hash).
- The bare fail-closed `startRun` execution path never reaches the wire; it only carries the field in the shared input type.

## Tests

Added to `friday-api-runtime-rust-route-compose.test.ts` because that harness drives the **real** `agent.runs.start` route handler end-to-end (route parse -> routeStartRun -> compose -> a stub `dispatchRun` whose request is captured), so it proves the whole threading path in one place — stronger than splitting route-validation and runtime-threading across two files:

- **ABSENT**: a qualifying run without `missionContext` -> dispatch carries no `missionContext` key (byte-identical).
- **PRESENT**: a valid 3-field handle -> threaded unchanged (camelCase preserved) to `dispatchRun`; `forwardedPrincipal` + `constraints` unchanged.
- **PARTIAL (missing field)**: handle missing `workItemId` -> treated as undefined (not forwarded, no crash, run still completes).
- **PARTIAL (blank field)**: a whitespace `missionId` -> treated as undefined.

The camelCase -> snake_case wire conversion is #750's tested job and is not re-tested here.

## Local verification

- `npm run lint` -> **0 errors** (pre-existing warnings only; none in touched files)
- `npm run typecheck` -> clean (src + contracts)
- vitest: compose **38 passed** (incl. 4 new), route **83 passed**, predicate **45 passed** (unchanged), sealed-client passed
- secrets: `check:secret-patterns` + `detect-secrets-hook` both clean

## Live proof is a gated follow-up

This is dark plumbing. The live mission-bound run proof needs the operator to flip **`FRIDAY_ROUTE_AGENT_RUN_VIA_RUST`** (TS, routes a qualifying run to Rust) **+ `FRIDAY_MISSION_BOUND_RUN`** (Rust, walks the bound path). Both default-off; until then this changes no live behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)