### PR TITLE
B2: gate packaging dependency dry-run

### DIFF
--- a/src/api/http/routes/friday-packaging-routes.ts
+++ b/src/api/http/routes/friday-packaging-routes.ts
@@ -309,6 +309,14 @@ export function createFridayPackagingRoutes(
         const { packageName } = ctx.params as { packageName: string };
         const body = ctx.body as FridayCheckDependenciesRequest;
         requireString(body, "tenantId");
+        await assertPackagingMutationAllowed({
+          deps: services,
+          gateAction: "packaging.packages.dependencies.check",
+          ctx,
+          resourceType: "package_dependency_resolution",
+          resourceId: packageName,
+          risk: "medium",
+        });
         return services.packages.checkDependencies(packageName, body);
       },
     },

--- a/test/unit/api/http/routes/friday-packaging-routes.test.ts
+++ b/test/unit/api/http/routes/friday-packaging-routes.test.ts
@@ -181,6 +181,53 @@ describe("B-008 FridayPackagingRoutes", () => {
       }));
       expect(deps.installs.uninstall).toHaveBeenCalledWith("@friday/test", { etag: "etag-1", idempotencyKey: "key-1" });
     });
+
+    it("fails closed before dependency dry-run when packaging deps have no governance gate", async () => {
+      const deps = makeDeps({ allowTestOnlyPackagingMutationExecution: false });
+      const routes = createFridayPackagingRoutes(deps);
+      const route = findRoute(routes, "packaging.packages.dependencies.check");
+
+      await expect(route.handler(makeCtx({
+        params: { packageName: "@friday/test" },
+        body: { tenantId: "tenant-1" },
+      }))).rejects.toMatchObject({
+        code: "PACKAGING_MUTATION_GOVERNANCE_REQUIRED",
+        httpStatus: 503,
+        details: {
+          classification: "fail_closed",
+          operationId: "packaging.packages.dependencies.check",
+        },
+      });
+      expect(deps.packages.checkDependencies).not.toHaveBeenCalled();
+    });
+
+    it("runs canonical governance before dependency dry-run resolution", async () => {
+      const gate = makeAllowGate();
+      const deps = makeDeps({
+        allowTestOnlyPackagingMutationExecution: false,
+        packagingMutationGate: gate,
+      });
+      const routes = createFridayPackagingRoutes(deps);
+      const route = findRoute(routes, "packaging.packages.dependencies.check");
+
+      await route.handler(makeCtx({
+        principal: { principalId: "operator-1", kind: "operator" },
+        params: { packageName: "@friday/test" },
+        body: { tenantId: "tenant-1" },
+      }));
+
+      expect(gate.evaluate).toHaveBeenCalledWith(expect.objectContaining({
+        action: "packaging.packages.dependencies.check",
+        surface: "packaging",
+        mutating: true,
+        risk: "medium",
+        resource: expect.objectContaining({
+          type: "package_dependency_resolution",
+          id: "@friday/test",
+        }),
+      }));
+      expect(deps.packages.checkDependencies).toHaveBeenCalledWith("@friday/test", { tenantId: "tenant-1" });
+    });
   });
 
   describe("package routes", () => {


### PR DESCRIPTION
## Summary
- routes `packaging.packages.dependencies.check` through the existing canonical packaging governance gate
- fails closed before dependency resolution when packaging deps are enabled without a governance gate
- adds production-posture route tests for the dry-run dependency check path

## Validation
- `npm test -- --run test/unit/api/http/routes/friday-packaging-routes.test.ts`
- `npm run build`
- `git diff --check`

Truth labels: B2 governance hardening only; packaging remains default-off unless `FRIDAY_PACKAGING_ENABLED=true`; no live packaging flip, no operator signature, no organic closed loop, no generic rollback engine.