### PR TITLE
Cap stale A1 run-outcome learning signals

### DIFF
--- a/rust-core/crates/friday-hub/src/lib.rs
+++ b/rust-core/crates/friday-hub/src/lib.rs
@@ -2539,15 +2539,17 @@ pub(crate) fn recall_preamble_for_principals_blended(
 fn matched_run_outcome_learning_candidates_for_principals<F>(
     db: &Db,
     principals: &[&str],
+    now_ms: i64,
     keep: F,
 ) -> Result<Vec<friday_storage::learning_candidate::RunOutcomeLearningCandidateRow>, StorageError>
 where
     F: Fn(&friday_storage::learning_candidate::RunOutcomeLearningCandidateRow) -> bool,
 {
     let rows =
-        friday_storage::learning_candidate::list_recent_eligible_confirmed_run_outcome_candidates(
+        friday_storage::learning_candidate::list_recent_eligible_confirmed_run_outcome_candidates_at(
             db.conn(),
             64,
+            Some(now_ms),
         )?;
     let mut matched = Vec::new();
     for row in rows {
@@ -2600,7 +2602,8 @@ pub(crate) fn a1_run_outcome_learning_preamble_for_principals_flagged(
         return Ok(String::new());
     }
 
-    let matched = matched_run_outcome_learning_candidates_for_principals(db, principals, |_| true)?;
+    let matched =
+        matched_run_outcome_learning_candidates_for_principals(db, principals, now_ms, |_| true)?;
     if matched.is_empty() {
         return Ok(String::new());
     }
@@ -2672,14 +2675,15 @@ pub(crate) fn a1_run_outcome_learning_consumer_preamble_for_principals_flagged(
         return Ok(String::new());
     }
 
-    let matched = matched_run_outcome_learning_candidates_for_principals(db, principals, |row| {
-        matches!(
-            row.kind,
-            friday_storage::learning_candidate::RunOutcomeLearningKind::Preference
-                | friday_storage::learning_candidate::RunOutcomeLearningKind::WorldModel
-                | friday_storage::learning_candidate::RunOutcomeLearningKind::Reflex
-        )
-    })?;
+    let matched =
+        matched_run_outcome_learning_candidates_for_principals(db, principals, now_ms, |row| {
+            matches!(
+                row.kind,
+                friday_storage::learning_candidate::RunOutcomeLearningKind::Preference
+                    | friday_storage::learning_candidate::RunOutcomeLearningKind::WorldModel
+                    | friday_storage::learning_candidate::RunOutcomeLearningKind::Reflex
+            )
+        })?;
     if matched.is_empty() {
         return Ok(String::new());
     }
@@ -17457,6 +17461,50 @@ mod tests {
                 && confirmed.contains("- preference:")
                 && confirmed.contains("friday://agent-run/run-a1-confirm"),
             "confirmed preference candidate must be the first point it can affect recall: {confirmed:?}"
+        );
+    }
+
+    #[test]
+    fn a1_run_outcome_learning_consumer_excludes_stale_confirmed_signals() {
+        let db = Db::open_hub(&temp_path("a1-consumer-stale")).unwrap();
+        let now = 1_000_000_000_000_i64;
+        seed_confirmed_run_outcome_learning(
+            &db,
+            "sess-a1-stale",
+            "alice",
+            "run-a1-stale",
+            now - friday_storage::learning_candidate::MAX_CONFIRMED_SIGNAL_AGE_MS - 10,
+        );
+        seed_confirmed_run_outcome_learning(
+            &db,
+            "sess-a1-fresh",
+            "alice",
+            "run-a1-fresh",
+            now - friday_storage::learning_candidate::MAX_CONFIRMED_SIGNAL_AGE_MS + 10,
+        );
+        let alice_ns =
+            crate::session_namespace::resolve_session_memory_namespace(None, None, Some("alice"))
+                .unwrap();
+
+        let preamble = recall_preamble_for_principals_blended(
+            &db,
+            &[alice_ns.as_str()],
+            None,
+            RecallPreambleFlags {
+                a1_run_outcome_consumer_on: true,
+                ..RecallPreambleFlags::default()
+            },
+            "audit-a1-consumer-stale",
+            now,
+        )
+        .unwrap();
+        assert!(
+            preamble.contains("run-a1-fresh"),
+            "fresh confirmed signal must still inject: {preamble:?}"
+        );
+        assert!(
+            !preamble.contains("run-a1-stale"),
+            "stale confirmed signal must not inject after the freshness cap: {preamble:?}"
         );
     }
 

--- a/rust-core/crates/friday-storage/src/learning_candidate.rs
+++ b/rust-core/crates/friday-storage/src/learning_candidate.rs
@@ -116,6 +116,7 @@ const SELECT_COLS: &str = "candidate_id, run_id, session_id, kind, state, eviden
 const MIN_CONFIRMED_TURNS: i64 = 1;
 const MIN_CONFIRMED_EXECUTED_TOOLS: i64 = 1;
 const MAX_ELIGIBILITY_SCAN_LIMIT: i64 = 256;
+pub const MAX_CONFIRMED_SIGNAL_AGE_MS: i64 = 30 * 24 * 60 * 60 * 1000;
 
 fn run_outcome_candidate_summary(
     kind: RunOutcomeLearningKind,
@@ -219,6 +220,14 @@ pub fn list_recent_eligible_confirmed_run_outcome_candidates(
     conn: &Connection,
     limit: i64,
 ) -> Result<Vec<RunOutcomeLearningCandidateRow>> {
+    list_recent_eligible_confirmed_run_outcome_candidates_at(conn, limit, None)
+}
+
+pub fn list_recent_eligible_confirmed_run_outcome_candidates_at(
+    conn: &Connection,
+    limit: i64,
+    now_ms: Option<i64>,
+) -> Result<Vec<RunOutcomeLearningCandidateRow>> {
     let limit = limit.max(1);
     let scan_limit = (limit * 4).clamp(limit, MAX_ELIGIBILITY_SCAN_LIMIT);
     let confirmed = list_recent_confirmed_run_outcome_candidates(conn, scan_limit)?;
@@ -230,6 +239,12 @@ pub fn list_recent_eligible_confirmed_run_outcome_candidates(
         }
         if let Some(pair) = contradiction_pair(&row.summary) {
             if blocked_pairs.contains(&pair) {
+                continue;
+            }
+        }
+        if let Some(now_ms) = now_ms {
+            let anchor_ms = row.decided_at_ms.unwrap_or(row.created_at_ms);
+            if now_ms.saturating_sub(anchor_ms) > MAX_CONFIRMED_SIGNAL_AGE_MS {
                 continue;
             }
         }
@@ -424,5 +439,21 @@ mod tests {
                 "a1:run-2:preference",
             ]
         );
+    }
+
+    #[test]
+    fn eligible_confirmed_candidates_enforce_freshness_cap_when_clocked() {
+        let db = Db::open_hub(&tmp("freshness")).unwrap();
+        let now = 1_000_000_000_000_i64;
+        confirm_preference(&db, "stale", 2, 1, now - MAX_CONFIRMED_SIGNAL_AGE_MS - 10);
+        confirm_preference(&db, "fresh", 2, 1, now - MAX_CONFIRMED_SIGNAL_AGE_MS + 10);
+
+        let ids: Vec<_> =
+            list_recent_eligible_confirmed_run_outcome_candidates_at(db.conn(), 10, Some(now))
+                .unwrap()
+                .into_iter()
+                .map(|row| row.candidate_id)
+                .collect();
+        assert_eq!(ids, vec!["a1:fresh:preference"]);
     }
 }


### PR DESCRIPTION
## Summary
- add a clocked eligibility path for confirmed A1 run-outcome learning candidates
- cap prompt-level A1 learning recall/consumer signals to fresh confirmed rows only
- add storage and hub behavior tests for stale exclusion while preserving flag-off/default behavior

## Truth label
- build-DARK / behavior-hardening only
- does not flip A1 live, does not satisfy organic, and does not mutate durable preference/world-model/reflex state at request time

## Validation
- cargo fmt --check
- cargo test -p friday-storage learning_candidate -- --nocapture
- cargo test -p friday-hub a1_run_outcome_learning_consumer -- --nocapture
- git diff --check