### PR TITLE
Run L1 critical fence behavior tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -323,8 +323,14 @@ jobs:
           node-version: 22
           cache: npm
 
+      - name: Install dependencies
+        run: npm ci
+
       - name: Verify L1 mechanism wiring matrix
-        run: node scripts/ci/verify-mechanism-wiring-matrix.mjs
+        run: npm run test:mechanism-wiring
+
+      - name: Run L1 critical fence behavior tests
+        run: npm run test:mechanism-wiring:behavior
 
   # ── Terminal CI Aggregator — single required check for branch protection ──
   quality-gate:

--- a/package.json
+++ b/package.json
@@ -133,6 +133,7 @@
     "ops:agent-adoption:closeout": "node dist/cli/friday-cli.js phases closeout",
     "test:install:smoke": "node scripts/ci/install-smoke.mjs",
     "test:mechanism-wiring": "node scripts/ci/verify-mechanism-wiring-matrix.mjs",
+    "test:mechanism-wiring:behavior": "npx vitest run test/unit/api/runtime/friday-api-runtime-rust-route-compose.test.ts test/integration/workflows/friday-workflow-trigger-retirement-guard.test.ts test/unit/api/http/routes/friday-auto-fix-routes.test.ts test/unit/api/http/routes/friday-skill-routes.test.ts test/unit/api/http/routes/friday-skill-converter-routes.test.ts test/unit/api/http/routes/friday-mcp-server-routes.test.ts",
     "test:docker:e2e:runtime": "FRIDAY_DOCKER_SMOKE_LAYER=runtime bash scripts/ci/docker-e2e-smoke.sh",
     "test:docker:e2e:bootstrap": "FRIDAY_DOCKER_SMOKE_LAYER=bootstrap bash scripts/ci/docker-e2e-smoke.sh",
     "test:docker:e2e:plugins": "FRIDAY_DOCKER_SMOKE_LAYER=plugins bash scripts/ci/docker-e2e-smoke.sh",


### PR DESCRIPTION
## Summary
- add a narrow `test:mechanism-wiring:behavior` script that executes the six critical TS fail-closed fence behavior test files
- make the CI `mechanism-wiring` job install dependencies, run the existing matrix/source gate, then run the behavior tests

## Local Validation
- npm run test:mechanism-wiring
- npm run test:mechanism-wiring:behavior (6 files, 148 tests)
- git diff --check

## Truth Boundary
- closes part of the L1 residue where the matrix gate previously checked bindings/snippets but did not execute the behavior tests in its own job
- does not make L1 done, does not build missing product transports, does not satisfy OG9 organic, and does not change GO-LIVE/v1 status
