### PR TITLE
Fail-close guide-lens routes

### DIFF
--- a/src/api/http/routes/friday-guide-lens-routes.ts
+++ b/src/api/http/routes/friday-guide-lens-routes.ts
@@ -13,6 +13,12 @@ import type {
 
 export interface FridayGuideLensRoutesDeps {
   service: FridayGuideLensService;
+  /**
+   * Test-oracle only: allow legacy TypeScript guide-lens routes in isolated validation.
+   * Production/runtime callers must leave this unset so guide-lens action/write routes
+   * stay fail-closed until the guide-lens surface is governed or Rust-owned.
+   */
+  allowTestOnlyGuideLensExecution?: boolean;
 }
 
 function requireBodyObject(body: unknown): Record<string, unknown> {
@@ -39,6 +45,26 @@ function validateNoMutatingIntent(service: FridayGuideLensService, body: unknown
   }
 }
 
+function throwRetiredGuideLens(): never {
+  throw new FridayDomainError(
+    "TS_RUNTIME_GUIDE_LENS_RETIRED",
+    "TypeScript guide-lens routes are fail-closed in default/live runtime; use the governed Rust-owned guide-lens entrypoint.",
+    {
+      httpStatus: 503,
+      details: {
+        classification: "fail_closed",
+        replacement: "rust_owned_guide_lens_entrypoint_required",
+      },
+    },
+  );
+}
+
+function assertGuideLensTestOracleAllowed(deps: FridayGuideLensRoutesDeps): void {
+  if (deps.allowTestOnlyGuideLensExecution !== true) {
+    throwRetiredGuideLens();
+  }
+}
+
 export function createFridayGuideLensRoutes(
   deps: FridayGuideLensRoutesDeps,
 ): FridayRouteDefinition<unknown, unknown, unknown, unknown>[] {
@@ -58,6 +84,7 @@ export function createFridayGuideLensRoutes(
       path: "/v1/guide-lens/snapshot",
       auth: { public: true },
       async handler(ctx) {
+        assertGuideLensTestOracleAllowed(deps);
         validateNoMutatingIntent(deps.service, ctx.body);
         return deps.service.captureSnapshot(ctx.body as FridayGuideLensSnapshotRequest);
       },
@@ -68,6 +95,7 @@ export function createFridayGuideLensRoutes(
       path: "/v1/guide-lens/targets/resolve",
       auth: { public: true },
       async handler(ctx) {
+        assertGuideLensTestOracleAllowed(deps);
         requireString(ctx.body, "instruction");
         validateNoMutatingIntent(deps.service, ctx.body);
         return deps.service.resolveTarget(ctx.body as FridayGuideLensResolveTargetRequest);
@@ -79,6 +107,7 @@ export function createFridayGuideLensRoutes(
       path: "/v1/guide-lens/overlay",
       auth: { public: true },
       async handler(ctx) {
+        assertGuideLensTestOracleAllowed(deps);
         requireString(ctx.body, "message");
         validateNoMutatingIntent(deps.service, ctx.body);
         return deps.service.showOverlay(ctx.body as FridayGuideLensShowOverlayRequest);
@@ -90,6 +119,7 @@ export function createFridayGuideLensRoutes(
       path: "/v1/guide-lens/overlay",
       auth: { public: true },
       async handler(ctx) {
+        assertGuideLensTestOracleAllowed(deps);
         const query = ctx.query as { sessionId?: string };
         return deps.service.clearOverlay(query.sessionId);
       },
@@ -100,6 +130,7 @@ export function createFridayGuideLensRoutes(
       path: "/v1/guide-lens/screenshots/analyze",
       auth: { public: true },
       async handler(ctx) {
+        assertGuideLensTestOracleAllowed(deps);
         validateNoMutatingIntent(deps.service, ctx.body);
         return deps.service.analyzeScreenshot(ctx.body as FridayGuideLensScreenshotIntakeRequest);
       },
@@ -110,6 +141,7 @@ export function createFridayGuideLensRoutes(
       path: "/v1/guide-lens/verifications",
       auth: { public: true },
       async handler(ctx) {
+        assertGuideLensTestOracleAllowed(deps);
         validateNoMutatingIntent(deps.service, ctx.body);
         return deps.service.verify(ctx.body as FridayGuideLensVerificationRequest);
       },
@@ -120,6 +152,7 @@ export function createFridayGuideLensRoutes(
       path: "/v1/guide-lens/preferences",
       auth: { public: true },
       async handler(ctx) {
+        assertGuideLensTestOracleAllowed(deps);
         const patch = requireBodyObject(ctx.body) as Partial<FridayGuideLensPreferences>;
         return deps.service.updatePreferences(patch);
       },
@@ -130,6 +163,7 @@ export function createFridayGuideLensRoutes(
       path: "/v1/guide-lens/avatar",
       auth: { public: true },
       async handler(ctx) {
+        assertGuideLensTestOracleAllowed(deps);
         const avatar = requireBodyObject(ctx.body) as Partial<FridayGuideLensAvatarPreference>;
         return deps.service.updateAvatar(avatar);
       },

--- a/src/hub/bootstrap/hub-helpers.ts
+++ b/src/hub/bootstrap/hub-helpers.ts
@@ -1901,6 +1901,8 @@ export interface FridayHubConfig {
   allowTestOnlySessionMemoryExtractionExecution?: boolean;
   /** Test-oracle only; production hub creation must leave legacy TS durable memory writes fail-closed. */
   allowTestOnlyTsMemoryWrites?: boolean;
+  /** Test-oracle only; production hub creation must leave /v1/guide-lens/* fail-closed. */
+  allowTestOnlyGuideLensExecution?: boolean;
   /** Test-oracle only; production hub creation must leave cross-border pack mutations fail-closed. */
   allowTestOnlyCrossBorderPackExecution?: boolean;
   /** Test-oracle only; production hub creation must leave self-healing diagnosis mutations fail-closed. */

--- a/src/hub/friday-hub-bootstrap.ts
+++ b/src/hub/friday-hub-bootstrap.ts
@@ -2664,6 +2664,7 @@ export async function createFridayHub(
     });
     guideLensRouteDeps = {
       service: guideLensService,
+      allowTestOnlyGuideLensExecution: config.allowTestOnlyGuideLensExecution,
     };
 
     console.log(

--- a/test/unit/api/http/routes/friday-guide-lens-routes.test.ts
+++ b/test/unit/api/http/routes/friday-guide-lens-routes.test.ts
@@ -76,9 +76,48 @@ describe("createFridayGuideLensRoutes", () => {
     expect(routes.every((route) => route.path.startsWith("/v1/guide-lens"))).toBe(true);
   });
 
+  it("keeps read-only state available by default", async () => {
+    const service = makeService();
+    const route = findRoute(createFridayGuideLensRoutes({ service }), "guidelens.state.get");
+
+    await expect(route.handler(makeCtx())).resolves.toEqual({ preferences: {}, sessions: [] });
+
+    expect(service.getState).toHaveBeenCalledOnce();
+  });
+
+  it("fails closed for guide-lens action routes by default", async () => {
+    const service = makeService();
+    const routes = createFridayGuideLensRoutes({ service })
+      .filter((route) => route.operationId !== "guidelens.state.get");
+
+    for (const route of routes) {
+      await expect(route.handler(makeCtx({
+        body: {
+          instruction: "Continue",
+          message: "Continue",
+        },
+        query: {
+          sessionId: "s-1",
+        },
+      }))).rejects.toThrow("guide-lens routes are fail-closed");
+    }
+
+    expect(service.captureSnapshot).not.toHaveBeenCalled();
+    expect(service.resolveTarget).not.toHaveBeenCalled();
+    expect(service.showOverlay).not.toHaveBeenCalled();
+    expect(service.clearOverlay).not.toHaveBeenCalled();
+    expect(service.analyzeScreenshot).not.toHaveBeenCalled();
+    expect(service.verify).not.toHaveBeenCalled();
+    expect(service.updatePreferences).not.toHaveBeenCalled();
+    expect(service.updateAvatar).not.toHaveBeenCalled();
+  });
+
   it("validates target instructions and delegates to the service", async () => {
     const service = makeService();
-    const route = findRoute(createFridayGuideLensRoutes({ service }), "guidelens.targets.resolve");
+    const route = findRoute(createFridayGuideLensRoutes({
+      service,
+      allowTestOnlyGuideLensExecution: true,
+    }), "guidelens.targets.resolve");
 
     await expect(route.handler(makeCtx({ body: {} }))).rejects.toThrow("instruction is required");
     await route.handler(makeCtx({ body: { instruction: "Continue" } }));
@@ -88,7 +127,10 @@ describe("createFridayGuideLensRoutes", () => {
 
   it("rejects mutating overlay messages before delegating", async () => {
     const service = makeService();
-    const route = findRoute(createFridayGuideLensRoutes({ service }), "guidelens.overlay.show");
+    const route = findRoute(createFridayGuideLensRoutes({
+      service,
+      allowTestOnlyGuideLensExecution: true,
+    }), "guidelens.overlay.show");
 
     await expect(route.handler(makeCtx({ body: { message: "click the button" } }))).rejects.toThrow("read-only violation");
     expect(service.showOverlay).not.toHaveBeenCalled();
@@ -96,7 +138,10 @@ describe("createFridayGuideLensRoutes", () => {
 
   it("updates avatar through the avatar route", async () => {
     const service = makeService();
-    const route = findRoute(createFridayGuideLensRoutes({ service }), "guidelens.avatar.update");
+    const route = findRoute(createFridayGuideLensRoutes({
+      service,
+      allowTestOnlyGuideLensExecution: true,
+    }), "guidelens.avatar.update");
 
     await route.handler(makeCtx({ body: { kind: "local_image", localPath: "/tmp/avatar.png" } }));
 


### PR DESCRIPTION
## What

Adds a default fail-closed guard to the legacy TypeScript `/v1/guide-lens/*` action/write surface:

- Introduces `allowTestOnlyGuideLensExecution` on the route deps / hub config.
- Leaves production/default hub config unset, so guide-lens action routes now return `503 TS_RUNTIME_GUIDE_LENS_RETIRED` before calling the service.
- Keeps `GET /v1/guide-lens/state` read-only and available so existing settings/UI status loading does not degrade.
- Preserves legacy action route behavior only under explicit test-only opt-in.
- Adds route tests proving read-only state remains available while action routes fail closed by default and do not call the service.

## Why

Registry D7 identified Guide Lens as a live public TS product route surface without a retirement/governance guard. The risky surface includes preference/avatar writes and screen/overlay guide actions. This PR fail-closes those action/write routes by default until a governed/Rust-owned entrypoint exists, without breaking the read-only UI state load used by `/settings`.

## Truth boundary

This is the D7 route guard slice. It does **not** claim all registry §D is done, and it does not retire the in-process guide-lens service or agent tool. It only closes the public HTTP action/write route surface by default; `GET /v1/guide-lens/state` remains read-only/live.

## Validation

- `npx vitest run test/unit/api/http/routes/friday-guide-lens-routes.test.ts --project default`
- `npx tsc --noEmit`
- `npx eslint . --quiet`
- `npm run build`
- `git diff --check`