### PR TITLE
Add iOS A1 learning decision controls

### DIFF
--- a/apps/friday-ios/Sources/FridayMobileShell/FridayApp.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayApp.swift
@@ -183,7 +183,9 @@ struct RootView: View {
 
   init(session: FridaySession) {
     self.session = session
-    _homeVM = StateObject(wrappedValue: HomeViewModel(client: session.readClient))
+    _homeVM = StateObject(wrappedValue: HomeViewModel(
+      client: session.readClient,
+      writeClient: session.missionClient))
   }
 
   var body: some View {

--- a/apps/friday-ios/Sources/FridayMobileShell/FridayProjectionScreens.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayProjectionScreens.swift
@@ -568,14 +568,41 @@ struct FridayProjectionScreen: View {
   }
 
   private func learningCandidateRow(_ candidate: HomeRunOutcomeLearningCandidate) -> some View {
+    let decisionState = viewModel.runOutcomeLearningDecisionStates[candidate.id]
     VStack(alignment: .leading, spacing: 6) {
-      Text(candidate.summary)
-        .font(.system(size: 13, weight: .medium))
-        .foregroundStyle(MobileTheme.textPrimary)
+      HStack(alignment: .top, spacing: 8) {
+        Text(candidate.summary)
+          .font(.system(size: 13, weight: .medium))
+          .foregroundStyle(MobileTheme.textPrimary)
+          .frame(maxWidth: .infinity, alignment: .leading)
+        HStack(spacing: 6) {
+          Button {
+            Task { await viewModel.decideRunOutcomeLearning(candidateId: candidate.id, confirm: true) }
+          } label: {
+            Image(systemName: "checkmark")
+              .frame(width: 26, height: 26)
+          }
+          .buttonStyle(.borderedProminent)
+          .tint(MobileTheme.cyan)
+          .disabled(learningDecisionControlsDisabled(decisionState))
+          .accessibilityLabel("Confirm run outcome learning candidate")
+
+          Button {
+            Task { await viewModel.decideRunOutcomeLearning(candidateId: candidate.id, confirm: false) }
+          } label: {
+            Image(systemName: "xmark")
+              .frame(width: 26, height: 26)
+          }
+          .buttonStyle(.bordered)
+          .disabled(learningDecisionControlsDisabled(decisionState))
+          .accessibilityLabel("Reject run outcome learning candidate")
+        }
+      }
       HStack(spacing: 6) {
         statusChip(candidate.kind)
         statusChip(candidate.state)
       }
+      learningDecisionStateView(decisionState)
       if !candidate.runId.isEmpty {
         RefPill(label: "runId", ref: candidate.runId)
       }
@@ -587,6 +614,31 @@ struct FridayProjectionScreen: View {
       }
     }
     .padding(.vertical, 4)
+  }
+
+  private func learningDecisionControlsDisabled(_ state: HomeLearningDecisionState?) -> Bool {
+    guard let state else { return false }
+    return state.isSent || state.isTerminal
+  }
+
+  @ViewBuilder
+  private func learningDecisionStateView(_ state: HomeLearningDecisionState?) -> some View {
+    switch state {
+    case .sent:
+      Text("Applying learning decision…")
+        .font(.caption2)
+        .foregroundStyle(MobileTheme.textSecondary)
+    case .confirmed(let summary):
+      Text(summary)
+        .font(.caption2)
+        .foregroundStyle(MobileTheme.textSecondary)
+    case .error(let reason):
+      Text(reason)
+        .font(.caption2)
+        .foregroundStyle(MobileTheme.coral)
+    case nil:
+      EmptyView()
+    }
   }
 
   private func readinessRow(title: String, value: String, healthy: Bool) -> some View {

--- a/apps/friday-ios/Sources/FridayMobileShellCore/HomeViewModel.swift
+++ b/apps/friday-ios/Sources/FridayMobileShellCore/HomeViewModel.swift
@@ -339,19 +339,40 @@ public enum HomeReadDetailState: Sendable, Equatable {
   }
 }
 
+public enum HomeLearningDecisionState: Sendable, Equatable {
+  case sent
+  case confirmed(summary: String)
+  case error(reason: String)
+
+  public var isSent: Bool {
+    if case .sent = self { return true }
+    return false
+  }
+
+  public var isTerminal: Bool {
+    switch self {
+    case .confirmed, .error: return true
+    case .sent: return false
+    }
+  }
+}
+
 @MainActor
 public final class HomeViewModel: ObservableObject {
   @Published public private(set) var state: HomeLoadState = .idle
   @Published public private(set) var detailState: HomeReadDetailState = .idle
+  @Published public private(set) var runOutcomeLearningDecisionStates: [String: HomeLearningDecisionState] = [:]
 
   /// The package's read protocol is `Sendable`; the view model still publishes only small
   /// refs-only value projections, never the package snapshot's raw body map.
   private let client: FridayRustReadClient
+  private let writeClient: FridayMissionSpineWriteClient?
 
   /// - Parameter client: the read client. In production this is the real `SealedWSReadClient`
   ///   (built by `FridayClientFactory.makeReadClient`); a preview/debug build injects a mock.
-  public init(client: FridayRustReadClient) {
+  public init(client: FridayRustReadClient, writeClient: FridayMissionSpineWriteClient? = nil) {
     self.client = client
+    self.writeClient = writeClient
   }
 
   /// Whether the Home is online — derived from the load state (ONLY a real loaded projection is
@@ -377,6 +398,33 @@ public final class HomeViewModel: ObservableObject {
       detailState = .loaded(HomeReadDetail(title: arm.title, snapshot: snapshot))
     } catch {
       detailState = .unavailable(title: arm.title, reason: Self.reason(for: error))
+    }
+  }
+
+  public func decideRunOutcomeLearning(candidateId: String, confirm: Bool) async {
+    guard let writeClient else {
+      runOutcomeLearningDecisionStates[candidateId] = .error(reason: "Write seam not configured.")
+      return
+    }
+    runOutcomeLearningDecisionStates[candidateId] = .sent
+    let request = RunOutcomeLearningDecisionRequestWire(
+      candidateId: candidateId,
+      decision: confirm ? "confirm" : "reject")
+    do {
+      let result = try await writeClient.submitRunOutcomeLearningDecision(request)
+      switch result.status {
+      case "confirmed", "rejected":
+        let kind = result.kind ?? "unknown"
+        runOutcomeLearningDecisionStates[candidateId] = .confirmed(
+          summary: "\(result.status) · state=\(result.state) · kind=\(kind)")
+        await refresh()
+      default:
+        let why = result.blocker ?? "blocked"
+        runOutcomeLearningDecisionStates[candidateId] = .error(
+          reason: "Learning decision blocked — \(why)")
+      }
+    } catch {
+      runOutcomeLearningDecisionStates[candidateId] = .error(reason: Self.reason(for: error))
     }
   }
 

--- a/apps/friday-ios/Tests/FridayMobileShellCoreTests/HomeViewModelTests.swift
+++ b/apps/friday-ios/Tests/FridayMobileShellCoreTests/HomeViewModelTests.swift
@@ -28,9 +28,11 @@ final class HomeViewModelTests: XCTestCase {
   final class FakeReadClient: FridayRustReadClient, @unchecked Sendable {
     enum Script { case snapshot(WorkbenchSnapshot); case fail(FridayReadClientError) }
     let script: Script
+    private(set) var fetchWorkbenchCount = 0
     private(set) var requestedDetails: [String] = []
     init(_ script: Script) { self.script = script }
     func fetchWorkbench() async throws -> WorkbenchSnapshot {
+      fetchWorkbenchCount += 1
       switch script {
       case .snapshot(let s): return s
       case .fail(let e): throw e
@@ -91,6 +93,38 @@ final class HomeViewModelTests: XCTestCase {
       if let runId { raw["runId"] = runId }
       let data = try JSONSerialization.data(withJSONObject: raw)
       return try ReadProjectionSnapshot(projectionJSON: data, generatedAtMs: 1_780_640_000_123)
+    }
+  }
+
+  final class FakeLearningWriteClient: FridayMissionSpineWriteClient, @unchecked Sendable {
+    enum Script {
+      case result(RunOutcomeLearningDecisionResultWire)
+      case fail(Error)
+    }
+
+    let script: Script
+    private(set) var learningRequests: [RunOutcomeLearningDecisionRequestWire] = []
+
+    init(_ script: Script) {
+      self.script = script
+    }
+
+    func submitMissionIntake(_ request: MissionIntakeRequestWire) async throws -> MissionIntakeResultWire {
+      throw NSError(domain: "unused", code: 1)
+    }
+
+    func submitMemoryDecision(_ request: MemoryDecisionRequestWire) async throws -> MemoryDecisionResultWire {
+      throw NSError(domain: "unused", code: 1)
+    }
+
+    func submitRunOutcomeLearningDecision(
+      _ request: RunOutcomeLearningDecisionRequestWire
+    ) async throws -> RunOutcomeLearningDecisionResultWire {
+      learningRequests.append(request)
+      switch script {
+      case .result(let result): return result
+      case .fail(let error): throw error
+      }
     }
   }
 
@@ -269,6 +303,59 @@ final class HomeViewModelTests: XCTestCase {
     XCTAssertEqual(title, "Session open")
     XCTAssertTrue(reason.contains("offline"), "reason: \(reason)")
   }
+
+  func testDecideRunOutcomeLearningConfirmRendersConfirmedAndRefreshes() async throws {
+    let read = FakeReadClient(.snapshot(try sampleSnapshot()))
+    let write = FakeLearningWriteClient(.result(RunOutcomeLearningDecisionResultWire(
+      candidateId: "learn-1",
+      runId: "run-1",
+      kind: "preference",
+      state: "confirmed",
+      status: "confirmed")))
+    let vm = HomeViewModel(client: read, writeClient: write)
+
+    await vm.decideRunOutcomeLearning(candidateId: "learn-1", confirm: true)
+
+    XCTAssertEqual(write.learningRequests, [
+      RunOutcomeLearningDecisionRequestWire(candidateId: "learn-1", decision: "confirm"),
+    ])
+    XCTAssertEqual(read.fetchWorkbenchCount, 1)
+    XCTAssertEqual(
+      vm.runOutcomeLearningDecisionStates["learn-1"],
+      .confirmed(summary: "confirmed · state=confirmed · kind=preference"))
+  }
+
+  func testDecideRunOutcomeLearningBlockedRendersErrorNotConfirmed() async throws {
+    let read = FakeReadClient(.snapshot(try sampleSnapshot()))
+    let write = FakeLearningWriteClient(.result(RunOutcomeLearningDecisionResultWire(
+      candidateId: "learn-1",
+      state: "unknown",
+      status: "blocked",
+      blocker: "candidate missing")))
+    let vm = HomeViewModel(client: read, writeClient: write)
+
+    await vm.decideRunOutcomeLearning(candidateId: "learn-1", confirm: false)
+
+    XCTAssertEqual(write.learningRequests, [
+      RunOutcomeLearningDecisionRequestWire(candidateId: "learn-1", decision: "reject"),
+    ])
+    XCTAssertEqual(read.fetchWorkbenchCount, 0)
+    XCTAssertEqual(
+      vm.runOutcomeLearningDecisionStates["learn-1"],
+      .error(reason: "Learning decision blocked — candidate missing"))
+  }
+
+  func testDecideRunOutcomeLearningWithoutWriteClientIsUnavailable() async throws {
+    let read = FakeReadClient(.snapshot(try sampleSnapshot()))
+    let vm = HomeViewModel(client: read)
+
+    await vm.decideRunOutcomeLearning(candidateId: "learn-1", confirm: true)
+
+    XCTAssertEqual(read.fetchWorkbenchCount, 0)
+    XCTAssertEqual(
+      vm.runOutcomeLearningDecisionStates["learn-1"],
+      .error(reason: "Write seam not configured."))
+  }
 }
 
 /// **Read-client integration over an in-memory read-server transport** — proves the REAL
@@ -372,6 +459,7 @@ final class ReadClientFactoryTests: XCTestCase {
     XCTAssertNil(vm.state.projection)
     XCTAssertFalse(vm.state.isOnline)
   }
+
 }
 
 // MARK: - Emulated read-server transport (mirrors the package's write-server emulator)


### PR DESCRIPTION
## Summary
- wire the mobile Home view model with an optional mission-spine write client for explicit A1 run-outcome learning decisions
- add icon-only confirm/reject controls for pending run-outcome learning candidates in the iOS projection surface
- cover success, blocked, and default-unconfigured paths in HomeViewModel tests

## Truth labels
- Product-surface governance control for A1 candidate confirm/reject.
- Default remains fail-closed unless the live mission write seam is explicitly configured.
- This is dogfood/works evidence only under the 2026-06-21 OG9 decision; it is not real-user adoption and does not mark A1 live-done by itself.

## Verification
- swift test --package-path apps/friday-ios
- git diff --check
