### PR TITLE
Add iOS session approval reject control

### DIFF
--- a/apps/friday-ios/Sources/FridayMobileShell/FridaySessionDetailScreen.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridaySessionDetailScreen.swift
@@ -128,6 +128,8 @@ struct FridaySessionDetailScreen: View {
                 Task { await viewModel.stop() }
               } else if control.id == "resume" {
                 Task { await viewModel.resume() }
+              } else if control.id == "reject" {
+                Task { await viewModel.reject() }
               }
             } label: {
               VStack(alignment: .leading, spacing: 6) {

--- a/apps/friday-ios/Sources/FridayMobileShellCore/SessionContinuationViewModel.swift
+++ b/apps/friday-ios/Sources/FridayMobileShellCore/SessionContinuationViewModel.swift
@@ -227,6 +227,36 @@ public final class SessionContinuationViewModel: ObservableObject {
     }
   }
 
+  public func reject() async {
+    guard case .loaded(let snapshot) = state else { return }
+    guard let approval = snapshot.pendingApproval else {
+      controlStates["reject"] = .error(reason: "Reject requires a pending approval ref.")
+      return
+    }
+    guard runControlEnabled else {
+      controlStates["reject"] = .error(reason: "Reject is gated off for this session.")
+      return
+    }
+    guard let writeClient else {
+      controlStates["reject"] = .error(reason: "Reject requires the governed write client.")
+      return
+    }
+
+    controlStates["reject"] = .sending
+    do {
+      let result = try await writeClient.rejectApproval(
+        runId: approval.runId,
+        approvalId: approval.approvalId)
+      if result.accepted {
+        controlStates["reject"] = .succeeded(summary: Self.controlSummary(for: result))
+      } else {
+        controlStates["reject"] = .error(reason: "Reject refused: \(Self.controlSummary(for: result))")
+      }
+    } catch {
+      controlStates["reject"] = .error(reason: Self.writeReason(for: error, verb: "reject"))
+    }
+  }
+
   private nonisolated static func fetchSessionOpen(
     client: FridayRustReadClient,
     agentSessionId: String
@@ -347,6 +377,7 @@ public final class SessionContinuationViewModel: ObservableObject {
   ) -> [SessionContinuationControl] {
     let stopReady = runId != nil && hasWriteClient && runControlEnabled
     let resumeReady = hasPendingApproval && hasWriteClient && hasSigner && runControlEnabled
+    let rejectReady = hasPendingApproval && hasWriteClient && runControlEnabled
     let stopReason: String
     if stopReady {
       stopReason = "Owner-authenticated cancel is wired through the governed write seam."
@@ -368,6 +399,16 @@ public final class SessionContinuationViewModel: ObservableObject {
       resumeReason = "Resume requires the operator signer relay."
     } else {
       resumeReason = "Resume requires the governed write client."
+    }
+    let rejectReason: String
+    if rejectReady {
+      rejectReason = "Pending approval refs are present; reject relays through the governed write seam without executing the mutation."
+    } else if !hasPendingApproval {
+      rejectReason = "Reject requires a pending approval ref from Needs-Me."
+    } else if !runControlEnabled {
+      rejectReason = "Reject is gated off for this session."
+    } else {
+      rejectReason = "Reject requires the governed write client."
     }
     return [
       SessionContinuationControl(
@@ -391,6 +432,13 @@ public final class SessionContinuationViewModel: ObservableObject {
         truthLabel: resumeReady ? "operator-gated" : "NO-GO",
         reason: resumeReason,
         isEnabled: resumeReady),
+      SessionContinuationControl(
+        id: "reject",
+        title: "Reject",
+        systemImage: "xmark.circle",
+        truthLabel: rejectReady ? "guarded" : "NO-GO",
+        reason: rejectReason,
+        isEnabled: rejectReady),
       SessionContinuationControl(
         id: "fork",
         title: "Fork",

--- a/apps/friday-ios/Tests/FridayMobileShellCoreTests/SessionContinuationViewModelTests.swift
+++ b/apps/friday-ios/Tests/FridayMobileShellCoreTests/SessionContinuationViewModelTests.swift
@@ -134,6 +134,8 @@ final class SessionContinuationViewModelTests: XCTestCase {
     private(set) var cancelReasons: [String?] = []
     private(set) var resumedRunIds: [String] = []
     private(set) var relayedBlobs: [[UInt8]] = []
+    private(set) var rejectedRunIds: [String] = []
+    private(set) var rejectedApprovalIds: [String] = []
 
     init(_ script: Script = .accepted(ResumeRelayResult(
       runId: "run-1",
@@ -163,7 +165,14 @@ final class SessionContinuationViewModelTests: XCTestCase {
     }
 
     func rejectApproval(runId: String, approvalId: String) async throws -> ResumeRelayResult {
-      throw FridayWriteClientError.transport("unused")
+      rejectedRunIds.append(runId)
+      rejectedApprovalIds.append(approvalId)
+      switch script {
+      case .accepted(let result), .refused(let result):
+        return result
+      case .fail(let error):
+        throw error
+      }
     }
 
     func cancelRun(runId: String, reason: String?) async throws -> ResumeRelayResult {
@@ -210,7 +219,7 @@ final class SessionContinuationViewModelTests: XCTestCase {
     XCTAssertTrue(readback?.summary.contains("db-wide tokens=99") == true)
     XCTAssertTrue(readback?.summary.contains("audit=verified") == true)
     XCTAssertEqual(snapshot.sections.first?.generatedAtMs, 1_780_640_000_123)
-    XCTAssertEqual(snapshot.controls.map(\.title), ["Send", "Stop", "Resume", "Fork"])
+    XCTAssertEqual(snapshot.controls.map(\.title), ["Send", "Stop", "Resume", "Reject", "Fork"])
     XCTAssertTrue(snapshot.controls.allSatisfy { !$0.isEnabled && $0.truthLabel == "NO-GO" })
     XCTAssertNil(snapshot.pendingApproval)
   }
@@ -273,6 +282,10 @@ final class SessionContinuationViewModelTests: XCTestCase {
     XCTAssertEqual(resume?.truthLabel, "operator-gated")
     XCTAssertEqual(resume?.isEnabled, true)
     XCTAssertTrue(resume?.reason.contains("operator signer") == true)
+    let reject = snapshot.controls.first { $0.id == "reject" }
+    XCTAssertEqual(reject?.truthLabel, "guarded")
+    XCTAssertEqual(reject?.isEnabled, true)
+    XCTAssertTrue(reject?.reason.contains("without executing") == true)
   }
 
   func testRefreshParsesActionableNeedsMeApprovalFallback() async {
@@ -383,6 +396,86 @@ final class SessionContinuationViewModelTests: XCTestCase {
       return XCTFail("expected signer error, got \(String(describing: vm.controlStates["resume"]))")
     }
     XCTAssertTrue(reason.contains("declined"), "reason: \(reason)")
+  }
+
+  func testRejectRelaysApprovalRefWithoutResumingMutation() async {
+    let raw: [String: Any] = [
+      "run_id": "run-1",
+      "needs_me": [
+        "signing_request": [
+          "run_id": "run-1",
+          "approval_id": "approval-1",
+          "action_digest": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+          "summary": "write_file pending",
+        ],
+      ],
+    ]
+    let write = FakeSessionWriteClient(.accepted(ResumeRelayResult(
+      runId: "run-1",
+      op: "reject",
+      accepted: true,
+      status: "rejected",
+      auditRef: "audit://reject/run-1")))
+    let vm = SessionContinuationViewModel(
+      client: FakeSessionReadClient(needsMeRaw: raw),
+      writeClient: write,
+      runControlEnabled: true)
+
+    await vm.refresh(agentSessionId: "session-1", runId: "run-1")
+    await vm.reject()
+
+    XCTAssertEqual(write.rejectedRunIds, ["run-1"])
+    XCTAssertEqual(write.rejectedApprovalIds, ["approval-1"])
+    XCTAssertTrue(write.resumedRunIds.isEmpty, "reject must not resume the paused mutation")
+    XCTAssertTrue(write.relayedBlobs.isEmpty, "reject uses refs only and must not relay a signed blob")
+    XCTAssertEqual(
+      vm.controlStates["reject"],
+      .succeeded(summary: "reject: rejected · accepted · audit://reject/run-1"))
+  }
+
+  func testRejectRefusalAndTransportFailureRenderErrorWithoutResume() async {
+    let raw: [String: Any] = [
+      "run_id": "run-1",
+      "needs_me": [
+        "signing_request": [
+          "run_id": "run-1",
+          "approval_id": "approval-1",
+          "action_digest": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+          "summary": "write_file pending",
+        ],
+      ],
+    ]
+
+    let refused = FakeSessionWriteClient(.refused(ResumeRelayResult(
+      runId: "run-1",
+      op: "reject",
+      accepted: false,
+      status: "already_terminal",
+      auditRef: nil)))
+    let refusedVM = SessionContinuationViewModel(
+      client: FakeSessionReadClient(needsMeRaw: raw),
+      writeClient: refused,
+      runControlEnabled: true)
+    await refusedVM.refresh(agentSessionId: "session-1", runId: "run-1")
+    await refusedVM.reject()
+    guard case .error(let refusedReason) = refusedVM.controlStates["reject"] else {
+      return XCTFail("expected reject refusal error, got \(String(describing: refusedVM.controlStates["reject"]))")
+    }
+    XCTAssertTrue(refusedReason.contains("already_terminal"), "reason: \(refusedReason)")
+    XCTAssertTrue(refused.resumedRunIds.isEmpty)
+
+    let failed = FakeSessionWriteClient(.fail(.transport("server dark")))
+    let failedVM = SessionContinuationViewModel(
+      client: FakeSessionReadClient(needsMeRaw: raw),
+      writeClient: failed,
+      runControlEnabled: true)
+    await failedVM.refresh(agentSessionId: "session-1", runId: "run-1")
+    await failedVM.reject()
+    guard case .error(let failedReason) = failedVM.controlStates["reject"] else {
+      return XCTFail("expected reject transport error, got \(String(describing: failedVM.controlStates["reject"]))")
+    }
+    XCTAssertTrue(failedReason.contains("offline"), "reason: \(failedReason)")
+    XCTAssertTrue(failed.resumedRunIds.isEmpty)
   }
 
   func testStopUsesGovernedCancelRunAndSurfacesReceipt() async {


### PR DESCRIPTION
## Summary
- add a governed Reject control to iOS Session Detail pending-approval state
- relay rejectApproval refs without requiring signer bytes or resuming the mutation
- cover success, refusal, and transport-failure paths in SessionContinuationViewModel tests

## Verification
- `swift test --package-path apps/friday-ios --filter SessionContinuationViewModelTests`
- `git diff --check`
- `detect-secrets-hook --baseline .secrets.baseline apps/friday-ios/Sources/FridayMobileShellCore/SessionContinuationViewModel.swift apps/friday-ios/Sources/FridayMobileShell/FridaySessionDetailScreen.swift apps/friday-ios/Tests/FridayMobileShellCoreTests/SessionContinuationViewModelTests.swift`