### PR TITLE
feat(hub): clarification gate — ask, don't guess on under-specified planning tasks (FRIDAY_CLARIFICATION_GATE, dark)

### DIFF
--- a/rust-core/crates/friday-core/src/lib.rs
+++ b/rust-core/crates/friday-core/src/lib.rs
@@ -73,7 +73,10 @@ pub use pairing::{
 };
 pub use passport::{build_context_passport, ContextPassport};
 pub use pathsafe::{contained, PathError};
-pub use planning::{classify_kind, PlanState, PlanningKind};
+pub use planning::{
+    build_clarification, classify_kind, is_task_detailed_enough, questions_for_kind, PlanState,
+    PlanningKind,
+};
 pub use process_registry::{
     ClaimState, LeaseState, OwnershipStatus, ProcessKind, ProcessLease, ProcessObservation,
     WorkspaceClaim, WorkspaceClaimKind,

--- a/rust-core/crates/friday-core/src/planning.rs
+++ b/rust-core/crates/friday-core/src/planning.rs
@@ -528,6 +528,150 @@ fn matches_major_decision(lower: &str) -> bool {
     HINTS.iter().any(|h| contains_word(lower, h))
 }
 
+// --- the clarification gate (faithful port of the oracle's gate half) --------
+//
+// The oracle's planning gate has TWO halves: classification (ported above as
+// [`classify_kind`]) and CLARIFICATION — deciding whether a CLASSIFIED task is
+// specified enough to plan from, and if not, generating the smallest decisive
+// set of specific questions. The Rust live loop dropped the clarification half;
+// these three pure functions restore it, faithful to the oracle's
+// `isTaskDetailedEnough` (TS :214-223), `questionsForKind` (TS :225-253), and
+// `buildClarificationPrompt` (TS :259-274).
+
+/// `DETAIL_HINTS` whole-word terms (oracle :94): the presence of any one signals
+/// the task carries concrete scope (a trigger, an output, a destination, …).
+const DETAIL_HINTS: &[&str] = &[
+    "trigger",
+    "input",
+    "output",
+    "destination",
+    "runtime",
+    "workspace",
+    "browser",
+    "provider",
+    "channel",
+    "timeline",
+    "success",
+    "goal",
+    "constraint",
+    "notify",
+    "deploy",
+    "export",
+];
+
+/// `CONSTRAINT_HINTS` whole-word terms (oracle :93): the presence of any one
+/// signals the task states a constraint/permission/safety boundary — required
+/// (in addition to detail) before a `MajorDecision` is treated as detailed.
+const CONSTRAINT_HINTS: &[&str] = &[
+    "must",
+    "should",
+    "avoid",
+    "without",
+    "constraint",
+    "permission",
+    "runtime",
+    "read-only",
+    "readonly",
+    "safe",
+    "safely",
+    "don't",
+    "do not",
+    "cannot",
+];
+
+/// Is a CLASSIFIED `task` already specified enough to plan from (so the gate can
+/// skip clarification)? Faithful to the oracle's `isTaskDetailedEnough`
+/// (`friday-agent-planning-gate.ts` :214-223):
+///
+/// 1. A destructive / high-risk `MajorDecision` is treated as "detailed" — it
+///    SKIPS clarification (the destructive path is handled by the existing
+///    approval Pause, not by interrogation). Detected via the shared multilingual
+///    [`is_destructive_request`] (the same detector [`classify_kind`] escalates on),
+///    matching `classify_kind`'s destructive divergence note above.
+/// 2. Otherwise: long enough AND carries a DETAIL hint AND (for `MajorDecision`)
+///    also a CONSTRAINT hint. The length threshold is `140` for `MajorDecision`,
+///    `110` for every other kind — measured in CHARS (`chars().count()`, NOT byte
+///    `len()`) so a CJK task (multi-byte per character) is not spuriously counted
+///    as "long" by its byte length.
+///
+/// Whitespace is normalized (trim + collapse runs) first, matching the oracle's
+/// `normalizeText`.
+pub fn is_task_detailed_enough(task: &str, kind: PlanningKind) -> bool {
+    let normalized = normalize_text(task);
+    // 1. Destructive/high-risk MajorDecision is "detailed" → skips clarification
+    //    (handled by the approval Pause instead). Same detector classify_kind uses.
+    if kind == PlanningKind::MajorDecision && is_destructive_request(&normalized) {
+        return true;
+    }
+    // CHARS not bytes (CJK safety): the oracle's `normalized.length` is a UTF-16
+    // code-unit count, but the load-bearing intent is "enough actual characters",
+    // and counting Rust bytes would wildly over-count CJK. `chars().count()` is the
+    // faithful, panic-free choice here.
+    let threshold = if kind == PlanningKind::MajorDecision {
+        140
+    } else {
+        110
+    };
+    let long_enough = normalized.chars().count() >= threshold;
+    // Whole-word matching via the existing `contains_word` helper (the oracle's
+    // `\b`-bounded hints) over the LOWERCASED normalized text.
+    let lower = normalized.to_ascii_lowercase();
+    let has_details = DETAIL_HINTS.iter().any(|h| contains_word(&lower, h));
+    let has_constraints = CONSTRAINT_HINTS.iter().any(|h| contains_word(&lower, h));
+    long_enough && has_details && (kind != PlanningKind::MajorDecision || has_constraints)
+}
+
+/// The two SPECIFIC clarifying questions for an under-specified task of `kind` —
+/// a verbatim port of the oracle's `questionsForKind`
+/// (`friday-agent-planning-gate.ts` :225-253). These are the smallest decisive
+/// set: enough to lock direction without interrogating.
+pub fn questions_for_kind(kind: PlanningKind) -> [&'static str; 2] {
+    match kind {
+        PlanningKind::GenerateSkill => [
+            "What exact outcome should this skill deliver for the user?",
+            "What inputs, tools, or systems should it use or avoid?",
+        ],
+        PlanningKind::GenerateWorkflow => [
+            "What should trigger this workflow, and what output should it produce?",
+            "Where should it run and what constraints or integrations matter?",
+        ],
+        PlanningKind::DeployWorkflow => [
+            "Which workflow or outcome are you trying to deploy, and to which environment?",
+            "Should Friday run it immediately after deploy, or only publish it?",
+        ],
+        PlanningKind::ExportBundle => [
+            "Which workflow outcome are you packaging, and what should be included in the export bundle?",
+            "What evidence or environment-specific settings need to be preserved in the bundle?",
+        ],
+        PlanningKind::MajorDecision => [
+            "What outcome matters most for this decision?",
+            "What constraints, risks, or non-goals must the plan respect?",
+        ],
+    }
+}
+
+/// Build the user-facing clarification message: a header naming the planning kind,
+/// then each question numbered `Question {i}/{n}`. Faithful to the oracle's
+/// `buildClarificationPrompt` (`friday-agent-planning-gate.ts` :259-274) for the
+/// INITIAL turn (`answeredCount == 0`, all questions shown at once).
+///
+/// The header uses the SPEC-mandated verbatim wording (intentionally dropping the
+/// oracle's `one detail`/`these details` pluralization nuance). The kind label is
+/// the snake_case [`PlanningKind::as_str`] with `_` rendered as spaces (the
+/// oracle's `kind.replaceAll("_", " ")`). Lines are joined with `\n`.
+pub fn build_clarification(kind: PlanningKind, questions: &[&str]) -> String {
+    let label = kind.as_str().replace('_', " ");
+    let n = questions.len();
+    let mut lines = Vec::with_capacity(n + 1);
+    lines.push(format!(
+        "Before I execute this {label}, I need more detail to make sure the direction is correct."
+    ));
+    for (i, q) in questions.iter().enumerate() {
+        lines.push(format!("Question {}/{}: {}", i + 1, n, q));
+    }
+    lines.join("\n")
+}
+
 /// The plan lifecycle the oracle drives through `planReview.gate.state`
 /// (`awaiting_clarification` → `awaiting_plan_approval` → `approved` /
 /// `rejected`). Encoded with the SAME state-machine idiom as
@@ -816,5 +960,147 @@ mod tests {
                 to: "approved",
             }
         );
+    }
+
+    // ── clarification gate (is_task_detailed_enough / questions_for_kind / build_clarification) ──
+
+    #[test]
+    fn vague_workflow_task_is_not_detailed_enough() {
+        // The mandated live-path vague task: classifies GenerateWorkflow, < 110 chars,
+        // no DETAIL hint ⇒ NOT detailed ⇒ the gate clarifies.
+        let task = "create a workflow that posts a daily summary";
+        assert_eq!(classify_kind(task), Some(PlanningKind::GenerateWorkflow));
+        assert!(!is_task_detailed_enough(
+            task,
+            PlanningKind::GenerateWorkflow
+        ));
+    }
+
+    #[test]
+    fn detailed_workflow_task_is_detailed_enough() {
+        // A long (≥110 chars) workflow task that carries DETAIL hints ("trigger",
+        // "output", "destination") ⇒ detailed ⇒ the gate SKIPS clarification.
+        let task = "create a workflow that triggers every morning at 9am, reads my \
+                    calendar, and posts a daily summary to the team Slack channel as \
+                    its output destination";
+        assert!(
+            task.chars().count() >= 110,
+            "fixture must clear the 110 threshold"
+        );
+        assert_eq!(classify_kind(task), Some(PlanningKind::GenerateWorkflow));
+        assert!(is_task_detailed_enough(
+            task,
+            PlanningKind::GenerateWorkflow
+        ));
+    }
+
+    #[test]
+    fn detail_threshold_is_counted_in_chars_not_bytes_cjk_safe() {
+        // 60 CJK chars = 180 bytes. With a DETAIL hint present it must still be UNDER
+        // the 110-CHAR threshold (NOT counted "long" by its 180-byte length) ⇒ NOT
+        // detailed. This is the CJK-safety property the byte-len bug would break.
+        let cjk = "工作流".repeat(20); // 60 chars, 180 bytes
+        assert_eq!(cjk.chars().count(), 60);
+        assert!(cjk.len() > 110, "byte length exceeds the char threshold");
+        let task = format!("{cjk} trigger"); // add an English DETAIL hint so only length decides
+        assert!(
+            !is_task_detailed_enough(&task, PlanningKind::GenerateWorkflow),
+            "60 chars must be under the 110-char threshold even at 180 bytes"
+        );
+    }
+
+    #[test]
+    fn major_decision_requires_a_constraint_in_addition_to_detail() {
+        // A long MajorDecision task with a DETAIL hint but NO CONSTRAINT hint is NOT
+        // detailed (the oracle's extra `hasConstraints` requirement for major_decision).
+        let detail_only = "we need to decide on the overall migration approach and the \
+                           rollout timeline and the deploy destination for the whole \
+                           platform across every team in the company this quarter";
+        assert!(detail_only.chars().count() >= 140);
+        assert!(!is_task_detailed_enough(
+            detail_only,
+            PlanningKind::MajorDecision
+        ));
+        // Same task plus a CONSTRAINT hint ("must") ⇒ detailed.
+        let with_constraint = format!("{detail_only} and it must stay read-only");
+        assert!(is_task_detailed_enough(
+            &with_constraint,
+            PlanningKind::MajorDecision
+        ));
+    }
+
+    #[test]
+    fn destructive_major_decision_is_detailed_and_skips_clarification() {
+        // A destructive/high-risk request is "detailed" by the shortcut ⇒ the gate does
+        // NOT clarify (the existing approval Pause handles it), even though it is short.
+        let task = "delete all the files in my workspace";
+        assert_eq!(classify_kind(task), Some(PlanningKind::MajorDecision));
+        assert!(is_task_detailed_enough(task, PlanningKind::MajorDecision));
+    }
+
+    #[test]
+    fn questions_per_kind_match_the_oracle_verbatim() {
+        assert_eq!(
+            questions_for_kind(PlanningKind::GenerateSkill),
+            [
+                "What exact outcome should this skill deliver for the user?",
+                "What inputs, tools, or systems should it use or avoid?",
+            ]
+        );
+        assert_eq!(
+            questions_for_kind(PlanningKind::GenerateWorkflow),
+            [
+                "What should trigger this workflow, and what output should it produce?",
+                "Where should it run and what constraints or integrations matter?",
+            ]
+        );
+        assert_eq!(
+            questions_for_kind(PlanningKind::DeployWorkflow),
+            [
+                "Which workflow or outcome are you trying to deploy, and to which environment?",
+                "Should Friday run it immediately after deploy, or only publish it?",
+            ]
+        );
+        assert_eq!(
+            questions_for_kind(PlanningKind::ExportBundle),
+            [
+                "Which workflow outcome are you packaging, and what should be included in the export bundle?",
+                "What evidence or environment-specific settings need to be preserved in the bundle?",
+            ]
+        );
+        assert_eq!(
+            questions_for_kind(PlanningKind::MajorDecision),
+            [
+                "What outcome matters most for this decision?",
+                "What constraints, risks, or non-goals must the plan respect?",
+            ]
+        );
+        // Every kind yields exactly two questions.
+        for kind in [
+            PlanningKind::GenerateSkill,
+            PlanningKind::GenerateWorkflow,
+            PlanningKind::DeployWorkflow,
+            PlanningKind::ExportBundle,
+            PlanningKind::MajorDecision,
+        ] {
+            assert_eq!(questions_for_kind(kind).len(), 2);
+        }
+    }
+
+    #[test]
+    fn build_clarification_formats_header_and_numbered_questions() {
+        let qs = questions_for_kind(PlanningKind::GenerateWorkflow);
+        let prompt = build_clarification(PlanningKind::GenerateWorkflow, &qs);
+        let expected = "Before I execute this generate workflow, I need more detail to make \
+                        sure the direction is correct.\n\
+                        Question 1/2: What should trigger this workflow, and what output should it produce?\n\
+                        Question 2/2: Where should it run and what constraints or integrations matter?";
+        assert_eq!(prompt, expected);
+        // The kind label renders `_` as a space (major_decision → "major decision").
+        let md = build_clarification(
+            PlanningKind::MajorDecision,
+            &questions_for_kind(PlanningKind::MajorDecision),
+        );
+        assert!(md.starts_with("Before I execute this major decision, I need more detail"));
     }
 }

--- a/rust-core/crates/friday-hub/src/lib.rs
+++ b/rust-core/crates/friday-hub/src/lib.rs
@@ -2574,6 +2574,14 @@ pub enum LoopStatus {
     /// NOTHING is billed after the trip. Carries no deliverable answer (like `Bounded`),
     /// so the post-loop owner-wiring tail (which persists only on `Finished`) skips it.
     Interrupted,
+    /// The flag-gated clarification gate ([`FRIDAY_CLARIFICATION_GATE`]) stopped an
+    /// under-specified, CLASSIFIED planning task BEFORE the first model call: it makes NO
+    /// model call (bills NOTHING) and returns the specific clarifying questions in
+    /// `final_message`. A NON-`Finished` terminal — unlike `Interrupted`/`Bounded` it
+    /// CARRIES a deliverable (`final_message` = the questions), so the persist tails wire
+    /// it to the owner as a `run_result` with status `"awaiting_clarification"` (the
+    /// questions reach the user); "is the run successful?" branches treat it as not-Finished.
+    AwaitingClarification,
 }
 
 /// The outcome of a whole [`run_loop`]. `executed_tools` is the count of tools that
@@ -3208,6 +3216,26 @@ fn activity_needs_me_from(raw: Option<&str>) -> bool {
     matches!(raw.map(str::trim), Some("1"))
 }
 
+/// The `FRIDAY_CLARIFICATION_GATE` env var. When ON, the loop asks intelligent clarifying
+/// questions on the LIVE path for an UNDER-SPECIFIED, CLASSIFIED planning task instead of
+/// guessing (restoring the clarification half of the TS oracle's planning gate that the Rust
+/// live loop had dropped). DEFAULT-OFF: unset / empty / `"0"` / any non-`"1"` value ⇒ OFF, and
+/// the loop is BYTE-IDENTICAL to today — no gate, no prompt steering, the model is prompted to
+/// pick a tool / finish exactly as now. It is read ONCE in the public [`run_loop_with_policy`]
+/// (the common chokepoint for every production caller, incl. the routed/session paths) and
+/// threaded as a pure bool to the inner [`run_loop_with_policy_flagged`] — the same
+/// "split env-read from pure logic" idiom as [`FRIDAY_ACTIVITY_NEEDS_ME`], so the behavioral
+/// tests inject the bool directly and never race `std::env`.
+pub const FRIDAY_CLARIFICATION_GATE: &str = "FRIDAY_CLARIFICATION_GATE";
+
+/// Pure flag-matcher for [`FRIDAY_CLARIFICATION_GATE`] (env read split out so it is unit-
+/// testable without `set_var`). DEFAULT-OFF: `None` (unset) ⇒ false; ON only for the exact
+/// opt-in value `"1"` (trimmed); everything else (including `"true"`) ⇒ false — the program's
+/// standard flag idiom, mirroring [`activity_needs_me_from`].
+fn clarification_gate_from(raw: Option<&str>) -> bool {
+    matches!(raw.map(str::trim), Some("1"))
+}
+
 /// `cancel` (C2-1) is an OPTIONAL cooperative cancellation handle checked at the TOP of
 /// each turn, BEFORE the model call. When `Some` and already tripped at a turn boundary,
 /// the loop stops with [`LoopStatus::Interrupted`]: it makes NO further model call and
@@ -3256,6 +3284,10 @@ pub fn run_loop_with_policy(
     // Read the NS-7 flag ONCE here; the loop body is pure on the resulting bool.
     let activity_needs_me =
         activity_needs_me_from(std::env::var(FRIDAY_ACTIVITY_NEEDS_ME).ok().as_deref());
+    // Read the clarification-gate flag ONCE here (same default-OFF, read-once idiom). When OFF
+    // the loop is byte-identical (no gate, no prompt steering).
+    let clarification_enabled =
+        clarification_gate_from(std::env::var(FRIDAY_CLARIFICATION_GATE).ok().as_deref());
     run_loop_with_policy_flagged(
         client,
         executor,
@@ -3271,6 +3303,7 @@ pub fn run_loop_with_policy(
         steer,
         now_ms,
         activity_needs_me,
+        clarification_enabled,
     )
 }
 
@@ -3295,11 +3328,15 @@ pub(crate) fn run_loop_with_policy_flagged(
     steer: Option<&SteerHandle>,
     now_ms: i64,
     activity_needs_me: bool,
+    clarification_enabled: bool,
 ) -> Result<LoopOutcome, StorageError> {
     // Plan classification recorded ONCE (it is a property of the task, constant across
     // turns). Uses the CLEAN `task` — the recall preamble below augments only the prompt,
-    // never the run row / classification / events.
-    let plan_kind = friday_core::classify_kind(task).map(|k| k.as_str());
+    // never the run row / classification / events. The `PlanningKind` is retained (not just
+    // its `&str`) so the clarification gate below can feed it to `is_task_detailed_enough`
+    // / `questions_for_kind` WITHOUT re-classifying.
+    let plan_kind_enum = friday_core::classify_kind(task);
+    let plan_kind = plan_kind_enum.map(|k| k.as_str());
     agent_run::record_event(
         conn,
         &format!("{run_id}:plan"),
@@ -3307,6 +3344,41 @@ pub(crate) fn run_loop_with_policy_flagged(
         &format!("plan.{}", plan_kind.unwrap_or("none")),
         now_ms,
     )?;
+
+    // ── The flag-gated CLARIFICATION GATE (FRIDAY_CLARIFICATION_GATE) ────────────────────
+    // When the flag is ON and the CLEAN task is a CLASSIFIED planning task that is NOT yet
+    // specified enough to plan from, stop here BEFORE the first model call: record a
+    // refs-only marker and return the specific clarifying questions as the deliverable.
+    // This makes NO model call (turns: 0, bills NOTHING) and asks the SMALLEST decisive set
+    // of questions instead of guessing missing scope/inputs/destinations/constraints.
+    //
+    // NO over-asking: `classify_kind` already returns `None` for ordinary Q&A / summaries /
+    // explanations (they bypass the gate), and `is_task_detailed_enough` lets a detailed
+    // planning task through — so only an UNDER-SPECIFIED, CLASSIFIED planning task stops here.
+    // A destructive/high-risk task is `is_task_detailed_enough == true` (the shortcut), so it
+    // is NOT clarified here — it continues into the loop where the existing approval Pause
+    // handles it. When the flag is OFF this whole block is SKIPPED ⇒ byte-identical to today.
+    if clarification_enabled {
+        if let Some(kind) = plan_kind_enum {
+            if !friday_core::is_task_detailed_enough(task, kind) {
+                let questions = friday_core::questions_for_kind(kind);
+                agent_run::record_event(
+                    conn,
+                    &format!("{run_id}:awaiting_clarification"),
+                    run_id,
+                    &format!("agent.awaiting_clarification:{}", kind.as_str()),
+                    now_ms,
+                )?;
+                return Ok(LoopOutcome {
+                    status: LoopStatus::AwaitingClarification,
+                    turns: 0, // NO model call was made — bills nothing.
+                    executed_tools: 0,
+                    final_message: Some(friday_core::build_clarification(kind, &questions)),
+                    detail: format!("awaiting_clarification:{}", kind.as_str()),
+                });
+            }
+        }
+    }
 
     // The prompt the model sees = recall preamble (PROOF-MEMORY-001; already
     // Passport-gated + PII-redacted by the caller) + the clean task. Built once
@@ -3328,6 +3400,29 @@ pub(crate) fn run_loop_with_policy_flagged(
     } else {
         format!("{recall_preamble}{task}")
     };
+
+    // (FRIDAY_CLARIFICATION_GATE) Prompt steering — GATED so flag-OFF is byte-identical. The
+    // hard gate above already short-circuits the under-specified+CLASSIFIED case with ZERO
+    // model calls; this steering only ever reaches the model on turns that DO call it: a
+    // detailed-but-still-ambiguous planning task and ordinary Q&A. It instructs the model to
+    // ask the smallest decisive set of specific clarifying questions BEFORE acting on an
+    // under-specified/ambiguous planning/build/automation request (never guess missing
+    // scope/inputs/destinations/constraints), AND — the over-asking guard — that ordinary
+    // questions/summaries/explanations are NOT planning tasks: answer them directly, do not
+    // interrogate. We realize the steering by prepending to `prompt_task` (the SAME channel the
+    // recall preamble rides into the prompt, reaching all three providers' `build_loop_prompt`),
+    // rather than threading a flag through the pure `build_tool_prompt_with` (which existing
+    // tests assert byte-for-byte). When the flag is OFF this is skipped ⇒ `prompt_task` is
+    // exactly what it was before.
+    if clarification_enabled {
+        let steer_lines = "Before acting on an under-specified or ambiguous \
+             planning/build/automation request, ask the SMALLEST decisive set of SPECIFIC \
+             clarifying questions and wait for the answer — NEVER guess missing scope, inputs, \
+             destinations, or constraints.\n\
+             Ordinary questions, summaries, and explanations are NOT planning tasks: answer them \
+             directly and do not interrogate the user.\n\n";
+        prompt_task = format!("{steer_lines}{prompt_task}");
+    }
 
     let mut history: Vec<TurnTrace> = Vec::new();
     let mut executed_tools: u64 = 0;
@@ -3826,6 +3921,27 @@ pub fn run_session_loop(
     if outcome.status == LoopStatus::Finished {
         let mut result = friday_storage::RunResult::new(
             "finished",
+            outcome.final_message.clone().unwrap_or_default(),
+            None,
+        );
+        if let Some(principal) = policy.principal_id() {
+            result = result.with_owner_principal(principal);
+        }
+        friday_storage::persist_run_result(conn, run_id, &result, now_ms)?;
+    }
+
+    // 5b. CLARIFICATION-GATE persist arm (load-bearing — WITHOUT it the questions never reach
+    //    the user). An `AwaitingClarification` outcome carries the specific clarifying questions
+    //    in `final_message`; persist them Hub-side keyed by `run_id` with status
+    //    `"awaiting_clarification"`, owner-wired to `policy.principal_id()` (the SAME owner-gated
+    //    discipline as the Finished arm) so `project_answer_for_authed` delivers
+    //    `AuthedAnswer::Delivered{ status: "awaiting_clarification", answer: <questions> }` to the
+    //    owner — zero new transport. No bound principal ⇒ no owner recorded ⇒ the body stays
+    //    unreadable (fail-closed). A fresh `run_id` cannot already hold a result, so a conflict
+    //    here signals a real bug and is propagated.
+    if outcome.status == LoopStatus::AwaitingClarification {
+        let mut result = friday_storage::RunResult::new(
+            "awaiting_clarification",
             outcome.final_message.clone().unwrap_or_default(),
             None,
         );
@@ -4663,6 +4779,7 @@ mod tests {
             None,
             1000,
             activity_needs_me,
+            false, // clarification gate OFF — the NS-7 scenario's task ("do it") classifies None anyway
         )
         .unwrap();
         let pending = friday_storage::list_pending_requests_for_run(db.conn(), "r1").unwrap();
@@ -4736,6 +4853,171 @@ mod tests {
             activity.is_empty(),
             "flag OFF ⇒ ZERO activity rows from the pause (byte-identical baseline)"
         );
+    }
+
+    // ── FRIDAY_CLARIFICATION_GATE: the clarification gate (loop-level, bool-injected) ──────
+    // FAITHFUL BEHAVIORAL TESTS (real DB + real FsToolExecutor + a Scripted client, NO mock of
+    // the loop). The flag is injected via `run_loop_with_policy_flagged`'s `clarification_enabled`
+    // bool — NOT `std::env::set_var` — so these never race the byte-identical loop tests
+    // in-process. The pure env-matcher glue is covered by `clarification_gate_from_*`. The
+    // persist+owner-projection (live authed path) proof lives in `tests/clarification_gate.rs`.
+
+    #[test]
+    fn clarification_gate_from_only_opt_in_enables() {
+        // Default-OFF; ON only for the exact opt-in value "1" (trimmed). Mirrors NS-7's matcher.
+        assert!(!clarification_gate_from(None), "unset ⇒ OFF (prod default)");
+        assert!(!clarification_gate_from(Some("")), "empty ⇒ OFF");
+        assert!(!clarification_gate_from(Some("0")), "0 ⇒ OFF");
+        assert!(!clarification_gate_from(Some("off")), "off ⇒ OFF");
+        assert!(clarification_gate_from(Some("1")), "1 ⇒ ON");
+        assert!(
+            clarification_gate_from(Some("  1  ")),
+            "padded 1 ⇒ ON (trimmed)"
+        );
+        assert!(
+            !clarification_gate_from(Some("true")),
+            "true ⇒ OFF (only exact 1)"
+        );
+    }
+
+    /// Drive a REAL run through `run_loop_with_policy_flagged` with `clarification_enabled`
+    /// injected, returning (outcome, model-call count). A `FinishOnly` script means a turn that
+    /// reaches the model immediately Finishes — so the model-call count distinguishes "the gate
+    /// stopped before any model call" (0) from "the loop ran" (≥1).
+    fn clarification_scenario(
+        tag: &str,
+        task: &str,
+        clarification_enabled: bool,
+    ) -> (LoopOutcome, usize) {
+        let root = TempDir::new(tag);
+        let db = Db::open_hub(&temp_path(tag)).unwrap();
+        agent_run::create_run(db.conn(), "r1", task, 1).unwrap();
+        // A client that immediately Finishes if it is ever called — proves the loop ran.
+        let client = ScriptedAgentLlmClient::new(vec![AgentStep::Finish {
+            message: "ran".to_string(),
+        }]);
+        let executor = FsToolExecutor::new(&root.0);
+        let policy = RunPolicy::new(Some("alice".to_string()), Vec::<String>::new(), false);
+        let out = run_loop_with_policy_flagged(
+            &client,
+            &executor,
+            db.conn(),
+            "r1",
+            task,
+            "",
+            None,
+            &no_approval(),
+            &policy,
+            5,
+            None,
+            None,
+            1000,
+            false, // activity_needs_me: irrelevant here
+            clarification_enabled,
+        )
+        .unwrap();
+        // `client.calls` counts `next_step` calls (the loop's metered call delegates to it);
+        // read it AFTER the loop while the client is still alive. 0 ⇒ the gate stopped before
+        // any model call; ≥1 ⇒ the loop ran.
+        (out, client.calls.get())
+    }
+
+    #[test]
+    fn clarification_gate_on_vague_workflow_returns_questions_with_no_model_call() {
+        // Flag ON + a vague, CLASSIFIED workflow task → AwaitingClarification, turns==0, NO model
+        // call, and final_message carries BOTH specific workflow questions (NOT a generic confirm).
+        let (out, model_calls) = clarification_scenario(
+            "clar-vague",
+            "create a workflow that posts a daily summary",
+            true,
+        );
+        assert_eq!(out.status, LoopStatus::AwaitingClarification);
+        assert_eq!(out.turns, 0, "no model call ⇒ turns 0 (bills nothing)");
+        assert_eq!(out.executed_tools, 0);
+        assert_eq!(
+            model_calls, 0,
+            "the gate stopped BEFORE the first model call"
+        );
+        let msg = out
+            .final_message
+            .expect("clarification carries the questions");
+        let qs = friday_core::questions_for_kind(friday_core::PlanningKind::GenerateWorkflow);
+        assert!(
+            msg.contains(qs[0]),
+            "first specific workflow question present: {msg}"
+        );
+        assert!(
+            msg.contains(qs[1]),
+            "second specific workflow question present: {msg}"
+        );
+        assert!(
+            msg.contains("Question 1/2") && msg.contains("Question 2/2"),
+            "numbered questions, not a generic confirm: {msg}"
+        );
+    }
+
+    #[test]
+    fn clarification_gate_off_vague_workflow_is_byte_identical_runs_the_loop() {
+        // Flag OFF (prod default) + the SAME vague task → the loop runs normally (the model is
+        // reached and Finishes); NOT AwaitingClarification. Byte-identical to today.
+        let (out, model_calls) = clarification_scenario(
+            "clar-off",
+            "create a workflow that posts a daily summary",
+            false,
+        );
+        assert_eq!(out.status, LoopStatus::Finished, "flag OFF ⇒ the loop runs");
+        assert_ne!(out.status, LoopStatus::AwaitingClarification);
+        assert_eq!(model_calls, 1, "the model WAS called (the loop ran)");
+    }
+
+    #[test]
+    fn clarification_gate_on_detailed_workflow_runs_the_loop_no_clarification() {
+        // Flag ON + a DETAILED (≥110 chars + DETAIL hints) workflow task → is_task_detailed_enough
+        // is true → the gate does NOT fire → the loop runs to Finished.
+        let task = "create a workflow that triggers every morning at 9am, reads my calendar, \
+                    and posts a daily summary to the team Slack channel as its output destination";
+        let (out, model_calls) = clarification_scenario("clar-detailed", task, true);
+        assert_eq!(
+            out.status,
+            LoopStatus::Finished,
+            "a detailed task is not clarified"
+        );
+        assert_ne!(out.status, LoopStatus::AwaitingClarification);
+        assert_eq!(model_calls, 1, "the model was reached (the loop ran)");
+    }
+
+    #[test]
+    fn clarification_gate_on_ordinary_qa_passes_through_no_interrogation() {
+        // Flag ON + an ordinary Q&A request (classifies None) → NO clarification (no over-asking):
+        // the loop runs normally and reaches the model.
+        let (out, model_calls) =
+            clarification_scenario("clar-qa", "summarize this thread for me", true);
+        assert_eq!(
+            out.status,
+            LoopStatus::Finished,
+            "Q&A is not a planning task"
+        );
+        assert_ne!(out.status, LoopStatus::AwaitingClarification);
+        assert_eq!(model_calls, 1, "Q&A reaches the model (no interrogation)");
+    }
+
+    #[test]
+    fn clarification_gate_on_destructive_underspecified_is_not_clarified_runs_loop() {
+        // A destructive/high-risk request is is_task_detailed_enough==true (the shortcut), so it
+        // is NOT clarified here — it continues into the loop (where the existing approval Pause
+        // would handle a real mutating action). With a Finish-only script here, it Finishes; the
+        // point is it is NOT short-circuited into AwaitingClarification.
+        let (out, model_calls) = clarification_scenario(
+            "clar-destruct",
+            "delete all the files in my workspace",
+            true,
+        );
+        assert_ne!(
+            out.status,
+            LoopStatus::AwaitingClarification,
+            "destructive requests are handled by the Pause, not clarified"
+        );
+        assert_eq!(model_calls, 1, "the destructive task reaches the loop");
     }
 
     // ── NS-2: flag-gated trust-grant enforcement at the gate-dispatch chokepoint ──────

--- a/rust-core/crates/friday-hub/src/runtime.rs
+++ b/rust-core/crates/friday-hub/src/runtime.rs
@@ -661,6 +661,22 @@ impl<T: Transport> HubRuntime<T> {
                 }
                 persist_run_result(self.db.conn(), run_id, &result, now_ms)?;
             }
+            // CLARIFICATION-GATE persist parity: an `AwaitingClarification` outcome carries the
+            // clarifying questions in `final_message`; persist them owner-wired with status
+            // "awaiting_clarification" so they reach the owner (same arm as the routed-loop tail
+            // below and `run_session_loop` step-5b). The codex gated-turn path does not itself
+            // produce this status today, but the parity arm keeps the persist discipline uniform.
+            if outcome.status == LoopStatus::AwaitingClarification {
+                let mut result = RunResult::new(
+                    "awaiting_clarification",
+                    outcome.final_message.clone().unwrap_or_default(),
+                    None,
+                );
+                if let Some(principal) = policy.principal_id() {
+                    result = result.with_owner_principal(principal);
+                }
+                persist_run_result(self.db.conn(), run_id, &result, now_ms)?;
+            }
             return Ok((selection, outcome));
         }
 
@@ -703,6 +719,26 @@ impl<T: Transport> HubRuntime<T> {
         if outcome.status == LoopStatus::Finished {
             let mut result = RunResult::new(
                 "finished",
+                outcome.final_message.clone().unwrap_or_default(),
+                None,
+            );
+            if let Some(principal) = policy.principal_id() {
+                result = result.with_owner_principal(principal);
+            }
+            persist_run_result(self.db.conn(), run_id, &result, now_ms)?;
+        }
+
+        // CLARIFICATION-GATE persist arm (the routed/sessionless parity of `run_session_loop`
+        // step-5b): the flag-gated clarification gate inside `run_loop_with_policy_flagged` can
+        // stop an under-specified planning task with `AwaitingClarification`, carrying the
+        // clarifying questions in `final_message`. Persist them owner-wired with status
+        // "awaiting_clarification" (same owner-gated discipline as the Finished arm) so
+        // `project_answer_for_authed` delivers the questions to the owner — the questions reach
+        // the user via the run_result, zero new transport. No bound principal ⇒ no owner ⇒
+        // body stays unreadable (fail-closed).
+        if outcome.status == LoopStatus::AwaitingClarification {
+            let mut result = RunResult::new(
+                "awaiting_clarification",
                 outcome.final_message.clone().unwrap_or_default(),
                 None,
             );

--- a/rust-core/crates/friday-hub/tests/clarification_gate.rs
+++ b/rust-core/crates/friday-hub/tests/clarification_gate.rs
@@ -1,0 +1,244 @@
+//! FRIDAY_CLARIFICATION_GATE — the clarification gate, proven end-to-end on the LIVE
+//! AUTHED path (`HubRuntime::run_session_task`), persist + owner-projection included.
+//!
+//! This is the PERSIST + DELIVERY half of the methodology gate (the loop-level bool-injected
+//! behavioral proofs live in-crate in `friday-hub/src/lib.rs` tests — `run_loop_with_policy_flagged`
+//! is `pub(crate)`, so a `tests/` binary cannot call it; and our env-race-free idiom forbids
+//! `std::env::set_var` inside a SHARED test binary). Here EVERY test wants the flag ON, so each
+//! sets `FRIDAY_CLARIFICATION_GATE="1"` as its first line and there is NO flag-OFF test in this
+//! binary (the byte-identical-when-off proof is `clarification_gate_off_*` in-crate).
+//!
+//! What this proves through the real `run_session_task` → `run_session_loop` →
+//! `run_loop_with_policy` (reads the env flag) → `run_loop_with_policy_flagged` (the gate) →
+//! step-5b persist arm → `project_answer_for_authed` chain:
+//!   1. A VAGUE, classified planning task is delivered to the owner as
+//!      `AuthedAnswer::Delivered{ status == "awaiting_clarification", answer == the 2 SPECIFIC
+//!      workflow questions }` — AND a PanicTransport proves NO model call was made (bills nothing).
+//!   2. A RESUME turn (same session, a plain answer that classifies None) runs the loop normally
+//!      and Finishes — the gate does NOT re-fire.
+
+use std::cell::Cell;
+use std::rc::Rc;
+
+use friday_crypto::{seal, DeviceKeypair};
+use friday_deepseek::{DeepSeekClient, DeepSeekError, Transport};
+use friday_hub::hub_server::{AuthedAnswer, AuthedPrincipal};
+use friday_hub::runtime::{DenyAllApprovals, HubConfig, HubRuntime};
+use friday_hub::DeepSeekAgentLlmClient;
+use serde_json::Value;
+
+const SECRET: &[u8] = b"clarification-gate-test-secret-0123"; // pragma: allowlist secret
+
+struct TempDir(std::path::PathBuf);
+impl TempDir {
+    fn new(tag: &str) -> Self {
+        let p = std::env::temp_dir().join(format!(
+            "friday-clar-ws-{}-{}-{}",
+            std::process::id(),
+            tag,
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&p).unwrap();
+        TempDir(p)
+    }
+}
+impl Drop for TempDir {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.0);
+    }
+}
+
+fn tmp_db(tag: &str) -> String {
+    std::env::temp_dir()
+        .join(format!(
+            "friday-clar-{}-{}-{}.sqlite",
+            std::process::id(),
+            tag,
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ))
+        .to_string_lossy()
+        .into_owned()
+}
+
+/// A transport that PANICS if the model is ever contacted — proves the clarification gate
+/// stopped the run BEFORE any model call (bills nothing).
+struct PanicTransport;
+impl Transport for PanicTransport {
+    fn get_json(&self, _u: &str, _b: &str) -> Result<Value, DeepSeekError> {
+        panic!("clarification gate must make NO model call (discover)");
+    }
+    fn post_json(&self, _u: &str, _b: &str, _body: &Value) -> Result<Value, DeepSeekError> {
+        panic!("clarification gate must make NO model call (chat)");
+    }
+}
+
+/// A scripted DeepSeek transport: GET /models → one flash model; POST /chat → the next scripted
+/// assistant `content` (a tool-call JSON the strict parser reads). Counts POST calls.
+struct ScriptTransport {
+    contents: Vec<String>,
+    post_calls: Rc<Cell<usize>>,
+}
+impl ScriptTransport {
+    fn new(contents: &[&str]) -> Self {
+        Self {
+            contents: contents.iter().map(|s| s.to_string()).collect(),
+            post_calls: Rc::new(Cell::new(0)),
+        }
+    }
+}
+impl Transport for ScriptTransport {
+    fn get_json(&self, _u: &str, _b: &str) -> Result<Value, DeepSeekError> {
+        Ok(serde_json::json!({"data":[{"id":"deepseek-v4-flash"}]}))
+    }
+    fn post_json(&self, _u: &str, _b: &str, _body: &Value) -> Result<Value, DeepSeekError> {
+        let n = self.post_calls.get();
+        self.post_calls.set(n + 1);
+        let content = self
+            .contents
+            .get(n)
+            .cloned()
+            .unwrap_or_else(|| "{\"tool\":\"none\",\"answer\":\"done\"}".to_string());
+        Ok(serde_json::json!({
+            "model":"deepseek-v4-flash",
+            "choices":[{"message":{"content":content},"finish_reason":"stop"}],
+            "usage":{"prompt_tokens":10,"completion_tokens":5,"total_tokens":15}
+        }))
+    }
+}
+
+fn runtime_with<T: Transport>(tag: &str, owner: &str, transport: T) -> (HubRuntime<T>, TempDir) {
+    let ws = TempDir::new(tag);
+    let client = DeepSeekClient::with_transport(transport, "k".into());
+    let agent = DeepSeekAgentLlmClient::new(client);
+    let rt = HubRuntime::new(
+        HubConfig {
+            db_path: tmp_db(tag),
+            workspace_root: ws.0.clone(),
+            secret: SECRET.to_vec(),
+            max_turns: 6,
+            principal_id: Some(owner.to_string()),
+            disabled_tools: vec![],
+            read_only: false,
+            operator_vk: None,
+        },
+        agent,
+        Box::new(DenyAllApprovals),
+    )
+    .unwrap();
+    (rt, ws)
+}
+
+/// Build an AuthedPrincipal bound to `principal` (same construction the in-crate tests use).
+fn authed_caller(principal: &str) -> AuthedPrincipal {
+    const AAD: &[u8] = b"clarification-gate-test-aad";
+    const CHALLENGE: &[u8] = b"clarification-gate-test-challenge";
+    let hub = DeviceKeypair::generate();
+    let phone = DeviceKeypair::generate();
+    let hub_session = hub.agree(&phone.public_bytes());
+    let caller_session = phone.agree(&hub.public_bytes());
+    let sealed = seal(&caller_session, CHALLENGE, AAD).unwrap();
+    AuthedPrincipal::authenticate(&hub_session, &sealed, AAD, CHALLENGE, principal).unwrap()
+}
+
+/// The two SPECIFIC workflow clarification questions (the oracle's verbatim wording).
+const WORKFLOW_Q1: &str = "What should trigger this workflow, and what output should it produce?";
+const WORKFLOW_Q2: &str = "Where should it run and what constraints or integrations matter?";
+
+#[test]
+fn vague_planning_task_delivers_specific_questions_with_no_model_call() {
+    std::env::set_var(friday_hub::FRIDAY_CLARIFICATION_GATE, "1");
+    // The vague workflow task classifies GenerateWorkflow, is < 110 chars with no DETAIL hint
+    // ⇒ NOT detailed ⇒ the gate clarifies. The PanicTransport proves NO model call is made.
+    let owner = "owner-clar-vague";
+    let (rt, _ws) = runtime_with("clar-vague", owner, PanicTransport);
+    let caller = authed_caller(owner);
+    let answer = rt.run_session_task(
+        &caller,
+        "run-clar-vague",
+        "sess-clar",
+        "create a workflow that posts a daily summary",
+        5_000,
+    );
+    match answer {
+        AuthedAnswer::Delivered { status, answer, .. } => {
+            assert_eq!(
+                status, "awaiting_clarification",
+                "the under-specified planning task is delivered as a clarification, not a guess"
+            );
+            // The 2 SPECIFIC workflow questions, numbered — NOT a generic confirm.
+            assert!(
+                answer.contains(WORKFLOW_Q1),
+                "first specific workflow question present: {answer}"
+            );
+            assert!(
+                answer.contains(WORKFLOW_Q2),
+                "second specific workflow question present: {answer}"
+            );
+            assert!(
+                answer.contains("Question 1/2") && answer.contains("Question 2/2"),
+                "numbered clarifying questions, not a generic confirm: {answer}"
+            );
+        }
+        other => panic!("expected a Delivered clarification, got {other:?}"),
+    }
+    // (If the model had been called, PanicTransport would have panicked — so reaching here is the
+    // "no model call / bills nothing" proof.)
+}
+
+#[test]
+fn resume_with_plain_answer_runs_the_loop_and_finishes_gate_does_not_refire() {
+    std::env::set_var(friday_hub::FRIDAY_CLARIFICATION_GATE, "1");
+    // SAME session as a prior (clarified) turn: a follow-up that is a PLAIN answer with no planning
+    // verb classifies None ⇒ the gate does NOT fire ⇒ the loop runs normally and Finishes
+    // (scripted mock client returns a finish object). Drive on a scripted transport so the loop
+    // really runs (no panic). A fresh run_id, same session_id.
+    let owner = "owner-clar-resume";
+    let (rt, _ws) = runtime_with(
+        "clar-resume",
+        owner,
+        ScriptTransport::new(&["{\"tool\":\"none\",\"answer\":\"Got it, scheduling it now.\"}"]),
+    );
+    let caller = authed_caller(owner);
+    // First turn: the vague planning task → clarification (gate fires; this transport's first POST
+    // is never reached because the gate stops before any model call).
+    let first = rt.run_session_task(
+        &caller,
+        "run-clar-resume-1",
+        "sess-clar-resume",
+        "create a workflow that posts a daily summary",
+        5_000,
+    );
+    match &first {
+        AuthedAnswer::Delivered { status, .. } => {
+            assert_eq!(status, "awaiting_clarification", "first turn clarifies")
+        }
+        other => panic!("expected a clarification on the first turn, got {other:?}"),
+    }
+    // Resume turn: a PLAIN answer (no planning verb) on the SAME session, a NEW run_id.
+    let resume = rt.run_session_task(
+        &caller,
+        "run-clar-resume-2",
+        "sess-clar-resume",
+        "Post it to the team Slack channel every morning at 9am please",
+        6_000,
+    );
+    match resume {
+        AuthedAnswer::Delivered { status, answer, .. } => {
+            assert_eq!(
+                status, "finished",
+                "a plain answer classifies None ⇒ the loop runs to Finished; the gate does NOT re-fire"
+            );
+            assert!(
+                !answer.contains("Question 1/2"),
+                "the resume answer is the model's reply, NOT another clarification: {answer}"
+            );
+        }
+        other => panic!("expected a Finished delivery on resume, got {other:?}"),
+    }
+}


### PR DESCRIPTION
## The lost capability, restored

The TS oracle (`src/agent/runtime/friday-agent-planning-gate.ts`) has the full clarification machinery, but the Rust live loop dropped the question-generation half — it only ever prompted the model to "pick one tool / finish" and **guessed** on under-specified planning/build/automation requests. This PR restores the clarification half on the LIVE path: with the new flag ON, a CLASSIFIED but under-specified planning task is stopped **before the first model call** and the owner is asked the smallest decisive set of **specific** clarifying questions instead of guessing missing scope/inputs/destinations/constraints.

## The gate — default-OFF, byte-identical when off, no model call, no over-asking

- **`FRIDAY_CLARIFICATION_GATE`** const + pure `clarification_gate_from` matcher (exact `"1"`, default-OFF), read **once** in the public `run_loop_with_policy` (`lib.rs`) and threaded as the last bool param of the `pub(crate)` `run_loop_with_policy_flagged` — **public signature unchanged**, every existing caller untouched.
- The gate fires in `run_loop_with_policy_flagged` (`lib.rs`, after the `plan.{kind}` event, before the turn loop): when ON and `classify_kind(task)==Some(kind) && !is_task_detailed_enough(task, kind)` → record `agent.awaiting_clarification:{kind}` → return `LoopOutcome{ status: AwaitingClarification, turns: 0 (NO model call → bills nothing), final_message: Some(build_clarification(...)) }`. **Flag-OFF skips the whole block → byte-identical.**
- **No over-asking**: `classify_kind` returns `None` for ordinary Q&A / summaries / explanations (they bypass the gate entirely); the gate fires **only** on a classified-AND-underspecified planning task. A destructive request is `is_task_detailed_enough==true` (the shortcut) so it is **not** clarified — the existing approval Pause handles it.
- **Prompt steering** (also GATED — flag-OFF byte-identical): when ON, a few steering lines are prepended to `prompt_task` (the same channel `recall_preamble` rides, reaching all three providers' `build_loop_prompt`) — ask before acting on an ambiguous request, never guess; **and** ordinary questions/summaries are NOT planning tasks, answer directly. Not threaded through the pure `build_tool_prompt_with` (existing tests assert it byte-for-byte).

## The persist arm — the questions reach the user (zero new transport)

`run_session_loop` step-5b persists a `run_result` with status `"awaiting_clarification"`, answer = the questions, **owner-wired** (`with_owner_principal(policy.principal_id())`). Parity arms added at `runtime.rs` `run_with_request` routed tail **and** the codex tail. `project_answer_for_authed` then delivers `AuthedAnswer::Delivered{ status: "awaiting_clarification", answer: <questions> }` to the owner — it reads the persisted `run_result`, so **no `match outcome.status` site needed changing except the three persist arms** (`cargo build --workspace --all-targets` shows no E0004).

## Three ported pure functions (`friday-core` `planning.rs`, re-exported next to `classify_kind`)

- `is_task_detailed_enough` (TS :214-223) — destructive `MajorDecision` is "detailed" (skips clarification); length 140 (MajorDecision) / 110 (else) via **`chars().count()` NOT byte len** (CJK safety); whole-word `DETAIL_HINTS` + `CONSTRAINT_HINTS` via the existing `contains_word`.
- `questions_for_kind` (TS :225-253) — verbatim 2 questions per kind.
- `build_clarification` (TS :259-274) — spec-verbatim header + numbered `Question i/n:` lines.

## End-to-end test results (all green)

**`tests/clarification_gate.rs`** (LIVE authed path via `run_session_task`, flag ON):
- **vague → questions**: `"create a workflow that posts a daily summary"` → `Delivered{ status=="awaiting_clarification", answer = the 2 SPECIFIC workflow questions, numbered }`, and a **`PanicTransport` proves NO model call** was made.
- **Q&A pass-through / resume**: a plain follow-up answer (classifies `None`) on the same session → `Delivered{finished}` — the gate does **not** re-fire.

**In-crate `lib.rs` (bool-injected, env-race-free, real `Db` + `FsToolExecutor` + Scripted client)** — the loop-level methodology proofs:
- vague → `AwaitingClarification`, `turns==0`, **0 model calls**, both specific questions present.
- **detailed → none**: a ≥110-char workflow task with DETAIL hints → `Finished`.
- **Q&A → pass-through**: `"summarize this thread for me"` → `Finished`, no interrogation.
- **flag-OFF → byte-identical**: same vague task, `clarification_enabled=false` → `Finished`, NOT `AwaitingClarification`.
- destructive under-specified → not clarified (runs the loop).
- `clarification_gate_from` matcher (`None`/`""`/`"0"`/`"true"` off; `"1"` on).

**`friday-core` planning unit tests**: detail true/false, CJK-length-not-overcounted, major-decision-needs-constraint, destructive-skips-clarification, questions-per-kind verbatim, prompt format.

## No-degrade + no-over-asking confirmation

Both new blocks are gated on `if clarification_enabled`; the only always-run change is splitting the existing single `classify_kind` call into `plan_kind_enum`/`plan_kind` (identical result). Default-OFF ⇒ production is byte-identical until someone sets `=1`. Over-asking is structurally impossible: ordinary Q&A classifies `None` and bypasses the gate.

## Local results

`cargo build` / `cargo clippy --workspace --all-targets` (0 warnings) / `cargo fmt --all` / `cargo test -p friday-core -p friday-hub` — all green. (Ran the two crates per the task; `--workspace --all-targets` compiles clean — other crates' tests not run locally, CI covers them.)

## Honest scope / deviations

- The **codex-tail persist arm** is **parity/defensive — not exercised today**: the codex gated-turn path does not drive `run_loop_with_policy_flagged`, so it cannot currently produce `AwaitingClarification` (documented in-comment).
- **Prompt steering** only ever reaches the model on turns that *do* call it (detailed-but-ambiguous planning + Q&A) — the hard gate already short-circuits the under-specified+classified case with zero model calls.
- **PR2 (named follow-up)**: the plan-approval handshake — appending the questions to session history (step-4 stays Finished-only) and the resume-with-answer → plan leg — is **deferred**. This PR is the clarification gate only; a mission-bound run that gates would stall until PR2 (fine: flag is default-OFF and mission tasks are typically detailed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)