### PR TITLE
Add D21 mission-scoped skill adoption receipts

### DIFF
--- a/rust-core/crates/friday-hub/src/bin/hub_skill_catalog_receipt.rs
+++ b/rust-core/crates/friday-hub/src/bin/hub_skill_catalog_receipt.rs
@@ -12,7 +12,8 @@ use std::path::Path;
 use friday_core::gate::{ApprovalDecision, CanonicalApproval, CANONICAL_GATE_ISSUER};
 use friday_hub::operator_vk::load_operator_vk_from_path;
 use friday_hub::skill_catalog::{
-    stage_link_skill_candidate_receipt_ed25519, LinkSkillCandidateReceiptRequest, SkillCatalogError,
+    record_skill_adoption_receipt_ed25519, stage_link_skill_candidate_receipt_ed25519,
+    LinkSkillCandidateReceiptRequest, SkillAdoptionReceiptRequest, SkillCatalogError,
 };
 use friday_storage::Db;
 use serde::Deserialize;
@@ -63,7 +64,7 @@ fn main() {
 fn run() -> Result<String, CliError> {
     let args: Vec<String> = env::args().collect();
     let command = args.get(1).map(String::as_str).unwrap_or_default();
-    if command != "stage-link-candidate" {
+    if command != "stage-link-candidate" && command != "adopt-managed-skill" {
         return Err(CliError::new("bad_args"));
     }
 
@@ -81,6 +82,9 @@ fn run() -> Result<String, CliError> {
         .unwrap_or_else(now_ms);
 
     let db = Db::open_hub(&db_path).map_err(|_| CliError::new("init_failed"))?;
+    if command == "adopt-managed-skill" {
+        return adopt_managed_skill(&args, &db, approval, &operator_vk, now_ms);
+    }
     let request = LinkSkillCandidateReceiptRequest {
         skill_id: arg_value(&args, "--skill-id").ok_or(CliError::new("bad_args"))?,
         safe_title: arg_value(&args, "--safe-title").ok_or(CliError::new("bad_args"))?,
@@ -104,6 +108,45 @@ fn run() -> Result<String, CliError> {
         "executes_skill": false,
         "skill_id": receipt.skill_id,
         "candidate_ref": receipt.candidate_ref,
+        "proof_ref": receipt.proof_ref,
+        "mission_id": receipt.mission_id,
+        "work_item_id": receipt.work_item_id,
+        "status": receipt.status,
+    });
+    let rendered =
+        serde_json::to_string(&payload).map_err(|_| CliError::new("serialize_failed"))?;
+    reject_forbidden_output(&rendered)?;
+    Ok(rendered)
+}
+
+fn adopt_managed_skill(
+    args: &[String],
+    db: &Db,
+    approval: CanonicalApproval,
+    operator_vk: &friday_crypto::OperatorVerifyingKey,
+    now_ms: i64,
+) -> Result<String, CliError> {
+    let request = SkillAdoptionReceiptRequest {
+        skill_id: arg_value(args, "--skill-id").ok_or(CliError::new("bad_args"))?,
+        mission_id: arg_value(args, "--mission-id").ok_or(CliError::new("bad_args"))?,
+        work_item_id: arg_value(args, "--work-item-id").ok_or(CliError::new("bad_args"))?,
+        operator_principal_id: arg_value(args, "--operator-principal-id")
+            .unwrap_or_else(|| "operator".to_string()),
+        canonical_approval: approval,
+        proof_ref: arg_value(args, "--proof-ref").ok_or(CliError::new("bad_args"))?,
+        now_ms,
+    };
+    let receipt = record_skill_adoption_receipt_ed25519(db, request, operator_vk)
+        .map_err(|err| CliError::new(skill_error_kind(&err)))?;
+    let payload = json!({
+        "truth_label": "d21_skill_adoption_receipt",
+        "ok": true,
+        "adopts_skill_for_mission": true,
+        "imports_skill": false,
+        "executes_skill": false,
+        "completes_work_item": false,
+        "skill_id": receipt.skill_id,
+        "adoption_ref": receipt.adoption_ref,
         "proof_ref": receipt.proof_ref,
         "mission_id": receipt.mission_id,
         "work_item_id": receipt.work_item_id,

--- a/rust-core/crates/friday-hub/src/skill_catalog.rs
+++ b/rust-core/crates/friday-hub/src/skill_catalog.rs
@@ -367,6 +367,27 @@ pub struct LinkSkillCandidateReceipt {
     pub status: String,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SkillAdoptionReceiptRequest {
+    pub skill_id: String,
+    pub mission_id: String,
+    pub work_item_id: String,
+    pub operator_principal_id: String,
+    pub canonical_approval: CanonicalApproval,
+    pub proof_ref: String,
+    pub now_ms: i64,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SkillAdoptionReceipt {
+    pub adoption_ref: String,
+    pub proof_ref: String,
+    pub skill_id: String,
+    pub mission_id: String,
+    pub work_item_id: String,
+    pub status: String,
+}
+
 pub fn record_skill_run_receipt(
     db: &Db,
     snapshot: &SkillCatalogSnapshot,
@@ -427,6 +448,35 @@ pub fn record_skill_run_receipt_ed25519(
     write_skill_run_receipt(db, entry, request)
 }
 
+pub fn record_skill_adoption_receipt_ed25519(
+    db: &Db,
+    request: SkillAdoptionReceiptRequest,
+    operator_vk: &OperatorVerifyingKey,
+) -> Result<SkillAdoptionReceipt, SkillCatalogError> {
+    validate_skill_adoption_receipt(db, &request)?;
+    let gate_request = skill_adoption_gate_request(
+        &request.skill_id,
+        &request.mission_id,
+        &request.work_item_id,
+        &request.operator_principal_id,
+    );
+    let gate = authorize_mutating_action_ed25519(
+        db.conn(),
+        &gate_request,
+        Some(&request.canonical_approval),
+        operator_vk,
+        request.now_ms,
+    )?;
+    if gate.decision != GateDecision::Allow {
+        return Err(SkillCatalogError::RunBlocked(format!(
+            "skill_adoption_canonical_gate_{}",
+            gate.reason
+        )));
+    }
+
+    write_skill_adoption_receipt(db, request)
+}
+
 fn validate_skill_run_receipt<'a>(
     db: &Db,
     snapshot: &'a SkillCatalogSnapshot,
@@ -449,6 +499,23 @@ fn validate_skill_run_receipt<'a>(
     }
     validate_mission_work_item(db, &request.mission_id, &request.work_item_id)?;
     Ok(entry)
+}
+
+fn validate_skill_adoption_receipt(
+    db: &Db,
+    request: &SkillAdoptionReceiptRequest,
+) -> Result<(), SkillCatalogError> {
+    if !is_safe_public_id(&request.skill_id) {
+        return Err(SkillCatalogError::RunBlocked(
+            "skill_adoption_safe_skill_id_required".to_string(),
+        ));
+    }
+    if !is_safe_proof_ref(&request.proof_ref) {
+        return Err(SkillCatalogError::RunBlocked(
+            "skill_adoption_proof_ref_required".to_string(),
+        ));
+    }
+    validate_mission_work_item(db, &request.mission_id, &request.work_item_id)
 }
 
 fn write_skill_run_receipt(
@@ -480,6 +547,37 @@ fn write_skill_run_receipt(
         mission_id: request.mission_id,
         work_item_id: request.work_item_id,
         status: "receipt_recorded_not_completed".to_string(),
+    })
+}
+
+fn write_skill_adoption_receipt(
+    db: &Db,
+    request: SkillAdoptionReceiptRequest,
+) -> Result<SkillAdoptionReceipt, SkillCatalogError> {
+    let adoption_ref = redacted_ref(
+        "skill-adoption",
+        &format!(
+            "{}:{}:{}:{}",
+            request.skill_id, request.mission_id, request.work_item_id, request.now_ms
+        ),
+    );
+    db.upsert_mission_link(&MissionLink {
+        link_id: adoption_ref.clone(),
+        mission_id: request.mission_id.clone(),
+        work_item_id: Some(request.work_item_id.clone()),
+        link_kind: MissionLinkKind::ProofReceipt,
+        target_ref: skill_adoption_target_ref(&request.skill_id),
+        proof_ref: Some(request.proof_ref.clone()),
+        created_at_ms: request.now_ms,
+    })?;
+
+    Ok(SkillAdoptionReceipt {
+        adoption_ref,
+        proof_ref: request.proof_ref,
+        skill_id: request.skill_id,
+        mission_id: request.mission_id,
+        work_item_id: request.work_item_id,
+        status: "skill_adoption_receipt_recorded_not_executed".to_string(),
     })
 }
 
@@ -628,6 +726,35 @@ fn write_link_skill_candidate_receipt(
     })
 }
 
+pub fn adopted_skill_ids_from_mission_links(
+    db: &Db,
+    mission_id: &str,
+    work_item_id: &str,
+) -> Result<Vec<String>, SkillCatalogError> {
+    let mut adopted = BTreeSet::new();
+    for link in db.list_mission_links(mission_id)? {
+        if link.work_item_id.as_deref() != Some(work_item_id) {
+            continue;
+        }
+        if link.link_kind != MissionLinkKind::ProofReceipt {
+            continue;
+        }
+        let Some(proof_ref) = link.proof_ref.as_deref() else {
+            continue;
+        };
+        if !is_safe_proof_ref(proof_ref) {
+            continue;
+        }
+        let Some(skill_id) = link.target_ref.strip_prefix("friday://skill-adoption/") else {
+            continue;
+        };
+        if is_safe_public_id(skill_id) {
+            adopted.insert(skill_id.to_string());
+        }
+    }
+    Ok(adopted.into_iter().collect())
+}
+
 pub fn skill_run_gate_request(
     skill_id: &str,
     mission_id: &str,
@@ -653,6 +780,37 @@ pub fn skill_run_gate_request(
             "skill_id={skill_id};mission_id={mission_id};work_item_id={work_item_id}"
         )),
         Some(format!("skill-run:{skill_id}:{mission_id}:{work_item_id}")),
+        None,
+    )
+}
+
+pub fn skill_adoption_gate_request(
+    skill_id: &str,
+    mission_id: &str,
+    work_item_id: &str,
+    operator_principal_id: &str,
+) -> MutatingActionRequest {
+    let params = vec![
+        ("target".to_string(), skill_id.to_string()),
+        ("mission_id".to_string(), mission_id.to_string()),
+        ("work_item_id".to_string(), work_item_id.to_string()),
+    ];
+    MutatingActionRequest::from_classification(
+        friday_core::gate::classify(true, friday_core::Risk::High, "adopt_skill", &params),
+        "adopt_skill".to_string(),
+        Actor {
+            kind: ActorKind::Owner,
+            id: operator_principal_id.to_string(),
+            principal_id: Some(operator_principal_id.to_string()),
+        },
+        "friday_hub_skill_catalog".to_string(),
+        Vec::new(),
+        Some(format!(
+            "skill_id={skill_id};mission_id={mission_id};work_item_id={work_item_id}"
+        )),
+        Some(format!(
+            "skill-adoption:{skill_id}:{mission_id}:{work_item_id}"
+        )),
         None,
     )
 }
@@ -736,6 +894,10 @@ pub fn link_skill_candidate_node(
         control_allowed: false,
         updated_at_ms: now_ms,
     }
+}
+
+fn skill_adoption_target_ref(skill_id: &str) -> String {
+    format!("friday://skill-adoption/{skill_id}")
 }
 
 fn skill_blockers(entry: &SkillCatalogEntry) -> Vec<String> {

--- a/rust-core/crates/friday-hub/src/skill_executor.rs
+++ b/rust-core/crates/friday-hub/src/skill_executor.rs
@@ -19,7 +19,10 @@ use friday_storage::{authorize_mutating_action_ed25519, Db, StorageError};
 use serde_json::Value;
 use sha2::{Digest, Sha256};
 
-use crate::skill_catalog::{discover_skill_catalog, skill_run_gate_request, SkillCatalogDiscovery};
+use crate::skill_catalog::{
+    adopted_skill_ids_from_mission_links, discover_skill_catalog, skill_run_gate_request,
+    SkillCatalogDiscovery,
+};
 
 pub const FRIDAY_D21_SKILL_RUN_LOCAL: &str = "FRIDAY_D21_SKILL_RUN_LOCAL";
 
@@ -97,9 +100,10 @@ pub fn run_local_skill_ed25519(
         ));
     }
 
+    let adopted_skill_ids = skill_run_adopted_skill_ids(db, &request)?;
     let snapshot = discover_skill_catalog(SkillCatalogDiscovery {
         managed_skills_root: request.managed_skills_root.clone(),
-        adopted_skill_ids: request.adopted_skill_ids.clone(),
+        adopted_skill_ids,
         approved_first_run_skill_ids: request.approved_first_run_skill_ids.clone(),
         proof_refs_by_skill_id: Default::default(),
         run_refs_by_skill_id: Default::default(),
@@ -183,6 +187,21 @@ pub fn run_local_skill_ed25519(
         output_sha256,
         output_len: result.output.len(),
     })
+}
+
+fn skill_run_adopted_skill_ids(
+    db: &Db,
+    request: &LocalSkillRunRequest,
+) -> Result<Vec<String>, SkillExecutionError> {
+    let mut adopted = request.adopted_skill_ids.clone();
+    adopted.extend(adopted_skill_ids_from_mission_links(
+        db,
+        &request.mission_id,
+        &request.work_item_id,
+    )?);
+    adopted.sort();
+    adopted.dedup();
+    Ok(adopted)
 }
 
 fn runnable_entry<'a>(

--- a/rust-core/crates/friday-hub/tests/skill_catalog_ed25519.rs
+++ b/rust-core/crates/friday-hub/tests/skill_catalog_ed25519.rs
@@ -15,8 +15,10 @@ use friday_core::{
 };
 use friday_crypto::{OperatorSigningKey, OperatorVerifyingKey};
 use friday_hub::skill_catalog::{
-    link_skill_candidate_gate_request, stage_link_skill_candidate_receipt_ed25519,
-    LinkSkillCandidateReceiptRequest,
+    adopted_skill_ids_from_mission_links, link_skill_candidate_gate_request,
+    record_skill_adoption_receipt_ed25519, skill_adoption_gate_request,
+    stage_link_skill_candidate_receipt_ed25519, LinkSkillCandidateReceiptRequest,
+    SkillAdoptionReceiptRequest,
 };
 use friday_storage::Db;
 
@@ -191,10 +193,107 @@ fn gate_request() -> MutatingActionRequest {
     )
 }
 
+fn adoption_gate_request() -> MutatingActionRequest {
+    skill_adoption_gate_request(
+        "invoice-link-skill",
+        "mission-skill-ed",
+        "work-skill-ed",
+        "operator",
+    )
+}
+
+fn adoption_request(approval: CanonicalApproval, now_ms: i64) -> SkillAdoptionReceiptRequest {
+    SkillAdoptionReceiptRequest {
+        skill_id: "invoice-link-skill".into(),
+        mission_id: "mission-skill-ed".into(),
+        work_item_id: "work-skill-ed".into(),
+        operator_principal_id: "operator".into(),
+        canonical_approval: approval,
+        proof_ref: "proof://skill-adoption/invoice".into(),
+        now_ms,
+    }
+}
+
 fn consumed_count(db: &Db) -> i64 {
     db.conn()
         .query_row("SELECT count(*) FROM consumed_approval", [], |r| r.get(0))
         .unwrap()
+}
+
+#[test]
+fn ed25519_skill_adoption_receipt_records_mission_scoped_adoption_without_execution() {
+    let db = Db::open_hub(&temp_db("adopt-allow")).unwrap();
+    seed_mission(&db);
+    let (sk, vk) = operator();
+    let approval = ed_approval(&adoption_gate_request(), &sk, "skill-adoption-ed-allow");
+
+    let receipt =
+        record_skill_adoption_receipt_ed25519(&db, adoption_request(approval, NOW + 1), &vk)
+            .unwrap();
+
+    assert_eq!(
+        receipt.status,
+        "skill_adoption_receipt_recorded_not_executed"
+    );
+    assert_eq!(receipt.skill_id, "invoice-link-skill");
+    let adopted =
+        adopted_skill_ids_from_mission_links(&db, "mission-skill-ed", "work-skill-ed").unwrap();
+    assert_eq!(adopted, vec!["invoice-link-skill".to_string()]);
+    let links = db.list_mission_links("mission-skill-ed").unwrap();
+    assert_eq!(links.len(), 1);
+    assert_eq!(
+        links[0].target_ref,
+        "friday://skill-adoption/invoice-link-skill"
+    );
+    assert_eq!(
+        links[0].proof_ref.as_deref(),
+        Some("proof://skill-adoption/invoice")
+    );
+    let item = db.get_work_item("work-skill-ed").unwrap().unwrap();
+    assert_eq!(item.status, WorkItemStatus::ReadyToDispatch);
+    assert!(item.proof_receipts.is_empty());
+    assert_eq!(consumed_count(&db), 1);
+}
+
+#[test]
+fn hmac_skill_adoption_approval_is_rejected_by_ed25519_path() {
+    let db = Db::open_hub(&temp_db("adopt-hmac")).unwrap();
+    seed_mission(&db);
+    let (_sk, vk) = operator();
+    let approval = hmac_approval(&adoption_gate_request(), "skill-adoption-hmac");
+
+    let blocked =
+        record_skill_adoption_receipt_ed25519(&db, adoption_request(approval, NOW + 1), &vk)
+            .unwrap_err();
+
+    assert!(blocked
+        .to_string()
+        .contains("skill_adoption_canonical_gate_canonical_approval_signature_invalid"));
+    assert!(db
+        .list_mission_links("mission-skill-ed")
+        .unwrap()
+        .is_empty());
+    assert_eq!(consumed_count(&db), 0);
+}
+
+#[test]
+fn ed25519_skill_adoption_approval_replay_is_refused_without_second_write() {
+    let db = Db::open_hub(&temp_db("adopt-replay")).unwrap();
+    seed_mission(&db);
+    let (sk, vk) = operator();
+    let approval = ed_approval(&adoption_gate_request(), &sk, "skill-adoption-replay");
+
+    record_skill_adoption_receipt_ed25519(&db, adoption_request(approval.clone(), NOW + 1), &vk)
+        .unwrap();
+    let blocked =
+        record_skill_adoption_receipt_ed25519(&db, adoption_request(approval, NOW + 2), &vk)
+            .unwrap_err();
+
+    assert!(blocked
+        .to_string()
+        .contains("skill_adoption_canonical_gate_canonical_approval_replay_refused"));
+    assert_eq!(db.list_mission_links("mission-skill-ed").unwrap().len(), 1);
+    assert_eq!(consumed_count(&db), 1);
 }
 
 #[test]

--- a/rust-core/crates/friday-hub/tests/skill_catalog_receipt_cli.rs
+++ b/rust-core/crates/friday-hub/tests/skill_catalog_receipt_cli.rs
@@ -15,7 +15,7 @@ use friday_core::{
     TruthStatus, WorkItem, WorkItemStatus, WorkLane,
 };
 use friday_crypto::{OperatorSigningKey, OperatorVerifyingKey};
-use friday_hub::skill_catalog::link_skill_candidate_gate_request;
+use friday_hub::skill_catalog::{link_skill_candidate_gate_request, skill_adoption_gate_request};
 use friday_storage::Db;
 use serde_json::Value;
 
@@ -200,6 +200,15 @@ fn gate_request() -> MutatingActionRequest {
     )
 }
 
+fn adoption_gate_request() -> MutatingActionRequest {
+    skill_adoption_gate_request(
+        "invoice-link-skill",
+        "mission-skill-cli",
+        "work-skill-cli",
+        "operator",
+    )
+}
+
 fn cli_base(db_path: &str, vk_path: &std::path::Path, approval_path: &std::path::Path) -> Command {
     let mut cmd = Command::new(env!("CARGO_BIN_EXE_hub_skill_catalog_receipt"));
     cmd.arg("stage-link-candidate")
@@ -225,6 +234,34 @@ fn cli_base(db_path: &str, vk_path: &std::path::Path, approval_path: &std::path:
         .arg("operator")
         .arg("--proof-ref")
         .arg("proof://link-skill-candidate/invoice")
+        .arg("--now-ms")
+        .arg((NOW + 1).to_string());
+    cmd
+}
+
+fn adoption_cli_base(
+    db_path: &str,
+    vk_path: &std::path::Path,
+    approval_path: &std::path::Path,
+) -> Command {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_hub_skill_catalog_receipt"));
+    cmd.arg("adopt-managed-skill")
+        .arg("--db")
+        .arg(db_path)
+        .arg("--operator-vk-path")
+        .arg(vk_path)
+        .arg("--approval-json")
+        .arg(approval_path)
+        .arg("--skill-id")
+        .arg("invoice-link-skill")
+        .arg("--mission-id")
+        .arg("mission-skill-cli")
+        .arg("--work-item-id")
+        .arg("work-skill-cli")
+        .arg("--operator-principal-id")
+        .arg("operator")
+        .arg("--proof-ref")
+        .arg("proof://skill-adoption/invoice")
         .arg("--now-ms")
         .arg((NOW + 1).to_string());
     cmd
@@ -265,6 +302,56 @@ fn cli_records_ed25519_candidate_receipt_without_import_or_execution() {
 
     let links = db.list_mission_links("mission-skill-cli").unwrap();
     assert_eq!(links.len(), 1);
+    let item = db.get_work_item("work-skill-cli").unwrap().unwrap();
+    assert_eq!(item.status, WorkItemStatus::ReadyToDispatch);
+    assert!(item.proof_receipts.is_empty());
+}
+
+#[test]
+fn cli_records_ed25519_skill_adoption_without_import_or_execution() {
+    let db_path = temp_db("adopt-allow");
+    let db = Db::open_hub(&db_path).unwrap();
+    seed_mission(&db);
+    let (sk, vk) = operator();
+    let vk_path = temp_path("operator-adopt.vk");
+    std::fs::write(&vk_path, vk_hex(&vk)).unwrap();
+    let approval_path = temp_path("approval-adopt.json");
+    write_approval(
+        &approval_path,
+        &ed_approval(&adoption_gate_request(), &sk, "skill-adopt-cli-ed-allow"),
+    );
+
+    let output = adoption_cli_base(&db_path, &vk_path, &approval_path)
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let json: Value = serde_json::from_str(stdout.trim()).unwrap();
+    assert_eq!(json["truth_label"], "d21_skill_adoption_receipt");
+    assert_eq!(json["ok"], true);
+    assert_eq!(json["adopts_skill_for_mission"], true);
+    assert_eq!(json["imports_skill"], false);
+    assert_eq!(json["executes_skill"], false);
+    assert_eq!(json["completes_work_item"], false);
+    assert_eq!(
+        json["status"],
+        "skill_adoption_receipt_recorded_not_executed"
+    );
+    assert!(json["adoption_ref"]
+        .as_str()
+        .unwrap()
+        .starts_with("friday://skill-adoption/"));
+
+    let links = db.list_mission_links("mission-skill-cli").unwrap();
+    assert_eq!(links.len(), 1);
+    assert_eq!(
+        links[0].target_ref,
+        "friday://skill-adoption/invoice-link-skill"
+    );
     let item = db.get_work_item("work-skill-cli").unwrap().unwrap();
     assert_eq!(item.status, WorkItemStatus::ReadyToDispatch);
     assert!(item.proof_receipts.is_empty());

--- a/rust-core/crates/friday-hub/tests/skill_run_local_cli.rs
+++ b/rust-core/crates/friday-hub/tests/skill_run_local_cli.rs
@@ -13,8 +13,8 @@ use friday_core::gate::{
     CanonicalApproval, MutatingActionRequest, CANONICAL_GATE_ISSUER,
 };
 use friday_core::{
-    ApprovalState, FridayConversation, HandoffJudgmentMemory, Mission, MissionStatus, Risk,
-    TruthStatus, WorkItem, WorkItemStatus, WorkLane,
+    ApprovalState, FridayConversation, HandoffJudgmentMemory, Mission, MissionLink,
+    MissionLinkKind, MissionStatus, Risk, TruthStatus, WorkItem, WorkItemStatus, WorkLane,
 };
 use friday_crypto::{OperatorSigningKey, OperatorVerifyingKey};
 use friday_hub::skill_catalog::skill_run_gate_request;
@@ -233,6 +233,7 @@ fn cli_base(
     vk_path: &std::path::Path,
     approval_path: &std::path::Path,
     managed_root: &std::path::Path,
+    include_explicit_adoption: bool,
 ) -> Command {
     let mut cmd = Command::new(env!("CARGO_BIN_EXE_hub_skill_run_local"));
     cmd.arg("run-local")
@@ -246,10 +247,6 @@ fn cli_base(
         .arg(managed_root)
         .arg("--skill-id")
         .arg("summarize-local")
-        .arg("--adopted-skill-id")
-        .arg("summarize-local")
-        .arg("--approved-first-run-skill-id")
-        .arg("summarize-local")
         .arg("--mission-id")
         .arg("mission-skill-run-local-cli")
         .arg("--work-item-id")
@@ -260,7 +257,25 @@ fn cli_base(
         .arg("5000")
         .arg("--now-ms")
         .arg((NOW + 1).to_string());
+    if include_explicit_adoption {
+        cmd.arg("--adopted-skill-id").arg("summarize-local");
+    }
+    cmd.arg("--approved-first-run-skill-id")
+        .arg("summarize-local");
     cmd
+}
+
+fn seed_adoption_receipt(db: &Db) {
+    db.upsert_mission_link(&MissionLink {
+        link_id: "friday://skill-adoption/test-receipt".into(),
+        mission_id: "mission-skill-run-local-cli".into(),
+        work_item_id: Some("work-skill-run-local-cli".into()),
+        link_kind: MissionLinkKind::ProofReceipt,
+        target_ref: "friday://skill-adoption/summarize-local".into(),
+        proof_ref: Some("proof://skill-adoption/summarize-local".into()),
+        created_at_ms: NOW,
+    })
+    .unwrap();
 }
 
 #[test]
@@ -281,7 +296,7 @@ fn flag_off_fails_closed_without_executing_skill() {
         &ed_approval(&gate_request(), &sk, "skill-run-local-flag-off"),
     );
 
-    let mut cmd = cli_base(&db_path, &vk_path, &approval_path, &managed_root);
+    let mut cmd = cli_base(&db_path, &vk_path, &approval_path, &managed_root, true);
     cmd.env_remove(FRIDAY_D21_SKILL_RUN_LOCAL);
     let output = cmd.output().unwrap();
     assert!(!output.status.success());
@@ -316,7 +331,7 @@ fn flag_on_executes_adopted_shell_skill_after_ed25519_approval() {
         &ed_approval(&gate_request(), &sk, "skill-run-local-ed-allow"),
     );
 
-    let mut cmd = cli_base(&db_path, &vk_path, &approval_path, &managed_root);
+    let mut cmd = cli_base(&db_path, &vk_path, &approval_path, &managed_root, true);
     cmd.env(FRIDAY_D21_SKILL_RUN_LOCAL, "1");
     let output = cmd.output().unwrap();
     assert!(
@@ -352,6 +367,56 @@ fn flag_on_executes_adopted_shell_skill_after_ed25519_approval() {
 }
 
 #[test]
+fn flag_on_executes_shell_skill_after_mission_scoped_adoption_receipt() {
+    let db_path = temp_db("adoption-receipt");
+    let db = Db::open_hub(&db_path).unwrap();
+    seed_mission(&db);
+    seed_adoption_receipt(&db);
+
+    let managed_root = temp_path("adoption-receipt-managed");
+    std::fs::create_dir_all(&managed_root).unwrap();
+    let skill_dir = write_shell_skill(&managed_root, "shell");
+    let (sk, vk) = operator();
+    let vk_path = temp_path("adoption-receipt.vk");
+    std::fs::write(&vk_path, vk_hex(&vk)).unwrap();
+    let approval_path = temp_path("adoption-receipt-approval.json");
+    write_approval(
+        &approval_path,
+        &ed_approval(&gate_request(), &sk, "skill-run-local-adoption-receipt"),
+    );
+
+    let mut cmd = cli_base(&db_path, &vk_path, &approval_path, &managed_root, false);
+    cmd.env(FRIDAY_D21_SKILL_RUN_LOCAL, "1");
+    let output = cmd.output().unwrap();
+    assert!(
+        output.status.success(),
+        "stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let json: Value = serde_json::from_str(stdout.trim()).unwrap();
+    assert_eq!(json["ok"], true);
+    assert_eq!(json["runs_skill"], true);
+    assert_eq!(json["executes_skill"], true);
+    assert_eq!(json["completes_work_item"], false);
+    assert!(skill_dir.join("marker.txt").is_file());
+
+    let item = db
+        .get_work_item("work-skill-run-local-cli")
+        .unwrap()
+        .unwrap();
+    assert_eq!(item.status, WorkItemStatus::ReadyToDispatch);
+    assert!(item.proof_receipts.is_empty());
+    let links = db
+        .list_mission_links("mission-skill-run-local-cli")
+        .unwrap();
+    assert_eq!(links.len(), 2);
+    assert!(links
+        .iter()
+        .any(|link| link.target_ref == "friday://skill-adoption/summarize-local"));
+}
+
+#[test]
 fn hmac_approval_is_rejected_before_execution() {
     let db_path = temp_db("hmac");
     let db = Db::open_hub(&db_path).unwrap();
@@ -369,7 +434,7 @@ fn hmac_approval_is_rejected_before_execution() {
         &hmac_approval(&gate_request(), "skill-run-local-hmac"),
     );
 
-    let mut cmd = cli_base(&db_path, &vk_path, &approval_path, &managed_root);
+    let mut cmd = cli_base(&db_path, &vk_path, &approval_path, &managed_root, true);
     cmd.env(FRIDAY_D21_SKILL_RUN_LOCAL, "1");
     let output = cmd.output().unwrap();
     assert!(!output.status.success());
@@ -403,7 +468,7 @@ fn imported_skill_md_runtime_is_not_executable() {
         &ed_approval(&gate_request(), &sk, "skill-run-local-imported-runtime"),
     );
 
-    let mut cmd = cli_base(&db_path, &vk_path, &approval_path, &managed_root);
+    let mut cmd = cli_base(&db_path, &vk_path, &approval_path, &managed_root, true);
     cmd.env(FRIDAY_D21_SKILL_RUN_LOCAL, "1");
     let output = cmd.output().unwrap();
     assert!(!output.status.success());


### PR DESCRIPTION
## Summary
- add an operator-Ed25519 verified `adopt-managed-skill` receipt path for D21 managed skills
- persist mission/work-scoped adoption evidence as refs-only MissionLink proof receipts
- let the dark local skill runner recover adopted skill ids from those mission-scoped receipts while still requiring exact `run_skill` approval

## Truth boundary
- built-DARK governance substrate only
- does not import, install, promote, or execute imported `SKILL.md` packages
- does not mark WorkItems complete
- does not flip live policy or satisfy OG9 organic / D20-B4 true-sign / GO-LIVE / v1

## Validation
- `cargo fmt --all --check`
- `cargo test -p friday-hub --test skill_catalog_ed25519 -- --nocapture`
- `cargo test -p friday-hub --test skill_catalog_receipt_cli -- --nocapture`
- `cargo test -p friday-hub --test skill_run_local_cli -- --nocapture`
- `cargo test -p friday-hub skill_executor -- --nocapture`
- `cargo clippy -p friday-hub --all-targets -- -D warnings`
- `cargo test -p friday-hub hub_crate_never_references_a_signing_key -- --nocapture`
- `cargo test -p friday-hub --test skill_catalog_receipt_cli --test skill_run_local_cli --test skill_catalog_ed25519 -- --nocapture`
- `cargo test -p friday-hub skill_catalog -- --nocapture`
- `node scripts/ci/verify-prod-flag-tests.mjs`
- `git diff --check`