### PR TITLE
[codex] prove live surface mission-spine writes

### DIFF
--- a/apps/friday-ios/Tests/FridayMobileShellCoreTests/LiveMissionSpineWriteDispatchIntegrationTests.swift
+++ b/apps/friday-ios/Tests/FridayMobileShellCoreTests/LiveMissionSpineWriteDispatchIntegrationTests.swift
@@ -1,0 +1,64 @@
+import Foundation
+import Testing
+
+@testable import FridayMobileShellCore
+@testable import FridayRustClient
+
+// MARK: - LIVE mission-spine write dispatch integration (MANUAL / env-gated)
+//
+// Drives the real iOS shared write transport against the live agent-run WRITE server on
+// 127.0.0.1:48750 as the enrolled master-derived peer. This sends a single Mission intake and
+// expects a refs-only server receipt.
+//
+// HONEST CEILING: this is an agent-driven live product-surface write proof. It is not OG9 organic
+// origin, not a provider/model turn, not a completed_with_proof claim, and not A1 live-done.
+
+private let liveMissionSpineWriteDispatchEnabled =
+  ProcessInfo.processInfo.environment["FRIDAY_MOBILE_LIVE_WRITE_DISPATCH_TEST"] == "1"
+
+@Test(.enabled(if: liveMissionSpineWriteDispatchEnabled))
+func liveMobileMissionSpineWriteDispatchReturnsReadyReceipt() async throws {
+  let keypair = try MasterKeyPeer.deriveKeypair()
+  let client = SealedWSWriteClient(
+    keypair: keypair,
+    forwardedPrincipal: liveAgentRunOwnerPrincipal,
+    makeTransport: {
+      try LoopbackSealedWSTransport(config: ReadProjectionServerConfig(
+        host: AgentRunServerConfig.liveLoopback.host,
+        port: AgentRunServerConfig.liveLoopback.port,
+        connectTimeout: AgentRunServerConfig.liveLoopback.connectTimeout))
+    })
+  let request = makeLiveMobileIntake()
+
+  let result = try await client.submitMissionIntake(request)
+
+  print(
+    "[live-write-dispatch][mobile] status=\(result.status) "
+      + "missionId=\(result.missionId) workItemId=\(result.workItemId ?? "<nil>") "
+      + "surfaceThreadId=\(result.surfaceThreadId) createdOrReady=\(result.createdOrReady)")
+
+  #expect(result.status == "ready")
+  #expect(result.createdOrReady)
+  #expect(result.missionId == request.missionId)
+  #expect(result.workItemId == request.workItemId)
+  #expect(result.surfaceThreadId == request.surfaceThreadId)
+}
+
+private func makeLiveMobileIntake() -> MissionIntakeRequestWire {
+  let id = UUID().uuidString.lowercased().replacingOccurrences(of: "-", with: "")
+  return MissionIntakeRequestWire(
+    fridayConversationId: "fconv_mobile_live_write_\(id)",
+    ownerPrincipal: liveAgentRunOwnerPrincipal,
+    surfaceThreadId: "surface-mobile-live-write-\(id)",
+    surfaceKind: "mobile",
+    deliveryRoute: "ios://friday-mobile/live-write-dispatch/\(id)",
+    visibilityPolicy: "compact",
+    missionId: "mission-mobile-live-write-\(id)",
+    workItemId: "work-mobile-live-write-\(id)",
+    title: "Verify live mobile mission-spine write receipt",
+    intent: "create a workflow that triggers every morning at 9am, reads the Friday live mobile "
+      + "write receipt, and posts a refs-only status summary to the operator console as its "
+      + "output destination",
+    lane: "deepseek",
+    targetProviderOrAgent: "deepseek")
+}

--- a/apps/macos/FridayHubConsole/Tests/FridayHubConsoleCoreTests/LiveMissionSpineWriteDispatchIntegrationTests.swift
+++ b/apps/macos/FridayHubConsole/Tests/FridayHubConsoleCoreTests/LiveMissionSpineWriteDispatchIntegrationTests.swift
@@ -1,0 +1,55 @@
+import Foundation
+import Testing
+
+@testable import FridayHubConsoleCore
+@testable import FridayRustClient
+
+// MARK: - LIVE mission-spine write dispatch integration (MANUAL / env-gated)
+//
+// Drives the real Console product write path (`RealWriteClientFactory.makeLiveWrite`) against the
+// live agent-run WRITE server on 127.0.0.1:48750 as the enrolled master-derived peer. This sends a
+// single Mission intake and expects a refs-only server receipt.
+//
+// HONEST CEILING: this is an agent-driven live product-surface write proof. It is not OG9 organic
+// origin, not a provider/model turn, not a completed_with_proof claim, and not A1 live-done.
+
+private let liveMissionSpineWriteDispatchEnabled =
+  ProcessInfo.processInfo.environment["FRIDAY_CONSOLE_LIVE_WRITE_DISPATCH_TEST"] == "1"
+
+@Test(.enabled(if: liveMissionSpineWriteDispatchEnabled))
+func liveConsoleMissionSpineWriteDispatchReturnsReadyReceipt() async throws {
+  let client = try RealWriteClientFactory.makeLiveWrite()
+  let request = makeLiveIntake(surface: "desktop", route: "desktop://hub-console/live-write-dispatch")
+
+  let result = try await client.submitMissionIntake(request)
+
+  print(
+    "[live-write-dispatch][desktop] status=\(result.status) "
+      + "missionId=\(result.missionId) workItemId=\(result.workItemId ?? "<nil>") "
+      + "surfaceThreadId=\(result.surfaceThreadId) createdOrReady=\(result.createdOrReady)")
+
+  #expect(result.status == "ready")
+  #expect(result.createdOrReady)
+  #expect(result.missionId == request.missionId)
+  #expect(result.workItemId == request.workItemId)
+  #expect(result.surfaceThreadId == request.surfaceThreadId)
+}
+
+private func makeLiveIntake(surface: String, route: String) -> MissionIntakeRequestWire {
+  let id = UUID().uuidString.lowercased().replacingOccurrences(of: "-", with: "")
+  return MissionIntakeRequestWire(
+    fridayConversationId: "fconv_\(surface)_live_write_\(id)",
+    ownerPrincipal: liveReadProjectionOwnerPrincipal,
+    surfaceThreadId: "surface-\(surface)-live-write-\(id)",
+    surfaceKind: surface,
+    deliveryRoute: "\(route)/\(id)",
+    visibilityPolicy: "compact",
+    missionId: "mission-\(surface)-live-write-\(id)",
+    workItemId: "work-\(surface)-live-write-\(id)",
+    title: "Verify live \(surface) mission-spine write receipt",
+    intent: "create a workflow that triggers every morning at 9am, reads the Friday live "
+      + "\(surface) write receipt, and posts a refs-only status summary to the operator console "
+      + "as its output destination",
+    lane: "deepseek",
+    targetProviderOrAgent: "deepseek")
+}


### PR DESCRIPTION
## Summary
- add env-gated macOS Console live mission-spine write dispatch proof
- add env-gated iOS live mission-spine write dispatch proof
- both use the enrolled master-derived peer and assert ready refs-only receipts from the live :48750 write server

## Validation
- `swift test --filter LiveMissionSpineWriteDispatchIntegrationTests` in `apps/macos/FridayHubConsole` PASS (default skip)
- `swift test --filter LiveMissionSpineWriteDispatchIntegrationTests` in `apps/friday-ios` PASS (default skip)
- `FRIDAY_CONSOLE_LIVE_WRITE_DISPATCH_TEST=1 swift test --filter LiveMissionSpineWriteDispatchIntegrationTests` PASS, wrote ready desktop mission/work/surface receipt
- `FRIDAY_MOBILE_LIVE_WRITE_DISPATCH_TEST=1 swift test --filter LiveMissionSpineWriteDispatchIntegrationTests` PASS, wrote ready mobile mission/work/surface receipt
- readonly DB verification confirmed desktop/mobile mission rows active, work_items ready_to_dispatch, surface_thread rows desktop/mobile
- `git diff --check` PASS

## Truth label
organic=0. This is agent-driven live product-surface mission-spine write proof only. It is not OG9 organic-origin, not provider/model-turn dispatch, not completed_with_proof, not A1 live-done, and not stage1 flawless-live done.