### PR TITLE
feat(memory): owner-authed memory-confirm arm closes the confirmation loop (dark, additive)

### DIFF
--- a/rust-core/crates/friday-ffi/src/lib.rs
+++ b/rust-core/crates/friday-ffi/src/lib.rs
@@ -1969,6 +1969,12 @@ fn message_kind_name(m: &friday_protocol::Message) -> &'static str {
         M::AgentRunCancel { .. } => "AgentRunCancel",
         M::AgentRunReject { .. } => "AgentRunReject",
         M::AgentRunControlResult { .. } => "AgentRunControlResult",
+        // Memory-confirmation loop terminal arm. DARK on the FFI surface (nothing here constructs or
+        // dispatches them — the owner-authed decision rides the sealed-WS agent-run server arm gated
+        // by FRIDAY_MEMORY_CONFIRM); NAMED so the truth label carries the real kind and this match
+        // stays exhaustive.
+        M::MemoryDecisionRequest { .. } => "MemoryDecisionRequest",
+        M::MemoryDecisionResult { .. } => "MemoryDecisionResult",
         M::Error { .. } => "Error",
     }
 }

--- a/rust-core/crates/friday-hub/src/bin/hub_agent_run_server.rs
+++ b/rust-core/crates/friday-hub/src/bin/hub_agent_run_server.rs
@@ -410,6 +410,22 @@ fn run() -> Result<(), ServerError> {
         );
     }
 
+    // Read the MEMORY-CONFIRM ingress flag ONCE at boot (default-off). When false the dispatch arm
+    // NEVER handles a `MemoryDecisionRequest` — it falls through to the EXISTING catch-all keepalive
+    // echo (byte-identical to today, since the server has never had this arm), so deploying this
+    // binary changes NO live behavior until the operator flips this flag.
+    let memory_confirm_enabled =
+        memory_confirm_enabled_from(env::var(MEMORY_CONFIRM_ENABLED_ENV).ok().as_deref());
+    if memory_confirm_enabled {
+        eprintln!(
+            "hub_agent_run_server: MEMORY-CONFIRM ingress ENABLED (FRIDAY_MEMORY_CONFIRM) — an inbound owner-authed MemoryDecisionRequest confirms/rejects a memory candidate (a confirm makes it recallable; no model call)"
+        );
+    } else {
+        eprintln!(
+            "hub_agent_run_server: MEMORY-CONFIRM ingress DISABLED (set FRIDAY_MEMORY_CONFIRM=1 to enable) — a MemoryDecisionRequest is a benign keepalive echo"
+        );
+    }
+
     // (Loop4 wire-fields) Read the per-run TOKEN-SURFACE flag ONCE at boot (default-off). When false
     // the terminal `AgentRunResult` emits `prompt_tokens: None` / `completion_tokens: None` —
     // byte-identical to today (the agent-run path is LIVE in prod). When true the emit path sums the
@@ -444,6 +460,7 @@ fn run() -> Result<(), ServerError> {
             mission_bound_run_enabled,
             mission_intake_enabled,
             mission_spine_dispatch_enabled,
+            memory_confirm_enabled,
             token_surface_enabled,
         ) {
             Ok(_served) => {}
@@ -554,6 +571,35 @@ const MISSION_SPINE_DISPATCH_ENABLED_ENV: &str = "FRIDAY_MISSION_SPINE_DISPATCH"
 /// false; ON only for the exact opt-in value `"1"` (trimmed), matching the program's standard flag
 /// idiom; everything else (including `"true"`) ⇒ false.
 fn mission_spine_dispatch_enabled_from(raw: Option<&str>) -> bool {
+    matches!(raw.map(str::trim), Some("1"))
+}
+
+/// The env flag that gates the MEMORY-CONFIRM dispatch arm — the live caller that CLOSES the
+/// Memory-confirmation loop's terminal arm (the confirm/reject surface had NO live caller before
+/// this; only `#[test]` callers reached `friday_storage::memory::decide`). DEFAULT-OFF: an inbound
+/// [`Message::MemoryDecisionRequest`] is HANDLED — the OWNER's explicit confirm/reject is applied to
+/// ONE pending memory candidate via the existing
+/// [`friday_hub::hub_server::memory_decision_result_for_db`] (owner/namespace-scoped, fail-closed on
+/// mismatch; a `confirm` makes the candidate durable AND recallable), replying with a
+/// [`Message::MemoryDecisionResult`] — ONLY when `FRIDAY_MEMORY_CONFIRM` is exactly `"1"` (after
+/// trim). Unset — or any other value — leaves the arm DARK: the `MemoryDecisionRequest` falls
+/// through to the EXISTING catch-all keepalive echo, BYTE-IDENTICAL to today (the server has never
+/// had this arm, so the live behavior on this message is the benign echo — births/changes nothing),
+/// so deploying this binary changes NO live behavior until the operator flips this SEPARATE flag.
+/// No model call is made (a pure `&Db` mutation ⇒ ZERO `token_ledger` rows). The decision is the
+/// OWNER's OWN action — the sealed single-peer session IS the channel auth (the SAME invariant the
+/// merged `FRIDAY_MISSION_INTAKE` / `FRIDAY_MISSION_SPINE_DISPATCH` arms rely on); it is NOT an
+/// agent mutating-tool action, so it does NOT route through the approval/trust gate; this wire shape
+/// carries no per-request `auth_proof`. SEPARATE from every other dark flag; flipping THIS one is an
+/// operator cutover decision (and the TS driver route that constructs this request is a separate
+/// operator-gated follow-up, like the mission-dispatch driver was).
+const MEMORY_CONFIRM_ENABLED_ENV: &str = "FRIDAY_MEMORY_CONFIRM";
+
+/// Pure flag-matcher for [`MEMORY_CONFIRM_ENABLED_ENV`] (separated from the env read so it is
+/// testable without mutating the process-global environment). DEFAULT-OFF: `None` (unset) ⇒ false;
+/// ON only for the exact opt-in value `"1"` (trimmed), matching the program's standard flag idiom;
+/// everything else (including `"true"`) ⇒ false.
+fn memory_confirm_enabled_from(raw: Option<&str>) -> bool {
     matches!(raw.map(str::trim), Some("1"))
 }
 
@@ -722,6 +768,7 @@ impl AgentRunWsListener {
         mission_bound_run_enabled: bool,
         mission_intake_enabled: bool,
         mission_spine_dispatch_enabled: bool,
+        memory_confirm_enabled: bool,
         token_surface_enabled: bool,
     ) -> Result<usize, TransportError> {
         let (stream, _peer) = self.listener.accept()?;
@@ -740,6 +787,7 @@ impl AgentRunWsListener {
             mission_bound_run_enabled,
             mission_intake_enabled,
             mission_spine_dispatch_enabled,
+            memory_confirm_enabled,
             token_surface_enabled,
         )
     }
@@ -784,6 +832,7 @@ fn serve_sealed_session<S: Read + Write, T: Transport>(
     mission_bound_run_enabled: bool,
     mission_intake_enabled: bool,
     mission_spine_dispatch_enabled: bool,
+    memory_confirm_enabled: bool,
     token_surface_enabled: bool,
 ) -> Result<usize, TransportError> {
     let mut processed = 0usize;
@@ -1316,12 +1365,42 @@ fn serve_sealed_session<S: Read + Write, T: Transport>(
                 )?;
                 processed += 1;
             }
+            // MEMORY-CONFIRM dispatch — FLAG-GATED. When `FRIDAY_MEMORY_CONFIRM` is ON, an inbound
+            // `MemoryDecisionRequest` applies the OWNER's explicit confirm/reject to ONE pending
+            // memory candidate via the existing `friday_hub::hub_server::memory_decision_result_for_db`
+            // — owner/namespace-scoped (fail-closed on mismatch / unowned / unknown / terminal) — and
+            // replies with a `MemoryDecisionResult` (confirmed / rejected / blocked). A `confirm` makes
+            // the candidate durable AND recallable; this is the live caller that CLOSES the
+            // Memory-confirmation loop's terminal arm. PURE `&Db` mutation: NO provider/model call,
+            // ZERO `token_ledger` rows. The decision is the owner's OWN action — the sealed session IS
+            // the channel auth (single-peer/single-owner SERVER invariant; this wire shape carries no
+            // per-request `auth_proof`), mirroring the merged mission-intake/spine arms; it does NOT
+            // route through the approval/trust gate. When the flag is OFF this guard FAILS and the
+            // request falls through to the catch-all keepalive echo below — BYTE-IDENTICAL to today
+            // (the server has never had this arm), births/changes nothing.
+            Message::MemoryDecisionRequest { request } if memory_confirm_enabled => {
+                let now_ms = now_ms();
+                let result = friday_hub::hub_server::memory_decision_result_for_db(
+                    runtime.db(),
+                    &env.msg_id,
+                    request,
+                    now_ms,
+                );
+                eprintln!(
+                    "hub_agent_run_server_dispatch: msg_id={} leg=memory_decision (memory-confirm enabled)",
+                    env.msg_id
+                );
+                // The handler already correlates the reply to `msg_id`; send it sealed.
+                ws_send_envelope(ws, session_key, &result, SESSION_AAD)?;
+                processed += 1;
+            }
             // Benign keepalive (S-B behaviour): echo the opened envelope back, sealed under the
             // SAME session key, correlated to the request. NO dispatch. This is ALSO where a
             // control message lands when the run-control flag is OFF (the guards above are not
             // met), so a v13 control message on a DARK server is a harmless echo — no handling.
             // (NS-5) A `MissionIntakeRequest` with the mission-intake flag OFF ALSO lands here, so
-            // a DARK server treats it as a harmless echo — byte-identical to today.
+            // a DARK server treats it as a harmless echo — byte-identical to today. A
+            // `MemoryDecisionRequest` with `FRIDAY_MEMORY_CONFIRM` OFF lands here too.
             _ => {
                 let reply = Envelope::new(env.msg_id.clone(), env.sent_at, env.message)
                     .with_correlation(env.msg_id.clone());
@@ -1803,6 +1882,7 @@ mod tests {
                 false,
                 false,
                 false, // (KEYSTONE) mission-spine dispatch OFF — byte-identical to today
+                false, // memory-confirm ingress OFF — byte-identical to today
                 false, // (Loop4) per-run token surface OFF — byte-identical to today
             )
             .unwrap();
@@ -1917,6 +1997,7 @@ mod tests {
                 false, // (NS-4) mission-bound seam OFF for the run-control flag tests
                 false, // (NS-5) mission-intake ingress OFF for the run-control flag tests
                 false, // (KEYSTONE) mission-spine dispatch OFF for the run-control flag tests
+                false, // memory-confirm ingress OFF — byte-identical to today
                 false, // (Loop4) per-run token surface OFF — byte-identical to today
             )
             .unwrap();
@@ -2152,6 +2233,7 @@ mod tests {
                     false, // mission-bound seam OFF
                     false, // mission-intake ingress OFF
                     false, // mission-spine dispatch OFF
+                    false, // memory-confirm ingress OFF
                     token_surface_enabled,
                 )
                 .unwrap();
@@ -2246,6 +2328,7 @@ mod tests {
                 false,
                 false,
                 false, // (KEYSTONE) mission-spine dispatch OFF — byte-identical to today
+                false, // memory-confirm ingress OFF — byte-identical to today
                 false, // (Loop4) per-run token surface OFF — byte-identical to today
             )
             .unwrap();
@@ -2290,6 +2373,7 @@ mod tests {
                 false,
                 false,
                 false, // (KEYSTONE) mission-spine dispatch OFF — byte-identical to today
+                false, // memory-confirm ingress OFF — byte-identical to today
                 false, // (Loop4) per-run token surface OFF — byte-identical to today
             )
             .unwrap();
@@ -2481,6 +2565,7 @@ mod tests {
                 false, // mission-bound seam OFF
                 true,  // (NS-5) mission-intake ingress ON
                 false, // (KEYSTONE) mission-spine dispatch OFF for the mission-intake test
+                false, // memory-confirm ingress OFF — byte-identical to today
                 false, // (Loop4) per-run token surface OFF — byte-identical to today
             )
             .unwrap();
@@ -2583,6 +2668,7 @@ mod tests {
                 false, // mission-bound seam OFF
                 false, // (NS-5) mission-intake ingress OFF — byte-identical to today
                 false, // (KEYSTONE) mission-spine dispatch OFF — byte-identical to today
+                false, // memory-confirm ingress OFF — byte-identical to today
                 false, // (Loop4) per-run token surface OFF — byte-identical to today
             )
             .unwrap();
@@ -2665,6 +2751,228 @@ mod tests {
         assert!(
             !mission_spine_dispatch_enabled_from(Some("  TRUE  ")),
             "padded TRUE ⇒ disabled (only exact 1)"
+        );
+    }
+
+    #[test]
+    fn memory_confirm_flag_is_default_off_and_fail_closed() {
+        // The memory-confirm dispatch arm is DEFAULT-OFF: unset ⇒ disabled (deploy-safe — the arm
+        // falls through to the keepalive echo). Only the exact opt-in value `"1"` enables it.
+        assert!(
+            !memory_confirm_enabled_from(None),
+            "unset ⇒ disabled (default-off, deploy-safe)"
+        );
+        assert!(!memory_confirm_enabled_from(Some("")), "empty ⇒ disabled");
+        assert!(!memory_confirm_enabled_from(Some("0")), "0 ⇒ disabled");
+        assert!(
+            !memory_confirm_enabled_from(Some("false")),
+            "false ⇒ disabled"
+        );
+        assert!(
+            !memory_confirm_enabled_from(Some("on")),
+            "garbage ⇒ disabled"
+        );
+        assert!(memory_confirm_enabled_from(Some("1")), "1 ⇒ enabled");
+        assert!(
+            memory_confirm_enabled_from(Some(" 1 ")),
+            "padded 1 ⇒ enabled (trimmed)"
+        );
+        assert!(
+            !memory_confirm_enabled_from(Some("true")),
+            "true ⇒ disabled (only exact 1)"
+        );
+        assert!(
+            !memory_confirm_enabled_from(Some("  TRUE  ")),
+            "padded TRUE ⇒ disabled (only exact 1)"
+        );
+    }
+
+    /// Seed ONE pending, owner-owned, content-bearing memory candidate directly into the runtime's
+    /// REAL DB (a pure `&Db` write — no session needed). Content is non-empty so a confirm makes it
+    /// recallable (`recall_confirmed` requires non-NULL/non-empty content).
+    fn seed_memory_candidate<T: Transport>(rt: &HubRuntime<T>, memory_id: &str) {
+        friday_storage::memory::record_candidate(
+            rt.db().conn(),
+            &friday_storage::memory::NewMemoryCandidate {
+                memory_id,
+                scope: friday_core::MemoryScope::Global,
+                content_ref: None,
+                content: Some("prefers rust"),
+                principal_id: Some(OWNER),
+                sensitive: false,
+                created_at: 1_000,
+            },
+        )
+        .unwrap();
+    }
+
+    /// A `MemoryDecisionRequest` envelope. No `auth_proof`: the sealed session IS the channel auth
+    /// (mirroring the merged mission-intake / mission-spine arms).
+    fn memory_decision_request(msg_id: &str, memory_id: &str, decision: &str) -> Envelope {
+        Envelope::new(
+            msg_id,
+            1000,
+            Message::MemoryDecisionRequest {
+                request: friday_protocol::MemoryDecisionRequestWire {
+                    memory_id: memory_id.into(),
+                    owner_principal: OWNER.into(),
+                    decision: decision.into(),
+                },
+            },
+        )
+    }
+
+    /// FLAG-ON: a `MemoryDecisionRequest{confirm}` driven through the REAL dispatch path
+    /// (`accept_one` → `serve_sealed_session`, NOT a direct `memory_decision_result_for_db` call)
+    /// CONFIRMS the candidate: the row becomes Confirmed, `recall_confirmed` now returns it (the
+    /// loop's payoff), the reply is a `MemoryDecisionResult{recallable:true}`, and ZERO
+    /// `token_ledger` rows are written (no model call). This proves the WIRING, not the inner helper.
+    #[test]
+    fn flag_on_memory_decision_confirms_and_makes_recallable_through_dispatch() {
+        let (rt, _ws) = mock_runtime("memory-confirm-on", OWNER);
+        seed_memory_candidate(&rt, "mem-wired");
+        // Pre-confirm: NOT recallable.
+        assert!(friday_storage::memory::recall_confirmed(rt.db().conn(), OWNER)
+            .unwrap()
+            .is_empty());
+
+        let server_kp = DeviceKeypair::generate();
+        let listener = AgentRunWsListener::bind_loopback(0).unwrap();
+        let addr = listener.local_addr().unwrap();
+        let allowlist = vec![OWNER.to_string()];
+        let client_kp = DeviceKeypair::generate();
+        let peer_allowlist = allowlist_of(client_kp.public_bytes());
+        let client = spawn_client(addr, client_kp, |session, _nonce| {
+            let req = memory_decision_request("req-mem-on", "mem-wired", "confirm");
+            (req, session.clone(), session.clone())
+        });
+
+        let processed = listener
+            .accept_one(
+                &server_kp,
+                &rt,
+                &allowlist,
+                &peer_allowlist,
+                false, // run-control OFF
+                false, // mission-bound seam OFF
+                false, // mission-intake ingress OFF
+                false, // mission-spine dispatch OFF
+                true,  // memory-confirm ingress ON
+                false, // (Loop4) per-run token surface OFF — byte-identical to today
+            )
+            .unwrap();
+        assert_eq!(processed, 1, "one memory-decision request processed");
+
+        let obs = client.join().unwrap();
+        let Some(Message::MemoryDecisionResult { result }) = obs.result.clone() else {
+            panic!(
+                "flag ON must reply with MemoryDecisionResult, got {:?}",
+                obs.result
+            );
+        };
+        assert_eq!(result.memory_id, "mem-wired");
+        assert_eq!(result.status, "confirmed");
+        assert_eq!(result.state, "confirmed");
+        assert!(result.recallable, "a confirmed candidate is recallable");
+
+        // STORAGE TRUTH: the row is Confirmed AND `recall_confirmed` now returns it.
+        let db = rt.db();
+        assert_eq!(
+            db.conn()
+                .query_row(
+                    "SELECT state FROM memory_item WHERE memory_id = 'mem-wired'",
+                    [],
+                    |r| r.get::<_, String>(0)
+                )
+                .unwrap(),
+            "confirmed"
+        );
+        let recalled = friday_storage::memory::recall_confirmed(db.conn(), OWNER).unwrap();
+        assert_eq!(recalled.len(), 1);
+        assert_eq!(recalled[0].memory_id, "mem-wired");
+
+        // ZERO model call: the decision is a pure &Db mutation ⇒ NO token_ledger rows.
+        let ledger_rows: i64 = db
+            .conn()
+            .query_row("SELECT COUNT(*) FROM token_ledger", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(
+            ledger_rows, 0,
+            "memory decision makes NO model call ⇒ ZERO token_ledger rows"
+        );
+    }
+
+    /// DEPLOY-SAFETY (the load-bearing test): with the memory-confirm flag OFF, an inbound
+    /// `MemoryDecisionRequest` is treated as a benign keepalive ECHO — BYTE-IDENTICAL to today (the
+    /// server has never had this arm). It changes NOTHING: the candidate stays a pending Candidate
+    /// and is NOT recallable. Same dark-when-off shape as the mission-intake/control keepalive tests.
+    #[test]
+    fn flag_off_memory_decision_is_keepalive_echo_and_changes_nothing() {
+        let (rt, _ws) = mock_runtime("memory-confirm-off", OWNER);
+        seed_memory_candidate(&rt, "mem-dark");
+
+        let server_kp = DeviceKeypair::generate();
+        let listener = AgentRunWsListener::bind_loopback(0).unwrap();
+        let addr = listener.local_addr().unwrap();
+        let allowlist = vec![OWNER.to_string()];
+        let client_kp = DeviceKeypair::generate();
+        let peer_allowlist = allowlist_of(client_kp.public_bytes());
+        let client = spawn_client(addr, client_kp, |session, _nonce| {
+            let req = memory_decision_request("req-mem-off", "mem-dark", "confirm");
+            (req, session.clone(), session.clone())
+        });
+
+        // Flag OFF ⇒ the MemoryDecisionRequest falls through to the keepalive echo.
+        let processed = listener
+            .accept_one(
+                &server_kp,
+                &rt,
+                &allowlist,
+                &peer_allowlist,
+                false, // run-control OFF
+                false, // mission-bound seam OFF
+                false, // mission-intake ingress OFF
+                false, // mission-spine dispatch OFF
+                false, // memory-confirm ingress OFF — byte-identical to today
+                false, // (Loop4) per-run token surface OFF — byte-identical to today
+            )
+            .unwrap();
+        assert_eq!(
+            processed, 1,
+            "the memory-decision message is processed as a keepalive"
+        );
+
+        // The flag is OFF ⇒ the request is ECHOED verbatim, NOT a MemoryDecisionResult.
+        match client.join().unwrap().result.expect("an echo reply") {
+            Message::MemoryDecisionRequest { request } => {
+                assert_eq!(
+                    request.memory_id, "mem-dark",
+                    "the request is echoed verbatim"
+                );
+                assert_eq!(request.decision, "confirm");
+            }
+            other => panic!("flag OFF must echo the MemoryDecisionRequest, got {other:?}"),
+        }
+
+        // BYTE-IDENTICAL deploy safety: NOTHING changed — the candidate is still a pending
+        // Candidate and is NOT recallable (the confirm was never applied).
+        let db = rt.db();
+        assert_eq!(
+            db.conn()
+                .query_row(
+                    "SELECT state FROM memory_item WHERE memory_id = 'mem-dark'",
+                    [],
+                    |r| r.get::<_, String>(0)
+                )
+                .unwrap(),
+            "candidate",
+            "flag OFF leaves the candidate pending (births/changes nothing)"
+        );
+        assert!(
+            friday_storage::memory::recall_confirmed(db.conn(), OWNER)
+                .unwrap()
+                .is_empty(),
+            "flag OFF ⇒ nothing recallable"
         );
     }
 
@@ -2760,6 +3068,7 @@ mod tests {
                 false, // mission-bound seam OFF
                 false, // mission-intake ingress OFF
                 true,  // (KEYSTONE) mission-spine dispatch ON
+                false, // memory-confirm ingress OFF — byte-identical to today
                 false, // (Loop4) per-run token surface OFF — byte-identical to today
             )
             .unwrap();
@@ -2847,6 +3156,7 @@ mod tests {
                 false,
                 false,
                 true,  // (KEYSTONE) mission-spine dispatch ON
+                false, // memory-confirm ingress OFF — byte-identical to today
                 false, // (Loop4) per-run token surface OFF — byte-identical to today
             )
             .unwrap();
@@ -2927,6 +3237,7 @@ mod tests {
                 false,
                 false,
                 true,  // (KEYSTONE) mission-spine dispatch ON
+                false, // memory-confirm ingress OFF — byte-identical to today
                 false, // (Loop4) per-run token surface OFF — byte-identical to today
             )
             .unwrap();
@@ -2994,6 +3305,7 @@ mod tests {
                 false,
                 false,
                 true,  // (KEYSTONE) mission-spine dispatch ON
+                false, // memory-confirm ingress OFF — byte-identical to today
                 false, // (Loop4) per-run token surface OFF — byte-identical to today
             )
             .unwrap();
@@ -3043,6 +3355,7 @@ mod tests {
                     false,
                     false,
                     false, // (KEYSTONE) mission-spine dispatch OFF
+                    false, // memory-confirm ingress OFF — byte-identical to today
                     false, // (Loop4) per-run token surface OFF — byte-identical to today
                 )
                 .unwrap();
@@ -3086,6 +3399,7 @@ mod tests {
                     false,
                     false,
                     false, // (KEYSTONE) mission-spine dispatch OFF
+                    false, // memory-confirm ingress OFF — byte-identical to today
                     false, // (Loop4) per-run token surface OFF — byte-identical to today
                 )
                 .unwrap();
@@ -3171,6 +3485,7 @@ mod tests {
                 false,
                 false,
                 false, // (KEYSTONE) mission-spine dispatch OFF — byte-identical to today
+                false, // memory-confirm ingress OFF — byte-identical to today
                 false, // (Loop4) per-run token surface OFF — byte-identical to today
             )
             .unwrap();
@@ -3216,6 +3531,7 @@ mod tests {
                 false,
                 false,
                 false, // (KEYSTONE) mission-spine dispatch OFF — byte-identical to today
+                false, // memory-confirm ingress OFF — byte-identical to today
                 false, // (Loop4) per-run token surface OFF — byte-identical to today
             )
             .unwrap();
@@ -3261,6 +3577,7 @@ mod tests {
             false,
             false,
             false, // (KEYSTONE) mission-spine dispatch OFF — byte-identical to today
+            false, // memory-confirm ingress OFF — byte-identical to today
             false, // (Loop4) per-run token surface OFF — byte-identical to today
         );
         client.join().unwrap();
@@ -3550,6 +3867,7 @@ mod tests {
                 false,
                 false,
                 false, // (KEYSTONE) mission-spine dispatch OFF — byte-identical to today
+                false, // memory-confirm ingress OFF — byte-identical to today
                 false, // (Loop4) per-run token surface OFF — byte-identical to today
             )
             .unwrap();
@@ -3594,6 +3912,7 @@ mod tests {
                 false,
                 false,
                 false, // (KEYSTONE) mission-spine dispatch OFF — byte-identical to today
+                false, // memory-confirm ingress OFF — byte-identical to today
                 false, // (Loop4) per-run token surface OFF — byte-identical to today
             )
             .unwrap();
@@ -3655,6 +3974,7 @@ mod tests {
                 false,
                 false,
                 false, // (KEYSTONE) mission-spine dispatch OFF — byte-identical to today
+                false, // memory-confirm ingress OFF — byte-identical to today
                 false, // (Loop4) per-run token surface OFF — byte-identical to today
             )
             .unwrap();
@@ -3733,6 +4053,7 @@ mod tests {
             false,
             false,
             false, // (KEYSTONE) mission-spine dispatch OFF — byte-identical to today
+            false, // memory-confirm ingress OFF — byte-identical to today
             false, // (Loop4) per-run token surface OFF — byte-identical to today
         );
         let obs = client.join().unwrap();
@@ -3792,6 +4113,7 @@ mod tests {
                 false,
                 false,
                 false, // (KEYSTONE) mission-spine dispatch OFF — byte-identical to today
+                false, // memory-confirm ingress OFF — byte-identical to today
                 false, // (Loop4) per-run token surface OFF — byte-identical to today
             )
             .unwrap();
@@ -4203,6 +4525,7 @@ mod tests {
                 false,
                 false,
                 false, // (KEYSTONE) mission-spine dispatch OFF — byte-identical to today
+                false, // memory-confirm ingress OFF — byte-identical to today
                 false, // (Loop4) per-run token surface OFF — byte-identical to today
             )
             .expect("server serves the interop session");
@@ -4260,6 +4583,7 @@ mod tests {
             false,
             false,
             false, // (KEYSTONE) mission-spine dispatch OFF — byte-identical to today
+            false, // memory-confirm ingress OFF — byte-identical to today
             false, // (Loop4) per-run token surface OFF — byte-identical to today
         );
         assert!(
@@ -4312,6 +4636,7 @@ mod tests {
                 false,
                 false,
                 false, // (KEYSTONE) mission-spine dispatch OFF — byte-identical to today
+                false, // memory-confirm ingress OFF — byte-identical to today
                 false, // (Loop4) per-run token surface OFF — byte-identical to today
             )
             .expect("server serves the session but runs nothing");
@@ -4422,6 +4747,7 @@ mod tests {
                 false,
                 false,
                 false, // (KEYSTONE) mission-spine dispatch OFF — byte-identical to today
+                false, // memory-confirm ingress OFF — byte-identical to today
                 false, // (Loop4) per-run token surface OFF — byte-identical to today
             )
             .expect("server serves the compose-adapter session");
@@ -4479,6 +4805,7 @@ mod tests {
             false,
             false,
             false, // (KEYSTONE) mission-spine dispatch OFF — byte-identical to today
+            false, // memory-confirm ingress OFF — byte-identical to today
             false, // (Loop4) per-run token surface OFF — byte-identical to today
         );
         assert!(
@@ -4542,6 +4869,7 @@ mod tests {
                 false,
                 false,
                 false, // (KEYSTONE) mission-spine dispatch OFF — byte-identical to today
+                false, // memory-confirm ingress OFF — byte-identical to today
                 false, // (Loop4) per-run token surface OFF — byte-identical to today
             )
             .unwrap();
@@ -4644,7 +4972,7 @@ mod tests {
         });
         assert_eq!(
             listener
-                .accept_one(&server_kp, &rt, &allowlist, &peer1, false, false, false, false, false)
+                .accept_one(&server_kp, &rt, &allowlist, &peer1, false, false, false, false, false, false)
                 .unwrap(),
             1
         );
@@ -4661,7 +4989,7 @@ mod tests {
         });
         assert_eq!(
             listener
-                .accept_one(&server_kp, &rt, &allowlist, &peer2, false, false, false, false, false)
+                .accept_one(&server_kp, &rt, &allowlist, &peer2, false, false, false, false, false, false)
                 .unwrap(),
             1
         );
@@ -4715,6 +5043,7 @@ mod tests {
                     false,
                     false,
                     false, // (KEYSTONE) mission-spine dispatch OFF — byte-identical to today
+                    false, // memory-confirm ingress OFF — byte-identical to today
                     false, // (Loop4) per-run token surface OFF — byte-identical to today
                 )
                 .unwrap(),

--- a/rust-core/crates/friday-hub/src/bin/hub_agent_run_server.rs
+++ b/rust-core/crates/friday-hub/src/bin/hub_agent_run_server.rs
@@ -2832,9 +2832,11 @@ mod tests {
         let (rt, _ws) = mock_runtime("memory-confirm-on", OWNER);
         seed_memory_candidate(&rt, "mem-wired");
         // Pre-confirm: NOT recallable.
-        assert!(friday_storage::memory::recall_confirmed(rt.db().conn(), OWNER)
-            .unwrap()
-            .is_empty());
+        assert!(
+            friday_storage::memory::recall_confirmed(rt.db().conn(), OWNER)
+                .unwrap()
+                .is_empty()
+        );
 
         let server_kp = DeviceKeypair::generate();
         let listener = AgentRunWsListener::bind_loopback(0).unwrap();
@@ -4972,7 +4974,9 @@ mod tests {
         });
         assert_eq!(
             listener
-                .accept_one(&server_kp, &rt, &allowlist, &peer1, false, false, false, false, false, false)
+                .accept_one(
+                    &server_kp, &rt, &allowlist, &peer1, false, false, false, false, false, false
+                )
                 .unwrap(),
             1
         );
@@ -4989,7 +4993,9 @@ mod tests {
         });
         assert_eq!(
             listener
-                .accept_one(&server_kp, &rt, &allowlist, &peer2, false, false, false, false, false, false)
+                .accept_one(
+                    &server_kp, &rt, &allowlist, &peer2, false, false, false, false, false, false
+                )
                 .unwrap(),
             1
         );

--- a/rust-core/crates/friday-hub/src/hub_server.rs
+++ b/rust-core/crates/friday-hub/src/hub_server.rs
@@ -23,13 +23,12 @@ use friday_crypto::{open, DataKey, Sealed};
 use friday_deepseek::{DeepSeekClient, Transport};
 use friday_protocol::{
     Envelope, ErrorCode, MemoryDecisionRequestWire, MemoryDecisionResultWire, Message,
-    MissionIntakeRequestWire, MissionIntakeResultWire,
-    MissionLifecycleRequestWire, MissionLifecycleResultWire, MissionProjectionSnapshotWire,
-    MissionTimelineLinkWire, MissionTimelineMissionWire, MissionTimelineRequestWire,
-    MissionTimelineSnapshotWire, MissionTimelineSurfaceEventWire, MissionTimelineWorkItemWire,
-    MissionWorkItemContextWire, ProviderWorkspaceActionRequestWire,
-    ProviderWorkspaceActionResultWire, RouteDecisionProjectionWire, WorkItemStatusRequestWire,
-    WorkItemStatusResultWire, SUPPORTED,
+    MissionIntakeRequestWire, MissionIntakeResultWire, MissionLifecycleRequestWire,
+    MissionLifecycleResultWire, MissionProjectionSnapshotWire, MissionTimelineLinkWire,
+    MissionTimelineMissionWire, MissionTimelineRequestWire, MissionTimelineSnapshotWire,
+    MissionTimelineSurfaceEventWire, MissionTimelineWorkItemWire, MissionWorkItemContextWire,
+    ProviderWorkspaceActionRequestWire, ProviderWorkspaceActionResultWire,
+    RouteDecisionProjectionWire, WorkItemStatusRequestWire, WorkItemStatusResultWire, SUPPORTED,
 };
 use friday_providers::unified::{FallbackStatus, PlatformProvider, ProviderSession, SessionStatus};
 use friday_storage::{
@@ -5928,7 +5927,9 @@ mod tests {
         let now = 1_700_000_000_000;
         seed_memory_candidate(&db, "mem-confirm", Some("owner-1"), now);
         // Pre-confirm: NOT recallable.
-        assert!(memory::recall_confirmed(db.conn(), "owner-1").unwrap().is_empty());
+        assert!(memory::recall_confirmed(db.conn(), "owner-1")
+            .unwrap()
+            .is_empty());
 
         let env = memory_decision_result_for_db(
             &db,
@@ -5943,12 +5944,18 @@ mod tests {
         let result = decode_memory_decision(&env);
         assert_eq!(result.status, "confirmed");
         assert_eq!(result.state, "confirmed");
-        assert!(result.recallable, "a confirmed candidate must be recallable");
+        assert!(
+            result.recallable,
+            "a confirmed candidate must be recallable"
+        );
         assert!(result.blocker.is_none());
 
         // Storage truth: the row is Confirmed AND `recall_confirmed` now returns it.
         assert_eq!(
-            memory::get(db.conn(), "mem-confirm").unwrap().unwrap().state,
+            memory::get(db.conn(), "mem-confirm")
+                .unwrap()
+                .unwrap()
+                .state,
             friday_core::MemoryState::Confirmed
         );
         let recalled = memory::recall_confirmed(db.conn(), "owner-1").unwrap();
@@ -5975,13 +5982,18 @@ mod tests {
         let result = decode_memory_decision(&env);
         assert_eq!(result.status, "rejected");
         assert_eq!(result.state, "rejected");
-        assert!(!result.recallable, "a rejected candidate is never recallable");
+        assert!(
+            !result.recallable,
+            "a rejected candidate is never recallable"
+        );
 
         assert_eq!(
             memory::get(db.conn(), "mem-reject").unwrap().unwrap().state,
             friday_core::MemoryState::Rejected
         );
-        assert!(memory::recall_confirmed(db.conn(), "owner-1").unwrap().is_empty());
+        assert!(memory::recall_confirmed(db.conn(), "owner-1")
+            .unwrap()
+            .is_empty());
     }
 
     #[test]
@@ -6011,8 +6023,12 @@ mod tests {
             memory::get(db.conn(), "mem-scope").unwrap().unwrap().state,
             friday_core::MemoryState::Candidate
         );
-        assert!(memory::recall_confirmed(db.conn(), "owner-1").unwrap().is_empty());
-        assert!(memory::recall_confirmed(db.conn(), "intruder").unwrap().is_empty());
+        assert!(memory::recall_confirmed(db.conn(), "owner-1")
+            .unwrap()
+            .is_empty());
+        assert!(memory::recall_confirmed(db.conn(), "intruder")
+            .unwrap()
+            .is_empty());
     }
 
     #[test]
@@ -6037,7 +6053,10 @@ mod tests {
         assert_eq!(result.status, "blocked");
         assert_eq!(result.blocker.as_deref(), Some("owner_scope_mismatch"));
         assert_eq!(
-            memory::get(db.conn(), "mem-unowned").unwrap().unwrap().state,
+            memory::get(db.conn(), "mem-unowned")
+                .unwrap()
+                .unwrap()
+                .state,
             friday_core::MemoryState::Candidate
         );
     }
@@ -6082,7 +6101,10 @@ mod tests {
         assert_eq!(result.blocker.as_deref(), Some("invalid_decision"));
         // The candidate is untouched (no decide call).
         assert_eq!(
-            memory::get(db.conn(), "mem-bad-token").unwrap().unwrap().state,
+            memory::get(db.conn(), "mem-bad-token")
+                .unwrap()
+                .unwrap()
+                .state,
             friday_core::MemoryState::Candidate
         );
     }
@@ -6111,10 +6133,18 @@ mod tests {
         assert_eq!(result.blocker.as_deref(), Some("not_decidable"));
         // Still Confirmed (no downgrade) and still recallable.
         assert_eq!(
-            memory::get(db.conn(), "mem-terminal").unwrap().unwrap().state,
+            memory::get(db.conn(), "mem-terminal")
+                .unwrap()
+                .unwrap()
+                .state,
             friday_core::MemoryState::Confirmed
         );
-        assert_eq!(memory::recall_confirmed(db.conn(), "owner-1").unwrap().len(), 1);
+        assert_eq!(
+            memory::recall_confirmed(db.conn(), "owner-1")
+                .unwrap()
+                .len(),
+            1
+        );
     }
 }
 

--- a/rust-core/crates/friday-hub/src/hub_server.rs
+++ b/rust-core/crates/friday-hub/src/hub_server.rs
@@ -22,7 +22,8 @@
 use friday_crypto::{open, DataKey, Sealed};
 use friday_deepseek::{DeepSeekClient, Transport};
 use friday_protocol::{
-    Envelope, ErrorCode, Message, MissionIntakeRequestWire, MissionIntakeResultWire,
+    Envelope, ErrorCode, MemoryDecisionRequestWire, MemoryDecisionResultWire, Message,
+    MissionIntakeRequestWire, MissionIntakeResultWire,
     MissionLifecycleRequestWire, MissionLifecycleResultWire, MissionProjectionSnapshotWire,
     MissionTimelineLinkWire, MissionTimelineMissionWire, MissionTimelineRequestWire,
     MissionTimelineSnapshotWire, MissionTimelineSurfaceEventWire, MissionTimelineWorkItemWire,
@@ -606,6 +607,184 @@ pub fn work_item_status_result_for_db(
             &format!("work item lifecycle blocked: {err}"),
         ),
     }
+}
+
+/// Apply the OWNER's explicit confirm/reject decision to ONE pending memory
+/// candidate — the live caller that CLOSES the Memory-confirmation loop's terminal
+/// arm (`07` §6/§7). Parameterized over `&Db` so the live agent-run server bin's
+/// flag-gated dispatch arm reuses the EXACT same mutation WITHOUT a `HubServer`,
+/// mirroring [`mission_intake_result_for_db`] / [`work_item_status_result_for_db`].
+/// It touches ONLY the DB and makes NO provider/model call — so it writes ZERO
+/// `token_ledger` rows.
+///
+/// **The decision is the OWNER's own action.** The sealed single-peer session IS the
+/// channel auth (the same invariant the mission arms rely on); this is NOT an agent
+/// mutating-tool action, so it does NOT route through the approval/trust gate. But it
+/// IS owner/namespace-scoped and **fail-closed on mismatch**, enforced BEFORE the
+/// decide so a blocked request leaves the candidate UNCHANGED:
+/// - `owner_principal` must be non-empty (after trim) — else blocked.
+/// - the candidate must exist — else blocked (`state="unknown"`).
+/// - the candidate's `principal_id` must equal `owner_principal` EXACTLY — the SAME
+///   key [`friday_storage::memory::recall_confirmed`] enforces. A candidate owned by a
+///   different principal, OR an UNOWNED (`None`-principal) candidate, is decidable by
+///   NO ONE (no wildcard, mirroring recall's blank→fail-closed rule).
+///
+/// Only after the scope check passes does it call
+/// [`friday_storage::memory::confirm`] / [`reject`]. A `confirm` makes the candidate
+/// durable AND recallable (the whole point of the loop): the SAME `principal_id`
+/// threads `record_candidate` → confirm → `recall_confirmed`. A `reject` makes it a
+/// terminal `Rejected` row (never recallable). A terminal candidate (already
+/// confirmed/rejected) is refused by the storage layer ("refusing to re-decide") and
+/// surfaced as a blocked result — never a panic. The reply is REFS-ONLY: the candidate
+/// id + resulting state + a coarse status/blocker — NEVER the candidate's content.
+///
+/// Returns a [`Message::MemoryDecisionResult`] envelope (confirmed / rejected /
+/// blocked) correlated to `msg_id`.
+pub fn memory_decision_result_for_db(
+    db: &Db,
+    msg_id: &str,
+    request: MemoryDecisionRequestWire,
+    now_ms: i64,
+) -> Envelope {
+    use friday_storage::memory;
+
+    let owner = request.owner_principal.trim();
+    let decision = request.decision.trim().to_ascii_lowercase();
+
+    // Validate the decision token fail-closed (the `*_from_wire` idiom): anything other
+    // than the two explicit decisions is a block, never a default.
+    let confirmed = match decision.as_str() {
+        "confirm" => true,
+        "reject" => false,
+        _ => {
+            return memory_decision_blocked(
+                msg_id,
+                now_ms,
+                &request.memory_id,
+                "unknown",
+                "invalid_decision",
+            );
+        }
+    };
+
+    // An owner-less request can match no candidate (recall's blank→fail-closed rule).
+    if owner.is_empty() {
+        return memory_decision_blocked(
+            msg_id,
+            now_ms,
+            &request.memory_id,
+            "unknown",
+            "owner_principal_required",
+        );
+    }
+
+    // Resolve the candidate. An unknown id is a block (no decide call, no panic).
+    let row = match memory::get(db.conn(), &request.memory_id) {
+        Ok(Some(row)) => row,
+        Ok(None) => {
+            return memory_decision_blocked(
+                msg_id,
+                now_ms,
+                &request.memory_id,
+                "unknown",
+                "unknown_candidate",
+            );
+        }
+        Err(_) => {
+            return memory_decision_blocked(
+                msg_id,
+                now_ms,
+                &request.memory_id,
+                "unknown",
+                "candidate_read_failed",
+            );
+        }
+    };
+
+    // Owner/namespace scope: EXACT-match the candidate's owning principal. An unowned
+    // (`None`) candidate, or one owned by a different principal, is decidable by no one —
+    // fail-closed, candidate left UNCHANGED (this check runs BEFORE any decide).
+    if row.principal_id.as_deref() != Some(owner) {
+        return memory_decision_blocked(
+            msg_id,
+            now_ms,
+            &request.memory_id,
+            row.state.as_str(),
+            "owner_scope_mismatch",
+        );
+    }
+
+    // Scope cleared: apply the explicit decision. A terminal candidate is refused by
+    // the storage layer (no re-decide / no downgrade) — surface it as a block.
+    let new_state = match memory::decide(db.conn(), &request.memory_id, confirmed, now_ms) {
+        Ok(state) => state,
+        Err(_) => {
+            return memory_decision_blocked(
+                msg_id,
+                now_ms,
+                &request.memory_id,
+                row.state.as_str(),
+                "not_decidable",
+            );
+        }
+    };
+
+    // Recallability is the loop's payoff: a confirmed, content-bearing, owner-owned
+    // candidate is now returned by `recall_confirmed`. Derive `recallable` from the
+    // SAME query the answer path uses (not just the state) so the surface never claims
+    // recallability a recall would not honor — e.g. a content-less confirmed row.
+    let recallable = matches!(new_state, friday_core::MemoryState::Confirmed)
+        && memory::recall_confirmed(db.conn(), owner)
+            .map(|rows| rows.iter().any(|r| r.memory_id == request.memory_id))
+            .unwrap_or(false);
+
+    let status = match new_state {
+        friday_core::MemoryState::Confirmed => "confirmed",
+        friday_core::MemoryState::Rejected => "rejected",
+        // `decide` over a pending candidate only ever returns Confirmed/Rejected;
+        // a still-Candidate result is impossible here (Some(true|false) was passed).
+        friday_core::MemoryState::Candidate => "blocked",
+    };
+
+    Envelope::new(
+        format!("{msg_id}-memory-decision"),
+        now_ms,
+        Message::MemoryDecisionResult {
+            result: MemoryDecisionResultWire {
+                memory_id: request.memory_id,
+                state: new_state.as_str().to_string(),
+                status: status.to_string(),
+                blocker: None,
+                recallable,
+            },
+        },
+    )
+    .with_correlation(msg_id.to_string())
+}
+
+/// A blocked [`Message::MemoryDecisionResult`] — the candidate is UNCHANGED. Refs-only:
+/// carries the id + the (unchanged) state + the coarse blocker reason; never content.
+fn memory_decision_blocked(
+    msg_id: &str,
+    now_ms: i64,
+    memory_id: &str,
+    state: &str,
+    blocker: &str,
+) -> Envelope {
+    Envelope::new(
+        format!("{msg_id}-memory-decision"),
+        now_ms,
+        Message::MemoryDecisionResult {
+            result: MemoryDecisionResultWire {
+                memory_id: memory_id.to_string(),
+                state: state.to_string(),
+                status: "blocked".to_string(),
+                blocker: Some(blocker.to_string()),
+                recallable: false,
+            },
+        },
+    )
+    .with_correlation(msg_id.to_string())
 }
 
 impl<T: Transport> HubServer<T> {
@@ -5711,6 +5890,231 @@ mod tests {
         }
         assert!(pages > 1);
         assert_eq!(provider_link_count, ask_count);
+    }
+
+    // --- Memory-confirm arm (the live caller that CLOSES the Memory-confirmation loop) ---------
+
+    /// Seed ONE pending memory candidate owned by `owner`, with content (so a confirm makes it
+    /// recallable — `recall_confirmed` requires non-NULL/non-empty content).
+    fn seed_memory_candidate(db: &Db, memory_id: &str, owner: Option<&str>, now: i64) {
+        memory::record_candidate(
+            db.conn(),
+            &memory::NewMemoryCandidate {
+                memory_id,
+                scope: MemoryScope::Global,
+                content_ref: None,
+                // Content-bearing: a confirm must yield a recallable row.
+                content: Some("prefers rust"),
+                principal_id: owner,
+                sensitive: false,
+                created_at: now,
+            },
+        )
+        .unwrap();
+    }
+
+    fn decode_memory_decision(env: &Envelope) -> &MemoryDecisionResultWire {
+        match &env.message {
+            Message::MemoryDecisionResult { result } => result,
+            other => panic!("expected MemoryDecisionResult, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn memory_decision_confirm_makes_candidate_recallable() {
+        // The whole point of the loop: a confirmed, owner-owned, content-bearing candidate becomes
+        // recallable (the answer path's `recall_confirmed` returns it).
+        let db = Db::open_hub(&tmp_db()).unwrap();
+        let now = 1_700_000_000_000;
+        seed_memory_candidate(&db, "mem-confirm", Some("owner-1"), now);
+        // Pre-confirm: NOT recallable.
+        assert!(memory::recall_confirmed(db.conn(), "owner-1").unwrap().is_empty());
+
+        let env = memory_decision_result_for_db(
+            &db,
+            "msg-confirm",
+            MemoryDecisionRequestWire {
+                memory_id: "mem-confirm".into(),
+                owner_principal: "owner-1".into(),
+                decision: "confirm".into(),
+            },
+            now + 1,
+        );
+        let result = decode_memory_decision(&env);
+        assert_eq!(result.status, "confirmed");
+        assert_eq!(result.state, "confirmed");
+        assert!(result.recallable, "a confirmed candidate must be recallable");
+        assert!(result.blocker.is_none());
+
+        // Storage truth: the row is Confirmed AND `recall_confirmed` now returns it.
+        assert_eq!(
+            memory::get(db.conn(), "mem-confirm").unwrap().unwrap().state,
+            friday_core::MemoryState::Confirmed
+        );
+        let recalled = memory::recall_confirmed(db.conn(), "owner-1").unwrap();
+        assert_eq!(recalled.len(), 1);
+        assert_eq!(recalled[0].memory_id, "mem-confirm");
+    }
+
+    #[test]
+    fn memory_decision_reject_is_terminal_and_not_recallable() {
+        let db = Db::open_hub(&tmp_db()).unwrap();
+        let now = 1_700_000_000_000;
+        seed_memory_candidate(&db, "mem-reject", Some("owner-1"), now);
+
+        let env = memory_decision_result_for_db(
+            &db,
+            "msg-reject",
+            MemoryDecisionRequestWire {
+                memory_id: "mem-reject".into(),
+                owner_principal: "owner-1".into(),
+                decision: "reject".into(),
+            },
+            now + 1,
+        );
+        let result = decode_memory_decision(&env);
+        assert_eq!(result.status, "rejected");
+        assert_eq!(result.state, "rejected");
+        assert!(!result.recallable, "a rejected candidate is never recallable");
+
+        assert_eq!(
+            memory::get(db.conn(), "mem-reject").unwrap().unwrap().state,
+            friday_core::MemoryState::Rejected
+        );
+        assert!(memory::recall_confirmed(db.conn(), "owner-1").unwrap().is_empty());
+    }
+
+    #[test]
+    fn memory_decision_owner_mismatch_is_blocked_and_leaves_candidate_unchanged() {
+        let db = Db::open_hub(&tmp_db()).unwrap();
+        let now = 1_700_000_000_000;
+        seed_memory_candidate(&db, "mem-scope", Some("owner-1"), now);
+
+        // A DIFFERENT principal tries to confirm owner-1's candidate.
+        let env = memory_decision_result_for_db(
+            &db,
+            "msg-scope",
+            MemoryDecisionRequestWire {
+                memory_id: "mem-scope".into(),
+                owner_principal: "intruder".into(),
+                decision: "confirm".into(),
+            },
+            now + 1,
+        );
+        let result = decode_memory_decision(&env);
+        assert_eq!(result.status, "blocked");
+        assert_eq!(result.blocker.as_deref(), Some("owner_scope_mismatch"));
+        assert!(!result.recallable);
+
+        // UNCHANGED: still a pending Candidate; recallable by no one.
+        assert_eq!(
+            memory::get(db.conn(), "mem-scope").unwrap().unwrap().state,
+            friday_core::MemoryState::Candidate
+        );
+        assert!(memory::recall_confirmed(db.conn(), "owner-1").unwrap().is_empty());
+        assert!(memory::recall_confirmed(db.conn(), "intruder").unwrap().is_empty());
+    }
+
+    #[test]
+    fn memory_decision_unowned_candidate_is_decidable_by_no_one() {
+        // An UNOWNED (`None`-principal) candidate must be decidable by no one — fail-closed, no
+        // wildcard (mirrors `recall_confirmed`'s blank→fail-closed rule).
+        let db = Db::open_hub(&tmp_db()).unwrap();
+        let now = 1_700_000_000_000;
+        seed_memory_candidate(&db, "mem-unowned", None, now);
+
+        let env = memory_decision_result_for_db(
+            &db,
+            "msg-unowned",
+            MemoryDecisionRequestWire {
+                memory_id: "mem-unowned".into(),
+                owner_principal: "owner-1".into(),
+                decision: "confirm".into(),
+            },
+            now + 1,
+        );
+        let result = decode_memory_decision(&env);
+        assert_eq!(result.status, "blocked");
+        assert_eq!(result.blocker.as_deref(), Some("owner_scope_mismatch"));
+        assert_eq!(
+            memory::get(db.conn(), "mem-unowned").unwrap().unwrap().state,
+            friday_core::MemoryState::Candidate
+        );
+    }
+
+    #[test]
+    fn memory_decision_unknown_candidate_is_blocked_no_panic() {
+        let db = Db::open_hub(&tmp_db()).unwrap();
+        let env = memory_decision_result_for_db(
+            &db,
+            "msg-unknown",
+            MemoryDecisionRequestWire {
+                memory_id: "does-not-exist".into(),
+                owner_principal: "owner-1".into(),
+                decision: "confirm".into(),
+            },
+            1_700_000_000_000,
+        );
+        let result = decode_memory_decision(&env);
+        assert_eq!(result.status, "blocked");
+        assert_eq!(result.state, "unknown");
+        assert_eq!(result.blocker.as_deref(), Some("unknown_candidate"));
+        assert!(!result.recallable);
+    }
+
+    #[test]
+    fn memory_decision_invalid_decision_token_is_blocked() {
+        let db = Db::open_hub(&tmp_db()).unwrap();
+        let now = 1_700_000_000_000;
+        seed_memory_candidate(&db, "mem-bad-token", Some("owner-1"), now);
+        let env = memory_decision_result_for_db(
+            &db,
+            "msg-bad-token",
+            MemoryDecisionRequestWire {
+                memory_id: "mem-bad-token".into(),
+                owner_principal: "owner-1".into(),
+                decision: "maybe".into(),
+            },
+            now + 1,
+        );
+        let result = decode_memory_decision(&env);
+        assert_eq!(result.status, "blocked");
+        assert_eq!(result.blocker.as_deref(), Some("invalid_decision"));
+        // The candidate is untouched (no decide call).
+        assert_eq!(
+            memory::get(db.conn(), "mem-bad-token").unwrap().unwrap().state,
+            friday_core::MemoryState::Candidate
+        );
+    }
+
+    #[test]
+    fn memory_decision_terminal_candidate_is_refused() {
+        // Re-deciding a terminal (already-confirmed) candidate is refused by the storage layer —
+        // surfaced as a block, never a panic; the confirmed row stays confirmed.
+        let db = Db::open_hub(&tmp_db()).unwrap();
+        let now = 1_700_000_000_000;
+        seed_memory_candidate(&db, "mem-terminal", Some("owner-1"), now);
+        memory::confirm(db.conn(), "mem-terminal", now + 1).unwrap();
+
+        let env = memory_decision_result_for_db(
+            &db,
+            "msg-terminal",
+            MemoryDecisionRequestWire {
+                memory_id: "mem-terminal".into(),
+                owner_principal: "owner-1".into(),
+                decision: "reject".into(),
+            },
+            now + 2,
+        );
+        let result = decode_memory_decision(&env);
+        assert_eq!(result.status, "blocked");
+        assert_eq!(result.blocker.as_deref(), Some("not_decidable"));
+        // Still Confirmed (no downgrade) and still recallable.
+        assert_eq!(
+            memory::get(db.conn(), "mem-terminal").unwrap().unwrap().state,
+            friday_core::MemoryState::Confirmed
+        );
+        assert_eq!(memory::recall_confirmed(db.conn(), "owner-1").unwrap().len(), 1);
     }
 }
 

--- a/rust-core/crates/friday-protocol/src/lib.rs
+++ b/rust-core/crates/friday-protocol/src/lib.rs
@@ -287,6 +287,52 @@ pub struct MissionIntakeResultWire {
     pub created_or_ready: bool,
 }
 
+/// Client request to apply the OWNER's explicit confirm/reject decision to ONE
+/// pending memory candidate (the Memory-confirmation loop's terminal action,
+/// `07` §6/§7). This is the owner's OWN action over the sealed single-peer session
+/// (the session IS the channel auth) — NOT an agent mutating-tool action, so it
+/// does NOT route through the approval/trust gate. It is a pure Hub `&Db` mutation
+/// (NO provider/model call). The decision is owner/namespace-scoped: it applies
+/// ONLY when `owner_principal` matches the candidate's owning principal, fail-closed
+/// on any mismatch (an unowned candidate is decidable by no one). A candidate becomes
+/// durable (`Confirmed`, recallable) ONLY through this explicit confirm — there is no
+/// auto-confirm path.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MemoryDecisionRequestWire {
+    /// The candidate `memory_item` to decide on.
+    pub memory_id: String,
+    /// The owner principal asserting the decision. MUST equal the candidate's owning
+    /// `principal_id` (the same key `recall_confirmed` enforces) — else fail-closed.
+    pub owner_principal: String,
+    /// The explicit decision: `"confirm"` (→ durable/recallable) or `"reject"`
+    /// (→ terminal, never recallable). Parsed fail-closed: any other token is an Error.
+    pub decision: String,
+}
+
+/// Hub response for a memory decision. Refs-only: it carries the candidate's id +
+/// the resulting lifecycle state + a coarse status/reason — NEVER the candidate's
+/// content (the content stays Hub-side; only the owner recalls it). `status` is
+/// `"confirmed"` / `"rejected"` (the decision applied) or `"blocked"` (scope
+/// mismatch / unknown candidate / terminal / invalid decision); `blocker` carries
+/// the coarse reason when blocked.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MemoryDecisionResultWire {
+    pub memory_id: String,
+    /// The resulting lifecycle state token (`"candidate"` / `"confirmed"` /
+    /// `"rejected"`) — the candidate's CURRENT state after the decision. On a block
+    /// this reflects no change (or `"unknown"` when the candidate does not exist).
+    pub state: String,
+    /// Coarse outcome: `"confirmed"` / `"rejected"` / `"blocked"`.
+    pub status: String,
+    /// Set ONLY when `status == "blocked"`: the coarse reason (scope mismatch /
+    /// unknown / terminal / invalid decision). Never echoes candidate content.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub blocker: Option<String>,
+    /// Whether the candidate is now recallable (durable `Confirmed`). Mirrors
+    /// `created_or_ready` on the intake result — a single honest yes/no.
+    pub recallable: bool,
+}
+
 /// Canonical Mission/WorkItem context for a user-facing request. This is not a
 /// provider thread id or frontend-local chat id; Hub resolves it against Mission
 /// Spine storage before the request can become product work.
@@ -1240,6 +1286,17 @@ pub enum Message {
     /// status here is honest precisely because the proof-on-completion invariant
     /// was enforced before the write.
     WorkItemStatusResult { result: WorkItemStatusResultWire },
+    /// client->hub: apply the OWNER's explicit confirm/reject decision to ONE
+    /// pending memory candidate (the Memory-confirmation loop's terminal action).
+    /// Never a provider/model call. Owner/namespace-scoped: applies ONLY when
+    /// `owner_principal` matches the candidate's owning principal (fail-closed on
+    /// mismatch / unowned / unknown / terminal). A candidate becomes durable
+    /// (recallable) ONLY through an explicit `confirm` here — no auto-confirm path.
+    MemoryDecisionRequest { request: MemoryDecisionRequestWire },
+    /// hub->client: memory decision receipt. Refs-only — carries the candidate id,
+    /// the resulting lifecycle state, a coarse status, and whether it is now
+    /// recallable. NEVER the candidate's content (the content stays Hub-side).
+    MemoryDecisionResult { result: MemoryDecisionResultWire },
     /// **S-R1** — UI→DARK read-server: request the Mission Workbench read projection over the
     /// sealed-WS READ seam. PURE READ — no model/provider call. Owner-scoped: the read server
     /// authenticates `forwarded_principal`/`auth_proof` against the sealed session (the SAME chain a
@@ -2066,6 +2123,22 @@ mod tests {
                     updated_at_ms: 1_700_000_000_007,
                 },
             },
+            Message::MemoryDecisionRequest {
+                request: MemoryDecisionRequestWire {
+                    memory_id: "mem-1".into(),
+                    owner_principal: "owner-1".into(),
+                    decision: "confirm".into(),
+                },
+            },
+            Message::MemoryDecisionResult {
+                result: MemoryDecisionResultWire {
+                    memory_id: "mem-1".into(),
+                    state: "confirmed".into(),
+                    status: "confirmed".into(),
+                    blocker: None,
+                    recallable: true,
+                },
+            },
         ];
         for msg in cases {
             let env = Envelope::new("m1", 1000, msg).with_correlation("c1");
@@ -2074,6 +2147,47 @@ mod tests {
             let back = Envelope::decode(&json).unwrap();
             assert_eq!(back, env);
         }
+    }
+
+    #[test]
+    fn memory_decision_wire_round_trips_and_uses_the_request_result_wrapper() {
+        // The decision request rides the SAME internally-tagged `{ request }` / `{ result }`
+        // wrapper as MissionIntake (enum `tag="kind"` + a single named field). A prior surface
+        // shipped a FLAT shape that 503'd every call — this asserts the wrapper is present so a
+        // regression to the flat shape is caught at the protocol layer.
+        let request = Message::MemoryDecisionRequest {
+            request: MemoryDecisionRequestWire {
+                memory_id: "mem-decision-1".into(),
+                owner_principal: "owner-1".into(),
+                decision: "confirm".into(),
+            },
+        };
+        let env = Envelope::new("mem-dec-req", 1000, request.clone()).with_correlation("c1");
+        let json = env.encode().unwrap();
+        assert!(json.contains("\"kind\":\"MemoryDecisionRequest\""));
+        // The load-bearing wrapper: the payload sits under `"request":{...}`, NOT flattened
+        // alongside `kind` (the flat-shape regression guard).
+        assert!(json.contains("\"request\":{"));
+        assert!(json.contains("\"memory_id\":\"mem-decision-1\""));
+        assert!(json.contains("\"decision\":\"confirm\""));
+        assert_eq!(Envelope::decode(&json).unwrap(), env);
+
+        let result = Message::MemoryDecisionResult {
+            result: MemoryDecisionResultWire {
+                memory_id: "mem-decision-1".into(),
+                state: "rejected".into(),
+                status: "blocked".into(),
+                blocker: Some("owner_scope_mismatch".into()),
+                recallable: false,
+            },
+        };
+        let env = Envelope::new("mem-dec-res", 1001, result).with_correlation("c1");
+        let json = env.encode().unwrap();
+        assert!(json.contains("\"kind\":\"MemoryDecisionResult\""));
+        assert!(json.contains("\"result\":{"));
+        assert!(json.contains("\"recallable\":false"));
+        assert!(json.contains("\"blocker\":\"owner_scope_mismatch\""));
+        assert_eq!(Envelope::decode(&json).unwrap(), env);
     }
 
     #[test]


### PR DESCRIPTION
## The closed gap

The memory-confirmation loop dead-ended: `friday_storage::memory::decide` / `confirm` / `reject` — the primitive that moves a candidate `Candidate → Confirmed → recallable` — had **no live caller anywhere**, only `#[test]` callers. An extracted memory candidate could never become a confirmed, recallable fact through any product path.

This adds the Rust **confirm arm**: an inbound owner-authed `MemoryDecisionRequest` confirms/rejects a candidate `memory_item`, so a confirmed candidate becomes recallable via `recall_confirmed`. DARK behind a new default-OFF flag `FRIDAY_MEMORY_CONFIRM`.

## Mirror of #741 (the mission-spine arms)

Structurally identical to the merged mission-intake / mission-spine-dispatch arms:

1. **Protocol** (`friday-protocol/src/lib.rs`): `MemoryDecisionRequestWire { memory_id, owner_principal, decision }` + `MemoryDecisionResultWire { memory_id, state, status, blocker, recallable }`, and `Message::MemoryDecisionRequest { request }` / `MemoryDecisionResult { result }`. **Internally-tagged with the `{request}`/`{result}` wrapper** (enum is `tag="kind"`), mirroring `MissionIntake` — NOT the flat shape a prior surface shipped that 503'd every call. A dedicated round-trip test asserts the wrapper (`"request":{`) is present, plus both cases added to `envelope_round_trips_for_each_kind`.
2. **Handler** (`friday-hub/src/hub_server.rs`): free fn `memory_decision_result_for_db(&Db, msg_id, request, now_ms) -> Envelope` (same signature shape as `mission_intake_result_for_db`). Resolves the candidate, enforces owner/namespace scope **before** the decide (`principal_id` exact-match — the same key `recall_confirmed` enforces), then calls `memory::decide`. Touches ONLY the DB; ZERO `token_ledger` rows. Refs-only result (id + state + status + `recallable`; **never** the candidate's content). `recallable` is derived from the SAME `recall_confirmed` query the answer path uses, so the surface never claims recallability a recall would not honor.
3. **Bin arm** (`hub_agent_run_server.rs`): new flag `FRIDAY_MEMORY_CONFIRM` (const + `memory_confirm_enabled_from` matcher, exact `"1"`, default-OFF) + boot-log ENABLED/DISABLED line + a `Message::MemoryDecisionRequest { request } if memory_confirm_enabled =>` arm. **Flag-OFF = benign keepalive echo (births/changes nothing, byte-identical to today).**

## Owner auth, not the trust gate

The decision is the owner's OWN action — the sealed single-peer session IS the channel auth (the same invariant the mission arms rely on; this wire shape carries no per-request `auth_proof`). It is NOT an agent mutating-tool action, so it does NOT route through the approval/trust gate. It IS owner/namespace-scoped and fail-closed on mismatch.

**Fail-closed cases return a `MemoryDecisionResult{status:"blocked"}` *result*, not a transport `Message::Error`** (the task enumerates "blocked" as a result status). Unowned (`None`-principal) candidate, owner mismatch, unknown id, terminal (already-decided), and invalid decision token all → blocked, candidate UNCHANGED, no panic.

## Dark-safety / preserve-architecture

- `runtime.rs` **untouched**. Extraction trigger and all other flag defaults **untouched**. No new dependency.
- `friday-ffi` `message_kind_name` gains the two variant names — this match is deliberately exhaustive (a new variant must be named, no wildcard); the variants are DARK on the FFI surface (nothing constructs/dispatches them there).
- The **TS driver route** that constructs `MemoryDecisionRequest`, and the `FRIDAY_MEMORY_CONFIRM` / `FRIDAY_RUN_LOOP_MEMORY_EXTRACTION` flips, are **operator-gated follow-ups** (like #752 was the dispatch driver follow-up).

## Tests (all green locally)

- Protocol: round-trip + wrapper-shape assertion; both new cases in the enumerated round-trip.
- Handler-level (`Db::open_hub` temp): **confirm → recallable** (the headline — `recall_confirmed` returns it), reject → terminal+not-recallable, owner-mismatch → blocked + unchanged, unowned → blocked, unknown → blocked-no-panic, invalid-token → blocked, terminal → refused (no downgrade).
- Bin-level: flag default-OFF + fail-closed matcher; **flag-ON confirm-through-real-dispatch → recallable + ZERO ledger**; **flag-OFF keepalive echo → changes nothing**.

Local: `cargo build -p friday-hub`, `cargo clippy --workspace --all-targets` (zero warnings), `cargo test -p friday-hub` (662 lib + all integration, 0 failed), `cargo test -p friday-protocol` (33), `cargo test -p friday-ffi` (26), `detect-secrets-hook` clean. The structural guard `hub_crate_never_references_a_signing_key` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)