### PR TITLE
Retire legacy memory item cleanup deletes

### DIFF
--- a/src/learning/services/friday-system-health-monitor.ts
+++ b/src/learning/services/friday-system-health-monitor.ts
@@ -77,6 +77,9 @@ interface HealthCheck {
   };
 }
 
+const RETIRED_MEMORY_ITEMS_MAINTENANCE =
+  "TS_RUNTIME_DURABLE_MEMORY_WRITE_RETIRED: expired memory_items maintenance is disabled in the TypeScript runtime; use the Rust memory owner/migration path instead.";
+
 const HEALTH_CHECKS: HealthCheck[] = [
   {
     name: "db_size",
@@ -112,17 +115,10 @@ const HEALTH_CHECKS: HealthCheck[] = [
       return { name: "expired_memory_items", healthy: count < 500, value: count, unit: "items" };
     },
     maintenance: {
-      detail: "Prune expired memory items in a bounded local batch",
+      detail: "Expired memory item cleanup must run through the Rust memory owner/migration path",
       nonReversibleReason: "Expired memory item deletion removes local rows and cannot be reconstructed by Friday.",
-      run: (deps) => {
-        const nowIso = deps.nowIso();
-        const result = deps.db.withWriteTransaction((db) =>
-          db
-            .prepare("DELETE FROM memory_items WHERE rowid IN (SELECT rowid FROM memory_items WHERE expires_at IS NOT NULL AND expires_at < ? LIMIT 200)")
-            .run(nowIso),
-        );
-        const pruned = (result as { changes?: number })?.changes ?? 0;
-        return { detail: `Pruned ${pruned} expired memory items`, changes: pruned };
+      run: () => {
+        throw new Error(RETIRED_MEMORY_ITEMS_MAINTENANCE);
       },
     },
   },

--- a/src/skills/generator/persistence/friday-skill-generation-session-repository.ts
+++ b/src/skills/generator/persistence/friday-skill-generation-session-repository.ts
@@ -163,27 +163,6 @@ function listMemoryItemsByNamespacePrefix(
     .all(namespace, `${keyPrefix}%`) as MemoryItemRow[];
 }
 
-function deleteMemoryItem(
-  db: Database.Database,
-  namespace: string,
-  key: string,
-): void {
-  db.prepare("DELETE FROM memory_items WHERE namespace = ? AND key = ?").run(
-    namespace,
-    key,
-  );
-}
-
-function deleteMemoryItemsByPrefix(
-  db: Database.Database,
-  namespace: string,
-  keyPrefix: string,
-): void {
-  db.prepare(
-    "DELETE FROM memory_items WHERE namespace = ? AND key LIKE ?",
-  ).run(namespace, `${keyPrefix}%`);
-}
-
 function deleteSkillGenerationSession(
   db: Database.Database,
   sessionId: string,
@@ -302,12 +281,6 @@ export function createFridaySkillGenerationSessionRepository(
       db.withWriteTransaction((writer) => {
         deleteSkillGenerationSession(writer, sessionKey(sessionId));
         deleteSkillGenerationTurns(writer, sessionKey(sessionId));
-        deleteMemoryItem(writer, SESSION_NAMESPACE, sessionKey(sessionId));
-        deleteMemoryItemsByPrefix(
-          writer,
-          TURN_NAMESPACE,
-          turnKeyPrefix(sessionId),
-        );
       });
     },
   };

--- a/src/skills/generator/services/friday-skill-generator-service.ts
+++ b/src/skills/generator/services/friday-skill-generator-service.ts
@@ -720,9 +720,6 @@ export function createFridaySkillGeneratorService(
       writer
         .prepare("DELETE FROM skill_generation_drafts WHERE session_id = ?")
         .run(sessionId);
-      writer
-        .prepare("DELETE FROM memory_items WHERE namespace = ? AND key = ?")
-        .run(DRAFT_NAMESPACE, sessionId);
     });
   }
 

--- a/src/workflows/generator/persistence/friday-workflow-generation-session-repository.ts
+++ b/src/workflows/generator/persistence/friday-workflow-generation-session-repository.ts
@@ -163,27 +163,6 @@ function listMemoryItemsByNamespacePrefix(
     .all(namespace, `${keyPrefix}%`) as MemoryItemRow[];
 }
 
-function deleteMemoryItem(
-  db: Database.Database,
-  namespace: string,
-  key: string,
-): void {
-  db.prepare("DELETE FROM memory_items WHERE namespace = ? AND key = ?").run(
-    namespace,
-    key,
-  );
-}
-
-function deleteMemoryItemsByPrefix(
-  db: Database.Database,
-  namespace: string,
-  keyPrefix: string,
-): void {
-  db.prepare(
-    "DELETE FROM memory_items WHERE namespace = ? AND key LIKE ?",
-  ).run(namespace, `${keyPrefix}%`);
-}
-
 function deleteWorkflowGenerationSession(
   db: Database.Database,
   sessionId: string,
@@ -298,12 +277,6 @@ export function createFridayWorkflowGenerationSessionRepository(
       db.withWriteTransaction((writer) => {
         deleteWorkflowGenerationTurns(writer, sessionId);
         deleteWorkflowGenerationSession(writer, sessionId);
-        deleteMemoryItem(writer, SESSION_NAMESPACE, sessionKey(sessionId));
-        deleteMemoryItemsByPrefix(
-          writer,
-          TURN_NAMESPACE,
-          turnKeyPrefix(sessionId),
-        );
       });
     },
   };

--- a/src/workflows/generator/services/friday-workflow-generator-service.ts
+++ b/src/workflows/generator/services/friday-workflow-generator-service.ts
@@ -577,9 +577,6 @@ export function createFridayWorkflowGeneratorService(
       writer
         .prepare("DELETE FROM workflow_generation_drafts WHERE session_id = ?")
         .run(sessionId);
-      writer
-        .prepare("DELETE FROM memory_items WHERE namespace = ? AND key = ?")
-        .run(DRAFT_NAMESPACE, sessionId);
     });
   }
 

--- a/test/unit/learning/services/friday-system-health-monitor.test.ts
+++ b/test/unit/learning/services/friday-system-health-monitor.test.ts
@@ -115,7 +115,7 @@ describe("FridaySystemHealthMonitor", () => {
     expect(summary.maintenanceRecommendations).toContainEqual({
       name: "expired_memory_items",
       gateRequired: "explicit_maintenance",
-      detail: "Prune expired memory items in a bounded local batch",
+      detail: "Expired memory item cleanup must run through the Rust memory owner/migration path",
       value: 600,
       unit: "items",
     });
@@ -142,7 +142,7 @@ describe("FridaySystemHealthMonitor", () => {
     expect(countStaleRealtimeCheckpoints()).toBe(1001);
   });
 
-  it("runs cleanup only with explicit maintenance gate and emits a non-reversible receipt", () => {
+  it("fails closed for expired memory cleanup even with an explicit maintenance gate", () => {
     insertExpiredMemoryItems(600);
 
     const summary = monitor.runAll({
@@ -159,8 +159,9 @@ describe("FridaySystemHealthMonitor", () => {
     expect(receipt).toMatchObject({
       receiptId: `system-health-maintenance:expired_memory_items:${NOW}`,
       name: "expired_memory_items",
-      status: "applied",
-      detail: "Pruned 200 expired memory items",
+      status: "failed",
+      detail:
+        "Maintenance failed: TS_RUNTIME_DURABLE_MEMORY_WRITE_RETIRED: expired memory_items maintenance is disabled in the TypeScript runtime; use the Rust memory owner/migration path instead.",
       runAt: NOW,
       requestedBy: "owner-user",
       reason: "manual maintenance window",
@@ -168,9 +169,9 @@ describe("FridaySystemHealthMonitor", () => {
       approvalRef: "maintenance-ticket-001",
       rollbackClass: "non_reversible_local",
       nonReversibleReason: "Expired memory item deletion removes local rows and cannot be reconstructed by Friday.",
-      evidence: { beforeValue: 600, unit: "items", changes: 200 },
+      evidence: { beforeValue: 600, unit: "items" },
     });
-    expect(countExpiredMemoryItems()).toBe(400);
+    expect(countExpiredMemoryItems()).toBe(600);
   });
 
   it("does not run cleanup with an incomplete maintenance gate", () => {

--- a/test/unit/skills/generator/persistence/friday-skill-generation-session-repository.test.ts
+++ b/test/unit/skills/generator/persistence/friday-skill-generation-session-repository.test.ts
@@ -127,6 +127,30 @@ describe("FridaySkillGenerationSessionRepository", () => {
     expect(repo.getTurns("sess-001")).toEqual([]);
   });
 
+  it("deleteSession does not mutate legacy memory_items fallback rows", () => {
+    db.withWriteTransaction((writer) => {
+      writer.prepare(
+        "INSERT INTO memory_items (id, namespace, key, value_json, tags_json, created_at, updated_at) VALUES (?, ?, ?, ?, '[]', ?, ?)",
+      ).run(
+        "legacy-session",
+        "skill-generator-session",
+        "sess-legacy",
+        JSON.stringify(baseSession),
+        NOW,
+        NOW,
+      );
+    });
+
+    repo.deleteSession("sess-legacy");
+
+    const row = db.withReadConnection((reader) =>
+      reader
+        .prepare("SELECT COUNT(*) AS count FROM memory_items WHERE namespace = ? AND key = ?")
+        .get("skill-generator-session", "sess-legacy"),
+    ) as { count: number };
+    expect(row.count).toBe(1);
+  });
+
   it("getTurns for one session does not return turns from another", () => {
     repo.createSession(baseSession);
     const session2: FridaySkillGenerationSession = {

--- a/test/unit/workflows/generator/persistence/friday-workflow-generation-session-repository.test.ts
+++ b/test/unit/workflows/generator/persistence/friday-workflow-generation-session-repository.test.ts
@@ -181,12 +181,13 @@ function makeMockDb(): FridaySqliteLayer {
 const NOW = "2026-02-18T10:00:00.000Z";
 
 describe("FridayWorkflowGenerationSessionRepository", () => {
+  let db: FridaySqliteLayer;
   let repo: FridayWorkflowGenerationSessionRepository;
   let idCounter: number;
 
   beforeEach(() => {
     idCounter = 0;
-    const db = makeMockDb();
+    db = makeMockDb();
     repo = createFridayWorkflowGenerationSessionRepository({
       db,
       idGenerator: () => `id-${++idCounter}`,
@@ -256,6 +257,27 @@ describe("FridayWorkflowGenerationSessionRepository", () => {
     repo.deleteSession("s-1");
     expect(repo.getSession("s-1")).toBeNull();
     expect(repo.getTurns("s-1")).toHaveLength(0);
+  });
+
+  it("deleteSession does not mutate legacy memory_items fallback rows", () => {
+    db.withWriteTransaction((writer) => {
+      (writer as { prepare: (sql: string) => { run: (...args: unknown[]) => void } }).prepare(
+        "INSERT INTO memory_items (id, namespace, key, value_json, tags_json, created_at, updated_at) VALUES (?, ?, ?, ?, '[]', ?, ?)",
+      ).run(
+        "legacy-session",
+        "workflow-generator-session",
+        "s-legacy",
+        JSON.stringify(makeSession({ sessionId: "s-legacy" })),
+        NOW,
+        NOW,
+      );
+    });
+
+    repo.deleteSession("s-legacy");
+
+    const legacySession = repo.getSession("s-legacy");
+    expect(legacySession).not.toBeNull();
+    expect(legacySession!.sessionId).toBe("s-legacy");
   });
 
   it("adds and retrieves turns in order", () => {


### PR DESCRIPTION
## Summary
- stop skill/workflow generator cleanup paths from deleting legacy memory_items fallback rows
- fail closed system-health expired memory_items maintenance instead of deleting from the TS runtime
- add regression coverage proving legacy fallback rows are not mutated and explicit maintenance does not prune old memory rows

## Verification
- npm test -- --run test/unit/skills/generator/persistence/friday-skill-generation-session-repository.test.ts test/unit/skills/generator/services/friday-skill-generator-service.test.ts test/unit/workflows/generator/persistence/friday-workflow-generation-session-repository.test.ts test/unit/workflows/generator/services/friday-workflow-generator-service.test.ts test/unit/learning/services/friday-system-health-monitor.test.ts
- npm test -- --run test/integration/state/sqlite/friday-migration-chain.test.ts
- npm test -- --run test/unit/memory/services/friday-memory-service.test.ts test/unit/memory/guard/persistence/friday-memory-guard-quota-repository.test.ts test/unit/memory/sync/friday-memory-file-sync-service.test.ts test/unit/quality/workspace-memory-facts.test.ts
- npm run build
- git diff --check

## Truth Boundary
- D1 residual legacy memory_items cleanup-delete slice only.
- This is not complete D1 acceptance, not registry/v1 done, and not D20 live.
- Remaining runtime memory_items mutations are the existing guarded memory service, memory guard quota, and test-only file reverse-import families; migrations remain allowed migration cleanup.