### PR TITLE
Pin generator route fail-closed behavior

### DIFF
--- a/docs/ops/ts-runtime-retirement-manifest.json
+++ b/docs/ops/ts-runtime-retirement-manifest.json
@@ -1621,6 +1621,7 @@
       "classification": "fail_closed",
       "user_triggerable": true,
       "executes_product_logic": false,
+      "routeBehavioralTest": "test/unit/api/http/routes/friday-skill-generator-routes.test.ts",
       "proof": "src/api/http/routes/friday-skill-generator-routes.ts wires default/live skill generator session routes to TS_RUNTIME_SKILL_GENERATOR_RETIRED before invoking the TypeScript skillGenerator service; legacy generator behavior is reachable only through explicit allowTestOnlySkillGeneratorExecution test-oracle wiring.",
       "next_action": "Replace fail-closed response with a Rust-owned skill generator entrypoint when available."
     },
@@ -1634,6 +1635,7 @@
       "classification": "fail_closed",
       "user_triggerable": true,
       "executes_product_logic": false,
+      "routeBehavioralTest": "test/unit/api/http/routes/friday-skill-generator-routes.test.ts",
       "proof": "src/api/http/routes/friday-skill-generator-routes.ts wires default/live skill generator session routes to TS_RUNTIME_SKILL_GENERATOR_RETIRED before reading TypeScript generator session state; legacy generator reads are reachable only through explicit allowTestOnlySkillGeneratorExecution test-oracle wiring.",
       "next_action": "Replace fail-closed response with a Rust-owned redacted skill generator session projection when available."
     },
@@ -1647,6 +1649,7 @@
       "classification": "fail_closed",
       "user_triggerable": true,
       "executes_product_logic": false,
+      "routeBehavioralTest": "test/unit/api/http/routes/friday-skill-generator-routes.test.ts",
       "proof": "src/api/http/routes/friday-skill-generator-routes.ts wires default/live skill generator message submission to TS_RUNTIME_SKILL_GENERATOR_RETIRED before invoking the TypeScript skillGenerator service; legacy generator behavior is reachable only through explicit allowTestOnlySkillGeneratorExecution test-oracle wiring.",
       "next_action": "Replace fail-closed response with a Rust-owned skill generator turn entrypoint when available."
     },
@@ -1660,6 +1663,7 @@
       "classification": "fail_closed",
       "user_triggerable": true,
       "executes_product_logic": false,
+      "routeBehavioralTest": "test/unit/api/http/routes/friday-skill-generator-routes.test.ts",
       "proof": "src/api/http/routes/friday-skill-generator-routes.ts wires default/live skill draft generation to TS_RUNTIME_SKILL_GENERATOR_RETIRED before invoking the TypeScript skillGenerator service; legacy generator behavior is reachable only through explicit allowTestOnlySkillGeneratorExecution test-oracle wiring.",
       "next_action": "Replace fail-closed response with a Rust-owned skill draft generation entrypoint when available."
     },
@@ -1673,6 +1677,7 @@
       "classification": "fail_closed",
       "user_triggerable": true,
       "executes_product_logic": false,
+      "routeBehavioralTest": "test/unit/api/http/routes/friday-skill-generator-routes.test.ts",
       "proof": "src/api/http/routes/friday-skill-generator-routes.ts wires default/live skill draft self-test to TS_RUNTIME_SKILL_GENERATOR_RETIRED before writing temp files or executing the TypeScript draft test path; legacy self-test behavior is reachable only through explicit allowTestOnlySkillGeneratorExecution test-oracle wiring.",
       "next_action": "Replace fail-closed response with a Rust-owned skill draft validation/test entrypoint when available."
     },
@@ -1686,6 +1691,7 @@
       "classification": "fail_closed",
       "user_triggerable": true,
       "executes_product_logic": false,
+      "routeBehavioralTest": "test/unit/api/http/routes/friday-skill-generator-routes.test.ts",
       "proof": "src/api/http/routes/friday-skill-generator-routes.ts wires default/live skill generator evidence reads to TS_RUNTIME_SKILL_GENERATOR_RETIRED before reading TypeScript generator evidence state; legacy generator evidence reads are reachable only through explicit allowTestOnlySkillGeneratorExecution test-oracle wiring.",
       "next_action": "Replace fail-closed response with a Rust-owned redacted skill generator evidence projection when available."
     },
@@ -1699,6 +1705,7 @@
       "classification": "fail_closed",
       "user_triggerable": true,
       "executes_product_logic": false,
+      "routeBehavioralTest": "test/unit/api/http/routes/friday-skill-generator-routes.test.ts",
       "proof": "src/api/http/routes/friday-skill-generator-routes.ts wires default/live generated skill approval to TS_RUNTIME_SKILL_GENERATOR_RETIRED before evaluating TypeScript candidate approval or staging a candidate; legacy generator approval is reachable only through explicit allowTestOnlySkillGeneratorExecution test-oracle wiring.",
       "next_action": "Replace fail-closed response with a Rust-owned generated skill candidate approval entrypoint when available."
     },
@@ -1712,6 +1719,7 @@
       "classification": "fail_closed",
       "user_triggerable": true,
       "executes_product_logic": false,
+      "routeBehavioralTest": "test/unit/api/http/routes/friday-skill-generator-routes.test.ts",
       "proof": "src/api/http/routes/friday-skill-generator-routes.ts wires default/live skill generator cancellation to TS_RUNTIME_SKILL_GENERATOR_RETIRED before invoking the TypeScript skillGenerator service; legacy generator cancellation is reachable only through explicit allowTestOnlySkillGeneratorExecution test-oracle wiring.",
       "next_action": "Replace fail-closed response with a Rust-owned skill generator cancellation entrypoint when available."
     },
@@ -1725,6 +1733,7 @@
       "classification": "fail_closed",
       "user_triggerable": true,
       "executes_product_logic": false,
+      "routeBehavioralTest": "test/unit/api/http/routes/friday-workflow-generator-routes.test.ts",
       "proof": "src/api/http/routes/friday-workflow-generator-routes.ts wires default/live workflow generator session routes to TS_RUNTIME_WORKFLOW_GENERATOR_RETIRED before invoking the TypeScript workflowGenerator service; legacy generator behavior is reachable only through explicit allowTestOnlyWorkflowGeneratorExecution test-oracle wiring.",
       "next_action": "Replace fail-closed response with a Rust-owned workflow generator entrypoint when available."
     },
@@ -1738,6 +1747,7 @@
       "classification": "fail_closed",
       "user_triggerable": true,
       "executes_product_logic": false,
+      "routeBehavioralTest": "test/unit/api/http/routes/friday-workflow-generator-routes.test.ts",
       "proof": "src/api/http/routes/friday-workflow-generator-routes.ts wires default/live workflow generator session reads to TS_RUNTIME_WORKFLOW_GENERATOR_RETIRED before reading TypeScript generator session state; legacy generator reads are reachable only through explicit allowTestOnlyWorkflowGeneratorExecution test-oracle wiring.",
       "next_action": "Replace fail-closed response with a Rust-owned redacted workflow generator session projection when available."
     },
@@ -1751,6 +1761,7 @@
       "classification": "fail_closed",
       "user_triggerable": true,
       "executes_product_logic": false,
+      "routeBehavioralTest": "test/unit/api/http/routes/friday-workflow-generator-routes.test.ts",
       "proof": "src/api/http/routes/friday-workflow-generator-routes.ts wires default/live workflow generator message submission to TS_RUNTIME_WORKFLOW_GENERATOR_RETIRED before invoking the TypeScript workflowGenerator service; legacy generator behavior is reachable only through explicit allowTestOnlyWorkflowGeneratorExecution test-oracle wiring.",
       "next_action": "Replace fail-closed response with a Rust-owned workflow generator turn entrypoint when available."
     },
@@ -1764,6 +1775,7 @@
       "classification": "fail_closed",
       "user_triggerable": true,
       "executes_product_logic": false,
+      "routeBehavioralTest": "test/unit/api/http/routes/friday-workflow-generator-routes.test.ts",
       "proof": "src/api/http/routes/friday-workflow-generator-routes.ts wires default/live workflow draft generation to TS_RUNTIME_WORKFLOW_GENERATOR_RETIRED before invoking the TypeScript workflowGenerator service; legacy generator behavior is reachable only through explicit allowTestOnlyWorkflowGeneratorExecution test-oracle wiring.",
       "next_action": "Replace fail-closed response with a Rust-owned workflow draft generation entrypoint when available."
     },
@@ -1777,6 +1789,7 @@
       "classification": "fail_closed",
       "user_triggerable": true,
       "executes_product_logic": false,
+      "routeBehavioralTest": "test/unit/api/http/routes/friday-workflow-generator-routes.test.ts",
       "proof": "src/api/http/routes/friday-workflow-generator-routes.ts wires default/live workflow generator evidence reads to TS_RUNTIME_WORKFLOW_GENERATOR_RETIRED before reading TypeScript generator evidence state; legacy generator evidence reads are reachable only through explicit allowTestOnlyWorkflowGeneratorExecution test-oracle wiring.",
       "next_action": "Replace fail-closed response with a Rust-owned redacted workflow generator evidence projection when available."
     },
@@ -1790,6 +1803,7 @@
       "classification": "fail_closed",
       "user_triggerable": true,
       "executes_product_logic": false,
+      "routeBehavioralTest": "test/unit/api/http/routes/friday-workflow-generator-routes.test.ts",
       "proof": "src/api/http/routes/friday-workflow-generator-routes.ts wires default/live generated workflow approval to TS_RUNTIME_WORKFLOW_GENERATOR_RETIRED before reading evidence, publishing through TypeScript Workflow CRUD, or recording observability; legacy generator approval is reachable only through explicit allowTestOnlyWorkflowGeneratorExecution test-oracle wiring.",
       "next_action": "Replace fail-closed response with a Rust-owned generated workflow approval entrypoint when available."
     },
@@ -1803,6 +1817,7 @@
       "classification": "fail_closed",
       "user_triggerable": true,
       "executes_product_logic": false,
+      "routeBehavioralTest": "test/unit/api/http/routes/friday-workflow-generator-routes.test.ts",
       "proof": "src/api/http/routes/friday-workflow-generator-routes.ts wires default/live workflow generator cancellation to TS_RUNTIME_WORKFLOW_GENERATOR_RETIRED before invoking the TypeScript workflowGenerator service; legacy generator cancellation is reachable only through explicit allowTestOnlyWorkflowGeneratorExecution test-oracle wiring.",
       "next_action": "Replace fail-closed response with a Rust-owned workflow generator cancellation entrypoint when available."
     },

--- a/test/unit/api/http/routes/friday-skill-generator-routes.test.ts
+++ b/test/unit/api/http/routes/friday-skill-generator-routes.test.ts
@@ -265,19 +265,34 @@ describe("FridaySkillGeneratorRoutes", () => {
     return { routes, generatorService, registry };
   }
 
-  it("fail-closes skill generator sessions by default without invoking the TypeScript generator", async () => {
+  it.each([
+    [
+      "skills.generator.sessions.create",
+      {
+        body: { goal: "Build a timer", userId: "user-1", channel: "discord" },
+        principal: { userId: "user-1", principalId: "user-1", tenantId: "tenant-1" },
+      },
+    ],
+    ["skills.generator.sessions.get", { params: { sessionId: "sess-1" } }],
+    [
+      "skills.generator.sessions.messages.create",
+      { params: { sessionId: "sess-1" }, body: { message: "JSON format please" } },
+    ],
+    ["skills.generator.sessions.generate", { params: { sessionId: "sess-1" }, body: {} }],
+    ["skills.generator.sessions.test", { params: { sessionId: "sess-1" } }],
+    ["skills.generator.sessions.evidence.get", { params: { sessionId: "sess-1" } }],
+    ["skills.generator.sessions.approve", { params: { sessionId: "sess-1" }, body: withCanonicalApproval() }],
+    ["skills.generator.sessions.cancel", { params: { sessionId: "sess-1" } }],
+  ])("%s fail-closes by default without invoking the TypeScript generator", async (operationId, ctxOverrides) => {
     const generatorService = makeMockGeneratorService();
     const routes = createFridaySkillGeneratorRoutes({
       skillGenerator: generatorService,
       registry: makeMockRegistry(),
     });
-    const route = routes.find((r) => r.operationId === "skills.generator.sessions.create")!;
+    const route = routes.find((r) => r.operationId === operationId)!;
 
     await expect(
-      route.handler(makeCtx({
-        body: { goal: "Build a timer", userId: "user-1", channel: "discord" },
-        principal: { userId: "user-1", principalId: "user-1", tenantId: "tenant-1" },
-      })),
+      route.handler(makeCtx(ctxOverrides)),
     ).rejects.toMatchObject({
       code: "TS_RUNTIME_SKILL_GENERATOR_RETIRED",
       httpStatus: 503,
@@ -287,6 +302,12 @@ describe("FridaySkillGeneratorRoutes", () => {
       },
     });
     expect(generatorService.startSession).not.toHaveBeenCalled();
+    expect(generatorService.getSession).not.toHaveBeenCalled();
+    expect(generatorService.submitTurn).not.toHaveBeenCalled();
+    expect(generatorService.generateDraft).not.toHaveBeenCalled();
+    expect(generatorService.recordExplicitTestResult).not.toHaveBeenCalled();
+    expect(generatorService.approveAndSave).not.toHaveBeenCalled();
+    expect(generatorService.cancelSession).not.toHaveBeenCalled();
   });
 
   function withCanonicalApproval(body: {

--- a/test/unit/api/http/routes/friday-workflow-generator-routes.test.ts
+++ b/test/unit/api/http/routes/friday-workflow-generator-routes.test.ts
@@ -137,19 +137,26 @@ describe("FridayWorkflowGeneratorRoutes", () => {
     allowTestOnlyWorkflowGeneratorExecution: true,
   });
 
-  it("fail-closes workflow generator sessions by default without invoking the TypeScript generator", async () => {
+  it.each([
+    ["workflows.generator.sessions.create", { body: { goal: "Build workflow", userId: "u-1", channel: "test" } }],
+    ["workflows.generator.sessions.get", { params: { sessionId: "s-1" } }],
+    [
+      "workflows.generator.sessions.messages.create",
+      { params: { sessionId: "s-1" }, body: { message: "Use manual trigger" } },
+    ],
+    ["workflows.generator.sessions.generate", { params: { sessionId: "s-1" }, body: {} }],
+    ["workflows.generator.sessions.evidence.get", { params: { sessionId: "s-1" } }],
+    ["workflows.generator.sessions.approve", { params: { sessionId: "s-1" }, body: {} }],
+    ["workflows.generator.sessions.cancel", { params: { sessionId: "s-1" } }],
+  ])("%s fail-closes by default without invoking the TypeScript generator", async (operationId, ctxOverrides) => {
     const localService = makeMockService();
     const localRoutes = createFridayWorkflowGeneratorRoutes({
       workflowGenerator: localService,
     });
-    const createRoute = localRoutes.find((r) => r.operationId === "workflows.generator.sessions.create")!;
+    const route = localRoutes.find((r) => r.operationId === operationId)!;
 
     await expect(
-      createRoute.handler(
-        makeCtx({
-          body: { goal: "Build workflow", userId: "u-1", channel: "test" },
-        }) as never,
-      ),
+      route.handler(makeCtx(ctxOverrides) as never),
     ).rejects.toMatchObject({
       code: "TS_RUNTIME_WORKFLOW_GENERATOR_RETIRED",
       httpStatus: 503,
@@ -159,6 +166,11 @@ describe("FridayWorkflowGeneratorRoutes", () => {
       },
     });
     expect(localService.startSession).not.toHaveBeenCalled();
+    expect(localService.getSession).not.toHaveBeenCalled();
+    expect(localService.submitTurn).not.toHaveBeenCalled();
+    expect(localService.generateDraft).not.toHaveBeenCalled();
+    expect(localService.approveAndSave).not.toHaveBeenCalled();
+    expect(localService.cancelSession).not.toHaveBeenCalled();
   });
 
   it("creates exactly 7 routes", () => {


### PR DESCRIPTION
## Summary
- add `routeBehavioralTest` anchors for skill/workflow generator fail-closed surfaces
- expand generator HTTP route tests so every operation proves default/live 503 `fail_closed` before TypeScript service execution

## Validation
- `npm exec -- vitest run test/unit/api/http/routes/friday-skill-generator-routes.test.ts test/unit/api/http/routes/friday-workflow-generator-routes.test.ts`
- `node scripts/quality/check-ts-runtime-retirement.mjs`
- `npm run test:mechanism-wiring:behavior`
- `npm run typecheck:src`
- `npm run lint` (0 errors, existing warnings)
- `git diff --check`

Truth: L1 route-behavior residue only; strict organic=0, GO-LIVE=false, v1=NO-GO.