### PR TITLE
Add governed skill catalog receipt CLI

### DIFF
--- a/rust-core/crates/friday-hub/src/bin/hub_skill_catalog_receipt.rs
+++ b/rust-core/crates/friday-hub/src/bin/hub_skill_catalog_receipt.rs
@@ -1,0 +1,183 @@
+//! D21 governed skill-catalog receipt CLI.
+//!
+//! This is an operator-facing, verify-only bridge for staging a SKILL.md candidate
+//! receipt. It never imports or executes a skill, and it never mints an approval:
+//! the Hub loads only the operator-controlled public verify key and verifies the
+//! supplied Ed25519 approval against the exact canonical action digest.
+
+use std::env;
+use std::io::Read;
+use std::path::Path;
+
+use friday_core::gate::{ApprovalDecision, CanonicalApproval, CANONICAL_GATE_ISSUER};
+use friday_hub::operator_vk::load_operator_vk_from_path;
+use friday_hub::skill_catalog::{
+    stage_link_skill_candidate_receipt_ed25519, LinkSkillCandidateReceiptRequest, SkillCatalogError,
+};
+use friday_storage::Db;
+use serde::Deserialize;
+use serde_json::json;
+
+struct CliError {
+    kind: &'static str,
+}
+
+impl CliError {
+    fn new(kind: &'static str) -> Self {
+        Self { kind }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct SignedApprovalIn {
+    decision: String,
+    approval_id: String,
+    action_digest: String,
+    expires_at: i64,
+    #[serde(default)]
+    issuer: Option<String>,
+    signature: String,
+}
+
+fn main() {
+    match run() {
+        Ok(rendered) => println!("{rendered}"),
+        Err(err) => {
+            let payload = json!({
+                "truth_label": "d21_skill_catalog_receipt",
+                "ok": false,
+                "imports_skill": false,
+                "executes_skill": false,
+                "error_kind": err.kind,
+            });
+            let rendered = payload.to_string();
+            if reject_forbidden_output(&rendered).is_ok() {
+                println!("{rendered}");
+            }
+            eprintln!("hub_skill_catalog_receipt_unavailable: {}", err.kind);
+            std::process::exit(2);
+        }
+    }
+}
+
+fn run() -> Result<String, CliError> {
+    let args: Vec<String> = env::args().collect();
+    let command = args.get(1).map(String::as_str).unwrap_or_default();
+    if command != "stage-link-candidate" {
+        return Err(CliError::new("bad_args"));
+    }
+
+    let db_path = arg_value(&args, "--db").ok_or(CliError::new("bad_args"))?;
+    let vk_path = arg_value(&args, "--operator-vk-path")
+        .or_else(|| env::var(friday_hub::operator_vk::OPERATOR_VK_PATH_ENV).ok())
+        .filter(|p| !p.trim().is_empty())
+        .ok_or(CliError::new("operator_vk_unprovisioned"))?;
+    let operator_vk = load_operator_vk_from_path(Path::new(vk_path.trim()))
+        .map_err(|_| CliError::new("operator_vk_malformed"))?;
+
+    let approval = read_approval(&args)?;
+    let now_ms = arg_value(&args, "--now-ms")
+        .and_then(|v| v.parse::<i64>().ok())
+        .unwrap_or_else(now_ms);
+
+    let db = Db::open_hub(&db_path).map_err(|_| CliError::new("init_failed"))?;
+    let request = LinkSkillCandidateReceiptRequest {
+        skill_id: arg_value(&args, "--skill-id").ok_or(CliError::new("bad_args"))?,
+        safe_title: arg_value(&args, "--safe-title").ok_or(CliError::new("bad_args"))?,
+        source_digest: arg_value(&args, "--source-digest").ok_or(CliError::new("bad_args"))?,
+        evidence_url: arg_value(&args, "--evidence-url").ok_or(CliError::new("bad_args"))?,
+        mission_id: arg_value(&args, "--mission-id").ok_or(CliError::new("bad_args"))?,
+        work_item_id: arg_value(&args, "--work-item-id").ok_or(CliError::new("bad_args"))?,
+        operator_principal_id: arg_value(&args, "--operator-principal-id")
+            .unwrap_or_else(|| "operator".to_string()),
+        canonical_approval: approval,
+        proof_ref: arg_value(&args, "--proof-ref").ok_or(CliError::new("bad_args"))?,
+        now_ms,
+    };
+
+    let receipt = stage_link_skill_candidate_receipt_ed25519(&db, request, &operator_vk)
+        .map_err(|err| CliError::new(skill_error_kind(&err)))?;
+    let payload = json!({
+        "truth_label": "d21_skill_catalog_receipt",
+        "ok": true,
+        "imports_skill": false,
+        "executes_skill": false,
+        "skill_id": receipt.skill_id,
+        "candidate_ref": receipt.candidate_ref,
+        "proof_ref": receipt.proof_ref,
+        "mission_id": receipt.mission_id,
+        "work_item_id": receipt.work_item_id,
+        "status": receipt.status,
+    });
+    let rendered =
+        serde_json::to_string(&payload).map_err(|_| CliError::new("serialize_failed"))?;
+    reject_forbidden_output(&rendered)?;
+    Ok(rendered)
+}
+
+fn read_approval(args: &[String]) -> Result<CanonicalApproval, CliError> {
+    let approval_json = match arg_value(args, "--approval-json") {
+        Some(path) => std::fs::read_to_string(path).map_err(|_| CliError::new("bad_args"))?,
+        None => {
+            let mut buf = String::new();
+            std::io::stdin()
+                .read_to_string(&mut buf)
+                .map_err(|_| CliError::new("bad_args"))?;
+            buf
+        }
+    };
+    let signed: SignedApprovalIn =
+        serde_json::from_str(approval_json.trim()).map_err(|_| CliError::new("bad_approval"))?;
+    Ok(CanonicalApproval {
+        decision: parse_decision(&signed.decision).ok_or(CliError::new("bad_approval"))?,
+        approval_id: signed.approval_id,
+        action_digest: signed.action_digest,
+        expires_at: Some(signed.expires_at),
+        issuer: Some(
+            signed
+                .issuer
+                .unwrap_or_else(|| CANONICAL_GATE_ISSUER.to_string()),
+        ),
+        signature: Some(signed.signature),
+    })
+}
+
+fn arg_value(args: &[String], name: &str) -> Option<String> {
+    args.windows(2)
+        .find_map(|pair| (pair[0] == name).then(|| pair[1].clone()))
+        .or_else(|| {
+            let prefix = format!("{name}=");
+            args.iter()
+                .find_map(|arg| arg.strip_prefix(&prefix).map(str::to_string))
+        })
+}
+
+fn parse_decision(value: &str) -> Option<ApprovalDecision> {
+    match value {
+        "approved" => Some(ApprovalDecision::Approved),
+        "denied" => Some(ApprovalDecision::Denied),
+        _ => None,
+    }
+}
+
+fn now_ms() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as i64)
+        .unwrap_or(0)
+}
+
+fn skill_error_kind(err: &SkillCatalogError) -> &'static str {
+    match err {
+        SkillCatalogError::RunBlocked(_) => "run_blocked",
+        SkillCatalogError::Storage(_) => "storage_failed",
+        SkillCatalogError::RootRead(_) => "root_read_failed",
+        SkillCatalogError::ManifestRead(_) => "manifest_read_failed",
+        SkillCatalogError::ManifestParse(_) => "manifest_parse_failed",
+    }
+}
+
+fn reject_forbidden_output(rendered: &str) -> Result<(), CliError> {
+    friday_hub::refs_guard::reject_forbidden_output(rendered, &["answer\":\""])
+        .map_err(|_| CliError::new("output_guard"))
+}

--- a/rust-core/crates/friday-hub/tests/skill_catalog_receipt_cli.rs
+++ b/rust-core/crates/friday-hub/tests/skill_catalog_receipt_cli.rs
@@ -1,0 +1,301 @@
+//! D21 skill catalog receipt CLI tests.
+//!
+//! The CLI verifies an operator Ed25519 approval with only the public key, records
+//! a LinkedOnly candidate receipt, and never imports or executes the skill.
+
+use std::process::Command;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use friday_core::gate::{
+    canonical_action_bytes, canonical_approval_signature_bytes, ApprovalDecision,
+    CanonicalApproval, MutatingActionRequest, CANONICAL_GATE_ISSUER,
+};
+use friday_core::{
+    ApprovalState, FridayConversation, HandoffJudgmentMemory, Mission, MissionStatus, Risk,
+    TruthStatus, WorkItem, WorkItemStatus, WorkLane,
+};
+use friday_crypto::{OperatorSigningKey, OperatorVerifyingKey};
+use friday_hub::skill_catalog::link_skill_candidate_gate_request;
+use friday_storage::Db;
+use serde_json::Value;
+
+const HUB_HMAC_SECRET: &[u8] = b"hub-held-hmac-gate-secret-0123456789";
+const NOW: i64 = 1_000;
+const FUTURE: i64 = 5_000_000_000_000;
+
+static C: AtomicU64 = AtomicU64::new(0);
+
+fn unique(tag: &str) -> String {
+    format!(
+        "{}-{}-{}",
+        std::process::id(),
+        tag,
+        C.fetch_add(1, Ordering::Relaxed)
+    )
+}
+
+fn temp_path(tag: &str) -> std::path::PathBuf {
+    std::env::temp_dir().join(format!("friday-skill-receipt-cli-{}", unique(tag)))
+}
+
+fn temp_db(tag: &str) -> String {
+    temp_path(&format!("{tag}.sqlite"))
+        .to_string_lossy()
+        .into_owned()
+}
+
+fn vk_hex(vk: &OperatorVerifyingKey) -> String {
+    vk.to_bytes()
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect()
+}
+
+fn operator() -> (OperatorSigningKey, OperatorVerifyingKey) {
+    let sk = OperatorSigningKey::generate();
+    let vk = sk.verifying_key();
+    (sk, vk)
+}
+
+fn ed_approval(
+    req: &MutatingActionRequest,
+    sk: &OperatorSigningKey,
+    approval_id: &str,
+) -> CanonicalApproval {
+    let digest = friday_crypto::action_digest(&canonical_action_bytes(req));
+    let mut approval = CanonicalApproval {
+        decision: ApprovalDecision::Approved,
+        approval_id: approval_id.to_string(),
+        action_digest: digest,
+        expires_at: Some(FUTURE),
+        issuer: Some(CANONICAL_GATE_ISSUER.to_string()),
+        signature: None,
+    };
+    approval.signature = Some(
+        sk.sign(&canonical_approval_signature_bytes(&approval))
+            .to_hex(),
+    );
+    approval
+}
+
+fn hmac_approval(req: &MutatingActionRequest, approval_id: &str) -> CanonicalApproval {
+    let digest = friday_crypto::action_digest(&canonical_action_bytes(req));
+    let mut approval = CanonicalApproval {
+        decision: ApprovalDecision::Approved,
+        approval_id: approval_id.to_string(),
+        action_digest: digest,
+        expires_at: Some(FUTURE),
+        issuer: Some(CANONICAL_GATE_ISSUER.to_string()),
+        signature: None,
+    };
+    approval.signature = Some(friday_crypto::sign_approval(
+        &canonical_approval_signature_bytes(&approval),
+        HUB_HMAC_SECRET,
+    ));
+    approval
+}
+
+fn write_approval(path: &std::path::Path, approval: &CanonicalApproval) {
+    let decision = match approval.decision {
+        ApprovalDecision::Approved => "approved",
+        ApprovalDecision::Denied => "denied",
+    };
+    let body = serde_json::json!({
+        "decision": decision,
+        "approval_id": approval.approval_id,
+        "action_digest": approval.action_digest,
+        "expires_at": approval.expires_at.unwrap(),
+        "issuer": approval.issuer,
+        "signature": approval.signature,
+    });
+    std::fs::write(path, body.to_string()).unwrap();
+}
+
+fn judgment() -> HandoffJudgmentMemory {
+    HandoffJudgmentMemory {
+        task: "Stage a governed skill candidate receipt".into(),
+        current_blocker: None,
+        target_lane_thread_agent_provider: WorkLane::FridayHub.as_str().into(),
+        read_first_files: vec![
+            "rust-core/crates/friday-hub/src/bin/hub_skill_catalog_receipt.rs".into(),
+        ],
+        required_output: "LinkedOnly candidate receipt".into(),
+        done_criteria: vec!["receipt recorded without import or execution".into()],
+        red_lines: vec!["Hub must not self-mint operator approval".into()],
+        why_this_route: "D21 CLI must verify an operator approval.".into(),
+        considered_options: vec!["raw import".into()],
+        deferred_options: vec!["runtime skill execution".into()],
+        previous_pitfalls: vec!["candidate link mistaken for runnable skill".into()],
+        inheritable_context: vec!["verify-only governance".into()],
+        proof_requirements: vec!["CLI receipt test".into()],
+        ownership_claim_ids: Vec::new(),
+    }
+}
+
+fn seed_mission(db: &Db) {
+    db.upsert_friday_conversation(&FridayConversation {
+        friday_conversation_id: "fconv_skill_cli".into(),
+        owner_principal: "operator".into(),
+        title: "Skill Candidate CLI".into(),
+        current_focus_summary: "Stage candidate receipt".into(),
+        active_mission_ids: vec!["mission-skill-cli".into()],
+        surface_thread_ids: Vec::new(),
+        memory_scope_ref: None,
+        truth_status: TruthStatus::Proven,
+        proof_refs: Vec::new(),
+        created_at_ms: NOW,
+        updated_at_ms: NOW,
+    })
+    .unwrap();
+    db.upsert_mission(&Mission {
+        mission_id: "mission-skill-cli".into(),
+        friday_conversation_id: "fconv_skill_cli".into(),
+        title: "Skill Candidate CLI".into(),
+        intent: "Stage a skill candidate without importing or executing it".into(),
+        status: MissionStatus::Active,
+        why_now: "D21 needs an operator-facing verify-only receipt entry.".into(),
+        decision_path_summary: "Verify Ed25519 approval before linking.".into(),
+        considered_options: vec!["HMAC self-mint".into()],
+        deferred_options: vec!["runtime import".into()],
+        known_pitfalls: vec!["receipt confused with execution".into()],
+        handoff_inheritance: vec!["Hub verifies, operator signs".into()],
+        work_item_ids: vec!["work-skill-cli".into()],
+        memory_candidate_refs: Vec::new(),
+        context_passport_refs: Vec::new(),
+        proof_refs: Vec::new(),
+        created_at_ms: NOW,
+        updated_at_ms: NOW,
+    })
+    .unwrap();
+    db.upsert_work_item(&WorkItem {
+        work_item_id: "work-skill-cli".into(),
+        mission_id: "mission-skill-cli".into(),
+        lane: WorkLane::FridayHub,
+        target_provider_or_agent: Some("skill:candidate".into()),
+        status: WorkItemStatus::ReadyToDispatch,
+        owner_claim_ids: Vec::new(),
+        workspace_refs: Vec::new(),
+        capability_id: Some("skill.candidate".into()),
+        risk_level: Risk::Low,
+        approval_state: ApprovalState::Approved,
+        blocking_reason: None,
+        input_refs: vec!["friday://body/skill-candidate".into()],
+        output_refs: Vec::new(),
+        proof_requirements: vec!["skill candidate receipt".into()],
+        proof_receipts: Vec::new(),
+        judgment_memory: judgment(),
+        created_at_ms: NOW,
+        updated_at_ms: NOW,
+    })
+    .unwrap();
+}
+
+fn gate_request() -> MutatingActionRequest {
+    link_skill_candidate_gate_request(
+        "invoice-link-skill",
+        "link-source-digest-alpha",
+        "mission-skill-cli",
+        "work-skill-cli",
+        "operator",
+    )
+}
+
+fn cli_base(db_path: &str, vk_path: &std::path::Path, approval_path: &std::path::Path) -> Command {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_hub_skill_catalog_receipt"));
+    cmd.arg("stage-link-candidate")
+        .arg("--db")
+        .arg(db_path)
+        .arg("--operator-vk-path")
+        .arg(vk_path)
+        .arg("--approval-json")
+        .arg(approval_path)
+        .arg("--skill-id")
+        .arg("invoice-link-skill")
+        .arg("--safe-title")
+        .arg("Invoice Link Skill")
+        .arg("--source-digest")
+        .arg("link-source-digest-alpha")
+        .arg("--evidence-url")
+        .arg("https://example.com/skill-guide")
+        .arg("--mission-id")
+        .arg("mission-skill-cli")
+        .arg("--work-item-id")
+        .arg("work-skill-cli")
+        .arg("--operator-principal-id")
+        .arg("operator")
+        .arg("--proof-ref")
+        .arg("proof://link-skill-candidate/invoice")
+        .arg("--now-ms")
+        .arg((NOW + 1).to_string());
+    cmd
+}
+
+#[test]
+fn cli_records_ed25519_candidate_receipt_without_import_or_execution() {
+    let db_path = temp_db("allow");
+    let db = Db::open_hub(&db_path).unwrap();
+    seed_mission(&db);
+    let (sk, vk) = operator();
+    let vk_path = temp_path("operator.vk");
+    std::fs::write(&vk_path, vk_hex(&vk)).unwrap();
+    let approval_path = temp_path("approval.json");
+    write_approval(
+        &approval_path,
+        &ed_approval(&gate_request(), &sk, "skill-cli-ed-allow"),
+    );
+
+    let output = cli_base(&db_path, &vk_path, &approval_path)
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let json: Value = serde_json::from_str(stdout.trim()).unwrap();
+    assert_eq!(json["ok"], true);
+    assert_eq!(json["imports_skill"], false);
+    assert_eq!(json["executes_skill"], false);
+    assert_eq!(json["status"], "candidate_receipt_recorded_not_imported");
+    assert!(json["candidate_ref"]
+        .as_str()
+        .unwrap()
+        .starts_with("friday://link-skill-candidate/"));
+
+    let links = db.list_mission_links("mission-skill-cli").unwrap();
+    assert_eq!(links.len(), 1);
+    let item = db.get_work_item("work-skill-cli").unwrap().unwrap();
+    assert_eq!(item.status, WorkItemStatus::ReadyToDispatch);
+    assert!(item.proof_receipts.is_empty());
+}
+
+#[test]
+fn cli_rejects_hmac_approval_without_writing_candidate_receipt() {
+    let db_path = temp_db("hmac");
+    let db = Db::open_hub(&db_path).unwrap();
+    seed_mission(&db);
+    let (_sk, vk) = operator();
+    let vk_path = temp_path("operator-hmac.vk");
+    std::fs::write(&vk_path, vk_hex(&vk)).unwrap();
+    let approval_path = temp_path("approval-hmac.json");
+    write_approval(
+        &approval_path,
+        &hmac_approval(&gate_request(), "skill-cli-hmac"),
+    );
+
+    let output = cli_base(&db_path, &vk_path, &approval_path)
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let json: Value = serde_json::from_str(stdout.trim()).unwrap();
+    assert_eq!(json["ok"], false);
+    assert_eq!(json["imports_skill"], false);
+    assert_eq!(json["executes_skill"], false);
+    assert_eq!(json["error_kind"], "run_blocked");
+    assert!(db
+        .list_mission_links("mission-skill-cli")
+        .unwrap()
+        .is_empty());
+}


### PR DESCRIPTION
## Summary
- add `hub_skill_catalog_receipt stage-link-candidate`, a refs-only CLI for staging a SKILL.md candidate receipt through the Ed25519 verify-only path
- load only the operator-controlled public verify key; the CLI never mints or reads an operator signing key
- add integration tests for Ed25519 success and HMAC downgrade rejection with no candidate write

## Truth labels
- mechanism-verified: CLI can drive a governed candidate receipt using a TEST Ed25519 keypair
- not live-done: this does not import or execute a skill and does not flip a live service path
- operator-only remains: true D20/B4 signing remains outside Hub; tests use an isolated TEST keypair only

## Tests
- `cargo fmt --all --check`
- `cargo test -p friday-hub --test skill_catalog_receipt_cli`
- `cargo test -p friday-hub --test skill_catalog_ed25519`
- `cargo test -p friday-hub skill_catalog`
- `cargo clippy -p friday-hub --tests --bins -- -D warnings`
