### PR TITLE
Pin A1 learning eligibility behavior

### DIFF
--- a/rust-core/crates/friday-hub/src/lib.rs
+++ b/rust-core/crates/friday-hub/src/lib.rs
@@ -2544,10 +2544,11 @@ fn matched_run_outcome_learning_candidates_for_principals<F>(
 where
     F: Fn(&friday_storage::learning_candidate::RunOutcomeLearningCandidateRow) -> bool,
 {
-    let rows = friday_storage::learning_candidate::list_recent_confirmed_run_outcome_candidates(
-        db.conn(),
-        64,
-    )?;
+    let rows =
+        friday_storage::learning_candidate::list_recent_eligible_confirmed_run_outcome_candidates(
+            db.conn(),
+            64,
+        )?;
     let mut matched = Vec::new();
     for row in rows {
         if !keep(&row) {
@@ -17179,6 +17180,28 @@ mod tests {
         .unwrap();
     }
 
+    fn run_outcome_learning_artifact_snapshot(db: &Db) -> String {
+        db.conn()
+            .query_row(
+                "SELECT COALESCE(group_concat(
+                    candidate_id || '|' || run_id || '|' || COALESCE(session_id, '') || '|' ||
+                    kind || '|' || state || '|' || evidence_ref || '|' || summary || '|' ||
+                    turns || '|' || executed_tools || '|' || created_at_ms || '|' ||
+                    COALESCE(decided_at_ms, '') || '|' || COALESCE(decision_reason, ''),
+                    '\n'
+                 ), '')
+                   FROM (
+                     SELECT candidate_id, run_id, session_id, kind, state, evidence_ref, summary,
+                            turns, executed_tools, created_at_ms, decided_at_ms, decision_reason
+                       FROM run_outcome_learning_candidate
+                      ORDER BY candidate_id
+                   )",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap()
+    }
+
     #[test]
     fn a1_run_outcome_learning_recall_flag_on_surfaces_confirmed_refs_only_signal() {
         let db = Db::open_hub(&temp_path("a1-drive-on")).unwrap();
@@ -17325,6 +17348,78 @@ mod tests {
     }
 
     #[test]
+    fn a1_run_outcome_learning_consumer_requires_candidate_confirm() {
+        let db = Db::open_hub(&temp_path("a1-consumer-confirm")).unwrap();
+        let now = 1_000_000_000_000_i64;
+        friday_storage::agent_session::ensure_session_with_owner(
+            db.conn(),
+            "sess-a1-confirm",
+            &friday_storage::agent_session::SessionOwner {
+                user_id: Some("alice".to_string()),
+                ..friday_storage::agent_session::SessionOwner::default()
+            },
+            now,
+        )
+        .unwrap();
+        friday_storage::learning_candidate::record_run_outcome_candidates(
+            db.conn(),
+            "run-a1-confirm",
+            Some("sess-a1-confirm"),
+            3,
+            1,
+            now,
+        )
+        .unwrap();
+        let alice_ns =
+            crate::session_namespace::resolve_session_memory_namespace(None, None, Some("alice"))
+                .unwrap();
+
+        let pending = recall_preamble_for_principals_blended(
+            &db,
+            &[alice_ns.as_str()],
+            None,
+            RecallPreambleFlags {
+                a1_run_outcome_consumer_on: true,
+                ..RecallPreambleFlags::default()
+            },
+            "audit-a1-consumer-pending",
+            now + 1,
+        )
+        .unwrap();
+        assert_eq!(
+            pending, "",
+            "pending A1 candidates must not affect recall before explicit confirm"
+        );
+
+        friday_storage::learning_candidate::decide_run_outcome_candidate(
+            db.conn(),
+            "a1:run-a1-confirm:preference",
+            true,
+            now + 2,
+            Some("operator confirmed"),
+        )
+        .unwrap();
+        let confirmed = recall_preamble_for_principals_blended(
+            &db,
+            &[alice_ns.as_str()],
+            None,
+            RecallPreambleFlags {
+                a1_run_outcome_consumer_on: true,
+                ..RecallPreambleFlags::default()
+            },
+            "audit-a1-consumer-confirmed",
+            now + 3,
+        )
+        .unwrap();
+        assert!(
+            confirmed.contains("Confirmed preference/world-model learning signals")
+                && confirmed.contains("- preference:")
+                && confirmed.contains("friday://agent-run/run-a1-confirm"),
+            "confirmed preference candidate must be the first point it can affect recall: {confirmed:?}"
+        );
+    }
+
+    #[test]
     fn a1_run_outcome_learning_consumer_surfaces_preference_world_model_only() {
         let db = Db::open_hub(&temp_path("a1-consumer-on")).unwrap();
         let now = 1_000_000_000_000_i64;
@@ -17381,6 +17476,79 @@ mod tests {
         assert!(
             !preamble.contains("operator confirmed"),
             "decision reasons are operator text and must not be prompt-injected: {preamble:?}"
+        );
+        assert!(friday_storage::audit::verify_audit_chain(db.conn()).is_ok());
+    }
+
+    #[test]
+    fn a1_run_outcome_learning_consumer_is_deterministic_without_learning_mutation() {
+        let db = Db::open_hub(&temp_path("a1-consumer-deterministic")).unwrap();
+        let now = 1_000_000_000_000_i64;
+        seed_confirmed_run_outcome_learning(
+            &db,
+            "sess-a1-deterministic",
+            "alice",
+            "run-a1-deterministic",
+            now,
+        );
+        friday_storage::learning_candidate::decide_run_outcome_candidate(
+            db.conn(),
+            "a1:run-a1-deterministic:world_model",
+            true,
+            now + 2,
+            Some("operator confirmed world-model text"),
+        )
+        .unwrap();
+        let alice_ns =
+            crate::session_namespace::resolve_session_memory_namespace(None, None, Some("alice"))
+                .unwrap();
+        let before = run_outcome_learning_artifact_snapshot(&db);
+
+        let mut rendered = Vec::new();
+        for i in 0..4 {
+            rendered.push(
+                recall_preamble_for_principals_blended(
+                    &db,
+                    &[alice_ns.as_str()],
+                    None,
+                    RecallPreambleFlags {
+                        a1_run_outcome_consumer_on: true,
+                        ..RecallPreambleFlags::default()
+                    },
+                    &format!("audit-a1-consumer-deterministic-{i}"),
+                    now + 10 + i,
+                )
+                .unwrap(),
+            );
+        }
+
+        for output in &rendered[1..] {
+            assert_eq!(
+                output, &rendered[0],
+                "same confirmed learning artifacts must render byte-identical prompt text"
+            );
+        }
+        assert!(
+            rendered[0].contains("Confirmed preference/world-model learning signals")
+                && rendered[0].contains("- preference:")
+                && rendered[0].contains("- world_model:")
+        );
+        assert_eq!(
+            run_outcome_learning_artifact_snapshot(&db),
+            before,
+            "request-time recall may append audit, but must not mutate learning artifacts"
+        );
+        let consumer_audits: i64 = db
+            .conn()
+            .query_row(
+                "SELECT count(*) FROM audit_ledger WHERE action LIKE 'run_outcome_learning.consumer:%'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(
+            consumer_audits, 4,
+            "audit append is governance accounting and is allowed by the scoped no-mutation rule"
         );
         assert!(friday_storage::audit::verify_audit_chain(db.conn()).is_ok());
     }

--- a/rust-core/crates/friday-storage/src/learning_candidate.rs
+++ b/rust-core/crates/friday-storage/src/learning_candidate.rs
@@ -7,6 +7,7 @@
 
 use crate::error::{Result, StorageError};
 use rusqlite::{params, Connection, OptionalExtension};
+use std::collections::HashSet;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum RunOutcomeLearningKind {
@@ -112,6 +113,10 @@ fn row_from(r: &rusqlite::Row) -> rusqlite::Result<RunOutcomeLearningCandidateRo
 const SELECT_COLS: &str = "candidate_id, run_id, session_id, kind, state, evidence_ref, summary, \
      turns, executed_tools, created_at_ms, decided_at_ms, decision_reason";
 
+const MIN_CONFIRMED_TURNS: i64 = 1;
+const MIN_CONFIRMED_EXECUTED_TOOLS: i64 = 1;
+const MAX_ELIGIBILITY_SCAN_LIMIT: i64 = 256;
+
 pub fn record_run_outcome_candidates(
     conn: &Connection,
     run_id: &str,
@@ -192,6 +197,58 @@ pub fn list_recent_confirmed_run_outcome_candidates(
     Ok(out)
 }
 
+pub fn list_recent_eligible_confirmed_run_outcome_candidates(
+    conn: &Connection,
+    limit: i64,
+) -> Result<Vec<RunOutcomeLearningCandidateRow>> {
+    let limit = limit.max(1);
+    let scan_limit = (limit * 4).clamp(limit, MAX_ELIGIBILITY_SCAN_LIMIT);
+    let confirmed = list_recent_confirmed_run_outcome_candidates(conn, scan_limit)?;
+    let blocked_pairs = reciprocal_contradiction_pairs(&confirmed);
+    let mut out = Vec::new();
+    for row in confirmed {
+        if row.turns < MIN_CONFIRMED_TURNS || row.executed_tools < MIN_CONFIRMED_EXECUTED_TOOLS {
+            continue;
+        }
+        if let Some(pair) = contradiction_pair(&row.summary) {
+            if blocked_pairs.contains(&pair) {
+                continue;
+            }
+        }
+        out.push(row);
+        if out.len() >= limit as usize {
+            break;
+        }
+    }
+    Ok(out)
+}
+
+fn reciprocal_contradiction_pairs(
+    rows: &[RunOutcomeLearningCandidateRow],
+) -> HashSet<(String, String)> {
+    let pairs: HashSet<(String, String)> = rows
+        .iter()
+        .filter_map(|row| contradiction_pair(&row.summary))
+        .collect();
+    pairs
+        .iter()
+        .filter(|(left, right)| pairs.contains(&(right.clone(), left.clone())))
+        .cloned()
+        .collect()
+}
+
+fn contradiction_pair(summary: &str) -> Option<(String, String)> {
+    let (left, right) = summary
+        .split_once('→')
+        .or_else(|| summary.split_once("->"))?;
+    let left = left.trim().to_ascii_lowercase();
+    let right = right.trim().to_ascii_lowercase();
+    if left.is_empty() || right.is_empty() {
+        return None;
+    }
+    Some((left, right))
+}
+
 pub fn get_run_outcome_candidate(
     conn: &Connection,
     candidate_id: &str,
@@ -241,4 +298,113 @@ pub fn decide_run_outcome_candidate(
         )?;
         Ok(next)
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Db;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    static C: AtomicU64 = AtomicU64::new(0);
+
+    fn tmp(tag: &str) -> String {
+        std::env::temp_dir()
+            .join(format!(
+                "friday-a1-learning-candidate-{}-{}-{}.sqlite",
+                std::process::id(),
+                tag,
+                C.fetch_add(1, Ordering::Relaxed)
+            ))
+            .to_string_lossy()
+            .into_owned()
+    }
+
+    fn confirm_preference(db: &Db, run_id: &str, turns: i64, executed_tools: i64, now: i64) {
+        record_run_outcome_candidates(
+            db.conn(),
+            run_id,
+            Some("sess-a1"),
+            turns,
+            executed_tools,
+            now,
+        )
+        .unwrap();
+        decide_run_outcome_candidate(
+            db.conn(),
+            &format!("a1:{run_id}:preference"),
+            true,
+            now + 1,
+            Some("operator confirmed"),
+        )
+        .unwrap();
+    }
+
+    fn insert_confirmed_summary(db: &Db, id: &str, summary: &str, now: i64) {
+        db.conn()
+            .execute(
+                "INSERT INTO run_outcome_learning_candidate
+                    (candidate_id, run_id, session_id, kind, state, evidence_ref, summary,
+                     turns, executed_tools, created_at_ms, decided_at_ms, decision_reason)
+                 VALUES (?1, ?2, ?3, 'preference', 'confirmed', ?4, ?5, 2, 1, ?6, ?7, 'test')",
+                params![
+                    id,
+                    format!("run-{id}"),
+                    "sess-a1",
+                    format!("friday://agent-run/run-{id}"),
+                    summary,
+                    now,
+                    now + 1,
+                ],
+            )
+            .unwrap();
+    }
+
+    #[test]
+    fn eligible_confirmed_candidates_enforce_min_evidence() {
+        let db = Db::open_hub(&tmp("min-evidence")).unwrap();
+        confirm_preference(&db, "low", 3, 0, 100);
+        confirm_preference(&db, "ok", 3, 1, 200);
+
+        let ids: Vec<_> = list_recent_eligible_confirmed_run_outcome_candidates(db.conn(), 10)
+            .unwrap()
+            .into_iter()
+            .map(|row| row.candidate_id)
+            .collect();
+        assert_eq!(ids, vec!["a1:ok:preference"]);
+    }
+
+    #[test]
+    fn eligible_confirmed_candidates_drop_reciprocal_contradictions() {
+        let db = Db::open_hub(&tmp("contradiction")).unwrap();
+        insert_confirmed_summary(&db, "ab", "A→B", 100);
+        insert_confirmed_summary(&db, "ba", "B→A", 200);
+        insert_confirmed_summary(&db, "ac", "A→C", 300);
+
+        let rows = list_recent_eligible_confirmed_run_outcome_candidates(db.conn(), 10).unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].candidate_id, "ac");
+    }
+
+    #[test]
+    fn eligible_confirmed_candidates_are_capped_to_recent_rows() {
+        let db = Db::open_hub(&tmp("cap")).unwrap();
+        for i in 0..5 {
+            confirm_preference(&db, &format!("run-{i}"), 2, 1, 100 + i);
+        }
+
+        let ids: Vec<_> = list_recent_eligible_confirmed_run_outcome_candidates(db.conn(), 3)
+            .unwrap()
+            .into_iter()
+            .map(|row| row.candidate_id)
+            .collect();
+        assert_eq!(
+            ids,
+            vec![
+                "a1:run-4:preference",
+                "a1:run-3:preference",
+                "a1:run-2:preference",
+            ]
+        );
+    }
 }


### PR DESCRIPTION
## Summary
- route A1 run-outcome recall through an eligible-confirmed projection with min-evidence, reciprocal-contradiction removal, and recent-result cap
- add storage tests for eligibility filtering
- add Hub A1 behavior tests for candidate->confirm gating, deterministic prompt rendering, and scoped no-learning-mutation while audit append remains allowed

## Validation
- cargo fmt --manifest-path rust-core/Cargo.toml --all -- --check
- git diff --check
- cargo test --manifest-path rust-core/Cargo.toml -p friday-storage learning_candidate -- --nocapture
- cargo test --manifest-path rust-core/Cargo.toml -p friday-hub a1_run_outcome_learning_consumer -- --nocapture
- cargo test --manifest-path rust-core/Cargo.toml -p friday-hub a1_run_outcome_learning -- --nocapture

Truth labels: built-DARK/behavioral proof only; organic=0; GO-LIVE=false; v1=NO-GO.