### PR TITLE
fix(storage): transition agent_run.state off awaiting_clarification on terminal result

### DIFF
--- a/rust-core/crates/friday-hub/tests/clarification_gate.rs
+++ b/rust-core/crates/friday-hub/tests/clarification_gate.rs
@@ -242,3 +242,129 @@ fn resume_with_plain_answer_runs_the_loop_and_finishes_gate_does_not_refire() {
         other => panic!("expected a Finished delivery on resume, got {other:?}"),
     }
 }
+
+// --- stuck-`awaiting_clarification` lifecycle fix (runtime integration) ----------
+//
+// The storage-level chokepoint is proven in `friday-storage::run_result` tests; these
+// lock that the LIVE RUNTIME actually routes a terminal run through it, so the
+// readback `agent_run.state` is coherent with the result instead of stuck at the
+// `create_run` entry value — AND that a genuine gate hold is NOT moved.
+
+/// INTEGRATION REPRO: a run that FINISHES through the real `run_session_task` →
+/// `run_session_loop` → step-5 `persist_run_result` chain must leave the persisted
+/// `agent_run.state` at the terminal `"finished"` — NOT stuck at the `create_run`
+/// `"awaiting_clarification"` value (the live-DB defect: 120 finished runs stuck).
+#[test]
+fn finished_run_through_runtime_persists_terminal_agent_run_state() {
+    std::env::set_var(friday_hub::FRIDAY_CLARIFICATION_GATE, "1");
+    let owner = "owner-state-finished";
+    // A PLAIN task (no planning verb) classifies None ⇒ the gate does not fire ⇒ the
+    // loop runs to Finished on the scripted transport.
+    let (rt, _ws) = runtime_with(
+        "state-finished",
+        owner,
+        ScriptTransport::new(&["{\"tool\":\"none\",\"answer\":\"All done.\"}"]),
+    );
+    let caller = authed_caller(owner);
+    let answer = rt.run_session_task(
+        &caller,
+        "run-state-finished",
+        "sess-state-finished",
+        "Tell me the current time in UTC",
+        5_000,
+    );
+    match &answer {
+        AuthedAnswer::Delivered { status, .. } => assert_eq!(status, "finished"),
+        other => panic!("expected a Finished delivery, got {other:?}"),
+    }
+    // THE FIX: the persisted run-state (what the refs-only readback surfaces as
+    // `run_state`) is now the terminal status, not the stuck entry value.
+    let summary =
+        friday_storage::agent_run_read::get_run_summary(rt.db().conn(), "run-state-finished")
+            .unwrap()
+            .expect("the finished run has an agent_run row");
+    assert_eq!(
+        summary.state, "finished",
+        "a finished run's agent_run.state must be terminal, not stuck at awaiting_clarification"
+    );
+    // The terminal transition stamps `updated_at` with the run's clock. This single-turn
+    // dispatch threads ONE `now_ms` through create + persist, so the two timestamps coincide
+    // (a real run that spans wall-clock time between create and finish strictly advances it —
+    // the storage-level test exercises that with distinct timestamps).
+    assert!(
+        summary.updated_at >= summary.created_at,
+        "the terminal transition must (re)stamp updated_at"
+    );
+}
+
+/// NO-DEGRADE (runtime): a genuine clarification HOLD — an under-specified, classified
+/// planning task — STILL persists `agent_run.state == "awaiting_clarification"` AND makes
+/// ZERO model calls (PanicTransport). The fix must never move a genuine hold to a terminal
+/// state; the gate is structurally preserved end-to-end.
+#[test]
+fn genuine_clarification_hold_keeps_awaiting_state_with_no_model_call() {
+    std::env::set_var(friday_hub::FRIDAY_CLARIFICATION_GATE, "1");
+    let owner = "owner-state-hold";
+    let (rt, _ws) = runtime_with("state-hold", owner, PanicTransport);
+    let caller = authed_caller(owner);
+    let answer = rt.run_session_task(
+        &caller,
+        "run-state-hold",
+        "sess-state-hold",
+        "create a workflow that posts a daily summary",
+        5_000,
+    );
+    match &answer {
+        AuthedAnswer::Delivered { status, .. } => assert_eq!(
+            status, "awaiting_clarification",
+            "the under-specified task is held at the gate (PanicTransport proves 0 model calls)"
+        ),
+        other => panic!("expected a clarification Delivered, got {other:?}"),
+    }
+    // THE GATE-PRESERVING INVARIANT: the persisted run-state stays at the gate's hold
+    // value — the fix's chokepoint is a no-op for the `awaiting_clarification` status.
+    let summary = friday_storage::agent_run_read::get_run_summary(rt.db().conn(), "run-state-hold")
+        .unwrap()
+        .expect("the held run has an agent_run row");
+    assert_eq!(
+        summary.state, "awaiting_clarification",
+        "a genuine clarification hold must remain awaiting_clarification (gate not weakened)"
+    );
+}
+
+/// INTEGRATION REPRO on the SESSIONLESS path that actually produced the stuck rows.
+/// The live-DB stuck rows ("Read-only self-probe: confirm the repository is reachable")
+/// flowed through `HubRuntime::run_task` → `run_with_request` (persist at the routed-loop
+/// tail), NOT the sessioned chat entry the tests above exercise. Both share the same
+/// `persist_run_result` chokepoint, but this mirrors the path of the actual defect: a
+/// finished sessionless run's `agent_run.state` must be terminal, not stuck.
+#[test]
+fn finished_sessionless_run_task_persists_terminal_agent_run_state() {
+    let owner = "owner-sessionless-finished";
+    let (rt, _ws) = runtime_with(
+        "sessionless-finished",
+        owner,
+        ScriptTransport::new(&["{\"tool\":\"none\",\"answer\":\"repo reachable\"}"]),
+    );
+    let (_selection, outcome) = rt
+        .run_task(
+            "run-sessionless-finished",
+            "Read-only self-probe: confirm the repository is reachable",
+            5_000,
+        )
+        .expect("the sessionless run drives to a terminal LoopOutcome");
+    assert_eq!(
+        outcome.status,
+        friday_hub::LoopStatus::Finished,
+        "the scripted finish must produce a Finished outcome"
+    );
+    let summary =
+        friday_storage::agent_run_read::get_run_summary(rt.db().conn(), "run-sessionless-finished")
+            .unwrap()
+            .expect("the finished sessionless run has an agent_run row");
+    assert_eq!(
+        summary.state, "finished",
+        "the sessionless path (which produced the live stuck rows) must also persist a \
+         terminal agent_run.state"
+    );
+}

--- a/rust-core/crates/friday-storage/src/agent_run.rs
+++ b/rust-core/crates/friday-storage/src/agent_run.rs
@@ -76,6 +76,71 @@ pub fn set_run_state(conn: &Connection, run_id: &str, next: PlanState, now: i64)
     Ok(())
 }
 
+/// The terminal `agent_run.state` value for a run that REACHED A RESULT but did
+/// NOT flow through the [`PlanState`] plan-approval machine (the common case: an
+/// ordinary Q&A / read-only task `Finished`, or a resumed mutation `mutation_completed`).
+///
+/// ## Why this exists (the stuck-state defect it fixes)
+/// `create_run` seeds every run at `awaiting_clarification` (the gate's entry
+/// state). The live agent loop records terminal *events* (`agent.finished`,
+/// `agent.outcome:*`) and persists a terminal `run_result`, but NOTHING moved the
+/// `agent_run.state` column off its `create_run` value — `set_run_state` (the
+/// [`PlanState`] machine) has zero live callers, and the loop never reaches the
+/// plan-approval lifecycle. So a finished run's `agent_run.state` stayed stuck at
+/// `awaiting_clarification` forever, contradicting both its terminal `run_result`
+/// AND the event-log-derived status the readback already reports. This is the
+/// chokepoint that completes the lifecycle, mirroring how [`cancel_run`] writes a
+/// terminal out-of-vocab state directly.
+///
+/// ## Vocabulary + no migration
+/// Like [`STATE_CANCELLED`], the written string is the `run_result.status` LABEL
+/// (`finished` / `mutation_completed` / `errored` / `bounded` / …) — DELIBERATELY
+/// OUTSIDE the closed [`PlanState`] vocab so [`parse_plan_state`] returns `None`
+/// (a terminal run has no live PlanState, exactly like a cancelled one). The
+/// `agent_run.state` column is free-form `TEXT` (no CHECK), so this writes WITHOUT
+/// a migration. Keeping the column value equal to `run_result.status` makes the
+/// readback (`run_state`) COHERENT with the stored result + the derived status.
+///
+/// ## Fail-closed, gate-preserving, cancel-safe (NO-DEGRADE)
+///   - It is a NO-OP for the `awaiting_clarification` status: a run genuinely held
+///     by the clarification gate (terminal `LoopStatus::AwaitingClarification`,
+///     ZERO model calls) keeps its `awaiting_clarification` column verbatim — the
+///     gate hold is structurally untouched (the only legitimate persisted
+///     `awaiting_clarification` is a genuine hold).
+///   - It NEVER clobbers [`STATE_CANCELLED`]: a run cancelled out-of-band keeps its
+///     terminal `cancelled` flag even if a late result is persisted (mirrors
+///     [`cancel_run`]'s "never touches `run_result`" half — the two terminal
+///     writers do not fight).
+///   - It is a no-op when the run row does not exist (`UPDATE … WHERE` affects 0
+///     rows) and when the column already holds the same terminal value (idempotent
+///     re-persist).
+///
+/// Intended to be called INSIDE the same transaction that persists the
+/// `run_result` (see [`crate::run_result::persist_run_result`]) so the result and
+/// the lifecycle state move atomically together.
+pub fn mark_run_terminal_state(
+    conn: &Connection,
+    run_id: &str,
+    status: &str,
+    now: i64,
+) -> Result<()> {
+    // A genuine clarification HOLD is the one legitimate non-terminal persisted
+    // status: leave the `create_run` `awaiting_clarification` column verbatim so the
+    // gate hold is structurally preserved (NO-DEGRADE). Any other status is terminal.
+    if status == PlanState::AwaitingClarification.as_str() {
+        return Ok(());
+    }
+    // Move the column to the terminal status string, EXCEPT when the run was cancelled
+    // out-of-band — a `cancelled` flag is never clobbered by a late result persist.
+    // `WHERE run_id = ?` over a missing row is a harmless 0-row update.
+    conn.execute(
+        "UPDATE agent_run SET state = ?1, updated_at = ?2 \
+         WHERE run_id = ?3 AND state != ?4",
+        params![status, now, run_id, STATE_CANCELLED],
+    )?;
+    Ok(())
+}
+
 /// Append an event to a run's log with the next monotonic `seq` (1-based,
 /// per-run). Returns the assigned `seq`. The run must exist.
 pub fn record_event(

--- a/rust-core/crates/friday-storage/src/run_result.rs
+++ b/rust-core/crates/friday-storage/src/run_result.rs
@@ -310,6 +310,15 @@ pub fn persist_run_result(
             PersistRunResultOutcome::Persisted
         }
     };
+    // Lifecycle-state coherence (stuck-`awaiting_clarification` fix): in the SAME
+    // transaction, move the `agent_run.state` column off its `create_run` entry value
+    // to this terminal status, so a finished run's persisted run-state matches its
+    // result instead of staying stuck at `awaiting_clarification`. This is a NO-OP for
+    // a genuine clarification HOLD (`status == "awaiting_clarification"`), never
+    // clobbers a `cancelled` run, and is harmless when no `agent_run` row exists or on
+    // an idempotent re-persist (re-writes the same terminal value). See
+    // [`crate::agent_run::mark_run_terminal_state`] for the full no-degrade contract.
+    crate::agent_run::mark_run_terminal_state(&tx, run_id, &result.status, now_ms)?;
     tx.commit()?;
     Ok(outcome)
 }
@@ -687,6 +696,159 @@ mod tests {
         assert_eq!(
             get_run_answer_for_principal(db.conn(), "nope", Q1_OWNER).unwrap(),
             RunAnswerAccess::NotFound
+        );
+    }
+
+    // --- stuck-`awaiting_clarification` lifecycle fix -----------------------------
+    //
+    // `create_run` seeds `agent_run.state = "awaiting_clarification"`. Before the fix,
+    // persisting a TERMINAL `run_result` left that column stuck (the 120 finished-but-
+    // stuck rows + 1 mutation_completed-but-stuck row the live DB surfaced). These lock
+    // that `persist_run_result` now transitions the column atomically with the result,
+    // WITHOUT weakening the clarification gate (the genuine-hold case stays put) and
+    // WITHOUT clobbering a cancelled run.
+    use crate::agent_run::{cancel_run, create_run, run_state_string, STATE_CANCELLED};
+
+    #[test]
+    fn persisting_a_finished_result_transitions_agent_run_off_awaiting_clarification() {
+        // REPRODUCES the live defect: a run created at `awaiting_clarification` whose
+        // FINISHED result is persisted must end with `agent_run.state == "finished"`,
+        // not stuck at `awaiting_clarification`. (Pre-fix this assertion fails — the
+        // column stayed `awaiting_clarification`.)
+        let db = Db::open_hub(&tmp("stuck-finished")).unwrap();
+        create_run(db.conn(), "run-f", "do a read-only self-probe", 100).unwrap();
+        assert_eq!(
+            run_state_string(db.conn(), "run-f").unwrap().as_deref(),
+            Some("awaiting_clarification"),
+            "create_run must seed the gate entry state"
+        );
+
+        persist_run_result(
+            db.conn(),
+            "run-f",
+            &RunResult::new("finished", "the answer", None),
+            200,
+        )
+        .unwrap();
+
+        assert_eq!(
+            run_state_string(db.conn(), "run-f").unwrap().as_deref(),
+            Some("finished"),
+            "a finished run's agent_run.state must move to the terminal status, \
+             not stay stuck at awaiting_clarification"
+        );
+    }
+
+    #[test]
+    fn persisting_a_mutation_completed_result_transitions_agent_run_state() {
+        // Covers the resume.rs path (the 1 stuck `mutation_completed` row in the live
+        // DB): a resumed mutation's terminal result also moves the column.
+        let db = Db::open_hub(&tmp("stuck-mut")).unwrap();
+        create_run(db.conn(), "run-m", "apply the approved mutation", 100).unwrap();
+        persist_run_result(
+            db.conn(),
+            "run-m",
+            &RunResult::new("mutation_completed", "mutation applied", None),
+            200,
+        )
+        .unwrap();
+        assert_eq!(
+            run_state_string(db.conn(), "run-m").unwrap().as_deref(),
+            Some("mutation_completed"),
+        );
+    }
+
+    #[test]
+    fn persisting_an_awaiting_clarification_result_is_a_noop_on_state_gate_preserved() {
+        // NO-DEGRADE: a genuine clarification HOLD persists status
+        // `awaiting_clarification` (the gate stopped an under-specified task with ZERO
+        // model calls and stored the questions). The column must STAY
+        // `awaiting_clarification` — the fix must never move a genuine hold to a
+        // terminal state, or it would weaken the gate.
+        let db = Db::open_hub(&tmp("genuine-hold")).unwrap();
+        create_run(db.conn(), "run-c", "create a workflow", 100).unwrap();
+        persist_run_result(
+            db.conn(),
+            "run-c",
+            &RunResult::new(
+                "awaiting_clarification",
+                "Before I execute this generate workflow, I need more detail...",
+                None,
+            ),
+            200,
+        )
+        .unwrap();
+        assert_eq!(
+            run_state_string(db.conn(), "run-c").unwrap().as_deref(),
+            Some("awaiting_clarification"),
+            "a genuine clarification hold must remain awaiting_clarification (gate preserved)"
+        );
+    }
+
+    #[test]
+    fn persisting_a_result_never_clobbers_a_cancelled_run() {
+        // A run cancelled out-of-band keeps its terminal `cancelled` flag even if a
+        // late terminal result is persisted — the two terminal writers do not fight.
+        let db = Db::open_hub(&tmp("cancelled-then-result")).unwrap();
+        create_run(db.conn(), "run-x", "do something", 100).unwrap();
+        cancel_run(db.conn(), "run-x", 150).unwrap();
+        assert_eq!(
+            run_state_string(db.conn(), "run-x").unwrap().as_deref(),
+            Some(STATE_CANCELLED)
+        );
+        // A late finished result still persists its run_result row...
+        persist_run_result(
+            db.conn(),
+            "run-x",
+            &RunResult::new("finished", "late answer", None),
+            200,
+        )
+        .unwrap();
+        assert_eq!(
+            get_run_result(db.conn(), "run-x").unwrap().unwrap().status,
+            "finished"
+        );
+        // ...but the agent_run.state stays cancelled (never clobbered).
+        assert_eq!(
+            run_state_string(db.conn(), "run-x").unwrap().as_deref(),
+            Some(STATE_CANCELLED),
+            "a cancelled run's state must not be clobbered by a late result persist"
+        );
+    }
+
+    #[test]
+    fn errored_and_bounded_statuses_also_transition_the_state_column() {
+        // Any non-`awaiting_clarification` terminal status moves the column (so the
+        // single chokepoint covers every persisted-result outcome coherently).
+        for status in ["errored", "bounded"] {
+            let db = Db::open_hub(&tmp("term")).unwrap();
+            create_run(db.conn(), "r", "t", 100).unwrap();
+            persist_run_result(db.conn(), "r", &RunResult::new(status, "", None), 200).unwrap();
+            assert_eq!(
+                run_state_string(db.conn(), "r").unwrap().as_deref(),
+                Some(status),
+            );
+        }
+    }
+
+    #[test]
+    fn idempotent_re_persist_keeps_the_terminal_state() {
+        // A benign identical re-persist (DuplicateIdentical) leaves the column at the
+        // terminal value (idempotent re-write of the same string).
+        let db = Db::open_hub(&tmp("idem-state")).unwrap();
+        create_run(db.conn(), "r", "t", 100).unwrap();
+        let r = RunResult::new("finished", "same", None);
+        assert_eq!(
+            persist_run_result(db.conn(), "r", &r, 200).unwrap(),
+            PersistRunResultOutcome::Persisted
+        );
+        assert_eq!(
+            persist_run_result(db.conn(), "r", &r, 300).unwrap(),
+            PersistRunResultOutcome::DuplicateIdentical
+        );
+        assert_eq!(
+            run_state_string(db.conn(), "r").unwrap().as_deref(),
+            Some("finished"),
         );
     }
 


### PR DESCRIPTION
## Diagnosis (verdict: REAL latent live-state bug)

A live-DB audit surfaced `agent_run` = 128 rows ALL stuck at `awaiting_clarification` while 122 `run_result` rows were terminal. Joining `agent_run` ↔ `run_result` by `run_id` (live DB, read-only):

| agent_run.state | run_result.status | n |
|---|---|---|
| awaiting_clarification | finished | 120 |
| awaiting_clarification | mutation_completed | 1 |
| awaiting_clarification | awaiting_clarification | 1 |

- **`updated_at == created_at` on ALL 128 rows** → the `state` column is write-once-at-insert, never updated.
- **120 stuck rows have a terminal `finished` result; 1 has `mutation_completed`** → they ran to a deliverable answer but `agent_run.state` never moved. The `delta` between `agent_run.created_at` and `run_result.created_at` is 0 (same dispatch).
- Only **1** row is genuinely awaiting (its `run_result.status` is also `awaiting_clarification` — the legitimate gate hold, correct/by-design) and **6** have no result yet.
- The readback already disagrees with itself: `run_readback_projection` reports `loop_status_derived = "finished"` (from the `agent.finished` event) while `run_state = "awaiting_clarification"` (the stuck column) on the same rows.

### Root cause
`agent_run::create_run` seeds every run at the gate entry state `awaiting_clarification`. The live agent loop records terminal *events* (`agent.finished`, `agent.outcome:*`) and persists a terminal `run_result`, but **nothing moves the `agent_run.state` column**. `agent_run::set_run_state` (the `PlanState` machine) has **zero live callers** (every `set_run_state` hit is the unrelated `workflow::set_run_state`), and the loop never reaches the plan-approval lifecycle. The only live `UPDATE agent_run SET state` was `cancel_run`. So `agent_run.state` stays stuck for every non-cancelled run.

Reader sweep confirmed **no live path branches on `agent_run.state == "awaiting_clarification"`** — the only live reads are the readback projection (display) and the cancel-keyed `== "cancelled"` check. So correcting the column is safe (no behavioral coupling to degrade).

## Fix (surgical, additive, no migration)

Co-locate a terminal-state transition **inside `persist_run_result`'s transaction**, keyed on the persisted status — completing the `cancel_run` precedent (free-form `TEXT`, out-of-`PlanState`-vocab so `parse_plan_state → None`, no migration). The column is set to the `run_result.status` label so the readback is coherent. One storage chokepoint covers all four terminal persist sites (routed Finished, codex Finished, session step-5, resume `mutation_completed`).

### NO-DEGRADE / clarification gate preserved (binding)
- **NO-OP for `awaiting_clarification` status**: a genuine under-specified+classified gate hold (terminal `LoopStatus::AwaitingClarification`, **0 model calls**) keeps its column verbatim — the gate is structurally untouched.
- **Never clobbers a `cancelled` run** (`WHERE state != 'cancelled'`) — the two terminal writers don't fight.
- Harmless on a missing row / idempotent re-persist.

## Tests
- **6 storage-level** (`friday-storage::run_result`): repro `finished`, `mutation_completed`, `errored`/`bounded`, genuine-hold NO-OP (gate preserved), cancel-safety, idempotency.
- **3 runtime-integration** (`friday-hub::clarification_gate`): finished run via `run_session_task` → terminal state; finished run via the **sessionless `run_task`** path that actually produced the live stuck rows ("Read-only self-probe...") → terminal state; genuine clarification hold stays `awaiting_clarification` with `PanicTransport` proving **0 model calls**.
- **Bug-bracketing proof**: neutering the chokepoint call turns the two repro tests RED while the no-degrade tests stay GREEN (they aren't vacuous).

Local `cargo test -p friday-hub -p friday-core -p friday-storage` green (67 binaries, 0 failed); `cargo fmt --check` + `cargo clippy` clean on both changed crates.

## ⚠️ Forward-only — verification note for the operator
This corrects the **code path**; it does **not** backfill the existing 128 historical rows (no prod-tree mutation; a backfill is a separate, riskier op). A post-deploy re-audit will **still show the historical stuck rows** — that is expected, NOT a failed fix. Correct verification = a **NEW** terminal run transitions:

```
# after deploy, drive one fresh run to completion, then:
sqlite3 "file:$HOME/Library/Application Support/Friday/state/rust-hub.sqlite?mode=ro" \
  "SELECT state, updated_at>created_at FROM agent_run WHERE run_id='<new-run-id>';"
# expect: finished|1  (NOT awaiting_clarification)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)