### PR TITLE
Tighten mission spine UI proof readiness gate

### DIFF
--- a/rust-core/scripts/mission-spine-ui-device-proof-gate-self-test.sh
+++ b/rust-core/scripts/mission-spine-ui-device-proof-gate-self-test.sh
@@ -371,7 +371,9 @@ assembled="$tmpdir/assembled.json"
 observations_manifest="$tmpdir/observations-manifest.json"
 template_manifest="$tmpdir/template-observations-manifest.json"
 fixture="$tmpdir/fixture.json"
+organic="$tmpdir/organic.json"
 placeholder="$tmpdir/placeholder.json"
+pending_marker="$tmpdir/pending-marker.json"
 missing_evidence="$tmpdir/missing-evidence.json"
 missing_metadata="$tmpdir/missing-metadata.json"
 missing_observations="$tmpdir/missing-observations.json"
@@ -392,11 +394,23 @@ echo "[mission-spine-ui-self-test] fixture/sample proof is rejected"
 write_proof "$fixture" "$mobile" "$desktop" "$channel" "$timeline" "fixture_sample" true
 expect_exit 5 env MISSION_SPINE_UI_DEVICE_PROOF="$fixture" "$gate"
 
+echo "[mission-spine-ui-self-test] organic proof claim is rejected"
+write_proof "$organic" "$mobile" "$desktop" "$channel" "$timeline"
+jq '.organic = true' "$organic" >"$organic.tmp"
+mv "$organic.tmp" "$organic"
+expect_exit 5 env MISSION_SPINE_UI_DEVICE_PROOF="$organic" "$gate"
+
 echo "[mission-spine-ui-self-test] placeholder/template proof is rejected"
 write_proof "$placeholder" "$mobile" "$desktop" "$channel" "$timeline"
 jq '.capture_run_id = "TODO_FILL_AFTER_REAL_CAPTURE_RUN"' "$placeholder" >"$placeholder.tmp"
 mv "$placeholder.tmp" "$placeholder"
 expect_exit 5 env MISSION_SPINE_UI_DEVICE_PROOF="$placeholder" "$gate"
+
+echo "[mission-spine-ui-self-test] pending real-capture marker is rejected"
+write_proof "$pending_marker" "$mobile" "$desktop" "$channel" "$timeline"
+jq '.capture_run_id = "pending-real-capture"' "$pending_marker" >"$pending_marker.tmp"
+mv "$pending_marker.tmp" "$pending_marker"
+expect_exit 5 env MISSION_SPINE_UI_DEVICE_PROOF="$pending_marker" "$gate"
 
 echo "[mission-spine-ui-self-test] missing evidence file is rejected"
 write_proof "$missing_evidence" "$mobile" "$desktop" "$channel" "$tmpdir/absent-timeline.trace"
@@ -484,7 +498,7 @@ expect_exit 64 env \
   OUT="$assembled" \
   scripts/mission-spine-ui-device-proof-assemble.sh
 
-rm "$valid" "$assembled" "$observations_manifest" "$template_manifest" "$fixture" "$placeholder" "$missing_evidence" "$missing_metadata" "$missing_observations" "$missing_stress" "$hash_mismatch" "$bytes_mismatch" "$secret_evidence" "$template_assembled" "$mobile" "$desktop" "$channel" "$timeline" "$secret_mobile"
+rm "$valid" "$assembled" "$observations_manifest" "$template_manifest" "$fixture" "$organic" "$placeholder" "$pending_marker" "$missing_evidence" "$missing_metadata" "$missing_observations" "$missing_stress" "$hash_mismatch" "$bytes_mismatch" "$secret_evidence" "$template_assembled" "$mobile" "$desktop" "$channel" "$timeline" "$secret_mobile"
 rmdir "$tmpdir"
 
 echo "[mission-spine-ui-self-test] PASS"

--- a/rust-core/scripts/mission-spine-ui-device-proof-gate.sh
+++ b/rust-core/scripts/mission-spine-ui-device-proof-gate.sh
@@ -66,7 +66,9 @@ reject_placeholder_markers() {
     "REPLACE_WITH_REAL_CAPTURE" \
     "__MISSION_ID__" \
     "\"template\": true" \
-    "\"not_real_proof\": true"
+    "\"not_real_proof\": true" \
+    "pending-real-capture" \
+    "mission_pending_runtime_projection"
   do
     if rg -q --fixed-strings --text "$marker" "$target"; then
       echo "BLOCKER: UI/device ${label} still contains proof-template placeholder marker: $marker" >&2
@@ -83,16 +85,17 @@ if jq -e '
   or (.synthetic // false) == true
   or (.sample // false) == true
   or (.dry_run // false) == true
-  or ((.proof_source // "") | test("fixture|sample|dry"; "i"))
+  or (.organic // false) == true
+  or ((.proof_source // "") | test("fixture|sample|dry|organic"; "i"))
 ' "$proof" >/dev/null; then
-  echo "BLOCKER: UI/device proof artifact is marked as fixture/sample/synthetic/dry-run: $proof" >&2
+  echo "BLOCKER: UI/device proof artifact is marked as fixture/sample/synthetic/dry-run/organic: $proof" >&2
   exit 5
 fi
 
 jq -e '
   def nonempty_string: type == "string" and length > 0;
   def safe_kind: type == "string" and test("^(screenshot|video|trace|log|json)$");
-  def not_fake_string: type == "string" and (test("fixture|sample|synthetic|dry"; "i") | not);
+  def not_fake_string: type == "string" and (test("fixture|sample|synthetic|dry|organic"; "i") | not);
   def sha256_hex: type == "string" and test("^[0-9a-f]{64}$");
   def ok_bool($path): getpath($path) == true;
   def has_status_label($needle): (.status_labels // []) | index($needle) != null;


### PR DESCRIPTION
## Summary
- reject pending real-capture/runtime projection markers in the mission-spine UI/device proof gate
- reject proof artifacts that label themselves organic, preserving the works-vs-adopted truth boundary
- extend the shell self-test for organic-claim and pending-capture rejection

Truth label: mechanism proof readiness only; this does not claim OG9 organic, GO-LIVE, or v1 done.

## Verification
- bash -n rust-core/scripts/mission-spine-ui-device-proof-gate.sh rust-core/scripts/mission-spine-ui-device-proof-gate-self-test.sh
- bash rust-core/scripts/mission-spine-ui-device-proof-gate-self-test.sh
- git diff --check