### PR TITLE
feat(desktop): slice-6 flip — Hub Console defaults to LIVE read client (J2/I3/I4)

### DIFF
--- a/apps/macos/FridayHubConsole/Sources/FridayHubConsole/FridayHubConsoleApp.swift
+++ b/apps/macos/FridayHubConsole/Sources/FridayHubConsole/FridayHubConsoleApp.swift
@@ -5,22 +5,28 @@ import SwiftUI
 ///
 /// A read-only operator workbench over Rust Hub Mission truth.
 ///
-/// LAUNCH MODES (mock is the SAFE DEFAULT):
-///   - DEFAULT — the in-memory `MockReadClient(.loaded)`. Keeps SwiftUI previews + design/demo
-///     work running without a live read-projection server, and keeps CI green (CI never flips
-///     to the live seam, never reads the host master key).
-///   - LIVE — set env `FRIDAY_CONSOLE_LIVE=1` (or launch arg `--live-read`) to wire the REAL
-///     `SealedWSReadClient` (the `FridayRustClient` package) over the read-projection server's
-///     loopback seam (127.0.0.1:48751) as the enrolled MASTER-DERIVED peer, authenticating as
-///     the LaunchAgent owner `admin-001` — "the app actually reads the live Rust core".
+/// LAUNCH MODES (LIVE is the DEFAULT — the slice-6 J2/I3/I4 flip):
+///   - DEFAULT (LIVE) — the REAL `SealedWSReadClient` (the `FridayRustClient` package) over the
+///     read-projection server's loopback seam (127.0.0.1:48751) as the enrolled MASTER-DERIVED
+///     peer, authenticating as the LaunchAgent owner `admin-001`. "The app actually reads the
+///     live Rust core." A normal run reads live truth.
+///   - MOCK (opt-in, design/demo only) — pass launch arg `--use-mock-read-client` (or set env
+///     `FRIDAY_CONSOLE_MOCK=1`) to use the in-memory `MockReadClient(.loaded)`. This is for
+///     SwiftUI design/demo work without a live read-projection server. It is NEVER selected by a
+///     normal launch and never silently substituted for a failed live read.
 ///
-/// HONEST-UNAVAILABLE: in LIVE mode, if the server is dark / the peer is not enrolled / the host
-/// master key is absent, the real client fails closed and the Console renders the HONEST
-/// "unavailable" state — never a fabricated mock-loaded view, never a crash.
+/// HONEST-UNAVAILABLE (the locked design): in the default LIVE mode, if the server is dark / the
+/// peer is not enrolled / the host master key is absent, the real client fails closed and the
+/// Console renders the HONEST "unavailable" state with the real reason — never a fabricated
+/// mock-loaded view, never a silent fall-back to mock data, never a crash.
 ///
-/// NOTE — this INVERTS PR #682's scheme (which defaulted to the real client behind
-/// `--use-mock-read-client`). The task pins mock-as-default + an explicit live opt-in; this is
-/// purely a launch-behavior choice (tests inject their own clients, so CI is unaffected).
+/// NO network at construction: `makeLive()` only derives the master-key peer + builds the client
+/// (no socket). The connect + 4s timeout happens later in the shell's async `.task`, so
+/// defaulting LIVE does not block app launch.
+///
+/// COMPAT: the pre-flip live opt-in (`--live-read` / `FRIDAY_CONSOLE_LIVE=1`) is now redundant
+/// (live is the default) and is accepted as a documented NO-OP so existing launch configs keep
+/// working. Only the MOCK opt-in changes behavior.
 @main
 struct FridayHubConsoleApp: App {
   init() {
@@ -46,17 +52,21 @@ struct FridayHubConsoleApp: App {
     .defaultSize(width: 1180, height: 720)
   }
 
-  /// The read client the shell uses. DEFAULT = mock; LIVE only when explicitly requested.
+  /// The read client the shell uses. DEFAULT = LIVE; MOCK only when explicitly opted in.
   static var readClient: FridayRustReadClient {
     let args = ProcessInfo.processInfo.arguments
     let env = ProcessInfo.processInfo.environment
-    let useLive = args.contains("--live-read") || env["FRIDAY_CONSOLE_LIVE"] == "1"
-    guard useLive else {
+    // MOCK is an explicit design/demo opt-in only (re-adopting #682's `--use-mock-read-client`
+    // flag, mirrored by an env for arg/env symmetry). A normal run NEVER takes this branch.
+    let useMock =
+      args.contains("--use-mock-read-client") || env["FRIDAY_CONSOLE_MOCK"] == "1"
+    if useMock {
       return MockReadClient(behavior: .loaded)
     }
-    // LIVE: derive the enrolled master-derived peer + target 48751 as `admin-001`. If the host
-    // master key is unavailable, surface the truth (honest unavailable) — NEVER fall back to the
-    // mock, which would fabricate a ready view the live seam did not produce.
+    // DEFAULT (LIVE): derive the enrolled master-derived peer + target 48751 as `admin-001`. If
+    // the host master key is unavailable, surface the truth (honest unavailable) — NEVER fall
+    // back to the mock, which would fabricate a ready view the live seam did not produce.
+    // (The actual connect happens later in the shell's async refresh; this is non-blocking.)
     do {
       return try RealReadClientFactory.makeLive()
     } catch {

--- a/apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/RealReadClientFactory.swift
+++ b/apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/RealReadClientFactory.swift
@@ -99,8 +99,10 @@ public enum RealReadClientFactory {
   /// authenticates as `admin-001` (the LaunchAgent's `--owner`). Throws (fail-closed) if the
   /// master key is missing/invalid — never substitutes an ephemeral key for the live path.
   ///
-  /// This is the launch-mode the app selects under `FRIDAY_CONSOLE_LIVE=1`. The mock stays the
-  /// default for previews + CI; this never runs without an enrolled host master key.
+  /// This is the DEFAULT launch-mode the app selects (the slice-6 flip): a normal run reads live.
+  /// The mock is an explicit opt-in (`--use-mock-read-client` / `FRIDAY_CONSOLE_MOCK=1`) for
+  /// design/demo work, and tests inject their own clients; this path never runs without an
+  /// enrolled host master key (fail-closed otherwise → honest unavailable).
   public static func makeLive(
     config: ReadProjectionServerConfig = .liveLoopback,
     forwardedPrincipal: String = liveReadProjectionOwnerPrincipal,


### PR DESCRIPTION
## What

The slice-6 J2/I3/I4 flip (operator-approved): the desktop Mission Workbench (`apps/macos/FridayHubConsole`) now DEFAULTS to the **LIVE** read client instead of the in-memory mock. The read-projection server is now LIVE + enrolled on loopback `:48751`, and `RealReadClientFactory.makeLive()` is proven-once against it — so a normal run should read the live Rust core, not fabricated mock data.

## Mock-vs-live selection — before / after

The **only** runtime selection site is `FridayHubConsoleApp.readClient`. The shell, previews, `StateRenderProof`, and all tests inject their own clients, so they are unaffected.

- **BEFORE:** default = `MockReadClient(.loaded)`; live wired only behind `--live-read` / `FRIDAY_CONSOLE_LIVE=1`.
- **AFTER:** default = LIVE via `RealReadClientFactory.makeLive()` (master-derived peer, owner `admin-001`, `127.0.0.1:48751`); mock is an explicit design/demo opt-in via `--use-mock-read-client` (re-adopting #682's flag) or `FRIDAY_CONSOLE_MOCK=1`.

The pre-flip live flags (`--live-read` / `FRIDAY_CONSOLE_LIVE=1`) are kept as **documented NO-OPs** (live is now the default) so existing launch configs keep working. Only the mock opt-in changes behavior.

## The exact flip

`readClient` inverts from a `guard useLive else { mock }` to `if useMock { mock }`, with the live `makeLive()` → `catch` → `makeHonestlyUnavailable(reason:)` path retained verbatim. The three doc-comment blocks that asserted "mock is the SAFE DEFAULT" (App header, the INVERTS-#682 note, and `RealReadClientFactory.makeLive`'s doc) are rewritten to state live-as-default.

## How the operator runs it live

```
swift run --package-path apps/macos/FridayHubConsole FridayHubConsole
```

(or build the product and launch the app bundle). With the read-projection LaunchAgent up on `:48751`, the host master key present at `~/.friday/master.key`, and the master-derived peer enrolled, the Console reads the live owner-sealed projection (or the typed `HUB_OFFLINE` empty-state if there's no active mission — itself end-to-end proof of an authenticated round-trip). For design/demo without a live server:

```
swift run --package-path apps/macos/FridayHubConsole FridayHubConsole --use-mock-read-client
```

## Honest-unavailable preservation (NO-DEGRADE)

`makeLive()` throws fail-closed if the master key is missing/invalid; on any connect/handshake/peer-enrollment failure the `SealedWSReadClient` surfaces a `transport(...)` error. Both render the real `UnavailableView` reason. The default **never** silently falls back to mock data, never fabricates a ready view, never crashes. Read-only / refs-only / owner-gated posture is unchanged — this PR touches only the client-selection default. `makeLive()` does no network at construction (key derivation + client build only); the connect + 4s timeout happens in the shell's async refresh, so defaulting LIVE does not block launch.

## Verification (local swift IS the gate — no Rust CI covers this Swift app)

- `swift build` — **Build complete**, clean.
- `swift test` — **21/21 pass**. The live integration tests self-skip without `FRIDAY_CONSOLE_LIVE_TEST=1`; view-model truth-rule + honest-unavailable + master-key fail-closed + KAT tests all pass. Tests/previews never touch `:48751`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)