### PR TITLE
Carry desktop UI proof blocks through device gate

### DIFF
--- a/rust-core/scripts/mission-spine-ui-device-proof-assemble.sh
+++ b/rust-core/scripts/mission-spine-ui-device-proof-assemble.sh
@@ -105,8 +105,22 @@ if ! jq -e '
   and (.timeline.cursor_verified | type == "boolean")
   and (.status_labels | type == "array")
   and (.memory_candidates | type == "array" and length >= 1)
+  and (.mission_workbench | type == "object")
+  and (.mission_workbench.visible == true)
+  and (.mission_workbench.same_mission_projection_visible == true)
+  and (.mission_workbench.provider_ack_not_done_visible == true)
+  and (.mission_workbench.memory_candidate_review_only_visible == true)
+  and (.mission_workbench.evidence_ref | type == "string" and length > 0)
+  and (.transcript_browser | type == "object")
+  and (.transcript_browser.visible == true)
+  and (.transcript_browser.collapsed_by_default == true)
+  and (.transcript_browser.redacted == true)
+  and (.transcript_browser.bounded_timeline_linked == true)
+  and (.transcript_browser.evidence_ref | type == "string" and length > 0)
+  and (.transcript_browser.search_facets | type == "array" and length >= 9)
+  and (.transcript_browser.evidence_facets | type == "array" and length >= 7)
 ' "$observations_manifest" >/dev/null; then
-  echo "BLOCKER: observations manifest is missing required checks/timeline/status/memory/observation shape: $observations_manifest" >&2
+  echo "BLOCKER: observations manifest is missing required checks/timeline/status/memory/workbench/transcript/observation shape: $observations_manifest" >&2
   exit 6
 fi
 
@@ -239,6 +253,8 @@ jq -n \
         cursor_verified: $manifest.timeline.cursor_verified,
         evidence_ref: $timeline
       },
+      mission_workbench: $manifest.mission_workbench,
+      transcript_browser: $manifest.transcript_browser,
       status_labels: $manifest.status_labels,
       memory_candidates: $manifest.memory_candidates
     }' >"$out"

--- a/rust-core/scripts/mission-spine-ui-device-proof-gate-self-test.sh
+++ b/rust-core/scripts/mission-spine-ui-device-proof-gate-self-test.sh
@@ -184,6 +184,40 @@ write_proof() {
       "grants_memory_authority": false
     }
   ],
+  "mission_workbench": {
+    "visible": true,
+    "same_mission_projection_visible": true,
+    "provider_ack_not_done_visible": true,
+    "memory_candidate_review_only_visible": true,
+    "evidence_ref": "$desktop"
+  },
+  "transcript_browser": {
+    "visible": true,
+    "collapsed_by_default": true,
+    "redacted": true,
+    "bounded_timeline_linked": true,
+    "evidence_ref": "$desktop",
+    "search_facets": [
+      "mission",
+      "work_item",
+      "surface",
+      "provider",
+      "skill",
+      "channel",
+      "status",
+      "proof_receipt",
+      "time"
+    ],
+    "evidence_facets": [
+      "providerRef",
+      "skillRunRef",
+      "channelRef",
+      "workflowRef",
+      "surfaceThreadRef",
+      "timelineRef",
+      "proofReceiptRef"
+    ]
+  },
   "event_order": [
     "mission_intake_submitted",
     "mission_resolve_or_create",
@@ -243,6 +277,18 @@ write_proof() {
     {
       "surface": "desktop",
       "event": "same_mission_projection_visible",
+      "mission_id": "mission_ui_gate_self_test",
+      "evidence_ref": "$desktop"
+    },
+    {
+      "surface": "desktop",
+      "event": "mission_workbench_visible",
+      "mission_id": "mission_ui_gate_self_test",
+      "evidence_ref": "$desktop"
+    },
+    {
+      "surface": "desktop",
+      "event": "transcript_browser_visible",
       "mission_id": "mission_ui_gate_self_test",
       "evidence_ref": "$desktop"
     },
@@ -378,6 +424,7 @@ missing_evidence="$tmpdir/missing-evidence.json"
 missing_metadata="$tmpdir/missing-metadata.json"
 missing_observations="$tmpdir/missing-observations.json"
 missing_stress="$tmpdir/missing-stress.json"
+missing_workbench="$tmpdir/missing-workbench.json"
 hash_mismatch="$tmpdir/hash-mismatch.json"
 bytes_mismatch="$tmpdir/bytes-mismatch.json"
 secret_evidence="$tmpdir/secret-evidence.json"
@@ -434,6 +481,12 @@ jq 'del(.stress)' "$missing_stress" >"$missing_stress.tmp"
 mv "$missing_stress.tmp" "$missing_stress"
 expect_exit 6 env MISSION_SPINE_UI_DEVICE_PROOF="$missing_stress" "$gate"
 
+echo "[mission-spine-ui-self-test] missing workbench/transcript desktop proof is rejected"
+write_proof "$missing_workbench" "$mobile" "$desktop" "$channel" "$timeline"
+jq 'del(.mission_workbench) | .transcript_browser.evidence_ref = .surfaces.mobile.evidence_ref' "$missing_workbench" >"$missing_workbench.tmp"
+mv "$missing_workbench.tmp" "$missing_workbench"
+expect_exit 6 env MISSION_SPINE_UI_DEVICE_PROOF="$missing_workbench" "$gate"
+
 echo "[mission-spine-ui-self-test] evidence hash mismatch is rejected"
 write_proof "$hash_mismatch" "$mobile" "$desktop" "$channel" "$timeline"
 jq '.evidence_files[0].sha256 = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"' "$hash_mismatch" >"$hash_mismatch.tmp"
@@ -460,7 +513,7 @@ write_proof "$valid" "$mobile" "$desktop" "$channel" "$timeline"
 env MISSION_SPINE_UI_DEVICE_PROOF="$valid" "$gate" >/tmp/friday-ui-proof-gate-self-test.out
 
 echo "[mission-spine-ui-self-test] assembler output passes current gate"
-jq '{checks, stress, timeline, status_labels, memory_candidates, event_order, observations}' "$valid" >"$observations_manifest"
+jq '{checks, stress, timeline, mission_workbench, transcript_browser, status_labels, memory_candidates, event_order, observations}' "$valid" >"$observations_manifest"
 MISSION_ID="mission_ui_gate_self_test" \
   MOBILE_EVIDENCE="$mobile" \
   DESKTOP_EVIDENCE="$desktop" \
@@ -478,7 +531,7 @@ MISSION_ID="mission_ui_gate_self_test" \
   TIMELINE_EVIDENCE_REF="$timeline" \
   OUT="$template_manifest" \
   scripts/mission-spine-ui-observations-manifest-template.sh >/tmp/friday-ui-proof-template-self-test.out
-expect_exit 5 env \
+expect_exit 6 env \
   MISSION_ID="mission_ui_gate_self_test" \
   MOBILE_EVIDENCE="$mobile" \
   DESKTOP_EVIDENCE="$desktop" \
@@ -498,7 +551,7 @@ expect_exit 64 env \
   OUT="$assembled" \
   scripts/mission-spine-ui-device-proof-assemble.sh
 
-rm "$valid" "$assembled" "$observations_manifest" "$template_manifest" "$fixture" "$organic" "$placeholder" "$pending_marker" "$missing_evidence" "$missing_metadata" "$missing_observations" "$missing_stress" "$hash_mismatch" "$bytes_mismatch" "$secret_evidence" "$template_assembled" "$mobile" "$desktop" "$channel" "$timeline" "$secret_mobile"
+rm -f "$valid" "$assembled" "$observations_manifest" "$template_manifest" "$fixture" "$organic" "$placeholder" "$pending_marker" "$missing_evidence" "$missing_metadata" "$missing_observations" "$missing_stress" "$missing_workbench" "$hash_mismatch" "$bytes_mismatch" "$secret_evidence" "$template_assembled" "$mobile" "$desktop" "$channel" "$timeline" "$secret_mobile"
 rmdir "$tmpdir"
 
 echo "[mission-spine-ui-self-test] PASS"

--- a/rust-core/scripts/mission-spine-ui-device-proof-gate.sh
+++ b/rust-core/scripts/mission-spine-ui-device-proof-gate.sh
@@ -99,6 +99,10 @@ jq -e '
   def sha256_hex: type == "string" and test("^[0-9a-f]{64}$");
   def ok_bool($path): getpath($path) == true;
   def has_status_label($needle): (.status_labels // []) | index($needle) != null;
+  def has_all_strings($items):
+    . as $values
+    | ($values | type == "array")
+    and ($items | all($values | index(.) != null));
   def evidence_file_ok($role; $mission_id):
     .role == $role
     and (.path | nonempty_string)
@@ -129,6 +133,7 @@ jq -e '
   def has_evidence_role($role; $mission_id): (.evidence_files // []) | any(evidence_file_ok($role; $mission_id));
   def evidence_ref_matches($role; $ref; $mission_id): (.evidence_files // []) | any(evidence_file_ok($role; $mission_id) and .path == $ref);
   def evidence_ref_known($root; $ref): ($root.evidence_files // []) | any(evidence_any_ok($root.mission_id) and .path == $ref);
+  def desktop_consumption_ref($root; $ref): evidence_ref_matches("desktop"; $ref; $root.mission_id);
   def observation($surface; $event; $root):
     ($root.observations // [])
     | any(
@@ -211,6 +216,22 @@ jq -e '
   and (.timeline.cursor_verified == true)
   and (.timeline.evidence_ref | nonempty_string)
   and (. as $root | evidence_ref_matches("timeline"; $root.timeline.evidence_ref; $root.mission_id))
+  and (.mission_workbench | type == "object")
+  and (.mission_workbench.visible == true)
+  and (.mission_workbench.same_mission_projection_visible == true)
+  and (.mission_workbench.provider_ack_not_done_visible == true)
+  and (.mission_workbench.memory_candidate_review_only_visible == true)
+  and (.mission_workbench.evidence_ref | nonempty_string)
+  and (. as $root | desktop_consumption_ref($root; $root.mission_workbench.evidence_ref))
+  and (.transcript_browser | type == "object")
+  and (.transcript_browser.visible == true)
+  and (.transcript_browser.collapsed_by_default == true)
+  and (.transcript_browser.redacted == true)
+  and (.transcript_browser.bounded_timeline_linked == true)
+  and (.transcript_browser.evidence_ref | nonempty_string)
+  and (. as $root | desktop_consumption_ref($root; $root.transcript_browser.evidence_ref))
+  and (.transcript_browser.search_facets | has_all_strings(["mission", "work_item", "surface", "provider", "skill", "channel", "status", "proof_receipt", "time"]))
+  and (.transcript_browser.evidence_facets | has_all_strings(["providerRef", "skillRunRef", "channelRef", "workflowRef", "surfaceThreadRef", "timelineRef", "proofReceiptRef"]))
   and (. as $root | (($root.observations // []) | length >= 18))
   and (. as $root | (($root.observations // []) | all(
     (.surface | nonempty_string)
@@ -238,6 +259,8 @@ jq -e '
   and (. as $root | observation_any("real_provider_execution_visible"; $root))
   and (. as $root | observation("mobile"; "proof_receipt_visible_before_done"; $root))
   and (. as $root | observation("desktop"; "same_mission_projection_visible"; $root))
+  and (. as $root | observation("desktop"; "mission_workbench_visible"; $root))
+  and (. as $root | observation("desktop"; "transcript_browser_visible"; $root))
   and (. as $root | observation("desktop"; "duplicate_blocked_opens_existing"; $root))
   and (. as $root | observation("channel"; "same_mission_projection_visible"; $root))
   and (. as $root | observation_any("same_mission_mobile_desktop_channel_visible"; $root))

--- a/test/unit/qa/mission-spine-ui-device-proof-assemble-cli.test.ts
+++ b/test/unit/qa/mission-spine-ui-device-proof-assemble-cli.test.ts
@@ -1,0 +1,206 @@
+import { execFileSync, spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const missionId = "mission_cli_ui_device_assemble";
+
+function writeEvidenceFiles(tempDir: string) {
+  const files = {
+    mobile: join(tempDir, "mobile.trace"),
+    desktop: join(tempDir, "desktop.trace"),
+    channel: join(tempDir, "channel.trace"),
+    timeline: join(tempDir, "timeline.trace"),
+  };
+  for (const [role, filePath] of Object.entries(files)) {
+    writeFileSync(filePath, `real device proof test evidence ${role} ${missionId}\n`);
+  }
+  return files;
+}
+
+function observation(surface: string, event: string, evidenceRef: string) {
+  return { surface, event, mission_id: missionId, evidence_ref: evidenceRef };
+}
+
+function makeManifest(files: ReturnType<typeof writeEvidenceFiles>) {
+  return {
+    checks: Object.fromEntries([
+      "same_mission_id_mobile_desktop",
+      "same_mission_id_channel",
+      "duplicate_blocked_opens_existing",
+      "mission_bound_provider_action_visible",
+      "proof_receipt_visible_before_done",
+      "provider_ack_not_done",
+      "pressure_20_50_consecutive_asks",
+      "invalid_key_error_visible",
+      "quota_error_visible",
+      "network_error_visible",
+      "channel_replay_blocked",
+      "reconnect_stale_verified",
+      "memory_candidate_not_confirmed",
+      "no_secret_leak",
+      "no_hidden_fallback",
+    ].map((check) => [check, true])),
+    stress: {
+      mission_bound_ask_count: 20,
+      consecutive: true,
+      duplicate_surface_count: 2,
+      provider_ack_not_done: true,
+      invalid_key_error_visible: true,
+      quota_error_visible: true,
+      network_error_visible: true,
+      long_timeline_pagination_visible: true,
+      long_timeline_page_count: 2,
+      reconnect_stale_verified: true,
+      channel_replay_blocked: true,
+      no_secret_leak: true,
+      no_hidden_fallback: true,
+      evidence_ref: files.timeline,
+    },
+    timeline: {
+      bounded: true,
+      page_count: 2,
+      cursor_verified: true,
+    },
+    mission_workbench: {
+      visible: true,
+      same_mission_projection_visible: true,
+      provider_ack_not_done_visible: true,
+      memory_candidate_review_only_visible: true,
+      evidence_ref: files.desktop,
+    },
+    transcript_browser: {
+      visible: true,
+      collapsed_by_default: true,
+      redacted: true,
+      bounded_timeline_linked: true,
+      evidence_ref: files.desktop,
+      search_facets: ["mission", "work_item", "surface", "provider", "skill", "channel", "status", "proof_receipt", "time"],
+      evidence_facets: ["providerRef", "skillRunRef", "channelRef", "workflowRef", "surfaceThreadRef", "timelineRef", "proofReceiptRef"],
+    },
+    status_labels: ["stale", "offline", "error"],
+    memory_candidates: [
+      { id: "memory_candidate_review_only", confirmed: false, grants_memory_authority: false },
+    ],
+    event_order: [
+      "mission_intake_submitted",
+      "mission_resolve_or_create",
+      "duplicate_preflight",
+      "mission_bound_provider_action",
+      "real_provider_execution",
+      "proof_receipt",
+      "timeline_page_1",
+      "timeline_page_2",
+      "same_mission_mobile_desktop_channel",
+      "memory_candidate_review_only",
+      "stale_offline_error_labels_verified",
+    ],
+    observations: [
+      observation("mobile", "mission_intake_submitted", files.mobile),
+      observation("mobile", "mission_intake_ready", files.mobile),
+      observation("desktop", "mission_resolve_or_create_visible", files.desktop),
+      observation("desktop", "duplicate_preflight_visible", files.desktop),
+      observation("mobile", "mission_bound_provider_action_visible", files.mobile),
+      observation("desktop", "real_provider_execution_visible", files.desktop),
+      observation("mobile", "proof_receipt_visible_before_done", files.mobile),
+      observation("desktop", "same_mission_projection_visible", files.desktop),
+      observation("desktop", "mission_workbench_visible", files.desktop),
+      observation("desktop", "transcript_browser_visible", files.desktop),
+      observation("desktop", "duplicate_blocked_opens_existing", files.desktop),
+      observation("channel", "same_mission_projection_visible", files.channel),
+      observation("channel", "same_mission_mobile_desktop_channel_visible", files.channel),
+      observation("timeline", "bounded_page_1_visible", files.timeline),
+      observation("timeline", "bounded_page_2_visible", files.timeline),
+      observation("timeline", "memory_candidate_review_only", files.timeline),
+      observation("desktop", "provider_ack_not_done_visible", files.desktop),
+      observation("desktop", "pressure_20_50_consecutive_asks_visible", files.desktop),
+      observation("desktop", "invalid_key_error_visible", files.desktop),
+      observation("desktop", "quota_error_visible", files.desktop),
+      observation("desktop", "network_error_visible", files.desktop),
+      observation("channel", "channel_replay_blocked_visible", files.channel),
+      observation("desktop", "reconnect_stale_verified", files.desktop),
+      observation("desktop", "real_provider_execution_receipt_visible", files.desktop),
+      observation("desktop", "stale_label_visible", files.desktop),
+      observation("desktop", "offline_label_visible", files.desktop),
+      observation("desktop", "error_label_visible", files.desktop),
+      observation("desktop", "no_hidden_fallback_verified", files.desktop),
+    ],
+  };
+}
+
+function runAssembler(files: ReturnType<typeof writeEvidenceFiles>, manifestPath: string, outPath: string) {
+  execFileSync("bash", ["rust-core/scripts/mission-spine-ui-device-proof-assemble.sh"], {
+    cwd: process.cwd(),
+    env: {
+      ...process.env,
+      MISSION_ID: missionId,
+      MOBILE_EVIDENCE: files.mobile,
+      DESKTOP_EVIDENCE: files.desktop,
+      CHANNEL_EVIDENCE: files.channel,
+      TIMELINE_EVIDENCE: files.timeline,
+      OBSERVATIONS_MANIFEST: manifestPath,
+      OUT: outPath,
+      CAPTURED_AT_UTC: "2026-06-23T13:30:00Z",
+      CAPTURE_RUN_ID: "ui-device-assemble-cli-test",
+    },
+    encoding: "utf8",
+  });
+}
+
+describe("mission-spine-ui-device-proof-assemble", () => {
+  it("carries workbench and transcript browser evidence into the final proof", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "friday-ui-device-assemble-"));
+    try {
+      const files = writeEvidenceFiles(tempDir);
+      const manifestPath = join(tempDir, "observations-manifest.json");
+      const outPath = join(tempDir, "proof.json");
+      writeFileSync(manifestPath, JSON.stringify(makeManifest(files), null, 2));
+
+      runAssembler(files, manifestPath, outPath);
+
+      const proof = JSON.parse(readFileSync(outPath, "utf8")) as {
+        mission_workbench?: { evidence_ref?: string };
+        transcript_browser?: { evidence_ref?: string; redacted?: boolean; search_facets?: string[] };
+      };
+      expect(proof.mission_workbench?.evidence_ref).toBe(files.desktop);
+      expect(proof.transcript_browser?.evidence_ref).toBe(files.desktop);
+      expect(proof.transcript_browser?.redacted).toBe(true);
+      expect(proof.transcript_browser?.search_facets).toContain("proof_receipt");
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("fails closed when the observations manifest omits desktop workbench proof", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "friday-ui-device-assemble-missing-"));
+    try {
+      const files = writeEvidenceFiles(tempDir);
+      const manifestPath = join(tempDir, "observations-manifest.json");
+      const outPath = join(tempDir, "proof.json");
+      const manifest = makeManifest(files);
+      delete (manifest as { mission_workbench?: unknown }).mission_workbench;
+      writeFileSync(manifestPath, JSON.stringify(manifest, null, 2));
+
+      const result = spawnSync("bash", ["rust-core/scripts/mission-spine-ui-device-proof-assemble.sh"], {
+        cwd: process.cwd(),
+        env: {
+          ...process.env,
+          MISSION_ID: missionId,
+          MOBILE_EVIDENCE: files.mobile,
+          DESKTOP_EVIDENCE: files.desktop,
+          CHANNEL_EVIDENCE: files.channel,
+          TIMELINE_EVIDENCE: files.timeline,
+          OBSERVATIONS_MANIFEST: manifestPath,
+          OUT: outPath,
+        },
+        encoding: "utf8",
+      });
+
+      expect(result.status).toBe(6);
+      expect(result.stderr).toContain("workbench/transcript");
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- carry mission_workbench and transcript_browser blocks from observations manifests into assembled UI/device proof artifacts
- require the final UI/device proof gate to validate desktop workbench and transcript-browser evidence refs, redaction, bounded linkage, and facets
- add assembler CLI coverage and update the device proof gate self-test for the stronger final schema

## Verification
- `npx vitest run test/unit/qa/mission-spine-ui-proof-inputs-cli.test.ts test/unit/qa/mission-spine-ui-device-proof-assemble-cli.test.ts`
- `bash rust-core/scripts/mission-spine-ui-device-proof-gate-self-test.sh`
- `MISSION_SPINE_CLOSURE_REPORT_OUT=/tmp/friday-mission-spine-closure-status.json bash rust-core/scripts/mission-spine-closure-audit-gate.sh --report`
- `git diff --check`
- `detect-secrets-hook --baseline .secrets.baseline rust-core/scripts/mission-spine-ui-device-proof-assemble.sh rust-core/scripts/mission-spine-ui-device-proof-gate.sh rust-core/scripts/mission-spine-ui-device-proof-gate-self-test.sh test/unit/qa/mission-spine-ui-device-proof-assemble-cli.test.ts`