### PR TITLE
Enable shared mission UI proof capture

### DIFF
--- a/apps/friday-ios/Sources/FridayMobileShellCore/FridayChatViewModel.swift
+++ b/apps/friday-ios/Sources/FridayMobileShellCore/FridayChatViewModel.swift
@@ -248,6 +248,7 @@ public final class FridayChatViewModel: ObservableObject {
   private let readClient: FridayRustReadClient?
   private let signer: OperatorSigner
   private let newId: () -> String
+  private let missionIdPrefix: String
   private let nowMs: () -> Int64
   private let historyStore: any ChatHistoryStoring
 
@@ -263,6 +264,7 @@ public final class FridayChatViewModel: ObservableObject {
     readClient: FridayRustReadClient? = nil,
     historyStore: any ChatHistoryStoring = UserDefaultsChatHistoryStore(),
     newId: @escaping () -> String = { UUID().uuidString.lowercased().replacingOccurrences(of: "-", with: "") },
+    missionIdPrefix: String = "mission-mobile-",
     nowMs: @escaping () -> Int64 = { Int64(Date().timeIntervalSince1970 * 1000) }
   ) {
     self.writeClient = writeClient
@@ -271,6 +273,7 @@ public final class FridayChatViewModel: ObservableObject {
     self.readClient = readClient
     self.historyStore = historyStore
     self.newId = newId
+    self.missionIdPrefix = missionIdPrefix
     self.nowMs = nowMs
     self.history = historyStore.load()
   }
@@ -325,7 +328,8 @@ public final class FridayChatViewModel: ObservableObject {
       let request = Self.buildMissionIntakeRequest(
         intent: task,
         owner: liveAgentRunOwnerPrincipal,
-        idFactory: newId)
+        idFactory: newId,
+        missionIdPrefix: missionIdPrefix)
       let result = try await missionClient.submitMissionIntake(request)
       guard result.status == "ready", let workItemId = result.workItemId else {
         phase = .unavailable(reason: "Mission intake not ready — \(result.status)")
@@ -550,7 +554,8 @@ public final class FridayChatViewModel: ObservableObject {
   static func buildMissionIntakeRequest(
     intent: String,
     owner: String,
-    idFactory: () -> String
+    idFactory: () -> String,
+    missionIdPrefix: String = "mission-mobile-"
   ) -> MissionIntakeRequestWire {
     let id = idFactory()
     return MissionIntakeRequestWire(
@@ -560,7 +565,7 @@ public final class FridayChatViewModel: ObservableObject {
       surfaceKind: "mobile",
       deliveryRoute: "ios://friday-mobile/chat/\(id)",
       visibilityPolicy: "compact",
-      missionId: "mission-mobile-\(id)",
+      missionId: "\(missionIdPrefix)\(id)",
       workItemId: "work-mobile-\(id)",
       title: String(intent.prefix(72)),
       intent: intent,

--- a/apps/friday-ios/Tests/FridayMobileShellCoreTests/FridayChatViewModelTests.swift
+++ b/apps/friday-ios/Tests/FridayMobileShellCoreTests/FridayChatViewModelTests.swift
@@ -280,6 +280,18 @@ final class FridayChatViewModelTests: XCTestCase {
     XCTAssertNil(request.targetProviderOrAgent)
   }
 
+  func testBuildMissionIntakeRequest_acceptsSharedMissionPrefixForUiProofCapture() {
+    let request = FridayChatViewModel.buildMissionIntakeRequest(
+      intent: "route through Codex first and Claude follow-up",
+      owner: "admin-001",
+      idFactory: { "ui_proof_fixed" },
+      missionIdPrefix: "mission_")
+    XCTAssertEqual(request.missionId, "mission_ui_proof_fixed")
+    XCTAssertEqual(request.workItemId, "work-mobile-ui_proof_fixed")
+    XCTAssertEqual(request.surfaceKind, "mobile")
+    XCTAssertEqual(request.deliveryRoute, "ios://friday-mobile/chat/ui_proof_fixed")
+  }
+
   func testSend_withMissionClient_dispatchesGeneratedClaudeFollowUp() async throws {
     let mission = FakeMissionClient()
     let snapshotJSON = """

--- a/apps/friday-ios/Tests/FridayMobileShellCoreTests/LiveMissionSpineWriteDispatchIntegrationTests.swift
+++ b/apps/friday-ios/Tests/FridayMobileShellCoreTests/LiveMissionSpineWriteDispatchIntegrationTests.swift
@@ -74,15 +74,16 @@ func liveMobileMissionSpineWriteDispatchCanStartMissionBoundRun() async throws {
 @Test(.enabled(if: liveProductAutoFollowUpRunEnabled))
 @MainActor
 func liveMobileChatSendAutoDispatchesHybridClaudeFollowUp() async throws {
-  let id = "liveauto\(UUID().uuidString.lowercased().replacingOccurrences(of: "-", with: ""))"
+  let identity = liveUiProofMissionIdentity(defaultSurface: "mobile")
   let writeClient = try RealWriteClientFactory.makeLive(config: mobileProductAutoFollowUpWriteConfig())
-  let readClient = try RealReadClientFactory.makeLive(missionId: "mission-mobile-\(id)")
+  let readClient = try RealReadClientFactory.makeLive(missionId: identity.missionId)
   let vm = FridayChatViewModel(
     writeClient: writeClient,
     signer: MockOperatorSigner(),
     missionClient: writeClient,
     readClient: readClient,
-    newId: { id })
+    newId: { identity.id },
+    missionIdPrefix: identity.missionIdPrefix)
 
   await vm.send(
     "In the Friday mobile shell test target, identify the mobile live mission-spine test file path, "
@@ -95,13 +96,13 @@ func liveMobileChatSendAutoDispatchesHybridClaudeFollowUp() async throws {
   }
 
   print(
-    "[live-mobile-product-auto-followup] id=\(id) firstRunId=\(receipt.runId) "
+    "[live-mobile-product-auto-followup] id=\(identity.id) firstRunId=\(receipt.runId) "
       + "missionId=\(receipt.missionId ?? "<nil>") workItemId=\(receipt.workItemId ?? "<nil>") "
       + "followUpWorkItemId=\(receipt.followUpWorkItemId ?? "<nil>") "
       + "followUpRunId=\(receipt.followUpRunId ?? "<nil>")")
-  #expect(receipt.missionId == "mission-mobile-\(id)")
-  #expect(receipt.workItemId == "work-mobile-\(id)")
-  #expect(receipt.followUpWorkItemId == "work-mobile-\(id)-claude-followup")
+  #expect(receipt.missionId == identity.missionId)
+  #expect(receipt.workItemId == "work-mobile-\(identity.id)")
+  #expect(receipt.followUpWorkItemId == "work-mobile-\(identity.id)-claude-followup")
   #expect(receipt.followUpRunId != nil)
   #expect(receipt.answerBodyRunId == receipt.followUpRunId)
   #expect(receipt.answerBodyOutcome == "delivered")
@@ -117,6 +118,30 @@ func liveMobileChatSendAutoDispatchesHybridClaudeFollowUp() async throws {
   #expect(learningRows.allSatisfy {
     (($0["evidenceRef"] as? String)?.hasPrefix("proof://run-outcome-learning-candidate/")) == true
   })
+}
+
+private struct LiveUiProofMissionIdentity {
+  let id: String
+  let missionIdPrefix: String
+  let missionId: String
+}
+
+private func liveUiProofMissionIdentity(defaultSurface: String) -> LiveUiProofMissionIdentity {
+  let rawSharedId = ProcessInfo.processInfo.environment["FRIDAY_MISSION_SPINE_UI_PROOF_SHARED_ID"]?
+    .trimmingCharacters(in: .whitespacesAndNewlines)
+  if let rawSharedId, !rawSharedId.isEmpty {
+    let id = rawSharedId.hasPrefix("mission_")
+      ? String(rawSharedId.dropFirst("mission_".count))
+      : rawSharedId
+    return LiveUiProofMissionIdentity(id: id, missionIdPrefix: "mission_", missionId: "mission_\(id)")
+  }
+
+  let id = "liveauto\(UUID().uuidString.lowercased().replacingOccurrences(of: "-", with: ""))"
+  let missionIdPrefix = "mission-\(defaultSurface)-"
+  return LiveUiProofMissionIdentity(
+    id: id,
+    missionIdPrefix: missionIdPrefix,
+    missionId: "\(missionIdPrefix)\(id)")
 }
 
 private func pollLiveRunOutcomeLearningCandidates(

--- a/apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/OperationsOverviewViewModel.swift
+++ b/apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/OperationsOverviewViewModel.swift
@@ -178,19 +178,22 @@ public final class OperationsOverviewViewModel: ObservableObject {
   /// A fresh-id factory for the client-supplied mission/work-item ids (the server births rows from
   /// them). Injectable for deterministic tests.
   private let newId: @Sendable () -> String
+  private let missionIdPrefix: String
 
   public init(
     client: FridayRustReadClient,
     writeClient: FridayMissionSpineWriteClient? = nil,
     missionRunClient: FridayMissionBoundRunWriteClient? = nil,
     writeOwnerPrincipal: String = liveReadProjectionOwnerPrincipal,
-    newId: @escaping @Sendable () -> String = { UUID().uuidString }
+    newId: @escaping @Sendable () -> String = { UUID().uuidString },
+    missionIdPrefix: String = "mission-desktop-"
   ) {
     self.client = client
     self.writeClient = writeClient
     self.missionRunClient = missionRunClient
     self.writeOwnerPrincipal = writeOwnerPrincipal
     self.newId = newId
+    self.missionIdPrefix = missionIdPrefix
   }
 
   /// Re-fetch the Workbench projection. The only mutating-looking action — and it
@@ -268,7 +271,8 @@ public final class OperationsOverviewViewModel: ObservableObject {
     }
     intakeState = .sent
     let request = Self.buildIntakeRequest(
-      intent: trimmed, owner: writeOwnerPrincipal, idFactory: newId)
+      intent: trimmed, owner: writeOwnerPrincipal, idFactory: newId,
+      missionIdPrefix: missionIdPrefix)
     do {
       let result = try await writeClient.submitMissionIntake(request)
       switch result.status {
@@ -456,7 +460,8 @@ public final class OperationsOverviewViewModel: ObservableObject {
   /// are server-accepted tokens; `delivery_route` is a non-empty desktop route hint. `owner` MUST
   /// equal the server `--owner` (FIX-Q3b). The title is a short prefix of the intent.
   static func buildIntakeRequest(
-    intent: String, owner: String, idFactory: () -> String
+    intent: String, owner: String, idFactory: () -> String,
+    missionIdPrefix: String = "mission-desktop-"
   ) -> MissionIntakeRequestWire {
     let title = String(intent.prefix(72))
     let id = idFactory()
@@ -467,7 +472,7 @@ public final class OperationsOverviewViewModel: ObservableObject {
       surfaceKind: "desktop",
       deliveryRoute: "desktop://hub-console/operations/\(id)",
       visibilityPolicy: "compact",
-      missionId: "mission-desktop-\(id)",
+      missionId: "\(missionIdPrefix)\(id)",
       workItemId: "work-desktop-\(id)",
       title: title,
       intent: intent,

--- a/apps/macos/FridayHubConsole/Tests/FridayHubConsoleCoreTests/LiveMissionSpineWriteDispatchIntegrationTests.swift
+++ b/apps/macos/FridayHubConsole/Tests/FridayHubConsoleCoreTests/LiveMissionSpineWriteDispatchIntegrationTests.swift
@@ -308,15 +308,16 @@ private func liveClaudeFollowUpTask(
 @Test(.enabled(if: liveProductAutoFollowUpRunEnabled))
 @MainActor
 func liveOperationsOverviewSubmitIntakeAutoDispatchesHybridClaudeFollowUp() async throws {
-  let id = "liveauto\(UUID().uuidString.lowercased().replacingOccurrences(of: "-", with: ""))"
-  let readClient = try RealReadClientFactory.makeLive(missionId: "mission-desktop-\(id)")
+  let identity = liveUiProofMissionIdentity(defaultSurface: "desktop")
+  let readClient = try RealReadClientFactory.makeLive(missionId: identity.missionId)
   let writeClient = try RealWriteClientFactory.makeLiveWrite(config: hybridFollowUpWriteConfig())
   let vm = OperationsOverviewViewModel(
     client: readClient,
     writeClient: writeClient,
     missionRunClient: writeClient,
     writeOwnerPrincipal: liveReadProjectionOwnerPrincipal,
-    newId: { id })
+    newId: { identity.id },
+    missionIdPrefix: identity.missionIdPrefix)
 
   await vm.submitIntake(
     intent: "In the FridayHubConsole test target, identify the live hybrid route test file path, "
@@ -328,10 +329,10 @@ func liveOperationsOverviewSubmitIntakeAutoDispatchesHybridClaudeFollowUp() asyn
     return
   }
 
-  print("[live-product-auto-followup] id=\(id) summary=\(summary)")
-  #expect(summary.contains("mission-desktop-\(id)"))
-  #expect(summary.contains("work-desktop-\(id)"))
-  #expect(summary.contains("follow_up_work_item_id=work-desktop-\(id)-claude-followup"))
+  print("[live-product-auto-followup] id=\(identity.id) summary=\(summary)")
+  #expect(summary.contains(identity.missionId))
+  #expect(summary.contains("work-desktop-\(identity.id)"))
+  #expect(summary.contains("follow_up_work_item_id=work-desktop-\(identity.id)-claude-followup"))
   #expect(answerBody?.contains("Codex:") == true)
   #expect(answerBody?.contains("Claude follow-up:") == true)
   #expect(answerBody?.contains("FRIDAY_PRODUCT_AUTO_FOLLOWUP_OK") == true)
@@ -347,6 +348,30 @@ func liveOperationsOverviewSubmitIntakeAutoDispatchesHybridClaudeFollowUp() asyn
   #expect(learningRows.allSatisfy {
     (($0["evidenceRef"] as? String)?.hasPrefix("proof://run-outcome-learning-candidate/")) == true
   })
+}
+
+private struct LiveUiProofMissionIdentity {
+  let id: String
+  let missionIdPrefix: String
+  let missionId: String
+}
+
+private func liveUiProofMissionIdentity(defaultSurface: String) -> LiveUiProofMissionIdentity {
+  let rawSharedId = ProcessInfo.processInfo.environment["FRIDAY_MISSION_SPINE_UI_PROOF_SHARED_ID"]?
+    .trimmingCharacters(in: .whitespacesAndNewlines)
+  if let rawSharedId, !rawSharedId.isEmpty {
+    let id = rawSharedId.hasPrefix("mission_")
+      ? String(rawSharedId.dropFirst("mission_".count))
+      : rawSharedId
+    return LiveUiProofMissionIdentity(id: id, missionIdPrefix: "mission_", missionId: "mission_\(id)")
+  }
+
+  let id = "liveauto\(UUID().uuidString.lowercased().replacingOccurrences(of: "-", with: ""))"
+  let missionIdPrefix = "mission-\(defaultSurface)-"
+  return LiveUiProofMissionIdentity(
+    id: id,
+    missionIdPrefix: missionIdPrefix,
+    missionId: "\(missionIdPrefix)\(id)")
 }
 
 private func summaryRunIds(in summary: String) -> [String] {

--- a/apps/macos/FridayHubConsole/Tests/FridayHubConsoleCoreTests/OperationsOverviewViewModelTests.swift
+++ b/apps/macos/FridayHubConsole/Tests/FridayHubConsoleCoreTests/OperationsOverviewViewModelTests.swift
@@ -651,6 +651,21 @@ func submitIntakeReadyRendersConfirmedAndWiresOwnerAdmin001() async {
 
 @Test
 @MainActor
+func buildIntakeRequestAcceptsSharedMissionPrefixForUiProofCapture() {
+  let request = OperationsOverviewViewModel.buildIntakeRequest(
+    intent: "keep one Mission across every surface",
+    owner: "admin-001",
+    idFactory: { "ui_proof_fixed" },
+    missionIdPrefix: "mission_")
+
+  #expect(request.missionId == "mission_ui_proof_fixed")
+  #expect(request.workItemId == "work-desktop-ui_proof_fixed")
+  #expect(request.surfaceKind == "desktop")
+  #expect(request.deliveryRoute == "desktop://hub-console/operations/ui_proof_fixed")
+}
+
+@Test
+@MainActor
 func submitIntakeReadyDispatchesMissionBoundModelTurnWhenRunClientConfigured() async {
   let write = MockMissionSpineWriteClient(behavior: .intakeReady)
   let vm = OperationsOverviewViewModel(


### PR DESCRIPTION
## Summary
- add default-preserving missionIdPrefix injection to iOS Chat and macOS Operations intake builders
- let live product auto-followup dogfood share one final-proof-shaped mission id via FRIDAY_MISSION_SPINE_UI_PROOF_SHARED_ID
- keep default product ids unchanged while enabling same-mission mobile+desktop capture for the UI/device proof gate

## Verification
- git diff --check
- swift test --package-path apps/friday-ios
- swift test --package-path apps/macos/FridayHubConsole
- FRIDAY_MISSION_SPINE_UI_PROOF_SHARED_ID=ui_proof_20260622T063800 FRIDAY_MOBILE_LIVE_PRODUCT_AUTO_FOLLOWUP_RUN_TEST=1 swift test --package-path apps/friday-ios --filter liveMobileChatSendAutoDispatchesHybridClaudeFollowUp
- FRIDAY_MISSION_SPINE_UI_PROOF_SHARED_ID=ui_proof_20260622T063800 FRIDAY_CONSOLE_LIVE_PRODUCT_AUTO_FOLLOWUP_RUN_TEST=1 swift test --package-path apps/macos/FridayHubConsole --filter liveOperationsOverviewSubmitIntakeAutoDispatchesHybridClaudeFollowUp
- DB readback: mission_ui_proof_20260622T063800 has mobile+desktop surface_thread rows, 12 mission_link rows
- API readback: /v1/mission-spine/workbench ok=true for mission_ui_proof_20260622T063800, providerReceipts=6, surfaces=[desktop,mobile,timeline], channelReceipts=0

## Truth labels
- proves same-mission mobile+desktop product capture is wired and live dogfood-stable
- does not prove channel/Telegram evidence, real-user adoption, release-GO, or full goal completion
