### PR TITLE
fix(storage): make retention sweep's per-table delete BUSY-retry resilient (de-flake RED main)

### DIFF
--- a/rust-core/crates/friday-storage/src/lib.rs
+++ b/rust-core/crates/friday-storage/src/lib.rs
@@ -253,10 +253,12 @@ fn is_storage_busy(e: &StorageError) -> bool {
 /// the final attempt the last busy error is returned so the caller still fails closed.
 ///
 /// This is the ONE bounded busy-retry idiom in the crate — the writable-Hub open
-/// ([`open_hub_with_busy_retry`]) and the run-billing write txn
-/// ([`record_run_model_call`]) BOTH go through it, so they share identical retry budget,
-/// backoff, and the [`is_storage_busy`] error class (never an ad-hoc second policy).
-fn with_busy_retry<T>(mut op: impl FnMut() -> Result<T>) -> Result<T> {
+/// ([`open_hub_with_busy_retry`]), the run-billing write txn ([`record_run_model_call`]),
+/// and the retention sweep's per-table delete ([`crate::retention::sweep_retention`]) ALL go
+/// through it, so they share identical retry budget, backoff, and the [`is_storage_busy`]
+/// error class (never an ad-hoc second policy). Exposed `pub(crate)` so the sibling
+/// `retention` module reuses this exact idiom rather than reinventing a second policy.
+pub(crate) fn with_busy_retry<T>(mut op: impl FnMut() -> Result<T>) -> Result<T> {
     let mut attempt: u32 = 0;
     loop {
         match op() {

--- a/rust-core/crates/friday-storage/src/retention.rs
+++ b/rust-core/crates/friday-storage/src/retention.rs
@@ -262,11 +262,31 @@ pub fn sweep_retention(
 /// table is all-or-nothing for THIS sweep (commit on success; the txn drops → rolls back on any
 /// error), and the error is returned to the caller so it can be ISOLATED to this table without
 /// affecting the others.
+///
+/// The body is wrapped in the crate's ONE bounded busy-retry idiom ([`crate::with_busy_retry`]) —
+/// the SAME wrapper the writable-Hub open and the run-billing write txn use, never a second
+/// policy. This is required because the reaper sweeps on a SEPARATE connection while N billers
+/// commit concurrently: a deferred write txn can hit `SQLITE_BUSY` (notably `SQLITE_BUSY_SNAPSHOT`,
+/// which `busy_timeout` does NOT auto-retry — only an app-level retry recovers it), and any of the
+/// five per-table deletes can surface it under WAL contention. After #786 the `memory_fts_ad`
+/// AFTER-DELETE trigger added an extra `memory_fts` write inside the `memory_item` delete txn,
+/// which made that path the most likely to hit it — but the wrap is at the SHARED helper so every
+/// table is uniformly resilient, not just the one the trigger made probable.
+///
+/// On a BUSY the failed txn has ALREADY rolled back (NOTHING committed), so each retry re-opens a
+/// fresh `unchecked_transaction` and re-runs the bounded DELETE cleanly — no half-delete, no
+/// double-count. NO-DEGRADE: the retry fires ONLY on [`crate::is_storage_busy`] (transient
+/// lock/snapshot contention); a GENUINE FK/constraint violation is NOT busy-classed, so it
+/// propagates on the FIRST attempt with zero delay and is still surfaced to the caller (counted in
+/// [`RetentionOutcome::table_errors`]). With no contention the closure runs EXACTLY ONCE and the
+/// result is byte-identical to the pre-wrap single-txn path.
 fn delete_bounded(conn: &Connection, sql: &str, cutoff: i64, limit: i64) -> Result<usize> {
-    let tx = conn.unchecked_transaction()?;
-    let n = tx.execute(sql, params![cutoff, limit])?;
-    tx.commit()?;
-    Ok(n)
+    crate::with_busy_retry(|| {
+        let tx = conn.unchecked_transaction()?;
+        let n = tx.execute(sql, params![cutoff, limit])?;
+        tx.commit()?;
+        Ok(n)
+    })
 }
 
 #[cfg(test)]

--- a/rust-core/crates/friday-storage/tests/atomic.rs
+++ b/rust-core/crates/friday-storage/tests/atomic.rs
@@ -470,9 +470,13 @@ fn concurrent_billing_survives_a_reaper_sweeping_on_a_short_cadence() {
         let reaper_errs = reaper_table_errors.clone();
         std::thread::spawn(move || {
             // Prod-faithful: the reaper opens via `Db::open_hub` (→ HUB_BUSY_TIMEOUT_MS), so its
-            // batched DELETE WAITS for the (microsecond) billing write lock and acquires it. With
-            // BUSY absorbed by the timeout, the ONLY thing that can set `table_errors` is a real FK
-            // violation — which is exactly the no-degrade "no FK errors" check below.
+            // batched DELETE WAITS for the (microsecond) billing write lock and acquires it. Most
+            // contention is absorbed by that timeout; the residual `SQLITE_BUSY`/`BUSY_SNAPSHOT`
+            // that the timeout does NOT auto-retry (e.g. the extra `memory_fts` write the v34
+            // `memory_fts_ad` AFTER-DELETE trigger adds inside the `memory_item` delete txn) is
+            // absorbed by the sweep's per-table busy-retry (`delete_bounded` → `with_busy_retry`).
+            // So the ONLY thing left that can set `table_errors` is a real FK violation — which is
+            // exactly the no-degrade "no FK errors" check below.
             let conn = raw_writer(&path, friday_storage::HUB_BUSY_TIMEOUT_MS);
             while !stop.load(Ordering::SeqCst) {
                 // sweep_lifecycle is best-effort (logged-and-swallowed in prod); ignore its


### PR DESCRIPTION
## URGENT fix-forward — main is RED

The push-event **Rust Core** workflow for `f35a0fb0` (just-merged #786) is RED on a timing-flaky storage test. This PR de-flakes it by making the retention sweep's delete path lock-resilient. **No assertion was weakened.**

### The failure
`concurrent_billing_survives_a_reaper_sweeping_on_a_short_cadence`
(`rust-core/crates/friday-storage/tests/atomic.rs`) fails with `reaper_table_errors == 1`:
> the retention sweep must never report a per-table (FK/lock) failure — `left: 1, right: 0`

It PRE-EXISTS #786 and passed #786's PR-CI, then failed the push-event for the **same** commit — classic timing flake.

### Confirmed root cause (file:line)
#786 (FTS5 hybrid recall, migration **v34**) added an **always-on** trigger with NO `WHEN` clause:
- `schema.rs:2421` — `CREATE TRIGGER memory_fts_ad AFTER DELETE ON memory_item ... DELETE FROM memory_fts WHERE memory_id = OLD.memory_id;`

So **every** `memory_item` delete now fires an EXTRA `memory_fts` write. The retention sweep's rejected/expired-**candidate** prune (`retention.rs`, the `memory_item` DELETE at the table-3 step) deletes `memory_item` rows → fires `memory_fts_ad` → the extra write lands INSIDE the sweep's per-table delete txn.

The per-table delete helper `delete_bounded` (`retention.rs`) had **no** busy-retry. Under the concurrent-billing write lock that wider txn hits `SQLITE_BUSY` / `SQLITE_BUSY_SNAPSHOT` — and `busy_timeout` does **not** auto-retry BUSY_SNAPSHOT (it returns immediately; only an app-level retry recovers it — documented at `lib.rs:227-236`). The transient BUSY was then counted as a per-table failure, breaking the test's correct "0 failures" invariant.

### Fix (NO-DEGRADE, reuses existing infra)
Wrap the **shared** `delete_bounded` txn body in the crate's ONE existing busy-retry idiom — `with_busy_retry` (the #777 helper the writable-Hub open and the run-billing `record_run_model_call` write txn both use). **No new dependency, no second policy.**

- Wrapped the shared helper (not just the `memory_item` call site): all five per-table deletes are now uniformly resilient. `memory_item` is merely the one the trigger made probable; any deferred write txn can hit BUSY_SNAPSHOT under WAL contention. The wrap is byte-identical when uncontended, so this is zero-degrade and uniform.
- Made `with_busy_retry` `pub(crate)` so the sibling `retention` module reuses it.
- Kept the always-on trigger (instant-flip design) — only the delete path is made lock-resilient, NOT the trigger gated behind the flag.
- Corrected a now-stale test comment that claimed the `busy_timeout` alone absorbs all BUSY (#786 invalidated that) to name the busy-retry as the residual absorber. **The assertion itself is unchanged.**

### No-degrade argument
- Retry fires **ONLY** on `is_storage_busy` (transient lock/snapshot). A **genuine** FK/constraint violation is NOT busy-classed → propagates on the FIRST attempt with zero delay → still surfaced in `RetentionOutcome::table_errors`.
- On a BUSY the failed txn has already rolled back (nothing committed) → each retry re-opens a fresh `unchecked_transaction` and re-runs the bounded DELETE cleanly — no half-delete, no double-count.
- Uncontended, the closure runs **exactly once** → byte-identical to the pre-wrap single-txn path.
- FK-safety behavior is exercised by the retention module tests (which run uncontended → closure runs once) and is unchanged.

### Proof (de-flake, not just rerun)
- **25/25 GREEN** on `concurrent_billing_survives_a_reaper_sweeping_on_a_short_cadence` run in a loop under load.
- Sibling `billing_retry_absorbs_a_busy_when_a_peer_write_lock_releases_within_budget`: green.
- All 7 `retention::tests` (incl. FK-safety `terminal_aged_mission_with_surviving_child...` and `no_non_terminal_mission_or_work_item_is_ever_deleted...`): green.
- Full `cargo test -p friday-storage`: all binaries green.
- `cargo clippy -p friday-storage --all-targets`: clean. `cargo fmt --check`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)