### PR TITLE
fix(read-seam): un-break workbench projection for real producer-minted mission ids

### DIFF
--- a/rust-core/crates/friday-hub/src/bin/hub_read_projection_server.rs
+++ b/rust-core/crates/friday-hub/src/bin/hub_read_projection_server.rs
@@ -967,7 +967,10 @@ mod tests {
     /// Seed a probe hub DB with one canonical Mission + a route decision + work items, then return
     /// its path. Reuses the SAME storage upserts the bin's `write_mission_workbench_probe_db` proof
     /// uses, but inlined here (the bin test is `#[ignore]`-gated on an env var). The shape mirrors
-    /// `project_workbench`'s requirements: a `mission_` id, ≥1 work item, ≥1 route decision.
+    /// `project_workbench`'s requirements: ≥1 work item + ≥1 route decision. The mission id is the
+    /// REAL producer HYPHEN shape (`mission-…`, the only shape the live hub mints) — NOT a synthetic
+    /// underscore `mission_` id, so this round-trip reflects producer reality (see the no-false-
+    /// closure regression in `workbench_projection`; the projection has no id-shape gate).
     fn seed_probe_db(tag: &str) -> String {
         use friday_core::{
             ApprovalState, FridayConversation, HandoffJudgmentMemory, Mission, MissionStatus,
@@ -977,7 +980,7 @@ mod tests {
         let db = Db::open_hub(&path).unwrap();
         let now = 1_780_640_000_000;
         let conversation_id = "fconv_read_seam_probe";
-        let mission_id = "mission_read_seam_probe_20260611";
+        let mission_id = "mission-read-seam-probe-20260611";
         let work_provider = "work_read_probe_provider";
 
         db.upsert_friday_conversation(&FridayConversation {
@@ -1359,8 +1362,8 @@ mod tests {
         let opened = crypto_open(&session_key, &decode_sealed(&sealed_bytes), SESSION_AAD).unwrap();
         let json = String::from_utf8(opened).unwrap();
         assert!(
-            json.contains("mission_read_seam_probe_20260611"),
-            "the owner-opened snapshot carries the canonical mission id"
+            json.contains("mission-read-seam-probe-20260611"),
+            "the owner-opened snapshot carries the real producer-shaped mission id"
         );
         assert!(json.contains("live_rust_hub_projection"));
         assert!(
@@ -1427,8 +1430,8 @@ mod tests {
                 crypto_open(&session_key, &decode_sealed(&sealed_bytes), SESSION_AAD).unwrap();
             let json = String::from_utf8(opened).unwrap();
             assert!(
-                json.contains("mission_read_seam_probe_20260611"),
-                "the owner-opened snapshot carries the canonical mission id"
+                json.contains("mission-read-seam-probe-20260611"),
+                "the owner-opened snapshot carries the real producer-shaped mission id"
             );
             drop(ws);
         });

--- a/rust-core/crates/friday-hub/src/workbench_projection.rs
+++ b/rust-core/crates/friday-hub/src/workbench_projection.rs
@@ -25,10 +25,15 @@ use serde_json::{json, Map, Value};
 /// when `None`) from an already-opened read-only hub [`Db`]. Returns the refs-only snapshot
 /// `serde_json::Value` on success.
 ///
-/// Fail-closed: a missing mission, a non-canonical `mission_` id, a mission with no work items / no
-/// route decision, or a forbidden-marker leak all return `Err(String)` (the same coarse error
-/// strings the bin surfaced) — never a partial or a raw body. The forbidden-output guard runs
-/// INSIDE this fn so both the bin and the read server inherit it.
+/// Fail-closed: a missing mission, a mission with no work items / no route decision, or a
+/// forbidden-marker leak all return `Err(String)` (the same coarse error strings the bin surfaced)
+/// — never a partial or a raw body. The forbidden-output guard runs INSIDE this fn so both the bin
+/// and the read server inherit it.
+///
+/// The projection is id-shape-AGNOSTIC: it accepts ANY mission id the real producer mints (the live
+/// hub mints HYPHEN ids — `mission-{work_item_id}` and `mission-autodisp-…` / `mission-loop1-…`),
+/// never an underscore `mission_` shape. There is no shape gate: safety is enforced SUBSTANTIVELY by
+/// the existence + work-item + route-decision + forbidden-output guards below, not by the id text.
 pub fn project_workbench(db: &Db, requested_mission_id: Option<&str>) -> Result<Value, String> {
     let mission = match requested_mission_id {
         Some(id) => db
@@ -42,9 +47,6 @@ pub fn project_workbench(db: &Db, requested_mission_id: Option<&str>) -> Result<
             .next()
             .ok_or_else(|| "no active mission found".to_string())?,
     };
-    if !mission.mission_id.starts_with("mission_") {
-        return Err("mission id is not UI proof canonical mission_ shape".to_string());
-    }
 
     let mut projections = db
         .list_mission_surface_projections(&mission.friday_conversation_id)
@@ -880,4 +882,156 @@ fn reject_forbidden_output(rendered: &str) -> Result<(), String> {
         ],
     )
     .map_err(|marker| format!("forbidden marker in projection: {marker}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use friday_core::{
+        ApprovalState, FridayConversation, HandoffJudgmentMemory, Mission, MissionStatus,
+        RouteDecisionCard, TruthStatus, WorkItem, WorkItemStatus, WorkLane,
+    };
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    static C: AtomicU64 = AtomicU64::new(0);
+    fn tmp() -> String {
+        std::env::temp_dir()
+            .join(format!(
+                "friday-workbench-projection-{}-{}.sqlite",
+                std::process::id(),
+                C.fetch_add(1, Ordering::Relaxed)
+            ))
+            .to_string_lossy()
+            .into_owned()
+    }
+
+    fn judgment() -> HandoffJudgmentMemory {
+        HandoffJudgmentMemory {
+            task: "Mission-bound provider action".into(),
+            current_blocker: None,
+            target_lane_thread_agent_provider: "deepseek".into(),
+            read_first_files: vec![],
+            required_output: "redacted Mission Workbench projection".into(),
+            done_criteria: vec!["proof receipt required before done".into()],
+            red_lines: vec!["do not leak raw transcripts or ids".into()],
+            why_this_route: "The Workbench must consume Rust Hub Mission truth.".into(),
+            considered_options: vec!["missing route".into(), "Rust Hub projection".into()],
+            deferred_options: vec!["final UI/device capture".into()],
+            previous_pitfalls: vec!["provider ack looked like done".into()],
+            inheritable_context: vec!["carry proof refs, not raw transcript".into()],
+            proof_requirements: vec!["redacted route projection".into()],
+            ownership_claim_ids: Vec::new(),
+        }
+    }
+
+    /// Seed a Mission EXACTLY the way the REAL live producer mints it — a HYPHEN `mission-{…}` id
+    /// (the live hub's `format!("mission-{work_item_id}")` shape; cf. `lib.rs` heartbeat seed +
+    /// the real prod DB rows `mission-autodisp-…` / `mission-loop1-proof-001`) and an underscore
+    /// `fconv_` conversation. Gives it the ≥1 work_item + ≥1 route_decision the SUBSTANTIVE guards
+    /// require. Returns the exact minted hyphen mission id.
+    ///
+    /// This is DELIBERATELY a hyphen id, NOT the synthetic underscore `mission_` fixtures the older
+    /// read-seam/surface-timeline tests use — those synthetic shapes the real producer never mints
+    /// false-passed the deleted `mission_`-prefix gate, while every REAL (hyphen) mission failed it,
+    /// rendering nothing in the live Console. This test drives producer reality.
+    fn seed_real_producer_mission(db: &Db) -> String {
+        let now = 1_780_640_000_000;
+        let work_item_id = "autodisp-1781492033";
+        // The live producer shape: HYPHEN mission id, underscore conversation id.
+        let mission_id = format!("mission-{work_item_id}");
+        let conversation_id = format!("fconv_{}", work_item_id.replace('-', "_"));
+
+        db.upsert_friday_conversation(&FridayConversation {
+            friday_conversation_id: conversation_id.clone(),
+            owner_principal: "owner-real".into(),
+            title: "Real producer-minted mission".into(),
+            current_focus_summary: "hyphen mission id must project".into(),
+            active_mission_ids: vec![mission_id.clone()],
+            surface_thread_ids: vec![],
+            memory_scope_ref: None,
+            truth_status: TruthStatus::Proven,
+            proof_refs: vec!["proof://mission/real-producer".into()],
+            created_at_ms: now,
+            updated_at_ms: now,
+        })
+        .unwrap();
+        db.upsert_mission(&Mission {
+            mission_id: mission_id.clone(),
+            friday_conversation_id: conversation_id.clone(),
+            title: "Prove the real (hyphen) mission projects".into(),
+            intent: "render the live producer-minted mission in the workbench".into(),
+            status: MissionStatus::Active,
+            why_now: "the read seam must project real producer ids".into(),
+            decision_path_summary: "Rust Hub owns the Mission projection; UI reads it.".into(),
+            considered_options: vec!["route missing".into(), "live Rust projection".into()],
+            deferred_options: vec!["final UI/device evidence".into()],
+            known_pitfalls: vec!["provider ack is not completion".into()],
+            handoff_inheritance: vec!["keep proof refs redacted".into()],
+            work_item_ids: vec![work_item_id.into()],
+            memory_candidate_refs: vec![],
+            context_passport_refs: Vec::new(),
+            proof_refs: vec!["proof://mission/real-producer".into()],
+            created_at_ms: now,
+            updated_at_ms: now + 10,
+        })
+        .unwrap();
+        let provider_item = WorkItem {
+            work_item_id: work_item_id.into(),
+            mission_id: mission_id.clone(),
+            lane: WorkLane::DeepSeek,
+            target_provider_or_agent: Some("deepseek".into()),
+            status: WorkItemStatus::ProviderWaiting,
+            owner_claim_ids: Vec::new(),
+            workspace_refs: Vec::new(),
+            capability_id: Some("skill.mission-advisor".into()),
+            risk_level: friday_core::Risk::Low,
+            approval_state: ApprovalState::Required,
+            blocking_reason: Some("provider receipt pending".into()),
+            input_refs: vec!["body://redacted/provider-request".into()],
+            output_refs: Vec::new(),
+            proof_requirements: vec!["provider proof receipt before completion".into()],
+            proof_receipts: Vec::new(),
+            judgment_memory: judgment(),
+            created_at_ms: now + 4,
+            updated_at_ms: now + 5,
+        };
+        db.upsert_work_item(&provider_item).unwrap();
+        db.upsert_route_decision(&RouteDecisionCard::from_work_item(
+            "route_real_producer".into(),
+            &provider_item,
+            vec!["trace://redacted/provider-route".into()],
+            now + 8,
+            None,
+        ))
+        .unwrap();
+        mission_id
+    }
+
+    /// NO-FALSE-CLOSURE regression. Drives the REAL producer id-shape (a HYPHEN `mission-…` id, the
+    /// ONLY shape the live hub mints) end-to-end through `project_workbench` and asserts it SUCCEEDS
+    /// and the snapshot carries that EXACT hyphen id.
+    ///
+    /// This FAILS against the deleted `if !mission.mission_id.starts_with("mission_")` gate — that
+    /// gate returned `Err("mission id is not UI proof canonical mission_ shape")` for every real
+    /// (hyphen) mission, so `.unwrap()` here would panic. Restore the 3-line gate locally to watch
+    /// it fail; that is what makes this a genuine contract guard, not a shape-coincidence pass.
+    #[test]
+    fn real_producer_hyphen_mission_id_projects_without_false_closure() {
+        let db = Db::open_hub(&tmp()).unwrap();
+        let mission_id = seed_real_producer_mission(&db);
+        assert!(
+            !mission_id.starts_with("mission_"),
+            "guard precondition: the real producer mints a HYPHEN id, never `mission_`: {mission_id}"
+        );
+
+        let snapshot = project_workbench(&db, Some(&mission_id)).expect(
+            "a real producer-minted (hyphen) mission must project — no shape false-closure",
+        );
+
+        assert_eq!(
+            snapshot.get("missionId").and_then(Value::as_str),
+            Some(mission_id.as_str()),
+            "the snapshot must carry the EXACT real hyphen mission id, not a rewritten/synthetic shape"
+        );
+    }
 }

--- a/rust-core/crates/friday-hub/tests/surface_events_timeline.rs
+++ b/rust-core/crates/friday-hub/tests/surface_events_timeline.rs
@@ -139,10 +139,12 @@ fn runtime_with(tag: &str) -> (HubRuntime<ScriptTransport>, TempDir) {
     (rt, ws)
 }
 
-// The mission/conversation MUST be UI-proof canonical (`mission_` / `fconv_`) so project_workbench
-// accepts the mission and the conversation id validates.
+// The conversation id MUST be `fconv_`-shaped (the intake path validates it). The mission id is the
+// REAL producer HYPHEN shape (`mission-…`, the only shape the live hub mints) — project_workbench has
+// no id-shape gate, so this reflects producer reality (cf. the no-false-closure regression in
+// `workbench_projection`).
 const FCONV: &str = "fconv_surface";
-const MISSION: &str = "mission_surface";
+const MISSION: &str = "mission-surface";
 const WORK_ITEM: &str = "work_surface";
 const SURFACE: &str = "surface_mobile_surface";
 
@@ -165,9 +167,10 @@ fn judgment() -> HandoffJudgmentMemory {
     }
 }
 
-/// Seed a canonical `FridayConversation -> Mission -> WorkItem` (+ a Mission-bound SurfaceThread, the
-/// thread the producer resolves BY MISSION) and a route_decision so `project_workbench` accepts the
-/// mission. Mirrors the in-crate `seed_loop_mission` but with `mission_`/`fconv_` canonical ids.
+/// Seed a `FridayConversation -> Mission -> WorkItem` (+ a Mission-bound SurfaceThread, the thread
+/// the producer resolves BY MISSION) and a route_decision so `project_workbench` projects the
+/// mission. Mirrors the in-crate `seed_loop_mission` with a `fconv_` conversation id + a real
+/// producer-shaped HYPHEN `mission-` id (the only shape the live hub mints).
 fn seed_mission(db: &Db) {
     let now = 1_700_000_000_000;
     db.upsert_friday_conversation(&FridayConversation {


### PR DESCRIPTION
## Confirmed live false-closure (verified on the real prod machine)

The desktop Console connects to the live read-projection server (`:48751`) and issues a real read, but EVERY read returned `unavailable reason="mission id is not UI proof canonical mission_ shape"` — the UI rendered nothing.

### Root cause: a producer/consumer id-shape contract mismatch

- **Consumer** `workbench_projection.rs:45` (now deleted): `if !mission.mission_id.starts_with("mission_") { return Err("mission id is not UI proof canonical mission_ shape") }` — required an UNDERSCORE `mission_` prefix.
- **Producer (real, live)**: `lib.rs:13221 format!("mission-{work_item_id}")` and the intake path (`hub_server.rs` `mission_intake_result_for_db`) mint **HYPHEN** ids. Real prod DB rows: `mission-autodisp-1781492033`, `mission-loop1-proof-001`, `mission-loop1b-001` — NONE start with `mission_`.
- **Why the e2e was green anyway:** the read-seam/workbench tests used SYNTHETIC underscore fixtures the real producer never creates (`hub_read_projection_server.rs` `mission_read_seam_probe_20260611`; `surface_events_timeline.rs` `mission_surface`). They passed the guard; real missions failed it. The test was green on a shape the producer never mints.

## The fix (NO DEGRADE)

**Deleted the 3-line `mission_`-prefix gate** in `project_workbench`. The function already validates SUBSTANTIVELY and those guards are untouched:
- mission must exist (`"mission not found"` / `"no active mission found"`),
- mission must have ≥1 work_item (`"mission has no work items"`),
- mission must have ≥1 route-decision projection (`"mission has no route decision projection"`),
- the refs-only `reject_forbidden_output` guard runs INSIDE the fn (rejects `provider_native_synced` / raw transcript / raw provider markers).

The prefix check added NO real safety — it only blocked reality. I confirmed it is safe to remove by enumerating both callers:
- CLI bin `mission_workbench_projection.rs:41` — just prints the `Err` string.
- Read server `hub_read_projection_server.rs:364` → `seal_and_frame` — wraps the `Err` string into an opaque `HubOffline` "unavailable reason=..." frame.

Neither caller branches on this specific error or relies on the rejection for any safety property; both treat it as an opaque coarse string. A repo-wide grep confirmed this is the ONLY `starts_with("mission_")` gate, and `validate_friday_conversation_id` (a separate `fconv_` check at write/intake) is NOT invoked by `project_workbench`, so removal is isolated. Updated the doc comments (lines 24-36) so they no longer claim a shape contract the producer violates.

## New NO-FALSE-CLOSURE regression test

`workbench_projection::tests::real_producer_hyphen_mission_id_projects_without_false_closure` drives the REAL producer id-shape — a HYPHEN `mission-{work_item_id}` id (mirroring `lib.rs`'s `format!("mission-{work_item_id}")` + the live `mission-autodisp-…` rows) with an `fconv_` conversation — gives it the work_item + route-decision the substantive guards require, calls `project_workbench`, and asserts it SUCCEEDS and `snapshot["missionId"]` equals the EXACT hyphen id (not a weak `.is_ok()`).

**Proven to fail against the old guard:** I temporarily restored the 3-line gate locally and re-ran the test — it FAILED with `a real producer-minted (hyphen) mission must project — no shape false-closure: "mission id is not UI proof canonical mission_ shape"` — then removed the gate again. So the test genuinely guards the producer/consumer contract.

## Methodology fix: synthetic underscore fixtures flipped to producer reality

To stop the false-closure recurring, the two synthetic underscore fixtures the suite used were flipped to hyphen shapes (full suite stays green — no cascade):
- `hub_read_projection_server.rs`: `mission_read_seam_probe_20260611` → `mission-read-seam-probe-20260611` (+ the two `json.contains(...)` round-trip assertions + the seed doc comment).
- `surface_events_timeline.rs`: `const MISSION = "mission_surface"` → `"mission-surface"` (+ comments). This test drives the live intake/loop producer end-to-end, so it now proves the producer path on a real-shaped id.

## HONEST secondary-wall assessment

Removing the gate is necessary but **not by itself sufficient** to claim the read-half is fully fixed. After removal, a mission renders only if it has ≥1 work_item AND ≥1 route_decision_projection (keyed on `mission_id`).

Code-level evidence (not a guess): the live intake path `hub_server.rs:531-575` mints a `route-intake-{mission}-{work_item}` RouteDecisionCard and `upsert_route_decision`s it on the READY path, alongside the work_item the preflight stages. So **missions born through the live intake/dispatch path get both a work_item and a route decision, and should now RENDER** (e.g. `mission-loop1-proof-001` if it came through intake). The corroborating proof: `surface_events_timeline.rs::seed_mission` seeds NO route decision yet `project_workbench(...).unwrap()` succeeds there — because the live intake/loop producer it drives mints the route decision.

The residual secondary wall: any mission that exists in the DB WITHOUT a route_decision_projection (or without a work_item) — e.g. minted by a path other than intake, or where the route-decision write was skipped — will now hit `"mission has no route decision projection"` (or `"mission has no work items"`) instead of the shape error. I could not enumerate every live prod row from this read-only worktree, so I do NOT claim the read-half is fully fixed: confirming that each target prod mission carries a route_decision_projection is the explicit next step.

## Green gate (local, all clean)

- `cargo fmt --all --check` — clean
- `cargo clippy --all-targets -p friday-hub -- -D warnings` — clean (0 warnings)
- `cargo test -p friday-hub` — all binaries 0 failed (lib 885 passed / 0 failed / 8 ignored; read-server bin 21 passed incl. all 3 round-trips; surface-events timeline green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)