### PR TITLE
Run memory-spine route interop proof in CI

### DIFF
--- a/.github/workflows/rust-core.yml
+++ b/.github/workflows/rust-core.yml
@@ -9,10 +9,24 @@ on:
     paths:
       - "rust-core/**"
       - ".github/workflows/rust-core.yml"
+      - "src/api/http/routes/friday-memory-spine-routes.ts"
+      - "src/api/mission-spine/friday-memory-spine-dispatch-adapter.ts"
+      - "src/api/mission-spine/friday-rust-hub-agent-run-ws-sealed-client.ts"
+      - "test/interop/**"
+      - "package.json"
+      - "package-lock.json"
+      - "docs/ops/prod-flags-manifest.json"
   pull_request:
     paths:
       - "rust-core/**"
       - ".github/workflows/rust-core.yml"
+      - "src/api/http/routes/friday-memory-spine-routes.ts"
+      - "src/api/mission-spine/friday-memory-spine-dispatch-adapter.ts"
+      - "src/api/mission-spine/friday-rust-hub-agent-run-ws-sealed-client.ts"
+      - "test/interop/**"
+      - "package.json"
+      - "package-lock.json"
+      - "docs/ops/prod-flags-manifest.json"
 
 concurrency:
   group: rust-core-${{ github.ref }}
@@ -21,7 +35,7 @@ concurrency:
 jobs:
   rust-core:
     runs-on: ubuntu-latest
-    timeout-minutes: 25
+    timeout-minutes: 35
     defaults:
       run:
         working-directory: rust-core
@@ -98,3 +112,16 @@ jobs:
       - name: Test
         # The one live DeepSeek test is #[ignore]d, so this needs no network/secrets.
         run: cargo test --workspace
+      - name: Setup Node for sealed-client interop proof
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: 22
+          cache: npm
+      - name: Install sealed-client interop dependencies
+        working-directory: .
+        run: npm ci
+      - name: Build sealed-client interop runner
+        working-directory: .
+        run: node test/interop/build-sealed-client-runner.mjs
+      - name: Memory-spine TS route to Rust confirm proof
+        run: cargo test -p friday-hub interop_ts_memory_route_decision_confirms_real_rust_candidate --bin hub_agent_run_server -- --ignored --nocapture

--- a/docs/ops/prod-flags-manifest.json
+++ b/docs/ops/prod-flags-manifest.json
@@ -125,7 +125,7 @@
       "closes_loop": "The TS memory-spine routes (confirm/decision) forward to the Rust hub instead of the legacy TS path; the loop closes Rust-side.",
       "coverage": "destination-only",
       "e2e_test": "rust-core/crates/friday-hub/src/runtime.rs::memory_loop_end_to_end_extract_confirm_recall_closes_on_agent_run_ingress",
-      "notes": "CRITICAL FINDING: this routing flag's destination loop (memory confirm->recall) is proven Rust-side by the mapped test. Manual ignored interop proof `interop_ts_memory_route_decision_confirms_real_rust_candidate` now drives the real TS `/v1/memory-spine/decide` route handler -> real dispatch adapter -> real sealed client -> real Rust memory-confirm arm, confirming a seeded candidate and proving recallable DB state with zero token/provider spend. Honest remaining gap: this is controlled loopback proof requiring the prebuilt Node interop bundle, not organic/operator traffic and not a non-ignored PR-CI flag-on e2e."
+      "notes": "CRITICAL FINDING: this routing flag's destination loop (memory confirm->recall) is proven Rust-side by the mapped test. PR-CI also runs the bounded controlled-loopback interop proof `interop_ts_memory_route_decision_confirms_real_rust_candidate`: the workflow builds the Node sealed-client runner, then drives the real TS `/v1/memory-spine/decide` route handler -> real dispatch adapter -> real sealed client -> real Rust memory-confirm arm, confirming a seeded candidate and proving recallable DB state with zero token/provider spend. Honest remaining gap: this is not organic/operator-origin traffic and not a GO-LIVE gate-3 satisfying flag-on e2e."
     },
     {
       "flag": "FRIDAY_MISSION_SPINE_ROUTES_VIA_RUST",

--- a/rust-core/crates/friday-hub/src/bin/hub_agent_run_server.rs
+++ b/rust-core/crates/friday-hub/src/bin/hub_agent_run_server.rs
@@ -122,7 +122,7 @@
 
 use std::env;
 use std::io::{Read, Write};
-use std::net::{Ipv4Addr, SocketAddr, TcpListener};
+use std::net::{Ipv4Addr, SocketAddr, TcpListener, TcpStream};
 use std::path::PathBuf;
 use std::thread;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
@@ -1168,6 +1168,99 @@ impl AgentRunWsListener {
         provider_workspace_dispatch_enabled: bool,
     ) -> Result<usize, TransportError> {
         let (stream, _peer) = self.listener.accept()?;
+        Self::serve_accepted_stream(
+            stream,
+            server_kp,
+            runtime,
+            owner_allowlist,
+            peer_allowlist,
+            run_control_enabled,
+            mission_bound_run_enabled,
+            mission_intake_enabled,
+            mission_spine_dispatch_enabled,
+            memory_confirm_enabled,
+            run_outcome_learning_confirm_enabled,
+            token_surface_enabled,
+            provider_workspace_dispatch_enabled,
+        )
+    }
+
+    #[cfg(test)]
+    #[allow(clippy::too_many_arguments)]
+    fn accept_one_with_timeout<T: Transport>(
+        &self,
+        timeout: Duration,
+        server_kp: &DeviceKeypair,
+        runtime: &HubRuntime<T>,
+        owner_allowlist: &[String],
+        peer_allowlist: &[[u8; X25519_PUBKEY_LEN]],
+        run_control_enabled: bool,
+        mission_bound_run_enabled: bool,
+        mission_intake_enabled: bool,
+        mission_spine_dispatch_enabled: bool,
+        memory_confirm_enabled: bool,
+        run_outcome_learning_confirm_enabled: bool,
+        token_surface_enabled: bool,
+        provider_workspace_dispatch_enabled: bool,
+    ) -> Result<usize, TransportError> {
+        self.listener.set_nonblocking(true)?;
+        let deadline = std::time::Instant::now() + timeout;
+        loop {
+            match self.listener.accept() {
+                Ok((stream, _peer)) => {
+                    self.listener.set_nonblocking(false)?;
+                    stream.set_nonblocking(false)?;
+                    return Self::serve_accepted_stream(
+                        stream,
+                        server_kp,
+                        runtime,
+                        owner_allowlist,
+                        peer_allowlist,
+                        run_control_enabled,
+                        mission_bound_run_enabled,
+                        mission_intake_enabled,
+                        mission_spine_dispatch_enabled,
+                        memory_confirm_enabled,
+                        run_outcome_learning_confirm_enabled,
+                        token_surface_enabled,
+                        provider_workspace_dispatch_enabled,
+                    );
+                }
+                Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                    if std::time::Instant::now() >= deadline {
+                        self.listener.set_nonblocking(false)?;
+                        return Err(std::io::Error::new(
+                            std::io::ErrorKind::TimedOut,
+                            "timed out waiting for TS interop client connection",
+                        )
+                        .into());
+                    }
+                    thread::sleep(Duration::from_millis(10));
+                }
+                Err(e) => {
+                    self.listener.set_nonblocking(false)?;
+                    return Err(e.into());
+                }
+            }
+        }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn serve_accepted_stream<T: Transport>(
+        stream: TcpStream,
+        server_kp: &DeviceKeypair,
+        runtime: &HubRuntime<T>,
+        owner_allowlist: &[String],
+        peer_allowlist: &[[u8; X25519_PUBKEY_LEN]],
+        run_control_enabled: bool,
+        mission_bound_run_enabled: bool,
+        mission_intake_enabled: bool,
+        mission_spine_dispatch_enabled: bool,
+        memory_confirm_enabled: bool,
+        run_outcome_learning_confirm_enabled: bool,
+        token_surface_enabled: bool,
+        provider_workspace_dispatch_enabled: bool,
+    ) -> Result<usize, TransportError> {
         // HARDENING: a per-connection read timeout BEFORE any read, so a stalled peer cannot
         // wedge the single-threaded accept loop before auth/dispatch.
         stream.set_read_timeout(Some(READ_TIMEOUT))?;
@@ -6534,7 +6627,29 @@ mod tests {
     }
 
     /// Read the ONE JSON line the runner prints on stdout.
-    fn read_client_json(child: std::process::Child) -> serde_json::Value {
+    fn read_client_json(mut child: std::process::Child) -> serde_json::Value {
+        let deadline = std::time::Instant::now() + Duration::from_secs(20);
+        loop {
+            if child
+                .try_wait()
+                .expect("poll TS client subprocess")
+                .is_some()
+            {
+                break;
+            }
+            if std::time::Instant::now() >= deadline {
+                let _ = child.kill();
+                let out = child
+                    .wait_with_output()
+                    .expect("await killed TS client subprocess");
+                panic!(
+                    "TS client did not exit before timeout. stdout={:?} stderr={:?}",
+                    String::from_utf8_lossy(&out.stdout),
+                    String::from_utf8_lossy(&out.stderr)
+                );
+            }
+            thread::sleep(Duration::from_millis(25));
+        }
         let out = child
             .wait_with_output()
             .expect("await TS client subprocess");
@@ -7087,8 +7202,9 @@ mod tests {
     // (1e) OPERATOR-SURFACE-SHAPED MEMORY CONFIRM ROUND-TRIP: real TS memory-spine POST route
     // handler -> real dispatch adapter -> real sealed MemoryDecisionRequest -> real Rust
     // memory-confirm arm -> real DB candidate transition to Confirmed/recallable. This is still
-    // manual/ignored (Node bundle + subprocess), not organic operator traffic, but closes the
-    // split proof at the HTTP route surface for Lane M without provider/model spend.
+    // controlled loopback proof (Node bundle + subprocess), not organic operator traffic, but it is
+    // PR-CI runnable via rust-core.yml and closes the split proof at the HTTP route surface for
+    // Lane M without provider/model spend.
     #[test]
     #[ignore = "needs `node` + the prebuilt interop bundle; opt in with --ignored"]
     fn interop_ts_memory_route_decision_confirms_real_rust_candidate() {
@@ -7118,7 +7234,8 @@ mod tests {
         );
 
         let processed = listener
-            .accept_one(
+            .accept_one_with_timeout(
+                Duration::from_secs(10),
                 &server_kp,
                 &rt,
                 &owner_allowlist,


### PR DESCRIPTION
Summary
- adds bounded test-side accept/client watchdogs around the existing memory-spine route interop proof
- wires Rust Core CI to install Node deps, build the sealed-client interop runner, and run the TS route to Rust confirm proof explicitly
- updates prod flag notes to truth-label the proof as PR-CI controlled loopback, not organic/live

Validation
- node test/interop/build-sealed-client-runner.mjs
- cargo fmt --all -- --check
- cargo test -p friday-hub interop_ts_memory_route_decision_confirms_real_rust_candidate --bin hub_agent_run_server -- --ignored --nocapture
- cargo clippy -p friday-hub --bin hub_agent_run_server --tests -- -D warnings
- node scripts/ci/verify-prod-flag-tests.mjs
- git diff --check

Truth labels
- controlled loopback proof only
- zero provider spend, no prod hub, no operator key
- organic remains 0; GO-LIVE remains false