### PR TITLE
Record device identity during QR pairing

### DIFF
--- a/apps/macos/FridayRustClient/Tests/FridayRustClientTests/PairingWireKATTests.swift
+++ b/apps/macos/FridayRustClient/Tests/FridayRustClientTests/PairingWireKATTests.swift
@@ -3,7 +3,7 @@ import XCTest
 
 /// T3 pairing wire contract tests. These lock the Swift client to the Rust
 /// `friday_protocol::Message::{Pair,PairAck,HubStatus}` serde shapes before a socket client is
-/// allowed to write `trusted_device` through `hub_pairing_server`.
+/// allowed to write `device_identity` + `trusted_device` through `hub_pairing_server`.
 final class PairingWireKATTests: XCTestCase {
   func testPairMessageWireContractIsRefsAndProofOnly() throws {
     let pair = PairingPairWire(

--- a/rust-core/crates/friday-hub/src/bin/hub_pairing_server.rs
+++ b/rust-core/crates/friday-hub/src/bin/hub_pairing_server.rs
@@ -12,9 +12,10 @@
 //!    test-only (no bin).
 //! 2. **On a SUCCESSFUL pair, enrolls the device's read pubkey.** A valid `Pair` (correct
 //!    `pairing_proof = HMAC(qr_secret, device_pubkey)`, UNEXPIRED, non-replay) writes a
-//!    `trusted_device` row AND THEN — and only then — appends that device's pubkey to the read-seam
-//!    allowlist ([`friday_hub::key_source::READ_SEAM_PEER_PUBKEY_ALLOWLIST_ID`]) so that device can
-//!    read (:48751). An invalid / replayed / expired / revoked pair enrolls NOTHING (fail-closed).
+//!    `device_identity` + `trusted_device` rows AND THEN — and only then — appends that device's
+//!    pubkey to the read-seam allowlist
+//!    ([`friday_hub::key_source::READ_SEAM_PEER_PUBKEY_ALLOWLIST_ID`]) so that device can read
+//!    (:48751). An invalid / replayed / expired / revoked pair enrolls NOTHING (fail-closed).
 //!
 //! ## Security (this bin GRANTS READ enrollment — built defensively)
 //! * **Only a VALID pairing enrolls.** The enroll is bound to a `PairAck { accepted: true }`, which
@@ -36,9 +37,10 @@
 //! * **No secret in logs, no panic path.** Coarse error categories only; the pairing secret + the
 //!   master key + device pubkey bytes are NEVER printed (only counts / fingerprints).
 //!
-//! ## Atomicity (HONEST): the `trusted_device` DB txn and the read-seam FileSecureStore are SEPARATE
-//! stores; a "trust written, enroll failed" window exists. It is surfaced LOUDLY (a stderr line) so
-//! the operator can re-run `hub_read_seam_enroll --pubkey … --add`; acceptable for this DARK bin.
+//! ## Atomicity (HONEST): the `device_identity` + `trusted_device` DB txn and the read-seam
+//! FileSecureStore are SEPARATE stores; a "trust written, enroll failed" window exists. It is
+//! surfaced LOUDLY (a stderr line) so the operator can re-run
+//! `hub_read_seam_enroll --pubkey … --add`; acceptable for this DARK bin.
 //!
 //! ## DARK / default-off — NOT a live flip
 //! There is NO LaunchAgent entry and NO production caller. The bin serves only when explicitly run.
@@ -87,7 +89,7 @@ enum ServerError {
     /// blank, or the payload is already expired. Coarse only (never the secret).
     BadPayload,
     Bind,
-    /// The hub DB could not be opened read-WRITE (pairing WRITES `trusted_device` + audit).
+    /// The hub DB could not be opened read-WRITE (pairing writes identity + trust + audit).
     DbUnavailable,
     /// The master key is absent/unreadable ⇒ REFUSE TO BOOT (never auto-generated). The master key
     /// is for the read-seam store KEK — NOT the pairing ECDH (that key rides the QR/preamble).
@@ -167,8 +169,9 @@ fn run() -> Result<(), ServerError> {
     // secret + expiry — a bad payload FAILS CLOSED before we serve anything.
     let payload = build_payload(&args, &default_endpoint)?;
 
-    // (2) Open the hub DB READ-WRITE — pairing WRITES `trusted_device` + audit_ledger (this is the
-    // ONE place this bin differs from the read-projection server, which opens read-only).
+    // (2) Open the hub DB READ-WRITE — pairing writes device_identity + trusted_device +
+    // audit_ledger (this is the ONE place this bin differs from the read-projection server, which
+    // opens read-only).
     let mut db = Db::open_hub(&db_path).map_err(|_| ServerError::DbUnavailable)?;
 
     // (3) Open the read-seam FileSecureStore (sealed under the host master KEK) so a successful pair

--- a/rust-core/crates/friday-hub/src/pair_runtime.rs
+++ b/rust-core/crates/friday-hub/src/pair_runtime.rs
@@ -283,8 +283,9 @@ impl PairingListener {
     /// Enroll goes through the SHARED [`enroll_read_seam_peer_additive`]: APPEND-only + idempotent,
     /// so the existing desktop master peer (and any other enrolled device) is NEVER evicted.
     ///
-    /// ## Atomicity (HONEST, NOTED): the `trusted_device` DB txn and the read-seam FileSecureStore
-    /// are SEPARATE stores. The enroll runs AFTER `complete_qr_pairing` committed, so a
+    /// ## Atomicity (HONEST, NOTED): the `device_identity` + `trusted_device` DB txn and the
+    /// read-seam FileSecureStore are SEPARATE stores. The enroll runs AFTER `complete_qr_pairing`
+    /// committed, so a
     /// "trust written, enroll failed" window exists. That is surfaced LOUDLY (the returned
     /// [`PairOutcome::enroll_error`]) so the operator can re-run `hub_read_seam_enroll --pubkey …
     /// --add`; acceptable for this DARK bin. The pairing trust itself is never rolled back.
@@ -491,7 +492,7 @@ mod tests {
     }
 
     #[test]
-    fn pair_message_records_trusted_device_and_no_model_call_rows() {
+    fn pair_message_records_device_identity_trusted_device_and_no_model_call_rows() {
         let tmp = TempDb::new("pair");
         let mut db = Db::open_hub(tmp.path()).unwrap();
         let payload = sample_payload(2000);
@@ -519,6 +520,7 @@ mod tests {
                 error_code: None
             }
         );
+        assert_eq!(db.count("device_identity").unwrap(), 1);
         assert_eq!(db.count("trusted_device").unwrap(), 1);
         assert_eq!(db.count("audit_ledger").unwrap(), 1);
         assert_eq!(db.count("token_ledger").unwrap(), 0);

--- a/rust-core/crates/friday-storage/src/lib.rs
+++ b/rust-core/crates/friday-storage/src/lib.rs
@@ -84,7 +84,7 @@ pub use trust_grant::{
 };
 
 use friday_core::{
-    ActivityState, ActivityType, ContextPassport, DeviceIdentity, FridayConversation,
+    ActivityState, ActivityType, ContextPassport, DeviceIdentity, DeviceRole, FridayConversation,
     FridayPairPayload, LedgerEntry, Mission, MissionLink, MissionSurfaceProjection,
     ProviderSessionEvent, ProviderSessionLink, ProviderSessionProjection, RouteDecisionCard,
     RouteDecisionProjection, SessionState, SurfaceEvent, SurfaceThread, ToolUsageMeasurement,
@@ -1384,6 +1384,8 @@ impl Db {
         pairing::pair_device(
             &mut self.conn,
             payload.pairing_secret.expose_for_qr().as_bytes(),
+            device_id,
+            DeviceRole::Ios,
             device_id,
             device_pubkey,
             pairing_proof,

--- a/rust-core/crates/friday-storage/src/pairing.rs
+++ b/rust-core/crates/friday-storage/src/pairing.rs
@@ -5,24 +5,28 @@
 //! substitutes its own key without the out-of-band QR secret is rejected — this
 //! is what closes the active-MITM gap the E2E session module defers to pairing.
 //!
-//! Every pairing / revoke / rotation writes an `audit_ledger` entry atomically
-//! with the `trusted_device` change. Hub-only (trusted_device is Hub-only).
+//! Every pairing writes `device_identity` + `trusted_device` and every pair /
+//! revoke / rotation writes an `audit_ledger` entry atomically with the trust
+//! change. Hub-only (trusted_device is Hub-only).
 
 use crate::audit;
 use crate::error::{Result, StorageError};
-use friday_core::TrustedDeviceProjection;
+use friday_core::{DeviceRole, TrustedDeviceProjection};
 use friday_crypto::verify_pairing_proof;
 use rusqlite::{params, Connection, OptionalExtension};
 use sha2::{Digest, Sha256};
 
 /// Complete a QR pairing handshake. Verifies the proof binds `device_pubkey` to
-/// the out-of-band `qr_secret`; on success records the trusted device + an audit
-/// entry; on failure returns `PairingDenied` and writes nothing.
+/// the out-of-band `qr_secret`; on success records the device identity, trusted
+/// device, and audit entry; on failure returns `PairingDenied` and writes
+/// nothing.
 #[allow(clippy::too_many_arguments)]
 pub fn pair_device(
     conn: &mut Connection,
     qr_secret: &[u8],
     device_id: &str,
+    device_role: DeviceRole,
+    display_name: &str,
     device_pubkey: &[u8],
     proof: &[u8],
     paired_at: i64,
@@ -32,6 +36,18 @@ pub fn pair_device(
         return Err(StorageError::PairingDenied(device_id.to_string()));
     }
     let tx = conn.transaction()?;
+    tx.execute(
+        "INSERT INTO device_identity
+            (device_id, role, public_key, created_at, display_name)
+         VALUES (?1, ?2, ?3, ?4, ?5)",
+        params![
+            device_id,
+            device_role.as_str(),
+            device_pubkey,
+            paired_at,
+            display_name
+        ],
+    )?;
     tx.execute(
         "INSERT INTO trusted_device
             (device_id, public_key, paired_at, revoked_at, key_rotated_at, sealed_key_ref, label)

--- a/rust-core/crates/friday-storage/tests/pairing.rs
+++ b/rust-core/crates/friday-storage/tests/pairing.rs
@@ -6,7 +6,7 @@ mod common;
 
 use common::temp_db_path;
 use friday_core::{
-    FridayPairPayload, PairAuthority, PairTransportHint, PairTransportKind,
+    DeviceRole, FridayPairPayload, PairAuthority, PairTransportHint, PairTransportKind,
     CURRENT_PAIR_PAYLOAD_VERSION,
 };
 use friday_crypto::pairing_proof;
@@ -43,6 +43,8 @@ fn authenticated_pairing_records_trusted_device() {
         db.conn_mut(),
         secret,
         "dev-1",
+        DeviceRole::Ios,
+        "Jarvis iPhone",
         &pubkey,
         &proof,
         100,
@@ -50,6 +52,7 @@ fn authenticated_pairing_records_trusted_device() {
     )
     .unwrap();
     assert!(pairing::is_trusted(db.conn(), "dev-1").unwrap());
+    assert_eq!(db.count("device_identity").unwrap(), 1);
     assert_eq!(db.count("trusted_device").unwrap(), 1);
     assert_eq!(audit::verify_audit_chain(db.conn()).unwrap(), 1);
 }
@@ -66,6 +69,16 @@ fn complete_qr_pairing_uses_payload_secret_and_records_redacted_projection() {
         .unwrap();
 
     assert!(pairing::is_trusted(db.conn(), "dev-1").unwrap());
+    assert_eq!(db.count("device_identity").unwrap(), 1);
+    let identity: (String, Vec<u8>, String) = db
+        .conn()
+        .query_row(
+            "SELECT role, public_key, display_name FROM device_identity WHERE device_id = 'dev-1'",
+            [],
+            |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)),
+        )
+        .unwrap();
+    assert_eq!(identity, ("ios".into(), pubkey.to_vec(), "dev-1".into()));
     let devices = db.list_trusted_device_projections().unwrap();
     assert_eq!(devices.len(), 1);
     assert_eq!(devices[0].device_id, "dev-1");
@@ -87,6 +100,7 @@ fn expired_payload_and_phone_profile_cannot_complete_qr_pairing() {
     assert!(db
         .complete_qr_pairing(&payload, "dev-1", &pubkey, &proof, 100, "au-expired")
         .is_err());
+    assert_eq!(db.count("device_identity").unwrap(), 0);
     assert_eq!(db.count("trusted_device").unwrap(), 0);
     assert_eq!(db.count("audit_ledger").unwrap(), 0);
 
@@ -120,6 +134,8 @@ fn mitm_substituted_pubkey_is_rejected() {
         db.conn_mut(),
         secret,
         "dev-evil",
+        DeviceRole::Ios,
+        "Evil Phone",
         &attacker_pubkey,
         &proof_for_real_key,
         100,
@@ -130,6 +146,11 @@ fn mitm_substituted_pubkey_is_rejected() {
         db.count("trusted_device").unwrap(),
         0,
         "nothing trusted on denied pairing"
+    );
+    assert_eq!(
+        db.count("device_identity").unwrap(),
+        0,
+        "no identity on denied pairing"
     );
     assert_eq!(
         db.count("audit_ledger").unwrap(),
@@ -148,6 +169,8 @@ fn wrong_secret_is_rejected() {
         db.conn_mut(),
         b"a-guessed-secret",
         "dev-1",
+        DeviceRole::Ios,
+        "Jarvis iPhone",
         &pubkey,
         &proof,
         1,
@@ -167,6 +190,8 @@ fn revoke_blocks_device_and_is_audited() {
         db.conn_mut(),
         secret,
         "dev-1",
+        DeviceRole::Ios,
+        "Jarvis iPhone",
         &pubkey,
         &proof,
         1,
@@ -190,7 +215,18 @@ fn key_rotation_updates_pubkey_and_audits() {
     let secret = b"s";
     let k1 = [1u8; 32];
     let proof = pairing_proof(secret, &k1);
-    pairing::pair_device(db.conn_mut(), secret, "dev-1", &k1, &proof, 1, "au-pair").unwrap();
+    pairing::pair_device(
+        db.conn_mut(),
+        secret,
+        "dev-1",
+        DeviceRole::Ios,
+        "Jarvis iPhone",
+        &k1,
+        &proof,
+        1,
+        "au-pair",
+    )
+    .unwrap();
 
     let k2 = [2u8; 32];
     pairing::rotate_device_key(db.conn_mut(), "dev-1", &k2, 5, "au-rot").unwrap();

--- a/scripts/ops/friday-start-pairing-session.sh
+++ b/scripts/ops/friday-start-pairing-session.sh
@@ -3,9 +3,10 @@
 # Start a short-lived Friday QR pairing session.
 #
 # Truth boundary:
-#   This launches the DARK hub_pairing_server explicitly. It can write trusted_device rows and
-#   append the paired device to the read-seam allowlist only after a valid PairAck. It does not mint
-#   trust_grant/context_passport rows, does not read operator signing keys, and does not flip flags.
+#   This launches the DARK hub_pairing_server explicitly. It can write device_identity +
+#   trusted_device rows and append the paired device to the read-seam allowlist only after a valid
+#   PairAck. It does not mint trust_grant/context_passport rows, does not read operator signing keys,
+#   and does not flip flags.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"


### PR DESCRIPTION
## Summary
- record `device_identity` in the same QR pairing transaction that records `trusted_device`
- keep the existing pairing proof boundary: denied/expired/MITM attempts write no identity, trust row, or audit row
- add storage and hub pair-runtime assertions for the T3 provisioning gap

## Truth labels
- T3 device pairing can now populate `device_identity` + `trusted_device` when a real PairAck succeeds
- This does not mint `trust_grant` or `context_passport`, does not touch operator signing keys, and does not make T3 fully provisioned by itself

## Tests
- `cargo test --manifest-path rust-core/Cargo.toml -p friday-storage --test pairing`
- `cargo test --manifest-path rust-core/Cargo.toml -p friday-hub pair_runtime`
- `cargo fmt --manifest-path rust-core/Cargo.toml --all && git diff --check`
- `detect-secrets-hook --baseline .secrets.baseline rust-core/crates/friday-storage/src/pairing.rs rust-core/crates/friday-storage/src/lib.rs rust-core/crates/friday-storage/tests/pairing.rs rust-core/crates/friday-hub/src/pair_runtime.rs`