### PR TITLE
Add D21 imported skill promotion gate

### DIFF
--- a/docs/ops/prod-flags-manifest.json
+++ b/docs/ops/prod-flags-manifest.json
@@ -244,7 +244,8 @@
       "additional_e2e_tests": [
         "rust-core/crates/friday-hub/tests/skill_run_local_cli.rs::flag_off_fails_closed_without_executing_skill",
         "rust-core/crates/friday-hub/tests/skill_run_local_cli.rs::hmac_approval_is_rejected_before_execution",
-        "rust-core/crates/friday-hub/tests/skill_run_local_cli.rs::imported_skill_md_runtime_is_not_executable"
+        "rust-core/crates/friday-hub/tests/skill_run_local_cli.rs::imported_skill_md_runtime_is_not_executable",
+        "rust-core/crates/friday-hub/tests/skill_run_local_cli.rs::sandbox_required_manifest_fails_closed_without_darwin_sandbox_request"
       ],
       "notes": "Built-dark D21/A4 execution substrate. The runner uses the existing shell-free/env-scrubbed/cwd-contained friday-fs command path and supports a required Darwin sandbox CLI switch, but this flag does not flip live product execution policy and does not make imported SKILL.md packages executable. Hub still verifies only; operator signing remains operator-only."
     },

--- a/rust-core/crates/friday-hub/src/bin/hub_skill_md_import.rs
+++ b/rust-core/crates/friday-hub/src/bin/hub_skill_md_import.rs
@@ -1,8 +1,8 @@
 //! D21 governed SKILL.md import CLI.
 //!
 //! Verifies an operator-signed approval and imports a local SKILL.md package as a
-//! managed manifest candidate. It never adopts, promotes, marks runnable, or executes
-//! the skill.
+//! managed manifest candidate or promotes an imported candidate to a sandbox-required
+//! local shell runtime. It never adopts, executes, or marks a WorkItem complete.
 
 use std::env;
 use std::io::Read;
@@ -11,7 +11,8 @@ use std::path::Path;
 use friday_core::gate::{ApprovalDecision, CanonicalApproval, CANONICAL_GATE_ISSUER};
 use friday_hub::operator_vk::load_operator_vk_from_path;
 use friday_hub::skill_md_importer::{
-    import_skill_md_candidate_ed25519, SkillMdImportError, SkillMdImportRequest,
+    import_skill_md_candidate_ed25519, promote_imported_skill_md_candidate_ed25519,
+    SkillMdImportError, SkillMdImportRequest, SkillMdPromoteRequest,
 };
 use friday_storage::Db;
 use serde::Deserialize;
@@ -39,13 +40,15 @@ struct SignedApprovalIn {
 }
 
 fn main() {
+    let command = env::args().nth(1).unwrap_or_default();
     match run() {
         Ok(rendered) => println!("{rendered}"),
         Err(err) => {
             let payload = json!({
-                "truth_label": "d21_skill_md_import",
+                "truth_label": if command == "promote-imported-local" { "d21_skill_md_promote" } else { "d21_skill_md_import" },
                 "ok": false,
                 "imports_skill": false,
+                "promotes_runtime": false,
                 "installs_skill": false,
                 "executes_skill": false,
                 "error_kind": err.kind,
@@ -62,7 +65,8 @@ fn main() {
 
 fn run() -> Result<String, CliError> {
     let args: Vec<String> = env::args().collect();
-    if args.get(1).map(String::as_str) != Some("import-local") {
+    let command = args.get(1).map(String::as_str).unwrap_or_default();
+    if command != "import-local" && command != "promote-imported-local" {
         return Err(CliError::new("bad_args"));
     }
 
@@ -79,6 +83,9 @@ fn run() -> Result<String, CliError> {
         .and_then(|v| v.parse::<i64>().ok())
         .unwrap_or_else(now_ms);
     let db = Db::open_hub(&db_path).map_err(|_| CliError::new("init_failed"))?;
+    if command == "promote-imported-local" {
+        return promote_imported_local(&args, &db, approval, &operator_vk, now_ms);
+    }
     let receipt = import_skill_md_candidate_ed25519(
         &db,
         SkillMdImportRequest {
@@ -103,6 +110,7 @@ fn run() -> Result<String, CliError> {
         "truth_label": "d21_skill_md_import",
         "ok": true,
         "imports_skill": true,
+        "promotes_runtime": false,
         "installs_skill": false,
         "executes_skill": false,
         "import_ref": receipt.import_ref,
@@ -113,6 +121,55 @@ fn run() -> Result<String, CliError> {
         "total_bytes": receipt.total_bytes,
         "mission_id": receipt.mission_id,
         "work_item_id": receipt.work_item_id,
+        "status": receipt.status,
+    });
+    let rendered =
+        serde_json::to_string(&payload).map_err(|_| CliError::new("serialize_failed"))?;
+    reject_forbidden_output(&rendered)?;
+    Ok(rendered)
+}
+
+fn promote_imported_local(
+    args: &[String],
+    db: &Db,
+    approval: CanonicalApproval,
+    operator_vk: &friday_crypto::OperatorVerifyingKey,
+    now_ms: i64,
+) -> Result<String, CliError> {
+    let receipt = promote_imported_skill_md_candidate_ed25519(
+        db,
+        SkillMdPromoteRequest {
+            managed_skills_root: arg_value(args, "--managed-skills-root")
+                .ok_or(CliError::new("bad_args"))?,
+            skill_id: arg_value(args, "--skill-id").ok_or(CliError::new("bad_args"))?,
+            entrypoint: arg_value(args, "--entrypoint").ok_or(CliError::new("bad_args"))?,
+            mission_id: arg_value(args, "--mission-id").ok_or(CliError::new("bad_args"))?,
+            work_item_id: arg_value(args, "--work-item-id").ok_or(CliError::new("bad_args"))?,
+            operator_principal_id: arg_value(args, "--operator-principal-id")
+                .unwrap_or_else(|| "operator".to_string()),
+            canonical_approval: approval,
+            proof_ref: arg_value(args, "--proof-ref").ok_or(CliError::new("bad_args"))?,
+            now_ms,
+        },
+        operator_vk,
+    )
+    .map_err(|err| CliError::new(skill_error_kind(&err)))?;
+
+    let payload = json!({
+        "truth_label": "d21_skill_md_promote",
+        "ok": true,
+        "imports_skill": false,
+        "promotes_runtime": true,
+        "installs_skill": false,
+        "executes_skill": false,
+        "completes_work_item": false,
+        "requires_darwin_sandbox": true,
+        "promote_ref": receipt.promote_ref,
+        "proof_ref": receipt.proof_ref,
+        "skill_id": receipt.skill_id,
+        "mission_id": receipt.mission_id,
+        "work_item_id": receipt.work_item_id,
+        "entrypoint": receipt.entrypoint,
         "status": receipt.status,
     });
     let rendered =

--- a/rust-core/crates/friday-hub/src/skill_executor.rs
+++ b/rust-core/crates/friday-hub/src/skill_executor.rs
@@ -77,6 +77,7 @@ pub struct LocalSkillRunReceipt {
 #[derive(Clone, Debug)]
 struct RuntimeManifest {
     entrypoint: PathBuf,
+    requires_darwin_sandbox: bool,
 }
 
 pub fn skill_run_local_enabled_from(value: Option<&str>) -> bool {
@@ -112,6 +113,11 @@ pub fn run_local_skill_ed25519(
     let entry = runnable_entry(&snapshot, &request.skill_id)?;
     let skill_dir = contained_skill_dir(&request.managed_skills_root, &request.skill_id)?;
     let runtime = read_runtime_manifest(&skill_dir)?;
+    if runtime.requires_darwin_sandbox && !request.require_darwin_sandbox {
+        return Err(SkillExecutionError::Blocked(
+            "skill_requires_darwin_sandbox".to_string(),
+        ));
+    }
     validate_mission_work_item(db, &request.mission_id, &request.work_item_id)?;
 
     let gate_request = skill_run_gate_request(
@@ -260,8 +266,14 @@ fn read_runtime_manifest(skill_dir: &Path) -> Result<RuntimeManifest, SkillExecu
         .and_then(|runtime| runtime.get("entrypoint"))
         .and_then(Value::as_str)
         .ok_or_else(|| SkillExecutionError::Blocked("skill_entrypoint_required".to_string()))?;
+    let requires_darwin_sandbox = value
+        .get("runtime")
+        .and_then(|runtime| runtime.get("requiresDarwinSandbox"))
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
     Ok(RuntimeManifest {
         entrypoint: safe_relative_entrypoint(entrypoint)?,
+        requires_darwin_sandbox,
     })
 }
 

--- a/rust-core/crates/friday-hub/src/skill_md_importer.rs
+++ b/rust-core/crates/friday-hub/src/skill_md_importer.rs
@@ -2,7 +2,9 @@
 //!
 //! This DARK leg turns a reviewed local SKILL.md package into a managed manifest
 //! candidate so the catalog can reason about it. Import is not adoption,
-//! promotion, runnable eligibility, or execution.
+//! runnable eligibility, or execution. A separate operator-gated promotion can
+//! arm the imported package as a sandbox-required local shell runtime; it still
+//! does not adopt, run, or complete the skill.
 
 use std::{
     collections::BTreeMap,
@@ -61,6 +63,30 @@ pub struct SkillMdImportReceipt {
     pub total_bytes: u64,
     pub mission_id: String,
     pub work_item_id: String,
+    pub status: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SkillMdPromoteRequest {
+    pub managed_skills_root: String,
+    pub skill_id: String,
+    pub entrypoint: String,
+    pub mission_id: String,
+    pub work_item_id: String,
+    pub operator_principal_id: String,
+    pub canonical_approval: CanonicalApproval,
+    pub proof_ref: String,
+    pub now_ms: i64,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SkillMdPromoteReceipt {
+    pub promote_ref: String,
+    pub proof_ref: String,
+    pub skill_id: String,
+    pub mission_id: String,
+    pub work_item_id: String,
+    pub entrypoint: String,
     pub status: String,
 }
 
@@ -161,6 +187,70 @@ pub fn skill_md_import_gate_request(
     )
 }
 
+pub fn promote_imported_skill_md_candidate_ed25519(
+    db: &Db,
+    request: SkillMdPromoteRequest,
+    operator_vk: &OperatorVerifyingKey,
+) -> Result<SkillMdPromoteReceipt, SkillMdImportError> {
+    let promote = validate_promote_request(db, &request)?;
+    let gate_request = skill_md_promote_gate_request(
+        &request.skill_id,
+        &request.mission_id,
+        &request.work_item_id,
+        &request.operator_principal_id,
+    );
+    let gate = authorize_mutating_action_ed25519(
+        db.conn(),
+        &gate_request,
+        Some(&request.canonical_approval),
+        operator_vk,
+        request.now_ms,
+    )?;
+    if gate.decision != GateDecision::Allow {
+        return Err(SkillMdImportError::Blocked(format!(
+            "skill_md_promote_canonical_gate_{}",
+            gate.reason
+        )));
+    }
+    write_promote(db, request, promote)
+}
+
+pub fn skill_md_promote_gate_request(
+    skill_id: &str,
+    mission_id: &str,
+    work_item_id: &str,
+    operator_principal_id: &str,
+) -> MutatingActionRequest {
+    let params = vec![
+        ("target".to_string(), skill_id.to_string()),
+        ("mission_id".to_string(), mission_id.to_string()),
+        ("work_item_id".to_string(), work_item_id.to_string()),
+    ];
+    MutatingActionRequest::from_classification(
+        friday_core::gate::classify(
+            true,
+            friday_core::Risk::High,
+            "promote_imported_skill_md",
+            &params,
+        ),
+        "promote_imported_skill_md".to_string(),
+        Actor {
+            kind: ActorKind::Owner,
+            id: operator_principal_id.to_string(),
+            principal_id: Some(operator_principal_id.to_string()),
+        },
+        "friday_hub_skill_md_importer".to_string(),
+        Vec::new(),
+        Some(format!(
+            "skill_id={skill_id};mission_id={mission_id};work_item_id={work_item_id}"
+        )),
+        Some(format!(
+            "skill-md-promote:{skill_id}:{mission_id}:{work_item_id}"
+        )),
+        None,
+    )
+}
+
 fn validate_import_request(
     db: &Db,
     request: &SkillMdImportRequest,
@@ -222,6 +312,84 @@ fn validate_import_request(
         return Err(SkillMdImportError::Blocked("source_digest_mismatch".into()));
     }
     Ok(files)
+}
+
+struct PromoteTarget {
+    manifest_path: PathBuf,
+    manifest: serde_json::Value,
+    entrypoint: PathBuf,
+}
+
+fn validate_promote_request(
+    db: &Db,
+    request: &SkillMdPromoteRequest,
+) -> Result<PromoteTarget, SkillMdImportError> {
+    if !is_safe_id(&request.skill_id) {
+        return Err(SkillMdImportError::Blocked("safe_skill_id_required".into()));
+    }
+    if !request.proof_ref.starts_with("proof://") {
+        return Err(SkillMdImportError::Blocked("proof_ref_required".into()));
+    }
+    validate_mission_work_item(db, &request.mission_id, &request.work_item_id)?;
+
+    let root = fs::canonicalize(&request.managed_skills_root)?;
+    let skill_dir = fs::canonicalize(root.join(&request.skill_id))?;
+    if !skill_dir.starts_with(&root) {
+        return Err(SkillMdImportError::Blocked("skill_dir_outside_root".into()));
+    }
+    if !skill_dir.join("SKILL.md").is_file() {
+        return Err(SkillMdImportError::Blocked("skill_md_required".into()));
+    }
+    let manifest_path = skill_dir.join("skill.manifest.json");
+    let manifest_raw = fs::read_to_string(&manifest_path)?;
+    let manifest: serde_json::Value = serde_json::from_str(&manifest_raw)?;
+    let runtime_kind = manifest
+        .get("runtime")
+        .and_then(|runtime| runtime.get("kind"))
+        .and_then(|kind| kind.as_str())
+        .unwrap_or("");
+    if runtime_kind != "skill-md-imported" {
+        return Err(SkillMdImportError::Blocked(
+            "imported_runtime_required".into(),
+        ));
+    }
+
+    let entrypoint = safe_relative_entrypoint(&request.entrypoint)?;
+    if !skill_dir.join(&entrypoint).is_file() {
+        return Err(SkillMdImportError::Blocked(
+            "skill_entrypoint_required".into(),
+        ));
+    }
+    Ok(PromoteTarget {
+        manifest_path,
+        manifest,
+        entrypoint,
+    })
+}
+
+fn validate_mission_work_item(
+    db: &Db,
+    mission_id: &str,
+    work_item_id: &str,
+) -> Result<(), SkillMdImportError> {
+    let mission = db
+        .get_mission(mission_id)?
+        .ok_or_else(|| SkillMdImportError::Blocked("unknown_mission".into()))?;
+    if mission.status.is_terminal() {
+        return Err(SkillMdImportError::Blocked("mission_is_terminal".into()));
+    }
+    let work_item = db
+        .get_work_item(work_item_id)?
+        .ok_or_else(|| SkillMdImportError::Blocked("unknown_work_item".into()))?;
+    if work_item.mission_id != mission_id {
+        return Err(SkillMdImportError::Blocked(
+            "work_item_mission_mismatch".into(),
+        ));
+    }
+    if work_item.status.is_terminal() {
+        return Err(SkillMdImportError::Blocked("work_item_is_terminal".into()));
+    }
+    Ok(())
 }
 
 fn write_import(
@@ -305,6 +473,57 @@ fn write_import(
     })
 }
 
+fn write_promote(
+    db: &Db,
+    request: SkillMdPromoteRequest,
+    mut promote: PromoteTarget,
+) -> Result<SkillMdPromoteReceipt, SkillMdImportError> {
+    let promote_ref = redacted_ref(
+        "skill-md-promote",
+        &format!(
+            "{}:{}:{}:{}",
+            request.skill_id, request.mission_id, request.work_item_id, request.now_ms
+        ),
+    );
+    let runtime = json!({
+        "kind": "shell",
+        "entrypoint": promote.entrypoint.to_string_lossy(),
+        "requiresDarwinSandbox": true
+    });
+    promote.manifest["runtime"] = runtime;
+    promote.manifest["permissions"] = json!({
+        "grants": [],
+        "promptOn": ["operator.adopt_skill", "operator.run_skill", "darwin_sandbox_required"]
+    });
+    promote.manifest["executionTargets"] = json!({
+        "requiredCapabilities": ["skill.import.review", "skill.run.local.darwin_sandbox"]
+    });
+    fs::write(
+        &promote.manifest_path,
+        serde_json::to_vec_pretty(&promote.manifest)?,
+    )?;
+
+    db.upsert_mission_link(&MissionLink {
+        link_id: promote_ref.clone(),
+        mission_id: request.mission_id.clone(),
+        work_item_id: Some(request.work_item_id.clone()),
+        link_kind: MissionLinkKind::ProofReceipt,
+        target_ref: format!("friday://skill-md-promote/{}", request.skill_id),
+        proof_ref: Some(request.proof_ref.clone()),
+        created_at_ms: request.now_ms,
+    })?;
+
+    Ok(SkillMdPromoteReceipt {
+        promote_ref,
+        proof_ref: request.proof_ref,
+        skill_id: request.skill_id,
+        mission_id: request.mission_id,
+        work_item_id: request.work_item_id,
+        entrypoint: request.entrypoint,
+        status: "imported_manifest_promoted_to_sandbox_required_shell_not_executed".to_string(),
+    })
+}
+
 fn collect_files(source: &Path) -> Result<Vec<CandidateFile>, SkillMdImportError> {
     let mut out = Vec::new();
     collect_files_inner(source, source, &mut out)?;
@@ -359,6 +578,38 @@ fn validate_relative_path(path: &Path) -> Result<(), SkillMdImportError> {
         }
     }
     Ok(())
+}
+
+fn safe_relative_entrypoint(value: &str) -> Result<PathBuf, SkillMdImportError> {
+    let value = value.trim();
+    if value.is_empty()
+        || value.len() > 160
+        || value.contains('\\')
+        || value.contains('"')
+        || value.contains('\'')
+        || value.chars().any(char::is_whitespace)
+    {
+        return Err(SkillMdImportError::Blocked(
+            "skill_entrypoint_safe_relative_required".into(),
+        ));
+    }
+    let path = PathBuf::from(value);
+    if path.is_absolute() {
+        return Err(SkillMdImportError::Blocked(
+            "skill_entrypoint_safe_relative_required".into(),
+        ));
+    }
+    for component in path.components() {
+        match component {
+            Component::Normal(_) => {}
+            _ => {
+                return Err(SkillMdImportError::Blocked(
+                    "skill_entrypoint_safe_relative_required".into(),
+                ));
+            }
+        }
+    }
+    Ok(path)
 }
 
 fn candidate_digest(files: &[CandidateFile]) -> String {

--- a/rust-core/crates/friday-hub/tests/skill_md_import_cli.rs
+++ b/rust-core/crates/friday-hub/tests/skill_md_import_cli.rs
@@ -15,7 +15,7 @@ use friday_core::{
     TruthStatus, WorkItem, WorkItemStatus, WorkLane,
 };
 use friday_crypto::{OperatorSigningKey, OperatorVerifyingKey};
-use friday_hub::skill_md_importer::skill_md_import_gate_request;
+use friday_hub::skill_md_importer::{skill_md_import_gate_request, skill_md_promote_gate_request};
 use friday_storage::Db;
 use serde_json::Value;
 use sha2::{Digest, Sha256};
@@ -113,11 +113,17 @@ fn write_approval(path: &std::path::Path, approval: &CanonicalApproval) {
 }
 
 fn source_digest(skill_md: &[u8]) -> String {
+    source_digest_files(&[("SKILL.md", skill_md)])
+}
+
+fn source_digest_files(files: &[(&str, &[u8])]) -> String {
     let mut hash = Sha256::new();
-    hash.update(b"SKILL.md");
-    hash.update([0]);
-    hash.update(skill_md);
-    hash.update([0]);
+    for (path, bytes) in files {
+        hash.update(path.as_bytes());
+        hash.update([0]);
+        hash.update(bytes);
+        hash.update([0]);
+    }
     let digest = hash
         .finalize()
         .iter()
@@ -212,6 +218,15 @@ fn gate_request(digest: &str) -> MutatingActionRequest {
     )
 }
 
+fn promote_gate_request() -> MutatingActionRequest {
+    skill_md_promote_gate_request(
+        "summarize-local",
+        "mission-skill-md-import-cli",
+        "work-skill-md-import-cli",
+        "operator",
+    )
+}
+
 fn cli_base(
     db_path: &str,
     vk_path: &std::path::Path,
@@ -246,6 +261,39 @@ fn cli_base(
         .arg("proof://skill-md-import/summarize-local")
         .arg("--now-ms")
         .arg((NOW + 1).to_string());
+    cmd
+}
+
+fn promote_cli_base(
+    db_path: &str,
+    vk_path: &std::path::Path,
+    approval_path: &std::path::Path,
+    managed_root: &std::path::Path,
+) -> Command {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_hub_skill_md_import"));
+    cmd.arg("promote-imported-local")
+        .arg("--db")
+        .arg(db_path)
+        .arg("--operator-vk-path")
+        .arg(vk_path)
+        .arg("--approval-json")
+        .arg(approval_path)
+        .arg("--managed-skills-root")
+        .arg(managed_root)
+        .arg("--skill-id")
+        .arg("summarize-local")
+        .arg("--entrypoint")
+        .arg("run.sh")
+        .arg("--mission-id")
+        .arg("mission-skill-md-import-cli")
+        .arg("--work-item-id")
+        .arg("work-skill-md-import-cli")
+        .arg("--operator-principal-id")
+        .arg("operator")
+        .arg("--proof-ref")
+        .arg("proof://skill-md-promote/summarize-local")
+        .arg("--now-ms")
+        .arg((NOW + 2).to_string());
     cmd
 }
 
@@ -311,6 +359,175 @@ fn cli_imports_ed25519_candidate_without_install_or_execution() {
         .unwrap();
     assert_eq!(item.status, WorkItemStatus::ReadyToDispatch);
     assert!(item.proof_receipts.is_empty());
+    let links = db
+        .list_mission_links("mission-skill-md-import-cli")
+        .unwrap();
+    assert_eq!(links.len(), 1);
+}
+
+#[test]
+fn cli_promotes_imported_candidate_to_sandbox_required_shell_without_execution() {
+    let db_path = temp_db("promote");
+    let db = Db::open_hub(&db_path).unwrap();
+    seed_mission(&db);
+
+    let source_dir = temp_path("promote-source");
+    let managed_root = temp_path("promote-managed");
+    std::fs::create_dir_all(&source_dir).unwrap();
+    std::fs::create_dir_all(&managed_root).unwrap();
+    let skill_md =
+        b"---\nid: summarize-local\ntitle: Summarize Local\n---\nSummarize local text.\n";
+    std::fs::write(source_dir.join("SKILL.md"), skill_md).unwrap();
+    std::fs::write(
+        source_dir.join("run.sh"),
+        "#!/bin/sh\nprintf 'should-not-run-during-promote'\n",
+    )
+    .unwrap();
+    let run_sh = b"#!/bin/sh\nprintf 'should-not-run-during-promote'\n";
+    let digest = source_digest_files(&[("SKILL.md", skill_md), ("run.sh", run_sh)]);
+
+    let (sk, vk) = operator();
+    let vk_path = temp_path("promote-operator.vk");
+    std::fs::write(&vk_path, vk_hex(&vk)).unwrap();
+    let import_approval_path = temp_path("promote-import-approval.json");
+    write_approval(
+        &import_approval_path,
+        &ed_approval(
+            &gate_request(&digest),
+            &sk,
+            "skill-md-import-before-promote",
+        ),
+    );
+    let import_output = cli_base(
+        &db_path,
+        &vk_path,
+        &import_approval_path,
+        &source_dir,
+        &managed_root,
+        &digest,
+    )
+    .output()
+    .unwrap();
+    assert!(
+        import_output.status.success(),
+        "stderr={}",
+        String::from_utf8_lossy(&import_output.stderr)
+    );
+
+    let promote_approval_path = temp_path("promote-approval.json");
+    write_approval(
+        &promote_approval_path,
+        &ed_approval(&promote_gate_request(), &sk, "skill-md-promote-ed-allow"),
+    );
+    let output = promote_cli_base(&db_path, &vk_path, &promote_approval_path, &managed_root)
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(!stdout.contains("should-not-run-during-promote"));
+    let json: Value = serde_json::from_str(stdout.trim()).unwrap();
+    assert_eq!(json["truth_label"], "d21_skill_md_promote");
+    assert_eq!(json["ok"], true);
+    assert_eq!(json["imports_skill"], false);
+    assert_eq!(json["promotes_runtime"], true);
+    assert_eq!(json["executes_skill"], false);
+    assert_eq!(json["completes_work_item"], false);
+    assert_eq!(json["requires_darwin_sandbox"], true);
+    assert_eq!(
+        json["status"],
+        "imported_manifest_promoted_to_sandbox_required_shell_not_executed"
+    );
+
+    let manifest_path = managed_root
+        .join("summarize-local")
+        .join("skill.manifest.json");
+    let manifest: Value =
+        serde_json::from_str(&std::fs::read_to_string(manifest_path).unwrap()).unwrap();
+    assert_eq!(manifest["runtime"]["kind"], "shell");
+    assert_eq!(manifest["runtime"]["entrypoint"], "run.sh");
+    assert_eq!(manifest["runtime"]["requiresDarwinSandbox"], true);
+    assert!(!managed_root
+        .join("summarize-local")
+        .join("marker.txt")
+        .exists());
+
+    let item = db
+        .get_work_item("work-skill-md-import-cli")
+        .unwrap()
+        .unwrap();
+    assert_eq!(item.status, WorkItemStatus::ReadyToDispatch);
+    assert!(item.proof_receipts.is_empty());
+    let links = db
+        .list_mission_links("mission-skill-md-import-cli")
+        .unwrap();
+    assert_eq!(links.len(), 2);
+}
+
+#[test]
+fn cli_rejects_hmac_promote_approval_without_changing_manifest() {
+    let db_path = temp_db("promote-hmac");
+    let db = Db::open_hub(&db_path).unwrap();
+    seed_mission(&db);
+
+    let source_dir = temp_path("promote-hmac-source");
+    let managed_root = temp_path("promote-hmac-managed");
+    std::fs::create_dir_all(&source_dir).unwrap();
+    std::fs::create_dir_all(&managed_root).unwrap();
+    let skill_md = b"---\nid: summarize-local\n---\nSummarize local text.\n";
+    std::fs::write(source_dir.join("SKILL.md"), skill_md).unwrap();
+    let run_sh = b"#!/bin/sh\nprintf nope\n";
+    std::fs::write(source_dir.join("run.sh"), run_sh).unwrap();
+    let digest = source_digest_files(&[("SKILL.md", skill_md), ("run.sh", run_sh)]);
+
+    let (sk, vk) = operator();
+    let vk_path = temp_path("operator-promote-hmac.vk");
+    std::fs::write(&vk_path, vk_hex(&vk)).unwrap();
+    let import_approval_path = temp_path("approval-promote-hmac-import.json");
+    write_approval(
+        &import_approval_path,
+        &ed_approval(
+            &gate_request(&digest),
+            &sk,
+            "skill-md-import-for-hmac-promote",
+        ),
+    );
+    let import_output = cli_base(
+        &db_path,
+        &vk_path,
+        &import_approval_path,
+        &source_dir,
+        &managed_root,
+        &digest,
+    )
+    .output()
+    .unwrap();
+    assert!(import_output.status.success());
+
+    let promote_approval_path = temp_path("approval-promote-hmac.json");
+    write_approval(
+        &promote_approval_path,
+        &hmac_approval(&promote_gate_request(), "skill-md-promote-hmac"),
+    );
+    let output = promote_cli_base(&db_path, &vk_path, &promote_approval_path, &managed_root)
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let json: Value = serde_json::from_str(stdout.trim()).unwrap();
+    assert_eq!(json["ok"], false);
+    assert_eq!(json["promotes_runtime"], false);
+    assert_eq!(json["executes_skill"], false);
+
+    let manifest_path = managed_root
+        .join("summarize-local")
+        .join("skill.manifest.json");
+    let manifest: Value =
+        serde_json::from_str(&std::fs::read_to_string(manifest_path).unwrap()).unwrap();
+    assert_eq!(manifest["runtime"]["kind"], "skill-md-imported");
     let links = db
         .list_mission_links("mission-skill-md-import-cli")
         .unwrap();

--- a/rust-core/crates/friday-hub/tests/skill_run_local_cli.rs
+++ b/rust-core/crates/friday-hub/tests/skill_run_local_cli.rs
@@ -228,6 +228,14 @@ fn write_shell_skill(managed_root: &std::path::Path, runtime_kind: &str) -> std:
     skill_dir
 }
 
+fn mark_skill_requires_darwin_sandbox(skill_dir: &std::path::Path) {
+    let manifest_path = skill_dir.join("skill.manifest.json");
+    let mut manifest: Value =
+        serde_json::from_str(&std::fs::read_to_string(&manifest_path).unwrap()).unwrap();
+    manifest["runtime"]["requiresDarwinSandbox"] = Value::Bool(true);
+    std::fs::write(&manifest_path, serde_json::to_string(&manifest).unwrap()).unwrap();
+}
+
 fn cli_base(
     db_path: &str,
     vk_path: &std::path::Path,
@@ -478,4 +486,39 @@ fn imported_skill_md_runtime_is_not_executable() {
     assert_eq!(json["executes_skill"], false);
     assert_eq!(json["error_kind"], "run_blocked");
     assert!(!skill_dir.join("marker.txt").exists());
+}
+
+#[test]
+fn sandbox_required_manifest_fails_closed_without_darwin_sandbox_request() {
+    let db_path = temp_db("sandbox-required");
+    let db = Db::open_hub(&db_path).unwrap();
+    seed_mission(&db);
+
+    let managed_root = temp_path("sandbox-required-managed");
+    std::fs::create_dir_all(&managed_root).unwrap();
+    let skill_dir = write_shell_skill(&managed_root, "shell");
+    mark_skill_requires_darwin_sandbox(&skill_dir);
+    let (sk, vk) = operator();
+    let vk_path = temp_path("sandbox-required.vk");
+    std::fs::write(&vk_path, vk_hex(&vk)).unwrap();
+    let approval_path = temp_path("sandbox-required-approval.json");
+    write_approval(
+        &approval_path,
+        &ed_approval(&gate_request(), &sk, "skill-run-local-sandbox-required"),
+    );
+
+    let mut cmd = cli_base(&db_path, &vk_path, &approval_path, &managed_root, true);
+    cmd.env(FRIDAY_D21_SKILL_RUN_LOCAL, "1");
+    let output = cmd.output().unwrap();
+    assert!(!output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let json: Value = serde_json::from_str(stdout.trim()).unwrap();
+    assert_eq!(json["ok"], false);
+    assert_eq!(json["executes_skill"], false);
+    assert_eq!(json["error_kind"], "run_blocked");
+    assert!(!skill_dir.join("marker.txt").exists());
+    assert!(db
+        .list_mission_links("mission-skill-run-local-cli")
+        .unwrap()
+        .is_empty());
 }


### PR DESCRIPTION
## Summary
- add an Ed25519 verify-only `promote-imported-local` arm for governed SKILL.md imports
- promote imported manifests only to sandbox-required local shell runtime, without adoption, execution, or WorkItem completion
- fail closed when a manifest requires Darwin sandbox but the run request does not include the sandbox requirement

## Validation
- cargo fmt --all --check
- cargo test -p friday-hub --test skill_md_import_cli --test skill_run_local_cli -- --nocapture
- cargo test -p friday-hub hub_crate_never_references_a_signing_key -- --nocapture
- cargo clippy -p friday-hub --all-targets -- -D warnings
- node scripts/ci/verify-prod-flag-tests.mjs
- git diff --check

## Truth Boundary
- built-DARK D21 promotion bridge only
- does not execute imported SKILL.md packages, adopt skills, complete WorkItems, or flip live product policy
- actual local execution still requires `FRIDAY_D21_SKILL_RUN_LOCAL=1`, mission-scoped adoption, exact `run_skill` Ed25519 approval, and the requested sandbox path
- not D20/B4 true-sign, not OG9 strict organic, not GO-LIVE, not v1 closure
