### PR TITLE
Wire LAN pairing session launcher

### DIFF
--- a/apps/friday-ios/Sources/FridayMobileShellCore/RealPairingClientFactory.swift
+++ b/apps/friday-ios/Sources/FridayMobileShellCore/RealPairingClientFactory.swift
@@ -3,15 +3,15 @@ import FridayRustClient
 
 public enum PairingServerConfigError: Error, Sendable, Equatable, CustomStringConvertible {
   case badEndpoint(String)
-  case nonLoopbackHost(String)
+  case disallowedHost(String)
   case missingPort(String)
 
   public var description: String {
     switch self {
     case let .badEndpoint(endpoint):
       return "bad pairing endpoint \(endpoint)"
-    case let .nonLoopbackHost(host):
-      return "pairing endpoint must be loopback, got \(host)"
+    case let .disallowedHost(host):
+      return "pairing endpoint must be loopback or private LAN, got \(host)"
     case let .missingPort(endpoint):
       return "pairing endpoint missing port \(endpoint)"
     }
@@ -44,13 +44,25 @@ public struct PairingServerConfig: Sendable, Equatable {
       throw PairingServerConfigError.badEndpoint(endpoint)
     }
     let host = url.host ?? ""
-    guard ["127.0.0.1", "localhost", "::1"].contains(host) else {
-      throw PairingServerConfigError.nonLoopbackHost(host)
+    guard Self.isAllowedPairingHost(host) else {
+      throw PairingServerConfigError.disallowedHost(host)
     }
     guard let port = url.port, let p = UInt16(exactly: port) else {
       throw PairingServerConfigError.missingPort(endpoint)
     }
     self.init(host: host == "localhost" ? "127.0.0.1" : host, port: p)
+  }
+
+  static func isAllowedPairingHost(_ host: String) -> Bool {
+    let h = host.lowercased()
+    if ["127.0.0.1", "localhost", "::1"].contains(h) { return true }
+    let parts = h.split(separator: ".").compactMap { UInt8(String($0)) }
+    guard parts.count == 4 else { return false }
+    if parts[0] == 10 { return true }
+    if parts[0] == 172 && (UInt8(16)...UInt8(31)).contains(parts[1]) { return true }
+    if parts[0] == 192 && parts[1] == 168 { return true }
+    if parts[0] == 169 && parts[1] == 254 { return true }
+    return false
   }
 }
 

--- a/apps/friday-ios/Tests/FridayMobileShellCoreTests/PairingPreflightTests.swift
+++ b/apps/friday-ios/Tests/FridayMobileShellCoreTests/PairingPreflightTests.swift
@@ -200,8 +200,48 @@ func homeViewModelPairScannedQrFailsClosedWhenPairingChannelNotConfigured() asyn
   #expect(vm.pairingAttempt.reason == "Pairing channel is not configured for this launch.")
 }
 
+@Test
+func pairingServerConfigAllowsLoopbackAndPrivateLanOnly() throws {
+  #expect(try PairingServerConfig(manifest: manifest(endpoint: "ws://127.0.0.1:49152")).host == "127.0.0.1")
+  #expect(try PairingServerConfig(manifest: manifest(endpoint: "ws://localhost:49152")).host == "127.0.0.1")
+  #expect(try PairingServerConfig(manifest: manifest(endpoint: "ws://10.0.0.8:49152")).host == "10.0.0.8")
+  #expect(try PairingServerConfig(manifest: manifest(endpoint: "ws://172.16.2.8:49152")).host == "172.16.2.8")
+  #expect(try PairingServerConfig(manifest: manifest(endpoint: "ws://172.31.2.8:49152")).host == "172.31.2.8")
+  #expect(try PairingServerConfig(manifest: manifest(endpoint: "ws://192.168.1.8:49152")).host == "192.168.1.8")
+  #expect(try PairingServerConfig(manifest: manifest(endpoint: "ws://169.254.1.8:49152")).host == "169.254.1.8")
+
+  #expect(throws: PairingServerConfigError.self) {
+    try PairingServerConfig(manifest: manifest(endpoint: "ws://8.8.8.8:49152"))
+  }
+  #expect(throws: PairingServerConfigError.self) {
+    try PairingServerConfig(manifest: manifest(endpoint: "ws://172.32.2.8:49152"))
+  }
+  #expect(throws: PairingServerConfigError.self) {
+    try PairingServerConfig(manifest: manifest(endpoint: "ws://friday.example.com:49152"))
+  }
+}
+
 private func pairingManifest(
   pairingSecret: String = "qr-secret-1234567890", // pragma: allowlist secret
+  expiresAt: Int64
+) throws -> String {
+  try manifestJSON(endpoint: "ws://127.0.0.1:49152", pairingSecret: pairingSecret, expiresAt: expiresAt)
+}
+
+private func manifest(
+  endpoint: String,
+  pairingSecret: String = "qr-secret-1234567890", // pragma: allowlist secret
+  expiresAt: Int64 = 1_900_000_000_000
+) throws -> FridayPairingManifest {
+  try JSONDecoder().decode(FridayPairingManifest.self, from: Data(manifestJSON(
+    endpoint: endpoint,
+    pairingSecret: pairingSecret,
+    expiresAt: expiresAt).utf8))
+}
+
+private func manifestJSON(
+  endpoint: String,
+  pairingSecret: String,
   expiresAt: Int64
 ) throws -> String {
   let hub = try FridayCrypto.DeviceKeypair(secretBytes: try Hex.decode(TestKeys.serverSecret))
@@ -216,7 +256,7 @@ private func pairingManifest(
       "pairing_secret": "\(pairingSecret)",
       "display_name": "Friday Local Hub",
       "transport_hints": [
-        {"kind": "websocket", "endpoint": "ws://127.0.0.1:49152", "label": "Local pairing"}
+        {"kind": "websocket", "endpoint": "\(endpoint)", "label": "Local pairing"}
       ],
       "expires_at": \(expiresAt),
       "capabilities_hint": ["pairing", "read_seam_enroll"]

--- a/scripts/ops/friday-start-pairing-session.sh
+++ b/scripts/ops/friday-start-pairing-session.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+#
+# Start a short-lived Friday QR pairing session.
+#
+# Truth boundary:
+#   This launches the DARK hub_pairing_server explicitly. It can write trusted_device rows and
+#   append the paired device to the read-seam allowlist only after a valid PairAck. It does not mint
+#   trust_grant/context_passport rows, does not read operator signing keys, and does not flip flags.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+DB_PATH="${FRIDAY_PAIRING_DB_PATH:-${HOME}/Library/Application Support/Friday/state/rust-hub.sqlite}"
+HOST="${FRIDAY_PAIRING_HOST:-127.0.0.1}"
+PORT="${FRIDAY_PAIRING_PORT:-0}"
+OWNER="${FRIDAY_PAIRING_OWNER:-jarvis}"
+HUB_ID="${FRIDAY_PAIRING_HUB_ID:-friday-hub-$(hostname -s 2>/dev/null || echo local)}"
+PAIRING_ID="${FRIDAY_PAIRING_ID:-pair-$(date -u +%Y%m%dT%H%M%SZ)-$RANDOM}"
+DISPLAY_NAME="${FRIDAY_PAIRING_DISPLAY_NAME:-Friday Hub on $(hostname -s 2>/dev/null || echo this-mac)}"
+TTL_SECONDS="${FRIDAY_PAIRING_TTL_SECONDS:-600}"
+OUT_DIR="${FRIDAY_PAIRING_OUT_DIR:-${TMPDIR:-/tmp}/friday-pairing}"
+QR_JSON_OUT="${FRIDAY_PAIRING_QR_JSON_OUT:-${OUT_DIR}/${PAIRING_ID}.json}"
+ONCE="${FRIDAY_PAIRING_ONCE:-0}"
+ALLOW_NON_LOOPBACK="${FRIDAY_PAIRING_ALLOW_NON_LOOPBACK:-0}"
+
+case "${TTL_SECONDS}" in
+  ''|*[!0-9]*)
+    echo "FATAL: FRIDAY_PAIRING_TTL_SECONDS must be a positive integer." >&2
+    exit 3
+    ;;
+esac
+if [ "${TTL_SECONDS}" -le 0 ]; then
+  echo "FATAL: FRIDAY_PAIRING_TTL_SECONDS must be positive." >&2
+  exit 3
+fi
+case "${PORT}" in
+  ''|*[!0-9]*)
+    echo "FATAL: FRIDAY_PAIRING_PORT must be a u16 integer." >&2
+    exit 3
+    ;;
+esac
+if [ "${PORT}" -gt 65535 ]; then
+  echo "FATAL: FRIDAY_PAIRING_PORT must be <= 65535." >&2
+  exit 3
+fi
+
+mkdir -p "${OUT_DIR}"
+chmod 700 "${OUT_DIR}" 2>/dev/null || true
+
+is_private_ipv4() {
+  case "$1" in
+    10.*|192.168.*|169.254.*) return 0 ;;
+    172.1[6-9].*|172.2[0-9].*|172.3[0-1].*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+if [ "${HOST}" = "auto-lan" ]; then
+  HOST=""
+  for iface in en0 en1 bridge100; do
+    candidate="$(ipconfig getifaddr "${iface}" 2>/dev/null || true)"
+    if [ -n "${candidate}" ] && is_private_ipv4 "${candidate}"; then
+      HOST="${candidate}"
+      break
+    fi
+  done
+  if [ -z "${HOST}" ]; then
+    echo "FATAL: could not discover a private LAN IPv4 for FRIDAY_PAIRING_HOST=auto-lan." >&2
+    exit 3
+  fi
+  ALLOW_NON_LOOPBACK="1"
+fi
+
+PAIRING_SECRET="$(node -e 'process.stdout.write(require("node:crypto").randomBytes(24).toString("hex"))')"
+EXPIRES_AT_MS="$(node -e "process.stdout.write(String(Date.now() + Number(${TTL_SECONDS}) * 1000))")"
+
+ARGS=(
+  run -p friday-hub --bin hub_pairing_server --
+  --db "${DB_PATH}"
+  --pairing-secret "${PAIRING_SECRET}"
+  --hub-id "${HUB_ID}"
+  --pairing-id "${PAIRING_ID}"
+  --display-name "${DISPLAY_NAME}"
+  --expires-at-ms "${EXPIRES_AT_MS}"
+  --owner "${OWNER}"
+  --host "${HOST}"
+  --port "${PORT}"
+  --qr-json-out "${QR_JSON_OUT}"
+)
+
+if [ "${ALLOW_NON_LOOPBACK}" = "1" ]; then
+  ARGS+=(--allow-non-loopback)
+fi
+if [ "${ONCE}" = "1" ]; then
+  ARGS+=(--once)
+fi
+
+cat >&2 <<EOF
+Friday pairing session starting.
+DB: ${DB_PATH}
+Host: ${HOST}
+Port: ${PORT}
+QR manifest: ${QR_JSON_OUT}
+TTL seconds: ${TTL_SECONDS}
+Truth: explicit DARK pairing server; no trust_grant/context_passport mint, no operator signing key.
+EOF
+
+cd "${REPO_ROOT}"
+exec cargo "${ARGS[@]}"

--- a/test/unit/scripts/ops/friday-start-pairing-session.test.ts
+++ b/test/unit/scripts/ops/friday-start-pairing-session.test.ts
@@ -1,0 +1,30 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const repoRoot = process.cwd();
+const scriptPath = resolve(repoRoot, "scripts/ops/friday-start-pairing-session.sh");
+const source = readFileSync(scriptPath, "utf8");
+
+describe("friday-start-pairing-session.sh", () => {
+  it("launches the dark pairing server with a QR manifest output", () => {
+    expect(source).toContain("hub_pairing_server");
+    expect(source).toContain("--qr-json-out");
+    expect(source).toContain("FRIDAY_PAIRING_QR_JSON_OUT");
+  });
+
+  it("keeps non-loopback exposure behind an explicit operator env", () => {
+    expect(source).toContain("FRIDAY_PAIRING_ALLOW_NON_LOOPBACK");
+    expect(source).toContain("--allow-non-loopback");
+    expect(source).toContain('ALLOW_NON_LOOPBACK}" = "1"');
+    expect(source).toContain('HOST}" = "auto-lan"');
+    expect(source).toContain("is_private_ipv4");
+  });
+
+  it("does not touch operator signing material or mint grants/passports", () => {
+    expect(source).not.toContain("operator-approve.key");
+    expect(source).not.toContain("friday-operator-sign");
+    expect(source).not.toContain("friday-operator-cli grant");
+    expect(source).not.toContain("attach_context_passport_ref");
+  });
+});


### PR DESCRIPTION
## Summary
- allow the iOS live pairing client to accept loopback plus private-LAN IPv4 QR endpoints while still rejecting public/DNS hosts
- add an operator-facing `friday-start-pairing-session.sh` wrapper that launches the explicit DARK `hub_pairing_server`, emits a short-lived QR manifest, and supports `FRIDAY_PAIRING_HOST=auto-lan`
- cover the new pairing endpoint policy and wrapper source guardrails

## Truth / Scope
- This advances T3 pairing/provisioning toward real phone PairAck and read-seam enrollment.
- It does **not** mint `trust_grant` or `context_passport`, does **not** read or proxy operator signing keys, and does **not** flip any live/default flags.
- Pairing remains explicit/operator-launched; default mobile live pairing remains off.

## Local Verification
- `swift test --package-path apps/friday-ios --filter PairingPreflightTests`
- `swift test --package-path apps/macos/FridayRustClient --filter PairingManifestTests`
- `bash -n scripts/ops/friday-start-pairing-session.sh`
- `/Users/jarvis/Projects/Friday/node_modules/.bin/vitest run test/unit/scripts/ops/friday-start-pairing-session.test.ts`
- `detect-secrets-hook --baseline .secrets.baseline scripts/ops/friday-start-pairing-session.sh test/unit/scripts/ops/friday-start-pairing-session.test.ts apps/friday-ios/Sources/FridayMobileShellCore/RealPairingClientFactory.swift apps/friday-ios/Tests/FridayMobileShellCoreTests/PairingPreflightTests.swift`
- `git diff --check`
- `apps/friday-ios/build-sim.sh`
