### PR TITLE
Wire managed skills read-only catalog

### DIFF
--- a/src/hub/friday-hub-bootstrap.ts
+++ b/src/hub/friday-hub-bootstrap.ts
@@ -61,6 +61,7 @@ import {
 import type { FridayEncryptedEnvelope, FridayProviderApi, FridayProviderKind, FridayProviderProfile, FridayProviderService } from "#providers";
 import { createFridayProviderContextCompactor, createFridayProviderContextPruner, createFridayProviderTokenEstimator } from "#providers";
 import {
+  createFridayManagedSkillsCatalogBackend,
   createFridaySkillInstallationRepository,
   createFridaySkillInstallationService,
   createFridaySkillLifecycleService,
@@ -6198,6 +6199,11 @@ export async function createFridayHub(
     db: stateRuntime.sqlite,
     nowIso,
     managedSkillsDir,
+    catalog: createFridayManagedSkillsCatalogBackend({
+      managedSkillsDir,
+      workspaceDir: workspaceRoot,
+      nowIso,
+    }),
     hubVersion: FRIDAY_HUB_SKILL_COMPAT_VERSION,
     supportedApiVersions: ["1"],
     registry,

--- a/src/skills/index.ts
+++ b/src/skills/index.ts
@@ -234,6 +234,11 @@ export {
   type FridayManifestValidationOutcome,
   type CreateFridaySkillLifecycleServiceDeps,
 } from "./services/friday-skill-lifecycle-service.js";
+export {
+  createFridayManagedSkillsCatalogBackend,
+  type CreateFridayManagedSkillsCatalogBackendOptions,
+  type FridaySkillCatalogBackend,
+} from "./services/friday-managed-skills-catalog-backend.js";
 
 export {
   createFridaySkillUpgradeAnalysisService,

--- a/src/skills/services/friday-managed-skills-catalog-backend.ts
+++ b/src/skills/services/friday-managed-skills-catalog-backend.ts
@@ -1,0 +1,136 @@
+import { readdirSync, statSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+import { loadFridaySkillPackage } from "../manifest/friday-skill-package-loader.js";
+import type {
+  FridaySkillCatalogItem,
+  FridaySkillCatalogQuery,
+  FridaySkillCatalogResult,
+  FridaySkillSourceEntity,
+} from "../model/friday-skill-catalog.types.js";
+
+export interface FridaySkillCatalogBackend {
+  listCatalog(query: FridaySkillCatalogQuery): FridaySkillCatalogResult;
+  getSource(sourceId?: string): FridaySkillSourceEntity | undefined;
+}
+
+export interface CreateFridayManagedSkillsCatalogBackendOptions {
+  managedSkillsDir: string;
+  workspaceDir?: string;
+  nowIso: () => string;
+}
+
+const MANAGED_SKILLS_SOURCE_ID = "managed-skills";
+
+export function createFridayManagedSkillsCatalogBackend(
+  options: CreateFridayManagedSkillsCatalogBackendOptions,
+): FridaySkillCatalogBackend {
+  const source = (): FridaySkillSourceEntity => {
+    const now = options.nowIso();
+    return {
+      id: MANAGED_SKILLS_SOURCE_ID,
+      name: "Managed Skills",
+      baseUrl: pathToFileURL(resolve(options.managedSkillsDir)).href,
+      enabled: true,
+      trustPolicy: "warn",
+      pinnedKeyIds: [],
+      createdAt: now,
+      updatedAt: now,
+    };
+  };
+
+  function loadItems(): FridaySkillCatalogItem[] {
+    let entries;
+    try {
+      entries = readdirSync(options.managedSkillsDir, { withFileTypes: true });
+    } catch {
+      return [];
+    }
+
+    const workspaceDir = options.workspaceDir ?? options.managedSkillsDir;
+    const items: FridaySkillCatalogItem[] = [];
+    for (const entry of entries) {
+      if (!entry.isDirectory()) {
+        continue;
+      }
+      const skillDir = join(options.managedSkillsDir, entry.name);
+      const loaded = loadFridaySkillPackage({ skillDir, workspaceDir });
+      if (!loaded.ok) {
+        continue;
+      }
+      const { manifest } = loaded.value;
+      let releasedAt = options.nowIso();
+      try {
+        releasedAt = statSync(skillDir).mtime.toISOString();
+      } catch {
+        // Keep catalog reads fail-open for entry metadata; package parsing already gates inclusion.
+      }
+      items.push({
+        sourceId: MANAGED_SKILLS_SOURCE_ID,
+        skillId: manifest.id,
+        skillName: manifest.name,
+        publisher: manifest.author.name,
+        version: manifest.version,
+        category: manifest.category,
+        releasedAt,
+        signatureValid: true,
+        trustScore: 80,
+        starter: (manifest.tags ?? []).includes("starter"),
+        manifest,
+        implementationStatus: "installed",
+        firstUsePrompts: [
+          ...(manifest.triggers.phrases ?? []),
+          ...(manifest.triggers.intents ?? []),
+        ].slice(0, 3),
+      });
+    }
+
+    return items.sort((left, right) => left.skillName.localeCompare(right.skillName));
+  }
+
+  return {
+    listCatalog(query) {
+      const sourceId = query.sourceId?.trim();
+      const q = query.q?.trim().toLowerCase();
+      const category = query.category?.trim().toLowerCase();
+      const filtered = loadItems().filter((item) => {
+        if (sourceId && item.sourceId !== sourceId) {
+          return false;
+        }
+        if (category && item.category?.toLowerCase() !== category) {
+          return false;
+        }
+        if (!q) {
+          return true;
+        }
+        const haystack = [
+          item.skillId,
+          item.skillName,
+          item.manifest.description,
+          item.publisher,
+          ...(item.manifest.tags ?? []),
+          ...(item.manifest.triggers.phrases ?? []),
+          ...(item.manifest.triggers.intents ?? []),
+        ].join("\n").toLowerCase();
+        return haystack.includes(q);
+      });
+
+      const offset = Math.max(0, Number.parseInt(query.cursor ?? "0", 10) || 0);
+      const limit = query.limit && query.limit > 0 ? Math.min(query.limit, 100) : filtered.length;
+      const items = filtered.slice(offset, offset + limit);
+      const nextOffset = offset + items.length;
+      return {
+        items,
+        total: filtered.length,
+        nextCursor: nextOffset < filtered.length ? String(nextOffset) : undefined,
+      };
+    },
+
+    getSource(sourceId) {
+      if (!sourceId || sourceId === MANAGED_SKILLS_SOURCE_ID) {
+        return source();
+      }
+      return undefined;
+    },
+  };
+}

--- a/src/skills/services/friday-skill-lifecycle-service.ts
+++ b/src/skills/services/friday-skill-lifecycle-service.ts
@@ -36,6 +36,7 @@ import type { FridaySkillRepository } from "../persistence/friday-skill-reposito
 import type { FridaySkillVersionRepository } from "../persistence/friday-skill-version-repository.js";
 import type { FridayRegisteredSkill, FridaySkillRegistry } from "../registry/friday-skill-registry.types.js";
 import type { FridaySkillInstallationService } from "./friday-skill-installation-service.js";
+import type { FridaySkillCatalogBackend } from "./friday-managed-skills-catalog-backend.js";
 import type { FridaySkillPackageInstaller } from "./friday-skill-package-installer.js";
 import type { FridaySkillSignatureVerifier } from "./friday-skill-signature-verifier.js";
 import type { FridaySkillTrustScoringService } from "./friday-skill-trust-scoring-service.js";
@@ -227,6 +228,7 @@ export interface CreateFridaySkillLifecycleServiceDeps {
   skillRepo: FridaySkillRepository;
   versionRepo: FridaySkillVersionRepository;
   installationRepo: FridaySkillInstallationRepository;
+  catalog?: FridaySkillCatalogBackend;
   selfHealing?: FridaySelfHealingApiService;
 }
 
@@ -880,31 +882,18 @@ function enrichSummary(input: {
 export function createFridaySkillLifecycleService(
   deps: CreateFridaySkillLifecycleServiceDeps,
 ): FridaySkillLifecycleService {
-  // B1 truth-labeling: this lifecycle service ships without a wired catalog
-  // backend. `getCatalogCandidates` and `getSource` below are placeholders
-  // that return empty/undefined so summaries built from persisted/registry
-  // state still render. Public `listCatalog` will return an empty result and
-  // `getSkill(...).sourceDetails` / `.catalogEntry` will be undefined regardless
-  // of which skillId is asked for. Emit a one-time INFO so operators reading
-  // diagnostics can see this is a known proof_pending feature, not data loss.
-  console.info(
-    "[friday][skill-lifecycle] Catalog backend is not wired in this build — listCatalog() returns empty and getSkill() omits sourceDetails/catalogEntry. This is proof_pending per B1; persisted + registry-based summaries remain truthful.",
-  );
+  if (deps.catalog) {
+    console.info(
+      "[friday][skill-lifecycle] Read-only managed-skills catalog backend wired — listCatalog() exposes local catalog entries; skill execution remains governed/fail-closed.",
+    );
+  } else {
+    console.info(
+      "[friday][skill-lifecycle] Catalog backend is not wired in this build — listCatalog() returns empty and getSkill() omits sourceDetails/catalogEntry. This is proof_pending per B1; persisted + registry-based summaries remain truthful.",
+    );
+  }
 
-  /**
-   * B1 catalog stub: returns `[]` for every skillId. The lifecycle service
-   * does not currently have a catalog repository wired through
-   * `CreateFridaySkillLifecycleServiceDeps`. Until a real catalog backend
-   * lands, every catalog-derived field in summaries (`catalogEntry`,
-   * `sourceDetails`, `sourceId`, `latestVersion` derived from catalog, etc.)
-   * is unavailable. Persisted DB state + in-memory registry state still
-   * power the rest of the summary.
-   *
-   * See `listCatalog` and `getSkill` below for the public surface.
-   */
   function getCatalogCandidates(skillId: string): FridaySkillCatalogItem[] {
-    void skillId;
-    return [];
+    return deps.catalog?.listCatalog({}).items.filter((item) => item.skillId === skillId) ?? [];
   }
 
   function getPersistedSkill(skillId: string): FridaySkillEntity | null {
@@ -925,13 +914,8 @@ export function createFridaySkillLifecycleService(
     );
   }
 
-  /**
-   * B1 catalog-source stub: returns `undefined` for every sourceId. Paired
-   * with `getCatalogCandidates`; see the rationale comment on that function.
-   */
   function getSource(sourceId?: string): FridaySkillSourceEntity | undefined {
-    void sourceId;
-    return undefined;
+    return deps.catalog?.getSource(sourceId);
   }
 
   function buildSummary(skillId: string): FridaySkillLifecycleSummary | null {
@@ -1270,22 +1254,8 @@ export function createFridaySkillLifecycleService(
       return [...summaries.values()].sort((left, right) => left.name.localeCompare(right.name));
     },
 
-    /**
-     * B1 truth-labeling note: this method returns `{ items: [], total: 0 }`
-     * for ALL queries because the lifecycle service ships without a wired
-     * catalog backend (see `getCatalogCandidates` stub above and the
-     * `console.info` advisory at service-creation time). An empty result is
-     * truthful — there ARE no catalog items in this build — but operators
-     * consuming the response should not interpret it as "user has not added
-     * anything"; it means "catalog feature is proof_pending."
-     *
-     * Future: wire a real catalog repository (likely a new dep slot in
-     * `CreateFridaySkillLifecycleServiceDeps`) and update this method + the
-     * `getCatalogCandidates` stub in lock-step.
-     */
     listCatalog(query) {
-      void query;
-      const result: FridaySkillCatalogResult = { items: [], total: 0 };
+      const result: FridaySkillCatalogResult = deps.catalog?.listCatalog(query) ?? { items: [], total: 0 };
       const items = result.items.map((item) => buildCatalogViewItem(item));
       return {
         ...result,
@@ -1293,15 +1263,6 @@ export function createFridaySkillLifecycleService(
       };
     },
 
-    /**
-     * B1 truth-labeling note: `sourceDetails` and `catalogEntry` will always be
-     * `undefined` in this build because the catalog backend is not wired
-     * (see `getCatalogCandidates` / `getSource` stubs and the `console.info`
-     * advisory at service-creation time). The persisted-skill + registered-skill
-     * portions of the summary are real; only the catalog-derived enrichments
-     * are unavailable. Callers should not treat the absence of `catalogEntry`
-     * as "no source available" — it means "catalog feature is proof_pending."
-     */
     getSkill(skillId) {
       const summary = buildSummary(skillId);
       if (!summary) {

--- a/test/unit/skills/lifecycle/friday-skill-lifecycle-catalog-stub.test.ts
+++ b/test/unit/skills/lifecycle/friday-skill-lifecycle-catalog-stub.test.ts
@@ -15,9 +15,19 @@
  * re-stub the full dep tree.
  */
 
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
-import { createFridaySkillLifecycleService, type FridaySkillRegistry } from "#skills";
+import {
+  createFridayManagedSkillsCatalogBackend,
+  createFridaySkillLifecycleService,
+  type CreateFridaySkillLifecycleServiceDeps,
+  type FridaySkillRegistry,
+} from "#skills";
 
 function makeStubRegistry(): FridaySkillRegistry {
   return {
@@ -34,7 +44,9 @@ function makeStubRegistry(): FridaySkillRegistry {
   } as unknown as FridaySkillRegistry;
 }
 
-function makeMinimalDeps() {
+function makeMinimalDeps(
+  overrides: Partial<CreateFridaySkillLifecycleServiceDeps> = {},
+): CreateFridaySkillLifecycleServiceDeps {
   // Database stub: returns null/empty for every read; no writes expected in
   // listCatalog or getSkill(unknown).
   const db = {
@@ -56,6 +68,7 @@ function makeMinimalDeps() {
     skillRepo: {
       getSkillById: vi.fn(() => null),
       listSkills: vi.fn(() => []),
+      listAll: vi.fn(() => []),
     } as never,
     versionRepo: {
       listVersions: vi.fn(() => []),
@@ -63,7 +76,70 @@ function makeMinimalDeps() {
     installationRepo: {
       listBySkill: vi.fn(() => []),
     } as never,
+    ...overrides,
   };
+}
+
+async function makeManagedSkillDir(): Promise<string> {
+  const managedSkillsDir = await mkdtemp(join(tmpdir(), "friday-d21-skill-catalog-"));
+  const skillDir = join(managedSkillsDir, "live-catalog-smoke");
+  mkdirSync(skillDir, { recursive: true });
+  writeFileSync(
+    join(skillDir, "skill.manifest.json"),
+    JSON.stringify({
+      schemaVersion: "2.0",
+      id: "live-catalog-smoke",
+      name: "Live Catalog Smoke",
+      description: "Exposes a managed skill through the read-only lifecycle catalog.",
+      version: "1.0.0",
+      kind: "conversation",
+      category: "utility",
+      author: {
+        name: "Friday",
+      },
+      tags: ["managed", "starter"],
+      runtime: {
+        kind: "shell",
+        entrypoint: "run.sh",
+        minHubVersion: "1.0.0",
+        apiVersion: "1",
+        timeoutMsDefault: 30000,
+      },
+      triggers: {
+        intents: ["catalog_smoke"],
+        phrases: ["catalog smoke"],
+        channels: ["*"],
+      },
+      invocation: {
+        userInvocable: true,
+        modelInvocable: true,
+        priority: 50,
+        modes: ["intent"],
+      },
+      requirements: {
+        bins: [],
+        env: [],
+        config: [],
+        os: ["darwin", "linux"],
+      },
+      inputs: [],
+      outputs: [],
+      permissions: {
+        grants: [],
+        promptOn: [],
+      },
+      schemas: null,
+      flow: null,
+      executionTargets: {
+        allowedSatelliteTypes: ["desktop", "cloud-vm"],
+        requiredCapabilities: [],
+      },
+      telemetry: {
+        events: [],
+      },
+    }),
+  );
+  return managedSkillsDir;
 }
 
 describe("createFridaySkillLifecycleService — B1 catalog truth-labeling", () => {
@@ -127,5 +203,71 @@ describe("createFridaySkillLifecycleService — B1 catalog truth-labeling", () =
       typeof msg === "string" && msg.includes("Catalog backend is not wired"),
     );
     expect(catalogAdvisories).toHaveLength(2);
+  });
+
+  it("listCatalog exposes managed-skills entries when a read-only catalog backend is wired", async () => {
+    const managedSkillsDir = await makeManagedSkillDir();
+    try {
+      const service = createFridaySkillLifecycleService(makeMinimalDeps({
+        managedSkillsDir,
+        catalog: createFridayManagedSkillsCatalogBackend({
+          managedSkillsDir,
+          workspaceDir: managedSkillsDir,
+          nowIso: () => "2026-05-24T13:30:00.000Z",
+        }),
+      }));
+
+      const result = service.listCatalog({ q: "smoke" } as never);
+      expect(result.total).toBe(1);
+      expect(result.items).toHaveLength(1);
+      expect(result.items[0]).toMatchObject({
+        sourceId: "managed-skills",
+        skillId: "live-catalog-smoke",
+        skillName: "Live Catalog Smoke",
+        publisher: "Friday",
+        category: "utility",
+        implementationStatus: "installed",
+      });
+      expect(result.items[0]?.sourceDetails).toMatchObject({
+        id: "managed-skills",
+        enabled: true,
+        trustPolicy: "warn",
+      });
+      expect(result.items[0]?.firstUsePrompts).toEqual(["catalog smoke", "catalog_smoke"]);
+    } finally {
+      rmSync(managedSkillsDir, { recursive: true, force: true });
+    }
+  });
+
+  it("getSkill enriches summaries with catalogEntry and sourceDetails from the backend", async () => {
+    const managedSkillsDir = await makeManagedSkillDir();
+    try {
+      const service = createFridaySkillLifecycleService(makeMinimalDeps({
+        managedSkillsDir,
+        catalog: createFridayManagedSkillsCatalogBackend({
+          managedSkillsDir,
+          workspaceDir: managedSkillsDir,
+          nowIso: () => "2026-05-24T13:30:00.000Z",
+        }),
+      }));
+
+      const result = service.getSkill("live-catalog-smoke");
+      expect(result).toMatchObject({
+        skillId: "live-catalog-smoke",
+        name: "Live Catalog Smoke",
+        sourceId: "managed-skills",
+        sourceDetails: {
+          id: "managed-skills",
+          enabled: true,
+        },
+        catalogEntry: {
+          skillId: "live-catalog-smoke",
+          sourceId: "managed-skills",
+          implementationStatus: "installed",
+        },
+      });
+    } finally {
+      rmSync(managedSkillsDir, { recursive: true, force: true });
+    }
   });
 });


### PR DESCRIPTION
## Summary\n- add a read-only managed-skills catalog backend backed by existing skill.manifest.json loading\n- wire the backend into hub bootstrap so /v1/skills/catalog exposes local managed skills without enabling execution/import\n- keep no-backend lifecycle behavior truth-labeled as proof_pending and add coverage for backend list/getSkill enrichment\n\n## Validation\n- /Users/jarvis/Projects/Friday/node_modules/.bin/vitest run --project default test/unit/skills/lifecycle/friday-skill-lifecycle-catalog-stub.test.ts\n- npm run typecheck:src\n- git diff --check\n\nTruth labels: read-only catalog visibility only; skill run/import remain governed/fail-closed. This is not D20/B4 true signing, OG9 strict organic closure, or phase1 done.