### PR TITLE
fix(hub): harden spine — atomic mission intake + busy-retry on state-machine producers (#H1/#H3/#H4)

### DIFF
--- a/rust-core/crates/friday-hub/src/mission_preflight.rs
+++ b/rust-core/crates/friday-hub/src/mission_preflight.rs
@@ -148,12 +148,13 @@ pub fn preflight_and_stage_work_item(
     work_item.status = WorkItemStatus::ReadyToDispatch;
     work_item.blocking_reason = None;
 
-    db.upsert_friday_conversation(&conversation)?;
-    db.upsert_mission(&mission)?;
-    if let Some(surface) = surface_thread {
-        db.upsert_surface_thread(&surface)?;
-    }
-    db.upsert_work_item(&work_item)?;
+    // (#H1, hardening audit) Stage the four rows ATOMICALLY in ONE transaction. Pre-fix these were
+    // four independent auto-committed upserts: a failure (or crash) AFTER the Mission upsert but
+    // BEFORE the WorkItem upsert left a permanently-stuck Active Mission with NO WorkItem, which the
+    // conversation+intent duplicate guard then matched and BLOCKED a clean retry against (binding the
+    // surface to the orphan). `stage_intake_atomic` writes all-or-nothing (and busy-retries under
+    // reaper/retention WAL contention), so a failure writes ZERO rows and a retry is clean.
+    db.stage_intake_atomic(&conversation, &mission, surface_thread.as_ref(), &work_item)?;
 
     Ok(MissionPreflightOutcome::Ready {
         mission_id: mission.mission_id,
@@ -1076,6 +1077,65 @@ mod tests {
                 duplicate_work_item_id: None
             }
         );
+        assert_eq!(db.count("mission").unwrap(), 1);
+        assert_eq!(db.count("work_item").unwrap(), 1);
+    }
+
+    // (#H1, hardening audit) A failure on the LAST upsert of the intake sequence (here the
+    // WorkItem, whose empty `work_item_id` trips `require_non_empty` INSIDE `upsert_work_item`,
+    // after the conversation + mission + surface upserts have run on the shared txn) must leave
+    // ZERO rows — proving the four upserts are now ONE atomic transaction. Pre-fix the conversation
+    // and mission (and surface) would have auto-committed, stranding a permanently-Active Mission
+    // with no WorkItem that the duplicate guard then matched, blocking a clean retry.
+    #[test]
+    fn mid_sequence_intake_failure_leaves_zero_rows_no_orphan_mission() {
+        let db = Db::open_hub(&tmp()).unwrap();
+        let mut req = request(
+            "mission-atomic",
+            "work-atomic",
+            "atomic intake must be all-or-nothing",
+            WorkLane::FridayHub,
+            Vec::new(),
+            false,
+            1,
+        );
+        // Inject the mid-txn failure: an empty WorkItem id is rejected by `upsert_work_item`'s
+        // `require_non_empty` — the LAST write in the staged sequence, so the conversation/mission/
+        // surface upserts ran first and MUST be rolled back with it.
+        req.work_item.work_item_id = String::new();
+
+        let result = preflight_and_stage_work_item(&db, req);
+        assert!(
+            result.is_err(),
+            "an empty work_item_id must fail the staged intake, got {result:?}"
+        );
+
+        // All-or-nothing: NOT ONE of the four rows persisted. Crucially mission == 0 (no orphan
+        // Active Mission) and conversation == 0 (no surface bound to an orphan).
+        assert_eq!(db.count("mission").unwrap(), 0, "no orphan Mission");
+        assert_eq!(
+            db.count("friday_conversation").unwrap(),
+            0,
+            "no orphan conversation"
+        );
+        assert_eq!(db.count("surface_thread").unwrap(), 0, "no orphan surface");
+        assert_eq!(db.count("work_item").unwrap(), 0, "no work_item");
+
+        // And a clean retry (valid ids) now SUCCEEDS — it is not blocked by a stranded orphan.
+        let retry = preflight_and_stage_work_item(
+            &db,
+            request(
+                "mission-atomic",
+                "work-atomic",
+                "atomic intake must be all-or-nothing",
+                WorkLane::FridayHub,
+                Vec::new(),
+                false,
+                2,
+            ),
+        )
+        .unwrap();
+        assert!(retry.is_ready(), "clean retry should stage, got {retry:?}");
         assert_eq!(db.count("mission").unwrap(), 1);
         assert_eq!(db.count("work_item").unwrap(), 1);
     }

--- a/rust-core/crates/friday-storage/src/lib.rs
+++ b/rust-core/crates/friday-storage/src/lib.rs
@@ -633,6 +633,54 @@ impl Db {
         mission::upsert_conversation(&self.conn, conversation)
     }
 
+    /// (#H1, hardening audit) ATOMICALLY stage a mission-intake's product graph: the
+    /// `FridayConversation`, the `Mission`, an OPTIONAL `SurfaceThread`, and the `WorkItem`, in ONE
+    /// transaction — so the four rows are all-or-nothing.
+    ///
+    /// Pre-fix the Hub's `preflight_and_stage_work_item` wrote these as FOUR independent
+    /// auto-committed upserts with no shared txn: a failure (or crash) AFTER the Mission upsert but
+    /// BEFORE the WorkItem upsert left a permanently-stuck Active Mission with NO WorkItem, and the
+    /// surface-bound duplicate guard (`find_duplicate_mission`, keyed on conversation+intent) then
+    /// matched the orphan and BLOCKED a clean retry. Folding the four upserts into one
+    /// `unchecked_transaction` makes a failure write ZERO rows, so a retry is clean (no orphan
+    /// Mission). The four `mission::upsert_*` free fns each take `&Connection`, and `&tx` derefs to
+    /// it, so they participate in the shared txn (the SAME mechanism `transition_work_item_status`
+    /// uses with `upsert_work_item(&tx, …)`).
+    ///
+    /// CONCURRENCY: the WHOLE txn is wrapped in the crate's ONE bounded busy-retry idiom
+    /// ([`with_busy_retry`]) — the SAME wrapper the writable open / run-billing txn / retention
+    /// sweep use, never a second policy. These upserts are pure INSERT…ON CONFLICT UPDATE writes (no
+    /// read-then-write inside), so a re-run after a BUSY-rolled-back attempt is idempotent and
+    /// re-applies the identical rows. NO-DEGRADE: the retry fires ONLY on [`is_storage_busy`]; with
+    /// no contention the closure runs EXACTLY ONCE and the four committed rows are byte-identical to
+    /// the pre-fix sequence (same upsert contents, same conversation→mission→surface→work_item
+    /// order). Hub-only (Missions/WorkItems/conversations are Hub-only).
+    pub fn stage_intake_atomic(
+        &self,
+        conversation: &FridayConversation,
+        mission: &Mission,
+        surface_thread: Option<&SurfaceThread>,
+        work_item: &WorkItem,
+    ) -> Result<()> {
+        if self.profile != Profile::Hub {
+            return Err(StorageError::Unsupported(
+                "mission intake is Hub-only".into(),
+            ));
+        }
+        let conn = &self.conn;
+        with_busy_retry(|| {
+            let tx = conn.unchecked_transaction()?;
+            mission::upsert_conversation(&tx, conversation)?;
+            mission::upsert_mission(&tx, mission)?;
+            if let Some(surface) = surface_thread {
+                mission::upsert_surface_thread(&tx, surface)?;
+            }
+            mission::upsert_work_item(&tx, work_item)?;
+            tx.commit()?;
+            Ok(())
+        })
+    }
+
     pub fn get_friday_conversation(
         &self,
         friday_conversation_id: &str,

--- a/rust-core/crates/friday-storage/src/memory.rs
+++ b/rust-core/crates/friday-storage/src/memory.rs
@@ -158,32 +158,53 @@ pub fn get(conn: &Connection, memory_id: &str) -> Result<Option<MemoryRow>> {
 /// sets `confidence` on its own, so a confirmed-confidence/non-confirmed-state
 /// row is unrepresentable. A terminal item is refused (no re-write / no
 /// downgrade). Returns the resulting state.
+///
+/// CONCURRENCY (#H3, hardening audit): the read (`current_state`) + the `UPDATE`
+/// run on the long-lived Hub connection while the reaper/retention tick writes on a
+/// SEPARATE connection. Under WAL contention either statement can return
+/// `SQLITE_BUSY` (notably `SQLITE_BUSY_SNAPSHOT`, which `busy_timeout` does NOT
+/// auto-retry — only an app-level retry recovers it). So the WHOLE body is wrapped
+/// in the crate's ONE bounded busy-retry idiom ([`crate::with_busy_retry`]) — the
+/// SAME wrapper the writable open, the run-billing txn, and the retention sweep use,
+/// never a second policy. The retry re-runs the read THEN the `UPDATE`: this is the
+/// IDEMPOTENT order — on a BUSY the `UPDATE` did NOT apply (the row stays its prior
+/// pending Candidate), so the retry re-reads the SAME pre-decision state and
+/// re-derives the SAME terminal write; there is no double-apply and no
+/// terminal-refusal-on-retry (a committed prior attempt would have returned `Ok`,
+/// not BUSY). NO-DEGRADE: the retry fires ONLY on [`crate::is_storage_busy`]; with
+/// no contention the closure runs EXACTLY ONCE and the result is byte-identical to
+/// the pre-fix path. When called inside an already-open txn (e.g. via
+/// [`edit_candidate`]'s `reject`), the inner retry is harmless — a single idempotent
+/// UPDATE — and the enclosing txn still governs atomicity.
 pub fn decide(
     conn: &Connection,
     memory_id: &str,
     user_confirmed: bool,
     now: i64,
 ) -> Result<MemoryState> {
-    let cur = current_state(conn, memory_id)?
-        .ok_or_else(|| StorageError::Unsupported(format!("memory_item '{memory_id}' not found")))?;
-    if cur.is_terminal() {
-        return Err(StorageError::Unsupported(format!(
-            "memory_item '{memory_id}' is already terminal ({}); refusing to re-decide",
-            cur.as_str()
-        )));
-    }
-    let next = decide_candidate(cur, Some(user_confirmed));
-    let (confidence, confirmed_at) = match next {
-        MemoryState::Confirmed => (Confidence::Confirmed, Some(now)),
-        // Rejected / still-Candidate are not durable: confidence stays non-confirmed.
-        MemoryState::Rejected | MemoryState::Candidate => (Confidence::Candidate, None),
-    };
-    conn.execute(
-        "UPDATE memory_item SET state = ?1, confidence = ?2, confirmed_at = ?3
-         WHERE memory_id = ?4",
-        params![next.as_str(), confidence.as_str(), confirmed_at, memory_id],
-    )?;
-    Ok(next)
+    crate::with_busy_retry(|| {
+        let cur = current_state(conn, memory_id)?.ok_or_else(|| {
+            StorageError::Unsupported(format!("memory_item '{memory_id}' not found"))
+        })?;
+        if cur.is_terminal() {
+            return Err(StorageError::Unsupported(format!(
+                "memory_item '{memory_id}' is already terminal ({}); refusing to re-decide",
+                cur.as_str()
+            )));
+        }
+        let next = decide_candidate(cur, Some(user_confirmed));
+        let (confidence, confirmed_at) = match next {
+            MemoryState::Confirmed => (Confidence::Confirmed, Some(now)),
+            // Rejected / still-Candidate are not durable: confidence stays non-confirmed.
+            MemoryState::Rejected | MemoryState::Candidate => (Confidence::Candidate, None),
+        };
+        conn.execute(
+            "UPDATE memory_item SET state = ?1, confidence = ?2, confirmed_at = ?3
+             WHERE memory_id = ?4",
+            params![next.as_str(), confidence.as_str(), confirmed_at, memory_id],
+        )?;
+        Ok(next)
+    })
 }
 
 /// Confirm a candidate (explicit user yes). Durable iff it was a pending candidate.

--- a/rust-core/crates/friday-storage/src/mission.rs
+++ b/rust-core/crates/friday-storage/src/mission.rs
@@ -525,6 +525,11 @@ pub fn transition_mission_status(
             "mission_lifecycle done requires proof_ref so completion is not fake-ready",
         ));
     }
+    if next_status != MissionStatus::Merged && merged_into_mission_id.is_some() {
+        return Err(unsupported(
+            "mission_lifecycle merged_into_mission_id is only valid for merged status",
+        ));
+    }
     if next_status == MissionStatus::Merged {
         let Some(target_mission_id) = merged_into_mission_id else {
             return Err(unsupported(
@@ -540,94 +545,121 @@ pub fn transition_mission_status(
                 "mission_lifecycle cannot merge a Mission into itself",
             ));
         }
-        let target = get_mission(conn, target_mission_id)?.ok_or_else(|| {
+    }
+
+    // ATOMICITY + CONCURRENCY (#H1/#H3, hardening audit): this transition reads the mission (and,
+    // on a merge, the merge target), the conversation, then writes BOTH the mission AND the
+    // conversation. Pre-fix those two writes (`upsert_mission` + `upsert_conversation`) were SEPARATE
+    // auto-committed statements on the bare conn — so a failure (or a crash) AFTER the mission write
+    // but BEFORE the conversation write left the mission's new status persisted while the
+    // conversation's `active_mission_ids` membership lagged: a split-brain active-set. AND, because
+    // it touches two rows in sequence on the long-lived Hub connection while the reaper/retention
+    // tick writes on a SEPARATE connection, a WAL `SQLITE_BUSY` (notably `SQLITE_BUSY_SNAPSHOT`,
+    // which `busy_timeout` does NOT auto-retry) on the second write would crash the transition
+    // spuriously. Naively wrapping the OLD two-write shape in busy-retry would be UNSAFE: a retry
+    // would re-read the ALREADY-committed new status and `try_transition` would re-apply from the
+    // mutated state (illegal-hop error or double-apply). So both writes are now made ONE
+    // `unchecked_transaction` (all reads + both upserts + commit) FIRST — all-or-nothing, no
+    // split-brain — and only THEN wrapped in the crate's ONE bounded busy-retry idiom
+    // ([`crate::with_busy_retry`]). On a BUSY the txn has rolled back (NOTHING committed), so the
+    // retry re-reads the live pre-transition mission/conversation and re-applies cleanly. NO-DEGRADE:
+    // the success-path rows are byte-identical (same upsert contents, mission-then-conversation
+    // order preserved inside the txn); the failure path goes from partial-write to all-or-nothing.
+    crate::with_busy_retry(|| {
+        let tx = conn.unchecked_transaction()?;
+
+        // Merge-target validation reads the live target row INSIDE the txn so the active-like /
+        // ownership check sees a consistent snapshot with the writes below (and rolls back with them
+        // on any error). The scalar guards above already rejected the empty/self-merge cases.
+        if next_status == MissionStatus::Merged {
+            let target_mission_id = merged_into_mission_id.expect("checked above");
+            let target = get_mission(&tx, target_mission_id)?.ok_or_else(|| {
+                unsupported(format!(
+                    "mission_lifecycle merge target Mission '{target_mission_id}' not found"
+                ))
+            })?;
+            if target.friday_conversation_id != friday_conversation_id {
+                return Err(unsupported(format!(
+                    "mission_lifecycle merge target belongs to conversation '{}' not '{}'",
+                    target.friday_conversation_id, friday_conversation_id
+                )));
+            }
+            if !target.status.is_active_like() {
+                return Err(unsupported(format!(
+                    "mission_lifecycle merge target Mission '{target_mission_id}' is not active-like"
+                )));
+            }
+        }
+
+        let mut mission = get_mission(&tx, mission_id)?.ok_or_else(|| {
             unsupported(format!(
-                "mission_lifecycle merge target Mission '{target_mission_id}' not found"
+                "mission_lifecycle Mission '{mission_id}' not found"
             ))
         })?;
-        if target.friday_conversation_id != friday_conversation_id {
+        if mission.friday_conversation_id != friday_conversation_id {
             return Err(unsupported(format!(
-                "mission_lifecycle merge target belongs to conversation '{}' not '{}'",
-                target.friday_conversation_id, friday_conversation_id
+                "mission_lifecycle Mission belongs to conversation '{}' not '{}'",
+                mission.friday_conversation_id, friday_conversation_id
             )));
         }
-        if !target.status.is_active_like() {
-            return Err(unsupported(format!(
-                "mission_lifecycle merge target Mission '{target_mission_id}' is not active-like"
-            )));
-        }
-    } else if merged_into_mission_id.is_some() {
-        return Err(unsupported(
-            "mission_lifecycle merged_into_mission_id is only valid for merged status",
-        ));
-    }
 
-    let mut mission = get_mission(conn, mission_id)?.ok_or_else(|| {
-        unsupported(format!(
-            "mission_lifecycle Mission '{mission_id}' not found"
-        ))
-    })?;
-    if mission.friday_conversation_id != friday_conversation_id {
-        return Err(unsupported(format!(
-            "mission_lifecycle Mission belongs to conversation '{}' not '{}'",
-            mission.friday_conversation_id, friday_conversation_id
-        )));
-    }
-
-    let previous_status = mission.status;
-    mission.status = previous_status
-        .try_transition(next_status)
-        .map_err(|e| unsupported(e.to_string()))?;
-    mission.updated_at_ms = now_ms;
-    if let Some(proof_ref) = proof_ref {
-        let proof_ref = proof_ref.to_string();
-        if !mission.proof_refs.contains(&proof_ref) {
-            mission.proof_refs.push(proof_ref);
+        let previous_status = mission.status;
+        mission.status = previous_status
+            .try_transition(next_status)
+            .map_err(|e| unsupported(e.to_string()))?;
+        mission.updated_at_ms = now_ms;
+        if let Some(proof_ref) = proof_ref {
+            let proof_ref = proof_ref.to_string();
+            if !mission.proof_refs.contains(&proof_ref) {
+                mission.proof_refs.push(proof_ref);
+            }
         }
-    }
-    let mut lifecycle_entry = format!(
-        "lifecycle:{}:{}->{} by {}: {}",
-        mission.mission_id,
-        previous_status.as_str(),
-        mission.status.as_str(),
-        actor_ref,
-        reason
-    );
-    if let Some(target) = merged_into_mission_id {
-        lifecycle_entry.push_str(&format!("; merged_into:{target}"));
-        let inherited = format!("merged_into_mission_id:{target}");
-        if !mission.handoff_inheritance.contains(&inherited) {
-            mission.handoff_inheritance.push(inherited);
+        let mut lifecycle_entry = format!(
+            "lifecycle:{}:{}->{} by {}: {}",
+            mission.mission_id,
+            previous_status.as_str(),
+            mission.status.as_str(),
+            actor_ref,
+            reason
+        );
+        if let Some(target) = merged_into_mission_id {
+            lifecycle_entry.push_str(&format!("; merged_into:{target}"));
+            let inherited = format!("merged_into_mission_id:{target}");
+            if !mission.handoff_inheritance.contains(&inherited) {
+                mission.handoff_inheritance.push(inherited);
+            }
         }
-    }
-    mission.decision_path_summary =
-        append_lifecycle_summary(&mission.decision_path_summary, &lifecycle_entry);
-    upsert_mission(conn, &mission)?;
+        mission.decision_path_summary =
+            append_lifecycle_summary(&mission.decision_path_summary, &lifecycle_entry);
+        upsert_mission(&tx, &mission)?;
 
-    let mut conversation = get_conversation(conn, friday_conversation_id)?.ok_or_else(|| {
-        unsupported(format!(
-            "mission_lifecycle conversation '{friday_conversation_id}' not found"
-        ))
-    })?;
-    if mission.status.is_active_like() {
-        if !conversation
-            .active_mission_ids
-            .iter()
-            .any(|id| id == &mission.mission_id)
-        {
+        let mut conversation = get_conversation(&tx, friday_conversation_id)?.ok_or_else(|| {
+            unsupported(format!(
+                "mission_lifecycle conversation '{friday_conversation_id}' not found"
+            ))
+        })?;
+        if mission.status.is_active_like() {
+            if !conversation
+                .active_mission_ids
+                .iter()
+                .any(|id| id == &mission.mission_id)
+            {
+                conversation
+                    .active_mission_ids
+                    .push(mission.mission_id.clone());
+            }
+        } else {
             conversation
                 .active_mission_ids
-                .push(mission.mission_id.clone());
+                .retain(|id| id != &mission.mission_id);
         }
-    } else {
-        conversation
-            .active_mission_ids
-            .retain(|id| id != &mission.mission_id);
-    }
-    conversation.updated_at_ms = now_ms;
-    upsert_conversation(conn, &conversation)?;
+        conversation.updated_at_ms = now_ms;
+        upsert_conversation(&tx, &conversation)?;
 
-    Ok((mission, previous_status, conversation.active_mission_ids))
+        tx.commit()?;
+
+        Ok((mission, previous_status, conversation.active_mission_ids))
+    })
 }
 
 /// Transition a WorkItem's lifecycle status at the persistence boundary — the
@@ -732,61 +764,78 @@ fn transition_work_item_status_inner(
         (_, None) => {}
     }
 
-    let mut item = get_work_item(conn, work_item_id)?.ok_or_else(|| {
-        unsupported(format!(
-            "work_item_lifecycle WorkItem '{work_item_id}' not found"
-        ))
-    })?;
+    // CONCURRENCY (#H3, hardening audit): the read (`get_work_item`) + the audit/upsert txn run
+    // on the long-lived Hub connection while the reaper/retention tick writes on a SEPARATE
+    // connection. Under WAL contention the read or the deferred write txn can return `SQLITE_BUSY`
+    // (notably `SQLITE_BUSY_SNAPSHOT`, which `busy_timeout` does NOT auto-retry — only an app-level
+    // retry recovers it); un-retried the caller's `?` would CRASH the transition spuriously. So the
+    // WHOLE read+txn body is wrapped in the crate's ONE bounded busy-retry idiom
+    // ([`crate::with_busy_retry`]) — the SAME wrapper the writable open / run-billing txn /
+    // retention sweep use, never a second policy. The retry re-runs the READ then the txn: this is
+    // REQUIRED for audit-chain atomicity (`append_audit` reads the prev chain hash THEN inserts, so
+    // a stale-prev-hash retry would forge a broken chain) AND for transition correctness (`item` is
+    // re-read from the live row, so `try_transition` is re-applied from the persisted state, never a
+    // stale in-memory copy). On a BUSY the failed txn has ALREADY rolled back (NOTHING committed),
+    // so each retry re-reads the live row and re-runs the deterministic `now_ms`-keyed audit id +
+    // upsert cleanly. NO-DEGRADE: the retry fires ONLY on [`crate::is_storage_busy`]; with no
+    // contention the closure runs EXACTLY ONCE and the result is byte-identical to the pre-fix path.
+    crate::with_busy_retry(|| {
+        let mut item = get_work_item(conn, work_item_id)?.ok_or_else(|| {
+            unsupported(format!(
+                "work_item_lifecycle WorkItem '{work_item_id}' not found"
+            ))
+        })?;
 
-    let previous_status = item.status;
-    item.status = previous_status
-        .try_transition(next_status)
-        .map_err(|e| unsupported(e.to_string()))?;
-    item.updated_at_ms = now_ms;
-    if let Some(receipt) = proof_receipt {
-        let receipt = receipt.to_string();
-        if !item.proof_receipts.contains(&receipt) {
-            item.proof_receipts.push(receipt);
+        let previous_status = item.status;
+        item.status = previous_status
+            .try_transition(next_status)
+            .map_err(|e| unsupported(e.to_string()))?;
+        item.updated_at_ms = now_ms;
+        if let Some(receipt) = proof_receipt {
+            let receipt = receipt.to_string();
+            if !item.proof_receipts.contains(&receipt) {
+                item.proof_receipts.push(receipt);
+            }
         }
-    }
 
-    // One transaction: the lifecycle audit row (the hash-chain read + insert) and the
-    // upsert commit together, so a recorded transition always has a persisted state.
-    // The audit row IS the WorkItem's lifecycle entry — it carries actor, the
-    // from->to hop, and the reason (a WorkItem has no decision_path_summary column).
-    let tx = conn.unchecked_transaction()?;
-    let audit_id = format!("workitem_lifecycle:{work_item_id}:{now_ms}");
-    let action = format!(
-        "work_item.lifecycle:{}->{}:{}",
-        previous_status.as_str(),
-        item.status.as_str(),
-        reason
-    );
-    crate::audit::append_audit(
-        &tx,
-        &audit_id,
-        actor_ref,
-        &action,
-        Some(work_item_id),
-        now_ms,
-    )?;
-    upsert_work_item(&tx, &item)?;
-    // (#24b degrade-3) ATOMIC executing-clear: when the caller routes a binding rest-state hop
-    // through `transition_work_item_status_clearing_executing`, clear the durable `executing`
-    // marker in the SAME transaction as the status write. `upsert_work_item` does NOT touch the
-    // execution columns (they are managed only by `set_work_item_executing`), so this targeted
-    // `UPDATE` is required to land `executing = 0` atomically with the status. `last_heartbeat_ms`
-    // is left as-is — PASS-2 only acts on `executing == 1` rows, so a cleared row's timestamp is
-    // never consulted by the reconcile.
-    if clear_executing {
-        tx.execute(
-            "UPDATE work_item SET executing = 0 WHERE work_item_id = ?1",
-            params![work_item_id],
+        // One transaction: the lifecycle audit row (the hash-chain read + insert) and the
+        // upsert commit together, so a recorded transition always has a persisted state.
+        // The audit row IS the WorkItem's lifecycle entry — it carries actor, the
+        // from->to hop, and the reason (a WorkItem has no decision_path_summary column).
+        let tx = conn.unchecked_transaction()?;
+        let audit_id = format!("workitem_lifecycle:{work_item_id}:{now_ms}");
+        let action = format!(
+            "work_item.lifecycle:{}->{}:{}",
+            previous_status.as_str(),
+            item.status.as_str(),
+            reason
+        );
+        crate::audit::append_audit(
+            &tx,
+            &audit_id,
+            actor_ref,
+            &action,
+            Some(work_item_id),
+            now_ms,
         )?;
-    }
-    tx.commit()?;
+        upsert_work_item(&tx, &item)?;
+        // (#24b degrade-3) ATOMIC executing-clear: when the caller routes a binding rest-state hop
+        // through `transition_work_item_status_clearing_executing`, clear the durable `executing`
+        // marker in the SAME transaction as the status write. `upsert_work_item` does NOT touch the
+        // execution columns (they are managed only by `set_work_item_executing`), so this targeted
+        // `UPDATE` is required to land `executing = 0` atomically with the status. `last_heartbeat_ms`
+        // is left as-is — PASS-2 only acts on `executing == 1` rows, so a cleared row's timestamp is
+        // never consulted by the reconcile.
+        if clear_executing {
+            tx.execute(
+                "UPDATE work_item SET executing = 0 WHERE work_item_id = ?1",
+                params![work_item_id],
+            )?;
+        }
+        tx.commit()?;
 
-    Ok((item, previous_status))
+        Ok((item, previous_status))
+    })
 }
 
 pub fn list_missions_for_conversation(


### PR DESCRIPTION
Adversarial hardening sweep of the **live-deployed spine**. The threat: the moment real (non-self-probe) traffic overlaps the reaper/retention tick (120s, on its own WAL connection). **No-degrade — only crash/contention resilience added; success paths are byte-identical; no gate/auth change.**

## #H1 — atomic mission intake (the involved one)
`preflight_and_stage_work_item` wrote FOUR independent auto-committed upserts (conversation, mission, surface, work_item) with no shared txn. A failure (or crash) **after** the Mission upsert but **before** the WorkItem upsert stranded a permanently-Active Mission with NO WorkItem — and the conversation+intent duplicate guard (`find_duplicate_mission`) then matched the orphan and **blocked a clean retry** (binding the surface to the orphan).

**Approach taken: atomic-txn (the real fix, not the minimal alternative).** Feasibility finding: the `mission::upsert_*` **free functions** each take `&Connection`, and `&tx` derefs to `&Connection`, so they are already transaction-aware (`transition_work_item_status_inner` proves this with `upsert_work_item(&tx, …)`). So NO invasive refactor of the shared `Db` upsert API was needed. Added `Db::stage_intake_atomic` (Hub-profile-checked) that opens ONE `unchecked_transaction`, calls the four upserts on `&tx`, commits, all inside `with_busy_retry` — mirroring `record_run_model_call`. A failure now writes ZERO rows; a retry is clean.

## #H3 — busy-retry on the state-machine producers
`SQLITE_BUSY_SNAPSHOT` is NOT auto-retried by `busy_timeout`; only an app-level retry recovers it. **The prompt's premise that all three were "already one atomic txn" held for only ONE of three:**
- `transition_work_item_status_inner` (mission.rs) — **already one atomic txn** (`unchecked_transaction`). Wrapped as-is; the pre-txn `get_work_item` read moved INSIDE the retry closure so a rolled-back attempt re-reads cleanly (mirrors billing).
- `transition_mission_status` (mission.rs) — **was NOT atomic**: two separate auto-commit writes (`upsert_mission` then `upsert_conversation`). Naively wrapping the old shape in busy-retry would re-read the already-committed new status and double-apply `try_transition`. So **atomicized first** (one `unchecked_transaction`: all reads + both upserts + commit), THEN wrapped. Sole caller (`hub_server.rs:734` via `db.`) holds no enclosing txn → opening one here is safe.
- `memory::decide` (memory.rs) — **was read + UPDATE, no txn**. Wrapped its body in `with_busy_retry` (idempotent: a BUSY means the UPDATE did not apply → retry re-reads the same pending Candidate and re-applies). This **covers the hub_server.rs memory-decision sequence (982/1026/1047)** at the producer: the only WRITE is `decide` (1026); `with_busy_retry` is `pub(crate)` in friday-storage so the friday-hub call site cannot call it directly. The two reads (982 get / 1047 recall) keep their existing fail-soft posture.

## #H4 — already correct (no code change)
The stale comment described in the task ("`open_hub` deliberately NOT `open_hub_concurrent` — flips the prod DB to WAL") **no longer exists anywhere in the tree**. Both the reaper (`hub_agent_run_server.rs:835`) and scheduler (`:958`) docs already state the truth: `Db::open_hub` IS `open_hub_concurrent` (WAL + busy_timeout). A prior PR corrected it. Verified-only, no change.

## Tests
- New `mission_preflight` test `mid_sequence_intake_failure_leaves_zero_rows_no_orphan_mission`: an injected mid-sequence failure (empty `work_item_id` trips `require_non_empty` in the LAST upsert) leaves ZERO rows (no orphan Mission/conversation/surface), and a clean retry then SUCCEEDS (proving no orphan blocks it).
- Existing `mission_spine` / `work_item_lifecycle` / `memory_persist` / `memory_fts5` tests confirm the success paths are byte-identical.

## Verification
- `cargo build --release -p friday-hub`: OK
- `cargo test -p friday-storage`: all green (30 binaries) · `cargo test -p friday-hub`: all green (incl. new test)
- `cargo clippy -p friday-storage --all-targets` and `-p friday-hub --all-targets`: no warnings/errors
- `cargo fmt --check`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)