### PR TITLE
Add T3 operator provisioning status tools

### DIFF
--- a/package.json
+++ b/package.json
@@ -129,6 +129,7 @@
     "ops:phase24h:telegram-natural-trigger": "node scripts/ops/phase24h-telegram-natural-trigger-listener.mjs",
     "ops:real-green-gate": "node scripts/ops/run-real-green-gate.mjs",
     "proof:d4:trust-passport": "bash scripts/ops/friday-d4-trust-passport-proof.sh",
+    "ops:t3:provisioning-status": "node scripts/ops/friday-t3-provisioning-status.mjs",
     "ops:harden-local-enablement": "bash scripts/ops/harden-local-enablement.sh",
     "ops:agent-adoption:doctor": "node dist/cli/friday-cli.js phases doctor",
     "ops:agent-adoption:list": "node dist/cli/friday-cli.js phases list",

--- a/scripts/ops/friday-t3-operator-provision.sh
+++ b/scripts/ops/friday-t3-operator-provision.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+#
+# Operator-only T3 provisioning wrapper.
+#
+# Truth boundary:
+#   This is a local operator ceremony wrapper around the existing
+#   friday-operator-approve CLI. It can mint trust_grant/context_passport rows only
+#   when the operator supplies an explicit ACK and explicit boundaries. It does not
+#   read an operator signing key, sign anything, flip flags, expose a Hub/app/agent
+#   mint endpoint, or insert fake organic evidence.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+ACK="${FRIDAY_T3_OPERATOR_PROVISION_ACK:-}"
+DB_PATH="${FRIDAY_T3_DB_PATH:-${HOME}/Library/Application Support/Friday/state/rust-hub.sqlite}"
+STEP="${FRIDAY_T3_STEP:-both}"
+
+GRANT_ID="${FRIDAY_T3_GRANT_ID:-}"
+AGENT_ID="${FRIDAY_T3_AGENT_ID:-}"
+RISK_CEILING="${FRIDAY_T3_RISK_CEILING:-}"
+EXPIRES_AT="${FRIDAY_T3_EXPIRES_AT:-}"
+WORKSPACE="${FRIDAY_T3_WORKSPACE:-}"
+TOKEN_CEILING="${FRIDAY_T3_TOKEN_CEILING:-}"
+MAX_RUNS="${FRIDAY_T3_MAX_RUNS:-}"
+AUTO_ALLOW_REVERSIBLE_CEILING="${FRIDAY_T3_AUTO_ALLOW_REVERSIBLE_CEILING:-}"
+TOOLS="${FRIDAY_T3_TOOLS:-}"
+PROVIDERS="${FRIDAY_T3_PROVIDERS:-}"
+CHANNELS="${FRIDAY_T3_CHANNELS:-}"
+WORKFLOW_FAMILIES="${FRIDAY_T3_WORKFLOW_FAMILIES:-}"
+SKILL_FAMILIES="${FRIDAY_T3_SKILL_FAMILIES:-}"
+
+PASSPORT_ID="${FRIDAY_T3_PASSPORT_ID:-}"
+MISSION_ID="${FRIDAY_T3_MISSION_ID:-}"
+WORK_ITEM_ID="${FRIDAY_T3_WORK_ITEM_ID:-}"
+DESTINATION_LANE="${FRIDAY_T3_DESTINATION_LANE:-}"
+DESTINATION_TARGET="${FRIDAY_T3_DESTINATION_TARGET:-}"
+ITEMS_JSON="${FRIDAY_T3_ITEMS_JSON:-}"
+APPROVED_SENSITIVE="${FRIDAY_T3_APPROVED_SENSITIVE:-0}"
+
+fail() {
+  echo "FATAL: $*" >&2
+  exit 3
+}
+
+need() {
+  local name="$1"
+  local value="$2"
+  if [[ -z "${value}" ]]; then
+    fail "${name} is required."
+  fi
+}
+
+if [[ "${ACK}" != "operator-runs-t3-provisioning" ]]; then
+  fail "set FRIDAY_T3_OPERATOR_PROVISION_ACK=operator-runs-t3-provisioning to run this operator ceremony."
+fi
+
+case "${STEP}" in
+  grant|passport|both) ;;
+  *) fail "FRIDAY_T3_STEP must be grant, passport, or both." ;;
+esac
+
+run_operator_cli() {
+  cargo run --quiet --manifest-path "${REPO_ROOT}/rust-core/Cargo.toml" \
+    -p friday-operator-cli --bin friday-operator-approve -- "$@"
+}
+
+run_grant() {
+  need "FRIDAY_T3_GRANT_ID" "${GRANT_ID}"
+  need "FRIDAY_T3_AGENT_ID" "${AGENT_ID}"
+  need "FRIDAY_T3_RISK_CEILING" "${RISK_CEILING}"
+
+  if [[ -z "${TOOLS}${PROVIDERS}${CHANNELS}${WORKFLOW_FAMILIES}${SKILL_FAMILIES}${WORKSPACE}" ]]; then
+    fail "at least one explicit grant boundary is required (tools/providers/channels/workflow families/skill families/workspace)."
+  fi
+
+  local args=(
+    grant
+    --db "${DB_PATH}"
+    --grant-id "${GRANT_ID}"
+    --agent "${AGENT_ID}"
+    --risk-ceiling "${RISK_CEILING}"
+  )
+  if [[ -n "${EXPIRES_AT}" ]]; then args+=(--expires-at "${EXPIRES_AT}"); fi
+  if [[ -n "${WORKSPACE}" ]]; then args+=(--workspace "${WORKSPACE}"); fi
+  if [[ -n "${TOKEN_CEILING}" ]]; then args+=(--token-ceiling "${TOKEN_CEILING}"); fi
+  if [[ -n "${MAX_RUNS}" ]]; then args+=(--max-runs "${MAX_RUNS}"); fi
+  if [[ -n "${AUTO_ALLOW_REVERSIBLE_CEILING}" ]]; then args+=(--auto-allow-reversible-ceiling "${AUTO_ALLOW_REVERSIBLE_CEILING}"); fi
+  if [[ -n "${TOOLS}" ]]; then args+=(--tools "${TOOLS}"); fi
+  if [[ -n "${PROVIDERS}" ]]; then args+=(--providers "${PROVIDERS}"); fi
+  if [[ -n "${CHANNELS}" ]]; then args+=(--channels "${CHANNELS}"); fi
+  if [[ -n "${WORKFLOW_FAMILIES}" ]]; then args+=(--workflow-families "${WORKFLOW_FAMILIES}"); fi
+  if [[ -n "${SKILL_FAMILIES}" ]]; then args+=(--skill-families "${SKILL_FAMILIES}"); fi
+
+  echo "Running operator trust_grant ceremony."
+  echo "truth_label=operator_cli_trust_grant_ceremony_not_app_or_agent_mint"
+  run_operator_cli "${args[@]}"
+}
+
+run_passport() {
+  need "FRIDAY_T3_PASSPORT_ID" "${PASSPORT_ID}"
+  need "FRIDAY_T3_MISSION_ID" "${MISSION_ID}"
+  need "FRIDAY_T3_DESTINATION_LANE" "${DESTINATION_LANE}"
+  need "FRIDAY_T3_ITEMS_JSON" "${ITEMS_JSON}"
+  if [[ ! -f "${ITEMS_JSON}" ]]; then
+    fail "FRIDAY_T3_ITEMS_JSON must point to an existing JSON file."
+  fi
+
+  local args=(
+    passport-mint
+    --db "${DB_PATH}"
+    --passport-id "${PASSPORT_ID}"
+    --mission-id "${MISSION_ID}"
+    --destination-lane "${DESTINATION_LANE}"
+    --items "${ITEMS_JSON}"
+  )
+  if [[ -n "${WORK_ITEM_ID}" ]]; then args+=(--work-item-id "${WORK_ITEM_ID}"); fi
+  if [[ -n "${DESTINATION_TARGET}" ]]; then args+=(--destination-target "${DESTINATION_TARGET}"); fi
+  if [[ "${APPROVED_SENSITIVE}" = "1" ]]; then
+    args+=(--approved-sensitive)
+  fi
+
+  echo "Running operator context_passport ceremony."
+  echo "truth_label=operator_cli_context_passport_ceremony_not_app_or_agent_mint"
+  run_operator_cli "${args[@]}"
+}
+
+cat >&2 <<EOF
+Friday T3 operator provisioning starting.
+DB: ${DB_PATH}
+Step: ${STEP}
+Truth: operator ACK required; no signing key read; no flags flipped; no app/agent mint endpoint.
+EOF
+
+if [[ "${STEP}" = "grant" || "${STEP}" = "both" ]]; then
+  run_grant
+fi
+if [[ "${STEP}" = "passport" || "${STEP}" = "both" ]]; then
+  run_passport
+fi

--- a/scripts/ops/friday-t3-provisioning-status.mjs
+++ b/scripts/ops/friday-t3-provisioning-status.mjs
@@ -1,0 +1,180 @@
+#!/usr/bin/env node
+import os from "node:os";
+import path from "node:path";
+import process from "node:process";
+import { spawnSync } from "node:child_process";
+
+const DEFAULT_DB = path.join(
+  os.homedir(),
+  "Library/Application Support/Friday/state/rust-hub.sqlite",
+);
+
+const T3_TABLES = [
+  "device_identity",
+  "trusted_device",
+  "trust_grant",
+  "context_passport",
+  "context_passport_item",
+];
+
+export function parseArgs(argv) {
+  const options = {
+    dbPath: process.env.FRIDAY_T3_DB_PATH || DEFAULT_DB,
+    json: false,
+    requireReady: false,
+  };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--json") {
+      options.json = true;
+    } else if (arg === "--require-ready") {
+      options.requireReady = true;
+    } else if (arg === "--db") {
+      const value = argv[i + 1];
+      if (!value) {
+        throw new Error("--db requires a path");
+      }
+      options.dbPath = value;
+      i += 1;
+    } else if (arg.startsWith("--db=")) {
+      options.dbPath = arg.slice("--db=".length);
+    } else if (arg === "--help" || arg === "-h") {
+      options.help = true;
+    } else {
+      throw new Error(`unknown argument: ${arg}`);
+    }
+  }
+  return options;
+}
+
+export function usage() {
+  return `Friday T3 provisioning status (read-only)
+
+USAGE:
+  node scripts/ops/friday-t3-provisioning-status.mjs [--db <hub.sqlite>] [--json] [--require-ready]
+
+This verifier only reads T3 provision tables. It never mints trust grants, context
+passports, device rows, signatures, or fake organic evidence.`;
+}
+
+function quoteSqlString(value) {
+  return `'${String(value).replaceAll("'", "''")}'`;
+}
+
+function queryScalar(dbPath, sql) {
+  const result = spawnSync("sqlite3", ["-readonly", dbPath, sql], {
+    encoding: "utf8",
+    maxBuffer: 1024 * 1024,
+  });
+  if (result.error) {
+    throw result.error;
+  }
+  if (result.status !== 0) {
+    throw new Error(result.stderr.trim() || `sqlite3 exited ${result.status}`);
+  }
+  return result.stdout.trim();
+}
+
+function tableExists(dbPath, tableName) {
+  const present = queryScalar(
+    dbPath,
+    `SELECT count(*) FROM sqlite_master WHERE type='table' AND name=${quoteSqlString(tableName)}`,
+  );
+  return Number(present) > 0;
+}
+
+function countTable(dbPath, tableName) {
+  if (!tableExists(dbPath, tableName)) {
+    return null;
+  }
+  const quoted = `"${tableName.replaceAll('"', '""')}"`;
+  return Number(queryScalar(dbPath, `SELECT count(*) FROM ${quoted}`));
+}
+
+function countActiveTrustGrants(dbPath, nowMs) {
+  if (!tableExists(dbPath, "trust_grant")) {
+    return null;
+  }
+  return Number(
+    queryScalar(
+      dbPath,
+      `SELECT count(*) FROM trust_grant WHERE revoked = 0 AND (expires_at IS NULL OR expires_at > ${Number(nowMs)})`,
+    ),
+  );
+}
+
+export function buildT3ProvisioningStatus(dbPath, nowMs = Date.now()) {
+  const counts = Object.fromEntries(
+    T3_TABLES.map((tableName) => [tableName, countTable(dbPath, tableName)]),
+  );
+  const activeTrustGrants = countActiveTrustGrants(dbPath, nowMs);
+  const checks = {
+    device_identity: (counts.device_identity ?? 0) > 0,
+    trusted_device: (counts.trusted_device ?? 0) > 0,
+    trust_grant: (counts.trust_grant ?? 0) > 0,
+    active_trust_grant: (activeTrustGrants ?? 0) > 0,
+    context_passport: (counts.context_passport ?? 0) > 0,
+    context_passport_item: (counts.context_passport_item ?? 0) > 0,
+  };
+  const missing = Object.entries(checks)
+    .filter(([, ok]) => !ok)
+    .map(([name]) => name);
+  return {
+    dbPath,
+    truth_label: "t3_provisioning_status_read_only_no_mint_no_signature",
+    generated_at_utc: new Date(nowMs).toISOString(),
+    counts,
+    active_trust_grants: activeTrustGrants,
+    checks,
+    status: missing.length === 0 ? "ready" : "incomplete",
+    t3_provisioned: missing.length === 0,
+    missing,
+    caveat:
+      "ready means the governed T3 rows exist; it does not claim END-BAR, GO-LIVE, adoption, release, or operator signature completion.",
+  };
+}
+
+export function renderText(status) {
+  const lines = [
+    "Friday T3 provisioning status",
+    `truth_label=${status.truth_label}`,
+    `db=${status.dbPath}`,
+    `status=${status.status}`,
+    `t3_provisioned=${status.t3_provisioned ? "true" : "false"}`,
+    "",
+    "counts:",
+  ];
+  for (const tableName of T3_TABLES) {
+    lines.push(`  ${tableName}=${status.counts[tableName] ?? "missing-table"}`);
+  }
+  lines.push(`  active_trust_grants=${status.active_trust_grants ?? "missing-table"}`);
+  if (status.missing.length > 0) {
+    lines.push("", `missing=${status.missing.join(",")}`);
+  }
+  lines.push("", `caveat=${status.caveat}`);
+  return `${lines.join("\n")}\n`;
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  if (options.help) {
+    process.stdout.write(`${usage()}\n`);
+    return;
+  }
+  const status = buildT3ProvisioningStatus(options.dbPath);
+  if (options.json) {
+    process.stdout.write(`${JSON.stringify(status, null, 2)}\n`);
+  } else {
+    process.stdout.write(renderText(status));
+  }
+  if (options.requireReady && !status.t3_provisioned) {
+    process.exitCode = 2;
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((error) => {
+    process.stderr.write(`friday-t3-provisioning-status: ${error.message}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/test/unit/scripts/ops/friday-t3-operator-provision.test.ts
+++ b/test/unit/scripts/ops/friday-t3-operator-provision.test.ts
@@ -1,0 +1,37 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const repoRoot = process.cwd();
+const scriptPath = resolve(repoRoot, "scripts/ops/friday-t3-operator-provision.sh");
+const source = readFileSync(scriptPath, "utf8");
+
+describe("friday-t3-operator-provision.sh", () => {
+  it("keeps T3 minting behind an explicit operator ceremony acknowledgement", () => {
+    expect(source).toContain("FRIDAY_T3_OPERATOR_PROVISION_ACK");
+    expect(source).toContain("operator-runs-t3-provisioning");
+    expect(source).toContain("STEP");
+    expect(source).toContain("grant|passport|both");
+  });
+
+  it("uses the operator CLI without reading signing keys or exposing an app mint endpoint", () => {
+    expect(source).toContain("friday-operator-approve");
+    expect(source).toContain("-p friday-operator-cli");
+    expect(source).toContain("passport-mint");
+    expect(source).not.toContain("operator-approve.key");
+    expect(source).not.toContain("FRIDAY_OPERATOR_APPROVE_KEY");
+    expect(source).not.toContain("launchctl");
+    expect(source).not.toContain("curl ");
+  });
+
+  it("requires explicit grant boundaries and context passport inputs", () => {
+    expect(source).toContain("FRIDAY_T3_GRANT_ID");
+    expect(source).toContain("FRIDAY_T3_AGENT_ID");
+    expect(source).toContain("FRIDAY_T3_RISK_CEILING");
+    expect(source).toContain("at least one explicit grant boundary is required");
+    expect(source).toContain("FRIDAY_T3_PASSPORT_ID");
+    expect(source).toContain("FRIDAY_T3_MISSION_ID");
+    expect(source).toContain("FRIDAY_T3_DESTINATION_LANE");
+    expect(source).toContain("FRIDAY_T3_ITEMS_JSON");
+  });
+});

--- a/test/unit/scripts/ops/friday-t3-provisioning-status.test.ts
+++ b/test/unit/scripts/ops/friday-t3-provisioning-status.test.ts
@@ -1,0 +1,123 @@
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { afterEach, describe, expect, it } from "vitest";
+
+type StatusModule = typeof import("../../../../scripts/ops/friday-t3-provisioning-status.mjs");
+
+const repoRoot = process.cwd();
+const scriptUrl = pathToFileURL(
+  path.resolve(repoRoot, "scripts/ops/friday-t3-provisioning-status.mjs"),
+).href;
+const tempRoots: string[] = [];
+
+async function loadStatusModule(): Promise<StatusModule> {
+  return (await import(`${scriptUrl}?t=${Date.now()}`)) as StatusModule;
+}
+
+function makeDbPath(): string {
+  const root = mkdtempSync(path.join(tmpdir(), "friday-t3-status-test-"));
+  tempRoots.push(root);
+  return path.join(root, "hub.sqlite");
+}
+
+function execSql(dbPath: string, sql: string): void {
+  execFileSync("sqlite3", [dbPath, sql], { encoding: "utf8" });
+}
+
+function createProvisionTables(dbPath: string): void {
+  execSql(
+    dbPath,
+    `
+    CREATE TABLE device_identity (device_id TEXT);
+    CREATE TABLE trusted_device (device_id TEXT);
+    CREATE TABLE trust_grant (grant_id TEXT, revoked INTEGER, expires_at INTEGER);
+    CREATE TABLE context_passport (passport_id TEXT);
+    CREATE TABLE context_passport_item (passport_id TEXT, item_id TEXT);
+  `,
+  );
+}
+
+afterEach(() => {
+  for (const root of tempRoots.splice(0)) {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+describe("friday-t3-provisioning-status", () => {
+  it("reports incomplete without minting or overclaiming when provision rows are absent", async () => {
+    const statusModule = await loadStatusModule();
+    const dbPath = makeDbPath();
+    createProvisionTables(dbPath);
+
+    const status = statusModule.buildT3ProvisioningStatus(dbPath, 1_780_000_000_000);
+
+    expect(status.status).toBe("incomplete");
+    expect(status.t3_provisioned).toBe(false);
+    expect(status.truth_label).toContain("read_only");
+    expect(status.missing).toEqual([
+      "device_identity",
+      "trusted_device",
+      "trust_grant",
+      "active_trust_grant",
+      "context_passport",
+      "context_passport_item",
+    ]);
+    expect(status.counts).toMatchObject({
+      device_identity: 0,
+      trusted_device: 0,
+      trust_grant: 0,
+      context_passport: 0,
+      context_passport_item: 0,
+    });
+  });
+
+  it("requires active grant and every T3 row family before reporting ready", async () => {
+    const statusModule = await loadStatusModule();
+    const dbPath = makeDbPath();
+    createProvisionTables(dbPath);
+    execSql(
+      dbPath,
+      `
+      INSERT INTO device_identity(device_id) VALUES ('device-1');
+      INSERT INTO trusted_device(device_id) VALUES ('device-1');
+      INSERT INTO trust_grant(grant_id, revoked, expires_at) VALUES ('grant-1', 0, 1900000000000);
+      INSERT INTO context_passport(passport_id) VALUES ('passport-1');
+      INSERT INTO context_passport_item(passport_id, item_id) VALUES ('passport-1', 'item-1');
+    `,
+    );
+
+    const status = statusModule.buildT3ProvisioningStatus(dbPath, 1_780_000_000_000);
+
+    expect(status.status).toBe("ready");
+    expect(status.t3_provisioned).toBe(true);
+    expect(status.active_trust_grants).toBe(1);
+    expect(status.missing).toEqual([]);
+    expect(status.caveat).toContain("does not claim END-BAR");
+  });
+
+  it("treats revoked or expired grants as not ready even when rows exist", async () => {
+    const statusModule = await loadStatusModule();
+    const dbPath = makeDbPath();
+    createProvisionTables(dbPath);
+    execSql(
+      dbPath,
+      `
+      INSERT INTO device_identity(device_id) VALUES ('device-1');
+      INSERT INTO trusted_device(device_id) VALUES ('device-1');
+      INSERT INTO trust_grant(grant_id, revoked, expires_at) VALUES ('grant-1', 1, 1900000000000);
+      INSERT INTO trust_grant(grant_id, revoked, expires_at) VALUES ('grant-2', 0, 1000);
+      INSERT INTO context_passport(passport_id) VALUES ('passport-1');
+      INSERT INTO context_passport_item(passport_id, item_id) VALUES ('passport-1', 'item-1');
+    `,
+    );
+
+    const status = statusModule.buildT3ProvisioningStatus(dbPath, 1_780_000_000_000);
+
+    expect(status.status).toBe("incomplete");
+    expect(status.active_trust_grants).toBe(0);
+    expect(status.missing).toEqual(["active_trust_grant"]);
+  });
+});


### PR DESCRIPTION
## Summary
- add a read-only T3 provisioning status verifier for device/trust/passport row families
- add an operator-ACK-gated provisioning wrapper around the existing friday-operator-approve grant/passport-mint ceremony
- cover the tools with focused unit tests and keep truth labels explicit

## Truth boundary
- no app/agent mint endpoint
- no operator signing key read or signing action
- no flag flip, no fake organic evidence, no prod write from the status verifier
- readiness means T3 rows exist; it does not claim END-BAR, GO-LIVE, release, or adoption

## Verification
- `bash -n scripts/ops/friday-t3-operator-provision.sh`
- `node --check scripts/ops/friday-t3-provisioning-status.mjs`
- `scripts/ops/friday-t3-operator-provision.sh` without ACK exits 3
- `npm run ops:t3:provisioning-status -- --json` (read-only; current prod T3 rows still 0)
- `./node_modules/.bin/vitest run test/unit/scripts/ops/friday-t3-provisioning-status.test.ts test/unit/scripts/ops/friday-t3-operator-provision.test.ts`
- `cargo test --manifest-path rust-core/Cargo.toml -p friday-operator-cli --test trust_grant_issuance --test context_passport_ceremony`
- `detect-secrets-hook --baseline .secrets.baseline package.json scripts/ops/friday-t3-operator-provision.sh scripts/ops/friday-t3-provisioning-status.mjs test/unit/scripts/ops/friday-t3-operator-provision.test.ts test/unit/scripts/ops/friday-t3-provisioning-status.test.ts`
- `git diff --check`