### PR TITLE
Add Ed25519 skill catalog receipts

### DIFF
--- a/rust-core/crates/friday-hub/src/skill_catalog.rs
+++ b/rust-core/crates/friday-hub/src/skill_catalog.rs
@@ -18,7 +18,10 @@ use friday_core::{
     SkillCatalogSnapshot, SkillCatalogSource, SkillState, WorkGraphNode, WorkGraphNodeKind,
     WorkGraphTruthLabel,
 };
-use friday_storage::{authorize_mutating_action, Db, StorageError};
+use friday_crypto::OperatorVerifyingKey;
+use friday_storage::{
+    authorize_mutating_action, authorize_mutating_action_ed25519, Db, StorageError,
+};
 use serde_json::Value;
 
 #[derive(Debug, thiserror::Error)]
@@ -364,42 +367,7 @@ pub fn record_skill_run_receipt(
     request: SkillRunReceiptRequest,
     approval_secret: &[u8],
 ) -> Result<SkillRunReceipt, SkillCatalogError> {
-    let entry = snapshot
-        .entries
-        .iter()
-        .find(|entry| entry.skill_id == request.skill_id)
-        .ok_or_else(|| SkillCatalogError::RunBlocked("unknown_skill".to_string()))?;
-    if !entry.can_be_recommended() {
-        return Err(SkillCatalogError::RunBlocked(
-            "skill_not_runnable_or_not_approved".to_string(),
-        ));
-    }
-    if !is_safe_proof_ref(&request.proof_ref) {
-        return Err(SkillCatalogError::RunBlocked(
-            "skill_run_proof_ref_required".to_string(),
-        ));
-    }
-    let mission = db
-        .get_mission(&request.mission_id)?
-        .ok_or_else(|| SkillCatalogError::RunBlocked("unknown_mission".to_string()))?;
-    if mission.status.is_terminal() {
-        return Err(SkillCatalogError::RunBlocked(
-            "mission_is_terminal".to_string(),
-        ));
-    }
-    let work_item = db
-        .get_work_item(&request.work_item_id)?
-        .ok_or_else(|| SkillCatalogError::RunBlocked("unknown_work_item".to_string()))?;
-    if work_item.mission_id != request.mission_id {
-        return Err(SkillCatalogError::RunBlocked(
-            "work_item_mission_mismatch".to_string(),
-        ));
-    }
-    if work_item.status.is_terminal() {
-        return Err(SkillCatalogError::RunBlocked(
-            "work_item_is_terminal".to_string(),
-        ));
-    }
+    let entry = validate_skill_run_receipt(db, snapshot, &request)?;
     let gate_request = skill_run_gate_request(
         &request.skill_id,
         &request.mission_id,
@@ -420,6 +388,68 @@ pub fn record_skill_run_receipt(
         )));
     }
 
+    write_skill_run_receipt(db, entry, request)
+}
+
+pub fn record_skill_run_receipt_ed25519(
+    db: &Db,
+    snapshot: &SkillCatalogSnapshot,
+    request: SkillRunReceiptRequest,
+    operator_vk: &OperatorVerifyingKey,
+) -> Result<SkillRunReceipt, SkillCatalogError> {
+    let entry = validate_skill_run_receipt(db, snapshot, &request)?;
+    let gate_request = skill_run_gate_request(
+        &request.skill_id,
+        &request.mission_id,
+        &request.work_item_id,
+        &request.operator_principal_id,
+    );
+    let gate = authorize_mutating_action_ed25519(
+        db.conn(),
+        &gate_request,
+        Some(&request.canonical_approval),
+        operator_vk,
+        request.now_ms,
+    )?;
+    if gate.decision != GateDecision::Allow {
+        return Err(SkillCatalogError::RunBlocked(format!(
+            "skill_run_canonical_gate_{}",
+            gate.reason
+        )));
+    }
+
+    write_skill_run_receipt(db, entry, request)
+}
+
+fn validate_skill_run_receipt<'a>(
+    db: &Db,
+    snapshot: &'a SkillCatalogSnapshot,
+    request: &SkillRunReceiptRequest,
+) -> Result<&'a SkillCatalogEntry, SkillCatalogError> {
+    let entry = snapshot
+        .entries
+        .iter()
+        .find(|entry| entry.skill_id == request.skill_id)
+        .ok_or_else(|| SkillCatalogError::RunBlocked("unknown_skill".to_string()))?;
+    if !entry.can_be_recommended() {
+        return Err(SkillCatalogError::RunBlocked(
+            "skill_not_runnable_or_not_approved".to_string(),
+        ));
+    }
+    if !is_safe_proof_ref(&request.proof_ref) {
+        return Err(SkillCatalogError::RunBlocked(
+            "skill_run_proof_ref_required".to_string(),
+        ));
+    }
+    validate_mission_work_item(db, &request.mission_id, &request.work_item_id)?;
+    Ok(entry)
+}
+
+fn write_skill_run_receipt(
+    db: &Db,
+    entry: &SkillCatalogEntry,
+    request: SkillRunReceiptRequest,
+) -> Result<SkillRunReceipt, SkillCatalogError> {
     let run_ref = redacted_ref(
         "skill-run",
         &format!(
@@ -452,45 +482,7 @@ pub fn stage_link_skill_candidate_receipt(
     request: LinkSkillCandidateReceiptRequest,
     approval_secret: &[u8],
 ) -> Result<LinkSkillCandidateReceipt, SkillCatalogError> {
-    if !is_safe_public_id(&request.skill_id) || !is_safe_public_text(&request.safe_title) {
-        return Err(SkillCatalogError::RunBlocked(
-            "link_skill_candidate_safe_public_metadata_required".to_string(),
-        ));
-    }
-    if !is_safe_public_id(&request.source_digest)
-        || !is_public_link_evidence_url(&request.evidence_url)
-    {
-        return Err(SkillCatalogError::RunBlocked(
-            "link_skill_candidate_public_evidence_required".to_string(),
-        ));
-    }
-    if !is_safe_proof_ref(&request.proof_ref) {
-        return Err(SkillCatalogError::RunBlocked(
-            "link_skill_candidate_proof_ref_required".to_string(),
-        ));
-    }
-
-    let mission = db
-        .get_mission(&request.mission_id)?
-        .ok_or_else(|| SkillCatalogError::RunBlocked("unknown_mission".to_string()))?;
-    if mission.status.is_terminal() {
-        return Err(SkillCatalogError::RunBlocked(
-            "mission_is_terminal".to_string(),
-        ));
-    }
-    let work_item = db
-        .get_work_item(&request.work_item_id)?
-        .ok_or_else(|| SkillCatalogError::RunBlocked("unknown_work_item".to_string()))?;
-    if work_item.mission_id != request.mission_id {
-        return Err(SkillCatalogError::RunBlocked(
-            "work_item_mission_mismatch".to_string(),
-        ));
-    }
-    if work_item.status.is_terminal() {
-        return Err(SkillCatalogError::RunBlocked(
-            "work_item_is_terminal".to_string(),
-        ));
-    }
+    validate_link_skill_candidate_receipt(db, &request)?;
 
     let gate_request = link_skill_candidate_gate_request(
         &request.skill_id,
@@ -513,6 +505,96 @@ pub fn stage_link_skill_candidate_receipt(
         )));
     }
 
+    write_link_skill_candidate_receipt(db, request)
+}
+
+pub fn stage_link_skill_candidate_receipt_ed25519(
+    db: &Db,
+    request: LinkSkillCandidateReceiptRequest,
+    operator_vk: &OperatorVerifyingKey,
+) -> Result<LinkSkillCandidateReceipt, SkillCatalogError> {
+    validate_link_skill_candidate_receipt(db, &request)?;
+    let gate_request = link_skill_candidate_gate_request(
+        &request.skill_id,
+        &request.source_digest,
+        &request.mission_id,
+        &request.work_item_id,
+        &request.operator_principal_id,
+    );
+    let gate = authorize_mutating_action_ed25519(
+        db.conn(),
+        &gate_request,
+        Some(&request.canonical_approval),
+        operator_vk,
+        request.now_ms,
+    )?;
+    if gate.decision != GateDecision::Allow {
+        return Err(SkillCatalogError::RunBlocked(format!(
+            "link_skill_candidate_canonical_gate_{}",
+            gate.reason
+        )));
+    }
+
+    write_link_skill_candidate_receipt(db, request)
+}
+
+fn validate_link_skill_candidate_receipt(
+    db: &Db,
+    request: &LinkSkillCandidateReceiptRequest,
+) -> Result<(), SkillCatalogError> {
+    if !is_safe_public_id(&request.skill_id) || !is_safe_public_text(&request.safe_title) {
+        return Err(SkillCatalogError::RunBlocked(
+            "link_skill_candidate_safe_public_metadata_required".to_string(),
+        ));
+    }
+    if !is_safe_public_id(&request.source_digest)
+        || !is_public_link_evidence_url(&request.evidence_url)
+    {
+        return Err(SkillCatalogError::RunBlocked(
+            "link_skill_candidate_public_evidence_required".to_string(),
+        ));
+    }
+    if !is_safe_proof_ref(&request.proof_ref) {
+        return Err(SkillCatalogError::RunBlocked(
+            "link_skill_candidate_proof_ref_required".to_string(),
+        ));
+    }
+    validate_mission_work_item(db, &request.mission_id, &request.work_item_id)
+}
+
+fn validate_mission_work_item(
+    db: &Db,
+    mission_id: &str,
+    work_item_id: &str,
+) -> Result<(), SkillCatalogError> {
+    let mission = db
+        .get_mission(mission_id)?
+        .ok_or_else(|| SkillCatalogError::RunBlocked("unknown_mission".to_string()))?;
+    if mission.status.is_terminal() {
+        return Err(SkillCatalogError::RunBlocked(
+            "mission_is_terminal".to_string(),
+        ));
+    }
+    let work_item = db
+        .get_work_item(work_item_id)?
+        .ok_or_else(|| SkillCatalogError::RunBlocked("unknown_work_item".to_string()))?;
+    if work_item.mission_id != mission_id {
+        return Err(SkillCatalogError::RunBlocked(
+            "work_item_mission_mismatch".to_string(),
+        ));
+    }
+    if work_item.status.is_terminal() {
+        return Err(SkillCatalogError::RunBlocked(
+            "work_item_is_terminal".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn write_link_skill_candidate_receipt(
+    db: &Db,
+    request: LinkSkillCandidateReceiptRequest,
+) -> Result<LinkSkillCandidateReceipt, SkillCatalogError> {
     let candidate_ref = redacted_ref(
         "link-skill-candidate",
         &format!(

--- a/rust-core/crates/friday-hub/tests/skill_catalog_ed25519.rs
+++ b/rust-core/crates/friday-hub/tests/skill_catalog_ed25519.rs
@@ -1,0 +1,265 @@
+//! D21 skill catalog Ed25519 receipt guards.
+//!
+//! These tests live in `tests/` because they construct a TEST operator signing
+//! key. Hub source keeps only the verify key path.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use friday_core::gate::{
+    canonical_action_bytes, canonical_approval_signature_bytes, ApprovalDecision,
+    CanonicalApproval, MutatingActionRequest, CANONICAL_GATE_ISSUER,
+};
+use friday_core::{
+    ApprovalState, FridayConversation, HandoffJudgmentMemory, Mission, MissionStatus, Risk,
+    TruthStatus, WorkItem, WorkItemStatus, WorkLane,
+};
+use friday_crypto::{OperatorSigningKey, OperatorVerifyingKey};
+use friday_hub::skill_catalog::{
+    link_skill_candidate_gate_request, stage_link_skill_candidate_receipt_ed25519,
+    LinkSkillCandidateReceiptRequest,
+};
+use friday_storage::Db;
+
+const HUB_HMAC_SECRET: &[u8] = b"hub-held-hmac-gate-secret-0123456789";
+const NOW: i64 = 1_000;
+const FUTURE: i64 = 5_000_000_000_000;
+
+static C: AtomicU64 = AtomicU64::new(0);
+
+fn unique(tag: &str) -> String {
+    format!(
+        "{}-{}-{}",
+        std::process::id(),
+        tag,
+        C.fetch_add(1, Ordering::Relaxed)
+    )
+}
+
+fn temp_db(tag: &str) -> String {
+    std::env::temp_dir()
+        .join(format!(
+            "friday-skill-catalog-ed25519-{}.sqlite",
+            unique(tag)
+        ))
+        .to_string_lossy()
+        .into_owned()
+}
+
+fn operator() -> (OperatorSigningKey, OperatorVerifyingKey) {
+    let sk = OperatorSigningKey::generate();
+    let vk = sk.verifying_key();
+    (sk, vk)
+}
+
+fn ed_approval(
+    req: &MutatingActionRequest,
+    sk: &OperatorSigningKey,
+    approval_id: &str,
+) -> CanonicalApproval {
+    let digest = friday_crypto::action_digest(&canonical_action_bytes(req));
+    let mut approval = CanonicalApproval {
+        decision: ApprovalDecision::Approved,
+        approval_id: approval_id.to_string(),
+        action_digest: digest,
+        expires_at: Some(FUTURE),
+        issuer: Some(CANONICAL_GATE_ISSUER.to_string()),
+        signature: None,
+    };
+    approval.signature = Some(
+        sk.sign(&canonical_approval_signature_bytes(&approval))
+            .to_hex(),
+    );
+    approval
+}
+
+fn hmac_approval(req: &MutatingActionRequest, approval_id: &str) -> CanonicalApproval {
+    let digest = friday_crypto::action_digest(&canonical_action_bytes(req));
+    let mut approval = CanonicalApproval {
+        decision: ApprovalDecision::Approved,
+        approval_id: approval_id.to_string(),
+        action_digest: digest,
+        expires_at: Some(FUTURE),
+        issuer: Some(CANONICAL_GATE_ISSUER.to_string()),
+        signature: None,
+    };
+    approval.signature = Some(friday_crypto::sign_approval(
+        &canonical_approval_signature_bytes(&approval),
+        HUB_HMAC_SECRET,
+    ));
+    approval
+}
+
+fn judgment() -> HandoffJudgmentMemory {
+    HandoffJudgmentMemory {
+        task: "Stage a governed skill candidate receipt".into(),
+        current_blocker: None,
+        target_lane_thread_agent_provider: WorkLane::FridayHub.as_str().into(),
+        read_first_files: vec!["rust-core/crates/friday-hub/src/skill_catalog.rs".into()],
+        required_output: "LinkedOnly candidate receipt".into(),
+        done_criteria: vec!["receipt recorded without import or execution".into()],
+        red_lines: vec!["Hub must not self-mint an operator approval".into()],
+        why_this_route: "D21 imports must pass through operator-governed receipts.".into(),
+        considered_options: vec!["legacy HMAC approval".into()],
+        deferred_options: vec!["runtime skill import".into()],
+        previous_pitfalls: vec!["candidate discovery looked executable".into()],
+        inheritable_context: vec!["skill catalog is advisory until imported".into()],
+        proof_requirements: vec!["Ed25519 receipt tests".into()],
+        ownership_claim_ids: Vec::new(),
+    }
+}
+
+fn seed_mission(db: &Db) {
+    db.upsert_friday_conversation(&FridayConversation {
+        friday_conversation_id: "fconv_skill_ed".into(),
+        owner_principal: "operator".into(),
+        title: "Skill Candidate".into(),
+        current_focus_summary: "Stage candidate receipt".into(),
+        active_mission_ids: vec!["mission-skill-ed".into()],
+        surface_thread_ids: Vec::new(),
+        memory_scope_ref: None,
+        truth_status: TruthStatus::Proven,
+        proof_refs: Vec::new(),
+        created_at_ms: NOW,
+        updated_at_ms: NOW,
+    })
+    .unwrap();
+    db.upsert_mission(&Mission {
+        mission_id: "mission-skill-ed".into(),
+        friday_conversation_id: "fconv_skill_ed".into(),
+        title: "Skill Candidate".into(),
+        intent: "Stage a skill candidate without importing or executing it".into(),
+        status: MissionStatus::Active,
+        why_now: "D21 skill hub needs a verify-only receipt path".into(),
+        decision_path_summary: "Require Ed25519 operator approval before linking.".into(),
+        considered_options: vec!["HMAC self-mint".into()],
+        deferred_options: vec!["runtime import".into()],
+        known_pitfalls: vec!["linked candidate mistaken for runnable skill".into()],
+        handoff_inheritance: vec!["Hub verifies, operator signs".into()],
+        work_item_ids: vec!["work-skill-ed".into()],
+        memory_candidate_refs: Vec::new(),
+        context_passport_refs: Vec::new(),
+        proof_refs: Vec::new(),
+        created_at_ms: NOW,
+        updated_at_ms: NOW,
+    })
+    .unwrap();
+    db.upsert_work_item(&WorkItem {
+        work_item_id: "work-skill-ed".into(),
+        mission_id: "mission-skill-ed".into(),
+        lane: WorkLane::FridayHub,
+        target_provider_or_agent: Some("skill:candidate".into()),
+        status: WorkItemStatus::ReadyToDispatch,
+        owner_claim_ids: Vec::new(),
+        workspace_refs: Vec::new(),
+        capability_id: Some("skill.candidate".into()),
+        risk_level: Risk::Low,
+        approval_state: ApprovalState::Approved,
+        blocking_reason: None,
+        input_refs: vec!["friday://body/skill-candidate".into()],
+        output_refs: Vec::new(),
+        proof_requirements: vec!["skill candidate receipt".into()],
+        proof_receipts: Vec::new(),
+        judgment_memory: judgment(),
+        created_at_ms: NOW,
+        updated_at_ms: NOW,
+    })
+    .unwrap();
+}
+
+fn link_request(approval: CanonicalApproval, now_ms: i64) -> LinkSkillCandidateReceiptRequest {
+    LinkSkillCandidateReceiptRequest {
+        skill_id: "invoice-link-skill".into(),
+        safe_title: "Invoice Link Skill".into(),
+        source_digest: "link-source-digest-alpha".into(),
+        evidence_url: "https://example.com/skill-guide".into(),
+        mission_id: "mission-skill-ed".into(),
+        work_item_id: "work-skill-ed".into(),
+        operator_principal_id: "operator".into(),
+        canonical_approval: approval,
+        proof_ref: "proof://link-skill-candidate/invoice".into(),
+        now_ms,
+    }
+}
+
+fn gate_request() -> MutatingActionRequest {
+    link_skill_candidate_gate_request(
+        "invoice-link-skill",
+        "link-source-digest-alpha",
+        "mission-skill-ed",
+        "work-skill-ed",
+        "operator",
+    )
+}
+
+fn consumed_count(db: &Db) -> i64 {
+    db.conn()
+        .query_row("SELECT count(*) FROM consumed_approval", [], |r| r.get(0))
+        .unwrap()
+}
+
+#[test]
+fn ed25519_link_candidate_receipt_records_without_import_or_execution() {
+    let db = Db::open_hub(&temp_db("allow")).unwrap();
+    seed_mission(&db);
+    let (sk, vk) = operator();
+    let approval = ed_approval(&gate_request(), &sk, "skill-link-ed-allow");
+
+    let receipt =
+        stage_link_skill_candidate_receipt_ed25519(&db, link_request(approval, NOW + 1), &vk)
+            .unwrap();
+
+    assert_eq!(receipt.status, "candidate_receipt_recorded_not_imported");
+    assert_eq!(receipt.skill_id, "invoice-link-skill");
+    let links = db.list_mission_links("mission-skill-ed").unwrap();
+    assert_eq!(links.len(), 1);
+    assert_eq!(links[0].target_ref, receipt.candidate_ref);
+    assert_eq!(
+        links[0].proof_ref.as_deref(),
+        Some("proof://link-skill-candidate/invoice")
+    );
+    let item = db.get_work_item("work-skill-ed").unwrap().unwrap();
+    assert_eq!(item.status, WorkItemStatus::ReadyToDispatch);
+    assert!(item.proof_receipts.is_empty());
+    assert_eq!(consumed_count(&db), 1);
+}
+
+#[test]
+fn hmac_link_candidate_approval_is_rejected_by_ed25519_path() {
+    let db = Db::open_hub(&temp_db("hmac")).unwrap();
+    seed_mission(&db);
+    let (_sk, vk) = operator();
+    let approval = hmac_approval(&gate_request(), "skill-link-hmac");
+
+    let blocked =
+        stage_link_skill_candidate_receipt_ed25519(&db, link_request(approval, NOW + 1), &vk)
+            .unwrap_err();
+
+    assert!(blocked
+        .to_string()
+        .contains("link_skill_candidate_canonical_gate_canonical_approval_signature_invalid"));
+    assert!(db
+        .list_mission_links("mission-skill-ed")
+        .unwrap()
+        .is_empty());
+    assert_eq!(consumed_count(&db), 0);
+}
+
+#[test]
+fn ed25519_link_candidate_approval_replay_is_refused_without_second_write() {
+    let db = Db::open_hub(&temp_db("replay")).unwrap();
+    seed_mission(&db);
+    let (sk, vk) = operator();
+    let approval = ed_approval(&gate_request(), &sk, "skill-link-replay");
+
+    stage_link_skill_candidate_receipt_ed25519(&db, link_request(approval.clone(), NOW + 1), &vk)
+        .unwrap();
+    let blocked =
+        stage_link_skill_candidate_receipt_ed25519(&db, link_request(approval, NOW + 2), &vk)
+            .unwrap_err();
+
+    assert!(blocked
+        .to_string()
+        .contains("link_skill_candidate_canonical_gate_canonical_approval_replay_refused"));
+    assert_eq!(db.list_mission_links("mission-skill-ed").unwrap().len(), 1);
+    assert_eq!(consumed_count(&db), 1);
+}


### PR DESCRIPTION
## Summary
- add Ed25519 verify-only skill run and SKILL.md candidate receipt entrypoints beside the existing HMAC test/backcompat path
- factor shared mission/work-item and receipt validation so HMAC and Ed25519 paths enforce the same pre-write guards
- add D21 skill-catalog Ed25519 tests covering allow, HMAC downgrade rejection, and replay refusal without a second write

## Truth labels
- mechanism-verified: D21 governed receipt path can be authorized by TEST Ed25519 operator key and verified by Hub public key
- not live-done: this does not import or execute a skill, does not flip a live flag, and does not consume the real operator key
- operator-only remains: D20/B4 true signing remains outside Hub; tests use an isolated TEST keypair only

## Tests
- cargo fmt --all --check
- cargo test -p friday-hub --test skill_catalog_ed25519
- cargo test -p friday-hub skill_catalog
- cargo clippy -p friday-hub --tests -- -D warnings