### PR TITLE
Clarify vague Codex repair before dispatch

### DIFF
--- a/apps/macos/FridayHubConsole/Tests/FridayHubConsoleCoreTests/LiveMissionSpineWriteDispatchIntegrationTests.swift
+++ b/apps/macos/FridayHubConsole/Tests/FridayHubConsoleCoreTests/LiveMissionSpineWriteDispatchIntegrationTests.swift
@@ -39,12 +39,12 @@ func liveConsoleMissionSpineWriteDispatchReturnsReadyReceipt() async throws {
 }
 
 @Test(.enabled(if: liveMissionBoundRunEnabled))
-func liveConsoleMissionSpineWriteDispatchCanStartMissionBoundRun() async throws {
+func liveConsoleMissionSpineWriteDispatchClarifiesVagueCodexRepairBeforeModelCall() async throws {
   let client = try RealWriteClientFactory.makeLiveWrite()
   let request = makeLiveIntake(
     surface: "desktop",
     route: "desktop://hub-console/live-bound-run",
-    title: "Verify live desktop auto-route mission-bound Codex run",
+    title: "Verify live desktop vague Codex repair clarifies before dispatch",
     intent: "Fix a small Rust compile failure in a workspace and describe the focused regression test that should be added.",
     lane: "auto",
     targetProviderOrAgent: nil)
@@ -68,7 +68,11 @@ func liveConsoleMissionSpineWriteDispatchCanStartMissionBoundRun() async throws 
   print(
     "[live-write-dispatch][desktop-bound] runId=\(receipt.runId) "
       + "status=\(receipt.status) turns=\(receipt.turns ?? 0)")
-  #expect(receipt.status == "completed" || receipt.status == "finished" || receipt.status == "ok")
+  #expect(receipt.status == "awaiting_clarification")
+  #expect(receipt.turns == 0)
+  #expect(receipt.executedTools == 0)
+  #expect(receipt.answerSha256 != nil)
+  #expect((receipt.answerLen ?? 0) > 0)
 }
 
 private func makeLiveIntake(

--- a/rust-core/crates/friday-core/src/planning.rs
+++ b/rust-core/crates/friday-core/src/planning.rs
@@ -111,6 +111,12 @@ pub fn classify_kind(task: &str) -> Option<PlanningKind> {
         return Some(PlanningKind::MajorDecision);
     }
 
+    // Direct code-repair actions must not be hidden by trailing read-only words like
+    // "describe the regression test"; classify them before the broad Q&A bypass.
+    if matches_vague_code_repair(&lower) {
+        return Some(PlanningKind::MajorDecision);
+    }
+
     // 2. Ordinary Q&A / summarization bypasses the gate.
     if matches_qa_bypass(&lower) {
         return None;
@@ -130,8 +136,8 @@ pub fn classify_kind(task: &str) -> Option<PlanningKind> {
         return Some(PlanningKind::GenerateWorkflow);
     }
 
-    // 4. Vague-deliverable / vague-improvement / vague-strategic-plan asks are
-    //    text-only and escalate to MajorDecision (the gate clarifies before
+    // 4. Vague-deliverable / vague-improvement / vague-strategic-plan / code-repair asks
+    //    are text-only and escalate to MajorDecision (the gate clarifies before
     //    building), in the oracle's order — BEFORE the major-decision hints.
     if matches_vague_deliverable(&lower)
         || matches_vague_improvement(&lower)
@@ -439,6 +445,51 @@ fn matches_vague_deliverable(lower: &str) -> bool {
         "product",
     ];
     CJK_HINTS.iter().any(|h| lower.contains(h)) || co_occurs_within(lower, VERBS, NOUNS, 80)
+}
+
+/// Under-specified code-repair requests ("fix a Rust compile failure", "debug the failing test")
+/// are action requests, not ordinary Q&A. Escalating them to MajorDecision lets the live
+/// clarification gate ask for the concrete repo/file/error before Codex spends a long turn
+/// guessing at an absent workspace.
+fn matches_vague_code_repair(lower: &str) -> bool {
+    const QA_PREFIXES: &[&str] = &[
+        "explain ",
+        "please explain ",
+        "describe ",
+        "please describe ",
+        "how do i ",
+        "how can i ",
+        "what steps ",
+        "guide me ",
+        "walk me through ",
+    ];
+    if QA_PREFIXES.iter().any(|prefix| lower.starts_with(prefix)) {
+        return false;
+    }
+
+    const VERBS: &[&str] = &[
+        "fix",
+        "debug",
+        "repair",
+        "resolve",
+        "troubleshoot",
+        "diagnose",
+        "investigate",
+    ];
+    const FAILURES: &[&str] = &[
+        "compile failure",
+        "compile error",
+        "build failure",
+        "build error",
+        "test failure",
+        "failing test",
+        "failing tests",
+        "ci failure",
+        "compiler error",
+        "rust error",
+        "bug",
+    ];
+    co_occurs_within(lower, VERBS, FAILURES, 100)
 }
 
 /// `VAGUE_IMPROVEMENT_HINTS`: "make Friday/this app/the repo … better/
@@ -811,6 +862,23 @@ mod tests {
         assert_eq!(
             classify_kind("make Friday more production-ready and stable"),
             Some(PlanningKind::MajorDecision)
+        );
+    }
+
+    #[test]
+    fn classifies_vague_code_repair_as_major_decision() {
+        assert_eq!(
+            classify_kind("Fix a small Rust compile failure in a workspace and describe the focused regression test that should be added."),
+            Some(PlanningKind::MajorDecision)
+        );
+        assert_eq!(
+            classify_kind("debug the failing tests in the repo"),
+            Some(PlanningKind::MajorDecision)
+        );
+        assert_eq!(
+            classify_kind("explain how to fix a Rust compile error"),
+            None,
+            "Q&A phrasing stays a read-only explanation, not an action request"
         );
     }
 

--- a/rust-core/crates/friday-hub/src/runtime.rs
+++ b/rust-core/crates/friday-hub/src/runtime.rs
@@ -1033,14 +1033,40 @@ impl<T: Transport> HubRuntime<T> {
     ) -> Result<LoopOutcome, RoutedLoopError> {
         // Plan classification + the SAME recall-preamble prompt the loop records/builds, so a
         // codex run's event log + prompt are consistent with a deepseek/claude run.
-        let plan_kind = friday_core::classify_kind(task).map(|k| k.as_str());
+        let plan_kind = friday_core::classify_kind(task);
         agent_run::record_event(
             self.db.conn(),
             &format!("{run_id}:plan"),
             run_id,
-            &format!("plan.{}", plan_kind.unwrap_or("none")),
+            &format!("plan.{}", plan_kind.map(|k| k.as_str()).unwrap_or("none")),
             now_ms,
         )?;
+        if crate::clarification_gate_from(
+            std::env::var(crate::FRIDAY_CLARIFICATION_GATE)
+                .ok()
+                .as_deref(),
+        ) {
+            if let Some(kind) = plan_kind {
+                if !friday_core::is_task_detailed_enough(task, kind) {
+                    let questions = friday_core::questions_for_kind(kind);
+                    let message = friday_core::build_clarification(kind, &questions);
+                    agent_run::record_event(
+                        self.db.conn(),
+                        &format!("{run_id}:awaiting_clarification"),
+                        run_id,
+                        &format!("agent.awaiting_clarification:{}", kind.as_str()),
+                        now_ms,
+                    )?;
+                    return Ok(LoopOutcome {
+                        status: LoopStatus::AwaitingClarification,
+                        turns: 0,
+                        executed_tools: 0,
+                        final_message: Some(message),
+                        detail: format!("awaiting_clarification:{}", kind.as_str()),
+                    });
+                }
+            }
+        }
         let prompt = if recall_preamble.is_empty() {
             task.to_string()
         } else {
@@ -8550,6 +8576,83 @@ mod tests {
         assert!(work_item
             .proof_receipts
             .contains(&format!("friday://agent-run/{run_id}")));
+        assert!(friday_storage::audit::verify_audit_chain(rt.db().conn()).is_ok());
+    }
+
+    #[test]
+    fn mission_bound_codex_vague_code_repair_clarifies_before_model_call() {
+        std::env::set_var(crate::FRIDAY_CLARIFICATION_GATE, "1");
+        let run_id = "run-mloop-codex-vague-code-clar";
+        let (rt, _ws, observe_probe) = runtime_with_codex_wired_observe_probe(
+            "mloop-codex-vague-code-clar",
+            vec![StubCodexGatedExecutor::finished("SHOULD_NOT_RUN")],
+        );
+        let claim = codex_provider_session_claim();
+        let claim_id = claim.claim_id.clone();
+        let workspace_ref = claim.workspace_ref.clone();
+        seed_loop_mission_with_ownership(
+            rt.db(),
+            WorkLane::Codex,
+            Some("codex"),
+            WorkItemStatus::ReadyToDispatch,
+            vec![claim_id],
+            vec![workspace_ref],
+        );
+        rt.db().upsert_workspace_claim(&claim).unwrap();
+
+        let outcome = rt
+            .run_codex_agent_loop_for_mission_with_overrides(
+                loop_lookup(),
+                "friday-hub-session",
+                run_id,
+                "Fix a small Rust compile failure in a workspace and describe the focused regression test that should be added.",
+                None,
+                None,
+                1_000,
+            )
+            .unwrap();
+
+        let MissionBoundLoopOutcome::Ran {
+            outcome,
+            attachment,
+            ..
+        } = outcome
+        else {
+            panic!("expected the mission-bound Codex loop to reach the clarification gate");
+        };
+        assert_eq!(outcome.status, LoopStatus::AwaitingClarification);
+        assert_eq!(
+            outcome.turns, 0,
+            "clarification happens before any Codex model call"
+        );
+        assert_eq!(outcome.executed_tools, 0);
+        assert!(
+            outcome
+                .final_message
+                .as_deref()
+                .unwrap_or_default()
+                .contains("Question 1/2"),
+            "clarification should be delivered as numbered questions"
+        );
+        assert!(
+            observe_probe.borrow().is_none(),
+            "the Codex executor must not be called when the clarification gate stops first"
+        );
+        assert!(matches!(
+            attachment,
+            MissionAttachmentOutcome::Attached {
+                work_item_status: WorkItemStatus::ProviderRouted,
+                ..
+            }
+        ));
+
+        let result = friday_storage::get_run_result(rt.db().conn(), run_id)
+            .unwrap()
+            .expect("clarifying Codex mission-bound run persists owner-visible questions");
+        assert_eq!(result.status, "awaiting_clarification");
+        let work_item = rt.db().get_work_item("work-loop").unwrap().unwrap();
+        assert_eq!(work_item.status, WorkItemStatus::ProviderRouted);
+        assert!(work_item.proof_receipts.is_empty());
         assert!(friday_storage::audit::verify_audit_chain(rt.db().conn()).is_ok());
     }
 


### PR DESCRIPTION
## Summary
- classify under-specified direct code-repair requests as planning decisions before the broad Q&A bypass
- stop mission-bound Codex runs at the live clarification gate before a model call when the request lacks concrete repo/file/error details
- update the desktop env-gated live proof to expect an awaiting-clarification receipt for the prior no-answer-safe-failure prompt

## Verification
- cargo test -p friday-core planning::tests::classifies_vague_code_repair_as_major_decision -- --nocapture
- cargo test -p friday-hub runtime::tests::mission_bound_codex_vague_code_repair_clarifies_before_model_call -- --nocapture
- cargo clippy -p friday-core -p friday-hub --all-targets -- -D warnings
- swift test --package-path apps/macos/FridayHubConsole --filter liveConsoleMissionSpineWriteDispatchClarifiesVagueCodexRepairBeforeModelCall
- git diff --check

Truth labels: this is a mechanism/product-surface fix for the desktop Codex no-answer-safe-failure shape. The updated Swift live test is env-gated and was compiled locally; live execution requires deploying this Rust runtime change first.