### PR TITLE
Add pairing proof CLI

### DIFF
--- a/apps/macos/FridayHubConsole/Package.swift
+++ b/apps/macos/FridayHubConsole/Package.swift
@@ -8,6 +8,7 @@ let package = Package(
   ],
   products: [
     .executable(name: "FridayHubConsole", targets: ["FridayHubConsole"]),
+    .executable(name: "FridayPairingProof", targets: ["FridayPairingProof"]),
     .library(name: "FridayHubConsoleCore", targets: ["FridayHubConsoleCore"]),
   ],
   dependencies: [
@@ -40,6 +41,11 @@ let package = Package(
       resources: [
         .copy("PetResources"),
       ]
+    ),
+    .executableTarget(
+      name: "FridayPairingProof",
+      dependencies: ["FridayHubConsoleCore"],
+      path: "Sources/FridayPairingProof"
     ),
     .testTarget(
       name: "FridayHubConsoleCoreTests",

--- a/apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/RealPairingClientFactory.swift
+++ b/apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/RealPairingClientFactory.swift
@@ -1,0 +1,89 @@
+import Foundation
+import FridayRustClient
+
+public enum PairingEndpointConfigError: Error, Sendable, Equatable, CustomStringConvertible {
+  case badEndpoint(String)
+  case disallowedHost(String)
+  case missingPort(String)
+
+  public var description: String {
+    switch self {
+    case let .badEndpoint(endpoint):
+      return "bad pairing endpoint \(endpoint)"
+    case let .disallowedHost(host):
+      return "pairing endpoint must be loopback or private LAN, got \(host)"
+    case let .missingPort(endpoint):
+      return "pairing endpoint missing port \(endpoint)"
+    }
+  }
+}
+
+public struct PairingEndpointConfig: Sendable, Equatable {
+  public let host: String
+  public let port: UInt16
+  public let connectTimeout: TimeInterval
+  public let receiveTimeout: TimeInterval
+
+  public init(
+    host: String,
+    port: UInt16,
+    connectTimeout: TimeInterval = 4,
+    receiveTimeout: TimeInterval = 8
+  ) {
+    self.host = host
+    self.port = port
+    self.connectTimeout = connectTimeout
+    self.receiveTimeout = receiveTimeout
+  }
+
+  public init(manifest: FridayPairingManifest) throws {
+    let endpoint = try manifest.webSocketEndpoint
+    guard let url = URL(string: endpoint), let scheme = url.scheme?.lowercased(),
+      scheme == "ws" || scheme == "wss"
+    else {
+      throw PairingEndpointConfigError.badEndpoint(endpoint)
+    }
+    let host = url.host ?? ""
+    guard Self.isAllowedPairingHost(host) else {
+      throw PairingEndpointConfigError.disallowedHost(host)
+    }
+    guard let port = url.port, let p = UInt16(exactly: port) else {
+      throw PairingEndpointConfigError.missingPort(endpoint)
+    }
+    self.init(host: host == "localhost" ? "127.0.0.1" : host, port: p)
+  }
+
+  var transportConfig: ReadProjectionServerConfig {
+    ReadProjectionServerConfig(
+      host: host,
+      port: port,
+      connectTimeout: connectTimeout,
+      receiveTimeout: receiveTimeout)
+  }
+
+  static func isAllowedPairingHost(_ host: String) -> Bool {
+    let h = host.lowercased()
+    if ["127.0.0.1", "localhost", "::1"].contains(h) { return true }
+    let parts = h.split(separator: ".").compactMap { UInt8(String($0)) }
+    guard parts.count == 4 else { return false }
+    if parts[0] == 10 { return true }
+    if parts[0] == 172 && (UInt8(16)...UInt8(31)).contains(parts[1]) { return true }
+    if parts[0] == 192 && parts[1] == 168 { return true }
+    if parts[0] == 169 && parts[1] == 254 { return true }
+    return false
+  }
+}
+
+public enum RealPairingProofClientFactory {
+  public static func make(
+    manifest: FridayPairingManifest,
+    keypair: FridayCrypto.DeviceKeypair
+  ) throws -> FridayPairingClient {
+    let config = try PairingEndpointConfig(manifest: manifest)
+    return SealedWSPairingClient(
+      keypair: keypair,
+      makeTransport: {
+        try LoopbackSealedWSTransport(config: config.transportConfig)
+      })
+  }
+}

--- a/apps/macos/FridayHubConsole/Sources/FridayPairingProof/main.swift
+++ b/apps/macos/FridayHubConsole/Sources/FridayPairingProof/main.swift
@@ -1,0 +1,136 @@
+import Foundation
+import FridayHubConsoleCore
+import FridayRustClient
+
+@main
+struct FridayPairingProof {
+  static func main() async {
+    do {
+      let args = try Args.parse(Array(CommandLine.arguments.dropFirst()))
+      let data = try Data(contentsOf: args.manifestURL)
+      let manifest = try JSONDecoder().decode(FridayPairingManifest.self, from: data)
+      try manifest.validate(nowMs: Int64(Date().timeIntervalSince1970 * 1000))
+
+      let keypair = try args.deviceSecretHex.map { try FridayCrypto.DeviceKeypair(secretBytes: try Hex.decode($0)) }
+        ?? FridayCrypto.DeviceKeypair()
+      let client = try RealPairingProofClientFactory.make(manifest: manifest, keypair: keypair)
+
+      if args.statusOnly {
+        let status = try await client.fetchHubStatus(manifest: manifest)
+        printJSON([
+          "truth": "pairing_status_only_no_trusted_device_write",
+          "hub_id": manifest.hubId,
+          "pairing_id": manifest.pairingId,
+          "device_pubkey_hex": Hex.encode(keypair.publicKey),
+          "hub_online": status.online ? "true" : "false",
+          "capabilities": status.capabilities.joined(separator: ","),
+        ])
+        return
+      }
+
+      guard args.pair else {
+        throw UsageError("pass --pair to send PairAck-producing proof, or --status-only for a no-write probe")
+      }
+      let ack = try await client.pairDevice(manifest: manifest, deviceId: args.deviceID)
+      printJSON([
+        "truth": "pairing_pairack_real_sealed_ws_no_grant_no_passport_no_operator_key",
+        "hub_id": manifest.hubId,
+        "pairing_id": manifest.pairingId,
+        "device_id": args.deviceID,
+        "device_pubkey_hex": Hex.encode(keypair.publicKey),
+        "ack_accepted": ack.accepted ? "true" : "false",
+        "ack_error_code": ack.errorCode.map { "\($0)" } ?? "",
+      ])
+      if !ack.accepted {
+        exit(4)
+      }
+    } catch {
+      fputs("FridayPairingProof: \(error)\n\n\(Args.usage)\n", stderr)
+      exit(2)
+    }
+  }
+
+  private static func printJSON(_ fields: [String: String]) {
+    let object = fields.mapValues { value in
+      value
+        .replacingOccurrences(of: "\\", with: "\\\\")
+        .replacingOccurrences(of: "\"", with: "\\\"")
+    }
+    let body = object.keys.sorted().map { key in
+      "  \"\(key)\": \"\(object[key] ?? "")\""
+    }.joined(separator: ",\n")
+    print("{\n\(body)\n}")
+  }
+}
+
+struct UsageError: Error, CustomStringConvertible {
+  let description: String
+  init(_ description: String) { self.description = description }
+}
+
+struct Args {
+  let manifestURL: URL
+  let pair: Bool
+  let statusOnly: Bool
+  let deviceID: String
+  let deviceSecretHex: String?
+
+  static let usage = """
+    usage:
+      swift run FridayPairingProof --manifest <qr-json> --pair [--device-id <id>] [--device-secret-hex <64-hex>]
+      swift run FridayPairingProof --manifest <qr-json> --status-only [--device-secret-hex <64-hex>]
+
+    truth:
+      Sends a real sealed-WS Pair request to an explicit hub_pairing_server session.
+      It never reads operator signing keys and never mints trust_grant/context_passport.
+    """
+
+  static func parse(_ raw: [String]) throws -> Args {
+    var manifest: String?
+    var pair = false
+    var statusOnly = false
+    var deviceID = "desktop-pairing-proof-\(UUID().uuidString.prefix(12))"
+    var deviceSecretHex: String?
+    var i = 0
+    while i < raw.count {
+      switch raw[i] {
+      case "--manifest":
+        i += 1
+        guard i < raw.count else { throw UsageError("--manifest requires a path") }
+        manifest = raw[i]
+      case "--pair":
+        pair = true
+      case "--status-only":
+        statusOnly = true
+      case "--device-id":
+        i += 1
+        guard i < raw.count else { throw UsageError("--device-id requires a value") }
+        deviceID = raw[i]
+      case "--device-secret-hex":
+        i += 1
+        guard i < raw.count else { throw UsageError("--device-secret-hex requires a 64-hex value") }
+        deviceSecretHex = raw[i]
+      case "-h", "--help":
+        throw UsageError(usage)
+      default:
+        throw UsageError("unknown argument \(raw[i])")
+      }
+      i += 1
+    }
+    guard pair != statusOnly else {
+      throw UsageError("choose exactly one of --pair or --status-only")
+    }
+    guard let manifest else {
+      throw UsageError("--manifest is required")
+    }
+    if let deviceSecretHex, deviceSecretHex.count != 64 {
+      throw UsageError("--device-secret-hex must be 64 lowercase/uppercase hex characters")
+    }
+    return Args(
+      manifestURL: URL(fileURLWithPath: manifest),
+      pair: pair,
+      statusOnly: statusOnly,
+      deviceID: deviceID,
+      deviceSecretHex: deviceSecretHex)
+  }
+}

--- a/apps/macos/FridayHubConsole/Tests/FridayHubConsoleCoreTests/RealPairingClientFactoryTests.swift
+++ b/apps/macos/FridayHubConsole/Tests/FridayHubConsoleCoreTests/RealPairingClientFactoryTests.swift
@@ -1,0 +1,47 @@
+import Foundation
+import FridayRustClient
+import Testing
+@testable import FridayHubConsoleCore
+
+@Test func pairingEndpointConfigAcceptsLoopbackAndPrivateLanOnly() throws {
+  #expect(try PairingEndpointConfig(manifest: manifest(endpoint: "ws://127.0.0.1:49152")).host == "127.0.0.1")
+  #expect(try PairingEndpointConfig(manifest: manifest(endpoint: "ws://localhost:49152")).host == "127.0.0.1")
+  #expect(try PairingEndpointConfig(manifest: manifest(endpoint: "ws://192.168.1.50:49152")).host == "192.168.1.50")
+  #expect(try PairingEndpointConfig(manifest: manifest(endpoint: "ws://10.0.0.5:49152")).host == "10.0.0.5")
+  #expect(try PairingEndpointConfig(manifest: manifest(endpoint: "ws://172.20.0.5:49152")).host == "172.20.0.5")
+
+  #expect(throws: PairingEndpointConfigError.disallowedHost("8.8.8.8")) {
+    try PairingEndpointConfig(manifest: manifest(endpoint: "ws://8.8.8.8:49152"))
+  }
+  #expect(throws: PairingEndpointConfigError.disallowedHost("example.com")) {
+    try PairingEndpointConfig(manifest: manifest(endpoint: "ws://example.com:49152"))
+  }
+}
+
+@Test func realPairingProofFactoryBuildsASealedPairingClient() throws {
+  let client = try RealPairingProofClientFactory.make(
+    manifest: manifest(endpoint: "ws://127.0.0.1:49152"),
+    keypair: FridayCrypto.DeviceKeypair())
+  #expect(client is SealedWSPairingClient)
+}
+
+private func manifest(endpoint: String) throws -> FridayPairingManifest {
+  let json = """
+    {
+      "kind": "friday.pairing.qr.v1",
+      "aad": "friday:pairing:ws:j1:qr-pair-session:aad:v1",
+      "hub_public_key_hex": "\(String(repeating: "a", count: 64))",
+      "v": 1,
+      "hub_id": "hub-test",
+      "pairing_id": "pair-test",
+      "pairing_secret": "friday-pairing-secret-for-test", // pragma: allowlist secret
+      "display_name": "Friday Test Hub",
+      "transport_hints": [
+        {"kind":"lan_websocket","endpoint":"\(endpoint)","label":"pairing"}
+      ],
+      "expires_at": 1900000000000,
+      "capabilities_hint": ["pairing", "read_seam_enroll"]
+    }
+    """
+  return try JSONDecoder().decode(FridayPairingManifest.self, from: Data(json.utf8))
+}

--- a/apps/macos/FridayRustClient/Sources/FridayRustClient/PairingClient.swift
+++ b/apps/macos/FridayRustClient/Sources/FridayRustClient/PairingClient.swift
@@ -85,10 +85,6 @@ public final class SealedWSPairingClient: FridayPairingClient, @unchecked Sendab
     guard serverPub == (try manifest.hubPublicKey) else {
       throw FridayPairingClientError.serverPubkeyMismatch
     }
-    let sessionNonce = try transport.readFrame()
-    guard sessionNonce.count == 64 else {
-      throw FridayPairingClientError.badSessionNonce
-    }
     try transport.upgrade()
 
     let sessionKey: [UInt8]

--- a/apps/macos/FridayRustClient/Sources/FridayRustClient/PairingManifest.swift
+++ b/apps/macos/FridayRustClient/Sources/FridayRustClient/PairingManifest.swift
@@ -69,7 +69,8 @@ public struct FridayPairingManifest: Codable, Equatable, Sendable, CustomStringC
 
   public var webSocketEndpoint: String {
     get throws {
-      guard let endpoint = transportHints.first(where: { $0.kind == "websocket" })?.endpoint,
+      let wsKinds = Set(["websocket", "lan_websocket", "manual_url"])
+      guard let endpoint = transportHints.first(where: { wsKinds.contains($0.kind) })?.endpoint,
         !endpoint.isEmpty
       else {
         throw FridayPairingManifestError.missingWebSocketEndpoint

--- a/apps/macos/FridayRustClient/Tests/FridayRustClientTests/PairingClientWiringTests.swift
+++ b/apps/macos/FridayRustClient/Tests/FridayRustClientTests/PairingClientWiringTests.swift
@@ -16,7 +16,6 @@ final class PairingClientWiringTests: XCTestCase {
 
   final class EmulatedPairingServerTransport: SealedWSTransport {
     private let serverKeypair: FridayCrypto.DeviceKeypair
-    private let sessionNonce: [UInt8]
     private let aad: [UInt8]
     private let mode: ServerMode
 
@@ -28,12 +27,10 @@ final class PairingClientWiringTests: XCTestCase {
 
     init(
       serverKeypair: FridayCrypto.DeviceKeypair,
-      sessionNonce: [UInt8],
       aad: [UInt8],
       mode: ServerMode
     ) {
       self.serverKeypair = serverKeypair
-      self.sessionNonce = sessionNonce
       self.aad = aad
       self.mode = mode
     }
@@ -42,7 +39,6 @@ final class PairingClientWiringTests: XCTestCase {
       if clientPub == nil {
         clientPub = payload
         queuedFromServer.append(serverKeypair.publicKey)
-        queuedFromServer.append(sessionNonce)
       }
     }
 
@@ -200,7 +196,6 @@ final class PairingClientWiringTests: XCTestCase {
     )
     let transport = EmulatedPairingServerTransport(
       serverKeypair: serverKp,
-      sessionNonce: try Hex.decode(B1KAT.k3Auth.sessionNonce),
       aad: Array(manifest.aad.utf8),
       mode: mode
     )

--- a/apps/macos/FridayRustClient/Tests/FridayRustClientTests/PairingManifestTests.swift
+++ b/apps/macos/FridayRustClient/Tests/FridayRustClientTests/PairingManifestTests.swift
@@ -35,6 +35,12 @@ final class PairingManifestTests: XCTestCase {
       "b82be6373123d412b180127398c090c940663a12574035523b71c629549282fc")  // pragma: allowlist secret
   }
 
+  func testAcceptsRustQrLanWebSocketTransportKind() throws {
+    let manifest = try decodeManifest(replacing: (#""websocket""#, #""lan_websocket""#))
+
+    XCTAssertEqual(try manifest.webSocketEndpoint, "ws://127.0.0.1:49152")
+  }
+
   func testValidationFailsClosedForBadManifestShapes() throws {
     let manifest = try decodeManifest()
     try manifest.validate(nowMs: 1_780_000_000_000)

--- a/scripts/ops/friday-start-pairing-session.sh
+++ b/scripts/ops/friday-start-pairing-session.sh
@@ -12,6 +12,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 
 DB_PATH="${FRIDAY_PAIRING_DB_PATH:-${HOME}/Library/Application Support/Friday/state/rust-hub.sqlite}"
+STORE_DIR="${FRIDAY_PAIRING_STORE_DIR:-}"
 HOST="${FRIDAY_PAIRING_HOST:-127.0.0.1}"
 PORT="${FRIDAY_PAIRING_PORT:-0}"
 OWNER="${FRIDAY_PAIRING_OWNER:-jarvis}"
@@ -76,7 +77,7 @@ PAIRING_SECRET="$(node -e 'process.stdout.write(require("node:crypto").randomByt
 EXPIRES_AT_MS="$(node -e "process.stdout.write(String(Date.now() + Number(${TTL_SECONDS}) * 1000))")"
 
 ARGS=(
-  run -p friday-hub --bin hub_pairing_server --
+  run --quiet --manifest-path "${REPO_ROOT}/rust-core/Cargo.toml" -p friday-hub --bin hub_pairing_server --
   --db "${DB_PATH}"
   --pairing-secret "${PAIRING_SECRET}"
   --hub-id "${HUB_ID}"
@@ -89,6 +90,9 @@ ARGS=(
   --qr-json-out "${QR_JSON_OUT}"
 )
 
+if [ -n "${STORE_DIR}" ]; then
+  ARGS+=(--store-dir "${STORE_DIR}")
+fi
 if [ "${ALLOW_NON_LOOPBACK}" = "1" ]; then
   ARGS+=(--allow-non-loopback)
 fi
@@ -99,6 +103,7 @@ fi
 cat >&2 <<EOF
 Friday pairing session starting.
 DB: ${DB_PATH}
+Store dir: ${STORE_DIR:-<default>}
 Host: ${HOST}
 Port: ${PORT}
 QR manifest: ${QR_JSON_OUT}
@@ -106,5 +111,4 @@ TTL seconds: ${TTL_SECONDS}
 Truth: explicit DARK pairing server; no trust_grant/context_passport mint, no operator signing key.
 EOF
 
-cd "${REPO_ROOT}"
 exec cargo "${ARGS[@]}"

--- a/test/unit/scripts/ops/friday-start-pairing-session.test.ts
+++ b/test/unit/scripts/ops/friday-start-pairing-session.test.ts
@@ -9,8 +9,11 @@ const source = readFileSync(scriptPath, "utf8");
 describe("friday-start-pairing-session.sh", () => {
   it("launches the dark pairing server with a QR manifest output", () => {
     expect(source).toContain("hub_pairing_server");
+    expect(source).toContain('run --quiet --manifest-path "${REPO_ROOT}/rust-core/Cargo.toml"');
     expect(source).toContain("--qr-json-out");
     expect(source).toContain("FRIDAY_PAIRING_QR_JSON_OUT");
+    expect(source).toContain("FRIDAY_PAIRING_STORE_DIR");
+    expect(source).toContain("--store-dir");
   });
 
   it("keeps non-loopback exposure behind an explicit operator env", () => {


### PR DESCRIPTION
## Summary
- fixes Swift pairing to match the Rust QR pairing handshake (no read/write session nonce) and accepts Rust-emitted `lan_websocket` QR manifests
- adds a narrow desktop `FridayPairingProof` executable that sends a real sealed-WS Pair request to an explicit pairing session
- lets `friday-start-pairing-session.sh` run from the rust-core Cargo workspace and use a scratch store dir for proof runs, with quiet cargo logs

## Verification
- `swift test --package-path apps/macos/FridayRustClient` (88 tests)
- `swift test --package-path apps/macos/FridayHubConsole --filter 'RealPairingClientFactoryTests|PairingProvisioningViewModelTests'` (5 tests)
- `swift test --package-path apps/friday-ios --filter PairingPreflightTests` (9 tests)
- `cargo test --manifest-path rust-core/Cargo.toml -p friday-hub --bin hub_pairing_server` (7 tests)
- `vitest run test/unit/scripts/ops/friday-start-pairing-session.test.ts` (3 tests)
- scratch proof: `hub_pairing_server --once` + `FridayPairingProof --pair` produced PairAck accepted, scratch `trusted_device=1`, scratch `audit_ledger=1`
- `git diff --check`
- `detect-secrets-hook --baseline .secrets.baseline ...`

Truth: T3 pairing mechanism proof only. This does not mint trust_grant/context_passport, does not touch operator signing material, does not flip defaults/live flags, and is not GO.