### PR TITLE
Close missions after run-bound follow-up materializes

### DIFF
--- a/rust-core/crates/friday-storage/src/mission.rs
+++ b/rust-core/crates/friday-storage/src/mission.rs
@@ -1219,7 +1219,8 @@ fn has_unmaterialized_deferred_follow_up(
     mission_id: &str,
     work_items: &[WorkItem],
 ) -> Result<bool> {
-    for decision in list_route_decisions_for_mission(conn, mission_id)? {
+    let route_decisions = list_route_decisions_for_mission(conn, mission_id)?;
+    for decision in &route_decisions {
         if decision.deferred_options.is_empty() {
             continue;
         }
@@ -1230,19 +1231,51 @@ fn has_unmaterialized_deferred_follow_up(
         {
             continue;
         }
-        let source_marker = format!("source_route_decision:{}", decision.decision_id);
-        let materialized = work_items.iter().any(|work_item| {
-            work_item
-                .judgment_memory
-                .inheritable_context
-                .iter()
-                .any(|context| context == &source_marker)
-        });
-        if !materialized {
+        if !deferred_route_decision_materialized(decision, &route_decisions, work_items) {
             return Ok(true);
         }
     }
     Ok(false)
+}
+
+fn deferred_route_decision_materialized(
+    decision: &RouteDecisionCard,
+    route_decisions: &[RouteDecisionCard],
+    work_items: &[WorkItem],
+) -> bool {
+    let source_marker = format!("source_route_decision:{}", decision.decision_id);
+    if work_items.iter().any(|work_item| {
+        work_item
+            .judgment_memory
+            .inheritable_context
+            .iter()
+            .any(|context| context == &source_marker)
+    }) {
+        return true;
+    }
+
+    // Product intake can record an early route decision, then the mission-bound run records the
+    // actionable route decision for the same source WorkItem and materializes the follow-up from
+    // that later card. Do not keep the Mission open on the stale intake twin once the same source
+    // WorkItem has a later materialized deferred decision.
+    route_decisions
+        .iter()
+        .filter(|candidate| {
+            candidate.decision_id != decision.decision_id
+                && candidate.work_item_id == decision.work_item_id
+                && candidate.created_at_ms >= decision.created_at_ms
+                && !candidate.deferred_options.is_empty()
+        })
+        .any(|candidate| {
+            let source_marker = format!("source_route_decision:{}", candidate.decision_id);
+            work_items.iter().any(|work_item| {
+                work_item
+                    .judgment_memory
+                    .inheritable_context
+                    .iter()
+                    .any(|context| context == &source_marker)
+            })
+        })
 }
 
 pub fn veto_route_decision(

--- a/rust-core/crates/friday-storage/tests/work_item_lifecycle.rs
+++ b/rust-core/crates/friday-storage/tests/work_item_lifecycle.rs
@@ -663,6 +663,91 @@ fn mission_closes_after_materialized_deferred_follow_up_completes() {
 }
 
 #[test]
+fn mission_closes_when_run_bound_deferred_decision_materializes_intake_twin() {
+    let db = Db::open_hub(&temp_db_path("wi-deferred-followup-intake-twin-close")).unwrap();
+    seed(&db, WorkItemStatus::ProviderWaiting);
+    seed_hybrid_route_decision(&db);
+
+    db.transition_work_item_status(
+        "work-wi",
+        WorkItemStatus::CompletedWithProof,
+        "agent:codex",
+        "codex first leg completed",
+        Some("friday://agent-run/run-codex-first"),
+        10,
+    )
+    .unwrap();
+
+    let mut source = db.get_work_item("work-wi").unwrap().unwrap();
+    source.judgment_memory.why_this_route =
+        "Codex first for workspace execution; Claude synthesis follow-up deferred".into();
+    source.judgment_memory.considered_options = vec![
+        "combination: Codex first, Claude synthesis after proof".into(),
+        "claude: writing only".into(),
+    ];
+    source.judgment_memory.deferred_options = vec!["Claude synthesis follow-up".into()];
+    db.upsert_route_decision(&RouteDecisionCard::from_work_item(
+        "route-decision:agent-loop:run-codex-first".into(),
+        &source,
+        vec![
+            "agent-run:run-codex-first".into(),
+            "friday://agent-run/run-codex-first".into(),
+        ],
+        11,
+        None,
+    ))
+    .unwrap();
+
+    db.materialize_deferred_route_follow_up(DeferredRouteFollowUpRequest {
+        decision_id: "route-decision:agent-loop:run-codex-first",
+        source_work_item_id: "work-wi",
+        follow_up_work_item_id: "work-wi-claude-followup",
+        follow_up_lane: WorkLane::Claude,
+        follow_up_provider_or_agent: Some("claude"),
+        actor_ref: "agent:friday",
+        reason: "create tracked Claude synthesis leg after Codex proof",
+        now_ms: 12,
+    })
+    .unwrap();
+
+    for (now, next) in [
+        (13, WorkItemStatus::Dispatched),
+        (14, WorkItemStatus::HubAccepted),
+        (15, WorkItemStatus::ProviderRouted),
+        (16, WorkItemStatus::ProviderWaiting),
+    ] {
+        db.transition_work_item_status(
+            "work-wi-claude-followup",
+            next,
+            "agent:friday",
+            "advance follow-up",
+            None,
+            now,
+        )
+        .unwrap();
+    }
+    db.transition_work_item_status(
+        "work-wi-claude-followup",
+        WorkItemStatus::CompletedWithProof,
+        "agent:claude",
+        "claude follow-up completed",
+        Some("proof://outcome/AnswerProduced/run-claude-followup?signal=answer_len=18"),
+        17,
+    )
+    .unwrap();
+
+    let mission = db.get_mission("mission-wi").unwrap().unwrap();
+    assert_eq!(
+        mission.status,
+        MissionStatus::Done,
+        "a stale intake-time deferred decision must not keep the Mission active after the same source WorkItem's run-bound decision materialized and completed its follow-up"
+    );
+    assert!(mission
+        .proof_refs
+        .contains(&"audit://workitem_lifecycle:work-wi-claude-followup:17".to_string()));
+}
+
+#[test]
 fn deferred_follow_up_requires_proven_source_and_unused_follow_up_id() {
     let db = Db::open_hub(&temp_db_path("wi-deferred-followup-gates")).unwrap();
     seed(&db, WorkItemStatus::ReadyToDispatch);


### PR DESCRIPTION
## Summary
- Treat stale intake-time deferred route decisions as materialized once a later run-bound route decision for the same source WorkItem has materialized its follow-up.
- Preserve the existing direct source_route_decision materialization check for normal deferred follow-ups.
- Add a regression for the live product shape where intake and run-bound route decisions coexist and the Claude follow-up completes.

## Validation
- cargo fmt --check
- cargo test -p friday-storage mission_closes_when_run_bound_deferred_decision_materializes_intake_twin -- --nocapture
- cargo test -p friday-storage --test work_item_lifecycle -- --nocapture
- cargo test -p friday-hub mission_preflight -- --nocapture

## Live finding
After #1018 + FRIDAY_WORKITEM_GUARDED_TRANSITION=1, the desktop live product dogfood produced lifecycle audit rows for both Codex and Claude WorkItems, but Mission remained active because the intake-time deferred decision still appeared unmaterialized. This patch fixes that storage truth condition.