### PR TITLE
Pin agent control route fail-closed behavior

### DIFF
--- a/docs/ops/ts-runtime-retirement-manifest.json
+++ b/docs/ops/ts-runtime-retirement-manifest.json
@@ -1046,6 +1046,7 @@
       "classification": "fail_closed",
       "user_triggerable": true,
       "executes_product_logic": false,
+      "routeBehavioralTest": "test/unit/api/runtime/friday-api-runtime-extra-route-registration.test.ts",
       "proof": "src/api/runtime/friday-api-runtime.ts wires default/live agent.runs.cancel to TS_RUNTIME_AGENT_RUN_CONTROLS_RETIRED before aborting TypeScript run controllers; the legacy TS cancel path is reachable only through explicit allowTestOnlyAgentRunControlExecution test-oracle wiring.",
       "next_action": "Replace fail-closed response with a Rust-owned agent run control entrypoint when available."
     },
@@ -1059,6 +1060,7 @@
       "classification": "fail_closed",
       "user_triggerable": true,
       "executes_product_logic": false,
+      "routeBehavioralTest": "test/unit/api/http/routes/friday-agent-routes.test.ts",
       "proof": "src/api/http/routes/friday-agent-routes.ts gates agent.runs.resume on FRIDAY_AGENT_RUN_CONTROL_VIA_RUST (default-off): flag-off short-circuits to the byte-identical TS_RUNTIME_AGENT_RUNS_RETIRED 503 BEFORE any run lookup (no run-existence leak). Flag-on enforces caller==the wire run's bound owner, then relays the OPAQUE operator-signed Ed25519 approval blob verbatim to the Rust sealed-WS resumeWithApproval (INV-1: TS never parses/validates/inspects the signature/digest); the wire runId is bound to the executed run (pending.run_id==run_id, the s6-687 fix). TS performs NO agent/mutation execution — signature verification and the single approved mutation are Rust-owned under the operator Ed25519 verify key.",
       "next_action": "Replace the flag-gated TS courier relay with a Rust-owned resume entrypoint when the UI connects the Rust hub directly (slice-6 end-state)."
     },
@@ -1086,6 +1088,7 @@
       "classification": "fail_closed",
       "user_triggerable": true,
       "executes_product_logic": false,
+      "routeBehavioralTest": "test/unit/api/runtime/friday-api-runtime-extra-route-registration.test.ts",
       "proof": "src/api/runtime/friday-api-runtime.ts wires default/live agent.runs.rollback to TS_RUNTIME_AGENT_RUN_CONTROLS_RETIRED before calling TypeScript rollbackRun; the legacy TS rollback path is reachable only through explicit allowTestOnlyAgentRunControlExecution test-oracle wiring.",
       "next_action": "Replace fail-closed response with a Rust-owned agent rollback/control entrypoint when available."
     },
@@ -1099,6 +1102,7 @@
       "classification": "fail_closed",
       "user_triggerable": true,
       "executes_product_logic": false,
+      "routeBehavioralTest": "test/unit/api/runtime/friday-api-runtime-extra-route-registration.test.ts",
       "proof": "src/api/runtime/friday-api-runtime.ts wires default/live agent.automations.run to TS_RUNTIME_AGENT_RUN_CONTROLS_RETIRED before invoking the TypeScript automation run service; the legacy TS automation-run path is reachable only through explicit allowTestOnlyAgentRunControlExecution test-oracle wiring.",
       "next_action": "Replace fail-closed response with a Rust-owned automation execution/control entrypoint when available."
     },
@@ -1112,6 +1116,7 @@
       "classification": "fail_closed",
       "user_triggerable": true,
       "executes_product_logic": false,
+      "routeBehavioralTest": "test/unit/api/runtime/friday-api-runtime-extra-route-registration.test.ts",
       "proof": "src/api/runtime/friday-api-runtime.ts wires default/live agent.automations.create to TS_RUNTIME_AGENT_RUN_CONTROLS_RETIRED before invoking the TypeScript automation save service; the legacy TS automation-create path is reachable only through explicit allowTestOnlyAgentRunControlExecution test-oracle wiring.",
       "next_action": "Replace fail-closed response with a Rust-owned automation asset create entrypoint when available."
     },
@@ -1125,6 +1130,7 @@
       "classification": "fail_closed",
       "user_triggerable": true,
       "executes_product_logic": false,
+      "routeBehavioralTest": "test/unit/api/runtime/friday-api-runtime-extra-route-registration.test.ts",
       "proof": "src/api/runtime/friday-api-runtime.ts wires default/live agent.automations.update to TS_RUNTIME_AGENT_RUN_CONTROLS_RETIRED before invoking the TypeScript automation update service; the legacy TS automation-update path is reachable only through explicit allowTestOnlyAgentRunControlExecution test-oracle wiring.",
       "next_action": "Replace fail-closed response with a Rust-owned automation asset update entrypoint when available."
     },
@@ -1138,6 +1144,7 @@
       "classification": "fail_closed",
       "user_triggerable": true,
       "executes_product_logic": false,
+      "routeBehavioralTest": "test/unit/api/runtime/friday-api-runtime-extra-route-registration.test.ts",
       "proof": "src/api/runtime/friday-api-runtime.ts wires default/live agent.automations.delete to TS_RUNTIME_AGENT_RUN_CONTROLS_RETIRED before invoking the TypeScript automation remove service; the legacy TS automation-delete path is reachable only through explicit allowTestOnlyAgentRunControlExecution test-oracle wiring.",
       "next_action": "Replace fail-closed response with a Rust-owned automation asset delete entrypoint when available."
     },
@@ -1235,6 +1242,7 @@
       "classification": "fail_closed",
       "user_triggerable": true,
       "executes_product_logic": false,
+      "routeBehavioralTest": "test/unit/api/runtime/friday-api-runtime-extra-route-registration.test.ts",
       "proof": "src/api/runtime/friday-api-runtime.ts wires default/live agent.runs.approve.plan to TS_RUNTIME_AGENT_RUN_CONTROLS_RETIRED after route visibility/principal checks and before calling the TypeScript planning gate or mirroring session state; the legacy TS approval path is reachable only through explicit allowTestOnlyAgentRunControlExecution test-oracle wiring.",
       "next_action": "Replace fail-closed response with a Rust-owned agent plan approval/control entrypoint when available."
     },
@@ -1248,6 +1256,7 @@
       "classification": "fail_closed",
       "user_triggerable": true,
       "executes_product_logic": false,
+      "routeBehavioralTest": "test/unit/api/runtime/friday-api-runtime-extra-route-registration.test.ts",
       "proof": "src/api/runtime/friday-api-runtime.ts wires default/live agent.runs.reject.plan to TS_RUNTIME_AGENT_RUN_CONTROLS_RETIRED after route visibility/principal checks and before calling the TypeScript planning gate or mirroring session state; the legacy TS rejection path is reachable only through explicit allowTestOnlyAgentRunControlExecution test-oracle wiring.",
       "next_action": "Replace fail-closed response with a Rust-owned agent plan rejection/control entrypoint when available."
     },
@@ -1261,6 +1270,7 @@
       "classification": "fail_closed",
       "user_triggerable": true,
       "executes_product_logic": false,
+      "routeBehavioralTest": "test/unit/api/runtime/friday-api-runtime-extra-route-registration.test.ts",
       "proof": "src/api/runtime/friday-api-runtime.ts wires default/live agent.runs.approve.tool to TS_RUNTIME_AGENT_RUN_CONTROLS_RETIRED after route visibility/principal/body checks and before resolving the TypeScript tool approval gate; the legacy TS tool approval path is reachable only through explicit allowTestOnlyAgentRunControlExecution test-oracle wiring.",
       "next_action": "Replace fail-closed response with a Rust-owned agent tool approval/control entrypoint when available."
     },
@@ -1274,6 +1284,7 @@
       "classification": "fail_closed",
       "user_triggerable": true,
       "executes_product_logic": false,
+      "routeBehavioralTest": "test/unit/api/runtime/friday-api-runtime-extra-route-registration.test.ts",
       "proof": "src/api/runtime/friday-api-runtime.ts wires default/live agent.runs.reject.tool to TS_RUNTIME_AGENT_RUN_CONTROLS_RETIRED after route visibility/principal/body checks and before resolving the TypeScript tool approval gate; the legacy TS tool rejection path is reachable only through explicit allowTestOnlyAgentRunControlExecution test-oracle wiring.",
       "next_action": "Replace fail-closed response with a Rust-owned agent tool rejection/control entrypoint when available."
     },

--- a/test/unit/api/runtime/friday-api-runtime-extra-route-registration.test.ts
+++ b/test/unit/api/runtime/friday-api-runtime-extra-route-registration.test.ts
@@ -386,6 +386,10 @@ describe("API Runtime — Extended Route Registration", () => {
     expect(thrown).toBeInstanceOf(FridayDomainError);
     expect((thrown as FridayDomainError).code).toBe("TS_RUNTIME_AGENT_RUN_CONTROLS_RETIRED");
     expect((thrown as FridayDomainError).httpStatus).toBe(503);
+    expect((thrown as FridayDomainError).details).toMatchObject({
+      classification: "fail_closed",
+      replacement: "rust_owned_agent_run_control_entrypoint_required",
+    });
     expect(executeRun).not.toHaveBeenCalled();
     expect(rollbackRun).not.toHaveBeenCalled();
   });
@@ -433,6 +437,10 @@ describe("API Runtime — Extended Route Registration", () => {
     expect(thrown).toBeInstanceOf(FridayDomainError);
     expect((thrown as FridayDomainError).code).toBe("TS_RUNTIME_AGENT_RUN_CONTROLS_RETIRED");
     expect((thrown as FridayDomainError).httpStatus).toBe(503);
+    expect((thrown as FridayDomainError).details).toMatchObject({
+      classification: "fail_closed",
+      replacement: "rust_owned_agent_run_control_entrypoint_required",
+    });
     expect(rollbackRun).not.toHaveBeenCalled();
   });
 
@@ -474,6 +482,10 @@ describe("API Runtime — Extended Route Registration", () => {
     expect(thrown).toBeInstanceOf(FridayDomainError);
     expect((thrown as FridayDomainError).code).toBe("TS_RUNTIME_AGENT_RUN_CONTROLS_RETIRED");
     expect((thrown as FridayDomainError).httpStatus).toBe(503);
+    expect((thrown as FridayDomainError).details).toMatchObject({
+      classification: "fail_closed",
+      replacement: "rust_owned_agent_run_control_entrypoint_required",
+    });
     expect(executeRun).not.toHaveBeenCalled();
   });
 
@@ -537,6 +549,10 @@ describe("API Runtime — Extended Route Registration", () => {
       expect(thrown).toBeInstanceOf(FridayDomainError);
       expect((thrown as FridayDomainError).code).toBe("TS_RUNTIME_AGENT_RUN_CONTROLS_RETIRED");
       expect((thrown as FridayDomainError).httpStatus).toBe(503);
+      expect((thrown as FridayDomainError).details).toMatchObject({
+        classification: "fail_closed",
+        replacement: "rust_owned_agent_run_control_entrypoint_required",
+      });
     });
   }
 
@@ -594,6 +610,10 @@ describe("API Runtime — Extended Route Registration", () => {
       expect(thrown).toBeInstanceOf(FridayDomainError);
       expect((thrown as FridayDomainError).code).toBe("TS_RUNTIME_AGENT_RUN_CONTROLS_RETIRED");
       expect((thrown as FridayDomainError).httpStatus).toBe(503);
+      expect((thrown as FridayDomainError).details).toMatchObject({
+        classification: "fail_closed",
+        replacement: "rust_owned_agent_run_control_entrypoint_required",
+      });
       expect(executeRun).not.toHaveBeenCalled();
     });
   }
@@ -653,6 +673,10 @@ describe("API Runtime — Extended Route Registration", () => {
       expect(thrown).toBeInstanceOf(FridayDomainError);
       expect((thrown as FridayDomainError).code).toBe("TS_RUNTIME_AGENT_RUN_CONTROLS_RETIRED");
       expect((thrown as FridayDomainError).httpStatus).toBe(503);
+      expect((thrown as FridayDomainError).details).toMatchObject({
+        classification: "fail_closed",
+        replacement: "rust_owned_agent_run_control_entrypoint_required",
+      });
       expect(resolveToolApproval).not.toHaveBeenCalled();
     });
   }


### PR DESCRIPTION
## Summary
- Add routeBehavioralTest anchors for agent run-control, plan/tool approval, and automation mutation fail-closed surfaces.
- Tighten runtime fail-closed assertions to verify the exact fail_closed replacement details.

## Validation
- `npm exec -- vitest run test/unit/api/runtime/friday-api-runtime-extra-route-registration.test.ts test/unit/api/http/routes/friday-agent-routes.test.ts`
- `node scripts/quality/check-ts-runtime-retirement.mjs > /tmp/friday-agent-control-ts-runtime-report.json && node scripts/quality/assert-ts-runtime-blocker-zero.mjs /tmp/friday-agent-control-ts-runtime-report.json`
- `npm run test:mechanism-wiring:behavior`
- `node -e "JSON.parse(require('fs').readFileSync('docs/ops/ts-runtime-retirement-manifest.json','utf8')); console.log('manifest json ok')" && git diff --check`
- `npm run typecheck:src`
- `npm run lint` (0 errors, existing warnings)

Truth labels: organic=0; GO-LIVE=false; v1=NO-GO. This is L1 fail-closed coverage, not live product completion.