### PR TITLE
Build A1 distinct learning signals

### DIFF
--- a/rust-core/crates/friday-hub/src/lib.rs
+++ b/rust-core/crates/friday-hub/src/lib.rs
@@ -17237,7 +17237,10 @@ mod tests {
         assert!(
             on.contains("Confirmed run-outcome learning signals")
                 && on.contains("preference")
-                && on.contains("refs-only run outcome: turns=3; executed_tools=1")
+                && on.contains("candidate_kind=preference")
+                && on.contains("consumer=recall-preference")
+                && on.contains("turns=3; executed_tools=1")
+                && on.contains("refs_only=true")
                 && on.contains("friday://agent-run/run-a1-drive"),
             "flag-ON must inject the confirmed refs-only learning signal: {on:?}"
         );

--- a/rust-core/crates/friday-hub/src/runtime.rs
+++ b/rust-core/crates/friday-hub/src/runtime.rs
@@ -7607,7 +7607,10 @@ mod tests {
             assert!(
                 on.contains("Confirmed run-outcome learning signals")
                     && on.contains("preference")
-                    && on.contains("refs-only run outcome: turns=3; executed_tools=1")
+                    && on.contains("candidate_kind=preference")
+                    && on.contains("consumer=recall-preference")
+                    && on.contains("turns=3; executed_tools=1")
+                    && on.contains("refs_only=true")
                     && on.contains("friday://agent-run/run-a1-source"),
                 "flag-ON session recall must inject the confirmed refs-only A1 signal: {on:?}"
             );

--- a/rust-core/crates/friday-storage/src/learning_candidate.rs
+++ b/rust-core/crates/friday-storage/src/learning_candidate.rs
@@ -117,6 +117,25 @@ const MIN_CONFIRMED_TURNS: i64 = 1;
 const MIN_CONFIRMED_EXECUTED_TOOLS: i64 = 1;
 const MAX_ELIGIBILITY_SCAN_LIMIT: i64 = 256;
 
+fn run_outcome_candidate_summary(
+    kind: RunOutcomeLearningKind,
+    turns: i64,
+    executed_tools: i64,
+) -> String {
+    let signal = match kind {
+        RunOutcomeLearningKind::Preference => {
+            "candidate_kind=preference; consumer=recall-preference; confirm_required=true"
+        }
+        RunOutcomeLearningKind::Reflex => {
+            "candidate_kind=reflex; consumer=governance-only; confirm_required=true"
+        }
+        RunOutcomeLearningKind::WorldModel => {
+            "candidate_kind=world_model; consumer=recall-world-model; confirm_required=true"
+        }
+    };
+    format!("{signal}; turns={turns}; executed_tools={executed_tools}; refs_only=true")
+}
+
 pub fn record_run_outcome_candidates(
     conn: &Connection,
     run_id: &str,
@@ -130,8 +149,7 @@ pub fn record_run_outcome_candidates(
         let mut inserted = 0usize;
         for kind in RunOutcomeLearningKind::ALL {
             let candidate_id = format!("a1:{run_id}:{}", kind.as_str());
-            let summary =
-                format!("refs-only run outcome: turns={turns}; executed_tools={executed_tools}");
+            let summary = run_outcome_candidate_summary(kind, turns, executed_tools);
             inserted += tx.execute(
                 "INSERT OR IGNORE INTO run_outcome_learning_candidate
                     (candidate_id, run_id, session_id, kind, state, evidence_ref, summary,

--- a/rust-core/crates/friday-storage/tests/learning_candidate.rs
+++ b/rust-core/crates/friday-storage/tests/learning_candidate.rs
@@ -85,8 +85,51 @@ fn record_candidates_is_refs_only_pending_and_idempotent_per_run() {
         assert_eq!(row.evidence_ref, "friday://agent-run/run-a1");
         assert!(row.summary.contains("turns=2"));
         assert!(row.summary.contains("executed_tools=1"));
+        assert!(row.summary.contains("refs_only=true"));
+        assert!(row.summary.contains("confirm_required=true"));
         assert!(!format!("{row:?}").contains("PONG"));
     }
+}
+
+#[test]
+fn record_candidates_builds_distinct_kind_signals_without_body_text() {
+    let db = Db::open_hub(&temp_db_path("a1-learning-kind-signals")).unwrap();
+
+    learning_candidate::record_run_outcome_candidates(
+        db.conn(),
+        "run-kind-signals",
+        Some("sess-kind-signals"),
+        4,
+        2,
+        10_000,
+    )
+    .unwrap();
+
+    let rows =
+        learning_candidate::list_run_outcome_candidates_for_run(db.conn(), "run-kind-signals")
+            .unwrap();
+    let preference = rows
+        .iter()
+        .find(|row| row.kind == RunOutcomeLearningKind::Preference)
+        .unwrap();
+    let reflex = rows
+        .iter()
+        .find(|row| row.kind == RunOutcomeLearningKind::Reflex)
+        .unwrap();
+    let world_model = rows
+        .iter()
+        .find(|row| row.kind == RunOutcomeLearningKind::WorldModel)
+        .unwrap();
+
+    assert!(preference.summary.contains("candidate_kind=preference"));
+    assert!(preference.summary.contains("consumer=recall-preference"));
+    assert!(reflex.summary.contains("candidate_kind=reflex"));
+    assert!(reflex.summary.contains("consumer=governance-only"));
+    assert!(world_model.summary.contains("candidate_kind=world_model"));
+    assert!(world_model.summary.contains("consumer=recall-world-model"));
+    assert_ne!(preference.summary, reflex.summary);
+    assert_ne!(preference.summary, world_model.summary);
+    assert!(rows.iter().all(|row| !row.summary.contains("PONG")));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- split A1 run-outcome candidate summaries into distinct preference/reflex/world_model signals
- keep signals refs-only and confirm-gated; preference/world_model are recall consumers, reflex remains governance-only
- update recall assertions so flag-on behavior proves the consumer-specific signal shape

## Truth labels
- built-DARK mechanism work only; this does not claim A1 live-done or organic completion
- organic=0 remains true until strict OG9 operator-origin traffic lands
- signing remains operator-only; no operator private key was read or used

## Verification
- cargo fmt --manifest-path rust-core/Cargo.toml --all -- --check
- cargo test --manifest-path rust-core/Cargo.toml -p friday-storage record_candidates
- cargo test --manifest-path rust-core/Cargo.toml -p friday-hub a1_run_outcome_learning_consumer
- cargo test --manifest-path rust-core/Cargo.toml -p friday-hub session_recall_public_path_surfaces
- cargo test --manifest-path rust-core/Cargo.toml -p friday-hub a1_run_outcome_learning_fanout
- git diff --check