### PR TITLE
Show redacted paired device in T3 status

### DIFF
--- a/scripts/ops/friday-t3-provisioning-status.mjs
+++ b/scripts/ops/friday-t3-provisioning-status.mjs
@@ -75,12 +75,61 @@ function queryScalar(dbPath, sql) {
   return result.stdout.trim();
 }
 
+function queryRowFields(dbPath, sql) {
+  const result = spawnSync("sqlite3", ["-readonly", "-separator", "\u001f", dbPath, sql], {
+    encoding: "utf8",
+    maxBuffer: 1024 * 1024,
+  });
+  if (result.error) {
+    throw result.error;
+  }
+  if (result.status !== 0) {
+    throw new Error(result.stderr.trim() || `sqlite3 exited ${result.status}`);
+  }
+  const row = result.stdout.trim();
+  return row ? row.split("\u001f") : null;
+}
+
 function tableExists(dbPath, tableName) {
   const present = queryScalar(
     dbPath,
     `SELECT count(*) FROM sqlite_master WHERE type='table' AND name=${quoteSqlString(tableName)}`,
   );
   return Number(present) > 0;
+}
+
+function latestTrustedDevice(dbPath) {
+  if (!tableExists(dbPath, "trusted_device") || !tableExists(dbPath, "device_identity")) {
+    return null;
+  }
+  const row = queryRowFields(
+    dbPath,
+    `SELECT
+       td.device_id,
+       COALESCE(di.role, ''),
+       COALESCE(NULLIF(td.label, ''), NULLIF(di.display_name, ''), ''),
+       td.paired_at,
+       COALESCE(td.revoked_at, ''),
+       COALESCE(td.key_rotated_at, ''),
+       lower(hex(substr(td.public_key, 1, 4))) || ':' || lower(hex(substr(td.public_key, -4)))
+     FROM trusted_device AS td
+     LEFT JOIN device_identity AS di ON di.device_id = td.device_id
+     ORDER BY td.paired_at DESC, td.device_id
+     LIMIT 1`,
+  );
+  if (!row) {
+    return null;
+  }
+  const [deviceId, role, label, pairedAt, revokedAt, keyRotatedAt, pubkeyFingerprint] = row;
+  return {
+    device_id: deviceId,
+    role: role || "unknown",
+    label: label || "",
+    paired_at: Number(pairedAt),
+    revoked_at: revokedAt === "" ? null : Number(revokedAt),
+    key_rotated_at: keyRotatedAt === "" ? null : Number(keyRotatedAt),
+    pubkey_fingerprint: pubkeyFingerprint,
+  };
 }
 
 function countTable(dbPath, tableName) {
@@ -108,6 +157,7 @@ export function buildT3ProvisioningStatus(dbPath, nowMs = Date.now()) {
     T3_TABLES.map((tableName) => [tableName, countTable(dbPath, tableName)]),
   );
   const activeTrustGrants = countActiveTrustGrants(dbPath, nowMs);
+  const latest_device = latestTrustedDevice(dbPath);
   const checks = {
     device_identity: (counts.device_identity ?? 0) > 0,
     trusted_device: (counts.trusted_device ?? 0) > 0,
@@ -124,6 +174,7 @@ export function buildT3ProvisioningStatus(dbPath, nowMs = Date.now()) {
     truth_label: "t3_provisioning_status_read_only_no_mint_no_signature",
     generated_at_utc: new Date(nowMs).toISOString(),
     counts,
+    latest_device,
     active_trust_grants: activeTrustGrants,
     checks,
     status: missing.length === 0 ? "ready" : "incomplete",
@@ -148,6 +199,19 @@ export function renderText(status) {
     lines.push(`  ${tableName}=${status.counts[tableName] ?? "missing-table"}`);
   }
   lines.push(`  active_trust_grants=${status.active_trust_grants ?? "missing-table"}`);
+  if (status.latest_device) {
+    lines.push(
+      "",
+      "latest_device:",
+      `  device_id=${status.latest_device.device_id}`,
+      `  role=${status.latest_device.role}`,
+      `  label=${status.latest_device.label || "<empty>"}`,
+      `  paired_at=${status.latest_device.paired_at}`,
+      `  revoked_at=${status.latest_device.revoked_at ?? "<active>"}`,
+      `  key_rotated_at=${status.latest_device.key_rotated_at ?? "<never>"}`,
+      `  pubkey_fingerprint=${status.latest_device.pubkey_fingerprint}`,
+    );
+  }
   if (status.missing.length > 0) {
     lines.push("", `missing=${status.missing.join(",")}`);
   }

--- a/test/unit/scripts/ops/friday-t3-provisioning-status.test.ts
+++ b/test/unit/scripts/ops/friday-t3-provisioning-status.test.ts
@@ -31,8 +31,21 @@ function createProvisionTables(dbPath: string): void {
   execSql(
     dbPath,
     `
-    CREATE TABLE device_identity (device_id TEXT);
-    CREATE TABLE trusted_device (device_id TEXT);
+    CREATE TABLE device_identity (
+      device_id TEXT,
+      role TEXT,
+      public_key BLOB,
+      created_at INTEGER,
+      display_name TEXT
+    );
+    CREATE TABLE trusted_device (
+      device_id TEXT,
+      public_key BLOB,
+      paired_at INTEGER,
+      revoked_at INTEGER,
+      key_rotated_at INTEGER,
+      label TEXT
+    );
     CREATE TABLE trust_grant (grant_id TEXT, revoked INTEGER, expires_at INTEGER);
     CREATE TABLE context_passport (passport_id TEXT);
     CREATE TABLE context_passport_item (passport_id TEXT, item_id TEXT);
@@ -72,6 +85,7 @@ describe("friday-t3-provisioning-status", () => {
       context_passport: 0,
       context_passport_item: 0,
     });
+    expect(status.latest_device).toBeNull();
   });
 
   it("requires active grant and every T3 row family before reporting ready", async () => {
@@ -81,8 +95,10 @@ describe("friday-t3-provisioning-status", () => {
     execSql(
       dbPath,
       `
-      INSERT INTO device_identity(device_id) VALUES ('device-1');
-      INSERT INTO trusted_device(device_id) VALUES ('device-1');
+      INSERT INTO device_identity(device_id, role, public_key, created_at, display_name)
+        VALUES ('device-1', 'ios', X'0101010101010101010101010101010101010101010101010101010101010101', 1700, 'Jarvis iPhone');
+      INSERT INTO trusted_device(device_id, public_key, paired_at, revoked_at, key_rotated_at, label)
+        VALUES ('device-1', X'0101010101010101010101010101010101010101010101010101010101010101', 1800, NULL, NULL, 'Jarvis iPhone');
       INSERT INTO trust_grant(grant_id, revoked, expires_at) VALUES ('grant-1', 0, 1900000000000);
       INSERT INTO context_passport(passport_id) VALUES ('passport-1');
       INSERT INTO context_passport_item(passport_id, item_id) VALUES ('passport-1', 'item-1');
@@ -96,6 +112,18 @@ describe("friday-t3-provisioning-status", () => {
     expect(status.active_trust_grants).toBe(1);
     expect(status.missing).toEqual([]);
     expect(status.caveat).toContain("does not claim END-BAR");
+    expect(status.latest_device).toMatchObject({
+      device_id: "device-1",
+      role: "ios",
+      label: "Jarvis iPhone",
+      paired_at: 1800,
+      revoked_at: null,
+      key_rotated_at: null,
+      pubkey_fingerprint: "01010101:01010101",
+    });
+    expect(JSON.stringify(status.latest_device)).not.toContain(
+      "0101010101010101010101010101010101010101010101010101010101010101",
+    );
   });
 
   it("treats revoked or expired grants as not ready even when rows exist", async () => {
@@ -105,8 +133,10 @@ describe("friday-t3-provisioning-status", () => {
     execSql(
       dbPath,
       `
-      INSERT INTO device_identity(device_id) VALUES ('device-1');
-      INSERT INTO trusted_device(device_id) VALUES ('device-1');
+      INSERT INTO device_identity(device_id, role, public_key, created_at, display_name)
+        VALUES ('device-1', 'ios', X'0101010101010101010101010101010101010101010101010101010101010101', 1700, 'Jarvis iPhone');
+      INSERT INTO trusted_device(device_id, public_key, paired_at, revoked_at, key_rotated_at, label)
+        VALUES ('device-1', X'0101010101010101010101010101010101010101010101010101010101010101', 1800, NULL, NULL, 'Jarvis iPhone');
       INSERT INTO trust_grant(grant_id, revoked, expires_at) VALUES ('grant-1', 1, 1900000000000);
       INSERT INTO trust_grant(grant_id, revoked, expires_at) VALUES ('grant-2', 0, 1000);
       INSERT INTO context_passport(passport_id) VALUES ('passport-1');


### PR DESCRIPTION
## Summary
- add a read-only latest_device summary to the T3 provisioning status verifier
- expose only device id, role, label, paired/revoked/key-rotated timestamps, and a short public-key fingerprint
- keep the verifier non-mutating and non-claiming: no trust mint, no signature, no organic/release claim

## Verification
- ln -s /Users/jarvis/Projects/Friday/node_modules node_modules && npx vitest run test/unit/scripts/ops/friday-t3-provisioning-status.test.ts; rm node_modules
- node scripts/ops/friday-t3-provisioning-status.mjs --db "$HOME/Library/Application Support/Friday/state/rust-hub.sqlite" --json
- detect-secrets-hook --baseline .secrets.baseline scripts/ops/friday-t3-provisioning-status.mjs test/unit/scripts/ops/friday-t3-provisioning-status.test.ts
- git diff --check

Truth: read-only status improvement only; latest_device is a redacted operator aid and does not satisfy T3 by itself.