### PR TITLE
feat(memory): wire memory-spine dispatch adapter into hub bootstrap (dark, additive)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -905,14 +905,14 @@
         "filename": "test/unit/hub/friday-hub-bootstrap-env.test.ts",
         "hashed_secret": "5c5a15a8b0b3e154d77746945e563ba40100681b",
         "is_verified": false,
-        "line_number": 135
+        "line_number": 136
       },
       {
         "type": "Secret Keyword",
         "filename": "test/unit/hub/friday-hub-bootstrap-env.test.ts",
         "hashed_secret": "8a8281cec699f5e51330e21dd7fab3531af6ef0c",
         "is_verified": false,
-        "line_number": 136
+        "line_number": 137
       }
     ],
     "test/unit/media-understanding/friday-openai-vision-provider.test.ts": [
@@ -1124,5 +1124,5 @@
       }
     ]
   },
-  "generated_at": "2026-06-14T05:43:03Z"
+  "generated_at": "2026-06-14T19:53:16Z"
 }

--- a/src/hub/bootstrap/hub-helpers.ts
+++ b/src/hub/bootstrap/hub-helpers.ts
@@ -1989,6 +1989,18 @@ export interface FridayHubConfig {
    * config wins; otherwise the `FRIDAY_MISSION_SPINE_ROUTES_VIA_RUST` env knob).
    */
   routeMissionSpineViaRust?: boolean;
+  /**
+   * (Lane M) ORGANIC memory-confirmation POST route bridge (DARK): "wire a real dispatch adapter into
+   * `memorySpine.dispatch` so `/v1/memory-spine/decide` becomes CALLABLE" flag. DEFAULT-FALSE —
+   * production hub creation must leave this unset so `memorySpine.dispatch` stays unset (null) and the
+   * POST route returns today's fail-closed 503 (`MEMORY_SPINE_DISPATCH_UNAVAILABLE`) → byte-identical.
+   * When true, bootstrap builds the sealed-WS dispatch adapter (mirroring the mission-spine sealed-WS
+   * config) and injects it. End-to-end memory-confirmation closure ALSO needs the SERVER flags
+   * (`FRIDAY_MEMORY_CONFIRM`, `FRIDAY_RUN_LOOP_MEMORY_EXTRACTION`) + a deploy (operator-gated). This
+   * client-side knob only makes the TS route CALLABLE. Resolution: `resolveRouteMemorySpineViaRust`
+   * (explicit config wins; otherwise the `FRIDAY_MEMORY_SPINE_ROUTES_VIA_RUST` env knob).
+   */
+  routeMemorySpineViaRust?: boolean;
 }
 
 // ─── Resolved Hub Config ───

--- a/src/hub/friday-hub-bootstrap.ts
+++ b/src/hub/friday-hub-bootstrap.ts
@@ -124,6 +124,10 @@ import {
   createFridayMissionSpineDispatchAdapter,
   readMissionSpineRustWsPort,
 } from "../api/mission-spine/friday-mission-spine-dispatch-adapter.js";
+import {
+  createFridayMemorySpineDispatchAdapter,
+  readMemorySpineRustWsPort,
+} from "../api/mission-spine/friday-memory-spine-dispatch-adapter.js";
 import { resolveRustAgentRunWsClientX25519Secret } from "../api/mission-spine/friday-rust-hub-agent-run-ws-client-x25519-secret.js";
 import type { FridayChannelPersonaConfig, FridayGuideLensRoutesDeps, FridaySystemRoutesDeps } from "#api";
 import type { FridayPackagingRoutesDeps } from "../api/http/routes/friday-packaging-routes.js";
@@ -1052,6 +1056,38 @@ export function resolveRouteMissionSpineViaRust(
     return configValue;
   }
   const raw = (env.FRIDAY_MISSION_SPINE_ROUTES_VIA_RUST ?? "").trim().toLowerCase();
+  return raw === "1" || raw === "true";
+}
+
+/**
+ * (Lane M) ORGANIC memory-confirmation POST route bridge (DARK): single source of truth resolving the
+ * `routeMemorySpineViaRust` flag from (1) an EXPLICIT {@link FridayHubConfig.routeMemorySpineViaRust}
+ * and, only as a fallback, (2) the `FRIDAY_MEMORY_SPINE_ROUTES_VIA_RUST` env var — the operator knob
+ * that flips the organic POST route (`/v1/memory-spine/decide`) from PERMANENTLY fail-closed (503
+ * `MEMORY_SPINE_DISPATCH_UNAVAILABLE`, because `memorySpine.dispatch` is never injected) to LIVE — by
+ * wiring a real dispatch adapter over the sealed-WS client.
+ *
+ * PRECEDENCE + PARSE mirror {@link resolveRouteMissionSpineViaRust} exactly: an explicit config boolean
+ * (true OR false) ALWAYS wins; the env is consulted ONLY when config does not specify. Case-insensitive,
+ * trimmed `"1"` or `"true"` ⇒ true; ABSENT / `""` / `"0"` / `"false"` / ANY other value ⇒ false.
+ * DEFAULT (both unset) ⇒ false, so `memorySpine.dispatch` stays unset (null) and the POST route is
+ * byte-identical to today's fail-closed 503.
+ *
+ * NOTE: the env var name deliberately mirrors the mission-spine `FRIDAY_MISSION_SPINE_ROUTES_VIA_RUST`
+ * sibling (it is `FRIDAY_MEMORY_SPINE_ROUTES_VIA_RUST`) to read clearly as "the memory-spine ROUTES
+ * knob". End-to-end memory-confirmation closure ALSO needs the SERVER flags (`FRIDAY_MEMORY_CONFIRM`,
+ * `FRIDAY_RUN_LOOP_MEMORY_EXTRACTION`) + a deploy (operator-gated); this client-side knob only makes
+ * the TS route CALLABLE.
+ */
+export function resolveRouteMemorySpineViaRust(
+  configValue: boolean | undefined,
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  // Config explicit (true OR false) wins — env is the fallback for the unset gap only.
+  if (typeof configValue === "boolean") {
+    return configValue;
+  }
+  const raw = (env.FRIDAY_MEMORY_SPINE_ROUTES_VIA_RUST ?? "").trim().toLowerCase();
   return raw === "1" || raw === "true";
 }
 
@@ -7036,6 +7072,28 @@ export async function createFridayHub(
     })
     : null;
 
+  // (Lane M) ORGANIC memory-confirmation POST route (DARK): construct the dispatch adapter that makes
+  // `/v1/memory-spine/decide` CALLABLE — but ONLY when the operator flag is on. SINGLE SOURCE OF TRUTH =
+  // `resolveRouteMemorySpineViaRust` (explicit config wins; else the `FRIDAY_MEMORY_SPINE_ROUTES_VIA_RUST`
+  // env knob, case-insensitive "1"/"true" → true; anything else, incl. unset → false). With nothing set
+  // (the default) this is `false`, so the adapter is NOT built, the `memorySpine` deps object is omitted
+  // entirely (undefined below) → the route resolves its own default (`dispatch: null`) and returns today's
+  // fail-closed 503 (`MEMORY_SPINE_DISPATCH_UNAVAILABLE`) → byte-identical.
+  //
+  // SIDE-EFFECT-FREE construction: the adapter factory captures host/port + the SecureStore X25519 secret
+  // resolver only — it resolves NO secret and opens NO socket here. The secret is resolved + the sealed
+  // client built LAZILY, per route call, so a flag-ON-but-unprovisioned host FAILS CLOSED (503) per call
+  // rather than crashing boot. Config (endpoint + ECDH secret resolver) MIRRORS the mission-spine sealed-WS
+  // path above; memory decisions are refs-only WS round-trips (no DB readback), same as mission.
+  const routeMemorySpineViaRust = resolveRouteMemorySpineViaRust(config.routeMemorySpineViaRust);
+  const memorySpineDispatch = routeMemorySpineViaRust
+    ? createFridayMemorySpineDispatchAdapter({
+      host: process.env.FRIDAY_HUB_AGENT_RUN_WS_HOST ?? "127.0.0.1",
+      port: readMemorySpineRustWsPort(process.env.FRIDAY_HUB_AGENT_RUN_WS_PORT),
+      secretResolver: resolveRustAgentRunWsClientX25519Secret,
+    })
+    : null;
+
   const runtimeSupportedChannelKinds = FRIDAY_SUPPORTED_CHANNEL_KINDS.filter(isFridayChannelKindSupported);
 
   const apiRuntime = createFridayApiRuntime({
@@ -7122,6 +7180,11 @@ export async function createFridayHub(
       ...(missionSpineDispatch ? { dispatch: missionSpineDispatch } : {}),
       disabledReason: null,
     },
+    // (Lane M) DARK: the `memorySpine` deps object is provided ONLY when the route flag is on (above).
+    // With the flag off `memorySpineDispatch` is null → this is `undefined`, the runtime falls back to
+    // the route's own default (`dispatch: null`), and `POST /v1/memory-spine/decide` is fail-closed 503
+    // (`MEMORY_SPINE_DISPATCH_UNAVAILABLE`) → byte-identical to today.
+    memorySpine: memorySpineDispatch ? { dispatch: memorySpineDispatch } : undefined,
     uix: {
       service: uixService,
       readSetupCompletedAt,

--- a/src/hub/index.ts
+++ b/src/hub/index.ts
@@ -40,6 +40,7 @@ export {
   resolveAgentRunControlViaRust,
   resolveRouteAgentRunViaRust,
   resolveRouteMissionSpineViaRust,
+  resolveRouteMemorySpineViaRust,
   resolveRouteProvidersViaRust,
   resolveRouteWorkflowsViaRust,
   sanitizeFridayChannelVisibleReply,

--- a/test/unit/hub/friday-hub-bootstrap-env.test.ts
+++ b/test/unit/hub/friday-hub-bootstrap-env.test.ts
@@ -6,6 +6,7 @@ import {
   resolveFridayHubConfig,
   resolveRouteAgentRunViaRust,
   resolveRouteMissionSpineViaRust,
+  resolveRouteMemorySpineViaRust,
   resolveRouteProvidersViaRust,
   resolveRouteWorkflowsViaRust,
 } from "#hub";
@@ -530,5 +531,38 @@ describe("resolveRouteMissionSpineViaRust (Lane B-2 organic POST routes flag)", 
     expect(resolveRouteMissionSpineViaRust(true, emptyEnv())).toBe(true);
     expect(resolveRouteMissionSpineViaRust(false, { FRIDAY_MISSION_SPINE_ROUTES_VIA_RUST: "1" })).toBe(false);
     expect(resolveRouteMissionSpineViaRust(false, { FRIDAY_MISSION_SPINE_ROUTES_VIA_RUST: "true" })).toBe(false);
+  });
+});
+
+describe("resolveRouteMemorySpineViaRust (Lane M organic memory-confirmation POST route flag)", () => {
+  // DEFAULT-OFF: nothing set → false → memorySpine.dispatch stays null → byte-identical 503.
+  it("defaults to false when neither config nor env is set", () => {
+    expect(resolveRouteMemorySpineViaRust(undefined, emptyEnv())).toBe(false);
+  });
+
+  it("parses FRIDAY_MEMORY_SPINE_ROUTES_VIA_RUST 1/true (case-insensitive, trimmed) as true", () => {
+    expect(resolveRouteMemorySpineViaRust(undefined, { FRIDAY_MEMORY_SPINE_ROUTES_VIA_RUST: "1" })).toBe(true);
+    expect(resolveRouteMemorySpineViaRust(undefined, { FRIDAY_MEMORY_SPINE_ROUTES_VIA_RUST: "true" })).toBe(true);
+    expect(resolveRouteMemorySpineViaRust(undefined, { FRIDAY_MEMORY_SPINE_ROUTES_VIA_RUST: "TRUE" })).toBe(true);
+    expect(resolveRouteMemorySpineViaRust(undefined, { FRIDAY_MEMORY_SPINE_ROUTES_VIA_RUST: "  1  " })).toBe(true);
+    expect(resolveRouteMemorySpineViaRust(undefined, { FRIDAY_MEMORY_SPINE_ROUTES_VIA_RUST: " true " })).toBe(true);
+  });
+
+  // Fail-safe OFF: everything that is not exactly "1"/"true" → false.
+  it("treats 0, false, empty, and garbage env values as false (fail-safe off)", () => {
+    expect(resolveRouteMemorySpineViaRust(undefined, { FRIDAY_MEMORY_SPINE_ROUTES_VIA_RUST: "0" })).toBe(false);
+    expect(resolveRouteMemorySpineViaRust(undefined, { FRIDAY_MEMORY_SPINE_ROUTES_VIA_RUST: "false" })).toBe(false);
+    expect(resolveRouteMemorySpineViaRust(undefined, { FRIDAY_MEMORY_SPINE_ROUTES_VIA_RUST: "" })).toBe(false);
+    expect(resolveRouteMemorySpineViaRust(undefined, { FRIDAY_MEMORY_SPINE_ROUTES_VIA_RUST: "yes" })).toBe(false);
+    expect(resolveRouteMemorySpineViaRust(undefined, { FRIDAY_MEMORY_SPINE_ROUTES_VIA_RUST: "on" })).toBe(false);
+    expect(resolveRouteMemorySpineViaRust(undefined, { FRIDAY_MEMORY_SPINE_ROUTES_VIA_RUST: "2" })).toBe(false);
+  });
+
+  // PRECEDENCE: explicit config wins over env (true wins, AND the discriminating false-beats-env-true).
+  it("uses explicit config over the env (true wins; false beats env true)", () => {
+    expect(resolveRouteMemorySpineViaRust(true, { FRIDAY_MEMORY_SPINE_ROUTES_VIA_RUST: "0" })).toBe(true);
+    expect(resolveRouteMemorySpineViaRust(true, emptyEnv())).toBe(true);
+    expect(resolveRouteMemorySpineViaRust(false, { FRIDAY_MEMORY_SPINE_ROUTES_VIA_RUST: "1" })).toBe(false);
+    expect(resolveRouteMemorySpineViaRust(false, { FRIDAY_MEMORY_SPINE_ROUTES_VIA_RUST: "true" })).toBe(false);
   });
 });


### PR DESCRIPTION
## Gap closed
`POST /v1/memory-spine/decide` is permanently **503** (`MEMORY_SPINE_DISPATCH_UNAVAILABLE`) today because `deps.memorySpine` is never set in the hub bootstrap. The dispatch adapter (`createFridayMemorySpineDispatchAdapter`, added by #754) and the runtime threading (`memorySpine: deps.memorySpine`, route default `dispatch: null`) already exist — only the bootstrap **construct + pass** was missing. This PR adds exactly that wiring, making the route **wireable** (still default-OFF).

## Direct mirror of the mission-spine bootstrap wiring
This is the precise analog of how `createFridayMissionSpineDispatchAdapter` is wired:

| Concern | mission-spine | memory-spine (this PR) |
| --- | --- | --- |
| Flag resolver | `resolveRouteMissionSpineViaRust` | `resolveRouteMemorySpineViaRust` (clone) |
| Env knob | `FRIDAY_MISSION_SPINE_ROUTES_VIA_RUST` | `FRIDAY_MEMORY_SPINE_ROUTES_VIA_RUST` |
| Config field | `routeMissionSpineViaRust?` | `routeMemorySpineViaRust?` |
| Adapter construct | `friday-hub-bootstrap.ts` ~7031 | `friday-hub-bootstrap.ts` (immediately after) |
| Deps pass | `missionSpine: { ...(dispatch?{dispatch}:{}) }` | `memorySpine: dispatch ? { dispatch } : undefined` |

The adapter **config is identical**: `host: FRIDAY_HUB_AGENT_RUN_WS_HOST ?? "127.0.0.1"`, `port: readMemorySpineRustWsPort(FRIDAY_HUB_AGENT_RUN_WS_PORT)`, `secretResolver: resolveRustAgentRunWsClientX25519Secret` — same sealed-WS server, same ECDH secret resolver. (`readMemorySpineRustWsPort` replicates `readMissionSpineRustWsPort` exactly; both adapter option shapes are byte-identical.)

## New flag
- **Env:** `FRIDAY_MEMORY_SPINE_ROUTES_VIA_RUST` — trimmed, case-insensitive `"1"`/`"true"` ⇒ true; absent / `""` / `"0"` / `"false"` / any other value ⇒ false.
- **Config:** `FridayHubConfig.routeMemorySpineViaRust?: boolean` — explicit boolean (true OR false) always wins over env.
- **Resolver:** `resolveRouteMemorySpineViaRust(configValue, env)` in `src/hub/friday-hub-bootstrap.ts`, exported via `src/hub/index.ts`.

## Default-OFF / 503 dark-safety
With the flag unset (the default): `routeMemorySpineViaRust === false` ⇒ `memorySpineDispatch === null` ⇒ `memorySpine` is `undefined` in the runtime deps ⇒ the runtime falls back to the route's own default (`dispatch: null`) ⇒ `POST /v1/memory-spine/decide` returns today's fail-closed 503 — **byte-identical**. Construction is side-effect-free (no secret resolved, no socket opened at boot); a flag-ON-but-unprovisioned host fails closed (503) per call, lazily.

The memory-spine route is **already always-registered** in the runtime, so no new route enters the retirement manifest.

## Going live (operator-gated, NOT done here)
The flag is **not** flipped in this PR. Live memory-confirmation closure requires the operator to:
1. Flip `FRIDAY_MEMORY_SPINE_ROUTES_VIA_RUST` (this client-side knob), AND
2. Set the Rust-side memory flags `FRIDAY_MEMORY_CONFIRM` + `FRIDAY_RUN_LOOP_MEMORY_EXTRACTION`, AND
3. Deploy.

## Scope guardrails
No Rust changes. No mission-spine changes. No other flag default changed. Pure additive wiring; existing architecture preserved.

## Tests / checks (local, all green)
- `npm run lint` — **0 errors** (pre-existing warnings only)
- `npm run typecheck` — **0 errors**
- `test/unit/hub/friday-hub-bootstrap-env.test.ts` — 69 passed (incl. new `resolveRouteMemorySpineViaRust` flag-ON/OFF/precedence block mirroring the mission-spine resolver test)
- `node scripts/quality/check-ts-runtime-retirement.mjs` — `status: passed`, `blockerFamilies: []`, `failures: []`, routeCount 589 (unchanged)
- `test/unit/quality/ts-runtime-retirement-gate.test.ts` — 4 passed
- `test/contracts/api/friday-api-route-contract.snapshot.test.ts` — 7 passed
- `friday-memory-spine-routes.test.ts` (11) + `friday-mission-spine-routes.test.ts` (22) — passed
- `npm run check:secret-patterns` — no provider/API key shaped secrets

🤖 Generated with [Claude Code](https://claude.com/claude-code)