### PR TITLE
Reject zero port pairing endpoints

### DIFF
--- a/apps/friday-ios/Sources/FridayMobileShellCore/RealPairingClientFactory.swift
+++ b/apps/friday-ios/Sources/FridayMobileShellCore/RealPairingClientFactory.swift
@@ -47,7 +47,7 @@ public struct PairingServerConfig: Sendable, Equatable {
     guard Self.isAllowedPairingHost(host) else {
       throw PairingServerConfigError.disallowedHost(host)
     }
-    guard let port = url.port, let p = UInt16(exactly: port) else {
+    guard let port = url.port, let p = UInt16(exactly: port), p > 0 else {
       throw PairingServerConfigError.missingPort(endpoint)
     }
     self.init(host: host == "localhost" ? "127.0.0.1" : host, port: p)

--- a/apps/friday-ios/Tests/FridayMobileShellCoreTests/PairingPreflightTests.swift
+++ b/apps/friday-ios/Tests/FridayMobileShellCoreTests/PairingPreflightTests.swift
@@ -222,6 +222,12 @@ func pairingServerConfigAllowsLoopbackAndPrivateLanOnly() throws {
   #expect(throws: PairingServerConfigError.self) {
     try PairingServerConfig(manifest: manifest(endpoint: "ws://friday.example.com:49152"))
   }
+  #expect(throws: PairingServerConfigError.missingPort("ws://127.0.0.1")) {
+    try PairingServerConfig(manifest: manifest(endpoint: "ws://127.0.0.1"))
+  }
+  #expect(throws: PairingServerConfigError.missingPort("ws://127.0.0.1:0")) {
+    try PairingServerConfig(manifest: manifest(endpoint: "ws://127.0.0.1:0"))
+  }
 }
 
 private func pairingManifest(

--- a/apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/RealPairingClientFactory.swift
+++ b/apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/RealPairingClientFactory.swift
@@ -47,7 +47,7 @@ public struct PairingEndpointConfig: Sendable, Equatable {
     guard Self.isAllowedPairingHost(host) else {
       throw PairingEndpointConfigError.disallowedHost(host)
     }
-    guard let port = url.port, let p = UInt16(exactly: port) else {
+    guard let port = url.port, let p = UInt16(exactly: port), p > 0 else {
       throw PairingEndpointConfigError.missingPort(endpoint)
     }
     self.init(host: host == "localhost" ? "127.0.0.1" : host, port: p)

--- a/apps/macos/FridayHubConsole/Tests/FridayHubConsoleCoreTests/RealPairingClientFactoryTests.swift
+++ b/apps/macos/FridayHubConsole/Tests/FridayHubConsoleCoreTests/RealPairingClientFactoryTests.swift
@@ -16,6 +16,12 @@ import Testing
   #expect(throws: PairingEndpointConfigError.disallowedHost("example.com")) {
     try PairingEndpointConfig(manifest: manifest(endpoint: "ws://example.com:49152"))
   }
+  #expect(throws: PairingEndpointConfigError.missingPort("ws://127.0.0.1")) {
+    try PairingEndpointConfig(manifest: manifest(endpoint: "ws://127.0.0.1"))
+  }
+  #expect(throws: PairingEndpointConfigError.missingPort("ws://127.0.0.1:0")) {
+    try PairingEndpointConfig(manifest: manifest(endpoint: "ws://127.0.0.1:0"))
+  }
 }
 
 @Test func realPairingProofFactoryBuildsASealedPairingClient() throws {


### PR DESCRIPTION
## Summary
- reject zero-port pairing endpoints in both iOS and macOS pairing endpoint config
- keep loopback/private LAN allowlist behavior intact
- add regression coverage for missing and zero ports on both clients

## Verification
- swift test --package-path apps/friday-ios --filter PairingPreflightTests
- swift test --package-path apps/macos/FridayHubConsole --filter RealPairingClientFactoryTests
- git diff --check
- detect-secrets-hook --baseline .secrets.baseline apps/friday-ios/Sources/FridayMobileShellCore/RealPairingClientFactory.swift apps/friday-ios/Tests/FridayMobileShellCoreTests/PairingPreflightTests.swift apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/RealPairingClientFactory.swift apps/macos/FridayHubConsole/Tests/FridayHubConsoleCoreTests/RealPairingClientFactoryTests.swift