### PR TITLE
Wire iOS session run readback

### DIFF
--- a/apps/friday-ios/Sources/FridayMobileShellCore/SessionContinuationViewModel.swift
+++ b/apps/friday-ios/Sources/FridayMobileShellCore/SessionContinuationViewModel.swift
@@ -113,16 +113,24 @@ public final class SessionContinuationViewModel: ObservableObject {
     var pendingApproval: SessionContinuationApproval?
     if let resolvedRunId {
       async let files = Self.fetchRunFileView(client: client, runId: resolvedRunId)
+      async let readback = Self.fetchRunReadback(client: client, runId: resolvedRunId)
       async let needsMe = Self.fetchActivityNeedsMeDetail(client: client, runId: resolvedRunId)
       let needsMeDetail = await needsMe
       pendingApproval = needsMeDetail.pendingApproval
-      sections.append(contentsOf: await [files, needsMeDetail.section])
+      sections.append(contentsOf: await [files, readback, needsMeDetail.section])
     } else {
       sections.append(SessionContinuationSection(
         id: "run-files",
         title: "Run Files",
         status: .notRequested(reason: "No run ref is available in the current projection."),
         summary: "run file view not requested",
+        generatedAtMs: nil,
+        refs: []))
+      sections.append(SessionContinuationSection(
+        id: "run-readback",
+        title: "Run Readback",
+        status: .notRequested(reason: "No run ref is available in the current projection."),
+        summary: "run readback not requested",
         generatedAtMs: nil,
         refs: []))
       sections.append(SessionContinuationSection(
@@ -247,6 +255,31 @@ public final class SessionContinuationViewModel: ObservableObject {
       id: "run-files",
       title: "Run Files",
       read: { try await client.fetchRunFileView(runId: runId) })
+  }
+
+  private nonisolated static func fetchRunReadback(
+    client: FridayRustReadClient,
+    runId: String
+  ) async -> SessionContinuationSection {
+    do {
+      let snapshot = try await client.fetchRunReadback(runId: runId)
+      let detail = HomeReadDetail(title: "Run Readback", snapshot: snapshot)
+      return SessionContinuationSection(
+        id: "run-readback",
+        title: "Run Readback",
+        status: .loaded,
+        summary: readbackSummary(from: snapshot.raw),
+        generatedAtMs: detail.generatedAtMs,
+        refs: detail.refs)
+    } catch {
+      return SessionContinuationSection(
+        id: "run-readback",
+        title: "Run Readback",
+        status: .unavailable(reason: reason(for: error)),
+        summary: "unavailable",
+        generatedAtMs: nil,
+        refs: [])
+    }
   }
 
   private nonisolated static func fetchActivityNeedsMeDetail(
@@ -377,6 +410,26 @@ public final class SessionContinuationViewModel: ObservableObject {
     return parts.joined(separator: " · ")
   }
 
+  private nonisolated static func readbackSummary(from raw: [String: Any]) -> String {
+    var parts: [String] = []
+    if let state = firstNonEmptyString(raw, ["run_state", "runState", "status"]) {
+      parts.append("state=\(state)")
+    }
+    if let loop = firstNonEmptyString(raw, ["loop_status_derived", "loopStatusDerived"]) {
+      parts.append("loop=\(loop)")
+    }
+    if let events = integerText(raw, ["event_count", "eventCount"]) {
+      parts.append("events=\(events)")
+    }
+    if let total = integerText(raw, ["db_wide_token_total", "dbWideTokenTotal"]) {
+      parts.append("db-wide tokens=\(total)")
+    }
+    if let audit = boolText(raw, ["audit_chain_verified", "auditChainVerified"]) {
+      parts.append("audit=\(audit)")
+    }
+    return parts.isEmpty ? "run readback loaded" : parts.joined(separator: " | ")
+  }
+
   private nonisolated static func approval(
     from raw: [String: Any],
     fallbackRunId: String
@@ -416,6 +469,33 @@ public final class SessionContinuationViewModel: ObservableObject {
     keys.lazy.compactMap { raw[$0] as? String }
       .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
       .first { !$0.isEmpty }
+  }
+
+  private nonisolated static func integerText(
+    _ raw: [String: Any],
+    _ keys: [String]
+  ) -> String? {
+    for key in keys {
+      if let value = raw[key] as? Int { return "\(value)" }
+      if let value = raw[key] as? UInt64 { return "\(value)" }
+      if let value = raw[key] as? Int64 { return "\(value)" }
+      if let value = raw[key] as? NSNumber, CFGetTypeID(value) != CFBooleanGetTypeID() {
+        return value.stringValue
+      }
+    }
+    return nil
+  }
+
+  private nonisolated static func boolText(
+    _ raw: [String: Any],
+    _ keys: [String]
+  ) -> String? {
+    for key in keys {
+      if let value = raw[key] as? Bool {
+        return value ? "verified" : "unverified"
+      }
+    }
+    return nil
   }
 
   private nonisolated static func reason(for error: Error) -> String {

--- a/apps/friday-ios/Tests/FridayMobileShellCoreTests/SessionContinuationViewModelTests.swift
+++ b/apps/friday-ios/Tests/FridayMobileShellCoreTests/SessionContinuationViewModelTests.swift
@@ -44,6 +44,21 @@ final class SessionContinuationViewModelTests: XCTestCase {
         proofRef: "proof://session/link/\(agentSessionId)")
     }
 
+    func fetchRunReadback(runId: String) async throws -> ReadProjectionSnapshot {
+      try recordAndReturn(
+        request: "run-readback:\(runId)",
+        status: "finished",
+        runId: runId,
+        proofRef: "proof://run-readback/\(runId)",
+        extra: [
+          "run_state": "finished",
+          "loop_status_derived": "finished",
+          "event_count": 3,
+          "db_wide_token_total": 99,
+          "audit_chain_verified": true,
+        ])
+    }
+
     func fetchRunFileView(runId: String) async throws -> ReadProjectionSnapshot {
       try recordAndReturn(
         request: "run-files:\(runId)",
@@ -81,7 +96,8 @@ final class SessionContinuationViewModelTests: XCTestCase {
       request: String,
       status: String,
       runId: String? = nil,
-      proofRef: String
+      proofRef: String,
+      extra: [String: Any] = [:]
     ) throws -> ReadProjectionSnapshot {
       lock.lock()
       requested.append(request)
@@ -97,6 +113,9 @@ final class SessionContinuationViewModelTests: XCTestCase {
         "evidenceRefs": ["proof://evidence/\(request)"],
         "timelineRef": "proof://timeline/\(request)",
       ]
+      for (key, value) in extra {
+        raw[key] = value
+      }
       if let runId { raw["runId"] = runId }
       let data = try JSONSerialization.data(withJSONObject: raw)
       return try ReadProjectionSnapshot(projectionJSON: data, generatedAtMs: 1_780_640_000_123)
@@ -171,12 +190,13 @@ final class SessionContinuationViewModelTests: XCTestCase {
     XCTAssertEqual(Set(client.requests), [
       "session-open:session-1",
       "session-link:session-1",
+      "run-readback:run-1",
       "run-files:run-1",
       "needs-me:run-1",
     ])
     XCTAssertEqual(snapshot.agentSessionId, "session-1")
     XCTAssertEqual(snapshot.runId, "run-1")
-    XCTAssertEqual(snapshot.sections.map(\.id), ["session-open", "session-link", "run-files", "needs-me"])
+    XCTAssertEqual(snapshot.sections.map(\.id), ["session-open", "session-link", "run-files", "run-readback", "needs-me"])
     XCTAssertTrue(snapshot.sections.allSatisfy {
       if case .loaded = $0.status { return true }
       return false
@@ -184,7 +204,11 @@ final class SessionContinuationViewModelTests: XCTestCase {
     XCTAssertTrue(snapshot.proofRefs.contains("proof://session/open/session-1"))
     XCTAssertTrue(snapshot.proofRefs.contains("proof://session/link/session-1"))
     XCTAssertTrue(snapshot.proofRefs.contains("proof://run-files/run-1"))
+    XCTAssertTrue(snapshot.proofRefs.contains("proof://run-readback/run-1"))
     XCTAssertTrue(snapshot.proofRefs.contains("proof://needs/run-1"))
+    let readback = snapshot.sections.first { $0.id == "run-readback" }
+    XCTAssertTrue(readback?.summary.contains("db-wide tokens=99") == true)
+    XCTAssertTrue(readback?.summary.contains("audit=verified") == true)
     XCTAssertEqual(snapshot.sections.first?.generatedAtMs, 1_780_640_000_123)
     XCTAssertEqual(snapshot.controls.map(\.title), ["Send", "Stop", "Resume", "Fork"])
     XCTAssertTrue(snapshot.controls.allSatisfy { !$0.isEnabled && $0.truthLabel == "NO-GO" })
@@ -424,8 +448,8 @@ final class SessionContinuationViewModelTests: XCTestCase {
       "session-link:session-1",
     ])
     XCTAssertNil(snapshot.runId)
-    XCTAssertEqual(snapshot.sections.map(\.id), ["session-open", "session-link", "run-files", "needs-me"])
-    let runSections = snapshot.sections.suffix(2)
+    XCTAssertEqual(snapshot.sections.map(\.id), ["session-open", "session-link", "run-files", "run-readback", "needs-me"])
+    let runSections = snapshot.sections.suffix(3)
     XCTAssertTrue(runSections.allSatisfy {
       if case .notRequested(let reason) = $0.status {
         return reason.contains("No run ref")
@@ -457,7 +481,7 @@ final class SessionContinuationViewModelTests: XCTestCase {
       return XCTFail("expected loaded shell with unavailable sections, got \(vm.state)")
     }
     XCTAssertEqual(snapshot.proofRefs, [])
-    XCTAssertEqual(snapshot.sections.count, 4)
+    XCTAssertEqual(snapshot.sections.count, 5)
     XCTAssertTrue(snapshot.sections.allSatisfy {
       if case .unavailable(let reason) = $0.status {
         return reason.contains("offline")


### PR DESCRIPTION
## Summary
- add the existing owner-gated run readback projection to iOS Session Detail
- surface run state, loop status, event count, DB-wide token total, audit verification, and proof refs as read-only session evidence
- keep no-run and read failures honest-unavailable / not-requested instead of fabricating state

## Truth labels
- T2 app-internal readback/TokenLedger visibility slice only
- no new backend write path, no trust grant/passport minting, no signing, no route selection, no GO-live claim
- DB-wide token total is labeled as DB-wide, not run-scoped

## Verification
- swift test --package-path apps/friday-ios
- apps/friday-ios/build-sim.sh
- git diff --check origin/main...HEAD
- detect-secrets-hook --baseline .secrets.baseline apps/friday-ios/Sources/FridayMobileShellCore/SessionContinuationViewModel.swift
apps/friday-ios/Tests/FridayMobileShellCoreTests/SessionContinuationViewModelTests.swift