### PR TITLE
Gate control-plane audit and grant reads

### DIFF
--- a/src/api/http/friday-sensitive-read-routes.ts
+++ b/src/api/http/friday-sensitive-read-routes.ts
@@ -29,6 +29,9 @@
  *                    leave the identical incident data anonymously readable via the alias.
  *   - /v1/sessions   session details (incl. conversation history; anonymous users must sign in
  *                    to list/read sessions — an accepted trade-off of the targeted scope)
+ *   - /v1/grants     active grants and authorization posture
+ *   - /v1/audit      runtime audit logs / forensic evidence
+ *   - /v1/observability/audit  observability audit entries and detail readback
  *
  * Intentionally NOT gated here (kept anonymous): health, setup, onboarding, auth
  * bootstrap/login/refresh, version/status/capabilities, and the core no-login UX surfaces
@@ -37,8 +40,8 @@
  *
  * Known-ungated personal/posture surfaces deliberately left OUT of this targeted scope
  * (recorded so they are not silently dropped — candidates for a follow-up classification, NOT
- * closed here): /v1/uix/learned-facts, /v1/uix/user-profile, /v1/audit, /v1/observability/audit,
- * /v1/grants, /v1/system/remote/devices, /v1/providers/usage, /v1/providers/budget. Each needs
+ * closed here): /v1/uix/learned-facts, /v1/uix/user-profile, /v1/system/remote/devices,
+ * /v1/providers/usage, /v1/providers/budget. Each needs
  * its own per-handler review before gating.
  */
 export const FRIDAY_SENSITIVE_READ_ROUTE_PREFIXES: readonly string[] = [
@@ -49,6 +52,9 @@ export const FRIDAY_SENSITIVE_READ_ROUTE_PREFIXES: readonly string[] = [
   "/v1/diagnosis",
   "/v1/learning",
   "/v1/sessions",
+  "/v1/grants",
+  "/v1/audit",
+  "/v1/observability/audit",
 ];
 
 /**

--- a/test/unit/api/http/friday-http-server-sensitive-read-gate.test.ts
+++ b/test/unit/api/http/friday-http-server-sensitive-read-gate.test.ts
@@ -74,6 +74,10 @@ describe("isFridaySensitiveReadRoute", () => {
     }
     expect(isFridaySensitiveReadRoute("/v1/memory/items/:id")).toBe(true);
     expect(isFridaySensitiveReadRoute("/v1/secrets")).toBe(true);
+    expect(isFridaySensitiveReadRoute("/v1/grants")).toBe(true);
+    expect(isFridaySensitiveReadRoute("/v1/grants/active")).toBe(true);
+    expect(isFridaySensitiveReadRoute("/v1/audit/logs")).toBe(true);
+    expect(isFridaySensitiveReadRoute("/v1/observability/audit/:entryId")).toBe(true);
   });
 
   it("does NOT match the core no-login UX or minimal-public surfaces", () => {
@@ -94,6 +98,9 @@ describe("isFridaySensitiveReadRoute", () => {
   it("respects the trailing-slash boundary (no sibling-prefix false positives)", () => {
     expect(isFridaySensitiveReadRoute("/v1/secretspolicy")).toBe(false);
     expect(isFridaySensitiveReadRoute("/v1/securityx")).toBe(false);
+    expect(isFridaySensitiveReadRoute("/v1/grantsx")).toBe(false);
+    expect(isFridaySensitiveReadRoute("/v1/auditx")).toBe(false);
+    expect(isFridaySensitiveReadRoute("/v1/observability/auditor")).toBe(false);
   });
 });
 
@@ -176,6 +183,54 @@ describe("FridayHttpServer sensitive-read floor", () => {
     expect(handlerCalls).toBe(0);
   });
 
+  it("negative: anonymous GET on control-plane audit/grant read routes → 401 before handlers run", async () => {
+    const handlerCalls: Record<string, number> = {
+      grants: 0,
+      audit: 0,
+      observabilityAudit: 0,
+    };
+    await startWith((routes) => {
+      routes.register({
+        operationId: "grants.list",
+        method: "GET",
+        path: "/v1/grants",
+        auth: { public: true },
+        async handler() {
+          handlerCalls.grants += 1;
+          return { grants: [] };
+        },
+      });
+      routes.register({
+        operationId: "audit.logs.list",
+        method: "GET",
+        path: "/v1/audit/logs",
+        auth: { public: true },
+        async handler() {
+          handlerCalls.audit += 1;
+          return { logs: [] };
+        },
+      });
+      routes.register({
+        operationId: "observability.audit.get",
+        method: "GET",
+        path: "/v1/observability/audit/:entryId",
+        auth: { public: true },
+        async handler() {
+          handlerCalls.observabilityAudit += 1;
+          return { entry: null };
+        },
+      });
+    });
+
+    for (const path of ["/v1/grants", "/v1/audit/logs", "/v1/observability/audit/entry-1"]) {
+      const response = await fetch(`${baseUrl}${path}`);
+      expect(response.status).toBe(401);
+      const body = await response.json() as { ok: false; error: { code: string } };
+      expect(body.error.code).toBe(ERROR_CODE_BOUND_PRINCIPAL_REQUIRED);
+    }
+    expect(handlerCalls).toEqual({ grants: 0, audit: 0, observabilityAudit: 0 });
+  });
+
   it("negative: anonymous HEAD on a sensitive read route → 401 (HEAD is a read)", async () => {
     await startWith((routes) => {
       routes.register({
@@ -224,6 +279,59 @@ describe("FridayHttpServer sensitive-read floor", () => {
     const body = await response.json() as { ok: true; data: { principalId: string } };
     expect(body.data.principalId).toBe("user:alice");
     expect(body.data.principalId).not.toBe(FRIDAY_DEFAULT_PUBLIC_HTTP_PRINCIPAL_ID);
+  });
+
+  it("positive: valid Bearer still reaches control-plane audit/grant read handlers", async () => {
+    await startWith(
+      (routes) => {
+        routes.register({
+          operationId: "grants.list",
+          method: "GET",
+          path: "/v1/grants",
+          auth: { public: true },
+          async handler(ctx) {
+            return { surface: "grants", principalId: ctx.principal!.principalId };
+          },
+        });
+        routes.register({
+          operationId: "audit.logs.list",
+          method: "GET",
+          path: "/v1/audit/logs",
+          auth: { public: true },
+          async handler(ctx) {
+            return { surface: "audit", principalId: ctx.principal!.principalId };
+          },
+        });
+        routes.register({
+          operationId: "observability.audit.get",
+          method: "GET",
+          path: "/v1/observability/audit/:entryId",
+          auth: { public: true },
+          async handler(ctx) {
+            return { surface: "observabilityAudit", principalId: ctx.principal!.principalId };
+          },
+        });
+      },
+      {
+        "real-token-abc": {
+          principalId: "user:alice",
+          userId: "11111111-1111-1111-1111-111111111111",
+          tenantId: "22222222-2222-2222-2222-222222222222",
+          role: "viewer",
+          scopes: ["session.read"],
+          tokenId: "33333333-3333-3333-3333-333333333333",
+        },
+      },
+    );
+
+    for (const path of ["/v1/grants", "/v1/audit/logs", "/v1/observability/audit/entry-1"]) {
+      const response = await fetch(`${baseUrl}${path}`, {
+        headers: { Authorization: "Bearer real-token-abc" },
+      });
+      expect(response.status).toBe(200);
+      const body = await response.json() as { ok: true; data: { principalId: string } };
+      expect(body.data.principalId).toBe("user:alice");
+    }
   });
 
   it("negative: malformed/invalid bearer on a sensitive route → 401 (falls back to synthetic, then gated)", async () => {


### PR DESCRIPTION
## Summary
- add grant and audit read prefixes to the sensitive-read floor
- keep sibling-prefix boundaries for grants/audit/observability audit paths
- prove anonymous reads fail before handlers while valid bearer reads still reach handlers

## Tests
- npm test -- test/unit/api/http/friday-http-server-sensitive-read-gate.test.ts test/unit/api/http/routes/friday-grant-routes.test.ts test/unit/api/http/routes/friday-observability-routes.test.ts test/unit/api/http/routes/friday-runtime-admin-routes.test.ts
- npm run build
- git diff --check HEAD~1..HEAD
- detect-secrets-hook --baseline .secrets.baseline src/api/http/friday-sensitive-read-routes.ts test/unit/api/http/friday-http-server-sensitive-read-gate.test.ts