### PR TITLE
Add activity mark-done sealed write loop

### DIFF
--- a/apps/friday-ios/Sources/FridayMobileShell/FridayProjectionScreens.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayProjectionScreens.swift
@@ -435,6 +435,7 @@ struct FridayProjectionScreen: View {
           emptyText("No transcript events in this projection.")
         } else {
           ForEach(projection.transcriptEvents.prefix(12)) { event in
+            let doneState = viewModel.activityMarkDoneStates[event.id]
             VStack(alignment: .leading, spacing: 5) {
               HStack {
                 Text(event.sectionTitle)
@@ -446,6 +447,20 @@ struct FridayProjectionScreen: View {
               Text(event.summary)
                 .font(.caption)
                 .foregroundStyle(MobileTheme.textSecondary)
+              HStack(spacing: 8) {
+                RefPill(label: "activity_id", ref: event.id)
+                Spacer()
+                Button {
+                  Task { await viewModel.markActivityDone(activityId: event.id) }
+                } label: {
+                  Image(systemName: "checkmark.circle")
+                    .frame(width: 26, height: 26)
+                }
+                .buttonStyle(.bordered)
+                .disabled(candidateDecisionControlsDisabled(doneState))
+                .accessibilityLabel("Mark activity done")
+              }
+              candidateDecisionStateView(doneState, pendingText: "Marking activity done...")
               if let proofRef = event.proofRef {
                 RefPill(label: "proofRef", ref: proofRef)
               }

--- a/apps/friday-ios/Sources/FridayMobileShellCore/HomeViewModel.swift
+++ b/apps/friday-ios/Sources/FridayMobileShellCore/HomeViewModel.swift
@@ -553,6 +553,7 @@ public final class HomeViewModel: ObservableObject {
   @Published public private(set) var detailState: HomeReadDetailState = .idle
   @Published public private(set) var memoryDecisionStates: [String: HomeLearningDecisionState] = [:]
   @Published public private(set) var runOutcomeLearningDecisionStates: [String: HomeLearningDecisionState] = [:]
+  @Published public private(set) var activityMarkDoneStates: [String: HomeLearningDecisionState] = [:]
   @Published public private(set) var pairingPreflight: MobilePairingPreflight = .empty
   @Published public private(set) var pairingAttempt: MobilePairingAttempt = .idle
 
@@ -660,6 +661,27 @@ public final class HomeViewModel: ObservableObject {
       }
     } catch {
       runOutcomeLearningDecisionStates[candidateId] = .error(reason: Self.reason(for: error))
+    }
+  }
+
+  public func markActivityDone(activityId: String) async {
+    guard let writeClient else {
+      activityMarkDoneStates[activityId] = .error(reason: "Write seam not configured.")
+      return
+    }
+    activityMarkDoneStates[activityId] = .sent
+    do {
+      let result = try await writeClient.submitActivityMarkDone(
+        ActivityMarkDoneRequestWire(activityId: activityId, reason: "owner cleared activity"))
+      if result.status == "done" {
+        activityMarkDoneStates[activityId] = .confirmed(summary: "done · activity_id=\(result.activityId)")
+        await refresh()
+      } else {
+        let why = result.blocker ?? "blocked"
+        activityMarkDoneStates[activityId] = .error(reason: "Activity mark done blocked — \(why)")
+      }
+    } catch {
+      activityMarkDoneStates[activityId] = .error(reason: Self.reason(for: error))
     }
   }
 

--- a/apps/friday-ios/Tests/FridayMobileShellCoreTests/FridayChatViewModelTests.swift
+++ b/apps/friday-ios/Tests/FridayMobileShellCoreTests/FridayChatViewModelTests.swift
@@ -145,6 +145,14 @@ final class FridayChatViewModelTests: XCTestCase {
         blocker: "unused")
     }
 
+    func submitActivityMarkDone(_ request: ActivityMarkDoneRequestWire) async throws -> ActivityMarkDoneResultWire {
+      ActivityMarkDoneResultWire(
+        activityId: request.activityId,
+        state: "unknown",
+        status: "blocked",
+        blocker: "unused")
+    }
+
     func dispatchMissionBoundAgentRun(
       task: String,
       missionContext: MissionWorkItemContextWire,

--- a/apps/friday-ios/Tests/FridayMobileShellCoreTests/HomeViewModelTests.swift
+++ b/apps/friday-ios/Tests/FridayMobileShellCoreTests/HomeViewModelTests.swift
@@ -180,15 +180,26 @@ final class HomeViewModelTests: XCTestCase {
       case result(MemoryDecisionResultWire)
       case fail(Error)
     }
+    enum ActivityScript {
+      case result(ActivityMarkDoneResultWire)
+      case fail(Error)
+    }
 
     let learningScript: LearningScript?
     let memoryScript: MemoryScript?
+    let activityScript: ActivityScript?
     private(set) var memoryRequests: [MemoryDecisionRequestWire] = []
     private(set) var learningRequests: [RunOutcomeLearningDecisionRequestWire] = []
+    private(set) var activityMarkDoneRequests: [ActivityMarkDoneRequestWire] = []
 
-    init(learningScript: LearningScript? = nil, memoryScript: MemoryScript? = nil) {
+    init(
+      learningScript: LearningScript? = nil,
+      memoryScript: MemoryScript? = nil,
+      activityScript: ActivityScript? = nil
+    ) {
       self.learningScript = learningScript
       self.memoryScript = memoryScript
+      self.activityScript = activityScript
     }
 
     func submitMissionIntake(_ request: MissionIntakeRequestWire) async throws -> MissionIntakeResultWire {
@@ -210,6 +221,15 @@ final class HomeViewModelTests: XCTestCase {
       learningRequests.append(request)
       guard let learningScript else { throw NSError(domain: "unused", code: 1) }
       switch learningScript {
+      case .result(let result): return result
+      case .fail(let error): throw error
+      }
+    }
+
+    func submitActivityMarkDone(_ request: ActivityMarkDoneRequestWire) async throws -> ActivityMarkDoneResultWire {
+      activityMarkDoneRequests.append(request)
+      guard let activityScript else { throw NSError(domain: "unused", code: 1) }
+      switch activityScript {
       case .result(let result): return result
       case .fail(let error): throw error
       }
@@ -502,6 +522,41 @@ final class HomeViewModelTests: XCTestCase {
     XCTAssertEqual(
       vm.runOutcomeLearningDecisionStates["learn-1"],
       .error(reason: "Write seam not configured."))
+  }
+
+  func testMarkActivityDoneRendersConfirmedAndRefreshes() async throws {
+    let read = FakeReadClient(.snapshot(try sampleSnapshot()))
+    let write = FakeMissionWriteClient(activityScript: .result(
+      ActivityMarkDoneResultWire(activityId: "activity-1", state: "done", status: "done")))
+    let vm = HomeViewModel(client: read, writeClient: write)
+
+    await vm.markActivityDone(activityId: "activity-1")
+
+    XCTAssertEqual(write.activityMarkDoneRequests, [
+      ActivityMarkDoneRequestWire(activityId: "activity-1", reason: "owner cleared activity"),
+    ])
+    XCTAssertEqual(read.fetchWorkbenchCount, 1)
+    XCTAssertEqual(
+      vm.activityMarkDoneStates["activity-1"],
+      .confirmed(summary: "done · activity_id=activity-1"))
+  }
+
+  func testMarkActivityDoneBlockedRendersErrorNotConfirmed() async throws {
+    let read = FakeReadClient(.snapshot(try sampleSnapshot()))
+    let write = FakeMissionWriteClient(activityScript: .result(
+      ActivityMarkDoneResultWire(
+        activityId: "missing-activity",
+        state: "unknown",
+        status: "blocked",
+        blocker: "unknown_activity")))
+    let vm = HomeViewModel(client: read, writeClient: write)
+
+    await vm.markActivityDone(activityId: "missing-activity")
+
+    XCTAssertEqual(read.fetchWorkbenchCount, 0)
+    XCTAssertEqual(
+      vm.activityMarkDoneStates["missing-activity"],
+      .error(reason: "Activity mark done blocked — unknown_activity"))
   }
 
   func testDecideMemoryConfirmRendersConfirmedAndRefreshes() async throws {

--- a/apps/macos/FridayHubConsole/Sources/FridayHubConsole/DesktopChatScreen.swift
+++ b/apps/macos/FridayHubConsole/Sources/FridayHubConsole/DesktopChatScreen.swift
@@ -384,6 +384,19 @@ struct DesktopChatScreen: View {
           Text("Approval remains operator-signature gated; this surface relays an external signer blob and does not mint a signature.")
             .font(.system(size: 10))
             .foregroundStyle(HubTheme.textSecondary)
+        } else {
+          HStack(spacing: 8) {
+            Button {
+              Task { await viewModel.markNeedsMeItemDone(item) }
+            } label: {
+              Label("Done", systemImage: "checkmark.circle")
+            }
+            .buttonStyle(.bordered)
+            .disabled(activityMarkDoneState(for: item).isSent || activityMarkDoneState(for: item).isTerminal)
+            .accessibilityLabel("Mark Needs Review row done")
+            .accessibilityIdentifier("friday.desktop.chat.markDone.\(item.refId)")
+            activityMarkDoneStatus(for: item)
+          }
         }
       }
       .padding(.vertical, 6)
@@ -396,9 +409,33 @@ struct DesktopChatScreen: View {
     viewModel.approvalRelayStates[item.id] ?? .ready
   }
 
+  private func activityMarkDoneState(for item: ChatNeedsMeItem) -> WriteActionState {
+    viewModel.activityMarkDoneStates[item.id] ?? .ready
+  }
+
   @ViewBuilder
   private func approvalRelayStatus(for item: ChatNeedsMeItem) -> some View {
     switch approvalRelayState(for: item) {
+    case .ready:
+      EmptyView()
+    case .sent:
+      ProgressView().scaleEffect(0.7)
+    case let .confirmed(summary, _, _):
+      Text(summary)
+        .font(.system(size: 10))
+        .foregroundStyle(HubTheme.textSecondary)
+        .lineLimit(2)
+    case let .error(reason):
+      Text(reason)
+        .font(.system(size: 10))
+        .foregroundStyle(HubTheme.textSecondary)
+        .lineLimit(2)
+    }
+  }
+
+  @ViewBuilder
+  private func activityMarkDoneStatus(for item: ChatNeedsMeItem) -> some View {
+    switch activityMarkDoneState(for: item) {
     case .ready:
       EmptyView()
     case .sent:

--- a/apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/OperationsOverviewViewModel.swift
+++ b/apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/OperationsOverviewViewModel.swift
@@ -285,6 +285,8 @@ public final class OperationsOverviewViewModel: ObservableObject {
   @Published public private(set) var runOutcomeLearningDecisionStates: [String: WriteActionState] = [:]
   /// Per pending approval resume state, keyed by the Needs-Me item id.
   @Published public private(set) var approvalRelayStates: [String: WriteActionState] = [:]
+  /// Per Activity / Needs-Me mark-done state, keyed by the Needs-Me item id.
+  @Published public private(set) var activityMarkDoneStates: [String: WriteActionState] = [:]
   /// Structured refs for the latest desktop Chat turn. This avoids parsing status prose in the UI.
   @Published public private(set) var latestChatTurn: ChatTurnRefs?
   /// Refs-only Needs-Me rows for the latest Chat turn's runs.
@@ -585,6 +587,31 @@ public final class OperationsOverviewViewModel: ObservableObject {
       }
     } catch {
       approvalRelayStates[key] = .error(reason: Self.writeReason(for: error))
+    }
+  }
+
+  /// Mark one existing Activity / Needs-Me row done. This is a refs-only owner action; it never
+  /// completes a WorkItem or mints proof.
+  public func markNeedsMeItemDone(_ item: ChatNeedsMeItem) async {
+    let key = item.id
+    guard let writeClient else {
+      activityMarkDoneStates[key] = .error(reason: "Write seam not configured.")
+      return
+    }
+    activityMarkDoneStates[key] = .sent
+    do {
+      let result = try await writeClient.submitActivityMarkDone(
+        ActivityMarkDoneRequestWire(activityId: item.refId, reason: "owner cleared needs-me row"))
+      if result.status == "done" {
+        activityMarkDoneStates[key] = .confirmed(summary: "done · activity_id=\(result.activityId)")
+        await refresh()
+        await loadLatestChatReview()
+      } else {
+        let why = result.blocker ?? "blocked"
+        activityMarkDoneStates[key] = .error(reason: "Activity mark done blocked — \(why)")
+      }
+    } catch {
+      activityMarkDoneStates[key] = .error(reason: Self.writeReason(for: error))
     }
   }
 

--- a/apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/RealWriteClientFactory.swift
+++ b/apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/RealWriteClientFactory.swift
@@ -147,6 +147,9 @@ struct HonestlyUnavailableWriteClient: FridayMissionSpineWriteClient, FridayMiss
   ) async throws -> RunOutcomeLearningDecisionResultWire {
     throw FridayWriteClientError.transport("live write client unavailable: \(reason)")
   }
+  func submitActivityMarkDone(_ request: ActivityMarkDoneRequestWire) async throws -> ActivityMarkDoneResultWire {
+    throw FridayWriteClientError.transport("live write client unavailable: \(reason)")
+  }
   func dispatchMissionBoundAgentRun(
     task: String,
     missionContext: MissionWorkItemContextWire,

--- a/apps/macos/FridayHubConsole/Tests/FridayHubConsoleCoreTests/OperationsOverviewViewModelTests.swift
+++ b/apps/macos/FridayHubConsole/Tests/FridayHubConsoleCoreTests/OperationsOverviewViewModelTests.swift
@@ -383,6 +383,8 @@ final class MockMissionSpineWriteClient: FridayMissionSpineWriteClient, FridayMi
     case memoryBlocked
     case learningConfirmed
     case learningBlocked
+    case activityDone
+    case activityBlocked
     case throwsTransport
   }
   let behavior: Behavior
@@ -390,6 +392,7 @@ final class MockMissionSpineWriteClient: FridayMissionSpineWriteClient, FridayMi
   private var _lastIntake: MissionIntakeRequestWire?
   private var _lastDecision: MemoryDecisionRequestWire?
   private var _lastLearningDecision: RunOutcomeLearningDecisionRequestWire?
+  private var _lastActivityMarkDone: ActivityMarkDoneRequestWire?
   private var _lastMissionContext: MissionWorkItemContextWire?
   private var _lastMissionRunConstraints: AgentRunConstraintsWire?
   private var _lastResumeRunId: String?
@@ -405,6 +408,7 @@ final class MockMissionSpineWriteClient: FridayMissionSpineWriteClient, FridayMi
   var lastLearningDecision: RunOutcomeLearningDecisionRequestWire? {
     lock.withLock { _lastLearningDecision }
   }
+  var lastActivityMarkDone: ActivityMarkDoneRequestWire? { lock.withLock { _lastActivityMarkDone } }
   var lastMissionContext: MissionWorkItemContextWire? { lock.withLock { _lastMissionContext } }
   var lastMissionRunConstraints: AgentRunConstraintsWire? { lock.withLock { _lastMissionRunConstraints } }
   var lastResumeRunId: String? { lock.withLock { _lastResumeRunId } }
@@ -477,6 +481,20 @@ final class MockMissionSpineWriteClient: FridayMissionSpineWriteClient, FridayMi
         kind: "preference",
         state: request.decision == "confirm" ? "confirmed" : "rejected",
         status: request.decision == "confirm" ? "confirmed" : "rejected")
+    }
+  }
+
+  func submitActivityMarkDone(_ request: ActivityMarkDoneRequestWire) async throws -> ActivityMarkDoneResultWire {
+    lock.withLock { _lastActivityMarkDone = request }
+    switch behavior {
+    case .throwsTransport:
+      throw FridayWriteClientError.transport("connection refused (write server dark)")
+    case .activityBlocked:
+      return ActivityMarkDoneResultWire(
+        activityId: request.activityId, state: "unknown", status: "blocked",
+        blocker: "unknown_activity")
+    default:
+      return ActivityMarkDoneResultWire(activityId: request.activityId, state: "done", status: "done")
     }
   }
 
@@ -1124,6 +1142,34 @@ func approveNeedsMeItemWithoutSignerFailsClosedWithoutResume() async {
   }
   #expect(reason.contains("not configured"))
   #expect(write.lastResumeRunId == nil)
+}
+
+@Test
+@MainActor
+func markNeedsMeItemDoneUsesRefIdAndRefreshesReview() async {
+  let write = MockMissionSpineWriteClient(behavior: .activityDone)
+  let item = ChatNeedsMeItem(
+    runId: "run-review",
+    kind: "review",
+    title: "review ready",
+    refId: "activity-review-1",
+    state: "pending",
+    deepLink: "friday://activity/activity-review-1")
+  let vm = OperationsOverviewViewModel(
+    client: MockReadClient(behavior: .loaded),
+    writeClient: write)
+
+  await vm.markNeedsMeItemDone(item)
+
+  #expect(write.lastActivityMarkDone == ActivityMarkDoneRequestWire(
+    activityId: "activity-review-1",
+    reason: "owner cleared needs-me row"))
+  guard case let .confirmed(summary, _, _) = vm.activityMarkDoneStates[item.id] else {
+    Issue.record("expected activity mark-done .confirmed, got \(String(describing: vm.activityMarkDoneStates[item.id]))")
+    return
+  }
+  #expect(summary.contains("done"))
+  #expect(summary.contains("activity-review-1"))
 }
 
 @Test

--- a/apps/macos/FridayRustClient/Sources/FridayRustClient/PairingClient.swift
+++ b/apps/macos/FridayRustClient/Sources/FridayRustClient/PairingClient.swift
@@ -162,6 +162,8 @@ private func pairingKind(_ message: FridayMessage) -> String {
   case .memoryDecisionResult: return "MemoryDecisionResult"
   case .runOutcomeLearningDecisionRequest: return "RunOutcomeLearningDecisionRequest"
   case .runOutcomeLearningDecisionResult: return "RunOutcomeLearningDecisionResult"
+  case .activityMarkDoneRequest: return "ActivityMarkDoneRequest"
+  case .activityMarkDoneResult: return "ActivityMarkDoneResult"
   case .runAnswerBodyRequest: return "RunAnswerBodyRequest"
   case .runAnswerBodySnapshot: return "RunAnswerBodySnapshot"
   }

--- a/apps/macos/FridayRustClient/Sources/FridayRustClient/Protocol.swift
+++ b/apps/macos/FridayRustClient/Sources/FridayRustClient/Protocol.swift
@@ -12,7 +12,7 @@ import Foundation
 
 /// Inclusive supported schema-version range / current version. Mirrors
 /// `friday_protocol::CURRENT_SCHEMA_VERSION`. Kept in step with the read-seam branch.
-public let fridayCurrentSchemaVersion: UInt16 = 13
+public let fridayCurrentSchemaVersion: UInt16 = 16
 
 // MARK: - ErrorCode
 
@@ -534,6 +534,10 @@ public enum FridayMessage: Equatable {
   /// hub→trusted-peer: A1 run-outcome learning decision receipt (refs-only). Mirrors
   /// `friday_protocol::Message::RunOutcomeLearningDecisionResult`.
   case runOutcomeLearningDecisionResult(RunOutcomeLearningDecisionResultWire)
+  /// trusted-peer→hub: mark ONE existing Activity / Needs-Me row done. Refs-only owner action.
+  case activityMarkDoneRequest(ActivityMarkDoneRequestWire)
+  /// hub→trusted-peer: refs-only receipt for Activity / Needs-Me mark-done.
+  case activityMarkDoneResult(ActivityMarkDoneResultWire)
   /// client→read-server: owner-gated run answer body readback. Kept separate from
   /// RunReadback so refs-only projections stay refs-only.
   case runAnswerBodyRequest(RunAnswerBodyRequestWire)
@@ -760,6 +764,12 @@ extension FridayMessage: Codable {
       let c = try decoder.container(keyedBy: ResultKey.self)
       self = .runOutcomeLearningDecisionResult(
         try c.decode(RunOutcomeLearningDecisionResultWire.self, forKey: .result))
+    case "ActivityMarkDoneRequest":
+      let c = try decoder.container(keyedBy: RequestKey.self)
+      self = .activityMarkDoneRequest(try c.decode(ActivityMarkDoneRequestWire.self, forKey: .request))
+    case "ActivityMarkDoneResult":
+      let c = try decoder.container(keyedBy: ResultKey.self)
+      self = .activityMarkDoneResult(try c.decode(ActivityMarkDoneResultWire.self, forKey: .result))
     case "RunAnswerBodyRequest":
       let c = try decoder.container(keyedBy: RequestKey.self)
       self = .runAnswerBodyRequest(try c.decode(RunAnswerBodyRequestWire.self, forKey: .request))
@@ -962,6 +972,14 @@ extension FridayMessage: Codable {
       try c.encode(r, forKey: .request)
     case .runOutcomeLearningDecisionResult(let r):
       try tag.encode("RunOutcomeLearningDecisionResult", forKey: .kind)
+      var c = encoder.container(keyedBy: ResultKey.self)
+      try c.encode(r, forKey: .result)
+    case .activityMarkDoneRequest(let r):
+      try tag.encode("ActivityMarkDoneRequest", forKey: .kind)
+      var c = encoder.container(keyedBy: RequestKey.self)
+      try c.encode(r, forKey: .request)
+    case .activityMarkDoneResult(let r):
+      try tag.encode("ActivityMarkDoneResult", forKey: .kind)
       var c = encoder.container(keyedBy: ResultKey.self)
       try c.encode(r, forKey: .result)
     case .runAnswerBodyRequest(let r):

--- a/apps/macos/FridayRustClient/Sources/FridayRustClient/ReadClient.swift
+++ b/apps/macos/FridayRustClient/Sources/FridayRustClient/ReadClient.swift
@@ -254,6 +254,10 @@ public final class SealedWSReadClient: FridayRustReadClient, @unchecked Sendable
       throw FridayReadClientError.unexpectedResponse(kind: "RunOutcomeLearningDecisionRequest")
     case .runOutcomeLearningDecisionResult:
       throw FridayReadClientError.unexpectedResponse(kind: "RunOutcomeLearningDecisionResult")
+    case .activityMarkDoneRequest:
+      throw FridayReadClientError.unexpectedResponse(kind: "ActivityMarkDoneRequest")
+    case .activityMarkDoneResult:
+      throw FridayReadClientError.unexpectedResponse(kind: "ActivityMarkDoneResult")
     case .runAnswerBodyRequest:
       throw FridayReadClientError.unexpectedResponse(kind: "RunAnswerBodyRequest")
     case .runAnswerBodySnapshot:
@@ -367,6 +371,10 @@ public final class SealedWSReadClient: FridayRustReadClient, @unchecked Sendable
       throw FridayReadClientError.unexpectedResponse(kind: "RunOutcomeLearningDecisionRequest")
     case .runOutcomeLearningDecisionResult:
       throw FridayReadClientError.unexpectedResponse(kind: "RunOutcomeLearningDecisionResult")
+    case .activityMarkDoneRequest:
+      throw FridayReadClientError.unexpectedResponse(kind: "ActivityMarkDoneRequest")
+    case .activityMarkDoneResult:
+      throw FridayReadClientError.unexpectedResponse(kind: "ActivityMarkDoneResult")
     case .runReadbackRequest:
       throw FridayReadClientError.unexpectedResponse(kind: "RunReadbackRequest")
     case .runReadbackSnapshot:

--- a/apps/macos/FridayRustClient/Sources/FridayRustClient/WriteClient.swift
+++ b/apps/macos/FridayRustClient/Sources/FridayRustClient/WriteClient.swift
@@ -179,6 +179,8 @@ public protocol FridayMissionSpineWriteClient: Sendable {
   func submitRunOutcomeLearningDecision(
     _ request: RunOutcomeLearningDecisionRequestWire
   ) async throws -> RunOutcomeLearningDecisionResultWire
+  /// Mark one existing Activity / Needs-Me row done. This is refs-only and never completes a WorkItem.
+  func submitActivityMarkDone(_ request: ActivityMarkDoneRequestWire) async throws -> ActivityMarkDoneResultWire
 }
 
 /// Product-facing bridge for MissionIntakeResult -> mission-bound AgentRunRequest. This is the
@@ -351,7 +353,8 @@ public final class SealedWSWriteClient: FridayRustWriteClient, FridayMissionSpin
          .activityNeedsMeRequest, .activityNeedsMeSnapshot,
          .missionIntakeRequest, .missionIntakeResult,
          .memoryDecisionRequest, .memoryDecisionResult,
-         .runOutcomeLearningDecisionRequest, .runOutcomeLearningDecisionResult:
+         .runOutcomeLearningDecisionRequest, .runOutcomeLearningDecisionResult,
+         .activityMarkDoneRequest, .activityMarkDoneResult:
       throw FridayWriteClientError.unexpectedResponse(kind: dispatchKind(message))
     case .unsupported(let kind):
       throw FridayWriteClientError.unexpectedResponse(kind: kind)
@@ -441,6 +444,33 @@ public final class SealedWSWriteClient: FridayRustWriteClient, FridayMissionSpin
     let resp = try openEnvelope(respBody, sessionKey: sessionKey)
     switch resp.message {
     case .runOutcomeLearningDecisionResult(let r):
+      return r
+    case .error(let code, let message):
+      throw FridayWriteClientError.serverError(code: code, message: message)
+    default:
+      throw FridayWriteClientError.unexpectedResponse(kind: dispatchKind(resp.message))
+    }
+  }
+
+  /// Mark ONE existing Activity / Needs-Me row done over the sealed WRITE session. This is a
+  /// refs-only owner action; a `status:"blocked"` result is returned to the caller as truth.
+  public func submitActivityMarkDone(_ request: ActivityMarkDoneRequestWire) async throws -> ActivityMarkDoneResultWire {
+    let transport = try makeTransport()
+    let (sessionKey, _) = try handshake(transport)
+    let msgId = "activity-mark-done-\(request.activityId)"
+    let env = FridayEnvelope(msgId: msgId, sentAt: now(), message: .activityMarkDoneRequest(request))
+      .withCorrelation(msgId)
+    try transport.sendMessage(try sealEnvelope(env, sessionKey: sessionKey))
+    let respBody: [UInt8]
+    do {
+      respBody = try transport.recvMessage()
+    } catch {
+      throw FridayWriteClientError.transport(
+        "no activity-mark-done result (session ended fail-closed): \(error)")
+    }
+    let resp = try openEnvelope(respBody, sessionKey: sessionKey)
+    switch resp.message {
+    case .activityMarkDoneResult(let r):
       return r
     case .error(let code, let message):
       throw FridayWriteClientError.serverError(code: code, message: message)
@@ -665,6 +695,8 @@ private func dispatchKind(_ message: FridayMessage) -> String {
   case .memoryDecisionResult: return "MemoryDecisionResult"
   case .runOutcomeLearningDecisionRequest: return "RunOutcomeLearningDecisionRequest"
   case .runOutcomeLearningDecisionResult: return "RunOutcomeLearningDecisionResult"
+  case .activityMarkDoneRequest: return "ActivityMarkDoneRequest"
+  case .activityMarkDoneResult: return "ActivityMarkDoneResult"
   case .unsupported(let kind): return kind
   }
 }

--- a/apps/macos/FridayRustClient/Sources/FridayRustClient/WriteProtocol.swift
+++ b/apps/macos/FridayRustClient/Sources/FridayRustClient/WriteProtocol.swift
@@ -173,6 +173,45 @@ public struct RunOutcomeLearningDecisionResultWire: Codable, Equatable, Sendable
   }
 }
 
+/// Client→hub Activity / Needs-Me mark-done request. Mirrors
+/// `friday_protocol::ActivityMarkDoneRequestWire`. Refs-only over an existing activity row; this
+/// never carries transcript/body material and never completes a WorkItem.
+public struct ActivityMarkDoneRequestWire: Codable, Equatable, Sendable {
+  public var activityId: String
+  public var reason: String?
+
+  public init(activityId: String, reason: String? = nil) {
+    self.activityId = activityId
+    self.reason = reason
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case activityId = "activity_id"
+    case reason
+  }
+}
+
+/// Hub→client Activity / Needs-Me mark-done receipt. Refs-only: id, resulting state, status, and
+/// optional blocker.
+public struct ActivityMarkDoneResultWire: Codable, Equatable, Sendable {
+  public var activityId: String
+  public var state: String
+  public var status: String
+  public var blocker: String?
+
+  public init(activityId: String, state: String, status: String, blocker: String? = nil) {
+    self.activityId = activityId
+    self.state = state
+    self.status = status
+    self.blocker = blocker
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case activityId = "activity_id"
+    case state, status, blocker
+  }
+}
+
 /// Client→read-server owner-gated answer-body request. This is a READ-seam message, but the shared
 /// wire types live beside the other protocol structs so `FridayMessage` can encode/decode it.
 public struct RunAnswerBodyRequestWire: Codable, Equatable, Sendable {

--- a/apps/macos/FridayRustClient/Tests/FridayRustClientTests/MissionSpineWriteKATTests.swift
+++ b/apps/macos/FridayRustClient/Tests/FridayRustClientTests/MissionSpineWriteKATTests.swift
@@ -295,4 +295,38 @@ final class MissionSpineWriteKATTests: XCTestCase {
     XCTAssertTrue(json.contains("\"result\":{"))
     XCTAssertTrue(json.contains("\"blocker\":\"unknown_candidate\""))
   }
+
+  // MARK: MS7 — ActivityMarkDone wire shape (nested + refs-only)
+
+  func testMS7_activityMarkDoneRequestNestedShapeRefsOnly() throws {
+    let req = ActivityMarkDoneRequestWire(activityId: "activity-1", reason: "owner cleared row")
+    let env = FridayEnvelope(msgId: "activity-done", sentAt: 1000, message: .activityMarkDoneRequest(req))
+    let json = String(decoding: try env.encodeJSON(), as: UTF8.self)
+
+    XCTAssertTrue(json.contains("\"kind\":\"ActivityMarkDoneRequest\""))
+    XCTAssertTrue(json.contains("\"request\":{"))
+    XCTAssertTrue(json.contains("\"activity_id\":\"activity-1\""))
+    XCTAssertFalse(json.contains("auth_proof"))
+    XCTAssertFalse(json.contains("transcript"))
+    XCTAssertFalse(json.contains("body"))
+
+    let messageObj = try messageObject(json)
+    XCTAssertEqual(Set(messageObj.keys), ["kind", "request"])
+    let request = try XCTUnwrap(messageObj["request"] as? [String: Any])
+    XCTAssertEqual(Set(request.keys), ["activity_id", "reason"])
+    XCTAssertEqual(try FridayEnvelope.decodeJSON(Data(json.utf8)).message, .activityMarkDoneRequest(req))
+  }
+
+  func testMS7_activityMarkDoneResultBlockedCarriesBlocker() throws {
+    let blocked = ActivityMarkDoneResultWire(
+      activityId: "missing-activity",
+      state: "unknown",
+      status: "blocked",
+      blocker: "unknown_activity")
+    let env = FridayEnvelope(msgId: "activity-result", sentAt: 1, message: .activityMarkDoneResult(blocked))
+    XCTAssertEqual(try FridayEnvelope.decodeJSON(try env.encodeJSON()).message, .activityMarkDoneResult(blocked))
+    let json = String(decoding: try env.encodeJSON(), as: UTF8.self)
+    XCTAssertTrue(json.contains("\"result\":{"))
+    XCTAssertTrue(json.contains("\"blocker\":\"unknown_activity\""))
+  }
 }

--- a/apps/macos/FridayRustClient/Tests/FridayRustClientTests/MissionSpineWriteWiringTests.swift
+++ b/apps/macos/FridayRustClient/Tests/FridayRustClientTests/MissionSpineWriteWiringTests.swift
@@ -2,7 +2,8 @@ import XCTest
 @testable import FridayRustClient
 
 /// **Tier-2 mission-spine-write wiring tests** — drive `SealedWSWriteClient.submitMissionIntake` +
-/// `submitMemoryDecision` + `submitRunOutcomeLearningDecision` end-to-end over an IN-MEMORY transport that emulates the Rust
+/// `submitMemoryDecision` + `submitRunOutcomeLearningDecision` + `submitActivityMarkDone`
+/// end-to-end over an IN-MEMORY transport that emulates the Rust
 /// `hub_agent_run_server`'s mission-spine arms: the cleartext preamble (server pubkey + 64-byte
 /// nonce), the SEALED session (the channel auth — NO per-request `auth_proof` for these messages),
 /// and a `MissionIntakeResult` / `MemoryDecisionResult` reply.
@@ -23,6 +24,8 @@ final class MissionSpineWriteWiringTests: XCTestCase {
     case memoryBlocked         // the synthetic-candidate-id reality today
     case learningConfirmed
     case learningBlocked
+    case activityDone
+    case activityBlocked
     case serverError           // a typed Error frame
   }
 
@@ -43,6 +46,7 @@ final class MissionSpineWriteWiringTests: XCTestCase {
     private(set) var receivedIntake: MissionIntakeRequestWire?
     private(set) var receivedDecision: MemoryDecisionRequestWire?
     private(set) var receivedLearningDecision: RunOutcomeLearningDecisionRequestWire?
+    private(set) var receivedActivityMarkDone: ActivityMarkDoneRequestWire?
     /// Proves the inbound message object carried NO `auth_proof` (sealed session is the channel auth).
     private(set) var sawAuthProof = false
 
@@ -140,6 +144,19 @@ final class MissionSpineWriteWiringTests: XCTestCase {
             kind: "preference",
             state: req.decision == "confirm" ? "confirmed" : "rejected",
             status: req.decision == "confirm" ? "confirmed" : "rejected"))
+        }
+      case .activityMarkDoneRequest(let req):
+        receivedActivityMarkDone = req
+        switch mode {
+        case .serverError:
+          reply = .error(code: .internal, message: "activity mark done failed")
+        case .activityBlocked:
+          reply = .activityMarkDoneResult(ActivityMarkDoneResultWire(
+            activityId: req.activityId, state: "unknown", status: "blocked",
+            blocker: "unknown_activity"))
+        default:
+          reply = .activityMarkDoneResult(ActivityMarkDoneResultWire(
+            activityId: req.activityId, state: "done", status: "done"))
         }
       default:
         throw FridayWriteClientError.transport("unexpected inbound on the spine session: \(env.msgId)")
@@ -289,6 +306,37 @@ final class MissionSpineWriteWiringTests: XCTestCase {
     do {
       _ = try await client.submitRunOutcomeLearningDecision(
         RunOutcomeLearningDecisionRequestWire(candidateId: "a1:run-a1:preference", decision: "confirm"))
+      XCTFail("a typed Error frame must throw")
+    } catch let err as FridayWriteClientError {
+      guard case .serverError = err else { return XCTFail("expected serverError, got \(err)") }
+    }
+  }
+
+  // MARK: submitActivityMarkDone
+
+  func testSubmitActivityMarkDone_returnsDoneNoAuthProof() async throws {
+    let (client, transport) = try makeClient(mode: .activityDone)
+    let result = try await client.submitActivityMarkDone(
+      ActivityMarkDoneRequestWire(activityId: "activity-1", reason: "owner cleared row"))
+    XCTAssertEqual(result.activityId, "activity-1")
+    XCTAssertEqual(result.status, "done")
+    XCTAssertEqual(result.state, "done")
+    XCTAssertEqual(transport.receivedActivityMarkDone?.activityId, "activity-1")
+    XCTAssertEqual(transport.receivedActivityMarkDone?.reason, "owner cleared row")
+    XCTAssertFalse(transport.sawAuthProof, "the activity mark-done request must carry NO auth_proof")
+  }
+
+  func testSubmitActivityMarkDone_blocked_isAReturnedReceiptNotAThrow() async throws {
+    let (client, _) = try makeClient(mode: .activityBlocked)
+    let result = try await client.submitActivityMarkDone(ActivityMarkDoneRequestWire(activityId: "missing-activity"))
+    XCTAssertEqual(result.status, "blocked")
+    XCTAssertEqual(result.blocker, "unknown_activity")
+  }
+
+  func testSubmitActivityMarkDone_serverError_throwsServerError() async throws {
+    let (client, _) = try makeClient(mode: .serverError)
+    do {
+      _ = try await client.submitActivityMarkDone(ActivityMarkDoneRequestWire(activityId: "activity-1"))
       XCTFail("a typed Error frame must throw")
     } catch let err as FridayWriteClientError {
       guard case .serverError = err else { return XCTFail("expected serverError, got \(err)") }

--- a/docs/ops/prod-flags-manifest.json
+++ b/docs/ops/prod-flags-manifest.json
@@ -83,6 +83,19 @@
       "notes": "This is the governance leg for A1 run-outcome learning. The mapped dispatch test seeds one pending owner-owned run-outcome candidate, sends the live sealed-message request shape through the flag-on server dispatch arm, and asserts the row transitions to Confirmed. Sibling proofs cover exact-'1' flag parsing and flag-off keepalive byte-identical behavior. Truth boundary: this enables product confirmation of candidates; A1 live-done still requires an operator-origin organic turn to feed a candidate and a real confirm decision."
     },
     {
+      "flag": "FRIDAY_ACTIVITY_MARK_DONE",
+      "process": "rust-ws-wrapper",
+      "prod_state": "dark",
+      "closes_loop": "An owner-authed ActivityMarkDoneRequest marks one existing Activity / Needs-Me row done, without completing a WorkItem, minting proof, or calling a provider/model.",
+      "coverage": "loop-e2e",
+      "e2e_test": "rust-core/crates/friday-hub/src/hub_server.rs::activity_mark_done_marks_only_activity_row_done",
+      "additional_e2e_tests": [
+        "rust-core/crates/friday-hub/src/bin/hub_agent_run_server.rs::activity_mark_done_flag_is_default_off_and_fail_closed",
+        "rust-core/crates/friday-protocol/src/lib.rs::activity_mark_done_wire_is_refs_only_and_round_trips"
+      ],
+      "notes": "Default-OFF product action for clearing Activity / Needs-Me rows from mobile/desktop surfaces. The mapped test drives the shared DB result producer and asserts only activity_item.state becomes done: no WorkItem completion, no proof receipt, no token_ledger row. The protocol proof pins the refs-only nested request/result shape. The serve-bin matcher proof pins exact-'1' opt-in and default-off fail-closed behavior; with the flag OFF, the sealed request is a benign keepalive echo."
+    },
+    {
       "flag": "FRIDAY_A1_RUN_OUTCOME_LEARNING_RECALL",
       "process": "rust-ws-wrapper",
       "prod_state": "dark",

--- a/rust-core/crates/friday-ffi/src/lib.rs
+++ b/rust-core/crates/friday-ffi/src/lib.rs
@@ -1992,6 +1992,10 @@ fn message_kind_name(m: &friday_protocol::Message) -> &'static str {
         M::RunFileViewSnapshot { .. } => "RunFileViewSnapshot",
         M::ActivityNeedsMeRequest { .. } => "ActivityNeedsMeRequest",
         M::ActivityNeedsMeSnapshot { .. } => "ActivityNeedsMeSnapshot",
+        // Activity mark-done rides the sealed-WS write surface, not FFI. Keep it named so
+        // unsupported out-of-slice envelopes carry their real truth label.
+        M::ActivityMarkDoneRequest { .. } => "ActivityMarkDoneRequest",
+        M::ActivityMarkDoneResult { .. } => "ActivityMarkDoneResult",
         // WS-transport substrate (S-A..S-F) message kinds. Still DARK on the FFI
         // surface (nothing here constructs or dispatches them), but they are
         // NAMED so the truth label carries the real kind — and so this match

--- a/rust-core/crates/friday-hub/src/bin/hub_agent_run_server.rs
+++ b/rust-core/crates/friday-hub/src/bin/hub_agent_run_server.rs
@@ -525,6 +525,18 @@ fn run() -> Result<(), ServerError> {
         );
     }
 
+    let activity_mark_done_enabled =
+        activity_mark_done_enabled_from(env::var(ACTIVITY_MARK_DONE_ENABLED_ENV).ok().as_deref());
+    if activity_mark_done_enabled {
+        eprintln!(
+            "hub_agent_run_server: ACTIVITY-MARK-DONE ingress ENABLED (FRIDAY_ACTIVITY_MARK_DONE) — an inbound owner-authed ActivityMarkDoneRequest marks one existing activity_item done (no model call)"
+        );
+    } else {
+        eprintln!(
+            "hub_agent_run_server: ACTIVITY-MARK-DONE ingress DISABLED (set FRIDAY_ACTIVITY_MARK_DONE=1 to enable) — an ActivityMarkDoneRequest is a benign keepalive echo"
+        );
+    }
+
     // (C1/C2 §3) Read the PROVIDER-WORKSPACE-DISPATCH flag ONCE at boot (default-off). It gates the
     // serve-bin's `ProviderWorkspaceActionRequest` arm: when false the dispatch arm NEVER handles a
     // `ProviderWorkspaceActionRequest` — it falls through to the EXISTING catch-all keepalive echo
@@ -753,6 +765,12 @@ fn memory_confirm_enabled_from(raw: Option<&str>) -> bool {
 const RUN_OUTCOME_LEARNING_CONFIRM_ENABLED_ENV: &str = "FRIDAY_RUN_OUTCOME_LEARNING_CONFIRM";
 
 fn run_outcome_learning_confirm_enabled_from(raw: Option<&str>) -> bool {
+    matches!(raw.map(str::trim), Some("1"))
+}
+
+const ACTIVITY_MARK_DONE_ENABLED_ENV: &str = "FRIDAY_ACTIVITY_MARK_DONE";
+
+fn activity_mark_done_enabled_from(raw: Option<&str>) -> bool {
     matches!(raw.map(str::trim), Some("1"))
 }
 
@@ -1329,6 +1347,8 @@ fn serve_sealed_session<S: Read + Write, T: Transport>(
     provider_workspace_dispatch_enabled: bool,
 ) -> Result<usize, TransportError> {
     let mut processed = 0usize;
+    let activity_mark_done_enabled =
+        activity_mark_done_enabled_from(env::var(ACTIVITY_MARK_DONE_ENABLED_ENV).ok().as_deref());
     // S-E: per-session msg_id dedup. A reconnect mints a FRESH tracker (so it is not a
     // cross-connection store) — combined with the per-handshake nonce, a captured envelope is
     // useless both within a session (dedup) and across handshakes (nonce).
@@ -2027,6 +2047,21 @@ fn serve_sealed_session<S: Read + Write, T: Transport>(
                 );
                 eprintln!(
                     "hub_agent_run_server_dispatch: msg_id={} leg=run_outcome_learning_decision (run-outcome-learning confirm enabled)",
+                    env.msg_id
+                );
+                ws_send_envelope(ws, session_key, &result, SESSION_AAD)?;
+                processed += 1;
+            }
+            Message::ActivityMarkDoneRequest { request } if activity_mark_done_enabled => {
+                let now_ms = now_ms();
+                let result = friday_hub::hub_server::activity_mark_done_result_for_db(
+                    runtime.db(),
+                    &env.msg_id,
+                    request,
+                    now_ms,
+                );
+                eprintln!(
+                    "hub_agent_run_server_dispatch: msg_id={} leg=activity_mark_done (activity-mark-done enabled)",
                     env.msg_id
                 );
                 ws_send_envelope(ws, session_key, &result, SESSION_AAD)?;
@@ -4327,6 +4362,17 @@ mod tests {
         assert!(!run_outcome_learning_confirm_enabled_from(Some("true")));
         assert!(run_outcome_learning_confirm_enabled_from(Some("1")));
         assert!(run_outcome_learning_confirm_enabled_from(Some(" 1 ")));
+    }
+
+    #[test]
+    fn activity_mark_done_flag_is_default_off_and_fail_closed() {
+        assert!(!activity_mark_done_enabled_from(None));
+        assert!(!activity_mark_done_enabled_from(Some("")));
+        assert!(!activity_mark_done_enabled_from(Some("0")));
+        assert!(!activity_mark_done_enabled_from(Some("true")));
+        assert!(!activity_mark_done_enabled_from(Some("on")));
+        assert!(activity_mark_done_enabled_from(Some("1")));
+        assert!(activity_mark_done_enabled_from(Some(" 1 ")));
     }
 
     fn seed_run_outcome_learning_candidate<T: Transport>(

--- a/rust-core/crates/friday-hub/src/hub_server.rs
+++ b/rust-core/crates/friday-hub/src/hub_server.rs
@@ -22,13 +22,14 @@
 use friday_crypto::{open, DataKey, Sealed};
 use friday_deepseek::{DeepSeekClient, Transport};
 use friday_protocol::{
-    Envelope, ErrorCode, MemoryDecisionRequestWire, MemoryDecisionResultWire, Message,
-    MissionIntakeRequestWire, MissionIntakeResultWire, MissionLifecycleRequestWire,
-    MissionLifecycleResultWire, MissionProjectionSnapshotWire, MissionTimelineLinkWire,
-    MissionTimelineMissionWire, MissionTimelineRequestWire, MissionTimelineSnapshotWire,
-    MissionTimelineSurfaceEventWire, MissionTimelineWorkItemWire, MissionWorkItemContextWire,
-    ProviderWorkspaceActionRequestWire, ProviderWorkspaceActionResultWire,
-    RouteDecisionControlRequestWire, RouteDecisionControlResultWire, RouteDecisionProjectionWire,
+    ActivityMarkDoneRequestWire, ActivityMarkDoneResultWire, Envelope, ErrorCode,
+    MemoryDecisionRequestWire, MemoryDecisionResultWire, Message, MissionIntakeRequestWire,
+    MissionIntakeResultWire, MissionLifecycleRequestWire, MissionLifecycleResultWire,
+    MissionProjectionSnapshotWire, MissionTimelineLinkWire, MissionTimelineMissionWire,
+    MissionTimelineRequestWire, MissionTimelineSnapshotWire, MissionTimelineSurfaceEventWire,
+    MissionTimelineWorkItemWire, MissionWorkItemContextWire, ProviderWorkspaceActionRequestWire,
+    ProviderWorkspaceActionResultWire, RouteDecisionControlRequestWire,
+    RouteDecisionControlResultWire, RouteDecisionProjectionWire,
     RunOutcomeLearningDecisionRequestWire, RunOutcomeLearningDecisionResultWire,
     WorkItemStatusRequestWire, WorkItemStatusResultWire, SUPPORTED,
 };
@@ -1764,6 +1765,68 @@ fn run_outcome_learning_decision_blocked(
                 candidate_id: candidate_id.to_string(),
                 run_id: run_id.map(str::to_string),
                 kind: kind.map(str::to_string),
+                state: state.to_string(),
+                status: "blocked".to_string(),
+                blocker: Some(blocker.to_string()),
+            },
+        },
+    )
+    .with_correlation(msg_id.to_string())
+}
+
+/// Mark one Activity / Needs-Me row done. This is a refs-only owner action over `activity_item`;
+/// it never completes a WorkItem, writes proof receipts, or calls a provider/model.
+pub fn activity_mark_done_result_for_db(
+    db: &Db,
+    msg_id: &str,
+    request: ActivityMarkDoneRequestWire,
+    now_ms: i64,
+) -> Envelope {
+    let activity_id = request.activity_id.trim();
+    if activity_id.is_empty() {
+        return activity_mark_done_blocked(msg_id, now_ms, "", "unknown", "activity_id_required");
+    }
+
+    match db.mark_activity_done(activity_id, now_ms) {
+        Ok(true) => Envelope::new(
+            format!("{msg_id}-activity-mark-done"),
+            now_ms,
+            Message::ActivityMarkDoneResult {
+                result: ActivityMarkDoneResultWire {
+                    activity_id: activity_id.to_string(),
+                    state: "done".to_string(),
+                    status: "done".to_string(),
+                    blocker: None,
+                },
+            },
+        )
+        .with_correlation(msg_id.to_string()),
+        Ok(false) => {
+            activity_mark_done_blocked(msg_id, now_ms, activity_id, "unknown", "unknown_activity")
+        }
+        Err(_) => activity_mark_done_blocked(
+            msg_id,
+            now_ms,
+            activity_id,
+            "unknown",
+            "activity_write_failed",
+        ),
+    }
+}
+
+fn activity_mark_done_blocked(
+    msg_id: &str,
+    now_ms: i64,
+    activity_id: &str,
+    state: &str,
+    blocker: &str,
+) -> Envelope {
+    Envelope::new(
+        format!("{msg_id}-activity-mark-done"),
+        now_ms,
+        Message::ActivityMarkDoneResult {
+            result: ActivityMarkDoneResultWire {
+                activity_id: activity_id.to_string(),
                 state: state.to_string(),
                 status: "blocked".to_string(),
                 blocker: Some(blocker.to_string()),
@@ -7539,6 +7602,82 @@ mod tests {
             Message::RunOutcomeLearningDecisionResult { result } => result,
             other => panic!("expected RunOutcomeLearningDecisionResult, got {other:?}"),
         }
+    }
+
+    fn decode_activity_mark_done(env: &Envelope) -> &ActivityMarkDoneResultWire {
+        match &env.message {
+            Message::ActivityMarkDoneResult { result } => result,
+            other => panic!("expected ActivityMarkDoneResult, got {other:?}"),
+        }
+    }
+
+    fn seed_activity(db: &Db, activity_id: &str) {
+        db.insert_activity(&friday_storage::ActivityRow {
+            activity_id: activity_id.to_string(),
+            session_id: Some("session-activity".to_string()),
+            kind: friday_core::ActivityType::ApprovalRequired,
+            state: friday_core::ActivityState::Pending,
+            summary: "approval required · refs only".to_string(),
+            created_at: 1_000,
+            updated_at: 1_000,
+            deep_link: Some("friday://activity/session-activity".to_string()),
+        })
+        .unwrap();
+    }
+
+    #[test]
+    fn activity_mark_done_marks_only_activity_row_done() {
+        let db = Db::open_hub(&tmp_db()).unwrap();
+        seed_activity(&db, "activity-mark-done-1");
+
+        let env = activity_mark_done_result_for_db(
+            &db,
+            "msg-activity-done",
+            ActivityMarkDoneRequestWire {
+                activity_id: "activity-mark-done-1".into(),
+                reason: Some("owner cleared it".into()),
+            },
+            1_200,
+        );
+        let result = decode_activity_mark_done(&env);
+        assert_eq!(result.status, "done");
+        assert_eq!(result.state, "done");
+        assert_eq!(result.activity_id, "activity-mark-done-1");
+        assert!(result.blocker.is_none());
+
+        let rows = db.list_activity().unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].activity_id, "activity-mark-done-1");
+        assert_eq!(rows[0].state, "done");
+        assert_eq!(
+            db.count("token_ledger").unwrap(),
+            0,
+            "marking activity done makes NO model call"
+        );
+        assert_eq!(
+            db.count("work_item").unwrap(),
+            0,
+            "marking activity done must not complete or create WorkItems"
+        );
+    }
+
+    #[test]
+    fn activity_mark_done_unknown_id_is_blocked_and_changes_nothing() {
+        let db = Db::open_hub(&tmp_db()).unwrap();
+        let env = activity_mark_done_result_for_db(
+            &db,
+            "msg-activity-unknown",
+            ActivityMarkDoneRequestWire {
+                activity_id: "missing-activity".into(),
+                reason: None,
+            },
+            1_200,
+        );
+        let result = decode_activity_mark_done(&env);
+        assert_eq!(result.status, "blocked");
+        assert_eq!(result.state, "unknown");
+        assert_eq!(result.blocker.as_deref(), Some("unknown_activity"));
+        assert_eq!(db.count("activity_item").unwrap(), 0);
     }
 
     #[test]

--- a/rust-core/crates/friday-protocol/src/lib.rs
+++ b/rust-core/crates/friday-protocol/src/lib.rs
@@ -61,9 +61,9 @@ use thiserror::Error;
 /// `RunOutcomeLearningDecisionRequest/Result`: the owner-authed, refs-only terminal
 /// confirm/reject caller for pending run-outcome learning candidates. It is a pure
 /// Hub DB mutation, default-dark behind the serving flag, and carries no answer body.
-pub const CURRENT_SCHEMA_VERSION: u16 = 15;
+pub const CURRENT_SCHEMA_VERSION: u16 = 16;
 /// The inclusive range of versions this build supports.
-pub const SUPPORTED: VersionRange = VersionRange { min: 1, max: 15 };
+pub const SUPPORTED: VersionRange = VersionRange { min: 1, max: 16 };
 
 /// A surface-safe Mission projection. This is the wire shape mobile, desktop, and
 /// channel surfaces may render. It intentionally has no raw provider ids, channel
@@ -452,6 +452,28 @@ pub struct RunOutcomeLearningDecisionResultWire {
     pub run_id: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub kind: Option<String>,
+    pub state: String,
+    pub status: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub blocker: Option<String>,
+}
+
+/// Client request to mark one Activity / Needs-Me item as `done`.
+///
+/// This is a refs-only owner action over an existing `activity_item`; it never carries a
+/// transcript/body, never completes a WorkItem, and never calls a provider/model.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ActivityMarkDoneRequestWire {
+    pub activity_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+}
+
+/// Hub response for an Activity / Needs-Me `done` action. Refs-only: the activity id,
+/// resulting state, coarse status, and optional blocker.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ActivityMarkDoneResultWire {
+    pub activity_id: String,
     pub state: String,
     pub status: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -1487,6 +1509,13 @@ pub enum Message {
     RunOutcomeLearningDecisionResult {
         result: RunOutcomeLearningDecisionResultWire,
     },
+    /// client->hub: mark ONE Activity / Needs-Me item done. This changes only
+    /// `activity_item.state`, never a WorkItem/proof/provider row.
+    ActivityMarkDoneRequest {
+        request: ActivityMarkDoneRequestWire,
+    },
+    /// hub->client: refs-only Activity / Needs-Me mark-done receipt.
+    ActivityMarkDoneResult { result: ActivityMarkDoneResultWire },
     /// **S-R1** — UI→DARK read-server: request the Mission Workbench read projection over the
     /// sealed-WS READ seam. PURE READ — no model/provider call. Owner-scoped: the read server
     /// authenticates `forwarded_principal`/`auth_proof` against the sealed session (the SAME chain a
@@ -2367,6 +2396,20 @@ mod tests {
                     blocker: None,
                 },
             },
+            Message::ActivityMarkDoneRequest {
+                request: ActivityMarkDoneRequestWire {
+                    activity_id: "activity-1".into(),
+                    reason: Some("owner cleared the row".into()),
+                },
+            },
+            Message::ActivityMarkDoneResult {
+                result: ActivityMarkDoneResultWire {
+                    activity_id: "activity-1".into(),
+                    state: "done".into(),
+                    status: "done".into(),
+                    blocker: None,
+                },
+            },
             Message::RunAnswerBodyRequest {
                 request: RunAnswerBodyRequestWire {
                     run_id: "run-readable".into(),
@@ -2434,6 +2477,50 @@ mod tests {
         assert!(json.contains("\"kind\":\"RunOutcomeLearningDecisionResult\""));
         assert!(json.contains("\"result\":{"));
         assert!(json.contains("\"blocker\":\"owner_scope_mismatch\""));
+        assert_eq!(Envelope::decode(&json).unwrap(), env);
+    }
+
+    #[test]
+    fn activity_mark_done_wire_is_refs_only_and_round_trips() {
+        let request = Message::ActivityMarkDoneRequest {
+            request: ActivityMarkDoneRequestWire {
+                activity_id: "activity-1".into(),
+                reason: Some("owner cleared the row".into()),
+            },
+        };
+        let env = Envelope::new("activity-done-req", 1000, request).with_correlation("c1");
+        let json = env.encode().unwrap();
+        assert!(json.contains("\"kind\":\"ActivityMarkDoneRequest\""));
+        assert!(json.contains("\"request\":{"));
+        assert!(json.contains("\"activity_id\":\"activity-1\""));
+        for forbidden in [
+            "transcript",
+            "answer body",
+            "proof_receipt",
+            "completed_with_proof",
+            "sk-",
+            "/Users/jarvis/private",
+        ] {
+            assert!(
+                !json.contains(forbidden),
+                "activity mark-done request leaked {forbidden}: {json}"
+            );
+        }
+        assert_eq!(Envelope::decode(&json).unwrap(), env);
+
+        let result = Message::ActivityMarkDoneResult {
+            result: ActivityMarkDoneResultWire {
+                activity_id: "activity-1".into(),
+                state: "done".into(),
+                status: "blocked".into(),
+                blocker: Some("unknown_activity".into()),
+            },
+        };
+        let env = Envelope::new("activity-done-res", 1001, result).with_correlation("c1");
+        let json = env.encode().unwrap();
+        assert!(json.contains("\"kind\":\"ActivityMarkDoneResult\""));
+        assert!(json.contains("\"result\":{"));
+        assert!(json.contains("\"blocker\":\"unknown_activity\""));
         assert_eq!(Envelope::decode(&json).unwrap(), env);
     }
 
@@ -3226,13 +3313,11 @@ mod tests {
     }
 
     #[test]
-    fn schema_version_bumped_to_fifteen_for_run_outcome_learning_decision() {
-        // A1 bumps the wire version so a v13 peer advertises the run-CONTROL kinds
-        // (Paused/Resume/Cancel/Reject/ControlResult) exist — wire-compat honesty — even
-        // while nothing emits them yet (DARK, behind the default-off flag). S-A's v12
-        // substrate kinds are still present and unchanged.
-        assert_eq!(CURRENT_SCHEMA_VERSION, 15);
-        assert_eq!(SUPPORTED.max, 15);
+    fn schema_version_bumped_to_sixteen_for_activity_mark_done() {
+        // Activity mark-done adds a new refs-only owner action over Activity / Needs-Me rows.
+        // Bump the advertised wire version so peers can tell the request/result kinds exist.
+        assert_eq!(CURRENT_SCHEMA_VERSION, 16);
+        assert_eq!(SUPPORTED.max, 16);
         assert_eq!(SUPPORTED.min, 1);
     }
 


### PR DESCRIPTION
## Summary
- add refs-only ActivityMarkDone request/result protocol and default-dark rust-ws-wrapper handling
- wire mobile Activity timeline and desktop Needs Review rows to mark existing activity rows done
- register FRIDAY_ACTIVITY_MARK_DONE in the prod flag manifest as dark, with loop-test anchors

## Truth / Safety
- default dark; flag must be exactly FRIDAY_ACTIVITY_MARK_DONE=1 before the serve-bin handles the request
- marks only activity_item.state=done; does not complete WorkItems, mint proof receipts, call providers/models, or write token ledger rows
- mobile/desktop surfaces render blocked/transport failures as honest errors

## Tests
- cargo test --manifest-path rust-core/Cargo.toml -p friday-protocol activity_mark_done
- cargo test --manifest-path rust-core/Cargo.toml -p friday-hub activity_mark_done
- swift test --package-path apps/macos/FridayRustClient
- swift test --package-path apps/macos/FridayHubConsole
- swift test --package-path apps/friday-ios
- node scripts/ci/verify-prod-flag-tests.mjs
- detect-secrets-hook --baseline .secrets.baseline <changed source files>
- git diff --check