### PR TITLE
[codex] Wire D20 route decision controls

### DIFF
--- a/rust-core/crates/friday-ffi/src/lib.rs
+++ b/rust-core/crates/friday-ffi/src/lib.rs
@@ -1956,6 +1956,11 @@ fn message_kind_name(m: &friday_protocol::Message) -> &'static str {
         M::MissionLifecycleResult { .. } => "MissionLifecycleResult",
         M::WorkItemStatusRequest { .. } => "WorkItemStatusRequest",
         M::WorkItemStatusResult { .. } => "WorkItemStatusResult",
+        // D20 W1-S3 route-decision control rides the sealed Mission-Spine dispatch arm, not FFI.
+        // Keep it named here so unsupported out-of-slice envelopes remain truth-labeled and this
+        // exhaustive match catches future protocol variants.
+        M::RouteDecisionControlRequest { .. } => "RouteDecisionControlRequest",
+        M::RouteDecisionControlResult { .. } => "RouteDecisionControlResult",
         // S-R1 — the DARK sealed-WS READ-seam projection kinds. NAMED here so the exhaustive match
         // holds and the truth label carries the real kind; nothing on the FFI surface constructs or
         // dispatches them (the UI reads them directly over the sealed-WS read server, not via FFI).

--- a/rust-core/crates/friday-hub/src/bin/hub_agent_run_server.rs
+++ b/rust-core/crates/friday-hub/src/bin/hub_agent_run_server.rs
@@ -477,20 +477,20 @@ fn run() -> Result<(), ServerError> {
     }
 
     // (KEYSTONE) Read the MISSION-SPINE DISPATCH flag ONCE at boot (default-off). When false the
-    // dispatch arms NEVER handle a `MissionLifecycleRequest` / `WorkItemStatusRequest` — each falls
-    // through to the EXISTING catch-all keepalive echo (byte-identical to today, since the server
-    // has never had these arms), so deploying this binary changes NO live behavior until the
-    // operator flips this flag.
+    // dispatch arms NEVER handle a `MissionLifecycleRequest` / `WorkItemStatusRequest` /
+    // `RouteDecisionControlRequest` — each falls through to the EXISTING catch-all keepalive echo
+    // (byte-identical to today, since the server has never had these arms), so deploying this
+    // binary changes NO live behavior until the operator flips this flag.
     let mission_spine_dispatch_enabled = mission_spine_dispatch_enabled_from(
         env::var(MISSION_SPINE_DISPATCH_ENABLED_ENV).ok().as_deref(),
     );
     if mission_spine_dispatch_enabled {
         eprintln!(
-            "hub_agent_run_server: MISSION-SPINE dispatch ENABLED (FRIDAY_MISSION_SPINE_DISPATCH) — Mission/WorkItem lifecycle requests transition the Hub state machine (no model call)"
+            "hub_agent_run_server: MISSION-SPINE dispatch ENABLED (FRIDAY_MISSION_SPINE_DISPATCH) — Mission/WorkItem lifecycle and RouteDecision control requests transition the Hub state machine (no model call)"
         );
     } else {
         eprintln!(
-            "hub_agent_run_server: MISSION-SPINE dispatch DISABLED (set FRIDAY_MISSION_SPINE_DISPATCH=1 to enable) — Mission/WorkItem lifecycle requests are benign keepalive echoes"
+            "hub_agent_run_server: MISSION-SPINE dispatch DISABLED (set FRIDAY_MISSION_SPINE_DISPATCH=1 to enable) — Mission/WorkItem lifecycle and RouteDecision control requests are benign keepalive echoes"
         );
     }
 
@@ -1804,6 +1804,34 @@ fn serve_sealed_session<S: Read + Write, T: Transport>(
                 );
                 eprintln!(
                     "hub_agent_run_server_dispatch: msg_id={} leg=work_item_status (mission-spine enabled)",
+                    env.msg_id
+                );
+                ws_send_envelope(
+                    ws,
+                    session_key,
+                    &result.with_correlation(env.msg_id.clone()),
+                    SESSION_AAD,
+                )?;
+                processed += 1;
+            }
+            // (D20 W1-S3) ROUTE-DECISION CONTROL — FLAG-GATED. When
+            // `FRIDAY_MISSION_SPINE_DISPATCH` is ON, an inbound `RouteDecisionControlRequest`
+            // persists an OWNER veto/override before dispatch. The storage lifecycle hook then
+            // blocks or remaps the later `ReadyToDispatch -> Dispatched` transition in the same DB
+            // transaction. PURE `&Db` mutation: NO provider/model call, ZERO `token_ledger` rows.
+            // When the flag is OFF this falls through to the catch-all keepalive echo below —
+            // byte-identical deploy safety.
+            Message::RouteDecisionControlRequest { request } if mission_spine_dispatch_enabled => {
+                let now_ms = now_ms();
+                let result = friday_hub::hub_server::route_decision_control_result_for_db(
+                    runtime.db(),
+                    &env.msg_id,
+                    request,
+                    runtime.policy().principal_id(),
+                    now_ms,
+                );
+                eprintln!(
+                    "hub_agent_run_server_dispatch: msg_id={} leg=route_decision_control (mission-spine enabled)",
                     env.msg_id
                 );
                 ws_send_envelope(
@@ -4398,6 +4426,31 @@ mod tests {
         )
     }
 
+    /// (D20 W1-S3) A `RouteDecisionControlRequest` envelope. No `auth_proof`: the sealed session is
+    /// the channel auth; the live arm owner-binds against the target decision's Mission owner.
+    fn route_decision_control_request(
+        msg_id: &str,
+        decision_id: &str,
+        control_kind: &str,
+    ) -> Envelope {
+        Envelope::new(
+            msg_id,
+            1000,
+            Message::RouteDecisionControlRequest {
+                request: friday_protocol::RouteDecisionControlRequestWire {
+                    decision_id: decision_id.into(),
+                    mission_id: None,
+                    work_item_id: None,
+                    control_kind: control_kind.into(),
+                    override_lane: None,
+                    override_provider_or_agent: None,
+                    actor_ref: OWNER.into(),
+                    reason: "operator controls the proposed route".into(),
+                },
+            },
+        )
+    }
+
     /// (KEYSTONE / KAT a) FLAG-ON: a `MissionLifecycleRequest` driven through the REAL dispatch path
     /// (`accept_one` → `serve_sealed_session`) advances the canonical Mission's status through the
     /// Hub state machine, returns a `MissionLifecycleResult`, and writes ZERO `token_ledger` rows.
@@ -4798,6 +4851,85 @@ mod tests {
             work.status,
             friday_core::WorkItemStatus::ReadyToDispatch,
             "a cross-owner request never transitions the foreign-owned WorkItem"
+        );
+    }
+
+    /// (D20 W1-S3) FLAG-ON: a `RouteDecisionControlRequest{veto}` driven through the REAL sealed
+    /// dispatch path persists a load-bearing pre-dispatch control. The subsequent
+    /// `ReadyToDispatch -> Dispatched` lifecycle hop is blocked by storage, proving this is not a
+    /// decorative field.
+    #[test]
+    fn flag_on_route_decision_veto_blocks_dispatch_lifecycle_hop() {
+        let (rt, _ws) = mock_runtime("spine-route-veto-on", OWNER);
+        seed_mission_and_work_item(&rt);
+        let route_decisions = rt
+            .db()
+            .list_route_decisions_for_mission("mission-ns5")
+            .unwrap();
+        let decision_id = route_decisions
+            .first()
+            .expect("seed intake writes a route decision")
+            .decision_id
+            .clone();
+        let server_kp = DeviceKeypair::generate();
+        let listener = AgentRunWsListener::bind_loopback(0).unwrap();
+        let addr = listener.local_addr().unwrap();
+        let allowlist = vec![OWNER.to_string()];
+        let client_kp = DeviceKeypair::generate();
+        let peer_allowlist = allowlist_of(client_kp.public_bytes());
+        let decision_for_client = decision_id.clone();
+        let client = spawn_client(addr, client_kp, move |session, _nonce| {
+            let req = route_decision_control_request(
+                "req-route-control-on",
+                &decision_for_client,
+                "veto",
+            );
+            (req, session.clone(), session.clone())
+        });
+        let processed = listener
+            .accept_one(
+                &server_kp,
+                &rt,
+                &allowlist,
+                &peer_allowlist,
+                false,
+                false,
+                false,
+                true,  // mission-spine dispatch ON, including route controls
+                false, // memory-confirm ingress OFF
+                false, // (Loop4) per-run token surface OFF
+                false, // (C1/C2) provider-workspace dispatch OFF
+            )
+            .unwrap();
+        assert_eq!(processed, 1);
+        match client
+            .join()
+            .unwrap()
+            .result
+            .expect("a route-control reply")
+        {
+            Message::RouteDecisionControlResult { result } => {
+                assert_eq!(result.decision_id, decision_id);
+                assert_eq!(result.control_kind, "veto");
+                assert_eq!(result.work_item_id, "work-ns5");
+            }
+            other => panic!("route-control flag ON must return a result, got {other:?}"),
+        }
+
+        let err = rt
+            .db()
+            .transition_work_item_status(
+                "work-ns5",
+                friday_core::WorkItemStatus::Dispatched,
+                OWNER,
+                "dispatch after route veto",
+                None,
+                2_000,
+            )
+            .expect_err("veto must block the dispatch lifecycle transition");
+        assert!(
+            err.to_string().contains("route_decision_veto_active"),
+            "expected the storage lifecycle hook to block dispatch, got {err:?}"
         );
     }
 

--- a/rust-core/crates/friday-hub/src/hub_server.rs
+++ b/rust-core/crates/friday-hub/src/hub_server.rs
@@ -28,7 +28,8 @@ use friday_protocol::{
     MissionTimelineMissionWire, MissionTimelineRequestWire, MissionTimelineSnapshotWire,
     MissionTimelineSurfaceEventWire, MissionTimelineWorkItemWire, MissionWorkItemContextWire,
     ProviderWorkspaceActionRequestWire, ProviderWorkspaceActionResultWire,
-    RouteDecisionProjectionWire, WorkItemStatusRequestWire, WorkItemStatusResultWire, SUPPORTED,
+    RouteDecisionControlRequestWire, RouteDecisionControlResultWire, RouteDecisionProjectionWire,
+    WorkItemStatusRequestWire, WorkItemStatusResultWire, SUPPORTED,
 };
 use friday_providers::unified::{FallbackStatus, PlatformProvider, ProviderSession, SessionStatus};
 use friday_storage::{
@@ -968,6 +969,189 @@ pub fn work_item_status_result_for_db(
             &format!("work item lifecycle blocked: {err}"),
         ),
     }
+}
+
+/// Apply one OWNER route-decision control before dispatch. This is the operator-facing half of
+/// D20 W1-S3: it does not decorate the card only; the persisted control is consulted by the
+/// `ReadyToDispatch -> Dispatched` WorkItem lifecycle transition in `friday-storage`, where a veto
+/// blocks dispatch and an override changes lane/target inside the same transaction.
+///
+/// Owner binding mirrors WorkItem status: resolve decision -> WorkItem -> Mission -> conversation
+/// owner, and require it to match the Rust-derived authenticated owner before writing.
+pub fn route_decision_control_result_for_db(
+    db: &Db,
+    msg_id: &str,
+    request: RouteDecisionControlRequestWire,
+    authenticated_owner: Option<&str>,
+    now_ms: i64,
+) -> Envelope {
+    let (resolved_decision_id, decision) = match resolve_route_decision_control_target(db, &request)
+    {
+        Ok((decision_id, Some(decision))) => (decision_id, decision),
+        Ok((_, None)) => {
+            return mission_intake_error(
+                msg_id,
+                now_ms,
+                ErrorCode::Internal,
+                "route decision control blocked: target RouteDecision not found",
+            );
+        }
+        Err(message) => {
+            return mission_intake_error(msg_id, now_ms, ErrorCode::Internal, message);
+        }
+    };
+
+    let authenticated_owner = authenticated_owner.unwrap_or("").trim();
+    let owner = db
+        .get_mission(&decision.mission_id)
+        .ok()
+        .flatten()
+        .and_then(|m| resolve_conversation_owner(db, &m.friday_conversation_id));
+    let owner_ok = !authenticated_owner.is_empty() && owner.as_deref() == Some(authenticated_owner);
+    if !owner_ok {
+        return mission_intake_error(
+            msg_id,
+            now_ms,
+            ErrorCode::Internal,
+            "route decision control blocked: target RouteDecision is not owned by the authenticated owner",
+        );
+    }
+
+    let (override_lane, override_provider_or_agent) = match request.control_kind.as_str() {
+        "veto" => {
+            if request.override_lane.is_some() || request.override_provider_or_agent.is_some() {
+                return mission_intake_error(
+                    msg_id,
+                    now_ms,
+                    ErrorCode::Internal,
+                    "route decision control blocked: veto cannot carry override target",
+                );
+            }
+            (None, None)
+        }
+        "override" => {
+            let Some(lane) = request.override_lane.as_deref() else {
+                return mission_intake_error(
+                    msg_id,
+                    now_ms,
+                    ErrorCode::Internal,
+                    "route decision control blocked: override requires override_lane",
+                );
+            };
+            let lane = match work_lane_from_wire(lane) {
+                Ok(lane) => lane,
+                Err(message) => {
+                    return mission_intake_error(msg_id, now_ms, ErrorCode::Internal, message);
+                }
+            };
+            (Some(lane), request.override_provider_or_agent.as_deref())
+        }
+        _ => {
+            return mission_intake_error(
+                msg_id,
+                now_ms,
+                ErrorCode::Internal,
+                "route decision control blocked: control_kind is unknown",
+            );
+        }
+    };
+
+    let result = match request.control_kind.as_str() {
+        "veto" => db.veto_route_decision(
+            &resolved_decision_id,
+            &request.actor_ref,
+            &request.reason,
+            now_ms,
+        ),
+        "override" => db.override_route_decision(
+            &resolved_decision_id,
+            override_lane.expect("override lane was validated above"),
+            override_provider_or_agent,
+            &request.actor_ref,
+            &request.reason,
+            now_ms,
+        ),
+        _ => unreachable!("control_kind was validated above"),
+    };
+
+    match result {
+        Ok(()) => match db.get_route_decision(&resolved_decision_id) {
+            Ok(Some(decision)) => Envelope::new(
+                format!("{msg_id}-route-decision-control"),
+                now_ms,
+                Message::RouteDecisionControlResult {
+                    result: RouteDecisionControlResultWire {
+                        decision_id: decision.decision_id,
+                        mission_id: decision.mission_id,
+                        work_item_id: decision.work_item_id,
+                        control_kind: request.control_kind,
+                        override_lane: override_lane.map(|lane| lane.as_str().to_string()),
+                        override_provider_or_agent: request.override_provider_or_agent,
+                        actor_ref: request.actor_ref,
+                        reason: request.reason,
+                        updated_at_ms: now_ms,
+                    },
+                },
+            ),
+            Ok(None) => mission_intake_error(
+                msg_id,
+                now_ms,
+                ErrorCode::Internal,
+                "route decision control blocked: RouteDecision disappeared after control write",
+            ),
+            Err(err) => mission_intake_error(
+                msg_id,
+                now_ms,
+                ErrorCode::Internal,
+                &format!("route decision control blocked: {err}"),
+            ),
+        },
+        Err(err) => mission_intake_error(
+            msg_id,
+            now_ms,
+            ErrorCode::Internal,
+            &format!("route decision control blocked: {err}"),
+        ),
+    }
+}
+
+fn resolve_route_decision_control_target(
+    db: &Db,
+    request: &RouteDecisionControlRequestWire,
+) -> Result<(String, Option<friday_core::RouteDecisionCard>), &'static str> {
+    let direct = db
+        .get_route_decision(&request.decision_id)
+        .map_err(|_| "route decision control blocked: target lookup failed")?;
+    if let Some(decision) = direct {
+        return Ok((request.decision_id.clone(), Some(decision)));
+    }
+
+    let mission_id = request
+        .mission_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .ok_or("route decision control blocked: projection ref requires mission_id")?;
+    let projection_ref = request.decision_id.trim();
+    let mut matches = db
+        .list_route_decisions_for_mission(mission_id)
+        .map_err(|_| "route decision control blocked: mission lookup failed")?
+        .into_iter()
+        .filter(|candidate| {
+            candidate.to_projection().route_decision_ref == projection_ref
+                && request
+                    .work_item_id
+                    .as_deref()
+                    .map(str::trim)
+                    .filter(|value| !value.is_empty())
+                    .map_or(true, |work_item_id| candidate.work_item_id == work_item_id)
+        })
+        .collect::<Vec<_>>();
+    if matches.len() != 1 {
+        return Err("route decision control blocked: projection ref did not resolve to exactly one RouteDecision");
+    }
+    let decision = matches.remove(0);
+    Ok((decision.decision_id.clone(), Some(decision)))
 }
 
 /// Apply the OWNER's explicit confirm/reject decision to ONE pending memory

--- a/rust-core/crates/friday-hub/src/workbench_projection.rs
+++ b/rust-core/crates/friday-hub/src/workbench_projection.rs
@@ -124,6 +124,8 @@ pub fn project_workbench(db: &Db, requested_mission_id: Option<&str>) -> Result<
         "routeDecision": {
             "advisorSummary": route_decision.why_this_route,
             "selectedRoute": redacted_ref("route-decision", &route_decision.route_decision_ref),
+            "controlRef": route_decision.route_decision_ref,
+            "workItemId": route_decision.work_item_id,
             "alternatives": route_decision.considered_options,
             "actionItems": route_decision_action_items_json(&route_decision.action_items),
             "truthLabel": "friday_owned"

--- a/rust-core/crates/friday-protocol/src/lib.rs
+++ b/rust-core/crates/friday-protocol/src/lib.rs
@@ -50,9 +50,15 @@ use thiserror::Error;
 /// so deploying a v13 binary changes NO live behavior. The constraint fields added
 /// to `AgentRunRequest` are additive-optional (absent ⇒ byte-identical to the
 /// pre-A1 wire), so the live courier's current bytes still decode to no-constraints.
-pub const CURRENT_SCHEMA_VERSION: u16 = 13;
+///
+/// v14 (D20 W1 route-decision control) adds `RouteDecisionControlRequest/Result`.
+/// These wire the existing Hub-owned route veto/override lifecycle controls through
+/// the sealed Mission Spine dispatch flag. They stay refs-only and default-dark: a
+/// v14 binary with the dispatch flag off still echoes the message as a keepalive,
+/// changing no live behavior.
+pub const CURRENT_SCHEMA_VERSION: u16 = 14;
 /// The inclusive range of versions this build supports.
-pub const SUPPORTED: VersionRange = VersionRange { min: 1, max: 13 };
+pub const SUPPORTED: VersionRange = VersionRange { min: 1, max: 14 };
 
 /// A surface-safe Mission projection. This is the wire shape mobile, desktop, and
 /// channel surfaces may render. It intentionally has no raw provider ids, channel
@@ -268,6 +274,43 @@ pub struct WorkItemStatusResultWire {
     pub reason: String,
     /// COUNT of persisted proof receipts (never the raw receipt refs themselves).
     pub proof_receipt_count: u64,
+    pub updated_at_ms: i64,
+}
+
+/// Client request to apply one OWNER route-decision control before dispatch.
+/// `control_kind="veto"` blocks the `ReadyToDispatch -> Dispatched` transition;
+/// `control_kind="override"` changes the selected lane/target when that transition
+/// is applied. This is Hub-owned lifecycle control, never a provider/model call.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RouteDecisionControlRequestWire {
+    pub decision_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mission_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub work_item_id: Option<String>,
+    pub control_kind: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub override_lane: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub override_provider_or_agent: Option<String>,
+    pub actor_ref: String,
+    pub reason: String,
+}
+
+/// Hub response after one route-decision control is persisted. It carries only
+/// canonical ids and the chosen control; it is not a provider dispatch receipt.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RouteDecisionControlResultWire {
+    pub decision_id: String,
+    pub mission_id: String,
+    pub work_item_id: String,
+    pub control_kind: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub override_lane: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub override_provider_or_agent: Option<String>,
+    pub actor_ref: String,
+    pub reason: String,
     pub updated_at_ms: i64,
 }
 
@@ -1328,6 +1371,17 @@ pub enum Message {
     /// status here is honest precisely because the proof-on-completion invariant
     /// was enforced before the write.
     WorkItemStatusResult { result: WorkItemStatusResultWire },
+    /// client->hub: apply an OWNER route-decision control before dispatch.
+    /// A veto blocks the dispatch transition; an override changes lane/target at
+    /// the lifecycle hook. Never a provider/model call.
+    RouteDecisionControlRequest {
+        request: RouteDecisionControlRequestWire,
+    },
+    /// hub->client: route-decision control receipt. This only records the
+    /// pre-dispatch control, not provider execution.
+    RouteDecisionControlResult {
+        result: RouteDecisionControlResultWire,
+    },
     /// client->hub: apply the OWNER's explicit confirm/reject decision to ONE
     /// pending memory candidate (the Memory-confirmation loop's terminal action).
     /// Never a provider/model call. Owner/namespace-scoped: applies ONLY when
@@ -2984,14 +3038,49 @@ mod tests {
     }
 
     #[test]
-    fn schema_version_bumped_to_thirteen_for_run_controls() {
+    fn schema_version_bumped_to_fourteen_for_route_decision_controls() {
         // A1 bumps the wire version so a v13 peer advertises the run-CONTROL kinds
         // (Paused/Resume/Cancel/Reject/ControlResult) exist — wire-compat honesty — even
         // while nothing emits them yet (DARK, behind the default-off flag). S-A's v12
         // substrate kinds are still present and unchanged.
-        assert_eq!(CURRENT_SCHEMA_VERSION, 13);
-        assert_eq!(SUPPORTED.max, 13);
+        assert_eq!(CURRENT_SCHEMA_VERSION, 14);
+        assert_eq!(SUPPORTED.max, 14);
         assert_eq!(SUPPORTED.min, 1);
+    }
+
+    #[test]
+    fn route_decision_control_wire_is_refs_only_and_round_trips() {
+        let env = Envelope::new(
+            "route-control-1",
+            1000,
+            Message::RouteDecisionControlRequest {
+                request: RouteDecisionControlRequestWire {
+                    decision_id: "route-decision-1".into(),
+                    mission_id: Some("mission-1".into()),
+                    work_item_id: Some("work-1".into()),
+                    control_kind: "override".into(),
+                    override_lane: Some("codex".into()),
+                    override_provider_or_agent: Some("codex".into()),
+                    actor_ref: "operator:jarvis".into(),
+                    reason: "Codex owns this edit".into(),
+                },
+            },
+        );
+        let json = env.encode().unwrap();
+        assert!(json.contains("\"kind\":\"RouteDecisionControlRequest\""));
+        assert!(json.contains("\"decision_id\":\"route-decision-1\""));
+        for forbidden in [
+            "raw transcript",
+            "provider-thread",
+            "sk-",
+            "/Users/jarvis/private",
+        ] {
+            assert!(
+                !json.contains(forbidden),
+                "route decision control wire leaked {forbidden}: {json}"
+            );
+        }
+        assert_eq!(Envelope::decode(&json).unwrap(), env);
     }
 
     // --- A1 run-controls: the on-wire control protocol (v13) --------------------

--- a/src/api/http/routes/friday-mission-spine-routes.ts
+++ b/src/api/http/routes/friday-mission-spine-routes.ts
@@ -11,6 +11,8 @@ import type {
   FridayRustHubMissionIntakeResult,
   FridayRustHubMissionLifecycleRequest,
   FridayRustHubMissionLifecycleResult,
+  FridayRustHubRouteDecisionControlRequest,
+  FridayRustHubRouteDecisionControlResult,
   FridayRustHubWorkItemStatusRequest,
   FridayRustHubWorkItemStatusResult,
 } from "../../mission-spine/friday-rust-hub-agent-run-ws-sealed-client.js";
@@ -44,6 +46,9 @@ export interface FridayMissionSpineDispatchService {
   transitionWorkItem(
     request: FridayRustHubWorkItemStatusRequest,
   ): Promise<FridayRustHubWorkItemStatusResult>;
+  controlRouteDecision(
+    request: FridayRustHubRouteDecisionControlRequest,
+  ): Promise<FridayRustHubRouteDecisionControlResult>;
 }
 
 export interface FridayMissionSpineRoutesDeps {
@@ -68,6 +73,9 @@ export interface FridayMissionSpineLifecycleResponse {
 }
 export interface FridayMissionSpineWorkItemStatusResponse {
   readonly result: FridayRustHubWorkItemStatusResult;
+}
+export interface FridayMissionSpineRouteDecisionControlResponse {
+  readonly result: FridayRustHubRouteDecisionControlResult;
 }
 
 const DEFAULT_DISABLED_MESSAGE =
@@ -96,6 +104,7 @@ const ROUTE_ACTION_REVERSIBILITY = new Set([
   "operator_gate_required",
   "pending_classify",
 ]);
+const WORK_LANES = new Set(["friday_hub", "codex", "claude", "deepseek", "workflow", "channel", "human", "future_api"]);
 const PLACEHOLDER_MARKERS = [
   "mission_pending_runtime_projection",
   "conversation_pending_runtime_projection",
@@ -353,6 +362,57 @@ function validateWorkItemStatusBody(workItemId: string, body: unknown): FridayRu
   };
 }
 
+/** Validate a RouteDecision control body + path decisionId into the typed request (or throw 400). */
+function validateRouteDecisionControlBody(
+  decisionId: string,
+  body: unknown,
+): FridayRustHubRouteDecisionControlRequest {
+  const surface = "api:/v1/mission-spine/route-decisions/:decisionId/control";
+  const b = asBody(body);
+  const failures: string[] = [];
+  const trimmedDecisionId = typeof decisionId === "string" ? decisionId.trim() : "";
+  if (trimmedDecisionId.length === 0) failures.push("decisionId_missing_or_empty");
+  const controlKind = readRequiredString(b, "controlKind", failures);
+  const missionId = readOptionalString(b, "missionId", failures);
+  const workItemId = readOptionalString(b, "workItemId", failures);
+  const overrideLane = readOptionalString(b, "overrideLane", failures);
+  const overrideProviderOrAgent = readOptionalString(b, "overrideProviderOrAgent", failures);
+  const actorRef = readRequiredString(b, "actorRef", failures);
+  const reason = readRequiredString(b, "reason", failures);
+  if (controlKind !== undefined && controlKind !== "veto" && controlKind !== "override") {
+    failures.push("control_kind_invalid");
+  }
+  if (controlKind === "veto" && (overrideLane !== undefined || overrideProviderOrAgent !== undefined)) {
+    failures.push("veto_cannot_carry_override_target");
+  }
+  if (controlKind === "override") {
+    if (overrideLane === undefined) {
+      failures.push("override_lane_required");
+    } else if (!WORK_LANES.has(overrideLane)) {
+      failures.push("override_lane_invalid");
+    }
+  }
+  if (
+    failures.length > 0 ||
+    controlKind === undefined ||
+    actorRef === undefined ||
+    reason === undefined
+  ) {
+    throwInvalidBody(surface, failures);
+  }
+  const parsedControlKind = controlKind as "veto" | "override";
+  return {
+    decisionId: trimmedDecisionId,
+    ...(missionId !== undefined ? { missionId } : {}),
+    ...(workItemId !== undefined ? { workItemId } : {}),
+    controlKind: parsedControlKind,
+    ...(overrideLane !== undefined ? { overrideLane } : {}),
+    ...(overrideProviderOrAgent !== undefined ? { overrideProviderOrAgent } : {}),
+    actorRef,
+    reason,
+  };
+}
+
 function readPathParam(params: unknown, key: string): string {
   if (!params || typeof params !== "object") return "";
   const value = (params as Record<string, unknown>)[key];
@@ -415,6 +475,8 @@ function validateSnapshotHeader(
   pushIfInvalid(failures, hasText(snapshot.duplicatePreflight.duplicateWorkItemId), "duplicate_work_item_missing");
   pushIfInvalid(failures, hasText(snapshot.routeDecision.advisorSummary), "route_decision_summary_missing");
   pushIfInvalid(failures, hasText(snapshot.routeDecision.selectedRoute), "route_decision_selected_missing");
+  pushIfInvalid(failures, hasText(snapshot.routeDecision.controlRef), "route_decision_control_ref_missing");
+  pushIfInvalid(failures, hasText(snapshot.routeDecision.workItemId), "route_decision_work_item_id_missing");
   pushIfInvalid(failures, TRUTH_LABELS.has(snapshot.routeDecision.truthLabel), "route_decision_truth_label_invalid");
   pushIfInvalid(failures, Array.isArray(snapshot.routeDecision.actionItems), "route_decision_action_items_not_array");
   if (Array.isArray(snapshot.routeDecision.actionItems)) {
@@ -760,6 +822,25 @@ export function createFridayMissionSpineRoutes(
         const workItemId = readPathParam(ctx.params, "workItemId");
         const request = validateWorkItemStatusBody(workItemId, ctx.body);
         const result = await dispatch.transitionWorkItem(request);
+        return { result };
+      },
+    },
+    // (D20 W1-S3) ROUTE-DECISION CONTROL — POST. This is the operator-triggerable control
+    // surface for veto/override before dispatch. It is load-bearing because Rust storage checks the
+    // persisted control at the ReadyToDispatch -> Dispatched transition.
+    {
+      operationId: "mission.spine.routedecision.control",
+      method: "POST",
+      path: "/v1/mission-spine/route-decisions/:decisionId/control",
+      auth: { public: true },
+      async handler(ctx): Promise<FridayMissionSpineRouteDecisionControlResponse> {
+        if (!dispatch) {
+          throwDispatchDisabled("api:/v1/mission-spine/route-decisions/:decisionId/control");
+        }
+        assertBoundPrincipalForOperation(ctx.principal ?? null, "mission.spine.routedecision.control", "api");
+        const decisionId = readPathParam(ctx.params, "decisionId");
+        const request = validateRouteDecisionControlBody(decisionId, ctx.body);
+        const result = await dispatch.controlRouteDecision(request);
         return { result };
       },
     },

--- a/src/api/mission-spine/friday-mission-spine-dispatch-adapter.ts
+++ b/src/api/mission-spine/friday-mission-spine-dispatch-adapter.ts
@@ -10,6 +10,8 @@ import {
   type FridayRustHubMissionIntakeResult,
   type FridayRustHubMissionLifecycleRequest,
   type FridayRustHubMissionLifecycleResult,
+  type FridayRustHubRouteDecisionControlRequest,
+  type FridayRustHubRouteDecisionControlResult,
   type FridayRustHubWorkItemStatusRequest,
   type FridayRustHubWorkItemStatusResult,
 } from "./friday-rust-hub-agent-run-ws-sealed-client.js";
@@ -191,6 +193,19 @@ export function createFridayMissionSpineDispatchAdapter(
         throw error instanceof FridayDomainError
           ? error
           : unavailable("Mission-spine work-item dispatch failed.");
+      }
+    },
+
+    async controlRouteDecision(
+      request: FridayRustHubRouteDecisionControlRequest,
+    ): Promise<FridayRustHubRouteDecisionControlResult> {
+      const client = buildClient();
+      try {
+        return await client.controlRouteDecision(request);
+      } catch (error) {
+        throw error instanceof FridayDomainError
+          ? error
+          : unavailable("Mission-spine route-decision control dispatch failed.");
       }
     },
   };

--- a/src/api/mission-spine/friday-rust-hub-agent-run-ws-sealed-client.ts
+++ b/src/api/mission-spine/friday-rust-hub-agent-run-ws-sealed-client.ts
@@ -402,6 +402,16 @@ export interface FridayRustHubAgentRunSealedClient {
     request: FridayRustHubWorkItemStatusRequest,
   ): Promise<FridayRustHubWorkItemStatusResult>;
   /**
+   * (D20 W1-S3) Apply one OWNER route-decision veto/override over a sealed session —
+   * `Message::RouteDecisionControlRequest`. PURE Hub mutation. Awaits the FIRST
+   * `RouteDecisionControlResult`; fails closed on any other inbound. The storage lifecycle hook
+   * makes this control load-bearing at `ReadyToDispatch -> Dispatched`; this is not a decorative
+   * UI-only field.
+   */
+  controlRouteDecision(
+    request: FridayRustHubRouteDecisionControlRequest,
+  ): Promise<FridayRustHubRouteDecisionControlResult>;
+  /**
    * (Lane M) Apply the OWNER's explicit confirm/reject to ONE pending memory candidate over a
    * sealed session — `Message::MemoryDecisionRequest`. PURE Hub `&Db` mutation (NO model/provider
    * call). Awaits the FIRST `MemoryDecisionResult`; fails closed on any other inbound (including the
@@ -530,6 +540,32 @@ export interface FridayRustHubWorkItemStatusResult {
   readonly reason: string;
   /** COUNT of persisted proof receipts (never the raw receipt refs themselves). */
   readonly proofReceiptCount: number;
+  readonly updatedAtMs: number;
+}
+
+/** (D20 W1-S3) A pre-dispatch route decision veto/override — `RouteDecisionControlRequestWire`. */
+export interface FridayRustHubRouteDecisionControlRequest {
+  readonly decisionId: string;
+  readonly missionId?: string;
+  readonly workItemId?: string;
+  readonly controlKind: "veto" | "override";
+  readonly overrideLane?: string;
+  readonly overrideProviderOrAgent?: string;
+  readonly actorRef: string;
+  readonly reason: string;
+}
+
+/** (D20 W1-S3) Refs-only route decision control result — `RouteDecisionControlResultWire`. */
+export interface FridayRustHubRouteDecisionControlResult {
+  readonly truthLabel: "rust_wired";
+  readonly decisionId: string;
+  readonly missionId: string;
+  readonly workItemId: string;
+  readonly controlKind: "veto" | "override";
+  readonly overrideLane?: string;
+  readonly overrideProviderOrAgent?: string;
+  readonly actorRef: string;
+  readonly reason: string;
   readonly updatedAtMs: number;
 }
 
@@ -990,6 +1026,32 @@ export function buildWorkItemStatusEnvelope(
 }
 
 /**
+ * (D20 W1-S3) Build the `RouteDecisionControlRequest` inner message — the EXACT
+ * `RouteDecisionControlRequestWire` shape. `override_*` fields are omitted unless present; Rust
+ * validates the control kind and lane fail-closed.
+ */
+export function buildRouteDecisionControlEnvelope(
+  request: FridayRustHubRouteDecisionControlRequest,
+): Record<string, unknown> {
+  const inner: Record<string, unknown> = {
+    decision_id: request.decisionId,
+    ...(request.missionId !== undefined ? { mission_id: request.missionId } : {}),
+    ...(request.workItemId !== undefined ? { work_item_id: request.workItemId } : {}),
+    control_kind: request.controlKind,
+    ...(request.overrideLane !== undefined ? { override_lane: request.overrideLane } : {}),
+    ...(request.overrideProviderOrAgent !== undefined
+      ? { override_provider_or_agent: request.overrideProviderOrAgent }
+      : {}),
+    actor_ref: request.actorRef,
+    reason: request.reason,
+  };
+  return buildMissionEnvelope(`route-decision-control-${request.decisionId}`, {
+    kind: "RouteDecisionControlRequest",
+    request: inner,
+  });
+}
+
+/**
  * (Lane M) Build the `MemoryDecisionRequest` inner message — the EXACT `MemoryDecisionRequestWire`
  * shape. CRITICAL: `Message::MemoryDecisionRequest { request: MemoryDecisionRequestWire }` is a
  * SINGLE-FIELD wrapper on an internally-tagged (`#[serde(tag = "kind")]`) `Message`, so serde
@@ -1171,6 +1233,50 @@ export function parseWorkItemStatusResult(
     actorRef,
     reason,
     proofReceiptCount,
+    updatedAtMs,
+  };
+}
+
+/**
+ * (D20 W1-S3) Parse a `RouteDecisionControlResult` inbound into the refs-only TS result.
+ */
+export function parseRouteDecisionControlResult(
+  fields: Record<string, unknown>,
+): FridayRustHubRouteDecisionControlResult | undefined {
+  const r = unwrapResult(fields);
+  if (r === undefined) {
+    return undefined;
+  }
+  const decisionId = asString(r.decision_id);
+  const missionId = asString(r.mission_id);
+  const workItemId = asString(r.work_item_id);
+  const controlKind = asString(r.control_kind);
+  const overrideLane = asString(r.override_lane);
+  const overrideProviderOrAgent = asString(r.override_provider_or_agent);
+  const actorRef = asString(r.actor_ref);
+  const reason = asString(r.reason);
+  const updatedAtMs = asNumber(r.updated_at_ms);
+  if (
+    !decisionId ||
+    !missionId ||
+    !workItemId ||
+    (controlKind !== "veto" && controlKind !== "override") ||
+    !actorRef ||
+    !reason ||
+    updatedAtMs === undefined
+  ) {
+    return undefined;
+  }
+  return {
+    truthLabel: "rust_wired",
+    decisionId,
+    missionId,
+    workItemId,
+    controlKind,
+    ...(overrideLane !== undefined ? { overrideLane } : {}),
+    ...(overrideProviderOrAgent !== undefined ? { overrideProviderOrAgent } : {}),
+    actorRef,
+    reason,
     updatedAtMs,
   };
 }
@@ -2099,6 +2205,26 @@ export function createFridayRustHubAgentRunSealedClient(
         expectedKind: "WorkItemStatusResult",
         parse: parseWorkItemStatusResult,
         leg: "work-item-status",
+      });
+    },
+
+    controlRouteDecision(
+      request: FridayRustHubRouteDecisionControlRequest,
+    ): Promise<FridayRustHubRouteDecisionControlResult> {
+      if (!request.decisionId || !request.controlKind) {
+        return Promise.reject(
+          unavailable("Sealed mission-spine client route decision control requires a decision id and control kind."),
+        );
+      }
+      return runMissionRoundTrip<FridayRustHubRouteDecisionControlResult>({
+        host,
+        port,
+        timeoutMs,
+        keypair,
+        envelope: buildRouteDecisionControlEnvelope(request),
+        expectedKind: "RouteDecisionControlResult",
+        parse: parseRouteDecisionControlResult,
+        leg: "route-decision-control",
       });
     },
 

--- a/src/api/model/friday-api-mission-spine.types.ts
+++ b/src/api/model/friday-api-mission-spine.types.ts
@@ -141,6 +141,8 @@ export interface FridayMissionSpineWorkbenchSnapshot {
   routeDecision: {
     advisorSummary: string;
     selectedRoute: string;
+    controlRef: string;
+    workItemId: string;
     alternatives: string[];
     actionItems: FridayMissionSpineRouteActionItem[];
     truthLabel: FridayMissionSpineTruthLabel;

--- a/src/security/friday-owner-session-channel-capability.ts
+++ b/src/security/friday-owner-session-channel-capability.ts
@@ -86,13 +86,14 @@ export type FridayPublicMutationOperation =
   | "cloud.worker.dns.validate"
   | "cloud.worker.package.generate"
   | "cloud.worker.teardown.receipt"
-  // Lane B — organic mission-spine mutations driven over the sealed-WS dispatch
-  // arms (Mission intake / Mission lifecycle / WorkItem status). Public mutating
-  // routes: refuse the synthetic public principal; only a bound owner drives a
-  // Mission/WorkItem transition.
+  // Lane B / D20 W1 — organic mission-spine mutations driven over the sealed-WS dispatch
+  // arms (Mission intake / Mission lifecycle / WorkItem status / RouteDecision control).
+  // Public mutating routes: refuse the synthetic public principal; only a bound owner drives a
+  // Mission/WorkItem transition or pre-dispatch route veto/override.
   | "mission.spine.intake"
   | "mission.spine.lifecycle"
   | "mission.spine.workitem.status"
+  | "mission.spine.routedecision.control"
   // Lane M — the memory-confirmation loop's terminal mutation driven over the
   // sealed-WS dispatch arm (OWNER confirm/reject of ONE memory candidate). Public
   // mutating route: refuse the synthetic public principal; only a bound owner can

--- a/test/contracts/api/__snapshots__/friday-api-route-contract.snapshot.test.ts.snap
+++ b/test/contracts/api/__snapshots__/friday-api-route-contract.snapshot.test.ts.snap
@@ -3,14 +3,14 @@
 exports[`MECHANISM-4 — API Route Contract (Snapshot) > Phase 14.5A WP-001: every public mutating route maps to an accepted gate family 1`] = `
 {
   "classified": {
-    "bound_principal": 63,
+    "bound_principal": 64,
     "channel_signature": 4,
     "hmac_or_bearer_opt_in": 1,
     "public_low_risk": 2,
     "rate_limited_pending": 4,
     "unclassified": 251,
   },
-  "total_public_mutating": 325,
+  "total_public_mutating": 326,
   "unclassified_sample_max_5": [
     "capabilities.acquisition.runs.create",
     "capabilities.acquisition.runs.approve",
@@ -21,7 +21,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > Phase 14.5A WP-001: eve
 }
 `;
 
-exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures route count to detect accidental additions/removals 1`] = `424`;
+exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures route count to detect accidental additions/removals 1`] = `425`;
 
 exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route surface as a stable contract 1`] = `
 [
@@ -1839,6 +1839,16 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
     "authKind": "public",
     "index": 181,
     "method": "POST",
+    "operationId": "mission.spine.routedecision.control",
+    "path": "/v1/mission-spine/route-decisions/:decisionId/control",
+    "rateLimitPolicyId": null,
+    "roles": [],
+    "scopes": [],
+  },
+  {
+    "authKind": "public",
+    "index": 182,
+    "method": "POST",
     "operationId": "memory.spine.decide.apply",
     "path": "/v1/memory-spine/decide",
     "rateLimitPolicyId": null,
@@ -1847,7 +1857,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 182,
+    "index": 183,
     "method": "POST",
     "operationId": "realtime.subscribe",
     "path": "/v1/realtime/subscriptions",
@@ -1857,7 +1867,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 183,
+    "index": 184,
     "method": "POST",
     "operationId": "realtime.pull",
     "path": "/v1/realtime/pull",
@@ -1867,7 +1877,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 184,
+    "index": 185,
     "method": "POST",
     "operationId": "realtime.ack",
     "path": "/v1/realtime/ack",
@@ -1877,7 +1887,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 185,
+    "index": 186,
     "method": "GET",
     "operationId": "providers.usage.get",
     "path": "/v1/providers/usage",
@@ -1887,7 +1897,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 186,
+    "index": 187,
     "method": "GET",
     "operationId": "providers.budget.get",
     "path": "/v1/providers/budget",
@@ -1897,7 +1907,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 187,
+    "index": 188,
     "method": "PUT",
     "operationId": "providers.budget.set",
     "path": "/v1/providers/budget",
@@ -1907,7 +1917,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 188,
+    "index": 189,
     "method": "GET",
     "operationId": "providers.templates.list",
     "path": "/v1/providers/templates",
@@ -1917,7 +1927,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 189,
+    "index": 190,
     "method": "GET",
     "operationId": "providers.templates.get",
     "path": "/v1/providers/templates/:templateId",
@@ -1927,7 +1937,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 190,
+    "index": 191,
     "method": "GET",
     "operationId": "providers.list",
     "path": "/v1/providers",
@@ -1937,7 +1947,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 191,
+    "index": 192,
     "method": "GET",
     "operationId": "providers.health.list",
     "path": "/v1/providers/health",
@@ -1947,7 +1957,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 192,
+    "index": 193,
     "method": "GET",
     "operationId": "providers.capability.health.list",
     "path": "/v1/providers/capability-health",
@@ -1957,7 +1967,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 193,
+    "index": 194,
     "method": "POST",
     "operationId": "capabilities.doctor",
     "path": "/v1/capabilities/doctor",
@@ -1967,7 +1977,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 194,
+    "index": 195,
     "method": "GET",
     "operationId": "providers.get",
     "path": "/v1/providers/:providerId",
@@ -1977,7 +1987,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 195,
+    "index": 196,
     "method": "POST",
     "operationId": "providers.create",
     "path": "/v1/providers",
@@ -1987,7 +1997,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 196,
+    "index": 197,
     "method": "PATCH",
     "operationId": "providers.update",
     "path": "/v1/providers/:providerId",
@@ -1997,7 +2007,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 197,
+    "index": 198,
     "method": "DELETE",
     "operationId": "providers.delete",
     "path": "/v1/providers/:providerId",
@@ -2007,7 +2017,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 198,
+    "index": 199,
     "method": "POST",
     "operationId": "providers.validate",
     "path": "/v1/providers/:providerId/validate",
@@ -2017,7 +2027,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 199,
+    "index": 200,
     "method": "GET",
     "operationId": "providers.doctor",
     "path": "/v1/providers/:providerId/doctor",
@@ -2027,7 +2037,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 200,
+    "index": 201,
     "method": "GET",
     "operationId": "providers.routing.explain",
     "path": "/v1/providers/routing/explain",
@@ -2037,7 +2047,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 201,
+    "index": 202,
     "method": "POST",
     "operationId": "providers.routing.pin",
     "path": "/v1/providers/routing/pin",
@@ -2047,7 +2057,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 202,
+    "index": 203,
     "method": "POST",
     "operationId": "providers.routing.penalty.clear",
     "path": "/v1/providers/routing/penalties/clear",
@@ -2057,7 +2067,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 203,
+    "index": 204,
     "method": "GET",
     "operationId": "providers.auth.profiles.list",
     "path": "/v1/providers/:providerId/auth-profiles",
@@ -2067,7 +2077,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 204,
+    "index": 205,
     "method": "POST",
     "operationId": "providers.auth.profiles.activate",
     "path": "/v1/providers/:providerId/auth-profiles/:profileKey/activate",
@@ -2077,7 +2087,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 205,
+    "index": 206,
     "method": "GET",
     "operationId": "providers.routing.get",
     "path": "/v1/model-routing",
@@ -2087,7 +2097,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 206,
+    "index": 207,
     "method": "PUT",
     "operationId": "providers.routing.set",
     "path": "/v1/model-routing",
@@ -2097,7 +2107,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 207,
+    "index": 208,
     "method": "POST",
     "operationId": "auth.oauth.anthropic.initiate",
     "path": "/v1/auth/oauth/anthropic/initiate",
@@ -2107,7 +2117,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 208,
+    "index": 209,
     "method": "POST",
     "operationId": "auth.oauth.anthropic.callback",
     "path": "/v1/auth/oauth/anthropic/callback",
@@ -2117,7 +2127,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 209,
+    "index": 210,
     "method": "POST",
     "operationId": "auth.oauth.openai.codex.device.initiate",
     "path": "/v1/auth/oauth/openai-codex/device/initiate",
@@ -2127,7 +2137,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 210,
+    "index": 211,
     "method": "POST",
     "operationId": "auth.oauth.openai.codex.device.complete",
     "path": "/v1/auth/oauth/openai-codex/device/complete",
@@ -2137,7 +2147,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 211,
+    "index": 212,
     "method": "POST",
     "operationId": "media.understanding.doctor",
     "path": "/v1/media-understanding/doctor",
@@ -2147,7 +2157,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 212,
+    "index": 213,
     "method": "POST",
     "operationId": "media.understanding.analyze",
     "path": "/v1/media-understanding/analyze",
@@ -2157,7 +2167,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 213,
+    "index": 214,
     "method": "GET",
     "operationId": "task.workflows.boundaries.list",
     "path": "/v1/task-workflows/boundaries",
@@ -2167,7 +2177,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 214,
+    "index": 215,
     "method": "GET",
     "operationId": "task.workflows.gates.list",
     "path": "/v1/task-workflows/gates",
@@ -2177,7 +2187,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 215,
+    "index": 216,
     "method": "POST",
     "operationId": "task.workflows.preview",
     "path": "/v1/task-workflows/preview",
@@ -2187,7 +2197,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 216,
+    "index": 217,
     "method": "POST",
     "operationId": "task.workflows.create",
     "path": "/v1/task-workflows",
@@ -2197,7 +2207,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 217,
+    "index": 218,
     "method": "GET",
     "operationId": "task.workflows.list",
     "path": "/v1/task-workflows",
@@ -2207,7 +2217,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 218,
+    "index": 219,
     "method": "GET",
     "operationId": "task.workflows.get",
     "path": "/v1/task-workflows/:workflowId",
@@ -2217,7 +2227,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 219,
+    "index": 220,
     "method": "POST",
     "operationId": "task.workflows.revise",
     "path": "/v1/task-workflows/:workflowId/revisions",
@@ -2227,7 +2237,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 220,
+    "index": 221,
     "method": "GET",
     "operationId": "task.workflows.revisions.list",
     "path": "/v1/task-workflows/:workflowId/revisions",
@@ -2237,7 +2247,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 221,
+    "index": 222,
     "method": "POST",
     "operationId": "task.workflows.claims.create",
     "path": "/v1/task-workflows/:workflowId/claims",
@@ -2247,7 +2257,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 222,
+    "index": 223,
     "method": "GET",
     "operationId": "task.workflows.claims.list",
     "path": "/v1/task-workflows/:workflowId/claims",
@@ -2257,7 +2267,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 223,
+    "index": 224,
     "method": "GET",
     "operationId": "task.workflows.claims.get",
     "path": "/v1/task-workflows/:workflowId/claims/:claimId",
@@ -2267,7 +2277,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 224,
+    "index": 225,
     "method": "POST",
     "operationId": "task.workflows.claims.evidence.attach",
     "path": "/v1/task-workflows/:workflowId/claims/:claimId/evidence-ref",
@@ -2277,7 +2287,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 225,
+    "index": 226,
     "method": "GET",
     "operationId": "task.workflows.claims.evidence.list",
     "path": "/v1/task-workflows/:workflowId/claims/:claimId/evidence-refs",
@@ -2287,7 +2297,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 226,
+    "index": 227,
     "method": "POST",
     "operationId": "task.workflows.claims.verify",
     "path": "/v1/task-workflows/:workflowId/claims/:claimId/verify",
@@ -2297,7 +2307,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 227,
+    "index": 228,
     "method": "POST",
     "operationId": "task.workflows.claims.block",
     "path": "/v1/task-workflows/:workflowId/claims/:claimId/block",
@@ -2307,7 +2317,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 228,
+    "index": 229,
     "method": "POST",
     "operationId": "task.workflows.closeout",
     "path": "/v1/task-workflows/:workflowId/closeout",
@@ -2317,7 +2327,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 229,
+    "index": 230,
     "method": "POST",
     "operationId": "task.workflows.lanes.executor.open",
     "path": "/v1/task-workflows/:workflowId/lanes/executor",
@@ -2327,7 +2337,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 230,
+    "index": 231,
     "method": "POST",
     "operationId": "task.workflows.lanes.verifier.open",
     "path": "/v1/task-workflows/:workflowId/lanes/verifier",
@@ -2337,7 +2347,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 231,
+    "index": 232,
     "method": "POST",
     "operationId": "task.workflows.lanes.complete",
     "path": "/v1/task-workflows/:workflowId/lanes/:laneId/complete",
@@ -2347,7 +2357,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 232,
+    "index": 233,
     "method": "POST",
     "operationId": "task.workflows.lanes.verdict",
     "path": "/v1/task-workflows/:workflowId/lanes/:laneId/verdict",
@@ -2357,7 +2367,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 233,
+    "index": 234,
     "method": "GET",
     "operationId": "task.workflows.lanes.list",
     "path": "/v1/task-workflows/:workflowId/lanes",
@@ -2367,7 +2377,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 234,
+    "index": 235,
     "method": "GET",
     "operationId": "task.workflows.lanes.get",
     "path": "/v1/task-workflows/:workflowId/lanes/:laneId",
@@ -2377,7 +2387,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 235,
+    "index": 236,
     "method": "POST",
     "operationId": "task.workflows.lanes.cli.handoff.record",
     "path": "/v1/task-workflows/:workflowId/lanes/:laneId/cli-handoffs",
@@ -2387,7 +2397,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 236,
+    "index": 237,
     "method": "GET",
     "operationId": "task.workflows.lanes.cli.handoffs.list",
     "path": "/v1/task-workflows/:workflowId/lanes/:laneId/cli-handoffs",
@@ -2397,7 +2407,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 237,
+    "index": 238,
     "method": "GET",
     "operationId": "task.workflows.cli.handoffs.list",
     "path": "/v1/task-workflows/:workflowId/cli-handoffs",
@@ -2407,7 +2417,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 238,
+    "index": 239,
     "method": "GET",
     "operationId": "task.workflows.supervisor.read",
     "path": "/v1/task-workflows/:workflowId/supervisor",
@@ -2417,7 +2427,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 239,
+    "index": 240,
     "method": "POST",
     "operationId": "task.workflows.channel.command.issue",
     "path": "/v1/task-workflows/:workflowId/channel-commands",
@@ -2427,7 +2437,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 240,
+    "index": 241,
     "method": "GET",
     "operationId": "task.workflows.channel.command.list",
     "path": "/v1/task-workflows/:workflowId/channel-commands",
@@ -2437,7 +2447,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 241,
+    "index": 242,
     "method": "POST",
     "operationId": "task.workflows.channel.command.confirm",
     "path": "/v1/task-workflows/:workflowId/channel-commands/confirm",
@@ -2447,7 +2457,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 242,
+    "index": 243,
     "method": "GET",
     "operationId": "task.workflows.evidence.explorer.query",
     "path": "/v1/task-workflows/evidence",
@@ -2457,7 +2467,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 243,
+    "index": 244,
     "method": "GET",
     "operationId": "task.workflows.evidence.explorer.raw",
     "path": "/v1/task-workflows/evidence/:evidenceRefId/raw",
@@ -2467,7 +2477,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 244,
+    "index": 245,
     "method": "POST",
     "operationId": "skills.social.import",
     "path": "/v1/skills/social-import",
@@ -2477,7 +2487,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 245,
+    "index": 246,
     "method": "GET",
     "operationId": "setup.status",
     "path": "/v1/setup/status",
@@ -2487,7 +2497,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 246,
+    "index": 247,
     "method": "POST",
     "operationId": "providers.detect",
     "path": "/v1/providers/detect",
@@ -2497,7 +2507,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 247,
+    "index": 248,
     "method": "GET",
     "operationId": "setup.network.get",
     "path": "/v1/setup/network",
@@ -2507,7 +2517,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 248,
+    "index": 249,
     "method": "POST",
     "operationId": "setup.network.save",
     "path": "/v1/setup/network",
@@ -2517,7 +2527,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 249,
+    "index": 250,
     "method": "POST",
     "operationId": "setup.channels.feishu.registration.begin",
     "path": "/v1/setup/channels/feishu/registration/begin",
@@ -2527,7 +2537,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 250,
+    "index": 251,
     "method": "POST",
     "operationId": "setup.channels.feishu.registration.poll",
     "path": "/v1/setup/channels/feishu/registration/poll",
@@ -2537,7 +2547,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 251,
+    "index": 252,
     "method": "POST",
     "operationId": "setup.channels.telegram.verification.begin",
     "path": "/v1/setup/channels/telegram/verification/begin",
@@ -2547,7 +2557,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 252,
+    "index": 253,
     "method": "POST",
     "operationId": "setup.channels.telegram.verification.poll",
     "path": "/v1/setup/channels/telegram/verification/poll",
@@ -2557,7 +2567,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 253,
+    "index": 254,
     "method": "POST",
     "operationId": "setup.channels.discord.verification.begin",
     "path": "/v1/setup/channels/discord/verification/begin",
@@ -2567,7 +2577,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 254,
+    "index": 255,
     "method": "POST",
     "operationId": "setup.channels.discord.verification.complete",
     "path": "/v1/setup/channels/discord/verification/complete",
@@ -2577,7 +2587,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 255,
+    "index": 256,
     "method": "POST",
     "operationId": "setup.channels.test",
     "path": "/v1/setup/channels/test",
@@ -2587,7 +2597,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 256,
+    "index": 257,
     "method": "POST",
     "operationId": "setup.channels.save",
     "path": "/v1/setup/channels",
@@ -2597,7 +2607,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 257,
+    "index": 258,
     "method": "POST",
     "operationId": "setup.complete",
     "path": "/v1/setup/complete",
@@ -2607,7 +2617,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 258,
+    "index": 259,
     "method": "GET",
     "operationId": "skills.list",
     "path": "/v1/skills",
@@ -2617,7 +2627,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 259,
+    "index": 260,
     "method": "GET",
     "operationId": "skills.catalog.list",
     "path": "/v1/skills/catalog",
@@ -2627,7 +2637,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 260,
+    "index": 261,
     "method": "GET",
     "operationId": "skills.get",
     "path": "/v1/skills/:skillId",
@@ -2637,7 +2647,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 261,
+    "index": 262,
     "method": "POST",
     "operationId": "skills.install",
     "path": "/v1/skills/install",
@@ -2647,7 +2657,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 262,
+    "index": 263,
     "method": "POST",
     "operationId": "skills.update",
     "path": "/v1/skills/:skillId/update",
@@ -2657,7 +2667,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 263,
+    "index": 264,
     "method": "DELETE",
     "operationId": "skills.delete",
     "path": "/v1/skills/:skillId",
@@ -2667,7 +2677,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 264,
+    "index": 265,
     "method": "POST",
     "operationId": "skills.manifest.validate",
     "path": "/v1/skills/validate-manifest",
@@ -2677,7 +2687,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 265,
+    "index": 266,
     "method": "POST",
     "operationId": "skills.verify",
     "path": "/v1/skills/:skillId/verify",
@@ -2687,7 +2697,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 266,
+    "index": 267,
     "method": "POST",
     "operationId": "skills.upgrade.analyze",
     "path": "/v1/skills/:skillId/upgrade/analyze",
@@ -2697,7 +2707,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 267,
+    "index": 268,
     "method": "POST",
     "operationId": "skills.upgrade.decide",
     "path": "/v1/skills/:skillId/upgrade/decide",
@@ -2707,7 +2717,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 268,
+    "index": 269,
     "method": "POST",
     "operationId": "skills.run",
     "path": "/v1/skills/:skillId/run",
@@ -2717,7 +2727,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 269,
+    "index": 270,
     "method": "POST",
     "operationId": "skills.generator.sessions.create",
     "path": "/v1/skills/generator/sessions",
@@ -2727,7 +2737,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 270,
+    "index": 271,
     "method": "GET",
     "operationId": "skills.generator.sessions.get",
     "path": "/v1/skills/generator/sessions/:sessionId",
@@ -2737,7 +2747,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 271,
+    "index": 272,
     "method": "POST",
     "operationId": "skills.generator.sessions.messages.create",
     "path": "/v1/skills/generator/sessions/:sessionId/messages",
@@ -2747,7 +2757,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 272,
+    "index": 273,
     "method": "POST",
     "operationId": "skills.generator.sessions.generate",
     "path": "/v1/skills/generator/sessions/:sessionId/generate",
@@ -2757,7 +2767,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 273,
+    "index": 274,
     "method": "POST",
     "operationId": "skills.generator.sessions.test",
     "path": "/v1/skills/generator/sessions/:sessionId/test",
@@ -2767,7 +2777,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 274,
+    "index": 275,
     "method": "GET",
     "operationId": "skills.generator.sessions.evidence.get",
     "path": "/v1/skills/generator/sessions/:sessionId/evidence",
@@ -2777,7 +2787,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 275,
+    "index": 276,
     "method": "POST",
     "operationId": "skills.generator.sessions.approve",
     "path": "/v1/skills/generator/sessions/:sessionId/approve",
@@ -2787,7 +2797,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 276,
+    "index": 277,
     "method": "DELETE",
     "operationId": "skills.generator.sessions.cancel",
     "path": "/v1/skills/generator/sessions/:sessionId",
@@ -2797,7 +2807,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 277,
+    "index": 278,
     "method": "GET",
     "operationId": "skills.ui.get",
     "path": "/v1/skills/:skillId/ui",
@@ -2807,7 +2817,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 278,
+    "index": 279,
     "method": "POST",
     "operationId": "uix.intents.resolve",
     "path": "/v1/uix/intents/resolve",
@@ -2817,7 +2827,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 279,
+    "index": 280,
     "method": "GET",
     "operationId": "uix.templates.list",
     "path": "/v1/uix/templates",
@@ -2827,7 +2837,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 280,
+    "index": 281,
     "method": "GET",
     "operationId": "uix.home.snapshot.get",
     "path": "/v1/uix/home-snapshot",
@@ -2837,7 +2847,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 281,
+    "index": 282,
     "method": "GET",
     "operationId": "uix.assistant.inbox.snapshot.get",
     "path": "/v1/uix/assistant-inbox-snapshot",
@@ -2847,7 +2857,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 282,
+    "index": 283,
     "method": "GET",
     "operationId": "uix.diagnostics.get",
     "path": "/v1/uix/diagnostics",
@@ -2857,7 +2867,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 283,
+    "index": 284,
     "method": "GET",
     "operationId": "uix.preferences.list",
     "path": "/v1/uix/preferences",
@@ -2867,7 +2877,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 284,
+    "index": 285,
     "method": "PUT",
     "operationId": "uix.preferences.update",
     "path": "/v1/uix/preferences",
@@ -2877,7 +2887,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 285,
+    "index": 286,
     "method": "DELETE",
     "operationId": "uix.preferences.delete",
     "path": "/v1/uix/preferences/:preferenceId",
@@ -2887,7 +2897,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 286,
+    "index": 287,
     "method": "GET",
     "operationId": "uix.persona.get",
     "path": "/v1/uix/persona",
@@ -2897,7 +2907,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 287,
+    "index": 288,
     "method": "PUT",
     "operationId": "uix.persona.update",
     "path": "/v1/uix/persona",
@@ -2907,7 +2917,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 288,
+    "index": 289,
     "method": "POST",
     "operationId": "uix.templates.execute",
     "path": "/v1/uix/templates/:templateId/execute",
@@ -2917,7 +2927,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 289,
+    "index": 290,
     "method": "POST",
     "operationId": "uix.wizards.start",
     "path": "/v1/uix/wizards/:wizardId/start",
@@ -2927,7 +2937,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 290,
+    "index": 291,
     "method": "POST",
     "operationId": "uix.wizards.continue",
     "path": "/v1/uix/wizards/:wizardId/continue",
@@ -2937,7 +2947,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 291,
+    "index": 292,
     "method": "GET",
     "operationId": "uix.issues.list",
     "path": "/v1/uix/issues",
@@ -2947,7 +2957,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 292,
+    "index": 293,
     "method": "GET",
     "operationId": "uix.user.profile.get",
     "path": "/v1/uix/user-profile",
@@ -2957,7 +2967,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 293,
+    "index": 294,
     "method": "PUT",
     "operationId": "uix.user.profile.update",
     "path": "/v1/uix/user-profile",
@@ -2967,7 +2977,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 294,
+    "index": 295,
     "method": "POST",
     "operationId": "uix.investigate",
     "path": "/v1/uix/investigate",
@@ -2977,7 +2987,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 295,
+    "index": 296,
     "method": "GET",
     "operationId": "uix.learnedfacts.list",
     "path": "/v1/uix/learned-facts",
@@ -2987,7 +2997,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 296,
+    "index": 297,
     "method": "DELETE",
     "operationId": "uix.learnedfacts.clear",
     "path": "/v1/uix/learned-facts",
@@ -2997,7 +3007,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 297,
+    "index": 298,
     "method": "PATCH",
     "operationId": "uix.learnedfacts.update",
     "path": "/v1/uix/learned-facts/:factKey",
@@ -3007,7 +3017,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 298,
+    "index": 299,
     "method": "DELETE",
     "operationId": "uix.learnedfacts.delete",
     "path": "/v1/uix/learned-facts/:factKey",
@@ -3017,7 +3027,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 299,
+    "index": 300,
     "method": "GET",
     "operationId": "packs.cross.border.profile.get",
     "path": "/v1/packs/cross-border/profile",
@@ -3027,7 +3037,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 300,
+    "index": 301,
     "method": "PUT",
     "operationId": "packs.cross.border.profile.put",
     "path": "/v1/packs/cross-border/profile",
@@ -3037,7 +3047,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 301,
+    "index": 302,
     "method": "GET",
     "operationId": "packs.cross.border.snapshot.get",
     "path": "/v1/packs/cross-border/snapshot",
@@ -3047,7 +3057,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 302,
+    "index": 303,
     "method": "POST",
     "operationId": "packs.cross.border.import.post",
     "path": "/v1/packs/cross-border/import",
@@ -3057,7 +3067,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 303,
+    "index": 304,
     "method": "POST",
     "operationId": "packs.cross.border.workflow.presets.apply",
     "path": "/v1/packs/cross-border/workflow-presets/apply",
@@ -3067,7 +3077,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 304,
+    "index": 305,
     "method": "PATCH",
     "operationId": "packs.cross.border.workflow.presets.toggle",
     "path": "/v1/packs/cross-border/workflow-presets/:workflowId",
@@ -3077,7 +3087,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 305,
+    "index": 306,
     "method": "POST",
     "operationId": "packs.cross.border.run.evidence.capture",
     "path": "/v1/packs/cross-border/run-evidence",
@@ -3087,7 +3097,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 306,
+    "index": 307,
     "method": "PATCH",
     "operationId": "packs.cross.border.import.stale",
     "path": "/v1/packs/cross-border/imports/:importBatchId/stale",
@@ -3097,7 +3107,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 307,
+    "index": 308,
     "method": "POST",
     "operationId": "packs.cross.border.workflows.disable.all",
     "path": "/v1/packs/cross-border/workflows/disable-all",
@@ -3107,7 +3117,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 308,
+    "index": 309,
     "method": "GET",
     "operationId": "skills.converters.list",
     "path": "/v1/skills/converters",
@@ -3117,7 +3127,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 309,
+    "index": 310,
     "method": "POST",
     "operationId": "skills.convert",
     "path": "/v1/skills/convert",
@@ -3127,7 +3137,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 310,
+    "index": 311,
     "method": "POST",
     "operationId": "skills.import",
     "path": "/v1/skills/import",
@@ -3137,7 +3147,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 311,
+    "index": 312,
     "method": "POST",
     "operationId": "skills.pack",
     "path": "/v1/skills/pack",
@@ -3147,7 +3157,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 312,
+    "index": 313,
     "method": "POST",
     "operationId": "workflows.generator.sessions.create",
     "path": "/v1/workflows/generator/sessions",
@@ -3157,7 +3167,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 313,
+    "index": 314,
     "method": "GET",
     "operationId": "workflows.generator.sessions.get",
     "path": "/v1/workflows/generator/sessions/:sessionId",
@@ -3167,7 +3177,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 314,
+    "index": 315,
     "method": "POST",
     "operationId": "workflows.generator.sessions.messages.create",
     "path": "/v1/workflows/generator/sessions/:sessionId/messages",
@@ -3177,7 +3187,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 315,
+    "index": 316,
     "method": "POST",
     "operationId": "workflows.generator.sessions.generate",
     "path": "/v1/workflows/generator/sessions/:sessionId/generate",
@@ -3187,7 +3197,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 316,
+    "index": 317,
     "method": "GET",
     "operationId": "workflows.generator.sessions.evidence.get",
     "path": "/v1/workflows/generator/sessions/:sessionId/evidence",
@@ -3197,7 +3207,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 317,
+    "index": 318,
     "method": "POST",
     "operationId": "workflows.generator.sessions.approve",
     "path": "/v1/workflows/generator/sessions/:sessionId/approve",
@@ -3207,7 +3217,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 318,
+    "index": 319,
     "method": "DELETE",
     "operationId": "workflows.generator.sessions.cancel",
     "path": "/v1/workflows/generator/sessions/:sessionId",
@@ -3217,7 +3227,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 319,
+    "index": 320,
     "method": "GET",
     "operationId": "rules.bundles.list",
     "path": "/v1/rules/bundles",
@@ -3227,7 +3237,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 320,
+    "index": 321,
     "method": "GET",
     "operationId": "rules.bundles.get",
     "path": "/v1/rules/bundles/:bundleId",
@@ -3237,7 +3247,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 321,
+    "index": 322,
     "method": "POST",
     "operationId": "rules.bundles.create",
     "path": "/v1/rules/bundles",
@@ -3247,7 +3257,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 322,
+    "index": 323,
     "method": "PATCH",
     "operationId": "rules.bundles.update",
     "path": "/v1/rules/bundles/:bundleId",
@@ -3257,7 +3267,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 323,
+    "index": 324,
     "method": "GET",
     "operationId": "rules.bundles.versions.list",
     "path": "/v1/rules/bundles/:bundleId/versions",
@@ -3267,7 +3277,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 324,
+    "index": 325,
     "method": "GET",
     "operationId": "rules.list",
     "path": "/v1/rules/bundles/:bundleId/rules",
@@ -3277,7 +3287,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 325,
+    "index": 326,
     "method": "POST",
     "operationId": "rules.evaluate",
     "path": "/v1/rules/evaluate",
@@ -3287,7 +3297,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 326,
+    "index": 327,
     "method": "POST",
     "operationId": "rules.simulate",
     "path": "/v1/rules/simulate",
@@ -3297,7 +3307,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 327,
+    "index": 328,
     "method": "GET",
     "operationId": "rules.versions.list",
     "path": "/v1/rules/:ruleId/versions",
@@ -3307,7 +3317,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 328,
+    "index": 329,
     "method": "GET",
     "operationId": "rules.audit.log.list",
     "path": "/v1/rules/audit-log",
@@ -3317,7 +3327,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 329,
+    "index": 330,
     "method": "POST",
     "operationId": "node.runner.execute",
     "path": "/v1/node-runner/execute",
@@ -3327,7 +3337,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 330,
+    "index": 331,
     "method": "GET",
     "operationId": "node.runner.executions.get",
     "path": "/v1/node-runner/executions/:executionId",
@@ -3337,7 +3347,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 331,
+    "index": 332,
     "method": "GET",
     "operationId": "node.runner.executions.list",
     "path": "/v1/node-runner/executions",
@@ -3347,7 +3357,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 332,
+    "index": 333,
     "method": "POST",
     "operationId": "acceptance.run",
     "path": "/v1/acceptance/run",
@@ -3357,7 +3367,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 333,
+    "index": 334,
     "method": "GET",
     "operationId": "acceptance.results.get",
     "path": "/v1/acceptance/results/:resultId",
@@ -3367,7 +3377,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 334,
+    "index": 335,
     "method": "GET",
     "operationId": "acceptance.results.list",
     "path": "/v1/acceptance/results",
@@ -3377,7 +3387,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 335,
+    "index": 336,
     "method": "GET",
     "operationId": "acceptance.runs.get",
     "path": "/v1/acceptance/runs/:runId",
@@ -3387,7 +3397,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 336,
+    "index": 337,
     "method": "GET",
     "operationId": "acceptance.tests.list",
     "path": "/v1/acceptance/tests",
@@ -3397,7 +3407,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 337,
+    "index": 338,
     "method": "GET",
     "operationId": "acceptance.tests.get",
     "path": "/v1/acceptance/tests/:testId",
@@ -3407,7 +3417,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 338,
+    "index": 339,
     "method": "POST",
     "operationId": "acceptance.tests.create",
     "path": "/v1/acceptance/tests",
@@ -3417,7 +3427,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 339,
+    "index": 340,
     "method": "PUT",
     "operationId": "acceptance.tests.update",
     "path": "/v1/acceptance/tests/:testId",
@@ -3427,7 +3437,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 340,
+    "index": 341,
     "method": "DELETE",
     "operationId": "acceptance.tests.delete",
     "path": "/v1/acceptance/tests/:testId",
@@ -3437,7 +3447,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 341,
+    "index": 342,
     "method": "GET",
     "operationId": "acceptance.tests.versions.list",
     "path": "/v1/acceptance/tests/:testId/versions",
@@ -3447,7 +3457,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 342,
+    "index": 343,
     "method": "GET",
     "operationId": "acceptance.artifacts.history",
     "path": "/v1/acceptance/artifacts/history",
@@ -3457,7 +3467,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 343,
+    "index": 344,
     "method": "GET",
     "operationId": "retry.policies.list",
     "path": "/v1/retry/policies",
@@ -3467,7 +3477,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 344,
+    "index": 345,
     "method": "GET",
     "operationId": "retry.policies.get",
     "path": "/v1/retry/policies/:policyId",
@@ -3477,7 +3487,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 345,
+    "index": 346,
     "method": "POST",
     "operationId": "retry.policies.create",
     "path": "/v1/retry/policies",
@@ -3487,7 +3497,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 346,
+    "index": 347,
     "method": "PUT",
     "operationId": "retry.policies.update",
     "path": "/v1/retry/policies/:policyId",
@@ -3497,7 +3507,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 347,
+    "index": 348,
     "method": "DELETE",
     "operationId": "retry.policies.delete",
     "path": "/v1/retry/policies/:policyId",
@@ -3507,7 +3517,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 348,
+    "index": 349,
     "method": "POST",
     "operationId": "retry.classify",
     "path": "/v1/retry/classify",
@@ -3517,7 +3527,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 349,
+    "index": 350,
     "method": "POST",
     "operationId": "retry.decide",
     "path": "/v1/retry/decide",
@@ -3527,7 +3537,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 350,
+    "index": 351,
     "method": "GET",
     "operationId": "retry.traces.list",
     "path": "/v1/retry/traces",
@@ -3537,7 +3547,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 351,
+    "index": 352,
     "method": "GET",
     "operationId": "retry.traces.get",
     "path": "/v1/retry/traces/:traceId",
@@ -3547,7 +3557,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 352,
+    "index": 353,
     "method": "GET",
     "operationId": "retry.costs.summary",
     "path": "/v1/retry/costs",
@@ -3557,7 +3567,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 353,
+    "index": 354,
     "method": "GET",
     "operationId": "retry.escalations.list",
     "path": "/v1/retry/escalations",
@@ -3567,7 +3577,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 354,
+    "index": 355,
     "method": "POST",
     "operationId": "retry.escalations.acknowledge",
     "path": "/v1/retry/escalations/:escalationId/acknowledge",
@@ -3577,7 +3587,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 355,
+    "index": 356,
     "method": "GET",
     "operationId": "retry.circuit.breakers.list",
     "path": "/v1/retry/circuit-breakers",
@@ -3587,7 +3597,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 356,
+    "index": 357,
     "method": "GET",
     "operationId": "playbook.list",
     "path": "/v1/playbooks",
@@ -3597,7 +3607,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 357,
+    "index": 358,
     "method": "GET",
     "operationId": "playbook.get",
     "path": "/v1/playbooks/:playbookId",
@@ -3607,7 +3617,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 358,
+    "index": 359,
     "method": "POST",
     "operationId": "playbook.select",
     "path": "/v1/playbooks/select",
@@ -3617,7 +3627,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 359,
+    "index": 360,
     "method": "GET",
     "operationId": "playbook.candidates.list",
     "path": "/v1/playbooks/candidates",
@@ -3627,7 +3637,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 360,
+    "index": 361,
     "method": "POST",
     "operationId": "playbook.candidates.promote",
     "path": "/v1/playbooks/candidates/:candidateId/promote",
@@ -3637,7 +3647,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 361,
+    "index": 362,
     "method": "POST",
     "operationId": "playbook.rollback",
     "path": "/v1/playbooks/:playbookId/rollback",
@@ -3647,7 +3657,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 362,
+    "index": 363,
     "method": "GET",
     "operationId": "playbook.scores",
     "path": "/v1/playbooks/:playbookId/scores",
@@ -3657,7 +3667,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 363,
+    "index": 364,
     "method": "POST",
     "operationId": "memory.store",
     "path": "/v1/memory/store",
@@ -3667,7 +3677,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 364,
+    "index": 365,
     "method": "POST",
     "operationId": "memory.items.create",
     "path": "/v1/memory/items",
@@ -3677,7 +3687,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 365,
+    "index": 366,
     "method": "POST",
     "operationId": "memory.search",
     "path": "/v1/memory/search",
@@ -3687,7 +3697,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 366,
+    "index": 367,
     "method": "GET",
     "operationId": "memory.get",
     "path": "/v1/memory/items/:id",
@@ -3697,7 +3707,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 367,
+    "index": 368,
     "method": "GET",
     "operationId": "memory.list",
     "path": "/v1/memory/items",
@@ -3707,7 +3717,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 368,
+    "index": 369,
     "method": "DELETE",
     "operationId": "memory.delete",
     "path": "/v1/memory/items/:id",
@@ -3717,7 +3727,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 369,
+    "index": 370,
     "method": "POST",
     "operationId": "memory.prune",
     "path": "/v1/memory/prune",
@@ -3727,7 +3737,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 370,
+    "index": 371,
     "method": "GET",
     "operationId": "sessions.usage.get",
     "path": "/v1/sessions/:sessionKey/usage",
@@ -3737,7 +3747,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 371,
+    "index": 372,
     "method": "GET",
     "operationId": "sessions.usage.list",
     "path": "/v1/sessions/usage",
@@ -3747,7 +3757,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 372,
+    "index": 373,
     "method": "GET",
     "operationId": "sessions.list",
     "path": "/v1/sessions",
@@ -3757,7 +3767,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 373,
+    "index": 374,
     "method": "POST",
     "operationId": "sessions.create",
     "path": "/v1/sessions",
@@ -3767,7 +3777,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 374,
+    "index": 375,
     "method": "GET",
     "operationId": "sessions.get",
     "path": "/v1/sessions/:sessionKey",
@@ -3777,7 +3787,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 375,
+    "index": 376,
     "method": "DELETE",
     "operationId": "sessions.delete",
     "path": "/v1/sessions/:sessionKey",
@@ -3787,7 +3797,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 376,
+    "index": 377,
     "method": "POST",
     "operationId": "sessions.archive",
     "path": "/v1/sessions/:sessionKey/archive",
@@ -3797,7 +3807,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 377,
+    "index": 378,
     "method": "POST",
     "operationId": "sessions.reset",
     "path": "/v1/sessions/:sessionKey/reset",
@@ -3807,7 +3817,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 378,
+    "index": 379,
     "method": "POST",
     "operationId": "sessions.prune",
     "path": "/v1/sessions/prune",
@@ -3817,7 +3827,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 379,
+    "index": 380,
     "method": "POST",
     "operationId": "sessions.sweep",
     "path": "/v1/sessions/sweep",
@@ -3827,7 +3837,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 380,
+    "index": 381,
     "method": "POST",
     "operationId": "sessions.compact",
     "path": "/v1/sessions/:sessionKey/compact",
@@ -3837,7 +3847,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 381,
+    "index": 382,
     "method": "GET",
     "operationId": "sessions.messages.list",
     "path": "/v1/sessions/:sessionKey/messages",
@@ -3847,7 +3857,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 382,
+    "index": 383,
     "method": "GET",
     "operationId": "sessions.export",
     "path": "/v1/sessions/:sessionKey/export",
@@ -3857,7 +3867,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 383,
+    "index": 384,
     "method": "POST",
     "operationId": "sessions.messages.create",
     "path": "/v1/sessions/:sessionKey/messages",
@@ -3867,7 +3877,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 384,
+    "index": 385,
     "method": "POST",
     "operationId": "sessions.outbound.send",
     "path": "/v1/sessions/:sessionKey/outbound",
@@ -3877,7 +3887,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 385,
+    "index": 386,
     "method": "POST",
     "operationId": "sessions.run",
     "path": "/v1/sessions/:sessionKey/run",
@@ -3887,7 +3897,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 386,
+    "index": 387,
     "method": "GET",
     "operationId": "sessions.memory.namespace.get",
     "path": "/v1/sessions/:sessionKey/memory-namespace",
@@ -3897,7 +3907,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 387,
+    "index": 388,
     "method": "POST",
     "operationId": "sessions.forks.create",
     "path": "/v1/sessions/:sessionKey/fork",
@@ -3907,7 +3917,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 388,
+    "index": 389,
     "method": "GET",
     "operationId": "sessions.forks.list",
     "path": "/v1/sessions/:sessionKey/forks",
@@ -3917,7 +3927,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 389,
+    "index": 390,
     "method": "POST",
     "operationId": "sessions.forks.merge",
     "path": "/v1/sessions/:sessionKey/merge",
@@ -3927,7 +3937,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 390,
+    "index": 391,
     "method": "POST",
     "operationId": "sessions.memory.extract",
     "path": "/v1/sessions/:sessionKey/memory/extract",
@@ -3937,7 +3947,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 391,
+    "index": 392,
     "method": "POST",
     "operationId": "sessions.memory.remember",
     "path": "/v1/sessions/:sessionKey/memory/remember",
@@ -3947,7 +3957,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 392,
+    "index": 393,
     "method": "GET",
     "operationId": "sessions.memory.extraction.get",
     "path": "/v1/sessions/:sessionKey/memory/extraction",
@@ -3957,7 +3967,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 393,
+    "index": 394,
     "method": "POST",
     "operationId": "sessions.memory.extraction.retry",
     "path": "/v1/sessions/memory/extraction/retry",
@@ -3967,7 +3977,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 394,
+    "index": 395,
     "method": "GET",
     "operationId": "plugins.list",
     "path": "/v1/plugins",
@@ -3977,7 +3987,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 395,
+    "index": 396,
     "method": "GET",
     "operationId": "plugins.get",
     "path": "/v1/plugins/:id",
@@ -3987,7 +3997,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 396,
+    "index": 397,
     "method": "GET",
     "operationId": "plugins.versions.list",
     "path": "/v1/plugins/:id/versions",
@@ -3997,7 +4007,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 397,
+    "index": 398,
     "method": "POST",
     "operationId": "plugins.install",
     "path": "/v1/plugins/:id/install",
@@ -4007,7 +4017,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 398,
+    "index": 399,
     "method": "POST",
     "operationId": "plugins.enable",
     "path": "/v1/plugins/:id/enable",
@@ -4017,7 +4027,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 399,
+    "index": 400,
     "method": "POST",
     "operationId": "plugins.disable",
     "path": "/v1/plugins/:id/disable",
@@ -4027,7 +4037,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 400,
+    "index": 401,
     "method": "DELETE",
     "operationId": "plugins.uninstall",
     "path": "/v1/plugins/:id",
@@ -4037,7 +4047,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 401,
+    "index": 402,
     "method": "POST",
     "operationId": "agent.runs.start",
     "path": "/v1/agent/runs",
@@ -4047,7 +4057,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 402,
+    "index": 403,
     "method": "GET",
     "operationId": "agent.runs.list",
     "path": "/v1/agent/runs",
@@ -4057,7 +4067,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 403,
+    "index": 404,
     "method": "GET",
     "operationId": "agent.runs.summary",
     "path": "/v1/agent/runs/summary",
@@ -4067,7 +4077,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 404,
+    "index": 405,
     "method": "GET",
     "operationId": "agent.runs.get",
     "path": "/v1/agent/runs/:runId",
@@ -4077,7 +4087,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 405,
+    "index": 406,
     "method": "POST",
     "operationId": "agent.runs.cancel",
     "path": "/v1/agent/runs/:runId/cancel",
@@ -4087,7 +4097,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 406,
+    "index": 407,
     "method": "POST",
     "operationId": "agent.runs.resume",
     "path": "/v1/agent/runs/:runId/resume",
@@ -4097,7 +4107,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 407,
+    "index": 408,
     "method": "GET",
     "operationId": "agent.runs.audit",
     "path": "/v1/agent/runs/:runId/audit",
@@ -4107,7 +4117,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 408,
+    "index": 409,
     "method": "POST",
     "operationId": "agent.runs.rollback",
     "path": "/v1/agent/runs/:runId/rollback",
@@ -4117,7 +4127,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 409,
+    "index": 410,
     "method": "POST",
     "operationId": "agent.runs.approve.plan",
     "path": "/v1/agent/runs/:runId/approve-plan",
@@ -4127,7 +4137,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 410,
+    "index": 411,
     "method": "POST",
     "operationId": "agent.runs.reject.plan",
     "path": "/v1/agent/runs/:runId/reject-plan",
@@ -4137,7 +4147,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 411,
+    "index": 412,
     "method": "POST",
     "operationId": "agent.runs.approve.tool",
     "path": "/v1/agent/runs/:runId/approve-tool",
@@ -4147,7 +4157,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 412,
+    "index": 413,
     "method": "POST",
     "operationId": "agent.runs.reject.tool",
     "path": "/v1/agent/runs/:runId/reject-tool",
@@ -4157,7 +4167,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 413,
+    "index": 414,
     "method": "GET",
     "operationId": "agent.runs.events",
     "path": "/v1/agent/runs/:runId/events",
@@ -4167,7 +4177,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 414,
+    "index": 415,
     "method": "POST",
     "operationId": "agent.automations.create",
     "path": "/v1/agent/automations",
@@ -4177,7 +4187,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 415,
+    "index": 416,
     "method": "GET",
     "operationId": "agent.automations.list",
     "path": "/v1/agent/automations",
@@ -4187,7 +4197,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 416,
+    "index": 417,
     "method": "GET",
     "operationId": "agent.automations.get",
     "path": "/v1/agent/automations/:automationId",
@@ -4197,7 +4207,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 417,
+    "index": 418,
     "method": "PATCH",
     "operationId": "agent.automations.update",
     "path": "/v1/agent/automations/:automationId",
@@ -4207,7 +4217,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 418,
+    "index": 419,
     "method": "DELETE",
     "operationId": "agent.automations.delete",
     "path": "/v1/agent/automations/:automationId",
@@ -4217,7 +4227,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 419,
+    "index": 420,
     "method": "POST",
     "operationId": "agent.automations.run",
     "path": "/v1/agent/automations/:automationId/run",
@@ -4227,7 +4237,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 420,
+    "index": 421,
     "method": "GET",
     "operationId": "agent.subagents.list",
     "path": "/v1/agent/subagents",
@@ -4237,7 +4247,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 421,
+    "index": 422,
     "method": "GET",
     "operationId": "agent.subagents.get",
     "path": "/v1/agent/subagents/:subagentId",
@@ -4247,7 +4257,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 422,
+    "index": 423,
     "method": "GET",
     "operationId": "agent.runs.subagents.list",
     "path": "/v1/agent/runs/:runId/subagents",
@@ -4257,7 +4267,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 423,
+    "index": 424,
     "method": "GET",
     "operationId": "assets.inventory.list",
     "path": "/v1/assets/inventory",

--- a/test/contracts/api/friday-api-route-contract.snapshot.test.ts
+++ b/test/contracts/api/friday-api-route-contract.snapshot.test.ts
@@ -865,6 +865,7 @@ describe("MECHANISM-4 — API Route Contract (Snapshot)", () => {
         "mission.spine.intake.create",
         "mission.spine.lifecycle.transition",
         "mission.spine.workitem.status.transition",
+        "mission.spine.routedecision.control",
         // Lane M: the memory-confirmation loop's terminal mutation driven over the sealed-WS
         // dispatch arm. Refuses the synthetic public principal before any dispatch; flag-OFF/503
         // by default (the merged Rust arm #753 is gated by FRIDAY_MEMORY_CONFIRM).

--- a/test/unit/api/mission-spine/friday-mission-spine-dispatch-adapter.test.ts
+++ b/test/unit/api/mission-spine/friday-mission-spine-dispatch-adapter.test.ts
@@ -16,6 +16,8 @@ import type {
   FridayRustHubMissionIntakeResult,
   FridayRustHubMissionLifecycleRequest,
   FridayRustHubMissionLifecycleResult,
+  FridayRustHubRouteDecisionControlRequest,
+  FridayRustHubRouteDecisionControlResult,
   FridayRustHubWorkItemStatusRequest,
   FridayRustHubWorkItemStatusResult,
 } from "../../../../src/api/mission-spine/friday-rust-hub-agent-run-ws-sealed-client.js";
@@ -90,17 +92,37 @@ const WORKITEM_RESULT: FridayRustHubWorkItemStatusResult = {
   updatedAtMs: 1,
 };
 
+const ROUTE_CONTROL_REQ: FridayRustHubRouteDecisionControlRequest = {
+  decisionId: "route-decision-1",
+  controlKind: "veto",
+  actorRef: "actor-1",
+  reason: "operator veto",
+};
+
+const ROUTE_CONTROL_RESULT: FridayRustHubRouteDecisionControlResult = {
+  truthLabel: "rust_wired",
+  decisionId: "route-decision-1",
+  missionId: "mission-1",
+  workItemId: "wi-1",
+  controlKind: "veto",
+  actorRef: "actor-1",
+  reason: "operator veto",
+  updatedAtMs: 1,
+};
+
 /** A fake underlying sealed client + a recorder of how it was constructed/called. */
 function makeFakeClient(behavior: {
   intake?: FridayRustHubMissionIntakeResult;
   lifecycle?: FridayRustHubMissionLifecycleResult;
   workItem?: FridayRustHubWorkItemStatusResult;
+  routeControl?: FridayRustHubRouteDecisionControlResult;
   reject?: unknown;
 }) {
   const constructed: CreateFridayRustHubAgentRunSealedClientOptions[] = [];
   const intakeCalls: FridayRustHubMissionIntakeRequest[] = [];
   const lifecycleCalls: FridayRustHubMissionLifecycleRequest[] = [];
   const workItemCalls: FridayRustHubWorkItemStatusRequest[] = [];
+  const routeControlCalls: FridayRustHubRouteDecisionControlRequest[] = [];
   const createClient = vi.fn(
     (options: CreateFridayRustHubAgentRunSealedClientOptions): FridayRustHubAgentRunSealedClient => {
       constructed.push(options);
@@ -126,10 +148,15 @@ function makeFakeClient(behavior: {
           if (behavior.reject !== undefined) throw behavior.reject;
           return behavior.workItem!;
         }),
+        controlRouteDecision: vi.fn(async (req: FridayRustHubRouteDecisionControlRequest) => {
+          routeControlCalls.push(req);
+          if (behavior.reject !== undefined) throw behavior.reject;
+          return behavior.routeControl!;
+        }),
       };
     },
   );
-  return { createClient, constructed, intakeCalls, lifecycleCalls, workItemCalls };
+  return { createClient, constructed, intakeCalls, lifecycleCalls, workItemCalls, routeControlCalls };
 }
 
 describe("createFridayMissionSpineDispatchAdapter (Lane B-2, dark, adapter)", () => {
@@ -157,8 +184,12 @@ describe("createFridayMissionSpineDispatchAdapter (Lane B-2, dark, adapter)", ()
       expect(fake.intakeCalls).toEqual([INTAKE_REQ]);
     });
 
-    it("transitionMission + transitionWorkItem delegate verbatim", async () => {
-      const fake = makeFakeClient({ lifecycle: LIFECYCLE_RESULT, workItem: WORKITEM_RESULT });
+    it("transitionMission + transitionWorkItem + controlRouteDecision delegate verbatim", async () => {
+      const fake = makeFakeClient({
+        lifecycle: LIFECYCLE_RESULT,
+        workItem: WORKITEM_RESULT,
+        routeControl: ROUTE_CONTROL_RESULT,
+      });
       const adapter = createFridayMissionSpineDispatchAdapter({
         port: 48750,
         secretResolver: () => SECRET,
@@ -167,8 +198,10 @@ describe("createFridayMissionSpineDispatchAdapter (Lane B-2, dark, adapter)", ()
 
       expect(await adapter.transitionMission(LIFECYCLE_REQ)).toBe(LIFECYCLE_RESULT);
       expect(await adapter.transitionWorkItem(WORKITEM_REQ)).toBe(WORKITEM_RESULT);
+      expect(await adapter.controlRouteDecision(ROUTE_CONTROL_REQ)).toBe(ROUTE_CONTROL_RESULT);
       expect(fake.lifecycleCalls).toEqual([LIFECYCLE_REQ]);
       expect(fake.workItemCalls).toEqual([WORKITEM_REQ]);
+      expect(fake.routeControlCalls).toEqual([ROUTE_CONTROL_REQ]);
     });
   });
 

--- a/test/unit/api/mission-spine/friday-rust-hub-mission-spine-wire.test.ts
+++ b/test/unit/api/mission-spine/friday-rust-hub-mission-spine-wire.test.ts
@@ -3,12 +3,15 @@ import { describe, expect, it } from "vitest";
 import {
   buildMissionIntakeEnvelope,
   buildMissionLifecycleEnvelope,
+  buildRouteDecisionControlEnvelope,
   buildWorkItemStatusEnvelope,
   parseMissionIntakeResult,
   parseMissionLifecycleResult,
+  parseRouteDecisionControlResult,
   parseWorkItemStatusResult,
   type FridayRustHubMissionIntakeRequest,
   type FridayRustHubMissionLifecycleRequest,
+  type FridayRustHubRouteDecisionControlRequest,
   type FridayRustHubWorkItemStatusRequest,
 } from "../../../../src/api/mission-spine/friday-rust-hub-agent-run-ws-sealed-client.js";
 
@@ -171,6 +174,50 @@ describe("buildWorkItemStatusEnvelope (WorkItemStatusRequestWire wire mapping)",
   });
 });
 
+const FULL_ROUTE_CONTROL: FridayRustHubRouteDecisionControlRequest = {
+  decisionId: "route-decision-x",
+  missionId: "mission-x",
+  workItemId: "work-x",
+  controlKind: "override",
+  overrideLane: "codex",
+  overrideProviderOrAgent: "codex",
+  actorRef: "actor_x",
+  reason: "Codex owns this edit",
+};
+
+describe("buildRouteDecisionControlEnvelope (RouteDecisionControlRequestWire wire mapping)", () => {
+  it("nests override control under `request`, omitting no required refs", () => {
+    const env = buildRouteDecisionControlEnvelope(FULL_ROUTE_CONTROL);
+    expect(env.msg_id).toBe("route-decision-control-route-decision-x");
+    const message = env.message as Record<string, unknown>;
+    expect(message.kind).toBe("RouteDecisionControlRequest");
+    expect(Object.keys(message).sort()).toEqual(["kind", "request"]);
+    expect(message.request).toEqual({
+      decision_id: "route-decision-x",
+      mission_id: "mission-x",
+      work_item_id: "work-x",
+      control_kind: "override",
+      override_lane: "codex",
+      override_provider_or_agent: "codex",
+      actor_ref: "actor_x",
+      reason: "Codex owns this edit",
+    });
+  });
+
+  it("omits override fields for a veto", () => {
+    const message = buildRouteDecisionControlEnvelope({
+      decisionId: "route-decision-x",
+      controlKind: "veto",
+      actorRef: "actor_x",
+      reason: "operator veto",
+    }).message as Record<string, unknown>;
+    const request = message.request as Record<string, unknown>;
+    expect(request.control_kind).toBe("veto");
+    expect("override_lane" in request).toBe(false);
+    expect("override_provider_or_agent" in request).toBe(false);
+  });
+});
+
 describe("parseMissionIntakeResult (fail-closed refs-only, NESTED result)", () => {
   // The parser is handed the whole `message` object: `{kind, result:{…refs…}}`.
   const valid = {
@@ -270,6 +317,54 @@ describe("parseMissionIntakeResult (fail-closed refs-only, NESTED result)", () =
   });
 });
 
+describe("parseRouteDecisionControlResult (fail-closed refs-only, NESTED result)", () => {
+  it("parses a valid route control result", () => {
+    expect(
+      parseRouteDecisionControlResult({
+        result: {
+          decision_id: "route-decision-x",
+          mission_id: "mission-x",
+          work_item_id: "work-x",
+          control_kind: "override",
+          override_lane: "codex",
+          override_provider_or_agent: "codex",
+          actor_ref: "actor_x",
+          reason: "Codex owns this edit",
+          updated_at_ms: 1700000000000,
+        },
+      }),
+    ).toEqual({
+      truthLabel: "rust_wired",
+      decisionId: "route-decision-x",
+      missionId: "mission-x",
+      workItemId: "work-x",
+      controlKind: "override",
+      overrideLane: "codex",
+      overrideProviderOrAgent: "codex",
+      actorRef: "actor_x",
+      reason: "Codex owns this edit",
+      updatedAtMs: 1700000000000,
+    });
+  });
+
+  it("fails closed on missing wrapper or invalid control kind", () => {
+    expect(parseRouteDecisionControlResult({})).toBeUndefined();
+    expect(
+      parseRouteDecisionControlResult({
+        result: {
+          decision_id: "route-decision-x",
+          mission_id: "mission-x",
+          work_item_id: "work-x",
+          control_kind: "decorate",
+          actor_ref: "actor_x",
+          reason: "bad",
+          updated_at_ms: 1,
+        },
+      }),
+    ).toBeUndefined();
+  });
+});
+
 describe("parseMissionLifecycleResult (fail-closed refs-only, NESTED result)", () => {
   const valid = {
     result: {
@@ -362,7 +457,7 @@ describe("parseWorkItemStatusResult (fail-closed refs-only, count not raw refs, 
 //  - We `JSON.parse` the Rust JSON and `toEqual` the `message.request`/`message.result` SUB-OBJECT
 //    against what the TS builder emits / what the TS parser consumes. SUB-OBJECT (not full-envelope
 //    byte) comparison is deliberate: the outer envelope cannot be byte-equal (`sent_at = Date.now()`,
-//    `msg_id` is per-entity not "m1", and TS `SCHEMA_VERSION` is 12 vs the current Rust 13 — all
+//    `msg_id` is per-entity not "m1", and TS `SCHEMA_VERSION` is 12 vs the current Rust 14 — all
 //    orthogonal to the wire-NESTING bug under repair). The sub-object equality is exactly the bug's
 //    surface: nesting depth + key names + types.
 //  - `includes_sensitive_context`: Rust has `#[serde(default)]` WITHOUT `skip_serializing_if`, so it
@@ -372,17 +467,17 @@ describe("parseWorkItemStatusResult (fail-closed refs-only, count not raw refs, 
 //    is covered by the dedicated build unit test above.)
 
 const RUST_INTAKE_REQUEST_JSON =
-  '{"schema_version":13,"msg_id":"m1","correlation_id":"c1","sent_at":1000,"message":{"kind":"MissionIntakeRequest","request":{"friday_conversation_id":"conversation_x","owner_principal":"owner_x","surface_thread_id":"surface_x","surface_kind":"mobile","delivery_route":"in_app","visibility_policy":"owner_only","mission_id":"mission_x","work_item_id":"work_x","title":"Title","intent":"Intent","lane":"deepseek","target_provider_or_agent":"deepseek-v4","capability_id":"cap_x","body_ref":"body://ref","includes_sensitive_context":true}}}';
+  '{"schema_version":14,"msg_id":"m1","correlation_id":"c1","sent_at":1000,"message":{"kind":"MissionIntakeRequest","request":{"friday_conversation_id":"conversation_x","owner_principal":"owner_x","surface_thread_id":"surface_x","surface_kind":"mobile","delivery_route":"in_app","visibility_policy":"owner_only","mission_id":"mission_x","work_item_id":"work_x","title":"Title","intent":"Intent","lane":"deepseek","target_provider_or_agent":"deepseek-v4","capability_id":"cap_x","body_ref":"body://ref","includes_sensitive_context":true}}}';
 const RUST_INTAKE_RESULT_JSON =
-  '{"schema_version":13,"msg_id":"m1","correlation_id":"c1","sent_at":1000,"message":{"kind":"MissionIntakeResult","result":{"friday_conversation_id":"conversation_x","mission_id":"mission_x","work_item_id":"work_x","surface_thread_id":"surface_x","status":"ready","blockers":[],"duplicate_mission_id":"mission_dup","duplicate_work_item_id":"work_dup","created_or_ready":true}}}';
+  '{"schema_version":14,"msg_id":"m1","correlation_id":"c1","sent_at":1000,"message":{"kind":"MissionIntakeResult","result":{"friday_conversation_id":"conversation_x","mission_id":"mission_x","work_item_id":"work_x","surface_thread_id":"surface_x","status":"ready","blockers":[],"duplicate_mission_id":"mission_dup","duplicate_work_item_id":"work_dup","created_or_ready":true}}}';
 const RUST_LIFECYCLE_REQUEST_JSON =
-  '{"schema_version":13,"msg_id":"m1","correlation_id":"c1","sent_at":1000,"message":{"kind":"MissionLifecycleRequest","request":{"friday_conversation_id":"conversation_x","mission_id":"mission_x","target_status":"queued","actor_ref":"actor_x","reason":"advance","proof_ref":"proof://ref","merged_into_mission_id":"mission_y"}}}';
+  '{"schema_version":14,"msg_id":"m1","correlation_id":"c1","sent_at":1000,"message":{"kind":"MissionLifecycleRequest","request":{"friday_conversation_id":"conversation_x","mission_id":"mission_x","target_status":"queued","actor_ref":"actor_x","reason":"advance","proof_ref":"proof://ref","merged_into_mission_id":"mission_y"}}}';
 const RUST_LIFECYCLE_RESULT_JSON =
-  '{"schema_version":13,"msg_id":"m1","correlation_id":"c1","sent_at":1000,"message":{"kind":"MissionLifecycleResult","result":{"friday_conversation_id":"conversation_x","mission_id":"mission_x","previous_status":"ready","status":"queued","actor_ref":"actor_x","reason":"advance","proof_ref":"proof://r","merged_into_mission_id":"mission_y","active_mission_ids":["mission_x"],"updated_at_ms":1700000000000}}}';
+  '{"schema_version":14,"msg_id":"m1","correlation_id":"c1","sent_at":1000,"message":{"kind":"MissionLifecycleResult","result":{"friday_conversation_id":"conversation_x","mission_id":"mission_x","previous_status":"ready","status":"queued","actor_ref":"actor_x","reason":"advance","proof_ref":"proof://r","merged_into_mission_id":"mission_y","active_mission_ids":["mission_x"],"updated_at_ms":1700000000000}}}';
 const RUST_WORK_ITEM_REQUEST_JSON =
-  '{"schema_version":13,"msg_id":"m1","correlation_id":"c1","sent_at":1000,"message":{"kind":"WorkItemStatusRequest","request":{"work_item_id":"work_x","target_status":"completed_with_proof","actor_ref":"actor_x","reason":"stage","proof_receipt":"proof://receipt"}}}';
+  '{"schema_version":14,"msg_id":"m1","correlation_id":"c1","sent_at":1000,"message":{"kind":"WorkItemStatusRequest","request":{"work_item_id":"work_x","target_status":"completed_with_proof","actor_ref":"actor_x","reason":"stage","proof_receipt":"proof://receipt"}}}';
 const RUST_WORK_ITEM_RESULT_JSON =
-  '{"schema_version":13,"msg_id":"m1","correlation_id":"c1","sent_at":1000,"message":{"kind":"WorkItemStatusResult","result":{"work_item_id":"work_x","mission_id":"mission_x","previous_status":"ready_to_dispatch","status":"completed_with_proof","actor_ref":"actor_x","reason":"done","proof_receipt_count":2,"updated_at_ms":1700000000000}}}';
+  '{"schema_version":14,"msg_id":"m1","correlation_id":"c1","sent_at":1000,"message":{"kind":"WorkItemStatusResult","result":{"work_item_id":"work_x","mission_id":"mission_x","previous_status":"ready_to_dispatch","status":"completed_with_proof","actor_ref":"actor_x","reason":"done","proof_receipt_count":2,"updated_at_ms":1700000000000}}}';
 
 /** Pull the inner `message.<key>` sub-object out of a captured Rust envelope JSON string. */
 function rustInner(json: string, key: "request" | "result"): Record<string, unknown> {

--- a/test/unit/api/routes/friday-mission-spine-routes.test.ts
+++ b/test/unit/api/routes/friday-mission-spine-routes.test.ts
@@ -20,6 +20,8 @@ const snapshot: FridayMissionSpineWorkbenchSnapshot = {
   routeDecision: {
     advisorSummary: "Rust Hub route decision projection.",
     selectedRoute: "route_decision_ref",
+    controlRef: "friday://route-decision-projection/mission_live_projection_test/work_live_projection_test/1700000000000",
+    workItemId: "work_live_projection_test",
     alternatives: ["alternate_ref"],
     actionItems: [
       {
@@ -594,6 +596,7 @@ function makeDispatch(overrides: Partial<FridayMissionSpineDispatchService> = {}
   intake: ReturnType<typeof vi.fn>;
   lifecycle: ReturnType<typeof vi.fn>;
   workItem: ReturnType<typeof vi.fn>;
+  routeControl: ReturnType<typeof vi.fn>;
 } {
   const intake = vi.fn(async () => ({
     truthLabel: "rust_wired" as const,
@@ -627,16 +630,28 @@ function makeDispatch(overrides: Partial<FridayMissionSpineDispatchService> = {}
     proofReceiptCount: 1,
     updatedAtMs: 1_700_000_000_000,
   }));
+  const routeControl = vi.fn(async () => ({
+    truthLabel: "rust_wired" as const,
+    decisionId: "route_decision_lane_b",
+    missionId: "mission_lane_b",
+    workItemId: "work_lane_b",
+    controlKind: "veto" as const,
+    actorRef: "actor_lane_b",
+    reason: "operator veto",
+    updatedAtMs: 1_700_000_000_000,
+  }));
   return {
     dispatch: {
       intakeMission: intake,
       transitionMission: lifecycle,
       transitionWorkItem: workItem,
+      controlRouteDecision: routeControl,
       ...overrides,
     } as FridayMissionSpineDispatchService,
     intake,
     lifecycle,
     workItem,
+    routeControl,
   };
 }
 
@@ -681,18 +696,27 @@ const VALID_WORK_ITEM_BODY = {
   reason: "stage",
 };
 
+const VALID_ROUTE_CONTROL_BODY = {
+  controlKind: "veto",
+  actorRef: "actor_lane_b",
+  reason: "operator veto",
+};
+
 describe("createFridayMissionSpineRoutes — Lane B organic mutation routes", () => {
-  it("registers the three POST routes as public, byte-additive to the GET route", () => {
+  it("registers the four POST routes as public, byte-additive to the GET route", () => {
     const { dispatch } = makeDispatch();
     const routes = createFridayMissionSpineRoutes({ workbench: null, disabledReason: null, dispatch });
     const intake = findPost(routes, "mission.spine.intake.create");
     const lifecycle = findPost(routes, "mission.spine.lifecycle.transition");
     const workItem = findPost(routes, "mission.spine.workitem.status.transition");
+    const routeControl = findPost(routes, "mission.spine.routedecision.control");
     expect(intake.method).toBe("POST");
     expect(intake.path).toBe("/v1/mission-spine/intake");
     expect(intake.auth).toEqual({ public: true });
     expect(lifecycle.path).toBe("/v1/mission-spine/:missionId/lifecycle");
     expect(workItem.path).toBe("/v1/mission-spine/work-items/:workItemId/status");
+    expect(routeControl.path).toBe("/v1/mission-spine/route-decisions/:decisionId/control");
+    expect(routeControl.auth).toEqual({ public: true });
     // The GET route is unchanged and still present.
     expect(findRoute(routes).method).toBe("GET");
   });
@@ -715,13 +739,15 @@ describe("createFridayMissionSpineRoutes — Lane B organic mutation routes", ()
       expect(intake).not.toHaveBeenCalled();
     });
 
-    it("lifecycle and work-item also 503 when dispatch is null", async () => {
+    it("lifecycle, work-item, and route-control also 503 when dispatch is null", async () => {
       const routes = createFridayMissionSpineRoutes({ workbench: null, disabledReason: null, dispatch: null });
       const lifecycle = findPost(routes, "mission.spine.lifecycle.transition");
       const workItem = findPost(routes, "mission.spine.workitem.status.transition");
+      const routeControl = findPost(routes, "mission.spine.routedecision.control");
       for (const [route, params, body] of [
         [lifecycle, { missionId: "mission_lane_b" }, VALID_LIFECYCLE_BODY],
         [workItem, { workItemId: "work_lane_b" }, VALID_WORK_ITEM_BODY],
+        [routeControl, { decisionId: "route_decision_lane_b" }, VALID_ROUTE_CONTROL_BODY],
       ] as const) {
         let thrown: unknown = null;
         try {
@@ -825,6 +851,34 @@ describe("createFridayMissionSpineRoutes — Lane B organic mutation routes", ()
       });
       expect((response as { result: { proofReceiptCount: number } }).result.proofReceiptCount).toBe(1);
     });
+
+    it("route-control takes the decisionId from the path and delegates veto/override", async () => {
+      const { dispatch, routeControl } = makeDispatch();
+      const routes = createFridayMissionSpineRoutes({ workbench: null, disabledReason: null, dispatch });
+      const route = findPost(routes, "mission.spine.routedecision.control");
+      const response = await route.handler(
+        makeCtx({
+          principal: BOUND_PRINCIPAL,
+          params: { decisionId: "route_decision_from_path" },
+          body: {
+            controlKind: "override",
+            overrideLane: "codex",
+            overrideProviderOrAgent: "codex",
+            actorRef: "actor_lane_b",
+            reason: "Codex owns this edit",
+          },
+        }) as never,
+      );
+      expect(routeControl).toHaveBeenCalledWith({
+        decisionId: "route_decision_from_path",
+        controlKind: "override",
+        overrideLane: "codex",
+        overrideProviderOrAgent: "codex",
+        actorRef: "actor_lane_b",
+        reason: "Codex owns this edit",
+      });
+      expect((response as { result: { decisionId: string } }).result.decisionId).toBe("route_decision_lane_b");
+    });
   });
 
   describe("flag-ON: invalid body → typed 400, fail-closed (no dispatch)", () => {
@@ -901,6 +955,29 @@ describe("createFridayMissionSpineRoutes — Lane B organic mutation routes", ()
         "proof_receipt_required_for_completion",
       );
       expect(workItem).not.toHaveBeenCalled();
+    });
+
+    it("route-control rejects malformed veto/override bodies before dispatch", async () => {
+      const { dispatch, routeControl } = makeDispatch();
+      const routes = createFridayMissionSpineRoutes({ workbench: null, disabledReason: null, dispatch });
+      const route = findPost(routes, "mission.spine.routedecision.control");
+      let thrown: unknown = null;
+      try {
+        await route.handler(
+          makeCtx({
+            principal: BOUND_PRINCIPAL,
+            params: { decisionId: "route_decision_from_path" },
+            body: { controlKind: "veto", overrideLane: "codex", actorRef: "a", reason: "r" },
+          }) as never,
+        );
+      } catch (err) {
+        thrown = err;
+      }
+      expect((thrown as FridayDomainError).httpStatus).toBe(400);
+      expect(JSON.stringify((thrown as FridayDomainError).details)).toContain(
+        "veto_cannot_carry_override_target",
+      );
+      expect(routeControl).not.toHaveBeenCalled();
     });
   });
 });

--- a/test/unit/qa/mission-workbench-snapshot-contract-cli.test.ts
+++ b/test/unit/qa/mission-workbench-snapshot-contract-cli.test.ts
@@ -19,6 +19,8 @@ function makeSnapshot(overrides: Record<string, unknown> = {}) {
     routeDecision: {
       advisorSummary: "Rust Hub route decision projection.",
       selectedRoute: "route_decision_ref",
+      controlRef: "friday://route-decision-projection/mission_cli_snapshot_contract/work_provider/1700000000000",
+      workItemId: "work_provider",
       alternatives: ["alternate_ref"],
       actionItems: [
         {

--- a/test/unit/ui/mission-workbench-api.test.ts
+++ b/test/unit/ui/mission-workbench-api.test.ts
@@ -5,6 +5,7 @@ import { apiClient } from "@/lib/api/client";
 vi.mock("@/lib/api/client", () => ({
   apiClient: {
     get: vi.fn(),
+    post: vi.fn(),
   },
 }));
 
@@ -17,6 +18,7 @@ describe("missionWorkbenchApi", () => {
 
   beforeEach(() => {
     vi.mocked(apiClient.get).mockReset();
+    vi.mocked(apiClient.post).mockReset();
   });
 
   it("reads the latest Mission Workbench snapshot when no mission id is supplied", async () => {
@@ -36,6 +38,44 @@ describe("missionWorkbenchApi", () => {
 
     expect(apiClient.get).toHaveBeenCalledWith(
       "/v1/mission-spine/workbench?missionId=mission_capture%2Ftarget%20space%3F",
+    );
+  });
+
+  it("posts route-decision controls through the encoded projection ref", async () => {
+    const result = {
+      truthLabel: "rust_wired",
+      decisionId: "route-decision-1",
+      missionId: "mission_capture_target",
+      workItemId: "work_capture_target",
+      controlKind: "veto",
+      actorRef: "operator:mission-workbench",
+      reason: "operator workbench route control",
+      updatedAtMs: 1_700_000_000_000,
+    };
+    vi.mocked(apiClient.post).mockResolvedValue({ result });
+
+    await expect(
+      missionWorkbenchApi.controlRouteDecision(
+        "friday://route-decision-projection/mission_capture_target/work_capture_target/1700000000000",
+        {
+          controlKind: "veto",
+          missionId: "mission_capture_target",
+          workItemId: "work_capture_target",
+          actorRef: "operator:mission-workbench",
+          reason: "operator workbench route control",
+        },
+      ),
+    ).resolves.toEqual(result);
+
+    expect(apiClient.post).toHaveBeenCalledWith(
+      "/v1/mission-spine/route-decisions/friday%3A%2F%2Froute-decision-projection%2Fmission_capture_target%2Fwork_capture_target%2F1700000000000/control",
+      {
+        controlKind: "veto",
+        missionId: "mission_capture_target",
+        workItemId: "work_capture_target",
+        actorRef: "operator:mission-workbench",
+        reason: "operator workbench route control",
+      },
     );
   });
 });

--- a/ui/src/lib/api/mission-workbench.ts
+++ b/ui/src/lib/api/mission-workbench.ts
@@ -5,6 +5,33 @@ interface GetMissionWorkbenchSnapshotResponse {
   snapshot: MissionWorkbenchSnapshot;
 }
 
+export interface MissionRouteDecisionControlRequest {
+  controlKind: "veto" | "override";
+  missionId: string;
+  workItemId: string;
+  overrideLane?: string;
+  overrideProviderOrAgent?: string;
+  actorRef: string;
+  reason: string;
+}
+
+export interface MissionRouteDecisionControlResult {
+  truthLabel: "rust_wired";
+  decisionId: string;
+  missionId: string;
+  workItemId: string;
+  controlKind: "veto" | "override";
+  overrideLane?: string;
+  overrideProviderOrAgent?: string;
+  actorRef: string;
+  reason: string;
+  updatedAtMs: number;
+}
+
+interface ControlMissionRouteDecisionResponse {
+  result: MissionRouteDecisionControlResult;
+}
+
 export const missionWorkbenchApi = {
   async getSnapshot(missionId?: string): Promise<MissionWorkbenchSnapshot> {
     const path = missionId
@@ -12,5 +39,17 @@ export const missionWorkbenchApi = {
       : "/v1/mission-spine/workbench";
     const data = await apiClient.get<GetMissionWorkbenchSnapshotResponse>(path);
     return data.snapshot;
+  },
+
+  async controlRouteDecision(
+    controlRef: string,
+    request: MissionRouteDecisionControlRequest,
+  ): Promise<MissionRouteDecisionControlResult> {
+    const path = `/v1/mission-spine/route-decisions/${encodeURIComponent(controlRef)}/control`;
+    const data = await apiClient.post<
+      MissionRouteDecisionControlRequest,
+      ControlMissionRouteDecisionResponse
+    >(path, request);
+    return data.result;
   },
 };

--- a/ui/src/lib/mission-workbench/mission-workbench-contract.ts
+++ b/ui/src/lib/mission-workbench/mission-workbench-contract.ts
@@ -141,6 +141,8 @@ export interface MissionWorkbenchSnapshot {
   routeDecision: {
     advisorSummary: string;
     selectedRoute: string;
+    controlRef: string;
+    workItemId: string;
     alternatives: string[];
     actionItems: MissionRouteActionItem[];
     truthLabel: MissionTruthLabel;

--- a/ui/src/routes/mission-workbench-page.tsx
+++ b/ui/src/routes/mission-workbench-page.tsx
@@ -1,8 +1,10 @@
 import { useMemo, useState } from "react";
-import { Search } from "lucide-react";
+import { GitBranch, Search, ShieldX } from "lucide-react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useSearchParams } from "react-router-dom";
-import { ShellCard, StatusPill } from "@/components/core/primitives";
+import { ActionButton, ShellCard, StatusPill } from "@/components/core/primitives";
 import { useMissionWorkbenchSnapshot } from "@/hooks/use-mission-workbench";
+import { missionWorkbenchApi } from "@/lib/api/mission-workbench";
 import { localize } from "@/lib/i18n/localized-text";
 import {
   type MissionWorkbenchApprovalState,
@@ -50,6 +52,7 @@ function truthLabelText(label: MissionTruthLabel): string {
 
 export function MissionWorkbenchPage() {
   const { locale } = useAppLocale();
+  const queryClient = useQueryClient();
   const [searchParams] = useSearchParams();
   const targetMissionId = searchParams.get("missionId")?.trim() || undefined;
   const { snapshot, isLoading, isLive, liveUnavailable } = useMissionWorkbenchSnapshot(targetMissionId);
@@ -58,6 +61,30 @@ export function MissionWorkbenchPage() {
   const [stateFilter, setStateFilter] = useState<MissionLifecycleState | "all">("all");
   const [groupFilter, setGroupFilter] = useState<MissionTranscriptGroupKind | "all">("all");
   const [facetFilter, setFacetFilter] = useState<MissionTranscriptFacetFilter>("all");
+  const [routeControlReason, setRouteControlReason] = useState("operator workbench route control");
+  const [routeOverrideLane, setRouteOverrideLane] = useState("codex");
+
+  const routeControlMutation = useMutation({
+    mutationFn: (input: { controlKind: "veto" | "override" }) => {
+      if (!snapshot) throw new Error("Mission Workbench snapshot is not loaded.");
+      const reason = routeControlReason.trim();
+      return missionWorkbenchApi.controlRouteDecision(snapshot.routeDecision.controlRef, {
+        controlKind: input.controlKind,
+        missionId: snapshot.missionId,
+        workItemId: snapshot.routeDecision.workItemId,
+        ...(input.controlKind === "override"
+          ? { overrideLane: routeOverrideLane, overrideProviderOrAgent: routeOverrideLane }
+          : {}),
+        actorRef: "operator:mission-workbench",
+        reason: reason.length > 0 ? reason : "operator workbench route control",
+      });
+    },
+    onSuccess: () => {
+      void queryClient.invalidateQueries({
+        queryKey: ["mission-spine", "workbench", "snapshot", targetMissionId ?? "latest"],
+      });
+    },
+  });
 
   const filteredSections = useMemo(() => {
     return filterMissionTranscriptSections(snapshot?.transcriptSections ?? [], {
@@ -179,6 +206,54 @@ export function MissionWorkbenchPage() {
                 <p className="mt-3 text-sm leading-6 text-[color:var(--color-text-secondary)]">
                   {snapshot.routeDecision.advisorSummary}
                 </p>
+                <div className="mt-4 grid gap-3 md:grid-cols-[minmax(0,1fr)_170px]">
+                  <input
+                    value={routeControlReason}
+                    onChange={(event) => setRouteControlReason(event.target.value)}
+                    className="min-h-[44px] rounded-lg border border-[color:var(--color-border-soft)] bg-[color:var(--color-bg-surface)] px-3 text-sm text-[color:var(--color-text-primary)] outline-none focus:border-[color:var(--color-accent)]"
+                    aria-label={localize(locale, "路由控制原因", "Route control reason")}
+                  />
+                  <select
+                    value={routeOverrideLane}
+                    onChange={(event) => setRouteOverrideLane(event.target.value)}
+                    className="min-h-[44px] rounded-lg border border-[color:var(--color-border-soft)] bg-[color:var(--color-bg-surface)] px-3 text-sm text-[color:var(--color-text-primary)] outline-none focus:border-[color:var(--color-accent)]"
+                    aria-label={localize(locale, "覆盖分配", "Override lane")}
+                  >
+                    <option value="codex">Codex</option>
+                    <option value="claude">Claude</option>
+                    <option value="deepseek">DeepSeek</option>
+                    <option value="workflow">Workflow</option>
+                    <option value="channel">Channel</option>
+                    <option value="human">Human</option>
+                    <option value="future_api">Future API</option>
+                  </select>
+                </div>
+                <div className="mt-3 flex flex-wrap gap-2">
+                  <ActionButton
+                    tone="danger"
+                    className="gap-2 rounded-lg"
+                    disabled={routeControlMutation.isPending}
+                    onClick={() => routeControlMutation.mutate({ controlKind: "veto" })}
+                  >
+                    <ShieldX className="h-4 w-4" aria-hidden="true" />
+                    Veto
+                  </ActionButton>
+                  <ActionButton
+                    tone="secondary"
+                    className="gap-2 rounded-lg"
+                    disabled={routeControlMutation.isPending}
+                    onClick={() => routeControlMutation.mutate({ controlKind: "override" })}
+                  >
+                    <GitBranch className="h-4 w-4" aria-hidden="true" />
+                    Override
+                  </ActionButton>
+                  {routeControlMutation.data ? (
+                    <StatusPill tone="success">{routeControlMutation.data.controlKind}</StatusPill>
+                  ) : null}
+                  {routeControlMutation.isError ? (
+                    <StatusPill tone="danger">blocked</StatusPill>
+                  ) : null}
+                </div>
               </div>
               <div className="space-y-2">
                 {snapshot.routeDecision.alternatives.map((alternative) => (


### PR DESCRIPTION
## Summary
- add v14 RouteDecisionControlRequest/Result wire types for D20 W1-S3 veto/override
- wire owner-bound Rust handler + live sealed-WS mission-spine dispatch arm
- expose TS sealed client, dispatch adapter, and HTTP POST `/v1/mission-spine/route-decisions/:decisionId/control`
- extend owner/session/channel operation gate and targeted tests

## Truth labels
- built/wired: route-decision control mechanism is wired through protocol, Rust sealed-WS ingress, TS adapter, and HTTP route
- live: still default-dark behind existing mission-spine dispatch wiring/flags; this PR does not claim TRUE operator/live dispatch soak
- D20 ceiling: Friday still has no action-rollback engine; this slice is W1 route control, not W2 trust-dial

## Validation
- `cargo fmt --all -- --check`
- `cargo check -p friday-hub --bin hub_agent_run_server`
- `cargo test -p friday-protocol route_decision_control_wire -- --nocapture`
- `cargo test -p friday-protocol schema_version_bumped_to_fourteen_for_route_decision_controls -- --nocapture`
- `cargo test -p friday-hub route_decision -- --nocapture`
- `npx vitest run test/unit/api/mission-spine/friday-rust-hub-mission-spine-wire.test.ts test/unit/api/mission-spine/friday-mission-spine-dispatch-adapter.test.ts test/unit/api/routes/friday-mission-spine-routes.test.ts`
- `npm run build`