### PR TITLE
[codex] Surface desktop Chat needs-review queue

### DIFF
--- a/apps/macos/FridayHubConsole/Sources/FridayHubConsole/DesktopChatScreen.swift
+++ b/apps/macos/FridayHubConsole/Sources/FridayHubConsole/DesktopChatScreen.swift
@@ -85,6 +85,7 @@ struct DesktopChatScreen: View {
       continuityCard(snapshot)
       transcriptCard
       stateCard
+      reviewCard(snapshot)
     }
     .padding(20)
   }
@@ -219,6 +220,131 @@ struct DesktopChatScreen: View {
         }
       }
       .accessibilityIdentifier("friday.desktop.chat.unavailable")
+    }
+  }
+
+  @ViewBuilder
+  private func reviewCard(_ snapshot: WorkbenchSnapshot) -> some View {
+    let actionableItems = chatReviewItems()
+    let learningCandidates = snapshot.runOutcomeLearningCandidates
+    if viewModel.latestChatTurn != nil || !actionableItems.isEmpty || !learningCandidates.isEmpty {
+      GlassPanel {
+        VStack(alignment: .leading, spacing: HubTheme.rowSpacing) {
+          HStack {
+            cardTitle("Needs Review")
+            Spacer()
+            if let turn = viewModel.latestChatTurn, !turn.runIds.isEmpty {
+              Button {
+                Task { await viewModel.loadLatestChatReview() }
+              } label: {
+                Label("Refresh", systemImage: "arrow.clockwise")
+              }
+              .buttonStyle(.borderless)
+              .disabled(viewModel.chatReviewState.isLoading)
+              .accessibilityLabel("Refresh desktop chat review queue")
+            }
+          }
+          if let turn = viewModel.latestChatTurn {
+            RefPill(label: "mission_id", ref: turn.missionId)
+            ForEach(turn.runIds, id: \.self) { runId in
+              RefPill(label: "run_id", ref: runId)
+            }
+          }
+          reviewStateBanner
+          ForEach(actionableItems) { item in
+            needsMeRow(item)
+          }
+          ForEach(learningCandidates) { candidate in
+            RunOutcomeLearningCandidateRow(
+              candidate: candidate,
+              state: viewModel.runOutcomeLearningDecisionStates[candidate.id] ?? .ready,
+              onConfirm: {
+                Task { await viewModel.decideRunOutcomeLearning(candidateId: candidate.id, confirm: true) }
+              },
+              onReject: {
+                Task { await viewModel.decideRunOutcomeLearning(candidateId: candidate.id, confirm: false) }
+              })
+          }
+          if actionableItems.isEmpty && learningCandidates.isEmpty {
+            Text("No approval, memory, or A1 learning rows are currently projected for this turn.")
+              .font(.system(size: 12))
+              .foregroundStyle(HubTheme.textSecondary)
+          }
+        }
+      }
+      .accessibilityIdentifier("friday.desktop.chat.review")
+    }
+  }
+
+  @ViewBuilder
+  private var reviewStateBanner: some View {
+    switch viewModel.chatReviewState {
+    case .idle:
+      EmptyView()
+    case .loading:
+      HStack(spacing: 8) {
+        ProgressView().scaleEffect(0.7)
+        Text("Reading activity needs-me rows...")
+          .font(.system(size: 12))
+          .foregroundStyle(HubTheme.textSecondary)
+      }
+    case .loaded:
+      EmptyView()
+    case let .unavailable(reason):
+      HStack(spacing: 8) {
+        StatusChip(text: "unavailable", bg: HubTheme.chipWarnBG, fg: HubTheme.chipWarnFG)
+        Text(reason)
+          .font(.system(size: 12))
+          .foregroundStyle(HubTheme.textSecondary)
+      }
+    }
+  }
+
+  private func chatReviewItems() -> [ChatNeedsMeItem] {
+    guard case let .loaded(items) = viewModel.chatReviewState else { return [] }
+    return items
+  }
+
+  @ViewBuilder
+  private func needsMeRow(_ item: ChatNeedsMeItem) -> some View {
+    if item.kind == "memory_review" {
+      MemoryCandidateRow(
+        candidate: MissionWorkbenchMemoryCandidate(
+          id: item.refId,
+          preview: item.title,
+          state: "candidate_review_only",
+          grantsMemoryAuthority: false,
+          evidenceRef: item.deepLink ?? item.refId),
+        state: viewModel.memoryDecisionStates[item.refId] ?? .ready,
+        onConfirm: {
+          Task { await viewModel.decideMemory(candidateId: item.refId, memoryId: item.refId, confirm: true) }
+        },
+        onReject: {
+          Task { await viewModel.decideMemory(candidateId: item.refId, memoryId: item.refId, confirm: false) }
+        })
+    } else {
+      VStack(alignment: .leading, spacing: 6) {
+        HStack {
+          StatusChip(text: item.kind, bg: HubTheme.chipPendingBG, fg: HubTheme.chipPendingFG)
+          Text(item.state)
+            .font(.system(size: 11))
+            .foregroundStyle(HubTheme.textSecondary)
+          Spacer()
+        }
+        Text(item.title)
+          .font(.system(size: 12))
+          .foregroundStyle(HubTheme.textPrimary)
+        RefPill(label: "run_id", ref: item.runId)
+        RefPill(label: "ref_id", ref: item.refId)
+        if item.kind == "approval_required" {
+          Text("Approval remains operator-signature gated; this surface shows the nonce and does not mint or relay a signature.")
+            .font(.system(size: 10))
+            .foregroundStyle(HubTheme.textSecondary)
+        }
+      }
+      .padding(.vertical, 6)
+      .accessibilityElement(children: .combine)
+      .accessibilityLabel("Needs review \(item.kind). \(item.title)")
     }
   }
 

--- a/apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/OperationsOverviewViewModel.swift
+++ b/apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/OperationsOverviewViewModel.swift
@@ -108,6 +108,58 @@ public enum ReadProjectionDetailState: Sendable, Equatable {
   }
 }
 
+public struct ChatTurnRefs: Sendable, Equatable {
+  public let missionId: String
+  public let workItemId: String?
+  public let runIds: [String]
+
+  public init(missionId: String, workItemId: String?, runIds: [String]) {
+    self.missionId = missionId
+    self.workItemId = workItemId
+    var seen = Set<String>()
+    self.runIds = runIds.filter { !$0.isEmpty && seen.insert($0).inserted }
+  }
+}
+
+public struct ChatNeedsMeItem: Sendable, Equatable, Identifiable {
+  public let runId: String
+  public let kind: String
+  public let title: String
+  public let refId: String
+  public let state: String
+  public let deepLink: String?
+
+  public var id: String { "\(runId):\(kind):\(refId)" }
+
+  public init(
+    runId: String,
+    kind: String,
+    title: String,
+    refId: String,
+    state: String,
+    deepLink: String?
+  ) {
+    self.runId = runId
+    self.kind = kind
+    self.title = title
+    self.refId = refId
+    self.state = state
+    self.deepLink = deepLink
+  }
+}
+
+public enum ChatReviewState: Sendable, Equatable {
+  case idle
+  case loading(runIds: [String])
+  case loaded(items: [ChatNeedsMeItem])
+  case unavailable(reason: String)
+
+  public var isLoading: Bool {
+    if case .loading = self { return true }
+    return false
+  }
+}
+
 /// The state of a single spine-WRITE action (mission intake / memory decision).
 ///
 /// Mirrors `WorkbenchLoadState`'s honest vocabulary: a `.sent` action shows pending, a terminal
@@ -164,6 +216,10 @@ public final class OperationsOverviewViewModel: ObservableObject {
   @Published public private(set) var memoryDecisionStates: [String: WriteActionState] = [:]
   /// Per-candidate A1 run-outcome learning decision state, keyed by candidate id.
   @Published public private(set) var runOutcomeLearningDecisionStates: [String: WriteActionState] = [:]
+  /// Structured refs for the latest desktop Chat turn. This avoids parsing status prose in the UI.
+  @Published public private(set) var latestChatTurn: ChatTurnRefs?
+  /// Refs-only Needs-Me rows for the latest Chat turn's runs.
+  @Published public private(set) var chatReviewState: ChatReviewState = .idle
 
   public let devicePairing: DesktopDevicePairingReadiness
 
@@ -234,6 +290,24 @@ public final class OperationsOverviewViewModel: ObservableObject {
     }
   }
 
+  public func loadLatestChatReview() async {
+    guard let turn = latestChatTurn, !turn.runIds.isEmpty else {
+      chatReviewState = .idle
+      return
+    }
+    chatReviewState = .loading(runIds: turn.runIds)
+    do {
+      var items: [ChatNeedsMeItem] = []
+      for runId in turn.runIds {
+        let snapshot = try await client.fetchActivityNeedsMe(runId: runId)
+        items.append(contentsOf: Self.chatNeedsMeItems(from: snapshot.raw, runId: runId))
+      }
+      chatReviewState = .loaded(items: items)
+    } catch {
+      chatReviewState = .unavailable(reason: Self.reason(for: error))
+    }
+  }
+
   private func readDetail(_ arm: ReadProjectionDetailArm) async throws -> ReadProjectionSnapshot {
     switch arm {
     case let .runReadback(runId):
@@ -271,9 +345,13 @@ public final class OperationsOverviewViewModel: ObservableObject {
     }
     guard let writeClient else {
       intakeState = .error(reason: "Write seam not configured — cannot submit an intake.")
+      latestChatTurn = nil
+      chatReviewState = .idle
       return
     }
     intakeState = .sent
+    latestChatTurn = nil
+    chatReviewState = .idle
     let request = Self.buildIntakeRequest(
       intent: trimmed, owner: writeOwnerPrincipal, idFactory: newId,
       missionIdPrefix: missionIdPrefix)
@@ -292,6 +370,7 @@ public final class OperationsOverviewViewModel: ObservableObject {
         // ready / created_or_ready
         var summary = "Mission intake \(result.status) · mission_id=\(result.missionId)"
         var answerBodies: [String] = []
+        var runIds: [String] = []
         if let workItemId = result.workItemId { summary += " · work_item_id=\(workItemId)" }
         if let workItemId = result.workItemId, let missionRunClient {
           let context = MissionWorkItemContextWire(
@@ -304,6 +383,7 @@ public final class OperationsOverviewViewModel: ObservableObject {
               missionContext: context,
               constraints: AgentRunConstraintsWire(readOnly: true))
             summary += Self.dispatchSummary(for: outcome)
+            runIds.append(contentsOf: Self.runIds(for: outcome))
             let codexAnswerBody = await answerBodyText(for: outcome, label: "Codex")
             if let codexAnswerBody {
               answerBodies.append(codexAnswerBody)
@@ -316,6 +396,7 @@ public final class OperationsOverviewViewModel: ObservableObject {
               missionRunClient: missionRunClient)
             {
               summary += followUpSummary.summary
+              runIds.append(contentsOf: Self.runIds(for: followUpSummary.outcome))
               if let answerBody = await answerBodyText(for: followUpSummary.outcome, label: "Claude follow-up") {
                 answerBodies.append(answerBody)
               }
@@ -331,10 +412,17 @@ public final class OperationsOverviewViewModel: ObservableObject {
         } else {
           intakeState = .confirmed(summary: summary, clarificationQuestions: result.clarificationQuestions)
         }
+        latestChatTurn = ChatTurnRefs(
+          missionId: result.missionId,
+          workItemId: result.workItemId,
+          runIds: runIds)
         await refresh()
+        await loadLatestChatReview()
       }
     } catch {
       intakeState = .error(reason: Self.writeReason(for: error))
+      latestChatTurn = nil
+      chatReviewState = .idle
     }
   }
 
@@ -584,6 +672,62 @@ public final class OperationsOverviewViewModel: ObservableObject {
   private static func runId(for outcome: AgentRunDispatchOutcome) -> String? {
     guard case let .result(result) = outcome else { return nil }
     return result.runId
+  }
+
+  private static func runIds(for outcome: AgentRunDispatchOutcome) -> [String] {
+    switch outcome {
+    case .result(let result):
+      return [result.runId]
+    case .paused(let paused):
+      return [paused.runId]
+    }
+  }
+
+  nonisolated static func chatNeedsMeItems(from raw: [String: Any], runId: String) -> [ChatNeedsMeItem] {
+    var items: [ChatNeedsMeItem] = []
+    if let needsMe = raw["needs_me"] as? [String: Any],
+      let item = chatNeedsMeItem(needsMe, runId: runId, fallbackKind: "approval")
+    {
+      items.append(item)
+    }
+    if let actionable = raw["actionable_needs_me"] as? [[String: Any]] {
+      for rawItem in actionable {
+        if let item = chatNeedsMeItem(rawItem, runId: runId, fallbackKind: "review") {
+          items.append(item)
+        }
+      }
+    }
+    var seen = Set<String>()
+    return items.filter { seen.insert($0.id).inserted }
+  }
+
+  nonisolated private static func chatNeedsMeItem(
+    _ raw: [String: Any],
+    runId: String,
+    fallbackKind: String
+  ) -> ChatNeedsMeItem? {
+    let kind = string(raw["kind"]) ?? fallbackKind
+    guard let refId = string(raw["ref_id"]), !refId.isEmpty else { return nil }
+    let title = string(raw["title"]) ?? string(raw["summary"]) ?? kind
+    let state = string(raw["state"]) ?? string(raw["status"]) ?? "pending"
+    return ChatNeedsMeItem(
+      runId: runId,
+      kind: kind,
+      title: title,
+      refId: refId,
+      state: state,
+      deepLink: string(raw["deep_link"]))
+  }
+
+  nonisolated private static func string(_ value: Any?) -> String? {
+    switch value {
+    case let value as String:
+      return value
+    case let value as CustomStringConvertible:
+      return value.description
+    default:
+      return nil
+    }
   }
 
   private static func reason(for error: Error) -> String {

--- a/apps/macos/FridayHubConsole/Tests/FridayHubConsoleCoreTests/OperationsOverviewViewModelTests.swift
+++ b/apps/macos/FridayHubConsole/Tests/FridayHubConsoleCoreTests/OperationsOverviewViewModelTests.swift
@@ -489,6 +489,7 @@ final class MockMissionSpineWriteClient: FridayMissionSpineWriteClient, FridayMi
 struct StaticWorkbenchReadClient: FridayRustReadClient {
   let snapshot: FridayHubConsoleCore.WorkbenchSnapshot
   var answerBodies: [String: String] = [:]
+  var activityNeedsMe: [String: String] = [:]
 
   func fetchWorkbench() async throws -> FridayRustClient.WorkbenchSnapshot {
     let json = try JSONEncoder().encode(snapshot)
@@ -510,6 +511,39 @@ struct StaticWorkbenchReadClient: FridayRustReadClient {
       """.data(using: .utf8)!
     return try RunAnswerBody(answerJSON: data, generatedAtMs: 1)
   }
+
+  func fetchActivityNeedsMe(runId: String) async throws -> ReadProjectionSnapshot {
+    guard let json = activityNeedsMe[runId]?.data(using: .utf8) else {
+      throw FridayReadClientError.transport("activity needs-me unavailable")
+    }
+    return try ReadProjectionSnapshot(projectionJSON: json, generatedAtMs: 1)
+  }
+}
+
+func activityNeedsMeJSON(runId: String, actionableKind: String, refId: String) -> String {
+  """
+  {
+    "run_id": "\(runId)",
+    "status": "waiting",
+    "truth_label": "friday_owned",
+    "needs_me": {
+      "kind": "approval",
+      "title": "Approval required",
+      "ref_id": "approval-pause-\(runId)",
+      "status": "awaiting_approval"
+    },
+    "actionable_needs_me": [
+      {
+        "kind": "\(actionableKind)",
+        "title": "\(actionableKind) ready",
+        "ref_id": "\(refId)",
+        "state": "pending",
+        "deep_link": "\(actionableKind == "memory_review" ? "memory/session/\(refId)" : "run/\(runId)/approval/\(refId)")"
+      }
+    ],
+    "actionable_needs_me_count": 1
+  }
+  """
 }
 
 final class DetailReadClient: FridayRustReadClient, @unchecked Sendable {
@@ -790,7 +824,13 @@ func submitIntakeDisplaysOwnerGatedRunAnswerBodyWhenDelivered() async {
       missionId: "mission-desktop-fixed",
       fridayConversationId: "fconv_desktop_fixed",
       workItemIds: ["work-desktop-fixed"]),
-    answerBodies: ["run-bound-1": "Readable desktop answer body"])
+    answerBodies: ["run-bound-1": "Readable desktop answer body"],
+    activityNeedsMe: [
+      "run-bound-1": activityNeedsMeJSON(
+        runId: "run-bound-1",
+        actionableKind: "approval_required",
+        refId: "approval-nonce-1")
+    ])
   let vm = OperationsOverviewViewModel(
     client: read, writeClient: write, missionRunClient: write,
     writeOwnerPrincipal: "admin-001", newId: { "fixed" })
@@ -804,6 +844,32 @@ func submitIntakeDisplaysOwnerGatedRunAnswerBodyWhenDelivered() async {
   #expect(summary.contains("run_id=run-bound-1"))
   #expect(answerBody?.contains("Readable desktop answer body") == true)
   #expect(answerBody?.contains("Codex:") == true)
+  #expect(vm.latestChatTurn == ChatTurnRefs(
+    missionId: "mission-desktop-fixed",
+    workItemId: "work-desktop-fixed",
+    runIds: ["run-bound-1"]))
+  guard case let .loaded(items) = vm.chatReviewState else {
+    Issue.record("expected loaded review state, got \(vm.chatReviewState)")
+    return
+  }
+  #expect(items.map(\.kind).contains("approval_required"))
+  #expect(items.map(\.refId).contains("approval-nonce-1"))
+}
+
+@Test
+func chatNeedsMeItemsParsesComputedPauseAndActionableRows() throws {
+  let data = activityNeedsMeJSON(
+    runId: "run-review",
+    actionableKind: "memory_review",
+    refId: "mem-review-1"
+  ).data(using: .utf8)!
+  let raw = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+
+  let items = OperationsOverviewViewModel.chatNeedsMeItems(from: raw, runId: "run-review")
+
+  #expect(items.map(\.kind) == ["approval", "memory_review"])
+  #expect(items.map(\.refId) == ["approval-pause-run-review", "mem-review-1"])
+  #expect(items[1].deepLink == "memory/session/mem-review-1")
 }
 
 @Test


### PR DESCRIPTION
## Summary
- track structured latest desktop Chat turn refs and load existing activity Needs-Me projections for those runs
- render a Chat Needs Review strip for approval, memory, and A1 learning rows without minting signatures or auto-approving
- add parser and submit-intake tests for owner-gated answer + actionable rows

## Truth labels
- organic=0
- product surface / refs-only review queue
- no signature minting, no backend protocol change, no prod DB write or restart

## Verification
- swift build --package-path apps/macos/FridayHubConsole
- swift test --package-path apps/macos/FridayHubConsole --filter OperationsOverviewViewModelTests
- swift run --package-path apps/macos/FridayHubConsole FridayHubConsole --state-render-proof /tmp/friday-t2-chat-review-proof
- git diff --check