### PR TITLE
Wire iOS memory candidate decisions

### DIFF
--- a/apps/friday-ios/Sources/FridayMobileShell/FridayProjectionScreens.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayProjectionScreens.swift
@@ -572,14 +572,41 @@ struct FridayProjectionScreen: View {
   }
 
   private func memoryCandidateRow(_ candidate: HomeMemoryCandidate) -> some View {
-    VStack(alignment: .leading, spacing: 6) {
-      Text(candidate.preview)
-        .font(.system(size: 13, weight: .medium))
-        .foregroundStyle(MobileTheme.textPrimary)
+    let decisionState = viewModel.memoryDecisionStates[candidate.id]
+    return VStack(alignment: .leading, spacing: 6) {
+      HStack(alignment: .top, spacing: 8) {
+        Text(candidate.preview)
+          .font(.system(size: 13, weight: .medium))
+          .foregroundStyle(MobileTheme.textPrimary)
+          .frame(maxWidth: .infinity, alignment: .leading)
+        HStack(spacing: 6) {
+          Button {
+            Task { await viewModel.decideMemory(candidateId: candidate.id, confirm: true) }
+          } label: {
+            Image(systemName: "checkmark")
+              .frame(width: 26, height: 26)
+          }
+          .buttonStyle(.borderedProminent)
+          .tint(MobileTheme.cyan)
+          .disabled(candidateDecisionControlsDisabled(decisionState))
+          .accessibilityLabel("Confirm memory candidate")
+
+          Button {
+            Task { await viewModel.decideMemory(candidateId: candidate.id, confirm: false) }
+          } label: {
+            Image(systemName: "xmark")
+              .frame(width: 26, height: 26)
+          }
+          .buttonStyle(.bordered)
+          .disabled(candidateDecisionControlsDisabled(decisionState))
+          .accessibilityLabel("Reject memory candidate")
+        }
+      }
       HStack(spacing: 6) {
         statusChip(candidate.state)
         statusChip(candidate.grantsMemoryAuthority ? "grants authority" : "review only")
       }
+      candidateDecisionStateView(decisionState, pendingText: "Applying memory decision...")
       if !candidate.evidenceRef.isEmpty {
         RefPill(label: "evidenceRef", ref: candidate.evidenceRef)
       }
@@ -637,15 +664,24 @@ struct FridayProjectionScreen: View {
   }
 
   private func learningDecisionControlsDisabled(_ state: HomeLearningDecisionState?) -> Bool {
+    candidateDecisionControlsDisabled(state)
+  }
+
+  private func candidateDecisionControlsDisabled(_ state: HomeLearningDecisionState?) -> Bool {
     guard let state else { return false }
     return state.isSent || state.isTerminal
   }
 
   @ViewBuilder
   private func learningDecisionStateView(_ state: HomeLearningDecisionState?) -> some View {
+    candidateDecisionStateView(state, pendingText: "Applying learning decision...")
+  }
+
+  @ViewBuilder
+  private func candidateDecisionStateView(_ state: HomeLearningDecisionState?, pendingText: String) -> some View {
     switch state {
     case .sent:
-      Text("Applying learning decision…")
+      Text(pendingText)
         .font(.caption2)
         .foregroundStyle(MobileTheme.textSecondary)
     case .confirmed(let summary):

--- a/apps/friday-ios/Sources/FridayMobileShellCore/HomeViewModel.swift
+++ b/apps/friday-ios/Sources/FridayMobileShellCore/HomeViewModel.swift
@@ -551,6 +551,7 @@ public struct MobilePairingAttempt: Sendable, Equatable {
 public final class HomeViewModel: ObservableObject {
   @Published public private(set) var state: HomeLoadState = .idle
   @Published public private(set) var detailState: HomeReadDetailState = .idle
+  @Published public private(set) var memoryDecisionStates: [String: HomeLearningDecisionState] = [:]
   @Published public private(set) var runOutcomeLearningDecisionStates: [String: HomeLearningDecisionState] = [:]
   @Published public private(set) var pairingPreflight: MobilePairingPreflight = .empty
   @Published public private(set) var pairingAttempt: MobilePairingAttempt = .idle
@@ -561,6 +562,7 @@ public final class HomeViewModel: ObservableObject {
   /// refs-only value projections, never the package snapshot's raw body map.
   private let client: FridayRustReadClient
   private let writeClient: FridayMissionSpineWriteClient?
+  private let writeOwnerPrincipal: String
   private let makePairingClient: (DeviceKeypair) -> FridayPairingClient?
 
   /// - Parameter client: the read client. In production this is the real `SealedWSReadClient`
@@ -568,6 +570,7 @@ public final class HomeViewModel: ObservableObject {
   public init(
     client: FridayRustReadClient,
     writeClient: FridayMissionSpineWriteClient? = nil,
+    writeOwnerPrincipal: String = liveAgentRunOwnerPrincipal,
     devicePairing: DevicePairingReadiness = .evaluate(
       deviceKeypairRequested: false,
       readLiveRequested: false,
@@ -576,6 +579,7 @@ public final class HomeViewModel: ObservableObject {
   ) {
     self.client = client
     self.writeClient = writeClient
+    self.writeOwnerPrincipal = writeOwnerPrincipal
     self.devicePairing = devicePairing
     self.makePairingClient = makePairingClient
   }
@@ -603,6 +607,32 @@ public final class HomeViewModel: ObservableObject {
       detailState = .loaded(HomeReadDetail(title: arm.title, snapshot: snapshot))
     } catch {
       detailState = .unavailable(title: arm.title, reason: Self.reason(for: error))
+    }
+  }
+
+  public func decideMemory(candidateId: String, confirm: Bool) async {
+    guard let writeClient else {
+      memoryDecisionStates[candidateId] = .error(reason: "Write seam not configured.")
+      return
+    }
+    memoryDecisionStates[candidateId] = .sent
+    let request = MemoryDecisionRequestWire(
+      memoryId: candidateId,
+      ownerPrincipal: writeOwnerPrincipal,
+      decision: confirm ? "confirm" : "reject")
+    do {
+      let result = try await writeClient.submitMemoryDecision(request)
+      switch result.status {
+      case "confirmed", "rejected":
+        memoryDecisionStates[candidateId] = .confirmed(
+          summary: "\(result.status) · state=\(result.state) · recallable=\(result.recallable)")
+        await refresh()
+      default:
+        let why = result.blocker ?? "blocked"
+        memoryDecisionStates[candidateId] = .error(reason: "Memory decision blocked — \(why)")
+      }
+    } catch {
+      memoryDecisionStates[candidateId] = .error(reason: Self.reason(for: error))
     }
   }
 

--- a/apps/friday-ios/Tests/FridayMobileShellCoreTests/HomeViewModelTests.swift
+++ b/apps/friday-ios/Tests/FridayMobileShellCoreTests/HomeViewModelTests.swift
@@ -171,17 +171,24 @@ final class HomeViewModelTests: XCTestCase {
     }
   }
 
-  final class FakeLearningWriteClient: FridayMissionSpineWriteClient, @unchecked Sendable {
-    enum Script {
+  final class FakeMissionWriteClient: FridayMissionSpineWriteClient, @unchecked Sendable {
+    enum LearningScript {
       case result(RunOutcomeLearningDecisionResultWire)
       case fail(Error)
     }
+    enum MemoryScript {
+      case result(MemoryDecisionResultWire)
+      case fail(Error)
+    }
 
-    let script: Script
+    let learningScript: LearningScript?
+    let memoryScript: MemoryScript?
+    private(set) var memoryRequests: [MemoryDecisionRequestWire] = []
     private(set) var learningRequests: [RunOutcomeLearningDecisionRequestWire] = []
 
-    init(_ script: Script) {
-      self.script = script
+    init(learningScript: LearningScript? = nil, memoryScript: MemoryScript? = nil) {
+      self.learningScript = learningScript
+      self.memoryScript = memoryScript
     }
 
     func submitMissionIntake(_ request: MissionIntakeRequestWire) async throws -> MissionIntakeResultWire {
@@ -189,14 +196,20 @@ final class HomeViewModelTests: XCTestCase {
     }
 
     func submitMemoryDecision(_ request: MemoryDecisionRequestWire) async throws -> MemoryDecisionResultWire {
-      throw NSError(domain: "unused", code: 1)
+      memoryRequests.append(request)
+      guard let memoryScript else { throw NSError(domain: "unused", code: 1) }
+      switch memoryScript {
+      case .result(let result): return result
+      case .fail(let error): throw error
+      }
     }
 
     func submitRunOutcomeLearningDecision(
       _ request: RunOutcomeLearningDecisionRequestWire
     ) async throws -> RunOutcomeLearningDecisionResultWire {
       learningRequests.append(request)
-      switch script {
+      guard let learningScript else { throw NSError(domain: "unused", code: 1) }
+      switch learningScript {
       case .result(let result): return result
       case .fail(let error): throw error
       }
@@ -438,12 +451,13 @@ final class HomeViewModelTests: XCTestCase {
 
   func testDecideRunOutcomeLearningConfirmRendersConfirmedAndRefreshes() async throws {
     let read = FakeReadClient(.snapshot(try sampleSnapshot()))
-    let write = FakeLearningWriteClient(.result(RunOutcomeLearningDecisionResultWire(
-      candidateId: "learn-1",
-      runId: "run-1",
-      kind: "preference",
-      state: "confirmed",
-      status: "confirmed")))
+    let write = FakeMissionWriteClient(learningScript: .result(
+      RunOutcomeLearningDecisionResultWire(
+        candidateId: "learn-1",
+        runId: "run-1",
+        kind: "preference",
+        state: "confirmed",
+        status: "confirmed")))
     let vm = HomeViewModel(client: read, writeClient: write)
 
     await vm.decideRunOutcomeLearning(candidateId: "learn-1", confirm: true)
@@ -459,11 +473,12 @@ final class HomeViewModelTests: XCTestCase {
 
   func testDecideRunOutcomeLearningBlockedRendersErrorNotConfirmed() async throws {
     let read = FakeReadClient(.snapshot(try sampleSnapshot()))
-    let write = FakeLearningWriteClient(.result(RunOutcomeLearningDecisionResultWire(
-      candidateId: "learn-1",
-      state: "unknown",
-      status: "blocked",
-      blocker: "candidate missing")))
+    let write = FakeMissionWriteClient(learningScript: .result(
+      RunOutcomeLearningDecisionResultWire(
+        candidateId: "learn-1",
+        state: "unknown",
+        status: "blocked",
+        blocker: "candidate missing")))
     let vm = HomeViewModel(client: read, writeClient: write)
 
     await vm.decideRunOutcomeLearning(candidateId: "learn-1", confirm: false)
@@ -486,6 +501,73 @@ final class HomeViewModelTests: XCTestCase {
     XCTAssertEqual(read.fetchWorkbenchCount, 0)
     XCTAssertEqual(
       vm.runOutcomeLearningDecisionStates["learn-1"],
+      .error(reason: "Write seam not configured."))
+  }
+
+  func testDecideMemoryConfirmRendersConfirmedAndRefreshes() async throws {
+    let read = FakeReadClient(.snapshot(try sampleSnapshot()))
+    let write = FakeMissionWriteClient(memoryScript: .result(
+      MemoryDecisionResultWire(
+        memoryId: "cand-1",
+        state: "confirmed",
+        status: "confirmed",
+        recallable: true)))
+    let vm = HomeViewModel(
+      client: read,
+      writeClient: write,
+      writeOwnerPrincipal: "owner-ios")
+
+    await vm.decideMemory(candidateId: "cand-1", confirm: true)
+
+    XCTAssertEqual(write.memoryRequests, [
+      MemoryDecisionRequestWire(
+        memoryId: "cand-1",
+        ownerPrincipal: "owner-ios",
+        decision: "confirm"),
+    ])
+    XCTAssertEqual(read.fetchWorkbenchCount, 1)
+    XCTAssertEqual(
+      vm.memoryDecisionStates["cand-1"],
+      .confirmed(summary: "confirmed · state=confirmed · recallable=true"))
+  }
+
+  func testDecideMemoryBlockedRendersErrorNotConfirmed() async throws {
+    let read = FakeReadClient(.snapshot(try sampleSnapshot()))
+    let write = FakeMissionWriteClient(memoryScript: .result(
+      MemoryDecisionResultWire(
+        memoryId: "cand-1",
+        state: "unknown",
+        status: "blocked",
+        blocker: "unknown_candidate",
+        recallable: false)))
+    let vm = HomeViewModel(
+      client: read,
+      writeClient: write,
+      writeOwnerPrincipal: "owner-ios")
+
+    await vm.decideMemory(candidateId: "cand-1", confirm: false)
+
+    XCTAssertEqual(write.memoryRequests, [
+      MemoryDecisionRequestWire(
+        memoryId: "cand-1",
+        ownerPrincipal: "owner-ios",
+        decision: "reject"),
+    ])
+    XCTAssertEqual(read.fetchWorkbenchCount, 0)
+    XCTAssertEqual(
+      vm.memoryDecisionStates["cand-1"],
+      .error(reason: "Memory decision blocked — unknown_candidate"))
+  }
+
+  func testDecideMemoryWithoutWriteClientIsUnavailable() async throws {
+    let read = FakeReadClient(.snapshot(try sampleSnapshot()))
+    let vm = HomeViewModel(client: read)
+
+    await vm.decideMemory(candidateId: "cand-1", confirm: true)
+
+    XCTAssertEqual(read.fetchWorkbenchCount, 0)
+    XCTAssertEqual(
+      vm.memoryDecisionStates["cand-1"],
       .error(reason: "Write seam not configured."))
   }
 }


### PR DESCRIPTION
## Summary
- add iOS Home memory candidate confirm/reject state and sealed WRITE submission through existing `MemoryDecisionRequest`
- render memory candidate check/reject controls next to existing review-only candidate rows
- add HomeViewModel tests for confirmed, blocked, and no-write-client memory decision paths

## Truth label
T2 mobile product-loop plumbing: the iOS app can now drive the existing owner-auth memory-candidate confirm/reject write arm when a durable memory id is projected. Projection remains review-only, server receipts decide success/error, and this does not grant memory authority locally, flip live gates, or move organic/GO.

## Verification
- `swift test --package-path apps/friday-ios`
- `apps/friday-ios/build-sim.sh`
- `git diff --check`
- `npm run check:secret-patterns`