### PR TITLE
Surface mobile run readback facts

### DIFF
--- a/apps/friday-ios/Sources/FridayMobileShell/FridaySessionDetailScreen.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridaySessionDetailScreen.swift
@@ -201,6 +201,24 @@ struct FridaySessionDetailScreen: View {
           .foregroundStyle(MobileTheme.textPrimary)
         switch section.status {
         case .loaded:
+          if !section.facts.isEmpty {
+            VStack(alignment: .leading, spacing: 6) {
+              ForEach(section.facts) { fact in
+                HStack(alignment: .firstTextBaseline, spacing: 8) {
+                  Text(fact.label)
+                    .font(.caption2)
+                    .foregroundStyle(MobileTheme.textSecondary)
+                    .frame(width: 74, alignment: .leading)
+                  Text(fact.value)
+                    .font(.caption2)
+                    .foregroundStyle(MobileTheme.textPrimary)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .lineLimit(2)
+                    .minimumScaleFactor(0.8)
+                }
+              }
+            }
+          }
           if let generatedAtMs = section.generatedAtMs {
             RefPill(label: "generated", ref: generatedText(generatedAtMs))
           }

--- a/apps/friday-ios/Sources/FridayMobileShellCore/SessionContinuationViewModel.swift
+++ b/apps/friday-ios/Sources/FridayMobileShellCore/SessionContinuationViewModel.swift
@@ -14,6 +14,31 @@ public struct SessionContinuationSection: Sendable, Identifiable, Equatable {
   public let summary: String
   public let generatedAtMs: Int64?
   public let refs: [String]
+  public let facts: [SessionContinuationFact]
+
+  public init(
+    id: String,
+    title: String,
+    status: SessionContinuationSectionStatus,
+    summary: String,
+    generatedAtMs: Int64?,
+    refs: [String],
+    facts: [SessionContinuationFact] = []
+  ) {
+    self.id = id
+    self.title = title
+    self.status = status
+    self.summary = summary
+    self.generatedAtMs = generatedAtMs
+    self.refs = refs
+    self.facts = facts
+  }
+}
+
+public struct SessionContinuationFact: Sendable, Identifiable, Equatable {
+  public let id: String
+  public let label: String
+  public let value: String
 }
 
 public struct SessionContinuationControl: Sendable, Identifiable, Equatable {
@@ -300,7 +325,8 @@ public final class SessionContinuationViewModel: ObservableObject {
         status: .loaded,
         summary: readbackSummary(from: snapshot.raw),
         generatedAtMs: detail.generatedAtMs,
-        refs: detail.refs)
+        refs: detail.refs,
+        facts: readbackFacts(from: snapshot.raw, fallbackRunId: runId))
     } catch {
       return SessionContinuationSection(
         id: "run-readback",
@@ -476,6 +502,29 @@ public final class SessionContinuationViewModel: ObservableObject {
       parts.append("audit=\(audit)")
     }
     return parts.isEmpty ? "run readback loaded" : parts.joined(separator: " | ")
+  }
+
+  private nonisolated static func readbackFacts(
+    from raw: [String: Any],
+    fallbackRunId: String
+  ) -> [SessionContinuationFact] {
+    var facts: [SessionContinuationFact] = []
+    func append(_ id: String, _ label: String, _ value: String?) {
+      guard let value, !value.isEmpty else { return }
+      facts.append(SessionContinuationFact(id: id, label: label, value: value))
+    }
+    append("run-id", "run", firstNonEmptyString(raw, ["run_id", "runId"]) ?? fallbackRunId)
+    append("state", "state", firstNonEmptyString(raw, ["run_state", "runState", "status"]))
+    append("loop", "loop", firstNonEmptyString(raw, ["loop_status_derived", "loopStatusDerived"]))
+    append("events", "events", integerText(raw, ["event_count", "eventCount"]))
+    append("db-wide-tokens", "db tokens", integerText(raw, ["db_wide_token_total", "dbWideTokenTotal"]))
+    append("prompt-tokens", "prompt", integerText(raw, ["prompt_tokens", "promptTokens"]))
+    append("completion-tokens", "completion", integerText(raw, ["completion_tokens", "completionTokens"]))
+    append("total-tokens", "total", integerText(raw, ["total_tokens", "totalTokens"]))
+    let costKeys = ["cost_usd", "costUsd", "estimated_cost_usd", "estimatedCostUsd"]
+    append("cost", "cost", firstNonEmptyString(raw, costKeys) ?? integerText(raw, costKeys))
+    append("audit", "audit", boolText(raw, ["audit_chain_verified", "auditChainVerified"]))
+    return facts
   }
 
   private nonisolated static func approval(

--- a/apps/friday-ios/Tests/FridayMobileShellCoreTests/SessionContinuationViewModelTests.swift
+++ b/apps/friday-ios/Tests/FridayMobileShellCoreTests/SessionContinuationViewModelTests.swift
@@ -55,6 +55,10 @@ final class SessionContinuationViewModelTests: XCTestCase {
           "loop_status_derived": "finished",
           "event_count": 3,
           "db_wide_token_total": 99,
+          "prompt_tokens": 41,
+          "completion_tokens": 58,
+          "total_tokens": 99,
+          "cost_usd": "0.0123",
           "audit_chain_verified": true,
         ])
     }
@@ -218,6 +222,18 @@ final class SessionContinuationViewModelTests: XCTestCase {
     let readback = snapshot.sections.first { $0.id == "run-readback" }
     XCTAssertTrue(readback?.summary.contains("db-wide tokens=99") == true)
     XCTAssertTrue(readback?.summary.contains("audit=verified") == true)
+    XCTAssertEqual(readback?.facts, [
+      SessionContinuationFact(id: "run-id", label: "run", value: "run-1"),
+      SessionContinuationFact(id: "state", label: "state", value: "finished"),
+      SessionContinuationFact(id: "loop", label: "loop", value: "finished"),
+      SessionContinuationFact(id: "events", label: "events", value: "3"),
+      SessionContinuationFact(id: "db-wide-tokens", label: "db tokens", value: "99"),
+      SessionContinuationFact(id: "prompt-tokens", label: "prompt", value: "41"),
+      SessionContinuationFact(id: "completion-tokens", label: "completion", value: "58"),
+      SessionContinuationFact(id: "total-tokens", label: "total", value: "99"),
+      SessionContinuationFact(id: "cost", label: "cost", value: "0.0123"),
+      SessionContinuationFact(id: "audit", label: "audit", value: "verified"),
+    ])
     XCTAssertEqual(snapshot.sections.first?.generatedAtMs, 1_780_640_000_123)
     XCTAssertEqual(snapshot.controls.map(\.title), ["Send", "Stop", "Resume", "Reject", "Fork"])
     XCTAssertTrue(snapshot.controls.allSatisfy { !$0.isEnabled && $0.truthLabel == "NO-GO" })


### PR DESCRIPTION
## Summary
- add structured run-readback facts for mobile session continuation sections
- surface run/state/loop/events/token/cost/audit facts in the iOS session detail card
- keep existing no-ref/unavailable behavior unchanged through default empty facts

## Tests
- swift test --package-path apps/friday-ios --filter SessionContinuationViewModelTests
- swift build --package-path apps/friday-ios
- git diff --check HEAD~1..HEAD
- detect-secrets-hook --baseline .secrets.baseline apps/friday-ios/Sources/FridayMobileShellCore/SessionContinuationViewModel.swift apps/friday-ios/Sources/FridayMobileShell/FridaySessionDetailScreen.swift apps/friday-ios/Tests/FridayMobileShellCoreTests/SessionContinuationViewModelTests.swift