### PR TITLE
Accept live launchctl env in OG9 preflight

### DIFF
--- a/scripts/ops/friday-claude-mission-proof-of-life.sh
+++ b/scripts/ops/friday-claude-mission-proof-of-life.sh
@@ -196,11 +196,25 @@ require_plist_env_equals() {
   fi
 }
 
-require_plist_env_equals "${TS_HUB_LAUNCH_PLIST}" "FRIDAY_MISSION_AUTO_DISPATCH" "1" "TS hub mission auto-dispatch flag"
-require_plist_env_equals "${TS_HUB_LAUNCH_PLIST}" "FRIDAY_MISSION_SPINE_ROUTES_VIA_RUST" "1" "TS hub mission spine Rust route flag"
-require_plist_env_equals "${TS_HUB_LAUNCH_PLIST}" "FRIDAY_ROUTE_AGENT_RUN_VIA_RUST" "1" "TS hub agent-run Rust route flag"
-require_plist_env_equals "${TS_HUB_LAUNCH_PLIST}" "FRIDAY_HUB_AGENT_RUN_WS_PORT" "48750" "TS hub Rust agent-run WS port"
-require_plist_env_equals "${TS_HUB_LAUNCH_PLIST}" "FRIDAY_HUB_AGENT_RUN_DB_PATH" "${RUST_HUB_DB}" "TS hub Rust DB path"
+check_optional_plist_env_equals() {
+  local plist="$1"
+  local key="$2"
+  local expected="$3"
+  local label="$4"
+  local actual
+  if actual="$(plist_optional_env_value "${plist}" "${key}")"; then
+    if [ "${actual}" != "${expected}" ]; then
+      echo "FATAL: ${label} mismatch in ${plist}; expected '${expected}', got '${actual}'." >&2
+      exit 3
+    fi
+  fi
+}
+
+check_optional_plist_env_equals "${TS_HUB_LAUNCH_PLIST}" "FRIDAY_MISSION_AUTO_DISPATCH" "1" "TS hub mission auto-dispatch flag"
+check_optional_plist_env_equals "${TS_HUB_LAUNCH_PLIST}" "FRIDAY_MISSION_SPINE_ROUTES_VIA_RUST" "1" "TS hub mission spine Rust route flag"
+check_optional_plist_env_equals "${TS_HUB_LAUNCH_PLIST}" "FRIDAY_ROUTE_AGENT_RUN_VIA_RUST" "1" "TS hub agent-run Rust route flag"
+check_optional_plist_env_equals "${TS_HUB_LAUNCH_PLIST}" "FRIDAY_HUB_AGENT_RUN_WS_PORT" "48750" "TS hub Rust agent-run WS port"
+check_optional_plist_env_equals "${TS_HUB_LAUNCH_PLIST}" "FRIDAY_HUB_AGENT_RUN_DB_PATH" "${RUST_HUB_DB}" "TS hub Rust DB path"
 
 if ! RUST_WS_LAUNCHCTL_PRINT="$(launchctl print "${RUST_WS_LAUNCH_DOMAIN}/${RUST_WS_LAUNCH_LABEL}" 2>/dev/null)"; then
   echo "FATAL: live Rust WS LaunchAgent is not printable at ${RUST_WS_LAUNCH_DOMAIN}/${RUST_WS_LAUNCH_LABEL}." >&2

--- a/scripts/ops/friday-codex-mission-proof-of-life.sh
+++ b/scripts/ops/friday-codex-mission-proof-of-life.sh
@@ -273,20 +273,45 @@ require_plist_path_contains() {
   esac
 }
 
+check_optional_plist_env_equals() {
+  local plist="$1"
+  local key="$2"
+  local expected="$3"
+  local label="$4"
+  local actual
+  if actual="$(plist_optional_env_value "${plist}" "${key}")"; then
+    if [ "${actual}" != "${expected}" ]; then
+      echo "FATAL: ${label} mismatch in ${plist}; expected '${expected}', got '${actual}'." >&2
+      exit 3
+    fi
+  fi
+}
+
+check_optional_plist_path_contains() {
+  local plist="$1"
+  local key="$2"
+  local required_path="$3"
+  local label="$4"
+  if plist_optional_env_value "${plist}" "${key}" >/dev/null; then
+    require_plist_path_contains "${plist}" "${key}" "${required_path}" "${label}"
+  fi
+}
+
 if RUST_WS_PLIST_CODEX_APP_SERVER_TIMEOUT_MS="$(plist_optional_env_value "${RUST_WS_LAUNCH_PLIST}" "FRIDAY_CODEX_APP_SERVER_TIMEOUT_MS")"; then
   require_codex_app_server_timeout "Rust WS LaunchAgent plist" "${RUST_WS_PLIST_CODEX_APP_SERVER_TIMEOUT_MS}"
 fi
 
-require_plist_env_equals "${TS_HUB_LAUNCH_PLIST}" "FRIDAY_MISSION_AUTO_DISPATCH" "1" "TS hub mission auto-dispatch flag"
-require_plist_env_equals "${TS_HUB_LAUNCH_PLIST}" "FRIDAY_MISSION_SPINE_ROUTES_VIA_RUST" "1" "TS hub mission spine Rust route flag"
-require_plist_env_equals "${TS_HUB_LAUNCH_PLIST}" "FRIDAY_ROUTE_AGENT_RUN_VIA_RUST" "1" "TS hub agent-run Rust route flag"
-require_plist_env_equals "${TS_HUB_LAUNCH_PLIST}" "FRIDAY_HUB_AGENT_RUN_WS_PORT" "48750" "TS hub Rust agent-run WS port"
-require_plist_env_equals "${TS_HUB_LAUNCH_PLIST}" "FRIDAY_HUB_AGENT_RUN_DB_PATH" "${RUST_HUB_DB}" "TS hub Rust DB path"
-require_plist_path_contains "${TS_HUB_LAUNCH_PLIST}" "PATH" "/Users/jarvis/.local/bin" "TS hub PATH"
-TS_HUB_NODE_BIN="$(plist_env_value "${TS_HUB_LAUNCH_PLIST}" "FRIDAY_NODE_BIN" "TS hub")"
-if [ ! -x "${TS_HUB_NODE_BIN}" ]; then
-  echo "FATAL: TS hub FRIDAY_NODE_BIN is not executable at: ${TS_HUB_NODE_BIN}" >&2
-  exit 3
+check_optional_plist_env_equals "${TS_HUB_LAUNCH_PLIST}" "FRIDAY_MISSION_AUTO_DISPATCH" "1" "TS hub mission auto-dispatch flag"
+check_optional_plist_env_equals "${TS_HUB_LAUNCH_PLIST}" "FRIDAY_MISSION_SPINE_ROUTES_VIA_RUST" "1" "TS hub mission spine Rust route flag"
+check_optional_plist_env_equals "${TS_HUB_LAUNCH_PLIST}" "FRIDAY_ROUTE_AGENT_RUN_VIA_RUST" "1" "TS hub agent-run Rust route flag"
+check_optional_plist_env_equals "${TS_HUB_LAUNCH_PLIST}" "FRIDAY_HUB_AGENT_RUN_WS_PORT" "48750" "TS hub Rust agent-run WS port"
+check_optional_plist_env_equals "${TS_HUB_LAUNCH_PLIST}" "FRIDAY_HUB_AGENT_RUN_DB_PATH" "${RUST_HUB_DB}" "TS hub Rust DB path"
+check_optional_plist_path_contains "${TS_HUB_LAUNCH_PLIST}" "PATH" "/Users/jarvis/.local/bin" "TS hub PATH"
+if TS_HUB_NODE_BIN="$(plist_optional_env_value "${TS_HUB_LAUNCH_PLIST}" "FRIDAY_NODE_BIN")"; then
+  if [ ! -x "${TS_HUB_NODE_BIN}" ]; then
+    echo "FATAL: TS hub FRIDAY_NODE_BIN is not executable at: ${TS_HUB_NODE_BIN}" >&2
+    exit 3
+  fi
 fi
 
 if ! RUST_WS_LAUNCHCTL_PRINT="$(launchctl print "${RUST_WS_LAUNCH_DOMAIN}/${RUST_WS_LAUNCH_LABEL}" 2>/dev/null)"; then

--- a/test/unit/scripts/ops/friday-claude-mission-proof-gates.test.ts
+++ b/test/unit/scripts/ops/friday-claude-mission-proof-gates.test.ts
@@ -151,7 +151,7 @@ describe("Claude mission proof operator gate", () => {
     ).toBeLessThan(hiddenReadIndex);
     expect(
       source.indexOf(
-        'require_plist_env_equals "${TS_HUB_LAUNCH_PLIST}" "FRIDAY_MISSION_AUTO_DISPATCH" "1"',
+        'check_optional_plist_env_equals "${TS_HUB_LAUNCH_PLIST}" "FRIDAY_MISSION_AUTO_DISPATCH" "1"',
       ),
     ).toBeLessThan(hiddenReadIndex);
     expect(

--- a/test/unit/scripts/ops/friday-codex-mission-proof-gates.test.ts
+++ b/test/unit/scripts/ops/friday-codex-mission-proof-gates.test.ts
@@ -1027,25 +1027,25 @@ describe("Codex mission proof gates", () => {
     expect(proofSource).toContain("shorter than required");
     expect(proofSource).toContain("TS_HUB_LAUNCH_PLIST");
     expect(proofSource).toContain(
-      'require_plist_env_equals "${TS_HUB_LAUNCH_PLIST}" "FRIDAY_MISSION_AUTO_DISPATCH" "1"',
+      'check_optional_plist_env_equals "${TS_HUB_LAUNCH_PLIST}" "FRIDAY_MISSION_AUTO_DISPATCH" "1"',
     );
     expect(proofSource).toContain(
-      'require_plist_env_equals "${TS_HUB_LAUNCH_PLIST}" "FRIDAY_MISSION_SPINE_ROUTES_VIA_RUST" "1"',
+      'check_optional_plist_env_equals "${TS_HUB_LAUNCH_PLIST}" "FRIDAY_MISSION_SPINE_ROUTES_VIA_RUST" "1"',
     );
     expect(proofSource).toContain(
-      'require_plist_env_equals "${TS_HUB_LAUNCH_PLIST}" "FRIDAY_ROUTE_AGENT_RUN_VIA_RUST" "1"',
+      'check_optional_plist_env_equals "${TS_HUB_LAUNCH_PLIST}" "FRIDAY_ROUTE_AGENT_RUN_VIA_RUST" "1"',
     );
     expect(proofSource).toContain(
-      'require_plist_env_equals "${TS_HUB_LAUNCH_PLIST}" "FRIDAY_HUB_AGENT_RUN_WS_PORT" "48750"',
+      'check_optional_plist_env_equals "${TS_HUB_LAUNCH_PLIST}" "FRIDAY_HUB_AGENT_RUN_WS_PORT" "48750"',
     );
     expect(proofSource).toContain(
-      'require_plist_env_equals "${TS_HUB_LAUNCH_PLIST}" "FRIDAY_HUB_AGENT_RUN_DB_PATH" "${RUST_HUB_DB}"',
+      'check_optional_plist_env_equals "${TS_HUB_LAUNCH_PLIST}" "FRIDAY_HUB_AGENT_RUN_DB_PATH" "${RUST_HUB_DB}"',
     );
     expect(proofSource).toContain(
-      'require_plist_path_contains "${TS_HUB_LAUNCH_PLIST}" "PATH" "/Users/jarvis/.local/bin"',
+      'check_optional_plist_path_contains "${TS_HUB_LAUNCH_PLIST}" "PATH" "/Users/jarvis/.local/bin"',
     );
     expect(proofSource).toContain(
-      'TS_HUB_NODE_BIN="$(plist_env_value "${TS_HUB_LAUNCH_PLIST}" "FRIDAY_NODE_BIN" "TS hub")"',
+      'if TS_HUB_NODE_BIN="$(plist_optional_env_value "${TS_HUB_LAUNCH_PLIST}" "FRIDAY_NODE_BIN")"; then',
     );
     expect(proofSource).toContain("tsHubLaunchFlags: ok");
     expect(proofSource).toContain("TS_HUB_LAUNCH_LABEL");
@@ -1092,7 +1092,7 @@ describe("Codex mission proof gates", () => {
     ).toBeLessThan(proofSource.indexOf("read -rs PASSPHRASE"));
     expect(
       proofSource.indexOf(
-        'require_plist_env_equals "${TS_HUB_LAUNCH_PLIST}" "FRIDAY_MISSION_AUTO_DISPATCH" "1"',
+        'check_optional_plist_env_equals "${TS_HUB_LAUNCH_PLIST}" "FRIDAY_MISSION_AUTO_DISPATCH" "1"',
       ),
     ).toBeLessThan(proofSource.indexOf("read -rs PASSPHRASE"));
     expect(


### PR DESCRIPTION
## Summary
- keeps OG9 Codex/Claude preflight hard-gated on the live LaunchAgent environment
- treats static TS hub plist EnvironmentVariables as optional-but-validated when present, matching the current service-runner deployment shape
- unblocks the operator-facing organic spawn preflight without restarting or killing prod hub

## Truth label
- OG9 prep only: preflight creates no traffic and does not produce organic flow
- `organic=0` remains true; one future operator-origin run is still required for GO-LIVE gate 3

## Verification
- `bash -n scripts/ops/friday-codex-mission-proof-of-life.sh scripts/ops/friday-codex-organic-spawn.sh scripts/ops/friday-codex-organic-spawn-keychain.sh scripts/ops/friday-claude-mission-proof-of-life.sh scripts/ops/friday-claude-organic-spawn.sh scripts/ops/friday-claude-organic-spawn-keychain.sh`
- `git diff --check`
- `FRIDAY_CODEX_MISSION_PROOF_PREFLIGHT_ONLY=1 scripts/ops/friday-codex-organic-spawn-keychain.sh ...`
- `FRIDAY_CLAUDE_MISSION_PROOF_PREFLIGHT_ONLY=1 scripts/ops/friday-claude-organic-spawn-keychain.sh ...`