### PR TITLE
Add dark A1 run-outcome learning fanout

### DIFF
--- a/docs/ops/friday-d1-split-db-acceptance-ledger.md
+++ b/docs/ops/friday-d1-split-db-acceptance-ledger.md
@@ -22,7 +22,7 @@ The currently shipped mainline satisfies the registry D1 block-release condition
 
 The TypeScript state runtime performs a Rust hub schema-version handshake before opening the split runtime:
 
-- `src/state/sqlite/friday-rust-hub-schema-handshake.ts` sets `FRIDAY_EXPECTED_RUST_HUB_SCHEMA_VERSION = 37`.
+- `src/state/sqlite/friday-rust-hub-schema-handshake.ts` sets `FRIDAY_EXPECTED_RUST_HUB_SCHEMA_VERSION = 38`.
 - The handshake reads `schema_version.version` from the configured Rust hub database or `stateDir/rust-hub.sqlite`.
 - Missing/invalid schema rows throw `RUST_HUB_SCHEMA_HANDSHAKE_FAILED`.
 - Version mismatch throws `RUST_HUB_SCHEMA_VERSION_MISMATCH` with HTTP 500 details and refuses to open the split TypeScript runtime.

--- a/docs/ops/prod-flags-manifest.json
+++ b/docs/ops/prod-flags-manifest.json
@@ -60,6 +60,15 @@
       "notes": "Drives maybe_extract_memory_post_run_flagged(.., enabled=true) on a Finished outcome and asserts a candidate is extracted while the run result is unchanged. Sibling proofs cover flag-off byte-identical, non-finished-no-fire, and isolated-failure."
     },
     {
+      "flag": "FRIDAY_A1_RUN_OUTCOME_LEARNING_FANOUT",
+      "process": "rust-ws-wrapper",
+      "prod_state": "dark",
+      "closes_loop": "After a finished sessioned agent run, emit refs-only preference/reflex/world-model learning candidates and require an explicit governance decision before any candidate is terminal.",
+      "coverage": "loop-e2e",
+      "e2e_test": "rust-core/crates/friday-hub/src/runtime.rs::a1_run_outcome_learning_fanout_writes_three_pending_refs_only_candidates",
+      "notes": "Built-DARK only. Drives maybe_emit_run_outcome_learning_candidates_flagged(.., enabled=true) on a Finished outcome and asserts exactly three refs-only pending candidates (preference/reflex/world_model), no answer-body leak, and no run_result mutation; then confirms one candidate through the explicit governance API. Sibling proofs cover exact-'1' flag parsing, flag-off byte-identical, and non-finished-no-fire. Truth boundary: this is mechanism-soak with test data, not TRUE organic A1 live-done and not an automatic durable-memory write."
+    },
+    {
       "flag": "FRIDAY_MEMORY_CONFIRM",
       "process": "rust-ws-wrapper",
       "prod_state": "on",

--- a/rust-core/crates/friday-hub/src/runtime.rs
+++ b/rust-core/crates/friday-hub/src/runtime.rs
@@ -30,7 +30,9 @@ use friday_core::gate::{CanonicalApproval, MutatingActionRequest};
 use friday_core::WorkLane;
 use friday_crypto::OperatorVerifyingKey;
 use friday_deepseek::{DeepSeekClient, DeepSeekError, Transport, UreqTransport};
-use friday_storage::{agent_run, persist_run_result, Db, RunResult, SessionOwner, StorageError};
+use friday_storage::{
+    agent_run, learning_candidate, persist_run_result, Db, RunResult, SessionOwner, StorageError,
+};
 
 use crate::hub_server::{project_answer_for_authed, AuthedAnswer, AuthedPrincipal};
 use crate::mission_context::MissionContextLookup;
@@ -1385,6 +1387,7 @@ impl<T: Transport> HubRuntime<T> {
         // Finished; result discarded; failure-isolated) AFTER the owner-gated answer is bound +
         // projected. See `maybe_extract_memory_post_run`.
         self.maybe_extract_memory_post_run(session_id, run_id, &outcome, now_ms);
+        self.maybe_emit_run_outcome_learning_candidates(session_id, run_id, &outcome, now_ms);
         answer
     }
 
@@ -1589,7 +1592,55 @@ impl<T: Transport> HubRuntime<T> {
         // Finished; result discarded; failure-isolated) AFTER the owner-gated answer is bound +
         // projected. See `maybe_extract_memory_post_run`.
         self.maybe_extract_memory_post_run(session_id, run_id, &outcome, now_ms);
+        self.maybe_emit_run_outcome_learning_candidates(session_id, run_id, &outcome, now_ms);
         Ok((selection, answer))
+    }
+
+    /// A1 DARK run-outcome fan-out. Default-OFF and refs-only: when enabled for a
+    /// Finished sessioned run, this creates pending governance candidates for
+    /// preference/reflex/world-model learning. It never writes durable memory, never
+    /// confirms anything, and failure is isolated from the already-projected answer.
+    fn maybe_emit_run_outcome_learning_candidates(
+        &self,
+        session_id: &str,
+        run_id: &str,
+        outcome: &LoopOutcome,
+        now_ms: i64,
+    ) {
+        let enabled = a1_run_outcome_learning_fanout_from(
+            std::env::var(ENV_A1_RUN_OUTCOME_LEARNING_FANOUT)
+                .ok()
+                .as_deref(),
+        );
+        self.maybe_emit_run_outcome_learning_candidates_flagged(
+            session_id, run_id, outcome, now_ms, enabled,
+        );
+    }
+
+    fn maybe_emit_run_outcome_learning_candidates_flagged(
+        &self,
+        session_id: &str,
+        run_id: &str,
+        outcome: &LoopOutcome,
+        now_ms: i64,
+        enabled: bool,
+    ) {
+        if !enabled {
+            return;
+        }
+        if outcome.status != LoopStatus::Finished {
+            return;
+        }
+        let turns = i64::try_from(outcome.turns).unwrap_or(i64::MAX);
+        let executed_tools = i64::try_from(outcome.executed_tools).unwrap_or(i64::MAX);
+        let _ = learning_candidate::record_run_outcome_candidates(
+            self.db.conn(),
+            run_id,
+            Some(session_id),
+            turns,
+            executed_tools,
+            now_ms,
+        );
     }
 
     /// (NS8-WIRE-1, Loop5) Fire POST-RUN session-memory extraction from the LIVE sessioned run
@@ -3005,11 +3056,19 @@ fn workitem_guarded_transition_from(raw: Option<&str>) -> bool {
 /// change cannot be enabled by accident.
 pub const ENV_RUN_LOOP_MEMORY_EXTRACTION: &str = "FRIDAY_RUN_LOOP_MEMORY_EXTRACTION";
 
+/// A1 default-OFF env gate for refs-only run-outcome learning fan-out. ON only for
+/// exact `"1"`; unset/empty/other values are OFF and produce no extra writes.
+pub const ENV_A1_RUN_OUTCOME_LEARNING_FANOUT: &str = "FRIDAY_A1_RUN_OUTCOME_LEARNING_FANOUT";
+
 /// Pure flag-matcher for [`ENV_RUN_LOOP_MEMORY_EXTRACTION`] (env read split out so it is
 /// unit-testable without `set_var` — the program-standard env-race-free idiom this file uses).
 /// DEFAULT-OFF: `None` (unset) ⇒ false; ON only for the exact opt-in value `"1"` (trimmed);
 /// everything else ⇒ false.
 fn run_loop_memory_extraction_from(raw: Option<&str>) -> bool {
+    matches!(raw.map(str::trim), Some("1"))
+}
+
+fn a1_run_outcome_learning_fanout_from(raw: Option<&str>) -> bool {
     matches!(raw.map(str::trim), Some("1"))
 }
 
@@ -8807,6 +8866,159 @@ mod tests {
                     .as_deref()
             ),
             "FRIDAY_RUN_LOOP_MEMORY_EXTRACTION must be unset/off in the test env (prod default)"
+        );
+    }
+
+    #[test]
+    fn a1_run_outcome_learning_fanout_flag_matcher_is_exact_one_default_off() {
+        assert!(
+            !a1_run_outcome_learning_fanout_from(None),
+            "unset ⇒ OFF (prod default)"
+        );
+        assert!(
+            a1_run_outcome_learning_fanout_from(Some("1")),
+            "exactly \"1\" ⇒ ON"
+        );
+        assert!(
+            a1_run_outcome_learning_fanout_from(Some(" 1 ")),
+            "trimmed \"1\" ⇒ ON"
+        );
+        for off in ["", "0", "true", "yes", "01", "1 0", "enabled", "TRUE"] {
+            assert!(
+                !a1_run_outcome_learning_fanout_from(Some(off)),
+                "{off:?} must NOT enable A1 fan-out"
+            );
+        }
+        assert!(
+            !a1_run_outcome_learning_fanout_from(
+                std::env::var(ENV_A1_RUN_OUTCOME_LEARNING_FANOUT)
+                    .ok()
+                    .as_deref()
+            ),
+            "FRIDAY_A1_RUN_OUTCOME_LEARNING_FANOUT must be unset/off in the test env"
+        );
+    }
+
+    #[test]
+    fn a1_run_outcome_learning_fanout_flag_off_is_byte_identical_even_on_finished() {
+        let owner = "owner-a1-off";
+        let (rt, _ws, _c) = runtime_with_owner("a1-fanout-off", owner, &["{\"tool\":\"none\"}"]);
+        let before = rt.db().count("run_outcome_learning_candidate").unwrap();
+
+        let outcome = LoopOutcome {
+            status: LoopStatus::Finished,
+            turns: 2,
+            executed_tools: 1,
+            final_message: Some("PONG".to_string()),
+            detail: String::new(),
+        };
+        rt.maybe_emit_run_outcome_learning_candidates_flagged(
+            "sess-a1-off",
+            "run-a1-off",
+            &outcome,
+            3_000,
+            false,
+        );
+
+        assert_eq!(
+            rt.db().count("run_outcome_learning_candidate").unwrap(),
+            before,
+            "flag-OFF creates no A1 candidates"
+        );
+    }
+
+    #[test]
+    fn a1_run_outcome_learning_fanout_writes_three_pending_refs_only_candidates() {
+        let owner = "owner-a1-on";
+        let (rt, _ws, _c) = runtime_with_owner("a1-fanout-on", owner, &["{\"tool\":\"none\"}"]);
+        let before_results = rt.db().count("run_result").unwrap();
+
+        let outcome = LoopOutcome {
+            status: LoopStatus::Finished,
+            turns: 2,
+            executed_tools: 1,
+            final_message: Some("PONG".to_string()),
+            detail: String::new(),
+        };
+        rt.maybe_emit_run_outcome_learning_candidates_flagged(
+            "sess-a1-on",
+            "run-a1-on",
+            &outcome,
+            4_000,
+            true,
+        );
+
+        let rows = friday_storage::learning_candidate::list_run_outcome_candidates_for_run(
+            rt.db().conn(),
+            "run-a1-on",
+        )
+        .unwrap();
+        assert_eq!(rows.len(), 3);
+        assert!(rows.iter().all(
+            |r| r.state == friday_storage::learning_candidate::RunOutcomeLearningState::Pending
+        ));
+        assert!(rows
+            .iter()
+            .all(|r| r.evidence_ref == "friday://agent-run/run-a1-on"));
+        assert!(rows.iter().all(|r| r.summary.contains("turns=2")
+            && r.summary.contains("executed_tools=1")
+            && !format!("{r:?}").contains("PONG")));
+        assert_eq!(
+            rt.db().count("run_result").unwrap(),
+            before_results,
+            "A1 fan-out is refs-only governance substrate; it does not alter run_result"
+        );
+
+        let decided = friday_storage::learning_candidate::decide_run_outcome_candidate(
+            rt.db().conn(),
+            "a1:run-a1-on:preference",
+            true,
+            4_500,
+            Some("operator-confirmed test governance leg"),
+        )
+        .unwrap();
+        assert_eq!(
+            decided,
+            friday_storage::learning_candidate::RunOutcomeLearningState::Confirmed,
+            "confirm is an explicit governance decision, not an automatic durable write"
+        );
+    }
+
+    #[test]
+    fn a1_run_outcome_learning_fanout_does_not_fire_on_non_finished() {
+        let owner = "owner-a1-np";
+        let (rt, _ws, _c) =
+            runtime_with_owner("a1-fanout-nonfinished", owner, &["{\"tool\":\"none\"}"]);
+        let before = rt.db().count("run_outcome_learning_candidate").unwrap();
+
+        for status in [
+            LoopStatus::Paused,
+            LoopStatus::Errored,
+            LoopStatus::Bounded,
+            LoopStatus::Blocked,
+            LoopStatus::Interrupted,
+            LoopStatus::AwaitingClarification,
+        ] {
+            let outcome = LoopOutcome {
+                status,
+                turns: 1,
+                executed_tools: 0,
+                final_message: None,
+                detail: String::new(),
+            };
+            rt.maybe_emit_run_outcome_learning_candidates_flagged(
+                "sess-a1-np",
+                "run-a1-np",
+                &outcome,
+                5_000,
+                true,
+            );
+        }
+
+        assert_eq!(
+            rt.db().count("run_outcome_learning_candidate").unwrap(),
+            before,
+            "A1 fan-out is gated on Finished only"
         );
     }
 

--- a/rust-core/crates/friday-storage/src/learning_candidate.rs
+++ b/rust-core/crates/friday-storage/src/learning_candidate.rs
@@ -1,0 +1,221 @@
+//! Refs-only A1 run-outcome learning candidates (Hub-only, DARK).
+//!
+//! These rows are governance candidates produced after a completed agent loop. They
+//! deliberately store only run/session refs and coarse counts: no answer body, no
+//! hidden durable memory write, and no auto-recall path. A candidate becomes terminal
+//! only through an explicit confirm/reject call.
+
+use crate::error::{Result, StorageError};
+use rusqlite::{params, Connection, OptionalExtension};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum RunOutcomeLearningKind {
+    Preference,
+    Reflex,
+    WorldModel,
+}
+
+impl RunOutcomeLearningKind {
+    pub const ALL: [Self; 3] = [Self::Preference, Self::Reflex, Self::WorldModel];
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Preference => "preference",
+            Self::Reflex => "reflex",
+            Self::WorldModel => "world_model",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum RunOutcomeLearningState {
+    Pending,
+    Confirmed,
+    Rejected,
+}
+
+impl RunOutcomeLearningState {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Pending => "pending",
+            Self::Confirmed => "confirmed",
+            Self::Rejected => "rejected",
+        }
+    }
+
+    fn is_terminal(self) -> bool {
+        matches!(self, Self::Confirmed | Self::Rejected)
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RunOutcomeLearningCandidateRow {
+    pub candidate_id: String,
+    pub run_id: String,
+    pub session_id: Option<String>,
+    pub kind: RunOutcomeLearningKind,
+    pub state: RunOutcomeLearningState,
+    pub evidence_ref: String,
+    pub summary: String,
+    pub turns: i64,
+    pub executed_tools: i64,
+    pub created_at_ms: i64,
+    pub decided_at_ms: Option<i64>,
+    pub decision_reason: Option<String>,
+}
+
+fn parse_kind(value: &str) -> Result<RunOutcomeLearningKind> {
+    match value {
+        "preference" => Ok(RunOutcomeLearningKind::Preference),
+        "reflex" => Ok(RunOutcomeLearningKind::Reflex),
+        "world_model" => Ok(RunOutcomeLearningKind::WorldModel),
+        other => Err(StorageError::Unsupported(format!(
+            "unknown run-outcome learning kind '{other}'"
+        ))),
+    }
+}
+
+fn parse_state(value: &str) -> Result<RunOutcomeLearningState> {
+    match value {
+        "pending" => Ok(RunOutcomeLearningState::Pending),
+        "confirmed" => Ok(RunOutcomeLearningState::Confirmed),
+        "rejected" => Ok(RunOutcomeLearningState::Rejected),
+        other => Err(StorageError::Unsupported(format!(
+            "unknown run-outcome learning state '{other}'"
+        ))),
+    }
+}
+
+fn row_from(r: &rusqlite::Row) -> rusqlite::Result<RunOutcomeLearningCandidateRow> {
+    let kind: String = r.get("kind")?;
+    let state: String = r.get("state")?;
+    Ok(RunOutcomeLearningCandidateRow {
+        candidate_id: r.get("candidate_id")?,
+        run_id: r.get("run_id")?,
+        session_id: r.get("session_id")?,
+        kind: parse_kind(&kind).map_err(|e| {
+            rusqlite::Error::FromSqlConversionFailure(0, rusqlite::types::Type::Text, Box::new(e))
+        })?,
+        state: parse_state(&state).map_err(|e| {
+            rusqlite::Error::FromSqlConversionFailure(0, rusqlite::types::Type::Text, Box::new(e))
+        })?,
+        evidence_ref: r.get("evidence_ref")?,
+        summary: r.get("summary")?,
+        turns: r.get("turns")?,
+        executed_tools: r.get("executed_tools")?,
+        created_at_ms: r.get("created_at_ms")?,
+        decided_at_ms: r.get("decided_at_ms")?,
+        decision_reason: r.get("decision_reason")?,
+    })
+}
+
+const SELECT_COLS: &str = "candidate_id, run_id, session_id, kind, state, evidence_ref, summary, \
+     turns, executed_tools, created_at_ms, decided_at_ms, decision_reason";
+
+pub fn record_run_outcome_candidates(
+    conn: &Connection,
+    run_id: &str,
+    session_id: Option<&str>,
+    turns: i64,
+    executed_tools: i64,
+    now_ms: i64,
+) -> Result<usize> {
+    crate::with_busy_retry(|| {
+        let tx = conn.unchecked_transaction()?;
+        let mut inserted = 0usize;
+        for kind in RunOutcomeLearningKind::ALL {
+            let candidate_id = format!("a1:{run_id}:{}", kind.as_str());
+            let summary =
+                format!("refs-only run outcome: turns={turns}; executed_tools={executed_tools}");
+            inserted += tx.execute(
+                "INSERT OR IGNORE INTO run_outcome_learning_candidate
+                    (candidate_id, run_id, session_id, kind, state, evidence_ref, summary,
+                     turns, executed_tools, created_at_ms, decided_at_ms, decision_reason)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, NULL, NULL)",
+                params![
+                    candidate_id,
+                    run_id,
+                    session_id,
+                    kind.as_str(),
+                    RunOutcomeLearningState::Pending.as_str(),
+                    format!("friday://agent-run/{run_id}"),
+                    summary,
+                    turns,
+                    executed_tools,
+                    now_ms
+                ],
+            )?;
+        }
+        tx.commit()?;
+        Ok(inserted)
+    })
+}
+
+pub fn list_run_outcome_candidates_for_run(
+    conn: &Connection,
+    run_id: &str,
+) -> Result<Vec<RunOutcomeLearningCandidateRow>> {
+    let mut stmt = conn.prepare(&format!(
+        "SELECT {SELECT_COLS}
+           FROM run_outcome_learning_candidate
+          WHERE run_id = ?1
+          ORDER BY kind"
+    ))?;
+    let rows = stmt.query_map([run_id], row_from)?;
+    let mut out = Vec::new();
+    for row in rows {
+        out.push(row?);
+    }
+    Ok(out)
+}
+
+pub fn get_run_outcome_candidate(
+    conn: &Connection,
+    candidate_id: &str,
+) -> Result<Option<RunOutcomeLearningCandidateRow>> {
+    Ok(conn
+        .query_row(
+            &format!(
+                "SELECT {SELECT_COLS}
+                   FROM run_outcome_learning_candidate
+                  WHERE candidate_id = ?1"
+            ),
+            [candidate_id],
+            row_from,
+        )
+        .optional()?)
+}
+
+pub fn decide_run_outcome_candidate(
+    conn: &Connection,
+    candidate_id: &str,
+    confirmed: bool,
+    now_ms: i64,
+    reason: Option<&str>,
+) -> Result<RunOutcomeLearningState> {
+    crate::with_busy_retry(|| {
+        let row = get_run_outcome_candidate(conn, candidate_id)?.ok_or_else(|| {
+            StorageError::Unsupported(format!(
+                "run_outcome_learning_candidate '{candidate_id}' not found"
+            ))
+        })?;
+        if row.state.is_terminal() {
+            return Err(StorageError::Unsupported(format!(
+                "run_outcome_learning_candidate '{candidate_id}' is already terminal ({})",
+                row.state.as_str()
+            )));
+        }
+        let next = if confirmed {
+            RunOutcomeLearningState::Confirmed
+        } else {
+            RunOutcomeLearningState::Rejected
+        };
+        conn.execute(
+            "UPDATE run_outcome_learning_candidate
+                SET state = ?1, decided_at_ms = ?2, decision_reason = ?3
+              WHERE candidate_id = ?4",
+            params![next.as_str(), now_ms, reason, candidate_id],
+        )?;
+        Ok(next)
+    })
+}

--- a/rust-core/crates/friday-storage/src/lib.rs
+++ b/rust-core/crates/friday-storage/src/lib.rs
@@ -18,6 +18,7 @@ pub mod authorize_ed25519;
 pub mod blob;
 pub mod channel;
 mod error;
+pub mod learning_candidate;
 pub mod memory;
 mod migrate;
 pub mod mission;

--- a/rust-core/crates/friday-storage/src/schema.rs
+++ b/rust-core/crates/friday-storage/src/schema.rs
@@ -63,6 +63,10 @@ pub const HUB_ONLY_TABLES: &[&str] = &[
     // and there is no answer-body-over-wire, so the tables are never on a phone.
     "agent_session",
     "agent_session_message",
+    // A1: refs-only run-outcome learning candidates (DARK). These rows are governance
+    // work items derived from a completed Hub agent loop; they are not durable memory,
+    // not auto-recalled facts, and never exist on a phone surface.
+    "run_outcome_learning_candidate",
     // SMOOTH-001: Hub-only durable provider-session timeline (file 83). The parent
     // `provider_timeline` row + its ordered `provider_timeline_event` log + the
     // `provider_timeline_pending` action table persist the in-memory timeline state
@@ -639,6 +643,14 @@ pub fn hub_migrations() -> Vec<Migration> {
             name: "route_decision_control",
             destructive: false,
             up: m0037_route_decision_control,
+        },
+        // A1: default-off Rust run-outcome fan-out substrate. The table stores only
+        // refs/counts and pending governance candidates; confirmation is explicit.
+        Migration {
+            version: 38,
+            name: "run_outcome_learning_candidate",
+            destructive: false,
+            up: m0038_run_outcome_learning_candidate,
         },
     ]
 }
@@ -1742,6 +1754,27 @@ CREATE TABLE route_decision_control (
 CREATE INDEX idx_route_decision_control_work_item_active
     ON route_decision_control(work_item_id, active, created_at_ms, decision_id);";
 
+const DDL_RUN_OUTCOME_LEARNING_CANDIDATE: &str = "
+CREATE TABLE run_outcome_learning_candidate (
+    candidate_id    TEXT PRIMARY KEY CHECK(length(trim(candidate_id)) > 0),
+    run_id          TEXT NOT NULL CHECK(length(trim(run_id)) > 0),
+    session_id      TEXT CHECK(session_id IS NULL OR length(trim(session_id)) > 0),
+    kind            TEXT NOT NULL CHECK(kind IN ('preference', 'reflex', 'world_model')),
+    state           TEXT NOT NULL CHECK(state IN ('pending', 'confirmed', 'rejected')),
+    evidence_ref    TEXT NOT NULL CHECK(length(trim(evidence_ref)) > 0),
+    summary         TEXT NOT NULL CHECK(length(trim(summary)) > 0),
+    turns           INTEGER NOT NULL CHECK(turns >= 0),
+    executed_tools  INTEGER NOT NULL CHECK(executed_tools >= 0),
+    created_at_ms   INTEGER NOT NULL,
+    decided_at_ms   INTEGER,
+    decision_reason TEXT,
+    UNIQUE(run_id, kind)
+);
+CREATE INDEX idx_run_outcome_learning_candidate_state_created
+    ON run_outcome_learning_candidate(state, created_at_ms, candidate_id);
+CREATE INDEX idx_run_outcome_learning_candidate_run_kind
+    ON run_outcome_learning_candidate(run_id, kind);";
+
 const DDL_REBUILD_MISSION_LINK_WITH_ROUTE_DECISION: &str = "
 CREATE TABLE mission_link_new (
     link_id        TEXT PRIMARY KEY,
@@ -2511,4 +2544,8 @@ fn m0036_trust_grant_run_usage(tx: &Transaction) -> rusqlite::Result<()> {
 
 fn m0037_route_decision_control(tx: &Transaction) -> rusqlite::Result<()> {
     tx.execute_batch(DDL_ROUTE_DECISION_CONTROL)
+}
+
+fn m0038_run_outcome_learning_candidate(tx: &Transaction) -> rusqlite::Result<()> {
+    tx.execute_batch(DDL_RUN_OUTCOME_LEARNING_CANDIDATE)
 }

--- a/rust-core/crates/friday-storage/tests/learning_candidate.rs
+++ b/rust-core/crates/friday-storage/tests/learning_candidate.rs
@@ -1,0 +1,132 @@
+//! A1 run-outcome learning candidate persistence.
+
+mod common;
+
+use common::temp_db_path;
+use friday_storage::learning_candidate::{self, RunOutcomeLearningKind, RunOutcomeLearningState};
+use friday_storage::{hub_migrations, Db, Profile, StorageError, HUB_ONLY_TABLES};
+
+fn hub_max_version() -> i64 {
+    hub_migrations().iter().map(|m| m.version).max().unwrap()
+}
+
+#[test]
+fn run_outcome_learning_candidate_is_hub_only_and_forward_migrated() {
+    assert!(HUB_ONLY_TABLES.contains(&"run_outcome_learning_candidate"));
+
+    let p = temp_db_path("a1-learning-mig");
+    {
+        let mut migs = hub_migrations();
+        migs.retain(|m| m.version < 38);
+        let db = Db::open(&p, Profile::Hub, &migs, "pre-a1").unwrap();
+        assert_eq!(db.version().unwrap(), 37);
+        assert!(!db
+            .table_names()
+            .unwrap()
+            .iter()
+            .any(|t| t == "run_outcome_learning_candidate"));
+    }
+
+    let db = Db::open_hub(&p).unwrap();
+    assert_eq!(db.version().unwrap(), hub_max_version());
+    assert!(db
+        .table_names()
+        .unwrap()
+        .iter()
+        .any(|t| t == "run_outcome_learning_candidate"));
+
+    let phone = Db::open_phone(&temp_db_path("a1-learning-phone")).unwrap();
+    assert!(!phone
+        .table_names()
+        .unwrap()
+        .iter()
+        .any(|t| t == "run_outcome_learning_candidate"));
+}
+
+#[test]
+fn record_candidates_is_refs_only_pending_and_idempotent_per_run() {
+    let db = Db::open_hub(&temp_db_path("a1-learning-record")).unwrap();
+
+    let inserted = learning_candidate::record_run_outcome_candidates(
+        db.conn(),
+        "run-a1",
+        Some("sess-a1"),
+        2,
+        1,
+        10_000,
+    )
+    .unwrap();
+    assert_eq!(inserted, 3);
+
+    let duplicate = learning_candidate::record_run_outcome_candidates(
+        db.conn(),
+        "run-a1",
+        Some("sess-a1"),
+        99,
+        99,
+        20_000,
+    )
+    .unwrap();
+    assert_eq!(duplicate, 0, "same run fan-out is idempotent");
+
+    let rows =
+        learning_candidate::list_run_outcome_candidates_for_run(db.conn(), "run-a1").unwrap();
+    assert_eq!(rows.len(), 3);
+    assert_eq!(
+        rows.iter().map(|r| r.kind).collect::<Vec<_>>(),
+        vec![
+            RunOutcomeLearningKind::Preference,
+            RunOutcomeLearningKind::Reflex,
+            RunOutcomeLearningKind::WorldModel,
+        ]
+    );
+    for row in rows {
+        assert_eq!(row.state, RunOutcomeLearningState::Pending);
+        assert_eq!(row.evidence_ref, "friday://agent-run/run-a1");
+        assert!(row.summary.contains("turns=2"));
+        assert!(row.summary.contains("executed_tools=1"));
+        assert!(!format!("{row:?}").contains("PONG"));
+    }
+}
+
+#[test]
+fn explicit_decision_confirms_or_rejects_once() {
+    let db = Db::open_hub(&temp_db_path("a1-learning-decide")).unwrap();
+    learning_candidate::record_run_outcome_candidates(
+        db.conn(),
+        "run-decision",
+        Some("sess-decision"),
+        1,
+        0,
+        1_000,
+    )
+    .unwrap();
+
+    let next = learning_candidate::decide_run_outcome_candidate(
+        db.conn(),
+        "a1:run-decision:preference",
+        true,
+        2_000,
+        Some("operator confirmed"),
+    )
+    .unwrap();
+    assert_eq!(next, RunOutcomeLearningState::Confirmed);
+
+    let row =
+        learning_candidate::get_run_outcome_candidate(db.conn(), "a1:run-decision:preference")
+            .unwrap()
+            .unwrap();
+    assert_eq!(row.state, RunOutcomeLearningState::Confirmed);
+    assert_eq!(row.decided_at_ms, Some(2_000));
+    assert_eq!(row.decision_reason.as_deref(), Some("operator confirmed"));
+
+    let err = learning_candidate::decide_run_outcome_candidate(
+        db.conn(),
+        "a1:run-decision:preference",
+        false,
+        3_000,
+        None,
+    )
+    .unwrap_err();
+    assert!(matches!(err, StorageError::Unsupported(_)));
+}

--- a/src/state/sqlite/friday-rust-hub-schema-handshake.ts
+++ b/src/state/sqlite/friday-rust-hub-schema-handshake.ts
@@ -6,7 +6,7 @@ import Database from "better-sqlite3";
 import { FridayDomainError } from "#errors";
 
 export const FRIDAY_HUB_AGENT_RUN_DB_PATH_ENV = "FRIDAY_HUB_AGENT_RUN_DB_PATH";
-export const FRIDAY_EXPECTED_RUST_HUB_SCHEMA_VERSION = 37;
+export const FRIDAY_EXPECTED_RUST_HUB_SCHEMA_VERSION = 38;
 
 export type FridayRustHubSchemaHandshakeStatus = "ok" | "skipped";
 


### PR DESCRIPTION
## Summary
- add a Hub-only refs-only run_outcome_learning_candidate substrate for A1 preference/reflex/world-model candidates
- wire a default-OFF FRIDAY_A1_RUN_OUTCOME_LEARNING_FANOUT trigger after finished sessioned runs
- bump the TS/Rust hub schema handshake to v38 with D1 ledger alignment
- add flag-off, flag-on, non-finished, storage, schema-profile, migration-chain, and prod-flag manifest coverage

## Truth boundary
- Built-DARK mechanism only: this does not mark A1 live-done.
- The fan-out emits pending refs-only candidates and requires an explicit governance decision before a candidate becomes terminal.
- This does not write durable memory, does not affect recall, does not prove a true organic/operator loop, and does not use the real operator key.
- Friday still has no action-rollback engine; this PR does not change trust-dial reversibility semantics.

## Validation
- cargo fmt --all
- cargo fmt --all -- --check
- cargo test -p friday-storage --test learning_candidate -- --nocapture
- cargo test -p friday-storage --test schema_profile -- --nocapture
- cargo test -p friday-hub a1_run_outcome_learning_fanout -- --nocapture
- cargo test -p friday-hub post_run_extraction -- --nocapture
- cargo test -p friday-storage -- --nocapture
- npx vitest run test/unit/state/friday-rust-hub-schema-handshake.test.ts test/unit/state/friday-d1-two-db-split-closure.test.ts
- npm test -- --run test/integration/state/sqlite/friday-migration-chain.test.ts
- node scripts/ci/verify-prod-flag-tests.mjs
- npm run build
- git diff --check