### PR TITLE
Add system-intent dark Hub entrypoint

### DIFF
--- a/docs/ops/prod-flags-manifest.json
+++ b/docs/ops/prod-flags-manifest.json
@@ -250,6 +250,19 @@
       "notes": "Built-dark D21/A4 execution substrate. The runner uses the existing shell-free/env-scrubbed/cwd-contained friday-fs command path and supports a required Darwin sandbox CLI switch, but this flag does not flip live product execution policy and does not make imported SKILL.md packages executable. Hub still verifies only; operator signing remains operator-only."
     },
     {
+      "flag": "FRIDAY_SYSTEM_INTENT_RUST_ENTRYPOINT",
+      "process": "rust-ws-wrapper",
+      "prod_state": "dark",
+      "closes_loop": "With the flag ON, a Hub-owned system-intent proof entrypoint reaches the Rust system-intent domain layer and records refs-only request/result rows through the production dry-run/unavailable OS executor. With the flag OFF it fails closed before opening a DB. Even with a valid operator Ed25519 approval for an OS-affecting intent, the entrypoint reports unavailable dry-run evidence and never completes or actuates the host effect.",
+      "coverage": "loop-e2e",
+      "e2e_test": "rust-core/crates/friday-hub/tests/system_intent_dispatch_cli.rs::valid_operator_approval_authorizes_launch_app_but_still_dry_runs",
+      "additional_e2e_tests": [
+        "rust-core/crates/friday-hub/tests/system_intent_dispatch_cli.rs::flag_off_fails_closed_without_creating_db",
+        "rust-core/crates/friday-hub/tests/system_intent_dispatch_cli.rs::flag_on_dispatches_snapshot_as_dry_run_unavailable_not_completed"
+      ],
+      "notes": "Built-dark B3 companion/system-intent Rust entrypoint. The CLI composes the existing system-intent domain, m0026 storage substrate, and Ed25519 verify-only approval path; it does not add a product route, does not read or mint signing keys, and does not wire a real OS actuation backend. Honest boundary: this is not live companion OS execution and not a GO-LIVE flip."
+    },
+    {
       "flag": "FRIDAY_WEB_FETCH_ENABLED",
       "process": "rust-ws-wrapper",
       "prod_state": "dark",

--- a/rust-core/crates/friday-hub/src/bin/hub_system_intent_dispatch.rs
+++ b/rust-core/crates/friday-hub/src/bin/hub_system_intent_dispatch.rs
@@ -1,0 +1,228 @@
+//! B3 system-intent DARK Hub entrypoint.
+//!
+//! This CLI reaches the Rust-owned system-intent domain layer behind an exact
+//! default-off flag. It is not a product route and never wires a real OS backend:
+//! the production executor is dry-run/unavailable only, so an approved OS intent
+//! is authorized and recorded without faking a completed host effect.
+
+use std::env;
+use std::io::Read;
+use std::path::Path;
+
+use friday_core::gate::{ApprovalDecision, CanonicalApproval, CANONICAL_GATE_ISSUER};
+use friday_hub::operator_vk::load_operator_vk_from_path;
+use friday_hub::system_intent::{
+    DispatchOutcome, IntentInput, OsIntentExecutor, SystemIntentEntrypoint,
+};
+use friday_storage::system_intent::{IntentAction, OwnerKind};
+use friday_storage::Db;
+use serde::Deserialize;
+use serde_json::json;
+
+const FLAG: &str = "FRIDAY_SYSTEM_INTENT_RUST_ENTRYPOINT";
+
+struct CliError {
+    kind: &'static str,
+}
+
+impl CliError {
+    fn new(kind: &'static str) -> Self {
+        Self { kind }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct SignedApprovalIn {
+    decision: String,
+    approval_id: String,
+    action_digest: String,
+    expires_at: i64,
+    #[serde(default)]
+    issuer: Option<String>,
+    signature: String,
+}
+
+fn main() {
+    match run() {
+        Ok(rendered) => println!("{rendered}"),
+        Err(err) => {
+            let payload = json!({
+                "truth_label": "b3_system_intent_rust_dark_entrypoint",
+                "ok": false,
+                "live": false,
+                "os_actuated": false,
+                "completes_effect": false,
+                "completes_host_effect": false,
+                "error_kind": err.kind,
+            });
+            println!("{}", payload);
+            eprintln!("hub_system_intent_dispatch_unavailable: {}", err.kind);
+            std::process::exit(2);
+        }
+    }
+}
+
+fn run() -> Result<String, CliError> {
+    let args: Vec<String> = env::args().collect();
+    if args.get(1).map(String::as_str) != Some("dispatch") {
+        return Err(CliError::new("bad_args"));
+    }
+    if !flag_enabled_from(env::var(FLAG).ok().as_deref()) {
+        return Err(CliError::new("flag_disabled"));
+    }
+
+    let db_path = arg_value(&args, "--db").ok_or(CliError::new("bad_args"))?;
+    let input = IntentInput {
+        intent_id: arg_value(&args, "--intent-id").ok_or(CliError::new("bad_args"))?,
+        action: parse_action(&arg_value(&args, "--action").ok_or(CliError::new("bad_args"))?)?,
+        actor_id: arg_value(&args, "--actor-id").ok_or(CliError::new("bad_args"))?,
+        actor_kind: parse_owner_kind(
+            &arg_value(&args, "--actor-kind").ok_or(CliError::new("bad_args"))?,
+        )?,
+        target_ref: arg_value(&args, "--target-ref"),
+        reason: arg_value(&args, "--reason"),
+        lease_ttl_ms: arg_value(&args, "--lease-ttl-ms").and_then(|v| v.parse::<i64>().ok()),
+    };
+    let now_ms = arg_value(&args, "--now-ms")
+        .and_then(|v| v.parse::<i64>().ok())
+        .unwrap_or_else(now_ms);
+    let db = Db::open_hub(&db_path).map_err(|_| CliError::new("init_failed"))?;
+    let ep = SystemIntentEntrypoint::with_execution_enabled(OsIntentExecutor::production_default());
+
+    let outcome = match arg_value(&args, "--approval-json") {
+        Some(approval_path) => {
+            let vk_path = arg_value(&args, "--operator-vk-path")
+                .or_else(|| env::var(friday_hub::operator_vk::OPERATOR_VK_PATH_ENV).ok())
+                .filter(|p| !p.trim().is_empty())
+                .ok_or(CliError::new("operator_vk_unprovisioned"))?;
+            let operator_vk = load_operator_vk_from_path(Path::new(vk_path.trim()))
+                .map_err(|_| CliError::new("operator_vk_malformed"))?;
+            let approval = read_approval(Some(&approval_path))?;
+            ep.dispatch_with_approval(db.conn(), &input, &approval, &operator_vk, now_ms)
+                .map_err(|_| CliError::new("dispatch_failed"))?
+        }
+        None => ep
+            .dispatch(db.conn(), &input, now_ms)
+            .map_err(|_| CliError::new("dispatch_failed"))?,
+    };
+
+    render(input.action, outcome)
+}
+
+fn flag_enabled_from(value: Option<&str>) -> bool {
+    value.map(str::trim) == Some("1")
+}
+
+fn parse_action(value: &str) -> Result<IntentAction, CliError> {
+    IntentAction::parse(value).map_err(|_| CliError::new("bad_args"))
+}
+
+fn parse_owner_kind(value: &str) -> Result<OwnerKind, CliError> {
+    OwnerKind::parse(value).map_err(|_| CliError::new("bad_args"))
+}
+
+fn read_approval(path: Option<&str>) -> Result<CanonicalApproval, CliError> {
+    let approval_json = match path {
+        Some(path) => std::fs::read_to_string(path).map_err(|_| CliError::new("bad_args"))?,
+        None => {
+            let mut buf = String::new();
+            std::io::stdin()
+                .read_to_string(&mut buf)
+                .map_err(|_| CliError::new("bad_args"))?;
+            buf
+        }
+    };
+    let signed: SignedApprovalIn =
+        serde_json::from_str(approval_json.trim()).map_err(|_| CliError::new("bad_approval"))?;
+    Ok(CanonicalApproval {
+        decision: parse_decision(&signed.decision).ok_or(CliError::new("bad_approval"))?,
+        approval_id: signed.approval_id,
+        action_digest: signed.action_digest,
+        expires_at: Some(signed.expires_at),
+        issuer: Some(
+            signed
+                .issuer
+                .unwrap_or_else(|| CANONICAL_GATE_ISSUER.to_string()),
+        ),
+        signature: Some(signed.signature),
+    })
+}
+
+fn parse_decision(value: &str) -> Option<ApprovalDecision> {
+    match value {
+        "approved" => Some(ApprovalDecision::Approved),
+        "denied" => Some(ApprovalDecision::Denied),
+        _ => None,
+    }
+}
+
+fn render(action: IntentAction, outcome: DispatchOutcome) -> Result<String, CliError> {
+    let status = outcome.result.status;
+    let message = outcome.result.message.clone();
+    let payload = json!({
+        "truth_label": "b3_system_intent_rust_dark_entrypoint",
+        "ok": true,
+        "live": false,
+        "db_writes": true,
+        "os_actuated": false,
+        "completes_effect": false,
+        "completes_host_effect": false,
+        "action": action.as_str(),
+        "status": status.as_str(),
+        "dry_run": outcome.dry_run,
+        "execution_deferred": outcome.execution_deferred,
+        "control_lease_id": outcome.result.control_lease_id,
+        "gate_reason": outcome.result.gate_reason,
+        "message": message,
+    });
+    let rendered =
+        serde_json::to_string(&payload).map_err(|_| CliError::new("serialize_failed"))?;
+    reject_forbidden_output(&rendered)?;
+    Ok(rendered)
+}
+
+fn reject_forbidden_output(rendered: &str) -> Result<(), CliError> {
+    friday_hub::refs_guard::reject_forbidden_output(
+        rendered,
+        &[
+            "clipboard:",
+            "notification body",
+            "raw_output",
+            "screenshot_base64",
+        ],
+    )
+    .map_err(|_| CliError::new("output_guard"))
+}
+
+fn arg_value(args: &[String], name: &str) -> Option<String> {
+    args.windows(2)
+        .find_map(|pair| (pair[0] == name).then(|| pair[1].clone()))
+        .or_else(|| {
+            let prefix = format!("{name}=");
+            args.iter()
+                .find_map(|arg| arg.strip_prefix(&prefix).map(str::to_string))
+        })
+}
+
+fn now_ms() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as i64)
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn flag_matcher_is_exact_one_default_off() {
+        assert!(!flag_enabled_from(None));
+        assert!(!flag_enabled_from(Some("")));
+        assert!(!flag_enabled_from(Some("true")));
+        assert!(!flag_enabled_from(Some("0")));
+        assert!(!flag_enabled_from(Some("2")));
+        assert!(flag_enabled_from(Some("1")));
+        assert!(flag_enabled_from(Some(" 1 ")));
+    }
+}

--- a/rust-core/crates/friday-hub/tests/system_intent_dispatch_cli.rs
+++ b/rust-core/crates/friday-hub/tests/system_intent_dispatch_cli.rs
@@ -1,0 +1,194 @@
+//! B3 system-intent DARK CLI tests.
+//!
+//! The CLI reaches the Rust system-intent domain layer behind a default-off flag.
+//! It never signs, never wires a host backend, and never reports a completed OS
+//! effect for dry-run/unavailable execution.
+
+use std::process::Command;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use friday_core::gate::{
+    canonical_approval_signature_bytes, ApprovalDecision, CanonicalApproval, CANONICAL_GATE_ISSUER,
+};
+use friday_crypto::{OperatorSigningKey, OperatorVerifyingKey};
+use friday_hub::system_intent::{intent_action_digest, IntentInput, DRY_RUN_OBSERVED_MARKER};
+use friday_storage::system_intent::{IntentAction, IntentStatus, OwnerKind};
+use friday_storage::Db;
+use serde_json::Value;
+
+const FLAG: &str = "FRIDAY_SYSTEM_INTENT_RUST_ENTRYPOINT";
+const NOW: i64 = 1_000;
+const FUTURE: i64 = 5_000_000_000_000;
+
+static C: AtomicU64 = AtomicU64::new(0);
+
+fn temp_path(tag: &str) -> std::path::PathBuf {
+    std::env::temp_dir().join(format!(
+        "friday-system-intent-cli-{}-{}-{}",
+        std::process::id(),
+        tag,
+        C.fetch_add(1, Ordering::Relaxed)
+    ))
+}
+
+fn base_cmd(db_path: &str, intent_id: &str, action: &str) -> Command {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_hub_system_intent_dispatch"));
+    cmd.arg("dispatch")
+        .arg("--db")
+        .arg(db_path)
+        .arg("--intent-id")
+        .arg(intent_id)
+        .arg("--action")
+        .arg(action)
+        .arg("--actor-id")
+        .arg("api-1")
+        .arg("--actor-kind")
+        .arg("api")
+        .arg("--now-ms")
+        .arg(NOW.to_string());
+    cmd
+}
+
+fn operator() -> (OperatorSigningKey, OperatorVerifyingKey) {
+    let sk = OperatorSigningKey::generate();
+    let vk = sk.verifying_key();
+    (sk, vk)
+}
+
+fn vk_hex(vk: &OperatorVerifyingKey) -> String {
+    vk.to_bytes()
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect()
+}
+
+fn write_vk(path: &std::path::Path, vk: &OperatorVerifyingKey) {
+    std::fs::write(path, vk_hex(vk)).unwrap();
+}
+
+fn launch_app_input(intent_id: &str) -> IntentInput {
+    IntentInput {
+        intent_id: intent_id.to_string(),
+        action: IntentAction::LaunchApp,
+        actor_id: "api-1".into(),
+        actor_kind: OwnerKind::Api,
+        target_ref: Some("com.apple.Safari".into()),
+        reason: None,
+        lease_ttl_ms: None,
+    }
+}
+
+fn ed_approval(inp: &IntentInput, sk: &OperatorSigningKey, approval_id: &str) -> CanonicalApproval {
+    let mut approval = CanonicalApproval {
+        decision: ApprovalDecision::Approved,
+        approval_id: approval_id.to_string(),
+        action_digest: intent_action_digest(inp),
+        expires_at: Some(FUTURE),
+        issuer: Some(CANONICAL_GATE_ISSUER.to_string()),
+        signature: None,
+    };
+    approval.signature = Some(
+        sk.sign(&canonical_approval_signature_bytes(&approval))
+            .to_hex(),
+    );
+    approval
+}
+
+fn write_approval(path: &std::path::Path, approval: &CanonicalApproval) {
+    let body = serde_json::json!({
+        "decision": "approved",
+        "approval_id": approval.approval_id,
+        "action_digest": approval.action_digest,
+        "expires_at": approval.expires_at.unwrap(),
+        "issuer": approval.issuer,
+        "signature": approval.signature,
+    });
+    std::fs::write(path, body.to_string()).unwrap();
+}
+
+#[test]
+fn flag_off_fails_closed_without_creating_db() {
+    let db_path = temp_path("flag-off.sqlite");
+    let output = base_cmd(db_path.to_str().unwrap(), "intent-flag-off", "snapshot")
+        .env_remove(FLAG)
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    assert!(!db_path.exists(), "flag-off must fail before opening a DB");
+    let value: Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(
+        value["truth_label"],
+        "b3_system_intent_rust_dark_entrypoint"
+    );
+    assert_eq!(value["ok"], false);
+    assert_eq!(value["error_kind"], "flag_disabled");
+    assert_eq!(value["os_actuated"], false);
+}
+
+#[test]
+fn flag_on_dispatches_snapshot_as_dry_run_unavailable_not_completed() {
+    let db_path = temp_path("snapshot.sqlite");
+    let output = base_cmd(db_path.to_str().unwrap(), "intent-snapshot", "snapshot")
+        .env(FLAG, "1")
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let value: Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(
+        value["truth_label"],
+        "b3_system_intent_rust_dark_entrypoint"
+    );
+    assert_eq!(value["ok"], true);
+    assert_eq!(value["live"], false);
+    assert_eq!(value["action"], "snapshot");
+    assert_eq!(value["status"], "unavailable");
+    assert_eq!(value["dry_run"], true);
+    assert_eq!(value["os_actuated"], false);
+    assert_eq!(value["completes_effect"], false);
+    assert_eq!(value["message"], DRY_RUN_OBSERVED_MARKER);
+
+    let db = Db::open_hub(db_path.to_str().unwrap()).unwrap();
+    let result = friday_storage::system_intent::get_intent_result(db.conn(), "intent-snapshot")
+        .unwrap()
+        .unwrap();
+    assert_eq!(result.status, IntentStatus::Unavailable);
+}
+
+#[test]
+fn valid_operator_approval_authorizes_launch_app_but_still_dry_runs() {
+    let db_path = temp_path("launch.sqlite");
+    let vk_path = temp_path("operator.vk");
+    let approval_path = temp_path("approval.json");
+    let (sk, vk) = operator();
+    write_vk(&vk_path, &vk);
+    let input = launch_app_input("intent-launch");
+    write_approval(&approval_path, &ed_approval(&input, &sk, "approval-launch"));
+
+    let output = base_cmd(db_path.to_str().unwrap(), "intent-launch", "launch_app")
+        .env(FLAG, "1")
+        .arg("--target-ref")
+        .arg("com.apple.Safari")
+        .arg("--operator-vk-path")
+        .arg(vk_path)
+        .arg("--approval-json")
+        .arg(approval_path)
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let value: Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(value["ok"], true);
+    assert_eq!(value["action"], "launch_app");
+    assert_eq!(value["status"], "unavailable");
+    assert_eq!(value["dry_run"], true);
+    assert_eq!(value["execution_deferred"], false);
+    assert_eq!(value["os_actuated"], false);
+    assert_eq!(value["completes_effect"], false);
+    assert_eq!(value["message"], DRY_RUN_OBSERVED_MARKER);
+    assert!(value["control_lease_id"].as_str().is_some());
+
+    let db = Db::open_hub(db_path.to_str().unwrap()).unwrap();
+    let approvals =
+        friday_storage::system_intent::list_approval_records(db.conn(), "intent-launch").unwrap();
+    assert_eq!(approvals.len(), 1);
+    assert_eq!(approvals[0].decision.as_str(), "allow");
+}


### PR DESCRIPTION
## Summary
- add a default-off `FRIDAY_SYSTEM_INTENT_RUST_ENTRYPOINT` Hub CLI that reaches the Rust system-intent domain/storage path
- compose the existing Ed25519 verify-only operator approval path without reading or minting signing keys
- record honest dry-run/unavailable evidence for OS-affecting intents and never report a completed host effect
- register the flag in the production flag manifest with loop-e2e coverage

## Truth label
- B3 companion/system-intent residue: built-DARK only
- no product route, no real OS actuation backend, no live companion execution, no GO-LIVE flip
- operator signatures remain operator-only; this only verifies a supplied public key + approval artifact

## Verification
- `cargo fmt --all -- --check`
- `cargo test -p friday-hub --test system_intent_dispatch_cli -- --nocapture`
- `cargo test -p friday-hub system_intent -- --nocapture`
- `cargo check -p friday-hub --bin hub_system_intent_dispatch`
- `cargo clippy -p friday-hub --bin hub_system_intent_dispatch -- -D warnings`
- `node scripts/ci/verify-prod-flag-tests.mjs`
- `git diff --check`

Prod source was re-pinned clean at `c426783546544681670ead8ad6490057307bae27`; no prod hub restart.