### PR TITLE
fix(hub): bind mission-spine dispatch owner to the authenticated owner (FIX-Q3b)

### DIFF
--- a/rust-core/crates/friday-hub/src/bin/hub_agent_run_server.rs
+++ b/rust-core/crates/friday-hub/src/bin/hub_agent_run_server.rs
@@ -1477,10 +1477,18 @@ fn serve_sealed_session<S: Read + Write, T: Transport>(
             // has never had a MissionIntakeRequest arm), the deploy-safety invariant.
             Message::MissionIntakeRequest { request } if mission_intake_enabled => {
                 let now_ms = now_ms();
+                // (FIX-Q3b) BIND the persisted Mission/conversation owner to the Rust-derived
+                // AUTHENTICATED owner (`runtime.policy().principal_id()` == the configured
+                // `--owner`), NOT the self-asserted `request.owner_principal` body field. A body
+                // owner that does not match the authenticated owner is fail-closed (writes ZERO
+                // rows) — mirroring the MemoryDecisionRequest arm. NO-DEGRADE: under single-peer
+                // the body owner already equals the configured owner (the same string the bound
+                // run forwards + the allowlist gates), so the live auto-dispatch path is unchanged.
                 let result = friday_hub::hub_server::mission_intake_result_for_db(
                     runtime.db(),
                     &env.msg_id,
                     request,
+                    runtime.policy().principal_id(),
                     now_ms,
                 );
                 eprintln!(
@@ -1509,10 +1517,15 @@ fn serve_sealed_session<S: Read + Write, T: Transport>(
             // echo below — BYTE-IDENTICAL to today (the server has never had this arm).
             Message::MissionLifecycleRequest { request } if mission_spine_dispatch_enabled => {
                 let now_ms = now_ms();
+                // (FIX-Q3b) BIND the transition to the Rust-derived AUTHENTICATED owner
+                // (`runtime.policy().principal_id()` == the configured `--owner`): the target
+                // Mission MUST be owned by it, else fail-closed (no transition). An unknown Mission
+                // still surfaces the existing not-found Error. NO-DEGRADE under single-peer.
                 let result = friday_hub::hub_server::mission_lifecycle_result_for_db(
                     runtime.db(),
                     &env.msg_id,
                     request,
+                    runtime.policy().principal_id(),
                     now_ms,
                 );
                 eprintln!(
@@ -1539,10 +1552,15 @@ fn serve_sealed_session<S: Read + Write, T: Transport>(
             // BYTE-IDENTICAL to today.
             Message::WorkItemStatusRequest { request } if mission_spine_dispatch_enabled => {
                 let now_ms = now_ms();
+                // (FIX-Q3b) BIND the transition to the Rust-derived AUTHENTICATED owner
+                // (`runtime.policy().principal_id()` == the configured `--owner`): the target
+                // WorkItem MUST be owned by it, else fail-closed (no transition). An unknown
+                // WorkItem still surfaces the existing not-found Error. NO-DEGRADE under single-peer.
                 let result = friday_hub::hub_server::work_item_status_result_for_db(
                     runtime.db(),
                     &env.msg_id,
                     request,
+                    runtime.policy().principal_id(),
                     now_ms,
                 );
                 eprintln!(
@@ -2763,6 +2781,18 @@ mod tests {
         )
     }
 
+    /// (FIX-Q3b) The SAME intake shape as [`mission_intake_request`] but with a SPOOFED
+    /// `owner_principal` — a principal that is NOT the configured/authenticated owner. The dispatch
+    /// arm binds the persisted owner to `runtime.policy().principal_id()` (== `OWNER`), so this
+    /// self-asserted body owner must be REJECTED (writes ZERO rows), never silently persisted.
+    fn mission_intake_request_spoofed_owner(msg_id: &str) -> Envelope {
+        let mut env = mission_intake_request(msg_id);
+        if let Message::MissionIntakeRequest { request } = &mut env.message {
+            request.owner_principal = "principal:not-the-owner".into();
+        }
+        env
+    }
+
     /// (NS-5) FLAG-ON: an inbound MissionIntakeRequest driven through the REAL dispatch path
     /// (`accept_one` → `serve_sealed_session`, NOT a direct `mission_intake_result_for_db` call)
     /// BIRTHS a Mission: it persists a Mission row + a WorkItem(Draft) + a SurfaceThread +
@@ -2939,6 +2969,145 @@ mod tests {
                 .unwrap()
                 .is_empty(),
             "flag OFF writes NO route_decision"
+        );
+    }
+
+    /// (FIX-Q3b) OWNER-SPOOF: with the mission-intake flag ON, an inbound MissionIntakeRequest whose
+    /// self-asserted `owner_principal` does NOT match the AUTHENTICATED owner
+    /// (`runtime.policy().principal_id()` == the configured `--owner`) is FAIL-CLOSED — a typed
+    /// `Error` that births NO Mission and writes ZERO rows. This closes the audit gap where a
+    /// self-asserted owner_principal was silently persisted (the FIX-Q3b precondition before
+    /// multi-owner / live-flip). The happy path (matching owner) is unchanged — proven by
+    /// `flag_on_mission_intake_births_a_mission_through_dispatch_and_writes_no_ledger`.
+    #[test]
+    fn flag_on_mission_intake_spoofed_owner_is_rejected_and_writes_zero_rows() {
+        let (rt, _ws) = mock_runtime("intake-spoof", OWNER);
+        let server_kp = DeviceKeypair::generate();
+        let listener = AgentRunWsListener::bind_loopback(0).unwrap();
+        let addr = listener.local_addr().unwrap();
+        let allowlist = vec![OWNER.to_string()];
+        let client_kp = DeviceKeypair::generate();
+        let peer_allowlist = allowlist_of(client_kp.public_bytes());
+        let client = spawn_client(addr, client_kp, |session, _nonce| {
+            // SPOOFED owner_principal — NOT the configured/authenticated owner.
+            let req = mission_intake_request_spoofed_owner("req-intake-spoof");
+            (req, session.clone(), session.clone())
+        });
+
+        let processed = listener
+            .accept_one(
+                &server_kp,
+                &rt,
+                &allowlist,
+                &peer_allowlist,
+                false, // run-control OFF
+                false, // mission-bound seam OFF
+                true,  // (NS-5) mission-intake ingress ON
+                false, // (KEYSTONE) mission-spine dispatch OFF
+                false, // memory-confirm ingress OFF
+                false, // (Loop4) per-run token surface OFF
+            )
+            .unwrap();
+        assert_eq!(
+            processed, 1,
+            "the spoofed intake is processed (then denied)"
+        );
+
+        // FAIL-CLOSED: a typed Error, NOT a MissionIntakeResult.
+        match client.join().unwrap().result.expect("a reply is sent") {
+            Message::Error { message, .. } => {
+                assert!(
+                    message.contains("owner_principal does not match the authenticated owner"),
+                    "the spoofed owner is rejected with the owner-binding error: {message}"
+                );
+            }
+            other => panic!("a spoofed owner_principal must be a typed Error, got {other:?}"),
+        }
+
+        // ZERO rows: no Mission/WorkItem/SurfaceThread/route_decision/conversation born under either
+        // the spoofed owner OR the authenticated owner. The intake fail-closed BEFORE any write.
+        let db = rt.db();
+        assert!(
+            db.get_mission("mission-ns5").unwrap().is_none(),
+            "a spoofed owner births NO Mission"
+        );
+        assert!(
+            db.get_work_item("work-ns5").unwrap().is_none(),
+            "a spoofed owner births NO WorkItem"
+        );
+        assert!(
+            db.get_surface_thread("surface-ns5-intake")
+                .unwrap()
+                .is_none(),
+            "a spoofed owner births NO SurfaceThread"
+        );
+        assert!(
+            db.get_friday_conversation("fconv_ns5_intake")
+                .unwrap()
+                .is_none(),
+            "a spoofed owner births NO conversation row"
+        );
+        assert!(
+            db.list_route_decisions_for_mission("mission-ns5")
+                .unwrap()
+                .is_empty(),
+            "a spoofed owner writes NO route_decision"
+        );
+    }
+
+    /// (FIX-Q3b) OWNER-BINDING: with the flag ON, the created Mission's conversation owner is the
+    /// AUTHENTICATED owner regardless of what the (matching) body field carried — the persisted
+    /// owner is BOUND to `runtime.policy().principal_id()`, never the raw body string. (Today the
+    /// body field MUST equal the authenticated owner to pass the binding gate; this test proves the
+    /// persisted value tracks the authenticated identity, the load-bearing invariant before
+    /// multi-owner.)
+    #[test]
+    fn flag_on_mission_intake_persists_authenticated_owner() {
+        let (rt, _ws) = mock_runtime("intake-owner-bind", OWNER);
+        let server_kp = DeviceKeypair::generate();
+        let listener = AgentRunWsListener::bind_loopback(0).unwrap();
+        let addr = listener.local_addr().unwrap();
+        let allowlist = vec![OWNER.to_string()];
+        let client_kp = DeviceKeypair::generate();
+        let peer_allowlist = allowlist_of(client_kp.public_bytes());
+        let client = spawn_client(addr, client_kp, |session, _nonce| {
+            let req = mission_intake_request("req-intake-owner-bind");
+            (req, session.clone(), session.clone())
+        });
+
+        let processed = listener
+            .accept_one(
+                &server_kp,
+                &rt,
+                &allowlist,
+                &peer_allowlist,
+                false,
+                false,
+                true, // mission-intake ON
+                false,
+                false,
+                false,
+            )
+            .unwrap();
+        assert_eq!(processed, 1, "one intake processed");
+        assert!(
+            matches!(
+                client.join().unwrap().result,
+                Some(Message::MissionIntakeResult { .. })
+            ),
+            "the matching-owner intake births a Mission"
+        );
+
+        // The persisted conversation owner == the AUTHENTICATED owner (OWNER), not a body-supplied
+        // string — the binding the audit fix requires.
+        let conversation = rt
+            .db()
+            .get_friday_conversation("fconv_ns5_intake")
+            .unwrap()
+            .expect("conversation row persisted");
+        assert_eq!(
+            conversation.owner_principal, OWNER,
+            "the persisted owner is BOUND to the authenticated owner"
         );
     }
 
@@ -3229,7 +3398,15 @@ mod tests {
             Message::MissionIntakeRequest { request } => request,
             _ => unreachable!("the seed builder produces a MissionIntakeRequest"),
         };
-        let env = friday_hub::hub_server::mission_intake_result_for_db(rt.db(), "seed", req, 1_000);
+        // (FIX-Q3b) The seed binds the persisted owner to the authenticated owner (OWNER), the
+        // same identity the live dispatch arm threads from `runtime.policy().principal_id()`.
+        let env = friday_hub::hub_server::mission_intake_result_for_db(
+            rt.db(),
+            "seed",
+            req,
+            Some(OWNER),
+            1_000,
+        );
         match env.message {
             Message::MissionIntakeResult { result } => {
                 assert_eq!(
@@ -3239,6 +3416,51 @@ mod tests {
             }
             other => panic!("seed intake must succeed, got {other:?}"),
         }
+    }
+
+    /// (FIX-Q3b) The principal a FOREIGN-owned seed Mission/WorkItem belongs to — deliberately NOT
+    /// the session's authenticated `OWNER`, so a cross-owner transition must fail-closed.
+    const FOREIGN_OWNER: &str = "principal:other-owner";
+
+    /// (FIX-Q3b) Seed a Mission + WorkItem owned by `FOREIGN_OWNER` (NOT the session owner) by
+    /// driving the intake free-fn with that authenticated owner directly. The body's
+    /// `owner_principal` is set to match so the birth succeeds — this is how a row owned by a
+    /// different principal exists in the (hypothetical multi-owner) DB. The canonical ids match
+    /// `mission_lifecycle_request` / `work_item_status_request` so the cross-owner KATs have a real,
+    /// foreign-owned target to be denied against.
+    fn seed_foreign_owned_mission_and_work_item<T: Transport>(rt: &HubRuntime<T>) {
+        let mut env = mission_intake_request("seed-foreign");
+        if let Message::MissionIntakeRequest { request } = &mut env.message {
+            request.owner_principal = FOREIGN_OWNER.into();
+        }
+        let req = match env.message {
+            Message::MissionIntakeRequest { request } => request,
+            _ => unreachable!("the seed builder produces a MissionIntakeRequest"),
+        };
+        let result = friday_hub::hub_server::mission_intake_result_for_db(
+            rt.db(),
+            "seed-foreign",
+            req,
+            Some(FOREIGN_OWNER),
+            1_000,
+        );
+        match result.message {
+            Message::MissionIntakeResult { result } => assert_eq!(
+                result.status, "ready",
+                "the foreign-owned seed births a ready Mission/WorkItem"
+            ),
+            other => panic!("foreign seed intake must succeed, got {other:?}"),
+        }
+        // Confirm the seeded owner really is the foreign principal (not OWNER).
+        assert_eq!(
+            rt.db()
+                .get_friday_conversation("fconv_ns5_intake")
+                .unwrap()
+                .unwrap()
+                .owner_principal,
+            FOREIGN_OWNER,
+            "the seed is owned by the foreign principal"
+        );
     }
 
     /// (KEYSTONE) A `MissionLifecycleRequest` envelope. No `auth_proof`: the sealed session IS the
@@ -3567,6 +3789,118 @@ mod tests {
         // The seeded (owner's own) WorkItem is untouched — no cross-bleed write.
         let work = rt.db().get_work_item("work-ns5").unwrap().unwrap();
         assert_eq!(work.status, friday_core::WorkItemStatus::ReadyToDispatch);
+    }
+
+    /// (FIX-Q3b) CROSS-OWNER MISSION-LIFECYCLE: with the flag ON, a MissionLifecycleRequest that
+    /// targets a Mission owned by a DIFFERENT principal (the session authenticated as `OWNER`, the
+    /// Mission owned by `FOREIGN_OWNER`) is FAIL-CLOSED — a typed `Error` that does NOT transition
+    /// the Mission. The transition binds to `runtime.policy().principal_id()`, not the request's
+    /// `actor_ref`/conversation field. (An UNKNOWN Mission keeps its existing not-found shape; this
+    /// is the EXISTS-but-not-owned arm.)
+    #[test]
+    fn flag_on_mission_lifecycle_cross_owner_is_rejected_no_transition() {
+        let (rt, _ws) = mock_runtime("spine-lifecycle-cross", OWNER);
+        seed_foreign_owned_mission_and_work_item(&rt);
+        let server_kp = DeviceKeypair::generate();
+        let listener = AgentRunWsListener::bind_loopback(0).unwrap();
+        let addr = listener.local_addr().unwrap();
+        let allowlist = vec![OWNER.to_string()];
+        let client_kp = DeviceKeypair::generate();
+        let peer_allowlist = allowlist_of(client_kp.public_bytes());
+        let client = spawn_client(addr, client_kp, |session, _nonce| {
+            let req = mission_lifecycle_request("req-lifecycle-cross", "paused");
+            (req, session.clone(), session.clone())
+        });
+
+        let processed = listener
+            .accept_one(
+                &server_kp,
+                &rt,
+                &allowlist,
+                &peer_allowlist,
+                false,
+                false,
+                false,
+                true, // mission-spine dispatch ON
+                false,
+                false,
+            )
+            .unwrap();
+        assert_eq!(
+            processed, 1,
+            "the cross-owner request is processed (then denied)"
+        );
+
+        match client.join().unwrap().result.expect("a reply is sent") {
+            Message::Error { message, .. } => assert!(
+                message.contains("not owned by the authenticated owner"),
+                "a cross-owner Mission lifecycle is owner-rejected: {message}"
+            ),
+            other => panic!("a cross-owner Mission lifecycle must be a typed Error, got {other:?}"),
+        }
+        // NO transition: the foreign-owned Mission stays Active (the seed's birth status).
+        let mission = rt.db().get_mission("mission-ns5").unwrap().unwrap();
+        assert_eq!(
+            mission.status,
+            friday_core::MissionStatus::Active,
+            "a cross-owner request never transitions the foreign-owned Mission"
+        );
+    }
+
+    /// (FIX-Q3b) CROSS-OWNER WORK-ITEM-STATUS: with the flag ON, a WorkItemStatusRequest that
+    /// targets a WorkItem owned (via its Mission's conversation) by a DIFFERENT principal is
+    /// FAIL-CLOSED — a typed `Error` that does NOT transition the WorkItem. The owner is resolved
+    /// from the WorkItem's Mission, compared to `runtime.policy().principal_id()`.
+    #[test]
+    fn flag_on_work_item_status_cross_owner_is_rejected_no_transition() {
+        let (rt, _ws) = mock_runtime("spine-workitem-cross", OWNER);
+        seed_foreign_owned_mission_and_work_item(&rt);
+        let server_kp = DeviceKeypair::generate();
+        let listener = AgentRunWsListener::bind_loopback(0).unwrap();
+        let addr = listener.local_addr().unwrap();
+        let allowlist = vec![OWNER.to_string()];
+        let client_kp = DeviceKeypair::generate();
+        let peer_allowlist = allowlist_of(client_kp.public_bytes());
+        let client = spawn_client(addr, client_kp, |session, _nonce| {
+            // Target the foreign-owned WorkItem ("work-ns5"), a status it WOULD otherwise accept.
+            let req =
+                work_item_status_request("req-workitem-cross", "work-ns5", "dispatched", None);
+            (req, session.clone(), session.clone())
+        });
+
+        let processed = listener
+            .accept_one(
+                &server_kp,
+                &rt,
+                &allowlist,
+                &peer_allowlist,
+                false,
+                false,
+                false,
+                true, // mission-spine dispatch ON
+                false,
+                false,
+            )
+            .unwrap();
+        assert_eq!(
+            processed, 1,
+            "the cross-owner request is processed (then denied)"
+        );
+
+        match client.join().unwrap().result.expect("a reply is sent") {
+            Message::Error { message, .. } => assert!(
+                message.contains("not owned by the authenticated owner"),
+                "a cross-owner WorkItem status is owner-rejected: {message}"
+            ),
+            other => panic!("a cross-owner WorkItem status must be a typed Error, got {other:?}"),
+        }
+        // NO transition: the foreign-owned WorkItem stays at its seeded ReadyToDispatch status.
+        let work = rt.db().get_work_item("work-ns5").unwrap().unwrap();
+        assert_eq!(
+            work.status,
+            friday_core::WorkItemStatus::ReadyToDispatch,
+            "a cross-owner request never transitions the foreign-owned WorkItem"
+        );
     }
 
     /// (KEYSTONE / KAT d) DEPLOY-SAFETY: with the flag OFF, BOTH a MissionLifecycleRequest and a
@@ -5326,6 +5660,132 @@ mod tests {
         assert_eq!(
             n, 1,
             "the sessionless dispatch creates exactly ONE ephemeral per-run session row"
+        );
+    }
+
+    /// (FIX-Q3b) IDENTITY FLOW end-to-end: the SAME owner principal threads through
+    /// authenticate_forwarded -> mission intake -> auto-dispatch -> run -> run_result. The session
+    /// authenticates as `OWNER` (`authenticate_forwarded` against the allowlist); the mission
+    /// intake binds the persisted Mission owner to that authenticated principal; the bound run
+    /// (the Rust equivalent of the auto-dispatch driver firing `startRun` with the intake's owner)
+    /// authenticates as the SAME principal and records its owner-scoped run answer + ephemeral
+    /// session under it. We assert ONE identity (`OWNER`) is the owner at EVERY hop — closing the
+    /// "no end-to-end identity flow exists today" gap. (Intake and the run are separate sealed
+    /// envelopes, so they use separate `accept_one` connections — transport-stateless, DB-stateful;
+    /// the binding is the persisted owner, not the connection.)
+    #[test]
+    fn identity_flows_through_authenticate_intake_dispatch_run_and_run_result() {
+        let (rt, _ws) = mock_runtime("identity-flow", OWNER);
+        let server_kp = DeviceKeypair::generate();
+        let listener = AgentRunWsListener::bind_loopback(0).unwrap();
+        let addr = listener.local_addr().unwrap();
+        let allowlist = vec![OWNER.to_string()];
+
+        // ── Hop 1: authenticate (sealed session) -> mission intake -> Mission owned by OWNER ──
+        let intake_kp = DeviceKeypair::generate();
+        let intake_peer_allowlist = allowlist_of(intake_kp.public_bytes());
+        let intake_client = spawn_client(addr, intake_kp, |session, _nonce| {
+            let req = mission_intake_request("req-identity-intake");
+            (req, session.clone(), session.clone())
+        });
+        assert_eq!(
+            listener
+                .accept_one(
+                    &server_kp,
+                    &rt,
+                    &allowlist,
+                    &intake_peer_allowlist,
+                    false,
+                    false,
+                    true, // mission-intake ON
+                    false,
+                    false,
+                    false,
+                )
+                .unwrap(),
+            1
+        );
+        let intake_owner = match intake_client.join().unwrap().result {
+            Some(Message::MissionIntakeResult { .. }) => {
+                rt.db()
+                    .get_friday_conversation("fconv_ns5_intake")
+                    .unwrap()
+                    .expect("intake born the conversation")
+                    .owner_principal
+            }
+            other => panic!("intake must birth a Mission, got {other:?}"),
+        };
+        assert_eq!(
+            intake_owner, OWNER,
+            "intake binds the Mission owner to the authenticated principal"
+        );
+
+        // ── Hop 2: auto-dispatch fires the bound run as the SAME principal -> run_result ──
+        // (The run authenticates via authenticate_forwarded against the SAME allowlist; the Rust
+        // auto-dispatch driver forwards the intake owner as the run principal.)
+        let run_kp = DeviceKeypair::generate();
+        let run_peer_allowlist = allowlist_of(run_kp.public_bytes());
+        let run_client = spawn_client(addr, run_kp, |session, nonce| {
+            let req = agent_run_request("req-identity-run", "run-identity", OWNER, session, nonce);
+            (req, session.clone(), session.clone())
+        });
+        assert_eq!(
+            listener
+                .accept_one(
+                    &server_kp,
+                    &rt,
+                    &allowlist,
+                    &run_peer_allowlist,
+                    false,
+                    false,
+                    false,
+                    false,
+                    false,
+                    false,
+                )
+                .unwrap(),
+            1
+        );
+        assert!(
+            matches!(
+                run_client.join().unwrap().result,
+                Some(Message::AgentRunResult { .. })
+            ),
+            "the bound run returns a refs result"
+        );
+
+        // ── The single identity threads through: the run's owner == the intake owner == OWNER ──
+        let run_session_owner = friday_storage::load_session_owner(rt.db().conn(), "run-identity")
+            .unwrap()
+            .expect("the bound run created its ephemeral session");
+        assert_eq!(
+            run_session_owner.user_id.as_deref(),
+            Some(OWNER),
+            "the run is owned by the SAME authenticated principal as the intake"
+        );
+        // The run answer is releasable ONLY to that same owner — a different principal is denied.
+        use friday_storage::{AnswerDenyReason, RunAnswerAccess};
+        assert!(
+            matches!(
+                friday_storage::get_run_answer_for_principal(rt.db().conn(), "run-identity", OWNER)
+                    .unwrap(),
+                RunAnswerAccess::Granted(_)
+            ),
+            "the same owner is Granted the bound run's answer"
+        );
+        assert_eq!(
+            friday_storage::get_run_answer_for_principal(
+                rt.db().conn(),
+                "run-identity",
+                "principal:not-the-owner"
+            )
+            .unwrap(),
+            RunAnswerAccess::Denied(AnswerDenyReason::PrincipalMismatch),
+            "a different principal is DENIED the bound run's answer"
+        );
+        assert_eq!(
+            intake_owner, OWNER,
+            "ONE identity (OWNER) is the owner at intake AND run — the end-to-end flow holds"
         );
     }
 }

--- a/rust-core/crates/friday-hub/src/hub_server.rs
+++ b/rust-core/crates/friday-hub/src/hub_server.rs
@@ -205,8 +205,33 @@ impl<T: Transport> HubServer<T> {
         // bin (which holds a `HubRuntime`, not a `HubServer`) REUSE the exact same Mission-birth
         // path through its flag-gated dispatch arm WITHOUT reimplementing it. This dispatch and the
         // bin's arm therefore birth a Mission identically (same rows, same wire result).
-        mission_intake_result_for_db(&self.db, msg_id, request, now_ms)
+        //
+        // (FIX-Q3b) `authenticated_owner` is the identity the persisted owner is BOUND to (never
+        // the raw body field). This LEGACY `HubServer::dispatch` path has NO production binary
+        // caller (both live bins use `HubRuntime`; this serve-loop is the in-crate TS-bridge under
+        // test only) and carries no session-derived principal, so it passes the request's own
+        // `owner_principal` as the authenticated owner — keeping this path BYTE-IDENTICAL (the
+        // equality check below is a tautology here, the persisted owner is unchanged). The LIVE
+        // mission-spine path is the bin's flag-gated arm, which threads `runtime.policy()
+        // .principal_id()` (== the configured `--owner`) as the real authenticated owner.
+        let body_owner = request.owner_principal.clone();
+        mission_intake_result_for_db(&self.db, msg_id, request, Some(body_owner.as_str()), now_ms)
     }
+}
+
+/// (FIX-Q3b) Resolve the canonical OWNER principal of `friday_conversation_id` from the Hub's
+/// `friday_conversation` row — the single source of truth for "who this Mission belongs to". Used
+/// by the mission-spine free fns to bind an inbound mutation to the AUTHENTICATED owner instead of
+/// trusting a self-asserted body field. `None` when the conversation does not exist OR its
+/// `owner_principal` is empty/whitespace (fail-closed: an unresolvable owner can match no
+/// authenticated principal). A DB read error is treated as unresolvable (`None`) so a transient
+/// failure fails CLOSED rather than admitting the mutation.
+fn resolve_conversation_owner(db: &Db, friday_conversation_id: &str) -> Option<String> {
+    db.get_friday_conversation(friday_conversation_id)
+        .ok()
+        .flatten()
+        .map(|c| c.owner_principal.trim().to_string())
+        .filter(|owner| !owner.is_empty())
 }
 
 /// (NS-5) The Mission-intake/preflight mutation, parameterized over `&Db` so BOTH the
@@ -223,12 +248,21 @@ impl<T: Transport> HubServer<T> {
 /// read; semantics in [`crate::mission_intake_clarify_from`]) and threaded as a pure bool
 /// to the parameterized [`mission_intake_result_for_db_flagged`]. **Default-OFF:** when
 /// off the producer is BYTE-IDENTICAL to the pre-clarification baseline — no detail check,
-/// every intent births a Mission exactly as now. The signature is unchanged so both callers
-/// (the [`HubServer::dispatch`] method + the live bin's flag-gated arm) are untouched.
+/// every intent births a Mission exactly as now.
+///
+/// ## Owner binding ([`crate::FRIDAY_MISSION_INTAKE`] dispatch — FIX-Q3b)
+/// `authenticated_owner` is the identity the persisted Mission/conversation owner is BOUND to —
+/// the Rust-derived session principal at the dispatch arm (`runtime.policy().principal_id()`),
+/// NEVER the self-asserted `request.owner_principal` body field. BEFORE persisting ANY row the
+/// producer fail-closes unless `request.owner_principal == authenticated_owner` (a `None`/empty
+/// authenticated owner, or any mismatch, is a typed `Error` and writes ZERO rows), then persists
+/// the AUTHENTICATED owner. Single-peer/single-owner happy path (the body owner == the configured
+/// owner) is UNCHANGED — only a MISMATCHED body owner is now rejected (was silently persisted).
 pub fn mission_intake_result_for_db(
     db: &Db,
     msg_id: &str,
     request: MissionIntakeRequestWire,
+    authenticated_owner: Option<&str>,
     now_ms: i64,
 ) -> Envelope {
     let clarify_enabled = crate::mission_intake_clarify_from(
@@ -244,6 +278,7 @@ pub fn mission_intake_result_for_db(
         db,
         msg_id,
         request,
+        authenticated_owner,
         now_ms,
         clarify_enabled,
         surface_events,
@@ -279,10 +314,28 @@ pub fn mission_intake_result_for_db_flagged(
     db: &Db,
     msg_id: &str,
     request: MissionIntakeRequestWire,
+    authenticated_owner: Option<&str>,
     now_ms: i64,
     clarify_enabled: bool,
     surface_events: bool,
 ) -> Envelope {
+    // (FIX-Q3b) OWNER BINDING — fail-closed BEFORE constructing or persisting ANY row. The
+    // persisted Mission/conversation owner MUST be the AUTHENTICATED owner (the Rust-derived
+    // session principal threaded from the dispatch arm), NEVER the self-asserted
+    // `request.owner_principal` body field. A `None`/empty authenticated owner, or a body
+    // `owner_principal` that does not byte-equal it (after trim), is a typed `Error` that writes
+    // ZERO rows — closing the audit gap where a self-asserted owner_principal was silently
+    // persisted. NO-DEGRADE: the single-peer/single-owner happy path (the body owner == the
+    // configured owner == the authenticated owner) passes this check unchanged.
+    let authenticated_owner = authenticated_owner.unwrap_or("").trim();
+    if authenticated_owner.is_empty() || request.owner_principal.trim() != authenticated_owner {
+        return mission_intake_error(
+            msg_id,
+            now_ms,
+            ErrorCode::Internal,
+            "mission intake owner_principal does not match the authenticated owner",
+        );
+    }
     if let Err(err) = friday_core::validate_friday_conversation_id(&request.friday_conversation_id)
     {
         return mission_intake_error(msg_id, now_ms, ErrorCode::Internal, &err.to_string());
@@ -387,7 +440,12 @@ pub fn mission_intake_result_for_db_flagged(
 
     let conversation = friday_core::FridayConversation {
         friday_conversation_id: request.friday_conversation_id.clone(),
-        owner_principal: request.owner_principal.clone(),
+        // (FIX-Q3b) BIND the persisted owner to the AUTHENTICATED owner, never the raw body field.
+        // The owner-binding check above already guarantees these are byte-equal (after trim), so
+        // this is byte-identical on the happy path — but persisting the authenticated identity is
+        // the load-bearing invariant: the audit-trail owner can never disagree with the executing
+        // owner, even if a future caller's body field and authenticated principal diverged.
+        owner_principal: authenticated_owner.to_string(),
         title: title.clone(),
         current_focus_summary: request.intent.clone(),
         active_mission_ids: Vec::new(),
@@ -620,10 +678,22 @@ fn mission_intake_error(msg_id: &str, now_ms: i64, code: ErrorCode, message: &st
 /// envelope on an unknown target status / invalid transition / missing Mission, correlated to
 /// `msg_id`. A status change here is a Mission-management fact, NOT provider completion unless the
 /// command carried and persisted valid proof.
+///
+/// ## Owner binding (FIX-Q3b)
+/// `authenticated_owner` is the Rust-derived session principal threaded from the dispatch arm
+/// (`runtime.policy().principal_id()`). The target Mission's OWNER (its conversation's
+/// `owner_principal`) MUST match it: a request to transition a Mission owned by a DIFFERENT
+/// principal — or by no authenticated principal at all (`None`/empty) — is a typed `Error` that
+/// transitions NOTHING. The owner check runs only when the target Mission EXISTS; an unknown
+/// Mission falls through to the storage transition, preserving the existing not-found Error shape
+/// (so the cross-owner/not-found denial stays "not found"). NO-DEGRADE: under single-peer/
+/// single-owner the Mission owner == the configured owner == the authenticated owner, so the
+/// happy-path transition is unchanged.
 pub fn mission_lifecycle_result_for_db(
     db: &Db,
     msg_id: &str,
     request: MissionLifecycleRequestWire,
+    authenticated_owner: Option<&str>,
     now_ms: i64,
 ) -> Envelope {
     let next_status = match mission_status_from_wire(&request.target_status) {
@@ -632,6 +702,30 @@ pub fn mission_lifecycle_result_for_db(
             return mission_intake_error(msg_id, now_ms, ErrorCode::Internal, message);
         }
     };
+
+    // (FIX-Q3b) OWNER BINDING — reject a cross-owner transition BEFORE any write. The target
+    // Mission's owner is its conversation's `owner_principal` (the Hub's single source of truth).
+    // Resolve it ONLY when the Mission exists; an unknown Mission yields `None` here and falls
+    // through to `transition_mission_status`, which produces the existing "not found" Error — so
+    // the cross-owner/not-found denial keeps its current shape. A present Mission whose owner does
+    // NOT match the authenticated owner (or a `None`/empty authenticated owner) is fail-closed.
+    let authenticated_owner = authenticated_owner.unwrap_or("").trim();
+    if let Ok(Some(mission)) = db.get_mission(&request.mission_id) {
+        // Resolve the owner from the Mission's OWN conversation (its source of truth), not the
+        // request's `friday_conversation_id` — so a body that points the wrong conversation at a
+        // real Mission cannot dodge the owner check.
+        let mission_owner = resolve_conversation_owner(db, &mission.friday_conversation_id);
+        let owner_ok = !authenticated_owner.is_empty()
+            && mission_owner.as_deref() == Some(authenticated_owner);
+        if !owner_ok {
+            return mission_intake_error(
+                msg_id,
+                now_ms,
+                ErrorCode::Internal,
+                "mission lifecycle blocked: target Mission is not owned by the authenticated owner",
+            );
+        }
+    }
 
     match db.transition_mission_status(
         &request.friday_conversation_id,
@@ -683,10 +777,21 @@ pub fn mission_lifecycle_result_for_db(
 /// `proof_receipt` (or an empty one), so "done" can never be claimed without proof. This function
 /// surfaces that rejection as a typed [`Message::Error`] — it never fakes a completion. Returns a
 /// [`Message::WorkItemStatusResult`] on success, correlated to `msg_id`.
+///
+/// ## Owner binding (FIX-Q3b)
+/// `authenticated_owner` is the Rust-derived session principal threaded from the dispatch arm
+/// (`runtime.policy().principal_id()`). The target WorkItem's OWNER (its Mission's conversation's
+/// `owner_principal`) MUST match it: advancing a WorkItem owned by a DIFFERENT principal — or by
+/// no authenticated principal (`None`/empty) — is a typed `Error` that transitions NOTHING. The
+/// check runs only when the target WorkItem EXISTS; an unknown WorkItem falls through to the
+/// storage transition, preserving the existing "not found" denial shape (the cross-owner/not-found
+/// equivalence under single-peer). NO-DEGRADE: under single-peer/single-owner the owner == the
+/// configured owner == the authenticated owner, so the happy-path transition is unchanged.
 pub fn work_item_status_result_for_db(
     db: &Db,
     msg_id: &str,
     request: WorkItemStatusRequestWire,
+    authenticated_owner: Option<&str>,
     now_ms: i64,
 ) -> Envelope {
     let next_status = match work_item_status_from_wire(&request.target_status) {
@@ -695,6 +800,31 @@ pub fn work_item_status_result_for_db(
             return mission_intake_error(msg_id, now_ms, ErrorCode::Internal, message);
         }
     };
+
+    // (FIX-Q3b) OWNER BINDING — reject a cross-owner transition BEFORE any write. The target
+    // WorkItem's owner is its Mission's conversation's `owner_principal`. Resolve it ONLY when the
+    // WorkItem (and its Mission) exists; an unknown WorkItem yields `None` and falls through to
+    // `transition_work_item_status`, which produces the existing "not found" Error — so the
+    // cross-owner/not-found denial keeps its current shape. A present WorkItem whose owner does NOT
+    // match the authenticated owner (or a `None`/empty authenticated owner) is fail-closed.
+    let authenticated_owner = authenticated_owner.unwrap_or("").trim();
+    if let Ok(Some(work_item)) = db.get_work_item(&request.work_item_id) {
+        let owner = db
+            .get_mission(&work_item.mission_id)
+            .ok()
+            .flatten()
+            .and_then(|m| resolve_conversation_owner(db, &m.friday_conversation_id));
+        let owner_ok =
+            !authenticated_owner.is_empty() && owner.as_deref() == Some(authenticated_owner);
+        if !owner_ok {
+            return mission_intake_error(
+                msg_id,
+                now_ms,
+                ErrorCode::Internal,
+                "work item lifecycle blocked: target WorkItem is not owned by the authenticated owner",
+            );
+        }
+    }
 
     // A blank proof_receipt is normalized to `None` BEFORE the call so the storage layer's
     // (CompletedWithProof, None) rejection fires for an all-whitespace receipt too — a
@@ -1342,7 +1472,21 @@ impl<T: Transport> HubServer<T> {
         // extracted to the free `mission_lifecycle_result_for_db` — letting the LIVE agent-run
         // server bin (which holds a `HubRuntime`, not a `HubServer`) REUSE the exact same Hub
         // state-machine transition through its flag-gated dispatch arm WITHOUT reimplementing it.
-        mission_lifecycle_result_for_db(&self.db, msg_id, request, now_ms)
+        //
+        // (FIX-Q3b) This LEGACY `HubServer::dispatch` path has NO production binary caller and
+        // carries no session-derived principal, so it supplies the target Mission's OWN owner
+        // (resolved from the Hub, the source of truth) as the authenticated owner — keeping this
+        // path BYTE-IDENTICAL (the owner check is a tautology here). The LIVE mission-spine path is
+        // the bin's flag-gated arm, which threads `runtime.policy().principal_id()` (== the
+        // configured `--owner`) as the real authenticated owner. An unknown Mission resolves to
+        // `None` here, which still flows through to the existing not-found Error.
+        let legacy_owner = self
+            .db
+            .get_mission(&request.mission_id)
+            .ok()
+            .flatten()
+            .and_then(|m| resolve_conversation_owner(&self.db, &m.friday_conversation_id));
+        mission_lifecycle_result_for_db(&self.db, msg_id, request, legacy_owner.as_deref(), now_ms)
     }
 
     fn error(msg_id: &str, now_ms: i64, code: ErrorCode, message: &str) -> Envelope {

--- a/rust-core/crates/friday-hub/tests/mission_intake_clarification.rs
+++ b/rust-core/crates/friday-hub/tests/mission_intake_clarification.rs
@@ -109,6 +109,7 @@ fn arm_a_flag_on_vague_intent_clarifies_and_writes_zero_rows() {
         &db,
         "req-arm-a",
         intake_request(VAGUE_INTENT),
+        Some(OWNER), // (FIX-Q3b) authenticated owner == the request's owner_principal
         1000,
         true,
         false, // FRIDAY_SURFACE_EVENTS OFF (orthogonal to the clarify arm under test)
@@ -168,6 +169,7 @@ fn arm_b_flag_on_detailed_classified_intent_births_a_mission_as_today() {
         &db,
         "req-arm-b",
         intake_request(DETAILED_INTENT),
+        Some(OWNER), // (FIX-Q3b) authenticated owner == the request's owner_principal
         2000,
         true,
         false, // FRIDAY_SURFACE_EVENTS OFF (orthogonal to the clarify arm under test)
@@ -211,6 +213,7 @@ fn arm_c_flag_off_vague_intent_births_a_mission_byte_identical() {
         &db,
         "req-arm-c",
         intake_request(VAGUE_INTENT),
+        Some(OWNER), // (FIX-Q3b) authenticated owner == the request's owner_principal
         3000,
         false,
         false, // FRIDAY_SURFACE_EVENTS OFF (orthogonal to the clarify arm under test)
@@ -253,6 +256,7 @@ fn arm_d_flag_on_unclassified_intent_births_a_mission() {
         &db,
         "req-arm-d",
         intake_request(UNCLASSIFIED_INTENT),
+        Some(OWNER), // (FIX-Q3b) authenticated owner == the request's owner_principal
         4000,
         true,
         false, // FRIDAY_SURFACE_EVENTS OFF (orthogonal to the clarify arm under test)
@@ -273,4 +277,103 @@ fn arm_d_flag_on_unclassified_intent_births_a_mission() {
         "Mission row written for an unclassified intent"
     );
     verify_audit_chain(db.conn()).expect("audit chain clean after an unclassified Mission birth");
+}
+
+/// (FIX-Q3b) OWNER-SPOOF at the producer boundary: an intake whose self-asserted `owner_principal`
+/// does NOT match the AUTHENTICATED owner is FAIL-CLOSED — a typed `Error` that writes ZERO rows
+/// (no Conversation/Mission/WorkItem/SurfaceThread/route_decision). This is the gating test that
+/// the persisted owner can never be a self-asserted body field — the FIX-Q3b precondition.
+#[test]
+fn owner_spoof_is_rejected_and_writes_zero_rows() {
+    let db = Db::open_hub(&temp_db("owner-spoof")).unwrap();
+    let mut request = intake_request(DETAILED_INTENT);
+    request.owner_principal = "owner-impersonator".into(); // a principal that is NOT the authed owner
+
+    let env = mission_intake_result_for_db_flagged(
+        &db,
+        "req-owner-spoof",
+        request,
+        Some(OWNER), // the AUTHENTICATED owner — differs from the spoofed body field
+        5000,
+        false, // clarify OFF (irrelevant — owner binding gates before any row)
+        false, // surface_events OFF
+    );
+
+    match env.message {
+        Message::Error { message, .. } => assert!(
+            message.contains("owner_principal does not match the authenticated owner"),
+            "a spoofed owner is owner-rejected: {message}"
+        ),
+        other => panic!("a spoofed owner_principal must be a typed Error, got {other:?}"),
+    }
+    // ZERO rows: nothing was born under either the spoofed owner OR the authenticated owner.
+    assert!(
+        db.get_mission(MISSION).unwrap().is_none(),
+        "a spoofed owner births NO Mission"
+    );
+    assert!(
+        db.get_work_item(WORK_ITEM).unwrap().is_none(),
+        "a spoofed owner births NO WorkItem"
+    );
+    assert!(
+        db.get_friday_conversation(FCONV).unwrap().is_none(),
+        "a spoofed owner births NO conversation row"
+    );
+    verify_audit_chain(db.conn()).expect("audit chain clean after a rejected owner-spoof intake");
+}
+
+/// (FIX-Q3b) The persisted Mission/conversation owner is BOUND to the AUTHENTICATED owner — the
+/// load-bearing invariant. With a MATCHING body field the intake births a Mission whose persisted
+/// `owner_principal` is the authenticated owner (here byte-equal — the only case the gate admits
+/// today; the binding is what lets multi-owner be safe later).
+#[test]
+fn persisted_owner_is_the_authenticated_owner() {
+    let db = Db::open_hub(&temp_db("owner-bind")).unwrap();
+    let env = mission_intake_result_for_db_flagged(
+        &db,
+        "req-owner-bind",
+        intake_request(DETAILED_INTENT),
+        Some(OWNER),
+        6000,
+        false,
+        false,
+    );
+    assert_eq!(
+        intake_result(env).status,
+        "ready",
+        "the matching-owner intake births a Mission"
+    );
+    assert_eq!(
+        db.get_friday_conversation(FCONV)
+            .unwrap()
+            .unwrap()
+            .owner_principal,
+        OWNER,
+        "the persisted owner is the authenticated owner, never a raw body field"
+    );
+}
+
+/// (FIX-Q3b) A MISSING authenticated owner (`None`) is FAIL-CLOSED — the producer can never persist
+/// an owner it cannot bind, even if the body carries one. (A future caller that forgets to thread
+/// the principal fails closed, never silently trusting the body.)
+#[test]
+fn missing_authenticated_owner_is_rejected() {
+    let db = Db::open_hub(&temp_db("owner-none")).unwrap();
+    let env = mission_intake_result_for_db_flagged(
+        &db,
+        "req-owner-none",
+        intake_request(DETAILED_INTENT), // body carries OWNER, but no AUTHENTICATED owner is supplied
+        None,
+        7000,
+        false,
+        false,
+    );
+    assert!(
+        matches!(env.message, Message::Error { .. }),
+        "a None authenticated owner fail-closes the intake"
+    );
+    assert!(
+        db.get_mission(MISSION).unwrap().is_none(),
+        "a None authenticated owner births NO Mission"
+    );
 }

--- a/rust-core/crates/friday-hub/tests/surface_events_timeline.rs
+++ b/rust-core/crates/friday-hub/tests/surface_events_timeline.rs
@@ -311,6 +311,7 @@ fn flag_on_emits_lifecycle_events_and_reader_includes_them_then_off_is_clean() {
         rt.db(),
         "req-surface-on",
         intake_request(),
+        Some("owner-surface"), // (FIX-Q3b) authenticated owner == the request's owner_principal
         900,
     );
     // The intake resolved READY (a row exists) — not an Error envelope.
@@ -378,6 +379,7 @@ fn flag_on_emits_lifecycle_events_and_reader_includes_them_then_off_is_clean() {
         rt_off.db(),
         "req-surface-off",
         intake_request(),
+        Some("owner-surface"), // (FIX-Q3b) authenticated owner == the request's owner_principal
         900,
     );
     run_to_completion(&rt_off, &ws_off, "run-surface-off");


### PR DESCRIPTION
## What / Why (FIX-Q3b)

The mission-spine dispatch arms persisted/acted on a **self-asserted** `request.owner_principal` without binding it to the authenticated session owner — an audit-trail integrity gap (the persisted owner could disagree with the actual executing owner) and the **FIX-Q3b** blocker before any multi-owner / live-flip. This mirrors the already-correct `memory_decision_result_for_db` pattern (which threads `authenticated_owner` and ignores the body field).

Single-peer/single-owner today ⇒ NOT a privilege escalation, but the binding is the load-bearing invariant that lets multi-owner be safe later.

## The fix (no-degrade)

**Free fns — `rust-core/crates/friday-hub/src/hub_server.rs`:**
- `mission_intake_result_for_db` / `_flagged` (~253 / ~301): add `authenticated_owner: Option<&str>`. **Before persisting any row**, fail-close unless `request.owner_principal` (trimmed) byte-equals it — `None`/empty/mismatch ⇒ typed `Error`, **zero rows**. The persisted conversation owner is **bound to the authenticated owner**, never the raw body field.
- `mission_lifecycle_result_for_db` (~648) / `work_item_status_result_for_db` (~736): add the param. Resolve the target Mission/WorkItem's owner (its conversation's `owner_principal`) and reject a transition not owned by the authenticated owner. The owner check runs **only when the target exists**, so an unknown id keeps its existing **"not found"** Error shape (KAT c unchanged).
- New private `resolve_conversation_owner` helper (fail-closed on missing/empty owner or DB read error).

**Bin arms — `hub_agent_run_server.rs`** thread `runtime.policy().principal_id()` (== the configured `--owner`) into all three, mirroring the `MemoryDecisionRequest` arm. The legacy `HubServer::dispatch` path (no production binary caller) passes a self-consistent owner so it stays byte-identical.

**Item-3 (owner-allowlist) — satisfied by subsumption (judgment call):** `authenticated_owner == principal_id() == owner_allowlist.first()` (the allowlist is ≤1 entry), so `owner_principal == authenticated_owner` is strictly tighter than `∈ allowlist`. A separate allowlist check on the free fn would be an unreachable, untestable branch; multi-owner will thread the per-session principal instead.

## No-degrade

- Single-peer/single-owner happy path (`owner_principal == configured owner`) is **unchanged** — all existing intake / auto-dispatch / spine happy-path tests still pass.
- Only a **mismatched** body owner is now rejected (was silently persisted).
- The live deploy-3 auto-dispatch proof was **not** re-run here (operator-gated). It is reasoned airtight from the run-auth chain: the TS auto-dispatch driver forwards the intake's `ownerPrincipal` as the run's `principalId` → `forwardedPrincipal` (api-runtime `friday-api-runtime.ts:1558`) → wire `forwarded_principal`, which the Rust server already rejects unless `∈ owner_allowlist`. So any flow that reaches `AUTODISPATCH_OK`→`completed_with_proof` already sends `ownerPrincipal == --owner` — exactly the condition the new intake check requires.

## Tests (gating)

- intake spoofed owner ⇒ `Error`, zero rows (dispatch-path + producer-boundary)
- created Mission's owner == authenticated owner regardless of body
- `None` authenticated owner ⇒ fail-closed
- mission-lifecycle / work-item-status cross-owner ⇒ rejected, no transition
- identity flow (Rust-side proxy): `authenticate_forwarded` → intake → bound run → run_result, one owner principal threads through every hop (does NOT exercise the TS driver end-to-end — it's an in-Rust proxy)

`cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test -p friday-hub` all green (56 bin + 7 clarification + 785 lib + integration). `.secrets.baseline` unchanged; `detect-secrets-hook` clean.

Closes **FIX-Q3b** (registry #4 precondition).

🤖 Generated with [Claude Code](https://claude.com/claude-code)