### PR TITLE
Prove A1 consumer session recall path

### DIFF
--- a/docs/ops/prod-flags-manifest.json
+++ b/docs/ops/prod-flags-manifest.json
@@ -97,8 +97,8 @@
       "prod_state": "dark",
       "closes_loop": "A later owner-scoped prompt includes confirmed preference/world-model run-outcome learning signals as refs-only guidance, while excluding reflex candidates and answer bodies.",
       "coverage": "loop-e2e",
-      "e2e_test": "rust-core/crates/friday-hub/src/lib.rs::a1_run_outcome_learning_consumer_surfaces_preference_world_model_only",
-      "notes": "A1 preference/world-model consumer leg. Drives the shared recall-preamble chokepoint with the consumer flag ON and confirmed preference/world_model/reflex candidates, asserting only preference/world_model refs-only signals are injected and reflex is excluded. Sibling proofs cover exact-'1' parsing and flag-off byte-identical behavior. Truth boundary: built-DARK mechanism only; not A1 live-done until an operator-origin organic turn feeds a candidate and a real confirm decision."
+      "e2e_test": "rust-core/crates/friday-hub/src/runtime.rs::session_recall_public_path_surfaces_a1_consumer_preference_world_model_only",
+      "notes": "A1 preference/world-model consumer leg. Drives the public session recall path with the consumer flag ON and confirmed preference/world_model/reflex candidates, asserting only preference/world_model refs-only signals are injected and reflex is excluded. Sibling proofs cover exact-'1' parsing, shared chokepoint behavior, and flag-off byte-identical behavior. Truth boundary: built-DARK mechanism only; not A1 live-done until an operator-origin organic turn feeds a candidate and a real confirm decision."
     },
     {
       "flag": "FRIDAY_MEMORY_CONFIRM",

--- a/rust-core/crates/friday-hub/src/runtime.rs
+++ b/rust-core/crates/friday-hub/src/runtime.rs
@@ -7633,6 +7633,99 @@ mod tests {
     }
 
     #[test]
+    fn session_recall_public_path_surfaces_a1_consumer_preference_world_model_only() {
+        // A1 preference/world-model consumer proof: the public session recall path reads the
+        // dark consumer gate and injects only refs-only preference/world_model signals. Reflex
+        // candidates remain governance-only, and operator decision text stays out of prompts.
+        let (rt, _ws, _bodies) = recall_runtime("session-a1-consumer-public", Some("alice"));
+        let now = 1_000_000_000_000_i64;
+        seed_confirmed_run_outcome_learning_signal(
+            &rt,
+            "sess-a1-consumer-source",
+            "alice",
+            "run-a1-consumer-source",
+            now,
+        );
+        friday_storage::learning_candidate::decide_run_outcome_candidate(
+            rt.db().conn(),
+            "a1:run-a1-consumer-source:world_model",
+            true,
+            now + 2,
+            Some("operator confirmed world-model text"),
+        )
+        .unwrap();
+        friday_storage::learning_candidate::decide_run_outcome_candidate(
+            rt.db().conn(),
+            "a1:run-a1-consumer-source:reflex",
+            true,
+            now + 3,
+            Some("operator confirmed reflex text"),
+        )
+        .unwrap();
+        bind_session_owner(&rt, "sess-a1-consumer-later", "alice");
+
+        {
+            let _consumer_flag = crate::test_env::EnvVarGuard::set(
+                crate::FRIDAY_A1_RUN_OUTCOME_LEARNING_CONSUMER,
+                "0",
+            );
+            let off = rt
+                .recall_preamble_for_session(
+                    "sess-a1-consumer-later",
+                    "run-a1-consumer-off",
+                    None,
+                    now + 4,
+                )
+                .expect("session recall composes with A1 consumer flag off");
+            assert_eq!(off, "", "consumer flag-OFF must not inject A1 signals");
+        }
+
+        {
+            let _consumer_flag = crate::test_env::EnvVarGuard::set(
+                crate::FRIDAY_A1_RUN_OUTCOME_LEARNING_CONSUMER,
+                "1",
+            );
+            let on = rt
+                .recall_preamble_for_session(
+                    "sess-a1-consumer-later",
+                    "run-a1-consumer-on",
+                    None,
+                    now + 5,
+                )
+                .expect("session recall composes with A1 consumer flag on");
+            assert!(
+                on.contains("Confirmed preference/world-model learning signals")
+                    && on.contains("- preference:")
+                    && on.contains("- world_model:")
+                    && on.contains("friday://agent-run/run-a1-consumer-source"),
+                "consumer flag-ON session recall must inject preference/world-model refs-only signals: {on:?}"
+            );
+            assert!(
+                !on.contains("- reflex:"),
+                "consumer must not inject reflex candidates: {on:?}"
+            );
+            assert!(
+                !on.contains("operator confirmed"),
+                "decision reasons are operator text and must not be prompt-injected: {on:?}"
+            );
+        }
+
+        let consumed: i64 = rt
+            .db()
+            .conn()
+            .query_row(
+                "SELECT count(*) FROM audit_ledger WHERE action LIKE 'run_outcome_learning.consumer%'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(
+            consumed, 1,
+            "flag-ON A1 consumer session recall writes one audit receipt"
+        );
+    }
+
+    #[test]
     fn session_recall_is_owner_isolated_no_cross_owner_leak() {
         // NO-LEAK (the CRITICAL guard): a confirmed candidate under owner O's composite
         // namespace is NEVER recalled for a DIFFERENT owner O2's session. The composite


### PR DESCRIPTION
## Summary
- add a public session-path dark proof for `FRIDAY_A1_RUN_OUTCOME_LEARNING_CONSUMER`
- prove confirmed preference/world_model run-outcome candidates reach later session recall as refs-only context while reflex stays excluded
- update the prod flag manifest e2e anchor to the stronger public session-path proof

## Validation
- `cargo fmt -p friday-hub`
- `cargo test -p friday-hub session_recall_public_path_surfaces_a1_consumer_preference_world_model_only`
- `cargo test -p friday-hub a1_run_outcome_learning_consumer`
- `cargo test -p friday-hub session_recall_public_path_surfaces`
- `npm run test:mechanism-wiring`
- `git diff --check`

## Truth label
Built-DARK proof only. This does not flip `FRIDAY_A1_RUN_OUTCOME_LEARNING_CONSUMER`, does not create strict organic traffic, does not satisfy A1 live-done, and does not change GO-LIVE/v1 status.