### PR TITLE
Render provider readiness in desktop console

### DIFF
--- a/apps/macos/FridayHubConsole/Sources/FridayHubConsole/DesktopProjectionScreens.swift
+++ b/apps/macos/FridayHubConsole/Sources/FridayHubConsole/DesktopProjectionScreens.swift
@@ -243,6 +243,9 @@ struct DesktopProjectionScreen: View {
           Text(detail.summary)
             .font(.system(size: 12))
             .foregroundStyle(HubTheme.textPrimary)
+          if let providerReadiness = detail.providerReadiness {
+            ProviderReadinessDetailView(readiness: providerReadiness)
+          }
           RefPill(label: "generated", ref: "\(detail.generatedAtMs)")
           ForEach(detail.refs, id: \.self) { ref in
             RefPill(label: nil, ref: ref)
@@ -449,5 +452,107 @@ struct DesktopProjectionScreen: View {
     Text(text)
       .font(.system(size: 14, weight: .semibold))
       .foregroundStyle(HubTheme.textPrimary)
+  }
+}
+
+private struct ProviderReadinessDetailView: View {
+  let readiness: ProviderReadinessDetail
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 10) {
+      HStack(spacing: 8) {
+        StatusChip(
+          text: readiness.keyValidationProbed == true ? "keys probed" : "keys not probed",
+          bg: readiness.keyValidationProbed == true ? HubTheme.chipPendingBG : HubTheme.chipNeutralBG,
+          fg: readiness.keyValidationProbed == true ? HubTheme.chipPendingFG : HubTheme.chipNeutralFG)
+        if let suggestedTextRoute = readiness.suggestedTextRoute {
+          RefPill(label: "text route", ref: suggestedTextRoute)
+        }
+        if let suggestedStrongRoute = readiness.suggestedStrongRoute {
+          RefPill(label: "strong route", ref: suggestedStrongRoute)
+        }
+      }
+
+      ForEach(readiness.routes) { route in
+        ProviderRouteReadinessRow(route: route)
+      }
+
+      if !readiness.failovers.isEmpty {
+        Text("Failover")
+          .font(.system(size: 11, weight: .semibold))
+          .foregroundStyle(HubTheme.textSecondary)
+        ForEach(readiness.failovers) { failover in
+          ProviderFailoverReadinessRow(failover: failover)
+        }
+      }
+
+      Text("Read-only projection — this surface does not select routes or enable failover.")
+        .font(.system(size: 10))
+        .foregroundStyle(HubTheme.textSecondary)
+    }
+    .accessibilityIdentifier("friday.desktop.provider-readiness-detail")
+  }
+}
+
+private struct ProviderRouteReadinessRow: View {
+  let route: ProviderRouteReadinessDisplay
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 4) {
+      HStack(spacing: 8) {
+        Text(route.providerId)
+          .font(.system(size: 12, weight: .semibold))
+          .foregroundStyle(HubTheme.textPrimary)
+        Text(route.model)
+          .font(.system(size: 11))
+          .foregroundStyle(HubTheme.textSecondary)
+        Spacer()
+        StatusChip(
+          text: route.dispatchable ? "dispatchable" : "blocked",
+          bg: route.dispatchable ? HubTheme.chipDoneBG : HubTheme.chipWarnBG,
+          fg: route.dispatchable ? HubTheme.chipDoneFG : HubTheme.chipWarnFG)
+      }
+      HStack(spacing: 6) {
+        StatusChip(text: route.strength, bg: HubTheme.chipNeutralBG, fg: HubTheme.chipNeutralFG)
+        StatusChip(text: route.modelSize, bg: HubTheme.chipNeutralBG, fg: HubTheme.chipNeutralFG)
+      }
+      if !route.blockers.isEmpty {
+        Text(route.blockers.joined(separator: ", "))
+          .font(.system(size: 10))
+          .foregroundStyle(HubTheme.textSecondary)
+          .fixedSize(horizontal: false, vertical: true)
+      }
+    }
+    .padding(.vertical, 3)
+  }
+}
+
+private struct ProviderFailoverReadinessRow: View {
+  let failover: ProviderFailoverReadinessDisplay
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 4) {
+      HStack(spacing: 8) {
+        Text(failover.direction)
+          .font(.system(size: 12, weight: .semibold))
+          .foregroundStyle(HubTheme.textPrimary)
+        Spacer()
+        StatusChip(
+          text: failover.canEnable ? "ready" : "blocked",
+          bg: failover.canEnable ? HubTheme.chipDoneBG : HubTheme.chipWarnBG,
+          fg: failover.canEnable ? HubTheme.chipDoneFG : HubTheme.chipWarnFG)
+        StatusChip(
+          text: failover.flagEnabled ? "flag on" : "flag off",
+          bg: failover.flagEnabled ? HubTheme.chipPendingBG : HubTheme.chipNeutralBG,
+          fg: failover.flagEnabled ? HubTheme.chipPendingFG : HubTheme.chipNeutralFG)
+      }
+      if !failover.blockers.isEmpty {
+        Text(failover.blockers.joined(separator: ", "))
+          .font(.system(size: 10))
+          .foregroundStyle(HubTheme.textSecondary)
+          .fixedSize(horizontal: false, vertical: true)
+      }
+    }
+    .padding(.vertical, 3)
   }
 }

--- a/apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/OperationsOverviewViewModel.swift
+++ b/apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/OperationsOverviewViewModel.swift
@@ -59,6 +59,7 @@ public struct ReadProjectionDetail: Sendable, Equatable {
   public let generatedAtMs: Int64
   public let summary: String
   public let refs: [String]
+  public let providerReadiness: ProviderReadinessDetail?
 
   public init(title: String, snapshot: ReadProjectionSnapshot) {
     let raw = snapshot.raw
@@ -66,6 +67,7 @@ public struct ReadProjectionDetail: Sendable, Equatable {
     self.generatedAtMs = snapshot.generatedAtMs
     self.summary = Self.summary(from: raw)
     self.refs = Self.refs(from: raw)
+    self.providerReadiness = ProviderReadinessDetail(raw: raw)
   }
 
   private static func summary(from raw: [String: Any]) -> String {
@@ -93,6 +95,65 @@ public struct ReadProjectionDetail: Sendable, Equatable {
 
   private static func firstString(_ raw: [String: Any], _ keys: [String]) -> String? {
     keys.lazy.compactMap { raw[$0] as? String }.first
+  }
+}
+
+public struct ProviderReadinessDetail: Sendable, Equatable {
+  public let routes: [ProviderRouteReadinessDisplay]
+  public let failovers: [ProviderFailoverReadinessDisplay]
+  public let suggestedTextRoute: String?
+  public let suggestedStrongRoute: String?
+  public let keyValidationProbed: Bool?
+
+  init?(raw: [String: Any]) {
+    guard let routeRows = raw["route_readiness"] as? [[String: Any]] else { return nil }
+    self.routes = routeRows.map(ProviderRouteReadinessDisplay.init(raw:))
+    let failoverRows = raw["failover_readiness"] as? [[String: Any]] ?? []
+    self.failovers = failoverRows.map(ProviderFailoverReadinessDisplay.init(raw:))
+    self.suggestedTextRoute = raw["suggested_text_route"] as? String
+    self.suggestedStrongRoute = raw["suggested_strong_route"] as? String
+    self.keyValidationProbed = raw["key_validation_probed"] as? Bool
+  }
+}
+
+public struct ProviderRouteReadinessDisplay: Sendable, Equatable, Identifiable {
+  public let providerId: String
+  public let model: String
+  public let modelSize: String
+  public let strength: String
+  public let dispatchable: Bool
+  public let blockers: [String]
+
+  public var id: String { providerId }
+
+  init(raw: [String: Any]) {
+    self.providerId = raw["provider_id"] as? String ?? "unknown"
+    self.model = raw["model"] as? String ?? "unknown"
+    self.modelSize = raw["model_size"] as? String ?? "unknown"
+    self.strength = raw["strength"] as? String ?? "unknown"
+    self.dispatchable = raw["dispatchable"] as? Bool ?? false
+    self.blockers = Self.blockerCodes(raw["blockers"])
+  }
+
+  static func blockerCodes(_ value: Any?) -> [String] {
+    guard let rows = value as? [[String: Any]] else { return [] }
+    return rows.compactMap { $0["code"] as? String }.filter { !$0.isEmpty }
+  }
+}
+
+public struct ProviderFailoverReadinessDisplay: Sendable, Equatable, Identifiable {
+  public let direction: String
+  public let flagEnabled: Bool
+  public let canEnable: Bool
+  public let blockers: [String]
+
+  public var id: String { direction }
+
+  init(raw: [String: Any]) {
+    self.direction = raw["direction"] as? String ?? "unknown"
+    self.flagEnabled = raw["flag_enabled"] as? Bool ?? false
+    self.canEnable = raw["can_enable"] as? Bool ?? false
+    self.blockers = ProviderRouteReadinessDisplay.blockerCodes(raw["blockers"])
   }
 }
 

--- a/apps/macos/FridayHubConsole/Tests/FridayHubConsoleCoreTests/OperationsOverviewViewModelTests.swift
+++ b/apps/macos/FridayHubConsole/Tests/FridayHubConsoleCoreTests/OperationsOverviewViewModelTests.swift
@@ -616,7 +616,45 @@ final class DetailReadClient: FridayRustReadClient, @unchecked Sendable {
   }
 
   func fetchProvidersDoctor(probe: String?) async throws -> ReadProjectionSnapshot {
-    try record("providers:\(probe ?? "")", kind: "providers", status: "ready", proofRef: "proof://provider/doctor")
+    try record(
+      "providers:\(probe ?? "")",
+      kind: "providers",
+      status: "ready",
+      proofRef: "proof://provider/doctor",
+      extra: [
+        "key_validation_probed": true,
+        "suggested_text_route": "deepseek",
+        "suggested_strong_route": "codex",
+        "route_readiness": [
+          [
+            "provider_id": "deepseek",
+            "model": "deepseek-v4-flash",
+            "model_size": "small",
+            "strength": "cheap",
+            "dispatchable": true,
+            "blockers": [],
+          ],
+          [
+            "provider_id": "claude",
+            "model": "claude-opus-4-8",
+            "model_size": "large",
+            "strength": "strong",
+            "dispatchable": false,
+            "blockers": [
+              ["kind": "operator_flag", "code": "friday_claude_route_disabled"],
+              ["kind": "credential", "code": "api_key_missing"],
+            ],
+          ],
+        ],
+        "failover_readiness": [
+          [
+            "direction": "deepseek_to_claude",
+            "flag_enabled": false,
+            "can_enable": false,
+            "blockers": [["kind": "operator_flag", "code": "failover_flag_off"]],
+          ]
+        ],
+      ])
   }
 
   func fetchSessionList() async throws -> ReadProjectionSnapshot {
@@ -648,7 +686,8 @@ final class DetailReadClient: FridayRustReadClient, @unchecked Sendable {
     kind: String,
     status: String,
     runId: String? = nil,
-    proofRef: String
+    proofRef: String,
+    extra: [String: Any] = [:]
   ) throws -> ReadProjectionSnapshot {
     if let failWith { throw failWith }
     lock.withLock { _requested.append(request) }
@@ -660,6 +699,9 @@ final class DetailReadClient: FridayRustReadClient, @unchecked Sendable {
       "evidenceRefs": ["proof://evidence/\(kind)"],
     ]
     if let runId { raw["runId"] = runId }
+    for (key, value) in extra {
+      raw[key] = value
+    }
     let data = try JSONSerialization.data(withJSONObject: raw)
     return try ReadProjectionSnapshot(projectionJSON: data, generatedAtMs: 1_780_640_000_123)
   }
@@ -714,6 +756,16 @@ func loadDetailCallsProviderDoctorReadArm() async {
   #expect(detail.title == "Provider doctor")
   #expect(detail.summary == "mission=mission-desktop | status=ready | truth=friday_owned")
   #expect(detail.refs == ["proof://provider/doctor", "proof://evidence/providers"])
+  let readiness = detail.providerReadiness
+  #expect(readiness?.keyValidationProbed == true)
+  #expect(readiness?.suggestedTextRoute == "deepseek")
+  #expect(readiness?.suggestedStrongRoute == "codex")
+  #expect(readiness?.routes.first { $0.providerId == "deepseek" }?.dispatchable == true)
+  #expect(readiness?.routes.first { $0.providerId == "claude" }?.blockers == [
+    "friday_claude_route_disabled",
+    "api_key_missing",
+  ])
+  #expect(readiness?.failovers.first?.blockers == ["failover_flag_off"])
 }
 
 @Test


### PR DESCRIPTION
## Summary
- parse provider route/failover readiness returned by the capability doctor read arm
- render provider route blockers, suggested routes, and failover readiness in the desktop console
- keep the surface read-only: no route selection, no failover flip, no provider substitution

## Truth labels
- Desktop provider readiness UI: built/read-only
- Depends on #1053 merged doctor payload shape
- No GO-LIVE claim, no organic claim, no new multi-agent switching

## Tests
- swift test --package-path apps/macos/FridayHubConsole
- git diff --check
- detect-secrets-hook --baseline .secrets.baseline <changed files>