### PR TITLE
[codex] Route mission-bound Claude through Rust

### DIFF
--- a/rust-core/crates/friday-hub/src/bin/hub_agent_run_server.rs
+++ b/rust-core/crates/friday-hub/src/bin/hub_agent_run_server.rs
@@ -443,18 +443,19 @@ fn run() -> Result<(), ServerError> {
         );
     }
 
-    // (NS-4) Read the MISSION-BOUND run seam flag ONCE at boot (default-off). When false the
-    // dispatch arm NEVER enters the bound-seam code — every run takes the EXACT pre-NS-4 unbound
-    // path, so deploying this binary changes NO live behavior until the operator flips this flag.
+    // (NS-4) Read the MISSION-BOUND run seam flag ONCE at boot (default-off). When false, ordinary
+    // no-handle requests still take the EXACT pre-NS-4 unbound path. A request that already carries
+    // `mission_context` has asserted mission-bound intent and fails closed to NoAnswer instead of
+    // running unbound under a false route projection.
     let mission_bound_run_enabled =
         mission_bound_run_enabled_from(env::var(MISSION_BOUND_RUN_ENABLED_ENV).ok().as_deref());
     if mission_bound_run_enabled {
         eprintln!(
-            "hub_agent_run_server: MISSION-BOUND run seam ENABLED (FRIDAY_MISSION_BOUND_RUN) — a run whose session resolves to a live Mission is dispatched bound"
+            "hub_agent_run_server: MISSION-BOUND run seam ENABLED (FRIDAY_MISSION_BOUND_RUN) — a run whose mission_context resolves to a live Mission is dispatched bound"
         );
     } else {
         eprintln!(
-            "hub_agent_run_server: MISSION-BOUND run seam DISABLED (set FRIDAY_MISSION_BOUND_RUN=1 to enable) — all runs dispatch unbound"
+            "hub_agent_run_server: MISSION-BOUND run seam DISABLED (set FRIDAY_MISSION_BOUND_RUN=1 to enable) — no-handle runs dispatch unbound; mission_context runs fail closed"
         );
     }
 
@@ -639,14 +640,15 @@ fn agent_run_control_enabled_from(raw: Option<&str>) -> bool {
 /// (NS-4) The env flag that gates the MISSION-BOUND run seam. DEFAULT-OFF: a run is dispatched
 /// through the Mission-bound entry ([`friday_hub::run_authed_agent_loop_mission_bound`] — which
 /// mints the mission-birth + WorkItem bind) ONLY when `FRIDAY_MISSION_BOUND_RUN` is exactly
-/// `"1"` (after trim). Unset — or any other value — leaves the seam DARK: every
-/// run takes the EXISTING unbound dispatch (`HubRuntime::run_session_task_with_overrides`, which
-/// BOTH the sessioned and the ephemeral-per-run-session arms now use), so deploying this binary
-/// changes
-/// NO live behavior until the operator flips this SEPARATE flag. Even with the flag ON, a run is
-/// bound only if it carries a FIRST-CLASS `mission_context` handle (NS45-PR1 / M-4) that resolves
-/// to a live Mission/WorkItem via `MissionContextLookup::by_mission_work_item`; a run with no
-/// handle (every live courier today) falls through unbound. SEPARATE from
+/// `"1"` (after trim). Unset — or any other value — leaves the seam DARK for ordinary runs: a
+/// request with NO `mission_context` takes the EXISTING unbound dispatch
+/// (`HubRuntime::run_session_task_with_overrides`, which BOTH the sessioned and the
+/// ephemeral-per-run-session arms now use), so deploying this binary changes NO live behavior for
+/// today's unbound courier. A request that DOES carry a FIRST-CLASS `mission_context` has asserted
+/// mission-bound intent; with this flag OFF, or with this flag ON but an unresolvable handle, it
+/// fails closed to body-free NoAnswer rather than falling through unbound. With the flag ON, a run
+/// is bound only if that handle (NS45-PR1 / M-4) resolves to a live Mission/WorkItem via
+/// `MissionContextLookup::by_mission_work_item`. SEPARATE from
 /// `FRIDAY_ROUTE_AGENT_RUN_VIA_RUST` (run-START) and `FRIDAY_AGENT_RUN_CONTROL_VIA_RUST`
 /// (run-CONTROL); flipping THIS one is an operator cutover decision gated on organic Mission
 /// ingress (the courier populating `AgentRunRequest.mission_context`).
@@ -1355,16 +1357,17 @@ fn serve_sealed_session<S: Read + Write, T: Transport>(
 
                 // (NS45-PR1 / M-4) MISSION-BOUND seam — FLAG-GATED, the FIRST dispatch consulted.
                 // When `FRIDAY_MISSION_BOUND_RUN` is ON **and** this run carries a FIRST-CLASS
-                // `mission_context` handle that resolves to a live DeepSeek-lane Mission/WorkItem,
-                // the run is dispatched BOUND (minting the mission-birth + WorkItem bind) and the
-                // seam returns `Some(answer)`. Otherwise it returns `None` and we fall through to
-                // the EXISTING unbound dispatch below — BYTE-IDENTICAL to the pre-NS-4 path.
+                // `mission_context` handle that resolves to a live Mission/WorkItem, the run is
+                // dispatched BOUND through that WorkItem's routed provider seam and returns
+                // `Some(answer)`. A present handle that cannot be serviced fails closed to
+                // body-free `NoAnswer`; only a request with NO handle falls through to the
+                // EXISTING unbound dispatch below.
                 //
                 // The mission handle, NOT the `session_id` shim, is now the resolution source
                 // (M-4: the provisional surface-thread conflation is retired). With the flag OFF
-                // the `else` arm binds `None` WITHOUT ever calling the seam; and with the flag ON
-                // but NO handle the seam returns `None` immediately — in BOTH cases the run takes
-                // the exact same `match session_id` unbound dispatch it always has, byte-identical.
+                // and NO handle the `else` arm binds `None` WITHOUT ever calling the seam. With the
+                // flag OFF but a handle present, fail closed rather than running unbound under a
+                // mission-bound route projection.
                 let mission_bound = if mission_bound_run_enabled {
                     friday_hub::hub_server::run_authed_agent_loop_mission_bound(
                         runtime,
@@ -1376,6 +1379,10 @@ fn serve_sealed_session<S: Read + Write, T: Transport>(
                         max_turns_override,
                         now_ms,
                     )
+                } else if mission_context.is_some() {
+                    Some(friday_hub::hub_server::AuthedAnswer::NoAnswer {
+                        run_id: run_id.clone(),
+                    })
                 } else {
                     None
                 };
@@ -2175,6 +2182,7 @@ mod tests {
     };
     use friday_hub::DeepSeekAgentLlmClient;
     use friday_transport::{read_frame, write_frame, ws_connect, ws_send_envelope};
+    use rusqlite::OptionalExtension;
     use serde_json::{json, Value};
     use sha2::{Digest, Sha256};
     use std::net::TcpStream;
@@ -2551,6 +2559,99 @@ mod tests {
         let inner = decode_sealed_proof(&inner_bytes).expect("owner-sealed body decodes");
         let opened = friday_crypto::open(&client_session, &inner, SESSION_AAD).unwrap();
         assert_eq!(opened, BODY.as_bytes(), "owner opens the sealed body");
+    }
+
+    // Explicit mission_context means "mission-bound or fail closed." If the server-side
+    // FRIDAY_MISSION_BOUND_RUN gate is off, the request must NOT run unbound and then surface a
+    // normal answer under the caller's mission/provider projection.
+    #[test]
+    fn mission_context_with_mission_bound_flag_off_returns_no_answer_not_unbound_success() {
+        let (rt, _ws) = mock_runtime("mission-flag-off", OWNER);
+        let server_kp = DeviceKeypair::generate();
+        let listener = AgentRunWsListener::bind_loopback(0).unwrap();
+        let addr = listener.local_addr().unwrap();
+        let allowlist = vec![OWNER.to_string()];
+        let client_kp = DeviceKeypair::generate();
+        let peer_allowlist = allowlist_of(client_kp.public_bytes());
+        let mission_context = friday_protocol::MissionWorkItemContextWire {
+            friday_conversation_id: "fconv_flag_off".into(),
+            mission_id: "mission-flag-off".into(),
+            work_item_id: "work-flag-off".into(),
+        };
+        let client = spawn_client(addr, client_kp, move |session, nonce| {
+            let req = mission_bound_agent_run_request(
+                "req-mission-flag-off",
+                "run-mission-flag-off",
+                OWNER,
+                session,
+                nonce,
+                mission_context,
+            );
+            (req, session.clone(), session.clone())
+        });
+
+        let processed = listener
+            .accept_one(
+                &server_kp,
+                &rt,
+                &allowlist,
+                &peer_allowlist,
+                false, // run-control OFF
+                false, // mission-bound run OFF: explicit handle must fail closed
+                false, // mission-intake ingress OFF
+                false, // mission-spine dispatch OFF
+                false, // memory-confirm ingress OFF
+                false, // token surface OFF
+                false, // provider-workspace dispatch OFF
+            )
+            .unwrap();
+        assert_eq!(processed, 1, "one authed dispatch processed");
+
+        let obs = client.join().unwrap();
+        let Some(Message::AgentRunResult {
+            run_id,
+            status,
+            answer_sha256,
+            answer_len,
+            ..
+        }) = obs.result.clone()
+        else {
+            panic!(
+                "expected AgentRunResult no-answer frame, got {:?}",
+                obs.result
+            );
+        };
+        assert_eq!(run_id, "run-mission-flag-off");
+        assert_eq!(
+            status, "no_answer_safe_failure",
+            "mission_context with the mission-bound flag off must fail closed, not execute unbound"
+        );
+        assert!(
+            answer_sha256.is_none(),
+            "no answer fingerprint on fail-closed no-answer"
+        );
+        assert!(
+            answer_len.is_none(),
+            "no answer length on fail-closed no-answer"
+        );
+        assert!(
+            obs.body_chunk.is_none(),
+            "fail-closed mission-context request must not deliver the unbound body"
+        );
+        let answer = rt
+            .db()
+            .conn()
+            .query_row(
+                "SELECT answer_sha256 FROM run_result WHERE run_id = ?1",
+                ["run-mission-flag-off"],
+                |row| row.get::<_, String>(0),
+            )
+            .optional()
+            .unwrap();
+        assert!(
+            answer.is_none(),
+            "mission_context flag-off fail-closed path must not persist an unbound run_result"
+        );
     }
 
     /// A MOCK transport that PROPOSES a mutating tool call (write_file) every turn. With the

--- a/rust-core/crates/friday-hub/src/hub_server.rs
+++ b/rust-core/crates/friday-hub/src/hub_server.rs
@@ -2230,18 +2230,17 @@ pub fn run_authed_agent_loop_with_policy<T: Transport>(
 ///     * `MissionBoundLoopOutcome::Ran` ⇒ the owner-gated body, projected by
 ///       [`project_answer_for_authed`] EXACTLY as the unbound entry does (same owner-wiring —
 ///       both go through `run_with_request`), with the loop's COUNTS attached.
+///     * `MissionBoundLoopOutcome::Blocked` ⇒ a body-free [`AuthedAnswer::NoAnswer`]. A request
+///       carrying an explicit first-class `mission_context` asserted mission-bound intent; if that
+///       handle cannot resolve/preflight, we fail closed instead of silently running an unbound
+///       session and letting upstream project a false mission/provider route.
 ///     * `Err(_)` ⇒ a body-free [`AuthedAnswer::NoAnswer`]. A SAFE FAILURE that MUST NOT fall
 ///       through: by the time `run_agent_loop_for_mission` errors it has ALREADY created the
 ///       `agent_run` row + may have spent model calls, so re-running the unbound path would
 ///       conflict on `create_run` and double-bill. We stop here.
 /// - `None` — the bound path was NOT taken; the caller falls through to the EXISTING unbound
-///   dispatch BYTE-IDENTICALLY. Two cases, both write NOTHING:
-///     * the flag is OFF, or no `MissionContextLookup` was derivable (sessionless run); OR
-///     * `MissionBoundLoopOutcome::Blocked` — the preflight failed closed (the common case: the
-///       run's `session_id` is an ordinary chat session, not a Mission surface thread). The
-///       preflight returns Blocked BEFORE `upsert_route_decision` and BEFORE `create_run`, so a
-///       fall-through leaves NO stray `route_decision`/`agent_run`/`mission_link` row — the
-///       unbound run that follows is byte-identical to today.
+///   dispatch BYTE-IDENTICALLY only when no first-class Mission handle was present. A present but
+///   invalid handle is never a fall-through.
 ///
 /// ## FIX-Q2 owner gate (UNCHANGED invariant)
 /// The `caller == configured_principal` gate is asserted HERE, BEFORE any dispatch — the SAME
@@ -2256,13 +2255,16 @@ pub fn run_authed_agent_loop_with_policy<T: Transport>(
 /// conflated the client-asserted `session_id` with a surface-thread id for mission resolution
 /// (the `session_id` field stays on the wire for the sessioned-chat unbound path, but it is NO
 /// LONGER the mission-resolution key). A run with NO handle (`None`) is NOT mission-resolvable ⇒
-/// `None` ⇒ the caller falls through to the unbound path, BYTE-IDENTICAL to today. The handle is
-/// a CLIENT ASSERTION that selects WHICH Mission to bind to; it is never an authority — the
-/// FIX-Q2 owner gate below is the authority.
+/// `None` ⇒ the caller falls through to the unbound path, BYTE-IDENTICAL to today. A present handle
+/// that fails preflight returns `Some(NoAnswer)`, not `None`, so upstream cannot turn an unbound
+/// answer into a false mission-bound provider projection. The handle is a CLIENT ASSERTION that
+/// selects WHICH Mission to bind to; it is never an authority — the FIX-Q2 owner gate below is the
+/// authority.
 ///
 /// The handle is populated by organic ingress (the native client / courier from the NS-5
-/// `MissionIntakeResult`) + the operator flips the flag; until both exist the flag is OFF and
-/// this returns `None` for every live request, so the live run path is unchanged.
+/// `MissionIntakeResult`) + the operator flips the flag. This helper is only called after the WS
+/// arm has admitted the mission-bound flag; the WS arm itself treats handle-present/flag-off as
+/// fail-closed `NoAnswer`, while no-handle requests keep the unchanged unbound path.
 ///
 /// ## Go-live caveat (DEFERRED — a named gate, NOT added here)
 /// A client-asserted `mission_id` under an `owner_allowlist > 1` is a cross-principal resolution
@@ -2280,8 +2282,9 @@ pub fn run_authed_agent_loop_with_policy<T: Transport>(
 /// (read-only / disabled-tools / max-turns).
 ///
 /// Codex WorkItems (`lane=codex`, `target_provider_or_agent=codex`) route to the Codex sibling;
-/// every other handle preserves the existing DeepSeek mission-bound entry and its fall-through
-/// behavior.
+/// Claude WorkItems (`lane=claude`, `target_provider_or_agent=claude`) route to the Claude
+/// sibling; every other handle preserves the existing DeepSeek mission-bound entry and its
+/// fail-closed preflight behavior.
 #[allow(clippy::too_many_arguments)]
 pub fn run_authed_agent_loop_mission_bound<T: Transport>(
     runtime: &HubRuntime<T>,
@@ -2325,8 +2328,28 @@ pub fn run_authed_agent_loop_mission_bound<T: Transport>(
     // matches the Mission's conversation by the time the bind runs.
     let session = handle.friday_conversation_id.as_str();
 
-    let result = if mission_handle_targets_codex(runtime, handle) {
-        runtime.run_codex_agent_loop_for_mission_with_overrides(
+    let result = match mission_handle_provider_target(runtime, handle) {
+        MissionBoundProviderTarget::Codex => runtime
+            .run_codex_agent_loop_for_mission_with_overrides(
+                lookup,
+                session,
+                run_id,
+                task,
+                policy_override,
+                max_turns_override,
+                now_ms,
+            ),
+        MissionBoundProviderTarget::Claude => runtime
+            .run_claude_agent_loop_for_mission_with_overrides(
+                lookup,
+                session,
+                run_id,
+                task,
+                policy_override,
+                max_turns_override,
+                now_ms,
+            ),
+        MissionBoundProviderTarget::DeepSeek => runtime.run_agent_loop_for_mission_with_overrides(
             lookup,
             session,
             run_id,
@@ -2334,17 +2357,7 @@ pub fn run_authed_agent_loop_mission_bound<T: Transport>(
             policy_override,
             max_turns_override,
             now_ms,
-        )
-    } else {
-        runtime.run_agent_loop_for_mission_with_overrides(
-            lookup,
-            session,
-            run_id,
-            task,
-            policy_override,
-            max_turns_override,
-            now_ms,
-        )
+        ),
     };
 
     match result {
@@ -2356,10 +2369,16 @@ pub fn run_authed_agent_loop_mission_bound<T: Transport>(
             project_answer_for_authed(runtime.db().conn(), run_id, caller)
                 .with_counts(outcome.turns, outcome.executed_tools),
         ),
-        // The preflight failed CLOSED (no resolvable/valid Mission for this run) — it wrote
-        // NOTHING (no `agent_run`, no `route_decision`, no `mission_link`). Fall through to the
-        // EXISTING unbound dispatch, BYTE-IDENTICAL to today.
-        Ok(crate::runtime::MissionBoundLoopOutcome::Blocked { .. }) => None,
+        // The preflight failed CLOSED (no resolvable/valid Mission for this explicit handle) — it
+        // wrote NOTHING (no `agent_run`, no `route_decision`, no `mission_link`). Do NOT fall
+        // through to unbound: the peer asserted a mission_context, and upstream may project the
+        // requested provider/model as the route shape. A body-free NoAnswer preserves fail-closed
+        // truth without running a different route.
+        Ok(crate::runtime::MissionBoundLoopOutcome::Blocked { .. }) => {
+            Some(AuthedAnswer::NoAnswer {
+                run_id: run_id.to_string(),
+            })
+        }
         // SAFE FAILURE: a route/storage error AFTER the run row exists. Body-free `NoAnswer`; we
         // MUST NOT fall through (the unbound path would re-`create_run` and double-bill).
         Err(_) => Some(AuthedAnswer::NoAnswer {
@@ -2368,15 +2387,27 @@ pub fn run_authed_agent_loop_mission_bound<T: Transport>(
     }
 }
 
-fn mission_handle_targets_codex<T: Transport>(
+enum MissionBoundProviderTarget {
+    DeepSeek,
+    Codex,
+    Claude,
+}
+
+fn mission_handle_provider_target<T: Transport>(
     runtime: &HubRuntime<T>,
     handle: &MissionWorkItemContextWire,
-) -> bool {
+) -> MissionBoundProviderTarget {
     let Ok(Some(work_item)) = runtime.db().get_work_item(&handle.work_item_id) else {
-        return false;
+        return MissionBoundProviderTarget::DeepSeek;
     };
-    work_item.lane == friday_core::WorkLane::Codex
-        && work_item.target_provider_or_agent.as_deref().map(str::trim) == Some("codex")
+    match (
+        work_item.lane,
+        work_item.target_provider_or_agent.as_deref().map(str::trim),
+    ) {
+        (friday_core::WorkLane::Codex, Some("codex")) => MissionBoundProviderTarget::Codex,
+        (friday_core::WorkLane::Claude, Some("claude")) => MissionBoundProviderTarget::Claude,
+        _ => MissionBoundProviderTarget::DeepSeek,
+    }
 }
 
 fn work_item_timeline_wire(item: friday_core::WorkItem) -> MissionTimelineWorkItemWire {
@@ -7858,14 +7889,15 @@ mod authed_route_tests {
     //
     // `run_authed_agent_loop_mission_bound` is the live-reachable counterpart of the unbound
     // entry: when (in the bin) `FRIDAY_MISSION_BOUND_RUN` is ON and the run carries a FIRST-CLASS
-    // `mission_context` handle that resolves to a live DeepSeek-lane Mission/WorkItem, a run is
+    // `mission_context` handle that resolves to a live routed-provider Mission/WorkItem, a run is
     // dispatched BOUND (minting the mission-birth + WorkItem bind). NS45-PR1 (M-4) retired the
     // `session_id`-as-surface-thread shim: resolution now keys off the handle
     // `{friday_conversation_id, mission_id, work_item_id}` via `by_mission_work_item`. These tests
-    // drive the SEAM directly (the bin's flag plumbing is exercised by its own `*_enabled_from`
-    // matcher tests). The flag-on test proves REAL mission binding (MissionLink + WorkItem
-    // transition + route_decision); the flag-off / no-handle / unresolvable tests prove
-    // byte-identical fall-through.
+    // drive the SEAM directly (the bin's flag plumbing, including handle-present/flag-off
+    // fail-closed behavior, is exercised by bin tests). The flag-on tests prove REAL mission
+    // binding (MissionLink + WorkItem transition + route_decision); the no-handle test proves
+    // byte-identical fall-through; the unresolvable-handle test proves explicit handles fail
+    // closed instead of falling through unbound.
 
     use friday_core::{
         ApprovalState as NsApprovalState, ClaimState as NsClaimState,
@@ -8068,6 +8100,52 @@ mod authed_route_tests {
         rt.mark_route_available("codex");
         rt.mark_route_validated("codex");
         (rt, ws, calls, last_context)
+    }
+
+    const CLAUDE_BOUND_BODY: &str = "CLAUDE-BOUND-BODY-CANARY-only-owner-P";
+    type ClaudeSeamFixture = (HubRuntime<ProviderDownTransport>, TempWs, Arc<AtomicU64>);
+
+    struct SeamClaudeStub {
+        answer: String,
+        calls: Arc<AtomicU64>,
+    }
+
+    impl crate::AgentLlmClient for SeamClaudeStub {
+        fn propose_tool_call(&self, _task: &str) -> Result<crate::RawToolCall, crate::AgentError> {
+            unreachable!("mission-bound Claude seam uses next_step_metered")
+        }
+
+        fn next_step_metered(
+            &self,
+            _task: &str,
+            _history: &[crate::TurnTrace],
+        ) -> Result<crate::MeteredStep, crate::AgentError> {
+            self.calls.fetch_add(1, Ordering::Relaxed);
+            Ok((
+                Ok(crate::AgentStep::Finish {
+                    message: self.answer.clone(),
+                }),
+                Some(crate::BilledUsage {
+                    provider_kind: friday_core::ProviderKind::Anthropic,
+                    model: friday_anthropic::DEFAULT_MODEL.to_string(),
+                    prompt_tokens: 11,
+                    completion_tokens: 8,
+                }),
+            ))
+        }
+    }
+
+    fn runtime_with_claude_stub(tag: &str) -> ClaudeSeamFixture {
+        let (rt, ws) = runtime_with(tag, ProviderDownTransport, "principal:owner");
+        let calls = Arc::new(AtomicU64::new(0));
+        let stub = SeamClaudeStub {
+            answer: CLAUDE_BOUND_BODY.into(),
+            calls: Arc::clone(&calls),
+        };
+        let mut rt = rt.with_claude(Box::new(stub));
+        rt.mark_route_available("claude");
+        rt.mark_route_validated("claude");
+        (rt, ws, calls)
     }
 
     fn ns4_codex_provider_claim() -> NsWorkspaceClaim {
@@ -8307,10 +8385,11 @@ mod authed_route_tests {
             .unwrap()
     }
 
-    /// FLAG-ON happy path: a run whose `session_id` resolves to a live DeepSeek-lane Mission is
-    /// dispatched BOUND. The seam returns the owner-gated body AND mints REAL mission binding —
-    /// a `MissionLink` tied to THIS run_id, a `ReadyToDispatch -> CompletedWithProof` WorkItem
-    /// transition (the run as proof), and a `route_decision` row keyed to this run.
+    /// FLAG-ON happy path: a run whose first-class `mission_context` handle resolves to a live
+    /// routed WorkItem is dispatched BOUND. The seam returns the owner-gated body AND mints REAL
+    /// mission binding — a `MissionLink` tied to THIS run_id, a
+    /// `ReadyToDispatch -> CompletedWithProof` WorkItem transition (the run as proof), and a
+    /// `route_decision` row keyed to this run.
     #[test]
     fn mission_bound_seam_on_binds_run_to_mission_and_delivers_body_to_owner() {
         let (rt, _ws) = runtime_with(
@@ -8463,6 +8542,68 @@ mod authed_route_tests {
     }
 
     #[test]
+    fn mission_bound_seam_on_claude_work_item_routes_to_claude_and_bills_anthropic() {
+        let (rt, _ws, claude_calls) = runtime_with_claude_stub("ns4-bound-claude");
+        ns4_seed_mission_with_route(
+            &rt,
+            "surface-ns4-claude-session",
+            NsWorkLane::Claude,
+            Some("claude"),
+            Vec::new(),
+            Vec::new(),
+        );
+        let caller = authed("principal:owner");
+        let handle = ns4_handle();
+
+        let out = run_authed_agent_loop_mission_bound(
+            &rt,
+            &caller,
+            "run-ns4-claude-bound",
+            "do the Claude mission work",
+            Some(&handle),
+            None,
+            None,
+            1000,
+        )
+        .expect("the bound Claude seam took the run (Some), not a fall-through");
+
+        assert_eq!(
+            out.delivered_body(),
+            Some(CLAUDE_BOUND_BODY),
+            "a Claude WorkItem must dispatch through the Claude client, not DeepSeek"
+        );
+        assert_eq!(
+            claude_calls.load(Ordering::Relaxed),
+            1,
+            "the Claude client was called exactly once"
+        );
+
+        let work_item = rt.db().get_work_item("work-ns4").unwrap().unwrap();
+        assert_eq!(work_item.status, NsWorkItemStatus::CompletedWithProof);
+        assert!(work_item
+            .proof_receipts
+            .contains(&"friday://agent-run/run-ns4-claude-bound".to_string()));
+        let route_decisions: i64 = rt
+            .db()
+            .conn()
+            .query_row(
+                "SELECT count(*) FROM route_decision WHERE decision_id = ?1",
+                ["route-decision:agent-loop:run-ns4-claude-bound"],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(route_decisions, 1);
+        let usage = rt
+            .db()
+            .list_run_token_usage("run-ns4-claude-bound")
+            .unwrap();
+        assert_eq!(usage.len(), 1);
+        assert_eq!(usage[0].provider_kind, "anthropic");
+        assert!(!usage[0].fallback);
+        assert!(friday_storage::audit::verify_audit_chain(rt.db().conn()).is_ok());
+    }
+
+    #[test]
     #[ignore = "live: needs logged-in Codex CLI; spawns codex app-server and spends one Codex turn"]
     fn live_mission_bound_codex_observe_wrapper_records_session_ledger_and_claimed_process() {
         let _observe = EnvRestore::set(
@@ -8595,13 +8736,11 @@ mod authed_route_tests {
         assert_eq!(claimed_observations, SOAK_SESSIONS as i64);
     }
 
-    /// FLAG-OFF byte-identical: when the flag is OFF, the bin NEVER calls the seam (the
-    /// `if mission_bound_run_enabled { seam } else { None }` else-arm) — every run takes the EXACT
-    /// unbound `run_authed_agent_loop_with_policy` path, even one carrying a resolvable
-    /// `mission_context` handle. This test pins that unbound result, with the SAME Mission staged,
-    /// produces ZERO mission binding (no MissionLink, no WorkItem transition, no route_decision)
-    /// and delivers the IDENTICAL body — i.e. the run is byte-identical to today even though a
-    /// resolvable Mission exists.
+    /// Direct unbound-entry parity: when the caller does not enter the mission-bound seam, the
+    /// unbound `run_authed_agent_loop_with_policy` path still produces ZERO mission binding (no
+    /// MissionLink, no WorkItem transition, no route_decision) and delivers the IDENTICAL body even
+    /// with the SAME Mission staged. The real WS flag-off + explicit `mission_context` case is
+    /// covered in `hub_agent_run_server` and must fail closed, not call this unbound path.
     #[test]
     fn mission_bound_flag_off_is_byte_identical_unbound_run_no_binding() {
         let (rt, _ws) = runtime_with(
@@ -8662,11 +8801,11 @@ mod authed_route_tests {
     }
 
     /// FLAG-ON but UNRESOLVABLE handle: a `mission_context` handle pointing at a Mission/WorkItem
-    /// that does NOT exist (no graph staged) makes the seam fail CLOSED to `None` — the caller
-    /// falls through to the unbound path, byte-identical to today, with NO crash. The preflight
-    /// blocked BEFORE `create_run`, so it wrote NOTHING.
+    /// that does NOT exist (no graph staged) fails CLOSED to `Some(NoAnswer)` — the caller must not
+    /// fall through to the unbound path and accidentally surface an unbound answer as mission-bound.
+    /// The preflight blocked BEFORE `create_run`, so it wrote NOTHING.
     #[test]
-    fn mission_bound_seam_on_unresolvable_handle_falls_through_none_no_binding() {
+    fn mission_bound_seam_on_unresolvable_handle_returns_no_answer_no_binding() {
         let (rt, _ws) = runtime_with(
             "ns4-fallthrough",
             FinishTransport {
@@ -8693,10 +8832,12 @@ mod authed_route_tests {
             1000,
         );
 
-        // The seam returned None ⇒ the caller falls through to the unbound dispatch (no crash).
+        // The seam returns Some(NoAnswer) ⇒ no unbound dispatch fallback for an explicit handle.
+        let out =
+            out.expect("an explicit but unresolvable handle must fail closed, not fall through");
         assert!(
-            out.is_none(),
-            "an unresolvable handle must fall through (None), not bind / not crash"
+            matches!(out, AuthedAnswer::NoAnswer { .. }),
+            "an unresolvable handle must not bind and must not fall through"
         );
         // The fail-closed preflight wrote nothing: no run, no route_decision, no mission_link.
         assert_eq!(

--- a/rust-core/crates/friday-hub/src/runtime.rs
+++ b/rust-core/crates/friday-hub/src/runtime.rs
@@ -1828,6 +1828,51 @@ impl<T: Transport> HubRuntime<T> {
         )
     }
 
+    /// Claude sibling of [`Self::run_agent_loop_for_mission_with_overrides`]. It uses the same
+    /// Mission preflight/bind path, but validates a Claude WorkItem (`lane=claude`,
+    /// `target_provider_or_agent=claude`) and pins the run to the dispatchable Claude route. The
+    /// generic routed-loop tail still owns billing, owner-wired result persistence, approvals, and
+    /// WorkItem proof attachment.
+    #[allow(clippy::too_many_arguments)]
+    pub fn run_claude_agent_loop_for_mission_with_overrides(
+        &self,
+        mission_lookup: MissionContextLookup,
+        session_id: &str,
+        run_id: &str,
+        task: &str,
+        policy_override: Option<&RunPolicy>,
+        max_turns_override: Option<u64>,
+        now_ms: i64,
+    ) -> Result<MissionBoundLoopOutcome, RoutedLoopError> {
+        let passport_mint = passport_mint_from(std::env::var(ENV_PASSPORT_MINT).ok().as_deref());
+        let workitem_guarded = workitem_guarded_transition_from(
+            std::env::var(ENV_WORKITEM_GUARDED_TRANSITION)
+                .ok()
+                .as_deref(),
+        );
+        let surface_events =
+            crate::surface_events_from(std::env::var(crate::FRIDAY_SURFACE_EVENTS).ok().as_deref());
+        let route_request = RouteRequest {
+            preferred_provider: Some("claude".to_string()),
+            ..RouteRequest::any()
+        };
+        self.run_agent_loop_for_mission_routed_with_overrides_flagged(
+            mission_lookup,
+            session_id,
+            run_id,
+            task,
+            WorkLane::Claude,
+            Some("claude".to_string()),
+            &route_request,
+            policy_override,
+            max_turns_override,
+            passport_mint,
+            workitem_guarded,
+            surface_events,
+            now_ms,
+        )
+    }
+
     /// (NS-6) [`Self::run_agent_loop_for_mission_with_overrides`] with the DARK passport-mint
     /// flag threaded in as a pure bool — the env read lives ONLY in the public wrapper (the
     /// "split env-read from pure logic" idiom), so the behavioral tests drive this directly with
@@ -4048,7 +4093,7 @@ mod tests {
         // runs the R7 live probe, which fails closed to CredentialMissing (NO quota spent, the
         // route stays non-validated). A subsequent claude pin therefore still fails closed with
         // RequestedProviderUnavailable. This is the no-key fail-closed proof; it presupposes the
-        // test env has no FRIDAY_ANTHROPIC_API_KEY (CI is DeepSeek-only; asserted below).
+        // test env has no FRIDAY_ANTHROPIC_API_KEY (CI is DeepSeek-backed here; asserted below).
         use friday_providers::KeyValidationOutcome;
         assert!(
             std::env::var("FRIDAY_ANTHROPIC_API_KEY")
@@ -8201,6 +8246,76 @@ mod tests {
         assert_eq!(observed_context.work_item_id, "work-loop");
         assert_eq!(observed_context.owner_claim_ids, vec![claim_id]);
 
+        let work_item = rt.db().get_work_item("work-loop").unwrap().unwrap();
+        assert_eq!(work_item.status, WorkItemStatus::CompletedWithProof);
+        assert!(work_item
+            .proof_receipts
+            .contains(&format!("friday://agent-run/{run_id}")));
+        assert!(friday_storage::audit::verify_audit_chain(rt.db().conn()).is_ok());
+    }
+
+    #[test]
+    fn mission_bound_claude_loop_routes_to_claude_and_records_anthropic_binding() {
+        let run_id = "run-mloop-claude";
+        let (rt, _ws) = runtime_with_claude_wired(
+            "mloop-claude",
+            vec![AgentStep::Finish {
+                message: "CLAUDE-PONG".to_string(),
+            }],
+            Box::new(DenyAllApprovals),
+        );
+        seed_loop_mission(
+            rt.db(),
+            WorkLane::Claude,
+            Some("claude"),
+            WorkItemStatus::ReadyToDispatch,
+        );
+
+        let outcome = rt
+            .run_claude_agent_loop_for_mission_with_overrides(
+                loop_lookup(),
+                "friday-hub-session",
+                run_id,
+                "say pong",
+                None,
+                None,
+                1_000,
+            )
+            .unwrap();
+
+        let MissionBoundLoopOutcome::Ran {
+            envelope,
+            selection,
+            outcome,
+            result_link,
+            attachment,
+        } = outcome
+        else {
+            panic!("expected the mission-bound Claude loop to run");
+        };
+        assert_eq!(selection.provider_id, "claude");
+        assert_eq!(outcome.status, LoopStatus::Finished);
+        assert_eq!(result_link, format!("friday://agent-run/{run_id}"));
+        assert_eq!(envelope.route_decision.selected_lane, WorkLane::Claude);
+        assert_eq!(
+            envelope
+                .route_decision
+                .selected_provider_or_agent
+                .as_deref(),
+            Some("claude")
+        );
+        assert!(matches!(
+            attachment,
+            MissionAttachmentOutcome::Attached {
+                work_item_status: WorkItemStatus::CompletedWithProof,
+                ..
+            }
+        ));
+
+        let usage = rt.db().list_run_token_usage(run_id).unwrap();
+        assert_eq!(usage.len(), 1);
+        assert_eq!(usage[0].provider_kind, "anthropic");
+        assert!(!usage[0].fallback);
         let work_item = rt.db().get_work_item("work-loop").unwrap().unwrap();
         assert_eq!(work_item.status, WorkItemStatus::CompletedWithProof);
         assert!(work_item

--- a/src/api/http/routes/friday-agent-routes.ts
+++ b/src/api/http/routes/friday-agent-routes.ts
@@ -37,6 +37,13 @@ import {
 } from "./friday-route-idempotency.js";
 import { assertBoundPrincipalForOperation } from "../../../security/friday-owner-session-channel-capability.js";
 import { buildPublicV1AgentRunIsolation } from "./friday-public-v1-agent-isolation.js";
+import {
+  RUST_ROUTE_CLAUDE_MODEL,
+  RUST_ROUTE_CLAUDE_PROVIDER_ID,
+  RUST_ROUTE_CODEX_MODEL,
+  RUST_ROUTE_CODEX_PROVIDER_ID,
+  RUST_ROUTE_READ_TOOL_ALLOWLIST,
+} from "../../runtime/friday-rust-route-constants.js";
 
 // ─── Constants ───
 
@@ -73,6 +80,83 @@ const CUSTOM_PACK_INTERNAL_LINE_DROP_PATTERNS: ReadonlyArray<RegExp> = [
   /(?:子代理|会话键|父会话|父子会话|运行深度|元数据)/i,
   /(?:当前运行.*正在执行中)/i,
 ];
+
+type FridayAgentRouteMissionContext = {
+  fridayConversationId: string;
+  missionId: string;
+  workItemId: string;
+};
+
+function parseMissionContext(value: unknown): FridayAgentRouteMissionContext | undefined {
+  if (
+    value === undefined
+    || typeof value !== "object"
+    || value === null
+    || Array.isArray(value)
+  ) {
+    return undefined;
+  }
+  const record = value as Record<string, unknown>;
+  const fridayConversationId =
+    typeof record.fridayConversationId === "string" && record.fridayConversationId.trim().length > 0
+      ? record.fridayConversationId.trim()
+      : undefined;
+  const missionId =
+    typeof record.missionId === "string" && record.missionId.trim().length > 0
+      ? record.missionId.trim()
+      : undefined;
+  const workItemId =
+    typeof record.workItemId === "string" && record.workItemId.trim().length > 0
+      ? record.workItemId.trim()
+      : undefined;
+  return fridayConversationId && missionId && workItemId
+    ? { fridayConversationId, missionId, workItemId }
+    : undefined;
+}
+
+function isMissionBoundRustRouteSentinel(input: {
+  providerId?: string;
+  model?: string;
+  constraints?: FridayAgentRunConstraints;
+  allowedRustRouteTools?: string[];
+  missionContext?: FridayAgentRouteMissionContext;
+  principal?: FridayAuthPrincipal | null;
+}): boolean {
+  const hasBoundPrincipal =
+    typeof input.principal?.principalId === "string"
+    && input.principal.principalId.trim().length > 0;
+  if (
+    !hasBoundPrincipal
+    || input.missionContext === undefined
+    || input.constraints?.readOnly !== true
+    || !hasExactRustReadToolGrant(input.allowedRustRouteTools)
+  ) {
+    return false;
+  }
+  return (
+    input.providerId === RUST_ROUTE_CODEX_PROVIDER_ID
+    && input.model === RUST_ROUTE_CODEX_MODEL
+  ) || (
+    input.providerId === RUST_ROUTE_CLAUDE_PROVIDER_ID
+    && input.model === RUST_ROUTE_CLAUDE_MODEL
+  );
+}
+
+function hasExactRustReadToolGrant(value: string[] | undefined): boolean {
+  if (!Array.isArray(value) || value.length !== RUST_ROUTE_READ_TOOL_ALLOWLIST.length) {
+    return false;
+  }
+  const granted = new Set(value);
+  if (granted.size !== RUST_ROUTE_READ_TOOL_ALLOWLIST.length) {
+    return false;
+  }
+  for (const tool of RUST_ROUTE_READ_TOOL_ALLOWLIST) {
+    if (!granted.has(tool)) {
+      return false;
+    }
+  }
+  return true;
+}
 const CUSTOM_PACK_UUID_RE = /\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b/gi;
 
 function getRunSurface(run: FridayAgentRunRecord): string | undefined {
@@ -925,7 +1009,7 @@ export interface FridayAgentRoutesDeps {
     mutationGate?: string;
     // (NS45-PR2 mission-bound driver — DARK) the first-class Mission handle this run binds to.
     // Additive + optional; forwarded straight to the route-bound startRun wrapper, which uses the
-    // validated 3-field body shape as the Codex mission-bound route selector and threads it
+    // validated 3-field body shape as the Codex/Claude mission-bound route selector and threads it
     // (UNCHANGED, camelCase) onto the sealed-WS dispatch ONLY when present. Absent for every
     // existing caller (→ omitted on the wire → byte-identical unbound run). SECURITY: the bound
     // owner stays the authenticated principal, never this handle; Rust re-validates the
@@ -1304,7 +1388,54 @@ export function createFridayAgentRoutes(
         const model = readPreferredString(body.model, body.requestedModel);
         const publicIsolation = buildPublicV1AgentRunIsolation(ctx.principal);
         const tenantContext = publicIsolation ? undefined : buildTenantContext(ctx.principal);
-        if (providerId || model) {
+
+        // IMPL-4: constraints
+        let constraints: FridayAgentRunConstraints | undefined;
+        if (body.constraints !== undefined && typeof body.constraints === "object" && body.constraints !== null && !Array.isArray(body.constraints)) {
+          const c = body.constraints as Record<string, unknown>;
+          const validModes = ["plan", "execute", "restricted"] as const;
+          const parsedMode = typeof c.operationalMode === "string" && (validModes as readonly string[]).includes(c.operationalMode)
+            ? (c.operationalMode as "plan" | "execute" | "restricted")
+            : undefined;
+          constraints = {
+            readOnly: typeof c.readOnly === "boolean" ? c.readOnly : undefined,
+            operationalMode: parsedMode,
+          };
+        }
+        if (publicIsolation) {
+          constraints = {
+            ...constraints,
+            ...publicIsolation.constraints,
+          };
+        }
+
+        // execrun-replacement S-F-compose (DARK): parse the explicit, optional per-run Rust
+        // read-tool grant. Accepted ONLY as an array of non-empty strings; any other shape
+        // (or absence) ⇒ undefined ⇒ the Rust-route predicate's clause-4 fails ⇒ today's
+        // unchanged 503. Additive: no existing caller sends it, so behavior is unchanged.
+        const allowedRustRouteTools = Array.isArray(body.allowedRustRouteTools)
+          && body.allowedRustRouteTools.every(
+            (t): t is string => typeof t === "string" && t.length > 0,
+          )
+          ? body.allowedRustRouteTools
+          : undefined;
+
+        // (NS45-PR2 mission-bound driver — DARK) parse the optional first-class Mission handle
+        // before provider validation: Codex/Claude mission-bound Rust routes use sentinel
+        // provider/model identifiers, not TS provider profile ids. Only a complete handle,
+        // bound authenticated principal, read-only constraint, and exact Rust read-tool grant may
+        // skip TS profile validation; otherwise ordinary provider validation remains unchanged and
+        // fail-closed.
+        const missionContext = parseMissionContext(body.missionContext);
+        const missionBoundRustRouteSentinel = isMissionBoundRustRouteSentinel({
+          providerId,
+          model,
+          constraints,
+          allowedRustRouteTools,
+          missionContext,
+          principal: publicIsolation ? null : ctx.principal,
+        });
+        if ((providerId || model) && !missionBoundRustRouteSentinel) {
           await deps.validateRequestedRoute?.(providerId, model, tenantContext);
         }
         const replyToMessageId = typeof body.replyToMessageId === "string" ? body.replyToMessageId : undefined;
@@ -1349,26 +1480,6 @@ export function createFridayAgentRoutes(
 
         // IMPL-1: requireReview flag
         const requireReview = typeof body.requireReview === "boolean" ? body.requireReview : undefined;
-
-        // IMPL-4: constraints
-        let constraints: FridayAgentRunConstraints | undefined;
-        if (body.constraints !== undefined && typeof body.constraints === "object" && body.constraints !== null && !Array.isArray(body.constraints)) {
-          const c = body.constraints as Record<string, unknown>;
-          const validModes = ["plan", "execute", "restricted"] as const;
-          const parsedMode = typeof c.operationalMode === "string" && (validModes as readonly string[]).includes(c.operationalMode)
-            ? (c.operationalMode as "plan" | "execute" | "restricted")
-            : undefined;
-          constraints = {
-            readOnly: typeof c.readOnly === "boolean" ? c.readOnly : undefined,
-            operationalMode: parsedMode,
-          };
-        }
-        if (publicIsolation) {
-          constraints = {
-            ...constraints,
-            ...publicIsolation.constraints,
-          };
-        }
 
         let executionContext:
           | {
@@ -1470,17 +1581,6 @@ export function createFridayAgentRoutes(
           })
           : undefined;
 
-        // execrun-replacement S-F-compose (DARK): parse the explicit, optional per-run Rust
-        // read-tool grant. Accepted ONLY as an array of non-empty strings; any other shape
-        // (or absence) ⇒ undefined ⇒ the Rust-route predicate's clause-4 fails ⇒ today's
-        // unchanged 503. Additive: no existing caller sends it, so behavior is unchanged.
-        const allowedRustRouteTools = Array.isArray(body.allowedRustRouteTools)
-          && body.allowedRustRouteTools.every(
-            (t): t is string => typeof t === "string" && t.length > 0,
-          )
-          ? body.allowedRustRouteTools
-          : undefined;
-
         // execrun S-F carry-forward (DARK): forward `body.planReviewOverride` RAW into the
         // route-bound startRun wrapper so the Rust-route predicate's clause-5 plan-review
         // disqualifier can fire (PRESENCE → disqualified → today's unchanged 503). Parsed
@@ -1512,43 +1612,6 @@ export function createFridayAgentRoutes(
           typeof body.mutationGate === "string" && body.mutationGate.length > 0
             ? body.mutationGate
             : undefined;
-
-        // (NS45-PR2 mission-bound driver — DARK) parse the optional first-class Mission handle.
-        // ALL-OR-NOTHING (mirrors the executionContext/taskProfile structured-body discipline):
-        // accepted ONLY as an object carrying all THREE required, non-empty string fields
-        // (fridayConversationId/missionId/workItemId — the exact 3 the Rust `MissionWorkItemContextWire`
-        // requires). Any other shape — absence, non-object, or a MISSING/blank field — ⇒ undefined ⇒
-        // the conditional spread below OMITS the key ⇒ a byte-identical unbound dispatch for
-        // non-Codex routes. PRESENCE-ONLY: never fabricate a field, never crash on a partial body.
-        // For Codex observe-wrapper admission this is part of route selection, not authorization:
-        // the run's owner stays the authenticated principal (forwarded below via `principalInput`),
-        // and Rust re-checks the Mission/WorkItem/owner binding before producing proof.
-        let missionContext:
-          | { fridayConversationId: string; missionId: string; workItemId: string }
-          | undefined;
-        if (
-          body.missionContext !== undefined
-          && typeof body.missionContext === "object"
-          && body.missionContext !== null
-          && !Array.isArray(body.missionContext)
-        ) {
-          const mc = body.missionContext as Record<string, unknown>;
-          const fridayConversationId =
-            typeof mc.fridayConversationId === "string" && mc.fridayConversationId.trim().length > 0
-              ? mc.fridayConversationId.trim()
-              : undefined;
-          const missionId =
-            typeof mc.missionId === "string" && mc.missionId.trim().length > 0
-              ? mc.missionId.trim()
-              : undefined;
-          const workItemId =
-            typeof mc.workItemId === "string" && mc.workItemId.trim().length > 0
-              ? mc.workItemId.trim()
-              : undefined;
-          if (fridayConversationId && missionId && workItemId) {
-            missionContext = { fridayConversationId, missionId, workItemId };
-          }
-        }
 
         const result = await deps.startRun({
           task: body.task,

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -288,10 +288,13 @@ export { createFridayApiRuntime } from "./runtime/friday-api-runtime.js";
 // admits. Re-exported so bootstrap can hand the mission auto-dispatch driver the EXACT qualifying
 // shapes without retyping literals.
 export {
+  RUST_ROUTE_CLAUDE_MODEL,
+  RUST_ROUTE_CLAUDE_PROVIDER_ID,
   RUST_ROUTE_CODEX_MODEL,
   RUST_ROUTE_CODEX_PROVIDER_ID,
   RUST_ROUTE_DEEPSEEK_FLASH_MODEL,
   RUST_ROUTE_DEEPSEEK_PROVIDER_ID,
+  RUST_ROUTE_READ_TOOL_ALLOWLIST,
 } from "./runtime/friday-api-runtime.js";
 export type {
   FridayApiRuntime,

--- a/src/api/mission-spine/friday-mission-auto-dispatch-driver.ts
+++ b/src/api/mission-spine/friday-mission-auto-dispatch-driver.ts
@@ -1,4 +1,5 @@
 import {
+  RUST_ROUTE_CLAUDE_PROVIDER_ID,
   RUST_ROUTE_CODEX_MISSION_DISPATCH_TIMEOUT_MS,
   RUST_ROUTE_READ_TOOL_ALLOWLIST,
 } from "../runtime/friday-rust-route-constants.js";
@@ -18,7 +19,7 @@ import type {
  * READ-ONLY bound agent-run carrying that server-produced handle. The already-merged route→sealed-
  * client `missionContext` road (#752) + the Rust bound seam + the DB resolver then walk the WorkItem
  * `ready_to_dispatch → … → completed_with_proof` (a read-only Finished closes WITHOUT an operator
- * signature). No Rust change; no runtime.rs touch; no new route.
+ * signature). The driver selects only provider/model shapes the Rust route qualifier already admits.
  *
  * ## Trigger contract (mirrors the Rust producer predicate exactly)
  * Dispatch fires ONLY for a FRESH ready intake — `status === "ready" && createdOrReady === true`
@@ -86,6 +87,10 @@ export interface CreateFridayMissionAutoDispatchDriverOptions {
   readonly codexProviderId: string;
   /** Codex model for mission-bound observe-wrapper WorkItems. */
   readonly codexModel: string;
+  /** Claude provider id for mission-bound mirror WorkItems. */
+  readonly claudeProviderId: string;
+  /** Claude model for mission-bound mirror WorkItems. */
+  readonly claudeModel: string;
   /**
    * Optional sink for the fire-and-forget run's rejection (never throws into the intake path).
    * Defaults to a silent swallow — the bound seam is the observability surface, not this driver.
@@ -136,6 +141,15 @@ function isCodexMissionTarget(
   );
 }
 
+function isClaudeMissionTarget(
+  request: FridayRustHubMissionIntakeRequest,
+): boolean {
+  return (
+    request.lane.trim() === RUST_ROUTE_CLAUDE_PROVIDER_ID &&
+    request.targetProviderOrAgent?.trim() === RUST_ROUTE_CLAUDE_PROVIDER_ID
+  );
+}
+
 export function createFridayMissionAutoDispatchDriver(
   options: CreateFridayMissionAutoDispatchDriverOptions,
 ): FridayMissionAutoDispatchDriver {
@@ -145,6 +159,8 @@ export function createFridayMissionAutoDispatchDriver(
     deepseekFlashModel,
     codexProviderId,
     codexModel,
+    claudeProviderId,
+    claudeModel,
     onDispatchError,
   } = options;
 
@@ -187,9 +203,12 @@ export function createFridayMissionAutoDispatchDriver(
             ? request.ownerPrincipal.trim()
             : undefined;
         const codexMissionTarget = isCodexMissionTarget(request);
+        const claudeMissionTarget = isClaudeMissionTarget(request);
         const route = codexMissionTarget
           ? { providerId: codexProviderId, model: codexModel }
-          : { providerId: deepseekProviderId, model: deepseekFlashModel };
+          : claudeMissionTarget
+            ? { providerId: claudeProviderId, model: claudeModel }
+            : { providerId: deepseekProviderId, model: deepseekFlashModel };
 
         // Fire-and-forget: invoke startRun WITHOUT awaiting. The intake response returns
         // immediately; the bound run walks the WorkItem via the Rust seam. A synchronous throw

--- a/src/api/runtime/friday-api-runtime.ts
+++ b/src/api/runtime/friday-api-runtime.ts
@@ -171,6 +171,8 @@ import { createFridayRustHubWorkflowCatalogBridgeService } from "../mission-spin
 import { resolveRustAgentRunWsClientX25519Secret } from "../mission-spine/friday-rust-hub-agent-run-ws-client-x25519-secret.js";
 import type { FridayRustAgentRunWsClientX25519SecretResolver } from "../mission-spine/friday-rust-hub-agent-run-ws-client-x25519-secret.js";
 import {
+  RUST_ROUTE_CLAUDE_MODEL,
+  RUST_ROUTE_CLAUDE_PROVIDER_ID,
   RUST_ROUTE_CODEX_MODEL,
   RUST_ROUTE_CODEX_PROVIDER_ID,
   RUST_ROUTE_DEEPSEEK_FLASH_MODEL,
@@ -178,6 +180,8 @@ import {
   RUST_ROUTE_READ_TOOL_ALLOWLIST,
 } from "./friday-rust-route-constants.js";
 export {
+  RUST_ROUTE_CLAUDE_MODEL,
+  RUST_ROUTE_CLAUDE_PROVIDER_ID,
   RUST_ROUTE_CODEX_MODEL,
   RUST_ROUTE_CODEX_PROVIDER_ID,
   RUST_ROUTE_DEEPSEEK_FLASH_MODEL,
@@ -978,16 +982,20 @@ export function resolveApiRuntimeCanonicalGateRequired(env: NodeJS.ProcessEnv = 
 //      this route, and never set the marker → never admitted. This avoids the historical
 //      route-only-retirement trap of pinning at the method chokepoint.
 //   2. constraints.readOnly === true (hard-blocks every mutating tool at the runtime).
-//   3. DeepSeek-flash ONLY: the provider identity must be DeepSeek via EITHER real shape —
-//      providerId === "deepseek" (the literal id the test/RGG envs seed), OR the requested
-//      providerId RESOLVES to an enabled provider record whose kind === "deepseek"
-//      (production rows carry UUID ids, e.g. kind="deepseek", id="fa15f1fe-…"; the route
-//      wrapper populates `resolvedProvider` from ONE cheap providerService.getProvider
-//      read). Fail-closed: unresolvable / disabled / non-deepseek kind → DISQUALIFIED.
-//      AND requested model === "deepseek-v4-flash" (still LITERAL). A request for
-//      deepseek-pro / codex / claude / chat / reasoner / a missing model → DISQUALIFIED
-//      (no silent downgrade to flash). If a taskProfile model override is present it must
-//      ALSO be exactly the flash identifier.
+//   3. Provider/model must match one of the admitted Rust route shapes:
+//      (a) DeepSeek flash via EITHER real provider shape — providerId === "deepseek" (the literal
+//          id the test/RGG envs seed), OR the requested providerId RESOLVES to an enabled provider
+//          record whose kind === "deepseek" (production rows carry UUID ids, e.g.
+//          kind="deepseek", id="fa15f1fe-…"; the route wrapper populates `resolvedProvider` from
+//          ONE cheap providerService.getProvider read). Fail-closed: unresolvable / disabled /
+//          non-deepseek kind → DISQUALIFIED. Requested model must be exactly
+//          "deepseek-v4-flash"; deepseek-pro / chat / reasoner / a missing model stay
+//          disqualified.
+//      (b) Mission-bound Codex observe route: exact Codex sentinel provider/model plus a valid
+//          3-field missionContext and non-empty authenticated principal.
+//      (c) Mission-bound Claude route: exact Claude sentinel provider/model plus the same
+//          missionContext + principal gates. Ordinary Codex/Claude requests remain disqualified.
+//      If a taskProfile model override is present it must match the admitted model for that route.
 //   4. The 4 READ tools ONLY: the run must positively grant exactly the Rust read-tool
 //      set {read_file, list_dir, stat_file, search} via `allowedRustRouteTools`. Any other
 //      tool (run_command / write_file / edit_file / append_file / delete_file / move_file /
@@ -999,8 +1007,8 @@ export function resolveApiRuntimeCanonicalGateRequired(env: NodeJS.ProcessEnv = 
 //      (mutating/approval) action:
 //        * plan-review: requireReview === true OR planReviewOverride present OR
 //          skipPlanningReview / resumeExistingRun truthy → disqualified.
-//        * session-mirror: input.sessionKey present → disqualified (a sessioned run
-//          participates in session mirroring).
+//        * session-mirror: a non-empty input.sessionKey is admitted only with a non-empty
+//          owner principal; blank/anonymous sessioned runs are disqualified.
 //        * subagents: no startRun-input field represents them — a subagent child reaches
 //          executeRun, not this HTTP route (covered by the route marker), and the
 //          allow-list excludes spawn_subagent. Stated explicitly; bound structurally.
@@ -1203,16 +1211,25 @@ function hasValidMissionContext(input: RustRouteQualificationInput): boolean {
     && context.workItemId.trim().length > 0;
 }
 
-// The sole Codex admission arm: a route-wrapper request with a validated 3-field
-// Mission handle plus an authenticated owner principal. The handle may come from
-// the HTTP body (for operator/driver-triggered mission-bound starts) or from
-// server-produced auto-dispatch, but it is only a selector. Authority remains the
-// authenticated principal, and the Rust mission-bound path re-validates the
-// Mission/WorkItem ownership before producing proof or readback.
+// Mission-bound provider admission arms: a route-wrapper request with a validated 3-field
+// Mission handle plus an authenticated owner principal. The handle may come from the HTTP
+// body (for operator/driver-triggered mission-bound starts) or from server-produced
+// auto-dispatch, but it is only a selector. Authority remains the authenticated principal,
+// and the Rust mission-bound path re-validates the Mission/WorkItem ownership before
+// producing proof or readback.
 function isMissionBoundCodexObserveRoute(input: RustRouteQualificationInput): boolean {
   return input.providerId === RUST_ROUTE_CODEX_PROVIDER_ID
     && input.model === RUST_ROUTE_CODEX_MODEL
     && (input.taskProfile?.model === undefined || input.taskProfile.model === RUST_ROUTE_CODEX_MODEL)
+    && hasValidMissionContext(input)
+    && typeof input.principalId === "string"
+    && input.principalId.trim().length > 0;
+}
+
+function isMissionBoundClaudeRoute(input: RustRouteQualificationInput): boolean {
+  return input.providerId === RUST_ROUTE_CLAUDE_PROVIDER_ID
+    && input.model === RUST_ROUTE_CLAUDE_MODEL
+    && (input.taskProfile?.model === undefined || input.taskProfile.model === RUST_ROUTE_CLAUDE_MODEL)
     && hasValidMissionContext(input)
     && typeof input.principalId === "string"
     && input.principalId.trim().length > 0;
@@ -1264,9 +1281,9 @@ export function qualifiesForRustReadOnlyRoute(input: RustRouteQualificationInput
     return false;
   }
 
-  // Clause 3 — Provider/model. The default route remains DeepSeek-flash only; the sole Codex
-  // admission is a mission-bound observe-wrapper run with a validated 3-field missionContext
-  // and bound owner principal. That context selects the Mission/WorkItem only; the
+  // Clause 3 — Provider/model. The default non-mission route remains exact DeepSeek flash; Codex
+  // and Claude are admitted only as mission-bound provider runs with a validated 3-field
+  // missionContext and bound owner principal. That context selects the Mission/WorkItem only; the
   // authenticated principal remains the owner and Rust re-validates the binding. Ordinary
   // Codex/Claude/pro/missing-provider runs stay disqualified.
   // Provider identity qualifies via EITHER real shape:
@@ -1284,7 +1301,11 @@ export function qualifiesForRustReadOnlyRoute(input: RustRouteQualificationInput
     (input.providerId === RUST_ROUTE_DEEPSEEK_PROVIDER_ID || resolvedDeepseekProvider)
     && input.model === RUST_ROUTE_DEEPSEEK_FLASH_MODEL
     && (input.taskProfile?.model === undefined || input.taskProfile.model === RUST_ROUTE_DEEPSEEK_FLASH_MODEL);
-  if (!deepseekFlashRoute && !isMissionBoundCodexObserveRoute(input)) {
+  if (
+    !deepseekFlashRoute
+    && !isMissionBoundCodexObserveRoute(input)
+    && !isMissionBoundClaudeRoute(input)
+  ) {
     return false;
   }
 
@@ -1335,8 +1356,8 @@ export function qualifiesForRustReadOnlyRoute(input: RustRouteQualificationInput
   // A non-empty `sessionKey` NO LONGER disqualifies — a read-only sessioned (multi-turn)
   // chat run may now route to Rust, where the server reloads + threads the session history
   // via the already-built `run_session_loop`. This is the ONLY relaxation in Phase 1: clause
-  // 2 (readOnly), clause 3 (deepseek-flash), clause 4 (exactly the 4 read tools), and the
-  // plan-review sub-clauses above all stay intact and fail-closed.
+  // 2 (readOnly), clause 3 (admitted provider/model shapes), clause 4 (exactly the 4 read tools),
+  // and the plan-review sub-clauses above all stay intact and fail-closed.
   //
   // COMPENSATING REQUIREMENT (the matched tightening): a sessioned run is admitted ONLY with
   // a NON-EMPTY owner `principalId`. The session history + answer body are releasable only to
@@ -4769,8 +4790,8 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
       // (NS45-PR2 mission-bound driver — DARK) the first-class Mission handle this run binds to.
       // Purely additive + optional — every existing caller omits it. The HTTP route forwards the
       // validated `body.missionContext`; server-produced auto-dispatch may also pass the same shape.
-      // `routeStartRun` uses it to qualify the sole Codex mission-bound observe route and threads it
-      // onto sealed-WS dispatch. It NEVER overrides principal/owner; Rust re-validates binding.
+      // `routeStartRun` uses it to qualify mission-bound Codex/Claude routes and threads it onto
+      // sealed-WS dispatch. It NEVER overrides principal/owner; Rust re-validates binding.
       missionContext?: FridayRustHubAgentRunMissionContext;
     }) => {
       if (deps.allowTestOnlyAgentRunStartExecution !== true) {
@@ -5048,8 +5069,8 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
 
           // Qualifying run: route via Rust. Fail-closed on missing key / WS / readback /
           // projector — this NEVER falls through to the TS `startRun`. providerId/model
-          // are guaranteed defined here (the predicate required the exact deepseek-flash
-          // identifiers), but coalesce defensively to satisfy the type.
+          // are guaranteed defined here (the predicate required an exact admitted route shape),
+          // but coalesce defensively to satisfy the type.
           return composeRustReadOnlyAgentRun({
             runId: deps.idGenerator(),
             task: input.task,
@@ -5094,9 +5115,9 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
             // (NS45-PR2 mission-bound driver — DARK) forward the Mission handle so the sealed-WS
             // dispatch emits the `mission_context` wire block when present (absent ⇒ omitted ⇒
             // byte-identical unbound dispatch). This is part of `rustRouteQualificationInput` for
-            // the sole Codex mission-bound observe route, but only as a selector: it does not touch
-            // `principalId`; the bound owner stays the authenticated `normalizedPrincipal`, and Rust
-            // re-validates the Mission/WorkItem binding before producing proof/readback.
+            // mission-bound Codex/Claude routes, but only as a selector: it does not touch
+            // `principalId`; the bound owner stays the authenticated `normalizedPrincipal`, and
+            // Rust re-validates the Mission/WorkItem binding before producing proof/readback.
             ...(input.missionContext !== undefined ? { missionContext: input.missionContext } : {}),
             // Stamp the apiRequest idempotency descriptor onto the projected row so a
             // SUBSEQUENT request sharing this key REPLAYS this run (the lookup above) rather

--- a/src/api/runtime/friday-rust-route-constants.ts
+++ b/src/api/runtime/friday-rust-route-constants.ts
@@ -22,6 +22,11 @@ export const RUST_ROUTE_DEEPSEEK_FLASH_MODEL = "deepseek-v4-flash";
 export const RUST_ROUTE_CODEX_PROVIDER_ID = "codex";
 export const RUST_ROUTE_CODEX_MODEL = "gpt-5.5";
 
+// Single source of truth for mission-bound Claude mirror runs. Like Codex, this route shape is
+// admitted only with a validated missionContext selector and authenticated principal.
+export const RUST_ROUTE_CLAUDE_PROVIDER_ID = "claude";
+export const RUST_ROUTE_CLAUDE_MODEL = "claude-opus-4-8";
+
 // Codex app-server observe-wrapper runs can legitimately take longer than the generic sealed-WS
 // default (30s). Keep the longer budget scoped to mission-bound Codex auto-dispatch so DeepSeek
 // read-only smoke runs stay on the short fail-closed path.

--- a/src/hub/friday-hub-bootstrap.ts
+++ b/src/hub/friday-hub-bootstrap.ts
@@ -112,6 +112,8 @@ import {
   createFridayReflexRoutes,
   getChannelPersona,
   hydrateChannelPersonaStore,
+  RUST_ROUTE_CLAUDE_MODEL,
+  RUST_ROUTE_CLAUDE_PROVIDER_ID,
   RUST_ROUTE_CODEX_MODEL,
   RUST_ROUTE_CODEX_PROVIDER_ID,
   RUST_ROUTE_DEEPSEEK_FLASH_MODEL,
@@ -7123,6 +7125,8 @@ export async function createFridayHub(
         deepseekFlashModel: RUST_ROUTE_DEEPSEEK_FLASH_MODEL,
         codexProviderId: RUST_ROUTE_CODEX_PROVIDER_ID,
         codexModel: RUST_ROUTE_CODEX_MODEL,
+        claudeProviderId: RUST_ROUTE_CLAUDE_PROVIDER_ID,
+        claudeModel: RUST_ROUTE_CLAUDE_MODEL,
       })
       : undefined;
   const missionSpineDispatch = routeMissionSpineViaRust

--- a/test/interop/friday-rust-hub-agent-run-sealed-client-runner.ts
+++ b/test/interop/friday-rust-hub-agent-run-sealed-client-runner.ts
@@ -21,6 +21,8 @@ import { createFridayMissionSpineDispatchAdapter } from "../../src/api/mission-s
 import { createFridayMissionAutoDispatchDriver } from "../../src/api/mission-spine/friday-mission-auto-dispatch-driver.js";
 import { createFridayMissionSpineRoutes } from "../../src/api/http/routes/friday-mission-spine-routes.js";
 import {
+  RUST_ROUTE_CLAUDE_MODEL,
+  RUST_ROUTE_CLAUDE_PROVIDER_ID,
   RUST_ROUTE_CODEX_MODEL,
   RUST_ROUTE_CODEX_PROVIDER_ID,
   RUST_ROUTE_DEEPSEEK_FLASH_MODEL,
@@ -95,6 +97,8 @@ async function main(): Promise<void> {
         deepseekFlashModel: RUST_ROUTE_DEEPSEEK_FLASH_MODEL,
         codexProviderId: RUST_ROUTE_CODEX_PROVIDER_ID,
         codexModel: RUST_ROUTE_CODEX_MODEL,
+        claudeProviderId: RUST_ROUTE_CLAUDE_PROVIDER_ID,
+        claudeModel: RUST_ROUTE_CLAUDE_MODEL,
         onDispatchError: (error) => {
           dispatchError = error;
         },
@@ -187,6 +191,8 @@ async function main(): Promise<void> {
         deepseekFlashModel: RUST_ROUTE_DEEPSEEK_FLASH_MODEL,
         codexProviderId: RUST_ROUTE_CODEX_PROVIDER_ID,
         codexModel: RUST_ROUTE_CODEX_MODEL,
+        claudeProviderId: RUST_ROUTE_CLAUDE_PROVIDER_ID,
+        claudeModel: RUST_ROUTE_CLAUDE_MODEL,
         onDispatchError: (error) => {
           dispatchError = error;
         },

--- a/test/unit/api/http/routes/friday-agent-routes.test.ts
+++ b/test/unit/api/http/routes/friday-agent-routes.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { createFridayAgentRoutes } from "#api";
+import {
+  createFridayAgentRoutes,
+  RUST_ROUTE_CLAUDE_MODEL,
+  RUST_ROUTE_CLAUDE_PROVIDER_ID,
+  RUST_ROUTE_READ_TOOL_ALLOWLIST,
+} from "#api";
 import type { FridayAgentRoutesDeps } from "#api";
 import type { FridayAgentEventEmitter } from "#agent";
 import type { FridayAgentRunRecord, FridayAgentRuntimeResult, FridayAgentAutomationService } from "#agent";
@@ -1480,6 +1485,118 @@ describe("FridayAgentRoutes", () => {
         tenantContext: { hubId: "user-approver-1", userId: "user-approver-1" },
         disabledToolNames: undefined,
       }));
+    });
+
+    it("skips TS provider-profile validation for an authenticated mission-bound Claude Rust sentinel", async () => {
+      stubDeps.validateRequestedRoute = vi.fn().mockRejectedValue(
+        new Error("ordinary provider validation must not run for mission-bound Claude sentinel"),
+      );
+      const routes = createFridayAgentRoutes(stubDeps);
+      const route = routes.find((r) => r.operationId === "agent.runs.start")!;
+      const principal = createStubPrincipal();
+      const ctx = {
+        body: {
+          task: "Run the Claude mission-bound work item",
+          providerId: RUST_ROUTE_CLAUDE_PROVIDER_ID,
+          model: RUST_ROUTE_CLAUDE_MODEL,
+          constraints: { readOnly: true },
+          allowedRustRouteTools: [...RUST_ROUTE_READ_TOOL_ALLOWLIST],
+          missionContext: {
+            fridayConversationId: " conv-claude ",
+            missionId: " mission-claude ",
+            workItemId: " work-claude ",
+          },
+        },
+        params: {},
+        query: {},
+        headers: {},
+        principal,
+        requestId: "req-claude-mission-bound",
+        receivedAt: "2026-01-01T00:00:00.000Z",
+      };
+
+      await route.handler(ctx);
+
+      expect(stubDeps.validateRequestedRoute).not.toHaveBeenCalled();
+      expect(stubDeps.startRun).toHaveBeenCalledWith(expect.objectContaining({
+        task: "Run the Claude mission-bound work item",
+        providerId: RUST_ROUTE_CLAUDE_PROVIDER_ID,
+        model: RUST_ROUTE_CLAUDE_MODEL,
+        principalId: principal.principalId,
+        constraints: { readOnly: true },
+        allowedRustRouteTools: [...RUST_ROUTE_READ_TOOL_ALLOWLIST],
+        missionContext: {
+          fridayConversationId: "conv-claude",
+          missionId: "mission-claude",
+          workItemId: "work-claude",
+        },
+      }));
+    });
+
+    it("still validates the Claude sentinel when the Rust read-tool grant is missing", async () => {
+      const routes = createFridayAgentRoutes(stubDeps);
+      const route = routes.find((r) => r.operationId === "agent.runs.start")!;
+      const principal = createStubPrincipal();
+      const ctx = {
+        body: {
+          task: "Run a malformed Claude mission-bound request",
+          providerId: RUST_ROUTE_CLAUDE_PROVIDER_ID,
+          model: RUST_ROUTE_CLAUDE_MODEL,
+          constraints: { readOnly: true },
+          missionContext: {
+            fridayConversationId: "conv-claude",
+            missionId: "mission-claude",
+            workItemId: "work-claude",
+          },
+        },
+        params: {},
+        query: {},
+        headers: {},
+        principal,
+        requestId: "req-claude-missing-read-grant",
+        receivedAt: "2026-01-01T00:00:00.000Z",
+      };
+
+      await route.handler(ctx);
+
+      expect(stubDeps.validateRequestedRoute).toHaveBeenCalledWith(
+        RUST_ROUTE_CLAUDE_PROVIDER_ID,
+        RUST_ROUTE_CLAUDE_MODEL,
+        { hubId: "user-approver-1", userId: "user-approver-1" },
+      );
+    });
+
+    it("still validates the Claude sentinel as an ordinary provider request without missionContext", async () => {
+      const routes = createFridayAgentRoutes(stubDeps);
+      const route = routes.find((r) => r.operationId === "agent.runs.start")!;
+      const principal = createStubPrincipal();
+      const ctx = {
+        body: {
+          task: "Run ordinary Claude without a mission binding",
+          providerId: RUST_ROUTE_CLAUDE_PROVIDER_ID,
+          model: RUST_ROUTE_CLAUDE_MODEL,
+        },
+        params: {},
+        query: {},
+        headers: {},
+        principal,
+        requestId: "req-ordinary-claude",
+        receivedAt: "2026-01-01T00:00:00.000Z",
+      };
+
+      await route.handler(ctx);
+
+      expect(stubDeps.validateRequestedRoute).toHaveBeenCalledWith(
+        RUST_ROUTE_CLAUDE_PROVIDER_ID,
+        RUST_ROUTE_CLAUDE_MODEL,
+        { hubId: "user-approver-1", userId: "user-approver-1" },
+      );
+      expect(stubDeps.startRun).toHaveBeenCalledWith(expect.objectContaining({
+        providerId: RUST_ROUTE_CLAUDE_PROVIDER_ID,
+        model: RUST_ROUTE_CLAUDE_MODEL,
+      }));
+      const startArg = vi.mocked(stubDeps.startRun).mock.calls[0][0] as Record<string, unknown>;
+      expect("missionContext" in startArg).toBe(false);
     });
 
     it("rejects conflicting provider/model aliases", async () => {

--- a/test/unit/api/mission-spine/friday-mission-auto-dispatch-driver.test.ts
+++ b/test/unit/api/mission-spine/friday-mission-auto-dispatch-driver.test.ts
@@ -4,7 +4,11 @@ import {
   createFridayMissionAutoDispatchDriver,
   type MissionAutoDispatchStartRun,
 } from "../../../../src/api/mission-spine/friday-mission-auto-dispatch-driver.js";
-import { RUST_ROUTE_CODEX_MISSION_DISPATCH_TIMEOUT_MS } from "../../../../src/api/runtime/friday-rust-route-constants.js";
+import {
+  RUST_ROUTE_CLAUDE_MODEL,
+  RUST_ROUTE_CLAUDE_PROVIDER_ID,
+  RUST_ROUTE_CODEX_MISSION_DISPATCH_TIMEOUT_MS,
+} from "../../../../src/api/runtime/friday-rust-route-constants.js";
 import type {
   FridayRustHubMissionIntakeRequest,
   FridayRustHubMissionIntakeResult,
@@ -20,6 +24,8 @@ const DEEPSEEK_PROVIDER = "deepseek";
 const DEEPSEEK_FLASH = "deepseek-v4-flash";
 const CODEX_PROVIDER = "codex";
 const CODEX_MODEL = "gpt-5.5";
+const CLAUDE_PROVIDER = RUST_ROUTE_CLAUDE_PROVIDER_ID;
+const CLAUDE_MODEL = RUST_ROUTE_CLAUDE_MODEL;
 const READ_TOOLS = ["read_file", "list_dir", "stat_file", "search"];
 
 const REQUEST: FridayRustHubMissionIntakeRequest = {
@@ -95,6 +101,8 @@ function makeDriver(opts?: {
     deepseekFlashModel: DEEPSEEK_FLASH,
     codexProviderId: CODEX_PROVIDER,
     codexModel: CODEX_MODEL,
+    claudeProviderId: CLAUDE_PROVIDER,
+    claudeModel: CLAUDE_MODEL,
     ...(opts?.onDispatchError ? { onDispatchError: opts.onDispatchError } : {}),
   });
   return { driver, startRun };
@@ -112,6 +120,8 @@ describe("createFridayMissionAutoDispatchDriver (organic mission→run binding P
         deepseekFlashModel: DEEPSEEK_FLASH,
         codexProviderId: CODEX_PROVIDER,
         codexModel: CODEX_MODEL,
+        claudeProviderId: CLAUDE_PROVIDER,
+        claudeModel: CLAUDE_MODEL,
       });
 
       driver.onIntakeReady(REQUEST, READY_RESULT);
@@ -144,6 +154,8 @@ describe("createFridayMissionAutoDispatchDriver (organic mission→run binding P
         deepseekFlashModel: DEEPSEEK_FLASH,
         codexProviderId: CODEX_PROVIDER,
         codexModel: CODEX_MODEL,
+        claudeProviderId: CLAUDE_PROVIDER,
+        claudeModel: CLAUDE_MODEL,
       });
 
       driver.onIntakeReady(
@@ -173,6 +185,49 @@ describe("createFridayMissionAutoDispatchDriver (organic mission→run binding P
           workItemId: "wi-from-SERVER-result",
         },
       });
+    });
+
+    it("dispatches a claude-targeted intake with the Claude mission-bound route shape", async () => {
+      const startRun = vi.fn(async () => ({
+        runId: "run-1",
+      })) as unknown as MissionAutoDispatchStartRun;
+      const driver = createFridayMissionAutoDispatchDriver({
+        startRun: () => startRun,
+        deepseekProviderId: DEEPSEEK_PROVIDER,
+        deepseekFlashModel: DEEPSEEK_FLASH,
+        codexProviderId: CODEX_PROVIDER,
+        codexModel: CODEX_MODEL,
+        claudeProviderId: CLAUDE_PROVIDER,
+        claudeModel: CLAUDE_MODEL,
+      });
+
+      driver.onIntakeReady(
+        {
+          ...REQUEST,
+          lane: "claude",
+          targetProviderOrAgent: "claude",
+        },
+        READY_RESULT,
+      );
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(startRun).toHaveBeenCalledTimes(1);
+      const arg = (startRun as unknown as ReturnType<typeof vi.fn>).mock
+        .calls[0][0];
+      expect(arg).toMatchObject({
+        principalId: "principal-owner",
+        providerId: CLAUDE_PROVIDER,
+        model: CLAUDE_MODEL,
+        constraints: { readOnly: true },
+        allowedRustRouteTools: READ_TOOLS,
+        missionContext: {
+          fridayConversationId: "conv-from-SERVER-result",
+          missionId: "mission-from-SERVER-result",
+          workItemId: "wi-from-SERVER-result",
+        },
+      });
+      expect(arg.timeoutMs).toBeUndefined();
     });
 
     it("does NOT dispatch for a blocked/duplicate intake (no re-spend)", async () => {
@@ -236,6 +291,8 @@ describe("createFridayMissionAutoDispatchDriver (organic mission→run binding P
         deepseekFlashModel: DEEPSEEK_FLASH,
         codexProviderId: CODEX_PROVIDER,
         codexModel: CODEX_MODEL,
+        claudeProviderId: CLAUDE_PROVIDER,
+        claudeModel: CLAUDE_MODEL,
       });
 
       driver.onIntakeReady(REQUEST, READY_RESULT);
@@ -273,6 +330,8 @@ describe("createFridayMissionAutoDispatchDriver (organic mission→run binding P
         deepseekFlashModel: DEEPSEEK_FLASH,
         codexProviderId: CODEX_PROVIDER,
         codexModel: CODEX_MODEL,
+        claudeProviderId: CLAUDE_PROVIDER,
+        claudeModel: CLAUDE_MODEL,
       });
 
       // The call must return (void) BEFORE the run promise settles — proving non-blocking.
@@ -294,6 +353,8 @@ describe("createFridayMissionAutoDispatchDriver (organic mission→run binding P
         deepseekFlashModel: DEEPSEEK_FLASH,
         codexProviderId: CODEX_PROVIDER,
         codexModel: CODEX_MODEL,
+        claudeProviderId: CLAUDE_PROVIDER,
+        claudeModel: CLAUDE_MODEL,
         onDispatchError,
       });
 
@@ -312,6 +373,8 @@ describe("createFridayMissionAutoDispatchDriver (organic mission→run binding P
         deepseekFlashModel: DEEPSEEK_FLASH,
         codexProviderId: CODEX_PROVIDER,
         codexModel: CODEX_MODEL,
+        claudeProviderId: CLAUDE_PROVIDER,
+        claudeModel: CLAUDE_MODEL,
       });
 
       expect(() => driver.onIntakeReady(REQUEST, READY_RESULT)).not.toThrow();

--- a/test/unit/api/mission-spine/friday-mission-spine-dispatch-adapter.test.ts
+++ b/test/unit/api/mission-spine/friday-mission-spine-dispatch-adapter.test.ts
@@ -319,6 +319,8 @@ describe("createFridayMissionSpineDispatchAdapter (Lane B-2, dark, adapter)", ()
         deepseekFlashModel: "deepseek-v4-flash",
         codexProviderId: "codex",
         codexModel: "gpt-5.5",
+        claudeProviderId: "claude",
+        claudeModel: "claude-opus-4-8",
       });
       const adapter = createFridayMissionSpineDispatchAdapter({
         port: 48750,

--- a/test/unit/api/runtime/friday-api-runtime-rust-route-predicate.test.ts
+++ b/test/unit/api/runtime/friday-api-runtime-rust-route-predicate.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from "vitest";
 
 import {
   qualifiesForRustReadOnlyRoute,
+  RUST_ROUTE_CLAUDE_MODEL,
+  RUST_ROUTE_CLAUDE_PROVIDER_ID,
   RUST_ROUTE_CODEX_MODEL,
   RUST_ROUTE_CODEX_PROVIDER_ID,
   RUST_ROUTE_READ_TOOL_ALLOWLIST,
@@ -41,6 +43,20 @@ function codexMissionBoundInput(): RustRouteQualificationInput {
   };
 }
 
+function claudeMissionBoundInput(): RustRouteQualificationInput {
+  return {
+    ...qualifyingInput(),
+    providerId: RUST_ROUTE_CLAUDE_PROVIDER_ID,
+    model: RUST_ROUTE_CLAUDE_MODEL,
+    principalId: "principal:owner-1",
+    missionContext: {
+      fridayConversationId: "conv-claude",
+      missionId: "mission-claude",
+      workItemId: "work-claude",
+    },
+  };
+}
+
 describe("qualifiesForRustReadOnlyRoute (execrun slice 4, dark predicate)", () => {
   it("admits a fully-qualifying read-only DeepSeek-flash route run", () => {
     expect(qualifiesForRustReadOnlyRoute(qualifyingInput())).toBe(true);
@@ -67,7 +83,7 @@ describe("qualifiesForRustReadOnlyRoute (execrun slice 4, dark predicate)", () =
     expect(qualifiesForRustReadOnlyRoute({ ...qualifyingInput(), constraints: undefined })).toBe(false);
   });
 
-  // ── Clause 3: DeepSeek-flash only, no silent downgrade ───────────────────────
+  // ── Clause 3: admitted provider/model route shapes, no silent downgrade ──────
   it("disqualifies a non-deepseek provider", () => {
     expect(qualifiesForRustReadOnlyRoute({ ...qualifyingInput(), providerId: "anthropic" })).toBe(false);
     expect(qualifiesForRustReadOnlyRoute({ ...qualifyingInput(), providerId: undefined })).toBe(false);
@@ -115,6 +131,52 @@ describe("qualifiesForRustReadOnlyRoute (execrun slice 4, dark predicate)", () =
       qualifiesForRustReadOnlyRoute({
         ...codexMissionBoundInput(),
         taskProfile: { model: RUST_ROUTE_CODEX_MODEL },
+      }),
+    ).toBe(true);
+  });
+
+  it("admits a mission-bound Claude mirror run with missionContext and owner principal", () => {
+    expect(qualifiesForRustReadOnlyRoute(claudeMissionBoundInput())).toBe(true);
+  });
+
+  it("disqualifies ordinary Claude runs without missionContext or owner principal", () => {
+    expect(
+      qualifiesForRustReadOnlyRoute({
+        ...claudeMissionBoundInput(),
+        missionContext: undefined,
+      }),
+    ).toBe(false);
+    expect(
+      qualifiesForRustReadOnlyRoute({
+        ...claudeMissionBoundInput(),
+        principalId: undefined,
+      }),
+    ).toBe(false);
+    expect(
+      qualifiesForRustReadOnlyRoute({
+        ...claudeMissionBoundInput(),
+        principalId: "   ",
+      }),
+    ).toBe(false);
+  });
+
+  it("disqualifies Claude mission-bound runs with the wrong model or taskProfile override", () => {
+    expect(
+      qualifiesForRustReadOnlyRoute({
+        ...claudeMissionBoundInput(),
+        model: "claude-3-7",
+      }),
+    ).toBe(false);
+    expect(
+      qualifiesForRustReadOnlyRoute({
+        ...claudeMissionBoundInput(),
+        taskProfile: { model: "deepseek-v4-flash" },
+      }),
+    ).toBe(false);
+    expect(
+      qualifiesForRustReadOnlyRoute({
+        ...claudeMissionBoundInput(),
+        taskProfile: { model: RUST_ROUTE_CLAUDE_MODEL },
       }),
     ).toBe(true);
   });
@@ -261,7 +323,7 @@ describe("qualifiesForRustReadOnlyRoute (execrun slice 4, dark predicate)", () =
     ).toBe(false);
   });
 
-  it("disqualifies deepseek-pro / codex / claude / a missing model (no downgrade to flash)", () => {
+  it("disqualifies deepseek-pro / codex / ordinary claude / a missing model (no downgrade to flash)", () => {
     for (const model of ["deepseek-v4-pro", "deepseek-chat", "deepseek-reasoner", "codex", "claude-3-7", undefined]) {
       expect(qualifiesForRustReadOnlyRoute({ ...qualifyingInput(), model })).toBe(false);
     }
@@ -493,14 +555,14 @@ describe("qualifiesForRustReadOnlyRoute (execrun slice 4, dark predicate)", () =
       ).toBe(true);
     });
 
-    // (d) clause 1 (route-marker) + clause 3 (deepseek-flash) + bound-owner STILL enforced.
+    // (d) clause 1 (route-marker) + clause 3 (provider/model shape) + bound-owner STILL enforced.
     it("(d) a gated mutating run STILL requires clause 1 (route marker)", () => {
       expect(
         qualifiesForRustReadOnlyRoute({ ...gatedMutatingInput(), invokedFromHttpStartRunRoute: false }),
       ).toBe(false);
     });
 
-    it("(d) a gated mutating run STILL requires clause 3 (deepseek-flash only; not Claude/pro)", () => {
+    it("(d) a gated mutating run STILL requires an admitted clause-3 provider/model shape", () => {
       expect(
         qualifiesForRustReadOnlyRoute({ ...gatedMutatingInput(), providerId: "anthropic", model: "claude-3-7" }),
       ).toBe(false);


### PR DESCRIPTION
## Summary

- Add the mission-bound Claude Rust route constants and thread them through mission auto-dispatch, bootstrap, interop runner, route predicate exports, and focused tests.
- Route Claude WorkItems through the Claude mission-bound Rust sibling so the local Rust seam records Anthropic ledger attribution in tests.
- Tighten HTTP sentinel validation: Codex/Claude sentinel provider/model skips TS provider-profile validation only with complete `missionContext`, authenticated non-public principal, `readOnly: true`, and the exact Rust read-tool grant.
- Fail closed for explicit `mission_context` requests when the Rust mission-bound seam is off or the handle preflight is blocked, preventing unbound execution from being projected as a mission-bound provider route.

## Root Cause

Claude mission-bound dispatch had constants/tests for adjacent paths but did not have a complete producer-to-Rust route path. The HTTP entry also validated provider/model against TS provider profiles before mission-bound sentinel handling, and Rust preflight-blocked handles could fall through to unbound execution.

## Validation

- `npx vitest run --project default test/unit/api/http/routes/friday-agent-routes.test.ts test/unit/api/runtime/friday-api-runtime-rust-route-predicate.test.ts test/unit/api/mission-spine/friday-mission-auto-dispatch-driver.test.ts test/unit/api/mission-spine/friday-mission-spine-dispatch-adapter.test.ts` PASS 160 tests.
- `npx tsc --noEmit` PASS.
- `cargo test --manifest-path rust-core/Cargo.toml -p friday-hub --lib mission_bound` PASS 27 passed / 3 ignored.
- `cargo test --manifest-path rust-core/Cargo.toml -p friday-hub --bin hub_agent_run_server mission_context_with_mission_bound_flag_off_returns_no_answer_not_unbound_success` PASS.
- `cargo fmt --manifest-path rust-core/Cargo.toml -p friday-hub --check` PASS.
- `cargo clippy --manifest-path rust-core/Cargo.toml -p friday-hub --lib -- -D warnings` PASS.
- `cargo clippy --manifest-path rust-core/Cargo.toml -p friday-hub --bin hub_agent_run_server -- -D warnings` PASS.
- `git diff --check` PASS.
- `npm run check:secret-patterns` PASS.

## Reviewer Results

Two read-only reviewer passes on the final diff:

- Reviewer A: PASS, no blockers after stale proof wording and fallback comments were corrected.
- Reviewer B: PASS, confirmed no remaining mission_context unbound fallback / false sentinel projection path.

## Truth Boundary

This is local/mock/compile proof plus read-only review. It does not claim a live Anthropic provider run, production deployment, or a real `outcome://` instance yet.