### PR TITLE
[codex] add OG9 Claude organic spawn launcher

### DIFF
--- a/scripts/ops/friday-claude-mission-proof-of-life.sh
+++ b/scripts/ops/friday-claude-mission-proof-of-life.sh
@@ -50,6 +50,13 @@ readonly TS_HUB_LAUNCH_PLIST="${FRIDAY_TS_HUB_LAUNCH_PLIST:-/Users/jarvis/Librar
 readonly TS_HUB_LAUNCH_LABEL="${FRIDAY_TS_HUB_LAUNCH_LABEL:-com.friday.hub}"
 readonly TS_HUB_LAUNCH_DOMAIN="${FRIDAY_TS_HUB_LAUNCH_DOMAIN:-gui/$(id -u)}"
 readonly CLAUDE_MODEL="claude-opus-4-8"
+readonly RUN_KIND="${FRIDAY_CLAUDE_MISSION_PROOF_RUN_KIND:-proof}"
+readonly SURFACE_KIND="${FRIDAY_CLAUDE_MISSION_PROOF_SURFACE_KIND:-mobile}"
+readonly DELIVERY_ROUTE="${FRIDAY_CLAUDE_MISSION_PROOF_DELIVERY_ROUTE:-ops://claude-mission-proof-of-life}"
+readonly MISSION_TITLE="${FRIDAY_CLAUDE_MISSION_PROOF_TITLE:-Claude proof token}"
+readonly MISSION_INTENT="${FRIDAY_CLAUDE_MISSION_PROOF_INTENT:-Answer exactly FRIDAY_CLAUDE_PROOF_OK.}"
+readonly CAPABILITY_ID="${FRIDAY_CLAUDE_MISSION_PROOF_CAPABILITY_ID:-ask_friday.claude}"
+readonly BODY_REF="${FRIDAY_CLAUDE_MISSION_PROOF_BODY_REF:-friday://body/ops/claude-mission-proof-of-life}"
 
 SQLITE_BIN="$(command -v sqlite3 || true)"
 if [ -z "${SQLITE_BIN}" ] && [ -x "/Users/jarvis/Library/Android/sdk/platform-tools/sqlite3" ]; then
@@ -96,6 +103,20 @@ if [ "${OUTCOME_CHECKED}" != "0" ] && [ "${OUTCOME_CHECKED}" != "1" ]; then
   echo "FATAL: FRIDAY_CLAUDE_MISSION_PROOF_OUTCOME_CHECKED must be 0 or 1; got '${OUTCOME_CHECKED}'." >&2
   exit 3
 fi
+case "${RUN_KIND}" in
+  proof|organic) ;;
+  *)
+    echo "FATAL: FRIDAY_CLAUDE_MISSION_PROOF_RUN_KIND must be proof or organic; got '${RUN_KIND}'." >&2
+    exit 3
+    ;;
+esac
+case "${SURFACE_KIND}" in
+  mobile|desktop) ;;
+  *)
+    echo "FATAL: FRIDAY_CLAUDE_MISSION_PROOF_SURFACE_KIND must be mobile or desktop; got '${SURFACE_KIND}'." >&2
+    exit 3
+    ;;
+esac
 if [ "${POLL_INTERVAL_SEC}" -gt "${TIMEOUT_SEC}" ]; then
   echo "FATAL: poll interval cannot be greater than timeout." >&2
   exit 3
@@ -359,20 +380,31 @@ if [ "${PREFLIGHT_ONLY}" = "1" ]; then
   echo "  anthropicLedgerRows: $(sql_count "preflight anthropic ledger" "SELECT COUNT(*) FROM token_ledger WHERE provider_kind='anthropic';")"
   echo "  claudeWorkItems: $(sql_count "preflight claude work items" "SELECT COUNT(*) FROM work_item WHERE lane='claude' OR target_provider_or_agent='claude';")"
   echo "  outcomeCheckedMode: ${OUTCOME_CHECKED}"
+  echo "  runKind: ${RUN_KIND}"
+  echo "  surfaceKind: ${SURFACE_KIND}"
+  echo "  deliveryRoute: ${DELIVERY_ROUTE}"
   echo "Truth: preflight creates no traffic and proves only local readiness, not Claude proof / D8 / GO."
   exit 0
 fi
 
 readonly RUN_TAG="$(new_id)"
-readonly FRIDAY_CONVERSATION_ID="fconv_claude_proof_${RUN_TAG//-/_}"
-readonly MISSION_ID="claude-proof-mission-${RUN_TAG}"
-readonly WORK_ITEM_ID="claude-proof-work-${RUN_TAG}"
-readonly SURFACE_THREAD_ID="claude-proof-surface-${RUN_TAG}"
+if [ "${RUN_KIND}" = "organic" ]; then
+  readonly ID_PREFIX="claude-organic"
+else
+  readonly ID_PREFIX="claude-proof"
+fi
+readonly FRIDAY_CONVERSATION_ID="fconv_${ID_PREFIX//-/_}_${RUN_TAG//-/_}"
+readonly MISSION_ID="${ID_PREFIX}-mission-${RUN_TAG}"
+readonly WORK_ITEM_ID="${ID_PREFIX}-work-${RUN_TAG}"
+readonly SURFACE_THREAD_ID="${ID_PREFIX}-surface-${RUN_TAG}"
 readonly STARTED_AT_MS="$(now_ms)"
 
 echo "Claude Mission proof starting."
 echo "  TS hub: ${TS_HUB}"
 echo "  Rust DB: ${RUST_HUB_DB}"
+echo "  runKind: ${RUN_KIND}"
+echo "  surfaceKind: ${SURFACE_KIND}"
+echo "  deliveryRoute: ${DELIVERY_ROUTE}"
 echo "  missionId: ${MISSION_ID}"
 echo "  workItemId: ${WORK_ITEM_ID}"
 echo "  startedAtMs: ${STARTED_AT_MS}"
@@ -427,22 +459,28 @@ INTAKE_BODY="$(jq -nc \
   --arg surface "${SURFACE_THREAD_ID}" \
   --arg mission "${MISSION_ID}" \
   --arg work "${WORK_ITEM_ID}" \
+  --arg surface_kind "${SURFACE_KIND}" \
+  --arg delivery_route "${DELIVERY_ROUTE}" \
+  --arg title "${MISSION_TITLE}" \
+  --arg intent "${MISSION_INTENT}" \
+  --arg capability_id "${CAPABILITY_ID}" \
+  --arg body_ref "${BODY_REF}" \
   --arg outcome_checked "${OUTCOME_CHECKED}" \
   '{
     fridayConversationId: $conv,
     ownerPrincipal: $owner,
     surfaceThreadId: $surface,
-    surfaceKind: "mobile",
-    deliveryRoute: "ops://claude-mission-proof-of-life",
+    surfaceKind: $surface_kind,
+    deliveryRoute: $delivery_route,
     visibilityPolicy: "compact",
     missionId: $mission,
     workItemId: $work,
-    title: "Claude proof token",
-    intent: "Answer exactly FRIDAY_CLAUDE_PROOF_OK.",
+    title: $title,
+    intent: $intent,
     lane: "claude",
     targetProviderOrAgent: "claude",
-    capabilityId: "ask_friday.claude",
-    bodyRef: "friday://body/ops/claude-mission-proof-of-life",
+    capabilityId: $capability_id,
+    bodyRef: $body_ref,
     includesSensitiveContext: false
   } + (if $outcome_checked == "1" then {proofRequirements: ["outcome:AnswerProduced:>=1"]} else {} end)')"
 
@@ -553,8 +591,8 @@ while [ "$(date +%s)" -le "${deadline}" ]; do
       ON surface.surface_thread_id = '${SURFACE_THREAD_ID}'
      AND surface.mission_id = w.mission_id
      AND surface.friday_conversation_id = m.friday_conversation_id
-     AND surface.surface_kind = 'mobile'
-     AND surface.delivery_route = 'ops://claude-mission-proof-of-life'
+     AND surface.surface_kind = '${SURFACE_KIND}'
+     AND surface.delivery_route = '${DELIVERY_ROUTE}'
      AND surface.created_at_ms >= ${STARTED_AT_MS}
      AND surface.created_at_ms <= w.updated_at_ms
     WHERE w.work_item_id = '${WORK_ITEM_ID}'
@@ -683,7 +721,11 @@ if [ "${joined_proof:-0}" -gt 0 ] && [ "${surface_bound_proof:-0}" -gt 0 ]; then
   else
     echo "PASS (STRONG) - this Claude WorkItem completed_with_proof, the proof receipt joins to a same-run non-fallback Anthropic ledger row for ${CLAUDE_MODEL}, and the operator surface binding is present."
   fi
-  echo "Truth: operator-triggered Claude mission proof, not D8 / not soak / not UI-device-channel proof / not GO."
+  if [ "${RUN_KIND}" = "organic" ]; then
+    echo "Truth: operator-triggered organic Claude spawn through Friday; one organic row is not Phase-1 done / not D8 / not GO."
+  else
+    echo "Truth: operator-triggered Claude mission proof, not D8 / not soak / not UI-device-channel proof / not GO."
+  fi
   exit 0
 fi
 

--- a/scripts/ops/friday-claude-organic-spawn-keychain.sh
+++ b/scripts/ops/friday-claude-organic-spawn-keychain.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+#
+# Non-interactive local wrapper for friday-claude-organic-spawn.sh.
+#
+# It reads the already-provisioned Friday local passphrase from macOS Keychain or
+# an owner-only file and streams it over stdin. The passphrase is never printed.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly SCRIPT_DIR
+readonly ORGANIC_SCRIPT="${SCRIPT_DIR}/friday-claude-organic-spawn.sh"
+readonly KEYCHAIN_ACCOUNT="${FRIDAY_CLAUDE_MISSION_PROOF_KEYCHAIN_ACCOUNT:-${FRIDAY_CODEX_MISSION_PROOF_KEYCHAIN_ACCOUNT:-friday}}"
+readonly KEYCHAIN_SERVICE="${FRIDAY_CLAUDE_MISSION_PROOF_KEYCHAIN_SERVICE:-${FRIDAY_CODEX_MISSION_PROOF_KEYCHAIN_SERVICE:-friday-proof-passphrase}}"
+readonly PASSPHRASE_FILE="${FRIDAY_CLAUDE_MISSION_PROOF_PASSPHRASE_FILE:-${FRIDAY_CODEX_MISSION_PROOF_PASSPHRASE_FILE:-${HOME}/.friday/friday-proof-passphrase}}"
+
+if [ ! -x "${ORGANIC_SCRIPT}" ]; then
+  echo "FATAL: organic launcher is not executable: ${ORGANIC_SCRIPT}" >&2
+  exit 3
+fi
+
+passphrase_file_ok() {
+  if [ ! -f "${PASSPHRASE_FILE}" ]; then
+    return 1
+  fi
+
+  local perms
+  local owner_uid
+  local self_uid
+  perms="$(stat -f '%Lp' "${PASSPHRASE_FILE}" 2>/dev/null || true)"
+  owner_uid="$(stat -f '%u' "${PASSPHRASE_FILE}" 2>/dev/null || true)"
+  self_uid="$(id -u)"
+
+  if [ "${owner_uid}" != "${self_uid}" ]; then
+    echo "FATAL: passphrase file must be owned by the current user: ${PASSPHRASE_FILE}" >&2
+    exit 4
+  fi
+  case "${perms}" in
+    400|600) ;;
+    *)
+      echo "FATAL: passphrase file must be mode 0600 or 0400; got ${perms:-unknown}: ${PASSPHRASE_FILE}" >&2
+      exit 4
+      ;;
+  esac
+  if [ ! -s "${PASSPHRASE_FILE}" ]; then
+    echo "FATAL: passphrase file is empty: ${PASSPHRASE_FILE}" >&2
+    exit 4
+  fi
+
+  return 0
+}
+
+read_provisioned_passphrase() {
+  if command -v security >/dev/null 2>&1 \
+    && security find-generic-password -a "${KEYCHAIN_ACCOUNT}" -s "${KEYCHAIN_SERVICE}" -w >/dev/null 2>&1; then
+    security find-generic-password -a "${KEYCHAIN_ACCOUNT}" -s "${KEYCHAIN_SERVICE}" -w
+    return 0
+  fi
+
+  if passphrase_file_ok; then
+    sed -n '1p' "${PASSPHRASE_FILE}"
+    return 0
+  fi
+
+  echo "FATAL: no provisioned proof passphrase found." >&2
+  echo "Checked keychain account='${KEYCHAIN_ACCOUNT}' service='${KEYCHAIN_SERVICE}' and file='${PASSPHRASE_FILE}'." >&2
+  exit 4
+}
+
+PASSPHRASE="$(read_provisioned_passphrase)"
+trap 'unset PASSPHRASE' EXIT
+if [ -z "${PASSPHRASE}" ]; then
+  echo "FATAL: provisioned proof passphrase is empty." >&2
+  exit 4
+fi
+
+printf '%s\n' "${PASSPHRASE}" \
+  | FRIDAY_CLAUDE_MISSION_PROOF_PASSPHRASE_STDIN=1 "${ORGANIC_SCRIPT}" "$@"

--- a/scripts/ops/friday-claude-organic-spawn.sh
+++ b/scripts/ops/friday-claude-organic-spawn.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+#
+# Thin operator-facing launcher for OG9: use Friday to start a real Claude task.
+#
+# This reuses friday-claude-mission-proof-of-life.sh's proven login -> mission
+# intake -> auto-dispatch -> sealed WS -> Claude route path, but requires
+# operator-provided task text instead of the fixed proof prompt.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly SCRIPT_DIR
+readonly PROOF_SCRIPT="${SCRIPT_DIR}/friday-claude-mission-proof-of-life.sh"
+
+if [ ! -x "${PROOF_SCRIPT}" ]; then
+  echo "FATAL: Claude mission launcher backend is not executable: ${PROOF_SCRIPT}" >&2
+  exit 3
+fi
+
+TASK_TEXT="${FRIDAY_CLAUDE_ORGANIC_TASK:-}"
+if [ -z "${TASK_TEXT}" ] && [ "$#" -gt 0 ]; then
+  TASK_TEXT="$*"
+fi
+if [ -z "${TASK_TEXT}" ]; then
+  echo "Usage: $0 '<operator task for Claude>'" >&2
+  echo "Or set FRIDAY_CLAUDE_ORGANIC_TASK." >&2
+  exit 3
+fi
+
+export FRIDAY_CLAUDE_MISSION_PROOF_RUN_KIND="organic"
+export FRIDAY_CLAUDE_MISSION_PROOF_SURFACE_KIND="${FRIDAY_CLAUDE_ORGANIC_SURFACE_KIND:-desktop}"
+export FRIDAY_CLAUDE_MISSION_PROOF_DELIVERY_ROUTE="ops://claude-organic-spawn"
+export FRIDAY_CLAUDE_MISSION_PROOF_TITLE="${FRIDAY_CLAUDE_ORGANIC_TITLE:-Claude organic operator task}"
+export FRIDAY_CLAUDE_MISSION_PROOF_INTENT="${TASK_TEXT}"
+export FRIDAY_CLAUDE_MISSION_PROOF_CAPABILITY_ID="observe-wrapper.claude.organic"
+export FRIDAY_CLAUDE_MISSION_PROOF_BODY_REF="friday://body/ops/claude-organic-spawn"
+
+exec "${PROOF_SCRIPT}"

--- a/test/unit/scripts/ops/friday-claude-mission-proof-gates.test.ts
+++ b/test/unit/scripts/ops/friday-claude-mission-proof-gates.test.ts
@@ -12,10 +12,23 @@ const keychainWrapper = resolve(
   repoRoot,
   "scripts/ops/friday-claude-mission-proof-of-life-keychain.sh",
 );
+const organicLauncher = resolve(
+  repoRoot,
+  "scripts/ops/friday-claude-organic-spawn.sh",
+);
+const organicKeychainWrapper = resolve(
+  repoRoot,
+  "scripts/ops/friday-claude-organic-spawn-keychain.sh",
+);
 
 describe("Claude mission proof operator gate", () => {
   it("keeps the script shell-parseable", () => {
-    for (const script of [proofScript, keychainWrapper]) {
+    for (const script of [
+      proofScript,
+      keychainWrapper,
+      organicLauncher,
+      organicKeychainWrapper,
+    ]) {
       const result = spawnSync("bash", ["-n", script], {
         cwd: repoRoot,
         encoding: "utf8",
@@ -30,13 +43,18 @@ describe("Claude mission proof operator gate", () => {
     expect(source).toContain("FRIDAY_CLAUDE_MISSION_PROOF_PREFLIGHT_ONLY");
     expect(source).toContain("FRIDAY_CLAUDE_MISSION_PROOF_PASSPHRASE_STDIN");
     expect(source).toContain("FRIDAY_CLAUDE_MISSION_PROOF_OUTCOME_CHECKED");
+    expect(source).toContain("FRIDAY_CLAUDE_MISSION_PROOF_RUN_KIND");
+    expect(source).toContain("FRIDAY_CLAUDE_MISSION_PROOF_SURFACE_KIND");
+    expect(source).toContain("FRIDAY_CLAUDE_MISSION_PROOF_DELIVERY_ROUTE");
     expect(source).toContain('readonly CLAUDE_MODEL="claude-opus-4-8"');
     expect(source).toContain('lane: "claude"');
     expect(source).toContain('targetProviderOrAgent: "claude"');
     expect(source).toContain('proofRequirements: ["outcome:AnswerProduced:>=1"]');
     expect(source).toContain(
-      'deliveryRoute: "ops://claude-mission-proof-of-life"',
+      "FRIDAY_CLAUDE_MISSION_PROOF_DELIVERY_ROUTE:-ops://claude-mission-proof-of-life",
     );
+    expect(source).toContain("deliveryRoute: $delivery_route");
+    expect(source).toContain("intent: $intent");
     expect(source).toContain(
       'require_file_contains "${RUST_WS_LAUNCH_WRAPPER}" "export FRIDAY_CLAUDE_ROUTE_ENABLED=1"',
     );
@@ -63,10 +81,8 @@ describe("Claude mission proof operator gate", () => {
     expect(source).toContain("ledger.model='${CLAUDE_MODEL}'");
     expect(source).toContain("ledger.fallback=0");
     expect(source).toContain("ledger.total_tokens > 0");
-    expect(source).toContain("surface.surface_kind = 'mobile'");
-    expect(source).toContain(
-      "surface.delivery_route = 'ops://claude-mission-proof-of-life'",
-    );
+    expect(source).toContain("surface.surface_kind = '${SURFACE_KIND}'");
+    expect(source).toContain("surface.delivery_route = '${DELIVERY_ROUTE}'");
     expect(source).toContain("PASS (STRONG)");
     expect(source).toContain("PASS (PARTIAL)");
     expect(source).toContain("PASS (STRONG OUTCOME)");
@@ -79,6 +95,36 @@ describe("Claude mission proof operator gate", () => {
     expect(source).not.toContain("provider_session_link");
     expect(source).not.toContain("process_observation");
     expect(source).not.toContain("codex_app_server");
+  });
+
+  it("exposes a Claude organic launcher without the fixed proof prompt", () => {
+    const launcherSource = readFileSync(organicLauncher, "utf8");
+    const keychainSource = readFileSync(organicKeychainWrapper, "utf8");
+
+    expect(launcherSource).toContain(
+      'FRIDAY_CLAUDE_MISSION_PROOF_RUN_KIND="organic"',
+    );
+    expect(launcherSource).toContain(
+      'FRIDAY_CLAUDE_MISSION_PROOF_SURFACE_KIND="${FRIDAY_CLAUDE_ORGANIC_SURFACE_KIND:-desktop}"',
+    );
+    expect(launcherSource).toContain(
+      'FRIDAY_CLAUDE_MISSION_PROOF_DELIVERY_ROUTE="ops://claude-organic-spawn"',
+    );
+    expect(launcherSource).toContain(
+      'FRIDAY_CLAUDE_MISSION_PROOF_INTENT="${TASK_TEXT}"',
+    );
+    expect(launcherSource).toContain("observe-wrapper.claude.organic");
+    expect(launcherSource).toContain("FRIDAY_CLAUDE_ORGANIC_TASK");
+    expect(launcherSource).not.toContain("FRIDAY_CLAUDE_PROOF_OK");
+
+    expect(keychainSource).toContain(
+      'FRIDAY_CLAUDE_MISSION_PROOF_PASSPHRASE_STDIN=1 "${ORGANIC_SCRIPT}"',
+    );
+    expect(keychainSource).toContain("passphrase_file_ok()");
+    expect(keychainSource).toContain("read_provisioned_passphrase()");
+    expect(keychainSource).toContain("stat -f '%Lp'");
+    expect(keychainSource).toContain("stat -f '%u'");
+    expect(keychainSource).toContain("400|600) ;;");
   });
 
   it("does not read secrets before preflight and does not put bearer in argv", () => {


### PR DESCRIPTION
## Summary
- parameterize the Claude mission proof backend for proof vs organic run kinds, surface kind, delivery route, title, intent, capability, and body ref
- add operator-facing Claude organic spawn launchers, including a keychain/passphrase wrapper matching the Codex organic launcher pattern
- extend focused script tests to cover shell parsing, organic launcher wiring, and proof backend truth boundaries

## Validation
- bash -n scripts/ops/friday-claude-mission-proof-of-life.sh scripts/ops/friday-claude-mission-proof-of-life-keychain.sh scripts/ops/friday-claude-organic-spawn.sh scripts/ops/friday-claude-organic-spawn-keychain.sh
- npx vitest run --project default test/unit/scripts/ops/friday-claude-mission-proof-gates.test.ts
- FRIDAY_CLAUDE_MISSION_PROOF_PREFLIGHT_ONLY=1 scripts/ops/friday-claude-organic-spawn.sh "Operator organic Claude spawn preflight only"
- git diff --check

## Truth boundary
This closes only the Claude side of the OG9 operator-facing launcher gap. The preflight creates zero traffic and does not prove a true organic row, Phase-1 flawless loop, A1 live-done, D8, or GO. A future operator-triggered organic run is still required for GO-LIVE gate organic evidence; one organic row alone still is not Phase-1 done.