### PR TITLE
Harden provider auth status probe

### DIFF
--- a/rust-core/crates/friday-providers/src/codex_appserver.rs
+++ b/rust-core/crates/friday-providers/src/codex_appserver.rs
@@ -1278,10 +1278,14 @@ impl LocalCodexAppServer {
     /// `initialize` handshake round-trips against the logged-in account with no broker in
     /// between. (The `app-server daemon start` + `app-server proxy --sock` bridge fails the
     /// handshake on 0.140.0 — the daemon closes the proxy's control connection, so the
-    /// client's `initialize` reads `response-eof`; remote-control enabled does not help. This
-    /// is the same single-process model the pre-0.140 bare `codex app-server` used, now made
-    /// explicit with the `--stdio` flag.) The handshake, methods, approval routing, and gating
-    /// downstream are all unchanged.
+    /// client's `initialize` reads `response-eof`; remote-control enabled does not help. That
+    /// proxy EOF was not evidence that stock bare `codex app-server` stopped speaking
+    /// newline-delimited JSON over stdio: the stock bare process and this explicit `--stdio`
+    /// path both answer JSON-RPC when driven on their stdio transport. The failure mode was
+    /// sending newline JSON to the WS-only control/proxy path.) This is the same
+    /// single-process model the pre-0.140 bare `codex app-server` used, now made explicit with
+    /// the `--stdio` flag. The handshake, methods, approval routing, and gating downstream are
+    /// all unchanged.
     ///
     /// The owned `child` IS the app-server process; `child_id`/`kill`/`Drop` manage it
     /// directly (killed on drop). Spawning requires the Codex CLI installed + logged in; a

--- a/rust-core/crates/friday-providers/src/lib.rs
+++ b/rust-core/crates/friday-providers/src/lib.rs
@@ -60,6 +60,11 @@ pub enum ProviderError {
     #[error("provider CLI not found or not runnable: {0}")]
     NotInstalled(String),
 
+    /// The provider CLI was runnable, but its read-only status command exited
+    /// non-zero. Carries only the exit code, never stdout/stderr.
+    #[error("provider status command failed (exit code {code:?})")]
+    StatusFailed { code: Option<i32> },
+
     /// A send was requested for a provider that is not authenticated. Refused —
     /// never silently routed to a different provider (no fallback, `04` §2/§4.5).
     #[error("provider {0} is not authenticated; refusing to send (no fallback)")]
@@ -118,10 +123,17 @@ impl Default for CliProbe {
 impl CliProbe {
     fn run(bin: &str, args: &[&str]) -> Result<ProbeOutput, ProviderError> {
         match Command::new(bin).args(args).output() {
-            Ok(out) => Ok(ProbeOutput {
-                stdout: String::from_utf8_lossy(&out.stdout).to_string(),
-                stderr: String::from_utf8_lossy(&out.stderr).to_string(),
-            }),
+            Ok(out) => {
+                if !out.status.success() {
+                    return Err(ProviderError::StatusFailed {
+                        code: out.status.code(),
+                    });
+                }
+                Ok(ProbeOutput {
+                    stdout: String::from_utf8_lossy(&out.stdout).to_string(),
+                    stderr: String::from_utf8_lossy(&out.stderr).to_string(),
+                })
+            }
             Err(e) => Err(ProviderError::NotInstalled(format!("{bin}: {e}"))),
         }
     }
@@ -154,6 +166,12 @@ pub fn parse_status(
     probe: Result<ProbeOutput, ProviderError>,
 ) -> ProviderAuthStatus {
     match probe {
+        Err(ProviderError::StatusFailed { .. }) => ProviderAuthStatus {
+            provider,
+            installed: true,
+            authenticated: false,
+            detail: "not_logged_in",
+        },
         Err(_) => ProviderAuthStatus {
             provider,
             installed: false,
@@ -260,6 +278,17 @@ mod tests {
     }
 
     #[test]
+    fn codex_nonzero_status_never_authenticates_logged_in_text() {
+        let s = parse_status(
+            Provider::Codex,
+            Err(ProviderError::StatusFailed { code: Some(1) }),
+        );
+        assert!(s.installed);
+        assert!(!s.authenticated);
+        assert_eq!(s.detail, "not_logged_in");
+    }
+
+    #[test]
     fn codex_not_logged_in_detected() {
         let p = MockProbe::new().set(Provider::Codex, "Not logged in");
         let s = detect(&p, Provider::Codex);
@@ -275,6 +304,17 @@ mod tests {
         );
         let s = detect(&p, Provider::Claude);
         assert!(s.installed && s.authenticated);
+    }
+
+    #[test]
+    fn claude_nonzero_status_never_authenticates_logged_in_json() {
+        let s = parse_status(
+            Provider::Claude,
+            Err(ProviderError::StatusFailed { code: Some(1) }),
+        );
+        assert!(s.installed);
+        assert!(!s.authenticated);
+        assert_eq!(s.detail, "not_logged_in");
     }
 
     #[test]

--- a/rust-core/crates/friday-providers/src/session.rs
+++ b/rust-core/crates/friday-providers/src/session.rs
@@ -281,6 +281,9 @@ impl SessionRunner for MockSession {
             }),
             Err(ProviderError::NotAuthenticated(p)) => Err(ProviderError::NotAuthenticated(p)),
             Err(ProviderError::NotInstalled(s)) => Err(ProviderError::NotInstalled(s.clone())),
+            Err(ProviderError::StatusFailed { code }) => {
+                Err(ProviderError::StatusFailed { code: *code })
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- treat non-zero provider auth-status exits as installed-but-not-authenticated instead of parsing potentially misleading output
- preserve Codex exit-0 stderr login detection and add Codex/Claude non-zero regression tests
- correct the #792 app-server transport record: proxy EOF was WS-control-path misuse, not proof that stock stdio stopped speaking newline JSON

## Verification
- cargo test --manifest-path rust-core/Cargo.toml -p friday-providers codex_logged_in_on_stderr_detected
- cargo test --manifest-path rust-core/Cargo.toml -p friday-providers
- cargo fmt --manifest-path rust-core/Cargo.toml --all -- --check
- git diff --check
- detect-secrets-hook --baseline .secrets.baseline rust-core/crates/friday-providers/src/lib.rs rust-core/crates/friday-providers/src/session.rs rust-core/crates/friday-providers/src/codex_appserver.rs