### PR TITLE
[codex] Surface D20 route action list

### DIFF
--- a/rust-core/crates/friday-hub/src/workbench_projection.rs
+++ b/rust-core/crates/friday-hub/src/workbench_projection.rs
@@ -125,6 +125,7 @@ pub fn project_workbench(db: &Db, requested_mission_id: Option<&str>) -> Result<
             "advisorSummary": route_decision.why_this_route,
             "selectedRoute": redacted_ref("route-decision", &route_decision.route_decision_ref),
             "alternatives": route_decision.considered_options,
+            "actionItems": route_decision_action_items_json(&route_decision.action_items),
             "truthLabel": "friday_owned"
         },
         "providerReceiptRefs": provider_receipt_refs,
@@ -188,6 +189,23 @@ fn channel_receipt_refs(links: &[friday_core::MissionLink]) -> Vec<String> {
             .map(|link| redacted_link_proof_ref("channel-receipt", link))
             .collect(),
     )
+}
+
+fn route_decision_action_items_json(items: &[friday_core::RouteActionItem]) -> Vec<Value> {
+    items
+        .iter()
+        .map(|item| {
+            json!({
+                "description": item.description.clone(),
+                "targetKind": item.target_kind.as_str(),
+                "targetRef": item.target_ref.clone(),
+                "reversibility": item.reversibility.as_str(),
+                "assignedLane": item.assigned_lane.as_str(),
+                "assignedProviderOrAgent": item.assigned_provider_or_agent.clone(),
+                "routeReason": item.route_reason.clone(),
+            })
+        })
+        .collect()
 }
 
 fn work_items_json(work_items: &[WorkItem]) -> Vec<Value> {

--- a/scripts/qa/check-mission-workbench-snapshot-contract.mjs
+++ b/scripts/qa/check-mission-workbench-snapshot-contract.mjs
@@ -56,6 +56,12 @@ const lifecycleStates = new Set([...nonDoneStates, "completed_with_proof"]);
 const capabilityKinds = new Set(["skill", "capability", "advisor"]);
 const approvalStates = new Set(["not_required", "required", "approved", "blocked"]);
 const controlTruthLabels = new Set(["friday_owned", "friday_adopted"]);
+const routeActionTargetKinds = new Set(["file", "command", "subtask"]);
+const routeActionReversibility = new Set([
+  "reversible_git_worktree",
+  "operator_gate_required",
+  "pending_classify",
+]);
 const transcriptGroupKinds = new Set([
   "mission",
   "work_item",
@@ -250,6 +256,27 @@ function validateSnapshot(snapshot, expectedMissionId, failures) {
     validateStringField(routeDecision.selectedRoute, failures, "route_decision_selected_missing", "routeDecision.selectedRoute");
     if (!truthLabels.has(routeDecision.truthLabel)) {
       recordFailure(failures, "route_decision_truth_label_invalid", String(routeDecision.truthLabel || ""));
+    }
+    const actionItems = Array.isArray(routeDecision.actionItems) ? routeDecision.actionItems : [];
+    if (!Array.isArray(routeDecision.actionItems)) {
+      recordFailure(failures, "route_decision_action_items_not_array", "routeDecision.actionItems");
+    }
+    for (const [index, item] of actionItems.entries()) {
+      const action = asObject(item);
+      if (!action) {
+        recordFailure(failures, "route_decision_action_not_object", `routeDecision.actionItems[${index}]`);
+        continue;
+      }
+      validateStringField(action.description, failures, "route_decision_action_description_missing", `routeDecision.actionItems[${index}].description`);
+      validateStringField(action.targetRef, failures, "route_decision_action_target_ref_missing", `routeDecision.actionItems[${index}].targetRef`);
+      validateStringField(action.assignedLane, failures, "route_decision_action_assigned_lane_missing", `routeDecision.actionItems[${index}].assignedLane`);
+      validateStringField(action.routeReason, failures, "route_decision_action_route_reason_missing", `routeDecision.actionItems[${index}].routeReason`);
+      if (!routeActionTargetKinds.has(action.targetKind)) {
+        recordFailure(failures, "route_decision_action_target_kind_invalid", String(action.targetKind || ""));
+      }
+      if (!routeActionReversibility.has(action.reversibility)) {
+        recordFailure(failures, "route_decision_action_reversibility_invalid", String(action.reversibility || ""));
+      }
     }
   }
 

--- a/src/api/http/routes/friday-mission-spine-routes.ts
+++ b/src/api/http/routes/friday-mission-spine-routes.ts
@@ -90,6 +90,12 @@ const CAPABILITY_KINDS = new Set(["skill", "capability", "advisor"]);
 const APPROVAL_STATES = new Set(["not_required", "required", "approved", "blocked"]);
 const TRUTH_LABELS = new Set(["friday_owned", "friday_adopted", "observed_only", "linked_only", "unknown"]);
 const CONTROL_TRUTH_LABELS = new Set(["friday_owned", "friday_adopted"]);
+const ROUTE_ACTION_TARGET_KINDS = new Set(["file", "command", "subtask"]);
+const ROUTE_ACTION_REVERSIBILITY = new Set([
+  "reversible_git_worktree",
+  "operator_gate_required",
+  "pending_classify",
+]);
 const PLACEHOLDER_MARKERS = [
   "mission_pending_runtime_projection",
   "conversation_pending_runtime_projection",
@@ -353,8 +359,12 @@ function readPathParam(params: unknown, key: string): string {
   return typeof value === "string" ? value : "";
 }
 
-function hasText(value: string | undefined): boolean {
+function hasText(value: unknown): boolean {
   return typeof value === "string" && value.trim().length > 0;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 function pushIfInvalid(failures: string[], condition: boolean, code: string): void {
@@ -406,6 +416,29 @@ function validateSnapshotHeader(
   pushIfInvalid(failures, hasText(snapshot.routeDecision.advisorSummary), "route_decision_summary_missing");
   pushIfInvalid(failures, hasText(snapshot.routeDecision.selectedRoute), "route_decision_selected_missing");
   pushIfInvalid(failures, TRUTH_LABELS.has(snapshot.routeDecision.truthLabel), "route_decision_truth_label_invalid");
+  pushIfInvalid(failures, Array.isArray(snapshot.routeDecision.actionItems), "route_decision_action_items_not_array");
+  if (Array.isArray(snapshot.routeDecision.actionItems)) {
+    for (const [index, item] of snapshot.routeDecision.actionItems.entries()) {
+      if (!isRecord(item)) {
+        failures.push(`route_decision_action_not_object:${index}`);
+        continue;
+      }
+      pushIfInvalid(failures, hasText(item.description), `route_decision_action_description_missing:${index}`);
+      pushIfInvalid(
+        failures,
+        typeof item.targetKind === "string" && ROUTE_ACTION_TARGET_KINDS.has(item.targetKind),
+        `route_decision_action_target_kind_invalid:${index}`,
+      );
+      pushIfInvalid(failures, hasText(item.targetRef), `route_decision_action_target_ref_missing:${index}`);
+      pushIfInvalid(
+        failures,
+        typeof item.reversibility === "string" && ROUTE_ACTION_REVERSIBILITY.has(item.reversibility),
+        `route_decision_action_reversibility_invalid:${index}`,
+      );
+      pushIfInvalid(failures, hasText(item.assignedLane), `route_decision_action_assigned_lane_missing:${index}`);
+      pushIfInvalid(failures, hasText(item.routeReason), `route_decision_action_route_reason_missing:${index}`);
+    }
+  }
   pushIfInvalid(failures, Array.isArray(snapshot.providerReceiptRefs), "provider_receipt_refs_not_array");
   pushIfInvalid(failures, Array.isArray(snapshot.channelReceiptRefs), "channel_receipt_refs_not_array");
 }

--- a/src/api/model/friday-api-mission-spine.types.ts
+++ b/src/api/model/friday-api-mission-spine.types.ts
@@ -66,6 +66,23 @@ export interface FridayMissionSpineWorkbenchCapabilityState {
   proofRef: string;
 }
 
+export type FridayMissionSpineRouteActionTargetKind = "file" | "command" | "subtask";
+
+export type FridayMissionSpineRouteActionReversibility =
+  | "reversible_git_worktree"
+  | "operator_gate_required"
+  | "pending_classify";
+
+export interface FridayMissionSpineRouteActionItem {
+  description: string;
+  targetKind: FridayMissionSpineRouteActionTargetKind;
+  targetRef: string;
+  reversibility: FridayMissionSpineRouteActionReversibility;
+  assignedLane: string;
+  assignedProviderOrAgent?: string | null;
+  routeReason: string;
+}
+
 export type FridayMissionSpineTranscriptGroupKind =
   | "mission"
   | "work_item"
@@ -125,6 +142,7 @@ export interface FridayMissionSpineWorkbenchSnapshot {
     advisorSummary: string;
     selectedRoute: string;
     alternatives: string[];
+    actionItems: FridayMissionSpineRouteActionItem[];
     truthLabel: FridayMissionSpineTruthLabel;
   };
   providerReceiptRefs: string[];

--- a/test/unit/api/routes/friday-mission-spine-routes.test.ts
+++ b/test/unit/api/routes/friday-mission-spine-routes.test.ts
@@ -21,6 +21,17 @@ const snapshot: FridayMissionSpineWorkbenchSnapshot = {
     advisorSummary: "Rust Hub route decision projection.",
     selectedRoute: "route_decision_ref",
     alternatives: ["alternate_ref"],
+    actionItems: [
+      {
+        description: "Implement Mission Spine domain types",
+        targetKind: "file",
+        targetRef: "rust-core/crates/friday-core/src/lib.rs",
+        reversibility: "operator_gate_required",
+        assignedLane: "codex",
+        assignedProviderOrAgent: "codex",
+        routeReason: "Rust Hub must own product truth before UI wiring",
+      },
+    ],
     truthLabel: "friday_owned",
   },
   providerReceiptRefs: ["proof://provider/receipt/redacted"],
@@ -348,6 +359,33 @@ describe("createFridayMissionSpineRoutes", () => {
     expect(error.httpStatus).toBe(503);
     expect(JSON.stringify(error.details)).toContain("runtime_feed_not_live");
     expect(JSON.stringify(error.details)).toContain("placeholder:mission_pending_runtime_projection");
+  });
+
+  it("fails closed instead of throwing a TypeError when route action items are malformed", async () => {
+    const invalidSnapshot = cloneSnapshot({
+      routeDecision: {
+        ...snapshot.routeDecision,
+        actionItems: [null],
+      } as never,
+    });
+    const routes = createFridayMissionSpineRoutes({
+      workbench: { getSnapshot: vi.fn(async () => invalidSnapshot) },
+      disabledReason: null,
+    });
+    const route = findRoute(routes);
+
+    let thrown: unknown = null;
+    try {
+      await route.handler(makeCtx() as never);
+    } catch (err) {
+      thrown = err;
+    }
+
+    expect(thrown).toBeInstanceOf(FridayDomainError);
+    const error = thrown as FridayDomainError;
+    expect(error.code).toBe("MISSION_SPINE_WORKBENCH_SNAPSHOT_INVALID");
+    expect(error.httpStatus).toBe(503);
+    expect(JSON.stringify(error.details)).toContain("route_decision_action_not_object:0");
   });
 
   it("fails closed when provider ack or timeline read is marked done", async () => {

--- a/test/unit/qa/mission-workbench-snapshot-contract-cli.test.ts
+++ b/test/unit/qa/mission-workbench-snapshot-contract-cli.test.ts
@@ -20,6 +20,17 @@ function makeSnapshot(overrides: Record<string, unknown> = {}) {
       advisorSummary: "Rust Hub route decision projection.",
       selectedRoute: "route_decision_ref",
       alternatives: ["alternate_ref"],
+      actionItems: [
+        {
+          description: "Implement Mission Spine domain types",
+          targetKind: "file",
+          targetRef: "rust-core/crates/friday-core/src/lib.rs",
+          reversibility: "operator_gate_required",
+          assignedLane: "codex",
+          assignedProviderOrAgent: "codex",
+          routeReason: "Rust Hub must own product truth before UI wiring",
+        },
+      ],
       truthLabel: "friday_owned",
     },
     providerReceiptRefs: ["proof://provider/receipt/redacted"],

--- a/ui/src/lib/mission-workbench/mission-workbench-contract.ts
+++ b/ui/src/lib/mission-workbench/mission-workbench-contract.ts
@@ -66,6 +66,23 @@ export interface MissionWorkbenchCapabilityState {
   proofRef: string;
 }
 
+export type MissionRouteActionTargetKind = "file" | "command" | "subtask";
+
+export type MissionRouteActionReversibility =
+  | "reversible_git_worktree"
+  | "operator_gate_required"
+  | "pending_classify";
+
+export interface MissionRouteActionItem {
+  description: string;
+  targetKind: MissionRouteActionTargetKind;
+  targetRef: string;
+  reversibility: MissionRouteActionReversibility;
+  assignedLane: string;
+  assignedProviderOrAgent?: string | null;
+  routeReason: string;
+}
+
 export type MissionTranscriptGroupKind =
   | "mission"
   | "work_item"
@@ -125,6 +142,7 @@ export interface MissionWorkbenchSnapshot {
     advisorSummary: string;
     selectedRoute: string;
     alternatives: string[];
+    actionItems: MissionRouteActionItem[];
     truthLabel: MissionTruthLabel;
   };
   providerReceiptRefs: string[];

--- a/ui/src/routes/mission-workbench-page.tsx
+++ b/ui/src/routes/mission-workbench-page.tsx
@@ -188,6 +188,42 @@ export function MissionWorkbenchPage() {
                 ))}
               </div>
             </div>
+            {snapshot.routeDecision.actionItems.length > 0 ? (
+              <div className="mt-4 border-t border-[color:var(--color-border-soft)] pt-4">
+                <div className="grid gap-3 md:grid-cols-2">
+                  {snapshot.routeDecision.actionItems.map((item, index) => (
+                    <div key={`${item.targetRef}-${index}`} className="rounded-lg border border-[color:var(--color-border-soft)] bg-[color:var(--color-bg-subtle)] p-3">
+                      <div className="flex flex-wrap items-center gap-2">
+                        <StatusPill tone="neutral">{item.targetKind}</StatusPill>
+                        <StatusPill
+                          tone={
+                            item.reversibility === "operator_gate_required"
+                              ? "warning"
+                              : item.reversibility === "pending_classify"
+                                ? "neutral"
+                                : "success"
+                          }
+                        >
+                          {item.reversibility}
+                        </StatusPill>
+                        <StatusPill tone="neutral">
+                          {item.assignedProviderOrAgent ?? item.assignedLane}
+                        </StatusPill>
+                      </div>
+                      <p className="mt-3 text-sm font-semibold leading-5 text-[color:var(--color-text-primary)]">
+                        {item.description}
+                      </p>
+                      <p className="mt-2 break-all text-xs text-[color:var(--color-text-tertiary)]">
+                        {item.targetRef}
+                      </p>
+                      <p className="mt-2 text-xs leading-5 text-[color:var(--color-text-secondary)]">
+                        {item.routeReason}
+                      </p>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            ) : null}
           </ShellCard>
 
           <ShellCard eyebrow="Bounded timeline" title={localize(locale, "分页时间线", "Timeline pages")}>


### PR DESCRIPTION
## Summary

Surfaces the D20 RouteDecision action list end to end through the existing Mission Workbench read path.

- Projects `RouteActionItem` rows from the Rust Hub workbench projection as `routeDecision.actionItems`.
- Adds TS API/UI contract types plus API and QA snapshot validation for the action-list wire shape.
- Renders action items in Mission Workbench with target kind, reversibility, assigned lane/provider, target ref, and route reason.
- Keeps this as W1 surface wiring only: no trust-dial live claim, no operator signing, no mission-spine write dispatch, and no change to D16-D19/gate core.

## Validation

- `git diff --check`
- `npx vitest run test/unit/api/routes/friday-mission-spine-routes.test.ts test/unit/qa/mission-workbench-snapshot-contract-cli.test.ts test/unit/ui/mission-workbench-api.test.ts`
- `cargo fmt --all -- --check && cargo test -p friday-hub workbench_projection -- --nocapture`
- `npm run build`

## Truth Labels

- built-DARK / surface contract wiring only.
- Friday still has no action-rollback engine; reversible semantics remain git/worktree containment, not undo.
- TEST/build verification here does not imply TRUE operator-in-the-loop or organic D20 live closure.