### PR TITLE
Add D20 signed-batch product entrypoint

### DIFF
--- a/docs/ops/ts-runtime-retirement-manifest.json
+++ b/docs/ops/ts-runtime-retirement-manifest.json
@@ -10,7 +10,7 @@
   "discovery": {
     "routeSourceDir": "src/api/http/routes",
     "includeMethods": ["GET", "POST", "PATCH", "PUT", "DELETE"],
-    "exactRouteSurfacesMin": 307,
+    "exactRouteSurfacesMin": 308,
     "requiredRouteBehaviorTestSurfaceIds": [
       "agent_runs_start",
       "workflow_runs_start",
@@ -1041,6 +1041,20 @@
       "executes_product_logic": false,
       "proof": "src/api/http/routes/friday-agent-routes.ts gates agent.runs.resume on FRIDAY_AGENT_RUN_CONTROL_VIA_RUST (default-off): flag-off short-circuits to the byte-identical TS_RUNTIME_AGENT_RUNS_RETIRED 503 BEFORE any run lookup (no run-existence leak). Flag-on enforces caller==the wire run's bound owner, then relays the OPAQUE operator-signed Ed25519 approval blob verbatim to the Rust sealed-WS resumeWithApproval (INV-1: TS never parses/validates/inspects the signature/digest); the wire runId is bound to the executed run (pending.run_id==run_id, the s6-687 fix). TS performs NO agent/mutation execution — signature verification and the single approved mutation are Rust-owned under the operator Ed25519 verify key.",
       "next_action": "Replace the flag-gated TS courier relay with a Rust-owned resume entrypoint when the UI connects the Rust hub directly (slice-6 end-state)."
+    },
+    {
+      "id": "agent_d20_worktree_batches_dispatch",
+      "route": {
+        "method": "POST",
+        "path": "/v1/agent/d20/worktree-batches/dispatch",
+        "operationId": "agent.d20.worktree.batch.dispatch"
+      },
+      "classification": "rust_delegated",
+      "user_triggerable": true,
+      "rust_entrypoint": "rust-core/crates/friday-hub/src/bin/hub_d20_signed_batch_worktree.rs",
+      "routeBehavioralTest": "test/unit/api/http/routes/friday-agent-routes.test.ts",
+      "proof": "src/api/http/routes/friday-agent-routes.ts gates the D20 signed-batch worktree product route on FRIDAY_D20_SIGNED_BATCH_WORKTREE_VIA_RUST (default-off) before body/owner work. Flag-on requires a bound owner and exact action.principal_id match, then relays the already operator-signed batch artifact and exact action JSON to the Rust hub_d20_signed_batch_worktree verifier/consumer. TS does not mint, verify, or rewrite the signature semantics; Rust owns Ed25519 verification, replay consumption, reversible-worktree scope, Irreversible/out-of-worktree pause, execution, and audit.",
+      "next_action": "Keep TS as a default-off owner-gated product courier until clients can call the Rust D20 signed-batch entrypoint directly; true live proof still requires an operator-signed batch and GO-LIVE gates."
     },
     {
       "id": "agent_runs_rollback",

--- a/src/api/http/routes/friday-agent-routes.ts
+++ b/src/api/http/routes/friday-agent-routes.ts
@@ -44,6 +44,10 @@ import {
   RUST_ROUTE_CODEX_PROVIDER_ID,
   RUST_ROUTE_READ_TOOL_ALLOWLIST,
 } from "../../runtime/friday-rust-route-constants.js";
+import type {
+  FridayD20SignedBatchWorktreeInput,
+  FridayD20SignedBatchWorktreeReceipt,
+} from "../../mission-spine/friday-rust-hub-d20-signed-batch-worktree-service.js";
 
 // ─── Constants ───
 
@@ -1069,6 +1073,10 @@ export interface FridayAgentRoutesDeps {
     opaqueSignedBlob: Uint8Array,
     principal: FridayAuthPrincipal | null,
   ) => Promise<FridayResumeAgentRunResponse>;
+  d20SignedBatchWorktreeViaRust?: boolean;
+  dispatchD20SignedBatchWorktree?: (
+    input: FridayD20SignedBatchWorktreeInput,
+  ) => Promise<FridayD20SignedBatchWorktreeReceipt>;
 }
 
 interface FridayAgentPlanControlInput {
@@ -1312,6 +1320,20 @@ export function createFridayAgentRoutes(
         details: {
           classification: "fail_closed",
           replacement: "rust_owned_agent_run_entrypoint_required",
+        },
+      },
+    );
+  }
+
+  function failClosedD20SignedBatchWorktreeRoute(): FridayDomainError {
+    return new FridayDomainError(
+      "D20_SIGNED_BATCH_WORKTREE_RETIRED",
+      "D20 signed-batch worktree dispatch is unavailable until the Rust-owned entrypoint is enabled.",
+      {
+        httpStatus: 503,
+        details: {
+          classification: "fail_closed",
+          replacement: "rust_owned_d20_signed_batch_worktree_required",
         },
       },
     );
@@ -1867,6 +1889,87 @@ export function createFridayAgentRoutes(
         // (e) Relay VERBATIM to the runtime resume (which resolves the WS secret + dials the sealed
         // resume; fails closed on any error). Returns the refs-only outcome (NEVER a body).
         return await deps.resumeRun(runId, opaqueSignedBlob, ctx.principal);
+      },
+    },
+
+    // ─── POST /v1/agent/d20/worktree-batches/dispatch ───
+    // D20 W2 trust-dial worktree batch PRODUCT ENTRYPOINT — DARK, default-off. TS is a thin
+    // owner-gated courier into the Rust verifier/consumer; it never verifies, mints, or rewrites
+    // the operator-signed batch. If the exact signed `action` JSON carries `principal_id`, it must
+    // match the authenticated owner; older signed artifacts may omit it and must remain digest-stable.
+    {
+      operationId: "agent.d20.worktree.batch.dispatch",
+      method: "POST",
+      path: "/v1/agent/d20/worktree-batches/dispatch",
+      auth: { public: true },
+      async handler(ctx) {
+        if (
+          deps.d20SignedBatchWorktreeViaRust !== true
+          || !deps.dispatchD20SignedBatchWorktree
+        ) {
+          throw failClosedD20SignedBatchWorktreeRoute();
+        }
+        const bound = assertBoundPrincipalForOperation(
+          ctx.principal,
+          "agent.d20.worktree.batch.dispatch",
+          "api",
+        );
+        const body = ctx.body;
+        if (!body || typeof body !== "object" || Array.isArray(body)) {
+          throw new FridayDomainError(
+            "D20_SIGNED_BATCH_WORKTREE_BODY_REQUIRED",
+            "D20 signed-batch worktree dispatch requires a JSON object body.",
+            { httpStatus: 400 },
+          );
+        }
+        const record = body as Record<string, unknown>;
+        const workspaceRoot = record.workspaceRoot;
+        if (typeof workspaceRoot !== "string" || workspaceRoot.trim().length === 0) {
+          throw new FridayDomainError(
+            "D20_SIGNED_BATCH_WORKTREE_WORKSPACE_REQUIRED",
+            "workspaceRoot is required.",
+            { httpStatus: 400 },
+          );
+        }
+        const action = record.action;
+        if (!action || typeof action !== "object" || Array.isArray(action)) {
+          throw new FridayDomainError(
+            "D20_SIGNED_BATCH_WORKTREE_ACTION_REQUIRED",
+            "action JSON is required.",
+            { httpStatus: 400 },
+          );
+        }
+        const actionPrincipalId = (action as Record<string, unknown>).principal_id;
+        if (actionPrincipalId != null && typeof actionPrincipalId !== "string") {
+          throw new FridayDomainError(
+            "D20_SIGNED_BATCH_WORKTREE_PRINCIPAL_INVALID",
+            "The signed action principal_id must be a string when present.",
+            { httpStatus: 400 },
+          );
+        }
+        if (typeof actionPrincipalId === "string" && actionPrincipalId !== bound.principalId) {
+          throw new FridayDomainError(
+            "D20_SIGNED_BATCH_WORKTREE_PRINCIPAL_MISMATCH",
+            "The signed action principal_id must match the authenticated owner.",
+            { httpStatus: 403 },
+          );
+        }
+        if (
+          !record.signedBatch
+          || typeof record.signedBatch !== "object"
+          || Array.isArray(record.signedBatch)
+        ) {
+          throw new FridayDomainError(
+            "D20_SIGNED_BATCH_WORKTREE_SIGNED_BATCH_REQUIRED",
+            "signedBatch JSON is required.",
+            { httpStatus: 400 },
+          );
+        }
+        return await deps.dispatchD20SignedBatchWorktree({
+          signedBatch: record.signedBatch,
+          action,
+          workspaceRoot: workspaceRoot.trim(),
+        });
       },
     },
 

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -311,5 +311,14 @@ export type {
   FridayMissionAutoDispatchDriver,
   MissionAutoDispatchStartRun,
 } from "./mission-spine/friday-mission-auto-dispatch-driver.js";
+export {
+  FRIDAY_D20_SIGNED_BATCH_WORKTREE_FLAG,
+  createFridayD20SignedBatchWorktreeService,
+} from "./mission-spine/friday-rust-hub-d20-signed-batch-worktree-service.js";
+export type {
+  FridayD20SignedBatchWorktreeInput,
+  FridayD20SignedBatchWorktreeReceipt,
+  FridayD20SignedBatchWorktreeService,
+} from "./mission-spine/friday-rust-hub-d20-signed-batch-worktree-service.js";
 export { createFridayDeterministicPipelineRuntime } from "./runtime/friday-deterministic-pipeline-runtime.js";
 export type { CreateFridayDeterministicPipelineRuntimeDeps } from "./runtime/friday-deterministic-pipeline-runtime.js";

--- a/src/api/mission-spine/friday-rust-hub-d20-signed-batch-worktree-service.ts
+++ b/src/api/mission-spine/friday-rust-hub-d20-signed-batch-worktree-service.ts
@@ -1,0 +1,210 @@
+import { execFile } from "node:child_process";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { existsSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+
+import { FridayDomainError } from "#errors";
+
+const execFileAsync = promisify(execFile);
+
+export const FRIDAY_D20_SIGNED_BATCH_WORKTREE_FLAG = "FRIDAY_D20_SIGNED_BATCH_WORKTREE_VIA_RUST";
+
+export interface FridayD20SignedBatchWorktreeInput {
+  readonly signedBatch: unknown;
+  readonly action: unknown;
+  readonly workspaceRoot: string;
+}
+
+export interface FridayD20SignedBatchWorktreeReceipt {
+  readonly truthLabel: "d20_worktree_signed_batch_artifact";
+  readonly proofOnly: true;
+  readonly ok: boolean;
+  readonly executed: boolean;
+  readonly resultStatus: string;
+  readonly action?: string;
+  readonly summary?: string;
+  readonly reason?: string;
+  readonly batchSignId?: string;
+  readonly auditChainVerified?: boolean;
+}
+
+export interface CreateFridayD20SignedBatchWorktreeServiceOptions {
+  readonly repoRoot?: string;
+  readonly dbPath?: string;
+  readonly operatorVkPath?: string;
+  readonly adapterBin?: string;
+  readonly timeoutMs?: number;
+}
+
+export interface FridayD20SignedBatchWorktreeService {
+  dispatch(
+    input: FridayD20SignedBatchWorktreeInput,
+  ): Promise<FridayD20SignedBatchWorktreeReceipt>;
+}
+
+function unavailable(message: string): FridayDomainError {
+  return new FridayDomainError("D20_SIGNED_BATCH_WORKTREE_UNAVAILABLE", message, {
+    httpStatus: 503,
+    details: {
+      surface: "service:d20_signed_batch_worktree",
+      truthLabel: "d20_worktree_signed_batch_artifact",
+      proofOnly: true,
+    },
+  });
+}
+
+function readTimeoutMs(raw: string | undefined, fallback: number): number {
+  if (!raw) return fallback;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function resolveDefaultRepoRoot(): string {
+  const moduleDir = dirname(fileURLToPath(import.meta.url));
+  return resolve(moduleDir, "../../..");
+}
+
+function requireExistingFile(path: string | undefined, label: string): string {
+  const resolved = path ? resolve(path) : "";
+  if (!resolved || !existsSync(resolved) || !statSync(resolved).isFile()) {
+    throw unavailable(`${label} is not provisioned.`);
+  }
+  return resolved;
+}
+
+function requireExistingDirectory(path: string, label: string): string {
+  const resolved = resolve(path);
+  if (!existsSync(resolved) || !statSync(resolved).isDirectory()) {
+    throw unavailable(`${label} is not present.`);
+  }
+  return resolved;
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function asBoolean(value: unknown): boolean | undefined {
+  return typeof value === "boolean" ? value : undefined;
+}
+
+function parseReceipt(payload: unknown): FridayD20SignedBatchWorktreeReceipt {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    throw unavailable("D20 signed-batch worktree bridge returned a non-object payload.");
+  }
+  const root = payload as Record<string, unknown>;
+  if (root.truth_label !== "d20_worktree_signed_batch_artifact") {
+    throw unavailable("D20 signed-batch worktree bridge returned the wrong truth label.");
+  }
+  if (root.proof_only !== true) {
+    throw unavailable("D20 signed-batch worktree bridge did not preserve proof_only.");
+  }
+  const ok = asBoolean(root.ok);
+  const executed = asBoolean(root.executed);
+  const resultStatus = asString(root.result_status);
+  if (ok === undefined || executed === undefined || !resultStatus) {
+    throw unavailable("D20 signed-batch worktree bridge payload is missing required refs.");
+  }
+  return {
+    truthLabel: "d20_worktree_signed_batch_artifact",
+    proofOnly: true,
+    ok,
+    executed,
+    resultStatus,
+    action: asString(root.action),
+    summary: asString(root.summary),
+    reason: asString(root.reason),
+    batchSignId: asString(root.batch_sign_id),
+    auditChainVerified: asBoolean(root.audit_chain_verified),
+  };
+}
+
+export function createFridayD20SignedBatchWorktreeService(
+  options: CreateFridayD20SignedBatchWorktreeServiceOptions = {},
+): FridayD20SignedBatchWorktreeService {
+  const repoRoot = resolve(
+    options.repoRoot ?? process.env.FRIDAY_REPO_ROOT ?? resolveDefaultRepoRoot(),
+  );
+  const rustCoreRoot = resolve(
+    process.env.FRIDAY_MISSION_SPINE_RUST_CORE_ROOT ?? join(repoRoot, "rust-core"),
+  );
+  const adapterBin = options.adapterBin ?? process.env.FRIDAY_D20_SIGNED_BATCH_WORKTREE_BIN;
+  const dbPath = options.dbPath ?? process.env.FRIDAY_HUB_AGENT_RUN_DB_PATH;
+  const operatorVkPath =
+    options.operatorVkPath ?? process.env.FRIDAY_OPERATOR_APPROVAL_VERIFY_KEY_PATH;
+  const timeoutMs =
+    options.timeoutMs
+    ?? readTimeoutMs(process.env.FRIDAY_D20_SIGNED_BATCH_WORKTREE_TIMEOUT_MS, 120_000);
+
+  return {
+    async dispatch(
+      input: FridayD20SignedBatchWorktreeInput,
+    ): Promise<FridayD20SignedBatchWorktreeReceipt> {
+      const db = requireExistingFile(dbPath, "D20 signed-batch hub DB");
+      const vk = requireExistingFile(operatorVkPath, "D20 operator verify key");
+      const workspace = requireExistingDirectory(input.workspaceRoot, "D20 active worktree");
+      const scratch = await mkdtemp(join(tmpdir(), "friday-d20-batch-"));
+      try {
+        const signedPath = join(scratch, "signed-batch.json");
+        const actionPath = join(scratch, "action.json");
+        await writeFile(signedPath, JSON.stringify(input.signedBatch), "utf8");
+        await writeFile(actionPath, JSON.stringify(input.action), "utf8");
+
+        const adapterArgs = [
+          "--db",
+          db,
+          "--workspace",
+          workspace,
+          "--signed-batch-json",
+          signedPath,
+          "--action-json",
+          actionPath,
+          "--operator-vk-path",
+          vk,
+        ];
+        const command = adapterBin ?? "cargo";
+        const args = adapterBin
+          ? adapterArgs
+          : [
+              "run",
+              "--quiet",
+              "--manifest-path",
+              join(rustCoreRoot, "Cargo.toml"),
+              "-p",
+              "friday-hub",
+              "--bin",
+              "hub_d20_signed_batch_worktree",
+              "--",
+              ...adapterArgs,
+            ];
+
+        let stdout = "";
+        try {
+          const result = await execFileAsync(command, args, {
+            cwd: repoRoot,
+            timeout: timeoutMs,
+            maxBuffer: 1024 * 1024,
+            env: {
+              ...process.env,
+              RUST_BACKTRACE: "0",
+            },
+          });
+          stdout = result.stdout;
+        } catch {
+          throw unavailable("D20 signed-batch worktree bridge could not produce a refs-only receipt.");
+        }
+        try {
+          return parseReceipt(JSON.parse(stdout));
+        } catch (err) {
+          if (err instanceof FridayDomainError) throw err;
+          throw unavailable("D20 signed-batch worktree bridge returned invalid JSON.");
+        }
+      } finally {
+        await rm(scratch, { recursive: true, force: true }).catch(() => undefined);
+      }
+    },
+  };
+}

--- a/src/api/runtime/friday-api-runtime.ts
+++ b/src/api/runtime/friday-api-runtime.ts
@@ -169,6 +169,7 @@ import type { FridayRustHubRunAnswerReadbackService } from "../mission-spine/fri
 import { createFridayRustHubProvidersDetectService } from "../mission-spine/friday-rust-hub-providers-detect-bridge-service.js";
 import { createFridayRustHubCapabilityDoctorService } from "../mission-spine/friday-rust-hub-capability-doctor-bridge-service.js";
 import { createFridayRustHubWorkflowCatalogBridgeService } from "../mission-spine/friday-rust-hub-workflow-catalog-bridge-service.js";
+import { createFridayD20SignedBatchWorktreeService } from "../mission-spine/friday-rust-hub-d20-signed-batch-worktree-service.js";
 import { resolveRustAgentRunWsClientX25519Secret } from "../mission-spine/friday-rust-hub-agent-run-ws-client-x25519-secret.js";
 import type { FridayRustAgentRunWsClientX25519SecretResolver } from "../mission-spine/friday-rust-hub-agent-run-ws-client-x25519-secret.js";
 import {
@@ -4982,6 +4983,8 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
     const rustWsClientSecretResolver =
       deps.rustAgentRunWsClientSecretResolver ?? resolveRustAgentRunWsClientX25519Secret;
     const rustHubDbPath = deps.rustAgentRunHubDbPath ?? process.env.FRIDAY_HUB_AGENT_RUN_DB_PATH;
+    const d20SignedBatchWorktreeService =
+      deps.d20SignedBatchWorktreeService ?? createFridayD20SignedBatchWorktreeService();
 
     // OPERATOR ENV KNOBS for this dark Rust read-only execrun route (kept discoverable
     // together here, alongside the WS host/port + DB path siblings above):
@@ -5369,6 +5372,8 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
       // byte-identical retired 503 before any run lookup; on, it relays an owner-authorized resume.
       agentRunControlViaRust: deps.agentRunControlViaRust,
       resumeRun: routeResumeRun,
+      d20SignedBatchWorktreeViaRust: deps.d20SignedBatchWorktreeViaRust,
+      dispatchD20SignedBatchWorktree: (input) => d20SignedBatchWorktreeService.dispatch(input),
     })) {
       routes.register(route);
     }

--- a/src/api/runtime/friday-api-runtime.types.ts
+++ b/src/api/runtime/friday-api-runtime.types.ts
@@ -35,6 +35,7 @@ import type { FridayRustHubProvidersDetectService } from "../mission-spine/frida
 import type { FridayRustHubCapabilityDoctorService } from "../mission-spine/friday-rust-hub-capability-doctor-bridge-service.js";
 import type { FridayRustAgentRunWsClientX25519SecretResolver } from "../mission-spine/friday-rust-hub-agent-run-ws-client-x25519-secret.js";
 import type { FridayRustHubWorkflowCatalogBridgeService } from "../mission-spine/friday-rust-hub-workflow-catalog-bridge-service.js";
+import type { FridayD20SignedBatchWorktreeService } from "../mission-spine/friday-rust-hub-d20-signed-batch-worktree-service.js";
 import type { FridayMediaUnderstandingRoutesDeps } from "../http/routes/friday-media-understanding-routes.js";
 import type { FridaySocialImportRoutesDeps } from "../http/routes/friday-social-import-routes.js";
 import type { FridayTaskWorkflowRoutesDeps } from "../http/routes/friday-task-workflow-routes.js";
@@ -383,6 +384,14 @@ export interface CreateFridayApiRuntimeDeps {
    * behavior is never reached (byte-identical 503 / result paths untouched).
    */
   agentRunControlViaRust?: boolean;
+  /**
+   * D20 W2 trust-dial worktree batch product entrypoint (DARK): default false. When true, the
+   * agent route can relay an owner-bound signed batch artifact + exact action JSON to the Rust
+   * verifier/consumer. It does not mint signatures and does not relax the normal GO-LIVE gates.
+   */
+  d20SignedBatchWorktreeViaRust?: boolean;
+  /** D20 W2 bridge service; tests inject stubs, production lazily constructs the Rust-bin bridge. */
+  d20SignedBatchWorktreeService?: FridayD20SignedBatchWorktreeService;
   /**
    * providers-bridge cut-over (DARK): the master ON/OFF (resolved boolean) for routing
    * the retired Tier-2 PROVIDER surfaces — `providers.detect` (setup routes) and

--- a/src/hub/bootstrap/hub-helpers.ts
+++ b/src/hub/bootstrap/hub-helpers.ts
@@ -1960,6 +1960,8 @@ export interface FridayHubConfig {
    * admits NO mutating run (the read-only qualifier stays hard — a SEPARATE later PR).
    */
   agentRunControlViaRust?: boolean;
+  /** D20 W2 signed-batch worktree product entrypoint flag; default false / env fallback. */
+  d20SignedBatchWorktreeViaRust?: boolean;
   /**
    * providers-bridge cut-over (DARK): master ON/OFF for routing the retired Tier-2
    * PROVIDER surfaces (`providers.detect` / `providers.doctor` / `providers.validate` /

--- a/src/hub/friday-hub-bootstrap.ts
+++ b/src/hub/friday-hub-bootstrap.ts
@@ -984,6 +984,23 @@ export function resolveAgentRunControlViaRust(
 }
 
 /**
+ * D20 W2 signed-batch worktree product entrypoint (DARK): single source of truth resolving the
+ * TS route flag from explicit config, else `FRIDAY_D20_SIGNED_BATCH_WORKTREE_VIA_RUST`.
+ * The route is still verify-only: Hub receives an operator-signed artifact and an exact action
+ * JSON, while Rust owns Ed25519 verification, replay consumption, worktree scope, and audit.
+ */
+export function resolveD20SignedBatchWorktreeViaRust(
+  configValue: boolean | undefined,
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  if (typeof configValue === "boolean") {
+    return configValue;
+  }
+  const raw = (env.FRIDAY_D20_SIGNED_BATCH_WORKTREE_VIA_RUST ?? "").trim().toLowerCase();
+  return raw === "1" || raw === "true";
+}
+
+/**
  * providers-bridge cut-over (DARK): single source of truth resolving the
  * `routeProvidersViaRust` flag from (1) an EXPLICIT
  * {@link FridayHubConfig.routeProvidersViaRust} and, only as a fallback, (2) the
@@ -7451,6 +7468,12 @@ export async function createFridayHub(
     // paused/resume behavior is inert → the compose path never sees a paused outcome → byte-identical
     // to today. It admits NO mutating run (the read-only qualifier stays hard — a SEPARATE later PR).
     agentRunControlViaRust: resolveAgentRunControlViaRust(config.agentRunControlViaRust),
+    // D20 W2 signed-batch worktree PRODUCT ENTRYPOINT (DARK): default-false flag that makes the
+    // owner-gated TS route callable. Rust still owns verify-only batch admission, replay, worktree
+    // scope, and audit; this does not mint signatures or satisfy GO-LIVE by itself.
+    d20SignedBatchWorktreeViaRust: resolveD20SignedBatchWorktreeViaRust(
+      config.d20SignedBatchWorktreeViaRust,
+    ),
     // providers-bridge cut-over (DARK): default-false master flag for routing the retired
     // Tier-2 PROVIDER surfaces to the merged Rust bins. SINGLE SOURCE OF TRUTH =
     // `resolveRouteProvidersViaRust` (explicit config wins; else FRIDAY_ROUTE_PROVIDERS_VIA_RUST,

--- a/src/security/friday-owner-session-channel-capability.ts
+++ b/src/security/friday-owner-session-channel-capability.ts
@@ -94,6 +94,7 @@ export type FridayPublicMutationOperation =
   | "mission.spine.lifecycle"
   | "mission.spine.workitem.status"
   | "mission.spine.routedecision.control"
+  | "agent.d20.worktree.batch.dispatch"
   // Lane M — the memory-confirmation loop's terminal mutation driven over the
   // sealed-WS dispatch arm (OWNER confirm/reject of ONE memory candidate). Public
   // mutating route: refuse the synthetic public principal; only a bound owner can

--- a/test/contracts/api/__snapshots__/friday-api-route-contract.snapshot.test.ts.snap
+++ b/test/contracts/api/__snapshots__/friday-api-route-contract.snapshot.test.ts.snap
@@ -3,14 +3,14 @@
 exports[`MECHANISM-4 — API Route Contract (Snapshot) > Phase 14.5A WP-001: every public mutating route maps to an accepted gate family 1`] = `
 {
   "classified": {
-    "bound_principal": 64,
+    "bound_principal": 65,
     "channel_signature": 4,
     "hmac_or_bearer_opt_in": 1,
     "public_low_risk": 2,
     "rate_limited_pending": 4,
     "unclassified": 251,
   },
-  "total_public_mutating": 326,
+  "total_public_mutating": 327,
   "unclassified_sample_max_5": [
     "capabilities.acquisition.runs.create",
     "capabilities.acquisition.runs.approve",
@@ -21,7 +21,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > Phase 14.5A WP-001: eve
 }
 `;
 
-exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures route count to detect accidental additions/removals 1`] = `425`;
+exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures route count to detect accidental additions/removals 1`] = `426`;
 
 exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route surface as a stable contract 1`] = `
 [
@@ -4108,6 +4108,16 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   {
     "authKind": "public",
     "index": 408,
+    "method": "POST",
+    "operationId": "agent.d20.worktree.batch.dispatch",
+    "path": "/v1/agent/d20/worktree-batches/dispatch",
+    "rateLimitPolicyId": null,
+    "roles": [],
+    "scopes": [],
+  },
+  {
+    "authKind": "public",
+    "index": 409,
     "method": "GET",
     "operationId": "agent.runs.audit",
     "path": "/v1/agent/runs/:runId/audit",
@@ -4117,7 +4127,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 409,
+    "index": 410,
     "method": "POST",
     "operationId": "agent.runs.rollback",
     "path": "/v1/agent/runs/:runId/rollback",
@@ -4127,7 +4137,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 410,
+    "index": 411,
     "method": "POST",
     "operationId": "agent.runs.approve.plan",
     "path": "/v1/agent/runs/:runId/approve-plan",
@@ -4137,7 +4147,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 411,
+    "index": 412,
     "method": "POST",
     "operationId": "agent.runs.reject.plan",
     "path": "/v1/agent/runs/:runId/reject-plan",
@@ -4147,7 +4157,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 412,
+    "index": 413,
     "method": "POST",
     "operationId": "agent.runs.approve.tool",
     "path": "/v1/agent/runs/:runId/approve-tool",
@@ -4157,7 +4167,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 413,
+    "index": 414,
     "method": "POST",
     "operationId": "agent.runs.reject.tool",
     "path": "/v1/agent/runs/:runId/reject-tool",
@@ -4167,7 +4177,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 414,
+    "index": 415,
     "method": "GET",
     "operationId": "agent.runs.events",
     "path": "/v1/agent/runs/:runId/events",
@@ -4177,7 +4187,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 415,
+    "index": 416,
     "method": "POST",
     "operationId": "agent.automations.create",
     "path": "/v1/agent/automations",
@@ -4187,7 +4197,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 416,
+    "index": 417,
     "method": "GET",
     "operationId": "agent.automations.list",
     "path": "/v1/agent/automations",
@@ -4197,7 +4207,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 417,
+    "index": 418,
     "method": "GET",
     "operationId": "agent.automations.get",
     "path": "/v1/agent/automations/:automationId",
@@ -4207,7 +4217,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 418,
+    "index": 419,
     "method": "PATCH",
     "operationId": "agent.automations.update",
     "path": "/v1/agent/automations/:automationId",
@@ -4217,7 +4227,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 419,
+    "index": 420,
     "method": "DELETE",
     "operationId": "agent.automations.delete",
     "path": "/v1/agent/automations/:automationId",
@@ -4227,7 +4237,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 420,
+    "index": 421,
     "method": "POST",
     "operationId": "agent.automations.run",
     "path": "/v1/agent/automations/:automationId/run",
@@ -4237,7 +4247,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 421,
+    "index": 422,
     "method": "GET",
     "operationId": "agent.subagents.list",
     "path": "/v1/agent/subagents",
@@ -4247,7 +4257,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 422,
+    "index": 423,
     "method": "GET",
     "operationId": "agent.subagents.get",
     "path": "/v1/agent/subagents/:subagentId",
@@ -4257,7 +4267,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 423,
+    "index": 424,
     "method": "GET",
     "operationId": "agent.runs.subagents.list",
     "path": "/v1/agent/runs/:runId/subagents",
@@ -4267,7 +4277,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 424,
+    "index": 425,
     "method": "GET",
     "operationId": "assets.inventory.list",
     "path": "/v1/assets/inventory",

--- a/test/contracts/api/friday-api-route-contract.snapshot.test.ts
+++ b/test/contracts/api/friday-api-route-contract.snapshot.test.ts
@@ -866,6 +866,7 @@ describe("MECHANISM-4 — API Route Contract (Snapshot)", () => {
         "mission.spine.lifecycle.transition",
         "mission.spine.workitem.status.transition",
         "mission.spine.routedecision.control",
+        "agent.d20.worktree.batch.dispatch",
         // Lane M: the memory-confirmation loop's terminal mutation driven over the sealed-WS
         // dispatch arm. Refuses the synthetic public principal before any dispatch; flag-OFF/503
         // by default (the merged Rust arm #753 is gated by FRIDAY_MEMORY_CONFIRM).

--- a/test/unit/api/http/routes/friday-agent-routes.test.ts
+++ b/test/unit/api/http/routes/friday-agent-routes.test.ts
@@ -101,9 +101,9 @@ describe("FridayAgentRoutes", () => {
     };
   });
 
-  it("registers 19 agent routes", () => {
+  it("registers 20 agent routes", () => {
     const routes = createFridayAgentRoutes(stubDeps);
-    expect(routes).toHaveLength(19);
+    expect(routes).toHaveLength(20);
   });
 
   it("POST /v1/agent/runs requires agent.run scope with workflow.run compatibility", () => {
@@ -477,6 +477,120 @@ describe("FridayAgentRoutes", () => {
       receivedAt: "2026-01-01T00:00:00.000Z",
     })).rejects.toMatchObject({ code: "AGENT_RUN_RESUME_SIGNED_APPROVAL_REQUIRED", httpStatus: 400 });
     expect(resumeRun).not.toHaveBeenCalled();
+  });
+
+  it("D20 signed-batch worktree route FLAG-OFF fail-closes before body/owner work", async () => {
+    const dispatch = vi.fn();
+    stubDeps.dispatchD20SignedBatchWorktree = dispatch;
+    const routes = createFridayAgentRoutes(stubDeps);
+    const route = routes.find((r) => r.operationId === "agent.d20.worktree.batch.dispatch")!;
+
+    await expect(route.handler({
+      body: null,
+      params: {},
+      query: {},
+      headers: {},
+      principal: null,
+      requestId: "req-1",
+      receivedAt: "2026-01-01T00:00:00.000Z",
+    })).rejects.toMatchObject({
+      code: "D20_SIGNED_BATCH_WORKTREE_RETIRED",
+      httpStatus: 503,
+      details: {
+        classification: "fail_closed",
+        replacement: "rust_owned_d20_signed_batch_worktree_required",
+      },
+    });
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+
+  it("D20 signed-batch worktree route rejects an action principal mismatch before dispatch", async () => {
+    const dispatch = vi.fn();
+    stubDeps.d20SignedBatchWorktreeViaRust = true;
+    stubDeps.dispatchD20SignedBatchWorktree = dispatch;
+    const routes = createFridayAgentRoutes(stubDeps);
+    const route = routes.find((r) => r.operationId === "agent.d20.worktree.batch.dispatch")!;
+
+    await expect(route.handler({
+      body: {
+        workspaceRoot: "/tmp/worktree",
+        signedBatch: { decision: "allow" },
+        action: { action: "write_file", principal_id: "owner:mallory", params: [] },
+      },
+      params: {},
+      query: {},
+      headers: {},
+      principal: createStubPrincipal({ principalId: "owner:alice" }),
+      requestId: "req-1",
+      receivedAt: "2026-01-01T00:00:00.000Z",
+    })).rejects.toMatchObject({
+      code: "D20_SIGNED_BATCH_WORKTREE_PRINCIPAL_MISMATCH",
+      httpStatus: 403,
+    });
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+
+  it("D20 signed-batch worktree route rejects a non-string action principal before dispatch", async () => {
+    const dispatch = vi.fn();
+    stubDeps.d20SignedBatchWorktreeViaRust = true;
+    stubDeps.dispatchD20SignedBatchWorktree = dispatch;
+    const routes = createFridayAgentRoutes(stubDeps);
+    const route = routes.find((r) => r.operationId === "agent.d20.worktree.batch.dispatch")!;
+
+    await expect(route.handler({
+      body: {
+        workspaceRoot: "/tmp/worktree",
+        signedBatch: { decision: "allow" },
+        action: { action: "write_file", principal_id: 42, params: [] },
+      },
+      params: {},
+      query: {},
+      headers: {},
+      principal: createStubPrincipal({ principalId: "owner:alice" }),
+      requestId: "req-1",
+      receivedAt: "2026-01-01T00:00:00.000Z",
+    })).rejects.toMatchObject({
+      code: "D20_SIGNED_BATCH_WORKTREE_PRINCIPAL_INVALID",
+      httpStatus: 400,
+    });
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+
+  it("D20 signed-batch worktree route relays the signed batch and exact action JSON to Rust dispatcher", async () => {
+    const receipt = {
+      truthLabel: "d20_worktree_signed_batch_artifact" as const,
+      proofOnly: true as const,
+      ok: true,
+      executed: false,
+      resultStatus: "requires_approval",
+      batchSignId: "batch-1",
+      auditChainVerified: true,
+    };
+    const dispatch = vi.fn().mockResolvedValue(receipt);
+    stubDeps.d20SignedBatchWorktreeViaRust = true;
+    stubDeps.dispatchD20SignedBatchWorktree = dispatch;
+    const routes = createFridayAgentRoutes(stubDeps);
+    const route = routes.find((r) => r.operationId === "agent.d20.worktree.batch.dispatch")!;
+    const signedBatch = { decision: "allow", batch_sign_id: "batch-1", action_digests: ["digest"] };
+    const action = { action: "write_file", params: [{ key: "path", value: "out.txt" }] };
+
+    const response = await route.handler({
+      body: { workspaceRoot: "/tmp/worktree", signedBatch, action },
+      params: {},
+      query: {},
+      headers: {},
+      principal: createStubPrincipal({ principalId: "owner:alice" }),
+      requestId: "req-1",
+      receivedAt: "2026-01-01T00:00:00.000Z",
+    });
+
+    expect(dispatch).toHaveBeenCalledTimes(1);
+    expect(dispatch).toHaveBeenCalledWith({
+      workspaceRoot: "/tmp/worktree",
+      signedBatch,
+      action,
+    });
+    expect(response).toBe(receipt);
   });
 
   it("GET /v1/agent/runs requires agent.read scope with workflow.run compatibility", () => {

--- a/test/unit/api/mission-spine/friday-rust-hub-d20-signed-batch-worktree-service.test.ts
+++ b/test/unit/api/mission-spine/friday-rust-hub-d20-signed-batch-worktree-service.test.ts
@@ -1,0 +1,94 @@
+import { chmod, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { createFridayD20SignedBatchWorktreeService } from "#api";
+
+const scratchDirs: string[] = [];
+
+async function makeScratch(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "friday-d20-service-test-"));
+  scratchDirs.push(dir);
+  return dir;
+}
+
+afterEach(async () => {
+  await Promise.all(scratchDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+describe("createFridayD20SignedBatchWorktreeService", () => {
+  it("runs the configured adapter with temp signed-batch/action files and parses refs-only output", async () => {
+    const dir = await makeScratch();
+    const dbPath = join(dir, "hub.db");
+    const vkPath = join(dir, "operator.vk");
+    const workspaceRoot = join(dir, "worktree");
+    const adapterBin = join(dir, "fake-adapter.mjs");
+    await writeFile(dbPath, "", "utf8");
+    await writeFile(vkPath, "verify-key", "utf8");
+    const actualWorkspace = await mkdtemp(`${workspaceRoot}-`);
+    scratchDirs.push(actualWorkspace);
+    await writeFile(adapterBin, `#!/usr/bin/env node
+const args = process.argv.slice(2);
+const value = (name) => args[args.indexOf(name) + 1];
+const fs = await import("node:fs");
+JSON.parse(fs.readFileSync(value("--signed-batch-json"), "utf8"));
+JSON.parse(fs.readFileSync(value("--action-json"), "utf8"));
+if (!fs.existsSync(value("--db")) || !fs.existsSync(value("--operator-vk-path"))) process.exit(7);
+if (value("--workspace") !== ${JSON.stringify(actualWorkspace)}) process.exit(8);
+console.log(JSON.stringify({
+  truth_label: "d20_worktree_signed_batch_artifact",
+  proof_only: true,
+  ok: true,
+  executed: false,
+  result_status: "requires_approval",
+  batch_sign_id: "batch-1",
+  audit_chain_verified: true
+}));
+`, "utf8");
+    await chmod(adapterBin, 0o755);
+
+    const service = createFridayD20SignedBatchWorktreeService({
+      repoRoot: dir,
+      dbPath,
+      operatorVkPath: vkPath,
+      adapterBin,
+      timeoutMs: 5_000,
+    });
+
+    await expect(service.dispatch({
+      workspaceRoot: actualWorkspace,
+      signedBatch: { decision: "allow" },
+      action: { action: "write_file", principal_id: "owner:alice", params: [] },
+    })).resolves.toMatchObject({
+      truthLabel: "d20_worktree_signed_batch_artifact",
+      proofOnly: true,
+      ok: true,
+      executed: false,
+      resultStatus: "requires_approval",
+      batchSignId: "batch-1",
+      auditChainVerified: true,
+    });
+  });
+
+  it("fails closed when the operator verify key is not provisioned", async () => {
+    const dir = await makeScratch();
+    const dbPath = join(dir, "hub.db");
+    await writeFile(dbPath, "", "utf8");
+    const service = createFridayD20SignedBatchWorktreeService({
+      repoRoot: dir,
+      dbPath,
+      operatorVkPath: join(dir, "missing.vk"),
+    });
+
+    await expect(service.dispatch({
+      workspaceRoot: dir,
+      signedBatch: { decision: "allow" },
+      action: { action: "write_file", principal_id: "owner:alice", params: [] },
+    })).rejects.toMatchObject({
+      code: "D20_SIGNED_BATCH_WORKTREE_UNAVAILABLE",
+      httpStatus: 503,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add a default-off `FRIDAY_D20_SIGNED_BATCH_WORKTREE_VIA_RUST` product route for D20 signed-batch worktree dispatch
- add a thin TS->Rust bridge service that writes temp signed/action artifacts, calls `hub_d20_signed_batch_worktree`, and accepts refs-only output
- wire runtime/bootstrap deps and owner-bound route validation without minting or parsing signature semantics in TS

## Validation
- npm test -- --run test/unit/api/http/routes/friday-agent-routes.test.ts test/unit/api/mission-spine/friday-rust-hub-d20-signed-batch-worktree-service.test.ts
- npm run typecheck
- npm run lint (0 errors; existing warning-only lint posture)
- npm run build
- npm run test:mechanism-wiring
- npm run test:mechanism-wiring:behavior
- git diff --check

## Truth Label
- built-DARK / product entrypoint wiring only
- Hub verifies only; no signing key read or minted
- TEST/local mechanism proof only, not true operator signature live proof
- not GO-LIVE, not strict OG9 organic, not v1 done
- strict organic remains 0
