### PR TITLE
Add D20 batch Ed25519 verifier seam

### DIFF
--- a/rust-core/crates/friday-core/src/gate.rs
+++ b/rust-core/crates/friday-core/src/gate.rs
@@ -98,6 +98,7 @@ pub struct MutatingActionRequest {
     mutating: bool,
     risk: Option<Risk>,
     resource: Option<Resource>,
+    reversibility: Reversibility,
     pub local_claims: Vec<LocalClaim>,
     /// Caller-supplied canonical serialization of the action parameters (opaque to
     /// the gate; bound into the digest). The caller is responsible for determinism.
@@ -241,6 +242,7 @@ impl MutatingActionRequest {
             surface,
             mutating: classification.mutating,
             risk: classification.risk,
+            reversibility: classification.reversibility,
             local_claims,
             resource: classification.resource,
             parameters,
@@ -261,6 +263,9 @@ impl MutatingActionRequest {
     }
     pub fn resource(&self) -> Option<&Resource> {
         self.resource.as_ref()
+    }
+    pub fn reversibility(&self) -> Reversibility {
+        self.reversibility
     }
 }
 
@@ -305,6 +310,18 @@ pub struct CanonicalApproval {
     /// Must be `"friday_canonical_gate"` for a valid approval.
     pub issuer: Option<String>,
     /// Hex HMAC-SHA256 over `canonical_approval_signature_bytes`.
+    pub signature: Option<String>,
+}
+
+/// A canonical operator-signed batch approval. It signs a set of exact action digests
+/// under one operator decision; authorization still evaluates each action separately.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CanonicalApprovalBatch {
+    pub decision: ApprovalDecision,
+    pub batch_sign_id: String,
+    pub action_digests: Vec<String>,
+    pub expires_at: Option<i64>,
+    pub issuer: Option<String>,
     pub signature: Option<String>,
 }
 
@@ -390,6 +407,30 @@ pub fn canonical_approval_signature_bytes(approval: &CanonicalApproval) -> Vec<u
         }
     }
     put_opt_str(&mut out, &approval.issuer);
+    out
+}
+
+/// Deterministic byte serialization of batch approval fields that are SIGNED.
+pub fn canonical_approval_batch_signature_bytes(batch: &CanonicalApprovalBatch) -> Vec<u8> {
+    let mut out = Vec::new();
+    put_bytes(&mut out, b"friday.canonical_approval_batch.v1");
+    out.push(match batch.decision {
+        ApprovalDecision::Approved => 1u8,
+        ApprovalDecision::Denied => 0u8,
+    });
+    put_str(&mut out, &batch.batch_sign_id);
+    out.extend_from_slice(&(batch.action_digests.len() as u64).to_le_bytes());
+    for digest in &batch.action_digests {
+        put_str(&mut out, digest);
+    }
+    match batch.expires_at {
+        None => out.push(0u8),
+        Some(v) => {
+            out.push(1u8);
+            out.extend_from_slice(&v.to_le_bytes());
+        }
+    }
+    put_opt_str(&mut out, &batch.issuer);
     out
 }
 
@@ -670,6 +711,11 @@ mod tests {
             surface: "system".to_string(),
             mutating,
             risk: None,
+            reversibility: if mutating {
+                Reversibility::ReversibleInWorkspace
+            } else {
+                Reversibility::Reversible
+            },
             local_claims: vec![],
             resource: None,
             parameters: None,

--- a/rust-core/crates/friday-storage/src/authorize_ed25519.rs
+++ b/rust-core/crates/friday-storage/src/authorize_ed25519.rs
@@ -32,8 +32,8 @@
 
 use crate::error::{Result, StorageError};
 use friday_core::gate::{
-    self, ApprovalDecision, CanonicalApproval, GateDecision, GateEvidenceRecord,
-    MutatingActionRequest, CANONICAL_GATE_ISSUER,
+    self, ApprovalDecision, CanonicalApproval, CanonicalApprovalBatch, GateDecision,
+    GateEvidenceRecord, MutatingActionRequest, Reversibility, CANONICAL_GATE_ISSUER,
 };
 use friday_crypto::OperatorVerifyingKey;
 use rusqlite::{params, Connection, Error as SqlErr, ErrorCode};
@@ -182,4 +182,101 @@ pub fn authorize_mutating_action_ed25519(
         }
         Err(e) => Err(StorageError::from(e)),
     }
+}
+
+/// Authorize one action against an operator-signed batch. This is verify-only and dark:
+/// callers must opt in explicitly, and the Hub still receives only the public verify key.
+pub fn authorize_mutating_action_ed25519_batch(
+    conn: &Connection,
+    request: &MutatingActionRequest,
+    batch: Option<&CanonicalApprovalBatch>,
+    operator_vk: &OperatorVerifyingKey,
+    now_ms: i64,
+) -> Result<GateEvidenceRecord> {
+    let base = gate::evaluate(request);
+    if base.decision != GateDecision::RequiresApproval {
+        return Ok(base);
+    }
+    if request.reversibility() == Reversibility::Irreversible {
+        return Ok(GateEvidenceRecord {
+            decision: GateDecision::RequiresApproval,
+            reason: "canonical_batch_irreversible_requires_single_approval".to_string(),
+            risk: base.risk,
+            approval_required: true,
+            denied_by: Some("canonical_gate".to_string()),
+        });
+    }
+    let batch = match batch {
+        Some(b) => b,
+        None => return Ok(base),
+    };
+    let deny = |reason: &str| GateEvidenceRecord {
+        decision: GateDecision::Deny,
+        reason: reason.to_string(),
+        risk: base.risk,
+        approval_required: true,
+        denied_by: Some("canonical_gate".to_string()),
+    };
+
+    let digest = friday_crypto::action_digest(&gate::canonical_action_bytes(request));
+    if !is_valid_digest_hex(&digest) {
+        return Ok(deny("canonical_batch_action_digest_invalid"));
+    }
+    if batch.batch_sign_id.trim().is_empty() {
+        return Ok(deny("canonical_batch_id_required"));
+    }
+    if batch.action_digests.is_empty() {
+        return Ok(deny("canonical_batch_empty"));
+    }
+    if batch.action_digests.iter().any(|d| !is_valid_digest_hex(d)) {
+        return Ok(deny("canonical_batch_member_digest_invalid"));
+    }
+    if !batch.action_digests.iter().any(|d| d == &digest) {
+        return Ok(deny("canonical_batch_digest_not_member"));
+    }
+    if batch.decision == ApprovalDecision::Denied {
+        return Ok(deny("canonical_batch_denied"));
+    }
+    if batch.issuer.as_deref() != Some(CANONICAL_GATE_ISSUER) {
+        return Ok(deny("canonical_batch_bad_issuer"));
+    }
+    let sig = match &batch.signature {
+        Some(s) => s,
+        None => return Ok(deny("canonical_batch_signature_missing")),
+    };
+    let sig_bytes = gate::canonical_approval_batch_signature_bytes(batch);
+    if !friday_crypto::verify_ed25519_approval_hex(&sig_bytes, &operator_vk.to_bytes(), sig) {
+        return Ok(deny("canonical_batch_signature_invalid"));
+    }
+    let expires_at = match batch.expires_at {
+        Some(e) => e,
+        None => return Ok(deny("canonical_batch_expiration_required")),
+    };
+    if expires_at <= now_ms {
+        return Ok(deny("canonical_batch_expired"));
+    }
+
+    let use_key = format!("ed25519-batch:{}:{}", batch.batch_sign_id, digest);
+    let insert = conn.execute(
+        "INSERT INTO consumed_approval (use_key, approval_id, action_digest, consumed_at)
+         VALUES (?1, ?2, ?3, ?4)",
+        params![use_key, batch.batch_sign_id, digest, now_ms],
+    );
+    match insert {
+        Ok(_) => Ok(GateEvidenceRecord {
+            decision: GateDecision::Allow,
+            reason: "canonical_batch_approval_granted".to_string(),
+            risk: base.risk,
+            approval_required: true,
+            denied_by: None,
+        }),
+        Err(SqlErr::SqliteFailure(e, _)) if e.code == ErrorCode::ConstraintViolation => {
+            Ok(deny("canonical_batch_replay_refused"))
+        }
+        Err(e) => Err(StorageError::from(e)),
+    }
+}
+
+fn is_valid_digest_hex(s: &str) -> bool {
+    s.len() == 64 && s.bytes().all(|b| matches!(b, b'0'..=b'9' | b'a'..=b'f'))
 }

--- a/rust-core/crates/friday-storage/src/lib.rs
+++ b/rust-core/crates/friday-storage/src/lib.rs
@@ -48,7 +48,10 @@ pub use agent_session::{
     SessionOwner, StoredSessionMessage,
 };
 pub use authorize::authorize_mutating_action;
-pub use authorize_ed25519::{authorize_mutating_action_ed25519, Ed25519VerifyOnlyPolicy};
+pub use authorize_ed25519::{
+    authorize_mutating_action_ed25519, authorize_mutating_action_ed25519_batch,
+    Ed25519VerifyOnlyPolicy,
+};
 pub use error::{Result, StorageError};
 pub use migrate::{
     apply_migrations, current_version, now_ms, Migration, MigrationFn, MigrationReport,

--- a/rust-core/crates/friday-storage/tests/authorize_ed25519.rs
+++ b/rust-core/crates/friday-storage/tests/authorize_ed25519.rs
@@ -13,14 +13,17 @@ mod common;
 
 use common::temp_db_path;
 use friday_core::gate::{
-    canonical_action_bytes, canonical_approval_signature_bytes, Actor, ActorKind, ApprovalDecision,
-    CanonicalApproval, GateDecision, MutatingActionRequest, CANONICAL_GATE_ISSUER,
+    canonical_action_bytes, canonical_approval_batch_signature_bytes,
+    canonical_approval_signature_bytes, Actor, ActorKind, ApprovalDecision, CanonicalApproval,
+    CanonicalApprovalBatch, GateDecision, MutatingActionRequest, Reversibility,
+    CANONICAL_GATE_ISSUER,
 };
 use friday_core::Risk;
 use friday_crypto::{OperatorSigningKey, OperatorVerifyingKey};
 use friday_storage::{
-    authorize_mutating_action_ed25519, get_pending_request, persist_pending_request, Db,
-    Ed25519VerifyOnlyPolicy, PendingApprovalRequest,
+    authorize_mutating_action_ed25519, authorize_mutating_action_ed25519_batch,
+    get_pending_request, persist_pending_request, Db, Ed25519VerifyOnlyPolicy,
+    PendingApprovalRequest,
 };
 
 /// The HMAC secret the HUB holds (the symmetric mint==verify key). A correct verify-only
@@ -43,8 +46,38 @@ fn req_with(
     let params: Vec<(String, String)> = path
         .map(|p| vec![("path".to_string(), p.to_string())])
         .unwrap_or_default();
+    req_from_params(
+        action,
+        actor_kind,
+        mutating,
+        base_risk,
+        if mutating {
+            Reversibility::ReversibleInWorkspace
+        } else {
+            Reversibility::Reversible
+        },
+        params,
+        principal,
+    )
+}
+
+fn req_from_params(
+    action: &str,
+    actor_kind: ActorKind,
+    mutating: bool,
+    base_risk: Risk,
+    base_reversibility: Reversibility,
+    params: Vec<(String, String)>,
+    principal: &str,
+) -> MutatingActionRequest {
     MutatingActionRequest::from_classification(
-        friday_core::gate::classify(mutating, base_risk, action, &params),
+        friday_core::gate::classify_with_reversibility(
+            mutating,
+            base_risk,
+            base_reversibility,
+            action,
+            &params,
+        ),
         action.to_string(),
         Actor {
             kind: actor_kind,
@@ -113,6 +146,53 @@ fn hmac_approval(
         HUB_HMAC_SECRET,
     ));
     a
+}
+
+fn batch_approval(
+    requests: &[&MutatingActionRequest],
+    sk: &OperatorSigningKey,
+    batch_sign_id: &str,
+    expires_at: Option<i64>,
+) -> CanonicalApprovalBatch {
+    let mut batch = CanonicalApprovalBatch {
+        decision: ApprovalDecision::Approved,
+        batch_sign_id: batch_sign_id.to_string(),
+        action_digests: requests
+            .iter()
+            .map(|request| friday_crypto::action_digest(&canonical_action_bytes(request)))
+            .collect(),
+        expires_at,
+        issuer: Some(CANONICAL_GATE_ISSUER.to_string()),
+        signature: None,
+    };
+    batch.signature = Some(
+        sk.sign(&canonical_approval_batch_signature_bytes(&batch))
+            .to_hex(),
+    );
+    batch
+}
+
+fn hmac_batch_approval(
+    requests: &[&MutatingActionRequest],
+    batch_sign_id: &str,
+    expires_at: Option<i64>,
+) -> CanonicalApprovalBatch {
+    let mut batch = CanonicalApprovalBatch {
+        decision: ApprovalDecision::Approved,
+        batch_sign_id: batch_sign_id.to_string(),
+        action_digests: requests
+            .iter()
+            .map(|request| friday_crypto::action_digest(&canonical_action_bytes(request)))
+            .collect(),
+        expires_at,
+        issuer: Some(CANONICAL_GATE_ISSUER.to_string()),
+        signature: None,
+    };
+    batch.signature = Some(friday_crypto::sign_approval(
+        &canonical_approval_batch_signature_bytes(&batch),
+        HUB_HMAC_SECRET,
+    ));
+    batch
 }
 
 fn consumed_count(db: &Db) -> i64 {
@@ -460,6 +540,145 @@ fn verify_only_policy_wrapper_grants_and_rejects_hmac() {
     let good = ed25519_approval(&req, &sk, "ap-pol", Some(FUTURE));
     let rg = policy.authorize(db.conn(), &req, Some(&good), NOW).unwrap();
     assert_eq!(rg.decision, GateDecision::Allow);
+}
+
+#[test]
+fn batch_approval_grants_each_member_once_with_composite_replay_key() {
+    let db = Db::open_hub(&temp_db_path("ed-batch-members")).unwrap();
+    let (sk, vk) = operator();
+    let req_a = req_with(
+        "write_file",
+        ActorKind::Owner,
+        true,
+        Risk::Medium,
+        Some("/worktree/a.txt"),
+        "p1",
+    );
+    let req_b = req_with(
+        "write_file",
+        ActorKind::Owner,
+        true,
+        Risk::Medium,
+        Some("/worktree/b.txt"),
+        "p1",
+    );
+    let batch = batch_approval(&[&req_a, &req_b], &sk, "batch-1", Some(FUTURE));
+
+    let a =
+        authorize_mutating_action_ed25519_batch(db.conn(), &req_a, Some(&batch), &vk, NOW).unwrap();
+    assert_eq!(a.decision, GateDecision::Allow);
+    assert_eq!(a.reason, "canonical_batch_approval_granted");
+
+    let b =
+        authorize_mutating_action_ed25519_batch(db.conn(), &req_b, Some(&batch), &vk, NOW).unwrap();
+    assert_eq!(
+        b.decision,
+        GateDecision::Allow,
+        "same batch id must not collide across distinct action digests"
+    );
+    assert_eq!(consumed_count(&db), 2);
+
+    let replay =
+        authorize_mutating_action_ed25519_batch(db.conn(), &req_a, Some(&batch), &vk, NOW).unwrap();
+    assert_eq!(replay.decision, GateDecision::Deny);
+    assert_eq!(replay.reason, "canonical_batch_replay_refused");
+    assert_eq!(consumed_count(&db), 2);
+}
+
+#[test]
+fn batch_approval_requires_digest_membership_and_ed25519_signature() {
+    let db = Db::open_hub(&temp_db_path("ed-batch-member-sig")).unwrap();
+    let (sk, vk) = operator();
+    let member = req_with(
+        "write_file",
+        ActorKind::Owner,
+        true,
+        Risk::Medium,
+        Some("/worktree/in.txt"),
+        "p1",
+    );
+    let outsider = req_with(
+        "write_file",
+        ActorKind::Owner,
+        true,
+        Risk::Medium,
+        Some("/worktree/out.txt"),
+        "p1",
+    );
+    let batch = batch_approval(&[&member], &sk, "batch-membership", Some(FUTURE));
+
+    let out = authorize_mutating_action_ed25519_batch(db.conn(), &outsider, Some(&batch), &vk, NOW)
+        .unwrap();
+    assert_eq!(out.decision, GateDecision::Deny);
+    assert_eq!(out.reason, "canonical_batch_digest_not_member");
+
+    let hmac = hmac_batch_approval(&[&member], "batch-hmac", Some(FUTURE));
+    let rh =
+        authorize_mutating_action_ed25519_batch(db.conn(), &member, Some(&hmac), &vk, NOW).unwrap();
+    assert_eq!(rh.decision, GateDecision::Deny);
+    assert_eq!(rh.reason, "canonical_batch_signature_invalid");
+    assert_eq!(consumed_count(&db), 0);
+}
+
+#[test]
+fn batch_approval_expiry_and_issuer_fail_closed_without_consuming() {
+    let db = Db::open_hub(&temp_db_path("ed-batch-expiry")).unwrap();
+    let (sk, vk) = operator();
+    let req = mutating_req();
+
+    let no_expiry = batch_approval(&[&req], &sk, "batch-no-expiry", None);
+    let rn = authorize_mutating_action_ed25519_batch(db.conn(), &req, Some(&no_expiry), &vk, NOW)
+        .unwrap();
+    assert_eq!(rn.decision, GateDecision::Deny);
+    assert_eq!(rn.reason, "canonical_batch_expiration_required");
+
+    let expired = batch_approval(&[&req], &sk, "batch-expired", Some(NOW));
+    let re =
+        authorize_mutating_action_ed25519_batch(db.conn(), &req, Some(&expired), &vk, NOW).unwrap();
+    assert_eq!(re.decision, GateDecision::Deny);
+    assert_eq!(re.reason, "canonical_batch_expired");
+
+    let mut bad_issuer = batch_approval(&[&req], &sk, "batch-bad-issuer", Some(FUTURE));
+    bad_issuer.issuer = Some("not_the_gate".to_string());
+    bad_issuer.signature = Some(
+        sk.sign(&canonical_approval_batch_signature_bytes(&bad_issuer))
+            .to_hex(),
+    );
+    let ri = authorize_mutating_action_ed25519_batch(db.conn(), &req, Some(&bad_issuer), &vk, NOW)
+        .unwrap();
+    assert_eq!(ri.decision, GateDecision::Deny);
+    assert_eq!(ri.reason, "canonical_batch_bad_issuer");
+    assert_eq!(consumed_count(&db), 0);
+}
+
+#[test]
+fn batch_approval_hard_excludes_classified_irreversible_actions() {
+    let db = Db::open_hub(&temp_db_path("ed-batch-irreversible")).unwrap();
+    let (sk, vk) = operator();
+    let req = req_from_params(
+        "write_file",
+        ActorKind::Owner,
+        true,
+        Risk::Medium,
+        Reversibility::Irreversible,
+        vec![("path".to_string(), "/worktree/signed.txt".to_string())],
+        "p1",
+    );
+    assert_eq!(req.reversibility(), Reversibility::Irreversible);
+    let batch = batch_approval(&[&req], &sk, "batch-irrev", Some(FUTURE));
+
+    let r =
+        authorize_mutating_action_ed25519_batch(db.conn(), &req, Some(&batch), &vk, NOW).unwrap();
+    assert_eq!(
+        r.decision,
+        GateDecision::RequiresApproval,
+        "Irreversible actions must Pause even inside a valid signed batch"
+    );
+    assert_eq!(
+        r.reason,
+        "canonical_batch_irreversible_requires_single_approval"
+    );
+    assert_eq!(consumed_count(&db), 0);
 }
 
 // ── pending-request persistence (the offline operator's to-sign work item) ──────────


### PR DESCRIPTION
## Summary
- carry sealed classification reversibility onto MutatingActionRequest for D20 hard-exclude checks
- add CanonicalApprovalBatch canonical bytes and a verify-only Ed25519 batch authorization seam
- enforce exact digest membership, expiry, composite (batch_sign_id, action_digest) replay keys, and Irreversible -> Pause hard-exclude

## Verification
- cargo fmt --manifest-path rust-core/Cargo.toml --all
- cargo test --manifest-path rust-core/Cargo.toml -p friday-core gate::tests
- cargo test --manifest-path rust-core/Cargo.toml -p friday-storage --test authorize_ed25519
- cargo test --manifest-path rust-core/Cargo.toml -p friday-storage --test trust_grant
- cargo test --manifest-path rust-core/Cargo.toml -p friday-operator-cli --test trust_grant_issuance
- cargo test --manifest-path rust-core/Cargo.toml -p friday-hub subagent --lib

## Truth boundary
- D20 W2-S3 build-DARK verifier seam only.
- No live loop caller, no trust-dial auto-allow, no worktree driver, no operator true-key batch closure.
- Hub remains verify-only; this adds no signing key or HMAC authorization arm.