### PR TITLE
Pin autonomy lifecycle route fail-closed behavior

### DIFF
--- a/docs/ops/ts-runtime-retirement-manifest.json
+++ b/docs/ops/ts-runtime-retirement-manifest.json
@@ -2903,6 +2903,7 @@
       "classification": "fail_closed",
       "user_triggerable": true,
       "executes_product_logic": false,
+      "routeBehavioralTest": "test/unit/api/http/routes/friday-autonomy-routes.test.ts",
       "proof": "src/api/http/routes/friday-autonomy-routes.ts fail-closes default/live autonomy.workflows.shadow to TS_RUNTIME_AUTONOMY_LIFECYCLE_RETIRED after principal/validation/canonical-approval checks and before calling the TypeScript workflow upgrade-lifecycle shadow service mutation; legacy behavior is reachable only through explicit allowTestOnlyAutonomyLifecycleExecution test-oracle wiring.",
       "next_action": "Replace fail-closed response with a Rust-owned autonomy workflow shadow entrypoint when available."
     },
@@ -2916,6 +2917,7 @@
       "classification": "fail_closed",
       "user_triggerable": true,
       "executes_product_logic": false,
+      "routeBehavioralTest": "test/unit/api/http/routes/friday-autonomy-routes.test.ts",
       "proof": "src/api/http/routes/friday-autonomy-routes.ts fail-closes default/live autonomy.workflows.canary to TS_RUNTIME_AUTONOMY_LIFECYCLE_RETIRED after principal/validation/canonical-approval checks and before calling the TypeScript workflow upgrade-lifecycle canary service mutation; legacy behavior is reachable only through explicit allowTestOnlyAutonomyLifecycleExecution test-oracle wiring.",
       "next_action": "Replace fail-closed response with a Rust-owned autonomy workflow canary entrypoint when available."
     },
@@ -2929,6 +2931,7 @@
       "classification": "fail_closed",
       "user_triggerable": true,
       "executes_product_logic": false,
+      "routeBehavioralTest": "test/unit/api/http/routes/friday-autonomy-routes.test.ts",
       "proof": "src/api/http/routes/friday-autonomy-routes.ts fail-closes default/live autonomy.workflows.promote to TS_RUNTIME_AUTONOMY_LIFECYCLE_RETIRED after principal/validation/canonical-approval checks and before calling the TypeScript workflow upgrade-lifecycle promote service mutation; legacy behavior is reachable only through explicit allowTestOnlyAutonomyLifecycleExecution test-oracle wiring.",
       "next_action": "Replace fail-closed response with a Rust-owned autonomy workflow promote entrypoint when available."
     },
@@ -2942,6 +2945,7 @@
       "classification": "fail_closed",
       "user_triggerable": true,
       "executes_product_logic": false,
+      "routeBehavioralTest": "test/unit/api/http/routes/friday-autonomy-routes.test.ts",
       "proof": "src/api/http/routes/friday-autonomy-routes.ts fail-closes default/live autonomy.workflows.rollback to TS_RUNTIME_AUTONOMY_LIFECYCLE_RETIRED after principal/validation/canonical-approval checks and before calling the TypeScript workflow upgrade-lifecycle rollback service mutation; legacy behavior is reachable only through explicit allowTestOnlyAutonomyLifecycleExecution test-oracle wiring.",
       "next_action": "Replace fail-closed response with a Rust-owned autonomy workflow rollback entrypoint when available."
     },
@@ -2955,6 +2959,7 @@
       "classification": "fail_closed",
       "user_triggerable": true,
       "executes_product_logic": false,
+      "routeBehavioralTest": "test/unit/api/http/routes/friday-autonomy-routes.test.ts",
       "proof": "src/api/http/routes/friday-autonomy-routes.ts fail-closes default/live autonomy.skills.shadow to TS_RUNTIME_AUTONOMY_LIFECYCLE_RETIRED after principal/validation/canonical-approval checks and before calling the TypeScript skill upgrade-lifecycle shadow service mutation; legacy behavior is reachable only through explicit allowTestOnlyAutonomyLifecycleExecution test-oracle wiring.",
       "next_action": "Replace fail-closed response with a Rust-owned autonomy skill shadow entrypoint when available."
     },
@@ -2968,6 +2973,7 @@
       "classification": "fail_closed",
       "user_triggerable": true,
       "executes_product_logic": false,
+      "routeBehavioralTest": "test/unit/api/http/routes/friday-autonomy-routes.test.ts",
       "proof": "src/api/http/routes/friday-autonomy-routes.ts fail-closes default/live autonomy.skills.canary to TS_RUNTIME_AUTONOMY_LIFECYCLE_RETIRED after principal/validation/canonical-approval checks and before calling the TypeScript skill upgrade-lifecycle canary service mutation; legacy behavior is reachable only through explicit allowTestOnlyAutonomyLifecycleExecution test-oracle wiring.",
       "next_action": "Replace fail-closed response with a Rust-owned autonomy skill canary entrypoint when available."
     },
@@ -2981,6 +2987,7 @@
       "classification": "fail_closed",
       "user_triggerable": true,
       "executes_product_logic": false,
+      "routeBehavioralTest": "test/unit/api/http/routes/friday-autonomy-routes.test.ts",
       "proof": "src/api/http/routes/friday-autonomy-routes.ts fail-closes default/live autonomy.skills.promote to TS_RUNTIME_AUTONOMY_LIFECYCLE_RETIRED after principal/validation/canonical-approval checks and before calling the TypeScript skill upgrade-lifecycle promote service mutation; legacy behavior is reachable only through explicit allowTestOnlyAutonomyLifecycleExecution test-oracle wiring.",
       "next_action": "Replace fail-closed response with a Rust-owned autonomy skill promote entrypoint when available."
     },
@@ -2994,6 +3001,7 @@
       "classification": "fail_closed",
       "user_triggerable": true,
       "executes_product_logic": false,
+      "routeBehavioralTest": "test/unit/api/http/routes/friday-autonomy-routes.test.ts",
       "proof": "src/api/http/routes/friday-autonomy-routes.ts fail-closes default/live autonomy.skills.rollback to TS_RUNTIME_AUTONOMY_LIFECYCLE_RETIRED after principal/validation/canonical-approval checks and before calling the TypeScript skill upgrade-lifecycle rollback service mutation; legacy behavior is reachable only through explicit allowTestOnlyAutonomyLifecycleExecution test-oracle wiring.",
       "next_action": "Replace fail-closed response with a Rust-owned autonomy skill rollback entrypoint when available."
     },
@@ -3007,6 +3015,7 @@
       "classification": "fail_closed",
       "user_triggerable": true,
       "executes_product_logic": false,
+      "routeBehavioralTest": "test/unit/api/http/routes/friday-autonomy-routes.test.ts",
       "proof": "src/api/http/routes/friday-autonomy-routes.ts fail-closes default/live autonomy.plugins.shadow to TS_RUNTIME_AUTONOMY_LIFECYCLE_RETIRED after principal/validation/canonical-approval checks and before calling the TypeScript plugin upgrade-lifecycle shadow service mutation; legacy behavior is reachable only through explicit allowTestOnlyAutonomyLifecycleExecution test-oracle wiring.",
       "next_action": "Replace fail-closed response with a Rust-owned autonomy plugin shadow entrypoint when available."
     },
@@ -3020,6 +3029,7 @@
       "classification": "fail_closed",
       "user_triggerable": true,
       "executes_product_logic": false,
+      "routeBehavioralTest": "test/unit/api/http/routes/friday-autonomy-routes.test.ts",
       "proof": "src/api/http/routes/friday-autonomy-routes.ts fail-closes default/live autonomy.plugins.canary to TS_RUNTIME_AUTONOMY_LIFECYCLE_RETIRED after principal/validation/canonical-approval checks and before calling the TypeScript plugin upgrade-lifecycle canary service mutation; legacy behavior is reachable only through explicit allowTestOnlyAutonomyLifecycleExecution test-oracle wiring.",
       "next_action": "Replace fail-closed response with a Rust-owned autonomy plugin canary entrypoint when available."
     },
@@ -3033,6 +3043,7 @@
       "classification": "fail_closed",
       "user_triggerable": true,
       "executes_product_logic": false,
+      "routeBehavioralTest": "test/unit/api/http/routes/friday-autonomy-routes.test.ts",
       "proof": "src/api/http/routes/friday-autonomy-routes.ts fail-closes default/live autonomy.plugins.promote to TS_RUNTIME_AUTONOMY_LIFECYCLE_RETIRED after principal/validation/canonical-approval checks and before calling the TypeScript plugin upgrade-lifecycle promote service mutation; legacy behavior is reachable only through explicit allowTestOnlyAutonomyLifecycleExecution test-oracle wiring.",
       "next_action": "Replace fail-closed response with a Rust-owned autonomy plugin promote entrypoint when available."
     },
@@ -3046,6 +3057,7 @@
       "classification": "fail_closed",
       "user_triggerable": true,
       "executes_product_logic": false,
+      "routeBehavioralTest": "test/unit/api/http/routes/friday-autonomy-routes.test.ts",
       "proof": "src/api/http/routes/friday-autonomy-routes.ts fail-closes default/live autonomy.plugins.rollback to TS_RUNTIME_AUTONOMY_LIFECYCLE_RETIRED after principal/validation/canonical-approval checks and before calling the TypeScript plugin upgrade-lifecycle rollback service mutation; legacy behavior is reachable only through explicit allowTestOnlyAutonomyLifecycleExecution test-oracle wiring.",
       "next_action": "Replace fail-closed response with a Rust-owned autonomy plugin rollback entrypoint when available."
     },
@@ -3059,6 +3071,7 @@
       "classification": "fail_closed",
       "user_triggerable": true,
       "executes_product_logic": false,
+      "routeBehavioralTest": "test/unit/api/http/routes/friday-autonomy-routes.test.ts",
       "proof": "src/api/http/routes/friday-autonomy-routes.ts fail-closes default/live autonomy.providers.shadow to TS_RUNTIME_AUTONOMY_LIFECYCLE_RETIRED after principal/validation/canonical-approval checks and before calling the TypeScript provider upgrade-lifecycle shadow service mutation; legacy behavior is reachable only through explicit allowTestOnlyAutonomyLifecycleExecution test-oracle wiring.",
       "next_action": "Replace fail-closed response with a Rust-owned autonomy provider shadow entrypoint when available."
     },
@@ -3072,6 +3085,7 @@
       "classification": "fail_closed",
       "user_triggerable": true,
       "executes_product_logic": false,
+      "routeBehavioralTest": "test/unit/api/http/routes/friday-autonomy-routes.test.ts",
       "proof": "src/api/http/routes/friday-autonomy-routes.ts fail-closes default/live autonomy.providers.canary to TS_RUNTIME_AUTONOMY_LIFECYCLE_RETIRED after principal/validation/canonical-approval checks and before calling the TypeScript provider upgrade-lifecycle canary service mutation; legacy behavior is reachable only through explicit allowTestOnlyAutonomyLifecycleExecution test-oracle wiring.",
       "next_action": "Replace fail-closed response with a Rust-owned autonomy provider canary entrypoint when available."
     },
@@ -3085,6 +3099,7 @@
       "classification": "fail_closed",
       "user_triggerable": true,
       "executes_product_logic": false,
+      "routeBehavioralTest": "test/unit/api/http/routes/friday-autonomy-routes.test.ts",
       "proof": "src/api/http/routes/friday-autonomy-routes.ts fail-closes default/live autonomy.providers.promote to TS_RUNTIME_AUTONOMY_LIFECYCLE_RETIRED after principal/validation/canonical-approval checks and before calling the TypeScript provider upgrade-lifecycle promote service mutation; legacy behavior is reachable only through explicit allowTestOnlyAutonomyLifecycleExecution test-oracle wiring.",
       "next_action": "Replace fail-closed response with a Rust-owned autonomy provider promote entrypoint when available."
     },
@@ -3098,6 +3113,7 @@
       "classification": "fail_closed",
       "user_triggerable": true,
       "executes_product_logic": false,
+      "routeBehavioralTest": "test/unit/api/http/routes/friday-autonomy-routes.test.ts",
       "proof": "src/api/http/routes/friday-autonomy-routes.ts fail-closes default/live autonomy.providers.rollback to TS_RUNTIME_AUTONOMY_LIFECYCLE_RETIRED after principal/validation/canonical-approval checks and before calling the TypeScript provider upgrade-lifecycle rollback service mutation; legacy behavior is reachable only through explicit allowTestOnlyAutonomyLifecycleExecution test-oracle wiring.",
       "next_action": "Replace fail-closed response with a Rust-owned autonomy provider rollback entrypoint when available."
     },
@@ -3111,6 +3127,7 @@
       "classification": "fail_closed",
       "user_triggerable": true,
       "executes_product_logic": false,
+      "routeBehavioralTest": "test/unit/api/http/routes/friday-autonomy-routes.test.ts",
       "proof": "src/api/http/routes/friday-autonomy-routes.ts fail-closes default/live autonomy.mcp.servers.shadow to TS_RUNTIME_AUTONOMY_LIFECYCLE_RETIRED after principal/validation/canonical-approval checks and before calling the TypeScript mcp-server upgrade-lifecycle shadow service mutation; legacy behavior is reachable only through explicit allowTestOnlyAutonomyLifecycleExecution test-oracle wiring.",
       "next_action": "Replace fail-closed response with a Rust-owned autonomy mcp-server shadow entrypoint when available."
     },
@@ -3124,6 +3141,7 @@
       "classification": "fail_closed",
       "user_triggerable": true,
       "executes_product_logic": false,
+      "routeBehavioralTest": "test/unit/api/http/routes/friday-autonomy-routes.test.ts",
       "proof": "src/api/http/routes/friday-autonomy-routes.ts fail-closes default/live autonomy.mcp.servers.canary to TS_RUNTIME_AUTONOMY_LIFECYCLE_RETIRED after principal/validation/canonical-approval checks and before calling the TypeScript mcp-server upgrade-lifecycle canary service mutation; legacy behavior is reachable only through explicit allowTestOnlyAutonomyLifecycleExecution test-oracle wiring.",
       "next_action": "Replace fail-closed response with a Rust-owned autonomy mcp-server canary entrypoint when available."
     },
@@ -3137,6 +3155,7 @@
       "classification": "fail_closed",
       "user_triggerable": true,
       "executes_product_logic": false,
+      "routeBehavioralTest": "test/unit/api/http/routes/friday-autonomy-routes.test.ts",
       "proof": "src/api/http/routes/friday-autonomy-routes.ts fail-closes default/live autonomy.mcp.servers.promote to TS_RUNTIME_AUTONOMY_LIFECYCLE_RETIRED after principal/validation/canonical-approval checks and before calling the TypeScript mcp-server upgrade-lifecycle promote service mutation; legacy behavior is reachable only through explicit allowTestOnlyAutonomyLifecycleExecution test-oracle wiring.",
       "next_action": "Replace fail-closed response with a Rust-owned autonomy mcp-server promote entrypoint when available."
     },
@@ -3150,6 +3169,7 @@
       "classification": "fail_closed",
       "user_triggerable": true,
       "executes_product_logic": false,
+      "routeBehavioralTest": "test/unit/api/http/routes/friday-autonomy-routes.test.ts",
       "proof": "src/api/http/routes/friday-autonomy-routes.ts fail-closes default/live autonomy.mcp.servers.rollback to TS_RUNTIME_AUTONOMY_LIFECYCLE_RETIRED after principal/validation/canonical-approval checks and before calling the TypeScript mcp-server upgrade-lifecycle rollback service mutation; legacy behavior is reachable only through explicit allowTestOnlyAutonomyLifecycleExecution test-oracle wiring.",
       "next_action": "Replace fail-closed response with a Rust-owned autonomy mcp-server rollback entrypoint when available."
     },
@@ -3163,6 +3183,7 @@
       "classification": "fail_closed",
       "user_triggerable": true,
       "executes_product_logic": false,
+      "routeBehavioralTest": "test/unit/api/http/routes/friday-autonomy-routes.test.ts",
       "proof": "src/api/http/routes/friday-autonomy-routes.ts fail-closes default/live autonomy.channels.shadow to TS_RUNTIME_AUTONOMY_LIFECYCLE_RETIRED after principal/validation/canonical-approval checks and before calling the TypeScript channel-adapter upgrade-lifecycle shadow service mutation; legacy behavior is reachable only through explicit allowTestOnlyAutonomyLifecycleExecution test-oracle wiring.",
       "next_action": "Replace fail-closed response with a Rust-owned autonomy channel-adapter shadow entrypoint when available."
     },
@@ -3176,6 +3197,7 @@
       "classification": "fail_closed",
       "user_triggerable": true,
       "executes_product_logic": false,
+      "routeBehavioralTest": "test/unit/api/http/routes/friday-autonomy-routes.test.ts",
       "proof": "src/api/http/routes/friday-autonomy-routes.ts fail-closes default/live autonomy.channels.canary to TS_RUNTIME_AUTONOMY_LIFECYCLE_RETIRED after principal/validation/canonical-approval checks and before calling the TypeScript channel-adapter upgrade-lifecycle canary service mutation; legacy behavior is reachable only through explicit allowTestOnlyAutonomyLifecycleExecution test-oracle wiring.",
       "next_action": "Replace fail-closed response with a Rust-owned autonomy channel-adapter canary entrypoint when available."
     },
@@ -3189,6 +3211,7 @@
       "classification": "fail_closed",
       "user_triggerable": true,
       "executes_product_logic": false,
+      "routeBehavioralTest": "test/unit/api/http/routes/friday-autonomy-routes.test.ts",
       "proof": "src/api/http/routes/friday-autonomy-routes.ts fail-closes default/live autonomy.channels.promote to TS_RUNTIME_AUTONOMY_LIFECYCLE_RETIRED after principal/validation/canonical-approval checks and before calling the TypeScript channel-adapter upgrade-lifecycle promote service mutation; legacy behavior is reachable only through explicit allowTestOnlyAutonomyLifecycleExecution test-oracle wiring.",
       "next_action": "Replace fail-closed response with a Rust-owned autonomy channel-adapter promote entrypoint when available."
     },
@@ -3202,6 +3225,7 @@
       "classification": "fail_closed",
       "user_triggerable": true,
       "executes_product_logic": false,
+      "routeBehavioralTest": "test/unit/api/http/routes/friday-autonomy-routes.test.ts",
       "proof": "src/api/http/routes/friday-autonomy-routes.ts fail-closes default/live autonomy.channels.rollback to TS_RUNTIME_AUTONOMY_LIFECYCLE_RETIRED after principal/validation/canonical-approval checks and before calling the TypeScript channel-adapter upgrade-lifecycle rollback service mutation; legacy behavior is reachable only through explicit allowTestOnlyAutonomyLifecycleExecution test-oracle wiring.",
       "next_action": "Replace fail-closed response with a Rust-owned autonomy channel-adapter rollback entrypoint when available."
     },
@@ -3215,6 +3239,7 @@
       "classification": "fail_closed",
       "user_triggerable": true,
       "executes_product_logic": false,
+      "routeBehavioralTest": "test/unit/api/http/routes/friday-autonomy-routes.test.ts",
       "proof": "src/api/http/routes/friday-autonomy-routes.ts fail-closes default/live autonomy.plugins.review.enable to TS_RUNTIME_AUTONOMY_LIFECYCLE_RETIRED after principal/availability checks and before calling the TypeScript plugin review-enable lifecycle service mutation; legacy behavior is reachable only through explicit allowTestOnlyAutonomyLifecycleExecution test-oracle wiring.",
       "next_action": "Replace fail-closed response with a Rust-owned autonomy plugin review-enable entrypoint when available."
     },

--- a/test/unit/api/http/routes/friday-autonomy-routes.test.ts
+++ b/test/unit/api/http/routes/friday-autonomy-routes.test.ts
@@ -6,6 +6,9 @@ import {
   createFridaySkillLifecycleMutatingActionRequest,
 } from "../../../../../src/autonomy/services/friday-skill-upgrade-lifecycle-service.js";
 import {
+  createFridayWorkflowLifecycleMutatingActionRequest,
+} from "../../../../../src/autonomy/services/friday-workflow-upgrade-lifecycle-service.js";
+import {
   createFridayProviderProfileLifecycleMutatingActionRequest,
 } from "../../../../../src/autonomy/services/friday-provider-profile-upgrade-lifecycle-service.js";
 import {
@@ -92,6 +95,62 @@ function makeChannelContext(body: Record<string, unknown>) {
     body,
     headers: {},
     principal,
+  };
+}
+
+function makeAutonomyLifecycleContext(body: Record<string, unknown>) {
+  return {
+    requestId: "req-1",
+    receivedAt: "2026-05-07T18:00:00.000Z",
+    params: {
+      workflowId: "workflow-1",
+      skillId: "skill-1",
+      providerId: "provider-1",
+      serverId: "mcp-1",
+      pluginId: "plugin-1",
+      channelKind: "webchat",
+    },
+    query: {},
+    body,
+    headers: {},
+    principal,
+  };
+}
+
+function makeWorkflowApproval(input: {
+  action: "shadow" | "canary" | "promote" | "rollback";
+  workflowVersionId?: string;
+  versionNumber?: number;
+  targetVersionNumber?: number;
+  success?: boolean;
+  planDigest?: string;
+}): FridayCanonicalApprovalResolution {
+  const planDigest = input.planDigest ?? "workflow-plan-1";
+  const request = createFridayWorkflowLifecycleMutatingActionRequest({
+    action: input.action,
+    workflowId: "workflow-1",
+    workflowVersionId: input.workflowVersionId,
+    versionNumber: input.versionNumber,
+    targetVersionNumber: input.targetVersionNumber,
+    success: input.success,
+    runtimeVersion: "runtime-v1",
+    actor: {
+      kind: "user",
+      id: "user-1",
+      principalId: "user-1",
+    },
+    surface: `api:/v1/autonomy/workflows/workflow-1/${input.action}`,
+    planDigest,
+    rollback: input.action === "rollback"
+      ? { planned: true, planDigest, actions: ["workflows.lifecycle.promote"] }
+      : undefined,
+  });
+  return {
+    decision: "approved",
+    approvalId: `workflow-${input.action}-approval`,
+    decidedByPrincipalId: "user-1",
+    actionDigest: createFridayMutatingActionDigest(request),
+    expiresAt: "2026-05-07T19:00:00.000Z",
   };
 }
 
@@ -530,6 +589,240 @@ function createChannelRoutes() {
   });
   return { routes, registerShadow, recordCanary };
 }
+
+function createAutonomyLifecycleRoutesDefaultOff() {
+  const workflowMutations = {
+    registerShadow: vi.fn(async () => ({ id: "workflow-1" })),
+    recordCanary: vi.fn(async () => ({ id: "workflow-1" })),
+    promote: vi.fn(async () => ({ id: "workflow-1" })),
+    rollback: vi.fn(async () => ({ id: "workflow-1" })),
+  };
+  const skillMutations = {
+    registerShadow: vi.fn(async () => ({ skillId: "skill-1", status: "not_installed", tags: [] })),
+    recordCanary: vi.fn(async () => ({ skillId: "skill-1", status: "not_installed", tags: [] })),
+    promote: vi.fn(async () => ({ skillId: "skill-1", status: "installed", tags: [] })),
+    rollback: vi.fn(async () => ({ skillId: "skill-1", status: "not_installed", tags: [] })),
+  };
+  const pluginMutations = {
+    registerShadow: vi.fn(async () => ({ id: "plugin-1" })),
+    recordCanary: vi.fn(async () => ({ id: "plugin-1" })),
+    promote: vi.fn(async () => ({ id: "plugin-1" })),
+    rollback: vi.fn(async () => ({ id: "plugin-1" })),
+    reviewEnable: vi.fn(async () => ({ id: "plugin-1" })),
+  };
+  const providerMutations = {
+    registerShadow: vi.fn(async () => ({ id: "provider-1" })),
+    recordCanary: vi.fn(async () => ({ id: "provider-1" })),
+    promote: vi.fn(async () => ({ id: "provider-1" })),
+    rollback: vi.fn(async () => ({ id: "provider-1" })),
+  };
+  const mcpMutations = {
+    registerShadow: vi.fn(async () => undefined),
+    recordCanary: vi.fn(async () => undefined),
+    promote: vi.fn(async () => undefined),
+    rollback: vi.fn(async () => undefined),
+  };
+  const channelMutations = {
+    registerShadow: vi.fn(async () => undefined),
+    recordCanary: vi.fn(async () => undefined),
+    promote: vi.fn(async () => undefined),
+    rollback: vi.fn(async () => undefined),
+  };
+  const routes = createFridayAutonomyRoutes({
+    allowTestOnlyAutonomyLifecycleExecution: false,
+    canonicalMutationGate: createFridayMutatingActionGate({
+      nowIso: () => "2026-05-07T18:00:00.000Z",
+      ticketIdGenerator: () => "ticket-1",
+    }),
+    listUpgradeStatus: () => ({ items: [] }),
+    workflowActions: {
+      ...workflowMutations,
+      getStatus: () => null,
+    },
+    skillActions: {
+      ...skillMutations,
+      getStatus: () => null,
+      getEvidence: vi.fn(() => null),
+    },
+    pluginActions: {
+      ...pluginMutations,
+      getStatus: () => null,
+      getEvidence: vi.fn(() => null),
+    },
+    providerProfileActions: {
+      ...providerMutations,
+      getStatus: () => null,
+      getEvidence: vi.fn(() => null),
+    },
+    mcpServerActions: {
+      ...mcpMutations,
+      getStatus: () => null,
+      getEvidence: vi.fn(() => null),
+    },
+    channelAdapterActions: {
+      ...channelMutations,
+      getStatus: () => null,
+      getEvidence: vi.fn(() => null),
+    },
+  });
+  return {
+    routes,
+    mutations: [
+      ...Object.values(workflowMutations),
+      ...Object.values(skillMutations),
+      ...Object.values(pluginMutations),
+      ...Object.values(providerMutations),
+      ...Object.values(mcpMutations),
+      ...Object.values(channelMutations),
+    ],
+  };
+}
+
+describe("createFridayAutonomyRoutes lifecycle route retirement", () => {
+  it.each([
+    {
+      operationId: "autonomy.workflows.shadow",
+      body: {
+        workflowVersionId: "workflow-version-1",
+        runtimeVersion: "runtime-v1",
+        planDigest: "workflow-plan-1",
+        canonicalApproval: makeWorkflowApproval({ action: "shadow", workflowVersionId: "workflow-version-1" }),
+      },
+    },
+    {
+      operationId: "autonomy.workflows.canary",
+      body: {
+        success: true,
+        runtimeVersion: "runtime-v1",
+        planDigest: "workflow-plan-1",
+        canonicalApproval: makeWorkflowApproval({ action: "canary", success: true }),
+      },
+    },
+    {
+      operationId: "autonomy.workflows.promote",
+      body: {
+        versionNumber: 1,
+        runtimeVersion: "runtime-v1",
+        planDigest: "workflow-plan-1",
+        canonicalApproval: makeWorkflowApproval({ action: "promote", versionNumber: 1 }),
+      },
+    },
+    {
+      operationId: "autonomy.workflows.rollback",
+      body: {
+        targetVersionNumber: 1,
+        runtimeVersion: "runtime-v1",
+        planDigest: "workflow-plan-1",
+        canonicalApproval: makeWorkflowApproval({ action: "rollback", targetVersionNumber: 1 }),
+      },
+    },
+    {
+      operationId: "autonomy.skills.shadow",
+      body: {
+        candidateId: "candidate-1",
+        runtimeVersion: "runtime-v1",
+        canonicalApproval: makeApproval({ action: "shadow", candidateId: "candidate-1" }),
+      },
+    },
+    {
+      operationId: "autonomy.skills.canary",
+      body: {
+        candidateId: "candidate-1",
+        runtimeVersion: "runtime-v1",
+        canonicalApproval: makeApproval({ action: "canary", candidateId: "candidate-1" }),
+      },
+    },
+    {
+      operationId: "autonomy.skills.promote",
+      body: {
+        candidateId: "candidate-1",
+        runtimeVersion: "runtime-v1",
+        planDigest: "plan-digest-1",
+        canonicalApproval: makeApproval({
+          action: "promote",
+          candidateId: "candidate-1",
+          planDigest: "plan-digest-1",
+        }),
+      },
+    },
+    {
+      operationId: "autonomy.skills.rollback",
+      body: {
+        candidateId: "candidate-1",
+        runtimeVersion: "runtime-v1",
+        planDigest: "plan-digest-1",
+        canonicalApproval: makeApproval({
+          action: "rollback",
+          candidateId: "candidate-1",
+          planDigest: "plan-digest-1",
+        }),
+      },
+    },
+    {
+      operationId: "autonomy.plugins.review.enable",
+      body: {
+        runtimeVersion: "runtime-v1",
+        providerModel: "model-v1",
+        idempotencyKey: "review-enable-key",
+      },
+    },
+    ...(["shadow", "canary", "promote", "rollback"] as const).map((action) => ({
+      operationId: `autonomy.plugins.${action}`,
+      body: {
+        shadowVersionId: "plugin-1@shadow",
+        runtimeVersion: "runtime-v1",
+        planDigest: PLUGIN_PLAN_DIGEST,
+        canonicalApproval: makePluginApproval({ action }),
+      },
+    })),
+    ...(["shadow", "canary", "promote", "rollback"] as const).map((action) => ({
+      operationId: `autonomy.providers.${action}`,
+      body: {
+        shadowVersionId: "provider-1@shadow",
+        runtimeVersion: "runtime-v1",
+        planDigest: PROVIDER_PLAN_DIGEST,
+        canonicalApproval: makeProviderApproval({ action }),
+      },
+    })),
+    ...(["shadow", "canary", "promote", "rollback"] as const).map((action) => ({
+      operationId: `autonomy.mcp.servers.${action}`,
+      body: {
+        shadowVersionId: "mcp-1@shadow",
+        runtimeVersion: "runtime-v1",
+        planDigest: MCP_PLAN_DIGEST,
+        canonicalApproval: makeMcpApproval({ action }),
+      },
+    })),
+    ...(["shadow", "canary", "promote", "rollback"] as const).map((action) => ({
+      operationId: `autonomy.channels.${action}`,
+      body: {
+        shadowVersionId: "webchat@shadow",
+        runtimeVersion: "runtime-v1",
+        planDigest: CHANNEL_PLAN_DIGEST,
+        canonicalApproval: makeChannelApproval({ action }),
+      },
+    })),
+  ])(
+    "fail-closes %s by default before invoking legacy TypeScript lifecycle mutations",
+    async ({ operationId, body }) => {
+      const deps = createAutonomyLifecycleRoutesDefaultOff();
+      const route = deps.routes.find((entry) => entry.operationId === operationId)!;
+
+      await expect(route.handler(makeAutonomyLifecycleContext(body))).rejects.toMatchObject({
+        code: "TS_RUNTIME_AUTONOMY_LIFECYCLE_RETIRED",
+        httpStatus: 503,
+        details: {
+          classification: "fail_closed",
+          replacement: "rust_owned_autonomy_subject_upgrade_lifecycle_entrypoint_required",
+        },
+      });
+
+      for (const mutation of deps.mutations) {
+        expect(mutation).not.toHaveBeenCalled();
+      }
+    },
+  );
+});
 
 describe("createFridayAutonomyRoutes skill lifecycle approval", () => {
   it.each([


### PR DESCRIPTION
## Summary
- add a parameterized default-off route behavior test for the autonomy lifecycle family
- cover workflow, skill, plugin, provider, MCP server, channel, and plugin review-enable autonomy mutations before legacy TypeScript mutation calls
- wire 25 autonomy fail-closed route surfaces to the executable routeBehavioralTest in the retirement manifest

## Truth labels
- organic=0
- GO-LIVE=false
- v1=NO-GO
- L1 route fail-closed proof only; legacy TypeScript lifecycle remains retired by default/live and Rust-owned replacements remain the next action

## Tests
- npm test -- --run test/unit/api/http/routes/friday-autonomy-routes.test.ts
- npm run check:ts-runtime-retirement
- npm run test:mechanism-wiring:behavior
- npm run test:mechanism-wiring
- git diff --check

## Notes
- Local ESLint for the changed test path is ignored by the repo pattern and produced only the standard ignored-file warning.