### PR TITLE
Project durable memory candidate ids in Workbench

### DIFF
--- a/apps/macos/FridayHubConsole/Sources/FridayHubConsole/OperationsOverviewScreen.swift
+++ b/apps/macos/FridayHubConsole/Sources/FridayHubConsole/OperationsOverviewScreen.swift
@@ -343,9 +343,9 @@ struct OperationsOverviewScreen: View {
             })
         }
         Text(
-          "Confirm/reject drives the owner decision through the Rust spine. NOTE: the read "
-            + "projection surfaces a synthetic candidate id today — a confirm returns "
-            + "\"blocked\" until the durable memory_id is projected (rendered honestly).")
+          "Confirm/reject drives the owner decision through the Rust spine. The projection "
+            + "surfaces the durable memory id; stale or out-of-scope candidates still render "
+            + "as a server block.")
           .font(.system(size: 10))
           .foregroundStyle(HubTheme.textSecondary)
       }

--- a/apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/MockReadClient.swift
+++ b/apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/MockReadClient.swift
@@ -132,7 +132,7 @@ public struct MockReadClient: FridayRustReadClient {
 
     let memoryCandidates: [MissionWorkbenchMemoryCandidate] = [
       MissionWorkbenchMemoryCandidate(
-        id: "memory_candidate_mission_workbench_probe_20260605_0",
+        id: "mem-workbench-probe",
         preview: "Review-only memory candidate attached to this Mission.",
         state: "candidate_review_only",
         grantsMemoryAuthority: false,

--- a/apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/OperationsOverviewViewModel.swift
+++ b/apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/OperationsOverviewViewModel.swift
@@ -618,11 +618,9 @@ public final class OperationsOverviewViewModel: ObservableObject {
   /// Submit ONE owner confirm/reject for a memory candidate over the sealed WRITE seam, keyed by the
   /// candidate's display id. `memoryId` is what the server decides on.
   ///
-  /// HONEST-STATE NOTE (Layer-D prerequisite): the read projection currently surfaces a SYNTHETIC
-  /// candidate id, not the durable `memory_item` row id, so a confirm against it returns
-  /// `status:"blocked"` (`unknown_candidate`) — which is rendered AS `.error` (never a fake confirm).
-  /// A real confirm closes only once the read projection surfaces the real memory_id (a cross-team
-  /// Rust change, out of scope here). Either way the control is wired end-to-end and honest.
+  /// Submit ONE owner confirm/reject for a memory candidate over the sealed WRITE seam. The read
+  /// projection surfaces the durable `memory_item` id; the server still owns all owner/namespace
+  /// gates and can return `status:"blocked"` for stale, malformed, or out-of-scope candidates.
   public func decideMemory(candidateId: String, memoryId: String, confirm: Bool) async {
     guard let writeClient else {
       memoryDecisionStates[candidateId] = .error(reason: "Write seam not configured.")

--- a/apps/macos/FridayHubConsole/Tests/FridayHubConsoleCoreTests/OperationsOverviewViewModelTests.swift
+++ b/apps/macos/FridayHubConsole/Tests/FridayHubConsoleCoreTests/OperationsOverviewViewModelTests.swift
@@ -1216,15 +1216,15 @@ func decideMemoryConfirmRendersConfirmedRecallable() async {
 @Test
 @MainActor
 func decideMemoryBlockedRendersErrorNotConfirmed() async {
-  // THE synthetic-candidate-id reality today: a confirm against the synthetic id returns
-  // status:"blocked" — which MUST render .error (never a fabricated confirm).
+  // A stale or out-of-scope durable id still returns status:"blocked" and MUST render .error
+  // rather than a fabricated confirm.
   let vm = OperationsOverviewViewModel(
     client: MockReadClient(behavior: .loaded),
     writeClient: MockMissionSpineWriteClient(behavior: .memoryBlocked))
   await vm.decideMemory(
-    candidateId: "cand-synthetic", memoryId: "memory_candidate_mission_x_0", confirm: true)
-  guard case let .error(reason) = vm.memoryDecisionStates["cand-synthetic"] else {
-    Issue.record("a blocked decision must render .error, got \(String(describing: vm.memoryDecisionStates["cand-synthetic"]))")
+    candidateId: "mem-stale", memoryId: "mem-stale", confirm: true)
+  guard case let .error(reason) = vm.memoryDecisionStates["mem-stale"] else {
+    Issue.record("a blocked decision must render .error, got \(String(describing: vm.memoryDecisionStates["mem-stale"]))")
     return
   }
   #expect(reason.contains("unknown_candidate") || reason.contains("blocked"))

--- a/rust-core/crates/friday-hub/src/workbench_projection.rs
+++ b/rust-core/crates/friday-hub/src/workbench_projection.rs
@@ -319,30 +319,54 @@ fn memory_candidates_json(
     mission: &friday_core::Mission,
     links: &[friday_core::MissionLink],
 ) -> Vec<Value> {
+    let mut seen_memory_ids: Vec<String> = Vec::new();
     let mut rows = links
         .iter()
         .filter(|link| link.link_kind == MissionLinkKind::MemoryCandidate)
-        .enumerate()
-        .map(|(index, link)| {
-            json!({
-                "id": format!("memory_candidate_{}_{}", safe_ref_part(&mission.mission_id), index),
-                "preview": "Review-only memory candidate attached to this Mission.",
-                "state": "candidate_review_only",
-                "grantsMemoryAuthority": false,
-                "evidenceRef": redacted_link_proof_ref("memory-candidate", link)
-            })
+        .filter_map(|link| {
+            let memory_id = memory_id_from_ref(&link.target_ref)?;
+            if seen_memory_ids.iter().any(|seen| seen == &memory_id) {
+                return None;
+            }
+            seen_memory_ids.push(memory_id.clone());
+            Some(memory_candidate_row(
+                &memory_id,
+                redacted_link_proof_ref("memory-candidate", link),
+            ))
         })
         .collect::<Vec<_>>();
-    for (index, _candidate_ref) in mission.memory_candidate_refs.iter().enumerate() {
-        rows.push(json!({
-            "id": format!("memory_candidate_{}_mission_{}", safe_ref_part(&mission.mission_id), index),
-            "preview": "Review-only memory candidate attached to this Mission.",
-            "state": "candidate_review_only",
-            "grantsMemoryAuthority": false,
-            "evidenceRef": redacted_ref("memory-candidate", &format!("{}:{index}", mission.mission_id))
-        }));
+    for candidate_ref in &mission.memory_candidate_refs {
+        let Some(memory_id) = memory_id_from_ref(candidate_ref) else {
+            continue;
+        };
+        if seen_memory_ids.iter().any(|seen| seen == &memory_id) {
+            continue;
+        }
+        seen_memory_ids.push(memory_id.clone());
+        rows.push(memory_candidate_row(
+            &memory_id,
+            redacted_ref("memory-candidate", candidate_ref),
+        ));
     }
     rows
+}
+
+fn memory_id_from_ref(memory_ref: &str) -> Option<String> {
+    let id = memory_ref.strip_prefix("friday://memory/")?.trim();
+    if id.is_empty() || id.contains('/') || id.contains('#') {
+        return None;
+    }
+    Some(id.to_string())
+}
+
+fn memory_candidate_row(memory_id: &str, evidence_ref: String) -> Value {
+    json!({
+        "id": memory_id,
+        "preview": "Review-only memory candidate attached to this Mission.",
+        "state": "candidate_review_only",
+        "grantsMemoryAuthority": false,
+        "evidenceRef": evidence_ref
+    })
 }
 
 fn run_outcome_learning_candidates_json(
@@ -1047,11 +1071,12 @@ mod tests {
     use super::*;
     use crate::channel_event::ingest_channel_inbound;
     use crate::channels::{redact_inbound, VerifiedInbound};
-    use crate::mission_preflight::attach_channel_inbound_receipt;
+    use crate::mission_preflight::{attach_channel_inbound_receipt, attach_memory_candidate_ref};
     use friday_core::{
-        ApprovalState, FridayConversation, HandoffJudgmentMemory, Mission, MissionStatus,
-        RouteDecisionCard, TruthStatus, WorkItem, WorkItemStatus, WorkLane,
+        ApprovalState, FridayConversation, HandoffJudgmentMemory, MemoryScope, Mission,
+        MissionStatus, RouteDecisionCard, TruthStatus, WorkItem, WorkItemStatus, WorkLane,
     };
+    use friday_storage::memory;
     use std::sync::atomic::{AtomicU64, Ordering};
 
     static C: AtomicU64 = AtomicU64::new(0);
@@ -1212,6 +1237,54 @@ mod tests {
             snapshot.get("missionId").and_then(Value::as_str),
             Some(mission_id.as_str()),
             "the snapshot must carry the EXACT real hyphen mission id, not a rewritten/synthetic shape"
+        );
+    }
+
+    #[test]
+    fn memory_candidates_project_durable_memory_id_once() {
+        let db = Db::open_hub(&tmp()).unwrap();
+        let mission_id = seed_real_producer_mission(&db);
+        memory::record_candidate(
+            db.conn(),
+            &memory::NewMemoryCandidate {
+                memory_id: "mem-workbench-confirm",
+                scope: MemoryScope::Global,
+                content_ref: Some("blob://mem-workbench-confirm"),
+                content: Some("User wants precise Friday progress reports."),
+                principal_id: Some("owner-real"),
+                sensitive: false,
+                created_at: 1_780_640_000_200,
+            },
+        )
+        .unwrap();
+        attach_memory_candidate_ref(&db, &mission_id, "mem-workbench-confirm", 1_780_640_000_300)
+            .unwrap();
+
+        let snapshot = project_workbench(&db, Some(&mission_id)).unwrap();
+        let candidates = snapshot
+            .get("memoryCandidates")
+            .and_then(Value::as_array)
+            .expect("memoryCandidates array");
+        assert_eq!(
+            candidates.len(),
+            1,
+            "mission links + mission refs point at the same durable memory id and must dedupe"
+        );
+        assert_eq!(
+            candidates[0].get("id").and_then(Value::as_str),
+            Some("mem-workbench-confirm"),
+            "projection must surface the server-decidable memory_id, not a synthetic display id"
+        );
+        assert_eq!(
+            candidates[0]
+                .get("grantsMemoryAuthority")
+                .and_then(Value::as_bool),
+            Some(false),
+            "candidate projection remains review-only until the write decision confirms it"
+        );
+        assert_ne!(
+            candidates[0].get("id").and_then(Value::as_str),
+            Some("memory_candidate_mission_x_0")
         );
     }
 


### PR DESCRIPTION
## Summary
- project Workbench memory candidates with durable `friday://memory/{id}` ids instead of synthetic display ids
- dedupe mission-link and mission-level candidate refs before presenting review-only rows
- update desktop Workbench copy/tests so confirm/reject can address a server-decidable memory id

## Truth label
T2 desktop product-loop plumbing: this makes existing memory confirm/reject UI target a durable server id. It does not auto-confirm memory, does not grant memory authority from projection, does not move organic/GO gates, and keeps server owner/namespace gates in charge.

## Verification
- `cargo fmt --manifest-path rust-core/Cargo.toml --all`
- `cargo test --manifest-path rust-core/Cargo.toml -p friday-hub memory_candidates_project_durable_memory_id_once -- --nocapture`
- `swift test --package-path apps/macos/FridayHubConsole --filter OperationsOverviewViewModelTests`
- `git diff --check`
- `npm run check:secret-patterns`