### PR TITLE
Terminalize failed mission-bound agent runs

### DIFF
--- a/rust-core/crates/friday-hub/src/lib.rs
+++ b/rust-core/crates/friday-hub/src/lib.rs
@@ -15023,25 +15023,20 @@ mod tests {
 
     #[test]
     fn errored_mission_bound_run_stays_ready_to_dispatch_not_stranded() {
-        // DEGRADE-1 regression guard: a mission-bound loop that ERRORS (no Finished) must NOT have
-        // advanced the WorkItem past `ReadyToDispatch` — it stays retryable (the pre-#24b rest
-        // state), NOT stranded at `ProviderRouted`. We drive the REAL post-loop binding with
-        // `completed = false` (the non-Finished outcome) and assert the row rests at `ProviderRouted`
-        // ONLY because the bind ran (post-loop); the during-call status was `ReadyToDispatch`. The
-        // dispatch-retryability property is the during-call status, proven by the reachability test
-        // above; here we assert the post-loop `completed=false` bind is END-STATE-identical to
-        // pre-#24b (rests at `ProviderRouted`, no over-claimed completion) — i.e. the reorder is gone.
+        // DEGRADE-1 regression guard: the post-loop binding still has an explicit routed rest
+        // state for paused/resumable runs, so the #24b reorder stays gone without over-claiming
+        // completion.
         use friday_core::WorkItemStatus;
         let db3 = Db::open_hub(&temp_path("hb-err")).unwrap();
         seed_loop_work_item_at(&db3, "wi-err", WorkItemStatus::ReadyToDispatch);
-        // The loop errored ⇒ the post-loop bind runs with completed=false (3 in-flight hops).
+        // The paused/non-terminal rest path drives the post-loop bind to ProviderRouted.
         let attach = crate::mission_runtime::attach_agent_loop_provider_state(
             &db3,
             &format!("mission-{}", "wi-err"),
             "wi-err",
             "sess-err",
             "run-err",
-            /* completed = */ false,
+            crate::mission_runtime::AgentLoopProviderRestState::Routed,
             "",
             None,
             /* guarded = */ false,
@@ -15097,7 +15092,7 @@ mod tests {
             "wi-deg3",
             "sess-deg3",
             "run-deg3",
-            /* completed = */ false,
+            crate::mission_runtime::AgentLoopProviderRestState::Routed,
             "",
             None,
             /* guarded = */ false,

--- a/rust-core/crates/friday-hub/src/mission_runtime.rs
+++ b/rust-core/crates/friday-hub/src/mission_runtime.rs
@@ -108,6 +108,13 @@ pub enum MissionBoundAskOutcome {
     },
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum AgentLoopProviderRestState {
+    Routed,
+    Completed,
+    FailedTerminal,
+}
+
 pub fn resolve_mission_runtime_envelope(
     db: &Db,
     request: MissionRuntimeRequest,
@@ -580,7 +587,7 @@ fn attach_completed_provider_state_for_ask(
 /// keeps the single caller-side `now_ms` (byte-identical to pre-WI-1).
 ///
 /// The COMBINED all-at-once agent-loop binding drive (`SentToHub -> AcceptedByHub ->
-/// RoutedToProvider`, plus `WaitingProvider -> ProviderCompleted` when `completed`), run AFTER the
+/// RoutedToProvider`, plus either the completion or terminal-failure rest hop), run AFTER the
 /// loop. This is the PRODUCTION drive — the pre-#24b order, RESTORED in the panel-BLOCK fix.
 ///
 /// (#24b history) The original #24b SPLIT this into a pre-dispatch leg (before the loop, advancing
@@ -601,7 +608,7 @@ pub(crate) fn attach_agent_loop_provider_state(
     work_item_id: &str,
     session_id: &str,
     run_id: &str,
-    completed: bool,
+    rest_state: AgentLoopProviderRestState,
     proof_ref: &str,
     completion_proof_receipt: Option<&str>,
     guarded: bool,
@@ -612,9 +619,15 @@ pub(crate) fn attach_agent_loop_provider_state(
         PendingState::AcceptedByHub,
         PendingState::RoutedToProvider,
     ];
-    if completed {
-        states.push(PendingState::WaitingProvider);
-        states.push(PendingState::ProviderCompleted);
+    match rest_state {
+        AgentLoopProviderRestState::Routed => {}
+        AgentLoopProviderRestState::Completed => {
+            states.push(PendingState::WaitingProvider);
+            states.push(PendingState::ProviderCompleted);
+        }
+        AgentLoopProviderRestState::FailedTerminal => {
+            states.push(PendingState::FailedTerminal);
+        }
     }
     drive_provider_states(
         db,
@@ -677,8 +690,9 @@ fn drive_provider_states(
         };
         // (#24b degrade-3 fix) Clear the durable `executing` marker ATOMICALLY with the FINAL hop's
         // status write. Every caller of this driver is the agent-loop binding, whose final hop is
-        // the run's resting state (`ProviderRouted` on pause/await/error, `CompletedWithProof` on
-        // completion) — a state where `executing` MUST be 0. Doing the clear in the SAME tx as that
+        // the run's resting state (`ProviderRouted` on pause/await, `FailedTerminal` on terminal
+        // failure, `CompletedWithProof` on completion) — a state where `executing` MUST be 0.
+        // Doing the clear in the SAME tx as that
         // status write means a swallowed best-effort loop tail-clear can NEVER strand
         // `executing == 1` on a live paused run (which PASS-2 would then falsely reconcile). The
         // non-final in-flight hops keep `false` (the marker is still live mid-drive).
@@ -712,7 +726,8 @@ fn drive_provider_states(
 /// advance its bound WorkItem `ProviderRouted → CompletedWithProof`. This closes the ONE gap left
 /// by the dark mission-bound run path: after the operator's Ed25519-signed approval executes the
 /// one paused mutation, NOTHING previously advanced the WorkItem off `ProviderRouted` (the
-/// pause-time bind state — see `attach_agent_loop_provider_state` with `completed=false`).
+/// pause-time bind state — see `attach_agent_loop_provider_state` with
+/// `AgentLoopProviderRestState::Routed`).
 ///
 /// ## THE LOOPHOLE GATE (a false proof is a security defect)
 /// The WorkItem is advanced ONLY when the ONE approved mutation actually ran — gate `Allow` AND
@@ -1769,7 +1784,7 @@ mod tests {
             "work-runtime",
             "friday-session-loop",
             "run-loop-1",
-            /* completed = */ true,
+            AgentLoopProviderRestState::Completed,
             "friday://agent-run/run-loop-1",
             None,
             /* guarded = */ true,
@@ -1834,7 +1849,7 @@ mod tests {
             "work-runtime",
             "friday-session-loop",
             "run-loop-2",
-            /* completed = */ true,
+            AgentLoopProviderRestState::Completed,
             "friday://agent-run/run-loop-2",
             None,
             /* guarded = */ false,
@@ -1913,7 +1928,7 @@ mod tests {
             "work-runtime",
             "sess-z",
             "run-z",
-            /* completed = */ false,
+            AgentLoopProviderRestState::Routed,
             "friday://agent-run/run-z",
             None,
             /* guarded = */ false,

--- a/rust-core/crates/friday-hub/src/runtime.rs
+++ b/rust-core/crates/friday-hub/src/runtime.rs
@@ -39,8 +39,8 @@ use crate::mission_context::MissionContextLookup;
 use crate::mission_preflight::MissionAttachmentOutcome;
 use crate::mission_runtime::{
     answer_produced_outcome_receipt_for_work_item, attach_agent_loop_provider_state,
-    resolve_mission_runtime_envelope, MissionRuntimeEnvelope, MissionRuntimeOutcome,
-    MissionRuntimeRequest,
+    resolve_mission_runtime_envelope, AgentLoopProviderRestState, MissionRuntimeEnvelope,
+    MissionRuntimeOutcome, MissionRuntimeRequest,
 };
 use crate::routing::{
     run_routed_loop_with_policy, ProviderClientResolver, ProviderRoute, RouteRegistry,
@@ -2182,14 +2182,25 @@ impl<T: Transport> HubRuntime<T> {
 
         // Bind the run to the Mission via the ask path's provider-timeline attachment, AFTER the
         // loop. Truth-honest: complete the WorkItem with the run as proof ONLY when the loop
-        // Finished; otherwise bind at `ProviderRouted` (the pause/await rest state the #755 resume
-        // path drives from) without over-claiming completion. The binding ALSO clears the durable
-        // `executing` marker ATOMICALLY in the SAME transaction as its FINAL status hop (degrade-3
-        // fix): a run that reaches a binding rest state (`ProviderRouted` on pause/await,
+        // Finished; keep resumable/user-waiting stops at `ProviderRouted`; and terminal non-answer
+        // failures at `FailedTerminal` so they cannot strand a WorkItem as apparently live routed
+        // work. The binding ALSO clears the durable `executing` marker ATOMICALLY in the SAME
+        // transaction as its FINAL status hop (degrade-3 fix): a run that reaches a binding rest
+        // state (`ProviderRouted` on pause/await, `FailedTerminal` on terminal failure,
         // `CompletedWithProof` on completion) ends with `executing == 0` written in the SAME tx, so
         // a swallowed best-effort tail-clear can NEVER strand `executing == 1` on a live paused run
         // (which PASS-2 would then falsely reconcile after a long human approval latency).
         let completed = outcome.status == LoopStatus::Finished;
+        let rest_state = match outcome.status {
+            LoopStatus::Finished => AgentLoopProviderRestState::Completed,
+            LoopStatus::Paused | LoopStatus::AwaitingClarification => {
+                AgentLoopProviderRestState::Routed
+            }
+            LoopStatus::Blocked
+            | LoopStatus::Bounded
+            | LoopStatus::Errored
+            | LoopStatus::Interrupted => AgentLoopProviderRestState::FailedTerminal,
+        };
         let result_link = format!("friday://agent-run/{run_id}");
         let completion_proof_receipt = if completed {
             answer_produced_outcome_receipt_for_work_item(
@@ -2207,7 +2218,7 @@ impl<T: Transport> HubRuntime<T> {
             &envelope.context.work_item_id,
             session_id,
             run_id,
-            completed,
+            rest_state,
             &result_link,
             completion_proof_receipt.as_deref(),
             // WI-1 (M-6): DARK-flag bool threaded from the entrypoint env read. OFF ⇒ the inline
@@ -8353,6 +8364,66 @@ mod tests {
         assert!(work_item
             .proof_receipts
             .contains(&"friday://agent-run/run-mloop".to_string()));
+        assert!(friday_storage::audit::verify_audit_chain(rt.db().conn()).is_ok());
+    }
+
+    #[test]
+    fn mission_bound_terminal_non_answer_marks_work_item_failed_terminal_without_proof() {
+        let (rt, root, _post) = runtime_with(
+            "mloop-bounded-terminal",
+            &["{\"tool\":\"read_file\",\"parameters\":{\"path\":\"notes.md\"}}"],
+            Box::new(DenyAllApprovals),
+        );
+        std::fs::write(root.join("notes.md"), b"mission-bound note").unwrap();
+        seed_loop_mission(
+            rt.db(),
+            WorkLane::DeepSeek,
+            Some("deepseek"),
+            WorkItemStatus::ReadyToDispatch,
+        );
+
+        let outcome = rt
+            .run_agent_loop_for_mission_with_overrides(
+                loop_lookup(),
+                "friday-hub-session",
+                "run-mloop-bounded",
+                "keep reading until done",
+                None,
+                Some(1),
+                1000,
+            )
+            .unwrap();
+
+        let MissionBoundLoopOutcome::Ran {
+            outcome,
+            attachment,
+            ..
+        } = outcome
+        else {
+            panic!("expected a Mission-bound loop run");
+        };
+        assert_eq!(outcome.status, LoopStatus::Bounded);
+        assert!(matches!(
+            attachment,
+            MissionAttachmentOutcome::Attached {
+                work_item_status: WorkItemStatus::FailedTerminal,
+                ..
+            }
+        ));
+        let work_item = rt.db().get_work_item("work-loop").unwrap().unwrap();
+        assert_eq!(work_item.status, WorkItemStatus::FailedTerminal);
+        assert!(
+            work_item.proof_receipts.is_empty(),
+            "terminal non-answer must not mint a completion proof"
+        );
+        assert!(
+            !rt.db()
+                .get_work_item_execution_state("work-loop")
+                .unwrap()
+                .unwrap()
+                .executing,
+            "the terminal rest hop must clear executing atomically"
+        );
         assert!(friday_storage::audit::verify_audit_chain(rt.db().conn()).is_ok());
     }
 


### PR DESCRIPTION
## Summary
- Add an explicit agent-loop provider rest state for routed, completed, and terminal-failure outcomes.
- Map mission-bound terminal non-answer outcomes to FailedTerminal instead of leaving WorkItems at ProviderRouted.
- Add regression coverage proving bounded non-answer runs fail terminally without completion proof and clear executing atomically.

## Tests
- cargo test -p friday-hub mission_bound_terminal_non_answer_marks_work_item_failed_terminal_without_proof -- --nocapture
- cargo test -p friday-hub wi1_agent_loop_single_now_ms -- --nocapture
- cargo test -p friday-hub errored_mission_bound_run_stays_ready_to_dispatch_not_stranded -- --nocapture
- cargo test -p friday-hub paused_run_with_swallowed_tail_clear_is_not_pass2_reconciled -- --nocapture
- git diff --check