### PR TITLE
Surface D20 worktree batch pause reasons

### DIFF
--- a/rust-core/crates/friday-hub/src/bin/hub_d20_signed_batch_worktree.rs
+++ b/rust-core/crates/friday-hub/src/bin/hub_d20_signed_batch_worktree.rs
@@ -174,12 +174,13 @@ fn run() -> Result<String, BridgeError> {
             "batch_sign_id": batch.batch_sign_id,
             "audit_chain_verified": audit_chain_verified,
         }),
-        D20WorktreeBatchOutcome::RequiresApproval => json!({
+        D20WorktreeBatchOutcome::RequiresApproval { reason } => json!({
             "truth_label": "d20_worktree_signed_batch_artifact",
             "proof_only": true,
             "ok": true,
             "executed": false,
             "result_status": "requires_approval",
+            "reason": reason,
             "batch_sign_id": batch.batch_sign_id,
             "audit_chain_verified": audit_chain_verified,
         }),

--- a/rust-core/crates/friday-hub/src/lib.rs
+++ b/rust-core/crates/friday-hub/src/lib.rs
@@ -3573,7 +3573,7 @@ pub(crate) enum GateDispatch {
 pub enum D20WorktreeBatchOutcome {
     Executed { action: String, summary: String },
     ExecError { reason: String },
-    RequiresApproval,
+    RequiresApproval { reason: String },
     Denied { reason: String },
     Unregistered { action: String },
 }
@@ -4178,20 +4178,57 @@ pub fn d20_dispatch_signed_batch_artifact_in_worktree(
     policy: &RunPolicy,
     now_ms: i64,
 ) -> Result<D20WorktreeBatchOutcome, StorageError> {
-    let outcome = d20_dispatch_signed_batch_in_worktree(
-        conn, executor, raw, vk, batch, scope, policy, now_ms,
-    )?;
-    Ok(match outcome {
-        GateDispatch::Executed(receipt) => D20WorktreeBatchOutcome::Executed {
-            action: receipt.action,
-            summary: receipt.summary,
+    if policy.is_tool_disabled(&raw.action) {
+        return Ok(D20WorktreeBatchOutcome::Denied {
+            reason: format!("tool_disabled_for_run:{}", raw.action),
+        });
+    }
+    let request = match build_request_with_policy(raw, policy) {
+        Ok(request) => request,
+        Err(ToolError::UnknownTool(action)) => {
+            return Ok(D20WorktreeBatchOutcome::Unregistered { action });
+        }
+    };
+    if !request.mutating() {
+        return Ok(D20WorktreeBatchOutcome::Denied {
+            reason: format!(
+                "dial_worktree_batch_requires_mutating_action:{}",
+                raw.action
+            ),
+        });
+    }
+    if policy.is_read_only() {
+        return Ok(D20WorktreeBatchOutcome::Denied {
+            reason: format!("run_is_read_only:{}", raw.action),
+        });
+    }
+
+    let record =
+        authorize_reversible_batch_in_worktree(conn, &request, Some(batch), vk, now_ms, scope)?;
+    Ok(match record.decision {
+        GateDecision::Allow => match executor.execute_with_usage(&raw.action, &raw.params) {
+            Ok((receipt, usage)) => {
+                if let Some(usage) = usage.as_ref() {
+                    let run_id = policy
+                        .action_context()
+                        .and_then(|ctx| ctx.run_id.as_deref());
+                    friday_storage::record_tool_usage(conn, usage, run_id, now_ms)?;
+                }
+                D20WorktreeBatchOutcome::Executed {
+                    action: receipt.action,
+                    summary: receipt.summary,
+                }
+            }
+            Err(err) => D20WorktreeBatchOutcome::ExecError {
+                reason: err.to_string(),
+            },
         },
-        GateDispatch::ExecError(err) => D20WorktreeBatchOutcome::ExecError {
-            reason: err.to_string(),
+        GateDecision::RequiresApproval => D20WorktreeBatchOutcome::RequiresApproval {
+            reason: record.reason,
         },
-        GateDispatch::RequiresApproval => D20WorktreeBatchOutcome::RequiresApproval,
-        GateDispatch::Denied(reason) => D20WorktreeBatchOutcome::Denied { reason },
-        GateDispatch::Unregistered(action) => D20WorktreeBatchOutcome::Unregistered { action },
+        GateDecision::Deny => D20WorktreeBatchOutcome::Denied {
+            reason: record.reason,
+        },
     })
 }
 

--- a/rust-core/crates/friday-hub/tests/d20_signed_batch_worktree_cli.rs
+++ b/rust-core/crates/friday-hub/tests/d20_signed_batch_worktree_cli.rs
@@ -287,6 +287,10 @@ fn cli_pauses_irreversible_member_before_executor() {
     assert_eq!(json["ok"], true);
     assert_eq!(json["executed"], false);
     assert_eq!(json["result_status"], "requires_approval");
+    assert_eq!(
+        json["reason"],
+        "dial_worktree_irreversible_requires_single_approval"
+    );
     assert!(
         !workspace.join("should_not_exist").exists(),
         "irreversible run_command must pause before executor"
@@ -339,9 +343,67 @@ fn cli_pauses_out_of_worktree_member_before_executor() {
     assert_eq!(json["ok"], true);
     assert_eq!(json["executed"], false);
     assert_eq!(json["result_status"], "requires_approval");
+    assert_eq!(json["reason"], "dial_worktree_resource_out_of_scope");
     assert!(
         !outside_target.exists(),
         "out-of-worktree write must pause before executor"
+    );
+    assert_eq!(audit_count(&db), 0);
+    assert_eq!(consumed_count(&db), 0);
+}
+
+#[test]
+fn cli_reports_never_revertable_workspace_reason_refs_only() {
+    let db_path = temp_db("never-revertable");
+    let db = Db::open_hub(&db_path).unwrap();
+    let workspace = temp_path("never-revertable-workspace");
+    std::fs::create_dir_all(&workspace).unwrap();
+    let never_revertable_dir =
+        std::path::Path::new(&std::env::var("HOME").unwrap()).join(".friday");
+    std::fs::create_dir_all(&never_revertable_dir).unwrap();
+    let never_revertable_target = never_revertable_dir.join("d20-never-revertable.txt");
+    let _ = std::fs::remove_file(&never_revertable_target);
+
+    let action = raw(
+        "write_file",
+        &[
+            ("path", "~/.friday/d20-never-revertable.txt"),
+            ("content", "nope"),
+        ],
+    );
+    let request = request_for(&action);
+    let (sk, vk) = operator();
+    let vk_path = temp_path("never-revertable.vk");
+    std::fs::write(&vk_path, vk_hex(&vk)).unwrap();
+    let batch = signed_batch(&request, &sk, "d20-cli-never-revertable");
+    let signed_path = temp_path("never-revertable-signed.json");
+    write_signed_batch(&signed_path, &batch);
+    let action_path = temp_path("never-revertable-action.json");
+    write_action(&action_path, &action);
+
+    let output = run_cli(
+        &db_path,
+        &workspace,
+        &vk_path,
+        &signed_path,
+        &action_path,
+        NOW,
+    );
+    assert!(
+        output.status.success(),
+        "stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let json = parse_stdout(&output);
+    assert_eq!(json["truth_label"], "d20_worktree_signed_batch_artifact");
+    assert_eq!(json["proof_only"], true);
+    assert_eq!(json["ok"], true);
+    assert_eq!(json["executed"], false);
+    assert_eq!(json["result_status"], "requires_approval");
+    assert_eq!(json["reason"], "dial_worktree_never_revertable_path");
+    assert!(
+        !never_revertable_target.exists(),
+        "never-revertable target must pause before executor"
     );
     assert_eq!(audit_count(&db), 0);
     assert_eq!(consumed_count(&db), 0);


### PR DESCRIPTION
## Summary
- Surface refs-only pause reason when the D20 signed-batch worktree artifact consumer returns requires_approval.
- Keep existing fail-closed behavior for irreversible, out-of-worktree, and never-revertable targets.
- Add CLI coverage for irreversible, out-of-worktree, and home-dot-friday never-revertable pause reasons.

## Verification
- cargo fmt --all -- --check
- cargo test -p friday-hub --test d20_signed_batch_worktree_cli -- --nocapture
- cargo check -p friday-hub --bin hub_d20_signed_batch_worktree
- git diff --check
- cargo clippy -p friday-hub --bin hub_d20_signed_batch_worktree -- -D warnings
- cargo test -p friday-hub d20_worktree_batch_driver -- --nocapture
- cargo test -p friday-hub d20_batch_authz_mode -- --nocapture

## Truth boundary
- Diagnostic/efficiency hardening only: this does not widen any D20 auto-execution path.
- Hub still verifies only; it never reads or mints operator signatures.
- Existing operator-signed artifact was proven executable only in a reversible tmp worktree with a fresh hub DB; the original home-dot-friday package correctly pauses as never-revertable.
- No GO-LIVE gate is newly satisfied; v1 remains NO-GO.