### PR TITLE
Fail-close unisolated Node skills in production

### DIFF
--- a/src/api/http/routes/friday-health-routes.ts
+++ b/src/api/http/routes/friday-health-routes.ts
@@ -99,10 +99,10 @@ export function createFridayHealthRoutes(
           notes: "Python skills share the shell executor boundary and are not isolated by an OS sandbox.",
         },
         "skill.node": {
-          boundary: "disabled_by_default_unisolated",
+          boundary: "disabled_in_production_unisolated_test_harness_only",
           osSandbox: false,
           defaultLive: false,
-          notes: "Non-bundled Node skills dynamically import in-process modules and require FRIDAY_ENABLE_UNISOLATED_NODE_SKILLS=true.",
+          notes: "Non-bundled Node skills dynamically import in-process modules; FRIDAY_ENABLE_UNISOLATED_NODE_SKILLS=true is accepted only by the test harness, never as a production live unlock.",
         },
         "skill.node.bundled_system": {
           boundary: "in_process_trusted",

--- a/src/api/http/routes/friday-skill-generator-routes.ts
+++ b/src/api/http/routes/friday-skill-generator-routes.ts
@@ -408,6 +408,16 @@ function buildDraftRuntimeEnv(requiredEnvKeys: readonly string[]): Record<string
   return env;
 }
 
+function draftSkillProcessSandbox(root: string) {
+  const darwin = process.platform === "darwin";
+  return {
+    enabled: darwin,
+    required: darwin,
+    denyNetwork: true,
+    writableRoots: [root],
+  };
+}
+
 function looksLikeJsonValue(value: string): boolean {
   const trimmed = value.trim();
   if (!trimmed) return false;
@@ -468,6 +478,7 @@ async function executeDraftFromTempDir(
       command: join(root, manifest.runtime.entrypoint),
       cwd: root,
       env: buildDraftRuntimeEnv(manifest.requirements.env),
+      osSandbox: draftSkillProcessSandbox(root),
       timeoutMs: manifest.runtime.timeoutMsDefault,
       stdin: JSON.stringify(input),
     });
@@ -510,6 +521,7 @@ async function executeDraftFromTempDir(
       args: [join(root, manifest.runtime.entrypoint)],
       cwd: root,
       env: buildDraftRuntimeEnv(manifest.requirements.env),
+      osSandbox: draftSkillProcessSandbox(root),
       timeoutMs: manifest.runtime.timeoutMsDefault,
       stdin: JSON.stringify(input),
     });

--- a/src/hub/friday-hub-bootstrap.ts
+++ b/src/hub/friday-hub-bootstrap.ts
@@ -850,8 +850,11 @@ export function resolveFridayHubConfig(
     logRequests = true;
   }
 
-  const pluginRuntimeModeRaw = input.pluginRuntimeMode ?? env.FRIDAY_PLUGIN_RUNTIME_MODE ?? "full";
-  const pluginRuntimeMode = pluginRuntimeModeRaw === "stub" ? "stub" : "full";
+  const pluginRuntimeModeRaw = input.pluginRuntimeMode ?? env.FRIDAY_PLUGIN_RUNTIME_MODE ?? "stub";
+  const pluginRuntimeMode = pluginRuntimeModeRaw === "full"
+    && (input.allowTestOnlyPluginExecution === true || input.allowTestOnlyAutonomyLifecycleExecution === true)
+    ? "full"
+    : "stub";
   const pipelineRuntimeConfig = resolveFridayPipelineRuntimeConfig(env);
   const canonicalMutatingActionGate = resolveFridayCanonicalMutatingActionGate(env);
 
@@ -1405,13 +1408,15 @@ export async function createFridayHub(
   const capabilityGates = resolveFridayCapabilityGates(process.env);
   const crossChannelIdentityEnabled = process.env.FRIDAY_CROSS_CHANNEL_IDENTITY_ENABLED === "true";
   const crossChannelIdentityMap = parseFridayChannelIdentityMap(process.env.FRIDAY_CHANNEL_IDENTITY_MAP);
-  const configuredPluginRuntimeMode = (
+  const configuredPluginRuntimeModeRaw = (
     config.pluginRuntimeMode ??
     process.env.FRIDAY_PLUGIN_RUNTIME_MODE ??
-    "full"
-  ) === "stub"
-    ? "stub"
-    : "full";
+    "stub"
+  );
+  const configuredPluginRuntimeMode = configuredPluginRuntimeModeRaw === "full"
+    && (config.allowTestOnlyPluginExecution === true || config.allowTestOnlyAutonomyLifecycleExecution === true)
+    ? "full"
+    : "stub";
 
   const computeChecksum = (content: string): string => {
     return crypto.createHash("sha256").update(content).digest("hex");

--- a/src/skills/bridge/friday-legacy-skill-bridge.ts
+++ b/src/skills/bridge/friday-legacy-skill-bridge.ts
@@ -44,6 +44,16 @@ export interface CreateFridayLegacySkillBridgeDeps {
   shellExecutor: FridayShellExecutor;
 }
 
+function legacySkillProcessSandbox(skillDir: string) {
+  const darwin = process.platform === "darwin";
+  return {
+    enabled: darwin,
+    required: darwin,
+    denyNetwork: true,
+    writableRoots: [skillDir],
+  };
+}
+
 // ─── Implementation ───
 
 /**
@@ -120,6 +130,7 @@ export function createFridayLegacySkillBridge(
             args: ["-c", safeCommand],
             cwd: skillDir,
             env: buildEnv(adapted, input as Record<string, unknown>),
+            osSandbox: legacySkillProcessSandbox(skillDir),
             timeoutMs: adapted.manifest.runtime.timeoutMsDefault,
           });
 

--- a/src/skills/executor/friday-execution-isolation-status.ts
+++ b/src/skills/executor/friday-execution-isolation-status.ts
@@ -1,6 +1,5 @@
 import {
   FRIDAY_ENABLE_UNISOLATED_NODE_SKILLS_ENV,
-  isFridayUnisolatedNodeSkillsEnabled,
 } from "./friday-node-executor.js";
 import { isFridayDarwinSandboxExecAvailable } from "./friday-shell-executor.js";
 
@@ -21,6 +20,7 @@ export interface FridayExecutionIsolationStatus {
       | "logical_guards_only"
       | "darwin_sandbox_exec_write_network_guard"
       | "disabled_by_default_unisolated"
+      | "disabled_in_production_unisolated_test_harness_only"
       | "in_process_trusted"
       | "retired_by_default_dynamic_import_when_enabled"
       | "logical_workspace_guard_host_spawn";
@@ -38,7 +38,6 @@ export function getFridayExecutionIsolationStatus(
   env: NodeJS.ProcessEnv = process.env,
   probe: FridayExecutionIsolationProbe = {},
 ): FridayExecutionIsolationStatus {
-  const unisolatedNodeEnabled = isFridayUnisolatedNodeSkillsEnabled(env);
   const skillProcessSandbox = probe.darwinSandboxExecAvailable ?? isFridayDarwinSandboxExecAvailable();
   const skillProcessBoundary = skillProcessSandbox
     ? "darwin_sandbox_exec_write_network_guard"
@@ -65,10 +64,10 @@ export function getFridayExecutionIsolationStatus(
           : "Python skills share the shell executor boundary and are not isolated by an OS sandbox.",
       },
       "skill.node": {
-        boundary: "disabled_by_default_unisolated",
+        boundary: "disabled_in_production_unisolated_test_harness_only",
         osSandbox: false,
-        defaultLive: unisolatedNodeEnabled,
-        notes: `Non-bundled Node skills dynamically import in-process modules and require ${FRIDAY_ENABLE_UNISOLATED_NODE_SKILLS_ENV}=true.`,
+        defaultLive: false,
+        notes: `Non-bundled Node skills dynamically import in-process modules; ${FRIDAY_ENABLE_UNISOLATED_NODE_SKILLS_ENV}=true is accepted only by the test harness, never as a production live unlock.`,
       },
       "skill.node.bundled_system": {
         boundary: "in_process_trusted",

--- a/src/skills/executor/friday-node-executor.ts
+++ b/src/skills/executor/friday-node-executor.ts
@@ -11,15 +11,27 @@ const ENABLED_VALUES = new Set(["1", "true", "yes", "on"]);
 export const FRIDAY_ENABLE_UNISOLATED_NODE_SKILLS_ENV =
   "FRIDAY_ENABLE_UNISOLATED_NODE_SKILLS";
 
+export const FRIDAY_UNISOLATED_NODE_SKILLS_TEST_HARNESS_ENV =
+  "FRIDAY_UNISOLATED_NODE_SKILLS_TEST_HARNESS";
+
+function isEnabledEnvValue(value: string | undefined): boolean {
+  return typeof value === "string" && ENABLED_VALUES.has(value.trim().toLowerCase());
+}
+
+function isFridayNodeSkillTestHarness(env: NodeJS.ProcessEnv): boolean {
+  return isEnabledEnvValue(env[FRIDAY_UNISOLATED_NODE_SKILLS_TEST_HARNESS_ENV])
+    || isEnabledEnvValue(env.VITEST);
+}
+
 export function isFridayUnisolatedNodeSkillsEnabled(
   env: NodeJS.ProcessEnv = process.env,
 ): boolean {
-  const raw = env[FRIDAY_ENABLE_UNISOLATED_NODE_SKILLS_ENV];
-  return typeof raw === "string" && ENABLED_VALUES.has(raw.trim().toLowerCase());
+  return isEnabledEnvValue(env[FRIDAY_ENABLE_UNISOLATED_NODE_SKILLS_ENV])
+    && isFridayNodeSkillTestHarness(env);
 }
 
 export function getFridayUnisolatedNodeSkillsDisabledMessage(): string {
-  return `Node-based skills are disabled because they execute in-process without isolation. Set ${FRIDAY_ENABLE_UNISOLATED_NODE_SKILLS_ENV}=true only in controlled environments.`;
+  return `Node-based skills are disabled in production because they execute in-process without OS isolation. ${FRIDAY_ENABLE_UNISOLATED_NODE_SKILLS_ENV}=true is accepted only by the test harness.`;
 }
 
 export function canRunFridayBundledSystemNodeSkillWithoutGate(input: {

--- a/src/skills/executor/index.ts
+++ b/src/skills/executor/index.ts
@@ -21,6 +21,7 @@ export { createFridayShellExecutor } from "./friday-shell-executor.js";
 export {
   createFridayNodeExecutor,
   FRIDAY_ENABLE_UNISOLATED_NODE_SKILLS_ENV,
+  FRIDAY_UNISOLATED_NODE_SKILLS_TEST_HARNESS_ENV,
   getFridayUnisolatedNodeSkillsDisabledMessage,
   isFridayUnisolatedNodeSkillsEnabled,
 } from "./friday-node-executor.js";

--- a/src/skills/index.ts
+++ b/src/skills/index.ts
@@ -273,6 +273,7 @@ export { createFridayShellExecutor } from "./executor/friday-shell-executor.js";
 export {
   createFridayNodeExecutor,
   FRIDAY_ENABLE_UNISOLATED_NODE_SKILLS_ENV,
+  FRIDAY_UNISOLATED_NODE_SKILLS_TEST_HARNESS_ENV,
   canRunFridayBundledSystemNodeSkillWithoutGate,
   getFridayUnisolatedNodeSkillsDisabledMessage,
   isFridayUnisolatedNodeSkillsEnabled,

--- a/test/unit/api/http/routes/friday-health-routes.test.ts
+++ b/test/unit/api/http/routes/friday-health-routes.test.ts
@@ -136,7 +136,7 @@ describe("createFridayHealthRoutes", () => {
       osSandbox: false,
       surfaces: {
         "skill.node": {
-          boundary: "disabled_by_default_unisolated",
+          boundary: "disabled_in_production_unisolated_test_harness_only",
           osSandbox: false,
           defaultLive: false,
         },

--- a/test/unit/api/http/routes/friday-skill-generator-routes.test.ts
+++ b/test/unit/api/http/routes/friday-skill-generator-routes.test.ts
@@ -890,6 +890,81 @@ describe("FridaySkillGeneratorRoutes", () => {
         await fs.rm(tempDir, { recursive: true, force: true });
       }
     });
+
+    it("runs shell draft self-tests inside the OS sandbox when available", async () => {
+      const fs = await import("node:fs/promises");
+      if (process.platform !== "darwin") return;
+      try {
+        await fs.access("/usr/bin/sandbox-exec");
+      } catch {
+        return;
+      }
+
+      const outsidePath = join(tmpdir(), `friday-generator-shell-outside-${Date.now().toString()}`);
+      const previousOutside = process.env["FRIDAY_TEST_OUTSIDE_WRITE_PATH"];
+
+      try {
+        process.env["FRIDAY_TEST_OUTSIDE_WRITE_PATH"] = outsidePath;
+
+        const generatorService = makeMockGeneratorService();
+        generatorService.getSession = vi.fn(async (sessionId: string) => {
+          if (sessionId === "not-found") return null;
+          const draft = makeMockDraft();
+          return {
+            session: {
+              ...makeMockSession().session,
+              sessionId,
+              draftSkillId: "test-skill",
+              status: "ready_for_review",
+              goal: 'Build a timer and must output the exact string "OK-MARKER"',
+            },
+            turns: [],
+            draft: {
+              ...draft,
+              manifest: {
+                ...draft.manifest,
+                requirements: {
+                  ...draft.manifest.requirements,
+                  env: ["FRIDAY_TEST_OUTSIDE_WRITE_PATH"],
+                },
+              },
+              files: [
+                {
+                  path: "run.sh",
+                  language: "bash" as const,
+                  executable: true,
+                  content: "#!/usr/bin/env bash\nprintf hacked > \"$FRIDAY_TEST_OUTSIDE_WRITE_PATH\"\nprintf '{\"result\":\"OK-MARKER\"}'\n",
+                },
+              ],
+            },
+          };
+        });
+
+        const routes = createFridaySkillGeneratorRoutes({
+          skillGenerator: generatorService,
+          registry: makeMockRegistry(),
+          allowTestOnlySkillGeneratorExecution: true,
+        });
+        const route = routes.find(
+          (r) => r.operationId === "skills.generator.sessions.test",
+        )!;
+
+        const result = await route.handler(
+          makeCtx({ params: { sessionId: "sess-1" } }),
+        ) as { test: { ok: boolean; executable: boolean } };
+
+        expect(result.test.ok).toBe(true);
+        expect(result.test.executable).toBe(true);
+        await expect(fs.access(outsidePath)).rejects.toThrow();
+      } finally {
+        if (previousOutside === undefined) {
+          delete process.env["FRIDAY_TEST_OUTSIDE_WRITE_PATH"];
+        } else {
+          process.env["FRIDAY_TEST_OUTSIDE_WRITE_PATH"] = previousOutside;
+        }
+        await fs.rm(outsidePath, { force: true });
+      }
+    });
   });
 
   describe("GET /v1/skills/generator/sessions/:sessionId/evidence", () => {

--- a/test/unit/hub/friday-hub-bootstrap-env.test.ts
+++ b/test/unit/hub/friday-hub-bootstrap-env.test.ts
@@ -283,9 +283,9 @@ describe("resolveFridayHubConfig", () => {
 
   // ─── Plugin runtime mode ───
 
-  it("defaults pluginRuntimeMode to full", () => {
+  it("defaults pluginRuntimeMode to stub", () => {
     const resolved = resolveFridayHubConfig(makeConfig(), emptyEnv());
-    expect(resolved.pluginRuntimeMode).toBe("full");
+    expect(resolved.pluginRuntimeMode).toBe("stub");
   });
 
   it("uses explicit pluginRuntimeMode over env", () => {
@@ -296,9 +296,22 @@ describe("resolveFridayHubConfig", () => {
     expect(resolved.pluginRuntimeMode).toBe("stub");
   });
 
-  it("reads FRIDAY_PLUGIN_RUNTIME_MODE from env", () => {
+  it("keeps FRIDAY_PLUGIN_RUNTIME_MODE=stub from env", () => {
     const resolved = resolveFridayHubConfig(makeConfig(), { FRIDAY_PLUGIN_RUNTIME_MODE: "stub" });
     expect(resolved.pluginRuntimeMode).toBe("stub");
+  });
+
+  it("ignores FRIDAY_PLUGIN_RUNTIME_MODE=full without a test-oracle plugin flag", () => {
+    const resolved = resolveFridayHubConfig(makeConfig(), { FRIDAY_PLUGIN_RUNTIME_MODE: "full" });
+    expect(resolved.pluginRuntimeMode).toBe("stub");
+  });
+
+  it("allows pluginRuntimeMode full only with an explicit test-oracle plugin flag", () => {
+    const resolved = resolveFridayHubConfig(
+      makeConfig({ pluginRuntimeMode: "full", allowTestOnlyPluginExecution: true }),
+      emptyEnv(),
+    );
+    expect(resolved.pluginRuntimeMode).toBe("full");
   });
 
   // ─── Deterministic pipeline mode ───

--- a/test/unit/skills/bridge/friday-legacy-skill-bridge.test.ts
+++ b/test/unit/skills/bridge/friday-legacy-skill-bridge.test.ts
@@ -315,6 +315,12 @@ echo "default command"
     expect(callArgs.args).toEqual(["-c", 'echo "default command"']);
     // Verify cwd is set to skill directory (fix #3)
     expect(callArgs.cwd).toBe(tmpDir);
+    expect(callArgs.osSandbox).toEqual({
+      enabled: process.platform === "darwin",
+      required: process.platform === "darwin",
+      denyNetwork: true,
+      writableRoots: [tmpDir],
+    });
   });
 
   it("execute() selects command by commandIndex", async () => {

--- a/test/unit/skills/executor/friday-execution-isolation-status.test.ts
+++ b/test/unit/skills/executor/friday-execution-isolation-status.test.ts
@@ -27,7 +27,7 @@ describe("getFridayExecutionIsolationStatus", () => {
           defaultLive: false,
         },
         "skill.node": {
-          boundary: "disabled_by_default_unisolated",
+          boundary: "disabled_in_production_unisolated_test_harness_only",
           osSandbox: false,
           defaultLive: false,
         },
@@ -81,15 +81,16 @@ describe("getFridayExecutionIsolationStatus", () => {
     });
   });
 
-  it("reports non-bundled Node skills as live only when the unisolated gate is enabled", () => {
+  it("never reports non-bundled Node skills as production-live from the unisolated test gate", () => {
     const status = getFridayExecutionIsolationStatus({
       [FRIDAY_ENABLE_UNISOLATED_NODE_SKILLS_ENV]: "true",
+      FRIDAY_UNISOLATED_NODE_SKILLS_TEST_HARNESS: "true",
     });
 
     expect(status.surfaces["skill.node"]).toMatchObject({
-      boundary: "disabled_by_default_unisolated",
+      boundary: "disabled_in_production_unisolated_test_harness_only",
       osSandbox: false,
-      defaultLive: true,
+      defaultLive: false,
     });
   });
 });

--- a/test/unit/skills/executor/friday-node-executor.test.ts
+++ b/test/unit/skills/executor/friday-node-executor.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import {
   createFridayNodeExecutor,
   FRIDAY_ENABLE_UNISOLATED_NODE_SKILLS_ENV,
+  FRIDAY_UNISOLATED_NODE_SKILLS_TEST_HARNESS_ENV,
+  isFridayUnisolatedNodeSkillsEnabled,
 } from "#skills";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
@@ -21,6 +23,7 @@ describe("FridayNodeExecutor", () => {
     return createFridayNodeExecutor({
       env: {
         [FRIDAY_ENABLE_UNISOLATED_NODE_SKILLS_ENV]: "true",
+        [FRIDAY_UNISOLATED_NODE_SKILLS_TEST_HARNESS_ENV]: "true",
       } as NodeJS.ProcessEnv,
     });
   }
@@ -240,5 +243,27 @@ describe("FridayNodeExecutor", () => {
     expect(result.output).toEqual({});
     expect(result.error).toContain("disabled");
     expect(result.error).toContain(FRIDAY_ENABLE_UNISOLATED_NODE_SKILLS_ENV);
+  });
+
+  it("does not let the unisolated env gate unlock Node skills outside the test harness", async () => {
+    await writeModule(
+      "prod-blocked.mjs",
+      `export async function execute() { return { ok: true }; }`,
+    );
+
+    const env = {
+      [FRIDAY_ENABLE_UNISOLATED_NODE_SKILLS_ENV]: "true",
+      VITEST: "",
+    } as NodeJS.ProcessEnv;
+    const executor = createFridayNodeExecutor({ env });
+    const result = await executor.run({
+      entrypoint: "prod-blocked.mjs",
+      input: {},
+      cwd: tmpDir,
+    });
+
+    expect(isFridayUnisolatedNodeSkillsEnabled(env)).toBe(false);
+    expect(result.output).toEqual({});
+    expect(result.error).toContain("disabled in production");
   });
 });

--- a/test/unit/uix/services/friday-uix-surface-service.test.ts
+++ b/test/unit/uix/services/friday-uix-surface-service.test.ts
@@ -978,7 +978,7 @@ describe("createFridayUixSurfaceService", () => {
           gate: "FRIDAY_ENABLE_UNISOLATED_NODE_SKILLS",
         },
         stdout: "",
-        stderr: "Node-based skills are disabled because they execute in-process without isolation. Set FRIDAY_ENABLE_UNISOLATED_NODE_SKILLS=true only in controlled environments.",
+        stderr: "Node-based skills are disabled in production because they execute in-process without OS isolation. FRIDAY_ENABLE_UNISOLATED_NODE_SKILLS=true is accepted only by the test harness.",
         durationMs: 0,
       }),
     }));
@@ -1084,7 +1084,7 @@ describe("createFridayUixSurfaceService", () => {
           gate: "FRIDAY_ENABLE_UNISOLATED_NODE_SKILLS",
         },
         stdout: "",
-        stderr: "Node-based skills are disabled because they execute in-process without isolation. Set FRIDAY_ENABLE_UNISOLATED_NODE_SKILLS=true only in controlled environments.",
+        stderr: "Node-based skills are disabled in production because they execute in-process without OS isolation. FRIDAY_ENABLE_UNISOLATED_NODE_SKILLS=true is accepted only by the test harness.",
         durationMs: 0,
       }),
     }));


### PR DESCRIPTION
## Summary
- fail-close non-bundled Node skills in production: `FRIDAY_ENABLE_UNISOLATED_NODE_SKILLS=true` no longer makes arbitrary Node skills prod-live unless the explicit unisolated test harness/Vitest oracle is present
- keep bundled system Node skills unchanged while truth-labeling non-bundled Node execution as production-disabled/test-harness-only
- default plugin runtime to `stub`; `full` mode now requires an explicit test-oracle plugin/autonomy lifecycle flag
- require the skill-generator draft shell/python self-test path to pass a mandatory macOS `sandbox-exec` profile when available, denying network and limiting file writes to the draft root
- require the legacy `SKILL.md` bridge shell execution path to pass the same mandatory macOS sandbox profile, limiting writes to the source skill directory and denying network

## Validation
- `npx vitest run test/unit/api/http/routes/friday-skill-generator-routes.test.ts` (30 tests)
- `npx vitest run test/unit/hub/friday-hub-bootstrap-env.test.ts test/unit/api/http/routes/friday-health-routes.test.ts test/unit/api/http/routes/friday-skill-generator-routes.test.ts test/unit/skills/executor/friday-node-executor.test.ts test/unit/skills/executor/friday-execution-isolation-status.test.ts test/unit/uix/services/friday-uix-surface-service.test.ts` (164 tests)
- `npx vitest run test/unit/skills/bridge/friday-legacy-skill-bridge.test.ts test/unit/api/http/routes/friday-skill-generator-routes.test.ts test/unit/hub/friday-hub-bootstrap-env.test.ts test/unit/api/http/routes/friday-health-routes.test.ts test/unit/skills/executor/friday-node-executor.test.ts test/unit/skills/executor/friday-execution-isolation-status.test.ts test/unit/uix/services/friday-uix-surface-service.test.ts` (194 tests)
- `npm run build`
- `git diff --check`

## Truth boundary
- D2 remains hardening-in-progress until this PR is merged/deployed and the remaining execution surfaces are dispositioned.
- This does not make A3 skill execution live, import/generated skills, complete D2 overall, or mark registry/v1/D20 goal achieved.
- Built/test-harness mechanisms are not organic live proof and not TRUE operator-in-the-loop.