### PR TITLE
Pin D20 trust dial acceptance guards

### DIFF
--- a/rust-core/crates/friday-core/src/gate.rs
+++ b/rust-core/crates/friday-core/src/gate.rs
@@ -1091,6 +1091,67 @@ mod tests {
     }
 
     #[test]
+    fn irreversible_always_gated() {
+        let classification = classify_with_reversibility(
+            true,
+            Risk::Medium,
+            Reversibility::Irreversible,
+            "write_file",
+            &[("path".to_string(), "/worktree/src/lib.rs".to_string())],
+        );
+        assert_eq!(classification.reversibility(), Reversibility::Irreversible);
+        let req = MutatingActionRequest::from_classification(
+            classification,
+            "write_file".to_string(),
+            actor(ActorKind::Owner),
+            "agent".to_string(),
+            vec![],
+            None,
+            None,
+            None,
+        );
+        assert_eq!(evaluate(&req).decision, GateDecision::RequiresApproval);
+    }
+
+    #[test]
+    fn run_command_is_always_irreversible() {
+        let c = classify(
+            true,
+            Risk::Low,
+            "run_command",
+            &[("command".to_string(), "pwd".to_string())],
+        );
+        assert_eq!(c.reversibility(), Reversibility::Irreversible);
+    }
+
+    #[test]
+    fn mislabeled_irreversible_still_pauses() {
+        let c = classify_with_reversibility(
+            true,
+            Risk::Low,
+            Reversibility::Reversible,
+            "write_file",
+            &[(
+                "path".to_string(),
+                "delete production deployment".to_string(),
+            )],
+        );
+        assert_eq!(c.risk(), Some(Risk::High));
+        assert_eq!(c.reversibility(), Reversibility::Irreversible);
+        let req = MutatingActionRequest::from_classification(
+            c,
+            "write_file".to_string(),
+            actor(ActorKind::Owner),
+            "agent".to_string(),
+            vec![],
+            None,
+            None,
+            None,
+        );
+        assert_eq!(evaluate(&req).decision, GateDecision::RequiresApproval);
+    }
+
+    #[test]
     fn base_reversibility_is_never_allowed_to_lower_authoritative_irreversible() {
         let mislabeled = classify_with_reversibility(
             true,

--- a/rust-core/crates/friday-core/src/trust.rs
+++ b/rust-core/crates/friday-core/src/trust.rs
@@ -258,6 +258,22 @@ mod tests {
     }
 
     #[test]
+    fn dial_off_is_byte_identical() {
+        let mut baseline = grant();
+        baseline.boundaries.auto_allow_reversible_ceiling = None;
+        let mut dial_metadata = baseline.clone();
+        dial_metadata.boundaries.auto_allow_reversible_ceiling = Some(Risk::Critical);
+        let mut c = check();
+        c.effective_risk = Risk::Medium;
+
+        assert_eq!(
+            check_grant(&baseline, &c),
+            check_grant(&dial_metadata, &c),
+            "D20 dial metadata is stored-only; with no signed-batch driver it must not alter trust-grant decisions"
+        );
+    }
+
+    #[test]
     fn workspace_outside_prefix_denies() {
         let mut c = check();
         c.workspace = Some("/etc/passwd".into());

--- a/rust-core/crates/friday-hub/src/lib.rs
+++ b/rust-core/crates/friday-hub/src/lib.rs
@@ -16411,6 +16411,21 @@ mod tool_registry_tests {
     }
 
     #[test]
+    fn outbound_send_tool_requires_irreversible() {
+        let classified = trusted_classify(
+            "web_fetch",
+            &[
+                ("url".into(), "https://example.test/collect".into()),
+                ("method".into(), "POST".into()),
+                ("body".into(), "payload".into()),
+            ],
+        )
+        .unwrap();
+        assert!(classified.mutating());
+        assert_eq!(classified.reversibility(), Reversibility::Irreversible);
+    }
+
+    #[test]
     fn custom_registry_late_binds_a_tool_pack() {
         // UNW-002: a runtime tool pack registers a NEW tool with a TRUSTED classification.
         let mut r = ToolRegistry::default();

--- a/rust-core/crates/friday-hub/src/operator_vk.rs
+++ b/rust-core/crates/friday-hub/src/operator_vk.rs
@@ -276,20 +276,36 @@ mod tests {
         std::fs::remove_file(&bad).ok();
     }
 
-    /// KEY-SUBSTITUTION DEFENSE (structural): the entire `friday-hub` source tree must
-    /// never reference `OperatorSigningKey`. The Hub holds ONLY a verify key; if any Hub
-    /// code could construct/derive a signing key, it could mint the very approvals it
+    /// KEY-SUBSTITUTION DEFENSE (structural): the loop-reachable runtime source trees
+    /// must never reference `OperatorSigningKey`. The Hub holds ONLY a verify key; if any
+    /// loop code could construct/derive a signing key, it could mint the very approvals it
     /// verifies (self-mint). We cannot runtime-prove the absence of a mint path, but we
-    /// CAN prove the type that produces signatures is never named in the Hub crate.
+    /// CAN prove the type that produces signatures is never named in the runtime crates.
     #[test]
     fn hub_crate_never_references_a_signing_key() {
-        let src = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+        loop_reachable_crates_never_reference_a_signing_key();
+    }
+
+    #[test]
+    fn loop_reachable_crates_never_reference_a_signing_key() {
+        let crates_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .expect("friday-hub crate has a parent crates dir");
+        let runtime_src_dirs = [
+            crates_dir.join("friday-core/src"),
+            crates_dir.join("friday-ffi/src"),
+            crates_dir.join("friday-hub/src"),
+            crates_dir.join("friday-protocol/src"),
+            crates_dir.join("friday-storage/src"),
+        ];
         let mut offenders = Vec::new();
-        scan_for(&src, "OperatorSigningKey", &mut offenders);
+        for src in runtime_src_dirs {
+            scan_for(&src, "OperatorSigningKey", &mut offenders);
+        }
         assert!(
             offenders.is_empty(),
-            "friday-hub must never reference OperatorSigningKey (a Hub-generated operator \
-             key would be full self-mint); found in: {offenders:?}"
+            "loop-reachable runtime crates must never reference OperatorSigningKey \
+             (a Hub-generated operator key would be full self-mint); found in: {offenders:?}"
         );
     }
 

--- a/rust-core/crates/friday-storage/tests/authorize_ed25519.rs
+++ b/rust-core/crates/friday-storage/tests/authorize_ed25519.rs
@@ -848,6 +848,52 @@ fn dial_worktree_driver_allows_signed_member_inside_active_worktree_and_audits()
 }
 
 #[test]
+fn audit_covers_every_dial_allow() {
+    let mut db = Db::open_hub(&temp_db_path("ed-dial-worktree-audit")).unwrap();
+    let worktree = temp_worktree("audit");
+    let (sk, vk) = operator();
+
+    for i in 0..3 {
+        let batch_id = format!("dial-audit-batch-{i}");
+        let target = worktree.join(format!("src/owned-{i}.txt"));
+        let req = req_with(
+            "write_file",
+            ActorKind::Owner,
+            true,
+            Risk::Medium,
+            Some(target.to_string_lossy().as_ref()),
+            "p1",
+        );
+        let batch = batch_approval(&[&req], &sk, &batch_id, Some(FUTURE));
+        let scope = DialWorktreeScope {
+            plan_sign_id: batch_id,
+            active_worktree: worktree.clone(),
+        };
+        let r = authorize_reversible_batch_in_worktree(
+            db.conn_mut(),
+            &req,
+            Some(&batch),
+            &vk,
+            NOW + i,
+            &scope,
+        )
+        .unwrap();
+        assert_eq!(r.decision, GateDecision::Allow);
+    }
+
+    assert_eq!(consumed_count(&db), 3);
+    assert_eq!(
+        audit_count(&db),
+        consumed_count(&db),
+        "every dial auto-allow must append exactly one audit row"
+    );
+    assert_eq!(
+        friday_storage::audit::verify_audit_chain(db.conn()).unwrap(),
+        3
+    );
+}
+
+#[test]
 fn dial_worktree_driver_pauses_resource_outside_active_worktree_without_consuming() {
     let mut db = Db::open_hub(&temp_db_path("ed-dial-worktree-escape")).unwrap();
     let worktree = temp_worktree("escape");


### PR DESCRIPTION
## Summary
- add explicit D20 W2 acceptance guard tests for irreversible gating, run_command irreversibility, mislabeled irreversible pause behavior, dial-off inertness, outbound-send irreversibility, and dial audit coverage
- expand the operator verify-key source scan from friday-hub/src to loop-reachable runtime src crates (core, ffi, hub, protocol, storage)

## Validation
- cargo fmt --all -- --check
- cargo test -p friday-core --lib -- --nocapture
- cargo test -p friday-hub outbound_send_tool_requires_irreversible -- --nocapture
- cargo test -p friday-hub loop_reachable_crates_never_reference_a_signing_key -- --nocapture
- cargo test -p friday-hub hub_crate_never_references_a_signing_key -- --nocapture
- cargo test -p friday-storage audit_covers_every_dial_allow -- --nocapture
- cargo test -p friday-storage dial_worktree_driver_twenty_round_mixed_batch_soak_never_auto_allows_irreversible -- --nocapture
- cargo clippy -p friday-core -p friday-storage -p friday-hub --all-targets -- -D warnings

## Truth labels
- D20 W2 acceptance-pin/testing slice only; no runtime behavior change.
- TEST-key mechanism-soak remains not TRUE operator-in-the-loop.
- Friday still has no action-rollback engine; reversible means worktree/git-confined mechanics, not undo.
- No operator private key was read or used.
- Goal-achieved remains false.