### PR TITLE
[codex] Add desktop operator approval relay

### DIFF
--- a/apps/macos/FridayHubConsole/Sources/FridayHubConsole/DesktopChatScreen.swift
+++ b/apps/macos/FridayHubConsole/Sources/FridayHubConsole/DesktopChatScreen.swift
@@ -346,7 +346,20 @@ struct DesktopChatScreen: View {
             .lineLimit(2)
         }
         if item.kind == "approval_required" {
-          Text("Approval remains operator-signature gated; this surface shows the signer refs and does not mint or relay a signature.")
+          HStack(spacing: 8) {
+            Button {
+              Task { await viewModel.approveNeedsMeItem(item) }
+            } label: {
+              Label("Approve", systemImage: "checkmark.seal")
+            }
+            .buttonStyle(.borderedProminent)
+            .tint(HubTheme.cyan)
+            .disabled(approvalRelayState(for: item).isSent)
+            .accessibilityLabel("Approve and relay operator signature")
+            .accessibilityIdentifier("friday.desktop.chat.approve.\(item.refId)")
+            approvalRelayStatus(for: item)
+          }
+          Text("Approval remains operator-signature gated; this surface relays an external signer blob and does not mint a signature.")
             .font(.system(size: 10))
             .foregroundStyle(HubTheme.textSecondary)
         }
@@ -354,6 +367,30 @@ struct DesktopChatScreen: View {
       .padding(.vertical, 6)
       .accessibilityElement(children: .combine)
       .accessibilityLabel("Needs review \(item.kind). \(item.title)")
+    }
+  }
+
+  private func approvalRelayState(for item: ChatNeedsMeItem) -> WriteActionState {
+    viewModel.approvalRelayStates[item.id] ?? .ready
+  }
+
+  @ViewBuilder
+  private func approvalRelayStatus(for item: ChatNeedsMeItem) -> some View {
+    switch approvalRelayState(for: item) {
+    case .ready:
+      EmptyView()
+    case .sent:
+      ProgressView().scaleEffect(0.7)
+    case let .confirmed(summary, _, _):
+      Text(summary)
+        .font(.system(size: 10))
+        .foregroundStyle(HubTheme.textSecondary)
+        .lineLimit(2)
+    case let .error(reason):
+      Text(reason)
+        .font(.system(size: 10))
+        .foregroundStyle(HubTheme.textSecondary)
+        .lineLimit(2)
     }
   }
 

--- a/apps/macos/FridayHubConsole/Sources/FridayHubConsole/FridayHubConsoleApp.swift
+++ b/apps/macos/FridayHubConsole/Sources/FridayHubConsole/FridayHubConsoleApp.swift
@@ -50,7 +50,9 @@ struct FridayHubConsoleApp: App {
       HubConsoleShell(
         client: Self.readClient,
         writeClient: Self.writeClient,
-        missionRunClient: Self.writeClient)
+        missionRunClient: Self.writeClient,
+        approvalSigner: Self.approvalSigner,
+        approvalResumeClient: Self.writeClient)
     }
     .windowStyle(.titleBar)
     .defaultSize(width: 1180, height: 720)
@@ -96,5 +98,11 @@ struct FridayHubConsoleApp: App {
     } catch {
       return RealWriteClientFactory.makeHonestlyUnavailableWrite(reason: "\(error)")
     }
+  }
+
+  /// Operator approval signer bridge. It invokes the external operator CLI only after the operator
+  /// clicks Approve; startup never reads or signs with the private key.
+  static var approvalSigner: OperatorApprovalSigner? {
+    useMock ? nil : OperatorApprovalCLISigner()
   }
 }

--- a/apps/macos/FridayHubConsole/Sources/FridayHubConsole/HubConsoleShell.swift
+++ b/apps/macos/FridayHubConsole/Sources/FridayHubConsole/HubConsoleShell.swift
@@ -13,13 +13,17 @@ struct HubConsoleShell: View {
   init(
     client: FridayRustReadClient,
     writeClient: FridayMissionSpineWriteClient? = nil,
-    missionRunClient: FridayMissionBoundRunWriteClient? = nil
+    missionRunClient: FridayMissionBoundRunWriteClient? = nil,
+    approvalSigner: OperatorApprovalSigner? = nil,
+    approvalResumeClient: FridayRustWriteClient? = nil
   ) {
     _operationsVM = StateObject(
       wrappedValue: OperationsOverviewViewModel(
         client: client,
         writeClient: writeClient,
-        missionRunClient: missionRunClient))
+        missionRunClient: missionRunClient,
+        approvalSigner: approvalSigner,
+        approvalResumeClient: approvalResumeClient))
   }
 
   var body: some View {

--- a/apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/OperationsOverviewViewModel.swift
+++ b/apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/OperationsOverviewViewModel.swift
@@ -222,6 +222,8 @@ public final class OperationsOverviewViewModel: ObservableObject {
   @Published public private(set) var memoryDecisionStates: [String: WriteActionState] = [:]
   /// Per-candidate A1 run-outcome learning decision state, keyed by candidate id.
   @Published public private(set) var runOutcomeLearningDecisionStates: [String: WriteActionState] = [:]
+  /// Per pending approval resume state, keyed by the Needs-Me item id.
+  @Published public private(set) var approvalRelayStates: [String: WriteActionState] = [:]
   /// Structured refs for the latest desktop Chat turn. This avoids parsing status prose in the UI.
   @Published public private(set) var latestChatTurn: ChatTurnRefs?
   /// Refs-only Needs-Me rows for the latest Chat turn's runs.
@@ -236,6 +238,9 @@ public final class OperationsOverviewViewModel: ObservableObject {
   /// Optional model-turn bridge. When present, a ready MissionIntake receipt immediately dispatches
   /// a read-only mission-bound run using the server-produced Mission handle.
   private let missionRunClient: FridayMissionBoundRunWriteClient?
+  /// Optional operator-controlled signer and resume client for paused mutating actions.
+  private let approvalSigner: OperatorApprovalSigner?
+  private let approvalResumeClient: FridayRustWriteClient?
   /// The owner principal the WRITE body self-supplies — MUST equal the server's `--owner`
   /// (`admin-001`); the server fail-closes a mismatch (FIX-Q3b). Wired from config, not UI input.
   private let writeOwnerPrincipal: String
@@ -243,23 +248,30 @@ public final class OperationsOverviewViewModel: ObservableObject {
   /// them). Injectable for deterministic tests.
   private let newId: @Sendable () -> String
   private let missionIdPrefix: String
+  private let nowMs: @Sendable () -> Int64
 
   public init(
     client: FridayRustReadClient,
     writeClient: FridayMissionSpineWriteClient? = nil,
     missionRunClient: FridayMissionBoundRunWriteClient? = nil,
+    approvalSigner: OperatorApprovalSigner? = nil,
+    approvalResumeClient: FridayRustWriteClient? = nil,
     writeOwnerPrincipal: String = liveReadProjectionOwnerPrincipal,
     devicePairing: DesktopDevicePairingReadiness = .evaluate(),
     newId: @escaping @Sendable () -> String = { UUID().uuidString },
-    missionIdPrefix: String = "mission-desktop-"
+    missionIdPrefix: String = "mission-desktop-",
+    nowMs: @escaping @Sendable () -> Int64 = { Int64(Date().timeIntervalSince1970 * 1000) }
   ) {
     self.client = client
     self.writeClient = writeClient
     self.missionRunClient = missionRunClient
+    self.approvalSigner = approvalSigner
+    self.approvalResumeClient = approvalResumeClient
     self.writeOwnerPrincipal = writeOwnerPrincipal
     self.devicePairing = devicePairing
     self.newId = newId
     self.missionIdPrefix = missionIdPrefix
+    self.nowMs = nowMs
   }
 
   /// Re-fetch the Workbench projection. The only mutating-looking action — and it
@@ -467,6 +479,58 @@ public final class OperationsOverviewViewModel: ObservableObject {
   private struct FollowUpDispatch {
     let summary: String
     let outcome: AgentRunDispatchOutcome
+  }
+
+  // MARK: - Operator approval resume relay
+
+  /// Sign and relay one pending operator approval from the desktop Needs Review queue.
+  ///
+  /// The app is only a courier: it hands refs to an injected signer, receives an opaque signed blob,
+  /// and relays that blob verbatim to the Rust write server. No key material or action body enters
+  /// the app, and a missing signer/resume client renders honest-unavailable.
+  public func approveNeedsMeItem(_ item: ChatNeedsMeItem) async {
+    let key = item.id
+    guard item.kind == "approval_required" || item.kind == "approval" else {
+      approvalRelayStates[key] = .error(reason: "This Needs Review row is not an operator approval.")
+      return
+    }
+    guard let actionDigest = item.actionDigest, !actionDigest.isEmpty else {
+      approvalRelayStates[key] = .error(reason: "Approval is missing action_digest; cannot sign.")
+      return
+    }
+    guard let approvalSigner, let approvalResumeClient else {
+      approvalRelayStates[key] = .error(
+        reason: "Operator signer relay not configured; approval remains paused.")
+      return
+    }
+
+    approvalRelayStates[key] = .sent
+    do {
+      let signedBlob = try await approvalSigner.signApproval(OperatorApprovalSigningRequest(
+        runId: item.runId,
+        approvalId: item.refId,
+        actionDigest: actionDigest,
+        summary: item.signingSummary ?? item.title,
+        expiresAtMs: nowMs() + 300_000))
+      let result = try await approvalResumeClient.resumeWithApproval(
+        runId: item.runId,
+        opaqueSignedBlob: signedBlob)
+      if result.accepted {
+        approvalRelayStates[key] = .confirmed(summary: Self.resumeSummary(for: result))
+        await refresh()
+        await loadLatestChatReview()
+      } else {
+        approvalRelayStates[key] = .error(reason: "Resume refused: \(Self.resumeSummary(for: result))")
+      }
+    } catch {
+      approvalRelayStates[key] = .error(reason: Self.writeReason(for: error))
+    }
+  }
+
+  private static func resumeSummary(for result: ResumeRelayResult) -> String {
+    var summary = "\(result.op) \(result.status) · run_id=\(result.runId)"
+    if let auditRef = result.auditRef { summary += " · audit_ref=\(auditRef)" }
+    return summary
   }
 
   private func answerBodyText(for outcome: AgentRunDispatchOutcome, label: String) async -> String? {

--- a/apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/OperatorApprovalSigner.swift
+++ b/apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/OperatorApprovalSigner.swift
@@ -1,0 +1,170 @@
+import Darwin
+import Foundation
+
+/// Refs-only approval material the desktop can hand to an operator-controlled signer.
+/// It contains no key material, tool body, session secret, or signature.
+public struct OperatorApprovalSigningRequest: Sendable, Equatable {
+  public let runId: String
+  public let approvalId: String
+  public let actionDigest: String
+  public let summary: String?
+  public let expiresAtMs: Int64
+  public let decision: String
+
+  public init(
+    runId: String,
+    approvalId: String,
+    actionDigest: String,
+    summary: String?,
+    expiresAtMs: Int64,
+    decision: String = "approved"
+  ) {
+    self.runId = runId
+    self.approvalId = approvalId
+    self.actionDigest = actionDigest
+    self.summary = summary
+    self.expiresAtMs = expiresAtMs
+    self.decision = decision
+  }
+}
+
+public protocol OperatorApprovalSigner: Sendable {
+  /// Returns the opaque `SignedApproval` JSON bytes the Hub verifies. The caller relays these
+  /// bytes verbatim; the app never inspects or mints a signature.
+  func signApproval(_ request: OperatorApprovalSigningRequest) async throws -> [UInt8]
+}
+
+public enum OperatorApprovalSignerError: Error, Sendable, Equatable, CustomStringConvertible {
+  case keyUnprovisioned
+  case invalidRequest(String)
+  case signerFailed(String)
+
+  public var description: String {
+    switch self {
+    case .keyUnprovisioned:
+      return "Operator approval key is not configured on this desktop signer"
+    case let .invalidRequest(reason):
+      return "Invalid approval request: \(reason)"
+    case let .signerFailed(reason):
+      return "Operator signer failed: \(reason)"
+    }
+  }
+}
+
+/// Desktop bridge to `friday-operator-approve sign`. It reads no key bytes itself; the external
+/// operator CLI owns key custody and emits only public signed-approval JSON on stdout.
+public struct OperatorApprovalCLISigner: OperatorApprovalSigner {
+  private let executablePath: String
+  private let keyPath: String?
+  private let tempDirectory: URL
+
+  public init(
+    executablePath: String? = ProcessInfo.processInfo.environment["FRIDAY_OPERATOR_APPROVE_BIN"],
+    keyPath: String? = ProcessInfo.processInfo.environment["FRIDAY_OPERATOR_APPROVE_KEY_PATH"],
+    tempDirectory: URL = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+  ) {
+    self.executablePath = executablePath?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
+      ?? "friday-operator-approve"
+    self.keyPath = keyPath?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
+    self.tempDirectory = tempDirectory
+  }
+
+  public func signApproval(_ request: OperatorApprovalSigningRequest) async throws -> [UInt8] {
+    guard let keyPath else { throw OperatorApprovalSignerError.keyUnprovisioned }
+    let requestFile = try writePendingRequest(request)
+    defer { try? FileManager.default.removeItem(at: requestFile) }
+    return try await runSigner(keyPath: keyPath, requestFile: requestFile)
+  }
+
+  private func writePendingRequest(_ request: OperatorApprovalSigningRequest) throws -> URL {
+    guard !request.runId.isEmpty else {
+      throw OperatorApprovalSignerError.invalidRequest("run_id must not be empty")
+    }
+    guard !request.approvalId.isEmpty else {
+      throw OperatorApprovalSignerError.invalidRequest("approval_id must not be empty")
+    }
+    guard request.actionDigest.range(of: #"^[0-9a-f]{64}$"#, options: .regularExpression) != nil else {
+      throw OperatorApprovalSignerError.invalidRequest("action_digest must be 64 lowercase hex chars")
+    }
+    guard request.expiresAtMs > 0 else {
+      throw OperatorApprovalSignerError.invalidRequest("expires_at must be positive")
+    }
+
+    let file = tempDirectory.appendingPathComponent("friday-approval-\(UUID().uuidString).json")
+    let payload = PendingApprovalRequestFile(
+      approvalId: request.approvalId,
+      actionDigest: request.actionDigest,
+      expiresAt: request.expiresAtMs,
+      decision: request.decision,
+      surface: "desktop",
+      summary: request.summary)
+    let data = try JSONEncoder().encode(payload)
+    guard FileManager.default.createFile(
+      atPath: file.path, contents: data,
+      attributes: [.posixPermissions: NSNumber(value: Int16(0o600))])
+    else {
+      throw OperatorApprovalSignerError.signerFailed("could not create temporary request file")
+    }
+    return file
+  }
+
+  private func runSigner(keyPath: String, requestFile: URL) async throws -> [UInt8] {
+    try await withCheckedThrowingContinuation { continuation in
+      let process = Process()
+      let stdout = Pipe()
+      let stderr = Pipe()
+      process.standardOutput = stdout
+      process.standardError = stderr
+
+      if executablePath.contains("/") {
+        process.executableURL = URL(fileURLWithPath: executablePath)
+        process.arguments = ["sign", "--key", keyPath, "--request", requestFile.path]
+      } else {
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+        process.arguments = [executablePath, "sign", "--key", keyPath, "--request", requestFile.path]
+      }
+
+      process.terminationHandler = { completed in
+        let out = stdout.fileHandleForReading.readDataToEndOfFile()
+        let err = stderr.fileHandleForReading.readDataToEndOfFile()
+        if completed.terminationStatus == 0, !out.isEmpty {
+          continuation.resume(returning: Array(out))
+        } else {
+          let stderrText = String(data: err, encoding: .utf8)?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+          continuation.resume(
+            throwing: OperatorApprovalSignerError.signerFailed(
+              stderrText?.nilIfEmpty ?? "exit \(completed.terminationStatus)"))
+        }
+      }
+
+      do {
+        try process.run()
+      } catch {
+        continuation.resume(throwing: OperatorApprovalSignerError.signerFailed(error.localizedDescription))
+      }
+    }
+  }
+}
+
+private struct PendingApprovalRequestFile: Encodable {
+  let approvalId: String
+  let actionDigest: String
+  let expiresAt: Int64
+  let decision: String
+  let surface: String
+  let summary: String?
+
+  enum CodingKeys: String, CodingKey {
+    case approvalId = "approval_id"
+    case actionDigest = "action_digest"
+    case expiresAt = "expires_at"
+    case decision, surface, summary
+  }
+}
+
+private extension String {
+  var nilIfEmpty: String? {
+    isEmpty ? nil : self
+  }
+}

--- a/apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/RealWriteClientFactory.swift
+++ b/apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/RealWriteClientFactory.swift
@@ -2,7 +2,7 @@ import Foundation
 import FridayRustClient
 
 public typealias FridayMissionSpineDispatchingWriteClient =
-  FridayMissionSpineWriteClient & FridayMissionBoundRunWriteClient
+  FridayMissionSpineWriteClient & FridayMissionBoundRunWriteClient & FridayRustWriteClient
 
 // MARK: - Real mission-spine WRITE-client factory (Lane-D entry-point-A organic driver)
 //
@@ -119,8 +119,17 @@ public enum RealWriteClientFactory {
 
 /// A `FridayMissionSpineWriteClient` that always throws — so the view model renders honest
 /// "unavailable". Never returns a result; it cannot fabricate a confirm.
-struct HonestlyUnavailableWriteClient: FridayMissionSpineWriteClient, FridayMissionBoundRunWriteClient {
+struct HonestlyUnavailableWriteClient: FridayMissionSpineWriteClient, FridayMissionBoundRunWriteClient, FridayRustWriteClient {
   let reason: String
+  func dispatchAgentRun(
+    task: String,
+    constraints: AgentRunConstraintsWire?
+  ) async throws -> AgentRunDispatchOutcome {
+    throw FridayWriteClientError.transport("live write client unavailable: \(reason)")
+  }
+  func resumeWithApproval(runId: String, opaqueSignedBlob: [UInt8]) async throws -> ResumeRelayResult {
+    throw FridayWriteClientError.transport("live write client unavailable: \(reason)")
+  }
   func submitMissionIntake(_ request: MissionIntakeRequestWire) async throws -> MissionIntakeResultWire {
     throw FridayWriteClientError.transport("live write client unavailable: \(reason)")
   }

--- a/apps/macos/FridayHubConsole/Tests/FridayHubConsoleCoreTests/OperationsOverviewViewModelTests.swift
+++ b/apps/macos/FridayHubConsole/Tests/FridayHubConsoleCoreTests/OperationsOverviewViewModelTests.swift
@@ -374,7 +374,7 @@ func realClientFactoryBuildsAgainstLoopbackConfig() {
 /// An in-memory `FridayMissionSpineWriteClient` for view-model tests. Returns a programmed
 /// intake/decision outcome, OR throws to exercise the honest-unavailable path. Captures the last
 /// request so a test can assert the owner_principal / decision the view model wired.
-final class MockMissionSpineWriteClient: FridayMissionSpineWriteClient, FridayMissionBoundRunWriteClient, @unchecked Sendable {
+final class MockMissionSpineWriteClient: FridayMissionSpineWriteClient, FridayMissionBoundRunWriteClient, FridayRustWriteClient, @unchecked Sendable {
   enum Behavior: Sendable {
     case intakeReady
     case intakeNeedsClarification
@@ -392,6 +392,8 @@ final class MockMissionSpineWriteClient: FridayMissionSpineWriteClient, FridayMi
   private var _lastLearningDecision: RunOutcomeLearningDecisionRequestWire?
   private var _lastMissionContext: MissionWorkItemContextWire?
   private var _lastMissionRunConstraints: AgentRunConstraintsWire?
+  private var _lastResumeRunId: String?
+  private var _lastResumeBlob: [UInt8]?
   private var _missionContexts: [MissionWorkItemContextWire] = []
   private var _dispatchedTasks: [String] = []
   var lastIntake: MissionIntakeRequestWire? { lock.withLock { _lastIntake } }
@@ -401,6 +403,8 @@ final class MockMissionSpineWriteClient: FridayMissionSpineWriteClient, FridayMi
   }
   var lastMissionContext: MissionWorkItemContextWire? { lock.withLock { _lastMissionContext } }
   var lastMissionRunConstraints: AgentRunConstraintsWire? { lock.withLock { _lastMissionRunConstraints } }
+  var lastResumeRunId: String? { lock.withLock { _lastResumeRunId } }
+  var lastResumeBlob: [UInt8]? { lock.withLock { _lastResumeBlob } }
   var missionContexts: [MissionWorkItemContextWire] { lock.withLock { _missionContexts } }
   var dispatchedTasks: [String] { lock.withLock { _dispatchedTasks } }
 
@@ -483,6 +487,48 @@ final class MockMissionSpineWriteClient: FridayMissionSpineWriteClient, FridayMi
       throw FridayWriteClientError.transport("connection refused (write server dark)")
     }
     return .result(AgentRunResultWire(runId: "run-bound-1", status: "completed", turns: 1))
+  }
+
+  func dispatchAgentRun(
+    task: String,
+    constraints: AgentRunConstraintsWire?
+  ) async throws -> AgentRunDispatchOutcome {
+    if case .throwsTransport = behavior {
+      throw FridayWriteClientError.transport("connection refused (write server dark)")
+    }
+    return .result(AgentRunResultWire(runId: "run-direct-1", status: "completed", turns: 1))
+  }
+
+  func resumeWithApproval(runId: String, opaqueSignedBlob: [UInt8]) async throws -> ResumeRelayResult {
+    lock.withLock {
+      _lastResumeRunId = runId
+      _lastResumeBlob = opaqueSignedBlob
+    }
+    if case .throwsTransport = behavior {
+      throw FridayWriteClientError.transport("connection refused (write server dark)")
+    }
+    if opaqueSignedBlob.isEmpty {
+      throw FridayWriteClientError.emptySignedBlob
+    }
+    return ResumeRelayResult(
+      runId: runId,
+      op: "resume",
+      accepted: true,
+      status: "mutation_completed",
+      auditRef: "audit://resume/1")
+  }
+}
+
+final class MockOperatorApprovalSigner: OperatorApprovalSigner, @unchecked Sendable {
+  private let lock = NSLock()
+  private(set) var lastRequest: OperatorApprovalSigningRequest?
+  var blob: [UInt8] = Array("{\"signed\":\"blob\"}".utf8)
+  var error: Error?
+
+  func signApproval(_ request: OperatorApprovalSigningRequest) async throws -> [UInt8] {
+    lock.withLock { lastRequest = request }
+    if let error { throw error }
+    return blob
   }
 }
 
@@ -903,6 +949,91 @@ func chatNeedsMeItemsParsesApprovalSigningRefsFromActionableRows() throws {
   #expect(approval?.refId == "approval-nonce-2")
   #expect(approval?.actionDigest == "digest-approval-nonce-2")
   #expect(approval?.signingSummary == "approval_required ready")
+}
+
+@Test
+@MainActor
+func approveNeedsMeItemSignsRefsAndRelaysOpaqueBlob() async {
+  let signer = MockOperatorApprovalSigner()
+  signer.blob = Array("{\"decision\":\"approved\"}".utf8)
+  let write = MockMissionSpineWriteClient(behavior: .intakeReady)
+  let item = ChatNeedsMeItem(
+    runId: "run-paused",
+    kind: "approval_required",
+    title: "approve write_file",
+    refId: "approval-nonce-9",
+    state: "pending",
+    deepLink: nil,
+    actionDigest: String(repeating: "a", count: 64),
+    signingSummary: "write_file paused")
+  let vm = OperationsOverviewViewModel(
+    client: MockReadClient(behavior: .loaded),
+    writeClient: write,
+    approvalSigner: signer,
+    approvalResumeClient: write,
+    nowMs: { 1_000 })
+
+  await vm.approveNeedsMeItem(item)
+
+  #expect(signer.lastRequest == OperatorApprovalSigningRequest(
+    runId: "run-paused",
+    approvalId: "approval-nonce-9",
+    actionDigest: String(repeating: "a", count: 64),
+    summary: "write_file paused",
+    expiresAtMs: 301_000))
+  #expect(write.lastResumeRunId == "run-paused")
+  #expect(write.lastResumeBlob == Array("{\"decision\":\"approved\"}".utf8))
+  guard case let .confirmed(summary, _, _) = vm.approvalRelayStates[item.id] else {
+    Issue.record("expected approval relay .confirmed, got \(String(describing: vm.approvalRelayStates[item.id]))")
+    return
+  }
+  #expect(summary.contains("mutation_completed"))
+  #expect(summary.contains("audit://resume/1"))
+}
+
+@Test
+@MainActor
+func approveNeedsMeItemWithoutSignerFailsClosedWithoutResume() async {
+  let write = MockMissionSpineWriteClient(behavior: .intakeReady)
+  let item = ChatNeedsMeItem(
+    runId: "run-paused",
+    kind: "approval_required",
+    title: "approve write_file",
+    refId: "approval-nonce-9",
+    state: "pending",
+    deepLink: nil,
+    actionDigest: String(repeating: "a", count: 64),
+    signingSummary: "write_file paused")
+  let vm = OperationsOverviewViewModel(
+    client: MockReadClient(behavior: .loaded),
+    approvalResumeClient: write)
+
+  await vm.approveNeedsMeItem(item)
+
+  guard case let .error(reason) = vm.approvalRelayStates[item.id] else {
+    Issue.record("expected approval relay .error, got \(String(describing: vm.approvalRelayStates[item.id]))")
+    return
+  }
+  #expect(reason.contains("not configured"))
+  #expect(write.lastResumeRunId == nil)
+}
+
+@Test
+func operatorApprovalCLISignerRejectsMalformedDigestBeforeInvokingSigner() async {
+  let signer = OperatorApprovalCLISigner(keyPath: "/tmp/not-read-in-this-test")
+  do {
+    _ = try await signer.signApproval(OperatorApprovalSigningRequest(
+      runId: "run-x",
+      approvalId: "approval-x",
+      actionDigest: "not-a-digest",
+      summary: nil,
+      expiresAtMs: 1_000))
+    Issue.record("malformed digest must fail closed")
+  } catch let error as OperatorApprovalSignerError {
+    #expect(error.description.contains("action_digest"))
+  } catch {
+    Issue.record("unexpected error \(error)")
+  }
 }
 
 @Test

--- a/apps/macos/FridayRustClient/Sources/FridayRustClient/WriteClient.swift
+++ b/apps/macos/FridayRustClient/Sources/FridayRustClient/WriteClient.swift
@@ -138,7 +138,7 @@ public enum FridayWriteClientError: Error, Equatable {
 
 /// The product-facing WRITE client. A UI depends on THIS, not the transport. It dispatches an
 /// agent-run (the chat read-WRITE loop) and relays an operator-signed resume.
-public protocol FridayRustWriteClient {
+public protocol FridayRustWriteClient: Sendable {
   /// Dispatch one agent-run over the sealed-WS WRITE seam. `constraints` DEFAULT read-only /
   /// no-grant (the mutation is operator-gated downstream). Settles refs-only on the first
   /// `AgentRunResult`, or `.paused` when the run-control flag is on AND the server pauses.


### PR DESCRIPTION
## Summary
- add a desktop OperatorApprovalSigner bridge that invokes `friday-operator-approve sign` only after an operator approval action
- wire Desktop Chat Needs Review approval rows to sign refs-only material and relay the opaque signed blob via the existing sealed write client resume path
- keep Hub verify-only and preserve honest-unavailable when signer/write relay is not configured

## Truth labels
- mechanism wired, not organic/live-done
- app never reads key bytes or mints signatures; external operator CLI owns key custody
- default/no signer path fail-closes and does not resume paused mutations

## Tests
- `swift test --package-path apps/macos/FridayHubConsole --filter OperationsOverviewViewModelTests`
- `git diff --check origin/main...HEAD`
- `detect-secrets-hook --baseline .secrets.baseline ...`