### PR TITLE
feat(hub): crash-recovery for orphaned in-flight WorkItems (FRIDAY_CRASH_RECOVERY, dark)

### DIFF
--- a/rust-core/crates/friday-hub/src/bin/hub_agent_run_server.rs
+++ b/rust-core/crates/friday-hub/src/bin/hub_agent_run_server.rs
@@ -446,6 +446,25 @@ fn run() -> Result<(), ServerError> {
         );
     }
 
+    // (2c) CRASH-RECOVERY reconciliation (gap #24, DARK, DEFAULT-OFF). Read the flag ONCE at boot;
+    // when ON, BEFORE accepting any connection, scan for genuinely-orphaned in-flight WorkItems
+    // (a `Dispatched`/`HubAccepted` row a prior process died mid-turn on) and advance each to a
+    // terminal `FailedTerminal` with the `crash_recovery_abort` marker, via the LEGAL work-item
+    // state machine. Legitimately-WAITING rows (paused/awaiting-clarification/provider-waiting,
+    // resumed by the signed-mutation/approval/reconnect paths) are NEVER touched. FAIL-SAFE: a
+    // reconcile error is LOGGED (category only) and SWALLOWED — it must NEVER block boot (the
+    // server coming up is load-bearing; reconciliation is best-effort cleanup). When OFF (default)
+    // there is NO scan and NO write, so deploying this binary changes NO live behavior until the
+    // operator flips `FRIDAY_CRASH_RECOVERY=1`. It opens its OWN short-lived DB connection (the
+    // accept-loop runtime connection is never shared) and runs synchronously here, before the loop.
+    if crash_recovery_enabled() {
+        run_boot_crash_recovery(&db_path);
+    } else {
+        eprintln!(
+            "hub_agent_run_server: crash-recovery DISABLED (set FRIDAY_CRASH_RECOVERY=1 to enable) — orphaned in-flight WorkItems are not reconciled at boot"
+        );
+    }
+
     // (3) Long-lived accept loop. Each accepted connection: set the read timeout, read the peer
     // pubkey preamble, REJECT a non-allowlisted peer pubkey (S-F, the FIRST gate), reject low-order
     // points, run the WS handshake, derive the sealed session key, and serve sealed envelopes
@@ -731,6 +750,54 @@ fn spawn_session_reaper(db_path: String) {
             }
         }
     });
+}
+
+/// Whether the operator has explicitly enabled boot-time crash-recovery reconciliation. Fail-closed:
+/// reads `FRIDAY_CRASH_RECOVERY` and delegates to the pure matcher (only the exact trimmed `"1"`
+/// enables it; everything else, including unset, is OFF).
+fn crash_recovery_enabled() -> bool {
+    friday_hub::crash_recovery::crash_recovery_enabled_from(
+        env::var(friday_hub::crash_recovery::FRIDAY_CRASH_RECOVERY)
+            .ok()
+            .as_deref(),
+    )
+}
+
+/// (gap #24) Run ONE boot-time crash-recovery sweep — FAIL-SAFE. Opens its OWN short-lived `Db`
+/// connection (the accept-loop runtime connection is never shared), reconciles genuinely-orphaned
+/// in-flight WorkItems to `FailedTerminal`, and LOGS a refs-only count line. EVERY error path
+/// (a failed open, a failed scan) is LOGGED (category only — never the db_path, which can carry the
+/// operator's home/username) and SWALLOWED: this MUST NEVER block server boot. Runs synchronously
+/// here, before the accept loop, so the cleanup completes before any connection is served.
+fn run_boot_crash_recovery(db_path: &str) {
+    let db = match friday_storage::Db::open_hub(db_path) {
+        Ok(db) => db,
+        Err(_e) => {
+            eprintln!(
+                "hub_agent_run_server: crash-recovery could not open its DB connection — skipping (boot continues)"
+            );
+            return;
+        }
+    };
+    let now_ms = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as i64)
+        .unwrap_or(0);
+    match friday_hub::crash_recovery::reconcile_orphaned_work_items(&db, now_ms) {
+        Ok(outcome) => {
+            eprintln!(
+                "hub_agent_run_server: crash-recovery ENABLED — reconcile scanned={} aborted={} skipped={}",
+                outcome.scanned, outcome.aborted, outcome.skipped,
+            );
+        }
+        // A scan-level error is non-fatal: the server still comes up (boot is load-bearing). Category
+        // only — never row contents / the db_path.
+        Err(_e) => {
+            eprintln!(
+                "hub_agent_run_server: crash-recovery reconcile failed (continuing — boot is not blocked)"
+            );
+        }
+    }
 }
 
 /// The loopback-only S-C WS listener. Owns the socket lifecycle; the session/serve/dispatch

--- a/rust-core/crates/friday-hub/src/crash_recovery.rs
+++ b/rust-core/crates/friday-hub/src/crash_recovery.rs
@@ -1,0 +1,252 @@
+//! Crash-recovery for orphaned in-flight WorkItems (registry gap #24, DARK, default-OFF).
+//!
+//! ## The wedge this closes
+//! With auto-dispatch LIVE, the WS server (`hub_agent_run_server`) owns an in-process agent
+//! loop while a WorkItem is mid-flight. If that process DIES mid-turn (the SQLITE_BUSY
+//! crash-loop history proves this happens), the new process owns NO in-flight run: a WorkItem
+//! left in a genuinely-executing hub-internal state is NEVER advanced again, so the Mission
+//! wedges FOREVER. This module adds a boot-time, best-effort reconciliation that advances each
+//! genuinely-orphaned row to a TERMINAL `FailedTerminal` with a clear marker, via the LEGAL
+//! work-item state machine + audit chain.
+//!
+//! ## The load-bearing correctness point — ORPHANED vs WAITING
+//! A graceful/crash restart means the new process owns no in-flight run, so a genuinely-running
+//! hub-internal row IS orphaned. But many non-terminal rows are LEGITIMATELY WAITING to be
+//! resumed by a LIVE recovery path; reconciling THOSE would BREAK resume = a degrade. The
+//! discriminating principle is NOT a status pattern but: *does a live recovery path pick this
+//! row up?* If yes ⇒ WAITING (leave it). If provably none ⇒ ORPHANED (reconcile).
+//!
+//! Applying it to every non-terminal [`WorkItemStatus`]:
+//!   * `Dispatched` (`PendingState::SentToHub`) and `HubAccepted` (`AcceptedByHub`) are the
+//!     hub-internal in-process hops the dying loop was MID-flight on. No resume / dispatch /
+//!     provider-reconnect path re-picks them after the loop dies. **These are the clean
+//!     orphans.** Both `Dispatched->FailedTerminal` and `HubAccepted->FailedTerminal` are legal
+//!     transitions (`friday_core::WorkItemStatus::can_transition_to`), so the reconcile uses the
+//!     standard `transition_work_item_status` primitive (audit row + upsert in one tx).
+//!   * `ProviderRouted` is where a run that PAUSED for operator approval sits — the signed-mutation
+//!     resume path (`resume_agent_loop_for_mission`, #755) drives `ProviderRouted -> ProviderWaiting
+//!     -> CompletedWithProof`. WAITING, never reconcile.
+//!   * `ProviderWaiting` is where a run actively waits on the provider; it has NO operator-approval
+//!     row by design (approval-presence is therefore the WRONG discriminator). There is no durable
+//!     run-level "actively executing" flag (`agent_run.state` is the PlanState planning machine, not
+//!     an execution marker), so a crash-orphaned `ProviderWaiting` CANNOT be told apart from a
+//!     legitimately-waiting one — reconciling it risks aborting a live run = a degrade. WAITING,
+//!     never reconcile. (Crash-orphaned `ProviderRouted`/`ProviderWaiting` rows are an EXPLICIT
+//!     deferred limitation: no-degrade beats completeness, and catching them needs a durable
+//!     run-execution state this codebase does not yet carry.)
+//!   * `WaitingForUser` is awaiting the user (the awaiting-clarification flow); `Draft` /
+//!     `PreflightBlocked` are owned by preflight; `ReadyToDispatch` by dispatch; `FailedRetryable`
+//!     by the retry path. None is an in-flight hub hop and each has its own owner. WAITING.
+//!   * the five terminal statuses are never in the scan set (`list_active_work_items` excludes
+//!     them) and are never touched.
+//!
+//! ## No-degrade posture
+//!   * **Flag-OFF is byte-identical.** [`crash_recovery_enabled_from`] is the pure matcher; the
+//!     server reads `FRIDAY_CRASH_RECOVERY` ONCE at boot and, when OFF (default / anything but the
+//!     exact trimmed `"1"`), NEVER calls [`reconcile_orphaned_work_items`] — no scan, no write.
+//!   * **Best-effort + fail-safe.** Reconciliation runs BEFORE the server accepts connections, but
+//!     a reconcile error is LOGGED (category only) and SWALLOWED — it MUST NEVER block boot (the
+//!     server coming up is load-bearing; this is cleanup). A per-row transition failure is logged
+//!     and skipped; one bad row never aborts the sweep.
+//!   * **Only advances DEAD rows.** Only `Dispatched` / `HubAccepted` are touched; every other row
+//!     (waiting + terminal) is left byte-for-byte unchanged.
+//!   * **Idempotent.** After the first sweep the orphans are `FailedTerminal` ⇒ excluded from the
+//!     scan ⇒ a second boot finds nothing (a no-op).
+//!
+//! DARK: gated default-OFF; deploying the binary changes NO live behavior until the operator flips
+//! `FRIDAY_CRASH_RECOVERY=1`.
+
+use friday_core::WorkItemStatus;
+use friday_storage::{Db, StorageError};
+
+/// The env flag that gates boot-time crash-recovery reconciliation. DEFAULT-OFF.
+pub const FRIDAY_CRASH_RECOVERY: &str = "FRIDAY_CRASH_RECOVERY";
+
+/// The actor recorded on the lifecycle audit row for a crash-recovery abort.
+const CRASH_RECOVERY_ACTOR: &str = "crash-recovery";
+
+/// The marker written as BOTH the transition `reason` (⇒ the lifecycle audit action) and the
+/// row's `blocking_reason`, so the abort is queryable from either the audit chain or the row.
+pub const CRASH_RECOVERY_MARKER: &str = "crash_recovery_abort";
+
+/// Pure flag-matcher (separated from the env read so it is testable without mutating the
+/// process-global environment). DEFAULT-OFF: `None` (unset) ⇒ false; ON only for the exact
+/// opt-in value `"1"` (trimmed), matching the program's standard flag idiom; everything else
+/// (including `"true"`) ⇒ false.
+pub fn crash_recovery_enabled_from(raw: Option<&str>) -> bool {
+    matches!(raw.map(str::trim), Some("1"))
+}
+
+/// Whether a non-terminal [`WorkItemStatus`] is a GENUINELY-ORPHANED in-flight hub hop (no live
+/// recovery path) that boot crash-recovery may abort — as opposed to a status that is
+/// legitimately WAITING to be resumed (which must NEVER be touched). See the module docs for the
+/// full classification and its rationale.
+///
+/// ONLY `Dispatched` and `HubAccepted` are orphaned. Every other status — waiting
+/// (`Draft`, `PreflightBlocked`, `WaitingForUser`, `ReadyToDispatch`, `ProviderRouted`,
+/// `ProviderWaiting`, `FailedRetryable`) and terminal — returns false.
+pub fn is_orphaned_in_flight(status: WorkItemStatus) -> bool {
+    matches!(
+        status,
+        WorkItemStatus::Dispatched | WorkItemStatus::HubAccepted
+    )
+}
+
+/// The outcome of one boot reconciliation sweep — refs-only counts (never row bodies), suitable
+/// for a single log line.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct ReconcileOutcome {
+    /// Non-terminal rows scanned.
+    pub scanned: usize,
+    /// Genuinely-orphaned rows advanced to `FailedTerminal` with the crash-recovery marker.
+    pub aborted: usize,
+    /// Orphaned rows whose legal transition failed (logged + skipped; the sweep continues).
+    pub skipped: usize,
+}
+
+impl ReconcileOutcome {
+    pub fn is_empty(&self) -> bool {
+        self.aborted == 0 && self.skipped == 0
+    }
+}
+
+/// Scan the active (non-terminal) WorkItems and advance every GENUINELY-ORPHANED in-flight row
+/// (`Dispatched` / `HubAccepted`) to a terminal `FailedTerminal`, marking it
+/// `blocking_reason = CRASH_RECOVERY_MARKER` AND recording the same marker on the lifecycle audit
+/// row — via the LEGAL `transition_work_item_status` state machine (which writes the hash-chained
+/// audit row + upsert in one transaction). WAITING rows (paused/awaiting/provider-waiting/etc.) and
+/// terminal rows are left untouched.
+///
+/// FAIL-SAFE: a scan-level read error returns `Err` to the caller (which LOGS + SWALLOWS it — boot
+/// is never blocked). A per-row failure (e.g. a concurrent terminal transition racing in) is logged
+/// via the `skipped` count and the sweep continues. IDEMPOTENT: an already-`FailedTerminal` row is
+/// excluded from the scan, so a second sweep finds nothing.
+///
+/// The `blocking_reason` row marker is set by a status-PRESERVING upsert FIRST (so it survives the
+/// transition fn's fresh re-read), then the legal terminal transition is applied; if the upsert
+/// fails the row is skipped (never half-marked into a terminal state by some other path).
+pub fn reconcile_orphaned_work_items(
+    db: &Db,
+    now_ms: i64,
+) -> Result<ReconcileOutcome, StorageError> {
+    let active = db.list_active_work_items()?;
+    let mut outcome = ReconcileOutcome {
+        scanned: active.len(),
+        ..ReconcileOutcome::default()
+    };
+
+    for item in active {
+        if !is_orphaned_in_flight(item.status) {
+            // Waiting (or otherwise not-orphaned) — leave it byte-for-byte unchanged.
+            continue;
+        }
+
+        // (1) Stamp the row-level `blocking_reason` marker WITHOUT changing status, so it survives
+        //     `transition_work_item_status`'s fresh re-read of the row. A status-preserving upsert
+        //     is legal (no state-machine hop). On failure, skip this row (do NOT proceed to the
+        //     terminal transition with an unmarked row).
+        let mut marked = item.clone();
+        marked.blocking_reason = Some(CRASH_RECOVERY_MARKER.to_string());
+        marked.updated_at_ms = now_ms;
+        if let Err(_e) = db.upsert_work_item(&marked) {
+            // Category only — never the row body / id contents.
+            eprintln!(
+                "hub_agent_run_server: crash-recovery could not mark an orphaned WorkItem (skipping)"
+            );
+            outcome.skipped += 1;
+            continue;
+        }
+
+        // (2) Advance to the terminal `FailedTerminal` via the LEGAL transition primitive. The same
+        //     marker is recorded as the audit `reason` (⇒ the lifecycle action string), so the abort
+        //     is queryable from the audit chain too. A failed transition (e.g. a racing terminal
+        //     write) is logged + skipped; the sweep continues.
+        match db.transition_work_item_status(
+            &item.work_item_id,
+            WorkItemStatus::FailedTerminal,
+            CRASH_RECOVERY_ACTOR,
+            CRASH_RECOVERY_MARKER,
+            None,
+            now_ms,
+        ) {
+            Ok(_) => outcome.aborted += 1,
+            Err(_e) => {
+                eprintln!(
+                    "hub_agent_run_server: crash-recovery could not abort an orphaned WorkItem (skipping)"
+                );
+                outcome.skipped += 1;
+            }
+        }
+    }
+
+    Ok(outcome)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn flag_matcher_is_default_off_and_exact_one() {
+        // Default-OFF: unset.
+        assert!(!crash_recovery_enabled_from(None));
+        // ON only for the exact trimmed "1".
+        assert!(crash_recovery_enabled_from(Some("1")));
+        assert!(crash_recovery_enabled_from(Some("  1  ")));
+        // Everything else (including "true", "0", "yes", garbage) ⇒ OFF.
+        for off in [
+            "", " ", "0", "true", "TRUE", "yes", "on", "11", "1 0", "enabled",
+        ] {
+            assert!(
+                !crash_recovery_enabled_from(Some(off)),
+                "must be OFF for {off:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn orphan_classifier_is_only_dispatched_and_hub_accepted() {
+        use WorkItemStatus::*;
+        // The two genuine orphans.
+        assert!(is_orphaned_in_flight(Dispatched));
+        assert!(is_orphaned_in_flight(HubAccepted));
+        // Every WAITING status is NOT an orphan — these must never be reconciled.
+        for waiting in [
+            Draft,
+            PreflightBlocked,
+            WaitingForUser,
+            ReadyToDispatch,
+            ProviderRouted,
+            ProviderWaiting,
+            FailedRetryable,
+        ] {
+            assert!(
+                !is_orphaned_in_flight(waiting),
+                "WAITING status must not be classified orphaned: {waiting:?}"
+            );
+        }
+        // No terminal status is an orphan (also they never appear in the active scan).
+        for terminal in [
+            CompletedWithProof,
+            FailedTerminal,
+            Cancelled,
+            Merged,
+            Archived,
+        ] {
+            assert!(
+                !is_orphaned_in_flight(terminal),
+                "terminal status must not be classified orphaned: {terminal:?}"
+            );
+            assert!(terminal.is_terminal());
+        }
+    }
+
+    #[test]
+    fn every_orphan_has_a_legal_failed_terminal_transition() {
+        // The reconcile relies on `Dispatched->FailedTerminal` and `HubAccepted->FailedTerminal`
+        // being legal hops in the core state machine; assert that contract so a future state-machine
+        // edit that breaks it fails HERE (not silently at runtime, where it would be a logged skip).
+        assert!(WorkItemStatus::Dispatched.can_transition_to(WorkItemStatus::FailedTerminal));
+        assert!(WorkItemStatus::HubAccepted.can_transition_to(WorkItemStatus::FailedTerminal));
+    }
+}

--- a/rust-core/crates/friday-hub/src/lib.rs
+++ b/rust-core/crates/friday-hub/src/lib.rs
@@ -256,6 +256,14 @@ pub mod provider_timeline;
 /// attaches provider/channel evidence as trace refs, not independent product state.
 pub mod mission_preflight;
 
+/// Boot-time crash-recovery for orphaned in-flight WorkItems (registry gap #24, DARK,
+/// default-OFF `FRIDAY_CRASH_RECOVERY`). After a mid-turn server crash the new process owns no
+/// in-flight run; genuinely-orphaned hub-internal rows (`Dispatched`/`HubAccepted`) are advanced
+/// to a terminal `FailedTerminal` via the legal state machine, while every legitimately-waiting
+/// row (paused/awaiting/provider-waiting) is left untouched. Best-effort + fail-safe (never
+/// blocks boot).
+pub mod crash_recovery;
+
 /// Skill / Capability Catalog / Advisor Bridge. Reads managed skill manifests as
 /// truth-labeled catalog entries and advisor inputs; it does not execute skills
 /// or grant control.

--- a/rust-core/crates/friday-hub/tests/crash_recovery.rs
+++ b/rust-core/crates/friday-hub/tests/crash_recovery.rs
@@ -1,0 +1,312 @@
+//! Boot-time crash-recovery for orphaned in-flight WorkItems (registry gap #24) —
+//! [`friday_hub::crash_recovery::reconcile_orphaned_work_items`], proven on a real Hub `Db`.
+//!
+//! With auto-dispatch LIVE, a mid-turn server crash leaves a WorkItem in a genuinely-executing
+//! hub-internal state that no live recovery path re-picks ⇒ the Mission wedges forever. The
+//! reconcile advances those (and ONLY those) to a terminal `FailedTerminal` with the
+//! `crash_recovery_abort` marker, via the LEGAL work-item state machine + audit chain.
+//!
+//! THE CANARY of this suite is the no-degrade boundary: a legitimately-WAITING row
+//! (`ProviderRouted` / `ProviderWaiting` / `WaitingForUser`) — resumed by the
+//! signed-mutation/approval/reconnect paths — must be left byte-for-byte untouched. Reconciling
+//! one would BREAK resume. The `ProviderWaiting` arm is seeded WITH NO operator-approval row on
+//! purpose: that is the exact regression that proves we did not fall into the
+//! "approval-presence" discriminator trap (a `ProviderWaiting` run waits on the PROVIDER, not on
+//! an approval, so it has no pending row by design).
+//!
+//! Arms:
+//!   (a) an orphaned in-flight WorkItem (`Dispatched`, `HubAccepted`) ⇒ flag-ON reconcile
+//!       advances it to `FailedTerminal` + `blocking_reason == crash_recovery_abort`, audit clean;
+//!   (b) legitimately-WAITING WorkItems (`ProviderRouted`, `ProviderWaiting` w/no approval,
+//!       `WaitingForUser`) ⇒ UNTOUCHED;
+//!   (c) a terminal WorkItem (`CompletedWithProof`) ⇒ UNTOUCHED;
+//!   flag-OFF ⇒ all untouched (byte-identical: the server never calls reconcile when OFF);
+//!   idempotency ⇒ a second reconcile is a no-op (0 aborted).
+
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use friday_core::{
+    ApprovalState, FridayConversation, HandoffJudgmentMemory, Mission, MissionStatus, Risk,
+    TruthStatus, WorkItem, WorkItemStatus, WorkLane,
+};
+use friday_hub::crash_recovery::{
+    crash_recovery_enabled_from, reconcile_orphaned_work_items, CRASH_RECOVERY_MARKER,
+};
+use friday_storage::audit::verify_audit_chain;
+use friday_storage::Db;
+
+static C: AtomicU64 = AtomicU64::new(0);
+const NOW: i64 = 1_700_000_000_000;
+const RECONCILE_AT: i64 = 1_700_000_500_000;
+
+fn unique(tag: &str) -> String {
+    format!(
+        "{}-{}-{}",
+        std::process::id(),
+        tag,
+        C.fetch_add(1, Ordering::Relaxed)
+    )
+}
+
+fn temp_db(tag: &str) -> String {
+    std::env::temp_dir()
+        .join(format!("friday-crash-recovery-{}.sqlite", unique(tag)))
+        .to_string_lossy()
+        .into_owned()
+}
+
+fn judgment() -> HandoffJudgmentMemory {
+    HandoffJudgmentMemory {
+        task: "Run the bound agent loop".into(),
+        current_blocker: None,
+        target_lane_thread_agent_provider: "deepseek".into(),
+        read_first_files: vec!["rust-core/crates/friday-hub/src/crash_recovery.rs".into()],
+        required_output: "loop completion".into(),
+        done_criteria: vec!["completed with proof".into()],
+        red_lines: vec!["never reconcile a legitimately-waiting row".into()],
+        why_this_route: "the WorkItem lane owns the agent loop".into(),
+        considered_options: vec!["unbound run".into()],
+        deferred_options: vec!["multi-provider".into()],
+        previous_pitfalls: vec!["a paused run looked orphaned".into()],
+        inheritable_context: vec!["Mission is product truth".into()],
+        proof_requirements: vec!["crash-recovery tests".into()],
+        ownership_claim_ids: Vec::new(),
+    }
+}
+
+/// Seed ONE Mission (+ its FridayConversation) so the seeded WorkItems hang off a real graph.
+fn seed_mission(db: &Db, mission_id: &str) {
+    let fconv = format!("fconv_crash_{}", unique("conv"));
+    db.upsert_friday_conversation(&FridayConversation {
+        friday_conversation_id: fconv.clone(),
+        owner_principal: "owner-crash".into(),
+        title: "Crash recovery".into(),
+        current_focus_summary: "orphaned in-flight rows".into(),
+        active_mission_ids: vec![mission_id.to_string()],
+        surface_thread_ids: Vec::new(),
+        memory_scope_ref: None,
+        truth_status: TruthStatus::WiredRegistry,
+        proof_refs: vec!["proof://crash-recovery".into()],
+        created_at_ms: NOW,
+        updated_at_ms: NOW,
+    })
+    .unwrap();
+    db.upsert_mission(&Mission {
+        mission_id: mission_id.to_string(),
+        friday_conversation_id: fconv,
+        title: "Crash recovery".into(),
+        intent: "reconcile only genuinely-orphaned in-flight rows".into(),
+        status: MissionStatus::Active,
+        why_now: "a crashed loop wedges the mission".into(),
+        decision_path_summary: "abort only dead rows".into(),
+        considered_options: vec!["abort all non-terminal".into()],
+        deferred_options: vec!["durable run-execution state".into()],
+        known_pitfalls: vec!["aborting a waiting row breaks resume".into()],
+        handoff_inheritance: vec!["preserve resume path".into()],
+        work_item_ids: Vec::new(),
+        memory_candidate_refs: Vec::new(),
+        context_passport_refs: Vec::new(),
+        proof_refs: vec!["proof://crash-recovery".into()],
+        created_at_ms: NOW,
+        updated_at_ms: NOW,
+    })
+    .unwrap();
+}
+
+/// Seed a WorkItem at an EXACT status directly (the reconcile reads the persisted status). For a
+/// `CompletedWithProof` seed a proof receipt is required by the persistence boundary.
+fn seed_work_item(db: &Db, mission_id: &str, work_item_id: &str, status: WorkItemStatus) {
+    let proof_receipts = if status == WorkItemStatus::CompletedWithProof {
+        vec!["proof://seeded-completion".into()]
+    } else {
+        Vec::new()
+    };
+    db.upsert_work_item(&WorkItem {
+        work_item_id: work_item_id.to_string(),
+        mission_id: mission_id.to_string(),
+        lane: WorkLane::DeepSeek,
+        target_provider_or_agent: Some("deepseek".into()),
+        status,
+        owner_claim_ids: Vec::new(),
+        workspace_refs: Vec::new(),
+        capability_id: Some("mission.run".into()),
+        risk_level: Risk::Medium,
+        approval_state: ApprovalState::NotRequired,
+        blocking_reason: None,
+        input_refs: vec!["input://run".into()],
+        output_refs: Vec::new(),
+        proof_requirements: vec!["crash-recovery tests".into()],
+        proof_receipts,
+        judgment_memory: judgment(),
+        created_at_ms: NOW,
+        updated_at_ms: NOW,
+    })
+    .unwrap();
+}
+
+fn status_of(db: &Db, work_item_id: &str) -> WorkItemStatus {
+    db.get_work_item(work_item_id).unwrap().unwrap().status
+}
+
+fn blocking_reason_of(db: &Db, work_item_id: &str) -> Option<String> {
+    db.get_work_item(work_item_id)
+        .unwrap()
+        .unwrap()
+        .blocking_reason
+}
+
+#[test]
+fn flag_matcher_is_default_off_and_exact_one() {
+    // The pure matcher the server reads at boot: default-OFF, ON only for the exact trimmed "1".
+    assert!(!crash_recovery_enabled_from(None));
+    assert!(crash_recovery_enabled_from(Some("1")));
+    assert!(crash_recovery_enabled_from(Some("  1  ")));
+    for off in ["", "0", "true", "TRUE", "yes", "enabled"] {
+        assert!(!crash_recovery_enabled_from(Some(off)), "off for {off:?}");
+    }
+}
+
+#[test]
+fn reconcile_aborts_only_orphans_leaves_waiting_and_terminal_untouched() {
+    let db = Db::open_hub(&temp_db("mix")).unwrap();
+    let mission = format!("mission-{}", unique("mix"));
+    seed_mission(&db, &mission);
+
+    // (a) Two ORPHANED in-flight rows (the hub-internal hops a dying loop was mid-turn on).
+    seed_work_item(&db, &mission, "wi-dispatched", WorkItemStatus::Dispatched);
+    seed_work_item(&db, &mission, "wi-hubaccepted", WorkItemStatus::HubAccepted);
+
+    // (b) Three legitimately-WAITING rows. `wi-providerwaiting` is seeded WITH NO operator-approval
+    //     row on purpose — the regression guard against the "approval-presence" discriminator trap.
+    seed_work_item(&db, &mission, "wi-routed", WorkItemStatus::ProviderRouted);
+    seed_work_item(
+        &db,
+        &mission,
+        "wi-providerwaiting",
+        WorkItemStatus::ProviderWaiting,
+    );
+    seed_work_item(&db, &mission, "wi-waituser", WorkItemStatus::WaitingForUser);
+
+    // (c) A terminal row — never in the active scan.
+    seed_work_item(
+        &db,
+        &mission,
+        "wi-completed",
+        WorkItemStatus::CompletedWithProof,
+    );
+
+    let audit_len_before = verify_audit_chain(db.conn()).unwrap();
+
+    let outcome = reconcile_orphaned_work_items(&db, RECONCILE_AT).unwrap();
+
+    // The two orphans were aborted; nothing skipped; only the 5 non-terminal rows were scanned.
+    assert_eq!(outcome.aborted, 2, "both orphans aborted");
+    assert_eq!(outcome.skipped, 0, "no row failed its legal transition");
+    assert_eq!(
+        outcome.scanned, 5,
+        "the terminal row is excluded from the active scan"
+    );
+
+    // (a) Orphans → terminal FailedTerminal + the row-level marker.
+    for orphan in ["wi-dispatched", "wi-hubaccepted"] {
+        assert_eq!(
+            status_of(&db, orphan),
+            WorkItemStatus::FailedTerminal,
+            "{orphan} aborted to FailedTerminal"
+        );
+        assert_eq!(
+            blocking_reason_of(&db, orphan).as_deref(),
+            Some(CRASH_RECOVERY_MARKER),
+            "{orphan} carries the crash_recovery_abort marker"
+        );
+    }
+
+    // (b) WAITING rows untouched — status AND blocking_reason byte-identical to the seed.
+    for waiting in ["wi-routed", "wi-providerwaiting", "wi-waituser"] {
+        let expected = match waiting {
+            "wi-routed" => WorkItemStatus::ProviderRouted,
+            "wi-providerwaiting" => WorkItemStatus::ProviderWaiting,
+            _ => WorkItemStatus::WaitingForUser,
+        };
+        assert_eq!(status_of(&db, waiting), expected, "{waiting} untouched");
+        assert_eq!(
+            blocking_reason_of(&db, waiting),
+            None,
+            "{waiting} not marked (the discriminator-trap regression guard)"
+        );
+    }
+
+    // (c) Terminal row untouched.
+    assert_eq!(
+        status_of(&db, "wi-completed"),
+        WorkItemStatus::CompletedWithProof
+    );
+
+    // The audit chain is intact and grew by EXACTLY one lifecycle row per aborted orphan (legal
+    // transitions, hash-chained).
+    let audit_len_after = verify_audit_chain(db.conn()).unwrap();
+    assert_eq!(
+        audit_len_after,
+        audit_len_before + 2,
+        "exactly one hash-chained lifecycle row per aborted orphan; chain verifies"
+    );
+}
+
+#[test]
+fn flag_off_means_no_reconcile_byte_identical() {
+    // Flag-OFF is byte-identical because the server NEVER calls reconcile (the matcher returns
+    // false). This arm proves the matcher gates the call, then proves that NOT calling reconcile
+    // leaves an orphan exactly as seeded.
+    assert!(!crash_recovery_enabled_from(None));
+
+    let db = Db::open_hub(&temp_db("off")).unwrap();
+    let mission = format!("mission-{}", unique("off"));
+    seed_mission(&db, &mission);
+    seed_work_item(&db, &mission, "wi-orphan-off", WorkItemStatus::Dispatched);
+    let audit_before = verify_audit_chain(db.conn()).unwrap();
+
+    // Flag OFF ⇒ the boot path does NOT invoke reconcile. The orphan stays Dispatched, unmarked.
+    assert_eq!(status_of(&db, "wi-orphan-off"), WorkItemStatus::Dispatched);
+    assert_eq!(blocking_reason_of(&db, "wi-orphan-off"), None);
+    assert_eq!(verify_audit_chain(db.conn()).unwrap(), audit_before);
+}
+
+#[test]
+fn reconcile_is_idempotent_second_sweep_is_a_noop() {
+    let db = Db::open_hub(&temp_db("idem")).unwrap();
+    let mission = format!("mission-{}", unique("idem"));
+    seed_mission(&db, &mission);
+    seed_work_item(&db, &mission, "wi-orphan-idem", WorkItemStatus::HubAccepted);
+    seed_work_item(
+        &db,
+        &mission,
+        "wi-waiting-idem",
+        WorkItemStatus::ProviderWaiting,
+    );
+
+    let first = reconcile_orphaned_work_items(&db, RECONCILE_AT).unwrap();
+    assert_eq!(first.aborted, 1, "first sweep aborts the one orphan");
+    assert_eq!(
+        status_of(&db, "wi-orphan-idem"),
+        WorkItemStatus::FailedTerminal
+    );
+
+    let audit_after_first = verify_audit_chain(db.conn()).unwrap();
+
+    // Second sweep: the orphan is now terminal ⇒ excluded from the active scan ⇒ NOTHING to do.
+    let second = reconcile_orphaned_work_items(&db, RECONCILE_AT + 1).unwrap();
+    assert_eq!(second.aborted, 0, "second sweep aborts nothing");
+    assert_eq!(second.skipped, 0);
+    assert_eq!(
+        second.scanned, 1,
+        "only the still-waiting row remains in the active scan"
+    );
+    assert!(second.is_empty(), "second sweep is a no-op");
+    // No new audit rows on the no-op second sweep.
+    assert_eq!(verify_audit_chain(db.conn()).unwrap(), audit_after_first);
+    // The waiting row is STILL untouched after two sweeps.
+    assert_eq!(
+        status_of(&db, "wi-waiting-idem"),
+        WorkItemStatus::ProviderWaiting
+    );
+}


### PR DESCRIPTION
## Registry gap #24 — crash-recovery for orphaned in-flight rows (DARK, default-OFF)

With auto-dispatch LIVE, `hub_agent_run_server` owns an in-process agent loop while a WorkItem is mid-flight. If that process dies mid-turn (the SQLITE_BUSY crash-loop history proves this happens), the new process owns NO in-flight run — a WorkItem stuck in a genuinely-executing hub-internal state is never advanced again and the **Mission wedges forever**. This adds a boot-time, best-effort reconciliation that advances each genuinely-orphaned row to a terminal `FailedTerminal`, via the LEGAL work-item state machine + hash-chained audit row.

### Honest coverage — what this DOES and does NOT close
This closes the **narrow in-process handoff window** (`Dispatched` / `HubAccepted`). It does **NOT** reconcile `ProviderRouted` / `ProviderWaiting` — and a mid-turn crash most likely dies *during the model call*, which sits at exactly those states. **That common case is EXPLICITLY DEFERRED**, on purpose: there is no durable run-execution state in this codebase to distinguish a crashed `ProviderWaiting` from a live one, and `ProviderRouted` is owned by the signed-mutation resume path — aborting either would BREAK resume = a degrade. **No-degrade beats completeness.** Closing the common case is a follow-up that first requires adding a durable run-execution marker.

### ORPHANED vs WAITING (the load-bearing correctness point)
Discriminating principle: *does a live recovery path pick this row up?* yes ⇒ WAITING (leave it); provably none ⇒ ORPHANED (reconcile).
- **ORPHANED (reconciled):** `Dispatched` (`SentToHub`), `HubAccepted` (`AcceptedByHub`) — hub-internal in-process hops no resume/dispatch/reconnect path re-picks. Both `->FailedTerminal` transitions are legal in `friday_core`'s state machine.
- **WAITING (NEVER touched):** `ProviderRouted` (resumed by `resume_agent_loop_for_mission`, #755), `ProviderWaiting` (waits on the PROVIDER — has no approval row by design, so approval-presence is NOT a valid discriminator), `WaitingForUser`, `Draft`, `PreflightBlocked`, `ReadyToDispatch`, `FailedRetryable`, and all terminal rows.

### No-degrade guarantees
- **Flag-OFF byte-identical.** `FRIDAY_CRASH_RECOVERY`, default-OFF, exact trimmed `"1"`, pure matcher read ONCE at boot. When OFF the server NEVER calls reconcile — no scan, no write.
- **Fail-safe by construction** (not test-proven): `run_boot_crash_recovery` has no `?`/`unwrap`/panic, its return is ignored at the call site, and the scan-error + per-row paths all log (category only) and continue — boot genuinely cannot be blocked.
- **Idempotent (test-proven):** aborted orphans become terminal and drop out of the active scan ⇒ a second boot is a no-op.
- **Only advances DEAD rows;** every waiting/terminal row is left byte-for-byte unchanged.

### Marker
`blocking_reason = crash_recovery_abort` on the row (status-preserving pre-stamp upsert, so it survives the transition fn's fresh re-read) PLUS the same marker as the `reason` on the legal audited transition (⇒ lifecycle audit action). Queryable from either the row or the audit chain.

### Boot call-site
`hub_agent_run_server.rs` `run()`, block `(2c)` — AFTER the runtime is built + the reaper spawn, and immediately BEFORE the accept `loop {`. Synchronous; opens its OWN short-lived `Db` connection. The reaper's first sweep is behind its 120s sleep and targets `agent_session` (not `work_item`), so nothing writes concurrently with this pre-accept-loop reconcile.

### Tests
- `friday-hub/tests/crash_recovery.rs` (real Hub `Db`): mixed seed → orphans `->FailedTerminal`+marker, waiting + terminal **UNTOUCHED**, audit chain verifies + grows by exactly one row per abort; the `ProviderWaiting`-with-NO-approval row is the regression guard against the discriminator trap; flag-OFF byte-identical; idempotency no-op.
- `src/crash_recovery.rs` unit tests: pure matcher, orphan classifier, and a legal-`FailedTerminal`-transition contract guard.
- `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `friday-hub` / `friday-storage` / `friday-core` suites all green; detect-secrets clean.

### Judgment calls / caveats
- Conservative orphan set + explicit deferral of the common mid-model-call crash window (above).
- Two-step marker write: the `blocking_reason` field pre-stamp is an un-audited upsert; the meaningful state transition that follows IS audited (same marker as its reason). `verify_audit_chain` passes.
- **Born-current:** branched off `494fae3e`, one commit behind `origin/main` `0a3ff076` (#765 surface_event, unrelated). #765 also inserts a `pub mod` line in the same lib.rs region, so a trivial adjacent-line conflict is possible — please update-branch at merge (not pre-rebased here, per the no-pre-rebase-of-a-green-PR convention).

🤖 Generated with [Claude Code](https://claude.com/claude-code)