### PR TITLE
Add L1 mechanism wiring matrix gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -305,11 +305,32 @@ jobs:
       - name: Verify every prod-ON flag maps to a loop e2e test
         run: node scripts/ci/verify-prod-flag-tests.mjs
 
+  # ── MECHANISM-9: L1 Mechanism Wiring Matrix Gate ──
+  # Reconciles the Rust-owned coarse mechanism matrix with the current-head docs
+  # and critical TS fail-closed mutation fences. This prevents L1 from drifting
+  # back into ungrounded percentage claims or stale "wired" labels.
+  mechanism-wiring:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+
+      - name: Setup Node
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Verify L1 mechanism wiring matrix
+        run: node scripts/ci/verify-mechanism-wiring-matrix.mjs
+
   # ── Terminal CI Aggregator — single required check for branch protection ──
   quality-gate:
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    needs: [build, test, migrations, security, contracts, ssd-lint, alignment-guard, agent-parity, secrets, ts-runtime-retirement, prod-flag-tests]
+    needs: [build, test, migrations, security, contracts, ssd-lint, alignment-guard, agent-parity, secrets, ts-runtime-retirement, prod-flag-tests, mechanism-wiring]
     if: ${{ always() }}
 
     steps:
@@ -326,6 +347,7 @@ jobs:
           echo "Secrets:            ${{ needs.secrets.result }}"
           echo "TS Runtime Retire:  ${{ needs.ts-runtime-retirement.result }}"
           echo "Prod-Flag Tests:    ${{ needs.prod-flag-tests.result }}"
+          echo "Mechanism Wiring:   ${{ needs.mechanism-wiring.result }}"
           echo ""
 
           FAILED=0
@@ -341,6 +363,7 @@ jobs:
             "${{ needs.secrets.result }}" \
             "${{ needs.ts-runtime-retirement.result }}" \
             "${{ needs.prod-flag-tests.result }}" \
+            "${{ needs.mechanism-wiring.result }}" \
           ; do
             if [ "$result" != "success" ]; then
               FAILED=1

--- a/docs/ops/friday-mechanism-wiring-matrix.md
+++ b/docs/ops/friday-mechanism-wiring-matrix.md
@@ -1,0 +1,72 @@
+# Friday Mechanism Wiring Matrix
+
+Basis: current main after #916 (`123ff34e`). This document reconciles the Rust-owned coarse mechanism matrix, the TS-runtime retirement manifest, and the prod-flag test map. It is a current-head wiring artifact, not a go-live claim.
+
+Truth labels:
+
+- `rust_owned_proven`: Rust owns the product mechanism and the named proof gate covers its product path.
+- `rust_owned_partial`: Rust owns the mechanism, but at least one product entrypoint or live proof is still missing.
+- `rust_wired_dev`: Rust can run the mechanism from a dev/test bridge only; product transport remains blocked.
+- `operator_gated` / `external_blocked`: mechanism requires operator-controlled environment or signatures.
+- `design_frozen` / `legacy_retire_required`: not a product-logic owner.
+
+Mutation defaults:
+
+- `governed`: writes or executions flow through the named Rust gate or owner.
+- `503-by-default`: TS/runtime product mutation is fenced until Rust ownership or an explicit test-only flag.
+- `operator-gated`: no agent-autonomous closure; operator action is required.
+- `not-a-product-mutator`: row is UI shell, release oracle, external proof, or read/projection surface.
+
+| mechanism_id | owner | status | product_logic | mutation_default | entrypoint | proof_or_guard | exact_blocker |
+|---|---|---|---|---|---|---|---|
+| `identity_principal_gate` | `rust_core` | `rust_owned_proven` | `yes` | `governed` | `friday_core::gate` | `cargo test -p friday-storage authorize_gate` | none |
+| `mission_work_item_spine` | `rust_hub` | `rust_owned_proven` | `yes` | `governed` | `friday_hub::mission_runtime` | `scripts/mission-spine-objective-coverage-gate.sh` | none |
+| `global_work_graph` | `rust_hub` | `rust_owned_proven` | `yes` | `governed` | `friday_hub::global_work_graph` | `cargo test -p friday-hub global_work_graph` | none |
+| `skill_capability_advisor_bridge` | `rust_hub` | `rust_owned_proven` | `yes` | `governed` | `friday_hub::skill_catalog::{discover_skill_catalog,record_skill_run_receipt}` | `cargo test -p friday-hub skill_catalog` | none |
+| `agent_tool_execution` | `rust_hub` | `rust_wired_dev` | `yes` | `503-by-default` | `friday_hub::runtime::HubRuntime::run_task` | `cargo test -p friday-hub run_loop`; TS `agent_runs_start` method guard | real multi-turn live agent/tool execution is dev-bridge-only (hub_run_task = Rust-wired-DEV); only 2/10 fs tools exist and the TS executeRun/startRun product paths stay fail-closed-fenced - no production transport, not proven through any product entrypoint |
+| `workflow_runtime` | `rust_hub` | `rust_wired_dev` | `yes` | `503-by-default` | `friday_hub::mission_runtime::run_workflow_for_mission` | `cargo test -p friday-hub mission_runtime`; TS `workflow_runs_start` method guard | workflow runtime is reachable only via a test-only entrypoint (TS startRun product path is fail-closed-fenced) - no production transport; product entrypoints must all use Mission-bound wrappers |
+| `memory_learning` | `rust_hub` | `rust_owned_partial` | `yes` | `governed` | `friday_hub::cognition` | `cargo test -p friday-hub cognition`; TS durable-memory writes are fail-closed | runtime memory writer and review surface are not fully attached to all live call sites |
+| `providers` | `rust_hub` | `rust_owned_partial` | `yes` | `governed` | `friday_hub::{provider_dispatch,mission_runtime}` | `scripts/mission-spine-proof-gate.sh --local`; prod flag tests | Codex/Claude remote/native live proofs and all product wrappers are still gated |
+| `channels` | `rust_hub` | `rust_owned_partial` | `yes` | `503-by-default` | `friday_hub::{channels,channel_event,mission_runtime}` | `cargo test -p friday-hub authenticated_channel`; TS channel/session authoring guards | live Telegram proof and all channel product entrypoints remain gated |
+| `process_workspace_control` | `rust_hub` | `rust_owned_partial` | `yes` | `governed` | `friday_hub::global_work_graph` | `cargo test -p friday-storage process_registry`; TS desktop action/recording guards | live supervisor/adoption/stop runtime is not proven; observed processes cannot be controlled |
+| `audit_token_proof_receipts` | `rust_hub` | `rust_owned_proven` | `yes` | `governed` | `friday_storage::{audit,token_usage}; friday_hub::mission_preflight` | `cargo test -p friday-storage audit token_usage && scripts/mission-spine-objective-coverage-gate.sh` | none |
+| `pairing` | `rust_hub` | `rust_owned_proven` | `yes` | `governed` | `friday_hub::pair_runtime` | `cargo test -p friday-hub pair_runtime && cargo test -p friday-storage pairing` | none |
+| `ui_shell` | `ui_shell_only` | `design_frozen` | `no` | `not-a-product-mutator` | `friday_ffi projections only` | `scripts/mission-spine-ui-device-proof-gate.sh` | UI is allowed as shell/contract only until Rust-owned product logic is proven |
+| `release_test_oracle` | `legacy_oracle_only` | `legacy_retire_required` | `no` | `not-a-product-mutator` | `none` | `n/a` | legacy may not own product runtime logic |
+| `live_external_proofs` | `operator_external` | `external_blocked` | `no` | `operator-gated` | `operator-gated proof scripts` | `strict final closure runbook` | requires operator environment: devices, accounts, Telegram, release credentials |
+
+## Critical TS Mutation Fences
+
+These TS surfaces remain in the retirement manifest as behavior-tested 503-by-default fences. They are not proof that the replacement Rust product path is complete; they are the no-ungated-hole side of L1.
+
+| surface_id | mechanism | default | behavior |
+|---|---|---|---|
+| `agent_runs_start` | `agent_tool_execution` | `503-by-default` | direct TS `executeRun` start is method-fenced before provider/tool execution |
+| `workflow_runs_start` | `workflow_runtime` | `503-by-default` | direct TS workflow start is method-fenced before product execution |
+| `autofix_execute` | `agent_tool_execution` | `503-by-default` | direct TS auto-fix execute sink is method-fenced |
+| `skills_run` | `skill_capability_advisor_bridge` | `503-by-default` | TS skill execution is fenced; Rust currently records gated receipts, not imported code execution |
+| `skills_import` | `skill_capability_advisor_bridge` | `503-by-default` | TS skill import route is fenced; Rust SKILL.md materialization remains a separate build item |
+| `mcp_server_rpc` | `agent_tool_execution` | `503-by-default` | TS MCP tool call route is fenced until Rust owns MCP execution |
+
+## Governed Non-503 Mutation Surfaces
+
+Not every mutation surface should be retired to 503. These surfaces stay reachable because they are bounded control or lifecycle surfaces, but they must remain governed by principal, scope, or canonical approval checks. Treating them as "must 503" would be a downgrade.
+
+| surface | mechanism | default | guard |
+|---|---|---|---|
+| `agent_cancel_rollback` | `agent_tool_execution` | `governed` | visible-run / terminal-state control checks; rollback is a separate control path, not the start/execute sink |
+| `agent_plan_tool_approvals` | `identity_principal_gate` | `governed` | bound-principal approval/rejection checks |
+| `workflow_run_controls` | `workflow_runtime` | `governed` | workflow write scope plus owner/admin/operator principal checks |
+| `skill_content_lifecycle` | `skill_capability_advisor_bridge` | `governed` | canonical approval for content/lifecycle/import mutations; execution remains separately fenced |
+| `capability_grant_revoke` | `identity_principal_gate` | `governed` | authority/owner gate for grant revocation; root minting remains operator-only |
+| `mission_spine_dispatch_status` | `mission_work_item_spine` | `governed` | Rust mission-spine ownership, dispatch-service absence fails closed, route decision/status mutations are owner-bound |
+
+## Current NO-GO Summary
+
+`friday_v1_no_go_blockers()` is expected to remain non-empty on this anchor. The hard blockers are:
+
+- `agent_tool_execution`: Rust-wired dev bridge exists, but product transport and broad tool execution are not proven.
+- `workflow_runtime`: Rust workflow runtime exists, but production product wrappers must be Mission-bound and are still fenced.
+- `memory_learning`, `providers`, `channels`, and `process_workspace_control`: Rust-owned partial mechanisms with live proof or surface gaps.
+
+This document closes the L1 documentation/wiring artifact gap only. It does not mark v1 done, does not satisfy strict physical-hand OG9, and does not replace D20/B4 operator-only signatures.

--- a/package.json
+++ b/package.json
@@ -132,6 +132,7 @@
     "ops:agent-adoption:resume": "node dist/cli/friday-cli.js phases resume",
     "ops:agent-adoption:closeout": "node dist/cli/friday-cli.js phases closeout",
     "test:install:smoke": "node scripts/ci/install-smoke.mjs",
+    "test:mechanism-wiring": "node scripts/ci/verify-mechanism-wiring-matrix.mjs",
     "test:docker:e2e:runtime": "FRIDAY_DOCKER_SMOKE_LAYER=runtime bash scripts/ci/docker-e2e-smoke.sh",
     "test:docker:e2e:bootstrap": "FRIDAY_DOCKER_SMOKE_LAYER=bootstrap bash scripts/ci/docker-e2e-smoke.sh",
     "test:docker:e2e:plugins": "FRIDAY_DOCKER_SMOKE_LAYER=plugins bash scripts/ci/docker-e2e-smoke.sh",

--- a/scripts/ci/verify-mechanism-wiring-matrix.mjs
+++ b/scripts/ci/verify-mechanism-wiring-matrix.mjs
@@ -1,0 +1,222 @@
+#!/usr/bin/env node
+
+import { readFile } from "node:fs/promises";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const RUST_MATRIX = join(REPO_ROOT, "rust-core", "crates", "friday-core", "src", "mechanism_matrix.rs");
+const DOC = join(REPO_ROOT, "docs", "ops", "friday-mechanism-wiring-matrix.md");
+const TS_MANIFEST = join(REPO_ROOT, "docs", "ops", "ts-runtime-retirement-manifest.json");
+
+const OWNER_STRINGS = {
+  RustCore: "rust_core",
+  RustHub: "rust_hub",
+  RustFfi: "rust_ffi",
+  UiShellOnly: "ui_shell_only",
+  LegacyOracleOnly: "legacy_oracle_only",
+  OperatorExternal: "operator_external",
+};
+
+const STATUS_STRINGS = {
+  RustOwnedProven: "rust_owned_proven",
+  RustOwnedPartial: "rust_owned_partial",
+  RustWiredDev: "rust_wired_dev",
+  NoGo: "NO-GO",
+  OperatorGated: "operator_gated",
+  ExternalBlocked: "external_blocked",
+  DesignFrozen: "design_frozen",
+  LegacyRetireRequired: "legacy_retire_required",
+};
+
+const ALLOWED_MUTATION_DEFAULTS = new Set([
+  "governed",
+  "503-by-default",
+  "operator-gated",
+  "not-a-product-mutator",
+]);
+
+const CRITICAL_TS_FENCES = new Map([
+  ["agent_runs_start", "agent_tool_execution"],
+  ["workflow_runs_start", "workflow_runtime"],
+  ["autofix_execute", "agent_tool_execution"],
+  ["skills_run", "skill_capability_advisor_bridge"],
+  ["skills_import", "skill_capability_advisor_bridge"],
+  ["mcp_server_rpc", "agent_tool_execution"],
+]);
+
+const GOVERNED_NON_503_SURFACES = [
+  "agent_cancel_rollback",
+  "agent_plan_tool_approvals",
+  "workflow_run_controls",
+  "skill_content_lifecycle",
+  "capability_grant_revoke",
+  "mission_spine_dispatch_status",
+];
+
+let errors = 0;
+
+function fail(message) {
+  console.error(`❌ ${message}`);
+  errors += 1;
+}
+
+function ok(message) {
+  console.log(`✅ ${message}`);
+}
+
+function extractString(block, field) {
+  const match = block.match(new RegExp(`${field}:\\s*"([^"]*)"`));
+  return match?.[1] ?? "";
+}
+
+function extractEnum(block, field) {
+  const match = block.match(new RegExp(`${field}:\\s*([A-Za-z0-9_]+)`));
+  return match?.[1] ?? "";
+}
+
+function parseRustRows(source) {
+  const start = source.indexOf("vec![");
+  const end = source.indexOf("\n    ]\n}", start);
+  const matrixSource = start >= 0 && end > start ? source.slice(start, end) : source;
+  const rows = [];
+  const rowRe = /MechanismRow\s*\{([\s\S]*?)\n\s*\},/g;
+  for (const match of matrixSource.matchAll(rowRe)) {
+    const block = match[1];
+    const id = extractString(block, "id");
+    if (!id) continue;
+    rows.push({
+      id,
+      owner: OWNER_STRINGS[extractEnum(block, "owner")] ?? "",
+      status: STATUS_STRINGS[extractEnum(block, "status")] ?? "",
+      entrypoint: extractString(block, "rust_entrypoint"),
+      proof: extractString(block, "proof_gate"),
+      blocker: extractString(block, "blocker"),
+      productLogic: /user_triggerable_product_logic:\s*true/.test(block),
+    });
+  }
+  return rows;
+}
+
+function normalizeCell(cell) {
+  return cell
+    .replace(/<br\s*\/?>/gi, " ")
+    .replace(/`/g, "")
+    .replace(/\\\|/g, "|")
+    .trim();
+}
+
+function parseDocRows(markdown) {
+  const rows = new Map();
+  const lines = markdown.split(/\r?\n/);
+  for (const line of lines) {
+    if (!line.startsWith("| `")) continue;
+    const cells = line.split("|").slice(1, -1).map(normalizeCell);
+    if (cells.length < 8) continue;
+    const [id, owner, status, productLogic, mutationDefault, entrypoint, proof, blocker] = cells;
+    rows.set(id, {
+      id,
+      owner,
+      status,
+      productLogic,
+      mutationDefault,
+      entrypoint,
+      proof,
+      blocker,
+    });
+  }
+  return rows;
+}
+
+const rustSource = await readFile(RUST_MATRIX, "utf8");
+const docSource = await readFile(DOC, "utf8");
+const manifest = JSON.parse(await readFile(TS_MANIFEST, "utf8"));
+
+const rustRows = parseRustRows(rustSource);
+const docRows = parseDocRows(docSource);
+const methodRetiredSurfaces = new Map(
+  (manifest.methodRetiredSurfaces?.surfaces ?? []).map((surface) => [surface.id, surface]),
+);
+
+if (rustRows.length === 0) {
+  fail("Rust mechanism matrix yielded zero rows");
+}
+
+const rustIds = new Set(rustRows.map((row) => row.id));
+for (const docId of docRows.keys()) {
+  if (!rustIds.has(docId)) {
+    fail(`documented mechanism ${docId} is not present in rust mechanism_matrix.rs`);
+  }
+}
+
+for (const rustRow of rustRows) {
+  const docRow = docRows.get(rustRow.id);
+  if (!docRow) {
+    fail(`missing doc row for Rust mechanism ${rustRow.id}`);
+    continue;
+  }
+  if (docRow.owner !== rustRow.owner) {
+    fail(`${rustRow.id}: owner doc=${docRow.owner} rust=${rustRow.owner}`);
+  }
+  if (docRow.status !== rustRow.status) {
+    fail(`${rustRow.id}: status doc=${docRow.status} rust=${rustRow.status}`);
+  }
+  const productLogic = rustRow.productLogic ? "yes" : "no";
+  if (docRow.productLogic !== productLogic) {
+    fail(`${rustRow.id}: product_logic doc=${docRow.productLogic} rust=${productLogic}`);
+  }
+  if (!ALLOWED_MUTATION_DEFAULTS.has(docRow.mutationDefault)) {
+    fail(`${rustRow.id}: invalid mutation_default ${docRow.mutationDefault}`);
+  }
+  if (!docRow.entrypoint || !docRow.proof) {
+    fail(`${rustRow.id}: doc row must name entrypoint and proof_or_guard`);
+  }
+  if (rustRow.blocker) {
+    if (docRow.blocker === "none") {
+      fail(`${rustRow.id}: Rust blocker is non-empty but doc says none`);
+    }
+  } else if (docRow.blocker !== "none") {
+    fail(`${rustRow.id}: Rust blocker is empty but doc has ${docRow.blocker}`);
+  }
+}
+
+const surfaces = new Map((manifest.surfaces ?? []).map((surface) => [surface.id, surface]));
+for (const [surfaceId, mechanismId] of CRITICAL_TS_FENCES.entries()) {
+  const surface = surfaces.get(surfaceId);
+  if (!surface) {
+    fail(`critical TS fence ${surfaceId} missing from ts-runtime-retirement manifest`);
+    continue;
+  }
+  if (surface.classification !== "fail_closed" || surface.executes_product_logic !== false) {
+    fail(`${surfaceId}: must remain fail_closed with executes_product_logic=false`);
+  }
+  const methodSurface = methodRetiredSurfaces.get(surfaceId);
+  const hasMethodBehaviorTest = typeof methodSurface?.behavioralTest === "string"
+    && methodSurface.behavioralTest.length > 0;
+  const hasRouteProof = typeof surface.proof === "string" && surface.proof.length > 0;
+  if (!hasMethodBehaviorTest && !hasRouteProof) {
+    fail(`${surfaceId}: missing method behavioralTest or route proof`);
+  }
+  if (!docSource.includes(`| \`${surfaceId}\` | \`${mechanismId}\``)) {
+    fail(`${surfaceId}: missing critical-fence row mapped to ${mechanismId} in docs`);
+  }
+}
+
+for (const surfaceId of GOVERNED_NON_503_SURFACES) {
+  if (!docSource.includes(`| \`${surfaceId}\``)) {
+    fail(`${surfaceId}: missing governed non-503 mutation surface row in docs`);
+  }
+}
+
+if (!docSource.includes("strict physical-hand OG9") || !docSource.includes("D20/B4 operator-only signatures")) {
+  fail("doc must carry the truth boundary for OG9 and D20/B4 operator-only signatures");
+}
+
+if (errors > 0) {
+  console.error(`\n💥 ${errors} mechanism wiring matrix error(s) found`);
+  process.exit(1);
+}
+
+ok(`${rustRows.length} Rust mechanism rows are documented and reconciled`);
+ok(`${CRITICAL_TS_FENCES.size} critical TS fail-closed fences are mapped`);
+console.log("\n🎉 mechanism wiring matrix gate passed");


### PR DESCRIPTION
## Summary
- add a current-head L1 mechanism wiring matrix that reconciles the Rust mechanism matrix, TS fail-closed fences, and governed non-503 mutation surfaces
- add a Node CI verifier that keeps the doc reconciled with rust-core/crates/friday-core/src/mechanism_matrix.rs and critical TS retirement fences
- wire the verifier into CI and package scripts

## Validation
- node scripts/ci/verify-mechanism-wiring-matrix.mjs
- node --check scripts/ci/verify-mechanism-wiring-matrix.mjs
- node scripts/quality/check-ts-runtime-retirement.mjs > /tmp/l1-ts-runtime-report.json && node scripts/quality/assert-ts-runtime-blocker-zero.mjs /tmp/l1-ts-runtime-report.json && node scripts/quality/assert-ts-runtime-method-guards.mjs
- node scripts/ci/verify-prod-flag-tests.mjs
- git diff --check

## Truth boundary
This closes the L1 documentation/wiring artifact gap only. It does not mark v1 done, does not satisfy strict physical-hand OG9, and does not replace D20/B4 operator-only signatures.