### PR TITLE
Pin task workflow route fail-closed behavior

### DIFF
--- a/docs/ops/ts-runtime-retirement-manifest.json
+++ b/docs/ops/ts-runtime-retirement-manifest.json
@@ -3228,6 +3228,7 @@
       "classification": "fail_closed",
       "user_triggerable": true,
       "executes_product_logic": false,
+      "routeBehavioralTest": "test/unit/api/routes/friday-task-workflow-routes.test.ts",
       "proof": "src/api/http/routes/friday-task-workflow-routes.ts fail-closes default/live task.workflows.preview to TS_RUNTIME_TASK_WORKFLOW_RETIRED after the TASK_WORKFLOWS_DISABLED availability check and request-body validation (400) (the route is public and non-mutating, so there is no bound-principal step), and immediately before the TypeScript task-workflow preview computation; legacy behavior is reachable only through explicit allowTestOnlyTaskWorkflowExecution test-oracle wiring.",
       "next_action": "Replace the fail-closed response with the Rust-owned task-workflow execution entrypoint when available."
     },
@@ -3241,6 +3242,7 @@
       "classification": "fail_closed",
       "user_triggerable": true,
       "executes_product_logic": false,
+      "routeBehavioralTest": "test/unit/api/routes/friday-task-workflow-routes.test.ts",
       "proof": "src/api/http/routes/friday-task-workflow-routes.ts fail-closes default/live task.workflows.create to TS_RUNTIME_TASK_WORKFLOW_RETIRED after the TASK_WORKFLOWS_DISABLED availability check, the bound-principal owner/session/channel check (401), and request-body validation (400), and immediately before the TypeScript task-workflow service mutation; legacy behavior is reachable only through explicit allowTestOnlyTaskWorkflowExecution test-oracle wiring.",
       "next_action": "Replace the fail-closed response with the Rust-owned task-workflow execution entrypoint when available."
     },
@@ -3254,6 +3256,7 @@
       "classification": "fail_closed",
       "user_triggerable": true,
       "executes_product_logic": false,
+      "routeBehavioralTest": "test/unit/api/routes/friday-task-workflow-routes.test.ts",
       "proof": "src/api/http/routes/friday-task-workflow-routes.ts fail-closes default/live task.workflows.revise to TS_RUNTIME_TASK_WORKFLOW_RETIRED after the TASK_WORKFLOWS_DISABLED availability check, the bound-principal owner/session/channel check (401), and request-body validation (400), and immediately before the TypeScript task-workflow service mutation; legacy behavior is reachable only through explicit allowTestOnlyTaskWorkflowExecution test-oracle wiring.",
       "next_action": "Replace the fail-closed response with the Rust-owned task-workflow execution entrypoint when available."
     },
@@ -3267,6 +3270,7 @@
       "classification": "fail_closed",
       "user_triggerable": true,
       "executes_product_logic": false,
+      "routeBehavioralTest": "test/unit/api/routes/friday-task-workflow-routes.test.ts",
       "proof": "src/api/http/routes/friday-task-workflow-routes.ts fail-closes default/live task.workflows.closeout to TS_RUNTIME_TASK_WORKFLOW_RETIRED after the TASK_WORKFLOWS_DISABLED availability check and the bound-principal owner/session/channel check (401), and immediately before the TypeScript task-workflow service mutation; legacy behavior is reachable only through explicit allowTestOnlyTaskWorkflowExecution test-oracle wiring.",
       "next_action": "Replace the fail-closed response with the Rust-owned task-workflow execution entrypoint when available."
     },
@@ -3280,6 +3284,7 @@
       "classification": "fail_closed",
       "user_triggerable": true,
       "executes_product_logic": false,
+      "routeBehavioralTest": "test/unit/api/routes/friday-task-workflow-routes.test.ts",
       "proof": "src/api/http/routes/friday-task-workflow-routes.ts fail-closes default/live task.workflows.claims.create to TS_RUNTIME_TASK_WORKFLOW_RETIRED after the TASK_WORKFLOWS_DISABLED availability check, the bound-principal owner/session/channel check (401), and request-body validation (400), and immediately before the TypeScript task-workflow service mutation; legacy behavior is reachable only through explicit allowTestOnlyTaskWorkflowExecution test-oracle wiring.",
       "next_action": "Replace the fail-closed response with the Rust-owned task-workflow execution entrypoint when available."
     },
@@ -3293,6 +3298,7 @@
       "classification": "fail_closed",
       "user_triggerable": true,
       "executes_product_logic": false,
+      "routeBehavioralTest": "test/unit/api/routes/friday-task-workflow-routes.test.ts",
       "proof": "src/api/http/routes/friday-task-workflow-routes.ts fail-closes default/live task.workflows.claims.block to TS_RUNTIME_TASK_WORKFLOW_RETIRED after the TASK_WORKFLOWS_DISABLED availability check, the bound-principal owner/session/channel check (401), and request-body validation (400), and immediately before the TypeScript task-workflow service mutation; legacy behavior is reachable only through explicit allowTestOnlyTaskWorkflowExecution test-oracle wiring.",
       "next_action": "Replace the fail-closed response with the Rust-owned task-workflow execution entrypoint when available."
     },
@@ -3306,6 +3312,7 @@
       "classification": "fail_closed",
       "user_triggerable": true,
       "executes_product_logic": false,
+      "routeBehavioralTest": "test/unit/api/routes/friday-task-workflow-routes.test.ts",
       "proof": "src/api/http/routes/friday-task-workflow-routes.ts fail-closes default/live task.workflows.claims.evidence.attach to TS_RUNTIME_TASK_WORKFLOW_RETIRED after the TASK_WORKFLOWS_DISABLED availability check, the bound-principal owner/session/channel check (401), and request-body validation (400), and immediately before the TypeScript task-workflow service mutation; legacy behavior is reachable only through explicit allowTestOnlyTaskWorkflowExecution test-oracle wiring.",
       "next_action": "Replace the fail-closed response with the Rust-owned task-workflow execution entrypoint when available."
     },
@@ -3319,6 +3326,7 @@
       "classification": "fail_closed",
       "user_triggerable": true,
       "executes_product_logic": false,
+      "routeBehavioralTest": "test/unit/api/routes/friday-task-workflow-routes.test.ts",
       "proof": "src/api/http/routes/friday-task-workflow-routes.ts fail-closes default/live task.workflows.claims.verify to TS_RUNTIME_TASK_WORKFLOW_RETIRED after the TASK_WORKFLOWS_DISABLED availability check, the bound-principal owner/session/channel check (401), and request-body validation (400), and immediately before the TypeScript task-workflow service mutation; legacy behavior is reachable only through explicit allowTestOnlyTaskWorkflowExecution test-oracle wiring.",
       "next_action": "Replace the fail-closed response with the Rust-owned task-workflow execution entrypoint when available."
     },
@@ -3332,6 +3340,7 @@
       "classification": "fail_closed",
       "user_triggerable": true,
       "executes_product_logic": false,
+      "routeBehavioralTest": "test/unit/api/routes/friday-task-workflow-routes.test.ts",
       "proof": "src/api/http/routes/friday-task-workflow-routes.ts fail-closes default/live task.workflows.lanes.executor.open to TS_RUNTIME_TASK_WORKFLOW_RETIRED after the TASK_WORKFLOWS_DISABLED availability check, the bound-principal owner/session/channel check (401), and request-body validation (400), and immediately before the TypeScript task-workflow service mutation; legacy behavior is reachable only through explicit allowTestOnlyTaskWorkflowExecution test-oracle wiring.",
       "next_action": "Replace the fail-closed response with the Rust-owned task-workflow execution entrypoint when available."
     },
@@ -3345,6 +3354,7 @@
       "classification": "fail_closed",
       "user_triggerable": true,
       "executes_product_logic": false,
+      "routeBehavioralTest": "test/unit/api/routes/friday-task-workflow-routes.test.ts",
       "proof": "src/api/http/routes/friday-task-workflow-routes.ts fail-closes default/live task.workflows.lanes.verifier.open to TS_RUNTIME_TASK_WORKFLOW_RETIRED after the TASK_WORKFLOWS_DISABLED availability check, the bound-principal owner/session/channel check (401), and request-body validation (400), and immediately before the TypeScript task-workflow service mutation; legacy behavior is reachable only through explicit allowTestOnlyTaskWorkflowExecution test-oracle wiring.",
       "next_action": "Replace the fail-closed response with the Rust-owned task-workflow execution entrypoint when available."
     },
@@ -3358,6 +3368,7 @@
       "classification": "fail_closed",
       "user_triggerable": true,
       "executes_product_logic": false,
+      "routeBehavioralTest": "test/unit/api/routes/friday-task-workflow-routes.test.ts",
       "proof": "src/api/http/routes/friday-task-workflow-routes.ts fail-closes default/live task.workflows.lanes.complete to TS_RUNTIME_TASK_WORKFLOW_RETIRED after the TASK_WORKFLOWS_DISABLED availability check, the bound-principal owner/session/channel check (401), and request-body validation (400), and immediately before the TypeScript task-workflow service mutation; legacy behavior is reachable only through explicit allowTestOnlyTaskWorkflowExecution test-oracle wiring.",
       "next_action": "Replace the fail-closed response with the Rust-owned task-workflow execution entrypoint when available."
     },
@@ -3371,6 +3382,7 @@
       "classification": "fail_closed",
       "user_triggerable": true,
       "executes_product_logic": false,
+      "routeBehavioralTest": "test/unit/api/routes/friday-task-workflow-routes.test.ts",
       "proof": "src/api/http/routes/friday-task-workflow-routes.ts fail-closes default/live task.workflows.lanes.verdict to TS_RUNTIME_TASK_WORKFLOW_RETIRED after the TASK_WORKFLOWS_DISABLED availability check, the bound-principal owner/session/channel check (401), and request-body validation (400), and immediately before the TypeScript task-workflow service mutation; legacy behavior is reachable only through explicit allowTestOnlyTaskWorkflowExecution test-oracle wiring.",
       "next_action": "Replace the fail-closed response with the Rust-owned task-workflow execution entrypoint when available."
     },
@@ -3384,6 +3396,7 @@
       "classification": "fail_closed",
       "user_triggerable": true,
       "executes_product_logic": false,
+      "routeBehavioralTest": "test/unit/api/routes/friday-task-workflow-routes.test.ts",
       "proof": "src/api/http/routes/friday-task-workflow-routes.ts fail-closes default/live task.workflows.lanes.cli.handoff.record to TS_RUNTIME_TASK_WORKFLOW_RETIRED after the TASK_WORKFLOWS_DISABLED availability check, the bound-principal owner/session/channel check (401), and request-body validation (400), and immediately before the TypeScript task-workflow service mutation; legacy behavior is reachable only through explicit allowTestOnlyTaskWorkflowExecution test-oracle wiring.",
       "next_action": "Replace the fail-closed response with the Rust-owned task-workflow execution entrypoint when available."
     },
@@ -3397,6 +3410,7 @@
       "classification": "fail_closed",
       "user_triggerable": true,
       "executes_product_logic": false,
+      "routeBehavioralTest": "test/unit/api/routes/friday-task-workflow-routes.test.ts",
       "proof": "src/api/http/routes/friday-task-workflow-routes.ts fail-closes default/live task.workflows.channel.command.issue to TS_RUNTIME_TASK_WORKFLOW_RETIRED after the TASK_WORKFLOWS_DISABLED availability check, the bound-principal owner/session/channel check (401), and request-body validation (400), and immediately before the TypeScript task-workflow service mutation; legacy behavior is reachable only through explicit allowTestOnlyTaskWorkflowExecution test-oracle wiring.",
       "next_action": "Replace the fail-closed response with the Rust-owned task-workflow execution entrypoint when available."
     },
@@ -3410,6 +3424,7 @@
       "classification": "fail_closed",
       "user_triggerable": true,
       "executes_product_logic": false,
+      "routeBehavioralTest": "test/unit/api/routes/friday-task-workflow-routes.test.ts",
       "proof": "src/api/http/routes/friday-task-workflow-routes.ts fail-closes default/live task.workflows.channel.command.confirm to TS_RUNTIME_TASK_WORKFLOW_RETIRED after the TASK_WORKFLOWS_DISABLED availability check, the bound-principal owner/session/channel check (401), and request-body validation (400), and immediately before the TypeScript task-workflow service mutation; legacy behavior is reachable only through explicit allowTestOnlyTaskWorkflowExecution test-oracle wiring.",
       "next_action": "Replace the fail-closed response with the Rust-owned task-workflow execution entrypoint when available."
     },

--- a/docs/ops/ts-runtime-retirement-manifest.json
+++ b/docs/ops/ts-runtime-retirement-manifest.json
@@ -2084,6 +2084,7 @@
       "user_triggerable": true,
       "executes_product_logic": false,
       "proof": "src/api/http/routes/friday-desktop-routes.ts wires default/live desktop.actions.execute to TS_RUNTIME_DESKTOP_ACTION_EXECUTION_RETIRED after request validation and before calling the TypeScript desktop action service; legacy TS execution is reachable only through explicit allowTestOnlyDesktopActionExecution test-oracle wiring.",
+      "routeBehavioralTest": "test/unit/api/http/routes/friday-desktop-routes.test.ts",
       "next_action": "Replace fail-closed response with a Rust-owned desktop action execution entrypoint when available."
     },
     {
@@ -2097,6 +2098,7 @@
       "user_triggerable": true,
       "executes_product_logic": false,
       "proof": "src/api/http/routes/friday-desktop-routes.ts wires default/live desktop.actions.batch to TS_RUNTIME_DESKTOP_ACTION_EXECUTION_RETIRED after request validation and before calling the TypeScript desktop batch action service; legacy TS execution is reachable only through explicit allowTestOnlyDesktopActionExecution test-oracle wiring.",
+      "routeBehavioralTest": "test/unit/api/http/routes/friday-desktop-routes.test.ts",
       "next_action": "Replace fail-closed response with a Rust-owned desktop batch action execution entrypoint when available."
     },
     {
@@ -2110,6 +2112,7 @@
       "user_triggerable": true,
       "executes_product_logic": false,
       "proof": "src/api/http/routes/friday-desktop-routes.ts wires default/live desktop.actions.cancel to TS_RUNTIME_DESKTOP_ACTION_CONTROL_RETIRED after request validation and before calling the TypeScript desktop action cancel service (which aborts an in-flight live action); legacy TS execution is reachable only through explicit allowTestOnlyDesktopActionControlExecution test-oracle wiring.",
+      "routeBehavioralTest": "test/unit/api/http/routes/friday-desktop-routes.test.ts",
       "next_action": "Replace fail-closed response with a Rust-owned desktop action control entrypoint when available."
     },
     {
@@ -2136,6 +2139,7 @@
       "user_triggerable": true,
       "executes_product_logic": false,
       "proof": "src/api/http/routes/friday-desktop-routes.ts wires default/live desktop.recordings.start to TS_RUNTIME_DESKTOP_RECORDING_RETIRED after request validation and before calling the TypeScript desktop recording service; legacy TS execution is reachable only through explicit allowTestOnlyDesktopRecordingExecution test-oracle wiring.",
+      "routeBehavioralTest": "test/unit/api/http/routes/friday-desktop-routes.test.ts",
       "next_action": "Replace fail-closed response with a Rust-owned desktop recording entrypoint when available."
     },
     {
@@ -2149,6 +2153,7 @@
       "user_triggerable": true,
       "executes_product_logic": false,
       "proof": "src/api/http/routes/friday-desktop-routes.ts wires default/live desktop.recordings.stop to TS_RUNTIME_DESKTOP_RECORDING_RETIRED after request validation and before calling the TypeScript desktop recording service; legacy TS execution is reachable only through explicit allowTestOnlyDesktopRecordingExecution test-oracle wiring.",
+      "routeBehavioralTest": "test/unit/api/http/routes/friday-desktop-routes.test.ts",
       "next_action": "Replace fail-closed response with a Rust-owned desktop recording entrypoint when available."
     },
     {
@@ -2162,6 +2167,7 @@
       "user_triggerable": true,
       "executes_product_logic": false,
       "proof": "src/api/http/routes/friday-desktop-routes.ts wires default/live desktop.recordings.pause to TS_RUNTIME_DESKTOP_RECORDING_RETIRED after request validation and before calling the TypeScript desktop recording service; legacy TS execution is reachable only through explicit allowTestOnlyDesktopRecordingExecution test-oracle wiring.",
+      "routeBehavioralTest": "test/unit/api/http/routes/friday-desktop-routes.test.ts",
       "next_action": "Replace fail-closed response with a Rust-owned desktop recording entrypoint when available."
     },
     {
@@ -2175,6 +2181,7 @@
       "user_triggerable": true,
       "executes_product_logic": false,
       "proof": "src/api/http/routes/friday-desktop-routes.ts wires default/live desktop.recordings.resume to TS_RUNTIME_DESKTOP_RECORDING_RETIRED after request validation and before calling the TypeScript desktop recording service; legacy TS execution is reachable only through explicit allowTestOnlyDesktopRecordingExecution test-oracle wiring.",
+      "routeBehavioralTest": "test/unit/api/http/routes/friday-desktop-routes.test.ts",
       "next_action": "Replace fail-closed response with a Rust-owned desktop recording entrypoint when available."
     },
     {
@@ -2188,6 +2195,7 @@
       "user_triggerable": true,
       "executes_product_logic": false,
       "proof": "src/api/http/routes/friday-desktop-routes.ts wires default/live desktop.recordings.replay to TS_RUNTIME_DESKTOP_RECORDING_RETIRED after request validation and before calling the TypeScript desktop recording service (which re-executes recorded steps against the live desktop); legacy TS execution is reachable only through explicit allowTestOnlyDesktopRecordingExecution test-oracle wiring.",
+      "routeBehavioralTest": "test/unit/api/http/routes/friday-desktop-routes.test.ts",
       "next_action": "Replace fail-closed response with a Rust-owned desktop recording replay entrypoint when available."
     },
     {
@@ -2201,6 +2209,7 @@
       "user_triggerable": true,
       "executes_product_logic": false,
       "proof": "src/api/http/routes/friday-desktop-routes.ts wires default/live desktop.recordings.delete to TS_RUNTIME_DESKTOP_RECORDING_RETIRED after request validation and before calling the TypeScript desktop recording service; legacy TS execution is reachable only through explicit allowTestOnlyDesktopRecordingExecution test-oracle wiring.",
+      "routeBehavioralTest": "test/unit/api/http/routes/friday-desktop-routes.test.ts",
       "next_action": "Replace fail-closed response with a Rust-owned desktop recording entrypoint when available."
     },
     {
@@ -2227,6 +2236,7 @@
       "user_triggerable": true,
       "executes_product_logic": false,
       "proof": "src/api/http/routes/friday-desktop-routes.ts wires default/live desktop.elements.inspect to TS_RUNTIME_DESKTOP_ELEMENT_INSPECTION_RETIRED after request validation and before calling the TypeScript desktop adapter, which actively queries the live desktop accessibility tree and returns raw element name/value/window title/accessibility attributes; legacy TS execution is reachable only through explicit allowTestOnlyDesktopElementInspectionExecution test-oracle wiring.",
+      "routeBehavioralTest": "test/unit/api/http/routes/friday-desktop-routes.test.ts",
       "next_action": "Replace fail-closed response with a Rust-owned desktop element inspection entrypoint when available."
     },
     {
@@ -2303,6 +2313,7 @@
       "user_triggerable": true,
       "executes_product_logic": false,
       "proof": "Default/live hub wiring (src/hub/friday-hub-bootstrap.ts desktopRouteDeps.policies.create) throws DESKTOP_POLICY_NOT_PERSISTED (503, status proof_pending) before any policy product logic, persistence, or enforcement; no durable storage/evaluator/audit exists. test/unit/hub/bootstrap/desktop-policy-fail-closed.test.ts is a source-wiring regression guard that asserts these throwing deps remain present (it checks bootstrap source text, not runtime 503 behavior). The route owns no policy truth.",
+      "routeBehavioralTest": "test/unit/api/http/routes/friday-desktop-routes.test.ts",
       "next_action": "Replace the proof_pending fail-closed response with a Rust-owned desktop policy create/persist/enforce entrypoint when available."
     },
     {
@@ -2342,6 +2353,7 @@
       "user_triggerable": true,
       "executes_product_logic": false,
       "proof": "Default/live hub wiring (src/hub/friday-hub-bootstrap.ts desktopRouteDeps.policies.update) throws DESKTOP_POLICY_NOT_PERSISTED (503, status proof_pending) before any policy mutation; no durable storage/evaluator/audit exists. test/unit/hub/bootstrap/desktop-policy-fail-closed.test.ts is a source-wiring regression guard that asserts these throwing deps remain present (it checks bootstrap source text, not runtime 503 behavior).",
+      "routeBehavioralTest": "test/unit/api/http/routes/friday-desktop-routes.test.ts",
       "next_action": "Replace the proof_pending fail-closed response with a Rust-owned desktop policy update/persist/enforce entrypoint when available."
     },
     {
@@ -2355,6 +2367,7 @@
       "user_triggerable": true,
       "executes_product_logic": false,
       "proof": "Default/live hub wiring (src/hub/friday-hub-bootstrap.ts desktopRouteDeps.policies.delete) throws DESKTOP_POLICY_NOT_PERSISTED (503, status proof_pending) before any policy mutation. test/unit/hub/bootstrap/desktop-policy-fail-closed.test.ts is a source-wiring regression guard that asserts these throwing deps remain present (it checks bootstrap source text, not runtime 503 behavior).",
+      "routeBehavioralTest": "test/unit/api/http/routes/friday-desktop-routes.test.ts",
       "next_action": "Replace the proof_pending fail-closed response with a Rust-owned desktop policy delete entrypoint when available."
     },
     {
@@ -2368,6 +2381,7 @@
       "user_triggerable": true,
       "executes_product_logic": false,
       "proof": "Default/live hub wiring (src/hub/friday-hub-bootstrap.ts desktopRouteDeps.policies.addRule) throws DESKTOP_POLICY_NOT_PERSISTED (503, status proof_pending) before any policy rule mutation. test/unit/hub/bootstrap/desktop-policy-fail-closed.test.ts is a source-wiring regression guard that asserts these throwing deps remain present (it checks bootstrap source text, not runtime 503 behavior).",
+      "routeBehavioralTest": "test/unit/api/http/routes/friday-desktop-routes.test.ts",
       "next_action": "Replace the proof_pending fail-closed response with a Rust-owned desktop policy rule create entrypoint when available."
     },
     {
@@ -2381,6 +2395,7 @@
       "user_triggerable": true,
       "executes_product_logic": false,
       "proof": "Default/live hub wiring (src/hub/friday-hub-bootstrap.ts desktopRouteDeps.policies.removeRule) throws DESKTOP_POLICY_NOT_PERSISTED (503, status proof_pending) before any policy rule mutation. test/unit/hub/bootstrap/desktop-policy-fail-closed.test.ts is a source-wiring regression guard that asserts these throwing deps remain present (it checks bootstrap source text, not runtime 503 behavior).",
+      "routeBehavioralTest": "test/unit/api/http/routes/friday-desktop-routes.test.ts",
       "next_action": "Replace the proof_pending fail-closed response with a Rust-owned desktop policy rule delete entrypoint when available."
     },
     {
@@ -2394,6 +2409,7 @@
       "user_triggerable": true,
       "executes_product_logic": false,
       "proof": "Default/live hub wiring (src/hub/friday-hub-bootstrap.ts desktopRouteDeps.permissions.respond) throws DESKTOP_PERMISSION_DECISION_NOT_PERSISTED (503, status proof_pending) before any permission decision is recorded or enforced; prompt decisions are not durably stored. test/unit/hub/bootstrap/desktop-policy-fail-closed.test.ts is a source-wiring regression guard that asserts these throwing deps remain present (it checks bootstrap source text, not runtime 503 behavior).",
+      "routeBehavioralTest": "test/unit/api/http/routes/friday-desktop-routes.test.ts",
       "next_action": "Replace the proof_pending fail-closed response with a Rust-owned desktop permission decision entrypoint when available."
     },
     {

--- a/test/unit/api/http/routes/friday-desktop-routes.test.ts
+++ b/test/unit/api/http/routes/friday-desktop-routes.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
+import { FridayDomainError } from "#errors";
 import { createFridayDesktopRoutes } from "../../../../../src/api/http/routes/friday-desktop-routes.js";
 import type { FridayDesktopRoutesDeps } from "../../../../../src/api/http/routes/friday-desktop-routes.js";
 import type { FridayRouteDefinition } from "../../../../../src/api/model/friday-api-common.types.js";
@@ -69,6 +70,13 @@ function findRoute(
   const route = routes.find((r) => r.operationId === operationId);
   if (!route) throw new Error(`Route ${operationId} not found`);
   return route;
+}
+
+function proofPendingDesktopError(code: "DESKTOP_POLICY_NOT_PERSISTED" | "DESKTOP_PERMISSION_DECISION_NOT_PERSISTED") {
+  return new FridayDomainError(code, "Desktop route dependency is proof-pending and fail-closed.", {
+    httpStatus: 503,
+    details: { status: "proof_pending" },
+  });
 }
 
 // ─── Tests ───
@@ -327,8 +335,28 @@ describe("createFridayDesktopRoutes", () => {
         ),
       ).rejects.toMatchObject({ code: "TS_RUNTIME_DESKTOP_RECORDING_RETIRED", httpStatus: 503 });
       await expect(
+        findRoute(routes, "desktop.recordings.stop").handler(
+          makeCtx({ params: { recordingId: "rec-1" }, body: { idempotencyKey: "k-fc-stop" } }),
+        ),
+      ).rejects.toMatchObject({ code: "TS_RUNTIME_DESKTOP_RECORDING_RETIRED", httpStatus: 503 });
+      await expect(
+        findRoute(routes, "desktop.recordings.pause").handler(
+          makeCtx({ params: { recordingId: "rec-1" }, body: { idempotencyKey: "k-fc-pause" } }),
+        ),
+      ).rejects.toMatchObject({ code: "TS_RUNTIME_DESKTOP_RECORDING_RETIRED", httpStatus: 503 });
+      await expect(
+        findRoute(routes, "desktop.recordings.resume").handler(
+          makeCtx({ params: { recordingId: "rec-1" }, body: { idempotencyKey: "k-fc-resume" } }),
+        ),
+      ).rejects.toMatchObject({ code: "TS_RUNTIME_DESKTOP_RECORDING_RETIRED", httpStatus: 503 });
+      await expect(
         findRoute(routes, "desktop.recordings.replay").handler(
           makeCtx({ params: { recordingId: "rec-1" }, body: { idempotencyKey: "k-fc-replay" } }),
+        ),
+      ).rejects.toMatchObject({ code: "TS_RUNTIME_DESKTOP_RECORDING_RETIRED", httpStatus: 503 });
+      await expect(
+        findRoute(routes, "desktop.recordings.delete").handler(
+          makeCtx({ params: { recordingId: "rec-1" }, body: { idempotencyKey: "k-fc-delete" } }),
         ),
       ).rejects.toMatchObject({ code: "TS_RUNTIME_DESKTOP_RECORDING_RETIRED", httpStatus: 503 });
       await expect(
@@ -338,7 +366,11 @@ describe("createFridayDesktopRoutes", () => {
       ).rejects.toMatchObject({ code: "TS_RUNTIME_DESKTOP_RECORDING_RETIRED", httpStatus: 503 });
 
       expect(deps.recordings.start).not.toHaveBeenCalled();
+      expect(deps.recordings.stop).not.toHaveBeenCalled();
+      expect(deps.recordings.pause).not.toHaveBeenCalled();
+      expect(deps.recordings.resume).not.toHaveBeenCalled();
       expect(deps.recordings.replay).not.toHaveBeenCalled();
+      expect(deps.recordings.delete).not.toHaveBeenCalled();
       expect(deps.recordings.listSteps).not.toHaveBeenCalled();
     });
   });
@@ -441,6 +473,50 @@ describe("createFridayDesktopRoutes", () => {
       }));
       expect(deps.policies.removeRule).toHaveBeenCalledWith("pol-1", "rule-1", { etag: "e1", idempotencyKey: "k14" });
     });
+
+    it("propagates default/live bootstrap proof-pending policy 503s", async () => {
+      const deps = makeDeps({
+        policies: {
+          create: vi.fn(() => { throw proofPendingDesktopError("DESKTOP_POLICY_NOT_PERSISTED"); }),
+          get: vi.fn(() => { throw proofPendingDesktopError("DESKTOP_POLICY_NOT_PERSISTED"); }),
+          list: vi.fn(() => { throw proofPendingDesktopError("DESKTOP_POLICY_NOT_PERSISTED"); }),
+          update: vi.fn(() => { throw proofPendingDesktopError("DESKTOP_POLICY_NOT_PERSISTED"); }),
+          delete: vi.fn(() => { throw proofPendingDesktopError("DESKTOP_POLICY_NOT_PERSISTED"); }),
+          addRule: vi.fn(() => { throw proofPendingDesktopError("DESKTOP_POLICY_NOT_PERSISTED"); }),
+          removeRule: vi.fn(() => { throw proofPendingDesktopError("DESKTOP_POLICY_NOT_PERSISTED"); }),
+        },
+      });
+      const routes = createFridayDesktopRoutes(deps);
+
+      await expect(
+        findRoute(routes, "desktop.policies.create").handler(
+          makeCtx({ body: { name: "Safe", rules: [], idempotencyKey: "k-pol-create" } }),
+        ),
+      ).rejects.toMatchObject({ code: "DESKTOP_POLICY_NOT_PERSISTED", httpStatus: 503 });
+      await expect(
+        findRoute(routes, "desktop.policies.update").handler(
+          makeCtx({ params: { policyId: "pol-1" }, body: { etag: "e1", idempotencyKey: "k-pol-update" } }),
+        ),
+      ).rejects.toMatchObject({ code: "DESKTOP_POLICY_NOT_PERSISTED", httpStatus: 503 });
+      await expect(
+        findRoute(routes, "desktop.policies.delete").handler(
+          makeCtx({ params: { policyId: "pol-1" }, body: { etag: "e1", idempotencyKey: "k-pol-delete" } }),
+        ),
+      ).rejects.toMatchObject({ code: "DESKTOP_POLICY_NOT_PERSISTED", httpStatus: 503 });
+      await expect(
+        findRoute(routes, "desktop.policies.rules.create").handler(
+          makeCtx({
+            params: { policyId: "pol-1" },
+            body: { rule: { actionType: "click", appFilter: "*", riskLevel: "low", decision: "allow" }, etag: "e1", idempotencyKey: "k-pol-rule-create" },
+          }),
+        ),
+      ).rejects.toMatchObject({ code: "DESKTOP_POLICY_NOT_PERSISTED", httpStatus: 503 });
+      await expect(
+        findRoute(routes, "desktop.policies.rules.delete").handler(
+          makeCtx({ params: { policyId: "pol-1", ruleId: "rule-1" }, body: { etag: "e1", idempotencyKey: "k-pol-rule-delete" } }),
+        ),
+      ).rejects.toMatchObject({ code: "DESKTOP_POLICY_NOT_PERSISTED", httpStatus: 503 });
+    });
   });
 
   // ─── Permissions ───
@@ -485,6 +561,26 @@ describe("createFridayDesktopRoutes", () => {
 
       await route.handler(makeCtx({ query: { actionType: "click" } }));
       expect(deps.permissions.listDecisions).toHaveBeenCalled();
+    });
+
+    it("propagates default/live bootstrap proof-pending permission decision 503s", async () => {
+      const deps = makeDeps({
+        permissions: {
+          list: vi.fn().mockResolvedValue({ permissions: [], platform: "darwin" }),
+          respond: vi.fn(() => { throw proofPendingDesktopError("DESKTOP_PERMISSION_DECISION_NOT_PERSISTED"); }),
+          listDecisions: vi.fn(() => { throw proofPendingDesktopError("DESKTOP_PERMISSION_DECISION_NOT_PERSISTED"); }),
+        },
+      });
+      const routes = createFridayDesktopRoutes(deps);
+
+      await expect(
+        findRoute(routes, "desktop.permissions.respond").handler(
+          makeCtx({ params: { promptId: "p-1" }, body: { decision: "allow_once", idempotencyKey: "k-perm-respond" } }),
+        ),
+      ).rejects.toMatchObject({ code: "DESKTOP_PERMISSION_DECISION_NOT_PERSISTED", httpStatus: 503 });
+      await expect(
+        findRoute(routes, "desktop.permissions.decisions.list").handler(makeCtx({ query: { actionType: "click" } })),
+      ).rejects.toMatchObject({ code: "DESKTOP_PERMISSION_DECISION_NOT_PERSISTED", httpStatus: 503 });
     });
   });
 

--- a/test/unit/api/routes/friday-task-workflow-routes.test.ts
+++ b/test/unit/api/routes/friday-task-workflow-routes.test.ts
@@ -649,44 +649,119 @@ describe("Phase 14.5A WP-001: task-workflow public mutating routes require bound
 });
 
 describe("TS runtime retirement — task-workflow mutations fail-close by default", () => {
-  it("fail-close with TS_RUNTIME_TASK_WORKFLOW_RETIRED (503) when the test-oracle flag is unset, even for otherwise-valid bound-principal requests", async () => {
-    // No allowTestOnlyTaskWorkflowExecution => production/runtime default.
-    const routes = createFridayTaskWorkflowRoutes({
-      service: makeStubService(),
-      disabledReason: null,
+  const VALID_RETIRED_TASK_WORKFLOW_CALLS: ReadonlyArray<{
+    operationId: string;
+    params?: Record<string, string>;
+    body?: Record<string, unknown>;
+  }> = [
+    {
+      operationId: "task.workflows.preview",
+      body: { charter: "x", taskKind: "general", contextPackage: {} },
+    },
+    {
+      operationId: "task.workflows.create",
+      body: { charter: "x", taskKind: "general", contextPackage: {} },
+    },
+    {
+      operationId: "task.workflows.revise",
+      params: { workflowId: "w-1" },
+      body: { charter: "x", reason: "update" },
+    },
+    { operationId: "task.workflows.closeout", params: { workflowId: "w-1" } },
+    {
+      operationId: "task.workflows.claims.create",
+      params: { workflowId: "w-1" },
+      body: { claimText: "x", claimKind: "runtime_evidence" },
+    },
+    {
+      operationId: "task.workflows.claims.block",
+      params: { workflowId: "w-1", claimId: "c-1" },
+      body: { reason: "x" },
+    },
+    {
+      operationId: "task.workflows.claims.evidence.attach",
+      params: { workflowId: "w-1", claimId: "c-1" },
+      body: {
+        refKind: "docs.start_here",
+        refId: "START_HERE_PROMPT.md",
+        refSource: "docs_intent_reference",
+      },
+    },
+    {
+      operationId: "task.workflows.claims.verify",
+      params: { workflowId: "w-1", claimId: "c-1" },
+      body: { verifierVerdict: "x", evidenceRefIds: ["ev-1"] },
+    },
+    {
+      operationId: "task.workflows.lanes.executor.open",
+      params: { workflowId: "w-1" },
+      body: { laneRole: "native" },
+    },
+    {
+      operationId: "task.workflows.lanes.verifier.open",
+      params: { workflowId: "w-1" },
+      body: {
+        parentLaneId: "lane-1",
+        laneRole: "provider",
+        independenceClaim: "independent",
+      },
+    },
+    {
+      operationId: "task.workflows.lanes.complete",
+      params: { workflowId: "w-1", laneId: "lane-1" },
+      body: { status: "completed" },
+    },
+    {
+      operationId: "task.workflows.lanes.verdict",
+      params: { workflowId: "w-1", laneId: "lane-1" },
+      body: { claimId: "c-1", verifierVerdict: "ok" },
+    },
+    {
+      operationId: "task.workflows.lanes.cli.handoff.record",
+      params: { workflowId: "w-1", laneId: "lane-1" },
+      body: {
+        backendId: "claude-cli",
+        systemPrompt: "system",
+        conversation: "summarize",
+      },
+    },
+    {
+      operationId: "task.workflows.channel.command.issue",
+      params: { workflowId: "w-1" },
+      body: {
+        channelKind: "discord",
+        channelChatId: "chat",
+        channelMessageId: "msg",
+        senderId: "sender",
+        intentKind: "progress_query",
+      },
+    },
+    {
+      operationId: "task.workflows.channel.command.confirm",
+      params: { workflowId: "w-1" },
+      body: { confirmationToken: "confirm-token" },
+    },
+  ];
+
+  for (const { operationId, params, body } of VALID_RETIRED_TASK_WORKFLOW_CALLS) {
+    it(`${operationId} fail-closes with TS_RUNTIME_TASK_WORKFLOW_RETIRED (503) when the test-oracle flag is unset`, async () => {
+      // No allowTestOnlyTaskWorkflowExecution => production/runtime default.
+      const routes = createFridayTaskWorkflowRoutes({
+        service: makeStubService(),
+        disabledReason: null,
+      });
+
+      await expect(
+        findRoute(routes, operationId).handler(
+          makeCtx({ params: params ?? {}, body: body ?? {} }) as never,
+        ),
+      ).rejects.toMatchObject({
+        code: "TS_RUNTIME_TASK_WORKFLOW_RETIRED",
+        httpStatus: 503,
+        details: { classification: "fail_closed" },
+      });
     });
-
-    // Pattern C: public, non-mutating preview still fail-closes (after body validation).
-    await expect(
-      findRoute(routes, "task.workflows.preview").handler(
-        makeCtx({ body: { charter: "x", taskKind: "general", contextPackage: {} } }) as never,
-      ),
-    ).rejects.toMatchObject({ code: "TS_RUNTIME_TASK_WORKFLOW_RETIRED", httpStatus: 503 });
-
-    // Pattern A: principal-gated create fail-closes for a valid bound principal + valid body.
-    await expect(
-      findRoute(routes, "task.workflows.create").handler(
-        makeCtx({ body: { charter: "x", taskKind: "general", contextPackage: {} } }) as never,
-      ),
-    ).rejects.toMatchObject({ code: "TS_RUNTIME_TASK_WORKFLOW_RETIRED", httpStatus: 503 });
-
-    // Pattern A with params + body: evidence-ref attach fail-closes after validation.
-    await expect(
-      findRoute(routes, "task.workflows.claims.evidence.attach").handler(
-        makeCtx({
-          params: { workflowId: "w-1", claimId: "c-1" },
-          body: { refKind: "docs.start_here", refId: "START_HERE_PROMPT.md", refSource: "docs_intent_reference" },
-        }) as never,
-      ),
-    ).rejects.toMatchObject({ code: "TS_RUNTIME_TASK_WORKFLOW_RETIRED", httpStatus: 503 });
-
-    // Pattern B: no-body closeout fail-closes after the bound-principal check.
-    await expect(
-      findRoute(routes, "task.workflows.closeout").handler(
-        makeCtx({ params: { workflowId: "w-1" } }) as never,
-      ),
-    ).rejects.toMatchObject({ code: "TS_RUNTIME_TASK_WORKFLOW_RETIRED", httpStatus: 503 });
-  });
+  }
 
   it("still enforces availability (503 DISABLED) and bound-principal (401) BEFORE the retirement guard", async () => {
     // Disabled service => availability check fires first (not the retirement guard).


### PR DESCRIPTION
## Summary
- expands task-workflow route-level default/live retirement tests to cover all 15 non-GET fail_closed task.workflows surfaces
- adds routeBehavioralTest anchors for those manifest rows
- keeps the test-oracle path explicit and does not change route implementation

## Validation
- npx vitest run test/unit/api/routes/friday-task-workflow-routes.test.ts
- node scripts/quality/check-ts-runtime-retirement.mjs
- npm run test:mechanism-wiring:behavior
- npm run typecheck:src
- npm run lint (0 errors; existing warnings only)
- git diff --check

Truth: route-level proof only; strict organic=0, GO-LIVE=false, v1=NO-GO.