### PR TITLE
Add D20 worktree-scoped batch driver

### DIFF
--- a/rust-core/crates/friday-storage/src/authorize_ed25519.rs
+++ b/rust-core/crates/friday-storage/src/authorize_ed25519.rs
@@ -37,6 +37,7 @@ use friday_core::gate::{
 };
 use friday_crypto::OperatorVerifyingKey;
 use rusqlite::{params, Connection, Error as SqlErr, ErrorCode};
+use std::path::{Component, Path, PathBuf};
 
 /// A **verify-only** Ed25519 approval policy. It holds ONLY the operator's PUBLIC
 /// verify key — no signing key, no HMAC secret — so it can VERIFY an operator-signed
@@ -279,4 +280,154 @@ pub fn authorize_mutating_action_ed25519_batch(
 
 fn is_valid_digest_hex(s: &str) -> bool {
     s.len() == 64 && s.bytes().all(|b| matches!(b, b'0'..=b'9' | b'a'..=b'f'))
+}
+
+/// DARK D20 W2-S4 driver scope for reversible batch auto-run.
+///
+/// This does not execute tools. It is the verify-only pre-dispatch guard that proves
+/// a signed batch member is confined to the git/worktree space where "reversible"
+/// actually means "operator can inspect/revert with git/worktree mechanics". The Hub
+/// still verifies only; it never mints the operator signature.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DialWorktreeScope {
+    pub plan_sign_id: String,
+    pub active_worktree: PathBuf,
+}
+
+/// Authorize one batch member only if its classified resource path is inside the
+/// active worktree and not in an explicitly never-revertable space (`~/.friday`,
+/// launchd plist, or Friday state DB files). On success, writes a hash-chain audit
+/// row in the same transaction as the batch replay consume.
+pub fn authorize_reversible_batch_in_worktree(
+    conn: &mut Connection,
+    request: &MutatingActionRequest,
+    batch: Option<&CanonicalApprovalBatch>,
+    operator_vk: &OperatorVerifyingKey,
+    now_ms: i64,
+    scope: &DialWorktreeScope,
+) -> Result<GateEvidenceRecord> {
+    let tx = conn.unchecked_transaction()?;
+    let preflight = worktree_revertable_preflight(request, batch, scope);
+    if let Some(reason) = preflight {
+        return Ok(GateEvidenceRecord {
+            decision: GateDecision::RequiresApproval,
+            reason: reason.to_string(),
+            risk: gate::evaluate(request).risk,
+            approval_required: true,
+            denied_by: Some("canonical_gate".to_string()),
+        });
+    }
+
+    let evidence =
+        authorize_mutating_action_ed25519_batch(&tx, request, batch, operator_vk, now_ms)?;
+    if evidence.decision == GateDecision::Allow {
+        let digest = friday_crypto::action_digest(&gate::canonical_action_bytes(request));
+        let audit_id = format!("dial.batch.worktree:{}:{}", scope.plan_sign_id, digest);
+        let payload_ref = format!("dial://batch/{}/action/{}", scope.plan_sign_id, digest);
+        crate::audit::append_audit(
+            &tx,
+            &audit_id,
+            "friday",
+            "dial.batch.worktree_authorized",
+            Some(&payload_ref),
+            now_ms,
+        )?;
+    }
+    tx.commit()?;
+    Ok(evidence)
+}
+
+fn worktree_revertable_preflight(
+    request: &MutatingActionRequest,
+    batch: Option<&CanonicalApprovalBatch>,
+    scope: &DialWorktreeScope,
+) -> Option<&'static str> {
+    if request.reversibility() == Reversibility::Irreversible {
+        return Some("dial_worktree_irreversible_requires_single_approval");
+    }
+    let batch = batch?;
+    if batch.batch_sign_id != scope.plan_sign_id {
+        return Some("dial_worktree_plan_sign_id_mismatch");
+    }
+    let resource_path = request.resource()?.id.as_deref()?;
+    let real_worktree = match std::fs::canonicalize(&scope.active_worktree) {
+        Ok(p) => p,
+        Err(_) => return Some("dial_worktree_active_root_unavailable"),
+    };
+    let real_target = match canonicalize_existing_parent(&real_worktree, resource_path) {
+        Ok(p) => p,
+        Err(reason) => return Some(reason),
+    };
+    if is_never_revertable_path(&real_target) {
+        return Some("dial_worktree_never_revertable_path");
+    }
+    if !real_target.starts_with(&real_worktree) {
+        return Some("dial_worktree_resource_out_of_scope");
+    }
+    None
+}
+
+fn canonicalize_existing_parent(
+    worktree: &Path,
+    path: &str,
+) -> std::result::Result<PathBuf, &'static str> {
+    let supplied = expand_home(path);
+    let candidate = if supplied.is_absolute() {
+        supplied
+    } else {
+        worktree.join(supplied)
+    };
+    if has_parent_traversal(&candidate) {
+        return Err("dial_worktree_resource_path_invalid");
+    }
+    if let Ok(real) = std::fs::canonicalize(&candidate) {
+        return Ok(real);
+    }
+    let Some(name) = candidate.file_name() else {
+        return Err("dial_worktree_resource_path_invalid");
+    };
+    let Some(parent) = candidate.parent() else {
+        return Err("dial_worktree_resource_path_invalid");
+    };
+    let real_parent =
+        std::fs::canonicalize(parent).map_err(|_| "dial_worktree_resource_parent_unavailable")?;
+    Ok(real_parent.join(name))
+}
+
+fn has_parent_traversal(path: &Path) -> bool {
+    path.components()
+        .any(|component| matches!(component, Component::ParentDir))
+}
+
+fn expand_home(path: &str) -> PathBuf {
+    if path == "~" {
+        std::env::var_os("HOME")
+            .map(PathBuf::from)
+            .unwrap_or_else(|| PathBuf::from(path))
+    } else if let Some(rest) = path.strip_prefix("~/") {
+        std::env::var_os("HOME")
+            .map(|home| PathBuf::from(home).join(rest))
+            .unwrap_or_else(|| PathBuf::from(path))
+    } else {
+        PathBuf::from(path)
+    }
+}
+
+fn is_never_revertable_path(path: &Path) -> bool {
+    if std::env::var_os("HOME")
+        .map(|home| PathBuf::from(home).join(".friday"))
+        .is_some_and(|friday_home| path.starts_with(friday_home))
+    {
+        return true;
+    }
+    if path
+        .file_name()
+        .and_then(|s| s.to_str())
+        .is_some_and(|name| {
+            matches!(name, "friday.db" | "rust-hub.sqlite") || name.ends_with(".plist")
+        })
+    {
+        return true;
+    }
+    false
 }

--- a/rust-core/crates/friday-storage/src/lib.rs
+++ b/rust-core/crates/friday-storage/src/lib.rs
@@ -50,7 +50,7 @@ pub use agent_session::{
 pub use authorize::authorize_mutating_action;
 pub use authorize_ed25519::{
     authorize_mutating_action_ed25519, authorize_mutating_action_ed25519_batch,
-    Ed25519VerifyOnlyPolicy,
+    authorize_reversible_batch_in_worktree, DialWorktreeScope, Ed25519VerifyOnlyPolicy,
 };
 pub use error::{Result, StorageError};
 pub use migrate::{

--- a/rust-core/crates/friday-storage/tests/authorize_ed25519.rs
+++ b/rust-core/crates/friday-storage/tests/authorize_ed25519.rs
@@ -22,9 +22,10 @@ use friday_core::Risk;
 use friday_crypto::{OperatorSigningKey, OperatorVerifyingKey};
 use friday_storage::{
     authorize_mutating_action_ed25519, authorize_mutating_action_ed25519_batch,
-    get_pending_request, persist_pending_request, Db, Ed25519VerifyOnlyPolicy,
-    PendingApprovalRequest,
+    authorize_reversible_batch_in_worktree, get_pending_request, persist_pending_request, Db,
+    DialWorktreeScope, Ed25519VerifyOnlyPolicy, PendingApprovalRequest,
 };
+use std::path::PathBuf;
 
 /// The HMAC secret the HUB holds (the symmetric mint==verify key). A correct verify-only
 /// Ed25519 policy must make this irrelevant for protected actions.
@@ -199,6 +200,24 @@ fn consumed_count(db: &Db) -> i64 {
     db.conn()
         .query_row("SELECT count(*) FROM consumed_approval", [], |r| r.get(0))
         .unwrap()
+}
+
+fn audit_count(db: &Db) -> i64 {
+    db.conn()
+        .query_row("SELECT count(*) FROM audit_ledger", [], |r| r.get(0))
+        .unwrap()
+}
+
+fn temp_worktree(tag: &str) -> PathBuf {
+    let mut dir = std::env::temp_dir();
+    dir.push(format!(
+        "friday-dial-worktree-{tag}-{}-{}",
+        std::process::id(),
+        NOW
+    ));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(dir.join("src")).unwrap();
+    dir
 }
 
 /// A fresh operator keypair; the Hub gets ONLY the verify key.
@@ -789,4 +808,173 @@ fn pending_tool_params_round_trip_and_status_update() {
         set_pending_status(db.conn(), "nope", "consumed").unwrap(),
         0
     );
+}
+
+#[test]
+fn dial_worktree_driver_allows_signed_member_inside_active_worktree_and_audits() {
+    let mut db = Db::open_hub(&temp_db_path("ed-dial-worktree-ok")).unwrap();
+    let worktree = temp_worktree("ok");
+    let target = worktree.join("src/owned.txt");
+    let (sk, vk) = operator();
+    let req = req_with(
+        "write_file",
+        ActorKind::Owner,
+        true,
+        Risk::Medium,
+        Some(target.to_string_lossy().as_ref()),
+        "p1",
+    );
+    let batch = batch_approval(&[&req], &sk, "dial-batch-ok", Some(FUTURE));
+    let scope = DialWorktreeScope {
+        plan_sign_id: "dial-batch-ok".to_string(),
+        active_worktree: worktree,
+    };
+
+    let r =
+        authorize_reversible_batch_in_worktree(db.conn_mut(), &req, Some(&batch), &vk, NOW, &scope)
+            .unwrap();
+    assert_eq!(r.decision, GateDecision::Allow);
+    assert_eq!(r.reason, "canonical_batch_approval_granted");
+    assert_eq!(consumed_count(&db), 1);
+    assert_eq!(
+        audit_count(&db),
+        1,
+        "successful dial worktree authorization must append an audit row"
+    );
+    assert_eq!(
+        friday_storage::audit::verify_audit_chain(db.conn()).unwrap(),
+        1
+    );
+}
+
+#[test]
+fn dial_worktree_driver_pauses_resource_outside_active_worktree_without_consuming() {
+    let mut db = Db::open_hub(&temp_db_path("ed-dial-worktree-escape")).unwrap();
+    let worktree = temp_worktree("escape");
+    let outside_parent = temp_worktree("outside");
+    let outside = outside_parent.join("outside.txt");
+    let (sk, vk) = operator();
+    let req = req_with(
+        "write_file",
+        ActorKind::Owner,
+        true,
+        Risk::Medium,
+        Some(outside.to_string_lossy().as_ref()),
+        "p1",
+    );
+    let batch = batch_approval(&[&req], &sk, "dial-batch-escape", Some(FUTURE));
+    let scope = DialWorktreeScope {
+        plan_sign_id: "dial-batch-escape".to_string(),
+        active_worktree: worktree,
+    };
+
+    let r =
+        authorize_reversible_batch_in_worktree(db.conn_mut(), &req, Some(&batch), &vk, NOW, &scope)
+            .unwrap();
+    assert_eq!(r.decision, GateDecision::RequiresApproval);
+    assert_eq!(r.reason, "dial_worktree_resource_out_of_scope");
+    assert_eq!(consumed_count(&db), 0);
+    assert_eq!(audit_count(&db), 0);
+}
+
+#[test]
+fn dial_worktree_driver_pauses_never_revertable_db_and_plist_targets() {
+    let mut db = Db::open_hub(&temp_db_path("ed-dial-worktree-never")).unwrap();
+    let worktree = temp_worktree("never");
+    let (sk, vk) = operator();
+    for (name, batch_id) in [
+        ("rust-hub.sqlite", "dial-batch-db"),
+        ("com.friday.hub.plist", "dial-batch-plist"),
+    ] {
+        let target = worktree.join(name);
+        let req = req_with(
+            "write_file",
+            ActorKind::Owner,
+            true,
+            Risk::Medium,
+            Some(target.to_string_lossy().as_ref()),
+            "p1",
+        );
+        let batch = batch_approval(&[&req], &sk, batch_id, Some(FUTURE));
+        let scope = DialWorktreeScope {
+            plan_sign_id: batch_id.to_string(),
+            active_worktree: worktree.clone(),
+        };
+        let r = authorize_reversible_batch_in_worktree(
+            db.conn_mut(),
+            &req,
+            Some(&batch),
+            &vk,
+            NOW,
+            &scope,
+        )
+        .unwrap();
+        assert_eq!(r.decision, GateDecision::RequiresApproval);
+        assert_eq!(r.reason, "dial_worktree_never_revertable_path");
+    }
+    assert_eq!(consumed_count(&db), 0);
+    assert_eq!(audit_count(&db), 0);
+}
+
+#[test]
+fn dial_worktree_driver_irreversible_and_plan_mismatch_pause_before_batch_consume() {
+    let mut db = Db::open_hub(&temp_db_path("ed-dial-worktree-guards")).unwrap();
+    let worktree = temp_worktree("guards");
+    let target = worktree.join("src/owned.txt");
+    let (sk, vk) = operator();
+    let irreversible = req_from_params(
+        "write_file",
+        ActorKind::Owner,
+        true,
+        Risk::Medium,
+        Reversibility::Irreversible,
+        vec![("path".to_string(), target.to_string_lossy().to_string())],
+        "p1",
+    );
+    let batch = batch_approval(&[&irreversible], &sk, "dial-batch-irrev", Some(FUTURE));
+    let scope = DialWorktreeScope {
+        plan_sign_id: "dial-batch-irrev".to_string(),
+        active_worktree: worktree.clone(),
+    };
+    let r = authorize_reversible_batch_in_worktree(
+        db.conn_mut(),
+        &irreversible,
+        Some(&batch),
+        &vk,
+        NOW,
+        &scope,
+    )
+    .unwrap();
+    assert_eq!(r.decision, GateDecision::RequiresApproval);
+    assert_eq!(
+        r.reason,
+        "dial_worktree_irreversible_requires_single_approval"
+    );
+
+    let reversible = req_with(
+        "write_file",
+        ActorKind::Owner,
+        true,
+        Risk::Medium,
+        Some(target.to_string_lossy().as_ref()),
+        "p1",
+    );
+    let batch = batch_approval(&[&reversible], &sk, "dial-batch-real", Some(FUTURE));
+    let bad_scope = DialWorktreeScope {
+        plan_sign_id: "dial-batch-other".to_string(),
+        active_worktree: worktree,
+    };
+    let r = authorize_reversible_batch_in_worktree(
+        db.conn_mut(),
+        &reversible,
+        Some(&batch),
+        &vk,
+        NOW,
+        &bad_scope,
+    )
+    .unwrap();
+    assert_eq!(r.decision, GateDecision::RequiresApproval);
+    assert_eq!(r.reason, "dial_worktree_plan_sign_id_mismatch");
+    assert_eq!(consumed_count(&db), 0);
+    assert_eq!(audit_count(&db), 0);
 }


### PR DESCRIPTION
## Summary
- add a DARK D20 W2-S4 verify-only worktree scope for operator-signed reversible batches
- require batch plan_sign_id match, canonicalized resource containment inside the active worktree, and explicit never-revertable refusal for ~/.friday, launchd plist, and Friday state DB targets
- append a hash-chain audit row when a worktree-scoped batch member is allowed

## Truth label
Built-DARK mechanism seam only. This does not execute tools, does not flip trust dial live, does not read/sign the operator private key, and does not prove TRUE operator-in-the-loop dial closure. Friday still has no action rollback engine; this confines auto-run eligibility to git/worktree revertable space.

## Validation
- cargo fmt --manifest-path rust-core/Cargo.toml --all -- --check
- cargo test --manifest-path rust-core/Cargo.toml -p friday-storage --test authorize_ed25519
- cargo test --manifest-path rust-core/Cargo.toml -p friday-storage --test trust_grant
- cargo test --manifest-path rust-core/Cargo.toml -p friday-core gate::tests
- git diff --check