### PR TITLE
Gate C1 XHS agent automation by default

### DIFF
--- a/src/agent/runtime/friday-agent-tool-mutation.ts
+++ b/src/agent/runtime/friday-agent-tool-mutation.ts
@@ -75,10 +75,11 @@ const CONDITIONAL_MUTATING_TOOLS: Record<string, (args: Record<string, unknown>)
     return mutatingActions.has(action);
   },
   xhs: (args) => {
-    // XHS actions that create/modify content
+    // XHS is C1-descope and default-unregistered. Keep the classifier
+    // fail-safe for test-only/future re-enable paths that still construct it.
     const action = typeof args.action === "string" ? args.action : "";
     const mutatingActions = new Set([
-      "publish_note", "comment", "like", "follow", "collect",
+      "login", "post", "publish", "publish_note", "comment", "comments", "like", "follow", "collect",
     ]);
     return mutatingActions.has(action);
   },

--- a/src/agent/tools/friday-agent-tool-registry.ts
+++ b/src/agent/tools/friday-agent-tool-registry.ts
@@ -93,6 +93,12 @@ export interface CreateFridayAgentToolRegistryOptions {
   subagentRegistry?: FridaySubagentRegistry;
   subagentContext?: FridaySubagentContext;
   browserManager?: FridayBrowserManager;
+  /**
+   * Test-oracle/descope override only. XHS automation is C1-descope and must
+   * not be exposed in the default/live agent tool registry even when bootstrap
+   * has legacy XHS deps available.
+   */
+  allowTestOnlyXhsExecution?: boolean;
   xhsPageInteractions?: XhsPageInteractions;
   xhsSessionManager?: XhsSessionManager;
   /** Optional SSRF guard for web_fetch tool. */
@@ -271,7 +277,11 @@ export function createFridayAgentToolRegistry(
     );
   }
 
-  if (options?.xhsPageInteractions && options?.xhsSessionManager) {
+  if (
+    options?.allowTestOnlyXhsExecution === true
+    && options.xhsPageInteractions
+    && options.xhsSessionManager
+  ) {
     tools.push(
       createFridayAgentXhsTool({
         pageInteractions: options.xhsPageInteractions,

--- a/test/unit/agent/runtime/friday-agent-tool-mutation.test.ts
+++ b/test/unit/agent/runtime/friday-agent-tool-mutation.test.ts
@@ -167,12 +167,16 @@ describe("isMutatingToolCall", () => {
 
   // ─── Conditional: xhs ───
 
-  it("classifies xhs publish_note as mutating", () => {
+  it("classifies xhs legacy publish_note as mutating", () => {
     expect(isMutatingToolCall("xhs", { action: "publish_note" })).toBe(true);
   });
 
-  it("classifies xhs with read action as non-mutating", () => {
+  it("classifies current xhs browser/egress actions conservatively", () => {
+    expect(isMutatingToolCall("xhs", { action: "login" })).toBe(true);
+    expect(isMutatingToolCall("xhs", { action: "post" })).toBe(true);
+    expect(isMutatingToolCall("xhs", { action: "comments" })).toBe(true);
     expect(isMutatingToolCall("xhs", { action: "search" })).toBe(false);
+    expect(isMutatingToolCall("xhs", { action: "status" })).toBe(false);
   });
 
   // ─── Unknown tools ───

--- a/test/unit/agent/tools/friday-agent-tool-registry.test.ts
+++ b/test/unit/agent/tools/friday-agent-tool-registry.test.ts
@@ -178,6 +178,22 @@ function stubGuideLensService(): FridayGuideLensService {
   } as unknown as FridayGuideLensService;
 }
 
+function stubXhsPageInteractions(): unknown {
+  return {
+    login: vi.fn(),
+    search: vi.fn(),
+    createPost: vi.fn(),
+    extractComments: vi.fn(),
+  };
+}
+
+function stubXhsSessionManager(): unknown {
+  return {
+    getSession: vi.fn(),
+    isSessionValid: vi.fn(),
+  };
+}
+
 describe("createFridayAgentToolRegistry", () => {
   // ─── Issue 1 & 2: Sessions tool with lazy runtime getter ───
 
@@ -213,6 +229,25 @@ describe("createFridayAgentToolRegistry", () => {
     });
     const names = tools.map((t) => t.name);
     expect(names).not.toContain("sessions");
+  });
+
+  it("keeps C1 XHS automation unregistered by default even when legacy deps exist", () => {
+    const tools = createFridayAgentToolRegistry({
+      xhsPageInteractions: stubXhsPageInteractions() as never,
+      xhsSessionManager: stubXhsSessionManager() as never,
+    });
+    const names = tools.map((t) => t.name);
+    expect(names).not.toContain("xhs");
+  });
+
+  it("registers C1 XHS automation only through the explicit test oracle", () => {
+    const tools = createFridayAgentToolRegistry({
+      allowTestOnlyXhsExecution: true,
+      xhsPageInteractions: stubXhsPageInteractions() as never,
+      xhsSessionManager: stubXhsSessionManager() as never,
+    });
+    const names = tools.map((t) => t.name);
+    expect(names).toContain("xhs");
   });
 
   // ─── Cron + message tools require their deps ───


### PR DESCRIPTION
## Summary
- keep legacy XHS/social-import code load-bearing but stop exposing the XHS agent tool in the default/live tool registry
- add an explicit test-only oracle for constructing the XHS agent tool in focused tests
- make the XHS mutation classifier conservative for current action names in any test-only/future re-enable path

## Validation
- npx vitest run --project default test/unit/agent/tools/friday-agent-tool-registry.test.ts test/unit/agent/runtime/friday-agent-tool-mutation.test.ts test/unit/api/routes/friday-social-import-routes.test.ts test/unit/skills/social-import/friday-social-import-service.test.ts
- git diff --check
- npm run build

Truth labels: C1 is descope-guarded/default-off here, not deleted. The social-import route already fail-closes before XHS browser extraction in default/live; this PR closes the separate agent-tool exposure. This is not C table complete, not registry/v1/D20 goal achieved.
