### PR TITLE
Add proof ops wrappers for T3 D20 and UI

### DIFF
--- a/scripts/ops/friday-d20-signed-batch-worktree-proof.sh
+++ b/scripts/ops/friday-d20-signed-batch-worktree-proof.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+#
+# Consume an existing D20 operator-signed batch artifact through the Rust worktree driver.
+#
+# Truth boundary:
+#   This script verifies/consumes an already-signed artifact. It never invokes operator-sign.sh,
+#   never reads an operator private key, and never mints a signature.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+ARTIFACT_DIR="${FRIDAY_D20_ARTIFACT_DIR:-}"
+SIGNED_BATCH_JSON="${FRIDAY_D20_SIGNED_BATCH_JSON:-}"
+ACTION_JSON="${FRIDAY_D20_ACTION_JSON:-}"
+WORKSPACE_ROOT="${FRIDAY_D20_WORKSPACE_ROOT:-}"
+DB_PATH="${FRIDAY_D20_DB_PATH:-}"
+OPERATOR_VK_PATH="${FRIDAY_OPERATOR_APPROVAL_VERIFY_KEY_PATH:-${HOME}/.friday/operator-approval.vk}"
+NOW_MS="${FRIDAY_D20_NOW_MS:-}"
+
+usage() {
+  cat <<'EOF'
+usage:
+  scripts/ops/friday-d20-signed-batch-worktree-proof.sh [--artifact-dir /abs/d20-live-dir]
+  scripts/ops/friday-d20-signed-batch-worktree-proof.sh \
+    --signed-batch-json /abs/signed-batch.json \
+    --action-json /abs/action.json \
+    --workspace /abs/worktree \
+    --db /abs/hub.sqlite \
+    --operator-vk /abs/operator-approval.vk
+
+truth:
+  Verify-only D20 artifact consumer. This invokes the Rust hub_d20_signed_batch_worktree bin,
+  using only the operator PUBLIC verify key. It does not sign, does not call operator-sign.sh,
+  and does not read ~/.friday/operator-approve.key.
+EOF
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --artifact-dir)
+      shift; ARTIFACT_DIR="${1:-}"
+      ;;
+    --signed-batch-json)
+      shift; SIGNED_BATCH_JSON="${1:-}"
+      ;;
+    --action-json)
+      shift; ACTION_JSON="${1:-}"
+      ;;
+    --workspace)
+      shift; WORKSPACE_ROOT="${1:-}"
+      ;;
+    --db)
+      shift; DB_PATH="${1:-}"
+      ;;
+    --operator-vk)
+      shift; OPERATOR_VK_PATH="${1:-}"
+      ;;
+    --now-ms)
+      shift; NOW_MS="${1:-}"
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "FATAL: unknown argument: $1" >&2
+      usage >&2
+      exit 64
+      ;;
+  esac
+  shift
+done
+
+latest_artifact_dir() {
+  find "${HOME}/.friday" -maxdepth 1 -type d -name 'd20-live-*' 2>/dev/null \
+    | while IFS= read -r dir; do
+      if [ -f "${dir}/signed-batch.json" ] \
+        && [ -f "${dir}/action.json" ] \
+        && [ -f "${dir}/hub.sqlite" ] \
+        && { [ -d "${dir}/worktree" ] || [ -d "${dir}/scratch-worktree" ]; }; then
+        printf '%s\n' "${dir}"
+      fi
+    done \
+    | sort \
+    | tail -1
+}
+
+if [ -z "${ARTIFACT_DIR}" ] && {
+  [ -z "${SIGNED_BATCH_JSON}" ] || [ -z "${ACTION_JSON}" ] || [ -z "${WORKSPACE_ROOT}" ] || [ -z "${DB_PATH}" ];
+}; then
+  ARTIFACT_DIR="$(latest_artifact_dir || true)"
+fi
+
+if [ -n "${ARTIFACT_DIR}" ]; then
+  SIGNED_BATCH_JSON="${SIGNED_BATCH_JSON:-${ARTIFACT_DIR}/signed-batch.json}"
+  ACTION_JSON="${ACTION_JSON:-${ARTIFACT_DIR}/action.json}"
+  DB_PATH="${DB_PATH:-${ARTIFACT_DIR}/hub.sqlite}"
+  if [ -z "${WORKSPACE_ROOT}" ]; then
+    if [ -d "${ARTIFACT_DIR}/worktree" ]; then
+      WORKSPACE_ROOT="${ARTIFACT_DIR}/worktree"
+    elif [ -d "${ARTIFACT_DIR}/scratch-worktree" ]; then
+      WORKSPACE_ROOT="${ARTIFACT_DIR}/scratch-worktree"
+    fi
+  fi
+fi
+
+require_file() {
+  local path="$1"
+  local label="$2"
+  if [ -z "${path}" ] || [ ! -f "${path}" ]; then
+    echo "FATAL: ${label} is required and must be a file: ${path:-<unset>}" >&2
+    exit 3
+  fi
+}
+
+require_dir() {
+  local path="$1"
+  local label="$2"
+  if [ -z "${path}" ] || [ ! -d "${path}" ]; then
+    echo "FATAL: ${label} is required and must be a directory: ${path:-<unset>}" >&2
+    exit 3
+  fi
+}
+
+require_file "${SIGNED_BATCH_JSON}" signed_batch_json
+require_file "${ACTION_JSON}" action_json
+require_file "${DB_PATH}" hub_db
+require_file "${OPERATOR_VK_PATH}" operator_public_verify_key
+require_dir "${WORKSPACE_ROOT}" active_worktree
+
+if [ -n "${ARTIFACT_DIR}" ] && [ -e "${ARTIFACT_DIR}/operator-sign.sh" ]; then
+  echo "Info: operator-sign.sh exists in artifact dir but will not be executed." >&2
+fi
+
+args=(
+  run --quiet --manifest-path "${REPO_ROOT}/rust-core/Cargo.toml" -p friday-hub --bin hub_d20_signed_batch_worktree --
+  --db "${DB_PATH}"
+  --workspace "${WORKSPACE_ROOT}"
+  --signed-batch-json "${SIGNED_BATCH_JSON}"
+  --action-json "${ACTION_JSON}"
+  --operator-vk-path "${OPERATOR_VK_PATH}"
+)
+if [ -n "${NOW_MS}" ]; then
+  args+=(--now-ms "${NOW_MS}")
+fi
+
+echo "truth=friday_d20_signed_batch_worktree_proof_no_private_key_no_signing"
+echo "artifact_dir=${ARTIFACT_DIR:-<explicit>}"
+echo "workspace=${WORKSPACE_ROOT}"
+echo "db=${DB_PATH}"
+echo "operator_vk=${OPERATOR_VK_PATH}"
+exec cargo "${args[@]}"

--- a/scripts/ops/friday-t3-pairing-proof.sh
+++ b/scripts/ops/friday-t3-pairing-proof.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+#
+# Run a real T3 QR-pairing proof against the DARK hub_pairing_server.
+#
+# Truth boundary:
+#   --status-only opens the sealed pairing channel and writes no trusted device.
+#   --pair sends a real Pair request and can write device_identity + trusted_device rows after
+#   PairAck. It never reads operator signing keys and never mints trust_grant/context_passport.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+MODE=""
+DEVICE_ID="${FRIDAY_T3_PAIRING_DEVICE_ID:-friday-t3-pairing-proof-$(date -u +%Y%m%dT%H%M%SZ)}"
+TIMEOUT_SECONDS="${FRIDAY_T3_PAIRING_PROOF_TIMEOUT_SECONDS:-45}"
+
+usage() {
+  cat <<'EOF'
+usage:
+  scripts/ops/friday-t3-pairing-proof.sh --status-only
+  FRIDAY_T3_PAIRING_PROOF_ACK=operator-runs-t3-pairing-proof \
+    scripts/ops/friday-t3-pairing-proof.sh --pair [--device-id <id>]
+
+truth:
+  Starts the explicit DARK hub_pairing_server, runs the Swift FridayPairingProof client, and
+  reconciles the observed DB delta. It does not read operator signing keys, does not mint
+  trust_grant/context_passport, and does not flip any live flags.
+EOF
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --status-only)
+      MODE="status-only"
+      ;;
+    --pair)
+      MODE="pair"
+      ;;
+    --device-id)
+      shift
+      if [ "$#" -eq 0 ]; then
+        echo "FATAL: --device-id requires a value." >&2
+        exit 3
+      fi
+      DEVICE_ID="$1"
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "FATAL: unknown argument: $1" >&2
+      usage >&2
+      exit 3
+      ;;
+  esac
+  shift
+done
+
+if [ -z "${MODE}" ]; then
+  echo "FATAL: choose --status-only or --pair." >&2
+  usage >&2
+  exit 3
+fi
+case "${TIMEOUT_SECONDS}" in
+  ''|*[!0-9]*)
+    echo "FATAL: FRIDAY_T3_PAIRING_PROOF_TIMEOUT_SECONDS must be a positive integer." >&2
+    exit 3
+    ;;
+esac
+if [ "${TIMEOUT_SECONDS}" -le 0 ]; then
+  echo "FATAL: FRIDAY_T3_PAIRING_PROOF_TIMEOUT_SECONDS must be positive." >&2
+  exit 3
+fi
+if [ "${MODE}" = "pair" ] && [ "${FRIDAY_T3_PAIRING_PROOF_ACK:-}" != "operator-runs-t3-pairing-proof" ]; then
+  echo "FATAL: --pair writes trusted-device state; set FRIDAY_T3_PAIRING_PROOF_ACK=operator-runs-t3-pairing-proof." >&2
+  exit 4
+fi
+
+DB_PATH="${FRIDAY_PAIRING_DB_PATH:-${HOME}/Library/Application Support/Friday/state/rust-hub.sqlite}"
+OUT_DIR="${FRIDAY_T3_PAIRING_PROOF_OUT_DIR:-${TMPDIR:-/tmp}/friday-t3-pairing-proof-$(date -u +%Y%m%dT%H%M%SZ)-$$}"
+PAIRING_ID="${FRIDAY_PAIRING_ID:-t3-pair-proof-$(date -u +%Y%m%dT%H%M%SZ)-$$}"
+QR_JSON_OUT="${OUT_DIR}/${PAIRING_ID}.json"
+SERVER_LOG="${OUT_DIR}/hub-pairing-server.log"
+CLIENT_OUT="${OUT_DIR}/friday-pairing-proof.json"
+STATUS_QUERY_OUT="${OUT_DIR}/db-reconcile.txt"
+
+mkdir -p "${OUT_DIR}"
+chmod 700 "${OUT_DIR}" 2>/dev/null || true
+
+server_pid=""
+cleanup() {
+  if [ -n "${server_pid}" ] && kill -0 "${server_pid}" 2>/dev/null; then
+    kill "${server_pid}" 2>/dev/null || true
+    wait "${server_pid}" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT INT TERM
+
+sqlite_count() {
+  local sql="$1"
+  if ! command -v sqlite3 >/dev/null 2>&1; then
+    echo "sqlite3_unavailable"
+    return 0
+  fi
+  sqlite3 -readonly "${DB_PATH}" "${sql}" 2>/dev/null || echo "query_unavailable"
+}
+
+before_device_count="$(sqlite_count "SELECT count(*) FROM trusted_device WHERE device_id = '${DEVICE_ID//\'/\'\'}';")"
+before_grants="$(sqlite_count "SELECT count(*) FROM trust_grant;")"
+before_passports="$(sqlite_count "SELECT count(*) FROM context_passport;")"
+
+FRIDAY_PAIRING_ID="${PAIRING_ID}" \
+FRIDAY_PAIRING_QR_JSON_OUT="${QR_JSON_OUT}" \
+FRIDAY_PAIRING_OUT_DIR="${OUT_DIR}" \
+FRIDAY_PAIRING_ONCE=1 \
+"${SCRIPT_DIR}/friday-start-pairing-session.sh" >"${SERVER_LOG}" 2>&1 &
+server_pid="$!"
+
+deadline=$((SECONDS + TIMEOUT_SECONDS))
+while [ ! -s "${QR_JSON_OUT}" ]; do
+  if ! kill -0 "${server_pid}" 2>/dev/null; then
+    echo "FATAL: pairing server exited before writing QR manifest. Log: ${SERVER_LOG}" >&2
+    sed -n '1,120p' "${SERVER_LOG}" >&2 || true
+    exit 5
+  fi
+  if [ "${SECONDS}" -ge "${deadline}" ]; then
+    echo "FATAL: timed out waiting for QR manifest. Log: ${SERVER_LOG}" >&2
+    exit 5
+  fi
+  sleep 0.25
+done
+
+proof_args=(run --package-path "${REPO_ROOT}/apps/macos/FridayHubConsole" FridayPairingProof --manifest "${QR_JSON_OUT}")
+if [ "${MODE}" = "status-only" ]; then
+  proof_args+=(--status-only)
+else
+  proof_args+=(--pair --device-id "${DEVICE_ID}")
+fi
+
+swift "${proof_args[@]}" | tee "${CLIENT_OUT}"
+
+after_device_count="$(sqlite_count "SELECT count(*) FROM trusted_device WHERE device_id = '${DEVICE_ID//\'/\'\'}';")"
+after_grants="$(sqlite_count "SELECT count(*) FROM trust_grant;")"
+after_passports="$(sqlite_count "SELECT count(*) FROM context_passport;")"
+
+{
+  echo "truth=friday_t3_pairing_proof_no_operator_key_no_grant_no_passport"
+  echo "mode=${MODE}"
+  echo "device_id=${DEVICE_ID}"
+  echo "pairing_id=${PAIRING_ID}"
+  echo "db=${DB_PATH}"
+  echo "trusted_device_count_before=${before_device_count}"
+  echo "trusted_device_count_after=${after_device_count}"
+  echo "trust_grant_count_before=${before_grants}"
+  echo "trust_grant_count_after=${after_grants}"
+  echo "context_passport_count_before=${before_passports}"
+  echo "context_passport_count_after=${after_passports}"
+  echo "client_output=${CLIENT_OUT}"
+  echo "server_log=${SERVER_LOG}"
+} | tee "${STATUS_QUERY_OUT}"
+
+if [ "${MODE}" = "pair" ] && [ "${after_device_count}" = "0" ]; then
+  echo "FATAL: PairAck proof completed but trusted_device was not observed for ${DEVICE_ID}." >&2
+  exit 6
+fi
+if [ "${before_grants}" != "sqlite3_unavailable" ] && [ "${after_grants}" != "${before_grants}" ]; then
+  echo "FATAL: trust_grant count changed during pairing proof; this wrapper must not mint grants." >&2
+  exit 7
+fi
+if [ "${before_passports}" != "sqlite3_unavailable" ] && [ "${after_passports}" != "${before_passports}" ]; then
+  echo "FATAL: context_passport count changed during pairing proof; this wrapper must not mint passports." >&2
+  exit 7
+fi

--- a/scripts/ops/friday-ui-device-proof-readiness.sh
+++ b/scripts/ops/friday-ui-device-proof-readiness.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+#
+# One-command readiness wrapper for the END-BAR UI/device proof chain.
+#
+# Truth boundary:
+#   With no evidence inputs this is report-only and explicitly NOT a UI/device proof.
+#   With all real evidence inputs it delegates to the existing assembler + final gate.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+RUST_SCRIPTS_DIR="${REPO_ROOT}/rust-core/scripts"
+
+MODE="report-only"
+RUN_LIVE_READINESS=0
+RUN_SNAPSHOT_CONTRACT=0
+
+usage() {
+  cat <<'EOF'
+usage:
+  scripts/ops/friday-ui-device-proof-readiness.sh [--live-readiness] [--snapshot-contract] [--require-proof]
+
+optional env for live/snapshot checks:
+  FRIDAY_MISSION_WORKBENCH_URL=http://127.0.0.1:5173/mission-workbench
+  MISSION_ID=mission_...
+  FRIDAY_WORKBENCH_SNAPSHOT_FILE=/abs/workbench-response.json
+  FRIDAY_WORKBENCH_SNAPSHOT_URL=http://127.0.0.1:3141/v1/mission-spine/workbench
+
+real proof env, all required to assemble:
+  MOBILE_EVIDENCE=/abs/mobile.trace
+  DESKTOP_EVIDENCE=/abs/desktop.trace
+  CHANNEL_EVIDENCE=/abs/channel.trace
+  TIMELINE_EVIDENCE=/abs/timeline.trace
+  OBSERVATIONS_MANIFEST=/abs/ui-observations-manifest.json
+  OUT=/tmp/mission-spine-ui-device-proof.json
+
+truth:
+  Default report-only mode never writes MISSION_SPINE_UI_DEVICE_PROOF and is not END-BAR proof.
+  When every evidence env is present, this delegates to the existing assembler and final gate.
+EOF
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --live-readiness)
+      RUN_LIVE_READINESS=1
+      ;;
+    --snapshot-contract)
+      RUN_SNAPSHOT_CONTRACT=1
+      ;;
+    --require-proof)
+      MODE="require-proof"
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "FATAL: unknown argument: $1" >&2
+      usage >&2
+      exit 64
+      ;;
+  esac
+  shift
+done
+
+json_escape() {
+  python3 -c 'import json,sys; print(json.dumps(sys.stdin.read().rstrip("\n")))' 2>/dev/null || {
+    sed 's/\\/\\\\/g; s/"/\\"/g; s/^/"/; s/$/"/'
+  }
+}
+
+have_all_evidence=1
+for name in MISSION_ID MOBILE_EVIDENCE DESKTOP_EVIDENCE CHANNEL_EVIDENCE TIMELINE_EVIDENCE OBSERVATIONS_MANIFEST; do
+  if [ -z "${!name:-}" ]; then
+    have_all_evidence=0
+  fi
+done
+
+blockers=()
+notes=()
+
+run_step() {
+  local label="$1"
+  shift
+  if "$@"; then
+    notes+=("${label}:pass")
+  else
+    local rc=$?
+    blockers+=("${label}:exit_${rc}")
+    return 0
+  fi
+}
+
+run_step "ui_device_gate_self_test" bash "${RUST_SCRIPTS_DIR}/mission-spine-ui-device-proof-gate-self-test.sh"
+
+if [ "${RUN_LIVE_READINESS}" = "1" ]; then
+  run_step "mission_workbench_live_readiness" \
+    node "${REPO_ROOT}/scripts/qa/check-mission-workbench-live-readiness.mjs" --expect-not-ready
+fi
+
+if [ "${RUN_SNAPSHOT_CONTRACT}" = "1" ]; then
+  if [ -n "${FRIDAY_WORKBENCH_SNAPSHOT_FILE:-}" ]; then
+    run_step "mission_workbench_snapshot_contract_file" \
+      node "${REPO_ROOT}/scripts/qa/check-mission-workbench-snapshot-contract.mjs" \
+        "--file=${FRIDAY_WORKBENCH_SNAPSHOT_FILE}" --expect-not-ready
+  elif [ -n "${FRIDAY_WORKBENCH_SNAPSHOT_URL:-}" ]; then
+    run_step "mission_workbench_snapshot_contract_url" \
+      node "${REPO_ROOT}/scripts/qa/check-mission-workbench-snapshot-contract.mjs" \
+        "--url=${FRIDAY_WORKBENCH_SNAPSHOT_URL}" --expect-not-ready
+  else
+    blockers+=("mission_workbench_snapshot_contract:missing_FRIDAY_WORKBENCH_SNAPSHOT_FILE_or_URL")
+  fi
+fi
+
+if [ "${have_all_evidence}" = "1" ]; then
+  run_step "ui_proof_inputs_preflight" \
+    node "${REPO_ROOT}/scripts/qa/check-mission-spine-ui-proof-inputs.mjs" \
+      "--mission-id=${MISSION_ID}" \
+      "--mobile=${MOBILE_EVIDENCE}" \
+      "--desktop=${DESKTOP_EVIDENCE}" \
+      "--channel=${CHANNEL_EVIDENCE}" \
+      "--timeline=${TIMELINE_EVIDENCE}" \
+      "--manifest=${OBSERVATIONS_MANIFEST}"
+  if [ "${#blockers[@]}" -eq 0 ]; then
+    (cd "${REPO_ROOT}/rust-core" && scripts/mission-spine-ui-device-proof-assemble.sh)
+    echo '{"truth":"assembled_real_ui_device_proof","status":"pass"}'
+    exit 0
+  fi
+else
+  blockers+=("ui_device_proof_evidence:missing_required_real_evidence_env")
+fi
+
+if [ "${MODE}" = "require-proof" ]; then
+  printf 'FATAL: UI/device proof not assembled. blockers=%s\n' "${blockers[*]}" >&2
+  exit 2
+fi
+
+printf '{\n'
+printf '  "truth": "report_only_not_ui_device_proof",\n'
+printf '  "status": "blocked",\n'
+printf '  "notes": ['
+for i in "${!notes[@]}"; do
+  [ "$i" -gt 0 ] && printf ', '
+  printf '%s' "$(printf '%s' "${notes[$i]}" | json_escape)"
+done
+printf '],\n'
+printf '  "blockers": ['
+for i in "${!blockers[@]}"; do
+  [ "$i" -gt 0 ] && printf ', '
+  printf '%s' "$(printf '%s' "${blockers[$i]}" | json_escape)"
+done
+printf ']\n'
+printf '}\n'


### PR DESCRIPTION
## Summary
- add an operator-facing T3 pairing proof wrapper that can run status-only probes or explicit PairAck proofs without touching operator signing keys or minting grants/passports
- add a D20 signed-batch worktree proof wrapper that consumes existing signed artifacts using only the public verify key
- add a UI/device proof readiness wrapper that remains report-only until real evidence inputs are present

## Verification
- `bash -n scripts/ops/friday-t3-pairing-proof.sh scripts/ops/friday-ui-device-proof-readiness.sh scripts/ops/friday-d20-signed-batch-worktree-proof.sh`
- `detect-secrets-hook --baseline .secrets.baseline scripts/ops/friday-t3-pairing-proof.sh scripts/ops/friday-ui-device-proof-readiness.sh scripts/ops/friday-d20-signed-batch-worktree-proof.sh`
- `scripts/ops/friday-ui-device-proof-readiness.sh` -> report_only_not_ui_device_proof with self-test pass and missing-real-evidence blocker
- `scripts/ops/friday-d20-signed-batch-worktree-proof.sh` -> refs-only requires_approval on never-revertable path
- `scripts/ops/friday-t3-pairing-proof.sh --status-only` -> sealed WS HubStatus, no trusted-device/grant/passport count changes
- `FRIDAY_T3_PAIRING_PROOF_ACK=operator-runs-t3-pairing-proof scripts/ops/friday-t3-pairing-proof.sh --pair ...` -> PairAck accepted, trusted_device +1, grant/passport unchanged

Truth: these wrappers do not claim END-BAR, do not sign, do not read private operator keys, and do not create fake organic rows.