### PR TITLE
Wire product intake to mission-bound dispatch

### DIFF
--- a/apps/friday-ios/Sources/FridayMobileShellCore/RealReadClientFactory.swift
+++ b/apps/friday-ios/Sources/FridayMobileShellCore/RealReadClientFactory.swift
@@ -35,11 +35,20 @@ public struct ReadProjectionServerConfig: Sendable, Equatable {
   public let port: UInt16
   /// Connect / preamble timeout. Past this, a dark server surfaces as honest unavailable.
   public let connectTimeout: TimeInterval
+  /// Response-frame timeout. Defaults to `connectTimeout`; write clients can extend this for
+  /// real model-turn agent runs without making dark-server connects hang.
+  public let receiveTimeout: TimeInterval
 
-  public init(host: String = "127.0.0.1", port: UInt16, connectTimeout: TimeInterval = 4) {
+  public init(
+    host: String = "127.0.0.1",
+    port: UInt16,
+    connectTimeout: TimeInterval = 4,
+    receiveTimeout: TimeInterval? = nil
+  ) {
     self.host = host
     self.port = port
     self.connectTimeout = connectTimeout
+    self.receiveTimeout = receiveTimeout ?? connectTimeout
   }
 
   /// The LIVE read-projection seam: the loopback host:port the slice-6 read-projection
@@ -170,7 +179,8 @@ public enum RealReadClientFactory {
 /// honest unavailable. Never fake-ready.
 final class LoopbackSealedWSTransport: SealedWSTransport {
   private let connection: NWConnection
-  private let timeout: TimeInterval
+  private let connectTimeout: TimeInterval
+  private let receiveTimeout: TimeInterval
   private let host: String
   private let port: UInt16
   private var started = false
@@ -184,7 +194,8 @@ final class LoopbackSealedWSTransport: SealedWSTransport {
     guard let port = NWEndpoint.Port(rawValue: config.port) else {
       throw FridayReadClientError.transport("invalid read-projection port \(config.port)")
     }
-    self.timeout = config.connectTimeout
+    self.connectTimeout = config.connectTimeout
+    self.receiveTimeout = config.receiveTimeout
     self.host = config.host
     self.port = config.port
     self.connection = NWConnection(
@@ -221,9 +232,9 @@ final class LoopbackSealedWSTransport: SealedWSTransport {
       }
     }
     connection.start(queue: .global())
-    if semaphore.wait(timeout: .now() + timeout) == .timedOut {
+    if semaphore.wait(timeout: .now() + connectTimeout) == .timedOut {
       connection.cancel()
-      throw FridayReadClientError.transport("connect timed out after \(timeout)s (server dark?)")
+      throw FridayReadClientError.transport("connect timed out after \(connectTimeout)s (server dark?)")
     }
     if let error = outcome.take() { throw error }
   }
@@ -453,7 +464,7 @@ final class LoopbackSealedWSTransport: SealedWSTransport {
         if let error { outcome.set(FridayReadClientError.transport("send failed: \(error)")) }
         semaphore.signal()
       })
-    if semaphore.wait(timeout: .now() + timeout) == .timedOut {
+    if semaphore.wait(timeout: .now() + connectTimeout) == .timedOut {
       throw FridayReadClientError.transport("send timed out (server dark?)")
     }
     if let error = outcome.take() { throw error }
@@ -474,8 +485,8 @@ final class LoopbackSealedWSTransport: SealedWSTransport {
       }
       semaphore.signal()
     }
-    if semaphore.wait(timeout: .now() + timeout) == .timedOut {
-      throw FridayReadClientError.transport("receive timed out (server dark?)")
+    if semaphore.wait(timeout: .now() + receiveTimeout) == .timedOut {
+      throw FridayReadClientError.transport("receive timed out after \(receiveTimeout)s")
     }
     if let error = outcome.take() { throw error }
     return dataBox.take()

--- a/apps/friday-ios/Sources/FridayMobileShellCore/RealWriteClientFactory.swift
+++ b/apps/friday-ios/Sources/FridayMobileShellCore/RealWriteClientFactory.swift
@@ -39,11 +39,19 @@ public struct AgentRunServerConfig: Sendable, Equatable {
   public let port: UInt16
   /// Connect / preamble timeout. Past this, a dark server surfaces as honest unavailable.
   public let connectTimeout: TimeInterval
+  /// Agent-run result timeout. Long enough for real model turns while connect failure remains fast.
+  public let receiveTimeout: TimeInterval
 
-  public init(host: String = "127.0.0.1", port: UInt16, connectTimeout: TimeInterval = 4) {
+  public init(
+    host: String = "127.0.0.1",
+    port: UInt16,
+    connectTimeout: TimeInterval = 4,
+    receiveTimeout: TimeInterval = 300
+  ) {
     self.host = host
     self.port = port
     self.connectTimeout = connectTimeout
+    self.receiveTimeout = receiveTimeout
   }
 
   /// The LIVE write seam: the loopback host:port the agent-run WRITE LaunchAgent
@@ -62,6 +70,11 @@ public struct AgentRunServerConfig: Sendable, Equatable {
 /// (A handshake-only probe never asserts the principal — owner-auth is exercised only by a
 /// dispatch, which the live-write transport proof deliberately does NOT send.)
 public let liveAgentRunOwnerPrincipal = "admin-001"
+
+/// Mobile live WRITE client with both the legacy chat dispatch API and the first-class
+/// mission-bound dispatch API. The concrete implementation is still the shared `SealedWSWriteClient`.
+public typealias FridayMobileMissionDispatchingWriteClient =
+  FridayRustWriteClient & FridayMissionSpineWriteClient & FridayMissionBoundRunWriteClient
 
 /// Builds the REAL `SealedWSWriteClient` for the agent-run WRITE server.
 public enum RealWriteClientFactory {
@@ -84,14 +97,17 @@ public enum RealWriteClientFactory {
     forwardedPrincipal: String,
     sessionId: String? = nil,
     agentRunControlViaRust: Bool = false
-  ) -> FridayRustWriteClient {
+  ) -> FridayMobileMissionDispatchingWriteClient {
     SealedWSWriteClient(
       keypair: keypair,
       forwardedPrincipal: forwardedPrincipal,
       sessionId: sessionId,
       agentRunControlViaRust: agentRunControlViaRust,
       makeTransport: { try LoopbackSealedWSTransport(config: ReadProjectionServerConfig(
-        host: config.host, port: config.port, connectTimeout: config.connectTimeout)) }
+        host: config.host,
+        port: config.port,
+        connectTimeout: config.connectTimeout,
+        receiveTimeout: config.receiveTimeout)) }
     )
   }
 
@@ -116,7 +132,7 @@ public enum RealWriteClientFactory {
     forwardedPrincipal: String = liveAgentRunOwnerPrincipal,
     sessionId: String? = nil,
     agentRunControlViaRust: Bool = false
-  ) throws -> FridayRustWriteClient {
+  ) throws -> FridayMobileMissionDispatchingWriteClient {
     let keypair = try MasterKeyPeer.deriveKeypair()
     return make(
       config: config,

--- a/apps/friday-ios/Tests/FridayMobileShellCoreTests/LiveMissionSpineWriteDispatchIntegrationTests.swift
+++ b/apps/friday-ios/Tests/FridayMobileShellCoreTests/LiveMissionSpineWriteDispatchIntegrationTests.swift
@@ -8,26 +8,20 @@ import Testing
 //
 // Drives the real iOS shared write transport against the live agent-run WRITE server on
 // 127.0.0.1:48750 as the enrolled master-derived peer. This sends a single Mission intake and
-// expects a refs-only server receipt.
+// expects a refs-only server receipt. A stricter opt-in test also dispatches the returned
+// Mission/WorkItem handle as a read-only mission-bound model turn.
 //
-// HONEST CEILING: this is an agent-driven live product-surface write proof. It is not OG9 organic
-// origin, not a provider/model turn, not a completed_with_proof claim, and not A1 live-done.
+// HONEST CEILING: these are agent-driven live product-surface proofs. They are not OG9 organic
+// origin and not A1 live-done.
 
 private let liveMissionSpineWriteDispatchEnabled =
   ProcessInfo.processInfo.environment["FRIDAY_MOBILE_LIVE_WRITE_DISPATCH_TEST"] == "1"
+private let liveMissionBoundRunEnabled =
+  ProcessInfo.processInfo.environment["FRIDAY_MOBILE_LIVE_MISSION_BOUND_RUN_TEST"] == "1"
 
 @Test(.enabled(if: liveMissionSpineWriteDispatchEnabled))
 func liveMobileMissionSpineWriteDispatchReturnsReadyReceipt() async throws {
-  let keypair = try MasterKeyPeer.deriveKeypair()
-  let client = SealedWSWriteClient(
-    keypair: keypair,
-    forwardedPrincipal: liveAgentRunOwnerPrincipal,
-    makeTransport: {
-      try LoopbackSealedWSTransport(config: ReadProjectionServerConfig(
-        host: AgentRunServerConfig.liveLoopback.host,
-        port: AgentRunServerConfig.liveLoopback.port,
-        connectTimeout: AgentRunServerConfig.liveLoopback.connectTimeout))
-    })
+  let client = try RealWriteClientFactory.makeLive()
   let request = makeLiveMobileIntake()
 
   let result = try await client.submitMissionIntake(request)
@@ -44,7 +38,45 @@ func liveMobileMissionSpineWriteDispatchReturnsReadyReceipt() async throws {
   #expect(result.surfaceThreadId == request.surfaceThreadId)
 }
 
-private func makeLiveMobileIntake() -> MissionIntakeRequestWire {
+@Test(.enabled(if: liveMissionBoundRunEnabled))
+func liveMobileMissionSpineWriteDispatchCanStartMissionBoundRun() async throws {
+  let client = try RealWriteClientFactory.makeLive()
+  let request = makeLiveMobileIntake(
+    title: "Verify live mobile auto-route mission-bound Claude run",
+    intent: "写一份调研综述，总结 Friday 这个方案的利弊和下一步计划。",
+    lane: "auto",
+    targetProviderOrAgent: nil)
+
+  let result = try await client.submitMissionIntake(request)
+  #expect(result.status == "ready")
+  #expect(result.workItemId == request.workItemId)
+
+  let outcome = try await client.dispatchMissionBoundAgentRun(
+    task: request.intent,
+    missionContext: MissionWorkItemContextWire(
+      fridayConversationId: result.fridayConversationId,
+      missionId: result.missionId,
+      workItemId: try #require(result.workItemId)),
+    constraints: AgentRunConstraintsWire(readOnly: true))
+
+  guard case .result(let receipt) = outcome else {
+    Issue.record("expected mission-bound read-only run to settle with a result")
+    return
+  }
+  print(
+    "[live-write-dispatch][mobile-bound] runId=\(receipt.runId) "
+      + "status=\(receipt.status) turns=\(receipt.turns ?? 0)")
+  #expect(receipt.status == "completed" || receipt.status == "finished" || receipt.status == "ok")
+}
+
+private func makeLiveMobileIntake(
+  title: String = "Verify live mobile mission-spine write receipt",
+  intent: String = "create a workflow that triggers every morning at 9am, reads the Friday live mobile "
+    + "write receipt, and posts a refs-only status summary to the operator console as its "
+    + "output destination",
+  lane: String = "deepseek",
+  targetProviderOrAgent: String? = "deepseek"
+) -> MissionIntakeRequestWire {
   let id = UUID().uuidString.lowercased().replacingOccurrences(of: "-", with: "")
   return MissionIntakeRequestWire(
     fridayConversationId: "fconv_mobile_live_write_\(id)",
@@ -55,10 +87,8 @@ private func makeLiveMobileIntake() -> MissionIntakeRequestWire {
     visibilityPolicy: "compact",
     missionId: "mission-mobile-live-write-\(id)",
     workItemId: "work-mobile-live-write-\(id)",
-    title: "Verify live mobile mission-spine write receipt",
-    intent: "create a workflow that triggers every morning at 9am, reads the Friday live mobile "
-      + "write receipt, and posts a refs-only status summary to the operator console as its "
-      + "output destination",
-    lane: "deepseek",
-    targetProviderOrAgent: "deepseek")
+    title: title,
+    intent: intent,
+    lane: lane,
+    targetProviderOrAgent: targetProviderOrAgent)
 }

--- a/apps/macos/FridayHubConsole/Sources/FridayHubConsole/FridayHubConsoleApp.swift
+++ b/apps/macos/FridayHubConsole/Sources/FridayHubConsole/FridayHubConsoleApp.swift
@@ -47,7 +47,10 @@ struct FridayHubConsoleApp: App {
 
   var body: some Scene {
     WindowGroup("Friday Hub Console") {
-      HubConsoleShell(client: Self.readClient, writeClient: Self.writeClient)
+      HubConsoleShell(
+        client: Self.readClient,
+        writeClient: Self.writeClient,
+        missionRunClient: Self.writeClient)
     }
     .windowStyle(.titleBar)
     .defaultSize(width: 1180, height: 720)
@@ -86,7 +89,7 @@ struct FridayHubConsoleApp: App {
   /// honest-unavailable rather than pretending to write against mock read data. The actual connect
   /// happens only when the operator submits an intake / decides a memory candidate (non-blocking
   /// at launch).
-  static var writeClient: FridayMissionSpineWriteClient? {
+  static var writeClient: FridayMissionSpineDispatchingWriteClient? {
     if useMock { return nil }
     do {
       return try RealWriteClientFactory.makeLiveWrite()

--- a/apps/macos/FridayHubConsole/Sources/FridayHubConsole/HubConsoleShell.swift
+++ b/apps/macos/FridayHubConsole/Sources/FridayHubConsole/HubConsoleShell.swift
@@ -10,9 +10,16 @@ struct HubConsoleShell: View {
   @State private var destination: HubDestination = .operations
   @StateObject private var operationsVM: OperationsOverviewViewModel
 
-  init(client: FridayRustReadClient, writeClient: FridayMissionSpineWriteClient? = nil) {
+  init(
+    client: FridayRustReadClient,
+    writeClient: FridayMissionSpineWriteClient? = nil,
+    missionRunClient: FridayMissionBoundRunWriteClient? = nil
+  ) {
     _operationsVM = StateObject(
-      wrappedValue: OperationsOverviewViewModel(client: client, writeClient: writeClient))
+      wrappedValue: OperationsOverviewViewModel(
+        client: client,
+        writeClient: writeClient,
+        missionRunClient: missionRunClient))
   }
 
   var body: some View {

--- a/apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/OperationsOverviewViewModel.swift
+++ b/apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/OperationsOverviewViewModel.swift
@@ -89,6 +89,9 @@ public final class OperationsOverviewViewModel: ObservableObject {
   /// The spine-WRITE collaborator. `nil` ⇒ the write seam is not configured (the drivers render
   /// honest-unavailable). Separate from `client` so the read contract stays a pure read.
   private let writeClient: FridayMissionSpineWriteClient?
+  /// Optional model-turn bridge. When present, a ready MissionIntake receipt immediately dispatches
+  /// a read-only mission-bound run using the server-produced Mission handle.
+  private let missionRunClient: FridayMissionBoundRunWriteClient?
   /// The owner principal the WRITE body self-supplies — MUST equal the server's `--owner`
   /// (`admin-001`); the server fail-closes a mismatch (FIX-Q3b). Wired from config, not UI input.
   private let writeOwnerPrincipal: String
@@ -99,11 +102,13 @@ public final class OperationsOverviewViewModel: ObservableObject {
   public init(
     client: FridayRustReadClient,
     writeClient: FridayMissionSpineWriteClient? = nil,
+    missionRunClient: FridayMissionBoundRunWriteClient? = nil,
     writeOwnerPrincipal: String = liveReadProjectionOwnerPrincipal,
     newId: @escaping @Sendable () -> String = { UUID().uuidString }
   ) {
     self.client = client
     self.writeClient = writeClient
+    self.missionRunClient = missionRunClient
     self.writeOwnerPrincipal = writeOwnerPrincipal
     self.newId = newId
   }
@@ -135,7 +140,8 @@ public final class OperationsOverviewViewModel: ObservableObject {
   // MARK: - Spine-WRITE drivers (Lane-D entry-point-A organic loop)
 
   /// Submit ONE operator-typed Mission intake over the sealed WRITE seam. Births a Mission +
-  /// WorkItem(Draft) server-side (NO model call); renders the refs-only receipt honestly:
+  /// WorkItem(Draft) server-side, then dispatches a mission-bound read-only model run when the
+  /// model-turn bridge is configured; renders the refs-only receipt honestly:
   ///  - `ready`               ⇒ `.confirmed` (status + mission/work-item ids),
   ///  - `needs_clarification` ⇒ `.confirmed` carrying the questions (rendered as a clarification ask),
   ///  - `blocked`             ⇒ `.error` (the blockers),
@@ -169,7 +175,25 @@ public final class OperationsOverviewViewModel: ObservableObject {
         // ready / created_or_ready
         var summary = "Mission intake \(result.status) · mission_id=\(result.missionId)"
         if let workItemId = result.workItemId { summary += " · work_item_id=\(workItemId)" }
-        intakeState = .confirmed(summary: summary, clarificationQuestions: result.clarificationQuestions)
+        if let workItemId = result.workItemId, let missionRunClient {
+          let context = MissionWorkItemContextWire(
+            fridayConversationId: result.fridayConversationId,
+            missionId: result.missionId,
+            workItemId: workItemId)
+          do {
+            let outcome = try await missionRunClient.dispatchMissionBoundAgentRun(
+              task: trimmed,
+              missionContext: context,
+              constraints: AgentRunConstraintsWire(readOnly: true))
+            summary += Self.dispatchSummary(for: outcome)
+            intakeState = .confirmed(summary: summary, clarificationQuestions: result.clarificationQuestions)
+          } catch {
+            intakeState = .error(
+              reason: "Mission intake ready, but model dispatch failed — \(Self.writeReason(for: error))")
+          }
+        } else {
+          intakeState = .confirmed(summary: summary, clarificationQuestions: result.clarificationQuestions)
+        }
         await refresh()
       }
     } catch {
@@ -265,6 +289,15 @@ public final class OperationsOverviewViewModel: ObservableObject {
       }
     }
     return "Write seam unavailable — \(error)"
+  }
+
+  static func dispatchSummary(for outcome: AgentRunDispatchOutcome) -> String {
+    switch outcome {
+    case .result(let result):
+      return " · run_id=\(result.runId) · run_status=\(result.status)"
+    case .paused(let paused):
+      return " · run_id=\(paused.runId) · paused_for_approval=\(paused.approvalId)"
+    }
   }
 
   private static func reason(for error: Error) -> String {

--- a/apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/RealReadClientFactory.swift
+++ b/apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/RealReadClientFactory.swift
@@ -29,11 +29,20 @@ public struct ReadProjectionServerConfig: Sendable, Equatable {
   public let port: UInt16
   /// Connect / preamble timeout. Past this, a dark server surfaces as honest unavailable.
   public let connectTimeout: TimeInterval
+  /// Response-frame timeout. Defaults to `connectTimeout`; write clients can extend this for
+  /// real model-turn agent runs without making dark-server connects hang.
+  public let receiveTimeout: TimeInterval
 
-  public init(host: String = "127.0.0.1", port: UInt16, connectTimeout: TimeInterval = 4) {
+  public init(
+    host: String = "127.0.0.1",
+    port: UInt16,
+    connectTimeout: TimeInterval = 4,
+    receiveTimeout: TimeInterval? = nil
+  ) {
     self.host = host
     self.port = port
     self.connectTimeout = connectTimeout
+    self.receiveTimeout = receiveTimeout ?? connectTimeout
   }
 
   /// A PLACEHOLDER loopback config for pre-slice-6.
@@ -150,7 +159,8 @@ struct HonestlyUnavailableReadClient: FridayRustReadClient {
 /// honest unavailable. Never fake-ready.
 final class LoopbackSealedWSTransport: SealedWSTransport {
   private let connection: NWConnection
-  private let timeout: TimeInterval
+  private let connectTimeout: TimeInterval
+  private let receiveTimeout: TimeInterval
   private let host: String
   private let port: UInt16
   private var started = false
@@ -164,7 +174,8 @@ final class LoopbackSealedWSTransport: SealedWSTransport {
     guard let port = NWEndpoint.Port(rawValue: config.port) else {
       throw FridayReadClientError.transport("invalid read-projection port \(config.port)")
     }
-    self.timeout = config.connectTimeout
+    self.connectTimeout = config.connectTimeout
+    self.receiveTimeout = config.receiveTimeout
     self.host = config.host
     self.port = config.port
     self.connection = NWConnection(
@@ -201,9 +212,9 @@ final class LoopbackSealedWSTransport: SealedWSTransport {
       }
     }
     connection.start(queue: .global())
-    if semaphore.wait(timeout: .now() + timeout) == .timedOut {
+    if semaphore.wait(timeout: .now() + connectTimeout) == .timedOut {
       connection.cancel()
-      throw FridayReadClientError.transport("connect timed out after \(timeout)s (server dark?)")
+      throw FridayReadClientError.transport("connect timed out after \(connectTimeout)s (server dark?)")
     }
     if let error = outcome.take() { throw error }
   }
@@ -433,7 +444,7 @@ final class LoopbackSealedWSTransport: SealedWSTransport {
         if let error { outcome.set(FridayReadClientError.transport("send failed: \(error)")) }
         semaphore.signal()
       })
-    if semaphore.wait(timeout: .now() + timeout) == .timedOut {
+    if semaphore.wait(timeout: .now() + connectTimeout) == .timedOut {
       throw FridayReadClientError.transport("send timed out (server dark?)")
     }
     if let error = outcome.take() { throw error }
@@ -454,8 +465,8 @@ final class LoopbackSealedWSTransport: SealedWSTransport {
       }
       semaphore.signal()
     }
-    if semaphore.wait(timeout: .now() + timeout) == .timedOut {
-      throw FridayReadClientError.transport("receive timed out (server dark?)")
+    if semaphore.wait(timeout: .now() + receiveTimeout) == .timedOut {
+      throw FridayReadClientError.transport("receive timed out after \(receiveTimeout)s")
     }
     if let error = outcome.take() { throw error }
     return dataBox.take()

--- a/apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/RealWriteClientFactory.swift
+++ b/apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/RealWriteClientFactory.swift
@@ -1,6 +1,9 @@
 import Foundation
 import FridayRustClient
 
+public typealias FridayMissionSpineDispatchingWriteClient =
+  FridayMissionSpineWriteClient & FridayMissionBoundRunWriteClient
+
 // MARK: - Real mission-spine WRITE-client factory (Lane-D entry-point-A organic driver)
 //
 // Builds the REAL `SealedWSWriteClient` (the package's sealed-WS write client) configured for the
@@ -33,11 +36,19 @@ public struct AgentRunWriteServerConfig: Sendable, Equatable {
   public let port: UInt16
   /// Connect / preamble timeout. Past this, a dark server surfaces as honest unavailable.
   public let connectTimeout: TimeInterval
+  /// Agent-run result timeout. Long enough for real model turns while connect failure remains fast.
+  public let receiveTimeout: TimeInterval
 
-  public init(host: String = "127.0.0.1", port: UInt16, connectTimeout: TimeInterval = 4) {
+  public init(
+    host: String = "127.0.0.1",
+    port: UInt16,
+    connectTimeout: TimeInterval = 4,
+    receiveTimeout: TimeInterval = 300
+  ) {
     self.host = host
     self.port = port
     self.connectTimeout = connectTimeout
+    self.receiveTimeout = receiveTimeout
   }
 
   /// The LIVE agent-run WRITE seam: the loopback host:port the agent-run WRITE LaunchAgent
@@ -51,7 +62,8 @@ public struct AgentRunWriteServerConfig: Sendable, Equatable {
 
   /// Map to the read client's transport config (the transport class is shared + port-parameterized).
   var transportConfig: ReadProjectionServerConfig {
-    ReadProjectionServerConfig(host: host, port: port, connectTimeout: connectTimeout)
+    ReadProjectionServerConfig(
+      host: host, port: port, connectTimeout: connectTimeout, receiveTimeout: receiveTimeout)
   }
 }
 
@@ -71,7 +83,7 @@ public enum RealWriteClientFactory {
     config: AgentRunWriteServerConfig,
     keypair: FridayCrypto.DeviceKeypair = FridayCrypto.DeviceKeypair(),
     forwardedPrincipal: String
-  ) -> FridayMissionSpineWriteClient {
+  ) -> FridayMissionSpineDispatchingWriteClient {
     let transportConfig = config.transportConfig
     return SealedWSWriteClient(
       keypair: keypair,
@@ -91,7 +103,7 @@ public enum RealWriteClientFactory {
   public static func makeLiveWrite(
     config: AgentRunWriteServerConfig = .liveLoopback,
     forwardedPrincipal: String = liveReadProjectionOwnerPrincipal
-  ) throws -> FridayMissionSpineWriteClient {
+  ) throws -> FridayMissionSpineDispatchingWriteClient {
     let keypair = try MasterKeyPeer.deriveKeypair()
     return make(config: config, keypair: keypair, forwardedPrincipal: forwardedPrincipal)
   }
@@ -100,19 +112,26 @@ public enum RealWriteClientFactory {
   /// Used by the app when LIVE mode is requested but the master key is unavailable: the compose /
   /// confirm controls must render the truth, NOT a fabricated success (mirrors the read side's
   /// `makeHonestlyUnavailable`).
-  public static func makeHonestlyUnavailableWrite(reason: String) -> FridayMissionSpineWriteClient {
+  public static func makeHonestlyUnavailableWrite(reason: String) -> FridayMissionSpineDispatchingWriteClient {
     HonestlyUnavailableWriteClient(reason: reason)
   }
 }
 
 /// A `FridayMissionSpineWriteClient` that always throws — so the view model renders honest
 /// "unavailable". Never returns a result; it cannot fabricate a confirm.
-struct HonestlyUnavailableWriteClient: FridayMissionSpineWriteClient {
+struct HonestlyUnavailableWriteClient: FridayMissionSpineWriteClient, FridayMissionBoundRunWriteClient {
   let reason: String
   func submitMissionIntake(_ request: MissionIntakeRequestWire) async throws -> MissionIntakeResultWire {
     throw FridayWriteClientError.transport("live write client unavailable: \(reason)")
   }
   func submitMemoryDecision(_ request: MemoryDecisionRequestWire) async throws -> MemoryDecisionResultWire {
+    throw FridayWriteClientError.transport("live write client unavailable: \(reason)")
+  }
+  func dispatchMissionBoundAgentRun(
+    task: String,
+    missionContext: MissionWorkItemContextWire,
+    constraints: AgentRunConstraintsWire?
+  ) async throws -> AgentRunDispatchOutcome {
     throw FridayWriteClientError.transport("live write client unavailable: \(reason)")
   }
 }

--- a/apps/macos/FridayHubConsole/Tests/FridayHubConsoleCoreTests/LiveMissionSpineWriteDispatchIntegrationTests.swift
+++ b/apps/macos/FridayHubConsole/Tests/FridayHubConsoleCoreTests/LiveMissionSpineWriteDispatchIntegrationTests.swift
@@ -8,13 +8,16 @@ import Testing
 //
 // Drives the real Console product write path (`RealWriteClientFactory.makeLiveWrite`) against the
 // live agent-run WRITE server on 127.0.0.1:48750 as the enrolled master-derived peer. This sends a
-// single Mission intake and expects a refs-only server receipt.
+// single Mission intake and expects a refs-only server receipt. A stricter opt-in test also
+// dispatches the returned Mission/WorkItem handle as a read-only mission-bound model turn.
 //
-// HONEST CEILING: this is an agent-driven live product-surface write proof. It is not OG9 organic
-// origin, not a provider/model turn, not a completed_with_proof claim, and not A1 live-done.
+// HONEST CEILING: these are agent-driven live product-surface proofs. They are not OG9 organic
+// origin and not A1 live-done.
 
 private let liveMissionSpineWriteDispatchEnabled =
   ProcessInfo.processInfo.environment["FRIDAY_CONSOLE_LIVE_WRITE_DISPATCH_TEST"] == "1"
+private let liveMissionBoundRunEnabled =
+  ProcessInfo.processInfo.environment["FRIDAY_CONSOLE_LIVE_MISSION_BOUND_RUN_TEST"] == "1"
 
 @Test(.enabled(if: liveMissionSpineWriteDispatchEnabled))
 func liveConsoleMissionSpineWriteDispatchReturnsReadyReceipt() async throws {
@@ -35,7 +38,47 @@ func liveConsoleMissionSpineWriteDispatchReturnsReadyReceipt() async throws {
   #expect(result.surfaceThreadId == request.surfaceThreadId)
 }
 
-private func makeLiveIntake(surface: String, route: String) -> MissionIntakeRequestWire {
+@Test(.enabled(if: liveMissionBoundRunEnabled))
+func liveConsoleMissionSpineWriteDispatchCanStartMissionBoundRun() async throws {
+  let client = try RealWriteClientFactory.makeLiveWrite()
+  let request = makeLiveIntake(
+    surface: "desktop",
+    route: "desktop://hub-console/live-bound-run",
+    title: "Verify live desktop auto-route mission-bound Codex run",
+    intent: "Fix a small Rust compile failure in a workspace and describe the focused regression test that should be added.",
+    lane: "auto",
+    targetProviderOrAgent: nil)
+
+  let result = try await client.submitMissionIntake(request)
+  #expect(result.status == "ready")
+  #expect(result.workItemId == request.workItemId)
+
+  let outcome = try await client.dispatchMissionBoundAgentRun(
+    task: request.intent,
+    missionContext: MissionWorkItemContextWire(
+      fridayConversationId: result.fridayConversationId,
+      missionId: result.missionId,
+      workItemId: try #require(result.workItemId)),
+    constraints: AgentRunConstraintsWire(readOnly: true))
+
+  guard case .result(let receipt) = outcome else {
+    Issue.record("expected mission-bound read-only run to settle with a result")
+    return
+  }
+  print(
+    "[live-write-dispatch][desktop-bound] runId=\(receipt.runId) "
+      + "status=\(receipt.status) turns=\(receipt.turns ?? 0)")
+  #expect(receipt.status == "completed" || receipt.status == "finished" || receipt.status == "ok")
+}
+
+private func makeLiveIntake(
+  surface: String,
+  route: String,
+  title: String? = nil,
+  intent: String? = nil,
+  lane: String = "deepseek",
+  targetProviderOrAgent: String? = "deepseek"
+) -> MissionIntakeRequestWire {
   let id = UUID().uuidString.lowercased().replacingOccurrences(of: "-", with: "")
   return MissionIntakeRequestWire(
     fridayConversationId: "fconv_\(surface)_live_write_\(id)",
@@ -46,10 +89,10 @@ private func makeLiveIntake(surface: String, route: String) -> MissionIntakeRequ
     visibilityPolicy: "compact",
     missionId: "mission-\(surface)-live-write-\(id)",
     workItemId: "work-\(surface)-live-write-\(id)",
-    title: "Verify live \(surface) mission-spine write receipt",
-    intent: "create a workflow that triggers every morning at 9am, reads the Friday live "
+    title: title ?? "Verify live \(surface) mission-spine write receipt",
+    intent: intent ?? "create a workflow that triggers every morning at 9am, reads the Friday live "
       + "\(surface) write receipt, and posts a refs-only status summary to the operator console "
       + "as its output destination",
-    lane: "deepseek",
-    targetProviderOrAgent: "deepseek")
+    lane: lane,
+    targetProviderOrAgent: targetProviderOrAgent)
 }

--- a/apps/macos/FridayHubConsole/Tests/FridayHubConsoleCoreTests/OperationsOverviewViewModelTests.swift
+++ b/apps/macos/FridayHubConsole/Tests/FridayHubConsoleCoreTests/OperationsOverviewViewModelTests.swift
@@ -269,7 +269,7 @@ func realClientFactoryBuildsAgainstLoopbackConfig() {
 /// An in-memory `FridayMissionSpineWriteClient` for view-model tests. Returns a programmed
 /// intake/decision outcome, OR throws to exercise the honest-unavailable path. Captures the last
 /// request so a test can assert the owner_principal / decision the view model wired.
-final class MockMissionSpineWriteClient: FridayMissionSpineWriteClient, @unchecked Sendable {
+final class MockMissionSpineWriteClient: FridayMissionSpineWriteClient, FridayMissionBoundRunWriteClient, @unchecked Sendable {
   enum Behavior: Sendable {
     case intakeReady
     case intakeNeedsClarification
@@ -282,8 +282,12 @@ final class MockMissionSpineWriteClient: FridayMissionSpineWriteClient, @uncheck
   private let lock = NSLock()
   private var _lastIntake: MissionIntakeRequestWire?
   private var _lastDecision: MemoryDecisionRequestWire?
+  private var _lastMissionContext: MissionWorkItemContextWire?
+  private var _lastMissionRunConstraints: AgentRunConstraintsWire?
   var lastIntake: MissionIntakeRequestWire? { lock.withLock { _lastIntake } }
   var lastDecision: MemoryDecisionRequestWire? { lock.withLock { _lastDecision } }
+  var lastMissionContext: MissionWorkItemContextWire? { lock.withLock { _lastMissionContext } }
+  var lastMissionRunConstraints: AgentRunConstraintsWire? { lock.withLock { _lastMissionRunConstraints } }
 
   init(behavior: Behavior) { self.behavior = behavior }
 
@@ -327,6 +331,21 @@ final class MockMissionSpineWriteClient: FridayMissionSpineWriteClient, @uncheck
         recallable: request.decision == "confirm")
     }
   }
+
+  func dispatchMissionBoundAgentRun(
+    task: String,
+    missionContext: MissionWorkItemContextWire,
+    constraints: AgentRunConstraintsWire?
+  ) async throws -> AgentRunDispatchOutcome {
+    lock.withLock {
+      _lastMissionContext = missionContext
+      _lastMissionRunConstraints = constraints
+    }
+    if case .throwsTransport = behavior {
+      throw FridayWriteClientError.transport("connection refused (write server dark)")
+    }
+    return .result(AgentRunResultWire(runId: "run-bound-1", status: "completed", turns: 1))
+  }
 }
 
 @Test
@@ -349,6 +368,27 @@ func submitIntakeReadyRendersConfirmedAndWiresOwnerAdmin001() async {
   #expect(write.lastIntake?.ownerPrincipal == "admin-001")
   #expect(write.lastIntake?.surfaceKind == "desktop")
   #expect(write.lastIntake?.lane == "deepseek")
+}
+
+@Test
+@MainActor
+func submitIntakeReadyDispatchesMissionBoundModelTurnWhenRunClientConfigured() async {
+  let write = MockMissionSpineWriteClient(behavior: .intakeReady)
+  let vm = OperationsOverviewViewModel(
+    client: MockReadClient(behavior: .loaded), writeClient: write, missionRunClient: write,
+    writeOwnerPrincipal: "admin-001", newId: { "fixed" })
+  await vm.submitIntake(intent: "keep one Mission across every surface")
+
+  guard case let .confirmed(summary, _) = vm.intakeState else {
+    Issue.record("expected .confirmed, got \(vm.intakeState)")
+    return
+  }
+  #expect(summary.contains("run_id=run-bound-1"))
+  #expect(write.lastMissionContext == MissionWorkItemContextWire(
+    fridayConversationId: "fconv_desktop_fixed",
+    missionId: "mission-desktop-fixed",
+    workItemId: "work-desktop-fixed"))
+  #expect(write.lastMissionRunConstraints?.readOnly == true)
 }
 
 @Test

--- a/apps/macos/FridayRustClient/Sources/FridayRustClient/Protocol.swift
+++ b/apps/macos/FridayRustClient/Sources/FridayRustClient/Protocol.swift
@@ -159,6 +159,7 @@ extension FridayMessage: Codable {
     case authProof = "auth_proof"
     case sessionId = "session_id"
     case constraints
+    case missionContext = "mission_context"
     case status
     case answerSha256 = "answer_sha256"
     case answerLen = "answer_len"
@@ -197,7 +198,8 @@ extension FridayMessage: Codable {
         forwardedPrincipal: try c.decode(String.self, forKey: .forwardedPrincipal),
         authProof: try c.decode([UInt8].self, forKey: .authProof),
         sessionId: try c.decodeIfPresent(String.self, forKey: .sessionId),
-        constraints: try c.decodeIfPresent(AgentRunConstraintsWire.self, forKey: .constraints)
+        constraints: try c.decodeIfPresent(AgentRunConstraintsWire.self, forKey: .constraints),
+        missionContext: try c.decodeIfPresent(MissionWorkItemContextWire.self, forKey: .missionContext)
       ))
     case "AgentRunResult":
       let c = try decoder.container(keyedBy: WriteKey.self)
@@ -271,7 +273,8 @@ extension FridayMessage: Codable {
     case .agentRunRequest(let req):
       var c = encoder.container(keyedBy: WriteKey.self)
       // Field order MIRRORS the Rust serde struct-variant order: kind, run_id, task,
-      // forwarded_principal, auth_proof, [session_id], [constraints]. Optional fields are
+      // forwarded_principal, auth_proof, [session_id], [constraints], [mission_context].
+      // Optional fields are
       // OMITTED when nil/empty (serde `skip_serializing_if`), keeping a sessionless/
       // constraint-free request byte-identical to the pre-A1/A2a wire.
       try c.encode("AgentRunRequest", forKey: .kind)
@@ -282,6 +285,9 @@ extension FridayMessage: Codable {
       if let sessionId = req.sessionId { try c.encode(sessionId, forKey: .sessionId) }
       if let constraints = req.constraints, !constraints.isWireEmpty {
         try c.encode(constraints, forKey: .constraints)
+      }
+      if let missionContext = req.missionContext {
+        try c.encode(missionContext, forKey: .missionContext)
       }
     case .agentRunResult(let r):
       var c = encoder.container(keyedBy: WriteKey.self)

--- a/apps/macos/FridayRustClient/Sources/FridayRustClient/WriteClient.swift
+++ b/apps/macos/FridayRustClient/Sources/FridayRustClient/WriteClient.swift
@@ -171,6 +171,16 @@ public protocol FridayMissionSpineWriteClient: Sendable {
   func submitMemoryDecision(_ request: MemoryDecisionRequestWire) async throws -> MemoryDecisionResultWire
 }
 
+/// Product-facing bridge for MissionIntakeResult -> mission-bound AgentRunRequest. This is the
+/// model-turn leg: it carries the server-produced Mission handle on the sealed WRITE dispatch.
+public protocol FridayMissionBoundRunWriteClient: Sendable {
+  func dispatchMissionBoundAgentRun(
+    task: String,
+    missionContext: MissionWorkItemContextWire,
+    constraints: AgentRunConstraintsWire?
+  ) async throws -> AgentRunDispatchOutcome
+}
+
 // MARK: - The sealed-WS write client implementation
 
 /// The sealed-WS WRITE client. Drives the full handshake + dispatch + courier LOGIC over an
@@ -183,7 +193,7 @@ public protocol FridayMissionSpineWriteClient: Sendable {
 /// carries no mutable shared state across an `await`, so it is safe to send — the SAME asserted
 /// posture as `SealedWSReadClient`. This lets a `@MainActor` view model store one and run the
 /// blocking synchronous transport OFF the main thread.
-public final class SealedWSWriteClient: FridayRustWriteClient, FridayMissionSpineWriteClient, @unchecked Sendable {
+public final class SealedWSWriteClient: FridayRustWriteClient, FridayMissionSpineWriteClient, FridayMissionBoundRunWriteClient, @unchecked Sendable {
   private let keypair: FridayCrypto.DeviceKeypair
   private let forwardedPrincipal: String
   private let sessionId: String?
@@ -229,6 +239,22 @@ public final class SealedWSWriteClient: FridayRustWriteClient, FridayMissionSpin
     task: String,
     constraints: AgentRunConstraintsWire? = nil
   ) async throws -> AgentRunDispatchOutcome {
+    try await dispatchAgentRun(task: task, constraints: constraints, missionContext: nil)
+  }
+
+  public func dispatchMissionBoundAgentRun(
+    task: String,
+    missionContext: MissionWorkItemContextWire,
+    constraints: AgentRunConstraintsWire? = nil
+  ) async throws -> AgentRunDispatchOutcome {
+    try await dispatchAgentRun(task: task, constraints: constraints, missionContext: missionContext)
+  }
+
+  private func dispatchAgentRun(
+    task: String,
+    constraints: AgentRunConstraintsWire?,
+    missionContext: MissionWorkItemContextWire?
+  ) async throws -> AgentRunDispatchOutcome {
     let transport = try makeTransport()
     let (sessionKey, sessionNonce) = try handshake(transport)
 
@@ -249,7 +275,8 @@ public final class SealedWSWriteClient: FridayRustWriteClient, FridayMissionSpin
       forwardedPrincipal: forwardedPrincipal,
       authProof: authProof,
       sessionId: normalizedSessionId(),
-      constraints: constraints
+      constraints: constraints,
+      missionContext: missionContext
     )
     let reqEnvelope = FridayEnvelope(
       msgId: "agent-run-\(runId)",

--- a/apps/macos/FridayRustClient/Sources/FridayRustClient/WriteProtocol.swift
+++ b/apps/macos/FridayRustClient/Sources/FridayRustClient/WriteProtocol.swift
@@ -121,6 +121,26 @@ public struct AgentRunConstraintsWire: Codable, Equatable, Sendable {
 
 // MARK: - AgentRunRequestWire
 
+/// First-class Mission handle for a bound agent run. Mirrors
+/// `friday_protocol::MissionWorkItemContextWire`; it is a selector, not authority.
+public struct MissionWorkItemContextWire: Codable, Equatable, Sendable {
+  public var fridayConversationId: String
+  public var missionId: String
+  public var workItemId: String
+
+  public init(fridayConversationId: String, missionId: String, workItemId: String) {
+    self.fridayConversationId = fridayConversationId
+    self.missionId = missionId
+    self.workItemId = workItemId
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case fridayConversationId = "friday_conversation_id"
+    case missionId = "mission_id"
+    case workItemId = "work_item_id"
+  }
+}
+
 /// trusted-peer→hub WRITE dispatch. Mirrors `friday_protocol::Message::AgentRunRequest`'s fields
 /// (flattened as siblings of `kind` on the wire). The `authProof` is the sealed possession proof
 /// bound to `(forwardedPrincipal, runId)`; `sessionId`/`constraints` are additive-optional.
@@ -131,6 +151,7 @@ public struct AgentRunRequestWire: Equatable, Sendable {
   public var authProof: [UInt8]
   public var sessionId: String?
   public var constraints: AgentRunConstraintsWire?
+  public var missionContext: MissionWorkItemContextWire?
 
   public init(
     runId: String,
@@ -138,7 +159,8 @@ public struct AgentRunRequestWire: Equatable, Sendable {
     forwardedPrincipal: String,
     authProof: [UInt8],
     sessionId: String? = nil,
-    constraints: AgentRunConstraintsWire? = nil
+    constraints: AgentRunConstraintsWire? = nil,
+    missionContext: MissionWorkItemContextWire? = nil
   ) {
     self.runId = runId
     self.task = task
@@ -146,6 +168,7 @@ public struct AgentRunRequestWire: Equatable, Sendable {
     self.authProof = authProof
     self.sessionId = sessionId
     self.constraints = constraints
+    self.missionContext = missionContext
   }
 }
 

--- a/apps/macos/FridayRustClient/Tests/FridayRustClientTests/WriteClientWiringTests.swift
+++ b/apps/macos/FridayRustClient/Tests/FridayRustClientTests/WriteClientWiringTests.swift
@@ -45,6 +45,7 @@ final class WriteClientWiringTests: XCTestCase {
     private(set) var receivedSignedBlob: [UInt8]?
     private(set) var receivedConstraints: AgentRunConstraintsWire?
     private(set) var receivedSessionId: String?
+    private(set) var receivedMissionContext: MissionWorkItemContextWire?
 
     init(serverKeypair: FridayCrypto.DeviceKeypair, sessionNonce: [UInt8],
          peerAllowlist: [[UInt8]], ownerAllowlist: [String], mode: ServerMode) {
@@ -96,6 +97,7 @@ final class WriteClientWiringTests: XCTestCase {
     private func handleDispatch(_ req: AgentRunRequestWire, sessionKey: [UInt8], correlation: String) throws {
       receivedConstraints = req.constraints
       receivedSessionId = req.sessionId
+      receivedMissionContext = req.missionContext
       // AUTH — the SAME chain: open the auth_proof under the session key with auth_aad(write_aad,
       // principal, run_id); it must equal the WRITE nonce-bound challenge; principal must be on the
       // owner allowlist. (The WRITE constants, not the read constants.)
@@ -204,6 +206,23 @@ final class WriteClientWiringTests: XCTestCase {
     XCTAssertTrue(got.mutatingToolGrant.isEmpty)
     XCTAssertNil(got.mutationGate)
     XCTAssertEqual(transport.receivedSessionId, "sess-1")
+  }
+
+  func testDispatch_missionBoundCarriesFirstClassMissionContext() async throws {
+    let (client, transport) = try makeClient(mode: .completeRun, controlEnabled: false)
+    let context = MissionWorkItemContextWire(
+      fridayConversationId: "fconv-product-1",
+      missionId: "mission-product-1",
+      workItemId: "work-product-1")
+    let outcome = try await client.dispatchMissionBoundAgentRun(
+      task: "summarize the mission state",
+      missionContext: context,
+      constraints: AgentRunConstraintsWire(readOnly: true))
+    guard case .result(let r) = outcome else { return XCTFail("expected a result outcome") }
+    XCTAssertEqual(r.runId, "run-wiring-1")
+    XCTAssertEqual(transport.receivedMissionContext, context)
+    XCTAssertEqual(transport.receivedConstraints?.readOnly, true)
+    XCTAssertEqual(transport.dispatched, 1)
   }
 
   // MARK: dispatch — pause (flag-gated)


### PR DESCRIPTION
## Summary
- add first-class Swift mission_context wire support for AgentRunRequest
- add product-facing mission-bound dispatch client APIs over the existing sealed WRITE transport
- have the desktop operations surface dispatch a read-only mission-bound model run after a ready Mission intake receipt
- expose the same mission-bound dispatch capability to the iOS shared live write client and add an env-gated mobile live-bound run test

## Truth labels
- organic=0
- This is a desktop+mobile product-surface model-turn dispatch mechanism, not OG9 organic-origin live-done and not A1 live-done.
- The live mobile-bound test remains explicit env-gated; default app behavior and shipped live flags stay unchanged.
- The dispatch remains governed by the existing sealed WRITE server, owner allowlist, and read-only constraints; no operator signing key is read or minted here.

## Tests
- swift test --package-path apps/macos/FridayRustClient --filter WriteClientWiringTests
- swift test --package-path apps/macos/FridayHubConsole --filter OperationsOverviewViewModelTests
- swift test --package-path apps/friday-ios
- git diff --check