### PR TITLE
Pin GuideLens route fail-closed behavior

### DIFF
--- a/docs/ops/ts-runtime-retirement-manifest.json
+++ b/docs/ops/ts-runtime-retirement-manifest.json
@@ -699,6 +699,7 @@
       "classification": "fail_closed",
       "user_triggerable": true,
       "executes_product_logic": false,
+      "routeBehavioralTest": "test/unit/api/http/routes/friday-guide-lens-routes.test.ts",
       "proof": "src/api/http/routes/friday-guide-lens-routes.ts calls assertGuideLensTestOracleAllowed before captureSnapshot; default/live deps leave allowTestOnlyGuideLensExecution unset, so the route throws TS_RUNTIME_GUIDE_LENS_RETIRED before service delegation. The default failure is covered by test/unit/api/http/routes/friday-guide-lens-routes.test.ts.",
       "next_action": "Replace the test-oracle-only TypeScript action with a governed Rust-owned guide-lens entrypoint before enabling."
     },
@@ -712,6 +713,7 @@
       "classification": "fail_closed",
       "user_triggerable": true,
       "executes_product_logic": false,
+      "routeBehavioralTest": "test/unit/api/http/routes/friday-guide-lens-routes.test.ts",
       "proof": "src/api/http/routes/friday-guide-lens-routes.ts calls assertGuideLensTestOracleAllowed before validating or resolving a target; default/live deps leave allowTestOnlyGuideLensExecution unset, so the route throws TS_RUNTIME_GUIDE_LENS_RETIRED before service delegation. The default failure is covered by test/unit/api/http/routes/friday-guide-lens-routes.test.ts.",
       "next_action": "Replace the test-oracle-only TypeScript action with a governed Rust-owned guide-lens entrypoint before enabling."
     },
@@ -725,6 +727,7 @@
       "classification": "fail_closed",
       "user_triggerable": true,
       "executes_product_logic": false,
+      "routeBehavioralTest": "test/unit/api/http/routes/friday-guide-lens-routes.test.ts",
       "proof": "src/api/http/routes/friday-guide-lens-routes.ts calls assertGuideLensTestOracleAllowed before overlay validation or showOverlay; default/live deps leave allowTestOnlyGuideLensExecution unset, so the route throws TS_RUNTIME_GUIDE_LENS_RETIRED before service delegation. The default failure is covered by test/unit/api/http/routes/friday-guide-lens-routes.test.ts.",
       "next_action": "Replace the test-oracle-only TypeScript action with a governed Rust-owned guide-lens entrypoint before enabling."
     },
@@ -738,6 +741,7 @@
       "classification": "fail_closed",
       "user_triggerable": true,
       "executes_product_logic": false,
+      "routeBehavioralTest": "test/unit/api/http/routes/friday-guide-lens-routes.test.ts",
       "proof": "src/api/http/routes/friday-guide-lens-routes.ts calls assertGuideLensTestOracleAllowed before clearOverlay; default/live deps leave allowTestOnlyGuideLensExecution unset, so the route throws TS_RUNTIME_GUIDE_LENS_RETIRED before service delegation. The default failure is covered by test/unit/api/http/routes/friday-guide-lens-routes.test.ts.",
       "next_action": "Replace the test-oracle-only TypeScript action with a governed Rust-owned guide-lens entrypoint before enabling."
     },
@@ -751,6 +755,7 @@
       "classification": "fail_closed",
       "user_triggerable": true,
       "executes_product_logic": false,
+      "routeBehavioralTest": "test/unit/api/http/routes/friday-guide-lens-routes.test.ts",
       "proof": "src/api/http/routes/friday-guide-lens-routes.ts calls assertGuideLensTestOracleAllowed before screenshot analysis; default/live deps leave allowTestOnlyGuideLensExecution unset, so the route throws TS_RUNTIME_GUIDE_LENS_RETIRED before service delegation. The default failure is covered by test/unit/api/http/routes/friday-guide-lens-routes.test.ts.",
       "next_action": "Replace the test-oracle-only TypeScript action with a governed Rust-owned guide-lens entrypoint before enabling."
     },
@@ -764,6 +769,7 @@
       "classification": "fail_closed",
       "user_triggerable": true,
       "executes_product_logic": false,
+      "routeBehavioralTest": "test/unit/api/http/routes/friday-guide-lens-routes.test.ts",
       "proof": "src/api/http/routes/friday-guide-lens-routes.ts calls assertGuideLensTestOracleAllowed before verify; default/live deps leave allowTestOnlyGuideLensExecution unset, so the route throws TS_RUNTIME_GUIDE_LENS_RETIRED before service delegation. The default failure is covered by test/unit/api/http/routes/friday-guide-lens-routes.test.ts.",
       "next_action": "Replace the test-oracle-only TypeScript action with a governed Rust-owned guide-lens entrypoint before enabling."
     },
@@ -777,6 +783,7 @@
       "classification": "fail_closed",
       "user_triggerable": true,
       "executes_product_logic": false,
+      "routeBehavioralTest": "test/unit/api/http/routes/friday-guide-lens-routes.test.ts",
       "proof": "src/api/http/routes/friday-guide-lens-routes.ts calls assertGuideLensTestOracleAllowed before updatePreferences; default/live deps leave allowTestOnlyGuideLensExecution unset, so the route throws TS_RUNTIME_GUIDE_LENS_RETIRED before service delegation. The default failure is covered by test/unit/api/http/routes/friday-guide-lens-routes.test.ts.",
       "next_action": "Replace the test-oracle-only TypeScript action with a governed Rust-owned guide-lens entrypoint before enabling."
     },
@@ -790,6 +797,7 @@
       "classification": "fail_closed",
       "user_triggerable": true,
       "executes_product_logic": false,
+      "routeBehavioralTest": "test/unit/api/http/routes/friday-guide-lens-routes.test.ts",
       "proof": "src/api/http/routes/friday-guide-lens-routes.ts calls assertGuideLensTestOracleAllowed before updateAvatar; default/live deps leave allowTestOnlyGuideLensExecution unset, so the route throws TS_RUNTIME_GUIDE_LENS_RETIRED before service delegation. The default failure is covered by test/unit/api/http/routes/friday-guide-lens-routes.test.ts.",
       "next_action": "Replace the test-oracle-only TypeScript action with a governed Rust-owned guide-lens entrypoint before enabling."
     },

--- a/test/unit/api/http/routes/friday-guide-lens-routes.test.ts
+++ b/test/unit/api/http/routes/friday-guide-lens-routes.test.ts
@@ -99,9 +99,17 @@ describe("createFridayGuideLensRoutes", () => {
         query: {
           sessionId: "s-1",
         },
-      }))).rejects.toThrow("guide-lens routes are fail-closed");
+      }))).rejects.toMatchObject({
+        code: "TS_RUNTIME_GUIDE_LENS_RETIRED",
+        httpStatus: 503,
+        details: {
+          classification: "fail_closed",
+          replacement: "rust_owned_guide_lens_entrypoint_required",
+        },
+      });
     }
 
+    expect(service.assertReadOnlyAction).not.toHaveBeenCalled();
     expect(service.captureSnapshot).not.toHaveBeenCalled();
     expect(service.resolveTarget).not.toHaveBeenCalled();
     expect(service.showOverlay).not.toHaveBeenCalled();


### PR DESCRIPTION
## Summary
- Pin all GuideLens test-oracle mutation routes to the shared route behavioral test in the TS-runtime retirement manifest.
- Strengthen the GuideLens default fail-closed test to assert the exact 503 retired error, classification, and replacement target before any service delegation.

## Truth labels
- organic=0
- GO-LIVE=false
- v1=NO-GO
- This is L1 behavior coverage for fail-closed GuideLens surfaces; it does not enable GuideLens product execution.

## Validation
- npx vitest run test/unit/api/http/routes/friday-guide-lens-routes.test.ts
- node scripts/quality/check-ts-runtime-retirement.mjs > /tmp/friday-guidelens-ts-runtime-report-rebased.json
- node scripts/quality/assert-ts-runtime-blocker-zero.mjs /tmp/friday-guidelens-ts-runtime-report-rebased.json
- node -e JSON.parse(...) for docs/ops/ts-runtime-retirement-manifest.json
- git diff --check
- npm run test:mechanism-wiring:behavior
- npm run typecheck:src
- npm run lint (0 errors; existing warnings only)