### PR TITLE
feat(mission-spine): organic mission-bound-run PRODUCER (FRIDAY_MISSION_AUTO_DISPATCH, dark)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -905,14 +905,14 @@
         "filename": "test/unit/hub/friday-hub-bootstrap-env.test.ts",
         "hashed_secret": "5c5a15a8b0b3e154d77746945e563ba40100681b",
         "is_verified": false,
-        "line_number": 136
+        "line_number": 137
       },
       {
         "type": "Secret Keyword",
         "filename": "test/unit/hub/friday-hub-bootstrap-env.test.ts",
         "hashed_secret": "8a8281cec699f5e51330e21dd7fab3531af6ef0c",
         "is_verified": false,
-        "line_number": 137
+        "line_number": 138
       }
     ],
     "test/unit/media-understanding/friday-openai-vision-provider.test.ts": [
@@ -1124,5 +1124,5 @@
       }
     ]
   },
-  "generated_at": "2026-06-14T19:53:16Z"
+  "generated_at": "2026-06-15T01:47:10Z"
 }

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -284,6 +284,27 @@ export type { FridayCloudWorkerSetupRoutesDeps } from "./http/routes/friday-clou
 
 // Runtime
 export { createFridayApiRuntime } from "./runtime/friday-api-runtime.js";
-export type { FridayApiRuntime, CreateFridayApiRuntimeDeps } from "./runtime/friday-api-runtime.types.js";
+// (Organic mission→run binding PRODUCER — DARK) The DeepSeek-flash provider id / model the Rust
+// read-only route qualifier requires (clause 3). Re-exported so bootstrap can hand the mission
+// auto-dispatch driver the EXACT qualifying shape without retyping literals.
+export {
+  RUST_ROUTE_DEEPSEEK_FLASH_MODEL,
+  RUST_ROUTE_DEEPSEEK_PROVIDER_ID,
+} from "./runtime/friday-api-runtime.js";
+export type {
+  FridayApiRuntime,
+  CreateFridayApiRuntimeDeps,
+  FridayAgentRouteStartRun,
+} from "./runtime/friday-api-runtime.types.js";
+// (Organic mission→run binding PRODUCER — DARK) The intake-triggered auto-dispatch driver factory +
+// types — the missing producer that originates a `mission_context` handle on a live read-only run.
+export {
+  createFridayMissionAutoDispatchDriver,
+} from "./mission-spine/friday-mission-auto-dispatch-driver.js";
+export type {
+  CreateFridayMissionAutoDispatchDriverOptions,
+  FridayMissionAutoDispatchDriver,
+  MissionAutoDispatchStartRun,
+} from "./mission-spine/friday-mission-auto-dispatch-driver.js";
 export { createFridayDeterministicPipelineRuntime } from "./runtime/friday-deterministic-pipeline-runtime.js";
 export type { CreateFridayDeterministicPipelineRuntimeDeps } from "./runtime/friday-deterministic-pipeline-runtime.js";

--- a/src/api/mission-spine/friday-mission-auto-dispatch-driver.ts
+++ b/src/api/mission-spine/friday-mission-auto-dispatch-driver.ts
@@ -1,0 +1,191 @@
+import { RUST_ROUTE_READ_TOOL_ALLOWLIST } from "../runtime/friday-api-runtime.js";
+
+import type {
+  FridayRustHubAgentRunMissionContext,
+  FridayRustHubMissionIntakeRequest,
+  FridayRustHubMissionIntakeResult,
+} from "./friday-rust-hub-agent-run-ws-sealed-client.js";
+
+/**
+ * (Organic mission→run binding PRODUCER — DARK, default-OFF) The thin TS driver that closes the #1
+ * organic-driver gap: today NOTHING originates a `mission_context` handle on a live run, so the
+ * mission→run binding loop never closes outside an operator-hand-fed test. This driver is the
+ * MISSING producer — when `POST /v1/mission-spine/intake` births a Mission + a Ready WorkItem (the
+ * server-validated `MissionIntakeResultWire`), it immediately (async, non-blocking) starts a
+ * READ-ONLY bound agent-run carrying that server-produced handle. The already-merged route→sealed-
+ * client `missionContext` road (#752) + the Rust bound seam + the DB resolver then walk the WorkItem
+ * `ready_to_dispatch → … → completed_with_proof` (a read-only Finished closes WITHOUT an operator
+ * signature). No Rust change; no runtime.rs touch; no new route.
+ *
+ * ## Trigger contract (mirrors the Rust producer predicate exactly)
+ * Dispatch fires ONLY for a FRESH ready intake — `status === "ready" && createdOrReady === true`
+ * AND a present `workItemId`. This is the camelCase mirror of `mission_intake_allows_new_work`
+ * (`friday-ffi/src/lib.rs`: `status.trim() == "ready" && created_or_ready`) plus the workItem
+ * presence guard the bound run requires. A blocked/duplicate intake (`status:"blocked"` /
+ * `createdOrReady:false`) dispatches NOTHING — no re-spend on a duplicate.
+ *
+ * ## The handle is the SERVER-PRODUCED result — NEVER a raw client body
+ * The `missionContext` is built from the intake RESULT's `{fridayConversationId, missionId,
+ * workItemId}` (the values the Rust persistence boundary minted/validated), NOT from the inbound
+ * request body. The request supplies ONLY the task text (title/intent) + the bound owner principal.
+ * The Rust resolver re-validates the handle and the owner gate re-asserts on the bound run, so this
+ * driver SELECTS a binding but confers NO authority.
+ *
+ * ## Read-only is load-bearing
+ * The dispatched run carries `constraints.readOnly:true` + EXACTLY the 4 Rust read tools — the shape
+ * that qualifies for the Rust read-only route AND closes the WorkItem WITHOUT an operator signature.
+ *
+ * ## NO-DEGRADE / dark-safety
+ * The driver is constructed ONLY when both `FRIDAY_MISSION_AUTO_DISPATCH` and the mission-spine route
+ * flag resolve true (bootstrap). With the flag off the driver is never built, the dispatch adapter's
+ * `autoDispatchDriver` option is omitted, `intakeMission` is byte-identical, and no auto-dispatch
+ * ever fires. `onIntakeReady` is also fully error-isolated (see below) so even a misconfigured
+ * flag-ON host can never perturb the intake response.
+ */
+
+/**
+ * The narrow `startRun` seam the driver needs — the routing `startRun` exposed on the api runtime
+ * (`apiRuntime.agent.startRun`, the `routeStartRun` wrapper). Typed structurally to the EXACT fields
+ * the driver sets so the driver stays decoupled from the full route signature and is trivially
+ * stubbable in tests. The return value is intentionally `unknown`/awaited-and-discarded — the driver
+ * is fire-and-forget; the run's outcome is observed via the bound seam, not here.
+ */
+export type MissionAutoDispatchStartRun = (input: {
+  task: string;
+  principalId?: string;
+  providerId?: string;
+  model?: string;
+  constraints?: { readOnly?: boolean };
+  allowedRustRouteTools?: string[];
+  missionContext?: FridayRustHubAgentRunMissionContext;
+}) => Promise<unknown>;
+
+export interface CreateFridayMissionAutoDispatchDriverOptions {
+  /**
+   * The routing `startRun` (`apiRuntime.agent.startRun`). Provided via a THUNK so bootstrap can
+   * construct the driver BEFORE the api runtime exists (the adapter is built before `create
+   * FridayApiRuntime`), then populate the ref afterward. `onIntakeReady` only fires at request
+   * time, by which point the ref is populated. A thunk returning `undefined` ⇒ harmless no-op.
+   */
+  readonly startRun: () => MissionAutoDispatchStartRun | undefined;
+  /**
+   * DeepSeek provider id the Rust read-only route qualifier requires (clause 3). Injected from the
+   * api-runtime constant so the driver never retypes the literal.
+   */
+  readonly deepseekProviderId: string;
+  /**
+   * DeepSeek-flash model the Rust read-only route qualifier requires (clause 3). Injected from the
+   * api-runtime constant.
+   */
+  readonly deepseekFlashModel: string;
+  /**
+   * Optional sink for the fire-and-forget run's rejection (never throws into the intake path).
+   * Defaults to a silent swallow — the bound seam is the observability surface, not this driver.
+   */
+  readonly onDispatchError?: (error: unknown) => void;
+}
+
+export interface FridayMissionAutoDispatchDriver {
+  /**
+   * Invoked by the mission-spine dispatch adapter AFTER a successful intake, BEFORE the result is
+   * returned verbatim. SYNCHRONOUS + void + fully error-isolated: it inspects the trigger condition,
+   * and for a fresh-ready intake FIRES `startRun` without awaiting it (the intake response returns
+   * immediately) and swallows any synchronous throw / async rejection so the intake path is NEVER
+   * perturbed. For a non-qualifying intake it is a no-op.
+   */
+  onIntakeReady(
+    request: FridayRustHubMissionIntakeRequest,
+    result: FridayRustHubMissionIntakeResult,
+  ): void;
+}
+
+/**
+ * Derive the bound run's task text from the intake REQUEST. Title is the primary handle; intent is
+ * appended when present + distinct so the read-only run has the mission's own framing. Falls back to
+ * a stable phrasing keyed on the (server-validated) workItemId so the task is never empty.
+ */
+function deriveTask(
+  request: FridayRustHubMissionIntakeRequest,
+  result: FridayRustHubMissionIntakeResult,
+): string {
+  const title = typeof request.title === "string" ? request.title.trim() : "";
+  const intent = typeof request.intent === "string" ? request.intent.trim() : "";
+  if (title.length > 0 && intent.length > 0 && intent !== title) {
+    return `${title} — ${intent}`;
+  }
+  if (title.length > 0) return title;
+  if (intent.length > 0) return intent;
+  return `Advance mission work item ${result.workItemId ?? ""}`.trim();
+}
+
+export function createFridayMissionAutoDispatchDriver(
+  options: CreateFridayMissionAutoDispatchDriverOptions,
+): FridayMissionAutoDispatchDriver {
+  const {
+    startRun: resolveStartRun,
+    deepseekProviderId,
+    deepseekFlashModel,
+    onDispatchError,
+  } = options;
+
+  return {
+    onIntakeReady(
+      request: FridayRustHubMissionIntakeRequest,
+      result: FridayRustHubMissionIntakeResult,
+    ): void {
+      try {
+        // Trigger ONLY for a FRESH ready intake with a present workItem (mirror of the Rust
+        // `mission_intake_allows_new_work` predicate + the workItem-presence guard). A blocked /
+        // duplicate intake (status !== "ready" OR createdOrReady !== true OR no workItemId)
+        // dispatches NOTHING — no re-spend.
+        if (
+          typeof result.status !== "string"
+          || result.status.trim() !== "ready"
+          || result.createdOrReady !== true
+          || typeof result.workItemId !== "string"
+          || result.workItemId.trim().length === 0
+        ) {
+          return;
+        }
+
+        const startRun = resolveStartRun();
+        if (!startRun) {
+          // Thunk not yet populated / runtime had no agent surface ⇒ harmless no-op.
+          return;
+        }
+
+        // Build the handle from the SERVER-PRODUCED result — NEVER the raw client body. The owner
+        // and task text are the only values taken from the request.
+        const missionContext: FridayRustHubAgentRunMissionContext = {
+          fridayConversationId: result.fridayConversationId,
+          missionId: result.missionId,
+          workItemId: result.workItemId,
+        };
+        const ownerPrincipal =
+          typeof request.ownerPrincipal === "string" && request.ownerPrincipal.trim().length > 0
+            ? request.ownerPrincipal.trim()
+            : undefined;
+
+        // Fire-and-forget: invoke startRun WITHOUT awaiting. The intake response returns
+        // immediately; the bound run walks the WorkItem via the Rust seam. A synchronous throw
+        // from startRun is caught by the outer try/catch; an async rejection is swallowed via
+        // `.catch` so there is no unhandled rejection and the intake path is never perturbed.
+        void startRun({
+          task: deriveTask(request, result),
+          ...(ownerPrincipal !== undefined ? { principalId: ownerPrincipal } : {}),
+          providerId: deepseekProviderId,
+          model: deepseekFlashModel,
+          constraints: { readOnly: true },
+          allowedRustRouteTools: [...RUST_ROUTE_READ_TOOL_ALLOWLIST],
+          missionContext,
+        }).catch((error: unknown) => {
+          onDispatchError?.(error);
+        });
+      } catch (error) {
+        // NO-DEGRADE: a synchronous throw inside the trigger (e.g. a malformed result) must NEVER
+        // surface into the intake response. Swallow + report via the optional sink.
+        onDispatchError?.(error);
+      }
+    },
+  };
+}

--- a/src/api/mission-spine/friday-mission-spine-dispatch-adapter.ts
+++ b/src/api/mission-spine/friday-mission-spine-dispatch-adapter.ts
@@ -1,5 +1,6 @@
 import { FridayDomainError } from "#errors";
 
+import type { FridayMissionAutoDispatchDriver } from "./friday-mission-auto-dispatch-driver.js";
 import type { FridayMissionSpineDispatchService } from "../http/routes/friday-mission-spine-routes.js";
 import {
   createFridayRustHubAgentRunSealedClient,
@@ -84,6 +85,17 @@ export interface CreateFridayMissionSpineDispatchAdapterOptions {
    * Constructed LAZILY per-call so this factory itself is side-effect-free.
    */
   readonly createClient?: CreateMissionSpineSealedClientFn;
+  /**
+   * (Organic mission→run binding PRODUCER — DARK, default-OFF) Optional auto-dispatch driver. When
+   * PRESENT (bootstrap injects it only behind `FRIDAY_MISSION_AUTO_DISPATCH` + the route flag), a
+   * SUCCESSFUL `intakeMission` invokes `onIntakeReady(request, result)` AFTER the dispatch returns
+   * but BEFORE the result is handed back — firing a read-only bound agent-run for a fresh-ready
+   * intake (async, non-blocking, fully error-isolated inside the driver). When ABSENT (the default)
+   * `intakeMission` is BYTE-IDENTICAL to today: no hook, no auto-dispatch. NEVER awaited and NEVER
+   * able to throw into the intake path (the driver isolates all errors), so an absent OR present
+   * driver leaves the intake response unchanged.
+   */
+  readonly autoDispatchDriver?: FridayMissionAutoDispatchDriver;
 }
 
 function unavailable(message: string): FridayDomainError {
@@ -110,6 +122,7 @@ export function createFridayMissionSpineDispatchAdapter(
   const { host, port, timeoutMs } = options;
   const createClient = options.createClient ?? createFridayRustHubAgentRunSealedClient;
   const secretResolver = options.secretResolver;
+  const autoDispatchDriver = options.autoDispatchDriver;
 
   /**
    * Resolve the X25519 secret + construct the underlying sealed client — shared by all three methods.
@@ -138,13 +151,21 @@ export function createFridayMissionSpineDispatchAdapter(
       request: FridayRustHubMissionIntakeRequest,
     ): Promise<FridayRustHubMissionIntakeResult> {
       const client = buildClient();
+      let result: FridayRustHubMissionIntakeResult;
       try {
-        return await client.intakeMission(request);
+        result = await client.intakeMission(request);
       } catch (error) {
         throw error instanceof FridayDomainError
           ? error
           : unavailable("Mission-spine intake dispatch failed.");
       }
+      // (Organic mission→run binding PRODUCER — DARK) When the auto-dispatch driver is injected
+      // (flag-ON only), fire the bound read-only run for a fresh-ready intake. The driver's
+      // `onIntakeReady` is SYNCHRONOUS + void + fully error-isolated and does NOT await the run,
+      // so the intake result returns immediately and the intake path is NEVER perturbed. When the
+      // driver is absent (the default) this is a no-op ⇒ byte-identical to today.
+      autoDispatchDriver?.onIntakeReady(request, result);
+      return result;
     },
 
     async transitionMission(

--- a/src/api/runtime/friday-api-runtime.ts
+++ b/src/api/runtime/friday-api-runtime.ts
@@ -48,7 +48,11 @@ import type { FridayDeterministicDispatchDeps } from "../../sessions/services/fr
 import { dispatchManagedAsync } from "../../sessions/services/friday-managed-async-dispatch.js";
 import type { FridayManagedAsyncDispatchDeps } from "../../sessions/services/friday-managed-async-dispatch.js";
 import { parseFridayReflexExplicitPreferenceMessage } from "../../reflex/index.js";
-import type { CreateFridayApiRuntimeDeps, FridayApiRuntime } from "./friday-api-runtime.types.js";
+import type {
+  CreateFridayApiRuntimeDeps,
+  FridayAgentRouteStartRun,
+  FridayApiRuntime,
+} from "./friday-api-runtime.types.js";
 import { createFridayAuthService } from "../auth/friday-auth-service.js";
 import { createFridayTokenValidator } from "../auth/friday-token-validator.js";
 import { createFridayRateLimitService } from "../auth/friday-rate-limit-service.js";
@@ -995,8 +999,11 @@ export function resolveApiRuntimeCanonicalGateRequired(env: NodeJS.ProcessEnv = 
 // read-only loop natively exposes, which is exactly what the future route gates.
 export const RUST_ROUTE_READ_TOOL_ALLOWLIST = ["read_file", "list_dir", "stat_file", "search"] as const;
 
-const RUST_ROUTE_DEEPSEEK_PROVIDER_ID = "deepseek";
-const RUST_ROUTE_DEEPSEEK_FLASH_MODEL = "deepseek-v4-flash";
+// EXPORTED so the mission auto-dispatch driver (and any future qualifying caller) can pass the EXACT
+// provider id / model the Rust read-only route qualifier (clause 3, `qualifiesForRustReadOnlyRoute`)
+// requires WITHOUT retyping the literal — a single source of truth for the qualifying shape.
+export const RUST_ROUTE_DEEPSEEK_PROVIDER_ID = "deepseek";
+export const RUST_ROUTE_DEEPSEEK_FLASH_MODEL = "deepseek-v4-flash";
 
 // (honest-non-finished) The well-known SHA-256 of the EMPTY byte string. A non-Finished terminal
 // run produced NO answer body, but the continuity-projector receipt requires a `finalMessageSha256`
@@ -4655,6 +4662,13 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
 
   // Register agent routes (optional — only if runtime and emitter are provided)
   let agentAutomationService: FridayAgentAutomationService | undefined;
+  // (Organic mission→run binding PRODUCER — DARK) Function-scoped ref to the ROUTING `startRun`
+  // (the `routeStartRun` wrapper at the route registration below). Hoisted here because
+  // `routeStartRun` is block-scoped inside the `if (deps.agentRuntime…)` arm and is otherwise
+  // invisible at the runtime return. Exposed as `agent.startRun` so bootstrap can hand the SAME
+  // route-qualifying entrypoint to the mission auto-dispatch driver. agentRuntime/emitter absent
+  // ⇒ this stays undefined ⇒ `agent.startRun` undefined ⇒ the driver no-ops (default-OFF safe).
+  let routeStartRunRef: FridayAgentRouteStartRun | undefined;
   if (deps.agentRuntime && deps.agentEventEmitter && agentRepo && agentRunEventRepo) {
     const agentAbortControllers = new Map<string, AbortController>();
     const throwRetiredAgentRunControl = (): never => {
@@ -5072,6 +5086,11 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
       // Flag off OR disqualified → today's unchanged path (byte-identical 503 inside).
       return startRun(input);
     };
+    // (Organic mission→run binding PRODUCER — DARK) Publish the ROUTING `startRun` (this wrapper, NOT
+    // the bare `startRun` nor the automation copy) so bootstrap can hand the mission auto-dispatch
+    // driver the SAME entrypoint the HTTP startRun route uses. Additive + default-OFF: nothing reads
+    // this ref unless the driver is constructed (behind two default-OFF flags).
+    routeStartRunRef = routeStartRun;
 
     // (S6 mutating-chat — DARK, default-off) Runtime-level RESUME relay handed to the resume HTTP
     // route. The route already (1) flag-gated on `deps.agentRunControlViaRust` BEFORE any run lookup
@@ -5313,6 +5332,10 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
     agentRuntime: deps.agentRuntime,
     agentEventEmitter: deps.agentEventEmitter,
     agentAutomationService,
+    // (Organic mission→run binding PRODUCER — DARK) Expose the ROUTING startRun so bootstrap can
+    // hand the mission auto-dispatch driver the SAME route-qualifying entrypoint. Undefined when the
+    // agent runtime/emitter are absent ⇒ the driver no-ops (default-OFF safe).
+    agent: { startRun: routeStartRunRef },
     mcpServer: deps.mcpServer,
     deterministicPipeline: deps.deterministicPipeline,
     diagnosis: deps.diagnosis,

--- a/src/api/runtime/friday-api-runtime.types.ts
+++ b/src/api/runtime/friday-api-runtime.types.ts
@@ -28,6 +28,7 @@ import type {
 } from "../../autonomy/index.js";
 import type { FridayProviderService } from "#providers";
 import type { FridayRustHubAgentRunSealedClientService } from "../mission-spine/friday-rust-hub-agent-run-sealed-client-service.js";
+import type { FridayRustHubAgentRunMissionContext } from "../mission-spine/friday-rust-hub-agent-run-ws-sealed-client.js";
 import type { FridayRustHubRunContinuityProjectorService } from "../mission-spine/friday-rust-hub-run-continuity-projector-service.js";
 import type { FridayRustHubRunAnswerReadbackService } from "../mission-spine/friday-rust-hub-run-answer-readback-service.js";
 import type { FridayRustHubProvidersDetectService } from "../mission-spine/friday-rust-hub-providers-detect-bridge-service.js";
@@ -88,6 +89,23 @@ import type {
   WhatsappWebhookService,
 } from "#channels";
 
+/**
+ * (Organic mission→run binding PRODUCER — DARK) The narrow structural shape of the ROUTING `startRun`
+ * (`routeStartRun`) exposed on {@link FridayApiRuntime.agent}. Typed to the fields the mission
+ * auto-dispatch driver sets (the route's full input type is a SUPERSET, so the assignment is
+ * type-compatible). The result is awaited-and-discarded by the driver (fire-and-forget); the bound
+ * seam is the observability surface.
+ */
+export type FridayAgentRouteStartRun = (input: {
+  task: string;
+  principalId?: string;
+  providerId?: string;
+  model?: string;
+  constraints?: { readOnly?: boolean };
+  allowedRustRouteTools?: string[];
+  missionContext?: FridayRustHubAgentRunMissionContext;
+}) => Promise<unknown>;
+
 export interface FridayApiRuntime {
   auth: FridayAuthService;
   tokenValidator: FridayTokenValidator;
@@ -118,6 +136,15 @@ export interface FridayApiRuntime {
   agentEventEmitter?: FridayAgentEventEmitter;
   agentRunRepository?: FridayAgentRunRepository;
   agentAutomationService?: FridayAgentAutomationService;
+  /**
+   * (Organic mission→run binding PRODUCER — DARK) The ROUTING `startRun` entrypoint (the
+   * `routeStartRun` wrapper the HTTP startRun route uses). Present only when the agent runtime +
+   * emitter are wired; `startRun` is undefined otherwise. Bootstrap hands this to the mission
+   * auto-dispatch driver (behind two default-OFF flags) so an organic intake can fire a bound
+   * read-only run via the SAME route-qualifying path as a manual startRun. No other consumer reads
+   * it, so exposing it is additive + dark-safe.
+   */
+  agent?: { startRun?: FridayAgentRouteStartRun };
   mcpServer?: FridayMcpServerRoutesDeps;
   deterministicPipeline?: FridayDeterministicPipelineRoutesDeps;
   diagnosis?: FridayDiagnosisRoutesDeps;

--- a/src/hub/bootstrap/hub-helpers.ts
+++ b/src/hub/bootstrap/hub-helpers.ts
@@ -2001,6 +2001,19 @@ export interface FridayHubConfig {
    * (explicit config wins; otherwise the `FRIDAY_MEMORY_SPINE_ROUTES_VIA_RUST` env knob).
    */
   routeMemorySpineViaRust?: boolean;
+  /**
+   * (Organic mission→run binding PRODUCER — DARK): "after a fresh-Ready `/v1/mission-spine/intake`,
+   * immediately fire a READ-ONLY bound agent-run carrying the server-produced mission handle" flag.
+   * DEFAULT-FALSE — production hub creation must leave this unset so the auto-dispatch driver is
+   * NEVER constructed, the dispatch adapter's `autoDispatchDriver` option is omitted, `intakeMission`
+   * is byte-identical, and no organic run is ever produced. When true (AND `routeMissionSpineViaRust`
+   * is also true), bootstrap constructs the driver and wires it into the dispatch adapter. End-to-end
+   * joined proof ALSO needs `FRIDAY_ROUTE_AGENT_RUN_VIA_RUST` (the Rust read-only route), the SERVER
+   * `FRIDAY_MISSION_INTAKE`/`FRIDAY_MISSION_SPINE_DISPATCH` flags, a deploy, and the SecureStore +
+   * launchd provisioning (operator-gated). Resolution: `resolveMissionAutoDispatch` (explicit config
+   * wins; otherwise the `FRIDAY_MISSION_AUTO_DISPATCH` env knob).
+   */
+  missionAutoDispatch?: boolean;
 }
 
 // ─── Resolved Hub Config ───

--- a/src/hub/friday-hub-bootstrap.ts
+++ b/src/hub/friday-hub-bootstrap.ts
@@ -108,10 +108,14 @@ import { createFridayWorkflowTriggerRepository } from "#workflows";
 import {
   createFridayApiRuntime,
   createFridayDeterministicPipelineRuntime,
+  createFridayMissionAutoDispatchDriver,
   createFridayReflexRoutes,
   getChannelPersona,
   hydrateChannelPersonaStore,
+  RUST_ROUTE_DEEPSEEK_FLASH_MODEL,
+  RUST_ROUTE_DEEPSEEK_PROVIDER_ID,
 } from "#api";
+import type { MissionAutoDispatchStartRun } from "#api";
 import {
   createFridayMediaUnderstandingService,
   createFridayOpenAiVisionProvider,
@@ -1088,6 +1092,39 @@ export function resolveRouteMemorySpineViaRust(
     return configValue;
   }
   const raw = (env.FRIDAY_MEMORY_SPINE_ROUTES_VIA_RUST ?? "").trim().toLowerCase();
+  return raw === "1" || raw === "true";
+}
+
+/**
+ * (Organic mission→run binding PRODUCER — DARK): single source of truth resolving the
+ * `missionAutoDispatch` flag from (1) an EXPLICIT {@link FridayHubConfig.missionAutoDispatch} and,
+ * only as a fallback, (2) the `FRIDAY_MISSION_AUTO_DISPATCH` env var — the operator knob that lets a
+ * fresh-Ready `/v1/mission-spine/intake` immediately fire a READ-ONLY bound agent-run carrying the
+ * server-produced mission handle (closing the #1 organic-driver gap: nothing originates a
+ * `mission_context` handle on a live run today).
+ *
+ * PRECEDENCE + PARSE mirror {@link resolveRouteMissionSpineViaRust} exactly: an explicit config
+ * boolean (true OR false) ALWAYS wins; the env is consulted ONLY when config does not specify.
+ * Case-insensitive, trimmed `"1"` or `"true"` ⇒ true; ABSENT / `""` / `"0"` / `"false"` / ANY other
+ * value ⇒ false. DEFAULT (both unset) ⇒ false, so the auto-dispatch driver is NEVER constructed, the
+ * dispatch adapter's `autoDispatchDriver` option is omitted, `intakeMission` is byte-identical, and
+ * no organic run is produced.
+ *
+ * NOTE: the driver is wired ONLY when BOTH this AND `resolveRouteMissionSpineViaRust` resolve true
+ * (the auto-dispatch road piggybacks the already-callable mission-spine dispatch adapter). End-to-end
+ * joined proof ALSO needs the Rust read-only route flag (`FRIDAY_ROUTE_AGENT_RUN_VIA_RUST`), the
+ * SERVER `FRIDAY_MISSION_INTAKE`/`FRIDAY_MISSION_SPINE_DISPATCH` flags, a deploy, and the SecureStore
+ * + launchd provisioning (operator-gated). This client-side knob only PRODUCES the bound run.
+ */
+export function resolveMissionAutoDispatch(
+  configValue: boolean | undefined,
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  // Config explicit (true OR false) wins — env is the fallback for the unset gap only.
+  if (typeof configValue === "boolean") {
+    return configValue;
+  }
+  const raw = (env.FRIDAY_MISSION_AUTO_DISPATCH ?? "").trim().toLowerCase();
   return raw === "1" || raw === "true";
 }
 
@@ -7064,11 +7101,34 @@ export async function createFridayHub(
   // agent-run sealed-WS path (friday-api-runtime.ts ~:4816); the DB path is intentionally NOT carried
   // (the mission round-trips are refs-only WS, no DB readback).
   const routeMissionSpineViaRust = resolveRouteMissionSpineViaRust(config.routeMissionSpineViaRust);
+  // (Organic mission→run binding PRODUCER — DARK) When BOTH `missionAutoDispatch` AND the mission-spine
+  // route flag resolve true, construct the auto-dispatch driver and wire it into the dispatch adapter so
+  // a fresh-Ready intake immediately fires a READ-ONLY bound agent-run carrying the server-produced
+  // handle. DEFAULT-OFF: with `missionAutoDispatch` false the driver is NEVER built, the adapter's
+  // `autoDispatchDriver` option is OMITTED, `intakeMission` is byte-identical, and no organic run fires.
+  //
+  // ORDERING: the adapter is constructed here, BEFORE `createFridayApiRuntime` below, so the driver
+  // cannot capture `apiRuntime.agent.startRun` directly. The driver instead takes a THUNK
+  // (`() => resolvedMissionAutoDispatchStartRun`) that is populated AFTER the runtime exists. The
+  // driver's `onIntakeReady` only fires at request time (long after boot), by which point the ref is set.
+  const missionAutoDispatch = resolveMissionAutoDispatch(config.missionAutoDispatch);
+  let resolvedMissionAutoDispatchStartRun: MissionAutoDispatchStartRun | undefined;
+  const missionAutoDispatchDriver =
+    missionAutoDispatch && routeMissionSpineViaRust
+      ? createFridayMissionAutoDispatchDriver({
+        startRun: () => resolvedMissionAutoDispatchStartRun,
+        deepseekProviderId: RUST_ROUTE_DEEPSEEK_PROVIDER_ID,
+        deepseekFlashModel: RUST_ROUTE_DEEPSEEK_FLASH_MODEL,
+      })
+      : undefined;
   const missionSpineDispatch = routeMissionSpineViaRust
     ? createFridayMissionSpineDispatchAdapter({
       host: process.env.FRIDAY_HUB_AGENT_RUN_WS_HOST ?? "127.0.0.1",
       port: readMissionSpineRustWsPort(process.env.FRIDAY_HUB_AGENT_RUN_WS_PORT),
       secretResolver: resolveRustAgentRunWsClientX25519Secret,
+      // DARK: present ONLY when `missionAutoDispatch` is also on (above). Absent (the default) ⇒ no
+      // hook ⇒ `intakeMission` byte-identical.
+      ...(missionAutoDispatchDriver ? { autoDispatchDriver: missionAutoDispatchDriver } : {}),
     })
     : null;
 
@@ -7407,6 +7467,14 @@ export async function createFridayHub(
     socialImport: socialImportDeps,
     taskWorkflows: taskWorkflowDeps,
   });
+
+  // (Organic mission→run binding PRODUCER — DARK) Populate the auto-dispatch driver's startRun thunk
+  // now that the api runtime exists. `apiRuntime.agent?.startRun` is the ROUTING `routeStartRun`
+  // (the SAME entrypoint the HTTP startRun route uses — route-qualifying for the Rust read-only path).
+  // No-op assignment when the driver was never constructed (flag-OFF) or the agent surface is absent.
+  if (missionAutoDispatchDriver) {
+    resolvedMissionAutoDispatchStartRun = apiRuntime.agent?.startRun;
+  }
 
   if (reflexService) {
     for (const route of createFridayReflexRoutes({ service: reflexService })) {

--- a/src/hub/index.ts
+++ b/src/hub/index.ts
@@ -41,6 +41,7 @@ export {
   resolveRouteAgentRunViaRust,
   resolveRouteMissionSpineViaRust,
   resolveRouteMemorySpineViaRust,
+  resolveMissionAutoDispatch,
   resolveRouteProvidersViaRust,
   resolveRouteWorkflowsViaRust,
   sanitizeFridayChannelVisibleReply,

--- a/test/unit/api/mission-spine/friday-mission-auto-dispatch-driver.test.ts
+++ b/test/unit/api/mission-spine/friday-mission-auto-dispatch-driver.test.ts
@@ -1,0 +1,216 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  createFridayMissionAutoDispatchDriver,
+  type MissionAutoDispatchStartRun,
+} from "../../../../src/api/mission-spine/friday-mission-auto-dispatch-driver.js";
+import type {
+  FridayRustHubMissionIntakeRequest,
+  FridayRustHubMissionIntakeResult,
+} from "../../../../src/api/mission-spine/friday-rust-hub-agent-run-ws-sealed-client.js";
+
+// (Organic mission→run binding PRODUCER — DARK) The driver is the MISSING producer that originates a
+// `mission_context` handle on a live run. These tests stub `startRun` and assert the trigger
+// condition, the server-validated handle (NOT a raw client body), async/non-blocking dispatch, and
+// full error isolation (a rejecting run never perturbs the intake path). The full WorkItem walk to
+// `completed_with_proof` is the Rust bound seam (already tested); the live joined proof is operator-gated.
+
+const DEEPSEEK_PROVIDER = "deepseek";
+const DEEPSEEK_FLASH = "deepseek-v4-flash";
+const READ_TOOLS = ["read_file", "list_dir", "stat_file", "search"];
+
+const REQUEST: FridayRustHubMissionIntakeRequest = {
+  fridayConversationId: "conv-req",
+  ownerPrincipal: "principal-owner",
+  surfaceThreadId: "thread-1",
+  surfaceKind: "mobile",
+  deliveryRoute: "mobile",
+  visibilityPolicy: "owner_only",
+  // Deliberately DIFFERENT ids from the RESULT below — the no-raw-body proof.
+  missionId: "mission-from-REQUEST-body",
+  workItemId: "wi-from-REQUEST-body",
+  title: "Summarize the repo",
+  intent: "produce a read-only overview",
+  lane: "lane",
+};
+
+const READY_RESULT: FridayRustHubMissionIntakeResult = {
+  truthLabel: "rust_wired",
+  // The SERVER-PRODUCED handle — these are the values the driver MUST bind to.
+  fridayConversationId: "conv-from-SERVER-result",
+  missionId: "mission-from-SERVER-result",
+  workItemId: "wi-from-SERVER-result",
+  surfaceThreadId: "thread-1",
+  status: "ready",
+  blockers: [],
+  createdOrReady: true,
+};
+
+const BLOCKED_RESULT: FridayRustHubMissionIntakeResult = {
+  truthLabel: "rust_wired",
+  fridayConversationId: "conv-from-SERVER-result",
+  missionId: "mission-from-SERVER-result",
+  surfaceThreadId: "thread-1",
+  status: "blocked",
+  blockers: ["duplicate_open_mission"],
+  duplicateMissionId: "mission-existing",
+  createdOrReady: false,
+};
+
+function makeDriver(opts?: {
+  startRun?: MissionAutoDispatchStartRun | undefined;
+  onDispatchError?: (error: unknown) => void;
+}) {
+  const startRunImpl =
+    opts && "startRun" in opts ? opts.startRun : (vi.fn(async () => ({ runId: "run-1" })) as MissionAutoDispatchStartRun);
+  const startRun = startRunImpl;
+  const driver = createFridayMissionAutoDispatchDriver({
+    startRun: () => startRun,
+    deepseekProviderId: DEEPSEEK_PROVIDER,
+    deepseekFlashModel: DEEPSEEK_FLASH,
+    ...(opts?.onDispatchError ? { onDispatchError: opts.onDispatchError } : {}),
+  });
+  return { driver, startRun };
+}
+
+describe("createFridayMissionAutoDispatchDriver (organic mission→run binding PRODUCER, dark)", () => {
+  describe("trigger condition", () => {
+    it("dispatches EXACTLY ONCE for a fresh-ready intake with the read-only bound shape", async () => {
+      const startRun = vi.fn(async () => ({ runId: "run-1" })) as unknown as MissionAutoDispatchStartRun;
+      const driver = createFridayMissionAutoDispatchDriver({
+        startRun: () => startRun,
+        deepseekProviderId: DEEPSEEK_PROVIDER,
+        deepseekFlashModel: DEEPSEEK_FLASH,
+      });
+
+      driver.onIntakeReady(REQUEST, READY_RESULT);
+      // Async/non-blocking: the call returned synchronously; flush the microtask queue to let the
+      // fire-and-forget promise resolve before asserting.
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(startRun).toHaveBeenCalledTimes(1);
+      const arg = (startRun as unknown as ReturnType<typeof vi.fn>).mock.calls[0][0];
+      expect(arg).toMatchObject({
+        task: "Summarize the repo — produce a read-only overview",
+        principalId: "principal-owner",
+        providerId: DEEPSEEK_PROVIDER,
+        model: DEEPSEEK_FLASH,
+        constraints: { readOnly: true },
+        allowedRustRouteTools: READ_TOOLS,
+      });
+    });
+
+    it("does NOT dispatch for a blocked/duplicate intake (no re-spend)", async () => {
+      const { driver, startRun } = makeDriver();
+
+      driver.onIntakeReady(REQUEST, BLOCKED_RESULT);
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(startRun).not.toHaveBeenCalled();
+    });
+
+    it("does NOT dispatch when createdOrReady is false even if status is 'ready'", async () => {
+      const { driver, startRun } = makeDriver();
+
+      driver.onIntakeReady(REQUEST, { ...READY_RESULT, createdOrReady: false });
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(startRun).not.toHaveBeenCalled();
+    });
+
+    it("does NOT dispatch when the result carries no workItemId", async () => {
+      const { driver, startRun } = makeDriver();
+      const { workItemId: _omit, ...noWorkItem } = READY_RESULT;
+      void _omit;
+
+      driver.onIntakeReady(REQUEST, noWorkItem as FridayRustHubMissionIntakeResult);
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(startRun).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("the handle is the SERVER-PRODUCED result — never a raw client body", () => {
+    it("binds missionContext to the RESULT ids, NOT the (different) REQUEST body ids", async () => {
+      const startRun = vi.fn(async () => ({ runId: "run-1" })) as unknown as MissionAutoDispatchStartRun;
+      const driver = createFridayMissionAutoDispatchDriver({
+        startRun: () => startRun,
+        deepseekProviderId: DEEPSEEK_PROVIDER,
+        deepseekFlashModel: DEEPSEEK_FLASH,
+      });
+
+      driver.onIntakeReady(REQUEST, READY_RESULT);
+      await Promise.resolve();
+      await Promise.resolve();
+
+      const arg = (startRun as unknown as ReturnType<typeof vi.fn>).mock.calls[0][0];
+      expect(arg.missionContext).toEqual({
+        fridayConversationId: "conv-from-SERVER-result",
+        missionId: "mission-from-SERVER-result",
+        workItemId: "wi-from-SERVER-result",
+      });
+      // The REQUEST body ids must NOT have leaked into the handle.
+      expect(arg.missionContext.missionId).not.toBe(REQUEST.missionId);
+      expect(arg.missionContext.workItemId).not.toBe(REQUEST.workItemId);
+      expect(arg.missionContext.fridayConversationId).not.toBe(REQUEST.fridayConversationId);
+    });
+  });
+
+  describe("async / non-blocking + error isolation (NO-DEGRADE)", () => {
+    it("onIntakeReady returns synchronously WITHOUT awaiting the run", () => {
+      let resolveRun: (() => void) | undefined;
+      const startRun = vi.fn(
+        () =>
+          new Promise<{ runId: string }>((resolve) => {
+            resolveRun = () => resolve({ runId: "run-1" });
+          }),
+      ) as unknown as MissionAutoDispatchStartRun;
+      const driver = createFridayMissionAutoDispatchDriver({
+        startRun: () => startRun,
+        deepseekProviderId: DEEPSEEK_PROVIDER,
+        deepseekFlashModel: DEEPSEEK_FLASH,
+      });
+
+      // The call must return (void) BEFORE the run promise settles — proving non-blocking.
+      const returned = driver.onIntakeReady(REQUEST, READY_RESULT);
+      expect(returned).toBeUndefined();
+      // The run is still pending here (we have not resolved it).
+      expect(resolveRun).toBeDefined();
+      resolveRun?.();
+    });
+
+    it("a REJECTING startRun never throws into the intake path (routed to onDispatchError)", async () => {
+      const onDispatchError = vi.fn();
+      const startRun = vi.fn(async () => {
+        throw new Error("run dispatch failed (e.g. flags misaligned → 503)");
+      }) as unknown as MissionAutoDispatchStartRun;
+      const driver = createFridayMissionAutoDispatchDriver({
+        startRun: () => startRun,
+        deepseekProviderId: DEEPSEEK_PROVIDER,
+        deepseekFlashModel: DEEPSEEK_FLASH,
+        onDispatchError,
+      });
+
+      // No throw, no unhandled rejection.
+      expect(() => driver.onIntakeReady(REQUEST, READY_RESULT)).not.toThrow();
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(onDispatchError).toHaveBeenCalledTimes(1);
+      expect(onDispatchError.mock.calls[0][0]).toBeInstanceOf(Error);
+    });
+
+    it("a startRun thunk returning undefined (runtime had no agent surface) is a harmless no-op", () => {
+      const driver = createFridayMissionAutoDispatchDriver({
+        startRun: () => undefined,
+        deepseekProviderId: DEEPSEEK_PROVIDER,
+        deepseekFlashModel: DEEPSEEK_FLASH,
+      });
+
+      expect(() => driver.onIntakeReady(REQUEST, READY_RESULT)).not.toThrow();
+    });
+  });
+});

--- a/test/unit/api/mission-spine/friday-mission-spine-dispatch-adapter.test.ts
+++ b/test/unit/api/mission-spine/friday-mission-spine-dispatch-adapter.test.ts
@@ -5,6 +5,10 @@ import {
   createFridayMissionSpineDispatchAdapter,
   readMissionSpineRustWsPort,
 } from "../../../../src/api/mission-spine/friday-mission-spine-dispatch-adapter.js";
+import {
+  createFridayMissionAutoDispatchDriver,
+  type MissionAutoDispatchStartRun,
+} from "../../../../src/api/mission-spine/friday-mission-auto-dispatch-driver.js";
 import type {
   CreateFridayRustHubAgentRunSealedClientOptions,
   FridayRustHubAgentRunSealedClient,
@@ -231,6 +235,132 @@ describe("createFridayMissionSpineDispatchAdapter (Lane B-2, dark, adapter)", ()
       expect(error).toBeInstanceOf(FridayDomainError);
       expect((error as FridayDomainError).code).toBe("MISSION_SPINE_DISPATCH_RUST_UNAVAILABLE");
       expect((error as FridayDomainError).httpStatus).toBe(503);
+    });
+  });
+
+  describe("auto-dispatch driver hook (organic mission→run binding PRODUCER, dark)", () => {
+    it("WITH the driver injected, a Ready intake invokes onIntakeReady(request, result) AFTER dispatch", async () => {
+      const fake = makeFakeClient({ intake: INTAKE_RESULT });
+      const onIntakeReady = vi.fn();
+      const adapter = createFridayMissionSpineDispatchAdapter({
+        port: 48750,
+        secretResolver: () => SECRET,
+        createClient: fake.createClient,
+        autoDispatchDriver: { onIntakeReady },
+      });
+
+      const result = await adapter.intakeMission(INTAKE_REQ);
+
+      // Result returned verbatim AND the hook saw the SAME request + result objects.
+      expect(result).toBe(INTAKE_RESULT);
+      expect(onIntakeReady).toHaveBeenCalledTimes(1);
+      expect(onIntakeReady).toHaveBeenCalledWith(INTAKE_REQ, INTAKE_RESULT);
+    });
+
+    it("WITHOUT the driver (the default) intakeMission is byte-identical — no hook is invoked", async () => {
+      const fake = makeFakeClient({ intake: INTAKE_RESULT });
+      const adapter = createFridayMissionSpineDispatchAdapter({
+        port: 48750,
+        secretResolver: () => SECRET,
+        createClient: fake.createClient,
+        // autoDispatchDriver omitted ⇒ default ⇒ no hook.
+      });
+
+      const result = await adapter.intakeMission(INTAKE_REQ);
+
+      expect(result).toBe(INTAKE_RESULT);
+      // transitionMission / transitionWorkItem never call the hook either (they have no driver path).
+      expect(fake.intakeCalls).toEqual([INTAKE_REQ]);
+    });
+
+    it("the hook is NOT invoked when the dispatch itself fails (the result never existed)", async () => {
+      const fake = makeFakeClient({ reject: new Error("socket ECONNREFUSED") });
+      const onIntakeReady = vi.fn();
+      const adapter = createFridayMissionSpineDispatchAdapter({
+        port: 48750,
+        secretResolver: () => SECRET,
+        createClient: fake.createClient,
+        autoDispatchDriver: { onIntakeReady },
+      });
+
+      await expect(adapter.intakeMission(INTAKE_REQ)).rejects.toBeInstanceOf(FridayDomainError);
+      expect(onIntakeReady).not.toHaveBeenCalled();
+    });
+  });
+
+  // End-to-end seam: the REAL driver injected into the REAL adapter (no spy across the seam). This
+  // is the only non-operator-gated proof that an organic intake actually PRODUCES a bound run. Note
+  // the trigger requires a `workItemId` on the RESULT — a ready result WITHOUT one (the shared
+  // INTAKE_RESULT above) would NOT fire, so this uses a COMPLETE ready result.
+  describe("real driver THROUGH real adapter (composed, organic mission→run binding PRODUCER)", () => {
+    const READY_WITH_WORK_ITEM: FridayRustHubMissionIntakeResult = {
+      truthLabel: "rust_wired",
+      fridayConversationId: "conv-from-SERVER",
+      missionId: "mission-from-SERVER",
+      workItemId: "wi-from-SERVER",
+      surfaceThreadId: "thread-1",
+      status: "ready",
+      blockers: [],
+      createdOrReady: true,
+    };
+    const BLOCKED: FridayRustHubMissionIntakeResult = {
+      ...READY_WITH_WORK_ITEM,
+      status: "blocked",
+      blockers: ["duplicate_open_mission"],
+      createdOrReady: false,
+    };
+
+    function composeAdapter(result: FridayRustHubMissionIntakeResult) {
+      const fake = makeFakeClient({ intake: result });
+      const startRun = vi.fn(async () => ({ runId: "run-1" })) as unknown as MissionAutoDispatchStartRun;
+      const driver = createFridayMissionAutoDispatchDriver({
+        startRun: () => startRun,
+        deepseekProviderId: "deepseek",
+        deepseekFlashModel: "deepseek-v4-flash",
+      });
+      const adapter = createFridayMissionSpineDispatchAdapter({
+        port: 48750,
+        secretResolver: () => SECRET,
+        createClient: fake.createClient,
+        autoDispatchDriver: driver,
+      });
+      return { adapter, startRun };
+    }
+
+    it("a complete Ready intake PRODUCES a bound read-only run with the RESULT-derived handle", async () => {
+      const { adapter, startRun } = composeAdapter(READY_WITH_WORK_ITEM);
+
+      const returned = await adapter.intakeMission(INTAKE_REQ);
+      // Intake result returned verbatim, immediately.
+      expect(returned).toBe(READY_WITH_WORK_ITEM);
+      // The fire-and-forget run is initiated synchronously inside the hook; flush a microtask.
+      await Promise.resolve();
+
+      expect(startRun).toHaveBeenCalledTimes(1);
+      const arg = (startRun as unknown as ReturnType<typeof vi.fn>).mock.calls[0][0];
+      expect(arg).toMatchObject({
+        providerId: "deepseek",
+        model: "deepseek-v4-flash",
+        constraints: { readOnly: true },
+        allowedRustRouteTools: ["read_file", "list_dir", "stat_file", "search"],
+      });
+      // Handle is the SERVER RESULT ids — never the request body.
+      expect(arg.missionContext).toEqual({
+        fridayConversationId: "conv-from-SERVER",
+        missionId: "mission-from-SERVER",
+        workItemId: "wi-from-SERVER",
+      });
+      expect(arg.missionContext.missionId).not.toBe(INTAKE_REQ.missionId);
+    });
+
+    it("a blocked/duplicate intake PRODUCES NO run (no re-spend) and still returns the result", async () => {
+      const { adapter, startRun } = composeAdapter(BLOCKED);
+
+      const returned = await adapter.intakeMission(INTAKE_REQ);
+      await Promise.resolve();
+
+      expect(returned).toBe(BLOCKED);
+      expect(startRun).not.toHaveBeenCalled();
     });
   });
 

--- a/test/unit/hub/friday-hub-bootstrap-env.test.ts
+++ b/test/unit/hub/friday-hub-bootstrap-env.test.ts
@@ -7,6 +7,7 @@ import {
   resolveRouteAgentRunViaRust,
   resolveRouteMissionSpineViaRust,
   resolveRouteMemorySpineViaRust,
+  resolveMissionAutoDispatch,
   resolveRouteProvidersViaRust,
   resolveRouteWorkflowsViaRust,
 } from "#hub";
@@ -564,5 +565,35 @@ describe("resolveRouteMemorySpineViaRust (Lane M organic memory-confirmation POS
     expect(resolveRouteMemorySpineViaRust(true, emptyEnv())).toBe(true);
     expect(resolveRouteMemorySpineViaRust(false, { FRIDAY_MEMORY_SPINE_ROUTES_VIA_RUST: "1" })).toBe(false);
     expect(resolveRouteMemorySpineViaRust(false, { FRIDAY_MEMORY_SPINE_ROUTES_VIA_RUST: "true" })).toBe(false);
+  });
+});
+
+describe("resolveMissionAutoDispatch (organic mission→run binding PRODUCER flag)", () => {
+  it("defaults OFF when neither config nor env is set", () => {
+    expect(resolveMissionAutoDispatch(undefined, emptyEnv())).toBe(false);
+  });
+
+  it("env exact opt-in (case-insensitive, trimmed) → true", () => {
+    expect(resolveMissionAutoDispatch(undefined, { FRIDAY_MISSION_AUTO_DISPATCH: "1" })).toBe(true);
+    expect(resolveMissionAutoDispatch(undefined, { FRIDAY_MISSION_AUTO_DISPATCH: "true" })).toBe(true);
+    expect(resolveMissionAutoDispatch(undefined, { FRIDAY_MISSION_AUTO_DISPATCH: "TRUE" })).toBe(true);
+    expect(resolveMissionAutoDispatch(undefined, { FRIDAY_MISSION_AUTO_DISPATCH: "  1  " })).toBe(true);
+    expect(resolveMissionAutoDispatch(undefined, { FRIDAY_MISSION_AUTO_DISPATCH: " true " })).toBe(true);
+  });
+
+  it("any non-exact env value (incl. 0/false/empty/yes/on/2) → false", () => {
+    expect(resolveMissionAutoDispatch(undefined, { FRIDAY_MISSION_AUTO_DISPATCH: "0" })).toBe(false);
+    expect(resolveMissionAutoDispatch(undefined, { FRIDAY_MISSION_AUTO_DISPATCH: "false" })).toBe(false);
+    expect(resolveMissionAutoDispatch(undefined, { FRIDAY_MISSION_AUTO_DISPATCH: "" })).toBe(false);
+    expect(resolveMissionAutoDispatch(undefined, { FRIDAY_MISSION_AUTO_DISPATCH: "yes" })).toBe(false);
+    expect(resolveMissionAutoDispatch(undefined, { FRIDAY_MISSION_AUTO_DISPATCH: "on" })).toBe(false);
+    expect(resolveMissionAutoDispatch(undefined, { FRIDAY_MISSION_AUTO_DISPATCH: "2" })).toBe(false);
+  });
+
+  it("uses explicit config over the env (true wins; false beats env true)", () => {
+    expect(resolveMissionAutoDispatch(true, { FRIDAY_MISSION_AUTO_DISPATCH: "0" })).toBe(true);
+    expect(resolveMissionAutoDispatch(true, emptyEnv())).toBe(true);
+    expect(resolveMissionAutoDispatch(false, { FRIDAY_MISSION_AUTO_DISPATCH: "1" })).toBe(false);
+    expect(resolveMissionAutoDispatch(false, { FRIDAY_MISSION_AUTO_DISPATCH: "true" })).toBe(false);
   });
 });


### PR DESCRIPTION
## Gap closed: organic mission→run binding (the #1 organic-driver gap)

Today **nothing originates a `mission_context` handle on a live run** — the mission→run binding loop only closes when an operator hand-feeds a handle in a test. The route→sealed-client `missionContext` road (#752), the Rust bound seam, and the DB resolver all exist, but there is **no producer**. This PR adds it.

## Option A — intake-triggered auto-dispatch (scout-recommended)

When `POST /v1/mission-spine/intake` births a Mission + a **fresh-Ready** WorkItem and returns the server-produced result, a thin TS driver immediately (async, non-blocking) starts a **READ-ONLY bound agent-run** carrying that server-produced handle → the existing Rust bound seam walks the WorkItem `ready_to_dispatch → … → completed_with_proof` (a read-only Finished closes **without** an operator signature). Reuses the already-merged road + seam + resolver. **No Rust change, no `runtime.rs` touch, no new route** (classifier `routeCount` unchanged at 589).

## What's in this PR (TS only, additive, default-OFF)

- **Flag** `FRIDAY_MISSION_AUTO_DISPATCH` + `HubConfig.missionAutoDispatch` + `resolveMissionAutoDispatch` (mirrors `resolveRouteMissionSpineViaRust`: explicit config wins, else env exact-`"1"`/`"true"`, else false). `src/hub/friday-hub-bootstrap.ts` (`resolveMissionAutoDispatch`), `src/hub/bootstrap/hub-helpers.ts` (`missionAutoDispatch?`).
- **Driver** `src/api/mission-spine/friday-mission-auto-dispatch-driver.ts` — `createFridayMissionAutoDispatchDriver({ startRun, deepseekProviderId, deepseekFlashModel, onDispatchError? })` exposing `onIntakeReady(request, result)`.
- **Adapter hook** `src/api/mission-spine/friday-mission-spine-dispatch-adapter.ts` — new optional `autoDispatchDriver?` ctor option; after a successful intake, calls `onIntakeReady(request, result)` before returning the result verbatim. Absent ⇒ no hook ⇒ byte-identical.
- **Runtime exposure** `src/api/runtime/friday-api-runtime.ts` — `routeStartRun` was only passed into `createFridayAgentRoutes`; it is now also published as `apiRuntime.agent.startRun` (the route-qualifying entrypoint). Exported `RUST_ROUTE_DEEPSEEK_PROVIDER_ID` / `RUST_ROUTE_DEEPSEEK_FLASH_MODEL` so the driver uses the exact qualifying shape without retyping literals.
- **Bootstrap wiring** `src/hub/friday-hub-bootstrap.ts` — when `missionAutoDispatch && routeMissionSpineViaRust`, construct the driver (with a `startRun` thunk that resolves to `apiRuntime.agent.startRun` after the runtime is built — breaking the adapter-before-runtime ordering cycle) and pass it into the dispatch adapter.

## Trigger condition (mirrors the Rust producer predicate)

Dispatch fires **only** when `result.status.trim() === "ready" && result.createdOrReady === true && result.workItemId` is present — the camelCase mirror of `mission_intake_allows_new_work` (`friday-ffi/src/lib.rs`: `status.trim() == "ready" && created_or_ready`) plus the workItem-presence guard the bound run requires. A **blocked/duplicate intake** (`status:"blocked"` / `createdOrReady:false`) dispatches **nothing** — no re-spend.

## No-degrade / dark-safety

Flag default-OFF ⇒ driver never constructed ⇒ `autoDispatchDriver` option omitted ⇒ `intakeMission` byte-identical ⇒ no auto-dispatch ⇒ existing runs + intake unaffected. `onIntakeReady` is synchronous-void + fully error-isolated (a rejecting/throwing `startRun` never perturbs the intake response).

## The handle is the SERVER-VALIDATED result (no raw-body trust)

`missionContext` is built from the intake **RESULT** `{fridayConversationId, missionId, workItemId}` (the DB-validated values Rust minted), never the inbound request body. The Rust resolver re-validates the handle and the owner gate re-asserts on the bound run. The dispatched run is `constraints.readOnly:true` + exactly the 4 Rust read tools (qualifies for the Rust route + closes without a signature).

## Tests (the gate)

- **Driver unit** (`friday-mission-auto-dispatch-driver.test.ts`, 8): dispatch-on-ready **exactly once** with `{constraints:{readOnly:true}, missionContext:<RESULT handle>, providerId/model/readTools}`; **no-dispatch-on-blocked** + on `createdOrReady:false` + on missing `workItemId`; **no-raw-body** (RESULT ids differ from REQUEST ids → handle uses RESULT); **async/non-blocking** (returns before the run settles); **error-isolation** (rejecting `startRun` → `onDispatchError`, no throw; undefined thunk → harmless no-op).
- **Adapter hook** (`friday-mission-spine-dispatch-adapter.test.ts`, +5): driver injected → `onIntakeReady(request,result)` invoked after dispatch; **flag-off byte-identical** (no driver → no call); hook not invoked when dispatch fails.
- **Composed end-to-end**: the **real** driver injected into the **real** adapter, fake sealed client returns a complete ready result → asserts the run is produced with the RESULT-derived handle; blocked → no run, result still returned. (This caught a fixture false-positive: a ready result without `workItemId` does not fire.)
- **Flag resolver** (`friday-hub-bootstrap-env.test.ts`, +4): default-OFF; exact opt-in; config-over-env precedence.
- Local: `npm run typecheck` clean, `npm run lint` 0 errors, vitest (driver/adapter/bootstrap-env + api/runtime + api/mission-spine sweeps) all green, `check-ts-runtime-retirement.mjs` `status:passed`/`failures:[]`/`routeCount:589` (no new route), secret-pattern check clean.

The **full WorkItem-walk-to-`completed_with_proof`** is the Rust bound seam (already tested). The **LIVE joined proof** needs the operator **deploy** + flipping **`FRIDAY_MISSION_AUTO_DISPATCH`** + **`FRIDAY_MISSION_SPINE_ROUTES_VIA_RUST`** + **`FRIDAY_ROUTE_AGENT_RUN_VIA_RUST`** (the Rust read-only route) + the server **`FRIDAY_MISSION_INTAKE`** / **`FRIDAY_MISSION_SPINE_DISPATCH`** flags + SecureStore/launchd provisioning.

## Deviations / notes

1. **Owner principal**: the spec said `principalId:<authenticated owner>`; the driver passes `request.ownerPrincipal` (the intake route asserts a bound principal but does **not** assert `body.ownerPrincipal === ctx.principal`, so this is a client-body value). Safe here — single-owner model + read-only run + the Rust owner gate re-asserts — but it diverges from the literal spec. The more-correct fix (threading `ctx.principal` through the dispatch interface to `onIntakeReady`) is deferred out-of-scope.
2. **Production provider shape**: the driver passes the literal `providerId:"deepseek"` (qualifies via clause-3 path (a)). Production provider rows carry UUID ids with `kind:"deepseek"` (only test/RGG seed the literal id) — so the live-join must verify the dispatched run qualifies in prod (clause-3 path (b) resolves a record's kind). Operator-gated live-join verify item.
3. **Signature**: `onIntakeReady(request, result)` (spec said `(result, ownerPrincipal)`) — the task text (title/intent) and owner all live on the REQUEST, so the request is required to derive them; the handle fields come from the RESULT.

## Out of scope

The **goal→intake ID-minting leg**: intake still requires caller-supplied ids (`missionId`/`workItemId`/etc.). This PR produces the bound run *from* a Ready intake; it does not originate the intake itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)