### PR TITLE
Enable desktop projection consumer surfaces

### DIFF
--- a/apps/macos/FridayHubConsole/Sources/FridayHubConsole/DesktopProjectionScreens.swift
+++ b/apps/macos/FridayHubConsole/Sources/FridayHubConsole/DesktopProjectionScreens.swift
@@ -1,0 +1,341 @@
+import FridayHubConsoleCore
+import SwiftUI
+
+private enum DesktopProjectionSurface {
+  case providerAdmin
+  case parity
+  case workflow
+  case channels
+  case evidence
+
+  init?(_ destination: HubDestination) {
+    switch destination {
+    case .operations:
+      return nil
+    case .providerAdmin:
+      self = .providerAdmin
+    case .parity:
+      self = .parity
+    case .workflow:
+      self = .workflow
+    case .channels:
+      self = .channels
+    case .evidence:
+      self = .evidence
+    }
+  }
+
+  var title: String {
+    switch self {
+    case .providerAdmin: return "Provider Admin"
+    case .parity: return "Provider Parity"
+    case .workflow: return "Workflow Builder"
+    case .channels: return "Channels"
+    case .evidence: return "Evidence Search"
+    }
+  }
+
+  var icon: String {
+    switch self {
+    case .providerAdmin: return "person.badge.key"
+    case .parity: return "square.grid.3x3"
+    case .workflow: return "point.3.connected.trianglepath.dotted"
+    case .channels: return "antenna.radiowaves.left.and.right"
+    case .evidence: return "doc.text.magnifyingglass"
+    }
+  }
+
+  var statusLabel: String {
+    switch self {
+    case .providerAdmin: return "status-only provider controls"
+    case .parity: return "route and receipt parity"
+    case .workflow: return "mission work-item projection"
+    case .channels: return "surface and channel receipts"
+    case .evidence: return "refs-only evidence index"
+    }
+  }
+}
+
+struct DesktopProjectionScreen: View {
+  let destination: HubDestination
+  @ObservedObject var viewModel: OperationsOverviewViewModel
+
+  var body: some View {
+    let surface = DesktopProjectionSurface(destination)
+    VStack(alignment: .leading, spacing: 0) {
+      if let surface {
+        header(surface)
+        stateContent(surface)
+      }
+    }
+    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+    .background(HubTheme.backgroundWarmOffWhite)
+  }
+
+  private func header(_ surface: DesktopProjectionSurface) -> some View {
+    HStack(alignment: .center, spacing: 10) {
+      Image(systemName: surface.icon)
+        .font(.system(size: 18, weight: .semibold))
+        .foregroundStyle(HubTheme.cyan)
+        .frame(width: 24)
+      VStack(alignment: .leading, spacing: 2) {
+        Text(surface.title)
+          .font(.system(size: 20, weight: .semibold))
+          .foregroundStyle(HubTheme.textPrimary)
+        Text(surface.statusLabel)
+          .font(.system(size: 12))
+          .foregroundStyle(HubTheme.textSecondary)
+      }
+      Spacer()
+      Button {
+        Task { await viewModel.refresh() }
+      } label: {
+        Label("Refresh Status", systemImage: "arrow.clockwise")
+      }
+      .buttonStyle(.borderedProminent)
+      .tint(HubTheme.cyan)
+      .disabled(viewModel.state.isLoading)
+    }
+    .padding(.horizontal, 20)
+    .padding(.vertical, 16)
+  }
+
+  @ViewBuilder
+  private func stateContent(_ surface: DesktopProjectionSurface) -> some View {
+    switch viewModel.state {
+    case .idle, .loading:
+      loadingView
+    case let .loaded(snapshot):
+      ScrollView {
+        loadedContent(snapshot)
+      }
+    case let .unavailable(reason):
+      UnavailableView(reason: reason)
+    }
+  }
+
+  private var loadingView: some View {
+    VStack(spacing: 12) {
+      ProgressView()
+      Text("Reading hub projection...")
+        .font(.system(size: 12))
+        .foregroundStyle(HubTheme.textSecondary)
+    }
+    .frame(maxWidth: .infinity, maxHeight: .infinity)
+  }
+
+  @ViewBuilder
+  func loadedContent(_ snapshot: WorkbenchSnapshot) -> some View {
+    VStack(alignment: .leading, spacing: 16) {
+      if !snapshot.statusLabels.isEmpty || !snapshot.runtimeFeedStatus.isHealthy {
+        StatusBanner(snapshot: snapshot)
+      }
+
+      switch DesktopProjectionSurface(destination) {
+      case .providerAdmin:
+        providerStatus(snapshot)
+      case .parity:
+        parityStatus(snapshot)
+      case .workflow:
+        workflowStatus(snapshot)
+      case .channels:
+        channelStatus(snapshot)
+      case .evidence:
+        evidenceStatus(snapshot)
+      case nil:
+        EmptyView()
+      }
+    }
+    .padding(20)
+  }
+
+  private func providerStatus(_ snapshot: WorkbenchSnapshot) -> some View {
+    VStack(alignment: .leading, spacing: 16) {
+      GlassPanel {
+        VStack(alignment: .leading, spacing: HubTheme.rowSpacing) {
+          cardTitle("Provider State")
+          Text("Dispatch is displayed as projected status only; this surface exposes no execute action.")
+            .font(.system(size: 11))
+            .foregroundStyle(HubTheme.textSecondary)
+          ForEach(snapshot.capabilityStates) { capability in
+            VStack(alignment: .leading, spacing: 6) {
+              HStack {
+                Text(capability.label)
+                  .font(.system(size: 13, weight: .medium))
+                  .foregroundStyle(HubTheme.textPrimary)
+                Spacer()
+                StatusChip(
+                  text: capability.dispatchAllowed ? "dispatch allowed" : "dispatch gated",
+                  bg: capability.dispatchAllowed ? HubTheme.chipPendingBG : HubTheme.chipNeutralBG,
+                  fg: capability.dispatchAllowed ? HubTheme.chipPendingFG : HubTheme.chipNeutralFG)
+              }
+              HStack(spacing: 6) {
+                StatusChip(
+                  text: capability.kind.rawValue, bg: HubTheme.chipNeutralBG,
+                  fg: HubTheme.chipNeutralFG)
+                StatusChip(
+                  text: capability.approvalState.displayText, bg: HubTheme.chipNeutralBG,
+                  fg: HubTheme.chipNeutralFG)
+                capability.truthLabel.chip
+              }
+              Text(capability.summary)
+                .font(.system(size: 11))
+                .foregroundStyle(HubTheme.textSecondary)
+              RefPill(label: "proofRef", ref: capability.proofRef)
+            }
+            .padding(.vertical, 4)
+          }
+        }
+      }
+      refsCard(title: "Provider Receipt Refs", refs: snapshot.providerReceiptRefs)
+    }
+  }
+
+  private func parityStatus(_ snapshot: WorkbenchSnapshot) -> some View {
+    VStack(alignment: .leading, spacing: 16) {
+      GlassPanel {
+        VStack(alignment: .leading, spacing: HubTheme.rowSpacing) {
+          cardTitle("Route Parity")
+          HStack {
+            Text(snapshot.routeDecision.advisorSummary)
+              .font(.system(size: 12))
+              .foregroundStyle(HubTheme.textSecondary)
+            Spacer()
+            snapshot.routeDecision.truthLabel.chip
+          }
+          RefPill(label: "selectedRoute", ref: snapshot.routeDecision.selectedRoute)
+          ForEach(snapshot.routeDecision.alternatives, id: \.self) { alternative in
+            RefPill(label: "alternative", ref: alternative)
+          }
+        }
+      }
+      refsCard(
+        title: "Receipt Parity",
+        refs: snapshot.providerReceiptRefs + snapshot.channelReceiptRefs)
+    }
+  }
+
+  private func workflowStatus(_ snapshot: WorkbenchSnapshot) -> some View {
+    GlassPanel {
+      VStack(alignment: .leading, spacing: HubTheme.rowSpacing) {
+        cardTitle("Workflow Work Items")
+        ForEach(snapshot.workItems) { item in
+          VStack(alignment: .leading, spacing: 6) {
+            HStack {
+              Text(item.title)
+                .font(.system(size: 13, weight: .medium))
+                .foregroundStyle(HubTheme.textPrimary)
+              Spacer()
+              StatusChip(
+                text: item.done ? "done" : "not done",
+                bg: item.done ? HubTheme.chipDoneBG : HubTheme.chipNeutralBG,
+                fg: item.done ? HubTheme.chipDoneFG : HubTheme.chipNeutralFG)
+            }
+            HStack(spacing: 6) {
+              item.state.chip
+              item.owner.chip
+            }
+            if let proofRef = item.proofRef {
+              RefPill(label: "proofRef", ref: proofRef)
+            }
+          }
+          .padding(.vertical, 4)
+        }
+      }
+    }
+  }
+
+  private func channelStatus(_ snapshot: WorkbenchSnapshot) -> some View {
+    VStack(alignment: .leading, spacing: 16) {
+      refsCard(title: "Channel Receipt Refs", refs: snapshot.channelReceiptRefs)
+      GlassPanel {
+        VStack(alignment: .leading, spacing: HubTheme.rowSpacing) {
+          cardTitle("Surface Events")
+          ForEach(surfaceSections(snapshot)) { section in
+            VStack(alignment: .leading, spacing: 6) {
+              HStack {
+                Text(section.title)
+                  .font(.system(size: 13, weight: .medium))
+                  .foregroundStyle(HubTheme.textPrimary)
+                Spacer()
+                section.status.chip
+              }
+              ForEach(section.events) { event in
+                Text(event.summary)
+                  .font(.system(size: 11))
+                  .foregroundStyle(HubTheme.textSecondary)
+                ForEach(event.evidenceRefs.orderedPairs, id: \.ref) { pair in
+                  RefPill(label: pair.label, ref: pair.ref)
+                }
+              }
+            }
+            .padding(.vertical, 4)
+          }
+        }
+      }
+    }
+  }
+
+  private func evidenceStatus(_ snapshot: WorkbenchSnapshot) -> some View {
+    refsCard(title: "Evidence Refs", refs: evidenceRefs(snapshot))
+  }
+
+  private func refsCard(title: String, refs: [String]) -> some View {
+    GlassPanel {
+      VStack(alignment: .leading, spacing: HubTheme.rowSpacing) {
+        HStack {
+          cardTitle(title)
+          Spacer()
+          StatusChip(text: "\(refs.count)", bg: HubTheme.chipNeutralBG, fg: HubTheme.chipNeutralFG)
+        }
+        if refs.isEmpty {
+          Text("No refs in this projection.")
+            .font(.system(size: 12))
+            .foregroundStyle(HubTheme.textSecondary)
+        } else {
+          ForEach(refs, id: \.self) { ref in
+            RefPill(label: nil, ref: ref)
+          }
+        }
+      }
+    }
+  }
+
+  private func surfaceSections(_ snapshot: WorkbenchSnapshot) -> [MissionTranscriptSection] {
+    snapshot.transcriptSections.filter {
+      $0.groupKind == .surface || $0.groupKind == .channelTask || $0.events.contains {
+        $0.surface == .desktop || $0.surface == .mobile
+      }
+    }
+  }
+
+  private func evidenceRefs(_ snapshot: WorkbenchSnapshot) -> [String] {
+    var refs: [String] = []
+    refs.append(contentsOf: snapshot.providerReceiptRefs)
+    refs.append(contentsOf: snapshot.channelReceiptRefs)
+    refs.append(snapshot.routeDecision.selectedRoute)
+    refs.append(contentsOf: snapshot.routeDecision.alternatives)
+    refs.append(contentsOf: snapshot.workItems.compactMap(\.proofRef))
+    refs.append(contentsOf: snapshot.capabilityStates.map(\.proofRef))
+    refs.append(contentsOf: snapshot.memoryCandidates.map(\.evidenceRef))
+    refs.append(contentsOf: snapshot.runOutcomeLearningCandidates.map(\.evidenceRef))
+    for section in snapshot.transcriptSections {
+      for event in section.events {
+        if let proofRef = event.proofRef { refs.append(proofRef) }
+        refs.append(contentsOf: event.evidenceRefs.orderedPairs.map(\.ref))
+      }
+    }
+    return unique(refs)
+  }
+
+  private func unique(_ refs: [String]) -> [String] {
+    var seen = Set<String>()
+    return refs.filter { seen.insert($0).inserted }
+  }
+
+  private func cardTitle(_ text: String) -> some View {
+    Text(text)
+      .font(.system(size: 14, weight: .semibold))
+      .foregroundStyle(HubTheme.textPrimary)
+  }
+}

--- a/apps/macos/FridayHubConsole/Sources/FridayHubConsole/HubConsoleShell.swift
+++ b/apps/macos/FridayHubConsole/Sources/FridayHubConsole/HubConsoleShell.swift
@@ -57,7 +57,7 @@ struct HubConsoleShell: View {
     case .operations:
       OperationsOverviewScreen(viewModel: operationsVM)
     default:
-      PlaceholderScreen(destination: destination)
+      DesktopProjectionScreen(destination: destination, viewModel: operationsVM)
     }
   }
 }
@@ -89,7 +89,7 @@ struct NavRail: View {
 
       Spacer()
 
-      Text("Read-only workbench · D-PR1")
+      Text("Read-only workbench")
         .font(.system(size: 10))
         .foregroundStyle(HubTheme.textSecondary)
         .padding(14)
@@ -133,30 +133,6 @@ struct NavRailItem: View {
       .padding(.horizontal, 8)
     }
     .buttonStyle(.plain)
-  }
-}
-
-/// Honest placeholder for design areas not implemented in D-PR1.
-/// No faked content — it states plainly that the surface is not in this PR.
-struct PlaceholderScreen: View {
-  let destination: HubDestination
-
-  var body: some View {
-    VStack(spacing: 10) {
-      Image(systemName: destination.systemImage)
-        .font(.system(size: 30))
-        .foregroundStyle(HubTheme.textSecondary)
-      Text(destination.title)
-        .font(.system(size: 17, weight: .semibold))
-        .foregroundStyle(HubTheme.textPrimary)
-      Text("This surface is part of the locked desktop design but is not built in D-PR1.")
-        .font(.system(size: 12))
-        .foregroundStyle(HubTheme.textSecondary)
-        .multilineTextAlignment(.center)
-        .frame(maxWidth: 360)
-    }
-    .frame(maxWidth: .infinity, maxHeight: .infinity)
-    .background(HubTheme.backgroundWarmOffWhite)
   }
 }
 

--- a/apps/macos/FridayHubConsole/Sources/FridayHubConsole/Navigation.swift
+++ b/apps/macos/FridayHubConsole/Sources/FridayHubConsole/Navigation.swift
@@ -2,9 +2,7 @@ import SwiftUI
 
 /// The nav-rail destinations of the Hub Console.
 ///
-/// Only `.operations` is built in D-PR1. The other destinations exist in the
-/// LOCKED desktop design (provider admin, parity, workflow, channels, evidence)
-/// and appear as honest "not in this PR" placeholders — never faked content.
+/// Desktop destinations backed by the Rust Hub Workbench projection.
 enum HubDestination: String, CaseIterable, Identifiable {
   case operations
   case providerAdmin
@@ -37,6 +35,6 @@ enum HubDestination: String, CaseIterable, Identifiable {
     }
   }
 
-  /// Whether this destination is implemented in D-PR1.
-  var isBuilt: Bool { self == .operations }
+  /// Whether this destination is implemented by the desktop shell.
+  var isBuilt: Bool { true }
 }

--- a/apps/macos/FridayHubConsole/Sources/FridayHubConsole/StateRenderProof.swift
+++ b/apps/macos/FridayHubConsole/Sources/FridayHubConsole/StateRenderProof.swift
@@ -3,8 +3,8 @@ import AppKit
 import FridayHubConsoleCore
 import SwiftUI
 
-/// Env/flag-gated visual-QA proof for the four honest Operations Overview states (C4):
-/// loaded-mock, unavailable-503, offline, and the empty-live `Error(HUB_OFFLINE)` honest state.
+/// Env/flag-gated visual-QA proof for the honest desktop states: Operations Overview's loaded /
+/// unavailable paths plus every projection-backed nav destination in the loaded mock state.
 ///
 /// Invoked via `FridayHubConsole --state-render-proof <outdir>`. Renders ONLY the center
 /// `OperationsOverviewScreen` (not the right pane) via `ImageRenderer` — deliberately excluding
@@ -34,12 +34,18 @@ enum StateRenderProof {
     // maps to "Hub unavailable — server error hubOffline: no active mission found". The
     // AUTHORITATIVE live empty-state proof is the C1 round-trip (env-gated `Live…` tests), NOT
     // this screenshot — this just confirms the view renders the empty case honestly.
-    let cases: [(String, MockReadClient.Behavior)] = [
-      ("operations-loaded-mock", .loaded),
-      ("operations-unavailable-503", .unavailable(.hubUnavailable(statusCode: 503))),
-      ("operations-offline", .unavailable(.offline)),
+    let cases: [(String, HubDestination, MockReadClient.Behavior)] = [
+      ("operations-loaded-mock", .operations, .loaded),
+      ("provider-admin-loaded-mock", .providerAdmin, .loaded),
+      ("provider-parity-loaded-mock", .parity, .loaded),
+      ("workflow-loaded-mock", .workflow, .loaded),
+      ("channels-loaded-mock", .channels, .loaded),
+      ("evidence-loaded-mock", .evidence, .loaded),
+      ("operations-unavailable-503", .operations, .unavailable(.hubUnavailable(statusCode: 503))),
+      ("operations-offline", .operations, .unavailable(.offline)),
       (
         "operations-no-active-mission",
+        .operations,
         .unavailable(.projectionUnavailable(reason: "no active mission found"))
       ),
     ]
@@ -48,7 +54,7 @@ enum StateRenderProof {
       try? FileManager.default.createDirectory(
         atPath: outputDir, withIntermediateDirectories: true)
       var failures = 0
-      for (name, behavior) in cases {
+      for (name, destination, behavior) in cases {
         let vm = OperationsOverviewViewModel(client: MockReadClient(behavior: behavior))
         await vm.refresh()  // mock is instant → materialize the target state.
         let outPath = "\(outputDir)/\(name).png"
@@ -57,9 +63,16 @@ enum StateRenderProof {
         // scroll content, so the whole screen rasterizes faithfully.
         let renderer: ImageRenderer<AnyView>
         if case .loaded = vm.state, let snapshot = vm.state.snapshot {
+          let loaded: AnyView
+          switch destination {
+          case .operations:
+            loaded = AnyView(OperationsOverviewScreen(viewModel: vm).loadedContent(snapshot))
+          default:
+            loaded = AnyView(DesktopProjectionScreen(destination: destination, viewModel: vm).loadedContent(snapshot))
+          }
           let content =
             VStack(alignment: .leading, spacing: 0) {
-              OperationsOverviewScreen(viewModel: vm).loadedContent(snapshot)
+              loaded
             }
             .frame(width: 760)
             .background(HubTheme.backgroundWarmOffWhite)


### PR DESCRIPTION
## Summary
- replace desktop placeholder destinations with projection-backed consumer screens for provider status, parity, workflow, channels, and evidence
- keep surfaces refs-only/read-only over the existing Workbench projection; no new backend schema or execution affordance
- extend the desktop state render proof to rasterize every projection-backed destination

## Validation
- swift test (apps/macos/FridayHubConsole)
- .build/debug/FridayHubConsole --state-render-proof /tmp/friday-desktop-consumer-projection-proof