### PR TITLE
Surface iOS PairAck device receipt

### DIFF
--- a/apps/friday-ios/Sources/FridayMobileShell/FridayHomeScreen.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayHomeScreen.swift
@@ -264,6 +264,9 @@ struct FridayHomeScreen: View {
       if let pairingId = attempt.pairingId {
         RefPill(label: "ack_pairing_id", ref: pairingId)
       }
+      if let deviceId = attempt.deviceId {
+        RefPill(label: "ack_device_id", ref: deviceId)
+      }
       if let errorCode = attempt.errorCode {
         RefPill(label: "ack_error", ref: errorCode)
       }

--- a/apps/friday-ios/Sources/FridayMobileShellCore/HomeViewModel.swift
+++ b/apps/friday-ios/Sources/FridayMobileShellCore/HomeViewModel.swift
@@ -591,6 +591,7 @@ public struct MobilePairingAttempt: Sendable, Equatable {
   public let mode: MobilePairingAttemptMode
   public let pairingId: String?
   public let hubId: String?
+  public let deviceId: String?
   public let errorCode: String?
   public let reason: String
 
@@ -598,47 +599,54 @@ public struct MobilePairingAttempt: Sendable, Equatable {
     mode: .idle,
     pairingId: nil,
     hubId: nil,
+    deviceId: nil,
     errorCode: nil,
     reason: "No PairAck has been received.")
 
-  public static func sending(_ projection: FridayPairingManifestProjection?) -> MobilePairingAttempt {
+  public static func sending(_ projection: FridayPairingManifestProjection?, deviceId: String?) -> MobilePairingAttempt {
     MobilePairingAttempt(
       mode: .sending,
       pairingId: projection?.pairingId,
       hubId: projection?.hubId,
+      deviceId: deviceId,
       errorCode: nil,
       reason: "Pair request sent; waiting for Hub PairAck.")
   }
 
-  public static func accepted(_ projection: FridayPairingManifestProjection?) -> MobilePairingAttempt {
+  public static func accepted(_ projection: FridayPairingManifestProjection?, deviceId: String?) -> MobilePairingAttempt {
     MobilePairingAttempt(
       mode: .accepted,
       pairingId: projection?.pairingId,
       hubId: projection?.hubId,
+      deviceId: deviceId,
       errorCode: nil,
       reason: "Hub returned PairAck accepted. Trust grant/passport and write authority still require their own governed gates.")
   }
 
   public static func denied(
     _ projection: FridayPairingManifestProjection?,
-    code: FridayErrorCode?
+    code: FridayErrorCode?,
+    deviceId: String?
   ) -> MobilePairingAttempt {
     MobilePairingAttempt(
       mode: .denied,
       pairingId: projection?.pairingId,
       hubId: projection?.hubId,
+      deviceId: deviceId,
       errorCode: code?.rawValue,
       reason: "Hub returned PairAck denied.")
   }
 
   public static func unavailable(
     _ projection: FridayPairingManifestProjection?,
-    reason: String
+    reason: String,
+    deviceId: String? = nil
   ) -> MobilePairingAttempt {
     MobilePairingAttempt(
       mode: .unavailable,
       pairingId: projection?.pairingId,
       hubId: projection?.hubId,
+      deviceId: deviceId,
       errorCode: nil,
       reason: reason)
   }
@@ -847,28 +855,33 @@ public final class HomeViewModel: ObservableObject {
       reason: "Pairing QR is valid and this device key is ready.",
       nextStep: "Pair request is bound to this device key; connected state requires PairAck.")
 
-    guard let pairingClient = makePairingClient(device) else {
-      pairingAttempt = .unavailable(
-        manifest.redactedProjection,
-        reason: "Pairing channel is not configured for this launch.")
-      return
-    }
-
     let resolvedDeviceId = deviceId.trimmingCharacters(in: .whitespacesAndNewlines)
     let finalDeviceId = resolvedDeviceId.isEmpty
       ? "ios-\(device.publicKeyHex.prefix(12))"
       : resolvedDeviceId
-    pairingAttempt = .sending(manifest.redactedProjection)
+
+    guard let pairingClient = makePairingClient(device) else {
+      pairingAttempt = .unavailable(
+        manifest.redactedProjection,
+        reason: "Pairing channel is not configured for this launch.",
+        deviceId: finalDeviceId)
+      return
+    }
+
+    pairingAttempt = .sending(manifest.redactedProjection, deviceId: finalDeviceId)
     do {
       let ack = try await pairingClient.pairDevice(manifest: manifest, deviceId: finalDeviceId)
       if ack.accepted {
-        pairingAttempt = .accepted(manifest.redactedProjection)
+        pairingAttempt = .accepted(manifest.redactedProjection, deviceId: finalDeviceId)
         await refresh()
       } else {
-        pairingAttempt = .denied(manifest.redactedProjection, code: ack.errorCode)
+        pairingAttempt = .denied(manifest.redactedProjection, code: ack.errorCode, deviceId: finalDeviceId)
       }
     } catch {
-      pairingAttempt = .unavailable(manifest.redactedProjection, reason: Self.pairingReason(for: error))
+      pairingAttempt = .unavailable(
+        manifest.redactedProjection,
+        reason: Self.pairingReason(for: error),
+        deviceId: finalDeviceId)
     }
   }
 

--- a/apps/friday-ios/Tests/FridayMobileShellCoreTests/PairingPreflightTests.swift
+++ b/apps/friday-ios/Tests/FridayMobileShellCoreTests/PairingPreflightTests.swift
@@ -158,6 +158,7 @@ func homeViewModelPairScannedQrDrivesPairAckAcceptedWithoutLeakingSecret() async
   #expect(vm.pairingAttempt.pairingId == "pair-123")
   #expect(fake.pairedDeviceIds.count == 1)
   #expect(fake.pairedDeviceIds.first?.hasPrefix("ios-") == true)
+  #expect(vm.pairingAttempt.deviceId == fake.pairedDeviceIds.first)
   #expect(!String(describing: vm.pairingPreflight).contains(secret))
   #expect(!String(describing: vm.pairingAttempt).contains(secret))
   #expect(!fake.sawRawSecret)
@@ -181,6 +182,7 @@ func homeViewModelPairScannedQrCarriesDeniedPairAckAsTruth() async throws {
   #expect(vm.pairingPreflight.mode == .ready)
   #expect(vm.pairingAttempt.mode == .denied)
   #expect(vm.pairingAttempt.errorCode == "PAIRING_DENIED")
+  #expect(vm.pairingAttempt.deviceId == "phone-1")
   #expect(fake.pairedDeviceIds == ["phone-1"])
 }
 
@@ -198,6 +200,7 @@ func homeViewModelPairScannedQrFailsClosedWhenPairingChannelNotConfigured() asyn
   #expect(vm.pairingPreflight.mode == .ready)
   #expect(vm.pairingAttempt.mode == .unavailable)
   #expect(vm.pairingAttempt.reason == "Pairing channel is not configured for this launch.")
+  #expect(vm.pairingAttempt.deviceId?.hasPrefix("ios-") == true)
 }
 
 @Test


### PR DESCRIPTION
## Summary
- retain the final iOS pairing device id in PairAck attempt state
- show ack_device_id on the mobile device-pairing card as a refs-only receipt
- cover accepted, denied, and unavailable pairing paths without leaking QR secret material

## Verification
- `swift test --package-path apps/friday-ios --filter PairingPreflightTests`
- `git diff --check`
- `detect-secrets-hook --baseline .secrets.baseline apps/friday-ios/Sources/FridayMobileShellCore/HomeViewModel.swift apps/friday-ios/Sources/FridayMobileShell/FridayHomeScreen.swift apps/friday-ios/Tests/FridayMobileShellCoreTests/PairingPreflightTests.swift`