### PR TITLE
Descope empty friday-browser Rust stub

### DIFF
--- a/rust-core/Cargo.lock
+++ b/rust-core/Cargo.lock
@@ -629,10 +629,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "friday-browser"
-version = "0.0.1"
-
-[[package]]
 name = "friday-core"
 version = "0.0.1"
 dependencies = [

--- a/rust-core/Cargo.toml
+++ b/rust-core/Cargo.toml
@@ -34,7 +34,6 @@ members = [
     "crates/friday-ocr",
     "crates/friday-tts",
     "crates/friday-pdf",
-    "crates/friday-browser",
 ]
 
 [workspace.package]
@@ -95,7 +94,6 @@ friday-vision = { path = "crates/friday-vision" }
 friday-ocr = { path = "crates/friday-ocr" }
 friday-tts = { path = "crates/friday-tts" }
 friday-pdf = { path = "crates/friday-pdf" }
-friday-browser = { path = "crates/friday-browser" }
 
 [profile.dev]
 # bundled SQLite compiles faster with some opt; keep debug assertions on.

--- a/rust-core/crates/friday-browser/Cargo.toml
+++ b/rust-core/crates/friday-browser/Cargo.toml
@@ -1,8 +1,0 @@
-[package]
-name = "friday-browser"
-description = "Friday F11 net-new media capability — browser crate skeleton. Empty compiling stub, no logic/deps/executors yet (Hub-only, heavy-binary → stays OUT of friday-ffi's phone dependency graph)."
-edition.workspace = true
-version.workspace = true
-license.workspace = true
-publish = false
-rust-version.workspace = true

--- a/rust-core/crates/friday-browser/src/lib.rs
+++ b/rust-core/crates/friday-browser/src/lib.rs
@@ -1,7 +1,0 @@
-//! Friday F11 net-new media capability — browser crate.
-//!
-//! Skeleton placeholder only: this crate carries no logic, no dependencies, and
-//! no executor yet. The BrowserBackend trait, the StubBrowserBackend, the
-//! action/param schema, the security guards, and the cargo-feature spine for
-//! the live CDP backend land in later F11 crate-internal PRs (B1, B2a-d). The
-//! `impl ToolExecutor` wrapper is a `friday-hub` module, not part of this crate.


### PR DESCRIPTION
## Summary
- verify C4 reality: TS `src/browser` is load-bearing and remains untouched
- remove the zero-caller `friday-browser` Rust skeleton crate from the Rust workspace
- prune the empty crate from Cargo.lock

## Truth label
C4 disposition only. This does not remove TS browser automation because it is currently wired through hub bootstrap, skill executor types, and browser/unit/e2e coverage. The removed Rust crate was an empty skeleton/stub with no callers.

## Validation
- cargo metadata --manifest-path rust-core/Cargo.toml --no-deps
- cargo fmt --manifest-path rust-core/Cargo.toml --all -- --check
- cargo test --manifest-path rust-core/Cargo.toml -p friday-arch-tests
- rg friday-browser over rust-core manifests/crates returned no remaining Rust crate refs
- npx vitest run --project default test/unit/browser/friday-browser-manager.test.ts test/unit/browser/friday-browser-target-id.test.ts test/unit/agent/tools/friday-agent-browser-tool.test.ts (with temporary node_modules symlink removed after)
- git diff --check