### PR TITLE
Pin workflow control route fail-closed behavior

### DIFF
--- a/docs/ops/ts-runtime-retirement-manifest.json
+++ b/docs/ops/ts-runtime-retirement-manifest.json
@@ -1454,6 +1454,7 @@
       "classification": "fail_closed",
       "user_triggerable": true,
       "executes_product_logic": false,
+      "routeBehavioralTest": "test/unit/api/runtime/friday-api-runtime-extra-route-registration.test.ts",
       "proof": "src/api/runtime/friday-api-runtime.ts wires default/live runs.cancel to TS_RUNTIME_WORKFLOW_RUNS_RETIRED before resolving TypeScript workflow run state or calling workflowRuntime.execution.cancelRun; the legacy TS control path is reachable only through explicit allowTestOnlyWorkflowRunExecution test-oracle wiring.",
       "next_action": "Replace fail-closed response with a Rust-owned workflow run control entrypoint when available."
     },
@@ -1467,6 +1468,7 @@
       "classification": "fail_closed",
       "user_triggerable": true,
       "executes_product_logic": false,
+      "routeBehavioralTest": "test/unit/api/runtime/friday-api-runtime-extra-route-registration.test.ts",
       "proof": "src/api/runtime/friday-api-runtime.ts wires default/live runs.retry to TS_RUNTIME_WORKFLOW_RUNS_RETIRED before resolving TypeScript workflow run state, enumerating nodes, or calling workflowRuntime.execution.retryRun; the legacy TS control path is reachable only through explicit allowTestOnlyWorkflowRunExecution test-oracle wiring.",
       "next_action": "Replace fail-closed response with a Rust-owned workflow retry/control entrypoint when available."
     },
@@ -1480,6 +1482,7 @@
       "classification": "fail_closed",
       "user_triggerable": true,
       "executes_product_logic": false,
+      "routeBehavioralTest": "test/unit/api/runtime/friday-api-runtime-extra-route-registration.test.ts",
       "proof": "src/api/runtime/friday-api-runtime.ts wires default/live workflows.runs.resume to TS_RUNTIME_WORKFLOW_RUNS_RETIRED before resolving TypeScript workflow run state or calling workflowRuntime.execution.resumeRun; the legacy TS control path is reachable only through explicit allowTestOnlyWorkflowRunExecution test-oracle wiring.",
       "next_action": "Replace fail-closed response with a Rust-owned workflow resume/control entrypoint when available."
     },
@@ -1493,6 +1496,7 @@
       "classification": "fail_closed",
       "user_triggerable": true,
       "executes_product_logic": false,
+      "routeBehavioralTest": "test/unit/api/runtime/friday-api-runtime-extra-route-registration.test.ts",
       "proof": "src/api/runtime/friday-api-runtime.ts wires default/live runs.evidence.export to TS_RUNTIME_WORKFLOW_RUN_EVIDENCE_EXPORT_RETIRED before resolving TypeScript workflow run evidence state or calling workflowRuntime.evidence.exportRunEvidence; the legacy TS evidence export path is reachable only through explicit allowTestOnlyWorkflowRunExecution test-oracle wiring.",
       "next_action": "Replace fail-closed response with a Rust-owned workflow run evidence export entrypoint when available."
     },

--- a/test/unit/api/runtime/friday-api-runtime-extra-route-registration.test.ts
+++ b/test/unit/api/runtime/friday-api-runtime-extra-route-registration.test.ts
@@ -190,6 +190,9 @@ function makeWorkflowRuntimeSpies(): {
     retryRun: ReturnType<typeof vi.fn>;
     resumeRun: ReturnType<typeof vi.fn>;
   };
+  evidence: {
+    exportRunEvidence: ReturnType<typeof vi.fn>;
+  };
 } {
   const run = {
     id: "workflow-run-1",
@@ -208,21 +211,22 @@ function makeWorkflowRuntimeSpies(): {
     retryRun: vi.fn(async () => ({ ...run, status: "running" })),
     resumeRun: vi.fn(async () => ({ ...run, status: "running" })),
   };
+  const evidence = {
+    getRunEvidenceStatus: vi.fn(() => ({ state: "not_required" })),
+    getRunEvidence: vi.fn(),
+    listRunEvidenceExports: vi.fn(() => []),
+    exportRunEvidence: vi.fn(),
+    getRunEvidenceExport: vi.fn(() => null),
+    downloadRunEvidenceExport: vi.fn(() => null),
+  };
   const workflowRuntime = {
     execution,
-    evidence: {
-      getRunEvidenceStatus: vi.fn(() => ({ state: "not_required" })),
-      getRunEvidence: vi.fn(),
-      listRunEvidenceExports: vi.fn(() => []),
-      exportRunEvidence: vi.fn(),
-      getRunEvidenceExport: vi.fn(() => null),
-      downloadRunEvidenceExport: vi.fn(() => null),
-    },
+    evidence,
     crud: {},
     approval: {},
     triggers: {},
   } as unknown as FridayWorkflowRuntime;
-  return { workflowRuntime, execution };
+  return { workflowRuntime, execution, evidence };
 }
 
 describe("API Runtime — Extended Route Registration", () => {
@@ -745,10 +749,48 @@ describe("API Runtime — Extended Route Registration", () => {
       expect(thrown).toBeInstanceOf(FridayDomainError);
       expect((thrown as FridayDomainError).code).toBe("TS_RUNTIME_WORKFLOW_RUNS_RETIRED");
       expect((thrown as FridayDomainError).httpStatus).toBe(503);
+      expect((thrown as FridayDomainError).details).toMatchObject({
+        classification: "fail_closed",
+        replacement: "rust_owned_workflow_run_entrypoint_required",
+      });
       expect(execution.getRun).not.toHaveBeenCalled();
       expect(execution[methodName]).not.toHaveBeenCalled();
     },
   );
+
+  it("fail-closes live workflow evidence export wiring before TypeScript evidence mutation", async () => {
+    const { workflowRuntime, evidence } = makeWorkflowRuntimeSpies();
+    const runtime = createFridayApiRuntime({
+      ...makeBaseDeps(),
+      workflowRuntime,
+    });
+    const route = runtime.routes.getRoutes().find((r) => r.operationId === "runs.evidence.export");
+    expect(route).toBeDefined();
+
+    let thrown: unknown = null;
+    try {
+      await route!.handler({
+        requestId: "req-workflow-evidence-export-retired",
+        receivedAt: NOW,
+        params: { runId: "workflow-run-1" },
+        query: {},
+        body: {},
+        headers: {},
+        principal: makePrincipal({ role: "admin", scopes: ["workflow.write"] }),
+      });
+    } catch (err) {
+      thrown = err;
+    }
+
+    expect(thrown).toBeInstanceOf(FridayDomainError);
+    expect((thrown as FridayDomainError).code).toBe("TS_RUNTIME_WORKFLOW_RUN_EVIDENCE_EXPORT_RETIRED");
+    expect((thrown as FridayDomainError).httpStatus).toBe(503);
+    expect((thrown as FridayDomainError).details).toMatchObject({
+      classification: "fail_closed",
+      replacement: "rust_owned_workflow_run_evidence_export_entrypoint_required",
+    });
+    expect(evidence.exportRunEvidence).not.toHaveBeenCalled();
+  });
 
   it("registers skills.social.import in disabled state when deps.socialImport is omitted", async () => {
     const runtime = createFridayApiRuntime(makeBaseDeps());


### PR DESCRIPTION
## Summary
- Add routeBehavioralTest anchors for workflow run cancel/retry/resume and evidence export fail-closed surfaces.
- Tighten workflow control runtime assertions to verify exact fail_closed replacement details.
- Add a runtime default fail-close assertion for workflow evidence export before any TypeScript evidence mutation.

## Validation
- `npm exec -- vitest run test/unit/api/runtime/friday-api-runtime-extra-route-registration.test.ts test/unit/api/http/routes/friday-workflow-run-routes.test.ts`
- `node scripts/quality/check-ts-runtime-retirement.mjs > /tmp/friday-workflow-control-ts-runtime-report.json && node scripts/quality/assert-ts-runtime-blocker-zero.mjs /tmp/friday-workflow-control-ts-runtime-report.json`
- `npm run test:mechanism-wiring:behavior`
- `node -e "JSON.parse(require('fs').readFileSync('docs/ops/ts-runtime-retirement-manifest.json','utf8')); console.log('manifest json ok')" && git diff --check`
- `npm run typecheck:src`
- `npm run lint` (0 errors, existing warnings)

Truth labels: organic=0; GO-LIVE=false; v1=NO-GO. This is L1 fail-closed coverage, not live product completion.