### PR TITLE
Upload Telegram channel live wrapper proof

### DIFF
--- a/.github/workflows/telegram-live-proof.yml
+++ b/.github/workflows/telegram-live-proof.yml
@@ -54,17 +54,20 @@ jobs:
       # ~8 min listen window — the trusted user must DM the bot within it.
       TELEGRAM_LISTEN_SECONDS: "480"
       TELEGRAM_PROOF_OUT: ${{ github.workspace }}/telegram_live_proof.json
+      MISSION_SPINE_CHANNEL_LIVE_PROOF_OUT: ${{ github.workspace }}/mission_spine_channel_live_proof.json
     steps:
       - name: Checkout
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
       - name: Toolchain
         run: rustup show && cargo --version
       - name: Live proof — real Telegram message through the Rust channels pipeline
-        run: cargo test -p friday-hub --test telegram_live -- --ignored --nocapture
+        run: scripts/mission-spine-channel-live-gate.sh
       - name: Upload live-proof evidence (redacted; no token)
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: telegram-live-proof-${{ github.run_id }}
-          path: ${{ github.workspace }}/telegram_live_proof.json
+          path: |
+            ${{ github.workspace }}/telegram_live_proof.json
+            ${{ github.workspace }}/mission_spine_channel_live_proof.json
           if-no-files-found: warn


### PR DESCRIPTION
## Summary
- run the existing Mission Spine channel live gate from the Telegram listen workflow
- upload both the raw redacted Telegram proof and the closure-audit wrapper artifact
- preserve the real allowlisted-DM requirement; this does not fake or synthesize channel evidence

## Verification
- ruby YAML parse for `.github/workflows/telegram-live-proof.yml`
- `bash -n rust-core/scripts/mission-spine-channel-live-gate.sh`
- `git diff --check`

## Truth label
This PR only fixes the artifact shape for the next real Telegram listen run. It is not a fresh channel proof by itself, not final UI/device proof, not release-GO, and not goal-achieved.