### PR TITLE
Wire iOS device keypair live path

### DIFF
--- a/apps/friday-ios/Sources/FridayMobileShell/FridayApp.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayApp.swift
@@ -68,7 +68,9 @@ final class FridaySession: ObservableObject {
     // store because no socket is opened. The master-derived LIVE write path (the iOS J2 mirror of
     // the read seam's `RealReadClientFactory.makeLive`) is now BUILT and wired behind an OPT-IN
     // env/arg gate (`FRIDAY_MOBILE_LIVE_WRITE=1` / `--live-write`, mirroring `FRIDAY_MOBILE_LIVE_READ`).
-    // This PR does NOT flip the shipped default (that, and the S6 control plane, are operator gates).
+    // A separate device-keypair live path is additive and explicitly opted in with
+    // `FRIDAY_MOBILE_LIVE_DEVICE_KEYPAIR=1` / `--live-device-keypair`; the shipped default still
+    // touches no keychain, opens no socket, and remains honest-unavailable.
     if preview {
       self.writeClient = Self.honestUnavailableWriteClient()
       self.missionClient = nil
@@ -99,6 +101,10 @@ final class FridaySession: ObservableObject {
       return HonestlyUnavailableReadClient()
     }
     do {
+      if useDeviceKeypair(args: args, env: env) {
+        let device = try DeviceKeypairStore.loadOrGenerate()
+        return RealReadClientFactory.makeLive(deviceKeypair: device)
+      }
       return try RealReadClientFactory.makeLive()
     } catch {
       return RealReadClientFactory.makeHonestlyUnavailable(reason: "\(error)")
@@ -131,12 +137,22 @@ final class FridaySession: ObservableObject {
       return nil
     }
     do {
+      if useDeviceKeypair(args: args, env: env) {
+        let device = try DeviceKeypairStore.loadOrGenerate()
+        return RealWriteClientFactory.makeLive(
+          deviceKeypair: device,
+          agentRunControlViaRust: runControlEnabled)
+      }
       return try RealWriteClientFactory.makeLive(agentRunControlViaRust: runControlEnabled)
     } catch {
-      // Master key unavailable (the J2 pairing problem on a real device): no mission-capable
-      // client. The caller falls back to the throwing honest-unavailable write client.
+      // Master/device key unavailable or corrupt: no mission-capable client. The caller falls back
+      // to the throwing honest-unavailable write client; never fabricate a ready chat surface.
       return nil
     }
+  }
+
+  static func useDeviceKeypair(args: [String], env: [String: String]) -> Bool {
+    args.contains("--live-device-keypair") || env["FRIDAY_MOBILE_LIVE_DEVICE_KEYPAIR"] == "1"
   }
 
   /// The honest-unavailable WRITE client: the shared `FridayClientFactory.makeWriteClient` with its

--- a/apps/friday-ios/Sources/FridayMobileShellCore/RealWriteClientFactory.swift
+++ b/apps/friday-ios/Sources/FridayMobileShellCore/RealWriteClientFactory.swift
@@ -141,4 +141,30 @@ public enum RealWriteClientFactory {
       sessionId: sessionId,
       agentRunControlViaRust: agentRunControlViaRust)
   }
+
+  /// Construct the LIVE write client for a REAL DEVICE using its OWN device-generated keypair
+  /// identity (the J2 mobile write-half client side).
+  ///
+  /// A real phone has no `~/.friday/master.key`, so `makeLive()` (the master-derived host path)
+  /// yields honest `.masterKeyMissing` there. This overload instead uses the device's
+  /// Keychain-persisted X25519 keypair (`DeviceKeypairStore.loadOrGenerate()`). Its PUBLIC key must
+  /// be enrolled in the write server's peer-allowlist before any live dispatch can authenticate.
+  ///
+  /// This only swaps the peer identity; it does NOT flip run-control, does NOT mint signatures, and
+  /// does NOT open any remote ingress. The default shipped app path remains the throwing
+  /// honest-unavailable client unless explicitly opted in by the app shell.
+  public static func makeLive(
+    deviceKeypair: DeviceKeypair,
+    config: AgentRunServerConfig = .liveLoopback,
+    forwardedPrincipal: String = liveAgentRunOwnerPrincipal,
+    sessionId: String? = nil,
+    agentRunControlViaRust: Bool = false
+  ) -> FridayMobileMissionDispatchingWriteClient {
+    make(
+      config: config,
+      keypair: deviceKeypair.keypair,
+      forwardedPrincipal: forwardedPrincipal,
+      sessionId: sessionId,
+      agentRunControlViaRust: agentRunControlViaRust)
+  }
 }

--- a/apps/friday-ios/Tests/FridayMobileShellCoreTests/DeviceKeypairStoreTests.swift
+++ b/apps/friday-ios/Tests/FridayMobileShellCoreTests/DeviceKeypairStoreTests.swift
@@ -107,3 +107,29 @@ func makeLiveWithDeviceKeypairBuildsClientAndIsHonestlyUnavailableWithNoServer()
     // Expected: honest-unavailable (connect/handshake failed) — not a mock, not a crash.
   }
 }
+
+@Test
+func makeLiveWriteWithDeviceKeypairBuildsClientAndIsHonestlyUnavailableWithNoServer() async throws {
+  // The WRITE-side device-keypair overload mirrors the read half: it builds a real sealed-WS write
+  // client, but against a DARK server it fails closed. This proves the device identity is no longer
+  // a read-only dead-code island without claiming a live mission dispatch, remote ingress, or S6.
+  let device = try DeviceKeypairStore.loadOrGenerate(backend: InMemoryDeviceKeypairBackend())
+
+  let deadConfig = AgentRunServerConfig(
+    host: "127.0.0.1",
+    port: 59998,
+    connectTimeout: 1,
+    receiveTimeout: 1)
+  let client = RealWriteClientFactory.makeLive(deviceKeypair: device, config: deadConfig)
+
+  do {
+    _ = try await client.dispatchAgentRun(task: "device-keypair dark write probe", constraints: nil)
+    Issue.record("a dark write server must NOT yield a successful dispatch")
+  } catch is FridayWriteClientError {
+    // Expected: honest-unavailable/fail-closed (connect/handshake failed), never a fabricated run.
+  } catch is FridayReadClientError {
+    // The write factory reuses the shared loopback transport; a dark socket can fail before the
+    // write wrapper seals an envelope, surfacing the shared transport error directly. Still
+    // fail-closed and never a fabricated run.
+  }
+}


### PR DESCRIPTION
## Summary
- add the iOS app-shell caller for the existing device-keypair read live path behind explicit opt-in (`FRIDAY_MOBILE_LIVE_DEVICE_KEYPAIR=1` / `--live-device-keypair`)
- add the matching write-side device-keypair live factory overload
- cover dark-server fail-closed behavior for the device-key write path

## Validation
- `swift test --package-path apps/friday-ios --filter DeviceKeypairStoreTests`
- `swift test --package-path apps/friday-ios`
- `./apps/friday-ios/build-sim.sh` and screenshot inspected
- `git diff --check`

## Truth labels
- default remains OFF / honest-unavailable; no shipped live flip
- no remote ingress, no true-device pairing proof, no S6/run-control flip, no operator signature
- moves J2 client prep only; not GO-LIVE and not v1 done
