### PR TITLE
Derive health isolation truth from shared status

### DIFF
--- a/src/api/http/routes/friday-health-routes.ts
+++ b/src/api/http/routes/friday-health-routes.ts
@@ -7,7 +7,10 @@
 
 import type { FridayRouteDefinition } from "../../model/friday-api-common.types.js";
 import type { FridayRuntimeCapabilityMatrix } from "#providers";
-import type { FridayExecutionIsolationStatus } from "../../../skills/executor/friday-execution-isolation-status.js";
+import {
+  type FridayExecutionIsolationStatus,
+  getFridayExecutionIsolationStatus,
+} from "../../../skills/executor/friday-execution-isolation-status.js";
 
 // ─── Types ───
 
@@ -53,6 +56,7 @@ export interface FridayHealthRoutesDeps {
   version: string;
   getUptimeSeconds?: () => number;
   getCapabilities?: () => FridayHealthCapabilities | Promise<FridayHealthCapabilities>;
+  getExecutionIsolationStatus?: () => FridayExecutionIsolationStatus;
 }
 
 // ─── Factory ───
@@ -61,79 +65,41 @@ export function createFridayHealthRoutes(
   deps: FridayHealthRoutesDeps,
 ): FridayRouteDefinition<unknown, unknown, unknown, unknown>[] {
   const startTime = Date.now();
-  const defaultCapabilities: FridayHealthCapabilities = {
-    schemaVersion: "1.0",
-    plugins: {
-      runtimeMode: "stub",
-    },
-    channels: {
-      supportedKinds: [],
-      enabledKinds: [],
-      webhookEndpoints: {
-        line: false,
-        whatsapp: false,
-        lark: false,
-      },
-    },
-    mcp: {
-      enabled: false,
-    },
-    packaging: {
-      enabled: false,
-    },
-    executionIsolation: {
+  const getExecutionIsolationStatus = deps.getExecutionIsolationStatus ?? getFridayExecutionIsolationStatus;
+
+  function defaultCapabilities(): FridayHealthCapabilities {
+    return {
       schemaVersion: "1.0",
-      disposition: "open_no_os_sandbox",
-      osSandbox: false,
-      surfaces: {
-        "skill.shell": {
-          boundary: "logical_guards_only",
-          osSandbox: false,
-          defaultLive: false,
-          notes: "Shell skills use host child_process.spawn with cwd/env/timeout/output guards; no kernel sandbox is applied.",
-        },
-        "skill.python": {
-          boundary: "logical_guards_only",
-          osSandbox: false,
-          defaultLive: false,
-          notes: "Python skills share the shell executor boundary and are not isolated by an OS sandbox.",
-        },
-        "skill.node": {
-          boundary: "disabled_in_production_unisolated_test_harness_only",
-          osSandbox: false,
-          defaultLive: false,
-          notes: "Non-bundled Node skills dynamically import in-process modules; FRIDAY_ENABLE_UNISOLATED_NODE_SKILLS=true is accepted only by the test harness, never as a production live unlock.",
-        },
-        "skill.node.bundled_system": {
-          boundary: "disabled_in_production_unisolated_test_harness_only",
-          osSandbox: false,
-          defaultLive: false,
-          notes: "Bundled system Node skills are also disabled in production because they dynamically import in-process modules without OS isolation; FRIDAY_ENABLE_UNISOLATED_NODE_SKILLS=true is accepted only by the test harness.",
-        },
-        "plugin.entrypoint": {
-          boundary: "retired_by_default_dynamic_import_when_enabled",
-          osSandbox: false,
-          defaultLive: false,
-          notes: "Plugin lifecycle routes are retired by default; enabled plugin entrypoints are dynamic imports, not OS-isolated processes.",
-        },
-        "agent.exec": {
-          boundary: "logical_workspace_guard_host_spawn",
-          osSandbox: false,
-          defaultLive: true,
-          notes: "Agent exec uses host spawn with workspace, shell, timeout, and output controls; no OS sandbox is applied.",
+      plugins: {
+        runtimeMode: "stub",
+      },
+      channels: {
+        supportedKinds: [],
+        enabledKinds: [],
+        webhookEndpoints: {
+          line: false,
+          whatsapp: false,
+          lark: false,
         },
       },
-    },
-    search: {
-      provider: "duckduckgo_html",
-      latestness: "unverified",
-    },
-    system: {
-      enabled: false,
-      remoteMode: "unavailable",
-      companionReadiness: "unavailable",
-    },
-  };
+      mcp: {
+        enabled: false,
+      },
+      packaging: {
+        enabled: false,
+      },
+      executionIsolation: getExecutionIsolationStatus(),
+      search: {
+        provider: "duckduckgo_html",
+        latestness: "unverified",
+      },
+      system: {
+        enabled: false,
+        remoteMode: "unavailable",
+        companionReadiness: "unavailable",
+      },
+    };
+  }
 
   async function buildHealthPayload(includeCapabilities: boolean) {
     const uptimeSeconds = deps.getUptimeSeconds
@@ -148,7 +114,7 @@ export function createFridayHealthRoutes(
     }
     const capabilities = deps.getCapabilities
       ? await deps.getCapabilities()
-      : defaultCapabilities;
+      : defaultCapabilities();
     return {
       status: "ok",
       version: deps.version,

--- a/test/unit/api/http/routes/friday-health-routes.test.ts
+++ b/test/unit/api/http/routes/friday-health-routes.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { createFridayHealthRoutes } from "#api";
 import type { FridayRouteDefinition, FridayHttpContext } from "#api";
+import { getFridayExecutionIsolationStatus } from "../../../../../src/skills/executor/friday-execution-isolation-status.js";
 
 // ─── Helpers ───
 
@@ -82,6 +83,7 @@ describe("createFridayHealthRoutes", () => {
     const routes = createFridayHealthRoutes({
       version: "0.1.0",
       getUptimeSeconds: () => 42,
+      getExecutionIsolationStatus: () => getFridayExecutionIsolationStatus({}, { darwinSandboxExecAvailable: false }),
     });
     const route = findRoute(routes, "health.capabilities");
     const result = await route.handler(makeCtx({
@@ -147,6 +149,43 @@ describe("createFridayHealthRoutes", () => {
         },
         "agent.exec": {
           boundary: "logical_workspace_guard_host_spawn",
+          osSandbox: false,
+          defaultLive: true,
+        },
+      },
+    });
+  });
+
+  it("derives default execution-isolation capabilities from the shared status provider", async () => {
+    const routes = createFridayHealthRoutes({
+      version: "0.1.0",
+      getUptimeSeconds: () => 42,
+      getExecutionIsolationStatus: () => getFridayExecutionIsolationStatus({}, { darwinSandboxExecAvailable: true }),
+    });
+    const route = findRoute(routes, "health.capabilities");
+    const result = await route.handler(makeCtx()) as {
+      capabilities: {
+        executionIsolation?: {
+          disposition?: string;
+          osSandbox?: boolean;
+          surfaces?: Record<string, { osSandbox?: boolean; defaultLive?: boolean }>;
+        };
+      };
+    };
+
+    expect(result.capabilities.executionIsolation).toMatchObject({
+      disposition: "partial_os_sandbox",
+      osSandbox: true,
+      surfaces: {
+        "skill.shell": {
+          osSandbox: true,
+          defaultLive: true,
+        },
+        "skill.python": {
+          osSandbox: true,
+          defaultLive: true,
+        },
+        "agent.exec": {
           osSandbox: false,
           defaultLive: true,
         },


### PR DESCRIPTION
## Summary
- make standalone health capabilities derive execution-isolation truth from the shared status provider
- add an injectable status seam so tests can prove both no-sandbox and partial-sandbox reports without host-dependent assertions
- keep agent.exec and dynamic-import surfaces explicitly non-OS-sandboxed

## Truth labels
- status/reporting closure only; this does not claim full OS sandbox coverage
- skill.shell/python may report partial_os_sandbox only when the shared probe sees sandbox-exec available
- agent.exec, plugin entrypoints, and Node skills remain non-OS-sandboxed in the reported truth

## Verification
- npx vitest run --project default test/unit/skills/executor/friday-execution-isolation-status.test.ts test/unit/skills/executor/friday-shell-executor.test.ts test/unit/api/http/routes/friday-health-routes.test.ts
- npm run typecheck:src
- git diff --check