### PR TITLE
Build A1 reflex learning drive

### DIFF
--- a/docs/ops/prod-flags-manifest.json
+++ b/docs/ops/prod-flags-manifest.json
@@ -95,10 +95,10 @@
       "flag": "FRIDAY_A1_RUN_OUTCOME_LEARNING_CONSUMER",
       "process": "rust-ws-wrapper",
       "prod_state": "dark",
-      "closes_loop": "A later owner-scoped prompt includes confirmed preference/world-model run-outcome learning signals as refs-only guidance, while excluding reflex candidates and answer bodies.",
+      "closes_loop": "A later owner-scoped prompt includes confirmed preference/world-model/reflex run-outcome learning signals as refs-only guidance, while excluding answer bodies and operator decision text.",
       "coverage": "loop-e2e",
-      "e2e_test": "rust-core/crates/friday-hub/src/runtime.rs::session_recall_public_path_surfaces_a1_consumer_preference_world_model_only",
-      "notes": "A1 preference/world-model consumer leg. Drives the public session recall path with the consumer flag ON and confirmed preference/world_model/reflex candidates, asserting only preference/world_model refs-only signals are injected and reflex is excluded. Sibling proofs cover exact-'1' parsing, shared chokepoint behavior, and flag-off byte-identical behavior. Truth boundary: built-DARK mechanism only; not A1 live-done until an operator-origin organic turn feeds a candidate and a real confirm decision."
+      "e2e_test": "rust-core/crates/friday-hub/src/runtime.rs::session_recall_public_path_surfaces_a1_consumer_preference_world_model_and_reflex",
+      "notes": "A1 preference/world-model/reflex consumer leg. Drives the public session recall path with the consumer flag ON and confirmed preference/world_model/reflex candidates, asserting refs-only signals are injected and operator decision text stays out of prompts. Sibling proofs cover exact-'1' parsing, shared chokepoint behavior, and flag-off byte-identical behavior. Truth boundary: built-DARK mechanism only; not A1 live-done until an operator-origin organic turn feeds a candidate and a real confirm decision."
     },
     {
       "flag": "FRIDAY_MEMORY_CONFIRM",

--- a/rust-core/crates/friday-hub/src/lib.rs
+++ b/rust-core/crates/friday-hub/src/lib.rs
@@ -2643,6 +2643,21 @@ pub(crate) fn a1_run_outcome_learning_preamble_for_principals_flagged(
     Ok(preamble)
 }
 
+fn push_run_outcome_learning_prompt_row(
+    preamble: &mut String,
+    row: &friday_storage::learning_candidate::RunOutcomeLearningCandidateRow,
+) {
+    preamble.push_str("- ");
+    preamble.push_str(row.kind.as_str());
+    preamble.push_str(": ");
+    preamble.push_str(&row.summary);
+    preamble.push_str("; evidence=");
+    preamble.push_str(&row.evidence_ref);
+    preamble.push_str("; run=");
+    preamble.push_str(&row.run_id);
+    preamble.push('\n');
+}
+
 pub(crate) fn a1_run_outcome_learning_consumer_preamble_for_principals_flagged(
     db: &Db,
     principals: &[&str],
@@ -2662,29 +2677,52 @@ pub(crate) fn a1_run_outcome_learning_consumer_preamble_for_principals_flagged(
             row.kind,
             friday_storage::learning_candidate::RunOutcomeLearningKind::Preference
                 | friday_storage::learning_candidate::RunOutcomeLearningKind::WorldModel
+                | friday_storage::learning_candidate::RunOutcomeLearningKind::Reflex
         )
     })?;
     if matched.is_empty() {
         return Ok(String::new());
     }
 
-    let mut preamble =
-        "Confirmed preference/world-model learning signals (refs-only; no answer body):\n"
-            .to_string();
+    let mut preamble = String::new();
     let mut injected_ids = Vec::new();
-    for row in matched {
-        injected_ids.push(row.candidate_id.clone());
-        preamble.push_str("- ");
-        preamble.push_str(row.kind.as_str());
-        preamble.push_str(": ");
-        preamble.push_str(&row.summary);
-        preamble.push_str("; evidence=");
-        preamble.push_str(&row.evidence_ref);
-        preamble.push_str("; run=");
-        preamble.push_str(&row.run_id);
+    let preference_world_model: Vec<_> = matched
+        .iter()
+        .filter(|row| {
+            matches!(
+                row.kind,
+                friday_storage::learning_candidate::RunOutcomeLearningKind::Preference
+                    | friday_storage::learning_candidate::RunOutcomeLearningKind::WorldModel
+            )
+        })
+        .collect();
+    if !preference_world_model.is_empty() {
+        preamble.push_str(
+            "Confirmed preference/world-model learning signals (refs-only; no answer body):\n",
+        );
+        for row in preference_world_model {
+            injected_ids.push(row.candidate_id.clone());
+            push_run_outcome_learning_prompt_row(&mut preamble, row);
+        }
         preamble.push('\n');
     }
-    preamble.push('\n');
+    let reflex_rows: Vec<_> = matched
+        .iter()
+        .filter(|row| {
+            matches!(
+                row.kind,
+                friday_storage::learning_candidate::RunOutcomeLearningKind::Reflex
+            )
+        })
+        .collect();
+    if !reflex_rows.is_empty() {
+        preamble.push_str("Confirmed reflex learning signals (refs-only; no answer body):\n");
+        for row in reflex_rows {
+            injected_ids.push(row.candidate_id.clone());
+            push_run_outcome_learning_prompt_row(&mut preamble, row);
+        }
+        preamble.push('\n');
+    }
 
     let tx = db
         .conn()
@@ -17423,7 +17461,7 @@ mod tests {
     }
 
     #[test]
-    fn a1_run_outcome_learning_consumer_surfaces_preference_world_model_only() {
+    fn a1_run_outcome_learning_consumer_surfaces_preference_world_model_and_reflex() {
         let db = Db::open_hub(&temp_path("a1-consumer-on")).unwrap();
         let now = 1_000_000_000_000_i64;
         seed_confirmed_run_outcome_learning(
@@ -17473,8 +17511,10 @@ mod tests {
             "consumer flag-ON must inject preference/world-model refs-only signals: {preamble:?}"
         );
         assert!(
-            !preamble.contains("- reflex:"),
-            "consumer must not inject reflex candidates: {preamble:?}"
+            preamble.contains("Confirmed reflex learning signals")
+                && preamble.contains("- reflex:")
+                && preamble.contains("consumer=governance-only"),
+            "confirmed reflex candidates must drive a refs-only reflex section after explicit confirm: {preamble:?}"
         );
         assert!(
             !preamble.contains("operator confirmed"),

--- a/rust-core/crates/friday-hub/src/runtime.rs
+++ b/rust-core/crates/friday-hub/src/runtime.rs
@@ -7636,10 +7636,10 @@ mod tests {
     }
 
     #[test]
-    fn session_recall_public_path_surfaces_a1_consumer_preference_world_model_only() {
+    fn session_recall_public_path_surfaces_a1_consumer_preference_world_model_and_reflex() {
         // A1 preference/world-model consumer proof: the public session recall path reads the
-        // dark consumer gate and injects only refs-only preference/world_model signals. Reflex
-        // candidates remain governance-only, and operator decision text stays out of prompts.
+        // dark consumer gate and injects refs-only preference/world_model/reflex signals only
+        // after explicit confirmation. Operator decision text stays out of prompts.
         let (rt, _ws, _bodies) = recall_runtime("session-a1-consumer-public", Some("alice"));
         let now = 1_000_000_000_000_i64;
         seed_confirmed_run_outcome_learning_signal(
@@ -7704,8 +7704,10 @@ mod tests {
                 "consumer flag-ON session recall must inject preference/world-model refs-only signals: {on:?}"
             );
             assert!(
-                !on.contains("- reflex:"),
-                "consumer must not inject reflex candidates: {on:?}"
+                on.contains("Confirmed reflex learning signals")
+                    && on.contains("- reflex:")
+                    && on.contains("consumer=governance-only"),
+                "consumer flag-ON session recall must inject confirmed reflex refs-only signals: {on:?}"
             );
             assert!(
                 !on.contains("operator confirmed"),


### PR DESCRIPTION
## Summary
- extend the existing A1 run-outcome consumer gate to surface explicitly confirmed reflex candidates as refs-only prompt signals
- keep flag-OFF byte-identical, confirm-required, owner-scoped, refs-only behavior; operator decision text stays out of prompts
- update public session recall and consumer behavior tests to prove preference/world-model/reflex behavior under the existing FRIDAY_A1_RUN_OUTCOME_LEARNING_CONSUMER gate

## Truth labels
- BUILT-DARK/behavior proof only; this does not flip the prod flag and does not make A1 live-done
- organic/adopted remains 0 until a true operator/adopted run feeds and confirms candidates

## Validation
- cargo fmt --check
- git diff --check
- cargo test -p friday-hub a1_consumer --lib
- cargo test -p friday-hub a1_run_outcome_learning_consumer --lib
- cargo test -p friday-hub run_outcome_learning --lib
- cargo test -p friday-hub --lib (pre-rebase on disjoint base): 998 passed, 10 ignored
- post-rebase cargo test -p friday-hub run_outcome_learning --lib: 21 passed
