### PR TITLE
Anchor product follow-up prompts to first-leg context

### DIFF
--- a/apps/friday-ios/Sources/FridayMobileShellCore/FridayChatViewModel.swift
+++ b/apps/friday-ios/Sources/FridayMobileShellCore/FridayChatViewModel.swift
@@ -344,8 +344,11 @@ public final class FridayChatViewModel: ObservableObject {
         return
       }
 
+      let firstAnswer = await fetchDeliveredAnswerBody(for: firstReceipt.runId)
       let followUp = try await dispatchClaudeFollowUpIfPresent(
         sourceWorkItemId: workItemId,
+        firstRunId: firstReceipt.runId,
+        firstAnswerBody: firstAnswer?.body,
         intakeResult: result,
         missionClient: missionClient)
       let bodyRunId = followUp?.runId ?? firstReceipt.runId
@@ -367,6 +370,8 @@ public final class FridayChatViewModel: ObservableObject {
 
   private func dispatchClaudeFollowUpIfPresent(
     sourceWorkItemId: String,
+    firstRunId: String,
+    firstAnswerBody: String?,
     intakeResult: MissionIntakeResultWire,
     missionClient: any FridayMissionBoundRunWriteClient
   ) async throws -> (workItemId: String, runId: String)? {
@@ -380,7 +385,11 @@ public final class FridayChatViewModel: ObservableObject {
     }
 
     let outcome = try await missionClient.dispatchMissionBoundAgentRun(
-      task: Self.claudeFollowUpTask,
+      task: Self.claudeFollowUpTask(
+        sourceWorkItemId: sourceWorkItemId,
+        followUpWorkItemId: followUpWorkItemId,
+        firstRunId: firstRunId,
+        firstAnswerBody: firstAnswerBody),
       missionContext: MissionWorkItemContextWire(
         fridayConversationId: intakeResult.fridayConversationId,
         missionId: intakeResult.missionId,
@@ -558,8 +567,31 @@ public final class FridayChatViewModel: ObservableObject {
       lane: "auto")
   }
 
-  private static let claudeFollowUpTask =
-    "Run the generated Claude follow-up for this Mission. Use the inherited Codex first-leg "
-      + "proof and input refs attached to this WorkItem, keep the run read-only, and summarize "
-      + "the follow-up outcome."
+  private static let claudeFollowUpTaskHeader =
+    "Run the generated Claude follow-up for this Mission."
+
+  private static func claudeFollowUpTask(
+    sourceWorkItemId: String,
+    followUpWorkItemId: String,
+    firstRunId: String,
+    firstAnswerBody: String?
+  ) -> String {
+    var lines = [
+      claudeFollowUpTaskHeader,
+      "source_work_item_id=\(sourceWorkItemId)",
+      "follow_up_work_item_id=\(followUpWorkItemId)",
+      "codex_first_run_id=\(firstRunId)",
+    ]
+    if let firstAnswerBody = firstAnswerBody?.trimmingCharacters(in: .whitespacesAndNewlines),
+      !firstAnswerBody.isEmpty
+    {
+      lines.append("Codex first-leg answer:")
+      lines.append(firstAnswerBody)
+    }
+    lines.append(
+      "Use the Mission context and the proof/input refs already attached to this WorkItem; do not ask the operator for paths, IDs, or artifact locations that are listed above.")
+    lines.append(
+      "Keep the run read-only; summarize the Codex first-leg answer and this follow-up outcome, and do not claim you verified unrelated files or artifacts unless that evidence is explicitly present in the provided context.")
+    return lines.joined(separator: "\n")
+  }
 }

--- a/apps/friday-ios/Tests/FridayMobileShellCoreTests/FridayChatViewModelTests.swift
+++ b/apps/friday-ios/Tests/FridayMobileShellCoreTests/FridayChatViewModelTests.swift
@@ -59,6 +59,7 @@ final class FridayChatViewModelTests: XCTestCase {
   final class FakeMissionClient: FridayMobileMissionDispatchingWriteClient, @unchecked Sendable {
     private(set) var submittedIntakes: [MissionIntakeRequestWire] = []
     private(set) var missionContexts: [MissionWorkItemContextWire] = []
+    private(set) var dispatchedTasks: [String] = []
 
     func dispatchAgentRun(
       task: String,
@@ -108,6 +109,7 @@ final class FridayChatViewModelTests: XCTestCase {
       missionContext: MissionWorkItemContextWire,
       constraints: AgentRunConstraintsWire?
     ) async throws -> AgentRunDispatchOutcome {
+      dispatchedTasks.append(task)
       missionContexts.append(missionContext)
       let runId = missionContext.workItemId.hasSuffix("-claude-followup") ? "run-followup" : "run-first"
       return .result(AgentRunResultWire(
@@ -296,7 +298,10 @@ final class FridayChatViewModelTests: XCTestCase {
       snapshot: try WorkbenchSnapshot(
         projectionJSON: Data(snapshotJSON.utf8),
         generatedAtMs: 0),
-      answerBodies: ["run-followup": "Claude follow-up body visible to the owner."])
+      answerBodies: [
+        "run-first": "Mobile Codex first answer",
+        "run-followup": "Claude follow-up body visible to the owner.",
+      ])
     let vm = FridayChatViewModel(
       writeClient: mission,
       signer: MockOperatorSigner(),
@@ -312,6 +317,13 @@ final class FridayChatViewModelTests: XCTestCase {
       "work-mobile-fixed",
       "work-mobile-fixed-claude-followup",
     ])
+    XCTAssertEqual(mission.dispatchedTasks.count, 2)
+    XCTAssertTrue(mission.dispatchedTasks[1].contains("source_work_item_id=work-mobile-fixed"))
+    XCTAssertTrue(mission.dispatchedTasks[1].contains("follow_up_work_item_id=work-mobile-fixed-claude-followup"))
+    XCTAssertTrue(mission.dispatchedTasks[1].contains("codex_first_run_id=run-first"))
+    XCTAssertTrue(mission.dispatchedTasks[1].contains("Mobile Codex first answer"))
+    XCTAssertTrue(mission.dispatchedTasks[1].contains("do not ask the operator for paths"))
+    XCTAssertTrue(mission.dispatchedTasks[1].contains("do not claim you verified unrelated files"))
     guard case .answered(let receipt) = vm.phase else { return XCTFail("expected answered, got \(vm.phase)") }
     XCTAssertEqual(receipt.runId, "run-first")
     XCTAssertEqual(receipt.missionId, "mission-mobile-fixed")

--- a/apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/OperationsOverviewViewModel.swift
+++ b/apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/OperationsOverviewViewModel.swift
@@ -296,11 +296,14 @@ public final class OperationsOverviewViewModel: ObservableObject {
               missionContext: context,
               constraints: AgentRunConstraintsWire(readOnly: true))
             summary += Self.dispatchSummary(for: outcome)
-            if let answerBody = await answerBodyText(for: outcome, label: "Codex") {
-              answerBodies.append(answerBody)
+            let codexAnswerBody = await answerBodyText(for: outcome, label: "Codex")
+            if let codexAnswerBody {
+              answerBodies.append(codexAnswerBody)
             }
             if let followUpSummary = try await dispatchClaudeFollowUpIfPresent(
               sourceWorkItemId: workItemId,
+              firstOutcome: outcome,
+              firstAnswerBody: codexAnswerBody,
               intakeResult: result,
               missionRunClient: missionRunClient)
             {
@@ -329,6 +332,8 @@ public final class OperationsOverviewViewModel: ObservableObject {
 
   private func dispatchClaudeFollowUpIfPresent(
     sourceWorkItemId: String,
+    firstOutcome: AgentRunDispatchOutcome,
+    firstAnswerBody: String?,
     intakeResult: MissionIntakeResultWire,
     missionRunClient: FridayMissionBoundRunWriteClient
   ) async throws -> FollowUpDispatch? {
@@ -342,7 +347,11 @@ public final class OperationsOverviewViewModel: ObservableObject {
     }
 
     let outcome = try await missionRunClient.dispatchMissionBoundAgentRun(
-      task: Self.claudeFollowUpTask,
+      task: Self.claudeFollowUpTask(
+        sourceWorkItemId: sourceWorkItemId,
+        followUpWorkItemId: followUpWorkItemId,
+        firstRunId: Self.runId(for: firstOutcome),
+        firstAnswerBody: firstAnswerBody),
       missionContext: MissionWorkItemContextWire(
         fridayConversationId: intakeResult.fridayConversationId,
         missionId: intakeResult.missionId,
@@ -508,10 +517,40 @@ public final class OperationsOverviewViewModel: ObservableObject {
     }
   }
 
-  private static let claudeFollowUpTask =
-    "Run the generated Claude follow-up for this Mission. Use the inherited Codex first-leg "
-      + "proof and input refs attached to this WorkItem, keep the run read-only, and summarize "
-      + "the follow-up outcome."
+  private static let claudeFollowUpTaskHeader =
+    "Run the generated Claude follow-up for this Mission."
+
+  private static func claudeFollowUpTask(
+    sourceWorkItemId: String,
+    followUpWorkItemId: String,
+    firstRunId: String?,
+    firstAnswerBody: String?
+  ) -> String {
+    var lines = [
+      claudeFollowUpTaskHeader,
+      "source_work_item_id=\(sourceWorkItemId)",
+      "follow_up_work_item_id=\(followUpWorkItemId)",
+    ]
+    if let firstRunId {
+      lines.append("codex_first_run_id=\(firstRunId)")
+    }
+    if let firstAnswerBody = firstAnswerBody?.trimmingCharacters(in: .whitespacesAndNewlines),
+      !firstAnswerBody.isEmpty
+    {
+      lines.append("Codex first-leg answer:")
+      lines.append(firstAnswerBody)
+    }
+    lines.append(
+      "Use the Mission context and the proof/input refs already attached to this WorkItem; do not ask the operator for paths, IDs, or artifact locations that are listed above.")
+    lines.append(
+      "Keep the run read-only; summarize the Codex first-leg answer and this follow-up outcome, and do not claim you verified unrelated files or artifacts unless that evidence is explicitly present in the provided context.")
+    return lines.joined(separator: "\n")
+  }
+
+  private static func runId(for outcome: AgentRunDispatchOutcome) -> String? {
+    guard case let .result(result) = outcome else { return nil }
+    return result.runId
+  }
 
   private static func reason(for error: Error) -> String {
     // Mock / preview / adapter vocabulary (503 / offline / projection-unavailable).

--- a/apps/macos/FridayHubConsole/Tests/FridayHubConsoleCoreTests/OperationsOverviewViewModelTests.swift
+++ b/apps/macos/FridayHubConsole/Tests/FridayHubConsoleCoreTests/OperationsOverviewViewModelTests.swift
@@ -298,6 +298,7 @@ final class MockMissionSpineWriteClient: FridayMissionSpineWriteClient, FridayMi
   private var _lastMissionContext: MissionWorkItemContextWire?
   private var _lastMissionRunConstraints: AgentRunConstraintsWire?
   private var _missionContexts: [MissionWorkItemContextWire] = []
+  private var _dispatchedTasks: [String] = []
   var lastIntake: MissionIntakeRequestWire? { lock.withLock { _lastIntake } }
   var lastDecision: MemoryDecisionRequestWire? { lock.withLock { _lastDecision } }
   var lastLearningDecision: RunOutcomeLearningDecisionRequestWire? {
@@ -306,6 +307,7 @@ final class MockMissionSpineWriteClient: FridayMissionSpineWriteClient, FridayMi
   var lastMissionContext: MissionWorkItemContextWire? { lock.withLock { _lastMissionContext } }
   var lastMissionRunConstraints: AgentRunConstraintsWire? { lock.withLock { _lastMissionRunConstraints } }
   var missionContexts: [MissionWorkItemContextWire] { lock.withLock { _missionContexts } }
+  var dispatchedTasks: [String] { lock.withLock { _dispatchedTasks } }
 
   init(behavior: Behavior) { self.behavior = behavior }
 
@@ -380,6 +382,7 @@ final class MockMissionSpineWriteClient: FridayMissionSpineWriteClient, FridayMi
       _lastMissionContext = missionContext
       _lastMissionRunConstraints = constraints
       _missionContexts.append(missionContext)
+      _dispatchedTasks.append(task)
     }
     if case .throwsTransport = behavior {
       throw FridayWriteClientError.transport("connection refused (write server dark)")
@@ -635,7 +638,8 @@ func submitIntakeDispatchesClaudeFollowUpWhenProjectionExposesGeneratedWorkItem(
     snapshot: snapshotWithWorkItems(
       missionId: "mission-desktop-fixed",
       fridayConversationId: "fconv_desktop_fixed",
-      workItemIds: ["work-desktop-fixed", "work-desktop-fixed-claude-followup"]))
+      workItemIds: ["work-desktop-fixed", "work-desktop-fixed-claude-followup"]),
+    answerBodies: ["run-bound-1": "Desktop Codex first answer"])
   let vm = OperationsOverviewViewModel(
     client: read, writeClient: write, missionRunClient: write,
     writeOwnerPrincipal: "admin-001", newId: { "fixed" })
@@ -650,6 +654,13 @@ func submitIntakeDispatchesClaudeFollowUpWhenProjectionExposesGeneratedWorkItem(
   #expect(
     write.missionContexts.map(\.workItemId)
       == ["work-desktop-fixed", "work-desktop-fixed-claude-followup"])
+  #expect(write.dispatchedTasks.count == 2)
+  #expect(write.dispatchedTasks[1].contains("source_work_item_id=work-desktop-fixed"))
+  #expect(write.dispatchedTasks[1].contains("follow_up_work_item_id=work-desktop-fixed-claude-followup"))
+  #expect(write.dispatchedTasks[1].contains("codex_first_run_id=run-bound-1"))
+  #expect(write.dispatchedTasks[1].contains("Desktop Codex first answer"))
+  #expect(write.dispatchedTasks[1].contains("do not ask the operator for paths"))
+  #expect(write.dispatchedTasks[1].contains("do not claim you verified unrelated files"))
 }
 
 @Test


### PR DESCRIPTION
## Summary
- pass Codex first-leg run id and answer body into generated Claude follow-up prompts on desktop and iOS product paths
- tell the follow-up not to ask for paths/IDs already present in mission context/proof refs
- prevent overclaiming unrelated artifact verification unless evidence is explicitly present in provided context
- add view-model tests proving the follow-up task contains source/follow-up IDs and first-leg answer context

## Evidence
- swift test --package-path apps/macos/FridayHubConsole --filter submitIntakeDispatchesClaudeFollowUpWhenProjectionExposesGeneratedWorkItem
- swift test --package-path apps/friday-ios --filter testSend_withMissionClient_dispatchesGeneratedClaudeFollowUp
- FRIDAY_MOBILE_LIVE_PRODUCT_AUTO_FOLLOWUP_RUN_TEST=1 swift test --package-path apps/friday-ios --filter liveMobileChatSendAutoDispatchesHybridClaudeFollowUp
- FRIDAY_CONSOLE_LIVE_PRODUCT_AUTO_FOLLOWUP_RUN_TEST=1 swift test --package-path apps/macos/FridayHubConsole --filter liveOperationsOverviewSubmitIntakeAutoDispatchesHybridClaudeFollowUp
- swift test --package-path apps/macos/FridayHubConsole
- swift test --package-path apps/friday-ios
- git diff --check

## Live proof
After the first change, live product runs completed on both surfaces and Claude follow-up answers no longer asked for missing WorkItem/path context. I then tightened the prompt to avoid claiming unrelated artifact verification unless explicit evidence is present.

- desktop mission `mission-desktop-liveauto2146970fe23642298468d8d28ea7d0f2`; Codex run `run-6E541778-F0E6-48E5-86B4-FE093D1A6F51`; Claude run `run-2335B743-0A36-4E36-A68F-E3AF8AC3D662`
- mobile mission `mission-mobile-liveauto9c05d4a90e1a4c8b920f76879a9347d4`; Codex run `run-3F9C3036-4641-4D28-95A3-5C6EEFC2E8A5`; Claude run `run-20E02A77-8EED-4E41-97BE-EF03FEB4AD62`
- DB cross-check: both missions `done`, all four WorkItems `completed_with_proof`, all run_results `finished`, all ledger rows `fallback=0`

## Truth label
This improves agent-driven product dogfood semantics after B4/D20 true-sign proofs. It is not release-GO, not human adoption, not full registry closure, and not v1 goal-achieved.