### PR TITLE
Prove A1 candidates in product dogfood

### DIFF
--- a/apps/friday-ios/Tests/FridayMobileShellCoreTests/LiveMissionSpineWriteDispatchIntegrationTests.swift
+++ b/apps/friday-ios/Tests/FridayMobileShellCoreTests/LiveMissionSpineWriteDispatchIntegrationTests.swift
@@ -106,6 +106,43 @@ func liveMobileChatSendAutoDispatchesHybridClaudeFollowUp() async throws {
   #expect(receipt.answerBodyRunId == receipt.followUpRunId)
   #expect(receipt.answerBodyOutcome == "delivered")
   #expect(receipt.answerBody?.contains("FRIDAY_MOBILE_PRODUCT_AUTO_FOLLOWUP_OK") == true)
+
+  let learningRows = try await pollLiveRunOutcomeLearningCandidates(
+    client: readClient,
+    runIds: Set([receipt.runId, try #require(receipt.followUpRunId)]))
+  let projectedRunIds = Set(learningRows.compactMap { $0["runId"] as? String })
+  #expect(projectedRunIds.contains(receipt.runId))
+  #expect(projectedRunIds.contains(try #require(receipt.followUpRunId)))
+  #expect(learningRows.allSatisfy { ($0["state"] as? String) == "pending" })
+  #expect(learningRows.allSatisfy {
+    (($0["evidenceRef"] as? String)?.hasPrefix("proof://run-outcome-learning-candidate/")) == true
+  })
+}
+
+private func pollLiveRunOutcomeLearningCandidates(
+  client: FridayRustReadClient,
+  runIds: Set<String>
+) async throws -> [[String: Any]] {
+  let deadline = Date().addingTimeInterval(20)
+  var lastRows: [[String: Any]] = []
+
+  repeat {
+    let snapshot = try await client.fetchWorkbench()
+    let rows = snapshot.raw["runOutcomeLearningCandidates"] as? [[String: Any]] ?? []
+    let matched = rows.filter { row in
+      guard let runId = row["runId"] as? String else { return false }
+      return runIds.contains(runId)
+    }
+    let matchedRunIds = Set(matched.compactMap { $0["runId"] as? String })
+    if runIds.isSubset(of: matchedRunIds) {
+      return matched
+    }
+    lastRows = rows
+    try await Task.sleep(for: .seconds(1))
+  } while Date() < deadline
+
+  Issue.record("expected live run-outcome learning candidates for \(runIds), got \(lastRows)")
+  return []
 }
 
 private func mobileProductAutoFollowUpWriteConfig() -> AgentRunServerConfig {

--- a/apps/macos/FridayHubConsole/Tests/FridayHubConsoleCoreTests/LiveMissionSpineWriteDispatchIntegrationTests.swift
+++ b/apps/macos/FridayHubConsole/Tests/FridayHubConsoleCoreTests/LiveMissionSpineWriteDispatchIntegrationTests.swift
@@ -335,6 +335,53 @@ func liveOperationsOverviewSubmitIntakeAutoDispatchesHybridClaudeFollowUp() asyn
   #expect(answerBody?.contains("Codex:") == true)
   #expect(answerBody?.contains("Claude follow-up:") == true)
   #expect(answerBody?.contains("FRIDAY_PRODUCT_AUTO_FOLLOWUP_OK") == true)
+
+  let expectedRunIds = Set(summaryRunIds(in: summary))
+  #expect(expectedRunIds.count >= 2)
+  let learningRows = try await pollLiveRunOutcomeLearningCandidates(
+    client: readClient,
+    runIds: expectedRunIds)
+  let projectedRunIds = Set(learningRows.compactMap { $0["runId"] as? String })
+  #expect(expectedRunIds.allSatisfy { projectedRunIds.contains($0) })
+  #expect(learningRows.allSatisfy { ($0["state"] as? String) == "pending" })
+  #expect(learningRows.allSatisfy {
+    (($0["evidenceRef"] as? String)?.hasPrefix("proof://run-outcome-learning-candidate/")) == true
+  })
+}
+
+private func summaryRunIds(in summary: String) -> [String] {
+  summary.split(separator: "·")
+    .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+    .compactMap { part in
+      guard part.hasPrefix("run_id=") else { return nil }
+      return String(part.dropFirst("run_id=".count))
+    }
+}
+
+private func pollLiveRunOutcomeLearningCandidates(
+  client: FridayRustReadClient,
+  runIds: Set<String>
+) async throws -> [[String: Any]] {
+  let deadline = Date().addingTimeInterval(20)
+  var lastRows: [[String: Any]] = []
+
+  repeat {
+    let snapshot = try await client.fetchWorkbench()
+    let rows = snapshot.raw["runOutcomeLearningCandidates"] as? [[String: Any]] ?? []
+    let matched = rows.filter { row in
+      guard let runId = row["runId"] as? String else { return false }
+      return runIds.contains(runId)
+    }
+    let matchedRunIds = Set(matched.compactMap { $0["runId"] as? String })
+    if runIds.isSubset(of: matchedRunIds) {
+      return matched
+    }
+    lastRows = rows
+    try await Task.sleep(for: .seconds(1))
+  } while Date() < deadline
+
+  Issue.record("expected live run-outcome learning candidates for \(runIds), got \(lastRows)")
+  return []
 }
 
 private func hybridFollowUpWriteConfig() -> AgentRunWriteServerConfig {

--- a/rust-core/crates/friday-hub/src/workbench_projection.rs
+++ b/rust-core/crates/friday-hub/src/workbench_projection.rs
@@ -310,16 +310,32 @@ fn run_outcome_learning_candidates_json(
 }
 
 fn work_item_agent_run_ids(item: &WorkItem) -> Vec<String> {
-    let mut ids = Vec::new();
+    let mut ids: Vec<String> = Vec::new();
     for value in item.proof_receipts.iter().chain(item.output_refs.iter()) {
-        if let Some(run_id) = value.strip_prefix("friday://agent-run/") {
-            let run_id = run_id.trim();
-            if !run_id.is_empty() && !ids.iter().any(|seen| seen == run_id) {
-                ids.push(run_id.to_string());
+        if let Some(run_id) = agent_run_id_from_ref(value) {
+            if !ids.iter().any(|seen| seen == &run_id) {
+                ids.push(run_id);
             }
         }
     }
     ids
+}
+
+fn agent_run_id_from_ref(value: &str) -> Option<String> {
+    let mut run_id = value
+        .strip_prefix("friday://agent-run/")
+        .or_else(|| value.strip_prefix("proof://outcome/AnswerProduced/"))?;
+    if let Some((id, _)) = run_id.split_once('?') {
+        run_id = id;
+    }
+    if let Some((id, _)) = run_id.split_once('#') {
+        run_id = id;
+    }
+    let run_id = run_id.trim();
+    if run_id.is_empty() {
+        return None;
+    }
+    Some(run_id.to_string())
 }
 
 fn capability_states_json(work_items: &[WorkItem], route_ref: &str) -> Vec<Value> {
@@ -1141,6 +1157,37 @@ mod tests {
             row.get("evidenceRef")
                 .and_then(Value::as_str)
                 .is_some_and(|ref_| ref_.starts_with("proof://run-outcome-learning-candidate/"))
+        }));
+    }
+
+    #[test]
+    fn projects_run_outcome_learning_candidates_from_answer_produced_proof_refs() {
+        let db = Db::open_hub(&tmp()).unwrap();
+        let mission_id = seed_real_producer_mission(&db);
+        let mut item = db.get_work_item("autodisp-1781492033").unwrap().unwrap();
+        item.status = WorkItemStatus::CompletedWithProof;
+        item.proof_receipts =
+            vec!["proof://outcome/AnswerProduced/run-follow-up-a1?signal=answer_len=572".into()];
+        db.upsert_work_item(&item).unwrap();
+        friday_storage::learning_candidate::record_run_outcome_candidates(
+            db.conn(),
+            "run-follow-up-a1",
+            Some("run-follow-up-a1"),
+            1,
+            0,
+            1_780_640_000_200,
+        )
+        .unwrap();
+
+        let snapshot = project_workbench(&db, Some(&mission_id)).unwrap();
+        let candidates = snapshot
+            .get("runOutcomeLearningCandidates")
+            .and_then(Value::as_array)
+            .expect("projection must include runOutcomeLearningCandidates");
+        assert_eq!(candidates.len(), 3);
+        assert!(candidates.iter().all(|row| {
+            row.get("runId").and_then(Value::as_str) == Some("run-follow-up-a1")
+                && row.get("workItemId").and_then(Value::as_str) == Some("autodisp-1781492033")
         }));
     }
 


### PR DESCRIPTION
## Summary
- Project A1 run-outcome candidates for `proof://outcome/AnswerProduced/<run>?...` receipts so Claude follow-up WorkItems expose already-produced learning candidates in the workbench.
- Strengthen iOS and desktop live product auto-followup tests to require A1 candidate projection for both first-leg and Claude follow-up run ids.
- Keep this refs-only: no learning write-leg changes, no synthetic DB rows, no operator key access.

## Verification
- `cargo test --manifest-path rust-core/Cargo.toml -p friday-hub workbench_projection::tests::projects_run_outcome_learning_candidates -- --nocapture`
- Patched read-only projection against prod DB showed first-leg + Claude follow-up A1 candidates for mobile mission `mission-mobile-liveautodb2c65864e0d4f3f993a44158dee2cf2`.
- Patched read-only projection against prod DB showed first-leg + Claude follow-up A1 candidates for desktop mission `mission-desktop-liveauto2542c8983879452a8f640dbcf7ad9220`.
- `swift test --package-path apps/friday-ios`
- `swift test --package-path apps/macos/FridayHubConsole`
- `git diff --check`

## Truth label
Agent-driven real product dogfood counts for v1 works/能跑通 per `FRIDAY_OG9_DECISION_INJECT_20260621.md`; this is not real-user adoption, not true-device proof, not release-GO, and not full v1 closure. Live Swift opt-in A1 projection assertions require this projection patch to be deployed before they can pass against the running read service.
