### PR TITLE
Add D20 worktree ref to dial audit

### DIFF
--- a/rust-core/crates/friday-storage/src/authorize_ed25519.rs
+++ b/rust-core/crates/friday-storage/src/authorize_ed25519.rs
@@ -323,7 +323,11 @@ pub fn authorize_reversible_batch_in_worktree(
     if evidence.decision == GateDecision::Allow {
         let digest = friday_crypto::action_digest(&gate::canonical_action_bytes(request));
         let audit_id = format!("dial.batch.worktree:{}:{}", scope.plan_sign_id, digest);
-        let payload_ref = format!("dial://batch/{}/action/{}", scope.plan_sign_id, digest);
+        let worktree_ref = dial_worktree_ref(&scope.active_worktree);
+        let payload_ref = format!(
+            "dial://batch/{}/worktree/{}/action/{}",
+            scope.plan_sign_id, worktree_ref, digest
+        );
         crate::audit::append_audit(
             &tx,
             &audit_id,
@@ -365,6 +369,14 @@ fn worktree_revertable_preflight(
         return Some("dial_worktree_resource_out_of_scope");
     }
     None
+}
+
+fn dial_worktree_ref(active_worktree: &Path) -> String {
+    let canonical = std::fs::canonicalize(active_worktree)
+        .unwrap_or_else(|_| active_worktree.to_path_buf())
+        .to_string_lossy()
+        .into_owned();
+    friday_crypto::action_digest(canonical.as_bytes())
 }
 
 fn canonicalize_existing_parent(

--- a/rust-core/crates/friday-storage/tests/authorize_ed25519.rs
+++ b/rust-core/crates/friday-storage/tests/authorize_ed25519.rs
@@ -25,7 +25,7 @@ use friday_storage::{
     authorize_reversible_batch_in_worktree, get_pending_request, persist_pending_request, Db,
     DialWorktreeScope, Ed25519VerifyOnlyPolicy, PendingApprovalRequest,
 };
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 /// The HMAC secret the HUB holds (the symmetric mint==verify key). A correct verify-only
 /// Ed25519 policy must make this irrelevant for protected actions.
@@ -206,6 +206,20 @@ fn audit_count(db: &Db) -> i64 {
     db.conn()
         .query_row("SELECT count(*) FROM audit_ledger", [], |r| r.get(0))
         .unwrap()
+}
+
+fn only_audit_payload_ref(db: &Db) -> String {
+    db.conn()
+        .query_row("SELECT payload_ref FROM audit_ledger", [], |r| r.get(0))
+        .unwrap()
+}
+
+fn worktree_ref(path: &Path) -> String {
+    let canonical = std::fs::canonicalize(path)
+        .unwrap()
+        .to_string_lossy()
+        .into_owned();
+    friday_crypto::action_digest(canonical.as_bytes())
 }
 
 fn temp_worktree(tag: &str) -> PathBuf {
@@ -827,7 +841,7 @@ fn dial_worktree_driver_allows_signed_member_inside_active_worktree_and_audits()
     let batch = batch_approval(&[&req], &sk, "dial-batch-ok", Some(FUTURE));
     let scope = DialWorktreeScope {
         plan_sign_id: "dial-batch-ok".to_string(),
-        active_worktree: worktree,
+        active_worktree: worktree.clone(),
     };
 
     let r =
@@ -844,6 +858,15 @@ fn dial_worktree_driver_allows_signed_member_inside_active_worktree_and_audits()
     assert_eq!(
         friday_storage::audit::verify_audit_chain(db.conn()).unwrap(),
         1
+    );
+    let payload_ref = only_audit_payload_ref(&db);
+    assert!(
+        payload_ref.contains(&format!("/worktree/{}/", worktree_ref(&worktree))),
+        "dial audit payload must carry a refs-only worktree digest, got {payload_ref}"
+    );
+    assert!(
+        payload_ref.starts_with("dial://batch/dial-batch-ok/worktree/"),
+        "dial audit payload must carry the plan sign id and worktree ref, got {payload_ref}"
     );
 }
 


### PR DESCRIPTION
## Summary\n- include a refs-only worktree digest in successful D20 dial worktree authorization audit payloads\n- keep the existing plan sign id and action digest in the audit URI\n- pin the audit shape with the existing worktree-driver test while keeping the 20-round mixed-batch soak green\n\n## Validation\n- cargo fmt --all -- --check\n- cargo test -p friday-storage --test authorize_ed25519 dial_worktree_driver_allows_signed_member_inside_active_worktree_and_audits -- --nocapture\n- cargo test -p friday-storage --test authorize_ed25519 dial_worktree_driver_twenty_round_mixed_batch_soak_never_auto_allows_irreversible -- --nocapture\n- cargo clippy -p friday-storage --all-targets -- -D warnings\n- git diff --check\n\nTruth labels: DARK audit/mechanism only; no trust-dial live flip, no TRUE operator-in-the-loop batch, no operator private key touched, no action rollback engine.