### PR TITLE
Surface provider route readiness on iOS

### DIFF
--- a/apps/friday-ios/Sources/FridayMobileShell/FridayProjectionScreens.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayProjectionScreens.swift
@@ -698,6 +698,21 @@ struct FridayProjectionScreen: View {
           .foregroundStyle(MobileTheme.textSecondary)
           .fixedSize(horizontal: false, vertical: true)
       }
+      if let suggestedTextRoute = detail.suggestedTextRoute {
+        Text("text route: \(suggestedTextRoute)")
+          .font(.caption)
+          .foregroundStyle(MobileTheme.textSecondary)
+          .fixedSize(horizontal: false, vertical: true)
+      }
+      if let suggestedStrongRoute = detail.suggestedStrongRoute {
+        Text("strong route: \(suggestedStrongRoute)")
+          .font(.caption)
+          .foregroundStyle(MobileTheme.textSecondary)
+          .fixedSize(horizontal: false, vertical: true)
+      }
+      if let keyValidationProbed = detail.keyValidationProbed {
+        statusChip(keyValidationProbed ? "keys probed" : "keys not probed")
+      }
       ForEach(detail.detected) { provider in
         VStack(alignment: .leading, spacing: 5) {
           HStack {
@@ -717,6 +732,52 @@ struct FridayProjectionScreen: View {
           HStack(spacing: 6) {
             statusChip(provider.installed ? "installed" : "not installed")
             statusChip(provider.truthLabel)
+          }
+        }
+        .padding(.vertical, 3)
+      }
+      ForEach(detail.routes) { route in
+        VStack(alignment: .leading, spacing: 5) {
+          HStack {
+            Text(route.providerId)
+              .font(.system(size: 13, weight: .medium))
+              .foregroundStyle(MobileTheme.textPrimary)
+            Spacer()
+            StatusChip(
+              text: route.dispatchable ? "dispatchable" : "blocked",
+              bg: route.dispatchable ? MobileTheme.chipPendingBG : MobileTheme.chipWarnBG,
+              fg: route.dispatchable ? MobileTheme.chipPendingFG : MobileTheme.chipWarnFG)
+          }
+          Text("\(route.model) - \(route.modelSize) - \(route.strength)")
+            .font(.caption)
+            .foregroundStyle(MobileTheme.textSecondary)
+            .fixedSize(horizontal: false, vertical: true)
+          if !route.blockers.isEmpty {
+            Text("blockers: \(route.blockers.joined(separator: ", "))")
+              .font(.caption2)
+              .foregroundStyle(MobileTheme.textSecondary)
+              .fixedSize(horizontal: false, vertical: true)
+          }
+        }
+        .padding(.vertical, 3)
+      }
+      ForEach(detail.failovers) { failover in
+        VStack(alignment: .leading, spacing: 5) {
+          HStack {
+            Text(failover.direction)
+              .font(.system(size: 13, weight: .medium))
+              .foregroundStyle(MobileTheme.textPrimary)
+            Spacer()
+            StatusChip(
+              text: failover.flagEnabled ? "armed" : "off",
+              bg: failover.flagEnabled ? MobileTheme.chipPendingBG : MobileTheme.chipNeutralBG,
+              fg: failover.flagEnabled ? MobileTheme.chipPendingFG : MobileTheme.chipNeutralFG)
+          }
+          HStack(spacing: 6) {
+            statusChip(failover.canEnable ? "can enable" : "blocked")
+            if !failover.blockers.isEmpty {
+              statusChip("blockers \(failover.blockers.count)")
+            }
           }
         }
         .padding(.vertical, 3)

--- a/apps/friday-ios/Sources/FridayMobileShellCore/HomeViewModel.swift
+++ b/apps/friday-ios/Sources/FridayMobileShellCore/HomeViewModel.swift
@@ -342,21 +342,38 @@ public struct HomeProviderReadinessDetail: Sendable, Equatable {
   public let proofOnly: Bool
   public let ok: Bool
   public let detected: [HomeProviderAuthReadiness]
+  public let routes: [HomeProviderRouteReadiness]
+  public let failovers: [HomeProviderFailoverReadiness]
   public let readyProviders: [String]
   public let anyAuthenticated: Bool
   public let allAuthenticated: Bool
+  public let suggestedTextRoute: String?
+  public let suggestedStrongRoute: String?
+  public let keyValidationProbed: Bool?
 
   init?(raw: [String: Any]) {
-    guard let rows = raw["detected"] as? [[String: Any]] else { return nil }
     let truthLabel = Self.firstString(raw, ["truth_label", "truthLabel"]) ?? "unknown"
-    guard truthLabel == "rust_providers_detect" else { return nil }
+    guard truthLabel == "rust_providers_detect" || truthLabel == "rust_capability_doctor" else {
+      return nil
+    }
+    let rows = Self.firstRows(raw, ["detected", "cli_detected", "cliDetected"])
     self.truthLabel = truthLabel
     self.proofOnly = Self.firstBool(raw, ["proof_only", "proofOnly"]) ?? true
     self.ok = Self.firstBool(raw, ["ok"]) ?? false
     self.detected = rows.map(HomeProviderAuthReadiness.init(raw:))
-    self.readyProviders = Self.firstStringArray(raw, ["ready_providers", "readyProviders"])
-    self.anyAuthenticated = Self.firstBool(raw, ["any_authenticated", "anyAuthenticated"]) ?? false
-    self.allAuthenticated = Self.firstBool(raw, ["all_authenticated", "allAuthenticated"]) ?? false
+    self.routes = Self.firstRows(raw, ["route_readiness", "routeReadiness"])
+      .map(HomeProviderRouteReadiness.init(raw:))
+    self.failovers = Self.firstRows(raw, ["failover_readiness", "failoverReadiness"])
+      .map(HomeProviderFailoverReadiness.init(raw:))
+    self.readyProviders = Self.firstStringArray(
+      raw, ["ready_providers", "readyProviders", "cli_logged_in", "cliLoggedIn"])
+    self.anyAuthenticated = Self.firstBool(raw, ["any_authenticated", "anyAuthenticated"])
+      ?? self.detected.contains { $0.authenticated }
+    self.allAuthenticated = Self.firstBool(raw, ["all_authenticated", "allAuthenticated"])
+      ?? (!self.detected.isEmpty && self.detected.allSatisfy { $0.authenticated })
+    self.suggestedTextRoute = Self.firstString(raw, ["suggested_text_route", "suggestedTextRoute"])
+    self.suggestedStrongRoute = Self.firstString(raw, ["suggested_strong_route", "suggestedStrongRoute"])
+    self.keyValidationProbed = Self.firstBool(raw, ["key_validation_probed", "keyValidationProbed"])
   }
 
   private static func firstString(_ raw: [String: Any], _ keys: [String]) -> String? {
@@ -369,6 +386,10 @@ public struct HomeProviderReadinessDetail: Sendable, Equatable {
 
   private static func firstBool(_ raw: [String: Any], _ keys: [String]) -> Bool? {
     keys.lazy.compactMap { raw[$0] as? Bool }.first
+  }
+
+  private static func firstRows(_ raw: [String: Any], _ keys: [String]) -> [[String: Any]] {
+    keys.lazy.compactMap { raw[$0] as? [[String: Any]] }.first ?? []
   }
 }
 
@@ -387,6 +408,47 @@ public struct HomeProviderAuthReadiness: Sendable, Equatable, Identifiable {
     self.authenticated = raw["authenticated"] as? Bool ?? false
     self.detail = raw["detail"] as? String ?? "unknown"
     self.truthLabel = raw["truthLabel"] as? String ?? "linked_only"
+  }
+}
+
+public struct HomeProviderRouteReadiness: Sendable, Equatable, Identifiable {
+  public let providerId: String
+  public let model: String
+  public let modelSize: String
+  public let strength: String
+  public let dispatchable: Bool
+  public let blockers: [String]
+
+  public var id: String { providerId }
+
+  init(raw: [String: Any]) {
+    self.providerId = raw["provider_id"] as? String ?? raw["providerId"] as? String ?? "unknown"
+    self.model = raw["model"] as? String ?? "unknown"
+    self.modelSize = raw["model_size"] as? String ?? raw["modelSize"] as? String ?? "unknown"
+    self.strength = raw["strength"] as? String ?? "unknown"
+    self.dispatchable = raw["dispatchable"] as? Bool ?? false
+    self.blockers = Self.blockerCodes(raw["blockers"])
+  }
+
+  static func blockerCodes(_ value: Any?) -> [String] {
+    guard let rows = value as? [[String: Any]] else { return [] }
+    return rows.compactMap { $0["code"] as? String }.filter { !$0.isEmpty }
+  }
+}
+
+public struct HomeProviderFailoverReadiness: Sendable, Equatable, Identifiable {
+  public let direction: String
+  public let flagEnabled: Bool
+  public let canEnable: Bool
+  public let blockers: [String]
+
+  public var id: String { direction }
+
+  init(raw: [String: Any]) {
+    self.direction = raw["direction"] as? String ?? "unknown"
+    self.flagEnabled = raw["flag_enabled"] as? Bool ?? raw["flagEnabled"] as? Bool ?? false
+    self.canEnable = raw["can_enable"] as? Bool ?? raw["canEnable"] as? Bool ?? false
+    self.blockers = HomeProviderRouteReadiness.blockerCodes(raw["blockers"])
   }
 }
 
@@ -665,8 +727,8 @@ public final class HomeViewModel: ObservableObject {
     switch arm {
     case let .runReadback(runId):
       return try await client.fetchRunReadback(runId: runId)
-    case let .providersDoctor(probe):
-      return try await client.fetchProvidersDoctor(probe: probe)
+    case .providersDoctor:
+      return try await client.fetchCapabilityDoctor(validateKeys: true)
     case .sessionList:
       return try await client.fetchSessionList()
     case let .sessionOpen(agentSessionId):

--- a/apps/friday-ios/Tests/FridayMobileShellCoreTests/HomeViewModelTests.swift
+++ b/apps/friday-ios/Tests/FridayMobileShellCoreTests/HomeViewModelTests.swift
@@ -41,14 +41,23 @@ final class HomeViewModelTests: XCTestCase {
 
     func fetchProvidersDoctor(probe: String?) async throws -> ReadProjectionSnapshot {
       requestedDetails.append("providers:\(probe ?? "")")
+      return try capabilityDoctorSnapshot()
+    }
+
+    func fetchCapabilityDoctor(validateKeys: Bool) async throws -> ReadProjectionSnapshot {
+      requestedDetails.append("capabilities:\(validateKeys)")
+      return try capabilityDoctorSnapshot()
+    }
+
+    private func capabilityDoctorSnapshot() throws -> ReadProjectionSnapshot {
       if case .fail(let error) = script {
         throw error
       }
       let raw: [String: Any] = [
-        "truth_label": "rust_providers_detect",
+        "truth_label": "rust_capability_doctor",
         "proof_only": true,
         "ok": true,
-        "detected": [
+        "cli_detected": [
           [
             "provider": "codex",
             "installed": true,
@@ -64,9 +73,41 @@ final class HomeViewModelTests: XCTestCase {
             "truthLabel": "linked_only",
           ],
         ],
-        "ready_providers": ["codex"],
-        "any_authenticated": true,
-        "all_authenticated": false,
+        "cli_logged_in": ["codex"],
+        "key_validation_probed": true,
+        "key_validation": [
+          ["provider": "deepseek", "label": "valid"],
+          ["provider": "anthropic", "label": "credential_missing"],
+        ],
+        "confirmed_valid_keys": ["deepseek"],
+        "route_readiness": [
+          [
+            "provider_id": "codex",
+            "model": "gpt-5.5",
+            "model_size": "frontier",
+            "strength": "strong",
+            "dispatchable": true,
+            "blockers": [],
+          ],
+          [
+            "provider_id": "claude",
+            "model": "claude-opus",
+            "model_size": "frontier",
+            "strength": "strong",
+            "dispatchable": false,
+            "blockers": [["code": "auth_missing"]],
+          ],
+        ],
+        "failover_readiness": [
+          [
+            "direction": "deepseek_to_claude",
+            "flag_enabled": true,
+            "can_enable": false,
+            "blockers": [["code": "fallback_route_not_dispatchable"]],
+          ],
+        ],
+        "suggested_text_route": "codex",
+        "suggested_strong_route": "codex",
       ]
       let data = try JSONSerialization.data(withJSONObject: raw)
       return try ReadProjectionSnapshot(projectionJSON: data, generatedAtMs: 1_780_640_000_123)
@@ -314,11 +355,11 @@ final class HomeViewModelTests: XCTestCase {
     guard case let .loaded(detail) = vm.detailState else {
       return XCTFail("expected detail .loaded, got \(vm.detailState)")
     }
-    XCTAssertEqual(client.requestedDetails, ["providers:anthropic"])
+    XCTAssertEqual(client.requestedDetails, ["capabilities:true"])
     XCTAssertEqual(detail.title, "Provider doctor")
-    XCTAssertEqual(detail.summary, "truth=rust_providers_detect")
+    XCTAssertEqual(detail.summary, "truth=rust_capability_doctor")
     XCTAssertEqual(detail.refs, [])
-    XCTAssertEqual(detail.providerReadiness?.truthLabel, "rust_providers_detect")
+    XCTAssertEqual(detail.providerReadiness?.truthLabel, "rust_capability_doctor")
     XCTAssertEqual(detail.providerReadiness?.proofOnly, true)
     XCTAssertEqual(detail.providerReadiness?.ok, true)
     XCTAssertEqual(detail.providerReadiness?.readyProviders, ["codex"])
@@ -328,6 +369,16 @@ final class HomeViewModelTests: XCTestCase {
     XCTAssertEqual(detail.providerReadiness?.detected.first?.authenticated, true)
     XCTAssertEqual(detail.providerReadiness?.detected.last?.detail, "claude auth missing")
     XCTAssertEqual(detail.providerReadiness?.detected.last?.truthLabel, "linked_only")
+    XCTAssertEqual(detail.providerReadiness?.routes.map(\.providerId), ["codex", "claude"])
+    XCTAssertEqual(detail.providerReadiness?.routes.first?.dispatchable, true)
+    XCTAssertEqual(detail.providerReadiness?.routes.last?.blockers, ["auth_missing"])
+    XCTAssertEqual(detail.providerReadiness?.failovers.first?.direction, "deepseek_to_claude")
+    XCTAssertEqual(detail.providerReadiness?.failovers.first?.flagEnabled, true)
+    XCTAssertEqual(detail.providerReadiness?.failovers.first?.canEnable, false)
+    XCTAssertEqual(detail.providerReadiness?.failovers.first?.blockers, ["fallback_route_not_dispatchable"])
+    XCTAssertEqual(detail.providerReadiness?.suggestedTextRoute, "codex")
+    XCTAssertEqual(detail.providerReadiness?.suggestedStrongRoute, "codex")
+    XCTAssertEqual(detail.providerReadiness?.keyValidationProbed, true)
   }
 
   func testProviderReadinessRequiresProviderDoctorTruthLabel() throws {

--- a/apps/macos/FridayRustClient/Sources/FridayRustClient/PairingClient.swift
+++ b/apps/macos/FridayRustClient/Sources/FridayRustClient/PairingClient.swift
@@ -141,6 +141,8 @@ private func pairingKind(_ message: FridayMessage) -> String {
   case .runReadbackSnapshot: return "RunReadbackSnapshot"
   case .providersDoctorRequest: return "ProvidersDoctorRequest"
   case .providersDoctorSnapshot: return "ProvidersDoctorSnapshot"
+  case .capabilityDoctorRequest: return "CapabilityDoctorRequest"
+  case .capabilityDoctorSnapshot: return "CapabilityDoctorSnapshot"
   case .sessionListRequest: return "SessionListRequest"
   case .sessionListSnapshot: return "SessionListSnapshot"
   case .sessionOpenRequest: return "SessionOpenRequest"

--- a/apps/macos/FridayRustClient/Sources/FridayRustClient/Protocol.swift
+++ b/apps/macos/FridayRustClient/Sources/FridayRustClient/Protocol.swift
@@ -220,6 +220,45 @@ public struct ProvidersDoctorSnapshotWire: Codable, Equatable, Sendable {
   }
 }
 
+public struct CapabilityDoctorRequestWire: Codable, Equatable, Sendable {
+  public var validateKeys: Bool
+  public var forwardedPrincipal: String
+  public var authProof: [UInt8]
+  public var requestId: String
+
+  public init(validateKeys: Bool, forwardedPrincipal: String, authProof: [UInt8], requestId: String) {
+    self.validateKeys = validateKeys
+    self.forwardedPrincipal = forwardedPrincipal
+    self.authProof = authProof
+    self.requestId = requestId
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case validateKeys = "validate_keys"
+    case forwardedPrincipal = "forwarded_principal"
+    case authProof = "auth_proof"
+    case requestId = "request_id"
+  }
+}
+
+public struct CapabilityDoctorSnapshotWire: Codable, Equatable, Sendable {
+  public var requestId: String
+  public var projectionJson: String
+  public var generatedAtMs: Int64
+
+  public init(requestId: String, projectionJson: String, generatedAtMs: Int64) {
+    self.requestId = requestId
+    self.projectionJson = projectionJson
+    self.generatedAtMs = generatedAtMs
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case requestId = "request_id"
+    case projectionJson = "projection_json"
+    case generatedAtMs = "generated_at_ms"
+  }
+}
+
 public struct SessionListRequestWire: Codable, Equatable, Sendable {
   public var forwardedPrincipal: String
   public var authProof: [UInt8]
@@ -435,6 +474,8 @@ public enum FridayMessage: Equatable {
   case runReadbackSnapshot(RunReadbackSnapshotWire)
   case providersDoctorRequest(ProvidersDoctorRequestWire)
   case providersDoctorSnapshot(ProvidersDoctorSnapshotWire)
+  case capabilityDoctorRequest(CapabilityDoctorRequestWire)
+  case capabilityDoctorSnapshot(CapabilityDoctorSnapshotWire)
   case sessionListRequest(SessionListRequestWire)
   case sessionListSnapshot(SessionListSnapshotWire)
   case sessionOpenRequest(SessionOpenRequestWire)
@@ -602,6 +643,12 @@ extension FridayMessage: Codable {
     case "ProvidersDoctorSnapshot":
       let c = try decoder.container(keyedBy: SnapshotKey.self)
       self = .providersDoctorSnapshot(try c.decode(ProvidersDoctorSnapshotWire.self, forKey: .snapshot))
+    case "CapabilityDoctorRequest":
+      let c = try decoder.container(keyedBy: RequestKey.self)
+      self = .capabilityDoctorRequest(try c.decode(CapabilityDoctorRequestWire.self, forKey: .request))
+    case "CapabilityDoctorSnapshot":
+      let c = try decoder.container(keyedBy: SnapshotKey.self)
+      self = .capabilityDoctorSnapshot(try c.decode(CapabilityDoctorSnapshotWire.self, forKey: .snapshot))
     case "SessionListRequest":
       let c = try decoder.container(keyedBy: RequestKey.self)
       self = .sessionListRequest(try c.decode(SessionListRequestWire.self, forKey: .request))
@@ -774,6 +821,14 @@ extension FridayMessage: Codable {
       try c.encode(req, forKey: .request)
     case .providersDoctorSnapshot(let snap):
       try tag.encode("ProvidersDoctorSnapshot", forKey: .kind)
+      var c = encoder.container(keyedBy: SnapshotKey.self)
+      try c.encode(snap, forKey: .snapshot)
+    case .capabilityDoctorRequest(let req):
+      try tag.encode("CapabilityDoctorRequest", forKey: .kind)
+      var c = encoder.container(keyedBy: RequestKey.self)
+      try c.encode(req, forKey: .request)
+    case .capabilityDoctorSnapshot(let snap):
+      try tag.encode("CapabilityDoctorSnapshot", forKey: .kind)
       var c = encoder.container(keyedBy: SnapshotKey.self)
       try c.encode(snap, forKey: .snapshot)
     case .sessionListRequest(let req):

--- a/apps/macos/FridayRustClient/Sources/FridayRustClient/ReadClient.swift
+++ b/apps/macos/FridayRustClient/Sources/FridayRustClient/ReadClient.swift
@@ -101,6 +101,8 @@ public protocol FridayRustReadClient: Sendable {
   func fetchRunAnswerBody(runId: String) async throws -> RunAnswerBody
   /// Fetch provider readiness labels through the read-only providers-doctor arm.
   func fetchProvidersDoctor(probe: String?) async throws -> ReadProjectionSnapshot
+  /// Fetch route/failover readiness through the owner-authenticated capability-doctor read arm.
+  func fetchCapabilityDoctor(validateKeys: Bool) async throws -> ReadProjectionSnapshot
   /// Fetch the owner's routed-session refs.
   func fetchSessionList() async throws -> ReadProjectionSnapshot
   /// Fetch one owner-gated routed session transcript. This is a deliberate owner-only body carve-out.
@@ -124,6 +126,10 @@ public extension FridayRustReadClient {
 
   func fetchProvidersDoctor(probe: String? = nil) async throws -> ReadProjectionSnapshot {
     throw FridayReadClientError.transport("providers doctor readback unavailable")
+  }
+
+  func fetchCapabilityDoctor(validateKeys: Bool = true) async throws -> ReadProjectionSnapshot {
+    throw FridayReadClientError.transport("capability doctor readback unavailable")
   }
 
   func fetchSessionList() async throws -> ReadProjectionSnapshot {
@@ -260,6 +266,10 @@ public final class SealedWSReadClient: FridayRustReadClient, @unchecked Sendable
       throw FridayReadClientError.unexpectedResponse(kind: "ProvidersDoctorRequest")
     case .providersDoctorSnapshot:
       throw FridayReadClientError.unexpectedResponse(kind: "ProvidersDoctorSnapshot")
+    case .capabilityDoctorRequest:
+      throw FridayReadClientError.unexpectedResponse(kind: "CapabilityDoctorRequest")
+    case .capabilityDoctorSnapshot:
+      throw FridayReadClientError.unexpectedResponse(kind: "CapabilityDoctorSnapshot")
     case .sessionListRequest:
       throw FridayReadClientError.unexpectedResponse(kind: "SessionListRequest")
     case .sessionListSnapshot:
@@ -365,6 +375,10 @@ public final class SealedWSReadClient: FridayRustReadClient, @unchecked Sendable
       throw FridayReadClientError.unexpectedResponse(kind: "ProvidersDoctorRequest")
     case .providersDoctorSnapshot:
       throw FridayReadClientError.unexpectedResponse(kind: "ProvidersDoctorSnapshot")
+    case .capabilityDoctorRequest:
+      throw FridayReadClientError.unexpectedResponse(kind: "CapabilityDoctorRequest")
+    case .capabilityDoctorSnapshot:
+      throw FridayReadClientError.unexpectedResponse(kind: "CapabilityDoctorSnapshot")
     case .sessionListRequest:
       throw FridayReadClientError.unexpectedResponse(kind: "SessionListRequest")
     case .sessionListSnapshot:
@@ -406,6 +420,24 @@ public final class SealedWSReadClient: FridayRustReadClient, @unchecked Sendable
         return nil
       },
       expected: "ProvidersDoctorSnapshot")
+  }
+
+  public func fetchCapabilityDoctor(validateKeys: Bool = true) async throws -> ReadProjectionSnapshot {
+    try await fetchProjection(
+      makeMessage: { requestId, authProof in
+        .capabilityDoctorRequest(CapabilityDoctorRequestWire(
+          validateKeys: validateKeys,
+          forwardedPrincipal: forwardedPrincipal,
+          authProof: authProof,
+          requestId: requestId))
+      },
+      extract: { message in
+        if case .capabilityDoctorSnapshot(let snap) = message {
+          return (snap.projectionJson, snap.generatedAtMs)
+        }
+        return nil
+      },
+      expected: "CapabilityDoctorSnapshot")
   }
 
   public func fetchSessionList() async throws -> ReadProjectionSnapshot {

--- a/apps/macos/FridayRustClient/Sources/FridayRustClient/WriteClient.swift
+++ b/apps/macos/FridayRustClient/Sources/FridayRustClient/WriteClient.swift
@@ -343,6 +343,7 @@ public final class SealedWSWriteClient: FridayRustWriteClient, FridayMissionSpin
          .runReadbackRequest, .runReadbackSnapshot,
          .runAnswerBodyRequest, .runAnswerBodySnapshot,
          .providersDoctorRequest, .providersDoctorSnapshot,
+         .capabilityDoctorRequest, .capabilityDoctorSnapshot,
          .sessionListRequest, .sessionListSnapshot,
          .sessionOpenRequest, .sessionOpenSnapshot,
          .sessionLinkStateRequest, .sessionLinkStateSnapshot,
@@ -635,6 +636,8 @@ private func dispatchKind(_ message: FridayMessage) -> String {
   case .runAnswerBodySnapshot: return "RunAnswerBodySnapshot"
   case .providersDoctorRequest: return "ProvidersDoctorRequest"
   case .providersDoctorSnapshot: return "ProvidersDoctorSnapshot"
+  case .capabilityDoctorRequest: return "CapabilityDoctorRequest"
+  case .capabilityDoctorSnapshot: return "CapabilityDoctorSnapshot"
   case .sessionListRequest: return "SessionListRequest"
   case .sessionListSnapshot: return "SessionListSnapshot"
   case .sessionOpenRequest: return "SessionOpenRequest"

--- a/apps/macos/FridayRustClient/Tests/FridayRustClientTests/ReadClientWiringTests.swift
+++ b/apps/macos/FridayRustClient/Tests/FridayRustClientTests/ReadClientWiringTests.swift
@@ -122,6 +122,14 @@ final class ReadClientWiringTests: XCTestCase {
           .providersDoctorSnapshot(ProvidersDoctorSnapshotWire(
             requestId: requestId, projectionJson: sealedHex, generatedAtMs: generatedAtMs))
         }
+      case .capabilityDoctorRequest(let req):
+        reqPrincipal = req.forwardedPrincipal
+        reqId = req.requestId
+        authProof = req.authProof
+        responseKind = .projection { requestId, sealedHex, generatedAtMs in
+          .capabilityDoctorSnapshot(CapabilityDoctorSnapshotWire(
+            requestId: requestId, projectionJson: sealedHex, generatedAtMs: generatedAtMs))
+        }
       case .sessionListRequest(let req):
         reqPrincipal = req.forwardedPrincipal
         reqId = req.requestId
@@ -231,6 +239,11 @@ final class ReadClientWiringTests: XCTestCase {
           generatedAtMs: snap.generatedAtMs))
       case .providersDoctorSnapshot(let snap):
         finalMessage = .providersDoctorSnapshot(ProvidersDoctorSnapshotWire(
+          requestId: snap.requestId,
+          projectionJson: sealedHex,
+          generatedAtMs: snap.generatedAtMs))
+      case .capabilityDoctorSnapshot(let snap):
+        finalMessage = .capabilityDoctorSnapshot(CapabilityDoctorSnapshotWire(
           requestId: snap.requestId,
           projectionJson: sealedHex,
           generatedAtMs: snap.generatedAtMs))
@@ -402,6 +415,11 @@ final class ReadClientWiringTests: XCTestCase {
     let providersDoctorSnapshot = try await providersDoctor.0.fetchProvidersDoctor(probe: "both")
     XCTAssertEqual(providersDoctorSnapshot.raw["missionId"] as? String, "mission_read_seam_probe_20260611")
     XCTAssertEqual(providersDoctor.1.processed, 1)
+
+    let capabilityDoctor = try makeClient(requestId: "req-capability-doctor")
+    let capabilityDoctorSnapshot = try await capabilityDoctor.0.fetchCapabilityDoctor(validateKeys: true)
+    XCTAssertEqual(capabilityDoctorSnapshot.raw["missionId"] as? String, "mission_read_seam_probe_20260611")
+    XCTAssertEqual(capabilityDoctor.1.processed, 1)
 
     let sessionList = try makeClient(requestId: "req-session-list")
     let sessionListSnapshot = try await sessionList.0.fetchSessionList()

--- a/rust-core/crates/friday-ffi/src/lib.rs
+++ b/rust-core/crates/friday-ffi/src/lib.rs
@@ -1976,6 +1976,8 @@ fn message_kind_name(m: &friday_protocol::Message) -> &'static str {
         M::RunAnswerBodySnapshot { .. } => "RunAnswerBodySnapshot",
         M::ProvidersDoctorRequest { .. } => "ProvidersDoctorRequest",
         M::ProvidersDoctorSnapshot { .. } => "ProvidersDoctorSnapshot",
+        M::CapabilityDoctorRequest { .. } => "CapabilityDoctorRequest",
+        M::CapabilityDoctorSnapshot { .. } => "CapabilityDoctorSnapshot",
         // C2I-PR2 — the 5 DARK sealed-WS READ-seam owner-gated C2 read-plane kinds. NAMED here for
         // the same reason as S-R1/S-R2/S-R3: nothing on the FFI surface constructs/dispatches them
         // (the UI reads them directly over the sealed-WS read server), but naming them keeps this

--- a/rust-core/crates/friday-hub/src/bin/hub_read_projection_server.rs
+++ b/rust-core/crates/friday-hub/src/bin/hub_read_projection_server.rs
@@ -68,8 +68,10 @@ use std::path::PathBuf;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use friday_crypto::{seal, DataKey, DeviceKeypair, FileSecureStore};
+use friday_hub::capability_doctor_projection::project_capability_doctor;
 use friday_hub::hub_server::{AuthedPrincipal, ForwardedAuth};
 use friday_hub::key_source::{READ_SEAM_PEER_PUBKEY_ALLOWLIST_ID, X25519_PUBKEY_LEN};
+use friday_hub::provider_key_validation::LiveKeyValidationProbe;
 use friday_hub::providers_doctor_projection::{parse_provider_selection, project_providers_doctor};
 use friday_hub::run_readback_projection::{
     project_activity_needs_me, project_run_file_view, project_run_readback,
@@ -80,8 +82,8 @@ use friday_hub::sealed_ws::{
 };
 use friday_hub::workbench_projection::project_workbench;
 use friday_protocol::{
-    ActivityNeedsMeSnapshotWire, Envelope, IdempotencyTracker, Message,
-    ProvidersDoctorSnapshotWire, RunAnswerBodySnapshotWire, RunFileViewSnapshotWire,
+    ActivityNeedsMeSnapshotWire, CapabilityDoctorSnapshotWire, Envelope, IdempotencyTracker,
+    Message, ProvidersDoctorSnapshotWire, RunAnswerBodySnapshotWire, RunFileViewSnapshotWire,
     RunReadbackSnapshotWire, Seen, SessionLinkStateSnapshotWire, SessionListSnapshotWire,
     SessionOpenSnapshotWire, WorkbenchProjectionSnapshotWire,
 };
@@ -480,6 +482,40 @@ fn serve_read_session<S: Read + Write>(
                     projection,
                     |sealed_hex| Message::ProvidersDoctorSnapshot {
                         snapshot: ProvidersDoctorSnapshotWire {
+                            request_id: request_id.clone(),
+                            projection_json: sealed_hex,
+                            generated_at_ms: now_ms,
+                        },
+                    },
+                )?
+            }
+            Message::CapabilityDoctorRequest { request } => {
+                // Auth-before-doctor. This projection can run provider readiness probes, so the
+                // owner-auth chain must pass before constructing the key-validation probe.
+                if authenticate_read_request(
+                    session_key,
+                    session_nonce,
+                    &request.auth_proof,
+                    &request.forwarded_principal,
+                    &request.request_id,
+                    owner_allowlist,
+                )
+                .is_none()
+                {
+                    return Ok(processed);
+                }
+                let request_id = request.request_id.clone();
+                let key_probe = LiveKeyValidationProbe::new();
+                let projection =
+                    project_capability_doctor(probe, &key_probe, request.validate_keys);
+                seal_and_frame(
+                    session_key,
+                    &env.msg_id,
+                    &request_id,
+                    now_ms,
+                    projection,
+                    |sealed_hex| Message::CapabilityDoctorSnapshot {
+                        snapshot: CapabilityDoctorSnapshotWire {
                             request_id: request_id.clone(),
                             projection_json: sealed_hex,
                             generated_at_ms: now_ms,

--- a/rust-core/crates/friday-hub/src/capability_doctor.rs
+++ b/rust-core/crates/friday-hub/src/capability_doctor.rs
@@ -79,7 +79,10 @@ impl CapabilityDoctor {
     /// CLI detect + `KeyProvider::all()` for key-validation) — the onboarding
     /// default. Generic over both probes so production injects the real probes and
     /// tests inject mocks through the identical path.
-    pub fn run<P: ProviderProbe, K: KeyValidationProbe>(cli_probe: &P, key_probe: &K) -> Self {
+    pub fn run<P: ProviderProbe + ?Sized, K: KeyValidationProbe + ?Sized>(
+        cli_probe: &P,
+        key_probe: &K,
+    ) -> Self {
         let cli_statuses = Provider::all()
             .iter()
             .map(|&p| detect(cli_probe, p))

--- a/rust-core/crates/friday-hub/src/capability_doctor_projection.rs
+++ b/rust-core/crates/friday-hub/src/capability_doctor_projection.rs
@@ -1,0 +1,297 @@
+//! Refs-only capability-doctor projection for the sealed read seam.
+//!
+//! This is the callable sibling of `hub_capability_doctor`: owner-auth happens in
+//! the read server before this function is called; this module only shapes the
+//! already-safe doctor signals into guarded JSON.
+
+use crate::capability_doctor::{CapabilityDoctor, KeyValidationSignal};
+use crate::provider_doctor::ProviderDoctor;
+use crate::provider_route_readiness::{
+    backend_kind_label, model_size_label, provider_api_label, FailoverReadiness,
+    ProviderReadinessFlags, ProviderReadinessReport, ProviderRouteReadiness,
+};
+use crate::routing::{ProviderRoute, RouteRegistry};
+use crate::runtime::{
+    ENV_CLAUDE_ROUTE_ENABLED, ENV_CODEX_ROUTE_ENABLED, ENV_DEEPSEEK_PRO_ROUTE_ENABLED,
+    ENV_PROVIDER_FAILOVER, ENV_PROVIDER_FAILOVER_CLAUDE_TO_DEEPSEEK,
+};
+use friday_providers::{
+    KeyValidationOutcome, KeyValidationProbe, Provider, ProviderAuthStatus, ProviderProbe,
+};
+use serde_json::{json, Value};
+
+pub fn project_capability_doctor<P: ProviderProbe + ?Sized, K: KeyValidationProbe + ?Sized>(
+    cli_probe: &P,
+    key_probe: &K,
+    validate_keys: bool,
+) -> Result<Value, String> {
+    if validate_keys {
+        let doctor = CapabilityDoctor::run(cli_probe, key_probe);
+        render_with_keys(&doctor)
+    } else {
+        let cli_doctor = ProviderDoctor::run_for(cli_probe, Provider::all());
+        render_cli_only(&cli_doctor.statuses)
+    }
+}
+
+fn cli_section(statuses: &[ProviderAuthStatus]) -> (Vec<Value>, Vec<&'static str>) {
+    let detected: Vec<Value> = statuses
+        .iter()
+        .map(|status| {
+            json!({
+                "provider": status.provider.as_str(),
+                "installed": status.installed,
+                "authenticated": status.authenticated,
+                "detail": status.detail,
+            })
+        })
+        .collect();
+    let logged_in: Vec<&'static str> = statuses
+        .iter()
+        .filter(|s| s.authenticated)
+        .map(|s| s.provider.as_str())
+        .collect();
+    (detected, logged_in)
+}
+
+fn key_entry(signal: &KeyValidationSignal) -> Value {
+    use KeyValidationOutcome::*;
+    let (status, detail) = match signal.outcome {
+        Invalid { status } => (Some(status), None),
+        Unavailable { detail } => (None, Some(detail)),
+        Valid | CredentialMissing => (None, None),
+    };
+    json!({
+        "provider": signal.provider.as_str(),
+        "label": signal.outcome.label(),
+        "status": status,
+        "detail": detail,
+    })
+}
+
+fn render_cli_only(statuses: &[ProviderAuthStatus]) -> Result<Value, String> {
+    let (detected, logged_in) = cli_section(statuses);
+    finish(json!({
+        "truth_label": "rust_capability_doctor",
+        "proof_only": true,
+        "ok": true,
+        "cli_detected": detected,
+        "cli_logged_in": logged_in,
+        "key_validation_probed": false,
+        "key_validation": Value::Null,
+        "confirmed_valid_keys": Value::Null,
+        "route_readiness": Value::Null,
+        "suggested_text_route": Value::Null,
+        "suggested_strong_route": Value::Null,
+        "failover_readiness": Value::Null,
+    }))
+}
+
+fn render_with_keys(doctor: &CapabilityDoctor) -> Result<Value, String> {
+    let (detected, logged_in) = cli_section(&doctor.cli_statuses);
+    let key_validation: Vec<Value> = doctor.key_signals.iter().map(key_entry).collect();
+    let confirmed: Vec<&'static str> = doctor
+        .confirmed_valid_keys()
+        .iter()
+        .map(|kp| kp.as_str())
+        .collect();
+    let readiness = doctor.provider_readiness_report(
+        &runtime_readiness_registry(),
+        ProviderReadinessFlags {
+            deepseek_to_claude_failover: env_exact_one(ENV_PROVIDER_FAILOVER),
+            claude_to_deepseek_failover: env_exact_one(ENV_PROVIDER_FAILOVER_CLAUDE_TO_DEEPSEEK),
+        },
+    );
+
+    finish(json!({
+        "truth_label": "rust_capability_doctor",
+        "proof_only": true,
+        "ok": true,
+        "cli_detected": detected,
+        "cli_logged_in": logged_in,
+        "key_validation_probed": true,
+        "key_validation": key_validation,
+        "confirmed_valid_keys": confirmed,
+        "route_readiness": route_readiness_entries(&readiness),
+        "suggested_text_route": readiness.suggested_text_route,
+        "suggested_strong_route": readiness.suggested_strong_route,
+        "failover_readiness": failover_readiness_entries(&readiness),
+    }))
+}
+
+fn runtime_readiness_registry() -> RouteRegistry {
+    let mut registry = RouteRegistry::autonomous_baseline();
+    if !env_exact_one(ENV_DEEPSEEK_PRO_ROUTE_ENABLED) {
+        set_route_state(&mut registry, "deepseek-pro", false, false);
+    }
+    if env_exact_one(ENV_CLAUDE_ROUTE_ENABLED) {
+        set_route_state(&mut registry, "claude", true, true);
+    }
+    if env_exact_one(ENV_CODEX_ROUTE_ENABLED) {
+        set_route_state(&mut registry, "codex", true, true);
+    }
+    registry
+}
+
+fn set_route_state(
+    registry: &mut RouteRegistry,
+    provider_id: &str,
+    available: bool,
+    validation_ok: bool,
+) {
+    if let Some(route) = registry.get(provider_id).cloned() {
+        registry.register(ProviderRoute {
+            available,
+            validation_ok,
+            ..route
+        });
+    }
+}
+
+fn env_exact_one(key: &str) -> bool {
+    matches!(std::env::var(key), Ok(value) if value.trim() == "1")
+}
+
+fn route_readiness_entries(report: &ProviderReadinessReport) -> Vec<Value> {
+    report.routes.iter().map(route_readiness_entry).collect()
+}
+
+fn route_readiness_entry(route: &ProviderRouteReadiness) -> Value {
+    let blockers: Vec<Value> = route
+        .blockers
+        .iter()
+        .map(|blocker| {
+            json!({
+                "kind": blocker.kind.as_str(),
+                "code": blocker.code,
+            })
+        })
+        .collect();
+    json!({
+        "provider_id": route.provider_id,
+        "api": provider_api_label(route.api),
+        "backend_kind": backend_kind_label(route.backend_kind),
+        "model": route.model,
+        "model_size": model_size_label(route.model_size),
+        "strength": route.strength.as_str(),
+        "dispatchable": route.dispatchable,
+        "blockers": blockers,
+    })
+}
+
+fn failover_readiness_entries(report: &ProviderReadinessReport) -> Vec<Value> {
+    report
+        .failovers
+        .iter()
+        .map(failover_readiness_entry)
+        .collect()
+}
+
+fn failover_readiness_entry(failover: &FailoverReadiness) -> Value {
+    let blockers: Vec<Value> = failover
+        .blockers
+        .iter()
+        .map(|blocker| {
+            json!({
+                "kind": blocker.kind.as_str(),
+                "code": blocker.code,
+            })
+        })
+        .collect();
+    json!({
+        "direction": failover.direction,
+        "flag_enabled": failover.flag_enabled,
+        "can_enable": failover.can_enable,
+        "blockers": blockers,
+    })
+}
+
+fn finish(payload: Value) -> Result<Value, String> {
+    let rendered = serde_json::to_string(&payload).map_err(|_| "serialize_failed".to_string())?;
+    reject_forbidden_output(&rendered)?;
+    Ok(payload)
+}
+
+pub fn reject_forbidden_output(rendered: &str) -> Result<(), String> {
+    crate::refs_guard::reject_forbidden_output(
+        rendered,
+        &["authMethod", "subscriptionType", "loggedIn"],
+    )
+    .map_err(|marker| format!("forbidden marker in projection: {marker}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use friday_providers::{
+        KeyProvider, KeyValidationOutcome, MockKeyValidationProbe, ProbeOutput, ProviderError,
+    };
+    use std::collections::HashMap;
+
+    struct MockCliProbe {
+        out: HashMap<&'static str, Result<ProbeOutput, ()>>,
+    }
+
+    impl MockCliProbe {
+        fn new() -> Self {
+            Self {
+                out: HashMap::new(),
+            }
+        }
+
+        fn set(mut self, provider: Provider, stdout: &str) -> Self {
+            self.out.insert(
+                provider.as_str(),
+                Ok(ProbeOutput {
+                    stdout: stdout.to_string(),
+                    stderr: String::new(),
+                }),
+            );
+            self
+        }
+    }
+
+    impl ProviderProbe for MockCliProbe {
+        fn status(&self, provider: Provider) -> Result<ProbeOutput, ProviderError> {
+            match self.out.get(provider.as_str()) {
+                Some(Ok(output)) => Ok(output.clone()),
+                _ => Err(ProviderError::NotInstalled("mock".into())),
+            }
+        }
+    }
+
+    #[test]
+    fn default_off_is_cli_only_and_route_null() {
+        let cli = MockCliProbe::new().set(Provider::Codex, "Logged in using ChatGPT");
+        let keys = MockKeyValidationProbe::new();
+        let payload =
+            project_capability_doctor(&cli, &keys, false).expect("renders default-off payload");
+        assert_eq!(payload["truth_label"], "rust_capability_doctor");
+        assert_eq!(payload["key_validation_probed"], false);
+        assert!(payload["route_readiness"].is_null());
+        assert!(payload["failover_readiness"].is_null());
+        assert_eq!(payload["cli_logged_in"][0], "codex");
+    }
+
+    #[test]
+    fn validate_keys_renders_route_readiness_refs_only() {
+        let cli = MockCliProbe::new()
+            .set(Provider::Codex, "Logged in using ChatGPT")
+            .set(Provider::Claude, "Logged in");
+        let keys = MockKeyValidationProbe::new()
+            .with(KeyProvider::DeepSeek, KeyValidationOutcome::Valid)
+            .with(
+                KeyProvider::Anthropic,
+                KeyValidationOutcome::CredentialMissing,
+            );
+        let payload =
+            project_capability_doctor(&cli, &keys, true).expect("renders route readiness payload");
+        assert_eq!(payload["key_validation_probed"], true);
+        assert!(payload["route_readiness"].is_array());
+        assert!(payload["failover_readiness"].is_array());
+        let rendered = serde_json::to_string(&payload).expect("json");
+        assert!(!rendered.contains("loggedIn"));
+        assert!(!rendered.contains("authMethod"));
+        assert!(!rendered.contains("subscriptionType"));
+    }
+}

--- a/rust-core/crates/friday-hub/src/lib.rs
+++ b/rust-core/crates/friday-hub/src/lib.rs
@@ -99,6 +99,7 @@ pub mod runtime;
 /// (never silent / fake-ready); an unknown command fails closed. Closes the contract's
 /// `menu_command_sheet_entrypoints` orphan. The HTTP route-family half stays NO-GO (no API).
 pub mod capability;
+pub mod capability_doctor_projection;
 
 /// A-PR4: channel→Hub event wiring (verified inbound → bound principal → Activity+audit).
 pub mod channel_event;

--- a/rust-core/crates/friday-protocol/src/lib.rs
+++ b/rust-core/crates/friday-protocol/src/lib.rs
@@ -1146,6 +1146,28 @@ pub struct ProvidersDoctorSnapshotWire {
     pub generated_at_ms: i64,
 }
 
+/// **S-R3b** — client->read-server request for the refs-only capability-doctor projection.
+/// PURE READ in the dispatch sense: no prompt/send and no model completion. When
+/// `validate_keys=true`, the Hub runs the existing key-validation doctor, which may perform
+/// provider auth probes and can spend the documented tiny Anthropic validation quota.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CapabilityDoctorRequestWire {
+    #[serde(default)]
+    pub validate_keys: bool,
+    pub forwarded_principal: String,
+    pub auth_proof: Vec<u8>,
+    pub request_id: String,
+}
+
+/// **S-R3b** — read-server->client owner-sealed capability-doctor snapshot. Carries
+/// refs-only capability readiness JSON; never raw CLI/account/key material.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CapabilityDoctorSnapshotWire {
+    pub request_id: String,
+    pub projection_json: String,
+    pub generated_at_ms: i64,
+}
+
 // ----------------------------------------------------------------------------------------------
 // **C2I-PR2** — the 5 OWNER-GATED C2 READ-PLANE request/snapshot wire shapes for the DARK read
 // server. Every one is the EXACT sibling of [`RunReadbackRequestWire`] / [`RunReadbackSnapshotWire`]:
@@ -1503,6 +1525,14 @@ pub enum Message {
     /// `linked_only` — never upgraded, never raw account info). Guard ran before sealing.
     ProvidersDoctorSnapshot {
         snapshot: ProvidersDoctorSnapshotWire,
+    },
+    /// **S-R3b** — UI->DARK read-server: owner-authenticated capability-doctor read projection.
+    CapabilityDoctorRequest {
+        request: CapabilityDoctorRequestWire,
+    },
+    /// **S-R3b** — DARK read-server->UI: owner-sealed, refs-only capability-doctor snapshot.
+    CapabilityDoctorSnapshot {
+        snapshot: CapabilityDoctorSnapshotWire,
     },
     /// **C2I-PR2 (C2-4)** — UI→DARK read-server: request the OWNER-SCOPED routed-session LIST over
     /// the sealed-WS READ seam. PURE READ — no model/provider call. Owner-scoped (the SAME chain a


### PR DESCRIPTION
## Summary
- add an owner-authenticated sealed-read CapabilityDoctorRequest/Snapshot arm for refs-only provider route/failover readiness
- expose `fetchCapabilityDoctor(validateKeys:)` through the shared Swift FridayRustClient and wire iOS provider detail to the real capability-doctor payload
- render suggested routes, failover blockers, and key-probe truth on iOS without flipping provider execution, spend routes, failover, signing, or organic gates

## Verification
- cargo test --manifest-path rust-core/Cargo.toml -p friday-hub capability_doctor_projection -- --nocapture
- swift test --package-path apps/friday-ios --filter HomeViewModelTests
- swift test --package-path apps/friday-ios
- swift test --package-path apps/macos/FridayRustClient --filter ReadClientWiringTests
- apps/friday-ios/build-sim.sh (sim install/launch/screenshot verified nonblank app)
- git diff --check
- npm run check:secret-patterns

Truth: this is a T2 read/client surface for existing capability-doctor readiness. It does not auto-dispatch, approve, sign, flip live provider routing, or count as organic/GO-LIVE.