### PR TITLE
Fail-close learned fact revocation gaps

### DIFF
--- a/src/api/http/routes/friday-memory-routes.ts
+++ b/src/api/http/routes/friday-memory-routes.ts
@@ -185,6 +185,14 @@ function readPrincipalUserId(principal: unknown): string {
   return userId;
 }
 
+function learnedFactRevocationUnavailable(): never {
+  throw new FridayDomainError(
+    "MEMORY_LEARNED_FACT_REVOCATION_UNAVAILABLE",
+    "Learned fact revocation is unavailable in this runtime",
+    { httpStatus: 503 },
+  );
+}
+
 function readStoreMetadata(body: FridayMemoryStoreRequest): Record<string, unknown> | undefined {
   return body.metadata && typeof body.metadata === "object" && !Array.isArray(body.metadata)
     ? body.metadata as Record<string, unknown>
@@ -599,11 +607,7 @@ export function createFridayMemoryRoutes(
         const { id } = ctx.params as { id: string };
         if (isLearnedFactSyntheticId(id)) {
           if (!deps.deleteLearnedFact) {
-            throw new FridayDomainError(
-              FRIDAY_MEMORY_ERROR_CODES.NOT_FOUND,
-              `Memory item '${id}' not found`,
-              { httpStatus: 404 },
-            );
+            learnedFactRevocationUnavailable();
           }
           const key = readLearnedFactKeyFromSyntheticId(id);
           if (!key) {

--- a/src/api/http/routes/friday-uix-routes.ts
+++ b/src/api/http/routes/friday-uix-routes.ts
@@ -68,6 +68,14 @@ function requireUserId(principal: { userId?: string } | null): string {
   return principal.userId;
 }
 
+function learnedFactRevocationUnavailable(): never {
+  throw new FridayDomainError(
+    "UIX_LEARNED_FACT_REVOCATION_UNAVAILABLE",
+    "Learned fact revocation is unavailable in this runtime",
+    { httpStatus: 503 },
+  );
+}
+
 function readText(body: unknown, key: string): string {
   if (!body || typeof body !== "object") {
     throw new FridayDomainError("VALIDATION_ERROR", `${key} is required`, { httpStatus: 400 });
@@ -535,7 +543,10 @@ export function createFridayUixRoutes(
       auth: { public: true },
       async handler(ctx): Promise<{ deletedCount: number }> {
         const userId = requireUserId(ctx.principal);
-        return { deletedCount: deps.clearLearnedFacts ? deps.clearLearnedFacts({ userId }) : 0 };
+        if (!deps.clearLearnedFacts) {
+          learnedFactRevocationUnavailable();
+        }
+        return { deletedCount: deps.clearLearnedFacts({ userId }) };
       },
     },
     {
@@ -581,7 +592,10 @@ export function createFridayUixRoutes(
         if (key.length === 0) {
           throw new FridayDomainError("VALIDATION_ERROR", "factKey is required", { httpStatus: 400 });
         }
-        if (!deps.deleteLearnedFact || !deps.deleteLearnedFact({ userId, key })) {
+        if (!deps.deleteLearnedFact) {
+          learnedFactRevocationUnavailable();
+        }
+        if (!deps.deleteLearnedFact({ userId, key })) {
           throw new FridayDomainError("UIX_PREFERENCE_NOT_FOUND", `Learned fact '${key}' was not found`, { httpStatus: 404 });
         }
         return { deleted: true, key };

--- a/test/unit/api/http/routes/friday-memory-routes.test.ts
+++ b/test/unit/api/http/routes/friday-memory-routes.test.ts
@@ -511,6 +511,34 @@ describe("FridayMemoryRoutes", () => {
     expect(deleteLearnedFact).toHaveBeenCalledWith({ userId: "user-1", key: "pref:display_name" });
   });
 
+  it("delete handler fails closed for learned fact ids when the revocation writer is unavailable", async () => {
+    const route = findRoute("memory.delete");
+
+    await expect(
+      route.handler(makeCtx({ params: { id: "learned-fact:pref:display_name" } })),
+    ).rejects.toMatchObject({
+      code: "MEMORY_LEARNED_FACT_REVOCATION_UNAVAILABLE",
+      httpStatus: 503,
+    });
+  });
+
+  it("delete handler keeps learned fact not-found distinct when the revocation writer is wired", async () => {
+    const deleteLearnedFact = vi.fn(() => false);
+    routes = createFridayMemoryRoutes({
+      memoryGuardFactory,
+      deleteLearnedFact,
+    });
+    const route = findRoute("memory.delete");
+
+    await expect(
+      route.handler(makeCtx({ params: { id: "learned-fact:pref:display_name" } })),
+    ).rejects.toMatchObject({
+      code: FRIDAY_MEMORY_ERROR_CODES.NOT_FOUND,
+      httpStatus: 404,
+    });
+    expect(deleteLearnedFact).toHaveBeenCalledWith({ userId: "user-1", key: "pref:display_name" });
+  });
+
   // ─── List handler ───
 
   it("list handler returns items", async () => {

--- a/test/unit/api/http/routes/friday-uix-routes.test.ts
+++ b/test/unit/api/http/routes/friday-uix-routes.test.ts
@@ -486,6 +486,39 @@ describe("FridayUixRoutes", () => {
     expect(deleteLearnedFact).toHaveBeenCalledWith({ userId: "user-1", key: "pref:display_name" });
   });
 
+  it("fails closed when learned fact revocation writers are unavailable", async () => {
+    const service = makeService();
+    const routes = createFridayUixRoutes({ service });
+    const clearRoute = routes.find((entry) => entry.operationId === "uix.learnedfacts.clear")!;
+    const deleteRoute = routes.find((entry) => entry.operationId === "uix.learnedfacts.delete")!;
+
+    await expect(clearRoute.handler(makeCtx())).rejects.toMatchObject({
+      code: "UIX_LEARNED_FACT_REVOCATION_UNAVAILABLE",
+      httpStatus: 503,
+    });
+    await expect(
+      deleteRoute.handler(makeCtx({ params: { factKey: encodeURIComponent("pref:display_name") } })),
+    ).rejects.toMatchObject({
+      code: "UIX_LEARNED_FACT_REVOCATION_UNAVAILABLE",
+      httpStatus: 503,
+    });
+  });
+
+  it("keeps learned fact delete not-found distinct when the revocation writer is wired", async () => {
+    const service = makeService();
+    const deleteLearnedFact = vi.fn(() => false);
+    const routes = createFridayUixRoutes({ service, deleteLearnedFact });
+    const deleteRoute = routes.find((entry) => entry.operationId === "uix.learnedfacts.delete")!;
+
+    await expect(
+      deleteRoute.handler(makeCtx({ params: { factKey: encodeURIComponent("pref:display_name") } })),
+    ).rejects.toMatchObject({
+      code: "UIX_PREFERENCE_NOT_FOUND",
+      httpStatus: 404,
+    });
+    expect(deleteLearnedFact).toHaveBeenCalledWith({ userId: "user-1", key: "pref:display_name" });
+  });
+
   it("lists learned facts with explicit memory and context-use boundaries", async () => {
     const service = makeService();
     const routes = createFridayUixRoutes({


### PR DESCRIPTION
## Summary
- make learned-fact revocation surfaces fail closed when the writer dependency is absent
- distinguish writer-unavailable 503 from writer-present not-found 404
- cover UIX clear/delete and synthetic memory learned-fact delete regressions

## Verification
- npx vitest run --project default test/unit/api/http/routes/friday-uix-routes.test.ts test/unit/api/http/routes/friday-memory-routes.test.ts
- npm run typecheck:src
- git diff --check

## Truth boundary
This is an L1 fail-closed behavior tightening only. It is not strict OG9 operator-origin organic, not D20/B4 true-sign evidence, and not GO-LIVE.