### PR TITLE
Show owner-gated answer bodies in desktop operations

### DIFF
--- a/apps/macos/FridayHubConsole/Sources/FridayHubConsole/OperationsOverviewScreen.swift
+++ b/apps/macos/FridayHubConsole/Sources/FridayHubConsole/OperationsOverviewScreen.swift
@@ -4,7 +4,7 @@ import SwiftUI
 /// The center pane: Operations Overview — a READ-ONLY typed projection of hub truth.
 ///
 /// Truth rules enforced here:
-///  - refs only (ledger/result/activity refs shown, never inline bodies),
+///  - projection refs only; answer text appears only via the owner-gated answer-body readback arm,
 ///  - 503 / stale / offline render AS truth (honest unavailable banner/state),
 ///  - the only actions are RefreshStatus and OpenEvidence-class selection,
 ///  - NO mutating action, NO provider-admin exec, NO NO-GO row made executable.
@@ -148,7 +148,7 @@ struct OperationsOverviewScreen: View {
             || intentDraft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
       }
       WriteActionStateView(state: viewModel.intakeState, pendingText: "Submitting intake…")
-      Text("Births a Mission + WorkItem(Draft) through the Rust spine — no model call.")
+      Text("Births a Mission + WorkItem(Draft), then dispatches the governed model run when configured.")
         .font(.system(size: 10))
         .foregroundStyle(HubTheme.textSecondary)
     }
@@ -396,7 +396,7 @@ struct WriteActionStateView: View {
           .font(.system(size: 11))
           .foregroundStyle(HubTheme.textSecondary)
       }
-    case let .confirmed(summary, clarificationQuestions):
+    case let .confirmed(summary, clarificationQuestions, answerBody):
       VStack(alignment: .leading, spacing: 4) {
         HStack(spacing: 8) {
           StatusChip(
@@ -412,6 +412,16 @@ struct WriteActionStateView: View {
           Text("• \(question)")
             .font(.system(size: 11))
             .foregroundStyle(HubTheme.textPrimary)
+        }
+        if let answerBody,
+          !answerBody.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        {
+          Text(answerBody)
+            .font(.system(size: 12))
+            .foregroundStyle(HubTheme.textPrimary)
+            .textSelection(.enabled)
+            .fixedSize(horizontal: false, vertical: true)
+            .padding(.top, 2)
         }
       }
     case let .error(reason):

--- a/apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/OperationsOverviewViewModel.swift
+++ b/apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/OperationsOverviewViewModel.swift
@@ -42,9 +42,10 @@ public enum WriteActionState: Sendable, Equatable {
   case ready
   /// The request is in flight (handshake + sealed send + awaiting the refs-only receipt).
   case sent
-  /// A terminal SUCCESS receipt. `summary` is a coarse refs-only line (status + ids + recallable);
+  /// A terminal SUCCESS receipt. `summary` is a coarse line (status + ids + recallable);
+  /// `answerBody` is populated only by the explicit owner-gated answer-body readback arm.
   /// `clarificationQuestions` is non-empty ONLY for a `needs_clarification` intake.
-  case confirmed(summary: String, clarificationQuestions: [String] = [])
+  case confirmed(summary: String, clarificationQuestions: [String] = [], answerBody: String? = nil)
   /// A terminal FAILURE rendered AS truth — a transport/honest-unavailable error, a typed server
   /// Error, OR a server `status:"blocked"` receipt (e.g. the synthetic-candidate-id block). Never a
   /// fabricated success.
@@ -176,6 +177,7 @@ public final class OperationsOverviewViewModel: ObservableObject {
       default:
         // ready / created_or_ready
         var summary = "Mission intake \(result.status) · mission_id=\(result.missionId)"
+        var answerBodies: [String] = []
         if let workItemId = result.workItemId { summary += " · work_item_id=\(workItemId)" }
         if let workItemId = result.workItemId, let missionRunClient {
           let context = MissionWorkItemContextWire(
@@ -188,14 +190,23 @@ public final class OperationsOverviewViewModel: ObservableObject {
               missionContext: context,
               constraints: AgentRunConstraintsWire(readOnly: true))
             summary += Self.dispatchSummary(for: outcome)
+            if let answerBody = await answerBodyText(for: outcome, label: "Codex") {
+              answerBodies.append(answerBody)
+            }
             if let followUpSummary = try await dispatchClaudeFollowUpIfPresent(
               sourceWorkItemId: workItemId,
               intakeResult: result,
               missionRunClient: missionRunClient)
             {
-              summary += followUpSummary
+              summary += followUpSummary.summary
+              if let answerBody = await answerBodyText(for: followUpSummary.outcome, label: "Claude follow-up") {
+                answerBodies.append(answerBody)
+              }
             }
-            intakeState = .confirmed(summary: summary, clarificationQuestions: result.clarificationQuestions)
+            intakeState = .confirmed(
+              summary: summary,
+              clarificationQuestions: result.clarificationQuestions,
+              answerBody: Self.joinAnswerBodies(answerBodies))
           } catch {
             intakeState = .error(
               reason: "Mission intake ready, but model dispatch failed — \(Self.writeReason(for: error))")
@@ -214,7 +225,7 @@ public final class OperationsOverviewViewModel: ObservableObject {
     sourceWorkItemId: String,
     intakeResult: MissionIntakeResultWire,
     missionRunClient: FridayMissionBoundRunWriteClient
-  ) async throws -> String? {
+  ) async throws -> FollowUpDispatch? {
     let followUpWorkItemId = "\(sourceWorkItemId)-claude-followup"
     let wire = try await client.fetchWorkbench()
     let snapshot = try WorkbenchSnapshotAdapter.display(from: wire)
@@ -231,7 +242,35 @@ public final class OperationsOverviewViewModel: ObservableObject {
         missionId: intakeResult.missionId,
         workItemId: followUpWorkItemId),
       constraints: AgentRunConstraintsWire(readOnly: true))
-    return " · follow_up_work_item_id=\(followUpWorkItemId)" + Self.dispatchSummary(for: outcome)
+    return FollowUpDispatch(
+      summary: " · follow_up_work_item_id=\(followUpWorkItemId)" + Self.dispatchSummary(for: outcome),
+      outcome: outcome)
+  }
+
+  private struct FollowUpDispatch {
+    let summary: String
+    let outcome: AgentRunDispatchOutcome
+  }
+
+  private func answerBodyText(for outcome: AgentRunDispatchOutcome, label: String) async -> String? {
+    guard case let .result(result) = outcome else { return nil }
+    do {
+      let body = try await client.fetchRunAnswerBody(runId: result.runId)
+      if let answer = body.deliveredAnswer?.trimmingCharacters(in: .whitespacesAndNewlines),
+        !answer.isEmpty
+      {
+        return "\(label): \(answer)"
+      }
+      let reason = body.denyReason ?? body.status ?? body.outcome
+      return "\(label): answer body unavailable (\(reason))"
+    } catch {
+      return "\(label): answer body unavailable (\(Self.reason(for: error)))"
+    }
+  }
+
+  private static func joinAnswerBodies(_ answerBodies: [String]) -> String? {
+    let nonEmpty = answerBodies.filter { !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
+    return nonEmpty.isEmpty ? nil : nonEmpty.joined(separator: "\n\n")
   }
 
   /// Submit ONE owner confirm/reject for a memory candidate over the sealed WRITE seam, keyed by the

--- a/apps/macos/FridayHubConsole/Tests/FridayHubConsoleCoreTests/LiveMissionSpineWriteDispatchIntegrationTests.swift
+++ b/apps/macos/FridayHubConsole/Tests/FridayHubConsoleCoreTests/LiveMissionSpineWriteDispatchIntegrationTests.swift
@@ -287,7 +287,7 @@ func liveOperationsOverviewSubmitIntakeAutoDispatchesHybridClaudeFollowUp() asyn
       + "then summarize that the product Operations view should automatically run the generated "
       + "Claude follow-up after the Codex first leg. Answer exactly FRIDAY_PRODUCT_AUTO_FOLLOWUP_OK.")
 
-  guard case let .confirmed(summary, _) = vm.intakeState else {
+  guard case let .confirmed(summary, _, _) = vm.intakeState else {
     Issue.record("expected product auto follow-up to confirm, got \(String(describing: vm.intakeState))")
     return
   }

--- a/apps/macos/FridayHubConsole/Tests/FridayHubConsoleCoreTests/OperationsOverviewViewModelTests.swift
+++ b/apps/macos/FridayHubConsole/Tests/FridayHubConsoleCoreTests/OperationsOverviewViewModelTests.swift
@@ -390,10 +390,27 @@ final class MockMissionSpineWriteClient: FridayMissionSpineWriteClient, FridayMi
 
 struct StaticWorkbenchReadClient: FridayRustReadClient {
   let snapshot: FridayHubConsoleCore.WorkbenchSnapshot
+  var answerBodies: [String: String] = [:]
 
   func fetchWorkbench() async throws -> FridayRustClient.WorkbenchSnapshot {
     let json = try JSONEncoder().encode(snapshot)
     return try FridayRustClient.WorkbenchSnapshot(projectionJSON: json, generatedAtMs: 0)
+  }
+
+  func fetchRunAnswerBody(runId: String) async throws -> RunAnswerBody {
+    guard let answer = answerBodies[runId] else {
+      throw FridayReadClientError.transport("run answer body unavailable")
+    }
+    let data = """
+      {
+        "run_id": "\(runId)",
+        "outcome": "delivered",
+        "status": "finished",
+        "answer": "\(answer)",
+        "truth_label": "owner_gated_answer_body"
+      }
+      """.data(using: .utf8)!
+    return try RunAnswerBody(answerJSON: data, generatedAtMs: 1)
   }
 }
 
@@ -440,7 +457,7 @@ func submitIntakeReadyRendersConfirmedAndWiresOwnerAdmin001() async {
     writeOwnerPrincipal: "admin-001", newId: { "fixed" })
   await vm.submitIntake(intent: "keep one Mission across every surface")
 
-  guard case let .confirmed(summary, questions) = vm.intakeState else {
+  guard case let .confirmed(summary, questions, _) = vm.intakeState else {
     Issue.record("expected .confirmed, got \(vm.intakeState)")
     return
   }
@@ -462,7 +479,7 @@ func submitIntakeReadyDispatchesMissionBoundModelTurnWhenRunClientConfigured() a
     writeOwnerPrincipal: "admin-001", newId: { "fixed" })
   await vm.submitIntake(intent: "keep one Mission across every surface")
 
-  guard case let .confirmed(summary, _) = vm.intakeState else {
+  guard case let .confirmed(summary, _, _) = vm.intakeState else {
     Issue.record("expected .confirmed, got \(String(describing: vm.intakeState))")
     return
   }
@@ -490,7 +507,7 @@ func submitIntakeDispatchesClaudeFollowUpWhenProjectionExposesGeneratedWorkItem(
 
   await vm.submitIntake(intent: "route through Codex first and Claude follow-up")
 
-  guard case let .confirmed(summary, _) = vm.intakeState else {
+  guard case let .confirmed(summary, _, _) = vm.intakeState else {
     Issue.record("expected .confirmed, got \(vm.intakeState)")
     return
   }
@@ -502,12 +519,37 @@ func submitIntakeDispatchesClaudeFollowUpWhenProjectionExposesGeneratedWorkItem(
 
 @Test
 @MainActor
+func submitIntakeDisplaysOwnerGatedRunAnswerBodyWhenDelivered() async {
+  let write = MockMissionSpineWriteClient(behavior: .intakeReady)
+  let read = StaticWorkbenchReadClient(
+    snapshot: snapshotWithWorkItems(
+      missionId: "mission-desktop-fixed",
+      fridayConversationId: "fconv_desktop_fixed",
+      workItemIds: ["work-desktop-fixed"]),
+    answerBodies: ["run-bound-1": "Readable desktop answer body"])
+  let vm = OperationsOverviewViewModel(
+    client: read, writeClient: write, missionRunClient: write,
+    writeOwnerPrincipal: "admin-001", newId: { "fixed" })
+
+  await vm.submitIntake(intent: "show the actual answer in desktop")
+
+  guard case let .confirmed(summary, _, answerBody) = vm.intakeState else {
+    Issue.record("expected .confirmed, got \(vm.intakeState)")
+    return
+  }
+  #expect(summary.contains("run_id=run-bound-1"))
+  #expect(answerBody?.contains("Readable desktop answer body") == true)
+  #expect(answerBody?.contains("Codex:") == true)
+}
+
+@Test
+@MainActor
 func submitIntakeNeedsClarificationCarriesQuestionsHonestly() async {
   let vm = OperationsOverviewViewModel(
     client: MockReadClient(behavior: .loaded),
     writeClient: MockMissionSpineWriteClient(behavior: .intakeNeedsClarification))
   await vm.submitIntake(intent: "do the thing")
-  guard case let .confirmed(_, questions) = vm.intakeState else {
+  guard case let .confirmed(_, questions, _) = vm.intakeState else {
     Issue.record("expected .confirmed (with questions), got \(vm.intakeState)")
     return
   }
@@ -575,7 +617,7 @@ func decideMemoryConfirmRendersConfirmedRecallable() async {
   let vm = OperationsOverviewViewModel(
     client: MockReadClient(behavior: .loaded), writeClient: write, writeOwnerPrincipal: "admin-001")
   await vm.decideMemory(candidateId: "cand-1", memoryId: "mem-1", confirm: true)
-  guard case let .confirmed(summary, _) = vm.memoryDecisionStates["cand-1"] else {
+  guard case let .confirmed(summary, _, _) = vm.memoryDecisionStates["cand-1"] else {
     Issue.record("expected .confirmed, got \(String(describing: vm.memoryDecisionStates["cand-1"]))")
     return
   }
@@ -609,7 +651,7 @@ func decideRunOutcomeLearningConfirmRendersConfirmedAndWiresCandidate() async {
   let vm = OperationsOverviewViewModel(client: MockReadClient(behavior: .loaded), writeClient: write)
   await vm.decideRunOutcomeLearning(candidateId: "a1:run-a1:preference", confirm: true)
 
-  guard case let .confirmed(summary, questions) =
+  guard case let .confirmed(summary, questions, _) =
     vm.runOutcomeLearningDecisionStates["a1:run-a1:preference"] else {
     Issue.record("expected .confirmed, got \(String(describing: vm.runOutcomeLearningDecisionStates["a1:run-a1:preference"]))")
     return


### PR DESCRIPTION
## Summary
- extend desktop Operations write-state rendering with an explicit owner-gated answer body field
- fetch run answer bodies after governed mission-bound dispatch and Claude follow-up dispatch
- add a desktop view-model test proving delivered body text is shown from the answer-body readback arm

## Validation
- swift test --package-path apps/macos/FridayHubConsole
- swift build --package-path apps/macos/FridayHubConsole
- git diff --check

## Truth labels
- Stacked on #916 / codex/answer-readback-ui-20260619 for early CI only; retarget/rebase to main after #916 lands.
- Mechanism/UI wiring only: not true-device UI, not physical-hand OG9, not D20/B4 true signature, not goal done.