### PR TITLE
Fail closed provisioned master key paths

### DIFF
--- a/src/api/mission-spine/friday-rust-hub-agent-run-ws-client-x25519-secret.ts
+++ b/src/api/mission-spine/friday-rust-hub-agent-run-ws-client-x25519-secret.ts
@@ -19,20 +19,15 @@
  *
  * ## Hard contracts enforced here (load-bearing — Directive-0i)
  * 1. **Fail-closed (no weak/zero/predictable key, ever)** — the resolver returns `null` (compose
- *    → today's 503) when: the presence env signal is explicitly off, {@link getMasterKey} THROWS
+ *    → today's 503) when: the presence env signal is explicitly off, {@link getProvisionedMasterKey} THROWS
  *    (misconfig, e.g. an invalid `FRIDAY_MASTER_KEY`), the key is empty, or the derived secret is
- *    not 32 bytes. There is no anonymous / default-key fallback. **IMPORTANT (6b):** `getMasterKey`
- *    AUTO-GENERATES + persists a random key on a fresh host, so a *merely-absent* master key does
- *    NOT fail closed HERE — it yields a valid secret from a random key, and the fail-closed is then
- *    enforced SERVER-side (the derived pubkey is not in the peer-allowlist → no session). So 6b must
- *    enroll the pubkey derived from the prod host's STABLE master key, and RE-ENROLL on key rotation
- *    (a rotated master key changes the derived secret → changes the pubkey → the stale allowlist
- *    entry no longer matches → fail-closed until re-provisioned).
- * 2. **SecureStore-derived, never an env-var key** — the secret is derived through the
- *    keychain-backed {@link getMasterKey} path (the SecureStore root the secret admin uses),
- *    domain-separated with {@link WS_X25519_SECRET_PURPOSE}. An env var may carry only the
- *    OPAQUE presence signal ({@link FRIDAY_HUB_AGENT_RUN_WS_X25519_SECRET_PRESENT}); it NEVER
- *    carries key material. The raw master key NEVER crosses the wire.
+ *    not 32 bytes. There is no anonymous / default-key fallback. A merely-absent master key fails
+ *    closed HERE; the client never derives a pubkey from fresh random key material.
+ * 2. **Provisioned-key-derived, never a WS env-var secret** — the secret is derived through
+ *    the keychain/file/env-backed {@link getProvisionedMasterKey} path (the same root the
+ *    secret admin uses), domain-separated with {@link WS_X25519_SECRET_PURPOSE}. This module
+ *    accepts the deployment's provisioned master key source but never reads X25519 secret
+ *    material from env, never generates one, and never sends the raw master key over the wire.
  * 3. **Never printed / logged** — the secret bytes are returned to the in-process caller only.
  *    This module logs nothing and throws no error carrying the secret; the returned value is an
  *    opaque `Uint8Array`. (`// pragma: allowlist secret` markers below sit on the SecureStore
@@ -46,7 +41,7 @@
  */
 import { createHash } from "node:crypto";
 
-import { getMasterKey } from "#providers";
+import { getProvisionedMasterKey } from "#providers";
 
 import {
   deviceKeypairFromSecret,
@@ -80,12 +75,12 @@ export const FRIDAY_HUB_AGENT_RUN_WS_X25519_SECRET_PRESENT =
 export type FridayRustAgentRunWsClientX25519SecretResolver = () => Uint8Array | null;
 
 /**
- * Default SecureStore-backed resolver. Derives a stable 32-byte X25519 SECRET from the keychain
+ * Default provisioned-key resolver. Derives a stable 32-byte X25519 SECRET from the provisioned
  * master key with a purpose tag (domain separation), so the raw master key never crosses the
  * wire and the same secret is reproduced deterministically on every call (so the derived pubkey
  * the operator enrolls at 6b stays stable). Fails closed (returns `null`) when:
  *   - the presence env signal is explicitly off, or
- *   - the SecureStore master key is unavailable / throws, or
+ *   - the provisioned master key is unavailable / throws, or
  *   - the derived secret is not exactly 32 bytes (defensive; sha256 is always 32 bytes).
  *
  * NOTE: a sha256 digest is a uniformly-random 32-byte string; X25519 clamps the scalar at use
@@ -102,13 +97,9 @@ export function resolveRustAgentRunWsClientX25519Secret(): Uint8Array | null {
 
   let masterKey: Buffer;
   try {
-    // SecureStore root (keychain-backed). NOTE: on a fresh host getMasterKey AUTO-GENERATES +
-    // persists a random key — it does NOT throw on a merely-absent key. It throws only on
-    // MISCONFIG (e.g. an invalid `FRIDAY_MASTER_KEY`), which this catch fail-closes. A
-    // merely-absent key therefore yields a VALID secret from a fresh random key; the resulting
-    // pubkey simply will not be in the server peer-allowlist (until 6b enrollment) → no session
-    // (fail-closed SERVER-side). The client never opens a weak/zero/predictable-key session.
-    masterKey = getMasterKey();
+    // SecureStore root (keychain/file/env-backed) with no auto-generation. A merely-absent key
+    // fails closed here, before deriving a client pubkey from unprovisioned random material.
+    masterKey = getProvisionedMasterKey();
   } catch {
     return null;
   }

--- a/src/api/mission-spine/friday-rust-hub-agent-run-ws-session-key.ts
+++ b/src/api/mission-spine/friday-rust-hub-agent-run-ws-session-key.ts
@@ -8,9 +8,9 @@
  * agent-run WS server. Before the TS client may open that socket and dispatch a run, it
  * must hold the WS SESSION KEY — the sealed `authProof` bytes the Rust auth sub-slice
  * (S-C) verifies against the session. The operator decision: that key is obtained via the
- * SecureStore path (the keychain-backed master-key store), NOT an unguarded env var that
- * a misconfigured process could leak. A MISSING / invalid key MUST fail CLOSED: the
- * composition never opens an UNAUTHENTICATED WS connection — it falls to today's 503.
+ * provisioned master-key path (env/keychain/existing file), never by generating fresh key
+ * material at first use. A MISSING / invalid key MUST fail CLOSED: the composition never
+ * opens an UNAUTHENTICATED WS connection — it falls to today's 503.
  *
  * ## Hard contracts enforced here (load-bearing)
  * 1. **Fail-closed on missing/invalid** — `resolveRustAgentRunWsSessionKey` returns
@@ -21,11 +21,11 @@
  *    only. This module throws no error carrying the key, logs nothing, and the returned
  *    value is opaque `Uint8Array`. (`// pragma: allowlist secret` markers below sit on
  *    the SecureStore lookup IDENTIFIERS, never on a literal key.)
- * 3. **SecureStore-only source** — the key is read through the keychain-backed
- *    {@link getMasterKey} path (the same SecureStore root the secret admin service uses),
- *    derived deterministically for this WS purpose. There is no plaintext env-var key
- *    path: an env var may carry the OPAQUE SecureStore presence signal (see
- *    {@link FRIDAY_HUB_AGENT_RUN_WS_SESSION_KEY_PRESENT}) but never the key material.
+ * 3. **Provisioned source only** — the key is read through the env/keychain/existing-file
+ *    {@link getProvisionedMasterKey} path (the same root the secret admin service uses),
+ *    derived deterministically for this WS purpose. This module accepts the deployment's
+ *    provisioned master key source but never reads WS key material from env, never generates
+ *    one, and never sends the raw master key over the wire.
  *
  * ## Truth labels (read before trusting this)
  * - **DARK substrate**: no production route resolves a real key here until the
@@ -35,7 +35,7 @@
  */
 import { createHash } from "node:crypto";
 
-import { getMasterKey } from "#providers";
+import { getProvisionedMasterKey } from "#providers";
 
 /**
  * The minimum acceptable derived-key length (bytes). A key shorter than this is treated
@@ -68,11 +68,11 @@ export const FRIDAY_HUB_AGENT_RUN_WS_SESSION_KEY_PRESENT =
 export type FridayRustAgentRunWsSessionKeyResolver = () => Uint8Array | null;
 
 /**
- * Default SecureStore-backed resolver. Derives the WS session key from the keychain master
+ * Default provisioned-key resolver. Derives the WS session key from the provisioned master
  * key with a purpose tag (domain separation) so the raw master key never crosses the wire.
  * Fails closed (returns `null`) when:
  *   - the presence env signal is explicitly off, or
- *   - the SecureStore master key is unavailable / throws, or
+ *   - the provisioned master key is unavailable / throws, or
  *   - the derived key is shorter than the floor (defensive; sha256 is always 32 bytes).
  */
 export function resolveRustAgentRunWsSessionKey(): Uint8Array | null {
@@ -86,8 +86,9 @@ export function resolveRustAgentRunWsSessionKey(): Uint8Array | null {
 
   let masterKey: Buffer;
   try {
-    // SecureStore root (keychain-backed). Throws when no key is provisioned → fail closed.
-    masterKey = getMasterKey();
+    // SecureStore root (keychain/file/env-backed) with no auto-generation.
+    // Throws when no key is provisioned → fail closed.
+    masterKey = getProvisionedMasterKey();
   } catch {
     return null;
   }

--- a/src/cli/friday-cli.ts
+++ b/src/cli/friday-cli.ts
@@ -49,7 +49,7 @@ import type { FridayHubConfig } from "#hub";
 import {
   createFridaySecretRepository,
   encryptSecret,
-  getMasterKey,
+  getProvisionedMasterKey,
 } from "#providers";
 import {
   redactFridaySkillCandidateSourceUri,
@@ -1107,7 +1107,7 @@ function persistMigratedChannels(
   }
 
   if (secretWrites.length > 0) {
-    const masterKey = getMasterKey();
+    const masterKey = getProvisionedMasterKey();
     for (const write of secretWrites) {
       const envelope = encryptSecret(write.plaintext, masterKey);
       channelSecretRepository.upsert(db, {

--- a/src/cloud-workers/services/friday-cloud-worker-package.ts
+++ b/src/cloud-workers/services/friday-cloud-worker-package.ts
@@ -130,7 +130,7 @@ function renderBootstrapScript(input: FridayCloudWorkerPackageInput): string {
     "",
     "# Generate FRIDAY_MASTER_KEY and FRIDAY_TOKEN_SECRET locally if still templated.",
     "if grep -qF 'FRIDAY_MASTER_KEY=" + PLACEHOLDER_MASTER_KEY + "' bootstrap.env; then",
-    "  MASTER_KEY=$(openssl rand -base64 48)",
+    "  MASTER_KEY=$(openssl rand -hex 32)",
     "  export MASTER_KEY",
     "  python3 -c 'import os,sys; sys.stdout.write(open(\"bootstrap.env\").read().replace(\"FRIDAY_MASTER_KEY=" + PLACEHOLDER_MASTER_KEY + "\", \"FRIDAY_MASTER_KEY=\"+os.environ[\"MASTER_KEY\"]))' > bootstrap.env.tmp && mv bootstrap.env.tmp bootstrap.env",
     "fi",

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -74,7 +74,7 @@ export {
 } from "./cli/friday-provider-cli-backend.js";
 
 // Security
-export { encryptSecret, decryptSecret, getMasterKey, getStrictMasterKey, resetMasterKeyCache } from "./security/friday-secret-crypto.js";
+export { encryptSecret, decryptSecret, getMasterKey, getProvisionedMasterKey, getStrictMasterKey, resetMasterKeyCache } from "./security/friday-secret-crypto.js";
 export type {
   CreateFridayEphemeralSecretHandleRegistryDeps,
   FridayEphemeralSecretHandle,

--- a/src/providers/security/friday-secret-crypto.ts
+++ b/src/providers/security/friday-secret-crypto.ts
@@ -2,6 +2,7 @@ export {
   decryptSecret,
   encryptSecret,
   getMasterKey,
+  getProvisionedMasterKey,
   getStrictMasterKey,
   resetMasterKeyCache,
 } from "../../security/friday-secret-crypto.js";

--- a/src/security/friday-secret-crypto.ts
+++ b/src/security/friday-secret-crypto.ts
@@ -86,6 +86,73 @@ const MASTER_KEY_FILE = path.join(MASTER_KEY_DIR, "master.key");
 const MASTER_KEY_KEYCHAIN_SERVICE = "Friday Master Key";
 const MASTER_KEY_KEYCHAIN_ACCOUNT = "friday";
 
+function parseMasterKeyHex(hex: string, sourceLabel: string): Buffer {
+  const buf = Buffer.from(hex, "hex");
+  if (buf.length !== KEY_BYTES) {
+    throw new FridayDomainError(
+      "VALIDATION_ERROR",
+      `${sourceLabel} must be ${KEY_BYTES} bytes (${KEY_BYTES * 2} hex chars), got ${String(buf.length)} bytes`,
+      { httpStatus: 400 },
+    );
+  }
+  return buf;
+}
+
+function cacheMasterKey(key: Buffer, source: MasterKeyCacheSource): Buffer {
+  cachedMasterKey = key;
+  cachedMasterKeySource = source;
+  cachedMasterKeyExpiresAt = Date.now() + MASTER_KEY_CACHE_TTL_MS;
+  return cachedMasterKey;
+}
+
+function readPersistedMasterKeyFile(options: {
+  readonly repairPermissions: boolean;
+  readonly failClosed: boolean;
+}): Buffer | null {
+  let hex: string;
+  try {
+    hex = fs.readFileSync(MASTER_KEY_FILE, "utf8").trim();
+  } catch (err) {
+    if (options.failClosed) {
+      throw new FridayDomainError(
+        "VALIDATION_ERROR",
+        "FRIDAY_MASTER_KEY is not configured. Set FRIDAY_MASTER_KEY (hex), set FRIDAY_MASTER_KEY_SOURCE=keychain, or provision an existing ~/.friday/master.key. Friday will not auto-generate a key for this path.",
+        { httpStatus: 503 },
+      );
+    }
+    console.warn("[friday][secret-crypto] master key file unreadable:", err instanceof Error ? err.message : String(err));
+    return null;
+  }
+
+  if (options.repairPermissions) {
+    try {
+      const stat = fs.statSync(MASTER_KEY_FILE);
+      if ((stat.mode & 0o077) !== 0) {
+        // eslint-disable-next-line no-console
+        console.warn(`[friday][SECURITY] Master key file permissions too open (0o${(stat.mode & 0o777).toString(8)}) — attempting chmod 0600`);
+        try {
+          fs.chmodSync(MASTER_KEY_FILE, 0o600);
+        } catch (chmodErr) {
+          // eslint-disable-next-line no-console
+          console.warn("[friday][SECURITY] Could not fix master key file permissions:", chmodErr instanceof Error ? chmodErr.message : String(chmodErr));
+        }
+      }
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.warn("[friday][secret-crypto] stat check failed:", err instanceof Error ? err.message : String(err));
+    }
+  }
+
+  try {
+    return parseMasterKeyHex(hex, "Persisted master key file");
+  } catch (err) {
+    if (options.failClosed) {
+      throw err;
+    }
+    return null;
+  }
+}
+
 function readKeychainMasterKey(): Buffer | null {
   if (process.platform !== "darwin") {
     throw new FridayDomainError(
@@ -145,18 +212,7 @@ export function getMasterKey(): Buffer {
   // 1. Prefer explicit env var
   const envKey = process.env.FRIDAY_MASTER_KEY;
   if (envKey) {
-    const buf = Buffer.from(envKey, "hex");
-    if (buf.length !== KEY_BYTES) {
-      throw new FridayDomainError(
-        "VALIDATION_ERROR",
-        `FRIDAY_MASTER_KEY must be ${KEY_BYTES} bytes (${KEY_BYTES * 2} hex chars), got ${String(buf.length)} bytes`,
-        { httpStatus: 400 },
-      );
-    }
-    cachedMasterKey = buf;
-    cachedMasterKeySource = "env";
-    cachedMasterKeyExpiresAt = Date.now() + MASTER_KEY_CACHE_TTL_MS;
-    return cachedMasterKey;
+    return cacheMasterKey(parseMasterKeyHex(envKey, "FRIDAY_MASTER_KEY"), "env");
   }
 
   // 2. Optional OS keystore mode. This is opt-in to avoid unexpected keychain
@@ -164,10 +220,7 @@ export function getMasterKey(): Buffer {
   if (process.env.FRIDAY_MASTER_KEY_SOURCE === "keychain") {
     const keychainKey = readKeychainMasterKey();
     if (keychainKey) {
-      cachedMasterKey = keychainKey;
-      cachedMasterKeySource = "keychain";
-      cachedMasterKeyExpiresAt = Date.now() + MASTER_KEY_CACHE_TTL_MS;
-      return cachedMasterKey;
+      return cacheMasterKey(keychainKey, "keychain");
     }
 
     throw new FridayDomainError(
@@ -178,36 +231,12 @@ export function getMasterKey(): Buffer {
   }
 
   // 3. Try to read persisted key file
-  try {
-    const hex = fs.readFileSync(MASTER_KEY_FILE, "utf8").trim();
-    // P2-SEC: Verify and fix master key file permissions
-    try {
-      const stat = fs.statSync(MASTER_KEY_FILE);
-      if ((stat.mode & 0o077) !== 0) {
-        // eslint-disable-next-line no-console
-        console.warn(`[friday][SECURITY] Master key file permissions too open (0o${(stat.mode & 0o777).toString(8)}) — attempting chmod 0600`);
-        try {
-          fs.chmodSync(MASTER_KEY_FILE, 0o600);
-        } catch (chmodErr) {
-          // eslint-disable-next-line no-console
-          console.warn("[friday][SECURITY] Could not fix master key file permissions:", chmodErr instanceof Error ? chmodErr.message : String(chmodErr));
-        }
-      }
-    } catch (err) {
-      // eslint-disable-next-line no-console
-      console.warn("[friday][secret-crypto] stat check failed:", err instanceof Error ? err.message : String(err));
-    }
-    const buf = Buffer.from(hex, "hex");
-    if (buf.length === KEY_BYTES) {
-      cachedMasterKey = buf;
-      cachedMasterKeySource = "file";
-      cachedMasterKeyExpiresAt = Date.now() + MASTER_KEY_CACHE_TTL_MS;
-      return cachedMasterKey;
-    }
-    // Invalid length — fall through to regenerate
-  } catch (err) {
-    // File unreadable — fall through to regenerate
-    console.warn("[friday][secret-crypto] master key file unreadable:", err instanceof Error ? err.message : String(err));
+  const persistedKey = readPersistedMasterKeyFile({
+    repairPermissions: true,
+    failClosed: false,
+  });
+  if (persistedKey) {
+    return cacheMasterKey(persistedKey, "file");
   }
 
   // 4. Generate, persist, and warn
@@ -233,10 +262,7 @@ export function getMasterKey(): Buffer {
       ". Set FRIDAY_MASTER_KEY for production use.",
   );
 
-  cachedMasterKey = newKey;
-  cachedMasterKeySource = "generated";
-  cachedMasterKeyExpiresAt = Date.now() + MASTER_KEY_CACHE_TTL_MS;
-  return cachedMasterKey;
+  return cacheMasterKey(newKey, "generated");
 }
 
 /**
@@ -299,6 +325,68 @@ export function getStrictMasterKey(): Buffer {
   throw new FridayDomainError(
     "VALIDATION_ERROR",
     "FRIDAY_MASTER_KEY is not configured. Set FRIDAY_MASTER_KEY (hex) or FRIDAY_MASTER_KEY_SOURCE=keychain. Multi-tenant security will not auto-generate a key.",
+    { httpStatus: 503 },
+  );
+}
+
+/**
+ * Fail-closed provisioned master-key resolver for legacy/file-backed paths.
+ *
+ * This is the no-generate counterpart to {@link getMasterKey}: it may read a
+ * configured env key, a configured keychain key, or an already-provisioned
+ * `~/.friday/master.key`, but it MUST NOT generate, create, or overwrite key
+ * material. Use this for production/default code paths that need to preserve
+ * an existing file-backed deployment without keeping the fail-open first-run
+ * behavior.
+ */
+export function getProvisionedMasterKey(): Buffer {
+  if (
+    cachedMasterKey
+    && Date.now() < cachedMasterKeyExpiresAt
+  ) {
+    if (cachedMasterKeySource === "env" && process.env.FRIDAY_MASTER_KEY) {
+      return cachedMasterKey;
+    }
+    if (cachedMasterKeySource === "keychain" && process.env.FRIDAY_MASTER_KEY_SOURCE === "keychain") {
+      return cachedMasterKey;
+    }
+    if (
+      cachedMasterKeySource === "file"
+      && !process.env.FRIDAY_MASTER_KEY
+      && process.env.FRIDAY_MASTER_KEY_SOURCE !== "keychain"
+    ) {
+      return cachedMasterKey;
+    }
+  }
+
+  const envKey = process.env.FRIDAY_MASTER_KEY;
+  if (envKey) {
+    return cacheMasterKey(parseMasterKeyHex(envKey, "FRIDAY_MASTER_KEY"), "env");
+  }
+
+  if (process.env.FRIDAY_MASTER_KEY_SOURCE === "keychain") {
+    const keychainKey = readKeychainMasterKey();
+    if (keychainKey) {
+      return cacheMasterKey(keychainKey, "keychain");
+    }
+    throw new FridayDomainError(
+      "VALIDATION_ERROR",
+      "FRIDAY_MASTER_KEY_SOURCE=keychain requires a pre-provisioned macOS keychain item",
+      { httpStatus: 400 },
+    );
+  }
+
+  const persistedKey = readPersistedMasterKeyFile({
+    repairPermissions: false,
+    failClosed: true,
+  });
+  if (persistedKey) {
+    return cacheMasterKey(persistedKey, "file");
+  }
+
+  throw new FridayDomainError(
+    "VALIDATION_ERROR",
+    "FRIDAY_MASTER_KEY is not configured. Set FRIDAY_MASTER_KEY (hex), set FRIDAY_MASTER_KEY_SOURCE=keychain, or provision an existing ~/.friday/master.key. Friday will not auto-generate a key for this path.",
     { httpStatus: 503 },
   );
 }

--- a/src/security/multi-tenant/engine/secret-manager.ts
+++ b/src/security/multi-tenant/engine/secret-manager.ts
@@ -33,7 +33,7 @@ import type { FridayCreateSecretScopeInput } from "../api/friday-multi-tenant-se
 
 import { cloneAndFreeze, generateEtag, generateId, now, SecurityEngineError } from "./utils.js";
 import type { AuditLogger } from "./audit-logger.js";
-import { decryptSecret, encryptSecret, getMasterKey } from "../../friday-secret-crypto.js";
+import { decryptSecret, encryptSecret, getProvisionedMasterKey } from "../../friday-secret-crypto.js";
 import type { FridayEncryptedEnvelope } from "../../friday-secret-crypto.js";
 
 // ─── Input Types ───
@@ -111,10 +111,9 @@ export interface SecretManagerPersistence {
 }
 
 /**
- * Optional master-key resolver override for the SecretManager.  Defaults
- * to {@link getMasterKey} which is fail-open (auto-generates and persists).
- * Bootstrap can pass `getStrictMasterKey` to fail closed when the env var
- * is not configured.
+ * Optional master-key resolver override for the SecretManager. Defaults to
+ * the no-generate provisioned resolver so production/default construction
+ * fails closed instead of silently creating a new encryption root.
  */
 export type MasterKeyResolver = () => Buffer;
 
@@ -130,7 +129,7 @@ export class SecretManager {
     options?: { persistence?: SecretManagerPersistence; masterKeyResolver?: MasterKeyResolver },
   ) {
     this.persistence = options?.persistence;
-    this.masterKeyResolver = options?.masterKeyResolver ?? getMasterKey;
+    this.masterKeyResolver = options?.masterKeyResolver ?? getProvisionedMasterKey;
     this.secrets = this.persistence?.hydrateSecrets() ?? new Map();
     this.rotations = this.persistence?.hydrateRotations() ?? new Map();
     this.accessLogs = this.persistence?.hydrateAccessLogs() ?? [];

--- a/test/unit/api/mission-spine/friday-rust-hub-agent-run-ws-client-x25519-secret.test.ts
+++ b/test/unit/api/mission-spine/friday-rust-hub-agent-run-ws-client-x25519-secret.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as crypto from "node:crypto";
 
 import {
   deriveRustAgentRunWsClientX25519PublicKey,
@@ -16,7 +17,10 @@ import { resetMasterKeyCache } from "../../../../src/security/friday-secret-cryp
 
 const SAVED_PRESENCE = process.env[FRIDAY_HUB_AGENT_RUN_WS_X25519_SECRET_PRESENT];
 const SAVED_MASTER_KEY = process.env.FRIDAY_MASTER_KEY;
-// A deterministic 32-byte hex master key so getMasterKey() returns a known value in-process.
+const SAVED_MASTER_KEY_SOURCE = process.env.FRIDAY_MASTER_KEY_SOURCE;
+const SAVED_KEYCHAIN_SERVICE = process.env.FRIDAY_MASTER_KEY_KEYCHAIN_SERVICE;
+const SAVED_KEYCHAIN_ACCOUNT = process.env.FRIDAY_MASTER_KEY_KEYCHAIN_ACCOUNT;
+// A deterministic 32-byte hex master key so getProvisionedMasterKey() returns a known value in-process.
 const FIXTURE_MASTER_KEY_HEX = "11".repeat(32); // pragma: allowlist secret
 
 function restoreEnv(name: string, saved: string | undefined): void {
@@ -32,7 +36,7 @@ describe("resolveRustAgentRunWsClientX25519Secret (B1-compose, dark, SecureStore
     delete process.env[FRIDAY_HUB_AGENT_RUN_WS_X25519_SECRET_PRESENT];
     // Hermetic: clear any inherited/leaked master-key env so each test controls it explicitly.
     delete process.env.FRIDAY_MASTER_KEY;
-    // getMasterKey() caches the master key for a TTL; reset it so a per-test FRIDAY_MASTER_KEY
+    // getProvisionedMasterKey() caches the master key for a TTL; reset it so a per-test FRIDAY_MASTER_KEY
     // takes effect deterministically (and the suite never inherits a real provisioned key).
     resetMasterKeyCache();
   });
@@ -40,6 +44,9 @@ describe("resolveRustAgentRunWsClientX25519Secret (B1-compose, dark, SecureStore
   afterEach(() => {
     restoreEnv(FRIDAY_HUB_AGENT_RUN_WS_X25519_SECRET_PRESENT, SAVED_PRESENCE);
     restoreEnv("FRIDAY_MASTER_KEY", SAVED_MASTER_KEY);
+    restoreEnv("FRIDAY_MASTER_KEY_SOURCE", SAVED_MASTER_KEY_SOURCE);
+    restoreEnv("FRIDAY_MASTER_KEY_KEYCHAIN_SERVICE", SAVED_KEYCHAIN_SERVICE);
+    restoreEnv("FRIDAY_MASTER_KEY_KEYCHAIN_ACCOUNT", SAVED_KEYCHAIN_ACCOUNT);
     resetMasterKeyCache();
     vi.restoreAllMocks();
   });
@@ -64,16 +71,12 @@ describe("resolveRustAgentRunWsClientX25519Secret (B1-compose, dark, SecureStore
   });
 
   it("when the SecureStore master key is unavailable → fail closed (null), never a throw", () => {
-    // With no keychain master key + no master-key env provisioned, the SecureStore lookup either
-    // throws internally (→ null) or yields a key; in BOTH cases the resolver never throws and never
-    // returns a short/invalid value.
     delete process.env.FRIDAY_MASTER_KEY;
-    const result = resolveRustAgentRunWsClientX25519Secret();
-    if (result !== null) {
-      expect(result.length).toBe(32);
-    } else {
-      expect(result).toBeNull();
-    }
+    process.env.FRIDAY_MASTER_KEY_SOURCE = "keychain";
+    process.env.FRIDAY_MASTER_KEY_KEYCHAIN_SERVICE = `Friday Test Missing ${crypto.randomUUID()}`;
+    process.env.FRIDAY_MASTER_KEY_KEYCHAIN_ACCOUNT = `friday-test-${crypto.randomUUID()}`;
+
+    expect(resolveRustAgentRunWsClientX25519Secret()).toBeNull();
   });
 
   it("derives a STABLE 32-byte secret from a fixture master key (idempotent across calls)", () => {

--- a/test/unit/api/mission-spine/friday-rust-hub-agent-run-ws-session-key.test.ts
+++ b/test/unit/api/mission-spine/friday-rust-hub-agent-run-ws-session-key.test.ts
@@ -1,9 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as crypto from "node:crypto";
 
 import {
   FRIDAY_HUB_AGENT_RUN_WS_SESSION_KEY_PRESENT,
   resolveRustAgentRunWsSessionKey,
 } from "../../../../src/api/mission-spine/friday-rust-hub-agent-run-ws-session-key.js";
+import { resetMasterKeyCache } from "../../../../src/security/friday-secret-crypto.js";
 
 // execrun-replacement S-F-compose (DARK): the SecureStore-backed WS session-key resolver.
 // Fail-closed contract: a MISSING / disabled SecureStore key resolves to `null` so the
@@ -11,9 +13,15 @@ import {
 
 describe("resolveRustAgentRunWsSessionKey (S-F-compose, dark, SecureStore-backed)", () => {
   const savedPresence = process.env[FRIDAY_HUB_AGENT_RUN_WS_SESSION_KEY_PRESENT];
+  const savedMasterKey = process.env.FRIDAY_MASTER_KEY;
+  const savedMasterKeySource = process.env.FRIDAY_MASTER_KEY_SOURCE;
+  const savedKeychainService = process.env.FRIDAY_MASTER_KEY_KEYCHAIN_SERVICE;
+  const savedKeychainAccount = process.env.FRIDAY_MASTER_KEY_KEYCHAIN_ACCOUNT;
 
   beforeEach(() => {
     delete process.env[FRIDAY_HUB_AGENT_RUN_WS_SESSION_KEY_PRESENT];
+    delete process.env.FRIDAY_MASTER_KEY;
+    resetMasterKeyCache();
   });
 
   afterEach(() => {
@@ -22,6 +30,27 @@ describe("resolveRustAgentRunWsSessionKey (S-F-compose, dark, SecureStore-backed
     } else {
       process.env[FRIDAY_HUB_AGENT_RUN_WS_SESSION_KEY_PRESENT] = savedPresence;
     }
+    if (savedMasterKey === undefined) {
+      delete process.env.FRIDAY_MASTER_KEY;
+    } else {
+      process.env.FRIDAY_MASTER_KEY = savedMasterKey;
+    }
+    if (savedMasterKeySource === undefined) {
+      delete process.env.FRIDAY_MASTER_KEY_SOURCE;
+    } else {
+      process.env.FRIDAY_MASTER_KEY_SOURCE = savedMasterKeySource;
+    }
+    if (savedKeychainService === undefined) {
+      delete process.env.FRIDAY_MASTER_KEY_KEYCHAIN_SERVICE;
+    } else {
+      process.env.FRIDAY_MASTER_KEY_KEYCHAIN_SERVICE = savedKeychainService;
+    }
+    if (savedKeychainAccount === undefined) {
+      delete process.env.FRIDAY_MASTER_KEY_KEYCHAIN_ACCOUNT;
+    } else {
+      process.env.FRIDAY_MASTER_KEY_KEYCHAIN_ACCOUNT = savedKeychainAccount;
+    }
+    resetMasterKeyCache();
     vi.restoreAllMocks();
   });
 
@@ -45,16 +74,10 @@ describe("resolveRustAgentRunWsSessionKey (S-F-compose, dark, SecureStore-backed
   });
 
   it("when the SecureStore master key is unavailable → fail closed (null)", () => {
-    // With no keychain master key + no master-key env provisioned, the SecureStore lookup
-    // throws internally and the resolver returns null (fail closed) rather than propagating.
-    // (The presence signal is unset here, so the SecureStore path is attempted.)
-    const result = resolveRustAgentRunWsSessionKey();
-    // Either null (no key provisioned) or a >=32-byte derived key (a key was provisioned in
-    // this environment) — but NEVER a short/invalid value, and NEVER a throw.
-    if (result !== null) {
-      expect(result.length).toBeGreaterThanOrEqual(32);
-    } else {
-      expect(result).toBeNull();
-    }
+    process.env.FRIDAY_MASTER_KEY_SOURCE = "keychain";
+    process.env.FRIDAY_MASTER_KEY_KEYCHAIN_SERVICE = `Friday Test Missing ${crypto.randomUUID()}`;
+    process.env.FRIDAY_MASTER_KEY_KEYCHAIN_ACCOUNT = `friday-test-${crypto.randomUUID()}`;
+
+    expect(resolveRustAgentRunWsSessionKey()).toBeNull();
   });
 });

--- a/test/unit/cli/friday-cli.test.ts
+++ b/test/unit/cli/friday-cli.test.ts
@@ -19,6 +19,29 @@ import {
 import { FRIDAY_SQLITE_MIGRATIONS, runFridayMigrations } from "#state";
 import Database from "better-sqlite3";
 
+const TEST_MASTER_KEY_HEX = "66".repeat(32);
+
+function withProvisionedMasterKey<T>(run: () => T): T {
+  const previousMasterKey = process.env.FRIDAY_MASTER_KEY;
+  const previousMasterKeySource = process.env.FRIDAY_MASTER_KEY_SOURCE;
+  process.env.FRIDAY_MASTER_KEY = TEST_MASTER_KEY_HEX;
+  delete process.env.FRIDAY_MASTER_KEY_SOURCE;
+  try {
+    return run();
+  } finally {
+    if (previousMasterKey === undefined) {
+      delete process.env.FRIDAY_MASTER_KEY;
+    } else {
+      process.env.FRIDAY_MASTER_KEY = previousMasterKey;
+    }
+    if (previousMasterKeySource === undefined) {
+      delete process.env.FRIDAY_MASTER_KEY_SOURCE;
+    } else {
+      process.env.FRIDAY_MASTER_KEY_SOURCE = previousMasterKeySource;
+    }
+  }
+}
+
 describe("parseArgs", () => {
   // Helper: simulate argv with node + script prefix
   const argv = (...args: string[]) => ["node", "friday-cli.js", ...args];
@@ -1041,11 +1064,13 @@ describe("prepareStartupChannelsConfig", () => {
         }, null, 2),
       );
 
-      const resolution = prepareStartupChannelsConfig({
-        env: { HOME: tmpHome },
-        dbPath,
-        nowIso: () => "2026-03-12T12:00:00.000Z",
-      });
+      const resolution = withProvisionedMasterKey(() =>
+        prepareStartupChannelsConfig({
+          env: { HOME: tmpHome },
+          dbPath,
+          nowIso: () => "2026-03-12T12:00:00.000Z",
+        }),
+      );
 
       expect(resolution.source).toBe("migrated_legacy_to_setup_state");
       expect(resolution.migrated).toBe(true);
@@ -1151,11 +1176,13 @@ describe("prepareStartupChannelsConfig", () => {
         },
       ]));
 
-      const resolution = prepareStartupChannelsConfig({
-        env: { HOME: tmpHome },
-        dbPath,
-        nowIso: () => "2026-03-12T12:30:00.000Z",
-      });
+      const resolution = withProvisionedMasterKey(() =>
+        prepareStartupChannelsConfig({
+          env: { HOME: tmpHome },
+          dbPath,
+          nowIso: () => "2026-03-12T12:30:00.000Z",
+        }),
+      );
 
       expect(resolution.source).toBe("setup_state");
       expect(resolution.migrated).toBe(true);

--- a/test/unit/providers/security/friday-secret-crypto.test.ts
+++ b/test/unit/providers/security/friday-secret-crypto.test.ts
@@ -1,9 +1,10 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import * as crypto from "node:crypto";
 import {
   encryptSecret,
   decryptSecret,
   getMasterKey,
+  getProvisionedMasterKey,
   getStrictMasterKey,
   resetMasterKeyCache,
 } from "#providers";
@@ -113,6 +114,7 @@ describe("FridaySecretCrypto", () => {
       } else {
         delete process.env.FRIDAY_MASTER_KEY_KEYCHAIN_ACCOUNT;
       }
+      vi.restoreAllMocks();
       resetMasterKeyCache();
     });
 
@@ -166,6 +168,22 @@ describe("FridaySecretCrypto", () => {
     it("throws on invalid hex length", () => {
       process.env.FRIDAY_MASTER_KEY = "abcd"; // Only 2 bytes
       expect(() => getMasterKey()).toThrow("32 bytes");
+    });
+
+    it("provisioned resolver reads explicit env key without generation", () => {
+      const key = crypto.randomBytes(32);
+      process.env.FRIDAY_MASTER_KEY = key.toString("hex");
+
+      expect(getProvisionedMasterKey()).toEqual(key);
+    });
+
+    it("provisioned resolver fails closed when configured keychain source is missing", () => {
+      delete process.env.FRIDAY_MASTER_KEY;
+      process.env.FRIDAY_MASTER_KEY_SOURCE = "keychain";
+      process.env.FRIDAY_MASTER_KEY_KEYCHAIN_SERVICE = `Friday Test Missing ${crypto.randomUUID()}`;
+      process.env.FRIDAY_MASTER_KEY_KEYCHAIN_ACCOUNT = `friday-test-${crypto.randomUUID()}`;
+
+      expect(() => getProvisionedMasterKey()).toThrow(/FRIDAY_MASTER_KEY_SOURCE=keychain/);
     });
   });
 });

--- a/test/unit/security/multi-tenant/engine/kpi-security.test.ts
+++ b/test/unit/security/multi-tenant/engine/kpi-security.test.ts
@@ -14,11 +14,13 @@ describe("Multi-tenant security KPI assertions", () => {
   let rbacEngine: RbacEngine;
   let policyEngine: PolicyEngine;
   const superadminActor = { principalId: "root", roles: ["superadmin"] };
+  const testMasterKey = Buffer.from("44".repeat(32), "hex");
+  const resolveTestMasterKey = () => Buffer.from(testMasterKey);
 
   beforeEach(() => {
     auditLogger = new AuditLogger();
     tenantManager = new TenantManager(auditLogger);
-    secretManager = new SecretManager(auditLogger);
+    secretManager = new SecretManager(auditLogger, { masterKeyResolver: resolveTestMasterKey });
     rbacEngine = new RbacEngine(auditLogger);
     policyEngine = new PolicyEngine(auditLogger);
   });

--- a/test/unit/security/multi-tenant/engine/migration-manager.test.ts
+++ b/test/unit/security/multi-tenant/engine/migration-manager.test.ts
@@ -14,12 +14,14 @@ describe("MigrationManager", () => {
   let secretManager: SecretManager;
   let idempotencyManager: IdempotencyManager;
   let migrationManager: MigrationManager;
+  const testMasterKey = Buffer.from("55".repeat(32), "hex");
+  const resolveTestMasterKey = () => Buffer.from(testMasterKey);
 
   beforeEach(() => {
     auditLogger = new AuditLogger();
     tenantManager = new TenantManager(auditLogger);
     rbacEngine = new RbacEngine(auditLogger);
-    secretManager = new SecretManager(auditLogger);
+    secretManager = new SecretManager(auditLogger, { masterKeyResolver: resolveTestMasterKey });
     idempotencyManager = new IdempotencyManager();
     migrationManager = new MigrationManager(
       tenantManager,

--- a/test/unit/security/multi-tenant/engine/secret-manager.test.ts
+++ b/test/unit/security/multi-tenant/engine/secret-manager.test.ts
@@ -1,8 +1,9 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { SecretManager } from "../../../../../src/security/multi-tenant/engine/secret-manager.js";
 import { AuditLogger } from "../../../../../src/security/multi-tenant/engine/audit-logger.js";
 import { SecurityEngineError } from "../../../../../src/security/multi-tenant/engine/utils.js";
 import { FRIDAY_MULTI_TENANT_SECURITY_ERROR_CODES } from "../../../../../src/security/multi-tenant/api/friday-multi-tenant-security-api.types.js";
+import { resetMasterKeyCache } from "../../../../../src/security/friday-secret-crypto.js";
 import type {
   FridaySecretEntry,
   FridaySecretRotation,
@@ -12,10 +13,41 @@ describe("SecretManager", () => {
   let auditLogger: AuditLogger;
   let manager: SecretManager;
   const tenantId = "tenant-1";
+  const testMasterKey = Buffer.from("33".repeat(32), "hex");
+  const resolveTestMasterKey = () => Buffer.from(testMasterKey);
+  const savedMasterKey = process.env.FRIDAY_MASTER_KEY;
+  const savedMasterKeySource = process.env.FRIDAY_MASTER_KEY_SOURCE;
+  const savedKeychainService = process.env.FRIDAY_MASTER_KEY_KEYCHAIN_SERVICE;
+  const savedKeychainAccount = process.env.FRIDAY_MASTER_KEY_KEYCHAIN_ACCOUNT;
 
   beforeEach(() => {
     auditLogger = new AuditLogger();
-    manager = new SecretManager(auditLogger);
+    manager = new SecretManager(auditLogger, { masterKeyResolver: resolveTestMasterKey });
+    resetMasterKeyCache();
+  });
+
+  afterEach(() => {
+    if (savedMasterKey === undefined) {
+      delete process.env.FRIDAY_MASTER_KEY;
+    } else {
+      process.env.FRIDAY_MASTER_KEY = savedMasterKey;
+    }
+    if (savedMasterKeySource === undefined) {
+      delete process.env.FRIDAY_MASTER_KEY_SOURCE;
+    } else {
+      process.env.FRIDAY_MASTER_KEY_SOURCE = savedMasterKeySource;
+    }
+    if (savedKeychainService === undefined) {
+      delete process.env.FRIDAY_MASTER_KEY_KEYCHAIN_SERVICE;
+    } else {
+      process.env.FRIDAY_MASTER_KEY_KEYCHAIN_SERVICE = savedKeychainService;
+    }
+    if (savedKeychainAccount === undefined) {
+      delete process.env.FRIDAY_MASTER_KEY_KEYCHAIN_ACCOUNT;
+    } else {
+      process.env.FRIDAY_MASTER_KEY_KEYCHAIN_ACCOUNT = savedKeychainAccount;
+    }
+    resetMasterKeyCache();
   });
 
   // ═══════════════════════════════════════════════════════════════
@@ -23,6 +55,22 @@ describe("SecretManager", () => {
   // ═══════════════════════════════════════════════════════════════
 
   describe("createSecret()", () => {
+    it("fails closed by default when no provisioned master key is available", () => {
+      delete process.env.FRIDAY_MASTER_KEY;
+      process.env.FRIDAY_MASTER_KEY_SOURCE = "keychain";
+      process.env.FRIDAY_MASTER_KEY_KEYCHAIN_SERVICE = "Friday Test Missing";
+      process.env.FRIDAY_MASTER_KEY_KEYCHAIN_ACCOUNT = "friday-test-missing";
+      const defaultManager = new SecretManager(auditLogger);
+
+      expect(() =>
+        defaultManager.createSecret(tenantId, {
+          name: "NO_KEY",
+          value: "value",
+          scope: { scopeType: "tenant" },
+        }),
+      ).toThrow(/FRIDAY_MASTER_KEY_SOURCE=keychain/);
+    });
+
     it("creates a tenant-scoped secret", () => {
       const secret = manager.createSecret(tenantId, {
         name: "API_KEY",


### PR DESCRIPTION
## Summary
- add `getProvisionedMasterKey()`, a no-generate resolver that can read env/keychain/existing `~/.friday/master.key` but never creates or overwrites key material
- switch default/production-adjacent paths off fail-open `getMasterKey()`:
  - `SecretManager` default resolver
  - CLI migrated channel-secret persistence
  - Rust agent-run WS session-key resolver
  - Rust sealed WS X25519 secret resolver
- generate cloud-worker `FRIDAY_MASTER_KEY` as 32-byte hex instead of base64
- update tests so multi-tenant/CLI cases use explicit fixture resolvers or fixture `FRIDAY_MASTER_KEY`

## Validation
- `npx vitest run test/unit/providers/security/friday-secret-crypto.test.ts test/unit/api/mission-spine/friday-rust-hub-agent-run-ws-client-x25519-secret.test.ts test/unit/api/mission-spine/friday-rust-hub-agent-run-ws-session-key.test.ts test/unit/security/multi-tenant/engine/secret-manager.test.ts test/unit/security/multi-tenant/engine/kpi-security.test.ts test/unit/security/multi-tenant/engine/migration-manager.test.ts test/unit/cli/friday-cli.test.ts --project default`
- `npx tsc --noEmit`
- `npm run check:secret-patterns`
- `npx eslint . --quiet`
- `npm run build`
- `npm run check:ts-runtime-retirement`
- `git diff --check`

Truth boundary: registry D3 fail-open master-key paths only; this does not claim D1/D2/D4-D7 or full registry completion.