### PR TITLE
Add operator context passport ceremony

### DIFF
--- a/rust-core/crates/friday-operator-cli/src/lib.rs
+++ b/rust-core/crates/friday-operator-cli/src/lib.rs
@@ -966,6 +966,184 @@ pub mod trust_grant {
     }
 }
 
+/// Operator-side Context Passport ceremony.
+///
+/// This is deliberately an operator CLI path, not a Hub/app/agent mint endpoint. It builds
+/// a destination-bound passport through the same fail-closed core constructor used by
+/// Hub preflight, persists the object, binds it to the Mission refs, and records a
+/// MissionLink so the existing preflight gate can satisfy a sensitive external transfer.
+pub mod context_passport {
+    use super::CliError;
+    use friday_core::{
+        build_context_passport, MissionLink, MissionLinkKind, PassportItem, PassportItemKind,
+        WorkLane,
+    };
+    use friday_storage::Db;
+
+    #[derive(Debug, Clone)]
+    pub struct PassportSpec {
+        pub passport_id: String,
+        pub mission_id: String,
+        pub work_item_id: Option<String>,
+        pub destination_lane: WorkLane,
+        pub destination_target: Option<String>,
+        pub items: Vec<PassportItem>,
+        pub approved_sensitive: bool,
+    }
+
+    #[derive(Debug, Clone)]
+    pub struct MintedPassport {
+        pub passport_id: String,
+        pub mission_id: String,
+        pub work_item_id: Option<String>,
+        pub destination_lane: WorkLane,
+        pub destination_target: Option<String>,
+        pub shared_item_count: usize,
+        pub mission_ref_count: usize,
+        pub link_id: String,
+    }
+
+    pub fn parse_lane(value: &str) -> Result<WorkLane, CliError> {
+        match value {
+            "friday_hub" => Ok(WorkLane::FridayHub),
+            "codex" => Ok(WorkLane::Codex),
+            "claude" => Ok(WorkLane::Claude),
+            "deepseek" => Ok(WorkLane::DeepSeek),
+            "workflow" => Ok(WorkLane::Workflow),
+            "channel" => Ok(WorkLane::Channel),
+            "human" => Ok(WorkLane::Human),
+            "future_api" => Ok(WorkLane::FutureApi),
+            other => Err(CliError::BadGrant(format!(
+                "unknown destination lane {other:?}: expected one of \
+                 friday_hub|codex|claude|deepseek|workflow|channel|human|future_api"
+            ))),
+        }
+    }
+
+    pub fn parse_item_kind(value: &str) -> Result<PassportItemKind, CliError> {
+        match value {
+            "memory_snippet" => Ok(PassportItemKind::MemorySnippet),
+            "summary" => Ok(PassportItemKind::Summary),
+            "file" => Ok(PassportItemKind::File),
+            "screenshot" => Ok(PassportItemKind::Screenshot),
+            "attachment" => Ok(PassportItemKind::Attachment),
+            "provider_secret" => Ok(PassportItemKind::ProviderSecret), // pragma: allowlist secret
+            "raw_token" => Ok(PassportItemKind::RawToken),
+            other => Err(CliError::BadGrant(format!(
+                "unknown passport item kind {other:?}: expected one of \
+                 memory_snippet|summary|file|screenshot|attachment|provider_secret|raw_token"
+            ))),
+        }
+    }
+
+    pub fn open_hub(path: &str) -> Result<Db, CliError> {
+        Db::open_hub(path).map_err(|_| CliError::OpenDb(path.to_string()))
+    }
+
+    pub fn mint(db: &Db, spec: &PassportSpec, now_ms: i64) -> Result<MintedPassport, CliError> {
+        if spec.passport_id.trim().is_empty() {
+            return Err(CliError::BadGrant(
+                "passport_id must not be empty".to_string(),
+            ));
+        }
+        if spec.mission_id.trim().is_empty() {
+            return Err(CliError::BadGrant(
+                "mission_id must not be empty".to_string(),
+            ));
+        }
+        if spec.items.is_empty() {
+            return Err(CliError::BadGrant(
+                "context passport requires at least one item".to_string(),
+            ));
+        }
+
+        let mut mission = db
+            .get_mission(&spec.mission_id)
+            .map_err(|e| CliError::Storage(e.to_string()))?
+            .ok_or_else(|| {
+                CliError::BadGrant(format!(
+                    "mission {:?} not found; create/stage the Mission before minting a passport",
+                    spec.mission_id
+                ))
+            })?;
+        if let Some(work_item_id) = &spec.work_item_id {
+            let work_item = db
+                .get_work_item(work_item_id)
+                .map_err(|e| CliError::Storage(e.to_string()))?
+                .ok_or_else(|| {
+                    CliError::BadGrant(format!(
+                        "work item {work_item_id:?} not found; omit --work-item-id for a \
+                         mission-scoped passport or stage the WorkItem first"
+                    ))
+                })?;
+            if work_item.mission_id != spec.mission_id {
+                return Err(CliError::BadGrant(format!(
+                    "work item {work_item_id:?} belongs to mission {:?}, not {:?}",
+                    work_item.mission_id, spec.mission_id
+                )));
+            }
+        }
+
+        let passport = build_context_passport(
+            spec.passport_id.clone(),
+            spec.mission_id.clone(),
+            spec.work_item_id.clone(),
+            spec.destination_lane,
+            spec.destination_target.clone(),
+            spec.items.clone(),
+            spec.approved_sensitive,
+            now_ms,
+        )
+        .map_err(|e| CliError::BadGrant(format!("context_passport_blocked:{e}")))?;
+
+        let link_id = format!(
+            "context-passport-{}-{}",
+            ref_id_part(&spec.passport_id),
+            now_ms
+        );
+        db.upsert_context_passport(&passport)
+            .map_err(|e| CliError::Storage(e.to_string()))?;
+        db.upsert_mission_link(&MissionLink {
+            link_id: link_id.clone(),
+            mission_id: spec.mission_id.clone(),
+            work_item_id: spec.work_item_id.clone(),
+            link_kind: MissionLinkKind::ContextPassport,
+            target_ref: format!("friday://context-passport/{}", spec.passport_id),
+            proof_ref: Some(spec.passport_id.clone()),
+            created_at_ms: now_ms,
+        })
+        .map_err(|e| CliError::Storage(e.to_string()))?;
+        push_unique(&mut mission.context_passport_refs, spec.passport_id.clone());
+        mission.updated_at_ms = now_ms;
+        db.upsert_mission(&mission)
+            .map_err(|e| CliError::Storage(e.to_string()))?;
+
+        Ok(MintedPassport {
+            passport_id: spec.passport_id.clone(),
+            mission_id: spec.mission_id.clone(),
+            work_item_id: spec.work_item_id.clone(),
+            destination_lane: spec.destination_lane,
+            destination_target: spec.destination_target.clone(),
+            shared_item_count: passport.shared_items().len(),
+            mission_ref_count: mission.context_passport_refs.len(),
+            link_id,
+        })
+    }
+
+    fn push_unique(values: &mut Vec<String>, value: String) {
+        if !values.iter().any(|existing| existing == &value) {
+            values.push(value);
+        }
+    }
+
+    fn ref_id_part(value: &str) -> String {
+        value
+            .chars()
+            .map(|ch| if ch.is_ascii_alphanumeric() { ch } else { '-' })
+            .collect()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/rust-core/crates/friday-operator-cli/src/main.rs
+++ b/rust-core/crates/friday-operator-cli/src/main.rs
@@ -35,7 +35,7 @@ use std::path::Path;
 use std::process::ExitCode;
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use friday_operator_cli::trust_grant;
+use friday_operator_cli::{context_passport, trust_grant};
 use friday_operator_cli::{
     keygen_to_path, prepare_batch_request, sign_batch_request, sign_request, PendingBatchRequest,
     PendingRequest, PrepareBatchRequest,
@@ -57,6 +57,10 @@ USAGE:
                                     [--tools a,b] [--providers a,b] [--channels a,b] \\
                                     [--workflow-families a,b] [--skill-families a,b]
     friday-operator-approve revoke --db <hub.sqlite> --grant-id <id>
+    friday-operator-approve passport-mint --db <hub.sqlite> --passport-id <id> \\
+                                    --mission-id <id> --destination-lane <lane> \\
+                                    --items <items.json> [--work-item-id <id>] \\
+                                    [--destination-target <target>] [--approved-sensitive]
 
 keygen writes the operator PRIVATE key (mode 0600) to --out and prints the PUBLIC
 verifying key (JSON) to stdout for Hub provisioning. The private key is never printed.
@@ -76,7 +80,13 @@ per-action manual gates.
 grant mints a TrustGrant for --agent with the given boundaries (operator POLICY action;
 the allowlists are fail-closed — an omitted dimension is DENY-ALL) and prints the
 persisted grant (JSON). revoke marks the grant --grant-id revoked. Both write a
-hash-chained audit row. DARK: this does NOT enable enforcement (NS-2 owns that flag).";
+hash-chained audit row. DARK: this does NOT enable enforcement (NS-2 owns that flag).
+
+passport-mint builds a ContextPassport through the fail-closed transfer gate, persists it,
+and binds it to the Mission refs/link set so the existing preflight gate can authorize
+that exact lane/target transfer. It is an operator ceremony; it reads no signing key and
+does not expose a Hub/app/agent mint endpoint. --items is a JSON array of objects:
+[{\"kind\":\"summary\",\"label\":\"...\",\"included\":true,\"sensitive\":false}].";
 
 fn main() -> ExitCode {
     match run() {
@@ -97,6 +107,7 @@ fn run() -> Result<(), String> {
         Some("sign-batch") => cmd_sign_batch(&args[2..]),
         Some("grant") => cmd_grant(&args[2..]),
         Some("revoke") => cmd_revoke(&args[2..]),
+        Some("passport-mint") => cmd_passport_mint(&args[2..]),
         Some("help") | Some("--help") | Some("-h") | None => {
             println!("{USAGE}");
             Ok(())
@@ -261,6 +272,80 @@ fn cmd_revoke(args: &[String]) -> Result<(), String> {
     Ok(())
 }
 
+#[derive(serde::Deserialize)]
+struct ItemSpec {
+    kind: String,
+    label: String,
+    #[serde(default = "default_true")]
+    included: bool,
+    #[serde(default)]
+    sensitive: bool,
+}
+
+fn default_true() -> bool {
+    true
+}
+
+fn cmd_passport_mint(args: &[String]) -> Result<(), String> {
+    let db_path = arg_value(args, "--db")
+        .ok_or_else(|| format!("passport-mint requires --db <hub.sqlite>\n\n{USAGE}"))?;
+    let passport_id = arg_value(args, "--passport-id")
+        .ok_or_else(|| format!("passport-mint requires --passport-id <id>\n\n{USAGE}"))?;
+    let mission_id = arg_value(args, "--mission-id")
+        .ok_or_else(|| format!("passport-mint requires --mission-id <id>\n\n{USAGE}"))?;
+    let destination_lane = arg_value(args, "--destination-lane")
+        .ok_or_else(|| format!("passport-mint requires --destination-lane <lane>\n\n{USAGE}"))?;
+    let items_path = arg_value(args, "--items")
+        .ok_or_else(|| format!("passport-mint requires --items <items.json>\n\n{USAGE}"))?;
+
+    let raw = std::fs::read_to_string(&items_path)
+        .map_err(|_| format!("could not read items file {items_path}"))?;
+    let item_specs: Vec<ItemSpec> =
+        serde_json::from_str(&raw).map_err(|e| format!("invalid items JSON: {e}"))?;
+    let items = item_specs
+        .into_iter()
+        .map(|item| {
+            Ok(friday_core::PassportItem {
+                kind: context_passport::parse_item_kind(&item.kind).map_err(|e| e.to_string())?,
+                label: item.label,
+                included: item.included,
+                sensitive: item.sensitive,
+            })
+        })
+        .collect::<Result<Vec<_>, String>>()?;
+
+    let spec = context_passport::PassportSpec {
+        passport_id,
+        mission_id,
+        work_item_id: arg_value(args, "--work-item-id"),
+        destination_lane: context_passport::parse_lane(&destination_lane)
+            .map_err(|e| e.to_string())?,
+        destination_target: arg_value(args, "--destination-target"),
+        items,
+        approved_sensitive: has_flag(args, "--approved-sensitive"),
+    };
+
+    let db = context_passport::open_hub(&db_path).map_err(|e| e.to_string())?;
+    let minted = context_passport::mint(&db, &spec, now_ms()?).map_err(|e| e.to_string())?;
+    let out = serde_json::json!({
+        "result": "context_passport_minted",
+        "truth_label": "operator_cli_context_passport_ceremony_not_app_or_agent_mint",
+        "passport_id": minted.passport_id,
+        "mission_id": minted.mission_id,
+        "work_item_id": minted.work_item_id,
+        "destination_lane": minted.destination_lane.as_str(),
+        "destination_target": minted.destination_target,
+        "shared_item_count": minted.shared_item_count,
+        "mission_ref_count": minted.mission_ref_count,
+        "link_id": minted.link_id,
+    });
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&out).map_err(|e| e.to_string())?
+    );
+    Ok(())
+}
+
 /// Current wall-clock as epoch-ms. The CLI supplies the clock; the library issuance fn
 /// takes `now` as an argument so a test can pin it.
 fn now_ms() -> Result<i64, String> {
@@ -292,4 +377,8 @@ fn arg_value(args: &[String], name: &str) -> Option<String> {
             args.iter()
                 .find_map(|arg| arg.strip_prefix(&prefix).map(str::to_string))
         })
+}
+
+fn has_flag(args: &[String], name: &str) -> bool {
+    args.iter().any(|arg| arg == name)
 }

--- a/rust-core/crates/friday-operator-cli/tests/cli_roundtrip.rs
+++ b/rust-core/crates/friday-operator-cli/tests/cli_roundtrip.rs
@@ -15,12 +15,14 @@ use std::process::{Command, Output};
 
 use friday_core::gate::canonical_action_bytes;
 use friday_core::gate::ApprovalDecision;
+use friday_core::{FridayConversation, Mission, MissionStatus, TruthStatus, WorkLane};
 use friday_crypto::verify_ed25519_approval;
 use friday_hub::{build_request, RawToolCall};
 use friday_operator_cli::{
     build_prepared_action_request, canonical_batch_bytes, canonical_bytes, decode_signature_hex,
     decode_verifying_key_hex, parse_decision, ActionParam, BatchActionSpec,
 };
+use friday_storage::Db;
 
 const BIN: &str = env!("CARGO_BIN_EXE_friday-operator-approve");
 
@@ -35,6 +37,44 @@ fn run_bin(args: &[&str]) -> Output {
         .args(args)
         .output()
         .expect("spawn friday-operator-approve")
+}
+
+fn conversation_for_passport(now: i64) -> FridayConversation {
+    FridayConversation {
+        friday_conversation_id: "fconv_cli_passport".into(),
+        owner_principal: "owner-cli".into(),
+        title: "CLI passport proof".into(),
+        current_focus_summary: "Operator CLI passport ceremony proof.".into(),
+        active_mission_ids: vec!["mission-cli-passport".into()],
+        surface_thread_ids: vec![],
+        memory_scope_ref: None,
+        truth_status: TruthStatus::Proven,
+        proof_refs: vec![],
+        created_at_ms: now,
+        updated_at_ms: now,
+    }
+}
+
+fn mission_for_passport(now: i64) -> Mission {
+    Mission {
+        mission_id: "mission-cli-passport".into(),
+        friday_conversation_id: "fconv_cli_passport".into(),
+        title: "CLI passport proof".into(),
+        intent: "Mint a context passport from the operator CLI.".into(),
+        status: MissionStatus::Active,
+        why_now: "T3 provisioning needs a real operator ceremony.".into(),
+        decision_path_summary: "Use CLI ceremony, not app mint.".into(),
+        considered_options: vec![],
+        deferred_options: vec![],
+        known_pitfalls: vec![],
+        handoff_inheritance: vec![],
+        work_item_ids: vec![],
+        memory_candidate_refs: vec![],
+        context_passport_refs: vec![],
+        proof_refs: vec![],
+        created_at_ms: now,
+        updated_at_ms: now,
+    }
 }
 
 fn sample_req() -> serde_json::Value {
@@ -735,4 +775,65 @@ fn keygen_refuses_to_overwrite_existing_key() {
         "keygen must refuse to clobber an existing key file"
     );
     assert!(String::from_utf8_lossy(&again.stderr).contains("already exists"));
+}
+
+#[test]
+fn passport_mint_cli_persists_mission_bound_passport_without_echoing_items() {
+    let dir = tmp_dir("passport-mint-cli");
+    let db_path = dir.join("hub.sqlite");
+    let _ = std::fs::remove_file(&db_path);
+    let db = Db::open_hub(db_path.to_str().unwrap()).unwrap();
+    let now = 1_780_000_010_000i64;
+    db.upsert_friday_conversation(&conversation_for_passport(now))
+        .unwrap();
+    db.upsert_mission(&mission_for_passport(now)).unwrap();
+
+    let items_path = dir.join("items.json");
+    std::fs::write(
+        &items_path,
+        br#"[{"kind":"summary","label":"approved operator summary","included":true,"sensitive":false}]"#,
+    )
+    .unwrap();
+    let out = run_bin(&[
+        "passport-mint",
+        "--db",
+        db_path.to_str().unwrap(),
+        "--passport-id",
+        "passport-cli-1",
+        "--mission-id",
+        "mission-cli-passport",
+        "--destination-lane",
+        "codex",
+        "--destination-target",
+        "codex",
+        "--items",
+        items_path.to_str().unwrap(),
+    ]);
+    assert!(
+        out.status.success(),
+        "passport-mint failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        !String::from_utf8_lossy(&out.stdout).contains("approved operator summary"),
+        "receipt must not echo passport item labels"
+    );
+    let receipt: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    assert_eq!(receipt["result"], "context_passport_minted");
+    assert_eq!(
+        receipt["truth_label"],
+        "operator_cli_context_passport_ceremony_not_app_or_agent_mint"
+    );
+    assert_eq!(receipt["destination_lane"], WorkLane::Codex.as_str());
+    assert_eq!(receipt["shared_item_count"], 1);
+
+    let db = Db::open_hub(db_path.to_str().unwrap()).unwrap();
+    let mission = db.get_mission("mission-cli-passport").unwrap().unwrap();
+    assert_eq!(mission.context_passport_refs, vec!["passport-cli-1"]);
+    assert!(db.get_context_passport("passport-cli-1").unwrap().is_some());
+    assert!(db
+        .list_mission_links("mission-cli-passport")
+        .unwrap()
+        .iter()
+        .any(|link| link.proof_ref.as_deref() == Some("passport-cli-1")));
 }

--- a/rust-core/crates/friday-operator-cli/tests/context_passport_ceremony.rs
+++ b/rust-core/crates/friday-operator-cli/tests/context_passport_ceremony.rs
@@ -1,0 +1,283 @@
+//! Operator-only Context Passport ceremony proof.
+//!
+//! The point is not that a row can be inserted. The proof is that the operator CLI
+//! call-site builds a real gated ContextPassport, binds it to the Mission refs/link
+//! set, and the existing Hub preflight gate then accepts the same sensitive external
+//! transfer that was blocked before the ceremony.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use friday_core::{
+    ApprovalState, FridayConversation, HandoffJudgmentMemory, Mission, MissionStatus, PassportItem,
+    PassportItemKind, Risk, SurfaceKind, SurfaceThread, TruthStatus, VisibilityPolicy, WorkItem,
+    WorkItemStatus, WorkLane,
+};
+use friday_hub::mission_preflight::{
+    preflight_and_stage_work_item, MissionPreflightOutcome, MissionPreflightRequest,
+};
+use friday_operator_cli::context_passport::{self, PassportSpec};
+use friday_storage::Db;
+
+static COUNTER: AtomicU64 = AtomicU64::new(0);
+
+fn temp_db_path(tag: &str) -> String {
+    let n = COUNTER.fetch_add(1, Ordering::SeqCst);
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let mut dir = std::env::temp_dir();
+    dir.push(format!(
+        "friday-context-passport-ceremony-{tag}-{}-{nanos}-{n}",
+        std::process::id()
+    ));
+    std::fs::create_dir_all(&dir).unwrap();
+    dir.push("hub.sqlite");
+    dir.to_string_lossy().to_string()
+}
+
+fn conversation(now: i64) -> FridayConversation {
+    FridayConversation {
+        friday_conversation_id: "fconv_passport_ceremony".into(),
+        owner_principal: "owner-1".into(),
+        title: "Passport ceremony".into(),
+        current_focus_summary: "Prove operator-only passport ceremony.".into(),
+        active_mission_ids: vec!["mission-passport".into()],
+        surface_thread_ids: vec!["surface-passport".into()],
+        memory_scope_ref: None,
+        truth_status: TruthStatus::Proven,
+        proof_refs: vec![],
+        created_at_ms: now,
+        updated_at_ms: now,
+    }
+}
+
+fn mission(context_passport_refs: Vec<String>, now: i64) -> Mission {
+    Mission {
+        mission_id: "mission-passport".into(),
+        friday_conversation_id: "fconv_passport_ceremony".into(),
+        title: "Passport ceremony".into(),
+        intent: "Send sensitive approved context to Codex.".into(),
+        status: MissionStatus::Active,
+        why_now: "T3 provisioning must be operator-governed.".into(),
+        decision_path_summary: "Use operator CLI ceremony, not app mint.".into(),
+        considered_options: vec!["app endpoint".into(), "operator CLI".into()],
+        deferred_options: vec![],
+        known_pitfalls: vec!["a raw row is not a passport".into()],
+        handoff_inheritance: vec![],
+        work_item_ids: vec![],
+        memory_candidate_refs: vec![],
+        context_passport_refs,
+        proof_refs: vec![],
+        created_at_ms: now,
+        updated_at_ms: now,
+    }
+}
+
+fn surface(now: i64) -> SurfaceThread {
+    SurfaceThread {
+        surface_thread_id: "surface-passport".into(),
+        friday_conversation_id: "fconv_passport_ceremony".into(),
+        mission_id: Some("mission-passport".into()),
+        surface_kind: SurfaceKind::Desktop,
+        channel_binding_id: None,
+        delivery_route: "test://desktop".into(),
+        visibility_policy: VisibilityPolicy::Compact,
+        allowed_actions: vec!["open".into()],
+        last_seen_at_ms: Some(now),
+        last_delivered_event_seq: None,
+        created_at_ms: now,
+        updated_at_ms: now,
+    }
+}
+
+fn judgment() -> HandoffJudgmentMemory {
+    HandoffJudgmentMemory {
+        task: "Prove context passport ceremony".into(),
+        current_blocker: None,
+        target_lane_thread_agent_provider: "codex".into(),
+        read_first_files: vec![],
+        required_output: "preflight Ready after operator ceremony".into(),
+        done_criteria: vec!["passport authorizes transfer".into()],
+        red_lines: vec!["no app mint endpoint".into()],
+        why_this_route: "operator owns context transfer approval".into(),
+        considered_options: vec!["operator CLI ceremony".into()],
+        deferred_options: vec!["work-item scoped passport after work item exists".into()],
+        previous_pitfalls: vec!["row-only passport proof is hollow".into()],
+        inheritable_context: vec!["mission refs carry the passport id".into()],
+        proof_requirements: vec!["preflight ready after passport".into()],
+        ownership_claim_ids: vec![],
+    }
+}
+
+fn work_item(now: i64) -> WorkItem {
+    WorkItem {
+        work_item_id: "work-passport".into(),
+        mission_id: "mission-passport".into(),
+        lane: WorkLane::Codex,
+        target_provider_or_agent: Some("codex".into()),
+        status: WorkItemStatus::Draft,
+        owner_claim_ids: Vec::new(),
+        workspace_refs: Vec::new(),
+        capability_id: Some("context-passport-proof".into()),
+        risk_level: Risk::Medium,
+        approval_state: ApprovalState::NotRequired,
+        blocking_reason: None,
+        input_refs: vec!["input://approved-context".into()],
+        output_refs: Vec::new(),
+        proof_requirements: vec!["context passport authorizes transfer".into()],
+        proof_receipts: Vec::new(),
+        judgment_memory: judgment(),
+        created_at_ms: now,
+        updated_at_ms: now,
+    }
+}
+
+fn request(mission: Mission, now: i64) -> MissionPreflightRequest {
+    MissionPreflightRequest {
+        conversation: conversation(now),
+        mission,
+        surface_thread: Some(surface(now)),
+        work_item: work_item(now),
+        body_snapshot: None,
+        includes_sensitive_context: true,
+    }
+}
+
+fn passport_spec(items: Vec<PassportItem>, approved_sensitive: bool) -> PassportSpec {
+    PassportSpec {
+        passport_id: "passport-operator-1".into(),
+        mission_id: "mission-passport".into(),
+        work_item_id: None,
+        destination_lane: WorkLane::Codex,
+        destination_target: Some("codex".into()),
+        items,
+        approved_sensitive,
+    }
+}
+
+#[test]
+fn operator_context_passport_ceremony_satisfies_existing_preflight_gate() {
+    let db = Db::open_hub(&temp_db_path("ready")).unwrap();
+    let now = 1_780_000_000_000i64;
+    db.upsert_friday_conversation(&conversation(now)).unwrap();
+    db.upsert_mission(&mission(Vec::new(), now)).unwrap();
+
+    let blocked =
+        preflight_and_stage_work_item(&db, request(mission(Vec::new(), now), now)).unwrap();
+    match blocked {
+        MissionPreflightOutcome::Blocked { blockers, .. } => assert!(blockers
+            .contains(&"context_passport_required_before_sensitive_external_transfer".into())),
+        other => panic!("expected context-passport blocker before ceremony, got {other:?}"),
+    }
+
+    let minted = context_passport::mint(
+        &db,
+        &passport_spec(
+            vec![PassportItem {
+                kind: PassportItemKind::Summary,
+                label: "approved design summary".into(),
+                included: true,
+                sensitive: true,
+            }],
+            true,
+        ),
+        now + 1,
+    )
+    .unwrap();
+    assert_eq!(minted.shared_item_count, 1);
+
+    let stored_mission = db.get_mission("mission-passport").unwrap().unwrap();
+    assert_eq!(
+        stored_mission.context_passport_refs,
+        vec!["passport-operator-1"]
+    );
+    assert!(db
+        .list_mission_links("mission-passport")
+        .unwrap()
+        .iter()
+        .any(|link| link.proof_ref.as_deref() == Some("passport-operator-1")));
+
+    let ready = preflight_and_stage_work_item(&db, request(stored_mission, now + 2)).unwrap();
+    assert!(
+        ready.is_ready(),
+        "operator-minted passport must satisfy the existing preflight gate, got {ready:?}"
+    );
+}
+
+#[test]
+fn operator_context_passport_ceremony_fails_closed_for_unapproved_sensitive_items() {
+    let db = Db::open_hub(&temp_db_path("blocked")).unwrap();
+    let now = 1_780_000_001_000i64;
+    db.upsert_friday_conversation(&conversation(now)).unwrap();
+    db.upsert_mission(&mission(Vec::new(), now)).unwrap();
+
+    let err = context_passport::mint(
+        &db,
+        &passport_spec(
+            vec![PassportItem {
+                kind: PassportItemKind::Summary,
+                label: "sensitive plan".into(),
+                included: true,
+                sensitive: true,
+            }],
+            false,
+        ),
+        now + 1,
+    )
+    .unwrap_err();
+    assert!(
+        err.to_string().contains("context_passport_blocked"),
+        "unapproved sensitive context must fail closed"
+    );
+    assert!(db
+        .get_context_passport("passport-operator-1")
+        .unwrap()
+        .is_none());
+    assert!(db
+        .get_mission("mission-passport")
+        .unwrap()
+        .unwrap()
+        .context_passport_refs
+        .is_empty());
+}
+
+#[test]
+fn operator_context_passport_ceremony_checks_work_item_scope_before_writing() {
+    let db = Db::open_hub(&temp_db_path("missing-work-item")).unwrap();
+    let now = 1_780_000_002_000i64;
+    db.upsert_friday_conversation(&conversation(now)).unwrap();
+    db.upsert_mission(&mission(Vec::new(), now)).unwrap();
+
+    let mut spec = passport_spec(
+        vec![PassportItem {
+            kind: PassportItemKind::Summary,
+            label: "benign summary".into(),
+            included: true,
+            sensitive: false,
+        }],
+        false,
+    );
+    spec.work_item_id = Some("missing-work-item".into());
+
+    let err = context_passport::mint(&db, &spec, now + 1).unwrap_err();
+    assert!(
+        err.to_string().contains("not found"),
+        "missing work-item scope must fail before writing"
+    );
+    assert!(db
+        .get_context_passport("passport-operator-1")
+        .unwrap()
+        .is_none());
+    assert!(db
+        .list_mission_links("mission-passport")
+        .unwrap()
+        .is_empty());
+    assert!(db
+        .get_mission("mission-passport")
+        .unwrap()
+        .unwrap()
+        .context_passport_refs
+        .is_empty());
+}


### PR DESCRIPTION
## Summary
- add an operator-only context passport ceremony to friday-operator-approve
- persist gated ContextPassport rows, bind Mission refs, and record ContextPassport MissionLinks without creating an app/agent mint endpoint
- add behavior tests proving the existing Hub preflight gate is blocked before ceremony and ready after ceremony, plus fail-closed tests for unapproved sensitive items and missing WorkItem scope

## Truth
- operator CLI ceremony only; reads no signing key for passport mint and does not expose Hub/app/agent mint APIs
- does not flip FRIDAY_PASSPORT_MINT, FRIDAY_TRUST_GRANT_ENFORCE, or any live defaults
- scratch/test proof only until operator runs it against intended prod/scratch DB

## Tests
- cargo test --manifest-path rust-core/Cargo.toml -p friday-operator-cli
- cargo test --manifest-path rust-core/Cargo.toml -p friday-hub context_passport -- --nocapture
- cargo fmt --all --manifest-path rust-core/Cargo.toml -- --check
- git diff --check
- detect-secrets-hook --baseline .secrets.baseline rust-core/crates/friday-operator-cli/src/lib.rs rust-core/crates/friday-operator-cli/src/main.rs rust-core/crates/friday-operator-cli/tests/context_passport_ceremony.rs rust-core/crates/friday-operator-cli/tests/cli_roundtrip.rs