### PR TITLE
Expose remaining UI read arm actions

### DIFF
--- a/apps/friday-ios/Sources/FridayMobileShell/FridayProjectionScreens.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayProjectionScreens.swift
@@ -193,6 +193,27 @@ struct FridayProjectionScreen: View {
           }
           .disabled(viewModel.detailState.isLoading)
         }
+        if let agentSessionId = projection.agentSessionId {
+          HStack(spacing: 8) {
+            Button {
+              Task { await viewModel.loadDetail(.sessionOpen(agentSessionId: agentSessionId)) }
+            } label: {
+              Label("Open", systemImage: "text.bubble")
+            }
+            .disabled(viewModel.detailState.isLoading)
+
+            Button {
+              Task { await viewModel.loadDetail(.sessionLinkState(agentSessionId: agentSessionId)) }
+            } label: {
+              Label("Link", systemImage: "link")
+            }
+            .disabled(viewModel.detailState.isLoading)
+          }
+        } else {
+          Text("Session detail arms require an agent session ref in the projection.")
+            .font(.caption)
+            .foregroundStyle(MobileTheme.textSecondary)
+        }
         if let runId = projection.runOutcomeLearningCandidates.first?.runId, !runId.isEmpty {
           HStack(spacing: 8) {
             Button {
@@ -203,12 +224,18 @@ struct FridayProjectionScreen: View {
             .disabled(viewModel.detailState.isLoading)
 
             Button {
-              Task { await viewModel.loadDetail(.activityNeedsMe(runId: runId)) }
+              Task { await viewModel.loadDetail(.runFileView(runId: runId)) }
             } label: {
-              Label("Needs Me", systemImage: "bell.badge")
+              Label("Files", systemImage: "folder")
             }
             .disabled(viewModel.detailState.isLoading)
           }
+          Button {
+            Task { await viewModel.loadDetail(.activityNeedsMe(runId: runId)) }
+          } label: {
+            Label("Needs Me", systemImage: "bell.badge")
+          }
+          .disabled(viewModel.detailState.isLoading)
         }
       }
     }

--- a/apps/friday-ios/Sources/FridayMobileShellCore/HomeViewModel.swift
+++ b/apps/friday-ios/Sources/FridayMobileShellCore/HomeViewModel.swift
@@ -37,6 +37,8 @@ public struct HomeProjection: Sendable, Equatable {
   public let runtimeFeedStatus: String
   /// Status labels the projection surfaced (`stale`/`offline`/`error`). Rides AS-IS.
   public let statusLabels: [String]
+  /// Optional owner-gated agent session ref for session-specific read arms.
+  public let agentSessionId: String?
   public let routeDecisionSummary: String?
   /// Work-item id REFS (counts/ids only — never a body).
   public let workItemIds: [String]
@@ -59,6 +61,10 @@ public struct HomeProjection: Sendable, Equatable {
     self.fridayConversationId = snapshot.fridayConversationId
     self.runtimeFeedStatus = snapshot.runtimeFeedStatus
     self.statusLabels = snapshot.statusLabels
+    self.agentSessionId = Self.firstString(
+      raw,
+      ["agentSessionId", "agent_session_id", "fridaySessionId", "friday_session_id"])
+      ?? Self.firstStringArray(raw, ["agentSessionIds", "agent_session_ids", "fridaySessionIds", "friday_session_ids"]).first
     self.routeDecisionSummary = snapshot.routeDecisionSummary
     self.workItemIds = snapshot.workItemIds
     self.routeSelected = route?["selectedRoute"] as? String
@@ -156,6 +162,16 @@ public struct HomeProjection: Sendable, Equatable {
           capturedAt: (event["capturedAt"] as? String) ?? "")
       }
     }
+  }
+
+  private static func firstString(_ raw: [String: Any], _ keys: [String]) -> String? {
+    keys.lazy.compactMap { raw[$0] as? String }
+      .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+      .first { !$0.isEmpty }
+  }
+
+  private static func firstStringArray(_ raw: [String: Any], _ keys: [String]) -> [String] {
+    keys.lazy.compactMap { raw[$0] as? [String] }.first ?? []
   }
 }
 

--- a/apps/friday-ios/Tests/FridayMobileShellCoreTests/HomeViewModelTests.swift
+++ b/apps/friday-ios/Tests/FridayMobileShellCoreTests/HomeViewModelTests.swift
@@ -47,9 +47,24 @@ final class HomeViewModelTests: XCTestCase {
       return try detailSnapshot(kind: "sessions", status: "ready", proofRef: "proof://session/list")
     }
 
+    func fetchSessionOpen(agentSessionId: String) async throws -> ReadProjectionSnapshot {
+      requestedDetails.append("session-open:\(agentSessionId)")
+      return try detailSnapshot(kind: "session-open", status: "open", proofRef: "proof://session/open/\(agentSessionId)")
+    }
+
+    func fetchSessionLinkState(agentSessionId: String) async throws -> ReadProjectionSnapshot {
+      requestedDetails.append("session-link:\(agentSessionId)")
+      return try detailSnapshot(kind: "session-link", status: "connected", proofRef: "proof://session/link/\(agentSessionId)")
+    }
+
     func fetchRunReadback(runId: String) async throws -> ReadProjectionSnapshot {
       requestedDetails.append("run:\(runId)")
       return try detailSnapshot(kind: "run", status: "complete", runId: runId, proofRef: "proof://run/\(runId)")
+    }
+
+    func fetchRunFileView(runId: String) async throws -> ReadProjectionSnapshot {
+      requestedDetails.append("run-files:\(runId)")
+      return try detailSnapshot(kind: "run-files", status: "ready", runId: runId, proofRef: "proof://run-files/\(runId)")
     }
 
     func fetchActivityNeedsMe(runId: String) async throws -> ReadProjectionSnapshot {
@@ -63,6 +78,9 @@ final class HomeViewModelTests: XCTestCase {
       runId: String? = nil,
       proofRef: String
     ) throws -> ReadProjectionSnapshot {
+      if case .fail(let error) = script {
+        throw error
+      }
       var raw: [String: Any] = [
         "missionId": "mission-7",
         "status": status,
@@ -83,6 +101,7 @@ final class HomeViewModelTests: XCTestCase {
       "fridayConversationId": "conv-7",
       "runtimeFeedStatus": "live_rust_hub_projection",
       "statusLabels": ["stale"],
+      "agentSessionId": "session-1",
       "routeDecision": {
         "advisorSummary": "route: deepseek (refs-only)",
         "selectedRoute": "deepseek",
@@ -122,6 +141,7 @@ final class HomeViewModelTests: XCTestCase {
     XCTAssertEqual(p.missionId, "mission-7")
     XCTAssertEqual(p.runtimeFeedStatus, "live_rust_hub_projection") // truth label rides AS-IS
     XCTAssertEqual(p.statusLabels, ["stale"])                       // no label upgrade
+    XCTAssertEqual(p.agentSessionId, "session-1")
     XCTAssertEqual(p.workItemIds, ["wi-1", "wi-2"])                 // refs/ids only (INV-5)
     XCTAssertTrue(vm.state.isOnline)
   }
@@ -183,6 +203,24 @@ final class HomeViewModelTests: XCTestCase {
     }
     XCTAssertEqual(detail.title, "Needs-me activity")
     XCTAssertTrue(detail.refs.contains("proof://needs/run-1"))
+  }
+
+  func testLoadDetail_callsSessionAndRunFileReadArms() async throws {
+    let client = FakeReadClient(.snapshot(try sampleSnapshot()))
+    let vm = HomeViewModel(client: client)
+    await vm.loadDetail(.sessionOpen(agentSessionId: "session-1"))
+    await vm.loadDetail(.sessionLinkState(agentSessionId: "session-1"))
+    await vm.loadDetail(.runFileView(runId: "run-1"))
+    XCTAssertEqual(client.requestedDetails, [
+      "session-open:session-1",
+      "session-link:session-1",
+      "run-files:run-1",
+    ])
+    guard case let .loaded(detail) = vm.detailState else {
+      return XCTFail("expected detail .loaded, got \(vm.detailState)")
+    }
+    XCTAssertEqual(detail.title, "Run files")
+    XCTAssertTrue(detail.refs.contains("proof://run-files/run-1"))
   }
 
   func testLoadDetail_transportFailureIsHonestUnavailable() async {

--- a/apps/macos/FridayHubConsole/Sources/FridayHubConsole/DesktopProjectionScreens.swift
+++ b/apps/macos/FridayHubConsole/Sources/FridayHubConsole/DesktopProjectionScreens.swift
@@ -170,11 +170,34 @@ struct DesktopProjectionScreen: View {
           }
           .disabled(viewModel.detailState.isLoading)
 
+          if let agentSessionId = snapshot.agentSessionId {
+            Button {
+              Task { await viewModel.loadDetail(.sessionOpen(agentSessionId: agentSessionId)) }
+            } label: {
+              Label("Open", systemImage: "text.bubble")
+            }
+            .disabled(viewModel.detailState.isLoading)
+
+            Button {
+              Task { await viewModel.loadDetail(.sessionLinkState(agentSessionId: agentSessionId)) }
+            } label: {
+              Label("Link", systemImage: "link")
+            }
+            .disabled(viewModel.detailState.isLoading)
+          }
+
           if let runId = snapshot.runOutcomeLearningCandidates.first?.runId, !runId.isEmpty {
             Button {
               Task { await viewModel.loadDetail(.runReadback(runId: runId)) }
             } label: {
               Label("Run", systemImage: "doc.text.magnifyingglass")
+            }
+            .disabled(viewModel.detailState.isLoading)
+
+            Button {
+              Task { await viewModel.loadDetail(.runFileView(runId: runId)) }
+            } label: {
+              Label("Files", systemImage: "folder")
             }
             .disabled(viewModel.detailState.isLoading)
 
@@ -185,6 +208,11 @@ struct DesktopProjectionScreen: View {
             }
             .disabled(viewModel.detailState.isLoading)
           }
+        }
+        if snapshot.agentSessionId == nil {
+          Text("Session detail arms require an agent session ref in the projection.")
+            .font(.system(size: 11))
+            .foregroundStyle(HubTheme.textSecondary)
         }
       }
     }

--- a/apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/WorkbenchSnapshot.swift
+++ b/apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/WorkbenchSnapshot.swift
@@ -408,6 +408,7 @@ public struct MissionWorkbenchRouteDecision: Codable, Sendable, Equatable {
 public struct WorkbenchSnapshot: Codable, Sendable, Equatable {
   public let missionId: String
   public let fridayConversationId: String
+  public let agentSessionId: String?
   public let runtimeFeedStatus: MissionWorkbenchRuntimeFeedStatus
   public let statusLabels: [MissionWorkbenchStatusLabel]
   public let duplicatePreflight: MissionWorkbenchDuplicatePreflight
@@ -424,6 +425,7 @@ public struct WorkbenchSnapshot: Codable, Sendable, Equatable {
   public init(
     missionId: String,
     fridayConversationId: String,
+    agentSessionId: String? = nil,
     runtimeFeedStatus: MissionWorkbenchRuntimeFeedStatus,
     statusLabels: [MissionWorkbenchStatusLabel],
     duplicatePreflight: MissionWorkbenchDuplicatePreflight,
@@ -439,6 +441,7 @@ public struct WorkbenchSnapshot: Codable, Sendable, Equatable {
   ) {
     self.missionId = missionId
     self.fridayConversationId = fridayConversationId
+    self.agentSessionId = agentSessionId
     self.runtimeFeedStatus = runtimeFeedStatus
     self.statusLabels = statusLabels
     self.duplicatePreflight = duplicatePreflight

--- a/apps/macos/FridayHubConsole/Tests/FridayHubConsoleCoreTests/OperationsOverviewViewModelTests.swift
+++ b/apps/macos/FridayHubConsole/Tests/FridayHubConsoleCoreTests/OperationsOverviewViewModelTests.swift
@@ -435,8 +435,20 @@ final class DetailReadClient: FridayRustReadClient, @unchecked Sendable {
     try record("sessions", kind: "sessions", status: "ready", proofRef: "proof://session/list")
   }
 
+  func fetchSessionOpen(agentSessionId: String) async throws -> ReadProjectionSnapshot {
+    try record("session-open:\(agentSessionId)", kind: "session-open", status: "open", proofRef: "proof://session/open/\(agentSessionId)")
+  }
+
+  func fetchSessionLinkState(agentSessionId: String) async throws -> ReadProjectionSnapshot {
+    try record("session-link:\(agentSessionId)", kind: "session-link", status: "connected", proofRef: "proof://session/link/\(agentSessionId)")
+  }
+
   func fetchRunReadback(runId: String) async throws -> ReadProjectionSnapshot {
     try record("run:\(runId)", kind: "run", status: "complete", runId: runId, proofRef: "proof://run/\(runId)")
+  }
+
+  func fetchRunFileView(runId: String) async throws -> ReadProjectionSnapshot {
+    try record("run-files:\(runId)", kind: "run-files", status: "ready", runId: runId, proofRef: "proof://run-files/\(runId)")
   }
 
   func fetchActivityNeedsMe(runId: String) async throws -> ReadProjectionSnapshot {
@@ -531,6 +543,28 @@ func loadDetailCallsRunAndNeedsMeReadArms() async {
   }
   #expect(detail.title == "Needs-me activity")
   #expect(detail.refs.contains("proof://needs/run-desktop"))
+}
+
+@Test
+@MainActor
+func loadDetailCallsSessionAndRunFileReadArms() async {
+  let client = DetailReadClient()
+  let vm = OperationsOverviewViewModel(client: client)
+  await vm.loadDetail(.sessionOpen(agentSessionId: "session-desktop"))
+  await vm.loadDetail(.sessionLinkState(agentSessionId: "session-desktop"))
+  await vm.loadDetail(.runFileView(runId: "run-desktop"))
+
+  #expect(client.requested == [
+    "session-open:session-desktop",
+    "session-link:session-desktop",
+    "run-files:run-desktop",
+  ])
+  guard case let .loaded(detail) = vm.detailState else {
+    Issue.record("expected detail .loaded, got \(vm.detailState)")
+    return
+  }
+  #expect(detail.title == "Run files")
+  #expect(detail.refs.contains("proof://run-files/run-desktop"))
 }
 
 @Test


### PR DESCRIPTION
## Summary
- expose session open/link-state and run file-view read arms in mobile + desktop projection screens
- parse optional agent session refs from read projections and render an honest disabled reason when absent
- add positive VM coverage for session-open/session-link/run-file read arms on both clients

## Verification
- swift test --package-path apps/friday-ios --filter HomeViewModelTests
- swift test --package-path apps/macos/FridayHubConsole --filter OperationsOverviewViewModelTests
- swift test --package-path apps/friday-ios
- swift test --package-path apps/macos/FridayHubConsole
- apps/friday-ios/build-sim.sh
- git diff --check

## Truth boundary
This improves mobile/desktop read-arm usability only. It is still agent/developer verification, not strict OG9 operator-origin organic, not D20/B4 true-sign evidence, and not GO-LIVE.