### PR TITLE
Route auto-dispatch from selected intake result

### DIFF
--- a/rust-core/crates/friday-ffi/src/lib.rs
+++ b/rust-core/crates/friday-ffi/src/lib.rs
@@ -3026,6 +3026,8 @@ mod tests {
                     duplicate_work_item_id: None,
                     created_or_ready: false,
                     clarification_questions: Vec::new(),
+                    selected_lane: None,
+                    selected_target_provider_or_agent: None,
                 },
             },
         );

--- a/rust-core/crates/friday-hub/src/hub_server.rs
+++ b/rust-core/crates/friday-hub/src/hub_server.rs
@@ -618,6 +618,8 @@ pub fn mission_intake_result_for_db_flagged(
                     duplicate_mission_id: None,
                     duplicate_work_item_id: None,
                     created_or_ready: false,
+                    selected_lane: None,
+                    selected_target_provider_or_agent: None,
                     clarification_questions: questions,
                 };
                 return Envelope::new(
@@ -750,7 +752,7 @@ pub fn mission_intake_result_for_db_flagged(
         work_item_id: request.work_item_id.clone(),
         mission_id: request.mission_id.clone(),
         lane,
-        target_provider_or_agent: target,
+        target_provider_or_agent: target.clone(),
         status: friday_core::WorkItemStatus::Draft,
         owner_claim_ids: owner_claim_ids.clone(),
         workspace_refs: Vec::new(),
@@ -900,6 +902,8 @@ pub fn mission_intake_result_for_db_flagged(
             duplicate_mission_id: None,
             duplicate_work_item_id: None,
             created_or_ready: true,
+            selected_lane: Some(lane.as_str().to_string()),
+            selected_target_provider_or_agent: target.clone(),
             clarification_questions: Vec::new(),
         },
         MissionPreflightOutcome::Blocked {
@@ -921,6 +925,8 @@ pub fn mission_intake_result_for_db_flagged(
                 duplicate_mission_id,
                 duplicate_work_item_id,
                 created_or_ready: false,
+                selected_lane: None,
+                selected_target_provider_or_agent: None,
                 clarification_questions: Vec::new(),
             }
         }

--- a/rust-core/crates/friday-protocol/src/lib.rs
+++ b/rust-core/crates/friday-protocol/src/lib.rs
@@ -368,6 +368,14 @@ pub struct MissionIntakeResultWire {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub duplicate_work_item_id: Option<String>,
     pub created_or_ready: bool,
+    /// The canonical WorkItem route selected by Rust intake. Optional for
+    /// backward compatibility and non-ready results; when present it lets thin
+    /// TS producers dispatch the server-selected route instead of re-reading
+    /// the raw request.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub selected_lane: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub selected_target_provider_or_agent: Option<String>,
     /// (Mission-intake clarification — DARK, default-OFF) The specific clarifying
     /// questions for an UNDER-SPECIFIED intent. NON-EMPTY only when
     /// `status == "needs_clarification"`; every existing ready/blocked path leaves
@@ -2248,6 +2256,8 @@ mod tests {
                     duplicate_mission_id: None,
                     duplicate_work_item_id: None,
                     created_or_ready: true,
+                    selected_lane: Some("deepseek".into()),
+                    selected_target_provider_or_agent: Some("deepseek".into()),
                     clarification_questions: Vec::new(),
                 },
             },

--- a/src/api/mission-spine/friday-mission-auto-dispatch-driver.ts
+++ b/src/api/mission-spine/friday-mission-auto-dispatch-driver.ts
@@ -132,22 +132,34 @@ function deriveTask(
   return `Advance mission work item ${result.workItemId ?? ""}`.trim();
 }
 
+function selectedLane(
+  request: FridayRustHubMissionIntakeRequest,
+  result: FridayRustHubMissionIntakeResult,
+): string {
+  return (result.selectedLane ?? request.lane).trim();
+}
+
+function selectedTargetProviderOrAgent(
+  request: FridayRustHubMissionIntakeRequest,
+  result: FridayRustHubMissionIntakeResult,
+): string | undefined {
+  return (result.selectedTargetProviderOrAgent ?? request.targetProviderOrAgent)?.trim();
+}
+
 function isCodexMissionTarget(
   request: FridayRustHubMissionIntakeRequest,
+  result: FridayRustHubMissionIntakeResult,
 ): boolean {
-  return (
-    request.lane.trim() === "codex" &&
-    request.targetProviderOrAgent?.trim() === "codex"
-  );
+  return selectedLane(request, result) === "codex" &&
+    selectedTargetProviderOrAgent(request, result) === "codex";
 }
 
 function isClaudeMissionTarget(
   request: FridayRustHubMissionIntakeRequest,
+  result: FridayRustHubMissionIntakeResult,
 ): boolean {
-  return (
-    request.lane.trim() === RUST_ROUTE_CLAUDE_PROVIDER_ID &&
-    request.targetProviderOrAgent?.trim() === RUST_ROUTE_CLAUDE_PROVIDER_ID
-  );
+  return selectedLane(request, result) === RUST_ROUTE_CLAUDE_PROVIDER_ID &&
+    selectedTargetProviderOrAgent(request, result) === RUST_ROUTE_CLAUDE_PROVIDER_ID;
 }
 
 export function createFridayMissionAutoDispatchDriver(
@@ -202,8 +214,8 @@ export function createFridayMissionAutoDispatchDriver(
           request.ownerPrincipal.trim().length > 0
             ? request.ownerPrincipal.trim()
             : undefined;
-        const codexMissionTarget = isCodexMissionTarget(request);
-        const claudeMissionTarget = isClaudeMissionTarget(request);
+        const codexMissionTarget = isCodexMissionTarget(request, result);
+        const claudeMissionTarget = isClaudeMissionTarget(request, result);
         const route = codexMissionTarget
           ? { providerId: codexProviderId, model: codexModel }
           : claudeMissionTarget

--- a/src/api/mission-spine/friday-rust-hub-agent-run-ws-sealed-client.ts
+++ b/src/api/mission-spine/friday-rust-hub-agent-run-ws-sealed-client.ts
@@ -480,6 +480,9 @@ export interface FridayRustHubMissionIntakeResult {
   readonly duplicateMissionId?: string;
   readonly duplicateWorkItemId?: string;
   readonly createdOrReady: boolean;
+  /** Server-selected WorkItem route, surfaced only when Rust sends it. */
+  readonly selectedLane?: string;
+  readonly selectedTargetProviderOrAgent?: string;
   /**
    * (Mission-intake clarification — DARK, default-OFF) The specific clarifying questions for an
    * UNDER-SPECIFIED intent. NON-EMPTY only when `status === "needs_clarification"` (the Rust
@@ -1132,6 +1135,8 @@ export function parseMissionIntakeResult(
   const workItemId = asString(r.work_item_id);
   const duplicateMissionId = asString(r.duplicate_mission_id);
   const duplicateWorkItemId = asString(r.duplicate_work_item_id);
+  const selectedLane = asString(r.selected_lane);
+  const selectedTargetProviderOrAgent = asString(r.selected_target_provider_or_agent);
   // (Mission-intake clarification — DARK) Optional, ADDITIVE: surfaced only when the server sends a
   // non-empty `clarification_questions` (the flag-gated needs_clarification arm). Absent / empty /
   // non-array / non-string entries ⇒ the field is OMITTED (never fabricated, never a parse failure
@@ -1155,6 +1160,10 @@ export function parseMissionIntakeResult(
     ...(workItemId !== undefined ? { workItemId } : {}),
     ...(duplicateMissionId !== undefined ? { duplicateMissionId } : {}),
     ...(duplicateWorkItemId !== undefined ? { duplicateWorkItemId } : {}),
+    ...(selectedLane !== undefined ? { selectedLane } : {}),
+    ...(selectedTargetProviderOrAgent !== undefined
+      ? { selectedTargetProviderOrAgent }
+      : {}),
     ...(clarificationQuestions !== undefined && clarificationQuestions.length > 0
       ? { clarificationQuestions }
       : {}),

--- a/test/unit/api/mission-spine/friday-mission-auto-dispatch-driver.test.ts
+++ b/test/unit/api/mission-spine/friday-mission-auto-dispatch-driver.test.ts
@@ -187,6 +187,45 @@ describe("createFridayMissionAutoDispatchDriver (organic mission→run binding P
       });
     });
 
+    it("uses the Rust-selected route for lane=auto instead of re-reading the raw request", async () => {
+      const startRun = vi.fn(async () => ({
+        runId: "run-1",
+      })) as unknown as MissionAutoDispatchStartRun;
+      const driver = createFridayMissionAutoDispatchDriver({
+        startRun: () => startRun,
+        deepseekProviderId: DEEPSEEK_PROVIDER,
+        deepseekFlashModel: DEEPSEEK_FLASH,
+        codexProviderId: CODEX_PROVIDER,
+        codexModel: CODEX_MODEL,
+        claudeProviderId: CLAUDE_PROVIDER,
+        claudeModel: CLAUDE_MODEL,
+      });
+
+      driver.onIntakeReady(
+        {
+          ...REQUEST,
+          lane: "auto",
+          targetProviderOrAgent: undefined,
+        },
+        {
+          ...READY_RESULT,
+          selectedLane: "codex",
+          selectedTargetProviderOrAgent: "codex",
+        },
+      );
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(startRun).toHaveBeenCalledTimes(1);
+      const arg = (startRun as unknown as ReturnType<typeof vi.fn>).mock
+        .calls[0][0];
+      expect(arg).toMatchObject({
+        providerId: CODEX_PROVIDER,
+        model: CODEX_MODEL,
+        timeoutMs: RUST_ROUTE_CODEX_MISSION_DISPATCH_TIMEOUT_MS,
+      });
+    });
+
     it("dispatches a claude-targeted intake with the Claude mission-bound route shape", async () => {
       const startRun = vi.fn(async () => ({
         runId: "run-1",

--- a/test/unit/api/mission-spine/friday-rust-hub-mission-spine-wire.test.ts
+++ b/test/unit/api/mission-spine/friday-rust-hub-mission-spine-wire.test.ts
@@ -247,11 +247,15 @@ describe("parseMissionIntakeResult (fail-closed refs-only, NESTED result)", () =
         work_item_id: "work_x",
         duplicate_mission_id: "mission_dup",
         duplicate_work_item_id: "work_dup",
+        selected_lane: "codex",
+        selected_target_provider_or_agent: "codex",
       },
     });
     expect(withOptionals?.workItemId).toBe("work_x");
     expect(withOptionals?.duplicateMissionId).toBe("mission_dup");
     expect(withOptionals?.duplicateWorkItemId).toBe("work_dup");
+    expect(withOptionals?.selectedLane).toBe("codex");
+    expect(withOptionals?.selectedTargetProviderOrAgent).toBe("codex");
   });
 
   it("does NOT surface clarificationQuestions when the field is absent (existing ready/blocked payloads)", () => {


### PR DESCRIPTION
## Summary
- add optional Rust MissionIntakeResult selected route fields
- parse selected route in the TS sealed client
- have mission auto-dispatch use the server-selected route before falling back to the raw request
- pin lane=auto so TS no longer defaults a Rust-selected Codex route to DeepSeek

## Truth label
- C1/C2 dispatch is already live-on-synthetic; this fixes selected-route propagation
- no live flip, no fallback semantic change, no operator signing
- strict organic remains 0

## Validation
- cargo fmt --all -- --check
- cargo test -p friday-hub auto_route -- --nocapture
- /Users/jarvis/Projects/Friday/node_modules/.bin/vitest --config /Users/jarvis/Projects/Friday/vitest.config.ts run test/unit/api/mission-spine/friday-mission-auto-dispatch-driver.test.ts
- with node_modules symlinked for local worktree dependency resolution: vitest run test/unit/api/mission-spine/friday-rust-hub-mission-spine-wire.test.ts test/unit/api/mission-spine/friday-mission-auto-dispatch-driver.test.ts
- focused eslint on changed TS files: 0 errors; existing max-lines/test-ignore warnings only
- git diff --check