### PR TITLE
Add voice IO controls to Friday chat

### DIFF
--- a/apps/friday-ios/Info.plist
+++ b/apps/friday-ios/Info.plist
@@ -20,6 +20,10 @@
     <string>1</string>
     <key>NSCameraUsageDescription</key>
     <string>Scan a Friday Hub pairing QR code.</string>
+    <key>NSMicrophoneUsageDescription</key>
+    <string>Capture your spoken Friday chat prompt.</string>
+    <key>NSSpeechRecognitionUsageDescription</key>
+    <string>Transcribe your spoken Friday chat prompt into the composer.</string>
     <key>LSRequiresIPhoneOS</key>
     <true/>
     <key>MinimumOSVersion</key>

--- a/apps/friday-ios/Sources/FridayMobileShell/FridayChatScreen.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayChatScreen.swift
@@ -1,4 +1,6 @@
 import FridayMobileShellCore
+import AVFoundation
+@preconcurrency import Speech
 import SwiftUI
 
 /// The full-screen, pet-centered Friday Chat read-WRITE surface (locked: the Friday Chat entry
@@ -15,6 +17,7 @@ import SwiftUI
 /// (the write receipt is refs-only; the answer body appears only through the owner-gated readback).
 struct FridayChatScreen: View {
   @StateObject private var viewModel: FridayChatViewModel
+  @StateObject private var voice = MobileVoiceController()
   /// Whether the S6 pause/approve/resume is enabled (the run-control flag). OFF ⇒ read-only.
   private let runControlEnabled: Bool
 
@@ -151,31 +154,55 @@ struct FridayChatScreen: View {
   // MARK: - Composer (Compose → Send)
 
   private var composer: some View {
-    HStack(spacing: 10) {
-      TextField("Ask Friday…", text: $draft, axis: .vertical)
-        .textFieldStyle(.plain)
-        .lineLimit(1...4)
-        .padding(.horizontal, 14)
-        .padding(.vertical, 10)
-        .background(
-          RoundedRectangle(cornerRadius: 18, style: .continuous)
-            .fill(Color.black.opacity(0.05)))
+    VStack(alignment: .leading, spacing: 6) {
+      HStack(spacing: 10) {
+        Button {
+          voice.toggleRecording { transcript in
+            Task { @MainActor in
+              draft = transcript
+            }
+          }
+        } label: {
+          Image(systemName: voice.isRecording ? "stop.circle.fill" : "mic.circle.fill")
+            .font(.system(size: 28))
+            .foregroundStyle(voice.isRecording ? MobileTheme.coral : MobileTheme.cyan)
+        }
         .disabled(viewModel.phase.isBusy || viewModel.phase.isAwaitingApproval)
-        .accessibilityLabel("Message Friday")
-        .accessibilityIdentifier("friday.chat.composer")
+        .accessibilityLabel(voice.isRecording ? "Stop voice input" : "Start voice input")
+        .accessibilityIdentifier("friday.chat.voice-input")
 
-      Button {
-        let task = draft
-        draft = ""
-        Task { await viewModel.send(task) }
-      } label: {
-        Image(systemName: "arrow.up.circle.fill")
-          .font(.system(size: 30))
-          .foregroundStyle(canSend ? MobileTheme.cyan : MobileTheme.cyan.opacity(0.25))
+        TextField("Ask Friday…", text: $draft, axis: .vertical)
+          .textFieldStyle(.plain)
+          .lineLimit(1...4)
+          .padding(.horizontal, 14)
+          .padding(.vertical, 10)
+          .background(
+            RoundedRectangle(cornerRadius: 18, style: .continuous)
+              .fill(Color.black.opacity(0.05)))
+          .disabled(viewModel.phase.isBusy || viewModel.phase.isAwaitingApproval)
+          .accessibilityLabel("Message Friday")
+          .accessibilityIdentifier("friday.chat.composer")
+
+        Button {
+          voice.stopRecording()
+          let task = draft
+          draft = ""
+          Task { await viewModel.send(task) }
+        } label: {
+          Image(systemName: "arrow.up.circle.fill")
+            .font(.system(size: 30))
+            .foregroundStyle(canSend ? MobileTheme.cyan : MobileTheme.cyan.opacity(0.25))
+        }
+        .disabled(!canSend)
+        .accessibilityLabel("Send message to Friday")
+        .accessibilityIdentifier("friday.chat.send")
       }
-      .disabled(!canSend)
-      .accessibilityLabel("Send message to Friday")
-      .accessibilityIdentifier("friday.chat.send")
+      if let voiceStatus = voice.status {
+        Text(voiceStatus)
+          .font(.caption2)
+          .foregroundStyle(voice.isRecording ? MobileTheme.cyan : MobileTheme.textSecondary)
+          .fixedSize(horizontal: false, vertical: true)
+      }
     }
     .padding(.horizontal, 16)
     .padding(.vertical, 12)
@@ -200,6 +227,25 @@ struct FridayChatScreen: View {
         }
         Text("Friday answered").font(.headline).foregroundStyle(MobileTheme.textPrimary)
         if let answer = readableAnswer(r.answerBody) {
+          HStack {
+            Button {
+              voice.speak(answer)
+            } label: {
+              Label("Speak", systemImage: "speaker.wave.2.fill")
+            }
+            .buttonStyle(.bordered)
+            .tint(MobileTheme.cyan)
+            .accessibilityLabel("Speak Friday answer")
+            .accessibilityIdentifier("friday.chat.voice-output")
+
+            Button {
+              voice.stopSpeaking()
+            } label: {
+              Image(systemName: "speaker.slash.fill")
+            }
+            .buttonStyle(.bordered)
+            .accessibilityLabel("Stop speaking Friday answer")
+          }
           Text(answer)
             .font(.body)
             .foregroundStyle(MobileTheme.textPrimary)
@@ -327,3 +373,123 @@ struct FridayChatScreen: View {
   NavigationStack { FridayChatScreen(session: FridaySession()) }
 }
 #endif
+
+@MainActor
+private final class MobileVoiceController: ObservableObject {
+  @Published var isRecording = false
+  @Published var status: String?
+
+  private let recognizer = SFSpeechRecognizer()
+  private let audioEngine = AVAudioEngine()
+  private let synthesizer = AVSpeechSynthesizer()
+  private var request: SFSpeechAudioBufferRecognitionRequest?
+  private var task: SFSpeechRecognitionTask?
+
+  func toggleRecording(onTranscript: @escaping @Sendable (String) -> Void) {
+    if isRecording {
+      stopRecording()
+    } else {
+      startRecording(onTranscript: onTranscript)
+    }
+  }
+
+  func startRecording(onTranscript: @escaping @Sendable (String) -> Void) {
+    guard let recognizer, recognizer.isAvailable else {
+      status = "Voice input is unavailable on this device."
+      return
+    }
+    SFSpeechRecognizer.requestAuthorization { [weak self] speechStatus in
+      Self.requestMicrophoneAccess { micAllowed in
+        Task { @MainActor in
+          guard let self else { return }
+          guard speechStatus == .authorized, micAllowed else {
+            self.status = "Voice input needs microphone and speech recognition permission."
+            return
+          }
+          self.beginRecognition(onTranscript: onTranscript)
+        }
+      }
+    }
+  }
+
+  func stopRecording() {
+    guard isRecording || audioEngine.isRunning else { return }
+    audioEngine.inputNode.removeTap(onBus: 0)
+    audioEngine.stop()
+    request?.endAudio()
+    task?.cancel()
+    request = nil
+    task = nil
+    isRecording = false
+    status = "Voice input stopped."
+  }
+
+  func speak(_ text: String) {
+    stopSpeaking()
+    let utterance = AVSpeechUtterance(string: text)
+    utterance.rate = AVSpeechUtteranceDefaultSpeechRate
+    synthesizer.speak(utterance)
+    status = "Speaking Friday answer."
+  }
+
+  func stopSpeaking() {
+    if synthesizer.isSpeaking {
+      synthesizer.stopSpeaking(at: .immediate)
+      status = "Voice output stopped."
+    }
+  }
+
+  private func beginRecognition(
+    onTranscript: @escaping @Sendable (String) -> Void
+  ) {
+    guard let recognizer else {
+      status = "Voice input is unavailable on this device."
+      return
+    }
+    stopRecording()
+    let request = SFSpeechAudioBufferRecognitionRequest()
+    request.shouldReportPartialResults = true
+    self.request = request
+
+    let input = audioEngine.inputNode
+    let format = input.outputFormat(forBus: 0)
+    input.installTap(onBus: 0, bufferSize: 1024, format: format) { buffer, _ in
+      request.append(buffer)
+    }
+
+    do {
+      try AVAudioSession.sharedInstance().setCategory(.record, mode: .measurement, options: .duckOthers)
+      try AVAudioSession.sharedInstance().setActive(true, options: .notifyOthersOnDeactivation)
+      audioEngine.prepare()
+      try audioEngine.start()
+      isRecording = true
+      status = "Listening..."
+      task = recognizer.recognitionTask(with: request) { [weak self] result, error in
+        Task { @MainActor in
+          guard let self else { return }
+          if let result {
+            onTranscript(result.bestTranscription.formattedString)
+          }
+          if let error {
+            self.status = "Voice input stopped: \(error.localizedDescription)"
+            self.stopRecording()
+          } else if result?.isFinal == true {
+            self.stopRecording()
+          }
+        }
+      }
+    } catch {
+      input.removeTap(onBus: 0)
+      self.request = nil
+      status = "Voice input failed: \(error.localizedDescription)"
+    }
+  }
+
+  private static func requestMicrophoneAccess(_ completion: @escaping @Sendable (Bool) -> Void) {
+    if #available(iOS 17.0, *) {
+      AVAudioApplication.requestRecordPermission(completionHandler: completion)
+    } else {
+      AVAudioSession.sharedInstance().requestRecordPermission(completion)
+    }
+  }
+}

--- a/apps/macos/FridayHubConsole/Info.plist
+++ b/apps/macos/FridayHubConsole/Info.plist
@@ -24,6 +24,10 @@
   <string>14.0</string>
   <key>NSHighResolutionCapable</key>
   <true/>
+  <key>NSMicrophoneUsageDescription</key>
+  <string>Capture your spoken Friday chat prompt.</string>
+  <key>NSSpeechRecognitionUsageDescription</key>
+  <string>Transcribe your spoken Friday chat prompt into the composer.</string>
   <key>NSSupportsAutomaticGraphicsSwitching</key>
   <true/>
 </dict>

--- a/apps/macos/FridayHubConsole/Sources/FridayHubConsole/DesktopChatScreen.swift
+++ b/apps/macos/FridayHubConsole/Sources/FridayHubConsole/DesktopChatScreen.swift
@@ -1,8 +1,11 @@
 import FridayHubConsoleCore
+import AVFoundation
+@preconcurrency import Speech
 import SwiftUI
 
 struct DesktopChatScreen: View {
   @ObservedObject var viewModel: OperationsOverviewViewModel
+  @StateObject private var voice = DesktopVoiceController()
   @State private var draft = ""
   @State private var history: [DesktopChatMessage]
 
@@ -198,7 +201,26 @@ struct DesktopChatScreen: View {
       GlassPanel {
         VStack(alignment: .leading, spacing: HubTheme.rowSpacing) {
           StatusChip(text: "confirmed", bg: HubTheme.chipDoneBG, fg: HubTheme.chipDoneFG)
-          Text(answerBodyText(answerBody) ?? summary)
+          let spokenText = answerBodyText(answerBody) ?? summary
+          HStack(spacing: 8) {
+            Button {
+              voice.speak(spokenText)
+            } label: {
+              Label("Speak", systemImage: "speaker.wave.2.fill")
+            }
+            .buttonStyle(.bordered)
+            .accessibilityLabel("Speak Friday desktop answer")
+            .accessibilityIdentifier("friday.desktop.chat.voice-output")
+
+            Button {
+              voice.stopSpeaking()
+            } label: {
+              Image(systemName: "speaker.slash.fill")
+            }
+            .buttonStyle(.bordered)
+            .accessibilityLabel("Stop speaking Friday desktop answer")
+          }
+          Text(spokenText)
             .font(.system(size: 13))
             .foregroundStyle(HubTheme.textPrimary)
             .textSelection(.enabled)
@@ -395,31 +417,55 @@ struct DesktopChatScreen: View {
   }
 
   private var composer: some View {
-    HStack(spacing: 10) {
-      TextField("Ask Friday...", text: $draft, axis: .vertical)
-        .textFieldStyle(.plain)
-        .font(.system(size: 13))
-        .lineLimit(1...4)
-        .padding(.horizontal, 12)
-        .padding(.vertical, 9)
-        .background(
-          RoundedRectangle(cornerRadius: 8, style: .continuous)
-            .fill(Color.black.opacity(0.05)))
+    VStack(alignment: .leading, spacing: 6) {
+      HStack(spacing: 10) {
+        Button {
+          voice.toggleRecording { transcript in
+            Task { @MainActor in
+              draft = transcript
+            }
+          }
+        } label: {
+          Image(systemName: voice.isRecording ? "stop.circle.fill" : "mic.circle.fill")
+            .font(.system(size: 26))
+            .foregroundStyle(voice.isRecording ? HubTheme.coral : HubTheme.cyan)
+        }
+        .buttonStyle(.plain)
         .disabled(viewModel.intakeState.isSent)
-        .accessibilityLabel("Message Friday on desktop")
-        .accessibilityIdentifier("friday.desktop.chat.composer")
+        .accessibilityLabel(voice.isRecording ? "Stop desktop voice input" : "Start desktop voice input")
+        .accessibilityIdentifier("friday.desktop.chat.voice-input")
 
-      Button {
-        sendDraft()
-      } label: {
-        Image(systemName: "arrow.up.circle.fill")
-          .font(.system(size: 28))
-          .foregroundStyle(canSend ? HubTheme.cyan : HubTheme.cyan.opacity(0.25))
+        TextField("Ask Friday...", text: $draft, axis: .vertical)
+          .textFieldStyle(.plain)
+          .font(.system(size: 13))
+          .lineLimit(1...4)
+          .padding(.horizontal, 12)
+          .padding(.vertical, 9)
+          .background(
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+              .fill(Color.black.opacity(0.05)))
+          .disabled(viewModel.intakeState.isSent)
+          .accessibilityLabel("Message Friday on desktop")
+          .accessibilityIdentifier("friday.desktop.chat.composer")
+
+        Button {
+          voice.stopRecording()
+          sendDraft()
+        } label: {
+          Image(systemName: "arrow.up.circle.fill")
+            .font(.system(size: 28))
+            .foregroundStyle(canSend ? HubTheme.cyan : HubTheme.cyan.opacity(0.25))
+        }
+        .buttonStyle(.plain)
+        .disabled(!canSend)
+        .accessibilityLabel("Send desktop chat message")
+        .accessibilityIdentifier("friday.desktop.chat.send")
       }
-      .buttonStyle(.plain)
-      .disabled(!canSend)
-      .accessibilityLabel("Send desktop chat message")
-      .accessibilityIdentifier("friday.desktop.chat.send")
+      if let status = voice.status {
+        Text(status)
+          .font(.system(size: 10))
+          .foregroundStyle(voice.isRecording ? HubTheme.cyan : HubTheme.textSecondary)
+      }
     }
     .padding(.horizontal, 20)
     .padding(.vertical, 12)
@@ -596,4 +642,114 @@ private func answerBodyText(_ answerBody: String?) -> String? {
   let vm = OperationsOverviewViewModel(client: MockReadClient(behavior: .loaded))
   DesktopChatScreen(viewModel: vm)
     .frame(width: 760, height: 720)
+}
+
+@MainActor
+private final class DesktopVoiceController: ObservableObject {
+  @Published var isRecording = false
+  @Published var status: String?
+
+  private let recognizer = SFSpeechRecognizer()
+  private let audioEngine = AVAudioEngine()
+  private let synthesizer = AVSpeechSynthesizer()
+  private var request: SFSpeechAudioBufferRecognitionRequest?
+  private var task: SFSpeechRecognitionTask?
+
+  func toggleRecording(onTranscript: @escaping @Sendable (String) -> Void) {
+    if isRecording {
+      stopRecording()
+    } else {
+      startRecording(onTranscript: onTranscript)
+    }
+  }
+
+  func startRecording(onTranscript: @escaping @Sendable (String) -> Void) {
+    guard let recognizer, recognizer.isAvailable else {
+      status = "Voice input is unavailable on this Mac."
+      return
+    }
+    SFSpeechRecognizer.requestAuthorization { [weak self] speechStatus in
+      AVCaptureDevice.requestAccess(for: .audio) { micAllowed in
+        Task { @MainActor in
+          guard let self else { return }
+          guard speechStatus == .authorized, micAllowed else {
+            self.status = "Voice input needs microphone and speech recognition permission."
+            return
+          }
+          self.beginRecognition(onTranscript: onTranscript)
+        }
+      }
+    }
+  }
+
+  func stopRecording() {
+    guard isRecording || audioEngine.isRunning else { return }
+    audioEngine.inputNode.removeTap(onBus: 0)
+    audioEngine.stop()
+    request?.endAudio()
+    task?.cancel()
+    request = nil
+    task = nil
+    isRecording = false
+    status = "Voice input stopped."
+  }
+
+  func speak(_ text: String) {
+    stopSpeaking()
+    let utterance = AVSpeechUtterance(string: text)
+    utterance.rate = AVSpeechUtteranceDefaultSpeechRate
+    synthesizer.speak(utterance)
+    status = "Speaking Friday answer."
+  }
+
+  func stopSpeaking() {
+    if synthesizer.isSpeaking {
+      synthesizer.stopSpeaking(at: .immediate)
+      status = "Voice output stopped."
+    }
+  }
+
+  private func beginRecognition(
+    onTranscript: @escaping @Sendable (String) -> Void
+  ) {
+    guard let recognizer else {
+      status = "Voice input is unavailable on this Mac."
+      return
+    }
+    stopRecording()
+    let request = SFSpeechAudioBufferRecognitionRequest()
+    request.shouldReportPartialResults = true
+    self.request = request
+
+    let input = audioEngine.inputNode
+    let format = input.outputFormat(forBus: 0)
+    input.installTap(onBus: 0, bufferSize: 1024, format: format) { buffer, _ in
+      request.append(buffer)
+    }
+
+    do {
+      audioEngine.prepare()
+      try audioEngine.start()
+      isRecording = true
+      status = "Listening..."
+      task = recognizer.recognitionTask(with: request) { [weak self] result, error in
+        Task { @MainActor in
+          guard let self else { return }
+          if let result {
+            onTranscript(result.bestTranscription.formattedString)
+          }
+          if let error {
+            self.status = "Voice input stopped: \(error.localizedDescription)"
+            self.stopRecording()
+          } else if result?.isFinal == true {
+            self.stopRecording()
+          }
+        }
+      }
+    } catch {
+      input.removeTap(onBus: 0)
+      self.request = nil
+      status = "Voice input failed: \(error.localizedDescription)"
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- add iOS speech-to-text composer input and answer speech output to the existing Friday Chat loop
- add macOS speech-to-text composer input and answer speech output to the desktop mission-backed chat
- add iOS and macOS app permission strings for microphone and speech recognition

## Truth labels
- Voice input only fills the existing composer; sending still uses Friday mission/chat write paths.
- Voice output only speaks owner-visible answer text already surfaced by readback.
- No approval/signature path is changed; no key is read or minted.

## Verification
- apps/friday-ios/build-sim.sh
- swift build --package-path apps/macos/FridayHubConsole
- scripts/ops/build-friday-hub-console-app.sh /Users/jarvis/.friday-worktrees/voice-io-chat-20260622
- scripts/ops/verify-friday-hub-console-app.sh /Users/jarvis/.friday-worktrees/voice-io-chat-20260622
- swift test --package-path apps/friday-ios --filter FridayChatViewModelTests
- swift test --package-path apps/macos/FridayHubConsole --filter OperationsOverviewViewModelTests
- detect-secrets-hook --baseline .secrets.baseline apps/friday-ios/Sources/FridayMobileShell/FridayChatScreen.swift apps/friday-ios/Info.plist apps/macos/FridayHubConsole/Sources/FridayHubConsole/DesktopChatScreen.swift apps/macos/FridayHubConsole/Info.plist