### PR TITLE
[codex] Expose WorkItem recovery controls in Workbench

### DIFF
--- a/apps/friday-ios/Sources/FridayMobileShell/FridayProjectionScreens.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayProjectionScreens.swift
@@ -543,6 +543,23 @@ struct FridayProjectionScreen: View {
       HStack(spacing: 6) {
         statusChip(item.state)
         statusChip(item.owner)
+        statusChip(item.recoveryKind)
+      }
+      if !item.blockingReason.isEmpty {
+        Text(item.blockingReason)
+          .font(.system(size: 11))
+          .foregroundStyle(MobileTheme.textSecondary)
+          .fixedSize(horizontal: false, vertical: true)
+      }
+      if item.canRetry || item.canCancel {
+        HStack(spacing: 6) {
+          if item.canRetry {
+            statusChip("retry available")
+          }
+          if item.canCancel {
+            statusChip("cancel available")
+          }
+        }
       }
       if let proofRef = item.proofRef {
         RefPill(label: "proofRef", ref: proofRef)

--- a/apps/friday-ios/Sources/FridayMobileShellCore/HomeViewModel.swift
+++ b/apps/friday-ios/Sources/FridayMobileShellCore/HomeViewModel.swift
@@ -107,7 +107,11 @@ public struct HomeProjection: Sendable, Equatable {
         state: (row["state"] as? String) ?? "unknown",
         owner: (row["owner"] as? String) ?? "unknown",
         proofRef: row["proofRef"] as? String,
-        done: row["done"] as? Bool ?? false)
+        done: row["done"] as? Bool ?? false,
+        blockingReason: (row["blockingReason"] as? String) ?? "",
+        recoveryKind: (row["recoveryKind"] as? String) ?? "none",
+        canRetry: row["canRetry"] as? Bool ?? false,
+        canCancel: row["canCancel"] as? Bool ?? false)
     }
   }
 
@@ -192,9 +196,13 @@ public struct HomeWorkItem: Sendable, Identifiable, Equatable {
   public let owner: String
   public let proofRef: String?
   public let done: Bool
+  public let blockingReason: String
+  public let recoveryKind: String
+  public let canRetry: Bool
+  public let canCancel: Bool
 
   public var needsAttention: Bool {
-    !done && ["blocked", "waiting", "error", "stale"].contains(state)
+    !done && (["blocked", "waiting", "error", "stale"].contains(state) || canRetry || canCancel)
   }
 }
 

--- a/apps/friday-ios/Tests/FridayMobileShellCoreTests/HomeViewModelTests.swift
+++ b/apps/friday-ios/Tests/FridayMobileShellCoreTests/HomeViewModelTests.swift
@@ -145,8 +145,8 @@ final class HomeViewModelTests: XCTestCase {
       "providerReceiptRefs": ["proof://provider/1"],
       "channelReceiptRefs": ["proof://surface/mobile/1"],
       "workItems": [
-        { "workItemId": "wi-1", "title": "Draft mission", "state": "ready", "owner": "friday_owned", "done": false },
-        { "workItemId": "wi-2", "title": "Needs approval", "state": "waiting", "owner": "linked_only", "proofRef": "proof://wi/2", "done": false }
+        { "workItemId": "wi-1", "title": "Draft mission", "state": "ready", "owner": "friday_owned", "done": false, "blockingReason": "ready for dispatch; no recovery action required", "recoveryKind": "dispatchable", "canRetry": false, "canCancel": true },
+        { "workItemId": "wi-2", "title": "Needs approval", "state": "stale", "owner": "linked_only", "proofRef": "proof://wi/2", "done": false, "blockingReason": "failed retryable; operator may retry by returning the WorkItem to ready_to_dispatch", "recoveryKind": "retryable", "canRetry": true, "canCancel": true }
       ],
       "memoryCandidates": [
         { "id": "cand-1", "preview": "Remember route preference.", "state": "candidate_review_only", "grantsMemoryAuthority": false, "evidenceRef": "proof://memory/1" }
@@ -208,12 +208,15 @@ final class HomeViewModelTests: XCTestCase {
     XCTAssertEqual(p.providerReceiptRefs, ["proof://provider/1"])
     XCTAssertEqual(p.channelReceiptRefs, ["proof://surface/mobile/1"])
     XCTAssertEqual(p.workItems.map(\.title), ["Draft mission", "Needs approval"])
-    XCTAssertEqual(p.workItems.filter(\.needsAttention).map(\.id), ["wi-2"])
+    XCTAssertEqual(p.workItems.filter(\.needsAttention).map(\.id), ["wi-1", "wi-2"])
+    XCTAssertEqual(p.workItems.last?.recoveryKind, "retryable")
+    XCTAssertEqual(p.workItems.last?.canRetry, true)
+    XCTAssertEqual(p.workItems.last?.blockingReason, "failed retryable; operator may retry by returning the WorkItem to ready_to_dispatch")
     XCTAssertEqual(p.memoryCandidates.first?.grantsMemoryAuthority, false)
     XCTAssertEqual(p.runOutcomeLearningCandidates.first?.runId, "run-1")
     XCTAssertEqual(p.capabilityStates.first?.dispatchAllowed, true)
     XCTAssertEqual(p.transcriptEvents.first?.summary, "Mobile surface read the mission projection.")
-    XCTAssertEqual(p.needsMeCount, 3)
+    XCTAssertEqual(p.needsMeCount, 4)
   }
 
   func testRefresh_loadedEmptyIsConnectedEmptyNotUnavailable() async throws {
@@ -536,7 +539,9 @@ final class EmulatedReadServerTransport: SealedWSTransport {
     "providerReceiptRefs":["proof://provider/emulated"],\
     "channelReceiptRefs":["proof://surface/mobile/emulated"],\
     "workItems":[{"workItemId":"wi-a","title":"Rendered answer-ready work item",\
-    "state":"waiting","owner":"friday_owned","proofRef":"proof://wi/a","done":false}],\
+    "state":"waiting","owner":"friday_owned","proofRef":"proof://wi/a","done":false,\
+    "blockingReason":"waiting on operator input or preflight resolution",\
+    "recoveryKind":"needs_operator","canRetry":false,"canCancel":true}],\
     "memoryCandidates":[{"id":"mem-a","preview":"Remember the preferred routing shape.",\
     "state":"candidate_review_only","grantsMemoryAuthority":false,\
     "evidenceRef":"proof://memory/emulated"}],\

--- a/rust-core/crates/friday-hub/src/workbench_projection.rs
+++ b/rust-core/crates/friday-hub/src/workbench_projection.rs
@@ -219,6 +219,7 @@ fn work_items_json(work_items: &[WorkItem]) -> Vec<Value> {
         .map(|item| {
             let state = lifecycle_state_for_work_item(item.status);
             let done = item.completion_is_proven();
+            let recovery = recovery_metadata_for_work_item(item.status);
             json!({
                 "id": item.work_item_id,
                 "title": item.judgment_memory.task,
@@ -227,7 +228,11 @@ fn work_items_json(work_items: &[WorkItem]) -> Vec<Value> {
                 "proofRef": item.proof_receipts.first()
                     .map(|proof| redacted_ref("work-item-proof", proof))
                     .unwrap_or_else(|| redacted_ref("work-item-required", &item.work_item_id)),
-                "done": done
+                "done": done,
+                "blockingReason": recovery.blocking_reason,
+                "recoveryKind": recovery.kind,
+                "canRetry": recovery.can_retry,
+                "canCancel": recovery.can_cancel
             })
         })
         .collect::<Vec<_>>();
@@ -238,10 +243,70 @@ fn work_items_json(work_items: &[WorkItem]) -> Vec<Value> {
             "state": "timeline_read",
             "owner": "friday_owned",
             "proofRef": redacted_ref("timeline-read", &first.mission_id),
-            "done": false
+            "done": false,
+            "blockingReason": "bounded timeline read only; no WorkItem recovery action applies",
+            "recoveryKind": "none",
+            "canRetry": false,
+            "canCancel": false
         }));
     }
     rows
+}
+
+struct WorkItemRecoveryMetadata {
+    kind: &'static str,
+    blocking_reason: &'static str,
+    can_retry: bool,
+    can_cancel: bool,
+}
+
+fn recovery_metadata_for_work_item(status: WorkItemStatus) -> WorkItemRecoveryMetadata {
+    match status {
+        WorkItemStatus::FailedRetryable => WorkItemRecoveryMetadata {
+            kind: "retryable",
+            blocking_reason: "failed retryable; operator may retry by returning the WorkItem to ready_to_dispatch",
+            can_retry: true,
+            can_cancel: true,
+        },
+        WorkItemStatus::FailedTerminal => WorkItemRecoveryMetadata {
+            kind: "terminal",
+            blocking_reason: "terminal failure; no automatic retry is exposed from the Workbench",
+            can_retry: false,
+            can_cancel: false,
+        },
+        WorkItemStatus::PreflightBlocked | WorkItemStatus::WaitingForUser => {
+            WorkItemRecoveryMetadata {
+                kind: "needs_operator",
+                blocking_reason: "waiting on operator input or preflight resolution",
+                can_retry: false,
+                can_cancel: true,
+            }
+        }
+        WorkItemStatus::Dispatched
+        | WorkItemStatus::HubAccepted
+        | WorkItemStatus::ProviderRouted
+        | WorkItemStatus::ProviderWaiting => WorkItemRecoveryMetadata {
+            kind: "in_flight",
+            blocking_reason: "provider or hub execution is still in flight; cancel is the only exposed recovery action",
+            can_retry: false,
+            can_cancel: true,
+        },
+        WorkItemStatus::Draft | WorkItemStatus::ReadyToDispatch => WorkItemRecoveryMetadata {
+            kind: "dispatchable",
+            blocking_reason: "ready for dispatch; no recovery action required",
+            can_retry: false,
+            can_cancel: true,
+        },
+        WorkItemStatus::CompletedWithProof
+        | WorkItemStatus::Cancelled
+        | WorkItemStatus::Merged
+        | WorkItemStatus::Archived => WorkItemRecoveryMetadata {
+            kind: "none",
+            blocking_reason: "terminal or archived WorkItem; no recovery action applies",
+            can_retry: false,
+            can_cancel: false,
+        },
+    }
 }
 
 fn memory_candidates_json(

--- a/src/api/http/routes/friday-mission-spine-routes.ts
+++ b/src/api/http/routes/friday-mission-spine-routes.ts
@@ -104,6 +104,14 @@ const ROUTE_ACTION_REVERSIBILITY = new Set([
   "operator_gate_required",
   "pending_classify",
 ]);
+const WORK_ITEM_RECOVERY_KINDS = new Set([
+  "none",
+  "dispatchable",
+  "in_flight",
+  "needs_operator",
+  "retryable",
+  "terminal",
+]);
 const WORK_LANES = new Set(["friday_hub", "codex", "claude", "deepseek", "workflow", "channel", "human", "future_api"]);
 const PLACEHOLDER_MARKERS = [
   "mission_pending_runtime_projection",
@@ -516,6 +524,19 @@ function validateWorkItems(snapshot: FridayMissionSpineWorkbenchSnapshot, failur
     pushIfInvalid(failures, hasText(item.title), `work_item_title_missing:${item.id}`);
     pushIfInvalid(failures, TRUTH_LABELS.has(item.owner), `work_item_truth_label_invalid:${item.id}`);
     pushIfInvalid(failures, LIFECYCLE_STATES.has(item.state), `work_item_state_invalid:${item.id}:${item.state}`);
+    pushIfInvalid(failures, hasText(item.blockingReason), `work_item_blocking_reason_missing:${item.id}`);
+    pushIfInvalid(failures, WORK_ITEM_RECOVERY_KINDS.has(item.recoveryKind), `work_item_recovery_kind_invalid:${item.id}:${item.recoveryKind}`);
+    pushIfInvalid(failures, typeof item.canRetry === "boolean", `work_item_can_retry_invalid:${item.id}`);
+    pushIfInvalid(failures, typeof item.canCancel === "boolean", `work_item_can_cancel_invalid:${item.id}`);
+    if (item.state === "stale") {
+      pushIfInvalid(failures, item.recoveryKind === "retryable", `stale_work_item_not_retryable:${item.id}`);
+      pushIfInvalid(failures, item.canRetry === true, `stale_work_item_retry_not_exposed:${item.id}`);
+    }
+    if (item.state === "completed_with_proof" || item.state === "timeline_read") {
+      if (item.canRetry || item.canCancel) {
+        failures.push(`non_actionable_work_item_exposes_recovery:${item.id}:${item.state}`);
+      }
+    }
     if (item.state === "provider_ack" && item.done === false) providerAckNotDone = true;
     if (item.state === "timeline_read" && item.done === false) timelineReadNotDone = true;
     if (NON_COMPLETION_STATES.has(item.state) && item.done === true) {

--- a/src/api/model/friday-api-mission-spine.types.ts
+++ b/src/api/model/friday-api-mission-spine.types.ts
@@ -23,6 +23,14 @@ export type FridayMissionSpineRuntimeFeedStatus =
   | "live_rust_hub_projection"
   | "pending_rust_hub_projection";
 
+export type FridayMissionSpineWorkItemRecoveryKind =
+  | "none"
+  | "dispatchable"
+  | "in_flight"
+  | "needs_operator"
+  | "retryable"
+  | "terminal";
+
 export interface FridayMissionSpineWorkbenchWorkItem {
   id: string;
   title: string;
@@ -30,6 +38,10 @@ export interface FridayMissionSpineWorkbenchWorkItem {
   owner: FridayMissionSpineTruthLabel;
   proofRef?: string;
   done: boolean;
+  blockingReason: string;
+  recoveryKind: FridayMissionSpineWorkItemRecoveryKind;
+  canRetry: boolean;
+  canCancel: boolean;
 }
 
 export interface FridayMissionSpineWorkbenchTimelinePage {

--- a/test/e2e/ui/friday-workflow-builder-performance.test.ts
+++ b/test/e2e/ui/friday-workflow-builder-performance.test.ts
@@ -96,7 +96,9 @@ describe.skipIf(!CHROMIUM_AVAILABLE)("Friday workflow builder interaction baseli
     await pageHandle.page.waitForLoadState("domcontentloaded");
     try {
       await pageHandle.page.waitForFunction(() =>
-        Boolean(document.querySelector('[data-testid="workflow-builder-node-library"]'))
+        window.performance.getEntriesByName("friday-workflow-builder-shell-ready").length > 0
+        || Boolean(document.querySelector('[data-testid="workflow-builder-shell"]'))
+        || Boolean(document.querySelector('[data-testid="workflow-builder-node-library"]'))
       );
     } catch (error) {
       const debugState = await pageHandle.page.evaluate(() => ({
@@ -115,7 +117,7 @@ describe.skipIf(!CHROMIUM_AVAILABLE)("Friday workflow builder interaction baseli
         ].join("\n"),
       );
     }
-    const firstSurfaceReadyMs = performance.now() - startedAt;
+    const shellReadyMs = performance.now() - startedAt;
 
     try {
       await pageHandle.page.waitForFunction(() =>
@@ -162,7 +164,7 @@ describe.skipIf(!CHROMIUM_AVAILABLE)("Friday workflow builder interaction baseli
 
     expect(benchmark.hasNodeLibrary).toBe(true);
     expect(benchmark.hasCanvas).toBe(true);
-    expect(firstSurfaceReadyMs).toBeLessThan(WORKFLOW_BUILDER_SHELL_BUDGET_MS);
+    expect(shellReadyMs).toBeLessThan(WORKFLOW_BUILDER_SHELL_BUDGET_MS);
     expect(canvasReadyMs).toBeLessThan(WORKFLOW_BUILDER_CANVAS_BUDGET_MS);
   });
 });

--- a/test/unit/api/routes/friday-mission-spine-routes.test.ts
+++ b/test/unit/api/routes/friday-mission-spine-routes.test.ts
@@ -54,6 +54,10 @@ const snapshot: FridayMissionSpineWorkbenchSnapshot = {
       owner: "friday_owned",
       proofRef: "proof://provider/ack/not-completion",
       done: false,
+      blockingReason: "provider or hub execution is still in flight; cancel is the only exposed recovery action",
+      recoveryKind: "in_flight",
+      canRetry: false,
+      canCancel: true,
     },
     {
       id: "work_timeline_projection_test",
@@ -62,6 +66,10 @@ const snapshot: FridayMissionSpineWorkbenchSnapshot = {
       owner: "friday_owned",
       proofRef: "proof://timeline/page-2/cursor",
       done: false,
+      blockingReason: "bounded timeline read only; no WorkItem recovery action applies",
+      recoveryKind: "none",
+      canRetry: false,
+      canCancel: false,
     },
     {
       id: "work_completed_projection_test",
@@ -70,6 +78,10 @@ const snapshot: FridayMissionSpineWorkbenchSnapshot = {
       owner: "friday_owned",
       proofRef: "proof://provider/receipt/redacted",
       done: true,
+      blockingReason: "terminal or archived WorkItem; no recovery action applies",
+      recoveryKind: "none",
+      canRetry: false,
+      canCancel: false,
     },
   ],
   timelinePages: [
@@ -423,6 +435,40 @@ describe("createFridayMissionSpineRoutes", () => {
     const error = thrown as FridayDomainError;
     expect(error.code).toBe("MISSION_SPINE_WORKBENCH_SNAPSHOT_INVALID");
     expect(JSON.stringify(error.details)).toContain("non_completion_state_marked_done");
+  });
+
+  it("fails closed when stale WorkItems omit the retry recovery affordance", async () => {
+    const invalidSnapshot = cloneSnapshot({
+      workItems: snapshot.workItems.map((item, index) => (
+        index === 0
+          ? {
+            ...item,
+            state: "stale",
+            recoveryKind: "in_flight",
+            canRetry: false,
+            canCancel: true,
+          }
+          : item
+      )),
+    });
+    const routes = createFridayMissionSpineRoutes({
+      workbench: { getSnapshot: vi.fn(async () => invalidSnapshot) },
+      disabledReason: null,
+    });
+    const route = findRoute(routes);
+
+    let thrown: unknown = null;
+    try {
+      await route.handler(makeCtx() as never);
+    } catch (err) {
+      thrown = err;
+    }
+
+    expect(thrown).toBeInstanceOf(FridayDomainError);
+    const error = thrown as FridayDomainError;
+    expect(error.code).toBe("MISSION_SPINE_WORKBENCH_SNAPSHOT_INVALID");
+    expect(JSON.stringify(error.details)).toContain("stale_work_item_not_retryable");
+    expect(JSON.stringify(error.details)).toContain("stale_work_item_retry_not_exposed");
   });
 
   it("fails closed when observed or approval-gated capability state can dispatch", async () => {

--- a/test/unit/qa/mission-workbench-snapshot-contract-cli.test.ts
+++ b/test/unit/qa/mission-workbench-snapshot-contract-cli.test.ts
@@ -45,6 +45,10 @@ function makeSnapshot(overrides: Record<string, unknown> = {}) {
         owner: "friday_owned",
         proofRef: "proof://provider/ack/not-completion",
         done: false,
+        blockingReason: "provider or hub execution is still in flight; cancel is the only exposed recovery action",
+        recoveryKind: "in_flight",
+        canRetry: false,
+        canCancel: true,
       },
       {
         id: "work_timeline",
@@ -53,6 +57,10 @@ function makeSnapshot(overrides: Record<string, unknown> = {}) {
         owner: "friday_owned",
         proofRef: "proof://timeline/page-2/cursor",
         done: false,
+        blockingReason: "bounded timeline read only; no WorkItem recovery action applies",
+        recoveryKind: "none",
+        canRetry: false,
+        canCancel: false,
       },
       {
         id: "work_completed",
@@ -61,6 +69,10 @@ function makeSnapshot(overrides: Record<string, unknown> = {}) {
         owner: "friday_owned",
         proofRef: "proof://provider/receipt/redacted",
         done: true,
+        blockingReason: "terminal or archived WorkItem; no recovery action applies",
+        recoveryKind: "none",
+        canRetry: false,
+        canCancel: false,
       },
     ],
     timelinePages: [

--- a/test/unit/ui/mission-workbench-api.test.ts
+++ b/test/unit/ui/mission-workbench-api.test.ts
@@ -78,4 +78,33 @@ describe("missionWorkbenchApi", () => {
       },
     );
   });
+
+  it("posts WorkItem recovery status transitions through the encoded WorkItem id", async () => {
+    const result = {
+      truthLabel: "rust_wired",
+      workItemId: "work/retry target",
+      status: "ready_to_dispatch",
+      actorRef: "operator:mission-workbench",
+      reason: "operator requested retry from Mission Workbench recovery surface",
+      updatedAtMs: 1_700_000_000_000,
+    };
+    vi.mocked(apiClient.post).mockResolvedValue({ result });
+
+    await expect(
+      missionWorkbenchApi.transitionWorkItemStatus("work/retry target", {
+        targetStatus: "ready_to_dispatch",
+        actorRef: "operator:mission-workbench",
+        reason: "operator requested retry from Mission Workbench recovery surface",
+      }),
+    ).resolves.toEqual(result);
+
+    expect(apiClient.post).toHaveBeenCalledWith(
+      "/v1/mission-spine/work-items/work%2Fretry%20target/status",
+      {
+        targetStatus: "ready_to_dispatch",
+        actorRef: "operator:mission-workbench",
+        reason: "operator requested retry from Mission Workbench recovery surface",
+      },
+    );
+  });
 });

--- a/ui/src/lib/api/mission-workbench.ts
+++ b/ui/src/lib/api/mission-workbench.ts
@@ -32,6 +32,27 @@ interface ControlMissionRouteDecisionResponse {
   result: MissionRouteDecisionControlResult;
 }
 
+export interface MissionWorkItemStatusRequest {
+  targetStatus: string;
+  actorRef: string;
+  reason: string;
+  proofReceipt?: string;
+}
+
+export interface MissionWorkItemStatusResult {
+  truthLabel: "rust_wired";
+  workItemId: string;
+  status: string;
+  actorRef: string;
+  reason: string;
+  proofReceipt?: string;
+  updatedAtMs: number;
+}
+
+interface TransitionMissionWorkItemStatusResponse {
+  result: MissionWorkItemStatusResult;
+}
+
 export const missionWorkbenchApi = {
   async getSnapshot(missionId?: string): Promise<MissionWorkbenchSnapshot> {
     const path = missionId
@@ -49,6 +70,18 @@ export const missionWorkbenchApi = {
     const data = await apiClient.post<
       MissionRouteDecisionControlRequest,
       ControlMissionRouteDecisionResponse
+    >(path, request);
+    return data.result;
+  },
+
+  async transitionWorkItemStatus(
+    workItemId: string,
+    request: MissionWorkItemStatusRequest,
+  ): Promise<MissionWorkItemStatusResult> {
+    const path = `/v1/mission-spine/work-items/${encodeURIComponent(workItemId)}/status`;
+    const data = await apiClient.post<
+      MissionWorkItemStatusRequest,
+      TransitionMissionWorkItemStatusResponse
     >(path, request);
     return data.result;
   },

--- a/ui/src/lib/mission-workbench/mission-workbench-contract.ts
+++ b/ui/src/lib/mission-workbench/mission-workbench-contract.ts
@@ -23,6 +23,14 @@ export type MissionWorkbenchRuntimeFeedStatus =
   | "live_rust_hub_projection"
   | "pending_rust_hub_projection";
 
+export type MissionWorkItemRecoveryKind =
+  | "none"
+  | "dispatchable"
+  | "in_flight"
+  | "needs_operator"
+  | "retryable"
+  | "terminal";
+
 export interface MissionWorkbenchWorkItem {
   id: string;
   title: string;
@@ -30,6 +38,10 @@ export interface MissionWorkbenchWorkItem {
   owner: MissionTruthLabel;
   proofRef?: string;
   done: boolean;
+  blockingReason: string;
+  recoveryKind: MissionWorkItemRecoveryKind;
+  canRetry: boolean;
+  canCancel: boolean;
 }
 
 export interface MissionWorkbenchTimelinePage {

--- a/ui/src/routes/mission-workbench-page.tsx
+++ b/ui/src/routes/mission-workbench-page.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from "react";
-import { GitBranch, Search, ShieldX } from "lucide-react";
+import { GitBranch, RotateCcw, Search, ShieldX, XCircle } from "lucide-react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useSearchParams } from "react-router-dom";
 import { ActionButton, ShellCard, StatusPill } from "@/components/core/primitives";
@@ -90,6 +90,24 @@ export function MissionWorkbenchPage() {
           : {}),
         actorRef: "operator:mission-workbench",
         reason: reason.length > 0 ? reason : "operator workbench route control",
+      });
+    },
+    onSuccess: () => {
+      void queryClient.invalidateQueries({
+        queryKey: ["mission-spine", "workbench", "snapshot", targetMissionId ?? "latest"],
+      });
+    },
+  });
+
+  const workItemRecoveryMutation = useMutation({
+    mutationFn: (input: { workItemId: string; action: "retry" | "cancel" }) => {
+      const targetStatus = input.action === "retry" ? "ready_to_dispatch" : "cancelled";
+      return missionWorkbenchApi.transitionWorkItemStatus(input.workItemId, {
+        targetStatus,
+        actorRef: "operator:mission-workbench",
+        reason: input.action === "retry"
+          ? "operator requested retry from Mission Workbench recovery surface"
+          : "operator cancelled WorkItem from Mission Workbench recovery surface",
       });
     },
     onSuccess: () => {
@@ -196,11 +214,43 @@ export function MissionWorkbenchPage() {
                     <StatusPill tone={item.done ? "success" : "warning"}>
                       {item.done ? "done with proof" : "not completion"}
                     </StatusPill>
+                    <StatusPill tone={item.canRetry ? "warning" : item.canCancel ? "neutral" : "success"}>
+                      {item.recoveryKind.replaceAll("_", " ")}
+                    </StatusPill>
                   </div>
+                  <p className="mt-3 text-xs leading-5 text-[color:var(--color-text-secondary)]">
+                    {item.blockingReason}
+                  </p>
                   {item.proofRef ? (
                     <p className="mt-3 break-all rounded-lg bg-[color:var(--color-bg-base)] p-2 text-xs text-[color:var(--color-text-secondary)]">
                       {item.proofRef}
                     </p>
+                  ) : null}
+                  {item.canRetry || item.canCancel ? (
+                    <div className="mt-3 flex flex-wrap gap-2">
+                      {item.canRetry ? (
+                        <ActionButton
+                          tone="secondary"
+                          className="gap-2 rounded-lg"
+                          disabled={workItemRecoveryMutation.isPending}
+                          onClick={() => workItemRecoveryMutation.mutate({ workItemId: item.id, action: "retry" })}
+                        >
+                          <RotateCcw className="h-4 w-4" aria-hidden="true" />
+                          Retry
+                        </ActionButton>
+                      ) : null}
+                      {item.canCancel ? (
+                        <ActionButton
+                          tone="danger"
+                          className="gap-2 rounded-lg"
+                          disabled={workItemRecoveryMutation.isPending}
+                          onClick={() => workItemRecoveryMutation.mutate({ workItemId: item.id, action: "cancel" })}
+                        >
+                          <XCircle className="h-4 w-4" aria-hidden="true" />
+                          Cancel
+                        </ActionButton>
+                      ) : null}
+                    </div>
                   ) : null}
                 </div>
               ))}


### PR DESCRIPTION
## Summary
- project refs-only WorkItem recovery metadata from Rust Hub: blockingReason, recoveryKind, canRetry, canCancel
- enforce recovery metadata in the Mission Workbench API snapshot contract
- surface retry/cancel controls in the desktop Workbench and recovery hints in iOS Home

## Verification
- cargo fmt --manifest-path rust-core/Cargo.toml --all --check
- cargo test --manifest-path rust-core/Cargo.toml -p friday-hub workbench_projection -- --nocapture
- npm test -- --run test/unit/api/routes/friday-mission-spine-routes.test.ts test/unit/qa/mission-workbench-snapshot-contract-cli.test.ts test/unit/ui/mission-workbench-api.test.ts
- npm run typecheck:src
- swift test --package-path apps/friday-ios --filter HomeViewModelTests
- swift build --package-path apps/friday-ios
- git diff --check

## Truth Labels
- T4 WorkItem recovery surface: product-visible mechanism, not organic completion
- organic=0 remains true
- no prod DB writes, no prod service restart, no synthetic organic rows