### PR TITLE
[codex] add OG9 Codex organic spawn launcher

### DIFF
--- a/scripts/ops/friday-codex-mission-proof-of-life.sh
+++ b/scripts/ops/friday-codex-mission-proof-of-life.sh
@@ -49,6 +49,13 @@ readonly TS_HUB_LAUNCH_LABEL="${FRIDAY_TS_HUB_LAUNCH_LABEL:-com.friday.hub}"
 readonly TS_HUB_LAUNCH_DOMAIN="${FRIDAY_TS_HUB_LAUNCH_DOMAIN:-gui/$(id -u)}"
 readonly CODEX_MODEL="gpt-5.5"
 readonly EXPECTED_CODEX_CLI_VERSION="${FRIDAY_CODEX_MISSION_PROOF_CODEX_VERSION:-codex-cli 0.140.0}"
+readonly RUN_KIND="${FRIDAY_CODEX_MISSION_PROOF_RUN_KIND:-proof}"
+readonly SURFACE_KIND="${FRIDAY_CODEX_MISSION_PROOF_SURFACE_KIND:-mobile}"
+readonly DELIVERY_ROUTE="${FRIDAY_CODEX_MISSION_PROOF_DELIVERY_ROUTE:-ops://codex-mission-proof-of-life}"
+readonly MISSION_TITLE="${FRIDAY_CODEX_MISSION_PROOF_TITLE:-Codex proof token}"
+readonly MISSION_INTENT="${FRIDAY_CODEX_MISSION_PROOF_INTENT:-What is the proof token? Answer exactly FRIDAY_CODEX_PROOF_OK.}"
+readonly CAPABILITY_ID="${FRIDAY_CODEX_MISSION_PROOF_CAPABILITY_ID:-observe-wrapper.codex}"
+readonly BODY_REF="${FRIDAY_CODEX_MISSION_PROOF_BODY_REF:-friday://body/ops/codex-mission-proof-of-life}"
 
 SQLITE_BIN="$(command -v sqlite3 || true)"
 if [ -z "${SQLITE_BIN}" ] && [ -x "/Users/jarvis/Library/Android/sdk/platform-tools/sqlite3" ]; then
@@ -112,6 +119,31 @@ if [ "${PREFLIGHT_ONLY}" != "0" ] && [ "${PREFLIGHT_ONLY}" != "1" ]; then
 fi
 if [ "${POLL_INTERVAL_SEC}" -gt "${TIMEOUT_SEC}" ]; then
   echo "FATAL: poll interval cannot be greater than timeout." >&2
+  exit 3
+fi
+case "${RUN_KIND}" in
+  proof|organic) ;;
+  *)
+    echo "FATAL: FRIDAY_CODEX_MISSION_PROOF_RUN_KIND must be proof or organic; got '${RUN_KIND}'." >&2
+    exit 3
+    ;;
+esac
+case "${SURFACE_KIND}" in
+  mobile|desktop) ;;
+  *)
+    echo "FATAL: FRIDAY_CODEX_MISSION_PROOF_SURFACE_KIND must be mobile or desktop; got '${SURFACE_KIND}'." >&2
+    exit 3
+    ;;
+esac
+case "${DELIVERY_ROUTE}" in
+  ops://codex-mission-proof-of-life|ops://codex-organic-spawn) ;;
+  *)
+    echo "FATAL: FRIDAY_CODEX_MISSION_PROOF_DELIVERY_ROUTE is not an allowed local Codex launcher route: '${DELIVERY_ROUTE}'." >&2
+    exit 3
+    ;;
+esac
+if [ -z "${MISSION_INTENT}" ]; then
+  echo "FATAL: FRIDAY_CODEX_MISSION_PROOF_INTENT must not be empty." >&2
   exit 3
 fi
 if [ ! -r "${RUST_WS_LAUNCH_WRAPPER}" ]; then
@@ -478,12 +510,17 @@ if [ "${PREFLIGHT_ONLY}" = "1" ]; then
 fi
 
 readonly RUN_TAG="$(new_id)"
-readonly FRIDAY_CONVERSATION_ID="fconv_codex_proof_${RUN_TAG//-/_}"
-readonly MISSION_ID="codex-proof-mission-${RUN_TAG}"
-readonly WORK_ITEM_ID="codex-proof-work-${RUN_TAG}"
-readonly SURFACE_THREAD_ID="codex-proof-surface-${RUN_TAG}"
+if [ "${RUN_KIND}" = "organic" ]; then
+  readonly ID_PREFIX="codex-organic"
+else
+  readonly ID_PREFIX="codex-proof"
+fi
+readonly FRIDAY_CONVERSATION_ID="fconv_${ID_PREFIX//-/_}_${RUN_TAG//-/_}"
+readonly MISSION_ID="${ID_PREFIX}-mission-${RUN_TAG}"
+readonly WORK_ITEM_ID="${ID_PREFIX}-work-${RUN_TAG}"
+readonly SURFACE_THREAD_ID="${ID_PREFIX}-surface-${RUN_TAG}"
 
-echo "Codex Mission proof starting."
+echo "Codex Mission ${RUN_KIND} starting."
 echo "  TS hub: ${TS_HUB}"
 echo "  Rust DB: ${RUST_HUB_DB}"
 echo "  missionId: ${MISSION_ID}"
@@ -542,21 +579,27 @@ INTAKE_BODY="$(jq -nc \
   --arg surface "${SURFACE_THREAD_ID}" \
   --arg mission "${MISSION_ID}" \
   --arg work "${WORK_ITEM_ID}" \
+  --arg surfaceKind "${SURFACE_KIND}" \
+  --arg deliveryRoute "${DELIVERY_ROUTE}" \
+  --arg title "${MISSION_TITLE}" \
+  --arg intent "${MISSION_INTENT}" \
+  --arg capability "${CAPABILITY_ID}" \
+  --arg bodyRef "${BODY_REF}" \
   '{
     fridayConversationId: $conv,
     ownerPrincipal: $owner,
     surfaceThreadId: $surface,
-    surfaceKind: "mobile",
-    deliveryRoute: "ops://codex-mission-proof-of-life",
+    surfaceKind: $surfaceKind,
+    deliveryRoute: $deliveryRoute,
     visibilityPolicy: "compact",
     missionId: $mission,
     workItemId: $work,
-    title: "Codex proof token",
-    intent: "What is the proof token? Answer exactly FRIDAY_CODEX_PROOF_OK.",
+    title: $title,
+    intent: $intent,
     lane: "codex",
     targetProviderOrAgent: "codex",
-    capabilityId: "observe-wrapper.codex",
-    bodyRef: "friday://body/ops/codex-mission-proof-of-life",
+    capabilityId: $capability,
+    bodyRef: $bodyRef,
     includesSensitiveContext: false
   }')"
 
@@ -673,8 +716,8 @@ while [ "$(date +%s)" -le "${deadline}" ]; do
       ON surface.surface_thread_id = '${SURFACE_THREAD_ID}'
      AND surface.mission_id = w.mission_id
      AND surface.friday_conversation_id = m.friday_conversation_id
-     AND surface.surface_kind = 'mobile'
-     AND surface.delivery_route = 'ops://codex-mission-proof-of-life'
+     AND surface.surface_kind = '${SURFACE_KIND}'
+     AND surface.delivery_route = '${DELIVERY_ROUTE}'
      AND surface.created_at_ms >= ${STARTED_AT_MS}
      AND surface.created_at_ms <= w.updated_at_ms
     WHERE w.work_item_id = '${WORK_ITEM_ID}'
@@ -776,7 +819,11 @@ if [ -n "${pass_reason}" ]; then
     && [ "${WORK_ITEM_SURFACE_BOUND_PROOF:-0}" -gt 0 ] \
     && [ "${UNPROVED_LINKED_SESSION_RUNS:-0}" -eq 0 ]; then
     echo "PASS (STRONG) - ${pass_reason}; matching WorkItem proof, bound Mission SurfaceThread, claim-bound Codex process observation, and per-run proof reconciliation also present."
-    echo "Truth: operator-triggered Codex mission proof, not D8 / not 20-session soak / not GO."
+    if [ "${RUN_KIND}" = "organic" ]; then
+      echo "Truth: operator-triggered organic Codex spawn through Friday; one organic row is not Phase-1 done / not D8 / not GO."
+    else
+      echo "Truth: operator-triggered Codex mission proof, not D8 / not 20-session soak / not GO."
+    fi
     exit 0
   fi
   if [ "${WORK_ITEM_COMPLETED:-0}" -eq 0 ]; then

--- a/scripts/ops/friday-codex-organic-spawn-keychain.sh
+++ b/scripts/ops/friday-codex-organic-spawn-keychain.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+#
+# Non-interactive local wrapper for friday-codex-organic-spawn.sh.
+#
+# It reads the already-provisioned Friday local passphrase from macOS Keychain or an
+# owner-only file and streams it over stdin. The passphrase is never printed.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly SCRIPT_DIR
+readonly ORGANIC_SCRIPT="${SCRIPT_DIR}/friday-codex-organic-spawn.sh"
+readonly KEYCHAIN_ACCOUNT="${FRIDAY_CODEX_MISSION_PROOF_KEYCHAIN_ACCOUNT:-friday}"
+readonly KEYCHAIN_SERVICE="${FRIDAY_CODEX_MISSION_PROOF_KEYCHAIN_SERVICE:-friday-proof-passphrase}"
+readonly PASSPHRASE_FILE="${FRIDAY_CODEX_MISSION_PROOF_PASSPHRASE_FILE:-${HOME}/.friday/friday-proof-passphrase}"
+
+if [ ! -x "${ORGANIC_SCRIPT}" ]; then
+  echo "FATAL: organic launcher is not executable: ${ORGANIC_SCRIPT}" >&2
+  exit 3
+fi
+
+passphrase_file_ok() {
+  if [ ! -f "${PASSPHRASE_FILE}" ]; then
+    return 1
+  fi
+
+  local perms
+  local owner_uid
+  local self_uid
+  perms="$(stat -f '%Lp' "${PASSPHRASE_FILE}" 2>/dev/null || true)"
+  owner_uid="$(stat -f '%u' "${PASSPHRASE_FILE}" 2>/dev/null || true)"
+  self_uid="$(id -u)"
+
+  if [ "${owner_uid}" != "${self_uid}" ]; then
+    echo "FATAL: passphrase file must be owned by the current user: ${PASSPHRASE_FILE}" >&2
+    exit 4
+  fi
+  case "${perms}" in
+    400|600) ;;
+    *)
+      echo "FATAL: passphrase file must be mode 0600 or 0400; got ${perms:-unknown}: ${PASSPHRASE_FILE}" >&2
+      exit 4
+      ;;
+  esac
+  if [ ! -s "${PASSPHRASE_FILE}" ]; then
+    echo "FATAL: passphrase file is empty: ${PASSPHRASE_FILE}" >&2
+    exit 4
+  fi
+
+  return 0
+}
+
+read_provisioned_passphrase() {
+  if command -v security >/dev/null 2>&1 \
+    && security find-generic-password -a "${KEYCHAIN_ACCOUNT}" -s "${KEYCHAIN_SERVICE}" -w >/dev/null 2>&1; then
+    security find-generic-password -a "${KEYCHAIN_ACCOUNT}" -s "${KEYCHAIN_SERVICE}" -w
+    return 0
+  fi
+
+  if passphrase_file_ok; then
+    sed -n '1p' "${PASSPHRASE_FILE}"
+    return 0
+  fi
+
+  echo "FATAL: no provisioned proof passphrase found." >&2
+  echo "Checked keychain account='${KEYCHAIN_ACCOUNT}' service='${KEYCHAIN_SERVICE}' and file='${PASSPHRASE_FILE}'." >&2
+  exit 4
+}
+
+PASSPHRASE="$(read_provisioned_passphrase)"
+trap 'unset PASSPHRASE' EXIT
+if [ -z "${PASSPHRASE}" ]; then
+  echo "FATAL: provisioned proof passphrase is empty." >&2
+  exit 4
+fi
+
+printf '%s\n' "${PASSPHRASE}" \
+  | FRIDAY_CODEX_MISSION_PROOF_PASSPHRASE_STDIN=1 "${ORGANIC_SCRIPT}" "$@"

--- a/scripts/ops/friday-codex-organic-spawn.sh
+++ b/scripts/ops/friday-codex-organic-spawn.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+#
+# Thin operator-facing launcher for OG9: use Friday to start a real Codex task.
+#
+# This reuses friday-codex-mission-proof-of-life.sh's proven login -> mission intake ->
+# auto-dispatch -> sealed WS -> Codex app-server -> observe-wrapper path, but requires
+# operator-provided task text instead of the fixed proof prompt.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly SCRIPT_DIR
+readonly PROOF_SCRIPT="${SCRIPT_DIR}/friday-codex-mission-proof-of-life.sh"
+
+if [ ! -x "${PROOF_SCRIPT}" ]; then
+  echo "FATAL: Codex mission launcher backend is not executable: ${PROOF_SCRIPT}" >&2
+  exit 3
+fi
+
+TASK_TEXT="${FRIDAY_CODEX_ORGANIC_TASK:-}"
+if [ -z "${TASK_TEXT}" ] && [ "$#" -gt 0 ]; then
+  TASK_TEXT="$*"
+fi
+if [ -z "${TASK_TEXT}" ]; then
+  echo "Usage: $0 '<operator task for Codex>'" >&2
+  echo "Or set FRIDAY_CODEX_ORGANIC_TASK." >&2
+  exit 3
+fi
+
+export FRIDAY_CODEX_MISSION_PROOF_RUN_KIND="organic"
+export FRIDAY_CODEX_MISSION_PROOF_SURFACE_KIND="${FRIDAY_CODEX_ORGANIC_SURFACE_KIND:-desktop}"
+export FRIDAY_CODEX_MISSION_PROOF_DELIVERY_ROUTE="ops://codex-organic-spawn"
+export FRIDAY_CODEX_MISSION_PROOF_TITLE="${FRIDAY_CODEX_ORGANIC_TITLE:-Codex organic operator task}"
+export FRIDAY_CODEX_MISSION_PROOF_INTENT="${TASK_TEXT}"
+export FRIDAY_CODEX_MISSION_PROOF_CAPABILITY_ID="observe-wrapper.codex.organic"
+export FRIDAY_CODEX_MISSION_PROOF_BODY_REF="friday://body/ops/codex-organic-spawn"
+
+exec "${PROOF_SCRIPT}"

--- a/test/unit/scripts/ops/friday-codex-mission-proof-gates.test.ts
+++ b/test/unit/scripts/ops/friday-codex-mission-proof-gates.test.ts
@@ -30,6 +30,14 @@ const proofKeychainWrapper = resolve(
   repoRoot,
   "scripts/ops/friday-codex-mission-proof-of-life-keychain.sh",
 );
+const organicSpawnScript = resolve(
+  repoRoot,
+  "scripts/ops/friday-codex-organic-spawn.sh",
+);
+const organicSpawnKeychainWrapper = resolve(
+  repoRoot,
+  "scripts/ops/friday-codex-organic-spawn-keychain.sh",
+);
 const proofProvisionPassphraseScript = resolve(
   repoRoot,
   "scripts/ops/friday-codex-mission-proof-provision-passphrase.sh",
@@ -444,6 +452,55 @@ async function runD8Audit(dbPath: string, requiredSessions = "1") {
 }
 
 describe("Codex mission proof gates", () => {
+  it("exposes an organic Codex launcher that requires operator task text", () => {
+    const proofSource = readFileSync(proofScript, "utf8");
+    const organicSource = readFileSync(organicSpawnScript, "utf8");
+    const organicKeychainSource = readFileSync(
+      organicSpawnKeychainWrapper,
+      "utf8",
+    );
+
+    expect(proofSource).toContain(
+      'readonly RUN_KIND="${FRIDAY_CODEX_MISSION_PROOF_RUN_KIND:-proof}"',
+    );
+    expect(proofSource).toContain(
+      'readonly MISSION_INTENT="${FRIDAY_CODEX_MISSION_PROOF_INTENT:-What is the proof token? Answer exactly FRIDAY_CODEX_PROOF_OK.}"',
+    );
+    expect(proofSource).toContain("FRIDAY_CODEX_MISSION_PROOF_RUN_KIND must be proof or organic");
+    expect(proofSource).toContain(
+      "ops://codex-mission-proof-of-life|ops://codex-organic-spawn",
+    );
+    expect(proofSource).toContain('surface.surface_kind = \'${SURFACE_KIND}\'');
+    expect(proofSource).toContain('surface.delivery_route = \'${DELIVERY_ROUTE}\'');
+    expect(proofSource).toContain(
+      "operator-triggered organic Codex spawn through Friday",
+    );
+
+    expect(organicSource).toContain("FRIDAY_CODEX_ORGANIC_TASK");
+    expect(organicSource).toContain("Usage: $0 '<operator task for Codex>'");
+    expect(organicSource).toContain(
+      'export FRIDAY_CODEX_MISSION_PROOF_RUN_KIND="organic"',
+    );
+    expect(organicSource).toContain(
+      'export FRIDAY_CODEX_MISSION_PROOF_DELIVERY_ROUTE="ops://codex-organic-spawn"',
+    );
+    expect(organicSource).toContain(
+      'export FRIDAY_CODEX_MISSION_PROOF_INTENT="${TASK_TEXT}"',
+    );
+    expect(organicSource).not.toContain("Answer exactly FRIDAY_CODEX_PROOF_OK");
+
+    expect(organicKeychainSource).toContain(
+      'readonly ORGANIC_SCRIPT="${SCRIPT_DIR}/friday-codex-organic-spawn.sh"',
+    );
+    expect(organicKeychainSource).toContain(
+      'FRIDAY_CODEX_MISSION_PROOF_PASSPHRASE_STDIN=1 "${ORGANIC_SCRIPT}" "$@"',
+    );
+    expect(organicKeychainSource).toContain(
+      'security find-generic-password -a "${KEYCHAIN_ACCOUNT}" -s "${KEYCHAIN_SERVICE}" -w >/dev/null 2>&1',
+    );
+    expect(organicKeychainSource).toContain("trap 'unset PASSPHRASE' EXIT");
+  });
+
   it("D8 audit passes only when a linked session has matching completed WorkItem proof", async () => {
     const tempRoot = makeTempRoot();
     const dbPath = join(tempRoot, "d8-pass.sqlite");
@@ -828,11 +885,13 @@ describe("Codex mission proof gates", () => {
 
     expect(proofSource).toContain("WORK_ITEM_COMPLETED");
     expect(proofSource).toContain(
-      'readonly FRIDAY_CONVERSATION_ID="fconv_codex_proof_${RUN_TAG//-/_}"',
+      'readonly FRIDAY_CONVERSATION_ID="fconv_${ID_PREFIX//-/_}_${RUN_TAG//-/_}"',
     );
     expect(proofSource).not.toContain(
       'readonly FRIDAY_CONVERSATION_ID="codex-proof-conv-${RUN_TAG}"',
     );
+    expect(proofSource).toContain('readonly ID_PREFIX="codex-proof"');
+    expect(proofSource).toContain('readonly ID_PREFIX="codex-organic"');
     expect(proofSource).toContain("status='completed_with_proof'");
     expect(proofSource).toContain("WORK_ITEM_LINKED_PROOF");
     expect(proofSource).toContain(
@@ -1042,9 +1101,9 @@ describe("Codex mission proof gates", () => {
     expect(proofSource).toContain(
       "surface.surface_thread_id = '${SURFACE_THREAD_ID}'",
     );
-    expect(proofSource).toContain("surface.surface_kind = 'mobile'");
+    expect(proofSource).toContain("surface.surface_kind = '${SURFACE_KIND}'");
     expect(proofSource).toContain(
-      "surface.delivery_route = 'ops://codex-mission-proof-of-life'",
+      "surface.delivery_route = '${DELIVERY_ROUTE}'",
     );
     expect(proofSource).toContain("Mission row:");
     expect(proofSource).toContain("Surface thread row:");


### PR DESCRIPTION
## Summary
- Adds a thin `friday-codex-organic-spawn.sh` operator launcher that reuses the proven Codex mission intake -> auto-dispatch -> sealed WS -> app-server observe path with operator-provided task text instead of the fixed proof prompt.
- Adds a keychain-backed wrapper for local dogfood runs without printing the Friday passphrase.
- Parameterizes the existing Codex mission proof backend so default proof behavior remains intact while the organic launcher can bind `desktop` + `ops://codex-organic-spawn` evidence.

## Truth Boundary
- This is OG9 launcher prep: it creates the exact operator-facing entrypoint for a real organic Codex spawn through Friday.
- Preflight creates no traffic and no provider spend.
- A future successful organic run through this launcher would produce the first organic row, but one row is still not Phase-1 flawless / not D8 / not GO.

## Validation
- `bash -n scripts/ops/friday-codex-mission-proof-of-life.sh && bash -n scripts/ops/friday-codex-organic-spawn.sh && bash -n scripts/ops/friday-codex-organic-spawn-keychain.sh`
- `npx vitest run --project default test/unit/scripts/ops/friday-codex-mission-proof-gates.test.ts`
- `FRIDAY_CODEX_MISSION_PROOF_PREFLIGHT_ONLY=1 scripts/ops/friday-codex-organic-spawn.sh "Operator organic spawn preflight only"`
- `npm run typecheck`
- `git diff --check`