### PR TITLE
Wire A1 fanout for mission-bound refs

### DIFF
--- a/rust-core/crates/friday-hub/src/bin/hub_agent_run_server.rs
+++ b/rust-core/crates/friday-hub/src/bin/hub_agent_run_server.rs
@@ -1392,54 +1392,62 @@ fn serve_sealed_session<S: Read + Write, T: Transport>(
                     None
                 };
 
-                let outcome = if let Some(answer) = mission_bound {
-                    answer
-                } else {
-                    match session_id
-                        .as_deref()
-                        .map(str::trim)
-                        .filter(|s| !s.is_empty())
-                    {
-                        Some(sid) => runtime.run_session_task_with_overrides(
-                            &caller,
-                            &run_id,
-                            sid,
-                            &task,
-                            policy_override,
-                            max_turns_override,
-                            now_ms,
-                        ),
-                        // (memory-loop) The no-`session_id` arm now routes through the SAME
-                        // SESSIONED entry with an EPHEMERAL per-run session_id == the run_id. This
-                        // CLOSES the previously-inert extract→confirm→recall loop on the common
-                        // live path: extraction structurally needs a session (it reads the
-                        // session's pending messages + derives the owner-composite namespace), and
-                        // recall is NAMESPACE-keyed (owner-derived), NOT session-keyed — so a
-                        // per-run ephemeral session writes a candidate under owner O's composite
-                        // namespace that a LATER run as O recalls across runs. A per-run id loads
-                        // EMPTY history, so the turn is behaviorally one-shot (equivalent to the
-                        // old sessionless arm) while now also writing session/message rows + firing
-                        // the flag-gated, Finished-only, failure-isolated post-run extraction.
-                        //
-                        // NO-DEGRADE caveat (deliberate, see the PR body): this arm is NO LONGER
-                        // byte-identical — closing an inert loop requires it. With
-                        // FRIDAY_RUN_LOOP_MEMORY_EXTRACTION ON (a memory feature flag, default-OFF)
-                        // every Finished run makes ONE extra extraction model call ⇒ one
-                        // token_ledger row (the intended memory behavior). Extraction is
-                        // failure-isolated (`let _` in the runtime) and can NEVER flip the run's
-                        // answer/status. The owner binding stays the AUTHENTICATED `caller` (never
-                        // the client-asserted session_id), so there is no cross-owner leak.
-                        None => runtime.run_session_task_with_overrides(
-                            &caller,
-                            &run_id,
-                            /* session_id = */ &run_id,
-                            &task,
-                            policy_override,
-                            max_turns_override,
-                            now_ms,
-                        ),
-                    }
-                };
+                let (outcome, mission_bound_learning_session_id) =
+                    if let Some(answer) = mission_bound {
+                        let learning_session_id = session_id
+                            .as_deref()
+                            .map(str::trim)
+                            .filter(|s| !s.is_empty())
+                            .unwrap_or(&run_id)
+                            .to_string();
+                        (answer, Some(learning_session_id))
+                    } else {
+                        let answer = match session_id
+                            .as_deref()
+                            .map(str::trim)
+                            .filter(|s| !s.is_empty())
+                        {
+                            Some(sid) => runtime.run_session_task_with_overrides(
+                                &caller,
+                                &run_id,
+                                sid,
+                                &task,
+                                policy_override,
+                                max_turns_override,
+                                now_ms,
+                            ),
+                            // (memory-loop) The no-`session_id` arm now routes through the SAME
+                            // SESSIONED entry with an EPHEMERAL per-run session_id == the run_id. This
+                            // CLOSES the previously-inert extract→confirm→recall loop on the common
+                            // live path: extraction structurally needs a session (it reads the
+                            // session's pending messages + derives the owner-composite namespace), and
+                            // recall is NAMESPACE-keyed (owner-derived), NOT session-keyed — so a
+                            // per-run ephemeral session writes a candidate under owner O's composite
+                            // namespace that a LATER run as O recalls across runs. A per-run id loads
+                            // EMPTY history, so the turn is behaviorally one-shot (equivalent to the
+                            // old sessionless arm) while now also writing session/message rows + firing
+                            // the flag-gated, Finished-only, failure-isolated post-run extraction.
+                            //
+                            // NO-DEGRADE caveat (deliberate, see the PR body): this arm is NO LONGER
+                            // byte-identical — closing an inert loop requires it. With
+                            // FRIDAY_RUN_LOOP_MEMORY_EXTRACTION ON (a memory feature flag, default-OFF)
+                            // every Finished run makes ONE extra extraction model call ⇒ one
+                            // token_ledger row (the intended memory behavior). Extraction is
+                            // failure-isolated (`let _` in the runtime) and can NEVER flip the run's
+                            // answer/status. The owner binding stays the AUTHENTICATED `caller` (never
+                            // the client-asserted session_id), so there is no cross-owner leak.
+                            None => runtime.run_session_task_with_overrides(
+                                &caller,
+                                &run_id,
+                                /* session_id = */ &run_id,
+                                &task,
+                                policy_override,
+                                max_turns_override,
+                                now_ms,
+                            ),
+                        };
+                        (answer, None)
+                    };
 
                 // (refs) REFS-ONLY terminal receipt over the wire: status + answer FINGERPRINT
                 // (sha256/len) + (A1) the run COUNTS (turns / executed_tools) — NEVER the body.
@@ -1456,6 +1464,16 @@ fn serve_sealed_session<S: Read + Write, T: Transport>(
                 // sends below means a transport drop ends the session; this line records that
                 // the refs leg was REACHED with the run_id, closing the diagnostic gap.
                 let has_body = outcome.delivered_body().is_some();
+                if let Some(sid) = mission_bound_learning_session_id.as_deref() {
+                    runtime.maybe_emit_run_outcome_learning_candidates_from_refs(
+                        sid,
+                        &run_id,
+                        &refs.status,
+                        refs.turns,
+                        refs.executed_tools,
+                        now_ms,
+                    );
+                }
                 eprintln!(
                     "hub_agent_run_server_dispatch: run_id={run_id} leg=refs status={} has_body={has_body}",
                     refs.status

--- a/rust-core/crates/friday-hub/src/runtime.rs
+++ b/rust-core/crates/friday-hub/src/runtime.rs
@@ -1625,6 +1625,58 @@ impl<T: Transport> HubRuntime<T> {
         );
     }
 
+    /// Emit the same refs-only A1 run-outcome candidates for a finished
+    /// mission-bound run result. The mission-bound server arm only has the
+    /// owner-projected proof refs, not the private `LoopOutcome`, so this helper
+    /// takes the already-redacted count fields from `AuthedAnswer::proof_refs_json`.
+    pub fn maybe_emit_run_outcome_learning_candidates_from_refs(
+        &self,
+        session_id: &str,
+        run_id: &str,
+        status: &str,
+        turns: Option<u64>,
+        executed_tools: Option<u64>,
+        now_ms: i64,
+    ) {
+        let enabled = a1_run_outcome_learning_fanout_from(
+            std::env::var(ENV_A1_RUN_OUTCOME_LEARNING_FANOUT)
+                .ok()
+                .as_deref(),
+        );
+        self.maybe_emit_run_outcome_learning_candidates_from_refs_flagged(
+            session_id,
+            run_id,
+            status,
+            (turns, executed_tools),
+            now_ms,
+            enabled,
+        );
+    }
+
+    fn maybe_emit_run_outcome_learning_candidates_from_refs_flagged(
+        &self,
+        session_id: &str,
+        run_id: &str,
+        status: &str,
+        counts: (Option<u64>, Option<u64>),
+        now_ms: i64,
+        enabled: bool,
+    ) {
+        if !enabled || status != "finished" {
+            return;
+        }
+        let outcome = LoopOutcome {
+            status: LoopStatus::Finished,
+            turns: counts.0.unwrap_or_default(),
+            executed_tools: counts.1.unwrap_or_default(),
+            final_message: None,
+            detail: String::new(),
+        };
+        self.maybe_emit_run_outcome_learning_candidates_flagged(
+            session_id, run_id, &outcome, now_ms, true,
+        );
+    }
+
     fn maybe_emit_run_outcome_learning_candidates_flagged(
         &self,
         session_id: &str,
@@ -9085,6 +9137,59 @@ mod tests {
             decided,
             friday_storage::learning_candidate::RunOutcomeLearningState::Confirmed,
             "confirm is an explicit governance decision, not an automatic durable write"
+        );
+    }
+
+    #[test]
+    fn a1_run_outcome_learning_fanout_from_refs_writes_three_pending_candidates() {
+        let owner = "owner-a1-refs";
+        let (rt, _ws, _c) = runtime_with_owner("a1-fanout-refs", owner, &["{\"tool\":\"none\"}"]);
+
+        rt.maybe_emit_run_outcome_learning_candidates_from_refs_flagged(
+            "sess-a1-refs",
+            "run-a1-refs",
+            "finished",
+            (Some(3), Some(0)),
+            5_000,
+            true,
+        );
+
+        let rows = friday_storage::learning_candidate::list_run_outcome_candidates_for_run(
+            rt.db().conn(),
+            "run-a1-refs",
+        )
+        .unwrap();
+        assert_eq!(rows.len(), 3);
+        assert!(rows
+            .iter()
+            .all(|r| r.session_id.as_deref() == Some("sess-a1-refs")));
+        assert!(rows
+            .iter()
+            .all(|r| r.summary.contains("turns=3") && r.summary.contains("executed_tools=0")));
+    }
+
+    #[test]
+    fn a1_run_outcome_learning_fanout_from_refs_ignores_non_finished() {
+        let owner = "owner-a1-refs-nonfinished";
+        let (rt, _ws, _c) = runtime_with_owner(
+            "a1-fanout-refs-nonfinished",
+            owner,
+            &["{\"tool\":\"none\"}"],
+        );
+
+        rt.maybe_emit_run_outcome_learning_candidates_from_refs_flagged(
+            "sess-a1-refs",
+            "run-a1-refs-paused",
+            "no_answer",
+            (Some(1), Some(0)),
+            5_000,
+            true,
+        );
+
+        assert_eq!(
+            rt.db().count("run_outcome_learning_candidate").unwrap(),
+            0,
+            "non-finished refs must not create A1 candidates"
         );
     }
 


### PR DESCRIPTION
## Summary\n- connect A1 run-outcome candidate fanout to mission-bound finished refs results\n- keep fanout refs-only, flag-gated, and failure-isolated\n- add focused tests for refs-derived fanout and non-finished no-op\n\n## Validation\n- cargo fmt --all --check\n- cargo test -p friday-hub run_outcome_learning -- --nocapture\n- git diff --check\n\n## Truth boundary\nThis fixes mechanism wiring for mission-bound organic runs. It is not pure physical OG9, not D20/B4 true signing, and not goal done until a live post-deploy run produces and confirms an organic-fed candidate.