### PR TITLE
Add D20 operator batch signing CLI

### DIFF
--- a/rust-core/crates/friday-operator-cli/src/lib.rs
+++ b/rust-core/crates/friday-operator-cli/src/lib.rs
@@ -49,13 +49,15 @@
 //! against. The human-readable context fields are echoed for operator review and
 //! are explicitly NOT part of the signature.
 
+use std::collections::HashSet;
 use std::fs;
 use std::io::Write;
 use std::os::unix::fs::OpenOptionsExt;
 use std::path::Path;
 
 use friday_core::gate::{
-    canonical_approval_signature_bytes, ApprovalDecision, CanonicalApproval, CANONICAL_GATE_ISSUER,
+    canonical_approval_batch_signature_bytes, canonical_approval_signature_bytes, ApprovalDecision,
+    CanonicalApproval, CanonicalApprovalBatch, CANONICAL_GATE_ISSUER,
 };
 use friday_crypto::ed25519_approval::{SEED_LEN, VERIFYING_KEY_LEN};
 use friday_crypto::OperatorSigningKey;
@@ -127,6 +129,30 @@ pub struct PendingRequest {
     pub surface: Option<String>,
 }
 
+/// A pending batch request the operator signs for D20 W2. It binds one operator
+/// decision to an exact list of action digests. Unknown fields are tolerated so the
+/// operator surface can include richer review context without changing signed bytes.
+#[derive(Debug, Clone, Deserialize)]
+pub struct PendingBatchRequest {
+    /// Batch replay namespace. Each member spends `(batch_sign_id, action_digest)`.
+    pub batch_sign_id: String,
+    /// Exact action digest members the operator reviewed.
+    pub action_digests: Vec<String>,
+    /// Epoch ms after which the batch approval is expired.
+    pub expires_at: i64,
+    /// Operator's decision: `"approved"` or `"denied"`.
+    pub decision: String,
+    /// Issuer string; defaults to the canonical gate issuer when omitted.
+    #[serde(default)]
+    pub issuer: Option<String>,
+
+    // ---- context-only (operator review); NOT part of the signature ----
+    #[serde(default)]
+    pub plan_label: Option<String>,
+    #[serde(default)]
+    pub worktree: Option<String>,
+}
+
 /// The operator-signed approval emitted to stdout. JSON the Hub-side S6d ingestion
 /// will parse; the `signature` is an Ed25519 signature (hex) over [`canonical_bytes`].
 /// The PUBLIC verify key is deliberately NOT carried here — the Hub MUST verify
@@ -143,6 +169,22 @@ pub struct SignedApproval {
     pub expires_at: i64,
     pub issuer: String,
     /// Hex Ed25519 signature (64 bytes -> 128 hex chars) over the canonical bytes.
+    pub signature: String,
+}
+
+/// Operator-signed D20 W2 batch approval emitted to stdout. The Hub verifies this
+/// under its provisioned operator public key; the private key is never carried here.
+#[derive(Debug, Clone, Serialize)]
+pub struct SignedApprovalBatch {
+    /// Always `"ed25519"`.
+    pub scheme: String,
+    /// `"approved"` or `"denied"` (normalized).
+    pub decision: String,
+    pub batch_sign_id: String,
+    pub action_digests: Vec<String>,
+    pub expires_at: i64,
+    pub issuer: String,
+    /// Hex Ed25519 signature over the canonical batch bytes.
     pub signature: String,
 }
 
@@ -210,6 +252,24 @@ fn validate_action_digest(s: &str) -> Result<(), CliError> {
     }
 }
 
+fn validate_batch_digests(digests: &[String]) -> Result<(), CliError> {
+    if digests.is_empty() {
+        return Err(CliError::BadRequest(
+            "action_digests must not be empty".to_string(),
+        ));
+    }
+    let mut seen = HashSet::with_capacity(digests.len());
+    for digest in digests {
+        validate_action_digest(digest)?;
+        if !seen.insert(digest) {
+            return Err(CliError::BadRequest(
+                "action_digests must not contain duplicates".to_string(),
+            ));
+        }
+    }
+    Ok(())
+}
+
 /// The single shared path that produces the bytes a signature covers. Builds a
 /// `CanonicalApproval` (with `signature: None` — the gate function does not read it)
 /// and calls the REAL gate serializer, so these are byte-identical to what the Hub
@@ -230,6 +290,27 @@ pub fn canonical_bytes(
         signature: None,
     };
     canonical_approval_signature_bytes(&approval)
+}
+
+/// The single shared path that produces the bytes a batch signature covers.
+/// Builds a `CanonicalApprovalBatch` with `signature: None` and calls the REAL gate
+/// serializer, so sign-time and verify-time bytes are identical by construction.
+pub fn canonical_batch_bytes(
+    decision: ApprovalDecision,
+    batch_sign_id: &str,
+    action_digests: &[String],
+    expires_at: i64,
+    issuer: &str,
+) -> Vec<u8> {
+    let batch = CanonicalApprovalBatch {
+        decision,
+        batch_sign_id: batch_sign_id.to_string(),
+        action_digests: action_digests.to_vec(),
+        expires_at: Some(expires_at),
+        issuer: Some(issuer.to_string()),
+        signature: None,
+    };
+    canonical_approval_batch_signature_bytes(&batch)
 }
 
 /// Write the operator's PRIVATE seed (hex) to `path`, created fresh with `0o600`
@@ -305,6 +386,17 @@ pub fn sign_request(key_path: &Path, req: &PendingRequest) -> Result<SignedAppro
     sign_request_with_key(&sk, req)
 }
 
+/// sign-batch: validate a D20 W2 pending batch, load the PRIVATE key from
+/// `key_path`, reconstruct the canonical batch bytes, Ed25519-sign them, and return
+/// the signed batch approval.
+pub fn sign_batch_request(
+    key_path: &Path,
+    req: &PendingBatchRequest,
+) -> Result<SignedApprovalBatch, CliError> {
+    let sk = read_signing_key(key_path)?;
+    sign_batch_request_with_key(&sk, req)
+}
+
 /// sign with an ALREADY-LOADED operator signing key: validate the pending request,
 /// reconstruct the canonical bytes, Ed25519-sign them, and return the signed approval.
 ///
@@ -358,6 +450,53 @@ pub fn sign_request_with_key(
         decision: decision_str(decision).to_string(),
         approval_id: req.approval_id.clone(),
         action_digest: req.action_digest.clone(),
+        expires_at: req.expires_at,
+        issuer,
+        signature: to_hex(&sig.to_bytes()),
+    })
+}
+
+/// Sign with an already-loaded operator signing key, for operator-controlled key
+/// sources. The caller owns key custody; this function only validates and signs the
+/// canonical batch bytes.
+pub fn sign_batch_request_with_key(
+    sk: &OperatorSigningKey,
+    req: &PendingBatchRequest,
+) -> Result<SignedApprovalBatch, CliError> {
+    let decision = parse_decision(&req.decision)?;
+    if req.batch_sign_id.trim().is_empty() {
+        return Err(CliError::BadRequest(
+            "batch_sign_id must not be empty".to_string(),
+        ));
+    }
+    validate_batch_digests(&req.action_digests)?;
+    if req.expires_at <= 0 {
+        return Err(CliError::BadRequest(
+            "expires_at must be a positive epoch-ms".to_string(),
+        ));
+    }
+    let issuer = req
+        .issuer
+        .clone()
+        .unwrap_or_else(|| CANONICAL_GATE_ISSUER.to_string());
+    if issuer.trim().is_empty() {
+        return Err(CliError::BadRequest("issuer must not be empty".to_string()));
+    }
+
+    let bytes = canonical_batch_bytes(
+        decision,
+        &req.batch_sign_id,
+        &req.action_digests,
+        req.expires_at,
+        &issuer,
+    );
+    let sig = sk.sign(&bytes);
+
+    Ok(SignedApprovalBatch {
+        scheme: SCHEME_ED25519.to_string(),
+        decision: decision_str(decision).to_string(),
+        batch_sign_id: req.batch_sign_id.clone(),
+        action_digests: req.action_digests.clone(),
         expires_at: req.expires_at,
         issuer,
         signature: to_hex(&sig.to_bytes()),
@@ -575,6 +714,18 @@ mod tests {
         }
     }
 
+    fn sample_batch_request() -> PendingBatchRequest {
+        PendingBatchRequest {
+            batch_sign_id: "batch-d20-001".to_string(),
+            action_digests: vec!["a".repeat(64), "b".repeat(64)],
+            expires_at: 1_900_000_000_000,
+            decision: "approved".to_string(),
+            issuer: None,
+            plan_label: Some("D20 reversible batch".to_string()),
+            worktree: Some("/tmp/friday-worktree".to_string()),
+        }
+    }
+
     #[test]
     fn keygen_then_sign_verifies() {
         let dir = std::env::temp_dir().join(format!("op-cli-unit-{}", std::process::id()));
@@ -634,6 +785,58 @@ mod tests {
     }
 
     #[test]
+    fn keygen_then_sign_batch_verifies() {
+        let dir = std::env::temp_dir().join(format!("op-cli-unit-batch-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let key_path = dir.join("operator.key");
+        let _ = std::fs::remove_file(&key_path);
+
+        let vk_hex = keygen_to_path(&key_path).unwrap();
+        let req = sample_batch_request();
+        let signed = sign_batch_request(&key_path, &req).unwrap();
+
+        let decision = parse_decision(&signed.decision).unwrap();
+        let bytes = canonical_batch_bytes(
+            decision,
+            &signed.batch_sign_id,
+            &signed.action_digests,
+            signed.expires_at,
+            &signed.issuer,
+        );
+        let vk = decode_verifying_key_hex(&vk_hex).unwrap();
+        let sig = decode_signature_hex(&signed.signature).unwrap();
+        assert!(
+            verify_ed25519_approval(&bytes, &vk, &sig),
+            "operator-signed batch must verify under the keygen public key"
+        );
+        assert_eq!(signed.issuer, CANONICAL_GATE_ISSUER);
+        std::fs::remove_file(&key_path).ok();
+    }
+
+    #[test]
+    fn sign_batch_request_and_with_key_are_byte_identical() {
+        let dir = std::env::temp_dir().join(format!("op-cli-unit-batch-eq-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let key_path = dir.join("operator.key");
+        let _ = std::fs::remove_file(&key_path);
+        keygen_to_path(&key_path).unwrap();
+
+        let req = sample_batch_request();
+        let from_file = sign_batch_request(&key_path, &req).unwrap();
+        let sk = read_signing_key(&key_path).unwrap();
+        let from_key = sign_batch_request_with_key(&sk, &req).unwrap();
+
+        assert_eq!(from_file.signature, from_key.signature);
+        assert_eq!(from_file.batch_sign_id, from_key.batch_sign_id);
+        assert_eq!(from_file.action_digests, from_key.action_digests);
+        assert_eq!(from_file.issuer, from_key.issuer);
+        assert_eq!(from_file.decision, from_key.decision);
+        assert_eq!(from_file.scheme, from_key.scheme);
+        assert_eq!(from_file.expires_at, from_key.expires_at);
+        std::fs::remove_file(&key_path).ok();
+    }
+
+    #[test]
     fn keygen_refuses_to_overwrite() {
         let dir = std::env::temp_dir().join(format!("op-cli-unit-ow-{}", std::process::id()));
         std::fs::create_dir_all(&dir).unwrap();
@@ -662,5 +865,7 @@ mod tests {
         assert!(validate_action_digest(&"A".repeat(64)).is_err()); // uppercase rejected
         assert!(validate_action_digest("abc").is_err()); // wrong length
         assert!(validate_action_digest(&"g".repeat(64)).is_err()); // non-hex
+        assert!(validate_batch_digests(&[]).is_err());
+        assert!(validate_batch_digests(&["a".repeat(64), "a".repeat(64)]).is_err());
     }
 }

--- a/rust-core/crates/friday-operator-cli/src/main.rs
+++ b/rust-core/crates/friday-operator-cli/src/main.rs
@@ -13,6 +13,10 @@
 //!     Read a pending request (the fields S6b persists when a mutating action
 //!     Pauses), load the PRIVATE key, and emit an Ed25519-signed CanonicalApproval
 //!     as JSON to stdout. No network. The private key never appears in the output.
+//!
+//! friday-operator-approve sign-batch --key <private-key-path> --request <pending-batch.json>
+//!     Read a D20 W2 pending batch (a batch_sign_id plus exact action digests), load
+//!     the PRIVATE key, and emit an Ed25519-signed CanonicalApprovalBatch as JSON.
 //! ```
 //!
 //! Truth label: offline operator-signing tool (operator-held private key; the Hub
@@ -28,7 +32,9 @@ use std::process::ExitCode;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use friday_operator_cli::trust_grant;
-use friday_operator_cli::{keygen_to_path, sign_request, PendingRequest};
+use friday_operator_cli::{
+    keygen_to_path, sign_batch_request, sign_request, PendingBatchRequest, PendingRequest,
+};
 
 const USAGE: &str = "\
 friday-operator-approve — operator CLI (S6c signing + NS-3 trust-grant issuance)
@@ -36,6 +42,7 @@ friday-operator-approve — operator CLI (S6c signing + NS-3 trust-grant issuanc
 USAGE:
     friday-operator-approve keygen --out <private-key-path>
     friday-operator-approve sign  --key <private-key-path> --request <pending-request.json>
+    friday-operator-approve sign-batch --key <private-key-path> --request <pending-batch.json>
     friday-operator-approve grant  --db <hub.sqlite> --grant-id <id> --agent <agent-id> \\
                                     --risk-ceiling <read_only|low|medium|high|critical> \\
                                     [--expires-at <epoch-ms>] [--workspace <path-prefix>] \\
@@ -50,6 +57,10 @@ verifying key (JSON) to stdout for Hub provisioning. The private key is never pr
 
 sign reads a pending request JSON and emits an Ed25519-signed CanonicalApproval (JSON)
 to stdout. The private key never appears in the output.
+
+sign-batch reads a D20 W2 pending batch JSON and emits an Ed25519-signed
+CanonicalApprovalBatch (JSON) for an exact digest set. The private key never appears in
+the output.
 
 grant mints a TrustGrant for --agent with the given boundaries (operator POLICY action;
 the allowlists are fail-closed — an omitted dimension is DENY-ALL) and prints the
@@ -71,6 +82,7 @@ fn run() -> Result<(), String> {
     match args.get(1).map(String::as_str) {
         Some("keygen") => cmd_keygen(&args[2..]),
         Some("sign") => cmd_sign(&args[2..]),
+        Some("sign-batch") => cmd_sign_batch(&args[2..]),
         Some("grant") => cmd_grant(&args[2..]),
         Some("revoke") => cmd_revoke(&args[2..]),
         Some("help") | Some("--help") | Some("-h") | None => {
@@ -110,6 +122,23 @@ fn cmd_sign(args: &[String]) -> Result<(), String> {
         serde_json::from_str(&json).map_err(|e| format!("invalid request JSON: {e}"))?;
     let signed = sign_request(Path::new(&key), &req).map_err(|e| e.to_string())?;
     // Signed approval -> stdout. The private key is never part of this output.
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&signed).map_err(|e| e.to_string())?
+    );
+    Ok(())
+}
+
+fn cmd_sign_batch(args: &[String]) -> Result<(), String> {
+    let key = arg_value(args, "--key")
+        .ok_or_else(|| format!("sign-batch requires --key <private-key-path>\n\n{USAGE}"))?;
+    let request = arg_value(args, "--request")
+        .ok_or_else(|| format!("sign-batch requires --request <pending-batch.json>\n\n{USAGE}"))?;
+    let json = std::fs::read_to_string(&request)
+        .map_err(|_| format!("could not read request file {request}"))?;
+    let req: PendingBatchRequest =
+        serde_json::from_str(&json).map_err(|e| format!("invalid batch request JSON: {e}"))?;
+    let signed = sign_batch_request(Path::new(&key), &req).map_err(|e| e.to_string())?;
     println!(
         "{}",
         serde_json::to_string_pretty(&signed).map_err(|e| e.to_string())?

--- a/rust-core/crates/friday-operator-cli/tests/cli_roundtrip.rs
+++ b/rust-core/crates/friday-operator-cli/tests/cli_roundtrip.rs
@@ -16,7 +16,8 @@ use std::process::{Command, Output};
 use friday_core::gate::ApprovalDecision;
 use friday_crypto::verify_ed25519_approval;
 use friday_operator_cli::{
-    canonical_bytes, decode_signature_hex, decode_verifying_key_hex, parse_decision,
+    canonical_batch_bytes, canonical_bytes, decode_signature_hex, decode_verifying_key_hex,
+    parse_decision,
 };
 
 const BIN: &str = env!("CARGO_BIN_EXE_friday-operator-approve");
@@ -43,6 +44,17 @@ fn sample_req() -> serde_json::Value {
         "principal": "owner:alice",
         "action": "fs.delete",
         "surface": "desktop"
+    })
+}
+
+fn sample_batch_req() -> serde_json::Value {
+    serde_json::json!({
+        "batch_sign_id": "batch-d20-cli",
+        "action_digests": ["a".repeat(64), "b".repeat(64)],
+        "expires_at": 1_900_000_000_000i64,
+        "decision": "approved",
+        "plan_label": "D20 reversible batch",
+        "worktree": "/tmp/friday-worktree"
     })
 }
 
@@ -83,6 +95,22 @@ fn rebuild_canonical_bytes(signed: &serde_json::Value) -> Vec<u8> {
         parse_decision(signed["decision"].as_str().unwrap()).unwrap(),
         signed["approval_id"].as_str().unwrap(),
         signed["action_digest"].as_str().unwrap(),
+        signed["expires_at"].as_i64().unwrap(),
+        signed["issuer"].as_str().unwrap(),
+    )
+}
+
+fn rebuild_canonical_batch_bytes(signed: &serde_json::Value) -> Vec<u8> {
+    let digests = signed["action_digests"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|v| v.as_str().unwrap().to_string())
+        .collect::<Vec<_>>();
+    canonical_batch_bytes(
+        parse_decision(signed["decision"].as_str().unwrap()).unwrap(),
+        signed["batch_sign_id"].as_str().unwrap(),
+        &digests,
         signed["expires_at"].as_i64().unwrap(),
         signed["issuer"].as_str().unwrap(),
     )
@@ -182,6 +210,69 @@ fn keygen_sign_roundtrip_verifies_and_never_leaks_private_key() {
 }
 
 #[test]
+fn keygen_sign_batch_roundtrip_verifies_and_never_leaks_private_key() {
+    let dir = tmp_dir("batch-roundtrip");
+    let key_path = dir.join("operator.key");
+    let _ = std::fs::remove_file(&key_path);
+
+    let kg = run_bin(&["keygen", "--out", key_path.to_str().unwrap()]);
+    assert!(
+        kg.status.success(),
+        "keygen failed: {}",
+        String::from_utf8_lossy(&kg.stderr)
+    );
+    let kg_stdout = String::from_utf8(kg.stdout).unwrap();
+    let kg_stderr = String::from_utf8(kg.stderr).unwrap();
+    let seed_hex = std::fs::read_to_string(&key_path)
+        .unwrap()
+        .trim()
+        .to_string();
+    assert!(!kg_stdout.contains(&seed_hex));
+    assert!(!kg_stderr.contains(&seed_hex));
+    let kg_json: serde_json::Value = serde_json::from_str(&kg_stdout).unwrap();
+    let vk_hex = kg_json["verifying_key"].as_str().unwrap().to_string();
+
+    let req_path = dir.join("pending-batch.json");
+    std::fs::write(&req_path, serde_json::to_vec(&sample_batch_req()).unwrap()).unwrap();
+    let sg = run_bin(&[
+        "sign-batch",
+        "--key",
+        key_path.to_str().unwrap(),
+        "--request",
+        req_path.to_str().unwrap(),
+    ]);
+    assert!(
+        sg.status.success(),
+        "sign-batch failed: {}",
+        String::from_utf8_lossy(&sg.stderr)
+    );
+    let sg_stdout = String::from_utf8(sg.stdout).unwrap();
+    let sg_stderr = String::from_utf8(sg.stderr).unwrap();
+    assert!(
+        !sg_stdout.contains(&seed_hex),
+        "PRIVATE KEY LEAKED to sign-batch stdout"
+    );
+    assert!(
+        !sg_stderr.contains(&seed_hex),
+        "PRIVATE KEY LEAKED to sign-batch stderr"
+    );
+
+    let signed: serde_json::Value = serde_json::from_str(&sg_stdout).unwrap();
+    assert_eq!(signed["scheme"], "ed25519");
+    assert_eq!(signed["decision"], "approved");
+    assert_eq!(signed["issuer"], "friday_canonical_gate");
+    assert_eq!(signed["action_digests"].as_array().unwrap().len(), 2);
+
+    let bytes = rebuild_canonical_batch_bytes(&signed);
+    let vk = decode_verifying_key_hex(&vk_hex).unwrap();
+    let sig = decode_signature_hex(signed["signature"].as_str().unwrap()).unwrap();
+    assert!(
+        verify_ed25519_approval(&bytes, &vk, &sig),
+        "operator-signed batch must verify under the keygen public key"
+    );
+}
+
+#[test]
 fn any_signed_field_tamper_breaks_verification() {
     let (vk_hex, signed) = keygen_and_sign("tamper", &sample_req());
     let vk = decode_verifying_key_hex(&vk_hex).unwrap();
@@ -236,6 +327,85 @@ fn any_signed_field_tamper_breaks_verification() {
             action_digest,
             expires_at,
             "attacker_issuer"
+        ),
+        &vk,
+        &sig
+    ));
+}
+
+#[test]
+fn any_signed_batch_field_tamper_breaks_verification() {
+    let dir = tmp_dir("batch-tamper");
+    let key_path = dir.join("operator.key");
+    let _ = std::fs::remove_file(&key_path);
+    let kg = run_bin(&["keygen", "--out", key_path.to_str().unwrap()]);
+    assert!(kg.status.success());
+    let kg_json: serde_json::Value = serde_json::from_slice(&kg.stdout).unwrap();
+    let vk_hex = kg_json["verifying_key"].as_str().unwrap().to_string();
+
+    let req_path = dir.join("pending-batch.json");
+    std::fs::write(&req_path, serde_json::to_vec(&sample_batch_req()).unwrap()).unwrap();
+    let sg = run_bin(&[
+        "sign-batch",
+        "--key",
+        key_path.to_str().unwrap(),
+        "--request",
+        req_path.to_str().unwrap(),
+    ]);
+    assert!(sg.status.success());
+    let signed: serde_json::Value = serde_json::from_slice(&sg.stdout).unwrap();
+    let vk = decode_verifying_key_hex(&vk_hex).unwrap();
+    let sig = decode_signature_hex(signed["signature"].as_str().unwrap()).unwrap();
+    let digests = signed["action_digests"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|v| v.as_str().unwrap().to_string())
+        .collect::<Vec<_>>();
+
+    assert!(verify_ed25519_approval(
+        &canonical_batch_bytes(
+            parse_decision(signed["decision"].as_str().unwrap()).unwrap(),
+            signed["batch_sign_id"].as_str().unwrap(),
+            &digests,
+            signed["expires_at"].as_i64().unwrap(),
+            signed["issuer"].as_str().unwrap(),
+        ),
+        &vk,
+        &sig
+    ));
+
+    let mut flipped_digests = digests.clone();
+    flipped_digests[0] = "c".repeat(64);
+    assert!(!verify_ed25519_approval(
+        &canonical_batch_bytes(
+            ApprovalDecision::Approved,
+            signed["batch_sign_id"].as_str().unwrap(),
+            &flipped_digests,
+            signed["expires_at"].as_i64().unwrap(),
+            signed["issuer"].as_str().unwrap(),
+        ),
+        &vk,
+        &sig
+    ));
+    assert!(!verify_ed25519_approval(
+        &canonical_batch_bytes(
+            ApprovalDecision::Denied,
+            signed["batch_sign_id"].as_str().unwrap(),
+            &digests,
+            signed["expires_at"].as_i64().unwrap(),
+            signed["issuer"].as_str().unwrap(),
+        ),
+        &vk,
+        &sig
+    ));
+    assert!(!verify_ed25519_approval(
+        &canonical_batch_bytes(
+            ApprovalDecision::Approved,
+            "batch-different",
+            &digests,
+            signed["expires_at"].as_i64().unwrap(),
+            signed["issuer"].as_str().unwrap(),
         ),
         &vk,
         &sig


### PR DESCRIPTION
## Summary
- add `sign-batch` to the offline `friday-operator-approve` CLI for D20 W2 exact-digest batch approvals
- add library types/helpers for `PendingBatchRequest`, `SignedApprovalBatch`, canonical batch bytes, and file/loaded-key signing paths
- validate batch digests fail-closed: non-empty, lowercase 64-hex, no duplicates
- add unit and compiled-binary roundtrip/tamper/no-private-key-leak tests

## Validation
- cargo fmt --all -- --check
- cargo test -p friday-operator-cli -- --nocapture
- cargo test -p friday-operator-cli keygen_sign_batch_roundtrip_verifies_and_never_leaks_private_key -- --nocapture
- cargo clippy -p friday-operator-cli --all-targets -- -D warnings
- git diff --check

Note: one earlier local command ran two copies of the same compiled-binary batch roundtrip test concurrently; they intentionally share a persistent target tmp path and one copy hit the expected create_new key-file refusal. The same test passed when run singly and the full package test passed.

## Truth labels
- DARK operator-side signing surface only; not a live trust-dial loop.
- This does not read or use the real operator private key.
- TEST-key validation is mechanism proof, not TRUE operator-in-the-loop.
- Friday still has no action-rollback engine; reversible remains git/worktree-confined mechanics, not undo.
- Goal-achieved remains false.