### PR TITLE
feat(mission): resume→WorkItem-completion leg (signed-mutation closes the loop, dark)

### DIFF
--- a/rust-core/crates/friday-hub/src/bin/hub_agent_run_server.rs
+++ b/rust-core/crates/friday-hub/src/bin/hub_agent_run_server.rs
@@ -1153,6 +1153,33 @@ fn serve_sealed_session<S: Read + Write, T: Transport>(
             } if run_control_enabled => {
                 let now_ms = now_ms();
                 let outcome = match runtime.operator_vk() {
+                    // MISSION-BOUND seam (FRIDAY_MISSION_BOUND_RUN, default-OFF): when ON, route
+                    // resume through the mission-bound wrapper, which (1) delegates VERBATIM to the
+                    // SAME `agent_run_control::resume` spine and then (2) — ONLY on a proven
+                    // execution (`accepted == executed == true`) AND a run that resolves to its OWN
+                    // pause-time bound WorkItem — advances that WorkItem ProviderRouted →
+                    // CompletedWithProof. A run with no resolvable bound WorkItem (every non-mission
+                    // resume) returns the bare-resume `ControlOutcome` UNMODIFIED after only reads,
+                    // so a flag-ON non-mission resume is BYTE-IDENTICAL to the bare path. Flag OFF ⇒
+                    // the bare spine, byte-identical to today.
+                    Some(vk) if mission_bound_run_enabled => {
+                        friday_hub::mission_runtime::resume_agent_loop_for_mission(
+                            runtime.db(),
+                            runtime.executor(),
+                            vk,
+                            run_id,
+                            signed_blob,
+                            now_ms,
+                        )
+                        .unwrap_or_else(|_| {
+                            friday_hub::agent_run_control::ControlOutcome {
+                                op: "resume",
+                                accepted: false,
+                                status: "storage_failed".to_string(),
+                                audit_ref: None,
+                            }
+                        })
+                    }
                     Some(vk) => friday_hub::agent_run_control::resume(
                         runtime.db().conn(),
                         runtime.executor(),

--- a/rust-core/crates/friday-hub/src/mission_runtime.rs
+++ b/rust-core/crates/friday-hub/src/mission_runtime.rs
@@ -8,12 +8,13 @@
 //! masquerade as Friday work.
 
 use friday_core::gate::{CanonicalApproval, MutatingActionRequest};
-use friday_core::{Risk, RouteDecisionCard, WorkLane};
-use friday_crypto::SecureStore;
+use friday_core::{MissionLinkKind, Risk, RouteDecisionCard, WorkLane};
+use friday_crypto::{OperatorVerifyingKey, SecureStore};
 use friday_deepseek::{DeepSeekClient, Transport};
 use friday_storage::channel::get_channel;
 use friday_storage::{Db, StorageError};
 
+use crate::agent_run_control::{resume as agent_run_control_resume, ControlOutcome};
 use crate::channel_event::{channel_event_id, ingest_channel_inbound, ChannelInboundReceipt};
 use crate::channels::{redact_inbound, resolve_and_verify, InboundRejection, RedactedInbound};
 use crate::mission_context::{
@@ -585,6 +586,156 @@ pub(crate) fn attach_agent_loop_provider_state(
         }
     }
     Ok(last)
+}
+
+/// RESUME a paused, mutating, MISSION-BOUND agent-loop run AND — only on a proven execution —
+/// advance its bound WorkItem `ProviderRouted → CompletedWithProof`. This closes the ONE gap left
+/// by the dark mission-bound run path: after the operator's Ed25519-signed approval executes the
+/// one paused mutation, NOTHING previously advanced the WorkItem off `ProviderRouted` (the
+/// pause-time bind state — see `attach_agent_loop_provider_state` with `completed=false`).
+///
+/// ## THE LOOPHOLE GATE (a false proof is a security defect)
+/// The WorkItem is advanced ONLY when the ONE approved mutation actually ran — gate `Allow` AND
+/// executor `Ok`. This is delegated VERBATIM to [`crate::agent_run_control::resume`] (which itself
+/// delegates to the S6 [`crate::resume::resume_with_approval`] spine): its returned
+/// [`ControlOutcome::accepted`] field is set to `outcome.executed` (agent_run_control.rs:472), and
+/// EVERY non-execution path — gate `Deny` (replayed/consumed nonce, expired/bad-signature/HMAC
+/// approval), `mutation_exec_failed` (gate Allow but executor `Err`), every `ResumeError`, and the
+/// fail-closed pre-checks (`malformed_blob`/`run_mismatch`/`run_cancelled`/`approval_rejected`) —
+/// returns `accepted: false`. So `accepted == true` ⟺ `executed == true` ⟺ the mutation ran. We
+/// gate the advance STRICTLY on `outcome.accepted`. If it is false we return the spine's outcome
+/// UNMODIFIED and the WorkItem is left UNCHANGED (stays `ProviderRouted`): no proof, no
+/// audit-completion row, no false proof.
+///
+/// ## Cross-mission proof-injection defense
+/// We NEVER trust a wire-supplied work_item_id. The WorkItem is resolved ONLY via the run's OWN
+/// pause-time `provider_timeline` MissionLink — the link whose `target_ref` encodes EXACTLY this
+/// `run_id` as its trailing `#`-segment (`friday://provider-timeline/{session}#{run_id}`,
+/// resolved by [`friday_storage::Db::find_provider_timeline_link_by_run_id`], which matches the
+/// last `#`-segment EXACTLY and fail-closes on zero or ambiguous matches). That link carries the
+/// bound `mission_id` + `work_item_id` directly; an attacker cannot steer the completion to a
+/// foreign WorkItem. If no own-link resolves (a non-mission run, or a foreign nonce), we DO NOT
+/// advance — we return the spine's outcome unchanged (so a flag-on non-mission resume is
+/// byte-identical to a bare `agent_run_control::resume`).
+///
+/// ## The partial advance (no backward / duplicate transition)
+/// The bound WorkItem is already at `ProviderRouted`, so we drive ONLY the remaining legal hops
+/// `RoutedToProvider → WaitingProvider → ProviderCompleted` via
+/// [`attach_provider_timeline_state_guarded`] with `proof_ref = friday://agent-run/{run_id}`,
+/// reusing the SAME `friday_session_id` (parsed from the matched link's `target_ref`) and
+/// `request_id = run_id` so the completion UPSERTS the same MissionLink rather than minting a
+/// second (which would later make the run_id resolution ambiguous). We do NOT re-drive
+/// `SentToHub`/`AcceptedByHub` (the item is past them — re-running would be an illegal backward
+/// transition). `guarded = false` (the pre-WI-1 inline write) is used here so the advance writes
+/// no extra audit row and never risks an `audit_ledger` PK collision; the completion proof_ref is
+/// always supplied, and `transition_work_item_status` / `work_item_status_for_provider_state`
+/// reject a proof-less `CompletedWithProof` as the final backstop.
+///
+/// A non-advancing attachment outcome (e.g. the idempotent already-`CompletedWithProof` case →
+/// `Blocked{illegal_work_item_transition:...}`) is NON-FATAL: we still return the spine's
+/// `accepted` outcome (the mutation DID run). The advance is a pure side-effect; it never alters
+/// the returned [`ControlOutcome`].
+///
+/// **Known boundary (dark PR):** the spine's mutation (its own transaction) and this WorkItem
+/// advance (separate transactions) are not atomic. A crash between them leaves
+/// `run_result=mutation_completed` with the WorkItem still at `ProviderRouted`/`ProviderWaiting` —
+/// an UNDER-claim, never a false proof; the next resume is `executed==false` (nonce consumed) so it
+/// cannot re-advance. Acceptable for this dark, default-off seam.
+///
+/// Returns `Result<ControlOutcome, StorageError>` — a drop-in for the bare
+/// `agent_run_control::resume` at the wire seam (same `send_control_result` / `storage_failed`
+/// fallback shape).
+pub fn resume_agent_loop_for_mission(
+    db: &Db,
+    executor: &dyn ToolExecutor,
+    operator_vk: &OperatorVerifyingKey,
+    run_id: &str,
+    signed_blob: &[u8],
+    now_ms: i64,
+) -> Result<ControlOutcome, StorageError> {
+    // (a) Delegate to the EXISTING resume spine UNCHANGED. This verifies the Ed25519 signature,
+    //     enforces single-use (nonce consume), runs the reject/cancel + wire-run-binding
+    //     pre-checks, and executes the ONE approved mutation. We add no verification/execution.
+    let outcome = agent_run_control_resume(
+        db.conn(),
+        executor,
+        operator_vk,
+        run_id,
+        signed_blob,
+        now_ms,
+    )?;
+
+    // (b) THE LOOPHOLE GATE. `outcome.accepted == outcome.executed` (agent_run_control.rs:472):
+    //     true IFF gate Allow AND executor Ok. Any refusal / exec-failure is `accepted:false` ⇒
+    //     return the spine outcome UNMODIFIED, WorkItem untouched (stays ProviderRouted). No proof.
+    if !outcome.accepted {
+        return Ok(outcome);
+    }
+
+    // (c) Resolve the bound WorkItem from the run's OWN pause-time provider_timeline link ONLY
+    //     (never a wire-supplied id). No own-link (non-mission run / foreign nonce) ⇒ no advance:
+    //     return the spine outcome unchanged (byte-identical to a bare resume on a non-mission run).
+    let Some(link) = db.find_provider_timeline_link_by_run_id(run_id)? else {
+        return Ok(outcome);
+    };
+    if link.link_kind != MissionLinkKind::ProviderTimeline {
+        // Defense-in-depth: the storage query already filters to provider_timeline.
+        return Ok(outcome);
+    }
+    let Some(work_item_id) = link.work_item_id.clone() else {
+        // A provider_timeline link with no bound WorkItem cannot be completed — leave it.
+        return Ok(outcome);
+    };
+    // The pause-time link's target_ref is `friday://provider-timeline/{session}#{run_id}`. Parse the
+    // session BACK out so the completion reuses the SAME link_id (mission_id+work_item+session+run)
+    // and UPSERTS the existing link instead of minting a second one (which would make a future
+    // run_id resolution ambiguous → fail-closed). The run_id segment was matched EXACTLY by the
+    // resolver, so the session is everything between the `provider-timeline/` prefix and the `#`.
+    let session_id = provider_timeline_session_from_target(&link.target_ref).unwrap_or_default();
+
+    // (d) Drive ONLY the remaining legal hops RoutedToProvider → WaitingProvider →
+    //     ProviderCompleted with the run as proof. `guarded=false` = the inline write (no extra
+    //     audit row, no PK risk); the proof_ref is always supplied so the completion is well-formed.
+    let proof_ref = format!("friday://agent-run/{run_id}");
+    for state in [
+        PendingState::WaitingProvider,
+        PendingState::ProviderCompleted,
+    ] {
+        let attachment = attach_provider_timeline_state_guarded(
+            db,
+            ProviderTimelineAttachment {
+                mission_id: link.mission_id.clone(),
+                work_item_id: work_item_id.clone(),
+                friday_session_id: session_id.clone(),
+                request_id: run_id.to_string(),
+                state,
+                proof_ref: (state == PendingState::ProviderCompleted).then(|| proof_ref.clone()),
+                now_ms,
+            },
+            /* guarded = */ false,
+        )?;
+        // A non-advancing outcome (e.g. an already-completed run ⇒ illegal/duplicate transition) is
+        // NON-FATAL: the mutation DID run (the spine returned accepted), so we still report it. The
+        // advance is a best-effort side-effect that never changes the returned ControlOutcome.
+        if matches!(attachment, MissionAttachmentOutcome::Blocked { .. }) {
+            break;
+        }
+    }
+
+    Ok(outcome)
+}
+
+/// Parse the `{session}` out of a provider-timeline `target_ref`
+/// (`friday://provider-timeline/{session}#{run_id}`): everything between the `provider-timeline/`
+/// prefix and the LAST `#`. Returns `None` if the ref is not in that shape.
+fn provider_timeline_session_from_target(target_ref: &str) -> Option<String> {
+    const PREFIX: &str = "friday://provider-timeline/";
+    let rest = target_ref.strip_prefix(PREFIX)?;
+    let (session, _run) = rest.rsplit_once('#')?;
+    if session.is_empty() {
+        return None;
+    }
+    Some(session.to_string())
 }
 
 #[cfg(test)]
@@ -1502,5 +1653,93 @@ mod tests {
             WorkItemStatus::CompletedWithProof
         );
         assert_eq!(lifecycle_audit_rows(&db), 0);
+    }
+
+    // ===================== resume → WorkItem-completion: pure (no-signing) seams ===============
+
+    #[test]
+    fn provider_timeline_session_parser_extracts_session_or_none() {
+        // The canonical pause-time shape: session is between the prefix and the LAST '#'.
+        assert_eq!(
+            provider_timeline_session_from_target(
+                "friday://provider-timeline/friday-hub-session#run-1"
+            )
+            .as_deref(),
+            Some("friday-hub-session")
+        );
+        // A session is allowed to contain '#'? No — we split on the LAST '#', so a session with an
+        // embedded '#' keeps the left part; the run_id is always the final segment (run ids have
+        // no '#'). This documents the rsplit behavior.
+        assert_eq!(
+            provider_timeline_session_from_target("friday://provider-timeline/a#b#run-1")
+                .as_deref(),
+            Some("a#b")
+        );
+        // Not the provider-timeline shape ⇒ None (the wrong prefix / no '#').
+        assert_eq!(
+            provider_timeline_session_from_target("friday://agent-run/run-1"),
+            None
+        );
+        assert_eq!(
+            provider_timeline_session_from_target("friday://provider-timeline/run-1"),
+            None,
+            "no '#' ⇒ not the bound shape"
+        );
+        assert_eq!(
+            provider_timeline_session_from_target("friday://provider-timeline/#run-1"),
+            None,
+            "empty session ⇒ None"
+        );
+    }
+
+    /// The run-id resolver matches the EXACT trailing '#'-segment and fail-closes on zero / ambiguous
+    /// matches — the cross-mission injection defense, exercised WITHOUT any signing (a pure storage
+    /// property). Seeds two provider_timeline links sharing a run_id SUFFIX and asserts exact match.
+    #[test]
+    fn resolve_provider_timeline_link_by_run_id_is_exact_and_fail_closed() {
+        let db = Db::open_hub(&tmp("resolve-runid")).unwrap();
+        // Reuse the existing seed helper (mission-runtime / work-runtime) for the first link...
+        seed_work_item(
+            &db,
+            WorkLane::DeepSeek,
+            Some("deepseek"),
+            WorkItemStatus::ReadyToDispatch,
+        );
+        // Drive RoutedToProvider for run "run-z" (writes the pause-time link target_ref).
+        attach_agent_loop_provider_state(
+            &db,
+            "mission-runtime",
+            "work-runtime",
+            "sess-z",
+            "run-z",
+            /* completed = */ false,
+            "friday://agent-run/run-z",
+            /* guarded = */ false,
+            10,
+        )
+        .unwrap();
+
+        // EXACT match: "run-z" resolves to the bound work-runtime link.
+        let link = db
+            .find_provider_timeline_link_by_run_id("run-z")
+            .unwrap()
+            .expect("run-z must resolve its own link");
+        assert_eq!(link.work_item_id.as_deref(), Some("work-runtime"));
+        assert_eq!(link.target_ref, "friday://provider-timeline/sess-z#run-z");
+
+        // SUPERSTRING must NOT match (exact trailing-segment): a search for "z" or "n-z" finds nothing.
+        assert!(db
+            .find_provider_timeline_link_by_run_id("z")
+            .unwrap()
+            .is_none());
+        assert!(db
+            .find_provider_timeline_link_by_run_id("n-z")
+            .unwrap()
+            .is_none());
+        // An unrelated run resolves to nothing.
+        assert!(db
+            .find_provider_timeline_link_by_run_id("run-absent")
+            .unwrap()
+            .is_none());
     }
 }

--- a/rust-core/crates/friday-hub/tests/resume_mission_workitem_completion.rs
+++ b/rust-core/crates/friday-hub/tests/resume_mission_workitem_completion.rs
@@ -1,0 +1,671 @@
+//! The resume → WorkItem-completion leg
+//! ([`friday_hub::mission_runtime::resume_agent_loop_for_mission`]) — closes the ONE gap left by
+//! the dark mission-bound run path: after an operator-signed approval EXECUTES the one paused
+//! mutation, advance the bound WorkItem `ProviderRouted → CompletedWithProof`.
+//!
+//! THE LOOPHOLE GATE is the canary of this suite: the WorkItem is advanced ONLY when the mutation
+//! ACTUALLY RAN (gate Allow + executor Ok). Every refusal / exec-failure must leave the WorkItem at
+//! `ProviderRouted` — minting a `CompletedWithProof` for a mutation that never ran is a FALSE PROOF
+//! (a security defect). The false-proof guards below assert the WorkItem is UNCHANGED on:
+//!   (i) a replayed/consumed nonce, (ii) an expired/bad-signature/HMAC approval, and
+//!   (iii) `mutation_exec_failed` (gate Allow but the executor returns Err).
+//! Plus the cross-mission proof-injection defense (resolve the WorkItem ONLY via the run's OWN
+//! pause-time link, never a wire-supplied id) and the flag-off / non-mission byte-identical path.
+//!
+//! This lives in `tests/` (NOT `src/`) because it constructs an operator SIGNING key to play the
+//! offline operator — `friday-hub/src/**` is forbidden from ever referencing `OperatorSigningKey`
+//! (the Hub holds only a verify key). Same reason as `a1_run_control` / `s6d_resume_ingestion`.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use friday_core::gate::{
+    canonical_action_bytes, canonical_approval_signature_bytes, ApprovalDecision,
+    CanonicalApproval, MutatingActionRequest, CANONICAL_GATE_ISSUER,
+};
+use friday_core::{
+    ApprovalState, FridayConversation, HandoffJudgmentMemory, Mission, MissionStatus, Risk,
+    SurfaceKind, SurfaceThread, TruthStatus, VisibilityPolicy, WorkItem, WorkItemStatus, WorkLane,
+};
+use friday_crypto::{OperatorSigningKey, OperatorVerifyingKey};
+use friday_hub::agent_run_control::resume as bare_resume;
+use friday_hub::mission_preflight::{
+    attach_provider_timeline_state, MissionAttachmentOutcome, ProviderTimelineAttachment,
+};
+use friday_hub::mission_runtime::resume_agent_loop_for_mission;
+use friday_hub::provider_timeline::PendingState;
+use friday_hub::{
+    build_request_with_policy, run_loop_with_policy, AgentError, AgentLlmClient, AgentStep,
+    ExecError, FsToolExecutor, LoopStatus, RawToolCall, RunPolicy, ToolExecutor, ToolReceipt,
+    TurnTrace,
+};
+use friday_storage::{agent_run, list_pending_requests_for_run, Db};
+
+static C: AtomicU64 = AtomicU64::new(0);
+
+fn unique(tag: &str) -> String {
+    format!(
+        "{}-{}-{}",
+        std::process::id(),
+        tag,
+        C.fetch_add(1, Ordering::Relaxed)
+    )
+}
+
+fn temp_db(tag: &str) -> String {
+    std::env::temp_dir()
+        .join(format!("friday-resume-mwic-{}.sqlite", unique(tag)))
+        .to_string_lossy()
+        .into_owned()
+}
+
+struct Workspace(std::path::PathBuf);
+impl Workspace {
+    fn new(tag: &str) -> Self {
+        let p = std::env::temp_dir().join(format!("friday-resume-mwic-ws-{}", unique(tag)));
+        std::fs::create_dir_all(&p).unwrap();
+        Workspace(p)
+    }
+    fn join(&self, n: &str) -> std::path::PathBuf {
+        self.0.join(n)
+    }
+}
+impl Drop for Workspace {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.0);
+    }
+}
+
+struct Script {
+    steps: std::cell::RefCell<std::vec::IntoIter<AgentStep>>,
+}
+impl Script {
+    fn new(steps: Vec<AgentStep>) -> Self {
+        Script {
+            steps: std::cell::RefCell::new(steps.into_iter()),
+        }
+    }
+}
+impl AgentLlmClient for Script {
+    fn propose_tool_call(&self, _task: &str) -> Result<RawToolCall, AgentError> {
+        Err(AgentError::Model("propose_tool_call unused".into()))
+    }
+    fn next_step(&self, _task: &str, _history: &[TurnTrace]) -> Result<AgentStep, AgentError> {
+        Ok(self.steps.borrow_mut().next().unwrap_or(AgentStep::Finish {
+            message: "done".into(),
+        }))
+    }
+}
+
+/// An executor that ALWAYS returns Err — used for the `mutation_exec_failed` guard (gate Allow but
+/// the executor fails). `FsToolExecutor` succeeds, so it cannot exercise that branch.
+struct FailingExec;
+impl ToolExecutor for FailingExec {
+    fn execute(
+        &self,
+        action: &str,
+        _params: &[(String, String)],
+    ) -> Result<ToolReceipt, ExecError> {
+        Err(ExecError::Unsupported(format!(
+            "forced exec failure: {action}"
+        )))
+    }
+}
+
+fn raw(action: &str, params: &[(&str, &str)]) -> RawToolCall {
+    RawToolCall {
+        action: action.to_string(),
+        params: params
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect(),
+    }
+}
+
+fn operator() -> (OperatorSigningKey, OperatorVerifyingKey) {
+    let sk = OperatorSigningKey::generate();
+    let vk = sk.verifying_key();
+    (sk, vk)
+}
+
+fn ed_approval(
+    req: &MutatingActionRequest,
+    sk: &OperatorSigningKey,
+    approval_id: &str,
+    expires_at: Option<i64>,
+) -> CanonicalApproval {
+    let digest = friday_crypto::action_digest(&canonical_action_bytes(req));
+    let mut a = CanonicalApproval {
+        decision: ApprovalDecision::Approved,
+        approval_id: approval_id.to_string(),
+        action_digest: digest,
+        expires_at,
+        issuer: Some(CANONICAL_GATE_ISSUER.to_string()),
+        signature: None,
+    };
+    a.signature = Some(sk.sign(&canonical_approval_signature_bytes(&a)).to_hex());
+    a
+}
+
+fn signed_blob(approval: &CanonicalApproval) -> Vec<u8> {
+    let decision = match approval.decision {
+        ApprovalDecision::Approved => "approved",
+        ApprovalDecision::Denied => "denied",
+    };
+    serde_json::json!({
+        "decision": decision,
+        "approval_id": approval.approval_id,
+        "action_digest": approval.action_digest,
+        "expires_at": approval.expires_at.unwrap(),
+        "issuer": approval.issuer,
+        "signature": approval.signature,
+    })
+    .to_string()
+    .into_bytes()
+}
+
+fn no_approval() -> impl Fn(&MutatingActionRequest) -> Option<CanonicalApproval> {
+    |_req| None
+}
+
+const NOW: i64 = 1_000;
+const FUTURE: i64 = 5_000_000_000_000;
+const PAST: i64 = 100; // an `expires_at` in the past ⇒ the gate refuses (expired).
+
+fn judgment(lane: WorkLane) -> HandoffJudgmentMemory {
+    HandoffJudgmentMemory {
+        task: "Run the Mission-bound mutating agent loop".into(),
+        current_blocker: None,
+        target_lane_thread_agent_provider: lane.as_str().into(),
+        read_first_files: vec!["rust-core/crates/friday-hub/src/mission_runtime.rs".into()],
+        required_output: "Mission-bound loop completion".into(),
+        done_criteria: vec!["loop bound + completed with proof".into()],
+        red_lines: vec!["never complete a mutation that did not run".into()],
+        why_this_route: "The WorkItem lane owns the agent loop.".into(),
+        considered_options: vec!["unbound run".into()],
+        deferred_options: vec!["multi-provider".into()],
+        previous_pitfalls: vec!["paused run looked completed".into()],
+        inheritable_context: vec!["Mission is product truth".into()],
+        proof_requirements: vec!["resume completion tests".into()],
+        ownership_claim_ids: Vec::new(),
+    }
+}
+
+/// Seed `FridayConversation -> Mission -> WorkItem` for ONE mission, with a distinct suffix so a
+/// single DB can hold two missions. `owner` is the WorkItem's bound principal (the run policy uses
+/// it, so the pending digest binds it).
+#[allow(clippy::too_many_arguments)]
+fn seed_mission(db: &Db, suffix: &str, owner: &str) {
+    let now = 1_700_000_000_000;
+    let mission_id = format!("mission-{suffix}");
+    let work_item_id = format!("work-{suffix}");
+    // The conversation id must be canonical (`fconv_*` with an underscore prefix — schema CHECK).
+    let fconv = format!("fconv_{suffix}");
+    let surface = format!("surface-{suffix}");
+    db.upsert_friday_conversation(&FridayConversation {
+        friday_conversation_id: fconv.clone(),
+        owner_principal: owner.into(),
+        title: "Resume completion".into(),
+        current_focus_summary: "Mission-bound mutating loop".into(),
+        active_mission_ids: vec![mission_id.clone()],
+        surface_thread_ids: vec![surface.clone()],
+        memory_scope_ref: None,
+        truth_status: TruthStatus::WiredRegistry,
+        proof_refs: vec!["proof://resume-mwic".into()],
+        created_at_ms: now,
+        updated_at_ms: now,
+    })
+    .unwrap();
+    db.upsert_mission(&Mission {
+        mission_id: mission_id.clone(),
+        friday_conversation_id: fconv.clone(),
+        title: "Resume completion".into(),
+        intent: "complete the bound WorkItem only on a proven mutation".into(),
+        status: MissionStatus::Active,
+        why_now: "resume must advance the bound WorkItem".into(),
+        decision_path_summary: "advance only on executed==true".into(),
+        considered_options: vec!["advance unconditionally".into()],
+        deferred_options: vec!["multi-provider".into()],
+        known_pitfalls: vec!["refused resume looked completed".into()],
+        handoff_inheritance: vec!["preserve route judgment".into()],
+        work_item_ids: vec![work_item_id.clone()],
+        memory_candidate_refs: Vec::new(),
+        context_passport_refs: Vec::new(),
+        proof_refs: vec!["proof://resume-mwic".into()],
+        created_at_ms: now,
+        updated_at_ms: now,
+    })
+    .unwrap();
+    db.upsert_surface_thread(&SurfaceThread {
+        surface_thread_id: surface,
+        friday_conversation_id: fconv,
+        mission_id: Some(mission_id.clone()),
+        surface_kind: SurfaceKind::Mobile,
+        channel_binding_id: None,
+        delivery_route: "mobile".into(),
+        visibility_policy: VisibilityPolicy::Compact,
+        allowed_actions: vec!["open_mission".into()],
+        last_seen_at_ms: Some(now),
+        last_delivered_event_seq: Some(1),
+        created_at_ms: now,
+        updated_at_ms: now,
+    })
+    .unwrap();
+    db.upsert_work_item(&WorkItem {
+        work_item_id,
+        mission_id,
+        lane: WorkLane::DeepSeek,
+        target_provider_or_agent: Some("deepseek".into()),
+        status: WorkItemStatus::ReadyToDispatch,
+        owner_claim_ids: Vec::new(),
+        workspace_refs: Vec::new(),
+        capability_id: Some("mission.resume".into()),
+        risk_level: Risk::Medium,
+        approval_state: ApprovalState::NotRequired,
+        blocking_reason: None,
+        input_refs: vec!["input://resume".into()],
+        output_refs: Vec::new(),
+        proof_requirements: vec!["resume completion tests".into()],
+        proof_receipts: Vec::new(),
+        judgment_memory: judgment(WorkLane::DeepSeek),
+        created_at_ms: now,
+        updated_at_ms: now,
+    })
+    .unwrap();
+}
+
+/// Drive a seeded WorkItem to `ProviderRouted` by replaying the pause-time provider-timeline
+/// states (SentToHub → AcceptedByHub → RoutedToProvider) with `request_id = run_id` — exactly the
+/// link an agent-loop pause writes (`friday://provider-timeline/{session}#{run_id}`). After this
+/// the WorkItem is at `ProviderRouted` with its OWN pause-time MissionLink in place.
+fn bind_to_provider_routed(db: &Db, suffix: &str, session_id: &str, run_id: &str) {
+    let mission_id = format!("mission-{suffix}");
+    let work_item_id = format!("work-{suffix}");
+    for state in [
+        PendingState::SentToHub,
+        PendingState::AcceptedByHub,
+        PendingState::RoutedToProvider,
+    ] {
+        let out = attach_provider_timeline_state(
+            db,
+            ProviderTimelineAttachment {
+                mission_id: mission_id.clone(),
+                work_item_id: work_item_id.clone(),
+                friday_session_id: session_id.to_string(),
+                request_id: run_id.to_string(),
+                state,
+                proof_ref: None,
+                now_ms: 1,
+            },
+        )
+        .unwrap();
+        assert!(matches!(out, MissionAttachmentOutcome::Attached { .. }));
+    }
+    assert_eq!(
+        db.get_work_item(&work_item_id).unwrap().unwrap().status,
+        WorkItemStatus::ProviderRouted
+    );
+}
+
+/// Create a real PAUSED, mutating run (a `write_file` Pause under deny-all) bound to `owner`, and
+/// return (nonce, the rebuilt request a signature must cover). Mirrors `a1_run_control`'s
+/// `pause_owned_run` but takes a caller-chosen `run_id`/`owner`/file so two runs can coexist.
+fn pause_run(
+    db: &Db,
+    ws: &Workspace,
+    run_id: &str,
+    owner: &str,
+    vk: &OperatorVerifyingKey,
+    out_file: &str,
+) -> (String, MutatingActionRequest) {
+    agent_run::create_run(db.conn(), run_id, "write a file", 1).unwrap();
+    let policy = RunPolicy::new(Some(owner.to_string()), Vec::<String>::new(), false);
+    let call = raw("write_file", &[("path", out_file), ("content", "RESUMED")]);
+    let client = Script::new(vec![AgentStep::Tool(call.clone())]);
+    let exec = FsToolExecutor::new(&ws.0);
+    let out = run_loop_with_policy(
+        &client,
+        &exec,
+        db.conn(),
+        run_id,
+        "write a file",
+        "",
+        Some(vk),
+        &no_approval(),
+        &policy,
+        5,
+        None,
+        None,
+        NOW,
+    )
+    .unwrap();
+    assert_eq!(out.status, LoopStatus::Paused);
+    let nonce = list_pending_requests_for_run(db.conn(), run_id).unwrap()[0]
+        .approval_id
+        .clone();
+    let request = build_request_with_policy(&call, &policy).unwrap();
+    (nonce, request)
+}
+
+fn work_status(db: &Db, suffix: &str) -> WorkItemStatus {
+    db.get_work_item(&format!("work-{suffix}"))
+        .unwrap()
+        .unwrap()
+        .status
+}
+
+// ─────────────────────────── executed==true → advance ───────────────────────────
+
+/// THE POSITIVE CONTROL: a correctly-signed resume that EXECUTES the one paused mutation advances
+/// the bound WorkItem ProviderRouted → CompletedWithProof, with proof_ref = friday://agent-run/{run}.
+#[test]
+fn executed_resume_advances_bound_work_item_to_completed_with_proof() {
+    let (sk, vk) = operator();
+    let db = Db::open_hub(&temp_db("ok")).unwrap();
+    let ws = Workspace::new("ok");
+    let owner = "owner:alice";
+    let run_id = "run-ok";
+    seed_mission(&db, "ok", owner);
+    bind_to_provider_routed(&db, "ok", "friday-session-ok", run_id);
+    let (nonce, request) = pause_run(&db, &ws, run_id, owner, &vk, "out-ok.txt");
+    let exec = FsToolExecutor::new(&ws.0);
+
+    let approval = ed_approval(&request, &sk, &nonce, Some(FUTURE));
+    let outcome =
+        resume_agent_loop_for_mission(&db, &exec, &vk, run_id, &signed_blob(&approval), NOW)
+            .unwrap();
+
+    assert!(outcome.accepted, "the mutation must have executed");
+    assert_eq!(outcome.status, "mutation_completed");
+    assert_eq!(
+        std::fs::read_to_string(ws.join("out-ok.txt")).unwrap(),
+        "RESUMED"
+    );
+
+    let item = db.get_work_item("work-ok").unwrap().unwrap();
+    assert_eq!(item.status, WorkItemStatus::CompletedWithProof);
+    assert!(
+        item.proof_receipts
+            .contains(&format!("friday://agent-run/{run_id}")),
+        "the run is the completion proof: {:?}",
+        item.proof_receipts
+    );
+    // The completion UPSERTS the SAME pause-time link (no second provider_timeline link minted),
+    // so a future resolution stays unambiguous.
+    let pt_links: Vec<_> = db
+        .list_mission_links("mission-ok")
+        .unwrap()
+        .into_iter()
+        .filter(|l| l.link_kind == friday_core::MissionLinkKind::ProviderTimeline)
+        .collect();
+    assert_eq!(
+        pt_links.len(),
+        1,
+        "exactly one provider_timeline link (upserted, not duplicated): {pt_links:?}"
+    );
+    assert_eq!(
+        pt_links[0].target_ref,
+        format!("friday://provider-timeline/friday-session-ok#{run_id}")
+    );
+}
+
+// ─────────────────────────── FALSE-PROOF GUARDS ───────────────────────────
+// Each MUST leave the WorkItem at ProviderRouted with NO completion proof.
+
+/// (i) A replayed/consumed nonce: the first resume executes + advances; a SECOND resume of the SAME
+/// approval is replay-refused (executed==false) and must NOT re-touch / clobber the WorkItem.
+#[test]
+fn false_proof_guard_replayed_nonce_does_not_re_advance() {
+    let (sk, vk) = operator();
+    let db = Db::open_hub(&temp_db("replay")).unwrap();
+    let ws = Workspace::new("replay");
+    let owner = "owner:alice";
+    let run_id = "run-replay";
+    seed_mission(&db, "replay", owner);
+    bind_to_provider_routed(&db, "replay", "friday-session-replay", run_id);
+    let (nonce, request) = pause_run(&db, &ws, run_id, owner, &vk, "out-replay.txt");
+    let exec = FsToolExecutor::new(&ws.0);
+    let approval = ed_approval(&request, &sk, &nonce, Some(FUTURE));
+
+    // First resume executes + completes.
+    let first =
+        resume_agent_loop_for_mission(&db, &exec, &vk, run_id, &signed_blob(&approval), NOW)
+            .unwrap();
+    assert!(first.accepted);
+    assert_eq!(
+        work_status(&db, "replay"),
+        WorkItemStatus::CompletedWithProof
+    );
+
+    // REPLAY: the same approval (consumed nonce) is refused — executed==false. The WorkItem must be
+    // unchanged (still CompletedWithProof, never re-driven through an illegal backward transition).
+    let replay =
+        resume_agent_loop_for_mission(&db, &exec, &vk, run_id, &signed_blob(&approval), NOW + 1)
+            .unwrap();
+    assert!(!replay.accepted, "a replayed nonce must not execute");
+    assert_eq!(
+        work_status(&db, "replay"),
+        WorkItemStatus::CompletedWithProof
+    );
+}
+
+/// (ii) An EXPIRED (and separately, a BAD-SIGNATURE) approval is a gate Deny (executed==false): the
+/// WorkItem stays ProviderRouted, no proof.
+#[test]
+fn false_proof_guard_expired_or_bad_signature_leaves_work_item_unchanged() {
+    let (sk, vk) = operator();
+    let db = Db::open_hub(&temp_db("expired")).unwrap();
+    let ws = Workspace::new("expired");
+    let owner = "owner:alice";
+    let run_id = "run-expired";
+    seed_mission(&db, "expired", owner);
+    bind_to_provider_routed(&db, "expired", "friday-session-expired", run_id);
+    let (nonce, request) = pause_run(&db, &ws, run_id, owner, &vk, "out-expired.txt");
+    let exec = FsToolExecutor::new(&ws.0);
+
+    // Expired: a correctly-signed approval whose expires_at is in the past.
+    let expired = ed_approval(&request, &sk, &nonce, Some(PAST));
+    let out = resume_agent_loop_for_mission(&db, &exec, &vk, run_id, &signed_blob(&expired), NOW)
+        .unwrap();
+    assert!(!out.accepted, "an expired approval must not execute");
+    assert!(!ws.join("out-expired.txt").exists());
+    assert_eq!(work_status(&db, "expired"), WorkItemStatus::ProviderRouted);
+
+    // Bad signature: sign with a DIFFERENT operator key (the Hub's verify key won't verify it).
+    let (other_sk, _other_vk) = operator();
+    let forged = ed_approval(&request, &other_sk, &nonce, Some(FUTURE));
+    let out =
+        resume_agent_loop_for_mission(&db, &exec, &vk, run_id, &signed_blob(&forged), NOW).unwrap();
+    assert!(!out.accepted, "a wrong-key signature must not execute");
+    assert!(!ws.join("out-expired.txt").exists());
+    assert_eq!(work_status(&db, "expired"), WorkItemStatus::ProviderRouted);
+}
+
+/// (iii) `mutation_exec_failed`: gate Allow but the EXECUTOR returns Err (executed==false). The
+/// approval verifies + the nonce is consumed, but no mutation ran — the WorkItem must stay
+/// ProviderRouted (the most dangerous false-proof: the gate said yes). Uses a FailingExec.
+#[test]
+fn false_proof_guard_exec_failed_leaves_work_item_unchanged() {
+    let (sk, vk) = operator();
+    let db = Db::open_hub(&temp_db("execfail")).unwrap();
+    let ws = Workspace::new("execfail");
+    let owner = "owner:alice";
+    let run_id = "run-execfail";
+    seed_mission(&db, "execfail", owner);
+    bind_to_provider_routed(&db, "execfail", "friday-session-execfail", run_id);
+    // The pending row / digest are built with the SAME write_file action; the run loop itself used
+    // an FsToolExecutor to PAUSE (it never executed). The RESUME uses the FailingExec.
+    let (nonce, request) = pause_run(&db, &ws, run_id, owner, &vk, "out-execfail.txt");
+
+    let approval = ed_approval(&request, &sk, &nonce, Some(FUTURE));
+    let out =
+        resume_agent_loop_for_mission(&db, &FailingExec, &vk, run_id, &signed_blob(&approval), NOW)
+            .unwrap();
+    assert!(
+        !out.accepted,
+        "gate Allow + executor Err is executed==false (mutation_exec_failed)"
+    );
+    assert_eq!(out.status, "mutation_exec_failed");
+    assert_eq!(
+        work_status(&db, "execfail"),
+        WorkItemStatus::ProviderRouted,
+        "an exec-failed mutation must NEVER complete the WorkItem"
+    );
+}
+
+// ─────────────────────────── cross-mission injection ───────────────────────────
+
+/// CROSS-MISSION PROOF INJECTION: two missions, two paused runs whose run_ids share a SUFFIX
+/// (`run-x` and `extra-run-x`). Resuming `run-x` must advance ONLY mission-x's WorkItem; the other
+/// (whose link target_ref ends `#extra-run-x`) must stay ProviderRouted. Proves the resolver matches
+/// the EXACT trailing `#`-segment, never a substring/ends_with — and resolves the WorkItem ONLY via
+/// the run's OWN link (never a wire-supplied id).
+#[test]
+fn cross_mission_resume_advances_only_its_own_work_item() {
+    let (sk, vk) = operator();
+    let db = Db::open_hub(&temp_db("xmission")).unwrap();
+    let ws = Workspace::new("xmission");
+    let owner = "owner:alice";
+
+    // mission-x bound to run "run-x"; mission-y bound to run "extra-run-x" (a SUPERSTRING of run-x).
+    seed_mission(&db, "x", owner);
+    seed_mission(&db, "y", owner);
+    bind_to_provider_routed(&db, "x", "friday-session-x", "run-x");
+    bind_to_provider_routed(&db, "y", "friday-session-y", "extra-run-x");
+
+    let (nonce_x, request_x) = pause_run(&db, &ws, "run-x", owner, &vk, "out-x.txt");
+    let (_nonce_y, _request_y) = pause_run(&db, &ws, "extra-run-x", owner, &vk, "out-y.txt");
+    let exec = FsToolExecutor::new(&ws.0);
+
+    // Resume ONLY run-x with its own approval.
+    let approval_x = ed_approval(&request_x, &sk, &nonce_x, Some(FUTURE));
+    let out =
+        resume_agent_loop_for_mission(&db, &exec, &vk, "run-x", &signed_blob(&approval_x), NOW)
+            .unwrap();
+    assert!(out.accepted);
+
+    assert_eq!(
+        work_status(&db, "x"),
+        WorkItemStatus::CompletedWithProof,
+        "the resumed run's OWN WorkItem advances"
+    );
+    assert_eq!(
+        work_status(&db, "y"),
+        WorkItemStatus::ProviderRouted,
+        "the suffix-sharing foreign WorkItem must NOT be advanced (exact #-segment match)"
+    );
+    // The foreign mission's WorkItem carries no proof from run-x.
+    let item_y = db.get_work_item("work-y").unwrap().unwrap();
+    assert!(item_y.proof_receipts.is_empty());
+}
+
+// ─────────────────────────── flag-off / non-mission byte-identical ───────────────────────────
+
+/// A run with NO resolvable bound WorkItem (an unbound paused run — no provider_timeline link) must
+/// resume BYTE-IDENTICALLY to the bare `agent_run_control::resume`: same `accepted`/`status`, and no
+/// WorkItem touched (there is none). Proves the no-binding fallthrough is a pure pass-through.
+#[test]
+fn non_mission_resume_is_byte_identical_to_bare_resume() {
+    let (sk, vk) = operator();
+
+    // (A) via the mission wrapper, on an UNBOUND run (no mission link).
+    let db_a = Db::open_hub(&temp_db("nonmission-a")).unwrap();
+    let ws_a = Workspace::new("nonmission-a");
+    let (nonce_a, req_a) = pause_run(&db_a, &ws_a, "run-unbound", "owner:alice", &vk, "out-a.txt");
+    let exec_a = FsToolExecutor::new(&ws_a.0);
+    let approval_a = ed_approval(&req_a, &sk, &nonce_a, Some(FUTURE));
+    let via_wrapper = resume_agent_loop_for_mission(
+        &db_a,
+        &exec_a,
+        &vk,
+        "run-unbound",
+        &signed_blob(&approval_a),
+        NOW,
+    )
+    .unwrap();
+
+    // (B) via the BARE resume, identical setup in a fresh DB/ws.
+    let db_b = Db::open_hub(&temp_db("nonmission-b")).unwrap();
+    let ws_b = Workspace::new("nonmission-b");
+    let (nonce_b, req_b) = pause_run(&db_b, &ws_b, "run-unbound", "owner:alice", &vk, "out-b.txt");
+    let exec_b = FsToolExecutor::new(&ws_b.0);
+    let approval_b = ed_approval(&req_b, &sk, &nonce_b, Some(FUTURE));
+    let via_bare = bare_resume(
+        db_b.conn(),
+        &exec_b,
+        &vk,
+        "run-unbound",
+        &signed_blob(&approval_b),
+        NOW,
+    )
+    .unwrap();
+
+    // Same op + accepted + coarse status; both executed the mutation (no WorkItem to advance).
+    assert_eq!(via_wrapper.op, via_bare.op);
+    assert_eq!(via_wrapper.accepted, via_bare.accepted);
+    assert_eq!(via_wrapper.status, via_bare.status);
+    assert!(via_wrapper.accepted);
+    assert_eq!(via_wrapper.status, "mutation_completed");
+    // The wrapper created NO WorkItem and NO mission link out of thin air.
+    assert_eq!(
+        db_a.conn()
+            .query_row("SELECT count(*) FROM mission_link", [], |r| r
+                .get::<_, i64>(0))
+            .unwrap(),
+        0,
+        "an unbound resume must not mint a mission link"
+    );
+    assert_eq!(
+        db_a.conn()
+            .query_row("SELECT count(*) FROM work_item", [], |r| r.get::<_, i64>(0))
+            .unwrap(),
+        0,
+        "an unbound resume must not mint a WorkItem"
+    );
+}
+
+// ─────────────────────────── no double-advance (idempotency) ───────────────────────────
+
+/// Resuming an already-`CompletedWithProof` run is idempotent: the FIRST resume completes it; a
+/// SECOND (consumed-nonce) resume is executed==false ⇒ no advance, no illegal backward transition,
+/// no panic. The WorkItem stays CompletedWithProof. (Same nonce can't re-execute; this asserts the
+/// completion leg itself never errors on an already-completed WorkItem.)
+#[test]
+fn no_double_advance_on_already_completed_run() {
+    let (sk, vk) = operator();
+    let db = Db::open_hub(&temp_db("double")).unwrap();
+    let ws = Workspace::new("double");
+    let owner = "owner:alice";
+    let run_id = "run-double";
+    seed_mission(&db, "double", owner);
+    bind_to_provider_routed(&db, "double", "friday-session-double", run_id);
+    let (nonce, request) = pause_run(&db, &ws, run_id, owner, &vk, "out-double.txt");
+    let exec = FsToolExecutor::new(&ws.0);
+    let approval = ed_approval(&request, &sk, &nonce, Some(FUTURE));
+
+    let first =
+        resume_agent_loop_for_mission(&db, &exec, &vk, run_id, &signed_blob(&approval), NOW)
+            .unwrap();
+    assert!(first.accepted);
+    assert_eq!(
+        work_status(&db, "double"),
+        WorkItemStatus::CompletedWithProof
+    );
+    let item_after_first = db.get_work_item("work-double").unwrap().unwrap();
+
+    // Second resume: refused (consumed nonce) ⇒ no advance. The completion leg is never reached
+    // (executed==false short-circuits), so the WorkItem is byte-for-byte unchanged.
+    let second =
+        resume_agent_loop_for_mission(&db, &exec, &vk, run_id, &signed_blob(&approval), NOW + 1)
+            .unwrap();
+    assert!(!second.accepted);
+    let item_after_second = db.get_work_item("work-double").unwrap().unwrap();
+    assert_eq!(item_after_first.status, item_after_second.status);
+    assert_eq!(
+        item_after_first.proof_receipts,
+        item_after_second.proof_receipts
+    );
+    assert_eq!(
+        item_after_first.updated_at_ms,
+        item_after_second.updated_at_ms
+    );
+}

--- a/rust-core/crates/friday-storage/src/lib.rs
+++ b/rust-core/crates/friday-storage/src/lib.rs
@@ -835,6 +835,23 @@ impl Db {
         mission::list_mission_links(&self.conn, mission_id)
     }
 
+    /// Resolve the SINGLE `provider_timeline` [`MissionLink`] whose `target_ref` encodes EXACTLY
+    /// this `run_id` as its trailing `#`-segment (the agent-loop pause-time binding). The run's OWN
+    /// binding — carries the bound `mission_id` + `work_item_id` directly — so a resume-completion
+    /// leg never trusts a wire-supplied work_item_id. Fail-closed (`Ok(None)`) on zero or ambiguous
+    /// (>1) matches. See [`mission::find_provider_timeline_link_by_run_id`].
+    pub fn find_provider_timeline_link_by_run_id(
+        &self,
+        run_id: &str,
+    ) -> Result<Option<MissionLink>> {
+        if self.profile != Profile::Hub {
+            return Err(StorageError::Unsupported(
+                "Mission links are Hub-only".into(),
+            ));
+        }
+        mission::find_provider_timeline_link_by_run_id(&self.conn, run_id)
+    }
+
     pub fn upsert_route_decision(&self, card: &RouteDecisionCard) -> Result<()> {
         if self.profile != Profile::Hub {
             return Err(StorageError::Unsupported(

--- a/rust-core/crates/friday-storage/src/mission.rs
+++ b/rust-core/crates/friday-storage/src/mission.rs
@@ -1415,6 +1415,67 @@ pub fn list_mission_links(conn: &Connection, mission_id: &str) -> Result<Vec<Mis
     Ok(out)
 }
 
+/// Resolve the SINGLE `provider_timeline` [`MissionLink`] whose `target_ref` encodes EXACTLY this
+/// `run_id` as its trailing `#`-segment (the pause-time binding an agent-loop run writes —
+/// `friday://provider-timeline/{session}#{run_id}`, see
+/// `friday_hub::mission_preflight::attach_provider_timeline_state_guarded`'s `target_ref`).
+///
+/// This is the run's OWN binding: it carries the bound `mission_id` + `work_item_id` directly, so a
+/// resume-completion leg can resolve the WorkItem to advance WITHOUT trusting any wire-supplied
+/// work_item_id (the cross-mission proof-injection defense). The match is EXACT on the segment after
+/// the LAST `#` (`rsplit_once('#')`), never a substring/`ends_with` — `run-x` must not resolve a
+/// link bound to `prefix-run-x`. Fail-closed on ambiguity: returns `Ok(None)` if ZERO links match
+/// OR if MORE THAN ONE matches (an ambiguous binding is never advanced). `run_id` is matched in Rust
+/// (not via a SQL `LIKE`), so a `run_id` containing SQL wildcards cannot widen the match.
+pub fn find_provider_timeline_link_by_run_id(
+    conn: &Connection,
+    run_id: &str,
+) -> Result<Option<MissionLink>> {
+    let mut stmt = conn.prepare(
+        "SELECT link_id, mission_id, work_item_id, link_kind, target_ref, proof_ref, created_at_ms
+         FROM mission_link
+         WHERE link_kind = 'provider_timeline'
+         ORDER BY created_at_ms, link_id",
+    )?;
+    let rows = stmt.query_map([], |r| {
+        Ok((
+            r.get::<_, String>(0)?,
+            r.get::<_, String>(1)?,
+            r.get::<_, Option<String>>(2)?,
+            r.get::<_, String>(3)?,
+            r.get::<_, String>(4)?,
+            r.get::<_, Option<String>>(5)?,
+            r.get::<_, i64>(6)?,
+        ))
+    })?;
+    let mut matched: Option<MissionLink> = None;
+    for row in rows {
+        let (link_id, mission_id, work_item_id, link_kind, target_ref, proof_ref, created_at_ms) =
+            row?;
+        // EXACT match on the segment after the LAST '#'. A target_ref with no '#' never matches.
+        let is_match = target_ref
+            .rsplit_once('#')
+            .is_some_and(|(_, tail)| tail == run_id);
+        if !is_match {
+            continue;
+        }
+        if matched.is_some() {
+            // Ambiguous: more than one provider_timeline link encodes this run_id ⇒ fail-closed.
+            return Ok(None);
+        }
+        matched = Some(MissionLink {
+            link_id,
+            mission_id,
+            work_item_id,
+            link_kind: parse_mission_link_kind(link_kind)?,
+            target_ref,
+            proof_ref,
+            created_at_ms,
+        });
+    }
+    Ok(matched)
+}
+
 pub fn upsert_route_decision(conn: &Connection, card: &RouteDecisionCard) -> Result<()> {
     card.validate().map_err(|e| unsupported(e.to_string()))?;
     let work_item_mission_id: Option<String> = conn


### PR DESCRIPTION
## What
Closes the one gap in the mutating mission-bound run loop: after an operator-signed resume **executes** the approved mutation, advance the bound WorkItem `ProviderRouted → CompletedWithProof` with proof receipt `friday://agent-run/{run_id}`. New `resume_agent_loop_for_mission` in mission_runtime.rs; wired into `Message::AgentRunResume` only under `FRIDAY_MISSION_BOUND_RUN` (else byte-identical to today's bare resume). runtime.rs untouched.

## The loophole gate (security-critical)
WorkItem advance is gated **strictly on `outcome.executed == true`** (gate Allow + executor Ok). Every refusal path — replayed/consumed nonce, expired/bad-signature, `mutation_exec_failed` — returns `executed:false` and leaves the WorkItem at `ProviderRouted` (NO false proof). WorkItem resolved ONLY via the run's own pause-time mission_link (no cross-mission proof-injection); static SQL (no injection); `transition_work_item_status` rejects CompletedWithProof without a receipt as a final backstop.

## Tests (7, false-proof guards are the canary)
executed→advance; replayed-nonce / expired-bad-sig / exec-failed → unchanged; cross-mission → own-only; non-mission → byte-identical; no-double-advance. clippy 0, fmt clean.

## Dark + follow-up
Dark behind FRIDAY_MISSION_BOUND_RUN. Live signed-mutation proof needs operator key-custody (S6e) + an Ed25519 signature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)