### PR TITLE
[codex] Align Codex proof audit timing with ledger receipts

### DIFF
--- a/scripts/diagnostics/friday-observe-wrapper-d8-audit.sh
+++ b/scripts/diagnostics/friday-observe-wrapper-d8-audit.sh
@@ -413,12 +413,7 @@ unproved_linked_session_runs="$(
         l.friday_session_id AS friday_session_id,
         e.provider AS provider,
         ledger.run_id AS run_id,
-        MAX(
-          CASE
-            WHEN e.observed_at >= ledger.created_at THEN e.observed_at
-            ELSE ledger.created_at
-          END
-        ) AS evidence_at
+        MAX(ledger.created_at) AS ledger_created_at
       FROM provider_session_link l
       JOIN provider_session_event e
         ON e.friday_session_id = l.friday_session_id
@@ -451,7 +446,7 @@ unproved_linked_session_runs="$(
       WHERE (w.lane = r.provider OR w.target_provider_or_agent = r.provider)
         AND w.status = 'completed_with_proof'
         AND w.updated_at_ms >= ${SINCE_MS}
-        AND w.updated_at_ms >= r.evidence_at
+        AND w.updated_at_ms >= r.ledger_created_at
     );
   "
 )"
@@ -611,7 +606,7 @@ last_n_claim_bound_process_proved_sessions="$(
         n.provider AS provider,
         n.seen_at AS seen_at,
         ledger.run_id AS run_id,
-        MAX(e.observed_at, ledger.created_at) AS evidence_at
+        ledger.created_at AS ledger_created_at
       FROM last_n n
       JOIN provider_session_event e
         ON e.friday_session_id = n.friday_session_id
@@ -639,7 +634,7 @@ last_n_claim_bound_process_proved_sessions="$(
         ON (w.lane = r.provider OR w.target_provider_or_agent = r.provider)
        AND w.status = 'completed_with_proof'
        AND w.updated_at_ms >= ${SINCE_MS}
-       AND w.updated_at_ms >= r.evidence_at
+       AND w.updated_at_ms >= r.ledger_created_at
       JOIN json_each(w.proof_receipts) proof
         ON proof.value = 'friday://agent-run/' || r.run_id
     )
@@ -799,7 +794,7 @@ last_n_completed_proof_sessions="$(
         n.friday_session_id AS friday_session_id,
         n.provider AS provider,
         ledger.run_id AS run_id,
-        MAX(e.observed_at, ledger.created_at) AS evidence_at
+        ledger.created_at AS ledger_created_at
       FROM last_n n
       JOIN provider_session_event e
         ON e.friday_session_id = n.friday_session_id
@@ -822,7 +817,7 @@ last_n_completed_proof_sessions="$(
       ON (w.lane = r.provider OR w.target_provider_or_agent = r.provider)
      AND w.status = 'completed_with_proof'
      AND w.updated_at_ms >= ${SINCE_MS}
-     AND w.updated_at_ms >= r.evidence_at
+     AND w.updated_at_ms >= r.ledger_created_at
     JOIN json_each(w.proof_receipts) proof
       ON proof.value = 'friday://agent-run/' || r.run_id;
   "
@@ -874,7 +869,7 @@ last_n_completed_proof_work_items="$(
         n.friday_session_id AS friday_session_id,
         n.provider AS provider,
         ledger.run_id AS run_id,
-        MAX(e.observed_at, ledger.created_at) AS evidence_at
+        ledger.created_at AS ledger_created_at
       FROM last_n n
       JOIN provider_session_event e
         ON e.friday_session_id = n.friday_session_id
@@ -897,7 +892,7 @@ last_n_completed_proof_work_items="$(
       ON (w.lane = r.provider OR w.target_provider_or_agent = r.provider)
      AND w.status = 'completed_with_proof'
      AND w.updated_at_ms >= ${SINCE_MS}
-     AND w.updated_at_ms >= r.evidence_at
+     AND w.updated_at_ms >= r.ledger_created_at
     JOIN json_each(w.proof_receipts) proof
       ON proof.value = 'friday://agent-run/' || r.run_id;
   "
@@ -949,7 +944,7 @@ multi_session_proof_work_items="$(
         n.friday_session_id AS friday_session_id,
         n.provider AS provider,
         ledger.run_id AS run_id,
-        MAX(e.observed_at, ledger.created_at) AS evidence_at
+        ledger.created_at AS ledger_created_at
       FROM last_n n
       JOIN provider_session_event e
         ON e.friday_session_id = n.friday_session_id
@@ -975,7 +970,7 @@ multi_session_proof_work_items="$(
         ON (w.lane = r.provider OR w.target_provider_or_agent = r.provider)
        AND w.status = 'completed_with_proof'
        AND w.updated_at_ms >= ${SINCE_MS}
-       AND w.updated_at_ms >= r.evidence_at
+       AND w.updated_at_ms >= r.ledger_created_at
       JOIN json_each(w.proof_receipts) proof
         ON proof.value = 'friday://agent-run/' || r.run_id
     )
@@ -1035,7 +1030,7 @@ last_n_surface_bound_proof_sessions="$(
         n.friday_session_id AS friday_session_id,
         n.provider AS provider,
         ledger.run_id AS run_id,
-        MAX(e.observed_at, ledger.created_at) AS evidence_at
+        ledger.created_at AS ledger_created_at
       FROM last_n n
       JOIN provider_session_event e
         ON e.friday_session_id = n.friday_session_id
@@ -1058,7 +1053,7 @@ last_n_surface_bound_proof_sessions="$(
       ON (w.lane = r.provider OR w.target_provider_or_agent = r.provider)
      AND w.status = 'completed_with_proof'
      AND w.updated_at_ms >= ${SINCE_MS}
-     AND w.updated_at_ms >= r.evidence_at
+     AND w.updated_at_ms >= r.ledger_created_at
     JOIN json_each(w.proof_receipts) proof
       ON proof.value = 'friday://agent-run/' || r.run_id
     JOIN mission m
@@ -1082,12 +1077,7 @@ surface_unbound_proof_session_runs="$(
         l.friday_session_id AS friday_session_id,
         e.provider AS provider,
         ledger.run_id AS run_id,
-        MAX(
-          CASE
-            WHEN e.observed_at >= ledger.created_at THEN e.observed_at
-            ELSE ledger.created_at
-          END
-        ) AS evidence_at
+        MAX(ledger.created_at) AS ledger_created_at
       FROM provider_session_link l
       JOIN provider_session_event e
         ON e.friday_session_id = l.friday_session_id
@@ -1120,7 +1110,7 @@ surface_unbound_proof_session_runs="$(
       WHERE (w.lane = r.provider OR w.target_provider_or_agent = r.provider)
         AND w.status = 'completed_with_proof'
         AND w.updated_at_ms >= ${SINCE_MS}
-        AND w.updated_at_ms >= r.evidence_at
+        AND w.updated_at_ms >= r.ledger_created_at
     )
     AND NOT EXISTS (
       SELECT 1
@@ -1141,7 +1131,7 @@ surface_unbound_proof_session_runs="$(
       WHERE (w.lane = r.provider OR w.target_provider_or_agent = r.provider)
         AND w.status = 'completed_with_proof'
         AND w.updated_at_ms >= ${SINCE_MS}
-        AND w.updated_at_ms >= r.evidence_at
+        AND w.updated_at_ms >= r.ledger_created_at
     );
   "
 )"

--- a/scripts/ops/friday-codex-mission-proof-of-life.sh
+++ b/scripts/ops/friday-codex-mission-proof-of-life.sh
@@ -609,7 +609,7 @@ while [ "$(date +%s)" -le "${deadline}" ]; do
       AND w.lane = 'codex'
       AND COALESCE(w.target_provider_or_agent,'') = 'codex'
       AND w.status = 'completed_with_proof'
-      AND w.updated_at_ms >= MAX(event.observed_at, ledger.created_at);
+      AND w.updated_at_ms >= ledger.created_at;
   ")"
   WORK_ITEM_CLAIM_BOUND_PROCESS_PROOF="$(sql_count "this completed codex work item with claim-bound process proof" "
     WITH matching_proofs AS (
@@ -621,10 +621,7 @@ while [ "$(date +%s)" -le "${deadline}" ]; do
             THEN COALESCE(link.last_provider_seen_at,0)
           ELSE event.observed_at
         END AS seen_at,
-        CASE
-          WHEN event.observed_at >= ledger.created_at THEN event.observed_at
-          ELSE ledger.created_at
-        END AS evidence_at
+        ledger.created_at AS ledger_created_at
       FROM work_item w
       JOIN json_each(w.proof_receipts) proof
         ON proof.value IS NOT NULL
@@ -648,10 +645,7 @@ while [ "$(date +%s)" -le "${deadline}" ]; do
         AND w.lane = 'codex'
         AND COALESCE(w.target_provider_or_agent,'') = 'codex'
         AND w.status = 'completed_with_proof'
-        AND w.updated_at_ms >= CASE
-          WHEN event.observed_at >= ledger.created_at THEN event.observed_at
-          ELSE ledger.created_at
-        END
+        AND w.updated_at_ms >= ledger.created_at
     )
     SELECT COUNT(DISTINCT p.friday_session_id)
     FROM matching_proofs p
@@ -694,12 +688,7 @@ while [ "$(date +%s)" -le "${deadline}" ]; do
       SELECT
         event.friday_session_id AS friday_session_id,
         ledger.run_id AS run_id,
-        MAX(
-          CASE
-            WHEN event.observed_at >= ledger.created_at THEN event.observed_at
-            ELSE ledger.created_at
-          END
-        ) AS evidence_at
+        MAX(ledger.created_at) AS ledger_created_at
       FROM provider_session_link link
       JOIN provider_session_event event
         ON event.friday_session_id = link.friday_session_id
@@ -728,7 +717,7 @@ while [ "$(date +%s)" -le "${deadline}" ]; do
       WHERE (w.lane = 'codex' OR w.target_provider_or_agent = 'codex')
         AND w.status = 'completed_with_proof'
         AND w.updated_at_ms >= ${STARTED_AT_MS}
-        AND w.updated_at_ms >= r.evidence_at
+        AND w.updated_at_ms >= r.ledger_created_at
     );
   ")"
   WORK_STATUS="$(sql_scalar "SELECT COALESCE(status, '') FROM work_item WHERE work_item_id='${WORK_ITEM_ID}' LIMIT 1;")"

--- a/test/unit/scripts/ops/friday-codex-mission-proof-gates.test.ts
+++ b/test/unit/scripts/ops/friday-codex-mission-proof-gates.test.ts
@@ -139,6 +139,9 @@ function createD8FixtureDb(
     addExtraMatchingWorkItemForFirstRun?: boolean;
     addUnrelatedCompletedWorkItem?: boolean;
     addUnqualifiedLinkedSession?: boolean;
+    eventObservedAt?: number;
+    lastProviderSeenAt?: number;
+    ledgerCreatedAt?: number;
     processKind?: string;
     processMatchedClaimId?: string | null;
     processObservedAt?: number;
@@ -191,6 +194,9 @@ function createD8FixtureDb(
   const workspaceClaimWorkItemId = options.workspaceClaimWorkItemId ?? "work-1";
   const workItemProvider = options.workItemProvider ?? provider;
   const workItemUpdatedAt = options.workItemUpdatedAt ?? 1000;
+  const eventObservedAt = options.eventObservedAt ?? 1000;
+  const lastProviderSeenAt = options.lastProviderSeenAt ?? 1000;
+  const ledgerCreatedAt = options.ledgerCreatedAt ?? 1000;
   const db = new Database(dbPath);
   db.exec(`
     CREATE TABLE provider_session_link (
@@ -252,18 +258,18 @@ function createD8FixtureDb(
   db.prepare(
     `INSERT INTO provider_session_link
       (friday_session_id, provider, sync_mode, last_provider_seen_at)
-      VALUES (?, ?, ?, 1000)`,
-  ).run(sessionId, provider, syncMode);
+      VALUES (?, ?, ?, ?)`,
+  ).run(sessionId, provider, syncMode, lastProviderSeenAt);
   db.prepare(
     `INSERT INTO provider_session_event
       (friday_session_id, provider_event_id, provider, observed_at, token_ledger_ref)
-      VALUES (?, 'event-1', ?, 1000, 'ledger-1')`,
-  ).run(sessionId, provider);
+      VALUES (?, 'event-1', ?, ?, 'ledger-1')`,
+  ).run(sessionId, provider, eventObservedAt);
   db.prepare(
     `INSERT INTO token_ledger
       (ledger_id, provider_kind, fallback, total_tokens, created_at, run_id)
-      VALUES ('ledger-1', ?, 0, 12, 1000, 'run-1')`,
-  ).run(ledgerProviderKind);
+      VALUES ('ledger-1', ?, 0, 12, ?, 'run-1')`,
+  ).run(ledgerProviderKind, ledgerCreatedAt);
   db.prepare(
     `INSERT INTO mission
       (mission_id, friday_conversation_id, created_at_ms)
@@ -455,6 +461,27 @@ describe("Codex mission proof gates", () => {
     expect(result.stdout).toContain("PASS - D8 evidence is present");
   });
 
+  it("D8 audit accepts provider events ledger-linked milliseconds after WorkItem completion", async () => {
+    const tempRoot = makeTempRoot();
+    const dbPath = join(tempRoot, "d8-event-after-workitem.sqlite");
+    createD8FixtureDb(dbPath, "friday://agent-run/run-1", {
+      eventObservedAt: 1016,
+      lastProviderSeenAt: 1016,
+      ledgerCreatedAt: 1000,
+      workItemUpdatedAt: 1000,
+    });
+
+    const result = await runD8Audit(dbPath);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("last_1_completed_proof_sessions=1");
+    expect(result.stdout).toContain(
+      "last_1_claim_bound_process_proved_sessions=1",
+    );
+    expect(result.stdout).toContain("unproved_linked_session_runs=0");
+    expect(result.stdout).toContain("PASS - D8 evidence is present");
+  });
+
   it("D8 audit rejects completed WorkItem proof without a bound Mission SurfaceThread", async () => {
     const tempRoot = makeTempRoot();
     const dbPath = join(tempRoot, "d8-proof-without-surface-thread.sqlite");
@@ -527,7 +554,7 @@ describe("Codex mission proof gates", () => {
     );
   });
 
-  it("D8 audit rejects completed WorkItem proof recorded before provider evidence", async () => {
+  it("D8 audit rejects completed WorkItem proof recorded before ledger creation", async () => {
     const tempRoot = makeTempRoot();
     const dbPath = join(tempRoot, "d8-proof-before-evidence.sqlite");
     createD8FixtureDb(dbPath, "friday://agent-run/run-1", {
@@ -1006,9 +1033,7 @@ describe("Codex mission proof gates", () => {
     expect(proofSource).toContain("WORK_ITEM_CLAIM_BOUND_PROCESS_PROOF");
     expect(proofSource).toContain("WORK_ITEM_SURFACE_BOUND_PROOF");
     expect(proofSource).toContain("UNPROVED_LINKED_SESSION_RUNS");
-    expect(proofSource).toContain(
-      "w.updated_at_ms >= MAX(event.observed_at, ledger.created_at)",
-    );
+    expect(proofSource).toContain("w.updated_at_ms >= ledger.created_at");
     expect(proofSource).toContain(
       "surface.surface_thread_id = '${SURFACE_THREAD_ID}'",
     );
@@ -1089,9 +1114,9 @@ describe("Codex mission proof gates", () => {
       "w.lane = r.provider OR w.target_provider_or_agent = r.provider",
     );
     expect(d8Source).toContain(
-      "MAX(e.observed_at, ledger.created_at) AS evidence_at",
+      "ledger.created_at AS ledger_created_at",
     );
-    expect(d8Source).toContain("w.updated_at_ms >= r.evidence_at");
+    expect(d8Source).toContain("w.updated_at_ms >= r.ledger_created_at");
     expect(d8Source).toContain("rust_agent_run_ws_port_ok");
     expect(d8Source).toContain(
       "Rust agent-run WS port did not accept a local TCP connection",


### PR DESCRIPTION
## Summary
- Treat a completed WorkItem proof receipt as time-bound to the matching token ledger row, not to later provider event backfill timestamps.
- Keep the strong proof requirements: run-bound receipt, non-fallback Codex ledger, linked provider_session_event, claim-bound process observation, and Mission SurfaceThread binding.
- Mirror the timing fix across the D8 observe-wrapper audit and add a fixture for provider events arriving milliseconds after WorkItem completion.

## Root Cause
After #808, the real keychain proof produced a completed Codex WorkItem, token ledger, provider_session_events, token_ledger_ref links, a claim-bound Codex app-server process observation, and a bound mobile surface. The proof script still returned partial because it required `work_item.updated_at_ms >= provider_session_event.observed_at`. In the real DB, the WorkItem proof receipt and ledger row landed at the same millisecond, while provider events were backfilled 1-16ms later for the same ledger/run.

## Validation
- `bash -n scripts/ops/friday-codex-mission-proof-of-life.sh && bash -n scripts/diagnostics/friday-observe-wrapper-d8-audit.sh`
- `npm test -- --run test/unit/scripts/ops/friday-codex-mission-proof-gates.test.ts`
- `FRIDAY_CODEX_MISSION_PROOF_PREFLIGHT_ONLY=1 scripts/ops/friday-codex-mission-proof-of-life.sh`
- `git diff --check`
- Real DB read-only D8 replay for mission `codex-proof-mission-30924383-baa6-44d0-81bb-1ddef88e82ed` with `FRIDAY_D8_AUDIT_SINCE_MS=1781683564684` returned PASS: completed proof sessions=1, claim-bound process sessions=1, surface-bound proof sessions=1, unproved linked session runs=0.
- Advisor audit PASS (Newton): no blocking findings; false-pass risk remains contained by run-bound receipt + ledger/event/process/surface constraints.