### PR TITLE
Pin autonomy control route behavior floor

### DIFF
--- a/docs/ops/ts-runtime-retirement-manifest.json
+++ b/docs/ops/ts-runtime-retirement-manifest.json
@@ -151,7 +151,15 @@
       "providers_validate",
       "capabilities_doctor",
       "providers_routing_pin",
-      "providers_routing_penalty_clear"
+      "providers_routing_penalty_clear",
+      "capabilities_acquisition_runs_create",
+      "capabilities_acquisition_runs_approve",
+      "capabilities_acquisition_runs_cancel",
+      "autonomy_policy_patch",
+      "standing_goals_create",
+      "standing_goals_patch",
+      "agenda_approve",
+      "agenda_run"
     ]
   },
   "classificationValues": [
@@ -2977,6 +2985,7 @@
       "classification": "fail_closed",
       "user_triggerable": true,
       "executes_product_logic": false,
+      "routeBehavioralTest": "test/unit/api/http/routes/friday-autonomy-routes.test.ts",
       "proof": "src/api/http/routes/friday-autonomy-routes.ts fail-closes default/live capabilities.acquisition.runs.create to TS_RUNTIME_CAPABILITY_ACQUISITION_RETIRED after goal/principal validation and before calling the TypeScript capability-acquisition startRun service mutation; legacy behavior is reachable only through explicit allowTestOnlyCapabilityAcquisitionExecution test-oracle wiring.",
       "next_action": "Replace fail-closed response with a Rust-owned capability-acquisition run-start entrypoint when available."
     },
@@ -2990,6 +2999,7 @@
       "classification": "fail_closed",
       "user_triggerable": true,
       "executes_product_logic": false,
+      "routeBehavioralTest": "test/unit/api/http/routes/friday-autonomy-routes.test.ts",
       "proof": "src/api/http/routes/friday-autonomy-routes.ts fail-closes default/live capabilities.acquisition.runs.approve to TS_RUNTIME_CAPABILITY_ACQUISITION_RETIRED after principal authority checks and before calling the TypeScript capability-acquisition approveRun service mutation; legacy behavior is reachable only through explicit allowTestOnlyCapabilityAcquisitionExecution test-oracle wiring.",
       "next_action": "Replace fail-closed response with a Rust-owned capability-acquisition run-approve entrypoint when available."
     },
@@ -3003,6 +3013,7 @@
       "classification": "fail_closed",
       "user_triggerable": true,
       "executes_product_logic": false,
+      "routeBehavioralTest": "test/unit/api/http/routes/friday-autonomy-routes.test.ts",
       "proof": "src/api/http/routes/friday-autonomy-routes.ts fail-closes default/live capabilities.acquisition.runs.cancel to TS_RUNTIME_CAPABILITY_ACQUISITION_RETIRED after principal authority checks and before calling the TypeScript capability-acquisition cancelRun service mutation; legacy behavior is reachable only through explicit allowTestOnlyCapabilityAcquisitionExecution test-oracle wiring.",
       "next_action": "Replace fail-closed response with a Rust-owned capability-acquisition run-cancel entrypoint when available."
     },
@@ -3016,6 +3027,7 @@
       "classification": "fail_closed",
       "user_triggerable": true,
       "executes_product_logic": false,
+      "routeBehavioralTest": "test/unit/api/http/routes/friday-autonomy-routes.test.ts",
       "proof": "src/api/http/routes/friday-autonomy-routes.ts fail-closes default/live autonomy.policy.patch to TS_RUNTIME_AUTONOMY_POLICY_MUTATION_RETIRED after principal authority checks and before calling the TypeScript autonomy policy updatePolicy service mutation; legacy behavior is reachable only through explicit allowTestOnlyAutonomyPolicyMutation test-oracle wiring.",
       "next_action": "Replace fail-closed response with a Rust-owned autonomy policy mutation entrypoint when available."
     },
@@ -3029,6 +3041,7 @@
       "classification": "fail_closed",
       "user_triggerable": true,
       "executes_product_logic": false,
+      "routeBehavioralTest": "test/unit/api/http/routes/friday-autonomy-routes.test.ts",
       "proof": "src/api/http/routes/friday-autonomy-routes.ts fail-closes default/live standing.goals.create to TS_RUNTIME_STANDING_AGENDA_RETIRED after principal/objective validation and before calling the TypeScript standing-agenda createStandingGoal service mutation; legacy behavior is reachable only through explicit allowTestOnlyStandingAgendaExecution test-oracle wiring.",
       "next_action": "Replace fail-closed response with a Rust-owned standing-goal create entrypoint when available."
     },
@@ -3042,6 +3055,7 @@
       "classification": "fail_closed",
       "user_triggerable": true,
       "executes_product_logic": false,
+      "routeBehavioralTest": "test/unit/api/http/routes/friday-autonomy-routes.test.ts",
       "proof": "src/api/http/routes/friday-autonomy-routes.ts fail-closes default/live standing.goals.patch to TS_RUNTIME_STANDING_AGENDA_RETIRED after principal authority checks and before calling the TypeScript standing-agenda updateStandingGoal service mutation; legacy behavior is reachable only through explicit allowTestOnlyStandingAgendaExecution test-oracle wiring.",
       "next_action": "Replace fail-closed response with a Rust-owned standing-goal patch entrypoint when available."
     },
@@ -3055,6 +3069,7 @@
       "classification": "fail_closed",
       "user_triggerable": true,
       "executes_product_logic": false,
+      "routeBehavioralTest": "test/unit/api/http/routes/friday-autonomy-routes.test.ts",
       "proof": "src/api/http/routes/friday-autonomy-routes.ts fail-closes default/live agenda.approve to TS_RUNTIME_STANDING_AGENDA_RETIRED after principal authority checks and before calling the TypeScript standing-agenda approveAgendaItem service mutation; legacy behavior is reachable only through explicit allowTestOnlyStandingAgendaExecution test-oracle wiring.",
       "next_action": "Replace fail-closed response with a Rust-owned agenda approve entrypoint when available."
     },
@@ -3068,6 +3083,7 @@
       "classification": "fail_closed",
       "user_triggerable": true,
       "executes_product_logic": false,
+      "routeBehavioralTest": "test/unit/api/http/routes/friday-autonomy-routes.test.ts",
       "proof": "src/api/http/routes/friday-autonomy-routes.ts fail-closes default/live agenda.run to TS_RUNTIME_STANDING_AGENDA_RETIRED after principal authority checks and before calling the TypeScript standing-agenda runAgendaItem service mutation; legacy behavior is reachable only through explicit allowTestOnlyStandingAgendaExecution test-oracle wiring.",
       "next_action": "Replace fail-closed response with a Rust-owned agenda run entrypoint when available."
     },

--- a/test/unit/api/http/routes/friday-autonomy-routes.test.ts
+++ b/test/unit/api/http/routes/friday-autonomy-routes.test.ts
@@ -678,6 +678,69 @@ function createAutonomyLifecycleRoutesDefaultOff() {
   };
 }
 
+function makeRouteContext(
+  input: {
+    body?: Record<string, unknown>;
+    params?: Record<string, string>;
+    query?: Record<string, unknown>;
+  } = {},
+) {
+  return {
+    requestId: "req-1",
+    receivedAt: "2026-05-07T18:00:00.000Z",
+    params: input.params ?? {},
+    query: input.query ?? {},
+    body: input.body ?? {},
+    headers: {},
+    principal,
+  };
+}
+
+function createAutonomyControlRoutesDefaultOff() {
+  const acquisitionMutations = {
+    startRun: vi.fn(async () => ({ id: "run-1" })),
+    approveRun: vi.fn(async () => ({ id: "run-1" })),
+    cancelRun: vi.fn(() => ({ id: "run-1" })),
+  };
+  const policyMutation = vi.fn(() => ({ enabled: false }));
+  const standingAgendaMutations = {
+    createStandingGoal: vi.fn(async () => ({
+      goal: { id: "goal-1", userId: "user-1", objective: "Ship Friday", status: "active" },
+      agendaItem: { id: "agenda-1", userId: "user-1", goalId: "goal-1", status: "pending" },
+    })),
+    updateStandingGoal: vi.fn(() => ({ id: "goal-1", userId: "user-1", objective: "Ship Friday", status: "active" })),
+    approveAgendaItem: vi.fn(() => ({ id: "agenda-1", userId: "user-1", status: "approved" })),
+    runAgendaItem: vi.fn(async () => ({ runId: "run-1", status: "queued" })),
+  };
+  const routes = createFridayAutonomyRoutes({
+    allowTestOnlyCapabilityAcquisitionExecution: false,
+    allowTestOnlyAutonomyPolicyMutation: false,
+    allowTestOnlyStandingAgendaExecution: false,
+    listUpgradeStatus: () => ({ items: [] }),
+    acquisitionService: {
+      plan: vi.fn(async () => ({ id: "plan-1" })),
+      ...acquisitionMutations,
+    },
+    policyService: {
+      getPolicy: vi.fn(() => ({ enabled: false })),
+      updatePolicy: policyMutation,
+    },
+    standingAgendaService: {
+      listStandingGoals: vi.fn(() => []),
+      listAgenda: vi.fn(() => []),
+      ...standingAgendaMutations,
+    },
+  });
+  return {
+    routes,
+    mutations: [
+      ...Object.values(acquisitionMutations),
+      policyMutation,
+      ...Object.values(standingAgendaMutations),
+    ],
+  };
+}
+
 describe("createFridayAutonomyRoutes lifecycle route retirement", () => {
   it.each([
     {
@@ -814,6 +877,78 @@ describe("createFridayAutonomyRoutes lifecycle route retirement", () => {
         details: {
           classification: "fail_closed",
           replacement: "rust_owned_autonomy_subject_upgrade_lifecycle_entrypoint_required",
+        },
+      });
+
+      for (const mutation of deps.mutations) {
+        expect(mutation).not.toHaveBeenCalled();
+      }
+    },
+  );
+});
+
+describe("createFridayAutonomyRoutes control route retirement", () => {
+  it.each([
+    {
+      operationId: "capabilities.acquisition.runs.create",
+      code: "TS_RUNTIME_CAPABILITY_ACQUISITION_RETIRED",
+      replacement: "rust_owned_capability_acquisition_entrypoint_required",
+      ctx: makeRouteContext({ body: { goal: "Ship Friday" } }),
+    },
+    {
+      operationId: "capabilities.acquisition.runs.approve",
+      code: "TS_RUNTIME_CAPABILITY_ACQUISITION_RETIRED",
+      replacement: "rust_owned_capability_acquisition_entrypoint_required",
+      ctx: makeRouteContext({ params: { id: "run-1" } }),
+    },
+    {
+      operationId: "capabilities.acquisition.runs.cancel",
+      code: "TS_RUNTIME_CAPABILITY_ACQUISITION_RETIRED",
+      replacement: "rust_owned_capability_acquisition_entrypoint_required",
+      ctx: makeRouteContext({ params: { id: "run-1" } }),
+    },
+    {
+      operationId: "autonomy.policy.patch",
+      code: "TS_RUNTIME_AUTONOMY_POLICY_MUTATION_RETIRED",
+      replacement: "rust_owned_autonomy_policy_mutation_entrypoint_required",
+      ctx: makeRouteContext({ body: { enabled: true } }),
+    },
+    {
+      operationId: "standing.goals.create",
+      code: "TS_RUNTIME_STANDING_AGENDA_RETIRED",
+      replacement: "rust_owned_autonomy_standing_agenda_entrypoint_required",
+      ctx: makeRouteContext({ body: { objective: "Ship Friday" } }),
+    },
+    {
+      operationId: "standing.goals.patch",
+      code: "TS_RUNTIME_STANDING_AGENDA_RETIRED",
+      replacement: "rust_owned_autonomy_standing_agenda_entrypoint_required",
+      ctx: makeRouteContext({ params: { id: "goal-1" }, body: { objective: "Ship Friday better" } }),
+    },
+    {
+      operationId: "agenda.approve",
+      code: "TS_RUNTIME_STANDING_AGENDA_RETIRED",
+      replacement: "rust_owned_autonomy_standing_agenda_entrypoint_required",
+      ctx: makeRouteContext({ params: { id: "agenda-1" } }),
+    },
+    {
+      operationId: "agenda.run",
+      code: "TS_RUNTIME_STANDING_AGENDA_RETIRED",
+      replacement: "rust_owned_autonomy_standing_agenda_entrypoint_required",
+      ctx: makeRouteContext({ params: { id: "agenda-1" } }),
+    },
+  ])(
+    "fail-closes %s by default before invoking TypeScript autonomy control mutations",
+    async ({ operationId, code, replacement, ctx }) => {
+      const deps = createAutonomyControlRoutesDefaultOff();
+      const route = deps.routes.find((entry) => entry.operationId === operationId)!;
+
+      await expect(route.handler(ctx)).rejects.toMatchObject({
+        code,
+        httpStatus: 503,
+        details: {
+          classification: "fail_closed",
+          replacement,
         },
       });
 


### PR DESCRIPTION
## Summary
- add default-off route behavior tests for capability acquisition, autonomy policy, and standing agenda control mutations
- assert 503 fail-closed responses occur before TypeScript service mutations are called
- pin routeBehavioralTest anchors for the eight autonomy control surfaces in the TS runtime retirement manifest

## Validation
- npm run check:ts-runtime-retirement
- npm run test:mechanism-wiring
- npm test -- --run test/unit/api/http/routes/friday-autonomy-routes.test.ts
- git diff --check

Truth labels: organic=0; GO-LIVE=false; v1=NO-GO. This is L1 mechanism/floor coverage only.