### PR TITLE
fix(storage): bounded busy-retry on run+ask billing txns (MED concurrency bug) + concurrency stress test

### DIFF
--- a/rust-core/crates/friday-storage/src/lib.rs
+++ b/rust-core/crates/friday-storage/src/lib.rs
@@ -216,32 +216,51 @@ const HUB_OPEN_RETRY_ATTEMPTS: u32 = 5;
 /// boot stall, while a never-clearing lock still fails closed promptly.
 const HUB_OPEN_RETRY_BACKOFF: std::time::Duration = std::time::Duration::from_millis(200);
 
-/// True iff `e` is a SQLite busy/locked failure — the ONLY class the writable-open
-/// retry self-heals. Matched on the STRUCTURED `ErrorCode` (never the message string,
-/// which is locale/version-fragile) so a real init error — `SchemaTooNew`, a migration
-/// failure, an IO error — is NEVER masked as "retryable" and propagates immediately.
-/// Reaches through the `StorageError::Sqlite` wrapper so a busy surfaced from the WAL
-/// flip pragma OR from the migration write-txn is recognised identically.
+/// True iff `e` is a SQLite busy/locked failure — the ONLY class the busy retry
+/// self-heals (the writable-open WAL flip AND the run-billing write txn). Matched on the
+/// STRUCTURED `ErrorCode` (never the message string, which is locale/version-fragile) so a
+/// real error — `SchemaTooNew`, a migration failure, an IO error, a constraint violation —
+/// is NEVER masked as "retryable" and propagates immediately. Reaches through the
+/// `StorageError::Sqlite` wrapper so a busy surfaced from the WAL flip pragma, the migration
+/// write-txn, OR a contended billing INSERT is recognised identically.
+///
+/// BUSY_SNAPSHOT (belt-and-suspenders): the extended result code `SQLITE_BUSY_SNAPSHOT`
+/// (517) is the contention a WAL writer hits when its snapshot is stale — and crucially, the
+/// `busy_timeout` handler does NOT auto-retry it (it returns immediately), so ONLY an
+/// application-level retry recovers it. NOTE this `extended_code` arm is REDUNDANT for
+/// MATCHING: rusqlite derives the primary `code` as `extended_code & 0xff`, and
+/// `517 & 0xff == 5 == SQLITE_BUSY`, so the `DatabaseBusy` arm above ALREADY returns true for
+/// BUSY_SNAPSHOT. It is kept EXPLICIT to (a) document that BUSY_SNAPSHOT's recovery path is
+/// this retry — not `busy_timeout` — and (b) stay correct if a future rusqlite ever decoded
+/// it to a distinct primary code. It widens nothing today; the retry, not this matcher, is
+/// what absorbs BUSY_SNAPSHOT.
 fn is_storage_busy(e: &StorageError) -> bool {
     matches!(
         e,
         StorageError::Sqlite(rusqlite::Error::SqliteFailure(err, _))
             if matches!(err.code, ErrorCode::DatabaseBusy | ErrorCode::DatabaseLocked)
+                || err.extended_code == rusqlite::ffi::SQLITE_BUSY_SNAPSHOT
     )
 }
 
-/// Run a writable-Hub open closure with a SHORT bounded retry on SQLite busy/locked.
-/// Each attempt re-runs `open` from scratch (a fresh `Connection` carries no partial
-/// state, and the WAL flip is atomic — a BUSY means the conversion did NOT happen — so
-/// a retry can never compound a half-converted file). Only the busy/locked case
-/// retries: every other error propagates on the FIRST attempt with zero delay (never
-/// mask a real init failure). After the final attempt the last busy error is returned
-/// so the caller still fails closed.
-fn open_hub_with_busy_retry(mut open: impl FnMut() -> Result<Db>) -> Result<Db> {
+/// Run a fallible storage `op` with a SHORT bounded retry on SQLite busy/locked. Each
+/// attempt re-runs `op` from scratch: for the writable-Hub open a fresh `Connection`
+/// carries no partial state (the WAL flip is atomic — a BUSY means the conversion did NOT
+/// happen — so a retry can never compound a half-converted file); for a write txn the
+/// failed txn has already rolled back (a BUSY means NOTHING committed), so a retry re-opens
+/// the txn and re-runs the body cleanly. Only the busy/locked case retries: every other
+/// error propagates on the FIRST attempt with zero delay (never mask a real failure). After
+/// the final attempt the last busy error is returned so the caller still fails closed.
+///
+/// This is the ONE bounded busy-retry idiom in the crate — the writable-Hub open
+/// ([`open_hub_with_busy_retry`]) and the run-billing write txn
+/// ([`record_run_model_call`]) BOTH go through it, so they share identical retry budget,
+/// backoff, and the [`is_storage_busy`] error class (never an ad-hoc second policy).
+fn with_busy_retry<T>(mut op: impl FnMut() -> Result<T>) -> Result<T> {
     let mut attempt: u32 = 0;
     loop {
-        match open() {
-            Ok(db) => return Ok(db),
+        match op() {
+            Ok(v) => return Ok(v),
             Err(e) if is_storage_busy(&e) && attempt + 1 < HUB_OPEN_RETRY_ATTEMPTS => {
                 attempt += 1;
                 std::thread::sleep(HUB_OPEN_RETRY_BACKOFF);
@@ -249,6 +268,12 @@ fn open_hub_with_busy_retry(mut open: impl FnMut() -> Result<Db>) -> Result<Db> 
             Err(e) => return Err(e),
         }
     }
+}
+
+/// Run a writable-Hub open closure with the bounded busy-retry idiom. Thin alias over the
+/// generic [`with_busy_retry`] preserved as a named seam so the open path reads as before.
+fn open_hub_with_busy_retry(open: impl FnMut() -> Result<Db>) -> Result<Db> {
+    with_busy_retry(open)
 }
 
 impl Db {
@@ -1193,6 +1218,17 @@ impl Db {
     /// `activity_item`, and `audit_ledger` in one transaction. If any insert
     /// fails, none persist (gate 21 §2.3). Hub-only (the audit ledger does not
     /// exist on a phone).
+    ///
+    /// CONCURRENCY: this is the ASK-path sibling of [`record_run_model_call`] and shares its
+    /// exact txn shape (open → token_ledger + activity + audit inserts → commit) on the same
+    /// long-lived Hub connection, so it carries the IDENTICAL latent `SQLITE_BUSY`-under-reaper
+    /// crash class. It is wrapped in the SAME bounded busy-retry idiom ([`with_busy_retry`]) for
+    /// the same reasons documented on `record_run_model_call`: the retry re-runs the WHOLE txn
+    /// (REQUIRED — `append_audit` reads the prev chain hash THEN inserts, so a stale-prev-hash
+    /// retry would forge a broken chain; a BUSY rolled the failed txn back, so a re-run re-reads
+    /// the live prev-hash). NO-DEGRADE: the retry fires ONLY on a busy error, so with no
+    /// contention the closure runs exactly once and the result is byte-identical to the pre-fix
+    /// single-txn path.
     pub fn record_model_call(
         &mut self,
         entry: &LedgerEntry,
@@ -1204,20 +1240,23 @@ impl Db {
                 "record_model_call requires the Hub profile (audit_ledger is Hub-only)".into(),
             ));
         }
-        let tx = self.conn.transaction()?;
-        // Ask path: DB-wide ledger row (no owning run) — `run_id` is NULL.
-        insert_token_ledger_conn(&tx, entry, None)?;
-        insert_activity_conn(&tx, activity)?;
-        audit::append_audit(
-            &tx,
-            &audit.audit_id,
-            &audit.actor,
-            &audit.action,
-            audit.payload_ref.as_deref(),
-            audit.created_at,
-        )?;
-        tx.commit()?;
-        Ok(())
+        let conn = &mut self.conn;
+        with_busy_retry(|| {
+            let tx = conn.transaction()?;
+            // Ask path: DB-wide ledger row (no owning run) — `run_id` is NULL.
+            insert_token_ledger_conn(&tx, entry, None)?;
+            insert_activity_conn(&tx, activity)?;
+            audit::append_audit(
+                &tx,
+                &audit.audit_id,
+                &audit.actor,
+                &audit.action,
+                audit.payload_ref.as_deref(),
+                audit.created_at,
+            )?;
+            tx.commit()?;
+            Ok(())
+        })
     }
 
     /// Atomically record a Hub EVENT: one `activity_item` + one hash-chained `audit_ledger`
@@ -1276,6 +1315,27 @@ impl Db {
 ///
 /// Hub-only: `audit_ledger` does not exist on a phone, so a phone connection fails closed
 /// on the audit insert. The agent loop runs only on a Hub DB by construction.
+///
+/// CONCURRENCY (MED bug, hardening audit): this txn opens a deferred write txn (its FIRST
+/// statement is the `token_ledger` INSERT) and runs on the long-lived WS-server connection.
+/// Once a SECOND writer exists — the reaper thread's `sweep_lifecycle` + (when
+/// `FRIDAY_RETENTION_SWEEP=1`) `sweep_retention`'s batched DELETE on a SEPARATE connection —
+/// a batch that out-holds the WAL write lock LONGER than `busy_timeout`
+/// ([`HUB_BUSY_TIMEOUT_MS`]) makes the billing INSERT return `SQLITE_BUSY`; un-retried the
+/// caller's `?` would CRASH the run mid-billing. So the WHOLE txn is wrapped in the SAME
+/// bounded busy-retry idiom as the writable open ([`with_busy_retry`]) — never a new policy.
+///
+/// The retry re-runs the ENTIRE body per attempt (open `unchecked_transaction` → the three
+/// inserts → commit), NOT just the commit: this is REQUIRED for audit-chain atomicity —
+/// `append_audit` reads the previous chain hash THEN inserts, so a stale-prev-hash retry
+/// would forge a broken chain. On a BUSY the failed txn has already rolled back (NOTHING
+/// committed), so the next attempt re-reads the live prev-hash and re-inserts the
+/// deterministic `run_id:tN:*` ids cleanly — no duplicate row, no half-bill.
+///
+/// NO-DEGRADE: the retry fires ONLY on [`is_storage_busy`]. With no contention the closure
+/// runs exactly ONCE and the result is BYTE-IDENTICAL to the pre-fix single-txn path (same
+/// txn contents, same insert ordering, same commit) — the wrapper adds a loop that is never
+/// re-entered. Every non-busy error still propagates on the first attempt with zero delay.
 pub fn record_run_model_call(
     conn: &Connection,
     run_id: &str,
@@ -1283,19 +1343,21 @@ pub fn record_run_model_call(
     activity: &ActivityRow,
     audit: &AuditEvent,
 ) -> Result<()> {
-    let tx = conn.unchecked_transaction()?;
-    insert_token_ledger_conn(&tx, entry, Some(run_id))?;
-    insert_activity_conn(&tx, activity)?;
-    audit::append_audit(
-        &tx,
-        &audit.audit_id,
-        &audit.actor,
-        &audit.action,
-        audit.payload_ref.as_deref(),
-        audit.created_at,
-    )?;
-    tx.commit()?;
-    Ok(())
+    with_busy_retry(|| {
+        let tx = conn.unchecked_transaction()?;
+        insert_token_ledger_conn(&tx, entry, Some(run_id))?;
+        insert_activity_conn(&tx, activity)?;
+        audit::append_audit(
+            &tx,
+            &audit.audit_id,
+            &audit.actor,
+            &audit.action,
+            audit.payload_ref.as_deref(),
+            audit.created_at,
+        )?;
+        tx.commit()?;
+        Ok(())
+    })
 }
 
 fn quote_existing_table(conn: &Connection, table: &str) -> Result<String> {
@@ -1424,8 +1486,8 @@ pub(crate) fn insert_activity_conn(conn: &Connection, a: &ActivityRow) -> rusqli
 #[cfg(test)]
 mod busy_retry_tests {
     use super::{
-        is_storage_busy, now_ms, open_hub_with_busy_retry, Db, Profile, StorageError,
-        HUB_OPEN_RETRY_ATTEMPTS,
+        is_storage_busy, now_ms, open_hub_with_busy_retry, with_busy_retry, Db, Profile, Result,
+        StorageError, HUB_OPEN_RETRY_ATTEMPTS,
     };
     use std::cell::Cell;
 
@@ -1459,6 +1521,58 @@ mod busy_retry_tests {
             disk: 99,
             code: 1
         }));
+    }
+
+    /// BUSY_SNAPSHOT (517) is recognised as busy — AND this proves WHY the explicit
+    /// `extended_code` arm is redundant-for-matching: rusqlite derives the primary `code` as
+    /// `extended_code & 0xff`, and `517 & 0xff == 5 == SQLITE_BUSY`, so the row already carries
+    /// `ErrorCode::DatabaseBusy`. We assert both: that `is_storage_busy` matches it, and that the
+    /// constructed error's primary code is already `DatabaseBusy` (so the `DatabaseBusy` arm
+    /// alone would suffice — the explicit arm is documentation + future-proofing, not coverage).
+    #[test]
+    fn busy_snapshot_extended_code_is_recognised_and_already_primary_busy() {
+        let e = busy_storage_error(rusqlite::ffi::SQLITE_BUSY_SNAPSHOT);
+        assert!(is_storage_busy(&e), "BUSY_SNAPSHOT must be treated as busy");
+        match &e {
+            StorageError::Sqlite(rusqlite::Error::SqliteFailure(err, _)) => {
+                assert_eq!(
+                    err.extended_code,
+                    rusqlite::ffi::SQLITE_BUSY_SNAPSHOT,
+                    "extended_code is 517"
+                );
+                assert_eq!(
+                    err.code,
+                    rusqlite::ErrorCode::DatabaseBusy,
+                    "the primary code of BUSY_SNAPSHOT is already DatabaseBusy (517 & 0xff == 5)"
+                );
+            }
+            other => panic!("expected a SqliteFailure, got {other:?}"),
+        }
+    }
+
+    /// The GENERIC `with_busy_retry` is the one idiom both the open path and the run-billing
+    /// path use: it retries a busy `Result<T>` for an arbitrary `T` (here `u32`) on the SAME
+    /// budget, then returns the value once contention clears. (`record_run_model_call` rides
+    /// this with `T = ()`.)
+    #[test]
+    fn generic_with_busy_retry_retries_then_yields_value() {
+        let calls = Cell::new(0u32);
+        let busy_before_success = HUB_OPEN_RETRY_ATTEMPTS - 1;
+        let out: Result<u32> = with_busy_retry(|| {
+            let n = calls.get();
+            calls.set(n + 1);
+            if n < busy_before_success {
+                Err(busy_storage_error(rusqlite::ffi::SQLITE_BUSY))
+            } else {
+                Ok(42)
+            }
+        });
+        assert_eq!(
+            out.unwrap(),
+            42,
+            "yields the closure's value once busy clears"
+        );
+        assert_eq!(calls.get(), HUB_OPEN_RETRY_ATTEMPTS);
     }
 
     /// The loop retries a busy open and SUCCEEDS once the contender clears — modeled

--- a/rust-core/crates/friday-storage/tests/atomic.rs
+++ b/rust-core/crates/friday-storage/tests/atomic.rs
@@ -5,7 +5,14 @@ mod common;
 
 use common::temp_db_path;
 use friday_core::{ActivityState, ActivityType, LedgerEntry};
-use friday_storage::{audit, ActivityRow, AuditEvent, Db, StorageError};
+use friday_storage::{
+    audit, sweep_lifecycle, sweep_retention, ActivityRow, AuditEvent, Db, RetentionWindows,
+    StorageError,
+};
+use rusqlite::{params, Connection};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
 
 fn ledger(id: &str) -> LedgerEntry {
     LedgerEntry::friday_route(id, "s1", "a1", "deepseek-v4-flash", 11, 8, None, None, 100).unwrap()
@@ -212,4 +219,370 @@ fn record_event_is_hub_only() {
     let res = db.record_event(&activity("evt-1"), &audit_event("evt-1"));
     assert!(matches!(res, Err(StorageError::Unsupported(_))));
     assert_eq!(db.count("activity_item").unwrap(), 0);
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// CONCURRENCY: the billing busy-retry (MED bug, hardening audit).
+//
+// `record_run_model_call` runs on the long-lived WS-server connection. Once a SECOND
+// writer exists — the reaper thread's `sweep_lifecycle` + `sweep_retention` batched DELETE
+// on its OWN connection — a batch that out-holds the WAL write lock LONGER than the billing
+// connection's `busy_timeout` makes the billing INSERT return `SQLITE_BUSY`; pre-fix the
+// caller's bare `?` crashed the run mid-billing. The fix wraps the whole txn in the bounded
+// busy-retry idiom. These tests prove it against a REAL on-disk WAL file (WAL is a no-op on
+// `:memory:`).
+// ───────────────────────────────────────────────────────────────────────────
+
+/// A run-attributed per-turn bill with DETERMINISTIC, turn-unique ids (mirroring the hub's
+/// `bill_model_call`: `run_id:tN:*`), so N concurrent turns leave N distinct rows and the
+/// audit chain never PK-collides.
+fn bill_turn(conn: &Connection, run_id: &str, turn: u64, now_ms: i64) -> Result<(), StorageError> {
+    let ledger_id = format!("{run_id}:t{turn}:ledger");
+    let activity_id = format!("{run_id}:t{turn}:askreceipt");
+    let audit_id = format!("{run_id}:t{turn}:modelcall");
+    let entry = LedgerEntry::friday_route(
+        &ledger_id,
+        run_id,
+        &activity_id,
+        "deepseek-v4-flash",
+        5,
+        3,
+        None,
+        None,
+        now_ms,
+    )
+    .unwrap();
+    let activity = ActivityRow {
+        activity_id,
+        session_id: Some(run_id.to_string()),
+        kind: ActivityType::AskReceipt,
+        state: ActivityState::Done,
+        summary: "turn done".into(),
+        created_at: now_ms,
+        updated_at: now_ms,
+        deep_link: None,
+    };
+    let audit = AuditEvent {
+        audit_id,
+        actor: "hub-agent".into(),
+        action: "agent_loop.model_call".into(),
+        payload_ref: Some(ledger_id),
+        created_at: now_ms,
+    };
+    friday_storage::record_run_model_call(conn, run_id, &entry, &activity, &audit)
+}
+
+/// Open a RAW writer connection to an already-WAL Hub file with a chosen `busy_timeout`.
+/// (The billing connection in prod sets `HUB_BUSY_TIMEOUT_MS`; the deterministic test sets
+/// 0 so ANY overlap surfaces `SQLITE_BUSY` immediately and the retry — not `busy_timeout` —
+/// is what must absorb it.)
+fn raw_writer(path: &str, busy_timeout_ms: i64) -> Connection {
+    let conn = Connection::open(path).unwrap();
+    conn.pragma_update(None, "foreign_keys", true).unwrap();
+    conn.pragma_update(None, "busy_timeout", busy_timeout_ms)
+        .unwrap();
+    conn
+}
+
+/// DETERMINISTIC retry-fires proof (the regression test). A blocker thread holds a write
+/// lock (`BEGIN IMMEDIATE`) on a SECOND connection; the billing connection has
+/// `busy_timeout = 0`, so its FIRST attempt hits an IMMEDIATE `SQLITE_BUSY`. The blocker
+/// releases WITHIN the bounded retry budget (4 × 200ms = 800ms), so the retry's next attempt
+/// commits and the call returns `Ok`.
+///
+/// PRE-FIX (no retry) this billing call propagates the BUSY and FAILS. This was VERIFIED by
+/// reverting `record_run_model_call` to the bare-`?` single-txn body and running this test:
+/// it went RED with exactly
+/// `Err(Sqlite(SqliteFailure(Error { code: DatabaseBusy, extended_code: 5 }, "database is
+/// locked")))`. That confirms (a) the busy error really reaches the application as a matchable
+/// `StorageError::Sqlite(SqliteFailure(..))` and (b) the retry is what recovers it. It ALSO
+/// empirically settles the BUSY_SNAPSHOT question: the surfaced `extended_code` is `5` =
+/// plain `SQLITE_BUSY`, NOT `517` = `SQLITE_BUSY_SNAPSHOT`. The billing txn is a write-first
+/// deferred txn (its FIRST statement is the `token_ledger` INSERT, BEFORE `append_audit`
+/// reads the chain), so it takes its snapshot at write time and contends as plain BUSY — the
+/// BUSY_SNAPSHOT arm of `is_storage_busy` is belt-and-suspenders, never the path this hits.
+#[test]
+fn billing_retry_absorbs_a_busy_when_a_peer_write_lock_releases_within_budget() {
+    let p = temp_db_path("billing-retry-deterministic");
+    // Convert the file to WAL + create the schema via the canonical writable opener, keep it
+    // OPEN for the duration (the WS-server holds its connection for the run's lifetime).
+    let _hub = Db::open_hub(&p).unwrap();
+
+    // Blocker connection: take a write lock and hold it ~250ms (< the ~800ms retry budget),
+    // then release. A barrier proves the lock is HELD before the billing call's first attempt.
+    let blocker = raw_writer(&p, 0);
+    let held = Arc::new(AtomicBool::new(false));
+    let held_w = held.clone();
+    let blocker_thread = std::thread::spawn(move || {
+        blocker.execute_batch("BEGIN IMMEDIATE;").unwrap();
+        held_w.store(true, Ordering::SeqCst);
+        std::thread::sleep(Duration::from_millis(250));
+        blocker.execute_batch("COMMIT;").unwrap();
+    });
+    while !held.load(Ordering::SeqCst) {
+        std::thread::sleep(Duration::from_millis(1));
+    }
+
+    // Billing connection with busy_timeout=0: its first attempt sees the held write lock and
+    // gets an IMMEDIATE busy. The bounded retry re-runs the whole txn; the blocker releases
+    // within budget, so a later attempt commits → Ok. (Pre-fix: this returns Err here.)
+    let billing = raw_writer(&p, 0);
+    let res = bill_turn(&billing, "run-retry", 0, 9_000_000_000_000);
+    assert!(
+        res.is_ok(),
+        "the billing busy-retry must absorb a peer write lock that releases within budget, got {res:?}"
+    );
+
+    blocker_thread.join().unwrap();
+
+    // The bill committed exactly once — all three rows present, audit chain clean.
+    let n_ledger: i64 = billing
+        .query_row("SELECT COUNT(*) FROM token_ledger", [], |r| r.get(0))
+        .unwrap();
+    let n_activity: i64 = billing
+        .query_row("SELECT COUNT(*) FROM activity_item", [], |r| r.get(0))
+        .unwrap();
+    assert_eq!(
+        n_ledger, 1,
+        "exactly one ledger row (no double-bill on retry)"
+    );
+    assert_eq!(n_activity, 1, "exactly one activity row");
+    assert_eq!(
+        audit::verify_audit_chain(&billing).unwrap(),
+        1,
+        "audit chain clean: the retry re-read prev-hash, never forged a stale link"
+    );
+}
+
+// --- stress-test seeders (raw SQL, grounded in the live schema; mirror retention.rs) ------
+
+fn seed_conversation(conn: &Connection, id: &str) {
+    conn.execute(
+        "INSERT OR IGNORE INTO friday_conversation
+            (friday_conversation_id, owner_principal, truth_status, created_at_ms, updated_at_ms)
+         VALUES (?1, 'owner', 'proven', 1, 1)",
+        [id],
+    )
+    .unwrap();
+}
+
+fn seed_mission(conn: &Connection, id: &str, conv: &str, status: &str, updated_at_ms: i64) {
+    conn.execute(
+        "INSERT INTO mission
+            (mission_id, friday_conversation_id, intent, status, created_at_ms, updated_at_ms)
+         VALUES (?1, ?2, 'do a thing', ?3, 1, ?4)",
+        params![id, conv, status, updated_at_ms],
+    )
+    .unwrap();
+}
+
+fn seed_aged_ledger(conn: &Connection, id: &str, created_at: i64) {
+    conn.execute(
+        "INSERT INTO token_ledger
+            (ledger_id, session_id, activity_id, provider_kind, model, base_url_host,
+             prompt_tokens, completion_tokens, total_tokens, cost_estimate, fallback,
+             result_link, created_at)
+         VALUES (?1, NULL, NULL, 'deepseek', 'deepseek-chat', 'api.deepseek.com',
+                 1, 1, 2, NULL, 0, NULL, ?2)",
+        params![id, created_at],
+    )
+    .unwrap();
+}
+
+fn ledger_exists(conn: &Connection, id: &str) -> bool {
+    conn.query_row(
+        "SELECT EXISTS(SELECT 1 FROM token_ledger WHERE ledger_id = ?1)",
+        [id],
+        |r| r.get::<_, bool>(0),
+    )
+    .unwrap()
+}
+
+fn mission_exists(conn: &Connection, id: &str) -> bool {
+    conn.query_row(
+        "SELECT EXISTS(SELECT 1 FROM mission WHERE mission_id = ?1)",
+        [id],
+        |r| r.get::<_, bool>(0),
+    )
+    .unwrap()
+}
+
+/// CONCURRENCY-CORRECTNESS STRESS (the invariant harness). On ONE WAL file:
+///   * N billing threads each run several `bill_turn` calls back-to-back (distinct ids), on
+///     their OWN connections — PROD-FAITHFUL (`busy_timeout = HUB_BUSY_TIMEOUT_MS`, the same as
+///     the real WS-server billing connection), with the busy-retry as the residual backstop;
+///   * a reaper thread runs `sweep_lifecycle` + `sweep_retention` on a SHORT cadence with a
+///     SMALL batch over SEEDED aged terminal rows (the exact prod second-writer shape).
+///
+/// Asserts the no-degrade INVARIANTS under genuine concurrent commits: (a) NO billing call
+/// errors and NO storage-busy propagates to the app; (b) aged rows are deleted while active
+/// missions + the freshly-billed recent rows survive; no FK errors (the reaper never reports
+/// a per-table failure); no double-bill; and the audit hash-chain verifies clean across every
+/// concurrent commit.
+///
+/// SCOPE NOTE: this test does NOT deterministically force the busy-retry to fire — every
+/// writer here holds the WAL lock for microseconds, so a patient `busy_timeout` acquires it
+/// and a real BUSY almost never surfaces. The DETERMINISTIC fix-proof (a controlled
+/// lock-hold that exceeds the timeout, the retry recovering it, and red-without-fix) is the
+/// sibling test above. This one proves the FK/atomicity/no-double-bill invariants hold while
+/// the reaper and N billers commit concurrently — which is the property that would regress if
+/// the fix interacted badly with the second writer. N + cadence are bounded so CI is fast.
+#[test]
+fn concurrent_billing_survives_a_reaper_sweeping_on_a_short_cadence() {
+    let p = temp_db_path("billing-reaper-stress");
+    // Canonical writable opener: WAL + schema. Held open for the whole test.
+    let hub = Db::open_hub(&p).unwrap();
+
+    // A logical "now" far past every retention window so the seeded-aged rows are eligible
+    // and the freshly-billed rows (created_at == now) are NOT. The reaper uses the SAME now.
+    let now_ms: i64 = 9_000_000_000_000; // ~year 2255 in epoch-ms; all billing uses this.
+    let one_year_ms: i64 = 365 * 24 * 60 * 60 * 1000;
+
+    // Seed aged terminal artifacts (reaper deletes these) + an ACTIVE mission (NEVER deleted).
+    seed_conversation(hub.conn(), "fconv_1");
+    seed_mission(hub.conn(), "miss_active", "fconv_1", "active", 1); // ancient but active
+    seed_mission(
+        hub.conn(),
+        "miss_term_old",
+        "fconv_1",
+        "done",
+        now_ms - one_year_ms - 1,
+    );
+    for i in 0..20 {
+        seed_aged_ledger(hub.conn(), &format!("aged_{i}"), now_ms - one_year_ms - 1);
+    }
+
+    // Small batch + the same `now_ms` so only the seeded-aged rows match the cutoffs. Large
+    // windows everywhere so the freshly-billed recent rows (created_at == now_ms) never age.
+    let windows = RetentionWindows {
+        batch_limit: 4,
+        ..RetentionWindows::default()
+    };
+
+    let stop = Arc::new(AtomicBool::new(false));
+    let billing_errors = Arc::new(AtomicUsize::new(0));
+    let reaper_table_errors = Arc::new(AtomicUsize::new(0));
+
+    // Reaper thread: its OWN connection, sweeping on a short cadence (the second writer).
+    let reaper = {
+        let path = p.clone();
+        let stop = stop.clone();
+        let reaper_errs = reaper_table_errors.clone();
+        std::thread::spawn(move || {
+            // Prod-faithful: the reaper opens via `Db::open_hub` (→ HUB_BUSY_TIMEOUT_MS), so its
+            // batched DELETE WAITS for the (microsecond) billing write lock and acquires it. With
+            // BUSY absorbed by the timeout, the ONLY thing that can set `table_errors` is a real FK
+            // violation — which is exactly the no-degrade "no FK errors" check below.
+            let conn = raw_writer(&path, friday_storage::HUB_BUSY_TIMEOUT_MS);
+            while !stop.load(Ordering::SeqCst) {
+                // sweep_lifecycle is best-effort (logged-and-swallowed in prod); ignore its
+                // Result here — the billing-side assertion is what gates the fix.
+                let _ = sweep_lifecycle(&conn, now_ms);
+                let out = sweep_retention(&conn, now_ms, windows);
+                reaper_errs.fetch_add(out.table_errors, Ordering::SeqCst);
+                std::thread::sleep(Duration::from_millis(10));
+            }
+        })
+    };
+
+    // N billing threads: each bills several turns back-to-back, on its OWN connection.
+    const N_THREADS: u64 = 6;
+    const TURNS_PER_THREAD: u64 = 25;
+    let mut billers = Vec::new();
+    for t in 0..N_THREADS {
+        let path = p.clone();
+        let billing_errors = billing_errors.clone();
+        billers.push(std::thread::spawn(move || {
+            // Prod-faithful: the WS-server billing connection carries HUB_BUSY_TIMEOUT_MS; the
+            // busy-retry is the residual backstop for a batch that out-holds even that.
+            let conn = raw_writer(&path, friday_storage::HUB_BUSY_TIMEOUT_MS);
+            let run_id = format!("run-{t}");
+            for turn in 0..TURNS_PER_THREAD {
+                if let Err(e) = bill_turn(&conn, &run_id, turn, now_ms) {
+                    eprintln!("billing error t={t} turn={turn}: {e:?}");
+                    billing_errors.fetch_add(1, Ordering::SeqCst);
+                }
+            }
+        }));
+    }
+    for b in billers {
+        b.join().unwrap();
+    }
+    stop.store(true, Ordering::SeqCst);
+    reaper.join().unwrap();
+
+    // (a) NO billing call errored — the busy-retry absorbed every contention from the reaper.
+    assert_eq!(
+        billing_errors.load(Ordering::SeqCst),
+        0,
+        "no billing call may error/crash under concurrent reaper contention"
+    );
+    // The reaper never hit an FK refusal / per-table failure on its own writes.
+    assert_eq!(
+        reaper_table_errors.load(Ordering::SeqCst),
+        0,
+        "the retention sweep must never report a per-table (FK/lock) failure"
+    );
+
+    // (b) Every billed turn committed exactly once: N*TURNS run-attributed ledger rows survive
+    // (created_at == now_ms, never aged). Read on a FRESH connection (avoid WAL staleness).
+    let verify = raw_writer(&p, friday_storage::HUB_BUSY_TIMEOUT_MS);
+
+    // DETERMINISM: the "aged rows deleted" assertions must not depend on how many ticks the
+    // reaper got before `stop`. Drain the small-batch backlog synchronously now (no contention,
+    // bounded), so deletion is settled before we assert it.
+    let mut drains = 0;
+    loop {
+        let out = sweep_retention(&verify, now_ms, windows);
+        assert_eq!(out.table_errors, 0, "uncontended drain must not FK-fail");
+        if out.is_empty() {
+            break;
+        }
+        drains += 1;
+        assert!(drains < 50, "drain must terminate (bounded backlog)");
+    }
+
+    let billed: i64 = verify
+        .query_row(
+            "SELECT COUNT(*) FROM token_ledger WHERE run_id IS NOT NULL",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(
+        billed as u64,
+        N_THREADS * TURNS_PER_THREAD,
+        "every billed turn must persist exactly once (no lost bill, no double-bill)"
+    );
+
+    // Aged rows pruned (the reaper's small batch drains 20 over its ticks); active mission +
+    // a freshly-billed recent row survive; the old-terminal mission is pruned.
+    for i in 0..20 {
+        assert!(
+            !ledger_exists(&verify, &format!("aged_{i}")),
+            "aged ledger row aged_{i} must be pruned by the reaper"
+        );
+    }
+    assert!(
+        mission_exists(&verify, "miss_active"),
+        "the active mission is NEVER deleted regardless of age"
+    );
+    assert!(
+        !mission_exists(&verify, "miss_term_old"),
+        "the old-terminal leaf mission must be pruned"
+    );
+    assert!(
+        ledger_exists(&verify, "run-0:t0:ledger"),
+        "a freshly-billed recent row survives (created_at == now, never aged)"
+    );
+
+    // The audit chain across all N*TURNS billed rows still verifies clean — every retry
+    // re-read the live prev-hash; not one forged a stale link.
+    assert_eq!(
+        audit::verify_audit_chain(&verify).unwrap() as u64,
+        N_THREADS * TURNS_PER_THREAD,
+        "audit chain clean across all concurrent bills"
+    );
+
+    drop(hub);
 }


### PR DESCRIPTION
## The bug (hardening audit, MED)

`record_run_model_call` (run-loop billing, `friday-storage/src/lib.rs`) opened a write txn (`unchecked_transaction` → `token_ledger` + `activity_item` + `audit_ledger` inserts → commit) with **no busy-retry**, called from `bill_model_call` (`friday-hub/src/lib.rs`) with a bare `?`. Under WAL (single writer), once a SECOND writer exists — the reaper thread's `sweep_lifecycle` + (when `FRIDAY_RETENTION_SWEEP=1`) `sweep_retention`'s batched DELETE on a separate connection — a batch that out-holds the WAL write lock longer than `busy_timeout` (`HUB_BUSY_TIMEOUT_MS=5000`) makes the billing INSERT return `SQLITE_BUSY`, and the `?` **crashes the run mid-billing**. Reachable once the reaper/retention flag is enabled.

## Fix (no-degrade, defensive)

1. **Generalized the existing idiom, didn't invent one.** `open_hub_with_busy_retry` → generic `fn with_busy_retry<T>(op) -> Result<T>` (the open path is now a thin alias). Same retry budget / backoff / `is_storage_busy` error class. The **whole** billing txn re-runs per attempt.
2. **Wrapped `record_run_model_call`** in `with_busy_retry`.
3. **Wrapped the ask-path sibling `record_model_call`** too — it shares the identical txn shape and the same latent crash class on the same connection (the audit flagged the run path; the ask path carries the same hazard, so leaving it would be a known un-fixed degrade).
4. **Extended `is_storage_busy`** to also match `SQLITE_BUSY_SNAPSHOT` as belt-and-suspenders — documented as **redundant-for-matching** (`517 & 0xff == 5 == SQLITE_BUSY`, so the primary `DatabaseBusy` arm already catches it). The point of the arm is documentation + future-proofing: `busy_timeout` never auto-retries BUSY_SNAPSHOT, so the application-level retry — not the timeout — is its recovery path.
5. **Left `DEFAULT_BATCH_LIMIT` at 5000** — prefer the billing retry (smaller blast radius), as the task directs.

### No-degrade & atomicity (preserved)
- The retry fires **only** on `is_storage_busy`. With no contention each closure runs **exactly once** → byte-identical to the pre-fix single-txn path (same txn contents, insert ordering, commit). Verified by the unchanged `record_*_writes_all_three_atomically` / `rolls_back_all_three_on_failure` tests passing.
- **Audit-chain atomicity intact:** the retry re-runs the **whole** txn (not just the commit), so `append_audit` re-reads the live prev-hash each attempt — a stale-prev-hash retry would forge a broken chain. A BUSY rolled the failed txn back (nothing committed), so the deterministic `run_id:tN:*` ids re-insert cleanly → no double-bill.

## Tests (`tests/atomic.rs`)

- **Deterministic regression proof (Test A):** a peer write lock held 250ms < the ~800ms retry budget; with `busy_timeout=0` on the billing conn its first attempt hits an immediate BUSY and the retry absorbs it → `Ok`. **Red-without-fix verified:** reverting `record_run_model_call` to the bare-`?` body makes this test go RED with `SqliteFailure(DatabaseBusy, extended_code: 5)`. This empirically settles BUSY_SNAPSHOT: the surfaced code is **plain BUSY (5), never 517** — the billing txn is write-first (first statement is the INSERT), so it takes its snapshot at write time.
- **Concurrent-invariant stress harness (Test B):** N=6 **prod-faithful** billers (`busy_timeout=HUB_BUSY_TIMEOUT_MS`) + a reaper thread running `sweep_lifecycle` + `sweep_retention` on a short cadence with a small batch over seeded aged rows. Asserts: no billing error, no FK error (reaper `table_errors==0`), aged rows pruned, active mission + freshly-billed recent rows survive, no double-bill, audit chain clean across all concurrent commits. **20/20 runs stable.** (Scope: Test B proves invariants under genuine concurrency; Test A is the deterministic retry-fires regression gate.)
- **Lib unit tests:** BUSY_SNAPSHOT recognition (proving `extended_code==517` already has primary `code==DatabaseBusy`), and the generic `with_busy_retry` for a non-`Db` type.

## CI

- `cargo fmt --all -- --check` ✅
- `cargo clippy --workspace --all-targets -- -D warnings` ✅
- `cargo test -p friday-storage -p friday-hub` ✅ (all green incl. the new tests)
- `.secrets.baseline` unchanged (only 2 Rust files touched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)