### PR TITLE
Map mission intake owner mismatch

### DIFF
--- a/src/api/mission-spine/friday-rust-hub-agent-run-ws-sealed-client.ts
+++ b/src/api/mission-spine/friday-rust-hub-agent-run-ws-sealed-client.ts
@@ -631,9 +631,31 @@ export function missionSpineUnavailableFromRustErrorEnvelope(
 ): FridayDomainError {
   const code = asString(fields.code) ?? "unknown";
   const message = asString(fields.message) ?? "unknown";
-  return unavailable(`Sealed mission-spine client (${leg}) received a Rust Error envelope.`, {
+  const details = {
     leg,
     rustError: { code, message },
+  };
+  if (
+    leg === "mission-intake" &&
+    message === "mission intake owner_principal does not match the authenticated owner"
+  ) {
+    return new FridayDomainError(
+      "MISSION_SPINE_OWNER_PRINCIPAL_MISMATCH",
+      "Mission intake owner_principal does not match the authenticated owner.",
+      {
+        httpStatus: 403,
+        details: {
+          surface: "service:rust_hub_agent_run_sealed_ws_client",
+          bridge: "rust_wired",
+          proofOnly: true,
+          proofReady: false,
+          ...details,
+        },
+      },
+    );
+  }
+  return unavailable(`Sealed mission-spine client (${leg}) received a Rust Error envelope.`, {
+    ...details,
   });
 }
 

--- a/test/unit/api/mission-spine/friday-rust-hub-agent-run-ws-sealed-client.test.ts
+++ b/test/unit/api/mission-spine/friday-rust-hub-agent-run-ws-sealed-client.test.ts
@@ -216,6 +216,30 @@ describe("friday-rust-hub-agent-run-ws-sealed-client mission-spine typed errors"
       },
     });
   });
+
+  it("maps mission-intake owner mismatch to a typed 403 without dropping Rust diagnostics", () => {
+    const err = missionSpineUnavailableFromRustErrorEnvelope("mission-intake", {
+      kind: "Error",
+      code: "Internal",
+      message: "mission intake owner_principal does not match the authenticated owner",
+    });
+
+    expect(err).toBeInstanceOf(FridayDomainError);
+    expect(err.code).toBe("MISSION_SPINE_OWNER_PRINCIPAL_MISMATCH");
+    expect(err.httpStatus).toBe(403);
+    expect(err.message).toContain("owner_principal");
+    expect(err.details).toMatchObject({
+      surface: "service:rust_hub_agent_run_sealed_ws_client",
+      bridge: "rust_wired",
+      proofOnly: true,
+      proofReady: false,
+      leg: "mission-intake",
+      rustError: {
+        code: "Internal",
+        message: "mission intake owner_principal does not match the authenticated owner",
+      },
+    });
+  });
 });
 
 // (A3 courier) The pause/resume PRODUCT TRANSPORT — DARK, gated DEFAULT-OFF behind the courier's


### PR DESCRIPTION
## Summary
- map the mission-intake owner_principal mismatch Rust Error envelope to a typed 403
- keep all other Rust Error envelopes on the existing fail-closed 503 path
- retain Rust diagnostic details for local inspection

## Validation
- vitest run --project default --project typecheck test/unit/api/mission-spine/friday-rust-hub-agent-run-ws-sealed-client.test.ts
- git diff --check

Truth: improves Phase1 owner-mismatch error expression only; the zero-write guard already held, and this is not Phase1/goal completion.