### PR TITLE
Use unique body refs for organic launchers

### DIFF
--- a/scripts/ops/friday-claude-organic-spawn.sh
+++ b/scripts/ops/friday-claude-organic-spawn.sh
@@ -26,12 +26,14 @@ if [ -z "${TASK_TEXT}" ]; then
   exit 3
 fi
 
+ORGANIC_BODY_REF_ID="$(node -e 'process.stdout.write((globalThis.crypto?.randomUUID?.() ?? (`id-${Date.now()}-${Math.random().toString(16).slice(2)}`)).toLowerCase())')"
+
 export FRIDAY_CLAUDE_MISSION_PROOF_RUN_KIND="organic"
 export FRIDAY_CLAUDE_MISSION_PROOF_SURFACE_KIND="${FRIDAY_CLAUDE_ORGANIC_SURFACE_KIND:-desktop}"
 export FRIDAY_CLAUDE_MISSION_PROOF_DELIVERY_ROUTE="ops://claude-organic-spawn"
 export FRIDAY_CLAUDE_MISSION_PROOF_TITLE="${FRIDAY_CLAUDE_ORGANIC_TITLE:-Claude organic operator task}"
 export FRIDAY_CLAUDE_MISSION_PROOF_INTENT="${TASK_TEXT}"
 export FRIDAY_CLAUDE_MISSION_PROOF_CAPABILITY_ID="observe-wrapper.claude.organic"
-export FRIDAY_CLAUDE_MISSION_PROOF_BODY_REF="friday://body/ops/claude-organic-spawn"
+export FRIDAY_CLAUDE_MISSION_PROOF_BODY_REF="${FRIDAY_CLAUDE_MISSION_PROOF_BODY_REF:-friday://body/ops/claude-organic-spawn/${ORGANIC_BODY_REF_ID}}"
 
 exec "${PROOF_SCRIPT}"

--- a/scripts/ops/friday-codex-organic-spawn.sh
+++ b/scripts/ops/friday-codex-organic-spawn.sh
@@ -26,12 +26,14 @@ if [ -z "${TASK_TEXT}" ]; then
   exit 3
 fi
 
+ORGANIC_BODY_REF_ID="$(node -e 'process.stdout.write((globalThis.crypto?.randomUUID?.() ?? (`id-${Date.now()}-${Math.random().toString(16).slice(2)}`)).toLowerCase())')"
+
 export FRIDAY_CODEX_MISSION_PROOF_RUN_KIND="organic"
 export FRIDAY_CODEX_MISSION_PROOF_SURFACE_KIND="${FRIDAY_CODEX_ORGANIC_SURFACE_KIND:-desktop}"
 export FRIDAY_CODEX_MISSION_PROOF_DELIVERY_ROUTE="ops://codex-organic-spawn"
 export FRIDAY_CODEX_MISSION_PROOF_TITLE="${FRIDAY_CODEX_ORGANIC_TITLE:-Codex organic operator task}"
 export FRIDAY_CODEX_MISSION_PROOF_INTENT="${TASK_TEXT}"
 export FRIDAY_CODEX_MISSION_PROOF_CAPABILITY_ID="observe-wrapper.codex.organic"
-export FRIDAY_CODEX_MISSION_PROOF_BODY_REF="friday://body/ops/codex-organic-spawn"
+export FRIDAY_CODEX_MISSION_PROOF_BODY_REF="${FRIDAY_CODEX_MISSION_PROOF_BODY_REF:-friday://body/ops/codex-organic-spawn/${ORGANIC_BODY_REF_ID}}"
 
 exec "${PROOF_SCRIPT}"


### PR DESCRIPTION
## Summary
- give Claude/Codex organic launchers a per-run default bodyRef
- keep explicit FRIDAY_*_MISSION_PROOF_BODY_REF overrides intact
- avoid repeat organic runs colliding with mission_body_snapshot owner/binding checks

## Validation
- bash -n scripts/ops/friday-claude-organic-spawn.sh scripts/ops/friday-codex-organic-spawn.sh scripts/ops/friday-claude-mission-proof-of-life.sh scripts/ops/friday-codex-mission-proof-of-life.sh
- FRIDAY_CLAUDE_MISSION_PROOF_PREFLIGHT_ONLY=1 scripts/ops/friday-claude-organic-spawn-keychain.sh ...
- FRIDAY_CODEX_MISSION_PROOF_PREFLIGHT_ONLY=1 scripts/ops/friday-codex-organic-spawn-keychain.sh ...
- live assisted organic Claude run succeeded with non-fallback Anthropic ledger and surface binding (mission claude-organic-mission-453fd9fd-5f6b-4600-8035-74c19b98e7ca)

Truth: fixes the launcher collision only; the live organic run is operator-authorized assisted, not pure-hand OG9 and not GO.