### PR TITLE
test(friday-fs): deterministic setsid-escape bound (sync pipe defeats loaded-runner race)

### DIFF
--- a/rust-core/crates/friday-fs/src/lib.rs
+++ b/rust-core/crates/friday-fs/src/lib.rs
@@ -1862,9 +1862,10 @@ mod tests {
 
     /// SETSID-ESCAPE BOUND (the load-bearing reliability test). A `perl` LEADER forks a grandchild
     /// that calls `POSIX::setsid()` — ESCAPING the leader's process group — and then HOLDS stdout
-    /// open while sleeping far longer than the timeout+grace; the leader then EXITS immediately.
+    /// open while sleeping far longer than the timeout+grace; the leader then EXITS (but only AFTER
+    /// the grandchild has escaped — a sync pipe enforces that ordering deterministically, see below).
     /// `recv_timeout` returns the instant the leader exits (`timed_out=false`), and our process-group
-    /// SIGKILL can NOT reach the escaped grandchild, so the stdout pipe never EOFs. Pre-fix the
+    /// SIGKILL can NOT reach the (now-escaped) grandchild, so the stdout pipe never EOFs. Pre-fix the
     /// unbounded `r.join()` would block on the grandchild's full lifetime (or forever), pinning the
     /// calling thread. Post-fix the reader drain is deadline-bounded, so the call MUST return within
     /// ~timeout + grace regardless. We use a 1s timeout (grace 2s ⇒ ~3s drain deadline) and a
@@ -1879,10 +1880,27 @@ mod tests {
         // single-quoted arg so the script survives as a single literal token (no shell, no $expand).
         // The grandchild setsid()'s (new session ⇒ new process group ⇒ escapes the leader's group),
         // keeps STDOUT (it does NOT close it) and sleeps 30s; the leader prints + exits at once.
-        let script = "my $pid = fork(); \
+        //
+        // DETERMINISM (the only thing that made this flake): the grandchild MUST complete
+        // `POSIX::setsid()` — i.e. ESCAPE the leader's process group — BEFORE the leader exits.
+        // The helper's recv_timeout returns the instant the leader exits and then fires the
+        // unconditional `kill(-pid, SIGKILL)` against the leader's group. If a loaded runner had
+        // not yet scheduled the grandchild's `setsid()`, the grandchild would still be IN that group,
+        // get killed, close its stdout fd → the pipe would EOF and `output_truncated` would be FALSE
+        // (the helper behaving correctly for the scenario that actually happened — an un-escaped,
+        // in-group descendant IS the killpg's job — but NOT the escape scenario this test means to
+        // exercise). We close that window with a SYNC PIPE created inside perl (`pipe`, on its own
+        // fds — NOT stdout/stderr, so the drains are untouched): the grandchild does `setsid()`
+        // first, then writes one byte; the leader BLOCKS reading that byte before it prints/exits.
+        // So the leader cannot exit (and the helper's kill cannot fire) until the escape is a fact.
+        // Each side closes the pipe end it does not use, so a grandchild that died for any reason
+        // yields EOF on the leader's `sysread` (returns 0, the leader proceeds and exits) — never a
+        // hang. The leader's `print "leader\n"` is therefore still emitted only after the escape.
+        let script = "pipe(my $rd, my $wr) or exit 4; \
+                      my $pid = fork(); \
                       if (!defined $pid) { exit 3 } \
-                      if ($pid == 0) { POSIX::setsid(); $| = 1; print \"grandchild\\n\"; sleep 30; exit 0 } \
-                      print \"leader\\n\"; exit 0;";
+                      if ($pid == 0) { close $rd; POSIX::setsid(); $| = 1; print \"grandchild\\n\"; syswrite($wr, \"x\", 1); sleep 30; exit 0 } \
+                      close $wr; my $b; sysread($rd, $b, 1); print \"leader\\n\"; exit 0;";
         let command = format!("perl -MPOSIX -e '{script}'");
         let timeout = std::time::Duration::from_secs(1);
         // Bound: well above the ~3s drain deadline (loaded-CI headroom) yet far below the


### PR DESCRIPTION
## Problem
The pre-existing `run_command_setsid_escaped_grandchild_does_not_pin_thread` test (from #590) reddened main's `rust-core` push-event CI on `6a6572b6`. It passed on every PR branch but **flaked on the loaded main run**. Only the third assertion — `r.output_truncated == true` (lib.rs:1908) — flaked; the primary `elapsed < 8s` and `!timed_out` held.

## Root cause — test-race (b), NOT a logic race
The grandchild is forked into the leader's process group and only **escapes** it when `POSIX::setsid()` runs. The helper's `recv_timeout` returns the instant the leader exits, then fires the unconditional `kill(-pid, SIGKILL)` (`lib.rs:1314-1316`) against the leader's group.

On a **loaded runner**, the grandchild's `setsid()` could be unscheduled when that kill fired → the still-in-group grandchild was SIGKILL'd → it closed its stdout fd → the pipe EOF'd via the `Ok(0)` branch (`lib.rs:1230`) **without** setting truncated → `output_truncated == false`.

That is the helper behaving **correctly** for the scenario that actually happened (killing an un-escaped, in-group descendant is the killpg's documented job, `lib.rs:1292-1297`). The test simply never guaranteed the grandchild escaped before the leader exited. The drain/deadline logic is sound: when the grandchild truly escapes and holds the pipe, the drain deterministically falls through `poll-timeout → remaining.is_zero() → truncated=true` (`lib.rs:1203-1206`).

### Deterministic reproduction (evidence)
Inserting a 200 ms sleep **before** `setsid()` made the test fail deterministically: **0.02 s, immediate EOF, `truncated=false`** — exactly the flake signature (only assertion 3 fails).

## Fix
A **sync pipe** created inside perl (on its own fds — NOT stdout/stderr, so the drains are untouched). The grandchild does `setsid()` first, then writes one byte; the leader **blocks** on `sysread` before it prints/exits. So the leader cannot exit (and the helper's kill cannot fire) until the escape is a **fact** → the grandchild always survives and holds the pipe past the ~3 s drain deadline → `output_truncated` is set **deterministically**. Each side closes its unused pipe end, so a grandchild that died for any reason yields EOF (not a hang) on the leader's read.

## No-degrade
All three assertions are **preserved unchanged**:
- PRIMARY not-pinned: `elapsed < 8s` (the load-bearing security/correctness intent).
- `!timed_out` (leader exits on its own within the 1s timeout).
- deadline-cut intent: `output_truncated == true` (verifies the drain-deadline semantics — NOT deleted/weakened).

The fix makes the test **reliably exercise the escape scenario it was always meant to test** rather than loosening it. The 1s timeout is kept on purpose (bumping it would lengthen the drain, since `drain_deadline = timeout + grace`, and tighten the 8s bound).

## Verification
- Re-running the adversarial **200 ms-pre-`setsid` delay** ON TOP of the fix now **PASSES** (3.01 s) — proving the sync defeats the exact unfavorable schedule that previously broke it.
- **25× repeat loop under 3×-core CPU load = 0 failures.**
- Full `friday-fs` suite green (lib 18/18, integration all pass).
- `cargo fmt --all -- --check` clean; `cargo clippy --workspace --all-targets -- -D warnings` clean (exit 0).
- `detect-secrets-hook` clean; `.secrets.baseline` unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)