### PR TITLE
Run all retired TS behavior tests in L1 gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -329,7 +329,7 @@ jobs:
       - name: Verify L1 mechanism wiring matrix
         run: npm run test:mechanism-wiring
 
-      - name: Run L1 critical fence behavior tests
+      - name: Run L1 method-retired behavior tests
         run: npm run test:mechanism-wiring:behavior
 
   # ── Terminal CI Aggregator — single required check for branch protection ──

--- a/docs/ops/friday-mechanism-wiring-matrix.md
+++ b/docs/ops/friday-mechanism-wiring-matrix.md
@@ -37,7 +37,7 @@ Mutation defaults:
 
 ## Critical TS Mutation Fences
 
-These TS surfaces remain in the retirement manifest as behavior-tested 503-by-default fences. They are not proof that the replacement Rust product path is complete; they are the no-ungated-hole side of L1.
+These TS surfaces remain in the retirement manifest as behavior-tested 503-by-default fences. They are not proof that the replacement Rust product path is complete; they are the no-ungated-hole side of L1. CI now runs every `methodRetiredSurfaces[*].behavioralTest` from `docs/ops/ts-runtime-retirement-manifest.json`; the table below is the critical subset mapped into the mechanism matrix, not the full behavior-test set.
 
 | surface_id | mechanism | default | behavior |
 |---|---|---|---|

--- a/package.json
+++ b/package.json
@@ -133,7 +133,7 @@
     "ops:agent-adoption:closeout": "node dist/cli/friday-cli.js phases closeout",
     "test:install:smoke": "node scripts/ci/install-smoke.mjs",
     "test:mechanism-wiring": "node scripts/ci/verify-mechanism-wiring-matrix.mjs",
-    "test:mechanism-wiring:behavior": "npx vitest run test/unit/api/runtime/friday-api-runtime-rust-route-compose.test.ts test/integration/workflows/friday-workflow-trigger-retirement-guard.test.ts test/unit/api/http/routes/friday-auto-fix-routes.test.ts test/unit/api/http/routes/friday-skill-routes.test.ts test/unit/api/http/routes/friday-skill-converter-routes.test.ts test/unit/api/http/routes/friday-mcp-server-routes.test.ts",
+    "test:mechanism-wiring:behavior": "node scripts/ci/run-ts-runtime-retirement-behavior-tests.mjs",
     "test:docker:e2e:runtime": "FRIDAY_DOCKER_SMOKE_LAYER=runtime bash scripts/ci/docker-e2e-smoke.sh",
     "test:docker:e2e:bootstrap": "FRIDAY_DOCKER_SMOKE_LAYER=bootstrap bash scripts/ci/docker-e2e-smoke.sh",
     "test:docker:e2e:plugins": "FRIDAY_DOCKER_SMOKE_LAYER=plugins bash scripts/ci/docker-e2e-smoke.sh",

--- a/scripts/ci/run-ts-runtime-retirement-behavior-tests.mjs
+++ b/scripts/ci/run-ts-runtime-retirement-behavior-tests.mjs
@@ -1,0 +1,45 @@
+#!/usr/bin/env node
+
+import { spawnSync } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const manifestPath = join(repoRoot, "docs", "ops", "ts-runtime-retirement-manifest.json");
+const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
+
+const files = [
+  ...new Set(
+    (manifest.methodRetiredSurfaces?.surfaces ?? [])
+      .map((surface) => surface.behavioralTest)
+      .filter((value) => typeof value === "string" && value.length > 0),
+  ),
+].sort();
+
+if (files.length === 0) {
+  console.error("No method-retired behavioral tests are declared in ts-runtime-retirement-manifest.json");
+  process.exit(1);
+}
+
+const missing = files.filter((file) => !existsSync(join(repoRoot, file)));
+if (missing.length > 0) {
+  console.error("Missing method-retired behavioral test file(s):");
+  for (const file of missing) console.error(`- ${file}`);
+  process.exit(1);
+}
+
+console.log(`Running ${files.length} unique method-retired behavioral test file(s) from ts-runtime-retirement-manifest.json`);
+for (const file of files) console.log(`- ${file}`);
+
+const result = spawnSync("npx", ["vitest", "run", ...files], {
+  cwd: repoRoot,
+  stdio: "inherit",
+});
+
+if (result.error) {
+  console.error(result.error.message);
+  process.exit(1);
+}
+
+process.exit(result.status ?? 1);


### PR DESCRIPTION
## Summary\n- add a manifest-driven CI runner for every method-retired behavioral test declared in docs/ops/ts-runtime-retirement-manifest.json\n- replace the L1 behavior gate's six-file hardcoded critical subset with the full manifest-derived behavior set\n- update the L1 mechanism matrix doc to truth-label the critical table as a subset while CI runs all declared method-retired behavior tests\n\n## Validation\n- npm run test:mechanism-wiring\n- npm run test:mechanism-wiring:behavior (20 files / 124 tests)\n- npm run check:ts-runtime-retirement\n- git diff --check\n\nTruth boundary: L1 behavior-gate hardening only; not L1 done, not strict organic, not GO-LIVE, not v1 closure.