### PR TITLE
Add desktop clear Codex live proof

### DIFF
--- a/apps/macos/FridayHubConsole/Tests/FridayHubConsoleCoreTests/LiveMissionSpineWriteDispatchIntegrationTests.swift
+++ b/apps/macos/FridayHubConsole/Tests/FridayHubConsoleCoreTests/LiveMissionSpineWriteDispatchIntegrationTests.swift
@@ -62,6 +62,45 @@ func liveConsoleMissionSpineWriteDispatchClarifiesVagueCodexRepairAtIntake() asy
   #expect(!result.clarificationQuestions.isEmpty)
 }
 
+@Test(.enabled(if: liveMissionBoundRunEnabled))
+func liveConsoleMissionSpineWriteDispatchCanCompleteClearCodexRun() async throws {
+  let client = try RealWriteClientFactory.makeLiveWrite()
+  let request = makeLiveIntake(
+    surface: "desktop",
+    route: "desktop://hub-console/live-clear-codex-bound-run",
+    title: "Verify live desktop clear Codex mission-bound run",
+    intent: "Answer exactly FRIDAY_DESKTOP_CODEX_CLEAR_OK.",
+    lane: "codex",
+    targetProviderOrAgent: "codex")
+
+  let result = try await client.submitMissionIntake(request)
+  #expect(result.status == "ready")
+  #expect(result.createdOrReady)
+  #expect(result.workItemId == request.workItemId)
+
+  let outcome = try await client.dispatchMissionBoundAgentRun(
+    task: request.intent,
+    missionContext: MissionWorkItemContextWire(
+      fridayConversationId: result.fridayConversationId,
+      missionId: result.missionId,
+      workItemId: try #require(result.workItemId)),
+    constraints: AgentRunConstraintsWire(readOnly: true))
+
+  guard case .result(let receipt) = outcome else {
+    Issue.record("expected clear Codex mission-bound read-only run to settle with a result")
+    return
+  }
+  print(
+    "[live-write-dispatch][desktop-clear-codex] runId=\(receipt.runId) "
+      + "status=\(receipt.status) turns=\(receipt.turns ?? 0) "
+      + "answerLen=\(receipt.answerLen ?? 0)")
+  #expect(receipt.status == "completed" || receipt.status == "finished" || receipt.status == "ok")
+  #expect((receipt.turns ?? 0) > 0)
+  #expect(receipt.executedTools == 0)
+  #expect(receipt.answerSha256 != nil)
+  #expect((receipt.answerLen ?? 0) > 0)
+}
+
 private func makeLiveIntake(
   surface: String,
   route: String,


### PR DESCRIPTION
## Summary
- add an env-gated desktop live integration proof for a clear Codex mission-bound run
- drive the real Console write client through mission intake, mission-bound dispatch, and refs-only completion
- assert the Codex run returns a terminal result with answer fingerprint, nonzero answer length, and zero tools

## Verification
- FRIDAY_CONSOLE_LIVE_WRITE_DISPATCH_TEST=1 FRIDAY_CONSOLE_LIVE_MISSION_BOUND_RUN_TEST=1 swift test --package-path apps/macos/FridayHubConsole --filter liveConsoleMissionSpineWriteDispatchCanCompleteClearCodexRun
- git diff --check

Live evidence from the verification run:
- run: run-E5F8B040-8C0E-45ED-B536-3ADB16D2E1D2
- receipt: status=finished, turns=1, answerLen=29
- DB: run_result finished answer_len=29 owner=admin-001
- ledger: codex|gpt-5.5|total_tokens=29064|fallback=0
- WorkItem: completed_with_proof lane/target codex/codex with friday://agent-run receipt

Truth label: desktop product-surface clear Codex completion proof. This is agent-driven env-gated live proof, not OG9 physical-hand organic and not D20/B4 true signing.