### PR TITLE
Rehome workflow builder drafts from memory_items

### DIFF
--- a/context/MEMORY.md
+++ b/context/MEMORY.md
@@ -18,4 +18,4 @@
 - Tool call summary (`src/agent/services/friday-tool-call-summary.ts`) captures privacy-safe tool execution metadata (arg keys only, no values) for observability and world model training data.
 - Warn-once pattern is used across 7+ modules (hub-bootstrap, auth, memory, system, http-server, workspace-context, unix-socket-bridge) to deduplicate runtime warnings without losing critical signals.
 - OpenAI Responses API (`openai-responses`) streaming is now supported alongside `openai-completions` in the agent LLM client.
-- Database migration count: 92 (latest: v092-reflex-secure-fact-candidates).
+- Database migration count: 93 (latest: v093-workflow-builder-draft-rehome).

--- a/src/api/runtime/friday-api-runtime.ts
+++ b/src/api/runtime/friday-api-runtime.ts
@@ -39,6 +39,7 @@ import type {
   FridayWorkflowRunNodeEntity,
   FridayWorkflowSpecV1,
   FridayWorkflowVersionEntity,
+  FridayWorkflowVisualGraphV1,
   JsonObject,
 } from "#workflows";
 
@@ -530,6 +531,49 @@ function sanitizePublicWorkflowSpec(spec: FridayWorkflowSpecV1): FridayWorkflowS
     errorPolicy: spec.errorPolicy,
     tests: [],
   };
+}
+
+function defaultDraftVisual(
+  workflowId: string,
+  spec: unknown,
+): FridayWorkflowVisualGraphV1 {
+  const maybeSpec = spec && typeof spec === "object" ? spec as Record<string, unknown> : {};
+  const rawStepIds = Array.isArray(maybeSpec.steps)
+    ? maybeSpec.steps.map((step) => (
+      step && typeof step === "object" && typeof (step as { id?: unknown }).id === "string"
+        ? (step as { id: string }).id
+        : undefined
+    ))
+    : Array.isArray(maybeSpec.nodes)
+      ? maybeSpec.nodes.map((node) => (
+        node && typeof node === "object" && typeof (node as { id?: unknown }).id === "string"
+          ? (node as { id: string }).id
+          : undefined
+      ))
+      : [];
+  const stepIds = rawStepIds.filter((id): id is string => Boolean(id));
+  const nodeIds = stepIds.length > 0 ? stepIds : ["__trigger__"];
+
+  return {
+    schemaVersion: "1.0",
+    workflowId,
+    viewport: { x: 0, y: 0, zoom: 1 },
+    panelLayout: { leftOpen: true, rightOpen: false, bottomOpen: false },
+    nodes: nodeIds.map((nodeId, index) => ({
+      nodeId,
+      x: index * 250,
+      y: 0,
+    })),
+    edges: [],
+  };
+}
+
+function draftVisualOrDefault(
+  workflowId: string,
+  spec: unknown,
+  visual: FridayWorkflowVisualGraphV1 | undefined,
+): FridayWorkflowVisualGraphV1 {
+  return visual ?? defaultDraftVisual(workflowId, spec);
 }
 
 function sanitizePublicWorkflowDraft(draft: FridayWorkflowDraftEntity): FridayWorkflowDraftEntity {
@@ -3196,7 +3240,7 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
         workflowId,
         title: input.title,
         spec: input.spec,
-        visual: input.visual,
+        visual: draftVisualOrDefault(workflowId, input.spec, input.visual),
         ownerUserId: input.ownerUserId,
         baseWorkflowVersionId: input.baseWorkflowVersionId,
       });
@@ -3274,7 +3318,7 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
         draftId,
         lockToken: input.lockToken,
         spec: input.spec,
-        visual: input.visual,
+        visual: input.visual ?? existing.visual,
       });
       return { draft };
     },

--- a/src/state/sqlite/migrations/index.ts
+++ b/src/state/sqlite/migrations/index.ts
@@ -91,6 +91,7 @@ import { V089_WORKFLOW_COMPLETION_VERIFICATION_MIGRATION } from "./v089-workflow
 import { V090_REFLEX_LEARNED_FACT_CANDIDATES_MIGRATION } from "./v090-reflex-learned-fact-candidates.js";
 import { V091_PREFERENCE_FACT_METADATA_MIGRATION } from "./v091-preference-fact-metadata.js";
 import { V092_REFLEX_SECURE_FACT_CANDIDATES_MIGRATION } from "./v092-reflex-secure-fact-candidates.js";
+import { V093_WORKFLOW_BUILDER_DRAFT_REHOME_MIGRATION } from "./v093-workflow-builder-draft-rehome.js";
 
 /**
  * Ordered migration list, always ascending by version.
@@ -188,6 +189,7 @@ export const FRIDAY_SQLITE_MIGRATIONS: readonly FridaySqliteMigration[] = [
   V090_REFLEX_LEARNED_FACT_CANDIDATES_MIGRATION,
   V091_PREFERENCE_FACT_METADATA_MIGRATION,
   V092_REFLEX_SECURE_FACT_CANDIDATES_MIGRATION,
+  V093_WORKFLOW_BUILDER_DRAFT_REHOME_MIGRATION,
 ];
 
 export { V003_PROVIDER_USAGE_COST_ROUTING_MIGRATION };

--- a/src/state/sqlite/migrations/v093-workflow-builder-draft-rehome.ts
+++ b/src/state/sqlite/migrations/v093-workflow-builder-draft-rehome.ts
@@ -1,0 +1,31 @@
+import { computeFridayMigrationChecksum } from "./friday-migration.types.js";
+import type { FridaySqliteMigration } from "./friday-migration.types.js";
+
+export const V093_WORKFLOW_BUILDER_DRAFT_REHOME_SQL = `
+-- V093: Rehome workflow-builder draft metadata out of memory_items.
+--
+-- The dedicated workflow_builder_drafts table predates this migration, but the
+-- repository still used memory_items as an operational KV store. These columns
+-- let the repository preserve the full draft entity while new writes stay out
+-- of the legacy durable-memory table.
+
+ALTER TABLE workflow_builder_drafts
+  ADD COLUMN published_workflow_version_id TEXT;
+
+ALTER TABLE workflow_builder_drafts
+  ADD COLUMN autosave_last_saved_at TEXT;
+
+ALTER TABLE workflow_builder_drafts
+  ADD COLUMN source_review_json TEXT;
+`;
+
+const V093_CHECKSUM = computeFridayMigrationChecksum(
+  V093_WORKFLOW_BUILDER_DRAFT_REHOME_SQL,
+);
+
+export const V093_WORKFLOW_BUILDER_DRAFT_REHOME_MIGRATION: FridaySqliteMigration = {
+  version: 93,
+  name: "v093-workflow-builder-draft-rehome",
+  sql: V093_WORKFLOW_BUILDER_DRAFT_REHOME_SQL,
+  checksum: V093_CHECKSUM,
+};

--- a/src/workflows/builder/persistence/friday-workflow-builder-draft-repository.ts
+++ b/src/workflows/builder/persistence/friday-workflow-builder-draft-repository.ts
@@ -4,8 +4,11 @@ import { FridayDomainError } from "#errors";
 import { safeJsonParse } from "#utilities";
 import type {
   FridayWorkflowDraftEntity,
+  FridayWorkflowDraftSourceReview,
   FridayWorkflowDraftStatus,
 } from "../model/friday-workflow-builder-draft.types.js";
+import type { FridayWorkflowSpecV1 } from "../../model/friday-workflow-spec.types.js";
+import type { FridayWorkflowVisualGraphV1 } from "../model/friday-workflow-builder-canvas.types.js";
 
 // ─── Interface ───
 
@@ -20,10 +23,188 @@ export interface FridayWorkflowBuilderDraftRepository {
 
 // ─── Constants ───
 
-const NAMESPACE = "workflow_builder_drafts";
+const LEGACY_MEMORY_NAMESPACE = "workflow_builder_drafts";
 
-function draftKey(workflowId: UUID, draftId: UUID): string {
-  return `${workflowId}:${draftId}`;
+interface DraftRow {
+  draft_id: string;
+  workflow_id: string;
+  title: string;
+  status: string;
+  revision: number;
+  spec_json: string;
+  visual_json: string;
+  owner_user_id: string | null;
+  base_workflow_version_id: string | null;
+  created_at: string;
+  updated_at: string;
+  autosave_enabled: number;
+  autosave_interval_ms: number;
+  autosave_last_saved_at: string | null;
+  published_workflow_version_id: string | null;
+  source_review_json: string | null;
+}
+
+function rowToDraft(row: DraftRow): FridayWorkflowDraftEntity | null {
+  const spec = safeJsonParse<FridayWorkflowSpecV1>(row.spec_json);
+  const visual = safeJsonParse<FridayWorkflowVisualGraphV1>(row.visual_json);
+  if (!spec || !visual) return null;
+
+  const sourceReview = row.source_review_json
+    ? safeJsonParse<FridayWorkflowDraftSourceReview>(row.source_review_json)
+    : undefined;
+
+  return {
+    draftId: row.draft_id,
+    workflowId: row.workflow_id,
+    ownerUserId: row.owner_user_id ?? undefined,
+    title: row.title,
+    status: row.status as FridayWorkflowDraftStatus,
+    revision: row.revision,
+    baseWorkflowVersionId: row.base_workflow_version_id ?? undefined,
+    spec,
+    visual,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+    publishedVersionId: row.published_workflow_version_id ?? undefined,
+    autosave: {
+      enabled: row.autosave_enabled === 1,
+      intervalMs: row.autosave_interval_ms,
+      lastSavedAt: row.autosave_last_saved_at ?? undefined,
+    },
+    sourceReview,
+  };
+}
+
+function readDraftRowById(
+  db: Database.Database,
+  draftId: UUID,
+): FridayWorkflowDraftEntity | null {
+  const row = db
+    .prepare("SELECT * FROM workflow_builder_drafts WHERE draft_id = ?")
+    .get(draftId) as DraftRow | undefined;
+  return row ? rowToDraft(row) : null;
+}
+
+function readLegacyDraftById(
+  db: Database.Database,
+  draftId: UUID,
+): FridayWorkflowDraftEntity | null {
+  const row = db
+    .prepare(
+      `SELECT value_json FROM memory_items WHERE namespace = ? AND key LIKE ?`,
+    )
+    .get(LEGACY_MEMORY_NAMESPACE, `%:${draftId}`) as { value_json: string } | undefined;
+  return row ? safeJsonParse<FridayWorkflowDraftEntity>(row.value_json) ?? null : null;
+}
+
+function insertDraftRow(db: Database.Database, draft: FridayWorkflowDraftEntity): void {
+  db.prepare(
+    `INSERT INTO workflow_builder_drafts (
+      draft_id, workflow_id, title, status, revision, spec_json, visual_json,
+      owner_user_id, base_workflow_version_id, created_at, updated_at,
+      autosave_enabled, autosave_interval_ms, autosave_last_saved_at,
+      published_workflow_version_id, source_review_json
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+  ).run(
+    draft.draftId,
+    draft.workflowId,
+    draft.title,
+    draft.status,
+    draft.revision,
+    JSON.stringify(draft.spec),
+    JSON.stringify(draft.visual),
+    draft.ownerUserId ?? null,
+    draft.baseWorkflowVersionId ?? null,
+    draft.createdAt,
+    draft.updatedAt,
+    draft.autosave.enabled ? 1 : 0,
+    draft.autosave.intervalMs,
+    draft.autosave.lastSavedAt ?? null,
+    draft.publishedVersionId ?? null,
+    draft.sourceReview ? JSON.stringify(draft.sourceReview) : null,
+  );
+}
+
+function upsertDraftRow(db: Database.Database, draft: FridayWorkflowDraftEntity): void {
+  db.prepare(
+    `INSERT INTO workflow_builder_drafts (
+      draft_id, workflow_id, title, status, revision, spec_json, visual_json,
+      owner_user_id, base_workflow_version_id, created_at, updated_at,
+      autosave_enabled, autosave_interval_ms, autosave_last_saved_at,
+      published_workflow_version_id, source_review_json
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    ON CONFLICT(draft_id) DO UPDATE SET
+      workflow_id = excluded.workflow_id,
+      title = excluded.title,
+      status = excluded.status,
+      revision = excluded.revision,
+      spec_json = excluded.spec_json,
+      visual_json = excluded.visual_json,
+      owner_user_id = excluded.owner_user_id,
+      base_workflow_version_id = excluded.base_workflow_version_id,
+      updated_at = excluded.updated_at,
+      autosave_enabled = excluded.autosave_enabled,
+      autosave_interval_ms = excluded.autosave_interval_ms,
+      autosave_last_saved_at = excluded.autosave_last_saved_at,
+      published_workflow_version_id = excluded.published_workflow_version_id,
+      source_review_json = excluded.source_review_json`,
+  ).run(
+    draft.draftId,
+    draft.workflowId,
+    draft.title,
+    draft.status,
+    draft.revision,
+    JSON.stringify(draft.spec),
+    JSON.stringify(draft.visual),
+    draft.ownerUserId ?? null,
+    draft.baseWorkflowVersionId ?? null,
+    draft.createdAt,
+    draft.updatedAt,
+    draft.autosave.enabled ? 1 : 0,
+    draft.autosave.intervalMs,
+    draft.autosave.lastSavedAt ?? null,
+    draft.publishedVersionId ?? null,
+    draft.sourceReview ? JSON.stringify(draft.sourceReview) : null,
+  );
+}
+
+function readLegacyDraftsByWorkflow(
+  db: Database.Database,
+  workflowId: UUID,
+): FridayWorkflowDraftEntity[] {
+  const rows = db
+    .prepare(
+      `SELECT value_json FROM memory_items WHERE namespace = ? AND key LIKE ? ORDER BY updated_at DESC`,
+    )
+    .all(LEGACY_MEMORY_NAMESPACE, `${workflowId}:%`) as Array<{ value_json: string }>;
+  return rows
+    .map((row) => safeJsonParse<FridayWorkflowDraftEntity>(row.value_json))
+    .filter((draft): draft is FridayWorkflowDraftEntity => draft !== undefined);
+}
+
+function readLegacyDraftsByStatus(
+  db: Database.Database,
+  status: FridayWorkflowDraftStatus,
+): FridayWorkflowDraftEntity[] {
+  const rows = db
+    .prepare(
+      `SELECT value_json FROM memory_items WHERE namespace = ? ORDER BY updated_at DESC`,
+    )
+    .all(LEGACY_MEMORY_NAMESPACE) as Array<{ value_json: string }>;
+  return rows
+    .map((row) => safeJsonParse<FridayWorkflowDraftEntity>(row.value_json))
+    .filter((draft): draft is FridayWorkflowDraftEntity => draft?.status === status);
+}
+
+function mergeLegacyDrafts(
+  rows: FridayWorkflowDraftEntity[],
+  legacyRows: FridayWorkflowDraftEntity[],
+): FridayWorkflowDraftEntity[] {
+  const seen = new Set(rows.map((row) => row.draftId));
+  return [
+    ...rows,
+    ...legacyRows.filter((row) => !seen.has(row.draftId)),
+  ].sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
 }
 
 // ─── Factory ───
@@ -31,65 +212,42 @@ function draftKey(workflowId: UUID, draftId: UUID): string {
 export function createFridayWorkflowBuilderDraftRepository(): FridayWorkflowBuilderDraftRepository {
   return {
     create(db, draft) {
-      db.prepare(
-        `INSERT INTO memory_items (id, namespace, key, value_json, tags_json, created_at, updated_at)
-         VALUES (?, ?, ?, ?, ?, ?, ?)`,
-      ).run(
-        draft.draftId,
-        NAMESPACE,
-        draftKey(draft.workflowId, draft.draftId),
-        JSON.stringify(draft),
-        JSON.stringify([draft.status]),
-        draft.createdAt,
-        draft.updatedAt,
-      );
+      insertDraftRow(db, draft);
     },
 
     getById(db, draftId) {
-      const row = db
-        .prepare(
-          `SELECT value_json FROM memory_items WHERE namespace = ? AND key LIKE ?`,
-        )
-        .get(NAMESPACE, `%:${draftId}`) as { value_json: string } | undefined;
-      return row ? safeJsonParse<FridayWorkflowDraftEntity>(row.value_json) ?? null : null;
+      return readDraftRowById(db, draftId) ?? readLegacyDraftById(db, draftId);
     },
 
     listByWorkflow(db, workflowId) {
       const rows = db
         .prepare(
-          `SELECT value_json FROM memory_items WHERE namespace = ? AND key LIKE ? ORDER BY updated_at DESC`,
+          `SELECT * FROM workflow_builder_drafts WHERE workflow_id = ? ORDER BY updated_at DESC`,
         )
-        .all(NAMESPACE, `${workflowId}:%`) as Array<{ value_json: string }>;
-      return rows.map((r) => safeJsonParse<FridayWorkflowDraftEntity>(r.value_json)).filter((r): r is FridayWorkflowDraftEntity => r !== undefined);
+        .all(workflowId) as DraftRow[];
+      const drafts = rows
+        .map((row) => rowToDraft(row))
+        .filter((draft): draft is FridayWorkflowDraftEntity => draft !== null);
+      return mergeLegacyDrafts(drafts, readLegacyDraftsByWorkflow(db, workflowId));
     },
 
     listByStatus(db, status) {
       const rows = db
         .prepare(
-          `SELECT value_json FROM memory_items WHERE namespace = ? ORDER BY updated_at DESC`,
+          `SELECT * FROM workflow_builder_drafts WHERE status = ? ORDER BY updated_at DESC`,
         )
-        .all(NAMESPACE) as Array<{ value_json: string }>;
-      return rows
-        .map((r) => safeJsonParse<FridayWorkflowDraftEntity>(r.value_json)).filter((d): d is FridayWorkflowDraftEntity => d !== undefined)
-        .filter((d) => d.status === status);
+        .all(status) as DraftRow[];
+      const drafts = rows
+        .map((row) => rowToDraft(row))
+        .filter((draft): draft is FridayWorkflowDraftEntity => draft !== null);
+      return mergeLegacyDrafts(drafts, readLegacyDraftsByStatus(db, status));
     },
 
     update(db, draft) {
-      const result = db
-        .prepare(
-          `UPDATE memory_items SET value_json = ?, tags_json = ?, updated_at = ?
-           WHERE namespace = ? AND key = ?`,
-        )
-        .run(
-          JSON.stringify(draft),
-          JSON.stringify([draft.status]),
-          draft.updatedAt,
-          NAMESPACE,
-          draftKey(draft.workflowId, draft.draftId),
-        );
-      if (result.changes === 0) {
+      if (!this.getById(db, draft.draftId)) {
         throw new FridayDomainError("DRAFT_NOT_FOUND", "DRAFT_NOT_FOUND", { httpStatus: 404 });
       }
+      upsertDraftRow(db, draft);
     },
 
     updateStatus(db, draftId, status, nowIso) {

--- a/test/e2e/ui/friday-surface-interaction-benchmark.test.ts
+++ b/test/e2e/ui/friday-surface-interaction-benchmark.test.ts
@@ -290,13 +290,27 @@ async function createBuilderDraft(env: FridayMockBrowserE2eEnv) {
     ?? templateList.json.data.items[0]?.templateId;
   expect(templateId).toBeTruthy();
 
+  const unique = `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+  const workflow = await env.apiFetch<{
+    workflow: {
+      id: string;
+    };
+  }>("POST", "/v1/workflows", {
+    slug: `benchmark-${unique}`,
+    name: "Workflow Benchmark Draft",
+    tags: ["browser-e2e", "benchmark"],
+    graph: { nodes: [], edges: [] },
+  });
+  expect(workflow.status).toBe(200);
+  expect(workflow.json.ok).toBe(true);
+
   const instantiate = await env.apiFetch<{
     draft: {
       workflowId: string;
       draftId: string;
     };
   }>("POST", `/v1/workflow-builder/templates/${encodeURIComponent(String(templateId))}/instantiate`, {
-    workflowId: `benchmark-${Date.now()}`,
+    workflowId: workflow.json.data.workflow.id,
     title: "Workflow Benchmark Draft",
     ownerUserId: "browser-e2e",
     taskProfileId: "planning",

--- a/test/e2e/ui/friday-workflow-builder-performance.test.ts
+++ b/test/e2e/ui/friday-workflow-builder-performance.test.ts
@@ -20,6 +20,23 @@ const BROWSER_E2E_TIMEOUT_MS = 120_000;
 const WORKFLOW_BUILDER_SHELL_BUDGET_MS = 2_000;
 const WORKFLOW_BUILDER_CANVAS_BUDGET_MS = 8_000;
 
+async function createWorkflowParent(env: FridayMockBrowserE2eEnv, name: string): Promise<string> {
+  const unique = `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+  const response = await env.apiFetch<{
+    workflow: {
+      id: string;
+    };
+  }>("POST", "/v1/workflows", {
+    slug: `browser-e2e-${unique}`,
+    name,
+    tags: ["browser-e2e"],
+    graph: { nodes: [], edges: [] },
+  });
+  expect(response.status).toBe(200);
+  expect(response.json.ok).toBe(true);
+  return response.json.data.workflow.id;
+}
+
 describe.skipIf(!CHROMIUM_AVAILABLE)("Friday workflow builder interaction baseline (mock hub browser E2E)", () => {
   let env: FridayMockBrowserE2eEnv | null = null;
   let pageHandle: FridayBrowserPageHandle | null = null;
@@ -58,13 +75,14 @@ describe.skipIf(!CHROMIUM_AVAILABLE)("Friday workflow builder interaction baseli
     const templateId = templates.json.data.stableItems[0]?.id ?? templates.json.data.items[0]?.id;
     expect(templateId).toBeTruthy();
 
+    const workflowId = await createWorkflowParent(env, "Browser E2E Draft");
     const instantiate = await env.apiFetch<{
       draft: {
         workflowId: string;
         draftId: string;
       };
     }>("POST", `/v1/workflow-builder/templates/${encodeURIComponent(String(templateId))}/instantiate`, {
-      workflowId: `browser-e2e-${Date.now()}`,
+      workflowId,
       title: "Browser E2E Draft",
       ownerUserId: "browser-e2e",
       taskProfileId: "planning",

--- a/test/unit/workflows/builder/friday-workflow-builder-compositor-service.test.ts
+++ b/test/unit/workflows/builder/friday-workflow-builder-compositor-service.test.ts
@@ -24,6 +24,7 @@ describe("FridayWorkflowBuilderCompositorService", () => {
 
   beforeEach(() => {
     db = createTestDb();
+    seedWorkflow("wf-1");
   });
 
   afterEach(() => {
@@ -96,6 +97,22 @@ describe("FridayWorkflowBuilderCompositorService", () => {
       crudService,
       specVersionRepo,
     };
+  }
+
+  function seedWorkflow(workflowId: string): void {
+    db.writer
+      .prepare(
+        `INSERT INTO workflows (id, slug, name, latest_version_number, is_archived, revision, etag, created_at, updated_at)
+         VALUES (?, ?, ?, 1, 0, 1, ?, ?, ?)`,
+      )
+      .run(
+        workflowId,
+        `test-${workflowId}`,
+        `Test ${workflowId}`,
+        `etag-${workflowId}`,
+        NOW,
+        NOW,
+      );
   }
 
   it("compiles a valid draft", () => {

--- a/test/unit/workflows/builder/friday-workflow-builder-draft-repository.test.ts
+++ b/test/unit/workflows/builder/friday-workflow-builder-draft-repository.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import type { FridaySqliteLayer } from "#state";
 import { createFridayWorkflowBuilderDraftRepository } from "#workflows";
 import type { FridayWorkflowDraftEntity } from "#workflows";
-import { createTestDb, createTestIdGenerator } from "../_helpers/create-test-db.helper.js";
+import { createTestDb } from "../_helpers/create-test-db.helper.js";
 import { createTestSpec, createTestVisual } from "./_helpers/create-test-spec.helper.js";
 
 describe("FridayWorkflowBuilderDraftRepository", () => {
@@ -11,6 +11,8 @@ describe("FridayWorkflowBuilderDraftRepository", () => {
 
   beforeEach(() => {
     db = createTestDb();
+    seedWorkflow("wf-1");
+    seedWorkflow("wf-2");
   });
 
   afterEach(() => {
@@ -32,6 +34,38 @@ describe("FridayWorkflowBuilderDraftRepository", () => {
       autosave: { enabled: true, intervalMs: 30000 },
       ...overrides,
     };
+  }
+
+  function seedWorkflow(workflowId: string): void {
+    db.writer
+      .prepare(
+        `INSERT INTO workflows (id, slug, name, latest_version_number, is_archived, revision, etag, created_at, updated_at)
+         VALUES (?, ?, ?, 1, 0, 1, ?, ?, ?)`,
+      )
+      .run(
+        workflowId,
+        `test-${workflowId}`,
+        `Test ${workflowId}`,
+        `etag-${workflowId}`,
+        NOW,
+        NOW,
+      );
+  }
+
+  function insertLegacyDraft(draft: FridayWorkflowDraftEntity): void {
+    db.writer
+      .prepare(
+        `INSERT INTO memory_items (id, namespace, key, value_json, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?)`,
+      )
+      .run(
+        draft.draftId,
+        "workflow_builder_drafts",
+        `${draft.workflowId}:${draft.draftId}`,
+        JSON.stringify(draft),
+        draft.createdAt,
+        draft.updatedAt,
+      );
   }
 
   it("creates and retrieves a draft", () => {
@@ -125,23 +159,91 @@ describe("FridayWorkflowBuilderDraftRepository", () => {
     expect(fetched!.status).toBe("archived");
   });
 
-  it("stores namespace and key correctly", () => {
+  it("stores new drafts in the workflow builder table without writing memory_items", () => {
     const repo = createFridayWorkflowBuilderDraftRepository();
-    const draft = makeDraft();
+    const draft = makeDraft({
+      autosave: { enabled: true, intervalMs: 45000, lastSavedAt: "2025-06-15T10:30:00.000Z" },
+      publishedVersionId: "version-1",
+      sourceReview: {
+        source: "external",
+        sourceUrl: "https://example.com/spec",
+        requiresReviewBeforePublish: true,
+        confirmedAt: "2025-06-15T10:15:00.000Z",
+      },
+    });
 
     db.withWriteTransaction((writerDb) => {
       repo.create(writerDb, draft);
     });
 
-    // Verify raw row
     const row = db.withReadConnection((readerDb) =>
       readerDb
-        .prepare("SELECT namespace, key FROM memory_items WHERE id = ?")
+        .prepare(
+          `SELECT draft_id, workflow_id, published_workflow_version_id, autosave_last_saved_at, source_review_json
+           FROM workflow_builder_drafts WHERE draft_id = ?`,
+        )
         .get("draft-1"),
-    ) as { namespace: string; key: string };
+    ) as {
+      draft_id: string;
+      workflow_id: string;
+      published_workflow_version_id: string | null;
+      autosave_last_saved_at: string | null;
+      source_review_json: string | null;
+    };
 
-    expect(row.namespace).toBe("workflow_builder_drafts");
-    expect(row.key).toBe("wf-1:draft-1");
+    const memoryRowCount = db.withReadConnection((readerDb) =>
+      readerDb
+        .prepare("SELECT COUNT(*) AS count FROM memory_items WHERE namespace = ?")
+        .get("workflow_builder_drafts"),
+    ) as { count: number };
+
+    expect(row.draft_id).toBe("draft-1");
+    expect(row.workflow_id).toBe("wf-1");
+    expect(row.published_workflow_version_id).toBe("version-1");
+    expect(row.autosave_last_saved_at).toBe("2025-06-15T10:30:00.000Z");
+    expect(JSON.parse(row.source_review_json ?? "{}")).toMatchObject({
+      source: "external",
+      sourceUrl: "https://example.com/spec",
+      requiresReviewBeforePublish: true,
+    });
+    expect(memoryRowCount.count).toBe(0);
+  });
+
+  it("reads legacy memory_items drafts and updates them into the dedicated table", () => {
+    const repo = createFridayWorkflowBuilderDraftRepository();
+    const legacyDraft = makeDraft({
+      draftId: "legacy-draft",
+      title: "Legacy Draft",
+      updatedAt: "2025-06-15T09:00:00.000Z",
+    });
+    insertLegacyDraft(legacyDraft);
+
+    const fetched = db.withReadConnection((readerDb) => repo.getById(readerDb, "legacy-draft"));
+    expect(fetched!.title).toBe("Legacy Draft");
+
+    db.withWriteTransaction((writerDb) => {
+      repo.update(writerDb, {
+        ...legacyDraft,
+        title: "Promoted Draft",
+        revision: 2,
+        updatedAt: "2025-06-15T11:00:00.000Z",
+      });
+    });
+
+    const dedicatedRow = db.withReadConnection((readerDb) =>
+      readerDb
+        .prepare("SELECT title, revision FROM workflow_builder_drafts WHERE draft_id = ?")
+        .get("legacy-draft"),
+    ) as { title: string; revision: number };
+    const memoryRowCount = db.withReadConnection((readerDb) =>
+      readerDb
+        .prepare("SELECT COUNT(*) AS count FROM memory_items WHERE namespace = ?")
+        .get("workflow_builder_drafts"),
+    ) as { count: number };
+
+    expect(dedicatedRow.title).toBe("Promoted Draft");
+    expect(dedicatedRow.revision).toBe(2);
+    expect(memoryRowCount.count).toBe(1);
   });
 
   it("round-trips JSON correctly", () => {

--- a/test/unit/workflows/builder/friday-workflow-builder-draft-service.test.ts
+++ b/test/unit/workflows/builder/friday-workflow-builder-draft-service.test.ts
@@ -17,6 +17,7 @@ describe("FridayWorkflowBuilderDraftService", () => {
 
   beforeEach(() => {
     db = createTestDb();
+    seedWorkflow("wf-1");
   });
 
   afterEach(() => {
@@ -42,6 +43,22 @@ describe("FridayWorkflowBuilderDraftService", () => {
     });
 
     return { draftService, collaborationService };
+  }
+
+  function seedWorkflow(workflowId: string): void {
+    db.writer
+      .prepare(
+        `INSERT INTO workflows (id, slug, name, latest_version_number, is_archived, revision, etag, created_at, updated_at)
+         VALUES (?, ?, ?, 1, 0, 1, ?, ?, ?)`,
+      )
+      .run(
+        workflowId,
+        `test-${workflowId}`,
+        `Test ${workflowId}`,
+        `etag-${workflowId}`,
+        NOW,
+        NOW,
+      );
   }
 
   it("creates a draft", () => {

--- a/test/unit/workflows/builder/friday-workflow-builder-import-export-service.test.ts
+++ b/test/unit/workflows/builder/friday-workflow-builder-import-export-service.test.ts
@@ -21,6 +21,10 @@ describe("FridayWorkflowBuilderImportExportService", () => {
 
   beforeEach(() => {
     db = createTestDb();
+    seedWorkflow("wf-1");
+    seedWorkflow("wf-original");
+    seedWorkflow("wf-imported");
+    seedWorkflow("wf-new");
   });
 
   afterEach(() => {
@@ -65,6 +69,22 @@ describe("FridayWorkflowBuilderImportExportService", () => {
     });
 
     return { draftService, importExportService };
+  }
+
+  function seedWorkflow(workflowId: string): void {
+    db.writer
+      .prepare(
+        `INSERT INTO workflows (id, slug, name, latest_version_number, is_archived, revision, etag, created_at, updated_at)
+         VALUES (?, ?, ?, 1, 0, 1, ?, ?, ?)`,
+      )
+      .run(
+        workflowId,
+        `test-${workflowId}`,
+        `Test ${workflowId}`,
+        `etag-${workflowId}`,
+        NOW,
+        NOW,
+      );
   }
 
   it("exports a draft as a bundle", () => {

--- a/test/unit/workflows/builder/friday-workflow-builder-runtime.test.ts
+++ b/test/unit/workflows/builder/friday-workflow-builder-runtime.test.ts
@@ -45,6 +45,22 @@ describe("FridayWorkflowBuilderRuntime", () => {
     };
   }
 
+  function seedWorkflow(workflowId: string): void {
+    db.writer
+      .prepare(
+        `INSERT INTO workflows (id, slug, name, latest_version_number, is_archived, revision, etag, created_at, updated_at)
+         VALUES (?, ?, ?, 1, 0, 1, ?, ?, ?)`,
+      )
+      .run(
+        workflowId,
+        `test-${workflowId}`,
+        `Test ${workflowId}`,
+        `etag-${workflowId}`,
+        NOW,
+        NOW,
+      );
+  }
+
   it("exposes all expected services", () => {
     const { runtime } = createRuntime();
 
@@ -59,6 +75,7 @@ describe("FridayWorkflowBuilderRuntime", () => {
 
   it("services are functional and wired correctly", () => {
     const { runtime } = createRuntime();
+    seedWorkflow("wf-rt");
 
     // Create a draft via runtime
     const draft = runtime.drafts.createDraft({
@@ -139,6 +156,7 @@ describe("FridayWorkflowBuilderRuntime", () => {
 
   it("template instantiation creates a functional draft", () => {
     const { runtime } = createRuntime();
+    seedWorkflow("wf-from-template");
 
     const draft = runtime.templates.instantiateTemplate(
       "builtin-simple-action",
@@ -157,6 +175,8 @@ describe("FridayWorkflowBuilderRuntime", () => {
 
   it("import/export roundtrip works", () => {
     const { runtime } = createRuntime();
+    seedWorkflow("wf-export");
+    seedWorkflow("wf-imported");
 
     // Create and export
     const original = runtime.drafts.createDraft({

--- a/test/unit/workflows/builder/friday-workflow-builder-template-service.test.ts
+++ b/test/unit/workflows/builder/friday-workflow-builder-template-service.test.ts
@@ -21,6 +21,8 @@ describe("FridayWorkflowBuilderTemplateService", () => {
 
   beforeEach(() => {
     db = createTestDb();
+    seedWorkflow("wf-new");
+    seedWorkflow("wf-cross-border");
   });
 
   afterEach(() => {
@@ -53,6 +55,22 @@ describe("FridayWorkflowBuilderTemplateService", () => {
       idGenerator: idGen,
       nowIso: () => NOW,
     });
+  }
+
+  function seedWorkflow(workflowId: string): void {
+    db.writer
+      .prepare(
+        `INSERT INTO workflows (id, slug, name, latest_version_number, is_archived, revision, etag, created_at, updated_at)
+         VALUES (?, ?, ?, 1, 0, 1, ?, ?, ?)`,
+      )
+      .run(
+        workflowId,
+        `test-${workflowId}`,
+        `Test ${workflowId}`,
+        `etag-${workflowId}`,
+        NOW,
+        NOW,
+      );
   }
 
   it("lists builtin templates", () => {


### PR DESCRIPTION
## Summary

- rehome workflow-builder draft persistence from `memory_items` into the existing `workflow_builder_drafts` table
- add V093 columns needed to preserve full draft entity metadata (`publishedVersionId`, autosave last-saved timestamp, source review)
- keep legacy `memory_items` draft rows read-compatible and promote them into the dedicated table on update
- update builder tests to seed parent workflows now that writes use the FK-backed dedicated table

## Verification

- `npx vitest run test/unit/workflows/builder/friday-workflow-builder-draft-repository.test.ts --project default`
- `npx vitest run test/unit/workflows/builder/friday-workflow-builder-draft-service.test.ts test/unit/workflows/builder/friday-workflow-builder-compositor-service.test.ts test/unit/workflows/builder/friday-workflow-builder-import-export-service.test.ts --project default`
- `npx vitest run test/integration/state/sqlite/friday-migration-chain.test.ts --project default`
- `npx tsc --noEmit`
- `npm run check:ts-runtime-retirement`
- `npm run check:secret-patterns`
- `npm run lint`
- `npm run build`
- `git diff --check origin/main...HEAD`

## Truth Boundary

This is only one D1(b) write-leg cleanup slice. It removes new workflow-builder draft writes from `memory_items`, but D1(b) remains open for other writer families including builder template/spec-version/test-run, skill generation/harness, workflow generation, skill-run ledger, file sync reverse import, core direct construction, and maintenance deletes. Not full D1, not registry done, not A1 live-done, not v1/goal-achieved.