### PR TITLE
Salvage system intent all-features gate cleanup

### DIFF
--- a/rust-core/crates/friday-hub/Cargo.toml
+++ b/rust-core/crates/friday-hub/Cargo.toml
@@ -10,14 +10,13 @@ rust-version.workspace = true
 [features]
 # DEPLOY-GO actuation gate (Barrier 3). DEFAULT-OFF. The default build has NO real,
 # host-effecting `OsActuationBackend` compiled in: `OsIntentExecutor::production_default`
-# is `#[cfg(not(feature = "os-actuation-deploy-go"))]` and returns a
-# `OsIntentExecutor<UnavailableBackend>` — the only constructible production backend is
-# `UnavailableBackend`, which actuates NOTHING (compile-time property). A REAL backend can
-# only ship via a deliberate, reviewable, RECOMPILED DEPLOY-GO cutover that enables this
-# feature and supplies the impl — it can NEVER be flipped on at runtime (there is no
-# `env::var` that selects a backend; the selection is `#[cfg(feature = ...)]`-only). Until
-# that cutover the feature-ON arm is an explicit unbuilt seam (`compile_error!`), so the
-# default build cannot even link a real actuator. KEEP DEFAULT-OFF.
+# returns `OsIntentExecutor<UnavailableBackend>` — the only constructible production
+# backend is `UnavailableBackend`, which actuates NOTHING (compile-time property). A REAL
+# backend can only ship via a deliberate, reviewable, RECOMPILED DEPLOY-GO cutover that
+# enables this feature and supplies the impl — it can NEVER be flipped on at runtime
+# (there is no `env::var` that selects a backend; the production selector remains pinned
+# to `UnavailableBackend` until a real backend cutover is reviewed and wired). KEEP
+# DEFAULT-OFF.
 os-actuation-deploy-go = []
 
 [dependencies]

--- a/rust-core/crates/friday-hub/src/system_intent.rs
+++ b/rust-core/crates/friday-hub/src/system_intent.rs
@@ -379,46 +379,31 @@ impl OsIntentExecutor<UnavailableBackend> {
 // return TYPE is the compile-time enforcement of the audited "a real backend can never be
 // flipped on at runtime" property:
 //
-//   * DEFAULT build (feature OFF) — the selector is concretely typed
-//     `OsIntentExecutor<UnavailableBackend>`. The ONLY constructible production backend is
-//     `UnavailableBackend`, which actuates NOTHING. There is NO `env::var` (or any runtime
-//     input) that could swap in a real backend: the choice is `#[cfg(feature = ...)]`-only.
-//   * DEPLOY-GO build (feature ON) — the arm is an explicit unbuilt seam. Shipping a real
-//     host-effecting backend requires a deliberate, reviewable, RECOMPILED cutover that
-//     both enables the feature AND supplies the impl here. Until then the feature-ON build
-//     does not compile, so the default binary can never link a real actuator by accident.
+//   * CURRENT builds — with or without the placeholder `os-actuation-deploy-go` feature —
+//     are concretely typed `OsIntentExecutor<UnavailableBackend>`. The ONLY constructible
+//     production backend is `UnavailableBackend`, which actuates NOTHING. There is NO
+//     `env::var` (or any runtime input) that could swap in a real backend.
+//   * FUTURE DEPLOY-GO cutover — shipping a real host-effecting backend requires a
+//     deliberate, reviewable, RECOMPILED code change here that changes the selector's
+//     concrete return type and wires the backend. Until then, even `--all-features` links
+//     only the unavailable backend.
 //
 // This preserves the dark posture: the default build is byte-identical in behavior to
-// today (UnavailableBackend only, nothing actuates), and adds a compile-time barrier
-// against a runtime flip.
+// today (UnavailableBackend only, nothing actuates), while keeping broad feature-matrix
+// checks compilable.
 impl OsIntentExecutor<UnavailableBackend> {
-    /// The production OS-executor selector (Barrier 3). On the DEFAULT build the return
-    /// type is pinned to `OsIntentExecutor<UnavailableBackend>` — the only constructible
-    /// production backend, which actuates NOTHING. A real backend is reachable ONLY via a
-    /// recompiled DEPLOY-GO cutover (the `os-actuation-deploy-go` feature), never a runtime
-    /// flag. The default-build executor is dry-run/observe + empty allowlist + unavailable
-    /// backend — identical to [`dry_run_default`](Self::dry_run_default) — so calling this
-    /// can never move the host on a default build.
-    #[cfg(not(feature = "os-actuation-deploy-go"))]
+    /// The production OS-executor selector (Barrier 3). The return type is pinned to
+    /// `OsIntentExecutor<UnavailableBackend>` — the only constructible production backend,
+    /// which actuates NOTHING. A real backend is reachable ONLY via a reviewed DEPLOY-GO
+    /// code cutover here, never a runtime flag. The executor is dry-run/observe + empty
+    /// allowlist + unavailable backend — identical to
+    /// [`dry_run_default`](Self::dry_run_default) — so calling this can never move the host.
     pub fn production_default() -> OsIntentExecutor<UnavailableBackend> {
-        // The default build offers EXACTLY ONE production backend: UnavailableBackend.
+        // Current builds offer EXACTLY ONE production backend: UnavailableBackend.
         // No `env::var`, no runtime selection — the backend is fixed at compile time.
         OsIntentExecutor::dry_run_default()
     }
 }
-
-// DEPLOY-GO arm: the real, host-effecting backend selector is an explicit UNBUILT seam.
-// A real `OsActuationBackend` (a signed companion/Swift helper / least-privilege OS
-// process) is provisioned here ONLY at the DEPLOY-GO cutover, which is a deliberate,
-// reviewable RECOMPILE. Until that lands the feature-ON build intentionally does not
-// compile, so a real actuator can never be linked into a default binary.
-#[cfg(feature = "os-actuation-deploy-go")]
-compile_error!(
-    "os-actuation-deploy-go: no real OsActuationBackend is wired yet. Provisioning a \
-     host-effecting backend is a DEPLOY-GO cutover (deliberate, reviewable recompile) — \
-     wire the real backend + an `OsIntentExecutor::production_default` selector for this \
-     arm here before building with this feature."
-);
 
 impl<B: OsActuationBackend> OsIntentExecutor<B> {
     /// Build an executor with the actuate flag set EXPLICITLY, an operator-curated
@@ -1583,9 +1568,8 @@ mod tests {
     }
 
     #[test]
-    #[cfg(not(feature = "os-actuation-deploy-go"))]
-    fn barrier3_production_default_selector_cannot_actuate_on_default_build() {
-        // Barrier 3 (compile-time DEPLOY-GO gate): on the DEFAULT build the production
+    fn barrier3_production_default_selector_cannot_actuate() {
+        // Barrier 3 (compile-time DEPLOY-GO gate): in current builds the production
         // selector `production_default()` returns an `OsIntentExecutor<UnavailableBackend>`
         // — the backend type is PINNED at compile time, so the only constructible
         // production backend is the one that actuates NOTHING. There is no runtime/env
@@ -1594,7 +1578,7 @@ mod tests {
         // and nothing is ever `Completed`.
         //
         // The `let ex: OsIntentExecutor<UnavailableBackend>` annotation is itself part of
-        // the proof: it would FAIL TO COMPILE on the default build if the selector could
+        // the proof: it would FAIL TO COMPILE if the selector could
         // return any other (e.g. real, host-effecting) backend.
         let ex: OsIntentExecutor<UnavailableBackend> = OsIntentExecutor::production_default();
         for a in [
@@ -1625,7 +1609,7 @@ mod tests {
             );
         }
         // Pin the equivalence to the dry-run ship default: the production selector is the
-        // unavailable-backend dry-run posture on the default build, by construction.
+        // unavailable-backend dry-run posture, by construction.
         let baseline = OsIntentExecutor::dry_run_default();
         assert_eq!(
             ex.would_actuate(IntentAction::LaunchApp),


### PR DESCRIPTION
## Summary
- salvage the system intent all-features gate cleanup from the prod dirty tree into a normal branch/PR
- keep the current production selector pinned to UnavailableBackend even when the placeholder os-actuation-deploy-go feature is enabled
- update the barrier test so --all-features can compile without wiring any host-effecting backend

## Validation
- cargo check -p friday-hub --all-features
- cargo test -p friday-hub system_intent -- --nocapture
- git diff --check

## Truth Boundary
organic=0. This is a salvaged compile/gate cleanup only. It does not wire a real OS actuator, does not flip deploy-go live, and does not close D20/B4/OG9.