### PR TITLE
Strengthen product dogfood answer assertions

### DIFF
--- a/apps/friday-ios/Tests/FridayMobileShellCoreTests/LiveMissionSpineWriteDispatchIntegrationTests.swift
+++ b/apps/friday-ios/Tests/FridayMobileShellCoreTests/LiveMissionSpineWriteDispatchIntegrationTests.swift
@@ -103,6 +103,9 @@ func liveMobileChatSendAutoDispatchesHybridClaudeFollowUp() async throws {
   #expect(receipt.workItemId == "work-mobile-\(id)")
   #expect(receipt.followUpWorkItemId == "work-mobile-\(id)-claude-followup")
   #expect(receipt.followUpRunId != nil)
+  #expect(receipt.answerBodyRunId == receipt.followUpRunId)
+  #expect(receipt.answerBodyOutcome == "delivered")
+  #expect(receipt.answerBody?.contains("FRIDAY_MOBILE_PRODUCT_AUTO_FOLLOWUP_OK") == true)
 }
 
 private func mobileProductAutoFollowUpWriteConfig() -> AgentRunServerConfig {

--- a/apps/macos/FridayHubConsole/Tests/FridayHubConsoleCoreTests/LiveMissionSpineWriteDispatchIntegrationTests.swift
+++ b/apps/macos/FridayHubConsole/Tests/FridayHubConsoleCoreTests/LiveMissionSpineWriteDispatchIntegrationTests.swift
@@ -323,7 +323,7 @@ func liveOperationsOverviewSubmitIntakeAutoDispatchesHybridClaudeFollowUp() asyn
       + "then summarize that the product Operations view should automatically run the generated "
       + "Claude follow-up after the Codex first leg. Answer exactly FRIDAY_PRODUCT_AUTO_FOLLOWUP_OK.")
 
-  guard case let .confirmed(summary, _, _) = vm.intakeState else {
+  guard case let .confirmed(summary, _, answerBody) = vm.intakeState else {
     Issue.record("expected product auto follow-up to confirm, got \(String(describing: vm.intakeState))")
     return
   }
@@ -332,6 +332,9 @@ func liveOperationsOverviewSubmitIntakeAutoDispatchesHybridClaudeFollowUp() asyn
   #expect(summary.contains("mission-desktop-\(id)"))
   #expect(summary.contains("work-desktop-\(id)"))
   #expect(summary.contains("follow_up_work_item_id=work-desktop-\(id)-claude-followup"))
+  #expect(answerBody?.contains("Codex:") == true)
+  #expect(answerBody?.contains("Claude follow-up:") == true)
+  #expect(answerBody?.contains("FRIDAY_PRODUCT_AUTO_FOLLOWUP_OK") == true)
 }
 
 private func hybridFollowUpWriteConfig() -> AgentRunWriteServerConfig {


### PR DESCRIPTION
## Summary
- Strengthen the iOS product auto-followup live test to require the owner-gated answer body to come from the generated Claude follow-up run and include the expected product token.
- Strengthen the desktop product auto-followup live test to require readable answer-body sections for both Codex and Claude follow-up, including the expected product token.

## Verification
- swift test --package-path apps/friday-ios
- swift test --package-path apps/macos/FridayHubConsole
- git diff --check origin/main..HEAD
- FRIDAY_MOBILE_LIVE_PRODUCT_AUTO_FOLLOWUP_RUN_TEST=1 swift test --package-path apps/friday-ios --filter liveMobileChatSendAutoDispatchesHybridClaudeFollowUp
- FRIDAY_CONSOLE_LIVE_PRODUCT_AUTO_FOLLOWUP_RUN_TEST=1 swift test --package-path apps/macos/FridayHubConsole --filter liveOperationsOverviewSubmitIntakeAutoDispatchesHybridClaudeFollowUp

## Truth Labels
- agent-dogfood v1-works evidence only; not real-user adoption, not true-device, not release-GO, not full registry/UI closure.
- No operator private key access and no synthetic organic/proof rows.