### PR TITLE
Guard OG9 organic launch origin acknowledgement

### DIFF
--- a/scripts/ops/friday-claude-organic-spawn.sh
+++ b/scripts/ops/friday-claude-organic-spawn.sh
@@ -26,6 +26,13 @@ if [ -z "${TASK_TEXT}" ]; then
   exit 3
 fi
 
+readonly REQUIRED_OPERATOR_ORIGIN_ACK="operator-physical-hand-starts-og9-organic-run"
+if [ "${FRIDAY_OG9_OPERATOR_ORIGIN_ACK:-}" != "${REQUIRED_OPERATOR_ORIGIN_ACK}" ]; then
+  echo "FATAL: strict OG9 organic launch requires FRIDAY_OG9_OPERATOR_ORIGIN_ACK=${REQUIRED_OPERATOR_ORIGIN_ACK}." >&2
+  echo "This must be set by the operator at launch time; agent automation must use proof/soak wrappers instead." >&2
+  exit 4
+fi
+
 ORGANIC_BODY_REF_ID="$(node -e 'process.stdout.write((globalThis.crypto?.randomUUID?.() ?? (`id-${Date.now()}-${Math.random().toString(16).slice(2)}`)).toLowerCase())')"
 
 export FRIDAY_CLAUDE_MISSION_PROOF_RUN_KIND="organic"

--- a/scripts/ops/friday-codex-organic-spawn.sh
+++ b/scripts/ops/friday-codex-organic-spawn.sh
@@ -26,6 +26,13 @@ if [ -z "${TASK_TEXT}" ]; then
   exit 3
 fi
 
+readonly REQUIRED_OPERATOR_ORIGIN_ACK="operator-physical-hand-starts-og9-organic-run"
+if [ "${FRIDAY_OG9_OPERATOR_ORIGIN_ACK:-}" != "${REQUIRED_OPERATOR_ORIGIN_ACK}" ]; then
+  echo "FATAL: strict OG9 organic launch requires FRIDAY_OG9_OPERATOR_ORIGIN_ACK=${REQUIRED_OPERATOR_ORIGIN_ACK}." >&2
+  echo "This must be set by the operator at launch time; agent automation must use proof/soak wrappers instead." >&2
+  exit 4
+fi
+
 ORGANIC_BODY_REF_ID="$(node -e 'process.stdout.write((globalThis.crypto?.randomUUID?.() ?? (`id-${Date.now()}-${Math.random().toString(16).slice(2)}`)).toLowerCase())')"
 
 export FRIDAY_CODEX_MISSION_PROOF_RUN_KIND="organic"

--- a/test/unit/scripts/ops/friday-claude-mission-proof-gates.test.ts
+++ b/test/unit/scripts/ops/friday-claude-mission-proof-gates.test.ts
@@ -122,6 +122,9 @@ describe("Claude mission proof operator gate", () => {
     expect(launcherSource).toContain(
       'FRIDAY_CLAUDE_MISSION_PROOF_INTENT="${TASK_TEXT}"',
     );
+    expect(launcherSource).toContain("FRIDAY_OG9_OPERATOR_ORIGIN_ACK");
+    expect(launcherSource).toContain("operator-physical-hand-starts-og9-organic-run");
+    expect(launcherSource).toContain("agent automation must use proof/soak wrappers instead");
     expect(launcherSource).toContain("observe-wrapper.claude.organic");
     expect(launcherSource).toContain("FRIDAY_CLAUDE_ORGANIC_TASK");
     expect(launcherSource).not.toContain("FRIDAY_CLAUDE_PROOF_OK");
@@ -129,11 +132,27 @@ describe("Claude mission proof operator gate", () => {
     expect(keychainSource).toContain(
       'FRIDAY_CLAUDE_MISSION_PROOF_PASSPHRASE_STDIN=1 "${ORGANIC_SCRIPT}"',
     );
+    expect(keychainSource).not.toContain("FRIDAY_OG9_OPERATOR_ORIGIN_ACK=");
     expect(keychainSource).toContain("passphrase_file_ok()");
     expect(keychainSource).toContain("read_provisioned_passphrase()");
     expect(keychainSource).toContain("stat -f '%Lp'");
     expect(keychainSource).toContain("stat -f '%u'");
     expect(keychainSource).toContain("400|600) ;;");
+  });
+
+  it("refuses Claude organic launch without operator-origin acknowledgement", () => {
+    const result = spawnSync(organicLauncher, ["operator task"], {
+      cwd: repoRoot,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        FRIDAY_OG9_OPERATOR_ORIGIN_ACK: "",
+      },
+    });
+
+    expect(result.status).toBe(4);
+    expect(result.stderr).toContain("strict OG9 organic launch requires FRIDAY_OG9_OPERATOR_ORIGIN_ACK");
+    expect(result.stderr).toContain("agent automation must use proof/soak wrappers instead");
   });
 
   it("does not read secrets before preflight and does not put bearer in argv", () => {

--- a/test/unit/scripts/ops/friday-codex-mission-proof-gates.test.ts
+++ b/test/unit/scripts/ops/friday-codex-mission-proof-gates.test.ts
@@ -487,6 +487,9 @@ describe("Codex mission proof gates", () => {
 
     expect(organicSource).toContain("FRIDAY_CODEX_ORGANIC_TASK");
     expect(organicSource).toContain("Usage: $0 '<operator task for Codex>'");
+    expect(organicSource).toContain("FRIDAY_OG9_OPERATOR_ORIGIN_ACK");
+    expect(organicSource).toContain("operator-physical-hand-starts-og9-organic-run");
+    expect(organicSource).toContain("agent automation must use proof/soak wrappers instead");
     expect(organicSource).toContain(
       'export FRIDAY_CODEX_MISSION_PROOF_RUN_KIND="organic"',
     );
@@ -504,10 +507,26 @@ describe("Codex mission proof gates", () => {
     expect(organicKeychainSource).toContain(
       'FRIDAY_CODEX_MISSION_PROOF_PASSPHRASE_STDIN=1 "${ORGANIC_SCRIPT}" "$@"',
     );
+    expect(organicKeychainSource).not.toContain("FRIDAY_OG9_OPERATOR_ORIGIN_ACK=");
     expect(organicKeychainSource).toContain(
       'security find-generic-password -a "${KEYCHAIN_ACCOUNT}" -s "${KEYCHAIN_SERVICE}" -w >/dev/null 2>&1',
     );
     expect(organicKeychainSource).toContain("trap 'unset PASSPHRASE' EXIT");
+  });
+
+  it("refuses Codex organic launch without operator-origin acknowledgement", () => {
+    const result = spawnSync(organicSpawnScript, ["operator task"], {
+      cwd: repoRoot,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        FRIDAY_OG9_OPERATOR_ORIGIN_ACK: "",
+      },
+    });
+
+    expect(result.status).toBe(4);
+    expect(result.stderr).toContain("strict OG9 organic launch requires FRIDAY_OG9_OPERATOR_ORIGIN_ACK");
+    expect(result.stderr).toContain("agent automation must use proof/soak wrappers instead");
   });
 
   it("D8 audit passes only when a linked session has matching completed WorkItem proof", async () => {


### PR DESCRIPTION
## Summary
- require an explicit operator-origin acknowledgement before Codex/Claude organic spawn launchers run
- keep keychain wrappers from auto-providing that acknowledgement so noninteractive automation cannot silently mark a proof/soak path as OG9 organic
- add focused launcher gate tests for both Codex and Claude

## Truth label
- built/product truth guard only; does not create strict OG9 organic traffic
- organic remains 0 until the operator physically launches a real Friday-origin session
- GO-LIVE/v1 remain NO-GO

## Tests
- `bash -n scripts/ops/friday-codex-organic-spawn.sh scripts/ops/friday-claude-organic-spawn.sh scripts/ops/friday-codex-organic-spawn-keychain.sh scripts/ops/friday-claude-organic-spawn-keychain.sh`
- `git diff --check`
- `npm test -- --run test/unit/scripts/ops/friday-codex-mission-proof-gates.test.ts test/unit/scripts/ops/friday-claude-mission-proof-gates.test.ts`
