### PR TITLE
Expose Swift read projection arms

### DIFF
--- a/apps/macos/FridayRustClient/Sources/FridayRustClient/Protocol.swift
+++ b/apps/macos/FridayRustClient/Sources/FridayRustClient/Protocol.swift
@@ -89,6 +89,284 @@ public struct WorkbenchProjectionSnapshotWire: Codable, Equatable {
   }
 }
 
+public struct RunReadbackRequestWire: Codable, Equatable, Sendable {
+  public var runId: String
+  public var forwardedPrincipal: String
+  public var authProof: [UInt8]
+  public var requestId: String
+
+  public init(runId: String, forwardedPrincipal: String, authProof: [UInt8], requestId: String) {
+    self.runId = runId
+    self.forwardedPrincipal = forwardedPrincipal
+    self.authProof = authProof
+    self.requestId = requestId
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case runId = "run_id"
+    case forwardedPrincipal = "forwarded_principal"
+    case authProof = "auth_proof"
+    case requestId = "request_id"
+  }
+}
+
+public struct RunReadbackSnapshotWire: Codable, Equatable, Sendable {
+  public var requestId: String
+  public var projectionJson: String
+  public var generatedAtMs: Int64
+
+  public init(requestId: String, projectionJson: String, generatedAtMs: Int64) {
+    self.requestId = requestId
+    self.projectionJson = projectionJson
+    self.generatedAtMs = generatedAtMs
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case requestId = "request_id"
+    case projectionJson = "projection_json"
+    case generatedAtMs = "generated_at_ms"
+  }
+}
+
+public struct ProvidersDoctorRequestWire: Codable, Equatable, Sendable {
+  public var probe: String?
+  public var forwardedPrincipal: String
+  public var authProof: [UInt8]
+  public var requestId: String
+
+  public init(probe: String?, forwardedPrincipal: String, authProof: [UInt8], requestId: String) {
+    self.probe = probe
+    self.forwardedPrincipal = forwardedPrincipal
+    self.authProof = authProof
+    self.requestId = requestId
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case probe
+    case forwardedPrincipal = "forwarded_principal"
+    case authProof = "auth_proof"
+    case requestId = "request_id"
+  }
+
+  public func encode(to encoder: Encoder) throws {
+    var c = encoder.container(keyedBy: CodingKeys.self)
+    if let probe { try c.encode(probe, forKey: .probe) }
+    try c.encode(forwardedPrincipal, forKey: .forwardedPrincipal)
+    try c.encode(authProof, forKey: .authProof)
+    try c.encode(requestId, forKey: .requestId)
+  }
+}
+
+public struct ProvidersDoctorSnapshotWire: Codable, Equatable, Sendable {
+  public var requestId: String
+  public var projectionJson: String
+  public var generatedAtMs: Int64
+
+  public init(requestId: String, projectionJson: String, generatedAtMs: Int64) {
+    self.requestId = requestId
+    self.projectionJson = projectionJson
+    self.generatedAtMs = generatedAtMs
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case requestId = "request_id"
+    case projectionJson = "projection_json"
+    case generatedAtMs = "generated_at_ms"
+  }
+}
+
+public struct SessionListRequestWire: Codable, Equatable, Sendable {
+  public var forwardedPrincipal: String
+  public var authProof: [UInt8]
+  public var requestId: String
+
+  public init(forwardedPrincipal: String, authProof: [UInt8], requestId: String) {
+    self.forwardedPrincipal = forwardedPrincipal
+    self.authProof = authProof
+    self.requestId = requestId
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case forwardedPrincipal = "forwarded_principal"
+    case authProof = "auth_proof"
+    case requestId = "request_id"
+  }
+}
+
+public struct SessionListSnapshotWire: Codable, Equatable, Sendable {
+  public var requestId: String
+  public var projectionJson: String
+  public var generatedAtMs: Int64
+
+  public init(requestId: String, projectionJson: String, generatedAtMs: Int64) {
+    self.requestId = requestId
+    self.projectionJson = projectionJson
+    self.generatedAtMs = generatedAtMs
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case requestId = "request_id"
+    case projectionJson = "projection_json"
+    case generatedAtMs = "generated_at_ms"
+  }
+}
+
+public struct SessionOpenRequestWire: Codable, Equatable, Sendable {
+  public var agentSessionId: String
+  public var forwardedPrincipal: String
+  public var authProof: [UInt8]
+  public var requestId: String
+
+  public init(agentSessionId: String, forwardedPrincipal: String, authProof: [UInt8], requestId: String) {
+    self.agentSessionId = agentSessionId
+    self.forwardedPrincipal = forwardedPrincipal
+    self.authProof = authProof
+    self.requestId = requestId
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case agentSessionId = "agent_session_id"
+    case forwardedPrincipal = "forwarded_principal"
+    case authProof = "auth_proof"
+    case requestId = "request_id"
+  }
+}
+
+public struct SessionOpenSnapshotWire: Codable, Equatable, Sendable {
+  public var requestId: String
+  public var projectionJson: String
+  public var generatedAtMs: Int64
+
+  public init(requestId: String, projectionJson: String, generatedAtMs: Int64) {
+    self.requestId = requestId
+    self.projectionJson = projectionJson
+    self.generatedAtMs = generatedAtMs
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case requestId = "request_id"
+    case projectionJson = "projection_json"
+    case generatedAtMs = "generated_at_ms"
+  }
+}
+
+public struct SessionLinkStateRequestWire: Codable, Equatable, Sendable {
+  public var agentSessionId: String
+  public var forwardedPrincipal: String
+  public var authProof: [UInt8]
+  public var requestId: String
+
+  public init(agentSessionId: String, forwardedPrincipal: String, authProof: [UInt8], requestId: String) {
+    self.agentSessionId = agentSessionId
+    self.forwardedPrincipal = forwardedPrincipal
+    self.authProof = authProof
+    self.requestId = requestId
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case agentSessionId = "agent_session_id"
+    case forwardedPrincipal = "forwarded_principal"
+    case authProof = "auth_proof"
+    case requestId = "request_id"
+  }
+}
+
+public struct SessionLinkStateSnapshotWire: Codable, Equatable, Sendable {
+  public var requestId: String
+  public var projectionJson: String
+  public var generatedAtMs: Int64
+
+  public init(requestId: String, projectionJson: String, generatedAtMs: Int64) {
+    self.requestId = requestId
+    self.projectionJson = projectionJson
+    self.generatedAtMs = generatedAtMs
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case requestId = "request_id"
+    case projectionJson = "projection_json"
+    case generatedAtMs = "generated_at_ms"
+  }
+}
+
+public struct RunFileViewRequestWire: Codable, Equatable, Sendable {
+  public var runId: String
+  public var forwardedPrincipal: String
+  public var authProof: [UInt8]
+  public var requestId: String
+
+  public init(runId: String, forwardedPrincipal: String, authProof: [UInt8], requestId: String) {
+    self.runId = runId
+    self.forwardedPrincipal = forwardedPrincipal
+    self.authProof = authProof
+    self.requestId = requestId
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case runId = "run_id"
+    case forwardedPrincipal = "forwarded_principal"
+    case authProof = "auth_proof"
+    case requestId = "request_id"
+  }
+}
+
+public struct RunFileViewSnapshotWire: Codable, Equatable, Sendable {
+  public var requestId: String
+  public var projectionJson: String
+  public var generatedAtMs: Int64
+
+  public init(requestId: String, projectionJson: String, generatedAtMs: Int64) {
+    self.requestId = requestId
+    self.projectionJson = projectionJson
+    self.generatedAtMs = generatedAtMs
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case requestId = "request_id"
+    case projectionJson = "projection_json"
+    case generatedAtMs = "generated_at_ms"
+  }
+}
+
+public struct ActivityNeedsMeRequestWire: Codable, Equatable, Sendable {
+  public var runId: String
+  public var forwardedPrincipal: String
+  public var authProof: [UInt8]
+  public var requestId: String
+
+  public init(runId: String, forwardedPrincipal: String, authProof: [UInt8], requestId: String) {
+    self.runId = runId
+    self.forwardedPrincipal = forwardedPrincipal
+    self.authProof = authProof
+    self.requestId = requestId
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case runId = "run_id"
+    case forwardedPrincipal = "forwarded_principal"
+    case authProof = "auth_proof"
+    case requestId = "request_id"
+  }
+}
+
+public struct ActivityNeedsMeSnapshotWire: Codable, Equatable, Sendable {
+  public var requestId: String
+  public var projectionJson: String
+  public var generatedAtMs: Int64
+
+  public init(requestId: String, projectionJson: String, generatedAtMs: Int64) {
+    self.requestId = requestId
+    self.projectionJson = projectionJson
+    self.generatedAtMs = generatedAtMs
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case requestId = "request_id"
+    case projectionJson = "projection_json"
+    case generatedAtMs = "generated_at_ms"
+  }
+}
+
 // MARK: - Message (tagged enum, `#[serde(tag = "kind")]`)
 
 /// The subset of `friday_protocol::Message` the read seam uses, tagged by `kind` (serde
@@ -99,6 +377,20 @@ public enum FridayMessage: Equatable {
   case workbenchProjectionRequest(WorkbenchProjectionRequestWire)
   case workbenchProjectionSnapshot(WorkbenchProjectionSnapshotWire)
   case error(code: FridayErrorCode, message: String)
+  case runReadbackRequest(RunReadbackRequestWire)
+  case runReadbackSnapshot(RunReadbackSnapshotWire)
+  case providersDoctorRequest(ProvidersDoctorRequestWire)
+  case providersDoctorSnapshot(ProvidersDoctorSnapshotWire)
+  case sessionListRequest(SessionListRequestWire)
+  case sessionListSnapshot(SessionListSnapshotWire)
+  case sessionOpenRequest(SessionOpenRequestWire)
+  case sessionOpenSnapshot(SessionOpenSnapshotWire)
+  case sessionLinkStateRequest(SessionLinkStateRequestWire)
+  case sessionLinkStateSnapshot(SessionLinkStateSnapshotWire)
+  case runFileViewRequest(RunFileViewRequestWire)
+  case runFileViewSnapshot(RunFileViewSnapshotWire)
+  case activityNeedsMeRequest(ActivityNeedsMeRequestWire)
+  case activityNeedsMeSnapshot(ActivityNeedsMeSnapshotWire)
 
   // MARK: - WRITE / agent-run seam (GATE-AGENT-REPLACE)
 
@@ -201,6 +493,48 @@ extension FridayMessage: Codable {
       let c = try decoder.container(keyedBy: ErrorKey.self)
       self = .error(code: try c.decode(FridayErrorCode.self, forKey: .code),
                     message: try c.decode(String.self, forKey: .message))
+    case "RunReadbackRequest":
+      let c = try decoder.container(keyedBy: RequestKey.self)
+      self = .runReadbackRequest(try c.decode(RunReadbackRequestWire.self, forKey: .request))
+    case "RunReadbackSnapshot":
+      let c = try decoder.container(keyedBy: SnapshotKey.self)
+      self = .runReadbackSnapshot(try c.decode(RunReadbackSnapshotWire.self, forKey: .snapshot))
+    case "ProvidersDoctorRequest":
+      let c = try decoder.container(keyedBy: RequestKey.self)
+      self = .providersDoctorRequest(try c.decode(ProvidersDoctorRequestWire.self, forKey: .request))
+    case "ProvidersDoctorSnapshot":
+      let c = try decoder.container(keyedBy: SnapshotKey.self)
+      self = .providersDoctorSnapshot(try c.decode(ProvidersDoctorSnapshotWire.self, forKey: .snapshot))
+    case "SessionListRequest":
+      let c = try decoder.container(keyedBy: RequestKey.self)
+      self = .sessionListRequest(try c.decode(SessionListRequestWire.self, forKey: .request))
+    case "SessionListSnapshot":
+      let c = try decoder.container(keyedBy: SnapshotKey.self)
+      self = .sessionListSnapshot(try c.decode(SessionListSnapshotWire.self, forKey: .snapshot))
+    case "SessionOpenRequest":
+      let c = try decoder.container(keyedBy: RequestKey.self)
+      self = .sessionOpenRequest(try c.decode(SessionOpenRequestWire.self, forKey: .request))
+    case "SessionOpenSnapshot":
+      let c = try decoder.container(keyedBy: SnapshotKey.self)
+      self = .sessionOpenSnapshot(try c.decode(SessionOpenSnapshotWire.self, forKey: .snapshot))
+    case "SessionLinkStateRequest":
+      let c = try decoder.container(keyedBy: RequestKey.self)
+      self = .sessionLinkStateRequest(try c.decode(SessionLinkStateRequestWire.self, forKey: .request))
+    case "SessionLinkStateSnapshot":
+      let c = try decoder.container(keyedBy: SnapshotKey.self)
+      self = .sessionLinkStateSnapshot(try c.decode(SessionLinkStateSnapshotWire.self, forKey: .snapshot))
+    case "RunFileViewRequest":
+      let c = try decoder.container(keyedBy: RequestKey.self)
+      self = .runFileViewRequest(try c.decode(RunFileViewRequestWire.self, forKey: .request))
+    case "RunFileViewSnapshot":
+      let c = try decoder.container(keyedBy: SnapshotKey.self)
+      self = .runFileViewSnapshot(try c.decode(RunFileViewSnapshotWire.self, forKey: .snapshot))
+    case "ActivityNeedsMeRequest":
+      let c = try decoder.container(keyedBy: RequestKey.self)
+      self = .activityNeedsMeRequest(try c.decode(ActivityNeedsMeRequestWire.self, forKey: .request))
+    case "ActivityNeedsMeSnapshot":
+      let c = try decoder.container(keyedBy: SnapshotKey.self)
+      self = .activityNeedsMeSnapshot(try c.decode(ActivityNeedsMeSnapshotWire.self, forKey: .snapshot))
     case "AgentRunRequest":
       let c = try decoder.container(keyedBy: WriteKey.self)
       self = .agentRunRequest(AgentRunRequestWire(
@@ -295,6 +629,62 @@ extension FridayMessage: Codable {
       var c = encoder.container(keyedBy: ErrorKey.self)
       try c.encode(code, forKey: .code)
       try c.encode(message, forKey: .message)
+    case .runReadbackRequest(let req):
+      try tag.encode("RunReadbackRequest", forKey: .kind)
+      var c = encoder.container(keyedBy: RequestKey.self)
+      try c.encode(req, forKey: .request)
+    case .runReadbackSnapshot(let snap):
+      try tag.encode("RunReadbackSnapshot", forKey: .kind)
+      var c = encoder.container(keyedBy: SnapshotKey.self)
+      try c.encode(snap, forKey: .snapshot)
+    case .providersDoctorRequest(let req):
+      try tag.encode("ProvidersDoctorRequest", forKey: .kind)
+      var c = encoder.container(keyedBy: RequestKey.self)
+      try c.encode(req, forKey: .request)
+    case .providersDoctorSnapshot(let snap):
+      try tag.encode("ProvidersDoctorSnapshot", forKey: .kind)
+      var c = encoder.container(keyedBy: SnapshotKey.self)
+      try c.encode(snap, forKey: .snapshot)
+    case .sessionListRequest(let req):
+      try tag.encode("SessionListRequest", forKey: .kind)
+      var c = encoder.container(keyedBy: RequestKey.self)
+      try c.encode(req, forKey: .request)
+    case .sessionListSnapshot(let snap):
+      try tag.encode("SessionListSnapshot", forKey: .kind)
+      var c = encoder.container(keyedBy: SnapshotKey.self)
+      try c.encode(snap, forKey: .snapshot)
+    case .sessionOpenRequest(let req):
+      try tag.encode("SessionOpenRequest", forKey: .kind)
+      var c = encoder.container(keyedBy: RequestKey.self)
+      try c.encode(req, forKey: .request)
+    case .sessionOpenSnapshot(let snap):
+      try tag.encode("SessionOpenSnapshot", forKey: .kind)
+      var c = encoder.container(keyedBy: SnapshotKey.self)
+      try c.encode(snap, forKey: .snapshot)
+    case .sessionLinkStateRequest(let req):
+      try tag.encode("SessionLinkStateRequest", forKey: .kind)
+      var c = encoder.container(keyedBy: RequestKey.self)
+      try c.encode(req, forKey: .request)
+    case .sessionLinkStateSnapshot(let snap):
+      try tag.encode("SessionLinkStateSnapshot", forKey: .kind)
+      var c = encoder.container(keyedBy: SnapshotKey.self)
+      try c.encode(snap, forKey: .snapshot)
+    case .runFileViewRequest(let req):
+      try tag.encode("RunFileViewRequest", forKey: .kind)
+      var c = encoder.container(keyedBy: RequestKey.self)
+      try c.encode(req, forKey: .request)
+    case .runFileViewSnapshot(let snap):
+      try tag.encode("RunFileViewSnapshot", forKey: .kind)
+      var c = encoder.container(keyedBy: SnapshotKey.self)
+      try c.encode(snap, forKey: .snapshot)
+    case .activityNeedsMeRequest(let req):
+      try tag.encode("ActivityNeedsMeRequest", forKey: .kind)
+      var c = encoder.container(keyedBy: RequestKey.self)
+      try c.encode(req, forKey: .request)
+    case .activityNeedsMeSnapshot(let snap):
+      try tag.encode("ActivityNeedsMeSnapshot", forKey: .kind)
+      var c = encoder.container(keyedBy: SnapshotKey.self)
+      try c.encode(snap, forKey: .snapshot)
     case .agentRunRequest(let req):
       var c = encoder.container(keyedBy: WriteKey.self)
       // Field order MIRRORS the Rust serde struct-variant order: kind, run_id, task,
@@ -506,6 +896,26 @@ public struct WorkbenchSnapshot: Equatable {
       self.workItemIds = items.compactMap { ($0["workItemId"] as? String) ?? ($0["id"] as? String) }
     } else {
       self.workItemIds = []
+    }
+    self.generatedAtMs = generatedAtMs
+    self.raw = obj
+  }
+}
+
+// MARK: - Generic owner-gated read projection
+
+public struct ReadProjectionSnapshot: Equatable {
+  public let generatedAtMs: Int64
+  public let raw: [String: Any]
+
+  public static func == (lhs: ReadProjectionSnapshot, rhs: ReadProjectionSnapshot) -> Bool {
+    lhs.generatedAtMs == rhs.generatedAtMs
+      && NSDictionary(dictionary: lhs.raw).isEqual(to: rhs.raw)
+  }
+
+  public init(projectionJSON: Data, generatedAtMs: Int64) throws {
+    guard let obj = try JSONSerialization.jsonObject(with: projectionJSON) as? [String: Any] else {
+      throw FridayReadClientError.malformedProjection("projection JSON is not an object")
     }
     self.generatedAtMs = generatedAtMs
     self.raw = obj

--- a/apps/macos/FridayRustClient/Sources/FridayRustClient/ReadClient.swift
+++ b/apps/macos/FridayRustClient/Sources/FridayRustClient/ReadClient.swift
@@ -93,15 +93,57 @@ public protocol FridayRustReadClient: Sendable {
   /// Fetch the Mission Workbench refs-only projection over the sealed-WS read seam:
   /// handshake → owner-authed request → open the owner-sealed snapshot → typed result.
   func fetchWorkbench() async throws -> WorkbenchSnapshot
+  /// Fetch one run's refs-only readback projection.
+  func fetchRunReadback(runId: String) async throws -> ReadProjectionSnapshot
   /// Fetch one run's owner-gated answer body over the sealed-WS read seam. This is the explicit
   /// body-bearing sibling of `fetchWorkbench()`/RunReadback; implementations must not source the
   /// body from refs-only projections.
   func fetchRunAnswerBody(runId: String) async throws -> RunAnswerBody
+  /// Fetch provider readiness labels through the read-only providers-doctor arm.
+  func fetchProvidersDoctor(probe: String?) async throws -> ReadProjectionSnapshot
+  /// Fetch the owner's routed-session refs.
+  func fetchSessionList() async throws -> ReadProjectionSnapshot
+  /// Fetch one owner-gated routed session transcript. This is a deliberate owner-only body carve-out.
+  func fetchSessionOpen(agentSessionId: String) async throws -> ReadProjectionSnapshot
+  /// Fetch one routed session's refs-only freshness/connectivity state.
+  func fetchSessionLinkState(agentSessionId: String) async throws -> ReadProjectionSnapshot
+  /// Fetch one run's refs-only workspace file-view projection.
+  func fetchRunFileView(runId: String) async throws -> ReadProjectionSnapshot
+  /// Fetch one paused run's refs-only Activity / Needs-Me projection.
+  func fetchActivityNeedsMe(runId: String) async throws -> ReadProjectionSnapshot
 }
 
 public extension FridayRustReadClient {
+  func fetchRunReadback(runId: String) async throws -> ReadProjectionSnapshot {
+    throw FridayReadClientError.transport("run readback unavailable")
+  }
+
   func fetchRunAnswerBody(runId: String) async throws -> RunAnswerBody {
     throw FridayReadClientError.transport("run answer body readback unavailable")
+  }
+
+  func fetchProvidersDoctor(probe: String? = nil) async throws -> ReadProjectionSnapshot {
+    throw FridayReadClientError.transport("providers doctor readback unavailable")
+  }
+
+  func fetchSessionList() async throws -> ReadProjectionSnapshot {
+    throw FridayReadClientError.transport("session list readback unavailable")
+  }
+
+  func fetchSessionOpen(agentSessionId: String) async throws -> ReadProjectionSnapshot {
+    throw FridayReadClientError.transport("session open readback unavailable")
+  }
+
+  func fetchSessionLinkState(agentSessionId: String) async throws -> ReadProjectionSnapshot {
+    throw FridayReadClientError.transport("session link-state readback unavailable")
+  }
+
+  func fetchRunFileView(runId: String) async throws -> ReadProjectionSnapshot {
+    throw FridayReadClientError.transport("run file-view readback unavailable")
+  }
+
+  func fetchActivityNeedsMe(runId: String) async throws -> ReadProjectionSnapshot {
+    throw FridayReadClientError.transport("activity needs-me readback unavailable")
   }
 }
 
@@ -147,78 +189,21 @@ public final class SealedWSReadClient: FridayRustReadClient, @unchecked Sendable
   }
 
   public func fetchWorkbench() async throws -> WorkbenchSnapshot {
-    let transport = try makeTransport()
-
-    // (1) HANDSHAKE — cleartext preamble over the raw socket, then WS upgrade.
-    //   client pubkey OUT → server pubkey IN → 64-byte session nonce IN.
-    try transport.writeFrame(keypair.publicKey)
-    let serverPub = try transport.readFrame()
-    guard serverPub.count == FridayCrypto.x25519PublicKeyLen else {
-      throw FridayReadClientError.badServerPubkey
-    }
-    let sessionNonce = try transport.readFrame()
-    // The server emits a 64-byte (hex-of-32-CSPRNG) nonce; the verifier rejects any other
-    // width (`SESSION_NONCE_LEN`). Bind it VERBATIM (do NOT hex-decode to 32 bytes).
-    guard sessionNonce.count == 64 else {
-      throw FridayReadClientError.badSessionNonce
-    }
-    try transport.upgrade()
-
-    // Derive the per-session key (ECDH + HKDF). Same key both ends agree on.
-    let sessionKey: [UInt8]
-    do {
-      sessionKey = try keypair.agree(peerPublicKey: serverPub)
-    } catch {
-      throw FridayReadClientError.transport("session-key agreement failed: \(error)")
+    let response = try sendReadMessage { requestId, authProof in
+      .workbenchProjectionRequest(WorkbenchProjectionRequestWire(
+        missionId: missionId,
+        forwardedPrincipal: forwardedPrincipal,
+        authProof: authProof,
+        requestId: requestId))
     }
 
-    // (2) REQUEST — a WorkbenchProjectionRequest, owner-authed, sealed under the session key.
-    let requestId = newRequestId()
-    let authProof = try FridayCrypto.buildAuthProof(
-      sessionKey: sessionKey,
-      sessionNonce: sessionNonce,
-      sessionAad: readSessionAad,
-      authChallenge: readAuthChallenge,
-      forwardedPrincipal: forwardedPrincipal,
-      boundContext: Array(requestId.utf8)
-    )
-    let request = WorkbenchProjectionRequestWire(
-      missionId: missionId,
-      forwardedPrincipal: forwardedPrincipal,
-      authProof: authProof,
-      requestId: requestId
-    )
-    let reqEnvelope = FridayEnvelope(
-      msgId: "msg-\(requestId)",
-      sentAt: now(),
-      message: .workbenchProjectionRequest(request)
-    )
-    let reqBody = try sealEnvelope(reqEnvelope, sessionKey: sessionKey)
-    try transport.sendMessage(reqBody)
-
-    // (3) RESPONSE — open the sealed envelope, then the owner-sealed snapshot body.
-    let respBody: [UInt8]
-    do {
-      respBody = try transport.recvMessage()
-    } catch {
-      // A read server that fails auth ENDS the session (no snapshot). Surface as fail-closed.
-      throw FridayReadClientError.transport("no response (session ended fail-closed): \(error)")
-    }
-    let respEnvelope = try openEnvelope(respBody, sessionKey: sessionKey)
-
-    switch respEnvelope.message {
+    switch response.message {
     case .workbenchProjectionSnapshot(let snap):
       // The projection JSON is OWNER-SEALED: hex of `[nonce_len][nonce][ciphertext]`,
       // sealed under the session key with the read SESSION_AAD. Only the bound owner can
       // open it. Open → the refs-only projection JSON → typed snapshot.
-      let sealedBytes = try Hex.decode(snap.projectionJson)
-      let innerSealed = try FridayCrypto.decodeSealed(sealedBytes)
-      let projectionBytes: [UInt8]
-      do {
-        projectionBytes = try FridayCrypto.open(key: sessionKey, sealed: innerSealed, aad: readSessionAad)
-      } catch {
-        throw FridayReadClientError.malformedProjection("owner-sealed projection failed to open: \(error)")
-      }
+      let projectionBytes = try openOwnerSealedJSON(
+        snap.projectionJson, sessionKey: response.sessionKey, label: "projection")
       return try WorkbenchSnapshot(
         projectionJSON: Data(projectionBytes),
         generatedAtMs: snap.generatedAtMs
@@ -257,70 +242,70 @@ public final class SealedWSReadClient: FridayRustReadClient, @unchecked Sendable
       throw FridayReadClientError.unexpectedResponse(kind: "RunAnswerBodyRequest")
     case .runAnswerBodySnapshot:
       throw FridayReadClientError.unexpectedResponse(kind: "RunAnswerBodySnapshot")
+    case .runReadbackRequest:
+      throw FridayReadClientError.unexpectedResponse(kind: "RunReadbackRequest")
+    case .runReadbackSnapshot:
+      throw FridayReadClientError.unexpectedResponse(kind: "RunReadbackSnapshot")
+    case .providersDoctorRequest:
+      throw FridayReadClientError.unexpectedResponse(kind: "ProvidersDoctorRequest")
+    case .providersDoctorSnapshot:
+      throw FridayReadClientError.unexpectedResponse(kind: "ProvidersDoctorSnapshot")
+    case .sessionListRequest:
+      throw FridayReadClientError.unexpectedResponse(kind: "SessionListRequest")
+    case .sessionListSnapshot:
+      throw FridayReadClientError.unexpectedResponse(kind: "SessionListSnapshot")
+    case .sessionOpenRequest:
+      throw FridayReadClientError.unexpectedResponse(kind: "SessionOpenRequest")
+    case .sessionOpenSnapshot:
+      throw FridayReadClientError.unexpectedResponse(kind: "SessionOpenSnapshot")
+    case .sessionLinkStateRequest:
+      throw FridayReadClientError.unexpectedResponse(kind: "SessionLinkStateRequest")
+    case .sessionLinkStateSnapshot:
+      throw FridayReadClientError.unexpectedResponse(kind: "SessionLinkStateSnapshot")
+    case .runFileViewRequest:
+      throw FridayReadClientError.unexpectedResponse(kind: "RunFileViewRequest")
+    case .runFileViewSnapshot:
+      throw FridayReadClientError.unexpectedResponse(kind: "RunFileViewSnapshot")
+    case .activityNeedsMeRequest:
+      throw FridayReadClientError.unexpectedResponse(kind: "ActivityNeedsMeRequest")
+    case .activityNeedsMeSnapshot:
+      throw FridayReadClientError.unexpectedResponse(kind: "ActivityNeedsMeSnapshot")
     case .unsupported(let kind):
       throw FridayReadClientError.unexpectedResponse(kind: kind)
     }
   }
 
+  public func fetchRunReadback(runId: String) async throws -> ReadProjectionSnapshot {
+    try await fetchProjection(
+      makeMessage: { requestId, authProof in
+        .runReadbackRequest(RunReadbackRequestWire(
+          runId: runId,
+          forwardedPrincipal: forwardedPrincipal,
+          authProof: authProof,
+          requestId: requestId))
+      },
+      extract: { message in
+        if case .runReadbackSnapshot(let snap) = message {
+          return (snap.projectionJson, snap.generatedAtMs)
+        }
+        return nil
+      },
+      expected: "RunReadbackSnapshot")
+  }
+
   public func fetchRunAnswerBody(runId: String) async throws -> RunAnswerBody {
-    let transport = try makeTransport()
-
-    try transport.writeFrame(keypair.publicKey)
-    let serverPub = try transport.readFrame()
-    guard serverPub.count == FridayCrypto.x25519PublicKeyLen else {
-      throw FridayReadClientError.badServerPubkey
-    }
-    let sessionNonce = try transport.readFrame()
-    guard sessionNonce.count == 64 else {
-      throw FridayReadClientError.badSessionNonce
-    }
-    try transport.upgrade()
-
-    let sessionKey: [UInt8]
-    do {
-      sessionKey = try keypair.agree(peerPublicKey: serverPub)
-    } catch {
-      throw FridayReadClientError.transport("session-key agreement failed: \(error)")
-    }
-
-    let requestId = newRequestId()
-    let authProof = try FridayCrypto.buildAuthProof(
-      sessionKey: sessionKey,
-      sessionNonce: sessionNonce,
-      sessionAad: readSessionAad,
-      authChallenge: readAuthChallenge,
-      forwardedPrincipal: forwardedPrincipal,
-      boundContext: Array(requestId.utf8)
-    )
-    let reqEnvelope = FridayEnvelope(
-      msgId: "msg-\(requestId)",
-      sentAt: now(),
-      message: .runAnswerBodyRequest(RunAnswerBodyRequestWire(
+    let response = try sendReadMessage { requestId, authProof in
+      .runAnswerBodyRequest(RunAnswerBodyRequestWire(
         runId: runId,
         forwardedPrincipal: forwardedPrincipal,
         authProof: authProof,
         requestId: requestId))
-    )
-    try transport.sendMessage(try sealEnvelope(reqEnvelope, sessionKey: sessionKey))
-
-    let respBody: [UInt8]
-    do {
-      respBody = try transport.recvMessage()
-    } catch {
-      throw FridayReadClientError.transport("no response (session ended fail-closed): \(error)")
     }
-    let respEnvelope = try openEnvelope(respBody, sessionKey: sessionKey)
 
-    switch respEnvelope.message {
+    switch response.message {
     case .runAnswerBodySnapshot(let snap):
-      let sealedBytes = try Hex.decode(snap.answerJson)
-      let innerSealed = try FridayCrypto.decodeSealed(sealedBytes)
-      let answerBytes: [UInt8]
-      do {
-        answerBytes = try FridayCrypto.open(key: sessionKey, sealed: innerSealed, aad: readSessionAad)
-      } catch {
-        throw FridayReadClientError.malformedProjection("owner-sealed answer failed to open: \(error)")
-      }
+      let answerBytes = try openOwnerSealedJSON(
+        snap.answerJson, sessionKey: response.sessionKey, label: "answer")
       return try RunAnswerBody(answerJSON: Data(answerBytes), generatedAtMs: snap.generatedAtMs)
     case .error(let code, let message):
       throw FridayReadClientError.serverError(code: code, message: message)
@@ -352,12 +337,230 @@ public final class SealedWSReadClient: FridayRustReadClient, @unchecked Sendable
       throw FridayReadClientError.unexpectedResponse(kind: "RunOutcomeLearningDecisionRequest")
     case .runOutcomeLearningDecisionResult:
       throw FridayReadClientError.unexpectedResponse(kind: "RunOutcomeLearningDecisionResult")
+    case .runReadbackRequest:
+      throw FridayReadClientError.unexpectedResponse(kind: "RunReadbackRequest")
+    case .runReadbackSnapshot:
+      throw FridayReadClientError.unexpectedResponse(kind: "RunReadbackSnapshot")
+    case .providersDoctorRequest:
+      throw FridayReadClientError.unexpectedResponse(kind: "ProvidersDoctorRequest")
+    case .providersDoctorSnapshot:
+      throw FridayReadClientError.unexpectedResponse(kind: "ProvidersDoctorSnapshot")
+    case .sessionListRequest:
+      throw FridayReadClientError.unexpectedResponse(kind: "SessionListRequest")
+    case .sessionListSnapshot:
+      throw FridayReadClientError.unexpectedResponse(kind: "SessionListSnapshot")
+    case .sessionOpenRequest:
+      throw FridayReadClientError.unexpectedResponse(kind: "SessionOpenRequest")
+    case .sessionOpenSnapshot:
+      throw FridayReadClientError.unexpectedResponse(kind: "SessionOpenSnapshot")
+    case .sessionLinkStateRequest:
+      throw FridayReadClientError.unexpectedResponse(kind: "SessionLinkStateRequest")
+    case .sessionLinkStateSnapshot:
+      throw FridayReadClientError.unexpectedResponse(kind: "SessionLinkStateSnapshot")
+    case .runFileViewRequest:
+      throw FridayReadClientError.unexpectedResponse(kind: "RunFileViewRequest")
+    case .runFileViewSnapshot:
+      throw FridayReadClientError.unexpectedResponse(kind: "RunFileViewSnapshot")
+    case .activityNeedsMeRequest:
+      throw FridayReadClientError.unexpectedResponse(kind: "ActivityNeedsMeRequest")
+    case .activityNeedsMeSnapshot:
+      throw FridayReadClientError.unexpectedResponse(kind: "ActivityNeedsMeSnapshot")
     case .unsupported(let kind):
       throw FridayReadClientError.unexpectedResponse(kind: kind)
     }
   }
 
+  public func fetchProvidersDoctor(probe: String? = nil) async throws -> ReadProjectionSnapshot {
+    try await fetchProjection(
+      makeMessage: { requestId, authProof in
+        .providersDoctorRequest(ProvidersDoctorRequestWire(
+          probe: probe,
+          forwardedPrincipal: forwardedPrincipal,
+          authProof: authProof,
+          requestId: requestId))
+      },
+      extract: { message in
+        if case .providersDoctorSnapshot(let snap) = message {
+          return (snap.projectionJson, snap.generatedAtMs)
+        }
+        return nil
+      },
+      expected: "ProvidersDoctorSnapshot")
+  }
+
+  public func fetchSessionList() async throws -> ReadProjectionSnapshot {
+    try await fetchProjection(
+      makeMessage: { requestId, authProof in
+        .sessionListRequest(SessionListRequestWire(
+          forwardedPrincipal: forwardedPrincipal,
+          authProof: authProof,
+          requestId: requestId))
+      },
+      extract: { message in
+        if case .sessionListSnapshot(let snap) = message {
+          return (snap.projectionJson, snap.generatedAtMs)
+        }
+        return nil
+      },
+      expected: "SessionListSnapshot")
+  }
+
+  public func fetchSessionOpen(agentSessionId: String) async throws -> ReadProjectionSnapshot {
+    try await fetchProjection(
+      makeMessage: { requestId, authProof in
+        .sessionOpenRequest(SessionOpenRequestWire(
+          agentSessionId: agentSessionId,
+          forwardedPrincipal: forwardedPrincipal,
+          authProof: authProof,
+          requestId: requestId))
+      },
+      extract: { message in
+        if case .sessionOpenSnapshot(let snap) = message {
+          return (snap.projectionJson, snap.generatedAtMs)
+        }
+        return nil
+      },
+      expected: "SessionOpenSnapshot")
+  }
+
+  public func fetchSessionLinkState(agentSessionId: String) async throws -> ReadProjectionSnapshot {
+    try await fetchProjection(
+      makeMessage: { requestId, authProof in
+        .sessionLinkStateRequest(SessionLinkStateRequestWire(
+          agentSessionId: agentSessionId,
+          forwardedPrincipal: forwardedPrincipal,
+          authProof: authProof,
+          requestId: requestId))
+      },
+      extract: { message in
+        if case .sessionLinkStateSnapshot(let snap) = message {
+          return (snap.projectionJson, snap.generatedAtMs)
+        }
+        return nil
+      },
+      expected: "SessionLinkStateSnapshot")
+  }
+
+  public func fetchRunFileView(runId: String) async throws -> ReadProjectionSnapshot {
+    try await fetchProjection(
+      makeMessage: { requestId, authProof in
+        .runFileViewRequest(RunFileViewRequestWire(
+          runId: runId,
+          forwardedPrincipal: forwardedPrincipal,
+          authProof: authProof,
+          requestId: requestId))
+      },
+      extract: { message in
+        if case .runFileViewSnapshot(let snap) = message {
+          return (snap.projectionJson, snap.generatedAtMs)
+        }
+        return nil
+      },
+      expected: "RunFileViewSnapshot")
+  }
+
+  public func fetchActivityNeedsMe(runId: String) async throws -> ReadProjectionSnapshot {
+    try await fetchProjection(
+      makeMessage: { requestId, authProof in
+        .activityNeedsMeRequest(ActivityNeedsMeRequestWire(
+          runId: runId,
+          forwardedPrincipal: forwardedPrincipal,
+          authProof: authProof,
+          requestId: requestId))
+      },
+      extract: { message in
+        if case .activityNeedsMeSnapshot(let snap) = message {
+          return (snap.projectionJson, snap.generatedAtMs)
+        }
+        return nil
+      },
+      expected: "ActivityNeedsMeSnapshot")
+  }
+
   // MARK: Envelope seal/open over the session key (transport layer)
+
+  private struct ReadResponse {
+    let message: FridayMessage
+    let sessionKey: [UInt8]
+  }
+
+  private func fetchProjection(
+    makeMessage: (String, [UInt8]) -> FridayMessage,
+    extract: (FridayMessage) -> (projectionJson: String, generatedAtMs: Int64)?,
+    expected: String
+  ) async throws -> ReadProjectionSnapshot {
+    let response = try sendReadMessage(makeMessage)
+    if case .error(let code, let message) = response.message {
+      throw FridayReadClientError.serverError(code: code, message: message)
+    }
+    guard let snapshot = extract(response.message) else {
+      throw FridayReadClientError.unexpectedResponse(kind: expected)
+    }
+    let projectionBytes = try openOwnerSealedJSON(
+      snapshot.projectionJson, sessionKey: response.sessionKey, label: "projection")
+    return try ReadProjectionSnapshot(
+      projectionJSON: Data(projectionBytes),
+      generatedAtMs: snapshot.generatedAtMs)
+  }
+
+  private func sendReadMessage(_ makeMessage: (String, [UInt8]) -> FridayMessage) throws -> ReadResponse {
+    let transport = try makeTransport()
+
+    try transport.writeFrame(keypair.publicKey)
+    let serverPub = try transport.readFrame()
+    guard serverPub.count == FridayCrypto.x25519PublicKeyLen else {
+      throw FridayReadClientError.badServerPubkey
+    }
+    let sessionNonce = try transport.readFrame()
+    guard sessionNonce.count == 64 else {
+      throw FridayReadClientError.badSessionNonce
+    }
+    try transport.upgrade()
+
+    let sessionKey: [UInt8]
+    do {
+      sessionKey = try keypair.agree(peerPublicKey: serverPub)
+    } catch {
+      throw FridayReadClientError.transport("session-key agreement failed: \(error)")
+    }
+
+    let requestId = newRequestId()
+    let authProof = try FridayCrypto.buildAuthProof(
+      sessionKey: sessionKey,
+      sessionNonce: sessionNonce,
+      sessionAad: readSessionAad,
+      authChallenge: readAuthChallenge,
+      forwardedPrincipal: forwardedPrincipal,
+      boundContext: Array(requestId.utf8))
+    let reqEnvelope = FridayEnvelope(
+      msgId: "msg-\(requestId)",
+      sentAt: now(),
+      message: makeMessage(requestId, authProof))
+    try transport.sendMessage(try sealEnvelope(reqEnvelope, sessionKey: sessionKey))
+
+    let respBody: [UInt8]
+    do {
+      respBody = try transport.recvMessage()
+    } catch {
+      throw FridayReadClientError.transport("no response (session ended fail-closed): \(error)")
+    }
+    let respEnvelope = try openEnvelope(respBody, sessionKey: sessionKey)
+    return ReadResponse(message: respEnvelope.message, sessionKey: sessionKey)
+  }
+
+  private func openOwnerSealedJSON(
+    _ sealedHex: String,
+    sessionKey: [UInt8],
+    label: String
+  ) throws -> [UInt8] {
+    let sealedBytes = try Hex.decode(sealedHex)
+    let innerSealed = try FridayCrypto.decodeSealed(sealedBytes)
+    do {
+      return try FridayCrypto.open(key: sessionKey, sealed: innerSealed, aad: readSessionAad)
+    } catch {
+      throw FridayReadClientError.malformedProjection("owner-sealed \(label) failed to open: \(error)")
+    }
+  }
 
   /// Serialize + seal an envelope into a WS Binary body. Mirrors
   /// `friday_transport::seal_envelope`: JSON → `seal(key, json, aad)` → `encodeSealed`.

--- a/apps/macos/FridayRustClient/Sources/FridayRustClient/WriteClient.swift
+++ b/apps/macos/FridayRustClient/Sources/FridayRustClient/WriteClient.swift
@@ -333,7 +333,14 @@ public final class SealedWSWriteClient: FridayRustWriteClient, FridayMissionSpin
       throw FridayWriteClientError.serverError(code: code, message: message)
     case .agentRunRequest, .agentRunResume, .agentRunControlResult,
          .workbenchProjectionRequest, .workbenchProjectionSnapshot,
+         .runReadbackRequest, .runReadbackSnapshot,
          .runAnswerBodyRequest, .runAnswerBodySnapshot,
+         .providersDoctorRequest, .providersDoctorSnapshot,
+         .sessionListRequest, .sessionListSnapshot,
+         .sessionOpenRequest, .sessionOpenSnapshot,
+         .sessionLinkStateRequest, .sessionLinkStateSnapshot,
+         .runFileViewRequest, .runFileViewSnapshot,
+         .activityNeedsMeRequest, .activityNeedsMeSnapshot,
          .missionIntakeRequest, .missionIntakeResult,
          .memoryDecisionRequest, .memoryDecisionResult,
          .runOutcomeLearningDecisionRequest, .runOutcomeLearningDecisionResult:
@@ -550,8 +557,22 @@ private func dispatchKind(_ message: FridayMessage) -> String {
   switch message {
   case .workbenchProjectionRequest: return "WorkbenchProjectionRequest"
   case .workbenchProjectionSnapshot: return "WorkbenchProjectionSnapshot"
+  case .runReadbackRequest: return "RunReadbackRequest"
+  case .runReadbackSnapshot: return "RunReadbackSnapshot"
   case .runAnswerBodyRequest: return "RunAnswerBodyRequest"
   case .runAnswerBodySnapshot: return "RunAnswerBodySnapshot"
+  case .providersDoctorRequest: return "ProvidersDoctorRequest"
+  case .providersDoctorSnapshot: return "ProvidersDoctorSnapshot"
+  case .sessionListRequest: return "SessionListRequest"
+  case .sessionListSnapshot: return "SessionListSnapshot"
+  case .sessionOpenRequest: return "SessionOpenRequest"
+  case .sessionOpenSnapshot: return "SessionOpenSnapshot"
+  case .sessionLinkStateRequest: return "SessionLinkStateRequest"
+  case .sessionLinkStateSnapshot: return "SessionLinkStateSnapshot"
+  case .runFileViewRequest: return "RunFileViewRequest"
+  case .runFileViewSnapshot: return "RunFileViewSnapshot"
+  case .activityNeedsMeRequest: return "ActivityNeedsMeRequest"
+  case .activityNeedsMeSnapshot: return "ActivityNeedsMeSnapshot"
   case .error: return "Error"
   case .agentRunRequest: return "AgentRunRequest"
   case .agentRunResult: return "AgentRunResult"

--- a/apps/macos/FridayRustClient/Tests/FridayRustClientTests/ReadClientWiringTests.swift
+++ b/apps/macos/FridayRustClient/Tests/FridayRustClientTests/ReadClientWiringTests.swift
@@ -89,7 +89,11 @@ final class ReadClientWiringTests: XCTestCase {
       let reqPrincipal: String
       let reqId: String
       let authProof: [UInt8]
-      enum ResponseKind { case workbench, answerBody(runId: String) }
+      enum ResponseKind {
+        case workbench
+        case projection((String, String, Int64) -> FridayMessage)
+        case answerBody(runId: String)
+      }
       let responseKind: ResponseKind
       switch env.message {
       case .workbenchProjectionRequest(let req):
@@ -97,11 +101,67 @@ final class ReadClientWiringTests: XCTestCase {
         reqId = req.requestId
         authProof = req.authProof
         responseKind = .workbench
+      case .runReadbackRequest(let req):
+        reqPrincipal = req.forwardedPrincipal
+        reqId = req.requestId
+        authProof = req.authProof
+        responseKind = .projection { requestId, sealedHex, generatedAtMs in
+          .runReadbackSnapshot(RunReadbackSnapshotWire(
+            requestId: requestId, projectionJson: sealedHex, generatedAtMs: generatedAtMs))
+        }
       case .runAnswerBodyRequest(let req):
         reqPrincipal = req.forwardedPrincipal
         reqId = req.requestId
         authProof = req.authProof
         responseKind = .answerBody(runId: req.runId)
+      case .providersDoctorRequest(let req):
+        reqPrincipal = req.forwardedPrincipal
+        reqId = req.requestId
+        authProof = req.authProof
+        responseKind = .projection { requestId, sealedHex, generatedAtMs in
+          .providersDoctorSnapshot(ProvidersDoctorSnapshotWire(
+            requestId: requestId, projectionJson: sealedHex, generatedAtMs: generatedAtMs))
+        }
+      case .sessionListRequest(let req):
+        reqPrincipal = req.forwardedPrincipal
+        reqId = req.requestId
+        authProof = req.authProof
+        responseKind = .projection { requestId, sealedHex, generatedAtMs in
+          .sessionListSnapshot(SessionListSnapshotWire(
+            requestId: requestId, projectionJson: sealedHex, generatedAtMs: generatedAtMs))
+        }
+      case .sessionOpenRequest(let req):
+        reqPrincipal = req.forwardedPrincipal
+        reqId = req.requestId
+        authProof = req.authProof
+        responseKind = .projection { requestId, sealedHex, generatedAtMs in
+          .sessionOpenSnapshot(SessionOpenSnapshotWire(
+            requestId: requestId, projectionJson: sealedHex, generatedAtMs: generatedAtMs))
+        }
+      case .sessionLinkStateRequest(let req):
+        reqPrincipal = req.forwardedPrincipal
+        reqId = req.requestId
+        authProof = req.authProof
+        responseKind = .projection { requestId, sealedHex, generatedAtMs in
+          .sessionLinkStateSnapshot(SessionLinkStateSnapshotWire(
+            requestId: requestId, projectionJson: sealedHex, generatedAtMs: generatedAtMs))
+        }
+      case .runFileViewRequest(let req):
+        reqPrincipal = req.forwardedPrincipal
+        reqId = req.requestId
+        authProof = req.authProof
+        responseKind = .projection { requestId, sealedHex, generatedAtMs in
+          .runFileViewSnapshot(RunFileViewSnapshotWire(
+            requestId: requestId, projectionJson: sealedHex, generatedAtMs: generatedAtMs))
+        }
+      case .activityNeedsMeRequest(let req):
+        reqPrincipal = req.forwardedPrincipal
+        reqId = req.requestId
+        authProof = req.authProof
+        responseKind = .projection { requestId, sealedHex, generatedAtMs in
+          .activityNeedsMeSnapshot(ActivityNeedsMeSnapshotWire(
+            requestId: requestId, projectionJson: sealedHex, generatedAtMs: generatedAtMs))
+        }
       default:
         throw FridayReadClientError.transport("expected a read projection request")
       }
@@ -136,6 +196,9 @@ final class ReadClientWiringTests: XCTestCase {
           projectionJson: "",
           generatedAtMs: 1_780_640_000_000
         ))
+      case .projection(let build):
+        plaintext = projectionJSON
+        responseMessage = build(reqId, "", 1_780_640_000_000)
       case .answerBody(let runId):
         if answerJSON.isEmpty {
           plaintext = Array("""
@@ -158,6 +221,41 @@ final class ReadClientWiringTests: XCTestCase {
       switch responseMessage {
       case .workbenchProjectionSnapshot(let snap):
         finalMessage = .workbenchProjectionSnapshot(WorkbenchProjectionSnapshotWire(
+          requestId: snap.requestId,
+          projectionJson: sealedHex,
+          generatedAtMs: snap.generatedAtMs))
+      case .runReadbackSnapshot(let snap):
+        finalMessage = .runReadbackSnapshot(RunReadbackSnapshotWire(
+          requestId: snap.requestId,
+          projectionJson: sealedHex,
+          generatedAtMs: snap.generatedAtMs))
+      case .providersDoctorSnapshot(let snap):
+        finalMessage = .providersDoctorSnapshot(ProvidersDoctorSnapshotWire(
+          requestId: snap.requestId,
+          projectionJson: sealedHex,
+          generatedAtMs: snap.generatedAtMs))
+      case .sessionListSnapshot(let snap):
+        finalMessage = .sessionListSnapshot(SessionListSnapshotWire(
+          requestId: snap.requestId,
+          projectionJson: sealedHex,
+          generatedAtMs: snap.generatedAtMs))
+      case .sessionOpenSnapshot(let snap):
+        finalMessage = .sessionOpenSnapshot(SessionOpenSnapshotWire(
+          requestId: snap.requestId,
+          projectionJson: sealedHex,
+          generatedAtMs: snap.generatedAtMs))
+      case .sessionLinkStateSnapshot(let snap):
+        finalMessage = .sessionLinkStateSnapshot(SessionLinkStateSnapshotWire(
+          requestId: snap.requestId,
+          projectionJson: sealedHex,
+          generatedAtMs: snap.generatedAtMs))
+      case .runFileViewSnapshot(let snap):
+        finalMessage = .runFileViewSnapshot(RunFileViewSnapshotWire(
+          requestId: snap.requestId,
+          projectionJson: sealedHex,
+          generatedAtMs: snap.generatedAtMs))
+      case .activityNeedsMeSnapshot(let snap):
+        finalMessage = .activityNeedsMeSnapshot(ActivityNeedsMeSnapshotWire(
           requestId: snap.requestId,
           projectionJson: sealedHex,
           generatedAtMs: snap.generatedAtMs))
@@ -271,6 +369,64 @@ final class ReadClientWiringTests: XCTestCase {
     XCTAssertEqual(body.answerLen, 50)
     XCTAssertEqual(body.truthLabel, "rust_wired_owner_gated")
     XCTAssertEqual(transport.processed, 1)
+  }
+
+  func testFetchAdditionalReadArms_decodeOwnerSealedProjection() async throws {
+    func makeClient(requestId: String) throws -> (SealedWSReadClient, EmulatedRustServerTransport) {
+      let clientKp = try FridayCrypto.DeviceKeypair(secretBytes: try Hex.decode(B1KAT.k1Agree.clientSecret))
+      let serverKp = try FridayCrypto.DeviceKeypair(secretBytes: try Hex.decode(B1KAT.k1Agree.serverSecret))
+      let nonce = try Hex.decode(B1KAT.k3Auth.sessionNonce)
+      let transport = EmulatedRustServerTransport(
+        serverKeypair: serverKp,
+        sessionNonce: nonce,
+        peerAllowlist: [clientKp.publicKey],
+        ownerAllowlist: [owner],
+        projectionJSON: Array(Self.refsOnlyProjection.utf8)
+      )
+      let client = SealedWSReadClient(
+        keypair: clientKp,
+        forwardedPrincipal: owner,
+        makeTransport: { transport },
+        now: { 1000 },
+        newRequestId: { requestId }
+      )
+      return (client, transport)
+    }
+
+    let runReadback = try makeClient(requestId: "req-run-readback")
+    let runReadbackSnapshot = try await runReadback.0.fetchRunReadback(runId: "run-1")
+    XCTAssertEqual(runReadbackSnapshot.raw["missionId"] as? String, "mission_read_seam_probe_20260611")
+    XCTAssertEqual(runReadback.1.processed, 1)
+
+    let providersDoctor = try makeClient(requestId: "req-providers")
+    let providersDoctorSnapshot = try await providersDoctor.0.fetchProvidersDoctor(probe: "both")
+    XCTAssertEqual(providersDoctorSnapshot.raw["missionId"] as? String, "mission_read_seam_probe_20260611")
+    XCTAssertEqual(providersDoctor.1.processed, 1)
+
+    let sessionList = try makeClient(requestId: "req-session-list")
+    let sessionListSnapshot = try await sessionList.0.fetchSessionList()
+    XCTAssertEqual(sessionListSnapshot.raw["missionId"] as? String, "mission_read_seam_probe_20260611")
+    XCTAssertEqual(sessionList.1.processed, 1)
+
+    let sessionOpen = try makeClient(requestId: "req-session-open")
+    let sessionOpenSnapshot = try await sessionOpen.0.fetchSessionOpen(agentSessionId: "session-1")
+    XCTAssertEqual(sessionOpenSnapshot.raw["missionId"] as? String, "mission_read_seam_probe_20260611")
+    XCTAssertEqual(sessionOpen.1.processed, 1)
+
+    let linkState = try makeClient(requestId: "req-link-state")
+    let linkStateSnapshot = try await linkState.0.fetchSessionLinkState(agentSessionId: "session-1")
+    XCTAssertEqual(linkStateSnapshot.raw["missionId"] as? String, "mission_read_seam_probe_20260611")
+    XCTAssertEqual(linkState.1.processed, 1)
+
+    let fileView = try makeClient(requestId: "req-file-view")
+    let fileViewSnapshot = try await fileView.0.fetchRunFileView(runId: "run-1")
+    XCTAssertEqual(fileViewSnapshot.raw["missionId"] as? String, "mission_read_seam_probe_20260611")
+    XCTAssertEqual(fileView.1.processed, 1)
+
+    let needsMe = try makeClient(requestId: "req-needs-me")
+    let needsMeSnapshot = try await needsMe.0.fetchActivityNeedsMe(runId: "run-1")
+    XCTAssertEqual(needsMeSnapshot.raw["missionId"] as? String, "mission_read_seam_probe_20260611")
+    XCTAssertEqual(needsMe.1.processed, 1)
   }
 
   func testFetchWorkbench_mismatchedPrincipal_endsFailClosed() async throws {


### PR DESCRIPTION
## Summary
- expose the remaining Swift read projection protocol arms for run readback, provider doctor, sessions, link state, run file view, and activity-needs-me
- add sealed read-client methods and fail-closed handling for these READ-only messages
- extend the in-memory Swift read client wiring server to prove owner-sealed decode paths for all added arms

## Verification
- `swift test --package-path apps/macos/FridayRustClient --filter ReadClientWiringTests`
- `swift test --package-path apps/macos/FridayRustClient`
- `swift test --package-path apps/friday-ios --filter HomeViewModelTests`
- `swift test --package-path apps/friday-ios --filter FridayChatViewModelTests`
- `swift test --package-path apps/macos/FridayHubConsole --filter OperationsOverviewViewModelTests`
- `swift test --package-path apps/friday-ios`
- `swift test --package-path apps/macos/FridayHubConsole`
- `git diff --check`

## Truth Label
- This is client/protocol wiring with in-memory owner-sealed proof coverage.
- It is not a live-server/device proof, not OG9 operator-origin organic traffic, not a GO-LIVE/v1 completion claim.