### PR TITLE
Accept real mission ids in UI proof gates

### DIFF
--- a/scripts/qa/check-mission-spine-ui-proof-inputs.mjs
+++ b/scripts/qa/check-mission-spine-ui-proof-inputs.mjs
@@ -248,6 +248,15 @@ function observationExists(observations, requiredSurface, eventName, missionId, 
   });
 }
 
+function isMissionIdProofEligible(value) {
+  if (typeof value !== "string") return false;
+  const missionId = value.trim();
+  return /^[A-Za-z0-9][A-Za-z0-9._:-]*$/.test(missionId)
+    && missionId.toLowerCase().includes("mission")
+    && missionId !== "mission_pending_runtime_projection"
+    && !missionId.includes("TODO");
+}
+
 function validateKnownEvidenceRef(value, knownEvidenceRefs, failures, code, detail) {
   if (!knownEvidenceRefs.has(value)) {
     recordFailure(failures, code, detail);
@@ -499,7 +508,7 @@ if (helpRequested) {
 const failures = [];
 const missionId = argValue("mission-id", "MISSION_ID");
 if (!missionId) recordFailure(failures, "missing_mission_id", "mission-id");
-if (missionId && !missionId.startsWith("mission_")) {
+if (missionId && !isMissionIdProofEligible(missionId)) {
   recordFailure(failures, "mission_id_unexpected_shape", missionId);
 }
 if (missionId === "mission_pending_runtime_projection" || missionId.includes("TODO")) {

--- a/scripts/qa/check-mission-workbench-snapshot-contract.mjs
+++ b/scripts/qa/check-mission-workbench-snapshot-contract.mjs
@@ -211,6 +211,15 @@ function validateStringField(value, failures, code, detail) {
   return value;
 }
 
+function isMissionIdProofEligible(value) {
+  if (typeof value !== "string") return false;
+  const missionId = value.trim();
+  return /^[A-Za-z0-9][A-Za-z0-9._:-]*$/.test(missionId)
+    && missionId.toLowerCase().includes("mission")
+    && missionId !== "mission_pending_runtime_projection"
+    && !missionId.includes("TODO");
+}
+
 function validateSnapshot(snapshot, expectedMissionId, failures) {
   if (!snapshot) return null;
   const text = JSON.stringify(snapshot);
@@ -218,7 +227,7 @@ function validateSnapshot(snapshot, expectedMissionId, failures) {
 
   const missionId = validateStringField(snapshot.missionId, failures, "mission_id_missing", "snapshot.missionId");
   validateStringField(snapshot.fridayConversationId, failures, "conversation_id_missing", "snapshot.fridayConversationId");
-  if (missionId && !missionId.startsWith("mission_")) {
+  if (missionId && !isMissionIdProofEligible(missionId)) {
     recordFailure(failures, "mission_id_unexpected_shape", missionId);
   }
   if (expectedMissionId && missionId !== expectedMissionId) {

--- a/src/api/http/routes/friday-mission-spine-routes.ts
+++ b/src/api/http/routes/friday-mission-spine-routes.ts
@@ -431,6 +431,15 @@ function hasText(value: unknown): boolean {
   return typeof value === "string" && value.trim().length > 0;
 }
 
+function isMissionIdProofEligible(value: unknown): boolean {
+  if (typeof value !== "string") return false;
+  const missionId = value.trim();
+  return /^[A-Za-z0-9][A-Za-z0-9._:-]*$/.test(missionId)
+    && missionId.toLowerCase().includes("mission")
+    && missionId !== "mission_pending_runtime_projection"
+    && !missionId.includes("TODO");
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
@@ -459,7 +468,7 @@ function validateSnapshotHeader(
   failures: string[],
   requestedMissionId?: string,
 ): void {
-  pushIfInvalid(failures, hasText(snapshot.missionId) && snapshot.missionId.startsWith("mission_"), "mission_id_missing_or_invalid");
+  pushIfInvalid(failures, isMissionIdProofEligible(snapshot.missionId), "mission_id_missing_or_invalid");
   if (requestedMissionId) {
     pushIfInvalid(
       failures,

--- a/test/unit/api/routes/friday-mission-spine-routes.test.ts
+++ b/test/unit/api/routes/friday-mission-spine-routes.test.ts
@@ -338,6 +338,43 @@ describe("createFridayMissionSpineRoutes", () => {
     expect(JSON.stringify(response)).not.toContain("prep fallback");
   });
 
+  it("accepts real Rust producer hyphen mission ids without weakening exact-match checks", async () => {
+    const missionId = "mission-autodisp-1781492033";
+    const hyphenSnapshot = cloneSnapshot({
+      missionId,
+      duplicatePreflight: {
+        ...snapshot.duplicatePreflight,
+        duplicateMissionId: missionId,
+      },
+      transcriptSections: snapshot.transcriptSections.map((section) => ({
+        ...section,
+        missionId,
+        events: section.events.map((event) => ({
+          ...event,
+          missionId,
+        })),
+      })),
+    });
+    const getSnapshot = vi.fn(async () => hyphenSnapshot);
+    const routes = createFridayMissionSpineRoutes({
+      workbench: { getSnapshot },
+      disabledReason: null,
+    });
+    const route = findRoute(routes);
+
+    const response = await route.handler(makeCtx({
+      query: { missionId },
+    }) as never);
+
+    expect(response).toEqual({ snapshot: hyphenSnapshot });
+    expect(getSnapshot).toHaveBeenCalledWith({
+      missionId,
+      principalId: "principal-1",
+      userId: "user-1",
+      surface: "api:/v1/mission-spine/workbench",
+    });
+  });
+
   it("accepts read-only T3 provisioning status but rejects raw device-key leaks", async () => {
     const routes = createFridayMissionSpineRoutes({
       workbench: { getSnapshot: vi.fn(async () => snapshot) },

--- a/test/unit/qa/mission-spine-ui-proof-inputs-cli.test.ts
+++ b/test/unit/qa/mission-spine-ui-proof-inputs-cli.test.ts
@@ -6,7 +6,7 @@ import { describe, expect, it } from "vitest";
 
 const missionId = "mission_cli_ui_proof_inputs";
 
-function writeEvidenceFiles(tempDir: string) {
+function writeEvidenceFiles(tempDir: string, activeMissionId = missionId) {
   const files = {
     mobile: join(tempDir, "mobile-real-consumption.json"),
     desktop: join(tempDir, "desktop-real-consumption.json"),
@@ -17,7 +17,7 @@ function writeEvidenceFiles(tempDir: string) {
   for (const [role, filePath] of Object.entries(files)) {
     writeFileSync(filePath, JSON.stringify({
       role,
-      mission_id: missionId,
+      mission_id: activeMissionId,
       capture: "redacted pre-assemble CLI fixture for harness validation only",
     }));
   }
@@ -25,16 +25,25 @@ function writeEvidenceFiles(tempDir: string) {
   return files;
 }
 
-function makeObservation(surface: string, event: string, evidenceRef: string) {
+function makeObservation(
+  surface: string,
+  event: string,
+  evidenceRef: string,
+  activeMissionId = missionId,
+) {
   return {
     surface,
     event,
-    mission_id: missionId,
+    mission_id: activeMissionId,
     evidence_ref: evidenceRef,
   };
 }
 
-function makeManifest(evidenceRefs: ReturnType<typeof writeEvidenceFiles>, overrides: Record<string, unknown> = {}) {
+function makeManifest(
+  evidenceRefs: ReturnType<typeof writeEvidenceFiles>,
+  overrides: Record<string, unknown> = {},
+  activeMissionId = missionId,
+) {
   const checks = Object.fromEntries([
     "same_mission_id_mobile_desktop",
     "same_mission_id_channel",
@@ -71,34 +80,34 @@ function makeManifest(evidenceRefs: ReturnType<typeof writeEvidenceFiles>, overr
   };
 
   const observations = [
-    makeObservation("mobile", "mission_intake_submitted", evidenceRefs.mobile),
-    makeObservation("mobile", "mission_intake_ready", evidenceRefs.mobile),
-    makeObservation("desktop", "mission_resolve_or_create_visible", evidenceRefs.desktop),
-    makeObservation("desktop", "duplicate_preflight_visible", evidenceRefs.desktop),
-    makeObservation("mobile", "mission_bound_provider_action_visible", evidenceRefs.mobile),
-    makeObservation("desktop", "real_provider_execution_visible", evidenceRefs.desktop),
-    makeObservation("mobile", "proof_receipt_visible_before_done", evidenceRefs.mobile),
-    makeObservation("desktop", "same_mission_projection_visible", evidenceRefs.desktop),
-    makeObservation("desktop", "mission_workbench_visible", evidenceRefs.desktop),
-    makeObservation("desktop", "transcript_browser_visible", evidenceRefs.desktop),
-    makeObservation("desktop", "duplicate_blocked_opens_existing", evidenceRefs.desktop),
-    makeObservation("channel", "same_mission_projection_visible", evidenceRefs.channel),
-    makeObservation("channel", "same_mission_mobile_desktop_channel_visible", evidenceRefs.channel),
-    makeObservation("timeline", "bounded_page_1_visible", evidenceRefs.timeline),
-    makeObservation("timeline", "bounded_page_2_visible", evidenceRefs.timeline),
-    makeObservation("timeline", "memory_candidate_review_only", evidenceRefs.timeline),
-    makeObservation("desktop", "provider_ack_not_done_visible", evidenceRefs.desktop),
-    makeObservation("desktop", "pressure_20_50_consecutive_asks_visible", evidenceRefs.desktop),
-    makeObservation("desktop", "invalid_key_error_visible", evidenceRefs.desktop),
-    makeObservation("desktop", "quota_error_visible", evidenceRefs.desktop),
-    makeObservation("desktop", "network_error_visible", evidenceRefs.desktop),
-    makeObservation("channel", "channel_replay_blocked_visible", evidenceRefs.channel),
-    makeObservation("desktop", "reconnect_stale_verified", evidenceRefs.desktop),
-    makeObservation("desktop", "real_provider_execution_receipt_visible", evidenceRefs.desktop),
-    makeObservation("desktop", "stale_label_visible", evidenceRefs.desktop),
-    makeObservation("desktop", "offline_label_visible", evidenceRefs.desktop),
-    makeObservation("desktop", "error_label_visible", evidenceRefs.desktop),
-    makeObservation("desktop", "no_hidden_fallback_verified", evidenceRefs.desktop),
+    makeObservation("mobile", "mission_intake_submitted", evidenceRefs.mobile, activeMissionId),
+    makeObservation("mobile", "mission_intake_ready", evidenceRefs.mobile, activeMissionId),
+    makeObservation("desktop", "mission_resolve_or_create_visible", evidenceRefs.desktop, activeMissionId),
+    makeObservation("desktop", "duplicate_preflight_visible", evidenceRefs.desktop, activeMissionId),
+    makeObservation("mobile", "mission_bound_provider_action_visible", evidenceRefs.mobile, activeMissionId),
+    makeObservation("desktop", "real_provider_execution_visible", evidenceRefs.desktop, activeMissionId),
+    makeObservation("mobile", "proof_receipt_visible_before_done", evidenceRefs.mobile, activeMissionId),
+    makeObservation("desktop", "same_mission_projection_visible", evidenceRefs.desktop, activeMissionId),
+    makeObservation("desktop", "mission_workbench_visible", evidenceRefs.desktop, activeMissionId),
+    makeObservation("desktop", "transcript_browser_visible", evidenceRefs.desktop, activeMissionId),
+    makeObservation("desktop", "duplicate_blocked_opens_existing", evidenceRefs.desktop, activeMissionId),
+    makeObservation("channel", "same_mission_projection_visible", evidenceRefs.channel, activeMissionId),
+    makeObservation("channel", "same_mission_mobile_desktop_channel_visible", evidenceRefs.channel, activeMissionId),
+    makeObservation("timeline", "bounded_page_1_visible", evidenceRefs.timeline, activeMissionId),
+    makeObservation("timeline", "bounded_page_2_visible", evidenceRefs.timeline, activeMissionId),
+    makeObservation("timeline", "memory_candidate_review_only", evidenceRefs.timeline, activeMissionId),
+    makeObservation("desktop", "provider_ack_not_done_visible", evidenceRefs.desktop, activeMissionId),
+    makeObservation("desktop", "pressure_20_50_consecutive_asks_visible", evidenceRefs.desktop, activeMissionId),
+    makeObservation("desktop", "invalid_key_error_visible", evidenceRefs.desktop, activeMissionId),
+    makeObservation("desktop", "quota_error_visible", evidenceRefs.desktop, activeMissionId),
+    makeObservation("desktop", "network_error_visible", evidenceRefs.desktop, activeMissionId),
+    makeObservation("channel", "channel_replay_blocked_visible", evidenceRefs.channel, activeMissionId),
+    makeObservation("desktop", "reconnect_stale_verified", evidenceRefs.desktop, activeMissionId),
+    makeObservation("desktop", "real_provider_execution_receipt_visible", evidenceRefs.desktop, activeMissionId),
+    makeObservation("desktop", "stale_label_visible", evidenceRefs.desktop, activeMissionId),
+    makeObservation("desktop", "offline_label_visible", evidenceRefs.desktop, activeMissionId),
+    makeObservation("desktop", "error_label_visible", evidenceRefs.desktop, activeMissionId),
+    makeObservation("desktop", "no_hidden_fallback_verified", evidenceRefs.desktop, activeMissionId),
   ];
 
   return {
@@ -197,6 +206,23 @@ describe("check-mission-spine-ui-proof-inputs CLI", () => {
       });
       expect(result.evidence.map((entry) => entry.role)).toEqual(["mobile", "desktop", "channel", "timeline"]);
       expect(result.evidence.every((entry) => /^[a-f0-9]{64}$/.test(entry.sha256) && entry.bytes > 0)).toBe(true);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("accepts real Rust producer hyphen mission ids across evidence and observations", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "friday-ui-proof-inputs-hyphen-"));
+    try {
+      const hyphenMissionId = "mission-autodisp-1781492033";
+      const files = writeEvidenceFiles(tempDir, hyphenMissionId);
+      const manifestPath = join(tempDir, "observations-manifest-hyphen.json");
+      writeFileSync(manifestPath, JSON.stringify(makeManifest(files, {}, hyphenMissionId), null, 2));
+
+      const result = runInputsCli(files, manifestPath, [], hyphenMissionId);
+
+      expect(result.readyForAssemble).toBe(true);
+      expect(result.failures).toEqual([]);
     } finally {
       rmSync(tempDir, { recursive: true, force: true });
     }

--- a/test/unit/qa/mission-workbench-snapshot-contract-cli.test.ts
+++ b/test/unit/qa/mission-workbench-snapshot-contract-cli.test.ts
@@ -4,8 +4,10 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 
-function makeSnapshot(overrides: Record<string, unknown> = {}) {
-  const missionId = "mission_cli_snapshot_contract";
+function makeSnapshot(
+  overrides: Record<string, unknown> = {},
+  missionId = "mission_cli_snapshot_contract",
+) {
   const snapshot = {
     missionId,
     fridayConversationId: "conversation_cli_snapshot_contract",
@@ -19,7 +21,7 @@ function makeSnapshot(overrides: Record<string, unknown> = {}) {
     routeDecision: {
       advisorSummary: "Rust Hub route decision projection.",
       selectedRoute: "route_decision_ref",
-      controlRef: "friday://route-decision-projection/mission_cli_snapshot_contract/work_provider/1700000000000",
+      controlRef: `friday://route-decision-projection/${missionId}/work_provider/1700000000000`,
       workItemId: "work_provider",
       alternatives: ["alternate_ref"],
       actionItems: [
@@ -225,11 +227,15 @@ function makeSnapshot(overrides: Record<string, unknown> = {}) {
   };
 }
 
-function runSnapshotContract(filePath: string, extraArgs: string[] = []) {
+function runSnapshotContract(
+  filePath: string,
+  extraArgs: string[] = [],
+  missionId = "mission_cli_snapshot_contract",
+) {
   const stdout = execFileSync(process.execPath, [
     "scripts/qa/check-mission-workbench-snapshot-contract.mjs",
     `--file=${filePath}`,
-    "--mission-id=mission_cli_snapshot_contract",
+    `--mission-id=${missionId}`,
     ...extraArgs,
   ], {
     cwd: process.cwd(),
@@ -272,6 +278,23 @@ describe("check-mission-workbench-snapshot-contract CLI", () => {
         "timelineRef",
         "workflowRef",
       ]);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("accepts real Rust producer hyphen mission ids without downgrading the contract", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "friday-workbench-contract-hyphen-"));
+    try {
+      const missionId = "mission-autodisp-1781492033";
+      const filePath = join(tempDir, "snapshot.json");
+      writeFileSync(filePath, JSON.stringify({ snapshot: makeSnapshot({}, missionId) }, null, 2));
+
+      const result = runSnapshotContract(filePath, [], missionId);
+
+      expect(result.readyForLiveCaptureInput).toBe(true);
+      expect(result.failures).toEqual([]);
+      expect(result.summary?.transcriptSurfaces).toEqual(["desktop", "mobile", "telegram", "timeline"]);
     } finally {
       rmSync(tempDir, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary
- preserve real mission/work item identifiers in mission-spine UI proof inputs
- allow the workbench snapshot contract gate to validate UUID-backed mission ids instead of only synthetic prefixes
- add route and QA CLI tests for real mission id handling

## Verification
- `npx vitest run test/unit/api/routes/friday-mission-spine-routes.test.ts test/unit/qa/mission-workbench-snapshot-contract-cli.test.ts test/unit/qa/mission-spine-ui-proof-inputs-cli.test.ts`
- `git diff --check`
- `detect-secrets-hook --baseline .secrets.baseline src/api/http/routes/friday-mission-spine-routes.ts scripts/qa/check-mission-workbench-snapshot-contract.mjs scripts/qa/check-mission-spine-ui-proof-inputs.mjs test/unit/api/routes/friday-mission-spine-routes.test.ts test/unit/qa/mission-workbench-snapshot-contract-cli.test.ts test/unit/qa/mission-spine-ui-proof-inputs-cli.test.ts`