### PR TITLE
Validate realtime pull numeric bounds

### DIFF
--- a/src/api/http/routes/friday-realtime-routes.ts
+++ b/src/api/http/routes/friday-realtime-routes.ts
@@ -51,6 +51,25 @@ function assertRealtimeTestOracleAllowed(deps: FridayRealtimeRoutesDeps): void {
   }
 }
 
+function readOptionalNonNegativeInteger(
+  body: Record<string, unknown>,
+  fieldName: "afterSeq" | "limit",
+  defaultValue: number,
+): number {
+  if (!(fieldName in body) || body[fieldName] === undefined) {
+    return defaultValue;
+  }
+  const value = body[fieldName];
+  if (typeof value !== "number" || !Number.isInteger(value) || value < 0) {
+    throw new FridayDomainError(
+      "VALIDATION_ERROR",
+      `${fieldName} must be a non-negative integer`,
+      { httpStatus: 400 },
+    );
+  }
+  return value;
+}
+
 export function createFridayRealtimeRoutes(
   deps: FridayRealtimeRoutesDeps,
 ): FridayRouteDefinition<unknown, unknown, unknown, unknown>[] {
@@ -96,7 +115,9 @@ export function createFridayRealtimeRoutes(
             { httpStatus: 400 },
           );
         }
-        const { streamId, afterSeq, limit, cursor } = pullBody as unknown as FridayRealtimePullRequest;
+        const { streamId, cursor } = pullBody as unknown as FridayRealtimePullRequest;
+        const requestedAfterSeq = readOptionalNonNegativeInteger(pullBody, "afterSeq", 0);
+        const requestedLimit = readOptionalNonNegativeInteger(pullBody, "limit", 50);
 
         // Verify stream authorization per principal
         if (!deps.subscriptionService.isStreamAuthorized(ctx.principal!, streamId)) {
@@ -107,17 +128,17 @@ export function createFridayRealtimeRoutes(
         }
 
         // Verify cursor HMAC if provided
-        if (cursor && !deps.subscriptionService.verifyCursor(cursor, streamId, afterSeq ?? 0, deps.currentEpoch)) {
+        if (cursor && !deps.subscriptionService.verifyCursor(cursor, streamId, requestedAfterSeq, deps.currentEpoch)) {
           throw Object.assign(new Error("Invalid cursor"), {
             code: "CURSOR_INVALID",
             statusCode: 400,
           });
         }
 
-        const clampedLimit = Math.min(limit ?? 50, REALTIME_MAX_PULL_LIMIT);
+        const clampedLimit = Math.min(requestedLimit, REALTIME_MAX_PULL_LIMIT);
         const events = deps.subscriptionService.pullEvents(
           streamId,
-          afterSeq ?? 0,
+          requestedAfterSeq,
           clampedLimit,
         );
         return {

--- a/test/unit/api/http/routes/friday-realtime-routes.test.ts
+++ b/test/unit/api/http/routes/friday-realtime-routes.test.ts
@@ -95,6 +95,46 @@ describe("FridayRealtimeRoutes", () => {
     ).rejects.toThrow(/Not authorized/);
   });
 
+  it("pull rejects negative afterSeq before querying events", async () => {
+    const routes = makeRoutes();
+    const route = routes.find((r) => r.operationId === "realtime.pull")!;
+
+    await expect(
+      route.handler({
+        requestId: "req-1",
+        receivedAt: NOW,
+        params: {},
+        query: {},
+        body: { streamId: "workflow:wf-1", afterSeq: -1, limit: 10 },
+        headers: {},
+        principal: adminPrincipal,
+      }),
+    ).rejects.toMatchObject({
+      code: "VALIDATION_ERROR",
+      httpStatus: 400,
+    } satisfies Partial<FridayDomainError>);
+  });
+
+  it("pull rejects fractional limits before querying events", async () => {
+    const routes = makeRoutes();
+    const route = routes.find((r) => r.operationId === "realtime.pull")!;
+
+    await expect(
+      route.handler({
+        requestId: "req-1",
+        receivedAt: NOW,
+        params: {},
+        query: {},
+        body: { streamId: "workflow:wf-1", afterSeq: 0, limit: 1.5 },
+        headers: {},
+        principal: adminPrincipal,
+      }),
+    ).rejects.toMatchObject({
+      code: "VALIDATION_ERROR",
+      httpStatus: 400,
+    } satisfies Partial<FridayDomainError>);
+  });
+
   it("ack rejects unauthorized stream", async () => {
     const routes = makeRoutes();
     const route = routes.find((r) => r.operationId === "realtime.ack")!;
@@ -160,6 +200,46 @@ describe("FridayRealtimeRoutes", () => {
     expect(result.streamId).toBe("workflow:wf-1");
     expect(result.epoch).toBe(EPOCH);
     expect(result.items.map((item) => item.eventId)).toEqual(["evt-offline-1", "evt-offline-2"]);
+  });
+
+  it("pull clamps oversized limits to the realtime maximum", async () => {
+    const eventRepo = createFridayRealtimeEventRepository();
+    const checkpointRepo = createFridayRealtimeCheckpointRepository();
+    db.withWriteTransaction((w) => {
+      for (let seq = 1; seq <= 201; seq += 1) {
+        eventRepo.append(w, {
+          eventId: `evt-${String(seq)}`,
+          streamId: "workflow:wf-1",
+          seq,
+          event: "workflow.updated",
+          payload: { workflowId: "wf-1", revision: seq, etag: `etag-${String(seq)}` },
+          emittedAt: NOW,
+        });
+      }
+    });
+    const subscriptionService = createFridayRealtimeSubscriptionService({
+      db,
+      eventRepo,
+      checkpointRepo,
+      nowIso: () => NOW,
+      currentEpoch: EPOCH,
+      cursorSecret: "test-secret",
+    });
+    const route = createFridayRealtimeRoutes({ subscriptionService, currentEpoch: EPOCH })
+      .find((r) => r.operationId === "realtime.pull")!;
+
+    const result = await route.handler({
+      requestId: "req-1",
+      receivedAt: NOW,
+      params: {},
+      query: {},
+      body: { streamId: "workflow:wf-1", afterSeq: 0, limit: 999 },
+      headers: {},
+      principal: adminPrincipal,
+    }) as { items: Array<{ seq: number; eventId: string }> };
+
+    expect(result.items).toHaveLength(200);
+    expect(result.items.at(-1)?.seq).toBe(200);
   });
 
   describe("TS runtime retirement (allowTestOnlyRealtimeExecution)", () => {


### PR DESCRIPTION
## Summary
- validate realtime pull `afterSeq` and `limit` as finite non-negative integers before cursor/event reads
- keep the existing default and max-limit clamp behavior
- add regression coverage for negative/fractional inputs and oversized limit clamping

## Verification
- npx vitest run test/unit/api/http/routes/friday-realtime-routes.test.ts
- git diff --check HEAD~1..HEAD
- detect-secrets-hook --baseline .secrets.baseline src/api/http/routes/friday-realtime-routes.ts test/unit/api/http/routes/friday-realtime-routes.test.ts