### PR TITLE
Stabilize iOS voice audio session

### DIFF
--- a/apps/friday-ios/Sources/FridayMobileShell/FridayChatScreen.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayChatScreen.swift
@@ -432,11 +432,20 @@ private final class MobileVoiceController: ObservableObject {
     request = nil
     task = nil
     isRecording = false
+    deactivateAudioSession()
     status = "Voice input stopped."
   }
 
   func speak(_ text: String) {
+    stopRecording()
     stopSpeaking()
+    do {
+      try AVAudioSession.sharedInstance().setCategory(.playback, mode: .spokenAudio, options: .duckOthers)
+      try AVAudioSession.sharedInstance().setActive(true, options: .notifyOthersOnDeactivation)
+    } catch {
+      status = "Voice output failed: \(error.localizedDescription)"
+      return
+    }
     let utterance = AVSpeechUtterance(string: text)
     utterance.rate = AVSpeechUtteranceDefaultSpeechRate
     synthesizer.speak(utterance)
@@ -491,9 +500,14 @@ private final class MobileVoiceController: ObservableObject {
       }
     } catch {
       input.removeTap(onBus: 0)
+      deactivateAudioSession()
       self.request = nil
       status = "Voice input failed: \(error.localizedDescription)"
     }
+  }
+
+  private func deactivateAudioSession() {
+    try? AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
   }
 
   private static func requestMicrophoneAccess(_ completion: @escaping @Sendable (Bool) -> Void) {


### PR DESCRIPTION
## Summary
- release the iOS recording audio session when voice input stops or fails to start
- switch to playback/spoken-audio before speaking an answer so voice output is not left behind the recording session
- keep voice I/O local to system Speech/AVSpeech; no provider, signature, memory, or approval behavior changes

## Verification
- `./apps/friday-ios/build-sim.sh apps/friday-ios/.build-sim/friday-ios-voice-session.png`
- inspected `apps/friday-ios/.build-sim/friday-ios-voice-session.png` and confirmed the app launched to Friday Home with normal offline/pairing state
- `git diff --check`
- `detect-secrets-hook --baseline .secrets.baseline apps/friday-ios/Sources/FridayMobileShell/FridayChatScreen.swift`

Truth: T6 mobile voice I/O hardening only; it does not claim provider-backed TTS live, organic adoption, or END-BAR completion.