### PR TITLE
Give write clients provider-timeout margin

### DIFF
--- a/apps/friday-ios/Sources/FridayMobileShellCore/RealWriteClientFactory.swift
+++ b/apps/friday-ios/Sources/FridayMobileShellCore/RealWriteClientFactory.swift
@@ -46,7 +46,7 @@ public struct AgentRunServerConfig: Sendable, Equatable {
     host: String = "127.0.0.1",
     port: UInt16,
     connectTimeout: TimeInterval = 4,
-    receiveTimeout: TimeInterval = 300
+    receiveTimeout: TimeInterval = 360
   ) {
     self.host = host
     self.port = port

--- a/apps/friday-ios/Tests/FridayMobileShellCoreTests/LiveWriteTransportIntegrationTests.swift
+++ b/apps/friday-ios/Tests/FridayMobileShellCoreTests/LiveWriteTransportIntegrationTests.swift
@@ -42,6 +42,13 @@ import Testing
 private let liveWriteTestEnabled =
   ProcessInfo.processInfo.environment["FRIDAY_MOBILE_LIVE_WRITE_TEST"] == "1"
 
+@Test
+func liveWriteConfigReceiveTimeoutOutlivesCodexWatchdog() {
+  // The client receive window must exceed the Rust Codex app-server watchdog (300s) so a
+  // provider timeout can settle as an honest AgentRunResult instead of racing the socket timeout.
+  #expect(AgentRunServerConfig.liveLoopback.receiveTimeout > 300)
+}
+
 /// Drive the sealed-WS handshake (preamble + WS upgrade + ECDH) over the live write transport as the
 /// enrolled master-derived peer, asserting peer-auth completes. NON-MUTATING: no envelope is sent.
 @Test(.enabled(if: liveWriteTestEnabled))

--- a/apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/RealWriteClientFactory.swift
+++ b/apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/RealWriteClientFactory.swift
@@ -43,7 +43,7 @@ public struct AgentRunWriteServerConfig: Sendable, Equatable {
     host: String = "127.0.0.1",
     port: UInt16,
     connectTimeout: TimeInterval = 4,
-    receiveTimeout: TimeInterval = 300
+    receiveTimeout: TimeInterval = 360
   ) {
     self.host = host
     self.port = port

--- a/apps/macos/FridayHubConsole/Tests/FridayHubConsoleCoreTests/OperationsOverviewViewModelTests.swift
+++ b/apps/macos/FridayHubConsole/Tests/FridayHubConsoleCoreTests/OperationsOverviewViewModelTests.swift
@@ -573,6 +573,9 @@ func realWriteClientFactoryBuildsLiveAgainst48750OrHonestUnavailable() {
   // Wiring-only; the live round-trip against a RUNNING server is the operator-gated AC.
   #expect(AgentRunWriteServerConfig.liveLoopback.port == 48750)
   #expect(AgentRunWriteServerConfig.liveLoopback.host == "127.0.0.1")
+  // The client receive window must exceed the Rust Codex app-server watchdog (300s) so a
+  // provider timeout can settle as an honest AgentRunResult instead of racing the socket timeout.
+  #expect(AgentRunWriteServerConfig.liveLoopback.receiveTimeout > 300)
   let client = RealWriteClientFactory.make(
     config: .liveLoopback, forwardedPrincipal: "admin-001")
   #expect(client is SealedWSWriteClient)


### PR DESCRIPTION
## Summary
- increase desktop and mobile live write-client receive windows from 300s to 360s
- pin tests that the live write-client receive timeout outlives the Rust Codex app-server watchdog

## Verification
- swift test --package-path apps/macos/FridayHubConsole --filter realWriteClientFactoryBuildsLiveAgainst48750OrHonestUnavailable
- swift test --package-path apps/friday-ios --filter liveWriteConfigReceiveTimeoutOutlivesCodexWatchdog
- Manual live regression: FRIDAY_CONSOLE_LIVE_WRITE_DISPATCH_TEST=1 FRIDAY_CONSOLE_LIVE_MISSION_BOUND_RUN_TEST=1 swift test --package-path apps/macos/FridayHubConsole --filter liveConsoleMissionSpineWriteDispatchCanStartMissionBoundRun
  - still FAILS honestly because the Codex mission-bound provider returned refs-only status no_answer_safe_failure after 300.175s, not completed/finished/ok
  - important improvement: no longer fails as client-side "no result (session ended fail-closed): receive timed out after 300.0s"

## Truth labels
- This fixes a desktop/mobile client timeout race against the provider watchdog.
- It does not make the Codex mission-bound route successful, does not satisfy OG9, and does not make Phase 1 flawless.
