### PR TITLE
Feed agent outcomes into learning extraction

### DIFF
--- a/src/agent/runtime/friday-agent-learning-bridge.ts
+++ b/src/agent/runtime/friday-agent-learning-bridge.ts
@@ -66,6 +66,9 @@ export function createFridayAgentLearningBridge(
         kind: "workflow_outcome",
         payload: {
           agentRunId: payload.runId,
+          workflowId: payload.runId,
+          success: payload.testsPassed,
+          status: payload.testsPassed ? "completed" : "failed",
           toolCallCount: payload.toolCallCount,
           durationMs: payload.durationMs,
           testsPassed: payload.testsPassed,

--- a/test/unit/agent/runtime/friday-agent-learning-bridge.test.ts
+++ b/test/unit/agent/runtime/friday-agent-learning-bridge.test.ts
@@ -64,10 +64,40 @@ describe("FridayAgentLearningBridge", () => {
     expect(event.userId).toBe("admin-001");
     expect(event.payload).toEqual({
       agentRunId: "run-2",
+      workflowId: "run-2",
+      success: true,
+      status: "completed",
       toolCallCount: 3,
       durationMs: 5000,
       testsPassed: true,
       artifactCount: 1,
+    });
+  });
+
+  it("marks failed completed runs so workflow outcome extraction can learn from them", () => {
+    const { emitter, bridge, learningEventWriter, written } = setup();
+    bridge.start();
+
+    emitter.emit("agent.run.completed", {
+      runId: "run-5",
+      durationMs: 7000,
+      toolCallCount: 2,
+      testsPassed: false,
+      artifacts: [],
+    });
+
+    expect(learningEventWriter).toHaveBeenCalledOnce();
+    const event = written[0]![0]!;
+    expect(event.kind).toBe("workflow_outcome");
+    expect(event.payload).toEqual({
+      agentRunId: "run-5",
+      workflowId: "run-5",
+      success: false,
+      status: "failed",
+      toolCallCount: 2,
+      durationMs: 7000,
+      testsPassed: false,
+      artifactCount: 0,
     });
   });
 

--- a/test/unit/learning/services/friday-preference-extraction-service.test.ts
+++ b/test/unit/learning/services/friday-preference-extraction-service.test.ts
@@ -361,6 +361,40 @@ describe("FridayPreferenceExtractionService", () => {
       expect(signals[0]!.key).toContain("build_job");
     });
 
+    it("extracts feedback from agent outcome bridge success fields", () => {
+      const successEvent = makeEvent({
+        kind: "workflow_outcome",
+        payload: {
+          agentRunId: "agent-run-ok",
+          workflowId: "agent-run-ok",
+          success: true,
+          status: "completed",
+          testsPassed: true,
+        },
+      });
+      const failedEvent = makeEvent({
+        kind: "workflow_outcome",
+        payload: {
+          agentRunId: "agent-run-failed",
+          workflowId: "agent-run-failed",
+          success: false,
+          status: "failed",
+          testsPassed: false,
+        },
+      });
+
+      const successSignals = service.extract(successEvent);
+      expect(successSignals).toHaveLength(1);
+      expect(successSignals[0]!.kind).toBe("positive_feedback");
+      expect(successSignals[0]!.key).toContain("agent_run_ok");
+
+      const failedSignals = service.extract(failedEvent);
+      expect(failedSignals).toHaveLength(1);
+      expect(failedSignals[0]!.kind).toBe("correction");
+      expect(failedSignals[0]!.key).toContain("agent_run_failed");
+      expect(failedSignals[0]!.confidence).toBe(0.3);
+    });
+
     it("emits failure signal for workflow with error field", () => {
       const event = makeEvent({
         kind: "workflow_outcome",


### PR DESCRIPTION
## Summary
- add `workflowId`, `success`, and `status` to agent completed-run learning events
- preserve the existing agent run metadata while making workflow_outcome events readable by the preference extraction service
- add focused tests for successful and failed agent outcomes flowing into extraction

## Truth label
- contract/build fix only; does not flip A1 live flags
- no organic traffic is created; strict organic remains 0
- GO-LIVE/v1 remain NO-GO

## Tests
- `npm test -- --run test/unit/agent/runtime/friday-agent-learning-bridge.test.ts test/unit/learning/services/friday-preference-extraction-service.test.ts`
- `git diff --check`
