### PR TITLE
Surface provider auth and token ledger entry points

### DIFF
--- a/apps/friday-ios/Sources/FridayMobileShell/FridayProjectionScreens.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayProjectionScreens.swift
@@ -193,6 +193,23 @@ struct FridayProjectionScreen: View {
           }
           .disabled(viewModel.detailState.isLoading)
         }
+        if let runId = projection.runOutcomeLearningCandidates.first?.runId, !runId.isEmpty {
+          HStack(spacing: 8) {
+            Button {
+              Task { await viewModel.loadDetail(.runReadback(runId: runId)) }
+            } label: {
+              Label("Token Ledger", systemImage: "chart.bar.doc.horizontal")
+            }
+            .disabled(viewModel.detailState.isLoading)
+
+            Button {
+              Task { await viewModel.loadDetail(.activityNeedsMe(runId: runId)) }
+            } label: {
+              Label("Needs Me", systemImage: "bell.badge")
+            }
+            .disabled(viewModel.detailState.isLoading)
+          }
+        }
         if let agentSessionId = projection.agentSessionId {
           HStack(spacing: 8) {
             Button {
@@ -217,25 +234,12 @@ struct FridayProjectionScreen: View {
         if let runId = projection.runOutcomeLearningCandidates.first?.runId, !runId.isEmpty {
           HStack(spacing: 8) {
             Button {
-              Task { await viewModel.loadDetail(.runReadback(runId: runId)) }
-            } label: {
-              Label("Run", systemImage: "doc.text.magnifyingglass")
-            }
-            .disabled(viewModel.detailState.isLoading)
-
-            Button {
               Task { await viewModel.loadDetail(.runFileView(runId: runId)) }
             } label: {
               Label("Files", systemImage: "folder")
             }
             .disabled(viewModel.detailState.isLoading)
           }
-          Button {
-            Task { await viewModel.loadDetail(.activityNeedsMe(runId: runId)) }
-          } label: {
-            Label("Needs Me", systemImage: "bell.badge")
-          }
-          .disabled(viewModel.detailState.isLoading)
         }
       }
     }
@@ -514,6 +518,16 @@ struct FridayProjectionScreen: View {
           title: "Device pairing",
           value: "sim loopback now; physical device later",
           healthy: false)
+        readinessRow(
+          title: "Provider auth",
+          value: "read-only doctor; never stores provider secrets",
+          healthy: viewModel.isOnline)
+        Button {
+          Task { await viewModel.loadDetail(.providersDoctor(probe: nil)) }
+        } label: {
+          Label("Check Provider Auth", systemImage: "stethoscope")
+        }
+        .disabled(viewModel.detailState.isLoading)
         RefPill(label: "mission_id", ref: projection.missionId)
       }
     }
@@ -527,6 +541,24 @@ struct FridayProjectionScreen: View {
         RefPill(label: "protocol", ref: "v\(fridayCurrentSchemaVersion)")
         RefPill(label: "feed", ref: projection.runtimeFeedStatus)
         RefPill(label: "generated", ref: generatedText(projection.generatedAtMs))
+        Button {
+          Task { await viewModel.loadDetail(.providersDoctor(probe: nil)) }
+        } label: {
+          Label("Provider Auth", systemImage: "person.badge.key")
+        }
+        .disabled(viewModel.detailState.isLoading)
+        if let runId = projection.runOutcomeLearningCandidates.first?.runId, !runId.isEmpty {
+          Button {
+            Task { await viewModel.loadDetail(.runReadback(runId: runId)) }
+          } label: {
+            Label("Token Ledger", systemImage: "chart.bar.doc.horizontal")
+          }
+          .disabled(viewModel.detailState.isLoading)
+        } else {
+          Text("Token ledger appears after a real run ref is present.")
+            .font(.caption)
+            .foregroundStyle(MobileTheme.textSecondary)
+        }
       }
     }
   }

--- a/apps/macos/FridayHubConsole/Sources/FridayHubConsole/DesktopProjectionScreens.swift
+++ b/apps/macos/FridayHubConsole/Sources/FridayHubConsole/DesktopProjectionScreens.swift
@@ -268,6 +268,24 @@ struct DesktopProjectionScreen: View {
     VStack(alignment: .leading, spacing: 16) {
       GlassPanel {
         VStack(alignment: .leading, spacing: HubTheme.rowSpacing) {
+          HStack {
+            cardTitle("Provider Auth")
+            Spacer()
+            Button {
+              Task { await viewModel.loadDetail(.providersDoctor(probe: nil)) }
+            } label: {
+              Label("Check", systemImage: "stethoscope")
+            }
+            .buttonStyle(.bordered)
+            .disabled(viewModel.detailState.isLoading)
+          }
+          Text("Runs the existing read-only provider doctor. It reports installed/authenticated providers, suggested routes, and failover blockers without storing keys or changing routing.")
+            .font(.system(size: 11))
+            .foregroundStyle(HubTheme.textSecondary)
+        }
+      }
+      GlassPanel {
+        VStack(alignment: .leading, spacing: HubTheme.rowSpacing) {
           cardTitle("Provider State")
           Text("Dispatch is displayed as projected status only; this surface exposes no execute action.")
             .font(.system(size: 11))
@@ -392,7 +410,30 @@ struct DesktopProjectionScreen: View {
   }
 
   private func evidenceStatus(_ snapshot: WorkbenchSnapshot) -> some View {
-    refsCard(title: "Evidence Refs", refs: evidenceRefs(snapshot))
+    VStack(alignment: .leading, spacing: 16) {
+      if let runId = snapshot.runOutcomeLearningCandidates.first?.runId, !runId.isEmpty {
+        GlassPanel {
+          VStack(alignment: .leading, spacing: HubTheme.rowSpacing) {
+            HStack {
+              cardTitle("Token Ledger")
+              Spacer()
+              Button {
+                Task { await viewModel.loadDetail(.runReadback(runId: runId)) }
+              } label: {
+                Label("Read", systemImage: "chart.bar.doc.horizontal")
+              }
+              .buttonStyle(.bordered)
+              .disabled(viewModel.detailState.isLoading)
+            }
+            Text("Reads the owner-gated run readback. Token totals come from the existing token_ledger projection; this screen does not estimate or mutate spend.")
+              .font(.system(size: 11))
+              .foregroundStyle(HubTheme.textSecondary)
+            RefPill(label: "run_id", ref: runId)
+          }
+        }
+      }
+      refsCard(title: "Evidence Refs", refs: evidenceRefs(snapshot))
+    }
   }
 
   private func refsCard(title: String, refs: [String]) -> some View {


### PR DESCRIPTION
## Summary
- add first-class iOS Settings/Onboarding entry points for provider auth doctor and token-ledger readback
- add desktop Provider Admin / Evidence entry points for read-only provider auth and token ledger readback
- keep all controls read-only: no provider routing changes, no key storage, no spend estimates

## Verification
- swift test --package-path apps/friday-ios --filter HomeViewModelTests
- swift test --package-path apps/macos/FridayHubConsole --filter OperationsOverviewViewModelTests
- apps/friday-ios/build-sim.sh
- swift build --package-path apps/macos/FridayHubConsole
- detect-secrets-hook --baseline .secrets.baseline apps/friday-ios/Sources/FridayMobileShell/FridayProjectionScreens.swift apps/macos/FridayHubConsole/Sources/FridayHubConsole/DesktopProjectionScreens.swift