### PR TITLE
feat(mission-spine): surface_event timeline PRODUCER (FRIDAY_SURFACE_EVENTS, dark)

### DIFF
--- a/rust-core/crates/friday-hub/src/hub_server.rs
+++ b/rust-core/crates/friday-hub/src/hub_server.rs
@@ -236,7 +236,18 @@ pub fn mission_intake_result_for_db(
             .ok()
             .as_deref(),
     );
-    mission_intake_result_for_db_flagged(db, msg_id, request, now_ms, clarify_enabled)
+    // FRIDAY_SURFACE_EVENTS (DARK, default-OFF): read ONCE here and thread the resulting bool to
+    // the flagged body — the "split env-read from pure logic" idiom. OFF ⇒ no surface_event emit.
+    let surface_events =
+        crate::surface_events_from(std::env::var(crate::FRIDAY_SURFACE_EVENTS).ok().as_deref());
+    mission_intake_result_for_db_flagged(
+        db,
+        msg_id,
+        request,
+        now_ms,
+        clarify_enabled,
+        surface_events,
+    )
 }
 
 /// The parameterized Mission-intake producer body — see [`mission_intake_result_for_db`]
@@ -256,12 +267,21 @@ pub fn mission_intake_result_for_db(
 /// [`friday_core::questions_for_kind`] — writing ZERO rows (no Conversation/Mission/
 /// SurfaceThread/WorkItem/route_decision) and making NO model call. `created_or_ready` is
 /// `false` so the auto-dispatch producer NEVER fires for an under-specified intent.
+///
+/// **`surface_events`** is the resolved [`crate::FRIDAY_SURFACE_EVENTS`] bool (DARK, default-OFF).
+/// When ON, AFTER preflight succeeds (the READY path only — never the `needs_clarification` or
+/// `blocked` paths), a single intake-birth [`friday_core::SurfaceEvent`]
+/// ([`friday_core::SurfaceEventKind::SystemStatus`]) is emitted BEST-EFFORT via
+/// [`crate::surface_events::emit_surface_event`] so the Mission Workbench timeline reader has a
+/// birth row to fold in. OFF ⇒ byte-identical (no emit). The emit is failure-isolated: a write
+/// failure is logged + swallowed and the intake result is UNCHANGED.
 pub fn mission_intake_result_for_db_flagged(
     db: &Db,
     msg_id: &str,
     request: MissionIntakeRequestWire,
     now_ms: i64,
     clarify_enabled: bool,
+    surface_events: bool,
 ) -> Envelope {
     if let Err(err) = friday_core::validate_friday_conversation_id(&request.friday_conversation_id)
     {
@@ -493,6 +513,38 @@ pub fn mission_intake_result_for_db_flagged(
                 now_ms,
                 ErrorCode::Internal,
                 &format!("mission intake route decision write failed: {err}"),
+            );
+        }
+        // (FRIDAY_SURFACE_EVENTS, DARK, default-OFF) Intake-birth surface_event — emitted ONLY on
+        // the READY path (NOT needs_clarification / blocked), AFTER preflight wrote the
+        // Mission/SurfaceThread (so the linkage validates) and the route decision succeeded. The
+        // SurfaceThread the preflight upserted is bound to this Mission with `surface_kind` (the
+        // value resolved above), so `validate_surface_event` passes and the workbench timeline
+        // reader folds the row in. BEST-EFFORT: a write failure is logged + swallowed inside
+        // `emit_surface_event`, so the intake result below is UNCHANGED. `surface_events == false`
+        // ⇒ `emit_surface_event` returns before any write (byte-identical-off, belt-and-suspenders
+        // on top of the caller already skipping on flag-OFF).
+        if let MissionPreflightOutcome::Ready {
+            mission_id,
+            work_item_id,
+        } = &outcome
+        {
+            crate::surface_events::emit_surface_event(
+                db,
+                surface_events,
+                crate::surface_events::SurfaceEventLifecycle::IntakeBirth,
+                &crate::surface_events::SurfaceEventLink {
+                    friday_conversation_id: &request.friday_conversation_id,
+                    mission_id,
+                    work_item_id: Some(work_item_id),
+                    surface_thread_id: &request.surface_thread_id,
+                    source_surface: surface_kind,
+                },
+                // No run yet at intake birth; the event_id keys on the mission_id for this point.
+                mission_id,
+                None,
+                None,
+                now_ms,
             );
         }
     }

--- a/rust-core/crates/friday-hub/src/lib.rs
+++ b/rust-core/crates/friday-hub/src/lib.rs
@@ -256,6 +256,12 @@ pub mod provider_timeline;
 /// attaches provider/channel evidence as trace refs, not independent product state.
 pub mod mission_preflight;
 
+/// The `surface_event` timeline PRODUCER (`FRIDAY_SURFACE_EVENTS`, DARK, default-OFF). Emits
+/// refs-only `surface_event` rows at the Mission lifecycle points (intake-birth, run-start,
+/// run-finish/proof) so the existing Mission Workbench timeline reader has rows to fold in. Reuses
+/// the existing `upsert_surface_event` persist; best-effort / non-fatal; never touches the reader.
+pub(crate) mod surface_events;
+
 /// Skill / Capability Catalog / Advisor Bridge. Reads managed skill manifests as
 /// truth-labeled catalog entries and advisor inputs; it does not execute skills
 /// or grant control.
@@ -3258,6 +3264,30 @@ fn mission_intake_clarify_from(raw: Option<&str>) -> bool {
     matches!(raw.map(str::trim), Some("1"))
 }
 
+/// The `FRIDAY_SURFACE_EVENTS` env var. When ON, the surface_event PRODUCER emits refs-only
+/// `surface_event` rows at the Mission lifecycle points (intake-birth, run-start, run-finish/proof)
+/// so the existing Mission Workbench timeline reader
+/// ([`workbench_projection::project_workbench`] → `append_surface_events`) — which already reads
+/// [`friday_storage::Db::list_surface_events_for_mission`] — has rows to fold in. Today nothing
+/// emits these rows on the live path, so the workbench timeline is empty of surface events. This is
+/// pure OBSERVABILITY: the emit is BEST-EFFORT (a write failure is logged + swallowed, never
+/// failing the run/intake) and NEVER changes a run outcome, billing, proof, or intake result.
+/// DEFAULT-OFF: unset / empty / `"0"` / any non-`"1"` value ⇒ OFF, and the intake + run paths are
+/// BYTE-IDENTICAL to today (no emit, no extra rows). The env is read ONCE inside each public
+/// producer entry and threaded as a pure bool to the inner flagged fn — the same "split env-read
+/// from pure logic" idiom as [`FRIDAY_MISSION_INTAKE_CLARIFY`], so the behavioral tests inject the
+/// bool directly and never race `std::env`.
+pub const FRIDAY_SURFACE_EVENTS: &str = "FRIDAY_SURFACE_EVENTS";
+
+/// Pure flag-matcher for [`FRIDAY_SURFACE_EVENTS`] (env read split out so it is unit-testable
+/// without `set_var`). DEFAULT-OFF: `None` (unset) ⇒ false; ON only for the exact opt-in value
+/// `"1"` (trimmed); everything else (including `"true"`) ⇒ false — the program's standard flag
+/// idiom, mirroring [`mission_intake_clarify_from`]. `pub(crate)` so BOTH producer entries (the
+/// intake in `hub_server` and the run loop in `runtime`) read it via `crate::`.
+pub(crate) fn surface_events_from(raw: Option<&str>) -> bool {
+    matches!(raw.map(str::trim), Some("1"))
+}
+
 /// `cancel` (C2-1) is an OPTIONAL cooperative cancellation handle checked at the TOP of
 /// each turn, BEFORE the model call. When `Some` and already tripped at a turn boundary,
 /// the loop stops with [`LoopStatus::Interrupted`]: it makes NO further model call and
@@ -4922,6 +4952,27 @@ mod tests {
         );
         assert!(
             !mission_intake_clarify_from(Some("true")),
+            "true ⇒ OFF (only exact 1)"
+        );
+    }
+
+    #[test]
+    fn surface_events_from_only_opt_in_enables() {
+        // FRIDAY_SURFACE_EVENTS: default-OFF; ON only for the exact opt-in value "1" (trimmed).
+        // The race-free env-string semantics proof for the surface_event PRODUCER (the ON/OFF
+        // behavioral arms inject the bool: the run path in-crate below, the intake + e2e in
+        // tests/surface_events_timeline.rs). Mirrors mission_intake_clarify_from's matcher.
+        assert!(!surface_events_from(None), "unset ⇒ OFF (prod default)");
+        assert!(!surface_events_from(Some("")), "empty ⇒ OFF");
+        assert!(!surface_events_from(Some("0")), "0 ⇒ OFF");
+        assert!(!surface_events_from(Some("off")), "off ⇒ OFF");
+        assert!(surface_events_from(Some("1")), "1 ⇒ ON");
+        assert!(
+            surface_events_from(Some("  1  ")),
+            "padded 1 ⇒ ON (trimmed)"
+        );
+        assert!(
+            !surface_events_from(Some("true")),
             "true ⇒ OFF (only exact 1)"
         );
     }

--- a/rust-core/crates/friday-hub/src/runtime.rs
+++ b/rust-core/crates/friday-hub/src/runtime.rs
@@ -1398,6 +1398,11 @@ impl<T: Transport> HubRuntime<T> {
                 .ok()
                 .as_deref(),
         );
+        // FRIDAY_SURFACE_EVENTS (DARK, default-OFF): read ONCE here and thread the resulting bool
+        // into the flagged inner fn — the same split-env-read idiom as `passport_mint`. DEFAULT-OFF:
+        // when off the body is BYTE-IDENTICAL (no run-start / run-proof surface_event emitted).
+        let surface_events =
+            crate::surface_events_from(std::env::var(crate::FRIDAY_SURFACE_EVENTS).ok().as_deref());
         self.run_agent_loop_for_mission_with_overrides_flagged(
             mission_lookup,
             session_id,
@@ -1407,6 +1412,7 @@ impl<T: Transport> HubRuntime<T> {
             max_turns_override,
             passport_mint,
             workitem_guarded,
+            surface_events,
             now_ms,
         )
     }
@@ -1437,6 +1443,16 @@ impl<T: Transport> HubRuntime<T> {
     /// The passport is gated as ONE transfer unit (all-or-nothing): ANY sensitive item in the
     /// recalled set blocks the WHOLE handoff (nothing partially carried) — DELIBERATELY tighter
     /// than the per-item recall path. See [`Self::mint_handoff_passport`] for the full semantics.
+    ///
+    /// `surface_events = false` (the prod default) is BYTE-IDENTICAL to the pre-surface_events
+    /// body: no run-start / run-proof [`friday_core::SurfaceEvent`] is emitted (the emits are
+    /// SKIPPED). `surface_events = true` emits, BEST-EFFORT, a run-start
+    /// ([`friday_core::SurfaceEventKind::ProviderTrace`]) surface_event AFTER the envelope is Ready
+    /// (before the loop) and a run-proof ([`friday_core::SurfaceEventKind::ProofReceipt`])
+    /// surface_event AFTER a Finished loop completes the bound WorkItem with proof — so the existing
+    /// Mission Workbench timeline reader has run rows to fold in. The emits are failure-isolated
+    /// (logged + swallowed): a surface_event write failure NEVER changes the run outcome, billing,
+    /// proof, or the `MissionBoundLoopOutcome` returned here.
     #[allow(clippy::too_many_arguments)]
     fn run_agent_loop_for_mission_with_overrides_flagged(
         &self,
@@ -1448,6 +1464,7 @@ impl<T: Transport> HubRuntime<T> {
         max_turns_override: Option<u64>,
         passport_mint: bool,
         workitem_guarded: bool,
+        surface_events: bool,
         now_ms: i64,
     ) -> Result<MissionBoundLoopOutcome, RoutedLoopError> {
         // PREFLIGHT (fail-closed): validate the Mission/work-item BEFORE any run exists. On
@@ -1486,6 +1503,43 @@ impl<T: Transport> HubRuntime<T> {
             }
         }
 
+        // (FRIDAY_SURFACE_EVENTS, DARK, default-OFF) Resolve the SurfaceThread bound to THIS
+        // Mission ONCE — both the run-start and the run-proof surface_event below link to it. The
+        // resolved context's `surface_thread_id` is `None` on the live mission-bound lookup
+        // (`by_mission_work_item`), so the producer resolves by the surface_thread row's OWN
+        // `mission_id` column. OFF ⇒ skip the resolve entirely (byte-identical). A Mission with no
+        // bound thread ⇒ `None` ⇒ no surface_event emitted (best-effort observability, never an
+        // error). The `source_surface` is read FROM the resolved thread so the linkage validates.
+        let bound_surface_thread = if surface_events {
+            crate::surface_events::resolve_bound_surface_thread(
+                &self.db,
+                &envelope.context.mission_id,
+            )
+        } else {
+            None
+        };
+        if let Some(thread) = bound_surface_thread.as_ref() {
+            // RUN-STARTED: Friday dispatched the bound WorkItem to its provider/agent. Emitted
+            // BEFORE the loop runs. ProviderTrace (the reader renders `provider_ack` — a run in
+            // flight, NOT completion). BEST-EFFORT: a write failure cannot fail the run.
+            crate::surface_events::emit_surface_event(
+                &self.db,
+                surface_events,
+                crate::surface_events::SurfaceEventLifecycle::RunStarted,
+                &crate::surface_events::SurfaceEventLink {
+                    friday_conversation_id: &envelope.context.friday_conversation_id,
+                    mission_id: &envelope.context.mission_id,
+                    work_item_id: Some(&envelope.context.work_item_id),
+                    surface_thread_id: &thread.surface_thread_id,
+                    source_surface: thread.surface_kind,
+                },
+                run_id,
+                Some(format!("friday://surface-event-body/run-start/{run_id}")),
+                None,
+                now_ms,
+            );
+        }
+
         // Run the SAME composed loop as the unbound entry (no divergence), threading the
         // (effective) per-run policy + ceiling so a mission-bound run enforces the IDENTICAL
         // tightening the unbound dispatch arm applies. Absent override ⇒ boot config unchanged.
@@ -1516,6 +1570,49 @@ impl<T: Transport> HubRuntime<T> {
             workitem_guarded,
             now_ms,
         )?;
+
+        // (FRIDAY_SURFACE_EVENTS, DARK, default-OFF) RUN-PROOF surface_event — emitted ONLY when
+        // the loop Finished AND the attachment actually completed the bound WorkItem with proof
+        // (`Attached { work_item_status: CompletedWithProof }`). A Paused / Blocked / Errored loop
+        // (which binds at most at `ProviderRouted`) emits NO proof row — truth-honest, mirroring
+        // the WorkItem completion's own truth-honesty. ProofReceipt (the reader renders
+        // `completed_with_proof`). The proof_ref is a Friday-owned `proof://`-prefixed ref (NOT the
+        // `friday://agent-run/...` result_link, which the storage proof-ref validator rejects).
+        // BEST-EFFORT: a write failure cannot change the completion the run already wrote.
+        //
+        // ORDERING: stamp the proof event `now_ms + 1` so it sorts STRICTLY AFTER the run-start
+        // (which used `now_ms`) in `list_surface_events_for_mission`'s `ORDER BY created_at_ms,
+        // surface_event_id`. With an equal stamp the id tiebreak would put `run-proof` BEFORE
+        // `run-start` (`p` < `s`), rendering "completed" ahead of "in flight" — wrong for a timeline.
+        // The loop genuinely ran between start and finish, so a later stamp is also more honest.
+        if let Some(thread) = bound_surface_thread.as_ref() {
+            if completed
+                && matches!(
+                    attachment,
+                    MissionAttachmentOutcome::Attached {
+                        work_item_status: friday_core::WorkItemStatus::CompletedWithProof,
+                        ..
+                    }
+                )
+            {
+                crate::surface_events::emit_surface_event(
+                    &self.db,
+                    surface_events,
+                    crate::surface_events::SurfaceEventLifecycle::RunCompletedWithProof,
+                    &crate::surface_events::SurfaceEventLink {
+                        friday_conversation_id: &envelope.context.friday_conversation_id,
+                        mission_id: &envelope.context.mission_id,
+                        work_item_id: Some(&envelope.context.work_item_id),
+                        surface_thread_id: &thread.surface_thread_id,
+                        source_surface: thread.surface_kind,
+                    },
+                    run_id,
+                    None,
+                    Some(format!("proof://agent-run/{run_id}")),
+                    now_ms.saturating_add(1),
+                );
+            }
+        }
 
         Ok(MissionBoundLoopOutcome::Ran {
             envelope,
@@ -6458,6 +6555,140 @@ mod tests {
         assert!(friday_storage::audit::verify_audit_chain(rt.db().conn()).is_ok());
     }
 
+    /// FRIDAY_SURFACE_EVENTS (DARK) — the run-path producer, bool-INJECTED (no `std::env`). OFF ⇒
+    /// the Finished mission-bound run writes ZERO surface_event rows (byte-identical to today); ON ⇒
+    /// the SAME run emits exactly the run-start (provider_trace) + run-proof (proof_receipt) rows,
+    /// each correctly linked to the Mission's bound SurfaceThread (resolved BY MISSION, since the
+    /// `by_work_item` lookup leaves the context's surface_thread_id None). The intake-birth row is
+    /// the intake producer's responsibility (proven in tests/surface_events_timeline.rs); this
+    /// behavioral test isolates the run path. The flagged inner fn is `pub(crate)`-private, so this
+    /// must live in-crate. Asserts the producer NEVER changes the run outcome (Finished +
+    /// CompletedWithProof either way) and the audit chain stays clean.
+    #[test]
+    fn surface_events_run_path_off_is_byte_identical_on_emits_run_rows() {
+        // OFF arm: a normal Finished run with surface_events=false ⇒ zero surface_event rows.
+        let (rt_off, root_off, _post) = runtime_with(
+            "surface-off",
+            &[
+                "{\"tool\":\"read_file\",\"parameters\":{\"path\":\"notes.md\"}}",
+                "{\"tool\":\"none\"}",
+            ],
+            Box::new(DenyAllApprovals),
+        );
+        std::fs::write(root_off.join("notes.md"), b"note").unwrap();
+        seed_loop_mission(
+            rt_off.db(),
+            WorkLane::DeepSeek,
+            Some("deepseek"),
+            WorkItemStatus::ReadyToDispatch,
+        );
+        let outcome_off = rt_off
+            .run_agent_loop_for_mission_with_overrides_flagged(
+                loop_lookup(),
+                "friday-hub-session",
+                "run-surface-off",
+                "read the notes",
+                None,
+                None,
+                false, // passport_mint
+                false, // workitem_guarded
+                false, // surface_events OFF
+                1000,
+            )
+            .unwrap();
+        assert!(matches!(outcome_off, MissionBoundLoopOutcome::Ran { .. }));
+        assert_eq!(
+            rt_off
+                .db()
+                .get_work_item("work-loop")
+                .unwrap()
+                .unwrap()
+                .status,
+            WorkItemStatus::CompletedWithProof,
+            "the run completes with proof regardless of the surface_events flag"
+        );
+        assert!(
+            rt_off
+                .db()
+                .list_surface_events_for_mission("mission-loop")
+                .unwrap()
+                .is_empty(),
+            "flag-OFF writes NO surface_event rows"
+        );
+        assert!(friday_storage::audit::verify_audit_chain(rt_off.db().conn()).is_ok());
+
+        // ON arm: the SAME run with surface_events=true ⇒ run-start + run-proof rows.
+        let (rt_on, root_on, _post) = runtime_with(
+            "surface-on",
+            &[
+                "{\"tool\":\"read_file\",\"parameters\":{\"path\":\"notes.md\"}}",
+                "{\"tool\":\"none\"}",
+            ],
+            Box::new(DenyAllApprovals),
+        );
+        std::fs::write(root_on.join("notes.md"), b"note").unwrap();
+        seed_loop_mission(
+            rt_on.db(),
+            WorkLane::DeepSeek,
+            Some("deepseek"),
+            WorkItemStatus::ReadyToDispatch,
+        );
+        let outcome_on = rt_on
+            .run_agent_loop_for_mission_with_overrides_flagged(
+                loop_lookup(),
+                "friday-hub-session",
+                "run-surface-on",
+                "read the notes",
+                None,
+                None,
+                false, // passport_mint
+                false, // workitem_guarded
+                true,  // surface_events ON
+                1000,
+            )
+            .unwrap();
+        assert!(matches!(outcome_on, MissionBoundLoopOutcome::Ran { .. }));
+        // Same run outcome as OFF: the producer NEVER changes completion/proof.
+        assert_eq!(
+            rt_on
+                .db()
+                .get_work_item("work-loop")
+                .unwrap()
+                .unwrap()
+                .status,
+            WorkItemStatus::CompletedWithProof
+        );
+        let events = rt_on
+            .db()
+            .list_surface_events_for_mission("mission-loop")
+            .unwrap();
+        let kinds: Vec<&str> = events.iter().map(|e| e.event_kind.as_str()).collect();
+        assert!(
+            kinds.contains(&"provider_trace"),
+            "run-start (provider_trace) emitted: {kinds:?}"
+        );
+        assert!(
+            kinds.contains(&"proof_receipt"),
+            "run-proof (proof_receipt) emitted: {kinds:?}"
+        );
+        // ORDER: the reader sorts by (created_at_ms, surface_event_id); run-start must precede
+        // run-proof in the timeline (the now_ms+1 proof stamp guards the equal-stamp id-tiebreak
+        // that would otherwise put "completed" ahead of "in flight").
+        let start_idx = kinds.iter().position(|k| *k == "provider_trace").unwrap();
+        let proof_idx = kinds.iter().position(|k| *k == "proof_receipt").unwrap();
+        assert!(
+            start_idx < proof_idx,
+            "run-start must sort before run-proof in the timeline: {kinds:?}"
+        );
+        // Linked to the Mission's bound surface thread (resolved BY MISSION, not via the lookup).
+        for event in &events {
+            assert_eq!(event.mission_id, "mission-loop");
+            assert_eq!(event.surface_thread_id, "surface-mobile-loop");
+            assert_eq!(event.source_surface, SurfaceKind::Mobile);
+        }
+        assert!(friday_storage::audit::verify_audit_chain(rt_on.db().conn()).is_ok());
+    }
+
     /// A NON-Finished (Paused) loop is still bound to the Mission (link tied to run_id) but
     /// the binding is TRUTH-honest: it does NOT over-claim `CompletedWithProof` — it stops at
     /// `ProviderRouted` (true for any Ok loop outcome).
@@ -7172,6 +7403,7 @@ mod tests {
                 None,
                 /* passport_mint = */ true,
                 /* workitem_guarded = */ false,
+                /* surface_events = */ false,
                 1000,
             )
             .unwrap();
@@ -7252,6 +7484,7 @@ mod tests {
                 None,
                 /* passport_mint = */ true,
                 /* workitem_guarded = */ false,
+                /* surface_events = */ false,
                 1000,
             )
             .unwrap();
@@ -7351,6 +7584,7 @@ mod tests {
                 None,
                 /* passport_mint = */ true,
                 /* workitem_guarded = */ false,
+                /* surface_events = */ false,
                 1000,
             )
             .unwrap();
@@ -7449,6 +7683,7 @@ mod tests {
                 None,
                 /* passport_mint = */ false,
                 /* workitem_guarded = */ false,
+                /* surface_events = */ false,
                 1000,
             )
             .unwrap();

--- a/rust-core/crates/friday-hub/src/surface_events.rs
+++ b/rust-core/crates/friday-hub/src/surface_events.rs
@@ -1,0 +1,154 @@
+//! The `surface_event` timeline PRODUCER (`FRIDAY_SURFACE_EVENTS`, DARK, default-OFF).
+//!
+//! Registry path #6: the storage (`surface_event` table), the [`friday_core::SurfaceEvent`]
+//! struct, the persist (`upsert_surface_event`), AND the workbench-timeline READER
+//! ([`crate::workbench_projection::project_workbench`] → `append_surface_events`, which reads
+//! [`friday_storage::Db::list_surface_events_for_mission`]) all already exist — but NOTHING emits
+//! `surface_event` rows on the live path, so the Mission Workbench timeline is empty of surface
+//! events. This module is the missing PRODUCER. It is the ONLY new emit; it reuses the existing
+//! [`friday_storage::Db::upsert_surface_event`] persist (no reimplementation) and never touches the
+//! reader.
+//!
+//! ## No-degrade · best-effort · refs-only
+//! Every emit is GATED by [`crate::FRIDAY_SURFACE_EVENTS`] (read once at each producer entry,
+//! threaded in as a pure bool). Flag-OFF ⇒ the caller skips this module entirely ⇒ byte-identical.
+//! Each emit is BEST-EFFORT / failure-isolated: a write failure is logged + swallowed and NEVER
+//! fails the run or the intake (the run/proof path is load-bearing; the timeline is observability).
+//! The rows carry only Friday-owned REFS (`body_ref` / `proof_ref` validated by the storage layer),
+//! never raw transcript / provider text.
+
+use friday_core::{SurfaceEvent, SurfaceEventKind, SurfaceKind, SurfaceThread, VisibilityPolicy};
+use friday_storage::Db;
+
+/// One lifecycle point at which a `surface_event` is emitted. Each maps to a defined
+/// [`SurfaceEventKind`] — we use ONLY existing kinds (no new kinds invented):
+/// - [`Self::IntakeBirth`] ⇒ [`SurfaceEventKind::SystemStatus`]: a Mission was just born from a
+///   surface input — a system-level lifecycle fact, not a user/Friday/provider chat message.
+/// - [`Self::RunStarted`] ⇒ [`SurfaceEventKind::ProviderTrace`]: Friday dispatched the bound
+///   WorkItem to its provider/agent (the reader renders this as `provider_ack` — honest: a run is
+///   in flight, NOT yet completion).
+/// - [`Self::RunCompletedWithProof`] ⇒ [`SurfaceEventKind::ProofReceipt`]: the run Finished and the
+///   bound WorkItem reached `CompletedWithProof` with the run as proof (the reader renders this as
+///   `completed_with_proof` — the unambiguous done state).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum SurfaceEventLifecycle {
+    IntakeBirth,
+    RunStarted,
+    RunCompletedWithProof,
+}
+
+impl SurfaceEventLifecycle {
+    fn event_kind(self) -> SurfaceEventKind {
+        match self {
+            SurfaceEventLifecycle::IntakeBirth => SurfaceEventKind::SystemStatus,
+            SurfaceEventLifecycle::RunStarted => SurfaceEventKind::ProviderTrace,
+            SurfaceEventLifecycle::RunCompletedWithProof => SurfaceEventKind::ProofReceipt,
+        }
+    }
+
+    /// The stable, idempotent `surface_event_id` slug per lifecycle point. Keying on the stable
+    /// id (the `mission_id` for the once-per-mission birth, the `run_id` for the per-run points)
+    /// makes a re-emit a clean UPSERT (`ON CONFLICT(surface_event_id) DO UPDATE`) — never a
+    /// duplicate row.
+    fn event_id(self, mission_id: &str, run_id: &str) -> String {
+        match self {
+            SurfaceEventLifecycle::IntakeBirth => {
+                format!("surface_event:intake:{mission_id}")
+            }
+            SurfaceEventLifecycle::RunStarted => {
+                format!("surface_event:run-start:{run_id}")
+            }
+            SurfaceEventLifecycle::RunCompletedWithProof => {
+                format!("surface_event:run-proof:{run_id}")
+            }
+        }
+    }
+}
+
+/// The fully-resolved linkage a `surface_event` needs to satisfy `validate_surface_event`:
+/// an existing Mission (conversation match), an existing SurfaceThread bound to that Mission with a
+/// matching `surface_kind`, and (optionally) a WorkItem of that Mission.
+pub(crate) struct SurfaceEventLink<'a> {
+    pub friday_conversation_id: &'a str,
+    pub mission_id: &'a str,
+    pub work_item_id: Option<&'a str>,
+    pub surface_thread_id: &'a str,
+    pub source_surface: SurfaceKind,
+}
+
+/// Emit ONE `surface_event` for `lifecycle`, BEST-EFFORT. `enabled = false` (the prod default) ⇒
+/// returns immediately with NO write (the caller already skips this on flag-OFF; this is a second
+/// belt-and-suspenders guard so the byte-identical-off invariant holds even on a stray call). On a
+/// persist error (e.g. the linkage validation rejects it) the error is logged to `stderr` and
+/// SWALLOWED — the caller's run/intake outcome is NEVER affected.
+///
+/// `proof_ref` is included ONLY for the proof point and MUST be a Friday-owned `proof://`/`audit://`
+/// ref (the storage layer's `require_safe_surface_proof_ref` enforces this); a `body_ref` (when
+/// present) MUST be a `friday://body/` / `friday://surface-event-body/` / `blob://` ref.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn emit_surface_event(
+    db: &Db,
+    enabled: bool,
+    lifecycle: SurfaceEventLifecycle,
+    link: &SurfaceEventLink<'_>,
+    run_id: &str,
+    body_ref: Option<String>,
+    proof_ref: Option<String>,
+    now_ms: i64,
+) {
+    if !enabled {
+        return;
+    }
+    let event = SurfaceEvent {
+        surface_event_id: lifecycle.event_id(link.mission_id, run_id),
+        friday_conversation_id: link.friday_conversation_id.to_string(),
+        mission_id: link.mission_id.to_string(),
+        work_item_id: link.work_item_id.map(str::to_string),
+        surface_thread_id: link.surface_thread_id.to_string(),
+        source_surface: link.source_surface,
+        event_kind: lifecycle.event_kind(),
+        body_ref,
+        // The timeline row is refs-only observability, so a Compact policy is correct (a proof
+        // point still carries its proof_ref; the reader applies its own visibility shaping).
+        visibility_policy: VisibilityPolicy::Compact,
+        proof_ref,
+        created_at_ms: now_ms,
+    };
+    // BEST-EFFORT / failure-isolated: a surface_event is OBSERVABILITY, never load-bearing. A write
+    // failure is logged + swallowed so it can NEVER fail the run or the intake. (Mirrors the
+    // memory-extraction producer's `let _ =` swallow at the run-finish point.)
+    if let Err(err) = db.upsert_surface_event(&event) {
+        eprintln!(
+            "[surface-events] non-fatal: emit {kind} for mission {mission} failed: {err}",
+            kind = lifecycle.event_kind().as_str(),
+            mission = link.mission_id,
+        );
+    }
+}
+
+/// Resolve the SurfaceThread bound to `mission_id` for the RUN lifecycle points (intake builds its
+/// thread inline and does NOT call this). The resolved mission context carries an OPTIONAL
+/// `surface_thread_id` (the `by_mission_work_item` lookup the live mission-bound run uses leaves it
+/// `None`), so the producer resolves the bound thread by the surface_thread row's OWN `mission_id`
+/// column here (index-backed `list_surface_threads_for_mission`). Returns the oldest bound thread
+/// (deterministic). `Ok(None)` ⇒ no bound thread exists ⇒ the caller SKIPS the emit (best-effort:
+/// a run without a bound surface thread simply produces no surface_event — never an error). A
+/// storage error is logged + swallowed (returns `None`) so resolution can never break the run.
+pub(crate) fn resolve_bound_surface_thread(db: &Db, mission_id: &str) -> Option<SurfaceThread> {
+    match db.list_surface_threads_for_mission(mission_id) {
+        Ok(mut threads) => {
+            if threads.is_empty() {
+                None
+            } else {
+                Some(threads.remove(0))
+            }
+        }
+        Err(err) => {
+            eprintln!(
+                "[surface-events] non-fatal: resolve bound surface thread for mission \
+                 {mission_id} failed: {err}"
+            );
+            None
+        }
+    }
+}

--- a/rust-core/crates/friday-hub/tests/mission_intake_clarification.rs
+++ b/rust-core/crates/friday-hub/tests/mission_intake_clarification.rs
@@ -111,6 +111,7 @@ fn arm_a_flag_on_vague_intent_clarifies_and_writes_zero_rows() {
         intake_request(VAGUE_INTENT),
         1000,
         true,
+        false, // FRIDAY_SURFACE_EVENTS OFF (orthogonal to the clarify arm under test)
     );
     let result = intake_result(env);
 
@@ -169,6 +170,7 @@ fn arm_b_flag_on_detailed_classified_intent_births_a_mission_as_today() {
         intake_request(DETAILED_INTENT),
         2000,
         true,
+        false, // FRIDAY_SURFACE_EVENTS OFF (orthogonal to the clarify arm under test)
     );
     let result = intake_result(env);
 
@@ -211,6 +213,7 @@ fn arm_c_flag_off_vague_intent_births_a_mission_byte_identical() {
         intake_request(VAGUE_INTENT),
         3000,
         false,
+        false, // FRIDAY_SURFACE_EVENTS OFF (orthogonal to the clarify arm under test)
     );
     let result = intake_result(env);
 
@@ -252,6 +255,7 @@ fn arm_d_flag_on_unclassified_intent_births_a_mission() {
         intake_request(UNCLASSIFIED_INTENT),
         4000,
         true,
+        false, // FRIDAY_SURFACE_EVENTS OFF (orthogonal to the clarify arm under test)
     );
     let result = intake_result(env);
 

--- a/rust-core/crates/friday-hub/tests/surface_events_timeline.rs
+++ b/rust-core/crates/friday-hub/tests/surface_events_timeline.rs
@@ -1,0 +1,439 @@
+//! FRIDAY_SURFACE_EVENTS — the surface_event timeline PRODUCER, proven end-to-end through a real
+//! [`friday_hub::runtime::HubRuntime`] mission-bound run (the live `run_agent_loop_for_mission`
+//! entry, the SAME one the production WS dispatch arm reaches) and the existing workbench-timeline
+//! READER (`workbench_projection::project_workbench`).
+//!
+//! Registry path #6: storage + struct + persist + the workbench READER all exist, but NOTHING
+//! emitted `surface_event` rows on the live path, so the Mission Workbench timeline was empty. This
+//! suite proves the PRODUCER now fills it WITHOUT touching the reader:
+//!
+//! - Flag ON: an intake-birth row (via the live `mission_intake_result_for_db`), a run-start row,
+//!   and a run-proof row exist for the mission (`list_surface_events_for_mission`), and the
+//!   `project_workbench` timeline now INCLUDES them (the `surface-event` refs in the snapshot).
+//! - Flag OFF: the SAME run writes ZERO surface_event rows, and the projection timeline is
+//!   byte-identical-minus-events (no `surface-event` ref at all).
+//! - The audit chain stays clean in both arms.
+//!
+//! The producer resolves the surface_thread by the thread row's OWN `mission_id` (the live
+//! `by_mission_work_item` lookup leaves the context's `surface_thread_id` None), so this test drives
+//! the SAME resolution the prod path does — it does NOT thread a surface_thread_id through the
+//! lookup (that would be a green-but-dead producer).
+//!
+//! This lives in `tests/` (not `src/`) because the env-flag-ON arm reads `std::env`
+//! (`FRIDAY_SURFACE_EVENTS`); the byte-identical-OFF behavioral proof + the pure-matcher unit test
+//! live in-crate where the bool is injected directly.
+
+use std::cell::Cell;
+use std::rc::Rc;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use friday_core::{
+    FridayConversation, HandoffJudgmentMemory, Mission, MissionStatus, Risk, SurfaceKind,
+    SurfaceThread, TruthStatus, VisibilityPolicy, WorkItem, WorkItemStatus, WorkLane,
+};
+use friday_deepseek::{DeepSeekClient, DeepSeekError, Transport};
+use friday_hub::mission_context::MissionContextLookup;
+use friday_hub::runtime::{DenyAllApprovals, HubConfig, HubRuntime, MissionBoundLoopOutcome};
+use friday_hub::workbench_projection::project_workbench;
+use friday_hub::{DeepSeekAgentLlmClient, LoopStatus};
+use friday_protocol::{Message, MissionIntakeRequestWire};
+use friday_storage::Db;
+use serde_json::Value;
+
+const SECRET: &[u8] = b"surface-events-test-secret-0123456789"; // pragma: allowlist secret
+
+static C: AtomicU64 = AtomicU64::new(0);
+
+fn unique(tag: &str) -> String {
+    format!(
+        "{}-{}-{}",
+        std::process::id(),
+        tag,
+        C.fetch_add(1, Ordering::Relaxed)
+    )
+}
+
+struct TempDir(std::path::PathBuf);
+impl TempDir {
+    fn new(tag: &str) -> Self {
+        let p = std::env::temp_dir().join(format!("friday-surface-events-ws-{}", unique(tag)));
+        std::fs::create_dir_all(&p).unwrap();
+        TempDir(p)
+    }
+    fn join(&self, name: &str) -> std::path::PathBuf {
+        self.0.join(name)
+    }
+}
+impl Drop for TempDir {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.0);
+    }
+}
+
+fn tmp_db(tag: &str) -> String {
+    std::env::temp_dir()
+        .join(format!("friday-surface-events-{}.sqlite", unique(tag)))
+        .to_string_lossy()
+        .into_owned()
+}
+
+/// Scripted DeepSeek transport: GET /models → one flash model; POST /chat → the next scripted
+/// assistant `content` (a tool-call JSON the strict parser reads). Mirrors the in-crate runtime
+/// tests' transport.
+struct ScriptTransport {
+    contents: Vec<String>,
+    post_calls: Rc<Cell<usize>>,
+}
+impl ScriptTransport {
+    fn new(contents: &[&str]) -> Self {
+        Self {
+            contents: contents.iter().map(|s| s.to_string()).collect(),
+            post_calls: Rc::new(Cell::new(0)),
+        }
+    }
+}
+impl Transport for ScriptTransport {
+    fn get_json(&self, _u: &str, _b: &str) -> Result<Value, DeepSeekError> {
+        Ok(serde_json::json!({"data":[{"id":"deepseek-v4-flash"}]}))
+    }
+    fn post_json(&self, _u: &str, _b: &str, _body: &Value) -> Result<Value, DeepSeekError> {
+        let n = self.post_calls.get();
+        self.post_calls.set(n + 1);
+        let content = self
+            .contents
+            .get(n)
+            .cloned()
+            .unwrap_or_else(|| "{\"tool\":\"none\"}".to_string());
+        Ok(serde_json::json!({
+            "model":"deepseek-v4-flash",
+            "choices":[{"message":{"content":content},"finish_reason":"stop"}],
+            "usage":{"prompt_tokens":10,"completion_tokens":5,"total_tokens":15}
+        }))
+    }
+}
+
+fn runtime_with(tag: &str) -> (HubRuntime<ScriptTransport>, TempDir) {
+    let ws = TempDir::new(tag);
+    // A read_file then a finish: the loop executes ONE tool then Finishes (CompletedWithProof).
+    let transport = ScriptTransport::new(&[
+        "{\"tool\":\"read_file\",\"parameters\":{\"path\":\"notes.md\"}}",
+        "{\"tool\":\"none\"}",
+    ]);
+    let client = DeepSeekClient::with_transport(transport, "k".into());
+    let agent = DeepSeekAgentLlmClient::new(client);
+    let rt = HubRuntime::new(
+        HubConfig {
+            db_path: tmp_db(tag),
+            workspace_root: ws.0.clone(),
+            secret: SECRET.to_vec(),
+            max_turns: 6,
+            principal_id: Some("owner-surface".to_string()),
+            disabled_tools: vec![],
+            read_only: false,
+            operator_vk: None,
+        },
+        agent,
+        Box::new(DenyAllApprovals),
+    )
+    .unwrap();
+    (rt, ws)
+}
+
+// The mission/conversation MUST be UI-proof canonical (`mission_` / `fconv_`) so project_workbench
+// accepts the mission and the conversation id validates.
+const FCONV: &str = "fconv_surface";
+const MISSION: &str = "mission_surface";
+const WORK_ITEM: &str = "work_surface";
+const SURFACE: &str = "surface_mobile_surface";
+
+fn judgment() -> HandoffJudgmentMemory {
+    HandoffJudgmentMemory {
+        task: "Run the Mission-bound agent loop and emit timeline events".into(),
+        current_blocker: None,
+        target_lane_thread_agent_provider: WorkLane::DeepSeek.as_str().into(),
+        read_first_files: vec!["rust-core/crates/friday-hub/src/surface_events.rs".into()],
+        required_output: "Mission-bound loop completion with timeline events".into(),
+        done_criteria: vec!["surface_event rows folded into the workbench timeline".into()],
+        red_lines: vec!["never fail the run on a surface_event write".into()],
+        why_this_route: "The WorkItem lane owns the agent loop.".into(),
+        considered_options: vec!["no timeline".into()],
+        deferred_options: vec!["multi-provider".into()],
+        previous_pitfalls: vec!["empty workbench timeline".into()],
+        inheritable_context: vec!["Mission is product truth".into()],
+        proof_requirements: vec!["surface_event timeline tests".into()],
+        ownership_claim_ids: Vec::new(),
+    }
+}
+
+/// Seed a canonical `FridayConversation -> Mission -> WorkItem` (+ a Mission-bound SurfaceThread, the
+/// thread the producer resolves BY MISSION) and a route_decision so `project_workbench` accepts the
+/// mission. Mirrors the in-crate `seed_loop_mission` but with `mission_`/`fconv_` canonical ids.
+fn seed_mission(db: &Db) {
+    let now = 1_700_000_000_000;
+    db.upsert_friday_conversation(&FridayConversation {
+        friday_conversation_id: FCONV.into(),
+        owner_principal: "owner-surface".into(),
+        title: "Surface events".into(),
+        current_focus_summary: "Mission-bound agent loop timeline".into(),
+        active_mission_ids: vec![MISSION.into()],
+        surface_thread_ids: vec![SURFACE.into()],
+        memory_scope_ref: None,
+        truth_status: TruthStatus::WiredRegistry,
+        proof_refs: vec!["proof://surface-events-test".into()],
+        created_at_ms: now,
+        updated_at_ms: now,
+    })
+    .unwrap();
+    db.upsert_mission(&Mission {
+        mission_id: MISSION.into(),
+        friday_conversation_id: FCONV.into(),
+        title: "Surface events".into(),
+        intent: "bind the agent loop and emit timeline events".into(),
+        status: MissionStatus::Active,
+        why_now: "the workbench timeline must show run lifecycle".into(),
+        decision_path_summary: "resolve mission context before the loop".into(),
+        considered_options: vec!["no timeline".into()],
+        deferred_options: vec!["multi-provider".into()],
+        known_pitfalls: vec!["empty timeline".into()],
+        handoff_inheritance: vec!["preserve route judgment".into()],
+        work_item_ids: vec![WORK_ITEM.into()],
+        memory_candidate_refs: Vec::new(),
+        context_passport_refs: Vec::new(),
+        proof_refs: vec!["proof://surface-events-test".into()],
+        created_at_ms: now,
+        updated_at_ms: now,
+    })
+    .unwrap();
+    db.upsert_surface_thread(&SurfaceThread {
+        surface_thread_id: SURFACE.into(),
+        friday_conversation_id: FCONV.into(),
+        mission_id: Some(MISSION.into()),
+        surface_kind: SurfaceKind::Mobile,
+        channel_binding_id: None,
+        delivery_route: "mobile".into(),
+        visibility_policy: VisibilityPolicy::Compact,
+        allowed_actions: vec!["open_mission".into()],
+        last_seen_at_ms: Some(now),
+        last_delivered_event_seq: Some(1),
+        created_at_ms: now,
+        updated_at_ms: now,
+    })
+    .unwrap();
+    db.upsert_work_item(&WorkItem {
+        work_item_id: WORK_ITEM.into(),
+        mission_id: MISSION.into(),
+        lane: WorkLane::DeepSeek,
+        target_provider_or_agent: Some("deepseek".into()),
+        status: WorkItemStatus::ReadyToDispatch,
+        owner_claim_ids: Vec::new(),
+        workspace_refs: Vec::new(),
+        capability_id: Some("mission.surface".into()),
+        risk_level: Risk::Medium,
+        approval_state: friday_core::ApprovalState::NotRequired,
+        blocking_reason: None,
+        input_refs: vec!["input://surface".into()],
+        output_refs: Vec::new(),
+        proof_requirements: vec!["surface_event timeline tests".into()],
+        proof_receipts: Vec::new(),
+        judgment_memory: judgment(),
+        created_at_ms: now,
+        updated_at_ms: now,
+    })
+    .unwrap();
+}
+
+fn lookup() -> MissionContextLookup {
+    // by_mission_work_item ⇒ the resolved context's surface_thread_id is None ⇒ the producer MUST
+    // resolve the bound thread by mission (the live path; NOT a threaded surface_thread_id).
+    MissionContextLookup::by_mission_work_item(FCONV, MISSION, WORK_ITEM)
+}
+
+/// Run the mission-bound loop to a Finished completion (drives `run_agent_loop_for_mission`, the
+/// live entry). The notes.md the read_file tool reads is written into the workspace first.
+fn run_to_completion(rt: &HubRuntime<ScriptTransport>, ws: &TempDir, run_id: &str) {
+    std::fs::write(ws.join("notes.md"), b"surface-events note").unwrap();
+    let outcome = rt
+        .run_agent_loop_for_mission(
+            lookup(),
+            "friday-hub-session",
+            run_id,
+            "read the notes",
+            1000,
+        )
+        .unwrap();
+    let MissionBoundLoopOutcome::Ran { outcome, .. } = outcome else {
+        panic!("expected a Mission-bound loop run, got {outcome:?}");
+    };
+    assert_eq!(
+        outcome.status,
+        LoopStatus::Finished,
+        "the scripted loop reads one file then finishes"
+    );
+    // The WorkItem is completed with proof (the run is the proof).
+    assert_eq!(
+        rt.db().get_work_item(WORK_ITEM).unwrap().unwrap().status,
+        WorkItemStatus::CompletedWithProof
+    );
+}
+
+/// Count the `surface_event`-ROW timeline entries the EXISTING reader (`append_surface_events`)
+/// folds into the projection. Keyed on the reader's `timeline://mission/{m}/surface-event/{i}`
+/// ref, which is UNIQUE to a `surface_event` row — deliberately NOT a substring of
+/// `event_surface_*` ids, since the unrelated existing `MissionSurfaceProjection` events render as
+/// `event_surface_projection_*` with a `.../surface-projection/...` ref. A non-zero count proves
+/// the reader is now populated by the PRODUCER (the reader itself is UNCHANGED).
+fn surface_event_refs_in_projection(snapshot: &Value) -> usize {
+    serde_json::to_string(snapshot)
+        .unwrap()
+        .matches("/surface-event/")
+        .count()
+}
+
+// ─────────────────────────── flag ON then OFF, in ONE sequential test ───────────────────────────
+//
+// `FRIDAY_SURFACE_EVENTS` is process-global. Each `tests/*.rs` file is its own binary, so the ONLY
+// thing that could race the env read in THIS binary is another `#[test]` fn in THIS file mutating
+// the var concurrently. Both arms therefore live in ONE sequential `#[test]` (no concurrency, no
+// race) on FRESH per-arm DBs. The byte-identical-OFF behavioral proof with the bool injected
+// directly (no env at all) is the in-crate
+// `runtime::tests::surface_events_run_path_off_is_byte_identical_on_emits_run_rows`.
+#[test]
+fn flag_on_emits_lifecycle_events_and_reader_includes_them_then_off_is_clean() {
+    // ── ON phase: produced + folded into the timeline ──────────────────────────────────────
+    std::env::set_var(friday_hub::FRIDAY_SURFACE_EVENTS, "1");
+    let (rt, ws) = runtime_with("on");
+    seed_mission(rt.db());
+
+    // INTAKE-BIRTH: drive the live intake producer (env flag ON) on the SAME canonical mission ids
+    // already seeded — the READY path emits the birth surface_event. (The intake upserts over the
+    // seeded rows idempotently.)
+    let intake = friday_hub::hub_server::mission_intake_result_for_db(
+        rt.db(),
+        "req-surface-on",
+        intake_request(),
+        900,
+    );
+    // The intake resolved READY (a row exists) — not an Error envelope.
+    assert!(
+        matches!(intake.message, Message::MissionIntakeResult { .. }),
+        "intake should resolve to a MissionIntakeResult, got {:?}",
+        intake.message
+    );
+
+    // RUN-START + RUN-PROOF: drive the mission-bound loop to completion.
+    run_to_completion(&rt, &ws, "run-surface-on");
+
+    // (1) The producer wrote the lifecycle surface_event rows for the mission.
+    let events = rt.db().list_surface_events_for_mission(MISSION).unwrap();
+    let kinds: Vec<&str> = events.iter().map(|e| e.event_kind.as_str()).collect();
+    assert!(
+        kinds.contains(&"system_status"),
+        "intake-birth (system_status) row present: {kinds:?}"
+    );
+    assert!(
+        kinds.contains(&"provider_trace"),
+        "run-start (provider_trace) row present: {kinds:?}"
+    );
+    assert!(
+        kinds.contains(&"proof_receipt"),
+        "run-proof (proof_receipt) row present: {kinds:?}"
+    );
+    // ORDER: the reader sorts by (created_at_ms, surface_event_id). The lifecycle must read
+    // birth → start → proof. intake-birth (900) < run-start (1000) < run-proof (1001 = now_ms+1);
+    // the proof bump guards the equal-stamp id-tiebreak that would otherwise put proof before start.
+    let birth_idx = kinds.iter().position(|k| *k == "system_status").unwrap();
+    let start_idx = kinds.iter().position(|k| *k == "provider_trace").unwrap();
+    let proof_idx = kinds.iter().position(|k| *k == "proof_receipt").unwrap();
+    assert!(
+        birth_idx < start_idx && start_idx < proof_idx,
+        "timeline order must be birth → run-start → run-proof: {kinds:?}"
+    );
+    // Each row is correctly linked to the mission + the bound surface thread (validate passed).
+    for event in &events {
+        assert_eq!(event.mission_id, MISSION);
+        assert_eq!(event.friday_conversation_id, FCONV);
+        assert_eq!(event.surface_thread_id, SURFACE);
+        assert_eq!(event.source_surface, SurfaceKind::Mobile);
+    }
+
+    // (2) The EXISTING reader now folds them into the workbench timeline.
+    let snapshot = project_workbench(rt.db(), Some(MISSION)).unwrap();
+    let count = surface_event_refs_in_projection(&snapshot);
+    assert!(
+        count >= 3,
+        "the workbench timeline includes the >=3 surface_event rows, found {count}: {snapshot}"
+    );
+
+    // (3) The audit chain stays clean — the producer never corrupts it.
+    assert!(friday_storage::audit::verify_audit_chain(rt.db().conn()).is_ok());
+
+    // ── OFF phase: zero rows, timeline byte-identical-minus-events ──────────────────────────
+    // Explicit "0" (NOT remove_var) so the read at call time below is deterministically OFF. Fresh
+    // DB/ws so the OFF arm cannot see the ON arm's rows.
+    std::env::set_var(friday_hub::FRIDAY_SURFACE_EVENTS, "0");
+    let (rt_off, ws_off) = runtime_with("off");
+    seed_mission(rt_off.db());
+
+    let _intake_off = friday_hub::hub_server::mission_intake_result_for_db(
+        rt_off.db(),
+        "req-surface-off",
+        intake_request(),
+        900,
+    );
+    run_to_completion(&rt_off, &ws_off, "run-surface-off");
+
+    // (1) ZERO surface_event rows — the producer is fully skipped.
+    let events_off = rt_off
+        .db()
+        .list_surface_events_for_mission(MISSION)
+        .unwrap();
+    assert!(
+        events_off.is_empty(),
+        "flag-OFF writes NO surface_event rows, found {events_off:?}"
+    );
+
+    // (2) The projection timeline carries NO surface_event ref (byte-identical-minus-events).
+    let snapshot_off = project_workbench(rt_off.db(), Some(MISSION)).unwrap();
+    assert_eq!(
+        surface_event_refs_in_projection(&snapshot_off),
+        0,
+        "flag-OFF timeline has no surface_event ref: {snapshot_off}"
+    );
+
+    // (3) The run still completed with proof (the producer never gates the run).
+    assert_eq!(
+        rt_off
+            .db()
+            .get_work_item(WORK_ITEM)
+            .unwrap()
+            .unwrap()
+            .status,
+        WorkItemStatus::CompletedWithProof
+    );
+    assert!(friday_storage::audit::verify_audit_chain(rt_off.db().conn()).is_ok());
+
+    // Hygiene: leave the process env clean for any later test in this binary.
+    std::env::remove_var(friday_hub::FRIDAY_SURFACE_EVENTS);
+}
+
+/// Build the intake request wire targeting the SAME canonical mission/work-item/conversation ids the
+/// seed uses, so the live intake producer resolves them READY (idempotent upsert over the seed).
+fn intake_request() -> MissionIntakeRequestWire {
+    MissionIntakeRequestWire {
+        friday_conversation_id: FCONV.into(),
+        owner_principal: "owner-surface".into(),
+        surface_thread_id: SURFACE.into(),
+        surface_kind: "mobile".into(),
+        delivery_route: "mobile".into(),
+        visibility_policy: "compact".into(),
+        mission_id: MISSION.into(),
+        work_item_id: WORK_ITEM.into(),
+        title: "Surface events".into(),
+        intent: "bind the agent loop and emit timeline events".into(),
+        lane: "deepseek".into(),
+        target_provider_or_agent: Some("deepseek".into()),
+        capability_id: Some("mission.surface".into()),
+        body_ref: None,
+        includes_sensitive_context: false,
+    }
+}

--- a/rust-core/crates/friday-storage/src/lib.rs
+++ b/rust-core/crates/friday-storage/src/lib.rs
@@ -787,6 +787,15 @@ impl Db {
         mission::get_surface_thread(&self.conn, surface_thread_id)
     }
 
+    pub fn list_surface_threads_for_mission(&self, mission_id: &str) -> Result<Vec<SurfaceThread>> {
+        if self.profile != Profile::Hub {
+            return Err(StorageError::Unsupported(
+                "SurfaceThread records are Hub-only".into(),
+            ));
+        }
+        mission::list_surface_threads_for_mission(&self.conn, mission_id)
+    }
+
     pub fn upsert_surface_event(&self, event: &SurfaceEvent) -> Result<()> {
         if self.profile != Profile::Hub {
             return Err(StorageError::Unsupported(

--- a/rust-core/crates/friday-storage/src/mission.rs
+++ b/rust-core/crates/friday-storage/src/mission.rs
@@ -1237,6 +1237,79 @@ pub fn get_surface_thread(
     .transpose()
 }
 
+/// All [`SurfaceThread`]s bound to `mission_id` (the surface_thread row's OWN `mission_id`
+/// column — the canonical binding, NOT the conversation's `surface_thread_ids` list), oldest
+/// first, with `surface_thread_id` as the deterministic tie-break. Index-backed by
+/// `idx_surface_thread_mission`.
+///
+/// This is the read the surface_event PRODUCER uses at the run lifecycle points: the resolved
+/// mission context carries an OPTIONAL `surface_thread_id` (the `by_mission_work_item` lookup the
+/// live mission-bound run uses leaves it `None`), so the producer resolves the bound thread by
+/// mission here instead. A surface_event REQUIRES a thread bound to its mission with a matching
+/// `surface_kind` (see `validate_surface_event`), so the producer reads `source_surface` FROM the
+/// thread returned here — never a hardcoded kind.
+pub fn list_surface_threads_for_mission(
+    conn: &Connection,
+    mission_id: &str,
+) -> Result<Vec<SurfaceThread>> {
+    let mut stmt = conn.prepare(
+        "SELECT surface_thread_id, friday_conversation_id, mission_id, surface_kind,
+                channel_binding_id, delivery_route, visibility_policy, allowed_actions,
+                last_seen_at_ms, last_delivered_event_seq, created_at_ms, updated_at_ms
+         FROM surface_thread
+         WHERE mission_id = ?1
+         ORDER BY created_at_ms, surface_thread_id",
+    )?;
+    let rows = stmt.query_map([mission_id], |r| {
+        Ok((
+            r.get::<_, String>(0)?,
+            r.get::<_, String>(1)?,
+            r.get::<_, Option<String>>(2)?,
+            r.get::<_, String>(3)?,
+            r.get::<_, Option<String>>(4)?,
+            r.get::<_, String>(5)?,
+            r.get::<_, String>(6)?,
+            r.get::<_, String>(7)?,
+            r.get::<_, Option<i64>>(8)?,
+            r.get::<_, Option<i64>>(9)?,
+            r.get::<_, i64>(10)?,
+            r.get::<_, i64>(11)?,
+        ))
+    })?;
+    let mut out = Vec::new();
+    for row in rows {
+        let (
+            surface_thread_id,
+            friday_conversation_id,
+            mission_id,
+            surface_kind,
+            channel_binding_id,
+            delivery_route,
+            visibility_policy,
+            allowed_actions,
+            last_seen_at_ms,
+            last_delivered_event_seq,
+            created_at_ms,
+            updated_at_ms,
+        ) = row?;
+        out.push(SurfaceThread {
+            surface_thread_id,
+            friday_conversation_id,
+            mission_id,
+            surface_kind: parse_surface_kind(surface_kind)?,
+            channel_binding_id,
+            delivery_route,
+            visibility_policy: parse_visibility_policy(visibility_policy)?,
+            allowed_actions: decode_vec(allowed_actions, "surface_thread.allowed_actions")?,
+            last_seen_at_ms,
+            last_delivered_event_seq: last_delivered_event_seq.map(|v| v as u64),
+            created_at_ms,
+            updated_at_ms,
+        });
+    }
+    Ok(out)
+}
+
 pub fn upsert_surface_event(conn: &Connection, event: &SurfaceEvent) -> Result<()> {
     validate_surface_event(conn, event)?;
     conn.execute(


### PR DESCRIPTION
## What & why

Registry path #6. The `surface_event` storage table, the `friday_core::SurfaceEvent` struct, `upsert_surface_event`, AND the Mission Workbench timeline READER (`workbench_projection::project_workbench` → `append_surface_events`, which reads `Db::list_surface_events_for_mission`) all **already existed** — but **nothing emitted `surface_event` rows on the live path**, so the workbench timeline was empty of surface events. This adds the missing **PRODUCER**, flag-gated and dark.

No-degrade · best-effort · refs-only. Reuses the existing persist (no reimplementation). Does **not** touch the reader.

## Flag

`FRIDAY_SURFACE_EVENTS` — env var, **default-OFF**, exact trimmed `"1"` matcher (`true`/`0`/empty/unset ⇒ OFF). Read once at each producer entry, threaded as a pure bool to the flagged inner fn (the codebase's "split env-read from pure logic" idiom, mirroring `FRIDAY_MISSION_INTAKE_CLARIFY`).

## Lifecycle points & SurfaceEventKinds (existing kinds only — none invented)

| Point | Call site | Kind | Why |
|---|---|---|---|
| Mission intake birth | `hub_server.rs` `mission_intake_result_for_db_flagged`, READY path only (not `needs_clarification`/`blocked`), after preflight + route decision | `SystemStatus` | a Mission born from a surface input is a system lifecycle fact, not a user/Friday/provider chat message |
| Run start | `runtime.rs` `run_agent_loop_for_mission_with_overrides_flagged`, after the envelope is Ready, before the loop | `ProviderTrace` | Friday dispatched the bound WorkItem to its provider/agent — reader renders `provider_ack` (in-flight, NOT completion) |
| Run finish/proof | same fn, after a successful `Attached { CompletedWithProof }` on a Finished loop | `ProofReceipt` | the run is the proof — reader renders `completed_with_proof` |

## Linkage & ordering

- The run path resolves the bound `SurfaceThread` by the thread row's **own `mission_id`** (new index-backed `list_surface_threads_for_mission`), because the live `by_mission_work_item` lookup leaves the resolved context's `surface_thread_id` `None`. `source_surface` is read **from the resolved thread** so `validate_surface_event` passes. Intake builds its thread inline and links directly.
- Refs respect the storage validators: proof events use `proof://agent-run/{run_id}` (`require_safe_surface_proof_ref`); run-start body uses `friday://surface-event-body/...` (`require_safe_surface_body_ref`).
- Run-proof is stamped `now_ms + 1` so it sorts strictly after run-start in the reader's `ORDER BY created_at_ms, surface_event_id` (equal stamps would put `run-proof` before `run-start` on the id tiebreak).

## No-degrade

- **Flag-OFF byte-identical**: no emit, no rows (the whole block is skipped; `emit_surface_event` also self-guards on `enabled`).
- The emit **never** changes run outcome, billing, proof, or intake result, and **never blocks**.
- **Best-effort / non-fatal**: a `surface_event` write failure is logged + swallowed (mirrors the memory-extraction producer's swallow). The run/proof path is load-bearing; the timeline is observability.

## Tests

- `tests/surface_events_timeline.rs` — real `HubRuntime`, in-process. Flag ON: intake-birth + run-start + run-proof rows exist (`list_surface_events_for_mission`), `project_workbench` timeline **includes** them in birth→start→proof order. Flag OFF: same run writes **zero** rows, projection timeline has no surface-event ref. `verify_audit_chain` clean both arms. (Merged into one sequential test to avoid the shared-process env race between two `#[test]` fns in one binary.)
- In-crate `runtime` test: bool-injected byte-identical-OFF vs ON run rows + ordering (the flagged fn is `pub(crate)`).
- In-crate pure-matcher unit test for `surface_events_from`.

## CI hygiene

Rust-only (no TS/route/manifest/`.secrets.baseline` change). `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test -p friday-hub -p friday-storage -p friday-core` all green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)