### PR TITLE
fix(hub): 3 flip-precondition hardening fixes — anthropic timeout, validate entrypoint, SSRF IPv6 transition (no-degrade)

### DIFF
--- a/rust-core/crates/friday-anthropic/src/lib.rs
+++ b/rust-core/crates/friday-anthropic/src/lib.rs
@@ -50,6 +50,21 @@ pub const DEFAULT_MODEL: &str = "claude-opus-4-8";
 /// Hub-only environment variable holding the Anthropic API key.
 pub const ENV_KEY: &str = "FRIDAY_ANTHROPIC_API_KEY";
 
+/// (#24b degrade-4, hardening) The wall-clock ceiling on a SINGLE Claude HTTP call (overall
+/// request: DNS + connect + send + read body). The bare `ureq::post().send_json()` this transport
+/// used had NO timeout, so one hung call (a server that ACCEPTS but never replies) could exceed the
+/// crash-recovery staleness threshold (`EXECUTION_STATE_STALE_THRESHOLD_MS` = 5 min) and let a
+/// concurrent boot reconcile ABORT a still-LIVE run. This bound bites BOTH the failover fallback
+/// (`ClaudeClient::chat`) AND vision (`friday_vision::ClaudeVisionClient`, which reuses this
+/// transport). 60s mirrors [`friday_deepseek::DEEPSEEK_REQUEST_TIMEOUT_MS`] exactly: with
+/// `FRIDAY_PROVIDER_FAILOVER=1` the worst-case gap is primary 60s + fallback 60s = 120s, still WELL
+/// under the 300s threshold (≈2.5x margin), and the agent loop re-sets its durable heartbeat before
+/// EACH attempt. It is generous for a real Claude completion (seconds to low tens-of-seconds). A
+/// timed-out call surfaces as a `ureq::Error::Transport` ⇒ [`ClaudeError::ProviderUnavailable`]
+/// (transient) ⇒ [`crate`-external `is_failover_worthy`] treats it as a transient outage — the run
+/// is never silently wedged.
+pub const ANTHROPIC_REQUEST_TIMEOUT_MS: u64 = 60_000;
+
 // `Clone + PartialEq + Eq` mirrors `DeepSeekError` so the structured error could be
 // carried (not stringified) if a future slice adds an `AgentError::ClaudeRoute`
 // variant + classifier arm. In THIS dark slice the friday-hub adapter maps a
@@ -96,12 +111,29 @@ pub trait Transport {
 
 /// Real blocking HTTP transport (ureq + rustls). Maps errors to controlled
 /// [`ClaudeError`] messages — it never formats the request (which carries the
-/// `x-api-key` header) into an error string.
-pub struct UreqTransport;
+/// `x-api-key` header) into an error string. Built on a shared [`ureq::Agent`] carrying the
+/// [`ANTHROPIC_REQUEST_TIMEOUT_MS`] overall-request timeout (#24b degrade-4, hardening) so no
+/// single Claude call (chat OR vision) can hang past the crash-recovery staleness threshold.
+pub struct UreqTransport {
+    agent: ureq::Agent,
+}
 
 impl UreqTransport {
     pub fn new() -> Self {
-        UreqTransport
+        Self::with_timeout_ms(ANTHROPIC_REQUEST_TIMEOUT_MS)
+    }
+
+    /// (#24b degrade-4, hardening) Build the transport with an explicit overall-request timeout
+    /// (ms). Used by [`Self::new`] with the production [`ANTHROPIC_REQUEST_TIMEOUT_MS`] ceiling, and
+    /// by tests with a short timeout to prove a hung server is bounded rather than wedging the run
+    /// forever. `pub` so the `friday-vision` tests can inject a short timeout into a
+    /// `ClaudeVisionClient` too (they construct the transport directly).
+    pub fn with_timeout_ms(timeout_ms: u64) -> Self {
+        UreqTransport {
+            agent: ureq::AgentBuilder::new()
+                .timeout(std::time::Duration::from_millis(timeout_ms))
+                .build(),
+        }
     }
 }
 
@@ -136,7 +168,11 @@ fn map_ureq_err(e: ureq::Error) -> ClaudeError {
 
 impl Transport for UreqTransport {
     fn post_json(&self, url: &str, api_key: &str, body: &Value) -> Result<Value, ClaudeError> {
-        let resp = ureq::post(url)
+        // (#24b degrade-4, hardening) Route through the timeout-bounded shared agent (see
+        // UreqTransport) — never a bare `ureq::post()` (which has no timeout).
+        let resp = self
+            .agent
+            .post(url)
             .set("x-api-key", api_key)
             .set("anthropic-version", ANTHROPIC_VERSION)
             .set("content-type", "application/json")
@@ -384,15 +420,45 @@ mod tests {
         let addr = listener.local_addr().unwrap();
         let handle = thread::spawn(move || {
             let (mut stream, _) = listener.accept().unwrap();
-            let mut req = [0u8; 2048];
-            let n = stream.read(&mut req).unwrap_or(0);
-            let captured = String::from_utf8_lossy(&req[..n]).into_owned();
+            // Read the FULL request header block. A single `read()` can return a PARTIAL request
+            // (TCP segments the request line + headers + JSON body across packets); closing the
+            // socket with UNREAD bytes still in the recv buffer sends an RST (not a clean FIN),
+            // which the client surfaces as `transport: Network Error` mid-response — a latent race
+            // in the old single-read helper, exposed under parallel test load. Loop until we've
+            // seen the header terminator (`\r\n\r\n`), then respond.
+            let mut captured: Vec<u8> = Vec::new();
+            let mut tmp = [0u8; 1024];
+            loop {
+                match stream.read(&mut tmp) {
+                    Ok(0) => break,
+                    Ok(n) => {
+                        captured.extend_from_slice(&tmp[..n]);
+                        if captured.windows(4).any(|w| w == b"\r\n\r\n") {
+                            break;
+                        }
+                    }
+                    Err(_) => break,
+                }
+            }
             let response = format!(
                 "HTTP/1.1 {status} {reason}\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{body}",
                 body.len()
             );
             stream.write_all(response.as_bytes()).unwrap();
-            captured
+            stream.flush().unwrap();
+            // Deliver the response, then a CLEAN close (FIN, not RST): half-close the write side
+            // and drain whatever the client still sends. A short read timeout keeps the drain
+            // bounded so a keep-alive client (Content-Length set ⇒ ureq pools the conn) cannot
+            // block `handle.join()` forever.
+            let _ = stream.shutdown(std::net::Shutdown::Write);
+            let _ = stream.set_read_timeout(Some(std::time::Duration::from_millis(200)));
+            let mut sink = [0u8; 1024];
+            while let Ok(n) = stream.read(&mut sink) {
+                if n == 0 {
+                    break;
+                }
+            }
+            String::from_utf8_lossy(&captured).into_owned()
         });
         (format!("http://{addr}"), handle)
     }
@@ -746,6 +812,56 @@ mod tests {
             );
         }
     }
+
+    #[test]
+    fn real_transport_bounds_a_hung_request_with_a_wall_clock_timeout() {
+        // (#24b degrade-4, hardening) A server that ACCEPTS the connection but never replies must
+        // NOT wedge the Claude call forever — the overall-request timeout fires and surfaces a
+        // TRANSIENT ProviderUnavailable (so the loop's bounded transient retry / the failover
+        // classifier handles it; the run is never silently hung past the crash-recovery staleness
+        // threshold). A SHORT (250ms) timeout keeps the test fast; production uses
+        // ANTHROPIC_REQUEST_TIMEOUT_MS. This proves the CHAT (failover-fallback) path.
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        let handle = thread::spawn(move || {
+            // Accept then HANG: read the request but never write a response, holding the socket
+            // open until the client times out and drops it. The sleep need only OUTLAST the
+            // client's 250ms timeout — keeping it SHORT (and dropping the stream/listener promptly
+            // after) avoids holding sockets long enough to contend with the other parallel
+            // real-transport tests in this binary.
+            if let Ok((mut stream, _)) = listener.accept() {
+                let mut req = [0u8; 2048];
+                let _ = stream.read(&mut req);
+                std::thread::sleep(std::time::Duration::from_millis(500));
+            }
+        });
+        let c = ClaudeClient::with_transport_and_base_url(
+            UreqTransport::with_timeout_ms(250),
+            "test-key-not-real".to_string(),
+            format!("http://{addr}"),
+        );
+        let start = std::time::Instant::now();
+        let err = c.chat("claude-opus-4-8", "hi", 16).unwrap_err();
+        let elapsed = start.elapsed();
+        let _ = handle.join();
+        // It returned (did not hang) well within a second, classified as transient.
+        assert!(
+            elapsed < std::time::Duration::from_millis(1_500),
+            "the timeout must bound the call; took {elapsed:?}"
+        );
+        assert!(
+            matches!(err, ClaudeError::ProviderUnavailable(_)),
+            "a timed-out call is a transient ProviderUnavailable, got {err:?}"
+        );
+    }
+
+    // The production per-call ceiling MUST be well under the crash-recovery staleness threshold
+    // (300_000ms / 5 min), so a slow-but-live Claude call can never be mistaken for a crash. A
+    // compile-time assert (clippy rejects a runtime assert on a constant), mirroring DeepSeek.
+    const _: () = assert!(
+        ANTHROPIC_REQUEST_TIMEOUT_MS < 300_000,
+        "the per-call timeout must be under the 5-min crash-recovery staleness threshold"
+    );
 
     #[test]
     fn malformed_json_body_is_bad_response() {

--- a/rust-core/crates/friday-hub/src/bin/hub_agent_run_server.rs
+++ b/rust-core/crates/friday-hub/src/bin/hub_agent_run_server.rs
@@ -128,7 +128,7 @@ use std::thread;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use friday_crypto::{seal, DataKey, DeviceKeypair, FileSecureStore};
-use friday_deepseek::Transport;
+use friday_deepseek::{Transport, UreqTransport};
 use friday_hub::hub_server::{AuthedPrincipal, ForwardedAuth};
 use friday_hub::key_source::{PEER_PUBKEY_ALLOWLIST_ID, X25519_PUBKEY_LEN};
 use friday_hub::runtime::{HubConfig, HubRuntime};
@@ -301,7 +301,7 @@ fn run() -> Result<(), ServerError> {
     // allowlist admits, so owner-wiring records `owner == caller` and the body is releasable to
     // them. `HubRuntime::live` only CONSTRUCTS the provider client (no network call); an actual
     // run needs the env key — the separate operator live-proof.
-    let runtime = HubRuntime::live(HubConfig {
+    let mut runtime = HubRuntime::live(HubConfig {
         // Clone here so the `db_path` binding stays alive for the session-reaper tick below,
         // which opens its OWN connection to the SAME path (the accept-loop's runtime
         // connection is never shared across threads).
@@ -315,6 +315,19 @@ fn run() -> Result<(), ServerError> {
         operator_vk: None,
     })
     .map_err(|_| ServerError::Init)?;
+
+    // (1b) BUG-6 — OPERATOR-TRIGGERED route validation. `HubRuntime::live` attaches a gated
+    // secondary route (claude / codex) `available:true, validation_ok:false`; the route is NOT
+    // dispatchable until validated, and `validate_and_enable_*` had NO production caller. When the
+    // operator passes `--validate-claude` / `--validate-codex`, run the probe NOW on the held
+    // serving runtime (so the in-process `validation_ok` flip lives in the long-lived process that
+    // serves requests — a separate one-shot would persist nothing). DEFAULT (no flag) ⇒ skipped ⇒
+    // ZERO quota, so a normal boot never spends an Anthropic token (the "never auto-run at boot"
+    // requirement). Fail-soft: a failed secondary-route probe leaves it closed; DeepSeek serves on.
+    let validate = ValidateRequest::from_args(&args);
+    if validate.any() {
+        run_boot_validation(&mut runtime, validate);
+    }
 
     // (2) The server's OWN long-lived keypair (the ONLY `generate()` in non-test code). In
     // production this comes from SecureStore; the peer's public key arrives FROM THE PEER over
@@ -1747,6 +1760,90 @@ fn arg_value(args: &[String], name: &str) -> Option<String> {
             args.iter()
                 .find_map(|arg| arg.strip_prefix(&prefix).map(str::to_string))
         })
+}
+
+/// True iff the bare flag `name` appears as its OWN argument (no value form). Used for the
+/// operator-triggered validate flags below.
+fn has_flag(args: &[String], name: &str) -> bool {
+    args.iter().any(|a| a == name)
+}
+
+/// (BUG-6) The operator CLI flag that triggers a ONE-SHOT live Claude key probe at boot, BEFORE
+/// the serve loop, marking the in-process `claude` route `validation_ok: true` on success so a
+/// claude-PINNED / claude-SIZE-ROUTED request becomes SELECTABLE in the long-lived serving runtime.
+/// DEFAULT-ABSENT: a normal boot passes this flag NOT AT ALL ⇒ no probe ⇒ ZERO Anthropic quota
+/// spent (the `validate_and_enable_claude` probe spends ~1-2 tokens, so it MUST NOT auto-run — this
+/// explicit, operator-supplied flag is the trigger). Only meaningful with
+/// `FRIDAY_CLAUDE_ROUTE_ENABLED=1` (else the `claude` route is not attached and the mark is a no-op).
+pub const VALIDATE_CLAUDE_FLAG: &str = "--validate-claude";
+
+/// (BUG-6) The operator CLI flag that triggers a ONE-SHOT creds-light Codex app-server health probe
+/// at boot, BEFORE the serve loop, marking the in-process `codex` route `validation_ok: true` on a
+/// healthy probe (spawns a local app-server; NO model turn ⇒ ZERO completion quota). DEFAULT-ABSENT
+/// (mirrors [`VALIDATE_CLAUDE_FLAG`]). Only meaningful with `FRIDAY_CODEX_ROUTE_ENABLED=1`.
+pub const VALIDATE_CODEX_FLAG: &str = "--validate-codex";
+
+/// Which routes the operator asked to validate at boot (pure parse of the CLI args — no env, no
+/// network — so it is unit-testable). The serve `run()` consults this AFTER building the runtime
+/// and BEFORE the serve loop. Absent flags ⇒ all `false` ⇒ no probe, no quota (the prod default).
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct ValidateRequest {
+    pub claude: bool,
+    pub codex: bool,
+}
+
+impl ValidateRequest {
+    pub fn from_args(args: &[String]) -> Self {
+        ValidateRequest {
+            claude: has_flag(args, VALIDATE_CLAUDE_FLAG),
+            codex: has_flag(args, VALIDATE_CODEX_FLAG),
+        }
+    }
+
+    fn any(&self) -> bool {
+        self.claude || self.codex
+    }
+}
+
+/// (BUG-6) Run the operator-requested route validation against the HELD serving runtime, in place,
+/// BEFORE the serve loop. This is the SINGLE production caller of
+/// [`HubRuntime::validate_and_enable_claude`] / [`HubRuntime::validate_and_enable_codex`] — without
+/// it those methods had ZERO bin callers, so `FRIDAY_CLAUDE_ROUTE_ENABLED=1` attached the route
+/// `available:true, validation_ok:false` and a claude-pinned/size-routed request fail-closed
+/// `NoEligibleRoute` forever (the silent route-selection no-op BUG-6 names).
+///
+/// FAIL-SOFT, not fail-boot: a CredentialMissing / Invalid / Unavailable / unhealthy outcome is
+/// LOGGED (coarse, secret-free label) and leaves that route NON-validated (claude/codex requests
+/// `NoEligibleRoute`; the DeepSeek primary is UNAFFECTED). Aborting the whole boot over a
+/// SECONDARY-route validation failure would needlessly take down a healthy DeepSeek hub — the
+/// safe posture is "DeepSeek serves; the unvalidated secondary route stays closed". The mutation is
+/// in-process only (mirrors `validate_and_enable_*`), which is exactly why it must run on the
+/// long-lived serving runtime here, not in a separate one-shot process that would exit and persist
+/// nothing.
+fn run_boot_validation(runtime: &mut HubRuntime<UreqTransport>, req: ValidateRequest) {
+    if req.claude {
+        eprintln!("hub_agent_run_server: --validate-claude — running live Claude key probe (spends ~1-2 Anthropic tokens)");
+        let outcome = runtime.validate_and_enable_claude();
+        if outcome.is_confirmed_valid() {
+            eprintln!("hub_agent_run_server: claude route VALIDATED — claude-pinned/size-routed requests now selectable");
+        } else {
+            eprintln!(
+                "hub_agent_run_server: claude validation NOT confirmed ({}) — claude route stays closed (DeepSeek unaffected)",
+                outcome.label()
+            );
+        }
+    }
+    if req.codex {
+        eprintln!("hub_agent_run_server: --validate-codex — running creds-light Codex app-server health probe (no model turn)");
+        match runtime.validate_and_enable_codex() {
+            Ok(_summary) => eprintln!(
+                "hub_agent_run_server: codex route VALIDATED — codex-pinned/size-routed requests now selectable"
+            ),
+            Err(_e) => eprintln!(
+                "hub_agent_run_server: codex validation NOT confirmed (app-server health probe failed) — codex route stays closed (DeepSeek unaffected)"
+            ),
+        }
+    }
 }
 
 /// Ephemeral, non-secret bytes for the boot-time runtime config (dormant under deny-all).
@@ -4315,6 +4412,39 @@ mod tests {
         assert_eq!(arg_value(&args, "--port").as_deref(), Some("7777"));
         assert_eq!(arg_value(&args, "--owner").as_deref(), Some("principal:o"));
         assert_eq!(arg_value(&args, "--missing"), None);
+    }
+
+    #[test]
+    fn validate_request_parses_the_operator_flags_default_off() {
+        // BUG-6: a normal boot (no flag) ⇒ NO validation ⇒ zero quota. The flags are bare
+        // (presence = true), independent, and accept the `=`-free OWN-argument form.
+        let base = vec![
+            "bin".to_string(),
+            "--workspace".to_string(),
+            "/tmp".to_string(),
+        ];
+        let none = ValidateRequest::from_args(&base);
+        assert_eq!(none, ValidateRequest::default());
+        assert!(
+            !none.any(),
+            "no flag ⇒ no probe (the prod default, zero quota)"
+        );
+
+        let mut claude = base.clone();
+        claude.push(VALIDATE_CLAUDE_FLAG.to_string());
+        let r = ValidateRequest::from_args(&claude);
+        assert!(r.claude && !r.codex && r.any());
+
+        let mut both = base.clone();
+        both.push(VALIDATE_CLAUDE_FLAG.to_string());
+        both.push(VALIDATE_CODEX_FLAG.to_string());
+        let r = ValidateRequest::from_args(&both);
+        assert!(r.claude && r.codex);
+
+        // A value-form `--validate-claude=1` is NOT the bare flag — only the OWN-argument form
+        // triggers (avoids an accidental enable from a stray `=`-suffixed arg).
+        let valueish = vec!["bin".to_string(), "--validate-claude=1".to_string()];
+        assert!(!ValidateRequest::from_args(&valueish).claude);
     }
 
     #[test]

--- a/rust-core/crates/friday-hub/src/ssrf_guard.rs
+++ b/rust-core/crates/friday-hub/src/ssrf_guard.rs
@@ -206,10 +206,55 @@ pub fn is_private_ipv4(ip: &Ipv4Addr) -> bool {
     false
 }
 
+/// Extract the IPv4 address that an IPv6 *transition-mechanism* prefix embeds/encodes, if `ip`
+/// belongs to one of the well-known transition prefixes whose tail (or encoding) carries a v4
+/// address that Rust's [`Ipv6Addr::to_ipv4`] does NOT recognize:
+///   - **NAT64** (`64:ff9b::/96`, RFC 6052 well-known prefix): the embedded v4 is the LAST 32 bits.
+///     (Network-specific NAT64 prefixes are operator-chosen and not detectable from the address
+///     alone, so only the well-known prefix is covered — an honest, documented gap.)
+///   - **6to4** (`2002::/16`, RFC 3056): the embedded v4 is segments `[1]` (high 16 bits) and
+///     `[2]` (low 16 bits), i.e. `2002:AABB:CCDD::` ⇒ `AA.BB.CC.DD`.
+///   - **Teredo** (`2001:0000::/32`, RFC 4380): the embedded (client) v4 is the LAST 32 bits XORed
+///     with `0xffff_ffff` (obfuscated). Teredo is `2001:0000::/32` — segment `[0]==0x2001` AND
+///     `[1]==0x0000`; gating on `[0]` alone would wrongly catch global `2001:db8::`/`2001:4860::`
+///     production IPv6.
+///
+/// Returns `None` when `ip` is not in any of these prefixes (the caller then falls through to the
+/// scope-bit checks). This MIRRORS the existing `to_ipv4()` reclassification — it only ADDS
+/// detection of v4 embedded in prefixes `to_ipv4()` returns `None` for; it never unblocks anything.
+fn embedded_transition_ipv4(ip: &Ipv6Addr) -> Option<Ipv4Addr> {
+    let s = ip.segments();
+    // NAT64 well-known prefix 64:ff9b::/96 ⇒ embedded v4 = last 32 bits (segments [6],[7]).
+    if s[0] == 0x0064 && s[1] == 0xff9b && s[2] == 0 && s[3] == 0 && s[4] == 0 && s[5] == 0 {
+        return Some(Ipv4Addr::new(
+            (s[6] >> 8) as u8,
+            (s[6] & 0xff) as u8,
+            (s[7] >> 8) as u8,
+            (s[7] & 0xff) as u8,
+        ));
+    }
+    // 6to4 2002::/16 ⇒ embedded v4 = segments [1] (AA.BB) + [2] (CC.DD).
+    if s[0] == 0x2002 {
+        return Some(Ipv4Addr::new(
+            (s[1] >> 8) as u8,
+            (s[1] & 0xff) as u8,
+            (s[2] >> 8) as u8,
+            (s[2] & 0xff) as u8,
+        ));
+    }
+    // Teredo 2001:0000::/32 ⇒ embedded (client) v4 = last 32 bits XOR 0xffff_ffff.
+    if s[0] == 0x2001 && s[1] == 0x0000 {
+        let obfuscated = ((s[6] as u32) << 16) | (s[7] as u32);
+        return Some(Ipv4Addr::from(obfuscated ^ 0xffff_ffff));
+    }
+    None
+}
+
 /// True if an IPv6 address is private / reserved / internal.
 /// Covers `::` (unspecified), `::1` (loopback), IPv4-mapped/embedded (`::ffff:a.b.c.d`,
-/// reclassified through the v4 table), `fe80::/10` (link-local), `fec0::/10` (deprecated
-/// site-local), and `fc00::/7` (unique-local).
+/// reclassified through the v4 table), the transition-mechanism embedded-v4 prefixes (NAT64
+/// `64:ff9b::/96`, 6to4 `2002::/16`, Teredo `2001:0000::/32` — see [`embedded_transition_ipv4`]),
+/// `fe80::/10` (link-local), `fec0::/10` (deprecated site-local), and `fc00::/7` (unique-local).
 pub fn is_private_ipv6(ip: &Ipv6Addr) -> bool {
     // Unspecified (all zeros).
     if ip.is_unspecified() {
@@ -225,6 +270,15 @@ pub fn is_private_ipv6(ip: &Ipv6Addr) -> bool {
     if let Some(v4) = ip.to_ipv4() {
         // Exclude the genuinely-global tiny tail (only ::/96 and ::ffff:/96 embed v4; any
         // other prefix is NOT an embedded-v4 address). `to_ipv4()` already restricts to those.
+        return is_private_ipv4(&v4);
+    }
+    // IPv6 transition mechanisms (NAT64 / 6to4 / Teredo) ENCODE an IPv4 address that `to_ipv4()`
+    // does NOT recognize. On an IPv6-only / NAT64-DNS64 egress (carrier-grade / IPv6 VPC) a host
+    // like `http://[64:ff9b::a00:1]/` (embeds 10.0.0.1) would otherwise classify PUBLIC and get
+    // pinned — an SSRF bypass. Extract the embedded v4 and run it through the v4 private table.
+    // This runs AFTER `to_ipv4()` (those prefixes return `None` from it, so there is no overlap)
+    // and only ADDS blocks: a transition prefix wrapping a PUBLIC v4 still classifies public.
+    if let Some(v4) = embedded_transition_ipv4(ip) {
         return is_private_ipv4(&v4);
     }
     let first = ip.segments()[0];
@@ -407,13 +461,25 @@ mod tests {
             "::ffff:127.0.0.1",       // IPv4-mapped loopback
             "::ffff:10.0.0.1",        // IPv4-mapped RFC1918
             "::ffff:169.254.169.254", // IPv4-mapped metadata
+            // ── IPv6 transition mechanisms embedding/encoding a PRIVATE v4 (the BUG-5 fix) ──
+            "64:ff9b::a00:1",           // NAT64 well-known prefix ⇒ 10.0.0.1
+            "64:ff9b::a9fe:a9fe",       // NAT64 ⇒ 169.254.169.254 (metadata)
+            "2002:0a00:0001::",         // 6to4 ⇒ 10.0.0.1
+            "2002:a9fe:a9fe::",         // 6to4 ⇒ 169.254.169.254 (metadata)
+            "2001:0:0:0:0:0:f5ff:fffe", // Teredo (2001:0000::/32) ⇒ last32 XOR ffffffff = 10.0.0.1
         ];
         for ip in blocked {
             let v6: Ipv6Addr = ip.parse().unwrap();
             assert!(is_private_ipv6(&v6), "{ip} must be classified private");
         }
-        // Public IPv6 (e.g. a Google DNS) is NOT blocked.
-        for ip in ["2001:4860:4860::8888", "2606:4700:4700::1111"] {
+        // Public IPv6 (e.g. a Google DNS) is NOT blocked. CRITICAL regression guard for Teredo:
+        // 2001:4860:4860::8888 has segment[0]==0x2001 but segment[1]!=0x0000, so it is NOT Teredo
+        // and must stay PUBLIC — gating Teredo on segment[0] alone would wrongly block it.
+        for ip in [
+            "2001:4860:4860::8888", // Google public DNS (2001:: but NOT Teredo)
+            "2606:4700:4700::1111", // Cloudflare public DNS
+            "2002:5db8:d822::",     // 6to4 wrapping a PUBLIC v4 (93.184.216.34) ⇒ still public
+        ] {
             let v6: Ipv6Addr = ip.parse().unwrap();
             assert!(!is_private_ipv6(&v6), "{ip} must be classified public");
         }
@@ -450,6 +516,12 @@ mod tests {
             "http://service.internal/",
             "http://app.localhost/",
             "http://100.64.1.1/", // CGNAT
+            // ── BUG-5: IPv6 transition mechanisms encoding a PRIVATE v4, reachable on an
+            //    IPv6-only / NAT64-DNS64 egress. Each embeds 10.0.0.1 or the metadata IP. ──
+            "http://[64:ff9b::a00:1]/",     // NAT64 well-known ⇒ 10.0.0.1
+            "http://[64:ff9b::a9fe:a9fe]/", // NAT64 ⇒ 169.254.169.254 metadata
+            "http://[2002:0a00:0001::]/",   // 6to4 ⇒ 10.0.0.1
+            "http://[2001:0:0:0:0:0:f5ff:fffe]/", // Teredo ⇒ 10.0.0.1
         ];
         for u in cases {
             let err = validate_url(u, &deny()).unwrap_err();
@@ -460,6 +532,35 @@ mod tests {
                 ),
                 "{u} must be SSRF-blocked, got {err:?}"
             );
+        }
+    }
+
+    // ── BUG-5 regression: octal/hex/decimal IPv4 literals. The task asks to assert these are
+    //    "handled today" — i.e. the `url` crate's host parser normalizes the encoded form to a
+    //    canonical IPv4 (e.g. `2130706433` ⇒ 127.0.0.1, `0x7f000001` ⇒ 127.0.0.1) so our literal-IP
+    //    classifier still blocks them. This pins that behavior so a future `url` upgrade that
+    //    stopped normalizing (re-opening the bypass) goes RED. We assert the OBSERVED contract:
+    //    forms the parser canonicalizes to a private IP are BlockedPrivateIp; forms it rejects
+    //    outright are an error (also fail-closed) — either way NEVER an Ok(public).
+    #[test]
+    fn validate_url_blocks_encoded_ipv4_literals_or_fails_closed() {
+        for u in [
+            "http://2130706433/",   // decimal 127.0.0.1
+            "http://0x7f000001/",   // hex 0x7f000001 = 127.0.0.1
+            "http://0x7f.0.0.1/",   // dotted-hex 127.0.0.1
+            "http://017700000001/", // octal 127.0.0.1
+            "http://0xa000001/",    // hex 10.0.0.1
+        ] {
+            // Must NOT be an Ok(public) — either blocked as a private IP, or rejected as
+            // unparseable/blocked. Fail-closed in every branch.
+            match validate_url(u, &deny()) {
+                Ok(host) => panic!("{u} normalized to a passable host {host:?} — SSRF bypass!"),
+                Err(SsrfError::BlockedPrivateIp(_))
+                | Err(SsrfError::BlockedHostname(_))
+                | Err(SsrfError::InvalidUrl(_))
+                | Err(SsrfError::EmptyHost) => {} // all fail-closed
+                Err(other) => panic!("{u} unexpected error {other:?}"),
+            }
         }
     }
 

--- a/rust-core/crates/friday-vision/src/lib.rs
+++ b/rust-core/crates/friday-vision/src/lib.rs
@@ -459,6 +459,46 @@ mod tests {
     }
 
     #[test]
+    fn claude_vision_real_transport_bounds_a_hung_request_with_a_wall_clock_timeout() {
+        // (#24b degrade-4, hardening) The vision client REUSES the friday-anthropic UreqTransport,
+        // so the same wall-clock bound that protects `ClaudeClient::chat` protects vision: a server
+        // that ACCEPTS but never replies must NOT wedge the call forever. We point the REAL
+        // transport (short 250ms timeout) at a hung localhost server and assert the call returns a
+        // VisionError::Provider (the mapped transient ProviderUnavailable) well within a second —
+        // never hanging past the crash-recovery staleness threshold.
+        use std::io::Read as _;
+        use std::net::TcpListener;
+        use std::thread;
+
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        let handle = thread::spawn(move || {
+            if let Ok((mut stream, _)) = listener.accept() {
+                let mut req = [0u8; 2048];
+                let _ = stream.read(&mut req);
+                std::thread::sleep(std::time::Duration::from_millis(2_000));
+            }
+        });
+        let client = ClaudeVisionClient::with_transport_and_base_url(
+            UreqTransport::with_timeout_ms(250),
+            "test-key-not-real",
+            format!("http://{addr}"),
+        );
+        let start = std::time::Instant::now();
+        let err = client.analyze(&sample_request()).unwrap_err();
+        let elapsed = start.elapsed();
+        let _ = handle.join();
+        assert!(
+            elapsed < std::time::Duration::from_millis(1_500),
+            "the timeout must bound the vision call; took {elapsed:?}"
+        );
+        assert!(
+            matches!(err, VisionError::Provider(_)),
+            "a timed-out vision call maps to a provider error, got {err:?}"
+        );
+    }
+
+    #[test]
     fn encode_image_base64_round_trips_standard_alphabet() {
         let bytes = b"\x00\x01\x02\xff\xfe binary image bytes";
         let encoded = encode_image_base64(bytes);


### PR DESCRIPTION
## Headline judgment call — the BUG 6 premise as stated is FALSE (corrected here)

The task's stated precondition — *"flipping `FRIDAY_PROVIDER_FAILOVER` requires running validate first, else failover is a silent no-op"* — is **false**, verified against `provider_failover.rs`:

- `ProviderFailoverWrapper::next_step_metered` calls the Claude fallback client **directly** (`self.fallback.next_step_metered(...)`); it never consults `route_selector` or `validation_ok`. So failover does NOT depend on validation.
- A misconfigured failover is a **loud HARD boot error**, not silent: `wrap_for_failover_flagged` returns `FailoverMisconfigured` if `claude.is_none()`, and the fallback `ClaudeClient::from_env()?` hard-errors on a missing key. The real failover precondition (`FRIDAY_CLAUDE_ROUTE_ENABLED=1` + key present) is already enforced fail-closed.

**The real silent gap is the ROUTE-SELECTION path** (not failover): `FRIDAY_CLAUDE_ROUTE_ENABLED=1` attaches the claude route `available:true, validation_ok:false`, and `validate_and_enable_claude/codex` had **zero** production callers, so a claude-PINNED / size-routed request `NoEligibleRoute`s forever. That is what this PR fixes. Shipping the task's literal precondition would itself be a degrade (false honesty label), so the docs/report state the honest split:

- **Route-selection precondition (the actual fix):** run `--validate-claude` once before a claude-pinned/size-routed request can be selected.
- **Failover precondition:** validation NOT required (wrapper calls Claude directly). Running validate first is **recommended as a pre-flight** — it catches a present-but-expired key before the operator relies on the net, rather than as a 401 at the moment failover fires.

---

## BUG 3 (HIGH) — friday-anthropic UreqTransport had no request timeout
`post_json` was a bare `ureq::post(url)...send_json()` — no timeout, no shared Agent — so a hung Claude server wedged BOTH `ClaudeClient::chat` (the failover fallback, #769) AND `ClaudeVisionClient` (#775) indefinitely, drifting the crash-recovery heartbeat past the 300s staleness threshold → false PASS-2 abort.

**Fix** (`friday-anthropic/src/lib.rs`): mirror friday-deepseek exactly.
- `ANTHROPIC_REQUEST_TIMEOUT_MS = 60_000` (lib.rs ~54).
- `UreqTransport` now holds a shared `ureq::Agent` built with that overall-request timeout; `new()` + `pub with_timeout_ms(ms)` (lib.rs ~112–135); `post_json` routes through `self.agent.post(...)` (lib.rs ~157).
- A timed-out call surfaces as `ureq::Error::Transport` ⇒ `ClaudeError::ProviderUnavailable` (transient) ⇒ `is_failover_worthy` (staleness math: primary 60s + fallback 60s = 120s ≪ 300s).
- Bounded-hang test `real_transport_bounds_a_hung_request_with_a_wall_clock_timeout` (CHAT) + `claude_vision_real_transport_bounds_a_hung_request_with_a_wall_clock_timeout` in friday-vision (VISION) — both point at an accept-then-never-reply server, assert the call errors within ~the timeout. Plus the compile-time `ANTHROPIC_REQUEST_TIMEOUT_MS < 300_000` assert.
- Also hardened the **pre-existing flaky** `serve_http_once` test helper: it did a single `read()` then closed the socket; a partial read (TCP segments the POST body) left unread recv bytes, so the close RST'd the client mid-response (`transport: Network Error`). Now it reads the full header block, then half-closes + bounded-drains for a clean FIN. **Proven pre-existing** (the unmodified bare-`ureq::post` suite flaked 3/8 under parallel load) — production change exonerated; helper fix is test-only.

## BUG 6 (MED) — validate_and_enable_claude/codex had no production caller
**Fix** (`friday-hub/src/bin/hub_agent_run_server.rs`): operator-triggered boot flags.
- `--validate-claude` / `--validate-codex` (consts `VALIDATE_CLAUDE_FLAG` / `VALIDATE_CODEX_FLAG`, ~1760).
- `ValidateRequest::from_args` (pure, unit-tested) + `run_boot_validation(&mut runtime, req)` (~1805) run the probe on the **held serving runtime** before the serve loop — so the in-process `validation_ok` flip lives in the long-lived process (a one-shot would exit and persist nothing).
- **Default-absent ⇒ no probe ⇒ ZERO Anthropic quota** (the "never auto-run at boot" requirement; the Claude probe spends ~1-2 tokens).
- **Fail-soft:** CredentialMissing/Invalid/Unavailable/unhealthy is logged (coarse label) and leaves the route closed; the DeepSeek primary is unaffected. Aborting a healthy DeepSeek boot over a secondary-route failure would be too aggressive.
- **Operator runs:** `hub_agent_run_server --workspace … --validate-claude` (requires `FRIDAY_CLAUDE_ROUTE_ENABLED=1`, else the route isn't attached and the mark is a no-op). Same for `--validate-codex` (`FRIDAY_CODEX_ROUTE_ENABLED=1`).
- Test `validate_request_parses_the_operator_flags_default_off`. The validated→selectable / unvalidated→NoEligibleRoute behaviors are already covered by existing runtime tests (`runtime_with_claude_wired`, `validation_probe_credential_missing_keeps_claude_undispatchable`) — not duplicated.

## BUG 5 (MED) — SSRF guard missed IPv6 transition-mechanism embedded IPv4
`is_private_ipv6` reclassified embedded v4 only via Rust `to_ipv4()` (recognizes only `::ffff:/96` + `::/96`), so NAT64 (`64:ff9b::/96`), 6to4 (`2002::/16`), Teredo (`2001:0000::/32`) wrapping a private v4 classified PUBLIC and got pinned — reachable on IPv6-only / NAT64-DNS64 egress. Affects `web_fetch` (#771) + vision URL fetch (#775).

**Fix** (`friday-hub/src/ssrf_guard.rs` ~225): `embedded_transition_ipv4()` extracts the embedded/encoded v4 (NAT64 last-32, 6to4 `[1]`/`[2]`, Teredo last-32 XOR `0xffffffff`) and runs `is_private_ipv4` on it, AFTER the `to_ipv4()` branch (no overlap — those prefixes return `None` from `to_ipv4()`). **Only ADDS blocks.** Teredo gated on `segment[0]==0x2001 AND [1]==0x0000` so global `2001:4860::`/`2001:db8::` stays public (gating on `[0]` alone would wrongly block Google DNS). Extends the IPv6 table + `validate_url` table with NAT64/6to4/Teredo (incl. metadata 169.254.169.254) + a public-6to4 negative + an encoded-IPv4-literal (decimal/hex/octal) fail-closed regression (the `url` crate canonicalizes these to a v4 today; the test pins that so a future `url` upgrade re-opening the bypass goes red).

## No-degrade
All three additive/defensive; flag-OFF paths byte-unchanged. The timeout only bounds a hang (no change on a responsive call); the validate entrypoint is new + operator-triggered (no auto-run); the SSRF additions only ADD blocks.

## CI
`cargo fmt --all -- --check` clean · `cargo clippy --workspace --all-targets -- -D warnings` clean (exit 0) · tests green: friday-anthropic 19/0, friday-vision 9/0, friday-hub 786 lib + all integration binaries 0-failed. `.secrets.baseline` unchanged. CI's `cargo test --workspace` (rust-core.yml) covers friday-vision.

## Base-SHA note
Born off `1f609585`; rebased onto current `8e0c24cb` (= the task's stated base, #777 storage-txn fix, disjoint from these files) so the PR is born current. #772/#774/#775 (the code under change) all present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)