### PR TITLE
Fail-close bundled Node skill runtime

### DIFF
--- a/src/agent/tools/friday-agent-skill-tool.ts
+++ b/src/agent/tools/friday-agent-skill-tool.ts
@@ -1,7 +1,6 @@
 import type { FridayAgentToolDefinition, FridayAgentToolResult } from "../model/friday-agent.types.js";
 import { FridayDomainError } from "#errors";
 import {
-  canRunFridayBundledSystemNodeSkillWithoutGate,
   evaluateFridaySkillExecutionReadiness,
   FRIDAY_ENABLE_UNISOLATED_NODE_SKILLS_ENV,
   type FridaySkillExecuteRequest,
@@ -184,15 +183,8 @@ export function createFridayAgentSkillTool(
         const runtimeReadiness = evaluateFridaySkillExecutionReadiness({
           manifest: registeredSkill.manifest,
         });
-        const allowBundledSystemNodeSkill = canRunFridayBundledSystemNodeSkillWithoutGate({
-          runtimeKind: registeredSkill.manifest.runtime.kind,
-          manifestKind: registeredSkill.manifest.kind,
-          source: registeredSkill.source,
-          origin: registeredSkill.origin,
-        });
         const nodeRuntimeBlocked =
           registeredSkill.manifest.runtime.kind === "node"
-          && !allowBundledSystemNodeSkill
           && !isFridayUnisolatedNodeSkillsEnabled();
         if (nodeRuntimeBlocked) {
           return jsonResult({

--- a/src/agent/tools/friday-agent-skills-list-tool.ts
+++ b/src/agent/tools/friday-agent-skills-list-tool.ts
@@ -1,5 +1,4 @@
 import {
-  canRunFridayBundledSystemNodeSkillWithoutGate,
   evaluateFridaySkillExecutionReadiness,
   FRIDAY_ENABLE_UNISOLATED_NODE_SKILLS_ENV,
   type FridayRegisteredSkill,
@@ -120,15 +119,8 @@ export function createFridayAgentSkillsListTool(
             const runtimeReadiness = evaluateFridaySkillExecutionReadiness({
               manifest: skill.manifest,
             });
-            const allowBundledSystemNodeSkill = canRunFridayBundledSystemNodeSkillWithoutGate({
-              runtimeKind: skill.manifest.runtime.kind,
-              manifestKind: skill.manifest.kind,
-              source: skill.source,
-              origin: skill.origin,
-            });
             const nodeRuntimeBlocked =
               skill.manifest.runtime.kind === "node"
-              && !allowBundledSystemNodeSkill
               && !isFridayUnisolatedNodeSkillsEnabled();
             const lifecycleBlocked = lifecycleStatus !== "installed";
             const blockers = [

--- a/src/api/http/routes/friday-health-routes.ts
+++ b/src/api/http/routes/friday-health-routes.ts
@@ -105,10 +105,10 @@ export function createFridayHealthRoutes(
           notes: "Non-bundled Node skills dynamically import in-process modules; FRIDAY_ENABLE_UNISOLATED_NODE_SKILLS=true is accepted only by the test harness, never as a production live unlock.",
         },
         "skill.node.bundled_system": {
-          boundary: "in_process_trusted",
+          boundary: "disabled_in_production_unisolated_test_harness_only",
           osSandbox: false,
-          defaultLive: true,
-          notes: "Bundled system Node skills may run without the unisolated env gate, but still execute in the hub process.",
+          defaultLive: false,
+          notes: "Bundled system Node skills are also disabled in production because they dynamically import in-process modules without OS isolation; FRIDAY_ENABLE_UNISOLATED_NODE_SKILLS=true is accepted only by the test harness.",
         },
         "plugin.entrypoint": {
           boundary: "retired_by_default_dynamic_import_when_enabled",

--- a/src/api/http/routes/friday-skill-routes.ts
+++ b/src/api/http/routes/friday-skill-routes.ts
@@ -10,7 +10,6 @@ import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import type { FridayAuthPrincipal, FridayRouteDefinition } from "../../model/friday-api-common.types.js";
 import {
-  canRunFridayBundledSystemNodeSkillWithoutGate,
   createFridaySkillRunMutatingActionRequest,
   evaluateFridaySkillExecutionReadiness,
   FRIDAY_ENABLE_UNISOLATED_NODE_SKILLS_ENV,
@@ -953,15 +952,7 @@ export function createFridaySkillRoutes(
           );
         }
       }
-      const allowBundledSystemNodeSkill = canRunFridayBundledSystemNodeSkillWithoutGate({
-        runtimeKind,
-        manifestKind: registeredSkill?.manifest.kind
-          ?? lifecycleSkill?.currentManifest?.kind
-          ?? lifecycleSkill?.catalogEntry?.manifest?.kind,
-        source: registeredSkill?.source,
-        origin: registeredSkill?.origin,
-      });
-      if (runtimeKind === "node" && !allowBundledSystemNodeSkill && !isFridayUnisolatedNodeSkillsEnabled()) {
+      if (runtimeKind === "node" && !isFridayUnisolatedNodeSkillsEnabled()) {
         throwFridayCapabilityDisabled({
           capability: "skill_node_runtime",
           surface: "POST /v1/skills/:skillId/run",

--- a/src/skills/executor/friday-execution-isolation-status.ts
+++ b/src/skills/executor/friday-execution-isolation-status.ts
@@ -21,7 +21,6 @@ export interface FridayExecutionIsolationStatus {
       | "darwin_sandbox_exec_write_network_guard"
       | "disabled_by_default_unisolated"
       | "disabled_in_production_unisolated_test_harness_only"
-      | "in_process_trusted"
       | "retired_by_default_dynamic_import_when_enabled"
       | "logical_workspace_guard_host_spawn";
     osSandbox: boolean;
@@ -70,10 +69,10 @@ export function getFridayExecutionIsolationStatus(
         notes: `Non-bundled Node skills dynamically import in-process modules; ${FRIDAY_ENABLE_UNISOLATED_NODE_SKILLS_ENV}=true is accepted only by the test harness, never as a production live unlock.`,
       },
       "skill.node.bundled_system": {
-        boundary: "in_process_trusted",
+        boundary: "disabled_in_production_unisolated_test_harness_only",
         osSandbox: false,
-        defaultLive: true,
-        notes: "Bundled system Node skills may run without the unisolated env gate, but still execute in the hub process.",
+        defaultLive: false,
+        notes: `Bundled system Node skills are also disabled in production because they dynamically import in-process modules without OS isolation; ${FRIDAY_ENABLE_UNISOLATED_NODE_SKILLS_ENV}=true is accepted only by the test harness.`,
       },
       "plugin.entrypoint": {
         boundary: "retired_by_default_dynamic_import_when_enabled",

--- a/src/skills/executor/friday-node-executor.ts
+++ b/src/skills/executor/friday-node-executor.ts
@@ -34,18 +34,6 @@ export function getFridayUnisolatedNodeSkillsDisabledMessage(): string {
   return `Node-based skills are disabled in production because they execute in-process without OS isolation. ${FRIDAY_ENABLE_UNISOLATED_NODE_SKILLS_ENV}=true is accepted only by the test harness.`;
 }
 
-export function canRunFridayBundledSystemNodeSkillWithoutGate(input: {
-  runtimeKind?: string;
-  manifestKind?: string;
-  source?: string;
-  origin?: string;
-}): boolean {
-  return input.runtimeKind === "node"
-    && input.manifestKind === "system"
-    && input.source === "bundled"
-    && input.origin === "bundled";
-}
-
 /**
  * Creates a node executor that dynamically imports JS modules and calls their
  * exported `execute` function. Handles timeouts via `AbortSignal.timeout`.
@@ -58,7 +46,7 @@ export function createFridayNodeExecutor(config?: {
       const startMs = Date.now();
       const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
 
-      if (!options.allowWithoutGate && !isFridayUnisolatedNodeSkillsEnabled(config?.env ?? process.env)) {
+      if (!isFridayUnisolatedNodeSkillsEnabled(config?.env ?? process.env)) {
         return {
           output: {},
           timedOut: false,

--- a/src/skills/executor/friday-skill-executor.ts
+++ b/src/skills/executor/friday-skill-executor.ts
@@ -21,7 +21,6 @@ import {
 } from "#providers";
 import { createFridayShellExecutor } from "./friday-shell-executor.js";
 import {
-  canRunFridayBundledSystemNodeSkillWithoutGate,
   createFridayNodeExecutor,
   FRIDAY_ENABLE_UNISOLATED_NODE_SKILLS_ENV,
   getFridayUnisolatedNodeSkillsDisabledMessage,
@@ -1156,13 +1155,7 @@ export function createFridaySkillExecutor(
                   }
 
                   case "node": {
-                    const allowBundledSystemNodeSkill = canRunFridayBundledSystemNodeSkillWithoutGate({
-                      runtimeKind: manifest.runtime.kind,
-                      manifestKind: manifest.kind,
-                      source: registered.source,
-                      origin: registered.origin,
-                    });
-                    if (!allowBundledSystemNodeSkill && !isFridayUnisolatedNodeSkillsEnabled()) {
+                    if (!isFridayUnisolatedNodeSkillsEnabled()) {
                       execResult = {
                         runId,
                         status: "failed",
@@ -1203,7 +1196,6 @@ export function createFridaySkillExecutor(
                       cwd: registered.skillDir,
                       timeoutMs,
                       signal: controller.signal,
-                      allowWithoutGate: allowBundledSystemNodeSkill,
                       aiHelper,
                       runtimeContext,
                     });

--- a/src/skills/executor/friday-skill-executor.types.ts
+++ b/src/skills/executor/friday-skill-executor.types.ts
@@ -158,7 +158,6 @@ export interface FridayNodeRunOptions {
   cwd?: string;
   timeoutMs?: number;
   signal?: AbortSignal;
-  allowWithoutGate?: boolean;
   aiHelper?: FridaySkillAiHelperContext;
   runtimeContext?: Omit<FridaySkillNodeRuntimeContext, "ai">;
 }

--- a/src/skills/index.ts
+++ b/src/skills/index.ts
@@ -274,7 +274,6 @@ export {
   createFridayNodeExecutor,
   FRIDAY_ENABLE_UNISOLATED_NODE_SKILLS_ENV,
   FRIDAY_UNISOLATED_NODE_SKILLS_TEST_HARNESS_ENV,
-  canRunFridayBundledSystemNodeSkillWithoutGate,
   getFridayUnisolatedNodeSkillsDisabledMessage,
   isFridayUnisolatedNodeSkillsEnabled,
 } from "./executor/friday-node-executor.js";

--- a/test/unit/api/http/routes/friday-health-routes.test.ts
+++ b/test/unit/api/http/routes/friday-health-routes.test.ts
@@ -140,6 +140,11 @@ describe("createFridayHealthRoutes", () => {
           osSandbox: false,
           defaultLive: false,
         },
+        "skill.node.bundled_system": {
+          boundary: "disabled_in_production_unisolated_test_harness_only",
+          osSandbox: false,
+          defaultLive: false,
+        },
         "agent.exec": {
           boundary: "logical_workspace_guard_host_spawn",
           osSandbox: false,

--- a/test/unit/api/http/routes/friday-skill-routes.test.ts
+++ b/test/unit/api/http/routes/friday-skill-routes.test.ts
@@ -728,7 +728,7 @@ describe("createFridaySkillRoutes", () => {
     }
   });
 
-  it("allows bundled system node skills when the runtime gate is off", async () => {
+  it("blocks bundled system node skills when the runtime gate is off", async () => {
     const previousGate = process.env[FRIDAY_ENABLE_UNISOLATED_NODE_SKILLS_ENV];
     delete process.env[FRIDAY_ENABLE_UNISOLATED_NODE_SKILLS_ENV];
     try {
@@ -752,16 +752,18 @@ describe("createFridaySkillRoutes", () => {
         allowTestOnlySkillRunExecution: true,
       });
 
-      const result = await routes.find((item) => item.operationId === "skills.run")!.handler(makeCtx({
+      await expect(routes.find((item) => item.operationId === "skills.run")!.handler(makeCtx({
         params: { skillId: "review-open-issues" },
         body: { input: { limit: 10 } },
-      }));
-
-      expect(executor.execute).toHaveBeenCalledWith(expect.objectContaining({
-        skillId: "review-open-issues",
-        input: { limit: 10 },
-      }));
-      expect(result).toHaveProperty("status", "completed");
+      }))).rejects.toMatchObject({
+        code: "CAPABILITY_DISABLED",
+        httpStatus: 501,
+        details: {
+          capability: "skill_node_runtime",
+          surface: "POST /v1/skills/:skillId/run",
+        },
+      });
+      expect(executor.execute).not.toHaveBeenCalled();
     } finally {
       if (previousGate === undefined) {
         delete process.env[FRIDAY_ENABLE_UNISOLATED_NODE_SKILLS_ENV];

--- a/test/unit/skills/executor/friday-execution-isolation-status.test.ts
+++ b/test/unit/skills/executor/friday-execution-isolation-status.test.ts
@@ -32,9 +32,9 @@ describe("getFridayExecutionIsolationStatus", () => {
           defaultLive: false,
         },
         "skill.node.bundled_system": {
-          boundary: "in_process_trusted",
+          boundary: "disabled_in_production_unisolated_test_harness_only",
           osSandbox: false,
-          defaultLive: true,
+          defaultLive: false,
         },
         "plugin.entrypoint": {
           boundary: "retired_by_default_dynamic_import_when_enabled",
@@ -70,6 +70,11 @@ describe("getFridayExecutionIsolationStatus", () => {
         },
         "skill.node": {
           osSandbox: false,
+        },
+        "skill.node.bundled_system": {
+          boundary: "disabled_in_production_unisolated_test_harness_only",
+          osSandbox: false,
+          defaultLive: false,
         },
         "plugin.entrypoint": {
           osSandbox: false,

--- a/test/unit/skills/executor/friday-skill-executor.test.ts
+++ b/test/unit/skills/executor/friday-skill-executor.test.ts
@@ -1285,7 +1285,7 @@ export async function execute(_input, ctx) {
     }
   });
 
-  it("allows bundled system node skills when the runtime gate is off", async () => {
+  it("blocks bundled system node skills when the runtime gate is off", async () => {
     const fs = await import("node:fs/promises");
     const scriptDir = await fs.mkdtemp("/tmp/friday-node-bundled-system-");
     const previousGate = process.env[FRIDAY_ENABLE_UNISOLATED_NODE_SKILLS_ENV];
@@ -1322,9 +1322,12 @@ export async function execute(_input, ctx) {
         skillId: "review-open-issues",
       }).result;
 
-      expect(result.status).toBe("completed");
+      expect(result.status).toBe("failed");
+      expect(result.stderr).toContain("disabled in production");
       expect(result.output).toMatchObject({
-        summary: "starter-ok",
+        code: "CAPABILITY_DISABLED",
+        capability: "skill_node_runtime",
+        runtimeKind: "node",
       });
     } finally {
       if (previousGate === undefined) {


### PR DESCRIPTION
## Summary

D2 follow-up: fail-close the bundled/system Node skill runtime in production instead of letting bundled identity bypass the unisolated Node runtime gate.

- Removed the `canRunFridayBundledSystemNodeSkillWithoutGate` bypass and the lower-level `allowWithoutGate` executor escape hatch.
- Updated API, agent tool, skill list, executor, and health/capability truth labels so bundled system Node skills are `disabled_in_production_unisolated_test_harness_only` with `defaultLive=false`.
- Reversed legacy tests that expected bundled system Node skills to run with the gate off.

## Validation

- `git diff --check`
- `rg -n "canRunFridayBundledSystemNodeSkillWithoutGate|allowWithoutGate|in_process_trusted|Bundled system Node skills may run|allows bundled system node" src test || true`
- `npx vitest run test/unit/skills/executor/friday-node-executor.test.ts test/unit/skills/executor/friday-skill-executor.test.ts test/unit/skills/executor/friday-execution-isolation-status.test.ts test/unit/api/http/routes/friday-health-routes.test.ts test/unit/api/http/routes/friday-skill-routes.test.ts test/unit/agent/tools/friday-agent-skill-tool.test.ts test/unit/agent/tools/friday-agent-skills-list-tool.test.ts`
  - 7 files, 96 tests passed, type errors 0
- `npx vitest run test/unit/hub/friday-hub-bootstrap-env.test.ts test/unit/api/http/routes/friday-health-routes.test.ts test/unit/api/http/routes/friday-skill-generator-routes.test.ts test/unit/skills/executor/friday-node-executor.test.ts test/unit/skills/executor/friday-execution-isolation-status.test.ts test/unit/uix/services/friday-uix-surface-service.test.ts`
  - 6 files, 164 tests passed, type errors 0
- `npm run build`

## Truth Boundary

This is a D2 bundled Node execution hardening slice. It does not mark full D2 disposition complete until remaining execution surfaces are audited/dispositioned, and it does not make A3 skill execution live or satisfy broader registry/organic/operator gates.