### PR TITLE
Add desktop pairing session launcher

### DIFF
--- a/apps/macos/FridayHubConsole/Sources/FridayHubConsole/PairingProvisioningScreen.swift
+++ b/apps/macos/FridayHubConsole/Sources/FridayHubConsole/PairingProvisioningScreen.swift
@@ -66,11 +66,19 @@ struct PairingProvisioningScreen: View {
           .accessibilityIdentifier("friday.desktop.pairing-qr-json-input")
         HStack(spacing: 8) {
           Button {
+            Task { await viewModel.startPairingSession() }
+          } label: {
+            Label("Start Session", systemImage: "antenna.radiowaves.left.and.right")
+          }
+          .buttonStyle(.borderedProminent)
+          .disabled(!viewModel.canStartPairingSession)
+
+          Button {
             viewModel.load(qrJSON: inputPayload)
           } label: {
             Label("Decode", systemImage: "checkmark.shield")
           }
-          .buttonStyle(.borderedProminent)
+          .buttonStyle(.bordered)
           .disabled(inputPayload.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
 
           Button {

--- a/apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/PairingProvisioningViewModel.swift
+++ b/apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/PairingProvisioningViewModel.swift
@@ -4,8 +4,10 @@ import FridayRustClient
 
 public enum PairingProvisioningMode: String, Sendable, Equatable {
   case empty
+  case starting
   case ready
   case invalid
+  case unavailable
 }
 
 public struct PairingProvisioningState: Sendable, Equatable, CustomStringConvertible,
@@ -39,14 +41,48 @@ public final class PairingProvisioningViewModel: ObservableObject {
   @Published public private(set) var state: PairingProvisioningState = .empty
   @Published public private(set) var qrPayload: String = ""
 
-  public init() {}
+  private let launcher: PairingSessionLaunching?
+
+  public init(launcher: PairingSessionLaunching? = OpsScriptPairingSessionLauncher.liveFromEnvironment()) {
+    self.launcher = launcher
+  }
 
   public var canRenderQRCode: Bool {
     state.mode == .ready && !qrPayload.isEmpty
   }
 
+  public var canStartPairingSession: Bool {
+    state.mode != .starting
+  }
+
   public var redactedSummary: String {
     state.description
+  }
+
+  public func startPairingSession(nowMs: Int64 = Int64(Date().timeIntervalSince1970 * 1000)) async {
+    guard let launcher else {
+      qrPayload = ""
+      state = PairingProvisioningState(
+        mode: .unavailable,
+        reason: "Pairing launcher is not configured for this build.",
+        projection: nil)
+      return
+    }
+    qrPayload = ""
+    state = PairingProvisioningState(
+      mode: .starting,
+      reason: "Starting a short-lived Hub pairing session.",
+      projection: nil)
+    do {
+      let result = try await launcher.startPairingSession()
+      load(qrJSON: result.manifestJSON, nowMs: nowMs)
+    } catch {
+      qrPayload = ""
+      state = PairingProvisioningState(
+        mode: .unavailable,
+        reason: Self.reason(forLaunchError: error),
+        projection: nil)
+    }
   }
 
   public func load(qrJSON: String, nowMs: Int64 = Int64(Date().timeIntervalSince1970 * 1000)) {
@@ -92,5 +128,170 @@ public final class PairingProvisioningViewModel: ObservableObject {
       }
     }
     return "Pairing QR is invalid."
+  }
+
+  private static func reason(forLaunchError error: Error) -> String {
+    if let e = error as? PairingSessionLauncherError {
+      return e.description
+    }
+    return "Pairing launcher failed."
+  }
+}
+
+public struct PairingSessionLaunchResult: Sendable, Equatable {
+  public let manifestJSON: String
+  public let manifestPath: String
+
+  public init(manifestJSON: String, manifestPath: String) {
+    self.manifestJSON = manifestJSON
+    self.manifestPath = manifestPath
+  }
+}
+
+@MainActor
+public protocol PairingSessionLaunching: AnyObject {
+  func startPairingSession() async throws -> PairingSessionLaunchResult
+}
+
+public enum PairingSessionLauncherError: Error, Equatable, CustomStringConvertible {
+  case scriptUnavailable
+  case processStartFailed
+  case processExited(String)
+  case manifestTimedOut
+  case invalidManifest
+
+  public var description: String {
+    switch self {
+    case .scriptUnavailable:
+      return "Pairing launcher script is unavailable."
+    case .processStartFailed:
+      return "Pairing launcher could not start."
+    case .processExited(let reason):
+      return reason.isEmpty ? "Pairing launcher exited before producing a QR manifest." : reason
+    case .manifestTimedOut:
+      return "Pairing launcher did not produce a QR manifest in time."
+    case .invalidManifest:
+      return "Pairing launcher produced an invalid QR manifest."
+    }
+  }
+}
+
+@MainActor
+public final class OpsScriptPairingSessionLauncher: PairingSessionLaunching {
+  private let scriptPath: String
+  private let outputDirectory: URL
+  private let environment: [String: String]
+  private let timeoutSeconds: TimeInterval
+  private var activeProcesses: [Process] = []
+
+  public init(
+    scriptPath: String,
+    outputDirectory: URL = FileManager.default.temporaryDirectory
+      .appendingPathComponent("friday-pairing-ui", isDirectory: true),
+    environment: [String: String] = ProcessInfo.processInfo.environment,
+    timeoutSeconds: TimeInterval = 5
+  ) {
+    self.scriptPath = scriptPath
+    self.outputDirectory = outputDirectory
+    self.environment = environment
+    self.timeoutSeconds = timeoutSeconds
+  }
+
+  deinit {
+    for process in activeProcesses where process.isRunning {
+      process.terminate()
+    }
+  }
+
+  public static func liveFromEnvironment(
+    environment: [String: String] = ProcessInfo.processInfo.environment,
+    fileManager: FileManager = .default
+  ) -> OpsScriptPairingSessionLauncher? {
+    if let script = environment["FRIDAY_PAIRING_LAUNCH_SCRIPT"], fileManager.fileExists(atPath: script) {
+      return OpsScriptPairingSessionLauncher(scriptPath: script, environment: environment)
+    }
+    if let root = environment["FRIDAY_REPO_ROOT"] {
+      let script = URL(fileURLWithPath: root)
+        .appendingPathComponent("scripts/ops/friday-start-pairing-session.sh")
+        .path
+      if fileManager.fileExists(atPath: script) {
+        return OpsScriptPairingSessionLauncher(scriptPath: script, environment: environment)
+      }
+    }
+    if let script = findScriptFromCurrentDirectory(fileManager: fileManager) {
+      return OpsScriptPairingSessionLauncher(scriptPath: script, environment: environment)
+    }
+    return nil
+  }
+
+  public func startPairingSession() async throws -> PairingSessionLaunchResult {
+    guard FileManager.default.fileExists(atPath: scriptPath) else {
+      throw PairingSessionLauncherError.scriptUnavailable
+    }
+    try FileManager.default.createDirectory(
+      at: outputDirectory,
+      withIntermediateDirectories: true,
+      attributes: [.posixPermissions: NSNumber(value: Int16(0o700))])
+
+    let manifestURL = outputDirectory
+      .appendingPathComponent("pairing-\(UUID().uuidString).json")
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: "/bin/bash")
+    process.arguments = [scriptPath]
+    var env = environment
+    env["FRIDAY_PAIRING_QR_JSON_OUT"] = manifestURL.path
+    env["FRIDAY_PAIRING_OUT_DIR"] = outputDirectory.path
+    process.environment = env
+
+    do {
+      try process.run()
+    } catch {
+      throw PairingSessionLauncherError.processStartFailed
+    }
+
+    let deadline = Date().addingTimeInterval(timeoutSeconds)
+    while Date() < deadline {
+      if FileManager.default.fileExists(atPath: manifestURL.path) {
+        let data = try Data(contentsOf: manifestURL)
+        guard let manifestJSON = String(data: data, encoding: .utf8) else {
+          process.terminate()
+          throw PairingSessionLauncherError.invalidManifest
+        }
+        do {
+          let manifest = try JSONDecoder().decode(FridayPairingManifest.self, from: data)
+          try manifest.validate(nowMs: Int64(Date().timeIntervalSince1970 * 1000))
+        } catch {
+          process.terminate()
+          throw PairingSessionLauncherError.invalidManifest
+        }
+        activeProcesses.append(process)
+        return PairingSessionLaunchResult(
+          manifestJSON: manifestJSON,
+          manifestPath: manifestURL.path)
+      }
+      if !process.isRunning {
+        throw PairingSessionLauncherError.processExited("")
+      }
+      try await Task.sleep(nanoseconds: 100_000_000)
+    }
+    process.terminate()
+    throw PairingSessionLauncherError.manifestTimedOut
+  }
+
+  private static func findScriptFromCurrentDirectory(fileManager: FileManager) -> String? {
+    var cursor = URL(fileURLWithPath: fileManager.currentDirectoryPath, isDirectory: true)
+    while true {
+      let script = cursor
+        .appendingPathComponent("scripts/ops/friday-start-pairing-session.sh")
+        .path
+      if fileManager.fileExists(atPath: script) {
+        return script
+      }
+      let parent = cursor.deletingLastPathComponent()
+      if parent.path == cursor.path {
+        return nil
+      }
+      cursor = parent
+    }
   }
 }

--- a/apps/macos/FridayHubConsole/Tests/FridayHubConsoleCoreTests/PairingProvisioningViewModelTests.swift
+++ b/apps/macos/FridayHubConsole/Tests/FridayHubConsoleCoreTests/PairingProvisioningViewModelTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Testing
 @testable import FridayHubConsoleCore
 
@@ -41,6 +42,92 @@ import Testing
   #expect(vm.state.projection == nil)
   #expect(vm.qrPayload.isEmpty)
   #expect(!vm.redactedSummary.contains("do-not-display"))
+}
+
+@MainActor
+@Test func pairingProvisioningStartsLauncherAndLoadsQrManifestWithoutDisplayingSecret() async throws {
+  let secret = "friday-pairing-launched-secret" // pragma: allowlist secret
+  let launcher = FakePairingLauncher(result: PairingSessionLaunchResult(
+    manifestJSON: pairingManifestJSON(secret: secret, expiresAt: 1_900_000_000_000),
+    manifestPath: "/tmp/friday-pairing.json"))
+  let vm = PairingProvisioningViewModel(launcher: launcher)
+
+  await vm.startPairingSession(nowMs: 1_780_000_000_000)
+
+  #expect(launcher.startCount == 1)
+  #expect(vm.state.mode == .ready)
+  #expect(vm.qrPayload.contains(secret))
+  #expect(!vm.redactedSummary.contains(secret))
+  #expect(vm.canRenderQRCode)
+}
+
+@MainActor
+@Test func pairingProvisioningLauncherFailureIsHonestUnavailableAndClearsPayload() async throws {
+  let launcher = FakePairingLauncher(error: .manifestTimedOut)
+  let vm = PairingProvisioningViewModel(launcher: launcher)
+
+  await vm.startPairingSession(nowMs: 1_780_000_000_000)
+
+  #expect(vm.state.mode == .unavailable)
+  #expect(vm.qrPayload.isEmpty)
+  #expect(!vm.canRenderQRCode)
+  #expect(vm.state.reason.contains("did not produce"))
+}
+
+@MainActor
+@Test func opsScriptPairingLauncherReadsManifestProducedByScript() async throws {
+  let temp = try temporaryDirectory()
+  defer { try? FileManager.default.removeItem(at: temp) }
+  let script = temp.appendingPathComponent("friday-start-pairing-session.sh")
+  let secret = "friday-pairing-script-secret" // pragma: allowlist secret
+  let body = pairingManifestJSON(secret: secret, expiresAt: 1_900_000_000_000)
+  try """
+    #!/bin/sh
+    set -eu
+    mkdir -p "$(dirname "$FRIDAY_PAIRING_QR_JSON_OUT")"
+    cat > "$FRIDAY_PAIRING_QR_JSON_OUT" <<'JSON'
+    \(body)
+    JSON
+    """.write(to: script, atomically: true, encoding: .utf8)
+  try FileManager.default.setAttributes(
+    [.posixPermissions: NSNumber(value: Int16(0o700))],
+    ofItemAtPath: script.path)
+
+  let launcher = OpsScriptPairingSessionLauncher(
+    scriptPath: script.path,
+    outputDirectory: temp.appendingPathComponent("out", isDirectory: true),
+    environment: [:],
+    timeoutSeconds: 2)
+  let result = try await launcher.startPairingSession()
+
+  #expect(result.manifestJSON.contains(secret))
+  #expect(FileManager.default.fileExists(atPath: result.manifestPath))
+}
+
+private final class FakePairingLauncher: PairingSessionLaunching {
+  private let result: PairingSessionLaunchResult?
+  private let error: PairingSessionLauncherError?
+  private(set) var startCount = 0
+
+  init(result: PairingSessionLaunchResult? = nil, error: PairingSessionLauncherError? = nil) {
+    self.result = result
+    self.error = error
+  }
+
+  func startPairingSession() async throws -> PairingSessionLaunchResult {
+    startCount += 1
+    if let error {
+      throw error
+    }
+    return result!
+  }
+}
+
+private func temporaryDirectory() throws -> URL {
+  let url = FileManager.default.temporaryDirectory
+    .appendingPathComponent("friday-pairing-tests-\(UUID().uuidString)", isDirectory: true)
+  try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+  return url
 }
 
 private func pairingManifestJSON(secret: String, expiresAt: Int64) -> String {


### PR DESCRIPTION
## Summary
- add a desktop Pairing Provisioning launcher seam that starts the existing `friday-start-pairing-session.sh` flow and loads the short-lived QR manifest into the current QR screen
- keep the existing pairing core semantics unchanged: no operator key access, no trust_grant/context_passport minting, no flag flip
- surface launcher failures as honest-unavailable instead of silently disabling the product path

## Truth label
T3 provisioning progress: this closes the desktop launcher gap for producing scan material in-app. It does not by itself prove a real physical device enrollment, trust grant, context passport, or END-BAR completion.

## Verification
- `swift test --package-path apps/macos/FridayHubConsole`
- `git diff --check`
- `detect-secrets-hook --baseline .secrets.baseline apps/macos/FridayHubConsole/Sources/FridayHubConsole/PairingProvisioningScreen.swift apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/PairingProvisioningViewModel.swift apps/macos/FridayHubConsole/Tests/FridayHubConsoleCoreTests/PairingProvisioningViewModelTests.swift`
- scratch live proof: `friday-start-pairing-session.sh` + `FridayPairingProof --pair` produced `PairAck accepted`, `trusted_device_count=1`, `audit_pairing_count=1` in scratch DB only
