### PR TITLE
Wire iOS session stop control

### DIFF
--- a/apps/friday-ios/Sources/FridayMobileShell/FridayApp.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayApp.swift
@@ -224,7 +224,9 @@ struct RootView: View {
       devicePairing: session.devicePairing,
       makePairingClient: session.makePairingClient))
     _sessionContinuationVM = StateObject(wrappedValue: SessionContinuationViewModel(
-      client: session.readClient))
+      client: session.readClient,
+      writeClient: session.writeClient,
+      runControlEnabled: session.runControlEnabled))
   }
 
   var body: some View {

--- a/apps/friday-ios/Sources/FridayMobileShell/FridaySessionDetailScreen.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridaySessionDetailScreen.swift
@@ -122,7 +122,12 @@ struct FridaySessionDetailScreen: View {
         cardHeader("Controls", count: nil)
         LazyVGrid(columns: [GridItem(.flexible()), GridItem(.flexible())], spacing: 10) {
           ForEach(controls) { control in
-            Button {} label: {
+            let controlState = viewModel.controlStates[control.id]
+            Button {
+              if control.id == "stop" {
+                Task { await viewModel.stop() }
+              }
+            } label: {
               VStack(alignment: .leading, spacing: 6) {
                 HStack {
                   Image(systemName: control.systemImage)
@@ -135,16 +140,47 @@ struct FridaySessionDetailScreen: View {
                   .font(.caption2)
                   .foregroundStyle(MobileTheme.textSecondary)
                   .fixedSize(horizontal: false, vertical: true)
+                controlStateView(controlState)
               }
               .frame(maxWidth: .infinity, minHeight: 70, alignment: .topLeading)
               .padding(10)
             }
             .buttonStyle(.bordered)
-            .disabled(!control.isEnabled)
+            .disabled(!control.isEnabled || controlStateDisablesButton(controlState))
             .accessibilityLabel("\(control.title) \(control.truthLabel). \(control.reason)")
           }
         }
       }
+    }
+  }
+
+  @ViewBuilder
+  private func controlStateView(_ state: SessionContinuationControlState?) -> some View {
+    switch state {
+    case .sending:
+      Text("Sending control...")
+        .font(.caption2)
+        .foregroundStyle(MobileTheme.textSecondary)
+    case .succeeded(let summary):
+      Text(summary)
+        .font(.caption2)
+        .foregroundStyle(MobileTheme.textSecondary)
+    case .error(let reason):
+      Text(reason)
+        .font(.caption2)
+        .foregroundStyle(MobileTheme.coral)
+    case .idle, nil:
+      EmptyView()
+    }
+  }
+
+  private func controlStateDisablesButton(_ state: SessionContinuationControlState?) -> Bool {
+    guard let state else { return false }
+    switch state {
+    case .sending, .succeeded:
+      return true
+    case .idle, .error:
+      return false
     }
   }
 

--- a/apps/friday-ios/Sources/FridayMobileShellCore/SessionContinuationViewModel.swift
+++ b/apps/friday-ios/Sources/FridayMobileShellCore/SessionContinuationViewModel.swift
@@ -37,6 +37,13 @@ public struct SessionContinuationSnapshot: Sendable, Equatable {
   }
 }
 
+public enum SessionContinuationControlState: Sendable, Equatable {
+  case idle
+  case sending
+  case succeeded(summary: String)
+  case error(reason: String)
+}
+
 public enum SessionContinuationLoadState: Sendable, Equatable {
   case idle
   case loading(agentSessionId: String)
@@ -52,11 +59,20 @@ public enum SessionContinuationLoadState: Sendable, Equatable {
 @MainActor
 public final class SessionContinuationViewModel: ObservableObject {
   @Published public private(set) var state: SessionContinuationLoadState = .idle
+  @Published public private(set) var controlStates: [String: SessionContinuationControlState] = [:]
 
   private let client: FridayRustReadClient
+  private let writeClient: FridayRustWriteClient?
+  private let runControlEnabled: Bool
 
-  public init(client: FridayRustReadClient) {
+  public init(
+    client: FridayRustReadClient,
+    writeClient: FridayRustWriteClient? = nil,
+    runControlEnabled: Bool = false
+  ) {
     self.client = client
+    self.writeClient = writeClient
+    self.runControlEnabled = runControlEnabled
   }
 
   public func refresh(agentSessionId: String?, runId: String?) async {
@@ -68,6 +84,7 @@ public final class SessionContinuationViewModel: ObservableObject {
 
     let trimmedRunId = runId?.trimmingCharacters(in: .whitespacesAndNewlines)
     let resolvedRunId = (trimmedRunId?.isEmpty == false) ? trimmedRunId : nil
+    controlStates = [:]
     state = .loading(agentSessionId: sessionId)
 
     async let open = Self.fetchSessionOpen(client: client, agentSessionId: sessionId)
@@ -99,7 +116,39 @@ public final class SessionContinuationViewModel: ObservableObject {
       agentSessionId: sessionId,
       runId: resolvedRunId,
       sections: sections,
-      controls: Self.disabledControls()))
+      controls: Self.controls(
+        runId: resolvedRunId,
+        hasWriteClient: writeClient != nil,
+        runControlEnabled: runControlEnabled)))
+  }
+
+  public func stop() async {
+    guard case .loaded(let snapshot) = state else { return }
+    guard let runId = snapshot.runId?.trimmingCharacters(in: .whitespacesAndNewlines), !runId.isEmpty else {
+      controlStates["stop"] = .error(reason: "Stop requires a run ref.")
+      return
+    }
+    guard runControlEnabled else {
+      controlStates["stop"] = .error(reason: "Stop is gated off for this session.")
+      return
+    }
+    guard let writeClient else {
+      controlStates["stop"] = .error(reason: "Stop requires the governed write client.")
+      return
+    }
+    controlStates["stop"] = .sending
+    do {
+      let result = try await writeClient.cancelRun(
+        runId: runId,
+        reason: "operator stopped run from mobile session detail")
+      if result.accepted {
+        controlStates["stop"] = .succeeded(summary: Self.controlSummary(for: result))
+      } else {
+        controlStates["stop"] = .error(reason: "Stop refused: \(Self.controlSummary(for: result))")
+      }
+    } catch {
+      controlStates["stop"] = .error(reason: Self.writeReason(for: error, verb: "stop"))
+    }
   }
 
   private nonisolated static func fetchSessionOpen(
@@ -167,8 +216,23 @@ public final class SessionContinuationViewModel: ObservableObject {
     }
   }
 
-  private nonisolated static func disabledControls() -> [SessionContinuationControl] {
-    [
+  private nonisolated static func controls(
+    runId: String?,
+    hasWriteClient: Bool,
+    runControlEnabled: Bool
+  ) -> [SessionContinuationControl] {
+    let stopReady = runId != nil && hasWriteClient && runControlEnabled
+    let stopReason: String
+    if stopReady {
+      stopReason = "Owner-authenticated cancel is wired through the governed write seam."
+    } else if runId == nil {
+      stopReason = "Stop requires a run ref."
+    } else if !runControlEnabled {
+      stopReason = "Stop is gated off for this session."
+    } else {
+      stopReason = "Stop requires the governed write client."
+    }
+    return [
       SessionContinuationControl(
         id: "send",
         title: "Send",
@@ -180,9 +244,9 @@ public final class SessionContinuationViewModel: ObservableObject {
         id: "stop",
         title: "Stop",
         systemImage: "stop.circle",
-        truthLabel: "NO-GO",
-        reason: "Stop requires a governed mutation endpoint; none is wired here.",
-        isEnabled: false),
+        truthLabel: stopReady ? "guarded" : "NO-GO",
+        reason: stopReason,
+        isEnabled: stopReady),
       SessionContinuationControl(
         id: "resume",
         title: "Resume",
@@ -200,6 +264,15 @@ public final class SessionContinuationViewModel: ObservableObject {
     ]
   }
 
+  private nonisolated static func controlSummary(for result: ResumeRelayResult) -> String {
+    var parts = ["\(result.op): \(result.status)"]
+    parts.append(result.accepted ? "accepted" : "refused")
+    if let auditRef = result.auditRef, !auditRef.isEmpty {
+      parts.append(auditRef)
+    }
+    return parts.joined(separator: " · ")
+  }
+
   private nonisolated static func reason(for error: Error) -> String {
     if let e = error as? FridayReadClientError {
       switch e {
@@ -211,6 +284,28 @@ public final class SessionContinuationViewModel: ObservableObject {
         return "Friday returned an unexpected response (\(kind))"
       case let .malformedProjection(why):
         return "Status unavailable — \(why)"
+      case let .transport(why):
+        return "Friday is offline — \(why)"
+      }
+    }
+    return "Friday is unavailable — \(error)"
+  }
+
+  private nonisolated static func writeReason(for error: Error, verb: String) -> String {
+    if let e = error as? FridayWriteClientError {
+      switch e {
+      case .badServerPubkey, .badSessionNonce:
+        return "Friday could not establish a trusted connection"
+      case let .serverError(code, message):
+        return "Friday is unavailable (\(code.rawValue)) — \(message)"
+      case let .unexpectedResponse(kind):
+        return "Friday returned an unexpected response (\(kind))"
+      case let .missingRef(why):
+        return "Friday returned an incomplete \(verb) response — \(why)"
+      case .runControlDisabled:
+        return "Stop is gated off for this session"
+      case .emptySignedBlob:
+        return "Stop unavailable — unexpected empty signature state"
       case let .transport(why):
         return "Friday is offline — \(why)"
       }

--- a/apps/friday-ios/Tests/FridayMobileShellCoreTests/SessionContinuationViewModelTests.swift
+++ b/apps/friday-ios/Tests/FridayMobileShellCoreTests/SessionContinuationViewModelTests.swift
@@ -84,6 +84,53 @@ final class SessionContinuationViewModelTests: XCTestCase {
     }
   }
 
+  final class FakeSessionWriteClient: FridayRustWriteClient, @unchecked Sendable {
+    enum Script {
+      case accepted(ResumeRelayResult)
+      case refused(ResumeRelayResult)
+      case fail(FridayWriteClientError)
+    }
+
+    let script: Script
+    private(set) var cancelledRunIds: [String] = []
+    private(set) var cancelReasons: [String?] = []
+
+    init(_ script: Script = .accepted(ResumeRelayResult(
+      runId: "run-1",
+      op: "cancel",
+      accepted: true,
+      status: "cancelled",
+      auditRef: "audit://cancel/run-1"))) {
+      self.script = script
+    }
+
+    func dispatchAgentRun(
+      task: String,
+      constraints: AgentRunConstraintsWire?
+    ) async throws -> AgentRunDispatchOutcome {
+      throw FridayWriteClientError.transport("unused")
+    }
+
+    func resumeWithApproval(runId: String, opaqueSignedBlob: [UInt8]) async throws -> ResumeRelayResult {
+      throw FridayWriteClientError.transport("unused")
+    }
+
+    func rejectApproval(runId: String, approvalId: String) async throws -> ResumeRelayResult {
+      throw FridayWriteClientError.transport("unused")
+    }
+
+    func cancelRun(runId: String, reason: String?) async throws -> ResumeRelayResult {
+      cancelledRunIds.append(runId)
+      cancelReasons.append(reason)
+      switch script {
+      case .accepted(let result), .refused(let result):
+        return result
+      case .fail(let error):
+        throw error
+      }
+    }
+  }
+
   func testRefreshWithSessionAndRunReadsAllContinuationArmsAndKeepsControlsNoGo() async {
     let client = FakeSessionReadClient()
     let vm = SessionContinuationViewModel(client: client)
@@ -113,6 +160,74 @@ final class SessionContinuationViewModelTests: XCTestCase {
     XCTAssertEqual(snapshot.sections.first?.generatedAtMs, 1_780_640_000_123)
     XCTAssertEqual(snapshot.controls.map(\.title), ["Send", "Stop", "Resume", "Fork"])
     XCTAssertTrue(snapshot.controls.allSatisfy { !$0.isEnabled && $0.truthLabel == "NO-GO" })
+  }
+
+  func testRefreshWithRunAndGateOnEnablesGuardedStop() async {
+    let client = FakeSessionReadClient()
+    let write = FakeSessionWriteClient()
+    let vm = SessionContinuationViewModel(
+      client: client,
+      writeClient: write,
+      runControlEnabled: true)
+
+    await vm.refresh(agentSessionId: "session-1", runId: "run-1")
+
+    guard case .loaded(let snapshot) = vm.state else {
+      return XCTFail("expected loaded session continuation, got \(vm.state)")
+    }
+    let stop = snapshot.controls.first { $0.id == "stop" }
+    XCTAssertEqual(stop?.truthLabel, "guarded")
+    XCTAssertEqual(stop?.isEnabled, true)
+    XCTAssertTrue(stop?.reason.contains("cancel") == true)
+  }
+
+  func testStopUsesGovernedCancelRunAndSurfacesReceipt() async {
+    let client = FakeSessionReadClient()
+    let write = FakeSessionWriteClient()
+    let vm = SessionContinuationViewModel(
+      client: client,
+      writeClient: write,
+      runControlEnabled: true)
+
+    await vm.refresh(agentSessionId: "session-1", runId: "run-1")
+    await vm.stop()
+
+    XCTAssertEqual(write.cancelledRunIds, ["run-1"])
+    XCTAssertEqual(write.cancelReasons, ["operator stopped run from mobile session detail"])
+    XCTAssertEqual(
+      vm.controlStates["stop"],
+      .succeeded(summary: "cancel: cancelled · accepted · audit://cancel/run-1"))
+  }
+
+  func testStopRefusalAndTransportFailureRenderError() async {
+    let refused = FakeSessionWriteClient(.refused(ResumeRelayResult(
+      runId: "run-1",
+      op: "cancel",
+      accepted: false,
+      status: "already_terminal",
+      auditRef: nil)))
+    let refusedVM = SessionContinuationViewModel(
+      client: FakeSessionReadClient(),
+      writeClient: refused,
+      runControlEnabled: true)
+    await refusedVM.refresh(agentSessionId: "session-1", runId: "run-1")
+    await refusedVM.stop()
+    guard case .error(let refusedReason) = refusedVM.controlStates["stop"] else {
+      return XCTFail("expected refused error, got \(String(describing: refusedVM.controlStates["stop"]))")
+    }
+    XCTAssertTrue(refusedReason.contains("already_terminal"), "reason: \(refusedReason)")
+
+    let failed = FakeSessionWriteClient(.fail(.transport("server dark")))
+    let failedVM = SessionContinuationViewModel(
+      client: FakeSessionReadClient(),
+      writeClient: failed,
+      runControlEnabled: true)
+    await failedVM.refresh(agentSessionId: "session-1", runId: "run-1")
+    await failedVM.stop()
+    guard case .error(let failedReason) = failedVM.controlStates["stop"] else {
+      return XCTFail("expected transport error, got \(String(describing: failedVM.controlStates["stop"]))")
+    }
+    XCTAssertTrue(failedReason.contains("offline"), "reason: \(failedReason)")
   }
 
   func testRefreshWithoutRunRefDoesNotReadRunArms() async {


### PR DESCRIPTION
## Summary
- wire the iOS Session Detail Stop control to the existing governed cancelRun write seam
- keep Stop gated/fail-closed unless run control, run ref, and write client are all present
- surface accepted/refused/transport outcomes as refs-only UI state without local fake dismissal

## Truth labels
- T2 app-internal control loop slice only
- no operator signing, no trust-grant/passport minting, no GO-LIVE claim
- organic remains exactly the already-proven operator-origin Codex run; this PR does not add organic load

## Verification
- swift test --package-path apps/friday-ios
- apps/friday-ios/build-sim.sh
- git diff --check
- detect-secrets-hook --baseline .secrets.baseline 