### PR TITLE
Wire system intent route to Rust courier

### DIFF
--- a/docs/ops/prod-flags-manifest.json
+++ b/docs/ops/prod-flags-manifest.json
@@ -253,14 +253,14 @@
       "flag": "FRIDAY_SYSTEM_INTENT_RUST_ENTRYPOINT",
       "process": "rust-ws-wrapper",
       "prod_state": "dark",
-      "closes_loop": "With the flag ON, a Hub-owned system-intent proof entrypoint reaches the Rust system-intent domain layer and records refs-only request/result rows through the production dry-run/unavailable OS executor. With the flag OFF it fails closed before opening a DB. Even with a valid operator Ed25519 approval for an OS-affecting intent, the entrypoint reports unavailable dry-run evidence and never completes or actuates the host effect.",
+      "closes_loop": "With the flag ON, a Hub-owned system-intent proof entrypoint reaches the Rust system-intent domain layer and records refs-only request/result rows through the production dry-run/unavailable OS executor; the product POST /v1/system/intents route can also courier requests to that Rust entrypoint instead of the retired TS executor. With the flag OFF it fails closed before opening a DB and the product route remains on today's 503 retirement path. Even with a valid operator Ed25519 approval for an OS-affecting intent, the entrypoint reports unavailable dry-run evidence and never completes or actuates the host effect.",
       "coverage": "loop-e2e",
       "e2e_test": "rust-core/crates/friday-hub/tests/system_intent_dispatch_cli.rs::valid_operator_approval_authorizes_launch_app_but_still_dry_runs",
       "additional_e2e_tests": [
         "rust-core/crates/friday-hub/tests/system_intent_dispatch_cli.rs::flag_off_fails_closed_without_creating_db",
         "rust-core/crates/friday-hub/tests/system_intent_dispatch_cli.rs::flag_on_dispatches_snapshot_as_dry_run_unavailable_not_completed"
       ],
-      "notes": "Built-dark B3 companion/system-intent Rust entrypoint. The CLI composes the existing system-intent domain, m0026 storage substrate, and Ed25519 verify-only approval path; it does not add a product route, does not read or mint signing keys, and does not wire a real OS actuation backend. Honest boundary: this is not live companion OS execution and not a GO-LIVE flip."
+      "notes": "Built-dark B3 companion/system-intent Rust entrypoint plus product courier. The CLI composes the existing system-intent domain, m0026 storage substrate, and Ed25519 verify-only approval path; the TS route strips client-supplied approval material and binds actor identity from the request principal before couriering. This does not read or mint signing keys and does not wire a real OS actuation backend. Honest boundary: this is not live companion OS execution and not a GO-LIVE flip."
     },
     {
       "flag": "FRIDAY_WEB_FETCH_ENABLED",

--- a/src/api/http/routes/friday-system-routes.ts
+++ b/src/api/http/routes/friday-system-routes.ts
@@ -55,6 +55,15 @@ export interface FridaySystemRoutesDeps {
   intents: {
     execute(req: FridayExecuteSystemIntentRequest): Promise<FridayExecuteSystemIntentResponse>;
   };
+  /**
+   * B3 system-intent Rust product courier (DARK): when true, POST /v1/system/intents
+   * calls the Rust-owned refs-only entrypoint instead of the retired TS executor.
+   * Default false/unset preserves today's 503 fail-closed posture.
+   */
+  systemIntentViaRust?: boolean;
+  executeSystemIntentViaRust?: (
+    req: FridayExecuteSystemIntentRequest,
+  ) => Promise<FridayExecuteSystemIntentResponse>;
   approvals: {
     list(query: FridayListSystemApprovalsQuery): FridayListSystemApprovalsResponse;
     update(
@@ -275,6 +284,13 @@ export function createFridaySystemRoutes(
         requireIdempotencyKey(body);
         const { canonicalApproval: _ignoredCanonicalApproval, ...safeBody } =
           body as FridayExecuteSystemIntentRequest & { canonicalApproval?: unknown };
+        if (deps.systemIntentViaRust === true && deps.executeSystemIntentViaRust) {
+          return deps.executeSystemIntentViaRust({
+            ...safeBody,
+            actorId: ctx.principal?.principalId ?? "system-intent-api",
+            actorKind: "api",
+          });
+        }
         assertSystemIntentTestOracleAllowed(deps);
         return deps.intents.execute(safeBody);
       },

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -320,5 +320,13 @@ export type {
   FridayD20SignedBatchWorktreeReceipt,
   FridayD20SignedBatchWorktreeService,
 } from "./mission-spine/friday-rust-hub-d20-signed-batch-worktree-service.js";
+export {
+  FRIDAY_SYSTEM_INTENT_RUST_FLAG,
+  createFridayRustHubSystemIntentService,
+} from "./mission-spine/friday-rust-hub-system-intent-service.js";
+export type {
+  CreateFridayRustHubSystemIntentServiceOptions,
+  FridayRustHubSystemIntentService,
+} from "./mission-spine/friday-rust-hub-system-intent-service.js";
 export { createFridayDeterministicPipelineRuntime } from "./runtime/friday-deterministic-pipeline-runtime.js";
 export type { CreateFridayDeterministicPipelineRuntimeDeps } from "./runtime/friday-deterministic-pipeline-runtime.js";

--- a/src/api/mission-spine/friday-rust-hub-system-intent-service.ts
+++ b/src/api/mission-spine/friday-rust-hub-system-intent-service.ts
@@ -1,0 +1,211 @@
+import { execFile } from "node:child_process";
+import { existsSync, statSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+
+import { FridayDomainError } from "#errors";
+import type { FridaySystemIntentAction, FridaySystemIntentResult } from "../../system/model/friday-system.types.js";
+import type { FridayExecuteSystemIntentRequest, FridayExecuteSystemIntentResponse } from "../model/friday-api-system.types.js";
+
+const execFileAsync = promisify(execFile);
+
+export const FRIDAY_SYSTEM_INTENT_RUST_FLAG = "FRIDAY_SYSTEM_INTENT_RUST_ENTRYPOINT";
+
+export interface CreateFridayRustHubSystemIntentServiceOptions {
+  readonly repoRoot?: string;
+  readonly dbPath?: string;
+  readonly adapterBin?: string;
+  readonly timeoutMs?: number;
+  readonly nowMs?: () => number;
+}
+
+export interface FridayRustHubSystemIntentService {
+  execute(req: FridayExecuteSystemIntentRequest): Promise<FridayExecuteSystemIntentResponse>;
+}
+
+function unavailable(message: string): FridayDomainError {
+  return new FridayDomainError("SYSTEM_INTENT_RUST_ENTRYPOINT_UNAVAILABLE", message, {
+    httpStatus: 503,
+    details: {
+      surface: "service:system_intent_rust_entrypoint",
+      truthLabel: "b3_system_intent_rust_dark_entrypoint",
+    },
+  });
+}
+
+function readTimeoutMs(raw: string | undefined, fallback: number): number {
+  if (!raw) return fallback;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function resolveDefaultRepoRoot(): string {
+  const moduleDir = dirname(fileURLToPath(import.meta.url));
+  return resolve(moduleDir, "../../..");
+}
+
+function requireExistingFile(path: string | undefined, label: string): string {
+  const resolved = path ? resolve(path) : "";
+  if (!resolved || !existsSync(resolved) || !statSync(resolved).isFile()) {
+    throw unavailable(`${label} is not provisioned.`);
+  }
+  return resolved;
+}
+
+function stringField(value: unknown, field: string): string {
+  if (typeof value !== "string" || value.length === 0) {
+    throw unavailable(`System-intent bridge payload is missing ${field}.`);
+  }
+  return value;
+}
+
+function boolField(value: unknown, field: string): boolean {
+  if (typeof value !== "boolean") {
+    throw unavailable(`System-intent bridge payload is missing ${field}.`);
+  }
+  return value;
+}
+
+function optionalString(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function refsOnlyTarget(req: FridayExecuteSystemIntentRequest): string | undefined {
+  return (req.targetKind !== "url" ? req.target : undefined)
+    ?? req.appIdentifier
+    ?? req.windowId
+    ?? req.notificationId
+    ?? req.deviceId
+    ?? (req.projectPath ? `project:${req.projectPath}` : undefined);
+}
+
+function actorKind(req: FridayExecuteSystemIntentRequest): string {
+  return req.actorKind ?? "api";
+}
+
+function actorId(req: FridayExecuteSystemIntentRequest): string {
+  return req.actorId ?? `${actorKind(req)}:system-intent`;
+}
+
+function intentId(req: FridayExecuteSystemIntentRequest): string {
+  return `system-intent:${actorKind(req)}:${actorId(req)}:${req.idempotencyKey}`;
+}
+
+function parseReceipt(req: FridayExecuteSystemIntentRequest, payload: unknown, performedAt: string): FridayExecuteSystemIntentResponse {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    throw unavailable("System-intent bridge returned a non-object payload.");
+  }
+  const root = payload as Record<string, unknown>;
+  if (root.truth_label !== "b3_system_intent_rust_dark_entrypoint") {
+    throw unavailable("System-intent bridge returned the wrong truth label.");
+  }
+  const ok = boolField(root.ok, "ok");
+  const status = stringField(root.status, "status") as FridaySystemIntentResult["status"];
+  return {
+    result: {
+      id: intentId(req),
+      action: stringField(root.action, "action") as FridaySystemIntentAction,
+      status,
+      message: stringField(root.message, "message"),
+      performedAt,
+      controlLeaseId: optionalString(root.control_lease_id),
+      payload: {
+        truthLabel: "b3_system_intent_rust_dark_entrypoint",
+        ok,
+        live: boolField(root.live, "live"),
+        dryRun: boolField(root.dry_run, "dry_run"),
+        executionDeferred: boolField(root.execution_deferred, "execution_deferred"),
+        osActuated: boolField(root.os_actuated, "os_actuated"),
+        completesEffect: boolField(root.completes_effect, "completes_effect"),
+        completesHostEffect: boolField(root.completes_host_effect, "completes_host_effect"),
+        gateReason: optionalString(root.gate_reason),
+      },
+    },
+  };
+}
+
+export function createFridayRustHubSystemIntentService(
+  options: CreateFridayRustHubSystemIntentServiceOptions = {},
+): FridayRustHubSystemIntentService {
+  const repoRoot = resolve(
+    options.repoRoot ?? process.env.FRIDAY_REPO_ROOT ?? resolveDefaultRepoRoot(),
+  );
+  const rustCoreRoot = resolve(
+    process.env.FRIDAY_MISSION_SPINE_RUST_CORE_ROOT ?? join(repoRoot, "rust-core"),
+  );
+  const adapterBin = options.adapterBin ?? process.env.FRIDAY_SYSTEM_INTENT_RUST_BIN;
+  const dbPath = options.dbPath ?? process.env.FRIDAY_HUB_AGENT_RUN_DB_PATH;
+  const timeoutMs =
+    options.timeoutMs ?? readTimeoutMs(process.env.FRIDAY_SYSTEM_INTENT_RUST_TIMEOUT_MS, 120_000);
+  const nowMs = options.nowMs ?? (() => Date.now());
+
+  return {
+    async execute(req): Promise<FridayExecuteSystemIntentResponse> {
+      const db = requireExistingFile(dbPath, "Rust hub DB");
+      const args = [
+        "dispatch",
+        "--db",
+        db,
+        "--intent-id",
+        intentId(req),
+        "--action",
+        req.action,
+        "--actor-id",
+        actorId(req),
+        "--actor-kind",
+        actorKind(req),
+        "--now-ms",
+        String(nowMs()),
+      ];
+      const targetRef = refsOnlyTarget(req);
+      if (targetRef) {
+        args.push("--target-ref", targetRef);
+      }
+      if (req.reason) {
+        args.push("--reason", req.reason);
+      }
+      if (typeof req.leaseTtlMs === "number" && Number.isFinite(req.leaseTtlMs)) {
+        args.push("--lease-ttl-ms", String(Math.floor(req.leaseTtlMs)));
+      }
+
+      const command = adapterBin ?? "cargo";
+      const commandArgs = adapterBin
+        ? args
+        : [
+            "run",
+            "--quiet",
+            "--manifest-path",
+            join(rustCoreRoot, "Cargo.toml"),
+            "-p",
+            "friday-hub",
+            "--bin",
+            "hub_system_intent_dispatch",
+            "--",
+            ...args,
+          ];
+      let stdout = "";
+      try {
+        const result = await execFileAsync(command, commandArgs, {
+          cwd: repoRoot,
+          timeout: timeoutMs,
+          maxBuffer: 1024 * 1024,
+          env: {
+            ...process.env,
+            RUST_BACKTRACE: "0",
+            [FRIDAY_SYSTEM_INTENT_RUST_FLAG]: "1",
+          },
+        });
+        stdout = result.stdout;
+      } catch {
+        throw unavailable("System-intent bridge could not produce a refs-only receipt.");
+      }
+      try {
+        return parseReceipt(req, JSON.parse(stdout), new Date(nowMs()).toISOString());
+      } catch (err) {
+        if (err instanceof FridayDomainError) throw err;
+        throw unavailable("System-intent bridge returned invalid JSON.");
+      }
+    },
+  };
+}

--- a/src/hub/bootstrap/hub-helpers.ts
+++ b/src/hub/bootstrap/hub-helpers.ts
@@ -1962,6 +1962,8 @@ export interface FridayHubConfig {
   agentRunControlViaRust?: boolean;
   /** D20 W2 signed-batch worktree product entrypoint flag; default false / env fallback. */
   d20SignedBatchWorktreeViaRust?: boolean;
+  /** B3 system-intent Rust product courier flag; default false / env fallback. */
+  systemIntentViaRust?: boolean;
   /**
    * providers-bridge cut-over (DARK): master ON/OFF for routing the retired Tier-2
    * PROVIDER surfaces (`providers.detect` / `providers.doctor` / `providers.validate` /

--- a/src/hub/friday-hub-bootstrap.ts
+++ b/src/hub/friday-hub-bootstrap.ts
@@ -111,6 +111,7 @@ import {
   createFridayDeterministicPipelineRuntime,
   createFridayMissionAutoDispatchDriver,
   createFridayReflexRoutes,
+  createFridayRustHubSystemIntentService,
   getChannelPersona,
   hydrateChannelPersonaStore,
   RUST_ROUTE_CLAUDE_MODEL,
@@ -997,6 +998,23 @@ export function resolveD20SignedBatchWorktreeViaRust(
     return configValue;
   }
   const raw = (env.FRIDAY_D20_SIGNED_BATCH_WORKTREE_VIA_RUST ?? "").trim().toLowerCase();
+  return raw === "1" || raw === "true";
+}
+
+/**
+ * B3 system-intent Rust product courier (DARK): single source of truth resolving
+ * the TS system-intent route cutover from explicit config, else
+ * `FRIDAY_SYSTEM_INTENT_RUST_ENTRYPOINT`. The Rust side remains refs-only and
+ * dry-run/unavailable: no host OS action is completed or actuated.
+ */
+export function resolveSystemIntentViaRust(
+  configValue: boolean | undefined,
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  if (typeof configValue === "boolean") {
+    return configValue;
+  }
+  const raw = (env.FRIDAY_SYSTEM_INTENT_RUST_ENTRYPOINT ?? "").trim().toLowerCase();
   return raw === "1" || raw === "true";
 }
 
@@ -2503,6 +2521,8 @@ export async function createFridayHub(
           result: await systemService!.executeIntent(req),
         }),
       },
+      systemIntentViaRust: resolveSystemIntentViaRust(config.systemIntentViaRust),
+      executeSystemIntentViaRust: createFridayRustHubSystemIntentService().execute,
       approvals: {
         list: (query) => {
           const items = systemService!.listApprovalRules({

--- a/test/unit/api/http/routes/friday-system-routes.test.ts
+++ b/test/unit/api/http/routes/friday-system-routes.test.ts
@@ -15,6 +15,20 @@ function makeDeps(overrides?: Partial<FridaySystemRoutesDeps>): FridaySystemRout
     intents: {
       execute: vi.fn().mockResolvedValue({ result: { id: "intent-1", status: "completed" } }),
     },
+    executeSystemIntentViaRust: vi.fn().mockResolvedValue({
+      result: {
+        id: "system-intent:api:u-1:k-1",
+        action: "snapshot",
+        status: "unavailable",
+        message: "rust_system_action_dry_run_observed",
+        performedAt: "2026-03-06T00:00:00.000Z",
+        payload: {
+          truthLabel: "b3_system_intent_rust_dark_entrypoint",
+          osActuated: false,
+          completesEffect: false,
+        },
+      },
+    }),
     approvals: {
       list: vi.fn().mockReturnValue({ items: [], nextCursor: undefined }),
       update: vi.fn().mockReturnValue({ approval: { id: "approval-1", decision: "allow" } }),
@@ -184,6 +198,51 @@ describe("createFridaySystemRoutes", () => {
       url: "https://example.com",
       idempotencyKey: "k-1",
     });
+  });
+
+  it("routes intent execution through the Rust courier only when explicitly enabled", async () => {
+    const deps = makeDeps({
+      allowTestOnlySystemIntentExecution: false,
+      systemIntentViaRust: true,
+    });
+    const routes = createFridaySystemRoutes(deps);
+    const route = findRoute(routes, "system.intents.execute");
+
+    await route.handler(makeCtx({
+      body: {
+        action: "snapshot",
+        idempotencyKey: "k-1",
+        actorId: "client-forged",
+        actorKind: "agent",
+        canonicalApproval: {
+          decision: "approved",
+          actionDigest: "forged",
+        },
+      },
+    }));
+
+    expect(deps.intents.execute).not.toHaveBeenCalled();
+    expect(deps.executeSystemIntentViaRust).toHaveBeenCalledWith({
+      action: "snapshot",
+      idempotencyKey: "k-1",
+      actorId: "u-1",
+      actorKind: "api",
+    });
+  });
+
+  it("keeps intent execution fail-closed when the Rust courier flag is absent", async () => {
+    const deps = makeDeps({
+      allowTestOnlySystemIntentExecution: false,
+      systemIntentViaRust: false,
+    });
+    const routes = createFridaySystemRoutes(deps);
+
+    await expect(
+      findRoute(routes, "system.intents.execute").handler(
+        makeCtx({ body: { action: "snapshot", idempotencyKey: "k-1" } }),
+      ),
+    ).rejects.toMatchObject({ code: "TS_RUNTIME_SYSTEM_INTENT_RETIRED", httpStatus: 503 });
+    expect(deps.executeSystemIntentViaRust).not.toHaveBeenCalled();
   });
 
   it("parses approval list limit before delegating", async () => {

--- a/test/unit/api/mission-spine/friday-rust-hub-system-intent-service.test.ts
+++ b/test/unit/api/mission-spine/friday-rust-hub-system-intent-service.test.ts
@@ -1,0 +1,123 @@
+import { chmod, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { describe, expect, it } from "vitest";
+
+import {
+  createFridayRustHubSystemIntentService,
+} from "../../../../src/api/mission-spine/friday-rust-hub-system-intent-service.js";
+
+async function makeFakeAdapter(dir: string, recordPath: string): Promise<string> {
+  const adapter = join(dir, "fake-system-intent-adapter.mjs");
+  await writeFile(
+    adapter,
+    `#!/usr/bin/env node
+import { writeFileSync } from "node:fs";
+const args = process.argv.slice(2);
+writeFileSync(${JSON.stringify(recordPath)}, JSON.stringify({
+  args,
+  flag: process.env.FRIDAY_SYSTEM_INTENT_RUST_ENTRYPOINT
+}));
+const valueAfter = (name) => args[args.indexOf(name) + 1];
+console.log(JSON.stringify({
+  truth_label: "b3_system_intent_rust_dark_entrypoint",
+  ok: true,
+  live: false,
+  db_writes: true,
+  os_actuated: false,
+  completes_effect: false,
+  completes_host_effect: false,
+  action: valueAfter("--action"),
+  status: "unavailable",
+  dry_run: true,
+  execution_deferred: false,
+  control_lease_id: null,
+  gate_reason: null,
+  message: "rust_system_action_dry_run_observed"
+}));
+`,
+    "utf8",
+  );
+  await chmod(adapter, 0o755);
+  return adapter;
+}
+
+describe("createFridayRustHubSystemIntentService", () => {
+  it("bridges to the Rust CLI with an owner-bound intent id and refs-only receipt", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "friday-system-intent-bridge-"));
+    try {
+      const dbPath = join(dir, "hub.sqlite");
+      const recordPath = join(dir, "record.json");
+      await writeFile(dbPath, "", "utf8");
+      const adapterBin = await makeFakeAdapter(dir, recordPath);
+      const service = createFridayRustHubSystemIntentService({
+        repoRoot: dir,
+        dbPath,
+        adapterBin,
+        nowMs: () => 1_000,
+      });
+
+      const receipt = await service.execute({
+        action: "snapshot",
+        appIdentifier: "com.example.App",
+        targetKind: "url",
+        target: "https://example.com/target-url-not-forwarded",
+        url: "https://example.com/raw-url-not-forwarded",
+        actorId: "u-1",
+        actorKind: "api",
+        idempotencyKey: "idem-1",
+      });
+
+      expect(receipt.result).toMatchObject({
+        id: "system-intent:api:u-1:idem-1",
+        action: "snapshot",
+        status: "unavailable",
+        message: "rust_system_action_dry_run_observed",
+        performedAt: "1970-01-01T00:00:01.000Z",
+        payload: {
+          truthLabel: "b3_system_intent_rust_dark_entrypoint",
+          live: false,
+          dryRun: true,
+          osActuated: false,
+          completesEffect: false,
+          completesHostEffect: false,
+        },
+      });
+      const record = JSON.parse(await readFile(recordPath, "utf8")) as {
+        args: string[];
+        flag?: string;
+      };
+      expect(record.flag).toBe("1");
+      expect(record.args).toContain("--target-ref");
+      expect(record.args[record.args.indexOf("--target-ref") + 1]).toBe("com.example.App");
+      expect(record.args).not.toContain("https://example.com/raw-url-not-forwarded");
+      expect(record.args).not.toContain("https://example.com/target-url-not-forwarded");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("fails closed before spawning when the Rust hub DB is not provisioned", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "friday-system-intent-bridge-missing-db-"));
+    try {
+      const recordPath = join(dir, "record.json");
+      const adapterBin = await makeFakeAdapter(dir, recordPath);
+      const service = createFridayRustHubSystemIntentService({
+        repoRoot: dir,
+        dbPath: join(dir, "missing.sqlite"),
+        adapterBin,
+      });
+
+      await expect(
+        service.execute({ action: "snapshot", idempotencyKey: "idem-1" }),
+      ).rejects.toMatchObject({
+        code: "SYSTEM_INTENT_RUST_ENTRYPOINT_UNAVAILABLE",
+        httpStatus: 503,
+      });
+      expect(existsSync(recordPath)).toBe(false);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Add a default-off B3 system-intent TS->Rust courier service for `hub_system_intent_dispatch`.
- Route `POST /v1/system/intents` to the Rust-owned refs-only entrypoint only when `FRIDAY_SYSTEM_INTENT_RUST_ENTRYPOINT` / explicit config is enabled.
- Preserve the retired TS 503 path by default, strip client-supplied `canonicalApproval`, and bind Rust actor identity to the request principal instead of trusting body actor fields.
- Update the prod flag manifest truth-label for the product courier boundary.

## Validation
- `npx vitest run test/unit/api/http/routes/friday-system-routes.test.ts test/unit/api/mission-spine/friday-rust-hub-system-intent-service.test.ts` (30 tests)
- `npx tsc --noEmit --pretty false`
- `node scripts/ci/verify-prod-flag-tests.mjs`
- `npm run check:ts-runtime-retirement`
- `git diff --check`

## Truth labels
- Built-DARK B3 product courier only.
- Rust executor remains dry-run/unavailable and does not actuate or complete host OS effects.
- No signing key read/minting; Hub/TS route only verifies/couriers existing Rust behavior.
- Not strict organic, not GO-LIVE, not v1 done.
