### PR TITLE
[codex] add mission body snapshot resolver

### DIFF
--- a/rust-core/crates/friday-hub/src/hub_server.rs
+++ b/rust-core/crates/friday-hub/src/hub_server.rs
@@ -33,8 +33,8 @@ use friday_protocol::{
 };
 use friday_providers::unified::{FallbackStatus, PlatformProvider, ProviderSession, SessionStatus};
 use friday_storage::{
-    get_run_answer_for_principal, get_run_result_ref, AnswerDenyReason, Db, RunAnswerAccess,
-    RunResultRef,
+    get_run_answer_for_principal, get_run_result_ref, AnswerDenyReason, Db, MissionBodySnapshot,
+    RunAnswerAccess, RunResultRef,
 };
 use friday_transport::{ws_recv_envelope, ws_send_envelope, TransportError, WireWebSocket};
 use serde_json::json;
@@ -51,7 +51,7 @@ use crate::provider_dispatch::{
     dispatch_provider_action, DispatchContext, DispatchError, ProviderDispatchAdapter,
 };
 use crate::provider_dispatch_adapter::{
-    provider_workspace_dispatch_enabled, LocalCodexWorkspaceClient,
+    provider_workspace_dispatch_enabled, DbPromptBodyResolver, LocalCodexWorkspaceClient,
     ProviderWorkspaceDispatchAdapter,
 };
 use crate::provider_workspace::ProviderWorkspaceCatalog;
@@ -630,6 +630,29 @@ pub fn mission_intake_result_for_db_flagged(
         None,
         action_list_enabled,
     );
+    let body_snapshot = match MissionBodySnapshot::new(
+        authenticated_owner,
+        &request.mission_id,
+        &request.work_item_id,
+        work_item
+            .input_refs
+            .first()
+            .map(String::as_str)
+            .unwrap_or(""),
+        surface_kind.as_str(),
+        &request.intent,
+        now_ms,
+    ) {
+        Ok(snapshot) => snapshot,
+        Err(err) => {
+            return mission_intake_error(
+                msg_id,
+                now_ms,
+                ErrorCode::Internal,
+                &format!("mission intake body snapshot blocked: {err}"),
+            );
+        }
+    };
 
     let outcome = match preflight_and_stage_work_item_with_workspace_claims(
         db,
@@ -638,6 +661,7 @@ pub fn mission_intake_result_for_db_flagged(
             mission,
             surface_thread: Some(surface_thread),
             work_item,
+            body_snapshot: Some(body_snapshot),
             includes_sensitive_context: request.includes_sensitive_context,
         },
         &workspace_claims,
@@ -1461,12 +1485,14 @@ pub fn provider_workspace_action_result_for_db(
                     // `Verified` (none in `friday_current()` are), so the guard refuses
                     // every real request before the adapter is consulted regardless.
                     let no_adapter = NoProviderWorkspaceDispatchAdapter;
-                    let live_adapter =
-                        ProviderWorkspaceDispatchAdapter::new(LocalCodexWorkspaceClient::new(
+                    let live_adapter = ProviderWorkspaceDispatchAdapter::with_prompt_resolver(
+                        LocalCodexWorkspaceClient::new(
                             "codex",
                             "friday-hub",
                             env!("CARGO_PKG_VERSION"),
-                        ));
+                        ),
+                        DbPromptBodyResolver::new(db),
+                    );
                     let adapter: &dyn ProviderDispatchAdapter =
                         if provider_workspace_dispatch_enabled() {
                             &live_adapter
@@ -2975,6 +3001,54 @@ mod tests {
             ))
             .to_string_lossy()
             .into_owned()
+    }
+
+    #[test]
+    fn mission_intake_writes_body_snapshot_bound_to_work_item_input_ref() {
+        let db = Db::open_hub(&tmp_db()).unwrap();
+        let now = 1_700_002_000_000;
+        let intent = "send this mission prompt to the Codex workspace";
+        let body_ref = "friday://body/mobile/snapshot-1";
+        let response = mission_intake_result_for_db(
+            &db,
+            "intake-snapshot",
+            MissionIntakeRequestWire {
+                friday_conversation_id: "fconv_snapshot".into(),
+                owner_principal: "principal:jarvis".into(),
+                surface_thread_id: "surface-snapshot".into(),
+                surface_kind: "mobile".into(),
+                delivery_route: "mobile://local/thread/snapshot".into(),
+                visibility_policy: "compact".into(),
+                mission_id: "mission-snapshot".into(),
+                work_item_id: "work-snapshot".into(),
+                title: "Snapshot Mission".into(),
+                intent: intent.into(),
+                lane: "codex".into(),
+                target_provider_or_agent: Some("codex".into()),
+                capability_id: Some("provider.codex.send_turn".into()),
+                body_ref: Some(body_ref.into()),
+                proof_requirements: Vec::new(),
+                includes_sensitive_context: false,
+            },
+            Some("principal:jarvis"),
+            now,
+        );
+        let Message::MissionIntakeResult { result } = response.message else {
+            panic!("expected MissionIntakeResult, got {response:?}");
+        };
+        assert_eq!(result.status, "ready");
+        let work_item = db
+            .get_work_item("work-snapshot")
+            .unwrap()
+            .expect("WorkItem row");
+        assert_eq!(work_item.input_refs, vec![body_ref.to_string()]);
+        let snapshot = db
+            .get_mission_body_snapshot("principal:jarvis", "work-snapshot", body_ref)
+            .unwrap()
+            .expect("mission body snapshot");
+        assert_eq!(snapshot.body, intent);
+        assert_eq!(snapshot.body_len, intent.len() as i64);
+        assert_eq!(snapshot.owner_principal, "principal:jarvis");
     }
 
     fn provider_session_link() -> ProviderSessionLink {

--- a/rust-core/crates/friday-hub/src/mission_preflight.rs
+++ b/rust-core/crates/friday-hub/src/mission_preflight.rs
@@ -12,7 +12,7 @@ use friday_core::{
     outcome_checked_proof_enabled, requires_context_passport, ApprovalState, FridayConversation,
     Mission, MissionLink, MissionLinkKind, SurfaceThread, WorkItem, WorkItemStatus, WorkspaceClaim,
 };
-use friday_storage::{memory, workflow, Db, StorageError};
+use friday_storage::{memory, workflow, Db, MissionBodySnapshot, StorageError};
 
 use crate::channel_event::ChannelInboundReceipt;
 use crate::provider_timeline::PendingState;
@@ -23,6 +23,7 @@ pub struct MissionPreflightRequest {
     pub mission: Mission,
     pub surface_thread: Option<SurfaceThread>,
     pub work_item: WorkItem,
+    pub body_snapshot: Option<MissionBodySnapshot>,
     pub includes_sensitive_context: bool,
 }
 
@@ -162,12 +163,13 @@ pub fn preflight_and_stage_work_item_with_workspace_claims(
     // conversation+intent duplicate guard then matched and BLOCKED a clean retry against (binding the
     // surface to the orphan). `stage_intake_atomic` writes all-or-nothing (and busy-retries under
     // reaper/retention WAL contention), so a failure writes ZERO rows and a retry is clean.
-    db.stage_intake_atomic_with_workspace_claims(
+    db.stage_intake_atomic_with_workspace_claims_and_body_snapshot(
         &conversation,
         &mission,
         surface_thread.as_ref(),
         &work_item,
         workspace_claims,
+        request.body_snapshot.as_ref(),
     )?;
 
     Ok(MissionPreflightOutcome::Ready {
@@ -1076,6 +1078,7 @@ mod tests {
             mission: mission(mission_id, intent, context_passport_refs, now),
             surface_thread: Some(surface(mission_id, now)),
             work_item: work_item(work_item_id, mission_id, lane, Vec::new(), now),
+            body_snapshot: None,
             includes_sensitive_context: sensitive,
         }
     }

--- a/rust-core/crates/friday-hub/src/provider_dispatch_adapter.rs
+++ b/rust-core/crates/friday-hub/src/provider_dispatch_adapter.rs
@@ -15,8 +15,9 @@
 //!   - [`ProviderWorkspaceAction::ListSessions`] → `CodexAppServerClient::list_threads`
 //!   - [`ProviderWorkspaceAction::StartSession`] → `CodexAppServerClient::start_thread`
 //! It can also route Codex `send_turn` when tests or a future live caller inject a prompt
-//! body resolver and the context carries a provider thread id. The current Hub selection
-//! intentionally injects no prompt resolver, so production remains fail-closed / DARK.
+//! body resolver and the context carries a provider thread id. The current Hub selection can
+//! inject the Mission body snapshot resolver, but production remains fail-closed / DARK because
+//! the flag is default-OFF and no `friday_current()` send-turn capability is `Verified`.
 //!
 //! Every OTHER action returns a typed [`DispatchError::AdapterNotReady`] with a code-only
 //! (secret-free) reason, NOT a fake success. The deferrals are honest and structural:
@@ -25,8 +26,8 @@
 //!   - Interrupt / Steer also need a provider `turn_id` (the session's `active_turn_id` is
 //!     not threaded through the dispatch context).
 //!   - Steer still needs both a provider `turn_id` and prompt text.
-//!   - Send needs prompt text and a provider thread id; the resolver seam exists here, but
-//!     the live Hub injects no resolver until a real body store / intake body snapshot lands.
+//!   - Send needs prompt text and a provider thread id; the resolver reads only a Mission-intake
+//!     body snapshot bound to the resolved WorkItem input refs.
 //!   - Fork / ApproveOrReject / AnswerQuestion have NO standalone client method (approve /
 //!     answer exist only as the in-turn handler inside `run_turn_with_handler`).
 //!   - OpenProviderNative is the unsupported / operator-gated native-link surface.
@@ -62,6 +63,7 @@ use friday_providers::codex_appserver::{
     CodexAppServerClient, CodexAppServerError, CodexAppServerTransport, LocalCodexAppServer,
     TurnSummary,
 };
+use friday_storage::Db;
 
 use crate::provider_dispatch::{
     DispatchContext, DispatchError, DispatchOutcome, DispatchStatus, ProviderDispatchAdapter,
@@ -224,6 +226,65 @@ impl PromptBodyResolver for NoPromptBodyResolver {
         Err(DispatchError::AdapterNotReady(
             "prompt_body_resolver_not_wired".to_string(),
         ))
+    }
+}
+
+pub struct DbPromptBodyResolver<'a> {
+    db: &'a Db,
+}
+
+impl<'a> DbPromptBodyResolver<'a> {
+    pub fn new(db: &'a Db) -> Self {
+        Self { db }
+    }
+}
+
+impl PromptBodyResolver for DbPromptBodyResolver<'_> {
+    fn resolve_prompt(&self, ctx: &DispatchContext<'_>) -> Result<String, DispatchError> {
+        let body_ref = ctx.payload_ref.ok_or_else(|| {
+            DispatchError::AdapterNotReady("prompt_body_ref_required".to_string())
+        })?;
+        if !ctx
+            .work_item_input_refs
+            .iter()
+            .any(|input| input == body_ref)
+        {
+            return Err(DispatchError::AdapterNotReady(
+                "prompt_body_ref_not_bound_to_work_item".to_string(),
+            ));
+        }
+        let mission = self
+            .db
+            .get_mission(&ctx.mission_context.mission_id)
+            .map_err(|_| {
+                DispatchError::AdapterNotReady("prompt_body_mission_lookup_failed".to_string())
+            })?
+            .ok_or_else(|| {
+                DispatchError::AdapterNotReady("prompt_body_mission_missing".to_string())
+            })?;
+        let conversation = self
+            .db
+            .get_friday_conversation(&mission.friday_conversation_id)
+            .map_err(|_| {
+                DispatchError::AdapterNotReady("prompt_body_conversation_lookup_failed".to_string())
+            })?
+            .ok_or_else(|| {
+                DispatchError::AdapterNotReady("prompt_body_conversation_missing".to_string())
+            })?;
+        let snapshot = self
+            .db
+            .get_mission_body_snapshot(
+                &conversation.owner_principal,
+                &ctx.mission_context.work_item_id,
+                body_ref,
+            )
+            .map_err(|_| {
+                DispatchError::AdapterNotReady("prompt_body_snapshot_lookup_failed".to_string())
+            })?
+            .ok_or_else(|| {
+                DispatchError::AdapterNotReady("prompt_body_snapshot_missing".to_string())
+            })?;
+        Ok(snapshot.body)
     }
 }
 
@@ -442,7 +503,7 @@ mod tests {
         CapabilityStatus, FallbackStatus, PlatformProvider, ProviderCapability,
         ProviderNativeAction, ProviderSession, ProviderSyncMode, SessionStatus,
     };
-    use friday_storage::Db;
+    use friday_storage::{Db, MissionBodySnapshot};
     use std::sync::atomic::{AtomicU64, Ordering};
 
     static C: AtomicU64 = AtomicU64::new(0);
@@ -604,6 +665,17 @@ mod tests {
             updated_at_ms: now,
         })
         .unwrap();
+        let snapshot = MissionBodySnapshot::new(
+            "owner-1",
+            "mission-1",
+            "work-1",
+            "friday://body/request/1",
+            "provider_workspace",
+            "Say exactly READY.",
+            now,
+        )
+        .unwrap();
+        db.upsert_mission_body_snapshot(&snapshot).unwrap();
         db
     }
 
@@ -717,6 +789,30 @@ mod tests {
             &adapter,
             &session(),
             &db_with_context(),
+            req("send_turn", "provider.codex.send_turn"),
+        );
+        assert!(result.accepted);
+        assert!(result.routed);
+        assert_eq!(result.status, "dispatched_running");
+        assert!(result.blocker.is_none());
+        assert!(result.dispatch_ref.is_some());
+        assert_eq!(result.truth_label, "verified test catalog");
+    }
+
+    #[test]
+    fn flag_on_send_turn_with_db_prompt_resolver_routes_to_turn_start() {
+        let db = db_with_context();
+        let adapter = ProviderWorkspaceDispatchAdapter::with_prompt_resolver(
+            transport_client(vec![ok(json!({
+                "turn": { "id": "turn-db", "status": "inProgress", "items": [] }
+            }))]),
+            DbPromptBodyResolver::new(&db),
+        );
+        let result = dispatch_provider_action(
+            &verified_codex_catalog(),
+            &adapter,
+            &session(),
+            &db,
             req("send_turn", "provider.codex.send_turn"),
         );
         assert!(result.accepted);

--- a/rust-core/crates/friday-storage/src/lib.rs
+++ b/rust-core/crates/friday-storage/src/lib.rs
@@ -57,6 +57,7 @@ pub use error::{Result, StorageError};
 pub use migrate::{
     apply_migrations, current_version, now_ms, Migration, MigrationFn, MigrationReport,
 };
+pub use mission::MissionBodySnapshot;
 pub use passport::{get_context_passport, list_for_mission, upsert_context_passport};
 pub use pending_request::{
     get_pending_request, insert_pending_approval_activity, list_pending_requests_for_run,
@@ -710,6 +711,26 @@ impl Db {
         work_item: &WorkItem,
         workspace_claims: &[WorkspaceClaim],
     ) -> Result<()> {
+        self.stage_intake_atomic_with_workspace_claims_and_body_snapshot(
+            conversation,
+            mission,
+            surface_thread,
+            work_item,
+            workspace_claims,
+            None,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn stage_intake_atomic_with_workspace_claims_and_body_snapshot(
+        &self,
+        conversation: &FridayConversation,
+        mission: &Mission,
+        surface_thread: Option<&SurfaceThread>,
+        work_item: &WorkItem,
+        workspace_claims: &[WorkspaceClaim],
+        body_snapshot: Option<&MissionBodySnapshot>,
+    ) -> Result<()> {
         if self.profile != Profile::Hub {
             return Err(StorageError::Unsupported(
                 "mission intake is Hub-only".into(),
@@ -726,6 +747,18 @@ impl Db {
             mission::upsert_work_item(&tx, work_item)?;
             for claim in workspace_claims {
                 process_registry::upsert_workspace_claim(&tx, claim)?;
+            }
+            if let Some(snapshot) = body_snapshot {
+                mission::upsert_mission_body_snapshot(
+                    &tx,
+                    &snapshot.owner_principal,
+                    &snapshot.mission_id,
+                    &snapshot.work_item_id,
+                    &snapshot.body_ref,
+                    &snapshot.source_surface,
+                    &snapshot.body,
+                    snapshot.created_at_ms,
+                )?;
             }
             tx.commit()?;
             Ok(())
@@ -832,6 +865,41 @@ impl Db {
             return Err(StorageError::Unsupported("WorkItems are Hub-only".into()));
         }
         mission::get_work_item(&self.conn, work_item_id)
+    }
+
+    pub fn get_mission_body_snapshot(
+        &self,
+        owner_principal: &str,
+        work_item_id: &str,
+        body_ref: &str,
+    ) -> Result<Option<MissionBodySnapshot>> {
+        if self.profile != Profile::Hub {
+            return Err(StorageError::Unsupported(
+                "Mission body snapshots are Hub-only".into(),
+            ));
+        }
+        mission::get_mission_body_snapshot(&self.conn, owner_principal, work_item_id, body_ref)
+    }
+
+    pub fn upsert_mission_body_snapshot(
+        &self,
+        snapshot: &MissionBodySnapshot,
+    ) -> Result<MissionBodySnapshot> {
+        if self.profile != Profile::Hub {
+            return Err(StorageError::Unsupported(
+                "Mission body snapshots are Hub-only".into(),
+            ));
+        }
+        mission::upsert_mission_body_snapshot(
+            &self.conn,
+            &snapshot.owner_principal,
+            &snapshot.mission_id,
+            &snapshot.work_item_id,
+            &snapshot.body_ref,
+            &snapshot.source_surface,
+            &snapshot.body,
+            snapshot.created_at_ms,
+        )
     }
 
     #[allow(clippy::too_many_arguments)]

--- a/rust-core/crates/friday-storage/src/mission.rs
+++ b/rust-core/crates/friday-storage/src/mission.rs
@@ -17,6 +17,7 @@ use friday_core::{
     TruthStatus, VisibilityPolicy, WorkItem, WorkItemStatus, WorkLane,
 };
 use rusqlite::{params, Connection, OptionalExtension};
+use sha2::{Digest, Sha256};
 
 fn unsupported(message: impl Into<String>) -> StorageError {
     StorageError::Unsupported(message.into())
@@ -358,16 +359,88 @@ fn validate_work_item(item: &WorkItem) -> Result<()> {
 fn require_safe_surface_body_ref(value: &str, field: &str) -> Result<()> {
     require_non_empty(value, field)?;
     let trimmed = value.trim();
-    if trimmed.starts_with("friday://body/")
-        || trimmed.starts_with("friday://surface-event-body/")
-        || trimmed.starts_with("blob://")
-    {
+    if is_safe_body_ref(trimmed) {
         Ok(())
     } else {
         Err(unsupported(format!(
             "surface_event {field} must be a Friday-owned body/blob ref"
         )))
     }
+}
+
+fn is_safe_body_ref(value: &str) -> bool {
+    value.starts_with("friday://body/")
+        || value.starts_with("friday://surface-event-body/")
+        || value.starts_with("blob://")
+}
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    let digest = Sha256::digest(bytes);
+    format!("{digest:x}")
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct MissionBodySnapshot {
+    pub body_ref: String,
+    pub owner_principal: String,
+    pub mission_id: String,
+    pub work_item_id: String,
+    pub source_surface: String,
+    pub body: String,
+    pub body_sha256: String,
+    pub body_len: i64,
+    pub created_at_ms: i64,
+}
+
+impl MissionBodySnapshot {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        owner_principal: &str,
+        mission_id: &str,
+        work_item_id: &str,
+        body_ref: &str,
+        source_surface: &str,
+        body: &str,
+        created_at_ms: i64,
+    ) -> Result<Self> {
+        let body_len = i64::try_from(body.len()).map_err(|_| {
+            unsupported("mission_body_snapshot.body length exceeds SQLite INTEGER range")
+        })?;
+        let snapshot = Self {
+            body_ref: body_ref.to_string(),
+            owner_principal: owner_principal.to_string(),
+            mission_id: mission_id.to_string(),
+            work_item_id: work_item_id.to_string(),
+            source_surface: source_surface.to_string(),
+            body: body.to_string(),
+            body_sha256: sha256_hex(body.as_bytes()),
+            body_len,
+            created_at_ms,
+        };
+        validate_mission_body_snapshot(&snapshot)?;
+        Ok(snapshot)
+    }
+}
+
+fn validate_mission_body_snapshot(snapshot: &MissionBodySnapshot) -> Result<()> {
+    require_non_empty(&snapshot.body_ref, "mission_body_snapshot.body_ref")?;
+    require_non_empty(
+        &snapshot.owner_principal,
+        "mission_body_snapshot.owner_principal",
+    )?;
+    require_non_empty(&snapshot.mission_id, "mission_body_snapshot.mission_id")?;
+    require_non_empty(&snapshot.work_item_id, "mission_body_snapshot.work_item_id")?;
+    require_non_empty(
+        &snapshot.source_surface,
+        "mission_body_snapshot.source_surface",
+    )?;
+    require_non_empty(&snapshot.body, "mission_body_snapshot.body")?;
+    if !is_safe_body_ref(snapshot.body_ref.trim()) {
+        return Err(unsupported(
+            "mission_body_snapshot.body_ref must be a Friday-owned body/blob ref",
+        ));
+    }
+    Ok(())
 }
 
 fn require_safe_surface_proof_ref(value: &str, field: &str) -> Result<()> {
@@ -1432,6 +1505,125 @@ pub fn upsert_work_item(conn: &Connection, item: &WorkItem) -> Result<()> {
         ],
     )?;
     Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn upsert_mission_body_snapshot(
+    conn: &Connection,
+    owner_principal: &str,
+    mission_id: &str,
+    work_item_id: &str,
+    body_ref: &str,
+    source_surface: &str,
+    body: &str,
+    created_at_ms: i64,
+) -> Result<MissionBodySnapshot> {
+    let snapshot = MissionBodySnapshot::new(
+        owner_principal,
+        mission_id,
+        work_item_id,
+        body_ref,
+        source_surface,
+        body,
+        created_at_ms,
+    )?;
+
+    let existing = conn
+        .query_row(
+            "SELECT owner_principal, mission_id, work_item_id, body_sha256, body_len
+             FROM mission_body_snapshot WHERE body_ref = ?1",
+            params![&snapshot.body_ref],
+            |r| {
+                Ok((
+                    r.get::<_, String>(0)?,
+                    r.get::<_, String>(1)?,
+                    r.get::<_, String>(2)?,
+                    r.get::<_, String>(3)?,
+                    r.get::<_, i64>(4)?,
+                ))
+            },
+        )
+        .optional()?;
+    if let Some((owner, mission, work_item, sha, len)) = existing {
+        if owner == snapshot.owner_principal
+            && mission == snapshot.mission_id
+            && work_item == snapshot.work_item_id
+            && sha == snapshot.body_sha256
+            && len == snapshot.body_len
+        {
+            return Ok(snapshot);
+        }
+        return Err(unsupported(format!(
+            "mission_body_snapshot '{}' already exists with a different binding or body",
+            snapshot.body_ref
+        )));
+    }
+
+    conn.execute(
+        "INSERT INTO mission_body_snapshot
+            (body_ref, owner_principal, mission_id, work_item_id, source_surface,
+             body, body_sha256, body_len, created_at_ms)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+        params![
+            &snapshot.body_ref,
+            &snapshot.owner_principal,
+            &snapshot.mission_id,
+            &snapshot.work_item_id,
+            &snapshot.source_surface,
+            &snapshot.body,
+            &snapshot.body_sha256,
+            snapshot.body_len,
+            snapshot.created_at_ms,
+        ],
+    )?;
+    Ok(snapshot)
+}
+
+pub fn get_mission_body_snapshot(
+    conn: &Connection,
+    owner_principal: &str,
+    work_item_id: &str,
+    body_ref: &str,
+) -> Result<Option<MissionBodySnapshot>> {
+    require_non_empty(owner_principal, "mission_body_snapshot.owner_principal")?;
+    require_non_empty(work_item_id, "mission_body_snapshot.work_item_id")?;
+    require_non_empty(body_ref, "mission_body_snapshot.body_ref")?;
+    let snapshot = conn
+        .query_row(
+            "SELECT body_ref, owner_principal, mission_id, work_item_id, source_surface,
+                    body, body_sha256, body_len, created_at_ms
+             FROM mission_body_snapshot
+             WHERE owner_principal = ?1 AND work_item_id = ?2 AND body_ref = ?3",
+            params![owner_principal, work_item_id, body_ref],
+            |r| {
+                Ok(MissionBodySnapshot {
+                    body_ref: r.get(0)?,
+                    owner_principal: r.get(1)?,
+                    mission_id: r.get(2)?,
+                    work_item_id: r.get(3)?,
+                    source_surface: r.get(4)?,
+                    body: r.get(5)?,
+                    body_sha256: r.get(6)?,
+                    body_len: r.get(7)?,
+                    created_at_ms: r.get(8)?,
+                })
+            },
+        )
+        .optional()?;
+    if let Some(snapshot) = snapshot {
+        let derived_sha = sha256_hex(snapshot.body.as_bytes());
+        let derived_len = i64::try_from(snapshot.body.len()).map_err(|_| {
+            unsupported("mission_body_snapshot.body length exceeds SQLite INTEGER range")
+        })?;
+        if snapshot.body_sha256 != derived_sha || snapshot.body_len != derived_len {
+            return Err(unsupported(format!(
+                "mission_body_snapshot '{}' fingerprint mismatch",
+                snapshot.body_ref
+            )));
+        }
+        return Ok(Some(snapshot));
+    }
+    Ok(None)
 }
 
 /// (#24b degrade-3 fix) `upsert_work_item` followed by clearing the durable `executing` marker

--- a/rust-core/crates/friday-storage/src/schema.rs
+++ b/rust-core/crates/friday-storage/src/schema.rs
@@ -46,6 +46,7 @@ pub const HUB_ONLY_TABLES: &[&str] = &[
     "mission_link",
     "route_decision",
     "route_decision_control",
+    "mission_body_snapshot",
     // Process Registry: Hub-owned workspace/process/port truth. Phone/channel
     // surfaces may see projections; only the Hub can own/control claims.
     "workspace_claim",
@@ -665,6 +666,16 @@ pub fn hub_migrations() -> Vec<Migration> {
             name: "tool_usage_ledger",
             destructive: false,
             up: m0039_tool_usage_ledger,
+        },
+        // C1/C2 dispatch: Hub-only mission-intake prompt snapshots. Provider
+        // workspace send_turn reads prompt text only through a body_ref that is
+        // bound to the authenticated owner + WorkItem input_refs; phone/surface
+        // projections remain refs-only.
+        Migration {
+            version: 40,
+            name: "mission_body_snapshot",
+            destructive: false,
+            up: m0040_mission_body_snapshot,
         },
     ]
 }
@@ -1807,6 +1818,23 @@ CREATE INDEX idx_run_outcome_learning_candidate_state_created
 CREATE INDEX idx_run_outcome_learning_candidate_run_kind
     ON run_outcome_learning_candidate(run_id, kind);";
 
+const DDL_MISSION_BODY_SNAPSHOT: &str = "
+CREATE TABLE mission_body_snapshot (
+    body_ref        TEXT PRIMARY KEY CHECK(length(trim(body_ref)) > 0),
+    owner_principal TEXT NOT NULL CHECK(length(trim(owner_principal)) > 0),
+    mission_id      TEXT NOT NULL CHECK(length(trim(mission_id)) > 0),
+    work_item_id    TEXT NOT NULL CHECK(length(trim(work_item_id)) > 0),
+    source_surface  TEXT NOT NULL CHECK(length(trim(source_surface)) > 0),
+    body            TEXT NOT NULL CHECK(length(trim(body)) > 0),
+    body_sha256     TEXT NOT NULL CHECK(length(body_sha256) = 64),
+    body_len        INTEGER NOT NULL CHECK(body_len >= 0),
+    created_at_ms   INTEGER NOT NULL,
+    FOREIGN KEY(mission_id) REFERENCES mission(mission_id),
+    FOREIGN KEY(work_item_id) REFERENCES work_item(work_item_id)
+);
+CREATE INDEX idx_mission_body_snapshot_work_item
+    ON mission_body_snapshot(owner_principal, work_item_id, body_ref);";
+
 const DDL_REBUILD_MISSION_LINK_WITH_ROUTE_DECISION: &str = "
 CREATE TABLE mission_link_new (
     link_id        TEXT PRIMARY KEY,
@@ -2584,4 +2612,8 @@ fn m0038_run_outcome_learning_candidate(tx: &Transaction) -> rusqlite::Result<()
 
 fn m0039_tool_usage_ledger(tx: &Transaction) -> rusqlite::Result<()> {
     tx.execute_batch(DDL_TOOL_USAGE_LEDGER)
+}
+
+fn m0040_mission_body_snapshot(tx: &Transaction) -> rusqlite::Result<()> {
+    tx.execute_batch(DDL_MISSION_BODY_SNAPSHOT)
 }

--- a/src/state/sqlite/friday-rust-hub-schema-handshake.ts
+++ b/src/state/sqlite/friday-rust-hub-schema-handshake.ts
@@ -6,7 +6,7 @@ import Database from "better-sqlite3";
 import { FridayDomainError } from "#errors";
 
 export const FRIDAY_HUB_AGENT_RUN_DB_PATH_ENV = "FRIDAY_HUB_AGENT_RUN_DB_PATH";
-export const FRIDAY_EXPECTED_RUST_HUB_SCHEMA_VERSION = 39;
+export const FRIDAY_EXPECTED_RUST_HUB_SCHEMA_VERSION = 40;
 
 export type FridayRustHubSchemaHandshakeStatus = "ok" | "skipped";
 


### PR DESCRIPTION
## Summary
- add Hub-only mission_body_snapshot storage (v40) for Mission intake prompt bodies bound to owner + WorkItem + body_ref
- write the snapshot atomically with Mission intake Ready preflight rows
- wire ProviderWorkspace send_turn to a DbPromptBodyResolver while keeping default-OFF / unverified catalog fail-closed

## Truth labels
- build-DARK / fail-closed: flag default-OFF and friday_current() send_turn remains not Verified
- no provider spend, no organic traffic, no live-product claim
- this removes the prompt-body gap for the provider workspace resolver seam only

## Validation
- cargo fmt --all --check
- cargo check -p friday-storage -p friday-hub --tests
- cargo clippy -p friday-storage -p friday-hub --tests -- -D warnings
- cargo test -p friday-hub provider_dispatch_adapter -- --nocapture
- cargo test -p friday-hub provider_dispatch -- --nocapture
- cargo test -p friday-hub mission_intake_writes_body_snapshot_bound_to_work_item_input_ref -- --nocapture