### PR TITLE
Add dark skill candidate materializer

### DIFF
--- a/rust-core/crates/friday-hub/src/bin/hub_skill_candidate_materialize.rs
+++ b/rust-core/crates/friday-hub/src/bin/hub_skill_candidate_materialize.rs
@@ -1,0 +1,189 @@
+//! D21 governed local skill-candidate materialize CLI.
+//!
+//! Operator-facing DARK bridge: verifies an operator-signed approval, copies a local
+//! SKILL.md package into a shadow candidate directory, and records a Mission-bound
+//! receipt. It never installs, promotes, or executes the candidate.
+
+use std::env;
+use std::io::Read;
+use std::path::Path;
+
+use friday_core::gate::{ApprovalDecision, CanonicalApproval, CANONICAL_GATE_ISSUER};
+use friday_hub::operator_vk::load_operator_vk_from_path;
+use friday_hub::skill_candidate_materializer::{
+    materialize_skill_candidate_ed25519, SkillCandidateMaterializeError,
+    SkillCandidateMaterializeRequest,
+};
+use friday_storage::Db;
+use serde::Deserialize;
+use serde_json::json;
+
+struct CliError {
+    kind: &'static str,
+}
+
+impl CliError {
+    fn new(kind: &'static str) -> Self {
+        Self { kind }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct SignedApprovalIn {
+    decision: String,
+    approval_id: String,
+    action_digest: String,
+    expires_at: i64,
+    #[serde(default)]
+    issuer: Option<String>,
+    signature: String,
+}
+
+fn main() {
+    match run() {
+        Ok(rendered) => println!("{rendered}"),
+        Err(err) => {
+            let payload = json!({
+                "truth_label": "d21_skill_candidate_materialize",
+                "ok": false,
+                "imports_skill": false,
+                "installs_skill": false,
+                "executes_skill": false,
+                "error_kind": err.kind,
+            });
+            let rendered = payload.to_string();
+            if reject_forbidden_output(&rendered).is_ok() {
+                println!("{rendered}");
+            }
+            eprintln!("hub_skill_candidate_materialize_unavailable: {}", err.kind);
+            std::process::exit(2);
+        }
+    }
+}
+
+fn run() -> Result<String, CliError> {
+    let args: Vec<String> = env::args().collect();
+    if args.get(1).map(String::as_str) != Some("materialize-local") {
+        return Err(CliError::new("bad_args"));
+    }
+
+    let db_path = arg_value(&args, "--db").ok_or(CliError::new("bad_args"))?;
+    let vk_path = arg_value(&args, "--operator-vk-path")
+        .or_else(|| env::var(friday_hub::operator_vk::OPERATOR_VK_PATH_ENV).ok())
+        .filter(|p| !p.trim().is_empty())
+        .ok_or(CliError::new("operator_vk_unprovisioned"))?;
+    let operator_vk = load_operator_vk_from_path(Path::new(vk_path.trim()))
+        .map_err(|_| CliError::new("operator_vk_malformed"))?;
+
+    let approval = read_approval(&args)?;
+    let now_ms = arg_value(&args, "--now-ms")
+        .and_then(|v| v.parse::<i64>().ok())
+        .unwrap_or_else(now_ms);
+    let db = Db::open_hub(&db_path).map_err(|_| CliError::new("init_failed"))?;
+    let receipt = materialize_skill_candidate_ed25519(
+        &db,
+        SkillCandidateMaterializeRequest {
+            source_dir: arg_value(&args, "--source-dir").ok_or(CliError::new("bad_args"))?,
+            candidate_root: arg_value(&args, "--candidate-root")
+                .ok_or(CliError::new("bad_args"))?,
+            skill_id: arg_value(&args, "--skill-id").ok_or(CliError::new("bad_args"))?,
+            source_digest: arg_value(&args, "--source-digest").ok_or(CliError::new("bad_args"))?,
+            mission_id: arg_value(&args, "--mission-id").ok_or(CliError::new("bad_args"))?,
+            work_item_id: arg_value(&args, "--work-item-id").ok_or(CliError::new("bad_args"))?,
+            operator_principal_id: arg_value(&args, "--operator-principal-id")
+                .unwrap_or_else(|| "operator".to_string()),
+            canonical_approval: approval,
+            proof_ref: arg_value(&args, "--proof-ref").ok_or(CliError::new("bad_args"))?,
+            now_ms,
+        },
+        &operator_vk,
+    )
+    .map_err(|err| CliError::new(skill_error_kind(&err)))?;
+
+    let payload = json!({
+        "truth_label": "d21_skill_candidate_materialize",
+        "ok": true,
+        "imports_skill": false,
+        "installs_skill": false,
+        "executes_skill": false,
+        "candidate_ref": receipt.candidate_ref,
+        "proof_ref": receipt.proof_ref,
+        "skill_id": receipt.skill_id,
+        "source_digest": receipt.source_digest,
+        "file_count": receipt.file_count,
+        "total_bytes": receipt.total_bytes,
+        "mission_id": receipt.mission_id,
+        "work_item_id": receipt.work_item_id,
+        "status": receipt.status,
+    });
+    let rendered =
+        serde_json::to_string(&payload).map_err(|_| CliError::new("serialize_failed"))?;
+    reject_forbidden_output(&rendered)?;
+    Ok(rendered)
+}
+
+fn read_approval(args: &[String]) -> Result<CanonicalApproval, CliError> {
+    let approval_json = match arg_value(args, "--approval-json") {
+        Some(path) => std::fs::read_to_string(path).map_err(|_| CliError::new("bad_args"))?,
+        None => {
+            let mut buf = String::new();
+            std::io::stdin()
+                .read_to_string(&mut buf)
+                .map_err(|_| CliError::new("bad_args"))?;
+            buf
+        }
+    };
+    let signed: SignedApprovalIn =
+        serde_json::from_str(approval_json.trim()).map_err(|_| CliError::new("bad_approval"))?;
+    Ok(CanonicalApproval {
+        decision: parse_decision(&signed.decision).ok_or(CliError::new("bad_approval"))?,
+        approval_id: signed.approval_id,
+        action_digest: signed.action_digest,
+        expires_at: Some(signed.expires_at),
+        issuer: Some(
+            signed
+                .issuer
+                .unwrap_or_else(|| CANONICAL_GATE_ISSUER.to_string()),
+        ),
+        signature: Some(signed.signature),
+    })
+}
+
+fn arg_value(args: &[String], name: &str) -> Option<String> {
+    args.windows(2)
+        .find_map(|pair| (pair[0] == name).then(|| pair[1].clone()))
+        .or_else(|| {
+            let prefix = format!("{name}=");
+            args.iter()
+                .find_map(|arg| arg.strip_prefix(&prefix).map(str::to_string))
+        })
+}
+
+fn parse_decision(value: &str) -> Option<ApprovalDecision> {
+    match value {
+        "approved" => Some(ApprovalDecision::Approved),
+        "denied" => Some(ApprovalDecision::Denied),
+        _ => None,
+    }
+}
+
+fn now_ms() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as i64)
+        .unwrap_or(0)
+}
+
+fn skill_error_kind(err: &SkillCandidateMaterializeError) -> &'static str {
+    match err {
+        SkillCandidateMaterializeError::Blocked(_) => "run_blocked",
+        SkillCandidateMaterializeError::Io(_) => "io_failed",
+        SkillCandidateMaterializeError::Serialize(_) => "serialize_failed",
+        SkillCandidateMaterializeError::Storage(_) => "storage_failed",
+    }
+}
+
+fn reject_forbidden_output(rendered: &str) -> Result<(), CliError> {
+    friday_hub::refs_guard::reject_forbidden_output(rendered, &["answer\":\""])
+        .map_err(|_| CliError::new("output_guard"))
+}

--- a/rust-core/crates/friday-hub/src/lib.rs
+++ b/rust-core/crates/friday-hub/src/lib.rs
@@ -336,6 +336,7 @@ pub mod crash_recovery;
 /// the existing `upsert_surface_event` persist; best-effort / non-fatal; never touches the reader.
 pub(crate) mod surface_events;
 
+pub mod skill_candidate_materializer;
 /// Skill / Capability Catalog / Advisor Bridge. Reads managed skill manifests as
 /// truth-labeled catalog entries and advisor inputs; it does not execute skills
 /// or grant control.

--- a/rust-core/crates/friday-hub/src/skill_candidate_materializer.rs
+++ b/rust-core/crates/friday-hub/src/skill_candidate_materializer.rs
@@ -204,6 +204,11 @@ fn validate_candidate_request(
             "source_inside_candidate_root".into(),
         ));
     }
+    if root.starts_with(&source) {
+        return Err(SkillCandidateMaterializeError::Blocked(
+            "candidate_root_inside_source".into(),
+        ));
+    }
     let files = collect_files(&source)?;
     if !files.iter().any(|file| file.rel == Path::new("SKILL.md")) {
         return Err(SkillCandidateMaterializeError::Blocked(
@@ -585,6 +590,41 @@ mod tests {
         .unwrap_err();
 
         assert!(err.to_string().contains("source_digest_mismatch"));
+        assert!(fs::read_dir(&candidate_root).unwrap().next().is_none());
+        assert!(db.list_mission_links("mission-skill").unwrap().is_empty());
+    }
+
+    #[test]
+    fn candidate_root_inside_source_is_rejected_before_writing() {
+        let source = temp_root("nested-source");
+        let candidate_root = source.join("candidates");
+        fs::create_dir_all(&source).unwrap();
+        fs::create_dir_all(&candidate_root).unwrap();
+        fs::write(source.join("SKILL.md"), "body").unwrap();
+        let files = collect_files(&source).unwrap();
+        let digest = candidate_digest(&files);
+        let db = Db::open_hub(&temp_db("nested")).unwrap();
+        seed_mission(&db);
+
+        let err = materialize_skill_candidate(
+            &db,
+            SkillCandidateMaterializeRequest {
+                source_dir: source.to_string_lossy().to_string(),
+                candidate_root: candidate_root.to_string_lossy().to_string(),
+                skill_id: "summarize".into(),
+                source_digest: digest.clone(),
+                mission_id: "mission-skill".into(),
+                work_item_id: "work-skill".into(),
+                operator_principal_id: "operator".into(),
+                canonical_approval: approval("summarize", &digest),
+                proof_ref: "proof://skill-candidate/summarize".into(),
+                now_ms: 10,
+            },
+            APPROVAL_SECRET,
+        )
+        .unwrap_err();
+
+        assert!(err.to_string().contains("candidate_root_inside_source"));
         assert!(fs::read_dir(&candidate_root).unwrap().next().is_none());
         assert!(db.list_mission_links("mission-skill").unwrap().is_empty());
     }

--- a/rust-core/crates/friday-hub/src/skill_candidate_materializer.rs
+++ b/rust-core/crates/friday-hub/src/skill_candidate_materializer.rs
@@ -1,0 +1,591 @@
+//! D21 local SKILL.md candidate materializer.
+//!
+//! This is a DARK, local-only import leg. It copies a reviewed local SKILL.md package
+//! into a shadow candidate area and records a Mission-bound receipt. It does not install,
+//! promote, mark runnable, or execute the skill.
+
+use std::{
+    collections::BTreeMap,
+    fs,
+    path::{Component, Path, PathBuf},
+};
+
+use friday_core::{
+    gate::{Actor, ActorKind, CanonicalApproval, GateDecision, MutatingActionRequest},
+    MissionLink, MissionLinkKind,
+};
+use friday_crypto::OperatorVerifyingKey;
+use friday_storage::{
+    authorize_mutating_action, authorize_mutating_action_ed25519, Db, StorageError,
+};
+use sha2::{Digest, Sha256};
+
+const MAX_FILES: usize = 64;
+const MAX_TOTAL_BYTES: u64 = 512 * 1024;
+const MAX_DEPTH: usize = 8;
+
+#[derive(Debug, thiserror::Error)]
+pub enum SkillCandidateMaterializeError {
+    #[error("skill candidate materialize blocked: {0}")]
+    Blocked(String),
+    #[error("skill candidate materialize io failed")]
+    Io(#[from] std::io::Error),
+    #[error("skill candidate materialize serialize failed")]
+    Serialize(#[from] serde_json::Error),
+    #[error("skill candidate materialize storage failed")]
+    Storage(#[from] StorageError),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SkillCandidateMaterializeRequest {
+    pub source_dir: String,
+    pub candidate_root: String,
+    pub skill_id: String,
+    pub source_digest: String,
+    pub mission_id: String,
+    pub work_item_id: String,
+    pub operator_principal_id: String,
+    pub canonical_approval: CanonicalApproval,
+    pub proof_ref: String,
+    pub now_ms: i64,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SkillCandidateMaterializeReceipt {
+    pub candidate_ref: String,
+    pub proof_ref: String,
+    pub skill_id: String,
+    pub source_digest: String,
+    pub file_count: usize,
+    pub total_bytes: u64,
+    pub mission_id: String,
+    pub work_item_id: String,
+    pub status: String,
+}
+
+#[derive(Clone, Debug)]
+struct CandidateFile {
+    rel: PathBuf,
+    bytes: Vec<u8>,
+}
+
+pub fn materialize_skill_candidate(
+    db: &Db,
+    request: SkillCandidateMaterializeRequest,
+    approval_secret: &[u8],
+) -> Result<SkillCandidateMaterializeReceipt, SkillCandidateMaterializeError> {
+    let files = validate_candidate_request(db, &request)?;
+    let gate_request = skill_candidate_materialize_gate_request(
+        &request.skill_id,
+        &request.source_digest,
+        &request.mission_id,
+        &request.work_item_id,
+        &request.operator_principal_id,
+    );
+    let gate = authorize_mutating_action(
+        db.conn(),
+        &gate_request,
+        Some(&request.canonical_approval),
+        approval_secret,
+        request.now_ms,
+    )?;
+    if gate.decision != GateDecision::Allow {
+        return Err(SkillCandidateMaterializeError::Blocked(format!(
+            "candidate_materialize_canonical_gate_{}",
+            gate.reason
+        )));
+    }
+    write_candidate(db, request, files)
+}
+
+pub fn materialize_skill_candidate_ed25519(
+    db: &Db,
+    request: SkillCandidateMaterializeRequest,
+    operator_vk: &OperatorVerifyingKey,
+) -> Result<SkillCandidateMaterializeReceipt, SkillCandidateMaterializeError> {
+    let files = validate_candidate_request(db, &request)?;
+    let gate_request = skill_candidate_materialize_gate_request(
+        &request.skill_id,
+        &request.source_digest,
+        &request.mission_id,
+        &request.work_item_id,
+        &request.operator_principal_id,
+    );
+    let gate = authorize_mutating_action_ed25519(
+        db.conn(),
+        &gate_request,
+        Some(&request.canonical_approval),
+        operator_vk,
+        request.now_ms,
+    )?;
+    if gate.decision != GateDecision::Allow {
+        return Err(SkillCandidateMaterializeError::Blocked(format!(
+            "candidate_materialize_canonical_gate_{}",
+            gate.reason
+        )));
+    }
+    write_candidate(db, request, files)
+}
+
+pub fn skill_candidate_materialize_gate_request(
+    skill_id: &str,
+    source_digest: &str,
+    mission_id: &str,
+    work_item_id: &str,
+    operator_principal_id: &str,
+) -> MutatingActionRequest {
+    let params = vec![
+        ("target".to_string(), skill_id.to_string()),
+        ("source_digest".to_string(), source_digest.to_string()),
+        ("mission_id".to_string(), mission_id.to_string()),
+        ("work_item_id".to_string(), work_item_id.to_string()),
+    ];
+    MutatingActionRequest::from_classification(
+        friday_core::gate::classify(true, friday_core::Risk::High, "materialize_skill_candidate", &params),
+        "materialize_skill_candidate".to_string(),
+        Actor {
+            kind: ActorKind::Owner,
+            id: operator_principal_id.to_string(),
+            principal_id: Some(operator_principal_id.to_string()),
+        },
+        "friday_hub_skill_candidate_materializer".to_string(),
+        Vec::new(),
+        Some(format!(
+            "skill_id={skill_id};source_digest={source_digest};mission_id={mission_id};work_item_id={work_item_id}"
+        )),
+        Some(format!("skill-candidate:{skill_id}:{source_digest}:{mission_id}:{work_item_id}")),
+        None,
+    )
+}
+
+fn validate_candidate_request(
+    db: &Db,
+    request: &SkillCandidateMaterializeRequest,
+) -> Result<Vec<CandidateFile>, SkillCandidateMaterializeError> {
+    if !is_safe_id(&request.skill_id) || !is_safe_id(&request.source_digest) {
+        return Err(SkillCandidateMaterializeError::Blocked(
+            "safe_public_metadata_required".into(),
+        ));
+    }
+    if !request.proof_ref.starts_with("proof://") {
+        return Err(SkillCandidateMaterializeError::Blocked(
+            "proof_ref_required".into(),
+        ));
+    }
+    let mission = db
+        .get_mission(&request.mission_id)?
+        .ok_or_else(|| SkillCandidateMaterializeError::Blocked("unknown_mission".into()))?;
+    if mission.status.is_terminal() {
+        return Err(SkillCandidateMaterializeError::Blocked(
+            "mission_is_terminal".into(),
+        ));
+    }
+    let work_item = db
+        .get_work_item(&request.work_item_id)?
+        .ok_or_else(|| SkillCandidateMaterializeError::Blocked("unknown_work_item".into()))?;
+    if work_item.mission_id != request.mission_id {
+        return Err(SkillCandidateMaterializeError::Blocked(
+            "work_item_mission_mismatch".into(),
+        ));
+    }
+    if work_item.status.is_terminal() {
+        return Err(SkillCandidateMaterializeError::Blocked(
+            "work_item_is_terminal".into(),
+        ));
+    }
+
+    let source = fs::canonicalize(&request.source_dir)?;
+    let root = fs::canonicalize(&request.candidate_root).or_else(|_| {
+        fs::create_dir_all(&request.candidate_root)?;
+        fs::canonicalize(&request.candidate_root)
+    })?;
+    if source.starts_with(&root) {
+        return Err(SkillCandidateMaterializeError::Blocked(
+            "source_inside_candidate_root".into(),
+        ));
+    }
+    let files = collect_files(&source)?;
+    if !files.iter().any(|file| file.rel == Path::new("SKILL.md")) {
+        return Err(SkillCandidateMaterializeError::Blocked(
+            "skill_md_required".into(),
+        ));
+    }
+    let digest = candidate_digest(&files);
+    if digest != request.source_digest {
+        return Err(SkillCandidateMaterializeError::Blocked(
+            "source_digest_mismatch".into(),
+        ));
+    }
+    Ok(files)
+}
+
+fn collect_files(source: &Path) -> Result<Vec<CandidateFile>, SkillCandidateMaterializeError> {
+    let mut out = Vec::new();
+    collect_files_inner(source, source, &mut out)?;
+    out.sort_by(|a, b| a.rel.cmp(&b.rel));
+    let total = out.iter().map(|f| f.bytes.len() as u64).sum::<u64>();
+    if out.len() > MAX_FILES || total > MAX_TOTAL_BYTES {
+        return Err(SkillCandidateMaterializeError::Blocked(
+            "candidate_size_limit".into(),
+        ));
+    }
+    Ok(out)
+}
+
+fn collect_files_inner(
+    root: &Path,
+    dir: &Path,
+    out: &mut Vec<CandidateFile>,
+) -> Result<(), SkillCandidateMaterializeError> {
+    for entry in fs::read_dir(dir)? {
+        let entry = entry?;
+        let ty = entry.file_type()?;
+        if ty.is_symlink() {
+            return Err(SkillCandidateMaterializeError::Blocked(
+                "symlink_rejected".into(),
+            ));
+        }
+        let path = entry.path();
+        if ty.is_dir() {
+            collect_files_inner(root, &path, out)?;
+            continue;
+        }
+        if !ty.is_file() {
+            return Err(SkillCandidateMaterializeError::Blocked(
+                "special_file_rejected".into(),
+            ));
+        }
+        let rel = path
+            .strip_prefix(root)
+            .map_err(|_| SkillCandidateMaterializeError::Blocked("path_escape".into()))?;
+        validate_relative_path(rel)?;
+        out.push(CandidateFile {
+            rel: rel.to_path_buf(),
+            bytes: fs::read(&path)?,
+        });
+    }
+    Ok(())
+}
+
+fn validate_relative_path(path: &Path) -> Result<(), SkillCandidateMaterializeError> {
+    let depth = path.components().count();
+    if depth == 0 || depth > MAX_DEPTH {
+        return Err(SkillCandidateMaterializeError::Blocked(
+            "path_depth_limit".into(),
+        ));
+    }
+    for component in path.components() {
+        match component {
+            Component::Normal(part) if is_safe_path_part(&part.to_string_lossy()) => {}
+            _ => {
+                return Err(SkillCandidateMaterializeError::Blocked(
+                    "unsafe_path".into(),
+                ))
+            }
+        }
+    }
+    Ok(())
+}
+
+fn write_candidate(
+    db: &Db,
+    request: SkillCandidateMaterializeRequest,
+    files: Vec<CandidateFile>,
+) -> Result<SkillCandidateMaterializeReceipt, SkillCandidateMaterializeError> {
+    let candidate_ref = redacted_ref(
+        "skill-candidate",
+        &format!(
+            "{}:{}:{}:{}",
+            request.skill_id, request.source_digest, request.mission_id, request.work_item_id
+        ),
+    );
+    let candidate_dir = Path::new(&request.candidate_root).join(&candidate_ref);
+    let files_dir = candidate_dir.join("files");
+    fs::create_dir_all(&files_dir)?;
+    for file in &files {
+        let target = files_dir.join(&file.rel);
+        if let Some(parent) = target.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        fs::write(target, &file.bytes)?;
+    }
+    let total_bytes = files
+        .iter()
+        .map(|file| file.bytes.len() as u64)
+        .sum::<u64>();
+    let metadata = BTreeMap::from([
+        ("candidate_ref", candidate_ref.clone()),
+        ("skill_id", request.skill_id.clone()),
+        ("source_digest", request.source_digest.clone()),
+        (
+            "status",
+            "materialized_candidate_not_installed_not_executable".to_string(),
+        ),
+    ]);
+    fs::write(
+        candidate_dir.join("candidate.json"),
+        serde_json::to_vec_pretty(&metadata)?,
+    )?;
+    db.upsert_mission_link(&MissionLink {
+        link_id: candidate_ref.clone(),
+        mission_id: request.mission_id.clone(),
+        work_item_id: Some(request.work_item_id.clone()),
+        link_kind: MissionLinkKind::ProofReceipt,
+        target_ref: candidate_ref.clone(),
+        proof_ref: Some(request.proof_ref.clone()),
+        created_at_ms: request.now_ms,
+    })?;
+    Ok(SkillCandidateMaterializeReceipt {
+        candidate_ref,
+        proof_ref: request.proof_ref,
+        skill_id: request.skill_id,
+        source_digest: request.source_digest,
+        file_count: files.len(),
+        total_bytes,
+        mission_id: request.mission_id,
+        work_item_id: request.work_item_id,
+        status: "materialized_candidate_not_installed_not_executable".to_string(),
+    })
+}
+
+fn candidate_digest(files: &[CandidateFile]) -> String {
+    let mut hash = Sha256::new();
+    for file in files {
+        hash.update(file.rel.to_string_lossy().as_bytes());
+        hash.update([0]);
+        hash.update(&file.bytes);
+        hash.update([0]);
+    }
+    format!("skill-candidate-{}", hex_digest(hash.finalize().as_slice()))
+}
+
+fn redacted_ref(prefix: &str, value: &str) -> String {
+    let mut hash = Sha256::new();
+    hash.update(value.as_bytes());
+    format!("{prefix}:{}", hex_digest(hash.finalize().as_slice()))
+}
+
+fn hex_digest(bytes: &[u8]) -> String {
+    bytes.iter().map(|b| format!("{b:02x}")).collect::<String>()
+}
+
+fn is_safe_id(value: &str) -> bool {
+    !value.is_empty()
+        && value.len() <= 96
+        && value
+            .chars()
+            .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '.'))
+}
+
+fn is_safe_path_part(value: &str) -> bool {
+    is_safe_id(value) || value == "SKILL.md"
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use friday_core::{
+        gate::CanonicalApproval, ApprovalState, FridayConversation, HandoffJudgmentMemory, Mission,
+        MissionStatus, Risk, TruthStatus, WorkItem, WorkItemStatus, WorkLane,
+    };
+    use friday_storage::Db;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    const APPROVAL_SECRET: &[u8] = b"skill-candidate-materialize-secret";
+    static TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+    fn temp_root(name: &str) -> PathBuf {
+        let seq = TEMP_COUNTER.fetch_add(1, Ordering::Relaxed);
+        std::env::temp_dir().join(format!(
+            "friday-skill-candidate-materialize-{name}-{}-{seq}",
+            std::process::id()
+        ))
+    }
+
+    fn temp_db(name: &str) -> String {
+        temp_root(name)
+            .with_extension("sqlite")
+            .to_string_lossy()
+            .into_owned()
+    }
+
+    fn seed_mission(db: &Db) {
+        db.upsert_friday_conversation(&FridayConversation {
+            friday_conversation_id: "fconv_skill".into(),
+            owner_principal: "operator".into(),
+            title: "Skill Conversation".into(),
+            current_focus_summary: "Materialize skill candidate".into(),
+            active_mission_ids: vec!["mission-skill".into()],
+            surface_thread_ids: Vec::new(),
+            memory_scope_ref: None,
+            truth_status: TruthStatus::Proven,
+            proof_refs: Vec::new(),
+            created_at_ms: 1,
+            updated_at_ms: 1,
+        })
+        .unwrap();
+        db.upsert_mission(&Mission {
+            mission_id: "mission-skill".into(),
+            friday_conversation_id: "fconv_skill".into(),
+            title: "Skill Mission".into(),
+            intent: "Review a local SKILL.md candidate".into(),
+            status: MissionStatus::Active,
+            why_now: "User wants a governed skill candidate".into(),
+            decision_path_summary: "Materialize shadow candidate only.".into(),
+            considered_options: vec!["direct install".into(), "shadow candidate".into()],
+            deferred_options: vec!["runtime execution".into()],
+            known_pitfalls: vec!["materialize is not install".into()],
+            handoff_inheritance: vec!["keep candidate dark".into()],
+            work_item_ids: vec!["work-skill".into()],
+            memory_candidate_refs: Vec::new(),
+            context_passport_refs: Vec::new(),
+            proof_refs: Vec::new(),
+            created_at_ms: 1,
+            updated_at_ms: 1,
+        })
+        .unwrap();
+        db.upsert_work_item(&WorkItem {
+            work_item_id: "work-skill".into(),
+            mission_id: "mission-skill".into(),
+            lane: WorkLane::FridayHub,
+            target_provider_or_agent: Some("skill-candidate".into()),
+            status: WorkItemStatus::ReadyToDispatch,
+            owner_claim_ids: Vec::new(),
+            workspace_refs: Vec::new(),
+            capability_id: Some("skill.materialize".into()),
+            risk_level: Risk::Low,
+            approval_state: ApprovalState::Approved,
+            blocking_reason: None,
+            input_refs: vec!["friday://body/skill-candidate".into()],
+            output_refs: Vec::new(),
+            proof_requirements: vec!["candidate materialize receipt".into()],
+            proof_receipts: Vec::new(),
+            judgment_memory: HandoffJudgmentMemory {
+                task: "Materialize a skill candidate".into(),
+                current_blocker: None,
+                target_lane_thread_agent_provider: "skill-candidate".into(),
+                read_first_files: vec!["SKILL.md".into()],
+                required_output: "candidate receipt only".into(),
+                done_criteria: vec!["shadow candidate written".into()],
+                red_lines: vec!["do not install or execute".into()],
+                why_this_route: "D21 governed import dark leg.".into(),
+                considered_options: vec!["direct install".into()],
+                deferred_options: vec!["execution".into()],
+                previous_pitfalls: vec!["import looked like runnable".into()],
+                inheritable_context: vec!["candidate is not installed".into()],
+                proof_requirements: vec!["operator approval".into()],
+                ownership_claim_ids: Vec::new(),
+            },
+            created_at_ms: 1,
+            updated_at_ms: 1,
+        })
+        .unwrap();
+    }
+
+    fn approval(skill_id: &str, digest: &str) -> CanonicalApproval {
+        crate::mint_approval(
+            &skill_candidate_materialize_gate_request(
+                skill_id,
+                digest,
+                "mission-skill",
+                "work-skill",
+                "operator",
+            ),
+            "approval-materialize",
+            APPROVAL_SECRET,
+            10_000,
+        )
+    }
+
+    #[test]
+    fn materializes_local_skill_md_candidate_without_install_or_execution() {
+        let source = temp_root("source");
+        let candidate_root = temp_root("candidates");
+        fs::create_dir_all(&source).unwrap();
+        fs::create_dir_all(&candidate_root).unwrap();
+        fs::write(
+            source.join("SKILL.md"),
+            "---\nid: summarize\n---\nSummarize safely.\n",
+        )
+        .unwrap();
+        let files = collect_files(&source).unwrap();
+        let digest = candidate_digest(&files);
+        let db = Db::open_hub(&temp_db("happy")).unwrap();
+        seed_mission(&db);
+
+        let receipt = materialize_skill_candidate(
+            &db,
+            SkillCandidateMaterializeRequest {
+                source_dir: source.to_string_lossy().to_string(),
+                candidate_root: candidate_root.to_string_lossy().to_string(),
+                skill_id: "summarize".into(),
+                source_digest: digest.clone(),
+                mission_id: "mission-skill".into(),
+                work_item_id: "work-skill".into(),
+                operator_principal_id: "operator".into(),
+                canonical_approval: approval("summarize", &digest),
+                proof_ref: "proof://skill-candidate/summarize".into(),
+                now_ms: 10,
+            },
+            APPROVAL_SECRET,
+        )
+        .unwrap();
+
+        assert_eq!(
+            receipt.status,
+            "materialized_candidate_not_installed_not_executable"
+        );
+        assert_eq!(receipt.file_count, 1);
+        assert!(candidate_root
+            .join(&receipt.candidate_ref)
+            .join("files")
+            .join("SKILL.md")
+            .is_file());
+        assert!(candidate_root
+            .join(&receipt.candidate_ref)
+            .join("candidate.json")
+            .is_file());
+        let item = db.get_work_item("work-skill").unwrap().unwrap();
+        assert_eq!(item.status, WorkItemStatus::ReadyToDispatch);
+        assert!(item.proof_receipts.is_empty());
+        let links = db.list_mission_links("mission-skill").unwrap();
+        assert_eq!(links.len(), 1);
+        assert_eq!(links[0].target_ref, receipt.candidate_ref);
+        let rendered = format!("{receipt:?}");
+        assert!(!rendered.contains(source.to_string_lossy().as_ref()));
+        assert!(!rendered.contains("Summarize safely"));
+    }
+
+    #[test]
+    fn digest_mismatch_blocks_before_writing_candidate() {
+        let source = temp_root("mismatch-source");
+        let candidate_root = temp_root("mismatch-candidates");
+        fs::create_dir_all(&source).unwrap();
+        fs::create_dir_all(&candidate_root).unwrap();
+        fs::write(source.join("SKILL.md"), "body").unwrap();
+        let db = Db::open_hub(&temp_db("mismatch")).unwrap();
+        seed_mission(&db);
+
+        let err = materialize_skill_candidate(
+            &db,
+            SkillCandidateMaterializeRequest {
+                source_dir: source.to_string_lossy().to_string(),
+                candidate_root: candidate_root.to_string_lossy().to_string(),
+                skill_id: "summarize".into(),
+                source_digest: "skill-candidate-wrong".into(),
+                mission_id: "mission-skill".into(),
+                work_item_id: "work-skill".into(),
+                operator_principal_id: "operator".into(),
+                canonical_approval: approval("summarize", "skill-candidate-wrong"),
+                proof_ref: "proof://skill-candidate/summarize".into(),
+                now_ms: 10,
+            },
+            APPROVAL_SECRET,
+        )
+        .unwrap_err();
+
+        assert!(err.to_string().contains("source_digest_mismatch"));
+        assert!(fs::read_dir(&candidate_root).unwrap().next().is_none());
+        assert!(db.list_mission_links("mission-skill").unwrap().is_empty());
+    }
+}

--- a/rust-core/crates/friday-hub/tests/skill_candidate_materialize_cli.rs
+++ b/rust-core/crates/friday-hub/tests/skill_candidate_materialize_cli.rs
@@ -1,0 +1,370 @@
+//! D21 local SKILL.md candidate materialize CLI tests.
+//!
+//! The CLI verifies an operator Ed25519 approval with only the public key, copies
+//! a local SKILL.md package into a shadow candidate directory, and never imports,
+//! installs, or executes the skill.
+
+use std::process::Command;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use friday_core::gate::{
+    canonical_action_bytes, canonical_approval_signature_bytes, ApprovalDecision,
+    CanonicalApproval, MutatingActionRequest, CANONICAL_GATE_ISSUER,
+};
+use friday_core::{
+    ApprovalState, FridayConversation, HandoffJudgmentMemory, Mission, MissionStatus, Risk,
+    TruthStatus, WorkItem, WorkItemStatus, WorkLane,
+};
+use friday_crypto::{OperatorSigningKey, OperatorVerifyingKey};
+use friday_hub::skill_candidate_materializer::skill_candidate_materialize_gate_request;
+use friday_storage::Db;
+use serde_json::Value;
+use sha2::{Digest, Sha256};
+
+const HUB_HMAC_SECRET: &[u8] = b"hub-held-hmac-gate-secret-0123456789";
+const NOW: i64 = 1_000;
+const FUTURE: i64 = 5_000_000_000_000;
+
+static C: AtomicU64 = AtomicU64::new(0);
+
+fn unique(tag: &str) -> String {
+    format!(
+        "{}-{}-{}",
+        std::process::id(),
+        tag,
+        C.fetch_add(1, Ordering::Relaxed)
+    )
+}
+
+fn temp_path(tag: &str) -> std::path::PathBuf {
+    std::env::temp_dir().join(format!("friday-skill-materialize-cli-{}", unique(tag)))
+}
+
+fn temp_db(tag: &str) -> String {
+    temp_path(&format!("{tag}.sqlite"))
+        .to_string_lossy()
+        .into_owned()
+}
+
+fn vk_hex(vk: &OperatorVerifyingKey) -> String {
+    vk.to_bytes()
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect()
+}
+
+fn operator() -> (OperatorSigningKey, OperatorVerifyingKey) {
+    let sk = OperatorSigningKey::generate();
+    let vk = sk.verifying_key();
+    (sk, vk)
+}
+
+fn ed_approval(
+    req: &MutatingActionRequest,
+    sk: &OperatorSigningKey,
+    approval_id: &str,
+) -> CanonicalApproval {
+    let digest = friday_crypto::action_digest(&canonical_action_bytes(req));
+    let mut approval = CanonicalApproval {
+        decision: ApprovalDecision::Approved,
+        approval_id: approval_id.to_string(),
+        action_digest: digest,
+        expires_at: Some(FUTURE),
+        issuer: Some(CANONICAL_GATE_ISSUER.to_string()),
+        signature: None,
+    };
+    approval.signature = Some(
+        sk.sign(&canonical_approval_signature_bytes(&approval))
+            .to_hex(),
+    );
+    approval
+}
+
+fn hmac_approval(req: &MutatingActionRequest, approval_id: &str) -> CanonicalApproval {
+    let digest = friday_crypto::action_digest(&canonical_action_bytes(req));
+    let mut approval = CanonicalApproval {
+        decision: ApprovalDecision::Approved,
+        approval_id: approval_id.to_string(),
+        action_digest: digest,
+        expires_at: Some(FUTURE),
+        issuer: Some(CANONICAL_GATE_ISSUER.to_string()),
+        signature: None,
+    };
+    approval.signature = Some(friday_crypto::sign_approval(
+        &canonical_approval_signature_bytes(&approval),
+        HUB_HMAC_SECRET,
+    ));
+    approval
+}
+
+fn write_approval(path: &std::path::Path, approval: &CanonicalApproval) {
+    let decision = match approval.decision {
+        ApprovalDecision::Approved => "approved",
+        ApprovalDecision::Denied => "denied",
+    };
+    let body = serde_json::json!({
+        "decision": decision,
+        "approval_id": approval.approval_id,
+        "action_digest": approval.action_digest,
+        "expires_at": approval.expires_at.unwrap(),
+        "issuer": approval.issuer,
+        "signature": approval.signature,
+    });
+    std::fs::write(path, body.to_string()).unwrap();
+}
+
+fn source_digest(skill_md: &[u8]) -> String {
+    let mut hash = Sha256::new();
+    hash.update(b"SKILL.md");
+    hash.update([0]);
+    hash.update(skill_md);
+    hash.update([0]);
+    let digest = hash
+        .finalize()
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect::<String>();
+    format!("skill-candidate-{digest}")
+}
+
+fn judgment() -> HandoffJudgmentMemory {
+    HandoffJudgmentMemory {
+        task: "Materialize a governed local SKILL.md candidate".into(),
+        current_blocker: None,
+        target_lane_thread_agent_provider: WorkLane::FridayHub.as_str().into(),
+        read_first_files: vec![
+            "rust-core/crates/friday-hub/src/bin/hub_skill_candidate_materialize.rs".into(),
+        ],
+        required_output: "shadow candidate receipt".into(),
+        done_criteria: vec!["candidate copied without import, install, or execution".into()],
+        red_lines: vec!["Hub must not self-mint operator approval".into()],
+        why_this_route: "D21 A4 needs a dark governed local materialize leg.".into(),
+        considered_options: vec!["legacy import route".into()],
+        deferred_options: vec!["runtime skill import".into(), "skill execution".into()],
+        previous_pitfalls: vec!["materialized candidate mistaken for runnable skill".into()],
+        inheritable_context: vec!["verify-only governance".into()],
+        proof_requirements: vec!["CLI materialize test".into()],
+        ownership_claim_ids: Vec::new(),
+    }
+}
+
+fn seed_mission(db: &Db) {
+    db.upsert_friday_conversation(&FridayConversation {
+        friday_conversation_id: "fconv_skill_materialize_cli".into(),
+        owner_principal: "operator".into(),
+        title: "Skill Candidate Materialize CLI".into(),
+        current_focus_summary: "Materialize shadow candidate".into(),
+        active_mission_ids: vec!["mission-skill-materialize-cli".into()],
+        surface_thread_ids: Vec::new(),
+        memory_scope_ref: None,
+        truth_status: TruthStatus::Proven,
+        proof_refs: Vec::new(),
+        created_at_ms: NOW,
+        updated_at_ms: NOW,
+    })
+    .unwrap();
+    db.upsert_mission(&Mission {
+        mission_id: "mission-skill-materialize-cli".into(),
+        friday_conversation_id: "fconv_skill_materialize_cli".into(),
+        title: "Skill Candidate Materialize CLI".into(),
+        intent: "Materialize a local skill candidate without importing or executing it".into(),
+        status: MissionStatus::Active,
+        why_now: "D21 needs an operator-facing verify-only local candidate bridge".into(),
+        decision_path_summary: "Verify Ed25519 approval before writing a shadow candidate.".into(),
+        considered_options: vec!["legacy import".into()],
+        deferred_options: vec!["runtime execution".into()],
+        known_pitfalls: vec!["candidate link confused with installation".into()],
+        handoff_inheritance: vec!["Hub verifies, operator signs".into()],
+        work_item_ids: vec!["work-skill-materialize-cli".into()],
+        memory_candidate_refs: Vec::new(),
+        context_passport_refs: Vec::new(),
+        proof_refs: Vec::new(),
+        created_at_ms: NOW,
+        updated_at_ms: NOW,
+    })
+    .unwrap();
+    db.upsert_work_item(&WorkItem {
+        work_item_id: "work-skill-materialize-cli".into(),
+        mission_id: "mission-skill-materialize-cli".into(),
+        lane: WorkLane::FridayHub,
+        target_provider_or_agent: Some("skill:candidate".into()),
+        status: WorkItemStatus::ReadyToDispatch,
+        owner_claim_ids: Vec::new(),
+        workspace_refs: Vec::new(),
+        capability_id: Some("skill.candidate.materialize".into()),
+        risk_level: Risk::Low,
+        approval_state: ApprovalState::Approved,
+        blocking_reason: None,
+        input_refs: vec!["friday://body/skill-candidate".into()],
+        output_refs: Vec::new(),
+        proof_requirements: vec!["skill candidate materialize receipt".into()],
+        proof_receipts: Vec::new(),
+        judgment_memory: judgment(),
+        created_at_ms: NOW,
+        updated_at_ms: NOW,
+    })
+    .unwrap();
+}
+
+fn gate_request(digest: &str) -> MutatingActionRequest {
+    skill_candidate_materialize_gate_request(
+        "summarize-local",
+        digest,
+        "mission-skill-materialize-cli",
+        "work-skill-materialize-cli",
+        "operator",
+    )
+}
+
+fn cli_base(
+    db_path: &str,
+    vk_path: &std::path::Path,
+    approval_path: &std::path::Path,
+    source_dir: &std::path::Path,
+    candidate_root: &std::path::Path,
+    digest: &str,
+) -> Command {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_hub_skill_candidate_materialize"));
+    cmd.arg("materialize-local")
+        .arg("--db")
+        .arg(db_path)
+        .arg("--operator-vk-path")
+        .arg(vk_path)
+        .arg("--approval-json")
+        .arg(approval_path)
+        .arg("--source-dir")
+        .arg(source_dir)
+        .arg("--candidate-root")
+        .arg(candidate_root)
+        .arg("--skill-id")
+        .arg("summarize-local")
+        .arg("--source-digest")
+        .arg(digest)
+        .arg("--mission-id")
+        .arg("mission-skill-materialize-cli")
+        .arg("--work-item-id")
+        .arg("work-skill-materialize-cli")
+        .arg("--operator-principal-id")
+        .arg("operator")
+        .arg("--proof-ref")
+        .arg("proof://skill-candidate-materialize/summarize-local")
+        .arg("--now-ms")
+        .arg((NOW + 1).to_string());
+    cmd
+}
+
+#[test]
+fn cli_materializes_ed25519_candidate_without_import_install_or_execution() {
+    let db_path = temp_db("allow");
+    let db = Db::open_hub(&db_path).unwrap();
+    seed_mission(&db);
+
+    let source_dir = temp_path("source");
+    let candidate_root = temp_path("candidate-root");
+    std::fs::create_dir_all(&source_dir).unwrap();
+    std::fs::create_dir_all(&candidate_root).unwrap();
+    let skill_md = b"---\nid: summarize-local\n---\nSummarize local text.\n";
+    std::fs::write(source_dir.join("SKILL.md"), skill_md).unwrap();
+    let digest = source_digest(skill_md);
+
+    let (sk, vk) = operator();
+    let vk_path = temp_path("operator.vk");
+    std::fs::write(&vk_path, vk_hex(&vk)).unwrap();
+    let approval_path = temp_path("approval.json");
+    write_approval(
+        &approval_path,
+        &ed_approval(&gate_request(&digest), &sk, "skill-materialize-ed-allow"),
+    );
+
+    let output = cli_base(
+        &db_path,
+        &vk_path,
+        &approval_path,
+        &source_dir,
+        &candidate_root,
+        &digest,
+    )
+    .output()
+    .unwrap();
+    assert!(
+        output.status.success(),
+        "stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let json: Value = serde_json::from_str(stdout.trim()).unwrap();
+    assert_eq!(json["truth_label"], "d21_skill_candidate_materialize");
+    assert_eq!(json["ok"], true);
+    assert_eq!(json["imports_skill"], false);
+    assert_eq!(json["installs_skill"], false);
+    assert_eq!(json["executes_skill"], false);
+    assert_eq!(
+        json["status"],
+        "materialized_candidate_not_installed_not_executable"
+    );
+
+    let candidate_ref = json["candidate_ref"].as_str().unwrap();
+    assert!(candidate_root
+        .join(candidate_ref)
+        .join("files")
+        .join("SKILL.md")
+        .is_file());
+    let item = db
+        .get_work_item("work-skill-materialize-cli")
+        .unwrap()
+        .unwrap();
+    assert_eq!(item.status, WorkItemStatus::ReadyToDispatch);
+    assert!(item.proof_receipts.is_empty());
+    let links = db
+        .list_mission_links("mission-skill-materialize-cli")
+        .unwrap();
+    assert_eq!(links.len(), 1);
+    assert_eq!(links[0].target_ref, candidate_ref);
+}
+
+#[test]
+fn cli_rejects_hmac_approval_without_writing_candidate() {
+    let db_path = temp_db("hmac");
+    let db = Db::open_hub(&db_path).unwrap();
+    seed_mission(&db);
+
+    let source_dir = temp_path("hmac-source");
+    let candidate_root = temp_path("hmac-candidate-root");
+    std::fs::create_dir_all(&source_dir).unwrap();
+    std::fs::create_dir_all(&candidate_root).unwrap();
+    let skill_md = b"---\nid: summarize-local\n---\nSummarize local text.\n";
+    std::fs::write(source_dir.join("SKILL.md"), skill_md).unwrap();
+    let digest = source_digest(skill_md);
+
+    let (_sk, vk) = operator();
+    let vk_path = temp_path("operator-hmac.vk");
+    std::fs::write(&vk_path, vk_hex(&vk)).unwrap();
+    let approval_path = temp_path("approval-hmac.json");
+    write_approval(
+        &approval_path,
+        &hmac_approval(&gate_request(&digest), "skill-materialize-hmac"),
+    );
+
+    let output = cli_base(
+        &db_path,
+        &vk_path,
+        &approval_path,
+        &source_dir,
+        &candidate_root,
+        &digest,
+    )
+    .output()
+    .unwrap();
+    assert!(!output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let json: Value = serde_json::from_str(stdout.trim()).unwrap();
+    assert_eq!(json["ok"], false);
+    assert_eq!(json["imports_skill"], false);
+    assert_eq!(json["installs_skill"], false);
+    assert_eq!(json["executes_skill"], false);
+    assert!(std::fs::read_dir(&candidate_root).unwrap().next().is_none());
+    assert!(db
+        .list_mission_links("mission-skill-materialize-cli")
+        .unwrap()
+        .is_empty());
+}


### PR DESCRIPTION
## Summary
- add a Rust-owned dark local SKILL.md candidate materializer that copies reviewed files into a shadow candidate area
- add an operator-facing CLI that verifies Ed25519 approvals with the operator public verify key only
- record a Mission-bound ProofReceipt while leaving the WorkItem uncompleted and the skill uninstalled/unexecuted

## Truth labels
- organic=0
- BUILT-DARK only: this does not import, install, promote, or execute a skill
- mechanism-soak uses TEST operator keys only; no operator signing key is read or minted by Hub

## Tests
- cargo fmt -p friday-hub --check
- cargo test --manifest-path rust-core/Cargo.toml -p friday-hub skill_candidate_materializer -- --nocapture
- cargo test --manifest-path rust-core/Cargo.toml -p friday-hub --test skill_candidate_materialize_cli -- --nocapture