### PR TITLE
Reject synthetic public cross-border principals

### DIFF
--- a/src/api/http/routes/friday-cross-border-pack-routes.ts
+++ b/src/api/http/routes/friday-cross-border-pack-routes.ts
@@ -1,5 +1,6 @@
 import { FridayDomainError } from "#errors";
 import type { FridayRouteDefinition } from "../../model/friday-api-common.types.js";
+import type { FridayAuthPrincipal } from "../../model/friday-api-auth.types.js";
 import type {
   FridayCrossBorderDisableAllResponse,
   FridayCrossBorderImportRequest,
@@ -15,6 +16,7 @@ import type {
 } from "../../model/friday-api-cross-border-pack.types.js";
 import type { FridayCrossBorderPackService } from "../../../packs/cross-border/friday-cross-border-pack-service.js";
 import type { FridayCrossBorderWorkflowId } from "../../../packs/cross-border/friday-cross-border-pack.types.js";
+import { isUnauthenticatedPublicPrincipal } from "../../../security/friday-owner-session-channel-capability.js";
 
 export interface FridayCrossBorderPackRoutesDeps {
   service: FridayCrossBorderPackService;
@@ -55,8 +57,8 @@ function assertCrossBorderPackTestOracleAllowed(deps: FridayCrossBorderPackRoute
   }
 }
 
-function requireUserId(principal: { userId?: string } | null): string {
-  if (!principal?.userId) {
+function requireUserId(principal: FridayAuthPrincipal | null | undefined): string {
+  if (isUnauthenticatedPublicPrincipal(principal) || !principal?.userId) {
     throw new FridayDomainError("UNAUTHORIZED", "A user-scoped assistant principal is required", {
       httpStatus: 401,
     });

--- a/test/unit/api/http/routes/friday-cross-border-pack-routes.test.ts
+++ b/test/unit/api/http/routes/friday-cross-border-pack-routes.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 
 import { FridayDomainError } from "#errors";
+import { createFridayDefaultPublicHttpPrincipal } from "../../../../../src/api/http/friday-default-public-principal.js";
 import { createFridayCrossBorderPackRoutes } from "../../../../../src/api/http/routes/friday-cross-border-pack-routes.js";
 
 function makeCtx(overrides: Record<string, unknown> = {}) {
@@ -131,6 +132,35 @@ describe("createFridayCrossBorderPackRoutes", () => {
   it("requires a user-scoped principal", async () => {
     const { route } = findRoute("packs.cross.border.profile.get");
     await expect(route.handler(makeCtx({ principal: null }))).rejects.toBeInstanceOf(FridayDomainError);
+  });
+
+  it("rejects the synthetic public principal before reading user pack state", async () => {
+    const { route, service } = findRoute("packs.cross.border.profile.get");
+
+    await expect(
+      route.handler(makeCtx({ principal: createFridayDefaultPublicHttpPrincipal() })),
+    ).rejects.toMatchObject({
+      code: "UNAUTHORIZED",
+      httpStatus: 401,
+    } satisfies Partial<FridayDomainError>);
+
+    expect(service.getProfile).not.toHaveBeenCalled();
+  });
+
+  it("rejects the synthetic public principal before test-oracle mutations", async () => {
+    const { route, service } = findRoute("packs.cross.border.import.post");
+
+    await expect(
+      route.handler(makeCtx({
+        principal: createFridayDefaultPublicHttpPrincipal(),
+        body: { kind: "store_report", source: "paste", title: "x" },
+      })),
+    ).rejects.toMatchObject({
+      code: "UNAUTHORIZED",
+      httpStatus: 401,
+    } satisfies Partial<FridayDomainError>);
+
+    expect(service.importBatch).not.toHaveBeenCalled();
   });
 
   it("forwards profile updates and snapshot reads to the service", async () => {


### PR DESCRIPTION
## Summary
- reject the synthetic default-public principal in cross-border pack user-bound routes
- keep real user principals working while refusing synthetic reads and test-oracle mutations before service calls
- add regression coverage for GET profile and import mutation boundaries

## Verification
- npx vitest run --project default test/unit/api/http/routes/friday-cross-border-pack-routes.test.ts test/unit/security/friday-owner-session-channel-capability.test.ts
- git diff --check HEAD~1..HEAD
- detect-secrets-hook --baseline .secrets.baseline src/api/http/routes/friday-cross-border-pack-routes.ts test/unit/api/http/routes/friday-cross-border-pack-routes.test.ts