### PR TITLE
Harden product follow-up outcome prompts

### DIFF
--- a/apps/friday-ios/Sources/FridayMobileShellCore/FridayChatViewModel.swift
+++ b/apps/friday-ios/Sources/FridayMobileShellCore/FridayChatViewModel.swift
@@ -573,7 +573,7 @@ public final class FridayChatViewModel: ObservableObject {
   }
 
   private static let claudeFollowUpTaskHeader =
-    "Summarize the generated Claude follow-up for this Mission."
+    "Write a concise owner-visible summary for this Mission result."
 
   private static func claudeFollowUpTask(
     sourceWorkItemId: String,
@@ -592,19 +592,36 @@ public final class FridayChatViewModel: ObservableObject {
     lines.append(
       "output destination: owner-visible answer body for \(followUpWorkItemId).")
     lines.append(
-      "success = concise final synthesis that preserves any requested sentinel or outcome from the Codex first-leg answer.")
+      "task: produce the final owner-visible answer for this follow-up WorkItem, not a plan.")
     lines.append(
-      "constraint = read-only; do not mutate the workspace, do not continue file discovery, and do not ask clarifying questions.")
-    if let firstAnswerBody = firstAnswerBody?.trimmingCharacters(in: .whitespacesAndNewlines),
-      !firstAnswerBody.isEmpty
-    {
-      lines.append("Codex first-leg answer:")
-      lines.append(firstAnswerBody)
+      "success = concise final synthesis that preserves the outcome token or requested result below.")
+    lines.append(
+      "constraints = read-only; no file changes; no extra discovery; do not ask clarifying questions.")
+    if let outcomeExcerpt = firstAnswerOutcomeExcerpt(firstAnswerBody) {
+      lines.append("Codex first-leg outcome excerpt:")
+      lines.append(outcomeExcerpt)
     }
     lines.append(
-      "Use the Mission context and the proof/input refs already attached to this WorkItem; do not ask the operator for paths, IDs, or artifact locations that are listed above.")
+      "Use only the Mission context, attached refs, and outcome excerpt above; do not ask the operator for paths, IDs, or artifact locations that are listed above.")
     lines.append(
-      "Keep the run read-only; summarize the Codex first-leg answer and this follow-up outcome, and do not claim you verified unrelated files or artifacts unless that evidence is explicitly present in the provided context.")
+      "Return the owner-visible answer directly; do not continue any first-person action described in the Codex excerpt, and do not claim you verified unrelated files or artifacts.")
     return lines.joined(separator: "\n")
+  }
+
+  private static func firstAnswerOutcomeExcerpt(_ body: String?) -> String? {
+    guard let raw = body?.trimmingCharacters(in: .whitespacesAndNewlines), !raw.isEmpty else {
+      return nil
+    }
+    if let sentinel = raw.range(of: #"FRIDAY_[A-Z0-9_]+_OK"#, options: .regularExpression) {
+      return String(raw[sentinel])
+    }
+    let lines = raw.split(whereSeparator: { $0.isNewline })
+      .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+      .filter { !$0.isEmpty }
+    let excerpt = lines.last ?? raw
+    if excerpt.count <= 800 {
+      return String(excerpt)
+    }
+    return String(excerpt.suffix(800))
   }
 }

--- a/apps/friday-ios/Tests/FridayMobileShellCoreTests/FridayChatViewModelTests.swift
+++ b/apps/friday-ios/Tests/FridayMobileShellCoreTests/FridayChatViewModelTests.swift
@@ -311,7 +311,7 @@ final class FridayChatViewModelTests: XCTestCase {
         projectionJSON: Data(snapshotJSON.utf8),
         generatedAtMs: 0),
       answerBodies: [
-        "run-first": "Mobile Codex first answer",
+        "run-first": "I am still checking files before the final answer. FRIDAY_MOBILE_PRODUCT_AUTO_FOLLOWUP_OK",
         "run-followup": "Claude follow-up body visible to the owner.",
       ])
     let vm = FridayChatViewModel(
@@ -334,9 +334,11 @@ final class FridayChatViewModelTests: XCTestCase {
     XCTAssertTrue(mission.dispatchedTasks[1].contains("follow_up_work_item_id=work-mobile-fixed-claude-followup"))
     XCTAssertTrue(mission.dispatchedTasks[1].contains("codex_first_run_id=run-first"))
     XCTAssertTrue(mission.dispatchedTasks[1].contains("output destination: owner-visible answer body"))
+    XCTAssertTrue(mission.dispatchedTasks[1].contains("task: produce the final owner-visible answer"))
     XCTAssertTrue(mission.dispatchedTasks[1].contains("success = concise final synthesis"))
-    XCTAssertTrue(mission.dispatchedTasks[1].contains("constraint = read-only"))
-    XCTAssertTrue(mission.dispatchedTasks[1].contains("Mobile Codex first answer"))
+    XCTAssertTrue(mission.dispatchedTasks[1].contains("constraints = read-only"))
+    XCTAssertTrue(mission.dispatchedTasks[1].contains("FRIDAY_MOBILE_PRODUCT_AUTO_FOLLOWUP_OK"))
+    XCTAssertFalse(mission.dispatchedTasks[1].contains("I am still checking files"))
     XCTAssertTrue(mission.dispatchedTasks[1].contains("do not ask the operator for paths"))
     XCTAssertTrue(mission.dispatchedTasks[1].contains("do not claim you verified unrelated files"))
     guard case .answered(let receipt) = vm.phase else { return XCTFail("expected answered, got \(vm.phase)") }

--- a/apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/OperationsOverviewViewModel.swift
+++ b/apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/OperationsOverviewViewModel.swift
@@ -523,7 +523,7 @@ public final class OperationsOverviewViewModel: ObservableObject {
   }
 
   private static let claudeFollowUpTaskHeader =
-    "Summarize the generated Claude follow-up for this Mission."
+    "Write a concise owner-visible summary for this Mission result."
 
   private static func claudeFollowUpTask(
     sourceWorkItemId: String,
@@ -544,20 +544,37 @@ public final class OperationsOverviewViewModel: ObservableObject {
     lines.append(
       "output destination: owner-visible answer body for \(followUpWorkItemId).")
     lines.append(
-      "success = concise final synthesis that preserves any requested sentinel or outcome from the Codex first-leg answer.")
+      "task: produce the final owner-visible answer for this follow-up WorkItem, not a plan.")
     lines.append(
-      "constraint = read-only; do not mutate the workspace, do not continue file discovery, and do not ask clarifying questions.")
-    if let firstAnswerBody = firstAnswerBody?.trimmingCharacters(in: .whitespacesAndNewlines),
-      !firstAnswerBody.isEmpty
-    {
-      lines.append("Codex first-leg answer:")
-      lines.append(firstAnswerBody)
+      "success = concise final synthesis that preserves the outcome token or requested result below.")
+    lines.append(
+      "constraints = read-only; no file changes; no extra discovery; do not ask clarifying questions.")
+    if let outcomeExcerpt = firstAnswerOutcomeExcerpt(firstAnswerBody) {
+      lines.append("Codex first-leg outcome excerpt:")
+      lines.append(outcomeExcerpt)
     }
     lines.append(
-      "Use the Mission context and the proof/input refs already attached to this WorkItem; do not ask the operator for paths, IDs, or artifact locations that are listed above.")
+      "Use only the Mission context, attached refs, and outcome excerpt above; do not ask the operator for paths, IDs, or artifact locations that are listed above.")
     lines.append(
-      "Keep the run read-only; summarize the Codex first-leg answer and this follow-up outcome, and do not claim you verified unrelated files or artifacts unless that evidence is explicitly present in the provided context.")
+      "Return the owner-visible answer directly; do not continue any first-person action described in the Codex excerpt, and do not claim you verified unrelated files or artifacts.")
     return lines.joined(separator: "\n")
+  }
+
+  private static func firstAnswerOutcomeExcerpt(_ body: String?) -> String? {
+    guard let raw = body?.trimmingCharacters(in: .whitespacesAndNewlines), !raw.isEmpty else {
+      return nil
+    }
+    if let sentinel = raw.range(of: #"FRIDAY_[A-Z0-9_]+_OK"#, options: .regularExpression) {
+      return String(raw[sentinel])
+    }
+    let lines = raw.split(whereSeparator: { $0.isNewline })
+      .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+      .filter { !$0.isEmpty }
+    let excerpt = lines.last ?? raw
+    if excerpt.count <= 800 {
+      return String(excerpt)
+    }
+    return String(excerpt.suffix(800))
   }
 
   private static func runId(for outcome: AgentRunDispatchOutcome) -> String? {

--- a/apps/macos/FridayHubConsole/Tests/FridayHubConsoleCoreTests/LiveMissionSpineWriteDispatchIntegrationTests.swift
+++ b/apps/macos/FridayHubConsole/Tests/FridayHubConsoleCoreTests/LiveMissionSpineWriteDispatchIntegrationTests.swift
@@ -287,22 +287,42 @@ private func liveClaudeFollowUpTask(
   firstAnswerBody: String?
 ) -> String {
   var lines = [
-    "Run the generated Claude follow-up for this Mission.",
+    "Write a concise owner-visible summary for this Mission result.",
     "source_work_item_id=\(sourceWorkItemId)",
     "follow_up_work_item_id=\(followUpWorkItemId)",
     "codex_first_run_id=\(firstRunId)",
+    "input refs: mission context, attached WorkItem refs, and the codex_first_run_id above are sufficient.",
+    "output destination: owner-visible answer body for \(followUpWorkItemId).",
+    "task: produce the final owner-visible answer for this follow-up WorkItem, not a plan.",
+    "success = concise final synthesis that preserves the outcome token or requested result below.",
+    "constraints = read-only; no file changes; no extra discovery; do not ask clarifying questions.",
   ]
-  if let firstAnswerBody = firstAnswerBody?.trimmingCharacters(in: .whitespacesAndNewlines),
-    !firstAnswerBody.isEmpty
-  {
-    lines.append("Codex first-leg answer:")
-    lines.append(firstAnswerBody)
+  if let outcomeExcerpt = firstAnswerOutcomeExcerpt(firstAnswerBody) {
+    lines.append("Codex first-leg outcome excerpt:")
+    lines.append(outcomeExcerpt)
   }
   lines.append(
-    "Use the Mission context and the proof/input refs already attached to this WorkItem; do not ask the operator for paths, IDs, or artifact locations that are listed above.")
+    "Use only the Mission context, attached refs, and outcome excerpt above; do not ask the operator for paths, IDs, or artifact locations that are listed above.")
   lines.append(
-    "Keep the run read-only; summarize the Codex first-leg answer and this follow-up outcome, and do not claim you verified unrelated files or artifacts unless that evidence is explicitly present in the provided context.")
+    "Return the owner-visible answer directly; do not continue any first-person action described in the Codex excerpt, and do not claim you verified unrelated files or artifacts.")
   return lines.joined(separator: "\n")
+}
+
+private func firstAnswerOutcomeExcerpt(_ body: String?) -> String? {
+  guard let raw = body?.trimmingCharacters(in: .whitespacesAndNewlines), !raw.isEmpty else {
+    return nil
+  }
+  if let sentinel = raw.range(of: #"FRIDAY_[A-Z0-9_]+_OK"#, options: .regularExpression) {
+    return String(raw[sentinel])
+  }
+  let lines = raw.split(whereSeparator: { $0.isNewline })
+    .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+    .filter { !$0.isEmpty }
+  let excerpt = lines.last ?? raw
+  if excerpt.count <= 800 {
+    return String(excerpt)
+  }
+  return String(excerpt.suffix(800))
 }
 
 @Test(.enabled(if: liveProductAutoFollowUpRunEnabled))

--- a/apps/macos/FridayHubConsole/Tests/FridayHubConsoleCoreTests/OperationsOverviewViewModelTests.swift
+++ b/apps/macos/FridayHubConsole/Tests/FridayHubConsoleCoreTests/OperationsOverviewViewModelTests.swift
@@ -695,7 +695,10 @@ func submitIntakeDispatchesClaudeFollowUpWhenProjectionExposesGeneratedWorkItem(
       missionId: "mission-desktop-fixed",
       fridayConversationId: "fconv_desktop_fixed",
       workItemIds: ["work-desktop-fixed", "work-desktop-fixed-claude-followup"]),
-    answerBodies: ["run-bound-1": "Desktop Codex first answer"])
+    answerBodies: [
+      "run-bound-1":
+        "I am still checking files before the final answer. FRIDAY_DESKTOP_PRODUCT_AUTO_FOLLOWUP_OK"
+    ])
   let vm = OperationsOverviewViewModel(
     client: read, writeClient: write, missionRunClient: write,
     writeOwnerPrincipal: "admin-001", newId: { "fixed" })
@@ -715,9 +718,11 @@ func submitIntakeDispatchesClaudeFollowUpWhenProjectionExposesGeneratedWorkItem(
   #expect(write.dispatchedTasks[1].contains("follow_up_work_item_id=work-desktop-fixed-claude-followup"))
   #expect(write.dispatchedTasks[1].contains("codex_first_run_id=run-bound-1"))
   #expect(write.dispatchedTasks[1].contains("output destination: owner-visible answer body"))
+  #expect(write.dispatchedTasks[1].contains("task: produce the final owner-visible answer"))
   #expect(write.dispatchedTasks[1].contains("success = concise final synthesis"))
-  #expect(write.dispatchedTasks[1].contains("constraint = read-only"))
-  #expect(write.dispatchedTasks[1].contains("Desktop Codex first answer"))
+  #expect(write.dispatchedTasks[1].contains("constraints = read-only"))
+  #expect(write.dispatchedTasks[1].contains("FRIDAY_DESKTOP_PRODUCT_AUTO_FOLLOWUP_OK"))
+  #expect(!write.dispatchedTasks[1].contains("I am still checking files"))
   #expect(write.dispatchedTasks[1].contains("do not ask the operator for paths"))
   #expect(write.dispatchedTasks[1].contains("do not claim you verified unrelated files"))
 }


### PR DESCRIPTION
## Summary
- make iOS and desktop generated Claude follow-up tasks owner-visible summary tasks instead of generated/run-style prompts
- pass a bounded Codex first-leg outcome excerpt, preserving FRIDAY_*_OK sentinels while dropping process narration that can re-trigger clarification
- update the desktop live helper and unit tests to assert process narration is not forwarded

## Verification
- git diff --check
- swift test --package-path apps/macos/FridayHubConsole --filter submitIntakeDispatchesClaudeFollowUpWhenProjectionExposesGeneratedWorkItem
- swift test --package-path apps/friday-ios --filter FridayChatViewModelTests/testSend_withMissionClient_dispatchesGeneratedClaudeFollowUp
- swift test --package-path apps/macos/FridayHubConsole
- swift test --package-path apps/friday-ios
- live mobile proof PASS: FRIDAY_MISSION_SPINE_UI_PROOF_SHARED_ID=ui_proof_fix2_20260622T091048, first run run-1D358A5E-05AC-4F7E-9B09-1A626EA00D5F, Claude follow-up run-49584E47-970C-49AE-9B29-189635644870
- live desktop proof PASS after serial rerun on same shared mission: first run run-A50A1D95-F750-477C-8985-20073D5E6B46, Claude follow-up run-2B29C65A-EC58-4EFE-B719-C660016CE6B6
- DB reconciliation for mission_ui_proof_fix2_20260622T091048: 4 work_items completed_with_proof, 4 run_results finished, Codex/Anthropic token_ledger fallback=0, 12 A1 candidates, mobile+desktop surface_events present

Truth label: agent-driven product dogfood / v1-works evidence only. Not final channel proof, not MISSION_SPINE_UI_DEVICE_PROOF, not strict closure, not release-GO, not goal-achieved.