### PR TITLE
Pin memory session route fail-closed behavior

### DIFF
--- a/docs/ops/ts-runtime-retirement-manifest.json
+++ b/docs/ops/ts-runtime-retirement-manifest.json
@@ -17,7 +17,19 @@
       "autofix_execute",
       "skills_run",
       "skills_import",
-      "mcp_server_rpc"
+      "mcp_server_rpc",
+      "sessions_messages_create",
+      "sessions_archive",
+      "sessions_reset",
+      "sessions_delete",
+      "sessions_prune",
+      "sessions_sweep",
+      "sessions_compact",
+      "sessions_forks_create",
+      "sessions_forks_merge",
+      "sessions_memory_remember",
+      "sessions_memory_extraction_retry",
+      "memory_items_create"
     ]
   },
   "classificationValues": [
@@ -3532,6 +3544,7 @@
       "classification": "fail_closed",
       "user_triggerable": true,
       "executes_product_logic": false,
+      "routeBehavioralTest": "test/unit/api/http/routes/friday-session-routes.test.ts",
       "proof": "src/api/http/routes/friday-session-routes.ts fail-closes default/live sessions.messages.create to TS_RUNTIME_SESSION_RETIRED after session-key decode and request-body validation and immediately before the TypeScript sessionService.getOrCreateSession/addMessage mutation; the route is public/unauthenticated (no bound-principal step); legacy behavior is reachable only through explicit allowTestOnlySessionExecution test-oracle wiring.",
       "next_action": "Replace the fail-closed response with the Rust-owned session lifecycle entrypoint when available."
     },
@@ -3545,6 +3558,7 @@
       "classification": "fail_closed",
       "user_triggerable": true,
       "executes_product_logic": false,
+      "routeBehavioralTest": "test/unit/api/http/routes/friday-session-routes.test.ts",
       "proof": "src/api/http/routes/friday-session-routes.ts fail-closes default/live sessions.archive to TS_RUNTIME_SESSION_RETIRED after session-key decode and immediately before the TypeScript sessionService.archiveSession mutation; the route is public/unauthenticated (no bound-principal step); legacy behavior is reachable only through explicit allowTestOnlySessionExecution test-oracle wiring.",
       "next_action": "Replace the fail-closed response with the Rust-owned session lifecycle entrypoint when available."
     },
@@ -3558,6 +3572,7 @@
       "classification": "fail_closed",
       "user_triggerable": true,
       "executes_product_logic": false,
+      "routeBehavioralTest": "test/unit/api/http/routes/friday-session-routes.test.ts",
       "proof": "src/api/http/routes/friday-session-routes.ts fail-closes default/live sessions.reset to TS_RUNTIME_SESSION_RETIRED after session-key decode and immediately before the TypeScript sessionService.resetSession mutation; the route is public/unauthenticated (no bound-principal step); legacy behavior is reachable only through explicit allowTestOnlySessionExecution test-oracle wiring.",
       "next_action": "Replace the fail-closed response with the Rust-owned session lifecycle entrypoint when available."
     },
@@ -3571,6 +3586,7 @@
       "classification": "fail_closed",
       "user_triggerable": true,
       "executes_product_logic": false,
+      "routeBehavioralTest": "test/unit/api/http/routes/friday-session-routes.test.ts",
       "proof": "src/api/http/routes/friday-session-routes.ts fail-closes default/live sessions.delete to TS_RUNTIME_SESSION_RETIRED after session-key decode and immediately before the TypeScript sessionService.archiveSession mutation; the route is public/unauthenticated (no bound-principal step); legacy behavior is reachable only through explicit allowTestOnlySessionExecution test-oracle wiring.",
       "next_action": "Replace the fail-closed response with the Rust-owned session lifecycle entrypoint when available."
     },
@@ -3584,6 +3600,7 @@
       "classification": "fail_closed",
       "user_triggerable": true,
       "executes_product_logic": false,
+      "routeBehavioralTest": "test/unit/api/http/routes/friday-session-routes.test.ts",
       "proof": "src/api/http/routes/friday-session-routes.ts fail-closes default/live sessions.prune to TS_RUNTIME_SESSION_RETIRED after request-body validation and immediately before the TypeScript sessionService.pruneOldSessions mutation; the route is public/unauthenticated (no bound-principal step); legacy behavior is reachable only through explicit allowTestOnlySessionExecution test-oracle wiring.",
       "next_action": "Replace the fail-closed response with the Rust-owned session lifecycle entrypoint when available."
     },
@@ -3597,6 +3614,7 @@
       "classification": "fail_closed",
       "user_triggerable": true,
       "executes_product_logic": false,
+      "routeBehavioralTest": "test/unit/api/http/routes/friday-session-routes.test.ts",
       "proof": "src/api/http/routes/friday-session-routes.ts fail-closes default/live sessions.sweep to TS_RUNTIME_SESSION_RETIRED as the first handler statement, before the TypeScript sessionService.sweepLifecycle mutation; the route is public/unauthenticated (no bound-principal step) and has no request body; legacy behavior is reachable only through explicit allowTestOnlySessionExecution test-oracle wiring.",
       "next_action": "Replace the fail-closed response with the Rust-owned session lifecycle entrypoint when available."
     },
@@ -3610,6 +3628,7 @@
       "classification": "fail_closed",
       "user_triggerable": true,
       "executes_product_logic": false,
+      "routeBehavioralTest": "test/unit/api/http/routes/friday-session-routes.test.ts",
       "proof": "src/api/http/routes/friday-session-routes.ts fail-closes default/live sessions.compact to TS_RUNTIME_SESSION_RETIRED after session-key decode and request-body validation and immediately before the first TypeScript sessionService read/mutation (getMessages, then setConversationFocus/mergeMetadata); the route is public/unauthenticated (no bound-principal step); legacy behavior is reachable only through explicit allowTestOnlySessionExecution test-oracle wiring.",
       "next_action": "Replace the fail-closed response with the Rust-owned session lifecycle entrypoint when available."
     },
@@ -3623,6 +3642,7 @@
       "classification": "fail_closed",
       "user_triggerable": true,
       "executes_product_logic": false,
+      "routeBehavioralTest": "test/unit/api/http/routes/friday-session-routes.test.ts",
       "proof": "src/api/http/routes/friday-session-routes.ts fail-closes default/live sessions.forks.create to TS_RUNTIME_SESSION_RETIRED after request-body validation and metadata sanitization and immediately before the TypeScript sessionService.forkSession mutation; the route is public/unauthenticated (no bound-principal step); legacy behavior is reachable only through explicit allowTestOnlySessionExecution test-oracle wiring.",
       "next_action": "Replace the fail-closed response with the Rust-owned session lifecycle entrypoint when available."
     },
@@ -3636,6 +3656,7 @@
       "classification": "fail_closed",
       "user_triggerable": true,
       "executes_product_logic": false,
+      "routeBehavioralTest": "test/unit/api/http/routes/friday-session-routes.test.ts",
       "proof": "src/api/http/routes/friday-session-routes.ts fail-closes default/live sessions.forks.merge to TS_RUNTIME_SESSION_RETIRED after request-body validation and metadata sanitization and immediately before the TypeScript sessionService.mergeForkSummary mutation; the route is public/unauthenticated (no bound-principal step); legacy behavior is reachable only through explicit allowTestOnlySessionExecution test-oracle wiring.",
       "next_action": "Replace the fail-closed response with the Rust-owned session lifecycle entrypoint when available."
     },
@@ -3675,6 +3696,7 @@
       "classification": "fail_closed",
       "user_triggerable": true,
       "executes_product_logic": false,
+      "routeBehavioralTest": "test/unit/api/http/routes/friday-session-routes.test.ts",
       "proof": "src/api/http/routes/friday-session-routes.ts fail-closes default/live sessions.memory.remember to TS_RUNTIME_SESSION_MEMORY_EXTRACTION_RETIRED after the memory-extraction availability check (501), session-key decode, and request-body validation (hoisted above the principal-alignment write), and immediately before the TypeScript principal alignment and extractionService.extractSpecificMessages mutation; the route is public/unauthenticated (no bound-principal step); legacy behavior is reachable only through explicit allowTestOnlySessionMemoryExtractionExecution test-oracle wiring.",
       "next_action": "Replace the fail-closed response with the Rust-owned session memory extraction entrypoint when available."
     },
@@ -3688,6 +3710,7 @@
       "classification": "fail_closed",
       "user_triggerable": true,
       "executes_product_logic": false,
+      "routeBehavioralTest": "test/unit/api/http/routes/friday-session-routes.test.ts",
       "proof": "src/api/http/routes/friday-session-routes.ts fail-closes default/live sessions.memory.extraction.retry to TS_RUNTIME_SESSION_MEMORY_EXTRACTION_RETIRED after the memory-extraction availability check (501) and request-body validation, and immediately before the TypeScript extractionService.retryFailedExtractions mutation; the route is public/unauthenticated (no bound-principal step); legacy behavior is reachable only through explicit allowTestOnlySessionMemoryExtractionExecution test-oracle wiring.",
       "next_action": "Replace the fail-closed response with the Rust-owned session memory extraction entrypoint when available."
     },
@@ -3701,6 +3724,7 @@
       "classification": "fail_closed",
       "user_triggerable": true,
       "executes_product_logic": false,
+      "routeBehavioralTest": "test/unit/api/http/routes/friday-memory-routes.test.ts",
       "proof": "D17/D1 retires legacy TypeScript durable memory writes to stop friday.db diverging from the Rust-owned memory confirmation spine. src/hub/friday-hub-bootstrap.ts wires createFridayMemoryService with tsMemoryWritesEnabled: config.allowTestOnlyTsMemoryWrites === true, so default/live hub construction disables TS durable writes. src/memory/services/friday-memory-service.ts then throws TS_RUNTIME_DURABLE_MEMORY_WRITE_RETIRED from store() before id generation, provider embedding, item insert, embedding insert, or dedup advisory writes. The POST /v1/memory/items route still performs request validation, approval-boundary checks, idempotency replay reads, and principal guard setup before delegating to the guarded core store; legacy create behavior is reachable only through explicit allowTestOnlyTsMemoryWrites test-oracle wiring.",
       "next_action": "Replace the fail-closed response with the Rust-owned memory confirmation spine write entrypoint when available; keep memory reads/search bounded as compatibility surfaces."
     },

--- a/test/unit/api/http/routes/friday-memory-routes.test.ts
+++ b/test/unit/api/http/routes/friday-memory-routes.test.ts
@@ -1,11 +1,13 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { createFridayMemoryRoutes } from "#api";
+import { createFridayMemoryService, FRIDAY_MEMORY_ERROR_CODES } from "#memory";
 import type { FridayMemoryService } from "#memory";
 import type { FridayMemoryGuardServiceFactory } from "#memory";
 import type { FridayRouteDefinition, FridayHttpContext } from "#api";
 import type { FridayMemoryItem, FridayMemorySearchResult } from "#memory";
 import { FridayDomainError } from "#errors";
 import { hashIdempotencyPayload } from "../../../../../src/api/http/routes/friday-route-idempotency.js";
+import { createTestDb } from "../../../satellites/_helpers/create-test-db.helper.js";
 
 describe("FridayMemoryRoutes", () => {
   let memoryService: FridayMemoryService;
@@ -222,6 +224,37 @@ describe("FridayMemoryRoutes", () => {
       code: "MEMORY_REQUIRES_REVIEW_CENTER_CONFIRMATION",
     });
     expect(memoryService.store).not.toHaveBeenCalled();
+  });
+
+  it("store alias fails closed through the retired durable-memory write guard", async () => {
+    const db = createTestDb();
+    try {
+      const disabledService = createFridayMemoryService({
+        db,
+        providerService: {} as never,
+        idGenerator: () => "mem-disabled-1",
+        nowIso: () => NOW,
+        tsMemoryWritesEnabled: false,
+      });
+      routes = createFridayMemoryRoutes({
+        memoryGuardFactory: {
+          forPrincipal: vi.fn().mockReturnValue(disabledService),
+          forContext: vi.fn().mockReturnValue(disabledService),
+        },
+      });
+      const route = findRoute("memory.items.create");
+
+      await expect(route.handler(makeCtx({
+        body: { namespace: "default", content: "do not persist via TS" },
+      }))).rejects.toMatchObject({
+        code: FRIDAY_MEMORY_ERROR_CODES.TS_RUNTIME_DURABLE_MEMORY_WRITE_RETIRED,
+        httpStatus: 503,
+      });
+
+      await expect(disabledService.list({ namespace: "default" })).resolves.toEqual([]);
+    } finally {
+      db.close();
+    }
   });
 
   it("store handler rejects preferenceKey metadata for high-impact preferences", async () => {

--- a/test/unit/api/http/routes/friday-session-routes.test.ts
+++ b/test/unit/api/http/routes/friday-session-routes.test.ts
@@ -2071,6 +2071,152 @@ describe("TS runtime retirement — session mutations fail-close by default", ()
     expect(sessionService.alignSessionContext).not.toHaveBeenCalled();
   });
 
+  it.each([
+    {
+      operationId: "sessions.delete",
+      ctx: makeMockCtx({
+        params: { sessionKey: "discord:default:user1" },
+        principal: makeBoundPrincipal(),
+      }),
+      assertNoCall: ({ sessionService }: ReturnType<typeof buildRetiredRoutes>) => {
+        expect(sessionService.archiveSession).not.toHaveBeenCalled();
+      },
+    },
+    {
+      operationId: "sessions.archive",
+      ctx: makeMockCtx({
+        params: { sessionKey: "discord:default:user1" },
+        principal: makeBoundPrincipal(),
+      }),
+      assertNoCall: ({ sessionService }: ReturnType<typeof buildRetiredRoutes>) => {
+        expect(sessionService.archiveSession).not.toHaveBeenCalled();
+      },
+    },
+    {
+      operationId: "sessions.reset",
+      ctx: makeMockCtx({
+        params: { sessionKey: "discord:default:user1" },
+        principal: makeBoundPrincipal(),
+      }),
+      assertNoCall: ({ sessionService }: ReturnType<typeof buildRetiredRoutes>) => {
+        expect(sessionService.resetSession).not.toHaveBeenCalled();
+      },
+    },
+    {
+      operationId: "sessions.prune",
+      ctx: makeMockCtx({
+        body: { olderThan: "2026-01-01T00:00:00.000Z" },
+        principal: makeBoundPrincipal(),
+      }),
+      assertNoCall: ({ sessionService }: ReturnType<typeof buildRetiredRoutes>) => {
+        expect(sessionService.pruneOldSessions).not.toHaveBeenCalled();
+      },
+    },
+    {
+      operationId: "sessions.sweep",
+      ctx: makeMockCtx({ principal: makeBoundPrincipal() }),
+      assertNoCall: ({ sessionService }: ReturnType<typeof buildRetiredRoutes>) => {
+        expect(sessionService.sweepLifecycle).not.toHaveBeenCalled();
+      },
+    },
+    {
+      operationId: "sessions.compact",
+      ctx: makeMockCtx({
+        params: { sessionKey: "discord:default:user1" },
+        body: { summary: "compacted" },
+        principal: makeBoundPrincipal(),
+      }),
+      assertNoCall: ({ sessionService }: ReturnType<typeof buildRetiredRoutes>) => {
+        expect(sessionService.getMessages).not.toHaveBeenCalled();
+        expect(sessionService.setConversationFocus).not.toHaveBeenCalled();
+        expect(sessionService.mergeMetadata).not.toHaveBeenCalled();
+      },
+    },
+    {
+      operationId: "sessions.messages.create",
+      ctx: makeMockCtx({
+        params: { sessionKey: "discord:default:user1" },
+        body: { role: "user", content: "hello" },
+        principal: makeBoundPrincipal(),
+      }),
+      assertNoCall: ({ sessionService }: ReturnType<typeof buildRetiredRoutes>) => {
+        expect(sessionService.getOrCreateSession).not.toHaveBeenCalled();
+        expect(sessionService.addMessage).not.toHaveBeenCalled();
+      },
+    },
+    {
+      operationId: "sessions.forks.create",
+      ctx: makeMockCtx({
+        params: { sessionKey: "discord:default:user1" },
+        body: {},
+        principal: makeBoundPrincipal(),
+      }),
+      assertNoCall: ({ sessionService }: ReturnType<typeof buildRetiredRoutes>) => {
+        expect(sessionService.forkSession).not.toHaveBeenCalled();
+      },
+    },
+    {
+      operationId: "sessions.forks.merge",
+      ctx: makeMockCtx({
+        params: { sessionKey: "discord:default:user1" },
+        body: { forkSessionKey: "subagent:discord:default:user1:task-1", summary: "done" },
+        principal: makeBoundPrincipal(),
+      }),
+      assertNoCall: ({ sessionService }: ReturnType<typeof buildRetiredRoutes>) => {
+        expect(sessionService.mergeForkSummary).not.toHaveBeenCalled();
+      },
+    },
+  ])(
+    "fail-closes $operationId with TS_RUNTIME_SESSION_RETIRED before TypeScript session mutation",
+    async ({ operationId, ctx, assertNoCall }) => {
+      const retired = buildRetiredRoutes();
+      const route = retired.routes.find((r) => r.operationId === operationId)!;
+
+      await expectFailClosed(
+        route.handler(ctx as never),
+        "TS_RUNTIME_SESSION_RETIRED",
+      );
+      assertNoCall(retired);
+    },
+  );
+
+  it.each([
+    {
+      operationId: "sessions.memory.remember",
+      ctx: makeMockCtx({
+        params: { sessionKey: "discord:default:user1" },
+        body: { messageIds: ["msg-1"] },
+        principal: makeBoundPrincipal(),
+      }),
+      assertNoCall: ({ extractionService, sessionService }: ReturnType<typeof buildRetiredRoutes>) => {
+        expect(extractionService.extractSpecificMessages).not.toHaveBeenCalled();
+        expect(sessionService.alignSessionContext).not.toHaveBeenCalled();
+      },
+    },
+    {
+      operationId: "sessions.memory.extraction.retry",
+      ctx: makeMockCtx({
+        body: { sessionKey: "discord:default:user1" },
+        principal: makeBoundPrincipal(),
+      }),
+      assertNoCall: ({ extractionService }: ReturnType<typeof buildRetiredRoutes>) => {
+        expect(extractionService.retryFailedExtractions).not.toHaveBeenCalled();
+      },
+    },
+  ])(
+    "fail-closes $operationId with TS_RUNTIME_SESSION_MEMORY_EXTRACTION_RETIRED before extraction mutation",
+    async ({ operationId, ctx, assertNoCall }) => {
+      const retired = buildRetiredRoutes();
+      const route = retired.routes.find((r) => r.operationId === operationId)!;
+
+      await expectFailClosed(
+        route.handler(ctx as never),
+        "TS_RUNTIME_SESSION_MEMORY_EXTRACTION_RETIRED",
+      );
+      assertNoCall(retired);
+    },
+  );
+
   it("(d) still rejects a malformed sessions.memory.extract body with the validation error (hoist proof, not 503)", async () => {
     const { routes, extractionService } = buildRetiredRoutes();
     const route = routes.find((r) => r.operationId === "sessions.memory.extract")!;


### PR DESCRIPTION
## Summary
- add route-level fail-closed tests for retired session mutation, fork, compact, prune/sweep, and session-memory extraction write legs
- add a durable-memory create-route proof that delegates to the retired TS memory write guard and persists nothing
- require those route behavior anchors in the TS runtime retirement manifest

## Truth labels
- organic=0; this is agent-driven route behavior coverage, not operator-origin organic traffic
- built/proven mechanism only; does not flip GO-LIVE or mark v1 done
- default/live remains fail-closed for these retired TS write legs

## Validation
- `npx vitest run test/unit/api/http/routes/friday-session-routes.test.ts test/unit/api/http/routes/friday-memory-routes.test.ts`
- `node scripts/quality/check-ts-runtime-retirement.mjs > /tmp/friday-ts-runtime-route-behavior-report.json`
- `node scripts/quality/assert-ts-runtime-blocker-zero.mjs /tmp/friday-ts-runtime-route-behavior-report.json`
- `node -e 'JSON.parse(require("fs").readFileSync("docs/ops/ts-runtime-retirement-manifest.json","utf8")); console.log("manifest json ok")'`
- `npm run test:mechanism-wiring`
- `npm run test:mechanism-wiring:behavior`
- `npm run typecheck:src`
- `npm run lint` (0 errors; existing warnings only)
- `git diff --check`
