### PR TITLE
Report active trusted device in T3 status

### DIFF
--- a/scripts/ops/friday-t3-provisioning-status.mjs
+++ b/scripts/ops/friday-t3-provisioning-status.mjs
@@ -159,15 +159,24 @@ function countActiveTrustGrants(dbPath, nowMs) {
   );
 }
 
+function countActiveTrustedDevices(dbPath) {
+  if (!tableExists(dbPath, "trusted_device")) {
+    return null;
+  }
+  return Number(queryScalar(dbPath, "SELECT count(*) FROM trusted_device WHERE revoked_at IS NULL"));
+}
+
 export function buildT3ProvisioningStatus(dbPath, nowMs = Date.now()) {
   const counts = Object.fromEntries(
     T3_TABLES.map((tableName) => [tableName, countTable(dbPath, tableName)]),
   );
   const activeTrustGrants = countActiveTrustGrants(dbPath, nowMs);
+  const activeTrustedDevices = countActiveTrustedDevices(dbPath);
   const latest_device = latestTrustedDevice(dbPath);
   const checks = {
     device_identity: (counts.device_identity ?? 0) > 0,
     trusted_device: (counts.trusted_device ?? 0) > 0,
+    active_trusted_device: (activeTrustedDevices ?? 0) > 0,
     trust_grant: (counts.trust_grant ?? 0) > 0,
     active_trust_grant: (activeTrustGrants ?? 0) > 0,
     context_passport: (counts.context_passport ?? 0) > 0,
@@ -182,6 +191,7 @@ export function buildT3ProvisioningStatus(dbPath, nowMs = Date.now()) {
     generated_at_utc: new Date(nowMs).toISOString(),
     counts,
     latest_device,
+    active_trusted_devices: activeTrustedDevices,
     active_trust_grants: activeTrustGrants,
     checks,
     status: missing.length === 0 ? "ready" : "incomplete",
@@ -193,7 +203,10 @@ export function buildT3ProvisioningStatus(dbPath, nowMs = Date.now()) {
 }
 
 export function buildT3OperatorAction(status) {
-  const missingDevice = status.missing.includes("device_identity") || status.missing.includes("trusted_device");
+  const missingDevice =
+    status.missing.includes("device_identity") ||
+    status.missing.includes("trusted_device") ||
+    status.missing.includes("active_trusted_device");
   const missingGrant =
     status.missing.includes("trust_grant") || status.missing.includes("active_trust_grant");
   const missingPassport =
@@ -294,6 +307,7 @@ export function renderText(status) {
   for (const tableName of T3_TABLES) {
     lines.push(`  ${tableName}=${status.counts[tableName] ?? "missing-table"}`);
   }
+  lines.push(`  active_trusted_devices=${status.active_trusted_devices ?? "missing-table"}`);
   lines.push(`  active_trust_grants=${status.active_trust_grants ?? "missing-table"}`);
   if (status.latest_device) {
     lines.push(

--- a/test/unit/scripts/ops/friday-t3-provisioning-status.test.ts
+++ b/test/unit/scripts/ops/friday-t3-provisioning-status.test.ts
@@ -73,6 +73,7 @@ describe("friday-t3-provisioning-status", () => {
     expect(status.missing).toEqual([
       "device_identity",
       "trusted_device",
+      "active_trusted_device",
       "trust_grant",
       "active_trust_grant",
       "context_passport",
@@ -85,6 +86,7 @@ describe("friday-t3-provisioning-status", () => {
       context_passport: 0,
       context_passport_item: 0,
     });
+    expect(status.active_trusted_devices).toBe(0);
     expect(status.latest_device).toBeNull();
   });
 
@@ -126,6 +128,7 @@ describe("friday-t3-provisioning-status", () => {
 
     expect(status.status).toBe("ready");
     expect(status.t3_provisioned).toBe(true);
+    expect(status.active_trusted_devices).toBe(1);
     expect(status.active_trust_grants).toBe(1);
     expect(status.missing).toEqual([]);
     expect(status.caveat).toContain("does not claim END-BAR");
@@ -170,6 +173,36 @@ describe("friday-t3-provisioning-status", () => {
     expect(rendered).toContain("FRIDAY_T3_ITEMS_JSON='<path-to-reviewed-context-passport-items.json>'");
     expect(rendered).toContain("At least one explicit grant boundary is required");
     expect(rendered).not.toContain("operator-approve.key");
+  });
+
+  it("treats revoked-only trusted devices as pairing-required before provisioning", async () => {
+    const statusModule = await loadStatusModule();
+    const dbPath = makeDbPath();
+    createProvisionTables(dbPath);
+    execSql(
+      dbPath,
+      `
+      INSERT INTO device_identity(device_id, role, public_key, created_at, display_name)
+        VALUES ('device-revoked', 'ios', X'0101010101010101010101010101010101010101010101010101010101010101', 1700, 'Revoked iPhone');
+      INSERT INTO trusted_device(device_id, public_key, paired_at, revoked_at, key_rotated_at, label)
+        VALUES ('device-revoked', X'0101010101010101010101010101010101010101010101010101010101010101', 1800, 1900, NULL, 'Revoked iPhone');
+    `,
+    );
+
+    const status = statusModule.buildT3ProvisioningStatus(dbPath, 1_780_000_000_000);
+    const action = statusModule.buildT3OperatorAction(status);
+    const rendered = statusModule.renderOperatorAction(action);
+
+    expect(status.status).toBe("incomplete");
+    expect(status.active_trusted_devices).toBe(0);
+    expect(status.missing).toContain("active_trusted_device");
+    expect(status.latest_device).toMatchObject({
+      device_id: "device-revoked",
+      revoked_at: 1900,
+    });
+    expect(action.status).toBe("pairing_required");
+    expect(rendered).toContain("friday-t3-pairing-proof.sh --pair");
+    expect(rendered).not.toContain("friday-t3-operator-provision.sh");
   });
 
   it("renders a no-action hint for fully provisioned T3 rows without claiming release", async () => {
@@ -220,6 +253,7 @@ describe("friday-t3-provisioning-status", () => {
     const status = statusModule.buildT3ProvisioningStatus(dbPath, 1_780_000_000_000);
 
     expect(status.status).toBe("incomplete");
+    expect(status.active_trusted_devices).toBe(1);
     expect(status.active_trust_grants).toBe(0);
     expect(status.missing).toEqual(["active_trust_grant"]);
   });


### PR DESCRIPTION
## Summary
- make the read-only T3 provisioning status verifier count active, unrevoked trusted_device rows
- require active_trusted_device before the operator action hint advances from pairing_required to provisioning_required
- add a revoked-only pairing regression so status/reporting matches the hardened operator provisioning preflight

## Verification
- npx vitest run test/unit/scripts/ops/friday-t3-provisioning-status.test.ts
- node scripts/ops/friday-t3-provisioning-status.mjs --help
- git diff --check
- detect-secrets-hook --baseline .secrets.baseline scripts/ops/friday-t3-provisioning-status.mjs test/unit/scripts/ops/friday-t3-provisioning-status.test.ts

Truth: read-only status/hint hardening only. It does not mint trust_grant/context_passport rows, read signing keys, flip flags, create organic evidence, or claim GO-LIVE/END-BAR.