### PR TITLE
fix(read-bins): name the schema-version skew on fail-closed read-only open (#23)

### DIFF
--- a/rust-core/crates/friday-hub/src/bin/diagnostics_snapshot.rs
+++ b/rust-core/crates/friday-hub/src/bin/diagnostics_snapshot.rs
@@ -45,7 +45,7 @@ use std::ffi::OsString;
 use std::path::Path;
 
 use friday_hub::diagnostics::{ChainStatus, DiagnosticsSnapshot};
-use friday_storage::Db;
+use friday_storage::{Db, StorageError};
 use serde_json::json;
 
 /// A fail-closed error: `kind` is a coarse, safe category (the only thing
@@ -122,7 +122,18 @@ fn run(args: &[String]) -> Result<String, BridgeError> {
         return Err(BridgeError::new("db_not_found"));
     }
     // Read-only open: a diagnostics read can NEVER mutate an operator DB.
-    let db = Db::open_hub_readonly(&db_path).map_err(|_| BridgeError::new("open_failed"))?;
+    // FAIL CLOSED + NAME the skew if the on-disk schema is strictly NEWER than this (stale)
+    // binary understands — the always-on `Db::open_hub_readonly` guard surfaced distinctly.
+    let db = Db::open_hub_readonly(&db_path).map_err(|e| match e {
+        StorageError::SchemaTooNew { disk, code } => {
+            eprintln!(
+                "diagnostics_snapshot: leg=open error_kind=schema_too_new disk_version={disk} \
+                 code_version={code} (stale binary: rebuild from the deploying commit)"
+            );
+            BridgeError::new("schema_too_new")
+        }
+        _ => BridgeError::new("open_failed"),
+    })?;
     // The collect error path is mapped to a coarse kind — a StorageError can
     // carry path/io detail, so it is never printed (same leak surface as the
     // omitted `reason`).

--- a/rust-core/crates/friday-hub/src/bin/hub_read_projection_server.rs
+++ b/rust-core/crates/friday-hub/src/bin/hub_read_projection_server.rs
@@ -83,7 +83,7 @@ use friday_protocol::{
     WorkbenchProjectionSnapshotWire,
 };
 use friday_providers::{CliProbe, ProviderProbe};
-use friday_storage::Db;
+use friday_storage::{Db, StorageError};
 use friday_transport::{ws_recv_envelope, ws_send_envelope, TransportError, WireWebSocket};
 
 /// The session AAD binding every sealed envelope on a READ session to this protocol/version. A
@@ -112,6 +112,16 @@ enum ServerError {
     /// The read-only hub DB could not be opened ⇒ the server refuses to start (no projection
     /// surface). The category only — never the db path.
     DbUnavailable,
+    /// The on-disk hub schema is STRICTLY NEWER than this binary understands ⇒ FAIL CLOSED.
+    /// A STALE read server (built from an older commit, lower `hub_code_max()`) must NEVER
+    /// serve projections over a forward-migrated DB it would misread — it refuses to boot and
+    /// NAMES the version skew (the 13:40-vs-19:04 stale-bin incident, made diagnosable). The
+    /// fail-closed behavior already lived in [`Db::open_hub_readonly`]; this distinct variant
+    /// surfaces the skew instead of collapsing it into the opaque `db_unavailable`.
+    SchemaTooNew {
+        disk: i64,
+        code: i64,
+    },
     /// The SecureStore peer-pubkey allowlist is MISSING, INVALID, or EMPTY ⇒ FAIL CLOSED. (J2: the
     /// read seam admits a NON-EMPTY MULTI-peer list, so there is no longer a multi-peer refusal —
     /// only the missing/empty/corrupt fail-closed remains.)
@@ -124,16 +134,36 @@ enum ServerError {
 
 fn main() {
     if let Err(err) = run() {
-        let kind = match err {
-            ServerError::BadArgs => "bad_args",
-            ServerError::Bind => "bind_failed",
-            ServerError::DbUnavailable => "db_unavailable",
-            ServerError::PeerAllowlist => "peer_allowlist_unavailable",
-            ServerError::MasterKeyUnavailable => "master_key_unavailable",
-            ServerError::StoreUnavailable => "secure_store_unavailable",
-        };
-        eprintln!("hub_read_projection_server_unavailable: {kind}");
+        // NAME the version skew on the schema-too-new fail-closed (the diagnosability fix). The
+        // pure `boot_error_kind` mapping is shared with the tests so the surfaced token can never
+        // drift from what `main` emits.
+        if let ServerError::SchemaTooNew { disk, code } = &err {
+            eprintln!(
+                "hub_read_projection_server: leg=open error_kind=schema_too_new \
+                 disk_version={disk} code_version={code} (stale binary: on-disk schema is \
+                 newer than this build understands — rebuild from the deploying commit)"
+            );
+        }
+        eprintln!(
+            "hub_read_projection_server_unavailable: {}",
+            boot_error_kind(&err)
+        );
         std::process::exit(2);
+    }
+}
+
+/// The coarse, closed-vocabulary `error_kind` token surfaced for each boot failure category.
+/// Pure (no I/O) so it is shared by `main` AND the tests — the surfaced token is asserted
+/// against the SAME mapping `main` uses, never a duplicate that could drift.
+fn boot_error_kind(err: &ServerError) -> &'static str {
+    match err {
+        ServerError::BadArgs => "bad_args",
+        ServerError::Bind => "bind_failed",
+        ServerError::DbUnavailable => "db_unavailable",
+        ServerError::SchemaTooNew { .. } => "schema_too_new",
+        ServerError::PeerAllowlist => "peer_allowlist_unavailable",
+        ServerError::MasterKeyUnavailable => "master_key_unavailable",
+        ServerError::StoreUnavailable => "secure_store_unavailable",
     }
 }
 
@@ -190,7 +220,7 @@ fn run() -> Result<(), ServerError> {
     // (1) Open the hub DB READ-ONLY. This is the capability-isolation cornerstone: NO HubRuntime, NO
     // DeepSeekClient, NO `from_env`, NO model-call path — the read server holds no provider
     // credential and can only READ. A read client cannot spend quota or write by construction.
-    let db = Db::open_hub_readonly(&db_path).map_err(|_| ServerError::DbUnavailable)?;
+    let db = open_hub_readonly_guarded(&db_path)?;
 
     // (1a) The provider-CLI status probe for the S-R3 providers-doctor projection. The REAL probe
     // runs ONLY each CLI's read-only `login/auth status` subcommand (never a prompt/send) — no model
@@ -819,6 +849,21 @@ fn arg_value(args: &[String], name: &str) -> Option<String> {
             args.iter()
                 .find_map(|arg| arg.strip_prefix(&prefix).map(str::to_string))
         })
+}
+
+/// Open the hub DB READ-ONLY, mapping a fail-closed schema-version skew to a DISTINCT,
+/// diagnosable [`ServerError::SchemaTooNew`]. [`Db::open_hub_readonly`] already FAILS CLOSED
+/// when the on-disk schema is strictly NEWER than this binary understands (`SchemaTooNew` — the
+/// always-on guard a STALE read server, built from an older commit with a lower `hub_code_max()`,
+/// hits against a forward-migrated DB). The behavior is unchanged — the open still errors and the
+/// server refuses to boot/serve — but instead of collapsing it into the generic `db_unavailable`,
+/// the skew is surfaced (and NAMED in `main`) so a stale-bin incident is attributable. Every other
+/// open error keeps `DbUnavailable`, byte-identical to before.
+fn open_hub_readonly_guarded(db_path: &str) -> Result<Db, ServerError> {
+    Db::open_hub_readonly(db_path).map_err(|e| match e {
+        StorageError::SchemaTooNew { disk, code } => ServerError::SchemaTooNew { disk, code },
+        _ => ServerError::DbUnavailable,
+    })
 }
 
 /// Lowercase-hex encode (the owner-sealed projection ciphertext rides a `String` field).
@@ -2463,6 +2508,58 @@ mod tests {
         assert!(!json.contains("PAUSED-RUN-TASK-BODY"), "no run task body");
         drop(ws);
         assert_eq!(server.join().unwrap(), 1);
+    }
+
+    /// NORMAL same-commit deploy: a DB at exactly `hub_code_max()` opens read-only and the read
+    /// server proceeds — BYTE-IDENTICAL to before the guard (the guard NEVER fires on equal).
+    #[test]
+    fn equal_schema_version_opens_read_only() {
+        let path = temp_db_path("ro-equal");
+        drop(Db::open_hub(&path).unwrap());
+        let db = open_hub_readonly_guarded(&path).expect("equal version must open read-only");
+        assert_eq!(db.version().unwrap(), friday_storage::hub_code_max());
+    }
+
+    /// STALE read server vs a forward-migrated DB: the on-disk version is `code_max + 1`, so the
+    /// open FAILS CLOSED with `ServerError::SchemaTooNew` (kind `schema_too_new`, NAMING the skew)
+    /// — the server never boots and never serves projections it would misread. The fail-closed
+    /// behavior already lived in `Db::open_hub_readonly`; this asserts the bin surfaces the skew
+    /// instead of the opaque `db_unavailable`.
+    #[test]
+    fn newer_on_disk_schema_fails_closed_with_named_skew() {
+        let path = temp_db_path("ro-too-new");
+        {
+            let db = Db::open_hub(&path).unwrap();
+            db.conn()
+                .execute(
+                    "UPDATE schema_version SET version = ?1 WHERE id = 1",
+                    [friday_storage::hub_code_max() + 1],
+                )
+                .unwrap();
+            drop(db);
+        }
+        let err = match open_hub_readonly_guarded(&path) {
+            Ok(_) => panic!("a stale read server must NOT open a forward-migrated DB"),
+            Err(e) => e,
+        };
+        match err {
+            ServerError::SchemaTooNew { disk, code } => {
+                assert_eq!(disk, friday_storage::hub_code_max() + 1);
+                assert_eq!(code, friday_storage::hub_code_max());
+            }
+            other => panic!("expected SchemaTooNew naming the skew, got {other:?}"),
+        }
+        // The surfaced error_kind is the distinct, diagnosable token — asserted against the SAME
+        // `boot_error_kind` mapping `main` emits (not a duplicate that could drift): a stale-bin
+        // open maps to `schema_too_new`, while every other open error stays `db_unavailable`.
+        assert_eq!(
+            boot_error_kind(&ServerError::SchemaTooNew { disk: 99, code: 1 }),
+            "schema_too_new"
+        );
+        assert_eq!(
+            boot_error_kind(&ServerError::DbUnavailable),
+            "db_unavailable"
+        );
     }
 
     /// Lowercase-hex decode helper for the test (mirror of the bin's `hex_encode`).

--- a/rust-core/crates/friday-hub/src/bin/hub_run_answer_readback.rs
+++ b/rust-core/crates/friday-hub/src/bin/hub_run_answer_readback.rs
@@ -44,7 +44,8 @@ use std::env;
 use std::path::Path;
 
 use friday_storage::{
-    get_run_answer_for_principal, AnswerDenyReason, Db, RunAnswerAccess, StoredRunResult,
+    get_run_answer_for_principal, AnswerDenyReason, Db, RunAnswerAccess, StorageError,
+    StoredRunResult,
 };
 use serde_json::json;
 
@@ -109,10 +110,7 @@ fn run() -> Result<String, ReadbackError> {
     // readback failure that left NO log trail is attributable to a leg next time. As of the
     // WAL + busy_timeout opener fix a contended open RETRIES instead of an immediate
     // SQLITE_BUSY, so `open_failed` should be rare; logging it confirms that.
-    let db = Db::open_hub_readonly(&db_path).map_err(|_| {
-        eprintln!("hub_run_answer_readback: run_id={run_id} leg=open error_kind=open_failed");
-        ReadbackError::new("open_failed")
-    })?;
+    let db = open_hub_readonly_guarded(&db_path, &run_id)?;
 
     // The OWNER-GATING decision lives entirely in this single storage primitive: it
     // releases the body ONLY inside `Granted` (caller == the run's bound owner); every
@@ -208,6 +206,32 @@ fn arg_value(args: &[String], name: &str) -> Option<String> {
         })
 }
 
+/// Open the hub DB READ-ONLY, mapping a fail-closed schema-version skew to a DISTINCT,
+/// diagnosable `error_kind`. [`Db::open_hub_readonly`] already FAILS CLOSED when the
+/// on-disk schema is strictly NEWER than this binary understands (`StorageError::SchemaTooNew`
+/// — the always-on guard a STALE bin, built from an older commit with a lower `hub_code_max()`,
+/// hits against a forward-migrated DB). The behavior is unchanged — the open still errors and
+/// the bin refuses to serve — but instead of collapsing it into the generic `open_failed`, we
+/// surface `schema_too_new` and a stderr line NAMING the version skew so the next stale-bin
+/// incident (the 13:40-vs-19:04 case) is attributable instead of an opaque open failure. Every
+/// other open error keeps the existing `open_failed` kind, byte-identical to before.
+fn open_hub_readonly_guarded(db_path: &str, run_id: &str) -> Result<Db, ReadbackError> {
+    Db::open_hub_readonly(db_path).map_err(|e| match e {
+        StorageError::SchemaTooNew { disk, code } => {
+            eprintln!(
+                "hub_run_answer_readback: run_id={run_id} leg=open error_kind=schema_too_new \
+                 disk_version={disk} code_version={code} (stale binary: on-disk schema is newer \
+                 than this build understands — rebuild from the deploying commit)"
+            );
+            ReadbackError::new("schema_too_new")
+        }
+        _ => {
+            eprintln!("hub_run_answer_readback: run_id={run_id} leg=open error_kind=open_failed");
+            ReadbackError::new("open_failed")
+        }
+    })
+}
+
 /// Defense-in-depth for the BODY-FREE payloads ONLY (`denied` / `not_found` / error):
 /// refuse to print if any forbidden marker leaked into a payload that must carry only
 /// labels/refs. Delegates to the SAME shared guard the refs-only proof bins use
@@ -274,8 +298,7 @@ mod tests {
         let db_path = arg_value(&args, "--db").unwrap();
         let run_id = arg_value(&args, "--run-id").unwrap();
         let caller_principal = arg_value(&args, "--caller-principal").unwrap();
-        let opened =
-            Db::open_hub_readonly(&db_path).map_err(|_| ReadbackError::new("open_failed"))?;
+        let opened = open_hub_readonly_guarded(&db_path, &run_id)?;
         let access = get_run_answer_for_principal(opened.conn(), &run_id, &caller_principal)
             .map_err(|_| ReadbackError::new("read_failed"))?;
         match access {
@@ -449,5 +472,56 @@ mod tests {
             deny_reason_label(AnswerDenyReason::PrincipalMismatch),
             "principal_mismatch"
         );
+    }
+
+    /// NORMAL same-commit deploy: the DB is at exactly `hub_code_max()` (what `open_hub`
+    /// migrates to), so the read bin OPENS and SERVES the owner's body — byte-identical to
+    /// before the guard. The schema-version guard NEVER fires on the equal case.
+    #[test]
+    fn equal_schema_version_serves_normally() {
+        let db = seed("equal", "run-1", Some(OWNER), BODY);
+        // The seeded DB is at exactly the binary's code_max.
+        {
+            let opened = Db::open_hub_readonly(&db).unwrap();
+            assert_eq!(opened.version().unwrap(), friday_storage::hub_code_max());
+        }
+        let rendered = run_with(&db, "run-1", OWNER).unwrap();
+        let v: Value = from_str(&rendered).unwrap();
+        assert_eq!(v["outcome"], "delivered");
+        assert_eq!(v["answer"], BODY);
+    }
+
+    /// STALE binary vs a forward-migrated DB: the on-disk version is `code_max + 1`, so the
+    /// read bin FAILS CLOSED with the distinct `schema_too_new` kind and serves NO data — it
+    /// does NOT misread the newer schema. (Today this collapsed into the opaque `open_failed`;
+    /// the guard always fired, but the skew was un-diagnosable — the 13:40-vs-19:04 incident.)
+    #[test]
+    fn newer_on_disk_schema_fails_closed_with_named_skew() {
+        let path = tmp("too-new");
+        {
+            // Seed a valid run, then forge a strictly-newer on-disk schema version to
+            // simulate a DB written by a NEWER deploy than this (stale) binary.
+            let db = Db::open_hub(&path).unwrap();
+            let result = RunResult::new("finished", BODY, Some("audit-skew".to_string()))
+                .with_owner_principal(OWNER);
+            persist_run_result(db.conn(), "run-1", &result, 7000).unwrap();
+            db.conn()
+                .execute(
+                    "UPDATE schema_version SET version = ?1 WHERE id = 1",
+                    [friday_storage::hub_code_max() + 1],
+                )
+                .unwrap();
+            drop(db);
+        }
+        // The owner — who WOULD be served on an equal-version DB — gets fail-closed instead.
+        let err = match run_with(&path, "run-1", OWNER) {
+            Ok(rendered) => panic!("a stale bin must NOT serve a forward-migrated DB: {rendered}"),
+            Err(e) => e,
+        };
+        assert_eq!(
+            err.kind, "schema_too_new",
+            "the fail-closed kind must NAME the version skew, not the opaque open_failed"
+        );
+        // The owner's body must never have been read/served under the skew.
     }
 }

--- a/rust-core/crates/friday-hub/src/bin/hub_run_readback.rs
+++ b/rust-core/crates/friday-hub/src/bin/hub_run_readback.rs
@@ -50,7 +50,7 @@ use std::env;
 use std::path::Path;
 
 use friday_hub::run_readback_projection::project_run_readback;
-use friday_storage::Db;
+use friday_storage::{Db, StorageError};
 use serde_json::json;
 
 /// A fail-closed error: `kind` is a coarse, safe category (the only thing
@@ -111,7 +111,19 @@ fn run() -> Result<String, ReadbackError> {
     let owner = arg_value(&args, "--owner").unwrap_or_default();
 
     // Read-only open: a readback can NEVER mutate an operator DB just because TS asks.
-    let db = Db::open_hub_readonly(&db_path).map_err(|_| ReadbackError::new("open_failed"))?;
+    // FAIL CLOSED + NAME the skew if the on-disk schema is strictly NEWER than this (stale)
+    // binary understands — the always-on `Db::open_hub_readonly` guard surfaced distinctly so a
+    // stale-bin-vs-forward-migrated-DB incident is diagnosable, not an opaque `open_failed`.
+    let db = Db::open_hub_readonly(&db_path).map_err(|e| match e {
+        StorageError::SchemaTooNew { disk, code } => {
+            eprintln!(
+                "hub_run_readback: leg=open error_kind=schema_too_new disk_version={disk} \
+                 code_version={code} (stale binary: rebuild from the deploying commit)"
+            );
+            ReadbackError::new("schema_too_new")
+        }
+        _ => ReadbackError::new("open_failed"),
+    })?;
 
     // S-R2: the refs-only projection (state/loop-status/event-kinds/counts + DB-WIDE token totals,
     // with the forbidden-output guard run INSIDE) is the SHARED library fn so this bin and the DARK

--- a/rust-core/crates/friday-hub/src/bin/hub_workflow_def_inspect.rs
+++ b/rust-core/crates/friday-hub/src/bin/hub_workflow_def_inspect.rs
@@ -26,7 +26,7 @@ use std::env;
 use std::path::Path;
 
 use friday_storage::workflow_def::list_definitions;
-use friday_storage::Db;
+use friday_storage::{Db, StorageError};
 use serde_json::json;
 
 /// Fail-closed error: only a coarse, safe category is surfaced (no raw detail,
@@ -70,7 +70,18 @@ fn run() -> Result<String, InspectError> {
     let workflow_filter = arg_value(&args, "--workflow-id");
 
     // Read-only open: inspection can NEVER mutate an operator DB.
-    let db = Db::open_hub_readonly(&db_path).map_err(|_| InspectError::new("open_failed"))?;
+    // FAIL CLOSED + NAME the skew if the on-disk schema is strictly NEWER than this (stale)
+    // binary understands — the always-on `Db::open_hub_readonly` guard surfaced distinctly.
+    let db = Db::open_hub_readonly(&db_path).map_err(|e| match e {
+        StorageError::SchemaTooNew { disk, code } => {
+            eprintln!(
+                "hub_workflow_def_inspect: leg=open error_kind=schema_too_new disk_version={disk} \
+                 code_version={code} (stale binary: rebuild from the deploying commit)"
+            );
+            InspectError::new("schema_too_new")
+        }
+        _ => InspectError::new("open_failed"),
+    })?;
 
     let mut summaries =
         list_definitions(db.conn()).map_err(|_| InspectError::new("read_failed"))?;

--- a/rust-core/crates/friday-hub/src/bin/hub_workflow_evidence_export.rs
+++ b/rust-core/crates/friday-hub/src/bin/hub_workflow_evidence_export.rs
@@ -47,7 +47,7 @@ use std::env;
 use std::path::Path;
 
 use friday_storage::workflow_read::{get_workflow_run_summary, list_evidence_export};
-use friday_storage::Db;
+use friday_storage::{Db, StorageError};
 use serde_json::json;
 use sha2::{Digest, Sha256};
 
@@ -97,7 +97,19 @@ fn run(args: &[String]) -> Result<String, ExportError> {
     let run_id = arg_value(args, "--run-id").ok_or(ExportError::new("bad_args"))?;
 
     // Read-only open: an export can NEVER mutate an operator DB just because TS asks.
-    let db = Db::open_hub_readonly(&db_path).map_err(|_| ExportError::new("open_failed"))?;
+    // FAIL CLOSED + NAME the skew if the on-disk schema is strictly NEWER than this (stale)
+    // binary understands — the always-on `Db::open_hub_readonly` guard surfaced distinctly.
+    let db = Db::open_hub_readonly(&db_path).map_err(|e| match e {
+        StorageError::SchemaTooNew { disk, code } => {
+            eprintln!(
+                "hub_workflow_evidence_export: leg=open error_kind=schema_too_new \
+                 disk_version={disk} code_version={code} (stale binary: rebuild from the \
+                 deploying commit)"
+            );
+            ExportError::new("schema_too_new")
+        }
+        _ => ExportError::new("open_failed"),
+    })?;
 
     // The run summary is the run-EXISTENCE oracle (an unknown run is an explicit
     // fail-closed `run_not_found`, distinct from a known run with zero steps).

--- a/rust-core/crates/friday-hub/src/bin/hub_workflow_run_readback.rs
+++ b/rust-core/crates/friday-hub/src/bin/hub_workflow_run_readback.rs
@@ -40,7 +40,7 @@ use std::path::Path;
 use friday_storage::audit::verify_audit_chain;
 use friday_storage::workflow::first_pending_seq;
 use friday_storage::workflow_read::{get_workflow_run_summary, list_workflow_step_summaries};
-use friday_storage::Db;
+use friday_storage::{Db, StorageError};
 use serde_json::json;
 use sha2::{Digest, Sha256};
 
@@ -90,7 +90,18 @@ fn run(args: &[String]) -> Result<String, ReadbackError> {
     let run_id = arg_value(args, "--run-id").ok_or(ReadbackError::new("bad_args"))?;
 
     // Read-only open: a readback can NEVER mutate an operator DB just because TS asks.
-    let db = Db::open_hub_readonly(&db_path).map_err(|_| ReadbackError::new("open_failed"))?;
+    // FAIL CLOSED + NAME the skew if the on-disk schema is strictly NEWER than this (stale)
+    // binary understands — the always-on `Db::open_hub_readonly` guard surfaced distinctly.
+    let db = Db::open_hub_readonly(&db_path).map_err(|e| match e {
+        StorageError::SchemaTooNew { disk, code } => {
+            eprintln!(
+                "hub_workflow_run_readback: leg=open error_kind=schema_too_new disk_version={disk} \
+                 code_version={code} (stale binary: rebuild from the deploying commit)"
+            );
+            ReadbackError::new("schema_too_new")
+        }
+        _ => ReadbackError::new("open_failed"),
+    })?;
 
     let summary = get_workflow_run_summary(db.conn(), &run_id)
         .map_err(|_| ReadbackError::new("read_failed"))?

--- a/rust-core/crates/friday-hub/src/bin/mission_workbench_projection.rs
+++ b/rust-core/crates/friday-hub/src/bin/mission_workbench_projection.rs
@@ -7,7 +7,7 @@
 //! `--mission-id`, opens the hub DB READ-ONLY, calls the library fn, and pretty-prints the
 //! refs-only snapshot to stdout. The forbidden-output guard runs INSIDE the library fn.
 
-use friday_storage::Db;
+use friday_storage::{Db, StorageError};
 use std::env;
 use std::path::Path;
 
@@ -25,7 +25,18 @@ fn run() -> Result<(), String> {
         return Err("rust hub db not found".to_string());
     }
     let requested_mission_id = arg_value(&args, "--mission-id");
-    let db = Db::open_hub_readonly(&db_path).map_err(|err| err.to_string())?;
+    // Read-only open. FAIL CLOSED + NAME the skew if the on-disk schema is strictly NEWER than
+    // this (stale) binary understands — the always-on `Db::open_hub_readonly` guard surfaced
+    // with an explicit `schema_too_new` marker (this bin already propagated the StorageError
+    // Display, which names disk-vs-code; the marker just makes the skew greppable like the
+    // other read bins). Every other open error keeps its existing message, unchanged.
+    let db = Db::open_hub_readonly(&db_path).map_err(|err| match err {
+        StorageError::SchemaTooNew { disk, code } => format!(
+            "schema_too_new: on-disk schema v{disk} is newer than this build v{code} \
+             (stale binary: rebuild from the deploying commit)"
+        ),
+        other => other.to_string(),
+    })?;
     let snapshot =
         friday_hub::workbench_projection::project_workbench(&db, requested_mission_id.as_deref())?;
     let rendered = serde_json::to_string_pretty(&snapshot).map_err(|err| err.to_string())?;

--- a/rust-core/crates/friday-storage/src/lib.rs
+++ b/rust-core/crates/friday-storage/src/lib.rs
@@ -67,7 +67,9 @@ pub use run_result::{
     AnswerDenyReason, PersistRunResultOutcome, RunAnswerAccess, RunResult, RunResultRef,
     StoredRunResult,
 };
-pub use schema::{hub_migrations, phone_migrations, HUB_ONLY_TABLES, PHONE_ONLY_TABLES};
+pub use schema::{
+    hub_code_max, hub_migrations, phone_migrations, HUB_ONLY_TABLES, PHONE_ONLY_TABLES,
+};
 pub use session_lifecycle::{sweep_lifecycle, SweepOutcome};
 pub use trust_grant::{
     active_grant, authorize_agent_action, grant_trust, latest_grant_any_state, revoke_trust,
@@ -1475,6 +1477,78 @@ mod busy_retry_tests {
         };
         assert!(matches!(err, StorageError::SchemaTooNew { .. }));
         assert_eq!(calls.get(), 1, "a non-busy error must NOT be retried");
+    }
+}
+
+/// The read-only opener ([`Db::open_hub_readonly`]) carries the SAME fail-closed
+/// schema-version guard as the writer's [`migrate::apply_migrations`]: a binary whose
+/// compiled `hub_code_max()` is STRICTLY OLDER than the on-disk schema version refuses
+/// to open (rather than silently misreading a forward-migrated DB — the 13:40-vs-19:04
+/// stale-bin incident). These tests pin that always-on behavior at the storage layer so
+/// every read bin that routes through it inherits the guard.
+#[cfg(test)]
+mod read_only_schema_guard_tests {
+    use super::{hub_code_max, Db, StorageError};
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    static C: AtomicU64 = AtomicU64::new(0);
+    fn tmp(tag: &str) -> String {
+        std::env::temp_dir()
+            .join(format!(
+                "friday-ro-schema-guard-{}-{}-{}.sqlite",
+                std::process::id(),
+                tag,
+                C.fetch_add(1, Ordering::Relaxed)
+            ))
+            .to_string_lossy()
+            .into_owned()
+    }
+
+    /// EQUAL on-disk version (the normal same-commit deploy): the read-only opener
+    /// succeeds and reports the current version — BYTE-IDENTICAL to before the guard.
+    #[test]
+    fn equal_version_opens_read_only() {
+        let path = tmp("equal");
+        // `open_hub` migrates the file to `hub_code_max()`.
+        drop(Db::open_hub(&path).unwrap());
+        let db = Db::open_hub_readonly(&path).expect("equal version must open read-only");
+        assert_eq!(db.version().unwrap(), hub_code_max());
+    }
+
+    /// A STALE binary (lower `hub_code_max()`) faced with a forward-migrated DB sees
+    /// `disk = code_max + 1 > code` and FAILS CLOSED with `SchemaTooNew` naming the skew —
+    /// it does NOT open and cannot misread the newer schema.
+    #[test]
+    fn newer_on_disk_version_fails_closed() {
+        let path = tmp("too-new");
+        {
+            // Migrate to current, then forge a strictly-newer on-disk version to
+            // simulate a DB written by a NEWER deploy than this (stale) binary.
+            let writer = Db::open_hub(&path).unwrap();
+            writer
+                .conn()
+                .execute(
+                    "UPDATE schema_version SET version = ?1 WHERE id = 1",
+                    [hub_code_max() + 1],
+                )
+                .unwrap();
+            drop(writer);
+        }
+        let err = match Db::open_hub_readonly(&path) {
+            Ok(_) => panic!("a strictly-newer on-disk schema must fail closed"),
+            Err(e) => e,
+        };
+        match err {
+            StorageError::SchemaTooNew { disk, code } => {
+                assert_eq!(
+                    disk,
+                    hub_code_max() + 1,
+                    "the skew names the on-disk version"
+                );
+                assert_eq!(code, hub_code_max(), "the skew names the binary's code_max");
+            }
+            other => panic!("expected SchemaTooNew naming the skew, got {other:?}"),
+        }
     }
 }
 

--- a/rust-core/crates/friday-storage/src/schema.rs
+++ b/rust-core/crates/friday-storage/src/schema.rs
@@ -557,6 +557,22 @@ pub fn hub_migrations() -> Vec<Migration> {
     ]
 }
 
+/// The MAXIMUM Hub schema version this build understands — the SAME `code_max`
+/// the writer's [`crate::apply_migrations`] guard (`disk > code_max ⇒ SchemaTooNew`)
+/// and the read-only opener ([`crate::Db::open_hub_readonly`]) compute from
+/// [`hub_migrations`]. It is derived (not a hand-kept constant) so the writer's
+/// guard, the read bins' fail-closed guard, and any test that seeds a "too-new"
+/// DB all read ONE source of truth and can never drift: a stale binary built from
+/// an older commit has a strictly LOWER `hub_code_max()`, so a forward-migrated
+/// on-disk version is `disk > code` and fails closed.
+pub fn hub_code_max() -> i64 {
+    hub_migrations()
+        .iter()
+        .map(|m| m.version)
+        .max()
+        .unwrap_or(0)
+}
+
 pub fn phone_migrations() -> Vec<Migration> {
     vec![
         Migration {


### PR DESCRIPTION
## Registry gap #23 — read-bin schema-version fail-closed guard

### Finding: the behavioral guard already exists; the residual gap was diagnosability

The Rust WRITER migrates `rust-hub.sqlite` forward and fails closed with `SchemaTooNew` when the on-disk version exceeds its `code_max` (`friday-storage/src/migrate.rs:84-95`).

Investigation confirmed that the read-only opener **`Db::open_hub_readonly`** (`friday-storage/src/lib.rs:387-419`, added by #521) **already carries the SAME always-on fail-closed guard**, sharing the SAME version source (the `schema_version` singleton table, id=1) and the SAME `code_max` (max of `hub_migrations()`). **Every** read-only bin routes through it (audited — see list below). So a STALE read bin (built from an older commit ⇒ lower `code_max`) faced with a forward-migrated DB (`disk > code`) **already fails closed** — the behavioral guard already covers the 13:40-vs-19:04 stale-bin incident.

The **residual gap** was diagnosability: every read bin collapsed the open error into a generic `open_failed` / `db_unavailable` via `.map_err(|_| ...)`, **erasing the version skew**. A stale-bin incident surfaced as an opaque open failure with no version numbers — exactly what made the prod incident hard to attribute.

### Change (no-degrade · fail-closed-correctness)

- **`friday_storage::hub_code_max()`** — new accessor derived from `hub_migrations()`; the single shared `code_max` source so the writer guard, the readers' guard, and test seeds can never drift (do not hard-code a second copy).
- **Each read bin** now branches `StorageError::SchemaTooNew { disk, code }` to a distinct `schema_too_new` `error_kind` + a stderr line **naming the disk-vs-code skew** ("stale binary: rebuild from the deploying commit"). Every non-schema open error keeps its existing kind/message, byte-identical.
- **No new guard, no flag** — reuses `open_hub_readonly`'s existing always-on check (mirrors the writer's always-on precedent). Only the error-mapping closure changed; success output and non-schema-error output/exit are untouched. The pre-existing `disk < code ⇒ Unsupported` reject is left intact.

### Tests
- Storage layer (`friday-storage`): `open_hub_readonly` serves at `code_max`, fails closed with `SchemaTooNew{disk,code}` at `code_max+1`.
- Per-bin (the two named read bins): serves at `code_max`; fails closed with the named `schema_too_new` skew at `code_max+1`, serving NO data. The read-projection-server test asserts the **real** `boot_error_kind` mapping `main` emits (no mirror that could drift).

### Read bins audited (all route through `Db::open_hub_readonly`)
`hub_run_answer_readback`, `hub_read_projection_server`, `hub_run_readback`, `hub_workflow_run_readback`, `hub_workflow_def_inspect`, `hub_workflow_evidence_export`, `diagnostics_snapshot`, `mission_workbench_projection`.

### CI hygiene
`cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test -p friday-hub -p friday-storage` all green. Rust-only; no `.secrets.baseline` shift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)