### PR TITLE
Add D21 dark governed local skill runner

### DIFF
--- a/docs/ops/prod-flags-manifest.json
+++ b/docs/ops/prod-flags-manifest.json
@@ -235,6 +235,20 @@
       "notes": "Built-dark D2 OS-sandbox wiring for the highest-risk Hub command arm. The mapped test uses an explicit sandboxed executor constructor to avoid global env races in parallel tests; on hosts with `/usr/bin/sandbox-exec` it executes through Seatbelt, and on other hosts it requires fail-closed `CommandSandboxUnavailable`. The friday-fs substrate tests prove root writes are allowed and outside-root writes are denied by the Seatbelt profile. Honest boundary: this does not flip live execution policy and does not replace operator approval/signature gates."
     },
     {
+      "flag": "FRIDAY_D21_SKILL_RUN_LOCAL",
+      "process": "rust-ws-wrapper",
+      "prod_state": "dark",
+      "closes_loop": "With the flag ON, Hub can execute an adopted managed-local `runtime.kind=shell` skill only after an operator Ed25519 approval for the exact `run_skill` request, emitting refs-only execution evidence without installing skills or completing WorkItems. With the flag OFF, the CLI fails closed before spawning anything.",
+      "coverage": "loop-e2e",
+      "e2e_test": "rust-core/crates/friday-hub/tests/skill_run_local_cli.rs::flag_on_executes_adopted_shell_skill_after_ed25519_approval",
+      "additional_e2e_tests": [
+        "rust-core/crates/friday-hub/tests/skill_run_local_cli.rs::flag_off_fails_closed_without_executing_skill",
+        "rust-core/crates/friday-hub/tests/skill_run_local_cli.rs::hmac_approval_is_rejected_before_execution",
+        "rust-core/crates/friday-hub/tests/skill_run_local_cli.rs::imported_skill_md_runtime_is_not_executable"
+      ],
+      "notes": "Built-dark D21/A4 execution substrate. The runner uses the existing shell-free/env-scrubbed/cwd-contained friday-fs command path and supports a required Darwin sandbox CLI switch, but this flag does not flip live product execution policy and does not make imported SKILL.md packages executable. Hub still verifies only; operator signing remains operator-only."
+    },
+    {
       "flag": "FRIDAY_WEB_FETCH_ENABLED",
       "process": "rust-ws-wrapper",
       "prod_state": "dark",

--- a/rust-core/crates/friday-hub/src/bin/hub_skill_run_local.rs
+++ b/rust-core/crates/friday-hub/src/bin/hub_skill_run_local.rs
@@ -1,0 +1,228 @@
+//! D21 governed local skill run CLI.
+//!
+//! Verifies an operator-signed approval with only the public key, then runs an
+//! adopted managed-local shell skill through the Hub's bounded local runner. It
+//! never adopts, installs, promotes, or marks a WorkItem complete.
+
+use std::env;
+use std::io::Read;
+use std::path::Path;
+
+use friday_core::gate::{ApprovalDecision, CanonicalApproval, CANONICAL_GATE_ISSUER};
+use friday_hub::operator_vk::load_operator_vk_from_path;
+use friday_hub::skill_executor::{
+    run_local_skill_ed25519, skill_run_local_enabled_from, LocalSkillRunRequest,
+    SkillExecutionError, FRIDAY_D21_SKILL_RUN_LOCAL,
+};
+use friday_storage::Db;
+use serde::Deserialize;
+use serde_json::json;
+
+struct CliError {
+    kind: &'static str,
+}
+
+impl CliError {
+    fn new(kind: &'static str) -> Self {
+        Self { kind }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct SignedApprovalIn {
+    decision: String,
+    approval_id: String,
+    action_digest: String,
+    expires_at: i64,
+    #[serde(default)]
+    issuer: Option<String>,
+    signature: String,
+}
+
+fn main() {
+    match run() {
+        Ok(rendered) => println!("{rendered}"),
+        Err(err) => {
+            let payload = json!({
+                "truth_label": "d21_skill_run_local",
+                "ok": false,
+                "runs_skill": false,
+                "installs_skill": false,
+                "executes_skill": false,
+                "completes_work_item": false,
+                "error_kind": err.kind,
+            });
+            let rendered = payload.to_string();
+            if reject_forbidden_output(&rendered).is_ok() {
+                println!("{rendered}");
+            }
+            eprintln!("hub_skill_run_local_unavailable: {}", err.kind);
+            std::process::exit(2);
+        }
+    }
+}
+
+fn run() -> Result<String, CliError> {
+    let args: Vec<String> = env::args().collect();
+    if args.get(1).map(String::as_str) != Some("run-local") {
+        return Err(CliError::new("bad_args"));
+    }
+    let enabled =
+        skill_run_local_enabled_from(env::var(FRIDAY_D21_SKILL_RUN_LOCAL).ok().as_deref());
+    if !enabled {
+        return Err(CliError::new("flag_off"));
+    }
+
+    let db_path = arg_value(&args, "--db").ok_or(CliError::new("bad_args"))?;
+    let vk_path = arg_value(&args, "--operator-vk-path")
+        .or_else(|| env::var(friday_hub::operator_vk::OPERATOR_VK_PATH_ENV).ok())
+        .filter(|p| !p.trim().is_empty())
+        .ok_or(CliError::new("operator_vk_unprovisioned"))?;
+    let operator_vk = load_operator_vk_from_path(Path::new(vk_path.trim()))
+        .map_err(|_| CliError::new("operator_vk_malformed"))?;
+    let approval = read_approval(&args)?;
+    let now_ms = arg_value(&args, "--now-ms")
+        .and_then(|v| v.parse::<i64>().ok())
+        .unwrap_or_else(now_ms);
+    let timeout_ms = arg_value(&args, "--timeout-ms")
+        .and_then(|v| v.parse::<u64>().ok())
+        .unwrap_or(30_000);
+    let db = Db::open_hub(&db_path).map_err(|_| CliError::new("init_failed"))?;
+    let adopted_skill_id = arg_values(&args, "--adopted-skill-id");
+    let approved_first_run_skill_id = arg_values(&args, "--approved-first-run-skill-id");
+    let receipt = run_local_skill_ed25519(
+        &db,
+        LocalSkillRunRequest {
+            managed_skills_root: arg_value(&args, "--managed-skills-root")
+                .ok_or(CliError::new("bad_args"))?,
+            adopted_skill_ids: adopted_skill_id,
+            approved_first_run_skill_ids: approved_first_run_skill_id,
+            skill_id: arg_value(&args, "--skill-id").ok_or(CliError::new("bad_args"))?,
+            mission_id: arg_value(&args, "--mission-id").ok_or(CliError::new("bad_args"))?,
+            work_item_id: arg_value(&args, "--work-item-id").ok_or(CliError::new("bad_args"))?,
+            operator_principal_id: arg_value(&args, "--operator-principal-id")
+                .unwrap_or_else(|| "operator".to_string()),
+            canonical_approval: approval,
+            now_ms,
+            require_darwin_sandbox: args.iter().any(|arg| arg == "--require-darwin-sandbox"),
+            timeout_ms,
+        },
+        &operator_vk,
+        true,
+    )
+    .map_err(|err| CliError::new(skill_error_kind(&err)))?;
+
+    let payload = json!({
+        "truth_label": "d21_skill_run_local",
+        "ok": true,
+        "runs_skill": true,
+        "installs_skill": false,
+        "executes_skill": true,
+        "completes_work_item": false,
+        "run_ref": receipt.run_ref,
+        "proof_ref": receipt.proof_ref,
+        "skill_ref": receipt.skill_ref,
+        "skill_id": receipt.skill_id,
+        "mission_id": receipt.mission_id,
+        "work_item_id": receipt.work_item_id,
+        "status": receipt.status,
+        "sandbox_mode": receipt.sandbox_mode,
+        "exit_code": receipt.exit_code,
+        "timed_out": receipt.timed_out,
+        "output_truncated": receipt.output_truncated,
+        "output_sha256": receipt.output_sha256,
+        "output_len": receipt.output_len,
+    });
+    let rendered =
+        serde_json::to_string(&payload).map_err(|_| CliError::new("serialize_failed"))?;
+    reject_forbidden_output(&rendered)?;
+    Ok(rendered)
+}
+
+fn read_approval(args: &[String]) -> Result<CanonicalApproval, CliError> {
+    let approval_json = match arg_value(args, "--approval-json") {
+        Some(path) => std::fs::read_to_string(path).map_err(|_| CliError::new("bad_args"))?,
+        None => {
+            let mut buf = String::new();
+            std::io::stdin()
+                .read_to_string(&mut buf)
+                .map_err(|_| CliError::new("bad_args"))?;
+            buf
+        }
+    };
+    let signed: SignedApprovalIn =
+        serde_json::from_str(approval_json.trim()).map_err(|_| CliError::new("bad_approval"))?;
+    Ok(CanonicalApproval {
+        decision: parse_decision(&signed.decision).ok_or(CliError::new("bad_approval"))?,
+        approval_id: signed.approval_id,
+        action_digest: signed.action_digest,
+        expires_at: Some(signed.expires_at),
+        issuer: Some(
+            signed
+                .issuer
+                .unwrap_or_else(|| CANONICAL_GATE_ISSUER.to_string()),
+        ),
+        signature: Some(signed.signature),
+    })
+}
+
+fn arg_value(args: &[String], name: &str) -> Option<String> {
+    args.windows(2)
+        .find_map(|pair| (pair[0] == name).then(|| pair[1].clone()))
+        .or_else(|| {
+            let prefix = format!("{name}=");
+            args.iter()
+                .find_map(|arg| arg.strip_prefix(&prefix).map(str::to_string))
+        })
+}
+
+fn arg_values(args: &[String], name: &str) -> Vec<String> {
+    let mut values = Vec::new();
+    let prefix = format!("{name}=");
+    let mut i = 0;
+    while i < args.len() {
+        if args[i] == name {
+            if let Some(value) = args.get(i + 1) {
+                values.push(value.clone());
+            }
+            i += 2;
+            continue;
+        }
+        if let Some(value) = args[i].strip_prefix(&prefix) {
+            values.push(value.to_string());
+        }
+        i += 1;
+    }
+    values
+}
+
+fn parse_decision(value: &str) -> Option<ApprovalDecision> {
+    match value {
+        "approved" => Some(ApprovalDecision::Approved),
+        "denied" => Some(ApprovalDecision::Denied),
+        _ => None,
+    }
+}
+
+fn now_ms() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as i64)
+        .unwrap_or(0)
+}
+
+fn skill_error_kind(err: &SkillExecutionError) -> &'static str {
+    match err {
+        SkillExecutionError::Blocked(_) => "run_blocked",
+        SkillExecutionError::Io(_) => "io_failed",
+        SkillExecutionError::ManifestParse(_) => "manifest_parse_failed",
+        SkillExecutionError::Storage(_) => "storage_failed",
+        SkillExecutionError::Catalog(_) => "catalog_failed",
+        SkillExecutionError::Runner(_) => "runner_failed",
+    }
+}
+
+fn reject_forbidden_output(rendered: &str) -> Result<(), CliError> {
+    friday_hub::refs_guard::reject_forbidden_output(rendered, &["answer\":\"", "output\":\""])
+        .map_err(|_| CliError::new("output_guard"))
+}

--- a/rust-core/crates/friday-hub/src/lib.rs
+++ b/rust-core/crates/friday-hub/src/lib.rs
@@ -341,6 +341,7 @@ pub mod skill_candidate_materializer;
 /// truth-labeled catalog entries and advisor inputs; it does not execute skills
 /// or grant control.
 pub mod skill_catalog;
+pub mod skill_executor;
 pub mod skill_md_importer;
 
 /// Shared refs-only output guard for the proof bins. Single source of truth for the

--- a/rust-core/crates/friday-hub/src/skill_executor.rs
+++ b/rust-core/crates/friday-hub/src/skill_executor.rs
@@ -1,0 +1,356 @@
+//! D21 governed local skill execution substrate.
+//!
+//! This DARK leg executes only adopted managed-local `runtime.kind = "shell"` skills
+//! after an operator Ed25519 approval for the exact `run_skill` gate request. It does
+//! not install skills, promote candidates, mark WorkItems complete, or infer GO-LIVE.
+
+use std::{
+    fs,
+    path::{Component, Path, PathBuf},
+    time::Duration,
+};
+
+use friday_core::{
+    gate::{CanonicalApproval, GateDecision},
+    MissionLink, MissionLinkKind, SkillCatalogEntry, SkillCatalogSnapshot,
+};
+use friday_crypto::OperatorVerifyingKey;
+use friday_storage::{authorize_mutating_action_ed25519, Db, StorageError};
+use serde_json::Value;
+use sha2::{Digest, Sha256};
+
+use crate::skill_catalog::{discover_skill_catalog, skill_run_gate_request, SkillCatalogDiscovery};
+
+pub const FRIDAY_D21_SKILL_RUN_LOCAL: &str = "FRIDAY_D21_SKILL_RUN_LOCAL";
+
+#[derive(Debug, thiserror::Error)]
+pub enum SkillExecutionError {
+    #[error("skill execution blocked: {0}")]
+    Blocked(String),
+    #[error("skill execution io failed")]
+    Io(#[from] std::io::Error),
+    #[error("skill execution manifest parse failed")]
+    ManifestParse(#[from] serde_json::Error),
+    #[error("skill execution storage failed")]
+    Storage(#[from] StorageError),
+    #[error("skill execution catalog failed")]
+    Catalog(#[from] crate::skill_catalog::SkillCatalogError),
+    #[error("skill execution runner failed")]
+    Runner(#[from] friday_fs::FsError),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct LocalSkillRunRequest {
+    pub managed_skills_root: String,
+    pub adopted_skill_ids: Vec<String>,
+    pub approved_first_run_skill_ids: Vec<String>,
+    pub skill_id: String,
+    pub mission_id: String,
+    pub work_item_id: String,
+    pub operator_principal_id: String,
+    pub canonical_approval: CanonicalApproval,
+    pub now_ms: i64,
+    pub require_darwin_sandbox: bool,
+    pub timeout_ms: u64,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct LocalSkillRunReceipt {
+    pub run_ref: String,
+    pub proof_ref: String,
+    pub skill_ref: String,
+    pub skill_id: String,
+    pub mission_id: String,
+    pub work_item_id: String,
+    pub status: String,
+    pub sandbox_mode: String,
+    pub exit_code: Option<i32>,
+    pub timed_out: bool,
+    pub output_truncated: bool,
+    pub output_sha256: String,
+    pub output_len: usize,
+}
+
+#[derive(Clone, Debug)]
+struct RuntimeManifest {
+    entrypoint: PathBuf,
+}
+
+pub fn skill_run_local_enabled_from(value: Option<&str>) -> bool {
+    matches!(value.map(str::trim), Some("1"))
+}
+
+pub fn run_local_skill_ed25519(
+    db: &Db,
+    request: LocalSkillRunRequest,
+    operator_vk: &OperatorVerifyingKey,
+    enabled: bool,
+) -> Result<LocalSkillRunReceipt, SkillExecutionError> {
+    if !enabled {
+        return Err(SkillExecutionError::Blocked(
+            "skill_run_local_flag_off".to_string(),
+        ));
+    }
+    if request.timeout_ms == 0 || request.timeout_ms > 120_000 {
+        return Err(SkillExecutionError::Blocked(
+            "skill_run_timeout_out_of_range".to_string(),
+        ));
+    }
+
+    let snapshot = discover_skill_catalog(SkillCatalogDiscovery {
+        managed_skills_root: request.managed_skills_root.clone(),
+        adopted_skill_ids: request.adopted_skill_ids.clone(),
+        approved_first_run_skill_ids: request.approved_first_run_skill_ids.clone(),
+        proof_refs_by_skill_id: Default::default(),
+        run_refs_by_skill_id: Default::default(),
+        now_ms: request.now_ms,
+    })?;
+    let entry = runnable_entry(&snapshot, &request.skill_id)?;
+    let skill_dir = contained_skill_dir(&request.managed_skills_root, &request.skill_id)?;
+    let runtime = read_runtime_manifest(&skill_dir)?;
+    validate_mission_work_item(db, &request.mission_id, &request.work_item_id)?;
+
+    let gate_request = skill_run_gate_request(
+        &request.skill_id,
+        &request.mission_id,
+        &request.work_item_id,
+        &request.operator_principal_id,
+    );
+    let gate = authorize_mutating_action_ed25519(
+        db.conn(),
+        &gate_request,
+        Some(&request.canonical_approval),
+        operator_vk,
+        request.now_ms,
+    )?;
+    if gate.decision != GateDecision::Allow {
+        return Err(SkillExecutionError::Blocked(format!(
+            "skill_run_canonical_gate_{}",
+            gate.reason
+        )));
+    }
+
+    let command = format!("./{}", runtime.entrypoint.to_string_lossy());
+    let timeout = Duration::from_millis(request.timeout_ms);
+    let result = if request.require_darwin_sandbox {
+        friday_fs::run_command_in_root_with_darwin_sandbox_timeout(&skill_dir, &command, timeout)?
+    } else {
+        friday_fs::run_command_in_root_with_timeout(&skill_dir, &command, timeout)?
+    };
+    let output_sha256 = sha256_hex(result.output.as_bytes());
+    let run_ref = redacted_ref(
+        "skill-run-local",
+        &format!(
+            "{}:{}:{}:{}:{}",
+            request.skill_id,
+            request.mission_id,
+            request.work_item_id,
+            request.now_ms,
+            output_sha256
+        ),
+    );
+    let proof_ref = format!(
+        "proof://skill-run-local/{}/{}",
+        request.skill_id, output_sha256
+    );
+    db.upsert_mission_link(&MissionLink {
+        link_id: run_ref.clone(),
+        mission_id: request.mission_id.clone(),
+        work_item_id: Some(request.work_item_id.clone()),
+        link_kind: MissionLinkKind::ProofReceipt,
+        target_ref: run_ref.clone(),
+        proof_ref: Some(proof_ref.clone()),
+        created_at_ms: request.now_ms,
+    })?;
+
+    Ok(LocalSkillRunReceipt {
+        run_ref,
+        proof_ref,
+        skill_ref: entry.skill_ref.clone(),
+        skill_id: request.skill_id,
+        mission_id: request.mission_id,
+        work_item_id: request.work_item_id,
+        status: "skill_executed_not_completed".to_string(),
+        sandbox_mode: if request.require_darwin_sandbox {
+            "darwin_seatbelt"
+        } else {
+            "workspace_contained"
+        }
+        .to_string(),
+        exit_code: result.exit_code,
+        timed_out: result.timed_out,
+        output_truncated: result.output_truncated,
+        output_sha256,
+        output_len: result.output.len(),
+    })
+}
+
+fn runnable_entry<'a>(
+    snapshot: &'a SkillCatalogSnapshot,
+    skill_id: &str,
+) -> Result<&'a SkillCatalogEntry, SkillExecutionError> {
+    let entry = snapshot
+        .entries
+        .iter()
+        .find(|entry| entry.skill_id == skill_id)
+        .ok_or_else(|| SkillExecutionError::Blocked("unknown_skill".to_string()))?;
+    if !entry.can_be_recommended() {
+        return Err(SkillExecutionError::Blocked(
+            "skill_not_runnable_or_not_approved".to_string(),
+        ));
+    }
+    if entry.runtime_kind != "shell" {
+        return Err(SkillExecutionError::Blocked(
+            "skill_runtime_not_shell".to_string(),
+        ));
+    }
+    Ok(entry)
+}
+
+fn contained_skill_dir(root: &str, skill_id: &str) -> Result<PathBuf, SkillExecutionError> {
+    if !is_safe_id(skill_id) {
+        return Err(SkillExecutionError::Blocked(
+            "safe_skill_id_required".to_string(),
+        ));
+    }
+    let root = fs::canonicalize(root)?;
+    let skill_dir = fs::canonicalize(root.join(skill_id))?;
+    if !skill_dir.starts_with(&root) {
+        return Err(SkillExecutionError::Blocked(
+            "skill_dir_outside_root".to_string(),
+        ));
+    }
+    Ok(skill_dir)
+}
+
+fn read_runtime_manifest(skill_dir: &Path) -> Result<RuntimeManifest, SkillExecutionError> {
+    let raw = fs::read_to_string(skill_dir.join("skill.manifest.json"))?;
+    let value: Value = serde_json::from_str(&raw)?;
+    let kind = value
+        .get("runtime")
+        .and_then(|runtime| runtime.get("kind"))
+        .and_then(Value::as_str)
+        .unwrap_or("");
+    if kind != "shell" {
+        return Err(SkillExecutionError::Blocked(
+            "skill_runtime_not_shell".to_string(),
+        ));
+    }
+    let entrypoint = value
+        .get("runtime")
+        .and_then(|runtime| runtime.get("entrypoint"))
+        .and_then(Value::as_str)
+        .ok_or_else(|| SkillExecutionError::Blocked("skill_entrypoint_required".to_string()))?;
+    Ok(RuntimeManifest {
+        entrypoint: safe_relative_entrypoint(entrypoint)?,
+    })
+}
+
+fn safe_relative_entrypoint(value: &str) -> Result<PathBuf, SkillExecutionError> {
+    let value = value.trim();
+    if value.is_empty()
+        || value.len() > 160
+        || value.contains('\\')
+        || value.contains('"')
+        || value.contains('\'')
+        || value.chars().any(char::is_whitespace)
+    {
+        return Err(SkillExecutionError::Blocked(
+            "skill_entrypoint_safe_relative_required".to_string(),
+        ));
+    }
+    let path = PathBuf::from(value);
+    if path.is_absolute() {
+        return Err(SkillExecutionError::Blocked(
+            "skill_entrypoint_safe_relative_required".to_string(),
+        ));
+    }
+    for component in path.components() {
+        match component {
+            Component::Normal(_) => {}
+            _ => {
+                return Err(SkillExecutionError::Blocked(
+                    "skill_entrypoint_safe_relative_required".to_string(),
+                ));
+            }
+        }
+    }
+    Ok(path)
+}
+
+fn validate_mission_work_item(
+    db: &Db,
+    mission_id: &str,
+    work_item_id: &str,
+) -> Result<(), SkillExecutionError> {
+    let mission = db
+        .get_mission(mission_id)?
+        .ok_or_else(|| SkillExecutionError::Blocked("unknown_mission".to_string()))?;
+    if mission.status.is_terminal() {
+        return Err(SkillExecutionError::Blocked(
+            "mission_is_terminal".to_string(),
+        ));
+    }
+    let work_item = db
+        .get_work_item(work_item_id)?
+        .ok_or_else(|| SkillExecutionError::Blocked("unknown_work_item".to_string()))?;
+    if work_item.mission_id != mission_id {
+        return Err(SkillExecutionError::Blocked(
+            "work_item_mission_mismatch".to_string(),
+        ));
+    }
+    if work_item.status.is_terminal() {
+        return Err(SkillExecutionError::Blocked(
+            "work_item_is_terminal".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn is_safe_id(value: &str) -> bool {
+    !value.is_empty()
+        && value.len() <= 128
+        && value
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.'))
+}
+
+fn redacted_ref(kind: &str, raw: &str) -> String {
+    format!("friday://{kind}/{}", sha256_hex(raw.as_bytes()))
+}
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    let mut hash = Sha256::new();
+    hash.update(bytes);
+    hash.finalize()
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn skill_run_local_flag_parser_is_exact_one_default_off() {
+        assert!(!skill_run_local_enabled_from(None));
+        assert!(!skill_run_local_enabled_from(Some("")));
+        assert!(!skill_run_local_enabled_from(Some("0")));
+        assert!(!skill_run_local_enabled_from(Some("true")));
+        assert!(!skill_run_local_enabled_from(Some("2")));
+        assert!(skill_run_local_enabled_from(Some("1")));
+        assert!(skill_run_local_enabled_from(Some(" 1 ")));
+    }
+
+    #[test]
+    fn entrypoint_must_be_safe_relative() {
+        assert!(safe_relative_entrypoint("./run.sh").is_err());
+        assert!(safe_relative_entrypoint("../run.sh").is_err());
+        assert!(safe_relative_entrypoint("/tmp/run.sh").is_err());
+        assert_eq!(
+            safe_relative_entrypoint("bin/run").unwrap(),
+            PathBuf::from("bin/run")
+        );
+    }
+}

--- a/rust-core/crates/friday-hub/tests/skill_run_local_cli.rs
+++ b/rust-core/crates/friday-hub/tests/skill_run_local_cli.rs
@@ -1,0 +1,416 @@
+//! D21 governed local skill run CLI tests.
+//!
+//! The CLI verifies an operator Ed25519 approval with only the public key, runs an
+//! adopted managed-local shell skill, emits refs-only evidence, and never marks the
+//! WorkItem complete.
+
+use std::os::unix::fs::PermissionsExt;
+use std::process::Command;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use friday_core::gate::{
+    canonical_action_bytes, canonical_approval_signature_bytes, ApprovalDecision,
+    CanonicalApproval, MutatingActionRequest, CANONICAL_GATE_ISSUER,
+};
+use friday_core::{
+    ApprovalState, FridayConversation, HandoffJudgmentMemory, Mission, MissionStatus, Risk,
+    TruthStatus, WorkItem, WorkItemStatus, WorkLane,
+};
+use friday_crypto::{OperatorSigningKey, OperatorVerifyingKey};
+use friday_hub::skill_catalog::skill_run_gate_request;
+use friday_hub::skill_executor::FRIDAY_D21_SKILL_RUN_LOCAL;
+use friday_storage::Db;
+use serde_json::Value;
+
+const HUB_HMAC_SECRET: &[u8] = b"hub-held-hmac-gate-secret-0123456789";
+const NOW: i64 = 1_000;
+const FUTURE: i64 = 5_000_000_000_000;
+
+static C: AtomicU64 = AtomicU64::new(0);
+
+fn unique(tag: &str) -> String {
+    format!(
+        "{}-{}-{}",
+        std::process::id(),
+        tag,
+        C.fetch_add(1, Ordering::Relaxed)
+    )
+}
+
+fn temp_path(tag: &str) -> std::path::PathBuf {
+    std::env::temp_dir().join(format!("friday-skill-run-local-cli-{}", unique(tag)))
+}
+
+fn temp_db(tag: &str) -> String {
+    temp_path(&format!("{tag}.sqlite"))
+        .to_string_lossy()
+        .into_owned()
+}
+
+fn vk_hex(vk: &OperatorVerifyingKey) -> String {
+    vk.to_bytes()
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect()
+}
+
+fn operator() -> (OperatorSigningKey, OperatorVerifyingKey) {
+    let sk = OperatorSigningKey::generate();
+    let vk = sk.verifying_key();
+    (sk, vk)
+}
+
+fn ed_approval(
+    req: &MutatingActionRequest,
+    sk: &OperatorSigningKey,
+    approval_id: &str,
+) -> CanonicalApproval {
+    let digest = friday_crypto::action_digest(&canonical_action_bytes(req));
+    let mut approval = CanonicalApproval {
+        decision: ApprovalDecision::Approved,
+        approval_id: approval_id.to_string(),
+        action_digest: digest,
+        expires_at: Some(FUTURE),
+        issuer: Some(CANONICAL_GATE_ISSUER.to_string()),
+        signature: None,
+    };
+    approval.signature = Some(
+        sk.sign(&canonical_approval_signature_bytes(&approval))
+            .to_hex(),
+    );
+    approval
+}
+
+fn hmac_approval(req: &MutatingActionRequest, approval_id: &str) -> CanonicalApproval {
+    let digest = friday_crypto::action_digest(&canonical_action_bytes(req));
+    let mut approval = CanonicalApproval {
+        decision: ApprovalDecision::Approved,
+        approval_id: approval_id.to_string(),
+        action_digest: digest,
+        expires_at: Some(FUTURE),
+        issuer: Some(CANONICAL_GATE_ISSUER.to_string()),
+        signature: None,
+    };
+    approval.signature = Some(friday_crypto::sign_approval(
+        &canonical_approval_signature_bytes(&approval),
+        HUB_HMAC_SECRET,
+    ));
+    approval
+}
+
+fn write_approval(path: &std::path::Path, approval: &CanonicalApproval) {
+    let decision = match approval.decision {
+        ApprovalDecision::Approved => "approved",
+        ApprovalDecision::Denied => "denied",
+    };
+    let body = serde_json::json!({
+        "decision": decision,
+        "approval_id": approval.approval_id,
+        "action_digest": approval.action_digest,
+        "expires_at": approval.expires_at.unwrap(),
+        "issuer": approval.issuer,
+        "signature": approval.signature,
+    });
+    std::fs::write(path, body.to_string()).unwrap();
+}
+
+fn seed_mission(db: &Db) {
+    db.upsert_friday_conversation(&FridayConversation {
+        friday_conversation_id: "fconv_skill_run_local_cli".into(),
+        owner_principal: "operator".into(),
+        title: "Skill Run Local CLI".into(),
+        current_focus_summary: "Run governed local skill".into(),
+        active_mission_ids: vec!["mission-skill-run-local-cli".into()],
+        surface_thread_ids: Vec::new(),
+        memory_scope_ref: None,
+        truth_status: TruthStatus::Proven,
+        proof_refs: Vec::new(),
+        created_at_ms: NOW,
+        updated_at_ms: NOW,
+    })
+    .unwrap();
+    db.upsert_mission(&Mission {
+        mission_id: "mission-skill-run-local-cli".into(),
+        friday_conversation_id: "fconv_skill_run_local_cli".into(),
+        title: "Skill Run Local CLI".into(),
+        intent: "Run an adopted managed local shell skill without completing the WorkItem".into(),
+        status: MissionStatus::Active,
+        why_now: "D21 needs a governed dark execution leg.".into(),
+        decision_path_summary: "Verify Ed25519 approval before local execution.".into(),
+        considered_options: vec!["receipt-only".into()],
+        deferred_options: vec!["imported SKILL.md runtime adapter".into()],
+        known_pitfalls: vec!["execution confused with completion".into()],
+        handoff_inheritance: vec!["Hub verifies, operator signs".into()],
+        work_item_ids: vec!["work-skill-run-local-cli".into()],
+        memory_candidate_refs: Vec::new(),
+        context_passport_refs: Vec::new(),
+        proof_refs: Vec::new(),
+        created_at_ms: NOW,
+        updated_at_ms: NOW,
+    })
+    .unwrap();
+    db.upsert_work_item(&WorkItem {
+        work_item_id: "work-skill-run-local-cli".into(),
+        mission_id: "mission-skill-run-local-cli".into(),
+        lane: WorkLane::FridayHub,
+        target_provider_or_agent: Some("skill:run".into()),
+        status: WorkItemStatus::ReadyToDispatch,
+        owner_claim_ids: Vec::new(),
+        workspace_refs: Vec::new(),
+        capability_id: Some("skill.run.local".into()),
+        risk_level: Risk::High,
+        approval_state: ApprovalState::Required,
+        blocking_reason: None,
+        input_refs: vec!["friday://body/skill-run-local".into()],
+        output_refs: Vec::new(),
+        proof_requirements: vec!["skill local run receipt".into()],
+        proof_receipts: Vec::new(),
+        judgment_memory: HandoffJudgmentMemory {
+            task: "Run a governed local skill".into(),
+            current_blocker: None,
+            target_lane_thread_agent_provider: WorkLane::FridayHub.as_str().into(),
+            read_first_files: vec![
+                "rust-core/crates/friday-hub/src/bin/hub_skill_run_local.rs".into()
+            ],
+            required_output: "refs-only execution receipt".into(),
+            done_criteria: vec!["local runner invoked after Ed25519 approval".into()],
+            red_lines: vec!["Hub must not self-mint operator approval".into()],
+            why_this_route: "D21 A4 needs a dark governed execution leg.".into(),
+            considered_options: vec!["legacy direct shell".into()],
+            deferred_options: vec!["live skill product route".into()],
+            previous_pitfalls: vec!["run receipt mistaken for completion".into()],
+            inheritable_context: vec!["verify-only governance".into()],
+            proof_requirements: vec!["CLI execution test".into()],
+            ownership_claim_ids: Vec::new(),
+        },
+        created_at_ms: NOW,
+        updated_at_ms: NOW,
+    })
+    .unwrap();
+}
+
+fn gate_request() -> MutatingActionRequest {
+    skill_run_gate_request(
+        "summarize-local",
+        "mission-skill-run-local-cli",
+        "work-skill-run-local-cli",
+        "operator",
+    )
+}
+
+fn write_shell_skill(managed_root: &std::path::Path, runtime_kind: &str) -> std::path::PathBuf {
+    let skill_dir = managed_root.join("summarize-local");
+    std::fs::create_dir_all(&skill_dir).unwrap();
+    let manifest = serde_json::json!({
+        "id": "summarize-local",
+        "name": "Summarize Local",
+        "runtime": {
+            "kind": runtime_kind,
+            "entrypoint": "run.sh"
+        },
+        "triggers": { "intents": ["summarize"], "phrases": ["summarize"] },
+        "permissions": { "promptOn": ["run"], "grants": ["local-write"] }
+    });
+    std::fs::write(
+        skill_dir.join("skill.manifest.json"),
+        serde_json::to_string(&manifest).unwrap(),
+    )
+    .unwrap();
+    let script = skill_dir.join("run.sh");
+    std::fs::write(
+        &script,
+        "#!/bin/sh\nprintf 'raw-skill-output-not-json\\n'\nprintf 'marker' > marker.txt\n",
+    )
+    .unwrap();
+    let mut permissions = std::fs::metadata(&script).unwrap().permissions();
+    permissions.set_mode(0o755);
+    std::fs::set_permissions(&script, permissions).unwrap();
+    skill_dir
+}
+
+fn cli_base(
+    db_path: &str,
+    vk_path: &std::path::Path,
+    approval_path: &std::path::Path,
+    managed_root: &std::path::Path,
+) -> Command {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_hub_skill_run_local"));
+    cmd.arg("run-local")
+        .arg("--db")
+        .arg(db_path)
+        .arg("--operator-vk-path")
+        .arg(vk_path)
+        .arg("--approval-json")
+        .arg(approval_path)
+        .arg("--managed-skills-root")
+        .arg(managed_root)
+        .arg("--skill-id")
+        .arg("summarize-local")
+        .arg("--adopted-skill-id")
+        .arg("summarize-local")
+        .arg("--approved-first-run-skill-id")
+        .arg("summarize-local")
+        .arg("--mission-id")
+        .arg("mission-skill-run-local-cli")
+        .arg("--work-item-id")
+        .arg("work-skill-run-local-cli")
+        .arg("--operator-principal-id")
+        .arg("operator")
+        .arg("--timeout-ms")
+        .arg("5000")
+        .arg("--now-ms")
+        .arg((NOW + 1).to_string());
+    cmd
+}
+
+#[test]
+fn flag_off_fails_closed_without_executing_skill() {
+    let db_path = temp_db("flag-off");
+    let db = Db::open_hub(&db_path).unwrap();
+    seed_mission(&db);
+
+    let managed_root = temp_path("flag-off-managed");
+    std::fs::create_dir_all(&managed_root).unwrap();
+    let skill_dir = write_shell_skill(&managed_root, "shell");
+    let (sk, vk) = operator();
+    let vk_path = temp_path("flag-off.vk");
+    std::fs::write(&vk_path, vk_hex(&vk)).unwrap();
+    let approval_path = temp_path("flag-off-approval.json");
+    write_approval(
+        &approval_path,
+        &ed_approval(&gate_request(), &sk, "skill-run-local-flag-off"),
+    );
+
+    let mut cmd = cli_base(&db_path, &vk_path, &approval_path, &managed_root);
+    cmd.env_remove(FRIDAY_D21_SKILL_RUN_LOCAL);
+    let output = cmd.output().unwrap();
+    assert!(!output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let json: Value = serde_json::from_str(stdout.trim()).unwrap();
+    assert_eq!(json["ok"], false);
+    assert_eq!(json["executes_skill"], false);
+    assert_eq!(json["completes_work_item"], false);
+    assert_eq!(json["error_kind"], "flag_off");
+    assert!(!skill_dir.join("marker.txt").exists());
+    assert!(db
+        .list_mission_links("mission-skill-run-local-cli")
+        .unwrap()
+        .is_empty());
+}
+
+#[test]
+fn flag_on_executes_adopted_shell_skill_after_ed25519_approval() {
+    let db_path = temp_db("allow");
+    let db = Db::open_hub(&db_path).unwrap();
+    seed_mission(&db);
+
+    let managed_root = temp_path("allow-managed");
+    std::fs::create_dir_all(&managed_root).unwrap();
+    let skill_dir = write_shell_skill(&managed_root, "shell");
+    let (sk, vk) = operator();
+    let vk_path = temp_path("allow.vk");
+    std::fs::write(&vk_path, vk_hex(&vk)).unwrap();
+    let approval_path = temp_path("allow-approval.json");
+    write_approval(
+        &approval_path,
+        &ed_approval(&gate_request(), &sk, "skill-run-local-ed-allow"),
+    );
+
+    let mut cmd = cli_base(&db_path, &vk_path, &approval_path, &managed_root);
+    cmd.env(FRIDAY_D21_SKILL_RUN_LOCAL, "1");
+    let output = cmd.output().unwrap();
+    assert!(
+        output.status.success(),
+        "stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(!stdout.contains("raw-skill-output-not-json"));
+    let json: Value = serde_json::from_str(stdout.trim()).unwrap();
+    assert_eq!(json["truth_label"], "d21_skill_run_local");
+    assert_eq!(json["ok"], true);
+    assert_eq!(json["runs_skill"], true);
+    assert_eq!(json["installs_skill"], false);
+    assert_eq!(json["executes_skill"], true);
+    assert_eq!(json["completes_work_item"], false);
+    assert_eq!(json["status"], "skill_executed_not_completed");
+    assert_eq!(json["sandbox_mode"], "workspace_contained");
+    assert_eq!(json["exit_code"], 0);
+    assert!(json["output_sha256"].as_str().unwrap().len() == 64);
+    assert!(skill_dir.join("marker.txt").is_file());
+
+    let item = db
+        .get_work_item("work-skill-run-local-cli")
+        .unwrap()
+        .unwrap();
+    assert_eq!(item.status, WorkItemStatus::ReadyToDispatch);
+    assert!(item.proof_receipts.is_empty());
+    let links = db
+        .list_mission_links("mission-skill-run-local-cli")
+        .unwrap();
+    assert_eq!(links.len(), 1);
+}
+
+#[test]
+fn hmac_approval_is_rejected_before_execution() {
+    let db_path = temp_db("hmac");
+    let db = Db::open_hub(&db_path).unwrap();
+    seed_mission(&db);
+
+    let managed_root = temp_path("hmac-managed");
+    std::fs::create_dir_all(&managed_root).unwrap();
+    let skill_dir = write_shell_skill(&managed_root, "shell");
+    let (_sk, vk) = operator();
+    let vk_path = temp_path("hmac.vk");
+    std::fs::write(&vk_path, vk_hex(&vk)).unwrap();
+    let approval_path = temp_path("hmac-approval.json");
+    write_approval(
+        &approval_path,
+        &hmac_approval(&gate_request(), "skill-run-local-hmac"),
+    );
+
+    let mut cmd = cli_base(&db_path, &vk_path, &approval_path, &managed_root);
+    cmd.env(FRIDAY_D21_SKILL_RUN_LOCAL, "1");
+    let output = cmd.output().unwrap();
+    assert!(!output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let json: Value = serde_json::from_str(stdout.trim()).unwrap();
+    assert_eq!(json["ok"], false);
+    assert_eq!(json["executes_skill"], false);
+    assert_eq!(json["error_kind"], "run_blocked");
+    assert!(!skill_dir.join("marker.txt").exists());
+    assert!(db
+        .list_mission_links("mission-skill-run-local-cli")
+        .unwrap()
+        .is_empty());
+}
+
+#[test]
+fn imported_skill_md_runtime_is_not_executable() {
+    let db_path = temp_db("imported-runtime");
+    let db = Db::open_hub(&db_path).unwrap();
+    seed_mission(&db);
+
+    let managed_root = temp_path("imported-runtime-managed");
+    std::fs::create_dir_all(&managed_root).unwrap();
+    let skill_dir = write_shell_skill(&managed_root, "skill-md-imported");
+    let (sk, vk) = operator();
+    let vk_path = temp_path("imported-runtime.vk");
+    std::fs::write(&vk_path, vk_hex(&vk)).unwrap();
+    let approval_path = temp_path("imported-runtime-approval.json");
+    write_approval(
+        &approval_path,
+        &ed_approval(&gate_request(), &sk, "skill-run-local-imported-runtime"),
+    );
+
+    let mut cmd = cli_base(&db_path, &vk_path, &approval_path, &managed_root);
+    cmd.env(FRIDAY_D21_SKILL_RUN_LOCAL, "1");
+    let output = cmd.output().unwrap();
+    assert!(!output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let json: Value = serde_json::from_str(stdout.trim()).unwrap();
+    assert_eq!(json["ok"], false);
+    assert_eq!(json["executes_skill"], false);
+    assert_eq!(json["error_kind"], "run_blocked");
+    assert!(!skill_dir.join("marker.txt").exists());
+}


### PR DESCRIPTION
## Summary
- add a default-off `FRIDAY_D21_SKILL_RUN_LOCAL` Hub CLI for governed managed-local shell skill execution
- verify the exact `run_skill` request with operator Ed25519 approval before spawning; Hub still verifies only and never signs
- emit refs-only run/proof metadata, never raw command output, never install/promote skills, and never mark the WorkItem complete
- keep imported `skill-md-imported` packages non-executable until a reviewed runtime adapter exists

## Validation
- `cargo fmt`
- `node scripts/ci/verify-prod-flag-tests.mjs`
- `cargo test -p friday-hub --test skill_run_local_cli -- --nocapture`
- `cargo test -p friday-hub skill_executor -- --nocapture`
- `cargo test -p friday-hub --test skill_md_import_cli --test skill_candidate_materialize_cli --test skill_catalog_ed25519 --test skill_catalog_receipt_cli -- --nocapture`
- `cargo clippy -p friday-hub --all-targets -- -D warnings`

## Truth boundary
Built-DARK D21/A4 execution substrate only. This does not flip live product execution policy, does not make imported SKILL.md packages executable, does not satisfy GO-LIVE organic gates, and does not complete v1.
