### PR TITLE
Require workflow IDs for node runner correlation

### DIFF
--- a/src/workflows/engine/friday-workflow-node-executor.ts
+++ b/src/workflows/engine/friday-workflow-node-executor.ts
@@ -11,7 +11,7 @@ import type { FridayNodeCompletionVerification } from "../runtime/friday-workflo
 
 export interface FridayNodeExecutionInput {
   runId: UUID;
-  workflowId?: UUID;
+  workflowId: UUID;
   nodeId: string;
   attemptId: UUID;
   node: FridayWorkflowNode;

--- a/src/workflows/engine/friday-workflow-node-runner-facade.ts
+++ b/src/workflows/engine/friday-workflow-node-runner-facade.ts
@@ -99,7 +99,7 @@ export function createFridayWorkflowNodeRunnerFacade(
       const executionContext: FridayNodeExecutionContext = {
         executionId: input.attemptId,
         runId: input.runId,
-        workflowId: input.workflowId ?? input.runId,
+        workflowId: input.workflowId,
         nodeId: input.nodeId,
         attemptNumber: 1,
         node,

--- a/src/workflows/runtime/friday-workflow-runtime.ts
+++ b/src/workflows/runtime/friday-workflow-runtime.ts
@@ -1540,7 +1540,7 @@ export function createFridayWorkflowRuntime(
         if (result.output != null) {
           const gateResult = await acceptanceGate.evaluate({
             runId: input.runId,
-            workflowId: input.workflowId ?? input.runId,
+            workflowId: input.workflowId,
             artifactType: inferArtifactType(result.output),
             artifactData: result.output,
             policy: pipelineEnforceMode

--- a/test/unit/workflows/engine/friday-workflow-node-runner-facade.test.ts
+++ b/test/unit/workflows/engine/friday-workflow-node-runner-facade.test.ts
@@ -42,6 +42,7 @@ function makeMockLegacyExecutor() {
 function makeInput(overrides: Partial<FridayNodeExecutionInput> = {}): FridayNodeExecutionInput {
   return {
     runId: "run-1",
+    workflowId: "workflow-1",
     nodeId: "node-1",
     attemptId: "attempt-1",
     node: {
@@ -202,10 +203,16 @@ describe("A-003 FridayWorkflowNodeRunnerFacade", () => {
   describe("execution context construction", () => {
     it("passes runId, nodeId, and attemptId through", async () => {
       const { facade, pipeline } = makeFacade();
-      await facade.executeNode(makeInput({ runId: "r-42", nodeId: "n-7", attemptId: "att-99" }));
+      await facade.executeNode(makeInput({
+        runId: "r-42",
+        workflowId: "w-42",
+        nodeId: "n-7",
+        attemptId: "att-99",
+      }));
 
       const ctx = (pipeline.execute as ReturnType<typeof vi.fn>).mock.calls[0][0];
       expect(ctx.runId).toBe("r-42");
+      expect(ctx.workflowId).toBe("w-42");
       expect(ctx.nodeId).toBe("n-7");
       expect(ctx.executionId).toBe("att-99");
     });

--- a/test/unit/workflows/friday-workflow-node-executor.test.ts
+++ b/test/unit/workflows/friday-workflow-node-executor.test.ts
@@ -37,6 +37,7 @@ describe("FridayWorkflowNodeExecutor", () => {
   ): FridayNodeExecutionInput {
     return {
       runId: "run-1",
+      workflowId: "workflow-1",
       nodeId: node.id,
       attemptId: "att-1",
       node,


### PR DESCRIPTION
## Summary
- Require FridayNodeExecutionInput.workflowId so NodeRunner correlation never silently falls back to runId.
- Pass the exact workflow id into NodeRunner execution context and workflow acceptance gate.
- Update workflow executor/facade fixtures to prove the real workflow id is preserved.

## Validation
- ./node_modules/.bin/vitest run test/unit/workflows/engine/friday-workflow-node-runner-facade.test.ts test/unit/workflows/friday-workflow-node-executor.test.ts
- ./node_modules/.bin/tsc --noEmit --pretty false
- ./node_modules/.bin/vitest run test/unit/workflows/engine/friday-workflow-node-runner-facade.test.ts test/unit/workflows/engine/friday-workflow-deterministic-pipeline-regression.test.ts test/unit/workflows/runtime/friday-workflow-runtime.test.ts
- git diff --check

Truth labels: strict organic=0; this is a workflow correlation hardening PR, not a GO-LIVE flip and not operator-signature/organic proof.
