### PR TITLE
feat(hub): provider failover on the live agent loop (deepseek→claude) (FRIDAY_PROVIDER_FAILOVER, dark) (#26)

### DIFF
--- a/docs/ops/prod-flags-manifest.json
+++ b/docs/ops/prod-flags-manifest.json
@@ -139,6 +139,15 @@
       "coverage": "loop-e2e",
       "e2e_test": "rust-core/crates/friday-hub/src/runtime.rs::passport_mint_on_benign_mints_persists_links_then_runs",
       "notes": "Built-but-dark. Drives run_agent_loop_for_mission_with_overrides_flagged(.., passport_mint=true, ..) and asserts a ContextPassport row + links are persisted then the run proceeds. Sibling proofs cover sensitive-item-fails-closed, mixed-set-blocks-whole-handoff, and flag-off byte-identical."
+    },
+    {
+      "flag": "FRIDAY_PROVIDER_FAILOVER",
+      "process": "rust-ws-wrapper",
+      "prod_state": "dark",
+      "closes_loop": "On a FAILOVER-WORTHY primary (deepseek) route failure (5xx/408/transport, 402 quota, 429 rate-limit), the live agent loop retries the SAME call ONCE on the fallback (claude) and FINISHES on the fallback's answer, billed truthfully to anthropic; a parse-success/400/auth/no-model primary error NEVER fails over (no double-bill, no silent substitute).",
+      "coverage": "loop-e2e",
+      "e2e_test": "rust-core/crates/friday-hub/tests/provider_failover.rs::quota_402_fails_over_to_claude_finishes_and_bills_anthropic",
+      "notes": "Built-but-dark (registry gap #26). RGG is DeepSeek-only, so both provider legs are MOCKED: the named test drives the ProviderFailoverWrapper THROUGH the real friday_hub::run_loop against a real Hub Db — a DeepSeek 402 fails over to a finishing Claude mock, the loop Finishes 'PONG', and EXACTLY ONE token_ledger row is written attributed to anthropic/api.anthropic.com (no double-bill). Sibling e2e proofs in the same file: 429 + 5xx failover, and 400-malformed → loop errors closed with NO failover + NO bill. The wrapper/classifier per-case behavior (incl. the inner-parse-error double-bill guard, auth/no-model no-failover) is pinned in src/provider_failover.rs tests; the WIRING decision (flag-off byte-identical: wrapper not constructed; flag-on-but-Claude-absent: hard boot error; the exact-'1' flag matcher) is pinned in src/runtime.rs tests (failover_flag_off_does_not_construct_wrapper_byte_identical, failover_flag_on_without_claude_is_hard_boot_error, provider_failover_flag_matcher_is_exact_one_default_off)."
     }
   ]
 }

--- a/rust-core/crates/friday-hub/src/lib.rs
+++ b/rust-core/crates/friday-hub/src/lib.rs
@@ -141,6 +141,15 @@ pub mod cognition;
 /// No silent fallback (a retry is the SAME route, never a reroute); bounded.
 pub mod retry;
 
+/// Registry gap #26 — provider FAILOVER on the live agent loop (deepseek → claude). A
+/// thin [`AgentLlmClient`] wrapper that retries a FAILOVER-WORTHY primary route failure
+/// ONCE on the fallback provider. Default-OFF (`FRIDAY_PROVIDER_FAILOVER`), explicit
+/// substitution (UNW-003), billing-truthful across failover (the fallback bills as
+/// Anthropic; the failed primary attempt bills nothing). Its OWN classifier — NOT
+/// [`retry::RetryDisposition`] — because failover treats 402/429 as worth a DIFFERENT
+/// provider where the same-route retry treats them Terminal.
+pub mod provider_failover;
+
 /// Step-5 (workflow/skills substrate) — the workflow PLANNER + minimal definition
 /// type. Decides per-step auto-advance vs checkpoint, ANCHORED to the trusted
 /// classifier (mutating/high-risk ⇒ checkpoint, the gate floor; template may only
@@ -566,6 +575,28 @@ pub trait AgentLlmClient {
         history: &[TurnTrace],
     ) -> Result<MeteredStep, AgentError> {
         Ok((self.next_step(task, history), None))
+    }
+}
+
+/// (#26) Blanket forward so a `Box<dyn AgentLlmClient>` is itself an [`AgentLlmClient`].
+/// This lets a boxed client be used as a GENERIC `AgentLlmClient` type parameter — e.g.
+/// the `F` (fallback) leg of [`crate::provider_failover::ProviderFailoverWrapper`], which
+/// in production is the boxed Claude client. Pure delegation to the inner `dyn` — adds no
+/// behavior, confers no classification authority, and is transparent to every existing
+/// `&dyn AgentLlmClient` caller (which is unaffected).
+impl AgentLlmClient for Box<dyn AgentLlmClient> {
+    fn propose_tool_call(&self, task: &str) -> Result<RawToolCall, AgentError> {
+        (**self).propose_tool_call(task)
+    }
+    fn next_step(&self, task: &str, history: &[TurnTrace]) -> Result<AgentStep, AgentError> {
+        (**self).next_step(task, history)
+    }
+    fn next_step_metered(
+        &self,
+        task: &str,
+        history: &[TurnTrace],
+    ) -> Result<MeteredStep, AgentError> {
+        (**self).next_step_metered(task, history)
     }
 }
 

--- a/rust-core/crates/friday-hub/src/provider_failover.rs
+++ b/rust-core/crates/friday-hub/src/provider_failover.rs
@@ -1,0 +1,442 @@
+//! Registry gap #26 — provider FAILOVER on the live agent loop (deepseek → claude).
+//!
+//! This is the ONLY missing piece of multi-provider failover: both the
+//! [`crate::DeepSeekAgentLlmClient`] (primary) and the [`crate::ClaudeAgentLlmClient`]
+//! (fallback) already exist + are wired selectable; this wraps them so that a
+//! FAILOVER-WORTHY route failure on the primary is retried ONCE on the fallback —
+//! transparently, behind the [`crate::AgentLlmClient`] seam, so the live loop's single
+//! model call-site (`run_loop_with_policy_flagged` → `client.next_step_metered`) gets
+//! failover with NO loop change.
+//!
+//! ## Default-OFF, explicit substitution (UNW-003 routing-truth)
+//! "No-fallback" was a DELIBERATE invariant: never silently substitute a provider the
+//! operator did not ask for (see `crate::retry`'s module doc + the per-adapter
+//! no-fallback contracts). This wrapper makes the substitution EXPLICIT and opt-in: it
+//! is constructed ONLY behind the default-OFF `FRIDAY_PROVIDER_FAILOVER` gate
+//! (see [`crate::runtime::HubRuntime`]). Flag-OFF ⇒ the wrapper is never constructed ⇒
+//! the deepseek route dispatches the bare primary, byte-identical to today. The wrapper
+//! lives INSIDE the loop's execution (it IS the resolved `&dyn AgentLlmClient`), NOT in
+//! the route-selection layer — selection still honestly reports `provider_id="deepseek"`
+//! (the requested provider); the failover is an execution-layer resilience step, not a
+//! reroute the registry would mis-report.
+//!
+//! ## The trigger set (own classifier — NOT [`crate::retry::RetryDisposition`])
+//! Failover fires on the OUTER [`crate::AgentError`] from the primary ONLY, and only for:
+//!   - [`friday_deepseek::DeepSeekError::ProviderUnavailable`] — 5xx / 408 / transport.
+//!   - [`friday_deepseek::DeepSeekError::ClientError`] with status **402** (quota) or
+//!     **429** (rate-limit).
+//! It NEVER fires on:
+//!   - [`friday_deepseek::DeepSeekError::ClientError`] with any OTHER 4xx (400 / 404 /
+//!     422 …) — a malformed/not-found request Claude would reject too.
+//!   - [`friday_deepseek::DeepSeekError::Auth`] / [`friday_deepseek::DeepSeekError::CredentialMissing`]
+//!     — a broken credential is operator-actionable, not a transient outage.
+//!   - [`friday_deepseek::DeepSeekError::NoModels`] / `BadResponse` / `Core` — discovery /
+//!     contract / Hub-internal failures, not a provider outage the fallback fixes.
+//!   - [`crate::AgentError::Model`] — "no model available" (discovery selection): a config
+//!     issue, not a transient outage; fallback would not help.
+//!   - [`crate::AgentError::Parse`] — the model REPLIED, the parse failed: never failover.
+//!
+//! ## The double-bill guard (billing-truth)
+//! The metered seam's success shape is `Ok((Err(Parse), Some(usage)))` — a chat that
+//! SUCCEEDED (spent + billed tokens) but whose content failed the tool-call contract.
+//! That is an OUTER `Ok`, so the wrapper returns it UNTOUCHED: no second (fallback) call,
+//! no double-bill. Failover triggers on the OUTER `Err(AgentError)` (a route failure that
+//! produced NO usage) ONLY — so a primary attempt that bills is NEVER also failed over,
+//! and a primary attempt that fails over bills NOTHING extra (the route error carries no
+//! usage). The fallback call is billed by the loop EXACTLY as a normal Claude turn would
+//! be — `provider_kind = Anthropic` (the fallback adapter's own
+//! [`crate::BilledUsage::from_anthropic`]) — so attribution stays truthful across failover.
+//!
+//! ## No overlap with the loop's same-route retry (`crate::retry`)
+//! The loop's bounded same-route retry only re-attempts a `Retryable`
+//! `AgentError::Route(ProviderUnavailable)` on the SAME client. When the wrapper IS that
+//! client, the wrapper's failover runs INSIDE each `next_step_metered` call — so a
+//! 402/429 (terminal-for-retry) fails over immediately, and a 5xx fails over within the
+//! call (the loop's outer retry then re-runs the WRAPPER, i.e. primary→fallback again,
+//! still bounded). There is no unbounded interaction: each wrapper call makes at most TWO
+//! provider attempts (one primary, one fallback), and the loop's retry bound caps the
+//! number of wrapper calls.
+
+use crate::{AgentError, AgentLlmClient, AgentStep, MeteredStep, RawToolCall, TurnTrace};
+use friday_deepseek::DeepSeekError;
+
+/// Is `err` — the OUTER error from the PRIMARY provider's call — a FAILOVER-worthy
+/// failure that should be retried once on the fallback provider? See the module doc for
+/// the exact trigger set. This is a PURE function of the error (no I/O, no state), and is
+/// DELIBERATELY distinct from [`crate::retry::RetryDisposition::classify_deepseek`]: the
+/// same-route retry classifier treats 402/429 as `Terminal` (no backoff ⇒ do not hammer
+/// the SAME route), whereas failover treats them as worth trying a DIFFERENT provider.
+pub fn is_failover_worthy(err: &AgentError) -> bool {
+    match err {
+        // Route failures carry the structured DeepSeek error — inspect the variant/status.
+        AgentError::Route(e) => match e {
+            // Transient outage: 5xx / 408 / transport. Worth a different provider.
+            DeepSeekError::ProviderUnavailable(_) => true,
+            // Quota (402) and rate-limit (429): the PRIMARY can't serve THIS call, but a
+            // DIFFERENT provider can. Every other client error (400/404/422 malformed,
+            // any other 4xx) is a bad request the fallback would also reject — do NOT
+            // failover.
+            DeepSeekError::ClientError { status } => *status == 402 || *status == 429,
+            // Broken credential / discovery / contract / Hub-internal: not a transient
+            // outage a fallback fixes.
+            DeepSeekError::Auth(_)
+            | DeepSeekError::CredentialMissing
+            | DeepSeekError::NoModels
+            | DeepSeekError::BadResponse(_)
+            | DeepSeekError::Core(_) => false,
+        },
+        // "no model available" (discovery selection) — a config issue, not an outage.
+        AgentError::Model(_) => false,
+        // The model REPLIED but the parse failed — NEVER failover (the double-bill trap is
+        // the metered `Ok((Err(Parse), ..))` path, but a direct `propose_tool_call` parse
+        // error is likewise not a route failure).
+        AgentError::Parse(_) => false,
+    }
+}
+
+/// Wraps a `primary` (deepseek) and a `fallback` (claude) [`AgentLlmClient`]: dispatches
+/// each call to the primary, and on a [`is_failover_worthy`] OUTER error retries the SAME
+/// call ONCE on the fallback. Impls [`AgentLlmClient`], so it slots in as the resolved
+/// `&dyn AgentLlmClient` the loop drives — failover is invisible to the loop.
+///
+/// Generic over both clients so the deterministic test can inject mocks for BOTH legs; in
+/// production `P = DeepSeekAgentLlmClient<UreqTransport>` and `F = Box<dyn AgentLlmClient>`
+/// (the Claude client, boxed). See the module doc for the trigger set + billing-truth.
+pub struct ProviderFailoverWrapper<P: AgentLlmClient, F: AgentLlmClient> {
+    primary: P,
+    fallback: F,
+}
+
+impl<P: AgentLlmClient, F: AgentLlmClient> ProviderFailoverWrapper<P, F> {
+    /// Construct the wrapper. `primary` is the deepseek leg, `fallback` the claude leg.
+    pub fn new(primary: P, fallback: F) -> Self {
+        Self { primary, fallback }
+    }
+}
+
+impl<P: AgentLlmClient, F: AgentLlmClient> AgentLlmClient for ProviderFailoverWrapper<P, F> {
+    /// Single-turn proposal. Tries the primary; on a failover-worthy error, retries on the
+    /// fallback ONCE. (Not on the live loop path — the loop uses `next_step_metered` — but
+    /// kept consistent so every trait method honors the same failover contract.)
+    fn propose_tool_call(&self, task: &str) -> Result<RawToolCall, AgentError> {
+        match self.primary.propose_tool_call(task) {
+            Ok(call) => Ok(call),
+            Err(e) if is_failover_worthy(&e) => self.fallback.propose_tool_call(task),
+            Err(e) => Err(e),
+        }
+    }
+
+    /// History-aware multi-turn step. Routed THROUGH [`Self::next_step_metered`] so there
+    /// is exactly ONE failover decision point (mirrors the DeepSeek/Claude adapters); the
+    /// usage is discarded here, the parse result surfaced.
+    fn next_step(&self, task: &str, history: &[TurnTrace]) -> Result<AgentStep, AgentError> {
+        self.next_step_metered(task, history)?.0
+    }
+
+    /// The live loop's metered step — the ONE call-site failover applies to.
+    ///
+    /// FAILOVER triggers on the OUTER `Err(AgentError)` ONLY (a route failure that
+    /// produced NO usage). A successful chat — including the `Ok((Err(Parse), Some(usage)))`
+    /// double-bill-trap shape (the primary answered + billed, the parse failed) — is an
+    /// OUTER `Ok` and is returned UNTOUCHED: no fallback call, no double-bill. When failover
+    /// does fire, the fallback's metered result is returned verbatim, so its
+    /// Anthropic-tagged [`crate::BilledUsage`] reaches the loop's biller and the call is
+    /// attributed to Anthropic — the failed primary attempt billed nothing.
+    fn next_step_metered(
+        &self,
+        task: &str,
+        history: &[TurnTrace],
+    ) -> Result<MeteredStep, AgentError> {
+        match self.primary.next_step_metered(task, history) {
+            // OUTER Ok: a chat that ran (and is billed by the loop). This INCLUDES the
+            // inner-parse-error shape `(Err(Parse), Some(usage))` — never failover it.
+            ok @ Ok(_) => ok,
+            // OUTER Err: the primary's route call failed (no usage). Failover iff worthy.
+            Err(e) if is_failover_worthy(&e) => self.fallback.next_step_metered(task, history),
+            // A non-failover-worthy route failure (auth / malformed / no-model / parse):
+            // surface the PRIMARY's error unchanged — never a silent substitute.
+            Err(e) => Err(e),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::BilledUsage;
+    use std::cell::Cell;
+
+    /// A scripted metered client: returns the configured OUTER result, and counts calls
+    /// (so a test can assert the fallback was / was not invoked). Each leg of the wrapper
+    /// gets its own instance.
+    struct ScriptedClient {
+        // The OUTER result this leg returns for `next_step_metered`.
+        result: Box<dyn Fn() -> Result<MeteredStep, AgentError>>,
+        calls: Cell<usize>,
+    }
+    impl ScriptedClient {
+        fn new(result: impl Fn() -> Result<MeteredStep, AgentError> + 'static) -> Self {
+            Self {
+                result: Box::new(result),
+                calls: Cell::new(0),
+            }
+        }
+        fn calls(&self) -> usize {
+            self.calls.get()
+        }
+    }
+    impl AgentLlmClient for ScriptedClient {
+        fn propose_tool_call(&self, _task: &str) -> Result<RawToolCall, AgentError> {
+            unreachable!("tests drive next_step_metered")
+        }
+        fn next_step_metered(
+            &self,
+            _task: &str,
+            _history: &[TurnTrace],
+        ) -> Result<MeteredStep, AgentError> {
+            self.calls.set(self.calls.get() + 1);
+            (self.result)()
+        }
+    }
+
+    fn deepseek_route(e: DeepSeekError) -> AgentError {
+        AgentError::Route(e)
+    }
+
+    fn claude_finish_with_anthropic_usage() -> Result<MeteredStep, AgentError> {
+        Ok((
+            Ok(AgentStep::Finish {
+                message: "PONG".to_string(),
+            }),
+            Some(BilledUsage {
+                provider_kind: friday_core::ProviderKind::Anthropic,
+                model: "claude-opus-4-8".to_string(),
+                prompt_tokens: 11,
+                completion_tokens: 8,
+            }),
+        ))
+    }
+
+    // ---- the classifier: exact trigger set --------------------------------------------
+
+    #[test]
+    fn classifier_failover_triggers() {
+        // ProviderUnavailable (5xx / 408 / transport).
+        assert!(is_failover_worthy(&deepseek_route(
+            DeepSeekError::ProviderUnavailable("HTTP 503".into())
+        )));
+        assert!(is_failover_worthy(&deepseek_route(
+            DeepSeekError::ProviderUnavailable("transport: ConnectionFailed".into())
+        )));
+        // 402 quota.
+        assert!(is_failover_worthy(&deepseek_route(
+            DeepSeekError::ClientError { status: 402 }
+        )));
+        // 429 rate-limit.
+        assert!(is_failover_worthy(&deepseek_route(
+            DeepSeekError::ClientError { status: 429 }
+        )));
+    }
+
+    #[test]
+    fn classifier_failover_never_triggers() {
+        // Other 4xx malformed — Claude would reject too.
+        for status in [400u16, 404, 413, 422] {
+            assert!(
+                !is_failover_worthy(&deepseek_route(DeepSeekError::ClientError { status })),
+                "client error {status} must NOT failover"
+            );
+        }
+        // Auth / credential — broken credential, operator-actionable.
+        assert!(!is_failover_worthy(&deepseek_route(DeepSeekError::Auth(
+            401
+        ))));
+        assert!(!is_failover_worthy(&deepseek_route(DeepSeekError::Auth(
+            403
+        ))));
+        assert!(!is_failover_worthy(&deepseek_route(
+            DeepSeekError::CredentialMissing
+        )));
+        // Discovery / contract / Hub-internal.
+        assert!(!is_failover_worthy(&deepseek_route(
+            DeepSeekError::NoModels
+        )));
+        assert!(!is_failover_worthy(&deepseek_route(
+            DeepSeekError::BadResponse("garbage".into())
+        )));
+        assert!(!is_failover_worthy(&deepseek_route(DeepSeekError::Core(
+            friday_core::CoreError::BlockedTransfer("x".into())
+        ))));
+        // The non-Route AgentError variants.
+        assert!(!is_failover_worthy(&AgentError::Model(
+            "no model available".into()
+        )));
+        assert!(!is_failover_worthy(&AgentError::Parse("not json".into())));
+    }
+
+    // ---- the wrapper: behavior per case -----------------------------------------------
+
+    #[test]
+    fn quota_402_fails_over_to_claude_with_anthropic_billing() {
+        let primary =
+            ScriptedClient::new(|| Err(deepseek_route(DeepSeekError::ClientError { status: 402 })));
+        let fallback = ScriptedClient::new(claude_finish_with_anthropic_usage);
+        let wrapper = ProviderFailoverWrapper::new(primary, fallback);
+        let (step, usage) = wrapper.next_step_metered("task", &[]).unwrap();
+        assert_eq!(
+            step.unwrap(),
+            AgentStep::Finish {
+                message: "PONG".into()
+            },
+            "the fallback's answer is surfaced"
+        );
+        let usage = usage.expect("the fallback chat surfaces usage to bill");
+        assert_eq!(
+            usage.provider_kind,
+            friday_core::ProviderKind::Anthropic,
+            "the failover call bills as Anthropic — never mis-attributed as DeepSeek"
+        );
+        assert_eq!(wrapper.primary.calls(), 1, "primary tried once");
+        assert_eq!(wrapper.fallback.calls(), 1, "fallback tried once");
+    }
+
+    #[test]
+    fn rate_limit_429_fails_over() {
+        let primary =
+            ScriptedClient::new(|| Err(deepseek_route(DeepSeekError::ClientError { status: 429 })));
+        let fallback = ScriptedClient::new(claude_finish_with_anthropic_usage);
+        let wrapper = ProviderFailoverWrapper::new(primary, fallback);
+        let (step, usage) = wrapper.next_step_metered("task", &[]).unwrap();
+        assert!(matches!(step, Ok(AgentStep::Finish { .. })));
+        assert_eq!(
+            usage.unwrap().provider_kind,
+            friday_core::ProviderKind::Anthropic
+        );
+        assert_eq!(wrapper.fallback.calls(), 1);
+    }
+
+    #[test]
+    fn provider_unavailable_5xx_fails_over() {
+        let primary = ScriptedClient::new(|| {
+            Err(deepseek_route(DeepSeekError::ProviderUnavailable(
+                "HTTP 503".into(),
+            )))
+        });
+        let fallback = ScriptedClient::new(claude_finish_with_anthropic_usage);
+        let wrapper = ProviderFailoverWrapper::new(primary, fallback);
+        let (step, usage) = wrapper.next_step_metered("task", &[]).unwrap();
+        assert!(matches!(step, Ok(AgentStep::Finish { .. })));
+        assert_eq!(
+            usage.unwrap().provider_kind,
+            friday_core::ProviderKind::Anthropic
+        );
+        assert_eq!(wrapper.fallback.calls(), 1);
+    }
+
+    #[test]
+    fn inner_parse_error_never_fails_over_no_double_bill() {
+        // The double-bill trap: a chat that SUCCEEDED (billed DeepSeek usage) but whose
+        // content failed to parse is the OUTER `Ok((Err(Parse), Some(usage)))` shape. The
+        // wrapper must return it UNTOUCHED — no fallback call, billed ONCE on DeepSeek.
+        let primary = ScriptedClient::new(|| {
+            Ok((
+                Err(AgentError::Parse("not a tool-call object".into())),
+                Some(BilledUsage {
+                    provider_kind: friday_core::ProviderKind::DeepSeek,
+                    model: "deepseek-v4-flash".to_string(),
+                    prompt_tokens: 10,
+                    completion_tokens: 5,
+                }),
+            ))
+        });
+        let fallback = ScriptedClient::new(claude_finish_with_anthropic_usage);
+        let wrapper = ProviderFailoverWrapper::new(primary, fallback);
+        let (step, usage) = wrapper.next_step_metered("task", &[]).unwrap();
+        assert!(
+            matches!(step, Err(AgentError::Parse(_))),
+            "the parse error is surfaced (the run fails closed) — NOT failed over"
+        );
+        assert_eq!(
+            usage.unwrap().provider_kind,
+            friday_core::ProviderKind::DeepSeek,
+            "billed ONCE on DeepSeek — the successful-but-unparseable chat"
+        );
+        assert_eq!(
+            wrapper.fallback.calls(),
+            0,
+            "NO second call — the double-bill guard holds"
+        );
+        assert_eq!(wrapper.primary.calls(), 1);
+    }
+
+    #[test]
+    fn malformed_400_never_fails_over() {
+        let primary =
+            ScriptedClient::new(|| Err(deepseek_route(DeepSeekError::ClientError { status: 400 })));
+        let fallback = ScriptedClient::new(claude_finish_with_anthropic_usage);
+        let wrapper = ProviderFailoverWrapper::new(primary, fallback);
+        let err = wrapper.next_step_metered("task", &[]).unwrap_err();
+        assert!(
+            matches!(
+                err,
+                AgentError::Route(DeepSeekError::ClientError { status: 400 })
+            ),
+            "the primary's 400 is surfaced unchanged"
+        );
+        assert_eq!(
+            wrapper.fallback.calls(),
+            0,
+            "a malformed request is not failed over"
+        );
+    }
+
+    #[test]
+    fn auth_error_never_fails_over() {
+        let primary = ScriptedClient::new(|| Err(deepseek_route(DeepSeekError::Auth(401))));
+        let fallback = ScriptedClient::new(claude_finish_with_anthropic_usage);
+        let wrapper = ProviderFailoverWrapper::new(primary, fallback);
+        let err = wrapper.next_step_metered("task", &[]).unwrap_err();
+        assert!(matches!(err, AgentError::Route(DeepSeekError::Auth(401))));
+        assert_eq!(
+            wrapper.fallback.calls(),
+            0,
+            "a broken credential is operator-actionable, not failed over"
+        );
+    }
+
+    #[test]
+    fn primary_success_never_calls_fallback() {
+        // The happy path: primary 200s + parses. The fallback must never be touched.
+        let primary = ScriptedClient::new(|| {
+            Ok((
+                Ok(AgentStep::Finish {
+                    message: "deepseek answer".into(),
+                }),
+                Some(BilledUsage {
+                    provider_kind: friday_core::ProviderKind::DeepSeek,
+                    model: "deepseek-v4-flash".to_string(),
+                    prompt_tokens: 10,
+                    completion_tokens: 5,
+                }),
+            ))
+        });
+        let fallback = ScriptedClient::new(claude_finish_with_anthropic_usage);
+        let wrapper = ProviderFailoverWrapper::new(primary, fallback);
+        let (step, usage) = wrapper.next_step_metered("task", &[]).unwrap();
+        assert_eq!(
+            step.unwrap(),
+            AgentStep::Finish {
+                message: "deepseek answer".into()
+            }
+        );
+        assert_eq!(
+            usage.unwrap().provider_kind,
+            friday_core::ProviderKind::DeepSeek
+        );
+        assert_eq!(
+            wrapper.fallback.calls(),
+            0,
+            "primary succeeded — no failover"
+        );
+    }
+}

--- a/rust-core/crates/friday-hub/src/runtime.rs
+++ b/rust-core/crates/friday-hub/src/runtime.rs
@@ -141,6 +141,12 @@ pub enum HubInitError {
     /// to "no key" (which would be a different, fail-closed-Pause state). An UNSET source
     /// is NOT an error (it is `operator_vk = None` ⇒ fail-closed Pause).
     OperatorVk(crate::operator_vk::OperatorVkError),
+    /// #26 — `FRIDAY_PROVIDER_FAILOVER` was ON but no Claude fallback client was wired
+    /// (`FRIDAY_CLAUDE_ROUTE_ENABLED` was OFF, or its key was absent). A failover wrapper
+    /// with no fallback is meaningless, so this is a HARD boot error, NEVER a silent no-op:
+    /// enabling failover without a fallback is an operator misconfiguration that must be
+    /// surfaced (carries no secret — a fixed message).
+    FailoverMisconfigured,
 }
 
 impl std::fmt::Display for HubInitError {
@@ -155,6 +161,12 @@ impl std::fmt::Display for HubInitError {
             HubInitError::OperatorVk(e) => {
                 write!(f, "operator verify key provisioning failed: {e:?}")
             }
+            HubInitError::FailoverMisconfigured => write!(
+                f,
+                "provider failover ({}) is ON but no Claude fallback is wired \
+                 (enable {} with a valid Anthropic key)",
+                ENV_PROVIDER_FAILOVER, ENV_CLAUDE_ROUTE_ENABLED
+            ),
         }
     }
 }
@@ -174,6 +186,19 @@ pub struct HubRuntime<T: Transport> {
     /// field stays `None`, AND the `claude` route is registered `available: false` so
     /// `select_route` never picks it. The DeepSeek path is unchanged.
     claude: Option<Box<dyn AgentLlmClient>>,
+    /// Registry gap #26 — DARK / default-off provider FAILOVER wrapper (deepseek→claude).
+    /// `None` in every build EXCEPT a `live()` build whose `FRIDAY_PROVIDER_FAILOVER` gate
+    /// is on AND a Claude client is present. When `Some`, it is a boxed
+    /// [`crate::provider_failover::ProviderFailoverWrapper`] whose primary is the DeepSeek
+    /// agent client and whose fallback is the Claude client — and it BECOMES the resolved
+    /// `&dyn AgentLlmClient` the deepseek route dispatches (see [`Self::loop_client`] /
+    /// `resolve`), so the live loop transparently fails over. It is an EXECUTION-layer
+    /// resilience wrapper, NOT a route-selection change: selection still honestly reports
+    /// `provider_id="deepseek"` (UNW-003 routing-truth). Default-off: this field stays
+    /// `None` (the wrapper is never constructed) ⇒ the bare `deepseek` client dispatches ⇒
+    /// byte-identical to today. `self.deepseek` (and its `.inner()` used by post-run memory
+    /// extraction — which must NOT failover) is retained UNTOUCHED alongside this.
+    failover: Option<Box<dyn AgentLlmClient>>,
     /// C1 PR-B — DARK / default-off Codex (app-server) route executor. MIRRORS `claude`'s
     /// dark-by-default discipline: `None` in every build EXCEPT a `live()` build whose
     /// `FRIDAY_CODEX_ROUTE_ENABLED` gate is on. UNLIKE `claude` (a `dyn AgentLlmClient`), this is
@@ -283,6 +308,11 @@ impl<T: Transport> HubRuntime<T> {
             // and only when the default-OFF `FRIDAY_CLAUDE_ROUTE_ENABLED` gate is on
             // (via [`Self::with_claude`]). Tests + the prod default leave it `None`.
             claude: None,
+            // #26: DARK — no failover wrapper by default. Only `maybe_wrap_for_failover`
+            // (reached from `live()` behind the default-OFF `FRIDAY_PROVIDER_FAILOVER` gate)
+            // may populate this. Tests + the prod default leave it `None` ⇒ the bare
+            // `deepseek` client dispatches ⇒ byte-identical to today.
+            failover: None,
             // C1-3: DARK — no Codex client by default (mirrors `claude`). Only `live()` may
             // populate this, and only when the default-OFF `FRIDAY_CODEX_ROUTE_ENABLED` gate
             // is on (via [`Self::with_codex`]). Tests + the prod default leave it `None`.
@@ -304,6 +334,96 @@ impl<T: Transport> HubRuntime<T> {
     pub fn with_claude(mut self, claude: Box<dyn AgentLlmClient>) -> Self {
         self.claude = Some(claude);
         self
+    }
+
+    /// Registry gap #26 — attach the DARK provider-failover wrapper (builder, default-off).
+    /// The ONLY way the `failover` field becomes `Some`. The boxed wrapper IS a
+    /// [`crate::provider_failover::ProviderFailoverWrapper`] (deepseek primary + claude
+    /// fallback); once attached it BECOMES the resolved `&dyn AgentLlmClient` the deepseek
+    /// route dispatches (see [`Self::loop_client`] / `resolve`). It does NOT touch the
+    /// route registry or any default — selection still reports `provider_id="deepseek"`.
+    /// Consumes + returns `self` so `maybe_wrap_for_failover` can chain it behind the env
+    /// gate. Tests inject a mock-leg wrapper through here directly.
+    pub fn with_failover(mut self, failover: Box<dyn AgentLlmClient>) -> Self {
+        self.failover = Some(failover);
+        self
+    }
+
+    /// Registry gap #26 — the client the LIVE agent loop drives for a `deepseek`-routed run.
+    /// When the failover wrapper is attached (the gated `live()` path with
+    /// `FRIDAY_PROVIDER_FAILOVER=1` + Claude present) it returns the WRAPPER (deepseek→claude
+    /// failover); otherwise the bare DeepSeek client — byte-identical to today. This is the
+    /// SINGLE accessor every deepseek-routed loop entry resolves through (the direct
+    /// `&self.deepseek` callers + the `resolve()` chokepoint), so failover applies uniformly
+    /// without each call-site re-deciding. It NEVER affects `self.deepseek.inner()` (the
+    /// structured-inference client used by post-run memory extraction — which must stay on
+    /// DeepSeek, never failover).
+    fn loop_client(&self) -> &dyn AgentLlmClient {
+        match self.failover.as_deref() {
+            Some(wrapper) => wrapper,
+            None => &self.deepseek,
+        }
+    }
+
+    /// #26 — read the default-OFF `FRIDAY_PROVIDER_FAILOVER` gate and, only when it is on,
+    /// wrap the deepseek route in the deepseek→claude failover wrapper (DARK). The env read
+    /// is split from the logic so the decision is unit-testable WITHOUT `set_var` (the
+    /// program-standard env-race-free idiom): the real work is in
+    /// [`Self::wrap_for_failover_flagged`]. Generic over `T` (it boxes the wrapper to
+    /// `dyn AgentLlmClient`, erasing the concrete leg types) so the test runtime drives it.
+    fn maybe_wrap_for_failover(self) -> Result<Self, HubInitError> {
+        let enabled = provider_failover_from(std::env::var(ENV_PROVIDER_FAILOVER).ok().as_deref());
+        self.wrap_for_failover_flagged(enabled)
+    }
+
+    /// #26 — the testable inner of [`Self::maybe_wrap_for_failover`].
+    ///
+    /// - `enabled == false` ⇒ `Ok(self)` UNCHANGED: the `failover` field stays `None`, the
+    ///   deepseek route dispatches the bare client — BYTE-IDENTICAL to today. No client is
+    ///   built, no env is read. This is the prod default.
+    /// - `enabled == true` but NO Claude fallback is wired (`self.claude.is_none()`) ⇒
+    ///   `Err(HubInitError::FailoverMisconfigured)`: a HARD boot error, never a silent
+    ///   no-op (a failover wrapper with no fallback is meaningless). Checked BEFORE any
+    ///   client construction, so a misconfigured boot fails fast + spends nothing.
+    /// - `enabled == true` AND Claude present ⇒ build the wrapper and attach it via
+    ///   [`Self::with_failover`]. The wrapper's PRIMARY is a FRESH DeepSeek agent client
+    ///   (from the SAME env key the boot `self.deepseek` used) and its FALLBACK a FRESH
+    ///   Claude agent client (from the SAME env key `maybe_attach_claude_from_env` used) —
+    ///   so `self.deepseek` (and its `.inner()` for memory extraction, which must NOT
+    ///   failover) AND the independent `self.claude` route both stay INTACT and untouched.
+    ///   The fresh primary is a `DeepSeekClient<UreqTransport>` regardless of `T` (boxed to
+    ///   `dyn`, so the method stays generic); reading the env keys spends no network/quota —
+    ///   and the only path that reaches this build branch is the gated `live()` (where the
+    ///   keys are present). A missing key here is a hard error, never a silent degrade.
+    ///
+    /// HONEST scope: the `enabled && claude present` build branch is reached only from
+    /// `live()` (it builds real env-keyed clients). The deterministic, no-key proofs are:
+    /// the wrapper's own behavior (src/provider_failover.rs tests + tests/provider_failover.rs
+    /// driving the wrapper through the real loop) and the two DECISION branches above
+    /// (`flag-off byte-identical` + `flag-on-Claude-absent hard error`) which this method
+    /// exposes for direct test without env or a real key.
+    fn wrap_for_failover_flagged(self, enabled: bool) -> Result<Self, HubInitError> {
+        if !enabled {
+            // OFF ⇒ wrapper not constructed ⇒ byte-identical to today.
+            return Ok(self);
+        }
+        // ON: a fallback is MANDATORY — fail closed (hard error) if Claude was not wired.
+        if self.claude.is_none() {
+            return Err(HubInitError::FailoverMisconfigured);
+        }
+        // ON + Claude present: build FRESH primary + fallback from env (the `live()` path),
+        // leaving `self.deepseek` and `self.claude` untouched.
+        let primary_client = DeepSeekClient::from_env().map_err(HubInitError::DeepSeek)?;
+        let primary = DeepSeekAgentLlmClient::new(primary_client);
+        let fallback_client =
+            friday_anthropic::ClaudeClient::from_env().map_err(HubInitError::Claude)?;
+        let fallback =
+            crate::ClaudeAgentLlmClient::new(fallback_client, friday_anthropic::DEFAULT_MODEL);
+        let wrapper = crate::provider_failover::ProviderFailoverWrapper::new(
+            primary,
+            Box::new(fallback) as Box<dyn AgentLlmClient>,
+        );
+        Ok(self.with_failover(Box::new(wrapper)))
     }
 
     /// C1 PR-B — attach the DARK Codex route EXECUTOR (builder, default-off). MIRRORS
@@ -1023,8 +1143,12 @@ impl<T: Transport> HubRuntime<T> {
         // gate-enforced; a mutating tool would Pause — Phase 1 admits none), appends this
         // turn, and owner-wires a Finished answer's `run_result`. NO new loop code.
         let approve = |req: &MutatingActionRequest| self.approval.approve(req);
+        // #26: this DeepSeek-routed sessioned entry drives `loop_client()` (the failover
+        // wrapper when the DARK gate is on; the bare DeepSeek client otherwise) so failover
+        // applies on the SAME deepseek route the resolver chokepoint serves. Default-off ⇒
+        // `&self.deepseek` ⇒ byte-identical to today.
         let outcome = match run_session_loop(
-            &self.deepseek,
+            self.loop_client(),
             &self.executor,
             self.db.conn(),
             run_id,
@@ -2076,9 +2200,15 @@ impl HubRuntime<UreqTransport> {
         // (`FRIDAY_CODEX_ROUTE_ENABLED`). Codex attach is INFALLIBLE (it reads no credential —
         // the local app-server is spawned lazily, per-turn / at validate), so it chains after
         // the fallible Claude attach without its own `?`.
-        Ok(runtime
+        //
+        // #26 — FINALLY, behind its OWN default-OFF gate (`FRIDAY_PROVIDER_FAILOVER`), wrap
+        // the deepseek route in the deepseek→claude failover wrapper. ORDERED AFTER
+        // `maybe_attach_claude_from_env` so it can see whether Claude was wired: flag ON but
+        // Claude absent is a HARD boot error (never a silent no-op). It is fallible.
+        runtime
             .maybe_attach_claude_from_env()?
-            .maybe_attach_codex_from_env())
+            .maybe_attach_codex_from_env()
+            .maybe_wrap_for_failover()
     }
 
     /// S7 — read the default-OFF gate and, only when it is on, build the live Claude
@@ -2163,6 +2293,23 @@ fn codex_route_enabled_from_env() -> bool {
     matches!(std::env::var(ENV_CODEX_ROUTE_ENABLED), Ok(v) if v.trim() == "1")
 }
 
+/// #26 — the default-OFF environment gate that governs whether [`HubRuntime::live`] wraps
+/// the deepseek route in the deepseek→claude FAILOVER wrapper. MIRRORS the route gates'
+/// narrow discipline: ON only when `FRIDAY_PROVIDER_FAILOVER` is exactly `"1"` (after
+/// trimming). UNSET / empty / `"0"` / any other value ⇒ OFF (unchanged prod default: the
+/// wrapper is never constructed, the bare deepseek client dispatches — BYTE-IDENTICAL to
+/// today). Kept narrow + explicit so this provider-substitution path cannot be enabled by
+/// accident.
+pub const ENV_PROVIDER_FAILOVER: &str = "FRIDAY_PROVIDER_FAILOVER";
+
+/// Pure flag-matcher for [`ENV_PROVIDER_FAILOVER`] (env read split out so it is
+/// unit-testable without `set_var` — the program-standard env-race-free idiom this file
+/// uses). DEFAULT-OFF: `None` (unset) ⇒ false; ON only for the exact opt-in value `"1"`
+/// (trimmed); everything else ⇒ false.
+fn provider_failover_from(raw: Option<&str>) -> bool {
+    matches!(raw.map(str::trim), Some("1"))
+}
+
 /// NS-6 — the default-OFF environment gate that governs whether the mission-bound agent
 /// handoff MINTS + PERSISTS + LINKS a destination-bound Context Passport for the WorkItem's
 /// lane/target. ON only when `FRIDAY_PASSPORT_MINT` is exactly `"1"` (after trimming). UNSET /
@@ -2245,7 +2392,12 @@ impl<T: Transport> ProviderClientResolver for HubRuntime<T> {
     /// (NoClientForProvider) rather than driving the WRONG conn-less path.
     fn resolve(&self, route: &ProviderRoute) -> Option<&dyn AgentLlmClient> {
         match route.provider_id.as_str() {
-            "deepseek" => Some(&self.deepseek),
+            // #26: when the DARK failover wrapper is attached (gated `live()` +
+            // `FRIDAY_PROVIDER_FAILOVER=1` + Claude present) the deepseek route dispatches
+            // the WRAPPER (deepseek→claude failover); otherwise the bare client. Selection
+            // still reports `provider_id="deepseek"` — failover is execution-layer, NOT a
+            // reroute (UNW-003 routing-truth). Default-off ⇒ `loop_client()` is `&self.deepseek`.
+            "deepseek" => Some(self.loop_client()),
             // DARK: `as_deref()` yields `None` whenever the Claude client was not wired
             // (the default), so the default-off route fail-closes exactly like any
             // other unwired provider.
@@ -2387,6 +2539,88 @@ mod tests {
         )
         .unwrap();
         (rt, ws, post_calls) // TempDir guard keeps the workspace alive; counter for the no-hidden test
+    }
+
+    // ── #26: provider-failover wiring DECISION (flag-off byte-identical / flag-on-no-fallback) ──
+    //
+    // These two tests cover the `wrap_for_failover_flagged` DECISION branches WITHOUT a real key
+    // (the `enabled && claude present` build branch reads env keys and is reached only from
+    // `live()`; the wrapper's BEHAVIOR is proven deterministically in src/provider_failover.rs +
+    // tests/provider_failover.rs). The flag-matcher truth table is pinned separately.
+
+    /// #26 — the pure flag matcher: ON only for exact trimmed `"1"`; everything else OFF
+    /// (the default). Mirrors the route gates' narrow discipline.
+    #[test]
+    fn provider_failover_flag_matcher_is_exact_one_default_off() {
+        assert!(provider_failover_from(Some("1")));
+        assert!(provider_failover_from(Some(" 1 ")), "trimmed");
+        for off in [
+            None,
+            Some(""),
+            Some("0"),
+            Some("true"),
+            Some("yes"),
+            Some("11"),
+            Some("1x"),
+        ] {
+            assert!(
+                !provider_failover_from(off),
+                "{off:?} must be OFF (default)"
+            );
+        }
+    }
+
+    /// #26 — flag-OFF ⇒ the wrapper is NOT constructed: the `failover` field stays `None`, so
+    /// the deepseek route dispatches the bare client (byte-identical to today). Proven even
+    /// WITH a Claude client wired — flag-off short-circuits before any wrap.
+    #[test]
+    fn failover_flag_off_does_not_construct_wrapper_byte_identical() {
+        let (mut rt, _ws, _c) = runtime_with(
+            "failover-off",
+            &["{\"tool\":\"none\"}"],
+            Box::new(DenyAllApprovals),
+        );
+        rt = rt.with_claude(Box::new(StubClaudeMeteredClient::new(vec![], 11, 8)));
+        assert!(rt.failover.is_none(), "precondition: no wrapper yet");
+        let rt = rt
+            .wrap_for_failover_flagged(false)
+            .expect("flag-off is infallible");
+        assert!(
+            rt.failover.is_none(),
+            "flag-OFF must NOT construct the failover wrapper — the bare deepseek client dispatches"
+        );
+        // The deepseek route still resolves to a client (the bare one) — selectable, unchanged.
+        let deepseek_route = ProviderRoute {
+            provider_id: "deepseek".into(),
+            ..RouteRegistry::autonomous_baseline()
+                .get("deepseek")
+                .unwrap()
+                .clone()
+        };
+        assert!(
+            rt.resolve(&deepseek_route).is_some(),
+            "the deepseek route still dispatches the bare client"
+        );
+    }
+
+    /// #26 — flag-ON but NO Claude fallback wired ⇒ a HARD boot error
+    /// (`FailoverMisconfigured`), NEVER a silent no-op. Checked BEFORE any client build, so a
+    /// misconfigured boot fails fast.
+    #[test]
+    fn failover_flag_on_without_claude_is_hard_boot_error() {
+        let (rt, _ws, _c) = runtime_with(
+            "failover-no-claude",
+            &["{\"tool\":\"none\"}"],
+            Box::new(DenyAllApprovals),
+        );
+        assert!(rt.claude.is_none(), "precondition: no Claude fallback");
+        // `HubRuntime` is not `Debug`, so match on the result directly rather than
+        // `expect_err` (which would need the Ok type to be Debug).
+        match rt.wrap_for_failover_flagged(true) {
+            Err(HubInitError::FailoverMisconfigured) => {}
+            Err(other) => panic!("expected FailoverMisconfigured, got {other:?}"),
+            Ok(_) => panic!("flag-ON with no fallback must be a hard error (no silent no-op)"),
+        }
     }
 
     // ── TP-PR2 (H-1): the live boot AgentActionContext PRODUCER ──────────────────────────

--- a/rust-core/crates/friday-hub/tests/provider_failover.rs
+++ b/rust-core/crates/friday-hub/tests/provider_failover.rs
@@ -1,0 +1,264 @@
+//! Registry gap #26 — provider FAILOVER (deepseek → claude) on the LIVE agent loop,
+//! proven END-TO-END through the real `friday_hub::run_loop` against a real Hub `Db`.
+//!
+//! This is the loop-closing e2e the prod-flag gate (#27) maps `FRIDAY_PROVIDER_FAILOVER`
+//! to. RGG CI is DeepSeek-ONLY, so BOTH provider legs are MOCKED (no key, no network):
+//! the wrapper's primary leg returns a FAILOVER-WORTHY DeepSeek route error, and its
+//! fallback leg returns a finishing Claude turn with Anthropic-tagged usage. Driving the
+//! wrapper THROUGH the real loop proves the WHOLE chain: a 402/429/5xx on the primary
+//! fails over to the fallback, the loop FINISHES on the fallback's answer, and the call is
+//! BILLED to `anthropic` (api.anthropic.com) — never mis-attributed as DeepSeek, never
+//! double-billed.
+//!
+//! The complementary deterministic proofs live in-crate:
+//!   - src/provider_failover.rs tests — the wrapper/classifier behavior per case
+//!     (402/429/5xx→failover; parse/400/auth→no-failover; double-bill guard).
+//!   - src/runtime.rs tests — the wiring DECISION (flag-off byte-identical; flag-on +
+//!     no-Claude hard boot error; the pure flag matcher).
+
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use friday_core::gate::MutatingActionRequest;
+use friday_hub::provider_failover::ProviderFailoverWrapper;
+use friday_hub::{
+    run_loop, AgentError, AgentLlmClient, AgentStep, BilledUsage, FsToolExecutor, LoopStatus,
+    MeteredStep, RawToolCall, TurnTrace,
+};
+use friday_storage::Db;
+
+static C: AtomicU64 = AtomicU64::new(0);
+const NOW: i64 = 1_700_000_000_000;
+const SECRET: &[u8] = b"failover-e2e-secret-0123456789012345";
+
+fn temp_db(tag: &str) -> String {
+    std::env::temp_dir()
+        .join(format!(
+            "friday-failover-{}-{}-{}.sqlite",
+            std::process::id(),
+            tag,
+            C.fetch_add(1, Ordering::Relaxed)
+        ))
+        .to_string_lossy()
+        .into_owned()
+}
+
+fn temp_ws(tag: &str) -> std::path::PathBuf {
+    let p = std::env::temp_dir().join(format!(
+        "friday-failover-ws-{}-{}-{}",
+        std::process::id(),
+        tag,
+        C.fetch_add(1, Ordering::Relaxed)
+    ));
+    std::fs::create_dir_all(&p).unwrap();
+    p
+}
+
+/// The PRIMARY (deepseek) leg: every metered step returns the configured OUTER route
+/// error (a failover-worthy DeepSeek failure). That the loop nonetheless FINISHES on the
+/// fallback's answer (billed `anthropic`) is the proof the primary was tried + failed over.
+struct FailingPrimary {
+    err: friday_deepseek::DeepSeekError,
+}
+impl FailingPrimary {
+    fn new(err: friday_deepseek::DeepSeekError) -> Self {
+        Self { err }
+    }
+}
+impl AgentLlmClient for FailingPrimary {
+    fn propose_tool_call(&self, _task: &str) -> Result<RawToolCall, AgentError> {
+        unreachable!("the loop drives next_step_metered")
+    }
+    fn next_step_metered(
+        &self,
+        _task: &str,
+        _history: &[TurnTrace],
+    ) -> Result<MeteredStep, AgentError> {
+        Err(AgentError::Route(self.err.clone()))
+    }
+}
+
+/// The FALLBACK (claude) leg: finishes with the given answer and surfaces Anthropic-tagged
+/// usage exactly as the live `ClaudeAgentLlmClient::next_step_metered` would after a real
+/// chat.
+struct FinishingFallback {
+    answer: String,
+}
+impl FinishingFallback {
+    fn new(answer: &str) -> Self {
+        Self {
+            answer: answer.to_string(),
+        }
+    }
+}
+impl AgentLlmClient for FinishingFallback {
+    fn propose_tool_call(&self, _task: &str) -> Result<RawToolCall, AgentError> {
+        unreachable!("the loop drives next_step_metered")
+    }
+    fn next_step_metered(
+        &self,
+        _task: &str,
+        _history: &[TurnTrace],
+    ) -> Result<MeteredStep, AgentError> {
+        Ok((
+            Ok(AgentStep::Finish {
+                message: self.answer.clone(),
+            }),
+            Some(BilledUsage {
+                provider_kind: friday_core::ProviderKind::Anthropic,
+                model: "claude-opus-4-8".to_string(),
+                prompt_tokens: 11,
+                completion_tokens: 8,
+            }),
+        ))
+    }
+}
+
+/// Run the wrapper through the REAL loop and return (outcome, the run's billed rows). The
+/// OBSERVABLE loop effect — `Finished` on the fallback's answer + a single `anthropic`
+/// billed row — is the proof the primary failed over to the fallback exactly once.
+fn run_failover_loop(
+    tag: &str,
+    primary_err: friday_deepseek::DeepSeekError,
+) -> (
+    friday_hub::LoopOutcome,
+    Vec<friday_storage::RunTokenUsageRow>,
+) {
+    let db = Db::open_hub(&temp_db(tag)).unwrap();
+    let ws = temp_ws(tag);
+    let executor = FsToolExecutor::new(ws);
+    friday_storage::agent_run::create_run(db.conn(), "run-f", "say pong", NOW).unwrap();
+
+    let primary = FailingPrimary::new(primary_err);
+    let fallback = FinishingFallback::new("PONG");
+    let wrapper = ProviderFailoverWrapper::new(primary, fallback);
+
+    // No approval fn fires (the fallback Finishes — no mutating tool), `_secret` unused.
+    let no_approve = |_req: &MutatingActionRequest| None;
+    let outcome = run_loop(
+        &wrapper,
+        &executor,
+        db.conn(),
+        "run-f",
+        "say pong",
+        "", // no recall preamble
+        SECRET,
+        &no_approve,
+        4,
+        NOW,
+    )
+    .unwrap();
+
+    let rows = db.list_run_token_usage("run-f").unwrap();
+    (outcome, rows)
+}
+
+/// Assert the loop FINISHED on the fallback's answer and billed EXACTLY ONE row, to
+/// Anthropic (api.anthropic.com) — billing-truth across failover, no double-bill, never
+/// mis-attributed as DeepSeek.
+fn assert_failover_finished_billed_anthropic(
+    outcome: &friday_hub::LoopOutcome,
+    rows: &[friday_storage::RunTokenUsageRow],
+) {
+    assert_eq!(
+        outcome.status,
+        LoopStatus::Finished,
+        "the loop must FINISH on the fallback's answer after failover"
+    );
+    assert_eq!(
+        outcome.final_message.as_deref(),
+        Some("PONG"),
+        "the fallback's answer is delivered"
+    );
+    assert_eq!(
+        rows.len(),
+        1,
+        "EXACTLY one billed row — the fallback turn; the failed primary attempt bills nothing (no double-bill)"
+    );
+    let row = &rows[0];
+    assert_eq!(
+        row.provider_kind, "anthropic",
+        "the failover call is billed as Anthropic — never mis-attributed as DeepSeek"
+    );
+    assert_eq!(row.base_url_host, "api.anthropic.com");
+    assert!(
+        !row.fallback,
+        "the chat itself is a non-fallback Anthropic call"
+    );
+    assert_eq!(row.prompt_tokens, 11);
+    assert_eq!(row.completion_tokens, 8);
+    assert_eq!(row.total_tokens, 19);
+}
+
+/// THE loop-closing e2e the #27 gate maps to: a DeepSeek 402 (quota) on the live loop
+/// FAILS OVER to Claude, the loop FINISHES on Claude's answer, and the turn is BILLED to
+/// Anthropic (one row, never DeepSeek, never double-billed).
+#[test]
+fn quota_402_fails_over_to_claude_finishes_and_bills_anthropic() {
+    let (outcome, rows) = run_failover_loop(
+        "402",
+        friday_deepseek::DeepSeekError::ClientError { status: 402 },
+    );
+    assert_failover_finished_billed_anthropic(&outcome, &rows);
+}
+
+/// A DeepSeek 429 (rate-limit) likewise fails over to Claude and bills Anthropic.
+#[test]
+fn rate_limit_429_fails_over_to_claude_finishes_and_bills_anthropic() {
+    let (outcome, rows) = run_failover_loop(
+        "429",
+        friday_deepseek::DeepSeekError::ClientError { status: 429 },
+    );
+    assert_failover_finished_billed_anthropic(&outcome, &rows);
+}
+
+/// A DeepSeek 5xx (ProviderUnavailable) likewise fails over to Claude and bills Anthropic.
+#[test]
+fn provider_unavailable_5xx_fails_over_to_claude_finishes_and_bills_anthropic() {
+    let (outcome, rows) = run_failover_loop(
+        "5xx",
+        friday_deepseek::DeepSeekError::ProviderUnavailable("HTTP 503".into()),
+    );
+    assert_failover_finished_billed_anthropic(&outcome, &rows);
+}
+
+/// NO-FAILOVER through the real loop: a DeepSeek 400 (malformed) does NOT fail over — the
+/// loop ERRORS closed on the primary's error, the fallback is never reached, and NOTHING
+/// is billed (a route error produces no usage). The double-bill / silent-substitute guard,
+/// proven end-to-end.
+#[test]
+fn malformed_400_does_not_fail_over_loop_errors_no_bill() {
+    let db = Db::open_hub(&temp_db("400")).unwrap();
+    let ws = temp_ws("400");
+    let executor = FsToolExecutor::new(ws);
+    friday_storage::agent_run::create_run(db.conn(), "run-f", "say pong", NOW).unwrap();
+
+    let primary = FailingPrimary::new(friday_deepseek::DeepSeekError::ClientError { status: 400 });
+    let fallback = FinishingFallback::new("PONG");
+    let wrapper = ProviderFailoverWrapper::new(primary, fallback);
+    let no_approve = |_req: &MutatingActionRequest| None;
+
+    let outcome = run_loop(
+        &wrapper,
+        &executor,
+        db.conn(),
+        "run-f",
+        "say pong",
+        "",
+        SECRET,
+        &no_approve,
+        4,
+        NOW,
+    )
+    .unwrap();
+
+    assert_eq!(
+        outcome.status,
+        LoopStatus::Errored,
+        "a malformed (400) primary error is surfaced — never failed over"
+    );
+    assert_eq!(
+        db.list_run_token_usage("run-f").unwrap().len(),
+        0,
+        "a route error produces no usage — NOTHING billed (no half-bill, no double-bill)"
+    );
+}


### PR DESCRIPTION
Closes registry gap **#26** — provider failover on the live agent loop (deepseek→claude). Operator-approved, born-current off main (`7c2144b4`, includes #767 crash-recovery). Default-OFF, dark, no-degrade.

## What this adds
The ONLY missing piece of multi-provider failover. Both `DeepSeekAgentLlmClient` (primary) and `ClaudeAgentLlmClient` (fallback) already exist + are wired selectable; this wraps them so a FAILOVER-worthy primary route failure retries the SAME call ONCE on the fallback, transparently behind the `AgentLlmClient` seam — the live loop's single model call-site (`run_loop_with_policy_flagged` → `client.next_step_metered`) gets failover with no loop change.

- **`provider_failover::ProviderFailoverWrapper<P,F>`** (new file) — impl `AgentLlmClient`, primary=deepseek + fallback=claude. On a failover-worthy OUTER error from the primary, retries on the fallback once; otherwise surfaces the primary error.
- **Own classifier `is_failover_worthy`** (NOT `retry::classify_deepseek`): failover on `ProviderUnavailable` (5xx/408/transport) + `ClientError{402 quota}` + `ClientError{429 rate-limit}`; NEVER on other 4xx (400/404/422), `Auth`/`CredentialMissing`, `NoModels`/`BadResponse`/`Core`, `AgentError::Model`, or `AgentError::Parse`.

## No-degrade criticals
- **Double-bill guard (billing-truth):** failover triggers on the OUTER `Err(AgentError)` ONLY. The inner parse-success shape `Ok((Err(Parse), Some(usage)))` (a chat that answered + billed but failed to parse) is an OUTER `Ok` → returned untouched: no second call, billed once on DeepSeek.
- **Billing-truth across failover:** the fallback call bills as `ProviderKind::Anthropic` (the Claude adapter's own `from_anthropic`); the failed primary attempt (a route error carries no usage) bills nothing extra.
- **Routing-truth (UNW-003):** the wrapper is the resolved `&dyn AgentLlmClient` (execution layer via a `loop_client()` accessor + the `resolve()` chokepoint), NOT a route-selection change — selection still reports `provider_id="deepseek"`. `self.deepseek` (and its `.inner()` for post-run memory extraction, which must NOT failover) is retained untouched.
- **Flag `FRIDAY_PROVIDER_FAILOVER`** (default-OFF, exact `"1"`, pure matcher): wrapper constructed via `maybe_wrap_for_failover()` AFTER `maybe_attach_claude_from_env()`, ONLY when ON AND Claude present; **HARD boot error** (`HubInitError::FailoverMisconfigured`) if ON but Claude absent (no silent no-op). Flag-OFF ⇒ wrapper not constructed ⇒ byte-identical to today.

## Manifest
`FRIDAY_PROVIDER_FAILOVER` added to `docs/ops/prod-flags-manifest.json` (`prod_state="dark"`) mapped to the loop-closing e2e — the #27 `prod-flag-tests` gate passes.

## Tests (RGG is DeepSeek-only — both legs mocked, no key/network)
- `src/provider_failover.rs` — per-case classifier + wrapper: 402/429/5xx→failover (answer + Anthropic billing); parse-error→NO failover (no 2nd call, no double-bill); 400→NO failover; auth→NO failover; primary-success→no fallback call.
- `tests/provider_failover.rs` — loop-closing e2e through the real `friday_hub::run_loop` against a real Hub `Db`: 402/429/5xx fail over to Claude, the loop Finishes "PONG", EXACTLY ONE token_ledger row attributed to `anthropic`/`api.anthropic.com`; 400 → loop errors closed, NO failover, NO bill.
- `src/runtime.rs` — wiring decision: flag-off byte-identical (wrapper not constructed), flag-on-but-Claude-absent hard boot error, exact-`"1"` flag matcher.

`cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test -p friday-hub` (702 lib + all integration suites) all green. `.secrets.baseline` unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)