### PR TITLE
Add iOS consumer projection surfaces

### DIFF
--- a/apps/friday-ios/Sources/FridayMobileShell/CommandSheet.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/CommandSheet.swift
@@ -8,9 +8,13 @@ import SwiftUI
 /// carry.
 enum MobileDestination: String, CaseIterable, Identifiable {
   case home
+  case missions
+  case needsMe
+  case memory
   case platform
   case activity
   case workflows
+  case onboarding
   case settings
 
   var id: String { rawValue }
@@ -18,9 +22,13 @@ enum MobileDestination: String, CaseIterable, Identifiable {
   var title: String {
     switch self {
     case .home: return "Friday Home"
+    case .missions: return "Missions"
+    case .needsMe: return "Needs Me"
+    case .memory: return "Memory"
     case .platform: return "Platform"
     case .activity: return "Activity"
     case .workflows: return "Workflows"
+    case .onboarding: return "Onboarding"
     case .settings: return "Settings"
     }
   }
@@ -28,9 +36,13 @@ enum MobileDestination: String, CaseIterable, Identifiable {
   var systemImage: String {
     switch self {
     case .home: return "house"
+    case .missions: return "list.bullet.rectangle"
+    case .needsMe: return "person.crop.circle.badge.exclamationmark"
+    case .memory: return "brain.head.profile"
     case .platform: return "square.grid.2x2"
     case .activity: return "bell.badge"
     case .workflows: return "arrow.triangle.branch"
+    case .onboarding: return "sparkles.rectangle.stack"
     case .settings: return "gearshape"
     }
   }

--- a/apps/friday-ios/Sources/FridayMobileShell/FridayApp.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayApp.swift
@@ -176,7 +176,8 @@ struct RootView: View {
         switch destination {
         case .home:
           FridayHomeScreen(viewModel: homeVM)
-        case .platform, .activity, .workflows, .settings:
+        case .missions, .needsMe, .memory, .platform, .activity, .workflows, .onboarding,
+             .settings:
           FridayProjectionScreen(destination: destination, viewModel: homeVM)
         }
       }

--- a/apps/friday-ios/Sources/FridayMobileShell/FridayProjectionScreens.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayProjectionScreens.swift
@@ -3,21 +3,33 @@ import FridayRustClient
 import SwiftUI
 
 private enum ProjectionSurface {
+  case missions
+  case needsMe
+  case memory
   case platform
   case activity
   case workflows
+  case onboarding
   case settings
 
   init?(_ destination: MobileDestination) {
     switch destination {
     case .home:
       return nil
+    case .missions:
+      self = .missions
+    case .needsMe:
+      self = .needsMe
+    case .memory:
+      self = .memory
     case .platform:
       self = .platform
     case .activity:
       self = .activity
     case .workflows:
       self = .workflows
+    case .onboarding:
+      self = .onboarding
     case .settings:
       self = .settings
     }
@@ -25,74 +37,42 @@ private enum ProjectionSurface {
 
   var icon: String {
     switch self {
+    case .missions: return "list.bullet.rectangle"
+    case .needsMe: return "person.crop.circle.badge.exclamationmark"
+    case .memory: return "brain.head.profile"
     case .platform: return "square.grid.2x2"
     case .activity: return "bell.badge"
     case .workflows: return "arrow.triangle.branch"
+    case .onboarding: return "sparkles.rectangle.stack"
     case .settings: return "gearshape"
     }
   }
 
   var title: String {
     switch self {
+    case .missions: return "Missions"
+    case .needsMe: return "Needs Me"
+    case .memory: return "Memory"
     case .platform: return "Platform"
     case .activity: return "Activity"
     case .workflows: return "Workflows"
+    case .onboarding: return "Onboarding"
     case .settings: return "Settings"
     }
   }
 
   var statusLabel: String {
     switch self {
+    case .missions: return "mission truth"
+    case .needsMe: return "operator attention"
+    case .memory: return "candidate review"
     case .platform: return "runtime"
-    case .activity: return "activity"
-    case .workflows: return "routing"
+    case .activity: return "timeline"
+    case .workflows: return "routing and work"
+    case .onboarding: return "local readiness"
     case .settings: return "read seam"
     }
   }
-
-  func detailRows(for projection: HomeProjection) -> [ProjectionRow] {
-    switch self {
-    case .platform:
-      return [
-        .init(label: "feed", value: projection.runtimeFeedStatus),
-        .init(label: "mission_id", value: projection.missionId),
-        .init(label: "conversation_id", value: projection.fridayConversationId),
-        .init(label: "route", value: projection.routeDecisionSummary ?? "no route ref"),
-      ]
-    case .activity:
-      return [
-        .init(label: "mission_id", value: projection.missionId),
-        .init(label: "work_item_refs", value: "\(projection.workItemIds.count)"),
-        .init(label: "labels", value: projection.statusLabels.isEmpty ? "none" : projection.statusLabels.joined(separator: ", ")),
-        .init(label: "generated", value: ProjectionSurface.generatedText(projection.generatedAtMs)),
-      ]
-    case .workflows:
-      return [
-        .init(label: "route", value: projection.routeDecisionSummary ?? "no route ref"),
-        .init(label: "mission_id", value: projection.missionId),
-        .init(label: "work_item_refs", value: "\(projection.workItemIds.count)"),
-      ]
-    case .settings:
-      return [
-        .init(label: "mode", value: "live-read projection"),
-        .init(label: "protocol", value: "v\(fridayCurrentSchemaVersion)"),
-        .init(label: "feed", value: projection.runtimeFeedStatus),
-        .init(label: "generated", value: ProjectionSurface.generatedText(projection.generatedAtMs)),
-      ]
-    }
-  }
-
-  private static func generatedText(_ generatedAtMs: Int64) -> String {
-    guard generatedAtMs > 0 else { return "unknown" }
-    let date = Date(timeIntervalSince1970: Double(generatedAtMs) / 1000.0)
-    return date.formatted(date: .abbreviated, time: .shortened)
-  }
-}
-
-private struct ProjectionRow: Identifiable {
-  var id: String { label }
-  let label: String
-  let value: String
 }
 
 struct FridayProjectionScreen: View {
@@ -161,61 +141,387 @@ struct FridayProjectionScreen: View {
     }
   }
 
+  @ViewBuilder
   private func loadedContent(_ surface: ProjectionSurface, _ projection: HomeProjection) -> some View {
     VStack(spacing: 16) {
       if !projection.statusLabels.isEmpty {
         StatusBanner(labels: projection.statusLabels)
       }
-      detailCard(surface, projection)
-      if surface != .settings {
-        refsCard(projection)
+
+      switch surface {
+      case .missions:
+        missionCard(projection)
+        workItemsCard(projection)
+      case .needsMe:
+        needsMeCard(projection)
+      case .memory:
+        memoryCard(projection)
+      case .platform:
+        platformCard(projection)
+        capabilityCard(projection)
+      case .activity:
+        activityCard(projection)
+      case .workflows:
+        workflowCard(projection)
+        receiptRefsCard(projection)
+      case .onboarding:
+        onboardingCard(projection)
+      case .settings:
+        settingsCard(projection)
       }
     }
   }
 
-  private func detailCard(_ surface: ProjectionSurface, _ projection: HomeProjection) -> some View {
+  private func missionCard(_ projection: HomeProjection) -> some View {
     GlassPanel {
       VStack(alignment: .leading, spacing: MobileTheme.rowSpacing) {
-        ForEach(surface.detailRows(for: projection)) { row in
-          VStack(alignment: .leading, spacing: 4) {
-            Text(row.label)
-              .font(.caption2)
-              .foregroundStyle(MobileTheme.textSecondary)
-            Text(row.value)
-              .font(.system(size: 13, design: .monospaced))
-              .foregroundStyle(MobileTheme.textMono)
-              .lineLimit(2)
-              .truncationMode(.middle)
-          }
-          .frame(maxWidth: .infinity, alignment: .leading)
-        }
-      }
-    }
-  }
-
-  private func refsCard(_ projection: HomeProjection) -> some View {
-    GlassPanel {
-      VStack(alignment: .leading, spacing: MobileTheme.rowSpacing) {
-        HStack {
-          Text("Work item refs")
-            .font(.headline)
-            .foregroundStyle(MobileTheme.textPrimary)
-          Spacer()
-          StatusChip(
-            text: "\(projection.workItemIds.count)",
-            bg: MobileTheme.chipNeutralBG,
-            fg: MobileTheme.chipNeutralFG)
-        }
-        if projection.workItemIds.isEmpty {
-          Text("No refs in this projection.")
+        cardHeader("Mission", count: nil)
+        RefPill(label: "mission_id", ref: projection.missionId)
+        RefPill(label: "conversation_id", ref: projection.fridayConversationId)
+        if let route = projection.routeDecisionSummary {
+          Text(route)
             .font(.caption)
             .foregroundStyle(MobileTheme.textSecondary)
+        }
+        if let selected = projection.routeSelected {
+          RefPill(label: "selectedRoute", ref: selected)
+        }
+      }
+    }
+  }
+
+  private func workItemsCard(_ projection: HomeProjection) -> some View {
+    GlassPanel {
+      VStack(alignment: .leading, spacing: MobileTheme.rowSpacing) {
+        cardHeader("Work Items", count: projection.workItems.count)
+        if projection.workItems.isEmpty {
+          emptyText("No work-item refs in this projection.")
         } else {
-          ForEach(projection.workItemIds, id: \.self) { id in
-            RefPill(label: "workItemId", ref: id)
+          ForEach(projection.workItems) { item in
+            workItemRow(item)
           }
         }
       }
     }
+  }
+
+  private func needsMeCard(_ projection: HomeProjection) -> some View {
+    GlassPanel {
+      VStack(alignment: .leading, spacing: MobileTheme.rowSpacing) {
+        cardHeader("Needs Me", count: projection.needsMeCount)
+        let attentionItems = projection.workItems.filter(\.needsAttention)
+        if attentionItems.isEmpty && projection.memoryCandidates.isEmpty
+          && projection.runOutcomeLearningCandidates.isEmpty
+        {
+          emptyText("No projected operator-attention refs.")
+        } else {
+          ForEach(attentionItems) { item in
+            workItemRow(item)
+          }
+          ForEach(projection.memoryCandidates) { candidate in
+            memoryCandidateRow(candidate)
+          }
+          ForEach(projection.runOutcomeLearningCandidates) { candidate in
+            learningCandidateRow(candidate)
+          }
+        }
+      }
+    }
+  }
+
+  private func memoryCard(_ projection: HomeProjection) -> some View {
+    VStack(spacing: 16) {
+      GlassPanel {
+        VStack(alignment: .leading, spacing: MobileTheme.rowSpacing) {
+          cardHeader("Memory Candidates", count: projection.memoryCandidates.count)
+          if projection.memoryCandidates.isEmpty {
+            emptyText("No pending memory candidates.")
+          } else {
+            ForEach(projection.memoryCandidates) { candidate in
+              memoryCandidateRow(candidate)
+            }
+          }
+        }
+      }
+      GlassPanel {
+        VStack(alignment: .leading, spacing: MobileTheme.rowSpacing) {
+          cardHeader("Run Outcome Learning", count: projection.runOutcomeLearningCandidates.count)
+          if projection.runOutcomeLearningCandidates.isEmpty {
+            emptyText("No pending run-outcome learning candidates.")
+          } else {
+            ForEach(projection.runOutcomeLearningCandidates) { candidate in
+              learningCandidateRow(candidate)
+            }
+          }
+        }
+      }
+    }
+  }
+
+  private func platformCard(_ projection: HomeProjection) -> some View {
+    GlassPanel {
+      VStack(alignment: .leading, spacing: MobileTheme.rowSpacing) {
+        cardHeader("Runtime", count: nil)
+        HStack(spacing: 8) {
+          Image(systemName: "antenna.radiowaves.left.and.right")
+            .foregroundStyle(MobileTheme.textSecondary)
+            .frame(width: 22)
+          Text("feed: \(projection.runtimeFeedStatus)")
+            .font(.subheadline)
+            .foregroundStyle(MobileTheme.textPrimary)
+          Spacer()
+        }
+        RefPill(label: "protocol", ref: "v\(fridayCurrentSchemaVersion)")
+        RefPill(label: "generated", ref: generatedText(projection.generatedAtMs))
+      }
+    }
+  }
+
+  private func capabilityCard(_ projection: HomeProjection) -> some View {
+    GlassPanel {
+      VStack(alignment: .leading, spacing: MobileTheme.rowSpacing) {
+        cardHeader("Capabilities", count: projection.capabilityStates.count)
+        if projection.capabilityStates.isEmpty {
+          emptyText("No capability refs in this projection.")
+        } else {
+          ForEach(projection.capabilityStates) { capability in
+            VStack(alignment: .leading, spacing: 6) {
+              HStack {
+                Text(capability.label)
+                  .font(.system(size: 13, weight: .medium))
+                  .foregroundStyle(MobileTheme.textPrimary)
+                Spacer()
+                statusChip(capability.dispatchAllowed ? "dispatch allowed" : "dispatch gated")
+              }
+              Text(capability.summary)
+                .font(.caption)
+                .foregroundStyle(MobileTheme.textSecondary)
+              HStack(spacing: 6) {
+                statusChip(capability.kind)
+                statusChip(capability.approvalState)
+                statusChip(capability.truthLabel)
+              }
+              if !capability.proofRef.isEmpty {
+                RefPill(label: "proofRef", ref: capability.proofRef)
+              }
+            }
+            .padding(.vertical, 4)
+          }
+        }
+      }
+    }
+  }
+
+  private func activityCard(_ projection: HomeProjection) -> some View {
+    GlassPanel {
+      VStack(alignment: .leading, spacing: MobileTheme.rowSpacing) {
+        cardHeader("Activity", count: projection.transcriptEvents.count)
+        if projection.transcriptEvents.isEmpty {
+          emptyText("No transcript events in this projection.")
+        } else {
+          ForEach(projection.transcriptEvents.prefix(12)) { event in
+            VStack(alignment: .leading, spacing: 5) {
+              HStack {
+                Text(event.sectionTitle)
+                  .font(.system(size: 12, weight: .semibold))
+                  .foregroundStyle(MobileTheme.textPrimary)
+                Spacer()
+                statusChip(event.status)
+              }
+              Text(event.summary)
+                .font(.caption)
+                .foregroundStyle(MobileTheme.textSecondary)
+              if let proofRef = event.proofRef {
+                RefPill(label: "proofRef", ref: proofRef)
+              }
+            }
+            .padding(.vertical, 4)
+          }
+        }
+      }
+    }
+  }
+
+  private func workflowCard(_ projection: HomeProjection) -> some View {
+    GlassPanel {
+      VStack(alignment: .leading, spacing: MobileTheme.rowSpacing) {
+        cardHeader("Workflow", count: nil)
+        if let selected = projection.routeSelected {
+          RefPill(label: "selectedRoute", ref: selected)
+        }
+        ForEach(projection.routeAlternatives, id: \.self) { alternative in
+          RefPill(label: "alternative", ref: alternative)
+        }
+        if projection.workItems.isEmpty {
+          emptyText("No workflow work-item refs.")
+        } else {
+          ForEach(projection.workItems) { item in
+            workItemRow(item)
+          }
+        }
+      }
+    }
+  }
+
+  private func receiptRefsCard(_ projection: HomeProjection) -> some View {
+    GlassPanel {
+      VStack(alignment: .leading, spacing: MobileTheme.rowSpacing) {
+        cardHeader(
+          "Receipt Refs",
+          count: projection.providerReceiptRefs.count + projection.channelReceiptRefs.count)
+        if projection.providerReceiptRefs.isEmpty && projection.channelReceiptRefs.isEmpty {
+          emptyText("No receipt refs in this projection.")
+        } else {
+          ForEach(projection.providerReceiptRefs, id: \.self) {
+            RefPill(label: "provider", ref: $0)
+          }
+          ForEach(projection.channelReceiptRefs, id: \.self) {
+            RefPill(label: "channel", ref: $0)
+          }
+        }
+      }
+    }
+  }
+
+  private func onboardingCard(_ projection: HomeProjection) -> some View {
+    GlassPanel {
+      VStack(alignment: .leading, spacing: MobileTheme.rowSpacing) {
+        cardHeader("Readiness", count: nil)
+        readinessRow(
+          title: "Read seam",
+          value: viewModel.isOnline ? "connected" : "unavailable",
+          healthy: viewModel.isOnline)
+        readinessRow(
+          title: "Write seam",
+          value: "chat surface checks live transport at send time",
+          healthy: true)
+        readinessRow(
+          title: "Operator signature",
+          value: "operator-only",
+          healthy: false)
+        readinessRow(
+          title: "Device pairing",
+          value: "sim loopback now; physical device later",
+          healthy: false)
+        RefPill(label: "mission_id", ref: projection.missionId)
+      }
+    }
+  }
+
+  private func settingsCard(_ projection: HomeProjection) -> some View {
+    GlassPanel {
+      VStack(alignment: .leading, spacing: MobileTheme.rowSpacing) {
+        cardHeader("Settings", count: nil)
+        RefPill(label: "mode", ref: "live-read projection")
+        RefPill(label: "protocol", ref: "v\(fridayCurrentSchemaVersion)")
+        RefPill(label: "feed", ref: projection.runtimeFeedStatus)
+        RefPill(label: "generated", ref: generatedText(projection.generatedAtMs))
+      }
+    }
+  }
+
+  private func workItemRow(_ item: HomeWorkItem) -> some View {
+    VStack(alignment: .leading, spacing: 6) {
+      HStack {
+        Text(item.title)
+          .font(.system(size: 13, weight: .medium))
+          .foregroundStyle(MobileTheme.textPrimary)
+        Spacer()
+        StatusChip(
+          text: item.done ? "done" : "not done",
+          bg: item.done ? MobileTheme.chipDoneBG : MobileTheme.chipNeutralBG,
+          fg: item.done ? MobileTheme.chipDoneFG : MobileTheme.chipNeutralFG)
+      }
+      HStack(spacing: 6) {
+        statusChip(item.state)
+        statusChip(item.owner)
+      }
+      if let proofRef = item.proofRef {
+        RefPill(label: "proofRef", ref: proofRef)
+      }
+    }
+    .padding(.vertical, 4)
+  }
+
+  private func memoryCandidateRow(_ candidate: HomeMemoryCandidate) -> some View {
+    VStack(alignment: .leading, spacing: 6) {
+      Text(candidate.preview)
+        .font(.system(size: 13, weight: .medium))
+        .foregroundStyle(MobileTheme.textPrimary)
+      HStack(spacing: 6) {
+        statusChip(candidate.state)
+        statusChip(candidate.grantsMemoryAuthority ? "grants authority" : "review only")
+      }
+      if !candidate.evidenceRef.isEmpty {
+        RefPill(label: "evidenceRef", ref: candidate.evidenceRef)
+      }
+    }
+    .padding(.vertical, 4)
+  }
+
+  private func learningCandidateRow(_ candidate: HomeRunOutcomeLearningCandidate) -> some View {
+    VStack(alignment: .leading, spacing: 6) {
+      Text(candidate.summary)
+        .font(.system(size: 13, weight: .medium))
+        .foregroundStyle(MobileTheme.textPrimary)
+      HStack(spacing: 6) {
+        statusChip(candidate.kind)
+        statusChip(candidate.state)
+      }
+      if !candidate.runId.isEmpty {
+        RefPill(label: "runId", ref: candidate.runId)
+      }
+      if !candidate.workItemId.isEmpty {
+        RefPill(label: "workItemId", ref: candidate.workItemId)
+      }
+      if !candidate.evidenceRef.isEmpty {
+        RefPill(label: "evidenceRef", ref: candidate.evidenceRef)
+      }
+    }
+    .padding(.vertical, 4)
+  }
+
+  private func readinessRow(title: String, value: String, healthy: Bool) -> some View {
+    HStack(alignment: .top, spacing: 8) {
+      Image(systemName: healthy ? "checkmark.circle" : "lock.circle")
+        .foregroundStyle(healthy ? MobileTheme.cyan : MobileTheme.textSecondary)
+      VStack(alignment: .leading, spacing: 3) {
+        Text(title)
+          .font(.system(size: 13, weight: .medium))
+          .foregroundStyle(MobileTheme.textPrimary)
+        Text(value)
+          .font(.caption)
+          .foregroundStyle(MobileTheme.textSecondary)
+      }
+      Spacer()
+    }
+  }
+
+  private func cardHeader(_ title: String, count: Int?) -> some View {
+    HStack {
+      Text(title)
+        .font(.headline)
+        .foregroundStyle(MobileTheme.textPrimary)
+      Spacer()
+      if let count {
+        StatusChip(text: "\(count)", bg: MobileTheme.chipNeutralBG, fg: MobileTheme.chipNeutralFG)
+      }
+    }
+  }
+
+  private func emptyText(_ text: String) -> some View {
+    Text(text)
+      .font(.caption)
+      .foregroundStyle(MobileTheme.textSecondary)
+  }
+
+  private func statusChip(_ text: String) -> some View {
+    StatusChip(text: text, bg: MobileTheme.chipNeutralBG, fg: MobileTheme.chipNeutralFG)
+  }
+
+  private func generatedText(_ generatedAtMs: Int64) -> String {
+    guard generatedAtMs > 0 else { return "unknown" }
+    let date = Date(timeIntervalSince1970: Double(generatedAtMs) / 1000.0)
+    return date.formatted(date: .abbreviated, time: .shortened)
   }
 }

--- a/apps/friday-ios/Sources/FridayMobileShellCore/HomeViewModel.swift
+++ b/apps/friday-ios/Sources/FridayMobileShellCore/HomeViewModel.swift
@@ -40,18 +40,175 @@ public struct HomeProjection: Sendable, Equatable {
   public let routeDecisionSummary: String?
   /// Work-item id REFS (counts/ids only — never a body).
   public let workItemIds: [String]
+  public let routeSelected: String?
+  public let routeAlternatives: [String]
+  public let providerReceiptRefs: [String]
+  public let channelReceiptRefs: [String]
+  public let workItems: [HomeWorkItem]
+  public let memoryCandidates: [HomeMemoryCandidate]
+  public let runOutcomeLearningCandidates: [HomeRunOutcomeLearningCandidate]
+  public let capabilityStates: [HomeCapabilityState]
+  public let transcriptEvents: [HomeTranscriptEvent]
   /// The Hub epoch-millis the snapshot was generated (lets the UI flag staleness).
   public let generatedAtMs: Int64
 
   public init(_ snapshot: WorkbenchSnapshot) {
+    let raw = snapshot.raw
+    let route = raw["routeDecision"] as? [String: Any]
     self.missionId = snapshot.missionId
     self.fridayConversationId = snapshot.fridayConversationId
     self.runtimeFeedStatus = snapshot.runtimeFeedStatus
     self.statusLabels = snapshot.statusLabels
     self.routeDecisionSummary = snapshot.routeDecisionSummary
     self.workItemIds = snapshot.workItemIds
+    self.routeSelected = route?["selectedRoute"] as? String
+    self.routeAlternatives = route?["alternatives"] as? [String] ?? []
+    self.providerReceiptRefs = raw["providerReceiptRefs"] as? [String] ?? []
+    self.channelReceiptRefs = raw["channelReceiptRefs"] as? [String] ?? []
+    self.workItems = Self.parseWorkItems(raw["workItems"])
+    self.memoryCandidates = Self.parseMemoryCandidates(raw["memoryCandidates"])
+    self.runOutcomeLearningCandidates = Self.parseRunOutcomeLearningCandidates(
+      raw["runOutcomeLearningCandidates"])
+    self.capabilityStates = Self.parseCapabilityStates(raw["capabilityStates"])
+    self.transcriptEvents = Self.parseTranscriptEvents(raw["transcriptSections"])
     self.generatedAtMs = snapshot.generatedAtMs
   }
+
+  public var needsMeCount: Int {
+    workItems.filter { $0.needsAttention }.count
+      + memoryCandidates.count
+      + runOutcomeLearningCandidates.count
+  }
+
+  private static func parseWorkItems(_ value: Any?) -> [HomeWorkItem] {
+    guard let rows = value as? [[String: Any]] else { return [] }
+    return rows.compactMap { row in
+      let id = (row["workItemId"] as? String) ?? (row["id"] as? String)
+      guard let id else { return nil }
+      return HomeWorkItem(
+        id: id,
+        title: (row["title"] as? String) ?? id,
+        state: (row["state"] as? String) ?? "unknown",
+        owner: (row["owner"] as? String) ?? "unknown",
+        proofRef: row["proofRef"] as? String,
+        done: row["done"] as? Bool ?? false)
+    }
+  }
+
+  private static func parseMemoryCandidates(_ value: Any?) -> [HomeMemoryCandidate] {
+    guard let rows = value as? [[String: Any]] else { return [] }
+    return rows.compactMap { row in
+      guard let id = row["id"] as? String else { return nil }
+      return HomeMemoryCandidate(
+        id: id,
+        preview: (row["preview"] as? String) ?? id,
+        state: (row["state"] as? String) ?? "candidate_review_only",
+        grantsMemoryAuthority: row["grantsMemoryAuthority"] as? Bool ?? false,
+        evidenceRef: (row["evidenceRef"] as? String) ?? "")
+    }
+  }
+
+  private static func parseRunOutcomeLearningCandidates(_ value: Any?) -> [HomeRunOutcomeLearningCandidate] {
+    guard let rows = value as? [[String: Any]] else { return [] }
+    return rows.compactMap { row in
+      guard let id = row["id"] as? String else { return nil }
+      return HomeRunOutcomeLearningCandidate(
+        id: id,
+        runId: (row["runId"] as? String) ?? "",
+        workItemId: (row["workItemId"] as? String) ?? "",
+        kind: (row["kind"] as? String) ?? "unknown",
+        state: (row["state"] as? String) ?? "unknown",
+        summary: (row["summary"] as? String) ?? id,
+        evidenceRef: (row["evidenceRef"] as? String) ?? "")
+    }
+  }
+
+  private static func parseCapabilityStates(_ value: Any?) -> [HomeCapabilityState] {
+    guard let rows = value as? [[String: Any]] else { return [] }
+    return rows.compactMap { row in
+      guard let id = row["id"] as? String else { return nil }
+      return HomeCapabilityState(
+        id: id,
+        label: (row["label"] as? String) ?? id,
+        kind: (row["kind"] as? String) ?? "unknown",
+        truthLabel: (row["truthLabel"] as? String) ?? "unknown",
+        approvalState: (row["approvalState"] as? String) ?? "unknown",
+        dispatchAllowed: row["dispatchAllowed"] as? Bool ?? false,
+        summary: (row["summary"] as? String) ?? "",
+        proofRef: (row["proofRef"] as? String) ?? "")
+    }
+  }
+
+  private static func parseTranscriptEvents(_ value: Any?) -> [HomeTranscriptEvent] {
+    guard let sections = value as? [[String: Any]] else { return [] }
+    return sections.flatMap { section -> [HomeTranscriptEvent] in
+      let sectionTitle = (section["title"] as? String) ?? "Transcript"
+      guard let events = section["events"] as? [[String: Any]] else { return [] }
+      return events.compactMap { event in
+        guard let id = event["id"] as? String else { return nil }
+        return HomeTranscriptEvent(
+          id: id,
+          sectionTitle: sectionTitle,
+          summary: (event["summary"] as? String) ?? id,
+          status: (event["status"] as? String) ?? "unknown",
+          truthLabel: (event["truthLabel"] as? String) ?? "unknown",
+          proofRef: event["proofRef"] as? String,
+          capturedAt: (event["capturedAt"] as? String) ?? "")
+      }
+    }
+  }
+}
+
+public struct HomeWorkItem: Sendable, Identifiable, Equatable {
+  public let id: String
+  public let title: String
+  public let state: String
+  public let owner: String
+  public let proofRef: String?
+  public let done: Bool
+
+  public var needsAttention: Bool {
+    !done && ["blocked", "waiting", "error", "stale"].contains(state)
+  }
+}
+
+public struct HomeMemoryCandidate: Sendable, Identifiable, Equatable {
+  public let id: String
+  public let preview: String
+  public let state: String
+  public let grantsMemoryAuthority: Bool
+  public let evidenceRef: String
+}
+
+public struct HomeRunOutcomeLearningCandidate: Sendable, Identifiable, Equatable {
+  public let id: String
+  public let runId: String
+  public let workItemId: String
+  public let kind: String
+  public let state: String
+  public let summary: String
+  public let evidenceRef: String
+}
+
+public struct HomeCapabilityState: Sendable, Identifiable, Equatable {
+  public let id: String
+  public let label: String
+  public let kind: String
+  public let truthLabel: String
+  public let approvalState: String
+  public let dispatchAllowed: Bool
+  public let summary: String
+  public let proofRef: String
+}
+
+public struct HomeTranscriptEvent: Sendable, Identifiable, Equatable {
+  public let id: String
+  public let sectionTitle: String
+  public let summary: String
+  public let status: String
+  public let truthLabel: String
+  public let proofRef: String?
+  public let capturedAt: String
 }
 
 /// The loadable state of the Home read surface. `.unavailable` is a FIRST-CLASS state — a
@@ -173,9 +330,90 @@ public struct PreviewReadClient: FridayRustReadClient {
   public func fetchWorkbench() async throws -> WorkbenchSnapshot {
     if let failure { throw failure }
     let json = """
-    {"missionId":"mission-preview","fridayConversationId":"conv-preview",\
-    "runtimeFeedStatus":"preview_sample","statusLabels":[],\
-    "workItems":[{"workItemId":"wi-preview-1"},{"workItemId":"wi-preview-2"}]}
+    {
+      "missionId": "mission-preview",
+      "fridayConversationId": "conv-preview",
+      "runtimeFeedStatus": "preview_sample",
+      "statusLabels": [],
+      "routeDecision": {
+        "advisorSummary": "route: deepseek (refs-only)",
+        "selectedRoute": "deepseek",
+        "alternatives": ["codex", "claude"],
+        "truthLabel": "friday_owned"
+      },
+      "providerReceiptRefs": ["proof://provider/preview-1"],
+      "channelReceiptRefs": ["proof://surface/mobile-preview-1"],
+      "workItems": [
+        {
+          "workItemId": "wi-preview-1",
+          "title": "Draft the Mission plan",
+          "state": "ready",
+          "owner": "friday_owned",
+          "done": false
+        },
+        {
+          "workItemId": "wi-preview-2",
+          "title": "Waiting for governed approval",
+          "state": "waiting",
+          "owner": "linked_only",
+          "proofRef": "proof://work-item/preview-2",
+          "done": false
+        }
+      ],
+      "memoryCandidates": [
+        {
+          "id": "cand-preview-1",
+          "preview": "Remember the operator prefers concise status reports.",
+          "state": "candidate_review_only",
+          "grantsMemoryAuthority": false,
+          "evidenceRef": "proof://memory/preview-1"
+        }
+      ],
+      "runOutcomeLearningCandidates": [
+        {
+          "id": "learn-preview-1",
+          "runId": "run-preview-1",
+          "workItemId": "wi-preview-2",
+          "kind": "preference",
+          "state": "candidate",
+          "summary": "DeepSeek handled the short planning leg well.",
+          "evidenceRef": "proof://learning/preview-1"
+        }
+      ],
+      "capabilityStates": [
+        {
+          "id": "cap-route",
+          "label": "Route advisor",
+          "kind": "advisor",
+          "truthLabel": "friday_owned",
+          "approvalState": "not_required",
+          "dispatchAllowed": true,
+          "summary": "Routes are advisory; execution still follows governed dispatch.",
+          "proofRef": "proof://capability/route-preview"
+        }
+      ],
+      "transcriptSections": [
+        {
+          "id": "sec-preview-1",
+          "title": "Mission",
+          "groupKind": "mission",
+          "missionId": "mission-preview",
+          "truthLabel": "friday_owned",
+          "status": "ready",
+          "events": [
+            {
+              "id": "evt-preview-1",
+              "missionId": "mission-preview",
+              "surface": "mobile",
+              "status": "ready",
+              "truthLabel": "friday_owned",
+              "summary": "Mobile surface read the Mission projection.",
+              "capturedAt": "2026-06-21T00:00:00Z"
+            }
+          ]
+        }
+      ]
+    }
     """
     return try WorkbenchSnapshot(projectionJSON: Data(json.utf8),
                                  generatedAtMs: Int64(Date().timeIntervalSince1970 * 1000))

--- a/apps/friday-ios/Tests/FridayMobileShellCoreTests/HomeViewModelTests.swift
+++ b/apps/friday-ios/Tests/FridayMobileShellCoreTests/HomeViewModelTests.swift
@@ -44,8 +44,32 @@ final class HomeViewModelTests: XCTestCase {
       "fridayConversationId": "conv-7",
       "runtimeFeedStatus": "live_rust_hub_projection",
       "statusLabels": ["stale"],
-      "routeDecision": { "advisorSummary": "route: deepseek (refs-only)" },
-      "workItems": [ { "workItemId": "wi-1" }, { "workItemId": "wi-2" } ]
+      "routeDecision": {
+        "advisorSummary": "route: deepseek (refs-only)",
+        "selectedRoute": "deepseek",
+        "alternatives": ["codex", "claude"],
+        "truthLabel": "friday_owned"
+      },
+      "providerReceiptRefs": ["proof://provider/1"],
+      "channelReceiptRefs": ["proof://surface/mobile/1"],
+      "workItems": [
+        { "workItemId": "wi-1", "title": "Draft mission", "state": "ready", "owner": "friday_owned", "done": false },
+        { "workItemId": "wi-2", "title": "Needs approval", "state": "waiting", "owner": "linked_only", "proofRef": "proof://wi/2", "done": false }
+      ],
+      "memoryCandidates": [
+        { "id": "cand-1", "preview": "Remember route preference.", "state": "candidate_review_only", "grantsMemoryAuthority": false, "evidenceRef": "proof://memory/1" }
+      ],
+      "runOutcomeLearningCandidates": [
+        { "id": "learn-1", "runId": "run-1", "workItemId": "wi-2", "kind": "preference", "state": "candidate", "summary": "DeepSeek handled the short planning leg well.", "evidenceRef": "proof://learning/1" }
+      ],
+      "capabilityStates": [
+        { "id": "cap-route", "label": "Route advisor", "kind": "advisor", "truthLabel": "friday_owned", "approvalState": "not_required", "dispatchAllowed": true, "summary": "Routes are advisory.", "proofRef": "proof://cap/1" }
+      ],
+      "transcriptSections": [
+        { "id": "sec-1", "title": "Mission", "groupKind": "mission", "missionId": "mission-7", "truthLabel": "friday_owned", "status": "ready", "events": [
+          { "id": "evt-1", "missionId": "mission-7", "surface": "mobile", "status": "ready", "truthLabel": "friday_owned", "summary": "Mobile surface read the mission projection.", "capturedAt": "2026-06-21T00:00:00Z" }
+        ] }
+      ]
     }
     """
     return try WorkbenchSnapshot(projectionJSON: Data(json.utf8), generatedAtMs: 1_780_640_000_000)
@@ -61,6 +85,23 @@ final class HomeViewModelTests: XCTestCase {
     XCTAssertEqual(p.statusLabels, ["stale"])                       // no label upgrade
     XCTAssertEqual(p.workItemIds, ["wi-1", "wi-2"])                 // refs/ids only (INV-5)
     XCTAssertTrue(vm.state.isOnline)
+  }
+
+  func testRefresh_liftsConsumerSurfaceProjectionRefs() async throws {
+    let vm = HomeViewModel(client: FakeReadClient(.snapshot(try sampleSnapshot())))
+    await vm.refresh()
+    guard case .loaded(let p) = vm.state else { return XCTFail("expected .loaded") }
+    XCTAssertEqual(p.routeSelected, "deepseek")
+    XCTAssertEqual(p.routeAlternatives, ["codex", "claude"])
+    XCTAssertEqual(p.providerReceiptRefs, ["proof://provider/1"])
+    XCTAssertEqual(p.channelReceiptRefs, ["proof://surface/mobile/1"])
+    XCTAssertEqual(p.workItems.map(\.title), ["Draft mission", "Needs approval"])
+    XCTAssertEqual(p.workItems.filter(\.needsAttention).map(\.id), ["wi-2"])
+    XCTAssertEqual(p.memoryCandidates.first?.grantsMemoryAuthority, false)
+    XCTAssertEqual(p.runOutcomeLearningCandidates.first?.runId, "run-1")
+    XCTAssertEqual(p.capabilityStates.first?.dispatchAllowed, true)
+    XCTAssertEqual(p.transcriptEvents.first?.summary, "Mobile surface read the mission projection.")
+    XCTAssertEqual(p.needsMeCount, 3)
   }
 
   func testRefresh_transportFailure_isHonestUnavailable() async {


### PR DESCRIPTION
## Summary
- add iOS command-sheet destinations for Missions, Needs Me, Memory, and Onboarding
- lift refs-only work items, memory candidates, run-outcome learning candidates, capabilities, receipts, and transcript events from the existing read-seam WorkbenchSnapshot.raw
- render the new mobile surfaces as truth-preserving projection views without adding execute/signing affordances

## Validation
- swift test --package-path apps/friday-ios --filter HomeViewModelTests
- swift test --package-path apps/friday-ios
- apps/friday-ios/build-sim.sh /tmp/friday-ios-consumer-navigation-surfaces.png
- FRIDAY_MOBILE_LIVE_WRITE_DISPATCH_TEST=1 swift test --package-path apps/friday-ios --filter liveMobileMissionSpineWriteDispatchReturnsReadyReceipt
- FRIDAY_MOBILE_LIVE_WRITE_READ_ROUNDTRIP_TEST=1 swift test --package-path apps/friday-ios --filter liveMobileMissionWriteAppearsInReadProjection
- FRIDAY_MOBILE_LIVE_MISSION_BOUND_RUN_TEST=1 swift test --package-path apps/friday-ios --filter liveMobileMissionSpineWriteDispatchCanStartMissionBoundRun
- FRIDAY_MOBILE_LIVE_PRODUCT_AUTO_FOLLOWUP_RUN_TEST=1 swift test --package-path apps/friday-ios --filter liveMobileChatSendAutoDispatchesHybridClaudeFollowUp
- swift test --package-path apps/macos/FridayHubConsole
- swift test --package-path apps/macos/FridayRustClient
- FRIDAY_CONSOLE_LIVE_WRITE_DISPATCH_TEST=1 swift test --package-path apps/macos/FridayHubConsole --filter liveConsoleMissionSpineWriteDispatchReturnsReadyReceipt
- FRIDAY_CONSOLE_LIVE_WRITE_READ_ROUNDTRIP_TEST=1 swift test --package-path apps/macos/FridayHubConsole --filter liveDesktopMissionWriteAppearsInReadProjection
- FRIDAY_CONSOLE_LIVE_MISSION_BOUND_RUN_TEST=1 swift test --package-path apps/macos/FridayHubConsole --filter liveConsoleMissionSpineWriteDispatchCanCompleteClearCodexRun
- FRIDAY_CONSOLE_LIVE_PRODUCT_AUTO_FOLLOWUP_RUN_TEST=1 swift test --package-path apps/macos/FridayHubConsole --filter liveOperationsOverviewSubmitIntakeAutoDispatchesHybridClaudeFollowUp
- FRIDAY_CONSOLE_LIVE_HYBRID_FOLLOWUP_RUN_TEST=1 swift test --package-path apps/macos/FridayHubConsole --filter liveConsoleMissionSpineWriteDispatchCanCompleteHybridCodexThenClaudeFollowUp
- cargo test -p friday-hub a1_run_outcome_learning_consumer -- --nocapture
- scripts/mission-spine-ui-device-proof-gate-self-test.sh
- git diff --check

Truth labels: built UI surface + simulator compile proof + agent-driven live mobile and desktop product-surface write/read/model-turn/hybrid follow-up proof; A1 consumer behavior verified on current HEAD; UI proof gate self-test passes; no slice-6 default flip, no operator signature, no fabricated ready state, no v1 done claim.
- cargo test -p friday-core gate:: -- --nocapture
- cargo test -p friday-core passport:: -- --nocapture
- cargo test -p friday-storage --test authorize_ed25519 -- --nocapture
- cargo test -p friday-hub d20_batch_authz_mode -- --nocapture