### PR TITLE
Fail closed default master key generation

### DIFF
--- a/src/security/friday-secret-crypto.ts
+++ b/src/security/friday-secret-crypto.ts
@@ -82,9 +82,14 @@ let cachedMasterKeySource: MasterKeyCacheSource | null = null;
 const MASTER_KEY_CACHE_TTL_MS = 3_600_000; // 1 hour
 
 const MASTER_KEY_DIR = path.join(os.homedir(), ".friday");
-const MASTER_KEY_FILE = path.join(MASTER_KEY_DIR, "master.key");
+const DEFAULT_MASTER_KEY_FILE = path.join(MASTER_KEY_DIR, "master.key");
 const MASTER_KEY_KEYCHAIN_SERVICE = "Friday Master Key";
 const MASTER_KEY_KEYCHAIN_ACCOUNT = "friday";
+const TEST_ONLY_MASTER_KEY_GENERATION_ENV = "FRIDAY_ALLOW_TEST_ONLY_MASTER_KEY_GENERATION";
+
+function getMasterKeyFilePath(): string {
+  return process.env.FRIDAY_MASTER_KEY_FILE ?? DEFAULT_MASTER_KEY_FILE;
+}
 
 function parseMasterKeyHex(hex: string, sourceLabel: string): Buffer {
   const buf = Buffer.from(hex, "hex");
@@ -110,8 +115,9 @@ function readPersistedMasterKeyFile(options: {
   readonly failClosed: boolean;
 }): Buffer | null {
   let hex: string;
+  const masterKeyFile = getMasterKeyFilePath();
   try {
-    hex = fs.readFileSync(MASTER_KEY_FILE, "utf8").trim();
+    hex = fs.readFileSync(masterKeyFile, "utf8").trim();
   } catch (err) {
     if (options.failClosed) {
       throw new FridayDomainError(
@@ -126,12 +132,12 @@ function readPersistedMasterKeyFile(options: {
 
   if (options.repairPermissions) {
     try {
-      const stat = fs.statSync(MASTER_KEY_FILE);
+      const stat = fs.statSync(masterKeyFile);
       if ((stat.mode & 0o077) !== 0) {
         // eslint-disable-next-line no-console
         console.warn(`[friday][SECURITY] Master key file permissions too open (0o${(stat.mode & 0o777).toString(8)}) — attempting chmod 0600`);
         try {
-          fs.chmodSync(MASTER_KEY_FILE, 0o600);
+          fs.chmodSync(masterKeyFile, 0o600);
         } catch (chmodErr) {
           // eslint-disable-next-line no-console
           console.warn("[friday][SECURITY] Could not fix master key file permissions:", chmodErr instanceof Error ? chmodErr.message : String(chmodErr));
@@ -193,12 +199,11 @@ function readKeychainMasterKey(): Buffer | null {
 
 /**
  * Resolves the master key from `FRIDAY_MASTER_KEY` env var (hex-encoded),
- * or persists/reads a random one from `~/.friday/master.key`.
+ * optional macOS keychain, or an already-provisioned `~/.friday/master.key`.
  *
- * When no explicit key is set:
- * - On first run, generates a random key, writes to `~/.friday/master.key`
- *   (mode 0600), and logs a warning.
- * - On subsequent runs, reads from that file so secrets survive restarts.
+ * Default runtime behavior is fail-closed: Friday must not silently create new
+ * encryption roots. Legacy/test generation exists only behind
+ * `FRIDAY_ALLOW_TEST_ONLY_MASTER_KEY_GENERATION=1`.
  */
 export function getMasterKey(): Buffer {
   // P2-SEC: Honor TTL — invalidate cache after expiry to support key rotation
@@ -233,24 +238,33 @@ export function getMasterKey(): Buffer {
   // 3. Try to read persisted key file
   const persistedKey = readPersistedMasterKeyFile({
     repairPermissions: true,
-    failClosed: false,
+    failClosed: process.env[TEST_ONLY_MASTER_KEY_GENERATION_ENV] !== "1",
   });
   if (persistedKey) {
     return cacheMasterKey(persistedKey, "file");
   }
 
-  // 4. Generate, persist, and warn
+  if (process.env[TEST_ONLY_MASTER_KEY_GENERATION_ENV] !== "1") {
+    throw new FridayDomainError(
+      "VALIDATION_ERROR",
+      "FRIDAY_MASTER_KEY is not configured. Set FRIDAY_MASTER_KEY (hex), set FRIDAY_MASTER_KEY_SOURCE=keychain, or provision an existing ~/.friday/master.key. Friday will not auto-generate a key for this path.",
+      { httpStatus: 503 },
+    );
+  }
+
+  // 4. Explicit test/legacy opt-in only: generate, persist, and warn
   const newKey = crypto.randomBytes(KEY_BYTES);
 
   try {
-    fs.mkdirSync(MASTER_KEY_DIR, { recursive: true, mode: 0o700 });
-    fs.writeFileSync(MASTER_KEY_FILE, newKey.toString("hex") + "\n", {
+    const masterKeyFile = getMasterKeyFilePath();
+    fs.mkdirSync(path.dirname(masterKeyFile), { recursive: true, mode: 0o700 });
+    fs.writeFileSync(masterKeyFile, newKey.toString("hex") + "\n", {
       mode: 0o600,
     });
   } catch (err) {
     // Best-effort: if we can't write, the key lives only in memory this run
     console.warn(
-      "[friday] WARNING: Could not persist master key to " + MASTER_KEY_FILE,
+      "[friday] WARNING: Could not persist master key to " + getMasterKeyFilePath(),
       err instanceof Error ? err.message : String(err),
     );
   }
@@ -258,7 +272,7 @@ export function getMasterKey(): Buffer {
   console.warn(
     "[friday] WARNING: No FRIDAY_MASTER_KEY env var set. " +
       "Generated a random master key and saved to " +
-      MASTER_KEY_FILE +
+      getMasterKeyFilePath() +
       ". Set FRIDAY_MASTER_KEY for production use.",
   );
 

--- a/test/unit/providers/security/friday-secret-crypto.test.ts
+++ b/test/unit/providers/security/friday-secret-crypto.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import * as crypto from "node:crypto";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
 import {
   encryptSecret,
   decryptSecret,
@@ -88,6 +91,8 @@ describe("FridaySecretCrypto", () => {
     const originalSource = process.env.FRIDAY_MASTER_KEY_SOURCE;
     const originalKeychainService = process.env.FRIDAY_MASTER_KEY_KEYCHAIN_SERVICE;
     const originalKeychainAccount = process.env.FRIDAY_MASTER_KEY_KEYCHAIN_ACCOUNT;
+    const originalAllowTestOnlyGeneration = process.env.FRIDAY_ALLOW_TEST_ONLY_MASTER_KEY_GENERATION;
+    const originalMasterKeyFile = process.env.FRIDAY_MASTER_KEY_FILE;
 
     beforeEach(() => {
       resetMasterKeyCache();
@@ -113,6 +118,16 @@ describe("FridaySecretCrypto", () => {
         process.env.FRIDAY_MASTER_KEY_KEYCHAIN_ACCOUNT = originalKeychainAccount;
       } else {
         delete process.env.FRIDAY_MASTER_KEY_KEYCHAIN_ACCOUNT;
+      }
+      if (originalAllowTestOnlyGeneration !== undefined) {
+        process.env.FRIDAY_ALLOW_TEST_ONLY_MASTER_KEY_GENERATION = originalAllowTestOnlyGeneration;
+      } else {
+        delete process.env.FRIDAY_ALLOW_TEST_ONLY_MASTER_KEY_GENERATION;
+      }
+      if (originalMasterKeyFile !== undefined) {
+        process.env.FRIDAY_MASTER_KEY_FILE = originalMasterKeyFile;
+      } else {
+        delete process.env.FRIDAY_MASTER_KEY_FILE;
       }
       vi.restoreAllMocks();
       resetMasterKeyCache();
@@ -142,16 +157,33 @@ describe("FridaySecretCrypto", () => {
       expect(() => getMasterKey()).toThrow("FRIDAY_MASTER_KEY_SOURCE=keychain");
     });
 
-    it("generates random key when env var not set", () => {
+    it("fails closed instead of generating a random key when env var is not set", () => {
       delete process.env.FRIDAY_MASTER_KEY;
+      delete process.env.FRIDAY_MASTER_KEY_SOURCE;
+      delete process.env.FRIDAY_ALLOW_TEST_ONLY_MASTER_KEY_GENERATION;
+      process.env.FRIDAY_MASTER_KEY_FILE = path.join(os.tmpdir(), `friday-missing-master-key-${crypto.randomUUID()}`, "master.key");
+
+      expect(() => getMasterKey()).toThrow(/will not auto-generate a key/);
+    });
+
+    it("generates random key only when the test-only generation escape hatch is explicit", () => {
+      delete process.env.FRIDAY_MASTER_KEY;
+      delete process.env.FRIDAY_MASTER_KEY_SOURCE;
+      process.env.FRIDAY_ALLOW_TEST_ONLY_MASTER_KEY_GENERATION = "1";
+      const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "friday-master-key-generation-"));
+      process.env.FRIDAY_MASTER_KEY_FILE = path.join(tempDir, "master.key");
+
       const key = getMasterKey();
       expect(key).toBeInstanceOf(Buffer);
       expect(key.length).toBe(32);
+      expect(fs.readFileSync(process.env.FRIDAY_MASTER_KEY_FILE, "utf8").trim()).toHaveLength(64);
+      fs.rmSync(tempDir, { recursive: true, force: true });
     });
 
     it("does not let fail-open cached keys satisfy strict runtime resolution", () => {
       delete process.env.FRIDAY_MASTER_KEY;
       delete process.env.FRIDAY_MASTER_KEY_SOURCE;
+      process.env.FRIDAY_ALLOW_TEST_ONLY_MASTER_KEY_GENERATION = "1";
       const key = getMasterKey();
       expect(key.length).toBe(32);
 
@@ -160,6 +192,8 @@ describe("FridaySecretCrypto", () => {
 
     it("caches the key across calls", () => {
       delete process.env.FRIDAY_MASTER_KEY;
+      delete process.env.FRIDAY_MASTER_KEY_SOURCE;
+      process.env.FRIDAY_ALLOW_TEST_ONLY_MASTER_KEY_GENERATION = "1";
       const k1 = getMasterKey();
       const k2 = getMasterKey();
       expect(k1).toBe(k2); // Same reference


### PR DESCRIPTION
## Summary
- make bare getMasterKey() fail closed when no env/keychain/provisioned file exists
- keep random master-key generation behind explicit FRIDAY_ALLOW_TEST_ONLY_MASTER_KEY_GENERATION=1 only
- add FRIDAY_MASTER_KEY_FILE seam so tests can prove missing-file behavior without touching the real ~/.friday/master.key
- update focused master-key tests to prove default no-generation and explicit test-only generation

## Validation
- npx vitest run --project default test/unit/providers/security/friday-secret-crypto.test.ts test/adversarial/crypto-http-attacks.test.ts
- npm run build
- npm run check:secret-patterns
- npx eslint src/security/friday-secret-crypto.ts test/unit/providers/security/friday-secret-crypto.test.ts --quiet
- git diff --check

Truth boundary: D3 default getMasterKey no-generate closure only. This does not claim D1/D2/D4-D7 completion, registry completion, or any live capability done state.