### PR TITLE
fix(memory): close the extract→confirm→recall loop end-to-end on the agent-run ingress

### DIFF
--- a/rust-core/crates/friday-hub/src/bin/hub_agent_run_server.rs
+++ b/rust-core/crates/friday-hub/src/bin/hub_agent_run_server.rs
@@ -129,7 +129,7 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use friday_crypto::{seal, DataKey, DeviceKeypair, FileSecureStore};
 use friday_deepseek::Transport;
-use friday_hub::hub_server::{run_authed_agent_loop_with_policy, AuthedPrincipal, ForwardedAuth};
+use friday_hub::hub_server::{AuthedPrincipal, ForwardedAuth};
 use friday_hub::key_source::{PEER_PUBKEY_ALLOWLIST_ID, X25519_PUBKEY_LEN};
 use friday_hub::runtime::{HubConfig, HubRuntime};
 // S-R0: the handshake + peer-allowlist + low-order check + sealed-proof codec now come from the
@@ -503,8 +503,9 @@ fn agent_run_control_enabled_from(raw: Option<&str>) -> bool {
 /// through the Mission-bound entry ([`friday_hub::run_authed_agent_loop_mission_bound`] — which
 /// mints the mission-birth + WorkItem bind) ONLY when `FRIDAY_MISSION_BOUND_RUN` is exactly
 /// `"1"` (after trim). Unset — or any other value — leaves the seam DARK: every
-/// run takes the EXISTING unbound dispatch (`run_authed_agent_loop_with_policy` /
-/// `run_session_task_with_overrides`), BYTE-IDENTICAL to today, so deploying this binary changes
+/// run takes the EXISTING unbound dispatch (`HubRuntime::run_session_task_with_overrides`, which
+/// BOTH the sessioned and the ephemeral-per-run-session arms now use), so deploying this binary
+/// changes
 /// NO live behavior until the operator flips this SEPARATE flag. Even with the flag ON, a run is
 /// bound only if it carries a FIRST-CLASS `mission_context` handle (NS45-PR1 / M-4) that resolves
 /// to a live Mission/WorkItem via `MissionContextLookup::by_mission_work_item`; a run with no
@@ -905,17 +906,21 @@ fn serve_sealed_session<S: Read + Write, T: Transport>(
                 // AUTHENTICATED: run the Rust loop AS the bound owner. A route/provider failure
                 // is a SAFE FAILURE (body-free NoAnswer) — never a panic, never a partial body.
                 //
-                // (A2a Phase 1) CONDITIONAL dispatch swap on the client-asserted `session_id`:
-                //   * PRESENT (non-empty) ⇒ the SESSIONED entry [`HubRuntime::run_session_task`]
-                //     (the EXISTING `run_session_loop` — reloads history, appends this turn), with
-                //     the session OWNER = the AUTHENTICATED `caller` (NEVER `session_id`).
-                //   * ABSENT (or blank) ⇒ the UNCHANGED sessionless [`run_authed_agent_loop`].
-                // The swap is CONDITIONAL by design: `run_session_loop` runs ensure_session/
-                // load_session_messages, so routing today's sessionless live path through it would
-                // NOT be byte-identical. A blank/whitespace `session_id` is treated as ABSENT so a
-                // degenerate value can never silently divert the sessionless path. Both arms then
-                // share the IDENTICAL refs + owner-sealed-body emit below (the body is owner-gated
-                // by `project_answer_for_authed` in BOTH), so the only difference is which loop ran.
+                // (A2a Phase 1 / memory-loop) Dispatch on the client-asserted `session_id`, but
+                // BOTH arms now run the SESSIONED entry [`HubRuntime::run_session_task_with_overrides`]
+                // (the EXISTING `run_session_loop`), with the session OWNER = the AUTHENTICATED
+                // `caller` (NEVER the client-asserted `session_id`):
+                //   * PRESENT (non-empty) ⇒ the caller's STABLE session id — reloads its history,
+                //     appends this turn (a real multi-turn conversation).
+                //   * ABSENT (or blank) ⇒ an EPHEMERAL per-run session id == the `run_id`. It loads
+                //     EMPTY history (behaviorally one-shot, like the prior sessionless arm) but now
+                //     fires the flag-gated post-run memory extraction + writes session/message rows,
+                //     CLOSING the extract→confirm→recall loop on the common live path (extraction
+                //     structurally needs a session; recall is owner-namespace-keyed, not
+                //     session-keyed, so the per-run session still recalls across runs as the owner).
+                // A blank/whitespace `session_id` is treated as ABSENT. Both arms share the IDENTICAL
+                // refs + owner-sealed-body emit below (the body is owner-gated by
+                // `project_answer_for_authed` in BOTH), so the only difference is which session id ran.
                 let now_ms = now_ms();
 
                 // (A1 run-controls — APPLICATION) Compute the per-run policy + max-turns OVERRIDE
@@ -1000,10 +1005,30 @@ fn serve_sealed_session<S: Read + Write, T: Transport>(
                             max_turns_override,
                             now_ms,
                         ),
-                        None => run_authed_agent_loop_with_policy(
-                            runtime,
+                        // (memory-loop) The no-`session_id` arm now routes through the SAME
+                        // SESSIONED entry with an EPHEMERAL per-run session_id == the run_id. This
+                        // CLOSES the previously-inert extract→confirm→recall loop on the common
+                        // live path: extraction structurally needs a session (it reads the
+                        // session's pending messages + derives the owner-composite namespace), and
+                        // recall is NAMESPACE-keyed (owner-derived), NOT session-keyed — so a
+                        // per-run ephemeral session writes a candidate under owner O's composite
+                        // namespace that a LATER run as O recalls across runs. A per-run id loads
+                        // EMPTY history, so the turn is behaviorally one-shot (equivalent to the
+                        // old sessionless arm) while now also writing session/message rows + firing
+                        // the flag-gated, Finished-only, failure-isolated post-run extraction.
+                        //
+                        // NO-DEGRADE caveat (deliberate, see the PR body): this arm is NO LONGER
+                        // byte-identical — closing an inert loop requires it. With
+                        // FRIDAY_RUN_LOOP_MEMORY_EXTRACTION ON (a memory feature flag, default-OFF)
+                        // every Finished run makes ONE extra extraction model call ⇒ one
+                        // token_ledger row (the intended memory behavior). Extraction is
+                        // failure-isolated (`let _` in the runtime) and can NEVER flip the run's
+                        // answer/status. The owner binding stays the AUTHENTICATED `caller` (never
+                        // the client-asserted session_id), so there is no cross-owner leak.
+                        None => runtime.run_session_task_with_overrides(
                             &caller,
                             &run_id,
+                            /* session_id = */ &run_id,
                             &task,
                             policy_override,
                             max_turns_override,
@@ -1395,7 +1420,8 @@ fn serve_sealed_session<S: Read + Write, T: Transport>(
             // MEMORY-CONFIRM dispatch — FLAG-GATED. When `FRIDAY_MEMORY_CONFIRM` is ON, an inbound
             // `MemoryDecisionRequest` applies the OWNER's explicit confirm/reject to ONE pending
             // memory candidate via the existing `friday_hub::hub_server::memory_decision_result_for_db`
-            // — owner/namespace-scoped (fail-closed on mismatch / unowned / unknown / terminal) — and
+            // — scoped by the Rust-derived AUTHENTICATED owner's COMPOSITE namespace candidate list
+            // (the SAME list recall uses), fail-closed on mismatch / unowned / unknown / terminal — and
             // replies with a `MemoryDecisionResult` (confirmed / rejected / blocked). A `confirm` makes
             // the candidate durable AND recallable; this is the live caller that CLOSES the
             // Memory-confirmation loop's terminal arm. PURE `&Db` mutation: NO provider/model call,
@@ -1407,10 +1433,16 @@ fn serve_sealed_session<S: Read + Write, T: Transport>(
             // (the server has never had this arm), births/changes nothing.
             Message::MemoryDecisionRequest { request } if memory_confirm_enabled => {
                 let now_ms = now_ms();
+                // The SCOPE source is the Rust-derived AUTHENTICATED owner
+                // (`runtime.policy().principal_id()`), NOT the raw `request.owner_principal` body
+                // field — the candidate's `principal_id` is the owner-COMPOSITE namespace (what
+                // the live extraction keys it on), which the raw body field never equals. This is
+                // the confirm-side half of the memory-loop fix (mirrors #759's recall alignment).
                 let result = friday_hub::hub_server::memory_decision_result_for_db(
                     runtime.db(),
                     &env.msg_id,
                     request,
+                    runtime.policy().principal_id(),
                     now_ms,
                 );
                 eprintln!(
@@ -2815,9 +2847,20 @@ mod tests {
     }
 
     /// Seed ONE pending, owner-owned, content-bearing memory candidate directly into the runtime's
-    /// REAL DB (a pure `&Db` write — no session needed). Content is non-empty so a confirm makes it
-    /// recallable (`recall_confirmed` requires non-NULL/non-empty content).
+    /// The COMPOSITE namespace OWNER's agent-run session resolves to — what the live extraction
+    /// keys a candidate's `principal_id` on, and the SAME scope source the confirm dispatch arm
+    /// now derives from `runtime.policy().principal_id()`. Account/channel unset, direct userId.
+    fn owner_composite_ns() -> String {
+        friday_hub::session_namespace::resolve_session_memory_namespace(None, None, Some(OWNER))
+            .unwrap()
+    }
+
+    /// REAL DB (a pure `&Db` write — no session needed). The candidate is keyed on OWNER's
+    /// COMPOSITE namespace (what live extraction stores), so the confirm dispatch arm — scoped by
+    /// the authenticated owner's composite namespace candidate list — matches it. Content is
+    /// non-empty so a confirm makes it recallable (`recall_confirmed` requires non-NULL content).
     fn seed_memory_candidate<T: Transport>(rt: &HubRuntime<T>, memory_id: &str) {
+        let ns = owner_composite_ns();
         friday_storage::memory::record_candidate(
             rt.db().conn(),
             &friday_storage::memory::NewMemoryCandidate {
@@ -2825,7 +2868,7 @@ mod tests {
                 scope: friday_core::MemoryScope::Global,
                 content_ref: None,
                 content: Some("prefers rust"),
-                principal_id: Some(OWNER),
+                principal_id: Some(ns.as_str()),
                 sensitive: false,
                 created_at: 1_000,
             },
@@ -2858,9 +2901,10 @@ mod tests {
     fn flag_on_memory_decision_confirms_and_makes_recallable_through_dispatch() {
         let (rt, _ws) = mock_runtime("memory-confirm-on", OWNER);
         seed_memory_candidate(&rt, "mem-wired");
-        // Pre-confirm: NOT recallable.
+        let ns = owner_composite_ns();
+        // Pre-confirm: NOT recallable (under the COMPOSITE namespace the candidate is keyed on).
         assert!(
-            friday_storage::memory::recall_confirmed(rt.db().conn(), OWNER)
+            friday_storage::memory::recall_confirmed(rt.db().conn(), &ns)
                 .unwrap()
                 .is_empty()
         );
@@ -2916,7 +2960,7 @@ mod tests {
                 .unwrap(),
             "confirmed"
         );
-        let recalled = friday_storage::memory::recall_confirmed(db.conn(), OWNER).unwrap();
+        let recalled = friday_storage::memory::recall_confirmed(db.conn(), &ns).unwrap();
         assert_eq!(recalled.len(), 1);
         assert_eq!(recalled[0].memory_id, "mem-wired");
 
@@ -2998,7 +3042,7 @@ mod tests {
             "flag OFF leaves the candidate pending (births/changes nothing)"
         );
         assert!(
-            friday_storage::memory::recall_confirmed(db.conn(), OWNER)
+            friday_storage::memory::recall_confirmed(db.conn(), &owner_composite_ns())
                 .unwrap()
                 .is_empty(),
             "flag OFF ⇒ nothing recallable"
@@ -5046,12 +5090,16 @@ mod tests {
         );
     }
 
-    // BYTE-IDENTICAL SESSIONLESS: a request with NO `session_id` (the pre-A2a shape) still
-    // routes through the UNCHANGED `run_authed_agent_loop` and creates NO session row — the
-    // sessioned path is not silently entered. This is the regression fence for the one
-    // currently-live, operator-fed sessionless path.
+    // (memory-loop) SESSIONLESS now routes through the SESSIONED entry with an EPHEMERAL per-run
+    // session_id == the run_id. A request with NO `session_id` still DELIVERS a result (the live
+    // dispatch is unbroken), AND it now creates EXACTLY ONE session row keyed on the run id (so
+    // post-run memory extraction can fire) — owned by the AUTHENTICATED caller. The turn loads
+    // EMPTY history (behaviorally one-shot, as the prior sessionless arm was). This is the
+    // regression fence for the deliberate NO-LONGER-byte-identical change that closes the
+    // extract→confirm→recall loop on the common live path. (Extraction itself stays flag-gated +
+    // default-OFF, so this run with the flag unset makes NO extra model call.)
     #[test]
-    fn sessionless_dispatch_uses_unchanged_path_and_creates_no_session_row() {
+    fn sessionless_dispatch_routes_through_ephemeral_per_run_session_owned_by_caller() {
         let (rt, _ws) = mock_runtime("sess-none", OWNER);
         let server_kp = DeviceKeypair::generate();
         let listener = AgentRunWsListener::bind_loopback(0).unwrap();
@@ -5061,7 +5109,7 @@ mod tests {
         let client_kp = DeviceKeypair::generate();
         let peer_allowlist = allowlist_of(client_kp.public_bytes());
         let client = spawn_client(addr, client_kp, |session, nonce| {
-            // The EXACT sessionless helper today's live path uses (session_id: None).
+            // The sessionless shape today's live path uses (session_id: None).
             let req = agent_run_request("req-none", "run-none", OWNER, session, nonce);
             (req, session.clone(), session.clone())
         });
@@ -5083,28 +5131,30 @@ mod tests {
             1
         );
         let obs = client.join().unwrap();
-        // The result is delivered (the unchanged sessionless path still works).
+        // The result is delivered (the live sessionless dispatch still works).
         assert!(
             matches!(obs.result, Some(Message::AgentRunResult { .. })),
             "sessionless dispatch still returns a refs result"
         );
-        // CRITICAL: NO session row was created for the sessionless run — `run_session_loop`
-        // (which ensure_session's) was NEVER entered. The run's own id is never a session id.
-        assert!(
-            friday_storage::load_session_owner(rt.db().conn(), "run-none")
-                .unwrap()
-                .is_none(),
-            "the sessionless path must NOT create a session row (byte-identical to today)"
+        // A session row keyed on the RUN ID now exists, OWNED by the authenticated caller — the
+        // ephemeral per-run session that lets post-run extraction fire + recall cross runs.
+        let owner = friday_storage::load_session_owner(rt.db().conn(), "run-none")
+            .unwrap()
+            .expect("the ephemeral per-run session row exists, keyed on the run id");
+        assert_eq!(
+            owner.user_id.as_deref(),
+            Some(OWNER),
+            "the ephemeral session is owned by the AUTHENTICATED caller (never a client id)"
         );
-        // And the agent_session table has NO rows at all from this run.
+        // EXACTLY ONE session row from this run (no extra/leaked sessions).
         let n: i64 = rt
             .db()
             .conn()
             .query_row("SELECT count(*) FROM agent_session", [], |r| r.get(0))
             .unwrap();
         assert_eq!(
-            n, 0,
-            "the sessionless dispatch created ZERO session rows (the session loop was never reached)"
+            n, 1,
+            "the sessionless dispatch creates exactly ONE ephemeral per-run session row"
         );
     }
 }

--- a/rust-core/crates/friday-hub/src/hub_server.rs
+++ b/rust-core/crates/friday-hub/src/hub_server.rs
@@ -621,12 +621,21 @@ pub fn work_item_status_result_for_db(
 /// mutating-tool action, so it does NOT route through the approval/trust gate. But it
 /// IS owner/namespace-scoped and **fail-closed on mismatch**, enforced BEFORE the
 /// decide so a blocked request leaves the candidate UNCHANGED:
-/// - `owner_principal` must be non-empty (after trim) — else blocked.
+/// - the scope source is the **`authenticated_owner`** (the Rust-derived principal at
+///   the dispatch arm — `runtime.policy().principal_id()`), NOT the raw
+///   `request.owner_principal` body field. An empty/absent `authenticated_owner` ⇒ no
+///   candidate matches ⇒ blocked.
 /// - the candidate must exist — else blocked (`state="unknown"`).
-/// - the candidate's `principal_id` must equal `owner_principal` EXACTLY — the SAME
-///   key [`friday_storage::memory::recall_confirmed`] enforces. A candidate owned by a
-///   different principal, OR an UNOWNED (`None`-principal) candidate, is decidable by
-///   NO ONE (no wildcard, mirroring recall's blank→fail-closed rule).
+/// - the candidate's `principal_id` must be a MEMBER of the SAME owner-derived dual-read
+///   namespace candidate list [`crate::session_namespace::resolve_session_memory_namespace_candidates`]
+///   that the SESSIONED recall consults (`(None, None, authenticated_owner)`). The live
+///   extraction keys a candidate's `principal_id` on this COMPOSITE namespace (never the
+///   raw principal), so scoping on the raw body field would NEVER match — the defect this
+///   fix closes (mirrors #759's recall alignment). A candidate owned by a different
+///   principal's namespace, OR an UNOWNED (`None`-principal) candidate, is decidable by NO
+///   ONE (no wildcard; an empty owner yields an EMPTY candidate list ⇒ fail-closed). The
+///   per-principal SQL stays exact-match, so a member-check over alice's candidate list can
+///   never contain bob's namespace — no cross-owner confirm.
 ///
 /// Only after the scope check passes does it call
 /// [`friday_storage::memory::confirm`] / [`reject`]. A `confirm` makes the candidate
@@ -643,12 +652,18 @@ pub fn memory_decision_result_for_db(
     db: &Db,
     msg_id: &str,
     request: MemoryDecisionRequestWire,
+    authenticated_owner: Option<&str>,
     now_ms: i64,
 ) -> Envelope {
     use friday_storage::memory;
 
-    let owner = request.owner_principal.trim();
     let decision = request.decision.trim().to_ascii_lowercase();
+
+    // The SCOPE source is the AUTHENTICATED owner (the Rust-derived principal threaded from
+    // the dispatch arm), NEVER the raw `request.owner_principal` body field. An empty/absent
+    // owner trims to the empty string, which yields an EMPTY candidate list below — so it
+    // matches NO candidate (fail-closed, preserving the old owner_principal_required block).
+    let owner = authenticated_owner.unwrap_or("").trim();
 
     // Validate the decision token fail-closed (the `*_from_wire` idiom): anything other
     // than the two explicit decisions is a block, never a default.
@@ -666,7 +681,9 @@ pub fn memory_decision_result_for_db(
         }
     };
 
-    // An owner-less request can match no candidate (recall's blank→fail-closed rule).
+    // An owner-less request (no AUTHENTICATED principal) can match no candidate (recall's
+    // blank→fail-closed rule; the candidate list below would be empty anyway, but we block
+    // early with the SAME `owner_principal_required` reason for a clear refs surface).
     if owner.is_empty() {
         return memory_decision_blocked(
             msg_id,
@@ -676,6 +693,22 @@ pub fn memory_decision_result_for_db(
             "owner_principal_required",
         );
     }
+
+    // The owner-derived dual-read namespace candidate list — the SAME `[hardened, legacy]`
+    // list the SESSIONED recall consults (account/channel unset, direct userId == the
+    // authenticated owner). The live extraction keys a candidate's `principal_id` on this
+    // COMPOSITE namespace, so this is the correct scope source (NOT the raw owner string).
+    // A non-empty owner always resolves (no fail-closed `UnresolvableNoUserId` here), but we
+    // `unwrap_or_default()` to an EMPTY list defensively so any unforeseen unresolvable owner
+    // fails closed (matches no candidate) rather than panicking. NO-WIDEN: this list for
+    // owner alice can NEVER contain bob's namespace, and the per-principal SQL stays
+    // exact-match, so a member-check can never confirm a cross-owner candidate.
+    let scope_candidates = crate::session_namespace::resolve_session_memory_namespace_candidates(
+        None,
+        None,
+        Some(owner),
+    )
+    .unwrap_or_default();
 
     // Resolve the candidate. An unknown id is a block (no decide call, no panic).
     let row = match memory::get(db.conn(), &request.memory_id) {
@@ -700,10 +733,17 @@ pub fn memory_decision_result_for_db(
         }
     };
 
-    // Owner/namespace scope: EXACT-match the candidate's owning principal. An unowned
-    // (`None`) candidate, or one owned by a different principal, is decidable by no one —
-    // fail-closed, candidate left UNCHANGED (this check runs BEFORE any decide).
-    if row.principal_id.as_deref() != Some(owner) {
+    // Owner/namespace scope: DUAL-READ MEMBERSHIP of the candidate's owning principal in the
+    // owner-derived namespace candidate list (the SAME list recall uses). An unowned (`None`)
+    // candidate, or one keyed on a DIFFERENT owner's namespace, is a MEMBER of no one's list —
+    // decidable by no one, fail-closed, candidate left UNCHANGED (this check runs BEFORE any
+    // decide). An empty `scope_candidates` (only when owner is unresolvable, defended above)
+    // matches nothing.
+    let scope_ok = row
+        .principal_id
+        .as_deref()
+        .is_some_and(|p| scope_candidates.iter().any(|c| c.as_str() == p));
+    if !scope_ok {
         return memory_decision_blocked(
             msg_id,
             now_ms,
@@ -728,12 +768,15 @@ pub fn memory_decision_result_for_db(
         }
     };
 
-    // Recallability is the loop's payoff: a confirmed, content-bearing, owner-owned
-    // candidate is now returned by `recall_confirmed`. Derive `recallable` from the
-    // SAME query the answer path uses (not just the state) so the surface never claims
-    // recallability a recall would not honor — e.g. a content-less confirmed row.
+    // Recallability is the loop's payoff: a confirmed, content-bearing candidate keyed on the
+    // owner's composite namespace is now returned by the SESSIONED recall. Derive `recallable`
+    // from the SAME dual-read query that recall uses (`recall_confirmed_multi` over the SAME
+    // namespace candidate list) — NOT the raw owner — so the surface never claims
+    // recallability a recall would not honor (e.g. a content-less confirmed row, OR — the bug
+    // this fix closes — a composite-namespace row a raw-owner query would miss).
+    let candidate_refs: Vec<&str> = scope_candidates.iter().map(String::as_str).collect();
     let recallable = matches!(new_state, friday_core::MemoryState::Confirmed)
-        && memory::recall_confirmed(db.conn(), owner)
+        && memory::recall_confirmed_multi(db.conn(), &candidate_refs)
             .map(|rows| rows.iter().any(|r| r.memory_id == request.memory_id))
             .unwrap_or(false);
 
@@ -5893,9 +5936,21 @@ mod tests {
 
     // --- Memory-confirm arm (the live caller that CLOSES the Memory-confirmation loop) ---------
 
-    /// Seed ONE pending memory candidate owned by `owner`, with content (so a confirm makes it
-    /// recallable — `recall_confirmed` requires non-NULL/non-empty content).
+    /// The COMPOSITE namespace a session owned by `owner` resolves to (account/channel unset →
+    /// "default"/"unknown", direct userId == owner) — EXACTLY what the live extraction keys a
+    /// candidate's `principal_id` on for an agent-run session bound to `owner`, and the SAME
+    /// scope source the confirm handler now derives from `authenticated_owner`.
+    fn composite_ns(owner: &str) -> String {
+        crate::session_namespace::resolve_session_memory_namespace(None, None, Some(owner)).unwrap()
+    }
+
+    /// Seed ONE pending memory candidate keyed on `owner`'s COMPOSITE namespace (what live
+    /// extraction stores) — or UNOWNED when `owner` is `None` — with content (so a confirm makes
+    /// it recallable; `recall_confirmed` requires non-NULL/non-empty content). The decision
+    /// handler is driven with `authenticated_owner = owner`, so a matching owner resolves the
+    /// SAME composite namespace and the membership scope check passes.
     fn seed_memory_candidate(db: &Db, memory_id: &str, owner: Option<&str>, now: i64) {
+        let ns = owner.map(composite_ns);
         memory::record_candidate(
             db.conn(),
             &memory::NewMemoryCandidate {
@@ -5904,7 +5959,7 @@ mod tests {
                 content_ref: None,
                 // Content-bearing: a confirm must yield a recallable row.
                 content: Some("prefers rust"),
-                principal_id: owner,
+                principal_id: ns.as_deref(),
                 sensitive: false,
                 created_at: now,
             },
@@ -5926,19 +5981,21 @@ mod tests {
         let db = Db::open_hub(&tmp_db()).unwrap();
         let now = 1_700_000_000_000;
         seed_memory_candidate(&db, "mem-confirm", Some("owner-1"), now);
-        // Pre-confirm: NOT recallable.
-        assert!(memory::recall_confirmed(db.conn(), "owner-1")
-            .unwrap()
-            .is_empty());
+        let ns = composite_ns("owner-1");
+        // Pre-confirm: NOT recallable (under the COMPOSITE namespace the candidate is keyed on).
+        assert!(memory::recall_confirmed(db.conn(), &ns).unwrap().is_empty());
 
         let env = memory_decision_result_for_db(
             &db,
             "msg-confirm",
             MemoryDecisionRequestWire {
+                // The raw body field is IRRELEVANT to scope now (the authenticated owner is) —
+                // pass an arbitrary value to prove it is no longer the scope source.
                 memory_id: "mem-confirm".into(),
-                owner_principal: "owner-1".into(),
+                owner_principal: "ignored-body-field".into(),
                 decision: "confirm".into(),
             },
+            Some("owner-1"),
             now + 1,
         );
         let result = decode_memory_decision(&env);
@@ -5950,7 +6007,8 @@ mod tests {
         );
         assert!(result.blocker.is_none());
 
-        // Storage truth: the row is Confirmed AND `recall_confirmed` now returns it.
+        // Storage truth: the row is Confirmed AND recall (keyed on the composite namespace, as
+        // the live sessioned recall is) now returns it.
         assert_eq!(
             memory::get(db.conn(), "mem-confirm")
                 .unwrap()
@@ -5958,7 +6016,7 @@ mod tests {
                 .state,
             friday_core::MemoryState::Confirmed
         );
-        let recalled = memory::recall_confirmed(db.conn(), "owner-1").unwrap();
+        let recalled = memory::recall_confirmed(db.conn(), &ns).unwrap();
         assert_eq!(recalled.len(), 1);
         assert_eq!(recalled[0].memory_id, "mem-confirm");
     }
@@ -5974,9 +6032,10 @@ mod tests {
             "msg-reject",
             MemoryDecisionRequestWire {
                 memory_id: "mem-reject".into(),
-                owner_principal: "owner-1".into(),
+                owner_principal: "ignored-body-field".into(),
                 decision: "reject".into(),
             },
+            Some("owner-1"),
             now + 1,
         );
         let result = decode_memory_decision(&env);
@@ -5991,9 +6050,11 @@ mod tests {
             memory::get(db.conn(), "mem-reject").unwrap().unwrap().state,
             friday_core::MemoryState::Rejected
         );
-        assert!(memory::recall_confirmed(db.conn(), "owner-1")
-            .unwrap()
-            .is_empty());
+        assert!(
+            memory::recall_confirmed(db.conn(), &composite_ns("owner-1"))
+                .unwrap()
+                .is_empty()
+        );
     }
 
     #[test]
@@ -6002,15 +6063,18 @@ mod tests {
         let now = 1_700_000_000_000;
         seed_memory_candidate(&db, "mem-scope", Some("owner-1"), now);
 
-        // A DIFFERENT principal tries to confirm owner-1's candidate.
+        // A DIFFERENT AUTHENTICATED principal tries to confirm owner-1's candidate. The
+        // intruder's namespace candidate list can NEVER contain owner-1's composite namespace —
+        // the no-cross-owner-confirm guard.
         let env = memory_decision_result_for_db(
             &db,
             "msg-scope",
             MemoryDecisionRequestWire {
                 memory_id: "mem-scope".into(),
-                owner_principal: "intruder".into(),
+                owner_principal: "owner-1".into(), // even spoofing the body field can't help
                 decision: "confirm".into(),
             },
+            Some("intruder"),
             now + 1,
         );
         let result = decode_memory_decision(&env);
@@ -6023,12 +6087,16 @@ mod tests {
             memory::get(db.conn(), "mem-scope").unwrap().unwrap().state,
             friday_core::MemoryState::Candidate
         );
-        assert!(memory::recall_confirmed(db.conn(), "owner-1")
-            .unwrap()
-            .is_empty());
-        assert!(memory::recall_confirmed(db.conn(), "intruder")
-            .unwrap()
-            .is_empty());
+        assert!(
+            memory::recall_confirmed(db.conn(), &composite_ns("owner-1"))
+                .unwrap()
+                .is_empty()
+        );
+        assert!(
+            memory::recall_confirmed(db.conn(), &composite_ns("intruder"))
+                .unwrap()
+                .is_empty()
+        );
     }
 
     #[test]
@@ -6047,6 +6115,7 @@ mod tests {
                 owner_principal: "owner-1".into(),
                 decision: "confirm".into(),
             },
+            Some("owner-1"),
             now + 1,
         );
         let result = decode_memory_decision(&env);
@@ -6072,6 +6141,7 @@ mod tests {
                 owner_principal: "owner-1".into(),
                 decision: "confirm".into(),
             },
+            Some("owner-1"),
             1_700_000_000_000,
         );
         let result = decode_memory_decision(&env);
@@ -6094,6 +6164,7 @@ mod tests {
                 owner_principal: "owner-1".into(),
                 decision: "maybe".into(),
             },
+            Some("owner-1"),
             now + 1,
         );
         let result = decode_memory_decision(&env);
@@ -6126,6 +6197,7 @@ mod tests {
                 owner_principal: "owner-1".into(),
                 decision: "reject".into(),
             },
+            Some("owner-1"),
             now + 2,
         );
         let result = decode_memory_decision(&env);
@@ -6140,7 +6212,7 @@ mod tests {
             friday_core::MemoryState::Confirmed
         );
         assert_eq!(
-            memory::recall_confirmed(db.conn(), "owner-1")
+            memory::recall_confirmed(db.conn(), &composite_ns("owner-1"))
                 .unwrap()
                 .len(),
             1

--- a/rust-core/crates/friday-hub/src/runtime.rs
+++ b/rust-core/crates/friday-hub/src/runtime.rs
@@ -5757,6 +5757,241 @@ mod tests {
         );
     }
 
+    // ---- THE END-TO-END MEMORY-LOOP GATE: extract → confirm → recall ---------
+    //
+    // The marquee proof that the loop is CLOSED on the live agent-run ingress: a sessioned run
+    // as alice MINTS a candidate under alice's COMPOSITE namespace (extraction), the LIVE confirm
+    // handler `memory_decision_result_for_db` (scoped by the AUTHENTICATED owner, NOT the body
+    // field) CONFIRMS it, and a LATER sessioned run as alice RECALLS the content. Plus the
+    // confirm-side owner-isolation negative (mallory cannot confirm alice's candidate).
+
+    /// Decode a `Message::MemoryDecisionResult` from the confirm handler's reply envelope.
+    fn decode_decision(
+        env: &friday_protocol::Envelope,
+    ) -> friday_protocol::MemoryDecisionResultWire {
+        match &env.message {
+            friday_protocol::Message::MemoryDecisionResult { result } => result.clone(),
+            other => panic!("expected MemoryDecisionResult, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn memory_loop_end_to_end_extract_confirm_recall_closes_on_agent_run_ingress() {
+        // FULL LOOP (the gate). One ScriptTransport serves, in order: post[0] = the agent loop's
+        // Finish answer; post[1] = the extraction `run_friday_ask` JSON (one item referencing the
+        // session's user turn `<session>:m0`). The session owner is the AUTHENTICATED caller alice
+        // (user_id set ⇒ a resolvable composite namespace), so extraction stores under alice's
+        // composite namespace — exactly the namespace recall + confirm derive.
+        let owner = "alice";
+        let session_id = "run-loop-alice"; // the EPHEMERAL per-run session id the None arm uses
+        let items = extraction_items_json(&format!("{session_id}:m0"));
+        let (rt, _ws, _c) = runtime_with_owner(
+            "memloop-e2e",
+            owner,
+            &["{\"tool\":\"none\",\"answer\":\"PONG\"}", &items],
+        );
+
+        // ---- 1. EXTRACT: run a sessioned run as alice, then fire post-run extraction. ----
+        let caller = authed_caller(owner);
+        let answer =
+            rt.run_session_task(&caller, "run-loop-alice", session_id, "remember me", 5_000);
+        let delivered_body = match &answer {
+            AuthedAnswer::Delivered { answer, status, .. } => {
+                assert_eq!(status, "finished", "the run finished");
+                answer.clone()
+            }
+            other => panic!("expected a Delivered answer, got {other:?}"),
+        };
+        assert_eq!(
+            rt.db().count("memory_item").unwrap(),
+            0,
+            "the run's OWN internal extraction is flag-OFF in the test env (no candidate yet)"
+        );
+        // Drive the flagged inner with a Finished outcome (env-race-free) ⇒ extraction fires,
+        // serving post[1] (the items JSON).
+        let outcome = LoopOutcome {
+            status: LoopStatus::Finished,
+            turns: 1,
+            executed_tools: 0,
+            final_message: Some(delivered_body),
+            detail: String::new(),
+        };
+        rt.maybe_extract_memory_post_run_flagged(
+            session_id,
+            "run-loop-alice",
+            &outcome,
+            6_000,
+            true,
+        );
+
+        // A Candidate was minted, keyed on alice's COMPOSITE namespace (NOT the raw "alice").
+        assert_eq!(
+            rt.db().count("memory_item").unwrap(),
+            1,
+            "extraction recorded exactly one candidate"
+        );
+        let composite_ns =
+            crate::session_namespace::resolve_session_memory_namespace(None, None, Some(owner))
+                .unwrap();
+        assert_eq!(
+            composite_ns, "tenant.default.channel.unknown.user.alice.shared",
+            "the composite namespace is the session-derived scope, not the raw principal"
+        );
+        // Find the minted candidate id + assert its principal_id is the composite namespace.
+        let cand_id: String = rt
+            .db()
+            .conn()
+            .query_row("SELECT memory_id FROM memory_item", [], |r| r.get(0))
+            .unwrap();
+        let cand = friday_storage::memory::get(rt.db().conn(), &cand_id)
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            cand.principal_id.as_deref(),
+            Some(composite_ns.as_str()),
+            "the candidate is keyed on alice's composite namespace (the recall+confirm scope)"
+        );
+        assert_eq!(
+            cand.state,
+            friday_core::MemoryState::Candidate,
+            "freshly extracted ⇒ pending Candidate (not yet recallable)"
+        );
+
+        // ---- 2. CONFIRM via the LIVE handler, scoped by authenticated_owner=Some("alice"). ----
+        // The raw body owner_principal is DELIBERATELY junk to prove it is no longer the scope
+        // source; the Rust-derived authenticated owner is what scopes.
+        let env = crate::hub_server::memory_decision_result_for_db(
+            rt.db(),
+            "msg-loop-confirm",
+            friday_protocol::MemoryDecisionRequestWire {
+                memory_id: cand_id.clone(),
+                owner_principal: "ignored-body-field".into(),
+                decision: "confirm".into(),
+            },
+            Some(owner),
+            7_000,
+        );
+        let result = decode_decision(&env);
+        assert_eq!(
+            result.status, "confirmed",
+            "the live confirm handler confirmed it"
+        );
+        assert_eq!(result.state, "confirmed");
+        assert!(
+            result.recallable,
+            "the confirmed candidate must report recallable (recompute via recall_confirmed_multi)"
+        );
+        assert!(result.blocker.is_none());
+
+        // ---- 3. RECALL: a LATER sessioned run as alice surfaces the confirmed content. ----
+        // Recall is owner-namespace-keyed (not session-keyed): a DIFFERENT (later) session bound
+        // to alice recalls the candidate across runs — the loop closed across the run boundary.
+        bind_session_owner_st(&rt, "later-sess-alice", owner);
+        let preamble = rt
+            .recall_preamble_for_session("later-sess-alice", "run-later", 8_000)
+            .expect("a later alice session recall composes");
+        assert!(
+            preamble.contains("User wants concise answers."),
+            "the confirmed candidate's content must be recalled by a LATER alice session, \
+             got preamble: {preamble:?}"
+        );
+    }
+
+    /// Bind a session to owner `user` on a ScriptTransport runtime (the sessioned loop's
+    /// `SessionOwner { user_id: .. }` shape: account/channel unset), as `run_session_task_*` does.
+    fn bind_session_owner_st(rt: &HubRuntime<ScriptTransport>, session_id: &str, user: &str) {
+        friday_storage::agent_session::ensure_session_with_owner(
+            rt.db().conn(),
+            session_id,
+            &SessionOwner {
+                user_id: Some(user.to_string()),
+                ..SessionOwner::default()
+            },
+            1,
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn memory_confirm_is_owner_isolated_mallory_cannot_confirm_alices_candidate() {
+        // CONFIRM OWNER-ISOLATION (the no-cross-owner-leak guard on the confirm side): seed a
+        // PENDING candidate under alice's composite namespace; mallory (authenticated) tries to
+        // confirm it ⇒ blocked owner_scope_mismatch, candidate UNCHANGED. Positive control: alice
+        // (authenticated) confirms the SAME candidate.
+        let (rt, _ws, _c) =
+            runtime_with_owner("memloop-isolation", "alice", &["{\"tool\":\"none\"}"]);
+        let alice_ns =
+            crate::session_namespace::resolve_session_memory_namespace(None, None, Some("alice"))
+                .unwrap();
+        let mallory_ns =
+            crate::session_namespace::resolve_session_memory_namespace(None, None, Some("mallory"))
+                .unwrap();
+        assert_ne!(
+            alice_ns, mallory_ns,
+            "distinct owners ⇒ distinct namespaces"
+        );
+        // Seed a PENDING (Candidate-state), content-bearing row under alice's composite namespace.
+        // record_candidate ONLY (NOT confirm) so the positive control below is decidable.
+        friday_storage::memory::record_candidate(
+            rt.db().conn(),
+            &friday_storage::memory::NewMemoryCandidate {
+                memory_id: "mem-iso",
+                scope: friday_core::MemoryScope::Global,
+                content_ref: None,
+                content: Some("alice's private fact"),
+                principal_id: Some(alice_ns.as_str()),
+                sensitive: false,
+                created_at: 1,
+            },
+        )
+        .unwrap();
+
+        // mallory CANNOT confirm: her namespace candidate list never contains alice's namespace.
+        let env = crate::hub_server::memory_decision_result_for_db(
+            rt.db(),
+            "msg-iso-mallory",
+            friday_protocol::MemoryDecisionRequestWire {
+                memory_id: "mem-iso".into(),
+                owner_principal: "alice".into(), // even spoofing alice in the body can't help
+                decision: "confirm".into(),
+            },
+            Some("mallory"),
+            100,
+        );
+        let blocked = decode_decision(&env);
+        assert_eq!(blocked.status, "blocked", "mallory must be blocked");
+        assert_eq!(blocked.blocker.as_deref(), Some("owner_scope_mismatch"));
+        assert!(!blocked.recallable);
+        // UNCHANGED: still a pending Candidate; recallable by no one.
+        assert_eq!(
+            friday_storage::memory::get(rt.db().conn(), "mem-iso")
+                .unwrap()
+                .unwrap()
+                .state,
+            friday_core::MemoryState::Candidate,
+            "the candidate is UNCHANGED after the blocked cross-owner confirm"
+        );
+
+        // POSITIVE CONTROL: alice (authenticated) confirms the SAME candidate ⇒ confirmed.
+        let env = crate::hub_server::memory_decision_result_for_db(
+            rt.db(),
+            "msg-iso-alice",
+            friday_protocol::MemoryDecisionRequestWire {
+                memory_id: "mem-iso".into(),
+                owner_principal: "ignored-body-field".into(),
+                decision: "confirm".into(),
+            },
+            Some("alice"),
+            101,
+        );
+        let confirmed = decode_decision(&env);
+        assert_eq!(
+            confirmed.status, "confirmed",
+            "alice (the true owner) confirms her own candidate"
+        );
+        assert!(confirmed.recallable);
+    }
+
     // ---- routing honesty (dispatchable_routes) ------------------------------
 
     #[test]


### PR DESCRIPTION
## Summary

The memory loop was silently **inert** on the common live path even with both prod flags ON (`RUN_LOOP_MEMORY_EXTRACTION=1` + `MEMORY_CONFIRM=1`):

1. The common live run (**no `session_id`**) took the SESSIONLESS dispatch arm, which never fired extraction (extraction structurally needs a session).
2. The confirm handler scoped by the **raw body `owner_principal`**, which never equals the candidate's **composite namespace** → confirm always blocked.

#759 already aligned the SESSIONED recall to the composite namespace (verified on main). This PR closes the remaining two halves + adds the end-to-end gate test.

## FIX 1 — route the sessionless dispatch arm through the sessioned path (Strategy A)

`crates/friday-hub/src/bin/hub_agent_run_server.rs`: the `None` (no-`session_id`) dispatch arm now calls `run_session_task_with_overrides` with an **ephemeral per-run `session_id == run_id`** (the `Some(sid)` arm is unchanged).

- **Why safe:** recall is **namespace-keyed (owner-derived), not session-keyed**, so a per-run ephemeral session closes the loop *across* runs: it writes a candidate under owner O's composite namespace that a LATER run as O recalls. A per-run id loads **empty history** (behaviorally one-shot, equivalent to the old sessionless arm) while now writing session/message rows + firing extraction. Reuses #759's aligned recall + owner-bind + `maybe_extract` wholesale. The change stays in the BIN, not the hot `runtime.rs`/`lib.rs`. The owner binding stays the **authenticated caller** (never the client-asserted id).

## FIX 2 — confirm-side: scope by the AUTHENTICATED owner, not the body field

`crates/friday-hub/src/hub_server.rs`, `memory_decision_result_for_db`:

1. New param `authenticated_owner: Option<&str>`, used as the scope source (NOT `request.owner_principal`).
2. Set at the dispatch arm (`hub_agent_run_server.rs`) to `runtime.policy().principal_id()`.
3. The exact-match scope check is replaced with **DUAL-READ MEMBERSHIP** against `resolve_session_memory_namespace_candidates(None, None, authenticated_owner)` — the SAME `[hardened, legacy]` list recall uses (`scope_ok = candidate.principal_id ∈ candidates`).
4. The `recallable` recompute uses `recall_confirmed_multi(db, &candidates)` (not the raw owner), so a confirmed candidate reports `recallable=true`.
5. All existing fail-closed blocks preserved (`owner_principal_required` / unowned / unknown-id / terminal `not_decidable`).

**NO-WIDEN guard:** `resolve_session_memory_namespace_candidates(None,None,alice)` can never contain bob's namespace; the per-principal SQL stays exact-match → **no cross-owner confirm**.

## The end-to-end gate test (the marquee proof)

Two Rust tests in `runtime.rs`, both driving the **LIVE confirm handler** `memory_decision_result_for_db` (not storage `confirm()` directly):

- **`memory_loop_end_to_end_extract_confirm_recall_closes_on_agent_run_ingress`** (full loop): a sessioned run as alice mints a Candidate under alice's composite namespace (asserted `principal_id == tenant.default.channel.unknown.user.alice.shared`) → the live handler confirms it (`authenticated_owner=Some("alice")`, body `owner_principal` set to junk to prove it is no longer the scope source) → `status="confirmed"`, `recallable=true` → a **LATER** alice session's `recall_preamble_for_session` surfaces the content.
- **`memory_confirm_is_owner_isolated_mallory_cannot_confirm_alices_candidate`** (confirm owner-isolation): a pending candidate under alice's namespace → `authenticated_owner=Some("mallory")` → `blocked` / `owner_scope_mismatch`, candidate **unchanged**; positive control `Some("alice")` → confirms.

> **Honest scope of the proof (no overclaim):** Test 1 drives `run_session_task` at the **runtime layer** — it does NOT itself run the bin's `None` dispatch arm. Fix 1's sessionless→sessioned routing is proven by the *separate* bin test `sessionless_dispatch_routes_through_ephemeral_per_run_session_owned_by_caller` (session-row keyed on run_id + owned by caller + delivery). The live sessionless ingress firing extraction in prod is closed by **composition** (the `None` arm calls the identical `run_session_task_with_overrides` Test 1 drives) — not by one literal prod-arm-to-recall test.

## NO-DEGRADE caveats (deliberate)

- The `None` dispatch arm is **deliberately no longer byte-identical** — closing an inert loop requires it.
- **Provider-spend:** with `FRIDAY_RUN_LOOP_MEMORY_EXTRACTION` ON, every Finished run now makes ONE extra extraction model call → one `token_ledger` row (the intended memory behavior). Extraction is failure-isolated (`let _`), Finished-only, flag-gated default-OFF; it can never flip the run's answer/status.
- **New side effect:** every sessionless run now creates a caller-owned `agent_session` row keyed on `run_id` (previously: zero). These rows surface in `list_sessions_for_owner` (the C2-4 user-facing read API, which only filters `archived`/`pruned`) until the idle `session_lifecycle` sweep archives them. **Candidate follow-up:** mark/skip ephemeral per-run sessions in that listing.

## Out of scope (named follow-up, NOT closed)

The **channels ingress** mints candidates under DM-chatId / subagent-parent-walk / non-default account-channel axes that the `MemoryDecisionRequest` does not carry → confirming those is a follow-up. This PR closes the **agent-run ingress** (account/channel unset, direct userId).

## Tests / regression

Local (NOT a CI-green claim): `cargo build`, `cargo clippy --workspace --all-targets` (0 warnings), `cargo fmt --all --check`, `cargo test -p friday-hub -p friday-storage` — all green (friday-hub lib 674 passed, bin 50 passed). The 7 existing confirm-handler tests + the bin wiring test + the sessionless dispatch regression test were updated to the new (correct) semantics: candidates keyed on the composite namespace, scoped by `authenticated_owner`. The read-only agent-run dispatch path still works (`sessioned_dispatch_*` + the updated sessionless test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)