### PR TITLE
Surface T3 provisioning gaps on iOS home

### DIFF
--- a/apps/friday-ios/Sources/FridayMobileShell/FridayHomeScreen.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayHomeScreen.swift
@@ -37,7 +37,7 @@ struct FridayHomeScreen: View {
           UnavailableView(reason: reason)
         }
 
-        devicePairingCard(viewModel.devicePairing)
+        devicePairingCard(viewModel.devicePairing, viewModel.state.projection?.t3ProvisioningStatus)
       }
       .padding(16)
     }
@@ -113,7 +113,10 @@ struct FridayHomeScreen: View {
     .accessibilityIdentifier("friday.home.status-card")
   }
 
-  private func devicePairingCard(_ readiness: DevicePairingReadiness) -> some View {
+  private func devicePairingCard(
+    _ readiness: DevicePairingReadiness,
+    _ t3Status: HomeT3ProvisioningStatus?
+  ) -> some View {
     GlassPanel {
       VStack(alignment: .leading, spacing: MobileTheme.rowSpacing) {
         HStack {
@@ -134,6 +137,7 @@ struct FridayHomeScreen: View {
         pairingEntry
         pairingPreflightRows(viewModel.pairingPreflight)
         pairingAttemptRows(viewModel.pairingAttempt)
+        hubProvisioningRows(t3Status)
         HStack(spacing: 8) {
           StatusChip(
             text: readiness.readLiveRequested ? "read requested" : "read off",
@@ -151,7 +155,8 @@ struct FridayHomeScreen: View {
       }
     }
     .accessibilityElement(children: .combine)
-    .accessibilityLabel("Device pairing \(readiness.mode.rawValue). \(readiness.reason)")
+    .accessibilityLabel(
+      "Device pairing \(readiness.mode.rawValue). \(readiness.reason). \(t3Status?.homeSummary ?? "Hub T3 projection is not loaded.")")
     .accessibilityIdentifier("friday.home.device-pairing-card")
   }
 
@@ -262,6 +267,42 @@ struct FridayHomeScreen: View {
       if let errorCode = attempt.errorCode {
         RefPill(label: "ack_error", ref: errorCode)
       }
+    }
+  }
+
+  @ViewBuilder
+  private func hubProvisioningRows(_ status: HomeT3ProvisioningStatus?) -> some View {
+    Divider().opacity(0.35)
+    HStack {
+      Text("Hub provisioning").font(.caption.weight(.semibold)).foregroundStyle(MobileTheme.textPrimary)
+      Spacer()
+      if let status {
+        StatusChip(
+          text: status.homeStatusLabel,
+          bg: status.isFullyProvisioned ? MobileTheme.chipPendingBG : MobileTheme.chipWarnBG,
+          fg: status.isFullyProvisioned ? MobileTheme.chipPendingFG : MobileTheme.chipWarnFG)
+      } else {
+        StatusChip(text: "not loaded", bg: MobileTheme.chipNeutralBG, fg: MobileTheme.chipNeutralFG)
+      }
+    }
+    if let status {
+      Text(status.homeSummary)
+        .font(.caption2)
+        .foregroundStyle(MobileTheme.textSecondary)
+        .fixedSize(horizontal: false, vertical: true)
+      if !status.missingOperatorSteps.isEmpty {
+        RefPill(label: "missing", ref: status.missingOperatorSteps.joined(separator: ", "))
+      }
+      if let device = status.latestDevice {
+        RefPill(label: "trusted_device", ref: device.deviceId)
+        RefPill(label: "device_fingerprint", ref: device.pubkeyFingerprint)
+      }
+      RefPill(label: "truth", ref: status.truthLabel)
+    } else {
+      Text("Open a loaded Hub projection to see PairAck, trust grant, and context passport status.")
+        .font(.caption2)
+        .foregroundStyle(MobileTheme.textSecondary)
+        .fixedSize(horizontal: false, vertical: true)
     }
   }
 

--- a/apps/friday-ios/Sources/FridayMobileShellCore/HomeViewModel.swift
+++ b/apps/friday-ios/Sources/FridayMobileShellCore/HomeViewModel.swift
@@ -268,6 +268,41 @@ public struct HomeT3ProvisioningStatus: Sendable, Equatable {
     paired && activeTrustGrantCount > 0 && contextPassportCount > 0 && contextPassportItemCount > 0
   }
 
+  public var homeStatusLabel: String {
+    if isFullyProvisioned {
+      return "fully provisioned"
+    }
+    if paired {
+      return "operator action needed"
+    }
+    return "pairing needed"
+  }
+
+  public var missingOperatorSteps: [String] {
+    var steps: [String] = []
+    if !paired {
+      steps.append("PairAck")
+    }
+    if activeTrustGrantCount == 0 {
+      steps.append("trust grant")
+    }
+    if contextPassportCount == 0 || contextPassportItemCount == 0 {
+      steps.append("context passport")
+    }
+    return steps
+  }
+
+  public var homeSummary: String {
+    if isFullyProvisioned {
+      return "Hub projection shows paired device, active trust grant, and context passport rows."
+    }
+    let missing = missingOperatorSteps.joined(separator: ", ")
+    if paired {
+      return "Paired device is visible in the Hub; missing \(missing)."
+    }
+    return "No complete T3 device pairing in the Hub projection; missing \(missing)."
+  }
+
   private static func int(_ value: Any?) -> Int {
     if let int = value as? Int { return int }
     if let number = value as? NSNumber { return number.intValue }

--- a/apps/friday-ios/Tests/FridayMobileShellCoreTests/HomeViewModelTests.swift
+++ b/apps/friday-ios/Tests/FridayMobileShellCoreTests/HomeViewModelTests.swift
@@ -367,8 +367,47 @@ final class HomeViewModelTests: XCTestCase {
     XCTAssertEqual(p.t3ProvisioningStatus?.latestDevice?.deviceId, "proof://device/paired-ios-1")
     XCTAssertEqual(p.t3ProvisioningStatus?.latestDevice?.pubkeyFingerprint, "abcd1234:dcba4321")
     XCTAssertEqual(p.t3ProvisioningStatus?.isFullyProvisioned, true)
+    XCTAssertEqual(p.t3ProvisioningStatus?.homeStatusLabel, "fully provisioned")
+    XCTAssertEqual(p.t3ProvisioningStatus?.missingOperatorSteps, [])
     XCTAssertEqual(p.transcriptEvents.first?.summary, "Mobile surface read the mission projection.")
     XCTAssertEqual(p.needsMeCount, 4)
+  }
+
+  func testT3ProvisioningHomeSummarySurfacesOperatorGapsWithoutClaimingReady() throws {
+    let data = Data("""
+    {
+      "missionId": "mission-t3",
+      "fridayConversationId": "conv-t3",
+      "runtimeFeedStatus": "live_rust_hub_projection",
+      "statusLabels": [],
+      "t3ProvisioningStatus": {
+        "truthLabel": "rust_hub_t3_provisioning_read_only_no_mint",
+        "paired": true,
+        "deviceIdentityCount": 1,
+        "trustedDeviceCount": 1,
+        "activeTrustedDeviceCount": 1,
+        "trustGrantCount": 0,
+        "activeTrustGrantCount": 0,
+        "contextPassportCount": 0,
+        "contextPassportItemCount": 0,
+        "latestDevice": {
+          "deviceId": "proof://device/paired-ios-1",
+          "label": "operator phone",
+          "pairedAt": 1780640000000,
+          "pubkeyFingerprint": "abcd1234:dcba4321"
+        }
+      }
+    }
+    """.utf8)
+    let snapshot = try WorkbenchSnapshot(projectionJSON: data, generatedAtMs: 1_780_640_000_000)
+    let projection = HomeProjection(snapshot)
+
+    XCTAssertEqual(projection.t3ProvisioningStatus?.isFullyProvisioned, false)
+    XCTAssertEqual(projection.t3ProvisioningStatus?.homeStatusLabel, "operator action needed")
+    XCTAssertEqual(projection.t3ProvisioningStatus?.missingOperatorSteps, ["trust grant", "context passport"])
+    XCTAssertEqual(
+      projection.t3ProvisioningStatus?.homeSummary,
+      "Paired device is visible in the Hub; missing trust grant, context passport.")
   }
 
   func testRefresh_loadedEmptyIsConnectedEmptyNotUnavailable() async throws {


### PR DESCRIPTION
## Summary
- surface T3 provisioning status on the iOS home model without claiming readiness
- show operator-facing next action text when trust grant, context passport, or pairing gaps remain
- cover the summary with HomeViewModel tests

## Verification
- `swift test --package-path apps/friday-ios --filter HomeViewModelTests`
- `git diff --check`
- `detect-secrets-hook --baseline .secrets.baseline apps/friday-ios/Sources/FridayMobileShellCore/HomeViewModel.swift apps/friday-ios/Sources/FridayMobileShell/FridayHomeScreen.swift apps/friday-ios/Tests/FridayMobileShellCoreTests/HomeViewModelTests.swift`