### PR TITLE
Gate iOS pairing network client

### DIFF
--- a/apps/friday-ios/Sources/FridayMobileShell/FridayApp.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayApp.swift
@@ -70,7 +70,9 @@ final class FridaySession: ObservableObject {
     self.devicePairing = preview
       ? .evaluate(deviceKeypairRequested: false, readLiveRequested: false, writeLiveRequested: false)
       : Self.defaultDevicePairingReadiness()
-    self.makePairingClient = preview ? { _ in nil } : Self.defaultPairingClient
+    self.makePairingClient = preview || !Self.livePairingRequested(args: args, env: env)
+      ? { _ in nil }
+      : Self.defaultPairingClient
 
     // The write client (Friday Chat read-WRITE / S6 surface). DEFAULT (gate OFF) = the throwing
     // `liveTransportNotWired` factory transport ⇒ honest-unavailable, with an ephemeral X25519
@@ -183,9 +185,12 @@ final class FridaySession: ObservableObject {
 
   static func defaultPairingClient(deviceKeypair: DeviceKeypair) -> FridayPairingClient? {
     // Explicit QR pairing is a user-initiated enrollment ceremony, not a shipped live-read/write
-    // flip. It still fails closed through manifest proof validation, PairingServerConfig's
-    // loopback/private-LAN allowlist, and the Hub's PairAck. Read, write, run-control, signing, and
-    // trust minting remain on their separate gates.
+    // flip. The network PairAck leg is wired only when `FRIDAY_MOBILE_LIVE_PAIRING=1` /
+    // `--live-pairing` selects this factory; otherwise Home can still scan/preflight a QR but
+    // `pairScannedQR` reports "Pairing channel is not configured for this launch." It still fails
+    // closed through manifest proof validation, PairingServerConfig's loopback/private-LAN
+    // allowlist, and the Hub's PairAck. Read, write, run-control, signing, and trust minting remain
+    // on their separate gates.
     return RealPairingClientFactory.makeLive(deviceKeypair: deviceKeypair)
   }
 


### PR DESCRIPTION
## Summary
- bind the iOS PairAck network client to the existing `--live-pairing` / `FRIDAY_MOBILE_LIVE_PAIRING=1` gate
- keep QR scan/preflight available by default while making the network pairing channel honest-unavailable when the gate is off
- document that read/write/run-control/signing/trust minting remain separate gates

## Verification
- `swift test --package-path apps/friday-ios --filter MobileRuntimeGatesTests`
- `./apps/friday-ios/build-sim.sh`
- inspected `apps/friday-ios/.build-sim/friday-ios-sim.png` and confirmed the app launched to Friday Home with the Device pairing card in default disabled/offline state
- `git diff --check`
- `detect-secrets-hook --baseline .secrets.baseline apps/friday-ios/Sources/FridayMobileShell/FridayApp.swift`

Truth: T3 gate-coherence hardening only; PairAck still requires a user-scanned/pasted QR and live pairing flag, and no trust grant/context passport/signature minting is introduced.