### PR TITLE
Polish iOS unavailable copy

### DIFF
--- a/apps/friday-ios/Sources/FridayMobileShell/CommandSheet.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/CommandSheet.swift
@@ -63,7 +63,7 @@ struct CommandSheet: View {
         }
         .padding(16)
 
-        Text("Read-only shell · M-PR1 · v1 NO-GO")
+        Text("Read-only mode · more surfaces coming online")
           .font(.caption2)
           .foregroundStyle(MobileTheme.textSecondary)
           .padding(.top, 8)

--- a/apps/friday-ios/Sources/FridayMobileShell/FridayChatScreen.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayChatScreen.swift
@@ -61,8 +61,8 @@ struct FridayChatScreen: View {
         "Ask Friday anything.",
         "Answers are refs-only (a fingerprint + counts). "
           + (runControlEnabled
-            ? "A mutating action pauses for your approval (S6)."
-            : "Read-only — approvals enable at slice-6."))
+            ? "A mutating action pauses for your approval."
+            : "Read-only — approvals are not available yet."))
     case .dispatching(let task):
       GlassPanel {
         VStack(alignment: .leading, spacing: 8) {

--- a/apps/friday-ios/Sources/FridayMobileShell/FridayHomeScreen.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayHomeScreen.swift
@@ -150,12 +150,12 @@ struct UnavailableView: View {
     VStack(spacing: 10) {
       Image(systemName: "exclamationmark.triangle")
         .font(.system(size: 28)).foregroundStyle(MobileTheme.coral)
-      Text("Hub projection unavailable")
+      Text("Friday is offline")
         .font(.headline).foregroundStyle(MobileTheme.textPrimary)
       Text(reason)
         .font(.footnote).foregroundStyle(MobileTheme.textSecondary)
         .multilineTextAlignment(.center)
-      Text("Showing this as truth — no cached or fabricated status is presented.")
+      Text("No cached or fabricated status is shown.")
         .font(.caption2).foregroundStyle(MobileTheme.textSecondary)
         .multilineTextAlignment(.center)
     }
@@ -174,7 +174,7 @@ struct PlaceholderScreen: View {
         .font(.system(size: 30)).foregroundStyle(MobileTheme.textSecondary)
       Text(destination.title)
         .font(.headline).foregroundStyle(MobileTheme.textPrimary)
-      Text("This surface is part of the locked mobile design but is not built in this PR.")
+      Text("This area is not available yet.")
         .font(.footnote).foregroundStyle(MobileTheme.textSecondary)
         .multilineTextAlignment(.center)
         .frame(maxWidth: 320)

--- a/apps/friday-ios/Sources/FridayMobileShellCore/FridayChatViewModel.swift
+++ b/apps/friday-ios/Sources/FridayMobileShellCore/FridayChatViewModel.swift
@@ -405,7 +405,7 @@ public final class FridayChatViewModel: ObservableObject {
 
   static func dispatchReason(for error: Error) -> String {
     if let e = error as? FridayWriteClientError { return writeReason(e, verb: "dispatch") }
-    return "Hub unavailable — \(error)"
+    return "Friday is unavailable — \(error)"
   }
 
   static func resumeReason(for error: Error) -> String {
@@ -421,19 +421,19 @@ public final class FridayChatViewModel: ObservableObject {
   private static func writeReason(_ e: FridayWriteClientError, verb: String) -> String {
     switch e {
     case .badServerPubkey, .badSessionNonce:
-      return "Hub handshake failed — server unavailable"
+      return "Friday could not establish a trusted connection"
     case let .serverError(code, message):
-      return "Hub unavailable (\(code.rawValue)) — \(message)"
+      return "Friday is unavailable (\(code.rawValue)) — \(message)"
     case let .unexpectedResponse(kind):
-      return "Hub returned an unexpected response (\(kind))"
+      return "Friday returned an unexpected response (\(kind))"
     case let .missingRef(why):
-      return "Hub returned an incomplete \(verb) frame — \(why)"
+      return "Friday returned an incomplete \(verb) response — \(why)"
     case .runControlDisabled:
-      return "Run-control is disabled — approvals are not yet enabled (slice-6 gate)"
+      return "Approvals are not available yet — no action was resumed"
     case .emptySignedBlob:
       return "Approval unavailable — the signer returned no signature"
     case let .transport(why):
-      return "Hub offline — \(why)"
+      return "Friday is offline — \(why)"
     }
   }
 

--- a/apps/friday-ios/Sources/FridayMobileShellCore/FridayClientFactory.swift
+++ b/apps/friday-ios/Sources/FridayMobileShellCore/FridayClientFactory.swift
@@ -77,7 +77,7 @@ public enum FridayClientFactoryError: Error, Sendable, Equatable, CustomStringCo
   public var description: String {
     switch self {
     case .liveTransportNotWired:
-      return "live Hub transport not wired (Rust servers dark — slice-6 gate)"
+      return "live connection is not set up yet"
     }
   }
 }

--- a/apps/friday-ios/Sources/FridayMobileShellCore/HomeViewModel.swift
+++ b/apps/friday-ios/Sources/FridayMobileShellCore/HomeViewModel.swift
@@ -122,18 +122,18 @@ public final class HomeViewModel: ObservableObject {
     if let e = error as? FridayReadClientError {
       switch e {
       case .badServerPubkey, .badSessionNonce:
-        return "Hub handshake failed — server unavailable"
+        return "Friday could not establish a trusted connection"
       case let .serverError(code, message):
-        return "Hub unavailable (\(code.rawValue)) — \(message)"
+        return "Friday is unavailable (\(code.rawValue)) — \(message)"
       case let .unexpectedResponse(kind):
-        return "Hub returned an unexpected response (\(kind))"
+        return "Friday returned an unexpected response (\(kind))"
       case let .malformedProjection(why):
-        return "Projection unavailable — \(why)"
+        return "Status unavailable — \(why)"
       case let .transport(why):
-        return "Hub offline — \(why)"
+        return "Friday is offline — \(why)"
       }
     }
-    return "Hub unavailable — \(error)"
+    return "Friday is unavailable — \(error)"
   }
 }
 
@@ -151,7 +151,7 @@ public final class HomeViewModel: ObservableObject {
 /// has no master key; that is the J2 pairing problem, deferred).
 public struct HonestlyUnavailableReadClient: FridayRustReadClient {
   private let reason: String
-  public init(reason: String = "live Hub transport not wired (Rust servers dark — slice-6 gate)") {
+  public init(reason: String = "live connection is not set up yet") {
     self.reason = reason
   }
   public func fetchWorkbench() async throws -> WorkbenchSnapshot {

--- a/apps/friday-ios/Sources/FridayMobileShellCore/OperatorSigner.swift
+++ b/apps/friday-ios/Sources/FridayMobileShellCore/OperatorSigner.swift
@@ -81,7 +81,7 @@ public enum OperatorSignerError: Error, Sendable, Equatable, CustomStringConvert
     switch self {
     case .signerUnavailable: return "Operator signer unavailable — connect the desktop signer to approve"
     case .declined: return "Operator declined the approval"
-    case .keyUnprovisioned: return "Operator signing key not provisioned (slice-6 / operator-key gate)"
+    case .keyUnprovisioned: return "Approval key is not set up on the trusted signer"
     }
   }
 }

--- a/apps/friday-ios/Tests/FridayMobileShellCoreTests/FridayChatViewModelTests.swift
+++ b/apps/friday-ios/Tests/FridayMobileShellCoreTests/FridayChatViewModelTests.swift
@@ -376,7 +376,7 @@ final class FridayChatViewModelTests: XCTestCase {
     await vm.send("edit notes.md")
     await vm.approve()
     guard case .unavailable(let reason) = vm.phase else { return XCTFail("expected .unavailable") }
-    XCTAssertTrue(reason.contains("operator-key") || reason.lowercased().contains("not provisioned"), "reason: \(reason)")
+    XCTAssertTrue(reason.lowercased().contains("approval key"), "reason: \(reason)")
     XCTAssertTrue(client.resumedRunIds.isEmpty)
   }
 
@@ -400,13 +400,13 @@ final class FridayChatViewModelTests: XCTestCase {
   }
 
   /// FLAG-OFF posture: a write client with run-control disabled refuses the resume relay — the
-  /// view model surfaces it as the honest slice-6-gated reason (no fabricated receipt).
-  func testApprove_runControlDisabled_isSlice6Gated() async {
+  /// view model surfaces an honest unavailable reason (no fabricated receipt).
+  func testApprove_runControlDisabled_isUnavailable() async {
     let client = FakeWriteClient(dispatch: .pause(makePause()), resume: .fail(.runControlDisabled))
     let vm = FridayChatViewModel(writeClient: client, signer: MockOperatorSigner())
     await vm.send("edit notes.md")
     await vm.approve()
     guard case .unavailable(let reason) = vm.phase else { return XCTFail("expected .unavailable") }
-    XCTAssertTrue(reason.contains("slice-6") || reason.lowercased().contains("disabled"), "reason: \(reason)")
+    XCTAssertTrue(reason.lowercased().contains("approvals are not available"), "reason: \(reason)")
   }
 }

--- a/apps/friday-ios/Tests/FridayMobileShellCoreTests/HomeViewModelTests.swift
+++ b/apps/friday-ios/Tests/FridayMobileShellCoreTests/HomeViewModelTests.swift
@@ -75,7 +75,7 @@ final class HomeViewModelTests: XCTestCase {
     let vm = HomeViewModel(client: FakeReadClient(.fail(.serverError(code: .hubOffline, message: "no active mission"))))
     await vm.refresh()
     guard case .unavailable(let reason) = vm.state else { return XCTFail("expected .unavailable") }
-    XCTAssertTrue(reason.contains("HUB_OFFLINE"), "reason: \(reason)")
+    XCTAssertTrue(reason.contains("Friday is unavailable"), "reason: \(reason)")
     XCTAssertNil(vm.state.projection) // never a fabricated ready projection
   }
 }
@@ -101,7 +101,7 @@ final class ReadClientFactoryTests: XCTestCase {
     let vm = HomeViewModel(client: client)
     await vm.refresh()
     guard case .unavailable(let reason) = vm.state else { return XCTFail("expected .unavailable, got \(vm.state)") }
-    XCTAssertTrue(reason.contains("offline") || reason.contains("not wired") || reason.contains("dark"),
+    XCTAssertTrue(reason.contains("offline") || reason.contains("not set up"),
                   "reason: \(reason)")
     XCTAssertFalse(vm.state.isOnline)
   }


### PR DESCRIPTION
## Summary
- replace user-visible engineering gate labels in iOS unavailable and read-only states
- keep honest-unavailable/fail-closed behavior while removing slice/PR/v1 jargon from consumer copy
- update view-model tests for the product-facing approval/key unavailable copy

## Verification
- swift test --package-path apps/friday-ios
- rg focused scan for user-visible slice/PR/v1/Hub projection jargon
- apps/friday-ios/build-sim.sh /tmp/friday-ios-copy-20260620-v2.png

## Truth labels
- UI dogfood gap fix only; no live flip, no operator signature, no organic traffic.
- Simulator render proof != true device proof.