### PR TITLE
Reject unknown satellite ack statuses

### DIFF
--- a/src/api/http/routes/friday-satellite-runtime-routes.ts
+++ b/src/api/http/routes/friday-satellite-runtime-routes.ts
@@ -158,6 +158,17 @@ function requireString(body: Record<string, unknown>, field: string): string {
   return value;
 }
 
+function requireCommandAckStatus(status: string): "received" | "completed" | "failed" {
+  if (status === "received" || status === "completed" || status === "failed") {
+    return status;
+  }
+  throw new FridayDomainError(
+    "VALIDATION_ERROR",
+    "status must be one of: received, completed, failed",
+    { httpStatus: 400 },
+  );
+}
+
 function parseCapabilities(
   body: Record<string, unknown>,
 ): FridaySatelliteCapabilityReport["capabilities"] {
@@ -364,7 +375,7 @@ export function createFridaySatelliteRuntimeRoutes(
         const params = ctx.params as Record<string, string>;
         requireSatellitePrincipal(ctx as Ctx, params.satelliteId);
         const body = ctx.body as Record<string, unknown>;
-        const status = requireString(body, "status");
+        const status = requireCommandAckStatus(requireString(body, "status"));
         const hasTerminalResult = status === "completed" || status === "failed";
         const reportTerminal = deps.reportCommandResult !== undefined && hasTerminalResult;
         // Hoist terminal-ack field validation above the retirement guard so a

--- a/test/unit/api/http/routes/friday-satellite-runtime-routes.test.ts
+++ b/test/unit/api/http/routes/friday-satellite-runtime-routes.test.ts
@@ -261,6 +261,25 @@ describe("FridaySatelliteRuntimeRoutes", () => {
     expect(result).toEqual({ acked: false, resultAccepted: true });
   });
 
+  it("rejects unknown command ack statuses before reporting or acking", async () => {
+    const route = findRoute("satellites.commands.ack");
+
+    await expect(
+      route.handler(
+        makeCtx("sat-1", {
+          params: { satelliteId: "sat-1", commandId: "cmd-1" },
+          body: { status: "complete" },
+        }),
+      ),
+    ).rejects.toMatchObject({
+      code: "VALIDATION_ERROR",
+      httpStatus: 400,
+    } satisfies Partial<FridayDomainError>);
+
+    expect(deps.reportCommandResult).not.toHaveBeenCalled();
+    expect(deps.ackCommand).not.toHaveBeenCalled();
+  });
+
   it("rejects non-terminal ack when the command is not leased", async () => {
     deps.ackCommand.mockResolvedValueOnce({ acked: false });
 


### PR DESCRIPTION
## Summary
- fail-close satellite command ack statuses to received/completed/failed
- reject unknown status values before reportCommandResult or ackCommand side effects
- add regression coverage for typo status handling

## Verification
- npx vitest run test/unit/api/http/routes/friday-satellite-runtime-routes.test.ts
- git diff --check HEAD~1..HEAD
- detect-secrets-hook --baseline .secrets.baseline src/api/http/routes/friday-satellite-runtime-routes.ts test/unit/api/http/routes/friday-satellite-runtime-routes.test.ts