### PR TITLE
Map A1 consumer flag in prod manifest

### DIFF
--- a/docs/ops/prod-flags-manifest.json
+++ b/docs/ops/prod-flags-manifest.json
@@ -92,6 +92,15 @@
       "notes": "A1 DRIVE/consumer leg. Drives the shared recall-preamble chokepoint with the flag ON and a confirmed run-outcome learning candidate, asserting the later owner-scoped prompt includes only refs/counts/evidence for that confirmed candidate. Sibling proof asserts owner isolation. Truth boundary: built-DARK mechanism only; not A1 live-done until an operator-origin organic turn feeds a candidate and a real confirm decision."
     },
     {
+      "flag": "FRIDAY_A1_RUN_OUTCOME_LEARNING_CONSUMER",
+      "process": "rust-ws-wrapper",
+      "prod_state": "dark",
+      "closes_loop": "A later owner-scoped prompt includes confirmed preference/world-model run-outcome learning signals as refs-only guidance, while excluding reflex candidates and answer bodies.",
+      "coverage": "loop-e2e",
+      "e2e_test": "rust-core/crates/friday-hub/src/lib.rs::a1_run_outcome_learning_consumer_surfaces_preference_world_model_only",
+      "notes": "A1 preference/world-model consumer leg. Drives the shared recall-preamble chokepoint with the consumer flag ON and confirmed preference/world_model/reflex candidates, asserting only preference/world_model refs-only signals are injected and reflex is excluded. Sibling proofs cover exact-'1' parsing and flag-off byte-identical behavior. Truth boundary: built-DARK mechanism only; not A1 live-done until an operator-origin organic turn feeds a candidate and a real confirm decision."
+    },
+    {
       "flag": "FRIDAY_MEMORY_CONFIRM",
       "process": "rust-ws-wrapper",
       "prod_state": "on",


### PR DESCRIPTION
## Summary
- Add `FRIDAY_A1_RUN_OUTCOME_LEARNING_CONSUMER` to the prod flag manifest as a dark Rust WS wrapper flag.
- Map it to the existing loop test `a1_run_outcome_learning_consumer_surfaces_preference_world_model_only`.

## Validation
- `node scripts/ci/verify-prod-flag-tests.mjs`
- `jq empty docs/ops/prod-flags-manifest.json`
- `git diff --check`
- `cargo test -p friday-hub a1_run_outcome_learning -- --nocapture` (from current main/prod tree; 13 passed)

Truth: built-DARK manifest coverage only. `organic=0`; no A1 live-done, no D20/B4 true signature, no GO-LIVE claim.