### PR TITLE
feat(hub): close the intelligent-clarification loop (answer-consumer + over-fire fix)

### DIFF
--- a/rust-core/crates/friday-hub/src/lib.rs
+++ b/rust-core/crates/friday-hub/src/lib.rs
@@ -4521,13 +4521,75 @@ pub fn run_loop_with_policy(
     work_item_id: Option<&str>,
     escalation_client: Option<&dyn AgentLlmClient>,
 ) -> Result<LoopOutcome, StorageError> {
+    // Every existing caller reads the clarification flag straight from env (no override). The
+    // env-read prologue lives in the shared [`run_loop_reading_flags`] helper so the
+    // clarification-resume path can pass an explicit `clarification_override` (suppress the gate
+    // on a turn that ANSWERS a prior hold) WITHOUT duplicating the five env reads. `None` here ⇒
+    // the env flag is used verbatim ⇒ BYTE-IDENTICAL to the pre-refactor entrypoint.
+    run_loop_reading_flags(
+        client,
+        executor,
+        conn,
+        run_id,
+        task,
+        recall_preamble,
+        operator_vk,
+        approve,
+        policy,
+        max_turns,
+        cancel,
+        steer,
+        now_ms,
+        work_item_id,
+        escalation_client,
+        /* clarification_override = */ None,
+    )
+}
+
+/// Shared env-read prologue for [`run_loop_with_policy`] (and the clarification-resume seam):
+/// read the five default-OFF flags ONCE, then delegate to [`run_loop_with_policy_flagged`].
+///
+/// `clarification_override`:
+/// * `None` — use the [`FRIDAY_CLARIFICATION_GATE`] env flag verbatim (every ordinary caller;
+///   byte-identical to the historical inline prologue).
+/// * `Some(false)` — FORCE the clarification gate OFF for this turn, REGARDLESS of the env flag.
+///   This is the clarification-RESUME path ([`run_session_loop`]): a turn that ANSWERS a prior
+///   `awaiting_clarification` hold must not RE-FIRE the gate (which would re-park a planning-shaped
+///   answer forever — an infinite clarification loop). It only ever forces the gate OFF (never on),
+///   so it can never widen clarification beyond what the env flag already enabled.
+/// * `Some(true)` — force ON (unused today; included for symmetry / future explicit-enable callers).
+///
+/// All OTHER flags (activity-needs-me / subagent / rich-prompt / self-critique) are read from env
+/// exactly as before — the override touches ONLY the clarification gate.
+#[allow(clippy::too_many_arguments)]
+fn run_loop_reading_flags(
+    client: &dyn AgentLlmClient,
+    executor: &dyn ToolExecutor,
+    conn: &Connection,
+    run_id: &str,
+    task: &str,
+    recall_preamble: &str,
+    operator_vk: Option<&OperatorVerifyingKey>,
+    approve: &dyn Fn(&MutatingActionRequest) -> Option<CanonicalApproval>,
+    policy: &RunPolicy,
+    max_turns: u64,
+    cancel: Option<&CancelToken>,
+    steer: Option<&SteerHandle>,
+    now_ms: i64,
+    work_item_id: Option<&str>,
+    escalation_client: Option<&dyn AgentLlmClient>,
+    clarification_override: Option<bool>,
+) -> Result<LoopOutcome, StorageError> {
     // Read the NS-7 flag ONCE here; the loop body is pure on the resulting bool.
     let activity_needs_me =
         activity_needs_me_from(std::env::var(FRIDAY_ACTIVITY_NEEDS_ME).ok().as_deref());
     // Read the clarification-gate flag ONCE here (same default-OFF, read-once idiom). When OFF
-    // the loop is byte-identical (no gate, no prompt steering).
-    let clarification_enabled =
-        clarification_gate_from(std::env::var(FRIDAY_CLARIFICATION_GATE).ok().as_deref());
+    // the loop is byte-identical (no gate, no prompt steering). A `clarification_override` (the
+    // resume seam) takes precedence over the env flag — `Some(false)` suppresses the gate for a
+    // turn that answers a prior hold; `None` uses the env flag verbatim.
+    let clarification_enabled = clarification_override.unwrap_or_else(|| {
+        clarification_gate_from(std::env::var(FRIDAY_CLARIFICATION_GATE).ok().as_deref())
+    });
     // Read the subagent-tool flag ONCE here (same default-OFF idiom). When OFF the `subagent`
     // dispatch-seam interception NEVER fires and the loop is byte-identical to today.
     let subagent_enabled = crate::subagent::subagent_tool_enabled_from(
@@ -5581,6 +5643,59 @@ fn spawn_subagent_turn(
     })
 }
 
+/// Is this session currently HELD by the clarification gate FOR THIS OWNER — i.e. did its MOST
+/// RECENT prior run park at `awaiting_clarification` AND is that parked run owned by `principal`?
+/// If so, the next turn is the OWNER ANSWERING the questions and the gate must be SUPPRESSED for it
+/// (see the resume seam in [`run_session_loop`]).
+///
+/// Detection (cheap, OWNER-SCOPED, no new table):
+///   * Walk `prior` (this session's own messages, already loaded — in `seq` order) from the END to
+///     find the run_id of the LAST turn that carries a producing-run `refs`.
+///   * Read THAT run's `run_result` ([`friday_storage::get_run_result`]). Suppress ONLY when its
+///     status is `awaiting_clarification` AND its recorded `owner_principal` equals `principal` —
+///     the authenticated owner of THIS turn. A parked run owned by a DIFFERENT principal (or an
+///     owner-less parked run) never suppresses this owner's gate.
+///
+/// Why owner-binding (NO CROSS-OWNER LEAK): a `session_id` is a client-asserted thread handle, not
+/// an identity. The run loop always binds the run to the AUTHENTICATED caller, but two different
+/// authenticated owners could (in principle) assert the same `session_id`. Keying the suppression on
+/// the parked run's recorded `owner_principal` makes a different owner's outstanding hold UNABLE to
+/// suppress this owner's gate — the suppression is a per-owner property, enforced locally here
+/// rather than assumed from the session handle.
+///
+/// Why "most recent run", not "any prior hold": once a hold is ANSWERED, the answering run produces
+/// a NON-`awaiting_clarification` result (it finished / errored / etc.), so the most-recent-run
+/// status is `awaiting_clarification` ONLY while a hold is genuinely OUTSTANDING. A later, fully
+/// separate vague task in the same session re-parks and is detected as a fresh hold — correct.
+///
+/// FAIL-SAFE + NO-DEGRADE: an empty session, a session whose last run finished, a last turn with no
+/// `refs`, a `None`/empty `principal`, or a parked run owned by someone else ⇒ `false` (the gate
+/// behaves exactly as the env flag dictates). A storage error PROPAGATES (never silently suppresses
+/// or fires the gate). It can ONLY return `true` for a session that actually parked under THIS
+/// owner, which requires the gate to have fired (flag ON); with the flag OFF this fn is not even
+/// consulted (see the caller's flag-gating) ⇒ byte-identical to the pre-fix loop.
+fn session_is_in_clarification_hold(
+    conn: &Connection,
+    prior: &[friday_storage::StoredSessionMessage],
+    principal: Option<&str>,
+) -> Result<bool, StorageError> {
+    // No bound principal ⇒ no owner to match ⇒ never suppress (fail-closed, no leak).
+    let Some(owner) = principal.filter(|p| !p.is_empty()) else {
+        return Ok(false);
+    };
+    // The producing run_id of the most-recent prior turn that records one.
+    let Some(last_run_id) = prior.iter().rev().find_map(|m| m.refs.as_deref()) else {
+        return Ok(false); // no prior run in this session ⇒ not a resume
+    };
+    match friday_storage::get_run_result(conn, last_run_id)? {
+        // Suppress ONLY a hold owned by THIS authenticated owner.
+        Some(r) => {
+            Ok(r.status == "awaiting_clarification" && r.owner_principal.as_deref() == Some(owner))
+        }
+        None => Ok(false), // the prior run has no persisted result ⇒ not a clarification hold
+    }
+}
+
 /// Drive a history-aware agent loop WITHIN a session (S5 inbound history + resume).
 /// A SESSION groups runs: this loads the session's prior conversation messages,
 /// prepends them (BOUNDED) to the prompt so the model sees the multi-turn inbound
@@ -5680,6 +5795,25 @@ pub fn run_session_loop(
     }
     let prior = friday_storage::load_session_messages(conn, session_id)?;
 
+    // 1b. CLARIFICATION-RESUME detection (the answer-consumer half of the loop). If the MOST
+    //     RECENT prior run in this session PARKED at `awaiting_clarification`, THIS turn is the
+    //     user ANSWERING those questions — it must NOT re-fire the gate. Without this a
+    //     planning-shaped answer (e.g. "trigger daily and build a dashboard") would re-classify as
+    //     a planning kind and re-park FOREVER (an infinite clarification loop — confirmed against
+    //     the pre-fix tree). The fold of the questions+answer into the prompt happens for free via
+    //     the session-history preamble (step 4 now also persists the asked questions as an
+    //     `assistant` turn), so the resumed turn sees `[task][questions][answer]` and acts.
+    //
+    //     OWNER-SCOPING + NO-DEGRADE: the detection is gated behind the SAME default-OFF
+    //     `FRIDAY_CLARIFICATION_GATE` flag, so with the flag OFF NO extra storage read happens at
+    //     all (byte-identical, including DB access). When ON, detection reads ONLY this session's
+    //     own prior turns + the parked run's `run_result`, and suppresses ONLY when that run parked
+    //     at `awaiting_clarification` AND is owned by the SAME authenticated principal (so a
+    //     different owner's hold can never suppress THIS owner's gate — no cross-owner leak).
+    let in_clarification_hold =
+        clarification_gate_from(std::env::var(FRIDAY_CLARIFICATION_GATE).ok().as_deref())
+            && session_is_in_clarification_hold(conn, &prior, policy.principal_id())?;
+
     // 2. Fold the BOUNDED prior-session history AHEAD of the recall preamble. The loop
     //    already builds `prompt_task = preamble + task`, so passing the combined
     //    preamble threads inbound history into the model WITHOUT any loop change.
@@ -5687,7 +5821,14 @@ pub fn run_session_loop(
     let combined_preamble = format!("{session_preamble}{recall_preamble}");
 
     // 3. Run the SAME gate-mandatory loop (principal/scope/operator-key/cancel/steer aware).
-    let outcome = run_loop_with_policy(
+    //    `clarification_override`: `Some(false)` ONLY on a resume turn (suppress the gate so the
+    //    answer is consumed, never re-asked); `None` otherwise ⇒ the env flag governs verbatim.
+    let clarification_override = if in_clarification_hold {
+        Some(false)
+    } else {
+        None
+    };
+    let outcome = run_loop_reading_flags(
         client,
         executor,
         conn,
@@ -5703,6 +5844,7 @@ pub fn run_session_loop(
         now_ms,
         work_item_id,
         escalation_client,
+        clarification_override,
     )?;
 
     // 4. Persist this run's turn(s) so the next run in the session resumes with them:
@@ -5720,6 +5862,29 @@ pub fn run_session_loop(
                 conn,
                 session_id,
                 &friday_storage::SessionMessage::new("assistant", answer, Some(run_id.to_string())),
+                now_ms,
+            )?;
+        }
+    }
+    // 4b. CLARIFICATION fold (the answer-consumer's SETUP half). An `AwaitingClarification` outcome
+    //     carries the SPECIFIC clarifying questions in `final_message`; persist them as an
+    //     `assistant` turn so the NEXT run in this session (the user's ANSWER) sees the questions in
+    //     its history preamble and can answer THEM — closing the loop. Without this the resume turn
+    //     saw only the original under-specified `user` task and had to GUESS what it was answering.
+    //     This append happens ONLY on `AwaitingClarification`, which ONLY occurs when the gate fired
+    //     (flag ON); with the flag OFF no run parks ⇒ this arm is never reached ⇒ byte-identical to
+    //     today (the session transcript is unchanged). The body stays Hub-side (refs-only event
+    //     below), exactly like the `user`/`assistant` answer turns.
+    if outcome.status == LoopStatus::AwaitingClarification {
+        if let Some(questions) = outcome.final_message.as_deref() {
+            friday_storage::append_session_message(
+                conn,
+                session_id,
+                &friday_storage::SessionMessage::new(
+                    "assistant",
+                    questions,
+                    Some(run_id.to_string()),
+                ),
                 now_ms,
             )?;
         }
@@ -6893,6 +7058,114 @@ mod tests {
             "destructive requests are handled by the Pause, not clarified"
         );
         assert_eq!(model_calls, 1, "the destructive task reaches the loop");
+    }
+
+    // ── session_is_in_clarification_hold: the answer-consumer's resume-detection, OWNER-BOUND ──
+    // Direct unit tests of the private detector (a `tests/` binary cannot reach it). They craft the
+    // exact DB shape (a parked run + a session message that refs it) and assert: a hold owned by THIS
+    // owner suppresses; a hold owned by ANOTHER owner does NOT (no cross-owner leak); a finished prior
+    // run, an empty session, and a None principal all return false.
+
+    /// Set up a session whose most-recent prior run has `prior_status`, owned by `run_owner`, then
+    /// ask whether `caller` sees a clarification hold. Returns the detector's verdict.
+    fn hold_scenario(
+        tag: &str,
+        prior_status: &str,
+        prior_answer: &str,
+        run_owner: Option<&str>,
+        caller: Option<&str>,
+    ) -> bool {
+        let db = Db::open_hub(&temp_path(tag)).unwrap();
+        let conn = db.conn();
+        // A prior run that produced `prior_status` (e.g. parked at awaiting_clarification),
+        // owner-wired to `run_owner`, plus a session message that refs it (as run_session_loop
+        // persists). The detector reads the run_result of the last refs'd run.
+        agent_run::create_run(conn, "prior-run", "create a workflow daily summary", 1).unwrap();
+        let mut result = friday_storage::RunResult::new(prior_status, prior_answer, None);
+        if let Some(o) = run_owner {
+            result = result.with_owner_principal(o);
+        }
+        friday_storage::persist_run_result(conn, "prior-run", &result, 2).unwrap();
+        friday_storage::ensure_session(conn, "sess-hold", 3).unwrap();
+        friday_storage::append_session_message(
+            conn,
+            "sess-hold",
+            &friday_storage::SessionMessage::new(
+                "user",
+                "create a workflow",
+                Some("prior-run".to_string()),
+            ),
+            3,
+        )
+        .unwrap();
+        let prior = friday_storage::load_session_messages(conn, "sess-hold").unwrap();
+        session_is_in_clarification_hold(conn, &prior, caller).unwrap()
+    }
+
+    #[test]
+    fn clarification_hold_detected_for_same_owner() {
+        assert!(
+            hold_scenario(
+                "hold-same",
+                "awaiting_clarification",
+                "Question 1/2: ...",
+                Some("alice"),
+                Some("alice"),
+            ),
+            "a parked run owned by the SAME caller IS a hold ⇒ suppress the gate (resume)"
+        );
+    }
+
+    #[test]
+    fn clarification_hold_not_detected_for_different_owner_no_cross_owner_leak() {
+        assert!(
+            !hold_scenario(
+                "hold-diff",
+                "awaiting_clarification",
+                "Question 1/2: ...",
+                Some("alice"),
+                Some("bob"), // a DIFFERENT authenticated owner on the same session_id
+            ),
+            "a parked run owned by ANOTHER principal must NOT suppress this owner's gate (no leak)"
+        );
+    }
+
+    #[test]
+    fn clarification_hold_not_detected_when_prior_run_finished() {
+        assert!(
+            !hold_scenario(
+                "hold-fin",
+                "finished",
+                "All done.",
+                Some("alice"),
+                Some("alice")
+            ),
+            "a prior run that FINISHED is not an outstanding hold ⇒ the gate evaluates normally"
+        );
+    }
+
+    #[test]
+    fn clarification_hold_not_detected_with_no_caller_principal() {
+        assert!(
+            !hold_scenario(
+                "hold-noprin",
+                "awaiting_clarification",
+                "Question 1/2: ...",
+                Some("alice"),
+                None, // no bound principal ⇒ never suppress (fail-closed)
+            ),
+            "no bound caller principal ⇒ never suppress (fail-closed, no owner to match)"
+        );
+    }
+
+    #[test]
+    fn clarification_hold_not_detected_for_empty_session() {
+        let db = Db::open_hub(&temp_path("hold-empty")).unwrap();
+        // No prior messages at all ⇒ not a resume.
+        assert!(
+            !session_is_in_clarification_hold(db.conn(), &[], Some("alice")).unwrap(),
+            "an empty session has no prior run ⇒ not a hold"
+        );
     }
 
     // ── FRIDAY_RICH_SYSTEM_PROMPT_ENABLED: rich operating-guidance preamble (bool-injected) ──

--- a/rust-core/crates/friday-hub/tests/clarification_gate.rs
+++ b/rust-core/crates/friday-hub/tests/clarification_gate.rs
@@ -368,3 +368,200 @@ fn finished_sessionless_run_task_persists_terminal_agent_run_state() {
          terminal agent_run.state"
     );
 }
+
+// ── CLARIFICATION LOOP CLOSURE: the answer-consumer seam + over-fire guard ──────────────
+//
+// The marquee proof. Before this fix the clarification gate PARKED a vague planning task but
+// nothing CONSUMED the user's answers: a follow-up turn worked only INCIDENTALLY (when the answer
+// happened to classify `None`). A planning-SHAPED answer (e.g. "trigger daily and build a
+// dashboard") re-classified as a planning kind and RE-FIRED the gate — re-parking forever (an
+// infinite clarification loop, confirmed against the pre-fix tree). These tests lock the closure:
+// the resume turn is gate-SUPPRESSED (consumes the answer → terminal), the questions are folded
+// into the resumed history, and the gate is owner-scoped (a different owner's session is unaffected).
+
+/// THE CLOSURE PROOF. A real under-detailed task PARKS at `awaiting_clarification` (with the
+/// specific questions); then a PLANNING-SHAPED answer on the SAME session RESUMES — the gate is
+/// suppressed for the answering turn, so the loop runs and reaches a TERMINAL `finished` state
+/// (NOT re-parked). This exact answer RE-FIRED the gate before the fix.
+#[test]
+fn parked_run_resumes_to_terminal_when_answer_is_supplied_even_if_answer_looks_like_planning() {
+    std::env::set_var(friday_hub::FRIDAY_CLARIFICATION_GATE, "1");
+    let owner = "owner-clar-close";
+    // Two scripted finishes: the FIRST POST is the resume turn (turn 1's gate makes NO model call).
+    let (rt, _ws) = runtime_with(
+        "clar-close",
+        owner,
+        ScriptTransport::new(&[
+            "{\"tool\":\"none\",\"answer\":\"Scheduled: a daily 9am summary to #team.\"}",
+        ]),
+    );
+    let caller = authed_caller(owner);
+
+    // Turn 1: a vague workflow task → the gate PARKS (NO model call; the questions are delivered).
+    let first = rt.run_session_task(
+        &caller,
+        "run-clar-close-1",
+        "sess-clar-close",
+        "create a workflow that posts a daily summary",
+        5_000,
+    );
+    match &first {
+        AuthedAnswer::Delivered { status, .. } => assert_eq!(
+            status, "awaiting_clarification",
+            "turn 1 is an under-specified planning task ⇒ the gate parks it"
+        ),
+        other => panic!("expected a clarification on turn 1, got {other:?}"),
+    }
+    // The parked run's state is correctly held (the genuine hold is preserved).
+    let held = friday_storage::agent_run_read::get_run_summary(rt.db().conn(), "run-clar-close-1")
+        .unwrap()
+        .expect("the parked run has an agent_run row");
+    assert_eq!(
+        held.state, "awaiting_clarification",
+        "turn 1 is a genuine hold"
+    );
+
+    // Turn 2: the ANSWER. It deliberately CONTAINS planning verbs ("trigger"/"build a dashboard")
+    // so that WITHOUT the resume-suppression it would re-classify as a planning kind and RE-PARK
+    // (the pre-fix infinite-loop bug). With the fix the gate is suppressed for this answering turn
+    // (the session's last run parked), so the loop RUNS to a terminal `finished`.
+    let resume = rt.run_session_task(
+        &caller,
+        "run-clar-close-2",
+        "sess-clar-close",
+        "Trigger it daily at 9am and build a dashboard summary for the team",
+        6_000,
+    );
+    match resume {
+        AuthedAnswer::Delivered { status, answer, .. } => {
+            assert_eq!(
+                status, "finished",
+                "THE CLOSURE: the answer is CONSUMED (gate suppressed) ⇒ the run reaches a \
+                 terminal state, NOT re-parked at awaiting_clarification"
+            );
+            assert!(
+                !answer.contains("Question 1/2"),
+                "the resume delivers the model's reply, NOT another clarification: {answer}"
+            );
+        }
+        other => panic!("expected a Finished delivery on resume, got {other:?}"),
+    }
+    // The resumed run's persisted state is terminal too.
+    let done = friday_storage::agent_run_read::get_run_summary(rt.db().conn(), "run-clar-close-2")
+        .unwrap()
+        .expect("the resumed run has an agent_run row");
+    assert_eq!(
+        done.state, "finished",
+        "the resumed run's agent_run.state is terminal (the loop closed)"
+    );
+}
+
+/// GAP-(a) PROOF: the asked questions are PERSISTED into the session as an `assistant` turn, so the
+/// resume turn's model sees `[task][questions]` in its history and can answer THEM (before the fix
+/// only the user task was persisted — the resume turn had to guess what it was answering).
+#[test]
+fn parked_run_persists_the_questions_into_session_history_for_the_resume_turn() {
+    std::env::set_var(friday_hub::FRIDAY_CLARIFICATION_GATE, "1");
+    let owner = "owner-clar-fold";
+    let (rt, _ws) = runtime_with("clar-fold", owner, PanicTransport);
+    let caller = authed_caller(owner);
+    let _ = rt.run_session_task(
+        &caller,
+        "run-clar-fold-1",
+        "sess-clar-fold",
+        "create a workflow that posts a daily summary",
+        5_000,
+    );
+    let msgs = friday_storage::load_session_messages(rt.db().conn(), "sess-clar-fold").unwrap();
+    // The user task is present (as before) AND the questions are now present as an assistant turn.
+    assert!(
+        msgs.iter().any(|m| m.role == "user"
+            && m.content
+                .contains("create a workflow that posts a daily summary")),
+        "the user's under-specified task is recorded"
+    );
+    let q_msg = msgs
+        .iter()
+        .find(|m| m.role == "assistant" && m.content.contains("Question 1/2"))
+        .expect("THE FOLD: the asked questions are persisted as an assistant turn");
+    assert!(
+        q_msg.content.contains(WORKFLOW_Q1) && q_msg.content.contains(WORKFLOW_Q2),
+        "the folded assistant turn carries the SPECIFIC questions: {}",
+        q_msg.content
+    );
+}
+
+/// OVER-FIRE GUARD: a clear, actionable directive ("reply with exactly PONG") must NOT park — it
+/// classifies as ordinary (non-planning) work and runs to `finished`. Documents that the gate is
+/// correctly calibrated (NOT loosened) — the "even PONG parked" live-DB symptom was the stuck
+/// `agent_run.state` column (the #783 lifecycle fix), NOT the gate mis-firing.
+#[test]
+fn clear_actionable_task_does_not_park_over_fire_guard() {
+    std::env::set_var(friday_hub::FRIDAY_CLARIFICATION_GATE, "1");
+    let owner = "owner-clar-pong";
+    let (rt, _ws) = runtime_with(
+        "clar-pong",
+        owner,
+        ScriptTransport::new(&["{\"tool\":\"none\",\"answer\":\"PONG\"}"]),
+    );
+    let caller = authed_caller(owner);
+    let answer = rt.run_session_task(
+        &caller,
+        "run-clar-pong",
+        "sess-clar-pong",
+        "reply with exactly PONG",
+        5_000,
+    );
+    match answer {
+        AuthedAnswer::Delivered { status, .. } => assert_eq!(
+            status, "finished",
+            "a clear actionable directive must NOT park at the clarification gate (no over-fire)"
+        ),
+        other => panic!("expected a Finished delivery, got {other:?}"),
+    }
+}
+
+/// SESSION-SCOPING: the resume-suppression is keyed on the SESSION's own prior runs. A FRESH
+/// session (here a distinct owner+DB) whose first turn is a vague planning task still PARKS — an
+/// unrelated session's outstanding hold can never suppress this session's gate. (The DIFFERENT-owner
+/// /SAME-session-id leak is locked at the unit level by the `session_is_in_clarification_hold`
+/// owner-binding tests in `lib.rs`, since this in-process runtime's policy principal is fixed at
+/// config and cannot vary per-caller.)
+#[test]
+fn fresh_session_still_parks_resume_suppression_does_not_leak_across_sessions() {
+    std::env::set_var(friday_hub::FRIDAY_CLARIFICATION_GATE, "1");
+    // Owner A parks a hold.
+    let owner_a = "owner-iso-a";
+    let (rt_a, _ws_a) = runtime_with("clar-iso-a", owner_a, PanicTransport);
+    let caller_a = authed_caller(owner_a);
+    let a = rt_a.run_session_task(
+        &caller_a,
+        "run-iso-a-1",
+        "sess-iso-a",
+        "create a workflow that posts a daily summary",
+        5_000,
+    );
+    match &a {
+        AuthedAnswer::Delivered { status, .. } => assert_eq!(status, "awaiting_clarification"),
+        other => panic!("{other:?}"),
+    }
+    // Owner B, a DIFFERENT runtime/db + a fresh session: a vague planning task STILL parks (B's
+    // session has no prior hold of its own; A's hold cannot suppress B's gate).
+    let owner_b = "owner-iso-b";
+    let (rt_b, _ws_b) = runtime_with("clar-iso-b", owner_b, PanicTransport);
+    let caller_b = authed_caller(owner_b);
+    let b = rt_b.run_session_task(
+        &caller_b,
+        "run-iso-b-1",
+        "sess-iso-b",
+        "create a workflow that posts a daily summary",
+        5_000,
+    );
+    match b {
+        AuthedAnswer::Delivered { status, .. } => assert_eq!(
+            status, "awaiting_clarification",
+            "a fresh session with no prior hold of its own must still park (no cross-session leak)"
+        ),
+        other => panic!("expected a clarification (no leak), got {other:?}"),
+    }
+}


### PR DESCRIPTION
## What

Closes the marquee **intelligent-clarification spine loop**: the clarification gate parks an under-detailed task at \`awaiting_clarification\` with generated questions, but **nothing consumed the user's answers** to resume the run. This adds the missing half (the answer-consumer seam) at the session level, plus an over-fire investigation.

All changes are confined to \`run_session_loop\` and a shared env-read helper, gated behind the existing default-OFF \`FRIDAY_CLARIFICATION_GATE\`.

## DIAGNOSIS (file:line, empirically confirmed against the unfixed tree)

**PRODUCER (parks):** \`lib.rs:run_loop_with_policy_inner\` (the gate at \`crates/friday-hub/src/lib.rs:4736\`) — when \`clarification_enabled\` (flag ON) AND \`friday_core::classify_kind\` returns a planning kind AND \`!is_task_detailed_enough\`, it returns \`LoopStatus::AwaitingClarification\` with the questions, making ZERO model calls. Persisted as a \`run_result{status:"awaiting_clarification"}\` in \`run_session_loop\` step-5b (\`lib.rs\`) + the runtime.rs parity arms (\`runtime.rs:876\`, \`runtime.rs:978\`).

**CONSUMER (was missing):** there was **no** path that took the user's answers and resumed the parked run. The only existing "resume" was incidental: the test \`resume_with_plain_answer_...\` (in \`tests/clarification_gate.rs\`) works ONLY because a plain answer happens to classify \`None\`. Two real gaps, both reproduced against the pre-fix tree:
- **(a)** On \`AwaitingClarification\`, \`run_session_loop\` step-4 appended the *user task* but **not** the questions — so a resume turn's model never saw what it was answering (probe: only the \`user\` row was present).
- **(b)** A planning-SHAPED answer (e.g. *"Trigger daily at 9am and build a dashboard summary"*) re-classified as a planning kind and **RE-FIRED the gate → re-parked forever** (infinite clarification loop; probe confirmed status came back \`awaiting_clarification\` again).

**OVER-FIRE:** investigated; **no threshold change made (deliberate).** A \`classify_kind\` probe shows *"reply with exactly PONG"* classifies \`None\` ⇒ the gate does **not** mis-park it. \`is_task_detailed_enough\` is a faithful oracle port; loosening it would diverge from parity and risk letting genuinely-vague tasks through — a degrade with no flag-OFF-identical justification. The "even PONG parked" live-DB symptom was the **stuck \`agent_run.state\` column**, already fixed by the \`mark_run_terminal_state\` lifecycle chokepoint (PR #783, present in this tree). STEP-2 part-2's deliverable is the documenting over-fire-guard test, not a logic change.

## THE TWO-PART FIX (both behind FRIDAY_CLARIFICATION_GATE, default-OFF)

1. **Answer-consumer seam (gap b — the core).** \`run_session_loop\` now detects whether the session's most-recent prior run parked at \`awaiting_clarification\` **and is owned by the same authenticated principal** (\`session_is_in_clarification_hold\`), and if so SUPPRESSES the gate for this turn (\`clarification_override = Some(false)\` threaded into the new shared \`run_loop_reading_flags\`). The user's answer is the next \`AgentRunRequest\` on the same session — no new protocol message needed (the supply mechanism + owner-auth already exist via the authenticated \`AgentRunRequest\` + owner-bound session).
2. **The fold (gap a — the setup).** On \`AwaitingClarification\`, step-4b now persists the questions as an \`assistant\` turn, so the resume turn's history preamble carries \`[task][questions][answer]\` for free via the existing \`render_session_history\`.

## NO-DEGRADE / FLAG JUSTIFICATION

- Both arms are reachable ONLY when a run parks at \`AwaitingClarification\`, which happens ONLY when the gate fires (flag ON). The hold-detection read is itself **flag-gated** (\`clarification_gate_from(env) && ...\`), so with the flag OFF there is **zero extra storage access** — byte-identical including DB I/O.
- \`run_loop_with_policy\` is refactored to delegate to a private \`run_loop_reading_flags\` with \`clarification_override: None\` — every existing caller is byte-identical (the override only ever forces the gate OFF, never on, so it can never widen clarification).
- **Owner-gated, no cross-owner leak:** suppression keys on the parked run's recorded \`owner_principal == policy.principal_id()\` (the authenticated owner). A different owner's hold on the same \`session_id\` gets a normal gate evaluation. Locked at the unit level (\`clarification_hold_not_detected_for_different_owner_no_cross_owner_leak\`).

## DESIGN NOTE — the parked run stays parked, BY DESIGN

\`persist_run_result\` is write-once and \`mark_run_terminal_state\` is a deliberate no-op for \`awaiting_clarification\` (to preserve genuine holds). So the **parked run (run-1) is NOT mutated** — it remains an immutable record of a real hold. "The run transitions out of \`awaiting_clarification\`" is realized **conversationally**: a NEW run on the same session consumes the answer and reaches a terminal state. (A reviewer reading the task literally and checking the live DB will see run-1 still parked — that is correct.)

## KNOWN BOUNDARIES (honest scope)

- Closure works on the **stable-session-id** path (the normal chat path). The **ephemeral per-run session arm** (\`session_id == run_id\`) and the **sessionless \`run_task\` routed/codex persist arms** (\`runtime.rs:876\`, \`runtime.rs:978\`) park **without a consumer by construction** — a one-shot dispatch has no follow-up thread to resume on. Named, not silently deferred.
- Different-owner/same-session-id isolation is proven at the **unit** level (the in-process runtime's policy principal is fixed at config, so it can't vary per-caller in an integration test).

## E2E CLOSURE TESTS (real Db, mock provider)

In \`tests/clarification_gate.rs\` (drives the real \`run_session_task → run_session_loop\` chain):
- \`parked_run_resumes_to_terminal_when_answer_is_supplied_even_if_answer_looks_like_planning\` — **THE CLOSURE**: vague task parks → a *planning-shaped* answer (which RE-PARKED before this fix) now resumes gate-suppressed → \`finished\` (run + persisted state terminal).
- \`parked_run_persists_the_questions_into_session_history_for_the_resume_turn\` — gap-(a): the questions are folded as an \`assistant\` turn.
- \`clear_actionable_task_does_not_park_over_fire_guard\` — "reply with exactly PONG" → \`finished\`, never parks.
- \`fresh_session_still_parks_..._does_not_leak_across_sessions\` — an unrelated session's hold never suppresses this session's gate.

In \`lib.rs\` unit tests: \`clarification_hold_{detected_for_same_owner, not_detected_for_different_owner_no_cross_owner_leak, not_detected_when_prior_run_finished, not_detected_with_no_caller_principal, not_detected_for_empty_session}\`.

## GREEN GATE (from \`rust-core\`, all clean)

- \`cargo fmt --all --check\` — clean
- \`cargo clippy --all-targets -p friday-hub -- -D warnings\` — clean
- \`cargo test -p friday-hub\` — **893 lib + all integration binaries pass, 0 failed** (clarification_gate 9 passed; the 5 new owner-binding unit tests pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)