### PR TITLE
Add channel live proof wrapper self-test

### DIFF
--- a/rust-core/scripts/mission-spine-channel-live-gate-self-test.sh
+++ b/rust-core/scripts/mission-spine-channel-live-gate-self-test.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$root"
+
+tmp="$(mktemp -d "${TMPDIR:-/tmp}/friday-channel-live-self-test.XXXXXX")"
+cleanup() {
+  rm -rf "$tmp"
+}
+trap cleanup EXIT
+
+raw="$tmp/raw-telegram-proof.json"
+wrapped="$tmp/channel-live-proof.json"
+fixture_token="fixture-telegram-token-not-real" # pragma: allowlist secret
+raw_text="hello from raw telegram message"
+raw_sender="987654321"
+
+cat >"$raw" <<EOF
+{
+  "proof": "telegram_inbound_through_rust_channels_pipeline",
+  "sender_id_present": true,
+  "sender_allowlisted": true,
+  "bearer_auth_accepted_correct": true,
+  "forged_bearer_rejected": true,
+  "non_allowlisted_sender_rejected": true,
+  "bot_identity_verified": true,
+  "channel_binding_created": true,
+  "redacted_text": "[redacted-message]",
+  "raw_text_chars": 31,
+  "pii_kinds_redacted": ["telegram_sender_id", "message_text"],
+  "raw_sender_id": "$raw_sender",
+  "raw_text": "$raw_text",
+  "bot_token": "$fixture_token"
+}
+EOF
+
+TELEGRAM_PROOF_OUT="$raw" \
+MISSION_SPINE_CHANNEL_LIVE_PROOF_OUT="$wrapped" \
+  scripts/mission-spine-channel-live-gate.sh --wrap-existing >/tmp/friday-channel-live-self-test.out
+
+jq -e '
+  .proof == "mission_spine_channel_live_proof"
+  and .status == "passed"
+  and .capture_mode == "--wrap-existing"
+  and .telegram_live.proof == "telegram_inbound_through_rust_channels_pipeline"
+  and .telegram_live.sender_allowlisted == true
+  and .secret_policy.artifact_contains_redacted_text_only == true
+  and .remaining_requirement == "real mobile/desktop/channel UI/device consumption evidence must still pass scripts/mission-spine-ui-device-proof-gate.sh"
+' "$wrapped" >/dev/null
+
+if grep -q "$fixture_token\\|$raw_sender\\|$raw_text" "$wrapped"; then
+  echo "BLOCKER: wrapped channel proof leaked raw Telegram secret/sender/text" >&2
+  exit 2
+fi
+
+echo "[mission-spine-channel-self-test] PASS"

--- a/rust-core/scripts/mission-spine-channel-live-gate.sh
+++ b/rust-core/scripts/mission-spine-channel-live-gate.sh
@@ -4,27 +4,54 @@ set -euo pipefail
 root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$root"
 
+mode="${1:---live}"
+case "$mode" in
+  --live|--wrap-existing)
+    ;;
+  -h|--help)
+    cat >&2 <<'EOF'
+usage:
+  scripts/mission-spine-channel-live-gate.sh [--live]
+  TELEGRAM_PROOF_OUT=/abs/raw-telegram-proof.json scripts/mission-spine-channel-live-gate.sh --wrap-existing
+
+--live is the default and runs the ignored real Telegram live test.
+--wrap-existing only converts an already-captured raw Telegram proof into the redacted
+mission_spine_channel_live_proof wrapper; it does not contact Telegram and does not make raw
+evidence fresh.
+EOF
+    exit 0
+    ;;
+  *)
+    echo "usage: $0 [--live|--wrap-existing]" >&2
+    exit 64
+    ;;
+esac
+
 generated_at="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
 channel_live_proof_out="${MISSION_SPINE_CHANNEL_LIVE_PROOF_OUT:-/tmp/friday-mission-spine-channel-live-proof.json}"
-
-if [[ -z "${FRIDAY_TELEGRAM_BOT_TOKEN:-}" ]]; then
-  echo "BLOCKER: FRIDAY_TELEGRAM_BOT_TOKEN not set - cannot run real Telegram/channel inbound proof" >&2
-  exit 2
-fi
-
-if [[ -z "${FRIDAY_TELEGRAM_ALLOWED_USER_ID:-}" ]]; then
-  echo "BLOCKER: FRIDAY_TELEGRAM_ALLOWED_USER_ID not set - cannot run allowlisted Telegram/channel inbound proof" >&2
-  exit 2
-fi
 
 export TELEGRAM_LISTEN_SECONDS="${TELEGRAM_LISTEN_SECONDS:-300}"
 export TELEGRAM_PROOF_OUT="${TELEGRAM_PROOF_OUT:-/tmp/friday-telegram-live-proof.json}"
 
-echo "[mission-spine-channel] live Telegram/channel inbound proof"
-echo "[mission-spine-channel] waiting up to ${TELEGRAM_LISTEN_SECONDS}s for one real message from the allowlisted user"
-cargo test -p friday-hub --test telegram_live \
-  telegram_inbound_through_rust_channels_pipeline \
-  -- --ignored --nocapture
+if [[ "$mode" == "--live" ]]; then
+  if [[ -z "${FRIDAY_TELEGRAM_BOT_TOKEN:-}" ]]; then
+    echo "BLOCKER: FRIDAY_TELEGRAM_BOT_TOKEN not set - cannot run real Telegram/channel inbound proof" >&2
+    exit 2
+  fi
+
+  if [[ -z "${FRIDAY_TELEGRAM_ALLOWED_USER_ID:-}" ]]; then
+    echo "BLOCKER: FRIDAY_TELEGRAM_ALLOWED_USER_ID not set - cannot run allowlisted Telegram/channel inbound proof" >&2
+    exit 2
+  fi
+
+  echo "[mission-spine-channel] live Telegram/channel inbound proof"
+  echo "[mission-spine-channel] waiting up to ${TELEGRAM_LISTEN_SECONDS}s for one real message from the allowlisted user"
+  cargo test -p friday-hub --test telegram_live \
+    telegram_inbound_through_rust_channels_pipeline \
+    -- --ignored --nocapture
+else
+  echo "[mission-spine-channel] wrapping existing Telegram proof artifact: ${TELEGRAM_PROOF_OUT}"
+fi
 
 if [[ ! -s "$TELEGRAM_PROOF_OUT" ]]; then
   echo "BLOCKER: Telegram live test did not write proof artifact at ${TELEGRAM_PROOF_OUT}" >&2
@@ -51,11 +78,13 @@ jq \
   --arg generated_at "$generated_at" \
   --arg worktree "$root" \
   --arg raw_artifact "$TELEGRAM_PROOF_OUT" \
+  --arg mode "$mode" \
   '{
     proof: "mission_spine_channel_live_proof",
     generated_at_utc: $generated_at,
     worktree: $worktree,
     status: "passed",
+    capture_mode: $mode,
     scope: "real Telegram/channel inbound proof through Rust channel auth and redaction pipeline; not real UI/device consumption proof",
     raw_artifact: $raw_artifact,
 	    telegram_live: {


### PR DESCRIPTION
## Summary
- add an explicit `--wrap-existing` mode to `mission-spine-channel-live-gate.sh` so an already-captured Telegram live proof can be converted into the redacted `mission_spine_channel_live_proof` wrapper without rerunning Telegram
- keep default `--live` behavior unchanged for true live Telegram capture
- add a self-test proving the wrapper schema passes while raw token/sender/text fixture fields do not leak into the redacted wrapper

## Verification
- `bash -n rust-core/scripts/mission-spine-channel-live-gate.sh rust-core/scripts/mission-spine-channel-live-gate-self-test.sh`
- `detect-secrets-hook --baseline .secrets.baseline rust-core/scripts/mission-spine-channel-live-gate.sh rust-core/scripts/mission-spine-channel-live-gate-self-test.sh`
- `rust-core/scripts/mission-spine-channel-live-gate-self-test.sh`
- `git diff --check`

Truth: `--wrap-existing` does not make evidence fresh and does not satisfy UI/device END-BAR; live Telegram still requires `--live` with real channel env and a real allowlisted message.