### PR TITLE
feat(desktop): spine-write client — MissionIntake + MemoryDecision over sealed-WS :48750 (Lane-D entry-A organic driver)

### DIFF
--- a/apps/macos/FridayHubConsole/Sources/FridayHubConsole/FridayHubConsoleApp.swift
+++ b/apps/macos/FridayHubConsole/Sources/FridayHubConsole/FridayHubConsoleApp.swift
@@ -1,4 +1,5 @@
 import FridayHubConsoleCore
+import FridayRustClient
 import SwiftUI
 
 /// Friday Hub Console — the v1 desktop UI shell (D-PR1).
@@ -46,20 +47,23 @@ struct FridayHubConsoleApp: App {
 
   var body: some Scene {
     WindowGroup("Friday Hub Console") {
-      HubConsoleShell(client: Self.readClient)
+      HubConsoleShell(client: Self.readClient, writeClient: Self.writeClient)
     }
     .windowStyle(.titleBar)
     .defaultSize(width: 1180, height: 720)
   }
 
-  /// The read client the shell uses. DEFAULT = LIVE; MOCK only when explicitly opted in.
-  static var readClient: FridayRustReadClient {
+  /// `true` when the explicit design/demo MOCK opt-in is set. A normal run is `false` (LIVE).
+  private static var useMock: Bool {
     let args = ProcessInfo.processInfo.arguments
     let env = ProcessInfo.processInfo.environment
+    return args.contains("--use-mock-read-client") || env["FRIDAY_CONSOLE_MOCK"] == "1"
+  }
+
+  /// The read client the shell uses. DEFAULT = LIVE; MOCK only when explicitly opted in.
+  static var readClient: FridayRustReadClient {
     // MOCK is an explicit design/demo opt-in only (re-adopting #682's `--use-mock-read-client`
     // flag, mirrored by an env for arg/env symmetry). A normal run NEVER takes this branch.
-    let useMock =
-      args.contains("--use-mock-read-client") || env["FRIDAY_CONSOLE_MOCK"] == "1"
     if useMock {
       return MockReadClient(behavior: .loaded)
     }
@@ -71,6 +75,23 @@ struct FridayHubConsoleApp: App {
       return try RealReadClientFactory.makeLive()
     } catch {
       return RealReadClientFactory.makeHonestlyUnavailable(reason: "\(error)")
+    }
+  }
+
+  /// The mission-spine WRITE client the shell uses (Lane-D entry-point-A). Mirrors `readClient`:
+  /// DEFAULT = LIVE (the enrolled master-derived peer targeting the agent-run WRITE server on
+  /// 48750 as `admin-001`), honest-unavailable on master-key failure (NEVER a fabricated confirm).
+  ///
+  /// In MOCK/design mode there is NO write seam — `nil` — so the compose/confirm controls render
+  /// honest-unavailable rather than pretending to write against mock read data. The actual connect
+  /// happens only when the operator submits an intake / decides a memory candidate (non-blocking
+  /// at launch).
+  static var writeClient: FridayMissionSpineWriteClient? {
+    if useMock { return nil }
+    do {
+      return try RealWriteClientFactory.makeLiveWrite()
+    } catch {
+      return RealWriteClientFactory.makeHonestlyUnavailableWrite(reason: "\(error)")
     }
   }
 }

--- a/apps/macos/FridayHubConsole/Sources/FridayHubConsole/HubConsoleShell.swift
+++ b/apps/macos/FridayHubConsole/Sources/FridayHubConsole/HubConsoleShell.swift
@@ -1,4 +1,5 @@
 import FridayHubConsoleCore
+import FridayRustClient
 import SwiftUI
 
 /// The three-pane Hub Console shell (locked: layout = threePane):
@@ -9,8 +10,9 @@ struct HubConsoleShell: View {
   @State private var destination: HubDestination = .operations
   @StateObject private var operationsVM: OperationsOverviewViewModel
 
-  init(client: FridayRustReadClient) {
-    _operationsVM = StateObject(wrappedValue: OperationsOverviewViewModel(client: client))
+  init(client: FridayRustReadClient, writeClient: FridayMissionSpineWriteClient? = nil) {
+    _operationsVM = StateObject(
+      wrappedValue: OperationsOverviewViewModel(client: client, writeClient: writeClient))
   }
 
   var body: some View {

--- a/apps/macos/FridayHubConsole/Sources/FridayHubConsole/OperationsOverviewScreen.swift
+++ b/apps/macos/FridayHubConsole/Sources/FridayHubConsole/OperationsOverviewScreen.swift
@@ -10,6 +10,8 @@ import SwiftUI
 ///  - NO mutating action, NO provider-admin exec, NO NO-GO row made executable.
 struct OperationsOverviewScreen: View {
   @ObservedObject var viewModel: OperationsOverviewViewModel
+  /// The operator-typed Mission-intake draft (the spine-WRITE compose field).
+  @State private var intentDraft: String = ""
 
   var body: some View {
     VStack(alignment: .leading, spacing: 0) {
@@ -111,7 +113,43 @@ struct OperationsOverviewScreen: View {
         }
         RefPill(label: "mission_id", ref: snapshot.missionId)
         RefPill(label: "friday_conversation_id", ref: snapshot.fridayConversationId)
+
+        Divider().opacity(0.3).padding(.vertical, 2)
+        missionIntakeCompose
       }
+    }
+  }
+
+  /// The spine-WRITE compose affordance — an operator types an intent and submits it as a
+  /// `MissionIntakeRequest` over the sealed WRITE seam (:48750). The result renders HONESTLY below:
+  /// pending while sent, the refs on a confirm, the questions on needs-clarification, and the truth
+  /// on an error/blocked. The button disables while in flight or on an empty draft.
+  @ViewBuilder
+  private var missionIntakeCompose: some View {
+    VStack(alignment: .leading, spacing: 6) {
+      Text("Submit Mission Intent")
+        .font(.system(size: 11, weight: .semibold))
+        .foregroundStyle(HubTheme.textSecondary)
+      HStack(spacing: 8) {
+        TextField("Describe what Friday should coordinate…", text: $intentDraft)
+          .textFieldStyle(.roundedBorder)
+          .font(.system(size: 12))
+          .disabled(viewModel.intakeState.isSent)
+        Button {
+          Task { await viewModel.submitIntake(intent: intentDraft) }
+        } label: {
+          Label("Submit Intent", systemImage: "paperplane")
+        }
+        .buttonStyle(.borderedProminent)
+        .tint(HubTheme.cyan)
+        .disabled(
+          viewModel.intakeState.isSent
+            || intentDraft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+      }
+      WriteActionStateView(state: viewModel.intakeState, pendingText: "Submitting intake…")
+      Text("Births a Mission + WorkItem(Draft) through the Rust spine — no model call.")
+        .font(.system(size: 10))
+        .foregroundStyle(HubTheme.textSecondary)
     }
   }
 
@@ -222,17 +260,28 @@ struct OperationsOverviewScreen: View {
       VStack(alignment: .leading, spacing: HubTheme.rowSpacing) {
         cardTitle("Memory Candidates")
         ForEach(snapshot.memoryCandidates) { candidate in
-          VStack(alignment: .leading, spacing: 4) {
-            HStack {
-              Text(candidate.preview)
-                .font(.system(size: 12))
-                .foregroundStyle(HubTheme.textPrimary)
-              Spacer()
-              StatusChip(text: "review only", bg: HubTheme.chipNeutralBG, fg: HubTheme.chipNeutralFG)
-            }
-            RefPill(label: "evidenceRef", ref: candidate.evidenceRef)
-          }
+          MemoryCandidateRow(
+            candidate: candidate,
+            state: viewModel.memoryDecisionStates[candidate.id] ?? .ready,
+            onConfirm: {
+              Task {
+                await viewModel.decideMemory(
+                  candidateId: candidate.id, memoryId: candidate.id, confirm: true)
+              }
+            },
+            onReject: {
+              Task {
+                await viewModel.decideMemory(
+                  candidateId: candidate.id, memoryId: candidate.id, confirm: false)
+              }
+            })
         }
+        Text(
+          "Confirm/reject drives the owner decision through the Rust spine. NOTE: the read "
+            + "projection surfaces a synthetic candidate id today — a confirm returns "
+            + "\"blocked\" until the durable memory_id is projected (rendered honestly).")
+          .font(.system(size: 10))
+          .foregroundStyle(HubTheme.textSecondary)
       }
     }
   }
@@ -299,6 +348,94 @@ struct StatusBanner: View {
         .fill(HubTheme.coralSoft)
     )
   }
+}
+
+// MARK: - Spine-WRITE controls (honest pending / confirmed / error rendering)
+
+/// Renders a `WriteActionState` AS truth — pending spinner while sent, a calm-green confirm chip +
+/// refs-only summary on success (plus any clarification questions), a coral error chip + reason on
+/// failure (incl. a server `blocked`). Never upgrades an error/blocked to a ready look.
+struct WriteActionStateView: View {
+  let state: WriteActionState
+  let pendingText: String
+
+  var body: some View {
+    switch state {
+    case .ready:
+      EmptyView()
+    case .sent:
+      HStack(spacing: 8) {
+        ProgressView().scaleEffect(0.6)
+        Text(pendingText)
+          .font(.system(size: 11))
+          .foregroundStyle(HubTheme.textSecondary)
+      }
+    case let .confirmed(summary, clarificationQuestions):
+      VStack(alignment: .leading, spacing: 4) {
+        HStack(spacing: 8) {
+          StatusChip(
+            text: clarificationQuestions.isEmpty ? "submitted" : "needs clarification",
+            bg: clarificationQuestions.isEmpty ? HubTheme.chipDoneBG : HubTheme.chipNeutralBG,
+            fg: clarificationQuestions.isEmpty ? HubTheme.chipDoneFG : HubTheme.chipNeutralFG)
+          Text(summary)
+            .font(.system(size: 11))
+            .foregroundStyle(HubTheme.textSecondary)
+            .textSelection(.enabled)
+        }
+        ForEach(clarificationQuestions, id: \.self) { question in
+          Text("• \(question)")
+            .font(.system(size: 11))
+            .foregroundStyle(HubTheme.textPrimary)
+        }
+      }
+    case let .error(reason):
+      HStack(spacing: 8) {
+        StatusChip(text: "unavailable", bg: HubTheme.chipWarnBG, fg: HubTheme.chipWarnFG)
+        Text(reason)
+          .font(.system(size: 11))
+          .foregroundStyle(HubTheme.textSecondary)
+          .textSelection(.enabled)
+      }
+    }
+  }
+}
+
+/// One memory-candidate row with the spine-WRITE confirm/reject control. The buttons drive the
+/// owner decision over the sealed WRITE seam; the per-candidate state renders AS truth (pending /
+/// confirmed / error|blocked) and the buttons disable while in flight and after a terminal outcome.
+struct MemoryCandidateRow: View {
+  let candidate: MissionWorkbenchMemoryCandidate
+  let state: WriteActionState
+  let onConfirm: () -> Void
+  let onReject: () -> Void
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 6) {
+      HStack {
+        Text(candidate.preview)
+          .font(.system(size: 12))
+          .foregroundStyle(HubTheme.textPrimary)
+        Spacer()
+        HStack(spacing: 6) {
+          Button("Confirm", action: onConfirm)
+            .buttonStyle(.borderedProminent)
+            .tint(HubTheme.cyan)
+            .controlSize(.small)
+            .disabled(controlsDisabled)
+          Button("Reject", action: onReject)
+            .buttonStyle(.bordered)
+            .controlSize(.small)
+            .disabled(controlsDisabled)
+        }
+      }
+      RefPill(label: "evidenceRef", ref: candidate.evidenceRef)
+      WriteActionStateView(state: state, pendingText: "Applying decision…")
+    }
+    .padding(.vertical, 2)
+  }
+
+  /// Disabled while in flight or after a terminal outcome (a decision is applied once).
+  private var controlsDisabled: Bool { state.isSent || state.isTerminal }
 }
 
 // MARK: - Rows

--- a/apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/OperationsOverviewViewModel.swift
+++ b/apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/OperationsOverviewViewModel.swift
@@ -32,22 +32,80 @@ public enum WorkbenchLoadState: Sendable, Equatable {
   }
 }
 
+/// The state of a single spine-WRITE action (mission intake / memory decision).
+///
+/// Mirrors `WorkbenchLoadState`'s honest vocabulary: a `.sent` action shows pending, a terminal
+/// `.confirmed` carries a coarse refs-only summary, and any failure (transport / typed Error / a
+/// server `status:"blocked"`) renders AS `.error` — never upgraded to a fake-confirmed look.
+public enum WriteActionState: Sendable, Equatable {
+  /// No action attempted (or reset) — the control is enabled.
+  case ready
+  /// The request is in flight (handshake + sealed send + awaiting the refs-only receipt).
+  case sent
+  /// A terminal SUCCESS receipt. `summary` is a coarse refs-only line (status + ids + recallable);
+  /// `clarificationQuestions` is non-empty ONLY for a `needs_clarification` intake.
+  case confirmed(summary: String, clarificationQuestions: [String] = [])
+  /// A terminal FAILURE rendered AS truth — a transport/honest-unavailable error, a typed server
+  /// Error, OR a server `status:"blocked"` receipt (e.g. the synthetic-candidate-id block). Never a
+  /// fabricated success.
+  case error(reason: String)
+
+  public var isSent: Bool {
+    if case .sent = self { return true }
+    return false
+  }
+
+  /// `true` once a terminal outcome has been reached (success or error) — the control disables.
+  public var isTerminal: Bool {
+    switch self {
+    case .confirmed, .error: return true
+    case .ready, .sent: return false
+    }
+  }
+}
+
 /// View model for the Operations Overview screen.
 ///
-/// READ-ONLY by construction. The only actions it exposes are:
-///  - `refresh()`         — re-fetch the projection (RefreshStatus),
-///  - `select(_:)`        — focus a row in the proof inspector (OpenEvidence-class nav).
-/// There is no mutate / dispatch / approve / provider-admin method, and none can
-/// be added without violating the D-PR1 truth contract.
+/// READ-FIRST: the read projection (`refresh()` + `select(_:)`) stays a pure read — it NEVER writes.
+/// The spine-WRITE surface is an ADDITIVE, separately-injected collaborator (`writeClient`), used
+/// ONLY by the two explicit organic-loop drivers below; it is never folded into `refresh()`:
+///  - `refresh()`              — re-fetch the projection (RefreshStatus),
+///  - `select(_:)`             — focus a row in the proof inspector (OpenEvidence-class nav),
+///  - `submitIntake(intent:)`  — drive ONE operator-typed Mission intake over the sealed WRITE seam,
+///  - `decideMemory(...)`      — drive ONE owner confirm/reject of a memory candidate.
+/// The write drivers are gated: with no `writeClient` (or an honest-unavailable one) they render the
+/// truth, never a fabricated confirm. No provider-admin / arbitrary-mutation method is exposed.
 @MainActor
 public final class OperationsOverviewViewModel: ObservableObject {
   @Published public private(set) var state: WorkbenchLoadState = .idle
   @Published public var selection: InspectorSelection = .none
 
-  private let client: FridayRustReadClient
+  /// The mission-intake compose action's honest state.
+  @Published public private(set) var intakeState: WriteActionState = .ready
+  /// Per-candidate memory-decision action state, keyed by the candidate's display id.
+  @Published public private(set) var memoryDecisionStates: [String: WriteActionState] = [:]
 
-  public init(client: FridayRustReadClient) {
+  private let client: FridayRustReadClient
+  /// The spine-WRITE collaborator. `nil` ⇒ the write seam is not configured (the drivers render
+  /// honest-unavailable). Separate from `client` so the read contract stays a pure read.
+  private let writeClient: FridayMissionSpineWriteClient?
+  /// The owner principal the WRITE body self-supplies — MUST equal the server's `--owner`
+  /// (`admin-001`); the server fail-closes a mismatch (FIX-Q3b). Wired from config, not UI input.
+  private let writeOwnerPrincipal: String
+  /// A fresh-id factory for the client-supplied mission/work-item ids (the server births rows from
+  /// them). Injectable for deterministic tests.
+  private let newId: @Sendable () -> String
+
+  public init(
+    client: FridayRustReadClient,
+    writeClient: FridayMissionSpineWriteClient? = nil,
+    writeOwnerPrincipal: String = liveReadProjectionOwnerPrincipal,
+    newId: @escaping @Sendable () -> String = { UUID().uuidString }
+  ) {
     self.client = client
+    self.writeClient = writeClient
+    self.writeOwnerPrincipal = writeOwnerPrincipal
+    self.newId = newId
   }
 
   /// Re-fetch the Workbench projection. The only mutating-looking action — and it
@@ -72,6 +130,141 @@ public final class OperationsOverviewViewModel: ObservableObject {
   /// Focus a row in the proof inspector (read-only navigation).
   public func select(_ selection: InspectorSelection) {
     self.selection = selection
+  }
+
+  // MARK: - Spine-WRITE drivers (Lane-D entry-point-A organic loop)
+
+  /// Submit ONE operator-typed Mission intake over the sealed WRITE seam. Births a Mission +
+  /// WorkItem(Draft) server-side (NO model call); renders the refs-only receipt honestly:
+  ///  - `ready`               ⇒ `.confirmed` (status + mission/work-item ids),
+  ///  - `needs_clarification` ⇒ `.confirmed` carrying the questions (rendered as a clarification ask),
+  ///  - `blocked`             ⇒ `.error` (the blockers),
+  ///  - a transport/honest-unavailable throw ⇒ `.error` (the truth).
+  /// On any SUCCESS path it then `await refresh()`s so the new Mission appears in the read projection.
+  public func submitIntake(intent: String) async {
+    let trimmed = intent.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty else {
+      intakeState = .error(reason: "Enter an intent before submitting.")
+      return
+    }
+    guard let writeClient else {
+      intakeState = .error(reason: "Write seam not configured — cannot submit an intake.")
+      return
+    }
+    intakeState = .sent
+    let request = Self.buildIntakeRequest(
+      intent: trimmed, owner: writeOwnerPrincipal, idFactory: newId)
+    do {
+      let result = try await writeClient.submitMissionIntake(request)
+      switch result.status {
+      case "blocked":
+        let why = result.blockers.isEmpty ? "blocked" : result.blockers.joined(separator: ", ")
+        intakeState = .error(reason: "Intake blocked — \(why)")
+      case "needs_clarification":
+        intakeState = .confirmed(
+          summary: "Needs clarification — no rows written yet (mission \(result.missionId))",
+          clarificationQuestions: result.clarificationQuestions)
+        await refresh()
+      default:
+        // ready / created_or_ready
+        var summary = "Mission intake \(result.status) · mission_id=\(result.missionId)"
+        if let workItemId = result.workItemId { summary += " · work_item_id=\(workItemId)" }
+        intakeState = .confirmed(summary: summary, clarificationQuestions: result.clarificationQuestions)
+        await refresh()
+      }
+    } catch {
+      intakeState = .error(reason: Self.writeReason(for: error))
+    }
+  }
+
+  /// Submit ONE owner confirm/reject for a memory candidate over the sealed WRITE seam, keyed by the
+  /// candidate's display id. `memoryId` is what the server decides on.
+  ///
+  /// HONEST-STATE NOTE (Layer-D prerequisite): the read projection currently surfaces a SYNTHETIC
+  /// candidate id, not the durable `memory_item` row id, so a confirm against it returns
+  /// `status:"blocked"` (`unknown_candidate`) — which is rendered AS `.error` (never a fake confirm).
+  /// A real confirm closes only once the read projection surfaces the real memory_id (a cross-team
+  /// Rust change, out of scope here). Either way the control is wired end-to-end and honest.
+  public func decideMemory(candidateId: String, memoryId: String, confirm: Bool) async {
+    guard let writeClient else {
+      memoryDecisionStates[candidateId] = .error(reason: "Write seam not configured.")
+      return
+    }
+    memoryDecisionStates[candidateId] = .sent
+    let request = MemoryDecisionRequestWire(
+      memoryId: memoryId, ownerPrincipal: writeOwnerPrincipal,
+      decision: confirm ? "confirm" : "reject")
+    do {
+      let result = try await writeClient.submitMemoryDecision(request)
+      switch result.status {
+      case "confirmed", "rejected":
+        memoryDecisionStates[candidateId] = .confirmed(
+          summary: "\(result.status) · state=\(result.state) · recallable=\(result.recallable)")
+        await refresh()
+      default:  // "blocked"
+        let why = result.blocker ?? "blocked"
+        memoryDecisionStates[candidateId] = .error(reason: "Decision blocked — \(why)")
+      }
+    } catch {
+      memoryDecisionStates[candidateId] = .error(reason: Self.writeReason(for: error))
+    }
+  }
+
+  /// Build a desktop Mission-intake request from one operator intent. The mission/work-item ids are
+  /// CLIENT-supplied (the server births rows from them); `surface_kind`/`visibility_policy`/`lane`
+  /// are server-accepted tokens; `delivery_route` is a non-empty desktop route hint. `owner` MUST
+  /// equal the server `--owner` (FIX-Q3b). The title is a short prefix of the intent.
+  static func buildIntakeRequest(
+    intent: String, owner: String, idFactory: () -> String
+  ) -> MissionIntakeRequestWire {
+    let title = String(intent.prefix(72))
+    let id = idFactory()
+    return MissionIntakeRequestWire(
+      fridayConversationId: "fconv_desktop_\(id)",
+      ownerPrincipal: owner,
+      surfaceThreadId: "surface-desktop-\(id)",
+      surfaceKind: "desktop",
+      deliveryRoute: "desktop://hub-console/operations/\(id)",
+      visibilityPolicy: "compact",
+      missionId: "mission-desktop-\(id)",
+      workItemId: "work-desktop-\(id)",
+      title: title,
+      intent: intent,
+      lane: "deepseek")
+  }
+
+  /// Map a write-client error to an honest unavailable reason (mirrors `reason(for:)`'s tone).
+  static func writeReason(for error: Error) -> String {
+    if let writeError = error as? FridayWriteClientError {
+      switch writeError {
+      case let .transport(detail):
+        return "Hub offline — write seam unavailable (\(detail))"
+      case .badServerPubkey:
+        return "Write seam unavailable — invalid server identity"
+      case .badSessionNonce:
+        return "Write seam unavailable — invalid session handshake"
+      case let .serverError(code, message):
+        return "Write rejected — server error \(code): \(message)"
+      case let .unexpectedResponse(kind):
+        return "Write seam unavailable — unexpected response (\(kind))"
+      case let .missingRef(detail):
+        return "Write seam unavailable — \(detail)"
+      case .runControlDisabled:
+        return "Write seam unavailable — run control disabled"
+      case .emptySignedBlob:
+        return "Write seam unavailable — empty signed blob"
+      }
+    }
+    // The LoopbackSealedWSTransport throws the package READ error type from its frame I/O.
+    if let readError = error as? FridayReadClientError {
+      switch readError {
+      case let .transport(detail):
+        return "Hub offline — write seam unavailable (\(detail))"
+      default:
+        return "Write seam unavailable — \(readError)"
+      }
+    }
+    return "Write seam unavailable — \(error)"
   }
 
   private static func reason(for error: Error) -> String {

--- a/apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/RealWriteClientFactory.swift
+++ b/apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/RealWriteClientFactory.swift
@@ -1,0 +1,118 @@
+import Foundation
+import FridayRustClient
+
+// MARK: - Real mission-spine WRITE-client factory (Lane-D entry-point-A organic driver)
+//
+// Builds the REAL `SealedWSWriteClient` (the package's sealed-WS write client) configured for the
+// agent-run WRITE server's LOOPBACK host:port (127.0.0.1:48750 — DISTINCT from the read seam on
+// 48751), reusing the SAME concrete `NWConnection`-backed `LoopbackSealedWSTransport` the read
+// client uses (it conforms to `SealedWSTransport` and is port-parameterized via its config). This
+// is the "the desktop actually WRITES the live Rust spine" seam.
+//
+// SINGLE-PEER IDENTITY (the load-bearing fact): the write client derives its keypair the SAME way
+// the read client does — `MasterKeyPeer.deriveKeypair()` — so its public key is the SAME
+// master-derived peer ALREADY enrolled on the WRITE allowlist
+// (`friday:execrun:ws:s-f:peer-pubkey-allowlist:v1`) by `hub_agent_run_enroll`. The desktop shares
+// the live courier's enrolled identity — NO enrollment, NO eviction, single-peer satisfied
+// automatically. We do NOT mint an ephemeral keypair for the live path (its pubkey is NOT enrolled
+// → handshake refused) and we do NOT add a 2nd peer (would trip `enforce_single_peer`).
+//
+// NO auth_proof: the mission-spine arms (`submitMissionIntake`/`submitMemoryDecision`) authenticate
+// by the SEALED SESSION alone (an allowlisted peer holding the session key). The server binds the
+// write to the Rust-derived AUTHENTICATED owner `--owner admin-001` (FIX-Q3b).
+//
+// HONEST-UNAVAILABLE: against a DARK / un-flipped server (nothing listening, or the peer not
+// enrolled, or the host master key absent) the connect / preamble / handshake fails and surfaces as
+// a transport error → the view model's honest "unavailable" — never fake-confirmed.
+
+/// Configuration for the real write client's connection to the agent-run WRITE server.
+public struct AgentRunWriteServerConfig: Sendable, Equatable {
+  /// Loopback host the WRITE server listens on (default `127.0.0.1`).
+  public let host: String
+  /// TCP port the WRITE server listens on.
+  public let port: UInt16
+  /// Connect / preamble timeout. Past this, a dark server surfaces as honest unavailable.
+  public let connectTimeout: TimeInterval
+
+  public init(host: String = "127.0.0.1", port: UInt16, connectTimeout: TimeInterval = 4) {
+    self.host = host
+    self.port = port
+    self.connectTimeout = connectTimeout
+  }
+
+  /// The LIVE agent-run WRITE seam: the loopback host:port the agent-run WRITE LaunchAgent
+  /// (`com.friday.rust-agent-run-ws-server`) listens on. The live launch script pins `--port 48750`
+  /// (distinct from the read-projection server on 48751 and the TS hub on 48060).
+  ///
+  /// HONEST NOTE: `48750` is the value the operator's launch script pins, NOT a bin default. If the
+  /// operator relaunches on a different port, update here / pass an explicit config. When nothing
+  /// listens on this port, the transport fails honestly → honest "unavailable".
+  public static let liveLoopback = AgentRunWriteServerConfig(host: "127.0.0.1", port: 48750)
+
+  /// Map to the read client's transport config (the transport class is shared + port-parameterized).
+  var transportConfig: ReadProjectionServerConfig {
+    ReadProjectionServerConfig(host: host, port: port, connectTimeout: connectTimeout)
+  }
+}
+
+/// Builds the REAL `SealedWSWriteClient` (as the product-facing `FridayMissionSpineWriteClient`) for
+/// the agent-run WRITE server.
+public enum RealWriteClientFactory {
+  /// Construct the real mission-spine write client.
+  ///
+  /// - Parameters:
+  ///   - config: the WRITE server's loopback host:port.
+  ///   - keypair: this client's X25519 keypair. Its public key MUST be enrolled in the WRITE
+  ///     SecureStore peer-allowlist (already done for the master-derived peer) or the handshake is
+  ///     refused. Defaults to a fresh ephemeral keypair (sufficient to PROVE honest-unavailable
+  ///     against a dark server; the real enrolled identity is `makeLiveWrite`).
+  ///   - forwardedPrincipal: the owner principal; MUST equal the server's `--owner` (`admin-001`).
+  public static func make(
+    config: AgentRunWriteServerConfig,
+    keypair: FridayCrypto.DeviceKeypair = FridayCrypto.DeviceKeypair(),
+    forwardedPrincipal: String
+  ) -> FridayMissionSpineWriteClient {
+    let transportConfig = config.transportConfig
+    return SealedWSWriteClient(
+      keypair: keypair,
+      forwardedPrincipal: forwardedPrincipal,
+      makeTransport: { try LoopbackSealedWSTransport(config: transportConfig) }
+    )
+  }
+
+  /// Construct the LIVE mission-spine write client — the enrolled master-derived peer writing the
+  /// live agent-run WRITE server (the SAME enrolled identity the courier uses).
+  ///
+  /// Derives the keypair from `~/.friday/master.key` (or `FRIDAY_MASTER_KEY`) the SAME way the
+  /// read client + the enroll CLI did, so its pubkey IS the allowlisted WRITE peer; targets
+  /// `liveLoopback` (48750); and authenticates as `admin-001` (the LaunchAgent's `--owner`). Throws
+  /// (fail-closed) if the master key is missing/invalid — never substitutes an ephemeral key for the
+  /// live path (mirrors `RealReadClientFactory.makeLive`).
+  public static func makeLiveWrite(
+    config: AgentRunWriteServerConfig = .liveLoopback,
+    forwardedPrincipal: String = liveReadProjectionOwnerPrincipal
+  ) throws -> FridayMissionSpineWriteClient {
+    let keypair = try MasterKeyPeer.deriveKeypair()
+    return make(config: config, keypair: keypair, forwardedPrincipal: forwardedPrincipal)
+  }
+
+  /// A real-protocol write client that always fails closed to honest "unavailable" with `reason`.
+  /// Used by the app when LIVE mode is requested but the master key is unavailable: the compose /
+  /// confirm controls must render the truth, NOT a fabricated success (mirrors the read side's
+  /// `makeHonestlyUnavailable`).
+  public static func makeHonestlyUnavailableWrite(reason: String) -> FridayMissionSpineWriteClient {
+    HonestlyUnavailableWriteClient(reason: reason)
+  }
+}
+
+/// A `FridayMissionSpineWriteClient` that always throws — so the view model renders honest
+/// "unavailable". Never returns a result; it cannot fabricate a confirm.
+struct HonestlyUnavailableWriteClient: FridayMissionSpineWriteClient {
+  let reason: String
+  func submitMissionIntake(_ request: MissionIntakeRequestWire) async throws -> MissionIntakeResultWire {
+    throw FridayWriteClientError.transport("live write client unavailable: \(reason)")
+  }
+  func submitMemoryDecision(_ request: MemoryDecisionRequestWire) async throws -> MemoryDecisionResultWire {
+    throw FridayWriteClientError.transport("live write client unavailable: \(reason)")
+  }
+}

--- a/apps/macos/FridayHubConsole/Tests/FridayHubConsoleCoreTests/OperationsOverviewViewModelTests.swift
+++ b/apps/macos/FridayHubConsole/Tests/FridayHubConsoleCoreTests/OperationsOverviewViewModelTests.swift
@@ -263,3 +263,205 @@ func realClientFactoryBuildsAgainstLoopbackConfig() {
   #expect(client is SealedWSReadClient)
   #expect(ReadProjectionServerConfig.slice6LoopbackPlaceholder.host == "127.0.0.1")
 }
+
+// MARK: - Spine-WRITE drivers (Lane-D entry-point-A organic loop)
+
+/// An in-memory `FridayMissionSpineWriteClient` for view-model tests. Returns a programmed
+/// intake/decision outcome, OR throws to exercise the honest-unavailable path. Captures the last
+/// request so a test can assert the owner_principal / decision the view model wired.
+final class MockMissionSpineWriteClient: FridayMissionSpineWriteClient, @unchecked Sendable {
+  enum Behavior: Sendable {
+    case intakeReady
+    case intakeNeedsClarification
+    case intakeBlocked
+    case memoryConfirmed
+    case memoryBlocked
+    case throwsTransport
+  }
+  let behavior: Behavior
+  private let lock = NSLock()
+  private var _lastIntake: MissionIntakeRequestWire?
+  private var _lastDecision: MemoryDecisionRequestWire?
+  var lastIntake: MissionIntakeRequestWire? { lock.withLock { _lastIntake } }
+  var lastDecision: MemoryDecisionRequestWire? { lock.withLock { _lastDecision } }
+
+  init(behavior: Behavior) { self.behavior = behavior }
+
+  func submitMissionIntake(_ request: MissionIntakeRequestWire) async throws -> MissionIntakeResultWire {
+    lock.withLock { _lastIntake = request }
+    switch behavior {
+    case .throwsTransport:
+      throw FridayWriteClientError.transport("connection refused (write server dark)")
+    case .intakeNeedsClarification:
+      return MissionIntakeResultWire(
+        fridayConversationId: request.fridayConversationId, missionId: request.missionId,
+        surfaceThreadId: request.surfaceThreadId, status: "needs_clarification",
+        createdOrReady: false, clarificationQuestions: ["What is the deadline?"])
+    case .intakeBlocked:
+      return MissionIntakeResultWire(
+        fridayConversationId: request.fridayConversationId, missionId: request.missionId,
+        surfaceThreadId: request.surfaceThreadId, status: "blocked",
+        blockers: ["duplicate_mission"], createdOrReady: false)
+    default:
+      return MissionIntakeResultWire(
+        fridayConversationId: request.fridayConversationId, missionId: request.missionId,
+        workItemId: request.workItemId, surfaceThreadId: request.surfaceThreadId,
+        status: "ready", createdOrReady: true)
+    }
+  }
+
+  func submitMemoryDecision(_ request: MemoryDecisionRequestWire) async throws -> MemoryDecisionResultWire {
+    lock.withLock { _lastDecision = request }
+    switch behavior {
+    case .throwsTransport:
+      throw FridayWriteClientError.transport("connection refused (write server dark)")
+    case .memoryBlocked:
+      return MemoryDecisionResultWire(
+        memoryId: request.memoryId, state: "unknown", status: "blocked",
+        blocker: "unknown_candidate", recallable: false)
+    default:
+      return MemoryDecisionResultWire(
+        memoryId: request.memoryId,
+        state: request.decision == "confirm" ? "confirmed" : "rejected",
+        status: request.decision == "confirm" ? "confirmed" : "rejected",
+        recallable: request.decision == "confirm")
+    }
+  }
+}
+
+@Test
+@MainActor
+func submitIntakeReadyRendersConfirmedAndWiresOwnerAdmin001() async {
+  let write = MockMissionSpineWriteClient(behavior: .intakeReady)
+  let vm = OperationsOverviewViewModel(
+    client: MockReadClient(behavior: .loaded), writeClient: write,
+    writeOwnerPrincipal: "admin-001", newId: { "fixed" })
+  await vm.submitIntake(intent: "keep one Mission across every surface")
+
+  guard case let .confirmed(summary, questions) = vm.intakeState else {
+    Issue.record("expected .confirmed, got \(vm.intakeState)")
+    return
+  }
+  #expect(summary.contains("ready"))
+  #expect(summary.contains("mission-desktop-fixed"))
+  #expect(questions.isEmpty)
+  // FIX-Q3b: the body owner the view model wired MUST be the configured owner (admin-001).
+  #expect(write.lastIntake?.ownerPrincipal == "admin-001")
+  #expect(write.lastIntake?.surfaceKind == "desktop")
+  #expect(write.lastIntake?.lane == "deepseek")
+}
+
+@Test
+@MainActor
+func submitIntakeNeedsClarificationCarriesQuestionsHonestly() async {
+  let vm = OperationsOverviewViewModel(
+    client: MockReadClient(behavior: .loaded),
+    writeClient: MockMissionSpineWriteClient(behavior: .intakeNeedsClarification))
+  await vm.submitIntake(intent: "do the thing")
+  guard case let .confirmed(_, questions) = vm.intakeState else {
+    Issue.record("expected .confirmed (with questions), got \(vm.intakeState)")
+    return
+  }
+  #expect(questions == ["What is the deadline?"])
+}
+
+@Test
+@MainActor
+func submitIntakeBlockedRendersErrorNotConfirmed() async {
+  let vm = OperationsOverviewViewModel(
+    client: MockReadClient(behavior: .loaded),
+    writeClient: MockMissionSpineWriteClient(behavior: .intakeBlocked))
+  await vm.submitIntake(intent: "duplicate intent")
+  guard case let .error(reason) = vm.intakeState else {
+    Issue.record("a blocked intake must render .error, got \(vm.intakeState)")
+    return
+  }
+  #expect(reason.contains("blocked"))
+}
+
+@Test
+@MainActor
+func submitIntakeEmptyDraftRendersErrorWithoutCallingWrite() async {
+  let write = MockMissionSpineWriteClient(behavior: .intakeReady)
+  let vm = OperationsOverviewViewModel(
+    client: MockReadClient(behavior: .loaded), writeClient: write)
+  await vm.submitIntake(intent: "   ")
+  guard case .error = vm.intakeState else {
+    Issue.record("an empty intent must render .error, got \(vm.intakeState)")
+    return
+  }
+  #expect(write.lastIntake == nil)
+}
+
+@Test
+@MainActor
+func submitIntakeWithNoWriteClientRendersHonestUnavailable() async {
+  let vm = OperationsOverviewViewModel(client: MockReadClient(behavior: .loaded))  // no write client
+  await vm.submitIntake(intent: "something")
+  guard case let .error(reason) = vm.intakeState else {
+    Issue.record("no write client must render .error, got \(vm.intakeState)")
+    return
+  }
+  #expect(reason.contains("not configured"))
+}
+
+@Test
+@MainActor
+func submitIntakeTransportFailureRendersHonestUnavailable() async {
+  let vm = OperationsOverviewViewModel(
+    client: MockReadClient(behavior: .loaded),
+    writeClient: MockMissionSpineWriteClient(behavior: .throwsTransport))
+  await vm.submitIntake(intent: "something")
+  guard case let .error(reason) = vm.intakeState else {
+    Issue.record("a transport failure must render .error, got \(vm.intakeState)")
+    return
+  }
+  #expect(reason.contains("offline") || reason.contains("unavailable"))
+}
+
+@Test
+@MainActor
+func decideMemoryConfirmRendersConfirmedRecallable() async {
+  let write = MockMissionSpineWriteClient(behavior: .memoryConfirmed)
+  let vm = OperationsOverviewViewModel(
+    client: MockReadClient(behavior: .loaded), writeClient: write, writeOwnerPrincipal: "admin-001")
+  await vm.decideMemory(candidateId: "cand-1", memoryId: "mem-1", confirm: true)
+  guard case let .confirmed(summary, _) = vm.memoryDecisionStates["cand-1"] else {
+    Issue.record("expected .confirmed, got \(String(describing: vm.memoryDecisionStates["cand-1"]))")
+    return
+  }
+  #expect(summary.contains("confirmed"))
+  #expect(summary.contains("recallable=true"))
+  #expect(write.lastDecision?.decision == "confirm")
+  #expect(write.lastDecision?.ownerPrincipal == "admin-001")
+}
+
+@Test
+@MainActor
+func decideMemoryBlockedRendersErrorNotConfirmed() async {
+  // THE synthetic-candidate-id reality today: a confirm against the synthetic id returns
+  // status:"blocked" — which MUST render .error (never a fabricated confirm).
+  let vm = OperationsOverviewViewModel(
+    client: MockReadClient(behavior: .loaded),
+    writeClient: MockMissionSpineWriteClient(behavior: .memoryBlocked))
+  await vm.decideMemory(
+    candidateId: "cand-synthetic", memoryId: "memory_candidate_mission_x_0", confirm: true)
+  guard case let .error(reason) = vm.memoryDecisionStates["cand-synthetic"] else {
+    Issue.record("a blocked decision must render .error, got \(String(describing: vm.memoryDecisionStates["cand-synthetic"]))")
+    return
+  }
+  #expect(reason.contains("unknown_candidate") || reason.contains("blocked"))
+}
+
+@Test
+@MainActor
+func realWriteClientFactoryBuildsLiveAgainst48750OrHonestUnavailable() {
+  // The factory builds a real `SealedWSWriteClient` for the WRITE server's loopback seam (48750),
+  // OR (if the host master key is absent) an honest-unavailable client — never a fabricated one.
+  // Wiring-only; the live round-trip against a RUNNING server is the operator-gated AC.
+  #expect(AgentRunWriteServerConfig.liveLoopback.port == 48750)
+  #expect(AgentRunWriteServerConfig.liveLoopback.host == "127.0.0.1")
+  let client = RealWriteClientFactory.make(
+    config: .liveLoopback, forwardedPrincipal: "admin-001")
+  #expect(client is SealedWSWriteClient)
+}

--- a/apps/macos/FridayRustClient/Sources/FridayRustClient/Protocol.swift
+++ b/apps/macos/FridayRustClient/Sources/FridayRustClient/Protocol.swift
@@ -120,6 +120,22 @@ public enum FridayMessage: Equatable {
   /// `friday_protocol::Message::AgentRunControlResult`.
   case agentRunControlResult(AgentRunControlResultWire)
 
+  // MARK: - Mission-spine WRITE seam (Lane-D entry-point-A organic driver)
+
+  /// trusted-peer→hub: resolve/create a Mission from one surface input (a Hub-owned preflight
+  /// mutation, NOT a provider/model call). Mirrors `friday_protocol::Message::MissionIntakeRequest`
+  /// — a NESTED struct variant `{ request: … }` (NOT flattened like the AgentRun* variants).
+  case missionIntakeRequest(MissionIntakeRequestWire)
+  /// hub→trusted-peer: Mission intake/preflight receipt (refs-only). Mirrors
+  /// `friday_protocol::Message::MissionIntakeResult` — NESTED `{ result: … }`.
+  case missionIntakeResult(MissionIntakeResultWire)
+  /// trusted-peer→hub: apply the OWNER's explicit confirm/reject to ONE pending memory candidate.
+  /// Mirrors `friday_protocol::Message::MemoryDecisionRequest` — NESTED `{ request: … }`.
+  case memoryDecisionRequest(MemoryDecisionRequestWire)
+  /// hub→trusted-peer: memory decision receipt (refs-only). Mirrors
+  /// `friday_protocol::Message::MemoryDecisionResult` — NESTED `{ result: … }`.
+  case memoryDecisionResult(MemoryDecisionResultWire)
+
   /// A decoded-but-not-handled message kind. Carries the raw `kind` for truth-labeled surfacing
   /// (e.g. an `AgentRunPaused` reaching the read client, or any frame the client cannot handle).
   case unsupported(kind: String)
@@ -129,6 +145,7 @@ extension FridayMessage: Codable {
   private enum TagKey: String, CodingKey { case kind }
   private enum SnapshotKey: String, CodingKey { case snapshot }
   private enum RequestKey: String, CodingKey { case request }
+  private enum ResultKey: String, CodingKey { case result }
   private enum ErrorKey: String, CodingKey { case code, message }
   /// The flattened keys the WRITE variants carry as SIBLINGS of `kind` (serde's internally-tagged
   /// shape for struct variants with named fields). The read variants nest a single `request`/
@@ -216,6 +233,20 @@ extension FridayMessage: Codable {
         status: try c.decode(String.self, forKey: .status),
         auditRef: try c.decodeIfPresent(String.self, forKey: .auditRef)
       ))
+    // Mission-spine WRITE variants — NESTED `{ request }` / `{ result }` (NOT the flattened
+    // WriteKey path). Same shape as the read WorkbenchProjection* variants.
+    case "MissionIntakeRequest":
+      let c = try decoder.container(keyedBy: RequestKey.self)
+      self = .missionIntakeRequest(try c.decode(MissionIntakeRequestWire.self, forKey: .request))
+    case "MissionIntakeResult":
+      let c = try decoder.container(keyedBy: ResultKey.self)
+      self = .missionIntakeResult(try c.decode(MissionIntakeResultWire.self, forKey: .result))
+    case "MemoryDecisionRequest":
+      let c = try decoder.container(keyedBy: RequestKey.self)
+      self = .memoryDecisionRequest(try c.decode(MemoryDecisionRequestWire.self, forKey: .request))
+    case "MemoryDecisionResult":
+      let c = try decoder.container(keyedBy: ResultKey.self)
+      self = .memoryDecisionResult(try c.decode(MemoryDecisionResultWire.self, forKey: .result))
     default:
       self = .unsupported(kind: kind)
     }
@@ -286,6 +317,24 @@ extension FridayMessage: Codable {
       try c.encode(r.accepted, forKey: .accepted)
       try c.encode(r.status, forKey: .status)
       if let v = r.auditRef { try c.encode(v, forKey: .auditRef) }
+    // Mission-spine WRITE variants — NEST the payload under a single `request`/`result` field
+    // (the internally-tagged struct-variant shape the Rust serde + the read variants use).
+    case .missionIntakeRequest(let r):
+      try tag.encode("MissionIntakeRequest", forKey: .kind)
+      var c = encoder.container(keyedBy: RequestKey.self)
+      try c.encode(r, forKey: .request)
+    case .missionIntakeResult(let r):
+      try tag.encode("MissionIntakeResult", forKey: .kind)
+      var c = encoder.container(keyedBy: ResultKey.self)
+      try c.encode(r, forKey: .result)
+    case .memoryDecisionRequest(let r):
+      try tag.encode("MemoryDecisionRequest", forKey: .kind)
+      var c = encoder.container(keyedBy: RequestKey.self)
+      try c.encode(r, forKey: .request)
+    case .memoryDecisionResult(let r):
+      try tag.encode("MemoryDecisionResult", forKey: .kind)
+      var c = encoder.container(keyedBy: ResultKey.self)
+      try c.encode(r, forKey: .result)
     case .unsupported(let kind):
       try tag.encode(kind, forKey: .kind)
     }

--- a/apps/macos/FridayRustClient/Sources/FridayRustClient/ReadClient.swift
+++ b/apps/macos/FridayRustClient/Sources/FridayRustClient/ReadClient.swift
@@ -229,6 +229,16 @@ public final class SealedWSReadClient: FridayRustReadClient, @unchecked Sendable
       throw FridayReadClientError.unexpectedResponse(kind: "AgentRunResume")
     case .agentRunControlResult:
       throw FridayReadClientError.unexpectedResponse(kind: "AgentRunControlResult")
+    // The mission-spine WRITE variants share the `FridayMessage` enum but are NEVER answers a READ
+    // server gives — surface them as unexpected (the read seam only answers a snapshot / Error).
+    case .missionIntakeRequest:
+      throw FridayReadClientError.unexpectedResponse(kind: "MissionIntakeRequest")
+    case .missionIntakeResult:
+      throw FridayReadClientError.unexpectedResponse(kind: "MissionIntakeResult")
+    case .memoryDecisionRequest:
+      throw FridayReadClientError.unexpectedResponse(kind: "MemoryDecisionRequest")
+    case .memoryDecisionResult:
+      throw FridayReadClientError.unexpectedResponse(kind: "MemoryDecisionResult")
     case .unsupported(let kind):
       throw FridayReadClientError.unexpectedResponse(kind: kind)
     }

--- a/apps/macos/FridayRustClient/Sources/FridayRustClient/WriteClient.swift
+++ b/apps/macos/FridayRustClient/Sources/FridayRustClient/WriteClient.swift
@@ -149,12 +149,41 @@ public protocol FridayRustWriteClient {
   func resumeWithApproval(runId: String, opaqueSignedBlob: [UInt8]) async throws -> ResumeRelayResult
 }
 
+// MARK: - The mission-spine WRITE client protocol (Lane-D entry-point-A organic driver)
+
+/// The product-facing mission-spine WRITE client — the two organic-loop drivers over the SAME
+/// sealed-WS WRITE seam (:48750) the agent-run client uses, but WITHOUT a per-request `auth_proof`
+/// (the sealed single-peer session IS the channel auth; the server binds the write to the
+/// authenticated `--owner`).
+///
+/// `Sendable` so a `@MainActor` view model can store one and `await` a call that hops off the
+/// MainActor (the concrete `SealedWSWriteClient` is `@unchecked Sendable`, justified by its
+/// all-immutable stored state — same posture as `SealedWSReadClient`). This lets the blocking
+/// synchronous transport run OFF the main thread.
+public protocol FridayMissionSpineWriteClient: Sendable {
+  /// Submit one operator-typed Mission intake over the sealed WRITE session. Births a Mission +
+  /// WorkItem(Draft) server-side (no model call); returns the refs-only receipt (which may be
+  /// `status:"needs_clarification"` with questions, or `status:"blocked"`).
+  func submitMissionIntake(_ request: MissionIntakeRequestWire) async throws -> MissionIntakeResultWire
+  /// Submit the owner's explicit confirm/reject for ONE pending memory candidate. Returns the
+  /// refs-only receipt (`status:"confirmed"`/`"rejected"`/`"blocked"`). `decision` MUST be
+  /// `"confirm"` or `"reject"`.
+  func submitMemoryDecision(_ request: MemoryDecisionRequestWire) async throws -> MemoryDecisionResultWire
+}
+
 // MARK: - The sealed-WS write client implementation
 
 /// The sealed-WS WRITE client. Drives the full handshake + dispatch + courier LOGIC over an
 /// injected `SealedWSTransport` (reused from #677). Pure byte-exact logic; the network is the
 /// injected pipe (the live transport is the deferred slice-6 AC).
-public final class SealedWSWriteClient: FridayRustWriteClient {
+///
+/// `@unchecked Sendable`: every stored property is an immutable `let` (the keypair, the principal,
+/// the injected `@escaping` factory/closures). The closures are not statically `@Sendable` (so the
+/// `FridayMissionSpineWriteClient: Sendable` conformance is not auto-satisfied), but the instance
+/// carries no mutable shared state across an `await`, so it is safe to send — the SAME asserted
+/// posture as `SealedWSReadClient`. This lets a `@MainActor` view model store one and run the
+/// blocking synchronous transport OFF the main thread.
+public final class SealedWSWriteClient: FridayRustWriteClient, FridayMissionSpineWriteClient, @unchecked Sendable {
   private let keypair: FridayCrypto.DeviceKeypair
   private let forwardedPrincipal: String
   private let sessionId: String?
@@ -272,10 +301,73 @@ public final class SealedWSWriteClient: FridayRustWriteClient {
     case .error(let code, let message):
       throw FridayWriteClientError.serverError(code: code, message: message)
     case .agentRunRequest, .agentRunResume, .agentRunControlResult,
-         .workbenchProjectionRequest, .workbenchProjectionSnapshot:
+         .workbenchProjectionRequest, .workbenchProjectionSnapshot,
+         .missionIntakeRequest, .missionIntakeResult,
+         .memoryDecisionRequest, .memoryDecisionResult:
       throw FridayWriteClientError.unexpectedResponse(kind: dispatchKind(message))
     case .unsupported(let kind):
       throw FridayWriteClientError.unexpectedResponse(kind: kind)
+    }
+  }
+
+  // MARK: Mission-spine WRITE drivers (NO auth_proof — the sealed session IS the channel auth)
+
+  /// Submit one Mission intake over the sealed WRITE session. SIMPLER than `dispatchAgentRun`: it
+  /// performs ONLY the handshake (the allowlisted peer pubkey is the admission) and sends the
+  /// `MissionIntakeRequest` sealed under the WRITE SESSION_AAD — it builds NO `auth_proof` (this
+  /// wire shape carries none; the server binds the write to the authenticated `--owner`). Settles
+  /// on the FIRST inbound: a `MissionIntakeResult` ⇒ returned; a typed `Error` ⇒ thrown; anything
+  /// else ⇒ fail-closed. The session nonce is unused (no possession proof to bind).
+  public func submitMissionIntake(_ request: MissionIntakeRequestWire) async throws -> MissionIntakeResultWire {
+    let transport = try makeTransport()
+    let (sessionKey, _) = try handshake(transport)
+    let msgId = "mission-intake-\(request.missionId)"
+    let env = FridayEnvelope(msgId: msgId, sentAt: now(), message: .missionIntakeRequest(request))
+      .withCorrelation(msgId)
+    try transport.sendMessage(try sealEnvelope(env, sessionKey: sessionKey))
+    let respBody: [UInt8]
+    do {
+      respBody = try transport.recvMessage()
+    } catch {
+      throw FridayWriteClientError.transport("no intake result (session ended fail-closed): \(error)")
+    }
+    let resp = try openEnvelope(respBody, sessionKey: sessionKey)
+    switch resp.message {
+    case .missionIntakeResult(let r):
+      return r
+    case .error(let code, let message):
+      throw FridayWriteClientError.serverError(code: code, message: message)
+    default:
+      throw FridayWriteClientError.unexpectedResponse(kind: dispatchKind(resp.message))
+    }
+  }
+
+  /// Submit the owner's confirm/reject for ONE pending memory candidate over the sealed WRITE
+  /// session. Like `submitMissionIntake`: handshake-only auth (NO `auth_proof`), seal the
+  /// `MemoryDecisionRequest` under the WRITE SESSION_AAD, settle on the first
+  /// `MemoryDecisionResult` (a `status:"blocked"` result is a VALID receipt the caller surfaces
+  /// honestly — NOT a thrown error), a typed `Error` is thrown, anything else fails closed.
+  public func submitMemoryDecision(_ request: MemoryDecisionRequestWire) async throws -> MemoryDecisionResultWire {
+    let transport = try makeTransport()
+    let (sessionKey, _) = try handshake(transport)
+    let msgId = "memory-decision-\(request.memoryId)"
+    let env = FridayEnvelope(msgId: msgId, sentAt: now(), message: .memoryDecisionRequest(request))
+      .withCorrelation(msgId)
+    try transport.sendMessage(try sealEnvelope(env, sessionKey: sessionKey))
+    let respBody: [UInt8]
+    do {
+      respBody = try transport.recvMessage()
+    } catch {
+      throw FridayWriteClientError.transport("no memory-decision result (session ended fail-closed): \(error)")
+    }
+    let resp = try openEnvelope(respBody, sessionKey: sessionKey)
+    switch resp.message {
+    case .memoryDecisionResult(let r):
+      return r
+    case .error(let code, let message):
+      throw FridayWriteClientError.serverError(code: code, message: message)
+    default:
+      throw FridayWriteClientError.unexpectedResponse(kind: dispatchKind(resp.message))
     }
   }
 
@@ -401,6 +493,10 @@ private func dispatchKind(_ message: FridayMessage) -> String {
   case .agentRunPaused: return "AgentRunPaused"
   case .agentRunResume: return "AgentRunResume"
   case .agentRunControlResult: return "AgentRunControlResult"
+  case .missionIntakeRequest: return "MissionIntakeRequest"
+  case .missionIntakeResult: return "MissionIntakeResult"
+  case .memoryDecisionRequest: return "MemoryDecisionRequest"
+  case .memoryDecisionResult: return "MemoryDecisionResult"
   case .unsupported(let kind): return kind
   }
 }

--- a/apps/macos/FridayRustClient/Sources/FridayRustClient/WriteProtocol.swift
+++ b/apps/macos/FridayRustClient/Sources/FridayRustClient/WriteProtocol.swift
@@ -224,3 +224,299 @@ public struct AgentRunControlResultWire: Equatable, Sendable {
     self.auditRef = auditRef
   }
 }
+
+// MARK: - Mission-spine WRITE wire types (MissionIntake + MemoryDecision)
+//
+// The Lane-D entry-point-A spine-WRITE shapes — Swift ports of the `friday-protocol` serde structs
+// the live agent-run WRITE server (`bin/hub_agent_run_server.rs`) handles under
+// `FRIDAY_MISSION_INTAKE=1` / `FRIDAY_MEMORY_CONFIRM=1` (BOTH ON in the live launch script). These
+// drive the FIRST organic loop through the Rust spine: an operator-typed `MissionIntakeRequest`
+// BIRTHS a Mission + WorkItem(Draft), and a `MemoryDecisionRequest{decision:"confirm"}` makes a
+// pending memory candidate durable/recallable.
+//
+// TWO load-bearing facts that differ from the AgentRun* variants above:
+//  1. WIRE SHAPE — the `FridayMessage` variants for these NEST the payload under a single named
+//     field (`{"kind":"MissionIntakeRequest","request":{…}}`), the SAME internally-tagged shape as
+//     the read `WorkbenchProjection*` variants — NOT the flattened `WriteKey` shape the AgentRun*
+//     variants use. The Rust test `memory_decision_wire_round_trips_and_uses_the_request_result_wrapper`
+//     asserts `"request":{` / `"result":{` and documents that a prior FLAT shape "503'd every call."
+//  2. AUTH — these carry NO per-request `auth_proof`. The SEALED SESSION itself is the channel auth
+//     (an allowlisted single peer holding the session key; the server binds the write to the
+//     Rust-derived AUTHENTICATED owner `--owner admin-001`, FIX-Q3b). Unlike `dispatchAgentRun`,
+//     the submit methods build NO `buildAuthProof` for these messages.
+
+/// Client→hub Mission intake/preflight request. Mirrors `friday_protocol::MissionIntakeRequestWire`.
+/// Resolves/creates a Mission from one surface input (a Hub-owned preflight mutation, NOT a
+/// provider/model call). The server FAIL-CLOSES (writes ZERO rows) when `ownerPrincipal` != the
+/// authenticated `--owner` (FIX-Q3b), so `ownerPrincipal` MUST equal the configured owner.
+public struct MissionIntakeRequestWire: Codable, Equatable, Sendable {
+  public var fridayConversationId: String
+  /// MUST equal the authenticated `--owner` (live: `admin-001`) — a mismatch is a typed Error that
+  /// persists nothing (NOT a silent write). Wire it from config, never raw UI input.
+  public var ownerPrincipal: String
+  public var surfaceThreadId: String
+  /// One of the server's `surface_kind_from_wire` tokens (e.g. `desktop`, `mobile`, …); an unknown
+  /// value blocks the intake.
+  public var surfaceKind: String
+  /// Non-empty free-form route hint (server only requires it non-empty).
+  public var deliveryRoute: String
+  /// One of `compact` / `rich_proof` / `status_only` / `hidden_trace_only`.
+  public var visibilityPolicy: String
+  /// The client SUPPLIES the Mission id (the server births the row from it).
+  public var missionId: String
+  /// The client SUPPLIES the WorkItem id (the server births the Draft from it).
+  public var workItemId: String
+  public var title: String
+  public var intent: String
+  /// One of `friday_hub`/`codex`/`claude`/`deepseek`/`workflow`/`channel`/`human`/`future_api`.
+  public var lane: String
+  /// Optional — omitted from the wire when nil (serde `skip_serializing_if`).
+  public var targetProviderOrAgent: String?
+  /// Optional — omitted when nil.
+  public var capabilityId: String?
+  /// Optional — omitted when nil. When present MUST be a Friday-owned body ref
+  /// (`friday://body/…` / `friday://surface-event-body/…` / `blob://…`) or the intake blocks.
+  public var bodyRef: String?
+  /// ALWAYS emitted (serde `#[serde(default)]` WITHOUT skip — the server itself always serializes it).
+  public var includesSensitiveContext: Bool
+
+  public init(
+    fridayConversationId: String, ownerPrincipal: String, surfaceThreadId: String,
+    surfaceKind: String, deliveryRoute: String, visibilityPolicy: String,
+    missionId: String, workItemId: String, title: String, intent: String, lane: String,
+    targetProviderOrAgent: String? = nil, capabilityId: String? = nil,
+    bodyRef: String? = nil, includesSensitiveContext: Bool = false
+  ) {
+    self.fridayConversationId = fridayConversationId
+    self.ownerPrincipal = ownerPrincipal
+    self.surfaceThreadId = surfaceThreadId
+    self.surfaceKind = surfaceKind
+    self.deliveryRoute = deliveryRoute
+    self.visibilityPolicy = visibilityPolicy
+    self.missionId = missionId
+    self.workItemId = workItemId
+    self.title = title
+    self.intent = intent
+    self.lane = lane
+    self.targetProviderOrAgent = targetProviderOrAgent
+    self.capabilityId = capabilityId
+    self.bodyRef = bodyRef
+    self.includesSensitiveContext = includesSensitiveContext
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case fridayConversationId = "friday_conversation_id"
+    case ownerPrincipal = "owner_principal"
+    case surfaceThreadId = "surface_thread_id"
+    case surfaceKind = "surface_kind"
+    case deliveryRoute = "delivery_route"
+    case visibilityPolicy = "visibility_policy"
+    case missionId = "mission_id"
+    case workItemId = "work_item_id"
+    case title, intent, lane
+    case targetProviderOrAgent = "target_provider_or_agent"
+    case capabilityId = "capability_id"
+    case bodyRef = "body_ref"
+    case includesSensitiveContext = "includes_sensitive_context"
+  }
+
+  /// Custom encode mirroring the Rust serde discipline: the 3 optionals are OMITTED when nil
+  /// (`skip_serializing_if`); `includes_sensitive_context` is ALWAYS emitted (the server's own
+  /// serialization always emits it — `#[serde(default)]` without skip).
+  public func encode(to encoder: Encoder) throws {
+    var c = encoder.container(keyedBy: CodingKeys.self)
+    try c.encode(fridayConversationId, forKey: .fridayConversationId)
+    try c.encode(ownerPrincipal, forKey: .ownerPrincipal)
+    try c.encode(surfaceThreadId, forKey: .surfaceThreadId)
+    try c.encode(surfaceKind, forKey: .surfaceKind)
+    try c.encode(deliveryRoute, forKey: .deliveryRoute)
+    try c.encode(visibilityPolicy, forKey: .visibilityPolicy)
+    try c.encode(missionId, forKey: .missionId)
+    try c.encode(workItemId, forKey: .workItemId)
+    try c.encode(title, forKey: .title)
+    try c.encode(intent, forKey: .intent)
+    try c.encode(lane, forKey: .lane)
+    if let v = targetProviderOrAgent { try c.encode(v, forKey: .targetProviderOrAgent) }
+    if let v = capabilityId { try c.encode(v, forKey: .capabilityId) }
+    if let v = bodyRef { try c.encode(v, forKey: .bodyRef) }
+    try c.encode(includesSensitiveContext, forKey: .includesSensitiveContext)
+  }
+
+  /// Decode tolerant of the optionals being absent and of `includes_sensitive_context` being
+  /// omitted (serde `default` tolerance) — `?? false`.
+  public init(from decoder: Decoder) throws {
+    let c = try decoder.container(keyedBy: CodingKeys.self)
+    fridayConversationId = try c.decode(String.self, forKey: .fridayConversationId)
+    ownerPrincipal = try c.decode(String.self, forKey: .ownerPrincipal)
+    surfaceThreadId = try c.decode(String.self, forKey: .surfaceThreadId)
+    surfaceKind = try c.decode(String.self, forKey: .surfaceKind)
+    deliveryRoute = try c.decode(String.self, forKey: .deliveryRoute)
+    visibilityPolicy = try c.decode(String.self, forKey: .visibilityPolicy)
+    missionId = try c.decode(String.self, forKey: .missionId)
+    workItemId = try c.decode(String.self, forKey: .workItemId)
+    title = try c.decode(String.self, forKey: .title)
+    intent = try c.decode(String.self, forKey: .intent)
+    lane = try c.decode(String.self, forKey: .lane)
+    targetProviderOrAgent = try c.decodeIfPresent(String.self, forKey: .targetProviderOrAgent)
+    capabilityId = try c.decodeIfPresent(String.self, forKey: .capabilityId)
+    bodyRef = try c.decodeIfPresent(String.self, forKey: .bodyRef)
+    includesSensitiveContext =
+      (try c.decodeIfPresent(Bool.self, forKey: .includesSensitiveContext)) ?? false
+  }
+}
+
+/// Hub→client Mission intake/preflight receipt. Mirrors `friday_protocol::MissionIntakeResultWire`.
+/// `status` is `"ready"` / `"blocked"` / `"needs_clarification"`. With `FRIDAY_MISSION_INTAKE_CLARIFY=1`
+/// LIVE, an UNDER-SPECIFIED intent returns `status:"needs_clarification"` + a non-empty
+/// `clarificationQuestions` + `createdOrReady:false` (no rows written) — the Swift result MUST carry
+/// these. Refs-only: it carries ids/status/blockers, never a body.
+public struct MissionIntakeResultWire: Codable, Equatable, Sendable {
+  public var fridayConversationId: String
+  public var missionId: String
+  /// Omitted from the wire when nil (serde `skip_serializing_if`).
+  public var workItemId: String?
+  public var surfaceThreadId: String
+  public var status: String
+  /// Always present (default `[]`).
+  public var blockers: [String]
+  public var duplicateMissionId: String?
+  public var duplicateWorkItemId: String?
+  public var createdOrReady: Bool
+  /// Non-empty ONLY when `status == "needs_clarification"`; omitted (skip-if-empty) otherwise.
+  public var clarificationQuestions: [String]
+
+  public init(
+    fridayConversationId: String, missionId: String, workItemId: String? = nil,
+    surfaceThreadId: String, status: String, blockers: [String] = [],
+    duplicateMissionId: String? = nil, duplicateWorkItemId: String? = nil,
+    createdOrReady: Bool, clarificationQuestions: [String] = []
+  ) {
+    self.fridayConversationId = fridayConversationId
+    self.missionId = missionId
+    self.workItemId = workItemId
+    self.surfaceThreadId = surfaceThreadId
+    self.status = status
+    self.blockers = blockers
+    self.duplicateMissionId = duplicateMissionId
+    self.duplicateWorkItemId = duplicateWorkItemId
+    self.createdOrReady = createdOrReady
+    self.clarificationQuestions = clarificationQuestions
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case fridayConversationId = "friday_conversation_id"
+    case missionId = "mission_id"
+    case workItemId = "work_item_id"
+    case surfaceThreadId = "surface_thread_id"
+    case status, blockers
+    case duplicateMissionId = "duplicate_mission_id"
+    case duplicateWorkItemId = "duplicate_work_item_id"
+    case createdOrReady = "created_or_ready"
+    case clarificationQuestions = "clarification_questions"
+  }
+
+  public init(from decoder: Decoder) throws {
+    let c = try decoder.container(keyedBy: CodingKeys.self)
+    fridayConversationId = try c.decode(String.self, forKey: .fridayConversationId)
+    missionId = try c.decode(String.self, forKey: .missionId)
+    workItemId = try c.decodeIfPresent(String.self, forKey: .workItemId)
+    surfaceThreadId = try c.decode(String.self, forKey: .surfaceThreadId)
+    status = try c.decode(String.self, forKey: .status)
+    blockers = (try c.decodeIfPresent([String].self, forKey: .blockers)) ?? []
+    duplicateMissionId = try c.decodeIfPresent(String.self, forKey: .duplicateMissionId)
+    duplicateWorkItemId = try c.decodeIfPresent(String.self, forKey: .duplicateWorkItemId)
+    createdOrReady = try c.decode(Bool.self, forKey: .createdOrReady)
+    clarificationQuestions =
+      (try c.decodeIfPresent([String].self, forKey: .clarificationQuestions)) ?? []
+  }
+
+  /// Mirror the serde skip discipline: `work_item_id`/`duplicate_*` omitted when nil;
+  /// `clarification_questions` omitted when empty; the rest always emitted.
+  public func encode(to encoder: Encoder) throws {
+    var c = encoder.container(keyedBy: CodingKeys.self)
+    try c.encode(fridayConversationId, forKey: .fridayConversationId)
+    try c.encode(missionId, forKey: .missionId)
+    if let v = workItemId { try c.encode(v, forKey: .workItemId) }
+    try c.encode(surfaceThreadId, forKey: .surfaceThreadId)
+    try c.encode(status, forKey: .status)
+    try c.encode(blockers, forKey: .blockers)
+    if let v = duplicateMissionId { try c.encode(v, forKey: .duplicateMissionId) }
+    if let v = duplicateWorkItemId { try c.encode(v, forKey: .duplicateWorkItemId) }
+    try c.encode(createdOrReady, forKey: .createdOrReady)
+    if !clarificationQuestions.isEmpty {
+      try c.encode(clarificationQuestions, forKey: .clarificationQuestions)
+    }
+  }
+}
+
+/// Client→hub memory-decision request. Mirrors `friday_protocol::MemoryDecisionRequestWire`. The
+/// owner's OWN action over the sealed session (NOT an agent mutating-tool action) — it does NOT
+/// route the approval/trust gate. All 3 fields are always emitted. `decision` MUST be exactly
+/// `"confirm"` or `"reject"` (the server parses fail-closed — any other token is an Error). The
+/// server scopes from the AUTHENTICATED owner's composite namespace and IGNORES this body
+/// `ownerPrincipal` for scope (set it to the configured owner anyway, for consistency).
+public struct MemoryDecisionRequestWire: Codable, Equatable, Sendable {
+  public var memoryId: String
+  public var ownerPrincipal: String
+  /// EXACTLY `"confirm"` or `"reject"`.
+  public var decision: String
+
+  public init(memoryId: String, ownerPrincipal: String, decision: String) {
+    self.memoryId = memoryId
+    self.ownerPrincipal = ownerPrincipal
+    self.decision = decision
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case memoryId = "memory_id"
+    case ownerPrincipal = "owner_principal"
+    case decision
+  }
+}
+
+/// Hub→client memory-decision receipt. Mirrors `friday_protocol::MemoryDecisionResultWire`.
+/// Refs-only: candidate id + resulting lifecycle state + coarse status + recallable flag — NEVER
+/// the candidate content. `status` is `"confirmed"` / `"rejected"` (applied) or `"blocked"`
+/// (scope mismatch / unknown candidate / terminal / invalid decision); `blocker` is set only when
+/// `status == "blocked"`.
+public struct MemoryDecisionResultWire: Codable, Equatable, Sendable {
+  public var memoryId: String
+  /// `"candidate"` / `"confirmed"` / `"rejected"` / `"unknown"`.
+  public var state: String
+  /// `"confirmed"` / `"rejected"` / `"blocked"`.
+  public var status: String
+  /// Set ONLY when `status == "blocked"` (omitted otherwise — serde `skip_serializing_if`).
+  public var blocker: String?
+  public var recallable: Bool
+
+  public init(memoryId: String, state: String, status: String, blocker: String? = nil, recallable: Bool) {
+    self.memoryId = memoryId
+    self.state = state
+    self.status = status
+    self.blocker = blocker
+    self.recallable = recallable
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case memoryId = "memory_id"
+    case state, status, blocker, recallable
+  }
+
+  public init(from decoder: Decoder) throws {
+    let c = try decoder.container(keyedBy: CodingKeys.self)
+    memoryId = try c.decode(String.self, forKey: .memoryId)
+    state = try c.decode(String.self, forKey: .state)
+    status = try c.decode(String.self, forKey: .status)
+    blocker = try c.decodeIfPresent(String.self, forKey: .blocker)
+    recallable = try c.decode(Bool.self, forKey: .recallable)
+  }
+
+  public func encode(to encoder: Encoder) throws {
+    var c = encoder.container(keyedBy: CodingKeys.self)
+    try c.encode(memoryId, forKey: .memoryId)
+    try c.encode(state, forKey: .state)
+    try c.encode(status, forKey: .status)
+    if let v = blocker { try c.encode(v, forKey: .blocker) }
+    try c.encode(recallable, forKey: .recallable)
+  }
+}

--- a/apps/macos/FridayRustClient/Tests/FridayRustClientTests/MissionSpineWriteKATTests.swift
+++ b/apps/macos/FridayRustClient/Tests/FridayRustClientTests/MissionSpineWriteKATTests.swift
@@ -1,0 +1,228 @@
+import XCTest
+@testable import FridayRustClient
+
+/// **The mission-spine WRITE deliverable — byte-asserted Swift↔Rust parity for the
+/// MissionIntake + MemoryDecision wire shapes (Lane-D entry-point-A).** These prove the Swift
+/// spine-write structs serialize to the EXACT JSON the Rust agent-run WRITE server
+/// (`bin/hub_agent_run_server.rs`) decodes under `FRIDAY_MISSION_INTAKE=1` / `FRIDAY_MEMORY_CONFIRM=1`.
+///
+/// Two load-bearing traps these lock:
+///  1. NESTED SHAPE — the `FridayMessage` variants NEST the payload under `request`/`result`
+///     (`{"kind":"MissionIntakeRequest","request":{…}}`), the SAME internally-tagged shape as the
+///     read `WorkbenchProjection*` variants — NOT the flattened AgentRun* `WriteKey` shape. The
+///     Rust test `memory_decision_wire_round_trips_and_uses_the_request_result_wrapper` asserts
+///     `"request":{` / `"result":{` and documents that a prior FLAT shape "503'd every call." These
+///     KATs reproduce that anti-flat-shape guard on the Swift side.
+///  2. NO auth_proof — neither message carries a per-request `auth_proof` field (the sealed session
+///     IS the channel auth). These KATs assert the message object's EXACT key set, so a regression
+///     that smuggles in an `auth_proof`/`forwarded_principal` is caught at the protocol layer.
+///
+/// Field-name + value parity is anchored to the Rust `friday_protocol` round-trip test vectors
+/// (`lib.rs` ~2061/2137/2169) read at origin/main `ba78fdb7`: owner_principal/surface_kind/etc are
+/// the SAME field NAMES the Rust serde struct uses (snake_case CodingKeys), and the values the live
+/// desktop sends (`owner_principal:"admin-001"`, `decision:"confirm"`) are the server-accepted ones.
+final class MissionSpineWriteKATTests: XCTestCase {
+
+  /// The live desktop owner — equals the write server's `--owner admin-001` (FIX-Q3b cross-check).
+  private let owner = "admin-001"
+
+  /// Decode an envelope's `message` object as a key/value map so a KAT can assert the EXACT key set
+  /// the message carries (order-agnostic), and the nested `request`/`result` object under it.
+  private func messageObject(_ json: String) throws -> [String: Any] {
+    let env = try XCTUnwrap(JSONSerialization.jsonObject(with: Data(json.utf8)) as? [String: Any])
+    return try XCTUnwrap(env["message"] as? [String: Any], "envelope has no message object")
+  }
+
+  // MARK: MS1 — MissionIntakeRequest wire shape (nested + no auth_proof)
+
+  /// MS1: a `MissionIntakeRequest` rides as `{"kind":"MissionIntakeRequest","request":{…}}` — the
+  /// payload NESTED under `request`, NOT flattened. `owner_principal` is `admin-001`,
+  /// `includes_sensitive_context` is ALWAYS emitted (even when false), and there is NO `auth_proof`.
+  func testMS1_missionIntakeRequestNestedShapeNoAuthProof() throws {
+    let req = MissionIntakeRequestWire(
+      fridayConversationId: "fconv_desktop_1",
+      ownerPrincipal: owner,
+      surfaceThreadId: "surface-desktop-1",
+      surfaceKind: "desktop",
+      deliveryRoute: "desktop://hub-console/operations",
+      visibilityPolicy: "compact",
+      missionId: "mission-desktop-1",
+      workItemId: "work-desktop-1",
+      title: "Coordinate Friday work",
+      intent: "keep one Mission across every surface",
+      lane: "deepseek")
+    let env = FridayEnvelope(msgId: "m1", sentAt: 1000, message: .missionIntakeRequest(req))
+      .withCorrelation("c1")
+    let json = String(decoding: try env.encodeJSON(), as: UTF8.self)
+
+    XCTAssertTrue(json.contains("\"kind\":\"MissionIntakeRequest\""))
+    // The load-bearing anti-flat-shape guard: the payload sits under `"request":{…}`.
+    XCTAssertTrue(json.contains("\"request\":{"), "intake must NEST under request, not flatten: \(json)")
+    XCTAssertTrue(json.contains("\"owner_principal\":\"admin-001\""))
+    XCTAssertTrue(json.contains("\"surface_kind\":\"desktop\""))
+    // includes_sensitive_context is ALWAYS emitted (the server itself always serializes it).
+    XCTAssertTrue(json.contains("\"includes_sensitive_context\":false"))
+
+    // The message object carries EXACTLY {kind, request} — no auth_proof/forwarded_principal smuggled in.
+    let messageObj = try messageObject(json)
+    XCTAssertEqual(Set(messageObj.keys), ["kind", "request"])
+    XCTAssertNil(messageObj["auth_proof"])
+    XCTAssertNil(messageObj["forwarded_principal"])
+    let request = try XCTUnwrap(messageObj["request"] as? [String: Any])
+    XCTAssertNil(request["auth_proof"], "MissionIntakeRequest carries NO per-request auth_proof")
+
+    // Round-trips back to the same message.
+    XCTAssertEqual(try FridayEnvelope.decodeJSON(Data(json.utf8)).message, .missionIntakeRequest(req))
+  }
+
+  /// MS1: the 3 optional fields are OMITTED when nil (serde `skip_serializing_if`); present + a
+  /// `body_ref`/`target_provider_or_agent`/`capability_id` round-trip when set.
+  func testMS1_missionIntakeOptionalsOmittedWhenNil_presentWhenSet() throws {
+    let bare = MissionIntakeRequestWire(
+      fridayConversationId: "f", ownerPrincipal: owner, surfaceThreadId: "s",
+      surfaceKind: "desktop", deliveryRoute: "d", visibilityPolicy: "compact",
+      missionId: "m", workItemId: "w", title: "t", intent: "i", lane: "deepseek")
+    let bareJson = String(decoding: try JSONEncoder().encode(bare), as: UTF8.self)
+    for omitted in ["target_provider_or_agent", "capability_id", "body_ref"] {
+      XCTAssertFalse(bareJson.contains(omitted), "a nil optional must be omitted: \(omitted)")
+    }
+
+    let full = MissionIntakeRequestWire(
+      fridayConversationId: "f", ownerPrincipal: owner, surfaceThreadId: "s",
+      surfaceKind: "desktop", deliveryRoute: "d", visibilityPolicy: "compact",
+      missionId: "m", workItemId: "w", title: "t", intent: "i", lane: "deepseek",
+      targetProviderOrAgent: "deepseek", capabilityId: "ask_friday.deepseek",
+      bodyRef: "friday://body/desktop/1", includesSensitiveContext: true)
+    let env = FridayEnvelope(msgId: "m", sentAt: 1, message: .missionIntakeRequest(full))
+    XCTAssertEqual(try FridayEnvelope.decodeJSON(try env.encodeJSON()).message, .missionIntakeRequest(full))
+    let fullJson = String(decoding: try env.encodeJSON(), as: UTF8.self)
+    XCTAssertTrue(fullJson.contains("\"includes_sensitive_context\":true"))
+    XCTAssertTrue(fullJson.contains("\"body_ref\":\"friday://body/desktop/1\""))
+  }
+
+  // MARK: MS2 — MissionIntakeResult decode (incl. the live needs_clarification arm)
+
+  /// MS2: a `status:"ready"` result decodes (the happy path) — work_item_id + created_or_ready true.
+  func testMS2_missionIntakeResultReadyDecodes() throws {
+    let json = """
+      {"schema_version":13,"msg_id":"m1","sent_at":1000,"message":{
+        "kind":"MissionIntakeResult","result":{
+          "friday_conversation_id":"fconv_desktop_1","mission_id":"mission-desktop-1",
+          "work_item_id":"work-desktop-1","surface_thread_id":"surface-desktop-1",
+          "status":"ready","blockers":[],"created_or_ready":true}}}
+      """
+    let env = try FridayEnvelope.decodeJSON(Data(json.utf8))
+    guard case .missionIntakeResult(let r) = env.message else { return XCTFail("expected MissionIntakeResult") }
+    XCTAssertEqual(r.status, "ready")
+    XCTAssertEqual(r.missionId, "mission-desktop-1")
+    XCTAssertEqual(r.workItemId, "work-desktop-1")
+    XCTAssertTrue(r.createdOrReady)
+    XCTAssertTrue(r.clarificationQuestions.isEmpty)
+  }
+
+  /// MS2 (the LIVE clarify arm, `FRIDAY_MISSION_INTAKE_CLARIFY=1`): a `needs_clarification` result
+  /// with a NON-EMPTY `clarification_questions` + `created_or_ready:false` round-trips — the Swift
+  /// result MUST carry the questions so the UI can render them honestly.
+  func testMS2_missionIntakeResultNeedsClarificationCarriesQuestions() throws {
+    let json = """
+      {"schema_version":13,"msg_id":"m1","sent_at":1000,"message":{
+        "kind":"MissionIntakeResult","result":{
+          "friday_conversation_id":"fconv_x","mission_id":"mission-x",
+          "surface_thread_id":"surface-x","status":"needs_clarification","blockers":[],
+          "created_or_ready":false,
+          "clarification_questions":["What is the deadline?","Which provider should handle it?"]}}}
+      """
+    let env = try FridayEnvelope.decodeJSON(Data(json.utf8))
+    guard case .missionIntakeResult(let r) = env.message else { return XCTFail("expected MissionIntakeResult") }
+    XCTAssertEqual(r.status, "needs_clarification")
+    XCTAssertFalse(r.createdOrReady)
+    XCTAssertNil(r.workItemId, "an under-specified intent writes no WorkItem")
+    XCTAssertEqual(r.clarificationQuestions, ["What is the deadline?", "Which provider should handle it?"])
+  }
+
+  /// MS2: a `status:"blocked"` result with duplicate ids round-trips (a duplicate-preflight outcome).
+  func testMS2_missionIntakeResultBlockedDuplicateRoundTrips() throws {
+    let blocked = MissionIntakeResultWire(
+      fridayConversationId: "f", missionId: "m", surfaceThreadId: "s",
+      status: "blocked", blockers: ["duplicate_mission"],
+      duplicateMissionId: "mission-existing", duplicateWorkItemId: "work-existing",
+      createdOrReady: false)
+    let env = FridayEnvelope(msgId: "m", sentAt: 1, message: .missionIntakeResult(blocked))
+    XCTAssertEqual(try FridayEnvelope.decodeJSON(try env.encodeJSON()).message, .missionIntakeResult(blocked))
+    let json = String(decoding: try env.encodeJSON(), as: UTF8.self)
+    XCTAssertTrue(json.contains("\"result\":{"))
+    XCTAssertTrue(json.contains("\"duplicate_mission_id\":\"mission-existing\""))
+    // clarification_questions is skipped when empty.
+    XCTAssertFalse(json.contains("clarification_questions"))
+  }
+
+  // MARK: MS3 — MemoryDecisionRequest wire shape (nested + no auth_proof + exact decision token)
+
+  /// MS3: a `MemoryDecisionRequest` rides as `{"kind":"MemoryDecisionRequest","request":{…}}` with
+  /// `decision:"confirm"` and the nested wrapper — mirroring the Rust
+  /// `memory_decision_wire_round_trips_and_uses_the_request_result_wrapper` test exactly.
+  func testMS3_memoryDecisionRequestNestedShapeConfirm() throws {
+    let req = MemoryDecisionRequestWire(memoryId: "mem-decision-1", ownerPrincipal: owner, decision: "confirm")
+    let env = FridayEnvelope(msgId: "mem-dec-req", sentAt: 1000, message: .memoryDecisionRequest(req))
+      .withCorrelation("c1")
+    let json = String(decoding: try env.encodeJSON(), as: UTF8.self)
+
+    XCTAssertTrue(json.contains("\"kind\":\"MemoryDecisionRequest\""))
+    XCTAssertTrue(json.contains("\"request\":{"), "decision must NEST under request, not flatten: \(json)")
+    XCTAssertTrue(json.contains("\"memory_id\":\"mem-decision-1\""))
+    XCTAssertTrue(json.contains("\"decision\":\"confirm\""))
+    XCTAssertTrue(json.contains("\"owner_principal\":\"admin-001\""))
+
+    // Message object carries EXACTLY {kind, request}; the nested request carries EXACTLY the 3 fields
+    // (no auth_proof).
+    let messageObj = try messageObject(json)
+    XCTAssertEqual(Set(messageObj.keys), ["kind", "request"])
+    let request = try XCTUnwrap(messageObj["request"] as? [String: Any])
+    XCTAssertEqual(Set(request.keys), ["memory_id", "owner_principal", "decision"])
+
+    XCTAssertEqual(try FridayEnvelope.decodeJSON(Data(json.utf8)).message, .memoryDecisionRequest(req))
+  }
+
+  /// MS3: a `decision:"reject"` request round-trips (the only other valid token).
+  func testMS3_memoryDecisionRequestRejectRoundTrips() throws {
+    let req = MemoryDecisionRequestWire(memoryId: "mem-2", ownerPrincipal: owner, decision: "reject")
+    let env = FridayEnvelope(msgId: "m", sentAt: 1, message: .memoryDecisionRequest(req))
+    let json = String(decoding: try env.encodeJSON(), as: UTF8.self)
+    XCTAssertTrue(json.contains("\"decision\":\"reject\""))
+    XCTAssertEqual(try FridayEnvelope.decodeJSON(Data(json.utf8)).message, .memoryDecisionRequest(req))
+  }
+
+  // MARK: MS4 — MemoryDecisionResult decode (confirmed / blocked-with-blocker)
+
+  /// MS4: a `status:"confirmed"` result decodes — `recallable:true`, no blocker. Mirrors the Rust
+  /// vector at `lib.rs` ~2144.
+  func testMS4_memoryDecisionResultConfirmedDecodes() throws {
+    let json = """
+      {"schema_version":13,"msg_id":"r","sent_at":1,"message":{
+        "kind":"MemoryDecisionResult","result":{
+          "memory_id":"mem-1","state":"confirmed","status":"confirmed","recallable":true}}}
+      """
+    let env = try FridayEnvelope.decodeJSON(Data(json.utf8))
+    guard case .memoryDecisionResult(let r) = env.message else { return XCTFail("expected MemoryDecisionResult") }
+    XCTAssertEqual(r.status, "confirmed")
+    XCTAssertEqual(r.state, "confirmed")
+    XCTAssertTrue(r.recallable)
+    XCTAssertNil(r.blocker)
+  }
+
+  /// MS4 (the synthetic-id reality — see PR Layer-D note): a `status:"blocked"` result carries the
+  /// coarse `blocker` and `recallable:false`. This is the EXPECTED outcome today when the UI sends
+  /// the synthetic candidate id (the read projection has not yet surfaced the real memory_id), and
+  /// the result wrapper carries it so the UI renders the block HONESTLY (not a fake success).
+  func testMS4_memoryDecisionResultBlockedCarriesBlocker() throws {
+    let blocked = MemoryDecisionResultWire(
+      memoryId: "memory_candidate_mission_x_0", state: "unknown", status: "blocked",
+      blocker: "unknown_candidate", recallable: false)
+    let env = FridayEnvelope(msgId: "r", sentAt: 1, message: .memoryDecisionResult(blocked))
+    XCTAssertEqual(try FridayEnvelope.decodeJSON(try env.encodeJSON()).message, .memoryDecisionResult(blocked))
+    let json = String(decoding: try env.encodeJSON(), as: UTF8.self)
+    XCTAssertTrue(json.contains("\"result\":{"))
+    XCTAssertTrue(json.contains("\"blocker\":\"unknown_candidate\""))
+    XCTAssertTrue(json.contains("\"recallable\":false"))
+  }
+}

--- a/apps/macos/FridayRustClient/Tests/FridayRustClientTests/MissionSpineWriteWiringTests.swift
+++ b/apps/macos/FridayRustClient/Tests/FridayRustClientTests/MissionSpineWriteWiringTests.swift
@@ -1,0 +1,243 @@
+import XCTest
+@testable import FridayRustClient
+
+/// **Tier-2 mission-spine-write wiring tests** — drive `SealedWSWriteClient.submitMissionIntake` +
+/// `submitMemoryDecision` end-to-end over an IN-MEMORY transport that emulates the Rust
+/// `hub_agent_run_server`'s mission-spine arms: the cleartext preamble (server pubkey + 64-byte
+/// nonce), the SEALED session (the channel auth — NO per-request `auth_proof` for these messages),
+/// and a `MissionIntakeResult` / `MemoryDecisionResult` reply.
+///
+/// HONEST LABEL: WIRING-ONLY, NOT a crypto-parity proof (the emulated server seals with the SAME
+/// Swift primitives the client uses). The byte-parity is proven by the Rust-anchored
+/// `MissionSpineWriteKATTests`. This proves the CLIENT correctly sequences the handshake, frames the
+/// NO-auth_proof mission-spine request, settles on the first result, surfaces a typed `Error`
+/// fail-closed, and — critically — that a `status:"blocked"` memory result is a VALID receipt the
+/// client RETURNS (the caller renders the block honestly), NOT a thrown error. The live round-trip
+/// against the REAL Rust server is the deferred operator-gated AC.
+final class MissionSpineWriteWiringTests: XCTestCase {
+
+  enum SpineMode {
+    case intakeReady
+    case intakeNeedsClarification
+    case memoryConfirmed
+    case memoryBlocked         // the synthetic-candidate-id reality today
+    case serverError           // a typed Error frame
+  }
+
+  /// An in-memory transport playing the Rust mission-spine arms over the WRITE SESSION_AAD. It
+  /// VERIFIES the inbound carries NO auth_proof field (the session is the auth) and captures the
+  /// decoded request so the test can assert the wire body.
+  final class EmulatedSpineServerTransport: SealedWSTransport {
+    private let serverKeypair: FridayCrypto.DeviceKeypair
+    private let sessionNonce: [UInt8]
+    private let peerAllowlist: [[UInt8]]
+    private let mode: SpineMode
+
+    private var clientPub: [UInt8]?
+    private var sessionKey: [UInt8]?
+    private var upgraded = false
+    private var queuedFromServer: [[UInt8]] = []
+    private(set) var endedFailClosed = false
+    private(set) var receivedIntake: MissionIntakeRequestWire?
+    private(set) var receivedDecision: MemoryDecisionRequestWire?
+    /// Proves the inbound message object carried NO `auth_proof` (sealed session is the channel auth).
+    private(set) var sawAuthProof = false
+
+    init(serverKeypair: FridayCrypto.DeviceKeypair, sessionNonce: [UInt8],
+         peerAllowlist: [[UInt8]], mode: SpineMode) {
+      self.serverKeypair = serverKeypair
+      self.sessionNonce = sessionNonce
+      self.peerAllowlist = peerAllowlist
+      self.mode = mode
+    }
+
+    func writeFrame(_ payload: [UInt8]) throws {
+      if clientPub == nil {
+        guard peerAllowlist.contains(payload) else {
+          endedFailClosed = true
+          throw FridayWriteClientError.transport("peer pubkey not in allowlist")
+        }
+        clientPub = payload
+        queuedFromServer.append(serverKeypair.publicKey)
+        queuedFromServer.append(sessionNonce)
+      }
+    }
+
+    func readFrame() throws -> [UInt8] {
+      guard !queuedFromServer.isEmpty else { throw FridayWriteClientError.transport("no preamble frame queued") }
+      return queuedFromServer.removeFirst()
+    }
+
+    func upgrade() throws {
+      guard let clientPub else { throw FridayWriteClientError.transport("no client pubkey before upgrade") }
+      sessionKey = try serverKeypair.agree(peerPublicKey: clientPub)
+      upgraded = true
+    }
+
+    func sendMessage(_ body: [UInt8]) throws {
+      guard upgraded, let sessionKey else { throw FridayWriteClientError.transport("not upgraded") }
+      let plaintext = try FridayCrypto.open(
+        key: sessionKey, sealed: FridayCrypto.decodeSealed(body), aad: writeSessionAad)
+      // Inspect the raw JSON to PROVE no auth_proof rode the wire for these messages.
+      if let obj = try JSONSerialization.jsonObject(with: Data(plaintext)) as? [String: Any],
+         let msg = obj["message"] as? [String: Any],
+         let request = msg["request"] as? [String: Any],
+         request["auth_proof"] != nil {
+        sawAuthProof = true
+      }
+      let env = try FridayEnvelope.decodeJSON(Data(plaintext))
+      let reply: FridayMessage
+      switch env.message {
+      case .missionIntakeRequest(let req):
+        receivedIntake = req
+        switch mode {
+        case .serverError:
+          reply = .error(code: .internal, message: "intake failed")
+        case .intakeNeedsClarification:
+          reply = .missionIntakeResult(MissionIntakeResultWire(
+            fridayConversationId: req.fridayConversationId, missionId: req.missionId,
+            surfaceThreadId: req.surfaceThreadId, status: "needs_clarification",
+            createdOrReady: false,
+            clarificationQuestions: ["What is the deadline?"]))
+        default:
+          reply = .missionIntakeResult(MissionIntakeResultWire(
+            fridayConversationId: req.fridayConversationId, missionId: req.missionId,
+            workItemId: req.workItemId, surfaceThreadId: req.surfaceThreadId,
+            status: "ready", createdOrReady: true))
+        }
+      case .memoryDecisionRequest(let req):
+        receivedDecision = req
+        switch mode {
+        case .serverError:
+          reply = .error(code: .internal, message: "decision failed")
+        case .memoryBlocked:
+          reply = .memoryDecisionResult(MemoryDecisionResultWire(
+            memoryId: req.memoryId, state: "unknown", status: "blocked",
+            blocker: "unknown_candidate", recallable: false))
+        default:
+          reply = .memoryDecisionResult(MemoryDecisionResultWire(
+            memoryId: req.memoryId,
+            state: req.decision == "confirm" ? "confirmed" : "rejected",
+            status: req.decision == "confirm" ? "confirmed" : "rejected",
+            recallable: req.decision == "confirm"))
+        }
+      default:
+        throw FridayWriteClientError.transport("unexpected inbound on the spine session: \(env.msgId)")
+      }
+      let resp = FridayEnvelope(msgId: "spine-result", sentAt: 1_780_640_000_000, message: reply)
+        .withCorrelation(env.msgId)
+      queuedFromServer.append(try FridayCrypto.encodeSealed(FridayCrypto.seal(
+        key: sessionKey, plaintext: [UInt8](resp.encodeJSON()), aad: writeSessionAad)))
+    }
+
+    func recvMessage() throws -> [UInt8] {
+      guard !queuedFromServer.isEmpty else { throw FridayWriteClientError.transport("session ended (no response)") }
+      return queuedFromServer.removeFirst()
+    }
+  }
+
+  private let owner = "admin-001"
+
+  private func makeClient(mode: SpineMode, peerEnrolled: Bool = true)
+    throws -> (SealedWSWriteClient, EmulatedSpineServerTransport) {
+    let clientKp = try FridayCrypto.DeviceKeypair(secretBytes: try Hex.decode(B1KAT.k1Agree.clientSecret))
+    let serverKp = try FridayCrypto.DeviceKeypair(secretBytes: try Hex.decode(B1KAT.k1Agree.serverSecret))
+    let nonce = try Hex.decode(B1KAT.k3Auth.sessionNonce)
+    let transport = EmulatedSpineServerTransport(
+      serverKeypair: serverKp, sessionNonce: nonce,
+      peerAllowlist: peerEnrolled ? [clientKp.publicKey] : [serverKp.publicKey], mode: mode)
+    let client = SealedWSWriteClient(
+      keypair: clientKp, forwardedPrincipal: owner,
+      makeTransport: { transport }, now: { 1000 }, newRunId: { "run-x" })
+    return (client, transport)
+  }
+
+  private func sampleIntake() -> MissionIntakeRequestWire {
+    MissionIntakeRequestWire(
+      fridayConversationId: "fconv_desktop_1", ownerPrincipal: owner,
+      surfaceThreadId: "surface-desktop-1", surfaceKind: "desktop",
+      deliveryRoute: "desktop://hub-console/operations", visibilityPolicy: "compact",
+      missionId: "mission-desktop-1", workItemId: "work-desktop-1",
+      title: "Coordinate Friday work", intent: "keep one Mission across every surface",
+      lane: "deepseek")
+  }
+
+  // MARK: submitMissionIntake
+
+  func testSubmitMissionIntake_ready_returnsResultNoAuthProof() async throws {
+    let (client, transport) = try makeClient(mode: .intakeReady)
+    let result = try await client.submitMissionIntake(sampleIntake())
+    XCTAssertEqual(result.status, "ready")
+    XCTAssertEqual(result.missionId, "mission-desktop-1")
+    XCTAssertEqual(result.workItemId, "work-desktop-1")
+    XCTAssertTrue(result.createdOrReady)
+    // The server saw the exact body (owner_principal == admin-001), and NO auth_proof rode the wire.
+    XCTAssertEqual(transport.receivedIntake?.ownerPrincipal, owner)
+    XCTAssertEqual(transport.receivedIntake?.surfaceKind, "desktop")
+    XCTAssertFalse(transport.sawAuthProof, "the mission-spine request must carry NO auth_proof")
+  }
+
+  func testSubmitMissionIntake_needsClarification_carriesQuestions() async throws {
+    let (client, _) = try makeClient(mode: .intakeNeedsClarification)
+    let result = try await client.submitMissionIntake(sampleIntake())
+    XCTAssertEqual(result.status, "needs_clarification")
+    XCTAssertFalse(result.createdOrReady)
+    XCTAssertEqual(result.clarificationQuestions, ["What is the deadline?"])
+  }
+
+  func testSubmitMissionIntake_serverError_throwsServerError() async throws {
+    let (client, _) = try makeClient(mode: .serverError)
+    do {
+      _ = try await client.submitMissionIntake(sampleIntake())
+      XCTFail("a typed Error frame must throw")
+    } catch let err as FridayWriteClientError {
+      guard case .serverError(let code, _) = err else { return XCTFail("expected serverError, got \(err)") }
+      XCTAssertEqual(code, .internal)
+    }
+  }
+
+  func testSubmitMissionIntake_nonAllowlistedPeer_rejectedAtHandshake() async throws {
+    let (client, transport) = try makeClient(mode: .intakeReady, peerEnrolled: false)
+    do {
+      _ = try await client.submitMissionIntake(sampleIntake())
+      XCTFail("a non-allowlisted peer must be rejected at the handshake")
+    } catch {
+      XCTAssertTrue(transport.endedFailClosed)
+    }
+  }
+
+  // MARK: submitMemoryDecision
+
+  func testSubmitMemoryDecision_confirm_returnsConfirmedRecallable() async throws {
+    let (client, transport) = try makeClient(mode: .memoryConfirmed)
+    let result = try await client.submitMemoryDecision(
+      MemoryDecisionRequestWire(memoryId: "mem-1", ownerPrincipal: owner, decision: "confirm"))
+    XCTAssertEqual(result.status, "confirmed")
+    XCTAssertEqual(result.state, "confirmed")
+    XCTAssertTrue(result.recallable)
+    XCTAssertEqual(transport.receivedDecision?.decision, "confirm")
+    XCTAssertFalse(transport.sawAuthProof, "the memory-decision request must carry NO auth_proof")
+  }
+
+  /// THE synthetic-id reality (Layer-D prerequisite): a `status:"blocked"` is a VALID receipt the
+  /// client RETURNS (so the UI renders it honestly), NOT a thrown error.
+  func testSubmitMemoryDecision_blocked_isAReturnedReceiptNotAThrow() async throws {
+    let (client, _) = try makeClient(mode: .memoryBlocked)
+    let result = try await client.submitMemoryDecision(
+      MemoryDecisionRequestWire(memoryId: "memory_candidate_mission_x_0", ownerPrincipal: owner, decision: "confirm"))
+    XCTAssertEqual(result.status, "blocked")
+    XCTAssertEqual(result.blocker, "unknown_candidate")
+    XCTAssertFalse(result.recallable)
+  }
+
+  func testSubmitMemoryDecision_serverError_throwsServerError() async throws {
+    let (client, _) = try makeClient(mode: .serverError)
+    do {
+      _ = try await client.submitMemoryDecision(
+        MemoryDecisionRequestWire(memoryId: "mem-1", ownerPrincipal: owner, decision: "reject"))
+      XCTFail("a typed Error frame must throw")
+    } catch let err as FridayWriteClientError {
+      guard case .serverError = err else { return XCTFail("expected serverError, got \(err)") }
+    }
+  }
+}


### PR DESCRIPTION
## What

Builds the desktop **spine-WRITE** client (Lane-D entry-point-A) so a real operator-typed **MissionIntake** and a **MemoryDecision(confirm)** can drive the first organic loop through the Rust spine on `:48750` — mirroring the already-proven read-seam pattern, scoped entirely to `apps/macos/` (disjoint from Rust/TS).

## How (mirroring the wire shapes + identity)

**Protocol (`FridayRustClient`)**
- `WriteProtocol.swift` — 4 Codable wire structs byte-mirroring the Rust `friday_protocol` serde structs: `MissionIntake{Request,Result}Wire`, `MemoryDecision{Request,Result}Wire`. snake_case `CodingKeys`, `skip_serializing_if` optionals omitted when nil/empty, `includes_sensitive_context` **always** emitted (the server itself always serializes it), `decision ∈ {confirm,reject}`.
- `Protocol.swift` — 4 `FridayMessage` cases. **The mission-spine variants NEST the payload under `request`/`result`** (`{"kind":"MissionIntakeRequest","request":{…}}`) — the internally-tagged shape the read `WorkbenchProjection*` variants use, **NOT** the flattened `AgentRun*` `WriteKey` path (a prior FLAT shape "503'd every call" per the Rust round-trip test). Read-client exhaustive switch updated.
- `WriteClient.swift` — `submitMissionIntake` / `submitMemoryDecision` on `SealedWSWriteClient`. **Handshake-only auth — NO per-request `auth_proof`** (the sealed single-peer session IS the channel auth; the server binds the write to the authenticated `--owner`). Reuses the **WRITE session AAD** `friday:execrun:ws:s-c:agent-run-session:aad:v1` + the same seal/open framing. A `status:"blocked"` memory result is a **valid returned receipt** rendered honestly, not a thrown error.

**Live write factory (`FridayHubConsoleCore`)**
- `RealWriteClientFactory.swift` — `makeLiveWrite()` derives the keypair via `MasterKeyPeer.deriveKeypair()`, the **SAME enrolled master-derived peer** the live courier + read client use → single-peer satisfied automatically (NO enrollment, NO colliding 2nd peer). Targets `127.0.0.1:48750`, authenticates as `admin-001` (the server `--owner`, FIX-Q3b). Honest-unavailable on master-key failure (never an ephemeral key on the live path). Reuses the read side's port-parameterized `LoopbackSealedWSTransport`.

**UI (`FridayHubConsole`)**
- `OperationsOverviewViewModel` — optional `writeClient` collaborator (read contract stays a pure read); `WriteActionState` (ready/sent/confirmed/error); `submitIntake` + `decideMemory` drivers wiring `owner=admin-001` from config.
- `OperationsOverviewScreen` — a mission-intake **compose field** + per-candidate **confirm/reject** controls; honest pending/confirmed/error rendering (never upgrades a block to a ready look).
- App/Shell — LIVE-by-default write client (`nil` in mock/design mode); the connect happens only on submit (non-blocking at launch).

## AAD / identity used
- Write session AAD `friday:execrun:ws:s-c:agent-run-session:aad:v1` (domain-separated from the read AAD), schema_version 13.
- Single-peer identity = `MasterKeyPeer.deriveKeypair()` (the enrolled WRITE-allowlist peer); `forwardedPrincipal`/body `owner_principal` = `admin-001`.

## Discipline
- No-degrade; **default honest-unavailable** against a dark/un-flipped server.
- **NO enrollment performed; NO live prod connect performed** — that is the coordinator/prod step.
- The live `:48750` round-trip is the **deferred operator-gated AC**; this PR proves the seam with offline byte-parity KATs + wiring tests + view-model tests.

## Known prerequisite (Layer-D, cross-team Rust)
The read projection surfaces a **synthetic** `memory_candidate_<missionId>_<index>` id, so a confirm returns `status:"blocked"`/`unknown_candidate` until the projection surfaces the **durable `memory_item` row id**. The control is wired end-to-end and renders the block honestly today; a real confirm closes once that Rust-side projection change lands.

## Tests (verbatim summary)
- `FridayRustClient`: **59 tests, 0 failures** — incl. **9** `MissionSpineWriteKATTests` + **7** `MissionSpineWriteWiringTests`. `swift build` clean.
- `FridayHubConsole`: **30 tests, 0 failures** — incl. the spine-write view-model + factory tests. `swift build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)