### PR TITLE
Surface iOS chat token receipt facts

### DIFF
--- a/apps/friday-ios/Sources/FridayMobileShell/FridayChatScreen.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayChatScreen.swift
@@ -269,6 +269,11 @@ struct FridayChatScreen: View {
         if let outcome = r.answerBodyOutcome { RefPill(label: "answer_body", ref: outcome) }
         if let turns = r.turns { RefPill(label: "turns", ref: "\(turns)") }
         if let tools = r.executedTools { RefPill(label: "executed_tools", ref: "\(tools)") }
+        if let prompt = r.promptTokens { RefPill(label: "prompt_tokens", ref: "\(prompt)") }
+        if let completion = r.completionTokens { RefPill(label: "completion_tokens", ref: "\(completion)") }
+        if let total = tokenTotal(prompt: r.promptTokens, completion: r.completionTokens) {
+          RefPill(label: "total_tokens", ref: "\(total)")
+        }
       }
     }
     .accessibilityElement(children: .contain)
@@ -365,6 +370,12 @@ struct FridayChatScreen: View {
       return nil
     }
     return trimmed
+  }
+
+  private func tokenTotal(prompt: UInt64?, completion: UInt64?) -> UInt64? {
+    guard let prompt, let completion else { return nil }
+    let sum = prompt.addingReportingOverflow(completion)
+    return sum.overflow ? nil : sum.partialValue
   }
 }
 

--- a/apps/friday-ios/Tests/FridayMobileShellCoreTests/FridayChatViewModelTests.swift
+++ b/apps/friday-ios/Tests/FridayMobileShellCoreTests/FridayChatViewModelTests.swift
@@ -220,7 +220,8 @@ final class FridayChatViewModelTests: XCTestCase {
 
   private func makeAnswer(_ runId: String = "run-1") -> AgentRunResultWire {
     AgentRunResultWire(runId: runId, status: "completed",
-                       answerSha256: String(repeating: "a", count: 64), answerLen: 128, turns: 2, executedTools: 0)
+                       answerSha256: String(repeating: "a", count: 64), answerLen: 128, turns: 2, executedTools: 0,
+                       promptTokens: 41, completionTokens: 58)
   }
 
   private func makePause(_ runId: String = "run-1") -> PausedOutcome {
@@ -238,6 +239,8 @@ final class FridayChatViewModelTests: XCTestCase {
     XCTAssertEqual(receipt.status, "completed")
     XCTAssertEqual(receipt.answerLen, 128)         // refs/counts only (INV-5)
     XCTAssertEqual(receipt.answerSha256?.count, 64) // a fingerprint, never a body
+    XCTAssertEqual(receipt.promptTokens, 41)
+    XCTAssertEqual(receipt.completionTokens, 58)
     XCTAssertNil(receipt.answerBody)
     XCTAssertEqual(client.dispatchedTasks, ["summarize my inbox"])
     // DEFAULT read-only/no-grant: a plain send carries NO constraints block.


### PR DESCRIPTION
## Summary
- show prompt/completion/total token counts in the iOS Friday Chat answer receipt when the refs-only run receipt provides them
- keep answer bodies owner-gated; this only surfaces existing count fields
- extend the chat view-model test fixture so token counts are preserved from wire receipt to ChatAnswerReceipt

## Verification
- swift test --package-path apps/friday-ios --filter FridayChatViewModelTests
- swift build --package-path apps/friday-ios
- git diff --check
- detect-secrets-hook --baseline .secrets.baseline apps/friday-ios/Sources/FridayMobileShell/FridayChatScreen.swift apps/friday-ios/Tests/FridayMobileShellCoreTests/FridayChatViewModelTests.swift