### PR TITLE
Surface T3 provisioning status across clients

### DIFF
--- a/apps/friday-ios/Sources/FridayMobileShell/FridayProjectionScreens.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayProjectionScreens.swift
@@ -531,8 +531,9 @@ struct FridayProjectionScreen: View {
           healthy: false)
         readinessRow(
           title: "Device pairing",
-          value: "sim loopback now; physical device later",
-          healthy: false)
+          value: projection.t3ProvisioningStatus?.paired == true ? "paired in Hub" : "no paired device in Hub",
+          healthy: projection.t3ProvisioningStatus?.paired == true)
+        t3ProvisioningRows(projection.t3ProvisioningStatus)
         readinessRow(
           title: "Provider auth",
           value: "read-only doctor; never stores provider secrets",
@@ -545,6 +546,34 @@ struct FridayProjectionScreen: View {
         .disabled(viewModel.detailState.isLoading)
         RefPill(label: "mission_id", ref: projection.missionId)
       }
+    }
+  }
+
+  @ViewBuilder
+  private func t3ProvisioningRows(_ status: HomeT3ProvisioningStatus?) -> some View {
+    if let status {
+      readinessRow(
+        title: "Trust grant",
+        value: status.activeTrustGrantCount > 0 ? "active grant present" : "operator grant not present",
+        healthy: status.activeTrustGrantCount > 0)
+      readinessRow(
+        title: "Context passport",
+        value: status.contextPassportCount > 0 ? "\(status.contextPassportCount) passport(s)" : "not minted",
+        healthy: status.contextPassportCount > 0 && status.contextPassportItemCount > 0)
+      if let device = status.latestDevice {
+        RefPill(label: "trusted_device", ref: device.deviceId)
+        RefPill(label: "device_fingerprint", ref: device.pubkeyFingerprint)
+      }
+      RefPill(label: "truth", ref: status.truthLabel)
+    } else {
+      readinessRow(
+        title: "Trust grant",
+        value: "not in projection",
+        healthy: false)
+      readinessRow(
+        title: "Context passport",
+        value: "not in projection",
+        healthy: false)
     }
   }
 

--- a/apps/friday-ios/Sources/FridayMobileShellCore/HomeViewModel.swift
+++ b/apps/friday-ios/Sources/FridayMobileShellCore/HomeViewModel.swift
@@ -50,6 +50,7 @@ public struct HomeProjection: Sendable, Equatable {
   public let memoryCandidates: [HomeMemoryCandidate]
   public let runOutcomeLearningCandidates: [HomeRunOutcomeLearningCandidate]
   public let capabilityStates: [HomeCapabilityState]
+  public let t3ProvisioningStatus: HomeT3ProvisioningStatus?
   public let transcriptEvents: [HomeTranscriptEvent]
   /// The Hub epoch-millis the snapshot was generated (lets the UI flag staleness).
   public let generatedAtMs: Int64
@@ -76,6 +77,7 @@ public struct HomeProjection: Sendable, Equatable {
     self.runOutcomeLearningCandidates = Self.parseRunOutcomeLearningCandidates(
       raw["runOutcomeLearningCandidates"])
     self.capabilityStates = Self.parseCapabilityStates(raw["capabilityStates"])
+    self.t3ProvisioningStatus = HomeT3ProvisioningStatus(raw: raw["t3ProvisioningStatus"])
     self.transcriptEvents = Self.parseTranscriptEvents(raw["transcriptSections"])
     self.generatedAtMs = snapshot.generatedAtMs
   }
@@ -93,6 +95,7 @@ public struct HomeProjection: Sendable, Equatable {
       && memoryCandidates.isEmpty
       && runOutcomeLearningCandidates.isEmpty
       && capabilityStates.isEmpty
+      && t3ProvisioningStatus == nil
       && transcriptEvents.isEmpty
   }
 
@@ -233,6 +236,65 @@ public struct HomeCapabilityState: Sendable, Identifiable, Equatable {
   public let dispatchAllowed: Bool
   public let summary: String
   public let proofRef: String
+}
+
+public struct HomeT3ProvisioningStatus: Sendable, Equatable {
+  public let truthLabel: String
+  public let paired: Bool
+  public let deviceIdentityCount: Int
+  public let trustedDeviceCount: Int
+  public let activeTrustedDeviceCount: Int
+  public let trustGrantCount: Int
+  public let activeTrustGrantCount: Int
+  public let contextPassportCount: Int
+  public let contextPassportItemCount: Int
+  public let latestDevice: HomeTrustedDeviceSummary?
+
+  init?(raw: Any?) {
+    guard let row = raw as? [String: Any] else { return nil }
+    self.truthLabel = row["truthLabel"] as? String ?? "unknown"
+    self.paired = row["paired"] as? Bool ?? false
+    self.deviceIdentityCount = Self.int(row["deviceIdentityCount"])
+    self.trustedDeviceCount = Self.int(row["trustedDeviceCount"])
+    self.activeTrustedDeviceCount = Self.int(row["activeTrustedDeviceCount"])
+    self.trustGrantCount = Self.int(row["trustGrantCount"])
+    self.activeTrustGrantCount = Self.int(row["activeTrustGrantCount"])
+    self.contextPassportCount = Self.int(row["contextPassportCount"])
+    self.contextPassportItemCount = Self.int(row["contextPassportItemCount"])
+    self.latestDevice = HomeTrustedDeviceSummary(raw: row["latestDevice"])
+  }
+
+  public var isFullyProvisioned: Bool {
+    paired && activeTrustGrantCount > 0 && contextPassportCount > 0 && contextPassportItemCount > 0
+  }
+
+  private static func int(_ value: Any?) -> Int {
+    if let int = value as? Int { return int }
+    if let number = value as? NSNumber { return number.intValue }
+    return 0
+  }
+}
+
+public struct HomeTrustedDeviceSummary: Sendable, Equatable {
+  public let deviceId: String
+  public let label: String
+  public let pairedAt: Int64
+  public let pubkeyFingerprint: String
+
+  init?(raw: Any?) {
+    guard let row = raw as? [String: Any] else { return nil }
+    self.deviceId = row["deviceId"] as? String ?? ""
+    self.label = row["label"] as? String ?? ""
+    self.pairedAt = Self.int64(row["pairedAt"])
+    self.pubkeyFingerprint = row["pubkeyFingerprint"] as? String ?? ""
+  }
+
+  private static func int64(_ value: Any?) -> Int64 {
+    if let int = value as? Int64 { return int }
+    if let int = value as? Int { return Int64(int) }
+    if let number = value as? NSNumber { return number.int64Value }
+    return 0
+  }
 }
 
 public struct HomeTranscriptEvent: Sendable, Identifiable, Equatable {

--- a/apps/friday-ios/Tests/FridayMobileShellCoreTests/HomeViewModelTests.swift
+++ b/apps/friday-ios/Tests/FridayMobileShellCoreTests/HomeViewModelTests.swift
@@ -265,6 +265,25 @@ final class HomeViewModelTests: XCTestCase {
       "capabilityStates": [
         { "id": "cap-route", "label": "Route advisor", "kind": "advisor", "truthLabel": "friday_owned", "approvalState": "not_required", "dispatchAllowed": true, "summary": "Routes are advisory.", "proofRef": "proof://cap/1" }
       ],
+      "t3ProvisioningStatus": {
+        "truthLabel": "rust_hub_t3_provisioning_read_only_no_mint",
+        "paired": true,
+        "deviceIdentityCount": 1,
+        "trustedDeviceCount": 1,
+        "activeTrustedDeviceCount": 1,
+        "trustGrantCount": 1,
+        "activeTrustGrantCount": 1,
+        "contextPassportCount": 1,
+        "contextPassportItemCount": 2,
+        "latestDevice": {
+          "deviceId": "proof://device/paired-ios-1",
+          "label": "operator phone",
+          "pairedAt": 1780640000000,
+          "revokedAt": null,
+          "keyRotatedAt": null,
+          "pubkeyFingerprint": "abcd1234:dcba4321"
+        }
+      },
       "transcriptSections": [
         { "id": "sec-1", "title": "Mission", "groupKind": "mission", "missionId": "mission-7", "truthLabel": "friday_owned", "status": "ready", "events": [
           { "id": "evt-1", "missionId": "mission-7", "surface": "mobile", "status": "ready", "truthLabel": "friday_owned", "summary": "Mobile surface read the mission projection.", "capturedAt": "2026-06-21T00:00:00Z" }
@@ -343,6 +362,11 @@ final class HomeViewModelTests: XCTestCase {
     XCTAssertEqual(p.memoryCandidates.first?.grantsMemoryAuthority, false)
     XCTAssertEqual(p.runOutcomeLearningCandidates.first?.runId, "run-1")
     XCTAssertEqual(p.capabilityStates.first?.dispatchAllowed, true)
+    XCTAssertEqual(p.t3ProvisioningStatus?.truthLabel, "rust_hub_t3_provisioning_read_only_no_mint")
+    XCTAssertEqual(p.t3ProvisioningStatus?.paired, true)
+    XCTAssertEqual(p.t3ProvisioningStatus?.latestDevice?.deviceId, "proof://device/paired-ios-1")
+    XCTAssertEqual(p.t3ProvisioningStatus?.latestDevice?.pubkeyFingerprint, "abcd1234:dcba4321")
+    XCTAssertEqual(p.t3ProvisioningStatus?.isFullyProvisioned, true)
     XCTAssertEqual(p.transcriptEvents.first?.summary, "Mobile surface read the mission projection.")
     XCTAssertEqual(p.needsMeCount, 4)
   }

--- a/apps/macos/FridayHubConsole/Sources/FridayHubConsole/OperationsOverviewScreen.swift
+++ b/apps/macos/FridayHubConsole/Sources/FridayHubConsole/OperationsOverviewScreen.swift
@@ -90,6 +90,7 @@ struct OperationsOverviewScreen: View {
       }
 
       devicePairingCard(viewModel.devicePairing)
+      t3ProvisioningCard(snapshot.t3ProvisioningStatus)
       missionCard(snapshot)
       if snapshot.isLoadedEmpty {
         loadedEmptyCard(snapshot)
@@ -159,6 +160,72 @@ struct OperationsOverviewScreen: View {
     .accessibilityElement(children: .combine)
     .accessibilityLabel("Device pairing readiness \(readiness.mode.rawValue). \(readiness.reason)")
     .accessibilityIdentifier("friday.desktop.device-pairing-readiness")
+  }
+
+  private func t3ProvisioningCard(_ status: MissionWorkbenchT3ProvisioningStatus?) -> some View {
+    GlassPanel {
+      VStack(alignment: .leading, spacing: HubTheme.rowSpacing) {
+        HStack {
+          cardTitle("T3 Provisioning")
+          Spacer()
+          StatusChip(
+            text: status?.isFullyProvisioned == true ? "fully provisioned" : "operator gated",
+            bg: status?.isFullyProvisioned == true ? HubTheme.chipPendingBG : HubTheme.chipWarnBG,
+            fg: status?.isFullyProvisioned == true ? HubTheme.chipPendingFG : HubTheme.chipWarnFG)
+        }
+
+        if let status {
+          Text(status.truthLabel)
+            .font(.system(size: 10))
+            .foregroundStyle(HubTheme.textSecondary)
+            .fixedSize(horizontal: false, vertical: true)
+          HStack(spacing: 8) {
+            StatusChip(
+              text: status.paired ? "paired" : "not paired",
+              bg: status.paired ? HubTheme.chipPendingBG : HubTheme.chipWarnBG,
+              fg: status.paired ? HubTheme.chipPendingFG : HubTheme.chipWarnFG)
+            StatusChip(
+              text: "active devices \(status.activeTrustedDeviceCount)",
+              bg: HubTheme.chipPendingBG,
+              fg: HubTheme.chipPendingFG)
+            StatusChip(
+              text: "active grants \(status.activeTrustGrantCount)",
+              bg: status.activeTrustGrantCount > 0 ? HubTheme.chipPendingBG : HubTheme.chipWarnBG,
+              fg: status.activeTrustGrantCount > 0 ? HubTheme.chipPendingFG : HubTheme.chipWarnFG)
+            StatusChip(
+              text: "passports \(status.contextPassportCount)",
+              bg: status.contextPassportCount > 0 ? HubTheme.chipPendingBG : HubTheme.chipWarnBG,
+              fg: status.contextPassportCount > 0 ? HubTheme.chipPendingFG : HubTheme.chipWarnFG)
+          }
+          .lineLimit(1)
+
+          if let device = status.latestDevice {
+            RefPill(label: "latest_device", ref: device.deviceId)
+            HStack(spacing: 8) {
+              RefPill(label: "device_label", ref: device.label.isEmpty ? "unlabeled" : device.label)
+              RefPill(label: "pubkey_fingerprint", ref: device.pubkeyFingerprint)
+            }
+          } else {
+            Text("No active trusted device row is visible in the Hub projection.")
+              .font(.system(size: 12))
+              .foregroundStyle(HubTheme.textSecondary)
+          }
+
+          Text("Read-only status from Hub DB; trust grant and context passport minting remain operator CLI ceremonies.")
+            .font(.system(size: 10))
+            .foregroundStyle(HubTheme.textSecondary)
+            .fixedSize(horizontal: false, vertical: true)
+        } else {
+          Text("This Hub projection does not expose T3 provisioning status yet.")
+            .font(.system(size: 12))
+            .foregroundStyle(HubTheme.textSecondary)
+        }
+      }
+    }
+    .accessibilityElement(children: .combine)
+    .accessibilityLabel(
+      "T3 provisioning \(status?.isFullyProvisioned == true ? "fully provisioned" : "operator gated")")
+    .accessibilityIdentifier("friday.desktop.t3-provisioning-status")
   }
 
   private func loadedEmptyCard(_ snapshot: WorkbenchSnapshot) -> some View {

--- a/apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/MockReadClient.swift
+++ b/apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/MockReadClient.swift
@@ -152,6 +152,23 @@ public struct MockReadClient: FridayRustReadClient {
         executedTools: 0
       )
     ]
+    let t3ProvisioningStatus = MissionWorkbenchT3ProvisioningStatus(
+      truthLabel: "rust_hub_t3_provisioning_read_only_no_mint",
+      paired: true,
+      deviceIdentityCount: 1,
+      trustedDeviceCount: 1,
+      activeTrustedDeviceCount: 1,
+      trustGrantCount: 1,
+      activeTrustGrantCount: 1,
+      contextPassportCount: 1,
+      contextPassportItemCount: 2,
+      latestDevice: MissionWorkbenchTrustedDeviceSummary(
+        deviceId: "proof://device/paired-desktop-1",
+        label: "Friday iPhone",
+        pairedAt: 1_780_640_000_123,
+        pubkeyFingerprint: "abcd1234:dcba4321"
+      )
+    )
 
     let providerReceiptRefs = [
       "proof://provider-receipt/3f9a1c2b7e004d18",
@@ -315,6 +332,7 @@ public struct MockReadClient: FridayRustReadClient {
       memoryCandidates: memoryCandidates,
       runOutcomeLearningCandidates: runOutcomeLearningCandidates,
       capabilityStates: capabilityStates,
+      t3ProvisioningStatus: t3ProvisioningStatus,
       transcriptSections: [missionSection, providerSection, channelSection, statusSection]
     )
   }()

--- a/apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/WorkbenchSnapshot.swift
+++ b/apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/WorkbenchSnapshot.swift
@@ -420,6 +420,7 @@ public struct WorkbenchSnapshot: Codable, Sendable, Equatable {
   public let memoryCandidates: [MissionWorkbenchMemoryCandidate]
   public let runOutcomeLearningCandidates: [MissionWorkbenchRunOutcomeLearningCandidate]
   public let capabilityStates: [MissionWorkbenchCapabilityState]
+  public let t3ProvisioningStatus: MissionWorkbenchT3ProvisioningStatus?
   public let transcriptSections: [MissionTranscriptSection]
 
   public init(
@@ -437,6 +438,7 @@ public struct WorkbenchSnapshot: Codable, Sendable, Equatable {
     memoryCandidates: [MissionWorkbenchMemoryCandidate],
     runOutcomeLearningCandidates: [MissionWorkbenchRunOutcomeLearningCandidate] = [],
     capabilityStates: [MissionWorkbenchCapabilityState],
+    t3ProvisioningStatus: MissionWorkbenchT3ProvisioningStatus? = nil,
     transcriptSections: [MissionTranscriptSection]
   ) {
     self.missionId = missionId
@@ -453,6 +455,7 @@ public struct WorkbenchSnapshot: Codable, Sendable, Equatable {
     self.memoryCandidates = memoryCandidates
     self.runOutcomeLearningCandidates = runOutcomeLearningCandidates
     self.capabilityStates = capabilityStates
+    self.t3ProvisioningStatus = t3ProvisioningStatus
     self.transcriptSections = transcriptSections
   }
 
@@ -464,8 +467,75 @@ public struct WorkbenchSnapshot: Codable, Sendable, Equatable {
       && memoryCandidates.isEmpty
       && runOutcomeLearningCandidates.isEmpty
       && capabilityStates.isEmpty
+      && t3ProvisioningStatus == nil
       && transcriptSections.isEmpty
   }
 }
 
 public typealias MissionWorkbenchSnapshot = WorkbenchSnapshot
+
+public struct MissionWorkbenchT3ProvisioningStatus: Codable, Sendable, Equatable {
+  public let truthLabel: String
+  public let paired: Bool
+  public let deviceIdentityCount: Int
+  public let trustedDeviceCount: Int
+  public let activeTrustedDeviceCount: Int
+  public let trustGrantCount: Int
+  public let activeTrustGrantCount: Int
+  public let contextPassportCount: Int
+  public let contextPassportItemCount: Int
+  public let latestDevice: MissionWorkbenchTrustedDeviceSummary?
+
+  public init(
+    truthLabel: String,
+    paired: Bool,
+    deviceIdentityCount: Int,
+    trustedDeviceCount: Int,
+    activeTrustedDeviceCount: Int,
+    trustGrantCount: Int,
+    activeTrustGrantCount: Int,
+    contextPassportCount: Int,
+    contextPassportItemCount: Int,
+    latestDevice: MissionWorkbenchTrustedDeviceSummary?
+  ) {
+    self.truthLabel = truthLabel
+    self.paired = paired
+    self.deviceIdentityCount = deviceIdentityCount
+    self.trustedDeviceCount = trustedDeviceCount
+    self.activeTrustedDeviceCount = activeTrustedDeviceCount
+    self.trustGrantCount = trustGrantCount
+    self.activeTrustGrantCount = activeTrustGrantCount
+    self.contextPassportCount = contextPassportCount
+    self.contextPassportItemCount = contextPassportItemCount
+    self.latestDevice = latestDevice
+  }
+
+  public var isFullyProvisioned: Bool {
+    paired && activeTrustGrantCount > 0 && contextPassportCount > 0 && contextPassportItemCount > 0
+  }
+}
+
+public struct MissionWorkbenchTrustedDeviceSummary: Codable, Sendable, Equatable {
+  public let deviceId: String
+  public let label: String
+  public let pairedAt: Int64
+  public let revokedAt: Int64?
+  public let keyRotatedAt: Int64?
+  public let pubkeyFingerprint: String
+
+  public init(
+    deviceId: String,
+    label: String,
+    pairedAt: Int64,
+    revokedAt: Int64? = nil,
+    keyRotatedAt: Int64? = nil,
+    pubkeyFingerprint: String
+  ) {
+    self.deviceId = deviceId
+    self.label = label
+    self.pairedAt = pairedAt
+    self.revokedAt = revokedAt
+    self.keyRotatedAt = keyRotatedAt
+    self.pubkeyFingerprint = pubkeyFingerprint
+  }
+}

--- a/apps/macos/FridayHubConsole/Tests/FridayHubConsoleCoreTests/OperationsOverviewViewModelTests.swift
+++ b/apps/macos/FridayHubConsole/Tests/FridayHubConsoleCoreTests/OperationsOverviewViewModelTests.swift
@@ -81,6 +81,10 @@ func snapshotExercisesEveryHonestRenderingRule() {
   #expect(snapshot.memoryCandidates.allSatisfy { !$0.grantsMemoryAuthority })
   #expect(snapshot.runOutcomeLearningCandidates.first?.state == "pending")
   #expect(snapshot.runOutcomeLearningCandidates.first?.evidenceRef.hasPrefix("proof://") == true)
+  #expect(snapshot.t3ProvisioningStatus?.truthLabel == "rust_hub_t3_provisioning_read_only_no_mint")
+  #expect(snapshot.t3ProvisioningStatus?.isFullyProvisioned == true)
+  #expect(snapshot.t3ProvisioningStatus?.latestDevice?.deviceId.hasPrefix("proof://device/") == true)
+  #expect(snapshot.t3ProvisioningStatus?.latestDevice?.pubkeyFingerprint == "abcd1234:dcba4321")
 }
 
 @Test
@@ -231,6 +235,23 @@ func decodesRustProjectionShapedJSON() throws {
          "approvalState": "not_required", "dispatchAllowed": false, "summary": "s",
          "proofRef": "proof://route-decision/abc"}
       ],
+      "t3ProvisioningStatus": {
+        "truthLabel": "rust_hub_t3_provisioning_read_only_no_mint",
+        "paired": true,
+        "deviceIdentityCount": 1,
+        "trustedDeviceCount": 1,
+        "activeTrustedDeviceCount": 1,
+        "trustGrantCount": 1,
+        "activeTrustGrantCount": 1,
+        "contextPassportCount": 1,
+        "contextPassportItemCount": 2,
+        "latestDevice": {
+          "deviceId": "proof://device/paired-desktop-1",
+          "label": "Friday iPhone",
+          "pairedAt": 1780640000123,
+          "pubkeyFingerprint": "abcd1234:dcba4321"
+        }
+      },
       "transcriptSections": [
         {"id": "sec", "title": "Mission", "groupKind": "mission", "missionId": "mission_x",
          "truthLabel": "friday_owned", "status": "waiting", "events": [
@@ -247,6 +268,9 @@ func decodesRustProjectionShapedJSON() throws {
   #expect(snapshot.statusLabels == [.stale, .offline, .error])
   #expect(snapshot.workItems.first?.state == .providerAck)
   #expect(snapshot.runOutcomeLearningCandidates.first?.id == "a1:run_x:preference")
+  #expect(snapshot.t3ProvisioningStatus?.paired == true)
+  #expect(snapshot.t3ProvisioningStatus?.latestDevice?.deviceId == "proof://device/paired-desktop-1")
+  #expect(snapshot.t3ProvisioningStatus?.latestDevice?.pubkeyFingerprint == "abcd1234:dcba4321")
   #expect(snapshot.transcriptSections.first?.events.first?.evidenceRefs.timelineRef != nil)
 }
 
@@ -284,6 +308,8 @@ func refreshPreservesRenderCriticalProjectionFieldsFromWire() async {
   #expect(snapshot.workItems.map(\.owner) == expected.workItems.map(\.owner))
   #expect(snapshot.memoryCandidates.map(\.evidenceRef) == expected.memoryCandidates.map(\.evidenceRef))
   #expect(snapshot.runOutcomeLearningCandidates.map(\.evidenceRef) == expected.runOutcomeLearningCandidates.map(\.evidenceRef))
+  #expect(snapshot.t3ProvisioningStatus == expected.t3ProvisioningStatus)
+  #expect(snapshot.t3ProvisioningStatus?.latestDevice?.deviceId.hasPrefix("proof://device/") == true)
   #expect(snapshot.transcriptSections.flatMap(\.events).map(\.proofRef) == expected.transcriptSections.flatMap(\.events).map(\.proofRef))
   #expect(!snapshot.isLoadedEmpty)
 }

--- a/rust-core/crates/friday-hub/src/workbench_projection.rs
+++ b/rust-core/crates/friday-hub/src/workbench_projection.rs
@@ -151,6 +151,7 @@ pub fn project_workbench(db: &Db, requested_mission_id: Option<&str>) -> Result<
         "memoryCandidates": memory_candidates_json(&mission, &links),
         "runOutcomeLearningCandidates": run_outcome_learning_candidates,
         "capabilityStates": capability_states_json(&work_items, route_decision.route_decision_ref.as_str()),
+        "t3ProvisioningStatus": t3_provisioning_status_json(db).map_err(|err| err.to_string())?,
         "transcriptSections": transcript_sections_json(&mission.mission_id, transcript_events)
     });
 
@@ -459,6 +460,45 @@ fn capability_states_json(work_items: &[WorkItem], route_ref: &str) -> Vec<Value
         }
     }
     rows
+}
+
+fn t3_provisioning_status_json(db: &Db) -> friday_storage::Result<Value> {
+    let device_identity_count = db.count("device_identity")?;
+    let trusted_device_count = db.count("trusted_device")?;
+    let active_trusted_device_count: i64 = db.conn().query_row(
+        "SELECT count(*) FROM trusted_device WHERE revoked_at IS NULL",
+        [],
+        |row| row.get(0),
+    )?;
+    let trust_grant_count = db.count("trust_grant")?;
+    let context_passport_count = db.count("context_passport")?;
+    let context_passport_item_count = db.count("context_passport_item")?;
+    let active_trust_grant_count: i64 = db.conn().query_row(
+        "SELECT count(*) FROM trust_grant WHERE revoked = 0 AND (expires_at IS NULL OR expires_at > strftime('%s','now') * 1000)",
+        [],
+        |row| row.get(0),
+    )?;
+    let latest_device = db.list_trusted_device_projections()?.into_iter().next();
+
+    Ok(json!({
+        "truthLabel": "rust_hub_t3_provisioning_read_only_no_mint",
+        "paired": device_identity_count > 0 && active_trusted_device_count > 0,
+        "deviceIdentityCount": device_identity_count,
+        "trustedDeviceCount": trusted_device_count,
+        "activeTrustedDeviceCount": active_trusted_device_count,
+        "trustGrantCount": trust_grant_count,
+        "activeTrustGrantCount": active_trust_grant_count,
+        "contextPassportCount": context_passport_count,
+        "contextPassportItemCount": context_passport_item_count,
+        "latestDevice": latest_device.map(|device| json!({
+            "deviceId": redacted_ref("device", &device.device_id),
+            "label": device.label,
+            "pairedAt": device.paired_at,
+            "revokedAt": device.revoked_at,
+            "keyRotatedAt": device.key_rotated_at,
+            "pubkeyFingerprint": device.pubkey_fingerprint,
+        }))
+    }))
 }
 
 fn transcript_sections_json(mission_id: &str, events: Vec<Value>) -> Vec<Value> {
@@ -1077,6 +1117,7 @@ mod tests {
         MissionStatus, RouteDecisionCard, TruthStatus, WorkItem, WorkItemStatus, WorkLane,
     };
     use friday_storage::memory;
+    use rusqlite::params;
     use std::sync::atomic::{AtomicU64, Ordering};
 
     static C: AtomicU64 = AtomicU64::new(0);
@@ -1352,6 +1393,95 @@ mod tests {
             row.get("runId").and_then(Value::as_str) == Some("run-follow-up-a1")
                 && row.get("workItemId").and_then(Value::as_str) == Some("autodisp-1781492033")
         }));
+    }
+
+    #[test]
+    fn projects_t3_provisioning_status_from_hub_tables_without_raw_device_key() {
+        let db = Db::open_hub(&tmp()).unwrap();
+        let mission_id = seed_real_producer_mission(&db);
+        let device_pubkey = vec![1_u8; 32];
+        db.conn()
+            .execute(
+                "INSERT INTO device_identity
+                    (device_id, role, public_key, created_at, display_name)
+                 VALUES (?1, 'phone', ?2, ?3, ?4)",
+                params![
+                    "ios-real-device-1",
+                    device_pubkey.clone(),
+                    1_780_640_000_010_i64,
+                    "Operator phone"
+                ],
+            )
+            .unwrap();
+        db.conn()
+            .execute(
+                "INSERT INTO trusted_device
+                    (device_id, public_key, paired_at, revoked_at, key_rotated_at, sealed_key_ref, label)
+                 VALUES (?1, ?2, ?3, NULL, NULL, NULL, ?4)",
+                params!["ios-real-device-1", device_pubkey, 1_780_640_000_010_i64, "Operator phone"],
+            )
+            .unwrap();
+        db.conn()
+            .execute(
+                "INSERT INTO trust_grant
+                    (grant_id, agent_id, granted_at, expires_at, revoked, revoked_at, boundaries)
+                 VALUES ('grant-t3-1', 'agent-codex', ?1, NULL, 0, NULL, '{}')",
+                [1_780_640_000_020_i64],
+            )
+            .unwrap();
+        db.conn()
+            .execute(
+                "INSERT INTO context_passport
+                    (passport_id, mission_id, work_item_id, destination_lane, destination_target, approved_sensitive, created_at_ms)
+                 VALUES ('passport-t3-1', ?1, 'autodisp-1781492033', 'codex', 'codex', 0, ?2)",
+                params![mission_id, 1_780_640_000_030_i64],
+            )
+            .unwrap();
+        db.conn()
+            .execute(
+                "INSERT INTO context_passport_item
+                    (passport_id, seq, kind, label, included, sensitive)
+                 VALUES ('passport-t3-1', 0, 'mission_link', 'mission refs', 1, 0)",
+                [],
+            )
+            .unwrap();
+
+        let snapshot = project_workbench(&db, Some(&mission_id)).unwrap();
+        let status = snapshot
+            .get("t3ProvisioningStatus")
+            .and_then(Value::as_object)
+            .expect("projection must include T3 provisioning status");
+        assert_eq!(
+            status.get("truthLabel").and_then(Value::as_str),
+            Some("rust_hub_t3_provisioning_read_only_no_mint")
+        );
+        assert_eq!(status.get("paired").and_then(Value::as_bool), Some(true));
+        assert_eq!(
+            status.get("activeTrustGrantCount").and_then(Value::as_i64),
+            Some(1)
+        );
+        assert_eq!(
+            status.get("contextPassportCount").and_then(Value::as_i64),
+            Some(1)
+        );
+        let latest = status
+            .get("latestDevice")
+            .and_then(Value::as_object)
+            .expect("latest trusted device");
+        assert!(latest
+            .get("deviceId")
+            .and_then(Value::as_str)
+            .is_some_and(|value| value.starts_with("proof://device/")));
+        let fingerprint = latest
+            .get("pubkeyFingerprint")
+            .and_then(Value::as_str)
+            .expect("redacted public-key fingerprint");
+        assert!(fingerprint.contains(':'));
+        let rendered = serde_json::to_string(&snapshot).unwrap();
+        assert!(!rendered.contains("ios-real-device-1"));
+        assert!(
+            !rendered.contains("0101010101010101010101010101010101010101010101010101010101010101")
+        );
     }
 
     #[test]

--- a/src/api/http/routes/friday-mission-spine-routes.ts
+++ b/src/api/http/routes/friday-mission-spine-routes.ts
@@ -608,6 +608,47 @@ function validateCapabilityStates(snapshot: FridayMissionSpineWorkbenchSnapshot,
   }
 }
 
+function validateT3ProvisioningStatus(snapshot: FridayMissionSpineWorkbenchSnapshot, failures: string[]): void {
+  const status = snapshot.t3ProvisioningStatus;
+  if (!status) return;
+  pushIfInvalid(
+    failures,
+    status.truthLabel === "rust_hub_t3_provisioning_read_only_no_mint",
+    "t3_provisioning_truth_label_invalid",
+  );
+  for (const [key, value] of Object.entries({
+    deviceIdentityCount: status.deviceIdentityCount,
+    trustedDeviceCount: status.trustedDeviceCount,
+    activeTrustedDeviceCount: status.activeTrustedDeviceCount,
+    trustGrantCount: status.trustGrantCount,
+    activeTrustGrantCount: status.activeTrustGrantCount,
+    contextPassportCount: status.contextPassportCount,
+    contextPassportItemCount: status.contextPassportItemCount,
+  })) {
+    pushIfInvalid(failures, Number.isInteger(value) && value >= 0, `t3_provisioning_count_invalid:${key}`);
+  }
+  pushIfInvalid(failures, typeof status.paired === "boolean", "t3_provisioning_paired_invalid");
+  if (status.latestDevice != null) {
+    pushIfInvalid(failures, isRecord(status.latestDevice), "t3_provisioning_latest_device_invalid");
+    if (isRecord(status.latestDevice)) {
+      pushIfInvalid(failures, hasText(status.latestDevice.deviceId), "t3_latest_device_id_missing");
+      pushIfInvalid(
+        failures,
+        typeof status.latestDevice.deviceId === "string" && status.latestDevice.deviceId.startsWith("proof://device/"),
+        "t3_latest_device_id_not_redacted",
+      );
+      pushIfInvalid(failures, hasText(status.latestDevice.pubkeyFingerprint), "t3_latest_device_fingerprint_missing");
+      pushIfInvalid(
+        failures,
+        typeof status.latestDevice.pubkeyFingerprint === "string"
+          && !/^[0-9a-f]{64}$/i.test(status.latestDevice.pubkeyFingerprint),
+        "t3_latest_device_raw_pubkey_leak",
+      );
+      pushIfInvalid(failures, Number.isInteger(status.latestDevice.pairedAt), "t3_latest_device_paired_at_invalid");
+    }
+  }
+}
+
 function validateTranscript(
   snapshot: FridayMissionSpineWorkbenchSnapshot,
   workItemIds: Set<string>,
@@ -698,6 +739,7 @@ function validateMissionSpineWorkbenchSnapshot(
   const timelineEventRefs = validateTimeline(snapshot, failures);
   validateMemoryCandidates(snapshot, failures);
   validateCapabilityStates(snapshot, failures);
+  validateT3ProvisioningStatus(snapshot, failures);
   validateTranscript(snapshot, workItemIds, timelineEventRefs, failures);
 
   return failures;

--- a/src/api/model/friday-api-mission-spine.types.ts
+++ b/src/api/model/friday-api-mission-spine.types.ts
@@ -140,6 +140,26 @@ export interface FridayMissionSpineTranscriptSection {
   events: FridayMissionSpineTranscriptEvent[];
 }
 
+export interface FridayMissionSpineT3ProvisioningStatus {
+  truthLabel: "rust_hub_t3_provisioning_read_only_no_mint";
+  paired: boolean;
+  deviceIdentityCount: number;
+  trustedDeviceCount: number;
+  activeTrustedDeviceCount: number;
+  trustGrantCount: number;
+  activeTrustGrantCount: number;
+  contextPassportCount: number;
+  contextPassportItemCount: number;
+  latestDevice?: {
+    deviceId: string;
+    label: string;
+    pairedAt: number;
+    revokedAt?: number | null;
+    keyRotatedAt?: number | null;
+    pubkeyFingerprint: string;
+  } | null;
+}
+
 export interface FridayMissionSpineWorkbenchSnapshot {
   missionId: string;
   fridayConversationId: string;
@@ -165,6 +185,7 @@ export interface FridayMissionSpineWorkbenchSnapshot {
   timelinePages: FridayMissionSpineWorkbenchTimelinePage[];
   memoryCandidates: FridayMissionSpineWorkbenchMemoryCandidate[];
   capabilityStates: FridayMissionSpineWorkbenchCapabilityState[];
+  t3ProvisioningStatus?: FridayMissionSpineT3ProvisioningStatus;
   transcriptSections: FridayMissionSpineTranscriptSection[];
 }
 

--- a/test/unit/api/routes/friday-mission-spine-routes.test.ts
+++ b/test/unit/api/routes/friday-mission-spine-routes.test.ts
@@ -128,6 +128,25 @@ const snapshot: FridayMissionSpineWorkbenchSnapshot = {
       proofRef: "proof://skill/observed-only/no-dispatch",
     },
   ],
+  t3ProvisioningStatus: {
+    truthLabel: "rust_hub_t3_provisioning_read_only_no_mint",
+    paired: true,
+    deviceIdentityCount: 1,
+    trustedDeviceCount: 1,
+    activeTrustedDeviceCount: 1,
+    trustGrantCount: 1,
+    activeTrustGrantCount: 1,
+    contextPassportCount: 1,
+    contextPassportItemCount: 2,
+    latestDevice: {
+      deviceId: "proof://device/paired-ios-1",
+      label: "operator phone",
+      pairedAt: 1_780_640_000_000,
+      revokedAt: null,
+      keyRotatedAt: null,
+      pubkeyFingerprint: "abcd1234:dcba4321",
+    },
+  },
   transcriptSections: [
     {
       id: "section_live_projection_test",
@@ -317,6 +336,41 @@ describe("createFridayMissionSpineRoutes", () => {
     });
     expect(JSON.stringify(response)).not.toContain("mission_pending_runtime_projection");
     expect(JSON.stringify(response)).not.toContain("prep fallback");
+  });
+
+  it("accepts read-only T3 provisioning status but rejects raw device-key leaks", async () => {
+    const routes = createFridayMissionSpineRoutes({
+      workbench: { getSnapshot: vi.fn(async () => snapshot) },
+      disabledReason: null,
+    });
+    const route = findRoute(routes);
+    const response = await route.handler(makeCtx() as never);
+
+    expect(response).toEqual({ snapshot });
+    expect(JSON.stringify(response)).toContain("rust_hub_t3_provisioning_read_only_no_mint");
+    expect(JSON.stringify(response)).not.toContain("0101010101010101010101010101010101010101010101010101010101010101");
+
+    const leaked = cloneSnapshot({
+      t3ProvisioningStatus: {
+        ...snapshot.t3ProvisioningStatus!,
+        latestDevice: {
+          ...snapshot.t3ProvisioningStatus!.latestDevice!,
+          pubkeyFingerprint: "0101010101010101010101010101010101010101010101010101010101010101",
+        },
+      },
+    });
+    const leakedRoutes = createFridayMissionSpineRoutes({
+      workbench: { getSnapshot: vi.fn(async () => leaked) },
+      disabledReason: null,
+    });
+    let thrown: unknown = null;
+    try {
+      await findRoute(leakedRoutes).handler(makeCtx() as never);
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(FridayDomainError);
+    expect(JSON.stringify((thrown as FridayDomainError).details)).toContain("t3_latest_device_raw_pubkey_leak");
   });
 
   it("fails closed when the live snapshot does not match the requested Mission id", async () => {

--- a/ui/src/lib/mission-workbench/mission-workbench-contract.ts
+++ b/ui/src/lib/mission-workbench/mission-workbench-contract.ts
@@ -78,6 +78,28 @@ export interface MissionWorkbenchCapabilityState {
   proofRef: string;
 }
 
+export interface MissionWorkbenchTrustedDeviceSummary {
+  deviceId: string;
+  label: string;
+  pairedAt: number;
+  revokedAt?: number | null;
+  keyRotatedAt?: number | null;
+  pubkeyFingerprint: string;
+}
+
+export interface MissionWorkbenchT3ProvisioningStatus {
+  truthLabel: "rust_hub_t3_provisioning_read_only_no_mint" | string;
+  paired: boolean;
+  deviceIdentityCount: number;
+  trustedDeviceCount: number;
+  activeTrustedDeviceCount: number;
+  trustGrantCount: number;
+  activeTrustGrantCount: number;
+  contextPassportCount: number;
+  contextPassportItemCount: number;
+  latestDevice?: MissionWorkbenchTrustedDeviceSummary | null;
+}
+
 export type MissionRouteActionTargetKind = "file" | "command" | "subtask";
 
 export type MissionRouteActionReversibility =
@@ -165,5 +187,6 @@ export interface MissionWorkbenchSnapshot {
   timelinePages: MissionWorkbenchTimelinePage[];
   memoryCandidates: MissionWorkbenchMemoryCandidate[];
   capabilityStates: MissionWorkbenchCapabilityState[];
+  t3ProvisioningStatus?: MissionWorkbenchT3ProvisioningStatus;
   transcriptSections: MissionTranscriptSection[];
 }

--- a/ui/src/routes/mission-workbench-page.tsx
+++ b/ui/src/routes/mission-workbench-page.tsx
@@ -393,6 +393,54 @@ export function MissionWorkbenchPage() {
             </div>
           </ShellCard>
 
+          <ShellCard
+            eyebrow="T3"
+            title={localize(locale, "设备与授权", "Device provisioning")}
+            aside={
+              <StatusPill tone={snapshot.t3ProvisioningStatus?.paired ? "success" : "warning"}>
+                {snapshot.t3ProvisioningStatus?.paired ? "paired" : "operator gated"}
+              </StatusPill>
+            }
+          >
+            {snapshot.t3ProvisioningStatus ? (
+              <div className="space-y-3">
+                <p className="break-all text-xs text-[color:var(--color-text-tertiary)]">
+                  {snapshot.t3ProvisioningStatus.truthLabel}
+                </p>
+                <div className="grid gap-2 text-xs text-[color:var(--color-text-secondary)] sm:grid-cols-2">
+                  <div className="rounded-lg border border-[color:var(--color-border-soft)] bg-[color:var(--color-bg-subtle)] p-3">
+                    active devices: {snapshot.t3ProvisioningStatus.activeTrustedDeviceCount}
+                  </div>
+                  <div className="rounded-lg border border-[color:var(--color-border-soft)] bg-[color:var(--color-bg-subtle)] p-3">
+                    active grants: {snapshot.t3ProvisioningStatus.activeTrustGrantCount}
+                  </div>
+                  <div className="rounded-lg border border-[color:var(--color-border-soft)] bg-[color:var(--color-bg-subtle)] p-3">
+                    passports: {snapshot.t3ProvisioningStatus.contextPassportCount}
+                  </div>
+                  <div className="rounded-lg border border-[color:var(--color-border-soft)] bg-[color:var(--color-bg-subtle)] p-3">
+                    passport items: {snapshot.t3ProvisioningStatus.contextPassportItemCount}
+                  </div>
+                </div>
+                {snapshot.t3ProvisioningStatus.latestDevice ? (
+                  <div className="space-y-2 rounded-lg border border-[color:var(--color-border-soft)] bg-[color:var(--color-bg-subtle)] p-3 text-xs text-[color:var(--color-text-secondary)]">
+                    <p className="break-all">device: {snapshot.t3ProvisioningStatus.latestDevice.deviceId}</p>
+                    <p>label: {snapshot.t3ProvisioningStatus.latestDevice.label || "unlabeled"}</p>
+                    <p>fingerprint: {snapshot.t3ProvisioningStatus.latestDevice.pubkeyFingerprint}</p>
+                  </div>
+                ) : (
+                  <p className="text-sm text-[color:var(--color-text-secondary)]">No active trusted device row is visible.</p>
+                )}
+                <p className="text-xs leading-5 text-[color:var(--color-text-tertiary)]">
+                  Read-only Hub DB projection. Trust grants and context passports remain operator CLI ceremonies.
+                </p>
+              </div>
+            ) : (
+              <p className="text-sm leading-6 text-[color:var(--color-text-secondary)]">
+                This projection does not expose T3 provisioning status yet.
+              </p>
+            )}
+          </ShellCard>
+
           <ShellCard eyebrow="Memory" title={localize(locale, "候选记忆", "Memory candidates")}>
             <div className="space-y-3">
               {snapshot.memoryCandidates.map((candidate) => (


### PR DESCRIPTION
## Summary
- Add read-only Rust Workbench T3 provisioning status from real Hub tables: device_identity/trusted_device/trust_grant/context_passport.
- Surface paired device / trust grant / context passport status in iOS, macOS, and web Workbench views without minting grants or reading operator keys.
- Extend route validation and client contracts/tests to reject raw device/public-key leakage.

## Verification
- cargo fmt --manifest-path rust-core/Cargo.toml --all -- --check
- cargo test --manifest-path rust-core/Cargo.toml -p friday-hub workbench_projection::tests::projects_t3_provisioning_status_from_hub_tables_without_raw_device_key
- npx vitest run test/unit/api/routes/friday-mission-spine-routes.test.ts test/unit/ui/mission-workbench-api.test.ts
- swift test --package-path apps/friday-ios --filter HomeViewModelTests
- swift test --package-path apps/macos/FridayHubConsole --filter OperationsOverviewViewModelTests
- detect-secrets-hook --baseline .secrets.baseline ...
- git diff --check

Truth: read-only status projection; no grant/passport mint, no operator signing, no live write-authority flip.