### PR TITLE
Wire A1 run outcome decisions into Console

### DIFF
--- a/apps/macos/FridayHubConsole/Sources/FridayHubConsole/OperationsOverviewScreen.swift
+++ b/apps/macos/FridayHubConsole/Sources/FridayHubConsole/OperationsOverviewScreen.swift
@@ -94,6 +94,7 @@ struct OperationsOverviewScreen: View {
       receiptsCard(snapshot)
       transcriptCard(snapshot)
       memoryCard(snapshot)
+      runOutcomeLearningCard(snapshot)
     }
     .padding(20)
   }
@@ -286,6 +287,31 @@ struct OperationsOverviewScreen: View {
     }
   }
 
+  private func runOutcomeLearningCard(_ snapshot: WorkbenchSnapshot) -> some View {
+    GlassPanel {
+      VStack(alignment: .leading, spacing: HubTheme.rowSpacing) {
+        cardTitle("Run Outcome Learning")
+        if snapshot.runOutcomeLearningCandidates.isEmpty {
+          Text("No pending run-outcome learning candidates.")
+            .font(.system(size: 12))
+            .foregroundStyle(HubTheme.textSecondary)
+        } else {
+          ForEach(snapshot.runOutcomeLearningCandidates) { candidate in
+            RunOutcomeLearningCandidateRow(
+              candidate: candidate,
+              state: viewModel.runOutcomeLearningDecisionStates[candidate.id] ?? .ready,
+              onConfirm: {
+                Task { await viewModel.decideRunOutcomeLearning(candidateId: candidate.id, confirm: true) }
+              },
+              onReject: {
+                Task { await viewModel.decideRunOutcomeLearning(candidateId: candidate.id, confirm: false) }
+              })
+          }
+        }
+      }
+    }
+  }
+
   private func cardTitle(_ text: String) -> some View {
     Text(text)
       .font(.system(size: 14, weight: .semibold))
@@ -435,6 +461,53 @@ struct MemoryCandidateRow: View {
   }
 
   /// Disabled while in flight or after a terminal outcome (a decision is applied once).
+  private var controlsDisabled: Bool { state.isSent || state.isTerminal }
+}
+
+/// One A1 run-outcome learning candidate row. The row remains refs-only: it shows the candidate's
+/// coarse summary, counters, and redacted evidence ref; confirm/reject is a governed WRITE call.
+struct RunOutcomeLearningCandidateRow: View {
+  let candidate: MissionWorkbenchRunOutcomeLearningCandidate
+  let state: WriteActionState
+  let onConfirm: () -> Void
+  let onReject: () -> Void
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 6) {
+      HStack(alignment: .top, spacing: 8) {
+        VStack(alignment: .leading, spacing: 4) {
+          Text(candidate.summary)
+            .font(.system(size: 12))
+            .foregroundStyle(HubTheme.textPrimary)
+          HStack(spacing: 6) {
+            StatusChip(text: candidate.kind, bg: HubTheme.chipNeutralBG, fg: HubTheme.chipNeutralFG)
+            StatusChip(text: candidate.state, bg: HubTheme.chipPendingBG, fg: HubTheme.chipPendingFG)
+            Text("turns \(candidate.turns) · tools \(candidate.executedTools)")
+              .font(.system(size: 11))
+              .foregroundStyle(HubTheme.textSecondary)
+          }
+        }
+        Spacer()
+        HStack(spacing: 6) {
+          Button("Confirm", action: onConfirm)
+            .buttonStyle(.borderedProminent)
+            .tint(HubTheme.cyan)
+            .controlSize(.small)
+            .disabled(controlsDisabled)
+          Button("Reject", action: onReject)
+            .buttonStyle(.bordered)
+            .controlSize(.small)
+            .disabled(controlsDisabled)
+        }
+      }
+      RefPill(label: "runId", ref: candidate.runId)
+      RefPill(label: "workItemId", ref: candidate.workItemId)
+      RefPill(label: "evidenceRef", ref: candidate.evidenceRef)
+      WriteActionStateView(state: state, pendingText: "Applying learning decision…")
+    }
+    .padding(.vertical, 2)
+  }
+
   private var controlsDisabled: Bool { state.isSent || state.isTerminal }
 }
 

--- a/apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/MockReadClient.swift
+++ b/apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/MockReadClient.swift
@@ -139,6 +139,19 @@ public struct MockReadClient: FridayRustReadClient {
         evidenceRef: "proof://memory-candidate/0fedcba987654321"
       )
     ]
+    let runOutcomeLearningCandidates: [MissionWorkbenchRunOutcomeLearningCandidate] = [
+      MissionWorkbenchRunOutcomeLearningCandidate(
+        id: "a1:run_probe_done:preference",
+        runId: "run_probe_done",
+        workItemId: "work_probe_done",
+        kind: "preference",
+        state: "pending",
+        summary: "refs-only run outcome: turns=1; executed_tools=0",
+        evidenceRef: "proof://run-outcome-learning-candidate/1122334455667788",
+        turns: 1,
+        executedTools: 0
+      )
+    ]
 
     let providerReceiptRefs = [
       "proof://provider-receipt/3f9a1c2b7e004d18",
@@ -300,6 +313,7 @@ public struct MockReadClient: FridayRustReadClient {
         ),
       ],
       memoryCandidates: memoryCandidates,
+      runOutcomeLearningCandidates: runOutcomeLearningCandidates,
       capabilityStates: capabilityStates,
       transcriptSections: [missionSection, providerSection, channelSection, statusSection]
     )

--- a/apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/OperationsOverviewViewModel.swift
+++ b/apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/OperationsOverviewViewModel.swift
@@ -84,6 +84,8 @@ public final class OperationsOverviewViewModel: ObservableObject {
   @Published public private(set) var intakeState: WriteActionState = .ready
   /// Per-candidate memory-decision action state, keyed by the candidate's display id.
   @Published public private(set) var memoryDecisionStates: [String: WriteActionState] = [:]
+  /// Per-candidate A1 run-outcome learning decision state, keyed by candidate id.
+  @Published public private(set) var runOutcomeLearningDecisionStates: [String: WriteActionState] = [:]
 
   private let client: FridayRustReadClient
   /// The spine-WRITE collaborator. `nil` ⇒ the write seam is not configured (the drivers render
@@ -231,6 +233,36 @@ public final class OperationsOverviewViewModel: ObservableObject {
       }
     } catch {
       memoryDecisionStates[candidateId] = .error(reason: Self.writeReason(for: error))
+    }
+  }
+
+  /// Submit ONE owner confirm/reject for an A1 run-outcome learning candidate over the sealed WRITE
+  /// seam. This is governance for a refs-only candidate emitted from a real run outcome; `blocked`
+  /// remains an error-shaped truth state, never a fake confirm.
+  public func decideRunOutcomeLearning(candidateId: String, confirm: Bool) async {
+    guard let writeClient else {
+      runOutcomeLearningDecisionStates[candidateId] = .error(reason: "Write seam not configured.")
+      return
+    }
+    runOutcomeLearningDecisionStates[candidateId] = .sent
+    let request = RunOutcomeLearningDecisionRequestWire(
+      candidateId: candidateId,
+      decision: confirm ? "confirm" : "reject")
+    do {
+      let result = try await writeClient.submitRunOutcomeLearningDecision(request)
+      switch result.status {
+      case "confirmed", "rejected":
+        let kind = result.kind ?? "unknown"
+        runOutcomeLearningDecisionStates[candidateId] = .confirmed(
+          summary: "\(result.status) · state=\(result.state) · kind=\(kind)")
+        await refresh()
+      default:
+        let why = result.blocker ?? "blocked"
+        runOutcomeLearningDecisionStates[candidateId] = .error(
+          reason: "Learning decision blocked — \(why)")
+      }
+    } catch {
+      runOutcomeLearningDecisionStates[candidateId] = .error(reason: Self.writeReason(for: error))
     }
   }
 

--- a/apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/RealWriteClientFactory.swift
+++ b/apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/RealWriteClientFactory.swift
@@ -127,6 +127,11 @@ struct HonestlyUnavailableWriteClient: FridayMissionSpineWriteClient, FridayMiss
   func submitMemoryDecision(_ request: MemoryDecisionRequestWire) async throws -> MemoryDecisionResultWire {
     throw FridayWriteClientError.transport("live write client unavailable: \(reason)")
   }
+  func submitRunOutcomeLearningDecision(
+    _ request: RunOutcomeLearningDecisionRequestWire
+  ) async throws -> RunOutcomeLearningDecisionResultWire {
+    throw FridayWriteClientError.transport("live write client unavailable: \(reason)")
+  }
   func dispatchMissionBoundAgentRun(
     task: String,
     missionContext: MissionWorkItemContextWire,

--- a/apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/WorkbenchSnapshot.swift
+++ b/apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/WorkbenchSnapshot.swift
@@ -194,6 +194,40 @@ public struct MissionWorkbenchMemoryCandidate: Codable, Sendable, Identifiable, 
   }
 }
 
+public struct MissionWorkbenchRunOutcomeLearningCandidate: Codable, Sendable, Identifiable, Equatable {
+  public let id: String
+  public let runId: String
+  public let workItemId: String
+  public let kind: String
+  public let state: String
+  public let summary: String
+  public let evidenceRef: String
+  public let turns: Int64
+  public let executedTools: Int64
+
+  public init(
+    id: String,
+    runId: String,
+    workItemId: String,
+    kind: String,
+    state: String,
+    summary: String,
+    evidenceRef: String,
+    turns: Int64,
+    executedTools: Int64
+  ) {
+    self.id = id
+    self.runId = runId
+    self.workItemId = workItemId
+    self.kind = kind
+    self.state = state
+    self.summary = summary
+    self.evidenceRef = evidenceRef
+    self.turns = turns
+    self.executedTools = executedTools
+  }
+}
+
 public struct MissionWorkbenchCapabilityState: Codable, Sendable, Identifiable, Equatable {
   public let id: String
   public let label: String
@@ -383,6 +417,7 @@ public struct WorkbenchSnapshot: Codable, Sendable, Equatable {
   public let workItems: [MissionWorkbenchWorkItem]
   public let timelinePages: [MissionWorkbenchTimelinePage]
   public let memoryCandidates: [MissionWorkbenchMemoryCandidate]
+  public let runOutcomeLearningCandidates: [MissionWorkbenchRunOutcomeLearningCandidate]
   public let capabilityStates: [MissionWorkbenchCapabilityState]
   public let transcriptSections: [MissionTranscriptSection]
 
@@ -398,6 +433,7 @@ public struct WorkbenchSnapshot: Codable, Sendable, Equatable {
     workItems: [MissionWorkbenchWorkItem],
     timelinePages: [MissionWorkbenchTimelinePage],
     memoryCandidates: [MissionWorkbenchMemoryCandidate],
+    runOutcomeLearningCandidates: [MissionWorkbenchRunOutcomeLearningCandidate] = [],
     capabilityStates: [MissionWorkbenchCapabilityState],
     transcriptSections: [MissionTranscriptSection]
   ) {
@@ -412,6 +448,7 @@ public struct WorkbenchSnapshot: Codable, Sendable, Equatable {
     self.workItems = workItems
     self.timelinePages = timelinePages
     self.memoryCandidates = memoryCandidates
+    self.runOutcomeLearningCandidates = runOutcomeLearningCandidates
     self.capabilityStates = capabilityStates
     self.transcriptSections = transcriptSections
   }

--- a/apps/macos/FridayHubConsole/Tests/FridayHubConsoleCoreTests/OperationsOverviewViewModelTests.swift
+++ b/apps/macos/FridayHubConsole/Tests/FridayHubConsoleCoreTests/OperationsOverviewViewModelTests.swift
@@ -68,6 +68,8 @@ func snapshotExercisesEveryHonestRenderingRule() {
 
   // Memory candidates never grant authority.
   #expect(snapshot.memoryCandidates.allSatisfy { !$0.grantsMemoryAuthority })
+  #expect(snapshot.runOutcomeLearningCandidates.first?.state == "pending")
+  #expect(snapshot.runOutcomeLearningCandidates.first?.evidenceRef.hasPrefix("proof://") == true)
 }
 
 @Test
@@ -146,6 +148,13 @@ func decodesRustProjectionShapedJSON() throws {
         {"page": 1, "cursor": "start", "nextCursor": "offset:1", "eventRefs": ["e0"]}
       ],
       "memoryCandidates": [],
+      "runOutcomeLearningCandidates": [
+        {"id": "a1:run_x:preference", "runId": "run_x", "workItemId": "wi_x",
+         "kind": "preference", "state": "pending",
+         "summary": "refs-only run outcome: turns=1; executed_tools=0",
+         "evidenceRef": "proof://run-outcome-learning-candidate/1",
+         "turns": 1, "executedTools": 0}
+      ],
       "capabilityStates": [
         {"id": "cap", "label": "Advisor", "kind": "advisor", "truthLabel": "friday_owned",
          "approvalState": "not_required", "dispatchAllowed": false, "summary": "s",
@@ -166,6 +175,7 @@ func decodesRustProjectionShapedJSON() throws {
   #expect(snapshot.missionId == "mission_x")
   #expect(snapshot.statusLabels == [.stale, .offline, .error])
   #expect(snapshot.workItems.first?.state == .providerAck)
+  #expect(snapshot.runOutcomeLearningCandidates.first?.id == "a1:run_x:preference")
   #expect(snapshot.transcriptSections.first?.events.first?.evidenceRefs.timelineRef != nil)
 }
 
@@ -276,16 +286,22 @@ final class MockMissionSpineWriteClient: FridayMissionSpineWriteClient, FridayMi
     case intakeBlocked
     case memoryConfirmed
     case memoryBlocked
+    case learningConfirmed
+    case learningBlocked
     case throwsTransport
   }
   let behavior: Behavior
   private let lock = NSLock()
   private var _lastIntake: MissionIntakeRequestWire?
   private var _lastDecision: MemoryDecisionRequestWire?
+  private var _lastLearningDecision: RunOutcomeLearningDecisionRequestWire?
   private var _lastMissionContext: MissionWorkItemContextWire?
   private var _lastMissionRunConstraints: AgentRunConstraintsWire?
   var lastIntake: MissionIntakeRequestWire? { lock.withLock { _lastIntake } }
   var lastDecision: MemoryDecisionRequestWire? { lock.withLock { _lastDecision } }
+  var lastLearningDecision: RunOutcomeLearningDecisionRequestWire? {
+    lock.withLock { _lastLearningDecision }
+  }
   var lastMissionContext: MissionWorkItemContextWire? { lock.withLock { _lastMissionContext } }
   var lastMissionRunConstraints: AgentRunConstraintsWire? { lock.withLock { _lastMissionRunConstraints } }
 
@@ -329,6 +345,27 @@ final class MockMissionSpineWriteClient: FridayMissionSpineWriteClient, FridayMi
         state: request.decision == "confirm" ? "confirmed" : "rejected",
         status: request.decision == "confirm" ? "confirmed" : "rejected",
         recallable: request.decision == "confirm")
+    }
+  }
+
+  func submitRunOutcomeLearningDecision(
+    _ request: RunOutcomeLearningDecisionRequestWire
+  ) async throws -> RunOutcomeLearningDecisionResultWire {
+    lock.withLock { _lastLearningDecision = request }
+    switch behavior {
+    case .throwsTransport:
+      throw FridayWriteClientError.transport("connection refused (write server dark)")
+    case .learningBlocked:
+      return RunOutcomeLearningDecisionResultWire(
+        candidateId: request.candidateId, state: "unknown", status: "blocked",
+        blocker: "unknown_candidate")
+    default:
+      return RunOutcomeLearningDecisionResultWire(
+        candidateId: request.candidateId,
+        runId: "run-a1",
+        kind: "preference",
+        state: request.decision == "confirm" ? "confirmed" : "rejected",
+        status: request.decision == "confirm" ? "confirmed" : "rejected")
     }
   }
 
@@ -491,6 +528,41 @@ func decideMemoryBlockedRendersErrorNotConfirmed() async {
     return
   }
   #expect(reason.contains("unknown_candidate") || reason.contains("blocked"))
+}
+
+@Test
+@MainActor
+func decideRunOutcomeLearningConfirmRendersConfirmedAndWiresCandidate() async {
+  let write = MockMissionSpineWriteClient(behavior: .learningConfirmed)
+  let vm = OperationsOverviewViewModel(client: MockReadClient(behavior: .loaded), writeClient: write)
+  await vm.decideRunOutcomeLearning(candidateId: "a1:run-a1:preference", confirm: true)
+
+  guard case let .confirmed(summary, questions) =
+    vm.runOutcomeLearningDecisionStates["a1:run-a1:preference"] else {
+    Issue.record("expected .confirmed, got \(String(describing: vm.runOutcomeLearningDecisionStates["a1:run-a1:preference"]))")
+    return
+  }
+  #expect(summary.contains("confirmed"))
+  #expect(summary.contains("kind=preference"))
+  #expect(questions.isEmpty)
+  #expect(write.lastLearningDecision?.candidateId == "a1:run-a1:preference")
+  #expect(write.lastLearningDecision?.decision == "confirm")
+}
+
+@Test
+@MainActor
+func decideRunOutcomeLearningBlockedRendersErrorNotConfirmed() async {
+  let write = MockMissionSpineWriteClient(behavior: .learningBlocked)
+  let vm = OperationsOverviewViewModel(client: MockReadClient(behavior: .loaded), writeClient: write)
+  await vm.decideRunOutcomeLearning(candidateId: "a1:missing:preference", confirm: false)
+
+  guard case let .error(reason) =
+    vm.runOutcomeLearningDecisionStates["a1:missing:preference"] else {
+    Issue.record("expected .error, got \(String(describing: vm.runOutcomeLearningDecisionStates["a1:missing:preference"]))")
+    return
+  }
+  #expect(reason.contains("unknown_candidate"))
+  #expect(write.lastLearningDecision?.decision == "reject")
 }
 
 @Test

--- a/apps/macos/FridayRustClient/Sources/FridayRustClient/Protocol.swift
+++ b/apps/macos/FridayRustClient/Sources/FridayRustClient/Protocol.swift
@@ -135,6 +135,12 @@ public enum FridayMessage: Equatable {
   /// hub→trusted-peer: memory decision receipt (refs-only). Mirrors
   /// `friday_protocol::Message::MemoryDecisionResult` — NESTED `{ result: … }`.
   case memoryDecisionResult(MemoryDecisionResultWire)
+  /// trusted-peer→hub: confirm/reject ONE pending A1 run-outcome learning candidate.
+  /// Mirrors `friday_protocol::Message::RunOutcomeLearningDecisionRequest`.
+  case runOutcomeLearningDecisionRequest(RunOutcomeLearningDecisionRequestWire)
+  /// hub→trusted-peer: A1 run-outcome learning decision receipt (refs-only). Mirrors
+  /// `friday_protocol::Message::RunOutcomeLearningDecisionResult`.
+  case runOutcomeLearningDecisionResult(RunOutcomeLearningDecisionResultWire)
 
   /// A decoded-but-not-handled message kind. Carries the raw `kind` for truth-labeled surfacing
   /// (e.g. an `AgentRunPaused` reaching the read client, or any frame the client cannot handle).
@@ -249,6 +255,14 @@ extension FridayMessage: Codable {
     case "MemoryDecisionResult":
       let c = try decoder.container(keyedBy: ResultKey.self)
       self = .memoryDecisionResult(try c.decode(MemoryDecisionResultWire.self, forKey: .result))
+    case "RunOutcomeLearningDecisionRequest":
+      let c = try decoder.container(keyedBy: RequestKey.self)
+      self = .runOutcomeLearningDecisionRequest(
+        try c.decode(RunOutcomeLearningDecisionRequestWire.self, forKey: .request))
+    case "RunOutcomeLearningDecisionResult":
+      let c = try decoder.container(keyedBy: ResultKey.self)
+      self = .runOutcomeLearningDecisionResult(
+        try c.decode(RunOutcomeLearningDecisionResultWire.self, forKey: .result))
     default:
       self = .unsupported(kind: kind)
     }
@@ -339,6 +353,14 @@ extension FridayMessage: Codable {
       try c.encode(r, forKey: .request)
     case .memoryDecisionResult(let r):
       try tag.encode("MemoryDecisionResult", forKey: .kind)
+      var c = encoder.container(keyedBy: ResultKey.self)
+      try c.encode(r, forKey: .result)
+    case .runOutcomeLearningDecisionRequest(let r):
+      try tag.encode("RunOutcomeLearningDecisionRequest", forKey: .kind)
+      var c = encoder.container(keyedBy: RequestKey.self)
+      try c.encode(r, forKey: .request)
+    case .runOutcomeLearningDecisionResult(let r):
+      try tag.encode("RunOutcomeLearningDecisionResult", forKey: .kind)
       var c = encoder.container(keyedBy: ResultKey.self)
       try c.encode(r, forKey: .result)
     case .unsupported(let kind):

--- a/apps/macos/FridayRustClient/Sources/FridayRustClient/ReadClient.swift
+++ b/apps/macos/FridayRustClient/Sources/FridayRustClient/ReadClient.swift
@@ -239,6 +239,10 @@ public final class SealedWSReadClient: FridayRustReadClient, @unchecked Sendable
       throw FridayReadClientError.unexpectedResponse(kind: "MemoryDecisionRequest")
     case .memoryDecisionResult:
       throw FridayReadClientError.unexpectedResponse(kind: "MemoryDecisionResult")
+    case .runOutcomeLearningDecisionRequest:
+      throw FridayReadClientError.unexpectedResponse(kind: "RunOutcomeLearningDecisionRequest")
+    case .runOutcomeLearningDecisionResult:
+      throw FridayReadClientError.unexpectedResponse(kind: "RunOutcomeLearningDecisionResult")
     case .unsupported(let kind):
       throw FridayReadClientError.unexpectedResponse(kind: kind)
     }

--- a/apps/macos/FridayRustClient/Sources/FridayRustClient/WriteClient.swift
+++ b/apps/macos/FridayRustClient/Sources/FridayRustClient/WriteClient.swift
@@ -169,6 +169,10 @@ public protocol FridayMissionSpineWriteClient: Sendable {
   /// refs-only receipt (`status:"confirmed"`/`"rejected"`/`"blocked"`). `decision` MUST be
   /// `"confirm"` or `"reject"`.
   func submitMemoryDecision(_ request: MemoryDecisionRequestWire) async throws -> MemoryDecisionResultWire
+  /// Submit the owner's explicit confirm/reject for ONE pending A1 run-outcome learning candidate.
+  func submitRunOutcomeLearningDecision(
+    _ request: RunOutcomeLearningDecisionRequestWire
+  ) async throws -> RunOutcomeLearningDecisionResultWire
 }
 
 /// Product-facing bridge for MissionIntakeResult -> mission-bound AgentRunRequest. This is the
@@ -330,7 +334,8 @@ public final class SealedWSWriteClient: FridayRustWriteClient, FridayMissionSpin
     case .agentRunRequest, .agentRunResume, .agentRunControlResult,
          .workbenchProjectionRequest, .workbenchProjectionSnapshot,
          .missionIntakeRequest, .missionIntakeResult,
-         .memoryDecisionRequest, .memoryDecisionResult:
+         .memoryDecisionRequest, .memoryDecisionResult,
+         .runOutcomeLearningDecisionRequest, .runOutcomeLearningDecisionResult:
       throw FridayWriteClientError.unexpectedResponse(kind: dispatchKind(message))
     case .unsupported(let kind):
       throw FridayWriteClientError.unexpectedResponse(kind: kind)
@@ -390,6 +395,36 @@ public final class SealedWSWriteClient: FridayRustWriteClient, FridayMissionSpin
     let resp = try openEnvelope(respBody, sessionKey: sessionKey)
     switch resp.message {
     case .memoryDecisionResult(let r):
+      return r
+    case .error(let code, let message):
+      throw FridayWriteClientError.serverError(code: code, message: message)
+    default:
+      throw FridayWriteClientError.unexpectedResponse(kind: dispatchKind(resp.message))
+    }
+  }
+
+  /// Submit the owner's confirm/reject for ONE pending A1 run-outcome learning candidate over the
+  /// sealed WRITE session. This is refs-only governance over an existing candidate row; a
+  /// `status:"blocked"` result is returned to the caller as truth, not thrown.
+  public func submitRunOutcomeLearningDecision(
+    _ request: RunOutcomeLearningDecisionRequestWire
+  ) async throws -> RunOutcomeLearningDecisionResultWire {
+    let transport = try makeTransport()
+    let (sessionKey, _) = try handshake(transport)
+    let msgId = "run-outcome-learning-decision-\(request.candidateId)"
+    let env = FridayEnvelope(msgId: msgId, sentAt: now(), message: .runOutcomeLearningDecisionRequest(request))
+      .withCorrelation(msgId)
+    try transport.sendMessage(try sealEnvelope(env, sessionKey: sessionKey))
+    let respBody: [UInt8]
+    do {
+      respBody = try transport.recvMessage()
+    } catch {
+      throw FridayWriteClientError.transport(
+        "no run-outcome-learning-decision result (session ended fail-closed): \(error)")
+    }
+    let resp = try openEnvelope(respBody, sessionKey: sessionKey)
+    switch resp.message {
+    case .runOutcomeLearningDecisionResult(let r):
       return r
     case .error(let code, let message):
       throw FridayWriteClientError.serverError(code: code, message: message)
@@ -524,6 +559,8 @@ private func dispatchKind(_ message: FridayMessage) -> String {
   case .missionIntakeResult: return "MissionIntakeResult"
   case .memoryDecisionRequest: return "MemoryDecisionRequest"
   case .memoryDecisionResult: return "MemoryDecisionResult"
+  case .runOutcomeLearningDecisionRequest: return "RunOutcomeLearningDecisionRequest"
+  case .runOutcomeLearningDecisionResult: return "RunOutcomeLearningDecisionResult"
   case .unsupported(let kind): return kind
   }
 }

--- a/apps/macos/FridayRustClient/Sources/FridayRustClient/WriteProtocol.swift
+++ b/apps/macos/FridayRustClient/Sources/FridayRustClient/WriteProtocol.swift
@@ -119,6 +119,60 @@ public struct AgentRunConstraintsWire: Codable, Equatable, Sendable {
   }
 }
 
+/// Client→hub A1 run-outcome learning decision. Mirrors
+/// `friday_protocol::RunOutcomeLearningDecisionRequestWire`.
+public struct RunOutcomeLearningDecisionRequestWire: Codable, Equatable, Sendable {
+  public var candidateId: String
+  /// EXACTLY `"confirm"` or `"reject"`.
+  public var decision: String
+  public var reason: String?
+
+  public init(candidateId: String, decision: String, reason: String? = nil) {
+    self.candidateId = candidateId
+    self.decision = decision
+    self.reason = reason
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case candidateId = "candidate_id"
+    case decision
+    case reason
+  }
+}
+
+/// Hub→client A1 run-outcome learning decision receipt. Refs-only: candidate/run/kind/state/status,
+/// never a run body or candidate content.
+public struct RunOutcomeLearningDecisionResultWire: Codable, Equatable, Sendable {
+  public var candidateId: String
+  public var runId: String?
+  public var kind: String?
+  public var state: String
+  public var status: String
+  public var blocker: String?
+
+  public init(
+    candidateId: String,
+    runId: String? = nil,
+    kind: String? = nil,
+    state: String,
+    status: String,
+    blocker: String? = nil
+  ) {
+    self.candidateId = candidateId
+    self.runId = runId
+    self.kind = kind
+    self.state = state
+    self.status = status
+    self.blocker = blocker
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case candidateId = "candidate_id"
+    case runId = "run_id"
+    case kind, state, status, blocker
+  }
+}
+
 // MARK: - AgentRunRequestWire
 
 /// First-class Mission handle for a bound agent run. Mirrors

--- a/apps/macos/FridayRustClient/Tests/FridayRustClientTests/MissionSpineWriteKATTests.swift
+++ b/apps/macos/FridayRustClient/Tests/FridayRustClientTests/MissionSpineWriteKATTests.swift
@@ -2,7 +2,7 @@ import XCTest
 @testable import FridayRustClient
 
 /// **The mission-spine WRITE deliverable — byte-asserted Swift↔Rust parity for the
-/// MissionIntake + MemoryDecision wire shapes (Lane-D entry-point-A).** These prove the Swift
+/// MissionIntake + MemoryDecision + RunOutcomeLearningDecision wire shapes (Lane-D entry-point-A).** These prove the Swift
 /// spine-write structs serialize to the EXACT JSON the Rust agent-run WRITE server
 /// (`bin/hub_agent_run_server.rs`) decodes under `FRIDAY_MISSION_INTAKE=1` / `FRIDAY_MEMORY_CONFIRM=1`.
 ///
@@ -224,5 +224,75 @@ final class MissionSpineWriteKATTests: XCTestCase {
     XCTAssertTrue(json.contains("\"result\":{"))
     XCTAssertTrue(json.contains("\"blocker\":\"unknown_candidate\""))
     XCTAssertTrue(json.contains("\"recallable\":false"))
+  }
+
+  // MARK: MS5 — RunOutcomeLearningDecision wire shape (nested + no auth_proof)
+
+  /// MS5: an A1 run-outcome learning decision rides as
+  /// `{"kind":"RunOutcomeLearningDecisionRequest","request":{…}}` with no per-request auth proof.
+  func testMS5_runOutcomeLearningDecisionRequestNestedShapeConfirm() throws {
+    let req = RunOutcomeLearningDecisionRequestWire(
+      candidateId: "a1:run-a1:preference",
+      decision: "confirm",
+      reason: "operator accepted the refs-only preference candidate")
+    let env = FridayEnvelope(msgId: "a1-dec-req", sentAt: 1000, message: .runOutcomeLearningDecisionRequest(req))
+      .withCorrelation("c1")
+    let json = String(decoding: try env.encodeJSON(), as: UTF8.self)
+
+    XCTAssertTrue(json.contains("\"kind\":\"RunOutcomeLearningDecisionRequest\""))
+    XCTAssertTrue(json.contains("\"request\":{"), "A1 decision must NEST under request, not flatten: \(json)")
+    XCTAssertTrue(json.contains("\"candidate_id\":\"a1:run-a1:preference\""))
+    XCTAssertTrue(json.contains("\"decision\":\"confirm\""))
+
+    let messageObj = try messageObject(json)
+    XCTAssertEqual(Set(messageObj.keys), ["kind", "request"])
+    let request = try XCTUnwrap(messageObj["request"] as? [String: Any])
+    XCTAssertEqual(Set(request.keys), ["candidate_id", "decision", "reason"])
+    XCTAssertNil(request["auth_proof"], "RunOutcomeLearningDecisionRequest carries NO per-request auth_proof")
+
+    XCTAssertEqual(try FridayEnvelope.decodeJSON(Data(json.utf8)).message, .runOutcomeLearningDecisionRequest(req))
+  }
+
+  /// MS5: a nil reason is omitted, matching Rust's optional serde field.
+  func testMS5_runOutcomeLearningDecisionReasonOmittedWhenNil() throws {
+    let req = RunOutcomeLearningDecisionRequestWire(candidateId: "a1:run-a1:preference", decision: "reject")
+    let env = FridayEnvelope(msgId: "a1", sentAt: 1, message: .runOutcomeLearningDecisionRequest(req))
+    let json = String(decoding: try env.encodeJSON(), as: UTF8.self)
+    XCTAssertFalse(json.contains("\"reason\""))
+    XCTAssertEqual(try FridayEnvelope.decodeJSON(Data(json.utf8)).message, .runOutcomeLearningDecisionRequest(req))
+  }
+
+  /// MS6: an A1 `status:"confirmed"` result decodes refs-only candidate/run/kind/state fields.
+  func testMS6_runOutcomeLearningDecisionResultConfirmedDecodes() throws {
+    let json = """
+      {"schema_version":15,"msg_id":"r","sent_at":1,"message":{
+        "kind":"RunOutcomeLearningDecisionResult","result":{
+          "candidate_id":"a1:run-a1:preference","run_id":"run-a1",
+          "kind":"preference","state":"confirmed","status":"confirmed"}}}
+      """
+    let env = try FridayEnvelope.decodeJSON(Data(json.utf8))
+    guard case .runOutcomeLearningDecisionResult(let r) = env.message else {
+      return XCTFail("expected RunOutcomeLearningDecisionResult")
+    }
+    XCTAssertEqual(r.candidateId, "a1:run-a1:preference")
+    XCTAssertEqual(r.runId, "run-a1")
+    XCTAssertEqual(r.kind, "preference")
+    XCTAssertEqual(r.state, "confirmed")
+    XCTAssertEqual(r.status, "confirmed")
+    XCTAssertNil(r.blocker)
+  }
+
+  /// MS6: a blocked A1 decision carries a blocker and stays a returned result, not a success.
+  func testMS6_runOutcomeLearningDecisionResultBlockedCarriesBlocker() throws {
+    let blocked = RunOutcomeLearningDecisionResultWire(
+      candidateId: "a1:missing:preference",
+      state: "unknown",
+      status: "blocked",
+      blocker: "unknown_candidate")
+    let env = FridayEnvelope(msgId: "r", sentAt: 1, message: .runOutcomeLearningDecisionResult(blocked))
+    XCTAssertEqual(try FridayEnvelope.decodeJSON(try env.encodeJSON()).message, .runOutcomeLearningDecisionResult(blocked))
+    let json = String(decoding: try env.encodeJSON(), as: UTF8.self)
+    XCTAssertTrue(json.contains("\"result\":{"))
+    XCTAssertTrue(json.contains("\"blocker\":\"unknown_candidate\""))
   }
 }

--- a/apps/macos/FridayRustClient/Tests/FridayRustClientTests/MissionSpineWriteWiringTests.swift
+++ b/apps/macos/FridayRustClient/Tests/FridayRustClientTests/MissionSpineWriteWiringTests.swift
@@ -2,7 +2,7 @@ import XCTest
 @testable import FridayRustClient
 
 /// **Tier-2 mission-spine-write wiring tests** — drive `SealedWSWriteClient.submitMissionIntake` +
-/// `submitMemoryDecision` end-to-end over an IN-MEMORY transport that emulates the Rust
+/// `submitMemoryDecision` + `submitRunOutcomeLearningDecision` end-to-end over an IN-MEMORY transport that emulates the Rust
 /// `hub_agent_run_server`'s mission-spine arms: the cleartext preamble (server pubkey + 64-byte
 /// nonce), the SEALED session (the channel auth — NO per-request `auth_proof` for these messages),
 /// and a `MissionIntakeResult` / `MemoryDecisionResult` reply.
@@ -21,6 +21,8 @@ final class MissionSpineWriteWiringTests: XCTestCase {
     case intakeNeedsClarification
     case memoryConfirmed
     case memoryBlocked         // the synthetic-candidate-id reality today
+    case learningConfirmed
+    case learningBlocked
     case serverError           // a typed Error frame
   }
 
@@ -40,6 +42,7 @@ final class MissionSpineWriteWiringTests: XCTestCase {
     private(set) var endedFailClosed = false
     private(set) var receivedIntake: MissionIntakeRequestWire?
     private(set) var receivedDecision: MemoryDecisionRequestWire?
+    private(set) var receivedLearningDecision: RunOutcomeLearningDecisionRequestWire?
     /// Proves the inbound message object carried NO `auth_proof` (sealed session is the channel auth).
     private(set) var sawAuthProof = false
 
@@ -120,6 +123,23 @@ final class MissionSpineWriteWiringTests: XCTestCase {
             state: req.decision == "confirm" ? "confirmed" : "rejected",
             status: req.decision == "confirm" ? "confirmed" : "rejected",
             recallable: req.decision == "confirm"))
+        }
+      case .runOutcomeLearningDecisionRequest(let req):
+        receivedLearningDecision = req
+        switch mode {
+        case .serverError:
+          reply = .error(code: .internal, message: "learning decision failed")
+        case .learningBlocked:
+          reply = .runOutcomeLearningDecisionResult(RunOutcomeLearningDecisionResultWire(
+            candidateId: req.candidateId, state: "unknown", status: "blocked",
+            blocker: "unknown_candidate"))
+        default:
+          reply = .runOutcomeLearningDecisionResult(RunOutcomeLearningDecisionResultWire(
+            candidateId: req.candidateId,
+            runId: "run-a1",
+            kind: "preference",
+            state: req.decision == "confirm" ? "confirmed" : "rejected",
+            status: req.decision == "confirm" ? "confirmed" : "rejected"))
         }
       default:
         throw FridayWriteClientError.transport("unexpected inbound on the spine session: \(env.msgId)")
@@ -235,6 +255,40 @@ final class MissionSpineWriteWiringTests: XCTestCase {
     do {
       _ = try await client.submitMemoryDecision(
         MemoryDecisionRequestWire(memoryId: "mem-1", ownerPrincipal: owner, decision: "reject"))
+      XCTFail("a typed Error frame must throw")
+    } catch let err as FridayWriteClientError {
+      guard case .serverError = err else { return XCTFail("expected serverError, got \(err)") }
+    }
+  }
+
+  // MARK: submitRunOutcomeLearningDecision
+
+  func testSubmitRunOutcomeLearningDecision_confirm_returnsConfirmedNoAuthProof() async throws {
+    let (client, transport) = try makeClient(mode: .learningConfirmed)
+    let result = try await client.submitRunOutcomeLearningDecision(
+      RunOutcomeLearningDecisionRequestWire(candidateId: "a1:run-a1:preference", decision: "confirm"))
+    XCTAssertEqual(result.status, "confirmed")
+    XCTAssertEqual(result.state, "confirmed")
+    XCTAssertEqual(result.runId, "run-a1")
+    XCTAssertEqual(result.kind, "preference")
+    XCTAssertEqual(transport.receivedLearningDecision?.candidateId, "a1:run-a1:preference")
+    XCTAssertEqual(transport.receivedLearningDecision?.decision, "confirm")
+    XCTAssertFalse(transport.sawAuthProof, "the A1 learning-decision request must carry NO auth_proof")
+  }
+
+  func testSubmitRunOutcomeLearningDecision_blocked_isAReturnedReceiptNotAThrow() async throws {
+    let (client, _) = try makeClient(mode: .learningBlocked)
+    let result = try await client.submitRunOutcomeLearningDecision(
+      RunOutcomeLearningDecisionRequestWire(candidateId: "a1:missing:preference", decision: "reject"))
+    XCTAssertEqual(result.status, "blocked")
+    XCTAssertEqual(result.blocker, "unknown_candidate")
+  }
+
+  func testSubmitRunOutcomeLearningDecision_serverError_throwsServerError() async throws {
+    let (client, _) = try makeClient(mode: .serverError)
+    do {
+      _ = try await client.submitRunOutcomeLearningDecision(
+        RunOutcomeLearningDecisionRequestWire(candidateId: "a1:run-a1:preference", decision: "confirm"))
       XCTFail("a typed Error frame must throw")
     } catch let err as FridayWriteClientError {
       guard case .serverError = err else { return XCTFail("expected serverError, got \(err)") }

--- a/rust-core/crates/friday-hub/src/workbench_projection.rs
+++ b/rust-core/crates/friday-hub/src/workbench_projection.rs
@@ -81,6 +81,8 @@ pub fn project_workbench(db: &Db, requested_mission_id: Option<&str>) -> Result<
         .first()
         .ok_or_else(|| "mission has no route decision projection".to_string())?;
 
+    let run_outcome_learning_candidates =
+        run_outcome_learning_candidates_json(db, &work_items).map_err(|err| err.to_string())?;
     let provider_receipt_refs = provider_receipt_refs(&work_items, &links);
     let channel_receipt_refs = channel_receipt_refs(&links);
     let mut transcript_events = Vec::new();
@@ -147,6 +149,7 @@ pub fn project_workbench(db: &Db, requested_mission_id: Option<&str>) -> Result<
             }
         ],
         "memoryCandidates": memory_candidates_json(&mission, &links),
+        "runOutcomeLearningCandidates": run_outcome_learning_candidates,
         "capabilityStates": capability_states_json(&work_items, route_decision.route_decision_ref.as_str()),
         "transcriptSections": transcript_sections_json(&mission.mission_id, transcript_events)
     });
@@ -269,6 +272,54 @@ fn memory_candidates_json(
         }));
     }
     rows
+}
+
+fn run_outcome_learning_candidates_json(
+    db: &Db,
+    work_items: &[WorkItem],
+) -> friday_storage::Result<Vec<Value>> {
+    let mut rows = Vec::new();
+    for item in work_items {
+        for run_id in work_item_agent_run_ids(item) {
+            let candidates =
+                friday_storage::learning_candidate::list_run_outcome_candidates_for_run(
+                    db.conn(),
+                    &run_id,
+                )?;
+            for candidate in candidates {
+                rows.push(json!({
+                    "id": candidate.candidate_id,
+                    "runId": candidate.run_id,
+                    "workItemId": item.work_item_id,
+                    "kind": candidate.kind.as_str(),
+                    "state": candidate.state.as_str(),
+                    "summary": candidate.summary,
+                    "evidenceRef": redacted_ref("run-outcome-learning-candidate", &candidate.evidence_ref),
+                    "turns": candidate.turns,
+                    "executedTools": candidate.executed_tools
+                }));
+            }
+        }
+    }
+    rows.sort_by(|left, right| {
+        let left_id = left.get("id").and_then(Value::as_str);
+        let right_id = right.get("id").and_then(Value::as_str);
+        left_id.cmp(&right_id)
+    });
+    Ok(rows)
+}
+
+fn work_item_agent_run_ids(item: &WorkItem) -> Vec<String> {
+    let mut ids = Vec::new();
+    for value in item.proof_receipts.iter().chain(item.output_refs.iter()) {
+        if let Some(run_id) = value.strip_prefix("friday://agent-run/") {
+            let run_id = run_id.trim();
+            if !run_id.is_empty() && !ids.iter().any(|seen| seen == run_id) {
+                ids.push(run_id.to_string());
+            }
+        }
+    }
+    ids
 }
 
 fn capability_states_json(work_items: &[WorkItem], route_ref: &str) -> Vec<Value> {
@@ -1053,5 +1104,40 @@ mod tests {
             Some(mission_id.as_str()),
             "the snapshot must carry the EXACT real hyphen mission id, not a rewritten/synthetic shape"
         );
+    }
+
+    #[test]
+    fn projects_run_outcome_learning_candidates_from_agent_run_proof_refs() {
+        let db = Db::open_hub(&tmp()).unwrap();
+        let mission_id = seed_real_producer_mission(&db);
+        let mut item = db.get_work_item("autodisp-1781492033").unwrap().unwrap();
+        item.status = WorkItemStatus::CompletedWithProof;
+        item.proof_receipts = vec!["friday://agent-run/run-a1-projected".into()];
+        db.upsert_work_item(&item).unwrap();
+        friday_storage::learning_candidate::record_run_outcome_candidates(
+            db.conn(),
+            "run-a1-projected",
+            Some("sess-a1-projected"),
+            2,
+            1,
+            1_780_640_000_100,
+        )
+        .unwrap();
+
+        let snapshot = project_workbench(&db, Some(&mission_id)).unwrap();
+        let candidates = snapshot
+            .get("runOutcomeLearningCandidates")
+            .and_then(Value::as_array)
+            .expect("projection must include runOutcomeLearningCandidates");
+        assert_eq!(candidates.len(), 3);
+        assert!(candidates.iter().all(|row| {
+            row.get("runId").and_then(Value::as_str) == Some("run-a1-projected")
+                && row.get("workItemId").and_then(Value::as_str) == Some("autodisp-1781492033")
+        }));
+        assert!(candidates.iter().all(|row| {
+            row.get("evidenceRef")
+                .and_then(Value::as_str)
+                .is_some_and(|ref_| ref_.starts_with("proof://run-outcome-learning-candidate/"))
+        }));
     }
 }


### PR DESCRIPTION
## Summary
- project A1 run-outcome learning candidates into the Workbench refs-only snapshot via existing friday://agent-run proof refs
- add Swift wire/client support for RunOutcomeLearningDecision request/result
- render Console confirm/reject controls and view-model state for A1 learning candidates

## Validation
- swift test --package-path apps/macos/FridayRustClient --filter MissionSpineWrite
- swift test --package-path apps/macos/FridayHubConsole --filter OperationsOverviewViewModelTests
- cargo test -p friday-hub workbench_projection -- --nocapture
- cargo test -p friday-hub run_outcome_learning -- --nocapture
- cargo test -p friday-storage learning_candidate -- --nocapture
- cargo fmt --all --check
- git diff --check

Truth label: A1 product caller is wired/mechanism-verified. organic=0; this does not claim A1 live-done or OG9 organic closure.