### PR TITLE
Enable iOS projection consumer surfaces

### DIFF
--- a/apps/friday-ios/Sources/FridayMobileShell/CommandSheet.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/CommandSheet.swift
@@ -3,9 +3,9 @@ import SwiftUI
 /// The full-screen grid launcher (locked: menuModel = commandSheet) opened from the
 /// top-left of Home.
 ///
-/// Only Home is built in M-PR1. The other destinations exist in the LOCKED mobile
-/// design (Platform/Provider workspace, Activity, Workflows, Settings) and appear
-/// as honest "not in this PR" placeholders — never faked content.
+/// The launcher surfaces all mobile read-projection destinations. Each non-Home destination
+/// consumes the same refs-only HomeProjection; none fabricates detail the read seam does not
+/// carry.
 enum MobileDestination: String, CaseIterable, Identifiable {
   case home
   case platform
@@ -35,8 +35,7 @@ enum MobileDestination: String, CaseIterable, Identifiable {
     }
   }
 
-  /// Whether this destination is implemented in M-PR1.
-  var isBuilt: Bool { self == .home }
+  var isBuilt: Bool { true }
 }
 
 /// The Command Sheet: a full-screen 2-column grid launcher.
@@ -63,7 +62,7 @@ struct CommandSheet: View {
         }
         .padding(16)
 
-        Text("Read-only mode · more surfaces coming online")
+        Text("Read-only projection")
           .font(.caption2)
           .foregroundStyle(MobileTheme.textSecondary)
           .padding(.top, 8)

--- a/apps/friday-ios/Sources/FridayMobileShell/FridayApp.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayApp.swift
@@ -176,8 +176,8 @@ struct RootView: View {
         switch destination {
         case .home:
           FridayHomeScreen(viewModel: homeVM)
-        default:
-          PlaceholderScreen(destination: destination)
+        case .platform, .activity, .workflows, .settings:
+          FridayProjectionScreen(destination: destination, viewModel: homeVM)
         }
       }
       .navigationTitle(destination.title)

--- a/apps/friday-ios/Sources/FridayMobileShell/FridayHomeScreen.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayHomeScreen.swift
@@ -163,23 +163,3 @@ struct UnavailableView: View {
     .frame(maxWidth: .infinity, minHeight: 200)
   }
 }
-
-/// Honest placeholder for mobile design areas not implemented in this PR.
-struct PlaceholderScreen: View {
-  let destination: MobileDestination
-
-  var body: some View {
-    VStack(spacing: 10) {
-      Image(systemName: destination.systemImage)
-        .font(.system(size: 30)).foregroundStyle(MobileTheme.textSecondary)
-      Text(destination.title)
-        .font(.headline).foregroundStyle(MobileTheme.textPrimary)
-      Text("This area is not available yet.")
-        .font(.footnote).foregroundStyle(MobileTheme.textSecondary)
-        .multilineTextAlignment(.center)
-        .frame(maxWidth: 320)
-    }
-    .frame(maxWidth: .infinity, maxHeight: .infinity)
-    .background(MobileTheme.backgroundWarmOffWhite.ignoresSafeArea())
-  }
-}

--- a/apps/friday-ios/Sources/FridayMobileShell/FridayProjectionScreens.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayProjectionScreens.swift
@@ -1,0 +1,221 @@
+import FridayMobileShellCore
+import FridayRustClient
+import SwiftUI
+
+private enum ProjectionSurface {
+  case platform
+  case activity
+  case workflows
+  case settings
+
+  init?(_ destination: MobileDestination) {
+    switch destination {
+    case .home:
+      return nil
+    case .platform:
+      self = .platform
+    case .activity:
+      self = .activity
+    case .workflows:
+      self = .workflows
+    case .settings:
+      self = .settings
+    }
+  }
+
+  var icon: String {
+    switch self {
+    case .platform: return "square.grid.2x2"
+    case .activity: return "bell.badge"
+    case .workflows: return "arrow.triangle.branch"
+    case .settings: return "gearshape"
+    }
+  }
+
+  var title: String {
+    switch self {
+    case .platform: return "Platform"
+    case .activity: return "Activity"
+    case .workflows: return "Workflows"
+    case .settings: return "Settings"
+    }
+  }
+
+  var statusLabel: String {
+    switch self {
+    case .platform: return "runtime"
+    case .activity: return "activity"
+    case .workflows: return "routing"
+    case .settings: return "read seam"
+    }
+  }
+
+  func detailRows(for projection: HomeProjection) -> [ProjectionRow] {
+    switch self {
+    case .platform:
+      return [
+        .init(label: "feed", value: projection.runtimeFeedStatus),
+        .init(label: "mission_id", value: projection.missionId),
+        .init(label: "conversation_id", value: projection.fridayConversationId),
+        .init(label: "route", value: projection.routeDecisionSummary ?? "no route ref"),
+      ]
+    case .activity:
+      return [
+        .init(label: "mission_id", value: projection.missionId),
+        .init(label: "work_item_refs", value: "\(projection.workItemIds.count)"),
+        .init(label: "labels", value: projection.statusLabels.isEmpty ? "none" : projection.statusLabels.joined(separator: ", ")),
+        .init(label: "generated", value: ProjectionSurface.generatedText(projection.generatedAtMs)),
+      ]
+    case .workflows:
+      return [
+        .init(label: "route", value: projection.routeDecisionSummary ?? "no route ref"),
+        .init(label: "mission_id", value: projection.missionId),
+        .init(label: "work_item_refs", value: "\(projection.workItemIds.count)"),
+      ]
+    case .settings:
+      return [
+        .init(label: "mode", value: "live-read projection"),
+        .init(label: "protocol", value: "v\(fridayCurrentSchemaVersion)"),
+        .init(label: "feed", value: projection.runtimeFeedStatus),
+        .init(label: "generated", value: ProjectionSurface.generatedText(projection.generatedAtMs)),
+      ]
+    }
+  }
+
+  private static func generatedText(_ generatedAtMs: Int64) -> String {
+    guard generatedAtMs > 0 else { return "unknown" }
+    let date = Date(timeIntervalSince1970: Double(generatedAtMs) / 1000.0)
+    return date.formatted(date: .abbreviated, time: .shortened)
+  }
+}
+
+private struct ProjectionRow: Identifiable {
+  var id: String { label }
+  let label: String
+  let value: String
+}
+
+struct FridayProjectionScreen: View {
+  let destination: MobileDestination
+  @ObservedObject var viewModel: HomeViewModel
+
+  var body: some View {
+    let surface = ProjectionSurface(destination)
+    ScrollView {
+      VStack(spacing: 16) {
+        if let surface {
+          header(surface)
+          stateContent(surface)
+        }
+      }
+      .padding(16)
+    }
+    .background(MobileTheme.backgroundWarmOffWhite.ignoresSafeArea())
+  }
+
+  @ViewBuilder
+  private func stateContent(_ surface: ProjectionSurface) -> some View {
+    switch viewModel.state {
+    case .idle, .loading:
+      loadingView
+    case .loaded(let projection):
+      loadedContent(surface, projection)
+    case .unavailable(let reason):
+      UnavailableView(reason: reason)
+    }
+  }
+
+  private func header(_ surface: ProjectionSurface) -> some View {
+    GlassPanel {
+      HStack(spacing: 12) {
+        Image(systemName: surface.icon)
+          .font(.system(size: 24, weight: .semibold))
+          .foregroundStyle(MobileTheme.cyan)
+          .frame(width: 34, height: 34)
+        VStack(alignment: .leading, spacing: 4) {
+          Text(surface.title)
+            .font(.headline)
+            .foregroundStyle(MobileTheme.textPrimary)
+          Text(surface.statusLabel)
+            .font(.caption)
+            .foregroundStyle(MobileTheme.textSecondary)
+        }
+        Spacer()
+        StatusChip(
+          text: viewModel.isOnline ? "online" : "offline",
+          bg: viewModel.isOnline ? MobileTheme.chipPendingBG : MobileTheme.chipWarnBG,
+          fg: viewModel.isOnline ? MobileTheme.chipPendingFG : MobileTheme.chipWarnFG)
+      }
+    }
+  }
+
+  private var loadingView: some View {
+    GlassPanel {
+      HStack(spacing: 12) {
+        ProgressView()
+        Text("Reading projection")
+          .font(.footnote)
+          .foregroundStyle(MobileTheme.textSecondary)
+      }
+      .frame(maxWidth: .infinity, minHeight: 86, alignment: .leading)
+    }
+  }
+
+  private func loadedContent(_ surface: ProjectionSurface, _ projection: HomeProjection) -> some View {
+    VStack(spacing: 16) {
+      if !projection.statusLabels.isEmpty {
+        StatusBanner(labels: projection.statusLabels)
+      }
+      detailCard(surface, projection)
+      if surface != .settings {
+        refsCard(projection)
+      }
+    }
+  }
+
+  private func detailCard(_ surface: ProjectionSurface, _ projection: HomeProjection) -> some View {
+    GlassPanel {
+      VStack(alignment: .leading, spacing: MobileTheme.rowSpacing) {
+        ForEach(surface.detailRows(for: projection)) { row in
+          VStack(alignment: .leading, spacing: 4) {
+            Text(row.label)
+              .font(.caption2)
+              .foregroundStyle(MobileTheme.textSecondary)
+            Text(row.value)
+              .font(.system(size: 13, design: .monospaced))
+              .foregroundStyle(MobileTheme.textMono)
+              .lineLimit(2)
+              .truncationMode(.middle)
+          }
+          .frame(maxWidth: .infinity, alignment: .leading)
+        }
+      }
+    }
+  }
+
+  private func refsCard(_ projection: HomeProjection) -> some View {
+    GlassPanel {
+      VStack(alignment: .leading, spacing: MobileTheme.rowSpacing) {
+        HStack {
+          Text("Work item refs")
+            .font(.headline)
+            .foregroundStyle(MobileTheme.textPrimary)
+          Spacer()
+          StatusChip(
+            text: "\(projection.workItemIds.count)",
+            bg: MobileTheme.chipNeutralBG,
+            fg: MobileTheme.chipNeutralFG)
+        }
+        if projection.workItemIds.isEmpty {
+          Text("No refs in this projection.")
+            .font(.caption)
+            .foregroundStyle(MobileTheme.textSecondary)
+        } else {
+          ForEach(projection.workItemIds, id: \.self) { id in
+            RefPill(label: "workItemId", ref: id)
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- enable the iOS Platform, Activity, Workflows, and Settings destinations in the Command Sheet
- replace the placeholder screen with refs-only read-projection consumer surfaces over the existing HomeViewModel
- keep all new surfaces read-only: no new backend fields, no write leg, no signature path, no organic/live claim

## Verification
- `swift test` in `apps/friday-ios`
- `bash build-sim.sh /tmp/friday-ios-consumer-refs-flows-v2.png`

## Truth labels
- Simulator proof only; not a physical-device proof.
- Refs-only projection consumer; not slice-6 live-read flip and not B4/D20 operator signature.
- Agent-driven UI build proof; not adopted-user organic evidence.