### PR TITLE
Reject empty provider routing ids

### DIFF
--- a/src/api/http/routes/friday-provider-routes.ts
+++ b/src/api/http/routes/friday-provider-routes.ts
@@ -372,13 +372,16 @@ function validateRoutingBody(body: unknown): asserts body is FridaySetRoutingCon
   const b = body as Record<string, unknown>;
   const errors: string[] = [];
 
-  if (typeof b.defaultProviderId !== "string") {
-    errors.push("defaultProviderId is required and must be a string");
+  if (typeof b.defaultProviderId !== "string" || b.defaultProviderId.trim() === "") {
+    errors.push("defaultProviderId is required and must be a non-empty string");
   }
   if (b.fallbackProviderIds === undefined) {
     (b as Record<string, unknown>).fallbackProviderIds = [];
-  } else if (!Array.isArray(b.fallbackProviderIds) || !b.fallbackProviderIds.every((id: unknown) => typeof id === "string")) {
-    errors.push("fallbackProviderIds must be an array of strings when provided");
+  } else if (
+    !Array.isArray(b.fallbackProviderIds)
+    || !b.fallbackProviderIds.every((id: unknown) => typeof id === "string" && id.trim() !== "")
+  ) {
+    errors.push("fallbackProviderIds must be an array of non-empty strings when provided");
   }
   if (b.defaultModel !== undefined && typeof b.defaultModel !== "string") {
     errors.push("defaultModel must be a string when provided");

--- a/test/unit/providers/api/friday-provider-routes.test.ts
+++ b/test/unit/providers/api/friday-provider-routes.test.ts
@@ -998,6 +998,36 @@ describe("FridayProviderRoutes", () => {
       expect(mockService.setRoutingConfig).not.toHaveBeenCalled();
     });
 
+    it("providers.routing.set rejects empty provider ids before service mutation", async () => {
+      const mockService = makeMockService();
+      const routes = createFridayProviderRoutes({
+        providerService: mockService,
+      });
+      const setRoutingRoute = routes.find(
+        (r) => r.operationId === "providers.routing.set",
+      )!;
+
+      await expect(
+        setRoutingRoute.handler(makeCtx({
+          body: {
+            defaultProviderId: " ",
+            fallbackProviderIds: [],
+          },
+        })),
+      ).rejects.toThrow("defaultProviderId is required and must be a non-empty string");
+
+      await expect(
+        setRoutingRoute.handler(makeCtx({
+          body: {
+            defaultProviderId: "prov-001",
+            fallbackProviderIds: ["prov-002", ""],
+          },
+        })),
+      ).rejects.toThrow("fallbackProviderIds must be an array of non-empty strings when provided");
+
+      expect(mockService.setRoutingConfig).not.toHaveBeenCalled();
+    });
+
     it("providers.routing.set requires canonical approval in gate-required profile before service mutation", async () => {
       const mockService = makeMockService();
       const routes = createProviderRoutesWithGate(mockService);


### PR DESCRIPTION
## Summary
- reject empty defaultProviderId values in model-routing config updates
- reject empty fallbackProviderIds before the provider service mutation
- add regression coverage for both invalid routing id cases

## Verification
- npx vitest run test/unit/providers/api/friday-provider-routes.test.ts
- git diff --check HEAD~1..HEAD
- detect-secrets-hook --baseline .secrets.baseline src/api/http/routes/friday-provider-routes.ts test/unit/providers/api/friday-provider-routes.test.ts