### PR TITLE
Harden desktop loaded-empty and accessibility states

### DIFF
--- a/apps/macos/FridayHubConsole/Sources/FridayHubConsole/OperationsOverviewScreen.swift
+++ b/apps/macos/FridayHubConsole/Sources/FridayHubConsole/OperationsOverviewScreen.swift
@@ -53,6 +53,8 @@ struct OperationsOverviewScreen: View {
       .buttonStyle(.borderedProminent)
       .tint(HubTheme.cyan)
       .disabled(viewModel.state.isLoading)
+      .accessibilityLabel("Refresh Operations Overview")
+      .accessibilityIdentifier("friday.desktop.refresh")
     }
     .padding(.horizontal, 20)
     .padding(.vertical, 16)
@@ -88,6 +90,9 @@ struct OperationsOverviewScreen: View {
       }
 
       missionCard(snapshot)
+      if snapshot.isLoadedEmpty {
+        loadedEmptyCard(snapshot)
+      }
       routeDecisionCard(snapshot)
       workItemsCard(snapshot)
       capabilityCard(snapshot)
@@ -119,6 +124,31 @@ struct OperationsOverviewScreen: View {
         missionIntakeCompose
       }
     }
+    .accessibilityElement(children: .contain)
+    .accessibilityLabel("Mission \(snapshot.missionId)")
+    .accessibilityIdentifier("friday.desktop.mission-card")
+  }
+
+  private func loadedEmptyCard(_ snapshot: WorkbenchSnapshot) -> some View {
+    GlassPanel {
+      VStack(alignment: .leading, spacing: HubTheme.rowSpacing) {
+        HStack(spacing: 8) {
+          Image(systemName: "tray")
+            .foregroundStyle(HubTheme.textSecondary)
+            .accessibilityHidden(true)
+          Text("No active Friday work yet")
+            .font(.system(size: 14, weight: .semibold))
+            .foregroundStyle(HubTheme.textPrimary)
+        }
+        Text("Connected to \(snapshot.runtimeFeedStatus.displayText); this owner has no visible work items, receipts, candidates, capabilities, or transcript events in the current projection.")
+          .font(.system(size: 12))
+          .foregroundStyle(HubTheme.textSecondary)
+          .fixedSize(horizontal: false, vertical: true)
+      }
+    }
+    .accessibilityElement(children: .combine)
+    .accessibilityLabel("Friday is connected, with no active desktop work for this owner")
+    .accessibilityIdentifier("friday.desktop.loaded-empty")
   }
 
   /// The spine-WRITE compose affordance — an operator types an intent and submits it as a
@@ -146,12 +176,15 @@ struct OperationsOverviewScreen: View {
         .disabled(
           viewModel.intakeState.isSent
             || intentDraft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+        .accessibilityLabel("Submit mission intent")
+        .accessibilityIdentifier("friday.desktop.submit-intent")
       }
       WriteActionStateView(state: viewModel.intakeState, pendingText: "Submitting intake…")
       Text("Births a Mission + WorkItem(Draft), then dispatches the governed model run when configured.")
         .font(.system(size: 10))
         .foregroundStyle(HubTheme.textSecondary)
     }
+    .accessibilityIdentifier("friday.desktop.mission-intake")
   }
 
   private func routeDecisionCard(_ snapshot: WorkbenchSnapshot) -> some View {
@@ -344,6 +377,9 @@ struct UnavailableView: View {
     }
     .padding(28)
     .frame(maxWidth: .infinity, maxHeight: .infinity)
+    .accessibilityElement(children: .combine)
+    .accessibilityLabel("Hub projection unavailable. \(reason)")
+    .accessibilityIdentifier("friday.desktop.unavailable")
   }
 }
 
@@ -373,6 +409,9 @@ struct StatusBanner: View {
       RoundedRectangle(cornerRadius: HubTheme.cornerRadius, style: .continuous)
         .fill(HubTheme.coralSoft)
     )
+    .accessibilityElement(children: .combine)
+    .accessibilityLabel("Workbench projection flagged")
+    .accessibilityIdentifier("friday.desktop.status-banner")
   }
 }
 
@@ -458,10 +497,12 @@ struct MemoryCandidateRow: View {
             .tint(HubTheme.cyan)
             .controlSize(.small)
             .disabled(controlsDisabled)
+            .accessibilityLabel("Confirm memory candidate")
           Button("Reject", action: onReject)
             .buttonStyle(.bordered)
             .controlSize(.small)
             .disabled(controlsDisabled)
+            .accessibilityLabel("Reject memory candidate")
         }
       }
       RefPill(label: "evidenceRef", ref: candidate.evidenceRef)
@@ -504,10 +545,12 @@ struct RunOutcomeLearningCandidateRow: View {
             .tint(HubTheme.cyan)
             .controlSize(.small)
             .disabled(controlsDisabled)
+            .accessibilityLabel("Confirm run outcome learning candidate")
           Button("Reject", action: onReject)
             .buttonStyle(.bordered)
             .controlSize(.small)
             .disabled(controlsDisabled)
+            .accessibilityLabel("Reject run outcome learning candidate")
         }
       }
       RefPill(label: "runId", ref: candidate.runId)

--- a/apps/macos/FridayHubConsole/Sources/FridayHubConsole/TruthChips.swift
+++ b/apps/macos/FridayHubConsole/Sources/FridayHubConsole/TruthChips.swift
@@ -16,6 +16,7 @@ struct StatusChip: View {
       .padding(.vertical, 3)
       .background(Capsule().fill(bg))
       .foregroundStyle(fg)
+      .accessibilityLabel(text)
   }
 }
 
@@ -131,6 +132,7 @@ struct RefPill: View {
         .foregroundStyle(HubTheme.textMono)
         .textSelection(.enabled)
         .lineLimit(1)
+        .minimumScaleFactor(0.75)
         .truncationMode(.middle)
     }
     .padding(.horizontal, 8)
@@ -139,5 +141,14 @@ struct RefPill: View {
       RoundedRectangle(cornerRadius: 7, style: .continuous)
         .fill(Color.black.opacity(0.04))
     )
+    .accessibilityElement(children: .ignore)
+    .accessibilityLabel(accessibilityText)
+  }
+
+  private var accessibilityText: String {
+    if let label {
+      return "\(label): \(ref)"
+    }
+    return ref
   }
 }

--- a/apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/WorkbenchSnapshot.swift
+++ b/apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/WorkbenchSnapshot.swift
@@ -455,6 +455,17 @@ public struct WorkbenchSnapshot: Codable, Sendable, Equatable {
     self.capabilityStates = capabilityStates
     self.transcriptSections = transcriptSections
   }
+
+  public var isLoadedEmpty: Bool {
+    providerReceiptRefs.isEmpty
+      && channelReceiptRefs.isEmpty
+      && workItems.isEmpty
+      && timelinePages.isEmpty
+      && memoryCandidates.isEmpty
+      && runOutcomeLearningCandidates.isEmpty
+      && capabilityStates.isEmpty
+      && transcriptSections.isEmpty
+  }
 }
 
 public typealias MissionWorkbenchSnapshot = WorkbenchSnapshot

--- a/apps/macos/FridayHubConsole/Tests/FridayHubConsoleCoreTests/OperationsOverviewViewModelTests.swift
+++ b/apps/macos/FridayHubConsole/Tests/FridayHubConsoleCoreTests/OperationsOverviewViewModelTests.swift
@@ -73,6 +73,23 @@ func snapshotExercisesEveryHonestRenderingRule() {
 }
 
 @Test
+func loadedEmptySnapshotIsConnectedEmptyNotUnavailable() {
+  let snapshot = snapshotWithWorkItems(
+    missionId: "mission-empty",
+    fridayConversationId: "fconv-empty",
+    workItemIds: [])
+  #expect(snapshot.isLoadedEmpty)
+  #expect(snapshot.runtimeFeedStatus == .liveRustHubProjection)
+  #expect(snapshot.statusLabels.isEmpty)
+}
+
+@Test
+func representativeSnapshotIsNotLoadedEmpty() {
+  let snapshot = MockReadClient.representativeSnapshot
+  #expect(!snapshot.isLoadedEmpty)
+}
+
+@Test
 @MainActor
 func inspectorReturnsRefsOnlyForSelection() async {
   let vm = OperationsOverviewViewModel(client: MockReadClient(behavior: .loaded))


### PR DESCRIPTION
## Summary
- Add `WorkbenchSnapshot.isLoadedEmpty` so a connected-but-empty desktop projection stays distinct from honest-unavailable/offline.
- Render an explicit Operations Overview loaded-empty card and add stable accessibility labels/identifiers for desktop refresh, intake, unavailable, status banner, ref/status chips, and candidate decision buttons.
- Add tests pinning loaded-empty and representative non-empty projection behavior.

## Verification
- `swift test --package-path apps/macos/FridayHubConsole --filter loadedEmpty`
- `swift test --package-path apps/macos/FridayHubConsole`
- `git diff --check`

Truth labels: desktop UI/product hardening only; agent-driven local verification, not OG9 operator-origin organic, not true-device pairing, not C1/C2 channel closure, not GO-LIVE, not v1 completion.
