### PR TITLE
Wire mobile chat product auto follow-up

### DIFF
--- a/apps/friday-ios/Sources/FridayMobileShell/FridayApp.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayApp.swift
@@ -40,6 +40,7 @@ final class FridaySession: ObservableObject {
 
   let readClient: FridayRustReadClient
   let writeClient: FridayRustWriteClient
+  let missionClient: FridayMobileMissionDispatchingWriteClient?
   /// The operator-signing RELAY. Mock today (NOT a real signature); the real desktop signer
   /// (PR #671) is the slice-6 / operator-key gate. The phone holds NO signing key (INV-1).
   let signer: OperatorSigner
@@ -68,9 +69,14 @@ final class FridaySession: ObservableObject {
     // the read seam's `RealReadClientFactory.makeLive`) is now BUILT and wired behind an OPT-IN
     // env/arg gate (`FRIDAY_MOBILE_LIVE_WRITE=1` / `--live-write`, mirroring `FRIDAY_MOBILE_LIVE_READ`).
     // This PR does NOT flip the shipped default (that, and the S6 control plane, are operator gates).
-    self.writeClient = preview
-      ? Self.honestUnavailableWriteClient()
-      : Self.defaultWriteClient(runControlEnabled: runControlEnabled)
+    if preview {
+      self.writeClient = Self.honestUnavailableWriteClient()
+      self.missionClient = nil
+    } else {
+      let liveWrite = Self.defaultLiveWriteClient(runControlEnabled: runControlEnabled)
+      self.writeClient = liveWrite ?? Self.honestUnavailableWriteClient(runControlEnabled: runControlEnabled)
+      self.missionClient = liveWrite
+    }
     self.signer = MockOperatorSigner()
   }
 
@@ -111,20 +117,25 @@ final class FridaySession: ObservableObject {
   /// is unavailable (e.g. a real phone — the J2 pairing problem), fall back to the throwing default
   /// (honest unavailable) — NEVER fabricate a ready chat surface the live seam did not produce.
   static func defaultWriteClient(runControlEnabled: Bool) -> FridayRustWriteClient {
+    defaultLiveWriteClient(runControlEnabled: runControlEnabled)
+      ?? honestUnavailableWriteClient(runControlEnabled: runControlEnabled)
+  }
+
+  static func defaultLiveWriteClient(
+    runControlEnabled: Bool
+  ) -> FridayMobileMissionDispatchingWriteClient? {
     let args = ProcessInfo.processInfo.arguments
     let env = ProcessInfo.processInfo.environment
     let useLive = args.contains("--live-write") || env["FRIDAY_MOBILE_LIVE_WRITE"] == "1"
     guard useLive else {
-      // SHIPPED DEFAULT — unchanged: the throwing `liveTransportNotWired` factory transport, no
-      // socket, no SecureStore touch.
-      return honestUnavailableWriteClient(runControlEnabled: runControlEnabled)
+      return nil
     }
     do {
       return try RealWriteClientFactory.makeLive(agentRunControlViaRust: runControlEnabled)
     } catch {
-      // Master key unavailable (the J2 pairing problem on a real device): surface the truth via the
-      // throwing default transport (honest-unavailable) — never fabricate a ready chat surface.
-      return honestUnavailableWriteClient(runControlEnabled: runControlEnabled)
+      // Master key unavailable (the J2 pairing problem on a real device): no mission-capable
+      // client. The caller falls back to the throwing honest-unavailable write client.
+      return nil
     }
   }
 

--- a/apps/friday-ios/Sources/FridayMobileShell/FridayChatScreen.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayChatScreen.swift
@@ -21,7 +21,10 @@ struct FridayChatScreen: View {
   init(session: FridaySession) {
     self.runControlEnabled = session.runControlEnabled
     _viewModel = StateObject(wrappedValue: FridayChatViewModel(
-      writeClient: session.writeClient, signer: session.signer))
+      writeClient: session.writeClient,
+      signer: session.signer,
+      missionClient: session.missionClient,
+      readClient: session.readClient))
   }
 
   @State private var draft = ""
@@ -146,6 +149,12 @@ struct FridayChatScreen: View {
         Text("answer is delivered refs-only — a fingerprint + counts (the body rides the owner-gated readback)")
           .font(.caption2).foregroundStyle(MobileTheme.textSecondary)
         if let sha = r.answerSha256 { RefPill(label: "answer_sha256", ref: short(sha)) }
+        if let missionId = r.missionId { RefPill(label: "mission_id", ref: missionId) }
+        if let workItemId = r.workItemId { RefPill(label: "work_item_id", ref: workItemId) }
+        if let followUpWorkItemId = r.followUpWorkItemId {
+          RefPill(label: "follow_up_work_item_id", ref: followUpWorkItemId)
+        }
+        if let followUpRunId = r.followUpRunId { RefPill(label: "follow_up_run_id", ref: followUpRunId) }
         if let len = r.answerLen { RefPill(label: "answer_len", ref: "\(len)") }
         if let turns = r.turns { RefPill(label: "turns", ref: "\(turns)") }
         if let tools = r.executedTools { RefPill(label: "executed_tools", ref: "\(tools)") }

--- a/apps/friday-ios/Sources/FridayMobileShellCore/FridayChatViewModel.swift
+++ b/apps/friday-ios/Sources/FridayMobileShellCore/FridayChatViewModel.swift
@@ -48,8 +48,18 @@ public struct ChatAnswerReceipt: Sendable, Equatable {
   public let executedTools: UInt64?
   public let promptTokens: UInt64?
   public let completionTokens: UInt64?
+  public let missionId: String?
+  public let workItemId: String?
+  public let followUpWorkItemId: String?
+  public let followUpRunId: String?
 
-  init(_ r: AgentRunResultWire) {
+  init(
+    _ r: AgentRunResultWire,
+    missionId: String? = nil,
+    workItemId: String? = nil,
+    followUpWorkItemId: String? = nil,
+    followUpRunId: String? = nil
+  ) {
     self.runId = r.runId
     self.status = r.status
     self.answerSha256 = r.answerSha256
@@ -58,6 +68,10 @@ public struct ChatAnswerReceipt: Sendable, Equatable {
     self.executedTools = r.executedTools
     self.promptTokens = r.promptTokens
     self.completionTokens = r.completionTokens
+    self.missionId = missionId
+    self.workItemId = workItemId
+    self.followUpWorkItemId = followUpWorkItemId
+    self.followUpRunId = followUpRunId
   }
 }
 
@@ -171,16 +185,28 @@ public final class FridayChatViewModel: ObservableObject {
   /// a FRESH transport — no shared mutable state to race. Resolved on the CONSUMER side (the #677
   /// package is never edited). The `signer` is already `Sendable` (the protocol requires it).
   nonisolated(unsafe) private let writeClient: FridayRustWriteClient
+  private let missionClient: (any FridayMobileMissionDispatchingWriteClient)?
+  private let readClient: FridayRustReadClient?
   private let signer: OperatorSigner
+  private let newId: () -> String
 
   /// - Parameters:
   ///   - writeClient: the real `SealedWSWriteClient` (or a mock in tests/preview). DEFAULT
   ///     read-only / no-grant dispatch; the run-control flag lives on the client.
   ///   - signer: the operator-signing RELAY seam (INV-1). Mock now (`MockOperatorSigner`); the
   ///     real desktop signer (PR #671) is the slice-6 / operator-key gate.
-  public init(writeClient: FridayRustWriteClient, signer: OperatorSigner) {
+  public init(
+    writeClient: FridayRustWriteClient,
+    signer: OperatorSigner,
+    missionClient: (any FridayMobileMissionDispatchingWriteClient)? = nil,
+    readClient: FridayRustReadClient? = nil,
+    newId: @escaping () -> String = { UUID().uuidString.lowercased().replacingOccurrences(of: "-", with: "") }
+  ) {
     self.writeClient = writeClient
     self.signer = signer
+    self.missionClient = missionClient
+    self.readClient = readClient
+    self.newId = newId
   }
 
   // MARK: 1. Compose → Send
@@ -196,6 +222,10 @@ public final class FridayChatViewModel: ObservableObject {
     let trimmed = task.trimmingCharacters(in: .whitespacesAndNewlines)
     guard !trimmed.isEmpty else { return }
     phase = .dispatching(task: trimmed)
+    if let missionClient {
+      await sendMission(trimmed, missionClient: missionClient)
+      return
+    }
     do {
       let outcome = try await writeClient.dispatchAgentRun(task: trimmed, constraints: constraints)
       switch outcome {
@@ -209,6 +239,75 @@ public final class FridayChatViewModel: ObservableObject {
     } catch {
       phase = .unavailable(reason: Self.dispatchReason(for: error))
     }
+  }
+
+  private func sendMission(
+    _ task: String,
+    missionClient: any FridayMobileMissionDispatchingWriteClient
+  ) async {
+    do {
+      let request = Self.buildMissionIntakeRequest(
+        intent: task,
+        owner: liveAgentRunOwnerPrincipal,
+        idFactory: newId)
+      let result = try await missionClient.submitMissionIntake(request)
+      guard result.status == "ready", let workItemId = result.workItemId else {
+        phase = .unavailable(reason: "Mission intake not ready — \(result.status)")
+        return
+      }
+
+      let firstOutcome = try await missionClient.dispatchMissionBoundAgentRun(
+        task: task,
+        missionContext: MissionWorkItemContextWire(
+          fridayConversationId: result.fridayConversationId,
+          missionId: result.missionId,
+          workItemId: workItemId),
+        constraints: AgentRunConstraintsWire(readOnly: true))
+      guard case .result(let firstReceipt) = firstOutcome else {
+        phase = .unavailable(reason: "Mission dispatch paused — approval required")
+        return
+      }
+
+      let followUp = try await dispatchClaudeFollowUpIfPresent(
+        sourceWorkItemId: workItemId,
+        intakeResult: result,
+        missionClient: missionClient)
+      phase = .answered(ChatAnswerReceipt(
+        firstReceipt,
+        missionId: result.missionId,
+        workItemId: workItemId,
+        followUpWorkItemId: followUp?.workItemId,
+        followUpRunId: followUp?.runId))
+    } catch {
+      phase = .unavailable(reason: Self.dispatchReason(for: error))
+    }
+  }
+
+  private func dispatchClaudeFollowUpIfPresent(
+    sourceWorkItemId: String,
+    intakeResult: MissionIntakeResultWire,
+    missionClient: any FridayMissionBoundRunWriteClient
+  ) async throws -> (workItemId: String, runId: String)? {
+    guard let readClient else { return nil }
+    let followUpWorkItemId = "\(sourceWorkItemId)-claude-followup"
+    let snapshot = try await readClient.fetchWorkbench()
+    guard snapshot.missionId == intakeResult.missionId,
+      snapshot.workItemIds.contains(followUpWorkItemId)
+    else {
+      return nil
+    }
+
+    let outcome = try await missionClient.dispatchMissionBoundAgentRun(
+      task: Self.claudeFollowUpTask,
+      missionContext: MissionWorkItemContextWire(
+        fridayConversationId: intakeResult.fridayConversationId,
+        missionId: intakeResult.missionId,
+        workItemId: followUpWorkItemId),
+      constraints: AgentRunConstraintsWire(readOnly: true))
+    guard case .result(let receipt) = outcome else {
+      return nil
+    }
+    return (followUpWorkItemId, receipt.runId)
   }
 
   // MARK: 3. Approve → Resume (the S6 relay — INV-1, INV-2)
@@ -307,4 +406,29 @@ public final class FridayChatViewModel: ObservableObject {
       return "Hub offline — \(why)"
     }
   }
+
+  static func buildMissionIntakeRequest(
+    intent: String,
+    owner: String,
+    idFactory: () -> String
+  ) -> MissionIntakeRequestWire {
+    let id = idFactory()
+    return MissionIntakeRequestWire(
+      fridayConversationId: "fconv_mobile_\(id)",
+      ownerPrincipal: owner,
+      surfaceThreadId: "surface-mobile-\(id)",
+      surfaceKind: "mobile",
+      deliveryRoute: "ios://friday-mobile/chat/\(id)",
+      visibilityPolicy: "compact",
+      missionId: "mission-mobile-\(id)",
+      workItemId: "work-mobile-\(id)",
+      title: String(intent.prefix(72)),
+      intent: intent,
+      lane: "auto")
+  }
+
+  private static let claudeFollowUpTask =
+    "Run the generated Claude follow-up for this Mission. Use the inherited Codex first-leg "
+      + "proof and input refs attached to this WorkItem, keep the run read-only, and summarize "
+      + "the follow-up outcome."
 }

--- a/apps/friday-ios/Tests/FridayMobileShellCoreTests/FridayChatViewModelTests.swift
+++ b/apps/friday-ios/Tests/FridayMobileShellCoreTests/FridayChatViewModelTests.swift
@@ -56,6 +56,72 @@ final class FridayChatViewModelTests: XCTestCase {
     }
   }
 
+  final class FakeMissionClient: FridayMobileMissionDispatchingWriteClient, @unchecked Sendable {
+    private(set) var submittedIntakes: [MissionIntakeRequestWire] = []
+    private(set) var missionContexts: [MissionWorkItemContextWire] = []
+
+    func dispatchAgentRun(
+      task: String,
+      constraints: AgentRunConstraintsWire?
+    ) async throws -> AgentRunDispatchOutcome {
+      .result(AgentRunResultWire(
+        runId: "run-legacy", status: "completed",
+        answerSha256: String(repeating: "d", count: 64), answerLen: 1, turns: 1, executedTools: 0))
+    }
+
+    func resumeWithApproval(runId: String, opaqueSignedBlob: [UInt8]) async throws -> ResumeRelayResult {
+      ResumeRelayResult(runId: runId, op: "resume", accepted: false, status: "denied", auditRef: nil)
+    }
+
+    func submitMissionIntake(_ request: MissionIntakeRequestWire) async throws -> MissionIntakeResultWire {
+      submittedIntakes.append(request)
+      return MissionIntakeResultWire(
+        fridayConversationId: request.fridayConversationId,
+        missionId: request.missionId,
+        workItemId: request.workItemId,
+        surfaceThreadId: request.surfaceThreadId,
+        status: "ready",
+        createdOrReady: true)
+    }
+
+    func submitMemoryDecision(_ request: MemoryDecisionRequestWire) async throws -> MemoryDecisionResultWire {
+      MemoryDecisionResultWire(
+        memoryId: request.memoryId,
+        state: "unknown",
+        status: "blocked",
+        blocker: "unused",
+        recallable: false)
+    }
+
+    func submitRunOutcomeLearningDecision(
+      _ request: RunOutcomeLearningDecisionRequestWire
+    ) async throws -> RunOutcomeLearningDecisionResultWire {
+      RunOutcomeLearningDecisionResultWire(
+        candidateId: request.candidateId,
+        state: "unknown",
+        status: "blocked",
+        blocker: "unused")
+    }
+
+    func dispatchMissionBoundAgentRun(
+      task: String,
+      missionContext: MissionWorkItemContextWire,
+      constraints: AgentRunConstraintsWire?
+    ) async throws -> AgentRunDispatchOutcome {
+      missionContexts.append(missionContext)
+      let runId = missionContext.workItemId.hasSuffix("-claude-followup") ? "run-followup" : "run-first"
+      return .result(AgentRunResultWire(
+        runId: runId, status: "finished",
+        answerSha256: String(repeating: "e", count: 64), answerLen: 42, turns: 1, executedTools: 0))
+    }
+  }
+
+  final class FakeReadClient: FridayRustReadClient, @unchecked Sendable {
+    let snapshot: WorkbenchSnapshot
+    init(snapshot: WorkbenchSnapshot) { self.snapshot = snapshot }
+    func fetchWorkbench() async throws -> WorkbenchSnapshot { snapshot }
+  }
+
   private func makeAnswer(_ runId: String = "run-1") -> AgentRunResultWire {
     AgentRunResultWire(runId: runId, status: "completed",
                        answerSha256: String(repeating: "a", count: 64), answerLen: 128, turns: 2, executedTools: 0)
@@ -79,6 +145,60 @@ final class FridayChatViewModelTests: XCTestCase {
     XCTAssertEqual(client.dispatchedTasks, ["summarize my inbox"])
     // DEFAULT read-only/no-grant: a plain send carries NO constraints block.
     XCTAssertEqual(client.dispatchedConstraints, [Optional<AgentRunConstraintsWire>.none])
+  }
+
+  func testBuildMissionIntakeRequest_usesMobileAutoRoute() {
+    let request = FridayChatViewModel.buildMissionIntakeRequest(
+      intent: "route through Codex first and Claude follow-up",
+      owner: "admin-001",
+      idFactory: { "fixed" })
+    XCTAssertEqual(request.ownerPrincipal, "admin-001")
+    XCTAssertEqual(request.surfaceKind, "mobile")
+    XCTAssertEqual(request.deliveryRoute, "ios://friday-mobile/chat/fixed")
+    XCTAssertEqual(request.missionId, "mission-mobile-fixed")
+    XCTAssertEqual(request.workItemId, "work-mobile-fixed")
+    XCTAssertEqual(request.lane, "auto")
+    XCTAssertNil(request.targetProviderOrAgent)
+  }
+
+  func testSend_withMissionClient_dispatchesGeneratedClaudeFollowUp() async throws {
+    let mission = FakeMissionClient()
+    let snapshotJSON = """
+    {
+      "missionId": "mission-mobile-fixed",
+      "fridayConversationId": "fconv_mobile_fixed",
+      "runtimeFeedStatus": "live_rust_hub_projection",
+      "statusLabels": [],
+      "workItems": [
+        { "workItemId": "work-mobile-fixed" },
+        { "workItemId": "work-mobile-fixed-claude-followup" }
+      ]
+    }
+    """
+    let read = FakeReadClient(snapshot: try WorkbenchSnapshot(
+      projectionJSON: Data(snapshotJSON.utf8),
+      generatedAtMs: 0))
+    let vm = FridayChatViewModel(
+      writeClient: mission,
+      signer: MockOperatorSigner(),
+      missionClient: mission,
+      readClient: read,
+      newId: { "fixed" })
+
+    await vm.send("route through Codex first and Claude follow-up")
+
+    XCTAssertEqual(mission.submittedIntakes.map(\.lane), ["auto"])
+    XCTAssertEqual(mission.submittedIntakes.map(\.surfaceKind), ["mobile"])
+    XCTAssertEqual(mission.missionContexts.map(\.workItemId), [
+      "work-mobile-fixed",
+      "work-mobile-fixed-claude-followup",
+    ])
+    guard case .answered(let receipt) = vm.phase else { return XCTFail("expected answered, got \(vm.phase)") }
+    XCTAssertEqual(receipt.runId, "run-first")
+    XCTAssertEqual(receipt.missionId, "mission-mobile-fixed")
+    XCTAssertEqual(receipt.workItemId, "work-mobile-fixed")
+    XCTAssertEqual(receipt.followUpWorkItemId, "work-mobile-fixed-claude-followup")
+    XCTAssertEqual(receipt.followUpRunId, "run-followup")
   }
 
   func testSend_blankTask_isNoOp() async {

--- a/apps/friday-ios/Tests/FridayMobileShellCoreTests/LiveMissionSpineWriteDispatchIntegrationTests.swift
+++ b/apps/friday-ios/Tests/FridayMobileShellCoreTests/LiveMissionSpineWriteDispatchIntegrationTests.swift
@@ -18,6 +18,8 @@ private let liveMissionSpineWriteDispatchEnabled =
   ProcessInfo.processInfo.environment["FRIDAY_MOBILE_LIVE_WRITE_DISPATCH_TEST"] == "1"
 private let liveMissionBoundRunEnabled =
   ProcessInfo.processInfo.environment["FRIDAY_MOBILE_LIVE_MISSION_BOUND_RUN_TEST"] == "1"
+private let liveProductAutoFollowUpRunEnabled =
+  ProcessInfo.processInfo.environment["FRIDAY_MOBILE_LIVE_PRODUCT_AUTO_FOLLOWUP_RUN_TEST"] == "1"
 
 @Test(.enabled(if: liveMissionSpineWriteDispatchEnabled))
 func liveMobileMissionSpineWriteDispatchReturnsReadyReceipt() async throws {
@@ -67,6 +69,50 @@ func liveMobileMissionSpineWriteDispatchCanStartMissionBoundRun() async throws {
     "[live-write-dispatch][mobile-bound] runId=\(receipt.runId) "
       + "status=\(receipt.status) turns=\(receipt.turns ?? 0)")
   #expect(receipt.status == "completed" || receipt.status == "finished" || receipt.status == "ok")
+}
+
+@Test(.enabled(if: liveProductAutoFollowUpRunEnabled))
+@MainActor
+func liveMobileChatSendAutoDispatchesHybridClaudeFollowUp() async throws {
+  let id = "liveauto\(UUID().uuidString.lowercased().replacingOccurrences(of: "-", with: ""))"
+  let writeClient = try RealWriteClientFactory.makeLive(config: mobileProductAutoFollowUpWriteConfig())
+  let readClient = try RealReadClientFactory.makeLive(missionId: "mission-mobile-\(id)")
+  let vm = FridayChatViewModel(
+    writeClient: writeClient,
+    signer: MockOperatorSigner(),
+    missionClient: writeClient,
+    readClient: readClient,
+    newId: { id })
+
+  await vm.send(
+    "In the Friday mobile shell test target, identify the mobile live mission-spine test file path, "
+      + "then summarize that the iOS Chat product path should automatically run the generated Claude "
+      + "follow-up after the Codex first leg. Answer exactly FRIDAY_MOBILE_PRODUCT_AUTO_FOLLOWUP_OK.")
+
+  guard case .answered(let receipt) = vm.phase else {
+    Issue.record("expected mobile product auto follow-up to answer, got \(String(describing: vm.phase))")
+    return
+  }
+
+  print(
+    "[live-mobile-product-auto-followup] id=\(id) firstRunId=\(receipt.runId) "
+      + "missionId=\(receipt.missionId ?? "<nil>") workItemId=\(receipt.workItemId ?? "<nil>") "
+      + "followUpWorkItemId=\(receipt.followUpWorkItemId ?? "<nil>") "
+      + "followUpRunId=\(receipt.followUpRunId ?? "<nil>")")
+  #expect(receipt.missionId == "mission-mobile-\(id)")
+  #expect(receipt.workItemId == "work-mobile-\(id)")
+  #expect(receipt.followUpWorkItemId == "work-mobile-\(id)-claude-followup")
+  #expect(receipt.followUpRunId != nil)
+}
+
+private func mobileProductAutoFollowUpWriteConfig() -> AgentRunServerConfig {
+  guard
+    let rawPort = ProcessInfo.processInfo.environment["FRIDAY_MOBILE_LIVE_PRODUCT_AUTO_FOLLOWUP_WRITE_PORT"],
+    let port = UInt16(rawPort)
+  else {
+    return .liveLoopback
+  }
+  return AgentRunServerConfig(host: "127.0.0.1", port: port)
 }
 
 private func makeLiveMobileIntake(


### PR DESCRIPTION
## Summary
- Route the iOS Chat live-write path through Mission Intake when a mission-capable write client is available.
- Preserve shipped default-OFF behavior: without `FRIDAY_MOBILE_LIVE_WRITE=1` / `--live-write`, Chat still uses the honest-unavailable write client and never fabricates readiness.
- Surface refs-only mission/work/follow-up identifiers in the answer card and add focused unit coverage plus an env-gated live product auto-follow-up test.

## Validation
- `swift test --package-path apps/friday-ios` PASS
- `git diff --check` PASS
- `apps/friday-ios/build-sim.sh` PASS; screenshot verified v9 dog visible and default honest-unavailable state
- Live proof against current-head temporary Rust WS on `127.0.0.1:49750` PASS:
  - `FRIDAY_MOBILE_LIVE_PRODUCT_AUTO_FOLLOWUP_RUN_TEST=1 FRIDAY_MOBILE_LIVE_PRODUCT_AUTO_FOLLOWUP_WRITE_PORT=49750 swift test --package-path apps/friday-ios --filter liveMobileChatSendAutoDispatchesHybridClaudeFollowUp`
  - Mission `mission-mobile-liveautodfd8f673472b41f99af1c4f05cadad5e`
  - Codex first leg `run-2FD5E32C-E42D-4A66-B9CA-15AEEC3D68A9`, ledger `codex|gpt-5.5|58342|fallback=0`, WorkItem `completed_with_proof`
  - Claude follow-up `run-8AA0D06C-8A8D-4F4B-A01A-7D61B423FC19`, ledger `anthropic|claude-opus-4-8|866|fallback=0`, follow-up WorkItem `completed_with_proof`
  - Audit row `route_decision.deferred_follow_up_materialized` present for the mobile follow-up WorkItem

## Truth boundary
- This proves mobile product path auto-dispatch on current-head runtime plus real Codex/Claude spend.
- The existing prod launchd `:48750` release binary appeared stale during the first live attempt: it completed the Codex first leg but did not materialize the follow-up. I did not restart prod from the dirty prod tree. Post-merge needs a normal prod re-pin/rebuild/restart of the Rust WS, then a post-merge live proof on `:48750`.
- Not D20/B4 true operator signature, not physical-hand GUI OG9, not full Phase 1 flawless, not goal done.
