### PR TITLE
Wire UI consumers to read projection arms

### DIFF
--- a/apps/friday-ios/Sources/FridayMobileShell/FridayProjectionScreens.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayProjectionScreens.swift
@@ -147,6 +147,8 @@ struct FridayProjectionScreen: View {
       if !projection.statusLabels.isEmpty {
         StatusBanner(labels: projection.statusLabels)
       }
+      detailActionsCard(projection)
+      detailResultCard
 
       switch surface {
       case .missions:
@@ -168,6 +170,85 @@ struct FridayProjectionScreen: View {
         onboardingCard(projection)
       case .settings:
         settingsCard(projection)
+      }
+    }
+  }
+
+  private func detailActionsCard(_ projection: HomeProjection) -> some View {
+    GlassPanel {
+      VStack(alignment: .leading, spacing: MobileTheme.rowSpacing) {
+        cardHeader("Read Arms", count: nil)
+        HStack(spacing: 8) {
+          Button {
+            Task { await viewModel.loadDetail(.providersDoctor(probe: nil)) }
+          } label: {
+            Label("Providers", systemImage: "stethoscope")
+          }
+          .disabled(viewModel.detailState.isLoading)
+
+          Button {
+            Task { await viewModel.loadDetail(.sessionList) }
+          } label: {
+            Label("Sessions", systemImage: "rectangle.stack")
+          }
+          .disabled(viewModel.detailState.isLoading)
+        }
+        if let runId = projection.runOutcomeLearningCandidates.first?.runId, !runId.isEmpty {
+          HStack(spacing: 8) {
+            Button {
+              Task { await viewModel.loadDetail(.runReadback(runId: runId)) }
+            } label: {
+              Label("Run", systemImage: "doc.text.magnifyingglass")
+            }
+            .disabled(viewModel.detailState.isLoading)
+
+            Button {
+              Task { await viewModel.loadDetail(.activityNeedsMe(runId: runId)) }
+            } label: {
+              Label("Needs Me", systemImage: "bell.badge")
+            }
+            .disabled(viewModel.detailState.isLoading)
+          }
+        }
+      }
+    }
+  }
+
+  @ViewBuilder
+  private var detailResultCard: some View {
+    switch viewModel.detailState {
+    case .idle:
+      EmptyView()
+    case let .loading(arm):
+      GlassPanel {
+        HStack(spacing: 12) {
+          ProgressView()
+          Text(arm.title)
+            .font(.caption)
+            .foregroundStyle(MobileTheme.textSecondary)
+        }
+      }
+    case let .loaded(detail):
+      GlassPanel {
+        VStack(alignment: .leading, spacing: MobileTheme.rowSpacing) {
+          cardHeader(detail.title, count: detail.refs.count)
+          Text(detail.summary)
+            .font(.caption)
+            .foregroundStyle(MobileTheme.textPrimary)
+          RefPill(label: "generated", ref: generatedText(detail.generatedAtMs))
+          ForEach(detail.refs, id: \.self) { ref in
+            RefPill(label: nil, ref: ref)
+          }
+        }
+      }
+    case let .unavailable(title, reason):
+      GlassPanel {
+        VStack(alignment: .leading, spacing: MobileTheme.rowSpacing) {
+          cardHeader(title, count: nil)
+          Text(reason)
+            .font(.caption)
+            .foregroundStyle(MobileTheme.textSecondary)
+        }
       }
     }
   }

--- a/apps/friday-ios/Sources/FridayMobileShellCore/HomeViewModel.swift
+++ b/apps/friday-ios/Sources/FridayMobileShellCore/HomeViewModel.swift
@@ -237,18 +237,90 @@ public enum HomeLoadState: Sendable, Equatable {
   }
 }
 
+public enum HomeReadDetailArm: Sendable, Equatable {
+  case runReadback(runId: String)
+  case providersDoctor(probe: String?)
+  case sessionList
+  case sessionOpen(agentSessionId: String)
+  case sessionLinkState(agentSessionId: String)
+  case runFileView(runId: String)
+  case activityNeedsMe(runId: String)
+
+  public var title: String {
+    switch self {
+    case .runReadback: return "Run readback"
+    case .providersDoctor: return "Provider doctor"
+    case .sessionList: return "Session list"
+    case .sessionOpen: return "Session open"
+    case .sessionLinkState: return "Session link state"
+    case .runFileView: return "Run files"
+    case .activityNeedsMe: return "Needs-me activity"
+    }
+  }
+}
+
+public struct HomeReadDetail: Sendable, Equatable {
+  public let title: String
+  public let generatedAtMs: Int64
+  public let summary: String
+  public let refs: [String]
+
+  public init(title: String, snapshot: ReadProjectionSnapshot) {
+    let raw = snapshot.raw
+    self.title = title
+    self.generatedAtMs = snapshot.generatedAtMs
+    self.summary = Self.summary(from: raw)
+    self.refs = Self.refs(from: raw)
+  }
+
+  private static func summary(from raw: [String: Any]) -> String {
+    let parts = [
+      firstString(raw, ["missionId", "mission_id"]).map { "mission=\($0)" },
+      firstString(raw, ["runId", "run_id"]).map { "run=\($0)" },
+      firstString(raw, ["status", "outcome"]).map { "status=\($0)" },
+      firstString(raw, ["truthLabel", "truth_label"]).map { "truth=\($0)" },
+    ].compactMap { $0 }
+    return parts.isEmpty ? "projection loaded" : parts.joined(separator: " | ")
+  }
+
+  private static func refs(from raw: [String: Any]) -> [String] {
+    let keys = [
+      "proofRef", "proof_ref", "evidenceRef", "evidence_ref", "providerRef", "provider_ref",
+      "channelRef", "channel_ref", "timelineRef", "timeline_ref", "receiptRef", "receipt_ref",
+    ]
+    var refs = keys.compactMap { raw[$0] as? String }
+    for key in ["proofRefs", "proof_refs", "evidenceRefs", "evidence_refs", "receiptRefs", "receipt_refs"] {
+      refs.append(contentsOf: raw[key] as? [String] ?? [])
+    }
+    var seen = Set<String>()
+    return refs.filter { !$0.isEmpty && seen.insert($0).inserted }
+  }
+
+  private static func firstString(_ raw: [String: Any], _ keys: [String]) -> String? {
+    keys.lazy.compactMap { raw[$0] as? String }.first
+  }
+}
+
+public enum HomeReadDetailState: Sendable, Equatable {
+  case idle
+  case loading(HomeReadDetailArm)
+  case loaded(HomeReadDetail)
+  case unavailable(title: String, reason: String)
+
+  public var isLoading: Bool {
+    if case .loading = self { return true }
+    return false
+  }
+}
+
 @MainActor
 public final class HomeViewModel: ObservableObject {
   @Published public private(set) var state: HomeLoadState = .idle
+  @Published public private(set) var detailState: HomeReadDetailState = .idle
 
-  /// The package's `FridayRustReadClient` is deliberately NOT `Sendable` (its `WorkbenchSnapshot`
-  /// carries a non-`Sendable` `raw: [String: Any]`), so awaiting its `nonisolated async`
-  /// `fetchWorkbench()` from this `@MainActor` VM would "send" main-actor state across the hop.
-  /// `nonisolated(unsafe)` drops the isolation and is SOUND here: the package clients are
-  /// `final class`, every stored property is an immutable `let` (no post-init mutation), and each
-  /// fetch builds a FRESH transport via `makeTransport()` — there is no shared mutable state to
-  /// race. We resolve the mismatch on the CONSUMER side (never editing the #677 package).
-  nonisolated(unsafe) private let client: FridayRustReadClient
+  /// The package's read protocol is `Sendable`; the view model still publishes only small
+  /// refs-only value projections, never the package snapshot's raw body map.
+  private let client: FridayRustReadClient
 
   /// - Parameter client: the read client. In production this is the real `SealedWSReadClient`
   ///   (built by `FridayClientFactory.makeReadClient`); a preview/debug build injects a mock.
@@ -269,6 +341,35 @@ public final class HomeViewModel: ObservableObject {
       state = .loaded(HomeProjection(snapshot))
     } catch {
       state = .unavailable(reason: Self.reason(for: error))
+    }
+  }
+
+  public func loadDetail(_ arm: HomeReadDetailArm) async {
+    detailState = .loading(arm)
+    do {
+      let snapshot = try await readDetail(arm)
+      detailState = .loaded(HomeReadDetail(title: arm.title, snapshot: snapshot))
+    } catch {
+      detailState = .unavailable(title: arm.title, reason: Self.reason(for: error))
+    }
+  }
+
+  private func readDetail(_ arm: HomeReadDetailArm) async throws -> ReadProjectionSnapshot {
+    switch arm {
+    case let .runReadback(runId):
+      return try await client.fetchRunReadback(runId: runId)
+    case let .providersDoctor(probe):
+      return try await client.fetchProvidersDoctor(probe: probe)
+    case .sessionList:
+      return try await client.fetchSessionList()
+    case let .sessionOpen(agentSessionId):
+      return try await client.fetchSessionOpen(agentSessionId: agentSessionId)
+    case let .sessionLinkState(agentSessionId):
+      return try await client.fetchSessionLinkState(agentSessionId: agentSessionId)
+    case let .runFileView(runId):
+      return try await client.fetchRunFileView(runId: runId)
+    case let .activityNeedsMe(runId):
+      return try await client.fetchActivityNeedsMe(runId: runId)
     }
   }
 

--- a/apps/friday-ios/Tests/FridayMobileShellCoreTests/HomeViewModelTests.swift
+++ b/apps/friday-ios/Tests/FridayMobileShellCoreTests/HomeViewModelTests.swift
@@ -28,12 +28,51 @@ final class HomeViewModelTests: XCTestCase {
   final class FakeReadClient: FridayRustReadClient, @unchecked Sendable {
     enum Script { case snapshot(WorkbenchSnapshot); case fail(FridayReadClientError) }
     let script: Script
+    private(set) var requestedDetails: [String] = []
     init(_ script: Script) { self.script = script }
     func fetchWorkbench() async throws -> WorkbenchSnapshot {
       switch script {
       case .snapshot(let s): return s
       case .fail(let e): throw e
       }
+    }
+
+    func fetchProvidersDoctor(probe: String?) async throws -> ReadProjectionSnapshot {
+      requestedDetails.append("providers:\(probe ?? "")")
+      return try detailSnapshot(kind: "providers", status: "ready", proofRef: "proof://provider/doctor")
+    }
+
+    func fetchSessionList() async throws -> ReadProjectionSnapshot {
+      requestedDetails.append("sessions")
+      return try detailSnapshot(kind: "sessions", status: "ready", proofRef: "proof://session/list")
+    }
+
+    func fetchRunReadback(runId: String) async throws -> ReadProjectionSnapshot {
+      requestedDetails.append("run:\(runId)")
+      return try detailSnapshot(kind: "run", status: "complete", runId: runId, proofRef: "proof://run/\(runId)")
+    }
+
+    func fetchActivityNeedsMe(runId: String) async throws -> ReadProjectionSnapshot {
+      requestedDetails.append("needs-me:\(runId)")
+      return try detailSnapshot(kind: "needs-me", status: "waiting", runId: runId, proofRef: "proof://needs/\(runId)")
+    }
+
+    private func detailSnapshot(
+      kind: String,
+      status: String,
+      runId: String? = nil,
+      proofRef: String
+    ) throws -> ReadProjectionSnapshot {
+      var raw: [String: Any] = [
+        "missionId": "mission-7",
+        "status": status,
+        "truthLabel": "friday_owned",
+        "proofRef": proofRef,
+        "evidenceRefs": ["proof://evidence/\(kind)"],
+      ]
+      if let runId { raw["runId"] = runId }
+      let data = try JSONSerialization.data(withJSONObject: raw)
+      return try ReadProjectionSnapshot(projectionJSON: data, generatedAtMs: 1_780_640_000_123)
     }
   }
 
@@ -118,6 +157,42 @@ final class HomeViewModelTests: XCTestCase {
     guard case .unavailable(let reason) = vm.state else { return XCTFail("expected .unavailable") }
     XCTAssertTrue(reason.contains("Friday is unavailable"), "reason: \(reason)")
     XCTAssertNil(vm.state.projection) // never a fabricated ready projection
+  }
+
+  func testLoadDetail_callsProviderDoctorReadArm() async throws {
+    let client = FakeReadClient(.snapshot(try sampleSnapshot()))
+    let vm = HomeViewModel(client: client)
+    await vm.loadDetail(.providersDoctor(probe: "anthropic"))
+    guard case let .loaded(detail) = vm.detailState else {
+      return XCTFail("expected detail .loaded, got \(vm.detailState)")
+    }
+    XCTAssertEqual(client.requestedDetails, ["providers:anthropic"])
+    XCTAssertEqual(detail.title, "Provider doctor")
+    XCTAssertEqual(detail.summary, "mission=mission-7 | status=ready | truth=friday_owned")
+    XCTAssertEqual(detail.refs, ["proof://provider/doctor", "proof://evidence/providers"])
+  }
+
+  func testLoadDetail_callsRunAndNeedsMeReadArms() async throws {
+    let client = FakeReadClient(.snapshot(try sampleSnapshot()))
+    let vm = HomeViewModel(client: client)
+    await vm.loadDetail(.runReadback(runId: "run-1"))
+    await vm.loadDetail(.activityNeedsMe(runId: "run-1"))
+    XCTAssertEqual(client.requestedDetails, ["run:run-1", "needs-me:run-1"])
+    guard case let .loaded(detail) = vm.detailState else {
+      return XCTFail("expected detail .loaded, got \(vm.detailState)")
+    }
+    XCTAssertEqual(detail.title, "Needs-me activity")
+    XCTAssertTrue(detail.refs.contains("proof://needs/run-1"))
+  }
+
+  func testLoadDetail_transportFailureIsHonestUnavailable() async {
+    let vm = HomeViewModel(client: FakeReadClient(.fail(.transport("server dark"))))
+    await vm.loadDetail(.sessionOpen(agentSessionId: "session-1"))
+    guard case let .unavailable(title, reason) = vm.detailState else {
+      return XCTFail("expected detail .unavailable, got \(vm.detailState)")
+    }
+    XCTAssertEqual(title, "Session open")
+    XCTAssertTrue(reason.contains("offline"), "reason: \(reason)")
   }
 }
 

--- a/apps/macos/FridayHubConsole/Sources/FridayHubConsole/DesktopProjectionScreens.swift
+++ b/apps/macos/FridayHubConsole/Sources/FridayHubConsole/DesktopProjectionScreens.swift
@@ -130,6 +130,8 @@ struct DesktopProjectionScreen: View {
       if !snapshot.statusLabels.isEmpty || !snapshot.runtimeFeedStatus.isHealthy {
         StatusBanner(snapshot: snapshot)
       }
+      detailActions(snapshot)
+      detailResult
 
       switch DesktopProjectionSurface(destination) {
       case .providerAdmin:
@@ -147,6 +149,88 @@ struct DesktopProjectionScreen: View {
       }
     }
     .padding(20)
+  }
+
+  private func detailActions(_ snapshot: WorkbenchSnapshot) -> some View {
+    GlassPanel {
+      VStack(alignment: .leading, spacing: HubTheme.rowSpacing) {
+        cardTitle("Read Arms")
+        HStack(spacing: 8) {
+          Button {
+            Task { await viewModel.loadDetail(.providersDoctor(probe: nil)) }
+          } label: {
+            Label("Providers", systemImage: "stethoscope")
+          }
+          .disabled(viewModel.detailState.isLoading)
+
+          Button {
+            Task { await viewModel.loadDetail(.sessionList) }
+          } label: {
+            Label("Sessions", systemImage: "rectangle.stack")
+          }
+          .disabled(viewModel.detailState.isLoading)
+
+          if let runId = snapshot.runOutcomeLearningCandidates.first?.runId, !runId.isEmpty {
+            Button {
+              Task { await viewModel.loadDetail(.runReadback(runId: runId)) }
+            } label: {
+              Label("Run", systemImage: "doc.text.magnifyingglass")
+            }
+            .disabled(viewModel.detailState.isLoading)
+
+            Button {
+              Task { await viewModel.loadDetail(.activityNeedsMe(runId: runId)) }
+            } label: {
+              Label("Needs Me", systemImage: "bell.badge")
+            }
+            .disabled(viewModel.detailState.isLoading)
+          }
+        }
+      }
+    }
+  }
+
+  @ViewBuilder
+  private var detailResult: some View {
+    switch viewModel.detailState {
+    case .idle:
+      EmptyView()
+    case let .loading(arm):
+      GlassPanel {
+        HStack(spacing: 12) {
+          ProgressView()
+          Text(arm.title)
+            .font(.system(size: 12))
+            .foregroundStyle(HubTheme.textSecondary)
+        }
+      }
+    case let .loaded(detail):
+      GlassPanel {
+        VStack(alignment: .leading, spacing: HubTheme.rowSpacing) {
+          HStack {
+            cardTitle(detail.title)
+            Spacer()
+            StatusChip(text: "\(detail.refs.count)", bg: HubTheme.chipNeutralBG, fg: HubTheme.chipNeutralFG)
+          }
+          Text(detail.summary)
+            .font(.system(size: 12))
+            .foregroundStyle(HubTheme.textPrimary)
+          RefPill(label: "generated", ref: "\(detail.generatedAtMs)")
+          ForEach(detail.refs, id: \.self) { ref in
+            RefPill(label: nil, ref: ref)
+          }
+        }
+      }
+    case let .unavailable(title, reason):
+      GlassPanel {
+        VStack(alignment: .leading, spacing: HubTheme.rowSpacing) {
+          cardTitle(title)
+          Text(reason)
+            .font(.system(size: 12))
+            .foregroundStyle(HubTheme.textSecondary)
+        }
+      }
+    }
   }
 
   private func providerStatus(_ snapshot: WorkbenchSnapshot) -> some View {

--- a/apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/OperationsOverviewViewModel.swift
+++ b/apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/OperationsOverviewViewModel.swift
@@ -32,6 +32,82 @@ public enum WorkbenchLoadState: Sendable, Equatable {
   }
 }
 
+public enum ReadProjectionDetailArm: Sendable, Equatable {
+  case runReadback(runId: String)
+  case providersDoctor(probe: String?)
+  case sessionList
+  case sessionOpen(agentSessionId: String)
+  case sessionLinkState(agentSessionId: String)
+  case runFileView(runId: String)
+  case activityNeedsMe(runId: String)
+
+  public var title: String {
+    switch self {
+    case .runReadback: return "Run readback"
+    case .providersDoctor: return "Provider doctor"
+    case .sessionList: return "Session list"
+    case .sessionOpen: return "Session open"
+    case .sessionLinkState: return "Session link state"
+    case .runFileView: return "Run files"
+    case .activityNeedsMe: return "Needs-me activity"
+    }
+  }
+}
+
+public struct ReadProjectionDetail: Sendable, Equatable {
+  public let title: String
+  public let generatedAtMs: Int64
+  public let summary: String
+  public let refs: [String]
+
+  public init(title: String, snapshot: ReadProjectionSnapshot) {
+    let raw = snapshot.raw
+    self.title = title
+    self.generatedAtMs = snapshot.generatedAtMs
+    self.summary = Self.summary(from: raw)
+    self.refs = Self.refs(from: raw)
+  }
+
+  private static func summary(from raw: [String: Any]) -> String {
+    let parts = [
+      firstString(raw, ["missionId", "mission_id"]).map { "mission=\($0)" },
+      firstString(raw, ["runId", "run_id"]).map { "run=\($0)" },
+      firstString(raw, ["status", "outcome"]).map { "status=\($0)" },
+      firstString(raw, ["truthLabel", "truth_label"]).map { "truth=\($0)" },
+    ].compactMap { $0 }
+    return parts.isEmpty ? "projection loaded" : parts.joined(separator: " | ")
+  }
+
+  private static func refs(from raw: [String: Any]) -> [String] {
+    let keys = [
+      "proofRef", "proof_ref", "evidenceRef", "evidence_ref", "providerRef", "provider_ref",
+      "channelRef", "channel_ref", "timelineRef", "timeline_ref", "receiptRef", "receipt_ref",
+    ]
+    var refs = keys.compactMap { raw[$0] as? String }
+    for key in ["proofRefs", "proof_refs", "evidenceRefs", "evidence_refs", "receiptRefs", "receipt_refs"] {
+      refs.append(contentsOf: raw[key] as? [String] ?? [])
+    }
+    var seen = Set<String>()
+    return refs.filter { !$0.isEmpty && seen.insert($0).inserted }
+  }
+
+  private static func firstString(_ raw: [String: Any], _ keys: [String]) -> String? {
+    keys.lazy.compactMap { raw[$0] as? String }.first
+  }
+}
+
+public enum ReadProjectionDetailState: Sendable, Equatable {
+  case idle
+  case loading(ReadProjectionDetailArm)
+  case loaded(ReadProjectionDetail)
+  case unavailable(title: String, reason: String)
+
+  public var isLoading: Bool {
+    if case .loading = self { return true }
+    return false
+  }
+}
+
 /// The state of a single spine-WRITE action (mission intake / memory decision).
 ///
 /// Mirrors `WorkbenchLoadState`'s honest vocabulary: a `.sent` action shows pending, a terminal
@@ -79,6 +155,7 @@ public enum WriteActionState: Sendable, Equatable {
 @MainActor
 public final class OperationsOverviewViewModel: ObservableObject {
   @Published public private(set) var state: WorkbenchLoadState = .idle
+  @Published public private(set) var detailState: ReadProjectionDetailState = .idle
   @Published public var selection: InspectorSelection = .none
 
   /// The mission-intake compose action's honest state.
@@ -138,6 +215,35 @@ public final class OperationsOverviewViewModel: ObservableObject {
   /// Focus a row in the proof inspector (read-only navigation).
   public func select(_ selection: InspectorSelection) {
     self.selection = selection
+  }
+
+  public func loadDetail(_ arm: ReadProjectionDetailArm) async {
+    detailState = .loading(arm)
+    do {
+      let snapshot = try await readDetail(arm)
+      detailState = .loaded(ReadProjectionDetail(title: arm.title, snapshot: snapshot))
+    } catch {
+      detailState = .unavailable(title: arm.title, reason: Self.reason(for: error))
+    }
+  }
+
+  private func readDetail(_ arm: ReadProjectionDetailArm) async throws -> ReadProjectionSnapshot {
+    switch arm {
+    case let .runReadback(runId):
+      return try await client.fetchRunReadback(runId: runId)
+    case let .providersDoctor(probe):
+      return try await client.fetchProvidersDoctor(probe: probe)
+    case .sessionList:
+      return try await client.fetchSessionList()
+    case let .sessionOpen(agentSessionId):
+      return try await client.fetchSessionOpen(agentSessionId: agentSessionId)
+    case let .sessionLinkState(agentSessionId):
+      return try await client.fetchSessionLinkState(agentSessionId: agentSessionId)
+    case let .runFileView(runId):
+      return try await client.fetchRunFileView(runId: runId)
+    case let .activityNeedsMe(runId):
+      return try await client.fetchActivityNeedsMe(runId: runId)
+    }
   }
 
   // MARK: - Spine-WRITE drivers (Lane-D entry-point-A organic loop)

--- a/apps/macos/FridayHubConsole/Tests/FridayHubConsoleCoreTests/OperationsOverviewViewModelTests.swift
+++ b/apps/macos/FridayHubConsole/Tests/FridayHubConsoleCoreTests/OperationsOverviewViewModelTests.swift
@@ -414,6 +414,57 @@ struct StaticWorkbenchReadClient: FridayRustReadClient {
   }
 }
 
+final class DetailReadClient: FridayRustReadClient, @unchecked Sendable {
+  private let lock = NSLock()
+  private var _requested: [String] = []
+  var failWith: FridayReadClientError?
+
+  var requested: [String] {
+    lock.withLock { _requested }
+  }
+
+  func fetchWorkbench() async throws -> FridayRustClient.WorkbenchSnapshot {
+    try MockReadClient.representativeWireSnapshot()
+  }
+
+  func fetchProvidersDoctor(probe: String?) async throws -> ReadProjectionSnapshot {
+    try record("providers:\(probe ?? "")", kind: "providers", status: "ready", proofRef: "proof://provider/doctor")
+  }
+
+  func fetchSessionList() async throws -> ReadProjectionSnapshot {
+    try record("sessions", kind: "sessions", status: "ready", proofRef: "proof://session/list")
+  }
+
+  func fetchRunReadback(runId: String) async throws -> ReadProjectionSnapshot {
+    try record("run:\(runId)", kind: "run", status: "complete", runId: runId, proofRef: "proof://run/\(runId)")
+  }
+
+  func fetchActivityNeedsMe(runId: String) async throws -> ReadProjectionSnapshot {
+    try record("needs-me:\(runId)", kind: "needs-me", status: "waiting", runId: runId, proofRef: "proof://needs/\(runId)")
+  }
+
+  private func record(
+    _ request: String,
+    kind: String,
+    status: String,
+    runId: String? = nil,
+    proofRef: String
+  ) throws -> ReadProjectionSnapshot {
+    if let failWith { throw failWith }
+    lock.withLock { _requested.append(request) }
+    var raw: [String: Any] = [
+      "missionId": "mission-desktop",
+      "status": status,
+      "truthLabel": "friday_owned",
+      "proofRef": proofRef,
+      "evidenceRefs": ["proof://evidence/\(kind)"],
+    ]
+    if let runId { raw["runId"] = runId }
+    let data = try JSONSerialization.data(withJSONObject: raw)
+    return try ReadProjectionSnapshot(projectionJSON: data, generatedAtMs: 1_780_640_000_123)
+  }
+}
+
 func snapshotWithWorkItems(
   missionId: String,
   fridayConversationId: String,
@@ -446,6 +497,56 @@ func snapshotWithWorkItems(
     memoryCandidates: [],
     capabilityStates: [],
     transcriptSections: [])
+}
+
+@Test
+@MainActor
+func loadDetailCallsProviderDoctorReadArm() async {
+  let client = DetailReadClient()
+  let vm = OperationsOverviewViewModel(client: client)
+  await vm.loadDetail(.providersDoctor(probe: "anthropic"))
+
+  #expect(client.requested == ["providers:anthropic"])
+  guard case let .loaded(detail) = vm.detailState else {
+    Issue.record("expected detail .loaded, got \(vm.detailState)")
+    return
+  }
+  #expect(detail.title == "Provider doctor")
+  #expect(detail.summary == "mission=mission-desktop | status=ready | truth=friday_owned")
+  #expect(detail.refs == ["proof://provider/doctor", "proof://evidence/providers"])
+}
+
+@Test
+@MainActor
+func loadDetailCallsRunAndNeedsMeReadArms() async {
+  let client = DetailReadClient()
+  let vm = OperationsOverviewViewModel(client: client)
+  await vm.loadDetail(.runReadback(runId: "run-desktop"))
+  await vm.loadDetail(.activityNeedsMe(runId: "run-desktop"))
+
+  #expect(client.requested == ["run:run-desktop", "needs-me:run-desktop"])
+  guard case let .loaded(detail) = vm.detailState else {
+    Issue.record("expected detail .loaded, got \(vm.detailState)")
+    return
+  }
+  #expect(detail.title == "Needs-me activity")
+  #expect(detail.refs.contains("proof://needs/run-desktop"))
+}
+
+@Test
+@MainActor
+func loadDetailFailureRendersUnavailable() async {
+  let client = DetailReadClient()
+  client.failWith = .transport("detail server dark")
+  let vm = OperationsOverviewViewModel(client: client)
+  await vm.loadDetail(.sessionList)
+
+  guard case let .unavailable(title, reason) = vm.detailState else {
+    Issue.record("expected detail .unavailable, got \(vm.detailState)")
+    return
+  }
+  #expect(title == "Session list")
+  #expect(reason.contains("offline"))
 }
 
 @Test


### PR DESCRIPTION
## Summary\n- Add refs-only read projection detail state to mobile and desktop view models.\n- Wire mobile/desktop projection surfaces to trigger provider/session/run/needs-me read arms exposed by #1004.\n- Cover the consumer calls and honest-unavailable detail states with focused tests.\n\n## Verification\n- swift test --package-path apps/friday-ios --filter HomeViewModelTests\n- swift test --package-path apps/macos/FridayHubConsole --filter OperationsOverviewViewModelTests\n- swift test --package-path apps/friday-ios\n- swift test --package-path apps/macos/FridayHubConsole\n- apps/friday-ios/build-sim.sh\n- git diff --check\n\nStacked on #1004; retarget to main after #1004 lands.