### PR TITLE
Add Swift pairing sealed client

### DIFF
--- a/apps/macos/FridayRustClient/Sources/FridayRustClient/PairingClient.swift
+++ b/apps/macos/FridayRustClient/Sources/FridayRustClient/PairingClient.swift
@@ -1,0 +1,168 @@
+import Foundation
+
+/// Product-facing pairing client for the QR pairing channel.
+///
+/// This client is intentionally narrow: it can ask for `HubStatus` and send exactly one `Pair`
+/// request derived from a scanned QR manifest. It does not mint trust grants, context passports, or
+/// signatures; those remain operator ceremonies outside the app/agent key boundary.
+public protocol FridayPairingClient: Sendable {
+  func fetchHubStatus(manifest: FridayPairingManifest) async throws -> PairingHubStatusWire
+  func pairDevice(manifest: FridayPairingManifest, deviceId: String) async throws -> PairingPairAckWire
+}
+
+public enum FridayPairingClientError: Error, Equatable {
+  case badServerPubkey
+  case serverPubkeyMismatch
+  case badSessionNonce
+  case serverError(code: FridayErrorCode, message: String)
+  case unexpectedResponse(kind: String)
+  case transport(String)
+}
+
+/// Sealed-WS client for `hub_pairing_server`.
+public final class SealedWSPairingClient: FridayPairingClient, @unchecked Sendable {
+  private let keypair: FridayCrypto.DeviceKeypair
+  private let makeTransport: () throws -> SealedWSTransport
+  private let now: () -> Int64
+  private let newMessageId: () -> String
+
+  public init(
+    keypair: FridayCrypto.DeviceKeypair,
+    makeTransport: @escaping () throws -> SealedWSTransport,
+    now: @escaping () -> Int64 = { Int64(Date().timeIntervalSince1970 * 1000) },
+    newMessageId: @escaping () -> String = { "pair-\(UUID().uuidString)" }
+  ) {
+    self.keypair = keypair
+    self.makeTransport = makeTransport
+    self.now = now
+    self.newMessageId = newMessageId
+  }
+
+  public func fetchHubStatus(manifest: FridayPairingManifest) async throws -> PairingHubStatusWire {
+    let response = try sendPairingMessage(manifest: manifest, message: .hubStatus(PairingHubStatusWire(
+      online: true,
+      capabilities: [],
+      minVersion: manifest.version,
+      maxVersion: manifest.version
+    )))
+    switch response {
+    case .hubStatus(let status):
+      return status
+    case .error(let code, let message):
+      throw FridayPairingClientError.serverError(code: code, message: message)
+    default:
+      throw FridayPairingClientError.unexpectedResponse(kind: pairingKind(response))
+    }
+  }
+
+  public func pairDevice(manifest: FridayPairingManifest, deviceId: String) async throws -> PairingPairAckWire {
+    let proof = try manifest.pairingProof(forDevicePublicKey: keypair.publicKey)
+    let response = try sendPairingMessage(manifest: manifest, message: .pair(PairingPairWire(
+      deviceId: deviceId,
+      devicePubkey: keypair.publicKey,
+      pairingProof: proof
+    )))
+    switch response {
+    case .pairAck(let ack):
+      return ack
+    case .error(let code, let message):
+      throw FridayPairingClientError.serverError(code: code, message: message)
+    default:
+      throw FridayPairingClientError.unexpectedResponse(kind: pairingKind(response))
+    }
+  }
+
+  private func sendPairingMessage(manifest: FridayPairingManifest, message: FridayMessage) throws -> FridayMessage {
+    try manifest.validate(nowMs: now())
+    let aad = Array(manifest.aad.utf8)
+    let transport = try makeTransport()
+
+    try transport.writeFrame(keypair.publicKey)
+    let serverPub = try transport.readFrame()
+    guard serverPub.count == FridayCrypto.x25519PublicKeyLen else {
+      throw FridayPairingClientError.badServerPubkey
+    }
+    guard serverPub == (try manifest.hubPublicKey) else {
+      throw FridayPairingClientError.serverPubkeyMismatch
+    }
+    let sessionNonce = try transport.readFrame()
+    guard sessionNonce.count == 64 else {
+      throw FridayPairingClientError.badSessionNonce
+    }
+    try transport.upgrade()
+
+    let sessionKey: [UInt8]
+    do {
+      sessionKey = try keypair.agree(peerPublicKey: serverPub)
+    } catch {
+      throw FridayPairingClientError.transport("session-key agreement failed: \(error)")
+    }
+
+    let msgId = newMessageId()
+    let env = FridayEnvelope(msgId: msgId, sentAt: now(), message: message)
+    try transport.sendMessage(try sealEnvelope(env, sessionKey: sessionKey, aad: aad))
+
+    let respBody: [UInt8]
+    do {
+      respBody = try transport.recvMessage()
+    } catch {
+      throw FridayPairingClientError.transport("no pairing response (session ended fail-closed): \(error)")
+    }
+    return try openEnvelope(respBody, sessionKey: sessionKey, aad: aad).message
+  }
+
+  private func sealEnvelope(_ env: FridayEnvelope, sessionKey: [UInt8], aad: [UInt8]) throws -> [UInt8] {
+    let sealed = try FridayCrypto.seal(key: sessionKey, plaintext: [UInt8](env.encodeJSON()), aad: aad)
+    return FridayCrypto.encodeSealed(sealed)
+  }
+
+  private func openEnvelope(_ body: [UInt8], sessionKey: [UInt8], aad: [UInt8]) throws -> FridayEnvelope {
+    let sealed = try FridayCrypto.decodeSealed(body)
+    let pt: [UInt8]
+    do {
+      pt = try FridayCrypto.open(key: sessionKey, sealed: sealed, aad: aad)
+    } catch {
+      throw FridayPairingClientError.transport("pairing envelope failed to open (fail-closed): \(error)")
+    }
+    return try FridayEnvelope.decodeJSON(Data(pt))
+  }
+}
+
+private func pairingKind(_ message: FridayMessage) -> String {
+  switch message {
+  case .pair: return "Pair"
+  case .pairAck: return "PairAck"
+  case .hubStatus: return "HubStatus"
+  case .error: return "Error"
+  case .unsupported(let kind): return kind
+  case .workbenchProjectionRequest: return "WorkbenchProjectionRequest"
+  case .workbenchProjectionSnapshot: return "WorkbenchProjectionSnapshot"
+  case .runReadbackRequest: return "RunReadbackRequest"
+  case .runReadbackSnapshot: return "RunReadbackSnapshot"
+  case .providersDoctorRequest: return "ProvidersDoctorRequest"
+  case .providersDoctorSnapshot: return "ProvidersDoctorSnapshot"
+  case .sessionListRequest: return "SessionListRequest"
+  case .sessionListSnapshot: return "SessionListSnapshot"
+  case .sessionOpenRequest: return "SessionOpenRequest"
+  case .sessionOpenSnapshot: return "SessionOpenSnapshot"
+  case .sessionLinkStateRequest: return "SessionLinkStateRequest"
+  case .sessionLinkStateSnapshot: return "SessionLinkStateSnapshot"
+  case .runFileViewRequest: return "RunFileViewRequest"
+  case .runFileViewSnapshot: return "RunFileViewSnapshot"
+  case .activityNeedsMeRequest: return "ActivityNeedsMeRequest"
+  case .activityNeedsMeSnapshot: return "ActivityNeedsMeSnapshot"
+  case .agentRunRequest: return "AgentRunRequest"
+  case .agentRunResult: return "AgentRunResult"
+  case .agentRunPaused: return "AgentRunPaused"
+  case .agentRunResume: return "AgentRunResume"
+  case .agentRunControlResult: return "AgentRunControlResult"
+  case .missionIntakeRequest: return "MissionIntakeRequest"
+  case .missionIntakeResult: return "MissionIntakeResult"
+  case .memoryDecisionRequest: return "MemoryDecisionRequest"
+  case .memoryDecisionResult: return "MemoryDecisionResult"
+  case .runOutcomeLearningDecisionRequest: return "RunOutcomeLearningDecisionRequest"
+  case .runOutcomeLearningDecisionResult: return "RunOutcomeLearningDecisionResult"
+  case .runAnswerBodyRequest: return "RunAnswerBodyRequest"
+  case .runAnswerBodySnapshot: return "RunAnswerBodySnapshot"
+  }
+}

--- a/apps/macos/FridayRustClient/Sources/FridayRustClient/Protocol.swift
+++ b/apps/macos/FridayRustClient/Sources/FridayRustClient/Protocol.swift
@@ -28,6 +28,51 @@ public enum FridayErrorCode: String, Codable, Equatable, Sendable {
   case `internal` = "INTERNAL"
 }
 
+// MARK: - Pairing wire types
+
+/// phone→hub QR pairing request. Mirrors `friday_protocol::Message::Pair`.
+///
+/// This carries the device's public key plus `HMAC(qr_secret, device_pubkey)` proof; it never
+/// carries the raw QR secret. `Vec<u8>` fields serialize as JSON arrays of byte numbers.
+public struct PairingPairWire: Equatable, Sendable {
+  public var deviceId: String
+  public var devicePubkey: [UInt8]
+  public var pairingProof: [UInt8]
+
+  public init(deviceId: String, devicePubkey: [UInt8], pairingProof: [UInt8]) {
+    self.deviceId = deviceId
+    self.devicePubkey = devicePubkey
+    self.pairingProof = pairingProof
+  }
+}
+
+/// hub→phone QR pairing acknowledgement. Mirrors `friday_protocol::Message::PairAck`.
+public struct PairingPairAckWire: Equatable, Sendable {
+  public var accepted: Bool
+  public var errorCode: FridayErrorCode?
+
+  public init(accepted: Bool, errorCode: FridayErrorCode? = nil) {
+    self.accepted = accepted
+    self.errorCode = errorCode
+  }
+}
+
+/// hub→phone status frame available on the pairing channel. Mirrors
+/// `friday_protocol::Message::HubStatus`; it is refs/capabilities only, never a model call.
+public struct PairingHubStatusWire: Equatable, Sendable {
+  public var online: Bool
+  public var capabilities: [String]
+  public var minVersion: UInt16
+  public var maxVersion: UInt16
+
+  public init(online: Bool, capabilities: [String], minVersion: UInt16, maxVersion: UInt16) {
+    self.online = online
+    self.capabilities = capabilities
+    self.minVersion = minVersion
+    self.maxVersion = maxVersion
+  }
+}
+
 // MARK: - WorkbenchProjection wire types
 
 /// Client→read-server request for the Mission Workbench read projection. Mirrors
@@ -374,6 +419,15 @@ public struct ActivityNeedsMeSnapshotWire: Codable, Equatable, Sendable {
 /// `WorkbenchProjectionRequest` and only decodes a `WorkbenchProjectionSnapshot` or an
 /// `Error` — every other inbound kind is surfaced as `.unsupported`, never silently dropped.
 public enum FridayMessage: Equatable {
+  // MARK: - Pairing seam (T3 zero-config QR provisioning)
+
+  /// phone→hub: complete QR pairing handshake. Flattened serde struct-variant shape.
+  case pair(PairingPairWire)
+  /// hub→phone: accept/deny pairing. Flattened serde struct-variant shape.
+  case pairAck(PairingPairAckWire)
+  /// hub→phone: status/capability frame on the pairing channel. No model/provider call.
+  case hubStatus(PairingHubStatusWire)
+
   case workbenchProjectionRequest(WorkbenchProjectionRequestWire)
   case workbenchProjectionSnapshot(WorkbenchProjectionSnapshotWire)
   case error(code: FridayErrorCode, message: String)
@@ -477,12 +531,47 @@ extension FridayMessage: Codable {
     case op
     case accepted
     case auditRef = "audit_ref"
+    case deviceId = "device_id"
+    case devicePubkey = "device_pubkey"
+    case pairingProof = "pairing_proof"
+    case errorCode = "error_code"
+    case online
+    case capabilities
+    case minVersion = "min_version"
+    case maxVersion = "max_version"
   }
 
   public init(from decoder: Decoder) throws {
     let tag = try decoder.container(keyedBy: TagKey.self)
     let kind = try tag.decode(String.self, forKey: .kind)
     switch kind {
+    case "Pair":
+      let c = try decoder.container(keyedBy: WriteKey.self)
+      self = .pair(
+        PairingPairWire(
+          deviceId: try c.decode(String.self, forKey: .deviceId),
+          devicePubkey: try c.decode([UInt8].self, forKey: .devicePubkey),
+          pairingProof: try c.decode([UInt8].self, forKey: .pairingProof)
+        )
+      )
+    case "PairAck":
+      let c = try decoder.container(keyedBy: WriteKey.self)
+      self = .pairAck(
+        PairingPairAckWire(
+          accepted: try c.decode(Bool.self, forKey: .accepted),
+          errorCode: try c.decodeIfPresent(FridayErrorCode.self, forKey: .errorCode)
+        )
+      )
+    case "HubStatus":
+      let c = try decoder.container(keyedBy: WriteKey.self)
+      self = .hubStatus(
+        PairingHubStatusWire(
+          online: try c.decode(Bool.self, forKey: .online),
+          capabilities: try c.decode([String].self, forKey: .capabilities),
+          minVersion: try c.decode(UInt16.self, forKey: .minVersion),
+          maxVersion: try c.decode(UInt16.self, forKey: .maxVersion)
+        )
+      )
     case "WorkbenchProjectionSnapshot":
       let c = try decoder.container(keyedBy: SnapshotKey.self)
       self = .workbenchProjectionSnapshot(try c.decode(WorkbenchProjectionSnapshotWire.self, forKey: .snapshot))
@@ -616,6 +705,26 @@ extension FridayMessage: Codable {
   public func encode(to encoder: Encoder) throws {
     var tag = encoder.container(keyedBy: TagKey.self)
     switch self {
+    case .pair(let p):
+      var c = encoder.container(keyedBy: WriteKey.self)
+      try c.encode("Pair", forKey: .kind)
+      try c.encode(p.deviceId, forKey: .deviceId)
+      try c.encode(p.devicePubkey, forKey: .devicePubkey)
+      try c.encode(p.pairingProof, forKey: .pairingProof)
+    case .pairAck(let a):
+      var c = encoder.container(keyedBy: WriteKey.self)
+      try c.encode("PairAck", forKey: .kind)
+      try c.encode(a.accepted, forKey: .accepted)
+      if let errorCode = a.errorCode {
+        try c.encode(errorCode, forKey: .errorCode)
+      }
+    case .hubStatus(let s):
+      var c = encoder.container(keyedBy: WriteKey.self)
+      try c.encode("HubStatus", forKey: .kind)
+      try c.encode(s.online, forKey: .online)
+      try c.encode(s.capabilities, forKey: .capabilities)
+      try c.encode(s.minVersion, forKey: .minVersion)
+      try c.encode(s.maxVersion, forKey: .maxVersion)
     case .workbenchProjectionRequest(let req):
       try tag.encode("WorkbenchProjectionRequest", forKey: .kind)
       var c = encoder.container(keyedBy: RequestKey.self)

--- a/apps/macos/FridayRustClient/Sources/FridayRustClient/ReadClient.swift
+++ b/apps/macos/FridayRustClient/Sources/FridayRustClient/ReadClient.swift
@@ -224,6 +224,12 @@ public final class SealedWSReadClient: FridayRustReadClient, @unchecked Sendable
       throw FridayReadClientError.unexpectedResponse(kind: "AgentRunResume")
     case .agentRunControlResult:
       throw FridayReadClientError.unexpectedResponse(kind: "AgentRunControlResult")
+    case .pair:
+      throw FridayReadClientError.unexpectedResponse(kind: "Pair")
+    case .pairAck:
+      throw FridayReadClientError.unexpectedResponse(kind: "PairAck")
+    case .hubStatus:
+      throw FridayReadClientError.unexpectedResponse(kind: "HubStatus")
     // The mission-spine WRITE variants share the `FridayMessage` enum but are NEVER answers a READ
     // server gives — surface them as unexpected (the read seam only answers a snapshot / Error).
     case .missionIntakeRequest:
@@ -325,6 +331,12 @@ public final class SealedWSReadClient: FridayRustReadClient, @unchecked Sendable
       throw FridayReadClientError.unexpectedResponse(kind: "AgentRunResume")
     case .agentRunControlResult:
       throw FridayReadClientError.unexpectedResponse(kind: "AgentRunControlResult")
+    case .pair:
+      throw FridayReadClientError.unexpectedResponse(kind: "Pair")
+    case .pairAck:
+      throw FridayReadClientError.unexpectedResponse(kind: "PairAck")
+    case .hubStatus:
+      throw FridayReadClientError.unexpectedResponse(kind: "HubStatus")
     case .missionIntakeRequest:
       throw FridayReadClientError.unexpectedResponse(kind: "MissionIntakeRequest")
     case .missionIntakeResult:

--- a/apps/macos/FridayRustClient/Sources/FridayRustClient/WriteClient.swift
+++ b/apps/macos/FridayRustClient/Sources/FridayRustClient/WriteClient.swift
@@ -332,6 +332,7 @@ public final class SealedWSWriteClient: FridayRustWriteClient, FridayMissionSpin
     case .error(let code, let message):
       throw FridayWriteClientError.serverError(code: code, message: message)
     case .agentRunRequest, .agentRunResume, .agentRunControlResult,
+         .pair, .pairAck, .hubStatus,
          .workbenchProjectionRequest, .workbenchProjectionSnapshot,
          .runReadbackRequest, .runReadbackSnapshot,
          .runAnswerBodyRequest, .runAnswerBodySnapshot,
@@ -569,6 +570,9 @@ private func dispatchKind(_ message: FridayMessage) -> String {
   case .sessionOpenSnapshot: return "SessionOpenSnapshot"
   case .sessionLinkStateRequest: return "SessionLinkStateRequest"
   case .sessionLinkStateSnapshot: return "SessionLinkStateSnapshot"
+  case .pair: return "Pair"
+  case .pairAck: return "PairAck"
+  case .hubStatus: return "HubStatus"
   case .runFileViewRequest: return "RunFileViewRequest"
   case .runFileViewSnapshot: return "RunFileViewSnapshot"
   case .activityNeedsMeRequest: return "ActivityNeedsMeRequest"

--- a/apps/macos/FridayRustClient/Tests/FridayRustClientTests/PairingClientWiringTests.swift
+++ b/apps/macos/FridayRustClient/Tests/FridayRustClientTests/PairingClientWiringTests.swift
@@ -1,0 +1,246 @@
+import XCTest
+@testable import FridayRustClient
+
+/// T3 pairing-client wiring tests over an in-memory `hub_pairing_server` facsimile.
+///
+/// HONEST LABEL: wiring-only. The Rust protocol shapes and HMAC proof are covered by the KATs; this
+/// proves the Swift client sequences the sealed pairing session, validates the QR hub key, sends no
+/// raw QR secret, and fail-closes outside `PairAck`/`HubStatus`.
+final class PairingClientWiringTests: XCTestCase {
+  enum ServerMode {
+    case status
+    case acceptPair
+    case denyPair
+    case wrongKind
+  }
+
+  final class EmulatedPairingServerTransport: SealedWSTransport {
+    private let serverKeypair: FridayCrypto.DeviceKeypair
+    private let sessionNonce: [UInt8]
+    private let aad: [UInt8]
+    private let mode: ServerMode
+
+    private var clientPub: [UInt8]?
+    private var sessionKey: [UInt8]?
+    private var upgraded = false
+    private var queuedFromServer: [[UInt8]] = []
+    private(set) var receivedPair: PairingPairWire?
+
+    init(
+      serverKeypair: FridayCrypto.DeviceKeypair,
+      sessionNonce: [UInt8],
+      aad: [UInt8],
+      mode: ServerMode
+    ) {
+      self.serverKeypair = serverKeypair
+      self.sessionNonce = sessionNonce
+      self.aad = aad
+      self.mode = mode
+    }
+
+    func writeFrame(_ payload: [UInt8]) throws {
+      if clientPub == nil {
+        clientPub = payload
+        queuedFromServer.append(serverKeypair.publicKey)
+        queuedFromServer.append(sessionNonce)
+      }
+    }
+
+    func readFrame() throws -> [UInt8] {
+      guard !queuedFromServer.isEmpty else {
+        throw FridayPairingClientError.transport("no preamble frame queued")
+      }
+      return queuedFromServer.removeFirst()
+    }
+
+    func upgrade() throws {
+      guard let clientPub else {
+        throw FridayPairingClientError.transport("no client pubkey before upgrade")
+      }
+      sessionKey = try serverKeypair.agree(peerPublicKey: clientPub)
+      upgraded = true
+    }
+
+    func sendMessage(_ body: [UInt8]) throws {
+      guard upgraded, let sessionKey else {
+        throw FridayPairingClientError.transport("not upgraded")
+      }
+      let env = try FridayEnvelope.decodeJSON(Data(try FridayCrypto.open(
+        key: sessionKey,
+        sealed: FridayCrypto.decodeSealed(body),
+        aad: aad
+      )))
+      let response: FridayMessage
+      switch env.message {
+      case .hubStatus:
+        response = .hubStatus(PairingHubStatusWire(
+          online: true,
+          capabilities: ["pairing", "read_seam_enroll"],
+          minVersion: 1,
+          maxVersion: 13
+        ))
+      case .pair(let pair):
+        receivedPair = pair
+        switch mode {
+        case .acceptPair:
+          response = .pairAck(PairingPairAckWire(accepted: true))
+        case .denyPair:
+          response = .pairAck(PairingPairAckWire(accepted: false, errorCode: .pairingDenied))
+        case .wrongKind:
+          response = .agentRunResult(AgentRunResultWire(
+            runId: "not-pairing",
+            status: "completed",
+            answerSha256: String(repeating: "a", count: 64),
+            answerLen: 1,
+            turns: 1,
+            executedTools: 0
+          ))
+        case .status:
+          response = .hubStatus(PairingHubStatusWire(
+            online: true,
+            capabilities: ["pairing"],
+            minVersion: 1,
+            maxVersion: 13
+          ))
+        }
+      default:
+        response = .error(code: .internal, message: "unsupported pairing message")
+      }
+      let resp = FridayEnvelope(
+        msgId: "\(env.msgId)-response",
+        sentAt: 1_780_640_000_000,
+        message: response
+      ).withCorrelation(env.msgId)
+      queuedFromServer.append(try FridayCrypto.encodeSealed(FridayCrypto.seal(
+        key: sessionKey,
+        plaintext: [UInt8](resp.encodeJSON()),
+        aad: aad
+      )))
+    }
+
+    func recvMessage() throws -> [UInt8] {
+      guard !queuedFromServer.isEmpty else {
+        throw FridayPairingClientError.transport("session ended (no response)")
+      }
+      return queuedFromServer.removeFirst()
+    }
+  }
+
+  func testFetchHubStatusValidatesManifestHubKeyAndDecodesStatus() async throws {
+    let fixture = try makeFixture(mode: .status)
+    let status = try await fixture.client.fetchHubStatus(manifest: fixture.manifest)
+    XCTAssertTrue(status.online)
+    XCTAssertEqual(status.capabilities, ["pairing", "read_seam_enroll"])
+    XCTAssertEqual(status.minVersion, 1)
+    XCTAssertEqual(status.maxVersion, 13)
+  }
+
+  func testPairDeviceSendsProofAndNeverSendsRawSecret() async throws {
+    let fixture = try makeFixture(mode: .acceptPair)
+    let ack = try await fixture.client.pairDevice(manifest: fixture.manifest, deviceId: "ios-device-1")
+    XCTAssertEqual(ack, PairingPairAckWire(accepted: true))
+
+    let pair = try XCTUnwrap(fixture.transport.receivedPair)
+    XCTAssertEqual(pair.deviceId, "ios-device-1")
+    XCTAssertEqual(pair.devicePubkey, fixture.clientKeypair.publicKey)
+    XCTAssertEqual(pair.pairingProof, try fixture.manifest.pairingProof(forDevicePublicKey: fixture.clientKeypair.publicKey))
+    XCTAssertNotEqual(pair.pairingProof, Array(fixture.rawPairingSecret.utf8))
+  }
+
+  func testPairDeviceReturnsDeniedAckWithoutPromotingItToSuccess() async throws {
+    let fixture = try makeFixture(mode: .denyPair)
+    let ack = try await fixture.client.pairDevice(manifest: fixture.manifest, deviceId: "ios-device-1")
+    XCTAssertEqual(ack, PairingPairAckWire(accepted: false, errorCode: .pairingDenied))
+  }
+
+  func testPairDeviceRejectsManifestServerKeyMismatchBeforeSendingPair() async throws {
+    var fixture = try makeFixture(mode: .acceptPair)
+    let wrongHub = try FridayCrypto.DeviceKeypair(secretBytes: Array(repeating: 7, count: 32))
+    fixture.manifest = try makeManifest(
+      hubPublicKey: wrongHub.publicKey,
+      pairingSecret: fixture.rawPairingSecret,
+      expiresAt: 1_900_000_000_000
+    )
+
+    do {
+      _ = try await fixture.client.pairDevice(manifest: fixture.manifest, deviceId: "ios-device-1")
+      XCTFail("expected server pubkey mismatch")
+    } catch {
+      XCTAssertEqual(error as? FridayPairingClientError, .serverPubkeyMismatch)
+    }
+    XCTAssertNil(fixture.transport.receivedPair)
+  }
+
+  func testPairDeviceFailsClosedOnUnexpectedResponseKind() async throws {
+    let fixture = try makeFixture(mode: .wrongKind)
+    do {
+      _ = try await fixture.client.pairDevice(manifest: fixture.manifest, deviceId: "ios-device-1")
+      XCTFail("expected unexpected response")
+    } catch {
+      XCTAssertEqual(error as? FridayPairingClientError, .unexpectedResponse(kind: "AgentRunResult"))
+    }
+  }
+
+  private struct Fixture {
+    var manifest: FridayPairingManifest
+    let client: SealedWSPairingClient
+    let transport: EmulatedPairingServerTransport
+    let clientKeypair: FridayCrypto.DeviceKeypair
+    let rawPairingSecret: String
+  }
+
+  private func makeFixture(mode: ServerMode) throws -> Fixture {
+    let clientKp = try FridayCrypto.DeviceKeypair(secretBytes: try Hex.decode(B1KAT.k1Agree.clientSecret))
+    let serverKp = try FridayCrypto.DeviceKeypair(secretBytes: try Hex.decode(B1KAT.k1Agree.serverSecret))
+    let secret = "qr-secret-1234567890" // pragma: allowlist secret
+    let manifest = try makeManifest(
+      hubPublicKey: serverKp.publicKey,
+      pairingSecret: secret,
+      expiresAt: 1_900_000_000_000
+    )
+    let transport = EmulatedPairingServerTransport(
+      serverKeypair: serverKp,
+      sessionNonce: try Hex.decode(B1KAT.k3Auth.sessionNonce),
+      aad: Array(manifest.aad.utf8),
+      mode: mode
+    )
+    let client = SealedWSPairingClient(
+      keypair: clientKp,
+      makeTransport: { transport },
+      now: { 1_780_640_000_000 },
+      newMessageId: { "pair-wiring-1" }
+    )
+    return Fixture(
+      manifest: manifest,
+      client: client,
+      transport: transport,
+      clientKeypair: clientKp,
+      rawPairingSecret: secret
+    )
+  }
+
+  private func makeManifest(
+    hubPublicKey: [UInt8],
+    pairingSecret: String,
+    expiresAt: Int64
+  ) throws -> FridayPairingManifest {
+    let json = """
+      {
+        "kind": "friday.pairing.qr.v1",
+        "aad": "friday:pairing:ws:j1:qr-pair-session:aad:v1",
+        "hub_public_key_hex": "\(Hex.encode(hubPublicKey))",
+        "v": 1,
+        "hub_id": "hub-local-1",
+        "pairing_id": "pair-123",
+        "pairing_secret": "\(pairingSecret)",
+        "display_name": "Friday Local Hub",
+        "transport_hints": [
+          {"kind": "websocket", "endpoint": "ws://127.0.0.1:49152", "label": "Local pairing"}
+        ],
+        "expires_at": \(expiresAt),
+        "capabilities_hint": ["pairing", "read_seam_enroll"]
+      }
+      """
+    return try JSONDecoder().decode(FridayPairingManifest.self, from: Data(json.utf8))
+  }
+}

--- a/apps/macos/FridayRustClient/Tests/FridayRustClientTests/PairingWireKATTests.swift
+++ b/apps/macos/FridayRustClient/Tests/FridayRustClientTests/PairingWireKATTests.swift
@@ -1,0 +1,68 @@
+import XCTest
+@testable import FridayRustClient
+
+/// T3 pairing wire contract tests. These lock the Swift client to the Rust
+/// `friday_protocol::Message::{Pair,PairAck,HubStatus}` serde shapes before a socket client is
+/// allowed to write `trusted_device` through `hub_pairing_server`.
+final class PairingWireKATTests: XCTestCase {
+  func testPairMessageWireContractIsRefsAndProofOnly() throws {
+    let pair = PairingPairWire(
+      deviceId: "device-ios-1",
+      devicePubkey: Array(0..<32),
+      pairingProof: Array(32..<64))
+    let env = FridayEnvelope(msgId: "pair-1", sentAt: 7, message: .pair(pair))
+    let json = String(decoding: try env.encodeJSON(), as: UTF8.self)
+
+    XCTAssertTrue(json.contains("\"kind\":\"Pair\""))
+    XCTAssertTrue(json.contains("\"device_id\":\"device-ios-1\""))
+    XCTAssertTrue(json.contains("\"device_pubkey\":[0,1,2"))
+    XCTAssertTrue(json.contains("\"pairing_proof\":[32,33,34"))
+    XCTAssertFalse(json.contains("pairing_secret"))
+
+    let messageObj = try messageObject(json)
+    XCTAssertEqual(Set(messageObj.keys), ["kind", "device_id", "device_pubkey", "pairing_proof"])
+    let back = try FridayEnvelope.decodeJSON(Data(json.utf8))
+    XCTAssertEqual(back.message, .pair(pair))
+  }
+
+  func testPairAckOmitsErrorCodeWhenAcceptedAndPreservesDenialCode() throws {
+    let accepted = FridayEnvelope(
+      msgId: "pair-ack-ok", sentAt: 8,
+      message: .pairAck(PairingPairAckWire(accepted: true)))
+    let acceptedJson = String(decoding: try accepted.encodeJSON(), as: UTF8.self)
+    let acceptedObj = try messageObject(acceptedJson)
+    XCTAssertEqual(Set(acceptedObj.keys), ["kind", "accepted"])
+    XCTAssertEqual(try FridayEnvelope.decodeJSON(Data(acceptedJson.utf8)).message,
+                   .pairAck(PairingPairAckWire(accepted: true)))
+
+    let denied = FridayEnvelope(
+      msgId: "pair-ack-denied", sentAt: 9,
+      message: .pairAck(PairingPairAckWire(accepted: false, errorCode: .pairingDenied)))
+    let deniedJson = String(decoding: try denied.encodeJSON(), as: UTF8.self)
+    XCTAssertTrue(deniedJson.contains("\"error_code\":\"PAIRING_DENIED\""))
+    XCTAssertEqual(try FridayEnvelope.decodeJSON(Data(deniedJson.utf8)).message,
+                   .pairAck(PairingPairAckWire(accepted: false, errorCode: .pairingDenied)))
+  }
+
+  func testHubStatusWireContract() throws {
+    let status = PairingHubStatusWire(
+      online: true,
+      capabilities: ["pairing", "read_seam_enroll"],
+      minVersion: 1,
+      maxVersion: 13)
+    let env = FridayEnvelope(msgId: "status-1", sentAt: 10, message: .hubStatus(status))
+    let json = String(decoding: try env.encodeJSON(), as: UTF8.self)
+
+    XCTAssertTrue(json.contains("\"kind\":\"HubStatus\""))
+    XCTAssertTrue(json.contains("\"online\":true"))
+    XCTAssertTrue(json.contains("\"capabilities\":[\"pairing\",\"read_seam_enroll\"]"))
+    XCTAssertTrue(json.contains("\"min_version\":1"))
+    XCTAssertTrue(json.contains("\"max_version\":13"))
+    XCTAssertEqual(try FridayEnvelope.decodeJSON(Data(json.utf8)).message, .hubStatus(status))
+  }
+
+  private func messageObject(_ json: String) throws -> [String: Any] {
+    let env = try XCTUnwrap(JSONSerialization.jsonObject(with: Data(json.utf8)) as? [String: Any])
+    return try XCTUnwrap(env["message"] as? [String: Any])
+  }
+}


### PR DESCRIPTION
## Summary
- add Swift `Pair`/`PairAck`/`HubStatus` wire support matching `friday_protocol::Message`
- add a narrow `SealedWSPairingClient` for QR pairing status + pair-device flows
- fail closed on QR hub-key mismatch and unexpected response kinds; no raw pairing secret is sent on the wire

## Tests
- `swift test --package-path apps/macos/FridayRustClient --filter Pairing`
- `swift test --package-path apps/macos/FridayRustClient`
- `git diff --check`
- `detect-secrets-hook --baseline .secrets.baseline apps/macos/FridayRustClient/Sources/FridayRustClient/Protocol.swift apps/macos/FridayRustClient/Sources/FridayRustClient/ReadClient.swift apps/macos/FridayRustClient/Sources/FridayRustClient/WriteClient.swift apps/macos/FridayRustClient/Sources/FridayRustClient/PairingClient.swift apps/macos/FridayRustClient/Tests/FridayRustClientTests/PairingWireKATTests.swift apps/macos/FridayRustClient/Tests/FridayRustClientTests/PairingClientWiringTests.swift`

Truth label: T3 pairing client contract only; no trust_grant/context_passport minting, no operator signature endpoint, no organic traffic.