### PR TITLE
Harden iOS loaded-empty and accessibility states

### DIFF
--- a/apps/friday-ios/Sources/FridayMobileShell/DesignTokens.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/DesignTokens.swift
@@ -82,6 +82,7 @@ struct StatusChip: View {
       .padding(.vertical, 3)
       .background(Capsule().fill(bg))
       .foregroundStyle(fg)
+      .accessibilityLabel(text)
   }
 }
 
@@ -101,6 +102,7 @@ struct RefPill: View {
         .font(.system(size: 11, design: .monospaced))
         .foregroundStyle(MobileTheme.textMono)
         .lineLimit(1)
+        .minimumScaleFactor(0.75)
         .truncationMode(.middle)
     }
     .padding(.horizontal, 8)
@@ -109,5 +111,14 @@ struct RefPill: View {
       RoundedRectangle(cornerRadius: 7, style: .continuous)
         .fill(Color.black.opacity(0.04))
     )
+    .accessibilityElement(children: .ignore)
+    .accessibilityLabel(accessibilityText)
+  }
+
+  private var accessibilityText: String {
+    if let label {
+      return "\(label): \(ref)"
+    }
+    return ref
   }
 }

--- a/apps/friday-ios/Sources/FridayMobileShell/FridayChatScreen.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayChatScreen.swift
@@ -67,6 +67,7 @@ struct FridayChatScreen: View {
             Button("Clear") { viewModel.clearHistory() }
               .font(.caption)
               .foregroundStyle(MobileTheme.cyan)
+              .accessibilityLabel("Clear Friday chat history")
           }
           ForEach(viewModel.history.suffix(8)) { item in
             VStack(alignment: .leading, spacing: 4) {
@@ -86,6 +87,7 @@ struct FridayChatScreen: View {
           }
         }
       }
+      .accessibilityIdentifier("friday.chat.history")
     }
   }
 
@@ -129,8 +131,12 @@ struct FridayChatScreen: View {
           Text(reason).font(.caption2).foregroundStyle(MobileTheme.textSecondary)
           Button("Start over") { viewModel.newTurn() }
             .font(.caption).foregroundStyle(MobileTheme.cyan)
+            .accessibilityLabel("Start a new Friday chat turn")
         }
       }
+      .accessibilityElement(children: .combine)
+      .accessibilityLabel("Friday unavailable. \(reason)")
+      .accessibilityIdentifier("friday.chat.unavailable")
     }
   }
 
@@ -147,6 +153,8 @@ struct FridayChatScreen: View {
           RoundedRectangle(cornerRadius: 18, style: .continuous)
             .fill(Color.black.opacity(0.05)))
         .disabled(viewModel.phase.isBusy || viewModel.phase.isAwaitingApproval)
+        .accessibilityLabel("Message Friday")
+        .accessibilityIdentifier("friday.chat.composer")
 
       Button {
         let task = draft
@@ -158,6 +166,8 @@ struct FridayChatScreen: View {
           .foregroundStyle(canSend ? MobileTheme.cyan : MobileTheme.cyan.opacity(0.25))
       }
       .disabled(!canSend)
+      .accessibilityLabel("Send message to Friday")
+      .accessibilityIdentifier("friday.chat.send")
     }
     .padding(.horizontal, 16)
     .padding(.vertical, 12)
@@ -207,6 +217,9 @@ struct FridayChatScreen: View {
         if let tools = r.executedTools { RefPill(label: "executed_tools", ref: "\(tools)") }
       }
     }
+    .accessibilityElement(children: .contain)
+    .accessibilityLabel("Friday answer")
+    .accessibilityIdentifier("friday.chat.answer")
   }
 
   /// The S6 approval card — summary-then-proof (the verb + summary, then the digest the operator
@@ -238,15 +251,20 @@ struct FridayChatScreen: View {
             Label("Approve", systemImage: "checkmark.seal").bold()
           }
           .buttonStyle(.borderedProminent).tint(MobileTheme.cyan)
+          .accessibilityLabel("Approve Friday action")
           Button(role: .destructive) {
             viewModel.reject()
           } label: {
             Label("Reject", systemImage: "xmark").foregroundStyle(MobileTheme.coral)
           }
           .buttonStyle(.bordered)
+          .accessibilityLabel("Reject Friday action")
         }
       }
     }
+    .accessibilityElement(children: .contain)
+    .accessibilityLabel("Approval required for \(card.actionVerb)")
+    .accessibilityIdentifier("friday.chat.approval-card")
   }
 
   /// The refs-only resume receipt (accepted ⇒ executed; refused ⇒ a successful relay of a refusal).
@@ -270,6 +288,9 @@ struct FridayChatScreen: View {
           .font(.caption2).foregroundStyle(MobileTheme.textSecondary)
       }
     }
+    .accessibilityElement(children: .combine)
+    .accessibilityLabel(r.accepted ? "Approved action executed" : "Action refused")
+    .accessibilityIdentifier("friday.chat.resume-receipt")
   }
 
   private func placeholder(_ title: String, _ sub: String) -> some View {

--- a/apps/friday-ios/Sources/FridayMobileShell/FridayHomeScreen.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayHomeScreen.swift
@@ -60,6 +60,9 @@ struct FridayHomeScreen: View {
     }
 
     statusCard(projection)
+    if projection.isLoadedEmpty {
+      loadedEmptyCard(projection)
+    }
     workItemsCard(projection)
   }
 
@@ -89,6 +92,32 @@ struct FridayHomeScreen: View {
         RefPill(label: "protocol", ref: "v\(fridayCurrentSchemaVersion)")
       }
     }
+    .accessibilityElement(children: .combine)
+    .accessibilityLabel(viewModel.isOnline ? "Friday status online" : "Friday status offline or stale")
+    .accessibilityIdentifier("friday.home.status-card")
+  }
+
+  private func loadedEmptyCard(_ projection: HomeProjection) -> some View {
+    GlassPanel {
+      VStack(alignment: .leading, spacing: MobileTheme.rowSpacing) {
+        HStack(spacing: 8) {
+          Image(systemName: "tray")
+            .foregroundStyle(MobileTheme.textSecondary)
+            .frame(width: 22)
+            .accessibilityHidden(true)
+          Text("No active Friday work yet")
+            .font(.headline)
+            .foregroundStyle(MobileTheme.textPrimary)
+        }
+        Text("Connected to \(projection.runtimeFeedStatus); this owner has no visible missions, work items, or learning candidates in the current projection.")
+          .font(.caption)
+          .foregroundStyle(MobileTheme.textSecondary)
+          .fixedSize(horizontal: false, vertical: true)
+      }
+    }
+    .accessibilityElement(children: .combine)
+    .accessibilityLabel("Friday is connected, with no active work for this owner")
+    .accessibilityIdentifier("friday.home.loaded-empty")
   }
 
   /// The refs-only work-item view: COUNTS + id refs only (INV-5) — never a body. The read-seam
@@ -116,6 +145,9 @@ struct FridayHomeScreen: View {
         }
       }
     }
+    .accessibilityElement(children: .combine)
+    .accessibilityLabel("Work items, \(projection.workItemIds.count) references")
+    .accessibilityIdentifier("friday.home.work-items-card")
   }
 }
 
@@ -138,6 +170,9 @@ struct StatusBanner: View {
     .background(
       RoundedRectangle(cornerRadius: MobileTheme.cornerRadius, style: .continuous)
         .fill(MobileTheme.coralSoft))
+    .accessibilityElement(children: .combine)
+    .accessibilityLabel("Friday projection flagged: \(labels.joined(separator: ", "))")
+    .accessibilityIdentifier("friday.home.status-banner")
   }
 }
 
@@ -161,5 +196,8 @@ struct UnavailableView: View {
     }
     .padding(28)
     .frame(maxWidth: .infinity, minHeight: 200)
+    .accessibilityElement(children: .combine)
+    .accessibilityLabel("Friday is offline. \(reason). No cached or fabricated status is shown.")
+    .accessibilityIdentifier("friday.home.unavailable")
   }
 }

--- a/apps/friday-ios/Sources/FridayMobileShellCore/HomeViewModel.swift
+++ b/apps/friday-ios/Sources/FridayMobileShellCore/HomeViewModel.swift
@@ -86,6 +86,16 @@ public struct HomeProjection: Sendable, Equatable {
       + runOutcomeLearningCandidates.count
   }
 
+  public var isLoadedEmpty: Bool {
+    workItemIds.isEmpty
+      && providerReceiptRefs.isEmpty
+      && channelReceiptRefs.isEmpty
+      && memoryCandidates.isEmpty
+      && runOutcomeLearningCandidates.isEmpty
+      && capabilityStates.isEmpty
+      && transcriptEvents.isEmpty
+  }
+
   private static func parseWorkItems(_ value: Any?) -> [HomeWorkItem] {
     guard let rows = value as? [[String: Any]] else { return [] }
     return rows.compactMap { row in

--- a/apps/friday-ios/Tests/FridayMobileShellCoreTests/HomeViewModelTests.swift
+++ b/apps/friday-ios/Tests/FridayMobileShellCoreTests/HomeViewModelTests.swift
@@ -133,6 +133,25 @@ final class HomeViewModelTests: XCTestCase {
     return try WorkbenchSnapshot(projectionJSON: Data(json.utf8), generatedAtMs: 1_780_640_000_000)
   }
 
+  private func emptySnapshot() throws -> WorkbenchSnapshot {
+    let json = """
+    {
+      "missionId": "mission-empty",
+      "fridayConversationId": "conv-empty",
+      "runtimeFeedStatus": "live_rust_hub_projection",
+      "statusLabels": [],
+      "workItems": [],
+      "providerReceiptRefs": [],
+      "channelReceiptRefs": [],
+      "memoryCandidates": [],
+      "runOutcomeLearningCandidates": [],
+      "capabilityStates": [],
+      "transcriptSections": []
+    }
+    """
+    return try WorkbenchSnapshot(projectionJSON: Data(json.utf8), generatedAtMs: 1_780_640_010_000)
+  }
+
   func testRefresh_loadsRefsOnlyProjection() async throws {
     let snapshot = try sampleSnapshot()
     let vm = HomeViewModel(client: FakeReadClient(.snapshot(snapshot)))
@@ -161,6 +180,24 @@ final class HomeViewModelTests: XCTestCase {
     XCTAssertEqual(p.capabilityStates.first?.dispatchAllowed, true)
     XCTAssertEqual(p.transcriptEvents.first?.summary, "Mobile surface read the mission projection.")
     XCTAssertEqual(p.needsMeCount, 3)
+  }
+
+  func testRefresh_loadedEmptyIsConnectedEmptyNotUnavailable() async throws {
+    let vm = HomeViewModel(client: FakeReadClient(.snapshot(try emptySnapshot())))
+    await vm.refresh()
+    guard case .loaded(let p) = vm.state else { return XCTFail("expected loaded empty projection, got \(vm.state)") }
+    XCTAssertEqual(p.missionId, "mission-empty")
+    XCTAssertTrue(p.isLoadedEmpty)
+    XCTAssertTrue(vm.state.isOnline)
+    XCTAssertNil(vm.state.projection?.statusLabels.first)
+  }
+
+  func testRefresh_nonEmptyProjectionIsNotLoadedEmpty() async throws {
+    let vm = HomeViewModel(client: FakeReadClient(.snapshot(try sampleSnapshot())))
+    await vm.refresh()
+    guard case .loaded(let p) = vm.state else { return XCTFail("expected loaded projection") }
+    XCTAssertFalse(p.isLoadedEmpty)
+    XCTAssertTrue(vm.state.isOnline)
   }
 
   func testRefresh_transportFailure_isHonestUnavailable() async {


### PR DESCRIPTION
## Summary
- Add a first-class `HomeProjection.isLoadedEmpty` so a connected-but-empty owner projection stays distinct from honest-unavailable/offline.
- Render an explicit Home loaded-empty card and add stable accessibility labels/identifiers for Home, Chat, ref pills, status chips, answer/resume/approval states.
- Add HomeViewModel tests pinning loaded-empty as `.loaded`/online rather than `.unavailable`.

## Verification
- `swift test --package-path apps/friday-ios --filter HomeViewModelTests`
- `swift test --package-path apps/friday-ios`
- `apps/friday-ios/build-sim.sh` plus screenshot visual check

Truth labels: UI/product hardening only; agent-driven/sim evidence, not OG9 operator-origin organic, not true-device pairing, not GO-LIVE, not v1 completion.
