### PR TITLE
Render iOS provider readiness detail

### DIFF
--- a/apps/friday-ios/Sources/FridayMobileShell/FridayProjectionScreens.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayProjectionScreens.swift
@@ -263,6 +263,9 @@ struct FridayProjectionScreen: View {
             .font(.caption)
             .foregroundStyle(MobileTheme.textPrimary)
           RefPill(label: "generated", ref: generatedText(detail.generatedAtMs))
+          if let providerReadiness = detail.providerReadiness {
+            providerReadinessRows(providerReadiness)
+          }
           ForEach(detail.refs, id: \.self) { ref in
             RefPill(label: nil, ref: ref)
           }
@@ -671,6 +674,53 @@ struct FridayProjectionScreen: View {
           .foregroundStyle(MobileTheme.textSecondary)
       }
       Spacer()
+    }
+  }
+
+  @ViewBuilder
+  private func providerReadinessRows(_ detail: HomeProviderReadinessDetail) -> some View {
+    VStack(alignment: .leading, spacing: 8) {
+      HStack(spacing: 6) {
+        statusChip(detail.truthLabel)
+        statusChip(detail.proofOnly ? "proof only" : "not proof only")
+        StatusChip(
+          text: detail.ok ? "doctor ok" : "doctor not ok",
+          bg: detail.ok ? MobileTheme.chipPendingBG : MobileTheme.chipWarnBG,
+          fg: detail.ok ? MobileTheme.chipPendingFG : MobileTheme.chipWarnFG)
+      }
+      HStack(spacing: 6) {
+        statusChip(detail.anyAuthenticated ? "some auth" : "none auth")
+        statusChip(detail.allAuthenticated ? "all auth" : "partial auth")
+      }
+      if !detail.readyProviders.isEmpty {
+        Text("ready: \(detail.readyProviders.joined(separator: ", "))")
+          .font(.caption)
+          .foregroundStyle(MobileTheme.textSecondary)
+          .fixedSize(horizontal: false, vertical: true)
+      }
+      ForEach(detail.detected) { provider in
+        VStack(alignment: .leading, spacing: 5) {
+          HStack {
+            Text(provider.provider)
+              .font(.system(size: 13, weight: .medium))
+              .foregroundStyle(MobileTheme.textPrimary)
+            Spacer()
+            StatusChip(
+              text: provider.authenticated ? "authenticated" : "not authenticated",
+              bg: provider.authenticated ? MobileTheme.chipPendingBG : MobileTheme.chipWarnBG,
+              fg: provider.authenticated ? MobileTheme.chipPendingFG : MobileTheme.chipWarnFG)
+          }
+          Text(provider.detail)
+            .font(.caption)
+            .foregroundStyle(MobileTheme.textSecondary)
+            .fixedSize(horizontal: false, vertical: true)
+          HStack(spacing: 6) {
+            statusChip(provider.installed ? "installed" : "not installed")
+            statusChip(provider.truthLabel)
+          }
+        }
+        .padding(.vertical, 3)
+      }
     }
   }
 

--- a/apps/friday-ios/Sources/FridayMobileShellCore/HomeViewModel.swift
+++ b/apps/friday-ios/Sources/FridayMobileShellCore/HomeViewModel.swift
@@ -298,6 +298,7 @@ public struct HomeReadDetail: Sendable, Equatable {
   public let generatedAtMs: Int64
   public let summary: String
   public let refs: [String]
+  public let providerReadiness: HomeProviderReadinessDetail?
 
   public init(title: String, snapshot: ReadProjectionSnapshot) {
     let raw = snapshot.raw
@@ -305,6 +306,7 @@ public struct HomeReadDetail: Sendable, Equatable {
     self.generatedAtMs = snapshot.generatedAtMs
     self.summary = Self.summary(from: raw)
     self.refs = Self.refs(from: raw)
+    self.providerReadiness = HomeProviderReadinessDetail(raw: raw)
   }
 
   private static func summary(from raw: [String: Any]) -> String {
@@ -332,6 +334,59 @@ public struct HomeReadDetail: Sendable, Equatable {
 
   private static func firstString(_ raw: [String: Any], _ keys: [String]) -> String? {
     keys.lazy.compactMap { raw[$0] as? String }.first
+  }
+}
+
+public struct HomeProviderReadinessDetail: Sendable, Equatable {
+  public let truthLabel: String
+  public let proofOnly: Bool
+  public let ok: Bool
+  public let detected: [HomeProviderAuthReadiness]
+  public let readyProviders: [String]
+  public let anyAuthenticated: Bool
+  public let allAuthenticated: Bool
+
+  init?(raw: [String: Any]) {
+    guard let rows = raw["detected"] as? [[String: Any]] else { return nil }
+    let truthLabel = Self.firstString(raw, ["truth_label", "truthLabel"]) ?? "unknown"
+    guard truthLabel == "rust_providers_detect" else { return nil }
+    self.truthLabel = truthLabel
+    self.proofOnly = Self.firstBool(raw, ["proof_only", "proofOnly"]) ?? true
+    self.ok = Self.firstBool(raw, ["ok"]) ?? false
+    self.detected = rows.map(HomeProviderAuthReadiness.init(raw:))
+    self.readyProviders = Self.firstStringArray(raw, ["ready_providers", "readyProviders"])
+    self.anyAuthenticated = Self.firstBool(raw, ["any_authenticated", "anyAuthenticated"]) ?? false
+    self.allAuthenticated = Self.firstBool(raw, ["all_authenticated", "allAuthenticated"]) ?? false
+  }
+
+  private static func firstString(_ raw: [String: Any], _ keys: [String]) -> String? {
+    keys.lazy.compactMap { raw[$0] as? String }.first
+  }
+
+  private static func firstStringArray(_ raw: [String: Any], _ keys: [String]) -> [String] {
+    keys.lazy.compactMap { raw[$0] as? [String] }.first ?? []
+  }
+
+  private static func firstBool(_ raw: [String: Any], _ keys: [String]) -> Bool? {
+    keys.lazy.compactMap { raw[$0] as? Bool }.first
+  }
+}
+
+public struct HomeProviderAuthReadiness: Sendable, Equatable, Identifiable {
+  public let provider: String
+  public let installed: Bool
+  public let authenticated: Bool
+  public let detail: String
+  public let truthLabel: String
+
+  public var id: String { provider }
+
+  init(raw: [String: Any]) {
+    self.provider = raw["provider"] as? String ?? "unknown"
+    self.installed = raw["installed"] as? Bool ?? false
+    self.authenticated = raw["authenticated"] as? Bool ?? false
+    self.detail = raw["detail"] as? String ?? "unknown"
+    self.truthLabel = raw["truthLabel"] as? String ?? "linked_only"
   }
 }
 

--- a/apps/friday-ios/Tests/FridayMobileShellCoreTests/HomeViewModelTests.swift
+++ b/apps/friday-ios/Tests/FridayMobileShellCoreTests/HomeViewModelTests.swift
@@ -41,7 +41,35 @@ final class HomeViewModelTests: XCTestCase {
 
     func fetchProvidersDoctor(probe: String?) async throws -> ReadProjectionSnapshot {
       requestedDetails.append("providers:\(probe ?? "")")
-      return try detailSnapshot(kind: "providers", status: "ready", proofRef: "proof://provider/doctor")
+      if case .fail(let error) = script {
+        throw error
+      }
+      let raw: [String: Any] = [
+        "truth_label": "rust_providers_detect",
+        "proof_only": true,
+        "ok": true,
+        "detected": [
+          [
+            "provider": "codex",
+            "installed": true,
+            "authenticated": true,
+            "detail": "codex cli authenticated",
+            "truthLabel": "linked_only",
+          ],
+          [
+            "provider": "claude",
+            "installed": true,
+            "authenticated": false,
+            "detail": "claude auth missing",
+            "truthLabel": "linked_only",
+          ],
+        ],
+        "ready_providers": ["codex"],
+        "any_authenticated": true,
+        "all_authenticated": false,
+      ]
+      let data = try JSONSerialization.data(withJSONObject: raw)
+      return try ReadProjectionSnapshot(projectionJSON: data, generatedAtMs: 1_780_640_000_123)
     }
 
     func fetchSessionList() async throws -> ReadProjectionSnapshot {
@@ -78,7 +106,8 @@ final class HomeViewModelTests: XCTestCase {
       kind: String,
       status: String,
       runId: String? = nil,
-      proofRef: String
+      proofRef: String,
+      extra: [String: Any] = [:]
     ) throws -> ReadProjectionSnapshot {
       if case .fail(let error) = script {
         throw error
@@ -86,11 +115,16 @@ final class HomeViewModelTests: XCTestCase {
       var raw: [String: Any] = [
         "missionId": "mission-7",
         "status": status,
-        "truthLabel": "friday_owned",
         "proofRef": proofRef,
         "evidenceRefs": ["proof://evidence/\(kind)"],
       ]
+      if extra["truth_label"] == nil && extra["truthLabel"] == nil {
+        raw["truthLabel"] = "friday_owned"
+      }
       if let runId { raw["runId"] = runId }
+      for (key, value) in extra {
+        raw[key] = value
+      }
       let data = try JSONSerialization.data(withJSONObject: raw)
       return try ReadProjectionSnapshot(projectionJSON: data, generatedAtMs: 1_780_640_000_123)
     }
@@ -282,8 +316,32 @@ final class HomeViewModelTests: XCTestCase {
     }
     XCTAssertEqual(client.requestedDetails, ["providers:anthropic"])
     XCTAssertEqual(detail.title, "Provider doctor")
-    XCTAssertEqual(detail.summary, "mission=mission-7 | status=ready | truth=friday_owned")
-    XCTAssertEqual(detail.refs, ["proof://provider/doctor", "proof://evidence/providers"])
+    XCTAssertEqual(detail.summary, "truth=rust_providers_detect")
+    XCTAssertEqual(detail.refs, [])
+    XCTAssertEqual(detail.providerReadiness?.truthLabel, "rust_providers_detect")
+    XCTAssertEqual(detail.providerReadiness?.proofOnly, true)
+    XCTAssertEqual(detail.providerReadiness?.ok, true)
+    XCTAssertEqual(detail.providerReadiness?.readyProviders, ["codex"])
+    XCTAssertEqual(detail.providerReadiness?.anyAuthenticated, true)
+    XCTAssertEqual(detail.providerReadiness?.allAuthenticated, false)
+    XCTAssertEqual(detail.providerReadiness?.detected.map(\.provider), ["codex", "claude"])
+    XCTAssertEqual(detail.providerReadiness?.detected.first?.authenticated, true)
+    XCTAssertEqual(detail.providerReadiness?.detected.last?.detail, "claude auth missing")
+    XCTAssertEqual(detail.providerReadiness?.detected.last?.truthLabel, "linked_only")
+  }
+
+  func testProviderReadinessRequiresProviderDoctorTruthLabel() throws {
+    let raw: [String: Any] = [
+      "truth_label": "not_provider_doctor",
+      "detected": [
+        ["provider": "codex", "installed": true, "authenticated": true, "detail": "logged_in", "truthLabel": "linked_only"],
+      ],
+    ]
+    let data = try JSONSerialization.data(withJSONObject: raw)
+    let snapshot = try ReadProjectionSnapshot(projectionJSON: data, generatedAtMs: 1_780_640_000_123)
+    let detail = HomeReadDetail(title: "Non-provider detail", snapshot: snapshot)
+
+    XCTAssertNil(detail.providerReadiness)
   }
 
   func testLoadDetail_callsRunAndNeedsMeReadArms() async throws {


### PR DESCRIPTION
## Summary
- parse the existing provider-auth doctor read-arm into structured iOS provider readiness rows
- render proof-only/truth-label, doctor ok/not-ok, ready providers, any/all authenticated, and detected provider installed/authenticated/detail state in the mobile projection detail card
- add view-model coverage for the live provider-auth doctor payload shape

## Truth labels
- T2 ProviderAuth visibility slice only
- read-only: no provider config mutation, no route selection, no key access, no failover enablement
- does not move GO-live/organic; it surfaces existing doctor truth as client-visible evidence

## Verification
- swift test --package-path apps/friday-ios
- apps/friday-ios/build-sim.sh
- git diff --check
- detect-secrets-hook --baseline .secrets.baseline apps/friday-ios/Sources/FridayMobileShell/FridayProjectionScreens.swift apps/friday-ios/Sources/FridayMobileShellCore/HomeViewModel.swift apps/friday-ios/Tests/FridayMobileShellCoreTests/HomeViewModelTests.swift