### PR TITLE
Add governed SKILL.md import point

### DIFF
--- a/rust-core/crates/friday-core/src/skill_catalog.rs
+++ b/rust-core/crates/friday-core/src/skill_catalog.rs
@@ -192,6 +192,13 @@ pub fn advise_skill(
     if entry.requires_operator_approval && !request.operator_approved_first_run {
         blockers.push("operator_approval_required_before_first_or_high_risk_run".to_string());
     }
+    let run_allowed = request.operator_approved_first_run
+        && entry.state == SkillState::Runnable
+        && matches!(
+            entry.truth_label,
+            WorkGraphTruthLabel::FridayOwned | WorkGraphTruthLabel::FridayAdopted
+        )
+        && blockers.is_empty();
     SkillAdvisorDecision {
         recommendation: SkillAdvisorRecommendationKind::RecommendAfterOperatorApproval,
         skill_ref,
@@ -202,12 +209,7 @@ pub fn advise_skill(
             "operator_approval_ref".to_string(),
             "skill_run_receipt".to_string(),
         ],
-        run_allowed: request.operator_approved_first_run
-            && entry.state == SkillState::Runnable
-            && matches!(
-                entry.truth_label,
-                WorkGraphTruthLabel::FridayOwned | WorkGraphTruthLabel::FridayAdopted
-            ),
+        run_allowed,
     }
 }
 
@@ -335,6 +337,41 @@ mod tests {
             decision.recommendation,
             SkillAdvisorRecommendationKind::RecommendAfterOperatorApproval
         );
+        assert!(!decision.run_allowed);
+    }
+
+    #[test]
+    fn runnable_skill_with_remaining_blocker_is_not_run_allowed() {
+        let mut blocked = entry(
+            "blocked",
+            WorkGraphTruthLabel::FridayAdopted,
+            SkillState::Runnable,
+            false,
+            50,
+        );
+        blocked
+            .approval_blockers
+            .push("sandboxed_executor_required".to_string());
+        let snapshot = SkillCatalogSnapshot {
+            generated_at_ms: 1,
+            entries: vec![blocked],
+            no_go: Vec::new(),
+        };
+        let decision = advise_skill(
+            &snapshot,
+            &SkillAdvisorRequest {
+                intent_key: "current_datetime".to_string(),
+                operator_approved_first_run: true,
+            },
+        );
+
+        assert_eq!(
+            decision.recommendation,
+            SkillAdvisorRecommendationKind::RecommendAfterOperatorApproval
+        );
+        assert!(decision
+            .blockers
+            .contains(&"sandboxed_executor_required".to_string()));
         assert!(!decision.run_allowed);
     }
 

--- a/rust-core/crates/friday-hub/src/bin/hub_skill_md_import.rs
+++ b/rust-core/crates/friday-hub/src/bin/hub_skill_md_import.rs
@@ -1,0 +1,188 @@
+//! D21 governed SKILL.md import CLI.
+//!
+//! Verifies an operator-signed approval and imports a local SKILL.md package as a
+//! managed manifest candidate. It never adopts, promotes, marks runnable, or executes
+//! the skill.
+
+use std::env;
+use std::io::Read;
+use std::path::Path;
+
+use friday_core::gate::{ApprovalDecision, CanonicalApproval, CANONICAL_GATE_ISSUER};
+use friday_hub::operator_vk::load_operator_vk_from_path;
+use friday_hub::skill_md_importer::{
+    import_skill_md_candidate_ed25519, SkillMdImportError, SkillMdImportRequest,
+};
+use friday_storage::Db;
+use serde::Deserialize;
+use serde_json::json;
+
+struct CliError {
+    kind: &'static str,
+}
+
+impl CliError {
+    fn new(kind: &'static str) -> Self {
+        Self { kind }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct SignedApprovalIn {
+    decision: String,
+    approval_id: String,
+    action_digest: String,
+    expires_at: i64,
+    #[serde(default)]
+    issuer: Option<String>,
+    signature: String,
+}
+
+fn main() {
+    match run() {
+        Ok(rendered) => println!("{rendered}"),
+        Err(err) => {
+            let payload = json!({
+                "truth_label": "d21_skill_md_import",
+                "ok": false,
+                "imports_skill": false,
+                "installs_skill": false,
+                "executes_skill": false,
+                "error_kind": err.kind,
+            });
+            let rendered = payload.to_string();
+            if reject_forbidden_output(&rendered).is_ok() {
+                println!("{rendered}");
+            }
+            eprintln!("hub_skill_md_import_unavailable: {}", err.kind);
+            std::process::exit(2);
+        }
+    }
+}
+
+fn run() -> Result<String, CliError> {
+    let args: Vec<String> = env::args().collect();
+    if args.get(1).map(String::as_str) != Some("import-local") {
+        return Err(CliError::new("bad_args"));
+    }
+
+    let db_path = arg_value(&args, "--db").ok_or(CliError::new("bad_args"))?;
+    let vk_path = arg_value(&args, "--operator-vk-path")
+        .or_else(|| env::var(friday_hub::operator_vk::OPERATOR_VK_PATH_ENV).ok())
+        .filter(|p| !p.trim().is_empty())
+        .ok_or(CliError::new("operator_vk_unprovisioned"))?;
+    let operator_vk = load_operator_vk_from_path(Path::new(vk_path.trim()))
+        .map_err(|_| CliError::new("operator_vk_malformed"))?;
+
+    let approval = read_approval(&args)?;
+    let now_ms = arg_value(&args, "--now-ms")
+        .and_then(|v| v.parse::<i64>().ok())
+        .unwrap_or_else(now_ms);
+    let db = Db::open_hub(&db_path).map_err(|_| CliError::new("init_failed"))?;
+    let receipt = import_skill_md_candidate_ed25519(
+        &db,
+        SkillMdImportRequest {
+            source_dir: arg_value(&args, "--source-dir").ok_or(CliError::new("bad_args"))?,
+            managed_skills_root: arg_value(&args, "--managed-skills-root")
+                .ok_or(CliError::new("bad_args"))?,
+            skill_id: arg_value(&args, "--skill-id").ok_or(CliError::new("bad_args"))?,
+            source_digest: arg_value(&args, "--source-digest").ok_or(CliError::new("bad_args"))?,
+            mission_id: arg_value(&args, "--mission-id").ok_or(CliError::new("bad_args"))?,
+            work_item_id: arg_value(&args, "--work-item-id").ok_or(CliError::new("bad_args"))?,
+            operator_principal_id: arg_value(&args, "--operator-principal-id")
+                .unwrap_or_else(|| "operator".to_string()),
+            canonical_approval: approval,
+            proof_ref: arg_value(&args, "--proof-ref").ok_or(CliError::new("bad_args"))?,
+            now_ms,
+        },
+        &operator_vk,
+    )
+    .map_err(|err| CliError::new(skill_error_kind(&err)))?;
+
+    let payload = json!({
+        "truth_label": "d21_skill_md_import",
+        "ok": true,
+        "imports_skill": true,
+        "installs_skill": false,
+        "executes_skill": false,
+        "import_ref": receipt.import_ref,
+        "proof_ref": receipt.proof_ref,
+        "skill_id": receipt.skill_id,
+        "source_digest": receipt.source_digest,
+        "file_count": receipt.file_count,
+        "total_bytes": receipt.total_bytes,
+        "mission_id": receipt.mission_id,
+        "work_item_id": receipt.work_item_id,
+        "status": receipt.status,
+    });
+    let rendered =
+        serde_json::to_string(&payload).map_err(|_| CliError::new("serialize_failed"))?;
+    reject_forbidden_output(&rendered)?;
+    Ok(rendered)
+}
+
+fn read_approval(args: &[String]) -> Result<CanonicalApproval, CliError> {
+    let approval_json = match arg_value(args, "--approval-json") {
+        Some(path) => std::fs::read_to_string(path).map_err(|_| CliError::new("bad_args"))?,
+        None => {
+            let mut buf = String::new();
+            std::io::stdin()
+                .read_to_string(&mut buf)
+                .map_err(|_| CliError::new("bad_args"))?;
+            buf
+        }
+    };
+    let signed: SignedApprovalIn =
+        serde_json::from_str(approval_json.trim()).map_err(|_| CliError::new("bad_approval"))?;
+    Ok(CanonicalApproval {
+        decision: parse_decision(&signed.decision).ok_or(CliError::new("bad_approval"))?,
+        approval_id: signed.approval_id,
+        action_digest: signed.action_digest,
+        expires_at: Some(signed.expires_at),
+        issuer: Some(
+            signed
+                .issuer
+                .unwrap_or_else(|| CANONICAL_GATE_ISSUER.to_string()),
+        ),
+        signature: Some(signed.signature),
+    })
+}
+
+fn arg_value(args: &[String], name: &str) -> Option<String> {
+    args.windows(2)
+        .find_map(|pair| (pair[0] == name).then(|| pair[1].clone()))
+        .or_else(|| {
+            let prefix = format!("{name}=");
+            args.iter()
+                .find_map(|arg| arg.strip_prefix(&prefix).map(str::to_string))
+        })
+}
+
+fn parse_decision(value: &str) -> Option<ApprovalDecision> {
+    match value {
+        "approved" => Some(ApprovalDecision::Approved),
+        "denied" => Some(ApprovalDecision::Denied),
+        _ => None,
+    }
+}
+
+fn now_ms() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as i64)
+        .unwrap_or(0)
+}
+
+fn skill_error_kind(err: &SkillMdImportError) -> &'static str {
+    match err {
+        SkillMdImportError::Blocked(_) => "run_blocked",
+        SkillMdImportError::Io(_) => "io_failed",
+        SkillMdImportError::Serialize(_) => "serialize_failed",
+        SkillMdImportError::Storage(_) => "storage_failed",
+    }
+}
+
+fn reject_forbidden_output(rendered: &str) -> Result<(), CliError> {
+    friday_hub::refs_guard::reject_forbidden_output(rendered, &["answer\":\""])
+        .map_err(|_| CliError::new("output_guard"))
+}

--- a/rust-core/crates/friday-hub/src/lib.rs
+++ b/rust-core/crates/friday-hub/src/lib.rs
@@ -341,6 +341,7 @@ pub mod skill_candidate_materializer;
 /// truth-labeled catalog entries and advisor inputs; it does not execute skills
 /// or grant control.
 pub mod skill_catalog;
+pub mod skill_md_importer;
 
 /// Shared refs-only output guard for the proof bins. Single source of truth for the
 /// common secret/path marker set; each bin passes its body-field markers as `extra`.

--- a/rust-core/crates/friday-hub/src/skill_catalog.rs
+++ b/rust-core/crates/friday-hub/src/skill_catalog.rs
@@ -157,6 +157,11 @@ pub fn discover_skill_catalog(
             approval_blockers
                 .push("operator_approval_required_before_first_or_high_risk_run".to_string());
         }
+        if runtime_kind == "skill-md-imported" {
+            approval_blockers.push(
+                "skill_md_imported_runtime_not_executable_until_sandboxed_executor".to_string(),
+            );
+        }
         entries.push(SkillCatalogEntry {
             skill_ref: redacted_ref("skill", &skill_id),
             skill_id: skill_id.clone(),
@@ -229,6 +234,7 @@ pub fn discover_skill_catalog(
             "skill_run_requires_gate_and_receipt".to_string(),
             "skill_memory_preference_is_not_auto_confirmed".to_string(),
             "legacy_skill_md_candidate_is_not_imported_or_executable".to_string(),
+            "skill_md_import_is_not_execution".to_string(),
         ],
     })
 }
@@ -1223,6 +1229,54 @@ mod tests {
         assert_eq!(snapshot.entries[0].skill_id, "time");
         assert_eq!(snapshot.entries[0].safe_name, "Manifest Time");
         assert_eq!(snapshot.entries[0].runtime_kind, "shell");
+    }
+
+    #[test]
+    fn imported_skill_md_manifest_remains_blocked_even_if_adopted_and_approved() {
+        let root = temp_root("skill-md-imported-manifest");
+        write_skill(
+            &root,
+            "summarize",
+            r#"{
+              "id":"summarize",
+              "name":"Imported Summarize",
+              "runtime":{"kind":"skill-md-imported"},
+              "triggers":{"intents":["summarize"],"phrases":[]},
+              "invocation":{"priority":50},
+              "permissions":{"grants":[],"promptOn":[]},
+              "executionTargets":{"requiredCapabilities":[]}
+            }"#,
+        );
+
+        let snapshot = discover_skill_catalog(SkillCatalogDiscovery {
+            managed_skills_root: root.to_string_lossy().to_string(),
+            adopted_skill_ids: vec!["summarize".to_string()],
+            approved_first_run_skill_ids: vec!["summarize".to_string()],
+            proof_refs_by_skill_id: BTreeMap::new(),
+            run_refs_by_skill_id: BTreeMap::new(),
+            now_ms: 72,
+        })
+        .unwrap();
+        let entry = &snapshot.entries[0];
+
+        assert_eq!(entry.runtime_kind, "skill-md-imported");
+        assert_eq!(entry.state, SkillState::Runnable);
+        assert!(!entry.can_be_recommended());
+        assert!(entry.approval_blockers.iter().any(|blocker| {
+            blocker == "skill_md_imported_runtime_not_executable_until_sandboxed_executor"
+        }));
+        let decision = advise_skill_from_catalog(
+            &snapshot,
+            SkillAdvisorRequest {
+                intent_key: "summarize".to_string(),
+                operator_approved_first_run: true,
+            },
+        );
+        assert_eq!(
+            decision.recommendation,
+            SkillAdvisorRecommendationKind::RecommendAfterOperatorApproval
+        );
+        assert!(!decision.run_allowed);
     }
 
     #[test]

--- a/rust-core/crates/friday-hub/src/skill_md_importer.rs
+++ b/rust-core/crates/friday-hub/src/skill_md_importer.rs
@@ -1,0 +1,448 @@
+//! D21 governed SKILL.md import point.
+//!
+//! This DARK leg turns a reviewed local SKILL.md package into a managed manifest
+//! candidate so the catalog can reason about it. Import is not adoption,
+//! promotion, runnable eligibility, or execution.
+
+use std::{
+    collections::BTreeMap,
+    fs,
+    path::{Component, Path, PathBuf},
+};
+
+use friday_core::{
+    gate::{Actor, ActorKind, CanonicalApproval, GateDecision, MutatingActionRequest},
+    MissionLink, MissionLinkKind,
+};
+use friday_crypto::OperatorVerifyingKey;
+use friday_storage::{
+    authorize_mutating_action, authorize_mutating_action_ed25519, Db, StorageError,
+};
+use serde_json::json;
+use sha2::{Digest, Sha256};
+
+const MAX_FILES: usize = 64;
+const MAX_TOTAL_BYTES: u64 = 512 * 1024;
+const MAX_DEPTH: usize = 8;
+
+#[derive(Debug, thiserror::Error)]
+pub enum SkillMdImportError {
+    #[error("skill md import blocked: {0}")]
+    Blocked(String),
+    #[error("skill md import io failed")]
+    Io(#[from] std::io::Error),
+    #[error("skill md import serialize failed")]
+    Serialize(#[from] serde_json::Error),
+    #[error("skill md import storage failed")]
+    Storage(#[from] StorageError),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SkillMdImportRequest {
+    pub source_dir: String,
+    pub managed_skills_root: String,
+    pub skill_id: String,
+    pub source_digest: String,
+    pub mission_id: String,
+    pub work_item_id: String,
+    pub operator_principal_id: String,
+    pub canonical_approval: CanonicalApproval,
+    pub proof_ref: String,
+    pub now_ms: i64,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SkillMdImportReceipt {
+    pub import_ref: String,
+    pub proof_ref: String,
+    pub skill_id: String,
+    pub source_digest: String,
+    pub file_count: usize,
+    pub total_bytes: u64,
+    pub mission_id: String,
+    pub work_item_id: String,
+    pub status: String,
+}
+
+#[derive(Clone, Debug)]
+struct CandidateFile {
+    rel: PathBuf,
+    bytes: Vec<u8>,
+}
+
+pub fn import_skill_md_candidate(
+    db: &Db,
+    request: SkillMdImportRequest,
+    approval_secret: &[u8],
+) -> Result<SkillMdImportReceipt, SkillMdImportError> {
+    let files = validate_import_request(db, &request)?;
+    let gate_request = skill_md_import_gate_request(
+        &request.skill_id,
+        &request.source_digest,
+        &request.mission_id,
+        &request.work_item_id,
+        &request.operator_principal_id,
+    );
+    let gate = authorize_mutating_action(
+        db.conn(),
+        &gate_request,
+        Some(&request.canonical_approval),
+        approval_secret,
+        request.now_ms,
+    )?;
+    if gate.decision != GateDecision::Allow {
+        return Err(SkillMdImportError::Blocked(format!(
+            "skill_md_import_canonical_gate_{}",
+            gate.reason
+        )));
+    }
+    write_import(db, request, files)
+}
+
+pub fn import_skill_md_candidate_ed25519(
+    db: &Db,
+    request: SkillMdImportRequest,
+    operator_vk: &OperatorVerifyingKey,
+) -> Result<SkillMdImportReceipt, SkillMdImportError> {
+    let files = validate_import_request(db, &request)?;
+    let gate_request = skill_md_import_gate_request(
+        &request.skill_id,
+        &request.source_digest,
+        &request.mission_id,
+        &request.work_item_id,
+        &request.operator_principal_id,
+    );
+    let gate = authorize_mutating_action_ed25519(
+        db.conn(),
+        &gate_request,
+        Some(&request.canonical_approval),
+        operator_vk,
+        request.now_ms,
+    )?;
+    if gate.decision != GateDecision::Allow {
+        return Err(SkillMdImportError::Blocked(format!(
+            "skill_md_import_canonical_gate_{}",
+            gate.reason
+        )));
+    }
+    write_import(db, request, files)
+}
+
+pub fn skill_md_import_gate_request(
+    skill_id: &str,
+    source_digest: &str,
+    mission_id: &str,
+    work_item_id: &str,
+    operator_principal_id: &str,
+) -> MutatingActionRequest {
+    let params = vec![
+        ("target".to_string(), skill_id.to_string()),
+        ("source_digest".to_string(), source_digest.to_string()),
+        ("mission_id".to_string(), mission_id.to_string()),
+        ("work_item_id".to_string(), work_item_id.to_string()),
+    ];
+    MutatingActionRequest::from_classification(
+        friday_core::gate::classify(true, friday_core::Risk::High, "import_skill_md", &params),
+        "import_skill_md".to_string(),
+        Actor {
+            kind: ActorKind::Owner,
+            id: operator_principal_id.to_string(),
+            principal_id: Some(operator_principal_id.to_string()),
+        },
+        "friday_hub_skill_md_importer".to_string(),
+        Vec::new(),
+        Some(format!(
+            "skill_id={skill_id};source_digest={source_digest};mission_id={mission_id};work_item_id={work_item_id}"
+        )),
+        Some(format!(
+            "skill-md-import:{skill_id}:{source_digest}:{mission_id}:{work_item_id}"
+        )),
+        None,
+    )
+}
+
+fn validate_import_request(
+    db: &Db,
+    request: &SkillMdImportRequest,
+) -> Result<Vec<CandidateFile>, SkillMdImportError> {
+    if !is_safe_id(&request.skill_id) || !is_safe_id(&request.source_digest) {
+        return Err(SkillMdImportError::Blocked(
+            "safe_public_metadata_required".into(),
+        ));
+    }
+    if !request.proof_ref.starts_with("proof://") {
+        return Err(SkillMdImportError::Blocked("proof_ref_required".into()));
+    }
+    let mission = db
+        .get_mission(&request.mission_id)?
+        .ok_or_else(|| SkillMdImportError::Blocked("unknown_mission".into()))?;
+    if mission.status.is_terminal() {
+        return Err(SkillMdImportError::Blocked("mission_is_terminal".into()));
+    }
+    let work_item = db
+        .get_work_item(&request.work_item_id)?
+        .ok_or_else(|| SkillMdImportError::Blocked("unknown_work_item".into()))?;
+    if work_item.mission_id != request.mission_id {
+        return Err(SkillMdImportError::Blocked(
+            "work_item_mission_mismatch".into(),
+        ));
+    }
+    if work_item.status.is_terminal() {
+        return Err(SkillMdImportError::Blocked("work_item_is_terminal".into()));
+    }
+
+    let source = fs::canonicalize(&request.source_dir)?;
+    let root = fs::canonicalize(&request.managed_skills_root).or_else(|_| {
+        fs::create_dir_all(&request.managed_skills_root)?;
+        fs::canonicalize(&request.managed_skills_root)
+    })?;
+    if source.starts_with(&root) {
+        return Err(SkillMdImportError::Blocked(
+            "source_inside_managed_root".into(),
+        ));
+    }
+    if root.starts_with(&source) {
+        return Err(SkillMdImportError::Blocked(
+            "managed_root_inside_source".into(),
+        ));
+    }
+    let destination = root.join(&request.skill_id);
+    if destination.exists() {
+        return Err(SkillMdImportError::Blocked(
+            "destination_already_exists".into(),
+        ));
+    }
+
+    let files = collect_files(&source)?;
+    if !files.iter().any(|file| file.rel == Path::new("SKILL.md")) {
+        return Err(SkillMdImportError::Blocked("skill_md_required".into()));
+    }
+    let digest = candidate_digest(&files);
+    if digest != request.source_digest {
+        return Err(SkillMdImportError::Blocked("source_digest_mismatch".into()));
+    }
+    Ok(files)
+}
+
+fn write_import(
+    db: &Db,
+    request: SkillMdImportRequest,
+    files: Vec<CandidateFile>,
+) -> Result<SkillMdImportReceipt, SkillMdImportError> {
+    let import_ref = redacted_ref(
+        "skill-md-import",
+        &format!(
+            "{}:{}:{}:{}",
+            request.skill_id, request.source_digest, request.mission_id, request.work_item_id
+        ),
+    );
+    let skill_dir = Path::new(&request.managed_skills_root).join(&request.skill_id);
+    fs::create_dir_all(&skill_dir)?;
+    for file in &files {
+        let target = skill_dir.join(&file.rel);
+        if let Some(parent) = target.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        fs::write(target, &file.bytes)?;
+    }
+    let title = files
+        .iter()
+        .find(|file| file.rel == Path::new("SKILL.md"))
+        .and_then(|file| std::str::from_utf8(&file.bytes).ok())
+        .map(skill_md_title)
+        .filter(|title| is_safe_public_text(title))
+        .unwrap_or_else(|| request.skill_id.clone());
+    let manifest = json!({
+        "id": request.skill_id,
+        "name": title,
+        "runtime": {
+            "kind": "skill-md-imported"
+        },
+        "triggers": {
+            "intents": [],
+            "phrases": []
+        },
+        "invocation": {
+            "priority": 0
+        },
+        "permissions": {
+            "grants": [],
+            "promptOn": ["operator.adopt_skill", "sandboxed_executor_required"]
+        },
+        "executionTargets": {
+            "requiredCapabilities": ["skill.import.review"]
+        }
+    });
+    fs::write(
+        skill_dir.join("skill.manifest.json"),
+        serde_json::to_vec_pretty(&manifest)?,
+    )?;
+
+    db.upsert_mission_link(&MissionLink {
+        link_id: import_ref.clone(),
+        mission_id: request.mission_id.clone(),
+        work_item_id: Some(request.work_item_id.clone()),
+        link_kind: MissionLinkKind::ProofReceipt,
+        target_ref: import_ref.clone(),
+        proof_ref: Some(request.proof_ref.clone()),
+        created_at_ms: request.now_ms,
+    })?;
+
+    let total_bytes = files
+        .iter()
+        .map(|file| file.bytes.len() as u64)
+        .sum::<u64>();
+    Ok(SkillMdImportReceipt {
+        import_ref,
+        proof_ref: request.proof_ref,
+        skill_id: request.skill_id,
+        source_digest: request.source_digest,
+        file_count: files.len(),
+        total_bytes,
+        mission_id: request.mission_id,
+        work_item_id: request.work_item_id,
+        status: "imported_manifest_candidate_not_executable".to_string(),
+    })
+}
+
+fn collect_files(source: &Path) -> Result<Vec<CandidateFile>, SkillMdImportError> {
+    let mut out = Vec::new();
+    collect_files_inner(source, source, &mut out)?;
+    out.sort_by(|a, b| a.rel.cmp(&b.rel));
+    let total = out.iter().map(|f| f.bytes.len() as u64).sum::<u64>();
+    if out.len() > MAX_FILES || total > MAX_TOTAL_BYTES {
+        return Err(SkillMdImportError::Blocked("candidate_size_limit".into()));
+    }
+    Ok(out)
+}
+
+fn collect_files_inner(
+    root: &Path,
+    dir: &Path,
+    out: &mut Vec<CandidateFile>,
+) -> Result<(), SkillMdImportError> {
+    for entry in fs::read_dir(dir)? {
+        let entry = entry?;
+        let ty = entry.file_type()?;
+        if ty.is_symlink() {
+            return Err(SkillMdImportError::Blocked("symlink_rejected".into()));
+        }
+        let path = entry.path();
+        if ty.is_dir() {
+            collect_files_inner(root, &path, out)?;
+            continue;
+        }
+        if !ty.is_file() {
+            return Err(SkillMdImportError::Blocked("special_file_rejected".into()));
+        }
+        let rel = path
+            .strip_prefix(root)
+            .map_err(|_| SkillMdImportError::Blocked("path_escape".into()))?;
+        validate_relative_path(rel)?;
+        out.push(CandidateFile {
+            rel: rel.to_path_buf(),
+            bytes: fs::read(&path)?,
+        });
+    }
+    Ok(())
+}
+
+fn validate_relative_path(path: &Path) -> Result<(), SkillMdImportError> {
+    let depth = path.components().count();
+    if depth == 0 || depth > MAX_DEPTH {
+        return Err(SkillMdImportError::Blocked("path_depth_limit".into()));
+    }
+    for component in path.components() {
+        match component {
+            Component::Normal(part) if is_safe_path_part(&part.to_string_lossy()) => {}
+            _ => return Err(SkillMdImportError::Blocked("unsafe_path".into())),
+        }
+    }
+    Ok(())
+}
+
+fn candidate_digest(files: &[CandidateFile]) -> String {
+    let mut hash = Sha256::new();
+    for file in files {
+        hash.update(file.rel.to_string_lossy().as_bytes());
+        hash.update([0]);
+        hash.update(&file.bytes);
+        hash.update([0]);
+    }
+    format!("skill-candidate-{}", hex_digest(hash.finalize().as_slice()))
+}
+
+fn redacted_ref(prefix: &str, value: &str) -> String {
+    let mut hash = Sha256::new();
+    hash.update(value.as_bytes());
+    format!("{prefix}:{}", hex_digest(hash.finalize().as_slice()))
+}
+
+fn hex_digest(bytes: &[u8]) -> String {
+    bytes.iter().map(|b| format!("{b:02x}")).collect::<String>()
+}
+
+fn skill_md_title(markdown: &str) -> String {
+    let fields = parse_skill_md_frontmatter(markdown);
+    fields
+        .get("title")
+        .or_else(|| fields.get("name"))
+        .cloned()
+        .unwrap_or_default()
+}
+
+fn parse_skill_md_frontmatter(markdown: &str) -> BTreeMap<String, String> {
+    let normalized = markdown.replace("\r\n", "\n");
+    let Some(after_open) = normalized.strip_prefix("---\n") else {
+        return BTreeMap::new();
+    };
+    let Some(end) = after_open.find("\n---") else {
+        return BTreeMap::new();
+    };
+    let yaml_block = &after_open[..end];
+    let mut fields = BTreeMap::new();
+    for line in yaml_block.lines() {
+        let line = line.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        let Some((key, value)) = line.split_once(':') else {
+            continue;
+        };
+        let key = key.trim();
+        if !is_safe_id(key) {
+            continue;
+        }
+        let value = value
+            .trim()
+            .trim_matches('"')
+            .trim_matches('\'')
+            .trim()
+            .to_string();
+        if !value.is_empty() && is_safe_public_text(&value) {
+            fields.insert(key.to_string(), value);
+        }
+    }
+    fields
+}
+
+fn is_safe_id(value: &str) -> bool {
+    !value.is_empty()
+        && value.len() <= 96
+        && value
+            .chars()
+            .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '.'))
+}
+
+fn is_safe_path_part(value: &str) -> bool {
+    is_safe_id(value) || value == "SKILL.md"
+}
+
+fn is_safe_public_text(value: &str) -> bool {
+    !value.is_empty()
+        && value.len() <= 160
+        && !value.contains("/Users/")
+        && !value.to_ascii_lowercase().contains("secret")
+        && !value.contains('\n')
+        && !value.contains('\r')
+}

--- a/rust-core/crates/friday-hub/tests/skill_md_import_cli.rs
+++ b/rust-core/crates/friday-hub/tests/skill_md_import_cli.rs
@@ -1,0 +1,365 @@
+//! D21 SKILL.md import CLI tests.
+//!
+//! The CLI verifies an operator Ed25519 approval with only the public key, imports
+//! a local SKILL.md package as a managed manifest candidate, and never executes it.
+
+use std::process::Command;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use friday_core::gate::{
+    canonical_action_bytes, canonical_approval_signature_bytes, ApprovalDecision,
+    CanonicalApproval, MutatingActionRequest, CANONICAL_GATE_ISSUER,
+};
+use friday_core::{
+    ApprovalState, FridayConversation, HandoffJudgmentMemory, Mission, MissionStatus, Risk,
+    TruthStatus, WorkItem, WorkItemStatus, WorkLane,
+};
+use friday_crypto::{OperatorSigningKey, OperatorVerifyingKey};
+use friday_hub::skill_md_importer::skill_md_import_gate_request;
+use friday_storage::Db;
+use serde_json::Value;
+use sha2::{Digest, Sha256};
+
+const HUB_HMAC_SECRET: &[u8] = b"hub-held-hmac-gate-secret-0123456789";
+const NOW: i64 = 1_000;
+const FUTURE: i64 = 5_000_000_000_000;
+
+static C: AtomicU64 = AtomicU64::new(0);
+
+fn unique(tag: &str) -> String {
+    format!(
+        "{}-{}-{}",
+        std::process::id(),
+        tag,
+        C.fetch_add(1, Ordering::Relaxed)
+    )
+}
+
+fn temp_path(tag: &str) -> std::path::PathBuf {
+    std::env::temp_dir().join(format!("friday-skill-md-import-cli-{}", unique(tag)))
+}
+
+fn temp_db(tag: &str) -> String {
+    temp_path(&format!("{tag}.sqlite"))
+        .to_string_lossy()
+        .into_owned()
+}
+
+fn vk_hex(vk: &OperatorVerifyingKey) -> String {
+    vk.to_bytes()
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect()
+}
+
+fn operator() -> (OperatorSigningKey, OperatorVerifyingKey) {
+    let sk = OperatorSigningKey::generate();
+    let vk = sk.verifying_key();
+    (sk, vk)
+}
+
+fn ed_approval(
+    req: &MutatingActionRequest,
+    sk: &OperatorSigningKey,
+    approval_id: &str,
+) -> CanonicalApproval {
+    let digest = friday_crypto::action_digest(&canonical_action_bytes(req));
+    let mut approval = CanonicalApproval {
+        decision: ApprovalDecision::Approved,
+        approval_id: approval_id.to_string(),
+        action_digest: digest,
+        expires_at: Some(FUTURE),
+        issuer: Some(CANONICAL_GATE_ISSUER.to_string()),
+        signature: None,
+    };
+    approval.signature = Some(
+        sk.sign(&canonical_approval_signature_bytes(&approval))
+            .to_hex(),
+    );
+    approval
+}
+
+fn hmac_approval(req: &MutatingActionRequest, approval_id: &str) -> CanonicalApproval {
+    let digest = friday_crypto::action_digest(&canonical_action_bytes(req));
+    let mut approval = CanonicalApproval {
+        decision: ApprovalDecision::Approved,
+        approval_id: approval_id.to_string(),
+        action_digest: digest,
+        expires_at: Some(FUTURE),
+        issuer: Some(CANONICAL_GATE_ISSUER.to_string()),
+        signature: None,
+    };
+    approval.signature = Some(friday_crypto::sign_approval(
+        &canonical_approval_signature_bytes(&approval),
+        HUB_HMAC_SECRET,
+    ));
+    approval
+}
+
+fn write_approval(path: &std::path::Path, approval: &CanonicalApproval) {
+    let decision = match approval.decision {
+        ApprovalDecision::Approved => "approved",
+        ApprovalDecision::Denied => "denied",
+    };
+    let body = serde_json::json!({
+        "decision": decision,
+        "approval_id": approval.approval_id,
+        "action_digest": approval.action_digest,
+        "expires_at": approval.expires_at.unwrap(),
+        "issuer": approval.issuer,
+        "signature": approval.signature,
+    });
+    std::fs::write(path, body.to_string()).unwrap();
+}
+
+fn source_digest(skill_md: &[u8]) -> String {
+    let mut hash = Sha256::new();
+    hash.update(b"SKILL.md");
+    hash.update([0]);
+    hash.update(skill_md);
+    hash.update([0]);
+    let digest = hash
+        .finalize()
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect::<String>();
+    format!("skill-candidate-{digest}")
+}
+
+fn seed_mission(db: &Db) {
+    db.upsert_friday_conversation(&FridayConversation {
+        friday_conversation_id: "fconv_skill_md_import_cli".into(),
+        owner_principal: "operator".into(),
+        title: "Skill MD Import CLI".into(),
+        current_focus_summary: "Import manifest candidate".into(),
+        active_mission_ids: vec!["mission-skill-md-import-cli".into()],
+        surface_thread_ids: Vec::new(),
+        memory_scope_ref: None,
+        truth_status: TruthStatus::Proven,
+        proof_refs: Vec::new(),
+        created_at_ms: NOW,
+        updated_at_ms: NOW,
+    })
+    .unwrap();
+    db.upsert_mission(&Mission {
+        mission_id: "mission-skill-md-import-cli".into(),
+        friday_conversation_id: "fconv_skill_md_import_cli".into(),
+        title: "Skill MD Import CLI".into(),
+        intent: "Import a local skill candidate without executing it".into(),
+        status: MissionStatus::Active,
+        why_now: "D21 needs an operator-facing verify-only import leg".into(),
+        decision_path_summary: "Verify Ed25519 approval before writing a manifest candidate."
+            .into(),
+        considered_options: vec!["direct execution".into()],
+        deferred_options: vec!["sandboxed runtime".into()],
+        known_pitfalls: vec!["import confused with runnable execution".into()],
+        handoff_inheritance: vec!["Hub verifies, operator signs".into()],
+        work_item_ids: vec!["work-skill-md-import-cli".into()],
+        memory_candidate_refs: Vec::new(),
+        context_passport_refs: Vec::new(),
+        proof_refs: Vec::new(),
+        created_at_ms: NOW,
+        updated_at_ms: NOW,
+    })
+    .unwrap();
+    db.upsert_work_item(&WorkItem {
+        work_item_id: "work-skill-md-import-cli".into(),
+        mission_id: "mission-skill-md-import-cli".into(),
+        lane: WorkLane::FridayHub,
+        target_provider_or_agent: Some("skill:import".into()),
+        status: WorkItemStatus::ReadyToDispatch,
+        owner_claim_ids: Vec::new(),
+        workspace_refs: Vec::new(),
+        capability_id: Some("skill.md.import".into()),
+        risk_level: Risk::Low,
+        approval_state: ApprovalState::Approved,
+        blocking_reason: None,
+        input_refs: vec!["friday://body/skill-md-import".into()],
+        output_refs: Vec::new(),
+        proof_requirements: vec!["skill md import receipt".into()],
+        proof_receipts: Vec::new(),
+        judgment_memory: HandoffJudgmentMemory {
+            task: "Import a governed local SKILL.md candidate".into(),
+            current_blocker: None,
+            target_lane_thread_agent_provider: WorkLane::FridayHub.as_str().into(),
+            read_first_files: vec![
+                "rust-core/crates/friday-hub/src/bin/hub_skill_md_import.rs".into()
+            ],
+            required_output: "manifest candidate import receipt".into(),
+            done_criteria: vec!["candidate imported without execution".into()],
+            red_lines: vec!["Hub must not self-mint operator approval".into()],
+            why_this_route: "D21 A4 needs a dark governed local import leg.".into(),
+            considered_options: vec!["legacy direct run".into()],
+            deferred_options: vec!["skill execution".into()],
+            previous_pitfalls: vec!["import mistaken for runnable".into()],
+            inheritable_context: vec!["verify-only governance".into()],
+            proof_requirements: vec!["CLI import test".into()],
+            ownership_claim_ids: Vec::new(),
+        },
+        created_at_ms: NOW,
+        updated_at_ms: NOW,
+    })
+    .unwrap();
+}
+
+fn gate_request(digest: &str) -> MutatingActionRequest {
+    skill_md_import_gate_request(
+        "summarize-local",
+        digest,
+        "mission-skill-md-import-cli",
+        "work-skill-md-import-cli",
+        "operator",
+    )
+}
+
+fn cli_base(
+    db_path: &str,
+    vk_path: &std::path::Path,
+    approval_path: &std::path::Path,
+    source_dir: &std::path::Path,
+    managed_root: &std::path::Path,
+    digest: &str,
+) -> Command {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_hub_skill_md_import"));
+    cmd.arg("import-local")
+        .arg("--db")
+        .arg(db_path)
+        .arg("--operator-vk-path")
+        .arg(vk_path)
+        .arg("--approval-json")
+        .arg(approval_path)
+        .arg("--source-dir")
+        .arg(source_dir)
+        .arg("--managed-skills-root")
+        .arg(managed_root)
+        .arg("--skill-id")
+        .arg("summarize-local")
+        .arg("--source-digest")
+        .arg(digest)
+        .arg("--mission-id")
+        .arg("mission-skill-md-import-cli")
+        .arg("--work-item-id")
+        .arg("work-skill-md-import-cli")
+        .arg("--operator-principal-id")
+        .arg("operator")
+        .arg("--proof-ref")
+        .arg("proof://skill-md-import/summarize-local")
+        .arg("--now-ms")
+        .arg((NOW + 1).to_string());
+    cmd
+}
+
+#[test]
+fn cli_imports_ed25519_candidate_without_install_or_execution() {
+    let db_path = temp_db("allow");
+    let db = Db::open_hub(&db_path).unwrap();
+    seed_mission(&db);
+
+    let source_dir = temp_path("source");
+    let managed_root = temp_path("managed");
+    std::fs::create_dir_all(&source_dir).unwrap();
+    std::fs::create_dir_all(&managed_root).unwrap();
+    let skill_md =
+        b"---\nid: summarize-local\ntitle: Summarize Local\n---\nSummarize local text.\n";
+    std::fs::write(source_dir.join("SKILL.md"), skill_md).unwrap();
+    let digest = source_digest(skill_md);
+
+    let (sk, vk) = operator();
+    let vk_path = temp_path("operator.vk");
+    std::fs::write(&vk_path, vk_hex(&vk)).unwrap();
+    let approval_path = temp_path("approval.json");
+    write_approval(
+        &approval_path,
+        &ed_approval(&gate_request(&digest), &sk, "skill-md-import-ed-allow"),
+    );
+
+    let output = cli_base(
+        &db_path,
+        &vk_path,
+        &approval_path,
+        &source_dir,
+        &managed_root,
+        &digest,
+    )
+    .output()
+    .unwrap();
+    assert!(
+        output.status.success(),
+        "stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let json: Value = serde_json::from_str(stdout.trim()).unwrap();
+    assert_eq!(json["truth_label"], "d21_skill_md_import");
+    assert_eq!(json["ok"], true);
+    assert_eq!(json["imports_skill"], true);
+    assert_eq!(json["installs_skill"], false);
+    assert_eq!(json["executes_skill"], false);
+    assert_eq!(json["status"], "imported_manifest_candidate_not_executable");
+
+    assert!(managed_root
+        .join("summarize-local")
+        .join("skill.manifest.json")
+        .is_file());
+    assert!(managed_root
+        .join("summarize-local")
+        .join("SKILL.md")
+        .is_file());
+    let item = db
+        .get_work_item("work-skill-md-import-cli")
+        .unwrap()
+        .unwrap();
+    assert_eq!(item.status, WorkItemStatus::ReadyToDispatch);
+    assert!(item.proof_receipts.is_empty());
+    let links = db
+        .list_mission_links("mission-skill-md-import-cli")
+        .unwrap();
+    assert_eq!(links.len(), 1);
+}
+
+#[test]
+fn cli_rejects_hmac_approval_without_importing_candidate() {
+    let db_path = temp_db("hmac");
+    let db = Db::open_hub(&db_path).unwrap();
+    seed_mission(&db);
+
+    let source_dir = temp_path("hmac-source");
+    let managed_root = temp_path("hmac-managed");
+    std::fs::create_dir_all(&source_dir).unwrap();
+    std::fs::create_dir_all(&managed_root).unwrap();
+    let skill_md = b"---\nid: summarize-local\n---\nSummarize local text.\n";
+    std::fs::write(source_dir.join("SKILL.md"), skill_md).unwrap();
+    let digest = source_digest(skill_md);
+
+    let (_sk, vk) = operator();
+    let vk_path = temp_path("operator-hmac.vk");
+    std::fs::write(&vk_path, vk_hex(&vk)).unwrap();
+    let approval_path = temp_path("approval-hmac.json");
+    write_approval(
+        &approval_path,
+        &hmac_approval(&gate_request(&digest), "skill-md-import-hmac"),
+    );
+
+    let output = cli_base(
+        &db_path,
+        &vk_path,
+        &approval_path,
+        &source_dir,
+        &managed_root,
+        &digest,
+    )
+    .output()
+    .unwrap();
+    assert!(!output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let json: Value = serde_json::from_str(stdout.trim()).unwrap();
+    assert_eq!(json["ok"], false);
+    assert_eq!(json["imports_skill"], false);
+    assert_eq!(json["installs_skill"], false);
+    assert_eq!(json["executes_skill"], false);
+    assert!(std::fs::read_dir(&managed_root).unwrap().next().is_none());
+    assert!(db
+        .list_mission_links("mission-skill-md-import-cli")
+        .unwrap()
+        .is_empty());
+}


### PR DESCRIPTION
## Summary
- Add a governed D21 SKILL.md import leg that verifies an operator-signed approval, copies a reviewed local SKILL.md package into managed skills, and writes a manifest candidate.
- Keep imported SKILL.md manifests fail-closed with a catalog blocker so import/adoption/approval cannot become execution eligibility until a sandboxed executor exists.
- Fix advisor run_allowed so remaining approval blockers prevent run permission, and cover the Ed25519-only CLI path plus HMAC rejection.

## Truth label
- DARK / mechanism only.
- imports_skill=true for the new CLI success path.
- installs_skill=false, executes_skill=false.
- Not A4 live execution, not GO-LIVE, and not v1 done.

## Verification
- cargo fmt --all -- --check
- cargo test -p friday-core skill_catalog -- --nocapture
- cargo test -p friday-hub skill_catalog -- --nocapture
- cargo test -p friday-hub --test skill_md_import_cli -- --nocapture
- cargo build -p friday-hub --bin hub_skill_md_import
- cargo clippy -p friday-core --all-targets -- -D warnings
- cargo clippy -p friday-hub --all-targets -- -D warnings