### PR TITLE
[codex] prove agent start route loopback

### DIFF
--- a/docs/ops/prod-flags-manifest.json
+++ b/docs/ops/prod-flags-manifest.json
@@ -111,7 +111,7 @@
       "closes_loop": "The TS agent-run start forwards the run to the Rust hub agent-run seam; the Rust run loop delivers the answer.",
       "coverage": "destination-only",
       "e2e_test": "rust-core/crates/friday-hub/src/runtime.rs::memory_loop_end_to_end_extract_confirm_recall_closes_on_agent_run_ingress",
-      "notes": "CRITICAL FINDING: the destination agent-run loop (run_session_task -> Delivered answer with status 'finished') is proven Rust-side by the mapped test, but NO PR-CI test drives flag-ON TS-routing -> real Rust -> delivered answer. The routed parity harnesses (routed_claude_parity.rs / routed_codex_parity.rs) ARE end-to-end but are #[ignore]'d + live-key-gated, so they never run in PR CI. The flag's own on-ramp is mock-only/live-gated in PR CI."
+      "notes": "CRITICAL FINDING: the destination agent-run loop (run_session_task -> Delivered answer with status 'finished') is proven Rust-side by the mapped test. Manual ignored interop proof `interop_ts_agent_start_route_drives_real_rust_run_and_readback` now drives the real TS `agent.runs.start` HTTP route through the real routeStartRun compose path -> real sealed-client service -> real Rust AgentRunRequest -> real owner-gated Rust answer readback, returning the delivered answer through the route with zero live provider/API-key spend. The routed parity harnesses (routed_claude_parity.rs / routed_codex_parity.rs) ARE end-to-end but are #[ignore]'d + live-key-gated, so they never run in PR CI. Honest remaining gap: this is controlled loopback proof requiring the prebuilt Node interop bundle, not organic/operator traffic and not a non-ignored PR-CI flag-on e2e."
     },
     {
       "flag": "FRIDAY_MISSION_AUTO_DISPATCH",

--- a/rust-core/crates/friday-hub/src/bin/hub_agent_run_server.rs
+++ b/rust-core/crates/friday-hub/src/bin/hub_agent_run_server.rs
@@ -6108,6 +6108,39 @@ mod tests {
             .expect("spawn node TS client subprocess")
     }
 
+    /// Spawn the TS sealed-client runner in agent-route start-run mode: the subprocess creates the
+    /// real TS API runtime, calls the real `agent.runs.start` route, and lets the routeStartRun
+    /// compose path drive the real sealed-client service plus owner-gated Rust answer readback.
+    fn spawn_ts_agent_route_start_run_client(
+        port: u16,
+        secret_hex: &str,
+        principal: &str,
+        run_id: &str,
+        hub_db_path: &str,
+    ) -> std::process::Child {
+        let root = worktree_root();
+        let bundle = root.join("test/interop/.build/sealed-client-runner.cjs");
+        assert!(
+            bundle.exists(),
+            "interop bundle missing at {bundle:?} — run `node test/interop/build-sealed-client-runner.mjs` first"
+        );
+        std::process::Command::new("node")
+            .arg(bundle)
+            .arg("--mode=agent-route-start-run")
+            .arg(format!("--port={port}"))
+            .arg(format!("--secret-hex={secret_hex}"))
+            .arg(format!("--principal={principal}"))
+            .arg(format!("--run-id={run_id}"))
+            .arg("--task=ping")
+            .arg(format!("--hub-db-path={hub_db_path}"))
+            .arg(format!("--repo-root={}", root.to_string_lossy()))
+            .arg("--timeout-ms=15000")
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .spawn()
+            .expect("spawn node TS agent-route start-run subprocess")
+    }
+
     /// Spawn the TS sealed-client runner in auto-dispatch mode: the subprocess first calls the real
     /// `intakeMission`, then invokes the real `createFridayMissionAutoDispatchDriver`, whose
     /// `startRun` thunk calls the real sealed client's `dispatchRun` with the emitted
@@ -6327,6 +6360,70 @@ mod tests {
             serde_json::json!(ANSWER.len()),
             "TS surfaced the refs len"
         );
+    }
+
+    // (1a) HTTP START-RUN ROUTE ON-RAMP: real TS API runtime -> real `agent.runs.start` route ->
+    // routeStartRun compose -> real sealed-client service -> real Rust AgentRunRequest -> real
+    // owner-gated Rust answer readback. This is still manual/ignored loopback proof, not organic
+    // operator traffic and not a non-ignored PR-CI e2e.
+    #[test]
+    #[ignore = "needs `node` + the prebuilt interop bundle; opt in with --ignored"]
+    fn interop_ts_agent_start_route_drives_real_rust_run_and_readback() {
+        const ANSWER: &str = "PONG";
+        const RUN_ID: &str = "run-interop-agent-route";
+
+        let (rt, _ws) = pong_runtime("interop-agent-route-start", OWNER, ANSWER);
+        let server_kp = DeviceKeypair::generate();
+        let listener = AgentRunWsListener::bind_loopback(0).unwrap();
+        let addr = listener.local_addr().unwrap();
+        let owner_allowlist = vec![OWNER.to_string()];
+        let peer_allowlist = allowlist_of(ts_client_pubkey());
+
+        let child = spawn_ts_agent_route_start_run_client(
+            addr.port(),
+            &ts_client_secret_hex(),
+            OWNER,
+            RUN_ID,
+            rt.db().path(),
+        );
+
+        let processed = listener
+            .accept_one(
+                &server_kp,
+                &rt,
+                &owner_allowlist,
+                &peer_allowlist,
+                true,  // run-control ON so the route's read-only constraints are enforced
+                false, // mission-bound seam OFF
+                false, // mission-intake ingress OFF
+                false, // mission-spine dispatch OFF
+                false, // memory-confirm ingress OFF
+                false, // token surface OFF
+                false, // provider-workspace dispatch OFF
+            )
+            .expect("server serves the TS agent start-route session");
+        assert_eq!(processed, 1, "one route-triggered agent run processed");
+
+        let v = read_client_json(child);
+        assert_eq!(
+            v["ok"],
+            serde_json::json!(true),
+            "TS agent start-route runner reports success: {v:?}"
+        );
+        assert_eq!(v["mode"], serde_json::json!("agent-route-start-run"));
+        assert_eq!(v["runId"], serde_json::json!(RUN_ID));
+        assert_eq!(v["status"], serde_json::json!("completed"));
+        assert_eq!(v["responseLen"], serde_json::json!(ANSWER.len()));
+        assert_eq!(v["finalResponseLen"], serde_json::json!(ANSWER.len()));
+
+        match friday_storage::get_run_answer_for_principal(rt.db().conn(), RUN_ID, OWNER)
+            .expect("owner-gated readback query succeeds")
+        {
+            friday_storage::RunAnswerAccess::Granted(stored) => {
+                assert_eq!(stored.answer, ANSWER, "Rust DB stores the delivered answer");
+            }
+            other => panic!("owner must read the route-triggered Rust answer, got {other:?}"),
+        }
     }
 
     // (1b) AUTO-DISPATCH FULL ROUND-TRIP: real TS sealed client -> real MissionIntakeRequest ->

--- a/test/interop/build-sealed-client-runner.mjs
+++ b/test/interop/build-sealed-client-runner.mjs
@@ -1,7 +1,7 @@
 /**
  * B1 interop runner BUILD STEP. Bundles the REAL sealed client + the runner into a single
- * `.mjs` that `node` can run without the repo's `#errors` import map. The Rust interop test
- * (and a human re-running it) invokes this first, then spawns `node <out>`.
+ * `.cjs` that `node` can run without a repo build step. The Rust interop test (and a human
+ * re-running it) invokes this first, then spawns `node <out>`.
  *
  * A tiny resolve plugin rewrites relative `.js` specifiers (the TS Node16 ESM convention) to
  * their `.ts` source so esbuild bundles from source — no prior `tsc` build required.
@@ -28,10 +28,37 @@ const tsFromJsPlugin = {
   },
 };
 
-// The repo maps `#errors` to a BUILT `dist/` path; for this source bundle alias it to source
-// so no prior `tsc` build is needed. Only `#errors` is reachable from the sealed client.
+// The repo maps package imports to BUILT `dist/` paths; this interop bundle resolves them to source
+// so no prior `tsc` build is needed.
 const repoRoot = resolvePath(here, "..", "..");
 const errorsSource = resolvePath(repoRoot, "src/errors/index.ts");
+const versionShim = resolvePath(here, "friday-version-shim.ts");
+const versionSource = resolvePath(repoRoot, "src/lib/version.js");
+const packageImportPlugin = {
+  name: "friday-package-imports",
+  setup(b) {
+    b.onResolve({ filter: /^#([^/]+)$/ }, (args) => {
+      return { path: resolvePath(repoRoot, "src", args.path.slice(1), "index.ts") };
+    });
+    b.onResolve({ filter: /^#([^/]+)\/(.+)$/ }, (args) => {
+      const [, pkg, rest] = args.path.match(/^#([^/]+)\/(.+)$/) ?? [];
+      if (!pkg || !rest) return undefined;
+      return { path: resolvePath(repoRoot, "src", pkg, rest, "index.ts") };
+    });
+  },
+};
+const interopShimPlugin = {
+  name: "friday-interop-shims",
+  setup(b) {
+    b.onResolve({ filter: /version\.js$/ }, (args) => {
+      const resolved = resolvePath(args.resolveDir, args.path);
+      if (resolved === versionSource) {
+        return { path: versionShim };
+      }
+      return undefined;
+    });
+  },
+};
 
 await build({
   entryPoints: [entry],
@@ -43,8 +70,16 @@ await build({
   format: "cjs",
   target: "node22",
   alias: { "#errors": errorsSource },
-  // node:* + the two real deps (ws, @noble/ciphers) bundle in; nothing is left external.
-  plugins: [tsFromJsPlugin],
+  // Native DB and browser-control deps are left to the repo's node_modules; they are not part of
+  // the Rust sealed-client protocol this bundle is proving.
+  plugins: [interopShimPlugin, packageImportPlugin, tsFromJsPlugin],
+  external: [
+    "better-sqlite3",
+    "chromium-bidi/*",
+    "playwright",
+    "playwright-core",
+    "playwright-core/*",
+  ],
   logLevel: "info",
 });
 

--- a/test/interop/friday-rust-hub-agent-run-sealed-client-runner.ts
+++ b/test/interop/friday-rust-hub-agent-run-sealed-client-runner.ts
@@ -20,8 +20,11 @@ import { createFridayRustHubAgentRunSealedClient } from "../../src/api/mission-s
 import { createFridayMissionSpineDispatchAdapter } from "../../src/api/mission-spine/friday-mission-spine-dispatch-adapter.js";
 import { createFridayMemorySpineDispatchAdapter } from "../../src/api/mission-spine/friday-memory-spine-dispatch-adapter.js";
 import { createFridayMissionAutoDispatchDriver } from "../../src/api/mission-spine/friday-mission-auto-dispatch-driver.js";
+import { createFridayRustHubAgentRunSealedClientService } from "../../src/api/mission-spine/friday-rust-hub-agent-run-sealed-client-service.js";
+import { createFridayRustHubRunAnswerReadbackService } from "../../src/api/mission-spine/friday-rust-hub-run-answer-readback-service.js";
 import { createFridayMissionSpineRoutes } from "../../src/api/http/routes/friday-mission-spine-routes.js";
 import { createFridayMemorySpineRoutes } from "../../src/api/http/routes/friday-memory-spine-routes.js";
+import { createFridayApiRuntime } from "../../src/api/runtime/friday-api-runtime.js";
 import {
   RUST_ROUTE_CLAUDE_MODEL,
   RUST_ROUTE_CLAUDE_PROVIDER_ID,
@@ -29,13 +32,63 @@ import {
   RUST_ROUTE_CODEX_PROVIDER_ID,
   RUST_ROUTE_DEEPSEEK_FLASH_MODEL,
   RUST_ROUTE_DEEPSEEK_PROVIDER_ID,
+  RUST_ROUTE_READ_TOOL_ALLOWLIST,
 } from "../../src/api/runtime/friday-rust-route-constants.js";
+import { createFridayAgentEventEmitter } from "../../src/agent/runtime/friday-agent-event-emitter.js";
+import { createTestDb } from "../helpers/friday-test-db.helper.js";
 import type { MissionAutoDispatchStartRun } from "../../src/api/mission-spine/friday-mission-auto-dispatch-driver.js";
 
 function arg(name: string): string | undefined {
   const prefix = `--${name}=`;
   const hit = process.argv.find((a) => a.startsWith(prefix));
   return hit ? hit.slice(prefix.length) : undefined;
+}
+
+function makeProviderService() {
+  const now = new Date(0).toISOString();
+  const provider = {
+    id: RUST_ROUTE_DEEPSEEK_PROVIDER_ID,
+    kind: "deepseek" as const,
+    name: "DeepSeek",
+    baseUrl: "https://api.deepseek.com",
+    enabled: true,
+    config: {
+      api: "openai-completions" as const,
+      authMode: "api-key" as const,
+      keySource: { kind: "env-ref" as const, envVar: "DEEPSEEK_API_KEY" },
+      supportedModels: [RUST_ROUTE_DEEPSEEK_FLASH_MODEL],
+      validation: { status: "ok" as const, checkedAt: now },
+    },
+    createdAt: now,
+    updatedAt: now,
+  };
+  return {
+    listProviders: async () => [provider],
+    getProvider: async (providerId: string) => (providerId === provider.id ? provider : null),
+    createProvider: async () => ({}),
+    updateProvider: async () => ({}),
+    deleteProvider: async () => undefined,
+    validateProvider: async () => ({ status: "ok" as const, checkedAt: now }),
+    getRoutingConfig: async () => ({ defaultProviderId: provider.id, fallbackProviderIds: [] }),
+    setRoutingConfig: async (input: unknown) => input,
+    resolveRoute: async () => ({
+      provider,
+      model: RUST_ROUTE_DEEPSEEK_FLASH_MODEL,
+    }),
+    runWithFallback: async () => ({}),
+  };
+}
+
+function makePrincipal(principal: string) {
+  return {
+    principalType: "user",
+    principalId: principal,
+    userId: principal,
+    tokenId: `${principal}-token`,
+    tokenKind: "access",
+    scopes: ["agent.write"],
+    issuedAt: new Date(0).toISOString(),
+  };
 }
 
 async function main(): Promise<void> {
@@ -408,6 +461,97 @@ async function main(): Promise<void> {
       );
       process.exit(0);
       return;
+    }
+
+    if (mode === "agent-route-start-run") {
+      const hubDbPath = arg("hub-db-path") ?? "";
+      const repoRoot = arg("repo-root") ?? process.cwd();
+      if (hubDbPath.length === 0) {
+        process.stdout.write(JSON.stringify({ ok: false, code: "MISSING_HUB_DB_PATH", httpStatus: 0 }) + "\n");
+        process.exit(2);
+        return;
+      }
+      const clientSecret = new Uint8Array(Buffer.from(secretHex, "hex"));
+      const tsDb = createTestDb();
+      try {
+        process.env.FRIDAY_REPO_ROOT = repoRoot;
+        process.env.FRIDAY_MISSION_SPINE_RUST_CORE_ROOT = `${repoRoot}/rust-core`;
+        const runtime = createFridayApiRuntime({
+          db: tsDb,
+          idGenerator: () => runId,
+          nowIso: () => new Date(0).toISOString(),
+          providerService: makeProviderService() as never,
+          agentRuntime: {
+            executeRun: async () => {
+              throw new Error("legacy executeRun must not be reached on agent-route-start-run");
+            },
+            registerTool: () => undefined,
+            resumeStaleRunsOnBoot: () => 0,
+          } as never,
+          agentEventEmitter: createFridayAgentEventEmitter(),
+          tokenSecret: "interop-route-agent-run-token-secret-000000", // pragma: allowlist secret
+          computeChecksum: (content: string) => `checksum-${content.length}`,
+          resolveSkill: () => null,
+          invokeSkill: async () => ({}),
+          routeAgentRunViaRust: true,
+          rustAgentRunWsClient: createFridayRustHubAgentRunSealedClientService({
+            host: "127.0.0.1",
+            port,
+            timeoutMs,
+          }),
+          rustAgentRunAnswerReadback: createFridayRustHubRunAnswerReadbackService({
+            repoRoot,
+            timeoutMs,
+          }),
+          rustAgentRunWsClientSecretResolver: () => clientSecret,
+          rustAgentRunHubDbPath: hubDbPath,
+        });
+        const route = runtime.routes
+          .getRoutes()
+          .find((candidate) => candidate.operationId === "agent.runs.start");
+        if (!route) {
+          process.stdout.write(JSON.stringify({ ok: false, code: "AGENT_RUN_ROUTE_MISSING", httpStatus: 0 }) + "\n");
+          process.exit(6);
+          return;
+        }
+        const routeResponse = await route.handler({
+          requestId: "req-interop-agent-route-start-run",
+          receivedAt: new Date(0).toISOString(),
+          params: {},
+          query: {},
+          headers: {},
+          body: {
+            task,
+            providerId: RUST_ROUTE_DEEPSEEK_PROVIDER_ID,
+            model: RUST_ROUTE_DEEPSEEK_FLASH_MODEL,
+            constraints: { readOnly: true },
+            allowedRustRouteTools: [...RUST_ROUTE_READ_TOOL_ALLOWLIST],
+          },
+          principal: makePrincipal(principal),
+        } as never);
+        const result = routeResponse as {
+          runId?: string;
+          status?: string;
+          response?: string;
+          finalResponse?: string;
+          toolCallCount?: number;
+        };
+        process.stdout.write(
+          JSON.stringify({
+            ok: true,
+            mode,
+            runId: result.runId ?? null,
+            status: result.status ?? null,
+            responseLen: result.response?.length ?? null,
+            finalResponseLen: result.finalResponse?.length ?? null,
+            toolCallCount: result.toolCallCount ?? null,
+          }) + "\n",
+        );
+        process.exit(0);
+        return;
+      } finally {
+        tsDb.close();
+      }
     }
 
     const result = await client.dispatchRun({ runId, task, forwardedPrincipal: principal });

--- a/test/interop/friday-version-shim.ts
+++ b/test/interop/friday-version-shim.ts
@@ -1,0 +1,1 @@
+export const FRIDAY_VERSION = "0.0.0-interop";


### PR DESCRIPTION
## Summary

- add a manual ignored Rust/TS interop KAT proving the real `agent.runs.start` route can drive the Rust agent-run loop and read back the delivered answer
- extend the sealed-client interop runner with an `agent-route-start-run` mode that builds the real API runtime, calls the real route handler, uses the real sealed-client service, and verifies owner-gated Rust answer readback
- update the prod flags manifest truth label for `FRIDAY_ROUTE_AGENT_RUN_VIA_RUST` to distinguish this controlled loopback proof from organic/operator live and non-ignored PR-CI e2e coverage

## Truth Boundary

This is a controlled loopback proof using the prebuilt Node interop bundle and an ignored Rust KAT. It does not claim organic/operator live traffic, provider-key spend, or a non-ignored PR-CI flag-on e2e. It leaves prod behavior and live flags unchanged.

## Validation

- `node test/interop/build-sealed-client-runner.mjs`
- `cargo test -p friday-hub --bin hub_agent_run_server interop_ts_agent_start_route_drives_real_rust_run_and_readback -- --ignored --nocapture`
- `npm run typecheck`
- `cargo clippy -p friday-hub --bin hub_agent_run_server --tests -- -D warnings`
- `cargo fmt --all --check`
- `git diff --check`