### PR TITLE
Expose execution isolation truth status

### DIFF
--- a/src/api/http/routes/friday-health-routes.ts
+++ b/src/api/http/routes/friday-health-routes.ts
@@ -7,6 +7,7 @@
 
 import type { FridayRouteDefinition } from "../../model/friday-api-common.types.js";
 import type { FridayRuntimeCapabilityMatrix } from "#providers";
+import type { FridayExecutionIsolationStatus } from "../../../skills/executor/friday-execution-isolation-status.js";
 
 // ─── Types ───
 
@@ -30,6 +31,7 @@ export interface FridayHealthCapabilities {
   packaging?: {
     enabled: boolean;
   };
+  executionIsolation?: FridayExecutionIsolationStatus;
   search: {
     provider: string;
     latestness: "provider_backed" | "unverified";
@@ -78,6 +80,49 @@ export function createFridayHealthRoutes(
     },
     packaging: {
       enabled: false,
+    },
+    executionIsolation: {
+      schemaVersion: "1.0",
+      disposition: "open_no_os_sandbox",
+      osSandbox: false,
+      surfaces: {
+        "skill.shell": {
+          boundary: "logical_guards_only",
+          osSandbox: false,
+          defaultLive: false,
+          notes: "Shell skills use host child_process.spawn with cwd/env/timeout/output guards; no kernel sandbox is applied.",
+        },
+        "skill.python": {
+          boundary: "logical_guards_only",
+          osSandbox: false,
+          defaultLive: false,
+          notes: "Python skills share the shell executor boundary and are not isolated by an OS sandbox.",
+        },
+        "skill.node": {
+          boundary: "disabled_by_default_unisolated",
+          osSandbox: false,
+          defaultLive: false,
+          notes: "Non-bundled Node skills dynamically import in-process modules and require FRIDAY_ENABLE_UNISOLATED_NODE_SKILLS=true.",
+        },
+        "skill.node.bundled_system": {
+          boundary: "in_process_trusted",
+          osSandbox: false,
+          defaultLive: true,
+          notes: "Bundled system Node skills may run without the unisolated env gate, but still execute in the hub process.",
+        },
+        "plugin.entrypoint": {
+          boundary: "retired_by_default_dynamic_import_when_enabled",
+          osSandbox: false,
+          defaultLive: false,
+          notes: "Plugin lifecycle routes are retired by default; enabled plugin entrypoints are dynamic imports, not OS-isolated processes.",
+        },
+        "agent.exec": {
+          boundary: "logical_workspace_guard_host_spawn",
+          osSandbox: false,
+          defaultLive: true,
+          notes: "Agent exec uses host spawn with workspace, shell, timeout, and output controls; no OS sandbox is applied.",
+        },
+      },
     },
     search: {
       provider: "duckduckgo_html",

--- a/src/api/runtime/friday-api-runtime-base-routes.ts
+++ b/src/api/runtime/friday-api-runtime-base-routes.ts
@@ -3,6 +3,7 @@ import type { FridayHttpRouteRegistry } from "../http/friday-http-route-registry
 import { createFridayHealthRoutes } from "../http/routes/friday-health-routes.js";
 import { createFridayTuiRoutes } from "../http/routes/friday-tui-routes.js";
 import type { CreateFridayApiRuntimeDeps } from "./friday-api-runtime.types.js";
+import { getFridayExecutionIsolationStatus } from "../../skills/executor/friday-execution-isolation-status.js";
 
 type FridayApiRuntimeBaseRouteDeps = Pick<
   CreateFridayApiRuntimeDeps,
@@ -72,6 +73,7 @@ export function installFridayApiRuntimeBaseRoutes(input: InstallFridayApiRuntime
         packaging: {
           enabled: deps.packaging !== undefined,
         },
+        executionIsolation: getFridayExecutionIsolationStatus(),
         search: searchHealth ?? {
           provider: "duckduckgo_html",
           latestness: "unverified" as const,

--- a/src/skills/executor/friday-execution-isolation-status.ts
+++ b/src/skills/executor/friday-execution-isolation-status.ts
@@ -1,0 +1,78 @@
+import {
+  FRIDAY_ENABLE_UNISOLATED_NODE_SKILLS_ENV,
+  isFridayUnisolatedNodeSkillsEnabled,
+} from "./friday-node-executor.js";
+
+export type FridayExecutionIsolationSurface =
+  | "skill.shell"
+  | "skill.python"
+  | "skill.node"
+  | "skill.node.bundled_system"
+  | "plugin.entrypoint"
+  | "agent.exec";
+
+export interface FridayExecutionIsolationStatus {
+  schemaVersion: "1.0";
+  disposition: "open_no_os_sandbox";
+  osSandbox: false;
+  surfaces: Record<FridayExecutionIsolationSurface, {
+    boundary:
+      | "logical_guards_only"
+      | "disabled_by_default_unisolated"
+      | "in_process_trusted"
+      | "retired_by_default_dynamic_import_when_enabled"
+      | "logical_workspace_guard_host_spawn";
+    osSandbox: false;
+    defaultLive: boolean;
+    notes: string;
+  }>;
+}
+
+export function getFridayExecutionIsolationStatus(
+  env: NodeJS.ProcessEnv = process.env,
+): FridayExecutionIsolationStatus {
+  const unisolatedNodeEnabled = isFridayUnisolatedNodeSkillsEnabled(env);
+  return {
+    schemaVersion: "1.0",
+    disposition: "open_no_os_sandbox",
+    osSandbox: false,
+    surfaces: {
+      "skill.shell": {
+        boundary: "logical_guards_only",
+        osSandbox: false,
+        defaultLive: false,
+        notes: "Shell skills use host child_process.spawn with cwd/env/timeout/output guards; no kernel sandbox is applied.",
+      },
+      "skill.python": {
+        boundary: "logical_guards_only",
+        osSandbox: false,
+        defaultLive: false,
+        notes: "Python skills share the shell executor boundary and are not isolated by an OS sandbox.",
+      },
+      "skill.node": {
+        boundary: "disabled_by_default_unisolated",
+        osSandbox: false,
+        defaultLive: unisolatedNodeEnabled,
+        notes: `Non-bundled Node skills dynamically import in-process modules and require ${FRIDAY_ENABLE_UNISOLATED_NODE_SKILLS_ENV}=true.`,
+      },
+      "skill.node.bundled_system": {
+        boundary: "in_process_trusted",
+        osSandbox: false,
+        defaultLive: true,
+        notes: "Bundled system Node skills may run without the unisolated env gate, but still execute in the hub process.",
+      },
+      "plugin.entrypoint": {
+        boundary: "retired_by_default_dynamic_import_when_enabled",
+        osSandbox: false,
+        defaultLive: false,
+        notes: "Plugin lifecycle routes are retired by default; enabled plugin entrypoints are dynamic imports, not OS-isolated processes.",
+      },
+      "agent.exec": {
+        boundary: "logical_workspace_guard_host_spawn",
+        osSandbox: false,
+        defaultLive: true,
+        notes: "Agent exec uses host spawn with workspace, shell, timeout, and output controls; no OS sandbox is applied.",
+      },
+    },
+  };
+}

--- a/test/unit/api/http/routes/friday-health-routes.test.ts
+++ b/test/unit/api/http/routes/friday-health-routes.test.ts
@@ -59,7 +59,7 @@ describe("createFridayHealthRoutes", () => {
     });
     const route = findRoute(routes, "health.check");
     const result = await route.handler(makeCtx());
-    expect(result).toEqual({
+    expect(result).toMatchObject({
       status: "ok",
       version: "0.1.0",
       uptime: 42,
@@ -96,7 +96,7 @@ describe("createFridayHealthRoutes", () => {
         issuedAt: "2025-06-15T10:00:00.000Z",
       },
     }));
-    expect(result).toEqual({
+    expect(result).toMatchObject({
       status: "ok",
       version: "0.1.0",
       uptime: 42,
@@ -128,6 +128,22 @@ describe("createFridayHealthRoutes", () => {
           enabled: false,
           remoteMode: "unavailable",
           companionReadiness: "unavailable",
+        },
+      },
+    });
+    expect((result as { capabilities: { executionIsolation?: unknown } }).capabilities.executionIsolation).toMatchObject({
+      disposition: "open_no_os_sandbox",
+      osSandbox: false,
+      surfaces: {
+        "skill.node": {
+          boundary: "disabled_by_default_unisolated",
+          osSandbox: false,
+          defaultLive: false,
+        },
+        "agent.exec": {
+          boundary: "logical_workspace_guard_host_spawn",
+          osSandbox: false,
+          defaultLive: true,
         },
       },
     });

--- a/test/unit/skills/executor/friday-execution-isolation-status.test.ts
+++ b/test/unit/skills/executor/friday-execution-isolation-status.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  FRIDAY_ENABLE_UNISOLATED_NODE_SKILLS_ENV,
+} from "../../../../src/skills/executor/friday-node-executor.js";
+import {
+  getFridayExecutionIsolationStatus,
+} from "../../../../src/skills/executor/friday-execution-isolation-status.js";
+
+describe("getFridayExecutionIsolationStatus", () => {
+  it("truth-labels execution boundaries as not OS-sandboxed by default", () => {
+    const status = getFridayExecutionIsolationStatus({});
+
+    expect(status).toMatchObject({
+      schemaVersion: "1.0",
+      disposition: "open_no_os_sandbox",
+      osSandbox: false,
+      surfaces: {
+        "skill.shell": {
+          boundary: "logical_guards_only",
+          osSandbox: false,
+          defaultLive: false,
+        },
+        "skill.python": {
+          boundary: "logical_guards_only",
+          osSandbox: false,
+          defaultLive: false,
+        },
+        "skill.node": {
+          boundary: "disabled_by_default_unisolated",
+          osSandbox: false,
+          defaultLive: false,
+        },
+        "skill.node.bundled_system": {
+          boundary: "in_process_trusted",
+          osSandbox: false,
+          defaultLive: true,
+        },
+        "plugin.entrypoint": {
+          boundary: "retired_by_default_dynamic_import_when_enabled",
+          osSandbox: false,
+          defaultLive: false,
+        },
+        "agent.exec": {
+          boundary: "logical_workspace_guard_host_spawn",
+          osSandbox: false,
+          defaultLive: true,
+        },
+      },
+    });
+  });
+
+  it("reports non-bundled Node skills as live only when the unisolated gate is enabled", () => {
+    const status = getFridayExecutionIsolationStatus({
+      [FRIDAY_ENABLE_UNISOLATED_NODE_SKILLS_ENV]: "true",
+    });
+
+    expect(status.surfaces["skill.node"]).toMatchObject({
+      boundary: "disabled_by_default_unisolated",
+      osSandbox: false,
+      defaultLive: true,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add a typed execution-isolation status helper that truth-labels current execution surfaces as not OS-sandboxed
- expose the status through health capabilities so D2 evidence is machine-readable instead of implied by audit notes
- cover the default and unisolated-node env-gated cases in unit tests

## Validation
- `npm run build`
- `vitest run --project default test/unit/skills/executor/friday-execution-isolation-status.test.ts test/unit/api/http/routes/friday-health-routes.test.ts test/unit/api/runtime/friday-api-runtime-extra-route-registration.test.ts`

Truth labels: this is a D2 reality probe / status surface only. It does not close D2, does not add an OS sandbox, and does not claim shell/python/agent exec are isolated.