### PR TITLE
Close missions after proven work completion

### DIFF
--- a/rust-core/crates/friday-storage/src/mission.rs
+++ b/rust-core/crates/friday-storage/src/mission.rs
@@ -1119,6 +1119,15 @@ fn transition_work_item_status_inner(
             now_ms,
         )?;
         upsert_work_item(&tx, &item)?;
+        maybe_close_mission_after_work_item_completion(
+            &tx,
+            &item,
+            previous_status,
+            &audit_id,
+            actor_ref,
+            reason,
+            now_ms,
+        )?;
         // (#24b degrade-3) ATOMIC executing-clear: when the caller routes a binding rest-state hop
         // through `transition_work_item_status_clearing_executing`, clear the durable `executing`
         // marker in the SAME transaction as the status write. `upsert_work_item` does NOT touch the
@@ -1136,6 +1145,104 @@ fn transition_work_item_status_inner(
 
         Ok((item, previous_status))
     })
+}
+
+fn maybe_close_mission_after_work_item_completion(
+    conn: &Connection,
+    item: &WorkItem,
+    previous_status: WorkItemStatus,
+    work_item_audit_id: &str,
+    actor_ref: &str,
+    reason: &str,
+    now_ms: i64,
+) -> Result<()> {
+    if previous_status == WorkItemStatus::CompletedWithProof
+        || item.status != WorkItemStatus::CompletedWithProof
+    {
+        return Ok(());
+    }
+
+    let Some(mut mission) = get_mission(conn, &item.mission_id)? else {
+        return Ok(());
+    };
+    if !mission.status.can_transition_to(MissionStatus::Done) {
+        return Ok(());
+    }
+
+    let work_items = list_work_items_for_mission(conn, &item.mission_id)?;
+    if work_items.is_empty()
+        || !work_items
+            .iter()
+            .all(|work_item| work_item.status == WorkItemStatus::CompletedWithProof)
+    {
+        return Ok(());
+    }
+    if has_unmaterialized_deferred_follow_up(conn, &item.mission_id, &work_items)? {
+        return Ok(());
+    }
+
+    let proof_ref = format!("audit://{work_item_audit_id}");
+    mission.status = mission
+        .status
+        .try_transition(MissionStatus::Done)
+        .map_err(|e| unsupported(e.to_string()))?;
+    mission.updated_at_ms = now_ms;
+    if !mission.proof_refs.contains(&proof_ref) {
+        mission.proof_refs.push(proof_ref.clone());
+    }
+    let lifecycle_entry = format!(
+        "lifecycle:{}:active->done by {}: auto-close after WorkItem '{}' completed_with_proof ({reason})",
+        mission.mission_id, actor_ref, item.work_item_id
+    );
+    mission.decision_path_summary =
+        append_lifecycle_summary(&mission.decision_path_summary, &lifecycle_entry);
+    upsert_mission(conn, &mission)?;
+
+    let mut conversation =
+        get_conversation(conn, &mission.friday_conversation_id)?.ok_or_else(|| {
+            unsupported(format!(
+                "mission_auto_close conversation '{}' not found",
+                mission.friday_conversation_id
+            ))
+        })?;
+    conversation
+        .active_mission_ids
+        .retain(|id| id != &mission.mission_id);
+    conversation.updated_at_ms = now_ms;
+    upsert_conversation(conn, &conversation)?;
+
+    Ok(())
+}
+
+fn has_unmaterialized_deferred_follow_up(
+    conn: &Connection,
+    mission_id: &str,
+    work_items: &[WorkItem],
+) -> Result<bool> {
+    for decision in list_route_decisions_for_mission(conn, mission_id)? {
+        if decision.deferred_options.is_empty() {
+            continue;
+        }
+        if decision
+            .inheritable_context
+            .iter()
+            .any(|context| context.starts_with("source_route_decision:"))
+        {
+            continue;
+        }
+        let source_marker = format!("source_route_decision:{}", decision.decision_id);
+        let materialized = work_items.iter().any(|work_item| {
+            work_item
+                .judgment_memory
+                .inheritable_context
+                .iter()
+                .any(|context| context == &source_marker)
+        });
+        if !materialized {
+            return Ok(true);
+        }
+    }
+    Ok(false)
 }
 
 pub fn veto_route_decision(
@@ -1248,6 +1355,12 @@ pub fn materialize_deferred_route_follow_up(
                 source.mission_id
             ))
         })?;
+        if mission.status.is_terminal() {
+            return Err(unsupported(format!(
+                "deferred_follow_up Mission '{}' is terminal",
+                source.mission_id
+            )));
+        }
         let source_proof_refs = if source.proof_receipts.is_empty() {
             vec![format!("friday://work-item/{}", source.work_item_id)]
         } else {

--- a/rust-core/crates/friday-storage/tests/work_item_lifecycle.rs
+++ b/rust-core/crates/friday-storage/tests/work_item_lifecycle.rs
@@ -135,6 +135,19 @@ fn seed(db: &Db, status: WorkItemStatus) {
     db.upsert_work_item(&work_item(status)).unwrap();
 }
 
+fn seed_extra_work_item(db: &Db, work_item_id: &str, status: WorkItemStatus) {
+    let mut item = work_item(status);
+    item.work_item_id = work_item_id.into();
+    item.judgment_memory.task = format!("extra WorkItem {work_item_id}");
+    db.upsert_work_item(&item).unwrap();
+
+    let mut mission = db.get_mission("mission-wi").unwrap().unwrap();
+    if !mission.work_item_ids.contains(&item.work_item_id) {
+        mission.work_item_ids.push(item.work_item_id);
+    }
+    db.upsert_mission(&mission).unwrap();
+}
+
 fn seed_route_decision(db: &Db) {
     let item = db.get_work_item("work-wi").unwrap().unwrap();
     let card = RouteDecisionCard::from_work_item(
@@ -267,6 +280,68 @@ fn completed_with_proof_without_a_receipt_is_rejected() {
     assert_eq!(prev, WorkItemStatus::ProviderWaiting);
     assert_eq!(item.status, WorkItemStatus::CompletedWithProof);
     assert!(item.completion_is_proven());
+}
+
+#[test]
+fn final_completed_work_item_closes_active_mission_with_audit_proof() {
+    let db = Db::open_hub(&temp_db_path("wi-final-closes-mission")).unwrap();
+    seed(&db, WorkItemStatus::ProviderWaiting);
+
+    let (item, prev) = db
+        .transition_work_item_status(
+            "work-wi",
+            WorkItemStatus::CompletedWithProof,
+            "agent:friday",
+            "claim done with proof",
+            Some("proof://provider-completed"),
+            10,
+        )
+        .unwrap();
+    assert_eq!(prev, WorkItemStatus::ProviderWaiting);
+    assert_eq!(item.status, WorkItemStatus::CompletedWithProof);
+
+    let mission = db.get_mission("mission-wi").unwrap().unwrap();
+    assert_eq!(mission.status, MissionStatus::Done);
+    assert!(mission
+        .proof_refs
+        .contains(&"audit://workitem_lifecycle:work-wi:10".to_string()));
+    assert!(mission
+        .decision_path_summary
+        .contains("auto-close after WorkItem 'work-wi' completed_with_proof"));
+
+    let conversation = db
+        .get_friday_conversation("fconv_wi_lifecycle")
+        .unwrap()
+        .unwrap();
+    assert!(
+        !conversation
+            .active_mission_ids
+            .contains(&"mission-wi".to_string()),
+        "closed Mission is removed from the active conversation set"
+    );
+}
+
+#[test]
+fn completed_work_item_does_not_close_mission_while_sibling_is_unfinished() {
+    let db = Db::open_hub(&temp_db_path("wi-sibling-open")).unwrap();
+    seed(&db, WorkItemStatus::ProviderWaiting);
+    seed_extra_work_item(&db, "work-wi-sibling", WorkItemStatus::ReadyToDispatch);
+
+    db.transition_work_item_status(
+        "work-wi",
+        WorkItemStatus::CompletedWithProof,
+        "agent:friday",
+        "first leg done",
+        Some("proof://provider-completed"),
+        10,
+    )
+    .unwrap();
+
+    assert_eq!(
+        db.get_mission("mission-wi").unwrap().unwrap().status,
+        MissionStatus::Active,
+        "Mission remains active until every WorkItem is completed_with_proof"
+    );
 }
 
 #[test]
@@ -446,6 +521,7 @@ fn route_decision_override_reassigns_before_dispatch_in_same_lifecycle_hop() {
 fn completed_hybrid_source_materializes_deferred_claude_follow_up_work_item() {
     let db = Db::open_hub(&temp_db_path("wi-deferred-followup")).unwrap();
     seed(&db, WorkItemStatus::ProviderWaiting);
+    seed_hybrid_route_decision(&db);
     let (source, _) = db
         .transition_work_item_status(
             "work-wi",
@@ -457,7 +533,11 @@ fn completed_hybrid_source_materializes_deferred_claude_follow_up_work_item() {
         )
         .unwrap();
     assert_eq!(source.status, WorkItemStatus::CompletedWithProof);
-    seed_hybrid_route_decision(&db);
+    assert_eq!(
+        db.get_mission("mission-wi").unwrap().unwrap().status,
+        MissionStatus::Active,
+        "unmaterialized deferred follow-up keeps Mission open"
+    );
 
     let follow = db
         .materialize_deferred_route_follow_up(DeferredRouteFollowUpRequest {
@@ -519,6 +599,67 @@ fn completed_hybrid_source_materializes_deferred_claude_follow_up_work_item() {
         )
         .unwrap();
     assert_eq!(audits, 1);
+}
+
+#[test]
+fn mission_closes_after_materialized_deferred_follow_up_completes() {
+    let db = Db::open_hub(&temp_db_path("wi-deferred-followup-close")).unwrap();
+    seed(&db, WorkItemStatus::ProviderWaiting);
+    seed_hybrid_route_decision(&db);
+
+    db.transition_work_item_status(
+        "work-wi",
+        WorkItemStatus::CompletedWithProof,
+        "agent:codex",
+        "codex first leg completed",
+        Some("proof://outcome/AnswerProduced/run-codex-first?signal=answer_len=12"),
+        10,
+    )
+    .unwrap();
+
+    db.materialize_deferred_route_follow_up(DeferredRouteFollowUpRequest {
+        decision_id: "route-decision-work-wi",
+        source_work_item_id: "work-wi",
+        follow_up_work_item_id: "work-wi-claude-followup",
+        follow_up_lane: WorkLane::Claude,
+        follow_up_provider_or_agent: Some("claude"),
+        actor_ref: "agent:friday",
+        reason: "create tracked Claude synthesis leg after Codex proof",
+        now_ms: 20,
+    })
+    .unwrap();
+
+    for (now, next) in [
+        (21, WorkItemStatus::Dispatched),
+        (22, WorkItemStatus::HubAccepted),
+        (23, WorkItemStatus::ProviderRouted),
+        (24, WorkItemStatus::ProviderWaiting),
+    ] {
+        db.transition_work_item_status(
+            "work-wi-claude-followup",
+            next,
+            "agent:friday",
+            "advance follow-up",
+            None,
+            now,
+        )
+        .unwrap();
+    }
+    db.transition_work_item_status(
+        "work-wi-claude-followup",
+        WorkItemStatus::CompletedWithProof,
+        "agent:claude",
+        "claude follow-up completed",
+        Some("proof://outcome/AnswerProduced/run-claude-followup?signal=answer_len=18"),
+        25,
+    )
+    .unwrap();
+
+    let mission = db.get_mission("mission-wi").unwrap().unwrap();
+    assert_eq!(mission.status, MissionStatus::Done);
+    assert!(mission
+        .proof_refs
+        .contains(&"audit://workitem_lifecycle:work-wi-claude-followup:25".to_string()));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Auto-close an active Mission to done when a WorkItem newly reaches completed_with_proof and every WorkItem in that Mission is completed_with_proof.
- Use the WorkItem lifecycle audit row as the Mission done proof ref and remove the Mission from the conversation active set in the same transaction.
- Keep hybrid/deferred routes open until their deferred follow-up WorkItems are materialized and completed; refuse materializing follow-ups into terminal Missions.

## Validation
- cargo fmt --check
- cargo test -p friday-storage --test work_item_lifecycle -- --nocapture
- cargo test -p friday-storage --test mission_spine -- --nocapture
- cargo test -p friday-storage retention -- --nocapture
- cargo test -p friday-hub mission_preflight -- --nocapture
- cargo test -p friday-hub mission_runtime -- --nocapture
- cargo test -p friday-hub --test resume_mission_workitem_completion -- --nocapture
- cargo clippy -p friday-storage --all-targets -- -D warnings
- git diff --check

## Truth Boundary
- This is Mission Spine lifecycle closure only.
- It is not strict OG9 organic, not D20/B4 true-sign closure, not GO-LIVE, and not v1 done.