### PR TITLE
[codex] Add Swift pairing QR manifest model

### DIFF
--- a/apps/macos/FridayRustClient/Sources/FridayRustClient/PairingManifest.swift
+++ b/apps/macos/FridayRustClient/Sources/FridayRustClient/PairingManifest.swift
@@ -1,0 +1,133 @@
+import CryptoKit
+import Foundation
+
+public enum FridayPairingManifestError: Error, Equatable {
+  case unsupportedKind(String)
+  case badHubPublicKey(String)
+  case missingWebSocketEndpoint
+  case expired(nowMs: Int64, expiresAtMs: Int64)
+}
+
+public struct FridayPairingTransportHint: Codable, Equatable, Sendable {
+  public let kind: String
+  public let endpoint: String
+  public let label: String
+
+  public init(kind: String, endpoint: String, label: String) {
+    self.kind = kind
+    self.endpoint = endpoint
+    self.label = label
+  }
+}
+
+/// Decodes the QR manifest emitted by `hub_pairing_server --qr-json-out`.
+///
+/// The manifest is scan material: it intentionally contains the short-lived `pairing_secret`.
+/// Keep it in memory only, do not log it, and use `redactedProjection` for UI display.
+public struct FridayPairingManifest: Codable, Equatable, Sendable, CustomStringConvertible,
+  CustomDebugStringConvertible
+{
+  public static let supportedKind = "friday.pairing.qr.v1"
+
+  public let kind: String
+  public let aad: String
+  public let hubPublicKeyHex: String
+  public let version: UInt16
+  public let hubId: String
+  public let pairingId: String
+  public let pairingSecret: String
+  public let displayName: String
+  public let transportHints: [FridayPairingTransportHint]
+  public let expiresAt: Int64
+  public let capabilitiesHint: [String]
+
+  enum CodingKeys: String, CodingKey {
+    case kind, aad
+    case hubPublicKeyHex = "hub_public_key_hex"
+    case version = "v"
+    case hubId = "hub_id"
+    case pairingId = "pairing_id"
+    case pairingSecret = "pairing_secret"  // pragma: allowlist secret
+    case displayName = "display_name"
+    case transportHints = "transport_hints"
+    case expiresAt = "expires_at"
+    case capabilitiesHint = "capabilities_hint"
+  }
+
+  public var description: String { redactedProjection.description }
+  public var debugDescription: String { redactedProjection.description }
+
+  public var hubPublicKey: [UInt8] {
+    get throws {
+      let key = try Hex.decode(hubPublicKeyHex)
+      guard key.count == FridayCrypto.x25519PublicKeyLen else {
+        throw FridayPairingManifestError.badHubPublicKey("hub public key must be 32 bytes")
+      }
+      return key
+    }
+  }
+
+  public var webSocketEndpoint: String {
+    get throws {
+      guard let endpoint = transportHints.first(where: { $0.kind == "websocket" })?.endpoint,
+        !endpoint.isEmpty
+      else {
+        throw FridayPairingManifestError.missingWebSocketEndpoint
+      }
+      return endpoint
+    }
+  }
+
+  public var redactedProjection: FridayPairingManifestProjection {
+    FridayPairingManifestProjection(
+      kind: kind,
+      aad: aad,
+      hubPublicKeyHex: hubPublicKeyHex,
+      version: version,
+      hubId: hubId,
+      pairingId: pairingId,
+      displayName: displayName,
+      transportLabels: transportHints.map(\.label),
+      endpoints: transportHints.map(\.endpoint),
+      expiresAt: expiresAt,
+      capabilitiesHint: capabilitiesHint)
+  }
+
+  public func validate(nowMs: Int64? = nil) throws {
+    guard kind == Self.supportedKind else {
+      throw FridayPairingManifestError.unsupportedKind(kind)
+    }
+    _ = try hubPublicKey
+    _ = try webSocketEndpoint
+    if let nowMs, expiresAt <= nowMs {
+      throw FridayPairingManifestError.expired(nowMs: nowMs, expiresAtMs: expiresAt)
+    }
+  }
+
+  public func pairingProof(forDevicePublicKey devicePublicKey: [UInt8]) throws -> [UInt8] {
+    guard devicePublicKey.count == FridayCrypto.x25519PublicKeyLen else {
+      throw FridayCryptoError.badLength("device public key must be 32 bytes")
+    }
+    let key = SymmetricKey(data: Data(pairingSecret.utf8))
+    let mac = HMAC<SHA256>.authenticationCode(for: Data(devicePublicKey), using: key)
+    return Array(mac)
+  }
+}
+
+public struct FridayPairingManifestProjection: Equatable, Sendable, CustomStringConvertible {
+  public let kind: String
+  public let aad: String
+  public let hubPublicKeyHex: String
+  public let version: UInt16
+  public let hubId: String
+  public let pairingId: String
+  public let displayName: String
+  public let transportLabels: [String]
+  public let endpoints: [String]
+  public let expiresAt: Int64
+  public let capabilitiesHint: [String]
+
+  public var description: String {
+    "FridayPairingManifestProjection(kind: \(kind), hubId: \(hubId), pairingId: \(pairingId), displayName: \(displayName), expiresAt: \(expiresAt))"
+  }
+}

--- a/apps/macos/FridayRustClient/Tests/FridayRustClientTests/PairingManifestTests.swift
+++ b/apps/macos/FridayRustClient/Tests/FridayRustClientTests/PairingManifestTests.swift
@@ -1,0 +1,87 @@
+import XCTest
+@testable import FridayRustClient
+
+final class PairingManifestTests: XCTestCase {
+  private let fixturePairingSecret = "qr-secret-1234567890" // pragma: allowlist secret
+
+  func testDecodesQrManifestAndRedactsSecretFromDisplaySurfaces() throws {
+    let manifest = try decodeManifest()
+
+    XCTAssertEqual(manifest.kind, FridayPairingManifest.supportedKind)
+    XCTAssertEqual(manifest.version, 1)
+    XCTAssertEqual(manifest.hubId, "hub-local")
+    XCTAssertEqual(try manifest.webSocketEndpoint, "ws://127.0.0.1:49152")
+    XCTAssertEqual(try manifest.hubPublicKey.count, 32)
+
+    let projection = manifest.redactedProjection
+    XCTAssertEqual(projection.transportLabels, ["Local pairing"])
+    XCTAssertEqual(projection.capabilitiesHint, ["status_only"])
+
+    let display = "\(manifest)"
+    let debug = String(reflecting: manifest)
+    XCTAssertFalse(display.contains(fixturePairingSecret))
+    XCTAssertFalse(debug.contains(fixturePairingSecret))
+    XCTAssertFalse("\(projection)".contains(fixturePairingSecret))
+  }
+
+  func testPairingProofMatchesRustHmacSha256Contract() throws {
+    let manifest = try decodeManifest()
+    let devicePubkey = Array(UInt8(0)..<UInt8(32))
+
+    let proof = try manifest.pairingProof(forDevicePublicKey: devicePubkey)
+
+    XCTAssertEqual(
+      Hex.encode(proof),
+      "b82be6373123d412b180127398c090c940663a12574035523b71c629549282fc")  // pragma: allowlist secret
+  }
+
+  func testValidationFailsClosedForBadManifestShapes() throws {
+    let manifest = try decodeManifest()
+    try manifest.validate(nowMs: 1_780_000_000_000)
+    XCTAssertThrowsError(try manifest.validate(nowMs: 1_790_000_000_000)) { error in
+      XCTAssertEqual(error as? FridayPairingManifestError, .expired(
+        nowMs: 1_790_000_000_000,
+        expiresAtMs: 1_780_650_000_000))
+    }
+
+    let badKind = try decodeManifest(replacing: ("friday.pairing.qr.v1", "friday.other"))
+    XCTAssertThrowsError(try badKind.validate()) { error in
+      XCTAssertEqual(error as? FridayPairingManifestError, .unsupportedKind("friday.other"))
+    }
+
+    let badKey = try decodeManifest(replacing: (String(repeating: "a", count: 64), "abcd"))
+    XCTAssertThrowsError(try badKey.validate()) { error in
+      XCTAssertEqual(
+        error as? FridayPairingManifestError,
+        .badHubPublicKey("hub public key must be 32 bytes"))
+    }
+
+    XCTAssertThrowsError(try manifest.pairingProof(forDevicePublicKey: [1, 2, 3])) { error in
+      XCTAssertEqual(error as? FridayCryptoError, .badLength("device public key must be 32 bytes"))
+    }
+  }
+
+  private func decodeManifest(replacing replacement: (String, String)? = nil) throws -> FridayPairingManifest {
+    var json = """
+      {
+        "kind": "friday.pairing.qr.v1",
+        "aad": "friday:pairing:ws:j1:qr-pair-session:aad:v1",
+        "hub_public_key_hex": "\(String(repeating: "a", count: 64))",
+        "v": 1,
+        "hub_id": "hub-local",
+        "pairing_id": "pair-123",
+        "pairing_secret": "\(fixturePairingSecret)",
+        "display_name": "Friday on Jarvis Mac",
+        "transport_hints": [
+          {"kind": "websocket", "endpoint": "ws://127.0.0.1:49152", "label": "Local pairing"}
+        ],
+        "expires_at": 1780650000000,
+        "capabilities_hint": ["status_only"]
+      }
+      """
+    if let replacement {
+      json = json.replacingOccurrences(of: replacement.0, with: replacement.1)
+    }
+    return try JSONDecoder().decode(FridayPairingManifest.self, from: Data(json.utf8))
+  }
+}


### PR DESCRIPTION
## Summary
- add a shared Swift `FridayPairingManifest` decoder for `hub_pairing_server --qr-json-out`
- expose redacted display projection so QR scan material is not logged/displayed with `pairing_secret`
- add HMAC-SHA256 `pairingProof(forDevicePublicKey:)` matching Rust `HMAC(qr_secret, device_pubkey)`

## Truth labels
- organic=0
- T3 bridge only: no socket, no trust DB write, no device enrollment claim
- QR manifest remains scan material; `pairing_secret` is intentionally decoded only for pairing proof and redacted from description/debug projection

## Verification
- swift test --package-path apps/macos/FridayRustClient --filter PairingManifestTests
- git diff --check
- swift format lint --recursive apps/macos/FridayRustClient 2>/dev/null || true