### PR TITLE
[codex] Fix Mission Workbench capability render keys

### DIFF
--- a/ui/src/routes/mission-workbench-page.tsx
+++ b/ui/src/routes/mission-workbench-page.tsx
@@ -8,6 +8,7 @@ import { missionWorkbenchApi } from "@/lib/api/mission-workbench";
 import { localize } from "@/lib/i18n/localized-text";
 import {
   type MissionWorkbenchApprovalState,
+  type MissionWorkbenchCapabilityState,
   type MissionLifecycleState,
   type MissionTranscriptGroupKind,
   type MissionSurfaceKind,
@@ -48,6 +49,18 @@ function stateMeansDone(state: MissionLifecycleState): boolean {
 
 function truthLabelText(label: MissionTruthLabel): string {
   return label.replaceAll("_", "-");
+}
+
+function capabilityStateRenderKey(capability: MissionWorkbenchCapabilityState, index: number): string {
+  return [
+    capability.id,
+    capability.kind,
+    capability.truthLabel,
+    capability.approvalState,
+    capability.dispatchAllowed ? "dispatch" : "gated",
+    capability.proofRef,
+    index,
+  ].join(":");
 }
 
 export function MissionWorkbenchPage() {
@@ -347,8 +360,8 @@ export function MissionWorkbenchPage() {
 
           <ShellCard eyebrow="Capabilities" title={localize(locale, "能力与审批", "Capability gates")}>
             <div className="space-y-3">
-              {snapshot.capabilityStates.map((capability) => (
-                <div key={capability.id} className="rounded-lg border border-[color:var(--color-border-soft)] bg-[color:var(--color-bg-subtle)] p-4">
+              {snapshot.capabilityStates.map((capability, index) => (
+                <div key={capabilityStateRenderKey(capability, index)} className="rounded-lg border border-[color:var(--color-border-soft)] bg-[color:var(--color-bg-subtle)] p-4">
                   <div className="flex items-start justify-between gap-3">
                     <div>
                       <p className="text-sm font-semibold text-[color:var(--color-text-primary)]">{capability.label}</p>


### PR DESCRIPTION
## Summary

Fixes the Mission Workbench capability list React keys so live projections that include repeated capability ids render without duplicate-key console errors.

## Why

The current live Mission Workbench projection for `mission_ui_device_capture_20260622T100322Z` includes repeated provider capability ids such as Claude turn capability rows. The page previously keyed capability cards only by `capability.id`, which made the readiness check report `pageErrorsAbsent=false` and blocked final capture readiness.

## Validation

- `./node_modules/.bin/tsc -p ui/tsconfig.json --noEmit`
- `FRIDAY_LOCAL_PASSPHRASE=... node scripts/qa/check-mission-workbench-live-readiness.mjs --mission-id=mission_ui_device_capture_20260622T100322Z`
  - `readyForFinalCapture=true`
  - `classification=live_rust_hub_ready_for_operator_capture`
  - `pageErrorsAbsent=true`
  - `consoleErrorCount=0`
- `git diff --check`

Notes: eslint on this single file produced only the existing config-scope warning: `File ignored because no matching configuration was supplied`.
