### PR TITLE
Add inert D20 trust dial ceiling metadata

### DIFF
--- a/rust-core/crates/friday-core/src/trust.rs
+++ b/rust-core/crates/friday-core/src/trust.rs
@@ -20,6 +20,8 @@
 //! Storage-enforced outside this PURE check: `max_runs` and action-time
 //! `token_ceiling` use the `friday-storage` compose plus a `(grant_id, run_id)`
 //! usage ledger. This pure check still ignores counters because it has no I/O.
+//! D20 `auto_allow_reversible_ceiling` is inert metadata for a later
+//! operator-signed batch verifier. This pure check ignores all three.
 
 use crate::gate::GateDecision;
 use crate::tool_policy::Risk;
@@ -35,6 +37,9 @@ pub struct TrustBoundaries {
     pub token_ceiling: Option<i64>,
     /// Storage-enforced outside the pure check: max distinct run ids under this grant.
     pub max_runs: Option<i64>,
+    /// D20 W2-S2 DARK metadata: operator-configured ceiling for a later reversible
+    /// auto-allow dial. Stored only here; `check_grant` does not consume it.
+    pub auto_allow_reversible_ceiling: Option<Risk>,
     /// Allowlists. EMPTY = DENY-ALL for that dimension (fail-closed).
     pub allowed_channels: Vec<String>,
     pub allowed_providers: Vec<String>,
@@ -162,6 +167,7 @@ mod tests {
             risk_ceiling: Risk::Medium,
             token_ceiling: Some(1000),
             max_runs: Some(5),
+            auto_allow_reversible_ceiling: Some(Risk::Low),
             allowed_channels: vec!["telegram".into()],
             allowed_providers: vec!["deepseek".into()],
             allowed_tools: vec!["read_file".into()],
@@ -235,6 +241,18 @@ mod tests {
         let mut c = check();
         c.effective_risk = Risk::High; // > Medium ceiling
         let (d, r) = check_grant(&grant(), &c);
+        assert_eq!(d, GateDecision::Deny);
+        assert_eq!(r, "trust_grant_risk_over_ceiling");
+    }
+
+    #[test]
+    fn auto_allow_reversible_ceiling_is_inert_metadata() {
+        let mut g = grant();
+        g.boundaries.risk_ceiling = Risk::Low;
+        g.boundaries.auto_allow_reversible_ceiling = Some(Risk::Critical);
+        let mut c = check();
+        c.effective_risk = Risk::Medium;
+        let (d, r) = check_grant(&g, &c);
         assert_eq!(d, GateDecision::Deny);
         assert_eq!(r, "trust_grant_risk_over_ceiling");
     }

--- a/rust-core/crates/friday-hub/src/codex_gated_turn.rs
+++ b/rust-core/crates/friday-hub/src/codex_gated_turn.rs
@@ -652,6 +652,7 @@ mod tests {
                 risk_ceiling,
                 token_ceiling: None,
                 max_runs: None,
+                auto_allow_reversible_ceiling: None,
                 allowed_channels: vec![],
                 allowed_providers: vec![],
                 allowed_tools: allowed_tools.iter().map(|s| s.to_string()).collect(),

--- a/rust-core/crates/friday-hub/src/lib.rs
+++ b/rust-core/crates/friday-hub/src/lib.rs
@@ -8122,6 +8122,7 @@ mod tests {
                 risk_ceiling: friday_core::Risk::Critical,
                 token_ceiling: None,
                 max_runs: None,
+                auto_allow_reversible_ceiling: None,
                 allowed_channels: vec![],
                 allowed_providers: vec![],
                 allowed_tools: vec!["write_file".to_string()],
@@ -9959,6 +9960,7 @@ mod tests {
                 risk_ceiling: friday_core::Risk::Critical,
                 token_ceiling: None,
                 max_runs: None,
+                auto_allow_reversible_ceiling: None,
                 allowed_channels: vec![],
                 allowed_providers: vec![],
                 allowed_tools: vec!["read_file".to_string()],
@@ -14769,6 +14771,7 @@ mod tests {
                 risk_ceiling: friday_core::Risk::High,
                 token_ceiling: None,
                 max_runs: None,
+                auto_allow_reversible_ceiling: None,
                 allowed_channels: vec![],
                 allowed_providers: vec![],
                 allowed_tools: vec![

--- a/rust-core/crates/friday-hub/src/runtime.rs
+++ b/rust-core/crates/friday-hub/src/runtime.rs
@@ -3635,6 +3635,7 @@ mod tests {
                 risk_ceiling: friday_core::Risk::Critical,
                 token_ceiling: None,
                 max_runs: None,
+                auto_allow_reversible_ceiling: None,
                 allowed_channels: vec![],
                 allowed_providers: vec![],
                 allowed_tools: vec!["write_file".to_string()],

--- a/rust-core/crates/friday-hub/src/subagent.rs
+++ b/rust-core/crates/friday-hub/src/subagent.rs
@@ -194,6 +194,7 @@ pub fn mint_child_boundaries(parent: &TrustBoundaries, req: &SubagentRequest) ->
         // DEFERRED dims carried from the parent (never raised).
         token_ceiling: parent.token_ceiling,
         max_runs: parent.max_runs,
+        auto_allow_reversible_ceiling: parent.auto_allow_reversible_ceiling,
         // Non-tool allowlists: the parent's set intersected with itself = the parent's set
         // (never a superset). A sub-agent inherits the SAME non-tool envelope, no wider.
         allowed_channels: parent.allowed_channels.clone(),
@@ -275,6 +276,7 @@ mod tests {
             risk_ceiling: Risk::High,
             token_ceiling: Some(1000),
             max_runs: Some(5),
+            auto_allow_reversible_ceiling: None,
             allowed_channels: vec!["telegram".into()],
             allowed_providers: vec!["deepseek".into()],
             // parent CAN spawn + read + write

--- a/rust-core/crates/friday-hub/tests/codex_gated_turn_ed25519.rs
+++ b/rust-core/crates/friday-hub/tests/codex_gated_turn_ed25519.rs
@@ -113,6 +113,7 @@ fn insert_grant(db: &Db, agent_id: &str, allowed_tools: &[&str], risk_ceiling: R
             risk_ceiling,
             token_ceiling: None,
             max_runs: None,
+            auto_allow_reversible_ceiling: None,
             allowed_channels: vec![],
             allowed_providers: vec![],
             allowed_tools: allowed_tools.iter().map(|s| s.to_string()).collect(),

--- a/rust-core/crates/friday-operator-cli/src/lib.rs
+++ b/rust-core/crates/friday-operator-cli/src/lib.rs
@@ -411,6 +411,9 @@ pub mod trust_grant {
         pub token_ceiling: Option<i64>,
         /// DEFERRED in storage (stored, NOT enforced).
         pub max_runs: Option<i64>,
+        /// D20 W2-S2 DARK metadata: operator-owned reversible auto-allow ceiling.
+        /// Stored and echoed only; the Hub does not consume it as authorization.
+        pub auto_allow_reversible_ceiling: Option<Risk>,
         pub allowed_channels: Vec<String>,
         pub allowed_providers: Vec<String>,
         pub allowed_tools: Vec<String>,
@@ -434,6 +437,7 @@ pub mod trust_grant {
                     risk_ceiling: self.risk_ceiling,
                     token_ceiling: self.token_ceiling,
                     max_runs: self.max_runs,
+                    auto_allow_reversible_ceiling: self.auto_allow_reversible_ceiling,
                     allowed_channels: self.allowed_channels.clone(),
                     allowed_providers: self.allowed_providers.clone(),
                     allowed_tools: self.allowed_tools.clone(),
@@ -488,6 +492,7 @@ pub mod trust_grant {
         workspace: Option<String>,
         token_ceiling: Option<i64>,
         max_runs: Option<i64>,
+        auto_allow_reversible_ceiling: Option<Risk>,
         allowed_channels: Vec<String>,
         allowed_providers: Vec<String>,
         allowed_tools: Vec<String>,
@@ -508,6 +513,7 @@ pub mod trust_grant {
             workspace,
             token_ceiling,
             max_runs,
+            auto_allow_reversible_ceiling,
             allowed_channels,
             allowed_providers,
             allowed_tools,

--- a/rust-core/crates/friday-operator-cli/src/main.rs
+++ b/rust-core/crates/friday-operator-cli/src/main.rs
@@ -40,6 +40,7 @@ USAGE:
                                     --risk-ceiling <read_only|low|medium|high|critical> \\
                                     [--expires-at <epoch-ms>] [--workspace <path-prefix>] \\
                                     [--token-ceiling <n>] [--max-runs <n>] \\
+                                    [--auto-allow-reversible-ceiling <read_only|low|medium|high|critical>] \\
                                     [--tools a,b] [--providers a,b] [--channels a,b] \\
                                     [--workflow-families a,b] [--skill-families a,b]
     friday-operator-approve revoke --db <hub.sqlite> --grant-id <id>
@@ -139,6 +140,9 @@ fn cmd_grant(args: &[String]) -> Result<(), String> {
         arg_value(args, "--workspace"),
         arg_i64(args, "--token-ceiling")?,
         arg_i64(args, "--max-runs")?,
+        arg_value(args, "--auto-allow-reversible-ceiling")
+            .map(|s| trust_grant::parse_risk(&s).map_err(|e| e.to_string()))
+            .transpose()?,
         trust_grant::parse_csv(arg_value(args, "--channels").as_deref()),
         trust_grant::parse_csv(arg_value(args, "--providers").as_deref()),
         trust_grant::parse_csv(arg_value(args, "--tools").as_deref()),
@@ -164,6 +168,7 @@ fn cmd_grant(args: &[String]) -> Result<(), String> {
             "risk_ceiling": b.risk_ceiling.as_str(),
             "token_ceiling": b.token_ceiling,
             "max_runs": b.max_runs,
+            "auto_allow_reversible_ceiling": b.auto_allow_reversible_ceiling.map(|risk| risk.as_str()),
             "allowed_channels": b.allowed_channels,
             "allowed_providers": b.allowed_providers,
             "allowed_tools": b.allowed_tools,

--- a/rust-core/crates/friday-operator-cli/tests/trust_grant_issuance.rs
+++ b/rust-core/crates/friday-operator-cli/tests/trust_grant_issuance.rs
@@ -65,8 +65,9 @@ fn in_boundary_spec(expires_at: Option<i64>) -> TrustGrantSpec {
         Risk::Medium,
         expires_at,
         Some(WORKSPACE.to_string()),
-        Some(1000), // token_ceiling — stored, DEFERRED-not-enforced
-        Some(5),    // max_runs — stored, DEFERRED-not-enforced
+        Some(1000),      // token_ceiling — stored, DEFERRED-not-enforced
+        Some(5),         // max_runs — stored, DEFERRED-not-enforced
+        Some(Risk::Low), // D20 trust-dial metadata — stored, inert
         trust_grant::parse_csv(Some("telegram")),
         trust_grant::parse_csv(Some("deepseek")),
         trust_grant::parse_csv(Some("read_file,write_file")),
@@ -238,6 +239,7 @@ fn empty_grant_id_and_empty_agent_fail_closed() {
         None,
         None,
         None,
+        None,
         Vec::new(),
         Vec::new(),
         Vec::new(),
@@ -249,6 +251,7 @@ fn empty_grant_id_and_empty_agent_fail_closed() {
         GRANT_ID.to_string(),
         String::new(),
         Risk::Low,
+        None,
         None,
         None,
         None,

--- a/rust-core/crates/friday-storage/src/trust_grant.rs
+++ b/rust-core/crates/friday-storage/src/trust_grant.rs
@@ -17,6 +17,8 @@
 //! a run and fail-closed when a capped grant is used without a run id. Token ceilings are
 //! action-time guardrails over already-ledgered model calls for claimed runs; they block
 //! subsequent actions after the ceiling is reached, not the model call that spent tokens.
+//! `auto_allow_reversible_ceiling` is D20 trust-dial metadata for a later signed-batch
+//! verifier. It is stored/decoded but not consumed here; no fake auto-allow branch exists.
 
 use crate::error::{Result, StorageError};
 use friday_core::gate::{
@@ -51,6 +53,7 @@ fn encode_boundaries(b: &TrustBoundaries) -> Result<String> {
         "risk_ceiling": risk_as_str(b.risk_ceiling),
         "token_ceiling": b.token_ceiling,
         "max_runs": b.max_runs,
+        "auto_allow_reversible_ceiling": b.auto_allow_reversible_ceiling.map(risk_as_str),
         "allowed_channels": b.allowed_channels,
         "allowed_providers": b.allowed_providers,
         "allowed_tools": b.allowed_tools,
@@ -86,6 +89,14 @@ fn decode_opt_i64(v: &Value, field: &str) -> Result<Option<i64>> {
     }
 }
 
+fn decode_opt_risk(v: &Value, field: &str) -> Result<Option<Risk>> {
+    match v {
+        Value::Null => Ok(None),
+        Value::String(s) => parse_risk(s).map(Some),
+        _ => Err(unsupported(format!("{field} not a string/null"))),
+    }
+}
+
 fn decode_opt_string(v: &Value, field: &str) -> Result<Option<String>> {
     match v {
         Value::Null => Ok(None),
@@ -109,6 +120,11 @@ fn decode_boundaries(blob: &str) -> Result<TrustBoundaries> {
             "token_ceiling",
         )?,
         max_runs: decode_opt_i64(v.get("max_runs").unwrap_or(&Value::Null), "max_runs")?,
+        auto_allow_reversible_ceiling: decode_opt_risk(
+            v.get("auto_allow_reversible_ceiling")
+                .unwrap_or(&Value::Null),
+            "auto_allow_reversible_ceiling",
+        )?,
         allowed_channels: decode_string_vec(
             v.get("allowed_channels").unwrap_or(&Value::Null),
             "allowed_channels",

--- a/rust-core/crates/friday-storage/tests/trust_grant.rs
+++ b/rust-core/crates/friday-storage/tests/trust_grant.rs
@@ -39,6 +39,7 @@ fn boundaries(tools: &[&str], risk_ceiling: Risk) -> TrustBoundaries {
         risk_ceiling,
         token_ceiling: Some(1000), // storage-enforced at action time
         max_runs: Some(5),         // storage-enforced per distinct run id
+        auto_allow_reversible_ceiling: Some(Risk::Low), // STORED, inert D20 metadata
         allowed_channels: vec![],
         allowed_providers: vec![],
         allowed_tools: tools.iter().map(|s| s.to_string()).collect(),


### PR DESCRIPTION
## Summary
- add operator-owned auto_allow_reversible_ceiling metadata to TrustBoundaries and storage JSON
- expose the metadata through friday-operator-approve grant issuance/JSON output
- carry the value through subagent boundary minting without widening and keep check_grant inert

## Validation
- cargo fmt --manifest-path rust-core/Cargo.toml --all
- cargo test --manifest-path rust-core/Cargo.toml -p friday-core trust::tests
- cargo test --manifest-path rust-core/Cargo.toml -p friday-storage --test trust_grant
- cargo test --manifest-path rust-core/Cargo.toml -p friday-operator-cli --test trust_grant_issuance
- cargo test --manifest-path rust-core/Cargo.toml -p friday-hub tool_registry_tests --lib
- cargo test --manifest-path rust-core/Cargo.toml -p friday-hub subagent --lib
- git diff --check

Truth label: D20 W2-S2 build-DARK/inert metadata only. This does not add auto-allow behavior, signed batch verification, worktree isolation, or TRUE operator-in-the-loop closure. Friday still has no action-rollback engine; reversible means constrained git/worktree eligibility, not undo.