### PR TITLE
[codex] Surface device pairing readiness in clients

### DIFF
--- a/apps/friday-ios/Sources/FridayMobileShell/FridayApp.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayApp.swift
@@ -41,6 +41,7 @@ final class FridaySession: ObservableObject {
   let readClient: FridayRustReadClient
   let writeClient: FridayRustWriteClient
   let missionClient: FridayMobileMissionDispatchingWriteClient?
+  let devicePairing: DevicePairingReadiness
   /// The operator-signing RELAY. Mock today (NOT a real signature); the real desktop signer
   /// (PR #671) is the slice-6 / operator-key gate. The phone holds NO signing key (INV-1).
   let signer: OperatorSigner
@@ -61,6 +62,9 @@ final class FridaySession: ObservableObject {
     // mirroring the desktop `FRIDAY_CONSOLE_LIVE`). The DEFAULT (gate OFF) stays the honest-
     // unavailable client — this PR does NOT flip the shipped default (that is the slice-6 gate).
     self.readClient = preview ? PreviewReadClient() : Self.defaultReadClient()
+    self.devicePairing = preview
+      ? .evaluate(deviceKeypairRequested: false, readLiveRequested: false, writeLiveRequested: false)
+      : Self.defaultDevicePairingReadiness()
 
     // The write client (Friday Chat read-WRITE / S6 surface). DEFAULT (gate OFF) = the throwing
     // `liveTransportNotWired` factory transport ⇒ honest-unavailable, with an ephemeral X25519
@@ -95,7 +99,7 @@ final class FridaySession: ObservableObject {
   static func defaultReadClient() -> FridayRustReadClient {
     let args = ProcessInfo.processInfo.arguments
     let env = ProcessInfo.processInfo.environment
-    let useLive = args.contains("--live-read") || env["FRIDAY_MOBILE_LIVE_READ"] == "1"
+    let useLive = liveReadRequested(args: args, env: env)
     guard useLive else {
       // SHIPPED DEFAULT — unchanged: no key, no socket, no SecureStore touch.
       return HonestlyUnavailableReadClient()
@@ -132,7 +136,7 @@ final class FridaySession: ObservableObject {
   ) -> FridayMobileMissionDispatchingWriteClient? {
     let args = ProcessInfo.processInfo.arguments
     let env = ProcessInfo.processInfo.environment
-    let useLive = args.contains("--live-write") || env["FRIDAY_MOBILE_LIVE_WRITE"] == "1"
+    let useLive = liveWriteRequested(args: args, env: env)
     guard useLive else {
       return nil
     }
@@ -153,6 +157,23 @@ final class FridaySession: ObservableObject {
 
   static func useDeviceKeypair(args: [String], env: [String: String]) -> Bool {
     args.contains("--live-device-keypair") || env["FRIDAY_MOBILE_LIVE_DEVICE_KEYPAIR"] == "1"
+  }
+
+  static func liveReadRequested(args: [String], env: [String: String]) -> Bool {
+    args.contains("--live-read") || env["FRIDAY_MOBILE_LIVE_READ"] == "1"
+  }
+
+  static func liveWriteRequested(args: [String], env: [String: String]) -> Bool {
+    args.contains("--live-write") || env["FRIDAY_MOBILE_LIVE_WRITE"] == "1"
+  }
+
+  static func defaultDevicePairingReadiness() -> DevicePairingReadiness {
+    let args = ProcessInfo.processInfo.arguments
+    let env = ProcessInfo.processInfo.environment
+    return DevicePairingReadiness.evaluate(
+      deviceKeypairRequested: useDeviceKeypair(args: args, env: env),
+      readLiveRequested: liveReadRequested(args: args, env: env),
+      writeLiveRequested: liveWriteRequested(args: args, env: env))
   }
 
   /// The honest-unavailable WRITE client: the shared `FridayClientFactory.makeWriteClient` with its
@@ -185,7 +206,8 @@ struct RootView: View {
     self.session = session
     _homeVM = StateObject(wrappedValue: HomeViewModel(
       client: session.readClient,
-      writeClient: session.missionClient))
+      writeClient: session.missionClient,
+      devicePairing: session.devicePairing))
   }
 
   var body: some View {

--- a/apps/friday-ios/Sources/FridayMobileShell/FridayHomeScreen.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayHomeScreen.swift
@@ -60,6 +60,7 @@ struct FridayHomeScreen: View {
     }
 
     statusCard(projection)
+    devicePairingCard(viewModel.devicePairing)
     if projection.isLoadedEmpty {
       loadedEmptyCard(projection)
     }
@@ -95,6 +96,45 @@ struct FridayHomeScreen: View {
     .accessibilityElement(children: .combine)
     .accessibilityLabel(viewModel.isOnline ? "Friday status online" : "Friday status offline or stale")
     .accessibilityIdentifier("friday.home.status-card")
+  }
+
+  private func devicePairingCard(_ readiness: DevicePairingReadiness) -> some View {
+    GlassPanel {
+      VStack(alignment: .leading, spacing: MobileTheme.rowSpacing) {
+        HStack {
+          Text("Device pairing").font(.headline).foregroundStyle(MobileTheme.textPrimary)
+          Spacer()
+          StatusChip(
+            text: readiness.mode.rawValue,
+            bg: readiness.mode == .ready ? MobileTheme.chipPendingBG : MobileTheme.chipNeutralBG,
+            fg: readiness.mode == .ready ? MobileTheme.chipPendingFG : MobileTheme.chipNeutralFG)
+        }
+        Text(readiness.reason)
+          .font(.caption)
+          .foregroundStyle(MobileTheme.textSecondary)
+          .fixedSize(horizontal: false, vertical: true)
+        if let publicKeyHex = readiness.publicKeyHex {
+          RefPill(label: "device_pubkey", ref: publicKeyHex)
+        }
+        HStack(spacing: 8) {
+          StatusChip(
+            text: readiness.readLiveRequested ? "read requested" : "read off",
+            bg: readiness.readLiveRequested ? MobileTheme.chipPendingBG : MobileTheme.chipNeutralBG,
+            fg: readiness.readLiveRequested ? MobileTheme.chipPendingFG : MobileTheme.chipNeutralFG)
+          StatusChip(
+            text: readiness.writeLiveRequested ? "write requested" : "write off",
+            bg: readiness.writeLiveRequested ? MobileTheme.chipWarnBG : MobileTheme.chipNeutralBG,
+            fg: readiness.writeLiveRequested ? MobileTheme.chipWarnFG : MobileTheme.chipNeutralFG)
+        }
+        Text(readiness.nextStep)
+          .font(.caption2)
+          .foregroundStyle(MobileTheme.textSecondary)
+          .fixedSize(horizontal: false, vertical: true)
+      }
+    }
+    .accessibilityElement(children: .combine)
+    .accessibilityLabel("Device pairing \(readiness.mode.rawValue). \(readiness.reason)")
+    .accessibilityIdentifier("friday.home.device-pairing-card")
   }
 
   private func loadedEmptyCard(_ projection: HomeProjection) -> some View {

--- a/apps/friday-ios/Sources/FridayMobileShellCore/DeviceKeypairStore.swift
+++ b/apps/friday-ios/Sources/FridayMobileShellCore/DeviceKeypairStore.swift
@@ -57,6 +57,62 @@ public struct DeviceKeypair {
   }
 }
 
+public enum DevicePairingReadinessMode: String, Sendable, Equatable {
+  case disabled
+  case ready
+  case unavailable
+}
+
+/// Refs-only device-pairing readiness surfaced to the mobile UI.
+///
+/// This is deliberately local/client-side: it reports whether this app launch has opted into the
+/// device-keypair path and, if so, the PUBLIC X25519 key the operator can enroll. It never claims a
+/// Hub row exists, never writes trust state, and never exposes the private scalar.
+public struct DevicePairingReadiness: Sendable, Equatable {
+  public let mode: DevicePairingReadinessMode
+  public let publicKeyHex: String?
+  public let readLiveRequested: Bool
+  public let writeLiveRequested: Bool
+  public let reason: String
+  public let nextStep: String
+
+  public static func evaluate(
+    deviceKeypairRequested: Bool,
+    readLiveRequested: Bool,
+    writeLiveRequested: Bool,
+    backend: DeviceKeypairBackend = KeychainDeviceKeypairBackend()
+  ) -> DevicePairingReadiness {
+    guard deviceKeypairRequested else {
+      return DevicePairingReadiness(
+        mode: .disabled,
+        publicKeyHex: nil,
+        readLiveRequested: readLiveRequested,
+        writeLiveRequested: writeLiveRequested,
+        reason: "Device keypair mode is not enabled for this launch.",
+        nextStep: "Relaunch with --live-device-keypair when pairing this phone.")
+    }
+
+    do {
+      let device = try DeviceKeypairStore.loadOrGenerate(backend: backend)
+      return DevicePairingReadiness(
+        mode: .ready,
+        publicKeyHex: device.publicKeyHex,
+        readLiveRequested: readLiveRequested,
+        writeLiveRequested: writeLiveRequested,
+        reason: "Device public key is ready for operator enrollment.",
+        nextStep: "Enroll this public key on the Hub; trust rows still require the pairing ceremony.")
+    } catch {
+      return DevicePairingReadiness(
+        mode: .unavailable,
+        publicKeyHex: nil,
+        readLiveRequested: readLiveRequested,
+        writeLiveRequested: writeLiveRequested,
+        reason: "Device keypair store is unavailable.",
+        nextStep: "Repair the device keypair store before pairing.")
+    }
+  }
+}
+
 /// Typed failures for the device-keypair store. The error vocabulary names a failure CATEGORY,
 /// never a secret value.
 public enum DeviceKeypairStoreError: Error, Equatable, CustomStringConvertible {

--- a/apps/friday-ios/Sources/FridayMobileShellCore/HomeViewModel.swift
+++ b/apps/friday-ios/Sources/FridayMobileShellCore/HomeViewModel.swift
@@ -371,6 +371,8 @@ public final class HomeViewModel: ObservableObject {
   @Published public private(set) var detailState: HomeReadDetailState = .idle
   @Published public private(set) var runOutcomeLearningDecisionStates: [String: HomeLearningDecisionState] = [:]
 
+  public let devicePairing: DevicePairingReadiness
+
   /// The package's read protocol is `Sendable`; the view model still publishes only small
   /// refs-only value projections, never the package snapshot's raw body map.
   private let client: FridayRustReadClient
@@ -378,9 +380,17 @@ public final class HomeViewModel: ObservableObject {
 
   /// - Parameter client: the read client. In production this is the real `SealedWSReadClient`
   ///   (built by `FridayClientFactory.makeReadClient`); a preview/debug build injects a mock.
-  public init(client: FridayRustReadClient, writeClient: FridayMissionSpineWriteClient? = nil) {
+  public init(
+    client: FridayRustReadClient,
+    writeClient: FridayMissionSpineWriteClient? = nil,
+    devicePairing: DevicePairingReadiness = .evaluate(
+      deviceKeypairRequested: false,
+      readLiveRequested: false,
+      writeLiveRequested: false)
+  ) {
     self.client = client
     self.writeClient = writeClient
+    self.devicePairing = devicePairing
   }
 
   /// Whether the Home is online — derived from the load state (ONLY a real loaded projection is

--- a/apps/friday-ios/Tests/FridayMobileShellCoreTests/DeviceKeypairStoreTests.swift
+++ b/apps/friday-ios/Tests/FridayMobileShellCoreTests/DeviceKeypairStoreTests.swift
@@ -22,13 +22,17 @@ import Testing
 /// Sendable` to satisfy the protocol's `Sendable` requirement.
 private final class InMemoryDeviceKeypairBackend: DeviceKeypairBackend, @unchecked Sendable {
   private var secret: [UInt8]?
+  private(set) var loadCount = 0
   /// Count of `storeSecret` calls — lets a test assert generation happened exactly once.
   private(set) var storeCount = 0
 
   /// Optionally seed a pre-existing stored secret (e.g. a wrong-length corrupt item).
   init(seed: [UInt8]? = nil) { self.secret = seed }
 
-  func loadSecret() throws -> [UInt8]? { secret }
+  func loadSecret() throws -> [UInt8]? {
+    loadCount += 1
+    return secret
+  }
   func storeSecret(_ secret: [UInt8]) throws {
     self.secret = secret
     storeCount += 1
@@ -132,4 +136,62 @@ func makeLiveWriteWithDeviceKeypairBuildsClientAndIsHonestlyUnavailableWithNoSer
     // write wrapper seals an envelope, surfacing the shared transport error directly. Still
     // fail-closed and never a fabricated run.
   }
+}
+
+@Test
+func devicePairingReadinessDefaultOffDoesNotTouchBackend() {
+  let backend = InMemoryDeviceKeypairBackend()
+
+  let readiness = DevicePairingReadiness.evaluate(
+    deviceKeypairRequested: false,
+    readLiveRequested: false,
+    writeLiveRequested: false,
+    backend: backend)
+
+  #expect(readiness.mode == .disabled)
+  #expect(readiness.publicKeyHex == nil)
+  #expect(readiness.readLiveRequested == false)
+  #expect(readiness.writeLiveRequested == false)
+  #expect(backend.loadCount == 0)
+  #expect(backend.storeCount == 0)
+}
+
+@Test
+func devicePairingReadinessSurfacesOnlyPublicKeyWhenRequested() throws {
+  let backend = InMemoryDeviceKeypairBackend()
+
+  let readiness = DevicePairingReadiness.evaluate(
+    deviceKeypairRequested: true,
+    readLiveRequested: true,
+    writeLiveRequested: true,
+    backend: backend)
+
+  #expect(readiness.mode == .ready)
+  #expect(readiness.publicKeyHex?.count == 64)
+  #expect(readiness.publicKeyHex?.allSatisfy { $0.isHexDigit && ($0.isNumber || $0.isLowercase) } == true)
+  #expect(readiness.readLiveRequested)
+  #expect(readiness.writeLiveRequested)
+  #expect(backend.loadCount == 1)
+  #expect(backend.storeCount == 1)
+  #expect(!readiness.reason.lowercased().contains("secret"))
+  #expect(!readiness.nextStep.lowercased().contains("secret"))
+}
+
+@Test
+func devicePairingReadinessFailsClosedOnCorruptStoredSecret() {
+  let backend = InMemoryDeviceKeypairBackend(seed: [UInt8](repeating: 0x42, count: 16))
+
+  let readiness = DevicePairingReadiness.evaluate(
+    deviceKeypairRequested: true,
+    readLiveRequested: true,
+    writeLiveRequested: false,
+    backend: backend)
+
+  #expect(readiness.mode == .unavailable)
+  #expect(readiness.publicKeyHex == nil)
+  #expect(readiness.readLiveRequested)
+  #expect(readiness.writeLiveRequested == false)
+  #expect(backend.storeCount == 0)
+  #expect(!readiness.reason.lowercased().contains("secret"))
+  #expect(!readiness.nextStep.lowercased().contains("secret"))
 }

--- a/apps/friday-ios/Tests/FridayMobileShellCoreTests/HomeViewModelTests.swift
+++ b/apps/friday-ios/Tests/FridayMobileShellCoreTests/HomeViewModelTests.swift
@@ -199,6 +199,26 @@ final class HomeViewModelTests: XCTestCase {
     XCTAssertTrue(vm.state.isOnline)
   }
 
+  func testHomeViewModelCarriesInjectedDevicePairingReadiness() async throws {
+    let readiness = DevicePairingReadiness(
+      mode: .ready,
+      publicKeyHex: String(repeating: "a", count: 64),
+      readLiveRequested: true,
+      writeLiveRequested: false,
+      reason: "Device public key is ready for operator enrollment.",
+      nextStep: "Enroll this public key on the Hub.")
+    let vm = HomeViewModel(
+      client: FakeReadClient(.snapshot(try sampleSnapshot())),
+      devicePairing: readiness)
+
+    await vm.refresh()
+
+    XCTAssertEqual(vm.devicePairing, readiness)
+    XCTAssertEqual(vm.devicePairing.publicKeyHex, String(repeating: "a", count: 64))
+    XCTAssertTrue(vm.devicePairing.readLiveRequested)
+    XCTAssertFalse(vm.devicePairing.writeLiveRequested)
+  }
+
   func testRefresh_liftsConsumerSurfaceProjectionRefs() async throws {
     let vm = HomeViewModel(client: FakeReadClient(.snapshot(try sampleSnapshot())))
     await vm.refresh()

--- a/apps/macos/FridayHubConsole/Sources/FridayHubConsole/OperationsOverviewScreen.swift
+++ b/apps/macos/FridayHubConsole/Sources/FridayHubConsole/OperationsOverviewScreen.swift
@@ -89,6 +89,7 @@ struct OperationsOverviewScreen: View {
         StatusBanner(snapshot: snapshot)
       }
 
+      devicePairingCard(viewModel.devicePairing)
       missionCard(snapshot)
       if snapshot.isLoadedEmpty {
         loadedEmptyCard(snapshot)
@@ -127,6 +128,37 @@ struct OperationsOverviewScreen: View {
     .accessibilityElement(children: .contain)
     .accessibilityLabel("Mission \(snapshot.missionId)")
     .accessibilityIdentifier("friday.desktop.mission-card")
+  }
+
+  private func devicePairingCard(_ readiness: DesktopDevicePairingReadiness) -> some View {
+    GlassPanel {
+      VStack(alignment: .leading, spacing: HubTheme.rowSpacing) {
+        HStack {
+          cardTitle("Device Pairing Readiness")
+          Spacer()
+          StatusChip(
+            text: readiness.mode.rawValue,
+            bg: readiness.mode == .ready ? HubTheme.chipPendingBG : HubTheme.chipWarnBG,
+            fg: readiness.mode == .ready ? HubTheme.chipPendingFG : HubTheme.chipWarnFG)
+        }
+        Text(readiness.reason)
+          .font(.system(size: 12))
+          .foregroundStyle(HubTheme.textSecondary)
+        if let publicKeyHex = readiness.publicKeyHex {
+          RefPill(label: "desktop_peer_pubkey", ref: publicKeyHex)
+        }
+        HStack(spacing: 8) {
+          RefPill(label: "owner", ref: readiness.ownerPrincipal)
+          RefPill(label: "read_seam", ref: "\(readiness.readHost):\(readiness.readPort)")
+        }
+        Text(readiness.nextStep)
+          .font(.system(size: 10))
+          .foregroundStyle(HubTheme.textSecondary)
+      }
+    }
+    .accessibilityElement(children: .combine)
+    .accessibilityLabel("Device pairing readiness \(readiness.mode.rawValue). \(readiness.reason)")
+    .accessibilityIdentifier("friday.desktop.device-pairing-readiness")
   }
 
   private func loadedEmptyCard(_ snapshot: WorkbenchSnapshot) -> some View {

--- a/apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/MasterKeyPeerKeypair.swift
+++ b/apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/MasterKeyPeerKeypair.swift
@@ -147,3 +147,52 @@ public enum MasterKeyPeer {
     }
   }
 }
+
+public enum DesktopDevicePairingReadinessMode: String, Sendable, Equatable {
+  case ready
+  case unavailable
+}
+
+/// Read-only desktop pairing/read-seam readiness for Operations Overview.
+///
+/// This reports the PUBLIC master-derived peer key the Hub Console will use against the read seam.
+/// It never enrolls a device, never writes trust state, and never exposes the host master key.
+public struct DesktopDevicePairingReadiness: Sendable, Equatable {
+  public let mode: DesktopDevicePairingReadinessMode
+  public let publicKeyHex: String?
+  public let readHost: String
+  public let readPort: UInt16
+  public let ownerPrincipal: String
+  public let reason: String
+  public let nextStep: String
+
+  public static func evaluate(
+    config: ReadProjectionServerConfig = .liveLoopback,
+    ownerPrincipal: String = liveReadProjectionOwnerPrincipal,
+    environment: [String: String] = ProcessInfo.processInfo.environment,
+    homeDirectory: URL = FileManager.default.homeDirectoryForCurrentUser
+  ) -> DesktopDevicePairingReadiness {
+    do {
+      let keypair = try MasterKeyPeer.deriveKeypair(
+        environment: environment,
+        homeDirectory: homeDirectory)
+      return DesktopDevicePairingReadiness(
+        mode: .ready,
+        publicKeyHex: Hex.encode(keypair.publicKey),
+        readHost: config.host,
+        readPort: config.port,
+        ownerPrincipal: ownerPrincipal,
+        reason: "Desktop read-seam peer is derived and ready.",
+        nextStep: "Pair mobile devices separately; this desktop status does not enroll a phone.")
+    } catch {
+      return DesktopDevicePairingReadiness(
+        mode: .unavailable,
+        publicKeyHex: nil,
+        readHost: config.host,
+        readPort: config.port,
+        ownerPrincipal: ownerPrincipal,
+        reason: "Desktop master-derived peer is unavailable.",
+        nextStep: "Provision the host master key before proving desktop read-seam readiness.")
+    }
+  }
+}

--- a/apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/OperationsOverviewViewModel.swift
+++ b/apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/OperationsOverviewViewModel.swift
@@ -165,6 +165,8 @@ public final class OperationsOverviewViewModel: ObservableObject {
   /// Per-candidate A1 run-outcome learning decision state, keyed by candidate id.
   @Published public private(set) var runOutcomeLearningDecisionStates: [String: WriteActionState] = [:]
 
+  public let devicePairing: DesktopDevicePairingReadiness
+
   private let client: FridayRustReadClient
   /// The spine-WRITE collaborator. `nil` ⇒ the write seam is not configured (the drivers render
   /// honest-unavailable). Separate from `client` so the read contract stays a pure read.
@@ -185,6 +187,7 @@ public final class OperationsOverviewViewModel: ObservableObject {
     writeClient: FridayMissionSpineWriteClient? = nil,
     missionRunClient: FridayMissionBoundRunWriteClient? = nil,
     writeOwnerPrincipal: String = liveReadProjectionOwnerPrincipal,
+    devicePairing: DesktopDevicePairingReadiness = .evaluate(),
     newId: @escaping @Sendable () -> String = { UUID().uuidString },
     missionIdPrefix: String = "mission-desktop-"
   ) {
@@ -192,6 +195,7 @@ public final class OperationsOverviewViewModel: ObservableObject {
     self.writeClient = writeClient
     self.missionRunClient = missionRunClient
     self.writeOwnerPrincipal = writeOwnerPrincipal
+    self.devicePairing = devicePairing
     self.newId = newId
     self.missionIdPrefix = missionIdPrefix
   }

--- a/apps/macos/FridayHubConsole/Tests/FridayHubConsoleCoreTests/OperationsOverviewViewModelTests.swift
+++ b/apps/macos/FridayHubConsole/Tests/FridayHubConsoleCoreTests/OperationsOverviewViewModelTests.swift
@@ -7,12 +7,23 @@ import Testing
 @Test
 @MainActor
 func refreshLoadsRepresentativeSnapshot() async {
-  let vm = OperationsOverviewViewModel(client: MockReadClient(behavior: .loaded))
+  let readiness = DesktopDevicePairingReadiness(
+    mode: .ready,
+    publicKeyHex: String(repeating: "b", count: 64),
+    readHost: "127.0.0.1",
+    readPort: 48751,
+    ownerPrincipal: "admin-001",
+    reason: "Desktop read-seam peer is derived and ready.",
+    nextStep: "Pair mobile devices separately.")
+  let vm = OperationsOverviewViewModel(
+    client: MockReadClient(behavior: .loaded),
+    devicePairing: readiness)
   await vm.refresh()
   let snapshot = vm.state.snapshot
   #expect(snapshot != nil)
   #expect(snapshot?.missionId == "mission_workbench_probe_20260605")
   #expect(snapshot?.runtimeFeedStatus == .liveRustHubProjection)
+  #expect(vm.devicePairing == readiness)
 }
 
 @Test
@@ -73,6 +84,42 @@ func snapshotExercisesEveryHonestRenderingRule() {
 }
 
 @Test
+func desktopDevicePairingReadinessSurfacesOnlyMasterDerivedPublicKey() throws {
+  let home = try temporaryHome()
+  let master = String(repeating: "11", count: 32)
+
+  let readiness = DesktopDevicePairingReadiness.evaluate(
+    config: ReadProjectionServerConfig(host: "127.0.0.1", port: 48751),
+    ownerPrincipal: "admin-001",
+    environment: [MasterKeyPeer.masterKeyEnv: master],
+    homeDirectory: home)
+
+  #expect(readiness.mode == .ready)
+  #expect(readiness.publicKeyHex?.count == 64)
+  #expect(readiness.publicKeyHex?.allSatisfy { $0.isHexDigit && ($0.isNumber || $0.isLowercase) } == true)
+  #expect(readiness.readHost == "127.0.0.1")
+  #expect(readiness.readPort == 48751)
+  #expect(readiness.ownerPrincipal == "admin-001")
+  #expect(!readiness.reason.lowercased().contains("secret"))
+  #expect(!readiness.nextStep.lowercased().contains("secret"))
+}
+
+@Test
+func desktopDevicePairingReadinessFailsClosedWhenMasterKeyMissing() throws {
+  let home = try temporaryHome()
+
+  let readiness = DesktopDevicePairingReadiness.evaluate(
+    environment: [:],
+    homeDirectory: home)
+
+  #expect(readiness.mode == .unavailable)
+  #expect(readiness.publicKeyHex == nil)
+  #expect(readiness.readPort == 48751)
+  #expect(!readiness.reason.lowercased().contains("secret"))
+  #expect(!readiness.nextStep.lowercased().contains("secret"))
+}
+
+@Test
 func loadedEmptySnapshotIsConnectedEmptyNotUnavailable() {
   let snapshot = snapshotWithWorkItems(
     missionId: "mission-empty",
@@ -87,6 +134,13 @@ func loadedEmptySnapshotIsConnectedEmptyNotUnavailable() {
 func representativeSnapshotIsNotLoadedEmpty() {
   let snapshot = MockReadClient.representativeSnapshot
   #expect(!snapshot.isLoadedEmpty)
+}
+
+private func temporaryHome() throws -> URL {
+  let url = FileManager.default.temporaryDirectory
+    .appendingPathComponent("friday-console-tests-\(UUID().uuidString)")
+  try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+  return url
 }
 
 @Test


### PR DESCRIPTION
## Summary
- surface iOS device-keypair readiness on the real launch Home, including only the public X25519 ref when `--live-device-keypair` / `FRIDAY_MOBILE_LIVE_DEVICE_KEYPAIR=1` is explicitly enabled
- keep iOS default OFF/no-key/no-socket/no-Keychain touch; corrupt device keypair state renders unavailable without leaking internal key material
- surface macOS Operations Overview desktop read-seam peer readiness from the master-derived public key, owner, and loopback read endpoint without registering or approving devices

## Truth labels
- organic=0; this is T3 product-visible readiness, not a completed mobile/desktop organic loop
- no prod DB writes, no trusted_device/trust_grant/context_passport mutation, no prod service restart, no synthetic rows
- pairing/trust enrollment and any operator signature remain operator-only
- replaces closed stacked #1042 after its temporary base branch was deleted by #1041 merge

## Verification
- swift test --package-path apps/friday-ios --filter DeviceKeypairStoreTests
- swift test --package-path apps/friday-ios --filter HomeViewModelTests
- swift build --package-path apps/friday-ios
- swift test --package-path apps/macos/FridayHubConsole --filter OperationsOverviewViewModelTests
- swift build --package-path apps/macos/FridayHubConsole
- git diff --check