### PR TITLE
Pin desktop route fail-closed behavior

### DIFF
--- a/docs/ops/ts-runtime-retirement-manifest.json
+++ b/docs/ops/ts-runtime-retirement-manifest.json
@@ -2084,6 +2084,7 @@
       "user_triggerable": true,
       "executes_product_logic": false,
       "proof": "src/api/http/routes/friday-desktop-routes.ts wires default/live desktop.actions.execute to TS_RUNTIME_DESKTOP_ACTION_EXECUTION_RETIRED after request validation and before calling the TypeScript desktop action service; legacy TS execution is reachable only through explicit allowTestOnlyDesktopActionExecution test-oracle wiring.",
+      "routeBehavioralTest": "test/unit/api/http/routes/friday-desktop-routes.test.ts",
       "next_action": "Replace fail-closed response with a Rust-owned desktop action execution entrypoint when available."
     },
     {
@@ -2097,6 +2098,7 @@
       "user_triggerable": true,
       "executes_product_logic": false,
       "proof": "src/api/http/routes/friday-desktop-routes.ts wires default/live desktop.actions.batch to TS_RUNTIME_DESKTOP_ACTION_EXECUTION_RETIRED after request validation and before calling the TypeScript desktop batch action service; legacy TS execution is reachable only through explicit allowTestOnlyDesktopActionExecution test-oracle wiring.",
+      "routeBehavioralTest": "test/unit/api/http/routes/friday-desktop-routes.test.ts",
       "next_action": "Replace fail-closed response with a Rust-owned desktop batch action execution entrypoint when available."
     },
     {
@@ -2110,6 +2112,7 @@
       "user_triggerable": true,
       "executes_product_logic": false,
       "proof": "src/api/http/routes/friday-desktop-routes.ts wires default/live desktop.actions.cancel to TS_RUNTIME_DESKTOP_ACTION_CONTROL_RETIRED after request validation and before calling the TypeScript desktop action cancel service (which aborts an in-flight live action); legacy TS execution is reachable only through explicit allowTestOnlyDesktopActionControlExecution test-oracle wiring.",
+      "routeBehavioralTest": "test/unit/api/http/routes/friday-desktop-routes.test.ts",
       "next_action": "Replace fail-closed response with a Rust-owned desktop action control entrypoint when available."
     },
     {
@@ -2136,6 +2139,7 @@
       "user_triggerable": true,
       "executes_product_logic": false,
       "proof": "src/api/http/routes/friday-desktop-routes.ts wires default/live desktop.recordings.start to TS_RUNTIME_DESKTOP_RECORDING_RETIRED after request validation and before calling the TypeScript desktop recording service; legacy TS execution is reachable only through explicit allowTestOnlyDesktopRecordingExecution test-oracle wiring.",
+      "routeBehavioralTest": "test/unit/api/http/routes/friday-desktop-routes.test.ts",
       "next_action": "Replace fail-closed response with a Rust-owned desktop recording entrypoint when available."
     },
     {
@@ -2149,6 +2153,7 @@
       "user_triggerable": true,
       "executes_product_logic": false,
       "proof": "src/api/http/routes/friday-desktop-routes.ts wires default/live desktop.recordings.stop to TS_RUNTIME_DESKTOP_RECORDING_RETIRED after request validation and before calling the TypeScript desktop recording service; legacy TS execution is reachable only through explicit allowTestOnlyDesktopRecordingExecution test-oracle wiring.",
+      "routeBehavioralTest": "test/unit/api/http/routes/friday-desktop-routes.test.ts",
       "next_action": "Replace fail-closed response with a Rust-owned desktop recording entrypoint when available."
     },
     {
@@ -2162,6 +2167,7 @@
       "user_triggerable": true,
       "executes_product_logic": false,
       "proof": "src/api/http/routes/friday-desktop-routes.ts wires default/live desktop.recordings.pause to TS_RUNTIME_DESKTOP_RECORDING_RETIRED after request validation and before calling the TypeScript desktop recording service; legacy TS execution is reachable only through explicit allowTestOnlyDesktopRecordingExecution test-oracle wiring.",
+      "routeBehavioralTest": "test/unit/api/http/routes/friday-desktop-routes.test.ts",
       "next_action": "Replace fail-closed response with a Rust-owned desktop recording entrypoint when available."
     },
     {
@@ -2175,6 +2181,7 @@
       "user_triggerable": true,
       "executes_product_logic": false,
       "proof": "src/api/http/routes/friday-desktop-routes.ts wires default/live desktop.recordings.resume to TS_RUNTIME_DESKTOP_RECORDING_RETIRED after request validation and before calling the TypeScript desktop recording service; legacy TS execution is reachable only through explicit allowTestOnlyDesktopRecordingExecution test-oracle wiring.",
+      "routeBehavioralTest": "test/unit/api/http/routes/friday-desktop-routes.test.ts",
       "next_action": "Replace fail-closed response with a Rust-owned desktop recording entrypoint when available."
     },
     {
@@ -2188,6 +2195,7 @@
       "user_triggerable": true,
       "executes_product_logic": false,
       "proof": "src/api/http/routes/friday-desktop-routes.ts wires default/live desktop.recordings.replay to TS_RUNTIME_DESKTOP_RECORDING_RETIRED after request validation and before calling the TypeScript desktop recording service (which re-executes recorded steps against the live desktop); legacy TS execution is reachable only through explicit allowTestOnlyDesktopRecordingExecution test-oracle wiring.",
+      "routeBehavioralTest": "test/unit/api/http/routes/friday-desktop-routes.test.ts",
       "next_action": "Replace fail-closed response with a Rust-owned desktop recording replay entrypoint when available."
     },
     {
@@ -2201,6 +2209,7 @@
       "user_triggerable": true,
       "executes_product_logic": false,
       "proof": "src/api/http/routes/friday-desktop-routes.ts wires default/live desktop.recordings.delete to TS_RUNTIME_DESKTOP_RECORDING_RETIRED after request validation and before calling the TypeScript desktop recording service; legacy TS execution is reachable only through explicit allowTestOnlyDesktopRecordingExecution test-oracle wiring.",
+      "routeBehavioralTest": "test/unit/api/http/routes/friday-desktop-routes.test.ts",
       "next_action": "Replace fail-closed response with a Rust-owned desktop recording entrypoint when available."
     },
     {
@@ -2227,6 +2236,7 @@
       "user_triggerable": true,
       "executes_product_logic": false,
       "proof": "src/api/http/routes/friday-desktop-routes.ts wires default/live desktop.elements.inspect to TS_RUNTIME_DESKTOP_ELEMENT_INSPECTION_RETIRED after request validation and before calling the TypeScript desktop adapter, which actively queries the live desktop accessibility tree and returns raw element name/value/window title/accessibility attributes; legacy TS execution is reachable only through explicit allowTestOnlyDesktopElementInspectionExecution test-oracle wiring.",
+      "routeBehavioralTest": "test/unit/api/http/routes/friday-desktop-routes.test.ts",
       "next_action": "Replace fail-closed response with a Rust-owned desktop element inspection entrypoint when available."
     },
     {
@@ -2303,6 +2313,7 @@
       "user_triggerable": true,
       "executes_product_logic": false,
       "proof": "Default/live hub wiring (src/hub/friday-hub-bootstrap.ts desktopRouteDeps.policies.create) throws DESKTOP_POLICY_NOT_PERSISTED (503, status proof_pending) before any policy product logic, persistence, or enforcement; no durable storage/evaluator/audit exists. test/unit/hub/bootstrap/desktop-policy-fail-closed.test.ts is a source-wiring regression guard that asserts these throwing deps remain present (it checks bootstrap source text, not runtime 503 behavior). The route owns no policy truth.",
+      "routeBehavioralTest": "test/unit/api/http/routes/friday-desktop-routes.test.ts",
       "next_action": "Replace the proof_pending fail-closed response with a Rust-owned desktop policy create/persist/enforce entrypoint when available."
     },
     {
@@ -2342,6 +2353,7 @@
       "user_triggerable": true,
       "executes_product_logic": false,
       "proof": "Default/live hub wiring (src/hub/friday-hub-bootstrap.ts desktopRouteDeps.policies.update) throws DESKTOP_POLICY_NOT_PERSISTED (503, status proof_pending) before any policy mutation; no durable storage/evaluator/audit exists. test/unit/hub/bootstrap/desktop-policy-fail-closed.test.ts is a source-wiring regression guard that asserts these throwing deps remain present (it checks bootstrap source text, not runtime 503 behavior).",
+      "routeBehavioralTest": "test/unit/api/http/routes/friday-desktop-routes.test.ts",
       "next_action": "Replace the proof_pending fail-closed response with a Rust-owned desktop policy update/persist/enforce entrypoint when available."
     },
     {
@@ -2355,6 +2367,7 @@
       "user_triggerable": true,
       "executes_product_logic": false,
       "proof": "Default/live hub wiring (src/hub/friday-hub-bootstrap.ts desktopRouteDeps.policies.delete) throws DESKTOP_POLICY_NOT_PERSISTED (503, status proof_pending) before any policy mutation. test/unit/hub/bootstrap/desktop-policy-fail-closed.test.ts is a source-wiring regression guard that asserts these throwing deps remain present (it checks bootstrap source text, not runtime 503 behavior).",
+      "routeBehavioralTest": "test/unit/api/http/routes/friday-desktop-routes.test.ts",
       "next_action": "Replace the proof_pending fail-closed response with a Rust-owned desktop policy delete entrypoint when available."
     },
     {
@@ -2368,6 +2381,7 @@
       "user_triggerable": true,
       "executes_product_logic": false,
       "proof": "Default/live hub wiring (src/hub/friday-hub-bootstrap.ts desktopRouteDeps.policies.addRule) throws DESKTOP_POLICY_NOT_PERSISTED (503, status proof_pending) before any policy rule mutation. test/unit/hub/bootstrap/desktop-policy-fail-closed.test.ts is a source-wiring regression guard that asserts these throwing deps remain present (it checks bootstrap source text, not runtime 503 behavior).",
+      "routeBehavioralTest": "test/unit/api/http/routes/friday-desktop-routes.test.ts",
       "next_action": "Replace the proof_pending fail-closed response with a Rust-owned desktop policy rule create entrypoint when available."
     },
     {
@@ -2381,6 +2395,7 @@
       "user_triggerable": true,
       "executes_product_logic": false,
       "proof": "Default/live hub wiring (src/hub/friday-hub-bootstrap.ts desktopRouteDeps.policies.removeRule) throws DESKTOP_POLICY_NOT_PERSISTED (503, status proof_pending) before any policy rule mutation. test/unit/hub/bootstrap/desktop-policy-fail-closed.test.ts is a source-wiring regression guard that asserts these throwing deps remain present (it checks bootstrap source text, not runtime 503 behavior).",
+      "routeBehavioralTest": "test/unit/api/http/routes/friday-desktop-routes.test.ts",
       "next_action": "Replace the proof_pending fail-closed response with a Rust-owned desktop policy rule delete entrypoint when available."
     },
     {
@@ -2394,6 +2409,7 @@
       "user_triggerable": true,
       "executes_product_logic": false,
       "proof": "Default/live hub wiring (src/hub/friday-hub-bootstrap.ts desktopRouteDeps.permissions.respond) throws DESKTOP_PERMISSION_DECISION_NOT_PERSISTED (503, status proof_pending) before any permission decision is recorded or enforced; prompt decisions are not durably stored. test/unit/hub/bootstrap/desktop-policy-fail-closed.test.ts is a source-wiring regression guard that asserts these throwing deps remain present (it checks bootstrap source text, not runtime 503 behavior).",
+      "routeBehavioralTest": "test/unit/api/http/routes/friday-desktop-routes.test.ts",
       "next_action": "Replace the proof_pending fail-closed response with a Rust-owned desktop permission decision entrypoint when available."
     },
     {

--- a/test/unit/api/http/routes/friday-desktop-routes.test.ts
+++ b/test/unit/api/http/routes/friday-desktop-routes.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
+import { FridayDomainError } from "#errors";
 import { createFridayDesktopRoutes } from "../../../../../src/api/http/routes/friday-desktop-routes.js";
 import type { FridayDesktopRoutesDeps } from "../../../../../src/api/http/routes/friday-desktop-routes.js";
 import type { FridayRouteDefinition } from "../../../../../src/api/model/friday-api-common.types.js";
@@ -69,6 +70,13 @@ function findRoute(
   const route = routes.find((r) => r.operationId === operationId);
   if (!route) throw new Error(`Route ${operationId} not found`);
   return route;
+}
+
+function proofPendingDesktopError(code: "DESKTOP_POLICY_NOT_PERSISTED" | "DESKTOP_PERMISSION_DECISION_NOT_PERSISTED") {
+  return new FridayDomainError(code, "Desktop route dependency is proof-pending and fail-closed.", {
+    httpStatus: 503,
+    details: { status: "proof_pending" },
+  });
 }
 
 // ─── Tests ───
@@ -327,8 +335,28 @@ describe("createFridayDesktopRoutes", () => {
         ),
       ).rejects.toMatchObject({ code: "TS_RUNTIME_DESKTOP_RECORDING_RETIRED", httpStatus: 503 });
       await expect(
+        findRoute(routes, "desktop.recordings.stop").handler(
+          makeCtx({ params: { recordingId: "rec-1" }, body: { idempotencyKey: "k-fc-stop" } }),
+        ),
+      ).rejects.toMatchObject({ code: "TS_RUNTIME_DESKTOP_RECORDING_RETIRED", httpStatus: 503 });
+      await expect(
+        findRoute(routes, "desktop.recordings.pause").handler(
+          makeCtx({ params: { recordingId: "rec-1" }, body: { idempotencyKey: "k-fc-pause" } }),
+        ),
+      ).rejects.toMatchObject({ code: "TS_RUNTIME_DESKTOP_RECORDING_RETIRED", httpStatus: 503 });
+      await expect(
+        findRoute(routes, "desktop.recordings.resume").handler(
+          makeCtx({ params: { recordingId: "rec-1" }, body: { idempotencyKey: "k-fc-resume" } }),
+        ),
+      ).rejects.toMatchObject({ code: "TS_RUNTIME_DESKTOP_RECORDING_RETIRED", httpStatus: 503 });
+      await expect(
         findRoute(routes, "desktop.recordings.replay").handler(
           makeCtx({ params: { recordingId: "rec-1" }, body: { idempotencyKey: "k-fc-replay" } }),
+        ),
+      ).rejects.toMatchObject({ code: "TS_RUNTIME_DESKTOP_RECORDING_RETIRED", httpStatus: 503 });
+      await expect(
+        findRoute(routes, "desktop.recordings.delete").handler(
+          makeCtx({ params: { recordingId: "rec-1" }, body: { idempotencyKey: "k-fc-delete" } }),
         ),
       ).rejects.toMatchObject({ code: "TS_RUNTIME_DESKTOP_RECORDING_RETIRED", httpStatus: 503 });
       await expect(
@@ -338,7 +366,11 @@ describe("createFridayDesktopRoutes", () => {
       ).rejects.toMatchObject({ code: "TS_RUNTIME_DESKTOP_RECORDING_RETIRED", httpStatus: 503 });
 
       expect(deps.recordings.start).not.toHaveBeenCalled();
+      expect(deps.recordings.stop).not.toHaveBeenCalled();
+      expect(deps.recordings.pause).not.toHaveBeenCalled();
+      expect(deps.recordings.resume).not.toHaveBeenCalled();
       expect(deps.recordings.replay).not.toHaveBeenCalled();
+      expect(deps.recordings.delete).not.toHaveBeenCalled();
       expect(deps.recordings.listSteps).not.toHaveBeenCalled();
     });
   });
@@ -441,6 +473,50 @@ describe("createFridayDesktopRoutes", () => {
       }));
       expect(deps.policies.removeRule).toHaveBeenCalledWith("pol-1", "rule-1", { etag: "e1", idempotencyKey: "k14" });
     });
+
+    it("propagates default/live bootstrap proof-pending policy 503s", async () => {
+      const deps = makeDeps({
+        policies: {
+          create: vi.fn(() => { throw proofPendingDesktopError("DESKTOP_POLICY_NOT_PERSISTED"); }),
+          get: vi.fn(() => { throw proofPendingDesktopError("DESKTOP_POLICY_NOT_PERSISTED"); }),
+          list: vi.fn(() => { throw proofPendingDesktopError("DESKTOP_POLICY_NOT_PERSISTED"); }),
+          update: vi.fn(() => { throw proofPendingDesktopError("DESKTOP_POLICY_NOT_PERSISTED"); }),
+          delete: vi.fn(() => { throw proofPendingDesktopError("DESKTOP_POLICY_NOT_PERSISTED"); }),
+          addRule: vi.fn(() => { throw proofPendingDesktopError("DESKTOP_POLICY_NOT_PERSISTED"); }),
+          removeRule: vi.fn(() => { throw proofPendingDesktopError("DESKTOP_POLICY_NOT_PERSISTED"); }),
+        },
+      });
+      const routes = createFridayDesktopRoutes(deps);
+
+      await expect(
+        findRoute(routes, "desktop.policies.create").handler(
+          makeCtx({ body: { name: "Safe", rules: [], idempotencyKey: "k-pol-create" } }),
+        ),
+      ).rejects.toMatchObject({ code: "DESKTOP_POLICY_NOT_PERSISTED", httpStatus: 503 });
+      await expect(
+        findRoute(routes, "desktop.policies.update").handler(
+          makeCtx({ params: { policyId: "pol-1" }, body: { etag: "e1", idempotencyKey: "k-pol-update" } }),
+        ),
+      ).rejects.toMatchObject({ code: "DESKTOP_POLICY_NOT_PERSISTED", httpStatus: 503 });
+      await expect(
+        findRoute(routes, "desktop.policies.delete").handler(
+          makeCtx({ params: { policyId: "pol-1" }, body: { etag: "e1", idempotencyKey: "k-pol-delete" } }),
+        ),
+      ).rejects.toMatchObject({ code: "DESKTOP_POLICY_NOT_PERSISTED", httpStatus: 503 });
+      await expect(
+        findRoute(routes, "desktop.policies.rules.create").handler(
+          makeCtx({
+            params: { policyId: "pol-1" },
+            body: { rule: { actionType: "click", appFilter: "*", riskLevel: "low", decision: "allow" }, etag: "e1", idempotencyKey: "k-pol-rule-create" },
+          }),
+        ),
+      ).rejects.toMatchObject({ code: "DESKTOP_POLICY_NOT_PERSISTED", httpStatus: 503 });
+      await expect(
+        findRoute(routes, "desktop.policies.rules.delete").handler(
+          makeCtx({ params: { policyId: "pol-1", ruleId: "rule-1" }, body: { etag: "e1", idempotencyKey: "k-pol-rule-delete" } }),
+        ),
+      ).rejects.toMatchObject({ code: "DESKTOP_POLICY_NOT_PERSISTED", httpStatus: 503 });
+    });
   });
 
   // ─── Permissions ───
@@ -485,6 +561,26 @@ describe("createFridayDesktopRoutes", () => {
 
       await route.handler(makeCtx({ query: { actionType: "click" } }));
       expect(deps.permissions.listDecisions).toHaveBeenCalled();
+    });
+
+    it("propagates default/live bootstrap proof-pending permission decision 503s", async () => {
+      const deps = makeDeps({
+        permissions: {
+          list: vi.fn().mockResolvedValue({ permissions: [], platform: "darwin" }),
+          respond: vi.fn(() => { throw proofPendingDesktopError("DESKTOP_PERMISSION_DECISION_NOT_PERSISTED"); }),
+          listDecisions: vi.fn(() => { throw proofPendingDesktopError("DESKTOP_PERMISSION_DECISION_NOT_PERSISTED"); }),
+        },
+      });
+      const routes = createFridayDesktopRoutes(deps);
+
+      await expect(
+        findRoute(routes, "desktop.permissions.respond").handler(
+          makeCtx({ params: { promptId: "p-1" }, body: { decision: "allow_once", idempotencyKey: "k-perm-respond" } }),
+        ),
+      ).rejects.toMatchObject({ code: "DESKTOP_PERMISSION_DECISION_NOT_PERSISTED", httpStatus: 503 });
+      await expect(
+        findRoute(routes, "desktop.permissions.decisions.list").handler(makeCtx({ query: { actionType: "click" } })),
+      ).rejects.toMatchObject({ code: "DESKTOP_PERMISSION_DECISION_NOT_PERSISTED", httpStatus: 503 });
     });
   });
 


### PR DESCRIPTION
## Summary
- add routeBehavioralTest anchors for 16 desktop non-GET fail-closed route surfaces
- expand desktop route tests to cover the remaining recording lifecycle fail-closed routes
- add bootstrap-style proof-pending 503 route tests for desktop policy mutations and permission prompt responses

## Validation
- npx vitest run test/unit/api/http/routes/friday-desktop-routes.test.ts
- node scripts/quality/check-ts-runtime-retirement.mjs
- npm run test:mechanism-wiring:behavior
- npm run typecheck:src
- npm run lint (0 errors; existing warnings only)
- git diff --check

Truth labels: route behavior proof only; organic=0; GO-LIVE=false; v1=NO-GO.