### PR TITLE
Add operator client remote heartbeat

### DIFF
--- a/packages/friday-operator-client/src/system-client.ts
+++ b/packages/friday-operator-client/src/system-client.ts
@@ -38,6 +38,8 @@ import type {
   FridayIssueCard,
   FridayGetWorkflowOverviewResponse,
   FridayGetWorkflowVisualizationResponse,
+  FridayHeartbeatSystemRemoteSessionRequest,
+  FridayHeartbeatSystemRemoteSessionResponse,
   FridayListAutoFixActionsResponse,
   FridayListAgentLoopRunsResponse,
   FridayListExpertAgentLoopRunsResponse,
@@ -334,6 +336,15 @@ export function createFridayOperatorClient(options: FridayOperatorClientOptions)
       >("/v1/system/remote/sessions", {
         deviceId: input.deviceId,
         assertionToken: input.assertionToken,
+        idempotencyKey: createIdempotencyKey(),
+      });
+    },
+
+    async heartbeatRemoteSession(sessionId: string): Promise<FridayHeartbeatSystemRemoteSessionResponse> {
+      return transport.post<
+        FridayHeartbeatSystemRemoteSessionRequest,
+        FridayHeartbeatSystemRemoteSessionResponse
+      >(`/v1/system/remote/sessions/${encodeURIComponent(sessionId)}/heartbeat`, {
         idempotencyKey: createIdempotencyKey(),
       });
     },

--- a/packages/friday-operator-client/src/system-types.ts
+++ b/packages/friday-operator-client/src/system-types.ts
@@ -872,6 +872,14 @@ export interface FridayCreateSystemRemoteSessionResponse {
   session: FridaySystemRemoteSession;
 }
 
+export interface FridayHeartbeatSystemRemoteSessionRequest {
+  idempotencyKey?: string;
+}
+
+export interface FridayHeartbeatSystemRemoteSessionResponse {
+  session: FridaySystemRemoteSession | null;
+}
+
 export interface FridayBeginSystemRemotePasskeyRegistrationRequest {
   deviceId: string;
   idempotencyKey?: string;

--- a/test/unit/operator-client/friday-operator-client.test.ts
+++ b/test/unit/operator-client/friday-operator-client.test.ts
@@ -61,6 +61,56 @@ describe("createFridayOperatorClient", () => {
     );
   });
 
+  it("posts a governed heartbeat for remote sessions with idempotency", async () => {
+    const activeSession = {
+      id: "remote-session-1",
+      deviceId: "device-1",
+      devicePlatform: "browser",
+      status: "active",
+      connectedAt: "2026-06-22T00:00:00.000Z",
+      lastSeenAt: "2026-06-22T00:01:00.000Z",
+    };
+    const transport = {
+      get: vi.fn(),
+      post: vi.fn().mockResolvedValue({ session: activeSession }),
+      patch: vi.fn(),
+      del: vi.fn(),
+    };
+
+    const client = createFridayOperatorClient({
+      transport,
+      createIdempotencyKey: () => "heartbeat-idem",
+    });
+    const result = await client.heartbeatRemoteSession("remote/session 1");
+
+    expect(transport.post).toHaveBeenCalledWith(
+      "/v1/system/remote/sessions/remote%2Fsession%201/heartbeat",
+      { idempotencyKey: "heartbeat-idem" },
+    );
+    expect(result.session).toEqual(activeSession);
+  });
+
+  it("passes through missing remote session heartbeat responses", async () => {
+    const transport = {
+      get: vi.fn(),
+      post: vi.fn().mockResolvedValue({ session: null }),
+      patch: vi.fn(),
+      del: vi.fn(),
+    };
+
+    const client = createFridayOperatorClient({
+      transport,
+      createIdempotencyKey: () => "heartbeat-null-idem",
+    });
+    const result = await client.heartbeatRemoteSession("missing-session");
+
+    expect(transport.post).toHaveBeenCalledWith(
+      "/v1/system/remote/sessions/missing-session/heartbeat",
+      { idempotencyKey: "heartbeat-null-idem" },
+    );
+    expect(result.session).toBeNull();
+  });
+
   it("builds system event listing routes in JSON mode by default", async () => {
     const transport = {
       get: vi.fn().mockResolvedValue({ items: [] }),


### PR DESCRIPTION
## Summary
- add remote-session heartbeat request/response types to the operator client contract
- expose heartbeatRemoteSession(sessionId) with path encoding and idempotency key generation
- cover the client route contract in operator-client tests

## Truth labels
- T3 provisioning/client parity slice only
- client contract closes an existing server route; it does not enable WebAuthn, remote execution, trust grants, or GO-live
- remote/WebAuthn remains default fail-closed and operator/provisioning gated

## Verification
- pnpm vitest run test/unit/operator-client/friday-operator-client.test.ts
- pnpm typecheck:src
- git diff --check
- detect-secrets-hook --baseline .secrets.baseline 