### PR TITLE
Wire approval reject controls into clients

### DIFF
--- a/apps/friday-ios/Sources/FridayMobileShell/FridayChatScreen.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayChatScreen.swift
@@ -119,6 +119,14 @@ struct FridayChatScreen: View {
             .font(.caption2).monospaced().foregroundStyle(MobileTheme.textSecondary)
         }
       }
+    case .rejecting(let card):
+      GlassPanel {
+        VStack(alignment: .leading, spacing: 8) {
+          HStack(spacing: 8) { ProgressView(); Text("Rejecting approval…").font(.headline) }
+          Text("\(card.actionVerb) · \(short(card.actionDigest))")
+            .font(.caption2).monospaced().foregroundStyle(MobileTheme.textSecondary)
+        }
+      }
     case .resumed(let r):
       resumeCard(r)
     case .unavailable(let reason):
@@ -253,7 +261,7 @@ struct FridayChatScreen: View {
           .buttonStyle(.borderedProminent).tint(MobileTheme.cyan)
           .accessibilityLabel("Approve Friday action")
           Button(role: .destructive) {
-            viewModel.reject()
+            Task { await viewModel.reject() }
           } label: {
             Label("Reject", systemImage: "xmark").foregroundStyle(MobileTheme.coral)
           }
@@ -267,29 +275,29 @@ struct FridayChatScreen: View {
     .accessibilityIdentifier("friday.chat.approval-card")
   }
 
-  /// The refs-only resume receipt (accepted ⇒ executed; refused ⇒ a successful relay of a refusal).
+  /// The refs-only control receipt (resume/reject/cancel).
   private func resumeCard(_ r: ChatResumeReceipt) -> some View {
     GlassPanel {
       VStack(alignment: .leading, spacing: 8) {
         HStack {
           StatusChip(
-            text: r.accepted ? "EXECUTED" : "REFUSED",
+            text: r.statusLabel,
             bg: r.accepted ? MobileTheme.chipDoneBG : MobileTheme.chipWarnBG,
             fg: r.accepted ? MobileTheme.chipDoneFG : MobileTheme.chipWarnFG)
           Spacer()
           Button("New") { viewModel.newTurn() }.font(.caption).foregroundStyle(MobileTheme.cyan)
         }
-        Text(r.accepted ? "Approved action executed" : "Action refused")
+        Text(r.title)
           .font(.headline).foregroundStyle(MobileTheme.textPrimary)
         RefPill(label: "op", ref: r.op)
         RefPill(label: "status", ref: r.status)
         if let audit = r.auditRef { RefPill(label: "audit_ref", ref: audit) }
-        Text(r.accepted ? "receipt is refs-only — no body" : "the action did NOT execute")
+        Text(r.detail)
           .font(.caption2).foregroundStyle(MobileTheme.textSecondary)
       }
     }
     .accessibilityElement(children: .combine)
-    .accessibilityLabel(r.accepted ? "Approved action executed" : "Action refused")
+    .accessibilityLabel(r.title)
     .accessibilityIdentifier("friday.chat.resume-receipt")
   }
 

--- a/apps/friday-ios/Sources/FridayMobileShellCore/FridayChatViewModel.swift
+++ b/apps/friday-ios/Sources/FridayMobileShellCore/FridayChatViewModel.swift
@@ -144,6 +144,36 @@ public struct ChatResumeReceipt: Sendable, Equatable {
     self.auditRef = r.auditRef
     self.truthLabel = r.truthLabel
   }
+
+  public var title: String {
+    switch (op, accepted) {
+    case ("resume", true): return "Approved action executed"
+    case ("reject", true): return "Approval rejected"
+    case ("cancel", true): return "Run cancelled"
+    case (_, false): return "Action refused"
+    default: return "Control accepted"
+    }
+  }
+
+  public var statusLabel: String {
+    switch (op, accepted) {
+    case ("resume", true): return "EXECUTED"
+    case ("reject", true): return "REJECTED"
+    case ("cancel", true): return "CANCELLED"
+    case (_, false): return "REFUSED"
+    default: return "ACCEPTED"
+    }
+  }
+
+  public var detail: String {
+    switch (op, accepted) {
+    case ("resume", true): return "receipt is refs-only — no body"
+    case ("reject", true): return "the pending approval was rejected; the action did NOT execute"
+    case ("cancel", true): return "the run was cancelled; no further mutation executes"
+    case (_, false): return "the action did NOT execute"
+    default: return "control receipt is refs-only — no body"
+    }
+  }
 }
 
 public struct ChatHistoryItem: Identifiable, Codable, Sendable, Equatable {
@@ -211,6 +241,8 @@ public enum ChatPhase: Sendable, Equatable {
   case pendingApproval(ApprovalCard)
   /// An approval is being signed + relayed (the resume is in flight).
   case resuming(ApprovalCard)
+  /// A rejection is being relayed to the hub (no mutation executes).
+  case rejecting(ApprovalCard)
   /// The resume relayed and settled with a refs-only receipt (accepted ⇒ executed; refused ⇒
   /// a successful relay of a refusal — the action did NOT execute).
   case resumed(ChatResumeReceipt)
@@ -226,7 +258,7 @@ public enum ChatPhase: Sendable, Equatable {
 
   public var isBusy: Bool {
     switch self {
-    case .dispatching, .resuming: return true
+    case .dispatching, .resuming, .rejecting: return true
     default: return false
     }
   }
@@ -237,13 +269,8 @@ public final class FridayChatViewModel: ObservableObject {
   @Published public private(set) var phase: ChatPhase = .composing
   @Published public private(set) var history: [ChatHistoryItem]
 
-  /// The package's `FridayRustWriteClient` is not `Sendable` (same reason as the read client),
-  /// so awaiting its `nonisolated async` dispatch/resume from this `@MainActor` VM would "send"
-  /// main-actor state across the hop. `nonisolated(unsafe)` is SOUND here: the package write
-  /// client is a `final class` with immutable `let` stored state, and each dispatch/resume builds
-  /// a FRESH transport — no shared mutable state to race. Resolved on the CONSUMER side (the #677
-  /// package is never edited). The `signer` is already `Sendable` (the protocol requires it).
-  nonisolated(unsafe) private let writeClient: FridayRustWriteClient
+  /// The package write client is `Sendable`; each dispatch/control call builds a fresh transport.
+  private let writeClient: FridayRustWriteClient
   private let missionClient: (any FridayMobileMissionDispatchingWriteClient)?
   private let readClient: FridayRustReadClient?
   private let signer: OperatorSigner
@@ -464,15 +491,21 @@ public final class FridayChatViewModel: ObservableObject {
 
   // MARK: 4. Reject / dismiss (no mutation executes)
 
-  /// Decline the paused mutation WITHOUT approving — the mutation does NOT execute (no resume is
-  /// relayed). Returns the loop to composing. A reject is local-only here; the run's pause times
-  /// out / is cancelled server-side (the resume is the ONLY thing that could execute it).
-  public func reject() {
-    guard phase.isAwaitingApproval else { return }
-    if case .pendingApproval(let card) = phase {
-      appendHistory(role: "friday", text: "Approval rejected.", runId: card.runId)
+  /// Decline the paused mutation WITHOUT approving — no resume is relayed, and the server records
+  /// the pending approval as rejected. This is not a local dismiss; a failure is surfaced honestly.
+  public func reject() async {
+    guard case .pendingApproval(let card) = phase else { return }
+    phase = .rejecting(card)
+    do {
+      let receipt = try await writeClient.rejectApproval(runId: card.runId, approvalId: card.approvalId)
+      appendHistory(
+        role: "friday",
+        text: receipt.accepted ? "Approval rejected." : "Approval rejection refused.",
+        runId: receipt.runId)
+      phase = .resumed(ChatResumeReceipt(receipt))
+    } catch {
+      phase = .unavailable(reason: Self.rejectReason(for: error))
     }
-    phase = .composing
   }
 
   public func clearHistory() {
@@ -501,6 +534,11 @@ public final class FridayChatViewModel: ObservableObject {
   static func resumeReason(for error: Error) -> String {
     if let e = error as? FridayWriteClientError { return writeReason(e, verb: "resume") }
     return "Resume unavailable — \(error)"
+  }
+
+  static func rejectReason(for error: Error) -> String {
+    if let e = error as? FridayWriteClientError { return writeReason(e, verb: "reject") }
+    return "Reject unavailable — \(error)"
   }
 
   static func signerReason(for error: Error) -> String {

--- a/apps/friday-ios/Tests/FridayMobileShellCoreTests/FridayChatViewModelTests.swift
+++ b/apps/friday-ios/Tests/FridayMobileShellCoreTests/FridayChatViewModelTests.swift
@@ -21,19 +21,34 @@ final class FridayChatViewModelTests: XCTestCase {
   final class FakeWriteClient: FridayRustWriteClient, @unchecked Sendable {
     enum DispatchScript { case answer(AgentRunResultWire); case pause(PausedOutcome); case fail(FridayWriteClientError) }
     enum ResumeScript { case accepted(ResumeRelayResult); case refused(ResumeRelayResult); case fail(FridayWriteClientError) }
+    enum RejectScript { case accepted(ResumeRelayResult); case refused(ResumeRelayResult); case fail(FridayWriteClientError) }
+    enum CancelScript { case accepted(ResumeRelayResult); case refused(ResumeRelayResult); case fail(FridayWriteClientError) }
 
     let dispatchScript: DispatchScript
     let resumeScript: ResumeScript
+    let rejectScript: RejectScript
+    let cancelScript: CancelScript
 
     private(set) var dispatchedTasks: [String] = []
     private(set) var dispatchedConstraints: [AgentRunConstraintsWire?] = []
     private(set) var resumedRunIds: [String] = []
+    private(set) var rejectedRunIds: [String] = []
+    private(set) var rejectedApprovalIds: [String] = []
+    private(set) var cancelledRunIds: [String] = []
+    private(set) var cancelReasons: [String?] = []
     /// The VERBATIM blob the view model relayed (the INV-1 proof at the view-model boundary).
     private(set) var relayedBlobs: [[UInt8]] = []
 
-    init(dispatch: DispatchScript, resume: ResumeScript = .fail(.runControlDisabled)) {
+    init(
+      dispatch: DispatchScript,
+      resume: ResumeScript = .fail(.runControlDisabled),
+      reject: RejectScript = .fail(.runControlDisabled),
+      cancel: CancelScript = .fail(.runControlDisabled)
+    ) {
       self.dispatchScript = dispatch
       self.resumeScript = resume
+      self.rejectScript = reject
+      self.cancelScript = cancel
     }
 
     func dispatchAgentRun(task: String, constraints: AgentRunConstraintsWire?) async throws -> AgentRunDispatchOutcome {
@@ -50,6 +65,24 @@ final class FridayChatViewModelTests: XCTestCase {
       resumedRunIds.append(runId)
       relayedBlobs.append(opaqueSignedBlob)
       switch resumeScript {
+      case .accepted(let r), .refused(let r): return r
+      case .fail(let e): throw e
+      }
+    }
+
+    func rejectApproval(runId: String, approvalId: String) async throws -> ResumeRelayResult {
+      rejectedRunIds.append(runId)
+      rejectedApprovalIds.append(approvalId)
+      switch rejectScript {
+      case .accepted(let r), .refused(let r): return r
+      case .fail(let e): throw e
+      }
+    }
+
+    func cancelRun(runId: String, reason: String?) async throws -> ResumeRelayResult {
+      cancelledRunIds.append(runId)
+      cancelReasons.append(reason)
+      switch cancelScript {
       case .accepted(let r), .refused(let r): return r
       case .fail(let e): throw e
       }
@@ -72,6 +105,14 @@ final class FridayChatViewModelTests: XCTestCase {
 
     func resumeWithApproval(runId: String, opaqueSignedBlob: [UInt8]) async throws -> ResumeRelayResult {
       ResumeRelayResult(runId: runId, op: "resume", accepted: false, status: "denied", auditRef: nil)
+    }
+
+    func rejectApproval(runId: String, approvalId: String) async throws -> ResumeRelayResult {
+      ResumeRelayResult(runId: runId, op: "reject", accepted: true, status: "rejected", auditRef: nil)
+    }
+
+    func cancelRun(runId: String, reason: String?) async throws -> ResumeRelayResult {
+      ResumeRelayResult(runId: runId, op: "cancel", accepted: true, status: "cancelled", auditRef: nil)
     }
 
     func submitMissionIntake(_ request: MissionIntakeRequestWire) async throws -> MissionIntakeResultWire {
@@ -438,14 +479,39 @@ final class FridayChatViewModelTests: XCTestCase {
   }
 
   func testReject_pausedMutation_executesNothing() async {
-    let client = FakeWriteClient(dispatch: .pause(makePause()),
-                                 resume: .accepted(ResumeRelayResult(runId: "run-1", op: "resume", accepted: true, status: "x", auditRef: nil)))
+    let client = FakeWriteClient(
+      dispatch: .pause(makePause()),
+      resume: .accepted(ResumeRelayResult(runId: "run-1", op: "resume", accepted: true, status: "x", auditRef: nil)),
+      reject: .accepted(ResumeRelayResult(
+        runId: "run-1", op: "reject", accepted: true, status: "rejected", auditRef: "audit://reject/run-1")))
     let vm = FridayChatViewModel(writeClient: client, signer: MockOperatorSigner())
     await vm.send("edit notes.md")
     XCTAssertTrue(vm.phase.isAwaitingApproval)
-    vm.reject()
-    XCTAssertEqual(vm.phase, .composing)
+    await vm.reject()
+    guard case .resumed(let receipt) = vm.phase else { return XCTFail("expected .resumed reject receipt, got \(vm.phase)") }
+    XCTAssertEqual(receipt.op, "reject")
+    XCTAssertTrue(receipt.accepted)
+    XCTAssertEqual(receipt.status, "rejected")
+    XCTAssertEqual(receipt.title, "Approval rejected")
+    XCTAssertEqual(receipt.statusLabel, "REJECTED")
+    XCTAssertEqual(client.rejectedRunIds, ["run-1"])
+    XCTAssertEqual(client.rejectedApprovalIds, ["ap-nonce-run-1"])
     XCTAssertTrue(client.resumedRunIds.isEmpty, "a rejected pause relays NO resume — nothing executes")
+  }
+
+  func testReject_transportFailure_isHonestUnavailableAndDoesNotResume() async {
+    let client = FakeWriteClient(
+      dispatch: .pause(makePause()),
+      resume: .accepted(ResumeRelayResult(runId: "run-1", op: "resume", accepted: true, status: "x", auditRef: nil)),
+      reject: .fail(.transport("closed before a control result")))
+    let vm = FridayChatViewModel(writeClient: client, signer: MockOperatorSigner())
+    await vm.send("edit notes.md")
+    await vm.reject()
+    guard case .unavailable(let reason) = vm.phase else { return XCTFail("expected .unavailable, got \(vm.phase)") }
+    XCTAssertTrue(reason.contains("offline"), "reason: \(reason)")
+    XCTAssertEqual(client.rejectedRunIds, ["run-1"])
+    XCTAssertEqual(client.rejectedApprovalIds, ["ap-nonce-run-1"])
+    XCTAssertTrue(client.resumedRunIds.isEmpty, "reject failure must not resume the mutation")
   }
 
   // MARK: INV-1 — the app holds no key; a signer that declines relays nothing

--- a/apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/RealWriteClientFactory.swift
+++ b/apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/RealWriteClientFactory.swift
@@ -130,6 +130,12 @@ struct HonestlyUnavailableWriteClient: FridayMissionSpineWriteClient, FridayMiss
   func resumeWithApproval(runId: String, opaqueSignedBlob: [UInt8]) async throws -> ResumeRelayResult {
     throw FridayWriteClientError.transport("live write client unavailable: \(reason)")
   }
+  func rejectApproval(runId: String, approvalId: String) async throws -> ResumeRelayResult {
+    throw FridayWriteClientError.transport("live write client unavailable: \(reason)")
+  }
+  func cancelRun(runId: String, reason: String?) async throws -> ResumeRelayResult {
+    throw FridayWriteClientError.transport("live write client unavailable: \(self.reason)")
+  }
   func submitMissionIntake(_ request: MissionIntakeRequestWire) async throws -> MissionIntakeResultWire {
     throw FridayWriteClientError.transport("live write client unavailable: \(reason)")
   }

--- a/apps/macos/FridayHubConsole/Tests/FridayHubConsoleCoreTests/OperationsOverviewViewModelTests.swift
+++ b/apps/macos/FridayHubConsole/Tests/FridayHubConsoleCoreTests/OperationsOverviewViewModelTests.swift
@@ -394,6 +394,10 @@ final class MockMissionSpineWriteClient: FridayMissionSpineWriteClient, FridayMi
   private var _lastMissionRunConstraints: AgentRunConstraintsWire?
   private var _lastResumeRunId: String?
   private var _lastResumeBlob: [UInt8]?
+  private var _lastRejectRunId: String?
+  private var _lastRejectApprovalId: String?
+  private var _lastCancelRunId: String?
+  private var _lastCancelReason: String?
   private var _missionContexts: [MissionWorkItemContextWire] = []
   private var _dispatchedTasks: [String] = []
   var lastIntake: MissionIntakeRequestWire? { lock.withLock { _lastIntake } }
@@ -405,6 +409,10 @@ final class MockMissionSpineWriteClient: FridayMissionSpineWriteClient, FridayMi
   var lastMissionRunConstraints: AgentRunConstraintsWire? { lock.withLock { _lastMissionRunConstraints } }
   var lastResumeRunId: String? { lock.withLock { _lastResumeRunId } }
   var lastResumeBlob: [UInt8]? { lock.withLock { _lastResumeBlob } }
+  var lastRejectRunId: String? { lock.withLock { _lastRejectRunId } }
+  var lastRejectApprovalId: String? { lock.withLock { _lastRejectApprovalId } }
+  var lastCancelRunId: String? { lock.withLock { _lastCancelRunId } }
+  var lastCancelReason: String? { lock.withLock { _lastCancelReason } }
   var missionContexts: [MissionWorkItemContextWire] { lock.withLock { _missionContexts } }
   var dispatchedTasks: [String] { lock.withLock { _dispatchedTasks } }
 
@@ -516,6 +524,38 @@ final class MockMissionSpineWriteClient: FridayMissionSpineWriteClient, FridayMi
       accepted: true,
       status: "mutation_completed",
       auditRef: "audit://resume/1")
+  }
+
+  func rejectApproval(runId: String, approvalId: String) async throws -> ResumeRelayResult {
+    lock.withLock {
+      _lastRejectRunId = runId
+      _lastRejectApprovalId = approvalId
+    }
+    if case .throwsTransport = behavior {
+      throw FridayWriteClientError.transport("connection refused (write server dark)")
+    }
+    return ResumeRelayResult(
+      runId: runId,
+      op: "reject",
+      accepted: true,
+      status: "rejected",
+      auditRef: "audit://reject/1")
+  }
+
+  func cancelRun(runId: String, reason: String?) async throws -> ResumeRelayResult {
+    lock.withLock {
+      _lastCancelRunId = runId
+      _lastCancelReason = reason
+    }
+    if case .throwsTransport = behavior {
+      throw FridayWriteClientError.transport("connection refused (write server dark)")
+    }
+    return ResumeRelayResult(
+      runId: runId,
+      op: "cancel",
+      accepted: true,
+      status: "cancelled",
+      auditRef: "audit://cancel/1")
   }
 }
 

--- a/apps/macos/FridayRustClient/Sources/FridayRustClient/PairingClient.swift
+++ b/apps/macos/FridayRustClient/Sources/FridayRustClient/PairingClient.swift
@@ -155,6 +155,8 @@ private func pairingKind(_ message: FridayMessage) -> String {
   case .agentRunResult: return "AgentRunResult"
   case .agentRunPaused: return "AgentRunPaused"
   case .agentRunResume: return "AgentRunResume"
+  case .agentRunCancel: return "AgentRunCancel"
+  case .agentRunReject: return "AgentRunReject"
   case .agentRunControlResult: return "AgentRunControlResult"
   case .missionIntakeRequest: return "MissionIntakeRequest"
   case .missionIntakeResult: return "MissionIntakeResult"

--- a/apps/macos/FridayRustClient/Sources/FridayRustClient/Protocol.swift
+++ b/apps/macos/FridayRustClient/Sources/FridayRustClient/Protocol.swift
@@ -462,6 +462,12 @@ public enum FridayMessage: Equatable {
   /// trusted-peer→hub: relay an operator's OPAQUE Ed25519-signed approval to resume a paused run.
   /// The courier authors NOTHING in `signed_blob` (INV-1). Mirrors `Message::AgentRunResume`.
   case agentRunResume(runId: String, signedBlob: [UInt8])
+  /// trusted-peer→hub: owner-authed terminal stop for one live run. Mirrors
+  /// `Message::AgentRunCancel`.
+  case agentRunCancel(runId: String, forwardedPrincipal: String, authProof: [UInt8], reason: String?)
+  /// trusted-peer→hub: owner-authed refusal of one pending approval. Mirrors
+  /// `Message::AgentRunReject`.
+  case agentRunReject(runId: String, approvalId: String, forwardedPrincipal: String, authProof: [UInt8])
   /// hub→trusted-peer: the body-free receipt for a control op (resume/cancel/reject). Mirrors
   /// `friday_protocol::Message::AgentRunControlResult`.
   case agentRunControlResult(AgentRunControlResultWire)
@@ -528,9 +534,11 @@ extension FridayMessage: Codable {
     case actionDigest = "action_digest"
     case summary
     case signedBlob = "signed_blob"
+    case approvalId = "approval_id"
     case op
     case accepted
     case auditRef = "audit_ref"
+    case reason
     case deviceId = "device_id"
     case devicePubkey = "device_pubkey"
     case pairingProof = "pairing_proof"
@@ -660,6 +668,20 @@ extension FridayMessage: Codable {
       self = .agentRunResume(
         runId: try c.decode(String.self, forKey: .runId),
         signedBlob: try c.decode([UInt8].self, forKey: .signedBlob))
+    case "AgentRunCancel":
+      let c = try decoder.container(keyedBy: WriteKey.self)
+      self = .agentRunCancel(
+        runId: try c.decode(String.self, forKey: .runId),
+        forwardedPrincipal: try c.decode(String.self, forKey: .forwardedPrincipal),
+        authProof: try c.decode([UInt8].self, forKey: .authProof),
+        reason: try c.decodeIfPresent(String.self, forKey: .reason))
+    case "AgentRunReject":
+      let c = try decoder.container(keyedBy: WriteKey.self)
+      self = .agentRunReject(
+        runId: try c.decode(String.self, forKey: .runId),
+        approvalId: try c.decode(String.self, forKey: .approvalId),
+        forwardedPrincipal: try c.decode(String.self, forKey: .forwardedPrincipal),
+        authProof: try c.decode([UInt8].self, forKey: .authProof))
     case "AgentRunControlResult":
       let c = try decoder.container(keyedBy: WriteKey.self)
       self = .agentRunControlResult(AgentRunControlResultWire(
@@ -839,6 +861,20 @@ extension FridayMessage: Codable {
       try c.encode("AgentRunResume", forKey: .kind)
       try c.encode(runId, forKey: .runId)
       try c.encode(signedBlob, forKey: .signedBlob)
+    case .agentRunCancel(let runId, let forwardedPrincipal, let authProof, let reason):
+      var c = encoder.container(keyedBy: WriteKey.self)
+      try c.encode("AgentRunCancel", forKey: .kind)
+      try c.encode(runId, forKey: .runId)
+      try c.encode(forwardedPrincipal, forKey: .forwardedPrincipal)
+      try c.encode(authProof, forKey: .authProof)
+      if let reason { try c.encode(reason, forKey: .reason) }
+    case .agentRunReject(let runId, let approvalId, let forwardedPrincipal, let authProof):
+      var c = encoder.container(keyedBy: WriteKey.self)
+      try c.encode("AgentRunReject", forKey: .kind)
+      try c.encode(runId, forKey: .runId)
+      try c.encode(approvalId, forKey: .approvalId)
+      try c.encode(forwardedPrincipal, forKey: .forwardedPrincipal)
+      try c.encode(authProof, forKey: .authProof)
     case .agentRunControlResult(let r):
       var c = encoder.container(keyedBy: WriteKey.self)
       try c.encode("AgentRunControlResult", forKey: .kind)

--- a/apps/macos/FridayRustClient/Sources/FridayRustClient/ReadClient.swift
+++ b/apps/macos/FridayRustClient/Sources/FridayRustClient/ReadClient.swift
@@ -222,6 +222,10 @@ public final class SealedWSReadClient: FridayRustReadClient, @unchecked Sendable
       throw FridayReadClientError.unexpectedResponse(kind: "AgentRunPaused")
     case .agentRunResume:
       throw FridayReadClientError.unexpectedResponse(kind: "AgentRunResume")
+    case .agentRunCancel:
+      throw FridayReadClientError.unexpectedResponse(kind: "AgentRunCancel")
+    case .agentRunReject:
+      throw FridayReadClientError.unexpectedResponse(kind: "AgentRunReject")
     case .agentRunControlResult:
       throw FridayReadClientError.unexpectedResponse(kind: "AgentRunControlResult")
     case .pair:
@@ -329,6 +333,10 @@ public final class SealedWSReadClient: FridayRustReadClient, @unchecked Sendable
       throw FridayReadClientError.unexpectedResponse(kind: "AgentRunPaused")
     case .agentRunResume:
       throw FridayReadClientError.unexpectedResponse(kind: "AgentRunResume")
+    case .agentRunCancel:
+      throw FridayReadClientError.unexpectedResponse(kind: "AgentRunCancel")
+    case .agentRunReject:
+      throw FridayReadClientError.unexpectedResponse(kind: "AgentRunReject")
     case .agentRunControlResult:
       throw FridayReadClientError.unexpectedResponse(kind: "AgentRunControlResult")
     case .pair:

--- a/apps/macos/FridayRustClient/Sources/FridayRustClient/WriteClient.swift
+++ b/apps/macos/FridayRustClient/Sources/FridayRustClient/WriteClient.swift
@@ -147,6 +147,12 @@ public protocol FridayRustWriteClient: Sendable {
   /// inspects NOTHING in `opaqueSignedBlob` and holds NO signing key (INV-1) — it relays VERBATIM.
   /// Fail-closed (`.runControlDisabled`) when the run-control flag is off.
   func resumeWithApproval(runId: String, opaqueSignedBlob: [UInt8]) async throws -> ResumeRelayResult
+  /// Reject one pending approval without resuming the mutation. Owner-authed over the sealed
+  /// session; fail-closed (`.runControlDisabled`) when run-control is off.
+  func rejectApproval(runId: String, approvalId: String) async throws -> ResumeRelayResult
+  /// Cancel one live run. Owner-authed over the sealed session; fail-closed
+  /// (`.runControlDisabled`) when run-control is off.
+  func cancelRun(runId: String, reason: String?) async throws -> ResumeRelayResult
 }
 
 // MARK: - The mission-spine WRITE client protocol (Lane-D entry-point-A organic driver)
@@ -331,7 +337,7 @@ public final class SealedWSWriteClient: FridayRustWriteClient, FridayMissionSpin
       ))
     case .error(let code, let message):
       throw FridayWriteClientError.serverError(code: code, message: message)
-    case .agentRunRequest, .agentRunResume, .agentRunControlResult,
+    case .agentRunRequest, .agentRunResume, .agentRunCancel, .agentRunReject, .agentRunControlResult,
          .pair, .pairAck, .hubStatus,
          .workbenchProjectionRequest, .workbenchProjectionSnapshot,
          .runReadbackRequest, .runReadbackSnapshot,
@@ -479,6 +485,71 @@ public final class SealedWSWriteClient: FridayRustWriteClient, FridayMissionSpin
     return try parseControlResult(respEnvelope.message)
   }
 
+  public func rejectApproval(runId: String, approvalId: String) async throws -> ResumeRelayResult {
+    guard !approvalId.isEmpty else { throw FridayWriteClientError.missingRef("reject requires an approval id") }
+    return try await sendOwnerAuthedControl(
+      runId: runId,
+      msgId: "agent-run-reject-\(runId)-\(approvalId)",
+      message: { authProof in
+        .agentRunReject(
+          runId: runId,
+          approvalId: approvalId,
+          forwardedPrincipal: forwardedPrincipal,
+          authProof: authProof)
+      },
+      closedMessage: "reject: connection closed before a control result")
+  }
+
+  public func cancelRun(runId: String, reason: String? = nil) async throws -> ResumeRelayResult {
+    try await sendOwnerAuthedControl(
+      runId: runId,
+      msgId: "agent-run-cancel-\(runId)",
+      message: { authProof in
+        .agentRunCancel(
+          runId: runId,
+          forwardedPrincipal: forwardedPrincipal,
+          authProof: authProof,
+          reason: reason)
+      },
+      closedMessage: "cancel: connection closed before a control result")
+  }
+
+  private func sendOwnerAuthedControl(
+    runId: String,
+    msgId: String,
+    message: ([UInt8]) -> FridayMessage,
+    closedMessage: String
+  ) async throws -> ResumeRelayResult {
+    guard agentRunControlViaRust else { throw FridayWriteClientError.runControlDisabled }
+    guard !runId.isEmpty else { throw FridayWriteClientError.missingRef("control requires a run id") }
+
+    let transport = try makeTransport()
+    let (sessionKey, sessionNonce) = try handshake(transport)
+    let authProof = try FridayCrypto.buildAuthProof(
+      sessionKey: sessionKey,
+      sessionNonce: sessionNonce,
+      sessionAad: writeSessionAad,
+      authChallenge: writeAuthChallenge,
+      forwardedPrincipal: forwardedPrincipal,
+      boundContext: Array(runId.utf8)
+    )
+    let env = FridayEnvelope(
+      msgId: msgId,
+      sentAt: now(),
+      message: message(authProof)
+    ).withCorrelation(msgId)
+    try transport.sendMessage(try sealEnvelope(env, sessionKey: sessionKey))
+
+    let respBody: [UInt8]
+    do {
+      respBody = try transport.recvMessage()
+    } catch {
+      throw FridayWriteClientError.transport("\(closedMessage): \(error)")
+    }
+    let respEnvelope = try openEnvelope(respBody, sessionKey: sessionKey)
+    return try parseControlResult(respEnvelope.message)
+  }
+
   /// Parse the refs-only `AgentRunControlResult` for a resume relay. A frame missing a required ref
   /// fails closed. A server REFUSAL (`accepted=false`) is a VALID parse — it is a refusal outcome,
   /// not a parse failure (the caller inspects `accepted`). EXPOSED `internal` for unit testing.
@@ -582,6 +653,8 @@ private func dispatchKind(_ message: FridayMessage) -> String {
   case .agentRunResult: return "AgentRunResult"
   case .agentRunPaused: return "AgentRunPaused"
   case .agentRunResume: return "AgentRunResume"
+  case .agentRunCancel: return "AgentRunCancel"
+  case .agentRunReject: return "AgentRunReject"
   case .agentRunControlResult: return "AgentRunControlResult"
   case .missionIntakeRequest: return "MissionIntakeRequest"
   case .missionIntakeResult: return "MissionIntakeResult"

--- a/apps/macos/FridayRustClient/Tests/FridayRustClientTests/WriteClientWiringTests.swift
+++ b/apps/macos/FridayRustClient/Tests/FridayRustClientTests/WriteClientWiringTests.swift
@@ -23,6 +23,8 @@ final class WriteClientWiringTests: XCTestCase {
     case pauseRun            // dispatch → AgentRunPaused(refs only)
     case resumeAccepted      // resume → AgentRunControlResult(accepted, mutation_completed)
     case resumeRefused       // resume → AgentRunControlResult(accepted=false, denied)
+    case rejectAccepted      // reject → AgentRunControlResult(accepted, rejected)
+    case cancelAccepted      // cancel → AgentRunControlResult(accepted, cancelled)
   }
 
   /// An in-memory transport playing the Rust agent-run WRITE server's half, in the byte sequence
@@ -40,9 +42,13 @@ final class WriteClientWiringTests: XCTestCase {
     private var queuedFromServer: [[UInt8]] = []
     private(set) var dispatched = 0
     private(set) var resumed = 0
+    private(set) var rejected = 0
+    private(set) var cancelled = 0
     private(set) var endedFailClosed = false
     /// Captured VERBATIM blob the client relayed (proves INV-1 verbatim relay end-to-end).
     private(set) var receivedSignedBlob: [UInt8]?
+    private(set) var receivedApprovalId: String?
+    private(set) var receivedCancelReason: String?
     private(set) var receivedConstraints: AgentRunConstraintsWire?
     private(set) var receivedSessionId: String?
     private(set) var receivedMissionContext: MissionWorkItemContextWire?
@@ -89,6 +95,34 @@ final class WriteClientWiringTests: XCTestCase {
         try handleDispatch(req, sessionKey: sessionKey, correlation: env.msgId)
       case .agentRunResume(let runId, let signedBlob):
         try handleResume(runId: runId, signedBlob: signedBlob, sessionKey: sessionKey, correlation: env.msgId)
+      case .agentRunReject(let runId, let approvalId, let forwardedPrincipal, let authProof):
+        try handleOwnerAuthedControl(
+          runId: runId,
+          forwardedPrincipal: forwardedPrincipal,
+          authProof: authProof,
+          sessionKey: sessionKey,
+          correlation: env.msgId,
+          op: "reject",
+          acceptedStatus: "rejected",
+          auditRef: "audit://reject/\(runId)",
+          onAccepted: {
+            self.receivedApprovalId = approvalId
+            self.rejected += 1
+          })
+      case .agentRunCancel(let runId, let forwardedPrincipal, let authProof, let reason):
+        try handleOwnerAuthedControl(
+          runId: runId,
+          forwardedPrincipal: forwardedPrincipal,
+          authProof: authProof,
+          sessionKey: sessionKey,
+          correlation: env.msgId,
+          op: "cancel",
+          acceptedStatus: "cancelled",
+          auditRef: "audit://cancel/\(runId)",
+          onAccepted: {
+            self.receivedCancelReason = reason
+            self.cancelled += 1
+          })
       default:
         throw FridayWriteClientError.transport("unexpected inbound on the write session: \(env.msgId)")
       }
@@ -146,6 +180,50 @@ final class WriteClientWiringTests: XCTestCase {
       queuedFromServer.append(try FridayCrypto.encodeSealed(FridayCrypto.seal(
         key: sessionKey, plaintext: [UInt8](resp.encodeJSON()), aad: writeSessionAad)))
       resumed += 1
+    }
+
+    private func handleOwnerAuthedControl(
+      runId: String,
+      forwardedPrincipal: String,
+      authProof: [UInt8],
+      sessionKey: [UInt8],
+      correlation: String,
+      op: String,
+      acceptedStatus: String,
+      auditRef: String,
+      onAccepted: () -> Void
+    ) throws {
+      let reqAad = FridayCrypto.authAad(
+        writeSessionAad,
+        forwardedPrincipal: forwardedPrincipal,
+        boundContext: Array(runId.utf8))
+      let opened: [UInt8]
+      do {
+        opened = try FridayCrypto.open(
+          key: sessionKey,
+          sealed: FridayCrypto.decodeSealed(authProof),
+          aad: reqAad)
+      } catch {
+        endedFailClosed = true
+        return
+      }
+      let expected = FridayCrypto.nonceBoundChallenge(writeAuthChallenge, sessionNonce: sessionNonce)
+      let accepted = opened == expected && ownerAllowlist.contains(forwardedPrincipal)
+      if accepted {
+        onAccepted()
+      }
+      let result = AgentRunControlResultWire(
+        runId: runId,
+        op: op,
+        accepted: accepted,
+        status: accepted ? acceptedStatus : "auth_failed",
+        auditRef: accepted ? auditRef : nil)
+      let resp = FridayEnvelope(
+        msgId: "agent-run-control-result-\(runId)",
+        sentAt: 1_780_640_000_000,
+        message: .agentRunControlResult(result)).withCorrelation(correlation)
+      queuedFromServer.append(try FridayCrypto.encodeSealed(FridayCrypto.seal(
+        key: sessionKey, plaintext: [UInt8](resp.encodeJSON()), aad: writeSessionAad)))
     }
 
     func recvMessage() throws -> [UInt8] {
@@ -326,6 +404,67 @@ final class WriteClientWiringTests: XCTestCase {
     } catch let err as FridayWriteClientError {
       XCTAssertEqual(err, .emptySignedBlob)
       XCTAssertEqual(transport.resumed, 0)
+    }
+  }
+
+  // MARK: reject/cancel (owner-authed run controls)
+
+  func testReject_flagOn_sendsOwnerAuthedApprovalReject() async throws {
+    let (client, transport) = try makeClient(mode: .rejectAccepted, controlEnabled: true)
+    let result = try await client.rejectApproval(runId: "run-paused-9", approvalId: "approval-123")
+    XCTAssertTrue(result.accepted)
+    XCTAssertEqual(result.op, "reject")
+    XCTAssertEqual(result.status, "rejected")
+    XCTAssertEqual(result.auditRef, "audit://reject/run-paused-9")
+    XCTAssertEqual(transport.rejected, 1)
+    XCTAssertEqual(transport.receivedApprovalId, "approval-123")
+    XCTAssertEqual(transport.resumed, 0, "reject must not relay a resume blob")
+  }
+
+  func testReject_flagOff_refusesWithoutOpeningASocket() async throws {
+    let (client, transport) = try makeClient(mode: .rejectAccepted, controlEnabled: false)
+    do {
+      _ = try await client.rejectApproval(runId: "run-x", approvalId: "approval-x")
+      XCTFail("reject with the flag off must fail closed")
+    } catch let err as FridayWriteClientError {
+      XCTAssertEqual(err, .runControlDisabled)
+      XCTAssertEqual(transport.rejected, 0)
+      XCTAssertNil(transport.receivedApprovalId)
+    }
+  }
+
+  func testReject_missingApprovalId_failsClosedBeforeSocket() async throws {
+    let (client, transport) = try makeClient(mode: .rejectAccepted, controlEnabled: true)
+    do {
+      _ = try await client.rejectApproval(runId: "run-x", approvalId: "")
+      XCTFail("reject requires a concrete approval id")
+    } catch let err as FridayWriteClientError {
+      XCTAssertEqual(err, .missingRef("reject requires an approval id"))
+      XCTAssertEqual(transport.rejected, 0)
+    }
+  }
+
+  func testCancel_flagOn_sendsOwnerAuthedCancel() async throws {
+    let (client, transport) = try makeClient(mode: .cancelAccepted, controlEnabled: true)
+    let result = try await client.cancelRun(runId: "run-live-1", reason: "operator stopped it")
+    XCTAssertTrue(result.accepted)
+    XCTAssertEqual(result.op, "cancel")
+    XCTAssertEqual(result.status, "cancelled")
+    XCTAssertEqual(result.auditRef, "audit://cancel/run-live-1")
+    XCTAssertEqual(transport.cancelled, 1)
+    XCTAssertEqual(transport.receivedCancelReason, "operator stopped it")
+    XCTAssertEqual(transport.resumed, 0)
+  }
+
+  func testCancel_flagOff_refusesWithoutOpeningASocket() async throws {
+    let (client, transport) = try makeClient(mode: .cancelAccepted, controlEnabled: false)
+    do {
+      _ = try await client.cancelRun(runId: "run-x", reason: nil)
+      XCTFail("cancel with the flag off must fail closed")
+    } catch let err as FridayWriteClientError {
+      XCTAssertEqual(err, .runControlDisabled)
+      XCTAssertEqual(transport.cancelled, 0)
+      XCTAssertNil(transport.receivedCancelReason)
     }
   }
 }

--- a/apps/macos/FridayRustClient/Tests/FridayRustClientTests/WriteKATTests.swift
+++ b/apps/macos/FridayRustClient/Tests/FridayRustClientTests/WriteKATTests.swift
@@ -258,6 +258,54 @@ final class WriteKATTests: XCTestCase {
     XCTAssertEqual(recovered, blob, "the signed blob must round-trip byte-for-byte (verbatim relay)")
   }
 
+  func testWK5_agentRunRejectCarriesOwnerAuthAndApprovalId() throws {
+    let msg = FridayMessage.agentRunReject(
+      runId: "run-1",
+      approvalId: "approval-1",
+      forwardedPrincipal: "owner-1",
+      authProof: [0x09, 0x0A])
+    let env = FridayEnvelope(msgId: "reject-1", sentAt: 1004, message: msg)
+    let json = String(decoding: try env.encodeJSON(), as: UTF8.self)
+    XCTAssertTrue(json.contains("\"kind\":\"AgentRunReject\""))
+    XCTAssertTrue(json.contains("\"approval_id\":\"approval-1\""))
+    XCTAssertTrue(json.contains("\"forwarded_principal\":\"owner-1\""))
+    XCTAssertTrue(json.contains("\"auth_proof\":[9,10]"))
+    XCTAssertFalse(json.contains("signed_blob"))
+    let messageObj = try messageObject(json)
+    XCTAssertEqual(Set(messageObj.keys), ["kind", "run_id", "approval_id", "forwarded_principal", "auth_proof"])
+    XCTAssertEqual(try FridayEnvelope.decodeJSON(Data(json.utf8)).message, msg)
+  }
+
+  func testWK5_agentRunCancelCarriesOwnerAuthAndOptionalReason() throws {
+    let withReason = FridayMessage.agentRunCancel(
+      runId: "run-1",
+      forwardedPrincipal: "owner-1",
+      authProof: [0x01, 0x02, 0x03],
+      reason: "operator stopped it")
+    let json = String(decoding: try FridayEnvelope(
+      msgId: "cancel-1",
+      sentAt: 1005,
+      message: withReason).encodeJSON(), as: UTF8.self)
+    XCTAssertTrue(json.contains("\"kind\":\"AgentRunCancel\""))
+    XCTAssertTrue(json.contains("\"reason\":\"operator stopped it\""))
+    XCTAssertFalse(json.contains("signed_blob"))
+    let messageObj = try messageObject(json)
+    XCTAssertEqual(Set(messageObj.keys), ["kind", "run_id", "forwarded_principal", "auth_proof", "reason"])
+    XCTAssertEqual(try FridayEnvelope.decodeJSON(Data(json.utf8)).message, withReason)
+
+    let withoutReason = FridayMessage.agentRunCancel(
+      runId: "run-2",
+      forwardedPrincipal: "owner-1",
+      authProof: [0x04],
+      reason: nil)
+    let noReasonJSON = String(decoding: try FridayEnvelope(
+      msgId: "cancel-2",
+      sentAt: 1006,
+      message: withoutReason).encodeJSON(), as: UTF8.self)
+    XCTAssertFalse(noReasonJSON.contains("reason"))
+    XCTAssertEqual(try FridayEnvelope.decodeJSON(Data(noReasonJSON.utf8)).message, withoutReason)
+  }
+
   // MARK: WK6 — the AgentRunPaused / AgentRunResult / AgentRunControlResult wire (refs-only)
 
   /// WK6: an `AgentRunPaused` frame round-trips and is REFS-ONLY — it carries the nonce +


### PR DESCRIPTION
## Summary
- add Swift wire/client support for `AgentRunReject` and `AgentRunCancel` over the existing sealed WRITE session
- make iOS chat Reject server-backed, surfacing a refs-only control receipt instead of locally dismissing the pause
- keep resume/operator signature semantics unchanged: app still only relays opaque signed blobs and never signs

## Truth / Scope
- This is a client/control wiring slice for T2 approval/stuck-card closure.
- It does not flip run-control live, does not mint operator signatures, and does not claim GO-LIVE or END-BAR completion.
- Reject/cancel are owner-authed with the same run-id-bound auth proof used by dispatch controls.

## Verification
- `swift test --package-path apps/macos/FridayRustClient`
- `swift test --package-path apps/friday-ios`
- `swift test --package-path apps/macos/FridayHubConsole`
- `git diff --check origin/main...HEAD`
- `detect-secrets-hook --baseline .secrets.baseline $(git diff --name-only origin/main...HEAD)`
