### PR TITLE
Batch proof hardening gates and readiness checks

### DIFF
--- a/docs/ops/ts-runtime-retirement-manifest.json
+++ b/docs/ops/ts-runtime-retirement-manifest.json
@@ -2524,6 +2524,13 @@
       "executes_product_logic": false,
       "proof": "Default/live hub wiring (src/hub/friday-hub-bootstrap.ts desktopRouteDeps.policies.create) throws DESKTOP_POLICY_NOT_PERSISTED (503, status proof_pending) before any policy product logic, persistence, or enforcement; no durable storage/evaluator/audit exists. test/unit/hub/bootstrap/desktop-policy-fail-closed.test.ts is a source-wiring regression guard that asserts these throwing deps remain present (it checks bootstrap source text, not runtime 503 behavior). The route owns no policy truth.",
       "routeBehavioralTest": "test/unit/api/http/routes/friday-desktop-routes.test.ts",
+      "routeBehavioralTestIncludes": [
+        "propagates default/live bootstrap proof-pending policy 503s for every policy route",
+        "desktop.policies.create",
+        "DESKTOP_POLICY_NOT_PERSISTED",
+        "details: { status: \"proof_pending\" }",
+        "expect(deps.policies[testCase.key]).toHaveBeenCalledTimes(1)"
+      ],
       "next_action": "Replace the proof_pending fail-closed response with a Rust-owned desktop policy create/persist/enforce entrypoint when available."
     },
     {
@@ -2537,6 +2544,13 @@
       "user_triggerable": true,
       "executes_product_logic": false,
       "routeBehavioralTest": "test/unit/api/http/routes/friday-desktop-routes.test.ts",
+      "routeBehavioralTestIncludes": [
+        "propagates default/live bootstrap proof-pending policy 503s for every policy route",
+        "desktop.policies.get",
+        "DESKTOP_POLICY_NOT_PERSISTED",
+        "details: { status: \"proof_pending\" }",
+        "expect(deps.policies[testCase.key]).toHaveBeenCalledTimes(1)"
+      ],
       "proof": "Default/live hub wiring (src/hub/friday-hub-bootstrap.ts desktopRouteDeps.policies.get) throws DESKTOP_POLICY_NOT_PERSISTED (503, status proof_pending) before any policy read; no durable policy store exists so there is no redactable projection. test/unit/hub/bootstrap/desktop-policy-fail-closed.test.ts is a source-wiring regression guard that asserts these throwing deps remain present (it checks bootstrap source text, not runtime 503 behavior).",
       "next_action": "Replace the proof_pending fail-closed response with a Rust-owned desktop policy read projection when available."
     },
@@ -2551,6 +2565,13 @@
       "user_triggerable": true,
       "executes_product_logic": false,
       "routeBehavioralTest": "test/unit/api/http/routes/friday-desktop-routes.test.ts",
+      "routeBehavioralTestIncludes": [
+        "propagates default/live bootstrap proof-pending policy 503s for every policy route",
+        "desktop.policies.list",
+        "DESKTOP_POLICY_NOT_PERSISTED",
+        "details: { status: \"proof_pending\" }",
+        "expect(deps.policies[testCase.key]).toHaveBeenCalledTimes(1)"
+      ],
       "proof": "Default/live hub wiring (src/hub/friday-hub-bootstrap.ts desktopRouteDeps.policies.list) throws DESKTOP_POLICY_NOT_PERSISTED (503, status proof_pending) before any policy read; no durable policy store exists so there is no redactable projection. test/unit/hub/bootstrap/desktop-policy-fail-closed.test.ts is a source-wiring regression guard that asserts these throwing deps remain present (it checks bootstrap source text, not runtime 503 behavior).",
       "next_action": "Replace the proof_pending fail-closed response with a Rust-owned desktop policy list projection when available."
     },
@@ -2566,6 +2587,13 @@
       "executes_product_logic": false,
       "proof": "Default/live hub wiring (src/hub/friday-hub-bootstrap.ts desktopRouteDeps.policies.update) throws DESKTOP_POLICY_NOT_PERSISTED (503, status proof_pending) before any policy mutation; no durable storage/evaluator/audit exists. test/unit/hub/bootstrap/desktop-policy-fail-closed.test.ts is a source-wiring regression guard that asserts these throwing deps remain present (it checks bootstrap source text, not runtime 503 behavior).",
       "routeBehavioralTest": "test/unit/api/http/routes/friday-desktop-routes.test.ts",
+      "routeBehavioralTestIncludes": [
+        "propagates default/live bootstrap proof-pending policy 503s for every policy route",
+        "desktop.policies.update",
+        "DESKTOP_POLICY_NOT_PERSISTED",
+        "details: { status: \"proof_pending\" }",
+        "expect(deps.policies[testCase.key]).toHaveBeenCalledTimes(1)"
+      ],
       "next_action": "Replace the proof_pending fail-closed response with a Rust-owned desktop policy update/persist/enforce entrypoint when available."
     },
     {
@@ -2580,6 +2608,13 @@
       "executes_product_logic": false,
       "proof": "Default/live hub wiring (src/hub/friday-hub-bootstrap.ts desktopRouteDeps.policies.delete) throws DESKTOP_POLICY_NOT_PERSISTED (503, status proof_pending) before any policy mutation. test/unit/hub/bootstrap/desktop-policy-fail-closed.test.ts is a source-wiring regression guard that asserts these throwing deps remain present (it checks bootstrap source text, not runtime 503 behavior).",
       "routeBehavioralTest": "test/unit/api/http/routes/friday-desktop-routes.test.ts",
+      "routeBehavioralTestIncludes": [
+        "propagates default/live bootstrap proof-pending policy 503s for every policy route",
+        "desktop.policies.delete",
+        "DESKTOP_POLICY_NOT_PERSISTED",
+        "details: { status: \"proof_pending\" }",
+        "expect(deps.policies[testCase.key]).toHaveBeenCalledTimes(1)"
+      ],
       "next_action": "Replace the proof_pending fail-closed response with a Rust-owned desktop policy delete entrypoint when available."
     },
     {
@@ -2594,6 +2629,13 @@
       "executes_product_logic": false,
       "proof": "Default/live hub wiring (src/hub/friday-hub-bootstrap.ts desktopRouteDeps.policies.addRule) throws DESKTOP_POLICY_NOT_PERSISTED (503, status proof_pending) before any policy rule mutation. test/unit/hub/bootstrap/desktop-policy-fail-closed.test.ts is a source-wiring regression guard that asserts these throwing deps remain present (it checks bootstrap source text, not runtime 503 behavior).",
       "routeBehavioralTest": "test/unit/api/http/routes/friday-desktop-routes.test.ts",
+      "routeBehavioralTestIncludes": [
+        "propagates default/live bootstrap proof-pending policy 503s for every policy route",
+        "desktop.policies.rules.create",
+        "DESKTOP_POLICY_NOT_PERSISTED",
+        "details: { status: \"proof_pending\" }",
+        "expect(deps.policies[testCase.key]).toHaveBeenCalledTimes(1)"
+      ],
       "next_action": "Replace the proof_pending fail-closed response with a Rust-owned desktop policy rule create entrypoint when available."
     },
     {
@@ -2608,6 +2650,13 @@
       "executes_product_logic": false,
       "proof": "Default/live hub wiring (src/hub/friday-hub-bootstrap.ts desktopRouteDeps.policies.removeRule) throws DESKTOP_POLICY_NOT_PERSISTED (503, status proof_pending) before any policy rule mutation. test/unit/hub/bootstrap/desktop-policy-fail-closed.test.ts is a source-wiring regression guard that asserts these throwing deps remain present (it checks bootstrap source text, not runtime 503 behavior).",
       "routeBehavioralTest": "test/unit/api/http/routes/friday-desktop-routes.test.ts",
+      "routeBehavioralTestIncludes": [
+        "propagates default/live bootstrap proof-pending policy 503s for every policy route",
+        "desktop.policies.rules.delete",
+        "DESKTOP_POLICY_NOT_PERSISTED",
+        "details: { status: \"proof_pending\" }",
+        "expect(deps.policies[testCase.key]).toHaveBeenCalledTimes(1)"
+      ],
       "next_action": "Replace the proof_pending fail-closed response with a Rust-owned desktop policy rule delete entrypoint when available."
     },
     {
@@ -2622,6 +2671,13 @@
       "executes_product_logic": false,
       "proof": "Default/live hub wiring (src/hub/friday-hub-bootstrap.ts desktopRouteDeps.permissions.respond) throws DESKTOP_PERMISSION_DECISION_NOT_PERSISTED (503, status proof_pending) before any permission decision is recorded or enforced; prompt decisions are not durably stored. test/unit/hub/bootstrap/desktop-policy-fail-closed.test.ts is a source-wiring regression guard that asserts these throwing deps remain present (it checks bootstrap source text, not runtime 503 behavior).",
       "routeBehavioralTest": "test/unit/api/http/routes/friday-desktop-routes.test.ts",
+      "routeBehavioralTestIncludes": [
+        "propagates default/live bootstrap proof-pending permission decision 503s",
+        "desktop.permissions.respond",
+        "DESKTOP_PERMISSION_DECISION_NOT_PERSISTED",
+        "details: { status: \"proof_pending\" }",
+        "expect(deps.permissions[testCase.key]).toHaveBeenCalledTimes(1)"
+      ],
       "next_action": "Replace the proof_pending fail-closed response with a Rust-owned desktop permission decision entrypoint when available."
     },
     {
@@ -2635,6 +2691,13 @@
       "user_triggerable": true,
       "executes_product_logic": false,
       "routeBehavioralTest": "test/unit/api/http/routes/friday-desktop-routes.test.ts",
+      "routeBehavioralTestIncludes": [
+        "propagates default/live bootstrap proof-pending permission decision 503s",
+        "desktop.permissions.decisions.list",
+        "DESKTOP_PERMISSION_DECISION_NOT_PERSISTED",
+        "details: { status: \"proof_pending\" }",
+        "expect(deps.permissions[testCase.key]).toHaveBeenCalledTimes(1)"
+      ],
       "proof": "Default/live hub wiring (src/hub/friday-hub-bootstrap.ts desktopRouteDeps.permissions.listDecisions) throws DESKTOP_PERMISSION_DECISION_NOT_PERSISTED (503, status proof_pending) before any read; no decisions log is wired so there is no redactable projection. test/unit/hub/bootstrap/desktop-policy-fail-closed.test.ts is a source-wiring regression guard that asserts these throwing deps remain present (it checks bootstrap source text, not runtime 503 behavior).",
       "next_action": "Replace the proof_pending fail-closed response with a Rust-owned desktop permission decision log projection when available."
     },

--- a/docs/ops/ts-runtime-retirement-manifest.json
+++ b/docs/ops/ts-runtime-retirement-manifest.json
@@ -10,7 +10,7 @@
   "discovery": {
     "routeSourceDir": "src/api/http/routes",
     "includeMethods": ["GET", "POST", "PATCH", "PUT", "DELETE"],
-    "exactRouteSurfacesMin": 308,
+    "exactRouteSurfacesMin": 312,
     "requiredRouteBehaviorTestSurfaceIds": [
       "agent_runs_start",
       "workflow_runs_start",
@@ -165,6 +165,12 @@
       "cloud_worker_teardown_receipt",
       "deeplink_preview",
       "providers_detect"
+    ],
+    "requiredGovernedRouteBehaviorTestSurfaceIds": [
+      "providers_create_governed_adapter",
+      "providers_routing_set_governed_adapter",
+      "skills_update_lifecycle_governed",
+      "skills_delete_lifecycle_governed"
     ]
   },
   "classificationValues": [
@@ -1729,6 +1735,48 @@
       "user_triggerable": true,
       "migration_intent": "Keep workflow run evidence export download as a bounded redacted compatibility projection while TypeScript workflow execution and evidence-export mutation remain blocked or separately owned. This download serializes sanitized evidence JSON instead of raw persisted file content or private filesystem paths.",
       "next_action": "Replace this compatibility read with a Rust-owned evidence export download projection when available."
+    },
+    {
+      "id": "skills_update_lifecycle_governed",
+      "route": {
+        "method": "POST",
+        "path": "/v1/skills/:skillId/update",
+        "operationId": "skills.update"
+      },
+      "classification": "compat_shim",
+      "user_triggerable": true,
+      "migration_intent": "Keep workspace skill lifecycle update as a governed compatibility surface while arbitrary skill execution and verification remain retired or Rust-owned. Non-managed updates require canonical approval before lifecycle.update mutates.",
+      "routeBehavioralTest": "test/unit/api/http/routes/friday-skill-routes.test.ts",
+      "routeBehavioralTestIncludes": [
+        "requires canonical approval before non-managed lifecycle update/delete",
+        "SKILL_LIFECYCLE_UPDATE_APPROVAL_REQUIRED",
+        "expect(lifecycle.update).not.toHaveBeenCalled",
+        "passes canonical approval through non-managed lifecycle update/delete",
+        "expect(lifecycle.update).toHaveBeenCalledWith(expect.objectContaining({"
+      ],
+      "proof": "src/api/http/routes/friday-skill-routes.ts skills.update uses assertCanonicalApproval for non-managed skill updates before deps.lifecycle.update. The behavior test proves missing approval blocks before mutation and a valid canonical approval is forwarded as the only mutation path.",
+      "next_action": "Move skill lifecycle update to a Rust-owned or explicitly governed product entrypoint when skill content lifecycle ownership is complete."
+    },
+    {
+      "id": "skills_delete_lifecycle_governed",
+      "route": {
+        "method": "DELETE",
+        "path": "/v1/skills/:skillId",
+        "operationId": "skills.delete"
+      },
+      "classification": "compat_shim",
+      "user_triggerable": true,
+      "migration_intent": "Keep workspace skill lifecycle delete as a governed compatibility surface while arbitrary skill execution and verification remain retired or Rust-owned. Non-managed deletes require canonical approval before lifecycle.deleteSkill mutates.",
+      "routeBehavioralTest": "test/unit/api/http/routes/friday-skill-routes.test.ts",
+      "routeBehavioralTestIncludes": [
+        "requires canonical approval before non-managed lifecycle update/delete",
+        "SKILL_LIFECYCLE_DELETE_APPROVAL_REQUIRED",
+        "expect(lifecycle.deleteSkill).not.toHaveBeenCalled",
+        "passes canonical approval through non-managed lifecycle update/delete",
+        "expect(lifecycle.deleteSkill).toHaveBeenCalledWith({"
+      ],
+      "proof": "src/api/http/routes/friday-skill-routes.ts skills.delete uses assertCanonicalApproval for non-managed skill deletes before deps.lifecycle.deleteSkill. The behavior test proves missing approval blocks before mutation and a valid canonical approval is forwarded as the only mutation path.",
+      "next_action": "Move skill lifecycle delete to a Rust-owned or explicitly governed product entrypoint when skill content lifecycle ownership is complete."
     },
     {
       "id": "skills_run",
@@ -4828,6 +4876,35 @@
       "next_action": "Replace the fail-closed response with the Rust-owned plugin uninstall entrypoint when available."
     },
     {
+      "id": "providers_create_governed_adapter",
+      "route": { "method": "POST", "path": "/v1/providers", "operationId": "providers.create" },
+      "classification": "operator_external_adapter",
+      "user_triggerable": true,
+      "trust_boundary": "Provider configuration adapter only; provider profile creation is not task completion truth and gate-required profiles must canonical-approve before service mutation.",
+      "leak_controls": {
+        "raw_private_data_allowed": false,
+        "forbidden": [
+          "raw_transcripts",
+          "secrets",
+          "private_paths",
+          "provider_ids",
+          "channel_ids",
+          "raw_commands",
+          "private_reasoning"
+        ]
+      },
+      "routeBehavioralTest": "test/unit/providers/api/friday-provider-routes.test.ts",
+      "routeBehavioralTestIncludes": [
+        "providers.create requires canonical approval in gate-required profile before service mutation",
+        "CANONICAL_APPROVAL_REQUIRED",
+        "expect(mockService.createProvider).not.toHaveBeenCalled",
+        "providers.create accepts canonical approval in gate-required profile and strips control fields",
+        "expect(mockService.createProvider).toHaveBeenCalledWith(providerBody)"
+      ],
+      "proof": "src/api/http/routes/friday-provider-routes.ts providers.create strips canonical control fields before providerService.createProvider and maybeRequireProviderMutationTicket gates the route in gate-required profiles. The behavior test proves missing approval blocks before service mutation and valid canonical approval strips control fields before delegation.",
+      "next_action": "Keep provider profile creation as a governed adapter until the provider configuration owner moves to a Rust projection/mutation entrypoint."
+    },
+    {
       "id": "providers_detect",
       "route": { "method": "POST", "path": "/v1/providers/detect", "operationId": "providers.detect" },
       "classification": "fail_closed",
@@ -4844,6 +4921,13 @@
       "user_triggerable": true,
       "executes_product_logic": false,
       "routeBehavioralTest": "test/unit/providers/api/friday-provider-routes.test.ts",
+      "routeBehavioralTestIncludes": [
+        "providers.validate requires canonical approval in gate-required profile before service mutation",
+        "CANONICAL_APPROVAL_REQUIRED",
+        "expect(mockService.validateProvider).not.toHaveBeenCalled",
+        "providers.validate accepts canonical approval in gate-required profile",
+        "expect(mockService.validateProvider).toHaveBeenCalledWith(\"prov-001\","
+      ],
       "proof": "src/api/http/routes/friday-provider-routes.ts providers.validate wires default/live to assertProviderProbeTestOracleAllowed(deps) AFTER request validation + the canonical mutation gate (maybeRequireProviderMutationTicket; gate-required profiles 503/CANONICAL_APPROVAL_REQUIRED before the guard) and BEFORE the providerService.validateProvider call. 503 TS_RUNTIME_PROVIDER_PROBE_RETIRED (classification fail_closed, replacement rust_owned_provider_probe_entrypoint_required). fail_closed NOT operator_external_adapter: validateProvider (src/providers/services/friday-provider-service.ts, verified by reading the impl) is a transient key/connectivity PROBE that egresses to the provider (validator.validate({credential,...}) for HTTP, validateCliProvider for CLI) AND persists the resulting validation state to the provider DB (withWriteTransaction) — it is both a probe and a state write, Rust-ownable product logic — same shape as providers.detect; it is not a permanent egress-delivery conduit, and when retired the guard fail-closes BEFORE the validateProvider call so neither the egress nor the state write runs. executes_product_logic:false: no provider validation runs in default/live. Flag allowTestOnlyProviderProbeExecution threaded CreateFridayApiRuntimeDeps -> createFridayProviderRoutes + hub-config (FridayHubConfig -> friday-hub-bootstrap) so mock-env (createMockHubEnv default-true), real-env (live, true), and the full/llm e2e (createFridayHub) set it. OPERATOR/RECONCILIATION NOTE: retiring this route 503s the release-GO closure harnesses scripts/e2e/run-friday-closure.mjs and scripts/e2e/run-friday-external-closure.mjs (both POST /v1/providers/:providerId/validate, throw on non-200) — these are NOT CI gates but need the Rust provider-probe entrypoint (or an operator decision) before release-verify; same shape as the providers.detect reconciliation note. Reachable only through explicit allowTestOnlyProviderProbeExecution test-oracle wiring.",
       "next_action": "Replace the fail-closed response with the Rust-owned provider-probe entrypoint when available; validate is on the release-GO path — coordinate with operator sign-off (see reconciliation note)."
     },
@@ -4886,6 +4970,35 @@
       "routeBehavioralTest": "test/unit/providers/api/friday-provider-routes.test.ts",
       "proof": "src/api/http/routes/friday-provider-routes.ts providers.routing.penalty.clear wires default/live to assertProviderRoutingControlsTestOracleAllowed(deps) AFTER the user-scoped principal check (401 UNAUTHORIZED), body validation (providerId/model/backendKind -> 400 VALIDATION_ERROR), and the canonical mutation gate (maybeRequireProviderMutationTicket) and IMMEDIATELY BEFORE the providerService.clearRoutePenalty user-scoped routing-penalty write. 503 TS_RUNTIME_PROVIDER_ROUTING_CONTROLS_RETIRED (classification fail_closed, replacement rust_owned_provider_routing_controls_entrypoint_required). fail_closed NOT operator_external_adapter: penalty.clear writes user-scoped routing-penalty state (runtime product logic), Rust-ownable; when retired the guard fail-closes BEFORE the write so no state mutates. executes_product_logic:false: no penalty-clear write runs in default/live. Flag allowTestOnlyProviderRoutingControlsExecution threaded as for providers.routing.pin. This flag does NOT cover the model-routing config surfaces (GET/PUT /v1/model-routing), which remain operator_external_adapter and are DEFERRED. Reachable only through explicit allowTestOnlyProviderRoutingControlsExecution test-oracle wiring.",
       "next_action": "Replace the fail-closed response with the Rust-owned routing-controls entrypoint when available."
+    },
+    {
+      "id": "providers_routing_set_governed_adapter",
+      "route": { "method": "PUT", "path": "/v1/model-routing", "operationId": "providers.routing.set" },
+      "classification": "operator_external_adapter",
+      "user_triggerable": true,
+      "trust_boundary": "Provider routing configuration adapter only; routing config writes are not task completion truth and gate-required profiles must canonical-approve before service mutation.",
+      "leak_controls": {
+        "raw_private_data_allowed": false,
+        "forbidden": [
+          "raw_transcripts",
+          "secrets",
+          "private_paths",
+          "provider_ids",
+          "channel_ids",
+          "raw_commands",
+          "private_reasoning"
+        ]
+      },
+      "routeBehavioralTest": "test/unit/providers/api/friday-provider-routes.test.ts",
+      "routeBehavioralTestIncludes": [
+        "providers.routing.set requires canonical approval in gate-required profile before service mutation",
+        "CANONICAL_APPROVAL_REQUIRED",
+        "expect(mockService.setRoutingConfig).not.toHaveBeenCalled",
+        "providers.routing.set accepts canonical approval in gate-required profile",
+        "expect(mockService.setRoutingConfig).toHaveBeenCalledWith(routingBody)"
+      ],
+      "proof": "src/api/http/routes/friday-provider-routes.ts providers.routing.set strips canonical control fields, validates routing config, and maybeRequireProviderMutationTicket gates the route in gate-required profiles before providerService.setRoutingConfig. The behavior test proves missing approval blocks before service mutation and valid canonical approval delegates only the stripped routing body.",
+      "next_action": "Keep model-routing configuration as a governed provider adapter until a Rust-owned provider routing config entrypoint exists."
     },
     {
       "id": "providers_health_list_compat",

--- a/rust-core/scripts/mission-spine-ui-device-proof-gate-self-test.sh
+++ b/rust-core/scripts/mission-spine-ui-device-proof-gate-self-test.sh
@@ -371,7 +371,9 @@ assembled="$tmpdir/assembled.json"
 observations_manifest="$tmpdir/observations-manifest.json"
 template_manifest="$tmpdir/template-observations-manifest.json"
 fixture="$tmpdir/fixture.json"
+organic="$tmpdir/organic.json"
 placeholder="$tmpdir/placeholder.json"
+pending_marker="$tmpdir/pending-marker.json"
 missing_evidence="$tmpdir/missing-evidence.json"
 missing_metadata="$tmpdir/missing-metadata.json"
 missing_observations="$tmpdir/missing-observations.json"
@@ -392,11 +394,23 @@ echo "[mission-spine-ui-self-test] fixture/sample proof is rejected"
 write_proof "$fixture" "$mobile" "$desktop" "$channel" "$timeline" "fixture_sample" true
 expect_exit 5 env MISSION_SPINE_UI_DEVICE_PROOF="$fixture" "$gate"
 
+echo "[mission-spine-ui-self-test] organic proof claim is rejected"
+write_proof "$organic" "$mobile" "$desktop" "$channel" "$timeline"
+jq '.organic = true' "$organic" >"$organic.tmp"
+mv "$organic.tmp" "$organic"
+expect_exit 5 env MISSION_SPINE_UI_DEVICE_PROOF="$organic" "$gate"
+
 echo "[mission-spine-ui-self-test] placeholder/template proof is rejected"
 write_proof "$placeholder" "$mobile" "$desktop" "$channel" "$timeline"
 jq '.capture_run_id = "TODO_FILL_AFTER_REAL_CAPTURE_RUN"' "$placeholder" >"$placeholder.tmp"
 mv "$placeholder.tmp" "$placeholder"
 expect_exit 5 env MISSION_SPINE_UI_DEVICE_PROOF="$placeholder" "$gate"
+
+echo "[mission-spine-ui-self-test] pending real-capture marker is rejected"
+write_proof "$pending_marker" "$mobile" "$desktop" "$channel" "$timeline"
+jq '.capture_run_id = "pending-real-capture"' "$pending_marker" >"$pending_marker.tmp"
+mv "$pending_marker.tmp" "$pending_marker"
+expect_exit 5 env MISSION_SPINE_UI_DEVICE_PROOF="$pending_marker" "$gate"
 
 echo "[mission-spine-ui-self-test] missing evidence file is rejected"
 write_proof "$missing_evidence" "$mobile" "$desktop" "$channel" "$tmpdir/absent-timeline.trace"
@@ -484,7 +498,7 @@ expect_exit 64 env \
   OUT="$assembled" \
   scripts/mission-spine-ui-device-proof-assemble.sh
 
-rm "$valid" "$assembled" "$observations_manifest" "$template_manifest" "$fixture" "$placeholder" "$missing_evidence" "$missing_metadata" "$missing_observations" "$missing_stress" "$hash_mismatch" "$bytes_mismatch" "$secret_evidence" "$template_assembled" "$mobile" "$desktop" "$channel" "$timeline" "$secret_mobile"
+rm "$valid" "$assembled" "$observations_manifest" "$template_manifest" "$fixture" "$organic" "$placeholder" "$pending_marker" "$missing_evidence" "$missing_metadata" "$missing_observations" "$missing_stress" "$hash_mismatch" "$bytes_mismatch" "$secret_evidence" "$template_assembled" "$mobile" "$desktop" "$channel" "$timeline" "$secret_mobile"
 rmdir "$tmpdir"
 
 echo "[mission-spine-ui-self-test] PASS"

--- a/rust-core/scripts/mission-spine-ui-device-proof-gate.sh
+++ b/rust-core/scripts/mission-spine-ui-device-proof-gate.sh
@@ -66,7 +66,9 @@ reject_placeholder_markers() {
     "REPLACE_WITH_REAL_CAPTURE" \
     "__MISSION_ID__" \
     "\"template\": true" \
-    "\"not_real_proof\": true"
+    "\"not_real_proof\": true" \
+    "pending-real-capture" \
+    "mission_pending_runtime_projection"
   do
     if rg -q --fixed-strings --text "$marker" "$target"; then
       echo "BLOCKER: UI/device ${label} still contains proof-template placeholder marker: $marker" >&2
@@ -83,16 +85,17 @@ if jq -e '
   or (.synthetic // false) == true
   or (.sample // false) == true
   or (.dry_run // false) == true
-  or ((.proof_source // "") | test("fixture|sample|dry"; "i"))
+  or (.organic // false) == true
+  or ((.proof_source // "") | test("fixture|sample|dry|organic"; "i"))
 ' "$proof" >/dev/null; then
-  echo "BLOCKER: UI/device proof artifact is marked as fixture/sample/synthetic/dry-run: $proof" >&2
+  echo "BLOCKER: UI/device proof artifact is marked as fixture/sample/synthetic/dry-run/organic: $proof" >&2
   exit 5
 fi
 
 jq -e '
   def nonempty_string: type == "string" and length > 0;
   def safe_kind: type == "string" and test("^(screenshot|video|trace|log|json)$");
-  def not_fake_string: type == "string" and (test("fixture|sample|synthetic|dry"; "i") | not);
+  def not_fake_string: type == "string" and (test("fixture|sample|synthetic|dry|organic"; "i") | not);
   def sha256_hex: type == "string" and test("^[0-9a-f]{64}$");
   def ok_bool($path): getpath($path) == true;
   def has_status_label($needle): (.status_labels // []) | index($needle) != null;

--- a/scripts/ops/friday-c1-c2-tier1-parity-artifact-runner.mjs
+++ b/scripts/ops/friday-c1-c2-tier1-parity-artifact-runner.mjs
@@ -20,6 +20,7 @@ function envEnabled(env, name) {
 function readConfig(env = process.env) {
   return {
     enabled: envEnabled(env, "FRIDAY_C1_C2_TIER1_ARTIFACT_RUN"),
+    allowCustomCommand: envEnabled(env, "FRIDAY_C1_C2_TIER1_ALLOW_CUSTOM_COMMAND"),
     artifactRoot: env.FRIDAY_C1_C2_TIER1_CAPTURE_ROOT?.trim() ?? "",
     flowId: env.FRIDAY_C1_C2_TIER1_FLOW_ID?.trim() ?? "",
     commandJson: env.FRIDAY_C1_C2_TIER1_FLOW_COMMAND_JSON?.trim() ?? "",
@@ -55,7 +56,7 @@ function digestOutput(stdout, stderr) {
   return crypto.createHash("sha256").update(stdout).update(stderr).digest("hex");
 }
 
-function buildRecord(flow, command, result, startedAt, completedAt) {
+function buildRecord(flow, command, commandSource, result, startedAt, completedAt) {
   const stdout = Buffer.isBuffer(result.stdout) ? result.stdout : Buffer.from(result.stdout ?? "");
   const stderr = Buffer.isBuffer(result.stderr) ? result.stderr : Buffer.from(result.stderr ?? "");
   const exitCode = typeof result.status === "number" ? result.status : null;
@@ -73,9 +74,10 @@ function buildRecord(flow, command, result, startedAt, completedAt) {
     startedAt,
     completedAt,
     harness: flow.expectedHarness,
+    commandSource,
     evidence: [
       {
-        kind: "harness-exit",
+        kind: commandSource === "default" ? "harness-exit" : "custom-command-exit",
         path: flow.expectedHarness,
         argv0: path.basename(command[0]),
         exitCode,
@@ -110,7 +112,15 @@ export async function runOneFlow(config = readConfig()) {
   if (!flow) {
     return { ok: false, status: "blocked", blocker: `unknown flow id: ${config.flowId || "(empty)"}` };
   }
+  if (config.commandJson && !config.allowCustomCommand) {
+    return {
+      ok: false,
+      status: "blocked",
+      blocker: "custom flow commands require FRIDAY_C1_C2_TIER1_ALLOW_CUSTOM_COMMAND=1",
+    };
+  }
 
+  const commandSource = config.commandJson ? "custom" : "default";
   const command = parseCommandJson(config.commandJson) ?? defaultCommandForFlow(config.repoRoot, flow);
   if (!command) {
     return { ok: false, status: "blocked", blocker: `no default command for ${flow.expectedHarness}` };
@@ -123,7 +133,7 @@ export async function runOneFlow(config = readConfig()) {
     env: process.env,
   });
   const completedAt = new Date().toISOString();
-  const record = buildRecord(flow, command, result, startedAt, completedAt);
+  const record = buildRecord(flow, command, commandSource, result, startedAt, completedAt);
   const artifactPath = await writeRecord(config.artifactRoot, flow, record);
   return {
     ok: record.status === "passed",

--- a/scripts/ops/friday-c1-c2-tier1-parity-capture.mjs
+++ b/scripts/ops/friday-c1-c2-tier1-parity-capture.mjs
@@ -262,6 +262,9 @@ export function validateCaptureRecord(flow, record) {
   if (recordObject.lane !== flow.lane) {
     errors.push(`lane mismatch for ${flow.flowId}`);
   }
+  if (recordObject.harness !== flow.expectedHarness) {
+    errors.push(`harness mismatch for ${flow.flowId}`);
+  }
   if (recordObject.organic === true || recordObject.runKind === "organic") {
     errors.push(`organic claim is not allowed for ${flow.flowId}`);
   }

--- a/scripts/quality/check-ts-runtime-retirement.mjs
+++ b/scripts/quality/check-ts-runtime-retirement.mjs
@@ -80,6 +80,7 @@ export function collectTsRuntimeRetirementFailures(manifest, routes) {
   const exactSurfaces = manifest.surfaces ?? [];
   const routeFamilies = manifest.routeFamilies ?? [];
   validateRequiredRouteBehaviorTests(manifest, exactSurfaces, failures);
+  validateRequiredGovernedRouteBehaviorTests(manifest, exactSurfaces, failures);
 
   for (const surface of exactSurfaces) {
     if (!surface.route) {
@@ -204,14 +205,56 @@ function validateRequiredRouteBehaviorTests(manifest, exactSurfaces, failures) {
   }
 }
 
+function validateRequiredGovernedRouteBehaviorTests(manifest, exactSurfaces, failures) {
+  const required = manifest.discovery?.requiredGovernedRouteBehaviorTestSurfaceIds ?? [];
+  if (!Array.isArray(required)) {
+    failures.push("discovery.requiredGovernedRouteBehaviorTestSurfaceIds must be an array when set");
+    return;
+  }
+
+  const allowedClassifications = new Set(["operator_external_adapter", "rust_delegated", "compat_shim"]);
+  const seen = new Set();
+  for (const surfaceId of required) {
+    if (!hasNonEmptyString(surfaceId)) {
+      failures.push("discovery.requiredGovernedRouteBehaviorTestSurfaceIds contains a non-string/empty id");
+      continue;
+    }
+    if (seen.has(surfaceId)) {
+      failures.push(`discovery.requiredGovernedRouteBehaviorTestSurfaceIds contains duplicate ${surfaceId}`);
+      continue;
+    }
+    seen.add(surfaceId);
+
+    const surface = exactSurfaces.find((entry) => entry.id === surfaceId);
+    if (!surface) {
+      failures.push(`required governed route behavior test surface ${surfaceId} is missing from exact surfaces`);
+      continue;
+    }
+    if (!surface.route) {
+      failures.push(`${surfaceId}: required governed route behavior test surface is missing an exact route`);
+    } else if (surface.route.method === "GET") {
+      failures.push(`${surfaceId}: required governed route behavior test surface must be non-GET`);
+    }
+    if (!allowedClassifications.has(surface.classification)) {
+      failures.push(`${surfaceId}: required governed route behavior test surface has unsupported classification ${surface.classification}`);
+    }
+    if (!hasNonEmptyString(surface.routeBehavioralTest)) {
+      failures.push(`${surfaceId}: missing routeBehavioralTest`);
+    }
+    if (!Array.isArray(surface.routeBehavioralTestIncludes) || surface.routeBehavioralTestIncludes.length === 0) {
+      failures.push(`${surfaceId}: missing routeBehavioralTestIncludes`);
+    }
+  }
+}
+
 function validateRequiredRouteBehaviorTestFiles(manifest, failures, repoRoot) {
   if (!repoRoot) {
     return;
   }
-  const required = manifest.discovery?.requiredRouteBehaviorTestSurfaceIds ?? [];
-  if (!Array.isArray(required)) {
-    return;
-  }
+  const required = [
+    ...(manifest.discovery?.requiredRouteBehaviorTestSurfaceIds ?? []),
+    ...(manifest.discovery?.requiredGovernedRouteBehaviorTestSurfaceIds ?? []),
+  ];
   for (const surfaceId of required) {
     const surface = (manifest.surfaces ?? []).find((entry) => entry.id === surfaceId);
     if (!hasNonEmptyString(surface?.routeBehavioralTest)) {
@@ -220,6 +263,17 @@ function validateRequiredRouteBehaviorTestFiles(manifest, failures, repoRoot) {
     const testPath = path.resolve(repoRoot, surface.routeBehavioralTest);
     if (!fs.existsSync(testPath)) {
       failures.push(`${surfaceId}: routeBehavioralTest file does not exist: ${surface.routeBehavioralTest}`);
+      continue;
+    }
+    const testSource = fs.readFileSync(testPath, "utf8");
+    for (const snippet of surface.routeBehavioralTestIncludes ?? []) {
+      if (!hasNonEmptyString(snippet)) {
+        failures.push(`${surfaceId}: routeBehavioralTestIncludes contains a non-string/empty snippet`);
+        continue;
+      }
+      if (!testSource.includes(snippet)) {
+        failures.push(`${surfaceId}: routeBehavioralTest ${surface.routeBehavioralTest} is missing ${JSON.stringify(snippet)}`);
+      }
     }
   }
 }

--- a/src/api/http/routes/friday-health-routes.ts
+++ b/src/api/http/routes/friday-health-routes.ts
@@ -7,7 +7,10 @@
 
 import type { FridayRouteDefinition } from "../../model/friday-api-common.types.js";
 import type { FridayRuntimeCapabilityMatrix } from "#providers";
-import type { FridayExecutionIsolationStatus } from "../../../skills/executor/friday-execution-isolation-status.js";
+import {
+  type FridayExecutionIsolationStatus,
+  getFridayExecutionIsolationStatus,
+} from "../../../skills/executor/friday-execution-isolation-status.js";
 
 // ─── Types ───
 
@@ -53,6 +56,7 @@ export interface FridayHealthRoutesDeps {
   version: string;
   getUptimeSeconds?: () => number;
   getCapabilities?: () => FridayHealthCapabilities | Promise<FridayHealthCapabilities>;
+  getExecutionIsolationStatus?: () => FridayExecutionIsolationStatus;
 }
 
 // ─── Factory ───
@@ -61,79 +65,41 @@ export function createFridayHealthRoutes(
   deps: FridayHealthRoutesDeps,
 ): FridayRouteDefinition<unknown, unknown, unknown, unknown>[] {
   const startTime = Date.now();
-  const defaultCapabilities: FridayHealthCapabilities = {
-    schemaVersion: "1.0",
-    plugins: {
-      runtimeMode: "stub",
-    },
-    channels: {
-      supportedKinds: [],
-      enabledKinds: [],
-      webhookEndpoints: {
-        line: false,
-        whatsapp: false,
-        lark: false,
-      },
-    },
-    mcp: {
-      enabled: false,
-    },
-    packaging: {
-      enabled: false,
-    },
-    executionIsolation: {
+  const getExecutionIsolationStatus = deps.getExecutionIsolationStatus ?? getFridayExecutionIsolationStatus;
+
+  function defaultCapabilities(): FridayHealthCapabilities {
+    return {
       schemaVersion: "1.0",
-      disposition: "open_no_os_sandbox",
-      osSandbox: false,
-      surfaces: {
-        "skill.shell": {
-          boundary: "logical_guards_only",
-          osSandbox: false,
-          defaultLive: false,
-          notes: "Shell skills use host child_process.spawn with cwd/env/timeout/output guards; no kernel sandbox is applied.",
-        },
-        "skill.python": {
-          boundary: "logical_guards_only",
-          osSandbox: false,
-          defaultLive: false,
-          notes: "Python skills share the shell executor boundary and are not isolated by an OS sandbox.",
-        },
-        "skill.node": {
-          boundary: "disabled_in_production_unisolated_test_harness_only",
-          osSandbox: false,
-          defaultLive: false,
-          notes: "Non-bundled Node skills dynamically import in-process modules; FRIDAY_ENABLE_UNISOLATED_NODE_SKILLS=true is accepted only by the test harness, never as a production live unlock.",
-        },
-        "skill.node.bundled_system": {
-          boundary: "disabled_in_production_unisolated_test_harness_only",
-          osSandbox: false,
-          defaultLive: false,
-          notes: "Bundled system Node skills are also disabled in production because they dynamically import in-process modules without OS isolation; FRIDAY_ENABLE_UNISOLATED_NODE_SKILLS=true is accepted only by the test harness.",
-        },
-        "plugin.entrypoint": {
-          boundary: "retired_by_default_dynamic_import_when_enabled",
-          osSandbox: false,
-          defaultLive: false,
-          notes: "Plugin lifecycle routes are retired by default; enabled plugin entrypoints are dynamic imports, not OS-isolated processes.",
-        },
-        "agent.exec": {
-          boundary: "logical_workspace_guard_host_spawn",
-          osSandbox: false,
-          defaultLive: true,
-          notes: "Agent exec uses host spawn with workspace, shell, timeout, and output controls; no OS sandbox is applied.",
+      plugins: {
+        runtimeMode: "stub",
+      },
+      channels: {
+        supportedKinds: [],
+        enabledKinds: [],
+        webhookEndpoints: {
+          line: false,
+          whatsapp: false,
+          lark: false,
         },
       },
-    },
-    search: {
-      provider: "duckduckgo_html",
-      latestness: "unverified",
-    },
-    system: {
-      enabled: false,
-      remoteMode: "unavailable",
-      companionReadiness: "unavailable",
-    },
-  };
+      mcp: {
+        enabled: false,
+      },
+      packaging: {
+        enabled: false,
+      },
+      executionIsolation: getExecutionIsolationStatus(),
+      search: {
+        provider: "duckduckgo_html",
+        latestness: "unverified",
+      },
+      system: {
+        enabled: false,
+        remoteMode: "unavailable",
+        companionReadiness: "unavailable",
+      },
+    };
+  }
 
   async function buildHealthPayload(includeCapabilities: boolean) {
     const uptimeSeconds = deps.getUptimeSeconds
@@ -148,7 +114,7 @@ export function createFridayHealthRoutes(
     }
     const capabilities = deps.getCapabilities
       ? await deps.getCapabilities()
-      : defaultCapabilities;
+      : defaultCapabilities();
     return {
       status: "ok",
       version: deps.version,

--- a/test/unit/api/http/routes/friday-desktop-routes.test.ts
+++ b/test/unit/api/http/routes/friday-desktop-routes.test.ts
@@ -474,48 +474,75 @@ describe("createFridayDesktopRoutes", () => {
       expect(deps.policies.removeRule).toHaveBeenCalledWith("pol-1", "rule-1", { etag: "e1", idempotencyKey: "k14" });
     });
 
-    it("propagates default/live bootstrap proof-pending policy 503s", async () => {
-      const deps = makeDeps({
-        policies: {
-          create: vi.fn(() => { throw proofPendingDesktopError("DESKTOP_POLICY_NOT_PERSISTED"); }),
-          get: vi.fn(() => { throw proofPendingDesktopError("DESKTOP_POLICY_NOT_PERSISTED"); }),
-          list: vi.fn(() => { throw proofPendingDesktopError("DESKTOP_POLICY_NOT_PERSISTED"); }),
-          update: vi.fn(() => { throw proofPendingDesktopError("DESKTOP_POLICY_NOT_PERSISTED"); }),
-          delete: vi.fn(() => { throw proofPendingDesktopError("DESKTOP_POLICY_NOT_PERSISTED"); }),
-          addRule: vi.fn(() => { throw proofPendingDesktopError("DESKTOP_POLICY_NOT_PERSISTED"); }),
-          removeRule: vi.fn(() => { throw proofPendingDesktopError("DESKTOP_POLICY_NOT_PERSISTED"); }),
+    it("propagates default/live bootstrap proof-pending policy 503s for every policy route", async () => {
+      const policyKeys = ["create", "get", "list", "update", "delete", "addRule", "removeRule"] as const;
+      const cases = [
+        {
+          operationId: "desktop.policies.create",
+          key: "create",
+          ctx: makeCtx({ body: { name: "Safe", rules: [], idempotencyKey: "k-pol-create" } }),
         },
-      });
-      const routes = createFridayDesktopRoutes(deps);
-
-      await expect(
-        findRoute(routes, "desktop.policies.create").handler(
-          makeCtx({ body: { name: "Safe", rules: [], idempotencyKey: "k-pol-create" } }),
-        ),
-      ).rejects.toMatchObject({ code: "DESKTOP_POLICY_NOT_PERSISTED", httpStatus: 503 });
-      await expect(
-        findRoute(routes, "desktop.policies.update").handler(
-          makeCtx({ params: { policyId: "pol-1" }, body: { etag: "e1", idempotencyKey: "k-pol-update" } }),
-        ),
-      ).rejects.toMatchObject({ code: "DESKTOP_POLICY_NOT_PERSISTED", httpStatus: 503 });
-      await expect(
-        findRoute(routes, "desktop.policies.delete").handler(
-          makeCtx({ params: { policyId: "pol-1" }, body: { etag: "e1", idempotencyKey: "k-pol-delete" } }),
-        ),
-      ).rejects.toMatchObject({ code: "DESKTOP_POLICY_NOT_PERSISTED", httpStatus: 503 });
-      await expect(
-        findRoute(routes, "desktop.policies.rules.create").handler(
-          makeCtx({
+        {
+          operationId: "desktop.policies.get",
+          key: "get",
+          ctx: makeCtx({ params: { policyId: "pol-1" } }),
+        },
+        {
+          operationId: "desktop.policies.list",
+          key: "list",
+          ctx: makeCtx({ query: { limit: 20 } }),
+        },
+        {
+          operationId: "desktop.policies.update",
+          key: "update",
+          ctx: makeCtx({ params: { policyId: "pol-1" }, body: { etag: "e1", idempotencyKey: "k-pol-update" } }),
+        },
+        {
+          operationId: "desktop.policies.delete",
+          key: "delete",
+          ctx: makeCtx({ params: { policyId: "pol-1" }, body: { etag: "e1", idempotencyKey: "k-pol-delete" } }),
+        },
+        {
+          operationId: "desktop.policies.rules.create",
+          key: "addRule",
+          ctx: makeCtx({
             params: { policyId: "pol-1" },
             body: { rule: { actionType: "click", appFilter: "*", riskLevel: "low", decision: "allow" }, etag: "e1", idempotencyKey: "k-pol-rule-create" },
           }),
-        ),
-      ).rejects.toMatchObject({ code: "DESKTOP_POLICY_NOT_PERSISTED", httpStatus: 503 });
-      await expect(
-        findRoute(routes, "desktop.policies.rules.delete").handler(
-          makeCtx({ params: { policyId: "pol-1", ruleId: "rule-1" }, body: { etag: "e1", idempotencyKey: "k-pol-rule-delete" } }),
-        ),
-      ).rejects.toMatchObject({ code: "DESKTOP_POLICY_NOT_PERSISTED", httpStatus: 503 });
+        },
+        {
+          operationId: "desktop.policies.rules.delete",
+          key: "removeRule",
+          ctx: makeCtx({ params: { policyId: "pol-1", ruleId: "rule-1" }, body: { etag: "e1", idempotencyKey: "k-pol-rule-delete" } }),
+        },
+      ] as const;
+
+      for (const testCase of cases) {
+        const deps = makeDeps({
+          policies: {
+            create: vi.fn(() => { throw proofPendingDesktopError("DESKTOP_POLICY_NOT_PERSISTED"); }),
+            get: vi.fn(() => { throw proofPendingDesktopError("DESKTOP_POLICY_NOT_PERSISTED"); }),
+            list: vi.fn(() => { throw proofPendingDesktopError("DESKTOP_POLICY_NOT_PERSISTED"); }),
+            update: vi.fn(() => { throw proofPendingDesktopError("DESKTOP_POLICY_NOT_PERSISTED"); }),
+            delete: vi.fn(() => { throw proofPendingDesktopError("DESKTOP_POLICY_NOT_PERSISTED"); }),
+            addRule: vi.fn(() => { throw proofPendingDesktopError("DESKTOP_POLICY_NOT_PERSISTED"); }),
+            removeRule: vi.fn(() => { throw proofPendingDesktopError("DESKTOP_POLICY_NOT_PERSISTED"); }),
+          },
+        });
+        const route = findRoute(createFridayDesktopRoutes(deps), testCase.operationId);
+
+        await expect(route.handler(testCase.ctx)).rejects.toMatchObject({
+          code: "DESKTOP_POLICY_NOT_PERSISTED",
+          httpStatus: 503,
+          details: { status: "proof_pending" },
+        });
+        expect(deps.policies[testCase.key]).toHaveBeenCalledTimes(1);
+        for (const key of policyKeys) {
+          if (key !== testCase.key) {
+            expect(deps.policies[key]).not.toHaveBeenCalled();
+          }
+        }
+      }
     });
   });
 
@@ -564,23 +591,39 @@ describe("createFridayDesktopRoutes", () => {
     });
 
     it("propagates default/live bootstrap proof-pending permission decision 503s", async () => {
-      const deps = makeDeps({
-        permissions: {
-          list: vi.fn().mockResolvedValue({ permissions: [], platform: "darwin" }),
-          respond: vi.fn(() => { throw proofPendingDesktopError("DESKTOP_PERMISSION_DECISION_NOT_PERSISTED"); }),
-          listDecisions: vi.fn(() => { throw proofPendingDesktopError("DESKTOP_PERMISSION_DECISION_NOT_PERSISTED"); }),
+      const cases = [
+        {
+          operationId: "desktop.permissions.respond",
+          key: "respond",
+          ctx: makeCtx({ params: { promptId: "p-1" }, body: { decision: "allow_once", idempotencyKey: "k-perm-respond" } }),
         },
-      });
-      const routes = createFridayDesktopRoutes(deps);
+        {
+          operationId: "desktop.permissions.decisions.list",
+          key: "listDecisions",
+          ctx: makeCtx({ query: { actionType: "click" } }),
+        },
+      ] as const;
 
-      await expect(
-        findRoute(routes, "desktop.permissions.respond").handler(
-          makeCtx({ params: { promptId: "p-1" }, body: { decision: "allow_once", idempotencyKey: "k-perm-respond" } }),
-        ),
-      ).rejects.toMatchObject({ code: "DESKTOP_PERMISSION_DECISION_NOT_PERSISTED", httpStatus: 503 });
-      await expect(
-        findRoute(routes, "desktop.permissions.decisions.list").handler(makeCtx({ query: { actionType: "click" } })),
-      ).rejects.toMatchObject({ code: "DESKTOP_PERMISSION_DECISION_NOT_PERSISTED", httpStatus: 503 });
+      for (const testCase of cases) {
+        const deps = makeDeps({
+          permissions: {
+            list: vi.fn().mockResolvedValue({ permissions: [], platform: "darwin" }),
+            respond: vi.fn(() => { throw proofPendingDesktopError("DESKTOP_PERMISSION_DECISION_NOT_PERSISTED"); }),
+            listDecisions: vi.fn(() => { throw proofPendingDesktopError("DESKTOP_PERMISSION_DECISION_NOT_PERSISTED"); }),
+          },
+        });
+        const route = findRoute(createFridayDesktopRoutes(deps), testCase.operationId);
+
+        await expect(route.handler(testCase.ctx)).rejects.toMatchObject({
+          code: "DESKTOP_PERMISSION_DECISION_NOT_PERSISTED",
+          httpStatus: 503,
+          details: { status: "proof_pending" },
+        });
+        expect(deps.permissions[testCase.key]).toHaveBeenCalledTimes(1);
+        expect(deps.permissions.list).not.toHaveBeenCalled();
+        const otherKey = testCase.key === "respond" ? "listDecisions" : "respond";
+        expect(deps.permissions[otherKey]).not.toHaveBeenCalled();
+      }
     });
   });
 

--- a/test/unit/api/http/routes/friday-health-routes.test.ts
+++ b/test/unit/api/http/routes/friday-health-routes.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { createFridayHealthRoutes } from "#api";
 import type { FridayRouteDefinition, FridayHttpContext } from "#api";
+import { getFridayExecutionIsolationStatus } from "../../../../../src/skills/executor/friday-execution-isolation-status.js";
 
 // ─── Helpers ───
 
@@ -82,6 +83,7 @@ describe("createFridayHealthRoutes", () => {
     const routes = createFridayHealthRoutes({
       version: "0.1.0",
       getUptimeSeconds: () => 42,
+      getExecutionIsolationStatus: () => getFridayExecutionIsolationStatus({}, { darwinSandboxExecAvailable: false }),
     });
     const route = findRoute(routes, "health.capabilities");
     const result = await route.handler(makeCtx({
@@ -147,6 +149,43 @@ describe("createFridayHealthRoutes", () => {
         },
         "agent.exec": {
           boundary: "logical_workspace_guard_host_spawn",
+          osSandbox: false,
+          defaultLive: true,
+        },
+      },
+    });
+  });
+
+  it("derives default execution-isolation capabilities from the shared status provider", async () => {
+    const routes = createFridayHealthRoutes({
+      version: "0.1.0",
+      getUptimeSeconds: () => 42,
+      getExecutionIsolationStatus: () => getFridayExecutionIsolationStatus({}, { darwinSandboxExecAvailable: true }),
+    });
+    const route = findRoute(routes, "health.capabilities");
+    const result = await route.handler(makeCtx()) as {
+      capabilities: {
+        executionIsolation?: {
+          disposition?: string;
+          osSandbox?: boolean;
+          surfaces?: Record<string, { osSandbox?: boolean; defaultLive?: boolean }>;
+        };
+      };
+    };
+
+    expect(result.capabilities.executionIsolation).toMatchObject({
+      disposition: "partial_os_sandbox",
+      osSandbox: true,
+      surfaces: {
+        "skill.shell": {
+          osSandbox: true,
+          defaultLive: true,
+        },
+        "skill.python": {
+          osSandbox: true,
+          defaultLive: true,
+        },
+        "agent.exec": {
           osSandbox: false,
           defaultLive: true,
         },

--- a/test/unit/scripts/ops/friday-c1-c2-tier1-parity-capture.test.ts
+++ b/test/unit/scripts/ops/friday-c1-c2-tier1-parity-capture.test.ts
@@ -36,6 +36,7 @@ function writeCaptureArtifact(root: string, flow: CaptureModule["TIER1_PARITY_FL
       builtDark: true,
       live: false,
       organic: false,
+      harness: flow.expectedHarness,
       truthLabel: "parity-capture artifact from existing routed harness output",
       evidence: [{ kind: "artifact", path: flow.expectedHarness }],
       ...patch,
@@ -152,6 +153,32 @@ describe("C1/C2 Tier-1 parity capture runner", () => {
     );
   });
 
+  it("rejects artifacts whose harness is not bound to the flow spec", async () => {
+    const capture = await loadCaptureModule();
+    const root = makeTempRoot();
+
+    for (const flow of capture.TIER1_PARITY_FLOW_SPECS) {
+      writeCaptureArtifact(
+        root,
+        flow,
+        flow.order === 1 ? { harness: "scripts/ops/unrelated-proof.sh" } : {},
+      );
+    }
+
+    const report = await capture.buildCaptureReport({
+      enabled: true,
+      artifactRoot: root,
+      reportPath: path.join(root, "report.json"),
+      generatedAt: "2026-06-19T00:00:00.000Z",
+    });
+
+    expect(report.status).toBe("blocked");
+    expect(report.blocker).toBe("1 capture artifact(s) missing or invalid");
+    expect(report.flows.find((flow) => flow.order === 1)?.errors).toContain(
+      "harness mismatch for c1-codex-routed-proof",
+    );
+  });
+
   it("keeps the runner source free of DB writes and operator-key reads", () => {
     const source = `${readFileSync(scriptPath, "utf8")}\n${readFileSync(artifactRunnerPath, "utf8")}`;
 
@@ -175,6 +202,7 @@ describe("C1/C2 Tier-1 parity capture runner", () => {
         FRIDAY_C1_C2_TIER1_ARTIFACT_RUN: "1",
         FRIDAY_C1_C2_TIER1_CAPTURE_ROOT: root,
         FRIDAY_C1_C2_TIER1_FLOW_ID: "c1-codex-routed-proof",
+        FRIDAY_C1_C2_TIER1_ALLOW_CUSTOM_COMMAND: "1",
         FRIDAY_C1_C2_TIER1_FLOW_COMMAND_JSON: JSON.stringify([process.execPath, "-e", "process.stdout.write('ok')"]),
       },
       encoding: "utf8",
@@ -193,10 +221,32 @@ describe("C1/C2 Tier-1 parity capture runner", () => {
 
     expect(captured?.status).toBe("captured");
     expect(captured?.record.status).toBe("passed");
+    expect(captured?.record.harness).toBe("scripts/ops/friday-codex-mission-proof-of-life.sh");
+    expect(captured?.record.commandSource).toBe("custom");
+    expect(captured?.record.evidence[0].kind).toBe("custom-command-exit");
     expect(captured?.record.evidence[0].outputSha256).toMatch(/^[a-f0-9]{64}$/);
     expect(captured?.record.truthLabel).toContain("parity-capture");
     expect(captured?.record.live).toBe(false);
     expect(captured?.record.organic).toBe(false);
+  });
+
+  it("requires an explicit opt-in before a custom flow command can mint artifacts", () => {
+    const root = makeTempRoot();
+    const result = spawnSync(process.execPath, [artifactRunnerPath], {
+      cwd: repoRoot,
+      env: {
+        ...process.env,
+        FRIDAY_C1_C2_TIER1_ARTIFACT_RUN: "1",
+        FRIDAY_C1_C2_TIER1_CAPTURE_ROOT: root,
+        FRIDAY_C1_C2_TIER1_FLOW_ID: "c1-codex-routed-proof",
+        FRIDAY_C1_C2_TIER1_FLOW_COMMAND_JSON: JSON.stringify([process.execPath, "-e", "process.stdout.write('ok')"]),
+      },
+      encoding: "utf8",
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stdout).toContain('"status": "blocked"');
+    expect(result.stdout).toContain("custom flow commands require FRIDAY_C1_C2_TIER1_ALLOW_CUSTOM_COMMAND=1");
   });
 
   it("does not let a failed flow artifact count as captured", async () => {
@@ -209,6 +259,7 @@ describe("C1/C2 Tier-1 parity capture runner", () => {
         FRIDAY_C1_C2_TIER1_ARTIFACT_RUN: "1",
         FRIDAY_C1_C2_TIER1_CAPTURE_ROOT: root,
         FRIDAY_C1_C2_TIER1_FLOW_ID: "c1-codex-routed-proof",
+        FRIDAY_C1_C2_TIER1_ALLOW_CUSTOM_COMMAND: "1",
         FRIDAY_C1_C2_TIER1_FLOW_COMMAND_JSON: JSON.stringify([process.execPath, "-e", "process.exit(7)"]),
       },
       encoding: "utf8",


### PR DESCRIPTION
## Summary
- batch the governed route behavior gate plus desktop policy proof-pending behavior coverage
- harden C1/C2 parity capture artifacts against mismatched harnesses and unauthorised custom commands
- derive health execution-isolation truth from the shared status provider
- tighten mission-spine UI/device proof readiness gates against pending markers and false organic claims

This supersedes the smaller PRs #1008, #1010, #1011, and #1012 to avoid serial strict-base CI churn.

Truth labels: mechanism/proof-hardening only; no OG9 organic claim, no GO-LIVE claim, no v1 done claim.

## Verification
- npm run check:ts-runtime-retirement -- --repo-root .
- npm run test:mechanism-wiring
- npx vitest run --project default test/unit/api/http/routes/friday-desktop-routes.test.ts test/unit/hub/bootstrap/desktop-policy-fail-closed.test.ts test/unit/scripts/ops/friday-c1-c2-tier1-parity-capture.test.ts test/unit/skills/executor/friday-execution-isolation-status.test.ts test/unit/skills/executor/friday-shell-executor.test.ts test/unit/api/http/routes/friday-health-routes.test.ts
- bash -n rust-core/scripts/mission-spine-ui-device-proof-gate.sh rust-core/scripts/mission-spine-ui-device-proof-gate-self-test.sh
- bash rust-core/scripts/mission-spine-ui-device-proof-gate-self-test.sh
- npm run lint -- --format stylish
- git diff --check