### PR TITLE
Record skill OS sandbox evidence

### DIFF
--- a/src/skills/executor/friday-skill-executor.ts
+++ b/src/skills/executor/friday-skill-executor.ts
@@ -750,6 +750,40 @@ export function createFridaySkillExecutor(
     };
   }
 
+  function skillProcessSandboxMetadata(
+    runtimeKind: FridayRegisteredSkill["manifest"]["runtime"]["kind"],
+    skillDir: string,
+  ): Record<string, unknown> {
+    if (runtimeKind === "shell" || runtimeKind === "python") {
+      const sandbox = skillProcessSandbox(skillDir);
+      return {
+        boundary: sandbox.enabled
+          ? "darwin_sandbox_exec_write_network_guard"
+          : "os_sandbox_unavailable_fail_closed",
+        requested: sandbox.enabled,
+        required: sandbox.required === true,
+        denyNetwork: sandbox.denyNetwork !== false,
+        writableRootCount: sandbox.writableRoots?.length ?? 0,
+      };
+    }
+    if (runtimeKind === "node") {
+      return {
+        boundary: "disabled_in_production_unisolated_test_harness_only",
+        requested: false,
+        required: false,
+        denyNetwork: false,
+        writableRootCount: 0,
+      };
+    }
+    return {
+      boundary: "not_process_skill_runtime",
+      requested: false,
+      required: false,
+      denyNetwork: false,
+      writableRootCount: 0,
+    };
+  }
+
   function executeInternal(
     request: InternalFridaySkillExecuteRequest,
   ): FridaySkillExecuteHandle {
@@ -1335,6 +1369,7 @@ export function createFridaySkillExecutor(
               executionMode: readExecutionMode(registered),
               trustTier: (registered.trust as Partial<FridayRegisteredSkill["trust"]> | undefined)?.trustTier,
               allowedExecutionModes: (registered.trust as Partial<FridayRegisteredSkill["trust"]> | undefined)?.sandboxPolicy?.allowedExecutionModes ?? [],
+              os: skillProcessSandboxMetadata(manifest.runtime.kind, registered.skillDir),
             },
           },
         });

--- a/test/unit/skills/executor/friday-skill-executor.test.ts
+++ b/test/unit/skills/executor/friday-skill-executor.test.ts
@@ -181,6 +181,19 @@ describe("FridaySkillExecutor", () => {
     const result = await handle.result;
     expect(result.status).toBe("completed");
     expect(result.durationMs).toBeGreaterThanOrEqual(0);
+
+    const snapshot = runStore.getRun(handle.runId);
+    expect(snapshot?.metadata?.sandbox).toMatchObject({
+      os: {
+        boundary: process.platform === "darwin"
+          ? "darwin_sandbox_exec_write_network_guard"
+          : "os_sandbox_unavailable_fail_closed",
+        requested: process.platform === "darwin",
+        required: process.platform === "darwin",
+        denyNetwork: true,
+        writableRootCount: 1,
+      },
+    });
   });
 
   it("runs shell skills that require the local shell capability", async () => {
@@ -1274,6 +1287,16 @@ export async function execute(_input, ctx) {
         code: "CAPABILITY_DISABLED",
         capability: "skill_node_runtime",
         runtimeKind: "node",
+      });
+      const snapshot = runStore.getRun("test-id-0001");
+      expect(snapshot?.metadata?.sandbox).toMatchObject({
+        os: {
+          boundary: "disabled_in_production_unisolated_test_harness_only",
+          requested: false,
+          required: false,
+          denyNetwork: false,
+          writableRootCount: 0,
+        },
       });
     } finally {
       if (previousGate === undefined) {


### PR DESCRIPTION
## Summary
- record per-run OS sandbox metadata for shell/python skill execution
- keep Node skill runtime truth-labeled as disabled/unisolated in production by default
- add executor assertions so D2 evidence is behavioral, not just health text

## Truth labels
- D2 partial: shell/python skill process runs now carry sandbox evidence; Node/plugin/agent.exec remain not OS-isolated.
- No live flip, no operator signature, no organic traffic.

## Verification
- npx vitest run test/unit/skills/executor/friday-skill-executor.test.ts
- npx vitest run test/unit/skills/executor/friday-shell-executor.test.ts test/unit/api/http/routes/friday-health-routes.test.ts
- npm run typecheck:src