### PR TITLE
Harden client ship artifact freshness gate

### DIFF
--- a/scripts/ops/check-friday-desktop-release-pipeline.mjs
+++ b/scripts/ops/check-friday-desktop-release-pipeline.mjs
@@ -4,6 +4,8 @@ import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 
+const TRUE_VALUES = new Set(["1", "true", "yes", "on"]);
+
 function resolveRepoRoot() {
   const explicit = process.argv[2]?.trim() || process.env.FRIDAY_DESKTOP_RELEASE_REPO_ROOT?.trim();
   if (explicit) {
@@ -37,6 +39,145 @@ function scriptCheck(pkg, name) {
       ? "passed"
       : "failed",
   };
+}
+
+function isTrue(value) {
+  return TRUE_VALUES.has(String(value ?? "").trim().toLowerCase());
+}
+
+function resolveRepoPath(repoRoot, value) {
+  return path.isAbsolute(value) ? value : path.join(repoRoot, value);
+}
+
+function latestMtimeMs(targetPath) {
+  const stat = fs.statSync(targetPath);
+  if (!stat.isDirectory()) {
+    return stat.mtimeMs;
+  }
+
+  let latest = 0;
+  for (const entry of fs.readdirSync(targetPath, { withFileTypes: true })) {
+    const childPath = path.join(targetPath, entry.name);
+    latest = Math.max(latest, latestMtimeMs(childPath));
+  }
+  return latest || stat.mtimeMs;
+}
+
+function readArtifactFreshnessSpecs(repoRoot) {
+  const specPath = process.env.FRIDAY_CLIENT_SHIP_ARTIFACTS_JSON?.trim();
+  if (!specPath) {
+    return [];
+  }
+
+  const absolutePath = resolveRepoPath(repoRoot, specPath);
+  const parsed = JSON.parse(fs.readFileSync(absolutePath, "utf8"));
+  if (!Array.isArray(parsed)) {
+    throw new Error("artifact freshness spec must be a JSON array");
+  }
+  return parsed;
+}
+
+function artifactFreshnessCheck(repoRoot, spec) {
+  const name = typeof spec?.name === "string" && spec.name.trim()
+    ? spec.name.trim()
+    : String(spec?.artifact ?? "unnamed artifact");
+  const artifact = typeof spec?.artifact === "string" ? spec.artifact.trim() : "";
+  const sources = Array.isArray(spec?.sources)
+    ? spec.sources.filter((source) => typeof source === "string" && source.trim()).map((source) => source.trim())
+    : [];
+
+  if (!artifact || sources.length === 0) {
+    return {
+      kind: "artifact-freshness",
+      label: `Fresh client artifact "${name}"`,
+      target: artifact || name,
+      status: "failed",
+      stderr: "artifact freshness specs require an artifact path and at least one source path",
+    };
+  }
+
+  const artifactPath = resolveRepoPath(repoRoot, artifact);
+  if (!fs.existsSync(artifactPath)) {
+    return {
+      kind: "artifact-freshness",
+      label: `Fresh client artifact "${name}"`,
+      target: artifact,
+      status: "failed",
+      stderr: "artifact is missing",
+    };
+  }
+
+  const missingSource = sources.find((source) => !fs.existsSync(resolveRepoPath(repoRoot, source)));
+  if (missingSource) {
+    return {
+      kind: "artifact-freshness",
+      label: `Fresh client artifact "${name}"`,
+      target: artifact,
+      status: "failed",
+      stderr: `source path is missing: ${missingSource}`,
+    };
+  }
+
+  const artifactMtime = latestMtimeMs(artifactPath);
+  const newestSource = sources
+    .map((source) => ({ source, mtimeMs: latestMtimeMs(resolveRepoPath(repoRoot, source)) }))
+    .sort((left, right) => right.mtimeMs - left.mtimeMs)[0];
+
+  if (newestSource && newestSource.mtimeMs > artifactMtime) {
+    return {
+      kind: "artifact-freshness",
+      label: `Fresh client artifact "${name}"`,
+      target: artifact,
+      status: "failed",
+      stderr: `source newer than artifact: ${newestSource.source}`,
+    };
+  }
+
+  return {
+    kind: "artifact-freshness",
+    label: `Fresh client artifact "${name}"`,
+    target: artifact,
+    status: "passed",
+  };
+}
+
+function artifactFreshnessChecks(repoRoot) {
+  const requireFreshArtifacts = isTrue(process.env.FRIDAY_CLIENT_SHIP_REQUIRE_FRESH_ARTIFACTS);
+  const specPath = process.env.FRIDAY_CLIENT_SHIP_ARTIFACTS_JSON?.trim();
+
+  if (!specPath) {
+    return [{
+      kind: "artifact-freshness",
+      label: "Fresh client artifact manifest",
+      target: "FRIDAY_CLIENT_SHIP_ARTIFACTS_JSON",
+      status: requireFreshArtifacts ? "failed" : "skipped",
+      stderr: requireFreshArtifacts
+        ? "FRIDAY_CLIENT_SHIP_REQUIRE_FRESH_ARTIFACTS is set but no artifact freshness manifest was provided"
+        : "",
+    }];
+  }
+
+  try {
+    const specs = readArtifactFreshnessSpecs(repoRoot);
+    if (specs.length === 0) {
+      return [{
+        kind: "artifact-freshness",
+        label: "Fresh client artifact manifest",
+        target: specPath,
+        status: requireFreshArtifacts ? "failed" : "skipped",
+        stderr: requireFreshArtifacts ? "artifact freshness manifest is empty" : "",
+      }];
+    }
+    return specs.map((spec) => artifactFreshnessCheck(repoRoot, spec));
+  } catch (error) {
+    return [{
+      kind: "artifact-freshness",
+      label: "Fresh client artifact manifest",
+      target: specPath,
+      status: "failed",
+      stderr: error instanceof Error ? error.message : String(error),
+    }];
+  }
 }
 
 function runEnvCheck(repoRoot) {
@@ -121,6 +262,7 @@ const checks = [
     "verify:hub-console:native",
   ].map((name) => scriptCheck(pkg, name)),
   runEnvCheck(repoRoot),
+  ...artifactFreshnessChecks(repoRoot),
 ];
 
 const failedChecks = checks.filter((check) => check.status === "failed");

--- a/test/integration/system/friday-desktop-release-pipeline.integration.test.ts
+++ b/test/integration/system/friday-desktop-release-pipeline.integration.test.ts
@@ -20,6 +20,11 @@ async function writeFileWithParents(root: string, relativePath: string, content:
   await fs.writeFile(target, content, "utf8");
 }
 
+async function touch(root: string, relativePath: string, date: Date) {
+  const target = path.join(root, relativePath);
+  await fs.utimes(target, date, date);
+}
+
 async function createFixtureRepo(): Promise<string> {
   const root = await fs.mkdtemp(path.join(os.tmpdir(), "friday-desktop-release-pipeline-"));
   await writeFileWithParents(root, "package.json", JSON.stringify({
@@ -113,6 +118,15 @@ describe("client ship gate pipeline check", () => {
         }),
       ]),
     );
+    expect(report.checks).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          kind: "artifact-freshness",
+          target: "FRIDAY_CLIENT_SHIP_ARTIFACTS_JSON",
+          status: "skipped",
+        }),
+      ]),
+    );
   });
 
   it("fails when a required release input is missing", async () => {
@@ -174,6 +188,103 @@ describe("client ship gate pipeline check", () => {
         expect.objectContaining({
           target: "apps/friday-android/app/src/main/AndroidManifest.xml",
           status: "failed",
+        }),
+      ]),
+    );
+  });
+
+  it("passes fresh artifact checks when declared artifacts are newer than sources", async () => {
+    const repoRoot = await createFixtureRepo();
+    await writeFileWithParents(repoRoot, "dist/macos/FridayHubConsole.app/Contents/MacOS/FridayHubConsole", "binary\n");
+    await writeFileWithParents(repoRoot, "client-artifacts.json", JSON.stringify([{
+      name: "hub-console-app",
+      artifact: "dist/macos/FridayHubConsole.app",
+      sources: [
+        "apps/macos/FridayHubConsole/Sources",
+        "apps/macos/FridayHubConsole/Package.swift",
+      ],
+    }], null, 2));
+
+    await touch(repoRoot, "apps/macos/FridayHubConsole/Sources/FridayHubConsole/FridayHubConsoleApp.swift", new Date("2026-06-22T00:00:00Z"));
+    await touch(repoRoot, "apps/macos/FridayHubConsole/Package.swift", new Date("2026-06-22T00:00:00Z"));
+    await touch(repoRoot, "dist/macos/FridayHubConsole.app/Contents/MacOS/FridayHubConsole", new Date("2026-06-23T00:00:00Z"));
+
+    const result = await execFileAsync(
+      "node",
+      [path.join(process.cwd(), "scripts/ops/check-friday-desktop-release-pipeline.mjs"), repoRoot],
+      {
+        cwd: process.cwd(),
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          FRIDAY_CLIENT_SHIP_REQUIRE_FRESH_ARTIFACTS: "1",
+          FRIDAY_CLIENT_SHIP_ARTIFACTS_JSON: "client-artifacts.json",
+        },
+      },
+    );
+
+    const report = JSON.parse(result.stdout) as {
+      status: string;
+      checks: Array<{ kind: string; target: string; status: string }>;
+    };
+    expect(report.status).toBe("passed");
+    expect(report.checks).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          kind: "artifact-freshness",
+          target: "dist/macos/FridayHubConsole.app",
+          status: "passed",
+        }),
+      ]),
+    );
+  });
+
+  it("fails fresh artifact checks when a client source is newer than the artifact", async () => {
+    const repoRoot = await createFixtureRepo();
+    await writeFileWithParents(repoRoot, "dist/macos/FridayHubConsole.app/Contents/MacOS/FridayHubConsole", "binary\n");
+    await writeFileWithParents(repoRoot, "client-artifacts.json", JSON.stringify([{
+      name: "hub-console-app",
+      artifact: "dist/macos/FridayHubConsole.app",
+      sources: [
+        "apps/macos/FridayHubConsole/Sources",
+        "apps/macos/FridayHubConsole/Package.swift",
+      ],
+    }], null, 2));
+
+    await touch(repoRoot, "dist/macos/FridayHubConsole.app/Contents/MacOS/FridayHubConsole", new Date("2026-06-22T00:00:00Z"));
+    await touch(repoRoot, "apps/macos/FridayHubConsole/Package.swift", new Date("2026-06-22T00:00:00Z"));
+    await touch(repoRoot, "apps/macos/FridayHubConsole/Sources/FridayHubConsole/FridayHubConsoleApp.swift", new Date("2026-06-23T00:00:00Z"));
+
+    const error = await execFileAsync(
+      "node",
+      [path.join(process.cwd(), "scripts/ops/check-friday-desktop-release-pipeline.mjs"), repoRoot],
+      {
+        cwd: process.cwd(),
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          FRIDAY_CLIENT_SHIP_REQUIRE_FRESH_ARTIFACTS: "1",
+          FRIDAY_CLIENT_SHIP_ARTIFACTS_JSON: "client-artifacts.json",
+        },
+      },
+    ).then(
+      () => null,
+      (failure) => failure as ExecFailure,
+    );
+
+    expect(error).not.toBeNull();
+    const report = JSON.parse(error!.stdout ?? "{}") as {
+      status: string;
+      checks: Array<{ kind: string; target: string; status: string; stderr?: string }>;
+    };
+    expect(report.status).toBe("failed");
+    expect(report.checks).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          kind: "artifact-freshness",
+          target: "dist/macos/FridayHubConsole.app",
+          status: "failed",
+          stderr: "source newer than artifact: apps/macos/FridayHubConsole/Sources",
         }),
       ]),
     );


### PR DESCRIPTION
## Summary
- add an opt-in client artifact freshness check to the existing client ship gate
- require declared artifacts to be newer than their source inputs when 
- cover default skipped behavior, fresh artifacts, and stale artifact failures

## Verification
- 
 RUN  v4.0.18 /Users/jarvis/.friday-worktrees/client-ship-fresh-artifacts-20260623

 ✓ |default| test/integration/system/friday-desktop-release-pipeline.integration.test.ts (5 tests) 161ms

 Test Files  1 passed (1)
      Tests  5 passed (5)
Type Errors  no errors
   Start at  08:00:03
   Duration  245ms (transform 22ms, setup 10ms, import 18ms, tests 161ms, environment 0ms)
- 
- 