### PR TITLE
Add hybrid follow-up live proof

### DIFF
--- a/apps/macos/FridayHubConsole/Tests/FridayHubConsoleCoreTests/LiveMissionSpineWriteDispatchIntegrationTests.swift
+++ b/apps/macos/FridayHubConsole/Tests/FridayHubConsoleCoreTests/LiveMissionSpineWriteDispatchIntegrationTests.swift
@@ -22,6 +22,8 @@ private let liveStrengthRouteEnabled =
   ProcessInfo.processInfo.environment["FRIDAY_CONSOLE_LIVE_STRENGTH_ROUTE_TEST"] == "1"
 private let liveStrengthRouteRunEnabled =
   ProcessInfo.processInfo.environment["FRIDAY_CONSOLE_LIVE_STRENGTH_ROUTE_RUN_TEST"] == "1"
+private let liveHybridFollowUpRunEnabled =
+  ProcessInfo.processInfo.environment["FRIDAY_CONSOLE_LIVE_HYBRID_FOLLOWUP_RUN_TEST"] == "1"
 
 @Test(.enabled(if: liveMissionSpineWriteDispatchEnabled))
 func liveConsoleMissionSpineWriteDispatchReturnsReadyReceipt() async throws {
@@ -187,6 +189,92 @@ func liveConsoleMissionSpineWriteDispatchCanCompleteHybridCodexFirstRun() async 
   #expect(receipt.executedTools == 0)
   #expect(receipt.answerSha256 != nil)
   #expect((receipt.answerLen ?? 0) > 0)
+}
+
+@Test(.enabled(if: liveHybridFollowUpRunEnabled))
+func liveConsoleMissionSpineWriteDispatchCanCompleteHybridCodexThenClaudeFollowUp() async throws {
+  let client = try RealWriteClientFactory.makeLiveWrite(config: hybridFollowUpWriteConfig())
+  let request = makeLiveIntake(
+    surface: "desktop",
+    route: "desktop://hub-console/live-strength-route-hybrid-followup",
+    title: "Verify live desktop hybrid route Codex then Claude follow-up",
+    intent: "In the FridayHubConsole test target, identify the live hybrid route test file path, "
+      + "then summarize that Claude synthesis follow-up should run after the Codex first leg. "
+      + "Answer exactly FRIDAY_HYBRID_CODEX_FIRST_FOR_CLAUDE_OK.",
+    lane: "auto",
+    targetProviderOrAgent: nil)
+
+  let result = try await client.submitMissionIntake(request)
+  #expect(result.status == "ready")
+  #expect(result.createdOrReady)
+  #expect(result.workItemId == request.workItemId)
+
+  let sourceWorkItemId = try #require(result.workItemId)
+  let firstSnapshot = try await pollLiveProjection(
+    client: RealReadClientFactory.makeLive(missionId: result.missionId),
+    missionId: result.missionId,
+    workItemId: sourceWorkItemId)
+  #expect(firstSnapshot.routeDecisionSummary?.contains("Codex first") == true)
+  #expect(firstSnapshot.rawRouteDecisionAlternatives.contains { $0.contains("combination: Codex first") })
+
+  let firstOutcome = try await client.dispatchMissionBoundAgentRun(
+    task: request.intent,
+    missionContext: MissionWorkItemContextWire(
+      fridayConversationId: result.fridayConversationId,
+      missionId: result.missionId,
+      workItemId: sourceWorkItemId),
+    constraints: AgentRunConstraintsWire(readOnly: true))
+
+  guard case .result(let firstReceipt) = firstOutcome else {
+    Issue.record("expected hybrid Codex-first mission-bound run to settle with a result")
+    return
+  }
+  #expect(firstReceipt.status == "completed" || firstReceipt.status == "finished" || firstReceipt.status == "ok")
+  #expect((firstReceipt.turns ?? 0) > 0)
+  #expect(firstReceipt.answerSha256 != nil)
+  #expect((firstReceipt.answerLen ?? 0) > 0)
+
+  let followUpWorkItemId = "\(sourceWorkItemId)-claude-followup"
+  _ = try await pollLiveProjection(
+    client: RealReadClientFactory.makeLive(missionId: result.missionId),
+    missionId: result.missionId,
+    workItemId: followUpWorkItemId)
+
+  let followUpOutcome = try await client.dispatchMissionBoundAgentRun(
+    task: "Read the completed Codex first-leg evidence already linked to this mission, summarize "
+      + "the follow-up in one sentence, and answer exactly FRIDAY_HYBRID_CLAUDE_FOLLOWUP_OK.",
+    missionContext: MissionWorkItemContextWire(
+      fridayConversationId: result.fridayConversationId,
+      missionId: result.missionId,
+      workItemId: followUpWorkItemId),
+    constraints: AgentRunConstraintsWire(readOnly: true))
+
+  guard case .result(let followUpReceipt) = followUpOutcome else {
+    Issue.record("expected hybrid Claude follow-up mission-bound run to settle with a result")
+    return
+  }
+  print(
+    "[live-strength-route][desktop-hybrid-followup] missionId=\(result.missionId) "
+      + "sourceWorkItemId=\(sourceWorkItemId) followUpWorkItemId=\(followUpWorkItemId) "
+      + "firstRunId=\(firstReceipt.runId) followUpRunId=\(followUpReceipt.runId) "
+      + "followUpStatus=\(followUpReceipt.status) followUpTurns=\(followUpReceipt.turns ?? 0) "
+      + "followUpAnswerLen=\(followUpReceipt.answerLen ?? 0)")
+  #expect(
+    followUpReceipt.status == "completed" || followUpReceipt.status == "finished"
+      || followUpReceipt.status == "ok")
+  #expect((followUpReceipt.turns ?? 0) > 0)
+  #expect(followUpReceipt.answerSha256 != nil)
+  #expect((followUpReceipt.answerLen ?? 0) > 0)
+}
+
+private func hybridFollowUpWriteConfig() -> AgentRunWriteServerConfig {
+  guard
+    let rawPort = ProcessInfo.processInfo.environment["FRIDAY_CONSOLE_LIVE_HYBRID_FOLLOWUP_WRITE_PORT"],
+    let port = UInt16(rawPort)
+  else {
+    return .liveLoopback
+  }
+  return AgentRunWriteServerConfig(host: "127.0.0.1", port: port)
 }
 
 private func makeLiveIntake(


### PR DESCRIPTION
## Summary
- add a default-off Console live integration test for hybrid auto route -> Codex first run -> materialized Claude follow-up run
- allow this proof test to target an explicit temporary write-port via `FRIDAY_CONSOLE_LIVE_HYBRID_FOLLOWUP_WRITE_PORT`, while defaulting to the live 48750 seam

## Local validation
- `swift test --package-path apps/macos/FridayHubConsole --filter LiveMissionSpineWriteDispatchIntegrationTests`
- `swift test --package-path apps/macos/FridayHubConsole`
- `swift test --package-path apps/macos/FridayHubConsole --filter liveConsoleMissionSpineWriteDispatchCanCompleteHybridCodexThenClaudeFollowUp`
- `cargo build --release -p friday-hub --bin hub_agent_run_server`
- live-spend proof with current-head temporary WS on `127.0.0.1:49750`:
  - `FRIDAY_CONSOLE_LIVE_HYBRID_FOLLOWUP_RUN_TEST=1 FRIDAY_CONSOLE_LIVE_HYBRID_FOLLOWUP_WRITE_PORT=49750 swift test --package-path apps/macos/FridayHubConsole --filter liveConsoleMissionSpineWriteDispatchCanCompleteHybridCodexThenClaudeFollowUp`

## Live proof evidence
- mission `mission-desktop-live-write-0d56babab13d4334857fead5a5f311d5`
- source WorkItem `work-desktop-live-write-0d56babab13d4334857fead5a5f311d5` -> `completed_with_proof`, lane/target `codex/codex`
- follow-up WorkItem `work-desktop-live-write-0d56babab13d4334857fead5a5f311d5-claude-followup` -> `completed_with_proof`, lane/target `claude/claude`
- Codex run `run-34AB4928-D5FB-4FB3-A613-55114A7A1B61` -> `finished`, `answer_len=39`, non-fallback `codex|gpt-5.5|29295`
- Claude follow-up run `run-A841A384-904D-455A-938D-F51CF669BA14` -> `finished`, `answer_len=168`, non-fallback Anthropic ledger rows for `claude-opus-4-8`

## Truth label
- This is an agent-driven product-driver live-spend proof for the hybrid follow-up path.
- It is not strict physical-hand OG9, not D20/B4 operator true-sign, not automatic Stage1 flawless closure, and not goal-done.
