### PR TITLE
Add dark Studio hub deck entrypoint

### DIFF
--- a/docs/ops/prod-flags-manifest.json
+++ b/docs/ops/prod-flags-manifest.json
@@ -210,6 +210,19 @@
       "notes": "Built-but-dark (registry gap #26). RGG is DeepSeek-only, so both provider legs are MOCKED: the named test drives the ProviderFailoverWrapper THROUGH the real friday_hub::run_loop against a real Hub Db — a DeepSeek 402 fails over to a finishing Claude mock, the loop Finishes 'PONG', and EXACTLY ONE token_ledger row is written attributed to anthropic/api.anthropic.com (no double-bill). Sibling e2e proofs in the same file: 429 + 5xx failover, and 400-malformed → loop errors closed with NO failover + NO bill. The wrapper/classifier per-case behavior (incl. the inner-parse-error double-bill guard, auth/no-model no-failover) is pinned in src/provider_failover.rs tests; the WIRING decision (flag-off byte-identical: wrapper not constructed; flag-on-but-Claude-absent: hard boot error; the exact-'1' flag matcher) is pinned in src/runtime.rs tests (failover_flag_off_does_not_construct_wrapper_byte_identical, failover_flag_on_without_claude_is_hard_boot_error, provider_failover_flag_matcher_is_exact_one_default_off)."
     },
     {
+      "flag": "FRIDAY_STUDIO_RUST_ENABLED",
+      "process": "rust-ws-wrapper",
+      "prod_state": "dark",
+      "closes_loop": "With the flag ON, a Hub-owned Studio proof entrypoint reaches the Rust Studio artifact core and returns metadata for real HTML/manifest/notes artifacts; with the flag OFF it fails closed before rendering, writes no files, calls no provider, and binary office exports remain explicitly unsupported.",
+      "coverage": "destination-only",
+      "e2e_test": "rust-core/crates/friday-hub/tests/studio_deck_cli.rs::flag_on_returns_metadata_for_real_html_manifest_and_notes_artifacts",
+      "additional_e2e_tests": [
+        "rust-core/crates/friday-hub/tests/studio_deck_cli.rs::flag_off_fails_closed_without_rendering_artifacts",
+        "rust-core/crates/friday-hub/tests/studio_deck_cli.rs::binary_exports_fail_closed_even_when_studio_flag_is_on"
+      ],
+      "notes": "Built-but-dark B4 Studio Hub wiring. The mapped CLI tests execute the real friday-studio core through a Hub binary while outputting only metadata (paths/mime/byte_len/sha256), never artifact bodies. Honest boundary: this is not a product route, not a TS replacement, and not live document export; PPTX/DOCX/PDF remain fail-closed until a later reviewed export cutover."
+    },
+    {
       "flag": "FRIDAY_WEB_FETCH_ENABLED",
       "process": "rust-ws-wrapper",
       "prod_state": "dark",

--- a/rust-core/Cargo.lock
+++ b/rust-core/Cargo.lock
@@ -699,6 +699,7 @@ dependencies = [
  "friday-protocol",
  "friday-providers",
  "friday-storage",
+ "friday-studio",
  "friday-transport",
  "friday-tts",
  "friday-vision",

--- a/rust-core/crates/friday-hub/Cargo.toml
+++ b/rust-core/crates/friday-hub/Cargo.toml
@@ -50,6 +50,9 @@ friday-vision.workspace = true
 friday-tts.workspace = true
 friday-pdf.workspace = true
 friday-ocr.workspace = true
+# B4 Studio/document export — Rust-owned DARK artifact core. Hub wiring stays
+# default-off and metadata-only until a later product route/export cutover.
+friday-studio.workspace = true
 friday-providers.workspace = true
 # The ToolExecutor's file read/write goes through the hardened workspace-root-contained
 # safe-open — NEVER std::fs on an agent-supplied path.

--- a/rust-core/crates/friday-hub/src/bin/hub_studio_deck.rs
+++ b/rust-core/crates/friday-hub/src/bin/hub_studio_deck.rs
@@ -1,0 +1,176 @@
+//! B4 Studio DARK Hub entrypoint.
+//!
+//! This is a metadata-only proof surface for the Rust Studio core. It does not
+//! create a product route, write files, call providers, or replace the TS Studio
+//! surface. The flag is exact-`1` default-off so prod behavior stays unchanged.
+
+use std::env;
+
+use friday_studio::{
+    generate_html_deck, render_binary_export, StudioDeckRequest, StudioError, StudioExportFormat,
+};
+use serde_json::json;
+use sha2::{Digest, Sha256};
+
+const FLAG: &str = "FRIDAY_STUDIO_RUST_ENABLED";
+
+struct CliError {
+    kind: &'static str,
+}
+
+impl CliError {
+    fn new(kind: &'static str) -> Self {
+        Self { kind }
+    }
+}
+
+fn main() {
+    match run() {
+        Ok(rendered) => println!("{rendered}"),
+        Err(err) => {
+            let payload = json!({
+                "truth_label": "b4_studio_rust_dark_hub",
+                "ok": false,
+                "live": false,
+                "writes_files": false,
+                "calls_provider": false,
+                "error_kind": err.kind,
+            });
+            let rendered = payload.to_string();
+            if reject_forbidden_output(&rendered).is_ok() {
+                println!("{rendered}");
+            }
+            eprintln!("hub_studio_deck_unavailable: {}", err.kind);
+            std::process::exit(2);
+        }
+    }
+}
+
+fn run() -> Result<String, CliError> {
+    if !studio_enabled_from_env() {
+        return Err(CliError::new("flag_disabled"));
+    }
+
+    let args: Vec<String> = env::args().collect();
+    if args.get(1).map(String::as_str) != Some("render-html-deck") {
+        return Err(CliError::new("bad_args"));
+    }
+
+    let request = StudioDeckRequest {
+        topic: arg_value(&args, "--topic").ok_or(CliError::new("bad_args"))?,
+        template: arg_value(&args, "--template"),
+        notes: arg_value(&args, "--notes"),
+        slide_count: arg_value(&args, "--slide-count").and_then(|v| v.parse::<usize>().ok()),
+    };
+    let outcome = generate_html_deck(&request).map_err(|err| CliError::new(studio_error(&err)))?;
+
+    if let Some(format) = arg_value(&args, "--binary-format") {
+        let format = parse_binary_format(&format).ok_or(CliError::new("bad_args"))?;
+        render_binary_export(&outcome, format).map_err(|err| CliError::new(studio_error(&err)))?;
+    }
+
+    let artifacts: Vec<serde_json::Value> = outcome
+        .artifacts
+        .iter()
+        .map(|artifact| {
+            json!({
+                "relative_path": artifact.relative_path,
+                "format": artifact.format,
+                "mime_type": artifact.mime_type,
+                "byte_len": artifact.bytes.len(),
+                "sha256": sha256_hex(&artifact.bytes),
+            })
+        })
+        .collect();
+
+    let payload = json!({
+        "truth_label": "b4_studio_rust_dark_hub",
+        "ok": true,
+        "live": false,
+        "writes_files": false,
+        "calls_provider": false,
+        "binary_exports_live": false,
+        "slide_count": outcome.slides.len(),
+        "artifact_count": artifacts.len(),
+        "artifacts": artifacts,
+    });
+    let rendered =
+        serde_json::to_string(&payload).map_err(|_| CliError::new("serialize_failed"))?;
+    reject_forbidden_output(&rendered)?;
+    Ok(rendered)
+}
+
+fn studio_enabled_from_env() -> bool {
+    env::var(FLAG).map(|v| v == "1").unwrap_or(false)
+}
+
+fn arg_value(args: &[String], name: &str) -> Option<String> {
+    args.windows(2)
+        .find_map(|pair| (pair[0] == name).then(|| pair[1].clone()))
+        .or_else(|| {
+            let prefix = format!("{name}=");
+            args.iter()
+                .find_map(|arg| arg.strip_prefix(&prefix).map(str::to_string))
+        })
+}
+
+fn parse_binary_format(value: &str) -> Option<StudioExportFormat> {
+    match value {
+        "pptx" => Some(StudioExportFormat::Pptx),
+        "docx" => Some(StudioExportFormat::Docx),
+        "pdf" => Some(StudioExportFormat::Pdf),
+        _ => None,
+    }
+}
+
+fn studio_error(err: &StudioError) -> &'static str {
+    match err {
+        StudioError::EmptyTopic => "empty_topic",
+        StudioError::TopicTooLong { .. } => "topic_too_long",
+        StudioError::NotesTooLong { .. } => "notes_too_long",
+        StudioError::InvalidSlideCount { .. } => "invalid_slide_count",
+        StudioError::ManifestSerialization(_) => "serialize_failed",
+        StudioError::UnsupportedFormat(_) => "unsupported_binary_format",
+    }
+}
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    hasher
+        .finalize()
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect()
+}
+
+fn reject_forbidden_output(rendered: &str) -> Result<(), CliError> {
+    friday_hub::refs_guard::reject_forbidden_output(
+        rendered,
+        &["<!doctype", "<section", "\"speaker_notes\"", "slides\":["],
+    )
+    .map_err(|_| CliError::new("output_guard"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn flag_matcher_is_exact_one_default_off() {
+        env::remove_var(FLAG);
+        assert!(!studio_enabled_from_env());
+        env::set_var(FLAG, "true");
+        assert!(!studio_enabled_from_env());
+        env::set_var(FLAG, "1");
+        assert!(studio_enabled_from_env());
+        env::remove_var(FLAG);
+    }
+
+    #[test]
+    fn forbidden_output_guard_blocks_artifact_bodies() {
+        assert!(reject_forbidden_output(r#"{"body":"<!doctype html>"}"#).is_err());
+        assert!(reject_forbidden_output(r#"{"speaker_notes":"x"}"#).is_err());
+        assert!(reject_forbidden_output(r#"{"ok":true,"artifact_count":3}"#).is_ok());
+    }
+}

--- a/rust-core/crates/friday-hub/tests/studio_deck_cli.rs
+++ b/rust-core/crates/friday-hub/tests/studio_deck_cli.rs
@@ -1,0 +1,87 @@
+//! B4 Studio Hub DARK CLI tests.
+//!
+//! The CLI proves Hub can reach the Rust Studio artifact core behind an exact
+//! default-off flag while remaining metadata-only: no file writes, no provider
+//! calls, and binary office exports fail closed.
+
+use std::process::Command;
+
+use serde_json::Value;
+
+fn base_cmd() -> Command {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_hub_studio_deck"));
+    cmd.arg("render-html-deck")
+        .arg("--topic")
+        .arg("Cross-border launch")
+        .arg("--template")
+        .arg("cross_border")
+        .arg("--notes")
+        .arg("Audience\nChannel\nRisk")
+        .arg("--slide-count")
+        .arg("3");
+    cmd
+}
+
+#[test]
+fn flag_off_fails_closed_without_rendering_artifacts() {
+    let output = base_cmd()
+        .env_remove("FRIDAY_STUDIO_RUST_ENABLED")
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let value: Value = serde_json::from_str(&stdout).unwrap();
+    assert_eq!(value["truth_label"], "b4_studio_rust_dark_hub");
+    assert_eq!(value["ok"], false);
+    assert_eq!(value["live"], false);
+    assert_eq!(value["error_kind"], "flag_disabled");
+    assert!(value.get("artifacts").is_none());
+}
+
+#[test]
+fn flag_on_returns_metadata_for_real_html_manifest_and_notes_artifacts() {
+    let output = base_cmd()
+        .env("FRIDAY_STUDIO_RUST_ENABLED", "1")
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(!stdout.contains("<!doctype"));
+    assert!(!stdout.contains("\"speaker_notes\""));
+    let value: Value = serde_json::from_str(&stdout).unwrap();
+    assert_eq!(value["truth_label"], "b4_studio_rust_dark_hub");
+    assert_eq!(value["ok"], true);
+    assert_eq!(value["live"], false);
+    assert_eq!(value["writes_files"], false);
+    assert_eq!(value["calls_provider"], false);
+    assert_eq!(value["binary_exports_live"], false);
+    assert_eq!(value["slide_count"], 3);
+    assert_eq!(value["artifact_count"], 3);
+    let artifacts = value["artifacts"].as_array().unwrap();
+    assert_eq!(artifacts[0]["relative_path"], "slides.html");
+    assert_eq!(artifacts[1]["relative_path"], "deck.json");
+    assert_eq!(artifacts[2]["relative_path"], "speaker-notes.md");
+    assert!(artifacts
+        .iter()
+        .all(|a| a["byte_len"].as_u64().unwrap() > 0));
+    assert!(artifacts
+        .iter()
+        .all(|a| a["sha256"].as_str().is_some_and(|s| s.len() == 64)));
+}
+
+#[test]
+fn binary_exports_fail_closed_even_when_studio_flag_is_on() {
+    let output = base_cmd()
+        .env("FRIDAY_STUDIO_RUST_ENABLED", "1")
+        .arg("--binary-format")
+        .arg("pptx")
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let value: Value = serde_json::from_str(&stdout).unwrap();
+    assert_eq!(value["truth_label"], "b4_studio_rust_dark_hub");
+    assert_eq!(value["ok"], false);
+    assert_eq!(value["live"], false);
+    assert_eq!(value["error_kind"], "unsupported_binary_format");
+}


### PR DESCRIPTION
## Summary
- add a default-off `hub_studio_deck` proof entrypoint that reaches the Rust Studio deck core through friday-hub
- return metadata only (artifact path/format/mime/byte_len/sha256), with no file writes, provider calls, product route, or TS Studio replacement
- register `FRIDAY_STUDIO_RUST_ENABLED` as a dark flag with CLI tests for flag-off fail-closed, flag-on artifact metadata, and binary export fail-closed

## Truth label
- BUILT-DARK / destination-only: not live Studio product, not GO-LIVE, not PPTX/DOCX/PDF export

## Validation
- `cargo fmt --all -- --check`
- `cargo test -p friday-hub --test studio_deck_cli -- --nocapture`
- `cargo test -p friday-hub --bin hub_studio_deck -- --nocapture`
- `node scripts/ci/verify-prod-flag-tests.mjs`
- `cargo clippy -p friday-hub --all-targets -- -D warnings`