### PR TITLE
ci(governance): prod-flag loop-test gate — every prod-ON flag maps to a loop e2e test (registry #27)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -281,11 +281,35 @@ jobs:
       - name: Assert TS-runtime method-guard coverage + no manifest shrinkage
         run: node scripts/quality/assert-ts-runtime-method-guards.mjs
 
+  # ── MECHANISM-8: Prod-Flag Loop-Test Gate (registry gap #27) ──
+  # Enforces "every prod-ON (and dark) loop flag names an existing loop-closing
+  # e2e test" against docs/ops/prod-flags-manifest.json. This is the single
+  # recurrence-prevention gate behind the L0 silently-inert-loop disaster: a flag
+  # may never go prod-ON with no committed loop test. Pure Node + fs (no compiler,
+  # no test execution) — fast + deterministic. It validates the mapping EXISTS and
+  # resolves; the tests themselves are RUN by rust-core.yml + the `test` job.
+  prod-flag-tests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+
+      - name: Setup Node
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Verify every prod-ON flag maps to a loop e2e test
+        run: node scripts/ci/verify-prod-flag-tests.mjs
+
   # ── Terminal CI Aggregator — single required check for branch protection ──
   quality-gate:
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    needs: [build, test, migrations, security, contracts, ssd-lint, alignment-guard, agent-parity, secrets, ts-runtime-retirement]
+    needs: [build, test, migrations, security, contracts, ssd-lint, alignment-guard, agent-parity, secrets, ts-runtime-retirement, prod-flag-tests]
     if: ${{ always() }}
 
     steps:
@@ -301,6 +325,7 @@ jobs:
           echo "Agent Parity:       ${{ needs.agent-parity.result }}"
           echo "Secrets:            ${{ needs.secrets.result }}"
           echo "TS Runtime Retire:  ${{ needs.ts-runtime-retirement.result }}"
+          echo "Prod-Flag Tests:    ${{ needs.prod-flag-tests.result }}"
           echo ""
 
           FAILED=0
@@ -315,6 +340,7 @@ jobs:
             "${{ needs.agent-parity.result }}" \
             "${{ needs.secrets.result }}" \
             "${{ needs.ts-runtime-retirement.result }}" \
+            "${{ needs.prod-flag-tests.result }}" \
           ; do
             if [ "$result" != "success" ]; then
               FAILED=1

--- a/docs/ops/prod-flag-test-gate.md
+++ b/docs/ops/prod-flag-test-gate.md
@@ -1,0 +1,94 @@
+# Prod-Flag Loop-Test Gate (registry gap #27)
+
+**The founding promise:** *every prod-ON loop flag has a passing loop e2e test.*
+
+This is the single recurrence-prevention gate behind the **L0 silently-inert-loop
+disaster** — three loops shipped with their flags ON in prod while **no committed
+test drove the loop to its outcome**. A loop can be hand-proven live once and still
+silently rot, because nothing in CI re-asserts that the flag-ON path closes its loop.
+The gate makes the **flag ↔ test mapping a committed, CI-enforced artifact** so a flag
+can never go prod-ON with no loop test again.
+
+## The two artifacts
+
+| Artifact | Role |
+| --- | --- |
+| [`docs/ops/prod-flags-manifest.json`](./prod-flags-manifest.json) | Canonical source-of-truth: every loop flag, its `process`, `prod_state`, `closes_loop`, `coverage`, and the exact `e2e_test` (`<file/path>::<test_fn_name>`) that drives the WHOLE loop with the flag ON. The prod launch files (rust-ws-wrapper script + TS plist) are **not committed**, so this manifest IS the authoritative record. |
+| [`scripts/ci/verify-prod-flag-tests.mjs`](../../scripts/ci/verify-prod-flag-tests.mjs) | The gate. Parses the manifest and, for every flag with `prod_state ∈ {on, dark}`, asserts the named test **file exists** and **declares the named test function** (Rust `fn <name>` or vitest `it/test("<name>")`). Fails (exit 1), **naming the offending flag**, on any missing/unmapped/unresolvable test. |
+
+## CI wiring
+
+Wired into `.github/workflows/ci.yml` as a dedicated job **`prod-flag-tests`** (MECHANISM-8),
+added to the `quality-gate` aggregator's `needs` + result loop (the single required check
+for branch protection). It runs on **every PR and push to main**. Pure Node + `fs` — no
+compiler, no test execution — so it is **fast and deterministic**.
+
+```bash
+node scripts/ci/verify-prod-flag-tests.mjs   # exit 0 = mapping complete; exit 1 = a flag has no resolvable loop test
+```
+
+## What the gate does and does NOT do
+
+- **Does:** prove the mapping is COMPLETE and RESOLVES — no prod-ON/dark flag is left
+  without a named, on-disk loop-closing test.
+- **Does NOT run the tests.** All 13 mapped tests today are **Rust `friday-hub` tests**,
+  executed by `cargo test --workspace` in `.github/workflows/rust-core.yml`. None are
+  `#[ignore]`'d, so they run with no key/network. This gate enforces that the mapping
+  *exists and resolves*; `rust-core.yml` enforces that the tests *pass*.
+  - **Caveat (PR coverage gap):** `rust-core.yml` is `pull_request`-triggered but
+    **path-filtered to `rust-core/**`** — so the loop tests run on PRs that touch
+    `rust-core/`, NOT on every PR. The mapped tests can only *break* when `rust-core/`
+    changes (and then `rust-core.yml` runs them), so this is sound, but a PR that does
+    not touch `rust-core/` gets the existence check only, not a fresh test run. THIS gate
+    (`prod-flag-tests` in `ci.yml`) DOES run on every PR — it just checks the mapping.
+  - If a future mapping points at a **vitest** test, it would be run by the `test` job in
+    `ci.yml` (no mapped test does today).
+- **Does NOT verify the live wrapper/plist.** Whether the running prod process actually
+  carries exactly the manifest's `prod_state=on` set is **deploy-time drift**, out of
+  CI scope (see follow-up below).
+
+## Coverage honesty (`coverage` field)
+
+The gate does not weaken itself to pass. Each flag declares a `coverage`:
+
+- **`loop-e2e`** — a committed, PR-CI-run test drives the WHOLE loop with the flag's
+  behavior ON and asserts the loop OUTCOME. This is the standard the founding promise
+  requires.
+- **`destination-only`** — the *destination* loop this flag routes into has a real
+  loop-e2e test (mapped here, real, runs every PR), but the flag's OWN routing/on-ramp
+  decision is **not** closed end-to-end in PR CI. This is a **recorded real gap**, not a
+  fabricated mapping. The four TS `*_ROUTES_VIA_RUST` / `FRIDAY_ROUTE_AGENT_RUN_VIA_RUST`
+  / `FRIDAY_MISSION_AUTO_DISPATCH` flags are `destination-only`: their loops close
+  Rust-side (proven) but the TS→Rust routing is only covered by **mocked unit tests**
+  (`*-dispatch-adapter.test.ts`) plus **`#[ignore]`'d live-key-gated** routed parity
+  harnesses that never run in PR CI.
+
+## Deploy contract (DEPLOYMENT-CRITICAL)
+
+The manifest's `prod_state` is the contract a deploy MUST honor: **set exactly the flags
+marked `prod_state=on`** on the named `process` (no more, no less). These flags are
+**deployment-critical** — the rust-ws-wrapper and the TS plist must persist them across
+restarts. A flag silently dropped on restart re-creates the inert-loop disaster
+(see the `friday-read-seam-enrollment-gap` / wrapper-flag-durability concern).
+
+## Follow-ups (out of this gate's CI scope)
+
+1. **Deploy-time drift check.** Compare the running prod process's env (rust-ws-wrapper +
+   TS plist) against the manifest's `prod_state=on` set; alarm on drift. This needs the
+   live host and is therefore a deploy/ops check, not a PR-CI check.
+2. **Close the `destination-only` gaps.** Add PR-CI tests that drive flag-ON TS routing →
+   real Rust → loop-closed (today's coverage is mocked-unit + live-gated). When such a
+   test lands, flip the flag's `coverage` to `loop-e2e`.
+3. **WorkItem-status dispatch arm.** `FRIDAY_MISSION_SPINE_DISPATCH` covers both the
+   Mission-lifecycle and WorkItem-status dispatch arms; the manifest maps it to the
+   Mission-lifecycle loop test. Add an equal-strength WorkItem-status dispatch test.
+4. **`deployment_critical.flags` ↔ `prod_state=on` cross-check.** The gate does not yet
+   assert the `deployment_critical.flags` list equals the set of `prod_state=on` entries;
+   a future editor could desync them. A one-line addition to the gate would harden this.
+5. **Optional: make `destination-only` a hard failure.** Today `destination-only` flags
+   PASS the gate (their destination loop is real + tested; the gap is recorded in the
+   `coverage` field + this doc, not in red CI). If reg #27 should enforce *direct*
+   loop coverage and block PRs until the on-ramp gaps close, flip `destination-only` out
+   of `KNOWN_COVERAGE`-as-pass in the gate — a one-line change. This is an **operator
+   decision**: making CI red on day one for a documented, real-test-backed gap would
+   block every PR.

--- a/docs/ops/prod-flags-manifest.json
+++ b/docs/ops/prod-flags-manifest.json
@@ -1,0 +1,144 @@
+{
+  "$schema_note": "Canonical source-of-truth for Friday loop feature-flags and their loop-closing e2e tests. The prod launch files (the rust-ws-wrapper script + the TS plist) are NOT committed to this repo, so THIS file is the authoritative, CI-enforced record of which flags exist, their intended prod state, and the committed test that drives the WHOLE loop with the flag ON. Registry gap #27 — 'every prod-ON flag has a passing loop e2e test' — is enforced against this file by scripts/ci/verify-prod-flag-tests.mjs.",
+  "why_this_exists": "Recurrence prevention for the L0 silently-inert-loop disaster: three loops shipped with their flags ON in prod while NO committed test drove the loop to its outcome. A hand-proof done once is not a committed, CI-run test. The MAPPING gate (scripts/ci/verify-prod-flag-tests.mjs) runs on EVERY PR and asserts the flag<->test mapping exists + resolves. It does NOT verify the live wrapper/plist actually sets these flags — that drift check is deploy-time (see deployment_critical + the docs note).",
+  "test_execution_note": "All mapped e2e_test entries are Rust friday-hub tests, RUN by `cargo test --workspace` in .github/workflows/rust-core.yml (none are #[ignore]'d; no key/network needed). Caveat: rust-core.yml is pull_request-triggered but PATH-FILTERED to rust-core/** — so the loop tests run on PRs that touch rust-core/, not on every PR. The mapped tests can only break when rust-core/ changes (and then rust-core.yml runs them), so coverage is sound; but a PR that does not touch rust-core/ gets only the existence check. A future vitest mapping would instead be run by the ci.yml `test` job.",
+  "deployment_critical": {
+    "note": "These flags are DEPLOYMENT-CRITICAL: their prod_state below is the contract a deploy MUST honor. A deploy must set EXACTLY the flags marked prod_state=on (no more, no less) on the named process. Wrapper-flag-durability concern: the rust-ws-wrapper and the TS plist must persist these env vars across restarts; a flag silently dropped on restart re-creates the inert-loop disaster. Drift-vs-live-wrapper (does the running process actually carry the manifest's prod_state=on set?) is a DEPLOY-TIME check, OUT OF CI SCOPE — tracked as a follow-up in docs/ops/prod-flag-test-gate.md.",
+    "flags": [
+      "FRIDAY_MISSION_INTAKE",
+      "FRIDAY_MISSION_SPINE_DISPATCH",
+      "FRIDAY_MISSION_BOUND_RUN",
+      "FRIDAY_RUN_LOOP_MEMORY_EXTRACTION",
+      "FRIDAY_MEMORY_CONFIRM",
+      "FRIDAY_CLARIFICATION_GATE",
+      "FRIDAY_MEMORY_SPINE_ROUTES_VIA_RUST",
+      "FRIDAY_MISSION_SPINE_ROUTES_VIA_RUST",
+      "FRIDAY_ROUTE_AGENT_RUN_VIA_RUST",
+      "FRIDAY_MISSION_AUTO_DISPATCH"
+    ]
+  },
+  "coverage_legend": {
+    "loop-e2e": "A committed, PR-CI-run test drives the WHOLE loop with the flag's behavior ON and asserts the LOOP OUTCOME (e.g. mission born, work-item CompletedWithProof, memory becomes recallable, surface events emitted+read, clarification questions returned with zero model calls). This is the standard the gate's founding promise requires.",
+    "destination-only": "The DESTINATION loop this flag routes into has a real loop-e2e test (mapped here), but the flag's OWN on-ramp/routing decision is NOT exercised by any PR-CI test that closes the loop end-to-end. The mapped test is real and runs every PR, but it does not read this flag. This is a REAL coverage gap, recorded honestly — not a fabricated mapping."
+  },
+  "test_kind_note": "Rust producer tests use the program-standard split-env idiom: the env read (== \"1\") lives in a thin public wrapper, and the loop logic is a private *_flagged(bool) inner the test drives with the bool set ON directly (avoids cross-test env races; see the test file doc comments). Mapping to those tests is legitimate — the injected bool IS the flag's semantics. The ONLY thing those tests do not exercise is the thin env-string read in the binary (hub_agent_run_server.rs / bootstrap), which is the trivial trim()==\"1\" parse.",
+  "flags": [
+    {
+      "flag": "FRIDAY_MISSION_INTAKE",
+      "process": "rust-ws-wrapper",
+      "prod_state": "on",
+      "closes_loop": "An inbound MissionIntakeRequest births a Mission + WorkItem (no model call).",
+      "coverage": "loop-e2e",
+      "e2e_test": "rust-core/crates/friday-hub/tests/mission_intake_clarification.rs::arm_b_flag_on_detailed_classified_intent_births_a_mission_as_today",
+      "notes": "Drives mission_intake_result_for_db_flagged(.., clarify=true, ..) on a detailed intent and asserts a Mission(Active) + WorkItem row are written (the birth). arm_c (flag-off byte-identical) and arm_d (unclassified births) are sibling proofs in the same file."
+    },
+    {
+      "flag": "FRIDAY_MISSION_SPINE_DISPATCH",
+      "process": "rust-ws-wrapper",
+      "prod_state": "on",
+      "closes_loop": "Mission/WorkItem lifecycle requests transition the Hub state machine (no model call).",
+      "coverage": "loop-e2e",
+      "e2e_test": "rust-core/crates/friday-hub/src/hub_server.rs::mission_lifecycle_request_updates_mission_without_provider_call",
+      "notes": "Drives HubServer::dispatch with a MissionLifecycleRequest through the SAME mission_lifecycle_result producer the flag-ON binary arm invokes; asserts active->archived transition, zero provider/model calls, zero token_ledger rows, then reads it back via MissionTimelineRequest. JUDGMENT: the WorkItem-status arm (work_item_status_result_for_db) shares this flag but has no by-name dispatch test of equal strength — sub-coverage gap noted in the report (the mission-lifecycle arm is the loop closure for the flag)."
+    },
+    {
+      "flag": "FRIDAY_MISSION_BOUND_RUN",
+      "process": "rust-ws-wrapper",
+      "prod_state": "on",
+      "closes_loop": "A run whose session resolves to a live Mission is dispatched bound; on executed approval the bound WorkItem advances ProviderRouted -> CompletedWithProof.",
+      "coverage": "loop-e2e",
+      "e2e_test": "rust-core/crates/friday-hub/tests/resume_mission_workitem_completion.rs::executed_resume_advances_bound_work_item_to_completed_with_proof",
+      "notes": "Seeds a mission, binds the run ProviderRouted, pauses, then resume_agent_loop_for_mission executes the operator-signed mutation and asserts WorkItem -> CompletedWithProof with the run as proof receipt. False-proof guards (replay/expired/exec-failed) are sibling proofs."
+    },
+    {
+      "flag": "FRIDAY_RUN_LOOP_MEMORY_EXTRACTION",
+      "process": "rust-ws-wrapper",
+      "prod_state": "on",
+      "closes_loop": "After a finished agent run, extract a memory candidate from the turn (writes memory_item as a pending Candidate; never mutates the run).",
+      "coverage": "loop-e2e",
+      "e2e_test": "rust-core/crates/friday-hub/src/runtime.rs::post_run_extraction_flag_on_finished_fires_and_never_changes_the_run",
+      "notes": "Drives maybe_extract_memory_post_run_flagged(.., enabled=true) on a Finished outcome and asserts a candidate is extracted while the run result is unchanged. Sibling proofs cover flag-off byte-identical, non-finished-no-fire, and isolated-failure."
+    },
+    {
+      "flag": "FRIDAY_MEMORY_CONFIRM",
+      "process": "rust-ws-wrapper",
+      "prod_state": "on",
+      "closes_loop": "An owner-authed MemoryDecisionRequest confirms a memory candidate, making it recallable by a later session (no model call).",
+      "coverage": "loop-e2e",
+      "e2e_test": "rust-core/crates/friday-hub/src/runtime.rs::memory_loop_end_to_end_extract_confirm_recall_closes_on_agent_run_ingress",
+      "notes": "FULL memory loop: extract -> confirm (via the LIVE memory_decision_result_for_db handler, owner-scoped) -> assert recallable -> a LATER session recalls the content across the run boundary. The confirm leg is the FRIDAY_MEMORY_CONFIRM closure. A narrower dispatch-level proof is hub_server.rs::memory_decision_confirm_makes_candidate_recallable."
+    },
+    {
+      "flag": "FRIDAY_CLARIFICATION_GATE",
+      "process": "rust-ws-wrapper",
+      "prod_state": "on",
+      "closes_loop": "An under-specified planning task is answered with specific clarification questions instead of guessing (zero model calls); a plain-answer resume then runs the loop and the gate does not re-fire.",
+      "coverage": "loop-e2e",
+      "e2e_test": "rust-core/crates/friday-hub/tests/clarification_gate.rs::vague_planning_task_delivers_specific_questions_with_no_model_call",
+      "notes": "Sets FRIDAY_CLARIFICATION_GATE=1 on the LIVE runtime path and asserts specific questions are delivered with no model call. Sibling: resume_with_plain_answer_runs_the_loop_and_finishes_gate_does_not_refire."
+    },
+    {
+      "flag": "FRIDAY_MEMORY_SPINE_ROUTES_VIA_RUST",
+      "process": "ts-plist",
+      "prod_state": "on",
+      "closes_loop": "The TS memory-spine routes (confirm/decision) forward to the Rust hub instead of the legacy TS path; the loop closes Rust-side.",
+      "coverage": "destination-only",
+      "e2e_test": "rust-core/crates/friday-hub/src/runtime.rs::memory_loop_end_to_end_extract_confirm_recall_closes_on_agent_run_ingress",
+      "notes": "CRITICAL FINDING: this routing flag's destination loop (memory confirm->recall) is proven Rust-side by the mapped test, but NO PR-CI test drives flag-ON TS-routing -> real Rust -> loop-closed. The TS dispatch adapter (friday-memory-spine-dispatch-adapter.test.ts) uses a MOCKED sealed client, and the bootstrap env test only parses config. The flag's own on-ramp is mock-only in PR CI."
+    },
+    {
+      "flag": "FRIDAY_MISSION_SPINE_ROUTES_VIA_RUST",
+      "process": "ts-plist",
+      "prod_state": "on",
+      "closes_loop": "The TS mission-spine routes (intake/lifecycle/workitem) forward to the Rust hub; the loop closes Rust-side.",
+      "coverage": "destination-only",
+      "e2e_test": "rust-core/crates/friday-hub/src/hub_server.rs::mission_lifecycle_request_updates_mission_without_provider_call",
+      "notes": "CRITICAL FINDING: destination loop (mission lifecycle dispatch) is proven Rust-side by the mapped test, but NO PR-CI test drives flag-ON TS-routing -> real Rust -> loop-closed. friday-mission-spine-dispatch-adapter.test.ts mocks the sealed client. The flag's own on-ramp is mock-only in PR CI."
+    },
+    {
+      "flag": "FRIDAY_ROUTE_AGENT_RUN_VIA_RUST",
+      "process": "ts-plist",
+      "prod_state": "on",
+      "closes_loop": "The TS agent-run start forwards the run to the Rust hub agent-run seam; the Rust run loop delivers the answer.",
+      "coverage": "destination-only",
+      "e2e_test": "rust-core/crates/friday-hub/src/runtime.rs::memory_loop_end_to_end_extract_confirm_recall_closes_on_agent_run_ingress",
+      "notes": "CRITICAL FINDING: the destination agent-run loop (run_session_task -> Delivered answer with status 'finished') is proven Rust-side by the mapped test, but NO PR-CI test drives flag-ON TS-routing -> real Rust -> delivered answer. The routed parity harnesses (routed_claude_parity.rs / routed_codex_parity.rs) ARE end-to-end but are #[ignore]'d + live-key-gated, so they never run in PR CI. The flag's own on-ramp is mock-only/live-gated in PR CI."
+    },
+    {
+      "flag": "FRIDAY_MISSION_AUTO_DISPATCH",
+      "process": "ts-plist",
+      "prod_state": "on",
+      "closes_loop": "A Ready mission intake automatically produces a bound read-only run (organic mission->run binding), no re-spend on blocked/duplicate intakes.",
+      "coverage": "destination-only",
+      "e2e_test": "rust-core/crates/friday-hub/tests/mission_intake_clarification.rs::arm_b_flag_on_detailed_classified_intent_births_a_mission_as_today",
+      "notes": "CRITICAL FINDING: the TS auto-dispatch DRIVER (friday-mission-auto-dispatch-driver.test.ts) is well-tested at the unit level (dispatch-exactly-once / no-dispatch-on-blocked / bind-to-result-ids), but with a MOCKED startRun thunk — no PR-CI test drives intake-ready -> real Rust bound run end-to-end. The mapped Rust test proves the upstream condition (a Ready intake that qualifies for auto-dispatch, asserted by auto_dispatch_allows_new_work); the bound-run production itself closes via FRIDAY_MISSION_BOUND_RUN's loop-e2e test. The auto-dispatch on-ramp is mock-only in PR CI."
+    },
+    {
+      "flag": "FRIDAY_MISSION_INTAKE_CLARIFY",
+      "process": "rust-ws-wrapper",
+      "prod_state": "dark",
+      "closes_loop": "A vague mission intent is CLARIFIED (specific questions returned, ZERO mission/workitem rows written) instead of silently birthing a Mission.",
+      "coverage": "loop-e2e",
+      "e2e_test": "rust-core/crates/friday-hub/tests/mission_intake_clarification.rs::arm_a_flag_on_vague_intent_clarifies_and_writes_zero_rows",
+      "notes": "Built-but-dark. Drives mission_intake_result_for_db_flagged(.., clarify=true, ..) on a vague intent and asserts clarification questions + zero rows. arm_c is the flag-off byte-identical birth proof."
+    },
+    {
+      "flag": "FRIDAY_SURFACE_EVENTS",
+      "process": "rust-ws-wrapper",
+      "prod_state": "dark",
+      "closes_loop": "Mission-bound run lifecycle emits surface_event timeline rows that the read projection includes; flag-off is byte-identical (no events).",
+      "coverage": "loop-e2e",
+      "e2e_test": "rust-core/crates/friday-hub/tests/surface_events_timeline.rs::flag_on_emits_lifecycle_events_and_reader_includes_them_then_off_is_clean",
+      "notes": "Built-but-dark. One sequential test sets FRIDAY_SURFACE_EVENTS=1, runs the loop, asserts lifecycle surface_events are emitted AND appear in the read projection, then flips to 0 and asserts a clean (event-free) run (no env race; both arms in one #[test])."
+    },
+    {
+      "flag": "FRIDAY_PASSPORT_MINT",
+      "process": "rust-ws-wrapper",
+      "prod_state": "dark",
+      "closes_loop": "A mission-bound run mints + persists a ContextPassport (carrying confirmed-memory items as handoff context) before running; a sensitive item fails the whole handoff closed.",
+      "coverage": "loop-e2e",
+      "e2e_test": "rust-core/crates/friday-hub/src/runtime.rs::passport_mint_on_benign_mints_persists_links_then_runs",
+      "notes": "Built-but-dark. Drives run_agent_loop_for_mission_with_overrides_flagged(.., passport_mint=true, ..) and asserts a ContextPassport row + links are persisted then the run proceeds. Sibling proofs cover sensitive-item-fails-closed, mixed-set-blocks-whole-handoff, and flag-off byte-identical."
+    }
+  ]
+}

--- a/scripts/ci/verify-prod-flag-tests.mjs
+++ b/scripts/ci/verify-prod-flag-tests.mjs
@@ -1,0 +1,189 @@
+#!/usr/bin/env node
+/**
+ * Registry gap #27 — the CI methodology gate:
+ *   "Every prod-ON loop flag has a passing loop e2e test."
+ *
+ * This is the single recurrence-prevention gate behind the L0 silently-inert-loop
+ * disaster (loops shipped with their flags ON in prod while NO committed test drove
+ * the loop to its outcome). The flag<->test mapping is a committed artifact in
+ * docs/ops/prod-flags-manifest.json; THIS script makes that mapping CI-enforced.
+ *
+ * What it checks (deterministic, fast, no compiler / no test execution):
+ *   1. The manifest is well-formed JSON with the required shape.
+ *   2. Every flag with prod_state in (on, dark) names an e2e_test of the form
+ *      "<relative/file/path>::<test_fn_name>".
+ *   3. The named test file EXISTS and contains the named test function
+ *      (Rust:  `fn <name>`  ·  vitest/TS:  `it("<name>"...)` or `test("<name>"...)`).
+ *   4. No duplicate flag entries; coverage is a known value.
+ *
+ * It FAILS (exit 1), naming the offending flag, on any missing/unmapped/unresolvable
+ * test. It does NOT verify the live wrapper/plist actually sets these flags — that
+ * drift check is deploy-time (see docs/ops/prod-flag-test-gate.md). It does NOT run
+ * the tests; "passing" is enforced by the existing test jobs (rust-core.yml + the
+ * `test` job) — this gate enforces that the mapping EXISTS and resolves so a flag can
+ * never go prod-ON with no committed loop test.
+ *
+ * Honesty note: a `destination-only` coverage value is a RECORDED gap, not a pass-by-
+ * weakening — the named test still must exist + resolve. The gate's job is to surface
+ * the mapping, not to launder it.
+ */
+
+import { readFile, access } from "node:fs/promises";
+import { constants } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const MANIFEST_PATH = join(REPO_ROOT, "docs", "ops", "prod-flags-manifest.json");
+
+const ENFORCED_STATES = new Set(["on", "dark"]);
+const KNOWN_STATES = new Set(["on", "dark"]);
+const KNOWN_PROCESSES = new Set(["rust-ws-wrapper", "ts-plist"]);
+const KNOWN_COVERAGE = new Set(["loop-e2e", "destination-only"]);
+
+let errors = 0;
+
+function fail(msg) {
+  console.error(`❌ ${msg}`);
+  errors++;
+}
+
+function ok(msg) {
+  console.log(`✅ ${msg}`);
+}
+
+// ── 1. Load + parse the manifest ──
+let manifest;
+try {
+  manifest = JSON.parse(await readFile(MANIFEST_PATH, "utf-8"));
+} catch (err) {
+  console.error(`❌ Could not read/parse ${MANIFEST_PATH}: ${err.message}`);
+  process.exit(1);
+}
+
+if (!Array.isArray(manifest.flags) || manifest.flags.length === 0) {
+  fail("manifest.flags must be a non-empty array");
+  process.exit(1);
+}
+
+// ── 2. Validate each flag entry + resolve its e2e_test ──
+const seenFlags = new Set();
+let enforcedCount = 0;
+let loopE2eCount = 0;
+let destinationOnlyCount = 0;
+
+// Parse "<path>::<fn>" once. Returns { file, fn } or null on a malformed ref.
+function parseTestRef(ref) {
+  if (typeof ref !== "string") return null;
+  const idx = ref.lastIndexOf("::");
+  if (idx <= 0 || idx + 2 >= ref.length) return null;
+  return { file: ref.slice(0, idx).trim(), fn: ref.slice(idx + 2).trim() };
+}
+
+// Does `content` contain a test named `fn`? Handles Rust fn decls + vitest it()/test().
+function fileDeclaresTest(content, fn) {
+  // Rust: `fn <name>(`  (covers #[test]/#[tokio::test] integration + inline mod tests)
+  const rustRe = new RegExp(String.raw`\bfn\s+${escapeRe(fn)}\s*\(`);
+  if (rustRe.test(content)) return true;
+  // vitest/jest: it("name"...) | test("name"...) | it('name'...) | it(`name`...)
+  const tsRe = new RegExp(
+    String.raw`\b(?:it|test)\s*\(\s*(['"\`])${escapeRe(fn)}\1`
+  );
+  return tsRe.test(content);
+}
+
+function escapeRe(s) {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+for (let i = 0; i < manifest.flags.length; i++) {
+  const entry = manifest.flags[i];
+  const label = entry && entry.flag ? entry.flag : `flags[${i}]`;
+
+  if (!entry || typeof entry.flag !== "string" || entry.flag.length === 0) {
+    fail(`flags[${i}]: missing/invalid "flag" name`);
+    continue;
+  }
+  if (seenFlags.has(entry.flag)) {
+    fail(`${label}: duplicate flag entry`);
+    continue;
+  }
+  seenFlags.add(entry.flag);
+
+  if (!KNOWN_PROCESSES.has(entry.process)) {
+    fail(`${label}: "process" must be one of ${[...KNOWN_PROCESSES].join(" | ")} (got ${JSON.stringify(entry.process)})`);
+  }
+  if (!KNOWN_STATES.has(entry.prod_state)) {
+    fail(`${label}: "prod_state" must be one of ${[...KNOWN_STATES].join(" | ")} (got ${JSON.stringify(entry.prod_state)})`);
+    continue;
+  }
+  if (!KNOWN_COVERAGE.has(entry.coverage)) {
+    fail(`${label}: "coverage" must be one of ${[...KNOWN_COVERAGE].join(" | ")} (got ${JSON.stringify(entry.coverage)})`);
+  }
+  if (typeof entry.closes_loop !== "string" || entry.closes_loop.trim().length === 0) {
+    fail(`${label}: "closes_loop" must be a non-empty one-line description`);
+  }
+
+  // Only flags that are or will be live (on|dark) MUST carry a resolvable loop test.
+  if (!ENFORCED_STATES.has(entry.prod_state)) continue;
+  enforcedCount++;
+  if (entry.coverage === "loop-e2e") loopE2eCount++;
+  if (entry.coverage === "destination-only") destinationOnlyCount++;
+
+  const ref = parseTestRef(entry.e2e_test);
+  if (!ref) {
+    fail(
+      `${label} (prod_state=${entry.prod_state}): "e2e_test" is missing or not of the form ` +
+        `"<file/path>::<test_fn_name>" (got ${JSON.stringify(entry.e2e_test)}). ` +
+        `A prod-${entry.prod_state} flag MUST name a loop-closing test — this is the registry-#27 gap.`
+    );
+    continue;
+  }
+
+  const absFile = join(REPO_ROOT, ref.file);
+  try {
+    await access(absFile, constants.R_OK);
+  } catch {
+    fail(
+      `${label} (prod_state=${entry.prod_state}): mapped test FILE does not exist: ${ref.file} ` +
+        `(referenced by e2e_test ${JSON.stringify(entry.e2e_test)})`
+    );
+    continue;
+  }
+
+  const content = await readFile(absFile, "utf-8");
+  if (!fileDeclaresTest(content, ref.fn)) {
+    fail(
+      `${label} (prod_state=${entry.prod_state}): mapped test FUNCTION "${ref.fn}" not found in ${ref.file}. ` +
+        `Expected a Rust \`fn ${ref.fn}(\` or a vitest it/test("${ref.fn}"). ` +
+        `If the test was renamed/removed, update the manifest — a prod-${entry.prod_state} flag may not be left without a loop test.`
+    );
+    continue;
+  }
+
+  ok(`${label} (${entry.prod_state}, ${entry.coverage}) -> ${ref.file}::${ref.fn}`);
+}
+
+// ── 3. Summary + exit ──
+console.log("");
+console.log(
+  `Summary: ${enforcedCount} enforced flag(s) [on|dark] | ` +
+    `${loopE2eCount} loop-e2e | ${destinationOnlyCount} destination-only.`
+);
+if (destinationOnlyCount > 0) {
+  console.log(
+    `Note: ${destinationOnlyCount} flag(s) are coverage="destination-only" — the destination loop is ` +
+      `tested but the flag's own routing/on-ramp is NOT closed end-to-end in PR CI (recorded, not a fail).`
+  );
+}
+
+if (errors > 0) {
+  console.error(`\n💥 ${errors} prod-flag-test mapping error(s) found`);
+  console.error(
+    `Registry gap #27: every prod-ON (and dark) loop flag must name an existing loop-closing test in ` +
+      `docs/ops/prod-flags-manifest.json. Fix the mapping or add the missing test — do NOT delete the flag entry.`
+  );
+  process.exit(1);
+}
+
+console.log("\n🎉 prod-flag-test gate: every enforced flag maps to an existing loop test");


### PR DESCRIPTION
## What

Closes **registry gap #27 — the CI methodology gate: _"every prod-ON loop flag has a passing loop e2e test."_** This is the single recurrence-prevention gate behind the **L0 silently-inert-loop disaster** (three loops shipped with flags ON in prod while *no committed test drove the loop to its outcome*). It was DECLARED but UNBUILT.

Purely **additive governance/CI** — no product code, no existing test, no existing flag changed.

## The three artifacts

| File | Role |
| --- | --- |
| `docs/ops/prod-flags-manifest.json` | Committed source-of-truth (the prod launch files — rust-ws-wrapper + TS plist — are not in-repo). **13 loop flags**: 10 `prod_state=on` + 3 `dark`, each with `process`, `closes_loop`, `coverage`, and the exact `<file>::<test_fn>` loop test. |
| `scripts/ci/verify-prod-flag-tests.mjs` | The gate. For every flag with `prod_state ∈ {on, dark}` asserts the named test **file exists** and **declares the named fn** (Rust `fn`/vitest `it/test`). Fails (exit 1) **naming the offending flag**. Pure Node+fs — deterministic, fast, no compiler/no test run. |
| `docs/ops/prod-flag-test-gate.md` | Gate doc + deploy contract (DEPLOYMENT-CRITICAL flag set) + follow-ups. |

## CI wiring

New job **`prod-flag-tests`** (MECHANISM-8) in `.github/workflows/ci.yml`, added to the `quality-gate` aggregator's `needs` + result loop (the single required check). Runs on **every PR + push to main**.

## Coverage (honest, not weakened to pass)

- **9 `loop-e2e`** — a committed test drives the whole loop with the flag ON and asserts the outcome (mission born, WorkItem `CompletedWithProof`, memory recallable, surface events emitted+read, clarification questions w/ zero model calls).
- **4 `destination-only`** — the **4 TS routing flags** (`FRIDAY_MEMORY_SPINE_ROUTES_VIA_RUST`, `FRIDAY_MISSION_SPINE_ROUTES_VIA_RUST`, `FRIDAY_ROUTE_AGENT_RUN_VIA_RUST`, `FRIDAY_MISSION_AUTO_DISPATCH`). Their loops close **Rust-side (proven)**, but the flag's own TS→Rust on-ramp is only covered by **mocked unit tests** + **`#[ignore]`'d live-key-gated** routed parity harnesses that never run in PR CI. This is a **recorded real gap**, not a fabricated mapping.

## Critical finding

**No prod-ON flag was found with zero loop coverage** — but the 4 TS routing flags lack a PR-CI test that drives flag-ON routing → real Rust → loop-closed. They PASS the gate (their Rust destination loop is real + tested); the gap lives in the `coverage` label + the doc, not red CI. Flipping `destination-only` to a hard failure is a one-line change — left as an **operator decision** (making CI red day-one for a documented gap blocks every PR).

## Fail-path demonstrated

Pointing one flag at a bogus test name → gate exits 1 naming the flag + the missing fn + remediation. Reverted; gate green (exit 0, 13/13 resolve).

## Notes

- All 13 mapped tests are Rust `friday-hub` tests run by `cargo test --workspace` in `rust-core.yml` (none `#[ignore]`'d). `rust-core.yml` is PR-triggered but **path-filtered to `rust-core/**`** — documented as a PR-coverage nuance.
- The existence check is grep-based (per the task scope: "the test fn/file is present"), so it is comment/string-permeable — a known limitation noted in the doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)