### PR TITLE
[codex] add run outcome learning decision caller

### DIFF
--- a/rust-core/crates/friday-ffi/src/lib.rs
+++ b/rust-core/crates/friday-ffi/src/lib.rs
@@ -2009,6 +2009,11 @@ fn message_kind_name(m: &friday_protocol::Message) -> &'static str {
         // stays exhaustive.
         M::MemoryDecisionRequest { .. } => "MemoryDecisionRequest",
         M::MemoryDecisionResult { .. } => "MemoryDecisionResult",
+        // A1 run-outcome learning terminal decision arm. DARK on the FFI surface (the owner-authed
+        // decision rides the sealed-WS agent-run server arm gated by
+        // FRIDAY_RUN_OUTCOME_LEARNING_CONFIRM); NAMED so unsupported envelopes keep the real kind.
+        M::RunOutcomeLearningDecisionRequest { .. } => "RunOutcomeLearningDecisionRequest",
+        M::RunOutcomeLearningDecisionResult { .. } => "RunOutcomeLearningDecisionResult",
         M::Error { .. } => "Error",
     }
 }
@@ -3473,6 +3478,53 @@ mod tests {
         );
         match parse_hub_response(request.encode().unwrap()) {
             AskResponseFfi::Unsupported { kind } => assert_eq!(kind, "AgentRunRequest"),
+            other => panic!("expected Unsupported, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn ffi_unsupported_kind_carries_the_real_message_kind_name_for_a1_learning_decisions() {
+        use friday_protocol::{
+            Envelope, Message, RunOutcomeLearningDecisionRequestWire,
+            RunOutcomeLearningDecisionResultWire,
+        };
+
+        let request = Envelope::new(
+            "a1d1",
+            0,
+            Message::RunOutcomeLearningDecisionRequest {
+                request: RunOutcomeLearningDecisionRequestWire {
+                    candidate_id: "cand-1".into(),
+                    decision: "confirm".into(),
+                    reason: Some("useful".into()),
+                },
+            },
+        );
+        match parse_hub_response(request.encode().unwrap()) {
+            AskResponseFfi::Unsupported { kind } => {
+                assert_eq!(kind, "RunOutcomeLearningDecisionRequest")
+            }
+            other => panic!("expected Unsupported, got {other:?}"),
+        }
+
+        let result = Envelope::new(
+            "a1d2",
+            0,
+            Message::RunOutcomeLearningDecisionResult {
+                result: RunOutcomeLearningDecisionResultWire {
+                    candidate_id: "cand-1".into(),
+                    run_id: Some("run-1".into()),
+                    kind: Some("preference".into()),
+                    state: "confirmed".into(),
+                    status: "ok".into(),
+                    blocker: None,
+                },
+            },
+        );
+        match parse_hub_response(result.encode().unwrap()) {
+            AskResponseFfi::Unsupported { kind } => {
+                assert_eq!(kind, "RunOutcomeLearningDecisionResult")
+            }
             other => panic!("expected Unsupported, got {other:?}"),
         }
     }

--- a/rust-core/crates/friday-hub/src/bin/hub_agent_run_server.rs
+++ b/rust-core/crates/friday-hub/src/bin/hub_agent_run_server.rs
@@ -510,6 +510,21 @@ fn run() -> Result<(), ServerError> {
         );
     }
 
+    let run_outcome_learning_confirm_enabled = run_outcome_learning_confirm_enabled_from(
+        env::var(RUN_OUTCOME_LEARNING_CONFIRM_ENABLED_ENV)
+            .ok()
+            .as_deref(),
+    );
+    if run_outcome_learning_confirm_enabled {
+        eprintln!(
+            "hub_agent_run_server: RUN-OUTCOME-LEARNING confirm ENABLED (FRIDAY_RUN_OUTCOME_LEARNING_CONFIRM) — an inbound owner-authed RunOutcomeLearningDecisionRequest confirms/rejects a refs-only candidate (no model call)"
+        );
+    } else {
+        eprintln!(
+            "hub_agent_run_server: RUN-OUTCOME-LEARNING confirm DISABLED (set FRIDAY_RUN_OUTCOME_LEARNING_CONFIRM=1 to enable) — a RunOutcomeLearningDecisionRequest is a benign keepalive echo"
+        );
+    }
+
     // (C1/C2 §3) Read the PROVIDER-WORKSPACE-DISPATCH flag ONCE at boot (default-off). It gates the
     // serve-bin's `ProviderWorkspaceActionRequest` arm: when false the dispatch arm NEVER handles a
     // `ProviderWorkspaceActionRequest` — it falls through to the EXISTING catch-all keepalive echo
@@ -578,6 +593,7 @@ fn run() -> Result<(), ServerError> {
             mission_intake_enabled,
             mission_spine_dispatch_enabled,
             memory_confirm_enabled,
+            run_outcome_learning_confirm_enabled,
             token_surface_enabled,
             provider_workspace_dispatch_enabled,
         ) {
@@ -731,6 +747,12 @@ const MEMORY_CONFIRM_ENABLED_ENV: &str = "FRIDAY_MEMORY_CONFIRM";
 /// ON only for the exact opt-in value `"1"` (trimmed), matching the program's standard flag idiom;
 /// everything else (including `"true"`) ⇒ false.
 fn memory_confirm_enabled_from(raw: Option<&str>) -> bool {
+    matches!(raw.map(str::trim), Some("1"))
+}
+
+const RUN_OUTCOME_LEARNING_CONFIRM_ENABLED_ENV: &str = "FRIDAY_RUN_OUTCOME_LEARNING_CONFIRM";
+
+fn run_outcome_learning_confirm_enabled_from(raw: Option<&str>) -> bool {
     matches!(raw.map(str::trim), Some("1"))
 }
 
@@ -1141,6 +1163,7 @@ impl AgentRunWsListener {
         mission_intake_enabled: bool,
         mission_spine_dispatch_enabled: bool,
         memory_confirm_enabled: bool,
+        run_outcome_learning_confirm_enabled: bool,
         token_surface_enabled: bool,
         provider_workspace_dispatch_enabled: bool,
     ) -> Result<usize, TransportError> {
@@ -1161,6 +1184,7 @@ impl AgentRunWsListener {
             mission_intake_enabled,
             mission_spine_dispatch_enabled,
             memory_confirm_enabled,
+            run_outcome_learning_confirm_enabled,
             token_surface_enabled,
             provider_workspace_dispatch_enabled,
         )
@@ -1207,6 +1231,7 @@ fn serve_sealed_session<S: Read + Write, T: Transport>(
     mission_intake_enabled: bool,
     mission_spine_dispatch_enabled: bool,
     memory_confirm_enabled: bool,
+    run_outcome_learning_confirm_enabled: bool,
     token_surface_enabled: bool,
     provider_workspace_dispatch_enabled: bool,
 ) -> Result<usize, TransportError> {
@@ -1878,6 +1903,24 @@ fn serve_sealed_session<S: Read + Write, T: Transport>(
                 ws_send_envelope(ws, session_key, &result, SESSION_AAD)?;
                 processed += 1;
             }
+            Message::RunOutcomeLearningDecisionRequest { request }
+                if run_outcome_learning_confirm_enabled =>
+            {
+                let now_ms = now_ms();
+                let result = friday_hub::hub_server::run_outcome_learning_decision_result_for_db(
+                    runtime.db(),
+                    &env.msg_id,
+                    request,
+                    runtime.policy().principal_id(),
+                    now_ms,
+                );
+                eprintln!(
+                    "hub_agent_run_server_dispatch: msg_id={} leg=run_outcome_learning_decision (run-outcome-learning confirm enabled)",
+                    env.msg_id
+                );
+                ws_send_envelope(ws, session_key, &result, SESSION_AAD)?;
+                processed += 1;
+            }
             // (C1/C2 §3) PROVIDER-WORKSPACE dispatch — FLAG-GATED. When `FRIDAY_PROVIDER_WORKSPACE_DISPATCH`
             // is ON, an inbound `ProviderWorkspaceActionRequest` is routed through the EXISTING
             // `friday_hub::hub_server::provider_workspace_action_result_for_db` — the SAME GATE-FIRST
@@ -2529,6 +2572,7 @@ mod tests {
                 false,
                 false, // (KEYSTONE) mission-spine dispatch OFF — byte-identical to today
                 false, // memory-confirm ingress OFF — byte-identical to today
+                false, // run-outcome-learning confirm OFF — byte-identical to today
                 false, // (Loop4) per-run token surface OFF — byte-identical to today
                 false, // (C1/C2) provider-workspace dispatch OFF — byte-identical to today
             )
@@ -2609,6 +2653,7 @@ mod tests {
                 false, // mission-intake ingress OFF
                 false, // mission-spine dispatch OFF
                 false, // memory-confirm ingress OFF
+                false, // run-outcome-learning confirm OFF — byte-identical to today
                 false, // token surface OFF
                 false, // provider-workspace dispatch OFF
             )
@@ -2738,6 +2783,7 @@ mod tests {
                 false, // (NS-5) mission-intake ingress OFF for the run-control flag tests
                 false, // (KEYSTONE) mission-spine dispatch OFF for the run-control flag tests
                 false, // memory-confirm ingress OFF — byte-identical to today
+                false, // run-outcome-learning confirm OFF — byte-identical to today
                 false, // (Loop4) per-run token surface OFF — byte-identical to today
                 false, // (C1/C2) provider-workspace dispatch OFF — byte-identical to today
             )
@@ -2975,6 +3021,7 @@ mod tests {
                     false, // mission-intake ingress OFF
                     false, // mission-spine dispatch OFF
                     false, // memory-confirm ingress OFF
+                    false, // run-outcome-learning confirm OFF — byte-identical to today
                     token_surface_enabled,
                     false, // (C1/C2) provider-workspace dispatch OFF — byte-identical to today
                 )
@@ -3071,6 +3118,7 @@ mod tests {
                 false,
                 false, // (KEYSTONE) mission-spine dispatch OFF — byte-identical to today
                 false, // memory-confirm ingress OFF — byte-identical to today
+                false, // run-outcome-learning confirm OFF — byte-identical to today
                 false, // (Loop4) per-run token surface OFF — byte-identical to today
                 false, // (C1/C2) provider-workspace dispatch OFF — byte-identical to today
             )
@@ -3117,6 +3165,7 @@ mod tests {
                 false,
                 false, // (KEYSTONE) mission-spine dispatch OFF — byte-identical to today
                 false, // memory-confirm ingress OFF — byte-identical to today
+                false, // run-outcome-learning confirm OFF — byte-identical to today
                 false, // (Loop4) per-run token surface OFF — byte-identical to today
                 false, // (C1/C2) provider-workspace dispatch OFF — byte-identical to today
             )
@@ -3385,6 +3434,7 @@ mod tests {
                 true,  // (NS-5) mission-intake ingress ON
                 false, // (KEYSTONE) mission-spine dispatch OFF for the mission-intake test
                 false, // memory-confirm ingress OFF — byte-identical to today
+                false, // run-outcome-learning confirm OFF — byte-identical to today
                 false, // (Loop4) per-run token surface OFF — byte-identical to today
                 false, // (C1/C2) provider-workspace dispatch OFF — byte-identical to today
             )
@@ -3489,6 +3539,7 @@ mod tests {
                 false, // (NS-5) mission-intake ingress OFF — byte-identical to today
                 false, // (KEYSTONE) mission-spine dispatch OFF — byte-identical to today
                 false, // memory-confirm ingress OFF — byte-identical to today
+                false, // run-outcome-learning confirm OFF — byte-identical to today
                 false, // (Loop4) per-run token surface OFF — byte-identical to today
                 false, // (C1/C2) provider-workspace dispatch OFF — byte-identical to today
             )
@@ -3566,6 +3617,7 @@ mod tests {
                 true,  // (NS-5) mission-intake ingress ON
                 false, // (KEYSTONE) mission-spine dispatch OFF
                 false, // memory-confirm ingress OFF
+                false, // run-outcome-learning confirm OFF — byte-identical to today
                 false, // (Loop4) per-run token surface OFF
                 false, // (C1/C2) provider-workspace dispatch OFF — byte-identical to today
             )
@@ -3646,6 +3698,7 @@ mod tests {
                 false,
                 false,
                 true, // mission-intake ON
+                false,
                 false,
                 false,
                 false,
@@ -3861,6 +3914,7 @@ mod tests {
                 false, // mission-intake ingress OFF
                 false, // mission-spine dispatch OFF
                 false, // memory-confirm ingress OFF
+                false, // run-outcome-learning confirm OFF — byte-identical to today
                 false, // (Loop4) per-run token surface OFF
                 false, // (C1/C2) provider-workspace dispatch OFF — the bit under test
             )
@@ -3914,6 +3968,7 @@ mod tests {
                 &rt,
                 &allowlist,
                 &peer_allowlist,
+                false,
                 false,
                 false,
                 false,
@@ -3978,6 +4033,7 @@ mod tests {
                 &rt,
                 &allowlist,
                 &peer_allowlist,
+                false,
                 false,
                 false,
                 false,
@@ -4104,6 +4160,185 @@ mod tests {
         );
     }
 
+    #[test]
+    fn run_outcome_learning_confirm_flag_is_default_off_and_fail_closed() {
+        assert!(!run_outcome_learning_confirm_enabled_from(None));
+        assert!(!run_outcome_learning_confirm_enabled_from(Some("")));
+        assert!(!run_outcome_learning_confirm_enabled_from(Some("0")));
+        assert!(!run_outcome_learning_confirm_enabled_from(Some("true")));
+        assert!(run_outcome_learning_confirm_enabled_from(Some("1")));
+        assert!(run_outcome_learning_confirm_enabled_from(Some(" 1 ")));
+    }
+
+    fn seed_run_outcome_learning_candidate<T: Transport>(
+        rt: &HubRuntime<T>,
+        run_id: &str,
+        session_id: &str,
+    ) {
+        friday_storage::ensure_session_with_owner(
+            rt.db().conn(),
+            session_id,
+            &friday_storage::SessionOwner {
+                user_id: Some(OWNER.to_string()),
+                ..Default::default()
+            },
+            1_000,
+        )
+        .unwrap();
+        friday_storage::agent_run::create_run(rt.db().conn(), run_id, "refs-only task", 1_000)
+            .unwrap();
+        friday_storage::learning_candidate::record_run_outcome_candidates(
+            rt.db().conn(),
+            run_id,
+            Some(session_id),
+            2,
+            1,
+            1_100,
+        )
+        .unwrap();
+    }
+
+    fn run_outcome_learning_decision_request(
+        msg_id: &str,
+        candidate_id: &str,
+        decision: &str,
+    ) -> Envelope {
+        Envelope::new(
+            msg_id,
+            1000,
+            Message::RunOutcomeLearningDecisionRequest {
+                request: friday_protocol::RunOutcomeLearningDecisionRequestWire {
+                    candidate_id: candidate_id.into(),
+                    decision: decision.into(),
+                    reason: Some("owner decision from sealed session".into()),
+                },
+            },
+        )
+    }
+
+    #[test]
+    fn flag_on_run_outcome_learning_decision_confirms_through_dispatch() {
+        let (rt, _ws) = mock_runtime("run-outcome-learning-on", OWNER);
+        seed_run_outcome_learning_candidate(&rt, "run-a1-wire", "sess-a1-wire");
+
+        let server_kp = DeviceKeypair::generate();
+        let listener = AgentRunWsListener::bind_loopback(0).unwrap();
+        let addr = listener.local_addr().unwrap();
+        let allowlist = vec![OWNER.to_string()];
+        let client_kp = DeviceKeypair::generate();
+        let peer_allowlist = allowlist_of(client_kp.public_bytes());
+        let client = spawn_client(addr, client_kp, |session, _nonce| {
+            let req = run_outcome_learning_decision_request(
+                "req-a1-learning-on",
+                "a1:run-a1-wire:preference",
+                "confirm",
+            );
+            (req, session.clone(), session.clone())
+        });
+
+        let processed = listener
+            .accept_one(
+                &server_kp,
+                &rt,
+                &allowlist,
+                &peer_allowlist,
+                false, // run-control OFF
+                false, // mission-bound seam OFF
+                false, // mission-intake ingress OFF
+                false, // mission-spine dispatch OFF
+                false, // memory-confirm ingress OFF
+                true,  // run-outcome-learning confirm ON
+                false, // token surface OFF
+                false, // provider-workspace dispatch OFF
+            )
+            .unwrap();
+        assert_eq!(processed, 1, "one run-outcome learning decision processed");
+
+        let Some(Message::RunOutcomeLearningDecisionResult { result }) =
+            client.join().unwrap().result.clone()
+        else {
+            panic!("flag ON must reply with RunOutcomeLearningDecisionResult");
+        };
+        assert_eq!(result.status, "confirmed");
+        assert_eq!(result.state, "confirmed");
+        assert_eq!(result.run_id.as_deref(), Some("run-a1-wire"));
+
+        let row = friday_storage::learning_candidate::get_run_outcome_candidate(
+            rt.db().conn(),
+            "a1:run-a1-wire:preference",
+        )
+        .unwrap()
+        .unwrap();
+        assert_eq!(
+            row.state,
+            friday_storage::learning_candidate::RunOutcomeLearningState::Confirmed
+        );
+        assert_eq!(
+            rt.db().count("token_ledger").unwrap(),
+            0,
+            "run-outcome learning decision makes NO model call"
+        );
+    }
+
+    #[test]
+    fn flag_off_run_outcome_learning_decision_is_keepalive_echo_and_changes_nothing() {
+        let (rt, _ws) = mock_runtime("run-outcome-learning-off", OWNER);
+        seed_run_outcome_learning_candidate(&rt, "run-a1-dark", "sess-a1-dark");
+
+        let server_kp = DeviceKeypair::generate();
+        let listener = AgentRunWsListener::bind_loopback(0).unwrap();
+        let addr = listener.local_addr().unwrap();
+        let allowlist = vec![OWNER.to_string()];
+        let client_kp = DeviceKeypair::generate();
+        let peer_allowlist = allowlist_of(client_kp.public_bytes());
+        let client = spawn_client(addr, client_kp, |session, _nonce| {
+            let req = run_outcome_learning_decision_request(
+                "req-a1-learning-off",
+                "a1:run-a1-dark:preference",
+                "confirm",
+            );
+            (req, session.clone(), session.clone())
+        });
+
+        let processed = listener
+            .accept_one(
+                &server_kp,
+                &rt,
+                &allowlist,
+                &peer_allowlist,
+                false, // run-control OFF
+                false, // mission-bound seam OFF
+                false, // mission-intake ingress OFF
+                false, // mission-spine dispatch OFF
+                false, // memory-confirm ingress OFF
+                false, // run-outcome-learning confirm OFF
+                false, // token surface OFF
+                false, // provider-workspace dispatch OFF
+            )
+            .unwrap();
+        assert_eq!(processed, 1, "the message is processed as a keepalive");
+
+        match client.join().unwrap().result.expect("an echo reply") {
+            Message::RunOutcomeLearningDecisionRequest { request } => {
+                assert_eq!(request.candidate_id, "a1:run-a1-dark:preference");
+                assert_eq!(request.decision, "confirm");
+            }
+            other => {
+                panic!("flag OFF must echo the RunOutcomeLearningDecisionRequest, got {other:?}")
+            }
+        }
+        let row = friday_storage::learning_candidate::get_run_outcome_candidate(
+            rt.db().conn(),
+            "a1:run-a1-dark:preference",
+        )
+        .unwrap()
+        .unwrap();
+        assert_eq!(
+            row.state,
+            friday_storage::learning_candidate::RunOutcomeLearningState::Pending
+        );
+    }
+
     /// Seed ONE pending, owner-owned, content-bearing memory candidate directly into the runtime's
     /// The COMPOSITE namespace OWNER's agent-run session resolves to — what the live extraction
     /// keys a candidate's `principal_id` on, and the SAME scope source the confirm dispatch arm
@@ -4189,6 +4424,7 @@ mod tests {
                 false, // mission-intake ingress OFF
                 false, // mission-spine dispatch OFF
                 true,  // memory-confirm ingress ON
+                false, // run-outcome-learning confirm OFF — byte-identical to today
                 false, // (Loop4) per-run token surface OFF — byte-identical to today
                 false, // (C1/C2) provider-workspace dispatch OFF — byte-identical to today
             )
@@ -4266,6 +4502,7 @@ mod tests {
                 false, // mission-intake ingress OFF
                 false, // mission-spine dispatch OFF
                 false, // memory-confirm ingress OFF — byte-identical to today
+                false, // run-outcome-learning confirm OFF — byte-identical to today
                 false, // (Loop4) per-run token surface OFF — byte-identical to today
                 false, // (C1/C2) provider-workspace dispatch OFF — byte-identical to today
             )
@@ -4480,6 +4717,7 @@ mod tests {
                 false, // mission-intake ingress OFF
                 true,  // (KEYSTONE) mission-spine dispatch ON
                 false, // memory-confirm ingress OFF — byte-identical to today
+                false, // run-outcome-learning confirm OFF — byte-identical to today
                 false, // (Loop4) per-run token surface OFF — byte-identical to today
                 false, // (C1/C2) provider-workspace dispatch OFF — byte-identical to today
             )
@@ -4569,6 +4807,7 @@ mod tests {
                 false,
                 true,  // (KEYSTONE) mission-spine dispatch ON
                 false, // memory-confirm ingress OFF — byte-identical to today
+                false, // run-outcome-learning confirm OFF — byte-identical to today
                 false, // (Loop4) per-run token surface OFF — byte-identical to today
                 false, // (C1/C2) provider-workspace dispatch OFF — byte-identical to today
             )
@@ -4651,6 +4890,7 @@ mod tests {
                 false,
                 true,  // (KEYSTONE) mission-spine dispatch ON
                 false, // memory-confirm ingress OFF — byte-identical to today
+                false, // run-outcome-learning confirm OFF — byte-identical to today
                 false, // (Loop4) per-run token surface OFF — byte-identical to today
                 false, // (C1/C2) provider-workspace dispatch OFF — byte-identical to today
             )
@@ -4720,6 +4960,7 @@ mod tests {
                 false,
                 true,  // (KEYSTONE) mission-spine dispatch ON
                 false, // memory-confirm ingress OFF — byte-identical to today
+                false, // run-outcome-learning confirm OFF — byte-identical to today
                 false, // (Loop4) per-run token surface OFF — byte-identical to today
                 false, // (C1/C2) provider-workspace dispatch OFF — byte-identical to today
             )
@@ -4771,6 +5012,7 @@ mod tests {
                 false,
                 false,
                 true, // mission-spine dispatch ON
+                false,
                 false,
                 false,
                 false, // (C1/C2) provider-workspace dispatch OFF
@@ -4828,6 +5070,7 @@ mod tests {
                 false,
                 false,
                 true, // mission-spine dispatch ON
+                false,
                 false,
                 false,
                 false, // (C1/C2) provider-workspace dispatch OFF
@@ -4897,6 +5140,7 @@ mod tests {
                 false,
                 true,  // mission-spine dispatch ON, including route controls
                 false, // memory-confirm ingress OFF
+                false, // run-outcome-learning confirm OFF — byte-identical to today
                 false, // (Loop4) per-run token surface OFF
                 false, // (C1/C2) provider-workspace dispatch OFF
             )
@@ -4964,6 +5208,7 @@ mod tests {
                     false,
                     false, // (KEYSTONE) mission-spine dispatch OFF
                     false, // memory-confirm ingress OFF — byte-identical to today
+                    false, // run-outcome-learning confirm OFF — byte-identical to today
                     false, // (Loop4) per-run token surface OFF — byte-identical to today
                     false, // (C1/C2) provider-workspace dispatch OFF — byte-identical to today
                 )
@@ -5009,6 +5254,7 @@ mod tests {
                     false,
                     false, // (KEYSTONE) mission-spine dispatch OFF
                     false, // memory-confirm ingress OFF — byte-identical to today
+                    false, // run-outcome-learning confirm OFF — byte-identical to today
                     false, // (Loop4) per-run token surface OFF — byte-identical to today
                     false, // (C1/C2) provider-workspace dispatch OFF — byte-identical to today
                 )
@@ -5096,6 +5342,7 @@ mod tests {
                 false,
                 false, // (KEYSTONE) mission-spine dispatch OFF — byte-identical to today
                 false, // memory-confirm ingress OFF — byte-identical to today
+                false, // run-outcome-learning confirm OFF — byte-identical to today
                 false, // (Loop4) per-run token surface OFF — byte-identical to today
                 false, // (C1/C2) provider-workspace dispatch OFF — byte-identical to today
             )
@@ -5143,6 +5390,7 @@ mod tests {
                 false,
                 false, // (KEYSTONE) mission-spine dispatch OFF — byte-identical to today
                 false, // memory-confirm ingress OFF — byte-identical to today
+                false, // run-outcome-learning confirm OFF — byte-identical to today
                 false, // (Loop4) per-run token surface OFF — byte-identical to today
                 false, // (C1/C2) provider-workspace dispatch OFF — byte-identical to today
             )
@@ -5190,6 +5438,7 @@ mod tests {
             false,
             false, // (KEYSTONE) mission-spine dispatch OFF — byte-identical to today
             false, // memory-confirm ingress OFF — byte-identical to today
+            false, // run-outcome-learning confirm OFF — byte-identical to today
             false, // (Loop4) per-run token surface OFF — byte-identical to today
             false, // (C1/C2) provider-workspace dispatch OFF — byte-identical to today
         );
@@ -5514,6 +5763,7 @@ mod tests {
                 false,
                 false, // (KEYSTONE) mission-spine dispatch OFF — byte-identical to today
                 false, // memory-confirm ingress OFF — byte-identical to today
+                false, // run-outcome-learning confirm OFF — byte-identical to today
                 false, // (Loop4) per-run token surface OFF — byte-identical to today
                 false, // (C1/C2) provider-workspace dispatch OFF — byte-identical to today
             )
@@ -5560,6 +5810,7 @@ mod tests {
                 false,
                 false, // (KEYSTONE) mission-spine dispatch OFF — byte-identical to today
                 false, // memory-confirm ingress OFF — byte-identical to today
+                false, // run-outcome-learning confirm OFF — byte-identical to today
                 false, // (Loop4) per-run token surface OFF — byte-identical to today
                 false, // (C1/C2) provider-workspace dispatch OFF — byte-identical to today
             )
@@ -5623,6 +5874,7 @@ mod tests {
                 false,
                 false, // (KEYSTONE) mission-spine dispatch OFF — byte-identical to today
                 false, // memory-confirm ingress OFF — byte-identical to today
+                false, // run-outcome-learning confirm OFF — byte-identical to today
                 false, // (Loop4) per-run token surface OFF — byte-identical to today
                 false, // (C1/C2) provider-workspace dispatch OFF — byte-identical to today
             )
@@ -5703,6 +5955,7 @@ mod tests {
             false,
             false, // (KEYSTONE) mission-spine dispatch OFF — byte-identical to today
             false, // memory-confirm ingress OFF — byte-identical to today
+            false, // run-outcome-learning confirm OFF — byte-identical to today
             false, // (Loop4) per-run token surface OFF — byte-identical to today
             false, // (C1/C2) provider-workspace dispatch OFF — byte-identical to today
         );
@@ -5764,6 +6017,7 @@ mod tests {
                 false,
                 false, // (KEYSTONE) mission-spine dispatch OFF — byte-identical to today
                 false, // memory-confirm ingress OFF — byte-identical to today
+                false, // run-outcome-learning confirm OFF — byte-identical to today
                 false, // (Loop4) per-run token surface OFF — byte-identical to today
                 false, // (C1/C2) provider-workspace dispatch OFF — byte-identical to today
             )
@@ -6330,6 +6584,7 @@ mod tests {
                 false,
                 false, // (KEYSTONE) mission-spine dispatch OFF — byte-identical to today
                 false, // memory-confirm ingress OFF — byte-identical to today
+                false, // run-outcome-learning confirm OFF — byte-identical to today
                 false, // (Loop4) per-run token surface OFF — byte-identical to today
                 false, // (C1/C2) provider-workspace dispatch OFF — byte-identical to today
             )
@@ -6398,6 +6653,7 @@ mod tests {
                 false, // mission-intake ingress OFF
                 false, // mission-spine dispatch OFF
                 false, // memory-confirm ingress OFF
+                false, // run-outcome-learning confirm OFF — byte-identical to today
                 false, // token surface OFF
                 false, // provider-workspace dispatch OFF
             )
@@ -6460,6 +6716,7 @@ mod tests {
                 true,  // mission-intake ingress ON
                 false, // mission-spine dispatch OFF
                 false, // memory-confirm ingress OFF
+                false, // run-outcome-learning confirm OFF — byte-identical to today
                 false, // token surface OFF
                 false, // provider-workspace dispatch OFF
             )
@@ -6486,6 +6743,7 @@ mod tests {
                 false, // mission-intake ingress OFF
                 false, // mission-spine dispatch OFF
                 false, // memory-confirm ingress OFF
+                false, // run-outcome-learning confirm OFF — byte-identical to today
                 false, // token surface OFF
                 false, // provider-workspace dispatch OFF
             )
@@ -6592,6 +6850,7 @@ mod tests {
                 true,  // mission-intake ingress ON
                 false, // mission-spine dispatch OFF
                 false, // memory-confirm ingress OFF
+                false, // run-outcome-learning confirm OFF — byte-identical to today
                 false, // token surface OFF
                 false, // provider-workspace dispatch OFF
             )
@@ -6623,6 +6882,7 @@ mod tests {
                 false, // mission-intake ingress OFF
                 false, // mission-spine dispatch OFF
                 false, // memory-confirm ingress OFF
+                false, // run-outcome-learning confirm OFF — byte-identical to today
                 false, // token surface OFF
                 false, // provider-workspace dispatch OFF
             )
@@ -6727,6 +6987,7 @@ mod tests {
                 false, // mission-intake ingress OFF
                 true,  // mission-spine dispatch ON
                 false, // memory-confirm ingress OFF
+                false, // run-outcome-learning confirm OFF — byte-identical to today
                 false, // token surface OFF
                 false, // provider-workspace dispatch OFF
             )
@@ -6757,6 +7018,7 @@ mod tests {
                 false, // mission-intake ingress OFF
                 true,  // mission-spine dispatch ON
                 false, // memory-confirm ingress OFF
+                false, // run-outcome-learning confirm OFF — byte-identical to today
                 false, // token surface OFF
                 false, // provider-workspace dispatch OFF
             )
@@ -6848,6 +7110,7 @@ mod tests {
                 false, // mission-intake ingress OFF
                 false, // mission-spine dispatch OFF
                 true,  // memory-confirm ingress ON
+                false, // run-outcome-learning confirm OFF — byte-identical to today
                 false, // token surface OFF
                 false, // provider-workspace dispatch OFF
             )
@@ -6917,6 +7180,7 @@ mod tests {
             false,
             false, // (KEYSTONE) mission-spine dispatch OFF — byte-identical to today
             false, // memory-confirm ingress OFF — byte-identical to today
+            false, // run-outcome-learning confirm OFF — byte-identical to today
             false, // (Loop4) per-run token surface OFF — byte-identical to today
             false, // (C1/C2) provider-workspace dispatch OFF — byte-identical to today
         );
@@ -6971,6 +7235,7 @@ mod tests {
                 false,
                 false, // (KEYSTONE) mission-spine dispatch OFF — byte-identical to today
                 false, // memory-confirm ingress OFF — byte-identical to today
+                false, // run-outcome-learning confirm OFF — byte-identical to today
                 false, // (Loop4) per-run token surface OFF — byte-identical to today
                 false, // (C1/C2) provider-workspace dispatch OFF — byte-identical to today
             )
@@ -7083,6 +7348,7 @@ mod tests {
                 false,
                 false, // (KEYSTONE) mission-spine dispatch OFF — byte-identical to today
                 false, // memory-confirm ingress OFF — byte-identical to today
+                false, // run-outcome-learning confirm OFF — byte-identical to today
                 false, // (Loop4) per-run token surface OFF — byte-identical to today
                 false, // (C1/C2) provider-workspace dispatch OFF — byte-identical to today
             )
@@ -7142,6 +7408,7 @@ mod tests {
             false,
             false, // (KEYSTONE) mission-spine dispatch OFF — byte-identical to today
             false, // memory-confirm ingress OFF — byte-identical to today
+            false, // run-outcome-learning confirm OFF — byte-identical to today
             false, // (Loop4) per-run token surface OFF — byte-identical to today
             false, // (C1/C2) provider-workspace dispatch OFF — byte-identical to today
         );
@@ -7207,6 +7474,7 @@ mod tests {
                 false,
                 false, // (KEYSTONE) mission-spine dispatch OFF — byte-identical to today
                 false, // memory-confirm ingress OFF — byte-identical to today
+                false, // run-outcome-learning confirm OFF — byte-identical to today
                 false, // (Loop4) per-run token surface OFF — byte-identical to today
                 false, // (C1/C2) provider-workspace dispatch OFF — byte-identical to today
             )
@@ -7312,7 +7580,7 @@ mod tests {
             listener
                 .accept_one(
                     &server_kp, &rt, &allowlist, &peer1, false, false, false, false, false, false,
-                    false
+                    false, false
                 )
                 .unwrap(),
             1
@@ -7332,7 +7600,7 @@ mod tests {
             listener
                 .accept_one(
                     &server_kp, &rt, &allowlist, &peer2, false, false, false, false, false, false,
-                    false
+                    false, false
                 )
                 .unwrap(),
             1
@@ -7392,6 +7660,7 @@ mod tests {
                     false,
                     false, // (KEYSTONE) mission-spine dispatch OFF — byte-identical to today
                     false, // memory-confirm ingress OFF — byte-identical to today
+                    false, // run-outcome-learning confirm OFF — byte-identical to today
                     false, // (Loop4) per-run token surface OFF — byte-identical to today
                     false, // (C1/C2) provider-workspace dispatch OFF — byte-identical to today
                 )
@@ -7464,6 +7733,7 @@ mod tests {
                     false,
                     false,
                     false,
+                    false,
                     false, // (C1/C2) provider-workspace dispatch OFF
                 )
                 .unwrap(),
@@ -7520,6 +7790,7 @@ mod tests {
                     &run_peer_allowlist,
                     false,
                     true, // mission-bound run ON
+                    false,
                     false,
                     false,
                     false,

--- a/rust-core/crates/friday-hub/src/hub_server.rs
+++ b/rust-core/crates/friday-hub/src/hub_server.rs
@@ -29,12 +29,13 @@ use friday_protocol::{
     MissionTimelineSurfaceEventWire, MissionTimelineWorkItemWire, MissionWorkItemContextWire,
     ProviderWorkspaceActionRequestWire, ProviderWorkspaceActionResultWire,
     RouteDecisionControlRequestWire, RouteDecisionControlResultWire, RouteDecisionProjectionWire,
+    RunOutcomeLearningDecisionRequestWire, RunOutcomeLearningDecisionResultWire,
     WorkItemStatusRequestWire, WorkItemStatusResultWire, SUPPORTED,
 };
 use friday_providers::unified::{FallbackStatus, PlatformProvider, ProviderSession, SessionStatus};
 use friday_storage::{
-    get_run_answer_for_principal, get_run_result_ref, AnswerDenyReason, Db, MissionBodySnapshot,
-    RunAnswerAccess, RunResultRef,
+    get_run_answer_for_principal, get_run_result_ref, load_session_owner, AnswerDenyReason, Db,
+    MissionBodySnapshot, RunAnswerAccess, RunResultRef,
 };
 use friday_transport::{ws_recv_envelope, ws_send_envelope, TransportError, WireWebSocket};
 use serde_json::json;
@@ -1523,6 +1524,200 @@ fn memory_decision_blocked(
                 status: "blocked".to_string(),
                 blocker: Some(blocker.to_string()),
                 recallable: false,
+            },
+        },
+    )
+    .with_correlation(msg_id.to_string())
+}
+
+/// Apply the OWNER's explicit confirm/reject decision to ONE pending A1 run-outcome
+/// learning candidate. This is the product caller for the already-built
+/// emit -> candidate leg: it is a pure Hub DB mutation, makes no provider/model
+/// call, and returns only refs/coarse state.
+///
+/// Owner scope is derived from the candidate's bound session, not from a client
+/// asserted owner field. The candidate stores `session_id` (or falls back to
+/// `run_id` for run-scoped sessions); that session's `user_id` must match the
+/// authenticated sealed-session owner before any decision is written.
+pub fn run_outcome_learning_decision_result_for_db(
+    db: &Db,
+    msg_id: &str,
+    request: RunOutcomeLearningDecisionRequestWire,
+    authenticated_owner: Option<&str>,
+    now_ms: i64,
+) -> Envelope {
+    use friday_storage::learning_candidate;
+
+    let decision = request.decision.trim().to_ascii_lowercase();
+    let confirmed = match decision.as_str() {
+        "confirm" => true,
+        "reject" => false,
+        _ => {
+            return run_outcome_learning_decision_blocked(
+                msg_id,
+                now_ms,
+                &request.candidate_id,
+                None,
+                None,
+                "unknown",
+                "invalid_decision",
+            );
+        }
+    };
+
+    let row = match learning_candidate::get_run_outcome_candidate(db.conn(), &request.candidate_id)
+    {
+        Ok(Some(row)) => row,
+        Ok(None) => {
+            return run_outcome_learning_decision_blocked(
+                msg_id,
+                now_ms,
+                &request.candidate_id,
+                None,
+                None,
+                "unknown",
+                "unknown_candidate",
+            );
+        }
+        Err(_) => {
+            return run_outcome_learning_decision_blocked(
+                msg_id,
+                now_ms,
+                &request.candidate_id,
+                None,
+                None,
+                "unknown",
+                "candidate_read_failed",
+            );
+        }
+    };
+
+    let authed = authenticated_owner.unwrap_or("").trim();
+    if authed.is_empty() {
+        return run_outcome_learning_decision_blocked(
+            msg_id,
+            now_ms,
+            &row.candidate_id,
+            Some(&row.run_id),
+            Some(row.kind.as_str()),
+            row.state.as_str(),
+            "owner_principal_required",
+        );
+    }
+
+    match run_outcome_candidate_owner_matches(db, &row, authed) {
+        Ok(true) => {}
+        Ok(false) => {
+            return run_outcome_learning_decision_blocked(
+                msg_id,
+                now_ms,
+                &row.candidate_id,
+                Some(&row.run_id),
+                Some(row.kind.as_str()),
+                row.state.as_str(),
+                "owner_scope_mismatch",
+            );
+        }
+        Err(_) => {
+            return run_outcome_learning_decision_blocked(
+                msg_id,
+                now_ms,
+                &row.candidate_id,
+                Some(&row.run_id),
+                Some(row.kind.as_str()),
+                row.state.as_str(),
+                "owner_read_failed",
+            );
+        }
+    }
+
+    let new_state = match learning_candidate::decide_run_outcome_candidate(
+        db.conn(),
+        &row.candidate_id,
+        confirmed,
+        now_ms,
+        request.reason.as_deref(),
+    ) {
+        Ok(state) => state,
+        Err(_) => {
+            return run_outcome_learning_decision_blocked(
+                msg_id,
+                now_ms,
+                &row.candidate_id,
+                Some(&row.run_id),
+                Some(row.kind.as_str()),
+                row.state.as_str(),
+                "not_decidable",
+            );
+        }
+    };
+
+    let status = match new_state {
+        learning_candidate::RunOutcomeLearningState::Confirmed => "confirmed",
+        learning_candidate::RunOutcomeLearningState::Rejected => "rejected",
+        learning_candidate::RunOutcomeLearningState::Pending => "blocked",
+    };
+
+    Envelope::new(
+        format!("{msg_id}-run-outcome-learning-decision"),
+        now_ms,
+        Message::RunOutcomeLearningDecisionResult {
+            result: RunOutcomeLearningDecisionResultWire {
+                candidate_id: row.candidate_id,
+                run_id: Some(row.run_id),
+                kind: Some(row.kind.as_str().to_string()),
+                state: new_state.as_str().to_string(),
+                status: status.to_string(),
+                blocker: None,
+            },
+        },
+    )
+    .with_correlation(msg_id.to_string())
+}
+
+fn run_outcome_candidate_owner_matches(
+    db: &Db,
+    row: &friday_storage::learning_candidate::RunOutcomeLearningCandidateRow,
+    authenticated_owner: &str,
+) -> friday_storage::Result<bool> {
+    let mut keys = Vec::new();
+    if let Some(session_id) = row.session_id.as_deref().filter(|s| !s.trim().is_empty()) {
+        keys.push(session_id);
+    }
+    if !keys.iter().any(|key| *key == row.run_id) {
+        keys.push(row.run_id.as_str());
+    }
+
+    for key in keys {
+        if let Some(owner) = load_session_owner(db.conn(), key)? {
+            if owner.user_id.as_deref().map(str::trim) == Some(authenticated_owner) {
+                return Ok(true);
+            }
+        }
+    }
+    Ok(false)
+}
+
+fn run_outcome_learning_decision_blocked(
+    msg_id: &str,
+    now_ms: i64,
+    candidate_id: &str,
+    run_id: Option<&str>,
+    kind: Option<&str>,
+    state: &str,
+    blocker: &str,
+) -> Envelope {
+    Envelope::new(
+        format!("{msg_id}-run-outcome-learning-decision"),
+        now_ms,
+        Message::RunOutcomeLearningDecisionResult {
+            result: RunOutcomeLearningDecisionResultWire {
+                candidate_id: candidate_id.to_string(),
+                run_id: run_id.map(str::to_string),
+                kind: kind.map(str::to_string),
+                state: state.to_string(),
+                status: "blocked".to_string(),
+                blocker: Some(blocker.to_string()),
             },
         },
     )
@@ -7085,6 +7280,152 @@ mod tests {
         }
         assert!(pages > 1);
         assert_eq!(provider_link_count, ask_count);
+    }
+
+    // --- A1 run-outcome learning confirm arm -----------------------------------------------
+
+    fn seed_run_outcome_candidate(db: &Db, run_id: &str, session_id: &str, owner: &str) {
+        friday_storage::ensure_session_with_owner(
+            db.conn(),
+            session_id,
+            &friday_storage::SessionOwner {
+                user_id: Some(owner.to_string()),
+                ..Default::default()
+            },
+            1_000,
+        )
+        .unwrap();
+        friday_storage::agent_run::create_run(db.conn(), run_id, "refs-only task", 1_000).unwrap();
+        friday_storage::learning_candidate::record_run_outcome_candidates(
+            db.conn(),
+            run_id,
+            Some(session_id),
+            2,
+            1,
+            1_100,
+        )
+        .unwrap();
+    }
+
+    fn decode_run_outcome_learning_decision(
+        env: &Envelope,
+    ) -> &RunOutcomeLearningDecisionResultWire {
+        match &env.message {
+            Message::RunOutcomeLearningDecisionResult { result } => result,
+            other => panic!("expected RunOutcomeLearningDecisionResult, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn run_outcome_learning_decision_confirm_marks_candidate_terminal_for_owner() {
+        let db = Db::open_hub(&tmp_db()).unwrap();
+        seed_run_outcome_candidate(&db, "run-a1-confirm", "sess-a1-confirm", "owner-1");
+
+        let env = run_outcome_learning_decision_result_for_db(
+            &db,
+            "msg-a1-confirm",
+            RunOutcomeLearningDecisionRequestWire {
+                candidate_id: "a1:run-a1-confirm:preference".into(),
+                decision: "confirm".into(),
+                reason: Some("owner accepted the preference".into()),
+            },
+            Some("owner-1"),
+            1_200,
+        );
+        let result = decode_run_outcome_learning_decision(&env);
+        assert_eq!(result.status, "confirmed");
+        assert_eq!(result.state, "confirmed");
+        assert_eq!(result.run_id.as_deref(), Some("run-a1-confirm"));
+        assert_eq!(result.kind.as_deref(), Some("preference"));
+        assert!(result.blocker.is_none());
+
+        let row = friday_storage::learning_candidate::get_run_outcome_candidate(
+            db.conn(),
+            "a1:run-a1-confirm:preference",
+        )
+        .unwrap()
+        .unwrap();
+        assert_eq!(
+            row.state,
+            friday_storage::learning_candidate::RunOutcomeLearningState::Confirmed
+        );
+        assert_eq!(
+            row.decision_reason.as_deref(),
+            Some("owner accepted the preference")
+        );
+    }
+
+    #[test]
+    fn run_outcome_learning_decision_wrong_owner_is_blocked_and_unchanged() {
+        let db = Db::open_hub(&tmp_db()).unwrap();
+        seed_run_outcome_candidate(&db, "run-a1-scope", "sess-a1-scope", "owner-1");
+
+        let env = run_outcome_learning_decision_result_for_db(
+            &db,
+            "msg-a1-scope",
+            RunOutcomeLearningDecisionRequestWire {
+                candidate_id: "a1:run-a1-scope:reflex".into(),
+                decision: "confirm".into(),
+                reason: None,
+            },
+            Some("intruder"),
+            1_200,
+        );
+        let result = decode_run_outcome_learning_decision(&env);
+        assert_eq!(result.status, "blocked");
+        assert_eq!(result.blocker.as_deref(), Some("owner_scope_mismatch"));
+
+        let row = friday_storage::learning_candidate::get_run_outcome_candidate(
+            db.conn(),
+            "a1:run-a1-scope:reflex",
+        )
+        .unwrap()
+        .unwrap();
+        assert_eq!(
+            row.state,
+            friday_storage::learning_candidate::RunOutcomeLearningState::Pending
+        );
+    }
+
+    #[test]
+    fn run_outcome_learning_decision_terminal_candidate_is_not_redone() {
+        let db = Db::open_hub(&tmp_db()).unwrap();
+        seed_run_outcome_candidate(&db, "run-a1-terminal", "sess-a1-terminal", "owner-1");
+        friday_storage::learning_candidate::decide_run_outcome_candidate(
+            db.conn(),
+            "a1:run-a1-terminal:world_model",
+            true,
+            1_200,
+            Some("first decision"),
+        )
+        .unwrap();
+
+        let env = run_outcome_learning_decision_result_for_db(
+            &db,
+            "msg-a1-terminal",
+            RunOutcomeLearningDecisionRequestWire {
+                candidate_id: "a1:run-a1-terminal:world_model".into(),
+                decision: "reject".into(),
+                reason: Some("try to change it".into()),
+            },
+            Some("owner-1"),
+            1_300,
+        );
+        let result = decode_run_outcome_learning_decision(&env);
+        assert_eq!(result.status, "blocked");
+        assert_eq!(result.blocker.as_deref(), Some("not_decidable"));
+
+        let row = friday_storage::learning_candidate::get_run_outcome_candidate(
+            db.conn(),
+            "a1:run-a1-terminal:world_model",
+        )
+        .unwrap()
+        .unwrap();
+        assert_eq!(
+            row.state,
+            friday_storage::learning_candidate::RunOutcomeLearningState::Confirmed
+        );
+        assert_eq!(row.decision_reason.as_deref(), Some("first decision"));
     }
 
     // --- Memory-confirm arm (the live caller that CLOSES the Memory-confirmation loop) ---------

--- a/rust-core/crates/friday-protocol/src/lib.rs
+++ b/rust-core/crates/friday-protocol/src/lib.rs
@@ -56,9 +56,14 @@ use thiserror::Error;
 /// the sealed Mission Spine dispatch flag. They stay refs-only and default-dark: a
 /// v14 binary with the dispatch flag off still echoes the message as a keepalive,
 /// changing no live behavior.
-pub const CURRENT_SCHEMA_VERSION: u16 = 14;
+///
+/// v15 (A1 run-outcome learning confirm) adds
+/// `RunOutcomeLearningDecisionRequest/Result`: the owner-authed, refs-only terminal
+/// confirm/reject caller for pending run-outcome learning candidates. It is a pure
+/// Hub DB mutation, default-dark behind the serving flag, and carries no answer body.
+pub const CURRENT_SCHEMA_VERSION: u16 = 15;
 /// The inclusive range of versions this build supports.
-pub const SUPPORTED: VersionRange = VersionRange { min: 1, max: 14 };
+pub const SUPPORTED: VersionRange = VersionRange { min: 1, max: 15 };
 
 /// A surface-safe Mission projection. This is the wire shape mobile, desktop, and
 /// channel surfaces may render. It intentionally has no raw provider ids, channel
@@ -416,6 +421,33 @@ pub struct MemoryDecisionResultWire {
     /// Whether the candidate is now recallable (durable `Confirmed`). Mirrors
     /// `created_or_ready` on the intake result — a single honest yes/no.
     pub recallable: bool,
+}
+
+/// Client request to apply the OWNER's explicit confirm/reject decision to ONE
+/// pending A1 run-outcome learning candidate. This is refs-only governance over a
+/// candidate row that already points at a run/session; it never carries the run
+/// answer body and never calls a provider/model.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RunOutcomeLearningDecisionRequestWire {
+    pub candidate_id: String,
+    pub decision: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+}
+
+/// Hub response for a run-outcome learning decision. Refs-only: candidate/run
+/// ids, lifecycle state, coarse status/blocker, and the candidate kind.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RunOutcomeLearningDecisionResultWire {
+    pub candidate_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub run_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub kind: Option<String>,
+    pub state: String,
+    pub status: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub blocker: Option<String>,
 }
 
 /// Canonical Mission/WorkItem context for a user-facing request. This is not a
@@ -1393,6 +1425,16 @@ pub enum Message {
     /// the resulting lifecycle state, a coarse status, and whether it is now
     /// recallable. NEVER the candidate's content (the content stays Hub-side).
     MemoryDecisionResult { result: MemoryDecisionResultWire },
+    /// client->hub: confirm/reject ONE pending A1 run-outcome learning candidate.
+    /// Owner scope is derived server-side from the candidate's bound session/run.
+    /// Never a provider/model call and never carries the run answer body.
+    RunOutcomeLearningDecisionRequest {
+        request: RunOutcomeLearningDecisionRequestWire,
+    },
+    /// hub->client: refs-only run-outcome learning decision receipt.
+    RunOutcomeLearningDecisionResult {
+        result: RunOutcomeLearningDecisionResultWire,
+    },
     /// **S-R1** — UI→DARK read-server: request the Mission Workbench read projection over the
     /// sealed-WS READ seam. PURE READ — no model/provider call. Owner-scoped: the read server
     /// authenticates `forwarded_principal`/`auth_proof` against the sealed session (the SAME chain a
@@ -2239,6 +2281,23 @@ mod tests {
                     recallable: true,
                 },
             },
+            Message::RunOutcomeLearningDecisionRequest {
+                request: RunOutcomeLearningDecisionRequestWire {
+                    candidate_id: "a1:run-1:preference".into(),
+                    decision: "confirm".into(),
+                    reason: Some("owner confirmed this learning".into()),
+                },
+            },
+            Message::RunOutcomeLearningDecisionResult {
+                result: RunOutcomeLearningDecisionResultWire {
+                    candidate_id: "a1:run-1:preference".into(),
+                    run_id: Some("run-1".into()),
+                    kind: Some("preference".into()),
+                    state: "confirmed".into(),
+                    status: "confirmed".into(),
+                    blocker: None,
+                },
+            },
         ];
         for msg in cases {
             let env = Envelope::new("m1", 1000, msg).with_correlation("c1");
@@ -2247,6 +2306,51 @@ mod tests {
             let back = Envelope::decode(&json).unwrap();
             assert_eq!(back, env);
         }
+    }
+
+    #[test]
+    fn run_outcome_learning_decision_wire_is_refs_only_and_round_trips() {
+        let request = Message::RunOutcomeLearningDecisionRequest {
+            request: RunOutcomeLearningDecisionRequestWire {
+                candidate_id: "a1:run-1:preference".into(),
+                decision: "confirm".into(),
+                reason: Some("operator confirmed".into()),
+            },
+        };
+        let env = Envelope::new("a1-dec-req", 1000, request.clone()).with_correlation("c1");
+        let json = env.encode().unwrap();
+        assert!(json.contains("\"kind\":\"RunOutcomeLearningDecisionRequest\""));
+        assert!(json.contains("\"request\":{"));
+        assert!(json.contains("\"candidate_id\":\"a1:run-1:preference\""));
+        for forbidden in [
+            "answer body",
+            "raw transcript",
+            "sk-",
+            "/Users/jarvis/private",
+        ] {
+            assert!(
+                !json.contains(forbidden),
+                "run-outcome learning request leaked {forbidden}: {json}"
+            );
+        }
+        assert_eq!(Envelope::decode(&json).unwrap(), env);
+
+        let result = Message::RunOutcomeLearningDecisionResult {
+            result: RunOutcomeLearningDecisionResultWire {
+                candidate_id: "a1:run-1:preference".into(),
+                run_id: Some("run-1".into()),
+                kind: Some("preference".into()),
+                state: "rejected".into(),
+                status: "blocked".into(),
+                blocker: Some("owner_scope_mismatch".into()),
+            },
+        };
+        let env = Envelope::new("a1-dec-res", 1001, result).with_correlation("c1");
+        let json = env.encode().unwrap();
+        assert!(json.contains("\"kind\":\"RunOutcomeLearningDecisionResult\""));
+        assert!(json.contains("\"result\":{"));
+        assert!(json.contains("\"blocker\":\"owner_scope_mismatch\""));
+        assert_eq!(Envelope::decode(&json).unwrap(), env);
     }
 
     #[test]
@@ -3038,13 +3142,13 @@ mod tests {
     }
 
     #[test]
-    fn schema_version_bumped_to_fourteen_for_route_decision_controls() {
+    fn schema_version_bumped_to_fifteen_for_run_outcome_learning_decision() {
         // A1 bumps the wire version so a v13 peer advertises the run-CONTROL kinds
         // (Paused/Resume/Cancel/Reject/ControlResult) exist — wire-compat honesty — even
         // while nothing emits them yet (DARK, behind the default-off flag). S-A's v12
         // substrate kinds are still present and unchanged.
-        assert_eq!(CURRENT_SCHEMA_VERSION, 14);
-        assert_eq!(SUPPORTED.max, 14);
+        assert_eq!(CURRENT_SCHEMA_VERSION, 15);
+        assert_eq!(SUPPORTED.max, 15);
         assert_eq!(SUPPORTED.min, 1);
     }
 

--- a/test/unit/api/mission-spine/friday-rust-hub-mission-spine-wire.test.ts
+++ b/test/unit/api/mission-spine/friday-rust-hub-mission-spine-wire.test.ts
@@ -457,7 +457,7 @@ describe("parseWorkItemStatusResult (fail-closed refs-only, count not raw refs, 
 //  - We `JSON.parse` the Rust JSON and `toEqual` the `message.request`/`message.result` SUB-OBJECT
 //    against what the TS builder emits / what the TS parser consumes. SUB-OBJECT (not full-envelope
 //    byte) comparison is deliberate: the outer envelope cannot be byte-equal (`sent_at = Date.now()`,
-//    `msg_id` is per-entity not "m1", and TS `SCHEMA_VERSION` is 12 vs the current Rust 14 — all
+//    `msg_id` is per-entity not "m1", and TS `SCHEMA_VERSION` is 12 vs the current Rust 15 — all
 //    orthogonal to the wire-NESTING bug under repair). The sub-object equality is exactly the bug's
 //    surface: nesting depth + key names + types.
 //  - `includes_sensitive_context`: Rust has `#[serde(default)]` WITHOUT `skip_serializing_if`, so it
@@ -467,17 +467,17 @@ describe("parseWorkItemStatusResult (fail-closed refs-only, count not raw refs, 
 //    is covered by the dedicated build unit test above.)
 
 const RUST_INTAKE_REQUEST_JSON =
-  '{"schema_version":14,"msg_id":"m1","correlation_id":"c1","sent_at":1000,"message":{"kind":"MissionIntakeRequest","request":{"friday_conversation_id":"conversation_x","owner_principal":"owner_x","surface_thread_id":"surface_x","surface_kind":"mobile","delivery_route":"in_app","visibility_policy":"owner_only","mission_id":"mission_x","work_item_id":"work_x","title":"Title","intent":"Intent","lane":"deepseek","target_provider_or_agent":"deepseek-v4","capability_id":"cap_x","body_ref":"body://ref","includes_sensitive_context":true}}}';
+  '{"schema_version":15,"msg_id":"m1","correlation_id":"c1","sent_at":1000,"message":{"kind":"MissionIntakeRequest","request":{"friday_conversation_id":"conversation_x","owner_principal":"owner_x","surface_thread_id":"surface_x","surface_kind":"mobile","delivery_route":"in_app","visibility_policy":"owner_only","mission_id":"mission_x","work_item_id":"work_x","title":"Title","intent":"Intent","lane":"deepseek","target_provider_or_agent":"deepseek-v4","capability_id":"cap_x","body_ref":"body://ref","includes_sensitive_context":true}}}';
 const RUST_INTAKE_RESULT_JSON =
-  '{"schema_version":14,"msg_id":"m1","correlation_id":"c1","sent_at":1000,"message":{"kind":"MissionIntakeResult","result":{"friday_conversation_id":"conversation_x","mission_id":"mission_x","work_item_id":"work_x","surface_thread_id":"surface_x","status":"ready","blockers":[],"duplicate_mission_id":"mission_dup","duplicate_work_item_id":"work_dup","created_or_ready":true}}}';
+  '{"schema_version":15,"msg_id":"m1","correlation_id":"c1","sent_at":1000,"message":{"kind":"MissionIntakeResult","result":{"friday_conversation_id":"conversation_x","mission_id":"mission_x","work_item_id":"work_x","surface_thread_id":"surface_x","status":"ready","blockers":[],"duplicate_mission_id":"mission_dup","duplicate_work_item_id":"work_dup","created_or_ready":true}}}';
 const RUST_LIFECYCLE_REQUEST_JSON =
-  '{"schema_version":14,"msg_id":"m1","correlation_id":"c1","sent_at":1000,"message":{"kind":"MissionLifecycleRequest","request":{"friday_conversation_id":"conversation_x","mission_id":"mission_x","target_status":"queued","actor_ref":"actor_x","reason":"advance","proof_ref":"proof://ref","merged_into_mission_id":"mission_y"}}}';
+  '{"schema_version":15,"msg_id":"m1","correlation_id":"c1","sent_at":1000,"message":{"kind":"MissionLifecycleRequest","request":{"friday_conversation_id":"conversation_x","mission_id":"mission_x","target_status":"queued","actor_ref":"actor_x","reason":"advance","proof_ref":"proof://ref","merged_into_mission_id":"mission_y"}}}';
 const RUST_LIFECYCLE_RESULT_JSON =
-  '{"schema_version":14,"msg_id":"m1","correlation_id":"c1","sent_at":1000,"message":{"kind":"MissionLifecycleResult","result":{"friday_conversation_id":"conversation_x","mission_id":"mission_x","previous_status":"ready","status":"queued","actor_ref":"actor_x","reason":"advance","proof_ref":"proof://r","merged_into_mission_id":"mission_y","active_mission_ids":["mission_x"],"updated_at_ms":1700000000000}}}';
+  '{"schema_version":15,"msg_id":"m1","correlation_id":"c1","sent_at":1000,"message":{"kind":"MissionLifecycleResult","result":{"friday_conversation_id":"conversation_x","mission_id":"mission_x","previous_status":"ready","status":"queued","actor_ref":"actor_x","reason":"advance","proof_ref":"proof://r","merged_into_mission_id":"mission_y","active_mission_ids":["mission_x"],"updated_at_ms":1700000000000}}}';
 const RUST_WORK_ITEM_REQUEST_JSON =
-  '{"schema_version":14,"msg_id":"m1","correlation_id":"c1","sent_at":1000,"message":{"kind":"WorkItemStatusRequest","request":{"work_item_id":"work_x","target_status":"completed_with_proof","actor_ref":"actor_x","reason":"stage","proof_receipt":"proof://receipt"}}}';
+  '{"schema_version":15,"msg_id":"m1","correlation_id":"c1","sent_at":1000,"message":{"kind":"WorkItemStatusRequest","request":{"work_item_id":"work_x","target_status":"completed_with_proof","actor_ref":"actor_x","reason":"stage","proof_receipt":"proof://receipt"}}}';
 const RUST_WORK_ITEM_RESULT_JSON =
-  '{"schema_version":14,"msg_id":"m1","correlation_id":"c1","sent_at":1000,"message":{"kind":"WorkItemStatusResult","result":{"work_item_id":"work_x","mission_id":"mission_x","previous_status":"ready_to_dispatch","status":"completed_with_proof","actor_ref":"actor_x","reason":"done","proof_receipt_count":2,"updated_at_ms":1700000000000}}}';
+  '{"schema_version":15,"msg_id":"m1","correlation_id":"c1","sent_at":1000,"message":{"kind":"WorkItemStatusResult","result":{"work_item_id":"work_x","mission_id":"mission_x","previous_status":"ready_to_dispatch","status":"completed_with_proof","actor_ref":"actor_x","reason":"done","proof_receipt_count":2,"updated_at_ms":1700000000000}}}';
 
 /** Pull the inner `message.<key>` sub-object out of a captured Rust envelope JSON string. */
 function rustInner(json: string, key: "request" | "result"): Record<string, unknown> {


### PR DESCRIPTION
Adds the A1 run-outcome learning terminal decision caller as a default-OFF, refs-only product surface.\n\nWhat changed:\n- Bumps friday-protocol to schema v15 and adds RunOutcomeLearningDecisionRequest/Result wire types.\n- Adds a Hub DB decision function that resolves candidate -> session/run owner and only then confirms/rejects the pending candidate. Wrong owner, missing owner, unknown candidate, invalid decision, and terminal re-decide all fail closed with refs-only blockers.\n- Wires the sealed agent-run server arm behind FRIDAY_RUN_OUTCOME_LEARNING_CONFIRM=1; flag OFF remains keepalive echo.\n- Updates the TS/Rust mission-spine golden envelope fixtures for Rust schema_version=15.\n\nCurrent-head local validation after rebase onto #880/main:\n- git diff --check origin/main...HEAD\n- cargo test -p friday-ffi ffi_unsupported_kind_carries_the_real_message_kind_name_for_a1_learning_decisions -- --nocapture\n- cargo test -p friday-protocol run_outcome_learning_decision_wire_is_refs_only_and_round_trips -- --nocapture\n- cargo test -p friday-protocol schema_version_bumped_to_fifteen_for_run_outcome_learning_decision -- --nocapture\n- npx vitest run test/unit/api/mission-spine/friday-rust-hub-mission-spine-wire.test.ts\n\nTruth label: mechanism-wired / built-DARK. This does not claim A1 live-done: organic=0 and no true operator-origin confirm has occurred.