### PR TITLE
[codex] Add mission-bound Claude outcome proof receipts

### DIFF
--- a/rust-core/crates/friday-ffi/src/lib.rs
+++ b/rust-core/crates/friday-ffi/src/lib.rs
@@ -781,6 +781,7 @@ pub fn build_mission_intake_request(
                 target_provider_or_agent,
                 capability_id,
                 body_ref,
+                proof_requirements: Vec::new(),
                 includes_sensitive_context,
             },
         },

--- a/rust-core/crates/friday-hub/src/bin/hub_agent_run_server.rs
+++ b/rust-core/crates/friday-hub/src/bin/hub_agent_run_server.rs
@@ -3325,6 +3325,7 @@ mod tests {
                     target_provider_or_agent: Some("deepseek".into()),
                     capability_id: Some("ask_friday.deepseek".into()),
                     body_ref: Some("friday://body/mobile/ns5-intake".into()),
+                    proof_requirements: Vec::new(),
                     includes_sensitive_context: false,
                 },
             },

--- a/rust-core/crates/friday-hub/src/hub_server.rs
+++ b/rust-core/crates/friday-hub/src/hub_server.rs
@@ -538,6 +538,11 @@ pub fn mission_intake_result_for_db_flagged(
         created_at_ms: now_ms,
         updated_at_ms: now_ms,
     };
+    let proof_requirements = if request.proof_requirements.is_empty() {
+        vec!["Mission-bound provider proof receipt".into()]
+    } else {
+        request.proof_requirements.clone()
+    };
     let work_item = friday_core::WorkItem {
         work_item_id: request.work_item_id.clone(),
         mission_id: request.mission_id.clone(),
@@ -552,7 +557,7 @@ pub fn mission_intake_result_for_db_flagged(
         blocking_reason: None,
         input_refs: vec![input_ref],
         output_refs: Vec::new(),
-        proof_requirements: vec!["Mission-bound provider proof receipt".into()],
+        proof_requirements: proof_requirements.clone(),
         proof_receipts: Vec::new(),
         judgment_memory: friday_core::HandoffJudgmentMemory {
             task: request.intent.clone(),
@@ -567,7 +572,7 @@ pub fn mission_intake_result_for_db_flagged(
             deferred_options: vec!["native UI implementation".into()],
             previous_pitfalls: vec!["provider ack looked like done".into()],
             inheritable_context: vec!["same Mission renders across surfaces".into()],
-            proof_requirements: vec!["ledger/activity/audit proof".into()],
+            proof_requirements,
             ownership_claim_ids: owner_claim_ids,
         },
         created_at_ms: now_ms,
@@ -4345,6 +4350,7 @@ mod tests {
                         target_provider_or_agent: Some("codex".into()),
                         capability_id: Some("observe-wrapper.codex".into()),
                         body_ref: Some("friday://body/mobile/intake-1".into()),
+                        proof_requirements: vec!["outcome:AnswerProduced:>=1".into()],
                         includes_sensitive_context: false,
                     },
                 },
@@ -4393,6 +4399,7 @@ mod tests {
                         target_provider_or_agent: Some("codex".into()),
                         capability_id: Some("observe-wrapper.codex".into()),
                         body_ref: Some("friday://body/desktop/intake-duplicate".into()),
+                        proof_requirements: Vec::new(),
                         includes_sensitive_context: false,
                     },
                 },
@@ -4436,6 +4443,7 @@ mod tests {
                         target_provider_or_agent: Some("codex".into()),
                         capability_id: Some("observe-wrapper.codex".into()),
                         body_ref: Some("friday://surface-event-body/telegram/intake".into()),
+                        proof_requirements: Vec::new(),
                         includes_sensitive_context: false,
                     },
                 },
@@ -4557,6 +4565,14 @@ mod tests {
             .expect("work item");
         assert_eq!(work.status, WorkItemStatus::ReadyToDispatch);
         assert_eq!(work.input_refs, vec!["friday://body/mobile/intake-1"]);
+        assert_eq!(
+            work.proof_requirements,
+            vec!["outcome:AnswerProduced:>=1".to_string()]
+        );
+        assert_eq!(
+            work.judgment_memory.proof_requirements,
+            vec!["outcome:AnswerProduced:>=1".to_string()]
+        );
         let claim_id = format!(
             "claim-codex-provider-session-{}-{}",
             projection_ref_part("mission-intake"),
@@ -4659,6 +4675,7 @@ mod tests {
                         target_provider_or_agent: Some("deepseek".into()),
                         capability_id: Some("ask_friday.deepseek".into()),
                         body_ref: Some("friday://body/mobile/chain".into()),
+                        proof_requirements: Vec::new(),
                         includes_sensitive_context: false,
                     },
                 },
@@ -4774,6 +4791,7 @@ mod tests {
                             target_provider_or_agent: Some("deepseek".into()),
                             capability_id: Some("ask_friday.deepseek".into()),
                             body_ref: Some(body_ref.into()),
+                            proof_requirements: Vec::new(),
                             includes_sensitive_context: false,
                         },
                     },

--- a/rust-core/crates/friday-hub/src/lib.rs
+++ b/rust-core/crates/friday-hub/src/lib.rs
@@ -14381,6 +14381,7 @@ mod tests {
             "run-err",
             /* completed = */ false,
             "",
+            None,
             /* guarded = */ false,
             10_000,
         )
@@ -14436,6 +14437,7 @@ mod tests {
             "run-deg3",
             /* completed = */ false,
             "",
+            None,
             /* guarded = */ false,
             10_000,
         )

--- a/rust-core/crates/friday-hub/src/mission_runtime.rs
+++ b/rust-core/crates/friday-hub/src/mission_runtime.rs
@@ -372,10 +372,10 @@ struct CompletedAskProviderAttachment<'a> {
     now_ms: i64,
 }
 
-fn answer_produced_outcome_receipt_for_work_item(
+pub(crate) fn answer_produced_outcome_receipt_for_work_item(
     db: &Db,
     work_item_id: &str,
-    ledger_id: &str,
+    proof_id: &str,
     answer: &str,
 ) -> Result<Option<String>, StorageError> {
     if !friday_core::outcome_checked_proof_enabled() {
@@ -392,7 +392,7 @@ fn answer_produced_outcome_receipt_for_work_item(
         return Ok(None);
     }
     Ok(Some(format!(
-        "proof://outcome/{}/{ledger_id}?signal=answer_len={}",
+        "proof://outcome/{}/{proof_id}?signal=answer_len={}",
         ProofRequirementKind::AnswerProduced.as_str(),
         answer.chars().count()
     )))
@@ -603,6 +603,7 @@ pub(crate) fn attach_agent_loop_provider_state(
     run_id: &str,
     completed: bool,
     proof_ref: &str,
+    completion_proof_receipt: Option<&str>,
     guarded: bool,
     now_ms: i64,
 ) -> Result<MissionAttachmentOutcome, StorageError> {
@@ -624,6 +625,7 @@ pub(crate) fn attach_agent_loop_provider_state(
         &states,
         0,
         proof_ref,
+        completion_proof_receipt,
         guarded,
         now_ms,
     )
@@ -650,6 +652,7 @@ fn drive_provider_states(
     states: &[PendingState],
     start_idx: usize,
     proof_ref: &str,
+    completion_proof_receipt: Option<&str>,
     guarded: bool,
     now_ms: i64,
 ) -> Result<MissionAttachmentOutcome, StorageError> {
@@ -680,7 +683,7 @@ fn drive_provider_states(
         // `executing == 1` on a live paused run (which PASS-2 would then falsely reconcile). The
         // non-final in-flight hops keep `false` (the marker is still live mid-drive).
         let clear_executing = idx + 1 == states.len();
-        last = attach_provider_timeline_state_guarded(
+        last = attach_provider_timeline_state_guarded_with_completion_receipt(
             db,
             ProviderTimelineAttachment {
                 mission_id: mission_id.to_string(),
@@ -694,6 +697,9 @@ fn drive_provider_states(
             },
             guarded,
             clear_executing,
+            (state == PendingState::ProviderCompleted)
+                .then_some(())
+                .and(completion_proof_receipt),
         )?;
         if matches!(last, MissionAttachmentOutcome::Blocked { .. }) {
             return Ok(last);
@@ -1765,6 +1771,7 @@ mod tests {
             "run-loop-1",
             /* completed = */ true,
             "friday://agent-run/run-loop-1",
+            None,
             /* guarded = */ true,
             now,
         )
@@ -1829,6 +1836,7 @@ mod tests {
             "run-loop-2",
             /* completed = */ true,
             "friday://agent-run/run-loop-2",
+            None,
             /* guarded = */ false,
             now,
         )
@@ -1907,6 +1915,7 @@ mod tests {
             "run-z",
             /* completed = */ false,
             "friday://agent-run/run-z",
+            None,
             /* guarded = */ false,
             10,
         )

--- a/rust-core/crates/friday-hub/src/runtime.rs
+++ b/rust-core/crates/friday-hub/src/runtime.rs
@@ -36,8 +36,9 @@ use crate::hub_server::{project_answer_for_authed, AuthedAnswer, AuthedPrincipal
 use crate::mission_context::MissionContextLookup;
 use crate::mission_preflight::MissionAttachmentOutcome;
 use crate::mission_runtime::{
-    attach_agent_loop_provider_state, resolve_mission_runtime_envelope, MissionRuntimeEnvelope,
-    MissionRuntimeOutcome, MissionRuntimeRequest,
+    answer_produced_outcome_receipt_for_work_item, attach_agent_loop_provider_state,
+    resolve_mission_runtime_envelope, MissionRuntimeEnvelope, MissionRuntimeOutcome,
+    MissionRuntimeRequest,
 };
 use crate::routing::{
     run_routed_loop_with_policy, ProviderClientResolver, ProviderRoute, RouteRegistry,
@@ -2077,6 +2078,16 @@ impl<T: Transport> HubRuntime<T> {
         // (which PASS-2 would then falsely reconcile after a long human approval latency).
         let completed = outcome.status == LoopStatus::Finished;
         let result_link = format!("friday://agent-run/{run_id}");
+        let completion_proof_receipt = if completed {
+            answer_produced_outcome_receipt_for_work_item(
+                &self.db,
+                &envelope.context.work_item_id,
+                run_id,
+                outcome.final_message.as_deref().unwrap_or_default(),
+            )?
+        } else {
+            None
+        };
         let attachment = attach_agent_loop_provider_state(
             &self.db,
             &envelope.context.mission_id,
@@ -2085,6 +2096,7 @@ impl<T: Transport> HubRuntime<T> {
             run_id,
             completed,
             &result_link,
+            completion_proof_receipt.as_deref(),
             // WI-1 (M-6): DARK-flag bool threaded from the entrypoint env read. OFF ⇒ the inline
             // status-advance write (byte-identical); ON ⇒ each hop goes through the guarded
             // `transition_work_item_status` primitive, adding the atomic hash-chained audit row.
@@ -8321,6 +8333,74 @@ mod tests {
         assert!(work_item
             .proof_receipts
             .contains(&format!("friday://agent-run/{run_id}")));
+        assert!(friday_storage::audit::verify_audit_chain(rt.db().conn()).is_ok());
+    }
+
+    #[test]
+    fn mission_bound_claude_loop_mints_answer_produced_outcome_receipt_when_required() {
+        let _guard =
+            crate::test_env::EnvVarGuard::set(friday_core::OUTCOME_CHECKED_PROOF_FLAG, "1");
+        let run_id = "run-mloop-claude-outcome";
+        let (rt, _ws) = runtime_with_claude_wired(
+            "mloop-claude-outcome",
+            vec![AgentStep::Finish {
+                message: "CLAUDE-PONG".to_string(),
+            }],
+            Box::new(DenyAllApprovals),
+        );
+        seed_loop_mission(
+            rt.db(),
+            WorkLane::Claude,
+            Some("claude"),
+            WorkItemStatus::ReadyToDispatch,
+        );
+        let mut work_item = rt.db().get_work_item("work-loop").unwrap().unwrap();
+        work_item.proof_requirements = vec!["outcome:AnswerProduced:>=1".into()];
+        rt.db().upsert_work_item(&work_item).unwrap();
+
+        let outcome = rt
+            .run_claude_agent_loop_for_mission_with_overrides(
+                loop_lookup(),
+                "friday-hub-session",
+                run_id,
+                "say pong",
+                None,
+                None,
+                1_000,
+            )
+            .unwrap();
+
+        let MissionBoundLoopOutcome::Ran {
+            outcome,
+            result_link,
+            attachment,
+            ..
+        } = outcome
+        else {
+            panic!("expected the outcome-checked mission-bound Claude loop to run");
+        };
+        assert_eq!(outcome.status, LoopStatus::Finished);
+        assert_eq!(result_link, format!("friday://agent-run/{run_id}"));
+        assert!(matches!(
+            attachment,
+            MissionAttachmentOutcome::Attached {
+                work_item_status: WorkItemStatus::CompletedWithProof,
+                ..
+            }
+        ));
+
+        let usage = rt.db().list_run_token_usage(run_id).unwrap();
+        assert_eq!(usage.len(), 1);
+        assert_eq!(usage[0].provider_kind, "anthropic");
+        let work_item = rt.db().get_work_item("work-loop").unwrap().unwrap();
+        assert_eq!(work_item.status, WorkItemStatus::CompletedWithProof);
+        assert_eq!(
+            work_item.proof_receipts,
+            vec![format!(
+                "proof://outcome/AnswerProduced/{run_id}?signal=answer_len=11"
+            )]
+        );
+        assert!(work_item.completion_outcome_is_proven());
         assert!(friday_storage::audit::verify_audit_chain(rt.db().conn()).is_ok());
     }
 

--- a/rust-core/crates/friday-hub/tests/mission_intake_clarification.rs
+++ b/rust-core/crates/friday-hub/tests/mission_intake_clarification.rs
@@ -71,6 +71,7 @@ fn intake_request(intent: &str) -> MissionIntakeRequestWire {
         target_provider_or_agent: Some("deepseek".into()),
         capability_id: Some("ask_friday.deepseek".into()),
         body_ref: Some("friday://body/mobile/clar".into()),
+        proof_requirements: Vec::new(),
         includes_sensitive_context: false,
     }
 }

--- a/rust-core/crates/friday-hub/tests/surface_events_timeline.rs
+++ b/rust-core/crates/friday-hub/tests/surface_events_timeline.rs
@@ -439,6 +439,7 @@ fn intake_request() -> MissionIntakeRequestWire {
         target_provider_or_agent: Some("deepseek".into()),
         capability_id: Some("mission.surface".into()),
         body_ref: None,
+        proof_requirements: Vec::new(),
         includes_sensitive_context: false,
     }
 }

--- a/rust-core/crates/friday-protocol/src/lib.rs
+++ b/rust-core/crates/friday-protocol/src/lib.rs
@@ -264,6 +264,8 @@ pub struct MissionIntakeRequestWire {
     pub capability_id: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub body_ref: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub proof_requirements: Vec<String>,
     #[serde(default)]
     pub includes_sensitive_context: bool,
 }
@@ -2074,6 +2076,7 @@ mod tests {
                     target_provider_or_agent: Some("deepseek".into()),
                     capability_id: Some("ask_friday.deepseek".into()),
                     body_ref: Some("friday://body/mobile/1".into()),
+                    proof_requirements: Vec::new(),
                     includes_sensitive_context: false,
                 },
             },

--- a/scripts/ops/friday-claude-mission-proof-of-life.sh
+++ b/scripts/ops/friday-claude-mission-proof-of-life.sh
@@ -39,6 +39,7 @@ readonly TIMEOUT_SEC="${FRIDAY_CLAUDE_MISSION_PROOF_TIMEOUT_SEC:-240}"
 readonly POLL_INTERVAL_SEC="${FRIDAY_CLAUDE_MISSION_PROOF_POLL_INTERVAL_SEC:-3}"
 readonly PASSPHRASE_STDIN="${FRIDAY_CLAUDE_MISSION_PROOF_PASSPHRASE_STDIN:-0}"
 readonly PREFLIGHT_ONLY="${FRIDAY_CLAUDE_MISSION_PROOF_PREFLIGHT_ONLY:-0}"
+readonly OUTCOME_CHECKED="${FRIDAY_CLAUDE_MISSION_PROOF_OUTCOME_CHECKED:-0}"
 readonly RUST_WS_LAUNCH_WRAPPER="${FRIDAY_RUST_AGENT_RUN_WS_WRAPPER:-/Users/jarvis/.friday/launchd/rust-agent-run-ws-server-run.sh}"
 readonly RUST_WS_LAUNCH_PLIST="${FRIDAY_RUST_AGENT_RUN_WS_LAUNCH_PLIST:-/Users/jarvis/Library/LaunchAgents/com.friday.rust-agent-run-ws-server.plist}"
 readonly RUST_WS_LAUNCH_LABEL="${FRIDAY_RUST_AGENT_RUN_WS_LAUNCH_LABEL:-com.friday.rust-agent-run-ws-server}"
@@ -89,6 +90,10 @@ if [ "${PASSPHRASE_STDIN}" != "0" ] && [ "${PASSPHRASE_STDIN}" != "1" ]; then
 fi
 if [ "${PREFLIGHT_ONLY}" != "0" ] && [ "${PREFLIGHT_ONLY}" != "1" ]; then
   echo "FATAL: FRIDAY_CLAUDE_MISSION_PROOF_PREFLIGHT_ONLY must be 0 or 1; got '${PREFLIGHT_ONLY}'." >&2
+  exit 3
+fi
+if [ "${OUTCOME_CHECKED}" != "0" ] && [ "${OUTCOME_CHECKED}" != "1" ]; then
+  echo "FATAL: FRIDAY_CLAUDE_MISSION_PROOF_OUTCOME_CHECKED must be 0 or 1; got '${OUTCOME_CHECKED}'." >&2
   exit 3
 fi
 if [ "${POLL_INTERVAL_SEC}" -gt "${TIMEOUT_SEC}" ]; then
@@ -353,6 +358,7 @@ if [ "${PREFLIGHT_ONLY}" = "1" ]; then
   fi
   echo "  anthropicLedgerRows: $(sql_count "preflight anthropic ledger" "SELECT COUNT(*) FROM token_ledger WHERE provider_kind='anthropic';")"
   echo "  claudeWorkItems: $(sql_count "preflight claude work items" "SELECT COUNT(*) FROM work_item WHERE lane='claude' OR target_provider_or_agent='claude';")"
+  echo "  outcomeCheckedMode: ${OUTCOME_CHECKED}"
   echo "Truth: preflight creates no traffic and proves only local readiness, not Claude proof / D8 / GO."
   exit 0
 fi
@@ -370,6 +376,7 @@ echo "  Rust DB: ${RUST_HUB_DB}"
 echo "  missionId: ${MISSION_ID}"
 echo "  workItemId: ${WORK_ITEM_ID}"
 echo "  startedAtMs: ${STARTED_AT_MS}"
+echo "  outcomeCheckedMode: ${OUTCOME_CHECKED}"
 echo
 
 if [ "${PASSPHRASE_STDIN}" = "1" ]; then
@@ -420,6 +427,7 @@ INTAKE_BODY="$(jq -nc \
   --arg surface "${SURFACE_THREAD_ID}" \
   --arg mission "${MISSION_ID}" \
   --arg work "${WORK_ITEM_ID}" \
+  --arg outcome_checked "${OUTCOME_CHECKED}" \
   '{
     fridayConversationId: $conv,
     ownerPrincipal: $owner,
@@ -436,7 +444,7 @@ INTAKE_BODY="$(jq -nc \
     capabilityId: "ask_friday.claude",
     bodyRef: "friday://body/ops/claude-mission-proof-of-life",
     includesSensitiveContext: false
-  }')"
+  } + (if $outcome_checked == "1" then {proofRequirements: ["outcome:AnswerProduced:>=1"]} else {} end)')"
 
 echo "Step 2: POST /v1/mission-spine/intake (Claude target)..."
 INTAKE_RAW="$(
@@ -463,34 +471,75 @@ surface_bound_proof=0
 work_status=""
 while [ "$(date +%s)" -le "${deadline}" ]; do
   work_status="$(sql_scalar "SELECT COALESCE(status, '') FROM work_item WHERE work_item_id='${WORK_ITEM_ID}' LIMIT 1;")"
-  joined_proof="$(sql_count "this completed Claude work item with linked Anthropic ledger proof" "
-    WITH proof AS (
-      SELECT
-        w.work_item_id AS work_item_id,
-        w.status AS status,
-        proof.value AS proof_receipt,
-        replace(proof.value, 'friday://agent-run/', '') AS run_id
-      FROM work_item w
-      JOIN json_each(w.proof_receipts) proof
-        ON proof.value IS NOT NULL
-      WHERE w.work_item_id='${WORK_ITEM_ID}'
-        AND w.mission_id='${MISSION_ID}'
-        AND w.lane='claude'
-        AND COALESCE(w.target_provider_or_agent,'')='claude'
-        AND w.status='completed_with_proof'
-        AND w.updated_at_ms >= ${STARTED_AT_MS}
-    )
-    SELECT COUNT(*)
-    FROM proof p
-    JOIN token_ledger ledger
-      ON p.proof_receipt = 'friday://agent-run/' || ledger.run_id
-     AND ledger.run_id = p.run_id
-     AND ledger.provider_kind='anthropic'
-     AND ledger.model='${CLAUDE_MODEL}'
-     AND ledger.fallback=0
-     AND ledger.total_tokens > 0
-     AND ledger.created_at >= ${STARTED_AT_MS};
-  ")"
+  if [ "${OUTCOME_CHECKED}" = "1" ]; then
+    joined_proof="$(sql_count "this completed Claude work item with linked Anthropic outcome proof" "
+      WITH raw_proof AS (
+        SELECT
+          w.work_item_id AS work_item_id,
+          w.status AS status,
+          proof.value AS proof_receipt,
+          replace(proof.value, 'proof://outcome/AnswerProduced/', '') AS payload
+        FROM work_item w
+        JOIN json_each(w.proof_receipts) proof
+          ON proof.value IS NOT NULL
+        WHERE w.work_item_id='${WORK_ITEM_ID}'
+          AND w.mission_id='${MISSION_ID}'
+          AND w.lane='claude'
+          AND COALESCE(w.target_provider_or_agent,'')='claude'
+          AND w.status='completed_with_proof'
+          AND w.updated_at_ms >= ${STARTED_AT_MS}
+          AND proof.value LIKE 'proof://outcome/AnswerProduced/%?signal=answer_len=%'
+      ),
+      proof AS (
+        SELECT
+          work_item_id,
+          status,
+          proof_receipt,
+          CASE WHEN instr(payload, '?') > 0 THEN substr(payload, 1, instr(payload, '?') - 1) ELSE payload END AS run_id,
+          CASE WHEN instr(payload, 'answer_len=') > 0 THEN substr(payload, instr(payload, 'answer_len=') + length('answer_len=')) ELSE '' END AS answer_len
+        FROM raw_proof
+      )
+      SELECT COUNT(*)
+      FROM proof p
+      JOIN token_ledger ledger
+        ON ledger.run_id = p.run_id
+       AND ledger.provider_kind='anthropic'
+       AND ledger.model='${CLAUDE_MODEL}'
+       AND ledger.fallback=0
+       AND ledger.total_tokens > 0
+       AND ledger.created_at >= ${STARTED_AT_MS}
+      WHERE CAST(p.answer_len AS INTEGER) > 0;
+    ")"
+  else
+    joined_proof="$(sql_count "this completed Claude work item with linked Anthropic ledger proof" "
+      WITH proof AS (
+        SELECT
+          w.work_item_id AS work_item_id,
+          w.status AS status,
+          proof.value AS proof_receipt,
+          replace(proof.value, 'friday://agent-run/', '') AS run_id
+        FROM work_item w
+        JOIN json_each(w.proof_receipts) proof
+          ON proof.value IS NOT NULL
+        WHERE w.work_item_id='${WORK_ITEM_ID}'
+          AND w.mission_id='${MISSION_ID}'
+          AND w.lane='claude'
+          AND COALESCE(w.target_provider_or_agent,'')='claude'
+          AND w.status='completed_with_proof'
+          AND w.updated_at_ms >= ${STARTED_AT_MS}
+      )
+      SELECT COUNT(*)
+      FROM proof p
+      JOIN token_ledger ledger
+        ON p.proof_receipt = 'friday://agent-run/' || ledger.run_id
+       AND ledger.run_id = p.run_id
+       AND ledger.provider_kind='anthropic'
+       AND ledger.model='${CLAUDE_MODEL}'
+       AND ledger.fallback=0
+       AND ledger.total_tokens > 0
+       AND ledger.created_at >= ${STARTED_AT_MS};
+    ")"
+  fi
   surface_bound_proof="$(sql_count "this completed Claude work item with bound surface thread" "
     SELECT COUNT(DISTINCT surface.surface_thread_id)
     FROM work_item w
@@ -516,8 +565,8 @@ while [ "$(date +%s)" -le "${deadline}" ]; do
   ")"
   ledger_count="$(sql_count "anthropic ledger since start" "SELECT COUNT(*) FROM token_ledger WHERE provider_kind='anthropic' AND model='${CLAUDE_MODEL}' AND fallback=0 AND total_tokens>0 AND created_at >= ${STARTED_AT_MS};")"
   proof_count="$(sql_count "this completed claude proof receipts" "SELECT COUNT(*) FROM work_item w JOIN json_each(w.proof_receipts) proof ON proof.value IS NOT NULL WHERE w.work_item_id='${WORK_ITEM_ID}' AND w.status='completed_with_proof';")"
-  printf 'Polling: workStatus=%s proofReceipts=%s anthropicLedger=%s joinedProof=%s surfaceBoundProof=%s\n' \
-    "${work_status:-<none>}" "${proof_count}" "${ledger_count}" "${joined_proof}" "${surface_bound_proof}"
+  printf 'Polling: outcomeChecked=%s workStatus=%s proofReceipts=%s anthropicLedger=%s joinedProof=%s surfaceBoundProof=%s\n' \
+    "${OUTCOME_CHECKED}" "${work_status:-<none>}" "${proof_count}" "${ledger_count}" "${joined_proof}" "${surface_bound_proof}"
   if [ "${joined_proof}" -gt 0 ] && [ "${surface_bound_proof}" -gt 0 ]; then
     break
   fi
@@ -531,41 +580,92 @@ echo "Work item: ${WORK_ITEM_ID}"
 echo "Started at ms: ${STARTED_AT_MS}"
 echo
 echo "Claude proof joined rows:"
-sql_json "
-  WITH proof AS (
+if [ "${OUTCOME_CHECKED}" = "1" ]; then
+  sql_json "
+    WITH raw_proof AS (
+      SELECT
+        w.work_item_id AS work_item_id,
+        w.mission_id AS mission_id,
+        w.status AS status,
+        proof.value AS proof_receipt,
+        replace(proof.value, 'proof://outcome/AnswerProduced/', '') AS payload
+      FROM work_item w
+      JOIN json_each(w.proof_receipts) proof
+        ON proof.value IS NOT NULL
+      WHERE w.work_item_id='${WORK_ITEM_ID}'
+        AND w.mission_id='${MISSION_ID}'
+        AND w.lane='claude'
+        AND COALESCE(w.target_provider_or_agent,'')='claude'
+        AND proof.value LIKE 'proof://outcome/AnswerProduced/%?signal=answer_len=%'
+    ),
+    proof AS (
+      SELECT
+        work_item_id,
+        mission_id,
+        status,
+        proof_receipt,
+        CASE WHEN instr(payload, '?') > 0 THEN substr(payload, 1, instr(payload, '?') - 1) ELSE payload END AS run_id,
+        CASE WHEN instr(payload, 'answer_len=') > 0 THEN substr(payload, instr(payload, 'answer_len=') + length('answer_len=')) ELSE '' END AS answer_len
+      FROM raw_proof
+    )
     SELECT
-      w.work_item_id AS work_item_id,
-      w.mission_id AS mission_id,
-      w.status AS status,
-      proof.value AS proof_receipt,
-      replace(proof.value, 'friday://agent-run/', '') AS run_id
-    FROM work_item w
-    JOIN json_each(w.proof_receipts) proof
-      ON proof.value IS NOT NULL
-    WHERE w.work_item_id='${WORK_ITEM_ID}'
-      AND w.mission_id='${MISSION_ID}'
-      AND w.lane='claude'
-      AND COALESCE(w.target_provider_or_agent,'')='claude'
-  )
-  SELECT
-    p.work_item_id,
-    p.mission_id,
-    p.status,
-    p.proof_receipt,
-    ledger.run_id,
-    ledger.provider_kind,
-    ledger.model,
-    ledger.base_url_host,
-    ledger.total_tokens,
-    ledger.fallback,
-    datetime(ledger.created_at/1000,'unixepoch') AS created_at_utc
-  FROM proof p
-  JOIN token_ledger ledger
-    ON ledger.run_id=p.run_id
-  WHERE ledger.created_at >= ${STARTED_AT_MS}
-  ORDER BY ledger.created_at DESC
-  LIMIT 5;
-"
+      p.work_item_id,
+      p.mission_id,
+      p.status,
+      p.proof_receipt,
+      p.run_id,
+      p.answer_len,
+      ledger.provider_kind,
+      ledger.model,
+      ledger.base_url_host,
+      ledger.total_tokens,
+      ledger.fallback,
+      datetime(ledger.created_at/1000,'unixepoch') AS created_at_utc
+    FROM proof p
+    JOIN token_ledger ledger
+      ON ledger.run_id=p.run_id
+    WHERE ledger.created_at >= ${STARTED_AT_MS}
+      AND CAST(p.answer_len AS INTEGER) > 0
+    ORDER BY ledger.created_at DESC
+    LIMIT 5;
+  "
+else
+  sql_json "
+    WITH proof AS (
+      SELECT
+        w.work_item_id AS work_item_id,
+        w.mission_id AS mission_id,
+        w.status AS status,
+        proof.value AS proof_receipt,
+        replace(proof.value, 'friday://agent-run/', '') AS run_id
+      FROM work_item w
+      JOIN json_each(w.proof_receipts) proof
+        ON proof.value IS NOT NULL
+      WHERE w.work_item_id='${WORK_ITEM_ID}'
+        AND w.mission_id='${MISSION_ID}'
+        AND w.lane='claude'
+        AND COALESCE(w.target_provider_or_agent,'')='claude'
+    )
+    SELECT
+      p.work_item_id,
+      p.mission_id,
+      p.status,
+      p.proof_receipt,
+      ledger.run_id,
+      ledger.provider_kind,
+      ledger.model,
+      ledger.base_url_host,
+      ledger.total_tokens,
+      ledger.fallback,
+      datetime(ledger.created_at/1000,'unixepoch') AS created_at_utc
+    FROM proof p
+    JOIN token_ledger ledger
+      ON ledger.run_id=p.run_id
+    WHERE ledger.created_at >= ${STARTED_AT_MS}
+    ORDER BY ledger.created_at DESC
+    LIMIT 5;
+  "
+fi
 echo
 echo "Work item row:"
 sql_json "SELECT work_item_id, mission_id, lane, target_provider_or_agent, status, proof_receipts, datetime(updated_at_ms/1000,'unixepoch') AS updated_at_utc FROM work_item WHERE work_item_id='${WORK_ITEM_ID}' LIMIT 1;"
@@ -578,13 +678,21 @@ sql_json "SELECT surface_thread_id, friday_conversation_id, mission_id, surface_
 echo "----------------------------------------------"
 
 if [ "${joined_proof:-0}" -gt 0 ] && [ "${surface_bound_proof:-0}" -gt 0 ]; then
-  echo "PASS (STRONG) - this Claude WorkItem completed_with_proof, the proof receipt joins to a same-run non-fallback Anthropic ledger row for ${CLAUDE_MODEL}, and the operator surface binding is present."
+  if [ "${OUTCOME_CHECKED}" = "1" ]; then
+    echo "PASS (STRONG OUTCOME) - this Claude WorkItem completed_with_proof, its AnswerProduced outcome proof receipt joins to a same-run non-fallback Anthropic ledger row for ${CLAUDE_MODEL}, and the operator surface binding is present."
+  else
+    echo "PASS (STRONG) - this Claude WorkItem completed_with_proof, the proof receipt joins to a same-run non-fallback Anthropic ledger row for ${CLAUDE_MODEL}, and the operator surface binding is present."
+  fi
   echo "Truth: operator-triggered Claude mission proof, not D8 / not soak / not UI-device-channel proof / not GO."
   exit 0
 fi
 
 if [ "${joined_proof:-0}" -gt 0 ]; then
-  echo "PASS (PARTIAL) - Claude WorkItem proof receipt joined to Anthropic ledger, but bound Mission SurfaceThread was not proven in the polling window."
+  if [ "${OUTCOME_CHECKED}" = "1" ]; then
+    echo "PASS (PARTIAL OUTCOME) - Claude WorkItem AnswerProduced outcome proof receipt joined to Anthropic ledger, but bound Mission SurfaceThread was not proven in the polling window."
+  else
+    echo "PASS (PARTIAL) - Claude WorkItem proof receipt joined to Anthropic ledger, but bound Mission SurfaceThread was not proven in the polling window."
+  fi
   echo "Truth: Claude route+ledger proof is present, but operator surface binding remains incomplete."
   exit 2
 fi

--- a/src/api/http/routes/friday-mission-spine-routes.ts
+++ b/src/api/http/routes/friday-mission-spine-routes.ts
@@ -199,6 +199,28 @@ function readOptionalBoolean(
   return value;
 }
 
+function readOptionalStringArray(
+  body: Record<string, unknown>,
+  field: string,
+  failures: string[],
+): string[] | undefined {
+  const value = body[field];
+  if (value === undefined || value === null) return undefined;
+  if (!Array.isArray(value) || value.length === 0) {
+    failures.push(`${field}_invalid`);
+    return undefined;
+  }
+  const items: string[] = [];
+  for (const entry of value) {
+    if (typeof entry !== "string" || entry.trim().length === 0) {
+      failures.push(`${field}_invalid`);
+      return undefined;
+    }
+    items.push(entry.trim());
+  }
+  return items;
+}
+
 const WORK_ITEM_COMPLETED_WITH_PROOF = "completed_with_proof";
 
 /** Validate a Mission intake body into the typed request (or throw a typed 400). */
@@ -220,6 +242,7 @@ function validateIntakeBody(body: unknown): FridayRustHubMissionIntakeRequest {
   const targetProviderOrAgent = readOptionalString(b, "targetProviderOrAgent", failures);
   const capabilityId = readOptionalString(b, "capabilityId", failures);
   const bodyRef = readOptionalString(b, "bodyRef", failures);
+  const proofRequirements = readOptionalStringArray(b, "proofRequirements", failures);
   const includesSensitiveContext = readOptionalBoolean(b, "includesSensitiveContext", failures);
   if (
     failures.length > 0 ||
@@ -252,6 +275,7 @@ function validateIntakeBody(body: unknown): FridayRustHubMissionIntakeRequest {
     ...(targetProviderOrAgent !== undefined ? { targetProviderOrAgent } : {}),
     ...(capabilityId !== undefined ? { capabilityId } : {}),
     ...(bodyRef !== undefined ? { bodyRef } : {}),
+    ...(proofRequirements !== undefined ? { proofRequirements } : {}),
     ...(includesSensitiveContext !== undefined ? { includesSensitiveContext } : {}),
   };
 }

--- a/src/api/mission-spine/friday-rust-hub-agent-run-ws-sealed-client.ts
+++ b/src/api/mission-spine/friday-rust-hub-agent-run-ws-sealed-client.ts
@@ -454,6 +454,7 @@ export interface FridayRustHubMissionIntakeRequest {
   readonly targetProviderOrAgent?: string;
   readonly capabilityId?: string;
   readonly bodyRef?: string;
+  readonly proofRequirements?: readonly string[];
   readonly includesSensitiveContext?: boolean;
 }
 
@@ -925,6 +926,7 @@ export function buildMissionIntakeEnvelope(
       : {}),
     ...(request.capabilityId !== undefined ? { capability_id: request.capabilityId } : {}),
     ...(request.bodyRef !== undefined ? { body_ref: request.bodyRef } : {}),
+    ...(request.proofRequirements !== undefined ? { proof_requirements: request.proofRequirements } : {}),
     // `includes_sensitive_context` is `#[serde(default)]` WITHOUT `skip_serializing_if` Rust-side,
     // so an absent key deserializes to `false` (interop-safe). We OMIT it when false to keep the
     // outbound minimal; serde's `default` accepts the omission. We only EMIT it when true.

--- a/test/unit/api/mission-spine/friday-rust-hub-mission-spine-wire.test.ts
+++ b/test/unit/api/mission-spine/friday-rust-hub-mission-spine-wire.test.ts
@@ -39,7 +39,7 @@ const FULL_INTAKE: FridayRustHubMissionIntakeRequest = {
 };
 
 describe("buildMissionIntakeEnvelope (MissionIntakeRequestWire wire mapping)", () => {
-  it("nests the required fields under `request` + kind, omitting all four optionals when absent", () => {
+  it("nests the required fields under `request` + kind, omitting all optionals when absent", () => {
     const env = buildMissionIntakeEnvelope(FULL_INTAKE);
     expect(env.schema_version).toBe(12);
     expect(env.msg_id).toBe("mission-intake-mission_x");
@@ -66,6 +66,7 @@ describe("buildMissionIntakeEnvelope (MissionIntakeRequestWire wire mapping)", (
     expect("target_provider_or_agent" in request).toBe(false);
     expect("capability_id" in request).toBe(false);
     expect("body_ref" in request).toBe(false);
+    expect("proof_requirements" in request).toBe(false);
     expect("includes_sensitive_context" in request).toBe(false);
   });
 
@@ -75,12 +76,14 @@ describe("buildMissionIntakeEnvelope (MissionIntakeRequestWire wire mapping)", (
       targetProviderOrAgent: "deepseek-v4",
       capabilityId: "cap_x",
       bodyRef: "body://ref",
+      proofRequirements: ["outcome:AnswerProduced:>=1"],
       includesSensitiveContext: true,
     }).message as Record<string, unknown>;
     const request = message.request as Record<string, unknown>;
     expect(request.target_provider_or_agent).toBe("deepseek-v4");
     expect(request.capability_id).toBe("cap_x");
     expect(request.body_ref).toBe("body://ref");
+    expect(request.proof_requirements).toEqual(["outcome:AnswerProduced:>=1"]);
     expect(request.includes_sensitive_context).toBe(true);
   });
 

--- a/test/unit/api/routes/friday-mission-spine-routes.test.ts
+++ b/test/unit/api/routes/friday-mission-spine-routes.test.ts
@@ -733,11 +733,19 @@ describe("createFridayMissionSpineRoutes — Lane B organic mutation routes", ()
       const routes = createFridayMissionSpineRoutes({ workbench: null, disabledReason: null, dispatch });
       const route = findPost(routes, "mission.spine.intake.create");
       const response = await route.handler(
-        makeCtx({ principal: BOUND_PRINCIPAL, body: { ...VALID_INTAKE_BODY, includesSensitiveContext: true } }) as never,
+        makeCtx({
+          principal: BOUND_PRINCIPAL,
+          body: {
+            ...VALID_INTAKE_BODY,
+            proofRequirements: [" outcome:AnswerProduced:>=1 "],
+            includesSensitiveContext: true,
+          },
+        }) as never,
       );
       expect(intake).toHaveBeenCalledTimes(1);
       expect(intake).toHaveBeenCalledWith({
         ...VALID_INTAKE_BODY,
+        proofRequirements: ["outcome:AnswerProduced:>=1"],
         includesSensitiveContext: true,
       });
       expect((response as { result: { status: string } }).result.status).toBe("ready");
@@ -796,6 +804,26 @@ describe("createFridayMissionSpineRoutes — Lane B organic mutation routes", ()
       expect((thrown as FridayDomainError).code).toBe("MISSION_SPINE_DISPATCH_REQUEST_INVALID");
       expect((thrown as FridayDomainError).httpStatus).toBe(400);
       expect(JSON.stringify((thrown as FridayDomainError).details)).toContain("missionId_missing_or_empty");
+      expect(intake).not.toHaveBeenCalled();
+    });
+
+    it("intake rejects invalid proofRequirements before dispatch", async () => {
+      const { dispatch, intake } = makeDispatch();
+      const routes = createFridayMissionSpineRoutes({ workbench: null, disabledReason: null, dispatch });
+      const route = findPost(routes, "mission.spine.intake.create");
+      let thrown: unknown = null;
+      try {
+        await route.handler(
+          makeCtx({
+            principal: BOUND_PRINCIPAL,
+            body: { ...VALID_INTAKE_BODY, proofRequirements: [""] },
+          }) as never,
+        );
+      } catch (err) {
+        thrown = err;
+      }
+      expect((thrown as FridayDomainError).httpStatus).toBe(400);
+      expect(JSON.stringify((thrown as FridayDomainError).details)).toContain("proofRequirements_invalid");
       expect(intake).not.toHaveBeenCalled();
     });
 

--- a/test/unit/scripts/ops/friday-claude-mission-proof-gates.test.ts
+++ b/test/unit/scripts/ops/friday-claude-mission-proof-gates.test.ts
@@ -29,9 +29,11 @@ describe("Claude mission proof operator gate", () => {
 
     expect(source).toContain("FRIDAY_CLAUDE_MISSION_PROOF_PREFLIGHT_ONLY");
     expect(source).toContain("FRIDAY_CLAUDE_MISSION_PROOF_PASSPHRASE_STDIN");
+    expect(source).toContain("FRIDAY_CLAUDE_MISSION_PROOF_OUTCOME_CHECKED");
     expect(source).toContain('readonly CLAUDE_MODEL="claude-opus-4-8"');
     expect(source).toContain('lane: "claude"');
     expect(source).toContain('targetProviderOrAgent: "claude"');
+    expect(source).toContain('proofRequirements: ["outcome:AnswerProduced:>=1"]');
     expect(source).toContain(
       'deliveryRoute: "ops://claude-mission-proof-of-life"',
     );
@@ -54,6 +56,9 @@ describe("Claude mission proof operator gate", () => {
     expect(source).toContain(
       "p.proof_receipt = 'friday://agent-run/' || ledger.run_id",
     );
+    expect(source).toContain("proof://outcome/AnswerProduced/");
+    expect(source).toContain("answer_len");
+    expect(source).toContain("CAST(p.answer_len AS INTEGER) > 0");
     expect(source).toContain("ledger.provider_kind='anthropic'");
     expect(source).toContain("ledger.model='${CLAUDE_MODEL}'");
     expect(source).toContain("ledger.fallback=0");
@@ -64,6 +69,8 @@ describe("Claude mission proof operator gate", () => {
     );
     expect(source).toContain("PASS (STRONG)");
     expect(source).toContain("PASS (PARTIAL)");
+    expect(source).toContain("PASS (STRONG OUTCOME)");
+    expect(source).toContain("PASS (PARTIAL OUTCOME)");
     expect(source).toContain(
       "Truth: operator-triggered Claude mission proof, not D8 / not soak / not UI-device-channel proof / not GO.",
     );


### PR DESCRIPTION
## Summary
- Adds optional Mission Spine `proofRequirements` intake support through the TS route, sealed WS wire, and Rust protocol.
- Persists requested proof requirements on intake-created WorkItems and judgment memory, while preserving the existing default provider-proof requirement when omitted.
- Lets mission-bound Claude finished runs satisfy `outcome:AnswerProduced` with a typed `proof://outcome/AnswerProduced/{run_id}?signal=answer_len=N` completion receipt, and adds outcome-aware Claude proof-of-life script checks.

## Why
Production had Anthropic ledger-backed Claude proof, but no real `proof://outcome` receipt instances. This is the minimal slice needed to request and prove an `AnswerProduced` outcome without weakening existing completion gates.

## Validation
- `bash -n scripts/ops/friday-claude-mission-proof-of-life.sh`
- `FRIDAY_CLAUDE_MISSION_PROOF_PREFLIGHT_ONLY=1 scripts/ops/friday-claude-mission-proof-of-life.sh`
- `FRIDAY_CLAUDE_MISSION_PROOF_OUTCOME_CHECKED=1 FRIDAY_CLAUDE_MISSION_PROOF_PREFLIGHT_ONLY=1 scripts/ops/friday-claude-mission-proof-of-life.sh`
- `npx vitest run test/unit/scripts/ops/friday-claude-mission-proof-gates.test.ts test/unit/api/routes/friday-mission-spine-routes.test.ts test/unit/api/mission-spine/friday-rust-hub-mission-spine-wire.test.ts --project default`
- `cargo check -p friday-hub --lib`
- `cargo test -p friday-hub mission_bound_claude_loop_mints_answer_produced_outcome_receipt_when_required`
- `cargo test -p friday-hub mission_bound_claude_loop_routes_to_claude_and_records_anthropic_binding`
- `cargo test -p friday-hub headless_e2e_mission_intake_mobile_create_desktop_channel_duplicate_bind_same_mission`
- `cargo test -p friday-protocol`
- `npx tsc --noEmit`
- `npm run check:secret-patterns`
- `git diff --check`
- `npx eslint src/api/http/routes/friday-mission-spine-routes.ts src/api/mission-spine/friday-rust-hub-agent-run-ws-sealed-client.ts test/unit/api/mission-spine/friday-rust-hub-mission-spine-wire.test.ts test/unit/api/routes/friday-mission-spine-routes.test.ts test/unit/scripts/ops/friday-claude-mission-proof-gates.test.ts` (warnings only: pre-existing security/max-lines plus ignored test-file warnings)

## Notes
- Default Claude mission proof behavior remains covered by the existing `friday://agent-run/{run_id}` test.
- Producing a live outcome proof after deploy still requires the Rust process to run with `FRIDAY_OUTCOME_CHECKED_PROOF=1`.