### PR TITLE
Add outcome-checked work item proofs

### DIFF
--- a/rust-core/crates/friday-core/src/lib.rs
+++ b/rust-core/crates/friday-core/src/lib.rs
@@ -59,12 +59,14 @@ pub use memory::{
     PassportItemKind, RedactedPassportItem, MEMORY_REVIEW_PRIORITY,
 };
 pub use mission::{
-    find_duplicate_mission, find_duplicate_work_item, requires_context_passport,
+    find_duplicate_mission, find_duplicate_work_item, outcome_checked_proof_enabled,
+    outcome_checked_proof_enabled_from, parse_outcome_receipt, requires_context_passport,
     validate_friday_conversation_id, ApprovalState, FridayConversation, HandoffJudgmentMemory,
     Mission, MissionLink, MissionLinkKind, MissionSpineError, MissionStatus,
-    MissionSurfaceProjection, RouteDecisionCard, RouteDecisionProjection, SurfaceEvent,
-    SurfaceEventKind, SurfaceKind, SurfaceThread, TruthStatus, VisibilityPolicy, WorkItem,
-    WorkItemStatus, WorkLane,
+    MissionSurfaceProjection, OutcomeProofReceipt, ProofRequirementKind, ProofRequirementSpec,
+    RouteDecisionCard, RouteDecisionProjection, SurfaceEvent, SurfaceEventKind, SurfaceKind,
+    SurfaceThread, TruthStatus, VisibilityPolicy, WorkItem, WorkItemStatus, WorkLane,
+    OUTCOME_CHECKED_PROOF_FLAG,
 };
 pub use offline::OfflineQueueState;
 pub use pairing::{

--- a/rust-core/crates/friday-core/src/mission.rs
+++ b/rust-core/crates/friday-core/src/mission.rs
@@ -494,6 +494,158 @@ impl HandoffJudgmentMemory {
     }
 }
 
+pub const OUTCOME_CHECKED_PROOF_FLAG: &str = "FRIDAY_OUTCOME_CHECKED_PROOF";
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ProofRequirementKind {
+    AnswerProduced,
+    ToolsExecuted,
+    AnswerFingerprintMatches,
+    TestsPassed,
+    ServerBooted,
+    ArtifactDiff,
+    FileContentMatches,
+}
+
+impl ProofRequirementKind {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            ProofRequirementKind::AnswerProduced => "AnswerProduced",
+            ProofRequirementKind::ToolsExecuted => "ToolsExecuted",
+            ProofRequirementKind::AnswerFingerprintMatches => "AnswerFingerprintMatches",
+            ProofRequirementKind::TestsPassed => "TestsPassed",
+            ProofRequirementKind::ServerBooted => "ServerBooted",
+            ProofRequirementKind::ArtifactDiff => "ArtifactDiff",
+            ProofRequirementKind::FileContentMatches => "FileContentMatches",
+        }
+    }
+
+    pub fn parse(value: &str) -> Option<Self> {
+        match value.trim() {
+            "AnswerProduced" => Some(ProofRequirementKind::AnswerProduced),
+            "ToolsExecuted" => Some(ProofRequirementKind::ToolsExecuted),
+            "AnswerFingerprintMatches" => Some(ProofRequirementKind::AnswerFingerprintMatches),
+            "TestsPassed" => Some(ProofRequirementKind::TestsPassed),
+            "ServerBooted" => Some(ProofRequirementKind::ServerBooted),
+            "ArtifactDiff" => Some(ProofRequirementKind::ArtifactDiff),
+            "FileContentMatches" => Some(ProofRequirementKind::FileContentMatches),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ProofRequirementSpec {
+    pub kind: ProofRequirementKind,
+    pub expectation: String,
+}
+
+impl ProofRequirementSpec {
+    pub fn parse(value: &str) -> Option<Self> {
+        let body = value.trim().strip_prefix("outcome:")?;
+        let (kind, expectation) = body.split_once(':')?;
+        let kind = ProofRequirementKind::parse(kind)?;
+        let expectation = expectation.trim();
+        if expectation.is_empty() {
+            return None;
+        }
+        Some(Self {
+            kind,
+            expectation: expectation.to_string(),
+        })
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct OutcomeProofReceipt {
+    pub kind: ProofRequirementKind,
+    pub run_id: String,
+    pub signal: String,
+}
+
+pub fn parse_outcome_receipt(value: &str) -> Option<OutcomeProofReceipt> {
+    let body = value.trim().strip_prefix("proof://outcome/")?;
+    let (path, query) = body.split_once('?')?;
+    let (kind, run_id) = path.split_once('/')?;
+    let kind = ProofRequirementKind::parse(kind)?;
+    let run_id = run_id.trim();
+    if run_id.is_empty() {
+        return None;
+    }
+    let signal = query
+        .split('&')
+        .find_map(|part| part.strip_prefix("signal="))?
+        .trim();
+    if signal.is_empty() {
+        return None;
+    }
+    Some(OutcomeProofReceipt {
+        kind,
+        run_id: run_id.to_string(),
+        signal: signal.to_string(),
+    })
+}
+
+pub fn outcome_checked_proof_enabled_from(value: Option<&str>) -> bool {
+    matches!(value.map(str::trim), Some("1"))
+}
+
+pub fn outcome_checked_proof_enabled() -> bool {
+    match std::env::var(OUTCOME_CHECKED_PROOF_FLAG) {
+        Ok(value) => outcome_checked_proof_enabled_from(Some(&value)),
+        Err(_) => false,
+    }
+}
+
+fn numeric_signal(value: &str) -> Option<i64> {
+    let value = value.trim();
+    if let Ok(parsed) = value.parse::<i64>() {
+        return Some(parsed);
+    }
+    let suffix: String = value
+        .chars()
+        .rev()
+        .take_while(|ch| ch.is_ascii_digit())
+        .collect::<String>()
+        .chars()
+        .rev()
+        .collect();
+    if suffix.is_empty() {
+        None
+    } else {
+        suffix.parse::<i64>().ok()
+    }
+}
+
+fn outcome_signal_satisfies(expectation: &str, signal: &str) -> bool {
+    let expectation = expectation.trim();
+    let signal = signal.trim();
+    if signal.is_empty() {
+        return false;
+    }
+    if matches!(expectation, "*" | "nonempty" | "present") {
+        return true;
+    }
+    if let Some(expected) = expectation.strip_prefix(">=") {
+        let expected = expected.trim().parse::<i64>().ok();
+        let actual = numeric_signal(signal);
+        return matches!((actual, expected), (Some(actual), Some(expected)) if actual >= expected);
+    }
+    if let Some(expected) = expectation.strip_prefix('>') {
+        let expected = expected.trim().parse::<i64>().ok();
+        let actual = numeric_signal(signal);
+        return matches!((actual, expected), (Some(actual), Some(expected)) if actual > expected);
+    }
+    for op in ["==", "="] {
+        if let Some(expected) = expectation.strip_prefix(op) {
+            let expected = expected.trim().parse::<i64>().ok();
+            let actual = numeric_signal(signal);
+            return matches!((actual, expected), (Some(actual), Some(expected)) if actual == expected);
+        }
+    }
+    signal == expectation
+}
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct WorkItem {
     pub work_item_id: String,
@@ -531,6 +683,38 @@ impl WorkItem {
     /// at least one proof receipt.
     pub fn completion_is_proven(&self) -> bool {
         self.status == WorkItemStatus::CompletedWithProof && !self.proof_receipts.is_empty()
+    }
+
+    pub fn outcome_requirement_specs(&self) -> Vec<ProofRequirementSpec> {
+        self.proof_requirements
+            .iter()
+            .filter_map(|requirement| ProofRequirementSpec::parse(requirement))
+            .collect()
+    }
+
+    pub fn has_outcome_proof_requirements(&self) -> bool {
+        self.proof_requirements
+            .iter()
+            .any(|requirement| ProofRequirementSpec::parse(requirement).is_some())
+    }
+
+    pub fn completion_outcome_is_proven(&self) -> bool {
+        if !self.completion_is_proven() {
+            return false;
+        }
+        let requirements = self.outcome_requirement_specs();
+        if requirements.is_empty() {
+            return true;
+        }
+        requirements.iter().all(|requirement| {
+            self.proof_receipts.iter().any(|receipt| {
+                let Some(receipt) = parse_outcome_receipt(receipt) else {
+                    return false;
+                };
+                receipt.kind == requirement.kind
+                    && outcome_signal_satisfies(&requirement.expectation, &receipt.signal)
+            })
+        })
     }
 }
 
@@ -1157,5 +1341,56 @@ mod tests {
         assert!(done.completion_is_proven());
         done.proof_receipts.clear();
         assert!(!done.completion_is_proven());
+    }
+
+    #[test]
+    fn outcome_specs_parse_and_require_matching_typed_signal() {
+        let spec = ProofRequirementSpec::parse("outcome:ToolsExecuted:>=1").unwrap();
+        assert_eq!(spec.kind, ProofRequirementKind::ToolsExecuted);
+        assert_eq!(spec.expectation, ">=1");
+        assert!(ProofRequirementSpec::parse("provider completion receipt").is_none());
+
+        let receipt =
+            parse_outcome_receipt("proof://outcome/ToolsExecuted/run-1?signal=executed_tools=2")
+                .unwrap();
+        assert_eq!(receipt.kind, ProofRequirementKind::ToolsExecuted);
+        assert_eq!(receipt.run_id, "run-1");
+        assert_eq!(receipt.signal, "executed_tools=2");
+        assert!(parse_outcome_receipt("proof://outcome/ToolsExecuted/run-1").is_none());
+        assert!(parse_outcome_receipt("proof://outcome/ToolsExecuted/run-1?signal=").is_none());
+
+        let mut done = work("wi-outcome", WorkItemStatus::CompletedWithProof);
+        done.proof_requirements = vec!["outcome:ToolsExecuted:>=1".into()];
+        done.proof_receipts =
+            vec!["proof://outcome/ToolsExecuted/run-1?signal=executed_tools=2".into()];
+        assert!(done.has_outcome_proof_requirements());
+        assert!(done.completion_outcome_is_proven());
+
+        done.proof_receipts = vec!["proof://outcome/ToolsExecuted/run-1?signal=0".into()];
+        assert!(!done.completion_outcome_is_proven());
+
+        done.proof_receipts = vec!["proof://provider-free-text".into()];
+        assert!(!done.completion_outcome_is_proven());
+
+        done.proof_requirements = vec![
+            "outcome:ToolsExecuted:>=1".into(),
+            "outcome:TestsPassed:>=1".into(),
+        ];
+        done.proof_receipts =
+            vec!["proof://outcome/ToolsExecuted/run-1?signal=executed_tools=2".into()];
+        assert!(!done.completion_outcome_is_proven());
+        done.proof_receipts
+            .push("proof://outcome/TestsPassed/run-1?signal=passed_tests=12".into());
+        assert!(done.completion_outcome_is_proven());
+    }
+
+    #[test]
+    fn legacy_requirements_remain_floor_only_for_outcome_predicate() {
+        let done = work("wi-legacy", WorkItemStatus::CompletedWithProof);
+        assert!(!done.has_outcome_proof_requirements());
+        assert!(done.completion_outcome_is_proven());
+        assert!(outcome_checked_proof_enabled_from(Some("1")));
+        assert!(!outcome_checked_proof_enabled_from(Some("true")));
+        assert!(!outcome_checked_proof_enabled_from(None));
     }
 }

--- a/rust-core/crates/friday-hub/src/hub_server.rs
+++ b/rust-core/crates/friday-hub/src/hub_server.rs
@@ -870,6 +870,17 @@ pub fn work_item_status_result_for_db(
                 "work item lifecycle blocked: target WorkItem is not owned by the authenticated owner",
             );
         }
+        if next_status == friday_core::WorkItemStatus::CompletedWithProof
+            && friday_core::outcome_checked_proof_enabled()
+            && work_item.has_outcome_proof_requirements()
+        {
+            return mission_intake_error(
+                msg_id,
+                now_ms,
+                ErrorCode::Internal,
+                "work item lifecycle blocked: outcome-checked completion requires a server-minted outcome receipt; WorkItemStatus WS ingress cannot accept client-supplied outcome proof",
+            );
+        }
     }
 
     // A blank proof_receipt is normalized to `None` BEFORE the call so the storage layer's
@@ -5351,6 +5362,46 @@ mod tests {
                 "Mission-bound ask leaked {forbidden}: {debug}"
             );
         }
+    }
+
+    #[test]
+    fn work_item_status_ws_ingress_rejects_client_supplied_outcome_proof_when_flag_on() {
+        let _guard = crate::test_env::EnvVarGuard::set("FRIDAY_OUTCOME_CHECKED_PROOF", "1");
+        let db_path = tmp_db();
+        let db = Db::open_hub(&db_path).unwrap();
+        seed_mission_ask(&db);
+        let mut work = db.get_work_item("work-hub-ask").unwrap().unwrap();
+        work.status = WorkItemStatus::ProviderWaiting;
+        work.proof_requirements = vec!["outcome:ToolsExecuted:>=1".into()];
+        db.upsert_work_item(&work).unwrap();
+
+        let response = work_item_status_result_for_db(
+            &db,
+            "ws-outcome-client-proof",
+            WorkItemStatusRequestWire {
+                work_item_id: "work-hub-ask".into(),
+                target_status: "completed_with_proof".into(),
+                actor_ref: "client:mobile".into(),
+                reason: "client claims outcome".into(),
+                proof_receipt: Some(
+                    "proof://outcome/ToolsExecuted/run-1?signal=executed_tools=1".into(),
+                ),
+            },
+            Some("owner-1"),
+            1_700_000_100_650,
+        );
+        let Message::Error { code, message } = response.message else {
+            panic!("expected outcome proof ingress block, got {response:?}");
+        };
+        assert_eq!(code, ErrorCode::Internal);
+        assert!(message.contains("server-minted outcome receipt"));
+
+        let stored = db.get_work_item("work-hub-ask").unwrap().unwrap();
+        assert_eq!(stored.status, WorkItemStatus::ProviderWaiting);
+        assert!(
+            stored.proof_receipts.is_empty(),
+            "client-supplied outcome receipt must not persist"
+        );
     }
 
     #[test]

--- a/rust-core/crates/friday-hub/src/lib.rs
+++ b/rust-core/crates/friday-hub/src/lib.rs
@@ -29,6 +29,41 @@
 //! `friday-ffi` (phone) must NOT. That compile-time no-provider-key-on-phone
 //! boundary is asserted by `friday-arch-tests`.
 
+#[cfg(test)]
+pub(crate) mod test_env {
+    use std::sync::{Mutex, MutexGuard};
+
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    pub(crate) struct EnvVarGuard {
+        key: &'static str,
+        previous: Option<String>,
+        _lock: MutexGuard<'static, ()>,
+    }
+
+    impl EnvVarGuard {
+        pub(crate) fn set(key: &'static str, value: &str) -> Self {
+            let lock = ENV_LOCK.lock().unwrap_or_else(|poison| poison.into_inner());
+            let previous = std::env::var(key).ok();
+            std::env::set_var(key, value);
+            Self {
+                key,
+                previous,
+                _lock: lock,
+            }
+        }
+    }
+
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            match &self.previous {
+                Some(value) => std::env::set_var(self.key, value),
+                None => std::env::remove_var(self.key),
+            }
+        }
+    }
+}
+
 /// UNW-003 — dynamic provider routing (which provider/model answers a request).
 /// Routing decides *who answers*; it has zero authority over tool-call
 /// classification, which stays the trusted [`build_request`]/`trusted_classify`

--- a/rust-core/crates/friday-hub/src/mission_preflight.rs
+++ b/rust-core/crates/friday-hub/src/mission_preflight.rs
@@ -9,8 +9,8 @@
 
 use friday_core::MemoryState;
 use friday_core::{
-    requires_context_passport, ApprovalState, FridayConversation, Mission, MissionLink,
-    MissionLinkKind, SurfaceThread, WorkItem, WorkItemStatus, WorkspaceClaim,
+    outcome_checked_proof_enabled, requires_context_passport, ApprovalState, FridayConversation,
+    Mission, MissionLink, MissionLinkKind, SurfaceThread, WorkItem, WorkItemStatus, WorkspaceClaim,
 };
 use friday_storage::{memory, workflow, Db, StorageError};
 
@@ -500,8 +500,8 @@ pub fn attach_provider_timeline_state(
     // untouched. The guarded variant is the single behavioral knob (default-OFF), threaded
     // in as a pure bool from the run-loop entrypoint's env read (the codebase's
     // "split env-read from pure logic" idiom). `false` here = the pre-WI-1 path, byte-identical.
-    attach_provider_timeline_state_guarded(
-        db, attachment, false, /* clear_executing = */ false,
+    attach_provider_timeline_state_guarded_with_completion_receipt(
+        db, attachment, false, /* clear_executing = */ false, None,
     )
 }
 
@@ -546,6 +546,22 @@ pub fn attach_provider_timeline_state_guarded(
     // (the resume completion legs, the tests) passes `false` (byte-identical to pre-#24b).
     clear_executing: bool,
 ) -> Result<MissionAttachmentOutcome, StorageError> {
+    attach_provider_timeline_state_guarded_with_completion_receipt(
+        db,
+        attachment,
+        guarded,
+        clear_executing,
+        None,
+    )
+}
+
+pub(crate) fn attach_provider_timeline_state_guarded_with_completion_receipt(
+    db: &Db,
+    attachment: ProviderTimelineAttachment,
+    guarded: bool,
+    clear_executing: bool,
+    completion_proof_receipt: Option<&str>,
+) -> Result<MissionAttachmentOutcome, StorageError> {
     let Some(mut mission) = db.get_mission(&attachment.mission_id)? else {
         return Ok(MissionAttachmentOutcome::blocked("unknown_mission"));
     };
@@ -588,7 +604,7 @@ pub fn attach_provider_timeline_state_guarded(
         let actor_ref = format!("friday://agent-run/{}", attachment.request_id);
         let reason = format!("provider_timeline:{}", attachment.state.as_str());
         let proof_receipt = if next_status == WorkItemStatus::CompletedWithProof {
-            attachment.proof_ref.as_deref()
+            completion_proof_receipt.or(attachment.proof_ref.as_deref())
         } else {
             None
         };
@@ -627,10 +643,22 @@ pub fn attach_provider_timeline_state_guarded(
         work_item.status = next_status;
         work_item.updated_at_ms = attachment.now_ms;
         if next_status == WorkItemStatus::CompletedWithProof {
+            if let Some(proof_receipt) =
+                completion_proof_receipt.or(attachment.proof_ref.as_deref())
+            {
+                push_unique(&mut work_item.proof_receipts, proof_receipt.to_string());
+            }
             if let Some(proof_ref) = attachment.proof_ref.as_ref() {
-                push_unique(&mut work_item.proof_receipts, proof_ref.clone());
                 push_unique(&mut mission.proof_refs, proof_ref.clone());
                 mission.updated_at_ms = attachment.now_ms;
+            }
+            if outcome_checked_proof_enabled()
+                && work_item.has_outcome_proof_requirements()
+                && !work_item.completion_outcome_is_proven()
+            {
+                return Err(StorageError::Unsupported(
+                    "provider_timeline outcome-checked completion requires a typed outcome proof receipt matching an outcome proof requirement".into(),
+                ));
             }
         }
         // (#24b degrade-3) On the binding's final resting-state hop, clear `executing = 0` in the
@@ -1543,6 +1571,74 @@ mod tests {
         assert!(links
             .iter()
             .any(|link| link.link_kind == MissionLinkKind::ProviderTimeline));
+    }
+
+    #[test]
+    fn provider_timeline_inline_completion_rejects_untyped_outcome_receipt_when_flag_on() {
+        let _guard =
+            crate::test_env::EnvVarGuard::set(friday_core::OUTCOME_CHECKED_PROOF_FLAG, "1");
+        let db = Db::open_hub(&tmp()).unwrap();
+        assert!(preflight_and_stage_work_item(
+            &db,
+            request(
+                "mission-provider-outcome",
+                "work-provider-outcome",
+                "provider routed task",
+                WorkLane::Codex,
+                Vec::new(),
+                false,
+                1,
+            ),
+        )
+        .unwrap()
+        .is_ready());
+
+        for state in [
+            PendingState::SentToHub,
+            PendingState::AcceptedByHub,
+            PendingState::RoutedToProvider,
+            PendingState::WaitingProvider,
+        ] {
+            attach_provider_timeline_state(
+                &db,
+                ProviderTimelineAttachment {
+                    mission_id: "mission-provider-outcome".into(),
+                    work_item_id: "work-provider-outcome".into(),
+                    friday_session_id: "friday-session-codex".into(),
+                    request_id: "req-outcome-1".into(),
+                    state,
+                    proof_ref: None,
+                    now_ms: 10,
+                },
+            )
+            .unwrap();
+        }
+
+        let mut item = db.get_work_item("work-provider-outcome").unwrap().unwrap();
+        item.proof_requirements = vec!["outcome:ToolsExecuted:>=1".into()];
+        db.upsert_work_item(&item).unwrap();
+
+        let err = attach_provider_timeline_state(
+            &db,
+            ProviderTimelineAttachment {
+                mission_id: "mission-provider-outcome".into(),
+                work_item_id: "work-provider-outcome".into(),
+                friday_session_id: "friday-session-codex".into(),
+                request_id: "req-outcome-1".into(),
+                state: PendingState::ProviderCompleted,
+                proof_ref: Some("friday://activity/not-an-outcome-proof".into()),
+                now_ms: 12,
+            },
+        )
+        .unwrap_err();
+        assert!(matches!(
+            err,
+            StorageError::Unsupported(message)
+                if message.contains("outcome-checked completion requires a typed outcome proof receipt")
+        ));
+        let item = db.get_work_item("work-provider-outcome").unwrap().unwrap();
+        assert_eq!(item.status, WorkItemStatus::ProviderWaiting);
+        assert!(item.proof_receipts.is_empty());
     }
 
     #[test]

--- a/rust-core/crates/friday-hub/src/mission_runtime.rs
+++ b/rust-core/crates/friday-hub/src/mission_runtime.rs
@@ -8,7 +8,7 @@
 //! masquerade as Friday work.
 
 use friday_core::gate::{CanonicalApproval, MutatingActionRequest};
-use friday_core::{MissionLinkKind, Risk, RouteDecisionCard, WorkLane};
+use friday_core::{MissionLinkKind, ProofRequirementKind, Risk, RouteDecisionCard, WorkLane};
 use friday_crypto::{OperatorVerifyingKey, SecureStore};
 use friday_deepseek::{DeepSeekClient, Transport};
 use friday_storage::channel::get_channel;
@@ -22,9 +22,9 @@ use crate::mission_context::{
     MissionContextResolution, ResolvedMissionContext,
 };
 use crate::mission_preflight::{
-    attach_channel_inbound_receipt, attach_provider_timeline_state,
-    attach_provider_timeline_state_guarded, attach_workflow_run_ref, MissionAttachmentOutcome,
-    ProviderTimelineAttachment,
+    attach_channel_inbound_receipt, attach_provider_timeline_state_guarded,
+    attach_provider_timeline_state_guarded_with_completion_receipt, attach_workflow_run_ref,
+    MissionAttachmentOutcome, ProviderTimelineAttachment,
 };
 use crate::planner::WorkflowDefinition;
 use crate::provider_timeline::PendingState;
@@ -321,7 +321,7 @@ pub fn ask_friday_for_mission<T: Transport>(
         }
     };
 
-    record_friday_ask(
+    let ask_outcome = record_friday_ask(
         db,
         client,
         ledger_id,
@@ -333,14 +333,24 @@ pub fn ask_friday_for_mission<T: Transport>(
     )?;
 
     let proof_ref = format!("friday://activity/{activity_id}");
+    let outcome_proof_receipt = answer_produced_outcome_receipt_for_work_item(
+        db,
+        &envelope.context.work_item_id,
+        ledger_id,
+        &ask_outcome.content,
+    )
+    .map_err(RecordAskError::Storage)?;
     let attachment = attach_completed_provider_state_for_ask(
         db,
-        &envelope.context.mission_id,
-        &envelope.context.work_item_id,
-        session_id,
-        ledger_id,
-        &proof_ref,
-        now_ms,
+        CompletedAskProviderAttachment {
+            mission_id: &envelope.context.mission_id,
+            work_item_id: &envelope.context.work_item_id,
+            session_id,
+            ledger_id,
+            proof_ref: &proof_ref,
+            completion_proof_receipt: outcome_proof_receipt.as_deref(),
+            now_ms,
+        },
     )
     .map_err(RecordAskError::Storage)?;
 
@@ -350,6 +360,42 @@ pub fn ask_friday_for_mission<T: Transport>(
         result_link: proof_ref,
         attachment,
     })
+}
+
+struct CompletedAskProviderAttachment<'a> {
+    mission_id: &'a str,
+    work_item_id: &'a str,
+    session_id: &'a str,
+    ledger_id: &'a str,
+    proof_ref: &'a str,
+    completion_proof_receipt: Option<&'a str>,
+    now_ms: i64,
+}
+
+fn answer_produced_outcome_receipt_for_work_item(
+    db: &Db,
+    work_item_id: &str,
+    ledger_id: &str,
+    answer: &str,
+) -> Result<Option<String>, StorageError> {
+    if !friday_core::outcome_checked_proof_enabled() {
+        return Ok(None);
+    }
+    let Some(work_item) = db.get_work_item(work_item_id)? else {
+        return Ok(None);
+    };
+    let requires_answer_produced = work_item
+        .outcome_requirement_specs()
+        .iter()
+        .any(|spec| spec.kind == ProofRequirementKind::AnswerProduced);
+    if !requires_answer_produced {
+        return Ok(None);
+    }
+    Ok(Some(format!(
+        "proof://outcome/{}/{ledger_id}?signal=answer_len={}",
+        ProofRequirementKind::AnswerProduced.as_str(),
+        answer.chars().count()
+    )))
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -460,12 +506,7 @@ fn inbound_rejection_label(reason: InboundRejection) -> &'static str {
 
 fn attach_completed_provider_state_for_ask(
     db: &Db,
-    mission_id: &str,
-    work_item_id: &str,
-    session_id: &str,
-    ledger_id: &str,
-    proof_ref: &str,
-    now_ms: i64,
+    input: CompletedAskProviderAttachment<'_>,
 ) -> Result<MissionAttachmentOutcome, StorageError> {
     let mut last = MissionAttachmentOutcome::Blocked {
         blockers: vec!["provider_state_not_attached".into()],
@@ -477,18 +518,23 @@ fn attach_completed_provider_state_for_ask(
         PendingState::WaitingProvider,
         PendingState::ProviderCompleted,
     ] {
-        last = attach_provider_timeline_state(
+        last = attach_provider_timeline_state_guarded_with_completion_receipt(
             db,
             ProviderTimelineAttachment {
-                mission_id: mission_id.to_string(),
-                work_item_id: work_item_id.to_string(),
-                friday_session_id: session_id.to_string(),
-                request_id: ledger_id.to_string(),
+                mission_id: input.mission_id.to_string(),
+                work_item_id: input.work_item_id.to_string(),
+                friday_session_id: input.session_id.to_string(),
+                request_id: input.ledger_id.to_string(),
                 state,
                 proof_ref: (state == PendingState::ProviderCompleted)
-                    .then(|| proof_ref.to_string()),
-                now_ms,
+                    .then(|| input.proof_ref.to_string()),
+                now_ms: input.now_ms,
             },
+            false,
+            false,
+            (state == PendingState::ProviderCompleted)
+                .then_some(input.completion_proof_receipt)
+                .flatten(),
         )?;
         if matches!(last, MissionAttachmentOutcome::Blocked { .. }) {
             return Ok(last);
@@ -1606,6 +1652,80 @@ mod tests {
                 && link.target_ref == "friday://provider-timeline/friday-hub-session#ledger-ask-1"
                 && link.proof_ref.as_deref() == Some("friday://activity/activity-ask-1")
         }));
+    }
+
+    #[test]
+    fn mission_bound_ask_mints_typed_outcome_receipt_when_required() {
+        let _guard =
+            crate::test_env::EnvVarGuard::set(friday_core::OUTCOME_CHECKED_PROOF_FLAG, "1");
+        let mut db = Db::open_hub(&tmp("ask-outcome-proof")).unwrap();
+        seed_work_item(
+            &db,
+            WorkLane::DeepSeek,
+            Some("deepseek"),
+            WorkItemStatus::ReadyToDispatch,
+        );
+        let mut work_item = db.get_work_item("work-runtime").unwrap().unwrap();
+        work_item.proof_requirements = vec!["outcome:AnswerProduced:>=1".into()];
+        db.upsert_work_item(&work_item).unwrap();
+        let gets = Rc::new(Cell::new(0));
+        let posts = Rc::new(Cell::new(0));
+        let client = deepseek_client(gets.clone(), posts.clone());
+
+        let outcome = ask_friday_for_mission(
+            &mut db,
+            &client,
+            lookup(),
+            "ledger-ask-outcome-1",
+            "friday-hub-session",
+            "activity-ask-outcome-1",
+            "what next?",
+            64,
+            7,
+        )
+        .unwrap();
+
+        let MissionBoundAskOutcome::Answered {
+            result_link,
+            attachment,
+            ..
+        } = outcome
+        else {
+            panic!("expected mission-bound ask answer");
+        };
+        assert_eq!(result_link, "friday://activity/activity-ask-outcome-1");
+        assert!(matches!(
+            attachment,
+            MissionAttachmentOutcome::Attached {
+                work_item_status: WorkItemStatus::CompletedWithProof,
+                ..
+            }
+        ));
+        let work_item = db.get_work_item("work-runtime").unwrap().unwrap();
+        assert_eq!(work_item.status, WorkItemStatus::CompletedWithProof);
+        assert_eq!(
+            work_item.proof_receipts,
+            vec![
+                "proof://outcome/AnswerProduced/ledger-ask-outcome-1?signal=answer_len=18"
+                    .to_string()
+            ]
+        );
+        assert!(!work_item
+            .proof_receipts
+            .contains(&"friday://activity/activity-ask-outcome-1".to_string()));
+        let mission = db.get_mission("mission-runtime").unwrap().unwrap();
+        assert!(mission
+            .proof_refs
+            .contains(&"friday://activity/activity-ask-outcome-1".to_string()));
+        let links = db.list_mission_links("mission-runtime").unwrap();
+        assert!(links.iter().any(|link| {
+            link.link_kind == friday_core::MissionLinkKind::ProviderTimeline
+                && link.target_ref
+                    == "friday://provider-timeline/friday-hub-session#ledger-ask-outcome-1"
+                && link.proof_ref.as_deref() == Some("friday://activity/activity-ask-outcome-1")
+        }));
+        assert_eq!(gets.get(), 1);
+        assert_eq!(posts.get(), 1);
     }
 
     // ===================== WI-1 (M-6) guarded transition — PRODUCTION caller shape =============

--- a/rust-core/crates/friday-storage/src/mission.rs
+++ b/rust-core/crates/friday-storage/src/mission.rs
@@ -9,11 +9,11 @@ use crate::error::{Result, StorageError};
 use friday_core::Risk;
 use friday_core::{
     find_duplicate_mission as core_find_duplicate_mission,
-    find_duplicate_work_item as core_find_duplicate_work_item, validate_friday_conversation_id,
-    ApprovalState, FridayConversation, HandoffJudgmentMemory, Mission, MissionLink,
-    MissionLinkKind, MissionStatus, MissionSurfaceProjection, RouteDecisionCard,
-    RouteDecisionProjection, SurfaceEvent, SurfaceEventKind, SurfaceKind, SurfaceThread,
-    TruthStatus, VisibilityPolicy, WorkItem, WorkItemStatus, WorkLane,
+    find_duplicate_work_item as core_find_duplicate_work_item, outcome_checked_proof_enabled,
+    validate_friday_conversation_id, ApprovalState, FridayConversation, HandoffJudgmentMemory,
+    Mission, MissionLink, MissionLinkKind, MissionStatus, MissionSurfaceProjection,
+    RouteDecisionCard, RouteDecisionProjection, SurfaceEvent, SurfaceEventKind, SurfaceKind,
+    SurfaceThread, TruthStatus, VisibilityPolicy, WorkItem, WorkItemStatus, WorkLane,
 };
 use rusqlite::{params, Connection, OptionalExtension};
 
@@ -192,6 +192,16 @@ fn validate_work_item(item: &WorkItem) -> Result<()> {
     if item.status == WorkItemStatus::CompletedWithProof && item.proof_receipts.is_empty() {
         return Err(unsupported(format!(
             "work_item '{}' cannot be completed_with_proof without proof_receipts",
+            item.work_item_id
+        )));
+    }
+    if item.status == WorkItemStatus::CompletedWithProof
+        && outcome_checked_proof_enabled()
+        && item.has_outcome_proof_requirements()
+        && !item.completion_outcome_is_proven()
+    {
+        return Err(unsupported(format!(
+            "work_item '{}' outcome-checked completion requires a typed outcome proof receipt matching every outcome proof requirement",
             item.work_item_id
         )));
     }
@@ -796,6 +806,15 @@ fn transition_work_item_status_inner(
             if !item.proof_receipts.contains(&receipt) {
                 item.proof_receipts.push(receipt);
             }
+        }
+        if item.status == WorkItemStatus::CompletedWithProof
+            && outcome_checked_proof_enabled()
+            && item.has_outcome_proof_requirements()
+            && !item.completion_outcome_is_proven()
+        {
+            return Err(unsupported(
+                "work_item_lifecycle outcome-checked completion requires a typed outcome proof receipt matching an outcome proof requirement",
+            ));
         }
 
         // One transaction: the lifecycle audit row (the hash-chain read + insert) and the

--- a/rust-core/crates/friday-storage/tests/work_item_lifecycle.rs
+++ b/rust-core/crates/friday-storage/tests/work_item_lifecycle.rs
@@ -15,6 +15,37 @@ use friday_core::{
     TruthStatus, WorkItem, WorkItemStatus, WorkLane,
 };
 use friday_storage::{Db, StorageError};
+use std::sync::{Mutex, MutexGuard};
+
+static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+struct EnvGuard {
+    key: &'static str,
+    previous: Option<String>,
+    _lock: MutexGuard<'static, ()>,
+}
+
+impl EnvGuard {
+    fn set(key: &'static str, value: &str) -> Self {
+        let lock = ENV_LOCK.lock().unwrap_or_else(|poison| poison.into_inner());
+        let previous = std::env::var(key).ok();
+        std::env::set_var(key, value);
+        Self {
+            key,
+            previous,
+            _lock: lock,
+        }
+    }
+}
+
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        match &self.previous {
+            Some(value) => std::env::set_var(self.key, value),
+            None => std::env::remove_var(self.key),
+        }
+    }
+}
 
 fn conversation() -> FridayConversation {
     FridayConversation {
@@ -204,6 +235,75 @@ fn completed_with_proof_without_a_receipt_is_rejected() {
     assert_eq!(prev, WorkItemStatus::ProviderWaiting);
     assert_eq!(item.status, WorkItemStatus::CompletedWithProof);
     assert!(item.completion_is_proven());
+}
+
+#[test]
+fn outcome_checked_flag_rejects_free_text_completion_for_outcome_requirement() {
+    let _guard = EnvGuard::set("FRIDAY_OUTCOME_CHECKED_PROOF", "1");
+    let db = Db::open_hub(&temp_db_path("wi-outcome-free-text")).unwrap();
+    seed(&db, WorkItemStatus::ProviderWaiting);
+    let mut item = db.get_work_item("work-wi").unwrap().unwrap();
+    item.proof_requirements = vec!["outcome:ToolsExecuted:>=1".into()];
+    db.upsert_work_item(&item).unwrap();
+
+    let err = db
+        .transition_work_item_status(
+            "work-wi",
+            WorkItemStatus::CompletedWithProof,
+            "agent:friday",
+            "claim done with free-text proof",
+            Some("proof://provider-completed"),
+            10,
+        )
+        .unwrap_err();
+    assert!(matches!(err, StorageError::Unsupported(_)));
+
+    let stored = db.get_work_item("work-wi").unwrap().unwrap();
+    assert_eq!(stored.status, WorkItemStatus::ProviderWaiting);
+    assert!(stored.proof_receipts.is_empty());
+}
+
+#[test]
+fn outcome_checked_flag_accepts_matching_typed_outcome_receipt() {
+    let _guard = EnvGuard::set("FRIDAY_OUTCOME_CHECKED_PROOF", "1");
+    let db = Db::open_hub(&temp_db_path("wi-outcome-typed")).unwrap();
+    seed(&db, WorkItemStatus::ProviderWaiting);
+    let mut item = db.get_work_item("work-wi").unwrap().unwrap();
+    item.proof_requirements = vec!["outcome:ToolsExecuted:>=1".into()];
+    db.upsert_work_item(&item).unwrap();
+
+    let (item, prev) = db
+        .transition_work_item_status(
+            "work-wi",
+            WorkItemStatus::CompletedWithProof,
+            "agent:friday",
+            "claim done with typed outcome",
+            Some("proof://outcome/ToolsExecuted/run-1?signal=executed_tools=1"),
+            10,
+        )
+        .unwrap();
+    assert_eq!(prev, WorkItemStatus::ProviderWaiting);
+    assert_eq!(item.status, WorkItemStatus::CompletedWithProof);
+    assert!(item.completion_outcome_is_proven());
+}
+
+#[test]
+fn outcome_checked_flag_rejects_direct_upsert_with_untyped_outcome_receipt() {
+    let _guard = EnvGuard::set("FRIDAY_OUTCOME_CHECKED_PROOF", "1");
+    let db = Db::open_hub(&temp_db_path("wi-outcome-direct-upsert")).unwrap();
+    seed(&db, WorkItemStatus::ProviderWaiting);
+
+    let mut item = db.get_work_item("work-wi").unwrap().unwrap();
+    item.status = WorkItemStatus::CompletedWithProof;
+    item.proof_requirements = vec!["outcome:ToolsExecuted:>=1".into()];
+    item.proof_receipts = vec!["proof://provider-completed".into()];
+
+    let err = db.upsert_work_item(&item).unwrap_err();
+    assert!(matches!(err, StorageError::Unsupported(_)));
+
+    let stored = db.get_work_item("work-wi").unwrap().unwrap();
+    assert_eq!(stored.status, WorkItemStatus::ProviderWaiting);
+    assert!(stored.proof_receipts.is_empty());
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add typed `outcome:*` proof requirements and `proof://outcome/...` receipt parsing
- enforce outcome-checked `CompletedWithProof` at storage transitions, direct WorkItem upserts, WS ingress, and provider timeline inline completion
- mint a server-side `AnswerProduced` outcome receipt for DeepSeek mission-bound ask while preserving legacy activity refs for mission/timeline trace

## Scope
This is a scoped §9.2 floor: typed enforcement plus the DeepSeek `AnswerProduced` path. It does not claim full §9.2/v1/GO coverage for every outcome kind or cryptographic receipt provenance.

## Verification
- `cargo test --manifest-path rust-core/Cargo.toml -p friday-core -p friday-storage -p friday-hub --all-targets`
- `cargo clippy --manifest-path rust-core/Cargo.toml -p friday-core -p friday-storage -p friday-hub --all-targets -- -D warnings`
- `cargo fmt --all --manifest-path rust-core/Cargo.toml -- --check`
- `git diff --check`

Advisor audit: PASS / NO BLOCKER after fixing direct-upsert enforcement and scoped env guards.