### PR TITLE
Require active trusted device for T3 provisioning

### DIFF
--- a/scripts/ops/friday-t3-operator-provision.sh
+++ b/scripts/ops/friday-t3-operator-provision.sh
@@ -82,6 +82,16 @@ table_count() {
   query_scalar "SELECT count(*) FROM ${table}"
 }
 
+active_trusted_device_count() {
+  local present
+  present="$(query_scalar "SELECT count(*) FROM sqlite_master WHERE type='table' AND name='trusted_device'")"
+  if [[ "${present}" != "1" ]]; then
+    echo "0"
+    return
+  fi
+  query_scalar "SELECT count(*) FROM trusted_device WHERE revoked_at IS NULL"
+}
+
 require_paired_device() {
   if [[ "${REQUIRE_PAIRED_DEVICE}" = "0" ]]; then
     echo "WARNING: FRIDAY_T3_REQUIRE_PAIRED_DEVICE=0 bypasses the paired-device preflight." >&2
@@ -89,14 +99,15 @@ require_paired_device() {
     return
   fi
 
-  local device_count trusted_count
+  local device_count trusted_count active_trusted_count
   device_count="$(table_count device_identity)"
   trusted_count="$(table_count trusted_device)"
-  if [[ "${device_count}" -lt 1 || "${trusted_count}" -lt 1 ]]; then
-    fail "T3 provisioning requires a completed QR pairing first (device_identity=${device_count}, trusted_device=${trusted_count}). Run scripts/ops/friday-start-pairing-session.sh and pair a real client before minting trust_grant/context_passport rows."
+  active_trusted_count="$(active_trusted_device_count)"
+  if [[ "${device_count}" -lt 1 || "${active_trusted_count}" -lt 1 ]]; then
+    fail "T3 provisioning requires a completed active QR pairing first (device_identity=${device_count}, trusted_device=${trusted_count}, active_trusted_device=${active_trusted_count}). Run scripts/ops/friday-start-pairing-session.sh and pair a real client before minting trust_grant/context_passport rows."
   fi
 
-  echo "paired_device_preflight=pass device_identity=${device_count} trusted_device=${trusted_count}" >&2
+  echo "paired_device_preflight=pass device_identity=${device_count} trusted_device=${trusted_count} active_trusted_device=${active_trusted_count}" >&2
 }
 
 run_operator_cli() {

--- a/test/unit/scripts/ops/friday-t3-operator-provision.test.ts
+++ b/test/unit/scripts/ops/friday-t3-operator-provision.test.ts
@@ -1,10 +1,47 @@
-import { readFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { resolve } from "node:path";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 
 const repoRoot = process.cwd();
 const scriptPath = resolve(repoRoot, "scripts/ops/friday-t3-operator-provision.sh");
 const source = readFileSync(scriptPath, "utf8");
+const tempRoots: string[] = [];
+
+function makeDbPath(): string {
+  const root = mkdtempSync(resolve(tmpdir(), "friday-t3-operator-provision-test-"));
+  tempRoots.push(root);
+  return resolve(root, "hub.sqlite");
+}
+
+function execSql(dbPath: string, sql: string): void {
+  execFileSync("sqlite3", [dbPath, sql], { encoding: "utf8" });
+}
+
+function runProvisionExpectFailure(dbPath: string): string {
+  try {
+    execFileSync("bash", [scriptPath], {
+      cwd: repoRoot,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        FRIDAY_T3_DB_PATH: dbPath,
+        FRIDAY_T3_OPERATOR_PROVISION_ACK: "operator-runs-t3-provisioning",
+      },
+    });
+  } catch (error) {
+    const failure = error as { stderr?: Buffer | string; stdout?: Buffer | string };
+    return `${failure.stdout ?? ""}\n${failure.stderr ?? ""}`;
+  }
+  throw new Error("expected friday-t3-operator-provision.sh to fail before operator CLI execution");
+}
+
+afterEach(() => {
+  for (const root of tempRoots.splice(0)) {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
 
 describe("friday-t3-operator-provision.sh", () => {
   it("keeps T3 minting behind an explicit operator ceremony acknowledgement", () => {
@@ -33,5 +70,44 @@ describe("friday-t3-operator-provision.sh", () => {
     expect(source).toContain("FRIDAY_T3_MISSION_ID");
     expect(source).toContain("FRIDAY_T3_DESTINATION_LANE");
     expect(source).toContain("FRIDAY_T3_ITEMS_JSON");
+  });
+
+  it("requires an active trusted device instead of accepting revoked pairing rows", () => {
+    expect(source).toContain("active_trusted_device_count");
+    expect(source).toContain("FROM trusted_device WHERE revoked_at IS NULL");
+    expect(source).toContain("active_trusted_device=");
+
+    const dbPath = makeDbPath();
+    execSql(
+      dbPath,
+      `
+      CREATE TABLE device_identity (
+        device_id TEXT,
+        role TEXT,
+        public_key BLOB,
+        created_at INTEGER,
+        display_name TEXT
+      );
+      CREATE TABLE trusted_device (
+        device_id TEXT,
+        public_key BLOB,
+        paired_at INTEGER,
+        revoked_at INTEGER,
+        key_rotated_at INTEGER,
+        label TEXT
+      );
+      INSERT INTO device_identity(device_id, role, public_key, created_at, display_name)
+        VALUES ('device-revoked', 'ios', X'0101010101010101010101010101010101010101010101010101010101010101', 1700, 'Revoked iPhone');
+      INSERT INTO trusted_device(device_id, public_key, paired_at, revoked_at, key_rotated_at, label)
+        VALUES ('device-revoked', X'0101010101010101010101010101010101010101010101010101010101010101', 1800, 1900, NULL, 'Revoked iPhone');
+    `,
+    );
+
+    const output = runProvisionExpectFailure(dbPath);
+
+    expect(output).toContain("active_trusted_device=0");
+    expect(output).toContain("completed active QR pairing");
+    expect(output).not.toContain("Running operator trust_grant ceremony");
+    expect(output).not.toContain("friday-operator-approve");
   });
 });


### PR DESCRIPTION
## Summary
- tighten the T3 operator provisioning wrapper so trust_grant/context_passport minting requires an active, unrevoked trusted_device row
- surface active_trusted_device diagnostics in the preflight pass/fail output
- add a SQLite-backed negative test proving a revoked trusted_device row fails before the operator CLI ceremony runs

## Verification
- bash -n scripts/ops/friday-t3-operator-provision.sh
- npx vitest run test/unit/scripts/ops/friday-t3-operator-provision.test.ts test/unit/scripts/ops/friday-t3-provisioning-status.test.ts
- cargo test --manifest-path rust-core/Cargo.toml -p friday-operator-cli --test trust_grant_issuance
- git diff --check
- detect-secrets-hook --baseline .secrets.baseline scripts/ops/friday-t3-operator-provision.sh test/unit/scripts/ops/friday-t3-operator-provision.test.ts

Truth: this hardens T3 operator-only provisioning preflight. It does not mint grants/passports, read signing keys, flip GO-LIVE flags, or claim END-BAR.