### PR TITLE
[codex] Surface approval signing refs in review queue

### DIFF
--- a/apps/macos/FridayHubConsole/Sources/FridayHubConsole/DesktopChatScreen.swift
+++ b/apps/macos/FridayHubConsole/Sources/FridayHubConsole/DesktopChatScreen.swift
@@ -336,8 +336,17 @@ struct DesktopChatScreen: View {
           .foregroundStyle(HubTheme.textPrimary)
         RefPill(label: "run_id", ref: item.runId)
         RefPill(label: "ref_id", ref: item.refId)
+        if let actionDigest = item.actionDigest {
+          RefPill(label: "action_digest", ref: actionDigest)
+        }
+        if let signingSummary = item.signingSummary {
+          Text(signingSummary)
+            .font(.system(size: 10))
+            .foregroundStyle(HubTheme.textSecondary)
+            .lineLimit(2)
+        }
         if item.kind == "approval_required" {
-          Text("Approval remains operator-signature gated; this surface shows the nonce and does not mint or relay a signature.")
+          Text("Approval remains operator-signature gated; this surface shows the signer refs and does not mint or relay a signature.")
             .font(.system(size: 10))
             .foregroundStyle(HubTheme.textSecondary)
         }

--- a/apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/OperationsOverviewViewModel.swift
+++ b/apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/OperationsOverviewViewModel.swift
@@ -128,6 +128,8 @@ public struct ChatNeedsMeItem: Sendable, Equatable, Identifiable {
   public let refId: String
   public let state: String
   public let deepLink: String?
+  public let actionDigest: String?
+  public let signingSummary: String?
 
   public var id: String { "\(runId):\(kind):\(refId)" }
 
@@ -137,7 +139,9 @@ public struct ChatNeedsMeItem: Sendable, Equatable, Identifiable {
     title: String,
     refId: String,
     state: String,
-    deepLink: String?
+    deepLink: String?,
+    actionDigest: String? = nil,
+    signingSummary: String? = nil
   ) {
     self.runId = runId
     self.kind = kind
@@ -145,6 +149,8 @@ public struct ChatNeedsMeItem: Sendable, Equatable, Identifiable {
     self.refId = refId
     self.state = state
     self.deepLink = deepLink
+    self.actionDigest = actionDigest
+    self.signingSummary = signingSummary
   }
 }
 
@@ -716,7 +722,21 @@ public final class OperationsOverviewViewModel: ObservableObject {
       title: title,
       refId: refId,
       state: state,
-      deepLink: string(raw["deep_link"]))
+      deepLink: string(raw["deep_link"]),
+      actionDigest: signingField("action_digest", raw),
+      signingSummary: signingField("summary", raw))
+  }
+
+  nonisolated private static func signingField(_ key: String, _ raw: [String: Any]) -> String? {
+    if let direct = string(raw[key]), !direct.isEmpty {
+      return direct
+    }
+    if let signingRequest = raw["signing_request"] as? [String: Any],
+      let nested = string(signingRequest[key]), !nested.isEmpty
+    {
+      return nested
+    }
+    return nil
   }
 
   nonisolated private static func string(_ value: Any?) -> String? {

--- a/apps/macos/FridayHubConsole/Tests/FridayHubConsoleCoreTests/OperationsOverviewViewModelTests.swift
+++ b/apps/macos/FridayHubConsole/Tests/FridayHubConsoleCoreTests/OperationsOverviewViewModelTests.swift
@@ -530,7 +530,15 @@ func activityNeedsMeJSON(runId: String, actionableKind: String, refId: String) -
       "kind": "approval",
       "title": "Approval required",
       "ref_id": "approval-pause-\(runId)",
-      "status": "awaiting_approval"
+      "status": "awaiting_approval",
+      "action_digest": "digest-pause-\(runId)",
+      "summary": "paused on write_file",
+      "signing_request": {
+        "run_id": "\(runId)",
+        "approval_id": "approval-pause-\(runId)",
+        "action_digest": "digest-pause-\(runId)",
+        "summary": "paused on write_file"
+      }
     },
     "actionable_needs_me": [
       {
@@ -538,7 +546,9 @@ func activityNeedsMeJSON(runId: String, actionableKind: String, refId: String) -
         "title": "\(actionableKind) ready",
         "ref_id": "\(refId)",
         "state": "pending",
-        "deep_link": "\(actionableKind == "memory_review" ? "memory/session/\(refId)" : "run/\(runId)/approval/\(refId)")"
+        "deep_link": "\(actionableKind == "memory_review" ? "memory/session/\(refId)" : "run/\(runId)/approval/\(refId)")",
+        "action_digest": "digest-\(refId)",
+        "summary": "\(actionableKind) ready"
       }
     ],
     "actionable_needs_me_count": 1
@@ -854,6 +864,9 @@ func submitIntakeDisplaysOwnerGatedRunAnswerBodyWhenDelivered() async {
   }
   #expect(items.map(\.kind).contains("approval_required"))
   #expect(items.map(\.refId).contains("approval-nonce-1"))
+  let approval = items.first { $0.kind == "approval_required" }
+  #expect(approval?.actionDigest == "digest-approval-nonce-1")
+  #expect(approval?.signingSummary == "approval_required ready")
 }
 
 @Test
@@ -869,7 +882,27 @@ func chatNeedsMeItemsParsesComputedPauseAndActionableRows() throws {
 
   #expect(items.map(\.kind) == ["approval", "memory_review"])
   #expect(items.map(\.refId) == ["approval-pause-run-review", "mem-review-1"])
+  #expect(items[0].actionDigest == "digest-pause-run-review")
+  #expect(items[0].signingSummary == "paused on write_file")
   #expect(items[1].deepLink == "memory/session/mem-review-1")
+}
+
+@Test
+func chatNeedsMeItemsParsesApprovalSigningRefsFromActionableRows() throws {
+  let data = activityNeedsMeJSON(
+    runId: "run-approval",
+    actionableKind: "approval_required",
+    refId: "approval-nonce-2"
+  ).data(using: .utf8)!
+  let raw = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+
+  let items = OperationsOverviewViewModel.chatNeedsMeItems(from: raw, runId: "run-approval")
+  let approval = items.first { $0.kind == "approval_required" }
+
+  #expect(approval?.runId == "run-approval")
+  #expect(approval?.refId == "approval-nonce-2")
+  #expect(approval?.actionDigest == "digest-approval-nonce-2")
+  #expect(approval?.signingSummary == "approval_required ready")
 }
 
 @Test

--- a/rust-core/crates/friday-hub/src/run_readback_projection.rs
+++ b/rust-core/crates/friday-hub/src/run_readback_projection.rs
@@ -32,9 +32,6 @@
 //! This fn takes an ALREADY-OPENED [`Db`] (the bin and the server open it `open_hub_readonly`) and
 //! does pure reads + JSON shaping. It never touches a provider credential or the model path.
 
-use friday_providers::unified::{
-    NeedsMeItem, NeedsMeKind, NeedsMePriority, PlatformProvider, SessionStatus,
-};
 use friday_storage::agent_run_read::{db_wide_token_totals, get_run_summary, list_event_kinds};
 use friday_storage::agent_session::{
     link_state_for_owner, LINK_OFFLINE_AFTER_MS, LINK_STALE_AFTER_MS,
@@ -396,15 +393,30 @@ pub fn project_activity_needs_me(
     // provider is Claude; the sessionless run's `friday_session_id` is the run id.
     let needs_me = crate::agent_run_control::detect_pause(conn, run_id)
         .map_err(|_| "read_failed".to_string())?
-        .map(|pause| NeedsMeItem {
-            item_id: format!("needs-me:{run_id}:{}", pause.nonce),
-            provider: PlatformProvider::Claude,
-            friday_session_id: run_id.to_string(),
-            kind: NeedsMeKind::Approval,
-            priority: NeedsMePriority::High,
-            // The live approval nonce — the real `pending_approval_request.approval_id`.
-            ref_id: pause.nonce,
-            status: SessionStatus::AwaitingApproval,
+        .map(|pause| {
+            let approval_id = pause.nonce;
+            let action_digest = pause.action_digest;
+            let summary = pause.summary;
+            json!({
+                "item_id": format!("needs-me:{run_id}:{approval_id}"),
+                "provider": "claude",
+                "friday_session_id": run_id,
+                "kind": "approval",
+                "priority": "high",
+                // The live approval nonce — the real `pending_approval_request.approval_id`.
+                "ref_id": approval_id,
+                "status": "awaiting_approval",
+                // Refs-only signing material. This is enough for an operator signer to review/sign
+                // the paused action, but still carries no tool body/args/key material.
+                "action_digest": action_digest,
+                "summary": summary,
+                "signing_request": {
+                    "run_id": run_id,
+                    "approval_id": approval_id,
+                    "action_digest": action_digest,
+                    "summary": summary,
+                },
+            })
         });
 
     // ADDITIVE (no-degrade): the actionable activity rows the producers write but the
@@ -475,23 +487,27 @@ fn collect_actionable_needs_me(
 ) -> Result<Vec<Value>, String> {
     // This run's STILL-pending approval nonces (oldest-first). The owner gate already ran, so
     // these are this owner's nonces — `approval-needs-me-{nonce}` is the producer's id scheme.
-    let pending_approval_ids: std::collections::HashSet<String> =
+    let pending_approvals: std::collections::HashMap<String, (String, String)> =
         friday_storage::list_pending_requests_for_run(conn, run_id)
             .map_err(|_| "read_failed".to_string())?
             .into_iter()
             .filter(|p| p.status == "pending")
-            .map(|p| format!("{APPROVAL_ACTIVITY_PREFIX}{}", p.approval_id))
+            .map(|p| {
+                (
+                    format!("{APPROVAL_ACTIVITY_PREFIX}{}", p.approval_id),
+                    (p.approval_id, p.action_digest),
+                )
+            })
             .collect();
 
     let mut out: Vec<Value> = Vec::new();
     for row in db.list_activity().map_err(|_| "read_failed".to_string())? {
         match row.kind.as_str() {
             // approval_required: surface ONLY if it is one of THIS run's live pending nonces.
-            "approval_required" if pending_approval_ids.contains(&row.activity_id) => {
-                let nonce = row
-                    .activity_id
-                    .strip_prefix(APPROVAL_ACTIVITY_PREFIX)
-                    .unwrap_or(&row.activity_id);
+            "approval_required" if pending_approvals.contains_key(&row.activity_id) => {
+                let Some((nonce, action_digest)) = pending_approvals.get(&row.activity_id) else {
+                    continue;
+                };
                 out.push(json!({
                     "kind": "approval_required",
                     // The producer's body-free summary ("approval required for {action} ...").
@@ -502,6 +518,14 @@ fn collect_actionable_needs_me(
                     "ref_id": nonce,
                     "state": row.state,
                     "activity_id": row.activity_id,
+                    "action_digest": action_digest,
+                    "summary": row.summary,
+                    "signing_request": {
+                        "run_id": run_id,
+                        "approval_id": nonce,
+                        "action_digest": action_digest,
+                        "summary": row.summary,
+                    },
                 }));
             }
             // memory_review: owner-scope by joining the parsed memory_id back to its
@@ -897,6 +921,14 @@ mod tests {
         );
         assert_eq!(v["needs_me"]["kind"], "approval");
         assert_eq!(v["needs_me"]["ref_id"], nonce);
+        assert_eq!(v["needs_me"]["action_digest"], format!("digest-{nonce}"));
+        assert_eq!(v["needs_me"]["summary"], "paused on write_file");
+        assert_eq!(v["needs_me"]["signing_request"]["run_id"], run_id);
+        assert_eq!(v["needs_me"]["signing_request"]["approval_id"], nonce);
+        assert_eq!(
+            v["needs_me"]["signing_request"]["action_digest"],
+            format!("digest-{nonce}")
+        );
 
         // The NEW actionable array surfaces BOTH the memory_review and the approval_required rows.
         let actionable = v["actionable_needs_me"].as_array().expect("array");
@@ -933,6 +965,13 @@ mod tests {
             .unwrap();
         assert_eq!(ar["ref_id"], nonce);
         assert_eq!(ar["deep_link"], format!("run/{run_id}/approval/{nonce}"));
+        assert_eq!(ar["action_digest"], format!("digest-{nonce}"));
+        assert_eq!(ar["signing_request"]["run_id"], run_id);
+        assert_eq!(ar["signing_request"]["approval_id"], nonce);
+        assert_eq!(
+            ar["signing_request"]["action_digest"],
+            format!("digest-{nonce}")
+        );
     }
 
     /// no-degrade regression: the pre-existing ask_receipt + detect_pause Needs-Me items still


### PR DESCRIPTION
## Summary
- project paused-run approval needs-me rows with refs-only signing material: run id, approval nonce, action digest, summary
- parse and display those signer refs in the desktop Chat Needs Review queue
- keep the surface operator-signature gated: no signing, no relay, no private key path

## Truth labels
- organic=0
- product bridge only: complete signing request refs are now surfaced for the next desktop-signer relay slice
- Hub remains verify-only; apps still do not mint signatures or hold operator key material

## Verification
- cargo fmt --manifest-path rust-core/Cargo.toml --all --check
- git diff --check
- cargo test --manifest-path rust-core/Cargo.toml -p friday-hub actionable_needs_me_surfaces_memory_review_and_approval_required_for_the_owner -- --nocapture
- swift test --package-path apps/macos/FridayHubConsole --filter OperationsOverviewViewModelTests