### PR TITLE
Require active fallback lane in provider truth

### DIFF
--- a/test/unit/ui/provider-truth.test.ts
+++ b/test/unit/ui/provider-truth.test.ts
@@ -109,4 +109,46 @@ describe("loadProviderTruth", () => {
     expect(truth.hasFallbackLane).toBe(true);
     expect(truth.alerts.some((alert) => alert.code === "fallback_missing")).toBe(false);
   });
+
+  it("does not treat a disabled fallback provider as a working fallback lane", async () => {
+    vi.mocked(providersApi.list).mockResolvedValue([
+      provider,
+      { ...provider, id: "provider-2", name: "Disabled fallback", enabled: false },
+    ] as never);
+    vi.mocked(providersApi.listHealth).mockResolvedValue([
+      health,
+      {
+        ...health,
+        providerId: "provider-2",
+        lane: "disabled",
+        enabled: false,
+        routingEligible: false,
+        reasons: ["provider_disabled"],
+      },
+    ] as never);
+    vi.mocked(providersApi.getRouting).mockResolvedValue({
+      defaultProviderId: "provider-1",
+      defaultModel: "gpt-4o-mini",
+      fallbackProviderIds: ["provider-2"],
+    });
+    vi.mocked(providersApi.explainRouting).mockResolvedValue({
+      selected: {
+        providerId: "provider-1",
+        providerKind: "openai",
+        model: "gpt-4o-mini",
+        backendKind: "http",
+        pinned: false,
+      },
+      selectedAdjusted: false,
+      candidates: [],
+      reasonText: "default",
+    } as never);
+
+    const truth = await loadProviderTruth();
+
+    expect(truth.currentStatus).toBe("healthy");
+    expect(truth.status).toBe("degraded");
+    expect(truth.hasFallbackLane).toBe(false);
+    expect(truth.alerts.some((alert) => alert.code === "fallback_missing")).toBe(true);
+  });
 });

--- a/ui/src/hooks/use-provider-truth.ts
+++ b/ui/src/hooks/use-provider-truth.ts
@@ -359,7 +359,14 @@ export async function loadProviderTruth(): Promise<ProviderTruthSnapshot> {
     });
   }
 
-  const hasFallbackLane = Boolean(routing?.fallbackProviderIds?.length);
+  const hasFallbackLane = (routing?.fallbackProviderIds ?? []).some((providerId) => {
+    const fallbackHealth = healthByProviderId.get(providerId);
+    return (
+      fallbackHealth?.enabled === true &&
+      fallbackHealth.lane !== "disabled" &&
+      classifyHealthSeverity(fallbackHealth) === "healthy"
+    );
+  });
   if (current && routingResult.status === "fulfilled" && !hasFallbackLane) {
     alerts.push({
       id: "fallback-missing",


### PR DESCRIPTION
## Summary
- tighten provider truth readiness so a configured fallback id only counts when its health row is enabled, non-disabled, and healthy
- keep degraded/fallback_missing visible when routing points at a disabled fallback provider
- add a regression covering disabled fallback health despite fallbackProviderIds being present

## Verification
- npx vitest run test/unit/ui/provider-truth.test.ts
- git diff --check
- detect-secrets-hook --baseline .secrets.baseline ui/src/hooks/use-provider-truth.ts test/unit/ui/provider-truth.test.ts

Truth: UI truth/readiness hardening only. It does not change provider credentials, routing configuration, live flags, or GO-LIVE/END-BAR status.