### PR TITLE
Add DeepSeek RGG core gate for C1/C2 parity capture

### DIFF
--- a/scripts/ops/friday-c1-c2-deepseek-rgg-core-gate.mjs
+++ b/scripts/ops/friday-c1-c2-deepseek-rgg-core-gate.mjs
@@ -1,0 +1,172 @@
+#!/usr/bin/env node
+
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+import { REAL_GREEN_GATE_RESULT_FILENAME } from "./lib/real-green-gate-result.mjs";
+
+const DEFAULT_BLOCKED_REASON = "external channel prerequisite is not ready: unknown";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const DEFAULT_REPO_ROOT = path.resolve(__dirname, "..", "..");
+
+function envEnabled(env, name) {
+  return ["1", "true", "yes", "on"].includes((env[name] ?? "").trim().toLowerCase());
+}
+
+function parseArgs(argv) {
+  const options = {
+    repoRoot: DEFAULT_REPO_ROOT,
+    reportRoot: process.env.FRIDAY_C1_C2_DEEPSEEK_RGG_REPORT_ROOT?.trim()
+      || path.join(os.tmpdir(), `friday-c1-c2-deepseek-rgg-core-${String(Date.now())}`),
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    const next = argv[index + 1];
+    switch (arg) {
+      case "--repo-root":
+        options.repoRoot = path.resolve(next);
+        index += 1;
+        break;
+      case "--report-root":
+        options.reportRoot = path.resolve(next);
+        index += 1;
+        break;
+      default:
+        break;
+    }
+  }
+
+  return options;
+}
+
+async function readJson(filePath) {
+  return JSON.parse(await fs.readFile(filePath, "utf8"));
+}
+
+async function readTextIfPresent(filePath) {
+  try {
+    return await fs.readFile(filePath, "utf8");
+  } catch {
+    return "";
+  }
+}
+
+function arrayOfStrings(value) {
+  return Array.isArray(value) ? value.filter((item) => typeof item === "string") : [];
+}
+
+export async function evaluateDeepSeekRggCoreResult(reportRoot) {
+  const resultPath = path.join(reportRoot, REAL_GREEN_GATE_RESULT_FILENAME);
+  const phaseStatusPath = path.join(reportRoot, "phase-status.json");
+  const runtimeMetaPath = path.join(reportRoot, "self-hosted-runtime-meta.txt");
+  const result = await readJson(resultPath);
+  const phaseStatus = await readJson(phaseStatusPath).catch(() => ({}));
+  const runtimeMeta = await readTextIfPresent(runtimeMetaPath);
+  const blockedReasons = arrayOfStrings(result.blocked_reasons);
+  const onlyExternalChannelPrereqBlocked = blockedReasons.length === 1
+    && blockedReasons[0] === DEFAULT_BLOCKED_REASON;
+  const noBlockedReasons = blockedReasons.length === 0;
+  const scenariosRun = Number(result.scenarios_run ?? 0);
+  const scenariosTotal = Number(result.scenarios_total ?? 0);
+  const scenariosPassed = Number(result.scenarios_passed ?? -1);
+  const allScenariosPassed = scenariosRun > 0
+    && scenariosRun === scenariosTotal
+    && scenariosPassed === scenariosTotal;
+  const deepseekRoutingConfigured = /^deepseekRoutingConfigured=true$/m.test(runtimeMeta);
+  const singleProviderDefaultOnly = result.provider_lane_scope?.scope === "single_provider_default_only";
+  const externalChannelsSkipped = phaseStatus.phases?.externalChannels?.status === "skipped";
+  const externalChannelReason = phaseStatus.phases?.externalChannels?.reason ?? null;
+
+  const ok = allScenariosPassed
+    && deepseekRoutingConfigured
+    && singleProviderDefaultOnly
+    && (
+      result.status === "passed"
+      || (result.status === "failed" && onlyExternalChannelPrereqBlocked && externalChannelsSkipped)
+    )
+    && (noBlockedReasons || onlyExternalChannelPrereqBlocked);
+
+  const failures = [];
+  if (!allScenariosPassed) failures.push("RGG scenarios did not all pass");
+  if (!deepseekRoutingConfigured) failures.push("DeepSeek routing was not configured");
+  if (!singleProviderDefaultOnly) failures.push("RGG did not prove the single-provider DeepSeek default lane");
+  if (!(noBlockedReasons || onlyExternalChannelPrereqBlocked)) {
+    failures.push(`unexpected blocked reasons: ${blockedReasons.join("; ") || "<none>"}`);
+  }
+  if (onlyExternalChannelPrereqBlocked && !externalChannelsSkipped) {
+    failures.push("external channel prerequisite was blocked but externalChannels phase was not skipped");
+  }
+  if (result.status !== "passed" && !(result.status === "failed" && onlyExternalChannelPrereqBlocked)) {
+    failures.push(`unexpected RGG status: ${String(result.status)}`);
+  }
+
+  return {
+    ok,
+    reportRoot,
+    resultPath,
+    phaseStatusPath,
+    status: ok ? "passed" : "failed",
+    truthLabel:
+      "C1/C2 DeepSeek RGG core diagnostic; external-channel prerequisite is tracked by live-synthetic flows; strict organic=0",
+    scenariosRun,
+    scenariosTotal,
+    scenariosPassed,
+    blockedReasons,
+    deepseekRoutingConfigured,
+    providerLaneScope: result.provider_lane_scope?.scope ?? null,
+    externalChannelsSkipped,
+    externalChannelReason,
+    failures,
+  };
+}
+
+export function runSelfHostedRgg({ repoRoot, reportRoot, env = process.env }) {
+  const scriptPath = path.join(repoRoot, "scripts", "ops", "run-real-green-gate-self-hosted.mjs");
+  return spawnSync(process.execPath, [
+    scriptPath,
+    "--repo-root",
+    repoRoot,
+    "--report-root",
+    reportRoot,
+  ], {
+    cwd: repoRoot,
+    env,
+    encoding: "utf8",
+  });
+}
+
+export async function main(argv = process.argv.slice(2), env = process.env) {
+  const options = parseArgs(argv);
+  const evaluateOnly = envEnabled(env, "FRIDAY_C1_C2_DEEPSEEK_RGG_EVALUATE_ONLY");
+  if (!evaluateOnly) {
+    await fs.rm(options.reportRoot, { recursive: true, force: true });
+  }
+  await fs.mkdir(options.reportRoot, { recursive: true });
+
+  if (!evaluateOnly) {
+    const result = runSelfHostedRgg({ repoRoot: options.repoRoot, reportRoot: options.reportRoot, env });
+    if (result.error) {
+      throw result.error;
+    }
+  }
+
+  const evaluation = await evaluateDeepSeekRggCoreResult(options.reportRoot);
+  console.log(JSON.stringify(evaluation, null, 2));
+  return evaluation.ok ? 0 : 1;
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main()
+    .then((exitCode) => {
+      process.exitCode = exitCode;
+    })
+    .catch((error) => {
+      console.error(error instanceof Error ? error.message : String(error));
+      process.exitCode = 1;
+    });
+}

--- a/scripts/ops/friday-c1-c2-tier1-parity-capture.mjs
+++ b/scripts/ops/friday-c1-c2-tier1-parity-capture.mjs
@@ -121,7 +121,7 @@ export const TIER1_PARITY_FLOW_SPECS = Object.freeze([
     flowId: "c1-deepseek-real-green-routing-diagnostic",
     lane: "C1",
     source: "deepseek",
-    expectedHarness: "scripts/ops/run-real-green-gate-self-hosted.mjs",
+    expectedHarness: "scripts/ops/friday-c1-c2-deepseek-rgg-core-gate.mjs",
   },
   {
     order: 17,

--- a/test/unit/ops/friday-c1-c2-deepseek-rgg-core-gate.test.ts
+++ b/test/unit/ops/friday-c1-c2-deepseek-rgg-core-gate.test.ts
@@ -1,0 +1,116 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { evaluateDeepSeekRggCoreResult } from "../../../scripts/ops/friday-c1-c2-deepseek-rgg-core-gate.mjs";
+
+let tempRoot: string | null = null;
+
+function makeReportRoot(): string {
+  tempRoot = mkdtempSync(join(tmpdir(), "friday-c1-c2-rgg-core-test-"));
+  return tempRoot;
+}
+
+function writeReport(root: string, patch = {}, phasePatch = {}, meta = "deepseekRoutingConfigured=true\n"): void {
+  mkdirSync(root, { recursive: true });
+  writeFileSync(join(root, "real-green-gate-result.json"), `${JSON.stringify({
+    schema_version: 1,
+    status: "failed",
+    blocked_reasons: ["external channel prerequisite is not ready: unknown"],
+    scenarios_run: 55,
+    scenarios_total: 55,
+    scenarios_passed: 55,
+    provider_lane_scope: {
+      scope: "single_provider_default_only",
+      fallback_resilience_proven: false,
+    },
+    ...patch,
+  }, null, 2)}\n`);
+  writeFileSync(join(root, "phase-status.json"), `${JSON.stringify({
+    phases: {
+      externalChannels: {
+        status: "skipped",
+        reason: "external_channels.ready is not true",
+      },
+    },
+    ...phasePatch,
+  }, null, 2)}\n`);
+  writeFileSync(join(root, "self-hosted-runtime-meta.txt"), meta);
+}
+
+afterEach(() => {
+  if (tempRoot) {
+    rmSync(tempRoot, { recursive: true, force: true });
+    tempRoot = null;
+  }
+});
+
+describe("C1/C2 DeepSeek RGG core gate", () => {
+  it("passes when all RGG scenarios pass and only the separately tracked external-channel prerequisite blocks", async () => {
+    const root = makeReportRoot();
+    writeReport(root);
+
+    const evaluation = await evaluateDeepSeekRggCoreResult(root);
+
+    expect(evaluation.ok).toBe(true);
+    expect(evaluation.status).toBe("passed");
+    expect(evaluation.scenariosRun).toBe(55);
+    expect(evaluation.scenariosPassed).toBe(55);
+    expect(evaluation.deepseekRoutingConfigured).toBe(true);
+    expect(evaluation.externalChannelsSkipped).toBe(true);
+    expect(evaluation.truthLabel).toContain("strict organic=0");
+  });
+
+  it("also accepts a fully passed RGG result with no blocked reasons", async () => {
+    const root = makeReportRoot();
+    writeReport(root, { status: "passed", blocked_reasons: [] }, {
+      phases: { externalChannels: { status: "completed" } },
+    });
+
+    const evaluation = await evaluateDeepSeekRggCoreResult(root);
+
+    expect(evaluation.ok).toBe(true);
+    expect(evaluation.blockedReasons).toEqual([]);
+  });
+
+  it("fails closed when any non-channel RGG reason is blocked", async () => {
+    const root = makeReportRoot();
+    writeReport(root, { blocked_reasons: ["provider routing failed"] });
+
+    const evaluation = await evaluateDeepSeekRggCoreResult(root);
+
+    expect(evaluation.ok).toBe(false);
+    expect(evaluation.failures.join("\n")).toContain("unexpected blocked reasons");
+  });
+
+  it("fails closed when DeepSeek routing was not configured", async () => {
+    const root = makeReportRoot();
+    writeReport(root, {}, {}, "deepseekRoutingConfigured=false\n");
+
+    const evaluation = await evaluateDeepSeekRggCoreResult(root);
+
+    expect(evaluation.ok).toBe(false);
+    expect(evaluation.failures).toContain("DeepSeek routing was not configured");
+  });
+
+  it("fails closed when the scenarios are not all green", async () => {
+    const root = makeReportRoot();
+    writeReport(root, { scenarios_passed: 54 });
+
+    const evaluation = await evaluateDeepSeekRggCoreResult(root);
+
+    expect(evaluation.ok).toBe(false);
+    expect(evaluation.failures).toContain("RGG scenarios did not all pass");
+  });
+
+  it("fails closed when the result does not prove the DeepSeek single-provider lane", async () => {
+    const root = makeReportRoot();
+    writeReport(root, { provider_lane_scope: { scope: "multi_provider_fallback" } });
+
+    const evaluation = await evaluateDeepSeekRggCoreResult(root);
+
+    expect(evaluation.ok).toBe(false);
+    expect(evaluation.failures).toContain("RGG did not prove the single-provider DeepSeek default lane");
+  });
+});

--- a/test/unit/scripts/ops/friday-c1-c2-tier1-parity-capture.test.ts
+++ b/test/unit/scripts/ops/friday-c1-c2-tier1-parity-capture.test.ts
@@ -85,6 +85,9 @@ describe("C1/C2 Tier-1 parity capture runner", () => {
       "live-synthetic",
       "live-synthetic",
     ]);
+    expect(capture.TIER1_PARITY_FLOW_SPECS.find(
+      (flow) => flow.flowId === "c1-deepseek-real-green-routing-diagnostic",
+    )?.expectedHarness).toBe("scripts/ops/friday-c1-c2-deepseek-rgg-core-gate.mjs");
 
     const report = await capture.buildCaptureReport({
       enabled: false,


### PR DESCRIPTION
## Summary
- add a focused C1/C2 DeepSeek RGG core wrapper that treats external-channel prerequisite failure as a separately tracked live-synthetic blocker, not a DeepSeek routing failure
- point flow 16 at the focused wrapper while keeping live parity/organic claims false
- add unit coverage for pass/fail boundaries and pin the updated flow harness

## Validation
- node --check scripts/ops/friday-c1-c2-deepseek-rgg-core-gate.mjs
- node --check scripts/ops/friday-c1-c2-tier1-parity-capture.mjs
- npx vitest run --project default test/unit/ops/friday-c1-c2-deepseek-rgg-core-gate.test.ts test/unit/scripts/ops/friday-c1-c2-tier1-parity-capture.test.ts (12 tests PASS; run in isolated worktree with temporary node_modules symlink to existing local deps)
- wrapper live validation against scratch self-hosted RGG: 55/55 scenarios passed, DeepSeek routing configured, only blocked reason was external channel prerequisite
- branch artifact validation root /tmp/friday-c1-c2-tier1-rgg-core-branch-1781914197 reached 13/24 captured, strict organic=0

## Truth boundary
- Does not claim live parity, OG9, D20/B4 true-sign, or organic traffic
- Does not mark Discord/Telegram/Lark channel flows as passed
- Does not weaken RGG; non-channel blocked reasons still fail closed