### PR TITLE
[codex] Prove mission-spine route loopback

### DIFF
--- a/docs/ops/prod-flags-manifest.json
+++ b/docs/ops/prod-flags-manifest.json
@@ -102,7 +102,7 @@
       "closes_loop": "The TS mission-spine routes (intake/lifecycle/workitem) forward to the Rust hub; the loop closes Rust-side.",
       "coverage": "destination-only",
       "e2e_test": "rust-core/crates/friday-hub/src/hub_server.rs::mission_lifecycle_request_updates_mission_without_provider_call",
-      "notes": "CRITICAL FINDING: destination loop (mission lifecycle dispatch) is proven Rust-side by the mapped test, but NO PR-CI test drives flag-ON TS-routing -> real Rust -> loop-closed. friday-mission-spine-dispatch-adapter.test.ts mocks the sealed client. The flag's own on-ramp is mock-only in PR CI."
+      "notes": "CRITICAL FINDING: destination loop (mission lifecycle dispatch) is proven Rust-side by the mapped test. Manual ignored interop proofs now cover (1) the real TS `/v1/mission-spine/intake` route handler -> real dispatch adapter -> real sealed client -> real auto-dispatch driver -> real Rust mission-bound run, and (2) the real TS lifecycle/workitem route handlers -> real dispatch adapter -> real sealed client -> real Rust mission-spine dispatch arm, mutating DB state with zero token/provider spend. Honest remaining gap: these are controlled loopback proofs requiring the prebuilt Node interop bundle, not organic/operator traffic and not a non-ignored PR-CI flag-on e2e."
     },
     {
       "flag": "FRIDAY_ROUTE_AGENT_RUN_VIA_RUST",

--- a/rust-core/crates/friday-hub/src/bin/hub_agent_run_server.rs
+++ b/rust-core/crates/friday-hub/src/bin/hub_agent_run_server.rs
@@ -6197,6 +6197,37 @@ mod tests {
             .expect("spawn node TS memory-route decision subprocess")
     }
 
+    /// Spawn the TS sealed-client runner in mission-route lifecycle/workitem mode: the subprocess
+    /// calls the REAL mission-spine POST handlers, which delegate to the REAL dispatch adapter +
+    /// REAL sealed client. The Rust side serves two loopback sealed sessions with the mission-spine
+    /// dispatch arm enabled.
+    fn spawn_ts_mission_route_lifecycle_workitem_client(
+        port: u16,
+        secret_hex: &str,
+        principal: &str,
+        mission_id: &str,
+        work_item_id: &str,
+    ) -> std::process::Child {
+        let bundle = worktree_root().join("test/interop/.build/sealed-client-runner.cjs");
+        assert!(
+            bundle.exists(),
+            "interop bundle missing at {bundle:?} — run `node test/interop/build-sealed-client-runner.mjs` first"
+        );
+        std::process::Command::new("node")
+            .arg(bundle)
+            .arg("--mode=mission-route-lifecycle-workitem")
+            .arg(format!("--port={port}"))
+            .arg(format!("--secret-hex={secret_hex}"))
+            .arg(format!("--principal={principal}"))
+            .arg(format!("--mission-id={mission_id}"))
+            .arg(format!("--work-item-id={work_item_id}"))
+            .arg("--timeout-ms=15000")
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .spawn()
+            .expect("spawn node TS mission-route lifecycle/workitem subprocess")
+    }
+
     /// Read the ONE JSON line the runner prints on stdout.
     fn read_client_json(child: std::process::Child) -> serde_json::Value {
         let out = child
@@ -6562,7 +6593,121 @@ mod tests {
         assert_eq!(route.selected_lane, friday_core::WorkLane::DeepSeek);
     }
 
-    // (1d) OPERATOR-SURFACE-SHAPED MEMORY CONFIRM ROUND-TRIP: real TS memory-spine POST route
+    // (1d) OPERATOR-SURFACE-SHAPED MISSION-SPINE ROUTE ROUND-TRIP: real TS mission-spine POST
+    // route handlers -> real dispatch adapter -> real sealed WorkItemStatusRequest +
+    // MissionLifecycleRequest -> real Rust mission-spine dispatch arm -> DB transitions. This is
+    // still manual/ignored (Node bundle + subprocess), not organic dogfood traffic.
+    #[test]
+    #[ignore = "needs `node` + the prebuilt interop bundle; opt in with --ignored"]
+    fn interop_ts_mission_route_lifecycle_and_workitem_hit_real_rust_spine() {
+        const MISSION_ID: &str = "mission-ns5";
+        const WORK_ITEM_ID: &str = "work-ns5";
+
+        let (rt, _ws) = mock_runtime("interop-mission-route-spine", OWNER);
+        seed_mission_and_work_item(&rt);
+        let server_kp = DeviceKeypair::generate();
+        let listener = AgentRunWsListener::bind_loopback(0).unwrap();
+        let addr = listener.local_addr().unwrap();
+        let owner_allowlist = vec![OWNER.to_string()];
+        let peer_allowlist = allowlist_of(ts_client_pubkey());
+
+        let mut child = spawn_ts_mission_route_lifecycle_workitem_client(
+            addr.port(),
+            &ts_client_secret_hex(),
+            OWNER,
+            MISSION_ID,
+            WORK_ITEM_ID,
+        );
+
+        let work_item_processed = listener
+            .accept_one(
+                &server_kp,
+                &rt,
+                &owner_allowlist,
+                &peer_allowlist,
+                false, // run-control OFF
+                false, // mission-bound seam OFF
+                false, // mission-intake ingress OFF
+                true,  // mission-spine dispatch ON
+                false, // memory-confirm ingress OFF
+                false, // token surface OFF
+                false, // provider-workspace dispatch OFF
+            )
+            .expect("server serves the TS mission-route workitem session");
+        assert_eq!(
+            work_item_processed, 1,
+            "one route-triggered workitem request processed"
+        );
+        std::thread::sleep(std::time::Duration::from_millis(250));
+        if let Some(status) = child
+            .try_wait()
+            .expect("poll TS mission-route lifecycle/workitem subprocess")
+        {
+            let v = read_client_json(child);
+            panic!(
+                "TS mission-route subprocess exited before lifecycle session: status={status:?} json={v:?}"
+            );
+        }
+
+        let lifecycle_processed = listener
+            .accept_one(
+                &server_kp,
+                &rt,
+                &owner_allowlist,
+                &peer_allowlist,
+                false, // run-control OFF
+                false, // mission-bound seam OFF
+                false, // mission-intake ingress OFF
+                true,  // mission-spine dispatch ON
+                false, // memory-confirm ingress OFF
+                false, // token surface OFF
+                false, // provider-workspace dispatch OFF
+            )
+            .expect("server serves the TS mission-route lifecycle session");
+        assert_eq!(
+            lifecycle_processed, 1,
+            "one route-triggered lifecycle request processed"
+        );
+
+        let v = read_client_json(child);
+        assert_eq!(
+            v["ok"],
+            serde_json::json!(true),
+            "TS mission-route lifecycle/workitem runner reports success: {v:?}"
+        );
+        assert_eq!(
+            v["mode"],
+            serde_json::json!("mission-route-lifecycle-workitem")
+        );
+        assert_eq!(v["workItem"]["workItemId"], serde_json::json!(WORK_ITEM_ID));
+        assert_eq!(v["workItem"]["status"], serde_json::json!("dispatched"));
+        assert_eq!(v["lifecycle"]["missionId"], serde_json::json!(MISSION_ID));
+        assert_eq!(v["lifecycle"]["status"], serde_json::json!("paused"));
+
+        let work = rt
+            .db()
+            .get_work_item(WORK_ITEM_ID)
+            .unwrap()
+            .expect("route-triggered work item still exists");
+        assert_eq!(work.status, friday_core::WorkItemStatus::Dispatched);
+        let mission = rt
+            .db()
+            .get_mission(MISSION_ID)
+            .unwrap()
+            .expect("route-triggered mission still exists");
+        assert_eq!(mission.status, friday_core::MissionStatus::Paused);
+        let ledger_rows: i64 = rt
+            .db()
+            .conn()
+            .query_row("SELECT COUNT(*) FROM token_ledger", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(
+            ledger_rows, 0,
+            "route-triggered mission-spine lifecycle/status transitions do not spend tokens"
+        );
+    }
+
+    // (1e) OPERATOR-SURFACE-SHAPED MEMORY CONFIRM ROUND-TRIP: real TS memory-spine POST route
     // handler -> real dispatch adapter -> real sealed MemoryDecisionRequest -> real Rust
     // memory-confirm arm -> real DB candidate transition to Confirmed/recallable. This is still
     // manual/ignored (Node bundle + subprocess), not organic operator traffic, but closes the

--- a/test/interop/friday-rust-hub-agent-run-sealed-client-runner.ts
+++ b/test/interop/friday-rust-hub-agent-run-sealed-client-runner.ts
@@ -338,6 +338,78 @@ async function main(): Promise<void> {
       return;
     }
 
+    if (mode === "mission-route-lifecycle-workitem") {
+      const clientSecret = new Uint8Array(Buffer.from(secretHex, "hex"));
+      const missionId = arg("mission-id") ?? "mission-ns5";
+      const workItemId = arg("work-item-id") ?? "work-ns5";
+      const dispatch = createFridayMissionSpineDispatchAdapter({
+        host: "127.0.0.1",
+        port,
+        timeoutMs,
+        secretResolver: () => clientSecret,
+      });
+      const routes = createFridayMissionSpineRoutes({
+        workbench: null,
+        disabledReason: null,
+        dispatch,
+      });
+      const lifecycleRoute = routes.find(
+        (candidate) => candidate.operationId === "mission.spine.lifecycle.transition",
+      );
+      const workItemRoute = routes.find(
+        (candidate) => candidate.operationId === "mission.spine.workitem.status.transition",
+      );
+      if (!lifecycleRoute || !workItemRoute) {
+        process.stdout.write(JSON.stringify({ ok: false, code: "MISSION_ROUTE_MISSING", httpStatus: 0 }) + "\n");
+        process.exit(6);
+        return;
+      }
+      const principalContext = {
+        principalType: "user",
+        principalId: principal,
+        userId: principal,
+        role: "admin",
+        scopes: ["hub.admin"],
+      };
+      const workItemResponse = await workItemRoute.handler({
+        requestId: "req-interop-mission-route-workitem",
+        receivedAt: new Date(0).toISOString(),
+        params: { workItemId },
+        query: {},
+        body: {
+          targetStatus: "dispatched",
+          actorRef: principal,
+          reason: "interop route work-item transition",
+        },
+        headers: {},
+        principal: principalContext,
+      } as never);
+      const lifecycleResponse = await lifecycleRoute.handler({
+        requestId: "req-interop-mission-route-lifecycle",
+        receivedAt: new Date(0).toISOString(),
+        params: { missionId },
+        query: {},
+        body: {
+          fridayConversationId: arg("friday-conversation-id") ?? "fconv_ns5_intake",
+          targetStatus: "paused",
+          actorRef: principal,
+          reason: "interop route lifecycle transition",
+        },
+        headers: {},
+        principal: principalContext,
+      } as never);
+      process.stdout.write(
+        JSON.stringify({
+          ok: true,
+          mode,
+          lifecycle: (lifecycleResponse as { result?: unknown }).result ?? null,
+          workItem: (workItemResponse as { result?: unknown }).result ?? null,
+        }) + "\n",
+      );
+      process.exit(0);
+      return;
+    }
+
     const result = await client.dispatchRun({ runId, task, forwardedPrincipal: principal });
     // (A3 courier) dispatch returns a discriminated union (result | paused). This runner drives the
     // read-only path with the run-control flag OFF, so a paused outcome is unreachable here — narrow


### PR DESCRIPTION
## Summary

- Add a TS interop runner mode that drives the real mission-spine lifecycle and workitem POST route handlers through the real dispatch adapter and sealed Rust client.
- Add an ignored Rust interop KAT that seeds a real Mission/WorkItem, serves the real Rust mission-spine dispatch arm for both route-triggered requests, and asserts DB state plus zero token/provider spend.
- Update the prod flags manifest truth label for `FRIDAY_MISSION_SPINE_ROUTES_VIA_RUST`.

## Truth Boundary

This is controlled loopback proof requiring the prebuilt Node interop bundle. It is not organic/operator traffic and not a non-ignored PR-CI flag-on e2e. It does not change prod behavior or flip any flag.

## Validation

- `node test/interop/build-sealed-client-runner.mjs`
- `cargo fmt --all --check`
- `cargo test -p friday-hub --bin hub_agent_run_server interop_ts_mission_route_lifecycle_and_workitem_hit_real_rust_spine -- --ignored --nocapture`
- `npm run typecheck`
- `cargo clippy -p friday-hub --bin hub_agent_run_server --tests -- -D warnings`
- `git diff --check`