### PR TITLE
Surface desktop run readback facts

### DIFF
--- a/apps/macos/FridayHubConsole/Sources/FridayHubConsole/DesktopProjectionScreens.swift
+++ b/apps/macos/FridayHubConsole/Sources/FridayHubConsole/DesktopProjectionScreens.swift
@@ -243,6 +243,24 @@ struct DesktopProjectionScreen: View {
           Text(detail.summary)
             .font(.system(size: 12))
             .foregroundStyle(HubTheme.textPrimary)
+          if !detail.facts.isEmpty {
+            VStack(alignment: .leading, spacing: 6) {
+              ForEach(detail.facts) { fact in
+                HStack(alignment: .firstTextBaseline, spacing: 8) {
+                  Text(fact.label)
+                    .font(.system(size: 11))
+                    .foregroundStyle(HubTheme.textSecondary)
+                    .frame(width: 78, alignment: .leading)
+                  Text(fact.value)
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundStyle(HubTheme.textPrimary)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .lineLimit(2)
+                    .minimumScaleFactor(0.8)
+                }
+              }
+            }
+          }
           if let providerReadiness = detail.providerReadiness {
             ProviderReadinessDetailView(readiness: providerReadiness)
           }

--- a/apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/OperationsOverviewViewModel.swift
+++ b/apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/OperationsOverviewViewModel.swift
@@ -59,6 +59,7 @@ public struct ReadProjectionDetail: Sendable, Equatable {
   public let generatedAtMs: Int64
   public let summary: String
   public let refs: [String]
+  public let facts: [ReadProjectionDetailFact]
   public let providerReadiness: ProviderReadinessDetail?
 
   public init(title: String, snapshot: ReadProjectionSnapshot) {
@@ -67,6 +68,7 @@ public struct ReadProjectionDetail: Sendable, Equatable {
     self.generatedAtMs = snapshot.generatedAtMs
     self.summary = Self.summary(from: raw)
     self.refs = Self.refs(from: raw)
+    self.facts = Self.facts(from: raw)
     self.providerReadiness = ProviderReadinessDetail(raw: raw)
   }
 
@@ -94,8 +96,62 @@ public struct ReadProjectionDetail: Sendable, Equatable {
   }
 
   private static func firstString(_ raw: [String: Any], _ keys: [String]) -> String? {
-    keys.lazy.compactMap { raw[$0] as? String }.first
+    keys.lazy.compactMap {
+      guard let value = raw[$0] as? String else { return nil }
+      let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+      return trimmed.isEmpty ? nil : trimmed
+    }.first
   }
+
+  private static func facts(from raw: [String: Any]) -> [ReadProjectionDetailFact] {
+    var facts: [ReadProjectionDetailFact] = []
+    func append(_ id: String, _ label: String, _ value: String?) {
+      guard let value, !value.isEmpty else { return }
+      facts.append(ReadProjectionDetailFact(id: id, label: label, value: value))
+    }
+    append("run-id", "run", firstString(raw, ["runId", "run_id"]))
+    append("state", "state", firstString(raw, ["run_state", "runState", "status"]))
+    append("loop", "loop", firstString(raw, ["loop_status_derived", "loopStatusDerived"]))
+    append("events", "events", valueText(raw, ["event_count", "eventCount"]))
+    append("db-wide-tokens", "db tokens", valueText(raw, ["db_wide_token_total", "dbWideTokenTotal"]))
+    append("prompt-tokens", "prompt", valueText(raw, ["prompt_tokens", "promptTokens"]))
+    append("completion-tokens", "completion", valueText(raw, ["completion_tokens", "completionTokens"]))
+    append("total-tokens", "total", valueText(raw, ["total_tokens", "totalTokens"]))
+    append("cost", "cost", valueText(raw, ["cost_usd", "costUsd", "estimated_cost_usd", "estimatedCostUsd"]))
+    append("audit", "audit", boolText(raw, ["audit_chain_verified", "auditChainVerified"]))
+    return facts
+  }
+
+  private static func valueText(_ raw: [String: Any], _ keys: [String]) -> String? {
+    for key in keys {
+      if let value = raw[key] as? String {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !trimmed.isEmpty { return trimmed }
+      }
+      if let value = raw[key] as? Int { return "\(value)" }
+      if let value = raw[key] as? Int64 { return "\(value)" }
+      if let value = raw[key] as? UInt64 { return "\(value)" }
+      if let value = raw[key] as? NSNumber, CFGetTypeID(value) != CFBooleanGetTypeID() {
+        return value.stringValue
+      }
+    }
+    return nil
+  }
+
+  private static func boolText(_ raw: [String: Any], _ keys: [String]) -> String? {
+    for key in keys {
+      if let value = raw[key] as? Bool {
+        return value ? "verified" : "unverified"
+      }
+    }
+    return nil
+  }
+}
+
+public struct ReadProjectionDetailFact: Sendable, Equatable, Identifiable {
+  public let id: String
+  public let label: String
+  public let value: String
 }
 
 public struct ProviderReadinessDetail: Sendable, Equatable {

--- a/apps/macos/FridayHubConsole/Tests/FridayHubConsoleCoreTests/OperationsOverviewViewModelTests.swift
+++ b/apps/macos/FridayHubConsole/Tests/FridayHubConsoleCoreTests/OperationsOverviewViewModelTests.swift
@@ -826,7 +826,23 @@ final class DetailReadClient: FridayRustReadClient, @unchecked Sendable {
   }
 
   func fetchRunReadback(runId: String) async throws -> ReadProjectionSnapshot {
-    try record("run:\(runId)", kind: "run", status: "complete", runId: runId, proofRef: "proof://run/\(runId)")
+    try record(
+      "run:\(runId)",
+      kind: "run",
+      status: "complete",
+      runId: runId,
+      proofRef: "proof://run/\(runId)",
+      extra: [
+        "run_state": "complete",
+        "loop_status_derived": "complete",
+        "event_count": 7,
+        "db_wide_token_total": 321,
+        "prompt_tokens": 120,
+        "completion_tokens": 201,
+        "total_tokens": 321,
+        "cost_usd": "0.0456",
+        "audit_chain_verified": true,
+      ])
   }
 
   func fetchRunFileView(runId: String) async throws -> ReadProjectionSnapshot {
@@ -930,6 +946,23 @@ func loadDetailCallsRunAndNeedsMeReadArms() async {
   let client = DetailReadClient()
   let vm = OperationsOverviewViewModel(client: client)
   await vm.loadDetail(.runReadback(runId: "run-desktop"))
+  guard case let .loaded(runDetail) = vm.detailState else {
+    Issue.record("expected run detail .loaded, got \(vm.detailState)")
+    return
+  }
+  #expect(runDetail.title == "Run readback")
+  #expect(runDetail.facts == [
+    ReadProjectionDetailFact(id: "run-id", label: "run", value: "run-desktop"),
+    ReadProjectionDetailFact(id: "state", label: "state", value: "complete"),
+    ReadProjectionDetailFact(id: "loop", label: "loop", value: "complete"),
+    ReadProjectionDetailFact(id: "events", label: "events", value: "7"),
+    ReadProjectionDetailFact(id: "db-wide-tokens", label: "db tokens", value: "321"),
+    ReadProjectionDetailFact(id: "prompt-tokens", label: "prompt", value: "120"),
+    ReadProjectionDetailFact(id: "completion-tokens", label: "completion", value: "201"),
+    ReadProjectionDetailFact(id: "total-tokens", label: "total", value: "321"),
+    ReadProjectionDetailFact(id: "cost", label: "cost", value: "0.0456"),
+    ReadProjectionDetailFact(id: "audit", label: "audit", value: "verified"),
+  ])
   await vm.loadDetail(.activityNeedsMe(runId: "run-desktop"))
 
   #expect(client.requested == ["run:run-desktop", "needs-me:run-desktop"])


### PR DESCRIPTION
## Summary
- surface run/readback facts in the desktop detail projection (run state, loop state, event counts, token totals, cost, audit chain)
- render the facts in the desktop projection detail panel without exposing bodies
- extend the OperationsOverview view-model test fixture to assert the desktop run fact rows

## Verification
- swift test --package-path apps/macos/FridayHubConsole --filter OperationsOverviewViewModelTests
- swift build --package-path apps/macos/FridayHubConsole
- git diff --check origin/main..HEAD
- detect-secrets-hook --baseline .secrets.baseline apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/OperationsOverviewViewModel.swift apps/macos/FridayHubConsole/Sources/FridayHubConsole/DesktopProjectionScreens.swift apps/macos/FridayHubConsole/Tests/FridayHubConsoleCoreTests/OperationsOverviewViewModelTests.swift