### PR TITLE
Wire iOS session resume approval relay

### DIFF
--- a/apps/friday-ios/Sources/FridayMobileShell/FridayApp.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayApp.swift
@@ -226,6 +226,7 @@ struct RootView: View {
     _sessionContinuationVM = StateObject(wrappedValue: SessionContinuationViewModel(
       client: session.readClient,
       writeClient: session.writeClient,
+      signer: session.signer,
       runControlEnabled: session.runControlEnabled))
   }
 

--- a/apps/friday-ios/Sources/FridayMobileShell/FridaySessionDetailScreen.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridaySessionDetailScreen.swift
@@ -126,6 +126,8 @@ struct FridaySessionDetailScreen: View {
             Button {
               if control.id == "stop" {
                 Task { await viewModel.stop() }
+              } else if control.id == "resume" {
+                Task { await viewModel.resume() }
               }
             } label: {
               VStack(alignment: .leading, spacing: 6) {

--- a/apps/friday-ios/Sources/FridayMobileShellCore/SessionContinuationViewModel.swift
+++ b/apps/friday-ios/Sources/FridayMobileShellCore/SessionContinuationViewModel.swift
@@ -30,10 +30,26 @@ public struct SessionContinuationSnapshot: Sendable, Equatable {
   public let runId: String?
   public let sections: [SessionContinuationSection]
   public let controls: [SessionContinuationControl]
+  public let pendingApproval: SessionContinuationApproval?
 
   public var proofRefs: [String] {
     var seen = Set<String>()
     return sections.flatMap(\.refs).filter { seen.insert($0).inserted }
+  }
+}
+
+public struct SessionContinuationApproval: Sendable, Equatable {
+  public let runId: String
+  public let approvalId: String
+  public let actionDigest: String
+  public let summary: String?
+
+  public var signingRequest: ApprovalSigningRequest {
+    ApprovalSigningRequest(
+      runId: runId,
+      approvalId: approvalId,
+      actionDigest: actionDigest,
+      summary: summary)
   }
 }
 
@@ -63,15 +79,18 @@ public final class SessionContinuationViewModel: ObservableObject {
 
   private let client: FridayRustReadClient
   private let writeClient: FridayRustWriteClient?
+  private let signer: OperatorSigner?
   private let runControlEnabled: Bool
 
   public init(
     client: FridayRustReadClient,
     writeClient: FridayRustWriteClient? = nil,
+    signer: OperatorSigner? = nil,
     runControlEnabled: Bool = false
   ) {
     self.client = client
     self.writeClient = writeClient
+    self.signer = signer
     self.runControlEnabled = runControlEnabled
   }
 
@@ -91,10 +110,13 @@ public final class SessionContinuationViewModel: ObservableObject {
     async let link = Self.fetchSessionLinkState(client: client, agentSessionId: sessionId)
 
     var sections = await [open, link]
+    var pendingApproval: SessionContinuationApproval?
     if let resolvedRunId {
       async let files = Self.fetchRunFileView(client: client, runId: resolvedRunId)
-      async let needsMe = Self.fetchActivityNeedsMe(client: client, runId: resolvedRunId)
-      sections.append(contentsOf: await [files, needsMe])
+      async let needsMe = Self.fetchActivityNeedsMeDetail(client: client, runId: resolvedRunId)
+      let needsMeDetail = await needsMe
+      pendingApproval = needsMeDetail.pendingApproval
+      sections.append(contentsOf: await [files, needsMeDetail.section])
     } else {
       sections.append(SessionContinuationSection(
         id: "run-files",
@@ -118,8 +140,11 @@ public final class SessionContinuationViewModel: ObservableObject {
       sections: sections,
       controls: Self.controls(
         runId: resolvedRunId,
+        hasPendingApproval: pendingApproval != nil,
         hasWriteClient: writeClient != nil,
-        runControlEnabled: runControlEnabled)))
+        hasSigner: signer != nil,
+        runControlEnabled: runControlEnabled),
+      pendingApproval: pendingApproval))
   }
 
   public func stop() async {
@@ -148,6 +173,49 @@ public final class SessionContinuationViewModel: ObservableObject {
       }
     } catch {
       controlStates["stop"] = .error(reason: Self.writeReason(for: error, verb: "stop"))
+    }
+  }
+
+  public func resume() async {
+    guard case .loaded(let snapshot) = state else { return }
+    guard let approval = snapshot.pendingApproval else {
+      controlStates["resume"] = .error(reason: "Resume requires a pending approval ref.")
+      return
+    }
+    guard runControlEnabled else {
+      controlStates["resume"] = .error(reason: "Resume is gated off for this session.")
+      return
+    }
+    guard let writeClient else {
+      controlStates["resume"] = .error(reason: "Resume requires the governed write client.")
+      return
+    }
+    guard let signer else {
+      controlStates["resume"] = .error(reason: "Resume requires the operator signer relay.")
+      return
+    }
+
+    controlStates["resume"] = .sending
+    let blob: [UInt8]
+    do {
+      blob = try await signer.signApproval(approval.signingRequest)
+    } catch {
+      controlStates["resume"] = .error(reason: Self.signerReason(for: error))
+      return
+    }
+    guard !blob.isEmpty else {
+      controlStates["resume"] = .error(reason: "Approval unavailable — the signer returned no signature")
+      return
+    }
+    do {
+      let result = try await writeClient.resumeWithApproval(runId: approval.runId, opaqueSignedBlob: blob)
+      if result.accepted {
+        controlStates["resume"] = .succeeded(summary: Self.controlSummary(for: result))
+      } else {
+        controlStates["resume"] = .error(reason: "Resume refused: \(Self.controlSummary(for: result))")
+      }
+    } catch {
+      controlStates["resume"] = .error(reason: Self.writeReason(for: error, verb: "resume"))
     }
   }
 
@@ -181,14 +249,35 @@ public final class SessionContinuationViewModel: ObservableObject {
       read: { try await client.fetchRunFileView(runId: runId) })
   }
 
-  private nonisolated static func fetchActivityNeedsMe(
+  private nonisolated static func fetchActivityNeedsMeDetail(
     client: FridayRustReadClient,
     runId: String
-  ) async -> SessionContinuationSection {
-    await fetch(
-      id: "needs-me",
-      title: "Needs Me",
-      read: { try await client.fetchActivityNeedsMe(runId: runId) })
+  ) async -> (section: SessionContinuationSection, pendingApproval: SessionContinuationApproval?) {
+    do {
+      let snapshot = try await client.fetchActivityNeedsMe(runId: runId)
+      let detail = HomeReadDetail(title: "Needs Me", snapshot: snapshot)
+      return (
+        SessionContinuationSection(
+          id: "needs-me",
+          title: "Needs Me",
+          status: .loaded,
+          summary: detail.summary,
+          generatedAtMs: detail.generatedAtMs,
+          refs: detail.refs),
+        approval(from: snapshot.raw, fallbackRunId: runId)
+      )
+    } catch {
+      return (
+        SessionContinuationSection(
+          id: "needs-me",
+          title: "Needs Me",
+          status: .unavailable(reason: reason(for: error)),
+          summary: "unavailable",
+          generatedAtMs: nil,
+          refs: []),
+        nil
+      )
+    }
   }
 
   private nonisolated static func fetch(
@@ -218,10 +307,13 @@ public final class SessionContinuationViewModel: ObservableObject {
 
   private nonisolated static func controls(
     runId: String?,
+    hasPendingApproval: Bool,
     hasWriteClient: Bool,
+    hasSigner: Bool,
     runControlEnabled: Bool
   ) -> [SessionContinuationControl] {
     let stopReady = runId != nil && hasWriteClient && runControlEnabled
+    let resumeReady = hasPendingApproval && hasWriteClient && hasSigner && runControlEnabled
     let stopReason: String
     if stopReady {
       stopReason = "Owner-authenticated cancel is wired through the governed write seam."
@@ -231,6 +323,18 @@ public final class SessionContinuationViewModel: ObservableObject {
       stopReason = "Stop is gated off for this session."
     } else {
       stopReason = "Stop requires the governed write client."
+    }
+    let resumeReason: String
+    if resumeReady {
+      resumeReason = "Pending approval refs are present; the operator signer relay can resume through the governed write seam."
+    } else if !hasPendingApproval {
+      resumeReason = "Resume requires a pending approval ref from Needs-Me."
+    } else if !runControlEnabled {
+      resumeReason = "Resume is gated off for this session."
+    } else if !hasSigner {
+      resumeReason = "Resume requires the operator signer relay."
+    } else {
+      resumeReason = "Resume requires the governed write client."
     }
     return [
       SessionContinuationControl(
@@ -251,9 +355,9 @@ public final class SessionContinuationViewModel: ObservableObject {
         id: "resume",
         title: "Resume",
         systemImage: "play.circle",
-        truthLabel: "NO-GO",
-        reason: "Resume is display-only until the governed continuation endpoint exists.",
-        isEnabled: false),
+        truthLabel: resumeReady ? "operator-gated" : "NO-GO",
+        reason: resumeReason,
+        isEnabled: resumeReady),
       SessionContinuationControl(
         id: "fork",
         title: "Fork",
@@ -271,6 +375,47 @@ public final class SessionContinuationViewModel: ObservableObject {
       parts.append(auditRef)
     }
     return parts.joined(separator: " · ")
+  }
+
+  private nonisolated static func approval(
+    from raw: [String: Any],
+    fallbackRunId: String
+  ) -> SessionContinuationApproval? {
+    if let needsMe = raw["needs_me"] as? [String: Any],
+       let approval = approval(fromItem: needsMe, fallbackRunId: fallbackRunId) {
+      return approval
+    }
+    guard let items = raw["actionable_needs_me"] as? [[String: Any]] else { return nil }
+    return items.lazy.compactMap { item in
+      guard (item["kind"] as? String) == "approval_required" else { return nil }
+      return approval(fromItem: item, fallbackRunId: fallbackRunId)
+    }.first
+  }
+
+  private nonisolated static func approval(
+    fromItem item: [String: Any],
+    fallbackRunId: String
+  ) -> SessionContinuationApproval? {
+    let signing = item["signing_request"] as? [String: Any] ?? item
+    let runId = firstNonEmptyString(signing, ["run_id", "runId"]) ?? fallbackRunId
+    guard let approvalId = firstNonEmptyString(signing, ["approval_id", "approvalId", "ref_id", "refId"]),
+          let actionDigest = firstNonEmptyString(signing, ["action_digest", "actionDigest"]) else {
+      return nil
+    }
+    return SessionContinuationApproval(
+      runId: runId,
+      approvalId: approvalId,
+      actionDigest: actionDigest,
+      summary: firstNonEmptyString(signing, ["summary"]) ?? firstNonEmptyString(item, ["summary", "title"]))
+  }
+
+  private nonisolated static func firstNonEmptyString(
+    _ raw: [String: Any],
+    _ keys: [String]
+  ) -> String? {
+    keys.lazy.compactMap { raw[$0] as? String }
+      .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+      .first { !$0.isEmpty }
   }
 
   private nonisolated static func reason(for error: Error) -> String {
@@ -311,5 +456,10 @@ public final class SessionContinuationViewModel: ObservableObject {
       }
     }
     return "Friday is unavailable — \(error)"
+  }
+
+  private nonisolated static func signerReason(for error: Error) -> String {
+    if let e = error as? OperatorSignerError { return e.description }
+    return "Approval unavailable — \(error)"
   }
 }

--- a/apps/friday-ios/Tests/FridayMobileShellCoreTests/SessionContinuationViewModelTests.swift
+++ b/apps/friday-ios/Tests/FridayMobileShellCoreTests/SessionContinuationViewModelTests.swift
@@ -11,11 +11,13 @@ final class SessionContinuationViewModelTests: XCTestCase {
     }
 
     private let script: Script
+    private let needsMeRaw: [String: Any]?
     private let lock = NSLock()
     private var requested: [String] = []
 
-    init(_ script: Script = .success) {
+    init(_ script: Script = .success, needsMeRaw: [String: Any]? = nil) {
       self.script = script
+      self.needsMeRaw = needsMeRaw
     }
 
     var requests: [String] {
@@ -51,11 +53,28 @@ final class SessionContinuationViewModelTests: XCTestCase {
     }
 
     func fetchActivityNeedsMe(runId: String) async throws -> ReadProjectionSnapshot {
-      try recordAndReturn(
+      if let needsMeRaw {
+        return try recordAndReturnRaw(request: "needs-me:\(runId)", raw: needsMeRaw)
+      }
+      return try recordAndReturn(
         request: "needs-me:\(runId)",
         status: "waiting",
         runId: runId,
         proofRef: "proof://needs/\(runId)")
+    }
+
+    private func recordAndReturnRaw(
+      request: String,
+      raw: [String: Any]
+    ) throws -> ReadProjectionSnapshot {
+      lock.lock()
+      requested.append(request)
+      lock.unlock()
+      if case .fail(let error) = script {
+        throw error
+      }
+      let data = try JSONSerialization.data(withJSONObject: raw)
+      return try ReadProjectionSnapshot(projectionJSON: data, generatedAtMs: 1_780_640_000_123)
     }
 
     private func recordAndReturn(
@@ -94,6 +113,8 @@ final class SessionContinuationViewModelTests: XCTestCase {
     let script: Script
     private(set) var cancelledRunIds: [String] = []
     private(set) var cancelReasons: [String?] = []
+    private(set) var resumedRunIds: [String] = []
+    private(set) var relayedBlobs: [[UInt8]] = []
 
     init(_ script: Script = .accepted(ResumeRelayResult(
       runId: "run-1",
@@ -112,7 +133,14 @@ final class SessionContinuationViewModelTests: XCTestCase {
     }
 
     func resumeWithApproval(runId: String, opaqueSignedBlob: [UInt8]) async throws -> ResumeRelayResult {
-      throw FridayWriteClientError.transport("unused")
+      resumedRunIds.append(runId)
+      relayedBlobs.append(opaqueSignedBlob)
+      switch script {
+      case .accepted(let result), .refused(let result):
+        return result
+      case .fail(let error):
+        throw error
+      }
     }
 
     func rejectApproval(runId: String, approvalId: String) async throws -> ResumeRelayResult {
@@ -160,6 +188,7 @@ final class SessionContinuationViewModelTests: XCTestCase {
     XCTAssertEqual(snapshot.sections.first?.generatedAtMs, 1_780_640_000_123)
     XCTAssertEqual(snapshot.controls.map(\.title), ["Send", "Stop", "Resume", "Fork"])
     XCTAssertTrue(snapshot.controls.allSatisfy { !$0.isEnabled && $0.truthLabel == "NO-GO" })
+    XCTAssertNil(snapshot.pendingApproval)
   }
 
   func testRefreshWithRunAndGateOnEnablesGuardedStop() async {
@@ -179,6 +208,157 @@ final class SessionContinuationViewModelTests: XCTestCase {
     XCTAssertEqual(stop?.truthLabel, "guarded")
     XCTAssertEqual(stop?.isEnabled, true)
     XCTAssertTrue(stop?.reason.contains("cancel") == true)
+  }
+
+  func testRefreshParsesNeedsMeApprovalAndEnablesOperatorGatedResume() async {
+    let raw: [String: Any] = [
+      "run_id": "run-1",
+      "status": "waiting",
+      "truthLabel": "friday_owned",
+      "proofRef": "proof://needs/run-1",
+      "needs_me": [
+        "kind": "approval",
+        "ref_id": "approval-1",
+        "action_digest": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "summary": "write_file pending",
+        "signing_request": [
+          "run_id": "run-1",
+          "approval_id": "approval-1",
+          "action_digest": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "summary": "write_file pending",
+        ],
+      ],
+    ]
+    let vm = SessionContinuationViewModel(
+      client: FakeSessionReadClient(needsMeRaw: raw),
+      writeClient: FakeSessionWriteClient(),
+      signer: MockOperatorSigner(),
+      runControlEnabled: true)
+
+    await vm.refresh(agentSessionId: "session-1", runId: "run-1")
+
+    guard case .loaded(let snapshot) = vm.state else {
+      return XCTFail("expected loaded session continuation, got \(vm.state)")
+    }
+    XCTAssertEqual(snapshot.pendingApproval, SessionContinuationApproval(
+      runId: "run-1",
+      approvalId: "approval-1",
+      actionDigest: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      summary: "write_file pending"))
+    let resume = snapshot.controls.first { $0.id == "resume" }
+    XCTAssertEqual(resume?.truthLabel, "operator-gated")
+    XCTAssertEqual(resume?.isEnabled, true)
+    XCTAssertTrue(resume?.reason.contains("operator signer") == true)
+  }
+
+  func testRefreshParsesActionableNeedsMeApprovalFallback() async {
+    let raw: [String: Any] = [
+      "run_id": "run-1",
+      "status": "waiting",
+      "truthLabel": "friday_owned",
+      "actionable_needs_me": [[
+        "kind": "approval_required",
+        "title": "approval required for write_file",
+        "ref_id": "approval-2",
+        "action_digest": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "signing_request": [
+          "run_id": "run-1",
+          "approval_id": "approval-2",
+          "action_digest": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+          "summary": "approval required for write_file",
+        ],
+      ]],
+    ]
+    let vm = SessionContinuationViewModel(
+      client: FakeSessionReadClient(needsMeRaw: raw),
+      writeClient: FakeSessionWriteClient(),
+      signer: MockOperatorSigner(),
+      runControlEnabled: true)
+
+    await vm.refresh(agentSessionId: "session-1", runId: "run-1")
+
+    guard case .loaded(let snapshot) = vm.state else {
+      return XCTFail("expected loaded session continuation, got \(vm.state)")
+    }
+    XCTAssertEqual(snapshot.pendingApproval?.approvalId, "approval-2")
+    XCTAssertEqual(snapshot.pendingApproval?.summary, "approval required for write_file")
+  }
+
+  func testResumeRelaysSignerBlobVerbatimAndSurfacesReceipt() async {
+    let digest = "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+    let raw: [String: Any] = [
+      "run_id": "run-1",
+      "status": "waiting",
+      "truthLabel": "friday_owned",
+      "needs_me": [
+        "signing_request": [
+          "run_id": "run-1",
+          "approval_id": "approval-1",
+          "action_digest": digest,
+          "summary": "write_file pending",
+        ],
+      ],
+    ]
+    let write = FakeSessionWriteClient(.accepted(ResumeRelayResult(
+      runId: "run-1",
+      op: "resume",
+      accepted: true,
+      status: "resumed",
+      auditRef: "audit://resume/run-1")))
+    let signer = MockOperatorSigner()
+    let vm = SessionContinuationViewModel(
+      client: FakeSessionReadClient(needsMeRaw: raw),
+      writeClient: write,
+      signer: signer,
+      runControlEnabled: true)
+
+    await vm.refresh(agentSessionId: "session-1", runId: "run-1")
+    await vm.resume()
+
+    let expectedBlob = try! await signer.signApproval(ApprovalSigningRequest(
+      runId: "run-1",
+      approvalId: "approval-1",
+      actionDigest: digest,
+      summary: "write_file pending"))
+    XCTAssertEqual(write.resumedRunIds, ["run-1"])
+    XCTAssertEqual(write.relayedBlobs, [expectedBlob])
+    XCTAssertEqual(
+      vm.controlStates["resume"],
+      .succeeded(summary: "resume: resumed · accepted · audit://resume/run-1"))
+  }
+
+  func testResumeSignerFailureDoesNotRelay() async {
+    let raw: [String: Any] = [
+      "run_id": "run-1",
+      "needs_me": [
+        "signing_request": [
+          "run_id": "run-1",
+          "approval_id": "approval-1",
+          "action_digest": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+          "summary": "write_file pending",
+        ],
+      ],
+    ]
+    let write = FakeSessionWriteClient(.accepted(ResumeRelayResult(
+      runId: "run-1",
+      op: "resume",
+      accepted: true,
+      status: "resumed",
+      auditRef: nil)))
+    let vm = SessionContinuationViewModel(
+      client: FakeSessionReadClient(needsMeRaw: raw),
+      writeClient: write,
+      signer: MockOperatorSigner(throwing: .declined),
+      runControlEnabled: true)
+
+    await vm.refresh(agentSessionId: "session-1", runId: "run-1")
+    await vm.resume()
+
+    XCTAssertEqual(write.resumedRunIds, [])
+    guard case .error(let reason) = vm.controlStates["resume"] else {
+      return XCTFail("expected signer error, got \(String(describing: vm.controlStates["resume"]))")
+    }
+    XCTAssertTrue(reason.contains("declined"), "reason: \(reason)")
   }
 
   func testStopUsesGovernedCancelRunAndSurfacesReceipt() async {


### PR DESCRIPTION
## Summary
- parse owner-gated Needs-Me signing_request refs into a typed iOS Session Detail pending approval
- enable Resume only when pending approval refs, governed write client, operator signer relay, and run-control gate are all present
- relay signer-produced opaque approval bytes verbatim through resumeWithApproval and surface refs-only accepted/refused/error state

## Truth labels
- T2 app-internal continuation loop slice only
- operator signing remains external/operator-only; the app still never reads or mints signing keys
- no trust-grant/passport mint, no GO-LIVE claim, no synthetic organic rows

## Verification
- swift test --package-path apps/friday-ios
- apps/friday-ios/build-sim.sh
- git diff --check
- detect-secrets-hook --baseline .secrets.baseline 