### PR TITLE
Pin agent loop route fail-closed behavior

### DIFF
--- a/docs/ops/ts-runtime-retirement-manifest.json
+++ b/docs/ops/ts-runtime-retirement-manifest.json
@@ -1299,6 +1299,7 @@
       "classification": "fail_closed",
       "user_triggerable": true,
       "executes_product_logic": false,
+      "routeBehavioralTest": "test/unit/api/http/routes/friday-agent-loop-routes.test.ts",
       "proof": "src/api/http/routes/friday-agent-loop-routes.ts wires default/live agent.loop.expertmode.update to TS_RUNTIME_AGENT_LOOP_POLICY_MUTATIONS_RETIRED after user-principal validation and before mutating TypeScript agent-loop expert-mode policy; legacy TS mutation is reachable only through explicit allowTestOnlyAgentLoopPolicyMutation test-oracle wiring.",
       "next_action": "Replace fail-closed response with a Rust-owned agent-loop expert-mode policy entrypoint when available."
     },
@@ -1324,6 +1325,7 @@
       "classification": "fail_closed",
       "user_triggerable": true,
       "executes_product_logic": false,
+      "routeBehavioralTest": "test/unit/api/http/routes/friday-agent-loop-routes.test.ts",
       "proof": "src/api/http/routes/friday-agent-loop-routes.ts wires default/live agent.loop.policy.update to TS_RUNTIME_AGENT_LOOP_POLICY_MUTATIONS_RETIRED after user-principal validation and before mutating TypeScript agent-loop policy; legacy TS mutation is reachable only through explicit allowTestOnlyAgentLoopPolicyMutation test-oracle wiring.",
       "next_action": "Replace fail-closed response with a Rust-owned agent-loop policy entrypoint when available."
     },
@@ -1385,6 +1387,7 @@
       "classification": "fail_closed",
       "user_triggerable": true,
       "executes_product_logic": false,
+      "routeBehavioralTest": "test/unit/api/http/routes/friday-agent-loop-routes.test.ts",
       "proof": "src/api/http/routes/friday-agent-loop-routes.ts wires default/live agent.loop.runs.pause to TS_RUNTIME_AGENT_LOOP_CONTROLS_RETIRED after user-principal validation and before calling the TypeScript agent loop service; legacy TS pause is reachable only through explicit allowTestOnlyAgentLoopRunControlExecution test-oracle wiring.",
       "next_action": "Replace fail-closed response with a Rust-owned agent-loop pause/control entrypoint when available."
     },
@@ -1398,6 +1401,7 @@
       "classification": "fail_closed",
       "user_triggerable": true,
       "executes_product_logic": false,
+      "routeBehavioralTest": "test/unit/api/http/routes/friday-agent-loop-routes.test.ts",
       "proof": "src/api/http/routes/friday-agent-loop-routes.ts wires default/live agent.loop.runs.resume to TS_RUNTIME_AGENT_LOOP_CONTROLS_RETIRED after user-principal validation and before calling the TypeScript agent loop service; legacy TS resume is reachable only through explicit allowTestOnlyAgentLoopRunControlExecution test-oracle wiring.",
       "next_action": "Replace fail-closed response with a Rust-owned agent-loop resume/control entrypoint when available."
     },
@@ -1411,6 +1415,7 @@
       "classification": "fail_closed",
       "user_triggerable": true,
       "executes_product_logic": false,
+      "routeBehavioralTest": "test/unit/api/http/routes/friday-agent-loop-routes.test.ts",
       "proof": "src/api/http/routes/friday-agent-loop-routes.ts wires default/live agent.loop.runs.cancel to TS_RUNTIME_AGENT_LOOP_CONTROLS_RETIRED after user-principal validation and before calling the TypeScript agent loop service; legacy TS cancel is reachable only through explicit allowTestOnlyAgentLoopRunControlExecution test-oracle wiring.",
       "next_action": "Replace fail-closed response with a Rust-owned agent-loop cancel/control entrypoint when available."
     },

--- a/test/unit/api/http/routes/friday-agent-loop-routes.test.ts
+++ b/test/unit/api/http/routes/friday-agent-loop-routes.test.ts
@@ -342,6 +342,10 @@ describe("FridayAgentLoopRoutes", () => {
       ).rejects.toMatchObject({
         code: "TS_RUNTIME_AGENT_LOOP_POLICY_MUTATIONS_RETIRED",
         httpStatus: 503,
+        details: {
+          classification: "fail_closed",
+          replacement: "rust_owned_agent_loop_policy_entrypoint_required",
+        },
       });
       expect(serviceCall).not.toHaveBeenCalled();
     }
@@ -434,6 +438,10 @@ describe("FridayAgentLoopRoutes", () => {
       ).rejects.toMatchObject({
         code: "TS_RUNTIME_AGENT_LOOP_CONTROLS_RETIRED",
         httpStatus: 503,
+        details: {
+          classification: "fail_closed",
+          replacement: "rust_owned_agent_loop_control_entrypoint_required",
+        },
       });
       expect(serviceCall).not.toHaveBeenCalled();
     }


### PR DESCRIPTION
## Summary
- Pin the 5 agent-loop fail-closed policy/control routes to the existing route behavioral test in the TS-runtime retirement manifest.
- Strengthen the default policy mutation and run-control assertions to cover the exact 503 retired code, fail_closed classification, and Rust-owned replacement target before service delegation.

## Truth labels
- organic=0
- GO-LIVE=false
- v1=NO-GO
- This is L1 route behavior coverage only; it does not enable agent-loop policy mutation or run control execution.

## Validation
- npx vitest run test/unit/api/http/routes/friday-agent-loop-routes.test.ts
- node scripts/quality/check-ts-runtime-retirement.mjs > /tmp/friday-agent-loop-ts-runtime-report.json
- node scripts/quality/assert-ts-runtime-blocker-zero.mjs /tmp/friday-agent-loop-ts-runtime-report.json
- manifest JSON parse
- git diff --check
- npm run test:mechanism-wiring:behavior
- npm run typecheck:src
- npm run lint (0 errors; existing warnings only)