### PR TITLE
Surface companion remote session heartbeat

### DIFF
--- a/apps/macos/FridayCompanion/Sources/FridayCompanion/main.swift
+++ b/apps/macos/FridayCompanion/Sources/FridayCompanion/main.swift
@@ -146,6 +146,8 @@ final class CompanionAppController: NSObject, NSApplicationDelegate {
   private var guideOverlayCommand: GuideOverlayCommand?
   private var panicActive = false
   private var lastHeartbeatAt = nowIso()
+  private var lastRemoteHeartbeatAt: String?
+  private var lastRemoteHeartbeatStatus: String = "disabled"
   private var lastNotificationRefreshError: String?
 
   init(config: CompanionConfig) {
@@ -158,6 +160,7 @@ final class CompanionAppController: NSObject, NSApplicationDelegate {
       databasePath: config.notificationDatabasePath
     )
     self.updater = makeCompanionUpdater()
+    self.lastRemoteHeartbeatStatus = config.remoteSessionHeartbeat == nil ? "disabled" : "pending"
     super.init()
   }
 
@@ -293,11 +296,56 @@ final class CompanionAppController: NSObject, NSApplicationDelegate {
   }
 
   private func installHeartbeatTimer() {
+    recordLocalHeartbeat()
+    Task { @MainActor in
+      await sendRemoteSessionHeartbeatIfConfigured()
+    }
     heartbeatTimer = Timer.scheduledTimer(withTimeInterval: Double(config.heartbeatIntervalMs) / 1000.0, repeats: true) { [weak self] _ in
       Task { @MainActor in
-        self?.lastHeartbeatAt = nowIso()
+        self?.recordLocalHeartbeat()
+        await self?.sendRemoteSessionHeartbeatIfConfigured()
       }
     }
+  }
+
+  private func recordLocalHeartbeat() {
+    lastHeartbeatAt = nowIso()
+  }
+
+  private func sendRemoteSessionHeartbeatIfConfigured() async {
+    guard let remoteHeartbeat = config.remoteSessionHeartbeat else {
+      lastRemoteHeartbeatStatus = "disabled"
+      return
+    }
+    do {
+      let request = try remoteHeartbeat.makeRequest(idempotencyKey: "\(config.id)-\(UUID().uuidString)")
+      let (data, response) = try await URLSession.shared.data(for: request)
+      guard let http = response as? HTTPURLResponse else {
+        lastRemoteHeartbeatStatus = "failed_non_http"
+        return
+      }
+      if (200...299).contains(http.statusCode) {
+        lastRemoteHeartbeatStatus = remoteSessionHeartbeatStatus(from: data)
+        if lastRemoteHeartbeatStatus == "ok" {
+          lastRemoteHeartbeatAt = nowIso()
+        }
+      } else {
+        lastRemoteHeartbeatStatus = "failed_\(http.statusCode)"
+      }
+    } catch {
+      lastRemoteHeartbeatStatus = "failed"
+    }
+  }
+
+  private func remoteSessionHeartbeatStatus(from data: Data) -> String {
+    guard
+      let object = try? JSONSerialization.jsonObject(with: data),
+      let payload = object as? [String: Any],
+      let session = payload["session"] as? [String: Any]
+    else {
+      return "missing_session"
+    }
+    return session["status"] as? String == "active" ? "ok" : "inactive_session"
   }
 
   private func handleKeyEvent(_ event: NSEvent) {
@@ -718,6 +766,11 @@ final class CompanionAppController: NSObject, NSApplicationDelegate {
       "safeMode": panicActive,
       "overlayVisible": overlayVisible,
       "lastHeartbeatAt": lastHeartbeatAt,
+      "remoteSessionHeartbeat": [
+        "enabled": config.remoteSessionHeartbeat != nil,
+        "status": lastRemoteHeartbeatStatus,
+        "lastHeartbeatAt": lastRemoteHeartbeatAt ?? (NSNull() as Any),
+      ],
       "capabilities": [
         "launchAtLogin": config.launchAtLoginEnabled,
         "menuBar": true,

--- a/apps/macos/FridayCompanion/Sources/FridayCompanionCore/CompanionConfig.swift
+++ b/apps/macos/FridayCompanion/Sources/FridayCompanionCore/CompanionConfig.swift
@@ -13,6 +13,7 @@ public struct CompanionConfig: Sendable {
   public let heartbeatIntervalMs: Int
   public let notificationDatabasePath: String
   public let notificationLimit: Int
+  public let remoteSessionHeartbeat: CompanionRemoteSessionHeartbeat?
 
   public init(
     id: String,
@@ -26,7 +27,8 @@ public struct CompanionConfig: Sendable {
     panicHotkey: CompanionHotkey,
     heartbeatIntervalMs: Int,
     notificationDatabasePath: String,
-    notificationLimit: Int
+    notificationLimit: Int,
+    remoteSessionHeartbeat: CompanionRemoteSessionHeartbeat? = nil
   ) {
     self.id = id
     self.socketPath = socketPath
@@ -40,6 +42,7 @@ public struct CompanionConfig: Sendable {
     self.heartbeatIntervalMs = heartbeatIntervalMs
     self.notificationDatabasePath = notificationDatabasePath
     self.notificationLimit = notificationLimit
+    self.remoteSessionHeartbeat = remoteSessionHeartbeat
   }
 
   public static func fromEnvironment(_ env: [String: String] = ProcessInfo.processInfo.environment) throws -> CompanionConfig {
@@ -62,6 +65,7 @@ public struct CompanionConfig: Sendable {
     let notificationDatabasePath = nonEmpty(env["FRIDAY_SYSTEM_NOTIFICATION_DB_PATH"])
       ?? CompanionUserNotedNotificationReader.defaultDatabasePath(homeDirectory: env["HOME"] ?? NSHomeDirectory())
     let notificationLimit = Int(env["FRIDAY_SYSTEM_NOTIFICATION_LIMIT"] ?? "") ?? 64
+    let remoteSessionHeartbeat = resolveRemoteSessionHeartbeat(env)
 
     return CompanionConfig(
       id: id,
@@ -75,9 +79,20 @@ public struct CompanionConfig: Sendable {
       panicHotkey: panicHotkey,
       heartbeatIntervalMs: max(1_000, heartbeatIntervalMs),
       notificationDatabasePath: notificationDatabasePath,
-      notificationLimit: max(1, notificationLimit)
+      notificationLimit: max(1, notificationLimit),
+      remoteSessionHeartbeat: remoteSessionHeartbeat
     )
   }
+}
+
+private func resolveRemoteSessionHeartbeat(_ env: [String: String]) -> CompanionRemoteSessionHeartbeat? {
+  guard let sessionId = nonEmpty(env["FRIDAY_SYSTEM_REMOTE_SESSION_ID"]) else {
+    return nil
+  }
+  let hubBaseURL = nonEmpty(env["FRIDAY_SYSTEM_REMOTE_HUB_BASE_URL"])
+    ?? nonEmpty(env["FRIDAY_PUBLIC_APP_BASE_URL"])
+    ?? defaultPublicAppBaseURL(env)
+  return CompanionRemoteSessionHeartbeat(hubBaseURL: hubBaseURL, sessionId: sessionId)
 }
 
 private func resolveControlPageURL(_ env: [String: String]) -> String {

--- a/apps/macos/FridayCompanion/Sources/FridayCompanionCore/CompanionRemoteSessionHeartbeat.swift
+++ b/apps/macos/FridayCompanion/Sources/FridayCompanionCore/CompanionRemoteSessionHeartbeat.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+public struct CompanionRemoteSessionHeartbeat: Sendable, Equatable {
+  public let hubBaseURL: String
+  public let sessionId: String
+
+  public init(hubBaseURL: String, sessionId: String) {
+    self.hubBaseURL = hubBaseURL
+    self.sessionId = sessionId
+  }
+
+  public func makeRequest(idempotencyKey: String) throws -> URLRequest {
+    guard let url = heartbeatURL() else {
+      throw CompanionRemoteSessionHeartbeatError.invalidBaseURL
+    }
+    var request = URLRequest(url: url)
+    request.httpMethod = "POST"
+    request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+    request.httpBody = try JSONSerialization.data(withJSONObject: ["idempotencyKey": idempotencyKey])
+    return request
+  }
+
+  private func heartbeatURL() -> URL? {
+    var base = hubBaseURL.trimmingCharacters(in: .whitespacesAndNewlines)
+    while base.hasSuffix("/") {
+      base.removeLast()
+    }
+    guard !base.isEmpty else {
+      return nil
+    }
+    let allowed = CharacterSet(charactersIn: "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~")
+    let encodedSessionId = sessionId.addingPercentEncoding(withAllowedCharacters: allowed) ?? sessionId
+    return URL(string: "\(base)/v1/system/remote/sessions/\(encodedSessionId)/heartbeat")
+  }
+}
+
+public enum CompanionRemoteSessionHeartbeatError: Error {
+  case invalidBaseURL
+}

--- a/apps/macos/FridayCompanion/Tests/FridayCompanionCoreTests/FridayCompanionCoreTests.swift
+++ b/apps/macos/FridayCompanion/Tests/FridayCompanionCoreTests/FridayCompanionCoreTests.swift
@@ -19,6 +19,8 @@ func configParsesExpectedEnvironment() throws {
     "FRIDAY_SYSTEM_COMPANION_HEARTBEAT_MS": "9000",
     "FRIDAY_SYSTEM_NOTIFICATION_DB_PATH": "/tmp/friday-usernoted.db",
     "FRIDAY_SYSTEM_NOTIFICATION_LIMIT": "8",
+    "FRIDAY_SYSTEM_REMOTE_SESSION_ID": "remote/session 1",
+    "FRIDAY_SYSTEM_REMOTE_HUB_BASE_URL": "https://friday.example/hub/",
   ])
 
   #expect(config.id == "native-companion")
@@ -31,6 +33,10 @@ func configParsesExpectedEnvironment() throws {
   #expect(config.heartbeatIntervalMs == 9000)
   #expect(config.notificationDatabasePath == "/tmp/friday-usernoted.db")
   #expect(config.notificationLimit == 8)
+  #expect(config.remoteSessionHeartbeat == CompanionRemoteSessionHeartbeat(
+    hubBaseURL: "https://friday.example/hub/",
+    sessionId: "remote/session 1"
+  ))
 }
 
 @Test
@@ -70,6 +76,46 @@ func configReadsAuthTokenFromSharedTokenFile() throws {
   ])
 
   #expect(config.authToken == "shared-secret")
+}
+
+@Test
+func configLeavesRemoteSessionHeartbeatDisabledByDefault() throws {
+  let config = try CompanionConfig.fromEnvironment([
+    "FRIDAY_SYSTEM_COMPANION_AUTH_TOKEN": "secret-token",
+  ])
+
+  #expect(config.remoteSessionHeartbeat == nil)
+}
+
+@Test
+func configBuildsRemoteHeartbeatBaseUrlFromPublicBaseUrl() throws {
+  let config = try CompanionConfig.fromEnvironment([
+    "FRIDAY_SYSTEM_COMPANION_AUTH_TOKEN": "secret-token",
+    "FRIDAY_SYSTEM_REMOTE_SESSION_ID": "session-123",
+    "FRIDAY_PUBLIC_APP_BASE_URL": "https://friday.example/app/",
+  ])
+
+  #expect(config.remoteSessionHeartbeat == CompanionRemoteSessionHeartbeat(
+    hubBaseURL: "https://friday.example/app/",
+    sessionId: "session-123"
+  ))
+}
+
+@Test
+func remoteSessionHeartbeatBuildsEncodedPostRequest() throws {
+  let heartbeat = CompanionRemoteSessionHeartbeat(
+    hubBaseURL: "https://friday.example/app/",
+    sessionId: "remote/session 1?x#y"
+  )
+
+  let request = try heartbeat.makeRequest(idempotencyKey: "heartbeat-idem")
+
+  #expect(request.url?.absoluteString == "https://friday.example/app/v1/system/remote/sessions/remote%2Fsession%201%3Fx%23y/heartbeat")
+  #expect(request.httpMethod == "POST")
+  #expect(request.value(forHTTPHeaderField: "Content-Type") == "application/json")
+  let body = try #require(request.httpBody)
+  let payload = try #require(JSONSerialization.jsonObject(with: body) as? [String: String])
+  #expect(payload["idempotencyKey"] == "heartbeat-idem")
 }
 
 @Test


### PR DESCRIPTION
## Summary
- add an opt-in companion remote-session heartbeat config driven by FRIDAY_SYSTEM_REMOTE_SESSION_ID
- post governed idempotent heartbeats to the existing /v1/system/remote/sessions/:id/heartbeat route
- surface remote heartbeat status in the companion socket snapshot while keeping the feature disabled by default

## Verification
- swift test --package-path apps/macos/FridayCompanion
- swift build --package-path apps/macos/FridayCompanion --product FridayCompanion
- git diff --check
- detect-secrets-hook --baseline .secrets.baseline apps/macos/FridayCompanion/Sources/FridayCompanion/main.swift apps/macos/FridayCompanion/Sources/FridayCompanionCore/CompanionConfig.swift apps/macos/FridayCompanion/Sources/FridayCompanionCore/CompanionRemoteSessionHeartbeat.swift apps/macos/FridayCompanion/Tests/FridayCompanionCoreTests/FridayCompanionCoreTests.swift

Truth: default-off T4 companion heartbeat surface only. It does not open sessions, mint grants/passports, sign approvals, or claim GO-LIVE/END-BAR.