### PR TITLE
Wire iOS run-control opt-in

### DIFF
--- a/apps/friday-ios/Sources/FridayMobileShell/FridayApp.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayApp.swift
@@ -36,7 +36,7 @@ import SwiftUI
 final class FridaySession: ObservableObject {
   /// DEFAULT-OFF run-control (the S6 pause/approve/resume). Flipping this ON in production is
   /// part of the slice-6 operator gate; OFF ⇒ the chat loop is read-only (a pause fails closed).
-  let runControlEnabled = false
+  let runControlEnabled: Bool
 
   let readClient: FridayRustReadClient
   let writeClient: FridayRustWriteClient
@@ -52,6 +52,10 @@ final class FridaySession: ObservableObject {
   ///   without a live Hub. DEFAULT `false` ⇒ the REAL `SealedWSReadClient` (honest-unavailable
   ///   while the servers are dark). A real build NEVER passes `preview: true`.
   init(preview: Bool = false) {
+    let args = ProcessInfo.processInfo.arguments
+    let env = ProcessInfo.processInfo.environment
+    self.runControlEnabled = preview ? false : Self.runControlRequested(args: args, env: env)
+
     // SINGLE-PEER-TRAP SAFETY: the DEFAULT read client mints NO X25519 keypair, opens NO socket,
     // and touches NO SecureStore — it is the no-key `HonestlyUnavailableReadClient`, which always
     // renders the honest dark-server state. This deliberately does NOT generate a fresh peer key:
@@ -158,19 +162,23 @@ final class FridaySession: ObservableObject {
   }
 
   static func useDeviceKeypair(args: [String], env: [String: String]) -> Bool {
-    args.contains("--live-device-keypair") || env["FRIDAY_MOBILE_LIVE_DEVICE_KEYPAIR"] == "1"
+    MobileRuntimeGates.useDeviceKeypair(args: args, env: env)
   }
 
   static func liveReadRequested(args: [String], env: [String: String]) -> Bool {
-    args.contains("--live-read") || env["FRIDAY_MOBILE_LIVE_READ"] == "1"
+    MobileRuntimeGates.liveReadRequested(args: args, env: env)
   }
 
   static func liveWriteRequested(args: [String], env: [String: String]) -> Bool {
-    args.contains("--live-write") || env["FRIDAY_MOBILE_LIVE_WRITE"] == "1"
+    MobileRuntimeGates.liveWriteRequested(args: args, env: env)
   }
 
   static func livePairingRequested(args: [String], env: [String: String]) -> Bool {
-    args.contains("--live-pairing") || env["FRIDAY_MOBILE_LIVE_PAIRING"] == "1"
+    MobileRuntimeGates.livePairingRequested(args: args, env: env)
+  }
+
+  static func runControlRequested(args: [String], env: [String: String]) -> Bool {
+    MobileRuntimeGates.runControlRequested(args: args, env: env)
   }
 
   static func defaultPairingClient(deviceKeypair: DeviceKeypair) -> FridayPairingClient? {

--- a/apps/friday-ios/Sources/FridayMobileShellCore/MobileRuntimeGates.swift
+++ b/apps/friday-ios/Sources/FridayMobileShellCore/MobileRuntimeGates.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+public enum MobileRuntimeGates {
+  public static func useDeviceKeypair(args: [String], env: [String: String]) -> Bool {
+    args.contains("--live-device-keypair") || env["FRIDAY_MOBILE_LIVE_DEVICE_KEYPAIR"] == "1"
+  }
+
+  public static func liveReadRequested(args: [String], env: [String: String]) -> Bool {
+    args.contains("--live-read") || env["FRIDAY_MOBILE_LIVE_READ"] == "1"
+  }
+
+  public static func liveWriteRequested(args: [String], env: [String: String]) -> Bool {
+    args.contains("--live-write") || env["FRIDAY_MOBILE_LIVE_WRITE"] == "1"
+  }
+
+  public static func livePairingRequested(args: [String], env: [String: String]) -> Bool {
+    args.contains("--live-pairing") || env["FRIDAY_MOBILE_LIVE_PAIRING"] == "1"
+  }
+
+  public static func runControlRequested(args: [String], env: [String: String]) -> Bool {
+    args.contains("--agent-run-control-via-rust")
+      || args.contains("--run-control")
+      || env["FRIDAY_MOBILE_AGENT_RUN_CONTROL_VIA_RUST"] == "1"
+      || env["FRIDAY_AGENT_RUN_CONTROL_VIA_RUST"] == "1"
+  }
+}

--- a/apps/friday-ios/Tests/FridayMobileShellCoreTests/MobileRuntimeGatesTests.swift
+++ b/apps/friday-ios/Tests/FridayMobileShellCoreTests/MobileRuntimeGatesTests.swift
@@ -1,0 +1,43 @@
+import Testing
+@testable import FridayMobileShellCore
+
+@Test
+func mobileRuntimeGatesDefaultOff() {
+  #expect(!MobileRuntimeGates.liveReadRequested(args: [], env: [:]))
+  #expect(!MobileRuntimeGates.liveWriteRequested(args: [], env: [:]))
+  #expect(!MobileRuntimeGates.livePairingRequested(args: [], env: [:]))
+  #expect(!MobileRuntimeGates.useDeviceKeypair(args: [], env: [:]))
+  #expect(!MobileRuntimeGates.runControlRequested(args: [], env: [:]))
+}
+
+@Test
+func mobileRuntimeGatesAcceptExplicitArgs() {
+  #expect(MobileRuntimeGates.liveReadRequested(args: ["--live-read"], env: [:]))
+  #expect(MobileRuntimeGates.liveWriteRequested(args: ["--live-write"], env: [:]))
+  #expect(MobileRuntimeGates.livePairingRequested(args: ["--live-pairing"], env: [:]))
+  #expect(MobileRuntimeGates.useDeviceKeypair(args: ["--live-device-keypair"], env: [:]))
+  #expect(MobileRuntimeGates.runControlRequested(args: ["--agent-run-control-via-rust"], env: [:]))
+  #expect(MobileRuntimeGates.runControlRequested(args: ["--run-control"], env: [:]))
+}
+
+@Test
+func mobileRuntimeGatesAcceptExplicitEnv() {
+  #expect(MobileRuntimeGates.liveReadRequested(args: [], env: ["FRIDAY_MOBILE_LIVE_READ": "1"]))
+  #expect(MobileRuntimeGates.liveWriteRequested(args: [], env: ["FRIDAY_MOBILE_LIVE_WRITE": "1"]))
+  #expect(MobileRuntimeGates.livePairingRequested(args: [], env: ["FRIDAY_MOBILE_LIVE_PAIRING": "1"]))
+  #expect(MobileRuntimeGates.useDeviceKeypair(args: [], env: ["FRIDAY_MOBILE_LIVE_DEVICE_KEYPAIR": "1"]))
+  #expect(MobileRuntimeGates.runControlRequested(
+    args: [],
+    env: ["FRIDAY_MOBILE_AGENT_RUN_CONTROL_VIA_RUST": "1"]))
+  #expect(MobileRuntimeGates.runControlRequested(args: [], env: ["FRIDAY_AGENT_RUN_CONTROL_VIA_RUST": "1"]))
+}
+
+@Test
+func mobileRuntimeGatesDoNotAcceptTruthyLookalikes() {
+  #expect(!MobileRuntimeGates.liveReadRequested(args: [], env: ["FRIDAY_MOBILE_LIVE_READ": "true"]))
+  #expect(!MobileRuntimeGates.liveWriteRequested(args: [], env: ["FRIDAY_MOBILE_LIVE_WRITE": "yes"]))
+  #expect(!MobileRuntimeGates.livePairingRequested(args: [], env: ["FRIDAY_MOBILE_LIVE_PAIRING": "TRUE"]))
+  #expect(!MobileRuntimeGates.runControlRequested(
+    args: [],
+    env: ["FRIDAY_MOBILE_AGENT_RUN_CONTROL_VIA_RUST": "true"]))
+}


### PR DESCRIPTION
## Summary\n- moves iOS live runtime launch gates into a small testable core helper\n- adds explicit default-off run-control opt-in via --agent-run-control-via-rust / --run-control or FRIDAY_MOBILE_AGENT_RUN_CONTROL_VIA_RUST=1 / FRIDAY_AGENT_RUN_CONTROL_VIA_RUST=1\n- threads the opt-in into FridaySession so mobile stop/resume controls and the write client can reflect the operator-enabled run-control plane\n\n## Truth / Non-goals\n- default remains OFF\n- no signing key is read or minted on mobile\n- does not flip production run-control or claim an organic/GO-LIVE loop\n\n## Verification\n- swift test --package-path apps/friday-ios --filter MobileRuntimeGatesTests\n- apps/friday-ios/build-sim.sh\n- detect-secrets-hook --baseline .secrets.baseline over changed files\n- visual screenshot checked: apps/friday-ios/.build-sim/friday-ios-sim.png