### PR TITLE
Clarify iOS QR pairing readiness copy

### DIFF
--- a/apps/friday-ios/Sources/FridayMobileShellCore/DeviceKeypairStore.swift
+++ b/apps/friday-ios/Sources/FridayMobileShellCore/DeviceKeypairStore.swift
@@ -88,8 +88,8 @@ public struct DevicePairingReadiness: Sendable, Equatable {
         publicKeyHex: nil,
         readLiveRequested: readLiveRequested,
         writeLiveRequested: writeLiveRequested,
-        reason: "Live read/write device-keypair mode is not enabled for this launch.",
-        nextStep: "Paste a Hub pairing QR below; live read/write still require their launch flags after PairAck.")
+        reason: "QR pairing is available; live read/write device-keypair mode is not enabled for this launch.",
+        nextStep: "Scan or paste a Hub pairing QR below; live read/write still require their launch flags after PairAck.")
     }
 
     do {

--- a/apps/friday-ios/Tests/FridayMobileShellCoreTests/DeviceKeypairStoreTests.swift
+++ b/apps/friday-ios/Tests/FridayMobileShellCoreTests/DeviceKeypairStoreTests.swift
@@ -152,6 +152,10 @@ func devicePairingReadinessDefaultOffDoesNotTouchBackend() {
   #expect(readiness.publicKeyHex == nil)
   #expect(readiness.readLiveRequested == false)
   #expect(readiness.writeLiveRequested == false)
+  #expect(readiness.reason.contains("QR pairing is available"))
+  #expect(readiness.nextStep.contains("Scan or paste"))
+  #expect(!readiness.reason.lowercased().contains("secret"))
+  #expect(!readiness.nextStep.lowercased().contains("secret"))
   #expect(backend.loadCount == 0)
   #expect(backend.storeCount == 0)
 }


### PR DESCRIPTION
## Summary
- Clarify the iOS device-pairing default copy now that explicit QR scan/paste pairing is available.
- Keep live read/write disabled by default and state that PairAck does not grant write authority.
- Add readiness-copy assertions so the UI text does not leak secrets or imply grant/passport minting.

## Verification
- swift test --package-path apps/friday-ios --filter 'DevicePairingReadiness|DeviceKeypair'\n- detect-secrets-hook --baseline .secrets.baseline apps/friday-ios/Sources/FridayMobileShellCore/DeviceKeypairStore.swift apps/friday-ios/Tests/FridayMobileShellCoreTests/DeviceKeypairStoreTests.swift\n- git diff --check\n\nTruth: copy-only follow-up after #1077; no live read/write flip, no grant/passport mint, no operator signing path.