### PR TITLE
Enforce trust grant run and token ceilings

### DIFF
--- a/rust-core/crates/friday-core/src/trust.rs
+++ b/rust-core/crates/friday-core/src/trust.rs
@@ -17,9 +17,9 @@
 //!   objection" — it is NEVER an upgrade (the storage compose feeds it to the mutating
 //!   gate, which can still require approval).
 //!
-//! DEFERRED (stored, NOT enforced — honest): `token_ceiling` / `max_runs` need a live
-//! token-ledger / run-state counter; this baseline stores them but does not enforce
-//! them (no fake counter). The check ignores them.
+//! Storage-enforced outside this PURE check: `max_runs` and action-time
+//! `token_ceiling` use the `friday-storage` compose plus a `(grant_id, run_id)`
+//! usage ledger. This pure check still ignores counters because it has no I/O.
 
 use crate::gate::GateDecision;
 use crate::tool_policy::Risk;
@@ -31,9 +31,9 @@ pub struct TrustBoundaries {
     pub workspace: Option<String>,
     /// The maximum risk an action may carry. An effective risk ABOVE this is denied.
     pub risk_ceiling: Risk,
-    /// DEFERRED (stored, not enforced): token spend ceiling.
+    /// Storage-enforced outside the pure check: action-time token spend ceiling.
     pub token_ceiling: Option<i64>,
-    /// DEFERRED (stored, not enforced): max runs under this grant.
+    /// Storage-enforced outside the pure check: max distinct run ids under this grant.
     pub max_runs: Option<i64>,
     /// Allowlists. EMPTY = DENY-ALL for that dimension (fail-closed).
     pub allowed_channels: Vec<String>,

--- a/rust-core/crates/friday-hub/src/lib.rs
+++ b/rust-core/crates/friday-hub/src/lib.rs
@@ -1972,6 +1972,18 @@ impl RunPolicy {
         self
     }
 
+    /// Attach the stable loop run id to an existing trust action context. This is done
+    /// at the loop entrypoint, where the authoritative `run_id` already exists, so
+    /// trust-grant `max_runs` is charged per run rather than per tool action.
+    fn with_run_id(mut self, run_id: &str) -> Self {
+        if let Some(ctx) = self.action_context.as_mut() {
+            if ctx.run_id.is_none() {
+                ctx.run_id = Some(run_id.to_string());
+            }
+        }
+        self
+    }
+
     /// (NS-1) The run's action context, as carried to the gate-dispatch chokepoint —
     /// the thin accessor NS-2 reads to build the [`friday_storage::AgentActionContext`]
     /// for the trust check. `None` ⇒ no context attached (every pre-NS-1 caller).
@@ -4847,6 +4859,7 @@ pub fn run_loop_with_policy_flagged(
     work_item_id: Option<&str>,
     escalation_client: Option<&dyn AgentLlmClient>,
 ) -> Result<LoopOutcome, StorageError> {
+    let policy_with_run_id = policy.clone().with_run_id(run_id);
     // (#24b) Run the loop body to completion, then CLEAR the durable execution marker EXACTLY ONCE
     // — covering EVERY exit (every `return` arm + every `?`-propagated error) structurally, so a
     // stale-executing row can never be left behind. The SET happens per-turn inside the inner fn,
@@ -4860,7 +4873,7 @@ pub fn run_loop_with_policy_flagged(
         recall_preamble,
         operator_vk,
         approve,
-        policy,
+        &policy_with_run_id,
         max_turns,
         cancel,
         steer,
@@ -6661,6 +6674,7 @@ mod tests {
     fn ns1_full_ctx() -> friday_storage::AgentActionContext {
         friday_storage::AgentActionContext {
             agent_id: "agent-ns1".to_string(),
+            run_id: None,
             workspace: Some("ws-ns1".to_string()),
             tool: Some("read_file".to_string()),
             provider: Some("deepseek".to_string()),
@@ -6703,6 +6717,31 @@ mod tests {
         assert_eq!(tightened.principal_id(), Some("alice"));
         assert!(tightened.is_read_only(), "tightening added read_only");
         assert!(tightened.is_tool_disabled("delete_file"));
+    }
+
+    #[test]
+    fn ns1_policy_run_id_is_attached_without_overwriting_existing_context_run_id() {
+        let policy = RunPolicy::new(Some("alice".to_string()), Vec::<String>::new(), false)
+            .with_action_context(ns1_full_ctx())
+            .with_run_id("run-1");
+        assert_eq!(
+            policy
+                .action_context()
+                .and_then(|ctx| ctx.run_id.as_deref()),
+            Some("run-1")
+        );
+
+        let mut prebound_ctx = ns1_full_ctx();
+        prebound_ctx.run_id = Some("prebound-run".to_string());
+        let prebound = RunPolicy::new(Some("alice".to_string()), Vec::<String>::new(), false)
+            .with_action_context(prebound_ctx)
+            .with_run_id("run-2");
+        assert_eq!(
+            prebound
+                .action_context()
+                .and_then(|ctx| ctx.run_id.as_deref()),
+            Some("prebound-run")
+        );
     }
 
     #[test]
@@ -8056,6 +8095,7 @@ mod tests {
     fn ns2_ctx() -> friday_storage::AgentActionContext {
         friday_storage::AgentActionContext {
             agent_id: "friday".to_string(),
+            run_id: None,
             workspace: None,
             tool: Some("write_file".to_string()),
             provider: None,
@@ -9892,6 +9932,7 @@ mod tests {
     fn tp1_producer_ctx_tool_none() -> friday_storage::AgentActionContext {
         friday_storage::AgentActionContext {
             agent_id: "friday".to_string(),
+            run_id: None,
             workspace: None,
             tool: None,
             provider: None,

--- a/rust-core/crates/friday-hub/src/runtime.rs
+++ b/rust-core/crates/friday-hub/src/runtime.rs
@@ -311,8 +311,8 @@ impl<T: Transport> HubRuntime<T> {
         //     workspace prefix is satisfiable; `check_grant` would otherwise DENY a
         //     workspace-scoped grant when `ctx.workspace` is None (the `_ => deny
         //     trust_grant_workspace_out_of_scope` arm in friday_core::check_grant). v1 enforce
-        //     honors agent_id + workspace-prefix + risk_ceiling + expiry + token/run ceilings +
-        //     tool allowlist.
+        //     honors agent_id + workspace-prefix + risk_ceiling + expiry + max_runs + action-time
+        //     token_ceiling (via the loop run_id usage ledger) + tool allowlist.
         //   - `tool` = None: enriched PER-ACTION at the chokepoint from
         //     `canonical_rust_name(raw.action)` (TP-PR1), so the `allowed_tools` allowlist is
         //     actually evaluated rather than silently skipped. A boot-level `tool` would be wrong.

--- a/rust-core/crates/friday-operator-cli/tests/trust_grant_issuance.rs
+++ b/rust-core/crates/friday-operator-cli/tests/trust_grant_issuance.rs
@@ -104,6 +104,7 @@ fn in_boundary_ctx() -> AgentActionContext {
         channel: None,
         workflow_family: None,
         skill_family: None,
+        run_id: Some("operator-cli-test-run".to_string()),
     }
 }
 

--- a/rust-core/crates/friday-storage/src/schema.rs
+++ b/rust-core/crates/friday-storage/src/schema.rs
@@ -618,6 +618,18 @@ pub fn hub_migrations() -> Vec<Migration> {
             destructive: false,
             up: m0035_route_decision_action_items,
         },
+        // D4: Hub-only trust-grant run-usage ledger for enforcing `max_runs`
+        // without changing the `trust_grant` row shape. The primary key is
+        // (grant_id, run_id), so a grant is charged at most once per distinct
+        // run and repeated tool calls inside the same run are idempotent. This
+        // is a NEW-TABLE migration; pre-v36 grants remain valid, and grants
+        // without max_runs still behave byte-identically.
+        Migration {
+            version: 36,
+            name: "trust_grant_run_usage",
+            destructive: false,
+            up: m0036_trust_grant_run_usage,
+        },
     ]
 }
 
@@ -882,6 +894,15 @@ CREATE TABLE trust_grant (
     boundaries TEXT NOT NULL
 );
 CREATE INDEX idx_trust_grant_agent_active ON trust_grant(agent_id, revoked, expires_at);";
+
+const DDL_TRUST_GRANT_RUN_USAGE: &str = "
+CREATE TABLE trust_grant_run_usage (
+    grant_id   TEXT NOT NULL,
+    run_id     TEXT NOT NULL,
+    claimed_at INTEGER NOT NULL,
+    PRIMARY KEY (grant_id, run_id)
+);
+CREATE INDEX idx_trust_grant_run_usage_grant ON trust_grant_run_usage(grant_id);";
 
 // --- PR-5 agent-loop fragments (Hub-only) -----------------------------------
 
@@ -2444,4 +2465,8 @@ fn m0035_route_decision_action_items(tx: &Transaction) -> rusqlite::Result<()> {
         "ALTER TABLE route_decision
            ADD COLUMN action_items TEXT NOT NULL DEFAULT '[]';",
     )
+}
+
+fn m0036_trust_grant_run_usage(tx: &Transaction) -> rusqlite::Result<()> {
+    tx.execute_batch(DDL_TRUST_GRANT_RUN_USAGE)
 }

--- a/rust-core/crates/friday-storage/src/trust_grant.rs
+++ b/rust-core/crates/friday-storage/src/trust_grant.rs
@@ -12,9 +12,11 @@
 //! types use manual `as_str`), so the `TrustBoundaries` <-> JSON map lives HERE (the
 //! storage boundary), hand-built with `serde_json`.
 //!
-//! DEFERRED (honest): `token_ceiling` / `max_runs` are STORED but NOT enforced (no live
-//! ledger/run-state counter — no fake counter). Nothing in production CALLS
-//! `authorize_agent_action` yet (the runtime call-site wiring is a deferred AC).
+//! `max_runs` and `token_ceiling` are enforced here through the Hub-only
+//! `trust_grant_run_usage` ledger: one claim per `(grant_id, run_id)`, idempotent within
+//! a run and fail-closed when a capped grant is used without a run id. Token ceilings are
+//! action-time guardrails over already-ledgered model calls for claimed runs; they block
+//! subsequent actions after the ceiling is reached, not the model call that spent tokens.
 
 use crate::error::{Result, StorageError};
 use friday_core::gate::{
@@ -286,6 +288,10 @@ pub fn latest_grant_any_state(conn: &Connection, agent_id: &str) -> Result<Optio
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct AgentActionContext {
     pub agent_id: String,
+    /// The stable run id consuming this grant. Required when `boundaries.max_runs`
+    /// or `boundaries.token_ceiling` is set so ceilings are enforced per distinct
+    /// run, not per tool action.
+    pub run_id: Option<String>,
     pub workspace: Option<String>,
     pub tool: Option<String>,
     pub provider: Option<String>,
@@ -354,10 +360,95 @@ pub fn authorize_agent_action(
         return Ok(denied(reason.to_string(), &base));
     }
 
+    if let Some(reason) = claim_trust_grant_run(conn, &grant, ctx.run_id.as_deref(), now)? {
+        return Ok(denied(reason.to_string(), &base));
+    }
+    if let Some(reason) = enforce_trust_grant_token_ceiling(conn, &grant)? {
+        return Ok(denied(reason.to_string(), &base));
+    }
+
     // (4) Grant OK ("no trust objection") => run the EXISTING mutating-action compose
     // verbatim. It alone decides Allow/RequiresApproval/Deny — the grant cannot upgrade
     // a RequiresApproval here (this branch never passes the grant decision down).
     crate::authorize::authorize_mutating_action(conn, request, approval, secret, now)
+}
+
+fn claim_trust_grant_run(
+    conn: &Connection,
+    grant: &TrustGrant,
+    run_id: Option<&str>,
+    now_ms: i64,
+) -> Result<Option<&'static str>> {
+    if grant.boundaries.max_runs.is_none() && grant.boundaries.token_ceiling.is_none() {
+        return Ok(None);
+    }
+    let Some(run_id) = run_id.filter(|value| !value.trim().is_empty()) else {
+        return Ok(Some("trust_grant_run_id_required"));
+    };
+
+    let tx = conn.unchecked_transaction()?;
+    let already_claimed: Option<i64> = tx
+        .query_row(
+            "SELECT 1 FROM trust_grant_run_usage
+             WHERE grant_id = ?1 AND run_id = ?2",
+            params![grant.grant_id, run_id],
+            |r| r.get(0),
+        )
+        .optional()?;
+    if already_claimed.is_some() {
+        tx.commit()?;
+        return Ok(None);
+    }
+
+    if let Some(max_runs) = grant.boundaries.max_runs {
+        let used: i64 = tx.query_row(
+            "SELECT count(*) FROM trust_grant_run_usage WHERE grant_id = ?1",
+            params![grant.grant_id],
+            |r| r.get(0),
+        )?;
+        if used >= max_runs {
+            tx.commit()?;
+            return Ok(Some("trust_grant_max_runs_exceeded"));
+        }
+    }
+
+    tx.execute(
+        "INSERT INTO trust_grant_run_usage (grant_id, run_id, claimed_at)
+         VALUES (?1, ?2, ?3)",
+        params![grant.grant_id, run_id, now_ms],
+    )?;
+    crate::audit::append_audit(
+        &tx,
+        &format!("trust_grant_run:{}:{run_id}:{now_ms}", grant.grant_id),
+        &grant.agent_id,
+        "trust.run_claim",
+        Some(&grant.grant_id),
+        now_ms,
+    )?;
+    tx.commit()?;
+    Ok(None)
+}
+
+fn enforce_trust_grant_token_ceiling(
+    conn: &Connection,
+    grant: &TrustGrant,
+) -> Result<Option<&'static str>> {
+    let Some(token_ceiling) = grant.boundaries.token_ceiling else {
+        return Ok(None);
+    };
+    let spent: i64 = conn.query_row(
+        "SELECT COALESCE(SUM(t.total_tokens), 0)
+         FROM trust_grant_run_usage AS u
+         LEFT JOIN token_ledger AS t
+              ON (t.session_id = u.run_id OR t.run_id = u.run_id)
+         WHERE u.grant_id = ?1",
+        params![grant.grant_id],
+        |r| r.get(0),
+    )?;
+    if spent >= token_ceiling {
+        return Ok(Some("trust_grant_token_ceiling_exceeded"));
+    }
+    Ok(None)
 }
 
 /// Build the `GrantCheck` from the action context + the gate's derived effective risk.

--- a/rust-core/crates/friday-storage/tests/trust_grant.rs
+++ b/rust-core/crates/friday-storage/tests/trust_grant.rs
@@ -37,8 +37,8 @@ fn boundaries(tools: &[&str], risk_ceiling: Risk) -> TrustBoundaries {
     TrustBoundaries {
         workspace: None,
         risk_ceiling,
-        token_ceiling: Some(1000), // STORED, DEFERRED-not-enforced
-        max_runs: Some(5),         // STORED, DEFERRED-not-enforced
+        token_ceiling: Some(1000), // storage-enforced at action time
+        max_runs: Some(5),         // storage-enforced per distinct run id
         allowed_channels: vec![],
         allowed_providers: vec![],
         allowed_tools: tools.iter().map(|s| s.to_string()).collect(),
@@ -60,8 +60,13 @@ fn grant_for(tools: &[&str], risk_ceiling: Risk, expires_at: Option<i64>) -> Tru
 }
 
 fn ctx(tool: &str) -> AgentActionContext {
+    ctx_for_run(tool, Some("run-friday-1"))
+}
+
+fn ctx_for_run(tool: &str, run_id: Option<&str>) -> AgentActionContext {
     AgentActionContext {
         agent_id: "friday".into(),
+        run_id: run_id.map(str::to_string),
         workspace: None,
         tool: Some(tool.into()),
         provider: None,
@@ -71,10 +76,39 @@ fn ctx(tool: &str) -> AgentActionContext {
     }
 }
 
+fn grant_usage_count(db: &Db, grant_id: &str) -> i64 {
+    db.conn()
+        .query_row(
+            "SELECT count(*) FROM trust_grant_run_usage WHERE grant_id = ?1",
+            [grant_id],
+            |r| r.get(0),
+        )
+        .unwrap()
+}
+
 fn audit_count(db: &Db) -> i64 {
     db.conn()
         .query_row("SELECT count(*) FROM audit_ledger", [], |r| r.get(0))
         .unwrap()
+}
+
+fn insert_run_tokens(db: &Db, run_id: &str, ledger_id: &str, total_tokens: i64) {
+    db.conn()
+        .execute(
+            "INSERT INTO token_ledger
+                (ledger_id, session_id, activity_id, provider_kind, model, base_url_host,
+                 prompt_tokens, completion_tokens, total_tokens, cost_estimate, fallback,
+                 result_link, created_at, run_id)
+             VALUES (?1, ?2, ?3, 'deepseek', 'deepseek-v4-flash', 'api.deepseek.com',
+                     ?4, 0, ?4, NULL, 0, NULL, 100, ?2)",
+            rusqlite::params![
+                ledger_id,
+                run_id,
+                format!("{ledger_id}:activity"),
+                total_tokens
+            ],
+        )
+        .unwrap();
 }
 
 #[test]
@@ -284,4 +318,124 @@ fn grant_then_revoke_writes_exactly_two_audit_rows_and_chain_verifies() {
         friday_storage::audit::verify_audit_chain(db.conn()).unwrap(),
         2
     );
+}
+
+#[test]
+fn max_runs_counts_distinct_run_ids_once_and_denies_over_limit() {
+    let db = Db::open_hub(&temp_db_path("trust-max-runs")).unwrap();
+    let mut grant = grant_for(&["read_file"], Risk::Medium, None);
+    grant.boundaries.max_runs = Some(1);
+    grant_trust(db.conn(), &grant, 1).unwrap();
+
+    let first = authorize_agent_action(
+        db.conn(),
+        &req("read_file", false, Risk::ReadOnly),
+        &ctx_for_run("read_file", Some("run-a")),
+        None,
+        SECRET,
+        100,
+    )
+    .unwrap();
+    assert_eq!(first.decision, GateDecision::Allow);
+    assert_eq!(grant_usage_count(&db, "g-friday"), 1);
+
+    let same_run = authorize_agent_action(
+        db.conn(),
+        &req("read_file", false, Risk::ReadOnly),
+        &ctx_for_run("read_file", Some("run-a")),
+        None,
+        SECRET,
+        101,
+    )
+    .unwrap();
+    assert_eq!(same_run.decision, GateDecision::Allow);
+    assert_eq!(
+        grant_usage_count(&db, "g-friday"),
+        1,
+        "same run id must not consume max_runs more than once"
+    );
+
+    let second_run = authorize_agent_action(
+        db.conn(),
+        &req("read_file", false, Risk::ReadOnly),
+        &ctx_for_run("read_file", Some("run-b")),
+        None,
+        SECRET,
+        102,
+    )
+    .unwrap();
+    assert_eq!(second_run.decision, GateDecision::Deny);
+    assert_eq!(second_run.reason, "trust_grant_max_runs_exceeded");
+    assert_eq!(second_run.denied_by.as_deref(), Some("trust_grant"));
+    assert_eq!(grant_usage_count(&db, "g-friday"), 1);
+}
+
+#[test]
+fn capped_grant_without_run_id_fails_closed() {
+    let db = Db::open_hub(&temp_db_path("trust-max-runs-no-run-id")).unwrap();
+    let mut grant = grant_for(&["read_file"], Risk::Medium, None);
+    grant.boundaries.max_runs = Some(1);
+    grant_trust(db.conn(), &grant, 1).unwrap();
+
+    let result = authorize_agent_action(
+        db.conn(),
+        &req("read_file", false, Risk::ReadOnly),
+        &ctx_for_run("read_file", None),
+        None,
+        SECRET,
+        100,
+    )
+    .unwrap();
+    assert_eq!(result.decision, GateDecision::Deny);
+    assert_eq!(result.reason, "trust_grant_run_id_required");
+    assert_eq!(result.denied_by.as_deref(), Some("trust_grant"));
+    assert_eq!(grant_usage_count(&db, "g-friday"), 0);
+}
+
+#[test]
+fn token_ceiling_requires_run_id_and_denies_after_claimed_runs_reach_ceiling() {
+    let db = Db::open_hub(&temp_db_path("trust-token-ceiling")).unwrap();
+    let mut grant = grant_for(&["read_file"], Risk::Medium, None);
+    grant.boundaries.max_runs = None;
+    grant.boundaries.token_ceiling = Some(10);
+    grant_trust(db.conn(), &grant, 1).unwrap();
+
+    let missing_run = authorize_agent_action(
+        db.conn(),
+        &req("read_file", false, Risk::ReadOnly),
+        &ctx_for_run("read_file", None),
+        None,
+        SECRET,
+        100,
+    )
+    .unwrap();
+    assert_eq!(missing_run.decision, GateDecision::Deny);
+    assert_eq!(missing_run.reason, "trust_grant_run_id_required");
+    assert_eq!(grant_usage_count(&db, "g-friday"), 0);
+
+    let under_ceiling = authorize_agent_action(
+        db.conn(),
+        &req("read_file", false, Risk::ReadOnly),
+        &ctx_for_run("read_file", Some("run-a")),
+        None,
+        SECRET,
+        101,
+    )
+    .unwrap();
+    assert_eq!(under_ceiling.decision, GateDecision::Allow);
+    assert_eq!(grant_usage_count(&db, "g-friday"), 1);
+
+    insert_run_tokens(&db, "run-a", "run-a:t0:ledger", 10);
+    let at_ceiling = authorize_agent_action(
+        db.conn(),
+        &req("read_file", false, Risk::ReadOnly),
+        &ctx_for_run("read_file", Some("run-a")),
+        None,
+        SECRET,
+        102,
+    )
+    .unwrap();
+    assert_eq!(at_ceiling.decision, GateDecision::Deny);
+    assert_eq!(at_ceiling.reason, "trust_grant_token_ceiling_exceeded");
+    assert_eq!(at_ceiling.denied_by.as_deref(), Some("trust_grant"));
 }

--- a/src/state/sqlite/friday-rust-hub-schema-handshake.ts
+++ b/src/state/sqlite/friday-rust-hub-schema-handshake.ts
@@ -6,7 +6,7 @@ import Database from "better-sqlite3";
 import { FridayDomainError } from "#errors";
 
 export const FRIDAY_HUB_AGENT_RUN_DB_PATH_ENV = "FRIDAY_HUB_AGENT_RUN_DB_PATH";
-export const FRIDAY_EXPECTED_RUST_HUB_SCHEMA_VERSION = 35;
+export const FRIDAY_EXPECTED_RUST_HUB_SCHEMA_VERSION = 36;
 
 export type FridayRustHubSchemaHandshakeStatus = "ok" | "skipped";
 


### PR DESCRIPTION
## Summary
- add Hub-only `trust_grant_run_usage` schema v36 to claim distinct `(grant_id, run_id)` uses
- enforce `boundaries.max_runs` inside `authorize_agent_action` after trust boundaries pass and before the existing mutating-action compose
- enforce `boundaries.token_ceiling` as an action-time guardrail over token ledger rows for claimed runs
- attach the loop `run_id` to trust action context at the run-loop entrypoint so ceilings are counted per run, not per tool action

## Validation
- `cargo fmt --manifest-path rust-core/Cargo.toml --all`
- `cargo test -p friday-storage --test trust_grant`
- `cargo test -p friday-hub ns1_policy_run_id --lib`
- `cargo test -p friday-hub ns2_ --lib`
- `cargo test -p friday-operator-cli --test trust_grant_issuance`

Truth labels: this is a real D4 max-runs plus action-time token-ceiling enforcement slice. It still does not claim all of D4 closed: post-response token accounting cannot prevent the model call that first reaches/exceeds a ceiling, and TS usage remains unattributed to Rust trust grants.