### PR TITLE
Add iOS session continuation surface

### DIFF
--- a/apps/friday-ios/Sources/FridayMobileShell/CommandSheet.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/CommandSheet.swift
@@ -9,6 +9,7 @@ import SwiftUI
 enum MobileDestination: String, CaseIterable, Identifiable {
   case home
   case missions
+  case session
   case needsMe
   case memory
   case platform
@@ -23,6 +24,7 @@ enum MobileDestination: String, CaseIterable, Identifiable {
     switch self {
     case .home: return "Friday Home"
     case .missions: return "Missions"
+    case .session: return "Session"
     case .needsMe: return "Needs Me"
     case .memory: return "Memory"
     case .platform: return "Platform"
@@ -37,6 +39,7 @@ enum MobileDestination: String, CaseIterable, Identifiable {
     switch self {
     case .home: return "house"
     case .missions: return "list.bullet.rectangle"
+    case .session: return "rectangle.connected.to.line.below"
     case .needsMe: return "person.crop.circle.badge.exclamationmark"
     case .memory: return "brain.head.profile"
     case .platform: return "square.grid.2x2"

--- a/apps/friday-ios/Sources/FridayMobileShell/FridayApp.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayApp.swift
@@ -210,6 +210,7 @@ final class FridaySession: ObservableObject {
 /// top-bar 💬 Friday Chat entry. Launch screen = Home (locked).
 struct RootView: View {
   @StateObject private var homeVM: HomeViewModel
+  @StateObject private var sessionContinuationVM: SessionContinuationViewModel
   private let session: FridaySession
   @State private var destination: MobileDestination = .home
   @State private var commandOpen = false
@@ -222,6 +223,8 @@ struct RootView: View {
       writeClient: session.missionClient,
       devicePairing: session.devicePairing,
       makePairingClient: session.makePairingClient))
+    _sessionContinuationVM = StateObject(wrappedValue: SessionContinuationViewModel(
+      client: session.readClient))
   }
 
   var body: some View {
@@ -230,6 +233,8 @@ struct RootView: View {
         switch destination {
         case .home:
           FridayHomeScreen(viewModel: homeVM)
+        case .session:
+          FridaySessionDetailScreen(homeViewModel: homeVM, viewModel: sessionContinuationVM)
         case .missions, .needsMe, .memory, .platform, .activity, .workflows, .onboarding,
              .settings:
           FridayProjectionScreen(destination: destination, viewModel: homeVM)

--- a/apps/friday-ios/Sources/FridayMobileShell/FridayProjectionScreens.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayProjectionScreens.swift
@@ -14,7 +14,7 @@ private enum ProjectionSurface {
 
   init?(_ destination: MobileDestination) {
     switch destination {
-    case .home:
+    case .home, .session:
       return nil
     case .missions:
       self = .missions

--- a/apps/friday-ios/Sources/FridayMobileShell/FridaySessionDetailScreen.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridaySessionDetailScreen.swift
@@ -1,0 +1,323 @@
+import FridayMobileShellCore
+import SwiftUI
+
+struct FridaySessionDetailScreen: View {
+  @ObservedObject var homeViewModel: HomeViewModel
+  @ObservedObject var viewModel: SessionContinuationViewModel
+
+  var body: some View {
+    ScrollView {
+      VStack(spacing: 16) {
+        switch homeViewModel.state {
+        case .idle, .loading:
+          loadingView
+        case .unavailable(let reason):
+          UnavailableView(reason: reason)
+        case .loaded(let projection):
+          loadedContent(projection)
+        }
+      }
+      .padding(16)
+    }
+    .background(MobileTheme.backgroundWarmOffWhite.ignoresSafeArea())
+  }
+
+  private var loadingView: some View {
+    GlassPanel {
+      HStack(spacing: 12) {
+        ProgressView()
+        Text("Reading session refs")
+          .font(.footnote)
+          .foregroundStyle(MobileTheme.textSecondary)
+      }
+      .frame(maxWidth: .infinity, minHeight: 86, alignment: .leading)
+    }
+  }
+
+  @ViewBuilder
+  private func loadedContent(_ projection: HomeProjection) -> some View {
+    VStack(spacing: 16) {
+      header(projection)
+      continuationState
+      learningCard(projection)
+    }
+    .task(id: "\(projection.agentSessionId ?? "none")|\(firstRunId(projection) ?? "none")") {
+      await viewModel.refresh(
+        agentSessionId: projection.agentSessionId,
+        runId: firstRunId(projection))
+    }
+  }
+
+  private func header(_ projection: HomeProjection) -> some View {
+    GlassPanel {
+      VStack(alignment: .leading, spacing: MobileTheme.rowSpacing) {
+        HStack(spacing: 12) {
+          Image(systemName: "rectangle.connected.to.line.below")
+            .font(.system(size: 24, weight: .semibold))
+            .foregroundStyle(MobileTheme.cyan)
+            .frame(width: 34, height: 34)
+          VStack(alignment: .leading, spacing: 4) {
+            Text("Session")
+              .font(.headline)
+              .foregroundStyle(MobileTheme.textPrimary)
+            Text("continuation truth")
+              .font(.caption)
+              .foregroundStyle(MobileTheme.textSecondary)
+          }
+          Spacer()
+          StatusChip(
+            text: projection.agentSessionId == nil ? "no session ref" : "read-only",
+            bg: projection.agentSessionId == nil ? MobileTheme.chipWarnBG : MobileTheme.chipPendingBG,
+            fg: projection.agentSessionId == nil ? MobileTheme.chipWarnFG : MobileTheme.chipPendingFG)
+        }
+        RefPill(label: "mission_id", ref: projection.missionId)
+        if let agentSessionId = projection.agentSessionId {
+          RefPill(label: "agent_session_id", ref: agentSessionId)
+        }
+        if let runId = firstRunId(projection) {
+          RefPill(label: "run_id", ref: runId)
+        }
+        RefPill(label: "generated", ref: generatedText(projection.generatedAtMs))
+      }
+    }
+  }
+
+  @ViewBuilder
+  private var continuationState: some View {
+    switch viewModel.state {
+    case .idle:
+      EmptyView()
+    case .loading:
+      GlassPanel {
+        HStack(spacing: 12) {
+          ProgressView()
+          Text("Reading continuation state")
+            .font(.footnote)
+            .foregroundStyle(MobileTheme.textSecondary)
+        }
+      }
+    case .unavailable(let reason):
+      GlassPanel {
+        VStack(alignment: .leading, spacing: MobileTheme.rowSpacing) {
+          cardHeader("Session Detail", count: nil)
+          Text(reason)
+            .font(.caption)
+            .foregroundStyle(MobileTheme.textSecondary)
+        }
+      }
+    case .loaded(let snapshot):
+      VStack(spacing: 16) {
+        controlsCard(snapshot.controls)
+        ForEach(snapshot.sections) { section in
+          sectionCard(section)
+        }
+        proofRefsCard(snapshot.proofRefs)
+      }
+    }
+  }
+
+  private func controlsCard(_ controls: [SessionContinuationControl]) -> some View {
+    GlassPanel {
+      VStack(alignment: .leading, spacing: MobileTheme.rowSpacing) {
+        cardHeader("Controls", count: nil)
+        LazyVGrid(columns: [GridItem(.flexible()), GridItem(.flexible())], spacing: 10) {
+          ForEach(controls) { control in
+            Button {} label: {
+              VStack(alignment: .leading, spacing: 6) {
+                HStack {
+                  Image(systemName: control.systemImage)
+                  Text(control.title)
+                    .font(.system(size: 13, weight: .semibold))
+                  Spacer()
+                  StatusChip(text: control.truthLabel, bg: MobileTheme.chipWarnBG, fg: MobileTheme.chipWarnFG)
+                }
+                Text(control.reason)
+                  .font(.caption2)
+                  .foregroundStyle(MobileTheme.textSecondary)
+                  .fixedSize(horizontal: false, vertical: true)
+              }
+              .frame(maxWidth: .infinity, minHeight: 70, alignment: .topLeading)
+              .padding(10)
+            }
+            .buttonStyle(.bordered)
+            .disabled(!control.isEnabled)
+            .accessibilityLabel("\(control.title) \(control.truthLabel). \(control.reason)")
+          }
+        }
+      }
+    }
+  }
+
+  private func sectionCard(_ section: SessionContinuationSection) -> some View {
+    GlassPanel {
+      VStack(alignment: .leading, spacing: MobileTheme.rowSpacing) {
+        HStack {
+          cardHeader(section.title, count: section.refs.count)
+          Spacer()
+          sectionStatusChip(section.status)
+        }
+        Text(section.summary)
+          .font(.caption)
+          .foregroundStyle(MobileTheme.textPrimary)
+        switch section.status {
+        case .loaded:
+          if let generatedAtMs = section.generatedAtMs {
+            RefPill(label: "generated", ref: generatedText(generatedAtMs))
+          }
+          ForEach(section.refs, id: \.self) { ref in
+            RefPill(label: nil, ref: ref)
+          }
+        case .unavailable(let reason), .notRequested(let reason):
+          Text(reason)
+            .font(.caption2)
+            .foregroundStyle(MobileTheme.textSecondary)
+            .fixedSize(horizontal: false, vertical: true)
+        }
+      }
+    }
+  }
+
+  private func proofRefsCard(_ refs: [String]) -> some View {
+    GlassPanel {
+      VStack(alignment: .leading, spacing: MobileTheme.rowSpacing) {
+        cardHeader("Proof Refs", count: refs.count)
+        if refs.isEmpty {
+          Text("No proof refs were returned by the session read arms.")
+            .font(.caption)
+            .foregroundStyle(MobileTheme.textSecondary)
+        } else {
+          ForEach(refs, id: \.self) { ref in
+            RefPill(label: "proof", ref: ref)
+          }
+        }
+      }
+    }
+  }
+
+  private func learningCard(_ projection: HomeProjection) -> some View {
+    GlassPanel {
+      VStack(alignment: .leading, spacing: MobileTheme.rowSpacing) {
+        cardHeader("Learning", count: projection.runOutcomeLearningCandidates.count)
+        if projection.runOutcomeLearningCandidates.isEmpty {
+          Text("No run-outcome learning candidates in this projection.")
+            .font(.caption)
+            .foregroundStyle(MobileTheme.textSecondary)
+        } else {
+          ForEach(projection.runOutcomeLearningCandidates) { candidate in
+            learningCandidateRow(candidate)
+          }
+        }
+      }
+    }
+  }
+
+  private func learningCandidateRow(_ candidate: HomeRunOutcomeLearningCandidate) -> some View {
+    let decisionState = homeViewModel.runOutcomeLearningDecisionStates[candidate.id]
+    return VStack(alignment: .leading, spacing: 6) {
+      HStack(alignment: .top, spacing: 8) {
+        Text(candidate.summary)
+          .font(.system(size: 13, weight: .medium))
+          .foregroundStyle(MobileTheme.textPrimary)
+          .frame(maxWidth: .infinity, alignment: .leading)
+        HStack(spacing: 6) {
+          Button {
+            Task { await homeViewModel.decideRunOutcomeLearning(candidateId: candidate.id, confirm: true) }
+          } label: {
+            Image(systemName: "checkmark")
+              .frame(width: 26, height: 26)
+          }
+          .buttonStyle(.borderedProminent)
+          .tint(MobileTheme.cyan)
+          .disabled(learningDecisionControlsDisabled(decisionState))
+          .accessibilityLabel("Confirm run outcome learning candidate")
+
+          Button {
+            Task { await homeViewModel.decideRunOutcomeLearning(candidateId: candidate.id, confirm: false) }
+          } label: {
+            Image(systemName: "xmark")
+              .frame(width: 26, height: 26)
+          }
+          .buttonStyle(.bordered)
+          .disabled(learningDecisionControlsDisabled(decisionState))
+          .accessibilityLabel("Reject run outcome learning candidate")
+        }
+      }
+      HStack(spacing: 6) {
+        statusChip(candidate.kind)
+        statusChip(candidate.state)
+      }
+      learningDecisionStateView(decisionState)
+      if !candidate.runId.isEmpty {
+        RefPill(label: "runId", ref: candidate.runId)
+      }
+      if !candidate.workItemId.isEmpty {
+        RefPill(label: "workItemId", ref: candidate.workItemId)
+      }
+      if !candidate.evidenceRef.isEmpty {
+        RefPill(label: "evidenceRef", ref: candidate.evidenceRef)
+      }
+    }
+    .padding(.vertical, 4)
+  }
+
+  private func sectionStatusChip(_ status: SessionContinuationSectionStatus) -> some View {
+    switch status {
+    case .loaded:
+      return StatusChip(text: "loaded", bg: MobileTheme.chipPendingBG, fg: MobileTheme.chipPendingFG)
+    case .unavailable:
+      return StatusChip(text: "unavailable", bg: MobileTheme.chipWarnBG, fg: MobileTheme.chipWarnFG)
+    case .notRequested:
+      return StatusChip(text: "no ref", bg: MobileTheme.chipNeutralBG, fg: MobileTheme.chipNeutralFG)
+    }
+  }
+
+  private func learningDecisionControlsDisabled(_ state: HomeLearningDecisionState?) -> Bool {
+    guard let state else { return false }
+    return state.isSent || state.isTerminal
+  }
+
+  @ViewBuilder
+  private func learningDecisionStateView(_ state: HomeLearningDecisionState?) -> some View {
+    switch state {
+    case .sent:
+      Text("Applying learning decision...")
+        .font(.caption2)
+        .foregroundStyle(MobileTheme.textSecondary)
+    case .confirmed(let summary):
+      Text(summary)
+        .font(.caption2)
+        .foregroundStyle(MobileTheme.textSecondary)
+    case .error(let reason):
+      Text(reason)
+        .font(.caption2)
+        .foregroundStyle(MobileTheme.coral)
+    case nil:
+      EmptyView()
+    }
+  }
+
+  private func cardHeader(_ title: String, count: Int?) -> some View {
+    HStack {
+      Text(title)
+        .font(.headline)
+        .foregroundStyle(MobileTheme.textPrimary)
+      if let count {
+        StatusChip(text: "\(count)", bg: MobileTheme.chipNeutralBG, fg: MobileTheme.chipNeutralFG)
+      }
+    }
+  }
+
+  private func statusChip(_ text: String) -> some View {
+    StatusChip(text: text, bg: MobileTheme.chipNeutralBG, fg: MobileTheme.chipNeutralFG)
+  }
+
+  private func firstRunId(_ projection: HomeProjection) -> String? {
+    projection.runOutcomeLearningCandidates.first { !$0.runId.isEmpty }?.runId
+  }
+
+  private func generatedText(_ generatedAtMs: Int64) -> String {
+    guard generatedAtMs > 0 else { return "unknown" }
+    let date = Date(timeIntervalSince1970: Double(generatedAtMs) / 1000.0)
+    return date.formatted(date: .abbreviated, time: .shortened)
+  }
+}

--- a/apps/friday-ios/Sources/FridayMobileShellCore/SessionContinuationViewModel.swift
+++ b/apps/friday-ios/Sources/FridayMobileShellCore/SessionContinuationViewModel.swift
@@ -1,0 +1,220 @@
+import Foundation
+import FridayRustClient
+
+public enum SessionContinuationSectionStatus: Sendable, Equatable {
+  case loaded
+  case unavailable(reason: String)
+  case notRequested(reason: String)
+}
+
+public struct SessionContinuationSection: Sendable, Identifiable, Equatable {
+  public let id: String
+  public let title: String
+  public let status: SessionContinuationSectionStatus
+  public let summary: String
+  public let generatedAtMs: Int64?
+  public let refs: [String]
+}
+
+public struct SessionContinuationControl: Sendable, Identifiable, Equatable {
+  public let id: String
+  public let title: String
+  public let systemImage: String
+  public let truthLabel: String
+  public let reason: String
+  public let isEnabled: Bool
+}
+
+public struct SessionContinuationSnapshot: Sendable, Equatable {
+  public let agentSessionId: String
+  public let runId: String?
+  public let sections: [SessionContinuationSection]
+  public let controls: [SessionContinuationControl]
+
+  public var proofRefs: [String] {
+    var seen = Set<String>()
+    return sections.flatMap(\.refs).filter { seen.insert($0).inserted }
+  }
+}
+
+public enum SessionContinuationLoadState: Sendable, Equatable {
+  case idle
+  case loading(agentSessionId: String)
+  case loaded(SessionContinuationSnapshot)
+  case unavailable(reason: String)
+
+  public var isLoading: Bool {
+    if case .loading = self { return true }
+    return false
+  }
+}
+
+@MainActor
+public final class SessionContinuationViewModel: ObservableObject {
+  @Published public private(set) var state: SessionContinuationLoadState = .idle
+
+  private let client: FridayRustReadClient
+
+  public init(client: FridayRustReadClient) {
+    self.client = client
+  }
+
+  public func refresh(agentSessionId: String?, runId: String?) async {
+    let sessionId = agentSessionId?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+    guard !sessionId.isEmpty else {
+      state = .unavailable(reason: "Session detail requires an owner-gated agent session ref.")
+      return
+    }
+
+    let trimmedRunId = runId?.trimmingCharacters(in: .whitespacesAndNewlines)
+    let resolvedRunId = (trimmedRunId?.isEmpty == false) ? trimmedRunId : nil
+    state = .loading(agentSessionId: sessionId)
+
+    async let open = Self.fetchSessionOpen(client: client, agentSessionId: sessionId)
+    async let link = Self.fetchSessionLinkState(client: client, agentSessionId: sessionId)
+
+    var sections = await [open, link]
+    if let resolvedRunId {
+      async let files = Self.fetchRunFileView(client: client, runId: resolvedRunId)
+      async let needsMe = Self.fetchActivityNeedsMe(client: client, runId: resolvedRunId)
+      sections.append(contentsOf: await [files, needsMe])
+    } else {
+      sections.append(SessionContinuationSection(
+        id: "run-files",
+        title: "Run Files",
+        status: .notRequested(reason: "No run ref is available in the current projection."),
+        summary: "run file view not requested",
+        generatedAtMs: nil,
+        refs: []))
+      sections.append(SessionContinuationSection(
+        id: "needs-me",
+        title: "Needs Me",
+        status: .notRequested(reason: "No run ref is available in the current projection."),
+        summary: "needs-me activity not requested",
+        generatedAtMs: nil,
+        refs: []))
+    }
+
+    state = .loaded(SessionContinuationSnapshot(
+      agentSessionId: sessionId,
+      runId: resolvedRunId,
+      sections: sections,
+      controls: Self.disabledControls()))
+  }
+
+  private nonisolated static func fetchSessionOpen(
+    client: FridayRustReadClient,
+    agentSessionId: String
+  ) async -> SessionContinuationSection {
+    await fetch(
+      id: "session-open",
+      title: "Session Open",
+      read: { try await client.fetchSessionOpen(agentSessionId: agentSessionId) })
+  }
+
+  private nonisolated static func fetchSessionLinkState(
+    client: FridayRustReadClient,
+    agentSessionId: String
+  ) async -> SessionContinuationSection {
+    await fetch(
+      id: "session-link",
+      title: "Link State",
+      read: { try await client.fetchSessionLinkState(agentSessionId: agentSessionId) })
+  }
+
+  private nonisolated static func fetchRunFileView(
+    client: FridayRustReadClient,
+    runId: String
+  ) async -> SessionContinuationSection {
+    await fetch(
+      id: "run-files",
+      title: "Run Files",
+      read: { try await client.fetchRunFileView(runId: runId) })
+  }
+
+  private nonisolated static func fetchActivityNeedsMe(
+    client: FridayRustReadClient,
+    runId: String
+  ) async -> SessionContinuationSection {
+    await fetch(
+      id: "needs-me",
+      title: "Needs Me",
+      read: { try await client.fetchActivityNeedsMe(runId: runId) })
+  }
+
+  private nonisolated static func fetch(
+    id: String,
+    title: String,
+    read: () async throws -> ReadProjectionSnapshot
+  ) async -> SessionContinuationSection {
+    do {
+      let detail = HomeReadDetail(title: title, snapshot: try await read())
+      return SessionContinuationSection(
+        id: id,
+        title: title,
+        status: .loaded,
+        summary: detail.summary,
+        generatedAtMs: detail.generatedAtMs,
+        refs: detail.refs)
+    } catch {
+      return SessionContinuationSection(
+        id: id,
+        title: title,
+        status: .unavailable(reason: reason(for: error)),
+        summary: "unavailable",
+        generatedAtMs: nil,
+        refs: [])
+    }
+  }
+
+  private nonisolated static func disabledControls() -> [SessionContinuationControl] {
+    [
+      SessionContinuationControl(
+        id: "send",
+        title: "Send",
+        systemImage: "paperplane",
+        truthLabel: "NO-GO",
+        reason: "Session send mutation is not built on mobile.",
+        isEnabled: false),
+      SessionContinuationControl(
+        id: "stop",
+        title: "Stop",
+        systemImage: "stop.circle",
+        truthLabel: "NO-GO",
+        reason: "Stop requires a governed mutation endpoint; none is wired here.",
+        isEnabled: false),
+      SessionContinuationControl(
+        id: "resume",
+        title: "Resume",
+        systemImage: "play.circle",
+        truthLabel: "NO-GO",
+        reason: "Resume is display-only until the governed continuation endpoint exists.",
+        isEnabled: false),
+      SessionContinuationControl(
+        id: "fork",
+        title: "Fork",
+        systemImage: "arrow.triangle.branch",
+        truthLabel: "NO-GO",
+        reason: "Fork is not a built mobile mutation.",
+        isEnabled: false),
+    ]
+  }
+
+  private nonisolated static func reason(for error: Error) -> String {
+    if let e = error as? FridayReadClientError {
+      switch e {
+      case .badServerPubkey, .badSessionNonce:
+        return "Friday could not establish a trusted connection"
+      case let .serverError(code, message):
+        return "Friday is unavailable (\(code.rawValue)) — \(message)"
+      case let .unexpectedResponse(kind):
+        return "Friday returned an unexpected response (\(kind))"
+      case let .malformedProjection(why):
+        return "Status unavailable — \(why)"
+      case let .transport(why):
+        return "Friday is offline — \(why)"
+      }
+    }
+    return "Friday is unavailable — \(error)"
+  }
+}

--- a/apps/friday-ios/Tests/FridayMobileShellCoreTests/SessionContinuationViewModelTests.swift
+++ b/apps/friday-ios/Tests/FridayMobileShellCoreTests/SessionContinuationViewModelTests.swift
@@ -1,0 +1,174 @@
+import XCTest
+@testable import FridayMobileShellCore
+@testable import FridayRustClient
+
+@MainActor
+final class SessionContinuationViewModelTests: XCTestCase {
+  final class FakeSessionReadClient: FridayRustReadClient, @unchecked Sendable {
+    enum Script {
+      case success
+      case fail(FridayReadClientError)
+    }
+
+    private let script: Script
+    private let lock = NSLock()
+    private var requested: [String] = []
+
+    init(_ script: Script = .success) {
+      self.script = script
+    }
+
+    var requests: [String] {
+      lock.lock()
+      defer { lock.unlock() }
+      return requested
+    }
+
+    func fetchWorkbench() async throws -> WorkbenchSnapshot {
+      throw FridayReadClientError.transport("unused")
+    }
+
+    func fetchSessionOpen(agentSessionId: String) async throws -> ReadProjectionSnapshot {
+      try recordAndReturn(
+        request: "session-open:\(agentSessionId)",
+        status: "open",
+        proofRef: "proof://session/open/\(agentSessionId)")
+    }
+
+    func fetchSessionLinkState(agentSessionId: String) async throws -> ReadProjectionSnapshot {
+      try recordAndReturn(
+        request: "session-link:\(agentSessionId)",
+        status: "connected",
+        proofRef: "proof://session/link/\(agentSessionId)")
+    }
+
+    func fetchRunFileView(runId: String) async throws -> ReadProjectionSnapshot {
+      try recordAndReturn(
+        request: "run-files:\(runId)",
+        status: "ready",
+        runId: runId,
+        proofRef: "proof://run-files/\(runId)")
+    }
+
+    func fetchActivityNeedsMe(runId: String) async throws -> ReadProjectionSnapshot {
+      try recordAndReturn(
+        request: "needs-me:\(runId)",
+        status: "waiting",
+        runId: runId,
+        proofRef: "proof://needs/\(runId)")
+    }
+
+    private func recordAndReturn(
+      request: String,
+      status: String,
+      runId: String? = nil,
+      proofRef: String
+    ) throws -> ReadProjectionSnapshot {
+      lock.lock()
+      requested.append(request)
+      lock.unlock()
+      if case .fail(let error) = script {
+        throw error
+      }
+      var raw: [String: Any] = [
+        "missionId": "mission-7",
+        "status": status,
+        "truthLabel": "friday_owned",
+        "proofRef": proofRef,
+        "evidenceRefs": ["proof://evidence/\(request)"],
+        "timelineRef": "proof://timeline/\(request)",
+      ]
+      if let runId { raw["runId"] = runId }
+      let data = try JSONSerialization.data(withJSONObject: raw)
+      return try ReadProjectionSnapshot(projectionJSON: data, generatedAtMs: 1_780_640_000_123)
+    }
+  }
+
+  func testRefreshWithSessionAndRunReadsAllContinuationArmsAndKeepsControlsNoGo() async {
+    let client = FakeSessionReadClient()
+    let vm = SessionContinuationViewModel(client: client)
+
+    await vm.refresh(agentSessionId: "session-1", runId: "run-1")
+
+    guard case .loaded(let snapshot) = vm.state else {
+      return XCTFail("expected loaded session continuation, got \(vm.state)")
+    }
+    XCTAssertEqual(Set(client.requests), [
+      "session-open:session-1",
+      "session-link:session-1",
+      "run-files:run-1",
+      "needs-me:run-1",
+    ])
+    XCTAssertEqual(snapshot.agentSessionId, "session-1")
+    XCTAssertEqual(snapshot.runId, "run-1")
+    XCTAssertEqual(snapshot.sections.map(\.id), ["session-open", "session-link", "run-files", "needs-me"])
+    XCTAssertTrue(snapshot.sections.allSatisfy {
+      if case .loaded = $0.status { return true }
+      return false
+    })
+    XCTAssertTrue(snapshot.proofRefs.contains("proof://session/open/session-1"))
+    XCTAssertTrue(snapshot.proofRefs.contains("proof://session/link/session-1"))
+    XCTAssertTrue(snapshot.proofRefs.contains("proof://run-files/run-1"))
+    XCTAssertTrue(snapshot.proofRefs.contains("proof://needs/run-1"))
+    XCTAssertEqual(snapshot.sections.first?.generatedAtMs, 1_780_640_000_123)
+    XCTAssertEqual(snapshot.controls.map(\.title), ["Send", "Stop", "Resume", "Fork"])
+    XCTAssertTrue(snapshot.controls.allSatisfy { !$0.isEnabled && $0.truthLabel == "NO-GO" })
+  }
+
+  func testRefreshWithoutRunRefDoesNotReadRunArms() async {
+    let client = FakeSessionReadClient()
+    let vm = SessionContinuationViewModel(client: client)
+
+    await vm.refresh(agentSessionId: "session-1", runId: nil)
+
+    guard case .loaded(let snapshot) = vm.state else {
+      return XCTFail("expected loaded session continuation, got \(vm.state)")
+    }
+    XCTAssertEqual(Set(client.requests), [
+      "session-open:session-1",
+      "session-link:session-1",
+    ])
+    XCTAssertNil(snapshot.runId)
+    XCTAssertEqual(snapshot.sections.map(\.id), ["session-open", "session-link", "run-files", "needs-me"])
+    let runSections = snapshot.sections.suffix(2)
+    XCTAssertTrue(runSections.allSatisfy {
+      if case .notRequested(let reason) = $0.status {
+        return reason.contains("No run ref")
+      }
+      return false
+    })
+  }
+
+  func testRefreshWithoutSessionRefFailsClosedWithoutReading() async {
+    let client = FakeSessionReadClient()
+    let vm = SessionContinuationViewModel(client: client)
+
+    await vm.refresh(agentSessionId: nil, runId: "run-1")
+
+    guard case .unavailable(let reason) = vm.state else {
+      return XCTFail("expected unavailable, got \(vm.state)")
+    }
+    XCTAssertTrue(reason.contains("agent session ref"))
+    XCTAssertTrue(client.requests.isEmpty)
+  }
+
+  func testRefreshReadArmFailuresRenderUnavailableSections() async {
+    let client = FakeSessionReadClient(.fail(.transport("server dark")))
+    let vm = SessionContinuationViewModel(client: client)
+
+    await vm.refresh(agentSessionId: "session-1", runId: "run-1")
+
+    guard case .loaded(let snapshot) = vm.state else {
+      return XCTFail("expected loaded shell with unavailable sections, got \(vm.state)")
+    }
+    XCTAssertEqual(snapshot.proofRefs, [])
+    XCTAssertEqual(snapshot.sections.count, 4)
+    XCTAssertTrue(snapshot.sections.allSatisfy {
+      if case .unavailable(let reason) = $0.status {
+        return reason.contains("offline")
+      }
+      return false
+    })
+    XCTAssertTrue(snapshot.controls.allSatisfy { !$0.isEnabled && $0.truthLabel == "NO-GO" })
+  }
+}


### PR DESCRIPTION
## Summary
- add an iOS Session destination with a continuation detail surface
- read existing sealed session/link/run-file/needs-me arms and render proof refs/freshness honestly
- keep Send/Stop/Resume/Fork disabled as NO-GO controls instead of wiring fake mutations
- keep existing run-outcome learning confirm/reject path only

## Truth labels
- Session surface: built, read-only, not live-proven against prod hub in this PR
- Continuation controls: NO-GO/disabled, no new mutation endpoint
- No operator key handling, no synthetic rows, no Litter-style new multi-agent switching

## Tests
- swift test --package-path apps/friday-ios
- ./build-sim.sh (worker run; nonblank Home/honest-offline screenshot)
- git diff --check
- detect-secrets-hook --baseline .secrets.baseline <changed files>