### PR TITLE
Add D20 signed batch worktree consumer

### DIFF
--- a/rust-core/crates/friday-hub/src/bin/hub_d20_signed_batch_worktree.rs
+++ b/rust-core/crates/friday-hub/src/bin/hub_d20_signed_batch_worktree.rs
@@ -1,0 +1,254 @@
+//! D20 trust-dial worktree batch artifact consumer.
+//!
+//! VERIFY-ONLY. This bin consumes an operator-signed `CanonicalApprovalBatch` artifact and
+//! dispatches one exact Hub tool call through the D20 worktree driver. It never reads an
+//! operator private key, never signs, and never mints approvals. The signed batch is verified
+//! against the operator PUBLIC verify key, single-use replay is consumed in storage, and
+//! Irreversible / out-of-worktree actions pause before the executor.
+//!
+//! The action JSON must describe the same Hub raw tool call shape used to compute the signed
+//! digest: actor Agent `hub-agent`, surface `agent`, optional `principal_id`, canonical params,
+//! no idempotency key, and no plan digest. Wider operator-review schemas stay on the prepare side;
+//! this bin is deliberately narrow so it cannot drift from the Hub dispatch chokepoint.
+//!
+//! Output is refs-only JSON: no file bodies, no secrets, no private paths.
+
+use std::env;
+use std::path::Path;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use friday_core::gate::{ApprovalDecision, CanonicalApprovalBatch, CANONICAL_GATE_ISSUER};
+use friday_hub::operator_vk::load_operator_vk_from_path;
+use friday_hub::{
+    d20_dispatch_signed_batch_artifact_in_worktree, D20WorktreeBatchOutcome, FsToolExecutor,
+    RawToolCall, RunPolicy,
+};
+use friday_storage::{audit::verify_audit_chain, Db, DialWorktreeScope};
+use serde::Deserialize;
+use serde_json::json;
+
+struct BridgeError {
+    kind: &'static str,
+}
+
+impl BridgeError {
+    fn new(kind: &'static str) -> Self {
+        Self { kind }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct SignedBatchIn {
+    decision: String,
+    batch_sign_id: String,
+    action_digests: Vec<String>,
+    expires_at: i64,
+    #[serde(default)]
+    issuer: Option<String>,
+    signature: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct ActionIn {
+    action: String,
+    #[serde(default)]
+    params: Vec<ActionParamIn>,
+    #[serde(default)]
+    principal_id: Option<String>,
+    #[serde(default)]
+    disabled_tools: Vec<String>,
+    #[serde(default)]
+    read_only: bool,
+}
+
+#[derive(Debug, Deserialize)]
+struct ActionParamIn {
+    key: String,
+    value: String,
+}
+
+fn main() {
+    match run() {
+        Ok(rendered) => println!("{rendered}"),
+        Err(err) => {
+            let payload = json!({
+                "truth_label": "d20_worktree_signed_batch_artifact",
+                "proof_only": true,
+                "ok": false,
+                "error_kind": err.kind,
+            });
+            let rendered = payload.to_string();
+            if reject_forbidden_output(&rendered).is_ok() {
+                println!("{rendered}");
+            }
+            eprintln!("hub_d20_signed_batch_worktree_unavailable: {}", err.kind);
+            std::process::exit(2);
+        }
+    }
+}
+
+fn run() -> Result<String, BridgeError> {
+    let args: Vec<String> = env::args().collect();
+    let db_path = arg_value(&args, "--db").ok_or(BridgeError::new("bad_args"))?;
+    let workspace_root = arg_value(&args, "--workspace").ok_or(BridgeError::new("bad_args"))?;
+    let signed_path =
+        arg_value(&args, "--signed-batch-json").ok_or(BridgeError::new("bad_args"))?;
+    let action_path = arg_value(&args, "--action-json").ok_or(BridgeError::new("bad_args"))?;
+
+    let signed: SignedBatchIn =
+        read_json_file(&signed_path).map_err(|_| BridgeError::new("bad_signed_batch"))?;
+    let action: ActionIn =
+        read_json_file(&action_path).map_err(|_| BridgeError::new("bad_action"))?;
+
+    let vk_path = arg_value(&args, "--operator-vk-path")
+        .or_else(|| env::var(friday_hub::operator_vk::OPERATOR_VK_PATH_ENV).ok())
+        .filter(|p| !p.trim().is_empty())
+        .ok_or(BridgeError::new("operator_vk_unprovisioned"))?;
+    let operator_vk = load_operator_vk_from_path(Path::new(vk_path.trim()))
+        .map_err(|_| BridgeError::new("operator_vk_malformed"))?;
+
+    let now_ms = arg_value(&args, "--now-ms")
+        .and_then(|v| v.parse::<i64>().ok())
+        .unwrap_or_else(current_epoch_ms);
+
+    let batch = CanonicalApprovalBatch {
+        decision: parse_decision(&signed.decision).ok_or(BridgeError::new("bad_signed_batch"))?,
+        batch_sign_id: nonempty(signed.batch_sign_id, "bad_signed_batch")?,
+        action_digests: signed.action_digests,
+        expires_at: Some(signed.expires_at),
+        issuer: Some(
+            signed
+                .issuer
+                .unwrap_or_else(|| CANONICAL_GATE_ISSUER.to_string()),
+        ),
+        signature: Some(nonempty(signed.signature, "bad_signed_batch")?),
+    };
+
+    let raw = RawToolCall {
+        action: nonempty(action.action, "bad_action")?,
+        params: action
+            .params
+            .into_iter()
+            .map(|p| Ok((nonempty(p.key, "bad_action")?, p.value)))
+            .collect::<Result<Vec<_>, BridgeError>>()?,
+    };
+    let policy = RunPolicy::new(action.principal_id, action.disabled_tools, action.read_only);
+    let scope = DialWorktreeScope {
+        plan_sign_id: batch.batch_sign_id.clone(),
+        active_worktree: Path::new(&workspace_root).to_path_buf(),
+    };
+
+    let mut db = Db::open_hub(&db_path).map_err(|_| BridgeError::new("init_failed"))?;
+    let executor = FsToolExecutor::new(&workspace_root);
+    let outcome = d20_dispatch_signed_batch_artifact_in_worktree(
+        db.conn_mut(),
+        &executor,
+        &raw,
+        &operator_vk,
+        &batch,
+        &scope,
+        &policy,
+        now_ms,
+    )
+    .map_err(|_| BridgeError::new("storage_failed"))?;
+
+    let audit_chain_verified = verify_audit_chain(db.conn()).is_ok();
+    let payload = match outcome {
+        D20WorktreeBatchOutcome::Executed { action, summary } => json!({
+            "truth_label": "d20_worktree_signed_batch_artifact",
+            "proof_only": true,
+            "ok": true,
+            "executed": true,
+            "result_status": "executed",
+            "action": action,
+            "summary": summary,
+            "batch_sign_id": batch.batch_sign_id,
+            "audit_chain_verified": audit_chain_verified,
+        }),
+        D20WorktreeBatchOutcome::ExecError { .. } => json!({
+            "truth_label": "d20_worktree_signed_batch_artifact",
+            "proof_only": true,
+            "ok": false,
+            "executed": false,
+            "result_status": "exec_error",
+            "batch_sign_id": batch.batch_sign_id,
+            "audit_chain_verified": audit_chain_verified,
+        }),
+        D20WorktreeBatchOutcome::RequiresApproval => json!({
+            "truth_label": "d20_worktree_signed_batch_artifact",
+            "proof_only": true,
+            "ok": true,
+            "executed": false,
+            "result_status": "requires_approval",
+            "batch_sign_id": batch.batch_sign_id,
+            "audit_chain_verified": audit_chain_verified,
+        }),
+        D20WorktreeBatchOutcome::Denied { reason } => json!({
+            "truth_label": "d20_worktree_signed_batch_artifact",
+            "proof_only": true,
+            "ok": true,
+            "executed": false,
+            "result_status": "denied",
+            "reason": reason,
+            "batch_sign_id": batch.batch_sign_id,
+            "audit_chain_verified": audit_chain_verified,
+        }),
+        D20WorktreeBatchOutcome::Unregistered { action } => json!({
+            "truth_label": "d20_worktree_signed_batch_artifact",
+            "proof_only": true,
+            "ok": true,
+            "executed": false,
+            "result_status": "unregistered",
+            "action": action,
+            "batch_sign_id": batch.batch_sign_id,
+            "audit_chain_verified": audit_chain_verified,
+        }),
+    };
+    let rendered =
+        serde_json::to_string(&payload).map_err(|_| BridgeError::new("serialize_failed"))?;
+    reject_forbidden_output(&rendered)?;
+    Ok(rendered)
+}
+
+fn read_json_file<T: for<'de> Deserialize<'de>>(path: &str) -> Result<T, ()> {
+    let contents = std::fs::read_to_string(path).map_err(|_| ())?;
+    serde_json::from_str(&contents).map_err(|_| ())
+}
+
+fn arg_value(args: &[String], name: &str) -> Option<String> {
+    args.windows(2)
+        .find_map(|pair| (pair[0] == name).then(|| pair[1].clone()))
+        .or_else(|| {
+            let prefix = format!("{name}=");
+            args.iter()
+                .find_map(|arg| arg.strip_prefix(&prefix).map(str::to_string))
+        })
+}
+
+fn parse_decision(s: &str) -> Option<ApprovalDecision> {
+    match s {
+        "approved" => Some(ApprovalDecision::Approved),
+        "denied" => Some(ApprovalDecision::Denied),
+        _ => None,
+    }
+}
+
+fn nonempty(value: String, kind: &'static str) -> Result<String, BridgeError> {
+    if value.trim().is_empty() {
+        Err(BridgeError::new(kind))
+    } else {
+        Ok(value)
+    }
+}
+
+fn current_epoch_ms() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as i64)
+        .unwrap_or(0)
+}
+
+fn reject_forbidden_output(rendered: &str) -> Result<(), BridgeError> {
+    friday_hub::refs_guard::reject_forbidden_output(rendered, &["\"content\"", "\"body\""])
+        .map_err(|_| BridgeError::new("output_guard"))
+}

--- a/rust-core/crates/friday-hub/src/lib.rs
+++ b/rust-core/crates/friday-hub/src/lib.rs
@@ -3532,6 +3532,20 @@ pub(crate) enum GateDispatch {
     Unregistered(String),
 }
 
+/// Public, refs-only outcome for the D20 signed-batch worktree artifact consumer.
+///
+/// This intentionally does not expose the private gate-dispatch enum or tool result content:
+/// callers get only the action/summary or a bounded status reason, enough for operator-facing
+/// proof JSON without leaking file bodies.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum D20WorktreeBatchOutcome {
+    Executed { action: String, summary: String },
+    ExecError { reason: String },
+    RequiresApproval,
+    Denied { reason: String },
+    Unregistered { action: String },
+}
+
 /// How a protected (`RequiresApproval`) action is authorized at the dispatch chokepoint.
 /// This makes the authorization scheme EXPLICIT at each call site — there is no implicit
 /// fallback that could let a protected action be Allowed by the wrong scheme.
@@ -4112,6 +4126,40 @@ pub(crate) fn d20_dispatch_signed_batch_in_worktree(
         },
         GateDecision::RequiresApproval => GateDispatch::RequiresApproval,
         GateDecision::Deny => GateDispatch::Denied(record.reason),
+    })
+}
+
+/// Verify-and-consume a D20 operator-signed batch member inside a reversible worktree scope.
+///
+/// This is the artifact-facing public wrapper around the crate-private driver. The caller supplies
+/// an already signed [`CanonicalApprovalBatch`] plus the operator PUBLIC verify key; the Hub never
+/// reads a signing key and never mints. Classified Irreversible or out-of-worktree actions pause
+/// before the executor, and allowed members are consumed single-use by storage before execution.
+#[allow(clippy::too_many_arguments)]
+pub fn d20_dispatch_signed_batch_artifact_in_worktree(
+    conn: &mut Connection,
+    executor: &dyn ToolExecutor,
+    raw: &RawToolCall,
+    vk: &OperatorVerifyingKey,
+    batch: &CanonicalApprovalBatch,
+    scope: &DialWorktreeScope,
+    policy: &RunPolicy,
+    now_ms: i64,
+) -> Result<D20WorktreeBatchOutcome, StorageError> {
+    let outcome = d20_dispatch_signed_batch_in_worktree(
+        conn, executor, raw, vk, batch, scope, policy, now_ms,
+    )?;
+    Ok(match outcome {
+        GateDispatch::Executed(receipt) => D20WorktreeBatchOutcome::Executed {
+            action: receipt.action,
+            summary: receipt.summary,
+        },
+        GateDispatch::ExecError(err) => D20WorktreeBatchOutcome::ExecError {
+            reason: err.to_string(),
+        },
+        GateDispatch::RequiresApproval => D20WorktreeBatchOutcome::RequiresApproval,
+        GateDispatch::Denied(reason) => D20WorktreeBatchOutcome::Denied { reason },
+        GateDispatch::Unregistered(action) => D20WorktreeBatchOutcome::Unregistered { action },
     })
 }
 


### PR DESCRIPTION
## Summary
- add a verify-only Hub bin for consuming an operator-signed D20 CanonicalApprovalBatch artifact inside a worktree scope
- expose a refs-only D20 worktree batch outcome wrapper around the existing private driver
- keep Hub verify-only: no private key reads, no signing, no minting; irreversible/out-of-worktree members pause before execution

## Validation
- cargo fmt --all -- --check
- cargo build -p friday-hub --bin hub_d20_signed_batch_worktree
- cargo test -p friday-hub d20_worktree_batch_driver -- --nocapture
- cargo clippy -p friday-hub --bin hub_d20_signed_batch_worktree -- -D warnings
- TEST-key artifact e2e: friday-operator-cli keygen/prepare-batch/sign-batch -> hub_d20_signed_batch_worktree -> isolated workspace write + audit_chain_verified=true

## Truth label
- built-DARK / verify-only consumer path
- TEST key mechanism soak only; not a true operator signature, not GO-LIVE, not v1 done