### PR TITLE
Sandbox shell and python skill processes on Darwin

### DIFF
--- a/src/skills/executor/friday-execution-isolation-status.ts
+++ b/src/skills/executor/friday-execution-isolation-status.ts
@@ -2,6 +2,7 @@ import {
   FRIDAY_ENABLE_UNISOLATED_NODE_SKILLS_ENV,
   isFridayUnisolatedNodeSkillsEnabled,
 } from "./friday-node-executor.js";
+import { isFridayDarwinSandboxExecAvailable } from "./friday-shell-executor.js";
 
 export type FridayExecutionIsolationSurface =
   | "skill.shell"
@@ -13,41 +14,55 @@ export type FridayExecutionIsolationSurface =
 
 export interface FridayExecutionIsolationStatus {
   schemaVersion: "1.0";
-  disposition: "open_no_os_sandbox";
-  osSandbox: false;
+  disposition: "open_no_os_sandbox" | "partial_os_sandbox";
+  osSandbox: boolean;
   surfaces: Record<FridayExecutionIsolationSurface, {
     boundary:
       | "logical_guards_only"
+      | "darwin_sandbox_exec_write_network_guard"
       | "disabled_by_default_unisolated"
       | "in_process_trusted"
       | "retired_by_default_dynamic_import_when_enabled"
       | "logical_workspace_guard_host_spawn";
-    osSandbox: false;
+    osSandbox: boolean;
     defaultLive: boolean;
     notes: string;
   }>;
 }
 
+export interface FridayExecutionIsolationProbe {
+  darwinSandboxExecAvailable?: boolean;
+}
+
 export function getFridayExecutionIsolationStatus(
   env: NodeJS.ProcessEnv = process.env,
+  probe: FridayExecutionIsolationProbe = {},
 ): FridayExecutionIsolationStatus {
   const unisolatedNodeEnabled = isFridayUnisolatedNodeSkillsEnabled(env);
+  const skillProcessSandbox = probe.darwinSandboxExecAvailable ?? isFridayDarwinSandboxExecAvailable();
+  const skillProcessBoundary = skillProcessSandbox
+    ? "darwin_sandbox_exec_write_network_guard"
+    : "logical_guards_only";
   return {
     schemaVersion: "1.0",
-    disposition: "open_no_os_sandbox",
-    osSandbox: false,
+    disposition: skillProcessSandbox ? "partial_os_sandbox" : "open_no_os_sandbox",
+    osSandbox: skillProcessSandbox,
     surfaces: {
       "skill.shell": {
-        boundary: "logical_guards_only",
-        osSandbox: false,
-        defaultLive: false,
-        notes: "Shell skills use host child_process.spawn with cwd/env/timeout/output guards; no kernel sandbox is applied.",
+        boundary: skillProcessBoundary,
+        osSandbox: skillProcessSandbox,
+        defaultLive: skillProcessSandbox,
+        notes: skillProcessSandbox
+          ? "Shell skills run through macOS sandbox-exec with network denied and file writes limited to the skill directory."
+          : "Shell skills use host child_process.spawn with cwd/env/timeout/output guards; no kernel sandbox is applied.",
       },
       "skill.python": {
-        boundary: "logical_guards_only",
-        osSandbox: false,
-        defaultLive: false,
-        notes: "Python skills share the shell executor boundary and are not isolated by an OS sandbox.",
+        boundary: skillProcessBoundary,
+        osSandbox: skillProcessSandbox,
+        defaultLive: skillProcessSandbox,
+        notes: skillProcessSandbox
+          ? "Python skills share the shell executor sandbox-exec boundary: network denied and file writes limited to the skill directory."
+          : "Python skills share the shell executor boundary and are not isolated by an OS sandbox.",
       },
       "skill.node": {
         boundary: "disabled_by_default_unisolated",

--- a/src/skills/executor/friday-shell-executor.ts
+++ b/src/skills/executor/friday-shell-executor.ts
@@ -1,7 +1,9 @@
 import { type ChildProcessWithoutNullStreams, spawn } from "node:child_process";
+import { existsSync, realpathSync } from "node:fs";
 import { extname } from "node:path";
 import type {
   FridayShellExecutor,
+  FridayShellOsSandboxOptions,
   FridayShellRunOptions,
   FridayShellRunResult,
 } from "./friday-skill-executor.types.js";
@@ -9,6 +11,7 @@ import type {
 const DEFAULT_TIMEOUT_MS = 30_000;
 const TERMINATION_GRACE_MS = 500;
 const DEFAULT_MAX_OUTPUT_BYTES = 1_048_576;
+const DARWIN_SANDBOX_EXEC = "/usr/bin/sandbox-exec";
 const WINDOWS_SHELL_SCRIPT_EXTENSIONS = new Set([".bash", ".sh"]);
 const SAFE_PARENT_ENV_KEYS = [
   "PATH",
@@ -53,6 +56,71 @@ function resolveSpawnSpec(command: string, args: string[] = []): { command: stri
   }
 
   return { command, args };
+}
+
+export function isFridayDarwinSandboxExecAvailable(): boolean {
+  return process.platform === "darwin" && existsSync(DARWIN_SANDBOX_EXEC);
+}
+
+function sandboxProfileString(value: string): string {
+  return JSON.stringify(value);
+}
+
+function expandWritableRoots(roots: readonly string[] = []): string[] {
+  const expanded = new Set<string>();
+  for (const root of roots) {
+    if (!root) continue;
+    expanded.add(root);
+    try {
+      expanded.add(realpathSync.native(root));
+    } catch {
+      try {
+        expanded.add(realpathSync(root));
+      } catch {
+        // Keep the caller-provided path; sandbox-exec will ignore nonexistent roots.
+      }
+    }
+  }
+  return [...expanded];
+}
+
+function buildSandboxProfile(options: FridayShellOsSandboxOptions): string {
+  const lines = ["(version 1)", "(allow default)"];
+  if (options.denyNetwork !== false) {
+    lines.push("(deny network*)");
+  }
+  lines.push("(deny file-write*)");
+
+  const writableRoots = expandWritableRoots(options.writableRoots);
+  if (writableRoots.length > 0) {
+    lines.push(`(allow file-write* ${writableRoots.map((root) => `(subpath ${sandboxProfileString(root)})`).join(" ")})`);
+  }
+
+  return lines.join("\n");
+}
+
+function resolveSandboxedSpawnSpec(
+  spawnSpec: { command: string; args: string[] },
+  sandbox: FridayShellOsSandboxOptions | undefined,
+): { command: string; args: string[]; unavailableReason?: string } {
+  if (!sandbox?.enabled) {
+    return spawnSpec;
+  }
+  if (process.platform !== "darwin") {
+    return sandbox.required
+      ? { ...spawnSpec, unavailableReason: "OS sandbox is required but sandbox-exec is only supported on Darwin." }
+      : spawnSpec;
+  }
+  if (!existsSync(DARWIN_SANDBOX_EXEC)) {
+    return sandbox.required
+      ? { ...spawnSpec, unavailableReason: `OS sandbox is required but ${DARWIN_SANDBOX_EXEC} is unavailable.` }
+      : spawnSpec;
+  }
+
+  return {
+    command: DARWIN_SANDBOX_EXEC,
+    args: ["-p", buildSandboxProfile(sandbox), spawnSpec.command, ...spawnSpec.args],
+  };
 }
 
 function createBoundedOutputCollector(streamName: "stdout" | "stderr", maxBytes: number = DEFAULT_MAX_OUTPUT_BYTES) {
@@ -102,7 +170,22 @@ export function createFridayShellExecutor(): FridayShellExecutor {
         let settled = false;
         let terminationFallbackTimer: NodeJS.Timeout | null = null;
 
-        const spawnSpec = resolveSpawnSpec(options.command, options.args ?? []);
+        const spawnSpec = resolveSandboxedSpawnSpec(
+          resolveSpawnSpec(options.command, options.args ?? []),
+          options.osSandbox,
+        );
+        if (spawnSpec.unavailableReason) {
+          stderr.append(spawnSpec.unavailableReason);
+          resolve({
+            exitCode: 126,
+            stdout: stdout.toString(),
+            stderr: stderr.toString(),
+            timedOut: false,
+            cancelled: false,
+            durationMs: Date.now() - startMs,
+          });
+          return;
+        }
         let child: ChildProcessWithoutNullStreams;
         try {
           child = spawn(spawnSpec.command, spawnSpec.args, {

--- a/src/skills/executor/friday-skill-executor.ts
+++ b/src/skills/executor/friday-skill-executor.ts
@@ -1,11 +1,11 @@
 import type {
   CreateFridaySkillExecutorDeps,
+  FridayShellOsSandboxOptions,
   FridaySkillAiHelperContext,
   FridaySkillExecuteHandle,
   FridaySkillExecuteRequest,
   FridaySkillExecuteResult,
   FridaySkillExecutor,
-  FridayShellOsSandboxOptions,
   FridaySkillLifecycleCanaryExecuteRequest,
 } from "./friday-skill-executor.types.js";
 import type { SkillManifestV2 } from "../model/friday-skill-manifest-v2.types.js";

--- a/src/skills/executor/friday-skill-executor.ts
+++ b/src/skills/executor/friday-skill-executor.ts
@@ -5,6 +5,7 @@ import type {
   FridaySkillExecuteRequest,
   FridaySkillExecuteResult,
   FridaySkillExecutor,
+  FridayShellOsSandboxOptions,
   FridaySkillLifecycleCanaryExecuteRequest,
 } from "./friday-skill-executor.types.js";
 import type { SkillManifestV2 } from "../model/friday-skill-manifest-v2.types.js";
@@ -740,6 +741,16 @@ export function createFridaySkillExecutor(
   const nodeExecutor = createFridayNodeExecutor();
   const activeRuns = new Map<string, { cancelled: boolean; controller: AbortController }>();
 
+  function skillProcessSandbox(skillDir: string): FridayShellOsSandboxOptions {
+    const darwin = process.platform === "darwin";
+    return {
+      enabled: darwin,
+      required: darwin,
+      denyNetwork: true,
+      writableRoots: [skillDir],
+    };
+  }
+
   function executeInternal(
     request: InternalFridaySkillExecuteRequest,
   ): FridaySkillExecuteHandle {
@@ -1012,6 +1023,7 @@ export function createFridaySkillExecutor(
                       command: entrypoint,
                       cwd: registered.skillDir,
                       env: buildRuntimeEnv(manifest.requirements.env),
+                      osSandbox: skillProcessSandbox(registered.skillDir),
                       timeoutMs,
                       stdin: JSON.stringify(preparedInput),
                       signal: controller.signal,
@@ -1089,6 +1101,7 @@ export function createFridaySkillExecutor(
                       args: [entrypoint],
                       cwd: registered.skillDir,
                       env: buildRuntimeEnv(manifest.requirements.env),
+                      osSandbox: skillProcessSandbox(registered.skillDir),
                       timeoutMs,
                       stdin: JSON.stringify(preparedInput),
                       signal: controller.signal,

--- a/src/skills/executor/friday-skill-executor.types.ts
+++ b/src/skills/executor/friday-skill-executor.types.ts
@@ -22,9 +22,17 @@ export interface FridayShellRunOptions {
   args?: string[];
   cwd?: string;
   env?: Record<string, string>;
+  osSandbox?: FridayShellOsSandboxOptions;
   timeoutMs?: number;
   stdin?: string;
   signal?: AbortSignal;
+}
+
+export interface FridayShellOsSandboxOptions {
+  enabled: boolean;
+  required?: boolean;
+  denyNetwork?: boolean;
+  writableRoots?: readonly string[];
 }
 
 export interface FridayShellRunResult {

--- a/test/unit/skills/executor/friday-execution-isolation-status.test.ts
+++ b/test/unit/skills/executor/friday-execution-isolation-status.test.ts
@@ -8,8 +8,8 @@ import {
 } from "../../../../src/skills/executor/friday-execution-isolation-status.js";
 
 describe("getFridayExecutionIsolationStatus", () => {
-  it("truth-labels execution boundaries as not OS-sandboxed by default", () => {
-    const status = getFridayExecutionIsolationStatus({});
+  it("truth-labels execution boundaries as not OS-sandboxed when no process sandbox is available", () => {
+    const status = getFridayExecutionIsolationStatus({}, { darwinSandboxExecAvailable: false });
 
     expect(status).toMatchObject({
       schemaVersion: "1.0",
@@ -45,6 +45,37 @@ describe("getFridayExecutionIsolationStatus", () => {
           boundary: "logical_workspace_guard_host_spawn",
           osSandbox: false,
           defaultLive: true,
+        },
+      },
+    });
+  });
+
+  it("truth-labels shell and python as partially OS-sandboxed when Darwin sandbox-exec is available", () => {
+    const status = getFridayExecutionIsolationStatus({}, { darwinSandboxExecAvailable: true });
+
+    expect(status).toMatchObject({
+      schemaVersion: "1.0",
+      disposition: "partial_os_sandbox",
+      osSandbox: true,
+      surfaces: {
+        "skill.shell": {
+          boundary: "darwin_sandbox_exec_write_network_guard",
+          osSandbox: true,
+          defaultLive: true,
+        },
+        "skill.python": {
+          boundary: "darwin_sandbox_exec_write_network_guard",
+          osSandbox: true,
+          defaultLive: true,
+        },
+        "skill.node": {
+          osSandbox: false,
+        },
+        "plugin.entrypoint": {
+          osSandbox: false,
+        },
+        "agent.exec": {
+          osSandbox: false,
         },
       },
     });

--- a/test/unit/skills/executor/friday-shell-executor.test.ts
+++ b/test/unit/skills/executor/friday-shell-executor.test.ts
@@ -1,4 +1,8 @@
 import { afterEach, describe, it, expect } from "vitest";
+import { existsSync } from "node:fs";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { createFridayShellExecutor } from "#skills";
 
 describe("FridayShellExecutor", () => {
@@ -159,5 +163,52 @@ describe("FridayShellExecutor", () => {
     expect(result.exitCode).toBe(0);
     // On macOS /tmp is a symlink to /private/tmp
     expect(result.stdout.trim()).toMatch(/\/(tmp|private\/tmp)$/);
+  });
+
+  const darwinSandboxIt = process.platform === "darwin" && existsSync("/usr/bin/sandbox-exec") ? it : it.skip;
+
+  darwinSandboxIt("uses macOS sandbox-exec to block writes outside declared roots", async () => {
+    const executor = createExecutor();
+    const root = await mkdtemp(join(tmpdir(), "friday-shell-sandbox-"));
+    const outsidePath = join(tmpdir(), `friday-shell-sandbox-outside-${Date.now().toString()}`);
+
+    try {
+      const result = await executor.run({
+        command: "sh",
+        args: ["-c", `printf ok > allowed.txt && touch ${outsidePath}`],
+        cwd: root,
+        osSandbox: {
+          enabled: true,
+          required: true,
+          writableRoots: [root],
+        },
+      });
+
+      expect(result.exitCode).not.toBe(0);
+      expect(result.stderr).toContain("Operation not permitted");
+      expect(existsSync(join(root, "allowed.txt"))).toBe(true);
+      expect(existsSync(outsidePath)).toBe(false);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+      await rm(outsidePath, { force: true });
+    }
+  });
+
+  const nonDarwinSandboxIt = process.platform === "darwin" ? it.skip : it;
+
+  nonDarwinSandboxIt("fails closed when a required OS sandbox is unavailable", async () => {
+    const executor = createExecutor();
+    const result = await executor.run({
+      command: "echo",
+      args: ["hello"],
+      osSandbox: {
+        enabled: true,
+        required: true,
+        writableRoots: [tmpdir()],
+      },
+    });
+
+    expect(result.exitCode).toBe(126);
+    expect(result.stderr).toContain("OS sandbox is required");
   });
 });


### PR DESCRIPTION
## Summary
- route shell and python skill executions through Darwin sandbox-exec when available
- expose sandbox status through the execution isolation truth/status surface
- keep non-Darwin and unavailable sandbox behavior truth-labeled rather than overclaiming

## Verification
- npx vitest run --project default test/unit/skills/executor/friday-shell-executor.test.ts test/unit/skills/executor/friday-execution-isolation-status.test.ts test/unit/skills/executor/friday-skill-executor.test.ts
- npm run build
- git diff --check

## Truth boundary
- Partial D2 hardening only: shell/python skill processes on Darwin.
- Node/plugin/agent.exec are not universally OS-sandboxed by this PR.
- sandbox-exec does not prove complete secret-read isolation.