### PR TITLE
Cover mission WorkItem-status dispatch flag

### DIFF
--- a/docs/ops/prod-flag-test-gate.md
+++ b/docs/ops/prod-flag-test-gate.md
@@ -79,9 +79,11 @@ restarts. A flag silently dropped on restart re-creates the inert-loop disaster
 2. **Close the `destination-only` gaps.** Add PR-CI tests that drive flag-ON TS routing →
    real Rust → loop-closed (today's coverage is mocked-unit + live-gated). When such a
    test lands, flip the flag's `coverage` to `loop-e2e`.
-3. **WorkItem-status dispatch arm.** `FRIDAY_MISSION_SPINE_DISPATCH` covers both the
-   Mission-lifecycle and WorkItem-status dispatch arms; the manifest maps it to the
-   Mission-lifecycle loop test. Add an equal-strength WorkItem-status dispatch test.
+3. **Closed 2026-06-19: WorkItem-status dispatch arm.** `FRIDAY_MISSION_SPINE_DISPATCH`
+   now maps to the Mission-lifecycle loop test plus an enforced
+   `additional_e2e_tests` WorkItem-status producer test; the WorkItem-status test
+   drives the same `work_item_status_result_for_db` path used by the flag-ON binary
+   arm, asserts audit+state write, zero token ledger rows, and MissionTimeline readback.
 4. **`deployment_critical.flags` ↔ `prod_state=on` cross-check.** The gate does not yet
    assert the `deployment_critical.flags` list equals the set of `prod_state=on` entries;
    a future editor could desync them. A one-line addition to the gate would harden this.

--- a/docs/ops/prod-flags-manifest.json
+++ b/docs/ops/prod-flags-manifest.json
@@ -41,7 +41,10 @@
       "closes_loop": "Mission/WorkItem lifecycle requests transition the Hub state machine (no model call).",
       "coverage": "loop-e2e",
       "e2e_test": "rust-core/crates/friday-hub/src/hub_server.rs::mission_lifecycle_request_updates_mission_without_provider_call",
-      "notes": "Drives HubServer::dispatch with a MissionLifecycleRequest through the SAME mission_lifecycle_result producer the flag-ON binary arm invokes; asserts active->archived transition, zero provider/model calls, zero token_ledger rows, then reads it back via MissionTimelineRequest. JUDGMENT: the WorkItem-status arm (work_item_status_result_for_db) shares this flag but has no by-name dispatch test of equal strength — sub-coverage gap noted in the report (the mission-lifecycle arm is the loop closure for the flag)."
+      "additional_e2e_tests": [
+        "rust-core/crates/friday-hub/src/hub_server.rs::work_item_status_dispatch_arm_updates_timeline_without_provider_call"
+      ],
+      "notes": "Primary manifest anchor drives HubServer::dispatch with a MissionLifecycleRequest through the SAME mission_lifecycle_result producer the flag-ON binary arm invokes; asserts active->archived transition, zero provider/model calls, zero token_ledger rows, then reads it back via MissionTimelineRequest. Additional enforced coverage drives the WorkItem-status flag-ON producer work_item_status_result_for_db through ready_to_dispatch->dispatched, asserts audit+state write, zero token_ledger rows, then reads the dispatched WorkItem back via MissionTimelineRequest."
     },
     {
       "flag": "FRIDAY_MISSION_BOUND_RUN",

--- a/rust-core/crates/friday-hub/src/hub_server.rs
+++ b/rust-core/crates/friday-hub/src/hub_server.rs
@@ -6310,6 +6310,86 @@ mod tests {
     }
 
     #[test]
+    fn work_item_status_dispatch_arm_updates_timeline_without_provider_call() {
+        let db_path = tmp_db();
+        let calls = Arc::new(AtomicUsize::new(0));
+        let db = Db::open_hub(&db_path).unwrap();
+        seed_mission_ask(&db);
+
+        let audit_before = db.count("audit_ledger").unwrap();
+        let response = work_item_status_result_for_db(
+            &db,
+            "workitem-dispatch-arm",
+            WorkItemStatusRequestWire {
+                work_item_id: "work-hub-ask".into(),
+                target_status: "dispatched".into(),
+                actor_ref: "system:mission-spine-dispatch".into(),
+                reason: "dispatch ready WorkItem through the mission spine".into(),
+                proof_receipt: None,
+            },
+            Some("owner-1"),
+            1_700_000_100_700,
+        );
+        let Message::WorkItemStatusResult { result } = response.message else {
+            panic!("expected WorkItem status result, got {response:?}");
+        };
+        assert_eq!(result.work_item_id, "work-hub-ask");
+        assert_eq!(result.mission_id, "mission-hub-ask");
+        assert_eq!(result.previous_status, "ready_to_dispatch");
+        assert_eq!(result.status, "dispatched");
+        assert_eq!(result.actor_ref, "system:mission-spine-dispatch");
+        assert_eq!(
+            result.reason,
+            "dispatch ready WorkItem through the mission spine"
+        );
+        assert_eq!(result.proof_receipt_count, 0);
+        assert_eq!(result.updated_at_ms, 1_700_000_100_700);
+
+        let stored = db.get_work_item("work-hub-ask").unwrap().unwrap();
+        assert_eq!(stored.status, WorkItemStatus::Dispatched);
+        assert_eq!(db.count("audit_ledger").unwrap(), audit_before + 1);
+        assert_eq!(db.count("token_ledger").unwrap(), 0);
+
+        let client = DeepSeekClient::with_transport(
+            CountingMock {
+                calls: calls.clone(),
+            },
+            "test-key-not-real".to_string(), // pragma: allowlist secret
+        );
+        let mut hub = HubServer::new(db, client, vec!["mission_timeline".into()], 64);
+        let timeline = hub.dispatch(
+            Envelope::new(
+                "workitem-dispatch-arm-timeline",
+                2,
+                Message::MissionTimelineRequest {
+                    request: friday_protocol::MissionTimelineRequestWire {
+                        friday_conversation_id: "fconv_hub_ask".into(),
+                        mission_id: "mission-hub-ask".into(),
+                        cursor: None,
+                        limit: None,
+                    },
+                },
+            ),
+            1_700_000_100_710,
+        );
+        let Message::MissionTimelineSnapshot { snapshot } = timeline.message else {
+            panic!("expected mission timeline snapshot, got {timeline:?}");
+        };
+        let item = snapshot
+            .work_items
+            .iter()
+            .find(|item| item.work_item_id == "work-hub-ask")
+            .expect("timeline should include dispatched WorkItem");
+        assert_eq!(item.status, "dispatched");
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            0,
+            "WorkItem status dispatch/readback must not call a provider/model"
+        );
+        assert_eq!(hub.db().count("token_ledger").unwrap(), 0);
+    }
+
+    #[test]
     fn mission_bound_ask_pressure_loop_paginates_and_preserves_memory_boundary() {
         const ASK_COUNT: usize = 25;
         let db_path = tmp_db();

--- a/scripts/ci/verify-prod-flag-tests.mjs
+++ b/scripts/ci/verify-prod-flag-tests.mjs
@@ -12,9 +12,10 @@
  *   1. The manifest is well-formed JSON with the required shape.
  *   2. Every flag with prod_state in (on, dark) names an e2e_test of the form
  *      "<relative/file/path>::<test_fn_name>".
- *   3. The named test file EXISTS and contains the named test function
+ *   3. Any additional_e2e_tests entries use the same form.
+ *   4. The named test file EXISTS and contains the named test function
  *      (Rust:  `fn <name>`  ·  vitest/TS:  `it("<name>"...)` or `test("<name>"...)`).
- *   4. No duplicate flag entries; coverage is a known value.
+ *   5. No duplicate flag entries; coverage is a known value.
  *
  * It FAILS (exit 1), naming the offending flag, on any missing/unmapped/unresolvable
  * test. It does NOT verify the live wrapper/plist actually sets these flags — that
@@ -96,6 +97,41 @@ function escapeRe(s) {
   return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
+async function checkTestRef(label, prodState, ref, fieldName) {
+  const parsed = parseTestRef(ref);
+  if (!parsed) {
+    fail(
+      `${label} (prod_state=${prodState}): "${fieldName}" is missing or not of the form ` +
+        `"<file/path>::<test_fn_name>" (got ${JSON.stringify(ref)}). ` +
+        `A prod-${prodState} flag MUST name a loop-closing test — this is the registry-#27 gap.`
+    );
+    return;
+  }
+
+  const absFile = join(REPO_ROOT, parsed.file);
+  try {
+    await access(absFile, constants.R_OK);
+  } catch {
+    fail(
+      `${label} (prod_state=${prodState}): mapped test FILE does not exist: ${parsed.file} ` +
+        `(referenced by ${fieldName} ${JSON.stringify(ref)})`
+    );
+    return;
+  }
+
+  const content = await readFile(absFile, "utf-8");
+  if (!fileDeclaresTest(content, parsed.fn)) {
+    fail(
+      `${label} (prod_state=${prodState}): mapped test FUNCTION "${parsed.fn}" not found in ${parsed.file}. ` +
+        `Expected a Rust \`fn ${parsed.fn}(\` or a vitest it/test("${parsed.fn}"). ` +
+        `If the test was renamed/removed, update the manifest — a prod-${prodState} flag may not be left without a loop test.`
+    );
+    return;
+  }
+
+  ok(`${label} (${prodState}, ${fieldName}) -> ${parsed.file}::${parsed.fn}`);
+}
+
 for (let i = 0; i < manifest.flags.length; i++) {
   const entry = manifest.flags[i];
   const label = entry && entry.flag ? entry.flag : `flags[${i}]`;
@@ -130,38 +166,22 @@ for (let i = 0; i < manifest.flags.length; i++) {
   if (entry.coverage === "loop-e2e") loopE2eCount++;
   if (entry.coverage === "destination-only") destinationOnlyCount++;
 
-  const ref = parseTestRef(entry.e2e_test);
-  if (!ref) {
-    fail(
-      `${label} (prod_state=${entry.prod_state}): "e2e_test" is missing or not of the form ` +
-        `"<file/path>::<test_fn_name>" (got ${JSON.stringify(entry.e2e_test)}). ` +
-        `A prod-${entry.prod_state} flag MUST name a loop-closing test — this is the registry-#27 gap.`
-    );
-    continue;
-  }
+  await checkTestRef(label, entry.prod_state, entry.e2e_test, "e2e_test");
 
-  const absFile = join(REPO_ROOT, ref.file);
-  try {
-    await access(absFile, constants.R_OK);
-  } catch {
-    fail(
-      `${label} (prod_state=${entry.prod_state}): mapped test FILE does not exist: ${ref.file} ` +
-        `(referenced by e2e_test ${JSON.stringify(entry.e2e_test)})`
-    );
-    continue;
+  if (entry.additional_e2e_tests !== undefined) {
+    if (!Array.isArray(entry.additional_e2e_tests)) {
+      fail(`${label}: "additional_e2e_tests" must be an array when present`);
+    } else {
+      for (const [index, ref] of entry.additional_e2e_tests.entries()) {
+        await checkTestRef(
+          label,
+          entry.prod_state,
+          ref,
+          `additional_e2e_tests[${index}]`
+        );
+      }
+    }
   }
-
-  const content = await readFile(absFile, "utf-8");
-  if (!fileDeclaresTest(content, ref.fn)) {
-    fail(
-      `${label} (prod_state=${entry.prod_state}): mapped test FUNCTION "${ref.fn}" not found in ${ref.file}. ` +
-        `Expected a Rust \`fn ${ref.fn}(\` or a vitest it/test("${ref.fn}"). ` +
-        `If the test was renamed/removed, update the manifest — a prod-${entry.prod_state} flag may not be left without a loop test.`
-    );
-    continue;
-  }
-
-  ok(`${label} (${entry.prod_state}, ${entry.coverage}) -> ${ref.file}::${ref.fn}`);
 }
 
 // ── 3. Summary + exit ──


### PR DESCRIPTION
## Summary
- add an equal-strength WorkItem-status dispatch-arm test for FRIDAY_MISSION_SPINE_DISPATCH
- enforce additional_e2e_tests in the prod-flag manifest gate so companion loop tests cannot silently disappear
- mark the WorkItem-status dispatch-arm follow-up closed in the flag-gate notes

## Validation
- cargo test -p friday-hub work_item_status_dispatch_arm_updates_timeline_without_provider_call
- node scripts/ci/verify-prod-flag-tests.mjs
- git diff --check

Truth: mechanism/CI coverage only; organic=0 strict physical-hand OG9; not D20/B4 true-sign; not goal done.