### PR TITLE
Fail-close memory file reverse imports

### DIFF
--- a/src/memory/index.ts
+++ b/src/memory/index.ts
@@ -67,6 +67,7 @@ export {
   FRIDAY_MEMORY_FILE_SYNC_SESSION_DELTA_BYTES,
   FRIDAY_MEMORY_FILE_SYNC_SESSION_DELTA_MESSAGES,
   FRIDAY_MEMORY_FILE_SYNC_EXPORT_DIR,
+  FRIDAY_MEMORY_FILE_IMPORT_RETIRED_ERROR,
 } from "./sync/friday-memory-file-sync.constants.js";
 
 export { createFridayMemoryFileSyncRepository } from "./sync/friday-memory-file-sync-repository.js";

--- a/src/memory/sync/friday-memory-file-sync-repository.ts
+++ b/src/memory/sync/friday-memory-file-sync-repository.ts
@@ -4,6 +4,7 @@ import type {
   FridayMemoryFileSyncStateRow,
   FridayMemorySyncEntityType,
 } from "./friday-memory-file-sync.types.js";
+import { FRIDAY_MEMORY_FILE_IMPORT_RETIRED_ERROR } from "./friday-memory-file-sync.constants.js";
 
 // ─── Raw DB row shapes ───
 
@@ -109,8 +110,11 @@ export interface FridayMemoryFileSyncRepository {
 
 export function createFridayMemoryFileSyncRepository(deps: {
   db: FridaySqliteLayer;
+  /** Test-only oracle for legacy file -> memory_items reverse imports. */
+  allowTestOnlyMemoryFileImport?: boolean;
 }): FridayMemoryFileSyncRepository {
   const { db } = deps;
+  const allowTestOnlyMemoryFileImport = deps.allowTestOnlyMemoryFileImport === true;
 
   return {
     dirtyCount(): number {
@@ -234,6 +238,10 @@ export function createFridayMemoryFileSyncRepository(deps: {
     },
 
     upsertMemoryItemsFromExport(namespace, items) {
+      if (!allowTestOnlyMemoryFileImport) {
+        throw new Error(FRIDAY_MEMORY_FILE_IMPORT_RETIRED_ERROR);
+      }
+
       return db.withWriteTransaction((conn) => {
         let upserted = 0;
 
@@ -271,6 +279,10 @@ export function createFridayMemoryFileSyncRepository(deps: {
     },
 
     deleteMemoryNamespace(namespace: string): number {
+      if (!allowTestOnlyMemoryFileImport) {
+        throw new Error(FRIDAY_MEMORY_FILE_IMPORT_RETIRED_ERROR);
+      }
+
       return db.withWriteTransaction((conn) => {
         const info = conn.prepare("DELETE FROM memory_items WHERE namespace = ?").run(namespace);
         return info.changes;

--- a/src/memory/sync/friday-memory-file-sync-service.ts
+++ b/src/memory/sync/friday-memory-file-sync-service.ts
@@ -27,6 +27,7 @@ import * as path from "node:path";
 import type { FridayMemoryFileSyncRepository } from "./friday-memory-file-sync-repository.js";
 import { memoryNamespaceExportPath, resolveExportRoot, sessionKeyExportPath } from "./friday-memory-file-sync-paths.js";
 import {
+  FRIDAY_MEMORY_FILE_IMPORT_RETIRED_ERROR,
   FRIDAY_MEMORY_FILE_SYNC_BATCH_SIZE,
   FRIDAY_MEMORY_FILE_SYNC_DEBOUNCE_MS,
   FRIDAY_MEMORY_FILE_SYNC_POLL_INTERVAL_MS,
@@ -58,6 +59,12 @@ export interface CreateFridayMemoryFileSyncServiceDeps {
   enableWatcher?: boolean;
   /** Override watcher debounce for testing. */
   watcherDebounceMs?: number;
+  /**
+   * Test-only oracle for legacy file -> memory_items import behavior.
+   * Production defaults fail-closed so external edits cannot keep splitting
+   * durable memory writes away from the Rust-owned memory path.
+   */
+  allowTestOnlyMemoryFileImport?: boolean;
 }
 
 // ─── Factory ───
@@ -68,6 +75,7 @@ export function createFridayMemoryFileSyncService(
   const { repository, stateDir } = deps;
   const nowIso = deps.nowIso ?? (() => new Date().toISOString());
   const enableWatcher = deps.enableWatcher ?? true;
+  const allowTestOnlyMemoryFileImport = deps.allowTestOnlyMemoryFileImport === true;
 
   let running = false;
   let syncing = false;
@@ -409,6 +417,11 @@ export function createFridayMemoryFileSyncService(
   ): Promise<void> {
     const state = repository.getState(entityType, entityKey);
     if (!state) return;
+
+    if (entityType === "memory_namespace" && !allowTestOnlyMemoryFileImport) {
+      result.errors.push({ entityType, entityKey, message: FRIDAY_MEMORY_FILE_IMPORT_RETIRED_ERROR });
+      return;
+    }
 
     const filePath = state.filePath;
 

--- a/src/memory/sync/friday-memory-file-sync.constants.ts
+++ b/src/memory/sync/friday-memory-file-sync.constants.ts
@@ -15,3 +15,7 @@ export const FRIDAY_MEMORY_FILE_SYNC_SESSION_DELTA_MESSAGES = 50;
 
 /** Export root subdirectory under stateDir. */
 export const FRIDAY_MEMORY_FILE_SYNC_EXPORT_DIR = ".friday/exports";
+
+/** Fail-closed code for legacy file -> memory_items reverse imports. */
+export const FRIDAY_MEMORY_FILE_IMPORT_RETIRED_ERROR =
+  "TS_RUNTIME_MEMORY_FILE_IMPORT_RETIRED: memory file reverse-import into memory_items is disabled by default; use the Rust memory owner/import migration path instead.";

--- a/test/integration/memory/friday-memory-cognition-v1-proof.test.ts
+++ b/test/integration/memory/friday-memory-cognition-v1-proof.test.ts
@@ -239,12 +239,13 @@ describe("Memory cognition v1 proof", () => {
     });
     expect(duplicates.filter((entry) => entry.item.content.includes("dedup advisory only")).length).toBeGreaterThanOrEqual(2);
 
-    const syncRepo = createFridayMemoryFileSyncRepository({ db });
+    const syncRepo = createFridayMemoryFileSyncRepository({ db, allowTestOnlyMemoryFileImport: true });
     const syncService = createFridayMemoryFileSyncService({
       repository: syncRepo,
       stateDir: tmpDir,
       enableWatcher: false,
       nowIso: () => nowIso,
+      allowTestOnlyMemoryFileImport: true,
     });
     const syncResult = await syncService.syncNow({ force: true });
     expect(syncResult.errors).toHaveLength(0);

--- a/test/unit/memory/sync/friday-memory-file-sync-watcher.test.ts
+++ b/test/unit/memory/sync/friday-memory-file-sync-watcher.test.ts
@@ -6,6 +6,7 @@ import { createFridaySqliteLayer } from "#state";
 import {
   createFridayMemoryFileSyncRepository,
   createFridayMemoryFileSyncService,
+  FRIDAY_MEMORY_FILE_IMPORT_RETIRED_ERROR,
   memoryNamespaceExportPath,
 } from "#memory";
 
@@ -80,14 +81,61 @@ describe("FridayMemoryFileSyncService — Watcher & Reindex", () => {
 
   // ─── Reindex: forced reindex from exported file ───
 
-  it("reindexNow imports changed data from file into DB", async () => {
-    insertMemoryItem("item-1", "reindex-ns", "key1", '{"hello":"world"}');
+  it("reindexNow fails closed by default for memory namespace file imports", async () => {
+    insertMemoryItem("item-default-1", "default-off-ns", "key1", '{"hello":"world"}');
 
     const repo = createFridayMemoryFileSyncRepository({ db });
     const service = createFridayMemoryFileSyncService({
       repository: repo,
       stateDir: tmpDir,
       enableWatcher: false,
+    });
+
+    await service.syncNow();
+
+    const filePath = memoryNamespaceExportPath(tmpDir, "default-off-ns");
+    const parsed = JSON.parse(await fs.readFile(filePath, "utf8"));
+    parsed.items[0].value = { hello: "modified" };
+    parsed.items.push({
+      id: "item-default-2",
+      key: "key2",
+      value: { should: "not import" },
+      contentText: null,
+      source: "file-edit",
+      tags: [],
+      metadata: null,
+      createdAt: "2025-01-02T00:00:00Z",
+      updatedAt: "2025-01-02T00:00:00Z",
+    });
+    await fs.writeFile(filePath, JSON.stringify(parsed, null, 2), "utf8");
+
+    const result = await service.reindexNow("memory_namespace", "default-off-ns");
+    expect(result.filesProcessed).toBe(0);
+    expect(result.itemsUpserted).toBe(0);
+    expect(result.itemsDeleted).toBe(0);
+    expect(result.errors).toEqual([{
+      entityType: "memory_namespace",
+      entityKey: "default-off-ns",
+      message: FRIDAY_MEMORY_FILE_IMPORT_RETIRED_ERROR,
+    }]);
+
+    const items = getMemoryItems("default-off-ns");
+    expect(items).toHaveLength(1);
+    expect(items[0]!.id).toBe("item-default-1");
+    expect(items[0]!.value_json).toBe('{"hello":"world"}');
+    expect(() => repo.upsertMemoryItemsFromExport("default-off-ns", [])).toThrow(FRIDAY_MEMORY_FILE_IMPORT_RETIRED_ERROR);
+    expect(() => repo.deleteMemoryNamespace("default-off-ns")).toThrow(FRIDAY_MEMORY_FILE_IMPORT_RETIRED_ERROR);
+  });
+
+  it("reindexNow imports changed data from file into DB", async () => {
+    insertMemoryItem("item-1", "reindex-ns", "key1", '{"hello":"world"}');
+
+    const repo = createFridayMemoryFileSyncRepository({ db, allowTestOnlyMemoryFileImport: true });
+    const service = createFridayMemoryFileSyncService({
+      repository: repo,
+      stateDir: tmpDir,
+      enableWatcher: false,
+      allowTestOnlyMemoryFileImport: true,
     });
 
     // Export to file
@@ -131,11 +179,12 @@ describe("FridayMemoryFileSyncService — Watcher & Reindex", () => {
   it("reindexNow rejects external imports that impersonate learned-fact synthetic ids", async () => {
     insertMemoryItem("item-boundary-1", "boundary-ns", "key1", '{"safe":true}');
 
-    const repo = createFridayMemoryFileSyncRepository({ db });
+    const repo = createFridayMemoryFileSyncRepository({ db, allowTestOnlyMemoryFileImport: true });
     const service = createFridayMemoryFileSyncService({
       repository: repo,
       stateDir: tmpDir,
       enableWatcher: false,
+      allowTestOnlyMemoryFileImport: true,
     });
 
     await service.syncNow();
@@ -170,11 +219,12 @@ describe("FridayMemoryFileSyncService — Watcher & Reindex", () => {
   it("reindexNow skips when file hash matches last export", async () => {
     insertMemoryItem("item-skip", "skip-reindex-ns", "key1", '{"val":1}');
 
-    const repo = createFridayMemoryFileSyncRepository({ db });
+    const repo = createFridayMemoryFileSyncRepository({ db, allowTestOnlyMemoryFileImport: true });
     const service = createFridayMemoryFileSyncService({
       repository: repo,
       stateDir: tmpDir,
       enableWatcher: false,
+      allowTestOnlyMemoryFileImport: true,
     });
 
     // Export to file
@@ -190,11 +240,12 @@ describe("FridayMemoryFileSyncService — Watcher & Reindex", () => {
     insertMemoryItem("item-d1", "del-ns", "key1", '{"val":1}');
     insertMemoryItem("item-d2", "del-ns", "key2", '{"val":2}');
 
-    const repo = createFridayMemoryFileSyncRepository({ db });
+    const repo = createFridayMemoryFileSyncRepository({ db, allowTestOnlyMemoryFileImport: true });
     const service = createFridayMemoryFileSyncService({
       repository: repo,
       stateDir: tmpDir,
       enableWatcher: false,
+      allowTestOnlyMemoryFileImport: true,
     });
 
     // Export
@@ -224,11 +275,12 @@ describe("FridayMemoryFileSyncService — Watcher & Reindex", () => {
     insertMemoryItem("item-a1", "ns-a", "key1", '{"val":"a"}');
     insertMemoryItem("item-b1", "ns-b", "key1", '{"val":"b"}');
 
-    const repo = createFridayMemoryFileSyncRepository({ db });
+    const repo = createFridayMemoryFileSyncRepository({ db, allowTestOnlyMemoryFileImport: true });
     const service = createFridayMemoryFileSyncService({
       repository: repo,
       stateDir: tmpDir,
       enableWatcher: false,
+      allowTestOnlyMemoryFileImport: true,
     });
 
     // Export both
@@ -254,11 +306,12 @@ describe("FridayMemoryFileSyncService — Watcher & Reindex", () => {
   it("reindexNow returns error for missing file", async () => {
     insertMemoryItem("item-miss", "missing-ns", "key1", '{"val":1}');
 
-    const repo = createFridayMemoryFileSyncRepository({ db });
+    const repo = createFridayMemoryFileSyncRepository({ db, allowTestOnlyMemoryFileImport: true });
     const service = createFridayMemoryFileSyncService({
       repository: repo,
       stateDir: tmpDir,
       enableWatcher: false,
+      allowTestOnlyMemoryFileImport: true,
     });
 
     // Export then delete the file
@@ -274,11 +327,12 @@ describe("FridayMemoryFileSyncService — Watcher & Reindex", () => {
   it("reindexNow returns error for invalid JSON in file", async () => {
     insertMemoryItem("item-bad", "bad-ns", "key1", '{"val":1}');
 
-    const repo = createFridayMemoryFileSyncRepository({ db });
+    const repo = createFridayMemoryFileSyncRepository({ db, allowTestOnlyMemoryFileImport: true });
     const service = createFridayMemoryFileSyncService({
       repository: repo,
       stateDir: tmpDir,
       enableWatcher: false,
+      allowTestOnlyMemoryFileImport: true,
     });
 
     // Export then corrupt the file


### PR DESCRIPTION
## What

Fail-close the legacy memory file-sync reverse-import path by default:

- Adds a shared `TS_RUNTIME_MEMORY_FILE_IMPORT_RETIRED` error code.
- Requires explicit test-only opt-in on both the file-sync service and repository before `memory_namespace` file imports can write to `memory_items`.
- Leaves DB -> file export behavior intact.
- Adds regression coverage that edited export files no longer upsert/delete `memory_items` by default, and that direct repository write methods throw without the test-only oracle.
- Keeps legacy import behavior covered only under explicit test-only opt-in.

## Why

This is a narrow D1(b) cleanup slice. The file watcher / `reindexNow` reverse-import path could continue mutating `memory_items` from external files, which is one of the remaining TS-side durable memory write legs that can keep the friday.db / Rust-owned memory split alive.

## Truth boundary

This PR does **not** claim D1 is complete. It only closes the memory file-sync reverse-import writer family. Remaining D1(b) writer families still need separate verification/fixes before D1 can be marked done.

## Validation

- `npx vitest run test/unit/memory/sync/friday-memory-file-sync-watcher.test.ts --project default`
- `npx vitest run test/unit/memory/sync/friday-memory-file-sync-service.test.ts test/integration/memory/friday-memory-file-sync-integration.test.ts test/integration/memory/friday-memory-cognition-v1-proof.test.ts --project default`
- `npx tsc --noEmit`
- `npx eslint . --quiet`
- `npm run check:ts-runtime-retirement`
- `npm run check:secret-patterns`
- `npm run build`
- `git diff --check`