### PR TITLE
Wire A1 run-outcome learning decision courier

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -905,14 +905,14 @@
         "filename": "test/unit/hub/friday-hub-bootstrap-env.test.ts",
         "hashed_secret": "5c5a15a8b0b3e154d77746945e563ba40100681b",
         "is_verified": false,
-        "line_number": 137
+        "line_number": 138
       },
       {
         "type": "Secret Keyword",
         "filename": "test/unit/hub/friday-hub-bootstrap-env.test.ts",
         "hashed_secret": "8a8281cec699f5e51330e21dd7fab3531af6ef0c",
         "is_verified": false,
-        "line_number": 138
+        "line_number": 139
       }
     ],
     "test/unit/media-understanding/friday-openai-vision-provider.test.ts": [
@@ -1124,5 +1124,5 @@
       }
     ]
   },
-  "generated_at": "2026-06-15T01:47:10Z"
+  "generated_at": "2026-06-21T06:29:03Z"
 }

--- a/docs/ops/ts-runtime-retirement-manifest.json
+++ b/docs/ops/ts-runtime-retirement-manifest.json
@@ -432,6 +432,17 @@
       "next_action": "Keep TypeScript as a redacted HTTP adapter over the Rust memory-confirmation arm."
     },
     {
+      "id": "run_outcome_learning_rust_delegated",
+      "match": {
+        "sourceFile": "src/api/http/routes/friday-run-outcome-learning-routes.ts"
+      },
+      "classification": "rust_delegated",
+      "user_triggerable": true,
+      "rust_entrypoint": "rust-core/crates/friday-hub/src/hub_server.rs",
+      "proof": "POST /v1/run-outcome-learning/decide is a redacted HTTP adapter forwarding RunOutcomeLearningDecisionRequest over sealed-WS to the Rust run-outcome learning confirm arm (run_outcome_learning_decision_result_for_db, gated by FRIDAY_RUN_OUTCOME_LEARNING_CONFIRM); dark default-OFF (503) until the operator wires the dispatch adapter and flips the flag",
+      "next_action": "Keep TypeScript as a redacted HTTP adapter over the Rust run-outcome learning confirmation arm; A1 live-done still requires operator-origin organic candidate feed plus explicit confirm."
+    },
+    {
       "id": "agent_runtime_blockers",
       "match": {
         "sourceFile": "src/api/http/routes/friday-agent-routes.ts"

--- a/src/api/http/routes/friday-run-outcome-learning-routes.ts
+++ b/src/api/http/routes/friday-run-outcome-learning-routes.ts
@@ -1,0 +1,129 @@
+import { FridayDomainError } from "#errors";
+import { assertBoundPrincipalForOperation } from "../../../security/friday-owner-session-channel-capability.js";
+import type { FridayRouteDefinition } from "../../model/friday-api-common.types.js";
+import type {
+  FridayRustHubRunOutcomeLearningDecisionRequest,
+  FridayRustHubRunOutcomeLearningDecisionResult,
+} from "../../mission-spine/friday-rust-hub-agent-run-ws-sealed-client.js";
+
+export interface FridayRunOutcomeLearningRoutesDispatchService {
+  decideRunOutcomeLearning(
+    request: FridayRustHubRunOutcomeLearningDecisionRequest,
+  ): Promise<FridayRustHubRunOutcomeLearningDecisionResult>;
+}
+
+export interface FridayRunOutcomeLearningRoutesDeps {
+  readonly dispatch?: FridayRunOutcomeLearningRoutesDispatchService | null;
+  readonly dispatchDisabledReason?: string | null;
+}
+
+export interface FridayRunOutcomeLearningDecideResponse {
+  readonly result: FridayRustHubRunOutcomeLearningDecisionResult;
+}
+
+const DEFAULT_DISPATCH_DISABLED_MESSAGE =
+  "Run-outcome learning confirmation dispatch is unavailable in this runtime; the Rust Hub sealed-WS decision seam has not been wired.";
+
+const SURFACE = "api:/v1/run-outcome-learning/decide";
+const VALID_DECISIONS = new Set(["confirm", "reject"]);
+
+function throwInvalidBody(failures: readonly string[]): never {
+  throw new FridayDomainError(
+    "RUN_OUTCOME_LEARNING_DECISION_REQUEST_INVALID",
+    "Run-outcome learning decision request body did not satisfy the dispatch contract.",
+    {
+      httpStatus: 400,
+      details: { surface: SURFACE, failures },
+    },
+  );
+}
+
+function asBody(body: unknown): Record<string, unknown> {
+  return body && typeof body === "object" && !Array.isArray(body) ? (body as Record<string, unknown>) : {};
+}
+
+function readRequiredString(
+  body: Record<string, unknown>,
+  field: string,
+  failures: string[],
+): string | undefined {
+  const value = body[field];
+  if (typeof value !== "string" || value.trim().length === 0) {
+    failures.push(`${field}_missing_or_empty`);
+    return undefined;
+  }
+  return value.trim();
+}
+
+function readOptionalString(body: Record<string, unknown>, field: string, failures: string[]): string | undefined {
+  const value = body[field];
+  if (value === undefined || value === null) return undefined;
+  if (typeof value !== "string") {
+    failures.push(`${field}_not_string`);
+    return undefined;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+export function validateRunOutcomeLearningDecisionBody(
+  body: unknown,
+): FridayRustHubRunOutcomeLearningDecisionRequest {
+  const b = asBody(body);
+  const failures: string[] = [];
+  const candidateId = readRequiredString(b, "candidateId", failures);
+  const decision = readRequiredString(b, "decision", failures);
+  const reason = readOptionalString(b, "reason", failures);
+  if (decision !== undefined && !VALID_DECISIONS.has(decision)) {
+    failures.push("decision_not_confirm_or_reject");
+  }
+  if (failures.length > 0 || candidateId === undefined || decision === undefined) {
+    throwInvalidBody(failures);
+  }
+  return {
+    candidateId,
+    decision: decision as "confirm" | "reject",
+    ...(reason !== undefined ? { reason } : {}),
+  };
+}
+
+export function createFridayRunOutcomeLearningRoutes(
+  deps: FridayRunOutcomeLearningRoutesDeps,
+): FridayRouteDefinition<unknown, unknown, unknown, unknown>[] {
+  const dispatch = deps.dispatch ?? null;
+
+  function dispatchDisabledMessage(): string {
+    return deps.dispatchDisabledReason && deps.dispatchDisabledReason.trim().length > 0
+      ? deps.dispatchDisabledReason
+      : DEFAULT_DISPATCH_DISABLED_MESSAGE;
+  }
+
+  function throwDispatchDisabled(): never {
+    throw new FridayDomainError(
+      "RUN_OUTCOME_LEARNING_DISPATCH_UNAVAILABLE",
+      dispatchDisabledMessage(),
+      {
+        httpStatus: 503,
+        details: { surface: SURFACE, dispatch: "rust_hub_unavailable", proofReady: false },
+      },
+    );
+  }
+
+  return [
+    {
+      operationId: "run.outcome.learning.decide.apply",
+      method: "POST",
+      path: "/v1/run-outcome-learning/decide",
+      auth: { public: true },
+      async handler(ctx): Promise<FridayRunOutcomeLearningDecideResponse> {
+        if (!dispatch) {
+          throwDispatchDisabled();
+        }
+        assertBoundPrincipalForOperation(ctx.principal ?? null, "run.outcome.learning.decide.apply", "api");
+        const request = validateRunOutcomeLearningDecisionBody(ctx.body);
+        const result = await dispatch.decideRunOutcomeLearning(request);
+        return { result };
+      },
+    },
+  ];
+}

--- a/src/api/mission-spine/friday-run-outcome-learning-dispatch-adapter.ts
+++ b/src/api/mission-spine/friday-run-outcome-learning-dispatch-adapter.ts
@@ -1,0 +1,81 @@
+import { FridayDomainError } from "#errors";
+
+import type { FridayRunOutcomeLearningRoutesDispatchService } from "../http/routes/friday-run-outcome-learning-routes.js";
+import {
+  createFridayRustHubAgentRunSealedClient,
+  type CreateFridayRustHubAgentRunSealedClientOptions,
+  type FridayRustHubAgentRunSealedClient,
+  type FridayRustHubRunOutcomeLearningDecisionRequest,
+  type FridayRustHubRunOutcomeLearningDecisionResult,
+} from "./friday-rust-hub-agent-run-ws-sealed-client.js";
+import type { FridayRustAgentRunWsClientX25519SecretResolver } from "./friday-rust-hub-agent-run-ws-client-x25519-secret.js";
+
+export type CreateRunOutcomeLearningSealedClientFn = (
+  options: CreateFridayRustHubAgentRunSealedClientOptions,
+) => FridayRustHubAgentRunSealedClient;
+
+export interface CreateFridayRunOutcomeLearningDispatchAdapterOptions {
+  readonly host?: string;
+  readonly port: number;
+  readonly timeoutMs?: number;
+  readonly secretResolver: FridayRustAgentRunWsClientX25519SecretResolver;
+  readonly createClient?: CreateRunOutcomeLearningSealedClientFn;
+}
+
+function unavailable(message: string): FridayDomainError {
+  return new FridayDomainError("RUN_OUTCOME_LEARNING_DISPATCH_RUST_UNAVAILABLE", message, {
+    httpStatus: 503,
+    details: {
+      surface: "service:run_outcome_learning_dispatch_adapter",
+      bridge: "rust_wired",
+      proofOnly: true,
+      proofReady: false,
+    },
+  });
+}
+
+export function createFridayRunOutcomeLearningDispatchAdapter(
+  options: CreateFridayRunOutcomeLearningDispatchAdapterOptions,
+): FridayRunOutcomeLearningRoutesDispatchService {
+  const { host, port, timeoutMs } = options;
+  const createClient = options.createClient ?? createFridayRustHubAgentRunSealedClient;
+  const secretResolver = options.secretResolver;
+
+  function buildClient(): FridayRustHubAgentRunSealedClient {
+    const clientSecret = secretResolver();
+    if (!clientSecret) {
+      throw unavailable("Run-outcome learning dispatch could not resolve the sealed-WS client secret.");
+    }
+    try {
+      return createClient({
+        ...(host !== undefined ? { host } : {}),
+        port,
+        clientSecret,
+        ...(timeoutMs !== undefined ? { timeoutMs } : {}),
+      });
+    } catch {
+      throw unavailable("Run-outcome learning dispatch could not construct the sealed-WS client.");
+    }
+  }
+
+  return {
+    async decideRunOutcomeLearning(
+      request: FridayRustHubRunOutcomeLearningDecisionRequest,
+    ): Promise<FridayRustHubRunOutcomeLearningDecisionResult> {
+      const client = buildClient();
+      try {
+        return await client.decideRunOutcomeLearning(request);
+      } catch (error) {
+        throw error instanceof FridayDomainError
+          ? error
+          : unavailable("Run-outcome learning decision dispatch failed.");
+      }
+    },
+  };
+}
+
+export function readRunOutcomeLearningRustWsPort(raw: string | undefined): number {
+  if (!raw) return 0;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : 0;
+}

--- a/src/api/mission-spine/friday-rust-hub-agent-run-ws-sealed-client.ts
+++ b/src/api/mission-spine/friday-rust-hub-agent-run-ws-sealed-client.ts
@@ -422,6 +422,14 @@ export interface FridayRustHubAgentRunSealedClient {
   decideMemory(
     request: FridayRustHubMemoryDecisionRequest,
   ): Promise<FridayRustHubMemoryDecisionResult>;
+  /**
+   * (A1) Apply the OWNER's explicit confirm/reject to ONE pending run-outcome learning candidate over
+   * a sealed session — `Message::RunOutcomeLearningDecisionRequest`. PURE Hub mutation; no
+   * provider/model call and no answer body. `status:"blocked"` is an honest refusal receipt.
+   */
+  decideRunOutcomeLearning(
+    request: FridayRustHubRunOutcomeLearningDecisionRequest,
+  ): Promise<FridayRustHubRunOutcomeLearningDecisionResult>;
 }
 
 /** (A3 courier) A resume relay: the run to resume + the operator's OPAQUE signed approval blob. */
@@ -609,6 +617,24 @@ export interface FridayRustHubMemoryDecisionResult {
   readonly blocker?: string;
   /** Whether the candidate is now recallable (durable `Confirmed`). */
   readonly recallable: boolean;
+}
+
+/** (A1) An OWNER confirm/reject decision for one refs-only run-outcome learning candidate. */
+export interface FridayRustHubRunOutcomeLearningDecisionRequest {
+  readonly candidateId: string;
+  readonly decision: "confirm" | "reject";
+  readonly reason?: string;
+}
+
+/** (A1) Refs-only run-outcome learning decision result. */
+export interface FridayRustHubRunOutcomeLearningDecisionResult {
+  readonly truthLabel: "rust_wired";
+  readonly candidateId: string;
+  readonly runId?: string;
+  readonly kind?: string;
+  readonly state: string;
+  readonly status: string;
+  readonly blocker?: string;
 }
 
 function unavailable(message: string, details?: Record<string, unknown>): FridayDomainError {
@@ -1102,6 +1128,21 @@ export function buildMemoryDecisionEnvelope(
   });
 }
 
+/** Build the exact nested `RunOutcomeLearningDecisionRequest { request: ... }` wire message. */
+export function buildRunOutcomeLearningDecisionEnvelope(
+  request: FridayRustHubRunOutcomeLearningDecisionRequest,
+): Record<string, unknown> {
+  const inner: Record<string, unknown> = {
+    candidate_id: request.candidateId,
+    decision: request.decision,
+    ...(request.reason !== undefined ? { reason: request.reason } : {}),
+  };
+  return buildMissionEnvelope(`run-outcome-learning-decision-${request.candidateId}`, {
+    kind: "RunOutcomeLearningDecisionRequest",
+    request: inner,
+  });
+}
+
 /**
  * (Lane B) Parse a `MissionIntakeResult` inbound into the refs-only TS result. Returns `undefined`
  * (caller fails closed) when a REQUIRED ref is missing/ill-typed. The optional refs are surfaced
@@ -1343,6 +1384,34 @@ export function parseMemoryDecisionResult(
     state,
     status,
     recallable,
+    ...(blocker !== undefined ? { blocker } : {}),
+  };
+}
+
+/** Parse a nested `RunOutcomeLearningDecisionResult { result: ... }` into refs-only TS shape. */
+export function parseRunOutcomeLearningDecisionResult(
+  fields: Record<string, unknown>,
+): FridayRustHubRunOutcomeLearningDecisionResult | undefined {
+  const r = unwrapResult(fields);
+  if (r === undefined) {
+    return undefined;
+  }
+  const candidateId = asString(r.candidate_id);
+  const state = asString(r.state);
+  const status = asString(r.status);
+  if (!candidateId || !state || !status) {
+    return undefined;
+  }
+  const runId = asString(r.run_id);
+  const kind = asString(r.kind);
+  const blocker = asString(r.blocker);
+  return {
+    truthLabel: "rust_wired",
+    candidateId,
+    state,
+    status,
+    ...(runId !== undefined ? { runId } : {}),
+    ...(kind !== undefined ? { kind } : {}),
     ...(blocker !== undefined ? { blocker } : {}),
   };
 }
@@ -2281,6 +2350,31 @@ export function createFridayRustHubAgentRunSealedClient(
         expectedKind: "MemoryDecisionResult",
         parse: parseMemoryDecisionResult,
         leg: "memory-decision",
+      });
+    },
+
+    decideRunOutcomeLearning(
+      request: FridayRustHubRunOutcomeLearningDecisionRequest,
+    ): Promise<FridayRustHubRunOutcomeLearningDecisionResult> {
+      if (!request.candidateId) {
+        return Promise.reject(
+          unavailable("Sealed A1 run-outcome learning decision requires a candidate id."),
+        );
+      }
+      if (request.decision !== "confirm" && request.decision !== "reject") {
+        return Promise.reject(
+          unavailable("Sealed A1 run-outcome learning decision must be 'confirm' or 'reject'."),
+        );
+      }
+      return runMissionRoundTrip<FridayRustHubRunOutcomeLearningDecisionResult>({
+        host,
+        port,
+        timeoutMs,
+        keypair,
+        envelope: buildRunOutcomeLearningDecisionEnvelope(request),
+        expectedKind: "RunOutcomeLearningDecisionResult",
+        parse: parseRunOutcomeLearningDecisionResult,
+        leg: "run-outcome-learning-decision",
       });
     },
   };

--- a/src/api/runtime/friday-api-runtime.ts
+++ b/src/api/runtime/friday-api-runtime.ts
@@ -131,6 +131,10 @@ import {
   createFridayMemorySpineRoutes,
   type FridayMemorySpineRoutesDeps,
 } from "../http/routes/friday-memory-spine-routes.js";
+import {
+  createFridayRunOutcomeLearningRoutes,
+  type FridayRunOutcomeLearningRoutesDeps,
+} from "../http/routes/friday-run-outcome-learning-routes.js";
 import { createFridayCrossBorderPackRoutes } from "../http/routes/friday-cross-border-pack-routes.js";
 import { createFridayAssetInventoryRoutes } from "../http/routes/friday-asset-inventory-routes.js";
 import { createFridayStudioRoutes } from "../http/routes/friday-studio-routes.js";
@@ -4130,6 +4134,15 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
     routes.register(route);
   }
 
+  const runOutcomeLearningDeps: FridayRunOutcomeLearningRoutesDeps =
+    deps.runOutcomeLearning ?? {
+      dispatch: null,
+      dispatchDisabledReason: "run-outcome learning decision dispatch deps not provided",
+    };
+  for (const route of createFridayRunOutcomeLearningRoutes(runOutcomeLearningDeps)) {
+    routes.register(route);
+  }
+
   // Register realtime routes
   for (const route of createFridayRealtimeRoutes({
     subscriptionService: subscriptions,
@@ -5449,6 +5462,7 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
     uix: deps.uix,
     missionSpine: deps.missionSpine,
     memorySpine: deps.memorySpine,
+    runOutcomeLearning: deps.runOutcomeLearning,
     system: deps.system,
     guideLens: deps.guideLens,
   };

--- a/src/api/runtime/friday-api-runtime.types.ts
+++ b/src/api/runtime/friday-api-runtime.types.ts
@@ -81,6 +81,7 @@ import type { FridayGuideLensRoutesDeps } from "../http/routes/friday-guide-lens
 import type { FridayUixRoutesDeps } from "../http/routes/friday-uix-routes.js";
 import type { FridayMissionSpineRoutesDeps } from "../http/routes/friday-mission-spine-routes.js";
 import type { FridayMemorySpineRoutesDeps } from "../http/routes/friday-memory-spine-routes.js";
+import type { FridayRunOutcomeLearningRoutesDeps } from "../http/routes/friday-run-outcome-learning-routes.js";
 import type { FridayCrossBorderPackRoutesDeps } from "../http/routes/friday-cross-border-pack-routes.js";
 import type { FridayPackagingRoutesDeps } from "../http/routes/friday-packaging-routes.js";
 import type {
@@ -155,6 +156,8 @@ export interface FridayApiRuntime {
   missionSpine?: FridayMissionSpineRoutesDeps;
   /** (Lane M) Memory-confirmation loop terminal route surface. Always registered; DEFAULT-OFF (503). */
   memorySpine?: FridayMemorySpineRoutesDeps;
+  /** A1 run-outcome learning candidate decision route surface. Always registered; DEFAULT-OFF (503). */
+  runOutcomeLearning?: FridayRunOutcomeLearningRoutesDeps;
   crossBorderPack?: FridayCrossBorderPackRoutesDeps;
   system?: FridaySystemRoutesDeps;
   guideLens?: FridayGuideLensRoutesDeps;
@@ -656,6 +659,8 @@ export interface CreateFridayApiRuntimeDeps {
    * needs an operator to wire the adapter AND flip the Rust `FRIDAY_MEMORY_CONFIRM` flag.
    */
   memorySpine?: FridayMemorySpineRoutesDeps;
+  /** Optional A1 run-outcome learning candidate decision route surface. Default: fail-closed 503. */
+  runOutcomeLearning?: FridayRunOutcomeLearningRoutesDeps;
   /** Optional: cross-border operating pack route surface. */
   crossBorderPack?: FridayCrossBorderPackRoutesDeps;
   /**

--- a/src/hub/bootstrap/hub-helpers.ts
+++ b/src/hub/bootstrap/hub-helpers.ts
@@ -2010,6 +2010,13 @@ export interface FridayHubConfig {
    */
   routeMemorySpineViaRust?: boolean;
   /**
+   * A1 run-outcome learning decision route bridge (DARK): wires a real dispatch adapter into
+   * `runOutcomeLearning.dispatch` so `/v1/run-outcome-learning/decide` becomes callable. DEFAULT-FALSE.
+   * End-to-end A1 live-done still requires Rust `FRIDAY_RUN_OUTCOME_LEARNING_CONFIRM`, an
+   * operator-origin organic candidate, and a real confirm.
+   */
+  routeRunOutcomeLearningViaRust?: boolean;
+  /**
    * (Organic mission→run binding PRODUCER — DARK): "after a fresh-Ready `/v1/mission-spine/intake`,
    * immediately fire a READ-ONLY bound agent-run carrying the server-produced mission handle" flag.
    * DEFAULT-FALSE — production hub creation must leave this unset so the auto-dispatch driver is

--- a/src/hub/friday-hub-bootstrap.ts
+++ b/src/hub/friday-hub-bootstrap.ts
@@ -138,6 +138,10 @@ import {
   createFridayMemorySpineDispatchAdapter,
   readMemorySpineRustWsPort,
 } from "../api/mission-spine/friday-memory-spine-dispatch-adapter.js";
+import {
+  createFridayRunOutcomeLearningDispatchAdapter,
+  readRunOutcomeLearningRustWsPort,
+} from "../api/mission-spine/friday-run-outcome-learning-dispatch-adapter.js";
 import { resolveRustAgentRunWsClientX25519Secret } from "../api/mission-spine/friday-rust-hub-agent-run-ws-client-x25519-secret.js";
 import type { FridayChannelPersonaConfig, FridayGuideLensRoutesDeps, FridaySystemRoutesDeps } from "#api";
 import type { FridayPackagingRoutesDeps } from "../api/http/routes/friday-packaging-routes.js";
@@ -1135,6 +1139,17 @@ export function resolveRouteMemorySpineViaRust(
     return configValue;
   }
   const raw = (env.FRIDAY_MEMORY_SPINE_ROUTES_VIA_RUST ?? "").trim().toLowerCase();
+  return raw === "1" || raw === "true";
+}
+
+export function resolveRouteRunOutcomeLearningViaRust(
+  configValue: boolean | undefined,
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  if (typeof configValue === "boolean") {
+    return configValue;
+  }
+  const raw = (env.FRIDAY_RUN_OUTCOME_LEARNING_ROUTES_VIA_RUST ?? "").trim().toLowerCase();
   return raw === "1" || raw === "true";
 }
 
@@ -7213,6 +7228,16 @@ export async function createFridayHub(
       secretResolver: resolveRustAgentRunWsClientX25519Secret,
     })
     : null;
+  const routeRunOutcomeLearningViaRust = resolveRouteRunOutcomeLearningViaRust(
+    config.routeRunOutcomeLearningViaRust,
+  );
+  const runOutcomeLearningDispatch = routeRunOutcomeLearningViaRust
+    ? createFridayRunOutcomeLearningDispatchAdapter({
+      host: process.env.FRIDAY_HUB_AGENT_RUN_WS_HOST ?? "127.0.0.1",
+      port: readRunOutcomeLearningRustWsPort(process.env.FRIDAY_HUB_AGENT_RUN_WS_PORT),
+      secretResolver: resolveRustAgentRunWsClientX25519Secret,
+    })
+    : null;
 
   const runtimeSupportedChannelKinds = FRIDAY_SUPPORTED_CHANNEL_KINDS.filter(isFridayChannelKindSupported);
 
@@ -7306,6 +7331,7 @@ export async function createFridayHub(
     // the route's own default (`dispatch: null`), and `POST /v1/memory-spine/decide` is fail-closed 503
     // (`MEMORY_SPINE_DISPATCH_UNAVAILABLE`) → byte-identical to today.
     memorySpine: memorySpineDispatch ? { dispatch: memorySpineDispatch } : undefined,
+    runOutcomeLearning: runOutcomeLearningDispatch ? { dispatch: runOutcomeLearningDispatch } : undefined,
     uix: {
       service: uixService,
       readSetupCompletedAt,

--- a/src/hub/index.ts
+++ b/src/hub/index.ts
@@ -41,6 +41,7 @@ export {
   resolveRouteAgentRunViaRust,
   resolveRouteMissionSpineViaRust,
   resolveRouteMemorySpineViaRust,
+  resolveRouteRunOutcomeLearningViaRust,
   resolveMissionAutoDispatch,
   resolveRouteProvidersViaRust,
   resolveRouteWorkflowsViaRust,

--- a/src/security/friday-owner-session-channel-capability.ts
+++ b/src/security/friday-owner-session-channel-capability.ts
@@ -51,6 +51,7 @@ export type FridayPublicMutationOperation =
   | "agent.tool.approve"
   | "agent.tool.reject"
   | "agent.run.resume"
+  | "run.outcome.learning.decide.apply"
   | "satellite.pairing.approve"
   | "satellite.pairing.reject"
   | "satellite.revoke"

--- a/test/contracts/api/__snapshots__/friday-api-route-contract.snapshot.test.ts.snap
+++ b/test/contracts/api/__snapshots__/friday-api-route-contract.snapshot.test.ts.snap
@@ -3,14 +3,14 @@
 exports[`MECHANISM-4 — API Route Contract (Snapshot) > Phase 14.5A WP-001: every public mutating route maps to an accepted gate family 1`] = `
 {
   "classified": {
-    "bound_principal": 65,
+    "bound_principal": 66,
     "channel_signature": 4,
     "hmac_or_bearer_opt_in": 1,
     "public_low_risk": 2,
     "rate_limited_pending": 4,
     "unclassified": 251,
   },
-  "total_public_mutating": 327,
+  "total_public_mutating": 328,
   "unclassified_sample_max_5": [
     "capabilities.acquisition.runs.create",
     "capabilities.acquisition.runs.approve",
@@ -21,7 +21,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > Phase 14.5A WP-001: eve
 }
 `;
 
-exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures route count to detect accidental additions/removals 1`] = `426`;
+exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures route count to detect accidental additions/removals 1`] = `427`;
 
 exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route surface as a stable contract 1`] = `
 [
@@ -1859,6 +1859,16 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
     "authKind": "public",
     "index": 183,
     "method": "POST",
+    "operationId": "run.outcome.learning.decide.apply",
+    "path": "/v1/run-outcome-learning/decide",
+    "rateLimitPolicyId": null,
+    "roles": [],
+    "scopes": [],
+  },
+  {
+    "authKind": "public",
+    "index": 184,
+    "method": "POST",
     "operationId": "realtime.subscribe",
     "path": "/v1/realtime/subscriptions",
     "rateLimitPolicyId": "realtime.subscribe",
@@ -1867,7 +1877,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 184,
+    "index": 185,
     "method": "POST",
     "operationId": "realtime.pull",
     "path": "/v1/realtime/pull",
@@ -1877,7 +1887,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 185,
+    "index": 186,
     "method": "POST",
     "operationId": "realtime.ack",
     "path": "/v1/realtime/ack",
@@ -1887,7 +1897,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 186,
+    "index": 187,
     "method": "GET",
     "operationId": "providers.usage.get",
     "path": "/v1/providers/usage",
@@ -1897,7 +1907,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 187,
+    "index": 188,
     "method": "GET",
     "operationId": "providers.budget.get",
     "path": "/v1/providers/budget",
@@ -1907,7 +1917,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 188,
+    "index": 189,
     "method": "PUT",
     "operationId": "providers.budget.set",
     "path": "/v1/providers/budget",
@@ -1917,7 +1927,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 189,
+    "index": 190,
     "method": "GET",
     "operationId": "providers.templates.list",
     "path": "/v1/providers/templates",
@@ -1927,7 +1937,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 190,
+    "index": 191,
     "method": "GET",
     "operationId": "providers.templates.get",
     "path": "/v1/providers/templates/:templateId",
@@ -1937,7 +1947,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 191,
+    "index": 192,
     "method": "GET",
     "operationId": "providers.list",
     "path": "/v1/providers",
@@ -1947,7 +1957,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 192,
+    "index": 193,
     "method": "GET",
     "operationId": "providers.health.list",
     "path": "/v1/providers/health",
@@ -1957,7 +1967,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 193,
+    "index": 194,
     "method": "GET",
     "operationId": "providers.capability.health.list",
     "path": "/v1/providers/capability-health",
@@ -1967,7 +1977,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 194,
+    "index": 195,
     "method": "POST",
     "operationId": "capabilities.doctor",
     "path": "/v1/capabilities/doctor",
@@ -1977,7 +1987,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 195,
+    "index": 196,
     "method": "GET",
     "operationId": "providers.get",
     "path": "/v1/providers/:providerId",
@@ -1987,7 +1997,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 196,
+    "index": 197,
     "method": "POST",
     "operationId": "providers.create",
     "path": "/v1/providers",
@@ -1997,7 +2007,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 197,
+    "index": 198,
     "method": "PATCH",
     "operationId": "providers.update",
     "path": "/v1/providers/:providerId",
@@ -2007,7 +2017,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 198,
+    "index": 199,
     "method": "DELETE",
     "operationId": "providers.delete",
     "path": "/v1/providers/:providerId",
@@ -2017,7 +2027,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 199,
+    "index": 200,
     "method": "POST",
     "operationId": "providers.validate",
     "path": "/v1/providers/:providerId/validate",
@@ -2027,7 +2037,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 200,
+    "index": 201,
     "method": "GET",
     "operationId": "providers.doctor",
     "path": "/v1/providers/:providerId/doctor",
@@ -2037,7 +2047,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 201,
+    "index": 202,
     "method": "GET",
     "operationId": "providers.routing.explain",
     "path": "/v1/providers/routing/explain",
@@ -2047,7 +2057,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 202,
+    "index": 203,
     "method": "POST",
     "operationId": "providers.routing.pin",
     "path": "/v1/providers/routing/pin",
@@ -2057,7 +2067,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 203,
+    "index": 204,
     "method": "POST",
     "operationId": "providers.routing.penalty.clear",
     "path": "/v1/providers/routing/penalties/clear",
@@ -2067,7 +2077,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 204,
+    "index": 205,
     "method": "GET",
     "operationId": "providers.auth.profiles.list",
     "path": "/v1/providers/:providerId/auth-profiles",
@@ -2077,7 +2087,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 205,
+    "index": 206,
     "method": "POST",
     "operationId": "providers.auth.profiles.activate",
     "path": "/v1/providers/:providerId/auth-profiles/:profileKey/activate",
@@ -2087,7 +2097,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 206,
+    "index": 207,
     "method": "GET",
     "operationId": "providers.routing.get",
     "path": "/v1/model-routing",
@@ -2097,7 +2107,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 207,
+    "index": 208,
     "method": "PUT",
     "operationId": "providers.routing.set",
     "path": "/v1/model-routing",
@@ -2107,7 +2117,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 208,
+    "index": 209,
     "method": "POST",
     "operationId": "auth.oauth.anthropic.initiate",
     "path": "/v1/auth/oauth/anthropic/initiate",
@@ -2117,7 +2127,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 209,
+    "index": 210,
     "method": "POST",
     "operationId": "auth.oauth.anthropic.callback",
     "path": "/v1/auth/oauth/anthropic/callback",
@@ -2127,7 +2137,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 210,
+    "index": 211,
     "method": "POST",
     "operationId": "auth.oauth.openai.codex.device.initiate",
     "path": "/v1/auth/oauth/openai-codex/device/initiate",
@@ -2137,7 +2147,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 211,
+    "index": 212,
     "method": "POST",
     "operationId": "auth.oauth.openai.codex.device.complete",
     "path": "/v1/auth/oauth/openai-codex/device/complete",
@@ -2147,7 +2157,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 212,
+    "index": 213,
     "method": "POST",
     "operationId": "media.understanding.doctor",
     "path": "/v1/media-understanding/doctor",
@@ -2157,7 +2167,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 213,
+    "index": 214,
     "method": "POST",
     "operationId": "media.understanding.analyze",
     "path": "/v1/media-understanding/analyze",
@@ -2167,7 +2177,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 214,
+    "index": 215,
     "method": "GET",
     "operationId": "task.workflows.boundaries.list",
     "path": "/v1/task-workflows/boundaries",
@@ -2177,7 +2187,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 215,
+    "index": 216,
     "method": "GET",
     "operationId": "task.workflows.gates.list",
     "path": "/v1/task-workflows/gates",
@@ -2187,7 +2197,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 216,
+    "index": 217,
     "method": "POST",
     "operationId": "task.workflows.preview",
     "path": "/v1/task-workflows/preview",
@@ -2197,7 +2207,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 217,
+    "index": 218,
     "method": "POST",
     "operationId": "task.workflows.create",
     "path": "/v1/task-workflows",
@@ -2207,7 +2217,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 218,
+    "index": 219,
     "method": "GET",
     "operationId": "task.workflows.list",
     "path": "/v1/task-workflows",
@@ -2217,7 +2227,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 219,
+    "index": 220,
     "method": "GET",
     "operationId": "task.workflows.get",
     "path": "/v1/task-workflows/:workflowId",
@@ -2227,7 +2237,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 220,
+    "index": 221,
     "method": "POST",
     "operationId": "task.workflows.revise",
     "path": "/v1/task-workflows/:workflowId/revisions",
@@ -2237,7 +2247,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 221,
+    "index": 222,
     "method": "GET",
     "operationId": "task.workflows.revisions.list",
     "path": "/v1/task-workflows/:workflowId/revisions",
@@ -2247,7 +2257,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 222,
+    "index": 223,
     "method": "POST",
     "operationId": "task.workflows.claims.create",
     "path": "/v1/task-workflows/:workflowId/claims",
@@ -2257,7 +2267,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 223,
+    "index": 224,
     "method": "GET",
     "operationId": "task.workflows.claims.list",
     "path": "/v1/task-workflows/:workflowId/claims",
@@ -2267,7 +2277,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 224,
+    "index": 225,
     "method": "GET",
     "operationId": "task.workflows.claims.get",
     "path": "/v1/task-workflows/:workflowId/claims/:claimId",
@@ -2277,7 +2287,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 225,
+    "index": 226,
     "method": "POST",
     "operationId": "task.workflows.claims.evidence.attach",
     "path": "/v1/task-workflows/:workflowId/claims/:claimId/evidence-ref",
@@ -2287,7 +2297,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 226,
+    "index": 227,
     "method": "GET",
     "operationId": "task.workflows.claims.evidence.list",
     "path": "/v1/task-workflows/:workflowId/claims/:claimId/evidence-refs",
@@ -2297,7 +2307,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 227,
+    "index": 228,
     "method": "POST",
     "operationId": "task.workflows.claims.verify",
     "path": "/v1/task-workflows/:workflowId/claims/:claimId/verify",
@@ -2307,7 +2317,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 228,
+    "index": 229,
     "method": "POST",
     "operationId": "task.workflows.claims.block",
     "path": "/v1/task-workflows/:workflowId/claims/:claimId/block",
@@ -2317,7 +2327,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 229,
+    "index": 230,
     "method": "POST",
     "operationId": "task.workflows.closeout",
     "path": "/v1/task-workflows/:workflowId/closeout",
@@ -2327,7 +2337,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 230,
+    "index": 231,
     "method": "POST",
     "operationId": "task.workflows.lanes.executor.open",
     "path": "/v1/task-workflows/:workflowId/lanes/executor",
@@ -2337,7 +2347,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 231,
+    "index": 232,
     "method": "POST",
     "operationId": "task.workflows.lanes.verifier.open",
     "path": "/v1/task-workflows/:workflowId/lanes/verifier",
@@ -2347,7 +2357,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 232,
+    "index": 233,
     "method": "POST",
     "operationId": "task.workflows.lanes.complete",
     "path": "/v1/task-workflows/:workflowId/lanes/:laneId/complete",
@@ -2357,7 +2367,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 233,
+    "index": 234,
     "method": "POST",
     "operationId": "task.workflows.lanes.verdict",
     "path": "/v1/task-workflows/:workflowId/lanes/:laneId/verdict",
@@ -2367,7 +2377,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 234,
+    "index": 235,
     "method": "GET",
     "operationId": "task.workflows.lanes.list",
     "path": "/v1/task-workflows/:workflowId/lanes",
@@ -2377,7 +2387,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 235,
+    "index": 236,
     "method": "GET",
     "operationId": "task.workflows.lanes.get",
     "path": "/v1/task-workflows/:workflowId/lanes/:laneId",
@@ -2387,7 +2397,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 236,
+    "index": 237,
     "method": "POST",
     "operationId": "task.workflows.lanes.cli.handoff.record",
     "path": "/v1/task-workflows/:workflowId/lanes/:laneId/cli-handoffs",
@@ -2397,7 +2407,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 237,
+    "index": 238,
     "method": "GET",
     "operationId": "task.workflows.lanes.cli.handoffs.list",
     "path": "/v1/task-workflows/:workflowId/lanes/:laneId/cli-handoffs",
@@ -2407,7 +2417,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 238,
+    "index": 239,
     "method": "GET",
     "operationId": "task.workflows.cli.handoffs.list",
     "path": "/v1/task-workflows/:workflowId/cli-handoffs",
@@ -2417,7 +2427,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 239,
+    "index": 240,
     "method": "GET",
     "operationId": "task.workflows.supervisor.read",
     "path": "/v1/task-workflows/:workflowId/supervisor",
@@ -2427,7 +2437,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 240,
+    "index": 241,
     "method": "POST",
     "operationId": "task.workflows.channel.command.issue",
     "path": "/v1/task-workflows/:workflowId/channel-commands",
@@ -2437,7 +2447,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 241,
+    "index": 242,
     "method": "GET",
     "operationId": "task.workflows.channel.command.list",
     "path": "/v1/task-workflows/:workflowId/channel-commands",
@@ -2447,7 +2457,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 242,
+    "index": 243,
     "method": "POST",
     "operationId": "task.workflows.channel.command.confirm",
     "path": "/v1/task-workflows/:workflowId/channel-commands/confirm",
@@ -2457,7 +2467,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 243,
+    "index": 244,
     "method": "GET",
     "operationId": "task.workflows.evidence.explorer.query",
     "path": "/v1/task-workflows/evidence",
@@ -2467,7 +2477,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 244,
+    "index": 245,
     "method": "GET",
     "operationId": "task.workflows.evidence.explorer.raw",
     "path": "/v1/task-workflows/evidence/:evidenceRefId/raw",
@@ -2477,7 +2487,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 245,
+    "index": 246,
     "method": "POST",
     "operationId": "skills.social.import",
     "path": "/v1/skills/social-import",
@@ -2487,7 +2497,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 246,
+    "index": 247,
     "method": "GET",
     "operationId": "setup.status",
     "path": "/v1/setup/status",
@@ -2497,7 +2507,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 247,
+    "index": 248,
     "method": "POST",
     "operationId": "providers.detect",
     "path": "/v1/providers/detect",
@@ -2507,7 +2517,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 248,
+    "index": 249,
     "method": "GET",
     "operationId": "setup.network.get",
     "path": "/v1/setup/network",
@@ -2517,7 +2527,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 249,
+    "index": 250,
     "method": "POST",
     "operationId": "setup.network.save",
     "path": "/v1/setup/network",
@@ -2527,7 +2537,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 250,
+    "index": 251,
     "method": "POST",
     "operationId": "setup.channels.feishu.registration.begin",
     "path": "/v1/setup/channels/feishu/registration/begin",
@@ -2537,7 +2547,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 251,
+    "index": 252,
     "method": "POST",
     "operationId": "setup.channels.feishu.registration.poll",
     "path": "/v1/setup/channels/feishu/registration/poll",
@@ -2547,7 +2557,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 252,
+    "index": 253,
     "method": "POST",
     "operationId": "setup.channels.telegram.verification.begin",
     "path": "/v1/setup/channels/telegram/verification/begin",
@@ -2557,7 +2567,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 253,
+    "index": 254,
     "method": "POST",
     "operationId": "setup.channels.telegram.verification.poll",
     "path": "/v1/setup/channels/telegram/verification/poll",
@@ -2567,7 +2577,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 254,
+    "index": 255,
     "method": "POST",
     "operationId": "setup.channels.discord.verification.begin",
     "path": "/v1/setup/channels/discord/verification/begin",
@@ -2577,7 +2587,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 255,
+    "index": 256,
     "method": "POST",
     "operationId": "setup.channels.discord.verification.complete",
     "path": "/v1/setup/channels/discord/verification/complete",
@@ -2587,7 +2597,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 256,
+    "index": 257,
     "method": "POST",
     "operationId": "setup.channels.test",
     "path": "/v1/setup/channels/test",
@@ -2597,7 +2607,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 257,
+    "index": 258,
     "method": "POST",
     "operationId": "setup.channels.save",
     "path": "/v1/setup/channels",
@@ -2607,7 +2617,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 258,
+    "index": 259,
     "method": "POST",
     "operationId": "setup.complete",
     "path": "/v1/setup/complete",
@@ -2617,7 +2627,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 259,
+    "index": 260,
     "method": "GET",
     "operationId": "skills.list",
     "path": "/v1/skills",
@@ -2627,7 +2637,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 260,
+    "index": 261,
     "method": "GET",
     "operationId": "skills.catalog.list",
     "path": "/v1/skills/catalog",
@@ -2637,7 +2647,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 261,
+    "index": 262,
     "method": "GET",
     "operationId": "skills.get",
     "path": "/v1/skills/:skillId",
@@ -2647,7 +2657,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 262,
+    "index": 263,
     "method": "POST",
     "operationId": "skills.install",
     "path": "/v1/skills/install",
@@ -2657,7 +2667,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 263,
+    "index": 264,
     "method": "POST",
     "operationId": "skills.update",
     "path": "/v1/skills/:skillId/update",
@@ -2667,7 +2677,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 264,
+    "index": 265,
     "method": "DELETE",
     "operationId": "skills.delete",
     "path": "/v1/skills/:skillId",
@@ -2677,7 +2687,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 265,
+    "index": 266,
     "method": "POST",
     "operationId": "skills.manifest.validate",
     "path": "/v1/skills/validate-manifest",
@@ -2687,7 +2697,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 266,
+    "index": 267,
     "method": "POST",
     "operationId": "skills.verify",
     "path": "/v1/skills/:skillId/verify",
@@ -2697,7 +2707,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 267,
+    "index": 268,
     "method": "POST",
     "operationId": "skills.upgrade.analyze",
     "path": "/v1/skills/:skillId/upgrade/analyze",
@@ -2707,7 +2717,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 268,
+    "index": 269,
     "method": "POST",
     "operationId": "skills.upgrade.decide",
     "path": "/v1/skills/:skillId/upgrade/decide",
@@ -2717,7 +2727,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 269,
+    "index": 270,
     "method": "POST",
     "operationId": "skills.run",
     "path": "/v1/skills/:skillId/run",
@@ -2727,7 +2737,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 270,
+    "index": 271,
     "method": "POST",
     "operationId": "skills.generator.sessions.create",
     "path": "/v1/skills/generator/sessions",
@@ -2737,7 +2747,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 271,
+    "index": 272,
     "method": "GET",
     "operationId": "skills.generator.sessions.get",
     "path": "/v1/skills/generator/sessions/:sessionId",
@@ -2747,7 +2757,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 272,
+    "index": 273,
     "method": "POST",
     "operationId": "skills.generator.sessions.messages.create",
     "path": "/v1/skills/generator/sessions/:sessionId/messages",
@@ -2757,7 +2767,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 273,
+    "index": 274,
     "method": "POST",
     "operationId": "skills.generator.sessions.generate",
     "path": "/v1/skills/generator/sessions/:sessionId/generate",
@@ -2767,7 +2777,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 274,
+    "index": 275,
     "method": "POST",
     "operationId": "skills.generator.sessions.test",
     "path": "/v1/skills/generator/sessions/:sessionId/test",
@@ -2777,7 +2787,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 275,
+    "index": 276,
     "method": "GET",
     "operationId": "skills.generator.sessions.evidence.get",
     "path": "/v1/skills/generator/sessions/:sessionId/evidence",
@@ -2787,7 +2797,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 276,
+    "index": 277,
     "method": "POST",
     "operationId": "skills.generator.sessions.approve",
     "path": "/v1/skills/generator/sessions/:sessionId/approve",
@@ -2797,7 +2807,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 277,
+    "index": 278,
     "method": "DELETE",
     "operationId": "skills.generator.sessions.cancel",
     "path": "/v1/skills/generator/sessions/:sessionId",
@@ -2807,7 +2817,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 278,
+    "index": 279,
     "method": "GET",
     "operationId": "skills.ui.get",
     "path": "/v1/skills/:skillId/ui",
@@ -2817,7 +2827,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 279,
+    "index": 280,
     "method": "POST",
     "operationId": "uix.intents.resolve",
     "path": "/v1/uix/intents/resolve",
@@ -2827,7 +2837,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 280,
+    "index": 281,
     "method": "GET",
     "operationId": "uix.templates.list",
     "path": "/v1/uix/templates",
@@ -2837,7 +2847,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 281,
+    "index": 282,
     "method": "GET",
     "operationId": "uix.home.snapshot.get",
     "path": "/v1/uix/home-snapshot",
@@ -2847,7 +2857,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 282,
+    "index": 283,
     "method": "GET",
     "operationId": "uix.assistant.inbox.snapshot.get",
     "path": "/v1/uix/assistant-inbox-snapshot",
@@ -2857,7 +2867,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 283,
+    "index": 284,
     "method": "GET",
     "operationId": "uix.diagnostics.get",
     "path": "/v1/uix/diagnostics",
@@ -2867,7 +2877,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 284,
+    "index": 285,
     "method": "GET",
     "operationId": "uix.preferences.list",
     "path": "/v1/uix/preferences",
@@ -2877,7 +2887,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 285,
+    "index": 286,
     "method": "PUT",
     "operationId": "uix.preferences.update",
     "path": "/v1/uix/preferences",
@@ -2887,7 +2897,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 286,
+    "index": 287,
     "method": "DELETE",
     "operationId": "uix.preferences.delete",
     "path": "/v1/uix/preferences/:preferenceId",
@@ -2897,7 +2907,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 287,
+    "index": 288,
     "method": "GET",
     "operationId": "uix.persona.get",
     "path": "/v1/uix/persona",
@@ -2907,7 +2917,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 288,
+    "index": 289,
     "method": "PUT",
     "operationId": "uix.persona.update",
     "path": "/v1/uix/persona",
@@ -2917,7 +2927,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 289,
+    "index": 290,
     "method": "POST",
     "operationId": "uix.templates.execute",
     "path": "/v1/uix/templates/:templateId/execute",
@@ -2927,7 +2937,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 290,
+    "index": 291,
     "method": "POST",
     "operationId": "uix.wizards.start",
     "path": "/v1/uix/wizards/:wizardId/start",
@@ -2937,7 +2947,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 291,
+    "index": 292,
     "method": "POST",
     "operationId": "uix.wizards.continue",
     "path": "/v1/uix/wizards/:wizardId/continue",
@@ -2947,7 +2957,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 292,
+    "index": 293,
     "method": "GET",
     "operationId": "uix.issues.list",
     "path": "/v1/uix/issues",
@@ -2957,7 +2967,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 293,
+    "index": 294,
     "method": "GET",
     "operationId": "uix.user.profile.get",
     "path": "/v1/uix/user-profile",
@@ -2967,7 +2977,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 294,
+    "index": 295,
     "method": "PUT",
     "operationId": "uix.user.profile.update",
     "path": "/v1/uix/user-profile",
@@ -2977,7 +2987,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 295,
+    "index": 296,
     "method": "POST",
     "operationId": "uix.investigate",
     "path": "/v1/uix/investigate",
@@ -2987,7 +2997,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 296,
+    "index": 297,
     "method": "GET",
     "operationId": "uix.learnedfacts.list",
     "path": "/v1/uix/learned-facts",
@@ -2997,7 +3007,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 297,
+    "index": 298,
     "method": "DELETE",
     "operationId": "uix.learnedfacts.clear",
     "path": "/v1/uix/learned-facts",
@@ -3007,7 +3017,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 298,
+    "index": 299,
     "method": "PATCH",
     "operationId": "uix.learnedfacts.update",
     "path": "/v1/uix/learned-facts/:factKey",
@@ -3017,7 +3027,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 299,
+    "index": 300,
     "method": "DELETE",
     "operationId": "uix.learnedfacts.delete",
     "path": "/v1/uix/learned-facts/:factKey",
@@ -3027,7 +3037,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 300,
+    "index": 301,
     "method": "GET",
     "operationId": "packs.cross.border.profile.get",
     "path": "/v1/packs/cross-border/profile",
@@ -3037,7 +3047,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 301,
+    "index": 302,
     "method": "PUT",
     "operationId": "packs.cross.border.profile.put",
     "path": "/v1/packs/cross-border/profile",
@@ -3047,7 +3057,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 302,
+    "index": 303,
     "method": "GET",
     "operationId": "packs.cross.border.snapshot.get",
     "path": "/v1/packs/cross-border/snapshot",
@@ -3057,7 +3067,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 303,
+    "index": 304,
     "method": "POST",
     "operationId": "packs.cross.border.import.post",
     "path": "/v1/packs/cross-border/import",
@@ -3067,7 +3077,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 304,
+    "index": 305,
     "method": "POST",
     "operationId": "packs.cross.border.workflow.presets.apply",
     "path": "/v1/packs/cross-border/workflow-presets/apply",
@@ -3077,7 +3087,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 305,
+    "index": 306,
     "method": "PATCH",
     "operationId": "packs.cross.border.workflow.presets.toggle",
     "path": "/v1/packs/cross-border/workflow-presets/:workflowId",
@@ -3087,7 +3097,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 306,
+    "index": 307,
     "method": "POST",
     "operationId": "packs.cross.border.run.evidence.capture",
     "path": "/v1/packs/cross-border/run-evidence",
@@ -3097,7 +3107,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 307,
+    "index": 308,
     "method": "PATCH",
     "operationId": "packs.cross.border.import.stale",
     "path": "/v1/packs/cross-border/imports/:importBatchId/stale",
@@ -3107,7 +3117,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 308,
+    "index": 309,
     "method": "POST",
     "operationId": "packs.cross.border.workflows.disable.all",
     "path": "/v1/packs/cross-border/workflows/disable-all",
@@ -3117,7 +3127,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 309,
+    "index": 310,
     "method": "GET",
     "operationId": "skills.converters.list",
     "path": "/v1/skills/converters",
@@ -3127,7 +3137,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 310,
+    "index": 311,
     "method": "POST",
     "operationId": "skills.convert",
     "path": "/v1/skills/convert",
@@ -3137,7 +3147,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 311,
+    "index": 312,
     "method": "POST",
     "operationId": "skills.import",
     "path": "/v1/skills/import",
@@ -3147,7 +3157,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 312,
+    "index": 313,
     "method": "POST",
     "operationId": "skills.pack",
     "path": "/v1/skills/pack",
@@ -3157,7 +3167,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 313,
+    "index": 314,
     "method": "POST",
     "operationId": "workflows.generator.sessions.create",
     "path": "/v1/workflows/generator/sessions",
@@ -3167,7 +3177,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 314,
+    "index": 315,
     "method": "GET",
     "operationId": "workflows.generator.sessions.get",
     "path": "/v1/workflows/generator/sessions/:sessionId",
@@ -3177,7 +3187,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 315,
+    "index": 316,
     "method": "POST",
     "operationId": "workflows.generator.sessions.messages.create",
     "path": "/v1/workflows/generator/sessions/:sessionId/messages",
@@ -3187,7 +3197,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 316,
+    "index": 317,
     "method": "POST",
     "operationId": "workflows.generator.sessions.generate",
     "path": "/v1/workflows/generator/sessions/:sessionId/generate",
@@ -3197,7 +3207,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 317,
+    "index": 318,
     "method": "GET",
     "operationId": "workflows.generator.sessions.evidence.get",
     "path": "/v1/workflows/generator/sessions/:sessionId/evidence",
@@ -3207,7 +3217,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 318,
+    "index": 319,
     "method": "POST",
     "operationId": "workflows.generator.sessions.approve",
     "path": "/v1/workflows/generator/sessions/:sessionId/approve",
@@ -3217,7 +3227,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 319,
+    "index": 320,
     "method": "DELETE",
     "operationId": "workflows.generator.sessions.cancel",
     "path": "/v1/workflows/generator/sessions/:sessionId",
@@ -3227,7 +3237,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 320,
+    "index": 321,
     "method": "GET",
     "operationId": "rules.bundles.list",
     "path": "/v1/rules/bundles",
@@ -3237,7 +3247,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 321,
+    "index": 322,
     "method": "GET",
     "operationId": "rules.bundles.get",
     "path": "/v1/rules/bundles/:bundleId",
@@ -3247,7 +3257,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 322,
+    "index": 323,
     "method": "POST",
     "operationId": "rules.bundles.create",
     "path": "/v1/rules/bundles",
@@ -3257,7 +3267,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 323,
+    "index": 324,
     "method": "PATCH",
     "operationId": "rules.bundles.update",
     "path": "/v1/rules/bundles/:bundleId",
@@ -3267,7 +3277,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 324,
+    "index": 325,
     "method": "GET",
     "operationId": "rules.bundles.versions.list",
     "path": "/v1/rules/bundles/:bundleId/versions",
@@ -3277,7 +3287,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 325,
+    "index": 326,
     "method": "GET",
     "operationId": "rules.list",
     "path": "/v1/rules/bundles/:bundleId/rules",
@@ -3287,7 +3297,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 326,
+    "index": 327,
     "method": "POST",
     "operationId": "rules.evaluate",
     "path": "/v1/rules/evaluate",
@@ -3297,7 +3307,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 327,
+    "index": 328,
     "method": "POST",
     "operationId": "rules.simulate",
     "path": "/v1/rules/simulate",
@@ -3307,7 +3317,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 328,
+    "index": 329,
     "method": "GET",
     "operationId": "rules.versions.list",
     "path": "/v1/rules/:ruleId/versions",
@@ -3317,7 +3327,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 329,
+    "index": 330,
     "method": "GET",
     "operationId": "rules.audit.log.list",
     "path": "/v1/rules/audit-log",
@@ -3327,7 +3337,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 330,
+    "index": 331,
     "method": "POST",
     "operationId": "node.runner.execute",
     "path": "/v1/node-runner/execute",
@@ -3337,7 +3347,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 331,
+    "index": 332,
     "method": "GET",
     "operationId": "node.runner.executions.get",
     "path": "/v1/node-runner/executions/:executionId",
@@ -3347,7 +3357,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 332,
+    "index": 333,
     "method": "GET",
     "operationId": "node.runner.executions.list",
     "path": "/v1/node-runner/executions",
@@ -3357,7 +3367,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 333,
+    "index": 334,
     "method": "POST",
     "operationId": "acceptance.run",
     "path": "/v1/acceptance/run",
@@ -3367,7 +3377,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 334,
+    "index": 335,
     "method": "GET",
     "operationId": "acceptance.results.get",
     "path": "/v1/acceptance/results/:resultId",
@@ -3377,7 +3387,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 335,
+    "index": 336,
     "method": "GET",
     "operationId": "acceptance.results.list",
     "path": "/v1/acceptance/results",
@@ -3387,7 +3397,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 336,
+    "index": 337,
     "method": "GET",
     "operationId": "acceptance.runs.get",
     "path": "/v1/acceptance/runs/:runId",
@@ -3397,7 +3407,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 337,
+    "index": 338,
     "method": "GET",
     "operationId": "acceptance.tests.list",
     "path": "/v1/acceptance/tests",
@@ -3407,7 +3417,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 338,
+    "index": 339,
     "method": "GET",
     "operationId": "acceptance.tests.get",
     "path": "/v1/acceptance/tests/:testId",
@@ -3417,7 +3427,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 339,
+    "index": 340,
     "method": "POST",
     "operationId": "acceptance.tests.create",
     "path": "/v1/acceptance/tests",
@@ -3427,7 +3437,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 340,
+    "index": 341,
     "method": "PUT",
     "operationId": "acceptance.tests.update",
     "path": "/v1/acceptance/tests/:testId",
@@ -3437,7 +3447,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 341,
+    "index": 342,
     "method": "DELETE",
     "operationId": "acceptance.tests.delete",
     "path": "/v1/acceptance/tests/:testId",
@@ -3447,7 +3457,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 342,
+    "index": 343,
     "method": "GET",
     "operationId": "acceptance.tests.versions.list",
     "path": "/v1/acceptance/tests/:testId/versions",
@@ -3457,7 +3467,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 343,
+    "index": 344,
     "method": "GET",
     "operationId": "acceptance.artifacts.history",
     "path": "/v1/acceptance/artifacts/history",
@@ -3467,7 +3477,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 344,
+    "index": 345,
     "method": "GET",
     "operationId": "retry.policies.list",
     "path": "/v1/retry/policies",
@@ -3477,7 +3487,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 345,
+    "index": 346,
     "method": "GET",
     "operationId": "retry.policies.get",
     "path": "/v1/retry/policies/:policyId",
@@ -3487,7 +3497,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 346,
+    "index": 347,
     "method": "POST",
     "operationId": "retry.policies.create",
     "path": "/v1/retry/policies",
@@ -3497,7 +3507,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 347,
+    "index": 348,
     "method": "PUT",
     "operationId": "retry.policies.update",
     "path": "/v1/retry/policies/:policyId",
@@ -3507,7 +3517,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 348,
+    "index": 349,
     "method": "DELETE",
     "operationId": "retry.policies.delete",
     "path": "/v1/retry/policies/:policyId",
@@ -3517,7 +3527,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 349,
+    "index": 350,
     "method": "POST",
     "operationId": "retry.classify",
     "path": "/v1/retry/classify",
@@ -3527,7 +3537,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 350,
+    "index": 351,
     "method": "POST",
     "operationId": "retry.decide",
     "path": "/v1/retry/decide",
@@ -3537,7 +3547,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 351,
+    "index": 352,
     "method": "GET",
     "operationId": "retry.traces.list",
     "path": "/v1/retry/traces",
@@ -3547,7 +3557,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 352,
+    "index": 353,
     "method": "GET",
     "operationId": "retry.traces.get",
     "path": "/v1/retry/traces/:traceId",
@@ -3557,7 +3567,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 353,
+    "index": 354,
     "method": "GET",
     "operationId": "retry.costs.summary",
     "path": "/v1/retry/costs",
@@ -3567,7 +3577,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 354,
+    "index": 355,
     "method": "GET",
     "operationId": "retry.escalations.list",
     "path": "/v1/retry/escalations",
@@ -3577,7 +3587,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 355,
+    "index": 356,
     "method": "POST",
     "operationId": "retry.escalations.acknowledge",
     "path": "/v1/retry/escalations/:escalationId/acknowledge",
@@ -3587,7 +3597,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 356,
+    "index": 357,
     "method": "GET",
     "operationId": "retry.circuit.breakers.list",
     "path": "/v1/retry/circuit-breakers",
@@ -3597,7 +3607,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 357,
+    "index": 358,
     "method": "GET",
     "operationId": "playbook.list",
     "path": "/v1/playbooks",
@@ -3607,7 +3617,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 358,
+    "index": 359,
     "method": "GET",
     "operationId": "playbook.get",
     "path": "/v1/playbooks/:playbookId",
@@ -3617,7 +3627,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 359,
+    "index": 360,
     "method": "POST",
     "operationId": "playbook.select",
     "path": "/v1/playbooks/select",
@@ -3627,7 +3637,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 360,
+    "index": 361,
     "method": "GET",
     "operationId": "playbook.candidates.list",
     "path": "/v1/playbooks/candidates",
@@ -3637,7 +3647,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 361,
+    "index": 362,
     "method": "POST",
     "operationId": "playbook.candidates.promote",
     "path": "/v1/playbooks/candidates/:candidateId/promote",
@@ -3647,7 +3657,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 362,
+    "index": 363,
     "method": "POST",
     "operationId": "playbook.rollback",
     "path": "/v1/playbooks/:playbookId/rollback",
@@ -3657,7 +3667,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 363,
+    "index": 364,
     "method": "GET",
     "operationId": "playbook.scores",
     "path": "/v1/playbooks/:playbookId/scores",
@@ -3667,7 +3677,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 364,
+    "index": 365,
     "method": "POST",
     "operationId": "memory.store",
     "path": "/v1/memory/store",
@@ -3677,7 +3687,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 365,
+    "index": 366,
     "method": "POST",
     "operationId": "memory.items.create",
     "path": "/v1/memory/items",
@@ -3687,7 +3697,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 366,
+    "index": 367,
     "method": "POST",
     "operationId": "memory.search",
     "path": "/v1/memory/search",
@@ -3697,7 +3707,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 367,
+    "index": 368,
     "method": "GET",
     "operationId": "memory.get",
     "path": "/v1/memory/items/:id",
@@ -3707,7 +3717,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 368,
+    "index": 369,
     "method": "GET",
     "operationId": "memory.list",
     "path": "/v1/memory/items",
@@ -3717,7 +3727,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 369,
+    "index": 370,
     "method": "DELETE",
     "operationId": "memory.delete",
     "path": "/v1/memory/items/:id",
@@ -3727,7 +3737,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 370,
+    "index": 371,
     "method": "POST",
     "operationId": "memory.prune",
     "path": "/v1/memory/prune",
@@ -3737,7 +3747,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 371,
+    "index": 372,
     "method": "GET",
     "operationId": "sessions.usage.get",
     "path": "/v1/sessions/:sessionKey/usage",
@@ -3747,7 +3757,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 372,
+    "index": 373,
     "method": "GET",
     "operationId": "sessions.usage.list",
     "path": "/v1/sessions/usage",
@@ -3757,7 +3767,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 373,
+    "index": 374,
     "method": "GET",
     "operationId": "sessions.list",
     "path": "/v1/sessions",
@@ -3767,7 +3777,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 374,
+    "index": 375,
     "method": "POST",
     "operationId": "sessions.create",
     "path": "/v1/sessions",
@@ -3777,7 +3787,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 375,
+    "index": 376,
     "method": "GET",
     "operationId": "sessions.get",
     "path": "/v1/sessions/:sessionKey",
@@ -3787,7 +3797,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 376,
+    "index": 377,
     "method": "DELETE",
     "operationId": "sessions.delete",
     "path": "/v1/sessions/:sessionKey",
@@ -3797,7 +3807,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 377,
+    "index": 378,
     "method": "POST",
     "operationId": "sessions.archive",
     "path": "/v1/sessions/:sessionKey/archive",
@@ -3807,7 +3817,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 378,
+    "index": 379,
     "method": "POST",
     "operationId": "sessions.reset",
     "path": "/v1/sessions/:sessionKey/reset",
@@ -3817,7 +3827,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 379,
+    "index": 380,
     "method": "POST",
     "operationId": "sessions.prune",
     "path": "/v1/sessions/prune",
@@ -3827,7 +3837,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 380,
+    "index": 381,
     "method": "POST",
     "operationId": "sessions.sweep",
     "path": "/v1/sessions/sweep",
@@ -3837,7 +3847,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 381,
+    "index": 382,
     "method": "POST",
     "operationId": "sessions.compact",
     "path": "/v1/sessions/:sessionKey/compact",
@@ -3847,7 +3857,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 382,
+    "index": 383,
     "method": "GET",
     "operationId": "sessions.messages.list",
     "path": "/v1/sessions/:sessionKey/messages",
@@ -3857,7 +3867,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 383,
+    "index": 384,
     "method": "GET",
     "operationId": "sessions.export",
     "path": "/v1/sessions/:sessionKey/export",
@@ -3867,7 +3877,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 384,
+    "index": 385,
     "method": "POST",
     "operationId": "sessions.messages.create",
     "path": "/v1/sessions/:sessionKey/messages",
@@ -3877,7 +3887,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 385,
+    "index": 386,
     "method": "POST",
     "operationId": "sessions.outbound.send",
     "path": "/v1/sessions/:sessionKey/outbound",
@@ -3887,7 +3897,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 386,
+    "index": 387,
     "method": "POST",
     "operationId": "sessions.run",
     "path": "/v1/sessions/:sessionKey/run",
@@ -3897,7 +3907,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 387,
+    "index": 388,
     "method": "GET",
     "operationId": "sessions.memory.namespace.get",
     "path": "/v1/sessions/:sessionKey/memory-namespace",
@@ -3907,7 +3917,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 388,
+    "index": 389,
     "method": "POST",
     "operationId": "sessions.forks.create",
     "path": "/v1/sessions/:sessionKey/fork",
@@ -3917,7 +3927,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 389,
+    "index": 390,
     "method": "GET",
     "operationId": "sessions.forks.list",
     "path": "/v1/sessions/:sessionKey/forks",
@@ -3927,7 +3937,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 390,
+    "index": 391,
     "method": "POST",
     "operationId": "sessions.forks.merge",
     "path": "/v1/sessions/:sessionKey/merge",
@@ -3937,7 +3947,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 391,
+    "index": 392,
     "method": "POST",
     "operationId": "sessions.memory.extract",
     "path": "/v1/sessions/:sessionKey/memory/extract",
@@ -3947,7 +3957,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 392,
+    "index": 393,
     "method": "POST",
     "operationId": "sessions.memory.remember",
     "path": "/v1/sessions/:sessionKey/memory/remember",
@@ -3957,7 +3967,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 393,
+    "index": 394,
     "method": "GET",
     "operationId": "sessions.memory.extraction.get",
     "path": "/v1/sessions/:sessionKey/memory/extraction",
@@ -3967,7 +3977,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 394,
+    "index": 395,
     "method": "POST",
     "operationId": "sessions.memory.extraction.retry",
     "path": "/v1/sessions/memory/extraction/retry",
@@ -3977,7 +3987,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 395,
+    "index": 396,
     "method": "GET",
     "operationId": "plugins.list",
     "path": "/v1/plugins",
@@ -3987,7 +3997,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 396,
+    "index": 397,
     "method": "GET",
     "operationId": "plugins.get",
     "path": "/v1/plugins/:id",
@@ -3997,7 +4007,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 397,
+    "index": 398,
     "method": "GET",
     "operationId": "plugins.versions.list",
     "path": "/v1/plugins/:id/versions",
@@ -4007,7 +4017,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 398,
+    "index": 399,
     "method": "POST",
     "operationId": "plugins.install",
     "path": "/v1/plugins/:id/install",
@@ -4017,7 +4027,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 399,
+    "index": 400,
     "method": "POST",
     "operationId": "plugins.enable",
     "path": "/v1/plugins/:id/enable",
@@ -4027,7 +4037,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 400,
+    "index": 401,
     "method": "POST",
     "operationId": "plugins.disable",
     "path": "/v1/plugins/:id/disable",
@@ -4037,7 +4047,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 401,
+    "index": 402,
     "method": "DELETE",
     "operationId": "plugins.uninstall",
     "path": "/v1/plugins/:id",
@@ -4047,7 +4057,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 402,
+    "index": 403,
     "method": "POST",
     "operationId": "agent.runs.start",
     "path": "/v1/agent/runs",
@@ -4057,7 +4067,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 403,
+    "index": 404,
     "method": "GET",
     "operationId": "agent.runs.list",
     "path": "/v1/agent/runs",
@@ -4067,7 +4077,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 404,
+    "index": 405,
     "method": "GET",
     "operationId": "agent.runs.summary",
     "path": "/v1/agent/runs/summary",
@@ -4077,7 +4087,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 405,
+    "index": 406,
     "method": "GET",
     "operationId": "agent.runs.get",
     "path": "/v1/agent/runs/:runId",
@@ -4087,7 +4097,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 406,
+    "index": 407,
     "method": "POST",
     "operationId": "agent.runs.cancel",
     "path": "/v1/agent/runs/:runId/cancel",
@@ -4097,7 +4107,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 407,
+    "index": 408,
     "method": "POST",
     "operationId": "agent.runs.resume",
     "path": "/v1/agent/runs/:runId/resume",
@@ -4107,7 +4117,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 408,
+    "index": 409,
     "method": "POST",
     "operationId": "agent.d20.worktree.batch.dispatch",
     "path": "/v1/agent/d20/worktree-batches/dispatch",
@@ -4117,7 +4127,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 409,
+    "index": 410,
     "method": "GET",
     "operationId": "agent.runs.audit",
     "path": "/v1/agent/runs/:runId/audit",
@@ -4127,7 +4137,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 410,
+    "index": 411,
     "method": "POST",
     "operationId": "agent.runs.rollback",
     "path": "/v1/agent/runs/:runId/rollback",
@@ -4137,7 +4147,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 411,
+    "index": 412,
     "method": "POST",
     "operationId": "agent.runs.approve.plan",
     "path": "/v1/agent/runs/:runId/approve-plan",
@@ -4147,7 +4157,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 412,
+    "index": 413,
     "method": "POST",
     "operationId": "agent.runs.reject.plan",
     "path": "/v1/agent/runs/:runId/reject-plan",
@@ -4157,7 +4167,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 413,
+    "index": 414,
     "method": "POST",
     "operationId": "agent.runs.approve.tool",
     "path": "/v1/agent/runs/:runId/approve-tool",
@@ -4167,7 +4177,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 414,
+    "index": 415,
     "method": "POST",
     "operationId": "agent.runs.reject.tool",
     "path": "/v1/agent/runs/:runId/reject-tool",
@@ -4177,7 +4187,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 415,
+    "index": 416,
     "method": "GET",
     "operationId": "agent.runs.events",
     "path": "/v1/agent/runs/:runId/events",
@@ -4187,7 +4197,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 416,
+    "index": 417,
     "method": "POST",
     "operationId": "agent.automations.create",
     "path": "/v1/agent/automations",
@@ -4197,7 +4207,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 417,
+    "index": 418,
     "method": "GET",
     "operationId": "agent.automations.list",
     "path": "/v1/agent/automations",
@@ -4207,7 +4217,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 418,
+    "index": 419,
     "method": "GET",
     "operationId": "agent.automations.get",
     "path": "/v1/agent/automations/:automationId",
@@ -4217,7 +4227,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 419,
+    "index": 420,
     "method": "PATCH",
     "operationId": "agent.automations.update",
     "path": "/v1/agent/automations/:automationId",
@@ -4227,7 +4237,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 420,
+    "index": 421,
     "method": "DELETE",
     "operationId": "agent.automations.delete",
     "path": "/v1/agent/automations/:automationId",
@@ -4237,7 +4247,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 421,
+    "index": 422,
     "method": "POST",
     "operationId": "agent.automations.run",
     "path": "/v1/agent/automations/:automationId/run",
@@ -4247,7 +4257,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 422,
+    "index": 423,
     "method": "GET",
     "operationId": "agent.subagents.list",
     "path": "/v1/agent/subagents",
@@ -4257,7 +4267,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 423,
+    "index": 424,
     "method": "GET",
     "operationId": "agent.subagents.get",
     "path": "/v1/agent/subagents/:subagentId",
@@ -4267,7 +4277,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 424,
+    "index": 425,
     "method": "GET",
     "operationId": "agent.runs.subagents.list",
     "path": "/v1/agent/runs/:runId/subagents",
@@ -4277,7 +4287,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 425,
+    "index": 426,
     "method": "GET",
     "operationId": "assets.inventory.list",
     "path": "/v1/assets/inventory",

--- a/test/contracts/api/friday-api-route-contract.snapshot.test.ts
+++ b/test/contracts/api/friday-api-route-contract.snapshot.test.ts
@@ -871,6 +871,9 @@ describe("MECHANISM-4 — API Route Contract (Snapshot)", () => {
         // dispatch arm. Refuses the synthetic public principal before any dispatch; flag-OFF/503
         // by default (the merged Rust arm #753 is gated by FRIDAY_MEMORY_CONFIRM).
         "memory.spine.decide.apply",
+        // A1 run-outcome learning decision courier. Refuses the synthetic public principal
+        // before any dispatch; flag-OFF/503 by default until the Rust arm is configured.
+        "run.outcome.learning.decide.apply",
       ]);
       // rate_limited_pending
       const RATE_LIMITED_PENDING: ReadonlySet<string> = new Set([

--- a/test/unit/api/mission-spine/friday-run-outcome-learning-dispatch-adapter.test.ts
+++ b/test/unit/api/mission-spine/friday-run-outcome-learning-dispatch-adapter.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { FridayDomainError } from "../../../../src/errors/friday-domain-error.js";
+import {
+  createFridayRunOutcomeLearningDispatchAdapter,
+  readRunOutcomeLearningRustWsPort,
+} from "../../../../src/api/mission-spine/friday-run-outcome-learning-dispatch-adapter.js";
+import type {
+  CreateFridayRustHubAgentRunSealedClientOptions,
+  FridayRustHubAgentRunSealedClient,
+  FridayRustHubRunOutcomeLearningDecisionRequest,
+  FridayRustHubRunOutcomeLearningDecisionResult,
+} from "../../../../src/api/mission-spine/friday-rust-hub-agent-run-ws-sealed-client.js";
+
+const SECRET = new Uint8Array(32).fill(9);
+
+const REQUEST: FridayRustHubRunOutcomeLearningDecisionRequest = {
+  candidateId: "a1:run-1:preference",
+  decision: "confirm",
+  reason: "owner confirmed",
+};
+
+const RESULT: FridayRustHubRunOutcomeLearningDecisionResult = {
+  truthLabel: "rust_wired",
+  candidateId: "a1:run-1:preference",
+  runId: "run-1",
+  kind: "preference",
+  state: "confirmed",
+  status: "confirmed",
+};
+
+function makeFakeClient(behavior: {
+  decide?: FridayRustHubRunOutcomeLearningDecisionResult;
+  reject?: unknown;
+}) {
+  const constructed: CreateFridayRustHubAgentRunSealedClientOptions[] = [];
+  const decideCalls: FridayRustHubRunOutcomeLearningDecisionRequest[] = [];
+  const createClient = vi.fn(
+    (options: CreateFridayRustHubAgentRunSealedClientOptions): FridayRustHubAgentRunSealedClient => {
+      constructed.push(options);
+      return {
+        dispatchRun: vi.fn(async () => {
+          throw new Error("dispatchRun not used by the A1 decision adapter");
+        }),
+        resumeWithApproval: vi.fn(async () => {
+          throw new Error("resumeWithApproval not used by the A1 decision adapter");
+        }),
+        intakeMission: vi.fn(async () => {
+          throw new Error("intakeMission not used by the A1 decision adapter");
+        }),
+        transitionMission: vi.fn(async () => {
+          throw new Error("transitionMission not used by the A1 decision adapter");
+        }),
+        transitionWorkItem: vi.fn(async () => {
+          throw new Error("transitionWorkItem not used by the A1 decision adapter");
+        }),
+        controlRouteDecision: vi.fn(async () => {
+          throw new Error("controlRouteDecision not used by the A1 decision adapter");
+        }),
+        decideMemory: vi.fn(async () => {
+          throw new Error("decideMemory not used by the A1 decision adapter");
+        }),
+        decideRunOutcomeLearning: vi.fn(async (req: FridayRustHubRunOutcomeLearningDecisionRequest) => {
+          decideCalls.push(req);
+          if (behavior.reject !== undefined) throw behavior.reject;
+          return behavior.decide!;
+        }),
+      };
+    },
+  );
+  return { createClient, constructed, decideCalls };
+}
+
+describe("createFridayRunOutcomeLearningDispatchAdapter", () => {
+  it("builds the sealed client lazily and delegates the refs-only decision", async () => {
+    const fake = makeFakeClient({ decide: RESULT });
+    const secretResolver = vi.fn(() => SECRET);
+    const adapter = createFridayRunOutcomeLearningDispatchAdapter({
+      host: "127.0.0.1",
+      port: 48750,
+      secretResolver,
+      createClient: fake.createClient,
+    });
+
+    expect(secretResolver).not.toHaveBeenCalled();
+    expect(fake.createClient).not.toHaveBeenCalled();
+
+    expect(await adapter.decideRunOutcomeLearning(REQUEST)).toBe(RESULT);
+
+    expect(secretResolver).toHaveBeenCalledTimes(1);
+    expect(fake.createClient).toHaveBeenCalledTimes(1);
+    expect(fake.constructed[0]).toMatchObject({ host: "127.0.0.1", port: 48750, clientSecret: SECRET });
+    expect(fake.decideCalls).toEqual([REQUEST]);
+  });
+
+  it("passes through a Hub blocked refusal as a successful round-trip", async () => {
+    const blocked: FridayRustHubRunOutcomeLearningDecisionResult = {
+      truthLabel: "rust_wired",
+      candidateId: "a1:run-1:preference",
+      state: "pending",
+      status: "blocked",
+      blocker: "owner_scope_mismatch",
+    };
+    const fake = makeFakeClient({ decide: blocked });
+    const adapter = createFridayRunOutcomeLearningDispatchAdapter({
+      port: 48750,
+      secretResolver: () => SECRET,
+      createClient: fake.createClient,
+    });
+    expect(await adapter.decideRunOutcomeLearning({ ...REQUEST, decision: "reject" })).toBe(blocked);
+  });
+
+  it("fails closed when the secret is unavailable or the client throws", async () => {
+    const fake = makeFakeClient({ decide: RESULT });
+    const noSecret = createFridayRunOutcomeLearningDispatchAdapter({
+      port: 48750,
+      secretResolver: () => null,
+      createClient: fake.createClient,
+    });
+    await expect(noSecret.decideRunOutcomeLearning(REQUEST)).rejects.toMatchObject({
+      code: "RUN_OUTCOME_LEARNING_DISPATCH_RUST_UNAVAILABLE",
+      httpStatus: 503,
+    });
+    expect(fake.createClient).not.toHaveBeenCalled();
+
+    const inner = new FridayDomainError("INNER", "inner", { httpStatus: 503 });
+    const failing = makeFakeClient({ reject: inner });
+    const adapter = createFridayRunOutcomeLearningDispatchAdapter({
+      port: 48750,
+      secretResolver: () => SECRET,
+      createClient: failing.createClient,
+    });
+    await expect(adapter.decideRunOutcomeLearning(REQUEST)).rejects.toBe(inner);
+  });
+});
+
+describe("readRunOutcomeLearningRustWsPort", () => {
+  it("parses valid ports and fails closed to 0 for missing/bad values", () => {
+    expect(readRunOutcomeLearningRustWsPort("48750")).toBe(48750);
+    expect(readRunOutcomeLearningRustWsPort(undefined)).toBe(0);
+    expect(readRunOutcomeLearningRustWsPort("")).toBe(0);
+    expect(readRunOutcomeLearningRustWsPort("-1")).toBe(0);
+    expect(readRunOutcomeLearningRustWsPort("abc")).toBe(0);
+  });
+});

--- a/test/unit/api/mission-spine/friday-rust-hub-run-outcome-learning-wire.test.ts
+++ b/test/unit/api/mission-spine/friday-rust-hub-run-outcome-learning-wire.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildRunOutcomeLearningDecisionEnvelope,
+  parseRunOutcomeLearningDecisionResult,
+} from "../../../../src/api/mission-spine/friday-rust-hub-agent-run-ws-sealed-client.js";
+
+describe("buildRunOutcomeLearningDecisionEnvelope", () => {
+  it("emits the exact nested RunOutcomeLearningDecisionRequest wire shape", () => {
+    const env = buildRunOutcomeLearningDecisionEnvelope({
+      candidateId: "a1:run-1:preference",
+      decision: "confirm",
+      reason: "owner confirmed",
+    });
+    expect(env.msg_id).toBe("run-outcome-learning-decision-a1:run-1:preference");
+    expect(env.correlation_id).toBe("run-outcome-learning-decision-a1:run-1:preference");
+    expect(env.message).toEqual({
+      kind: "RunOutcomeLearningDecisionRequest",
+      request: {
+        candidate_id: "a1:run-1:preference",
+        decision: "confirm",
+        reason: "owner confirmed",
+      },
+    });
+    const message = env.message as Record<string, unknown>;
+    expect(Object.keys(message).sort()).toEqual(["kind", "request"]);
+  });
+
+  it("omits reason when absent and carries reject verbatim", () => {
+    const message = buildRunOutcomeLearningDecisionEnvelope({
+      candidateId: "a1:run-1:world_model",
+      decision: "reject",
+    }).message as Record<string, unknown>;
+    expect(message).toEqual({
+      kind: "RunOutcomeLearningDecisionRequest",
+      request: {
+        candidate_id: "a1:run-1:world_model",
+        decision: "reject",
+      },
+    });
+  });
+});
+
+describe("parseRunOutcomeLearningDecisionResult", () => {
+  it("unwraps refs-only confirmed result", () => {
+    expect(
+      parseRunOutcomeLearningDecisionResult({
+        kind: "RunOutcomeLearningDecisionResult",
+        result: {
+          candidate_id: "a1:run-1:preference",
+          run_id: "run-1",
+          kind: "preference",
+          state: "confirmed",
+          status: "confirmed",
+        },
+      }),
+    ).toEqual({
+      truthLabel: "rust_wired",
+      candidateId: "a1:run-1:preference",
+      runId: "run-1",
+      kind: "preference",
+      state: "confirmed",
+      status: "confirmed",
+    });
+  });
+
+  it("surfaces blocked blocker and fails closed on missing required refs", () => {
+    expect(
+      parseRunOutcomeLearningDecisionResult({
+        result: {
+          candidate_id: "a1:run-1:preference",
+          state: "pending",
+          status: "blocked",
+          blocker: "owner_scope_mismatch",
+        },
+      }),
+    ).toEqual({
+      truthLabel: "rust_wired",
+      candidateId: "a1:run-1:preference",
+      state: "pending",
+      status: "blocked",
+      blocker: "owner_scope_mismatch",
+    });
+
+    expect(parseRunOutcomeLearningDecisionResult({ kind: "RunOutcomeLearningDecisionResult" })).toBeUndefined();
+    expect(
+      parseRunOutcomeLearningDecisionResult({
+        result: { state: "confirmed", status: "confirmed" },
+      }),
+    ).toBeUndefined();
+  });
+});

--- a/test/unit/api/routes/friday-run-outcome-learning-routes.test.ts
+++ b/test/unit/api/routes/friday-run-outcome-learning-routes.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { FridayDomainError } from "../../../../src/errors/friday-domain-error.js";
+import {
+  createFridayRunOutcomeLearningRoutes,
+  validateRunOutcomeLearningDecisionBody,
+  type FridayRunOutcomeLearningRoutesDispatchService,
+} from "../../../../src/api/http/routes/friday-run-outcome-learning-routes.js";
+import type { FridayRustHubRunOutcomeLearningDecisionResult } from "../../../../src/api/mission-spine/friday-rust-hub-agent-run-ws-sealed-client.js";
+
+const RESULT: FridayRustHubRunOutcomeLearningDecisionResult = {
+  truthLabel: "rust_wired",
+  candidateId: "a1:run-1:preference",
+  runId: "run-1",
+  kind: "preference",
+  state: "confirmed",
+  status: "confirmed",
+};
+
+const VALID_BODY = {
+  candidateId: "a1:run-1:preference",
+  decision: "confirm",
+  reason: "owner confirmed",
+};
+
+function makeCtx(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    requestId: "req-a1-decision",
+    receivedAt: "2026-06-20T00:00:00Z",
+    params: {},
+    query: {},
+    body: null,
+    headers: {},
+    principal: {
+      principalId: "principal-1",
+      userId: "user-1",
+      principalType: "user",
+      role: "admin",
+      scopes: ["hub.admin"],
+    },
+    ...overrides,
+  };
+}
+
+function makeDispatch(): {
+  dispatch: FridayRunOutcomeLearningRoutesDispatchService;
+  decide: ReturnType<typeof vi.fn>;
+} {
+  const decide = vi.fn(async () => RESULT);
+  return {
+    dispatch: { decideRunOutcomeLearning: decide },
+    decide,
+  };
+}
+
+function findRoute(routes: ReturnType<typeof createFridayRunOutcomeLearningRoutes>) {
+  const route = routes.find((candidate) => candidate.operationId === "run.outcome.learning.decide.apply");
+  if (!route) throw new Error("run.outcome.learning.decide.apply route missing");
+  return route;
+}
+
+describe("createFridayRunOutcomeLearningRoutes (A1 decision courier, dark)", () => {
+  it("registers a public POST /v1/run-outcome-learning/decide route", () => {
+    const { dispatch } = makeDispatch();
+    const routes = createFridayRunOutcomeLearningRoutes({ dispatch });
+    const route = findRoute(routes);
+    expect(route.method).toBe("POST");
+    expect(route.path).toBe("/v1/run-outcome-learning/decide");
+    expect(route.auth).toEqual({ public: true });
+  });
+
+  it("default-off returns 503 before principal/body checks and sends nothing", async () => {
+    const routes = createFridayRunOutcomeLearningRoutes({});
+    const route = findRoute(routes);
+    const error = await route
+      .handler(makeCtx({ principal: null, body: VALID_BODY }) as never)
+      .catch((e) => e);
+    expect(error).toBeInstanceOf(FridayDomainError);
+    expect((error as FridayDomainError).code).toBe("RUN_OUTCOME_LEARNING_DISPATCH_UNAVAILABLE");
+    expect((error as FridayDomainError).httpStatus).toBe(503);
+  });
+
+  it("flag-on refuses the synthetic public principal before dispatch", async () => {
+    const { dispatch, decide } = makeDispatch();
+    const route = findRoute(createFridayRunOutcomeLearningRoutes({ dispatch }));
+    const error = await route
+      .handler(makeCtx({ principal: null, body: VALID_BODY }) as never)
+      .catch((e) => e);
+    expect((error as FridayDomainError).httpStatus).toBe(401);
+    expect(decide).not.toHaveBeenCalled();
+  });
+
+  it("validates and dispatches a refs-only decision request", async () => {
+    const { dispatch, decide } = makeDispatch();
+    const route = findRoute(createFridayRunOutcomeLearningRoutes({ dispatch }));
+    const response = (await route.handler(makeCtx({ body: VALID_BODY }) as never)) as {
+      result: FridayRustHubRunOutcomeLearningDecisionResult;
+    };
+    expect(response.result).toBe(RESULT);
+    expect(decide).toHaveBeenCalledWith({
+      candidateId: "a1:run-1:preference",
+      decision: "confirm",
+      reason: "owner confirmed",
+    });
+  });
+
+  it("rejects malformed bodies with 400 and no dispatch", async () => {
+    const { dispatch, decide } = makeDispatch();
+    const route = findRoute(createFridayRunOutcomeLearningRoutes({ dispatch }));
+    const error = await route
+      .handler(makeCtx({ body: { candidateId: "a1:run-1:preference", decision: "maybe" } }) as never)
+      .catch((e) => e);
+    expect((error as FridayDomainError).code).toBe("RUN_OUTCOME_LEARNING_DECISION_REQUEST_INVALID");
+    expect((error as FridayDomainError).httpStatus).toBe(400);
+    expect(decide).not.toHaveBeenCalled();
+  });
+});
+
+describe("validateRunOutcomeLearningDecisionBody", () => {
+  it("accepts reject and trims optional reason", () => {
+    expect(
+      validateRunOutcomeLearningDecisionBody({
+        candidateId: " a1:run-1:world_model ",
+        decision: "reject",
+        reason: " no ",
+      }),
+    ).toEqual({
+      candidateId: "a1:run-1:world_model",
+      decision: "reject",
+      reason: "no",
+    });
+  });
+});

--- a/test/unit/hub/friday-hub-bootstrap-env.test.ts
+++ b/test/unit/hub/friday-hub-bootstrap-env.test.ts
@@ -7,6 +7,7 @@ import {
   resolveRouteAgentRunViaRust,
   resolveRouteMissionSpineViaRust,
   resolveRouteMemorySpineViaRust,
+  resolveRouteRunOutcomeLearningViaRust,
   resolveMissionAutoDispatch,
   resolveRouteProvidersViaRust,
   resolveRouteWorkflowsViaRust,
@@ -578,6 +579,30 @@ describe("resolveRouteMemorySpineViaRust (Lane M organic memory-confirmation POS
     expect(resolveRouteMemorySpineViaRust(true, emptyEnv())).toBe(true);
     expect(resolveRouteMemorySpineViaRust(false, { FRIDAY_MEMORY_SPINE_ROUTES_VIA_RUST: "1" })).toBe(false);
     expect(resolveRouteMemorySpineViaRust(false, { FRIDAY_MEMORY_SPINE_ROUTES_VIA_RUST: "true" })).toBe(false);
+  });
+});
+
+describe("resolveRouteRunOutcomeLearningViaRust (A1 run-outcome learning decision route flag)", () => {
+  it("defaults to false when neither config nor env is set", () => {
+    expect(resolveRouteRunOutcomeLearningViaRust(undefined, emptyEnv())).toBe(false);
+  });
+
+  it("parses FRIDAY_RUN_OUTCOME_LEARNING_ROUTES_VIA_RUST 1/true as true", () => {
+    expect(resolveRouteRunOutcomeLearningViaRust(undefined, { FRIDAY_RUN_OUTCOME_LEARNING_ROUTES_VIA_RUST: "1" })).toBe(true);
+    expect(resolveRouteRunOutcomeLearningViaRust(undefined, { FRIDAY_RUN_OUTCOME_LEARNING_ROUTES_VIA_RUST: "true" })).toBe(true);
+    expect(resolveRouteRunOutcomeLearningViaRust(undefined, { FRIDAY_RUN_OUTCOME_LEARNING_ROUTES_VIA_RUST: " TRUE " })).toBe(true);
+  });
+
+  it("treats false-ish and garbage env values as false", () => {
+    expect(resolveRouteRunOutcomeLearningViaRust(undefined, { FRIDAY_RUN_OUTCOME_LEARNING_ROUTES_VIA_RUST: "0" })).toBe(false);
+    expect(resolveRouteRunOutcomeLearningViaRust(undefined, { FRIDAY_RUN_OUTCOME_LEARNING_ROUTES_VIA_RUST: "false" })).toBe(false);
+    expect(resolveRouteRunOutcomeLearningViaRust(undefined, { FRIDAY_RUN_OUTCOME_LEARNING_ROUTES_VIA_RUST: "on" })).toBe(false);
+    expect(resolveRouteRunOutcomeLearningViaRust(undefined, { FRIDAY_RUN_OUTCOME_LEARNING_ROUTES_VIA_RUST: "" })).toBe(false);
+  });
+
+  it("uses explicit config over env", () => {
+    expect(resolveRouteRunOutcomeLearningViaRust(true, { FRIDAY_RUN_OUTCOME_LEARNING_ROUTES_VIA_RUST: "0" })).toBe(true);
+    expect(resolveRouteRunOutcomeLearningViaRust(false, { FRIDAY_RUN_OUTCOME_LEARNING_ROUTES_VIA_RUST: "1" })).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary
- add a default-off A1 run-outcome learning decision route and Rust sealed-WS dispatch adapter
- extend the sealed client envelope/parser for RunOutcomeLearningDecisionResult
- wire bootstrap/runtime injection behind FRIDAY_RUN_OUTCOME_LEARNING_ROUTES_VIA_RUST and add route/adapter/wire tests

## Truth label
- mechanism/courier wiring only; does not flip A1 live
- organic=0, GO-LIVE=false, v1=NO-GO
- operator-origin organic candidate + real confirm/flag flip remain separate gates

## Validation
- npm test -- --run test/unit/api/routes/friday-run-outcome-learning-routes.test.ts test/unit/api/mission-spine/friday-rust-hub-run-outcome-learning-wire.test.ts test/unit/api/mission-spine/friday-run-outcome-learning-dispatch-adapter.test.ts test/unit/hub/friday-hub-bootstrap-env.test.ts
- npm test -- --run test/unit/api/mission-spine/friday-rust-hub-agent-run-ws-sealed-client.test.ts test/unit/api/mission-spine/friday-memory-spine-dispatch-adapter.test.ts test/unit/api/mission-spine/friday-mission-spine-dispatch-adapter.test.ts test/unit/api/mission-spine/friday-rust-hub-agent-run-sealed-client-service.test.ts test/unit/api/runtime/friday-api-runtime-extra-route-registration.test.ts test/unit/api/runtime/friday-api-runtime-rust-route-compose.test.ts
- npm run check:ts-runtime-retirement
- npm run test:mechanism-wiring
- git diff --check