### PR TITLE
Surface desktop recovery attention controls

### DIFF
--- a/apps/macos/FridayHubConsole/Sources/FridayHubConsole/DesktopChatScreen.swift
+++ b/apps/macos/FridayHubConsole/Sources/FridayHubConsole/DesktopChatScreen.swift
@@ -376,9 +376,30 @@ struct DesktopChatScreen: View {
             }
             .buttonStyle(.borderedProminent)
             .tint(HubTheme.cyan)
-            .disabled(approvalRelayState(for: item).isSent)
+            .disabled(approvalRelayControlsDisabled(for: item))
             .accessibilityLabel("Approve and relay operator signature")
             .accessibilityIdentifier("friday.desktop.chat.approve.\(item.refId)")
+
+            Button {
+              Task { await viewModel.rejectNeedsMeApproval(item) }
+            } label: {
+              Label("Reject", systemImage: "xmark.seal")
+            }
+            .buttonStyle(.bordered)
+            .disabled(approvalRelayControlsDisabled(for: item))
+            .accessibilityLabel("Reject pending operator approval")
+            .accessibilityIdentifier("friday.desktop.chat.reject.\(item.refId)")
+
+            Button {
+              Task { await viewModel.cancelNeedsMeRun(item) }
+            } label: {
+              Label("Cancel Run", systemImage: "stop.circle")
+            }
+            .buttonStyle(.bordered)
+            .disabled(approvalRelayControlsDisabled(for: item))
+            .accessibilityLabel("Cancel paused run")
+            .accessibilityIdentifier("friday.desktop.chat.cancelRun.\(item.refId)")
+
             approvalRelayStatus(for: item)
           }
           Text("Approval remains operator-signature gated; this surface relays an external signer blob and does not mint a signature.")
@@ -407,6 +428,11 @@ struct DesktopChatScreen: View {
 
   private func approvalRelayState(for item: ChatNeedsMeItem) -> WriteActionState {
     viewModel.approvalRelayStates[item.id] ?? .ready
+  }
+
+  private func approvalRelayControlsDisabled(for item: ChatNeedsMeItem) -> Bool {
+    let state = approvalRelayState(for: item)
+    return state.isSent || state.isTerminal
   }
 
   private func activityMarkDoneState(for item: ChatNeedsMeItem) -> WriteActionState {

--- a/apps/macos/FridayHubConsole/Sources/FridayHubConsole/OperationsOverviewScreen.swift
+++ b/apps/macos/FridayHubConsole/Sources/FridayHubConsole/OperationsOverviewScreen.swift
@@ -91,6 +91,7 @@ struct OperationsOverviewScreen: View {
 
       devicePairingCard(viewModel.devicePairing)
       t3ProvisioningCard(snapshot.t3ProvisioningStatus)
+      attentionCard(snapshot)
       missionCard(snapshot)
       if snapshot.isLoadedEmpty {
         loadedEmptyCard(snapshot)
@@ -248,6 +249,65 @@ struct OperationsOverviewScreen: View {
     .accessibilityElement(children: .combine)
     .accessibilityLabel("Friday is connected, with no active desktop work for this owner")
     .accessibilityIdentifier("friday.desktop.loaded-empty")
+  }
+
+  private func attentionCard(_ snapshot: WorkbenchSnapshot) -> some View {
+    GlassPanel {
+      VStack(alignment: .leading, spacing: HubTheme.rowSpacing) {
+        HStack {
+          cardTitle("Needs Attention")
+          Spacer()
+          let count = snapshot.attentionWorkItems.count
+          StatusChip(
+            text: count == 0 ? "clear" : "\(count) open",
+            bg: count == 0 ? HubTheme.chipDoneBG : HubTheme.chipWarnBG,
+            fg: count == 0 ? HubTheme.chipDoneFG : HubTheme.chipWarnFG)
+        }
+        Text(snapshot.attentionSummary)
+          .font(.system(size: 12))
+          .foregroundStyle(HubTheme.textSecondary)
+
+        if snapshot.attentionWorkItems.isEmpty {
+          Text("No blocked, stale, waiting, or provider-ack work items are visible in this projection.")
+            .font(.system(size: 10))
+            .foregroundStyle(HubTheme.textSecondary)
+        } else {
+          ForEach(snapshot.attentionWorkItems.prefix(5)) { item in
+            VStack(alignment: .leading, spacing: 4) {
+              HStack(spacing: 6) {
+                item.state.chip
+                item.owner.chip
+                Text(item.title)
+                  .font(.system(size: 12, weight: .medium))
+                  .foregroundStyle(HubTheme.textPrimary)
+                  .lineLimit(1)
+              }
+              Text(item.attentionReason)
+                .font(.system(size: 10))
+                .foregroundStyle(HubTheme.textSecondary)
+              RefPill(label: "workItemId", ref: item.id)
+              if let proof = item.proofRef {
+                RefPill(label: "proofRef", ref: proof)
+              }
+            }
+            .padding(.vertical, 2)
+          }
+          if snapshot.attentionWorkItems.count > 5 {
+            Text("+ \(snapshot.attentionWorkItems.count - 5) more attention item(s) in Work Items.")
+              .font(.system(size: 10))
+              .foregroundStyle(HubTheme.textSecondary)
+          }
+        }
+
+        Text("Read-only recovery visibility; no dispatch, retry, signing, or close action is exposed here.")
+          .font(.system(size: 10))
+          .foregroundStyle(HubTheme.textSecondary)
+          .fixedSize(horizontal: false, vertical: true)
+      }
+    }
+    .accessibilityElement(children: .combine)
+    .accessibilityLabel("Needs attention. \(snapshot.attentionSummary)")
+    .accessibilityIdentifier("friday.desktop.needs-attention")
   }
 
   /// The spine-WRITE compose affordance — an operator types an intent and submits it as a

--- a/apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/OperationsOverviewViewModel.swift
+++ b/apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/OperationsOverviewViewModel.swift
@@ -269,6 +269,8 @@ public enum WriteActionState: Sendable, Equatable {
 ///  - `select(_:)`             — focus a row in the proof inspector (OpenEvidence-class nav),
 ///  - `submitIntake(intent:)`  — drive ONE operator-typed Mission intake over the sealed WRITE seam,
 ///  - `decideMemory(...)`      — drive ONE owner confirm/reject of a memory candidate.
+///  - `approve/reject/cancelNeedsMe...` — relay operator choices for a paused run; signing stays
+///    external and the app never holds the operator key.
 /// The write drivers are gated: with no `writeClient` (or an honest-unavailable one) they render the
 /// truth, never a fabricated confirm. No provider-admin / arbitrary-mutation method is exposed.
 @MainActor
@@ -584,6 +586,62 @@ public final class OperationsOverviewViewModel: ObservableObject {
         await loadLatestChatReview()
       } else {
         approvalRelayStates[key] = .error(reason: "Resume refused: \(Self.resumeSummary(for: result))")
+      }
+    } catch {
+      approvalRelayStates[key] = .error(reason: Self.writeReason(for: error))
+    }
+  }
+
+  /// Reject one pending operator approval from the desktop Needs Review queue without resuming the
+  /// paused mutation. This is owner-authenticated run-control, not signing.
+  public func rejectNeedsMeApproval(_ item: ChatNeedsMeItem) async {
+    let key = item.id
+    guard item.kind == "approval_required" || item.kind == "approval" else {
+      approvalRelayStates[key] = .error(reason: "This Needs Review row is not an operator approval.")
+      return
+    }
+    guard let approvalResumeClient else {
+      approvalRelayStates[key] = .error(reason: "Run-control write seam not configured.")
+      return
+    }
+
+    approvalRelayStates[key] = .sent
+    do {
+      let result = try await approvalResumeClient.rejectApproval(
+        runId: item.runId,
+        approvalId: item.refId)
+      if result.accepted {
+        approvalRelayStates[key] = .confirmed(summary: Self.resumeSummary(for: result))
+        await refresh()
+        await loadLatestChatReview()
+      } else {
+        approvalRelayStates[key] = .error(reason: "Reject refused: \(Self.resumeSummary(for: result))")
+      }
+    } catch {
+      approvalRelayStates[key] = .error(reason: Self.writeReason(for: error))
+    }
+  }
+
+  /// Cancel the paused run backing a Needs Review row. This is a recovery/stop affordance for a
+  /// real run; it does not complete work, mint proof, or sign approval.
+  public func cancelNeedsMeRun(_ item: ChatNeedsMeItem) async {
+    let key = item.id
+    guard let approvalResumeClient else {
+      approvalRelayStates[key] = .error(reason: "Run-control write seam not configured.")
+      return
+    }
+
+    approvalRelayStates[key] = .sent
+    do {
+      let result = try await approvalResumeClient.cancelRun(
+        runId: item.runId,
+        reason: "operator cancelled from desktop Needs Review")
+      if result.accepted {
+        approvalRelayStates[key] = .confirmed(summary: Self.resumeSummary(for: result))
+        await refresh()
+        await loadLatestChatReview()
+      } else {
+        approvalRelayStates[key] = .error(reason: "Cancel refused: \(Self.resumeSummary(for: result))")
       }
     } catch {
       approvalRelayStates[key] = .error(reason: Self.writeReason(for: error))

--- a/apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/WorkbenchSnapshot.swift
+++ b/apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/WorkbenchSnapshot.swift
@@ -155,6 +155,45 @@ public struct MissionWorkbenchWorkItem: Codable, Sendable, Identifiable, Equatab
     self.proofRef = proofRef
     self.done = done
   }
+
+  public var needsAttention: Bool {
+    guard !done else { return false }
+    switch state {
+    case .completedWithProof, .timelineRead:
+      return false
+    case .ready:
+      return owner != .fridayOwned
+    case .queued, .providerAck, .waiting, .stale, .reconnecting, .blocked, .error, .unknown:
+      return true
+    }
+  }
+
+  public var attentionReason: String {
+    switch state {
+    case .providerAck:
+      return "provider acknowledged; waiting for proof"
+    case .waiting:
+      return "waiting for user, provider, or recovery path"
+    case .stale:
+      return "stale projection state"
+    case .reconnecting:
+      return "reconnecting"
+    case .blocked:
+      return "blocked"
+    case .error:
+      return "error"
+    case .unknown:
+      return "unknown lifecycle state"
+    case .queued:
+      return "queued"
+    case .ready:
+      return owner == .fridayOwned ? "ready" : "linked item not owned by Friday"
+    case .completedWithProof:
+      return "completed with proof"
+    case .timelineRead:
+      return "timeline read only"
+    }
+  }
 }
 
 public struct MissionWorkbenchTimelinePage: Codable, Sendable, Identifiable, Equatable {
@@ -469,6 +508,16 @@ public struct WorkbenchSnapshot: Codable, Sendable, Equatable {
       && capabilityStates.isEmpty
       && t3ProvisioningStatus == nil
       && transcriptSections.isEmpty
+  }
+
+  public var attentionWorkItems: [MissionWorkbenchWorkItem] {
+    workItems.filter(\.needsAttention)
+  }
+
+  public var attentionSummary: String {
+    let count = attentionWorkItems.count
+    if count == 0 { return "No work items need attention." }
+    return "\(count) work item\(count == 1 ? "" : "s") need attention."
   }
 }
 

--- a/apps/macos/FridayHubConsole/Tests/FridayHubConsoleCoreTests/OperationsOverviewViewModelTests.swift
+++ b/apps/macos/FridayHubConsole/Tests/FridayHubConsoleCoreTests/OperationsOverviewViewModelTests.swift
@@ -140,6 +140,62 @@ func representativeSnapshotIsNotLoadedEmpty() {
   #expect(!snapshot.isLoadedEmpty)
 }
 
+@Test
+func attentionSummarySurfacesOnlyUnfinishedRecoveryRelevantWorkItems() {
+  let snapshot = MockReadClient.representativeSnapshot
+  let attentionIds = snapshot.attentionWorkItems.map(\.id)
+
+  #expect(attentionIds.contains("work_probe_provider"))
+  #expect(attentionIds.contains("work_probe_blocked"))
+  #expect(!attentionIds.contains("work_probe_done"))
+  #expect(!attentionIds.contains("workbench_timeline_read_mission_workbench_probe_20260605"))
+  #expect(snapshot.attentionSummary == "2 work items need attention.")
+  #expect(
+    snapshot.attentionWorkItems.first { $0.id == "work_probe_provider" }?.attentionReason
+      == "provider acknowledged; waiting for proof")
+}
+
+@Test
+func attentionSummaryStaysClearForCompletedAndTimelineOnlySnapshots() {
+  let snapshot = FridayHubConsoleCore.WorkbenchSnapshot(
+    missionId: "mission-clear",
+    fridayConversationId: "fconv-clear",
+    runtimeFeedStatus: .liveRustHubProjection,
+    statusLabels: [],
+    duplicatePreflight: MissionWorkbenchDuplicatePreflight(
+      status: "none", duplicateMissionId: "", duplicateWorkItemId: ""),
+    routeDecision: MissionWorkbenchRouteDecision(
+      advisorSummary: "complete",
+      selectedRoute: "proof://route-decision/clear",
+      alternatives: [],
+      truthLabel: .fridayOwned),
+    providerReceiptRefs: [],
+    channelReceiptRefs: [],
+    workItems: [
+      MissionWorkbenchWorkItem(
+        id: "work-done",
+        title: "Done",
+        state: .completedWithProof,
+        owner: .fridayOwned,
+        proofRef: "proof://done",
+        done: true),
+      MissionWorkbenchWorkItem(
+        id: "work-timeline",
+        title: "Timeline read",
+        state: .timelineRead,
+        owner: .fridayOwned,
+        proofRef: "proof://timeline",
+        done: false),
+    ],
+    timelinePages: [],
+    memoryCandidates: [],
+    capabilityStates: [],
+    transcriptSections: [])
+
+  #expect(snapshot.attentionWorkItems.isEmpty)
+  #expect(snapshot.attentionSummary == "No work items need attention.")
+}
+
 private func temporaryHome() throws -> URL {
   let url = FileManager.default.temporaryDirectory
     .appendingPathComponent("friday-console-tests-\(UUID().uuidString)")
@@ -1168,6 +1224,89 @@ func approveNeedsMeItemWithoutSignerFailsClosedWithoutResume() async {
   }
   #expect(reason.contains("not configured"))
   #expect(write.lastResumeRunId == nil)
+}
+
+@Test
+@MainActor
+func rejectNeedsMeApprovalUsesRunControlWithoutSigner() async {
+  let write = MockMissionSpineWriteClient(behavior: .intakeReady)
+  let item = ChatNeedsMeItem(
+    runId: "run-paused",
+    kind: "approval_required",
+    title: "reject write_file",
+    refId: "approval-nonce-10",
+    state: "pending",
+    deepLink: nil,
+    actionDigest: String(repeating: "b", count: 64),
+    signingSummary: "write_file paused")
+  let vm = OperationsOverviewViewModel(
+    client: MockReadClient(behavior: .loaded),
+    approvalResumeClient: write)
+
+  await vm.rejectNeedsMeApproval(item)
+
+  #expect(write.lastRejectRunId == "run-paused")
+  #expect(write.lastRejectApprovalId == "approval-nonce-10")
+  #expect(write.lastResumeRunId == nil)
+  guard case let .confirmed(summary, _, _) = vm.approvalRelayStates[item.id] else {
+    Issue.record("expected approval reject .confirmed, got \(String(describing: vm.approvalRelayStates[item.id]))")
+    return
+  }
+  #expect(summary.contains("reject"))
+  #expect(summary.contains("audit://reject/1"))
+}
+
+@Test
+@MainActor
+func cancelNeedsMeRunUsesRunControlReason() async {
+  let write = MockMissionSpineWriteClient(behavior: .intakeReady)
+  let item = ChatNeedsMeItem(
+    runId: "run-paused",
+    kind: "approval_required",
+    title: "cancel paused run",
+    refId: "approval-nonce-11",
+    state: "pending",
+    deepLink: nil,
+    actionDigest: nil,
+    signingSummary: nil)
+  let vm = OperationsOverviewViewModel(
+    client: MockReadClient(behavior: .loaded),
+    approvalResumeClient: write)
+
+  await vm.cancelNeedsMeRun(item)
+
+  #expect(write.lastCancelRunId == "run-paused")
+  #expect(write.lastCancelReason == "operator cancelled from desktop Needs Review")
+  #expect(write.lastResumeRunId == nil)
+  guard case let .confirmed(summary, _, _) = vm.approvalRelayStates[item.id] else {
+    Issue.record("expected cancel .confirmed, got \(String(describing: vm.approvalRelayStates[item.id]))")
+    return
+  }
+  #expect(summary.contains("cancel"))
+  #expect(summary.contains("audit://cancel/1"))
+}
+
+@Test
+@MainActor
+func rejectNeedsMeApprovalWithoutRunControlFailsClosed() async {
+  let item = ChatNeedsMeItem(
+    runId: "run-paused",
+    kind: "approval_required",
+    title: "reject write_file",
+    refId: "approval-nonce-12",
+    state: "pending",
+    deepLink: nil,
+    actionDigest: nil,
+    signingSummary: nil)
+  let vm = OperationsOverviewViewModel(client: MockReadClient(behavior: .loaded))
+
+  await vm.rejectNeedsMeApproval(item)
+
+  guard case let .error(reason) = vm.approvalRelayStates[item.id] else {
+    Issue.record("expected reject .error, got \(String(describing: vm.approvalRelayStates[item.id]))")
+    return
+  }
+  #expect(reason.contains("not configured"))
 }
 
 @Test


### PR DESCRIPTION
## Summary
- add a read-only desktop Needs Attention summary for blocked/stale/waiting/provider-ack work items
- add Reject and Cancel Run controls to desktop approval-required Needs Review rows using existing sealed run-control methods
- keep operator signing external: Approve only relays a signed blob, Reject/Cancel do not mint signatures or proof

## Verification
- `swift test --package-path apps/macos/FridayHubConsole --filter OperationsOverviewViewModelTests`
- `git diff --check`
- `detect-secrets-hook --baseline .secrets.baseline apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/WorkbenchSnapshot.swift apps/macos/FridayHubConsole/Sources/FridayHubConsole/OperationsOverviewScreen.swift apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/OperationsOverviewViewModel.swift apps/macos/FridayHubConsole/Sources/FridayHubConsole/DesktopChatScreen.swift apps/macos/FridayHubConsole/Tests/FridayHubConsoleCoreTests/OperationsOverviewViewModelTests.swift`