### PR TITLE
Stabilize live product dogfood A1 polling

### DIFF
--- a/apps/friday-ios/Tests/FridayMobileShellCoreTests/LiveMissionSpineWriteDispatchIntegrationTests.swift
+++ b/apps/friday-ios/Tests/FridayMobileShellCoreTests/LiveMissionSpineWriteDispatchIntegrationTests.swift
@@ -11,8 +11,8 @@ import Testing
 // expects a refs-only server receipt. A stricter opt-in test also dispatches the returned
 // Mission/WorkItem handle as a read-only mission-bound model turn.
 //
-// HONEST CEILING: these are agent-driven live product-surface proofs. They are not OG9 organic
-// origin and not A1 live-done.
+// HONEST CEILING: these are agent-driven live product-surface proofs. They count as v1-works
+// evidence only: works_not_adopted, not real-user adoption, and not A1 live-done.
 
 private let liveMissionSpineWriteDispatchEnabled =
   ProcessInfo.processInfo.environment["FRIDAY_MOBILE_LIVE_WRITE_DISPATCH_TEST"] == "1"
@@ -123,8 +123,9 @@ private func pollLiveRunOutcomeLearningCandidates(
   client: FridayRustReadClient,
   runIds: Set<String>
 ) async throws -> [[String: Any]] {
-  let deadline = Date().addingTimeInterval(20)
+  let deadline = Date().addingTimeInterval(90)
   var lastRows: [[String: Any]] = []
+  var lastMatchedRunIds = Set<String>()
 
   repeat {
     let snapshot = try await client.fetchWorkbench()
@@ -138,10 +139,12 @@ private func pollLiveRunOutcomeLearningCandidates(
       return matched
     }
     lastRows = rows
+    lastMatchedRunIds = matchedRunIds
     try await Task.sleep(for: .seconds(1))
   } while Date() < deadline
 
-  Issue.record("expected live run-outcome learning candidates for \(runIds), got \(lastRows)")
+  let missingRunIds = runIds.subtracting(lastMatchedRunIds)
+  Issue.record("expected live run-outcome learning candidates for \(runIds); missing=\(missingRunIds); got \(lastRows)")
   return []
 }
 

--- a/apps/macos/FridayHubConsole/Tests/FridayHubConsoleCoreTests/LiveMissionSpineWriteDispatchIntegrationTests.swift
+++ b/apps/macos/FridayHubConsole/Tests/FridayHubConsoleCoreTests/LiveMissionSpineWriteDispatchIntegrationTests.swift
@@ -11,8 +11,8 @@ import Testing
 // single Mission intake and expects a refs-only server receipt. A stricter opt-in test also
 // dispatches the returned Mission/WorkItem handle as a read-only mission-bound model turn.
 //
-// HONEST CEILING: these are agent-driven live product-surface proofs. They are not OG9 organic
-// origin and not A1 live-done.
+// HONEST CEILING: these are agent-driven live product-surface proofs. They count as v1-works
+// evidence only: works_not_adopted, not real-user adoption, and not A1 live-done.
 
 private let liveMissionSpineWriteDispatchEnabled =
   ProcessInfo.processInfo.environment["FRIDAY_CONSOLE_LIVE_WRITE_DISPATCH_TEST"] == "1"
@@ -362,8 +362,9 @@ private func pollLiveRunOutcomeLearningCandidates(
   client: FridayRustReadClient,
   runIds: Set<String>
 ) async throws -> [[String: Any]] {
-  let deadline = Date().addingTimeInterval(20)
+  let deadline = Date().addingTimeInterval(90)
   var lastRows: [[String: Any]] = []
+  var lastMatchedRunIds = Set<String>()
 
   repeat {
     let snapshot = try await client.fetchWorkbench()
@@ -377,10 +378,12 @@ private func pollLiveRunOutcomeLearningCandidates(
       return matched
     }
     lastRows = rows
+    lastMatchedRunIds = matchedRunIds
     try await Task.sleep(for: .seconds(1))
   } while Date() < deadline
 
-  Issue.record("expected live run-outcome learning candidates for \(runIds), got \(lastRows)")
+  let missingRunIds = runIds.subtracting(lastMatchedRunIds)
+  Issue.record("expected live run-outcome learning candidates for \(runIds); missing=\(missingRunIds); got \(lastRows)")
   return []
 }
 


### PR DESCRIPTION
## Summary
- extend the iOS and desktop live product dogfood A1 candidate polling window from 20s to 90s
- include missing run ids in failure output so follow-up projection gaps are immediately visible

## Verification
- swift test --package-path apps/friday-ios --filter LiveMissionSpineWriteDispatchIntegrationTests
- swift test --package-path apps/macos/FridayHubConsole --filter LiveMissionSpineWriteDispatchIntegrationTests
- FRIDAY_CONSOLE_LIVE_TEST=1 swift test --package-path apps/macos/FridayHubConsole --filter LiveReadProjection
- FRIDAY_MOBILE_LIVE_READ_TEST=1 swift test --package-path apps/friday-ios --filter LiveReadProjection
- rebuilt and kickstarted only com.friday.read-projection-server from clean prod source at 88b8a99b; no prod hub kill
- FRIDAY_CONSOLE_LIVE_PRODUCT_AUTO_FOLLOWUP_RUN_TEST=1 swift test --package-path apps/macos/FridayHubConsole --filter liveOperationsOverviewSubmitIntakeAutoDispatchesHybridClaudeFollowUp
- FRIDAY_MOBILE_LIVE_PRODUCT_AUTO_FOLLOWUP_RUN_TEST=1 swift test --package-path apps/friday-ios --filter liveMobileChatSendAutoDispatchesHybridClaudeFollowUp

Truth label: agent-driven product dogfood / v1 works; works_not_adopted; not real-user adoption.