### PR TITLE
Fail closed on Rust hub schema mismatch

### DIFF
--- a/src/state/index.ts
+++ b/src/state/index.ts
@@ -8,6 +8,7 @@ import { createFridayMigrationTelemetryWriter } from "./telemetry/friday-migrati
 import type { FridayMigrationTelemetryWriter } from "./telemetry/friday-migration-telemetry.js";
 import { resolveStateDir } from "./paths/friday-state-dir-resolver.js";
 import { createFridaySqliteLayer } from "./sqlite/friday-sqlite-layer.js";
+import { verifyFridayRustHubSchemaHandshake } from "./sqlite/friday-rust-hub-schema-handshake.js";
 
 // SQLite types
 export type {
@@ -35,6 +36,11 @@ export type {
 
 // Migration runner
 export { runFridayMigrations } from "./sqlite/friday-migration-runner.js";
+export {
+  FRIDAY_EXPECTED_RUST_HUB_SCHEMA_VERSION,
+  FRIDAY_HUB_AGENT_RUN_DB_PATH_ENV,
+  verifyFridayRustHubSchemaHandshake,
+} from "./sqlite/friday-rust-hub-schema-handshake.js";
 
 // Migration types
 export type { FridaySqliteMigration } from "./sqlite/migrations/friday-migration.types.js";
@@ -77,7 +83,13 @@ export function initializeFridayState(
     summaryFileName: config.telemetry.summaryFileName,
   });
 
-  // 4. Create sqlite layer (includes migrations)
+  // 4. Fail closed if a configured/present Rust hub DB is not this build's schema peer.
+  const rustHubSchemaHandshake = verifyFridayRustHubSchemaHandshake({
+    stateDir,
+    env: options?.env,
+  });
+
+  // 5. Create sqlite layer (includes migrations)
   const dbPath = `${stateDir}/friday.db`;
   const sqlite = createFridaySqliteLayer({
     dbPath,
@@ -88,11 +100,11 @@ export function initializeFridayState(
     },
   });
 
-  // 5. Record migration telemetry
+  // 6. Record migration telemetry
   telemetry.record({
     type: "sqlite-migration",
     status: "ok",
-    message: "Phase 0 state initialized",
+    message: `Phase 0 state initialized; rust hub schema handshake=${rustHubSchemaHandshake.status}`,
   });
 
   return {

--- a/src/state/sqlite/friday-rust-hub-schema-handshake.ts
+++ b/src/state/sqlite/friday-rust-hub-schema-handshake.ts
@@ -1,0 +1,112 @@
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+
+import Database from "better-sqlite3";
+
+import { FridayDomainError } from "#errors";
+
+export const FRIDAY_HUB_AGENT_RUN_DB_PATH_ENV = "FRIDAY_HUB_AGENT_RUN_DB_PATH";
+export const FRIDAY_EXPECTED_RUST_HUB_SCHEMA_VERSION = 34;
+
+export type FridayRustHubSchemaHandshakeStatus = "ok" | "skipped";
+
+export interface FridayRustHubSchemaHandshakeResult {
+  status: FridayRustHubSchemaHandshakeStatus;
+  dbPath: string;
+  expectedVersion: number;
+  actualVersion?: number;
+  reason?: "rust_hub_db_not_present";
+  source: "env" | "state_dir";
+}
+
+export interface VerifyFridayRustHubSchemaHandshakeOptions {
+  stateDir: string;
+  env?: NodeJS.ProcessEnv;
+  expectedVersion?: number;
+}
+
+function readConfiguredRustHubDbPath(env: NodeJS.ProcessEnv): string | undefined {
+  const configured = env[FRIDAY_HUB_AGENT_RUN_DB_PATH_ENV]?.trim();
+  return configured && configured.length > 0 ? configured : undefined;
+}
+
+function readRustHubSchemaVersion(dbPath: string): number {
+  let db: Database.Database | undefined;
+  try {
+    db = new Database(dbPath, { readonly: true, fileMustExist: true });
+    const row = db
+      .prepare("SELECT version FROM schema_version WHERE id = 1")
+      .get() as { version?: unknown } | undefined;
+    const version = row?.version;
+    if (typeof version !== "number" || !Number.isInteger(version)) {
+      throw new FridayDomainError(
+        "RUST_HUB_SCHEMA_HANDSHAKE_FAILED",
+        "Rust hub schema_version row is missing or invalid; refusing to open the split TypeScript runtime.",
+        { httpStatus: 500, details: { dbPath } },
+      );
+    }
+    return version;
+  } catch (error) {
+    if (error instanceof FridayDomainError) {
+      throw error;
+    }
+    throw new FridayDomainError(
+      "RUST_HUB_SCHEMA_HANDSHAKE_FAILED",
+      "Rust hub schema handshake failed; refusing to open the split TypeScript runtime.",
+      {
+        httpStatus: 500,
+        details: {
+          dbPath,
+          cause: error instanceof Error ? error.message : String(error),
+        },
+      },
+    );
+  } finally {
+    db?.close();
+  }
+}
+
+export function verifyFridayRustHubSchemaHandshake(
+  options: VerifyFridayRustHubSchemaHandshakeOptions,
+): FridayRustHubSchemaHandshakeResult {
+  const env = options.env ?? process.env;
+  const expectedVersion = options.expectedVersion ?? FRIDAY_EXPECTED_RUST_HUB_SCHEMA_VERSION;
+  const configuredPath = readConfiguredRustHubDbPath(env);
+  const dbPath = configuredPath ?? join(options.stateDir, "rust-hub.sqlite");
+  const source: FridayRustHubSchemaHandshakeResult["source"] = configuredPath ? "env" : "state_dir";
+
+  if (!configuredPath && !existsSync(dbPath)) {
+    return {
+      status: "skipped",
+      reason: "rust_hub_db_not_present",
+      dbPath,
+      expectedVersion,
+      source,
+    };
+  }
+
+  const actualVersion = readRustHubSchemaVersion(dbPath);
+  if (actualVersion !== expectedVersion) {
+    throw new FridayDomainError(
+      "RUST_HUB_SCHEMA_VERSION_MISMATCH",
+      `Rust hub schema version mismatch: expected ${expectedVersion}, found ${actualVersion}; refusing to open the split TypeScript runtime.`,
+      {
+        httpStatus: 500,
+        details: {
+          dbPath,
+          expectedVersion,
+          actualVersion,
+          source,
+        },
+      },
+    );
+  }
+
+  return {
+    status: "ok",
+    dbPath,
+    expectedVersion,
+    actualVersion,
+    source,
+  };
+}

--- a/test/unit/state/friday-rust-hub-schema-handshake.test.ts
+++ b/test/unit/state/friday-rust-hub-schema-handshake.test.ts
@@ -1,0 +1,155 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { tmpdir } from "node:os";
+
+import Database from "better-sqlite3";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  FRIDAY_EXPECTED_RUST_HUB_SCHEMA_VERSION,
+  FRIDAY_HUB_AGENT_RUN_DB_PATH_ENV,
+  initializeFridayState,
+  verifyFridayRustHubSchemaHandshake,
+} from "#state";
+
+const roots: string[] = [];
+
+function tempRoot(tag: string): string {
+  const root = mkdtempSync(join(tmpdir(), `friday-rust-hub-schema-${tag}-`));
+  roots.push(root);
+  return root;
+}
+
+function createRustHubDb(root: string, version: number): string {
+  const dbPath = join(root, "rust-hub.sqlite");
+  const db = new Database(dbPath);
+  try {
+    db.exec("CREATE TABLE schema_version (id INTEGER PRIMARY KEY CHECK (id = 1), version INTEGER NOT NULL)");
+    db.prepare("INSERT INTO schema_version (id, version) VALUES (1, ?)").run(version);
+  } finally {
+    db.close();
+  }
+  return dbPath;
+}
+
+describe("Friday Rust hub schema handshake", () => {
+  afterEach(() => {
+    while (roots.length > 0) {
+      const root = roots.pop();
+      if (root) rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("passes when the configured Rust hub DB schema matches this build", () => {
+    const root = tempRoot("match");
+    const dbPath = createRustHubDb(root, FRIDAY_EXPECTED_RUST_HUB_SCHEMA_VERSION);
+
+    const result = verifyFridayRustHubSchemaHandshake({
+      stateDir: root,
+      env: { [FRIDAY_HUB_AGENT_RUN_DB_PATH_ENV]: dbPath },
+    });
+
+    expect(result).toMatchObject({
+      status: "ok",
+      dbPath,
+      expectedVersion: FRIDAY_EXPECTED_RUST_HUB_SCHEMA_VERSION,
+      actualVersion: FRIDAY_EXPECTED_RUST_HUB_SCHEMA_VERSION,
+      source: "env",
+    });
+  });
+
+  it("skips only when no Rust hub DB is configured or present", () => {
+    const root = tempRoot("absent");
+
+    const result = verifyFridayRustHubSchemaHandshake({
+      stateDir: root,
+      env: {},
+    });
+
+    expect(result).toMatchObject({
+      status: "skipped",
+      reason: "rust_hub_db_not_present",
+      dbPath: join(root, "rust-hub.sqlite"),
+      source: "state_dir",
+    });
+  });
+
+  it("checks the stateDir Rust hub DB when no explicit path is configured", () => {
+    const root = tempRoot("state-dir");
+    const dbPath = createRustHubDb(root, FRIDAY_EXPECTED_RUST_HUB_SCHEMA_VERSION);
+
+    const result = verifyFridayRustHubSchemaHandshake({
+      stateDir: root,
+      env: {},
+    });
+
+    expect(result).toMatchObject({
+      status: "ok",
+      dbPath,
+      expectedVersion: FRIDAY_EXPECTED_RUST_HUB_SCHEMA_VERSION,
+      actualVersion: FRIDAY_EXPECTED_RUST_HUB_SCHEMA_VERSION,
+      source: "state_dir",
+    });
+  });
+
+  it("fails closed when a configured Rust hub DB is missing", () => {
+    const root = tempRoot("missing");
+    const missingPath = join(root, "missing-rust-hub.sqlite");
+
+    expect(() =>
+      verifyFridayRustHubSchemaHandshake({
+        stateDir: root,
+        env: { [FRIDAY_HUB_AGENT_RUN_DB_PATH_ENV]: missingPath },
+      }),
+    ).toThrow(expect.objectContaining({
+      code: "RUST_HUB_SCHEMA_HANDSHAKE_FAILED",
+    }));
+  });
+
+  it("fails closed when the Rust hub DB schema is not this build's peer", () => {
+    const root = tempRoot("mismatch");
+    const dbPath = createRustHubDb(root, FRIDAY_EXPECTED_RUST_HUB_SCHEMA_VERSION + 1);
+
+    expect(() =>
+      verifyFridayRustHubSchemaHandshake({
+        stateDir: root,
+        env: { [FRIDAY_HUB_AGENT_RUN_DB_PATH_ENV]: dbPath },
+      }),
+    ).toThrow(expect.objectContaining({
+      code: "RUST_HUB_SCHEMA_VERSION_MISMATCH",
+    }));
+  });
+
+  it("blocks TypeScript state initialization before opening friday.db on mismatch", () => {
+    const root = tempRoot("boot");
+    const dbPath = createRustHubDb(root, FRIDAY_EXPECTED_RUST_HUB_SCHEMA_VERSION + 1);
+
+    expect(() =>
+      initializeFridayState({
+        env: {
+          FRIDAY_STATE_DIR: root,
+          [FRIDAY_HUB_AGENT_RUN_DB_PATH_ENV]: dbPath,
+        },
+      }),
+    ).toThrow(expect.objectContaining({
+      code: "RUST_HUB_SCHEMA_VERSION_MISMATCH",
+    }));
+    expect(existsSync(join(root, "friday.db"))).toBe(false);
+  });
+
+  it("pins the expected version to Rust hub_migrations code_max", () => {
+    const schemaPath = resolve("rust-core/crates/friday-storage/src/schema.rs");
+    const schema = readFileSync(schemaPath, "utf8");
+    const hubBlock = schema.slice(
+      schema.indexOf("pub fn hub_migrations()"),
+      schema.indexOf("pub fn phone_migrations()"),
+    );
+    expect(hubBlock).toContain("pub fn hub_migrations()");
+
+    const versions = [...hubBlock.matchAll(/version:\s*(\d+)/gu)]
+      .map((match) => Number(match[1]))
+      .filter((version) => Number.isInteger(version));
+    expect(versions.length).toBeGreaterThan(0);
+    expect(FRIDAY_EXPECTED_RUST_HUB_SCHEMA_VERSION).toBe(Math.max(...versions));
+  });
+});


### PR DESCRIPTION
## Summary
- add a TypeScript boot-time Rust hub schema handshake before opening `friday.db`
- fail closed when configured/present `rust-hub.sqlite` is missing, unreadable, or not schema version 34
- cover configured path, stateDir fallback, mismatch, missing DB, and no-`friday.db` creation on mismatch

## D1 truth boundary
This is the D1(a) schema-handshake slice only. PR #816 already fail-closed the legacy TS durable memory write legs. D1 is still not fully done until remaining writer coverage/proofs and orphan in-flight crash-recovery are landed and verified.

## Verification
- `npx vitest run test/unit/state/friday-rust-hub-schema-handshake.test.ts --project default`
- `npx vitest run test/unit/state/friday-state-index.test.ts test/unit/state/friday-rust-hub-schema-handshake.test.ts --project default`
- `npx tsc --noEmit`
- `git diff --check`
- `npm run check:secret-patterns`
- `npm run check:ts-runtime-retirement`
- `npm run lint` (passes with existing warnings)
- `npm run build`