### PR TITLE
Teach clarification gate Chinese vague intents

### DIFF
--- a/rust-core/crates/friday-core/src/planning.rs
+++ b/rust-core/crates/friday-core/src/planning.rs
@@ -399,6 +399,18 @@ fn matches_export_bundle(lower: &str) -> bool {
 /// request — text-only, so it escalates to MajorDecision (the gate clarifies
 /// before building). Faithful to the oracle's verb`[\s\S]{0,80}`noun co-occurrence.
 fn matches_vague_deliverable(lower: &str) -> bool {
+    const CJK_HINTS: &[&str] = &[
+        "帮我做个计划",
+        "帮我做一个计划",
+        "帮我制定计划",
+        "制定一个计划",
+        "做个计划",
+        "做一个计划",
+        "帮我做个工具",
+        "帮我做一个工具",
+        "做个工具",
+        "做一个工具",
+    ];
     const VERBS: &[&str] = &[
         "build",
         "create",
@@ -426,7 +438,7 @@ fn matches_vague_deliverable(lower: &str) -> bool {
         "feature",
         "product",
     ];
-    co_occurs_within(lower, VERBS, NOUNS, 80)
+    CJK_HINTS.iter().any(|h| lower.contains(h)) || co_occurs_within(lower, VERBS, NOUNS, 80)
 }
 
 /// `VAGUE_IMPROVEMENT_HINTS`: "make Friday/this app/the repo … better/
@@ -785,6 +797,14 @@ mod tests {
         );
         assert_eq!(
             classify_kind("build a simple tool to track tasks"),
+            Some(PlanningKind::MajorDecision)
+        );
+        assert_eq!(
+            classify_kind("帮我做个计划"),
+            Some(PlanningKind::MajorDecision)
+        );
+        assert_eq!(
+            classify_kind("帮我做个工具"),
             Some(PlanningKind::MajorDecision)
         );
         // VAGUE_IMPROVEMENT: "make Friday production-ready" -> MajorDecision.


### PR DESCRIPTION
organic=0

## Summary
- extend the vague-deliverable clarification classifier to catch common Chinese/CJK requests like “帮我做个计划” and “帮我做个工具”
- add focused planning classifier coverage so these requests route to the clarification gate instead of dispatching directly

## Validation
- cargo test -p friday-core planning -- --nocapture
- cargo fmt --all --check
- git diff --check
- cargo test -p friday-hub --test mission_intake_clarification -- --nocapture

## Truth label
- Fixes a Phase 1 live negative-stress finding: Chinese vague intent previously bypassed clarification and auto-dispatched.
- This is not OG9 organic, not live-done, and not goal-done.