### PR TITLE
Add pairing QR provisioning surfaces

### DIFF
--- a/apps/friday-ios/Info.plist
+++ b/apps/friday-ios/Info.plist
@@ -18,6 +18,8 @@
     <string>0.0.1</string>
     <key>CFBundleVersion</key>
     <string>1</string>
+    <key>NSCameraUsageDescription</key>
+    <string>Scan a Friday Hub pairing QR code.</string>
     <key>LSRequiresIPhoneOS</key>
     <true/>
     <key>MinimumOSVersion</key>

--- a/apps/friday-ios/Sources/FridayMobileShell/FridayHomeScreen.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayHomeScreen.swift
@@ -16,6 +16,7 @@ import SwiftUI
 struct FridayHomeScreen: View {
   @ObservedObject var viewModel: HomeViewModel
   @State private var pairingQRPayload = ""
+  @State private var showingPairingScanner = false
 
   var body: some View {
     ScrollView {
@@ -41,6 +42,18 @@ struct FridayHomeScreen: View {
       .padding(16)
     }
     .background(MobileTheme.backgroundWarmOffWhite.ignoresSafeArea())
+    .sheet(isPresented: $showingPairingScanner) {
+      PairingQRScannerView(
+        onScan: { payload in
+          pairingQRPayload = payload
+          viewModel.preflightPairingQR(payload)
+          showingPairingScanner = false
+        },
+        onCancel: {
+          showingPairingScanner = false
+        })
+        .ignoresSafeArea()
+    }
   }
 
   private var loadingView: some View {
@@ -171,6 +184,14 @@ struct FridayHomeScreen: View {
         .disabled(pairingQRPayload.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
           || viewModel.pairingAttempt.mode == .sending)
         .accessibilityIdentifier("friday.home.pair-button")
+
+        Button {
+          showingPairingScanner = true
+        } label: {
+          Label("Scan", systemImage: "qrcode.viewfinder")
+        }
+        .buttonStyle(.bordered)
+        .accessibilityIdentifier("friday.home.pairing-scan-button")
 
         Button {
           pairingQRPayload = ""

--- a/apps/friday-ios/Sources/FridayMobileShell/PairingQRScannerView.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/PairingQRScannerView.swift
@@ -1,0 +1,132 @@
+import AVFoundation
+import SwiftUI
+import UIKit
+
+struct PairingQRScannerView: UIViewControllerRepresentable {
+  let onScan: (String) -> Void
+  let onCancel: () -> Void
+
+  func makeCoordinator() -> Coordinator {
+    Coordinator(onScan: onScan)
+  }
+
+  func makeUIViewController(context: Context) -> ScannerViewController {
+    let controller = ScannerViewController()
+    controller.delegate = context.coordinator
+    controller.onCancel = onCancel
+    return controller
+  }
+
+  func updateUIViewController(_ uiViewController: ScannerViewController, context: Context) {}
+
+  final class Coordinator: NSObject, AVCaptureMetadataOutputObjectsDelegate {
+    private let onScan: (String) -> Void
+    private var delivered = false
+
+    init(onScan: @escaping (String) -> Void) {
+      self.onScan = onScan
+    }
+
+    func metadataOutput(
+      _ output: AVCaptureMetadataOutput,
+      didOutput metadataObjects: [AVMetadataObject],
+      from connection: AVCaptureConnection
+    ) {
+      guard !delivered,
+        let object = metadataObjects.compactMap({ $0 as? AVMetadataMachineReadableCodeObject }).first,
+        object.type == .qr,
+        let value = object.stringValue
+      else {
+        return
+      }
+      delivered = true
+      onScan(value)
+    }
+  }
+}
+
+final class ScannerViewController: UIViewController {
+  weak var delegate: AVCaptureMetadataOutputObjectsDelegate?
+  var onCancel: (() -> Void)?
+
+  private let session = AVCaptureSession()
+  private var previewLayer: AVCaptureVideoPreviewLayer?
+
+  override func viewDidLoad() {
+    super.viewDidLoad()
+    view.backgroundColor = .black
+    configureCancelButton()
+    configureScanner()
+  }
+
+  override func viewDidLayoutSubviews() {
+    super.viewDidLayoutSubviews()
+    previewLayer?.frame = view.bounds
+  }
+
+  override func viewWillDisappear(_ animated: Bool) {
+    super.viewWillDisappear(animated)
+    session.stopRunning()
+  }
+
+  private func configureCancelButton() {
+    let button = UIButton(type: .system)
+    button.setTitle("Cancel", for: .normal)
+    button.tintColor = .white
+    button.backgroundColor = UIColor.black.withAlphaComponent(0.46)
+    button.layer.cornerRadius = 8
+    button.translatesAutoresizingMaskIntoConstraints = false
+    button.addAction(UIAction { [weak self] _ in self?.onCancel?() }, for: .touchUpInside)
+    view.addSubview(button)
+    NSLayoutConstraint.activate([
+      button.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 16),
+      button.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 16),
+      button.widthAnchor.constraint(equalToConstant: 88),
+      button.heightAnchor.constraint(equalToConstant: 40),
+    ])
+  }
+
+  private func configureScanner() {
+    guard AVCaptureDevice.authorizationStatus(for: .video) != .denied,
+      let device = AVCaptureDevice.default(for: .video),
+      let input = try? AVCaptureDeviceInput(device: device),
+      session.canAddInput(input)
+    else {
+      showUnavailable()
+      return
+    }
+
+    session.addInput(input)
+    let output = AVCaptureMetadataOutput()
+    guard session.canAddOutput(output) else {
+      showUnavailable()
+      return
+    }
+    session.addOutput(output)
+    output.setMetadataObjectsDelegate(delegate, queue: .main)
+    output.metadataObjectTypes = [.qr]
+
+    let preview = AVCaptureVideoPreviewLayer(session: session)
+    preview.videoGravity = .resizeAspectFill
+    preview.frame = view.bounds
+    view.layer.insertSublayer(preview, at: 0)
+    previewLayer = preview
+
+    DispatchQueue.global(qos: .userInitiated).async { [session] in
+      session.startRunning()
+    }
+  }
+
+  private func showUnavailable() {
+    let label = UILabel()
+    label.text = "Camera is unavailable"
+    label.textColor = .white
+    label.textAlignment = .center
+    label.translatesAutoresizingMaskIntoConstraints = false
+    view.addSubview(label)
+    NSLayoutConstraint.activate([
+      label.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+      label.centerYAnchor.constraint(equalTo: view.centerYAnchor),
+    ])
+  }
+}

--- a/apps/macos/FridayHubConsole/Sources/FridayHubConsole/DesktopProjectionScreens.swift
+++ b/apps/macos/FridayHubConsole/Sources/FridayHubConsole/DesktopProjectionScreens.swift
@@ -10,7 +10,7 @@ private enum DesktopProjectionSurface {
 
   init?(_ destination: HubDestination) {
     switch destination {
-    case .operations, .chat:
+    case .operations, .chat, .pairingProvisioning:
       return nil
     case .providerAdmin:
       self = .providerAdmin

--- a/apps/macos/FridayHubConsole/Sources/FridayHubConsole/HubConsoleShell.swift
+++ b/apps/macos/FridayHubConsole/Sources/FridayHubConsole/HubConsoleShell.swift
@@ -62,6 +62,8 @@ struct HubConsoleShell: View {
       OperationsOverviewScreen(viewModel: operationsVM)
     case .chat:
       DesktopChatScreen(viewModel: operationsVM)
+    case .pairingProvisioning:
+      PairingProvisioningScreen()
     default:
       DesktopProjectionScreen(destination: destination, viewModel: operationsVM)
     }

--- a/apps/macos/FridayHubConsole/Sources/FridayHubConsole/Navigation.swift
+++ b/apps/macos/FridayHubConsole/Sources/FridayHubConsole/Navigation.swift
@@ -8,6 +8,7 @@ enum HubDestination: String, CaseIterable, Identifiable {
   case chat
   case providerAdmin
   case parity
+  case pairingProvisioning
   case workflow
   case channels
   case evidence
@@ -20,6 +21,7 @@ enum HubDestination: String, CaseIterable, Identifiable {
     case .chat: return "Friday Chat"
     case .providerAdmin: return "Provider Admin"
     case .parity: return "Provider Parity"
+    case .pairingProvisioning: return "Pairing"
     case .workflow: return "Workflow Builder"
     case .channels: return "Channels"
     case .evidence: return "Evidence Search"
@@ -32,6 +34,7 @@ enum HubDestination: String, CaseIterable, Identifiable {
     case .chat: return "bubble.left.and.bubble.right"
     case .providerAdmin: return "person.badge.key"
     case .parity: return "square.grid.3x3"
+    case .pairingProvisioning: return "qrcode.viewfinder"
     case .workflow: return "point.3.connected.trianglepath.dotted"
     case .channels: return "antenna.radiowaves.left.and.right"
     case .evidence: return "doc.text.magnifyingglass"

--- a/apps/macos/FridayHubConsole/Sources/FridayHubConsole/PairingProvisioningScreen.swift
+++ b/apps/macos/FridayHubConsole/Sources/FridayHubConsole/PairingProvisioningScreen.swift
@@ -1,0 +1,196 @@
+import AppKit
+import CoreImage.CIFilterBuiltins
+import FridayHubConsoleCore
+import SwiftUI
+import UniformTypeIdentifiers
+
+struct PairingProvisioningScreen: View {
+  @StateObject private var viewModel = PairingProvisioningViewModel()
+  @State private var inputPayload = ""
+  @State private var showImporter = false
+
+  var body: some View {
+    ScrollView {
+      VStack(alignment: .leading, spacing: 16) {
+        header
+        inputPanel
+        qrPanel
+      }
+      .padding(20)
+      .frame(maxWidth: .infinity, alignment: .topLeading)
+    }
+    .background(HubTheme.backgroundWarmOffWhite)
+    .fileImporter(
+      isPresented: $showImporter,
+      allowedContentTypes: [.json, .plainText],
+      allowsMultipleSelection: false,
+      onCompletion: importManifest)
+  }
+
+  private var header: some View {
+    GlassPanel {
+      VStack(alignment: .leading, spacing: 10) {
+        HStack(spacing: 10) {
+          Image(systemName: "qrcode.viewfinder")
+            .font(.system(size: 24, weight: .semibold))
+            .foregroundStyle(HubTheme.cyan)
+          VStack(alignment: .leading, spacing: 3) {
+            Text("Pairing Provisioning")
+              .font(.system(size: 18, weight: .semibold))
+              .foregroundStyle(HubTheme.textPrimary)
+            Text("short-lived scan material")
+              .font(.system(size: 11))
+              .foregroundStyle(HubTheme.textSecondary)
+          }
+          Spacer()
+          statusChip(viewModel.state.mode.rawValue)
+        }
+        Text(viewModel.state.reason)
+          .font(.system(size: 12))
+          .foregroundStyle(HubTheme.textSecondary)
+      }
+    }
+  }
+
+  private var inputPanel: some View {
+    GlassPanel {
+      VStack(alignment: .leading, spacing: 12) {
+        Text("Hub QR Manifest")
+          .font(.system(size: 13, weight: .semibold))
+          .foregroundStyle(HubTheme.textPrimary)
+        TextEditor(text: $inputPayload)
+          .font(.system(size: 12, design: .monospaced))
+          .frame(minHeight: 120)
+          .scrollContentBackground(.hidden)
+          .background(Color.white.opacity(0.62), in: RoundedRectangle(cornerRadius: 8))
+          .accessibilityIdentifier("friday.desktop.pairing-qr-json-input")
+        HStack(spacing: 8) {
+          Button {
+            viewModel.load(qrJSON: inputPayload)
+          } label: {
+            Label("Decode", systemImage: "checkmark.shield")
+          }
+          .buttonStyle(.borderedProminent)
+          .disabled(inputPayload.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+
+          Button {
+            showImporter = true
+          } label: {
+            Label("Import", systemImage: "tray.and.arrow.down")
+          }
+          .buttonStyle(.bordered)
+
+          Button {
+            inputPayload = ""
+            viewModel.clear()
+          } label: {
+            Image(systemName: "xmark.circle")
+          }
+          .buttonStyle(.bordered)
+          .accessibilityLabel("Clear pairing manifest")
+        }
+      }
+    }
+  }
+
+  private var qrPanel: some View {
+    GlassPanel {
+      VStack(alignment: .leading, spacing: 12) {
+        HStack {
+          Text("Scan")
+            .font(.system(size: 13, weight: .semibold))
+            .foregroundStyle(HubTheme.textPrimary)
+          Spacer()
+          Button {
+            copyPayload()
+          } label: {
+            Label("Copy", systemImage: "doc.on.doc")
+          }
+          .buttonStyle(.bordered)
+          .disabled(!viewModel.canRenderQRCode)
+        }
+        if let projection = viewModel.state.projection, viewModel.canRenderQRCode {
+          HStack(alignment: .top, spacing: 16) {
+            if let image = QRCodeRenderer.image(for: viewModel.qrPayload) {
+              Image(nsImage: image)
+                .interpolation(.none)
+                .resizable()
+                .scaledToFit()
+                .frame(width: 220, height: 220)
+                .background(Color.white, in: RoundedRectangle(cornerRadius: 8))
+                .accessibilityLabel("Friday pairing QR code")
+            }
+            VStack(alignment: .leading, spacing: 8) {
+              RefPill(label: "hub_id", ref: projection.hubId)
+              RefPill(label: "pairing_id", ref: projection.pairingId)
+              RefPill(label: "expires_at", ref: String(projection.expiresAt))
+              ForEach(projection.transportLabels, id: \.self) { label in
+                statusChip(label)
+              }
+              Text("Scan material stays local to this screen; display rows are redacted.")
+                .font(.system(size: 11))
+                .foregroundStyle(HubTheme.textSecondary)
+                .fixedSize(horizontal: false, vertical: true)
+            }
+          }
+        } else {
+          Text("No trusted QR manifest loaded.")
+            .font(.system(size: 12))
+            .foregroundStyle(HubTheme.textSecondary)
+            .frame(maxWidth: .infinity, minHeight: 160, alignment: .center)
+        }
+      }
+    }
+  }
+
+  private func importManifest(_ result: Result<[URL], Error>) {
+    do {
+      guard let url = try result.get().first else { return }
+      let scoped = url.startAccessingSecurityScopedResource()
+      defer {
+        if scoped { url.stopAccessingSecurityScopedResource() }
+      }
+      let data = try Data(contentsOf: url)
+      let payload = String(decoding: data, as: UTF8.self)
+      inputPayload = payload
+      viewModel.load(data: data)
+    } catch {
+      inputPayload = ""
+      viewModel.clear()
+    }
+  }
+
+  private func copyPayload() {
+    guard viewModel.canRenderQRCode else { return }
+    NSPasteboard.general.clearContents()
+    NSPasteboard.general.setString(viewModel.qrPayload, forType: .string)
+  }
+
+  private func statusChip(_ text: String) -> some View {
+    Text(text)
+      .font(.system(size: 10, weight: .semibold))
+      .foregroundStyle(HubTheme.textSecondary)
+      .padding(.horizontal, 8)
+      .padding(.vertical, 4)
+      .background(Capsule().fill(Color.black.opacity(0.06)))
+  }
+}
+
+private enum QRCodeRenderer {
+  static func image(for payload: String) -> NSImage? {
+    let filter = CIFilter.qrCodeGenerator()
+    filter.message = Data(payload.utf8)
+    filter.correctionLevel = "M"
+    guard let output = filter.outputImage else { return nil }
+    let image = output.transformed(by: CGAffineTransform(scaleX: 10, y: 10))
+    let rep = NSCIImageRep(ciImage: image)
+    let nsImage = NSImage(size: rep.size)
+    nsImage.addRepresentation(rep)
+    return nsImage
+  }
+}
+
+#Preview("Pairing Provisioning") {
+  PairingProvisioningScreen()
+    .frame(width: 860, height: 680)
+}

--- a/apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/PairingProvisioningViewModel.swift
+++ b/apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/PairingProvisioningViewModel.swift
@@ -1,0 +1,96 @@
+import Combine
+import Foundation
+import FridayRustClient
+
+public enum PairingProvisioningMode: String, Sendable, Equatable {
+  case empty
+  case ready
+  case invalid
+}
+
+public struct PairingProvisioningState: Sendable, Equatable, CustomStringConvertible,
+  CustomDebugStringConvertible
+{
+  public let mode: PairingProvisioningMode
+  public let reason: String
+  public let projection: FridayPairingManifestProjection?
+
+  public var description: String {
+    [
+      "mode=\(mode.rawValue)",
+      projection.map { "hub=\($0.hubId)" },
+      projection.map { "pairing=\($0.pairingId)" },
+      "reason=\(reason)",
+    ]
+    .compactMap { $0 }
+    .joined(separator: " ")
+  }
+
+  public var debugDescription: String { description }
+
+  public static let empty = PairingProvisioningState(
+    mode: .empty,
+    reason: "Paste or import a Hub pairing QR manifest.",
+    projection: nil)
+}
+
+@MainActor
+public final class PairingProvisioningViewModel: ObservableObject {
+  @Published public private(set) var state: PairingProvisioningState = .empty
+  @Published public private(set) var qrPayload: String = ""
+
+  public init() {}
+
+  public var canRenderQRCode: Bool {
+    state.mode == .ready && !qrPayload.isEmpty
+  }
+
+  public var redactedSummary: String {
+    state.description
+  }
+
+  public func load(qrJSON: String, nowMs: Int64 = Int64(Date().timeIntervalSince1970 * 1000)) {
+    let payload = qrJSON.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !payload.isEmpty else {
+      clear()
+      return
+    }
+
+    do {
+      let manifest = try JSONDecoder().decode(FridayPairingManifest.self, from: Data(payload.utf8))
+      try manifest.validate(nowMs: nowMs)
+      qrPayload = payload
+      state = PairingProvisioningState(
+        mode: .ready,
+        reason: "Short-lived pairing QR is ready to scan.",
+        projection: manifest.redactedProjection)
+    } catch {
+      qrPayload = ""
+      state = PairingProvisioningState(
+        mode: .invalid,
+        reason: Self.reason(for: error),
+        projection: nil)
+    }
+  }
+
+  public func load(data: Data, nowMs: Int64 = Int64(Date().timeIntervalSince1970 * 1000)) {
+    load(qrJSON: String(decoding: data, as: UTF8.self), nowMs: nowMs)
+  }
+
+  public func clear() {
+    qrPayload = ""
+    state = .empty
+  }
+
+  private static func reason(for error: Error) -> String {
+    if let e = error as? FridayPairingManifestError {
+      switch e {
+      case .expired:
+        return "Pairing QR has expired."
+      case .unsupportedKind, .badHubPublicKey, .missingWebSocketEndpoint:
+        return "Pairing QR cannot be trusted."
+      }
+    }
+    return "Pairing QR is invalid."
+  }
+}

--- a/apps/macos/FridayHubConsole/Tests/FridayHubConsoleCoreTests/PairingProvisioningViewModelTests.swift
+++ b/apps/macos/FridayHubConsole/Tests/FridayHubConsoleCoreTests/PairingProvisioningViewModelTests.swift
@@ -1,0 +1,64 @@
+import Testing
+@testable import FridayHubConsoleCore
+
+@MainActor
+@Test func pairingProvisioningAcceptsValidManifestWithoutDisplayingSecret() async throws {
+  let secret = "friday-pairing-secret-for-test" // pragma: allowlist secret
+  let payload = pairingManifestJSON(secret: secret, expiresAt: 1_900_000_000_000)
+  let vm = PairingProvisioningViewModel()
+
+  vm.load(qrJSON: payload, nowMs: 1_780_000_000_000)
+
+  #expect(vm.state.mode == .ready)
+  #expect(vm.state.projection?.hubId == "hub-test")
+  #expect(vm.qrPayload.contains(secret))
+  #expect(!vm.redactedSummary.contains(secret))
+  #expect(!vm.state.description.contains(secret))
+  #expect(vm.canRenderQRCode)
+}
+
+@MainActor
+@Test func pairingProvisioningRejectsExpiredManifestAndClearsPayload() async throws {
+  let secret = "friday-pairing-expired-secret" // pragma: allowlist secret
+  let payload = pairingManifestJSON(secret: secret, expiresAt: 1_700_000_000_000)
+  let vm = PairingProvisioningViewModel()
+
+  vm.load(qrJSON: payload, nowMs: 1_780_000_000_000)
+
+  #expect(vm.state.mode == .invalid)
+  #expect(vm.qrPayload.isEmpty)
+  #expect(!vm.redactedSummary.contains(secret))
+  #expect(!vm.canRenderQRCode)
+}
+
+@MainActor
+@Test func pairingProvisioningRejectsMalformedManifest() async throws {
+  let vm = PairingProvisioningViewModel()
+
+  vm.load(qrJSON: #"{"kind":"not-friday","pairing_secret":"do-not-display"}"#) // pragma: allowlist secret
+
+  #expect(vm.state.mode == .invalid)
+  #expect(vm.state.projection == nil)
+  #expect(vm.qrPayload.isEmpty)
+  #expect(!vm.redactedSummary.contains("do-not-display"))
+}
+
+private func pairingManifestJSON(secret: String, expiresAt: Int64) -> String {
+  """
+  {
+    "kind": "friday.pairing.qr.v1",
+    "aad": "friday:pairing:ws:j1:qr-pair-session:aad:v1",
+    "hub_public_key_hex": "\(String(repeating: "a", count: 64))",
+    "v": 1,
+    "hub_id": "hub-test",
+    "pairing_id": "pair-test",
+    "pairing_secret": "\(secret)",
+    "display_name": "Friday Test Hub",
+    "transport_hints": [
+      {"kind":"websocket","endpoint":"ws://127.0.0.1:48752","label":"loopback"}
+    ],
+    "expires_at": \(expiresAt),
+    "capabilities_hint": ["read", "write"]
+  }
+  """
+}


### PR DESCRIPTION
## Summary
- Add a macOS Pairing surface that decodes Friday pairing manifests, keeps raw QR payload local for QR rendering/copy, and only surfaces redacted manifest details.
- Add an iOS QR scanner entry point that scans pairing QR payloads into the existing pairing preflight path.
- Cover manifest parsing/projection with focused macOS tests and rebuild the iOS simulator shell.

## Truth Label
T3 app plumbing only: this does not start a pairing server, mint trust_grant/context_passport, flip live pairing, satisfy organic/GO, or claim END-BAR. Scan material stays local/redacted and pairing still requires the governed backend path.

## Verification
- swift test --package-path apps/macos/FridayHubConsole --filter PairingProvisioningViewModelTests
- swift build --package-path apps/macos/FridayHubConsole
- apps/friday-ios/build-sim.sh
- git diff --check
- npm run check:secret-patterns