### PR TITLE
Show owner-gated answer bodies in mobile chat

### DIFF
--- a/apps/friday-ios/Sources/FridayMobileShell/FridayChatScreen.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayChatScreen.swift
@@ -6,13 +6,13 @@ import SwiftUI
 ///
 /// This is the strict S6 needle: the 4-state chat loop over the package's REAL
 /// `SealedWSWriteClient` + the `OperatorSigner` relay (driven by `FridayChatViewModel`):
-///   compose → send → refs-only answer; mutating → AgentRunPaused → S6 approval card →
+///   compose → send → owner-gated readable answer; mutating → AgentRunPaused → S6 approval card →
 ///   operator-signs (relay-only) → resumeWithApproval VERBATIM → refs-only receipt; and
 ///   honest-unavailable when the Rust write server is DARK (the EXPECTED slice-6 state).
 ///
 /// Truth rules (enforced in the view model): INV-1 (no signing key on the app — the phone relays
 /// an OPAQUE blob), INV-2 (a mutation executes ONLY via an operator-approved resume), INV-5
-/// (every surfaced field is a ref/label/count/fingerprint — never an inline body).
+/// (the write receipt is refs-only; the answer body appears only through the owner-gated readback).
 struct FridayChatScreen: View {
   @StateObject private var viewModel: FridayChatViewModel
   /// Whether the S6 pause/approve/resume is enabled (the run-control flag). OFF ⇒ read-only.
@@ -134,20 +134,31 @@ struct FridayChatScreen: View {
       && !viewModel.phase.isBusy && !viewModel.phase.isAwaitingApproval
   }
 
-  // MARK: - Cards (refs-only throughout — INV-5)
+  // MARK: - Cards
 
-  /// The refs-only answer receipt (a fingerprint + counts, never a body).
+  /// The answer receipt: readable body when the owner-gated readback grants it, refs otherwise.
   private func answerCard(_ r: ChatAnswerReceipt) -> some View {
     GlassPanel {
-      VStack(alignment: .leading, spacing: 8) {
+      VStack(alignment: .leading, spacing: 10) {
         HStack {
           StatusChip(text: r.status.uppercased(), bg: MobileTheme.chipDoneBG, fg: MobileTheme.chipDoneFG)
           Spacer()
           Button("New") { viewModel.newTurn() }.font(.caption).foregroundStyle(MobileTheme.cyan)
         }
         Text("Friday answered").font(.headline).foregroundStyle(MobileTheme.textPrimary)
-        Text("answer is delivered refs-only — a fingerprint + counts (the body rides the owner-gated readback)")
-          .font(.caption2).foregroundStyle(MobileTheme.textSecondary)
+        if let answer = readableAnswer(r.answerBody) {
+          Text(answer)
+            .font(.body)
+            .foregroundStyle(MobileTheme.textPrimary)
+            .fixedSize(horizontal: false, vertical: true)
+            .textSelection(.enabled)
+          if let runId = r.answerBodyRunId {
+            RefPill(label: "answer_body_run_id", ref: runId)
+          }
+        } else {
+          Text("Answer body is not available from the owner-gated readback yet.")
+            .font(.caption2).foregroundStyle(MobileTheme.textSecondary)
+        }
         if let sha = r.answerSha256 { RefPill(label: "answer_sha256", ref: short(sha)) }
         if let missionId = r.missionId { RefPill(label: "mission_id", ref: missionId) }
         if let workItemId = r.workItemId { RefPill(label: "work_item_id", ref: workItemId) }
@@ -156,6 +167,7 @@ struct FridayChatScreen: View {
         }
         if let followUpRunId = r.followUpRunId { RefPill(label: "follow_up_run_id", ref: followUpRunId) }
         if let len = r.answerLen { RefPill(label: "answer_len", ref: "\(len)") }
+        if let outcome = r.answerBodyOutcome { RefPill(label: "answer_body", ref: outcome) }
         if let turns = r.turns { RefPill(label: "turns", ref: "\(turns)") }
         if let tools = r.executedTools { RefPill(label: "executed_tools", ref: "\(tools)") }
       }
@@ -236,6 +248,13 @@ struct FridayChatScreen: View {
 
   private func short(_ s: String) -> String {
     s.count > 16 ? "\(s.prefix(10))…\(s.suffix(4))" : s
+  }
+
+  private func readableAnswer(_ value: String?) -> String? {
+    guard let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines), !trimmed.isEmpty else {
+      return nil
+    }
+    return trimmed
   }
 }
 

--- a/apps/friday-ios/Sources/FridayMobileShellCore/FridayChatViewModel.swift
+++ b/apps/friday-ios/Sources/FridayMobileShellCore/FridayChatViewModel.swift
@@ -27,18 +27,17 @@ import FridayRustClient
 ///     which is reachable ONLY from `.pendingApproval`, which is reached ONLY by a server pause.
 ///     `approve()` is a NO-OP unless the loop is `.pendingApproval`. There is NO method that
 ///     executes a mutation without first pausing for approval — no bypass.
-///   - **INV-5 (refs-only):** every surfaced field is a ref/label/count/fingerprint — the answer
-///     is shown as `{status, answerSha256, answerLen, turns}`, NEVER an inline body; the pause is
-///     `{summary, actionDigest}`; the receipt is `{op, accepted, status, auditRef}`.
+///   - **INV-5 (answer-body carve-out):** write/dispatch receipts stay refs-only. An answer body is
+///     shown only after the separate owner-gated readback grants the authenticated owner access.
+///     The pause is `{summary, actionDigest}`; the receipt is `{op, accepted, status, auditRef}`.
 ///   - **Honest-unavailable:** the Rust write server is DARK; `dispatchAgentRun` /
 ///     `resumeWithApproval` are EXPECTED to throw — every throw renders `.unavailable`, never a
 ///     fabricated answer/approval/receipt, never a label upgrade.
 
-// MARK: - Refs-only surfaced models (INV-5)
+// MARK: - Surfaced models
 
-/// The refs-only ANSWER receipt the chat shows on a non-paused settle. Mirrors
-/// `AgentRunResultWire`: a coarse status + the answer FINGERPRINT (sha256/len) + run COUNTS —
-/// NEVER a body. The body is sourced by the owner-gated DB readback downstream, not here.
+/// The ANSWER receipt the chat shows on a non-paused settle. The write receipt remains refs-only
+/// (status/fingerprint/counts). `answerBody` is populated only by the separate owner-gated readback.
 public struct ChatAnswerReceipt: Sendable, Equatable {
   public let runId: String
   public let status: String
@@ -52,13 +51,19 @@ public struct ChatAnswerReceipt: Sendable, Equatable {
   public let workItemId: String?
   public let followUpWorkItemId: String?
   public let followUpRunId: String?
+  public let answerBody: String?
+  public let answerBodyRunId: String?
+  public let answerBodyOutcome: String?
 
   init(
     _ r: AgentRunResultWire,
     missionId: String? = nil,
     workItemId: String? = nil,
     followUpWorkItemId: String? = nil,
-    followUpRunId: String? = nil
+    followUpRunId: String? = nil,
+    answerBody: String? = nil,
+    answerBodyRunId: String? = nil,
+    answerBodyOutcome: String? = nil
   ) {
     self.runId = r.runId
     self.status = r.status
@@ -72,6 +77,9 @@ public struct ChatAnswerReceipt: Sendable, Equatable {
     self.workItemId = workItemId
     self.followUpWorkItemId = followUpWorkItemId
     self.followUpRunId = followUpRunId
+    self.answerBody = answerBody
+    self.answerBodyRunId = answerBodyRunId
+    self.answerBodyOutcome = answerBodyOutcome
   }
 }
 
@@ -230,8 +238,12 @@ public final class FridayChatViewModel: ObservableObject {
       let outcome = try await writeClient.dispatchAgentRun(task: trimmed, constraints: constraints)
       switch outcome {
       case .result(let r):
-        // Non-mutating settle: the refs-only answer receipt (fingerprint + counts, never a body).
-        phase = .answered(ChatAnswerReceipt(r))
+        let answer = await fetchDeliveredAnswerBody(for: r.runId)
+        phase = .answered(ChatAnswerReceipt(
+          r,
+          answerBody: answer?.body,
+          answerBodyRunId: answer?.runId,
+          answerBodyOutcome: answer?.outcome))
       case .paused(let p):
         // INV-2: a mutating run PAUSED — surface the S6 approval card. No mutation has executed.
         phase = .pendingApproval(ApprovalCard(p))
@@ -272,12 +284,17 @@ public final class FridayChatViewModel: ObservableObject {
         sourceWorkItemId: workItemId,
         intakeResult: result,
         missionClient: missionClient)
+      let bodyRunId = followUp?.runId ?? firstReceipt.runId
+      let answer = await fetchDeliveredAnswerBody(for: bodyRunId)
       phase = .answered(ChatAnswerReceipt(
         firstReceipt,
         missionId: result.missionId,
         workItemId: workItemId,
         followUpWorkItemId: followUp?.workItemId,
-        followUpRunId: followUp?.runId))
+        followUpRunId: followUp?.runId,
+        answerBody: answer?.body,
+        answerBodyRunId: answer?.runId,
+        answerBodyOutcome: answer?.outcome))
     } catch {
       phase = .unavailable(reason: Self.dispatchReason(for: error))
     }
@@ -308,6 +325,19 @@ public final class FridayChatViewModel: ObservableObject {
       return nil
     }
     return (followUpWorkItemId, receipt.runId)
+  }
+
+  private func fetchDeliveredAnswerBody(for runId: String) async -> (runId: String, body: String, outcome: String)? {
+    guard let readClient else { return nil }
+    do {
+      let body = try await readClient.fetchRunAnswerBody(runId: runId)
+      guard let answer = body.deliveredAnswer else {
+        return nil
+      }
+      return (body.runId, answer, body.outcome)
+    } catch {
+      return nil
+    }
   }
 
   // MARK: 3. Approve → Resume (the S6 relay — INV-1, INV-2)

--- a/apps/friday-ios/Tests/FridayMobileShellCoreTests/FridayChatViewModelTests.swift
+++ b/apps/friday-ios/Tests/FridayMobileShellCoreTests/FridayChatViewModelTests.swift
@@ -118,8 +118,37 @@ final class FridayChatViewModelTests: XCTestCase {
 
   final class FakeReadClient: FridayRustReadClient, @unchecked Sendable {
     let snapshot: WorkbenchSnapshot
-    init(snapshot: WorkbenchSnapshot) { self.snapshot = snapshot }
+    let answerBodies: [String: String]
+
+    init(snapshot: WorkbenchSnapshot, answerBodies: [String: String] = [:]) {
+      self.snapshot = snapshot
+      self.answerBodies = answerBodies
+    }
+
     func fetchWorkbench() async throws -> WorkbenchSnapshot { snapshot }
+
+    func fetchRunAnswerBody(runId: String) async throws -> RunAnswerBody {
+      guard let answer = answerBodies[runId] else {
+        let data = try JSONSerialization.data(withJSONObject: [
+          "truth_label": "rust_wired_owner_gated",
+          "ok": true,
+          "outcome": "not_found",
+          "run_id": runId,
+        ])
+        return try RunAnswerBody(answerJSON: data, generatedAtMs: 1)
+      }
+      let data = try JSONSerialization.data(withJSONObject: [
+        "truth_label": "rust_wired_owner_gated",
+        "ok": true,
+        "outcome": "delivered",
+        "run_id": runId,
+        "status": "finished",
+        "answer": answer,
+        "answer_sha256": String(repeating: "f", count: 64),
+        "answer_len": answer.utf8.count,
+      ])
+      return try RunAnswerBody(answerJSON: data, generatedAtMs: 1)
+    }
   }
 
   private func makeAnswer(_ runId: String = "run-1") -> AgentRunResultWire {
@@ -142,9 +171,34 @@ final class FridayChatViewModelTests: XCTestCase {
     XCTAssertEqual(receipt.status, "completed")
     XCTAssertEqual(receipt.answerLen, 128)         // refs/counts only (INV-5)
     XCTAssertEqual(receipt.answerSha256?.count, 64) // a fingerprint, never a body
+    XCTAssertNil(receipt.answerBody)
     XCTAssertEqual(client.dispatchedTasks, ["summarize my inbox"])
     // DEFAULT read-only/no-grant: a plain send carries NO constraints block.
     XCTAssertEqual(client.dispatchedConstraints, [Optional<AgentRunConstraintsWire>.none])
+  }
+
+  func testSend_withReadClient_surfacesOwnerGatedAnswerBody() async throws {
+    let client = FakeWriteClient(dispatch: .answer(makeAnswer("run-readable")))
+    let read = FakeReadClient(
+      snapshot: try WorkbenchSnapshot(
+        projectionJSON: Data("""
+        {"missionId":"mission-readable","fridayConversationId":"fconv-readable",\
+        "runtimeFeedStatus":"live_rust_hub_projection","statusLabels":[],"workItems":[]}
+        """.utf8),
+        generatedAtMs: 0),
+      answerBodies: ["run-readable": "Readable answer from the owner-gated readback."])
+    let vm = FridayChatViewModel(
+      writeClient: client,
+      signer: MockOperatorSigner(),
+      readClient: read)
+
+    await vm.send("summarize my inbox")
+
+    guard case .answered(let receipt) = vm.phase else { return XCTFail("expected .answered, got \(vm.phase)") }
+    XCTAssertEqual(receipt.runId, "run-readable")
+    XCTAssertEqual(receipt.answerBodyRunId, "run-readable")
+    XCTAssertEqual(receipt.answerBodyOutcome, "delivered")
+    XCTAssertEqual(receipt.answerBody, "Readable answer from the owner-gated readback.")
   }
 
   func testBuildMissionIntakeRequest_usesMobileAutoRoute() {
@@ -175,9 +229,11 @@ final class FridayChatViewModelTests: XCTestCase {
       ]
     }
     """
-    let read = FakeReadClient(snapshot: try WorkbenchSnapshot(
-      projectionJSON: Data(snapshotJSON.utf8),
-      generatedAtMs: 0))
+    let read = FakeReadClient(
+      snapshot: try WorkbenchSnapshot(
+        projectionJSON: Data(snapshotJSON.utf8),
+        generatedAtMs: 0),
+      answerBodies: ["run-followup": "Claude follow-up body visible to the owner."])
     let vm = FridayChatViewModel(
       writeClient: mission,
       signer: MockOperatorSigner(),
@@ -199,6 +255,8 @@ final class FridayChatViewModelTests: XCTestCase {
     XCTAssertEqual(receipt.workItemId, "work-mobile-fixed")
     XCTAssertEqual(receipt.followUpWorkItemId, "work-mobile-fixed-claude-followup")
     XCTAssertEqual(receipt.followUpRunId, "run-followup")
+    XCTAssertEqual(receipt.answerBodyRunId, "run-followup")
+    XCTAssertEqual(receipt.answerBody, "Claude follow-up body visible to the owner.")
   }
 
   func testSend_blankTask_isNoOp() async {

--- a/apps/macos/FridayRustClient/Sources/FridayRustClient/Protocol.swift
+++ b/apps/macos/FridayRustClient/Sources/FridayRustClient/Protocol.swift
@@ -141,6 +141,11 @@ public enum FridayMessage: Equatable {
   /// hub→trusted-peer: A1 run-outcome learning decision receipt (refs-only). Mirrors
   /// `friday_protocol::Message::RunOutcomeLearningDecisionResult`.
   case runOutcomeLearningDecisionResult(RunOutcomeLearningDecisionResultWire)
+  /// client→read-server: owner-gated run answer body readback. Kept separate from
+  /// RunReadback so refs-only projections stay refs-only.
+  case runAnswerBodyRequest(RunAnswerBodyRequestWire)
+  /// read-server→client: owner-sealed answer-body snapshot.
+  case runAnswerBodySnapshot(RunAnswerBodySnapshotWire)
 
   /// A decoded-but-not-handled message kind. Carries the raw `kind` for truth-labeled surfacing
   /// (e.g. an `AgentRunPaused` reaching the read client, or any frame the client cannot handle).
@@ -263,6 +268,12 @@ extension FridayMessage: Codable {
       let c = try decoder.container(keyedBy: ResultKey.self)
       self = .runOutcomeLearningDecisionResult(
         try c.decode(RunOutcomeLearningDecisionResultWire.self, forKey: .result))
+    case "RunAnswerBodyRequest":
+      let c = try decoder.container(keyedBy: RequestKey.self)
+      self = .runAnswerBodyRequest(try c.decode(RunAnswerBodyRequestWire.self, forKey: .request))
+    case "RunAnswerBodySnapshot":
+      let c = try decoder.container(keyedBy: SnapshotKey.self)
+      self = .runAnswerBodySnapshot(try c.decode(RunAnswerBodySnapshotWire.self, forKey: .snapshot))
     default:
       self = .unsupported(kind: kind)
     }
@@ -363,6 +374,14 @@ extension FridayMessage: Codable {
       try tag.encode("RunOutcomeLearningDecisionResult", forKey: .kind)
       var c = encoder.container(keyedBy: ResultKey.self)
       try c.encode(r, forKey: .result)
+    case .runAnswerBodyRequest(let r):
+      try tag.encode("RunAnswerBodyRequest", forKey: .kind)
+      var c = encoder.container(keyedBy: RequestKey.self)
+      try c.encode(r, forKey: .request)
+    case .runAnswerBodySnapshot(let r):
+      try tag.encode("RunAnswerBodySnapshot", forKey: .kind)
+      var c = encoder.container(keyedBy: SnapshotKey.self)
+      try c.encode(r, forKey: .snapshot)
     case .unsupported(let kind):
       try tag.encode(kind, forKey: .kind)
     }
@@ -490,5 +509,50 @@ public struct WorkbenchSnapshot: Equatable {
     }
     self.generatedAtMs = generatedAtMs
     self.raw = obj
+  }
+}
+
+// MARK: - Owner-gated answer body projection
+
+public struct RunAnswerBody: Equatable, Sendable {
+  public let runId: String
+  public let outcome: String
+  public let status: String?
+  public let answer: String?
+  public let answerSha256: String?
+  public let answerLen: UInt64?
+  public let denyReason: String?
+  public let truthLabel: String
+  public let generatedAtMs: Int64
+
+  public var deliveredAnswer: String? {
+    outcome == "delivered" ? answer : nil
+  }
+
+  public init(answerJSON: Data, generatedAtMs: Int64) throws {
+    guard let obj = try JSONSerialization.jsonObject(with: answerJSON) as? [String: Any] else {
+      throw FridayReadClientError.malformedProjection("answer JSON is not an object")
+    }
+    guard let runId = obj["run_id"] as? String else {
+      throw FridayReadClientError.malformedProjection("answer JSON missing run_id")
+    }
+    guard let outcome = obj["outcome"] as? String else {
+      throw FridayReadClientError.malformedProjection("answer JSON missing outcome")
+    }
+    self.runId = runId
+    self.outcome = outcome
+    self.status = obj["status"] as? String
+    self.answer = obj["answer"] as? String
+    self.answerSha256 = obj["answer_sha256"] as? String
+    if let n = obj["answer_len"] as? UInt64 {
+      self.answerLen = n
+    } else if let n = obj["answer_len"] as? Int {
+      self.answerLen = UInt64(n)
+    } else {
+      self.answerLen = nil
+    }
+    self.denyReason = obj["deny_reason"] as? String
+    self.truthLabel = (obj["truth_label"] as? String) ?? "unknown"
+    self.generatedAtMs = generatedAtMs
   }
 }

--- a/apps/macos/FridayRustClient/Sources/FridayRustClient/ReadClient.swift
+++ b/apps/macos/FridayRustClient/Sources/FridayRustClient/ReadClient.swift
@@ -93,6 +93,16 @@ public protocol FridayRustReadClient: Sendable {
   /// Fetch the Mission Workbench refs-only projection over the sealed-WS read seam:
   /// handshake → owner-authed request → open the owner-sealed snapshot → typed result.
   func fetchWorkbench() async throws -> WorkbenchSnapshot
+  /// Fetch one run's owner-gated answer body over the sealed-WS read seam. This is the explicit
+  /// body-bearing sibling of `fetchWorkbench()`/RunReadback; implementations must not source the
+  /// body from refs-only projections.
+  func fetchRunAnswerBody(runId: String) async throws -> RunAnswerBody
+}
+
+public extension FridayRustReadClient {
+  func fetchRunAnswerBody(runId: String) async throws -> RunAnswerBody {
+    throw FridayReadClientError.transport("run answer body readback unavailable")
+  }
 }
 
 // MARK: - The sealed-WS read client implementation
@@ -231,6 +241,105 @@ public final class SealedWSReadClient: FridayRustReadClient, @unchecked Sendable
       throw FridayReadClientError.unexpectedResponse(kind: "AgentRunControlResult")
     // The mission-spine WRITE variants share the `FridayMessage` enum but are NEVER answers a READ
     // server gives — surface them as unexpected (the read seam only answers a snapshot / Error).
+    case .missionIntakeRequest:
+      throw FridayReadClientError.unexpectedResponse(kind: "MissionIntakeRequest")
+    case .missionIntakeResult:
+      throw FridayReadClientError.unexpectedResponse(kind: "MissionIntakeResult")
+    case .memoryDecisionRequest:
+      throw FridayReadClientError.unexpectedResponse(kind: "MemoryDecisionRequest")
+    case .memoryDecisionResult:
+      throw FridayReadClientError.unexpectedResponse(kind: "MemoryDecisionResult")
+    case .runOutcomeLearningDecisionRequest:
+      throw FridayReadClientError.unexpectedResponse(kind: "RunOutcomeLearningDecisionRequest")
+    case .runOutcomeLearningDecisionResult:
+      throw FridayReadClientError.unexpectedResponse(kind: "RunOutcomeLearningDecisionResult")
+    case .runAnswerBodyRequest:
+      throw FridayReadClientError.unexpectedResponse(kind: "RunAnswerBodyRequest")
+    case .runAnswerBodySnapshot:
+      throw FridayReadClientError.unexpectedResponse(kind: "RunAnswerBodySnapshot")
+    case .unsupported(let kind):
+      throw FridayReadClientError.unexpectedResponse(kind: kind)
+    }
+  }
+
+  public func fetchRunAnswerBody(runId: String) async throws -> RunAnswerBody {
+    let transport = try makeTransport()
+
+    try transport.writeFrame(keypair.publicKey)
+    let serverPub = try transport.readFrame()
+    guard serverPub.count == FridayCrypto.x25519PublicKeyLen else {
+      throw FridayReadClientError.badServerPubkey
+    }
+    let sessionNonce = try transport.readFrame()
+    guard sessionNonce.count == 64 else {
+      throw FridayReadClientError.badSessionNonce
+    }
+    try transport.upgrade()
+
+    let sessionKey: [UInt8]
+    do {
+      sessionKey = try keypair.agree(peerPublicKey: serverPub)
+    } catch {
+      throw FridayReadClientError.transport("session-key agreement failed: \(error)")
+    }
+
+    let requestId = newRequestId()
+    let authProof = try FridayCrypto.buildAuthProof(
+      sessionKey: sessionKey,
+      sessionNonce: sessionNonce,
+      sessionAad: readSessionAad,
+      authChallenge: readAuthChallenge,
+      forwardedPrincipal: forwardedPrincipal,
+      boundContext: Array(requestId.utf8)
+    )
+    let reqEnvelope = FridayEnvelope(
+      msgId: "msg-\(requestId)",
+      sentAt: now(),
+      message: .runAnswerBodyRequest(RunAnswerBodyRequestWire(
+        runId: runId,
+        forwardedPrincipal: forwardedPrincipal,
+        authProof: authProof,
+        requestId: requestId))
+    )
+    try transport.sendMessage(try sealEnvelope(reqEnvelope, sessionKey: sessionKey))
+
+    let respBody: [UInt8]
+    do {
+      respBody = try transport.recvMessage()
+    } catch {
+      throw FridayReadClientError.transport("no response (session ended fail-closed): \(error)")
+    }
+    let respEnvelope = try openEnvelope(respBody, sessionKey: sessionKey)
+
+    switch respEnvelope.message {
+    case .runAnswerBodySnapshot(let snap):
+      let sealedBytes = try Hex.decode(snap.answerJson)
+      let innerSealed = try FridayCrypto.decodeSealed(sealedBytes)
+      let answerBytes: [UInt8]
+      do {
+        answerBytes = try FridayCrypto.open(key: sessionKey, sealed: innerSealed, aad: readSessionAad)
+      } catch {
+        throw FridayReadClientError.malformedProjection("owner-sealed answer failed to open: \(error)")
+      }
+      return try RunAnswerBody(answerJSON: Data(answerBytes), generatedAtMs: snap.generatedAtMs)
+    case .error(let code, let message):
+      throw FridayReadClientError.serverError(code: code, message: message)
+    case .runAnswerBodyRequest:
+      throw FridayReadClientError.unexpectedResponse(kind: "RunAnswerBodyRequest")
+    case .workbenchProjectionSnapshot:
+      throw FridayReadClientError.unexpectedResponse(kind: "WorkbenchProjectionSnapshot")
+    case .workbenchProjectionRequest:
+      throw FridayReadClientError.unexpectedResponse(kind: "WorkbenchProjectionRequest")
+    case .agentRunRequest:
+      throw FridayReadClientError.unexpectedResponse(kind: "AgentRunRequest")
+    case .agentRunResult:
+      throw FridayReadClientError.unexpectedResponse(kind: "AgentRunResult")
+    case .agentRunPaused:
+      throw FridayReadClientError.unexpectedResponse(kind: "AgentRunPaused")
+    case .agentRunResume:
+      throw FridayReadClientError.unexpectedResponse(kind: "AgentRunResume")
+    case .agentRunControlResult:
+      throw FridayReadClientError.unexpectedResponse(kind: "AgentRunControlResult")
     case .missionIntakeRequest:
       throw FridayReadClientError.unexpectedResponse(kind: "MissionIntakeRequest")
     case .missionIntakeResult:

--- a/apps/macos/FridayRustClient/Sources/FridayRustClient/WriteClient.swift
+++ b/apps/macos/FridayRustClient/Sources/FridayRustClient/WriteClient.swift
@@ -333,6 +333,7 @@ public final class SealedWSWriteClient: FridayRustWriteClient, FridayMissionSpin
       throw FridayWriteClientError.serverError(code: code, message: message)
     case .agentRunRequest, .agentRunResume, .agentRunControlResult,
          .workbenchProjectionRequest, .workbenchProjectionSnapshot,
+         .runAnswerBodyRequest, .runAnswerBodySnapshot,
          .missionIntakeRequest, .missionIntakeResult,
          .memoryDecisionRequest, .memoryDecisionResult,
          .runOutcomeLearningDecisionRequest, .runOutcomeLearningDecisionResult:
@@ -549,6 +550,8 @@ private func dispatchKind(_ message: FridayMessage) -> String {
   switch message {
   case .workbenchProjectionRequest: return "WorkbenchProjectionRequest"
   case .workbenchProjectionSnapshot: return "WorkbenchProjectionSnapshot"
+  case .runAnswerBodyRequest: return "RunAnswerBodyRequest"
+  case .runAnswerBodySnapshot: return "RunAnswerBodySnapshot"
   case .error: return "Error"
   case .agentRunRequest: return "AgentRunRequest"
   case .agentRunResult: return "AgentRunResult"

--- a/apps/macos/FridayRustClient/Sources/FridayRustClient/WriteProtocol.swift
+++ b/apps/macos/FridayRustClient/Sources/FridayRustClient/WriteProtocol.swift
@@ -173,6 +173,49 @@ public struct RunOutcomeLearningDecisionResultWire: Codable, Equatable, Sendable
   }
 }
 
+/// Client→read-server owner-gated answer-body request. This is a READ-seam message, but the shared
+/// wire types live beside the other protocol structs so `FridayMessage` can encode/decode it.
+public struct RunAnswerBodyRequestWire: Codable, Equatable, Sendable {
+  public var runId: String
+  public var forwardedPrincipal: String
+  public var authProof: [UInt8]
+  public var requestId: String
+
+  public init(runId: String, forwardedPrincipal: String, authProof: [UInt8], requestId: String) {
+    self.runId = runId
+    self.forwardedPrincipal = forwardedPrincipal
+    self.authProof = authProof
+    self.requestId = requestId
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case runId = "run_id"
+    case forwardedPrincipal = "forwarded_principal"
+    case authProof = "auth_proof"
+    case requestId = "request_id"
+  }
+}
+
+/// Read-server→client owner-sealed answer-body snapshot. The opened JSON carries an `answer` only
+/// when the authenticated caller owns the run; denied/not-found payloads are body-free.
+public struct RunAnswerBodySnapshotWire: Codable, Equatable, Sendable {
+  public var requestId: String
+  public var answerJson: String
+  public var generatedAtMs: Int64
+
+  public init(requestId: String, answerJson: String, generatedAtMs: Int64) {
+    self.requestId = requestId
+    self.answerJson = answerJson
+    self.generatedAtMs = generatedAtMs
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case requestId = "request_id"
+    case answerJson = "answer_json"
+    case generatedAtMs = "generated_at_ms"
+  }
+}
+
 // MARK: - AgentRunRequestWire
 
 /// First-class Mission handle for a bound agent run. Mirrors

--- a/apps/macos/FridayRustClient/Tests/FridayRustClientTests/ReadClientWiringTests.swift
+++ b/apps/macos/FridayRustClient/Tests/FridayRustClientTests/ReadClientWiringTests.swift
@@ -24,6 +24,7 @@ final class ReadClientWiringTests: XCTestCase {
     private let peerAllowlist: [[UInt8]]
     private let ownerAllowlist: [String]
     private let projectionJSON: [UInt8]
+    private let answerJSON: [UInt8]
 
     // Handshake state.
     private var clientPub: [UInt8]?
@@ -37,12 +38,14 @@ final class ReadClientWiringTests: XCTestCase {
          sessionNonce: [UInt8],
          peerAllowlist: [[UInt8]],
          ownerAllowlist: [String],
-         projectionJSON: [UInt8]) {
+         projectionJSON: [UInt8],
+         answerJSON: [UInt8] = []) {
       self.serverKeypair = serverKeypair
       self.sessionNonce = sessionNonce
       self.peerAllowlist = peerAllowlist
       self.ownerAllowlist = ownerAllowlist
       self.projectionJSON = projectionJSON
+      self.answerJSON = answerJSON
     }
 
     // Phase 1 — preamble. The client writes its pubkey; we (server) reply with our pubkey
@@ -83,17 +86,33 @@ final class ReadClientWiringTests: XCTestCase {
       let envSealed = try FridayCrypto.decodeSealed(body)
       let envPt = try FridayCrypto.open(key: sessionKey, sealed: envSealed, aad: readSessionAad)
       let env = try FridayEnvelope.decodeJSON(Data(envPt))
-      guard case .workbenchProjectionRequest(let req) = env.message else {
-        throw FridayReadClientError.transport("expected a WorkbenchProjectionRequest")
+      let reqPrincipal: String
+      let reqId: String
+      let authProof: [UInt8]
+      enum ResponseKind { case workbench, answerBody(runId: String) }
+      let responseKind: ResponseKind
+      switch env.message {
+      case .workbenchProjectionRequest(let req):
+        reqPrincipal = req.forwardedPrincipal
+        reqId = req.requestId
+        authProof = req.authProof
+        responseKind = .workbench
+      case .runAnswerBodyRequest(let req):
+        reqPrincipal = req.forwardedPrincipal
+        reqId = req.requestId
+        authProof = req.authProof
+        responseKind = .answerBody(runId: req.runId)
+      default:
+        throw FridayReadClientError.transport("expected a read projection request")
       }
 
       // AUTH — the SAME chain `authenticate_forwarded` runs: open the auth_proof under the
       // session key with auth_aad(read_aad, principal, request_id); it must equal the
       // nonce-bound challenge; principal must be on the owner allowlist.
       let reqAad = FridayCrypto.authAad(readSessionAad,
-                                        forwardedPrincipal: req.forwardedPrincipal,
-                                        boundContext: Array(req.requestId.utf8))
-      let proofSealed = try FridayCrypto.decodeSealed(req.authProof)
+                                        forwardedPrincipal: reqPrincipal,
+                                        boundContext: Array(reqId.utf8))
+      let proofSealed = try FridayCrypto.decodeSealed(authProof)
       let openedChallenge: [UInt8]
       do {
         openedChallenge = try FridayCrypto.open(key: sessionKey, sealed: proofSealed, aad: reqAad)
@@ -102,23 +121,58 @@ final class ReadClientWiringTests: XCTestCase {
         return // NO snapshot — session ends fail-closed (the client recv will see EOF).
       }
       let expected = FridayCrypto.nonceBoundChallenge(readAuthChallenge, sessionNonce: sessionNonce)
-      guard openedChallenge == expected, ownerAllowlist.contains(req.forwardedPrincipal) else {
+      guard openedChallenge == expected, ownerAllowlist.contains(reqPrincipal) else {
         endedFailClosed = true
         return // fail-closed: no snapshot.
       }
 
-      // AUTHENTICATED — owner-seal the refs-only projection JSON under the session key, hex
-      // it, and answer with a WorkbenchProjectionSnapshot.
-      let inner = try FridayCrypto.seal(key: sessionKey, plaintext: projectionJSON, aad: readSessionAad)
-      let sealedHex = Hex.encode(FridayCrypto.encodeSealed(inner))
-      let resp = FridayEnvelope(
-        msgId: "read-projection-snapshot-\(req.requestId)",
-        sentAt: 1_780_640_000_000,
-        message: .workbenchProjectionSnapshot(WorkbenchProjectionSnapshotWire(
-          requestId: req.requestId,
-          projectionJson: sealedHex,
+      let responseMessage: FridayMessage
+      let plaintext: [UInt8]
+      switch responseKind {
+      case .workbench:
+        plaintext = projectionJSON
+        responseMessage = .workbenchProjectionSnapshot(WorkbenchProjectionSnapshotWire(
+          requestId: reqId,
+          projectionJson: "",
           generatedAtMs: 1_780_640_000_000
         ))
+      case .answerBody(let runId):
+        if answerJSON.isEmpty {
+          plaintext = Array("""
+          {"truth_label":"rust_wired_owner_gated","ok":true,"outcome":"not_found","run_id":"\(runId)"}
+          """.utf8)
+        } else {
+          plaintext = answerJSON
+        }
+        responseMessage = .runAnswerBodySnapshot(RunAnswerBodySnapshotWire(
+          requestId: reqId,
+          answerJson: "",
+          generatedAtMs: 1_780_640_000_000
+        ))
+      }
+
+      // AUTHENTICATED — owner-seal the projection JSON under the session key, hex it, and answer.
+      let inner = try FridayCrypto.seal(key: sessionKey, plaintext: plaintext, aad: readSessionAad)
+      let sealedHex = Hex.encode(FridayCrypto.encodeSealed(inner))
+      let finalMessage: FridayMessage
+      switch responseMessage {
+      case .workbenchProjectionSnapshot(let snap):
+        finalMessage = .workbenchProjectionSnapshot(WorkbenchProjectionSnapshotWire(
+          requestId: snap.requestId,
+          projectionJson: sealedHex,
+          generatedAtMs: snap.generatedAtMs))
+      case .runAnswerBodySnapshot(let snap):
+        finalMessage = .runAnswerBodySnapshot(RunAnswerBodySnapshotWire(
+          requestId: snap.requestId,
+          answerJson: sealedHex,
+          generatedAtMs: snap.generatedAtMs))
+      default:
+        throw FridayReadClientError.transport("unreachable response kind")
+      }
+      let resp = FridayEnvelope(
+        msgId: "read-projection-snapshot-\(reqId)",
+        sentAt: 1_780_640_000_000,
+        message: finalMessage
       ).withCorrelation(env.msgId)
       let respSealed = try FridayCrypto.seal(key: sessionKey, plaintext: [UInt8](resp.encodeJSON()), aad: readSessionAad)
       queuedFromServer.append(FridayCrypto.encodeSealed(respSealed))
@@ -181,6 +235,42 @@ final class ReadClientWiringTests: XCTestCase {
     let rawStr = String(decoding: raw, as: UTF8.self)
     XCTAssertFalse(rawStr.contains("Authorization"))
     XCTAssertFalse(rawStr.contains("Bearer"))
+  }
+
+  func testFetchRunAnswerBody_happyPath_decodesOwnerSealedAnswer() async throws {
+    let clientKp = try FridayCrypto.DeviceKeypair(secretBytes: try Hex.decode(B1KAT.k1Agree.clientSecret))
+    let serverKp = try FridayCrypto.DeviceKeypair(secretBytes: try Hex.decode(B1KAT.k1Agree.serverSecret))
+    let nonce = try Hex.decode(B1KAT.k3Auth.sessionNonce)
+    let answerJSON = """
+    {"truth_label":"rust_wired_owner_gated","ok":true,"outcome":"delivered","run_id":"run-readable",\
+    "status":"finished","answer":"Friday can now show the owner-gated answer body.",\
+    "answer_sha256":"\(String(repeating: "a", count: 64))","answer_len":50}
+    """
+
+    let transport = EmulatedRustServerTransport(
+      serverKeypair: serverKp,
+      sessionNonce: nonce,
+      peerAllowlist: [clientKp.publicKey],
+      ownerAllowlist: [owner],
+      projectionJSON: Array(Self.refsOnlyProjection.utf8),
+      answerJSON: Array(answerJSON.utf8)
+    )
+    let client = SealedWSReadClient(
+      keypair: clientKp,
+      forwardedPrincipal: owner,
+      makeTransport: { transport },
+      now: { 1000 },
+      newRequestId: { "req-answer-1" }
+    )
+
+    let body = try await client.fetchRunAnswerBody(runId: "run-readable")
+    XCTAssertEqual(body.runId, "run-readable")
+    XCTAssertEqual(body.outcome, "delivered")
+    XCTAssertEqual(body.deliveredAnswer, "Friday can now show the owner-gated answer body.")
+    XCTAssertEqual(body.status, "finished")
+    XCTAssertEqual(body.answerLen, 50)
+    XCTAssertEqual(body.truthLabel, "rust_wired_owner_gated")
+    XCTAssertEqual(transport.processed, 1)
   }
 
   func testFetchWorkbench_mismatchedPrincipal_endsFailClosed() async throws {
@@ -257,5 +347,16 @@ final class ReadClientWiringTests: XCTestCase {
     let json = String(decoding: data, as: UTF8.self)
     XCTAssertFalse(json.contains("mission_id"))
     XCTAssertTrue(json.contains("\"kind\":\"WorkbenchProjectionRequest\""))
+
+    let answerReq = RunAnswerBodyRequestWire(
+      runId: "run-1", forwardedPrincipal: owner, authProof: [4, 5, 6], requestId: "req-answer"
+    )
+    let answerEnv = FridayEnvelope(msgId: "msg-answer", sentAt: 8, message: .runAnswerBodyRequest(answerReq))
+      .withCorrelation("corr-answer")
+    let answerData = try answerEnv.encodeJSON()
+    let answerBack = try FridayEnvelope.decodeJSON(answerData)
+    XCTAssertEqual(answerBack, answerEnv)
+    let answerJson = String(decoding: answerData, as: UTF8.self)
+    XCTAssertTrue(answerJson.contains("\"kind\":\"RunAnswerBodyRequest\""))
   }
 }

--- a/rust-core/crates/friday-ffi/src/lib.rs
+++ b/rust-core/crates/friday-ffi/src/lib.rs
@@ -1972,6 +1972,8 @@ fn message_kind_name(m: &friday_protocol::Message) -> &'static str {
         // but naming them keeps this match exhaustive and carries the real kind in the truth label.
         M::RunReadbackRequest { .. } => "RunReadbackRequest",
         M::RunReadbackSnapshot { .. } => "RunReadbackSnapshot",
+        M::RunAnswerBodyRequest { .. } => "RunAnswerBodyRequest",
+        M::RunAnswerBodySnapshot { .. } => "RunAnswerBodySnapshot",
         M::ProvidersDoctorRequest { .. } => "ProvidersDoctorRequest",
         M::ProvidersDoctorSnapshot { .. } => "ProvidersDoctorSnapshot",
         // C2I-PR2 — the 5 DARK sealed-WS READ-seam owner-gated C2 read-plane kinds. NAMED here for

--- a/rust-core/crates/friday-hub/src/bin/hub_read_projection_server.rs
+++ b/rust-core/crates/friday-hub/src/bin/hub_read_projection_server.rs
@@ -18,14 +18,17 @@
 //!   `claude auth status`) via a [`friday_providers::ProviderProbe`] — never a prompt/send. That is
 //!   still NO model call, NO quota spend, NO credential read, and no network beyond the CLI's own
 //!   local auth check; it surfaces only booleans + a coarse static `detail`, never raw CLI text.
-//! * **Refs-only responses.** Each projection runs the SHARED library fn
+//! * **Refs-only responses, with one explicit answer-body carve-out.** The workbench/readback/
+//!   doctor projections run the SHARED library fn
 //!   ([`friday_hub::workbench_projection::project_workbench`] for S-R1,
 //!   [`friday_hub::run_readback_projection::project_run_readback`] for S-R2,
 //!   [`friday_hub::providers_doctor_projection::project_providers_doctor`] for S-R3), which runs the
 //!   forbidden-output guard INSIDE itself — so the snapshot carries redacted proof refs / counts /
 //!   labels / booleans only, never an inline body or raw CLI text. Truth labels ride as-is (provider
-//!   lanes conservatively `linked_only`, never upgraded); a `503`/unavailable state is surfaced as a
-//!   typed error, never a fabricated success.
+//!   lanes conservatively `linked_only`, never upgraded). S-R2b is deliberately separate: it releases
+//!   an answer body only after the same owner-auth chain passes and storage confirms the caller owns
+//!   the run; denied/not-found S-R2b payloads remain body-free. A `503`/unavailable state is
+//!   surfaced as a typed error, never a fabricated success.
 //! * **Owner-scoped, never client-asserted.** Every read request carries `forwarded_principal` +
 //!   `auth_proof`, verified by the SAME nonce-bound + owner-allowlisted + possession-of-session chain
 //!   a write uses (`authenticate_forwarded`), with the proof bound to the request's `request_id` (the
@@ -78,12 +81,14 @@ use friday_hub::sealed_ws::{
 use friday_hub::workbench_projection::project_workbench;
 use friday_protocol::{
     ActivityNeedsMeSnapshotWire, Envelope, IdempotencyTracker, Message,
-    ProvidersDoctorSnapshotWire, RunFileViewSnapshotWire, RunReadbackSnapshotWire, Seen,
-    SessionLinkStateSnapshotWire, SessionListSnapshotWire, SessionOpenSnapshotWire,
-    WorkbenchProjectionSnapshotWire,
+    ProvidersDoctorSnapshotWire, RunAnswerBodySnapshotWire, RunFileViewSnapshotWire,
+    RunReadbackSnapshotWire, Seen, SessionLinkStateSnapshotWire, SessionListSnapshotWire,
+    SessionOpenSnapshotWire, WorkbenchProjectionSnapshotWire,
 };
 use friday_providers::{CliProbe, ProviderProbe};
-use friday_storage::{Db, StorageError};
+use friday_storage::{
+    get_run_answer_for_principal, AnswerDenyReason, Db, RunAnswerAccess, StorageError,
+};
 use friday_transport::{ws_recv_envelope, ws_send_envelope, TransportError, WireWebSocket};
 
 /// The session AAD binding every sealed envelope on a READ session to this protocol/version. A
@@ -408,6 +413,38 @@ fn serve_read_session<S: Read + Write>(
                         snapshot: RunReadbackSnapshotWire {
                             request_id: request_id.clone(),
                             projection_json: sealed_hex,
+                            generated_at_ms: now_ms,
+                        },
+                    },
+                )?
+            }
+            Message::RunAnswerBodyRequest { request } => {
+                // Auth-before-body. This is the deliberate body-bearing sibling of RunReadback:
+                // authenticate the caller first, then release the answer only through the storage
+                // owner gate. Non-owner/unknown-run responses are body-free and owner-free.
+                let caller = match authenticate_read_request(
+                    session_key,
+                    session_nonce,
+                    &request.auth_proof,
+                    &request.forwarded_principal,
+                    &request.request_id,
+                    owner_allowlist,
+                ) {
+                    Some(caller) => caller,
+                    None => return Ok(processed),
+                };
+                let request_id = request.request_id.clone();
+                let projection = project_run_answer_body(db, caller.principal(), &request.run_id);
+                seal_and_frame(
+                    session_key,
+                    &env.msg_id,
+                    &request_id,
+                    now_ms,
+                    projection,
+                    |sealed_hex| Message::RunAnswerBodySnapshot {
+                        snapshot: RunAnswerBodySnapshotWire {
+                            request_id: request_id.clone(),
+                            answer_json: sealed_hex,
                             generated_at_ms: now_ms,
                         },
                     },
@@ -825,6 +862,48 @@ fn seal_and_frame(
     Ok(envelope)
 }
 
+fn project_run_answer_body(
+    db: &Db,
+    caller_principal: &str,
+    run_id: &str,
+) -> Result<serde_json::Value, String> {
+    match get_run_answer_for_principal(db.conn(), run_id, caller_principal)
+        .map_err(|_| "run_answer_read_failed".to_string())?
+    {
+        RunAnswerAccess::Granted(stored) => Ok(serde_json::json!({
+            "truth_label": "rust_wired_owner_gated",
+            "ok": true,
+            "outcome": "delivered",
+            "run_id": run_id,
+            "status": stored.status,
+            "answer": stored.answer,
+            "answer_sha256": stored.answer_sha256,
+            "answer_len": stored.answer_len,
+        })),
+        RunAnswerAccess::Denied(reason) => Ok(serde_json::json!({
+            "truth_label": "rust_wired_owner_gated",
+            "ok": true,
+            "outcome": "denied",
+            "run_id": run_id,
+            "deny_reason": answer_deny_reason_label(reason),
+        })),
+        RunAnswerAccess::NotFound => Ok(serde_json::json!({
+            "truth_label": "rust_wired_owner_gated",
+            "ok": true,
+            "outcome": "not_found",
+            "run_id": run_id,
+        })),
+    }
+}
+
+fn answer_deny_reason_label(reason: AnswerDenyReason) -> &'static str {
+    match reason {
+        AnswerDenyReason::NoOwnerPrincipal => "no_owner_principal",
+        AnswerDenyReason::AnonymousCaller => "anonymous_caller",
+        AnswerDenyReason::PrincipalMismatch => "principal_mismatch",
+    }
+}
+
 /// The current wall-clock in epoch-millis (best-effort; 0 on a pre-epoch clock).
 fn now_ms() -> i64 {
     SystemTime::now()
@@ -883,7 +962,8 @@ mod tests {
     use friday_hub::hub_server::{auth_aad, nonce_bound_challenge};
     use friday_hub::sealed_ws::encode_sealed_proof;
     use friday_protocol::{
-        ProvidersDoctorRequestWire, RunReadbackRequestWire, WorkbenchProjectionRequestWire,
+        ProvidersDoctorRequestWire, RunAnswerBodyRequestWire, RunReadbackRequestWire,
+        WorkbenchProjectionRequestWire,
     };
     use friday_providers::{ProbeOutput, Provider, ProviderError};
     use friday_transport::{read_frame, write_frame, ws_connect};
@@ -1637,6 +1717,65 @@ mod tests {
         assert!(
             !json.contains("Authorization") && !json.contains("Bearer") && !json.contains("sk-"),
             "refs-only: no secret markers"
+        );
+        drop(ws);
+        let processed = server.join().unwrap();
+        assert_eq!(processed, 1);
+    }
+
+    /// KAT (S-R2b) — the answer-body projection round-trips through the read server: handshake →
+    /// owner auth → storage owner gate → owner-sealed body snapshot. This is the deliberate
+    /// body-bearing sibling of run-readback; the body reaches only the verified run owner.
+    #[test]
+    fn run_answer_body_round_trips_through_the_read_server_for_owner() {
+        let db_path = seed_run_db("r2b-answer");
+        let server_kp = DeviceKeypair::generate();
+        let client_kp = DeviceKeypair::from_secret_bytes(CLIENT_SECRET);
+        let peer_allowlist = vec![client_kp.public_bytes()];
+        let owner_allowlist = vec![OWNER.to_string()];
+
+        let listener = ReadWsListener::bind_loopback(0).unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        let server = thread::spawn(move || {
+            let db = Db::open_hub_readonly(&db_path).unwrap();
+            let probe = null_probe();
+            listener
+                .accept_one(&server_kp, &db, &probe, &owner_allowlist, &peer_allowlist)
+                .unwrap()
+        });
+
+        let (mut ws, session_key, session_nonce) = client_handshake(addr, &client_kp);
+        let request_id = "req-r2b-answer-1";
+        let req = Envelope::new(
+            "msg-r2b-answer-1",
+            1000,
+            Message::RunAnswerBodyRequest {
+                request: RunAnswerBodyRequestWire {
+                    run_id: "run_read_seam_probe".to_string(),
+                    forwarded_principal: OWNER.to_string(),
+                    auth_proof: read_auth_proof(&session_key, &session_nonce, OWNER, request_id),
+                    request_id: request_id.to_string(),
+                },
+            },
+        );
+        ws_send_envelope(&mut ws, &session_key, &req, SESSION_AAD).unwrap();
+
+        let resp = ws_recv_envelope(&mut ws, &session_key, SESSION_AAD).unwrap();
+        let Message::RunAnswerBodySnapshot { snapshot } = resp.message else {
+            panic!("expected a RunAnswerBodySnapshot, got a different/typed-error frame");
+        };
+        assert_eq!(snapshot.request_id, request_id);
+        let sealed_bytes = hex_decode(&snapshot.answer_json);
+        let opened = crypto_open(&session_key, &decode_sealed(&sealed_bytes), SESSION_AAD).unwrap();
+        let json = String::from_utf8(opened).unwrap();
+        assert!(json.contains("\"outcome\":\"delivered\""));
+        assert!(json.contains("\"run_id\":\"run_read_seam_probe\""));
+        assert!(json.contains("\"truth_label\":\"rust_wired_owner_gated\""));
+        assert!(json.contains("owner-only run answer body that must never leak"));
+        assert!(
+            !json.contains("raw run task body"),
+            "task body must never ride answer readback"
         );
         drop(ws);
         let processed = server.join().unwrap();

--- a/rust-core/crates/friday-protocol/src/lib.rs
+++ b/rust-core/crates/friday-protocol/src/lib.rs
@@ -1079,6 +1079,28 @@ pub struct RunReadbackSnapshotWire {
     pub generated_at_ms: i64,
 }
 
+/// **S-R2b** — client->read-server request for the owner-gated run ANSWER BODY over the sealed-WS
+/// READ seam. This is deliberately separate from [`RunReadbackRequestWire`]: run-readback remains
+/// refs-only, while this path releases the body only after the same owner-auth chain succeeds and
+/// storage confirms the caller owns the run.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RunAnswerBodyRequestWire {
+    pub run_id: String,
+    pub forwarded_principal: String,
+    pub auth_proof: Vec<u8>,
+    pub request_id: String,
+}
+
+/// **S-R2b** — read-server->client owner-sealed run answer body snapshot. The `answer_json` field is
+/// the owner-sealed JSON payload. On the delivered path that opened payload includes the answer body;
+/// denied/not-found payloads are body-free.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RunAnswerBodySnapshotWire {
+    pub request_id: String,
+    pub answer_json: String,
+    pub generated_at_ms: i64,
+}
+
 /// **S-R3** — client→read-server request for the providers-doctor read projection over the DARK
 /// sealed-WS READ seam. The sibling of [`WorkbenchProjectionRequestWire`]: a PURE READ that runs
 /// the SAME owner-auth chain. Unlike the workbench/run-readback reads, the providers-doctor does NOT
@@ -1457,6 +1479,13 @@ pub enum Message {
     /// (state/loop-status/event-kinds/counts + DB-WIDE token totals labelled as such, never run
     /// cost). The shared projection fn ran the forbidden-output guard; truth labels never upgraded.
     RunReadbackSnapshot { snapshot: RunReadbackSnapshotWire },
+    /// **S-R2b** — UI→DARK read-server: request the OWNER-GATED run answer body over the sealed-WS
+    /// READ seam. PURE READ — no model/provider call. This is the body-bearing sibling of
+    /// RunReadback, kept separate so refs-only projections stay refs-only.
+    RunAnswerBodyRequest { request: RunAnswerBodyRequestWire },
+    /// **S-R2b** — DARK read-server→UI: owner-sealed answer-body snapshot. The opened payload
+    /// carries the answer only on the delivered path; denied/not-found paths stay body-free.
+    RunAnswerBodySnapshot { snapshot: RunAnswerBodySnapshotWire },
     /// **S-R3** — UI→DARK read-server: request the providers-doctor read projection over the
     /// sealed-WS READ seam. PURE READ — runs each provider CLI's read-only status command only (no
     /// prompt/send, no model call, no quota). Owner-scoped + DARK.
@@ -2296,6 +2325,21 @@ mod tests {
                     state: "confirmed".into(),
                     status: "confirmed".into(),
                     blocker: None,
+                },
+            },
+            Message::RunAnswerBodyRequest {
+                request: RunAnswerBodyRequestWire {
+                    run_id: "run-readable".into(),
+                    forwarded_principal: "owner-1".into(),
+                    auth_proof: vec![1, 2, 3],
+                    request_id: "req-r2b".into(),
+                },
+            },
+            Message::RunAnswerBodySnapshot {
+                snapshot: RunAnswerBodySnapshotWire {
+                    request_id: "req-r2b".into(),
+                    answer_json: "c0ffee".into(),
+                    generated_at_ms: 1_700_000_000_011,
                 },
             },
         ];


### PR DESCRIPTION
## Summary
- add a separate owner-gated RunAnswerBody read message and read-server arm so refs-only readback stays refs-only
- teach the Swift read client to fetch owner-sealed answer JSON and show delivered bodies in iOS chat
- cover the new read path with Rust read-server KATs plus Swift client/view-model tests

## Validation
- cargo fmt --all -- --check
- cargo test -p friday-protocol
- cargo test -p friday-hub --bin hub_read_projection_server
- swift test --package-path apps/macos/FridayRustClient
- swift test --package-path apps/friday-ios
- swift build --package-path apps/friday-ios
- git diff --check

Truth: mechanism/UI wiring only; not true-device pairing, not physical-hand OG9, not D20/B4 true signature, not goal done.