### PR TITLE
Expose learning context fact provenance

### DIFF
--- a/src/learning/model/friday-learning.types.ts
+++ b/src/learning/model/friday-learning.types.ts
@@ -207,11 +207,28 @@ export interface FridayLearningPattern {
   evidence: JsonObject;
 }
 
+export interface FridayLearningAppliedFact {
+  factId: string;
+  key: string;
+  confidence: number;
+  evidenceCount: number;
+  lastConfirmedAt: ISODateTime;
+  sourceEventIds: string[];
+  reviewBoundary: string;
+  contextUseBoundary: "learning_context_service_gated";
+  provenance: {
+    source: "preference_fact";
+    reviewBoundary: string;
+    reviewCenterCandidateId?: string;
+    reviewCenterOrigin?: string;
+  };
+}
+
 export interface FridayLearningContext {
   userId: string;
   lifecycleState: FridayLearningLifecycleState;
   preferences: Record<string, JsonValue>;
-  appliedFacts: Array<{ factId: string; key: string; confidence: number }>;
+  appliedFacts: FridayLearningAppliedFact[];
   activePatterns: FridayLearningPattern[];
   individuationStage?: string;
   generatedAt: ISODateTime;

--- a/src/learning/services/friday-learning-context-enrichment-service.ts
+++ b/src/learning/services/friday-learning-context-enrichment-service.ts
@@ -7,6 +7,10 @@ import type {
   JsonValue,
 } from "../model/friday-learning.types.js";
 import { FRIDAY_LEARNING_DEFAULTS } from "../model/friday-learning.types.js";
+import {
+  FRIDAY_LEARNED_FACT_CONTEXT_USE_BOUNDARY,
+  readLearnedFactReviewBoundary,
+} from "./friday-learned-fact-memory-view.js";
 
 export interface FridayLearningContextEnrichmentService {
   buildContext(input: {
@@ -56,11 +60,27 @@ export function createFridayLearningContextEnrichmentService(
       const appliedFacts: FridayLearningContext["appliedFacts"] = [];
 
       for (const fact of activeFacts) {
+        const reviewBoundary = readLearnedFactReviewBoundary(fact);
         preferences[fact.key] = fact.value;
         appliedFacts.push({
           factId: fact.factId,
           key: fact.key,
           confidence: fact.confidence,
+          evidenceCount: fact.evidenceCount,
+          lastConfirmedAt: fact.lastConfirmedAt,
+          sourceEventIds: fact.sourceEventIds,
+          reviewBoundary,
+          contextUseBoundary: FRIDAY_LEARNED_FACT_CONTEXT_USE_BOUNDARY,
+          provenance: {
+            source: "preference_fact",
+            reviewBoundary,
+            reviewCenterCandidateId: typeof fact.metadata?.reviewCenterCandidateId === "string"
+              ? fact.metadata.reviewCenterCandidateId
+              : undefined,
+            reviewCenterOrigin: typeof fact.metadata?.reviewCenterOrigin === "string"
+              ? fact.metadata.reviewCenterOrigin
+              : undefined,
+          },
         });
       }
 

--- a/test/unit/learning/runtime/friday-self-learning-runtime.test.ts
+++ b/test/unit/learning/runtime/friday-self-learning-runtime.test.ts
@@ -176,6 +176,14 @@ describe("FridaySelfLearningRuntime", () => {
       nowIso: NOW,
     });
     expect(ctx.preferences).toHaveProperty("pref:editor", "nvim");
+    expect(ctx.appliedFacts[0]).toMatchObject({
+      key: "pref:editor",
+      contextUseBoundary: "learning_context_service_gated",
+      provenance: {
+        source: "preference_fact",
+        reviewBoundary: "not_review_center_confirmed",
+      },
+    });
   });
 
   it("pipeline end-to-end: explicit user-message preference is active on first evidence", () => {

--- a/test/unit/learning/services/friday-learning-context-enrichment-service.test.ts
+++ b/test/unit/learning/services/friday-learning-context-enrichment-service.test.ts
@@ -92,6 +92,73 @@ describe("FridayLearningContextEnrichmentService", () => {
     expect(ctx.appliedFacts).toHaveLength(1);
     expect(ctx.appliedFacts[0]!.key).toBe("pref:language");
     expect(ctx.appliedFacts[0]!.confidence).toBe(0.90);
+    expect(ctx.appliedFacts[0]).toMatchObject({
+      evidenceCount: 1,
+      lastConfirmedAt: NOW,
+      sourceEventIds: ["evt-001"],
+      reviewBoundary: "not_review_center_confirmed",
+      contextUseBoundary: "learning_context_service_gated",
+      provenance: {
+        source: "preference_fact",
+        reviewBoundary: "not_review_center_confirmed",
+      },
+    });
+  });
+
+  it("buildContext carries Review Center provenance for confirmed learned facts", () => {
+    const factRepo = createFridayPreferenceFactRepository();
+    const factService = createFridayPreferenceFactService({
+      db,
+      factRepo,
+      idGenerator: idGen,
+      nowIso: () => NOW,
+    });
+
+    factService.applySignals({
+      event: {
+        eventId: "evt-review-learned-fact",
+        ts: NOW,
+        userId: "test-user",
+        kind: "user_correction",
+        payload: { feedbackKind: "learned_fact_approval" },
+      },
+      signals: [
+        {
+          signalId: "sig-review-learned-fact",
+          kind: "preference",
+          key: "learned.preferred_editor",
+          value: "Helix",
+          confidence: 0.9,
+          sourceEventId: "evt-review-learned-fact",
+          userId: "test-user",
+          ts: NOW,
+          situationalContext: {
+            candidateId: "candidate-123",
+            origin: "post_run",
+          },
+        },
+      ],
+      nowIso: NOW,
+    });
+
+    const ctx = service.buildContext({
+      userId: "test-user",
+      nowIso: NOW,
+    });
+
+    expect(ctx.preferences).toHaveProperty("learned.preferred_editor", "Helix");
+    expect(ctx.appliedFacts).toHaveLength(1);
+    expect(ctx.appliedFacts[0]).toMatchObject({
+      key: "learned.preferred_editor",
+      reviewBoundary: "review_center_confirmed",
+      contextUseBoundary: "learning_context_service_gated",
+      provenance: {
+        source: "preference_fact",
+        reviewBoundary: "review_center_confirmed",
+        reviewCenterCandidateId: "candidate-123",
+        reviewCenterOrigin: "post_run",
+      },
+    });
   });
 
   it("buildContext excludes low-confidence facts", () => {


### PR DESCRIPTION
## Summary
- add provenance/review-boundary metadata to learning context appliedFacts
- carry Review Center confirmed learned facts through downstream context as review_center_confirmed
- prove the context path only enriches from active facts while keeping preferences behavior unchanged

## Truth label
- A1 DRIVE/context consumer hardening only
- no organic traffic is created; strict organic remains 0
- does not flip A1 live flags, D20/B4 true-sign, GO-LIVE, or v1

## Tests
- npx vitest run test/unit/learning/services/friday-learning-context-enrichment-service.test.ts test/unit/learning/runtime/friday-self-learning-runtime.test.ts
- npm run typecheck:src
- git diff --check
