### PR TITLE
feat(memory): TS driver for the owner-authed memory-confirm loop (dark, additive)

### DIFF
--- a/docs/ops/ts-runtime-retirement-manifest.json
+++ b/docs/ops/ts-runtime-retirement-manifest.json
@@ -355,6 +355,17 @@
       "next_action": "Keep TypeScript as a redacted HTTP adapter over Rust Mission Spine projections."
     },
     {
+      "id": "memory_spine_rust_delegated",
+      "match": {
+        "sourceFile": "src/api/http/routes/friday-memory-spine-routes.ts"
+      },
+      "classification": "rust_delegated",
+      "user_triggerable": true,
+      "rust_entrypoint": "rust-core/crates/friday-hub/src/hub_server.rs",
+      "proof": "POST /v1/memory-spine/decide is a redacted HTTP adapter forwarding MemoryDecisionRequest over the sealed-WS to the Rust memory-confirm arm (memory_decision_result_for_db, gated by FRIDAY_MEMORY_CONFIRM); dark default-OFF (503) until the operator wires the dispatch adapter and flips the flag",
+      "next_action": "Keep TypeScript as a redacted HTTP adapter over the Rust memory-confirmation arm."
+    },
+    {
       "id": "agent_runtime_blockers",
       "match": {
         "sourceFile": "src/api/http/routes/friday-agent-routes.ts"

--- a/src/api/http/routes/friday-memory-spine-routes.ts
+++ b/src/api/http/routes/friday-memory-spine-routes.ts
@@ -1,0 +1,163 @@
+import { FridayDomainError } from "#errors";
+import { assertBoundPrincipalForOperation } from "../../../security/friday-owner-session-channel-capability.js";
+import type { FridayRouteDefinition } from "../../model/friday-api-common.types.js";
+import type {
+  FridayRustHubMemoryDecisionRequest,
+  FridayRustHubMemoryDecisionResult,
+} from "../../mission-spine/friday-rust-hub-agent-run-ws-sealed-client.js";
+
+/**
+ * (Lane M) The memory-confirmation loop's TERMINAL driver: the `POST /v1/memory-spine/decide`
+ * route that lets an authenticated OWNER confirm/reject ONE pending memory candidate, transitioning
+ * it Candidate→Confirmed (recallable) or Candidate→Rejected (terminal) in the Rust Hub. This MIRRORS
+ * the mission-spine dispatch routes exactly (`friday-mission-spine-routes.ts`): the handler validates
+ * the body, refuses the synthetic public principal, then hands a typed request to a (flag-gated) Rust
+ * sealed-WS dispatch service which seals + sends a `Message::MemoryDecisionRequest` and returns the
+ * refs-only `MemoryDecisionResult`.
+ *
+ * ## DARK by default (503 until wired + flag-ON)
+ * When this service is `null` (the DEFAULT — no adapter wired) the POST route is honest-unavailable
+ * (503 `MEMORY_SPINE_DISPATCH_UNAVAILABLE`). PROVIDING it (an operator step in bootstrap) makes the
+ * route LIVE — and live closure of the confirmation loop ALSO needs the SERVER flag
+ * `FRIDAY_MEMORY_CONFIRM` (the merged Rust arm #753 is DEFAULT-OFF; a `MemoryDecisionRequest` is a
+ * benign keepalive echo until it is flipped) plus `FRIDAY_RUN_LOOP_MEMORY_EXTRACTION` to produce
+ * candidates to decide on. Registering this route with the service `null` is byte-additive to today.
+ */
+export interface FridayMemorySpineDispatchService {
+  decideMemory(
+    request: FridayRustHubMemoryDecisionRequest,
+  ): Promise<FridayRustHubMemoryDecisionResult>;
+}
+
+export interface FridayMemorySpineRoutesDeps {
+  /**
+   * (Lane M) The organic memory-decision dispatcher, DEFAULT-OFF (`null`). `null` ⇒ the POST route
+   * is honest-unavailable (503); a real adapter ⇒ it seals + dispatches over the sealed-WS client.
+   * Registering the route with this `null` is byte-identical to today for existing traffic.
+   */
+  readonly dispatch?: FridayMemorySpineDispatchService | null;
+  /** (Lane M) Optional reason for the dispatch-unavailable 503; falls back to a default message. */
+  readonly dispatchDisabledReason?: string | null;
+}
+
+/** (Lane M) Response envelope for the memory-decision route — refs-only result passthrough. */
+export interface FridayMemorySpineDecideResponse {
+  readonly result: FridayRustHubMemoryDecisionResult;
+}
+
+const DEFAULT_DISPATCH_DISABLED_MESSAGE =
+  "Memory Spine confirmation dispatch is unavailable in this runtime; the Rust Hub sealed-WS memory-decision seam has not been wired.";
+
+const MEMORY_DECISION_SURFACE = "api:/v1/memory-spine/decide";
+const VALID_DECISIONS = new Set(["confirm", "reject"]);
+
+/** Throw a typed 400 for an invalid memory-decision body. Never echoes the raw body. */
+function throwInvalidBody(failures: readonly string[]): never {
+  throw new FridayDomainError(
+    "MEMORY_SPINE_DECISION_REQUEST_INVALID",
+    "Memory Spine confirmation request body did not satisfy the dispatch contract.",
+    {
+      httpStatus: 400,
+      details: { surface: MEMORY_DECISION_SURFACE, failures },
+    },
+  );
+}
+
+function asBody(body: unknown): Record<string, unknown> {
+  return body && typeof body === "object" && !Array.isArray(body) ? (body as Record<string, unknown>) : {};
+}
+
+/** A required, trimmed, non-empty string field — or `undefined` (pushes a failure code). */
+function readRequiredString(
+  body: Record<string, unknown>,
+  field: string,
+  failures: string[],
+): string | undefined {
+  const value = body[field];
+  if (typeof value !== "string" || value.trim().length === 0) {
+    failures.push(`${field}_missing_or_empty`);
+    return undefined;
+  }
+  return value.trim();
+}
+
+/**
+ * (Lane M) Validate a memory-decision body into the typed request (or throw a typed 400). `memoryId`
+ * + `ownerPrincipal` are required non-empty strings; `decision` is required AND must be exactly
+ * `"confirm"` or `"reject"` (an extra-invariant enum check beyond presence — mirrors the
+ * proof-on-completion check in the mission-spine work-item validator). The Rust side ALSO parses
+ * `decision` fail-closed (an invalid token → `status:"blocked"`); this edge check is a fail-fast
+ * convenience that rejects with a 400 (never a 500) BEFORE any send.
+ */
+export function validateMemoryDecisionBody(body: unknown): FridayRustHubMemoryDecisionRequest {
+  const b = asBody(body);
+  const failures: string[] = [];
+  const memoryId = readRequiredString(b, "memoryId", failures);
+  const ownerPrincipal = readRequiredString(b, "ownerPrincipal", failures);
+  const decision = readRequiredString(b, "decision", failures);
+  if (decision !== undefined && !VALID_DECISIONS.has(decision)) {
+    failures.push("decision_not_confirm_or_reject");
+  }
+  if (
+    failures.length > 0 ||
+    memoryId === undefined ||
+    ownerPrincipal === undefined ||
+    decision === undefined
+  ) {
+    throwInvalidBody(failures);
+  }
+  return {
+    memoryId,
+    ownerPrincipal,
+    decision: decision as "confirm" | "reject",
+  };
+}
+
+export function createFridayMemorySpineRoutes(
+  deps: FridayMemorySpineRoutesDeps,
+): FridayRouteDefinition<unknown, unknown, unknown, unknown>[] {
+  // (Lane M) DEFAULT-OFF: `deps.dispatch` is null/undefined unless an adapter is wired, so the POST
+  // route is honest-unavailable (503) by default — byte-additive to today (a new flag-OFF route
+  // never alters any existing route's behavior).
+  const dispatch = deps.dispatch ?? null;
+
+  function dispatchDisabledMessage(): string {
+    return deps.dispatchDisabledReason && deps.dispatchDisabledReason.trim().length > 0
+      ? deps.dispatchDisabledReason
+      : DEFAULT_DISPATCH_DISABLED_MESSAGE;
+  }
+
+  function throwDispatchDisabled(): never {
+    throw new FridayDomainError(
+      "MEMORY_SPINE_DISPATCH_UNAVAILABLE",
+      dispatchDisabledMessage(),
+      {
+        httpStatus: 503,
+        details: { surface: MEMORY_DECISION_SURFACE, dispatch: "rust_hub_unavailable", proofReady: false },
+      },
+    );
+  }
+
+  return [
+    // (Lane M) ORGANIC MEMORY DECISION — POST. Guard order mirrors the mission-spine dispatch
+    // routes exactly: (1) dispatch-disabled (flag-OFF) → 503 FIRST regardless of caller, so a
+    // flag-OFF route is a uniform honest-unavailable; (2) bound-principal (refuse the synthetic
+    // public principal) → 401; (3) body validation → 400; (4) seal + dispatch over the sealed-WS
+    // client. Refs-only result passthrough (a `status:"blocked"` is the Hub's honest refusal).
+    {
+      operationId: "memory.spine.decide.apply",
+      method: "POST",
+      path: "/v1/memory-spine/decide",
+      auth: { public: true },
+      async handler(ctx): Promise<FridayMemorySpineDecideResponse> {
+        if (!dispatch) {
+          throwDispatchDisabled();
+        }
+        assertBoundPrincipalForOperation(ctx.principal ?? null, "memory.spine.decide", "api");
+        const request = validateMemoryDecisionBody(ctx.body);
+        const result = await dispatch.decideMemory(request);
+        return { result };
+      },
+    },
+  ];
+}

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -241,6 +241,11 @@ export { createFridayUixRoutes } from "./http/routes/friday-uix-routes.js";
 export type { FridayUixRoutesDeps } from "./http/routes/friday-uix-routes.js";
 export { createFridayMissionSpineRoutes } from "./http/routes/friday-mission-spine-routes.js";
 export type { FridayMissionSpineRoutesDeps } from "./http/routes/friday-mission-spine-routes.js";
+export { createFridayMemorySpineRoutes } from "./http/routes/friday-memory-spine-routes.js";
+export type {
+  FridayMemorySpineRoutesDeps,
+  FridayMemorySpineDispatchService,
+} from "./http/routes/friday-memory-spine-routes.js";
 export { createFridayReflexRoutes } from "./http/routes/friday-reflex-routes.js";
 export type { FridayReflexRoutesDeps } from "./http/routes/friday-reflex-routes.js";
 export { createFridayCrossBorderPackRoutes } from "./http/routes/friday-cross-border-pack-routes.js";

--- a/src/api/mission-spine/friday-memory-spine-dispatch-adapter.ts
+++ b/src/api/mission-spine/friday-memory-spine-dispatch-adapter.ts
@@ -1,0 +1,144 @@
+import { FridayDomainError } from "#errors";
+
+import type { FridayMemorySpineDispatchService } from "../http/routes/friday-memory-spine-routes.js";
+import {
+  createFridayRustHubAgentRunSealedClient,
+  type CreateFridayRustHubAgentRunSealedClientOptions,
+  type FridayRustHubAgentRunSealedClient,
+  type FridayRustHubMemoryDecisionRequest,
+  type FridayRustHubMemoryDecisionResult,
+} from "./friday-rust-hub-agent-run-ws-sealed-client.js";
+import type { FridayRustAgentRunWsClientX25519SecretResolver } from "./friday-rust-hub-agent-run-ws-client-x25519-secret.js";
+
+/**
+ * (Lane M) The bootstrap-side ADAPTER that makes the ORGANIC `POST /v1/memory-spine/decide` route
+ * CALLABLE — by satisfying the route's `deps.dispatch` ({@link FridayMemorySpineDispatchService}).
+ * Until something provides that dispatcher, the POST route is PERMANENTLY 503
+ * (`MEMORY_SPINE_DISPATCH_UNAVAILABLE`); this adapter is what an operator flag wires in to flip it
+ * from honest-unavailable to live. It is the DIRECT MIRROR of the mission-spine dispatch adapter
+ * ({@link createFridayMissionSpineDispatchAdapter}) — same construction seam, same lazy per-call
+ * build, same fail-closed contract — delegating to the SAME low-level sealed client's `decideMemory`.
+ *
+ * ## Construction seam (load-bearing for flag-OFF byte-identical)
+ * SIDE-EFFECT-FREE: captures host/port/timeout + the injectable resolver/createClient seams only. It
+ * resolves NO secret and constructs NO underlying client at construction time — that happens LAZILY,
+ * INSIDE the method, so a flag-ON-but-unprovisioned host FAILS CLOSED (503) per call rather than
+ * crashing boot. When the route flag is OFF this adapter is never constructed at all and the route's
+ * `dispatch` stays unset (null) → byte-identical to today.
+ *
+ * ## Fail-closed contract (never a fake success)
+ * - The X25519 secret resolver returns `null` ⇒ this throws a typed 503 BEFORE any socket is opened.
+ * - The underlying client constructor throws (malformed secret) ⇒ caught and surfaced as a typed 503.
+ * - The underlying round-trip rejects (connect error / closed session / timeout / wrong inbound kind /
+ *   the server's `Error` envelope / unparseable result) ⇒ its `FridayDomainError` (503) surfaces
+ *   UNCHANGED; any non-domain throw is wrapped as a typed 503. A `status:"blocked"` from the Hub is a
+ *   SUCCESSFUL round-trip of a refusal (resolved, not thrown) — passed through verbatim, never coerced.
+ *
+ * ## Truth labels (read before trusting this)
+ * - `rust_wired` ceiling: confers NO v1 GO. End-to-end Memory-confirmation closure ALSO needs the
+ *   SERVER flag `FRIDAY_MEMORY_CONFIRM` (the merged Rust arm is DEFAULT-OFF) + `FRIDAY_RUN_LOOP_
+ *   MEMORY_EXTRACTION` (to produce candidates) + a deploy (operator-gated). This adapter only makes
+ *   the TS route callable.
+ */
+
+/**
+ * Factory seam for the underlying sealed client. Defaults to the real
+ * {@link createFridayRustHubAgentRunSealedClient}; tests inject a fake to delegate/fail-closed
+ * WITHOUT a socket (and without re-proving the already-proven interop).
+ */
+export type CreateMemorySpineSealedClientFn = (
+  options: CreateFridayRustHubAgentRunSealedClientOptions,
+) => FridayRustHubAgentRunSealedClient;
+
+export interface CreateFridayMemorySpineDispatchAdapterOptions {
+  /** Loopback host for the Rust agent-run WS server. Defaults to `127.0.0.1` (in the client). */
+  readonly host?: string;
+  /** Port the Rust agent-run WS server listens on (the SAME server the agent-run path dials). */
+  readonly port: number;
+  /** Bounded await (ms) for one memory-decision round-trip before failing closed. */
+  readonly timeoutMs?: number;
+  /**
+   * SecureStore resolver for the sealed WS client's X25519 SECRET — the SAME ECDH-model resolver the
+   * agent-run + mission-spine paths use. A `null`/short resolve fails closed → no WS call, today's
+   * 503. Tests inject a fixture secret. NEVER logs it.
+   */
+  readonly secretResolver: FridayRustAgentRunWsClientX25519SecretResolver;
+  /**
+   * Injectable factory for the underlying sealed client (test seam). Default = the real sealed client.
+   * Constructed LAZILY per-call so this factory itself is side-effect-free.
+   */
+  readonly createClient?: CreateMemorySpineSealedClientFn;
+}
+
+function unavailable(message: string): FridayDomainError {
+  return new FridayDomainError("MEMORY_SPINE_DISPATCH_RUST_UNAVAILABLE", message, {
+    httpStatus: 503,
+    details: {
+      surface: "service:memory_spine_dispatch_adapter",
+      bridge: "rust_wired",
+      proofOnly: true,
+      proofReady: false,
+    },
+  });
+}
+
+/**
+ * Build the memory-spine dispatch ADAPTER the bootstrap injects into the memory-spine route's
+ * `dispatch` when the operator flag is on. SIDE-EFFECT-FREE: captures host/port/timeout +
+ * resolver/createClient seams only; resolves no secret and opens no socket until the route actually
+ * calls `decideMemory` on a real request.
+ */
+export function createFridayMemorySpineDispatchAdapter(
+  options: CreateFridayMemorySpineDispatchAdapterOptions,
+): FridayMemorySpineDispatchService {
+  const { host, port, timeoutMs } = options;
+  const createClient = options.createClient ?? createFridayRustHubAgentRunSealedClient;
+  const secretResolver = options.secretResolver;
+
+  /**
+   * Resolve the X25519 secret + construct the underlying sealed client. Fail-closed (503): a
+   * `null`/short resolve → no client; a constructor throw (non-32-byte secret) → mapped to 503.
+   */
+  function buildClient(): FridayRustHubAgentRunSealedClient {
+    const clientSecret = secretResolver();
+    if (!clientSecret) {
+      throw unavailable("Memory-spine dispatch could not resolve the sealed-WS client secret.");
+    }
+    try {
+      return createClient({
+        ...(host !== undefined ? { host } : {}),
+        port,
+        clientSecret,
+        ...(timeoutMs !== undefined ? { timeoutMs } : {}),
+      });
+    } catch {
+      throw unavailable("Memory-spine dispatch could not construct the sealed-WS client.");
+    }
+  }
+
+  return {
+    async decideMemory(
+      request: FridayRustHubMemoryDecisionRequest,
+    ): Promise<FridayRustHubMemoryDecisionResult> {
+      const client = buildClient();
+      try {
+        return await client.decideMemory(request);
+      } catch (error) {
+        throw error instanceof FridayDomainError
+          ? error
+          : unavailable("Memory-spine decision dispatch failed.");
+      }
+    },
+  };
+}
+
+/**
+ * Parse the Rust agent-run WS port from a raw env string — REPLICATES `readMissionSpineRustWsPort`
+ * EXACTLY so the memory-spine adapter dials the SAME port as the agent-run / mission-spine paths:
+ * absent/blank/non-finite/negative ⇒ `0` (with the flag off this port is never dialed).
+ */
+export function readMemorySpineRustWsPort(raw: string | undefined): number {
+  if (!raw) return 0;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : 0;
+}

--- a/src/api/mission-spine/friday-rust-hub-agent-run-ws-sealed-client.ts
+++ b/src/api/mission-spine/friday-rust-hub-agent-run-ws-sealed-client.ts
@@ -401,6 +401,17 @@ export interface FridayRustHubAgentRunSealedClient {
   transitionWorkItem(
     request: FridayRustHubWorkItemStatusRequest,
   ): Promise<FridayRustHubWorkItemStatusResult>;
+  /**
+   * (Lane M) Apply the OWNER's explicit confirm/reject to ONE pending memory candidate over a
+   * sealed session — `Message::MemoryDecisionRequest`. PURE Hub `&Db` mutation (NO model/provider
+   * call). Awaits the FIRST `MemoryDecisionResult`; fails closed on any other inbound (including the
+   * server's `Error` envelope). The `status`/`recallable` here are the Hub's honest outcome — a
+   * `status:"blocked"` (scope mismatch / unknown / terminal / invalid decision) is a SUCCESSFUL
+   * round-trip of a refusal, NOT a transport failure, and surfaces as a parsed result.
+   */
+  decideMemory(
+    request: FridayRustHubMemoryDecisionRequest,
+  ): Promise<FridayRustHubMemoryDecisionResult>;
 }
 
 /** (A3 courier) A resume relay: the run to resume + the operator's OPAQUE signed approval blob. */
@@ -512,6 +523,45 @@ export interface FridayRustHubWorkItemStatusResult {
   /** COUNT of persisted proof receipts (never the raw receipt refs themselves). */
   readonly proofReceiptCount: number;
   readonly updatedAtMs: number;
+}
+
+// ─── (Lane M) Memory-confirmation loop terminal mutation request/result ──────
+//
+// The merged Rust arm (#753) wired an OWNER-authed memory decision into the live
+// `hub_agent_run_server` behind a SERVER flag (`FRIDAY_MEMORY_CONFIRM`, DEFAULT-OFF):
+// an inbound `Message::MemoryDecisionRequest { request: MemoryDecisionRequestWire }`
+// applies the OWNER's explicit confirm/reject to ONE pending memory candidate (a
+// confirm makes it durable/recallable; a reject is terminal) and replies with a
+// `Message::MemoryDecisionResult { result: MemoryDecisionResultWire }`. This is a PURE
+// `&Db` mutation — NO provider/model call, ZERO token_ledger rows. Like the
+// mission-spine arms, the wire carries NO per-request `auth_proof`/`forwarded_principal`
+// — the sealed session IS the channel auth (single-peer/single-owner SERVER invariant).
+// The decision is owner/namespace-scoped: it applies ONLY when `owner_principal` matches
+// the candidate's owning principal (the server fails closed — `status:"blocked"` — on a
+// scope mismatch / unknown / terminal / invalid decision).
+
+/** (Lane M) An OWNER memory confirm/reject decision — `MemoryDecisionRequestWire`. */
+export interface FridayRustHubMemoryDecisionRequest {
+  /** The candidate `memory_item` to decide on. */
+  readonly memoryId: string;
+  /** The owner principal asserting the decision (MUST match the candidate's owning principal). */
+  readonly ownerPrincipal: string;
+  /** The explicit decision — `"confirm"` (→ durable/recallable) or `"reject"` (→ terminal). */
+  readonly decision: "confirm" | "reject";
+}
+
+/** (Lane M) Refs-only memory decision result — `MemoryDecisionResultWire`. */
+export interface FridayRustHubMemoryDecisionResult {
+  readonly truthLabel: "rust_wired";
+  readonly memoryId: string;
+  /** Resulting lifecycle state token (`"candidate"` / `"confirmed"` / `"rejected"` / `"unknown"`). */
+  readonly state: string;
+  /** Coarse outcome — `"confirmed"` / `"rejected"` / `"blocked"`. */
+  readonly status: string;
+  /** Coarse block reason — present ONLY when `status === "blocked"` (never echoes candidate content). */
+  readonly blocker?: string;
+  /** Whether the candidate is now recallable (durable `Confirmed`). */
+  readonly recallable: boolean;
 }
 
 function unavailable(message: string): FridayDomainError {
@@ -914,6 +964,32 @@ export function buildWorkItemStatusEnvelope(
 }
 
 /**
+ * (Lane M) Build the `MemoryDecisionRequest` inner message — the EXACT `MemoryDecisionRequestWire`
+ * shape. CRITICAL: `Message::MemoryDecisionRequest { request: MemoryDecisionRequestWire }` is a
+ * SINGLE-FIELD wrapper on an internally-tagged (`#[serde(tag = "kind")]`) `Message`, so serde
+ * NESTS the inner wire fields under a `request` key:
+ *   {"kind":"MemoryDecisionRequest","request":{ memory_id, owner_principal, decision }}
+ * A prior surface shipped a FLAT shape that failed `Envelope::decode` server-side (missing the
+ * `request` key) ⇒ 503 every call — the byte-exact `{kind,request}` nesting (cross-checked against
+ * the Rust round-trip test at friday-protocol lib.rs:2158-2172) is the regression guard. All three
+ * fields are REQUIRED (no Option / conditional-spread); the server parses `decision` fail-closed.
+ * EXPORTED + pure so the precise wire shape is unit-testable without a socket.
+ */
+export function buildMemoryDecisionEnvelope(
+  request: FridayRustHubMemoryDecisionRequest,
+): Record<string, unknown> {
+  const inner: Record<string, unknown> = {
+    memory_id: request.memoryId,
+    owner_principal: request.ownerPrincipal,
+    decision: request.decision,
+  };
+  return buildMissionEnvelope(`memory-decision-${request.memoryId}`, {
+    kind: "MemoryDecisionRequest",
+    request: inner,
+  });
+}
+
+/**
  * (Lane B) Parse a `MissionIntakeResult` inbound into the refs-only TS result. Returns `undefined`
  * (caller fails closed) when a REQUIRED ref is missing/ill-typed. The optional refs are surfaced
  * only when present (absent ⇒ omitted, never fabricated). EXPORTED + pure for socket-free testing.
@@ -1058,6 +1134,41 @@ export function parseWorkItemStatusResult(
     reason,
     proofReceiptCount,
     updatedAtMs,
+  };
+}
+
+/**
+ * (Lane M) Parse a `MemoryDecisionResult` inbound into the refs-only TS result. Returns `undefined`
+ * (caller fails closed 503) when a REQUIRED ref is missing/ill-typed. `recallable` is a REQUIRED
+ * boolean and `false` is a VALID value (a rejected/blocked candidate) — checked with an explicit
+ * `typeof === "boolean"`, NEVER a truthy test (mirrors `created_or_ready`). `blocker` is
+ * `skip_serializing_if Option::is_none` Rust-side ⇒ OMITTED from the wire when absent; surfaced
+ * only when present, never fabricated. EXPORTED + pure for socket-free testing.
+ */
+export function parseMemoryDecisionResult(
+  fields: Record<string, unknown>,
+): FridayRustHubMemoryDecisionResult | undefined {
+  // The refs live NESTED under `result` (single-field wrapper); unwrap fail-closed.
+  const r = unwrapResult(fields);
+  if (r === undefined) {
+    return undefined;
+  }
+  const memoryId = asString(r.memory_id);
+  const state = asString(r.state);
+  const status = asString(r.status);
+  const recallable = r.recallable;
+  if (!memoryId || !state || !status || typeof recallable !== "boolean") {
+    return undefined;
+  }
+  const blocker = asString(r.blocker);
+  return {
+    // No `truth_label` on `MemoryDecisionResultWire`; TS-side ceiling label (see intake parser).
+    truthLabel: "rust_wired",
+    memoryId,
+    state,
+    status,
+    recallable,
+    ...(blocker !== undefined ? { blocker } : {}),
   };
 }
 
@@ -1944,6 +2055,31 @@ export function createFridayRustHubAgentRunSealedClient(
         expectedKind: "WorkItemStatusResult",
         parse: parseWorkItemStatusResult,
         leg: "work-item-status",
+      });
+    },
+
+    decideMemory(
+      request: FridayRustHubMemoryDecisionRequest,
+    ): Promise<FridayRustHubMemoryDecisionResult> {
+      if (!request.memoryId || !request.ownerPrincipal) {
+        return Promise.reject(
+          unavailable("Sealed memory-spine client decision requires a memory id and owner principal."),
+        );
+      }
+      if (request.decision !== "confirm" && request.decision !== "reject") {
+        return Promise.reject(
+          unavailable("Sealed memory-spine client decision must be 'confirm' or 'reject'."),
+        );
+      }
+      return runMissionRoundTrip<FridayRustHubMemoryDecisionResult>({
+        host,
+        port,
+        timeoutMs,
+        keypair,
+        envelope: buildMemoryDecisionEnvelope(request),
+        expectedKind: "MemoryDecisionResult",
+        parse: parseMemoryDecisionResult,
+        leg: "memory-decision",
       });
     },
   };

--- a/src/api/runtime/friday-api-runtime.ts
+++ b/src/api/runtime/friday-api-runtime.ts
@@ -122,6 +122,10 @@ import {
   createFridayMissionSpineRoutes,
   type FridayMissionSpineRoutesDeps,
 } from "../http/routes/friday-mission-spine-routes.js";
+import {
+  createFridayMemorySpineRoutes,
+  type FridayMemorySpineRoutesDeps,
+} from "../http/routes/friday-memory-spine-routes.js";
 import { createFridayCrossBorderPackRoutes } from "../http/routes/friday-cross-border-pack-routes.js";
 import { createFridayAssetInventoryRoutes } from "../http/routes/friday-asset-inventory-routes.js";
 import { createFridayStudioRoutes } from "../http/routes/friday-studio-routes.js";
@@ -4008,6 +4012,18 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
     routes.register(route);
   }
 
+  // (Lane M) Memory-confirmation loop terminal route. ALWAYS registered (byte-additive); DEFAULT-OFF
+  // (dispatch null) ⇒ POST /v1/memory-spine/decide is honest-unavailable (503) until an operator
+  // wires the adapter AND flips the Rust `FRIDAY_MEMORY_CONFIRM` flag. Mirrors mission-spine above.
+  const memorySpineDeps: FridayMemorySpineRoutesDeps =
+    deps.memorySpine ?? {
+      dispatch: null,
+      dispatchDisabledReason: "memory spine confirmation dispatch deps not provided",
+    };
+  for (const route of createFridayMemorySpineRoutes(memorySpineDeps)) {
+    routes.register(route);
+  }
+
   // Register realtime routes
   for (const route of createFridayRealtimeRoutes({
     subscriptionService: subscriptions,
@@ -5304,6 +5320,7 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
     agentLoop: deps.agentLoop,
     uix: deps.uix,
     missionSpine: deps.missionSpine,
+    memorySpine: deps.memorySpine,
     system: deps.system,
     guideLens: deps.guideLens,
   };

--- a/src/api/runtime/friday-api-runtime.types.ts
+++ b/src/api/runtime/friday-api-runtime.types.ts
@@ -78,6 +78,7 @@ import type { FridaySystemRoutesDeps } from "../http/routes/friday-system-routes
 import type { FridayGuideLensRoutesDeps } from "../http/routes/friday-guide-lens-routes.js";
 import type { FridayUixRoutesDeps } from "../http/routes/friday-uix-routes.js";
 import type { FridayMissionSpineRoutesDeps } from "../http/routes/friday-mission-spine-routes.js";
+import type { FridayMemorySpineRoutesDeps } from "../http/routes/friday-memory-spine-routes.js";
 import type { FridayCrossBorderPackRoutesDeps } from "../http/routes/friday-cross-border-pack-routes.js";
 import type { FridayPackagingRoutesDeps } from "../http/routes/friday-packaging-routes.js";
 import type {
@@ -124,6 +125,8 @@ export interface FridayApiRuntime {
   agentLoop?: FridayAgentLoopRoutesDeps;
   uix?: FridayUixRoutesDeps;
   missionSpine?: FridayMissionSpineRoutesDeps;
+  /** (Lane M) Memory-confirmation loop terminal route surface. Always registered; DEFAULT-OFF (503). */
+  memorySpine?: FridayMemorySpineRoutesDeps;
   crossBorderPack?: FridayCrossBorderPackRoutesDeps;
   system?: FridaySystemRoutesDeps;
   guideLens?: FridayGuideLensRoutesDeps;
@@ -603,6 +606,13 @@ export interface CreateFridayApiRuntimeDeps {
    * snapshot as live proof.
    */
   missionSpine?: FridayMissionSpineRoutesDeps;
+  /**
+   * (Lane M) Memory-confirmation loop terminal route surface. The route is ALWAYS registered. When
+   * omitted (the DEFAULT), POST `/v1/memory-spine/decide` fails closed with
+   * `503 MEMORY_SPINE_DISPATCH_UNAVAILABLE` instead of driving a confirm/reject — the live path
+   * needs an operator to wire the adapter AND flip the Rust `FRIDAY_MEMORY_CONFIRM` flag.
+   */
+  memorySpine?: FridayMemorySpineRoutesDeps;
   /** Optional: cross-border operating pack route surface. */
   crossBorderPack?: FridayCrossBorderPackRoutesDeps;
   /**

--- a/src/security/friday-owner-session-channel-capability.ts
+++ b/src/security/friday-owner-session-channel-capability.ts
@@ -92,7 +92,13 @@ export type FridayPublicMutationOperation =
   // Mission/WorkItem transition.
   | "mission.spine.intake"
   | "mission.spine.lifecycle"
-  | "mission.spine.workitem.status";
+  | "mission.spine.workitem.status"
+  // Lane M — the memory-confirmation loop's terminal mutation driven over the
+  // sealed-WS dispatch arm (OWNER confirm/reject of ONE memory candidate). Public
+  // mutating route: refuse the synthetic public principal; only a bound owner can
+  // confirm/reject (and the Rust side ALSO scopes the decision to the candidate's
+  // owning principal).
+  | "memory.spine.decide";
 
 export type FridayBoundPrincipalSource = "api" | "session" | "channel" | "satellite";
 

--- a/test/contracts/api/__snapshots__/friday-api-route-contract.snapshot.test.ts.snap
+++ b/test/contracts/api/__snapshots__/friday-api-route-contract.snapshot.test.ts.snap
@@ -3,14 +3,14 @@
 exports[`MECHANISM-4 — API Route Contract (Snapshot) > Phase 14.5A WP-001: every public mutating route maps to an accepted gate family 1`] = `
 {
   "classified": {
-    "bound_principal": 62,
+    "bound_principal": 63,
     "channel_signature": 4,
     "hmac_or_bearer_opt_in": 1,
     "public_low_risk": 2,
     "rate_limited_pending": 4,
     "unclassified": 251,
   },
-  "total_public_mutating": 324,
+  "total_public_mutating": 325,
   "unclassified_sample_max_5": [
     "capabilities.acquisition.runs.create",
     "capabilities.acquisition.runs.approve",
@@ -21,7 +21,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > Phase 14.5A WP-001: eve
 }
 `;
 
-exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures route count to detect accidental additions/removals 1`] = `423`;
+exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures route count to detect accidental additions/removals 1`] = `424`;
 
 exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route surface as a stable contract 1`] = `
 [
@@ -1839,6 +1839,16 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
     "authKind": "public",
     "index": 181,
     "method": "POST",
+    "operationId": "memory.spine.decide.apply",
+    "path": "/v1/memory-spine/decide",
+    "rateLimitPolicyId": null,
+    "roles": [],
+    "scopes": [],
+  },
+  {
+    "authKind": "public",
+    "index": 182,
+    "method": "POST",
     "operationId": "realtime.subscribe",
     "path": "/v1/realtime/subscriptions",
     "rateLimitPolicyId": "realtime.subscribe",
@@ -1847,7 +1857,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 182,
+    "index": 183,
     "method": "POST",
     "operationId": "realtime.pull",
     "path": "/v1/realtime/pull",
@@ -1857,7 +1867,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 183,
+    "index": 184,
     "method": "POST",
     "operationId": "realtime.ack",
     "path": "/v1/realtime/ack",
@@ -1867,7 +1877,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 184,
+    "index": 185,
     "method": "GET",
     "operationId": "providers.usage.get",
     "path": "/v1/providers/usage",
@@ -1877,7 +1887,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 185,
+    "index": 186,
     "method": "GET",
     "operationId": "providers.budget.get",
     "path": "/v1/providers/budget",
@@ -1887,7 +1897,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 186,
+    "index": 187,
     "method": "PUT",
     "operationId": "providers.budget.set",
     "path": "/v1/providers/budget",
@@ -1897,7 +1907,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 187,
+    "index": 188,
     "method": "GET",
     "operationId": "providers.templates.list",
     "path": "/v1/providers/templates",
@@ -1907,7 +1917,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 188,
+    "index": 189,
     "method": "GET",
     "operationId": "providers.templates.get",
     "path": "/v1/providers/templates/:templateId",
@@ -1917,7 +1927,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 189,
+    "index": 190,
     "method": "GET",
     "operationId": "providers.list",
     "path": "/v1/providers",
@@ -1927,7 +1937,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 190,
+    "index": 191,
     "method": "GET",
     "operationId": "providers.health.list",
     "path": "/v1/providers/health",
@@ -1937,7 +1947,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 191,
+    "index": 192,
     "method": "GET",
     "operationId": "providers.capability.health.list",
     "path": "/v1/providers/capability-health",
@@ -1947,7 +1957,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 192,
+    "index": 193,
     "method": "POST",
     "operationId": "capabilities.doctor",
     "path": "/v1/capabilities/doctor",
@@ -1957,7 +1967,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 193,
+    "index": 194,
     "method": "GET",
     "operationId": "providers.get",
     "path": "/v1/providers/:providerId",
@@ -1967,7 +1977,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 194,
+    "index": 195,
     "method": "POST",
     "operationId": "providers.create",
     "path": "/v1/providers",
@@ -1977,7 +1987,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 195,
+    "index": 196,
     "method": "PATCH",
     "operationId": "providers.update",
     "path": "/v1/providers/:providerId",
@@ -1987,7 +1997,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 196,
+    "index": 197,
     "method": "DELETE",
     "operationId": "providers.delete",
     "path": "/v1/providers/:providerId",
@@ -1997,7 +2007,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 197,
+    "index": 198,
     "method": "POST",
     "operationId": "providers.validate",
     "path": "/v1/providers/:providerId/validate",
@@ -2007,7 +2017,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 198,
+    "index": 199,
     "method": "GET",
     "operationId": "providers.doctor",
     "path": "/v1/providers/:providerId/doctor",
@@ -2017,7 +2027,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 199,
+    "index": 200,
     "method": "GET",
     "operationId": "providers.routing.explain",
     "path": "/v1/providers/routing/explain",
@@ -2027,7 +2037,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 200,
+    "index": 201,
     "method": "POST",
     "operationId": "providers.routing.pin",
     "path": "/v1/providers/routing/pin",
@@ -2037,7 +2047,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 201,
+    "index": 202,
     "method": "POST",
     "operationId": "providers.routing.penalty.clear",
     "path": "/v1/providers/routing/penalties/clear",
@@ -2047,7 +2057,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 202,
+    "index": 203,
     "method": "GET",
     "operationId": "providers.auth.profiles.list",
     "path": "/v1/providers/:providerId/auth-profiles",
@@ -2057,7 +2067,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 203,
+    "index": 204,
     "method": "POST",
     "operationId": "providers.auth.profiles.activate",
     "path": "/v1/providers/:providerId/auth-profiles/:profileKey/activate",
@@ -2067,7 +2077,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 204,
+    "index": 205,
     "method": "GET",
     "operationId": "providers.routing.get",
     "path": "/v1/model-routing",
@@ -2077,7 +2087,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 205,
+    "index": 206,
     "method": "PUT",
     "operationId": "providers.routing.set",
     "path": "/v1/model-routing",
@@ -2087,7 +2097,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 206,
+    "index": 207,
     "method": "POST",
     "operationId": "auth.oauth.anthropic.initiate",
     "path": "/v1/auth/oauth/anthropic/initiate",
@@ -2097,7 +2107,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 207,
+    "index": 208,
     "method": "POST",
     "operationId": "auth.oauth.anthropic.callback",
     "path": "/v1/auth/oauth/anthropic/callback",
@@ -2107,7 +2117,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 208,
+    "index": 209,
     "method": "POST",
     "operationId": "auth.oauth.openai.codex.device.initiate",
     "path": "/v1/auth/oauth/openai-codex/device/initiate",
@@ -2117,7 +2127,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 209,
+    "index": 210,
     "method": "POST",
     "operationId": "auth.oauth.openai.codex.device.complete",
     "path": "/v1/auth/oauth/openai-codex/device/complete",
@@ -2127,7 +2137,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 210,
+    "index": 211,
     "method": "POST",
     "operationId": "media.understanding.doctor",
     "path": "/v1/media-understanding/doctor",
@@ -2137,7 +2147,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 211,
+    "index": 212,
     "method": "POST",
     "operationId": "media.understanding.analyze",
     "path": "/v1/media-understanding/analyze",
@@ -2147,7 +2157,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 212,
+    "index": 213,
     "method": "GET",
     "operationId": "task.workflows.boundaries.list",
     "path": "/v1/task-workflows/boundaries",
@@ -2157,7 +2167,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 213,
+    "index": 214,
     "method": "GET",
     "operationId": "task.workflows.gates.list",
     "path": "/v1/task-workflows/gates",
@@ -2167,7 +2177,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 214,
+    "index": 215,
     "method": "POST",
     "operationId": "task.workflows.preview",
     "path": "/v1/task-workflows/preview",
@@ -2177,7 +2187,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 215,
+    "index": 216,
     "method": "POST",
     "operationId": "task.workflows.create",
     "path": "/v1/task-workflows",
@@ -2187,7 +2197,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 216,
+    "index": 217,
     "method": "GET",
     "operationId": "task.workflows.list",
     "path": "/v1/task-workflows",
@@ -2197,7 +2207,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 217,
+    "index": 218,
     "method": "GET",
     "operationId": "task.workflows.get",
     "path": "/v1/task-workflows/:workflowId",
@@ -2207,7 +2217,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 218,
+    "index": 219,
     "method": "POST",
     "operationId": "task.workflows.revise",
     "path": "/v1/task-workflows/:workflowId/revisions",
@@ -2217,7 +2227,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 219,
+    "index": 220,
     "method": "GET",
     "operationId": "task.workflows.revisions.list",
     "path": "/v1/task-workflows/:workflowId/revisions",
@@ -2227,7 +2237,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 220,
+    "index": 221,
     "method": "POST",
     "operationId": "task.workflows.claims.create",
     "path": "/v1/task-workflows/:workflowId/claims",
@@ -2237,7 +2247,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 221,
+    "index": 222,
     "method": "GET",
     "operationId": "task.workflows.claims.list",
     "path": "/v1/task-workflows/:workflowId/claims",
@@ -2247,7 +2257,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 222,
+    "index": 223,
     "method": "GET",
     "operationId": "task.workflows.claims.get",
     "path": "/v1/task-workflows/:workflowId/claims/:claimId",
@@ -2257,7 +2267,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 223,
+    "index": 224,
     "method": "POST",
     "operationId": "task.workflows.claims.evidence.attach",
     "path": "/v1/task-workflows/:workflowId/claims/:claimId/evidence-ref",
@@ -2267,7 +2277,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 224,
+    "index": 225,
     "method": "GET",
     "operationId": "task.workflows.claims.evidence.list",
     "path": "/v1/task-workflows/:workflowId/claims/:claimId/evidence-refs",
@@ -2277,7 +2287,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 225,
+    "index": 226,
     "method": "POST",
     "operationId": "task.workflows.claims.verify",
     "path": "/v1/task-workflows/:workflowId/claims/:claimId/verify",
@@ -2287,7 +2297,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 226,
+    "index": 227,
     "method": "POST",
     "operationId": "task.workflows.claims.block",
     "path": "/v1/task-workflows/:workflowId/claims/:claimId/block",
@@ -2297,7 +2307,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 227,
+    "index": 228,
     "method": "POST",
     "operationId": "task.workflows.closeout",
     "path": "/v1/task-workflows/:workflowId/closeout",
@@ -2307,7 +2317,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 228,
+    "index": 229,
     "method": "POST",
     "operationId": "task.workflows.lanes.executor.open",
     "path": "/v1/task-workflows/:workflowId/lanes/executor",
@@ -2317,7 +2327,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 229,
+    "index": 230,
     "method": "POST",
     "operationId": "task.workflows.lanes.verifier.open",
     "path": "/v1/task-workflows/:workflowId/lanes/verifier",
@@ -2327,7 +2337,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 230,
+    "index": 231,
     "method": "POST",
     "operationId": "task.workflows.lanes.complete",
     "path": "/v1/task-workflows/:workflowId/lanes/:laneId/complete",
@@ -2337,7 +2347,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 231,
+    "index": 232,
     "method": "POST",
     "operationId": "task.workflows.lanes.verdict",
     "path": "/v1/task-workflows/:workflowId/lanes/:laneId/verdict",
@@ -2347,7 +2357,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 232,
+    "index": 233,
     "method": "GET",
     "operationId": "task.workflows.lanes.list",
     "path": "/v1/task-workflows/:workflowId/lanes",
@@ -2357,7 +2367,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 233,
+    "index": 234,
     "method": "GET",
     "operationId": "task.workflows.lanes.get",
     "path": "/v1/task-workflows/:workflowId/lanes/:laneId",
@@ -2367,7 +2377,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 234,
+    "index": 235,
     "method": "POST",
     "operationId": "task.workflows.lanes.cli.handoff.record",
     "path": "/v1/task-workflows/:workflowId/lanes/:laneId/cli-handoffs",
@@ -2377,7 +2387,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 235,
+    "index": 236,
     "method": "GET",
     "operationId": "task.workflows.lanes.cli.handoffs.list",
     "path": "/v1/task-workflows/:workflowId/lanes/:laneId/cli-handoffs",
@@ -2387,7 +2397,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 236,
+    "index": 237,
     "method": "GET",
     "operationId": "task.workflows.cli.handoffs.list",
     "path": "/v1/task-workflows/:workflowId/cli-handoffs",
@@ -2397,7 +2407,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 237,
+    "index": 238,
     "method": "GET",
     "operationId": "task.workflows.supervisor.read",
     "path": "/v1/task-workflows/:workflowId/supervisor",
@@ -2407,7 +2417,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 238,
+    "index": 239,
     "method": "POST",
     "operationId": "task.workflows.channel.command.issue",
     "path": "/v1/task-workflows/:workflowId/channel-commands",
@@ -2417,7 +2427,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 239,
+    "index": 240,
     "method": "GET",
     "operationId": "task.workflows.channel.command.list",
     "path": "/v1/task-workflows/:workflowId/channel-commands",
@@ -2427,7 +2437,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 240,
+    "index": 241,
     "method": "POST",
     "operationId": "task.workflows.channel.command.confirm",
     "path": "/v1/task-workflows/:workflowId/channel-commands/confirm",
@@ -2437,7 +2447,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 241,
+    "index": 242,
     "method": "GET",
     "operationId": "task.workflows.evidence.explorer.query",
     "path": "/v1/task-workflows/evidence",
@@ -2447,7 +2457,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 242,
+    "index": 243,
     "method": "GET",
     "operationId": "task.workflows.evidence.explorer.raw",
     "path": "/v1/task-workflows/evidence/:evidenceRefId/raw",
@@ -2457,7 +2467,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 243,
+    "index": 244,
     "method": "POST",
     "operationId": "skills.social.import",
     "path": "/v1/skills/social-import",
@@ -2467,7 +2477,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 244,
+    "index": 245,
     "method": "GET",
     "operationId": "setup.status",
     "path": "/v1/setup/status",
@@ -2477,7 +2487,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 245,
+    "index": 246,
     "method": "POST",
     "operationId": "providers.detect",
     "path": "/v1/providers/detect",
@@ -2487,7 +2497,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 246,
+    "index": 247,
     "method": "GET",
     "operationId": "setup.network.get",
     "path": "/v1/setup/network",
@@ -2497,7 +2507,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 247,
+    "index": 248,
     "method": "POST",
     "operationId": "setup.network.save",
     "path": "/v1/setup/network",
@@ -2507,7 +2517,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 248,
+    "index": 249,
     "method": "POST",
     "operationId": "setup.channels.feishu.registration.begin",
     "path": "/v1/setup/channels/feishu/registration/begin",
@@ -2517,7 +2527,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 249,
+    "index": 250,
     "method": "POST",
     "operationId": "setup.channels.feishu.registration.poll",
     "path": "/v1/setup/channels/feishu/registration/poll",
@@ -2527,7 +2537,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 250,
+    "index": 251,
     "method": "POST",
     "operationId": "setup.channels.telegram.verification.begin",
     "path": "/v1/setup/channels/telegram/verification/begin",
@@ -2537,7 +2547,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 251,
+    "index": 252,
     "method": "POST",
     "operationId": "setup.channels.telegram.verification.poll",
     "path": "/v1/setup/channels/telegram/verification/poll",
@@ -2547,7 +2557,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 252,
+    "index": 253,
     "method": "POST",
     "operationId": "setup.channels.discord.verification.begin",
     "path": "/v1/setup/channels/discord/verification/begin",
@@ -2557,7 +2567,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 253,
+    "index": 254,
     "method": "POST",
     "operationId": "setup.channels.discord.verification.complete",
     "path": "/v1/setup/channels/discord/verification/complete",
@@ -2567,7 +2577,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 254,
+    "index": 255,
     "method": "POST",
     "operationId": "setup.channels.test",
     "path": "/v1/setup/channels/test",
@@ -2577,7 +2587,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 255,
+    "index": 256,
     "method": "POST",
     "operationId": "setup.channels.save",
     "path": "/v1/setup/channels",
@@ -2587,7 +2597,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 256,
+    "index": 257,
     "method": "POST",
     "operationId": "setup.complete",
     "path": "/v1/setup/complete",
@@ -2597,7 +2607,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 257,
+    "index": 258,
     "method": "GET",
     "operationId": "skills.list",
     "path": "/v1/skills",
@@ -2607,7 +2617,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 258,
+    "index": 259,
     "method": "GET",
     "operationId": "skills.catalog.list",
     "path": "/v1/skills/catalog",
@@ -2617,7 +2627,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 259,
+    "index": 260,
     "method": "GET",
     "operationId": "skills.get",
     "path": "/v1/skills/:skillId",
@@ -2627,7 +2637,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 260,
+    "index": 261,
     "method": "POST",
     "operationId": "skills.install",
     "path": "/v1/skills/install",
@@ -2637,7 +2647,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 261,
+    "index": 262,
     "method": "POST",
     "operationId": "skills.update",
     "path": "/v1/skills/:skillId/update",
@@ -2647,7 +2657,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 262,
+    "index": 263,
     "method": "DELETE",
     "operationId": "skills.delete",
     "path": "/v1/skills/:skillId",
@@ -2657,7 +2667,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 263,
+    "index": 264,
     "method": "POST",
     "operationId": "skills.manifest.validate",
     "path": "/v1/skills/validate-manifest",
@@ -2667,7 +2677,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 264,
+    "index": 265,
     "method": "POST",
     "operationId": "skills.verify",
     "path": "/v1/skills/:skillId/verify",
@@ -2677,7 +2687,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 265,
+    "index": 266,
     "method": "POST",
     "operationId": "skills.upgrade.analyze",
     "path": "/v1/skills/:skillId/upgrade/analyze",
@@ -2687,7 +2697,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 266,
+    "index": 267,
     "method": "POST",
     "operationId": "skills.upgrade.decide",
     "path": "/v1/skills/:skillId/upgrade/decide",
@@ -2697,7 +2707,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 267,
+    "index": 268,
     "method": "POST",
     "operationId": "skills.run",
     "path": "/v1/skills/:skillId/run",
@@ -2707,7 +2717,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 268,
+    "index": 269,
     "method": "POST",
     "operationId": "skills.generator.sessions.create",
     "path": "/v1/skills/generator/sessions",
@@ -2717,7 +2727,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 269,
+    "index": 270,
     "method": "GET",
     "operationId": "skills.generator.sessions.get",
     "path": "/v1/skills/generator/sessions/:sessionId",
@@ -2727,7 +2737,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 270,
+    "index": 271,
     "method": "POST",
     "operationId": "skills.generator.sessions.messages.create",
     "path": "/v1/skills/generator/sessions/:sessionId/messages",
@@ -2737,7 +2747,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 271,
+    "index": 272,
     "method": "POST",
     "operationId": "skills.generator.sessions.generate",
     "path": "/v1/skills/generator/sessions/:sessionId/generate",
@@ -2747,7 +2757,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 272,
+    "index": 273,
     "method": "POST",
     "operationId": "skills.generator.sessions.test",
     "path": "/v1/skills/generator/sessions/:sessionId/test",
@@ -2757,7 +2767,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 273,
+    "index": 274,
     "method": "GET",
     "operationId": "skills.generator.sessions.evidence.get",
     "path": "/v1/skills/generator/sessions/:sessionId/evidence",
@@ -2767,7 +2777,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 274,
+    "index": 275,
     "method": "POST",
     "operationId": "skills.generator.sessions.approve",
     "path": "/v1/skills/generator/sessions/:sessionId/approve",
@@ -2777,7 +2787,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 275,
+    "index": 276,
     "method": "DELETE",
     "operationId": "skills.generator.sessions.cancel",
     "path": "/v1/skills/generator/sessions/:sessionId",
@@ -2787,7 +2797,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 276,
+    "index": 277,
     "method": "GET",
     "operationId": "skills.ui.get",
     "path": "/v1/skills/:skillId/ui",
@@ -2797,7 +2807,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 277,
+    "index": 278,
     "method": "POST",
     "operationId": "uix.intents.resolve",
     "path": "/v1/uix/intents/resolve",
@@ -2807,7 +2817,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 278,
+    "index": 279,
     "method": "GET",
     "operationId": "uix.templates.list",
     "path": "/v1/uix/templates",
@@ -2817,7 +2827,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 279,
+    "index": 280,
     "method": "GET",
     "operationId": "uix.home.snapshot.get",
     "path": "/v1/uix/home-snapshot",
@@ -2827,7 +2837,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 280,
+    "index": 281,
     "method": "GET",
     "operationId": "uix.assistant.inbox.snapshot.get",
     "path": "/v1/uix/assistant-inbox-snapshot",
@@ -2837,7 +2847,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 281,
+    "index": 282,
     "method": "GET",
     "operationId": "uix.diagnostics.get",
     "path": "/v1/uix/diagnostics",
@@ -2847,7 +2857,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 282,
+    "index": 283,
     "method": "GET",
     "operationId": "uix.preferences.list",
     "path": "/v1/uix/preferences",
@@ -2857,7 +2867,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 283,
+    "index": 284,
     "method": "PUT",
     "operationId": "uix.preferences.update",
     "path": "/v1/uix/preferences",
@@ -2867,7 +2877,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 284,
+    "index": 285,
     "method": "DELETE",
     "operationId": "uix.preferences.delete",
     "path": "/v1/uix/preferences/:preferenceId",
@@ -2877,7 +2887,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 285,
+    "index": 286,
     "method": "GET",
     "operationId": "uix.persona.get",
     "path": "/v1/uix/persona",
@@ -2887,7 +2897,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 286,
+    "index": 287,
     "method": "PUT",
     "operationId": "uix.persona.update",
     "path": "/v1/uix/persona",
@@ -2897,7 +2907,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 287,
+    "index": 288,
     "method": "POST",
     "operationId": "uix.templates.execute",
     "path": "/v1/uix/templates/:templateId/execute",
@@ -2907,7 +2917,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 288,
+    "index": 289,
     "method": "POST",
     "operationId": "uix.wizards.start",
     "path": "/v1/uix/wizards/:wizardId/start",
@@ -2917,7 +2927,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 289,
+    "index": 290,
     "method": "POST",
     "operationId": "uix.wizards.continue",
     "path": "/v1/uix/wizards/:wizardId/continue",
@@ -2927,7 +2937,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 290,
+    "index": 291,
     "method": "GET",
     "operationId": "uix.issues.list",
     "path": "/v1/uix/issues",
@@ -2937,7 +2947,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 291,
+    "index": 292,
     "method": "GET",
     "operationId": "uix.user.profile.get",
     "path": "/v1/uix/user-profile",
@@ -2947,7 +2957,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 292,
+    "index": 293,
     "method": "PUT",
     "operationId": "uix.user.profile.update",
     "path": "/v1/uix/user-profile",
@@ -2957,7 +2967,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 293,
+    "index": 294,
     "method": "POST",
     "operationId": "uix.investigate",
     "path": "/v1/uix/investigate",
@@ -2967,7 +2977,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 294,
+    "index": 295,
     "method": "GET",
     "operationId": "uix.learnedfacts.list",
     "path": "/v1/uix/learned-facts",
@@ -2977,7 +2987,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 295,
+    "index": 296,
     "method": "DELETE",
     "operationId": "uix.learnedfacts.clear",
     "path": "/v1/uix/learned-facts",
@@ -2987,7 +2997,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 296,
+    "index": 297,
     "method": "PATCH",
     "operationId": "uix.learnedfacts.update",
     "path": "/v1/uix/learned-facts/:factKey",
@@ -2997,7 +3007,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 297,
+    "index": 298,
     "method": "DELETE",
     "operationId": "uix.learnedfacts.delete",
     "path": "/v1/uix/learned-facts/:factKey",
@@ -3007,7 +3017,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 298,
+    "index": 299,
     "method": "GET",
     "operationId": "packs.cross.border.profile.get",
     "path": "/v1/packs/cross-border/profile",
@@ -3017,7 +3027,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 299,
+    "index": 300,
     "method": "PUT",
     "operationId": "packs.cross.border.profile.put",
     "path": "/v1/packs/cross-border/profile",
@@ -3027,7 +3037,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 300,
+    "index": 301,
     "method": "GET",
     "operationId": "packs.cross.border.snapshot.get",
     "path": "/v1/packs/cross-border/snapshot",
@@ -3037,7 +3047,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 301,
+    "index": 302,
     "method": "POST",
     "operationId": "packs.cross.border.import.post",
     "path": "/v1/packs/cross-border/import",
@@ -3047,7 +3057,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 302,
+    "index": 303,
     "method": "POST",
     "operationId": "packs.cross.border.workflow.presets.apply",
     "path": "/v1/packs/cross-border/workflow-presets/apply",
@@ -3057,7 +3067,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 303,
+    "index": 304,
     "method": "PATCH",
     "operationId": "packs.cross.border.workflow.presets.toggle",
     "path": "/v1/packs/cross-border/workflow-presets/:workflowId",
@@ -3067,7 +3077,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 304,
+    "index": 305,
     "method": "POST",
     "operationId": "packs.cross.border.run.evidence.capture",
     "path": "/v1/packs/cross-border/run-evidence",
@@ -3077,7 +3087,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 305,
+    "index": 306,
     "method": "PATCH",
     "operationId": "packs.cross.border.import.stale",
     "path": "/v1/packs/cross-border/imports/:importBatchId/stale",
@@ -3087,7 +3097,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 306,
+    "index": 307,
     "method": "POST",
     "operationId": "packs.cross.border.workflows.disable.all",
     "path": "/v1/packs/cross-border/workflows/disable-all",
@@ -3097,7 +3107,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 307,
+    "index": 308,
     "method": "GET",
     "operationId": "skills.converters.list",
     "path": "/v1/skills/converters",
@@ -3107,7 +3117,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 308,
+    "index": 309,
     "method": "POST",
     "operationId": "skills.convert",
     "path": "/v1/skills/convert",
@@ -3117,7 +3127,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 309,
+    "index": 310,
     "method": "POST",
     "operationId": "skills.import",
     "path": "/v1/skills/import",
@@ -3127,7 +3137,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 310,
+    "index": 311,
     "method": "POST",
     "operationId": "skills.pack",
     "path": "/v1/skills/pack",
@@ -3137,7 +3147,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 311,
+    "index": 312,
     "method": "POST",
     "operationId": "workflows.generator.sessions.create",
     "path": "/v1/workflows/generator/sessions",
@@ -3147,7 +3157,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 312,
+    "index": 313,
     "method": "GET",
     "operationId": "workflows.generator.sessions.get",
     "path": "/v1/workflows/generator/sessions/:sessionId",
@@ -3157,7 +3167,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 313,
+    "index": 314,
     "method": "POST",
     "operationId": "workflows.generator.sessions.messages.create",
     "path": "/v1/workflows/generator/sessions/:sessionId/messages",
@@ -3167,7 +3177,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 314,
+    "index": 315,
     "method": "POST",
     "operationId": "workflows.generator.sessions.generate",
     "path": "/v1/workflows/generator/sessions/:sessionId/generate",
@@ -3177,7 +3187,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 315,
+    "index": 316,
     "method": "GET",
     "operationId": "workflows.generator.sessions.evidence.get",
     "path": "/v1/workflows/generator/sessions/:sessionId/evidence",
@@ -3187,7 +3197,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 316,
+    "index": 317,
     "method": "POST",
     "operationId": "workflows.generator.sessions.approve",
     "path": "/v1/workflows/generator/sessions/:sessionId/approve",
@@ -3197,7 +3207,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 317,
+    "index": 318,
     "method": "DELETE",
     "operationId": "workflows.generator.sessions.cancel",
     "path": "/v1/workflows/generator/sessions/:sessionId",
@@ -3207,7 +3217,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 318,
+    "index": 319,
     "method": "GET",
     "operationId": "rules.bundles.list",
     "path": "/v1/rules/bundles",
@@ -3217,7 +3227,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 319,
+    "index": 320,
     "method": "GET",
     "operationId": "rules.bundles.get",
     "path": "/v1/rules/bundles/:bundleId",
@@ -3227,7 +3237,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 320,
+    "index": 321,
     "method": "POST",
     "operationId": "rules.bundles.create",
     "path": "/v1/rules/bundles",
@@ -3237,7 +3247,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 321,
+    "index": 322,
     "method": "PATCH",
     "operationId": "rules.bundles.update",
     "path": "/v1/rules/bundles/:bundleId",
@@ -3247,7 +3257,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 322,
+    "index": 323,
     "method": "GET",
     "operationId": "rules.bundles.versions.list",
     "path": "/v1/rules/bundles/:bundleId/versions",
@@ -3257,7 +3267,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 323,
+    "index": 324,
     "method": "GET",
     "operationId": "rules.list",
     "path": "/v1/rules/bundles/:bundleId/rules",
@@ -3267,7 +3277,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 324,
+    "index": 325,
     "method": "POST",
     "operationId": "rules.evaluate",
     "path": "/v1/rules/evaluate",
@@ -3277,7 +3287,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 325,
+    "index": 326,
     "method": "POST",
     "operationId": "rules.simulate",
     "path": "/v1/rules/simulate",
@@ -3287,7 +3297,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 326,
+    "index": 327,
     "method": "GET",
     "operationId": "rules.versions.list",
     "path": "/v1/rules/:ruleId/versions",
@@ -3297,7 +3307,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 327,
+    "index": 328,
     "method": "GET",
     "operationId": "rules.audit.log.list",
     "path": "/v1/rules/audit-log",
@@ -3307,7 +3317,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 328,
+    "index": 329,
     "method": "POST",
     "operationId": "node.runner.execute",
     "path": "/v1/node-runner/execute",
@@ -3317,7 +3327,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 329,
+    "index": 330,
     "method": "GET",
     "operationId": "node.runner.executions.get",
     "path": "/v1/node-runner/executions/:executionId",
@@ -3327,7 +3337,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 330,
+    "index": 331,
     "method": "GET",
     "operationId": "node.runner.executions.list",
     "path": "/v1/node-runner/executions",
@@ -3337,7 +3347,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 331,
+    "index": 332,
     "method": "POST",
     "operationId": "acceptance.run",
     "path": "/v1/acceptance/run",
@@ -3347,7 +3357,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 332,
+    "index": 333,
     "method": "GET",
     "operationId": "acceptance.results.get",
     "path": "/v1/acceptance/results/:resultId",
@@ -3357,7 +3367,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 333,
+    "index": 334,
     "method": "GET",
     "operationId": "acceptance.results.list",
     "path": "/v1/acceptance/results",
@@ -3367,7 +3377,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 334,
+    "index": 335,
     "method": "GET",
     "operationId": "acceptance.runs.get",
     "path": "/v1/acceptance/runs/:runId",
@@ -3377,7 +3387,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 335,
+    "index": 336,
     "method": "GET",
     "operationId": "acceptance.tests.list",
     "path": "/v1/acceptance/tests",
@@ -3387,7 +3397,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 336,
+    "index": 337,
     "method": "GET",
     "operationId": "acceptance.tests.get",
     "path": "/v1/acceptance/tests/:testId",
@@ -3397,7 +3407,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 337,
+    "index": 338,
     "method": "POST",
     "operationId": "acceptance.tests.create",
     "path": "/v1/acceptance/tests",
@@ -3407,7 +3417,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 338,
+    "index": 339,
     "method": "PUT",
     "operationId": "acceptance.tests.update",
     "path": "/v1/acceptance/tests/:testId",
@@ -3417,7 +3427,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 339,
+    "index": 340,
     "method": "DELETE",
     "operationId": "acceptance.tests.delete",
     "path": "/v1/acceptance/tests/:testId",
@@ -3427,7 +3437,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 340,
+    "index": 341,
     "method": "GET",
     "operationId": "acceptance.tests.versions.list",
     "path": "/v1/acceptance/tests/:testId/versions",
@@ -3437,7 +3447,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 341,
+    "index": 342,
     "method": "GET",
     "operationId": "acceptance.artifacts.history",
     "path": "/v1/acceptance/artifacts/history",
@@ -3447,7 +3457,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 342,
+    "index": 343,
     "method": "GET",
     "operationId": "retry.policies.list",
     "path": "/v1/retry/policies",
@@ -3457,7 +3467,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 343,
+    "index": 344,
     "method": "GET",
     "operationId": "retry.policies.get",
     "path": "/v1/retry/policies/:policyId",
@@ -3467,7 +3477,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 344,
+    "index": 345,
     "method": "POST",
     "operationId": "retry.policies.create",
     "path": "/v1/retry/policies",
@@ -3477,7 +3487,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 345,
+    "index": 346,
     "method": "PUT",
     "operationId": "retry.policies.update",
     "path": "/v1/retry/policies/:policyId",
@@ -3487,7 +3497,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 346,
+    "index": 347,
     "method": "DELETE",
     "operationId": "retry.policies.delete",
     "path": "/v1/retry/policies/:policyId",
@@ -3497,7 +3507,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 347,
+    "index": 348,
     "method": "POST",
     "operationId": "retry.classify",
     "path": "/v1/retry/classify",
@@ -3507,7 +3517,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 348,
+    "index": 349,
     "method": "POST",
     "operationId": "retry.decide",
     "path": "/v1/retry/decide",
@@ -3517,7 +3527,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 349,
+    "index": 350,
     "method": "GET",
     "operationId": "retry.traces.list",
     "path": "/v1/retry/traces",
@@ -3527,7 +3537,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 350,
+    "index": 351,
     "method": "GET",
     "operationId": "retry.traces.get",
     "path": "/v1/retry/traces/:traceId",
@@ -3537,7 +3547,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 351,
+    "index": 352,
     "method": "GET",
     "operationId": "retry.costs.summary",
     "path": "/v1/retry/costs",
@@ -3547,7 +3557,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 352,
+    "index": 353,
     "method": "GET",
     "operationId": "retry.escalations.list",
     "path": "/v1/retry/escalations",
@@ -3557,7 +3567,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 353,
+    "index": 354,
     "method": "POST",
     "operationId": "retry.escalations.acknowledge",
     "path": "/v1/retry/escalations/:escalationId/acknowledge",
@@ -3567,7 +3577,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 354,
+    "index": 355,
     "method": "GET",
     "operationId": "retry.circuit.breakers.list",
     "path": "/v1/retry/circuit-breakers",
@@ -3577,7 +3587,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 355,
+    "index": 356,
     "method": "GET",
     "operationId": "playbook.list",
     "path": "/v1/playbooks",
@@ -3587,7 +3597,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 356,
+    "index": 357,
     "method": "GET",
     "operationId": "playbook.get",
     "path": "/v1/playbooks/:playbookId",
@@ -3597,7 +3607,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 357,
+    "index": 358,
     "method": "POST",
     "operationId": "playbook.select",
     "path": "/v1/playbooks/select",
@@ -3607,7 +3617,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 358,
+    "index": 359,
     "method": "GET",
     "operationId": "playbook.candidates.list",
     "path": "/v1/playbooks/candidates",
@@ -3617,7 +3627,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 359,
+    "index": 360,
     "method": "POST",
     "operationId": "playbook.candidates.promote",
     "path": "/v1/playbooks/candidates/:candidateId/promote",
@@ -3627,7 +3637,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 360,
+    "index": 361,
     "method": "POST",
     "operationId": "playbook.rollback",
     "path": "/v1/playbooks/:playbookId/rollback",
@@ -3637,7 +3647,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 361,
+    "index": 362,
     "method": "GET",
     "operationId": "playbook.scores",
     "path": "/v1/playbooks/:playbookId/scores",
@@ -3647,7 +3657,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 362,
+    "index": 363,
     "method": "POST",
     "operationId": "memory.store",
     "path": "/v1/memory/store",
@@ -3657,7 +3667,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 363,
+    "index": 364,
     "method": "POST",
     "operationId": "memory.items.create",
     "path": "/v1/memory/items",
@@ -3667,7 +3677,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 364,
+    "index": 365,
     "method": "POST",
     "operationId": "memory.search",
     "path": "/v1/memory/search",
@@ -3677,7 +3687,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 365,
+    "index": 366,
     "method": "GET",
     "operationId": "memory.get",
     "path": "/v1/memory/items/:id",
@@ -3687,7 +3697,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 366,
+    "index": 367,
     "method": "GET",
     "operationId": "memory.list",
     "path": "/v1/memory/items",
@@ -3697,7 +3707,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 367,
+    "index": 368,
     "method": "DELETE",
     "operationId": "memory.delete",
     "path": "/v1/memory/items/:id",
@@ -3707,7 +3717,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 368,
+    "index": 369,
     "method": "POST",
     "operationId": "memory.prune",
     "path": "/v1/memory/prune",
@@ -3717,7 +3727,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 369,
+    "index": 370,
     "method": "GET",
     "operationId": "sessions.usage.get",
     "path": "/v1/sessions/:sessionKey/usage",
@@ -3727,7 +3737,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 370,
+    "index": 371,
     "method": "GET",
     "operationId": "sessions.usage.list",
     "path": "/v1/sessions/usage",
@@ -3737,7 +3747,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 371,
+    "index": 372,
     "method": "GET",
     "operationId": "sessions.list",
     "path": "/v1/sessions",
@@ -3747,7 +3757,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 372,
+    "index": 373,
     "method": "POST",
     "operationId": "sessions.create",
     "path": "/v1/sessions",
@@ -3757,7 +3767,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 373,
+    "index": 374,
     "method": "GET",
     "operationId": "sessions.get",
     "path": "/v1/sessions/:sessionKey",
@@ -3767,7 +3777,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 374,
+    "index": 375,
     "method": "DELETE",
     "operationId": "sessions.delete",
     "path": "/v1/sessions/:sessionKey",
@@ -3777,7 +3787,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 375,
+    "index": 376,
     "method": "POST",
     "operationId": "sessions.archive",
     "path": "/v1/sessions/:sessionKey/archive",
@@ -3787,7 +3797,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 376,
+    "index": 377,
     "method": "POST",
     "operationId": "sessions.reset",
     "path": "/v1/sessions/:sessionKey/reset",
@@ -3797,7 +3807,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 377,
+    "index": 378,
     "method": "POST",
     "operationId": "sessions.prune",
     "path": "/v1/sessions/prune",
@@ -3807,7 +3817,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 378,
+    "index": 379,
     "method": "POST",
     "operationId": "sessions.sweep",
     "path": "/v1/sessions/sweep",
@@ -3817,7 +3827,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 379,
+    "index": 380,
     "method": "POST",
     "operationId": "sessions.compact",
     "path": "/v1/sessions/:sessionKey/compact",
@@ -3827,7 +3837,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 380,
+    "index": 381,
     "method": "GET",
     "operationId": "sessions.messages.list",
     "path": "/v1/sessions/:sessionKey/messages",
@@ -3837,7 +3847,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 381,
+    "index": 382,
     "method": "GET",
     "operationId": "sessions.export",
     "path": "/v1/sessions/:sessionKey/export",
@@ -3847,7 +3857,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 382,
+    "index": 383,
     "method": "POST",
     "operationId": "sessions.messages.create",
     "path": "/v1/sessions/:sessionKey/messages",
@@ -3857,7 +3867,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 383,
+    "index": 384,
     "method": "POST",
     "operationId": "sessions.outbound.send",
     "path": "/v1/sessions/:sessionKey/outbound",
@@ -3867,7 +3877,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 384,
+    "index": 385,
     "method": "POST",
     "operationId": "sessions.run",
     "path": "/v1/sessions/:sessionKey/run",
@@ -3877,7 +3887,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 385,
+    "index": 386,
     "method": "GET",
     "operationId": "sessions.memory.namespace.get",
     "path": "/v1/sessions/:sessionKey/memory-namespace",
@@ -3887,7 +3897,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 386,
+    "index": 387,
     "method": "POST",
     "operationId": "sessions.forks.create",
     "path": "/v1/sessions/:sessionKey/fork",
@@ -3897,7 +3907,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 387,
+    "index": 388,
     "method": "GET",
     "operationId": "sessions.forks.list",
     "path": "/v1/sessions/:sessionKey/forks",
@@ -3907,7 +3917,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 388,
+    "index": 389,
     "method": "POST",
     "operationId": "sessions.forks.merge",
     "path": "/v1/sessions/:sessionKey/merge",
@@ -3917,7 +3927,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 389,
+    "index": 390,
     "method": "POST",
     "operationId": "sessions.memory.extract",
     "path": "/v1/sessions/:sessionKey/memory/extract",
@@ -3927,7 +3937,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 390,
+    "index": 391,
     "method": "POST",
     "operationId": "sessions.memory.remember",
     "path": "/v1/sessions/:sessionKey/memory/remember",
@@ -3937,7 +3947,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 391,
+    "index": 392,
     "method": "GET",
     "operationId": "sessions.memory.extraction.get",
     "path": "/v1/sessions/:sessionKey/memory/extraction",
@@ -3947,7 +3957,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 392,
+    "index": 393,
     "method": "POST",
     "operationId": "sessions.memory.extraction.retry",
     "path": "/v1/sessions/memory/extraction/retry",
@@ -3957,7 +3967,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 393,
+    "index": 394,
     "method": "GET",
     "operationId": "plugins.list",
     "path": "/v1/plugins",
@@ -3967,7 +3977,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 394,
+    "index": 395,
     "method": "GET",
     "operationId": "plugins.get",
     "path": "/v1/plugins/:id",
@@ -3977,7 +3987,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 395,
+    "index": 396,
     "method": "GET",
     "operationId": "plugins.versions.list",
     "path": "/v1/plugins/:id/versions",
@@ -3987,7 +3997,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 396,
+    "index": 397,
     "method": "POST",
     "operationId": "plugins.install",
     "path": "/v1/plugins/:id/install",
@@ -3997,7 +4007,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 397,
+    "index": 398,
     "method": "POST",
     "operationId": "plugins.enable",
     "path": "/v1/plugins/:id/enable",
@@ -4007,7 +4017,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 398,
+    "index": 399,
     "method": "POST",
     "operationId": "plugins.disable",
     "path": "/v1/plugins/:id/disable",
@@ -4017,7 +4027,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 399,
+    "index": 400,
     "method": "DELETE",
     "operationId": "plugins.uninstall",
     "path": "/v1/plugins/:id",
@@ -4027,7 +4037,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 400,
+    "index": 401,
     "method": "POST",
     "operationId": "agent.runs.start",
     "path": "/v1/agent/runs",
@@ -4037,7 +4047,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 401,
+    "index": 402,
     "method": "GET",
     "operationId": "agent.runs.list",
     "path": "/v1/agent/runs",
@@ -4047,7 +4057,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 402,
+    "index": 403,
     "method": "GET",
     "operationId": "agent.runs.summary",
     "path": "/v1/agent/runs/summary",
@@ -4057,7 +4067,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 403,
+    "index": 404,
     "method": "GET",
     "operationId": "agent.runs.get",
     "path": "/v1/agent/runs/:runId",
@@ -4067,7 +4077,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 404,
+    "index": 405,
     "method": "POST",
     "operationId": "agent.runs.cancel",
     "path": "/v1/agent/runs/:runId/cancel",
@@ -4077,7 +4087,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 405,
+    "index": 406,
     "method": "POST",
     "operationId": "agent.runs.resume",
     "path": "/v1/agent/runs/:runId/resume",
@@ -4087,7 +4097,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 406,
+    "index": 407,
     "method": "GET",
     "operationId": "agent.runs.audit",
     "path": "/v1/agent/runs/:runId/audit",
@@ -4097,7 +4107,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 407,
+    "index": 408,
     "method": "POST",
     "operationId": "agent.runs.rollback",
     "path": "/v1/agent/runs/:runId/rollback",
@@ -4107,7 +4117,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 408,
+    "index": 409,
     "method": "POST",
     "operationId": "agent.runs.approve.plan",
     "path": "/v1/agent/runs/:runId/approve-plan",
@@ -4117,7 +4127,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 409,
+    "index": 410,
     "method": "POST",
     "operationId": "agent.runs.reject.plan",
     "path": "/v1/agent/runs/:runId/reject-plan",
@@ -4127,7 +4137,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 410,
+    "index": 411,
     "method": "POST",
     "operationId": "agent.runs.approve.tool",
     "path": "/v1/agent/runs/:runId/approve-tool",
@@ -4137,7 +4147,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 411,
+    "index": 412,
     "method": "POST",
     "operationId": "agent.runs.reject.tool",
     "path": "/v1/agent/runs/:runId/reject-tool",
@@ -4147,7 +4157,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 412,
+    "index": 413,
     "method": "GET",
     "operationId": "agent.runs.events",
     "path": "/v1/agent/runs/:runId/events",
@@ -4157,7 +4167,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 413,
+    "index": 414,
     "method": "POST",
     "operationId": "agent.automations.create",
     "path": "/v1/agent/automations",
@@ -4167,7 +4177,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 414,
+    "index": 415,
     "method": "GET",
     "operationId": "agent.automations.list",
     "path": "/v1/agent/automations",
@@ -4177,7 +4187,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 415,
+    "index": 416,
     "method": "GET",
     "operationId": "agent.automations.get",
     "path": "/v1/agent/automations/:automationId",
@@ -4187,7 +4197,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 416,
+    "index": 417,
     "method": "PATCH",
     "operationId": "agent.automations.update",
     "path": "/v1/agent/automations/:automationId",
@@ -4197,7 +4207,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 417,
+    "index": 418,
     "method": "DELETE",
     "operationId": "agent.automations.delete",
     "path": "/v1/agent/automations/:automationId",
@@ -4207,7 +4217,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 418,
+    "index": 419,
     "method": "POST",
     "operationId": "agent.automations.run",
     "path": "/v1/agent/automations/:automationId/run",
@@ -4217,7 +4227,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 419,
+    "index": 420,
     "method": "GET",
     "operationId": "agent.subagents.list",
     "path": "/v1/agent/subagents",
@@ -4227,7 +4237,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 420,
+    "index": 421,
     "method": "GET",
     "operationId": "agent.subagents.get",
     "path": "/v1/agent/subagents/:subagentId",
@@ -4237,7 +4247,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 421,
+    "index": 422,
     "method": "GET",
     "operationId": "agent.runs.subagents.list",
     "path": "/v1/agent/runs/:runId/subagents",
@@ -4247,7 +4257,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 422,
+    "index": 423,
     "method": "GET",
     "operationId": "assets.inventory.list",
     "path": "/v1/assets/inventory",

--- a/test/contracts/api/friday-api-route-contract.snapshot.test.ts
+++ b/test/contracts/api/friday-api-route-contract.snapshot.test.ts
@@ -865,6 +865,10 @@ describe("MECHANISM-4 — API Route Contract (Snapshot)", () => {
         "mission.spine.intake.create",
         "mission.spine.lifecycle.transition",
         "mission.spine.workitem.status.transition",
+        // Lane M: the memory-confirmation loop's terminal mutation driven over the sealed-WS
+        // dispatch arm. Refuses the synthetic public principal before any dispatch; flag-OFF/503
+        // by default (the merged Rust arm #753 is gated by FRIDAY_MEMORY_CONFIRM).
+        "memory.spine.decide.apply",
       ]);
       // rate_limited_pending
       const RATE_LIMITED_PENDING: ReadonlySet<string> = new Set([

--- a/test/unit/api/mission-spine/friday-memory-spine-dispatch-adapter.test.ts
+++ b/test/unit/api/mission-spine/friday-memory-spine-dispatch-adapter.test.ts
@@ -1,0 +1,193 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { FridayDomainError } from "../../../../src/errors/friday-domain-error.js";
+import {
+  createFridayMemorySpineDispatchAdapter,
+  readMemorySpineRustWsPort,
+} from "../../../../src/api/mission-spine/friday-memory-spine-dispatch-adapter.js";
+import type {
+  CreateFridayRustHubAgentRunSealedClientOptions,
+  FridayRustHubAgentRunSealedClient,
+  FridayRustHubMemoryDecisionRequest,
+  FridayRustHubMemoryDecisionResult,
+} from "../../../../src/api/mission-spine/friday-rust-hub-agent-run-ws-sealed-client.js";
+
+// (Lane M) The bootstrap-side ADAPTER that satisfies the memory-spine route's `dispatch` so
+// POST /v1/memory-spine/decide becomes callable. These tests mock the underlying sealed client at
+// the `createClient` seam + the secret resolver — so we exercise the adapter's lazy-build /
+// delegation / fail-closed WITHOUT a socket (and without re-proving the proven ECDH interop).
+
+const SECRET = new Uint8Array(32).fill(7);
+
+const DECIDE_REQ: FridayRustHubMemoryDecisionRequest = {
+  memoryId: "mem-1",
+  ownerPrincipal: "owner-1",
+  decision: "confirm",
+};
+
+const DECIDE_RESULT: FridayRustHubMemoryDecisionResult = {
+  truthLabel: "rust_wired",
+  memoryId: "mem-1",
+  state: "confirmed",
+  status: "confirmed",
+  recallable: true,
+};
+
+/** A fake underlying sealed client + a recorder of how it was constructed/called. */
+function makeFakeClient(behavior: {
+  decide?: FridayRustHubMemoryDecisionResult;
+  reject?: unknown;
+}) {
+  const constructed: CreateFridayRustHubAgentRunSealedClientOptions[] = [];
+  const decideCalls: FridayRustHubMemoryDecisionRequest[] = [];
+  const createClient = vi.fn(
+    (options: CreateFridayRustHubAgentRunSealedClientOptions): FridayRustHubAgentRunSealedClient => {
+      constructed.push(options);
+      return {
+        dispatchRun: vi.fn(async () => {
+          throw new Error("dispatchRun not used by the memory adapter");
+        }),
+        resumeWithApproval: vi.fn(async () => {
+          throw new Error("resumeWithApproval not used by the memory adapter");
+        }),
+        intakeMission: vi.fn(async () => {
+          throw new Error("intakeMission not used by the memory adapter");
+        }),
+        transitionMission: vi.fn(async () => {
+          throw new Error("transitionMission not used by the memory adapter");
+        }),
+        transitionWorkItem: vi.fn(async () => {
+          throw new Error("transitionWorkItem not used by the memory adapter");
+        }),
+        decideMemory: vi.fn(async (req: FridayRustHubMemoryDecisionRequest) => {
+          decideCalls.push(req);
+          if (behavior.reject !== undefined) throw behavior.reject;
+          return behavior.decide!;
+        }),
+      };
+    },
+  );
+  return { createClient, constructed, decideCalls };
+}
+
+describe("createFridayMemorySpineDispatchAdapter (Lane M, dark, adapter)", () => {
+  describe("happy path — delegates to the (mocked) sealed client", () => {
+    it("decideMemory builds the client lazily with the resolved secret + delegates the request", async () => {
+      const fake = makeFakeClient({ decide: DECIDE_RESULT });
+      const secretResolver = vi.fn(() => SECRET);
+      const adapter = createFridayMemorySpineDispatchAdapter({
+        host: "127.0.0.1",
+        port: 48750,
+        secretResolver,
+        createClient: fake.createClient,
+      });
+
+      // Side-effect-free construction: NO secret resolved, NO client built until the first call.
+      expect(secretResolver).not.toHaveBeenCalled();
+      expect(fake.createClient).not.toHaveBeenCalled();
+
+      const result = await adapter.decideMemory(DECIDE_REQ);
+
+      expect(result).toBe(DECIDE_RESULT);
+      expect(secretResolver).toHaveBeenCalledTimes(1);
+      expect(fake.createClient).toHaveBeenCalledTimes(1);
+      expect(fake.constructed[0]).toMatchObject({ host: "127.0.0.1", port: 48750, clientSecret: SECRET });
+      expect(fake.decideCalls).toEqual([DECIDE_REQ]);
+    });
+
+    it("a Hub `blocked` outcome is a SUCCESSFUL round-trip of a refusal (resolved, not thrown)", async () => {
+      const blocked: FridayRustHubMemoryDecisionResult = {
+        truthLabel: "rust_wired",
+        memoryId: "mem-1",
+        state: "rejected",
+        status: "blocked",
+        blocker: "owner_scope_mismatch",
+        recallable: false,
+      };
+      const fake = makeFakeClient({ decide: blocked });
+      const adapter = createFridayMemorySpineDispatchAdapter({
+        port: 48750,
+        secretResolver: () => SECRET,
+        createClient: fake.createClient,
+      });
+
+      expect(await adapter.decideMemory({ ...DECIDE_REQ, decision: "reject" })).toBe(blocked);
+    });
+  });
+
+  describe("fail-closed — never a fake success", () => {
+    it("a null secret resolve → typed 503, no client built", async () => {
+      const fake = makeFakeClient({ decide: DECIDE_RESULT });
+      const adapter = createFridayMemorySpineDispatchAdapter({
+        port: 48750,
+        secretResolver: () => null,
+        createClient: fake.createClient,
+      });
+
+      await expect(adapter.decideMemory(DECIDE_REQ)).rejects.toMatchObject({
+        code: "MEMORY_SPINE_DISPATCH_RUST_UNAVAILABLE",
+        httpStatus: 503,
+      });
+      expect(fake.createClient).not.toHaveBeenCalled();
+      expect(fake.decideCalls).toEqual([]);
+    });
+
+    it("the underlying client constructor throwing → typed 503", async () => {
+      const adapter = createFridayMemorySpineDispatchAdapter({
+        port: 48750,
+        secretResolver: () => SECRET,
+        createClient: () => {
+          throw new RangeError("clientSecret must be 32 bytes");
+        },
+      });
+
+      const error = await adapter.decideMemory(DECIDE_REQ).catch((e) => e);
+      expect(error).toBeInstanceOf(FridayDomainError);
+      expect((error as FridayDomainError).code).toBe("MEMORY_SPINE_DISPATCH_RUST_UNAVAILABLE");
+      expect((error as FridayDomainError).httpStatus).toBe(503);
+    });
+
+    it("an inner FridayDomainError (e.g. a WS error / server Error envelope) surfaces UNCHANGED", async () => {
+      const innerWsError = new FridayDomainError(
+        "MISSION_SPINE_RUST_AGENT_RUN_SEALED_WS_CLIENT_UNAVAILABLE",
+        "sealed session closed before a result",
+        { httpStatus: 503, details: { surface: "ws" } },
+      );
+      const fake = makeFakeClient({ reject: innerWsError });
+      const adapter = createFridayMemorySpineDispatchAdapter({
+        port: 48750,
+        secretResolver: () => SECRET,
+        createClient: fake.createClient,
+      });
+
+      const error = await adapter.decideMemory(DECIDE_REQ).catch((e) => e);
+      expect(error).toBe(innerWsError);
+      expect((error as FridayDomainError).httpStatus).toBe(503);
+    });
+
+    it("a NON-domain inner throw is wrapped as a typed 503 (never leaks as an unhandled throw)", async () => {
+      const fake = makeFakeClient({ reject: new Error("socket ECONNREFUSED") });
+      const adapter = createFridayMemorySpineDispatchAdapter({
+        port: 48750,
+        secretResolver: () => SECRET,
+        createClient: fake.createClient,
+      });
+
+      const error = await adapter.decideMemory(DECIDE_REQ).catch((e) => e);
+      expect(error).toBeInstanceOf(FridayDomainError);
+      expect((error as FridayDomainError).code).toBe("MEMORY_SPINE_DISPATCH_RUST_UNAVAILABLE");
+      expect((error as FridayDomainError).httpStatus).toBe(503);
+    });
+  });
+
+  describe("readMemorySpineRustWsPort — replicates the agent-run port parse exactly", () => {
+    it("absent / blank / non-finite / negative ⇒ 0; a valid port parses", () => {
+      expect(readMemorySpineRustWsPort(undefined)).toBe(0);
+      expect(readMemorySpineRustWsPort("")).toBe(0);
+      expect(readMemorySpineRustWsPort("not-a-number")).toBe(0);
+      expect(readMemorySpineRustWsPort("-5")).toBe(0);
+      expect(readMemorySpineRustWsPort("48750")).toBe(48750);
+      expect(readMemorySpineRustWsPort("0")).toBe(0);
+    });
+  });
+});

--- a/test/unit/api/mission-spine/friday-rust-hub-memory-spine-wire.test.ts
+++ b/test/unit/api/mission-spine/friday-rust-hub-memory-spine-wire.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildMemoryDecisionEnvelope,
+  parseMemoryDecisionResult,
+  type FridayRustHubMemoryDecisionRequest,
+} from "../../../../src/api/mission-spine/friday-rust-hub-agent-run-ws-sealed-client.js";
+
+// (Lane M) The memory-decision wire builder maps the TS request onto the EXACT snake_case
+// `friday-protocol` `MemoryDecisionRequestWire` shape. CRITICAL: `Message::MemoryDecisionRequest`
+// is a SINGLE-FIELD WRAPPER (`{ request: MemoryDecisionRequestWire }`) on an internally-tagged
+// (`#[serde(tag = "kind")]`) `Message`, so serde NESTS the inner wire fields under a `request`
+// key — they are NOT flat under `message`. A prior surface shipped a FLAT shape that failed
+// `Envelope::decode` server-side (missing `request`) ⇒ 503 EVERY call. The GOLDEN cross-check
+// below pins the byte-exact `{kind,request}` nesting against the EXACT shape the merged Rust
+// round-trip test emits (friday-protocol/src/lib.rs:2126-2141 + 2158-2172, #753).
+
+const REQUEST: FridayRustHubMemoryDecisionRequest = {
+  memoryId: "mem-1",
+  ownerPrincipal: "owner-1",
+  decision: "confirm",
+};
+
+// GOLDEN fixture — cross-checked field-by-field against the Rust struct + round-trip test:
+//   MemoryDecisionRequestWire { memory_id, owner_principal, decision }  (lib.rs:301-310)
+//   Message::MemoryDecisionRequest { request: MemoryDecisionRequestWire }  (lib.rs:1295, tag="kind")
+//   round-trip emits: {"kind":"MemoryDecisionRequest","request":{"memory_id":...,"owner_principal":...,"decision":...}}
+//   (lib.rs:2158-2172 asserts "\"kind\":\"MemoryDecisionRequest\"" + "\"request\":{" + the snake_case fields)
+const GOLDEN_MESSAGE = {
+  kind: "MemoryDecisionRequest",
+  request: {
+    memory_id: "mem-1",
+    owner_principal: "owner-1",
+    decision: "confirm",
+  },
+} as const;
+
+describe("buildMemoryDecisionEnvelope (MemoryDecisionRequestWire wire mapping)", () => {
+  it("emits EXACTLY the golden {kind, request:{memory_id, owner_principal, decision}} envelope", () => {
+    const env = buildMemoryDecisionEnvelope(REQUEST);
+    // schema_version rides the SHARED `buildMissionEnvelope` constant (the same value every
+    // mission-spine builder emits). NOTE: this is a TS-const, NOT a Rust cross-check — the Rust
+    // `CURRENT_SCHEMA_VERSION` is 13 (lib.rs:53) while this TS constant is 12; the server's
+    // `Envelope::decode` is a pure serde deser that does NOT enforce the field (no version check in
+    // hub_agent_run_server), so a 12-tagged envelope is accepted — identical to the live mission-spine
+    // path. The LOAD-BEARING golden is the {kind,request} body below, not this informational field.
+    expect(env.schema_version).toBe(12);
+    expect(env.msg_id).toBe("memory-decision-mem-1");
+    expect(env.correlation_id).toBe("memory-decision-mem-1");
+
+    const message = env.message as Record<string, unknown>;
+    // DEEP-EQUAL the whole message to the golden fixture — the anti-mock-green core.
+    expect(message).toEqual(GOLDEN_MESSAGE);
+    // The wrapper key is `request` (NOT flat fields under `message`) — flat-shape 503 regression guard.
+    expect(Object.keys(message).sort()).toEqual(["kind", "request"]);
+    const request = message.request as Record<string, unknown>;
+    // NO camelCase leak, NO extra/missing key.
+    expect(Object.keys(request).sort()).toEqual(["decision", "memory_id", "owner_principal"]);
+    expect("memoryId" in request).toBe(false);
+    expect("ownerPrincipal" in request).toBe(false);
+  });
+
+  it("carries the reject decision verbatim (the second valid token)", () => {
+    const message = buildMemoryDecisionEnvelope({ ...REQUEST, decision: "reject" }).message as Record<
+      string,
+      unknown
+    >;
+    const request = message.request as Record<string, unknown>;
+    expect(request.decision).toBe("reject");
+  });
+});
+
+describe("parseMemoryDecisionResult (MemoryDecisionResultWire wire mapping)", () => {
+  it("unwraps the nested `result` and surfaces the refs-only result with the rust_wired label", () => {
+    const parsed = parseMemoryDecisionResult({
+      kind: "MemoryDecisionResult",
+      result: {
+        memory_id: "mem-1",
+        state: "confirmed",
+        status: "confirmed",
+        recallable: true,
+      },
+    });
+    expect(parsed).toEqual({
+      truthLabel: "rust_wired",
+      memoryId: "mem-1",
+      state: "confirmed",
+      status: "confirmed",
+      recallable: true,
+    });
+  });
+
+  it("surfaces a `blocked` outcome WITH the coarse blocker (recallable=false is a VALID value)", () => {
+    const parsed = parseMemoryDecisionResult({
+      kind: "MemoryDecisionResult",
+      result: {
+        memory_id: "mem-1",
+        state: "rejected",
+        status: "blocked",
+        blocker: "owner_scope_mismatch",
+        recallable: false,
+      },
+    });
+    expect(parsed).toEqual({
+      truthLabel: "rust_wired",
+      memoryId: "mem-1",
+      state: "rejected",
+      status: "blocked",
+      blocker: "owner_scope_mismatch",
+      recallable: false,
+    });
+  });
+
+  it("omits `blocker` when absent (skip_serializing_if Option::is_none) — never fabricated", () => {
+    const parsed = parseMemoryDecisionResult({
+      kind: "MemoryDecisionResult",
+      result: { memory_id: "mem-1", state: "confirmed", status: "confirmed", recallable: true },
+    });
+    expect(parsed && "blocker" in parsed).toBe(false);
+  });
+
+  it("fails closed (undefined) on a missing/ill-typed result wrapper or required ref", () => {
+    // No `result` wrapper at all.
+    expect(parseMemoryDecisionResult({ kind: "MemoryDecisionResult" })).toBeUndefined();
+    // Missing memory_id.
+    expect(
+      parseMemoryDecisionResult({ result: { state: "confirmed", status: "confirmed", recallable: true } }),
+    ).toBeUndefined();
+    // recallable absent → not a boolean → fail closed (NEVER coerced to false).
+    expect(
+      parseMemoryDecisionResult({ result: { memory_id: "m", state: "confirmed", status: "confirmed" } }),
+    ).toBeUndefined();
+    // recallable present but ill-typed (string) → fail closed.
+    expect(
+      parseMemoryDecisionResult({
+        result: { memory_id: "m", state: "confirmed", status: "confirmed", recallable: "true" },
+      }),
+    ).toBeUndefined();
+  });
+});

--- a/test/unit/api/routes/friday-memory-spine-routes.test.ts
+++ b/test/unit/api/routes/friday-memory-spine-routes.test.ts
@@ -1,0 +1,201 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { FridayDomainError } from "../../../../src/errors/friday-domain-error.js";
+import {
+  createFridayMemorySpineRoutes,
+  validateMemoryDecisionBody,
+  type FridayMemorySpineDispatchService,
+} from "../../../../src/api/http/routes/friday-memory-spine-routes.js";
+import type { FridayRustHubMemoryDecisionResult } from "../../../../src/api/mission-spine/friday-rust-hub-agent-run-ws-sealed-client.js";
+
+// (Lane M) The memory-confirmation loop's terminal route. MIRRORS the mission-spine dispatch routes:
+// guard order is (1) dispatch-disabled (flag-OFF) → 503 FIRST regardless of caller; (2)
+// bound-principal → 401; (3) body validation → 400; (4) seal + dispatch. DARK by default (503).
+
+const RESULT: FridayRustHubMemoryDecisionResult = {
+  truthLabel: "rust_wired",
+  memoryId: "mem-1",
+  state: "confirmed",
+  status: "confirmed",
+  recallable: true,
+};
+
+const VALID_BODY = {
+  memoryId: "mem-1",
+  ownerPrincipal: "owner-1",
+  decision: "confirm",
+};
+
+function makeCtx(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    requestId: "req-memory-spine-decide",
+    receivedAt: "2026-06-14T00:00:00Z",
+    params: {},
+    query: {},
+    body: null,
+    headers: {},
+    principal: {
+      principalId: "principal-1",
+      userId: "user-1",
+      principalType: "user",
+      role: "admin",
+      scopes: ["hub.admin"],
+    },
+    ...overrides,
+  };
+}
+
+function makeDispatch(overrides: Partial<FridayMemorySpineDispatchService> = {}): {
+  dispatch: FridayMemorySpineDispatchService;
+  decide: ReturnType<typeof vi.fn>;
+} {
+  const decide = vi.fn(async () => RESULT);
+  return {
+    dispatch: { decideMemory: decide, ...overrides },
+    decide,
+  };
+}
+
+function findRoute(routes: ReturnType<typeof createFridayMemorySpineRoutes>) {
+  const route = routes.find((candidate) => candidate.operationId === "memory.spine.decide.apply");
+  if (!route) throw new Error("memory.spine.decide.apply route missing");
+  return route;
+}
+
+describe("createFridayMemorySpineRoutes (Lane M, dark)", () => {
+  it("registers a single public POST /v1/memory-spine/decide route", () => {
+    const { dispatch } = makeDispatch();
+    const routes = createFridayMemorySpineRoutes({ dispatch });
+    expect(routes).toHaveLength(1);
+    const route = findRoute(routes);
+    expect(route.method).toBe("POST");
+    expect(route.path).toBe("/v1/memory-spine/decide");
+    expect(route.auth).toEqual({ public: true });
+  });
+
+  describe("DEFAULT-OFF (no dispatch service) → honest-unavailable 503", () => {
+    it("returns 503 MEMORY_SPINE_DISPATCH_UNAVAILABLE when dispatch is omitted, no send", async () => {
+      const { decide } = makeDispatch();
+      const routes = createFridayMemorySpineRoutes({});
+      const route = findRoute(routes);
+      let thrown: unknown = null;
+      try {
+        await route.handler(makeCtx({ body: VALID_BODY }) as never);
+      } catch (err) {
+        thrown = err;
+      }
+      expect(thrown).toBeInstanceOf(FridayDomainError);
+      const error = thrown as FridayDomainError;
+      expect(error.code).toBe("MEMORY_SPINE_DISPATCH_UNAVAILABLE");
+      expect(error.httpStatus).toBe(503);
+      expect(decide).not.toHaveBeenCalled();
+    });
+
+    it("503 also when dispatch is explicitly null", async () => {
+      const routes = createFridayMemorySpineRoutes({ dispatch: null });
+      const route = findRoute(routes);
+      const error = await route.handler(makeCtx({ body: VALID_BODY }) as never).catch((e) => e);
+      expect((error as FridayDomainError).code).toBe("MEMORY_SPINE_DISPATCH_UNAVAILABLE");
+      expect((error as FridayDomainError).httpStatus).toBe(503);
+    });
+
+    it("503-unavailable fires FIRST — even for a null (unauthenticated) principal", async () => {
+      const routes = createFridayMemorySpineRoutes({});
+      const route = findRoute(routes);
+      const error = await route
+        .handler(makeCtx({ principal: null, body: VALID_BODY }) as never)
+        .catch((e) => e);
+      // Flag-OFF is a uniform honest-unavailable, NOT a principal refusal.
+      expect((error as FridayDomainError).code).toBe("MEMORY_SPINE_DISPATCH_UNAVAILABLE");
+    });
+  });
+
+  describe("flag-ON: bound-principal gate", () => {
+    it("refuses the synthetic public (null) principal with a 401, no dispatch", async () => {
+      const { dispatch, decide } = makeDispatch();
+      const routes = createFridayMemorySpineRoutes({ dispatch });
+      const route = findRoute(routes);
+      const error = await route
+        .handler(makeCtx({ principal: null, body: VALID_BODY }) as never)
+        .catch((e) => e);
+      expect(error).toBeInstanceOf(FridayDomainError);
+      expect((error as FridayDomainError).httpStatus).toBe(401);
+      expect(decide).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("flag-ON: validation — a 4xx (never a 500), no send", () => {
+    it("maps a valid body to the typed request and passes through the refs-only result", async () => {
+      const { dispatch, decide } = makeDispatch();
+      const routes = createFridayMemorySpineRoutes({ dispatch });
+      const route = findRoute(routes);
+      const response = (await route.handler(makeCtx({ body: VALID_BODY }) as never)) as {
+        result: FridayRustHubMemoryDecisionResult;
+      };
+      expect(response.result).toBe(RESULT);
+      expect(decide).toHaveBeenCalledTimes(1);
+      expect(decide).toHaveBeenCalledWith({
+        memoryId: "mem-1",
+        ownerPrincipal: "owner-1",
+        decision: "confirm",
+      });
+    });
+
+    it("a missing field → 400, no send", async () => {
+      const { dispatch, decide } = makeDispatch();
+      const routes = createFridayMemorySpineRoutes({ dispatch });
+      const route = findRoute(routes);
+      const error = await route
+        .handler(makeCtx({ body: { memoryId: "mem-1", decision: "confirm" } }) as never)
+        .catch((e) => e);
+      expect(error).toBeInstanceOf(FridayDomainError);
+      expect((error as FridayDomainError).code).toBe("MEMORY_SPINE_DECISION_REQUEST_INVALID");
+      expect((error as FridayDomainError).httpStatus).toBe(400);
+      expect(decide).not.toHaveBeenCalled();
+    });
+
+    it("a `decision` not in {confirm,reject} → 400, no send", async () => {
+      const { dispatch, decide } = makeDispatch();
+      const routes = createFridayMemorySpineRoutes({ dispatch });
+      const route = findRoute(routes);
+      const error = await route
+        .handler(makeCtx({ body: { ...VALID_BODY, decision: "maybe" } }) as never)
+        .catch((e) => e);
+      expect((error as FridayDomainError).httpStatus).toBe(400);
+      expect(JSON.stringify((error as FridayDomainError).details)).toContain(
+        "decision_not_confirm_or_reject",
+      );
+      expect(decide).not.toHaveBeenCalled();
+    });
+
+    it("an empty/non-object body → 400, no send", async () => {
+      const { dispatch, decide } = makeDispatch();
+      const routes = createFridayMemorySpineRoutes({ dispatch });
+      const route = findRoute(routes);
+      const error = await route.handler(makeCtx({ body: null }) as never).catch((e) => e);
+      expect((error as FridayDomainError).httpStatus).toBe(400);
+      expect(decide).not.toHaveBeenCalled();
+    });
+  });
+});
+
+describe("validateMemoryDecisionBody (pure)", () => {
+  it("accepts both confirm and reject; trims whitespace", () => {
+    expect(validateMemoryDecisionBody({ memoryId: " m ", ownerPrincipal: " o ", decision: "reject" })).toEqual(
+      { memoryId: "m", ownerPrincipal: "o", decision: "reject" },
+    );
+  });
+
+  it("rejects an empty-string field as a 400", () => {
+    const error = (() => {
+      try {
+        validateMemoryDecisionBody({ memoryId: "", ownerPrincipal: "o", decision: "confirm" });
+        return null;
+      } catch (e) {
+        return e;
+      }
+    })();
+    expect((error as FridayDomainError).httpStatus).toBe(400);
+    expect(JSON.stringify((error as FridayDomainError).details)).toContain("memoryId_missing_or_empty");
+  });
+});

--- a/test/unit/api/runtime/friday-api-runtime-memory-registration.test.ts
+++ b/test/unit/api/runtime/friday-api-runtime-memory-registration.test.ts
@@ -100,7 +100,13 @@ describe("FridayApiRuntime — Memory Registration", () => {
     });
 
     const allRoutes = runtime.routes.getRoutes();
-    const memoryRoutes = allRoutes.filter((r) => r.operationId.startsWith("memory."));
+    // `memory.spine.*` is the always-registered memory-confirmation spine route (503-dark until the
+    // dispatch adapter is wired + FRIDAY_MEMORY_CONFIRM flipped), mirroring the mission-spine pattern.
+    // It is orthogonal to the memoryService-gated routes (memory.store/search/get/list/delete/prune)
+    // this test guards, so it is excluded here.
+    const memoryRoutes = allRoutes.filter(
+      (r) => r.operationId.startsWith("memory.") && !r.operationId.startsWith("memory.spine."),
+    );
 
     expect(memoryRoutes).toHaveLength(0);
   });


### PR DESCRIPTION
## Gap closed
The Rust memory-confirmation arm was merged in #753 — an inbound `Message::MemoryDecisionRequest { request }` handled by `hub_agent_run_server.rs`, gated by `FRIDAY_MEMORY_CONFIRM` (default-OFF), calling `memory::decide` to transition a candidate `memory_item` Candidate→Confirmed (recallable) / Candidate→Rejected (terminal). **The TS side had no way to send that message**, so the confirmation loop was unreachable from the product. This PR adds the TS DRIVER that closes it.

## Mirror of the proven mission-spine dispatch driver
Built 1:1 against the merged mission-spine path (sealed-client builder → dispatch adapter → HTTP route). Same construction seam, same lazy per-call build, same fail-closed contract, same guard order.

- **Sealed-client** (`friday-rust-hub-agent-run-ws-sealed-client.ts`): `buildMemoryDecisionEnvelope` / `parseMemoryDecisionResult` + a `decideMemory` method on `FridayRustHubAgentRunSealedClient`, reusing the proven `runMissionRoundTrip` handshake.
- **Dispatch adapter** (`friday-memory-spine-dispatch-adapter.ts`): `createFridayMemorySpineDispatchAdapter` — side-effect-free, resolves the X25519 secret + builds the client lazily, fail-closed 503.
- **HTTP route** (`friday-memory-spine-routes.ts`): `POST /v1/memory-spine/decide`. Always registered; **DEFAULT-OFF (dispatch `null`) → 503 `MEMORY_SPINE_DISPATCH_UNAVAILABLE`**. Body `{ memoryId, ownerPrincipal, decision:"confirm"|"reject" }`, all required, `decision` enum-checked. Guard order mirrors mission-spine: dispatch-null 503 → bound-principal 401 → body-validation 400 → dispatch. A 4xx on bad input, never a 500, no send.

## Golden cross-check (anti-mock-green)
The emitted envelope is the internally-tagged wrapper, NOT the flat shape a prior PR shipped that 503'd every call:
```
{ kind: "MemoryDecisionRequest", request: { memory_id, owner_principal, decision } }
```
The wire test deep-equals this against a GOLDEN fixture cross-checked field-by-field against the merged Rust struct — `MemoryDecisionRequestWire { memory_id, owner_principal, decision }` at `friday-protocol/src/lib.rs:301-310`, `Message::MemoryDecisionRequest { request }` at `lib.rs:1295` (`#[serde(tag="kind")]`), and the Rust round-trip assertions at `lib.rs:2158-2172`. It asserts `Object.keys(message) == ["kind","request"]` and no camelCase leak.

## Tests (24 new, all green)
- DEFAULT-OFF: route returns 503 with no send (and 503 fires first, even for a null principal).
- WIRE-SHAPE golden: builder emits exactly the `{kind,request:{snake_case}}` envelope.
- VALIDATION: missing field / `decision` not in {confirm,reject} / empty body → 400, no send.
- Parser: `recallable=false` is a valid value (`typeof === "boolean"`, never truthy-coerced); `blocker` omitted when absent (`skip_serializing_if`); fail-closed on a missing/ill-typed result wrapper or required ref.

Existing mission-spine + runtime suites: 246 tests still green. `tsc` clean, `eslint` 0 errors, route-contract snapshot updated (+1 route, `bound_principal` 62→63, pure index renumbering).

## Dark-safety / what the live path still needs (operator-gated follow-ups)
No Rust touched, no flag default changed, no dispatch-leg/intake code touched — pure additive driver. To go live the operator must: wire the adapter into the route's `dispatch`, flip the Rust `FRIDAY_MEMORY_CONFIRM` flag (the merged arm treats a `MemoryDecisionRequest` as a benign keepalive echo until then), and enable `FRIDAY_RUN_LOOP_MEMORY_EXTRACTION` to produce candidates to decide on. `rust_wired` ceiling confers no v1 GO.

## Note (out of scope, flagged for the record)
The shared TS envelope constant `SCHEMA_VERSION` is `12` while Rust's `CURRENT_SCHEMA_VERSION` is now `13` (`lib.rs:53`). This is **pre-existing** across all mission-spine builders and not introduced here. It is not a functional blocker: `Envelope::decode` is a pure serde deserialize and `hub_agent_run_server` performs no version enforcement, so a 12-tagged envelope is accepted exactly as the live mission-spine path is. Worth a separate cleanup pass on the shared constant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)