### PR TITLE
Auto dispatch product Claude follow-up

### DIFF
--- a/apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/OperationsOverviewViewModel.swift
+++ b/apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/OperationsOverviewViewModel.swift
@@ -188,6 +188,13 @@ public final class OperationsOverviewViewModel: ObservableObject {
               missionContext: context,
               constraints: AgentRunConstraintsWire(readOnly: true))
             summary += Self.dispatchSummary(for: outcome)
+            if let followUpSummary = try await dispatchClaudeFollowUpIfPresent(
+              sourceWorkItemId: workItemId,
+              intakeResult: result,
+              missionRunClient: missionRunClient)
+            {
+              summary += followUpSummary
+            }
             intakeState = .confirmed(summary: summary, clarificationQuestions: result.clarificationQuestions)
           } catch {
             intakeState = .error(
@@ -201,6 +208,30 @@ public final class OperationsOverviewViewModel: ObservableObject {
     } catch {
       intakeState = .error(reason: Self.writeReason(for: error))
     }
+  }
+
+  private func dispatchClaudeFollowUpIfPresent(
+    sourceWorkItemId: String,
+    intakeResult: MissionIntakeResultWire,
+    missionRunClient: FridayMissionBoundRunWriteClient
+  ) async throws -> String? {
+    let followUpWorkItemId = "\(sourceWorkItemId)-claude-followup"
+    let wire = try await client.fetchWorkbench()
+    let snapshot = try WorkbenchSnapshotAdapter.display(from: wire)
+    guard snapshot.missionId == intakeResult.missionId,
+      snapshot.workItems.contains(where: { $0.id == followUpWorkItemId })
+    else {
+      return nil
+    }
+
+    let outcome = try await missionRunClient.dispatchMissionBoundAgentRun(
+      task: Self.claudeFollowUpTask,
+      missionContext: MissionWorkItemContextWire(
+        fridayConversationId: intakeResult.fridayConversationId,
+        missionId: intakeResult.missionId,
+        workItemId: followUpWorkItemId),
+      constraints: AgentRunConstraintsWire(readOnly: true))
+    return " · follow_up_work_item_id=\(followUpWorkItemId)" + Self.dispatchSummary(for: outcome)
   }
 
   /// Submit ONE owner confirm/reject for a memory candidate over the sealed WRITE seam, keyed by the
@@ -286,7 +317,7 @@ public final class OperationsOverviewViewModel: ObservableObject {
       workItemId: "work-desktop-\(id)",
       title: title,
       intent: intent,
-      lane: "deepseek")
+      lane: "auto")
   }
 
   /// Map a write-client error to an honest unavailable reason (mirrors `reason(for:)`'s tone).
@@ -331,6 +362,11 @@ public final class OperationsOverviewViewModel: ObservableObject {
       return " · run_id=\(paused.runId) · paused_for_approval=\(paused.approvalId)"
     }
   }
+
+  private static let claudeFollowUpTask =
+    "Run the generated Claude follow-up for this Mission. Use the inherited Codex first-leg "
+      + "proof and input refs attached to this WorkItem, keep the run read-only, and summarize "
+      + "the follow-up outcome."
 
   private static func reason(for error: Error) -> String {
     // Mock / preview / adapter vocabulary (503 / offline / projection-unavailable).

--- a/apps/macos/FridayHubConsole/Tests/FridayHubConsoleCoreTests/LiveMissionSpineWriteDispatchIntegrationTests.swift
+++ b/apps/macos/FridayHubConsole/Tests/FridayHubConsoleCoreTests/LiveMissionSpineWriteDispatchIntegrationTests.swift
@@ -24,6 +24,8 @@ private let liveStrengthRouteRunEnabled =
   ProcessInfo.processInfo.environment["FRIDAY_CONSOLE_LIVE_STRENGTH_ROUTE_RUN_TEST"] == "1"
 private let liveHybridFollowUpRunEnabled =
   ProcessInfo.processInfo.environment["FRIDAY_CONSOLE_LIVE_HYBRID_FOLLOWUP_RUN_TEST"] == "1"
+private let liveProductAutoFollowUpRunEnabled =
+  ProcessInfo.processInfo.environment["FRIDAY_CONSOLE_LIVE_PRODUCT_AUTO_FOLLOWUP_RUN_TEST"] == "1"
 
 @Test(.enabled(if: liveMissionSpineWriteDispatchEnabled))
 func liveConsoleMissionSpineWriteDispatchReturnsReadyReceipt() async throws {
@@ -265,6 +267,35 @@ func liveConsoleMissionSpineWriteDispatchCanCompleteHybridCodexThenClaudeFollowU
   #expect((followUpReceipt.turns ?? 0) > 0)
   #expect(followUpReceipt.answerSha256 != nil)
   #expect((followUpReceipt.answerLen ?? 0) > 0)
+}
+
+@Test(.enabled(if: liveProductAutoFollowUpRunEnabled))
+@MainActor
+func liveOperationsOverviewSubmitIntakeAutoDispatchesHybridClaudeFollowUp() async throws {
+  let id = "liveauto\(UUID().uuidString.lowercased().replacingOccurrences(of: "-", with: ""))"
+  let readClient = try RealReadClientFactory.makeLive(missionId: "mission-desktop-\(id)")
+  let writeClient = try RealWriteClientFactory.makeLiveWrite(config: hybridFollowUpWriteConfig())
+  let vm = OperationsOverviewViewModel(
+    client: readClient,
+    writeClient: writeClient,
+    missionRunClient: writeClient,
+    writeOwnerPrincipal: liveReadProjectionOwnerPrincipal,
+    newId: { id })
+
+  await vm.submitIntake(
+    intent: "In the FridayHubConsole test target, identify the live hybrid route test file path, "
+      + "then summarize that the product Operations view should automatically run the generated "
+      + "Claude follow-up after the Codex first leg. Answer exactly FRIDAY_PRODUCT_AUTO_FOLLOWUP_OK.")
+
+  guard case let .confirmed(summary, _) = vm.intakeState else {
+    Issue.record("expected product auto follow-up to confirm, got \(String(describing: vm.intakeState))")
+    return
+  }
+
+  print("[live-product-auto-followup] id=\(id) summary=\(summary)")
+  #expect(summary.contains("mission-desktop-\(id)"))
+  #expect(summary.contains("work-desktop-\(id)"))
+  #expect(summary.contains("follow_up_work_item_id=work-desktop-\(id)-claude-followup"))
 }
 
 private func hybridFollowUpWriteConfig() -> AgentRunWriteServerConfig {

--- a/apps/macos/FridayHubConsole/Tests/FridayHubConsoleCoreTests/OperationsOverviewViewModelTests.swift
+++ b/apps/macos/FridayHubConsole/Tests/FridayHubConsoleCoreTests/OperationsOverviewViewModelTests.swift
@@ -297,6 +297,7 @@ final class MockMissionSpineWriteClient: FridayMissionSpineWriteClient, FridayMi
   private var _lastLearningDecision: RunOutcomeLearningDecisionRequestWire?
   private var _lastMissionContext: MissionWorkItemContextWire?
   private var _lastMissionRunConstraints: AgentRunConstraintsWire?
+  private var _missionContexts: [MissionWorkItemContextWire] = []
   var lastIntake: MissionIntakeRequestWire? { lock.withLock { _lastIntake } }
   var lastDecision: MemoryDecisionRequestWire? { lock.withLock { _lastDecision } }
   var lastLearningDecision: RunOutcomeLearningDecisionRequestWire? {
@@ -304,6 +305,7 @@ final class MockMissionSpineWriteClient: FridayMissionSpineWriteClient, FridayMi
   }
   var lastMissionContext: MissionWorkItemContextWire? { lock.withLock { _lastMissionContext } }
   var lastMissionRunConstraints: AgentRunConstraintsWire? { lock.withLock { _lastMissionRunConstraints } }
+  var missionContexts: [MissionWorkItemContextWire] { lock.withLock { _missionContexts } }
 
   init(behavior: Behavior) { self.behavior = behavior }
 
@@ -377,12 +379,56 @@ final class MockMissionSpineWriteClient: FridayMissionSpineWriteClient, FridayMi
     lock.withLock {
       _lastMissionContext = missionContext
       _lastMissionRunConstraints = constraints
+      _missionContexts.append(missionContext)
     }
     if case .throwsTransport = behavior {
       throw FridayWriteClientError.transport("connection refused (write server dark)")
     }
     return .result(AgentRunResultWire(runId: "run-bound-1", status: "completed", turns: 1))
   }
+}
+
+struct StaticWorkbenchReadClient: FridayRustReadClient {
+  let snapshot: FridayHubConsoleCore.WorkbenchSnapshot
+
+  func fetchWorkbench() async throws -> FridayRustClient.WorkbenchSnapshot {
+    let json = try JSONEncoder().encode(snapshot)
+    return try FridayRustClient.WorkbenchSnapshot(projectionJSON: json, generatedAtMs: 0)
+  }
+}
+
+func snapshotWithWorkItems(
+  missionId: String,
+  fridayConversationId: String,
+  workItemIds: [String]
+) -> FridayHubConsoleCore.WorkbenchSnapshot {
+  FridayHubConsoleCore.WorkbenchSnapshot(
+    missionId: missionId,
+    fridayConversationId: fridayConversationId,
+    runtimeFeedStatus: .liveRustHubProjection,
+    statusLabels: [],
+    duplicatePreflight: MissionWorkbenchDuplicatePreflight(
+      status: "none", duplicateMissionId: "", duplicateWorkItemId: ""),
+    routeDecision: MissionWorkbenchRouteDecision(
+      advisorSummary: "Codex first with Claude follow-up.",
+      selectedRoute: "proof://route-decision/test",
+      alternatives: ["combination: Codex first, Claude follow-up"],
+      truthLabel: .fridayOwned),
+    providerReceiptRefs: [],
+    channelReceiptRefs: [],
+    workItems: workItemIds.map {
+      MissionWorkbenchWorkItem(
+        id: $0,
+        title: $0,
+        state: .ready,
+        owner: .fridayOwned,
+        proofRef: nil,
+        done: false)
+    },
+    timelinePages: [],
+    memoryCandidates: [],
+    capabilityStates: [],
+    transcriptSections: [])
 }
 
 @Test
@@ -404,7 +450,7 @@ func submitIntakeReadyRendersConfirmedAndWiresOwnerAdmin001() async {
   // FIX-Q3b: the body owner the view model wired MUST be the configured owner (admin-001).
   #expect(write.lastIntake?.ownerPrincipal == "admin-001")
   #expect(write.lastIntake?.surfaceKind == "desktop")
-  #expect(write.lastIntake?.lane == "deepseek")
+  #expect(write.lastIntake?.lane == "auto")
 }
 
 @Test
@@ -417,7 +463,7 @@ func submitIntakeReadyDispatchesMissionBoundModelTurnWhenRunClientConfigured() a
   await vm.submitIntake(intent: "keep one Mission across every surface")
 
   guard case let .confirmed(summary, _) = vm.intakeState else {
-    Issue.record("expected .confirmed, got \(vm.intakeState)")
+    Issue.record("expected .confirmed, got \(String(describing: vm.intakeState))")
     return
   }
   #expect(summary.contains("run_id=run-bound-1"))
@@ -426,6 +472,32 @@ func submitIntakeReadyDispatchesMissionBoundModelTurnWhenRunClientConfigured() a
     missionId: "mission-desktop-fixed",
     workItemId: "work-desktop-fixed"))
   #expect(write.lastMissionRunConstraints?.readOnly == true)
+  #expect(write.missionContexts.map(\.workItemId) == ["work-desktop-fixed"])
+}
+
+@Test
+@MainActor
+func submitIntakeDispatchesClaudeFollowUpWhenProjectionExposesGeneratedWorkItem() async {
+  let write = MockMissionSpineWriteClient(behavior: .intakeReady)
+  let read = StaticWorkbenchReadClient(
+    snapshot: snapshotWithWorkItems(
+      missionId: "mission-desktop-fixed",
+      fridayConversationId: "fconv_desktop_fixed",
+      workItemIds: ["work-desktop-fixed", "work-desktop-fixed-claude-followup"]))
+  let vm = OperationsOverviewViewModel(
+    client: read, writeClient: write, missionRunClient: write,
+    writeOwnerPrincipal: "admin-001", newId: { "fixed" })
+
+  await vm.submitIntake(intent: "route through Codex first and Claude follow-up")
+
+  guard case let .confirmed(summary, _) = vm.intakeState else {
+    Issue.record("expected .confirmed, got \(vm.intakeState)")
+    return
+  }
+  #expect(summary.contains("follow_up_work_item_id=work-desktop-fixed-claude-followup"))
+  #expect(
+    write.missionContexts.map(\.workItemId)
+      == ["work-desktop-fixed", "work-desktop-fixed-claude-followup"])
 }
 
 @Test


### PR DESCRIPTION
## Summary
- Route the Operations product intake through the existing auto router instead of the fixed DeepSeek lane.
- After a mission-bound first leg completes, fetch the Workbench projection and automatically dispatch the generated `<source>-claude-followup` WorkItem when present.
- Add unit coverage plus a default-off live product proof for `OperationsOverviewViewModel` auto Codex -> Claude follow-up.

## Validation
- PASS: `swift test --package-path apps/macos/FridayHubConsole` (42 tests)
- PASS: `git diff --check`
- PASS: `cargo build --release -p friday-hub --bin hub_agent_run_server`
- PASS LIVE: `FRIDAY_CONSOLE_LIVE_PRODUCT_AUTO_FOLLOWUP_RUN_TEST=1 FRIDAY_CONSOLE_LIVE_HYBRID_FOLLOWUP_WRITE_PORT=49750 swift test --package-path apps/macos/FridayHubConsole --filter liveOperationsOverviewSubmitIntakeAutoDispatchesHybridClaudeFollowUp`

## Live Evidence
- Product mission: `mission-desktop-liveautof9a4e2e4ac5b409d88e75f1749dc296d`
- Source WorkItem: `work-desktop-liveautof9a4e2e4ac5b409d88e75f1749dc296d` -> `codex/codex completed_with_proof`, run `run-12827807-53B0-46A6-A916-AEFE05216E2C`, ledger `codex|gpt-5.5|43959|fallback=0`
- Follow-up WorkItem: `work-desktop-liveautof9a4e2e4ac5b409d88e75f1749dc296d-claude-followup` -> `claude/claude completed_with_proof`, run `run-9A1BB4A4-BCCB-4B83-ABAE-B3CC41835538`, ledger `anthropic|claude-opus-4-8|832|fallback=0`
- OG9 computer-control organic Codex proof also refreshed: `codex-organic-mission-24bbdeba-cdee-4d92-a4e0-0cd3f654403e`, run `c7234bfe-52bb-48e9-8f27-62e4fc897f61`, ledger `codex|gpt-5.5|29175|fallback=0`, PASS (STRONG)

## Truth Boundary
- Product-driver live-spend proof, not physical-hand GUI OG9.
- OG9 proof above is operator-authorized computer-control organic, not D20/B4 operator true-sign.
- Still not goal-achieved / not full Phase 1 flawless by itself.