### PR TITLE
feat(mission-spine): mission-intake clarification — ask, don't silently birth a Mission (FRIDAY_MISSION_INTAKE_CLARIFY, dark)

### DIFF
--- a/rust-core/crates/friday-ffi/src/lib.rs
+++ b/rust-core/crates/friday-ffi/src/lib.rs
@@ -2984,6 +2984,7 @@ mod tests {
                     duplicate_mission_id: Some("mission-1".into()),
                     duplicate_work_item_id: None,
                     created_or_ready: false,
+                    clarification_questions: Vec::new(),
                 },
             },
         );

--- a/rust-core/crates/friday-hub/src/hub_server.rs
+++ b/rust-core/crates/friday-hub/src/hub_server.rs
@@ -217,11 +217,51 @@ impl<T: Transport> HubServer<T> {
 ///
 /// Returns either a [`Message::MissionIntakeResult`] envelope (ready/blocked) or a
 /// [`Message::Error`] envelope on a validation/preflight failure, correlated to `msg_id`.
+///
+/// ## Mission-intake clarification ([`crate::FRIDAY_MISSION_INTAKE_CLARIFY`], DARK)
+/// The [`crate::FRIDAY_MISSION_INTAKE_CLARIFY`] env flag is read ONCE here (the only env
+/// read; semantics in [`crate::mission_intake_clarify_from`]) and threaded as a pure bool
+/// to the parameterized [`mission_intake_result_for_db_flagged`]. **Default-OFF:** when
+/// off the producer is BYTE-IDENTICAL to the pre-clarification baseline — no detail check,
+/// every intent births a Mission exactly as now. The signature is unchanged so both callers
+/// (the [`HubServer::dispatch`] method + the live bin's flag-gated arm) are untouched.
 pub fn mission_intake_result_for_db(
     db: &Db,
     msg_id: &str,
     request: MissionIntakeRequestWire,
     now_ms: i64,
+) -> Envelope {
+    let clarify_enabled = crate::mission_intake_clarify_from(
+        std::env::var(crate::FRIDAY_MISSION_INTAKE_CLARIFY)
+            .ok()
+            .as_deref(),
+    );
+    mission_intake_result_for_db_flagged(db, msg_id, request, now_ms, clarify_enabled)
+}
+
+/// The parameterized Mission-intake producer body — see [`mission_intake_result_for_db`]
+/// for the public env-reading entrypoint. `clarify_enabled` is the resolved
+/// [`crate::FRIDAY_MISSION_INTAKE_CLARIFY`] bool, injected directly so the behavioral
+/// arms (clarify-ON, clarify-OFF) are testable WITHOUT racing `std::env` in a shared test
+/// binary (the codebase's "split env-read from pure logic" idiom).
+///
+/// **`clarify_enabled == false` ⇒ this is BYTE-IDENTICAL to the pre-clarification baseline:**
+/// the whole detail-check block is skipped and the Mission/WorkItem/SurfaceThread/route_decision
+/// rows are written exactly as before.
+///
+/// **`clarify_enabled == true` ⇒** BEFORE constructing or persisting ANY row, the intent is
+/// classified ([`friday_core::classify_kind`]); if it classifies to a planning kind that is
+/// NOT detailed enough ([`friday_core::is_task_detailed_enough`]), the producer returns a
+/// `needs_clarification` [`MissionIntakeResultWire`] carrying the specific
+/// [`friday_core::questions_for_kind`] — writing ZERO rows (no Conversation/Mission/
+/// SurfaceThread/WorkItem/route_decision) and making NO model call. `created_or_ready` is
+/// `false` so the auto-dispatch producer NEVER fires for an under-specified intent.
+pub fn mission_intake_result_for_db_flagged(
+    db: &Db,
+    msg_id: &str,
+    request: MissionIntakeRequestWire,
+    now_ms: i64,
+    clarify_enabled: bool,
 ) -> Envelope {
     if let Err(err) = friday_core::validate_friday_conversation_id(&request.friday_conversation_id)
     {
@@ -261,6 +301,46 @@ pub fn mission_intake_result_for_db(
                 ErrorCode::Internal,
                 "mission intake body_ref must be a Friday-owned body/blob ref",
             );
+        }
+    }
+
+    // (FRIDAY_MISSION_INTAKE_CLARIFY, DARK) Ask-first detail check — GATED so flag-OFF is
+    // BYTE-IDENTICAL (the whole block is skipped). BEFORE constructing or persisting ANY row:
+    // if the intent classifies to a planning kind that is NOT detailed enough, return a
+    // `needs_clarification` result carrying the specific questions and write ZERO rows
+    // (no Conversation/Mission/SurfaceThread/WorkItem/route_decision). `created_or_ready` is
+    // `false`, so the auto-dispatch producer never fires for an under-specified intent — we
+    // ask first instead of silently minting an Active Mission. Validation errors above still
+    // take precedence identically (this runs only on an already-validated request).
+    if clarify_enabled {
+        if let Some(kind) = friday_core::classify_kind(&request.intent) {
+            if !friday_core::is_task_detailed_enough(&request.intent, kind) {
+                let questions: Vec<String> = friday_core::questions_for_kind(kind)
+                    .iter()
+                    .map(|q| (*q).to_string())
+                    .collect();
+                // Echo the request's mission_id / surface_thread_id (NO row was written for
+                // either — these are the client's proposed ids, surfaced so the TS result
+                // parser's required-ref check passes and the clarification is delivered, not
+                // buried under a fail-closed 503). work_item_id is None; blockers is empty.
+                let result = MissionIntakeResultWire {
+                    friday_conversation_id: request.friday_conversation_id.clone(),
+                    mission_id: request.mission_id.clone(),
+                    work_item_id: None,
+                    surface_thread_id: request.surface_thread_id.clone(),
+                    status: "needs_clarification".into(),
+                    blockers: Vec::new(),
+                    duplicate_mission_id: None,
+                    duplicate_work_item_id: None,
+                    created_or_ready: false,
+                    clarification_questions: questions,
+                };
+                return Envelope::new(
+                    format!("{msg_id}-mission-intake"),
+                    now_ms,
+                    Message::MissionIntakeResult { result },
+                );
+            }
         }
     }
 
@@ -431,6 +511,7 @@ pub fn mission_intake_result_for_db(
             duplicate_mission_id: None,
             duplicate_work_item_id: None,
             created_or_ready: true,
+            clarification_questions: Vec::new(),
         },
         MissionPreflightOutcome::Blocked {
             blockers,
@@ -451,6 +532,7 @@ pub fn mission_intake_result_for_db(
                 duplicate_mission_id,
                 duplicate_work_item_id,
                 created_or_ready: false,
+                clarification_questions: Vec::new(),
             }
         }
     };

--- a/rust-core/crates/friday-hub/src/lib.rs
+++ b/rust-core/crates/friday-hub/src/lib.rs
@@ -3236,6 +3236,28 @@ fn clarification_gate_from(raw: Option<&str>) -> bool {
     matches!(raw.map(str::trim), Some("1"))
 }
 
+/// The `FRIDAY_MISSION_INTAKE_CLARIFY` env var. When ON, the Mission-intake producer
+/// ([`hub_server::mission_intake_result_for_db`]) asks clarifying questions for an
+/// UNDER-SPECIFIED, CLASSIFIED intent BEFORE birthing any row — instead of silently
+/// minting an Active Mission from a vague intent. DEFAULT-OFF: unset / empty / `"0"` /
+/// any non-`"1"` value ⇒ OFF, and the producer is BYTE-IDENTICAL to today (no detail
+/// check, the Mission/WorkItem/SurfaceThread/route_decision rows are written exactly as
+/// now). The env is read ONCE inside the public producer and threaded as a pure bool to
+/// the inner [`hub_server::mission_intake_result_for_db_flagged`] — the same "split
+/// env-read from pure logic" idiom as [`FRIDAY_CLARIFICATION_GATE`], so the behavioral
+/// tests inject the bool directly and never race `std::env`.
+pub const FRIDAY_MISSION_INTAKE_CLARIFY: &str = "FRIDAY_MISSION_INTAKE_CLARIFY";
+
+/// Pure flag-matcher for [`FRIDAY_MISSION_INTAKE_CLARIFY`] (env read split out so it is
+/// unit-testable without `set_var`). DEFAULT-OFF: `None` (unset) ⇒ false; ON only for the
+/// exact opt-in value `"1"` (trimmed); everything else (including `"true"`) ⇒ false — the
+/// program's standard flag idiom, mirroring [`clarification_gate_from`]. Private (in-crate
+/// only): the producer wrapper calls it via `crate::`, and the in-crate unit test reaches it
+/// — parity with the private `clarification_gate_from`.
+fn mission_intake_clarify_from(raw: Option<&str>) -> bool {
+    matches!(raw.map(str::trim), Some("1"))
+}
+
 /// `cancel` (C2-1) is an OPTIONAL cooperative cancellation handle checked at the TOP of
 /// each turn, BEFORE the model call. When `Some` and already tripped at a turn boundary,
 /// the loop stops with [`LoopStatus::Interrupted`]: it makes NO further model call and
@@ -4876,6 +4898,30 @@ mod tests {
         );
         assert!(
             !clarification_gate_from(Some("true")),
+            "true ⇒ OFF (only exact 1)"
+        );
+    }
+
+    #[test]
+    fn mission_intake_clarify_from_only_opt_in_enables() {
+        // FRIDAY_MISSION_INTAKE_CLARIFY: default-OFF; ON only for the exact opt-in value "1"
+        // (trimmed). This is the race-free env-string semantics proof for the mission-intake
+        // clarification arm (the ON/OFF behavioral arms inject the bool in
+        // tests/mission_intake_clarification.rs). Mirrors clarification_gate_from's matcher.
+        assert!(
+            !mission_intake_clarify_from(None),
+            "unset ⇒ OFF (prod default)"
+        );
+        assert!(!mission_intake_clarify_from(Some("")), "empty ⇒ OFF");
+        assert!(!mission_intake_clarify_from(Some("0")), "0 ⇒ OFF");
+        assert!(!mission_intake_clarify_from(Some("off")), "off ⇒ OFF");
+        assert!(mission_intake_clarify_from(Some("1")), "1 ⇒ ON");
+        assert!(
+            mission_intake_clarify_from(Some("  1  ")),
+            "padded 1 ⇒ ON (trimmed)"
+        );
+        assert!(
+            !mission_intake_clarify_from(Some("true")),
             "true ⇒ OFF (only exact 1)"
         );
     }

--- a/rust-core/crates/friday-hub/tests/mission_intake_clarification.rs
+++ b/rust-core/crates/friday-hub/tests/mission_intake_clarification.rs
@@ -1,0 +1,272 @@
+//! FRIDAY_MISSION_INTAKE_CLARIFY — the Mission-intake clarification arm, proven at the
+//! producer boundary (`hub_server::mission_intake_result_for_db_flagged`).
+//!
+//! Closes registry path #5: today a VAGUE/under-specified mission intent silently becomes an
+//! Active Mission (Mission + WorkItem(Draft) + SurfaceThread + route_decision) with no clarifying
+//! questions. With the flag ON, an under-specified, CLASSIFIED intent is asked-first instead:
+//! the producer returns a `needs_clarification` result carrying the specific questions and writes
+//! ZERO rows. With the flag OFF the producer is BYTE-IDENTICAL to today.
+//!
+//! ## Why the injected bool (NOT `std::env::set_var`)
+//! This binary mixes flag-ON arms (a)(b) AND a flag-OFF arm (c). Rust runs `#[test]`s on parallel
+//! threads sharing ONE process env, so a `set_var("1")` in one arm would race an unset/`set_var`
+//! in another. The producer splits the env read (in the public `mission_intake_result_for_db`)
+//! from the pure body (`mission_intake_result_for_db_flagged`), so each arm injects its
+//! `clarify_enabled` bool DIRECTLY — no env, no race. The env-string semantics
+//! ("1"/" 1 "/""/None/"true") are covered race-free by the in-crate
+//! `mission_intake_clarify_from_*` pure-matcher unit test.
+
+use friday_hub::hub_server::mission_intake_result_for_db_flagged;
+use friday_protocol::{Message, MissionIntakeRequestWire};
+use friday_storage::audit::verify_audit_chain;
+use friday_storage::Db;
+
+/// The auto-dispatch trigger predicate, an EXACT mirror of
+/// `friday_ffi::mission_intake_allows_new_work` (`friday-ffi/src/lib.rs`:
+/// `status.trim() == "ready" && created_or_ready`) — which the TS auto-dispatch driver
+/// also mirrors (`status === "ready" && createdOrReady === true`). Mirrored inline here
+/// rather than importing `friday-ffi` (a heavy uniffi crate friday-hub does not depend on)
+/// so this binary stays light; the AUTHORITATIVE interaction-guard test lives in the TS
+/// driver test (the real consumer). A clarification result MUST make this false.
+fn auto_dispatch_allows_new_work(status: &str, created_or_ready: bool) -> bool {
+    status.trim() == "ready" && created_or_ready
+}
+
+fn temp_db(tag: &str) -> String {
+    std::env::temp_dir()
+        .join(format!(
+            "friday-mintake-clar-{}-{}-{}.sqlite",
+            std::process::id(),
+            tag,
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ))
+        .to_string_lossy()
+        .into_owned()
+}
+
+const FCONV: &str = "fconv_mintake_clar";
+const OWNER: &str = "owner-mintake-clar";
+const SURFACE_THREAD: &str = "surface-mintake-clar";
+const MISSION: &str = "mission-mintake-clar";
+const WORK_ITEM: &str = "work-mintake-clar";
+
+/// A valid Mission-intake request with the given `intent` — every required field present so the
+/// validation block passes and ONLY the clarification arm decides the outcome.
+fn intake_request(intent: &str) -> MissionIntakeRequestWire {
+    MissionIntakeRequestWire {
+        friday_conversation_id: FCONV.into(),
+        owner_principal: OWNER.into(),
+        surface_thread_id: SURFACE_THREAD.into(),
+        surface_kind: "mobile".into(),
+        delivery_route: "mobile://local/thread/clar".into(),
+        visibility_policy: "compact".into(),
+        mission_id: MISSION.into(),
+        work_item_id: WORK_ITEM.into(),
+        title: "Mission intake clarification".into(),
+        intent: intent.into(),
+        lane: "deepseek".into(),
+        target_provider_or_agent: Some("deepseek".into()),
+        capability_id: Some("ask_friday.deepseek".into()),
+        body_ref: Some("friday://body/mobile/clar".into()),
+        includes_sensitive_context: false,
+    }
+}
+
+/// Extract the `MissionIntakeResultWire` from a reply envelope, or panic with the actual message.
+fn intake_result(env: friday_protocol::Envelope) -> friday_protocol::MissionIntakeResultWire {
+    match env.message {
+        Message::MissionIntakeResult { result } => result,
+        other => panic!("expected a MissionIntakeResult, got {other:?}"),
+    }
+}
+
+// A VAGUE deliverable intent: classifies (VAGUE_DELIVERABLE -> MajorDecision) but is short with no
+// CONSTRAINT hint ⇒ NOT detailed ⇒ the clarification arm fires. Used by arms (a) AND (c) so (c) is
+// the byte-identical-off proof for the SAME vague intent.
+const VAGUE_INTENT: &str = "build me a tool";
+
+// A DETAILED, CLASSIFIED intent: classifies GenerateWorkflow, clears the 110-char threshold AND
+// carries DETAIL hints ("trigger"/"output"/"destination") ⇒ is_task_detailed_enough == TRUE ⇒ the
+// detail-check's true-branch is EXERCISED and the producer falls through to birth the Mission. This
+// is the load-bearing NO-DEGRADE arm: flag ON must NOT over-clarify a well-specified planning task.
+// (Verbatim the proven `detailed_workflow_task_is_detailed_enough` fixture from planning.rs.)
+const DETAILED_INTENT: &str = "create a workflow that triggers every morning at 9am, reads my \
+                               calendar, and posts a daily summary to the team Slack channel as \
+                               its output destination";
+
+// A non-planning intent that classifies None ⇒ the clarification arm is a no-op even ON (the
+// detail-check is never reached) ⇒ the Mission is born exactly as today.
+const UNCLASSIFIED_INTENT: &str = "resolve the organic surface intake into a Mission";
+
+#[test]
+fn arm_a_flag_on_vague_intent_clarifies_and_writes_zero_rows() {
+    let db = Db::open_hub(&temp_db("arm-a")).unwrap();
+    // Flag ON (injected bool) + a vague, classified intent ⇒ needs_clarification.
+    let env = mission_intake_result_for_db_flagged(
+        &db,
+        "req-arm-a",
+        intake_request(VAGUE_INTENT),
+        1000,
+        true,
+    );
+    let result = intake_result(env);
+
+    // (1) status is the distinct needs_clarification value — NOT "ready" — carrying ≥1 question.
+    assert_eq!(
+        result.status, "needs_clarification",
+        "an under-specified intent is asked-first, not silently birthed"
+    );
+    assert!(
+        !result.clarification_questions.is_empty(),
+        "the clarification carries the specific questions: {:?}",
+        result.clarification_questions
+    );
+    assert!(!result.created_or_ready, "no Mission was created/readied");
+    assert!(
+        result.work_item_id.is_none(),
+        "no WorkItem id (no row written)"
+    );
+    // The wire still echoes mission_id / surface_thread_id (the client's PROPOSED ids — no row was
+    // written for either) so the TS result parser's required-ref check passes and the clarification
+    // is delivered, not buried under a fail-closed 503.
+    assert_eq!(result.mission_id, MISSION);
+    assert_eq!(result.surface_thread_id, SURFACE_THREAD);
+
+    // (2) ZERO rows: the Mission and WorkItem the request proposed do NOT exist.
+    assert!(
+        db.get_mission(MISSION).unwrap().is_none(),
+        "no Mission row was written for an under-specified intent"
+    );
+    assert!(
+        db.get_work_item(WORK_ITEM).unwrap().is_none(),
+        "no WorkItem row was written for an under-specified intent"
+    );
+
+    // (3) INTERACTION GUARD: the auto-dispatch predicate MUST be false for a clarification result —
+    // we must NEVER auto-dispatch an under-specified mission. This is the exact predicate the TS
+    // driver mirrors (`status === "ready" && createdOrReady === true`).
+    assert!(
+        !auto_dispatch_allows_new_work(&result.status, result.created_or_ready),
+        "a needs_clarification result must NOT trigger auto-dispatch"
+    );
+
+    // (4) the audit chain is clean (no partial write left the ledger inconsistent).
+    verify_audit_chain(db.conn()).expect("audit chain clean after a clarification (no rows)");
+}
+
+#[test]
+fn arm_b_flag_on_detailed_classified_intent_births_a_mission_as_today() {
+    let db = Db::open_hub(&temp_db("arm-b")).unwrap();
+    // Flag ON + a DETAILED, CLASSIFIED intent ⇒ the detail-check's true-branch fires
+    // (is_task_detailed_enough == true) ⇒ the producer falls through and births the Mission exactly
+    // as today. This is the no-degrade guarantee: a well-specified planning task is NOT over-clarified.
+    let env = mission_intake_result_for_db_flagged(
+        &db,
+        "req-arm-b",
+        intake_request(DETAILED_INTENT),
+        2000,
+        true,
+    );
+    let result = intake_result(env);
+
+    assert_eq!(
+        result.status, "ready",
+        "a sufficiently-specified intent births a ready Mission"
+    );
+    assert!(result.created_or_ready, "the WorkItem was created");
+    assert_eq!(result.work_item_id.as_deref(), Some(WORK_ITEM));
+    assert!(
+        result.clarification_questions.is_empty(),
+        "the ready path carries NO clarification questions"
+    );
+    // The rows exist (Mission born Active, WorkItem in Draft).
+    let mission = db
+        .get_mission(MISSION)
+        .unwrap()
+        .expect("Mission row written");
+    assert_eq!(mission.status, friday_core::MissionStatus::Active);
+    assert!(
+        db.get_work_item(WORK_ITEM).unwrap().is_some(),
+        "WorkItem row written"
+    );
+    // This IS a ready intake ⇒ the auto-dispatch predicate is TRUE (the binding may fire).
+    assert!(
+        auto_dispatch_allows_new_work(&result.status, result.created_or_ready),
+        "a ready intake qualifies for auto-dispatch"
+    );
+    verify_audit_chain(db.conn()).expect("audit chain clean after a ready Mission birth");
+}
+
+#[test]
+fn arm_c_flag_off_vague_intent_births_a_mission_byte_identical() {
+    let db = Db::open_hub(&temp_db("arm-c")).unwrap();
+    // Flag OFF + the SAME vague intent as arm (a). Flag-OFF skips the whole clarification block ⇒
+    // BYTE-IDENTICAL to today: the Mission is born ready, no clarification.
+    let env = mission_intake_result_for_db_flagged(
+        &db,
+        "req-arm-c",
+        intake_request(VAGUE_INTENT),
+        3000,
+        false,
+    );
+    let result = intake_result(env);
+
+    assert_eq!(
+        result.status, "ready",
+        "flag-OFF: the vague intent births a ready Mission exactly as today (no clarification)"
+    );
+    assert!(
+        result.created_or_ready,
+        "flag-OFF: the WorkItem was created"
+    );
+    assert_eq!(result.work_item_id.as_deref(), Some(WORK_ITEM));
+    assert!(
+        result.clarification_questions.is_empty(),
+        "flag-OFF: NO clarification questions (the field stays empty / serializes away)"
+    );
+    // The rows exist — flag-OFF behavior is unchanged from today.
+    assert!(
+        db.get_mission(MISSION).unwrap().is_some(),
+        "flag-OFF: Mission row written"
+    );
+    assert!(
+        db.get_work_item(WORK_ITEM).unwrap().is_some(),
+        "flag-OFF: WorkItem row written"
+    );
+    verify_audit_chain(db.conn()).expect("audit chain clean (flag-OFF baseline)");
+}
+
+#[test]
+fn arm_d_flag_on_unclassified_intent_births_a_mission() {
+    let db = Db::open_hub(&temp_db("arm-d")).unwrap();
+    // Flag ON + an intent that classifies None (no planning verb) ⇒ classify_kind returns None ⇒
+    // the whole detail-check block is skipped ⇒ the Mission is born exactly as today. This covers
+    // the `classify_kind == None` skip path (distinct from arm (b)'s classified-AND-detailed path),
+    // so neither the "unclassified" nor the "detailed" fall-through can silently start clarifying.
+    let env = mission_intake_result_for_db_flagged(
+        &db,
+        "req-arm-d",
+        intake_request(UNCLASSIFIED_INTENT),
+        4000,
+        true,
+    );
+    let result = intake_result(env);
+
+    assert_eq!(
+        result.status, "ready",
+        "an unclassified intent (classify_kind None) births a ready Mission, never clarifies"
+    );
+    assert!(result.created_or_ready, "the WorkItem was created");
+    assert!(
+        result.clarification_questions.is_empty(),
+        "the None-classified path carries NO clarification questions"
+    );
+    assert!(
+        db.get_mission(MISSION).unwrap().is_some(),
+        "Mission row written for an unclassified intent"
+    );
+    verify_audit_chain(db.conn()).expect("audit chain clean after an unclassified Mission birth");
+}

--- a/rust-core/crates/friday-protocol/src/lib.rs
+++ b/rust-core/crates/friday-protocol/src/lib.rs
@@ -270,7 +270,10 @@ pub struct MissionIntakeRequestWire {
 
 /// Hub response for Mission intake/preflight. `status=blocked` means no new
 /// WorkItem was written; duplicate ids tell the client which existing Mission or
-/// WorkItem to show.
+/// WorkItem to show. `status=needs_clarification` (the flag-gated mission-intake
+/// clarification arm) means the intent was UNDER-SPECIFIED so NO rows were written
+/// at all — `clarification_questions` carries the specific questions to ask, and
+/// `created_or_ready` is `false` so the auto-dispatch producer never fires for it.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct MissionIntakeResultWire {
     pub friday_conversation_id: String,
@@ -285,6 +288,13 @@ pub struct MissionIntakeResultWire {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub duplicate_work_item_id: Option<String>,
     pub created_or_ready: bool,
+    /// (Mission-intake clarification — DARK, default-OFF) The specific clarifying
+    /// questions for an UNDER-SPECIFIED intent. NON-EMPTY only when
+    /// `status == "needs_clarification"`; every existing ready/blocked path leaves
+    /// it empty. Additive + optional on the wire (`#[serde(default)]` + skipped when
+    /// empty) so existing serialized payloads round-trip BYTE-IDENTICALLY.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub clarification_questions: Vec<String>,
 }
 
 /// Client request to apply the OWNER's explicit confirm/reject decision to ONE
@@ -2078,6 +2088,7 @@ mod tests {
                     duplicate_mission_id: None,
                     duplicate_work_item_id: None,
                     created_or_ready: true,
+                    clarification_questions: Vec::new(),
                 },
             },
             mission_projection_snapshot(),

--- a/src/api/mission-spine/friday-rust-hub-agent-run-ws-sealed-client.ts
+++ b/src/api/mission-spine/friday-rust-hub-agent-run-ws-sealed-client.ts
@@ -469,6 +469,13 @@ export interface FridayRustHubMissionIntakeResult {
   readonly duplicateMissionId?: string;
   readonly duplicateWorkItemId?: string;
   readonly createdOrReady: boolean;
+  /**
+   * (Mission-intake clarification — DARK, default-OFF) The specific clarifying questions for an
+   * UNDER-SPECIFIED intent. NON-EMPTY only when `status === "needs_clarification"` (the Rust
+   * producer's flag-gated clarification arm); every existing ready/blocked path omits it.
+   * Surfaced only when present (the Rust wire skips the field when empty), never fabricated.
+   */
+  readonly clarificationQuestions?: readonly string[];
 }
 
 /** (Lane B) A Mission lifecycle transition request — `MissionLifecycleRequestWire`. */
@@ -1022,6 +1029,15 @@ export function parseMissionIntakeResult(
   const workItemId = asString(r.work_item_id);
   const duplicateMissionId = asString(r.duplicate_mission_id);
   const duplicateWorkItemId = asString(r.duplicate_work_item_id);
+  // (Mission-intake clarification — DARK) Optional, ADDITIVE: surfaced only when the server sends a
+  // non-empty `clarification_questions` (the flag-gated needs_clarification arm). Absent / empty /
+  // non-array / non-string entries ⇒ the field is OMITTED (never fabricated, never a parse failure
+  // — backward-compatible with every existing ready/blocked payload that omits it).
+  const rawQuestions = r.clarification_questions;
+  const clarificationQuestions =
+    Array.isArray(rawQuestions) && rawQuestions.every((q): q is string => typeof q === "string")
+      ? rawQuestions
+      : undefined;
   return {
     // `MissionIntakeResultWire` carries NO `truth_label` field (verified in friday-protocol), so the
     // server cannot send one — this `rust_wired` label is the TS-side ceiling for a Rust-served refs
@@ -1036,6 +1052,9 @@ export function parseMissionIntakeResult(
     ...(workItemId !== undefined ? { workItemId } : {}),
     ...(duplicateMissionId !== undefined ? { duplicateMissionId } : {}),
     ...(duplicateWorkItemId !== undefined ? { duplicateWorkItemId } : {}),
+    ...(clarificationQuestions !== undefined && clarificationQuestions.length > 0
+      ? { clarificationQuestions }
+      : {}),
   };
 }
 

--- a/test/unit/api/mission-spine/friday-mission-auto-dispatch-driver.test.ts
+++ b/test/unit/api/mission-spine/friday-mission-auto-dispatch-driver.test.ts
@@ -57,6 +57,24 @@ const BLOCKED_RESULT: FridayRustHubMissionIntakeResult = {
   createdOrReady: false,
 };
 
+// (Mission-intake clarification — DARK) A `needs_clarification` result: the Rust producer asked
+// clarifying questions for an UNDER-SPECIFIED intent and wrote ZERO rows (no workItemId, status is
+// NOT "ready", createdOrReady is false). This is the INTERACTION GUARD fixture — it must NEVER
+// trigger auto-dispatch (we never dispatch an under-specified mission).
+const NEEDS_CLARIFICATION_RESULT: FridayRustHubMissionIntakeResult = {
+  truthLabel: "rust_wired",
+  fridayConversationId: "conv-from-SERVER-result",
+  missionId: "mission-from-SERVER-result",
+  surfaceThreadId: "thread-1",
+  status: "needs_clarification",
+  blockers: [],
+  createdOrReady: false,
+  clarificationQuestions: [
+    "What outcome matters most for this decision?",
+    "What constraints, risks, or non-goals must the plan respect?",
+  ],
+};
+
 function makeDriver(opts?: {
   startRun?: MissionAutoDispatchStartRun | undefined;
   onDispatchError?: (error: unknown) => void;
@@ -127,6 +145,20 @@ describe("createFridayMissionAutoDispatchDriver (organic mission→run binding P
       void _omit;
 
       driver.onIntakeReady(REQUEST, noWorkItem as FridayRustHubMissionIntakeResult);
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(startRun).not.toHaveBeenCalled();
+    });
+
+    // INTERACTION GUARD (Mission-intake clarification × auto-dispatch): a needs_clarification result
+    // (status !== "ready", createdOrReady false, no workItemId) must NEVER auto-dispatch. The driver
+    // keys on `status === "ready"`, so this naturally won't fire — this test PINS that invariant so
+    // we can never auto-dispatch an under-specified mission.
+    it("does NOT dispatch for a needs_clarification result (never dispatch an under-specified mission)", async () => {
+      const { driver, startRun } = makeDriver();
+
+      driver.onIntakeReady(REQUEST, NEEDS_CLARIFICATION_RESULT);
       await Promise.resolve();
       await Promise.resolve();
 

--- a/test/unit/api/mission-spine/friday-rust-hub-mission-spine-wire.test.ts
+++ b/test/unit/api/mission-spine/friday-rust-hub-mission-spine-wire.test.ts
@@ -204,6 +204,52 @@ describe("parseMissionIntakeResult (fail-closed refs-only, NESTED result)", () =
     expect(withOptionals?.duplicateWorkItemId).toBe("work_dup");
   });
 
+  it("does NOT surface clarificationQuestions when the field is absent (existing ready/blocked payloads)", () => {
+    // Backward-compat: a payload with no clarification_questions parses fine and omits the field.
+    expect(parseMissionIntakeResult(valid)).not.toHaveProperty("clarificationQuestions");
+    // An empty array is treated as absent (the Rust wire skips it when empty) — still omitted.
+    expect(
+      parseMissionIntakeResult({ result: { ...valid.result, clarification_questions: [] } }),
+    ).not.toHaveProperty("clarificationQuestions");
+  });
+
+  it("surfaces clarificationQuestions for a needs_clarification result (the DARK clarification arm)", () => {
+    const clarified = parseMissionIntakeResult({
+      result: {
+        ...valid.result,
+        status: "needs_clarification",
+        work_item_id: undefined,
+        created_or_ready: false,
+        clarification_questions: [
+          "What exact outcome should this skill deliver for the user?",
+          "What inputs, tools, or systems should it use or avoid?",
+        ],
+      },
+    });
+    expect(clarified?.status).toBe("needs_clarification");
+    expect(clarified?.createdOrReady).toBe(false);
+    expect(clarified?.workItemId).toBeUndefined();
+    expect(clarified?.clarificationQuestions).toEqual([
+      "What exact outcome should this skill deliver for the user?",
+      "What inputs, tools, or systems should it use or avoid?",
+    ]);
+  });
+
+  it("ignores an ill-typed clarification_questions (non-array / non-string entries) without failing the parse", () => {
+    // NO-DEGRADE: a malformed clarification_questions must NOT bury the whole result under a 503 —
+    // the field is simply omitted (never fabricated), the rest of the refs still parse.
+    const nonArray = parseMissionIntakeResult({
+      result: { ...valid.result, clarification_questions: "oops" },
+    });
+    expect(nonArray).toBeDefined();
+    expect(nonArray).not.toHaveProperty("clarificationQuestions");
+    const nonString = parseMissionIntakeResult({
+      result: { ...valid.result, clarification_questions: ["ok", 7] },
+    });
+    expect(nonString).toBeDefined();
+    expect(nonString).not.toHaveProperty("clarificationQuestions");
+  });
+
   it("fails closed (undefined) on a missing required ref or ill-typed fields", () => {
     expect(parseMissionIntakeResult({ result: { ...valid.result, mission_id: "" } })).toBeUndefined();
     expect(parseMissionIntakeResult({ result: { ...valid.result, created_or_ready: "yes" } })).toBeUndefined();


### PR DESCRIPTION
## What

Closes **registry path #5: mission-intake clarification**. Today a vague/under-specified mission intent silently becomes an **Active Mission** (Mission + WorkItem(Draft) + SurfaceThread + RouteDecisionCard) with no clarifying questions. With the new flag ON, the intake producer **classifies the intent first** and, when it is a CLASSIFIED-but-under-specified planning task, returns a `needs_clarification` result carrying the specific questions and writes **ZERO rows** — ask first, don't guess.

Dark / flag-gated / no-degrade: flag-OFF is byte-identical to today.

## Flag

`FRIDAY_MISSION_INTAKE_CLARIFY` — **default-OFF**, ON only for the exact trimmed `"1"` (mirrors `clarification_gate_from`). Read **once** in `mission_intake_result_for_db`, split from the pure body `mission_intake_result_for_db_flagged` (the "split env-read from pure logic" idiom).

## Producer (detail-check)

`rust-core/crates/friday-hub/src/hub_server.rs` — `mission_intake_result_for_db` (the env-reading wrapper) + `mission_intake_result_for_db_flagged` (pure body). The detail-check runs **after validation, before any row is constructed/persisted**: `if let Some(kind) = classify_kind(&request.intent) { if !is_task_detailed_enough(...) { return needs_clarification } }`, reusing the already-live, LIVE-PROVEN clarification primitives (`classify_kind` / `is_task_detailed_enough` / `questions_for_kind` from `planning.rs`). The clarification return writes ZERO rows (no Conversation/Mission/SurfaceThread/WorkItem/RouteDecision) and makes NO model call.

## Result wire (additive, backward-compatible)

- `MissionIntakeResultWire.clarification_questions: Vec<String>` (`#[serde(default, skip_serializing_if = "Vec::is_empty")]`) — empty on every existing ready/blocked path, so serialized payloads round-trip byte-identically.
- Clarification result carries `status = "needs_clarification"` (a distinct value, NOT `"ready"`), `created_or_ready = false`, `work_item_id = None`, and echoes the request's `mission_id` / `surface_thread_id` (no row was written — they're the client's proposed ids, surfaced so the TS parser's required-ref check passes and the clarification is delivered, not buried under a fail-closed 503).
- TS: `FridayRustHubMissionIntakeResult.clarificationQuestions?` + `parseMissionIntakeResult` (ill-typed → field omitted, never a parse failure). The intake route is a pure pass-through (no change). **Manifest unchanged** — the mission-spine family is keyed on `sourceFile` + `classification` (`rust_delegated`), not response field shapes.

## Interaction guard (critical)

A `needs_clarification` result must **never** auto-dispatch. The auto-dispatch driver keys on `status === "ready"`, so it naturally won't fire — pinned by an **explicit TS driver test** (`onIntakeReady(needs_clarification)` ⇒ `startRun` not called) and a Rust predicate-mirror assertion. We never auto-dispatch an under-specified mission.

## Tests

- `rust-core/crates/friday-hub/tests/mission_intake_clarification.rs` (4 arms, all pass): **(a)** vague + flag ON ⇒ `needs_clarification` + ≥1 question + `get_mission`/`get_work_item` None + auto-dispatch predicate false + clean audit; **(b)** DETAILED classified intent + flag ON ⇒ Mission born Active/ready (exercises the `is_task_detailed_enough == true` fall-through — the no-degrade branch); **(c)** flag OFF + vague intent ⇒ Mission born ready (byte-identical baseline) + clean audit; **(d)** flag ON + unclassified intent (`classify_kind` None) ⇒ Mission born (covers the skip path).
- `mission_intake_clarify_from_only_opt_in_enables` pure-matcher unit test (off-by-default + on-only-for-`"1"`, race-free).
- TS driver guard test + `parseMissionIntakeResult` clarification tests.

## Local verification

- `cargo fmt --all -- --check` clean.
- `cargo test -p friday-hub` (685 lib + bin + new e2e), `-p friday-protocol`, `-p friday-ffi` all green.
- `npm run lint` 0 errors; `tsc --noEmit` clean; mission-spine vitest green (46 tests); `detect-secrets-hook` clean.

## Flag-OFF byte-identical

With `clarify_enabled == false` the entire detail-check block is skipped and the Mission/WorkItem/SurfaceThread/route_decision rows are written exactly as before; the new wire field stays empty and `skip_serializing_if` drops it from the payload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)