### PR TITLE
Surface desktop work item recovery facts

### DIFF
--- a/apps/macos/FridayHubConsole/Sources/FridayHubConsole/DesktopProjectionScreens.swift
+++ b/apps/macos/FridayHubConsole/Sources/FridayHubConsole/DesktopProjectionScreens.swift
@@ -385,6 +385,25 @@ struct DesktopProjectionScreen: View {
             HStack(spacing: 6) {
               item.state.chip
               item.owner.chip
+              if item.recoveryKind != "none" {
+                StatusChip(text: item.recoveryKind, bg: HubTheme.chipNeutralBG, fg: HubTheme.chipNeutralFG)
+              }
+            }
+            if !item.blockingReason.isEmpty {
+              Text(item.blockingReason)
+                .font(.system(size: 11))
+                .foregroundStyle(HubTheme.textSecondary)
+                .fixedSize(horizontal: false, vertical: true)
+            }
+            if item.canRetry || item.canCancel {
+              HStack(spacing: 6) {
+                if item.canRetry {
+                  StatusChip(text: "retry available", bg: HubTheme.chipWarnBG, fg: HubTheme.chipWarnFG)
+                }
+                if item.canCancel {
+                  StatusChip(text: "cancel available", bg: HubTheme.chipNeutralBG, fg: HubTheme.chipNeutralFG)
+                }
+              }
             }
             if let proofRef = item.proofRef {
               RefPill(label: "proofRef", ref: proofRef)

--- a/apps/macos/FridayHubConsole/Sources/FridayHubConsole/OperationsOverviewScreen.swift
+++ b/apps/macos/FridayHubConsole/Sources/FridayHubConsole/OperationsOverviewScreen.swift
@@ -781,6 +781,25 @@ struct WorkItemRow: View {
         HStack(spacing: 6) {
           item.state.chip
           item.owner.chip
+          if item.recoveryKind != "none" {
+            StatusChip(text: item.recoveryKind, bg: HubTheme.chipNeutralBG, fg: HubTheme.chipNeutralFG)
+          }
+        }
+        if !item.blockingReason.isEmpty {
+          Text(item.blockingReason)
+            .font(.system(size: 10))
+            .foregroundStyle(HubTheme.textSecondary)
+            .fixedSize(horizontal: false, vertical: true)
+        }
+        if item.canRetry || item.canCancel {
+          HStack(spacing: 6) {
+            if item.canRetry {
+              StatusChip(text: "retry available", bg: HubTheme.chipWarnBG, fg: HubTheme.chipWarnFG)
+            }
+            if item.canCancel {
+              StatusChip(text: "cancel available", bg: HubTheme.chipNeutralBG, fg: HubTheme.chipNeutralFG)
+            }
+          }
         }
         if let proof = item.proofRef {
           RefPill(label: "proofRef", ref: proof)

--- a/apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/MockReadClient.swift
+++ b/apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/MockReadClient.swift
@@ -64,7 +64,11 @@ public struct MockReadClient: FridayRustReadClient {
         state: .providerAck,
         owner: .linkedOnly,
         proofRef: "proof://provider-receipt/3f9a1c2b7e004d18",
-        done: false
+        done: false,
+        blockingReason: "provider acknowledged; cancel is the only safe recovery action",
+        recoveryKind: "in_flight",
+        canRetry: false,
+        canCancel: true
       ),
       // Friday-owned item: completed and backed by a proof receipt.
       MissionWorkbenchWorkItem(
@@ -82,7 +86,24 @@ public struct MockReadClient: FridayRustReadClient {
         state: .blocked,
         owner: .linkedOnly,
         proofRef: "proof://work-item-required/0c0ffee0deadbeef",
-        done: false
+        done: false,
+        blockingReason: "provider login required before dispatch can resume",
+        recoveryKind: "needs_operator",
+        canRetry: false,
+        canCancel: true
+      ),
+      // Retryable stale row — desktop must surface recovery affordance facts as truth.
+      MissionWorkbenchWorkItem(
+        id: "work_probe_stale_retryable",
+        title: "Retry stale provider turn",
+        state: .stale,
+        owner: .fridayOwned,
+        proofRef: "proof://work-item-stale/1122334455667788",
+        done: false,
+        blockingReason: "failed retryable; operator may retry by returning the WorkItem to ready_to_dispatch",
+        recoveryKind: "retryable",
+        canRetry: true,
+        canCancel: true
       ),
       // Bounded timeline read appended by the projection — not completion.
       MissionWorkbenchWorkItem(

--- a/apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/WorkbenchSnapshot.swift
+++ b/apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/WorkbenchSnapshot.swift
@@ -139,6 +139,10 @@ public struct MissionWorkbenchWorkItem: Codable, Sendable, Identifiable, Equatab
   public let owner: MissionTruthLabel
   public let proofRef: String?
   public let done: Bool
+  public let blockingReason: String
+  public let recoveryKind: String
+  public let canRetry: Bool
+  public let canCancel: Bool
 
   public init(
     id: String,
@@ -146,7 +150,11 @@ public struct MissionWorkbenchWorkItem: Codable, Sendable, Identifiable, Equatab
     state: MissionLifecycleState,
     owner: MissionTruthLabel,
     proofRef: String?,
-    done: Bool
+    done: Bool,
+    blockingReason: String = "",
+    recoveryKind: String = "none",
+    canRetry: Bool = false,
+    canCancel: Bool = false
   ) {
     self.id = id
     self.title = title
@@ -154,10 +162,42 @@ public struct MissionWorkbenchWorkItem: Codable, Sendable, Identifiable, Equatab
     self.owner = owner
     self.proofRef = proofRef
     self.done = done
+    self.blockingReason = blockingReason
+    self.recoveryKind = recoveryKind
+    self.canRetry = canRetry
+    self.canCancel = canCancel
+  }
+
+  private enum CodingKeys: String, CodingKey {
+    case id
+    case title
+    case state
+    case owner
+    case proofRef
+    case done
+    case blockingReason
+    case recoveryKind
+    case canRetry
+    case canCancel
+  }
+
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    self.id = try container.decode(String.self, forKey: .id)
+    self.title = try container.decode(String.self, forKey: .title)
+    self.state = try container.decode(MissionLifecycleState.self, forKey: .state)
+    self.owner = try container.decode(MissionTruthLabel.self, forKey: .owner)
+    self.proofRef = try container.decodeIfPresent(String.self, forKey: .proofRef)
+    self.done = try container.decode(Bool.self, forKey: .done)
+    self.blockingReason = try container.decodeIfPresent(String.self, forKey: .blockingReason) ?? ""
+    self.recoveryKind = try container.decodeIfPresent(String.self, forKey: .recoveryKind) ?? "none"
+    self.canRetry = try container.decodeIfPresent(Bool.self, forKey: .canRetry) ?? false
+    self.canCancel = try container.decodeIfPresent(Bool.self, forKey: .canCancel) ?? false
   }
 
   public var needsAttention: Bool {
     guard !done else { return false }
+    if canRetry || canCancel { return true }
     switch state {
     case .completedWithProof, .timelineRead:
       return false
@@ -169,6 +209,7 @@ public struct MissionWorkbenchWorkItem: Codable, Sendable, Identifiable, Equatab
   }
 
   public var attentionReason: String {
+    if !blockingReason.isEmpty { return blockingReason }
     switch state {
     case .providerAck:
       return "provider acknowledged; waiting for proof"

--- a/apps/macos/FridayHubConsole/Tests/FridayHubConsoleCoreTests/OperationsOverviewViewModelTests.swift
+++ b/apps/macos/FridayHubConsole/Tests/FridayHubConsoleCoreTests/OperationsOverviewViewModelTests.swift
@@ -73,6 +73,17 @@ func snapshotExercisesEveryHonestRenderingRule() {
   let blocked = snapshot.workItems.first { $0.state == .blocked }
   #expect(blocked != nil)
   #expect(blocked?.done == false)
+  #expect(blocked?.recoveryKind == "needs_operator")
+  #expect(blocked?.canRetry == false)
+  #expect(blocked?.canCancel == true)
+
+  // A stale retryable row must keep its recovery affordance facts on desktop.
+  let retryable = snapshot.workItems.first { $0.id == "work_probe_stale_retryable" }
+  #expect(retryable?.state == .stale)
+  #expect(retryable?.blockingReason.contains("operator may retry") == true)
+  #expect(retryable?.recoveryKind == "retryable")
+  #expect(retryable?.canRetry == true)
+  #expect(retryable?.canCancel == true)
 
   // Honest status: stale must be present.
   #expect(snapshot.statusLabels.contains(.stale))
@@ -147,12 +158,16 @@ func attentionSummarySurfacesOnlyUnfinishedRecoveryRelevantWorkItems() {
 
   #expect(attentionIds.contains("work_probe_provider"))
   #expect(attentionIds.contains("work_probe_blocked"))
+  #expect(attentionIds.contains("work_probe_stale_retryable"))
   #expect(!attentionIds.contains("work_probe_done"))
   #expect(!attentionIds.contains("workbench_timeline_read_mission_workbench_probe_20260605"))
-  #expect(snapshot.attentionSummary == "2 work items need attention.")
+  #expect(snapshot.attentionSummary == "3 work items need attention.")
   #expect(
     snapshot.attentionWorkItems.first { $0.id == "work_probe_provider" }?.attentionReason
-      == "provider acknowledged; waiting for proof")
+      == "provider acknowledged; cancel is the only safe recovery action")
+  #expect(
+    snapshot.attentionWorkItems.first { $0.id == "work_probe_stale_retryable" }?.recoveryKind
+      == "retryable")
 }
 
 @Test
@@ -273,7 +288,9 @@ func decodesRustProjectionShapedJSON() throws {
       "channelReceiptRefs": [],
       "workItems": [
         {"id": "wi_x", "title": "t", "state": "provider_ack", "owner": "linked_only",
-         "proofRef": "proof://provider-receipt/1", "done": false}
+         "proofRef": "proof://provider-receipt/1", "done": false,
+         "blockingReason": "provider acknowledged; cancel only",
+         "recoveryKind": "in_flight", "canRetry": false, "canCancel": true}
       ],
       "timelinePages": [
         {"page": 1, "cursor": "start", "nextCursor": "offset:1", "eventRefs": ["e0"]}
@@ -323,6 +340,10 @@ func decodesRustProjectionShapedJSON() throws {
   #expect(snapshot.missionId == "mission_x")
   #expect(snapshot.statusLabels == [.stale, .offline, .error])
   #expect(snapshot.workItems.first?.state == .providerAck)
+  #expect(snapshot.workItems.first?.blockingReason == "provider acknowledged; cancel only")
+  #expect(snapshot.workItems.first?.recoveryKind == "in_flight")
+  #expect(snapshot.workItems.first?.canRetry == false)
+  #expect(snapshot.workItems.first?.canCancel == true)
   #expect(snapshot.runOutcomeLearningCandidates.first?.id == "a1:run_x:preference")
   #expect(snapshot.t3ProvisioningStatus?.paired == true)
   #expect(snapshot.t3ProvisioningStatus?.latestDevice?.deviceId == "proof://device/paired-desktop-1")


### PR DESCRIPTION
## Summary
- carry Mission Workbench work-item recovery facts through the macOS rich Workbench contract (`blockingReason`, `recoveryKind`, `canRetry`, `canCancel`)
- render recovery facts in desktop Work Items / Projection rows without adding write controls
- extend representative snapshot + contract tests with retryable stale and needs-operator recovery rows

## Verification
- `swift test --package-path apps/macos/FridayHubConsole --filter OperationsOverviewViewModelTests`
- `swift build --package-path apps/macos/FridayHubConsole`
- `git diff --check`
- `detect-secrets-hook --baseline .secrets.baseline apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/WorkbenchSnapshot.swift apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/MockReadClient.swift apps/macos/FridayHubConsole/Sources/FridayHubConsole/OperationsOverviewScreen.swift apps/macos/FridayHubConsole/Sources/FridayHubConsole/DesktopProjectionScreens.swift apps/macos/FridayHubConsole/Tests/FridayHubConsoleCoreTests/OperationsOverviewViewModelTests.swift`

Truth: refs-only/product visibility improvement for T4 recovery state; no retry/cancel/signing mutation is introduced.