### PR TITLE
Add D20 prepared batch CLI

### DIFF
--- a/rust-core/Cargo.lock
+++ b/rust-core/Cargo.lock
@@ -720,6 +720,7 @@ version = "0.0.1"
 dependencies = [
  "friday-core",
  "friday-crypto",
+ "friday-hub",
  "friday-storage",
  "serde",
  "serde_json",

--- a/rust-core/crates/friday-operator-cli/Cargo.toml
+++ b/rust-core/crates/friday-operator-cli/Cargo.toml
@@ -25,6 +25,9 @@ thiserror.workspace = true
 # Wipe transient secret buffers (decoded seed / hex) after use.
 zeroize.workspace = true
 
+[dev-dependencies]
+friday-hub.workspace = true
+
 [[bin]]
 name = "friday-operator-approve"
 path = "src/main.rs"

--- a/rust-core/crates/friday-operator-cli/src/lib.rs
+++ b/rust-core/crates/friday-operator-cli/src/lib.rs
@@ -56,11 +56,14 @@ use std::os::unix::fs::OpenOptionsExt;
 use std::path::Path;
 
 use friday_core::gate::{
-    canonical_approval_batch_signature_bytes, canonical_approval_signature_bytes, ApprovalDecision,
-    CanonicalApproval, CanonicalApprovalBatch, CANONICAL_GATE_ISSUER,
+    canonical_action_bytes, canonical_approval_batch_signature_bytes,
+    canonical_approval_signature_bytes, Actor, ActorKind, ApprovalDecision, CanonicalApproval,
+    CanonicalApprovalBatch, LocalClaim, MutatingActionRequest, Reversibility,
+    CANONICAL_GATE_ISSUER,
 };
+use friday_core::Risk;
 use friday_crypto::ed25519_approval::{SEED_LEN, VERIFYING_KEY_LEN};
-use friday_crypto::OperatorSigningKey;
+use friday_crypto::{action_digest, OperatorSigningKey};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use zeroize::Zeroize;
@@ -132,7 +135,7 @@ pub struct PendingRequest {
 /// A pending batch request the operator signs for D20 W2. It binds one operator
 /// decision to an exact list of action digests. Unknown fields are tolerated so the
 /// operator surface can include richer review context without changing signed bytes.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct PendingBatchRequest {
     /// Batch replay namespace. Each member spends `(batch_sign_id, action_digest)`.
     pub batch_sign_id: String,
@@ -151,6 +154,50 @@ pub struct PendingBatchRequest {
     pub plan_label: Option<String>,
     #[serde(default)]
     pub worktree: Option<String>,
+}
+
+/// Operator-side input for producing a D20 W2 pending batch from canonical action
+/// specs. This CLI does NOT sign or execute the actions; it computes the exact
+/// digests that a later operator-held-key `sign-batch` decision may cover.
+#[derive(Debug, Clone, Deserialize)]
+pub struct PrepareBatchRequest {
+    pub batch_sign_id: String,
+    pub expires_at: i64,
+    pub decision: String,
+    #[serde(default)]
+    pub issuer: Option<String>,
+    #[serde(default)]
+    pub plan_label: Option<String>,
+    #[serde(default)]
+    pub worktree: Option<String>,
+    pub actions: Vec<BatchActionSpec>,
+}
+
+/// One action candidate to include in an operator batch. `mutating`, `base_risk`,
+/// and reversibility are never accepted from JSON; they come from the built-in
+/// registry mirror below and are recomputed by `friday_core::gate::classify`.
+#[derive(Debug, Clone, Deserialize)]
+pub struct BatchActionSpec {
+    pub action: String,
+    pub actor_kind: String,
+    pub actor_id: String,
+    #[serde(default)]
+    pub principal_id: Option<String>,
+    pub surface: String,
+    #[serde(default)]
+    pub params: Vec<ActionParam>,
+    #[serde(default)]
+    pub idempotency_key: Option<String>,
+    #[serde(default)]
+    pub plan_digest: Option<String>,
+}
+
+/// Ordered action parameter entry. Order is preserved in both classification and the
+/// opaque canonical parameter string that is bound into the digest.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct ActionParam {
+    pub key: String,
+    pub value: String,
 }
 
 /// The operator-signed approval emitted to stdout. JSON the Hub-side S6d ingestion
@@ -241,6 +288,119 @@ fn decision_str(d: ApprovalDecision) -> &'static str {
     }
 }
 
+fn parse_actor_kind(s: &str) -> Result<ActorKind, CliError> {
+    match s {
+        "owner" => Ok(ActorKind::Owner),
+        "agent" => Ok(ActorKind::Agent),
+        "api" => Ok(ActorKind::Api),
+        "channel" => Ok(ActorKind::Channel),
+        other => Err(CliError::BadRequest(format!(
+            "unknown actor_kind {other:?}: expected owner|agent|api|channel"
+        ))),
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+struct BuiltinToolSpec {
+    mutating: bool,
+    base_risk: Risk,
+    base_reversibility: Reversibility,
+}
+
+fn builtin_tool_spec(
+    action: &str,
+    params: &[(String, String)],
+) -> Result<BuiltinToolSpec, CliError> {
+    let mut spec = match action {
+        "read_file" | "list_dir" | "stat_file" | "search" | "web_search" | "memory_recall"
+        | "memory_store" => BuiltinToolSpec {
+            mutating: false,
+            base_risk: Risk::ReadOnly,
+            base_reversibility: Reversibility::Reversible,
+        },
+        "write_file" | "edit_file" | "append_file" => BuiltinToolSpec {
+            mutating: true,
+            base_risk: Risk::Medium,
+            base_reversibility: Reversibility::ReversibleInWorkspace,
+        },
+        "delete_file" | "move_file" | "run_command" => BuiltinToolSpec {
+            mutating: true,
+            base_risk: Risk::High,
+            base_reversibility: Reversibility::Irreversible,
+        },
+        "web_fetch" => BuiltinToolSpec {
+            mutating: false,
+            base_risk: Risk::ReadOnly,
+            base_reversibility: Reversibility::Reversible,
+        },
+        "image_analysis" => BuiltinToolSpec {
+            mutating: false,
+            base_risk: Risk::ReadOnly,
+            base_reversibility: Reversibility::Reversible,
+        },
+        "subagent" => BuiltinToolSpec {
+            mutating: true,
+            base_risk: Risk::Medium,
+            base_reversibility: Reversibility::Irreversible,
+        },
+        other => {
+            return Err(CliError::BadRequest(format!(
+                "unknown built-in action {other:?}; prepare-batch only supports default Hub tools"
+            )))
+        }
+    };
+    if (action == "web_fetch" && web_fetch_is_egress_mutating(params))
+        || (action == "image_analysis" && image_analysis_has_url_image(params))
+    {
+        spec.mutating = true;
+        spec.base_reversibility = Reversibility::Irreversible;
+    }
+    Ok(spec)
+}
+
+fn param_value<'a>(params: &'a [(String, String)], key: &str) -> Option<&'a str> {
+    params
+        .iter()
+        .find(|(k, _)| k == key)
+        .map(|(_, v)| v.as_str())
+}
+
+fn web_fetch_is_egress_mutating(params: &[(String, String)]) -> bool {
+    let method = param_value(params, "method")
+        .unwrap_or("GET")
+        .to_uppercase();
+    let has_body = param_value(params, "body").is_some_and(|body| !body.is_empty());
+    method != "GET" || has_body
+}
+
+fn image_analysis_has_url_image(params: &[(String, String)]) -> bool {
+    let Some(images_raw) = param_value(params, "images") else {
+        return false;
+    };
+    images_raw
+        .lines()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .any(|spec| spec.starts_with("http://") || spec.starts_with("https://"))
+}
+
+fn canonical_params(pairs: &[(String, String)]) -> String {
+    let mut sorted = pairs.to_vec();
+    sorted.sort();
+    let mut out = String::new();
+    for (key, value) in &sorted {
+        out.push_str(&key.len().to_string());
+        out.push(':');
+        out.push_str(key);
+        out.push('=');
+        out.push_str(&value.len().to_string());
+        out.push(':');
+        out.push_str(value);
+        out.push(';');
+    }
+    out
+}
+
 fn validate_action_digest(s: &str) -> Result<(), CliError> {
     // The Hub's digest is lowercase 64-hex SHA-256 (friday_crypto::action_digest).
     // We must sign the EXACT form the Hub compares against, so require lowercase.
@@ -249,6 +409,14 @@ fn validate_action_digest(s: &str) -> Result<(), CliError> {
         Ok(())
     } else {
         Err(CliError::BadActionDigest)
+    }
+}
+
+fn validate_nonempty_field(value: &str, field: &str) -> Result<(), CliError> {
+    if value.trim().is_empty() {
+        Err(CliError::BadRequest(format!("{field} must not be empty")))
+    } else {
+        Ok(())
     }
 }
 
@@ -311,6 +479,109 @@ pub fn canonical_batch_bytes(
         signature: None,
     };
     canonical_approval_batch_signature_bytes(&batch)
+}
+
+/// Produce a signable D20 W2 pending batch from action specs, without reading an
+/// operator key, signing, executing, or touching live state. Irreversible actions are
+/// fail-closed here so a batch signature can never become a path around the per-action
+/// manual gate for hard-excluded operations.
+pub fn prepare_batch_request(req: &PrepareBatchRequest) -> Result<PendingBatchRequest, CliError> {
+    let decision = parse_decision(&req.decision)?;
+    validate_nonempty_field(&req.batch_sign_id, "batch_sign_id")?;
+    if req.expires_at <= 0 {
+        return Err(CliError::BadRequest(
+            "expires_at must be a positive epoch-ms".to_string(),
+        ));
+    }
+    if req.actions.is_empty() {
+        return Err(CliError::BadRequest(
+            "actions must not be empty".to_string(),
+        ));
+    }
+    let issuer = req
+        .issuer
+        .clone()
+        .unwrap_or_else(|| CANONICAL_GATE_ISSUER.to_string());
+    validate_nonempty_field(&issuer, "issuer")?;
+
+    let mut action_digests = Vec::with_capacity(req.actions.len());
+    for spec in &req.actions {
+        let request = build_prepared_action_request(spec)?;
+        action_digests.push(action_digest(&canonical_action_bytes(&request)));
+    }
+    validate_batch_digests(&action_digests)?;
+
+    Ok(PendingBatchRequest {
+        batch_sign_id: req.batch_sign_id.clone(),
+        action_digests,
+        expires_at: req.expires_at,
+        decision: decision_str(decision).to_string(),
+        issuer: Some(issuer),
+        plan_label: req.plan_label.clone(),
+        worktree: req.worktree.clone(),
+    })
+}
+
+/// Build the same canonical request shape that the Hub will authorize for the supplied
+/// action spec: registry-owned mutating/risk/reversibility, sorted length-prefixed
+/// params, and caller-supplied actor/surface identity.
+pub fn build_prepared_action_request(
+    spec: &BatchActionSpec,
+) -> Result<MutatingActionRequest, CliError> {
+    validate_nonempty_field(&spec.action, "action")?;
+    validate_nonempty_field(&spec.actor_id, "actor_id")?;
+    validate_nonempty_field(&spec.surface, "surface")?;
+    if let Some(principal_id) = &spec.principal_id {
+        validate_nonempty_field(principal_id, "principal_id")?;
+    }
+    if let Some(idempotency_key) = &spec.idempotency_key {
+        validate_nonempty_field(idempotency_key, "idempotency_key")?;
+    }
+    if let Some(plan_digest) = &spec.plan_digest {
+        validate_nonempty_field(plan_digest, "plan_digest")?;
+    }
+
+    let actor_kind = parse_actor_kind(&spec.actor_kind)?;
+    let mut param_pairs = Vec::with_capacity(spec.params.len());
+    for param in &spec.params {
+        validate_nonempty_field(&param.key, "param.key")?;
+        param_pairs.push((param.key.clone(), param.value.clone()));
+    }
+
+    let tool_spec = builtin_tool_spec(&spec.action, &param_pairs)?;
+    let classification = friday_core::gate::classify_with_reversibility(
+        tool_spec.mutating,
+        tool_spec.base_risk,
+        tool_spec.base_reversibility,
+        &spec.action,
+        &param_pairs,
+    );
+    if classification.reversibility() == Reversibility::Irreversible {
+        return Err(CliError::BadRequest(format!(
+            "batch action classified irreversible: {}",
+            spec.action
+        )));
+    }
+
+    let parameters = if spec.params.is_empty() {
+        None
+    } else {
+        Some(canonical_params(&param_pairs))
+    };
+    Ok(MutatingActionRequest::from_classification(
+        classification,
+        spec.action.clone(),
+        Actor {
+            kind: actor_kind,
+            id: spec.actor_id.clone(),
+            principal_id: spec.principal_id.clone(),
+        },
+        spec.surface.clone(),
+        Vec::<LocalClaim>::new(),
+        parameters,
+        spec.idempotency_key.clone(),
+        spec.plan_digest.clone(),
+    ))
 }
 
 /// Write the operator's PRIVATE seed (hex) to `path`, created fresh with `0o600`

--- a/rust-core/crates/friday-operator-cli/src/main.rs
+++ b/rust-core/crates/friday-operator-cli/src/main.rs
@@ -17,6 +17,10 @@
 //! friday-operator-approve sign-batch --key <private-key-path> --request <pending-batch.json>
 //!     Read a D20 W2 pending batch (a batch_sign_id plus exact action digests), load
 //!     the PRIVATE key, and emit an Ed25519-signed CanonicalApprovalBatch as JSON.
+//!
+//! friday-operator-approve prepare-batch --request <batch-actions.json>
+//!     Read operator/tool-registry action specs, classify them through the real gate,
+//!     and emit a signable pending batch JSON. No key is read and no action executes.
 //! ```
 //!
 //! Truth label: offline operator-signing tool (operator-held private key; the Hub
@@ -33,7 +37,8 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use friday_operator_cli::trust_grant;
 use friday_operator_cli::{
-    keygen_to_path, sign_batch_request, sign_request, PendingBatchRequest, PendingRequest,
+    keygen_to_path, prepare_batch_request, sign_batch_request, sign_request, PendingBatchRequest,
+    PendingRequest, PrepareBatchRequest,
 };
 
 const USAGE: &str = "\
@@ -41,6 +46,7 @@ friday-operator-approve — operator CLI (S6c signing + NS-3 trust-grant issuanc
 
 USAGE:
     friday-operator-approve keygen --out <private-key-path>
+    friday-operator-approve prepare-batch --request <batch-actions.json>
     friday-operator-approve sign  --key <private-key-path> --request <pending-request.json>
     friday-operator-approve sign-batch --key <private-key-path> --request <pending-batch.json>
     friday-operator-approve grant  --db <hub.sqlite> --grant-id <id> --agent <agent-id> \\
@@ -62,6 +68,11 @@ sign-batch reads a D20 W2 pending batch JSON and emits an Ed25519-signed
 CanonicalApprovalBatch (JSON) for an exact digest set. The private key never appears in
 the output.
 
+prepare-batch reads operator/tool-registry action specs, runs the real gate
+classification, and emits a signable pending batch JSON. It reads no key, signs
+nothing, executes nothing, and rejects Irreversible actions so batches cannot bypass
+per-action manual gates.
+
 grant mints a TrustGrant for --agent with the given boundaries (operator POLICY action;
 the allowlists are fail-closed — an omitted dimension is DENY-ALL) and prints the
 persisted grant (JSON). revoke marks the grant --grant-id revoked. Both write a
@@ -81,6 +92,7 @@ fn run() -> Result<(), String> {
     let args: Vec<String> = std::env::args().collect();
     match args.get(1).map(String::as_str) {
         Some("keygen") => cmd_keygen(&args[2..]),
+        Some("prepare-batch") => cmd_prepare_batch(&args[2..]),
         Some("sign") => cmd_sign(&args[2..]),
         Some("sign-batch") => cmd_sign_batch(&args[2..]),
         Some("grant") => cmd_grant(&args[2..]),
@@ -108,6 +120,22 @@ fn cmd_keygen(args: &[String]) -> Result<(), String> {
     );
     // Operator note -> stderr (the PATH is not secret; the key bytes never appear).
     eprintln!("operator private key written to {out} (mode 0600); keep it off the Hub. Provision the verifying_key above into the Hub.");
+    Ok(())
+}
+
+fn cmd_prepare_batch(args: &[String]) -> Result<(), String> {
+    let request = arg_value(args, "--request").ok_or_else(|| {
+        format!("prepare-batch requires --request <batch-actions.json>\n\n{USAGE}")
+    })?;
+    let json = std::fs::read_to_string(&request)
+        .map_err(|_| format!("could not read request file {request}"))?;
+    let req: PrepareBatchRequest =
+        serde_json::from_str(&json).map_err(|e| format!("invalid batch request JSON: {e}"))?;
+    let pending = prepare_batch_request(&req).map_err(|e| e.to_string())?;
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&pending).map_err(|e| e.to_string())?
+    );
     Ok(())
 }
 

--- a/rust-core/crates/friday-operator-cli/tests/cli_roundtrip.rs
+++ b/rust-core/crates/friday-operator-cli/tests/cli_roundtrip.rs
@@ -13,11 +13,13 @@
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output};
 
+use friday_core::gate::canonical_action_bytes;
 use friday_core::gate::ApprovalDecision;
 use friday_crypto::verify_ed25519_approval;
+use friday_hub::{build_request, RawToolCall};
 use friday_operator_cli::{
-    canonical_batch_bytes, canonical_bytes, decode_signature_hex, decode_verifying_key_hex,
-    parse_decision,
+    build_prepared_action_request, canonical_batch_bytes, canonical_bytes, decode_signature_hex,
+    decode_verifying_key_hex, parse_decision, ActionParam, BatchActionSpec,
 };
 
 const BIN: &str = env!("CARGO_BIN_EXE_friday-operator-approve");
@@ -55,6 +57,26 @@ fn sample_batch_req() -> serde_json::Value {
         "decision": "approved",
         "plan_label": "D20 reversible batch",
         "worktree": "/tmp/friday-worktree"
+    })
+}
+
+fn sample_prepare_batch_req(action: &str) -> serde_json::Value {
+    serde_json::json!({
+        "batch_sign_id": "batch-d20-prepared",
+        "expires_at": 1_900_000_000_000i64,
+        "decision": "approved",
+        "plan_label": "D20 prepared reversible batch",
+        "worktree": "/tmp/friday-worktree",
+        "actions": [{
+            "action": action,
+            "actor_kind": "agent",
+            "actor_id": "hub-agent",
+            "surface": "agent",
+            "params": [
+                {"key": "path", "value": "/tmp/friday-worktree/out.txt"},
+                {"key": "content", "value": "hello"}
+            ]
+        }]
     })
 }
 
@@ -114,6 +136,186 @@ fn rebuild_canonical_batch_bytes(signed: &serde_json::Value) -> Vec<u8> {
         signed["expires_at"].as_i64().unwrap(),
         signed["issuer"].as_str().unwrap(),
     )
+}
+
+#[test]
+fn prepared_action_digest_matches_hub_default_request() {
+    let params = vec![
+        ("content".to_string(), "hello".to_string()),
+        (
+            "path".to_string(),
+            "/tmp/friday-worktree/out.txt".to_string(),
+        ),
+    ];
+    let spec = BatchActionSpec {
+        action: "write_file".to_string(),
+        actor_kind: "agent".to_string(),
+        actor_id: "hub-agent".to_string(),
+        principal_id: None,
+        surface: "agent".to_string(),
+        params: params
+            .iter()
+            .map(|(key, value)| ActionParam {
+                key: key.clone(),
+                value: value.clone(),
+            })
+            .collect(),
+        idempotency_key: None,
+        plan_digest: None,
+    };
+    let prepared = build_prepared_action_request(&spec).unwrap();
+    let hub = build_request(&RawToolCall {
+        action: "write_file".to_string(),
+        params,
+    })
+    .unwrap();
+
+    assert_eq!(
+        friday_crypto::action_digest(&canonical_action_bytes(&prepared)),
+        friday_crypto::action_digest(&canonical_action_bytes(&hub)),
+        "prepared batch digest must match the live Hub default request digest"
+    );
+}
+
+#[test]
+fn prepare_batch_then_sign_batch_roundtrip_verifies() {
+    let dir = tmp_dir("prepare-batch-roundtrip");
+    let key_path = dir.join("operator.key");
+    let _ = std::fs::remove_file(&key_path);
+
+    let kg = run_bin(&["keygen", "--out", key_path.to_str().unwrap()]);
+    assert!(
+        kg.status.success(),
+        "keygen failed: {}",
+        String::from_utf8_lossy(&kg.stderr)
+    );
+    let kg_json: serde_json::Value = serde_json::from_slice(&kg.stdout).unwrap();
+    let vk_hex = kg_json["verifying_key"].as_str().unwrap().to_string();
+
+    let actions_path = dir.join("batch-actions.json");
+    std::fs::write(
+        &actions_path,
+        serde_json::to_vec(&sample_prepare_batch_req("write_file")).unwrap(),
+    )
+    .unwrap();
+    let prepared = run_bin(&["prepare-batch", "--request", actions_path.to_str().unwrap()]);
+    assert!(
+        prepared.status.success(),
+        "prepare-batch failed: {}",
+        String::from_utf8_lossy(&prepared.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&prepared.stderr).trim().is_empty(),
+        "prepare-batch should not print operator-key guidance or leak-like noise"
+    );
+    let pending: serde_json::Value = serde_json::from_slice(&prepared.stdout).unwrap();
+    assert_eq!(pending["batch_sign_id"], "batch-d20-prepared");
+    assert_eq!(pending["decision"], "approved");
+    assert_eq!(pending["issuer"], "friday_canonical_gate");
+    assert!(
+        pending.get("signature").is_none(),
+        "prepare-batch must not sign"
+    );
+
+    let digests = pending["action_digests"].as_array().unwrap();
+    assert_eq!(digests.len(), 1);
+    let digest = digests[0].as_str().unwrap();
+    assert_eq!(digest.len(), 64);
+    assert!(digest
+        .bytes()
+        .all(|c| matches!(c, b'0'..=b'9' | b'a'..=b'f')));
+
+    let pending_path = dir.join("pending-batch.json");
+    std::fs::write(&pending_path, serde_json::to_vec(&pending).unwrap()).unwrap();
+    let signed = run_bin(&[
+        "sign-batch",
+        "--key",
+        key_path.to_str().unwrap(),
+        "--request",
+        pending_path.to_str().unwrap(),
+    ]);
+    assert!(
+        signed.status.success(),
+        "sign-batch failed: {}",
+        String::from_utf8_lossy(&signed.stderr)
+    );
+    let signed_json: serde_json::Value = serde_json::from_slice(&signed.stdout).unwrap();
+    let bytes = rebuild_canonical_batch_bytes(&signed_json);
+    let vk = decode_verifying_key_hex(&vk_hex).unwrap();
+    let sig = decode_signature_hex(signed_json["signature"].as_str().unwrap()).unwrap();
+    assert!(
+        verify_ed25519_approval(&bytes, &vk, &sig),
+        "prepared pending batch must sign and verify under the operator test key"
+    );
+}
+
+#[test]
+fn prepare_batch_rejects_logical_duplicate_after_param_sorting() {
+    let dir = tmp_dir("prepare-batch-duplicate");
+    let actions_path = dir.join("batch-actions.json");
+    let req = serde_json::json!({
+        "batch_sign_id": "batch-d20-dupe",
+        "expires_at": 1_900_000_000_000i64,
+        "decision": "approved",
+        "actions": [
+            {
+                "action": "write_file",
+                "actor_kind": "agent",
+                "actor_id": "hub-agent",
+                "surface": "agent",
+                "params": [
+                    {"key": "path", "value": "/tmp/friday-worktree/out.txt"},
+                    {"key": "content", "value": "hello"}
+                ]
+            },
+            {
+                "action": "write_file",
+                "actor_kind": "agent",
+                "actor_id": "hub-agent",
+                "surface": "agent",
+                "params": [
+                    {"key": "content", "value": "hello"},
+                    {"key": "path", "value": "/tmp/friday-worktree/out.txt"}
+                ]
+            }
+        ]
+    });
+    std::fs::write(&actions_path, serde_json::to_vec(&req).unwrap()).unwrap();
+
+    let prepared = run_bin(&["prepare-batch", "--request", actions_path.to_str().unwrap()]);
+    assert!(
+        !prepared.status.success(),
+        "same logical params in different order must collapse to a duplicate digest"
+    );
+    assert!(
+        String::from_utf8_lossy(&prepared.stderr).contains("duplicates"),
+        "expected duplicate digest error"
+    );
+}
+
+#[test]
+fn prepare_batch_rejects_irreversible_actions() {
+    let dir = tmp_dir("prepare-batch-irreversible");
+    let actions_path = dir.join("batch-actions.json");
+    std::fs::write(
+        &actions_path,
+        serde_json::to_vec(&sample_prepare_batch_req("run_command")).unwrap(),
+    )
+    .unwrap();
+
+    let prepared = run_bin(&["prepare-batch", "--request", actions_path.to_str().unwrap()]);
+    assert!(
+        !prepared.status.success(),
+        "run_command must never enter a batch approval"
+    );
+    assert!(
+        String::from_utf8_lossy(&prepared.stdout).trim().is_empty(),
+        "no pending batch may be emitted on irreversible input"
+    );
+    assert!(
+        String::from_utf8_lossy(&prepared.stderr).contains("irreversible"),
+        "expected a clean irreversible-action error"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add an offline `prepare-batch` operator CLI path that turns action specs into signable D20 pending-batch JSON
- compute exact action digests through the real Rust gate classification and canonical action bytes
- fail closed for empty batches, malformed fields, duplicate digests, and Irreversible actions such as `run_command`

## Truth label
D20 DARK/offline mechanism only. No operator private key is read by `prepare-batch`; it signs nothing, executes nothing, flips no live flags, and does not prove TRUE operator-in-the-loop. Friday still has no generic action rollback engine; reversible remains a git/worktree-contained space, not undo.

## Tests
- `cargo test -p friday-operator-cli prepare_batch -- --nocapture`
- `cargo test -p friday-operator-cli -- --nocapture`
- `cargo clippy -p friday-operator-cli --all-targets -- -D warnings`
- `git diff --check`