### PR TITLE
Fix mission proof body refs

### DIFF
--- a/scripts/ops/friday-claude-mission-proof-of-life.sh
+++ b/scripts/ops/friday-claude-mission-proof-of-life.sh
@@ -56,7 +56,7 @@ readonly DELIVERY_ROUTE="${FRIDAY_CLAUDE_MISSION_PROOF_DELIVERY_ROUTE:-ops://cla
 readonly MISSION_TITLE="${FRIDAY_CLAUDE_MISSION_PROOF_TITLE:-Claude proof token}"
 readonly MISSION_INTENT="${FRIDAY_CLAUDE_MISSION_PROOF_INTENT:-Answer exactly FRIDAY_CLAUDE_PROOF_OK.}"
 readonly CAPABILITY_ID="${FRIDAY_CLAUDE_MISSION_PROOF_CAPABILITY_ID:-ask_friday.claude}"
-readonly BODY_REF="${FRIDAY_CLAUDE_MISSION_PROOF_BODY_REF:-friday://body/ops/claude-mission-proof-of-life}"
+readonly BODY_REF_PREFIX="friday://body/ops/claude-mission-proof-of-life"
 
 SQLITE_BIN="$(command -v sqlite3 || true)"
 if [ -z "${SQLITE_BIN}" ] && [ -x "/Users/jarvis/Library/Android/sdk/platform-tools/sqlite3" ]; then
@@ -397,6 +397,7 @@ readonly FRIDAY_CONVERSATION_ID="fconv_${ID_PREFIX//-/_}_${RUN_TAG//-/_}"
 readonly MISSION_ID="${ID_PREFIX}-mission-${RUN_TAG}"
 readonly WORK_ITEM_ID="${ID_PREFIX}-work-${RUN_TAG}"
 readonly SURFACE_THREAD_ID="${ID_PREFIX}-surface-${RUN_TAG}"
+readonly BODY_REF="${FRIDAY_CLAUDE_MISSION_PROOF_BODY_REF:-${BODY_REF_PREFIX}/${WORK_ITEM_ID}}"
 readonly STARTED_AT_MS="$(now_ms)"
 
 echo "Claude Mission proof starting."

--- a/scripts/ops/friday-codex-mission-proof-of-life.sh
+++ b/scripts/ops/friday-codex-mission-proof-of-life.sh
@@ -55,7 +55,7 @@ readonly DELIVERY_ROUTE="${FRIDAY_CODEX_MISSION_PROOF_DELIVERY_ROUTE:-ops://code
 readonly MISSION_TITLE="${FRIDAY_CODEX_MISSION_PROOF_TITLE:-Codex proof token}"
 readonly MISSION_INTENT="${FRIDAY_CODEX_MISSION_PROOF_INTENT:-What is the proof token? Answer exactly FRIDAY_CODEX_PROOF_OK.}"
 readonly CAPABILITY_ID="${FRIDAY_CODEX_MISSION_PROOF_CAPABILITY_ID:-observe-wrapper.codex}"
-readonly BODY_REF="${FRIDAY_CODEX_MISSION_PROOF_BODY_REF:-friday://body/ops/codex-mission-proof-of-life}"
+readonly BODY_REF_PREFIX="friday://body/ops/codex-mission-proof-of-life"
 
 SQLITE_BIN="$(command -v sqlite3 || true)"
 if [ -z "${SQLITE_BIN}" ] && [ -x "/Users/jarvis/Library/Android/sdk/platform-tools/sqlite3" ]; then
@@ -519,6 +519,7 @@ readonly FRIDAY_CONVERSATION_ID="fconv_${ID_PREFIX//-/_}_${RUN_TAG//-/_}"
 readonly MISSION_ID="${ID_PREFIX}-mission-${RUN_TAG}"
 readonly WORK_ITEM_ID="${ID_PREFIX}-work-${RUN_TAG}"
 readonly SURFACE_THREAD_ID="${ID_PREFIX}-surface-${RUN_TAG}"
+readonly BODY_REF="${FRIDAY_CODEX_MISSION_PROOF_BODY_REF:-${BODY_REF_PREFIX}/${WORK_ITEM_ID}}"
 
 echo "Codex Mission ${RUN_KIND} starting."
 echo "  TS hub: ${TS_HUB}"

--- a/test/unit/scripts/ops/friday-claude-mission-proof-gates.test.ts
+++ b/test/unit/scripts/ops/friday-claude-mission-proof-gates.test.ts
@@ -46,6 +46,15 @@ describe("Claude mission proof operator gate", () => {
     expect(source).toContain("FRIDAY_CLAUDE_MISSION_PROOF_RUN_KIND");
     expect(source).toContain("FRIDAY_CLAUDE_MISSION_PROOF_SURFACE_KIND");
     expect(source).toContain("FRIDAY_CLAUDE_MISSION_PROOF_DELIVERY_ROUTE");
+    expect(source).toContain(
+      'readonly BODY_REF_PREFIX="friday://body/ops/claude-mission-proof-of-life"',
+    );
+    expect(source).toContain(
+      'readonly BODY_REF="${FRIDAY_CLAUDE_MISSION_PROOF_BODY_REF:-${BODY_REF_PREFIX}/${WORK_ITEM_ID}}"',
+    );
+    expect(source).not.toContain(
+      'readonly BODY_REF="${FRIDAY_CLAUDE_MISSION_PROOF_BODY_REF:-friday://body/ops/claude-mission-proof-of-life}"',
+    );
     expect(source).toContain('readonly CLAUDE_MODEL="claude-opus-4-8"');
     expect(source).toContain('lane: "claude"');
     expect(source).toContain('targetProviderOrAgent: "claude"');

--- a/test/unit/scripts/ops/friday-codex-mission-proof-gates.test.ts
+++ b/test/unit/scripts/ops/friday-codex-mission-proof-gates.test.ts
@@ -466,6 +466,15 @@ describe("Codex mission proof gates", () => {
     expect(proofSource).toContain(
       'readonly MISSION_INTENT="${FRIDAY_CODEX_MISSION_PROOF_INTENT:-What is the proof token? Answer exactly FRIDAY_CODEX_PROOF_OK.}"',
     );
+    expect(proofSource).toContain(
+      'readonly BODY_REF_PREFIX="friday://body/ops/codex-mission-proof-of-life"',
+    );
+    expect(proofSource).toContain(
+      'readonly BODY_REF="${FRIDAY_CODEX_MISSION_PROOF_BODY_REF:-${BODY_REF_PREFIX}/${WORK_ITEM_ID}}"',
+    );
+    expect(proofSource).not.toContain(
+      'readonly BODY_REF="${FRIDAY_CODEX_MISSION_PROOF_BODY_REF:-friday://body/ops/codex-mission-proof-of-life}"',
+    );
     expect(proofSource).toContain("FRIDAY_CODEX_MISSION_PROOF_RUN_KIND must be proof or organic");
     expect(proofSource).toContain(
       "ops://codex-mission-proof-of-life|ops://codex-organic-spawn",


### PR DESCRIPTION
## Summary
- derive Codex/Claude proof body refs from the current WorkItem id by default
- keep explicit FRIDAY_*_MISSION_PROOF_BODY_REF overrides intact
- pin the non-static default in focused ops proof gate tests

## Validation
- bash -n scripts/ops/friday-codex-mission-proof-of-life.sh scripts/ops/friday-claude-mission-proof-of-life.sh
- git diff --check
- vitest run --project default --project typecheck test/unit/scripts/ops/friday-codex-mission-proof-gates.test.ts test/unit/scripts/ops/friday-claude-mission-proof-gates.test.ts
- live Phase0 smoke: Codex PASS(STRONG) work codex-proof-work-65373ca0-4766-46ca-8c09-4b826d04f950 run 81ba8a14-d3ae-4c8c-aac9-cc308956fe4b
- live Phase0 smoke: Claude PASS(STRONG) work claude-proof-work-0ab8c0d6-2ab6-453f-a57e-4d42d71c08ce run d45009ea-54ac-4a01-9661-62d5bb154abb

Truth: fixes repeatability of the proof scripts after mission_body_snapshot became a required intake write; this is Phase0 proof plumbing, not Phase1 flawless/goal completion.