### PR TITLE
Build D20 route action-list dark slice

### DIFF
--- a/docs/ops/prod-flags-manifest.json
+++ b/docs/ops/prod-flags-manifest.json
@@ -133,6 +133,15 @@
       "notes": "Built-but-dark. One sequential test sets FRIDAY_SURFACE_EVENTS=1, runs the loop, asserts lifecycle surface_events are emitted AND appear in the read projection, then flips to 0 and asserts a clean (event-free) run (no env race; both arms in one #[test])."
     },
     {
+      "flag": "FRIDAY_D20_ACTION_LIST_ENABLED",
+      "process": "rust-ws-wrapper",
+      "prod_state": "dark",
+      "closes_loop": "A ready Mission intake persists a structured D20 plan-as-action-list item on the route_decision and projects it back through the surface-safe route decision projection.",
+      "coverage": "loop-e2e",
+      "e2e_test": "rust-core/crates/friday-hub/tests/mission_intake_clarification.rs::d20_action_list_flag_on_persists_route_action_items_for_ready_intake",
+      "notes": "Built-but-dark. Drives mission_intake_result_for_db_flagged(.., action_list_enabled=true) on a detailed intent and asserts route_decision.action_items round-trip through Hub storage plus list_route_decision_projections_for_mission. Sibling storage proof verifies the full Hub card can retain raw refs while the projection redacts channel targets and file paths."
+    },
+    {
       "flag": "FRIDAY_PASSPORT_MINT",
       "process": "rust-ws-wrapper",
       "prod_state": "dark",

--- a/rust-core/crates/friday-core/src/lib.rs
+++ b/rust-core/crates/friday-core/src/lib.rs
@@ -64,9 +64,9 @@ pub use mission::{
     validate_friday_conversation_id, ApprovalState, FridayConversation, HandoffJudgmentMemory,
     Mission, MissionLink, MissionLinkKind, MissionSpineError, MissionStatus,
     MissionSurfaceProjection, OutcomeProofReceipt, ProofRequirementKind, ProofRequirementSpec,
-    RouteDecisionCard, RouteDecisionProjection, SurfaceEvent, SurfaceEventKind, SurfaceKind,
-    SurfaceThread, TruthStatus, VisibilityPolicy, WorkItem, WorkItemStatus, WorkLane,
-    OUTCOME_CHECKED_PROOF_FLAG,
+    RouteActionItem, RouteActionReversibility, RouteActionTargetKind, RouteDecisionCard,
+    RouteDecisionProjection, SurfaceEvent, SurfaceEventKind, SurfaceKind, SurfaceThread,
+    TruthStatus, VisibilityPolicy, WorkItem, WorkItemStatus, WorkLane, OUTCOME_CHECKED_PROOF_FLAG,
 };
 pub use offline::OfflineQueueState;
 pub use pairing::{

--- a/rust-core/crates/friday-core/src/mission.rs
+++ b/rust-core/crates/friday-core/src/mission.rs
@@ -668,6 +668,56 @@ pub struct WorkItem {
     pub updated_at_ms: i64,
 }
 
+/// D20 W1 plan-as-action-list item attached to a route decision.
+///
+/// This is a planning/display record, not an authorization decision. The W2
+/// trust-dial slice will replace the provisional reversibility label with the
+/// authoritative `classify()` output before any auto-allow logic exists.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RouteActionItem {
+    pub description: String,
+    pub target_kind: RouteActionTargetKind,
+    pub target_ref: String,
+    pub reversibility: RouteActionReversibility,
+    pub assigned_lane: WorkLane,
+    pub assigned_provider_or_agent: Option<String>,
+    pub route_reason: String,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum RouteActionTargetKind {
+    File,
+    Command,
+    Subtask,
+}
+
+impl RouteActionTargetKind {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            RouteActionTargetKind::File => "file",
+            RouteActionTargetKind::Command => "command",
+            RouteActionTargetKind::Subtask => "subtask",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum RouteActionReversibility {
+    ReversibleGitWorktree,
+    OperatorGateRequired,
+    PendingClassify,
+}
+
+impl RouteActionReversibility {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            RouteActionReversibility::ReversibleGitWorktree => "reversible_git_worktree",
+            RouteActionReversibility::OperatorGateRequired => "operator_gate_required",
+            RouteActionReversibility::PendingClassify => "pending_classify",
+        }
+    }
+}
+
 impl WorkItem {
     pub fn is_active_like(&self) -> bool {
         !self.status.is_terminal()
@@ -737,6 +787,7 @@ pub struct RouteDecisionCard {
     pub proof_requirements: Vec<String>,
     pub ownership_claim_ids: Vec<String>,
     pub trace_refs: Vec<String>,
+    pub action_items: Vec<RouteActionItem>,
     pub created_at_ms: i64,
     pub expires_at_ms: Option<i64>,
 }
@@ -761,6 +812,7 @@ pub struct RouteDecisionProjection {
     pub proof_requirements: Vec<String>,
     pub ownership_claim_count: usize,
     pub trace_ref_count: usize,
+    pub action_items: Vec<RouteActionItem>,
     pub created_at_ms: i64,
     pub expires_at_ms: Option<i64>,
 }
@@ -793,8 +845,55 @@ impl RouteDecisionCard {
             proof_requirements: item.judgment_memory.proof_requirements.clone(),
             ownership_claim_ids: item.judgment_memory.ownership_claim_ids.clone(),
             trace_refs,
+            action_items: Vec::new(),
             created_at_ms,
             expires_at_ms,
+        }
+    }
+
+    pub fn from_work_item_flagged(
+        decision_id: String,
+        item: &WorkItem,
+        trace_refs: Vec<String>,
+        created_at_ms: i64,
+        expires_at_ms: Option<i64>,
+        action_list_enabled: bool,
+    ) -> Self {
+        let card =
+            Self::from_work_item(decision_id, item, trace_refs, created_at_ms, expires_at_ms);
+        if action_list_enabled {
+            card.with_action_items(vec![Self::action_item_from_work_item(item)])
+        } else {
+            card
+        }
+    }
+
+    pub fn with_action_items(mut self, action_items: Vec<RouteActionItem>) -> Self {
+        self.action_items = action_items;
+        self
+    }
+
+    pub fn action_item_from_work_item(item: &WorkItem) -> RouteActionItem {
+        let (target_kind, target_ref) = item
+            .judgment_memory
+            .read_first_files
+            .first()
+            .map(|path| (RouteActionTargetKind::File, path.clone()))
+            .unwrap_or_else(|| {
+                (
+                    RouteActionTargetKind::Subtask,
+                    format!("friday://work-item/{}", item.work_item_id),
+                )
+            });
+
+        RouteActionItem {
+            description: item.judgment_memory.task.clone(),
+            target_kind,
+            target_ref,
+            reversibility: action_reversibility_for_work_item(item),
+            assigned_lane: item.lane,
+            assigned_provider_or_agent: item.target_provider_or_agent.clone(),
+            route_reason: item.judgment_memory.why_this_route.clone(),
         }
     }
 
@@ -814,6 +913,9 @@ impl RouteDecisionCard {
         require_non_empty_decision_vec(&self.conflict_refs, "conflict_refs")?;
         require_non_empty_decision_vec(&self.ownership_claim_ids, "ownership_claim_ids")?;
         require_non_empty_decision_vec(&self.trace_refs, "trace_refs")?;
+        for item in &self.action_items {
+            item.validate()?;
+        }
         Ok(())
     }
 
@@ -837,6 +939,11 @@ impl RouteDecisionCard {
             proof_requirements: self.proof_requirements.clone(),
             ownership_claim_count: self.ownership_claim_ids.len(),
             trace_ref_count: self.trace_refs.len(),
+            action_items: self
+                .action_items
+                .iter()
+                .map(project_route_action_item)
+                .collect(),
             created_at_ms: self.created_at_ms,
             expires_at_ms: self.expires_at_ms,
         }
@@ -857,6 +964,51 @@ impl RouteDecisionCard {
                 target.clone()
             }
         })
+    }
+}
+
+fn project_route_action_item(item: &RouteActionItem) -> RouteActionItem {
+    let mut projected = item.clone();
+    if projected.assigned_lane == WorkLane::Channel {
+        projected.assigned_provider_or_agent = Some("bound_channel".to_string());
+    }
+    projected.target_ref = match projected.target_kind {
+        RouteActionTargetKind::File => redacted_file_target(&projected.target_ref),
+        RouteActionTargetKind::Command => "command://redacted".to_string(),
+        RouteActionTargetKind::Subtask => projected.target_ref,
+    };
+    projected
+}
+
+fn redacted_file_target(value: &str) -> String {
+    let Some(last) = value
+        .rsplit(['/', '\\'])
+        .find(|part| !part.trim().is_empty())
+    else {
+        return "file://redacted".to_string();
+    };
+    format!("file://redacted/{last}")
+}
+
+impl RouteActionItem {
+    pub fn validate(&self) -> Result<(), MissionSpineError> {
+        require_non_empty_decision(&self.description, "action_item.description")?;
+        require_non_empty_decision(&self.target_ref, "action_item.target_ref")?;
+        if let Some(target) = self.assigned_provider_or_agent.as_deref() {
+            require_non_empty_decision(target, "action_item.assigned_provider_or_agent")?;
+        }
+        require_non_empty_decision(&self.route_reason, "action_item.route_reason")?;
+        Ok(())
+    }
+}
+
+fn action_reversibility_for_work_item(item: &WorkItem) -> RouteActionReversibility {
+    if item.approval_state == ApprovalState::Required || item.risk_level >= Risk::High {
+        RouteActionReversibility::OperatorGateRequired
+    } else if !item.workspace_refs.is_empty() {
+        RouteActionReversibility::ReversibleGitWorktree
+    } else {
+        RouteActionReversibility::PendingClassify
     }
 }
 
@@ -1259,6 +1411,37 @@ mod tests {
         assert_eq!(projection.selected_target_label.as_deref(), Some("codex"));
         assert_eq!(projection.trace_ref_count, 1);
         assert_eq!(projection.why_this_route, card.why_this_route);
+        assert!(projection.action_items.is_empty());
+    }
+
+    #[test]
+    fn route_decision_card_flagged_builds_plan_action_item() {
+        let item = work("wi-route", WorkItemStatus::ReadyToDispatch);
+        let card = RouteDecisionCard::from_work_item_flagged(
+            "route-decision-1".into(),
+            &item,
+            vec!["friday://trace/route-decision-1".into()],
+            10,
+            None,
+            true,
+        );
+
+        assert!(card.validate().is_ok());
+        assert_eq!(card.action_items.len(), 1);
+        let action = &card.action_items[0];
+        assert_eq!(action.description, "Implement Mission Spine domain types");
+        assert_eq!(action.target_kind, RouteActionTargetKind::File);
+        assert_eq!(action.target_ref, "rust-core/crates/friday-core/src/lib.rs");
+        assert_eq!(
+            action.reversibility,
+            RouteActionReversibility::OperatorGateRequired
+        );
+        assert_eq!(action.assigned_lane, WorkLane::Codex);
+        assert_eq!(action.assigned_provider_or_agent.as_deref(), Some("codex"));
+        assert_eq!(
+            action.route_reason,
+            "Rust Hub must own product truth before UI wiring"
+        );
     }
 
     #[test]

--- a/rust-core/crates/friday-ffi/src/lib.rs
+++ b/rust-core/crates/friday-ffi/src/lib.rs
@@ -1230,6 +1230,31 @@ impl From<friday_protocol::MissionSurfaceProjectionWire> for MissionSurfaceProje
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, uniffi::Record)]
+pub struct RouteActionItemFfi {
+    pub description: String,
+    pub target_kind: String,
+    pub target_ref: String,
+    pub reversibility: String,
+    pub assigned_lane: String,
+    pub assigned_provider_or_agent: Option<String>,
+    pub route_reason: String,
+}
+
+impl From<friday_protocol::RouteActionItemWire> for RouteActionItemFfi {
+    fn from(value: friday_protocol::RouteActionItemWire) -> Self {
+        Self {
+            description: value.description,
+            target_kind: value.target_kind,
+            target_ref: value.target_ref,
+            reversibility: value.reversibility,
+            assigned_lane: value.assigned_lane,
+            assigned_provider_or_agent: value.assigned_provider_or_agent,
+            route_reason: value.route_reason,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, uniffi::Record)]
 pub struct RouteDecisionProjectionFfi {
     pub route_decision_ref: String,
     pub mission_id: String,
@@ -1245,6 +1270,7 @@ pub struct RouteDecisionProjectionFfi {
     pub proof_requirements: Vec<String>,
     pub ownership_claim_count: u64,
     pub trace_ref_count: u64,
+    pub action_items: Vec<RouteActionItemFfi>,
     pub created_at_ms: i64,
     pub expires_at_ms: Option<i64>,
 }
@@ -1266,6 +1292,7 @@ impl From<friday_protocol::RouteDecisionProjectionWire> for RouteDecisionProject
             proof_requirements: value.proof_requirements,
             ownership_claim_count: value.ownership_claim_count,
             trace_ref_count: value.trace_ref_count,
+            action_items: value.action_items.into_iter().map(Into::into).collect(),
             created_at_ms: value.created_at_ms,
             expires_at_ms: value.expires_at_ms,
         }
@@ -1577,6 +1604,7 @@ pub fn sample_mission_spine_responses() -> Vec<AskResponseFfi> {
         proof_requirements: vec!["ledger and provider timeline proof".to_string()],
         ownership_claim_count: 0,
         trace_ref_count: 3,
+        action_items: vec![],
         created_at_ms: 1_700_100_000_020,
         expires_at_ms: None,
     };
@@ -3053,6 +3081,7 @@ mod tests {
                         proof_requirements: vec!["FFI exposes redacted route trace".into()],
                         ownership_claim_count: 0,
                         trace_ref_count: 2,
+                        action_items: vec![],
                         created_at_ms: 125,
                         expires_at_ms: None,
                     }],
@@ -3191,6 +3220,7 @@ mod tests {
                         proof_requirements: vec!["FFI timeline redaction test".into()],
                         ownership_claim_count: 0,
                         trace_ref_count: 2,
+                        action_items: vec![],
                         created_at_ms: 132,
                         expires_at_ms: None,
                     }],

--- a/rust-core/crates/friday-hub/src/global_work_graph.rs
+++ b/rust-core/crates/friday-hub/src/global_work_graph.rs
@@ -512,6 +512,7 @@ pub fn adopt_observed_work(
         proof_requirements: proposal.proof_requirements.clone(),
         ownership_claim_ids: work_item.owner_claim_ids.clone(),
         trace_refs: vec![adoption_ref.clone(), operator_ref.clone()],
+        action_items: vec![],
         created_at_ms: command.now_ms,
         expires_at_ms: None,
     };

--- a/rust-core/crates/friday-hub/src/hub_server.rs
+++ b/rust-core/crates/friday-hub/src/hub_server.rs
@@ -248,6 +248,27 @@ fn resolve_conversation_owner(db: &Db, friday_conversation_id: &str) -> Option<S
 /// Returns either a [`Message::MissionIntakeResult`] envelope (ready/blocked) or a
 /// [`Message::Error`] envelope on a validation/preflight failure, correlated to `msg_id`.
 ///
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct MissionIntakeFeatureFlags {
+    pub clarify_enabled: bool,
+    pub surface_events: bool,
+    pub action_list_enabled: bool,
+}
+
+impl MissionIntakeFeatureFlags {
+    pub const fn new(
+        clarify_enabled: bool,
+        surface_events: bool,
+        action_list_enabled: bool,
+    ) -> Self {
+        Self {
+            clarify_enabled,
+            surface_events,
+            action_list_enabled,
+        }
+    }
+}
+
 /// ## Mission-intake clarification ([`crate::FRIDAY_MISSION_INTAKE_CLARIFY`], DARK)
 /// The [`crate::FRIDAY_MISSION_INTAKE_CLARIFY`] env flag is read ONCE here (the only env
 /// read; semantics in [`crate::mission_intake_clarify_from`]) and threaded as a pure bool
@@ -279,14 +300,20 @@ pub fn mission_intake_result_for_db(
     // the flagged body — the "split env-read from pure logic" idiom. OFF ⇒ no surface_event emit.
     let surface_events =
         crate::surface_events_from(std::env::var(crate::FRIDAY_SURFACE_EVENTS).ok().as_deref());
+    let action_list_enabled = crate::d20_action_list_from(
+        std::env::var(crate::FRIDAY_D20_ACTION_LIST_ENABLED)
+            .ok()
+            .as_deref(),
+    );
+    let feature_flags =
+        MissionIntakeFeatureFlags::new(clarify_enabled, surface_events, action_list_enabled);
     mission_intake_result_for_db_flagged(
         db,
         msg_id,
         request,
         authenticated_owner,
         now_ms,
-        clarify_enabled,
-        surface_events,
+        feature_flags,
     )
 }
 
@@ -315,15 +342,23 @@ pub fn mission_intake_result_for_db(
 /// [`crate::surface_events::emit_surface_event`] so the Mission Workbench timeline reader has a
 /// birth row to fold in. OFF ⇒ byte-identical (no emit). The emit is failure-isolated: a write
 /// failure is logged + swallowed and the intake result is UNCHANGED.
+///
+/// **`action_list_enabled`** is the resolved [`crate::FRIDAY_D20_ACTION_LIST_ENABLED`] bool.
+/// OFF leaves route decisions without `action_items`; ON adds the D20 W1 plan-as-action-list
+/// item derived from the WorkItem's existing judgment memory.
 pub fn mission_intake_result_for_db_flagged(
     db: &Db,
     msg_id: &str,
     request: MissionIntakeRequestWire,
     authenticated_owner: Option<&str>,
     now_ms: i64,
-    clarify_enabled: bool,
-    surface_events: bool,
+    feature_flags: MissionIntakeFeatureFlags,
 ) -> Envelope {
+    let MissionIntakeFeatureFlags {
+        clarify_enabled,
+        surface_events,
+        action_list_enabled,
+    } = feature_flags;
     // (FIX-Q3b) OWNER BINDING — fail-closed BEFORE constructing or persisting ANY row. The
     // persisted Mission/conversation owner MUST be the AUTHENTICATED owner (the Rust-derived
     // session principal threaded from the dispatch arm), NEVER the self-asserted
@@ -578,7 +613,7 @@ pub fn mission_intake_result_for_db_flagged(
         created_at_ms: now_ms,
         updated_at_ms: now_ms,
     };
-    let route_decision = friday_core::RouteDecisionCard::from_work_item(
+    let route_decision = friday_core::RouteDecisionCard::from_work_item_flagged(
         format!(
             "route-intake-{}-{}",
             projection_ref_part(&request.mission_id),
@@ -591,6 +626,7 @@ pub fn mission_intake_result_for_db_flagged(
         )],
         now_ms,
         None,
+        action_list_enabled,
     );
 
     let outcome = match preflight_and_stage_work_item_with_workspace_claims(

--- a/rust-core/crates/friday-hub/src/lib.rs
+++ b/rust-core/crates/friday-hub/src/lib.rs
@@ -4126,6 +4126,18 @@ fn mission_intake_clarify_from(raw: Option<&str>) -> bool {
     matches!(raw.map(str::trim), Some("1"))
 }
 
+/// The `FRIDAY_D20_ACTION_LIST_ENABLED` env var. When ON, Mission route decisions
+/// carry the D20 W1 structured plan-as-action-list (`action_items`) in addition
+/// to the existing route judgment. DEFAULT-OFF: no action items are generated, so
+/// existing route_decision projections remain byte-identical at the JSON surface.
+pub const FRIDAY_D20_ACTION_LIST_ENABLED: &str = "FRIDAY_D20_ACTION_LIST_ENABLED";
+
+/// Pure flag-matcher for [`FRIDAY_D20_ACTION_LIST_ENABLED`]. ON only for exact
+/// `"1"` after trimming; all other values are OFF.
+fn d20_action_list_from(raw: Option<&str>) -> bool {
+    matches!(raw.map(str::trim), Some("1"))
+}
+
 /// The `FRIDAY_SURFACE_EVENTS` env var. When ON, the surface_event PRODUCER emits refs-only
 /// `surface_event` rows at the Mission lifecycle points (intake-birth, run-start, run-finish/proof)
 /// so the existing Mission Workbench timeline reader

--- a/rust-core/crates/friday-hub/src/mission_context.rs
+++ b/rust-core/crates/friday-hub/src/mission_context.rs
@@ -197,6 +197,32 @@ pub fn route_decision_card_for_context(
     now_ms: i64,
     expires_at_ms: Option<i64>,
 ) -> Result<RouteDecisionCard, StorageError> {
+    let action_list_enabled = crate::d20_action_list_from(
+        std::env::var(crate::FRIDAY_D20_ACTION_LIST_ENABLED)
+            .ok()
+            .as_deref(),
+    );
+    route_decision_card_for_context_flagged(
+        db,
+        context,
+        decision_id,
+        trace_refs,
+        now_ms,
+        expires_at_ms,
+        action_list_enabled,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn route_decision_card_for_context_flagged(
+    db: &Db,
+    context: &ResolvedMissionContext,
+    decision_id: String,
+    trace_refs: Vec<String>,
+    now_ms: i64,
+    expires_at_ms: Option<i64>,
+    action_list_enabled: bool,
+) -> Result<RouteDecisionCard, StorageError> {
     let Some(work_item) = db.get_work_item(&context.work_item_id)? else {
         return Err(StorageError::Unsupported(
             "resolved Mission context points to unknown WorkItem".into(),
@@ -207,12 +233,13 @@ pub fn route_decision_card_for_context(
             "resolved Mission context WorkItem/Mission mismatch".into(),
         ));
     }
-    let card = RouteDecisionCard::from_work_item(
+    let card = RouteDecisionCard::from_work_item_flagged(
         decision_id,
         &work_item,
         trace_refs,
         now_ms,
         expires_at_ms,
+        action_list_enabled,
     );
     card.validate()
         .map_err(|e| StorageError::Unsupported(e.to_string()))?;

--- a/rust-core/crates/friday-hub/tests/mission_intake_clarification.rs
+++ b/rust-core/crates/friday-hub/tests/mission_intake_clarification.rs
@@ -16,7 +16,7 @@
 //! ("1"/" 1 "/""/None/"true") are covered race-free by the in-crate
 //! `mission_intake_clarify_from_*` pure-matcher unit test.
 
-use friday_hub::hub_server::mission_intake_result_for_db_flagged;
+use friday_hub::hub_server::{mission_intake_result_for_db_flagged, MissionIntakeFeatureFlags};
 use friday_protocol::{Message, MissionIntakeRequestWire};
 use friday_storage::audit::verify_audit_chain;
 use friday_storage::Db;
@@ -30,6 +30,14 @@ use friday_storage::Db;
 /// driver test (the real consumer). A clarification result MUST make this false.
 fn auto_dispatch_allows_new_work(status: &str, created_or_ready: bool) -> bool {
     status.trim() == "ready" && created_or_ready
+}
+
+fn intake_flags(
+    clarify_enabled: bool,
+    surface_events: bool,
+    action_list_enabled: bool,
+) -> MissionIntakeFeatureFlags {
+    MissionIntakeFeatureFlags::new(clarify_enabled, surface_events, action_list_enabled)
 }
 
 fn temp_db(tag: &str) -> String {
@@ -112,8 +120,11 @@ fn arm_a_flag_on_vague_intent_clarifies_and_writes_zero_rows() {
         intake_request(VAGUE_INTENT),
         Some(OWNER), // (FIX-Q3b) authenticated owner == the request's owner_principal
         1000,
-        true,
-        false, // FRIDAY_SURFACE_EVENTS OFF (orthogonal to the clarify arm under test)
+        intake_flags(
+            true,
+            false, // FRIDAY_SURFACE_EVENTS OFF (orthogonal to the clarify arm under test)
+            false, // FRIDAY_D20_ACTION_LIST_ENABLED OFF (orthogonal to clarify)
+        ),
     );
     let result = intake_result(env);
 
@@ -172,8 +183,11 @@ fn arm_b_flag_on_detailed_classified_intent_births_a_mission_as_today() {
         intake_request(DETAILED_INTENT),
         Some(OWNER), // (FIX-Q3b) authenticated owner == the request's owner_principal
         2000,
-        true,
-        false, // FRIDAY_SURFACE_EVENTS OFF (orthogonal to the clarify arm under test)
+        intake_flags(
+            true,
+            false, // FRIDAY_SURFACE_EVENTS OFF (orthogonal to the clarify arm under test)
+            false, // FRIDAY_D20_ACTION_LIST_ENABLED OFF (orthogonal to clarify)
+        ),
     );
     let result = intake_result(env);
 
@@ -206,6 +220,52 @@ fn arm_b_flag_on_detailed_classified_intent_births_a_mission_as_today() {
 }
 
 #[test]
+fn d20_action_list_flag_on_persists_route_action_items_for_ready_intake() {
+    let db = Db::open_hub(&temp_db("d20-action-list")).unwrap();
+    let env = mission_intake_result_for_db_flagged(
+        &db,
+        "req-d20-action-list",
+        intake_request(DETAILED_INTENT),
+        Some(OWNER),
+        2500,
+        intake_flags(
+            true, false, // FRIDAY_SURFACE_EVENTS OFF (orthogonal)
+            true,  // FRIDAY_D20_ACTION_LIST_ENABLED ON
+        ),
+    );
+    let result = intake_result(env);
+    assert_eq!(result.status, "ready");
+
+    let route_decisions = db.list_route_decisions_for_mission(MISSION).unwrap();
+    assert_eq!(route_decisions.len(), 1);
+    let action_items = &route_decisions[0].action_items;
+    assert_eq!(action_items.len(), 1);
+    let item = &action_items[0];
+    assert_eq!(item.description, DETAILED_INTENT);
+    assert_eq!(
+        item.target_kind,
+        friday_core::RouteActionTargetKind::Subtask
+    );
+    assert_eq!(item.target_ref, format!("friday://work-item/{WORK_ITEM}"));
+    assert_eq!(
+        item.reversibility,
+        friday_core::RouteActionReversibility::PendingClassify
+    );
+    assert_eq!(item.assigned_lane, friday_core::WorkLane::DeepSeek);
+    assert_eq!(item.assigned_provider_or_agent.as_deref(), Some("deepseek"));
+    assert_eq!(
+        item.route_reason,
+        "Surface input must resolve to a canonical Mission."
+    );
+
+    let projections = db
+        .list_route_decision_projections_for_mission(MISSION)
+        .unwrap();
+    assert_eq!(projections[0].action_items, *action_items);
+    verify_audit_chain(db.conn()).expect("audit chain clean after D20 action-list intake");
+}
+
+#[test]
 fn arm_c_flag_off_vague_intent_births_a_mission_byte_identical() {
     let db = Db::open_hub(&temp_db("arm-c")).unwrap();
     // Flag OFF + the SAME vague intent as arm (a). Flag-OFF skips the whole clarification block ⇒
@@ -216,8 +276,11 @@ fn arm_c_flag_off_vague_intent_births_a_mission_byte_identical() {
         intake_request(VAGUE_INTENT),
         Some(OWNER), // (FIX-Q3b) authenticated owner == the request's owner_principal
         3000,
-        false,
-        false, // FRIDAY_SURFACE_EVENTS OFF (orthogonal to the clarify arm under test)
+        intake_flags(
+            false,
+            false, // FRIDAY_SURFACE_EVENTS OFF (orthogonal to the clarify arm under test)
+            false, // FRIDAY_D20_ACTION_LIST_ENABLED OFF (baseline)
+        ),
     );
     let result = intake_result(env);
 
@@ -259,8 +322,11 @@ fn arm_d_flag_on_unclassified_intent_births_a_mission() {
         intake_request(UNCLASSIFIED_INTENT),
         Some(OWNER), // (FIX-Q3b) authenticated owner == the request's owner_principal
         4000,
-        true,
-        false, // FRIDAY_SURFACE_EVENTS OFF (orthogonal to the clarify arm under test)
+        intake_flags(
+            true,
+            false, // FRIDAY_SURFACE_EVENTS OFF (orthogonal to the clarify arm under test)
+            false, // FRIDAY_D20_ACTION_LIST_ENABLED OFF (orthogonal to clarify)
+        ),
     );
     let result = intake_result(env);
 
@@ -296,8 +362,11 @@ fn owner_spoof_is_rejected_and_writes_zero_rows() {
         request,
         Some(OWNER), // the AUTHENTICATED owner — differs from the spoofed body field
         5000,
-        false, // clarify OFF (irrelevant — owner binding gates before any row)
-        false, // surface_events OFF
+        intake_flags(
+            false, // clarify OFF (irrelevant — owner binding gates before any row)
+            false, // surface_events OFF
+            false, // D20 action list OFF
+        ),
     );
 
     match env.message {
@@ -336,8 +405,7 @@ fn persisted_owner_is_the_authenticated_owner() {
         intake_request(DETAILED_INTENT),
         Some(OWNER),
         6000,
-        false,
-        false,
+        intake_flags(false, false, false),
     );
     assert_eq!(
         intake_result(env).status,
@@ -366,8 +434,7 @@ fn missing_authenticated_owner_is_rejected() {
         intake_request(DETAILED_INTENT), // body carries OWNER, but no AUTHENTICATED owner is supplied
         None,
         7000,
-        false,
-        false,
+        intake_flags(false, false, false),
     );
     assert!(
         matches!(env.message, Message::Error { .. }),

--- a/rust-core/crates/friday-protocol/src/lib.rs
+++ b/rust-core/crates/friday-protocol/src/lib.rs
@@ -90,6 +90,33 @@ impl From<friday_core::MissionSurfaceProjection> for MissionSurfaceProjectionWir
     }
 }
 
+/// Surface-safe D20 W1 plan action attached to a route decision.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RouteActionItemWire {
+    pub description: String,
+    pub target_kind: String,
+    pub target_ref: String,
+    pub reversibility: String,
+    pub assigned_lane: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub assigned_provider_or_agent: Option<String>,
+    pub route_reason: String,
+}
+
+impl From<friday_core::RouteActionItem> for RouteActionItemWire {
+    fn from(value: friday_core::RouteActionItem) -> Self {
+        Self {
+            description: value.description,
+            target_kind: value.target_kind.as_str().to_string(),
+            target_ref: value.target_ref,
+            reversibility: value.reversibility.as_str().to_string(),
+            assigned_lane: value.assigned_lane.as_str().to_string(),
+            assigned_provider_or_agent: value.assigned_provider_or_agent,
+            route_reason: value.route_reason,
+        }
+    }
+}
+
 /// Surface-safe route judgment attached to a Mission snapshot. This preserves
 /// Friday's lane/agent/channel judgment path for UI and handoff dashboards, but
 /// carries only redacted refs/counts. Raw channel chat ids, provider thread ids,
@@ -111,6 +138,8 @@ pub struct RouteDecisionProjectionWire {
     pub proof_requirements: Vec<String>,
     pub ownership_claim_count: u64,
     pub trace_ref_count: u64,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub action_items: Vec<RouteActionItemWire>,
     pub created_at_ms: i64,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub expires_at_ms: Option<i64>,
@@ -133,6 +162,7 @@ impl From<friday_core::RouteDecisionProjection> for RouteDecisionProjectionWire 
             proof_requirements: value.proof_requirements,
             ownership_claim_count: value.ownership_claim_count as u64,
             trace_ref_count: value.trace_ref_count as u64,
+            action_items: value.action_items.into_iter().map(Into::into).collect(),
             created_at_ms: value.created_at_ms,
             expires_at_ms: value.expires_at_ms,
         }
@@ -1885,6 +1915,7 @@ mod tests {
                     proof_requirements: vec!["route decision projection test".into()],
                     ownership_claim_count: 0,
                     trace_ref_count: 2,
+                    action_items: vec![],
                     created_at_ms: 1_700_000_000_002,
                     expires_at_ms: None,
                 }],
@@ -1987,6 +2018,7 @@ mod tests {
                     proof_requirements: vec!["route decision projection test".into()],
                     ownership_claim_count: 0,
                     trace_ref_count: 2,
+                    action_items: vec![],
                     created_at_ms: 1_700_000_000_002,
                     expires_at_ms: None,
                 }],

--- a/rust-core/crates/friday-storage/src/mission.rs
+++ b/rust-core/crates/friday-storage/src/mission.rs
@@ -12,8 +12,9 @@ use friday_core::{
     find_duplicate_work_item as core_find_duplicate_work_item, outcome_checked_proof_enabled,
     validate_friday_conversation_id, ApprovalState, FridayConversation, HandoffJudgmentMemory,
     Mission, MissionLink, MissionLinkKind, MissionStatus, MissionSurfaceProjection,
-    RouteDecisionCard, RouteDecisionProjection, SurfaceEvent, SurfaceEventKind, SurfaceKind,
-    SurfaceThread, TruthStatus, VisibilityPolicy, WorkItem, WorkItemStatus, WorkLane,
+    RouteActionItem, RouteActionReversibility, RouteActionTargetKind, RouteDecisionCard,
+    RouteDecisionProjection, SurfaceEvent, SurfaceEventKind, SurfaceKind, SurfaceThread,
+    TruthStatus, VisibilityPolicy, WorkItem, WorkItemStatus, WorkLane,
 };
 use rusqlite::{params, Connection, OptionalExtension};
 
@@ -39,6 +40,121 @@ fn encode_vec(values: &[String], field: &str) -> Result<String> {
 fn decode_vec(value: String, field: &str) -> Result<Vec<String>> {
     serde_json::from_str(&value)
         .map_err(|e| unsupported(format!("failed to decode {field} json: {e}")))
+}
+
+fn encode_route_action_items(values: &[RouteActionItem], field: &str) -> Result<String> {
+    let items = values
+        .iter()
+        .map(|item| {
+            serde_json::json!({
+                "description": item.description,
+                "target_kind": item.target_kind.as_str(),
+                "target_ref": item.target_ref,
+                "reversibility": item.reversibility.as_str(),
+                "assigned_lane": item.assigned_lane.as_str(),
+                "assigned_provider_or_agent": item.assigned_provider_or_agent,
+                "route_reason": item.route_reason,
+            })
+        })
+        .collect::<Vec<_>>();
+    serde_json::to_string(&items)
+        .map_err(|e| unsupported(format!("failed to encode {field} as json: {e}")))
+}
+
+fn decode_route_action_items(value: String, field: &str) -> Result<Vec<RouteActionItem>> {
+    let values = serde_json::from_str::<Vec<serde_json::Value>>(&value)
+        .map_err(|e| unsupported(format!("failed to decode {field} json: {e}")))?;
+    values
+        .into_iter()
+        .enumerate()
+        .map(|(index, value)| decode_route_action_item(value, field, index))
+        .collect()
+}
+
+fn decode_route_action_item(
+    value: serde_json::Value,
+    field: &str,
+    index: usize,
+) -> Result<RouteActionItem> {
+    let object = value
+        .as_object()
+        .ok_or_else(|| unsupported(format!("{field}[{index}] must be a route action object")))?;
+    let assigned_provider_or_agent = match object.get("assigned_provider_or_agent") {
+        None | Some(serde_json::Value::Null) => None,
+        Some(value) => Some(json_string(
+            value,
+            field,
+            index,
+            "assigned_provider_or_agent",
+        )?),
+    };
+    Ok(RouteActionItem {
+        description: json_string(
+            object
+                .get("description")
+                .ok_or_else(|| missing_json_field(field, index, "description"))?,
+            field,
+            index,
+            "description",
+        )?,
+        target_kind: parse_route_action_target_kind(&json_string(
+            object
+                .get("target_kind")
+                .ok_or_else(|| missing_json_field(field, index, "target_kind"))?,
+            field,
+            index,
+            "target_kind",
+        )?)?,
+        target_ref: json_string(
+            object
+                .get("target_ref")
+                .ok_or_else(|| missing_json_field(field, index, "target_ref"))?,
+            field,
+            index,
+            "target_ref",
+        )?,
+        reversibility: parse_route_action_reversibility(&json_string(
+            object
+                .get("reversibility")
+                .ok_or_else(|| missing_json_field(field, index, "reversibility"))?,
+            field,
+            index,
+            "reversibility",
+        )?)?,
+        assigned_lane: parse_work_lane(json_string(
+            object
+                .get("assigned_lane")
+                .ok_or_else(|| missing_json_field(field, index, "assigned_lane"))?,
+            field,
+            index,
+            "assigned_lane",
+        )?)?,
+        assigned_provider_or_agent,
+        route_reason: json_string(
+            object
+                .get("route_reason")
+                .ok_or_else(|| missing_json_field(field, index, "route_reason"))?,
+            field,
+            index,
+            "route_reason",
+        )?,
+    })
+}
+
+fn json_string(
+    value: &serde_json::Value,
+    field: &str,
+    index: usize,
+    child: &str,
+) -> Result<String> {
+    value
+        .as_str()
+        .map(ToString::to_string)
+        .ok_or_else(|| unsupported(format!("{field}[{index}].{child} must be a string")))
+}
+
+fn missing_json_field(field: &str, index: usize, child: &str) -> StorageError {
+    unsupported(format!("{field}[{index}].{child} is required"))
 }
 
 fn parse_truth_status(value: String) -> Result<TruthStatus> {
@@ -78,6 +194,28 @@ fn parse_work_lane(value: String) -> Result<WorkLane> {
         "human" => Ok(WorkLane::Human),
         "future_api" => Ok(WorkLane::FutureApi),
         _ => Err(unsupported(format!("unknown work lane '{value}'"))),
+    }
+}
+
+fn parse_route_action_target_kind(value: &str) -> Result<RouteActionTargetKind> {
+    match value {
+        "file" => Ok(RouteActionTargetKind::File),
+        "command" => Ok(RouteActionTargetKind::Command),
+        "subtask" => Ok(RouteActionTargetKind::Subtask),
+        _ => Err(unsupported(format!(
+            "unknown route action target kind '{value}'"
+        ))),
+    }
+}
+
+fn parse_route_action_reversibility(value: &str) -> Result<RouteActionReversibility> {
+    match value {
+        "reversible_git_worktree" => Ok(RouteActionReversibility::ReversibleGitWorktree),
+        "operator_gate_required" => Ok(RouteActionReversibility::OperatorGateRequired),
+        "pending_classify" => Ok(RouteActionReversibility::PendingClassify),
+        _ => Err(unsupported(format!(
+            "unknown route action reversibility '{value}'"
+        ))),
     }
 }
 
@@ -1790,8 +1928,8 @@ pub fn upsert_route_decision(conn: &Connection, card: &RouteDecisionCard) -> Res
              selected_provider_or_agent, why_this_route, considered_options,
              deferred_options, previous_pitfalls, inheritable_context,
              conflict_refs, proof_requirements, ownership_claim_ids, trace_refs,
-             created_at_ms, expires_at_ms)
-         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16)
+             action_items, created_at_ms, expires_at_ms)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17)
          ON CONFLICT(decision_id) DO UPDATE SET
             mission_id = excluded.mission_id,
             work_item_id = excluded.work_item_id,
@@ -1806,6 +1944,7 @@ pub fn upsert_route_decision(conn: &Connection, card: &RouteDecisionCard) -> Res
             proof_requirements = excluded.proof_requirements,
             ownership_claim_ids = excluded.ownership_claim_ids,
             trace_refs = excluded.trace_refs,
+            action_items = excluded.action_items,
             created_at_ms = excluded.created_at_ms,
             expires_at_ms = excluded.expires_at_ms",
         params![
@@ -1835,6 +1974,7 @@ pub fn upsert_route_decision(conn: &Connection, card: &RouteDecisionCard) -> Res
                 "route_decision.ownership_claim_ids"
             )?,
             encode_vec(&card.trace_refs, "route_decision.trace_refs")?,
+            encode_route_action_items(&card.action_items, "route_decision.action_items")?,
             card.created_at_ms,
             card.expires_at_ms,
         ],
@@ -1863,7 +2003,7 @@ pub fn get_route_decision(
                     selected_provider_or_agent, why_this_route, considered_options,
                     deferred_options, previous_pitfalls, inheritable_context,
                     conflict_refs, proof_requirements, ownership_claim_ids, trace_refs,
-                    created_at_ms, expires_at_ms
+                    action_items, created_at_ms, expires_at_ms
              FROM route_decision
              WHERE decision_id = ?1",
             [decision_id],
@@ -1883,8 +2023,9 @@ pub fn get_route_decision(
                     r.get::<_, String>(11)?,
                     r.get::<_, String>(12)?,
                     r.get::<_, String>(13)?,
-                    r.get::<_, i64>(14)?,
-                    r.get::<_, Option<i64>>(15)?,
+                    r.get::<_, String>(14)?,
+                    r.get::<_, i64>(15)?,
+                    r.get::<_, Option<i64>>(16)?,
                 ))
             },
         )
@@ -1901,7 +2042,7 @@ pub fn list_route_decisions_for_mission(
                 selected_provider_or_agent, why_this_route, considered_options,
                 deferred_options, previous_pitfalls, inheritable_context,
                 conflict_refs, proof_requirements, ownership_claim_ids, trace_refs,
-                created_at_ms, expires_at_ms
+                action_items, created_at_ms, expires_at_ms
          FROM route_decision
          WHERE mission_id = ?1
          ORDER BY created_at_ms, decision_id",
@@ -1922,8 +2063,9 @@ pub fn list_route_decisions_for_mission(
             r.get::<_, String>(11)?,
             r.get::<_, String>(12)?,
             r.get::<_, String>(13)?,
-            r.get::<_, i64>(14)?,
-            r.get::<_, Option<i64>>(15)?,
+            r.get::<_, String>(14)?,
+            r.get::<_, i64>(15)?,
+            r.get::<_, Option<i64>>(16)?,
         ))
     })?;
     let mut out = Vec::new();
@@ -1960,6 +2102,7 @@ fn route_decision_from_row(
         String,
         String,
         String,
+        String,
         i64,
         Option<i64>,
     ),
@@ -1979,6 +2122,7 @@ fn route_decision_from_row(
         proof_requirements,
         ownership_claim_ids,
         trace_refs,
+        action_items,
         created_at_ms,
         expires_at_ms,
     ) = row;
@@ -1997,6 +2141,7 @@ fn route_decision_from_row(
         proof_requirements: decode_vec(proof_requirements, "route_decision.proof_requirements")?,
         ownership_claim_ids: decode_vec(ownership_claim_ids, "route_decision.ownership_claim_ids")?,
         trace_refs: decode_vec(trace_refs, "route_decision.trace_refs")?,
+        action_items: decode_route_action_items(action_items, "route_decision.action_items")?,
         created_at_ms,
         expires_at_ms,
     };

--- a/rust-core/crates/friday-storage/src/schema.rs
+++ b/rust-core/crates/friday-storage/src/schema.rs
@@ -608,6 +608,16 @@ pub fn hub_migrations() -> Vec<Migration> {
             destructive: false,
             up: m0034_memory_fts5_hybrid_recall,
         },
+        // D20 W1: structured plan-as-action-list carried by route decisions. This
+        // is an additive Hub-only JSON column with DEFAULT [] so existing
+        // route_decision rows project byte-identically when the D20 action-list
+        // flag is OFF.
+        Migration {
+            version: 35,
+            name: "route_decision_action_items",
+            destructive: false,
+            up: m0035_route_decision_action_items,
+        },
     ]
 }
 
@@ -2426,5 +2436,12 @@ fn m0034_memory_fts5_hybrid_recall(tx: &Transaction) -> rusqlite::Result<()> {
          INSERT INTO memory_fts(content, memory_id)
            SELECT content, memory_id FROM memory_item
             WHERE state = 'confirmed' AND content IS NOT NULL AND content != '';",
+    )
+}
+
+fn m0035_route_decision_action_items(tx: &Transaction) -> rusqlite::Result<()> {
+    tx.execute_batch(
+        "ALTER TABLE route_decision
+           ADD COLUMN action_items TEXT NOT NULL DEFAULT '[]';",
     )
 }

--- a/rust-core/crates/friday-storage/tests/mission_spine.rs
+++ b/rust-core/crates/friday-storage/tests/mission_spine.rs
@@ -594,7 +594,10 @@ fn route_decision_persists_as_trace_without_memory_authority_or_raw_surface_ids(
         ],
         42,
         None,
-    );
+    )
+    .with_action_items(vec![RouteDecisionCard::action_item_from_work_item(
+        &channel_work,
+    )]);
     db.upsert_route_decision(&card).unwrap();
 
     let stored = db
@@ -610,6 +613,7 @@ fn route_decision_persists_as_trace_without_memory_authority_or_raw_surface_ids(
         .trace_refs
         .iter()
         .any(|trace| trace.contains("tg:room-1")));
+    assert_eq!(stored.action_items, card.action_items);
 
     let links = db.list_mission_links("mission-spine").unwrap();
     let route_link = links
@@ -633,9 +637,21 @@ fn route_decision_persists_as_trace_without_memory_authority_or_raw_surface_ids(
     );
     assert_eq!(projection.trace_ref_count, 2);
     assert_eq!(projection.why_this_route, judgment().why_this_route);
+    assert_eq!(projection.action_items.len(), 1);
+    assert_eq!(
+        projection.action_items[0]
+            .assigned_provider_or_agent
+            .as_deref(),
+        Some("bound_channel")
+    );
+    assert_eq!(
+        projection.action_items[0].target_ref,
+        "file://redacted/schema.rs"
+    );
     let rendered_projection = format!("{projection:?}");
     assert!(!rendered_projection.contains("tg:room-1"));
     assert!(!rendered_projection.contains("chan:tg"));
+    assert!(!rendered_projection.contains("friday-storage/src"));
 }
 
 #[test]

--- a/src/state/sqlite/friday-rust-hub-schema-handshake.ts
+++ b/src/state/sqlite/friday-rust-hub-schema-handshake.ts
@@ -6,7 +6,7 @@ import Database from "better-sqlite3";
 import { FridayDomainError } from "#errors";
 
 export const FRIDAY_HUB_AGENT_RUN_DB_PATH_ENV = "FRIDAY_HUB_AGENT_RUN_DB_PATH";
-export const FRIDAY_EXPECTED_RUST_HUB_SCHEMA_VERSION = 34;
+export const FRIDAY_EXPECTED_RUST_HUB_SCHEMA_VERSION = 35;
 
 export type FridayRustHubSchemaHandshakeStatus = "ok" | "skipped";
 


### PR DESCRIPTION
## Summary
- Adds a default-off D20 W1 plan-as-action-list slice on RouteDecisionCard.
- Persists action items through Hub-owned mission spine storage and projects them through protocol/FFI with redacted refs.
- Registers FRIDAY_D20_ACTION_LIST_ENABLED in the prod flag manifest with loop-e2e coverage.

## Truth Labels
- built-DARK only; this is not W1 live-done and does not enable trust-dial.
- Reversibility here is planning/display metadata only. W2 classify() remains the required authority before any auto-allow path exists.
- Friday still has no action rollback engine; D20 reversibility will rely on constrained git/worktree space, not undo.

## Verification
- cargo fmt --all -- --check
- cargo test -p friday-core mission::tests::route_decision_card --lib
- cargo test -p friday-storage --test mission_spine
- cargo test -p friday-hub --test mission_intake_clarification
- cargo check -p friday-protocol -p friday-ffi
- node scripts/ci/verify-prod-flag-tests.mjs