### PR TITLE
Harden C1/C2 parity capture artifacts

### DIFF
--- a/scripts/ops/friday-c1-c2-tier1-parity-artifact-runner.mjs
+++ b/scripts/ops/friday-c1-c2-tier1-parity-artifact-runner.mjs
@@ -20,6 +20,7 @@ function envEnabled(env, name) {
 function readConfig(env = process.env) {
   return {
     enabled: envEnabled(env, "FRIDAY_C1_C2_TIER1_ARTIFACT_RUN"),
+    allowCustomCommand: envEnabled(env, "FRIDAY_C1_C2_TIER1_ALLOW_CUSTOM_COMMAND"),
     artifactRoot: env.FRIDAY_C1_C2_TIER1_CAPTURE_ROOT?.trim() ?? "",
     flowId: env.FRIDAY_C1_C2_TIER1_FLOW_ID?.trim() ?? "",
     commandJson: env.FRIDAY_C1_C2_TIER1_FLOW_COMMAND_JSON?.trim() ?? "",
@@ -55,7 +56,7 @@ function digestOutput(stdout, stderr) {
   return crypto.createHash("sha256").update(stdout).update(stderr).digest("hex");
 }
 
-function buildRecord(flow, command, result, startedAt, completedAt) {
+function buildRecord(flow, command, commandSource, result, startedAt, completedAt) {
   const stdout = Buffer.isBuffer(result.stdout) ? result.stdout : Buffer.from(result.stdout ?? "");
   const stderr = Buffer.isBuffer(result.stderr) ? result.stderr : Buffer.from(result.stderr ?? "");
   const exitCode = typeof result.status === "number" ? result.status : null;
@@ -73,9 +74,10 @@ function buildRecord(flow, command, result, startedAt, completedAt) {
     startedAt,
     completedAt,
     harness: flow.expectedHarness,
+    commandSource,
     evidence: [
       {
-        kind: "harness-exit",
+        kind: commandSource === "default" ? "harness-exit" : "custom-command-exit",
         path: flow.expectedHarness,
         argv0: path.basename(command[0]),
         exitCode,
@@ -110,7 +112,15 @@ export async function runOneFlow(config = readConfig()) {
   if (!flow) {
     return { ok: false, status: "blocked", blocker: `unknown flow id: ${config.flowId || "(empty)"}` };
   }
+  if (config.commandJson && !config.allowCustomCommand) {
+    return {
+      ok: false,
+      status: "blocked",
+      blocker: "custom flow commands require FRIDAY_C1_C2_TIER1_ALLOW_CUSTOM_COMMAND=1",
+    };
+  }
 
+  const commandSource = config.commandJson ? "custom" : "default";
   const command = parseCommandJson(config.commandJson) ?? defaultCommandForFlow(config.repoRoot, flow);
   if (!command) {
     return { ok: false, status: "blocked", blocker: `no default command for ${flow.expectedHarness}` };
@@ -123,7 +133,7 @@ export async function runOneFlow(config = readConfig()) {
     env: process.env,
   });
   const completedAt = new Date().toISOString();
-  const record = buildRecord(flow, command, result, startedAt, completedAt);
+  const record = buildRecord(flow, command, commandSource, result, startedAt, completedAt);
   const artifactPath = await writeRecord(config.artifactRoot, flow, record);
   return {
     ok: record.status === "passed",

--- a/scripts/ops/friday-c1-c2-tier1-parity-capture.mjs
+++ b/scripts/ops/friday-c1-c2-tier1-parity-capture.mjs
@@ -262,6 +262,9 @@ export function validateCaptureRecord(flow, record) {
   if (recordObject.lane !== flow.lane) {
     errors.push(`lane mismatch for ${flow.flowId}`);
   }
+  if (recordObject.harness !== flow.expectedHarness) {
+    errors.push(`harness mismatch for ${flow.flowId}`);
+  }
   if (recordObject.organic === true || recordObject.runKind === "organic") {
     errors.push(`organic claim is not allowed for ${flow.flowId}`);
   }

--- a/test/unit/scripts/ops/friday-c1-c2-tier1-parity-capture.test.ts
+++ b/test/unit/scripts/ops/friday-c1-c2-tier1-parity-capture.test.ts
@@ -36,6 +36,7 @@ function writeCaptureArtifact(root: string, flow: CaptureModule["TIER1_PARITY_FL
       builtDark: true,
       live: false,
       organic: false,
+      harness: flow.expectedHarness,
       truthLabel: "parity-capture artifact from existing routed harness output",
       evidence: [{ kind: "artifact", path: flow.expectedHarness }],
       ...patch,
@@ -152,6 +153,32 @@ describe("C1/C2 Tier-1 parity capture runner", () => {
     );
   });
 
+  it("rejects artifacts whose harness is not bound to the flow spec", async () => {
+    const capture = await loadCaptureModule();
+    const root = makeTempRoot();
+
+    for (const flow of capture.TIER1_PARITY_FLOW_SPECS) {
+      writeCaptureArtifact(
+        root,
+        flow,
+        flow.order === 1 ? { harness: "scripts/ops/unrelated-proof.sh" } : {},
+      );
+    }
+
+    const report = await capture.buildCaptureReport({
+      enabled: true,
+      artifactRoot: root,
+      reportPath: path.join(root, "report.json"),
+      generatedAt: "2026-06-19T00:00:00.000Z",
+    });
+
+    expect(report.status).toBe("blocked");
+    expect(report.blocker).toBe("1 capture artifact(s) missing or invalid");
+    expect(report.flows.find((flow) => flow.order === 1)?.errors).toContain(
+      "harness mismatch for c1-codex-routed-proof",
+    );
+  });
+
   it("keeps the runner source free of DB writes and operator-key reads", () => {
     const source = `${readFileSync(scriptPath, "utf8")}\n${readFileSync(artifactRunnerPath, "utf8")}`;
 
@@ -175,6 +202,7 @@ describe("C1/C2 Tier-1 parity capture runner", () => {
         FRIDAY_C1_C2_TIER1_ARTIFACT_RUN: "1",
         FRIDAY_C1_C2_TIER1_CAPTURE_ROOT: root,
         FRIDAY_C1_C2_TIER1_FLOW_ID: "c1-codex-routed-proof",
+        FRIDAY_C1_C2_TIER1_ALLOW_CUSTOM_COMMAND: "1",
         FRIDAY_C1_C2_TIER1_FLOW_COMMAND_JSON: JSON.stringify([process.execPath, "-e", "process.stdout.write('ok')"]),
       },
       encoding: "utf8",
@@ -193,10 +221,32 @@ describe("C1/C2 Tier-1 parity capture runner", () => {
 
     expect(captured?.status).toBe("captured");
     expect(captured?.record.status).toBe("passed");
+    expect(captured?.record.harness).toBe("scripts/ops/friday-codex-mission-proof-of-life.sh");
+    expect(captured?.record.commandSource).toBe("custom");
+    expect(captured?.record.evidence[0].kind).toBe("custom-command-exit");
     expect(captured?.record.evidence[0].outputSha256).toMatch(/^[a-f0-9]{64}$/);
     expect(captured?.record.truthLabel).toContain("parity-capture");
     expect(captured?.record.live).toBe(false);
     expect(captured?.record.organic).toBe(false);
+  });
+
+  it("requires an explicit opt-in before a custom flow command can mint artifacts", () => {
+    const root = makeTempRoot();
+    const result = spawnSync(process.execPath, [artifactRunnerPath], {
+      cwd: repoRoot,
+      env: {
+        ...process.env,
+        FRIDAY_C1_C2_TIER1_ARTIFACT_RUN: "1",
+        FRIDAY_C1_C2_TIER1_CAPTURE_ROOT: root,
+        FRIDAY_C1_C2_TIER1_FLOW_ID: "c1-codex-routed-proof",
+        FRIDAY_C1_C2_TIER1_FLOW_COMMAND_JSON: JSON.stringify([process.execPath, "-e", "process.stdout.write('ok')"]),
+      },
+      encoding: "utf8",
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stdout).toContain('"status": "blocked"');
+    expect(result.stdout).toContain("custom flow commands require FRIDAY_C1_C2_TIER1_ALLOW_CUSTOM_COMMAND=1");
   });
 
   it("does not let a failed flow artifact count as captured", async () => {
@@ -209,6 +259,7 @@ describe("C1/C2 Tier-1 parity capture runner", () => {
         FRIDAY_C1_C2_TIER1_ARTIFACT_RUN: "1",
         FRIDAY_C1_C2_TIER1_CAPTURE_ROOT: root,
         FRIDAY_C1_C2_TIER1_FLOW_ID: "c1-codex-routed-proof",
+        FRIDAY_C1_C2_TIER1_ALLOW_CUSTOM_COMMAND: "1",
         FRIDAY_C1_C2_TIER1_FLOW_COMMAND_JSON: JSON.stringify([process.execPath, "-e", "process.exit(7)"]),
       },
       encoding: "utf8",


### PR DESCRIPTION
## Summary
- bind C1/C2 parity capture artifacts to each flow's expected harness
- require explicit opt-in before custom flow commands can mint artifacts
- label custom-command evidence separately from default harness execution

## Truth labels
- built-DARK capture hardening only; live parity is not claimed
- organic=0 remains true
- no operator key or production DB writes are introduced

## Verification
- npx vitest run --project default test/unit/scripts/ops/friday-c1-c2-tier1-parity-capture.test.ts
- authorized custom artifact smoke check for harness/commandSource/evidence kind
- git diff --check