### PR TITLE
Materialize deferred route follow-up work items

### DIFF
--- a/rust-core/crates/friday-storage/src/lib.rs
+++ b/rust-core/crates/friday-storage/src/lib.rs
@@ -993,6 +993,18 @@ impl Db {
         )
     }
 
+    pub fn materialize_deferred_route_follow_up(
+        &self,
+        request: mission::DeferredRouteFollowUpRequest<'_>,
+    ) -> Result<WorkItem> {
+        if self.profile != Profile::Hub {
+            return Err(StorageError::Unsupported(
+                "Deferred route follow-up materialization is Hub-only".into(),
+            ));
+        }
+        mission::materialize_deferred_route_follow_up(&self.conn, request)
+    }
+
     pub fn list_work_items_for_mission(&self, mission_id: &str) -> Result<Vec<WorkItem>> {
         if self.profile != Profile::Hub {
             return Err(StorageError::Unsupported("WorkItems are Hub-only".into()));

--- a/rust-core/crates/friday-storage/src/mission.rs
+++ b/rust-core/crates/friday-storage/src/mission.rs
@@ -33,6 +33,13 @@ fn require_non_empty(value: &str, field: &str) -> Result<()> {
     }
 }
 
+fn ref_id_part(value: &str) -> String {
+    value
+        .chars()
+        .map(|ch| if ch.is_ascii_alphanumeric() { ch } else { '-' })
+        .collect()
+}
+
 #[derive(Debug)]
 struct ActiveRouteDecisionControl {
     decision_id: String,
@@ -40,6 +47,17 @@ struct ActiveRouteDecisionControl {
     override_lane: Option<WorkLane>,
     override_provider_or_agent: Option<String>,
     reason: String,
+}
+
+pub struct DeferredRouteFollowUpRequest<'a> {
+    pub decision_id: &'a str,
+    pub source_work_item_id: &'a str,
+    pub follow_up_work_item_id: &'a str,
+    pub follow_up_lane: WorkLane,
+    pub follow_up_provider_or_agent: Option<&'a str>,
+    pub actor_ref: &'a str,
+    pub reason: &'a str,
+    pub now_ms: i64,
 }
 
 fn encode_vec(values: &[String], field: &str) -> Result<String> {
@@ -1158,6 +1176,195 @@ pub fn override_route_decision(
         reason,
         now_ms,
     )
+}
+
+pub fn materialize_deferred_route_follow_up(
+    conn: &Connection,
+    request: DeferredRouteFollowUpRequest<'_>,
+) -> Result<WorkItem> {
+    require_non_empty(request.decision_id, "deferred_follow_up.decision_id")?;
+    require_non_empty(
+        request.source_work_item_id,
+        "deferred_follow_up.source_work_item_id",
+    )?;
+    require_non_empty(
+        request.follow_up_work_item_id,
+        "deferred_follow_up.follow_up_work_item_id",
+    )?;
+    require_non_empty(request.actor_ref, "deferred_follow_up.actor_ref")?;
+    require_non_empty(request.reason, "deferred_follow_up.reason")?;
+    if let Some(target) = request.follow_up_provider_or_agent {
+        require_non_empty(target, "deferred_follow_up.follow_up_provider_or_agent")?;
+    }
+    if request.source_work_item_id == request.follow_up_work_item_id {
+        return Err(unsupported(
+            "deferred_follow_up follow-up WorkItem must be distinct from source WorkItem",
+        ));
+    }
+
+    crate::with_busy_retry(|| {
+        let tx = conn.unchecked_transaction()?;
+        let source = get_work_item(&tx, request.source_work_item_id)?.ok_or_else(|| {
+            unsupported(format!(
+                "deferred_follow_up source WorkItem '{}' not found",
+                request.source_work_item_id
+            ))
+        })?;
+        if source.status != WorkItemStatus::CompletedWithProof {
+            return Err(unsupported(format!(
+                "deferred_follow_up source WorkItem '{}' must be completed_with_proof",
+                request.source_work_item_id
+            )));
+        }
+        if get_work_item(&tx, request.follow_up_work_item_id)?.is_some() {
+            return Err(unsupported(format!(
+                "deferred_follow_up WorkItem '{}' already exists",
+                request.follow_up_work_item_id
+            )));
+        }
+
+        let route = get_route_decision(&tx, request.decision_id)?.ok_or_else(|| {
+            unsupported(format!(
+                "deferred_follow_up route_decision '{}' not found",
+                request.decision_id
+            ))
+        })?;
+        if route.work_item_id != source.work_item_id {
+            return Err(unsupported(format!(
+                "deferred_follow_up route_decision '{}' belongs to WorkItem '{}' not '{}'",
+                request.decision_id, route.work_item_id, source.work_item_id
+            )));
+        }
+        let Some(deferred_option) = route.deferred_options.first() else {
+            return Err(unsupported(format!(
+                "deferred_follow_up route_decision '{}' has no deferred options",
+                request.decision_id
+            )));
+        };
+
+        let mut mission = get_mission(&tx, &source.mission_id)?.ok_or_else(|| {
+            unsupported(format!(
+                "deferred_follow_up Mission '{}' not found",
+                source.mission_id
+            ))
+        })?;
+        let source_proof_refs = if source.proof_receipts.is_empty() {
+            vec![format!("friday://work-item/{}", source.work_item_id)]
+        } else {
+            source.proof_receipts.clone()
+        };
+        let target_label = request
+            .follow_up_provider_or_agent
+            .unwrap_or(request.follow_up_lane.as_str())
+            .to_string();
+
+        let mut inheritable_context = source.judgment_memory.inheritable_context.clone();
+        for value in [
+            format!("source_work_item:{}", source.work_item_id),
+            format!("source_route_decision:{}", route.decision_id),
+        ] {
+            if !inheritable_context.contains(&value) {
+                inheritable_context.push(value);
+            }
+        }
+        for proof_ref in &source_proof_refs {
+            let value = format!("source_proof:{proof_ref}");
+            if !inheritable_context.contains(&value) {
+                inheritable_context.push(value);
+            }
+        }
+
+        let mut considered_options = route.considered_options.clone();
+        if !considered_options.contains(deferred_option) {
+            considered_options.push(deferred_option.clone());
+        }
+        let follow_up = WorkItem {
+            work_item_id: request.follow_up_work_item_id.to_string(),
+            mission_id: source.mission_id.clone(),
+            lane: request.follow_up_lane,
+            target_provider_or_agent: request.follow_up_provider_or_agent.map(str::to_string),
+            status: WorkItemStatus::ReadyToDispatch,
+            owner_claim_ids: Vec::new(),
+            workspace_refs: Vec::new(),
+            capability_id: Some(format!("provider.{target_label}.turn")),
+            risk_level: source.risk_level,
+            approval_state: ApprovalState::NotRequired,
+            blocking_reason: None,
+            input_refs: source_proof_refs,
+            output_refs: Vec::new(),
+            proof_requirements: vec!["outcome:AnswerProduced:>=1".into()],
+            proof_receipts: Vec::new(),
+            judgment_memory: HandoffJudgmentMemory {
+                task: format!("Deferred follow-up for {}: {deferred_option}", source.work_item_id),
+                current_blocker: None,
+                target_lane_thread_agent_provider: target_label.clone(),
+                read_first_files: Vec::new(),
+                required_output: "synthesis follow-up answer with proof-backed completion".into(),
+                done_criteria: vec![
+                    "follow-up WorkItem reaches completed_with_proof with an answer receipt".into(),
+                ],
+                red_lines: vec![
+                    "do not claim dual-model completion until this follow-up completes with proof"
+                        .into(),
+                ],
+                why_this_route: format!(
+                    "Materialized deferred route option from {} after source proof: {deferred_option}",
+                    route.decision_id
+                ),
+                considered_options,
+                deferred_options: vec![
+                    "automatic follow-up execution is separate from materialization".into(),
+                ],
+                previous_pitfalls: route.previous_pitfalls.clone(),
+                inheritable_context,
+                proof_requirements: vec!["outcome:AnswerProduced:>=1".into()],
+                ownership_claim_ids: Vec::new(),
+            },
+            created_at_ms: request.now_ms,
+            updated_at_ms: request.now_ms,
+        };
+
+        upsert_work_item(&tx, &follow_up)?;
+        if !mission.work_item_ids.contains(&follow_up.work_item_id) {
+            mission.work_item_ids.push(follow_up.work_item_id.clone());
+        }
+        let marker = format!("deferred_follow_up:{}", follow_up.work_item_id);
+        if !mission.handoff_inheritance.contains(&marker) {
+            mission.handoff_inheritance.push(marker);
+        }
+        mission.updated_at_ms = request.now_ms;
+        upsert_mission(&tx, &mission)?;
+
+        let follow_route = RouteDecisionCard::from_work_item(
+            format!(
+                "route-deferred-{}-{}",
+                ref_id_part(&route.decision_id),
+                ref_id_part(&follow_up.work_item_id)
+            ),
+            &follow_up,
+            vec![route.route_decision_ref()],
+            request.now_ms,
+            None,
+        );
+        upsert_route_decision(&tx, &follow_route)?;
+        crate::audit::append_audit(
+            &tx,
+            &format!(
+                "route_decision_deferred_follow_up:{}:{}",
+                ref_id_part(&route.decision_id),
+                request.now_ms
+            ),
+            request.actor_ref,
+            &format!(
+                "route_decision.deferred_follow_up_materialized:{}:{}->{}:{}",
+                route.decision_id, source.work_item_id, follow_up.work_item_id, request.reason
+            ),
+            Some(&follow_up.work_item_id),
+            request.now_ms,
+        )?;
+        tx.commit()?;
+        Ok(follow_up)
+    })
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/rust-core/crates/friday-storage/tests/work_item_lifecycle.rs
+++ b/rust-core/crates/friday-storage/tests/work_item_lifecycle.rs
@@ -14,7 +14,7 @@ use friday_core::{
     ApprovalState, FridayConversation, HandoffJudgmentMemory, Mission, MissionStatus, Risk,
     RouteDecisionCard, TruthStatus, WorkItem, WorkItemStatus, WorkLane,
 };
-use friday_storage::{Db, StorageError};
+use friday_storage::{mission::DeferredRouteFollowUpRequest, Db, StorageError};
 use std::sync::{Mutex, MutexGuard};
 
 static ENV_LOCK: Mutex<()> = Mutex::new(());
@@ -141,6 +141,26 @@ fn seed_route_decision(db: &Db) {
         "route-decision-work-wi".into(),
         &item,
         vec!["friday://trace/route-decision-work-wi".into()],
+        2,
+        None,
+    );
+    db.upsert_route_decision(&card).unwrap();
+}
+
+fn seed_hybrid_route_decision(db: &Db) {
+    let mut item = db.get_work_item("work-wi").unwrap().unwrap();
+    item.judgment_memory.why_this_route =
+        "Codex first for workspace execution; Claude synthesis follow-up deferred".into();
+    item.judgment_memory.considered_options = vec![
+        "combination: Codex first, Claude synthesis after proof".into(),
+        "claude: writing only".into(),
+    ];
+    item.judgment_memory.deferred_options = vec!["Claude synthesis follow-up".into()];
+    db.upsert_work_item(&item).unwrap();
+    let card = RouteDecisionCard::from_work_item(
+        "route-decision-work-wi".into(),
+        &item,
+        vec!["friday://trace/hybrid-route".into()],
         2,
         None,
     );
@@ -419,6 +439,159 @@ fn route_decision_override_reassigns_before_dispatch_in_same_lifecycle_hop() {
     assert_eq!(
         override_audits, 1,
         "override must be applied as a real audited pre-dispatch lifecycle control"
+    );
+}
+
+#[test]
+fn completed_hybrid_source_materializes_deferred_claude_follow_up_work_item() {
+    let db = Db::open_hub(&temp_db_path("wi-deferred-followup")).unwrap();
+    seed(&db, WorkItemStatus::ProviderWaiting);
+    let (source, _) = db
+        .transition_work_item_status(
+            "work-wi",
+            WorkItemStatus::CompletedWithProof,
+            "agent:codex",
+            "codex first leg completed",
+            Some("friday://agent-run/run-codex-first"),
+            10,
+        )
+        .unwrap();
+    assert_eq!(source.status, WorkItemStatus::CompletedWithProof);
+    seed_hybrid_route_decision(&db);
+
+    let follow = db
+        .materialize_deferred_route_follow_up(DeferredRouteFollowUpRequest {
+            decision_id: "route-decision-work-wi",
+            source_work_item_id: "work-wi",
+            follow_up_work_item_id: "work-wi-claude-followup",
+            follow_up_lane: WorkLane::Claude,
+            follow_up_provider_or_agent: Some("claude"),
+            actor_ref: "agent:friday",
+            reason: "create tracked Claude synthesis leg after Codex proof",
+            now_ms: 20,
+        })
+        .unwrap();
+
+    assert_eq!(follow.status, WorkItemStatus::ReadyToDispatch);
+    assert_eq!(follow.lane, WorkLane::Claude);
+    assert_eq!(follow.target_provider_or_agent.as_deref(), Some("claude"));
+    assert_eq!(
+        follow.input_refs,
+        vec!["friday://agent-run/run-codex-first".to_string()],
+        "the Claude follow-up inherits the proven Codex first-leg receipt as input"
+    );
+    assert!(follow
+        .judgment_memory
+        .why_this_route
+        .contains("Materialized deferred route option"));
+    assert!(follow
+        .judgment_memory
+        .deferred_options
+        .iter()
+        .any(|option| option.contains("automatic follow-up execution is separate")));
+
+    let mission = db.get_mission("mission-wi").unwrap().unwrap();
+    assert!(mission
+        .work_item_ids
+        .contains(&"work-wi-claude-followup".to_string()));
+    assert!(mission
+        .handoff_inheritance
+        .contains(&"deferred_follow_up:work-wi-claude-followup".to_string()));
+
+    let route = db
+        .list_route_decisions_for_mission("mission-wi")
+        .unwrap()
+        .into_iter()
+        .find(|route| route.work_item_id == "work-wi-claude-followup")
+        .expect("follow-up route decision");
+    assert_eq!(route.selected_lane, WorkLane::Claude);
+    assert_eq!(route.selected_provider_or_agent.as_deref(), Some("claude"));
+    assert!(route
+        .trace_refs
+        .contains(&"friday://route-decision/route-decision-work-wi".to_string()));
+
+    let audits: i64 = db
+        .conn()
+        .query_row(
+            "SELECT COUNT(*) FROM audit_ledger WHERE action LIKE 'route_decision.deferred_follow_up_materialized:%'",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(audits, 1);
+}
+
+#[test]
+fn deferred_follow_up_requires_proven_source_and_unused_follow_up_id() {
+    let db = Db::open_hub(&temp_db_path("wi-deferred-followup-gates")).unwrap();
+    seed(&db, WorkItemStatus::ReadyToDispatch);
+    seed_route_decision(&db);
+
+    let unproven = db
+        .materialize_deferred_route_follow_up(DeferredRouteFollowUpRequest {
+            decision_id: "route-decision-work-wi",
+            source_work_item_id: "work-wi",
+            follow_up_work_item_id: "work-wi-claude-followup",
+            follow_up_lane: WorkLane::Claude,
+            follow_up_provider_or_agent: Some("claude"),
+            actor_ref: "agent:friday",
+            reason: "should fail",
+            now_ms: 20,
+        })
+        .unwrap_err();
+    assert!(
+        matches!(unproven, StorageError::Unsupported(ref message) if message.contains("must be completed_with_proof")),
+        "unproven source must fail closed, got {unproven:?}"
+    );
+
+    for (now, next) in [
+        (21, WorkItemStatus::Dispatched),
+        (22, WorkItemStatus::HubAccepted),
+        (23, WorkItemStatus::ProviderRouted),
+        (24, WorkItemStatus::ProviderWaiting),
+    ] {
+        db.transition_work_item_status("work-wi", next, "agent:friday", "advance", None, now)
+            .unwrap();
+    }
+    db.transition_work_item_status(
+        "work-wi",
+        WorkItemStatus::CompletedWithProof,
+        "agent:friday",
+        "advance",
+        Some("friday://agent-run/run-codex-first"),
+        25,
+    )
+    .unwrap();
+
+    let follow = db
+        .materialize_deferred_route_follow_up(DeferredRouteFollowUpRequest {
+            decision_id: "route-decision-work-wi",
+            source_work_item_id: "work-wi",
+            follow_up_work_item_id: "work-wi-claude-followup",
+            follow_up_lane: WorkLane::Claude,
+            follow_up_provider_or_agent: Some("claude"),
+            actor_ref: "agent:friday",
+            reason: "create tracked Claude synthesis leg after Codex proof",
+            now_ms: 26,
+        })
+        .unwrap();
+    assert_eq!(follow.status, WorkItemStatus::ReadyToDispatch);
+
+    let duplicate_follow_up = db
+        .materialize_deferred_route_follow_up(DeferredRouteFollowUpRequest {
+            decision_id: "route-decision-work-wi",
+            source_work_item_id: "work-wi",
+            follow_up_work_item_id: "work-wi-claude-followup",
+            follow_up_lane: WorkLane::Claude,
+            follow_up_provider_or_agent: Some("claude"),
+            actor_ref: "agent:friday",
+            reason: "should fail",
+            now_ms: 27,
+        })
+        .unwrap_err();
+    assert!(
+        matches!(duplicate_follow_up, StorageError::Unsupported(ref message) if message.contains("already exists")),
+        "duplicate follow-up id must fail closed, got {duplicate_follow_up:?}"
     );
 }
 


### PR DESCRIPTION
## Summary
- add a Hub-only storage primitive to materialize a deferred route option into a tracked follow-up WorkItem
- require the source WorkItem to be completed_with_proof and the source route_decision to match before creating the follow-up
- append the follow-up to the Mission, create its own RouteDecisionCard, and audit the materialization in one storage transaction

## Validation
- cargo fmt --all -- --check
- cargo test -p friday-storage --test work_item_lifecycle -- --nocapture
- cargo test -p friday-storage
- cargo clippy -p friday-storage --all-targets -- -D warnings
- git diff --check

## Truth boundary
This makes the deferred Claude/synthesis leg a real tracked WorkItem object. It does not automatically execute Claude, does not spend provider quota, does not satisfy D20/B4 true signing, and does not make Phase 1 flawless or the overall goal done.