### PR TITLE
Enable explicit iOS QR pairing by default

### DIFF
--- a/apps/friday-ios/Sources/FridayMobileShell/FridayApp.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayApp.swift
@@ -182,9 +182,10 @@ final class FridaySession: ObservableObject {
   }
 
   static func defaultPairingClient(deviceKeypair: DeviceKeypair) -> FridayPairingClient? {
-    let args = ProcessInfo.processInfo.arguments
-    let env = ProcessInfo.processInfo.environment
-    guard livePairingRequested(args: args, env: env) else { return nil }
+    // Explicit QR pairing is a user-initiated enrollment ceremony, not a shipped live-read/write
+    // flip. It still fails closed through manifest proof validation, PairingServerConfig's
+    // loopback/private-LAN allowlist, and the Hub's PairAck. Read, write, run-control, signing, and
+    // trust minting remain on their separate gates.
     return RealPairingClientFactory.makeLive(deviceKeypair: deviceKeypair)
   }
 


### PR DESCRIPTION
## Summary
- let the shipped iOS app create the real pairing client for explicit QR/paste pairing attempts by default
- keep live read, live write, run-control, signing, and trust minting on their existing separate gates
- rely on the existing manifest proof validation, loopback/private-LAN host allowlist, and Hub PairAck for fail-closed pairing behavior

## Verification
- swift test --package-path apps/friday-ios --filter 'Pairing|MobileRuntimeGates|DeviceKeypair'\n- apps/friday-ios/build-sim.sh /tmp/friday-ios-qr-pairing-default.png\n- detect-secrets-hook --baseline .secrets.baseline apps/friday-ios/Sources/FridayMobileShell/FridayApp.swift\n- git diff --check\n\nTruth: this does not create trust_grant/context_passport rows and does not count as real device pairing until a real QR ceremony succeeds against the Hub.