### PR TITLE
Require bound packaging mutation actors

### DIFF
--- a/src/api/http/routes/friday-packaging-routes.ts
+++ b/src/api/http/routes/friday-packaging-routes.ts
@@ -49,6 +49,7 @@ import type {
   FridayMutatingActionGate,
   FridayMutatingActionGateResult,
 } from "../../../security/friday-mutating-action-gate.js";
+import { isUnauthenticatedPublicPrincipal } from "../../../security/friday-owner-session-channel-capability.js";
 
 // ─── Service Dependencies ───
 
@@ -168,9 +169,15 @@ async function assertPackagingMutationAllowed(input: {
 function actorFromPrincipal(principal: unknown): { kind: string; id: string; principalId?: string } {
   const obj = principal as Record<string, unknown> | null | undefined;
   const principalId = readFirstString(obj, ["principalId", "id", "userId", "subject", "sub"]);
+  if (isUnauthenticatedPublicPrincipal(principal as never) || principalId === undefined) {
+    throw new FridayDomainError(
+      "PACKAGING_MUTATION_BOUND_PRINCIPAL_REQUIRED",
+      "Packaging mutation requires a bound principal before governance evaluation.",
+      { httpStatus: 401 },
+    );
+  }
   const kind = readFirstString(obj, ["kind", "type", "role"]) ?? "api";
-  const id = principalId ?? "anonymous";
-  return { kind, id, principalId };
+  return { kind, id: principalId, principalId };
 }
 
 function readFirstString(obj: Record<string, unknown> | null | undefined, keys: readonly string[]): string | undefined {

--- a/test/unit/api/http/routes/friday-packaging-routes.test.ts
+++ b/test/unit/api/http/routes/friday-packaging-routes.test.ts
@@ -18,6 +18,7 @@ import type {
   FridayMutatingActionGate,
   FridayMutatingActionGateResult,
 } from "../../../../../src/security/friday-mutating-action-gate.js";
+import { createFridayDefaultPublicHttpPrincipal } from "../../../../../src/api/http/friday-default-public-principal.js";
 
 // ─── Helpers ───
 
@@ -180,6 +181,50 @@ describe("B-008 FridayPackagingRoutes", () => {
         }),
       }));
       expect(deps.installs.uninstall).toHaveBeenCalledWith("@friday/test", { etag: "etag-1", idempotencyKey: "key-1" });
+    });
+
+    it("rejects anonymous packaging mutations before canonical governance", async () => {
+      const gate = makeAllowGate();
+      const deps = makeDeps({
+        allowTestOnlyPackagingMutationExecution: false,
+        packagingMutationGate: gate,
+      });
+      const routes = createFridayPackagingRoutes(deps);
+      const route = findRoute(routes, "packaging.installs.install");
+
+      await expect(route.handler(makeCtx({
+        principal: null,
+        params: { packageName: "@friday/test" },
+        body: { tenantId: "tenant-1", idempotencyKey: "key-1" },
+      }))).rejects.toMatchObject({
+        code: "PACKAGING_MUTATION_BOUND_PRINCIPAL_REQUIRED",
+        httpStatus: 401,
+      });
+
+      expect(gate.evaluate).not.toHaveBeenCalled();
+      expect(deps.installs.install).not.toHaveBeenCalled();
+    });
+
+    it("rejects the synthetic public principal before canonical governance", async () => {
+      const gate = makeAllowGate();
+      const deps = makeDeps({
+        allowTestOnlyPackagingMutationExecution: false,
+        packagingMutationGate: gate,
+      });
+      const routes = createFridayPackagingRoutes(deps);
+      const route = findRoute(routes, "packaging.installs.install");
+
+      await expect(route.handler(makeCtx({
+        principal: createFridayDefaultPublicHttpPrincipal(),
+        params: { packageName: "@friday/test" },
+        body: { tenantId: "tenant-1", idempotencyKey: "key-1" },
+      }))).rejects.toMatchObject({
+        code: "PACKAGING_MUTATION_BOUND_PRINCIPAL_REQUIRED",
+        httpStatus: 401,
+      });
+
+      expect(gate.evaluate).not.toHaveBeenCalled();
+      expect(deps.installs.install).not.toHaveBeenCalled();
     });
 
     it("fails closed before dependency dry-run when packaging deps have no governance gate", async () => {


### PR DESCRIPTION
## Summary
- reject anonymous and synthetic-public packaging mutation actors before canonical governance evaluation
- keep governed real-principal packaging mutations working
- add regression coverage for null and synthetic default-public principals

## Verification
- npx vitest run --project default test/unit/api/http/routes/friday-packaging-routes.test.ts test/unit/security/friday-mutating-action-gate.test.ts
- git diff --check HEAD~1..HEAD
- detect-secrets-hook --baseline .secrets.baseline src/api/http/routes/friday-packaging-routes.ts test/unit/api/http/routes/friday-packaging-routes.test.ts