### PR TITLE
[codex] Add Claude-to-DeepSeek failover guard

### DIFF
--- a/docs/ops/prod-flags-manifest.json
+++ b/docs/ops/prod-flags-manifest.json
@@ -210,6 +210,15 @@
       "notes": "Built-but-dark (registry gap #26). RGG is DeepSeek-only, so both provider legs are MOCKED: the named test drives the ProviderFailoverWrapper THROUGH the real friday_hub::run_loop against a real Hub Db — a DeepSeek 402 fails over to a finishing Claude mock, the loop Finishes 'PONG', and EXACTLY ONE token_ledger row is written attributed to anthropic/api.anthropic.com (no double-bill). Sibling e2e proofs in the same file: 429 + 5xx failover, and 400-malformed → loop errors closed with NO failover + NO bill. The wrapper/classifier per-case behavior (incl. the inner-parse-error double-bill guard, auth/no-model no-failover) is pinned in src/provider_failover.rs tests; the WIRING decision (flag-off byte-identical: wrapper not constructed; flag-on-but-Claude-absent: hard boot error; the exact-'1' flag matcher) is pinned in src/runtime.rs tests (failover_flag_off_does_not_construct_wrapper_byte_identical, failover_flag_on_without_claude_is_hard_boot_error, provider_failover_flag_matcher_is_exact_one_default_off). Rust Core CI now names this stress leg explicitly with `cargo test -p friday-hub --test provider_failover -- --nocapture` plus the in-crate provider_failover tests, so this residue is mechanism-verified on every Rust Core gate without model spend. Honest ceiling unchanged: this is mocked-provider loop proof, not a live Claude failover row, not strict OG9 organic, and not a GO-LIVE claim."
     },
     {
+      "flag": "FRIDAY_PROVIDER_FAILOVER_CLAUDE_TO_DEEPSEEK",
+      "process": "rust-ws-wrapper",
+      "prod_state": "dark",
+      "closes_loop": "On a FAILOVER-WORTHY primary (claude) route failure (5xx/408/529/transport, 402 quota, 429 rate-limit), the live agent loop retries the SAME call ONCE on the fallback (deepseek) and FINISHES on the fallback's answer, billed truthfully to deepseek; auth/missing-credential/bad-response/malformed primary errors NEVER fail over.",
+      "coverage": "loop-e2e",
+      "e2e_test": "rust-core/crates/friday-hub/tests/provider_failover.rs::claude_provider_unavailable_fails_over_to_deepseek_finishes_and_bills_deepseek",
+      "notes": "Built-but-dark. The mapped test drives ClaudeToDeepSeekFailoverWrapper THROUGH the real friday_hub::run_loop against a real Hub Db: a structured ClaudeRoute ProviderUnavailable fails over to a finishing DeepSeek mock, the loop Finishes 'PONG', and EXACTLY ONE token_ledger row is written attributed to deepseek/api.deepseek.com. The classifier and wrapper guards are pinned in src/provider_failover.rs tests (Claude ProviderUnavailable/402/429 fail over; auth/missing credential/bad response/ordinary 4xx/parse do not; no string matching). Runtime wiring stays default-OFF behind exact-'1' FRIDAY_PROVIDER_FAILOVER_CLAUDE_TO_DEEPSEEK; flag-OFF leaves the bare Claude route client in place, and flag-ON without a Claude primary is a hard boot error. Honest ceiling unchanged: this is mocked-provider loop proof, not a live DeepSeek fallback row, not strict OG9 organic, and not a GO-LIVE claim."
+    },
+    {
       "flag": "FRIDAY_STUDIO_RUST_ENABLED",
       "process": "rust-ws-wrapper",
       "prod_state": "dark",

--- a/rust-core/crates/friday-hub/src/lib.rs
+++ b/rust-core/crates/friday-hub/src/lib.rs
@@ -547,6 +547,12 @@ pub enum AgentError {
     /// or response body — see `map_ureq_err`), so this leaks no more than the prior
     /// `format!("{e:?}")` did.
     Route(friday_deepseek::DeepSeekError),
+    /// The Claude/Anthropic provider route failed with a structured, coarse
+    /// [`friday_anthropic::ClaudeError`]. Kept separate from [`AgentError::Route`] because
+    /// DeepSeek and Claude have different error enums/classifiers; preserving this shape lets
+    /// a gated Claude→DeepSeek failover classify transient/quota failures without string
+    /// matching. Display remains secret-free by delegating to `ClaudeError`.
+    ClaudeRoute(friday_anthropic::ClaudeError),
     /// A model/transport failure that is only available as a string (no structured
     /// `DeepSeekError` to carry — e.g. "no model available" from discovery selection).
     /// Never retried (it is not a transient route failure with a disposition).
@@ -562,6 +568,7 @@ impl std::fmt::Display for AgentError {
             // Coarse, secret-free: delegates to DeepSeekError's own thiserror `Display`
             // (status code / kind only — no API key, no response body).
             AgentError::Route(e) => write!(f, "model_error: {e}"),
+            AgentError::ClaudeRoute(e) => write!(f, "model_error: {e}"),
             AgentError::Model(m) => write!(f, "model_error: {m}"),
             AgentError::Parse(m) => write!(f, "parse_error: {m}"),
         }
@@ -896,12 +903,10 @@ impl<T: friday_deepseek::Transport> AgentLlmClient for DeepSeekAgentLlmClient<T>
 /// [`AgentError`], never a silent substitute. The model id is supplied by the caller
 /// (from the route), so there is no model-discovery step.
 ///
-/// **Error mapping (retry-classification DEFERRED).** [`AgentError::Route`] carries a
-/// concrete `friday_deepseek::DeepSeekError`, so a [`friday_anthropic::ClaudeError`]
-/// cannot go there. The lowest-blast-radius mapping for this dark, never-selected path
-/// is the existing string-bearing [`AgentError::Model`] (never retried by the run-loop's
-/// `classify_deepseek`). A future non-dark slice that actually selects Claude would add
-/// an `AgentError::ClaudeRoute(ClaudeError)` variant + a classifier arm; out of scope here.
+/// **Error mapping.** Claude route failures are preserved as
+/// [`AgentError::ClaudeRoute`], not string-matched. The run-loop's same-route retry still
+/// only retries DeepSeek [`AgentError::Route`] errors; Claude's structured shape is consumed
+/// only by the explicit, default-OFF Claude→DeepSeek failover wrapper.
 ///
 /// **Ledger/metering (C2).** This adapter OVERRIDES `next_step_metered` to surface its
 /// chat usage as a provider-neutral [`BilledUsage`] tagged [`friday_core::ProviderKind::Anthropic`]
@@ -933,9 +938,7 @@ impl<T: friday_anthropic::Transport> AgentLlmClient for ClaudeAgentLlmClient<T> 
         let outcome = self
             .client
             .chat(&self.model, &prompt, AGENTLOOP_MAX_TOKENS)
-            // ClaudeError → string-bearing AgentError::Model (retry-classification deferred;
-            // see the adapter doc). Coarse, secret-free Display.
-            .map_err(|e| AgentError::Model(e.to_string()))?;
+            .map_err(AgentError::ClaudeRoute)?;
         parse_tool_call(&outcome.content)
     }
 
@@ -965,9 +968,7 @@ impl<T: friday_anthropic::Transport> AgentLlmClient for ClaudeAgentLlmClient<T> 
         let outcome = self
             .client
             .chat(&self.model, &prompt, AGENTLOOP_MAX_TOKENS)
-            // ClaudeError → string-bearing AgentError::Model (retry-classification deferred;
-            // see the adapter doc). Coarse, secret-free Display.
-            .map_err(|e| AgentError::Model(e.to_string()))?;
+            .map_err(AgentError::ClaudeRoute)?;
         // The chat SUCCEEDED — `outcome` carries real, billable usage even if the content
         // below fails to parse. Surface it (neutral `BilledUsage`, Anthropic kind) so the
         // loop bills the call with the CORRECT provider regardless of parse.

--- a/rust-core/crates/friday-hub/src/provider_failover.rs
+++ b/rust-core/crates/friday-hub/src/provider_failover.rs
@@ -58,6 +58,7 @@
 //! number of wrapper calls.
 
 use crate::{AgentError, AgentLlmClient, AgentStep, MeteredStep, RawToolCall, TurnTrace};
+use friday_anthropic::ClaudeError;
 use friday_deepseek::DeepSeekError;
 
 /// Is `err` — the OUTER error from the PRIMARY provider's call — a FAILOVER-worthy
@@ -85,12 +86,30 @@ pub fn is_failover_worthy(err: &AgentError) -> bool {
             | DeepSeekError::BadResponse(_)
             | DeepSeekError::Core(_) => false,
         },
+        AgentError::ClaudeRoute(_) => false,
         // "no model available" (discovery selection) — a config issue, not an outage.
         AgentError::Model(_) => false,
         // The model REPLIED but the parse failed — NEVER failover (the double-bill trap is
         // the metered `Ok((Err(Parse), ..))` path, but a direct `propose_tool_call` parse
         // error is likewise not a route failure).
         AgentError::Parse(_) => false,
+    }
+}
+
+/// Is a structured Claude route error worth retrying once on a different provider? This mirrors
+/// [`is_failover_worthy`] without collapsing Claude's error into a string:
+/// transient provider unavailable, quota (402), and rate-limit (429) may use a different provider;
+/// auth, missing credentials, malformed/ordinary 4xx, and bad response fail closed unchanged.
+pub fn is_claude_failover_worthy(err: &AgentError) -> bool {
+    match err {
+        AgentError::ClaudeRoute(e) => match e {
+            ClaudeError::ProviderUnavailable(_) => true,
+            ClaudeError::ClientError { status } => *status == 402 || *status == 429,
+            ClaudeError::Auth(_) | ClaudeError::CredentialMissing | ClaudeError::BadResponse(_) => {
+                false
+            }
+        },
+        AgentError::Route(_) | AgentError::Model(_) | AgentError::Parse(_) => false,
     }
 }
 
@@ -160,6 +179,50 @@ impl<P: AgentLlmClient, F: AgentLlmClient> AgentLlmClient for ProviderFailoverWr
     }
 }
 
+/// The reverse, gated resilience wrapper: Claude primary, DeepSeek fallback. Kept as a distinct
+/// type so each direction has an explicit classifier and billing expectations; it still slots into
+/// the same [`AgentLlmClient`] seam and makes at most one fallback attempt per provider call.
+pub struct ClaudeToDeepSeekFailoverWrapper<P: AgentLlmClient, F: AgentLlmClient> {
+    primary: P,
+    fallback: F,
+}
+
+impl<P: AgentLlmClient, F: AgentLlmClient> ClaudeToDeepSeekFailoverWrapper<P, F> {
+    pub fn new(primary: P, fallback: F) -> Self {
+        Self { primary, fallback }
+    }
+}
+
+impl<P: AgentLlmClient, F: AgentLlmClient> AgentLlmClient
+    for ClaudeToDeepSeekFailoverWrapper<P, F>
+{
+    fn propose_tool_call(&self, task: &str) -> Result<RawToolCall, AgentError> {
+        match self.primary.propose_tool_call(task) {
+            Ok(call) => Ok(call),
+            Err(e) if is_claude_failover_worthy(&e) => self.fallback.propose_tool_call(task),
+            Err(e) => Err(e),
+        }
+    }
+
+    fn next_step(&self, task: &str, history: &[TurnTrace]) -> Result<AgentStep, AgentError> {
+        self.next_step_metered(task, history)?.0
+    }
+
+    fn next_step_metered(
+        &self,
+        task: &str,
+        history: &[TurnTrace],
+    ) -> Result<MeteredStep, AgentError> {
+        match self.primary.next_step_metered(task, history) {
+            ok @ Ok(_) => ok,
+            Err(e) if is_claude_failover_worthy(&e) => {
+                self.fallback.next_step_metered(task, history)
+            }
+            Err(e) => Err(e),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -213,6 +276,20 @@ mod tests {
                 model: "claude-opus-4-8".to_string(),
                 prompt_tokens: 11,
                 completion_tokens: 8,
+            }),
+        ))
+    }
+
+    fn deepseek_finish_with_deepseek_usage() -> Result<MeteredStep, AgentError> {
+        Ok((
+            Ok(AgentStep::Finish {
+                message: "PONG".to_string(),
+            }),
+            Some(BilledUsage {
+                provider_kind: friday_core::ProviderKind::DeepSeek,
+                model: "deepseek-v4-flash".to_string(),
+                prompt_tokens: 7,
+                completion_tokens: 5,
             }),
         ))
     }
@@ -271,7 +348,47 @@ mod tests {
         assert!(!is_failover_worthy(&AgentError::Model(
             "no model available".into()
         )));
+        assert!(!is_failover_worthy(&AgentError::ClaudeRoute(
+            ClaudeError::ProviderUnavailable("HTTP 503".into())
+        )));
         assert!(!is_failover_worthy(&AgentError::Parse("not json".into())));
+    }
+
+    #[test]
+    fn claude_classifier_failover_triggers() {
+        assert!(is_claude_failover_worthy(&AgentError::ClaudeRoute(
+            ClaudeError::ProviderUnavailable("HTTP 503".into())
+        )));
+        assert!(is_claude_failover_worthy(&AgentError::ClaudeRoute(
+            ClaudeError::ClientError { status: 402 }
+        )));
+        assert!(is_claude_failover_worthy(&AgentError::ClaudeRoute(
+            ClaudeError::ClientError { status: 429 }
+        )));
+    }
+
+    #[test]
+    fn claude_classifier_failover_never_triggers() {
+        for status in [400u16, 404, 413, 422] {
+            assert!(!is_claude_failover_worthy(&AgentError::ClaudeRoute(
+                ClaudeError::ClientError { status }
+            )));
+        }
+        assert!(!is_claude_failover_worthy(&AgentError::ClaudeRoute(
+            ClaudeError::Auth(401)
+        )));
+        assert!(!is_claude_failover_worthy(&AgentError::ClaudeRoute(
+            ClaudeError::CredentialMissing
+        )));
+        assert!(!is_claude_failover_worthy(&AgentError::ClaudeRoute(
+            ClaudeError::BadResponse("garbage".into())
+        )));
+        assert!(!is_claude_failover_worthy(&AgentError::Route(
+            DeepSeekError::ProviderUnavailable("HTTP 503".into())
+        )));
+        assert!(!is_claude_failover_worthy(&AgentError::Parse(
+            "not json".into()
+        )));
     }
 
     // ---- the wrapper: behavior per case -----------------------------------------------
@@ -402,6 +519,43 @@ mod tests {
             0,
             "a broken credential is operator-actionable, not failed over"
         );
+    }
+
+    #[test]
+    fn claude_provider_unavailable_fails_over_to_deepseek_with_deepseek_billing() {
+        let primary = ScriptedClient::new(|| {
+            Err(AgentError::ClaudeRoute(ClaudeError::ProviderUnavailable(
+                "HTTP 503".into(),
+            )))
+        });
+        let fallback = ScriptedClient::new(deepseek_finish_with_deepseek_usage);
+        let wrapper = ClaudeToDeepSeekFailoverWrapper::new(primary, fallback);
+        let (step, usage) = wrapper.next_step_metered("task", &[]).unwrap();
+        assert_eq!(
+            step.unwrap(),
+            AgentStep::Finish {
+                message: "PONG".into()
+            }
+        );
+        assert_eq!(
+            usage.unwrap().provider_kind,
+            friday_core::ProviderKind::DeepSeek
+        );
+        assert_eq!(wrapper.primary.calls(), 1);
+        assert_eq!(wrapper.fallback.calls(), 1);
+    }
+
+    #[test]
+    fn claude_auth_error_never_fails_over() {
+        let primary = ScriptedClient::new(|| Err(AgentError::ClaudeRoute(ClaudeError::Auth(401))));
+        let fallback = ScriptedClient::new(deepseek_finish_with_deepseek_usage);
+        let wrapper = ClaudeToDeepSeekFailoverWrapper::new(primary, fallback);
+        let err = wrapper.next_step_metered("task", &[]).unwrap_err();
+        assert!(matches!(
+            err,
+            AgentError::ClaudeRoute(ClaudeError::Auth(401))
+        ));
+        assert_eq!(wrapper.fallback.calls(), 0);
     }
 
     #[test]

--- a/rust-core/crates/friday-hub/src/runtime.rs
+++ b/rust-core/crates/friday-hub/src/runtime.rs
@@ -151,6 +151,9 @@ pub enum HubInitError {
     /// enabling failover without a fallback is an operator misconfiguration that must be
     /// surfaced (carries no secret — a fixed message).
     FailoverMisconfigured,
+    /// The reverse Claude→DeepSeek failover gate was ON, but no Claude primary route was wired.
+    /// A wrapper without its primary would be a misleading no-op, so boot fails closed.
+    ClaudeFailoverMisconfigured,
 }
 
 impl std::fmt::Display for HubInitError {
@@ -170,6 +173,12 @@ impl std::fmt::Display for HubInitError {
                 "provider failover ({}) is ON but no Claude fallback is wired \
                  (enable {} with a valid Anthropic key)",
                 ENV_PROVIDER_FAILOVER, ENV_CLAUDE_ROUTE_ENABLED
+            ),
+            HubInitError::ClaudeFailoverMisconfigured => write!(
+                f,
+                "claude provider failover ({}) is ON but no Claude primary is wired \
+                 (enable {} with a valid Anthropic key)",
+                ENV_PROVIDER_FAILOVER_CLAUDE_TO_DEEPSEEK, ENV_CLAUDE_ROUTE_ENABLED
             ),
         }
     }
@@ -203,6 +212,12 @@ pub struct HubRuntime<T: Transport> {
     /// byte-identical to today. `self.deepseek` (and its `.inner()` used by post-run memory
     /// extraction — which must NOT failover) is retained UNTOUCHED alongside this.
     failover: Option<Box<dyn AgentLlmClient>>,
+    /// DARK / default-off reverse provider FAILOVER wrapper (claude→deepseek). `None` in every
+    /// build except `live()` when `FRIDAY_PROVIDER_FAILOVER_CLAUDE_TO_DEEPSEEK=1` and Claude is
+    /// wired. When present it becomes the resolved `claude` route client; selection still reports
+    /// `provider_id="claude"`, while execution may retry once on DeepSeek for a classified
+    /// Claude route outage/quota/rate-limit failure. Default-off keeps the bare Claude client.
+    claude_failover: Option<Box<dyn AgentLlmClient>>,
     /// (PR-A1) DARK / default-off DeepSeek-PRO route client. `None` in every build EXCEPT a
     /// `live()` build whose `FRIDAY_DEEPSEEK_PRO_ROUTE_ENABLED` gate is on. It is the SAME
     /// DeepSeek key/client as `self.deepseek`, but built via
@@ -349,6 +364,9 @@ impl<T: Transport> HubRuntime<T> {
             // may populate this. Tests + the prod default leave it `None` ⇒ the bare
             // `deepseek` client dispatches ⇒ byte-identical to today.
             failover: None,
+            // T4 — DARK reverse failover wrapper. Default-off means the claude route, when wired,
+            // dispatches its bare client exactly as before.
+            claude_failover: None,
             // PR-A1: DARK — no DeepSeek-PRO route client by default. Only
             // `maybe_attach_deepseek_pro_from_env` (reached from `live()` behind the default-OFF
             // `FRIDAY_DEEPSEEK_PRO_ROUTE_ENABLED` gate) may populate this. Tests + the prod
@@ -397,6 +415,11 @@ impl<T: Transport> HubRuntime<T> {
         self
     }
 
+    pub fn with_claude_failover(mut self, failover: Box<dyn AgentLlmClient>) -> Self {
+        self.claude_failover = Some(failover);
+        self
+    }
+
     /// Registry gap #26 — the client the LIVE agent loop drives for a `deepseek`-routed run.
     /// When the failover wrapper is attached (the gated `live()` path with
     /// `FRIDAY_PROVIDER_FAILOVER=1` + Claude present) it returns the WRAPPER (deepseek→claude
@@ -410,6 +433,13 @@ impl<T: Transport> HubRuntime<T> {
         match self.failover.as_deref() {
             Some(wrapper) => wrapper,
             None => &self.deepseek,
+        }
+    }
+
+    fn claude_loop_client(&self) -> Option<&dyn AgentLlmClient> {
+        match self.claude_failover.as_deref() {
+            Some(wrapper) => Some(wrapper),
+            None => self.claude.as_deref(),
         }
     }
 
@@ -472,6 +502,35 @@ impl<T: Transport> HubRuntime<T> {
             Box::new(fallback) as Box<dyn AgentLlmClient>,
         );
         Ok(self.with_failover(Box::new(wrapper)))
+    }
+
+    fn maybe_wrap_for_claude_failover(self) -> Result<Self, HubInitError> {
+        let enabled = provider_failover_claude_to_deepseek_from(
+            std::env::var(ENV_PROVIDER_FAILOVER_CLAUDE_TO_DEEPSEEK)
+                .ok()
+                .as_deref(),
+        );
+        self.wrap_for_claude_failover_flagged(enabled)
+    }
+
+    fn wrap_for_claude_failover_flagged(self, enabled: bool) -> Result<Self, HubInitError> {
+        if !enabled {
+            return Ok(self);
+        }
+        if self.claude.is_none() {
+            return Err(HubInitError::ClaudeFailoverMisconfigured);
+        }
+        let primary_client =
+            friday_anthropic::ClaudeClient::from_env().map_err(HubInitError::Claude)?;
+        let primary =
+            crate::ClaudeAgentLlmClient::new(primary_client, friday_anthropic::DEFAULT_MODEL);
+        let fallback_client = DeepSeekClient::from_env().map_err(HubInitError::DeepSeek)?;
+        let fallback = DeepSeekAgentLlmClient::new(fallback_client);
+        let wrapper = crate::provider_failover::ClaudeToDeepSeekFailoverWrapper::new(
+            primary,
+            Box::new(fallback) as Box<dyn AgentLlmClient>,
+        );
+        Ok(self.with_claude_failover(Box::new(wrapper)))
     }
 
     /// C1 PR-B — attach the DARK Codex route EXECUTOR (builder, default-off). MIRRORS
@@ -2961,7 +3020,8 @@ impl HubRuntime<UreqTransport> {
             .maybe_attach_codex_from_env()
             .maybe_attach_deepseek_pro_from_env()?
             .maybe_attach_escalation_from_env()?
-            .maybe_wrap_for_failover()
+            .maybe_wrap_for_failover()?
+            .maybe_wrap_for_claude_failover()
     }
 
     /// S7 — read the default-OFF gate and, only when it is on, build the live Claude
@@ -3169,6 +3229,16 @@ fn provider_failover_from(raw: Option<&str>) -> bool {
     matches!(raw.map(str::trim), Some("1"))
 }
 
+/// Default-OFF gate for the reverse Claude→DeepSeek failover wrapper. This is intentionally
+/// separate from [`ENV_PROVIDER_FAILOVER`] so enabling DeepSeek→Claude resilience never silently
+/// changes a Claude-pinned route's execution semantics.
+pub const ENV_PROVIDER_FAILOVER_CLAUDE_TO_DEEPSEEK: &str =
+    "FRIDAY_PROVIDER_FAILOVER_CLAUDE_TO_DEEPSEEK";
+
+fn provider_failover_claude_to_deepseek_from(raw: Option<&str>) -> bool {
+    matches!(raw.map(str::trim), Some("1"))
+}
+
 /// (PR-A1) The default-OFF environment gate that governs whether the DARK `deepseek-pro` route
 /// is DISPATCHABLE (and its forced-`deepseek-v4-pro` client wired). MIRRORS the route gates'
 /// narrow discipline: ON only when `FRIDAY_DEEPSEEK_PRO_ROUTE_ENABLED` is exactly `"1"` (after
@@ -3317,7 +3387,7 @@ impl<T: Transport> ProviderClientResolver for HubRuntime<T> {
             // DARK: `as_deref()` yields `None` whenever the Claude client was not wired
             // (the default), so the default-off route fail-closes exactly like any
             // other unwired provider.
-            "claude" => self.claude.as_deref(),
+            "claude" => self.claude_loop_client(),
             _ => None,
         }
     }
@@ -3536,6 +3606,67 @@ mod tests {
             Err(HubInitError::FailoverMisconfigured) => {}
             Err(other) => panic!("expected FailoverMisconfigured, got {other:?}"),
             Ok(_) => panic!("flag-ON with no fallback must be a hard error (no silent no-op)"),
+        }
+    }
+
+    #[test]
+    fn claude_to_deepseek_failover_flag_matcher_is_exact_one_default_off() {
+        assert!(provider_failover_claude_to_deepseek_from(Some("1")));
+        assert!(provider_failover_claude_to_deepseek_from(Some(" 1 ")));
+        for off in [
+            None,
+            Some(""),
+            Some("0"),
+            Some("true"),
+            Some("yes"),
+            Some("11"),
+            Some("1x"),
+        ] {
+            assert!(
+                !provider_failover_claude_to_deepseek_from(off),
+                "{off:?} must be OFF (default)"
+            );
+        }
+    }
+
+    #[test]
+    fn claude_to_deepseek_failover_flag_off_does_not_construct_wrapper() {
+        let (mut rt, _ws, _c) = runtime_with(
+            "claude-failover-off",
+            &["{\"tool\":\"none\"}"],
+            Box::new(DenyAllApprovals),
+        );
+        rt = rt.with_claude(Box::new(StubClaudeMeteredClient::new(vec![], 11, 8)));
+        assert!(rt.claude_failover.is_none());
+        let rt = rt
+            .wrap_for_claude_failover_flagged(false)
+            .expect("flag-off is infallible");
+        assert!(
+            rt.claude_failover.is_none(),
+            "flag-OFF must leave the bare Claude route client in place"
+        );
+        let claude_route = ProviderRoute {
+            provider_id: "claude".into(),
+            ..RouteRegistry::autonomous_baseline()
+                .get("claude")
+                .unwrap()
+                .clone()
+        };
+        assert!(rt.resolve(&claude_route).is_some());
+    }
+
+    #[test]
+    fn claude_to_deepseek_failover_flag_on_without_claude_is_hard_boot_error() {
+        let (rt, _ws, _c) = runtime_with(
+            "claude-failover-no-claude",
+            &["{\"tool\":\"none\"}"],
+            Box::new(DenyAllApprovals),
+        );
+        assert!(rt.claude.is_none());
+        match rt.wrap_for_claude_failover_flagged(true) {
+            Err(HubInitError::ClaudeFailoverMisconfigured) => {}
+            Err(other) => panic!("expected ClaudeFailoverMisconfigured, got {other:?}"),
+            Ok(_) => panic!("flag-ON without Claude primary must be a hard error"),
         }
     }
 

--- a/rust-core/crates/friday-hub/src/workbench_projection.rs
+++ b/rust-core/crates/friday-hub/src/workbench_projection.rs
@@ -261,12 +261,13 @@ struct WorkItemRecoveryMetadata {
 }
 
 fn recovery_metadata_for_work_item(status: WorkItemStatus) -> WorkItemRecoveryMetadata {
+    let can_cancel = status.can_transition_to(WorkItemStatus::Cancelled);
     match status {
         WorkItemStatus::FailedRetryable => WorkItemRecoveryMetadata {
             kind: "retryable",
             blocking_reason: "failed retryable; operator may retry by returning the WorkItem to ready_to_dispatch",
             can_retry: true,
-            can_cancel: true,
+            can_cancel,
         },
         WorkItemStatus::FailedTerminal => WorkItemRecoveryMetadata {
             kind: "terminal",
@@ -279,23 +280,28 @@ fn recovery_metadata_for_work_item(status: WorkItemStatus) -> WorkItemRecoveryMe
                 kind: "needs_operator",
                 blocking_reason: "waiting on operator input or preflight resolution",
                 can_retry: false,
-                can_cancel: true,
+                can_cancel,
             }
         }
-        WorkItemStatus::Dispatched
-        | WorkItemStatus::HubAccepted
-        | WorkItemStatus::ProviderRouted
-        | WorkItemStatus::ProviderWaiting => WorkItemRecoveryMetadata {
+        WorkItemStatus::Dispatched | WorkItemStatus::HubAccepted | WorkItemStatus::ProviderRouted => {
+            WorkItemRecoveryMetadata {
+                kind: "in_flight",
+                blocking_reason: "provider or hub execution is still in flight; cancel is the only exposed recovery action",
+                can_retry: false,
+                can_cancel,
+            }
+        }
+        WorkItemStatus::ProviderWaiting => WorkItemRecoveryMetadata {
             kind: "in_flight",
-            blocking_reason: "provider or hub execution is still in flight; cancel is the only exposed recovery action",
+            blocking_reason: "provider execution is waiting; no legal recovery action is exposed until the provider returns or crash-recovery reconciles it",
             can_retry: false,
-            can_cancel: true,
+            can_cancel,
         },
         WorkItemStatus::Draft | WorkItemStatus::ReadyToDispatch => WorkItemRecoveryMetadata {
             kind: "dispatchable",
             blocking_reason: "ready for dispatch; no recovery action required",
             can_retry: false,
-            can_cancel: true,
+            can_cancel,
         },
         WorkItemStatus::CompletedWithProof
         | WorkItemStatus::Cancelled
@@ -1077,6 +1083,25 @@ mod tests {
             proof_requirements: vec!["redacted route projection".into()],
             ownership_claim_ids: Vec::new(),
         }
+    }
+
+    #[test]
+    fn recovery_can_cancel_matches_core_cancel_transition() {
+        let provider_waiting = recovery_metadata_for_work_item(WorkItemStatus::ProviderWaiting);
+        assert!(
+            !provider_waiting.can_cancel,
+            "ProviderWaiting has no core ProviderWaiting->Cancelled edge"
+        );
+        let ready = recovery_metadata_for_work_item(WorkItemStatus::ReadyToDispatch);
+        assert!(
+            ready.can_cancel,
+            "ReadyToDispatch keeps its legal core cancel affordance"
+        );
+        let failed = recovery_metadata_for_work_item(WorkItemStatus::FailedRetryable);
+        assert!(
+            failed.can_cancel,
+            "FailedRetryable keeps its legal core cancel affordance"
+        );
     }
 
     /// Seed a Mission EXACTLY the way the REAL live producer mints it — a HYPHEN `mission-{…}` id

--- a/rust-core/crates/friday-hub/tests/provider_failover.rs
+++ b/rust-core/crates/friday-hub/tests/provider_failover.rs
@@ -19,7 +19,7 @@
 use std::sync::atomic::{AtomicU64, Ordering};
 
 use friday_core::gate::MutatingActionRequest;
-use friday_hub::provider_failover::ProviderFailoverWrapper;
+use friday_hub::provider_failover::{ClaudeToDeepSeekFailoverWrapper, ProviderFailoverWrapper};
 use friday_hub::{
     run_loop, AgentError, AgentLlmClient, AgentStep, BilledUsage, FsToolExecutor, LoopStatus,
     MeteredStep, RawToolCall, TurnTrace,
@@ -64,6 +64,27 @@ impl FailingPrimary {
         Self { err }
     }
 }
+
+struct FailingClaudePrimary {
+    err: friday_anthropic::ClaudeError,
+}
+impl FailingClaudePrimary {
+    fn new(err: friday_anthropic::ClaudeError) -> Self {
+        Self { err }
+    }
+}
+impl AgentLlmClient for FailingClaudePrimary {
+    fn propose_tool_call(&self, _task: &str) -> Result<RawToolCall, AgentError> {
+        unreachable!("the loop drives next_step_metered")
+    }
+    fn next_step_metered(
+        &self,
+        _task: &str,
+        _history: &[TurnTrace],
+    ) -> Result<MeteredStep, AgentError> {
+        Err(AgentError::ClaudeRoute(self.err.clone()))
+    }
+}
 impl AgentLlmClient for FailingPrimary {
     fn propose_tool_call(&self, _task: &str) -> Result<RawToolCall, AgentError> {
         unreachable!("the loop drives next_step_metered")
@@ -88,6 +109,39 @@ impl FinishingFallback {
         Self {
             answer: answer.to_string(),
         }
+    }
+}
+
+struct FinishingDeepSeekFallback {
+    answer: String,
+}
+impl FinishingDeepSeekFallback {
+    fn new(answer: &str) -> Self {
+        Self {
+            answer: answer.to_string(),
+        }
+    }
+}
+impl AgentLlmClient for FinishingDeepSeekFallback {
+    fn propose_tool_call(&self, _task: &str) -> Result<RawToolCall, AgentError> {
+        unreachable!("the loop drives next_step_metered")
+    }
+    fn next_step_metered(
+        &self,
+        _task: &str,
+        _history: &[TurnTrace],
+    ) -> Result<MeteredStep, AgentError> {
+        Ok((
+            Ok(AgentStep::Finish {
+                message: self.answer.clone(),
+            }),
+            Some(BilledUsage {
+                provider_kind: friday_core::ProviderKind::DeepSeek,
+                model: "deepseek-v4-flash".to_string(),
+                prompt_tokens: 7,
+                completion_tokens: 5,
+            }),
+        ))
     }
 }
 impl AgentLlmClient for FinishingFallback {
@@ -152,6 +206,41 @@ fn run_failover_loop(
     (outcome, rows)
 }
 
+fn run_claude_failover_loop(
+    tag: &str,
+    primary_err: friday_anthropic::ClaudeError,
+) -> (
+    friday_hub::LoopOutcome,
+    Vec<friday_storage::RunTokenUsageRow>,
+) {
+    let db = Db::open_hub(&temp_db(tag)).unwrap();
+    let ws = temp_ws(tag);
+    let executor = FsToolExecutor::new(ws);
+    friday_storage::agent_run::create_run(db.conn(), "run-f", "say pong", NOW).unwrap();
+
+    let primary = FailingClaudePrimary::new(primary_err);
+    let fallback = FinishingDeepSeekFallback::new("PONG");
+    let wrapper = ClaudeToDeepSeekFailoverWrapper::new(primary, fallback);
+
+    let no_approve = |_req: &MutatingActionRequest| None;
+    let outcome = run_loop(
+        &wrapper,
+        &executor,
+        db.conn(),
+        "run-f",
+        "say pong",
+        "",
+        SECRET,
+        &no_approve,
+        4,
+        NOW,
+    )
+    .unwrap();
+
+    let rows = db.list_run_token_usage("run-f").unwrap();
+    (outcome, rows)
+}
+
 /// Assert the loop FINISHED on the fallback's answer and billed EXACTLY ONE row, to
 /// Anthropic (api.anthropic.com) — billing-truth across failover, no double-bill, never
 /// mis-attributed as DeepSeek.
@@ -189,6 +278,25 @@ fn assert_failover_finished_billed_anthropic(
     assert_eq!(row.total_tokens, 19);
 }
 
+fn assert_failover_finished_billed_deepseek(
+    outcome: &friday_hub::LoopOutcome,
+    rows: &[friday_storage::RunTokenUsageRow],
+) {
+    assert_eq!(outcome.status, LoopStatus::Finished);
+    assert_eq!(outcome.final_message.as_deref(), Some("PONG"));
+    assert_eq!(
+        rows.len(),
+        1,
+        "EXACTLY one billed row — the DeepSeek fallback turn; the failed Claude attempt bills nothing"
+    );
+    let row = &rows[0];
+    assert_eq!(row.provider_kind, "deepseek");
+    assert_eq!(row.base_url_host, "api.deepseek.com");
+    assert_eq!(row.prompt_tokens, 7);
+    assert_eq!(row.completion_tokens, 5);
+    assert_eq!(row.total_tokens, 12);
+}
+
 /// THE loop-closing e2e the #27 gate maps to: a DeepSeek 402 (quota) on the live loop
 /// FAILS OVER to Claude, the loop FINISHES on Claude's answer, and the turn is BILLED to
 /// Anthropic (one row, never DeepSeek, never double-billed).
@@ -219,6 +327,18 @@ fn provider_unavailable_5xx_fails_over_to_claude_finishes_and_bills_anthropic() 
         friday_deepseek::DeepSeekError::ProviderUnavailable("HTTP 503".into()),
     );
     assert_failover_finished_billed_anthropic(&outcome, &rows);
+}
+
+/// The reverse gated path: a Claude transient outage fails over to DeepSeek, finishes,
+/// and bills the fallback as DeepSeek. This proves the structured ClaudeRoute error shape
+/// drives the same real loop without string matching or double-billing.
+#[test]
+fn claude_provider_unavailable_fails_over_to_deepseek_finishes_and_bills_deepseek() {
+    let (outcome, rows) = run_claude_failover_loop(
+        "claude-5xx",
+        friday_anthropic::ClaudeError::ProviderUnavailable("HTTP 503".into()),
+    );
+    assert_failover_finished_billed_deepseek(&outcome, &rows);
 }
 
 /// NO-FAILOVER through the real loop: a DeepSeek 400 (malformed) does NOT fail over — the


### PR DESCRIPTION
## Summary
- preserve Claude route errors as structured `AgentError::ClaudeRoute` instead of stringifying them
- add a default-off Claude→DeepSeek failover wrapper with exact trigger classification and manifest coverage
- align Workbench `canCancel` recovery affordances with the core WorkItem status transition table

## Verification
- cargo fmt --manifest-path rust-core/Cargo.toml --all --check
- cargo test --manifest-path rust-core/Cargo.toml -p friday-hub provider_failover -- --nocapture
- cargo test --manifest-path rust-core/Cargo.toml -p friday-hub claude_to_deepseek_failover -- --nocapture
- cargo test --manifest-path rust-core/Cargo.toml -p friday-hub recovery_can_cancel_matches_core_cancel_transition -- --nocapture
- cargo test --manifest-path rust-core/Cargo.toml -p friday-hub --test provider_failover -- --nocapture
- node scripts/ci/verify-prod-flag-tests.mjs
- git diff --check

Truth: default-off/dark only; mocked-provider loop proof, not a live provider fallback row, not organic traffic, not GO-LIVE.
