### PR TITLE
fix(providers): re-port Codex app-server client to codex-cli 0.140.0 daemon+proxy transport

### DIFF
--- a/rust-core/crates/friday-providers/src/codex_appserver.rs
+++ b/rust-core/crates/friday-providers/src/codex_appserver.rs
@@ -16,7 +16,13 @@ use thiserror::Error;
 use friday_core::ProviderSessionEvent;
 
 pub const CODEX_APP_SERVER_SYNC_MODE: &str = "provider_app_server_local";
-pub const CODEX_APP_SERVER_CLI_VERSION: &str = "codex-cli 0.136.0";
+pub const CODEX_APP_SERVER_CLI_VERSION: &str = "codex-cli 0.140.0";
+
+/// Relative location of the Codex app-server daemon's control socket under the Codex home
+/// (`$CODEX_HOME`, else `$HOME/.codex`). Documented + verified against codex-cli 0.140.0
+/// (`codex app-server daemon version` / `daemon start` both name this exact path on failure).
+/// The daemon binds it; `codex app-server proxy` bridges stdio ↔ it. See [`control_socket_path`].
+const CODEX_CONTROL_SOCKET_REL: &str = "app-server-control/app-server-control.sock";
 
 /// Approval policy pinned for a [`CodexAppServerClient::run_turn`] model turn. `"never"`
 /// (a value of `v2/AskForApproval`) keeps a non-interactive completion from triggering an
@@ -1194,11 +1200,99 @@ pub struct LocalCodexAppServer {
     client: CodexAppServerClient<JsonLineTransport<ChildStdout, ChildStdin>>,
 }
 
+/// Resolve the Codex app-server daemon's control-socket path the SAME way codex-cli does:
+/// `$CODEX_HOME/<rel>` if `CODEX_HOME` is set (and non-empty), else `$HOME/.codex/<rel>`.
+/// Split out (taking the env values, not reading the process env) so it is unit-testable
+/// without `set_var` — the env-race-free idiom this module already uses (see
+/// [`codex_mutating_gate_from`]). Returns `None` only when neither `CODEX_HOME` nor `HOME`
+/// is available, so the caller can fail closed with `control-socket-home-unset` rather than
+/// guess a path. NEVER hardcodes `~/.codex` (would diverge from where the daemon actually
+/// bound under a custom `CODEX_HOME`).
+fn control_socket_path(
+    codex_home: Option<&std::ffi::OsStr>,
+    home: Option<&std::ffi::OsStr>,
+) -> Option<std::path::PathBuf> {
+    let base = match codex_home {
+        Some(h) if !h.is_empty() => std::path::PathBuf::from(h),
+        _ => {
+            let home = home.filter(|h| !h.is_empty())?;
+            std::path::PathBuf::from(home).join(".codex")
+        }
+    };
+    Some(base.join(CODEX_CONTROL_SOCKET_REL))
+}
+
 impl LocalCodexAppServer {
-    /// Spawn `<program> app-server` (default `program` = `"codex"`) over piped stdio.
+    /// Boot (idempotently) the persistent Codex app-server daemon, then spawn a
+    /// `<program> app-server proxy` stdio bridge to its control socket and wrap that JSON-RPC
+    /// stream (default `program` = `"codex"`). codex-cli 0.140.0 made bare `codex app-server`
+    /// a selector that HANGS on stdio; the working stdio path is daemon + proxy:
+    ///
+    ///   1. `<program> app-server daemon start` — idempotent (boots a daemon only when none is
+    ///      running; blocks until ready). The exit code is NOT trusted as the success signal
+    ///      (the common path is "already running", whose exit status we do not assume) — see (2).
+    ///   2. Resolve the documented control socket (`$CODEX_HOME|$HOME/.codex` +
+    ///      `app-server-control/app-server-control.sock`); the socket EXISTING is the readiness
+    ///      gate (bound = ready, freshly-started OR already-running). If absent, fail closed:
+    ///      `daemon-start` when the start command itself failed, else `control-socket-missing`
+    ///      (a silently-degraded start) — never hand the transport a proxy that cannot connect.
+    ///   3. `<program> app-server proxy --sock <path>` over piped stdin/stdout — THIS is the
+    ///      newline-delimited JSON-RPC stream the (UNCHANGED) [`JsonLineTransport`] reads. The
+    ///      handshake, methods, approval routing, and gating downstream are all unchanged.
+    ///
+    /// The `child` this owns is the PROXY (the daemon persists by design — idempotent reuse
+    /// across spawns); `child_id`/`kill`/`Drop` therefore manage the bridge, not the daemon.
     pub fn spawn(program: &str) -> Result<Self, CodexAppServerError> {
+        // (1) Ensure the daemon is up (idempotent). `daemon start` BLOCKS until the daemon is
+        // ready (or it times out with "did not become ready"), so the bound control socket —
+        // NOT the exit code — is the authoritative readiness signal. This is deliberate: the
+        // common production path is "daemon already running" (the daemon persists across spawns
+        // by design), and we do not assume the CLI returns exit 0 in that case. A `.spawn()`
+        // failure here means the CLI itself is absent. Output is CAPTURED (so a slow start can
+        // never hang this call on a piped stderr) but NEVER relayed into an error — the error
+        // type is code-only / secret-free by contract (see `friday-hub`'s `codex_error_code`).
+        let daemon = Command::new(program)
+            .arg("app-server")
+            .arg("daemon")
+            .arg("start")
+            .stdin(Stdio::null())
+            .output()
+            .map_err(|_| CodexAppServerError::Transport {
+                code: "daemon-start",
+            })?;
+
+        // (2) Resolve + require the control socket. Honors `CODEX_HOME`; fails closed if the
+        // home is unresolvable. The socket EXISTING is the readiness gate: it succeeds whenever
+        // the daemon is bound (freshly started by us OR already running, regardless of the
+        // `daemon start` exit code). If it is absent, the exit code picks the diagnostic —
+        // `daemon-start` when the start itself failed, else `control-socket-missing` (a
+        // silently-degraded/partial start).
+        let socket = control_socket_path(
+            std::env::var_os("CODEX_HOME").as_deref(),
+            std::env::var_os("HOME").as_deref(),
+        )
+        .ok_or(CodexAppServerError::Transport {
+            code: "control-socket-home-unset",
+        })?;
+        if !socket.exists() {
+            return Err(CodexAppServerError::Transport {
+                code: if daemon.status.success() {
+                    "control-socket-missing"
+                } else {
+                    "daemon-start"
+                },
+            });
+        }
+
+        // (3) Spawn the stdio↔socket proxy. This stdout/stdin pair is the JSON-RPC stream the
+        // existing transport drives — byte-identical downstream to the pre-0.140 bare-stdio
+        // app-server. `--sock` pins the resolved path (proxy would default to the same socket,
+        // but pinning keeps the bridge and the existence check we just made in lock-step).
         let mut child = Command::new(program)
             .arg("app-server")
+            .arg("proxy")
+            .arg("--sock")
+            .arg(&socket)
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::null())
@@ -1216,7 +1310,9 @@ impl LocalCodexAppServer {
         Ok(Self { child, client })
     }
 
-    /// The OS pid of the spawned app-server (for an external watchdog kill).
+    /// The OS pid of the spawned proxy bridge (for an external watchdog kill). NOTE: this is
+    /// the PROXY pid, not the daemon's — killing it tears down this turn's stdio bridge; the
+    /// persistent daemon is left running for the next idempotent [`Self::spawn`].
     pub fn child_id(&self) -> u32 {
         self.child.id()
     }
@@ -1227,7 +1323,9 @@ impl LocalCodexAppServer {
         &mut self.client
     }
 
-    /// Terminate the app-server process (idempotent).
+    /// Terminate the proxy bridge (idempotent). The persistent app-server daemon is NOT
+    /// stopped (it is shared, idempotently reused; the coordinator stops it explicitly with
+    /// `codex app-server daemon stop` / `daemon restart`).
     pub fn kill(&mut self) {
         let _ = self.child.kill();
         let _ = self.child.wait();
@@ -2454,6 +2552,48 @@ mod tests {
         assert!(!codex_mutating_gate_from(Some("true".to_string())));
         assert!(!codex_mutating_gate_from(Some(String::new())));
         assert!(!codex_mutating_gate_from(None));
+    }
+
+    #[test]
+    fn control_socket_path_honors_codex_home_then_home() {
+        use std::ffi::OsStr;
+        use std::path::PathBuf;
+
+        // CODEX_HOME set (and non-empty) wins — never `~/.codex`.
+        assert_eq!(
+            control_socket_path(
+                Some(OsStr::new("/custom/codex")),
+                Some(OsStr::new("/home/u"))
+            ),
+            Some(PathBuf::from(
+                "/custom/codex/app-server-control/app-server-control.sock"
+            ))
+        );
+        // CODEX_HOME unset → `$HOME/.codex/...` (the codex-cli default, verified vs 0.140.0).
+        assert_eq!(
+            control_socket_path(None, Some(OsStr::new("/home/u"))),
+            Some(PathBuf::from(
+                "/home/u/.codex/app-server-control/app-server-control.sock"
+            ))
+        );
+        // Empty CODEX_HOME is treated as unset (falls back to HOME), not as a root-relative path.
+        assert_eq!(
+            control_socket_path(Some(OsStr::new("")), Some(OsStr::new("/home/u"))),
+            Some(PathBuf::from(
+                "/home/u/.codex/app-server-control/app-server-control.sock"
+            ))
+        );
+        // Neither resolvable (and empty HOME) → None, so `spawn` fails closed
+        // (`control-socket-home-unset`) rather than guessing a path.
+        assert_eq!(control_socket_path(None, None), None);
+        assert_eq!(control_socket_path(None, Some(OsStr::new(""))), None);
+    }
+
+    #[test]
+    fn cli_version_constant_pins_codex_0_140() {
+        // Doc-only constant (no live code reads it); pinned to the daemon+proxy era so the
+        // re-port's target version is greppable. Format mirrors `codex --version`.
+        assert_eq!(CODEX_APP_SERVER_CLI_VERSION, "codex-cli 0.140.0");
     }
 
     #[test]

--- a/rust-core/crates/friday-providers/tests/codex_live.rs
+++ b/rust-core/crates/friday-providers/tests/codex_live.rs
@@ -1,14 +1,18 @@
 //! LIVE Codex app-server smoke (CODEX-LIVE-001). `#[ignore]`d — run only where the Codex
 //! CLI is installed + logged in (`cargo test -p friday-providers --test codex_live -- --ignored`).
 //!
-//! Spawns `codex app-server` over stdio and drives the REAL local lifecycle:
-//! `initialize` -> `initialized` -> `thread/list` (a metadata read — NO model turn, NO
-//! `codex exec`). It proves Friday's LOCAL Codex control lane, labeled
+//! Boots the persistent Codex app-server daemon (idempotent `codex app-server daemon start`),
+//! spawns a `codex app-server proxy` stdio bridge to its control socket, and drives the REAL
+//! local lifecycle over that bridge: `initialize` -> `initialized` -> `thread/list` (a
+//! metadata read — NO model turn, NO `codex exec`). (codex-cli 0.140.0 retired the bare
+//! `codex app-server` stdio handler; `LocalCodexAppServer::spawn` performs the daemon+proxy
+//! bootstrap.) It proves Friday's LOCAL Codex control lane, labeled
 //! `provider_app_server_local`; it deliberately does NOT claim official ChatGPT/Codex
 //! same-account history sync (that is the operator-gated CODEX-REMOTE-001 lane).
 //!
 //! Honesty / safety:
-//! - codex CLI absent -> graceful SKIP (not a Friday defect).
+//! - codex CLI absent / daemon won't boot / control socket missing -> graceful SKIP
+//!   (a typed `CodexAppServerError`, not a Friday defect).
 //! - codex present but a real round trip fails (login/account) -> exact blocker surfaced,
 //!   never faked.
 //! - a pid watchdog kills the child if the lifecycle hangs, so a blocking read can never
@@ -30,13 +34,14 @@ fn codex_app_server_local_lifecycle_smoke() {
     let mut server = match LocalCodexAppServer::spawn(&program) {
         Ok(s) => s,
         Err(e) => {
-            eprintln!("SKIP: could not spawn `{program} app-server` ({e:?}) — Codex CLI not available here");
+            eprintln!("SKIP: could not bootstrap daemon+proxy for `{program} app-server` ({e:?}) — Codex CLI / daemon not available here");
             return;
         }
     };
 
-    // Watchdog: if the lifecycle hangs > 20s, kill the child by pid so the blocking read
-    // returns EOF and the call errors (never a frozen suite). Stood down on completion.
+    // Watchdog: if the lifecycle hangs > 20s, kill the PROXY bridge by pid so the blocking read
+    // returns EOF and the call errors (never a frozen suite); the persistent daemon survives.
+    // Stood down on completion.
     let pid = server.child_id();
     let (done_tx, done_rx) = mpsc::channel::<()>();
     let watchdog = std::thread::spawn(move || {
@@ -119,8 +124,9 @@ fn codex_app_server_local_lifecycle_smoke() {
 /// Codex CLI is installed + logged in:
 /// `cargo test -p friday-providers --test codex_live -- --ignored run_turn`.
 ///
-/// Drives the REAL model-turn path end-to-end: spawn `codex app-server` ->
-/// `initialize` -> `initialized` -> `thread/start` -> `run_turn("…ping…")` ->
+/// Drives the REAL model-turn path end-to-end: daemon+proxy bootstrap (`codex app-server
+/// daemon start` then `codex app-server proxy`) -> `initialize` -> `initialized` ->
+/// `thread/start` -> `run_turn("…ping…")` ->
 /// the server's `turn/started`/`item/*`/`thread/tokenUsage/updated` notification stream
 /// is drained until `turn/completed`, returning the authoritative assistant text +
 /// terminal status + (if emitted) token usage. A failure surfaces the EXACT blocker
@@ -136,13 +142,14 @@ fn codex_model_turn_live_completion() {
     let mut server = match LocalCodexAppServer::spawn(&program) {
         Ok(s) => s,
         Err(e) => {
-            eprintln!("SKIP: could not spawn `{program} app-server` ({e:?}) — Codex CLI not available here");
+            eprintln!("SKIP: could not bootstrap daemon+proxy for `{program} app-server` ({e:?}) — Codex CLI / daemon not available here");
             return;
         }
     };
 
-    // Watchdog: a model turn is slower than a metadata read; allow 90s, then kill by pid
-    // so a blocking read returns EOF and the call errors (never a frozen suite).
+    // Watchdog: a model turn is slower than a metadata read; allow 90s, then kill the PROXY
+    // bridge by pid so a blocking read returns EOF and the call errors (never a frozen suite);
+    // the persistent daemon survives.
     let pid = server.child_id();
     let (done_tx, done_rx) = mpsc::channel::<()>();
     let watchdog = std::thread::spawn(move || {


### PR DESCRIPTION
## What

codex-cli **0.140.0** turned bare `codex app-server` into a *selector* that no longer speaks JSON-RPC over stdio (empirically verified on the host: it answers no `initialize` and exits; `codex --version` = `codex-cli 0.140.0`). The only break is the spawn/transport **bootstrap** — protocol, methods, handshake, and the newline-delimited `JsonLineTransport` are all unchanged.

This re-ports `LocalCodexAppServer::spawn` (`friday-providers/src/codex_appserver.rs`) to the daemon+proxy transport:

1. `codex app-server daemon start` — idempotent (boots a daemon only when none is running; **blocks until ready**). The exit code is **not** trusted as the success signal — the common production path is "daemon already running", whose exit status we do not assume.
2. Resolve the documented control socket (`$CODEX_HOME` else `$HOME/.codex`, + `app-server-control/app-server-control.sock`). The socket **existing** is the readiness gate (bound = ready, whether freshly started OR already running). If absent → fail closed: `daemon-start` when the start command itself failed, else `control-socket-missing`.
3. `codex app-server proxy --sock <path>` over piped stdin/stdout — **this is the JSON-RPC stream the existing transport reads, byte-identical downstream.**

The owned `child` is now the **proxy**; the daemon persists by design (idempotent reuse across per-turn spawns — far cheaper than full-booting an app-server every turn). `child_id`/`kill`/`Drop` manage the bridge, not the daemon.

## Error arms (fail-closed)

Added typed fail-closed **codes** on the existing code-only `Transport` variant: `daemon-start`, `control-socket-missing`, `control-socket-home-unset`. New `String`-carrying variants were deliberately **not** added — the `CodexAppServerError` type is code-only / secret-free **by documented contract** (`friday-hub`'s `codex_error_code` / `errored_outcome` both comment "NEVER carries the raw command/path"), and the two exhaustive projection sites already handle `Transport`, so the new codes flow through secret-free with zero ripple. Daemon stderr is captured (so a slow start can't hang the call) but **never** relayed into an error.

## Unchanged (in scope)

Transport, handshake (`initialize`/`initialized`), method names, approval routing, gating (`FRIDAY_CODEX_ROUTE_ENABLED` / `FRIDAY_CODEX_MUTATING_GATE` / approval-policy pins). `CODEX_APP_SERVER_CLI_VERSION` bumped `0.136.0` → `0.140.0`. The drift detector `assert_required_surface()` is untouched — **all 31 required methods verified present in the v0.140.0 `generate-json-schema` bundle** (independently extracted; zero protocol drift), and its unit tests synthesize their own fixtures, so no re-capture was needed.

## Tests

- New `control_socket_path_honors_codex_home_then_home` (pure, env-race-free, CI-safe) covers CODEX_HOME-wins / HOME-fallback / empty-treated-as-unset / both-unset→None.
- New `cli_version_constant_pins_codex_0_140`.
- KATs (byte-stream transport + handshake + schema-drift) are unchanged — they use fake transports and never call `spawn()`, so they need no surgery.
- Live `codex_live.rs` / `codex_appserver_live_stdio.rs` stay `#[ignore]`d (no real daemon in CI). Doc/comments updated to the daemon+proxy path.
- Green gate run locally: `cargo fmt --check` ✅, `cargo clippy --workspace --all-targets -D warnings` ✅, `cargo test -p friday-providers -p friday-hub` (codex/providers all pass).

## Live re-proof (coordinator, authed host)

The real daemon will not boot in the agent sandbox ("did not become ready" — environment limitation, not a code defect), so the daemon→proxy bridge itself was not exercised here. On the authed host:

```
cargo test -p friday-providers --test codex_live -- --ignored
```

Optionally pre-warm with `codex app-server daemon start`. **Specifically verify a SECOND spawn (daemon already running) succeeds** — that's the one behavior that could not be tested here and the one that would bite production. Watchdog now SIGKILLs the proxy; the daemon survives. Levers: `codex app-server daemon stop` / `daemon restart`.

## CI note

`friday-hub`'s `hub_agent_run_server` tests show a **pre-existing** shared-DB parallel flake (UNIQUE constraint on `token_ledger`/`memory_item`/`audit_ledger` ids) — all 3 pass single-threaded and are unrelated to this `friday-providers` change (zero DB/ledger surface here). If PR CI reds on them, de-flake/rerun rather than attributing to this PR.

## Known alternative

`codex app-server --stdio` (explicit flag) still works directly in 0.140.0 and would be a smaller diff, but full-boots an app-server per turn; the daemon+proxy path (per the task) keeps the persistent daemon and only spawns the cheap proxy per turn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)