### PR TITLE
Surface iOS session approval details

### DIFF
--- a/apps/friday-ios/Sources/FridayMobileShell/FridaySessionDetailScreen.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridaySessionDetailScreen.swift
@@ -107,12 +107,90 @@ struct FridaySessionDetailScreen: View {
       }
     case .loaded(let snapshot):
       VStack(spacing: 16) {
+        approvalPanel(snapshot)
         controlsCard(snapshot.controls)
         ForEach(snapshot.sections) { section in
           sectionCard(section)
         }
         proofRefsCard(snapshot.proofRefs)
       }
+    }
+  }
+
+  @ViewBuilder
+  private func approvalPanel(_ snapshot: SessionContinuationSnapshot) -> some View {
+    if let approval = snapshot.pendingApproval {
+      let resume = snapshot.controls.first { $0.id == "resume" }
+      let reject = snapshot.controls.first { $0.id == "reject" }
+      GlassPanel {
+        VStack(alignment: .leading, spacing: MobileTheme.rowSpacing) {
+          HStack(alignment: .top, spacing: 10) {
+            Image(systemName: "checkmark.seal")
+              .font(.system(size: 22, weight: .semibold))
+              .foregroundStyle(MobileTheme.coral)
+              .frame(width: 30, height: 30)
+            VStack(alignment: .leading, spacing: 3) {
+              Text("Approval Required")
+                .font(.headline)
+                .foregroundStyle(MobileTheme.textPrimary)
+              Text("operator-signed relay only")
+                .font(.caption)
+                .foregroundStyle(MobileTheme.textSecondary)
+            }
+            Spacer()
+            StatusChip(
+              text: resume?.truthLabel ?? "NO-GO",
+              bg: resume?.isEnabled == true ? MobileTheme.chipPendingBG : MobileTheme.chipWarnBG,
+              fg: resume?.isEnabled == true ? MobileTheme.chipPendingFG : MobileTheme.chipWarnFG)
+          }
+
+          if let summary = approval.summary, !summary.isEmpty {
+            Text(summary)
+              .font(.callout.weight(.medium))
+              .foregroundStyle(MobileTheme.textPrimary)
+              .fixedSize(horizontal: false, vertical: true)
+          }
+          RefPill(label: "run_id", ref: approval.runId)
+          RefPill(label: "approval_id", ref: approval.approvalId)
+          RefPill(label: "action_digest", ref: short(approval.actionDigest))
+
+          VStack(alignment: .leading, spacing: 5) {
+            approvalCapabilityRow("Resume", control: resume)
+            approvalCapabilityRow("Reject", control: reject)
+          }
+          Text("The app displays the paused action proof and relays an operator signature when one is available; it never holds signing key material.")
+            .font(.caption2)
+            .foregroundStyle(MobileTheme.textSecondary)
+            .fixedSize(horizontal: false, vertical: true)
+          controlStateView(viewModel.controlStates["resume"])
+          controlStateView(viewModel.controlStates["reject"])
+        }
+      }
+      .accessibilityElement(children: .contain)
+      .accessibilityLabel("Approval required. \(approval.summary ?? "No summary"). Digest \(approval.actionDigest)")
+      .accessibilityIdentifier("friday.session.approval-panel")
+    }
+  }
+
+  @ViewBuilder
+  private func approvalCapabilityRow(_ title: String, control: SessionContinuationControl?) -> some View {
+    HStack(spacing: 8) {
+      Image(systemName: control?.isEnabled == true ? "checkmark.circle" : "exclamationmark.triangle")
+        .foregroundStyle(control?.isEnabled == true ? MobileTheme.cyan : MobileTheme.coral)
+      Text(title)
+        .font(.caption.weight(.semibold))
+        .foregroundStyle(MobileTheme.textPrimary)
+      Spacer()
+      StatusChip(
+        text: control?.truthLabel ?? "NO-GO",
+        bg: control?.isEnabled == true ? MobileTheme.chipPendingBG : MobileTheme.chipWarnBG,
+        fg: control?.isEnabled == true ? MobileTheme.chipPendingFG : MobileTheme.chipWarnFG)
+    }
+    if let reason = control?.reason {
+      Text(reason)
+        .font(.caption2)
+        .foregroundStyle(MobileTheme.textSecondary)
+        .fixedSize(horizontal: false, vertical: true)
     }
   }
 
@@ -367,6 +445,10 @@ struct FridaySessionDetailScreen: View {
 
   private func statusChip(_ text: String) -> some View {
     StatusChip(text: text, bg: MobileTheme.chipNeutralBG, fg: MobileTheme.chipNeutralFG)
+  }
+
+  private func short(_ s: String) -> String {
+    s.count > 16 ? "\(s.prefix(10))...\(s.suffix(4))" : s
   }
 
   private func firstRunId(_ projection: HomeProjection) -> String? {

--- a/apps/friday-ios/Tests/FridayMobileShellCoreTests/SessionContinuationViewModelTests.swift
+++ b/apps/friday-ios/Tests/FridayMobileShellCoreTests/SessionContinuationViewModelTests.swift
@@ -337,6 +337,59 @@ final class SessionContinuationViewModelTests: XCTestCase {
     XCTAssertEqual(snapshot.pendingApproval?.summary, "approval required for write_file")
   }
 
+  func testPendingApprovalWithoutSignerKeepsResumeNoGoButAllowsRejectRelay() async {
+    let raw: [String: Any] = [
+      "run_id": "run-1",
+      "status": "waiting",
+      "truthLabel": "friday_owned",
+      "needs_me": [
+        "signing_request": [
+          "run_id": "run-1",
+          "approval_id": "approval-1",
+          "action_digest": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+          "summary": "write_file pending",
+        ],
+      ],
+    ]
+    let write = FakeSessionWriteClient(.accepted(ResumeRelayResult(
+      runId: "run-1",
+      op: "reject",
+      accepted: true,
+      status: "rejected",
+      auditRef: "audit://reject/run-1")))
+    let vm = SessionContinuationViewModel(
+      client: FakeSessionReadClient(needsMeRaw: raw),
+      writeClient: write,
+      signer: nil,
+      runControlEnabled: true)
+
+    await vm.refresh(agentSessionId: "session-1", runId: "run-1")
+
+    guard case .loaded(let snapshot) = vm.state else {
+      return XCTFail("expected loaded session continuation, got \(vm.state)")
+    }
+    XCTAssertEqual(snapshot.pendingApproval?.approvalId, "approval-1")
+    let resume = snapshot.controls.first { $0.id == "resume" }
+    XCTAssertEqual(resume?.truthLabel, "NO-GO")
+    XCTAssertEqual(resume?.isEnabled, false)
+    XCTAssertTrue(resume?.reason.contains("operator signer relay") == true)
+    let reject = snapshot.controls.first { $0.id == "reject" }
+    XCTAssertEqual(reject?.truthLabel, "guarded")
+    XCTAssertEqual(reject?.isEnabled, true)
+
+    await vm.resume()
+    XCTAssertTrue(write.resumedRunIds.isEmpty, "missing signer must not relay a resume")
+    guard case .error(let resumeReason) = vm.controlStates["resume"] else {
+      return XCTFail("expected resume signer error, got \(String(describing: vm.controlStates["resume"]))")
+    }
+    XCTAssertTrue(resumeReason.contains("operator signer relay"), "reason: \(resumeReason)")
+
+    await vm.reject()
+    XCTAssertEqual(write.rejectedRunIds, ["run-1"])
+    XCTAssertEqual(write.rejectedApprovalIds, ["approval-1"])
+    XCTAssertTrue(write.relayedBlobs.isEmpty, "reject must stay refs-only")
+  }
+
   func testResumeRelaysSignerBlobVerbatimAndSurfacesReceipt() async {
     let digest = "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
     let raw: [String: Any] = [


### PR DESCRIPTION
## Summary
- add a dedicated Session Detail approval panel for pending Needs-Me approvals
- show run, approval, action digest, resume/reject readiness, and relay-only truth text
- cover the missing-signer boundary so resume remains NO-GO while reject stays refs-only and cannot relay a signature blob

## Verification
- swift test --package-path apps/friday-ios --filter SessionContinuationViewModelTests
- ./apps/friday-ios/build-sim.sh apps/friday-ios/.build-sim/session-approval-detail.png
- git diff --check
- detect-secrets-hook --baseline .secrets.baseline apps/friday-ios/Sources/FridayMobileShell/FridaySessionDetailScreen.swift apps/friday-ios/Tests/FridayMobileShellCoreTests/SessionContinuationViewModelTests.swift

Truth: T2 application approval surface improvement only. This does not make the app an operator signer, does not read or mint operator key material, and does not claim true operator-signed live closure.