### PR TITLE
Mirror Anthropic metered turns into provider sessions

### DIFF
--- a/rust-core/crates/friday-hub/src/lib.rs
+++ b/rust-core/crates/friday-hub/src/lib.rs
@@ -499,7 +499,9 @@ use friday_core::gate::{
 // The risk-escalation primitives (`shell_risk`/`is_destructive_request`) now live behind
 // the sealed `friday_core::gate::classify`; `Resource` is constructed there too.
 use friday_core::gate::Reversibility;
-use friday_core::{ActivityState, ActivityType, Risk};
+use friday_core::{
+    ActivityState, ActivityType, ProviderSessionEvent, ProviderSessionLink, Risk, SyncMode,
+};
 use friday_crypto::OperatorVerifyingKey;
 use friday_storage::{
     agent_run, authorize_mutating_action, authorize_mutating_action_ed25519,
@@ -4300,10 +4302,67 @@ pub(crate) fn bill_model_call_keyed(
         audit_id,
         actor: "hub-agent".to_string(),
         action: "agent_loop.model_call".to_string(),
-        payload_ref: Some(ledger_id),
+        payload_ref: Some(ledger_id.clone()),
         created_at: now_ms,
     };
-    friday_storage::record_run_model_call(conn, run_id, &entry, &activity, &audit)
+    friday_storage::record_run_model_call(conn, run_id, &entry, &activity, &audit)?;
+    if outcome.provider_kind == friday_core::ProviderKind::Anthropic {
+        mirror_anthropic_metered_turn(
+            conn,
+            run_id,
+            slot,
+            outcome,
+            ledger_id.as_str(),
+            audit.audit_id.as_str(),
+            now_ms,
+        )?;
+    }
+    Ok(())
+}
+
+fn mirror_anthropic_metered_turn(
+    conn: &Connection,
+    run_id: &str,
+    slot: &str,
+    outcome: &BilledUsage,
+    ledger_id: &str,
+    audit_id: &str,
+    now_ms: i64,
+) -> Result<(), StorageError> {
+    let friday_session_id = format!("claude-metered-{run_id}");
+    let provider_event_id = format!("claude-metered:{run_id}:{slot}");
+    let link = ProviderSessionLink {
+        friday_session_id: friday_session_id.clone(),
+        provider: "claude".to_string(),
+        account_key_hash: "sha256:claude-account-unresolved".to_string(),
+        workspace_id: "anthropic-messages-api".to_string(),
+        cwd: None,
+        external_session_id: None,
+        external_thread_id: None,
+        external_url: None,
+        sync_mode: SyncMode::FridayLocalMirror,
+        capability_snapshot: format!("claude_anthropic_metered_route:v1;model={}", outcome.model),
+        last_provider_seen_at: Some(now_ms),
+        last_friday_event_id: Some(provider_event_id.clone()),
+        truth_label: "claude_anthropic_metered_turn_metadata_only".to_string(),
+    };
+    friday_storage::provider_session::upsert_link(conn, &link)?;
+
+    let event = ProviderSessionEvent {
+        friday_session_id,
+        provider_event_id,
+        provider: "claude".to_string(),
+        event_kind: "metered_turn".to_string(),
+        transcript_item_kind: "model_call".to_string(),
+        body_ref: format!("friday://token-ledger/{ledger_id}"),
+        redaction_level: "metadata_only".to_string(),
+        token_ledger_ref: Some(ledger_id.to_string()),
+        approval_ref: None,
+        audit_receipt_ref: Some(audit_id.to_string()),
+        observed_at: now_ms,
+    };
+    friday_storage::provider_session::append_event(conn, &event)?;
+    Ok(())
 }
 
 /// Drive a MULTI-TURN agent loop with the pre-S4 default policy (no per-run principal
@@ -12175,6 +12234,16 @@ mod tests {
             "loop biller now stamps the pricing-table cost estimate (a#4 — was NULL)"
         );
         assert_eq!(fallback, 0, "Friday route is never a fallback (unchanged)");
+        assert_eq!(
+            db.count("provider_session_link").unwrap(),
+            0,
+            "DeepSeek billing does not synthesize a provider-session mirror"
+        );
+        assert_eq!(
+            db.count("provider_session_event").unwrap(),
+            0,
+            "DeepSeek billing remains byte-identical on provider-session evidence"
+        );
     }
 
     // ---- (a#3) flash→pro quality escalation (loop-layer) ----------------------------------
@@ -12852,6 +12921,40 @@ mod tests {
             )
             .unwrap();
         assert_eq!(host, "api.anthropic.com");
+
+        let session_id = "claude-metered-r1";
+        let link = friday_storage::provider_session::get_link(db.conn(), session_id)
+            .unwrap()
+            .expect("Anthropic metered turns are mirrored into a Claude provider-session link");
+        assert_eq!(link.provider, "claude");
+        assert_eq!(link.sync_mode, friday_core::SyncMode::FridayLocalMirror);
+        assert_eq!(
+            link.truth_label,
+            "claude_anthropic_metered_turn_metadata_only"
+        );
+        assert_eq!(
+            link.last_friday_event_id.as_deref(),
+            Some("claude-metered:r1:t0")
+        );
+
+        let events = friday_storage::provider_session::list_events(db.conn(), session_id).unwrap();
+        assert_eq!(
+            events.len(),
+            1,
+            "the Anthropic ledger row has exactly one provider-session event mirror"
+        );
+        let event = &events[0];
+        assert_eq!(event.provider_event_id, "claude-metered:r1:t0");
+        assert_eq!(event.provider, "claude");
+        assert_eq!(event.event_kind, "metered_turn");
+        assert_eq!(event.transcript_item_kind, "model_call");
+        assert_eq!(event.redaction_level, "metadata_only");
+        assert_eq!(event.token_ledger_ref.as_deref(), Some("r1:t0:ledger"));
+        assert_eq!(
+            event.body_ref, "friday://token-ledger/r1:t0:ledger",
+            "the mirror is refs-only; it does not persist model text"
+        );
+        assert_eq!(event.audit_receipt_ref.as_deref(), Some("r1:t0:modelcall"));
     }
 
     #[test]

--- a/rust-core/crates/friday-hub/src/lib.rs
+++ b/rust-core/crates/friday-hub/src/lib.rs
@@ -4305,30 +4305,31 @@ pub(crate) fn bill_model_call_keyed(
         payload_ref: Some(ledger_id.clone()),
         created_at: now_ms,
     };
-    friday_storage::record_run_model_call(conn, run_id, &entry, &activity, &audit)?;
     if outcome.provider_kind == friday_core::ProviderKind::Anthropic {
-        mirror_anthropic_metered_turn(
-            conn,
+        let (link, event) = anthropic_metered_turn_mirror(
             run_id,
             slot,
             outcome,
             ledger_id.as_str(),
             audit.audit_id.as_str(),
             now_ms,
-        )?;
+        );
+        friday_storage::record_run_model_call_with_provider_session_mirror(
+            conn, run_id, &entry, &activity, &audit, &link, &event,
+        )
+    } else {
+        friday_storage::record_run_model_call(conn, run_id, &entry, &activity, &audit)
     }
-    Ok(())
 }
 
-fn mirror_anthropic_metered_turn(
-    conn: &Connection,
+fn anthropic_metered_turn_mirror(
     run_id: &str,
     slot: &str,
     outcome: &BilledUsage,
     ledger_id: &str,
     audit_id: &str,
     now_ms: i64,
-) -> Result<(), StorageError> {
+) -> (ProviderSessionLink, ProviderSessionEvent) {
     let friday_session_id = format!("claude-metered-{run_id}");
     let provider_event_id = format!("claude-metered:{run_id}:{slot}");
     let link = ProviderSessionLink {
@@ -4346,7 +4347,6 @@ fn mirror_anthropic_metered_turn(
         last_friday_event_id: Some(provider_event_id.clone()),
         truth_label: "claude_anthropic_metered_turn_metadata_only".to_string(),
     };
-    friday_storage::provider_session::upsert_link(conn, &link)?;
 
     let event = ProviderSessionEvent {
         friday_session_id,
@@ -4361,8 +4361,7 @@ fn mirror_anthropic_metered_turn(
         audit_receipt_ref: Some(audit_id.to_string()),
         observed_at: now_ms,
     };
-    friday_storage::provider_session::append_event(conn, &event)?;
-    Ok(())
+    (link, event)
 }
 
 /// Drive a MULTI-TURN agent loop with the pre-S4 default policy (no per-run principal
@@ -12955,6 +12954,69 @@ mod tests {
             "the mirror is refs-only; it does not persist model text"
         );
         assert_eq!(event.audit_receipt_ref.as_deref(), Some("r1:t0:modelcall"));
+    }
+
+    #[test]
+    fn claude_provider_session_conflict_rolls_back_metered_billing() {
+        let db = Db::open_hub(&temp_path("claude-provider-session-conflict")).unwrap();
+        agent_run::create_run(db.conn(), "r-conflict", "ask claude", 1).unwrap();
+        let (link, event) = anthropic_metered_turn_mirror(
+            "r-conflict",
+            "t0",
+            &BilledUsage {
+                provider_kind: friday_core::ProviderKind::Anthropic,
+                model: "claude-opus-4-8".to_string(),
+                prompt_tokens: 11,
+                completion_tokens: 8,
+            },
+            "preexisting-ledger",
+            "preexisting-audit",
+            999,
+        );
+        friday_storage::provider_session::upsert_link(db.conn(), &link).unwrap();
+        friday_storage::provider_session::append_event(db.conn(), &event).unwrap();
+
+        let outcome = BilledUsage {
+            provider_kind: friday_core::ProviderKind::Anthropic,
+            model: "claude-opus-4-8".to_string(),
+            prompt_tokens: 3,
+            completion_tokens: 5,
+        };
+        let err = bill_model_call_keyed(db.conn(), "r-conflict", "t0", &outcome, 1000)
+            .expect_err("duplicate provider-session event must fail the metered write");
+        assert!(
+            format!("{err:?}").contains("UNIQUE") || format!("{err:?}").contains("constraint"),
+            "unexpected error: {err:?}"
+        );
+
+        assert!(
+            db.list_run_token_usage("r-conflict").unwrap().is_empty(),
+            "provider-session mirror conflict must roll back the token_ledger row"
+        );
+        let audit_rows: i64 = db
+            .conn()
+            .query_row(
+                "SELECT COUNT(*) FROM audit_ledger WHERE audit_id = 'r-conflict:t0:modelcall'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(
+            audit_rows, 0,
+            "provider-session mirror conflict must roll back the audit receipt"
+        );
+        let activity_rows: i64 = db
+            .conn()
+            .query_row(
+                "SELECT COUNT(*) FROM activity_item WHERE activity_id = 'r-conflict:t0:askreceipt'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(
+            activity_rows, 0,
+            "provider-session mirror conflict must roll back the activity receipt"
+        );
     }
 
     #[test]

--- a/rust-core/crates/friday-hub/src/lib.rs
+++ b/rust-core/crates/friday-hub/src/lib.rs
@@ -4334,7 +4334,7 @@ fn mirror_anthropic_metered_turn(
     let link = ProviderSessionLink {
         friday_session_id: friday_session_id.clone(),
         provider: "claude".to_string(),
-        account_key_hash: "sha256:claude-account-unresolved".to_string(),
+        account_key_hash: "sha256:claude-account-unresolved".to_string(), // pragma: allowlist secret
         workspace_id: "anthropic-messages-api".to_string(),
         cwd: None,
         external_session_id: None,

--- a/rust-core/crates/friday-hub/tests/routed_claude_parity.rs
+++ b/rust-core/crates/friday-hub/tests/routed_claude_parity.rs
@@ -246,6 +246,43 @@ fn assert_anthropic_rows(
         assert_eq!(row.base_url_host, "api.anthropic.com");
         assert!(!row.fallback, "the claude route is never a fallback");
     }
+    assert_claude_metered_provider_session_refs(rt, run_id);
+}
+
+fn assert_claude_metered_provider_session_refs(
+    rt: &HubRuntime<friday_deepseek::UreqTransport>,
+    run_id: &str,
+) {
+    let rows = rt.db().list_run_token_usage(run_id).unwrap();
+    let session_id = format!("claude-metered-{run_id}");
+    let link = friday_storage::provider_session::get_link(rt.db().conn(), &session_id)
+        .unwrap()
+        .expect("anthropic metered turns must write a Claude provider-session link");
+    assert_eq!(link.provider, "claude");
+    assert_eq!(link.sync_mode, friday_core::SyncMode::FridayLocalMirror);
+    assert_eq!(
+        link.truth_label,
+        "claude_anthropic_metered_turn_metadata_only"
+    );
+
+    let events =
+        friday_storage::provider_session::list_events(rt.db().conn(), &session_id).unwrap();
+    assert_eq!(
+        events.len(),
+        rows.len(),
+        "each Anthropic token_ledger row has one refs-only provider-session event"
+    );
+    for row in &rows {
+        assert!(
+            events.iter().any(|event| {
+                event.provider == "claude"
+                    && event.redaction_level == "metadata_only"
+                    && event.token_ledger_ref.as_deref() == Some(row.ledger_id.as_str())
+            }),
+            "missing provider-session event for ledger {}",
+            row.ledger_id
+        );
+    }
 }
 
 /// Build an authenticated caller bound to `principal` over a freshly paired sealed session — the
@@ -285,6 +322,7 @@ fn assert_sessioned_anthropic_rows(rt: &HubRuntime<friday_deepseek::UreqTranspor
         assert_eq!(row.base_url_host, "api.anthropic.com");
         assert!(!row.fallback, "the claude route is never a fallback");
     }
+    assert_claude_metered_provider_session_refs(rt, run_id);
 }
 
 // ---- CHAT-expressible flows (LIVE) ----------------------------------------------------------

--- a/rust-core/crates/friday-storage/src/lib.rs
+++ b/rust-core/crates/friday-storage/src/lib.rs
@@ -1619,6 +1619,39 @@ pub fn record_run_model_call(
     })
 }
 
+/// Atomic Anthropic/Claude metered-turn sibling of [`record_run_model_call`].
+///
+/// This writes the normal run-attributed model-call evidence and the refs-only provider-session
+/// mirror in one busy-retried transaction. A provider-session conflict can therefore never leave a
+/// half-billed run that reports failure after the ledger/audit rows have already committed.
+pub fn record_run_model_call_with_provider_session_mirror(
+    conn: &Connection,
+    run_id: &str,
+    entry: &LedgerEntry,
+    activity: &ActivityRow,
+    audit: &AuditEvent,
+    link: &ProviderSessionLink,
+    event: &ProviderSessionEvent,
+) -> Result<()> {
+    with_busy_retry(|| {
+        let tx = conn.unchecked_transaction()?;
+        insert_token_ledger_conn(&tx, entry, Some(run_id))?;
+        insert_activity_conn(&tx, activity)?;
+        audit::append_audit(
+            &tx,
+            &audit.audit_id,
+            &audit.actor,
+            &audit.action,
+            audit.payload_ref.as_deref(),
+            audit.created_at,
+        )?;
+        provider_session::upsert_link(&tx, link)?;
+        provider_session::append_event(&tx, event)?;
+        tx.commit()?;
+        Ok(())
+    })
+}
+
 fn quote_existing_table(conn: &Connection, table: &str) -> Result<String> {
     if table.is_empty()
         || !table


### PR DESCRIPTION
## Summary\n- mirror Anthropic/Claude metered billing into a refs-only provider_session_link + provider_session_event\n- link each mirrored event to the token_ledger row and audit receipt without persisting model text\n- lock DeepSeek billing to no provider-session mirror as a no-degrade check\n\n## Tests\n- cargo fmt --manifest-path rust-core/Cargo.toml -p friday-hub --check\n- cargo test --manifest-path rust-core/Cargo.toml -p friday-hub claude_step_writes_anthropic_provider_row -- --nocapture\n- cargo test --manifest-path rust-core/Cargo.toml -p friday-hub deepseek_provider_row_is_byte_identical_post_refactor -- --nocapture\n- cargo test --manifest-path rust-core/Cargo.toml -p friday-hub run_task_pinned_claude_routes_through_runtime_and_writes_anthropic_row -- --nocapture\n- cargo test --manifest-path rust-core/Cargo.toml -p friday-hub claude_mutating_turn_bills_anthropic_row_then_pauses_for_approval -- --nocapture\n- cargo test --manifest-path rust-core/Cargo.toml -p friday-hub --test routed_claude_parity -- --nocapture\n\nTruth labels: mechanism-tested / refs-only metadata mirror / not organic / not GO-LIVE.