### PR TITLE
Add D20 route decision veto controls

### DIFF
--- a/docs/ops/friday-d1-split-db-acceptance-ledger.md
+++ b/docs/ops/friday-d1-split-db-acceptance-ledger.md
@@ -22,7 +22,7 @@ The currently shipped mainline satisfies the registry D1 block-release condition
 
 The TypeScript state runtime performs a Rust hub schema-version handshake before opening the split runtime:
 
-- `src/state/sqlite/friday-rust-hub-schema-handshake.ts` sets `FRIDAY_EXPECTED_RUST_HUB_SCHEMA_VERSION = 35`.
+- `src/state/sqlite/friday-rust-hub-schema-handshake.ts` sets `FRIDAY_EXPECTED_RUST_HUB_SCHEMA_VERSION = 37`.
 - The handshake reads `schema_version.version` from the configured Rust hub database or `stateDir/rust-hub.sqlite`.
 - Missing/invalid schema rows throw `RUST_HUB_SCHEMA_HANDSHAKE_FAILED`.
 - Version mismatch throws `RUST_HUB_SCHEMA_VERSION_MISMATCH` with HTTP 500 details and refuses to open the split TypeScript runtime.
@@ -138,4 +138,3 @@ Production deployment proof after #832:
 - `launchctl kickstart -k gui/501/com.friday.hub`
 - `/health` returned OK with version `1.0.3`
 - `com.friday.hub` was running with last exit code 0
-

--- a/rust-core/crates/friday-storage/src/lib.rs
+++ b/rust-core/crates/friday-storage/src/lib.rs
@@ -854,6 +854,46 @@ impl Db {
         )
     }
 
+    pub fn veto_route_decision(
+        &self,
+        decision_id: &str,
+        actor_ref: &str,
+        reason: &str,
+        now_ms: i64,
+    ) -> Result<()> {
+        if self.profile != Profile::Hub {
+            return Err(StorageError::Unsupported(
+                "Route decision controls are Hub-only".into(),
+            ));
+        }
+        mission::veto_route_decision(&self.conn, decision_id, actor_ref, reason, now_ms)
+    }
+
+    pub fn override_route_decision(
+        &self,
+        decision_id: &str,
+        override_lane: friday_core::WorkLane,
+        override_provider_or_agent: Option<&str>,
+        actor_ref: &str,
+        reason: &str,
+        now_ms: i64,
+    ) -> Result<()> {
+        if self.profile != Profile::Hub {
+            return Err(StorageError::Unsupported(
+                "Route decision controls are Hub-only".into(),
+            ));
+        }
+        mission::override_route_decision(
+            &self.conn,
+            decision_id,
+            override_lane,
+            override_provider_or_agent,
+            actor_ref,
+            reason,
+            now_ms,
+        )
+    }
+
     pub fn list_work_items_for_mission(&self, mission_id: &str) -> Result<Vec<WorkItem>> {
         if self.profile != Profile::Hub {
             return Err(StorageError::Unsupported("WorkItems are Hub-only".into()));

--- a/rust-core/crates/friday-storage/src/mission.rs
+++ b/rust-core/crates/friday-storage/src/mission.rs
@@ -32,6 +32,15 @@ fn require_non_empty(value: &str, field: &str) -> Result<()> {
     }
 }
 
+#[derive(Debug)]
+struct ActiveRouteDecisionControl {
+    decision_id: String,
+    control_kind: String,
+    override_lane: Option<WorkLane>,
+    override_provider_or_agent: Option<String>,
+    reason: String,
+}
+
 fn encode_vec(values: &[String], field: &str) -> Result<String> {
     serde_json::to_string(values)
         .map_err(|e| unsupported(format!("failed to encode {field} as json: {e}")))
@@ -960,6 +969,49 @@ fn transition_work_item_status_inner(
         // The audit row IS the WorkItem's lifecycle entry — it carries actor, the
         // from->to hop, and the reason (a WorkItem has no decision_path_summary column).
         let tx = conn.unchecked_transaction()?;
+        if previous_status == WorkItemStatus::ReadyToDispatch
+            && item.status == WorkItemStatus::Dispatched
+        {
+            if let Some(control) = active_route_decision_control_for_work_item(&tx, work_item_id)? {
+                match control.control_kind.as_str() {
+                    "veto" => {
+                        return Err(unsupported(format!(
+                            "route_decision_veto_active:{}:{}",
+                            control.decision_id, control.reason
+                        )));
+                    }
+                    "override" => {
+                        let Some(override_lane) = control.override_lane else {
+                            return Err(unsupported(format!(
+                                "route_decision_override_missing_lane:{}",
+                                control.decision_id
+                            )));
+                        };
+                        item.lane = override_lane;
+                        item.target_provider_or_agent = control.override_provider_or_agent.clone();
+                        crate::audit::append_audit(
+                            &tx,
+                            &format!(
+                                "route_decision_override_applied:{work_item_id}:{}",
+                                control.decision_id
+                            ),
+                            actor_ref,
+                            &format!(
+                                "route_decision.override_applied:{}:{}",
+                                control.decision_id, control.reason
+                            ),
+                            Some(work_item_id),
+                            now_ms,
+                        )?;
+                    }
+                    other => {
+                        return Err(unsupported(format!(
+                            "unknown route_decision_control kind '{other}'"
+                        )));
+                    }
+                }
+            }
+        }
         let audit_id = format!("workitem_lifecycle:{work_item_id}:{now_ms}");
         let action = format!(
             "work_item.lifecycle:{}->{}:{}",
@@ -993,6 +1045,172 @@ fn transition_work_item_status_inner(
 
         Ok((item, previous_status))
     })
+}
+
+pub fn veto_route_decision(
+    conn: &Connection,
+    decision_id: &str,
+    actor_ref: &str,
+    reason: &str,
+    now_ms: i64,
+) -> Result<()> {
+    record_route_decision_control(
+        conn,
+        decision_id,
+        "veto",
+        None,
+        None,
+        actor_ref,
+        reason,
+        now_ms,
+    )
+}
+
+pub fn override_route_decision(
+    conn: &Connection,
+    decision_id: &str,
+    override_lane: WorkLane,
+    override_provider_or_agent: Option<&str>,
+    actor_ref: &str,
+    reason: &str,
+    now_ms: i64,
+) -> Result<()> {
+    record_route_decision_control(
+        conn,
+        decision_id,
+        "override",
+        Some(override_lane),
+        override_provider_or_agent,
+        actor_ref,
+        reason,
+        now_ms,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn record_route_decision_control(
+    conn: &Connection,
+    decision_id: &str,
+    control_kind: &str,
+    override_lane: Option<WorkLane>,
+    override_provider_or_agent: Option<&str>,
+    actor_ref: &str,
+    reason: &str,
+    now_ms: i64,
+) -> Result<()> {
+    require_non_empty(decision_id, "route_decision_control.decision_id")?;
+    require_non_empty(actor_ref, "route_decision_control.actor_ref")?;
+    require_non_empty(reason, "route_decision_control.reason")?;
+    if control_kind == "veto" {
+        if override_lane.is_some() || override_provider_or_agent.is_some() {
+            return Err(unsupported(
+                "route_decision_control veto cannot carry override target",
+            ));
+        }
+    } else if control_kind == "override" {
+        if let Some(target) = override_provider_or_agent {
+            require_non_empty(target, "route_decision_control.override_provider_or_agent")?;
+        }
+        if override_lane.is_none() {
+            return Err(unsupported(
+                "route_decision_control override requires override_lane",
+            ));
+        }
+    } else {
+        return Err(unsupported(format!(
+            "unknown route_decision_control kind '{control_kind}'"
+        )));
+    }
+
+    crate::with_busy_retry(|| {
+        let (mission_id, work_item_id): (String, String) = conn
+            .query_row(
+                "SELECT mission_id, work_item_id FROM route_decision WHERE decision_id = ?1",
+                [decision_id],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .optional()?
+            .ok_or_else(|| {
+                unsupported(format!(
+                    "route_decision_control points to unknown route_decision '{decision_id}'"
+                ))
+            })?;
+        let tx = conn.unchecked_transaction()?;
+        tx.execute(
+            "INSERT INTO route_decision_control
+                (decision_id, mission_id, work_item_id, control_kind, override_lane,
+                 override_provider_or_agent, actor_ref, reason, active, created_at_ms)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, 1, ?9)
+             ON CONFLICT(decision_id) DO UPDATE SET
+                mission_id = excluded.mission_id,
+                work_item_id = excluded.work_item_id,
+                control_kind = excluded.control_kind,
+                override_lane = excluded.override_lane,
+                override_provider_or_agent = excluded.override_provider_or_agent,
+                actor_ref = excluded.actor_ref,
+                reason = excluded.reason,
+                active = 1,
+                created_at_ms = excluded.created_at_ms",
+            params![
+                decision_id,
+                mission_id,
+                work_item_id,
+                control_kind,
+                override_lane.map(|lane| lane.as_str().to_string()),
+                override_provider_or_agent,
+                actor_ref,
+                reason,
+                now_ms,
+            ],
+        )?;
+        crate::audit::append_audit(
+            &tx,
+            &format!("route_decision_control:{decision_id}:{now_ms}"),
+            actor_ref,
+            &format!("route_decision.{control_kind}:{decision_id}:{reason}"),
+            Some(&work_item_id),
+            now_ms,
+        )?;
+        tx.commit()?;
+        Ok(())
+    })
+}
+
+fn active_route_decision_control_for_work_item(
+    conn: &Connection,
+    work_item_id: &str,
+) -> Result<Option<ActiveRouteDecisionControl>> {
+    conn.query_row(
+        "SELECT decision_id, control_kind, override_lane, override_provider_or_agent, reason
+           FROM route_decision_control
+          WHERE work_item_id = ?1 AND active = 1
+          ORDER BY created_at_ms DESC, decision_id DESC
+          LIMIT 1",
+        [work_item_id],
+        |r| {
+            Ok((
+                r.get::<_, String>(0)?,
+                r.get::<_, String>(1)?,
+                r.get::<_, Option<String>>(2)?,
+                r.get::<_, Option<String>>(3)?,
+                r.get::<_, String>(4)?,
+            ))
+        },
+    )
+    .optional()?
+    .map(
+        |(decision_id, control_kind, override_lane, override_provider_or_agent, reason)| {
+            let override_lane = override_lane.map(parse_work_lane).transpose()?;
+            Ok(ActiveRouteDecisionControl {
+                decision_id,
+                control_kind,
+                override_lane,
+                override_provider_or_agent,
+                reason,
+            })
+        },
+    )
+    .transpose()
 }
 
 pub fn list_missions_for_conversation(

--- a/rust-core/crates/friday-storage/src/retention.rs
+++ b/rust-core/crates/friday-storage/src/retention.rs
@@ -30,10 +30,11 @@
 //!   2. **FK-safe parent deletes (no orphans, no FK crash).** `mission` and `work_item` are
 //!      RESTRICT-referenced (no `ON DELETE CASCADE`) by child tables and `foreign_keys` is ON on
 //!      every connection. `mission` is referenced by `work_item`, `surface_event`,
-//!      `surface_thread`, `mission_link`, `route_decision`, `workspace_claim`, `process_lease`;
-//!      `work_item` is referenced by `surface_event`, `mission_link`, `route_decision`,
-//!      `workspace_claim`, `process_lease`. (`process_observation` reaches them only TRANSITIVELY
-//!      via `workspace_claim`, so it is not a direct guard; and the v1 `mission_link` was rebuilt
+//!      `surface_thread`, `mission_link`, `route_decision`, `route_decision_control`,
+//!      `workspace_claim`, `process_lease`; `work_item` is referenced by `surface_event`,
+//!      `mission_link`, `route_decision`, `route_decision_control`, `workspace_claim`,
+//!      `process_lease`. (`process_observation` reaches them only TRANSITIVELY via
+//!      `workspace_claim`, so it is not a direct guard; and the v1 `mission_link` was rebuilt
 //!      then RENAMED from `mission_link_new`, so `mission_link` is the live child table.) A
 //!      parent DELETE while ANY child still references it would FAIL the FK constraint. So a
 //!      parent is deleted ONLY when NO surviving child references it (a `NOT EXISTS` guard across
@@ -217,6 +218,7 @@ pub fn sweep_retention(
                  AND NOT EXISTS (SELECT 1 FROM surface_event  c WHERE c.work_item_id = w.work_item_id)
                  AND NOT EXISTS (SELECT 1 FROM mission_link    c WHERE c.work_item_id = w.work_item_id)
                  AND NOT EXISTS (SELECT 1 FROM route_decision  c WHERE c.work_item_id = w.work_item_id)
+                 AND NOT EXISTS (SELECT 1 FROM route_decision_control c WHERE c.work_item_id = w.work_item_id)
                  AND NOT EXISTS (SELECT 1 FROM workspace_claim c WHERE c.work_item_id = w.work_item_id)
                  AND NOT EXISTS (SELECT 1 FROM process_lease   c WHERE c.work_item_id = w.work_item_id)
                ORDER BY w.updated_at_ms LIMIT ?2
@@ -244,6 +246,7 @@ pub fn sweep_retention(
                  AND NOT EXISTS (SELECT 1 FROM surface_thread  c WHERE c.mission_id = m.mission_id)
                  AND NOT EXISTS (SELECT 1 FROM mission_link    c WHERE c.mission_id = m.mission_id)
                  AND NOT EXISTS (SELECT 1 FROM route_decision  c WHERE c.mission_id = m.mission_id)
+                 AND NOT EXISTS (SELECT 1 FROM route_decision_control c WHERE c.mission_id = m.mission_id)
                  AND NOT EXISTS (SELECT 1 FROM workspace_claim c WHERE c.mission_id = m.mission_id)
                  AND NOT EXISTS (SELECT 1 FROM process_lease   c WHERE c.mission_id = m.mission_id)
                ORDER BY m.updated_at_ms LIMIT ?2
@@ -667,6 +670,60 @@ mod tests {
         );
         assert!(!exists(&db, "work_item", "work_item_id", "w"));
         assert!(!exists(&db, "mission", "mission_id", "m"));
+    }
+
+    #[test]
+    fn route_decision_control_child_keeps_terminal_aged_parents_fk_safe() {
+        // Structural guard: route_decision_control is a direct FK child of BOTH mission and
+        // work_item. Even if a future caller inserts an unusual but FK-valid control row, the
+        // parent sweep must skip instead of relying on the route_decision guard alone.
+        let db = Db::open_hub(&tmp("rd-control-fk-safe")).unwrap();
+        let now = 2_000 * 24 * 60 * 60 * 1000_i64;
+        let w = RetentionWindows::default();
+        seed_conversation(&db, "fconv_1");
+        seed_mission(
+            &db,
+            "m_guarded",
+            "fconv_1",
+            "done",
+            now - MISSION_MAX_AGE_MS - 1,
+        );
+        seed_work_item(
+            &db,
+            "w_guarded",
+            "m_guarded",
+            "completed_with_proof",
+            now - WORK_ITEM_MAX_AGE_MS - 1,
+        );
+        seed_mission(&db, "m_route", "fconv_1", "active", now);
+        seed_work_item(&db, "w_route", "m_route", "provider_waiting", now);
+        db.conn()
+            .execute(
+                "INSERT INTO route_decision
+                    (decision_id, mission_id, work_item_id, selected_lane,
+                     selected_provider_or_agent, why_this_route, created_at_ms)
+                 VALUES ('rd_guard', 'm_route', 'w_route', 'codex', 'codex',
+                         'seed route decision for control FK guard', ?1)",
+                [now],
+            )
+            .unwrap();
+        db.conn()
+            .execute(
+                "INSERT INTO route_decision_control
+                    (decision_id, mission_id, work_item_id, control_kind, actor_ref, reason,
+                     active, created_at_ms)
+                 VALUES ('rd_guard', 'm_guarded', 'w_guarded', 'veto', 'operator:test',
+                         'retention guard proof', 1, ?1)",
+                [now],
+            )
+            .unwrap();
+
+        let out = sweep_retention(db.conn(), now, w);
+        assert_eq!(out.table_errors, 0, "guard skips instead of hitting FK");
+        assert_eq!(out.work_item_deleted, 0);
+        assert_eq!(out.mission_deleted, 0);
+        assert!(exists(&db, "work_item", "work_item_id", "w_guarded"));
+        assert!(exists(&db, "mission", "mission_id", "m_guarded"));
     }
 
     // --- flag-OFF parity is the CALLER's concern; here prove the empty/boundary behavior ---

--- a/rust-core/crates/friday-storage/src/schema.rs
+++ b/rust-core/crates/friday-storage/src/schema.rs
@@ -45,6 +45,7 @@ pub const HUB_ONLY_TABLES: &[&str] = &[
     "surface_event",
     "mission_link",
     "route_decision",
+    "route_decision_control",
     // Process Registry: Hub-owned workspace/process/port truth. Phone/channel
     // surfaces may see projections; only the Hub can own/control claims.
     "workspace_claim",
@@ -629,6 +630,15 @@ pub fn hub_migrations() -> Vec<Migration> {
             name: "trust_grant_run_usage",
             destructive: false,
             up: m0036_trust_grant_run_usage,
+        },
+        // D20 W1-S3: operator/user route veto and override are lifecycle
+        // controls, not decorative card fields. This Hub-only table is read at
+        // the ReadyToDispatch -> Dispatched persistence boundary.
+        Migration {
+            version: 37,
+            name: "route_decision_control",
+            destructive: false,
+            up: m0037_route_decision_control,
         },
     ]
 }
@@ -1704,6 +1714,34 @@ CREATE INDEX idx_route_decision_mission_created
 CREATE INDEX idx_route_decision_work_item_created
     ON route_decision(work_item_id, created_at_ms, decision_id);";
 
+const DDL_ROUTE_DECISION_CONTROL: &str = "
+CREATE TABLE route_decision_control (
+    decision_id                 TEXT PRIMARY KEY,
+    mission_id                  TEXT NOT NULL,
+    work_item_id                TEXT NOT NULL,
+    control_kind                TEXT NOT NULL CHECK(control_kind IN ('veto', 'override')),
+    override_lane               TEXT CHECK(override_lane IS NULL OR override_lane IN (
+        'friday_hub',
+        'codex',
+        'claude',
+        'deepseek',
+        'workflow',
+        'channel',
+        'human',
+        'future_api'
+    )),
+    override_provider_or_agent  TEXT,
+    actor_ref                   TEXT NOT NULL CHECK(length(trim(actor_ref)) > 0),
+    reason                      TEXT NOT NULL CHECK(length(trim(reason)) > 0),
+    active                      INTEGER NOT NULL DEFAULT 1 CHECK(active IN (0, 1)),
+    created_at_ms               INTEGER NOT NULL,
+    FOREIGN KEY(decision_id) REFERENCES route_decision(decision_id),
+    FOREIGN KEY(mission_id) REFERENCES mission(mission_id),
+    FOREIGN KEY(work_item_id) REFERENCES work_item(work_item_id)
+);
+CREATE INDEX idx_route_decision_control_work_item_active
+    ON route_decision_control(work_item_id, active, created_at_ms, decision_id);";
+
 const DDL_REBUILD_MISSION_LINK_WITH_ROUTE_DECISION: &str = "
 CREATE TABLE mission_link_new (
     link_id        TEXT PRIMARY KEY,
@@ -2469,4 +2507,8 @@ fn m0035_route_decision_action_items(tx: &Transaction) -> rusqlite::Result<()> {
 
 fn m0036_trust_grant_run_usage(tx: &Transaction) -> rusqlite::Result<()> {
     tx.execute_batch(DDL_TRUST_GRANT_RUN_USAGE)
+}
+
+fn m0037_route_decision_control(tx: &Transaction) -> rusqlite::Result<()> {
+    tx.execute_batch(DDL_ROUTE_DECISION_CONTROL)
 }

--- a/rust-core/crates/friday-storage/tests/work_item_lifecycle.rs
+++ b/rust-core/crates/friday-storage/tests/work_item_lifecycle.rs
@@ -12,7 +12,7 @@ mod common;
 use common::temp_db_path;
 use friday_core::{
     ApprovalState, FridayConversation, HandoffJudgmentMemory, Mission, MissionStatus, Risk,
-    TruthStatus, WorkItem, WorkItemStatus, WorkLane,
+    RouteDecisionCard, TruthStatus, WorkItem, WorkItemStatus, WorkLane,
 };
 use friday_storage::{Db, StorageError};
 use std::sync::{Mutex, MutexGuard};
@@ -133,6 +133,18 @@ fn seed(db: &Db, status: WorkItemStatus) {
     db.upsert_friday_conversation(&conversation()).unwrap();
     db.upsert_mission(&mission()).unwrap();
     db.upsert_work_item(&work_item(status)).unwrap();
+}
+
+fn seed_route_decision(db: &Db) {
+    let item = db.get_work_item("work-wi").unwrap().unwrap();
+    let card = RouteDecisionCard::from_work_item(
+        "route-decision-work-wi".into(),
+        &item,
+        vec!["friday://trace/route-decision-work-wi".into()],
+        2,
+        None,
+    );
+    db.upsert_route_decision(&card).unwrap();
 }
 
 #[test]
@@ -327,6 +339,86 @@ fn proof_receipt_on_a_non_completion_transition_is_rejected() {
     assert_eq!(
         db.get_work_item("work-wi").unwrap().unwrap().status,
         WorkItemStatus::Draft
+    );
+}
+
+#[test]
+fn route_decision_veto_blocks_ready_to_dispatched_lifecycle_hop() {
+    let db = Db::open_hub(&temp_db_path("wi-route-veto")).unwrap();
+    seed(&db, WorkItemStatus::ReadyToDispatch);
+    seed_route_decision(&db);
+
+    db.veto_route_decision(
+        "route-decision-work-wi",
+        "operator:jarvis",
+        "operator vetoed the proposed Codex route",
+        20,
+    )
+    .unwrap();
+
+    let err = db
+        .transition_work_item_status(
+            "work-wi",
+            WorkItemStatus::Dispatched,
+            "agent:friday",
+            "dispatch proposed route",
+            None,
+            21,
+        )
+        .unwrap_err();
+    assert!(
+        matches!(err, StorageError::Unsupported(ref message) if message.contains("route_decision_veto_active:route-decision-work-wi")),
+        "veto must fail closed at the dispatch lifecycle edge, got {err:?}"
+    );
+    let stored = db.get_work_item("work-wi").unwrap().unwrap();
+    assert_eq!(stored.status, WorkItemStatus::ReadyToDispatch);
+    assert_eq!(stored.lane, WorkLane::Codex);
+    assert_eq!(stored.target_provider_or_agent.as_deref(), Some("codex"));
+}
+
+#[test]
+fn route_decision_override_reassigns_before_dispatch_in_same_lifecycle_hop() {
+    let db = Db::open_hub(&temp_db_path("wi-route-override")).unwrap();
+    seed(&db, WorkItemStatus::ReadyToDispatch);
+    seed_route_decision(&db);
+
+    db.override_route_decision(
+        "route-decision-work-wi",
+        WorkLane::Claude,
+        Some("claude"),
+        "operator:jarvis",
+        "operator reassigned review-heavy work to Claude",
+        20,
+    )
+    .unwrap();
+
+    let (item, prev) = db
+        .transition_work_item_status(
+            "work-wi",
+            WorkItemStatus::Dispatched,
+            "agent:friday",
+            "dispatch with operator route override",
+            None,
+            21,
+        )
+        .unwrap();
+
+    assert_eq!(prev, WorkItemStatus::ReadyToDispatch);
+    assert_eq!(item.status, WorkItemStatus::Dispatched);
+    assert_eq!(item.lane, WorkLane::Claude);
+    assert_eq!(item.target_provider_or_agent.as_deref(), Some("claude"));
+
+    let override_audits: i64 = db
+        .conn()
+        .query_row(
+            "SELECT COUNT(*) FROM audit_ledger WHERE action LIKE 'route_decision.override_applied:%'",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(
+        override_audits, 1,
+        "override must be applied as a real audited pre-dispatch lifecycle control"
     );
 }
 

--- a/src/state/sqlite/friday-rust-hub-schema-handshake.ts
+++ b/src/state/sqlite/friday-rust-hub-schema-handshake.ts
@@ -6,7 +6,7 @@ import Database from "better-sqlite3";
 import { FridayDomainError } from "#errors";
 
 export const FRIDAY_HUB_AGENT_RUN_DB_PATH_ENV = "FRIDAY_HUB_AGENT_RUN_DB_PATH";
-export const FRIDAY_EXPECTED_RUST_HUB_SCHEMA_VERSION = 36;
+export const FRIDAY_EXPECTED_RUST_HUB_SCHEMA_VERSION = 37;
 
 export type FridayRustHubSchemaHandshakeStatus = "ok" | "skipped";
 


### PR DESCRIPTION
## Summary
- Adds the D20 W1-S3 build-DARK RouteDecisionCard control plane: a Hub-only `route_decision_control` table plus Db APIs for operator veto and override.
- Enforces controls at the real lifecycle boundary before `ReadyToDispatch -> Dispatched`: veto blocks dispatch; override reassigns lane/provider and writes audit before dispatch.
- Extends retention FK guards/tests so the new direct child table cannot make aged parent cleanup hit FK errors.

## Truth labels
- D20 W1-S3 mechanism only; built-DARK != live.
- This does not prove W1 live-done: no true dual-model dispatch/organic operator turn is claimed here.
- This does not touch operator signing keys, trust-dial TRUE operator loop, D16-D19 gate core, or rollback semantics. Friday still has no action rollback engine; reversible work is constrained worktree/git space only.

## Validation
- `cargo fmt --all -- --check`
- `cargo test -p friday-storage --test work_item_lifecycle -- --nocapture`
- `cargo test -p friday-storage retention -- --nocapture`
- `cargo test -p friday-storage --test migration`
- `cargo test -p friday-storage --test schema_profile`
- `git diff --check`
- `npm ci` then `npm run build`