### PR TITLE
Bind DeepSeek no-fallback capture to RGG core

### DIFF
--- a/scripts/ops/friday-c1-c2-tier1-parity-capture.mjs
+++ b/scripts/ops/friday-c1-c2-tier1-parity-capture.mjs
@@ -135,7 +135,7 @@ export const TIER1_PARITY_FLOW_SPECS = Object.freeze([
     flowId: "c2-deepseek-no-openai-fallback-diagnostic",
     lane: "C2",
     source: "deepseek",
-    expectedHarness: "scripts/ops/phase24h-telegram-natural-trigger-listener.mjs",
+    expectedHarness: "scripts/ops/friday-c1-c2-deepseek-rgg-core-gate.mjs",
   },
   {
     order: 19,

--- a/test/unit/scripts/ops/friday-c1-c2-tier1-parity-capture.test.ts
+++ b/test/unit/scripts/ops/friday-c1-c2-tier1-parity-capture.test.ts
@@ -88,6 +88,9 @@ describe("C1/C2 Tier-1 parity capture runner", () => {
     expect(capture.TIER1_PARITY_FLOW_SPECS.find(
       (flow) => flow.flowId === "c1-deepseek-real-green-routing-diagnostic",
     )?.expectedHarness).toBe("scripts/ops/friday-c1-c2-deepseek-rgg-core-gate.mjs");
+    expect(capture.TIER1_PARITY_FLOW_SPECS.find(
+      (flow) => flow.flowId === "c2-deepseek-no-openai-fallback-diagnostic",
+    )?.expectedHarness).toBe("scripts/ops/friday-c1-c2-deepseek-rgg-core-gate.mjs");
     for (const flowId of [
       "c1-claude-process-observation-audit",
       "c1-claude-session-ledger-link-audit",


### PR DESCRIPTION
## Summary
- bind the C2 DeepSeek no-OpenAI-fallback capture flow to the existing DeepSeek RGG core diagnostic instead of the Telegram natural-trigger listener
- keep the channel/live-synthetic flows separate and truth-labeled
- add a unit assertion so this engine evidence does not drift back behind the channel prerequisite

## Truth label
- strict organic=0
- artifact/capture binding only; not live parity, not channel proof, not GO
- stacked on #935 and draft until #935 lands

## Validation
- bash -n scripts/diagnostics/friday-claude-provider-session-artifact-audit.sh
- git diff --check
- npx vitest run --project default test/unit/scripts/ops/friday-c1-c2-tier1-parity-capture.test.ts