### PR TITLE
Harden L1 route mutation fences

### DIFF
--- a/src/api/http/routes/friday-skill-routes.ts
+++ b/src/api/http/routes/friday-skill-routes.ts
@@ -984,7 +984,7 @@ export function createFridaySkillRoutes(
           idempotencyKey: asOptionalString(body.idempotencyKey, "idempotencyKey"),
         })
         : undefined;
-      if (managedExternalSkillRun && canonicalApproval?.decision !== "approved") {
+      if (managedExternalSkillRun) {
         assertCanonicalApproval({
           deps,
           request: canonicalApprovalRequest!,

--- a/test/unit/api/http/routes/friday-autonomy-routes.test.ts
+++ b/test/unit/api/http/routes/friday-autonomy-routes.test.ts
@@ -260,7 +260,7 @@ function makeChannelApproval(input: {
   };
 }
 
-function createRoutes() {
+function createRoutes(input: { allowTestOnlyAutonomyLifecycleExecution?: boolean } = {}) {
   const evidence = {
     candidateId: "candidate-1",
     events: [{ type: "shadow", at: "2026-05-07T18:00:00.000Z" }],
@@ -275,8 +275,10 @@ function createRoutes() {
     status: "not_installed",
     tags: [],
   }));
+  const promote = vi.fn(async () => ({ skillId: "skill-1", status: "installed", tags: [] }));
+  const rollback = vi.fn(async () => ({ skillId: "skill-1", status: "not_installed", tags: [] }));
   const routes = createFridayAutonomyRoutes({
-    allowTestOnlyAutonomyLifecycleExecution: true,
+    allowTestOnlyAutonomyLifecycleExecution: input.allowTestOnlyAutonomyLifecycleExecution ?? true,
     canonicalMutationGate: createFridayMutatingActionGate({
       nowIso: () => "2026-05-07T18:00:00.000Z",
       ticketIdGenerator: () => "ticket-1",
@@ -285,13 +287,13 @@ function createRoutes() {
     skillActions: {
       registerShadow,
       recordCanary,
-      promote: vi.fn(async () => ({ skillId: "skill-1", status: "installed", tags: [] })),
-      rollback: vi.fn(async () => ({ skillId: "skill-1", status: "not_installed", tags: [] })),
+      promote,
+      rollback,
       getStatus: () => null,
       getEvidence: vi.fn(() => evidence),
     },
   });
-  return { routes, registerShadow, recordCanary };
+  return { routes, registerShadow, recordCanary, promote, rollback };
 }
 
 function createProviderRoutes() {
@@ -530,6 +532,72 @@ function createChannelRoutes() {
 }
 
 describe("createFridayAutonomyRoutes skill lifecycle approval", () => {
+  it.each([
+    {
+      operationId: "autonomy.skills.shadow",
+      body: {
+        candidateId: "candidate-1",
+        runtimeVersion: "runtime-v1",
+        canonicalApproval: makeApproval({ action: "shadow", candidateId: "candidate-1" }),
+      },
+      mutation: "registerShadow",
+    },
+    {
+      operationId: "autonomy.skills.canary",
+      body: {
+        candidateId: "candidate-1",
+        runtimeVersion: "runtime-v1",
+        canonicalApproval: makeApproval({ action: "canary", candidateId: "candidate-1" }),
+      },
+      mutation: "recordCanary",
+    },
+    {
+      operationId: "autonomy.skills.promote",
+      body: {
+        candidateId: "candidate-1",
+        runtimeVersion: "runtime-v1",
+        planDigest: "plan-digest-1",
+        canonicalApproval: makeApproval({
+          action: "promote",
+          candidateId: "candidate-1",
+          planDigest: "plan-digest-1",
+        }),
+      },
+      mutation: "promote",
+    },
+    {
+      operationId: "autonomy.skills.rollback",
+      body: {
+        candidateId: "candidate-1",
+        runtimeVersion: "runtime-v1",
+        planDigest: "plan-digest-1",
+        canonicalApproval: makeApproval({
+          action: "rollback",
+          candidateId: "candidate-1",
+          planDigest: "plan-digest-1",
+        }),
+      },
+      mutation: "rollback",
+    },
+  ] as const)(
+    "fail-closes %s by default before invoking the TypeScript skill lifecycle mutation",
+    async ({ operationId, body, mutation }) => {
+      const deps = createRoutes({ allowTestOnlyAutonomyLifecycleExecution: false });
+      const route = deps.routes.find((entry) => entry.operationId === operationId)!;
+
+      await expect(route.handler(makeContext(body))).rejects.toMatchObject({
+        code: "TS_RUNTIME_AUTONOMY_LIFECYCLE_RETIRED",
+        httpStatus: 503,
+        details: {
+          classification: "fail_closed",
+          replacement: "rust_owned_autonomy_subject_upgrade_lifecycle_entrypoint_required",
+        },
+      });
+
+      expect(deps[mutation]).not.toHaveBeenCalled();
+    },
+  );
+
   it("requires canonical approval before shadow can mutate", async () => {
     const { routes, registerShadow } = createRoutes();
     const route = routes.find((entry) => entry.operationId === "autonomy.skills.shadow")!;

--- a/test/unit/api/http/routes/friday-skill-routes.test.ts
+++ b/test/unit/api/http/routes/friday-skill-routes.test.ts
@@ -565,6 +565,59 @@ describe("createFridaySkillRoutes", () => {
     expect(result).toHaveProperty("output.result", "ok");
   });
 
+  it("rejects caller-forged approved canonicalApproval before running managed external skills", async () => {
+    const lifecycle = makeLifecycle();
+    const executor = makeExecutor();
+    const routes = createFridaySkillRoutes({
+      skillRegistry: {
+        list: () => [],
+        get: vi.fn(() => ({
+          source: "external",
+          origin: "managed",
+          status: "installed",
+          managed: true,
+          manifest: {
+            id: "skill.external",
+            kind: "conversation",
+            runtime: { kind: "shell" },
+            requirements: { bins: [], env: [], config: [], os: [] },
+            executionTargets: {
+              allowedSatelliteTypes: ["desktop"],
+              requiredCapabilities: [],
+            },
+          },
+        })),
+      } as never,
+      lifecycle: lifecycle as never,
+      skillExecutor: executor as never,
+      canonicalMutationGate: makeCanonicalMutationGate(),
+      allowTestOnlySkillRunExecution: true,
+    });
+
+    await expect(
+      routes.find((item) => item.operationId === "skills.run")!.handler(makeCtx({
+        params: { skillId: "skill.external" },
+        body: {
+          input: { name: "world" },
+          channel: "api",
+          timeoutMs: 1000,
+          canonicalApproval: {
+            decision: "approved",
+            approvalId: "forged-approval",
+            decidedByPrincipalId: "user-1",
+            actionDigest: "wrong-digest",
+            expiresAt: "2026-03-07T01:00:00.000Z",
+          },
+        },
+      })),
+    ).rejects.toMatchObject({
+      code: "SKILL_RUN_APPROVAL_DENIED",
+      httpStatus: 409,
+    });
+
+    expect(executor.execute).not.toHaveBeenCalled();
+  });
+
   it("runs registered shell skills that require the local shell capability", async () => {
     const lifecycle = makeLifecycle();
     const executor = makeExecutor();


### PR DESCRIPTION
## Summary
- require the canonical mutation gate for managed external skill runs even when callers submit an approved canonicalApproval object
- add default/live fail-closed behavior coverage for autonomy skill shadow/canary/promote/rollback before TypeScript lifecycle mutations
- keep this as a medium L1 route-fence batch rather than one tiny PR per assertion

## Validation
- npm run test -- --run test/unit/api/http/routes/friday-autonomy-routes.test.ts test/unit/api/http/routes/friday-skill-routes.test.ts -t "skill lifecycle|skills.run|canonicalApproval|fail-closes" (9 passed)
- npm run test -- --run test/unit/api/http/routes/friday-autonomy-routes.test.ts test/unit/api/http/routes/friday-skill-routes.test.ts (42 passed)
- npm run test:mechanism-wiring
- npm run typecheck:src
- git diff --check

Truth labels: L1 route-fence hardening only. No GO-LIVE claim, no organic traffic, no operator signature, no v1 completion claim.