### PR TITLE
Add explicit desktop LAN pairing launch

### DIFF
--- a/apps/macos/FridayHubConsole/Sources/FridayHubConsole/PairingProvisioningScreen.swift
+++ b/apps/macos/FridayHubConsole/Sources/FridayHubConsole/PairingProvisioningScreen.swift
@@ -68,10 +68,19 @@ struct PairingProvisioningScreen: View {
           Button {
             Task { await viewModel.startPairingSession() }
           } label: {
-            Label("Start Session", systemImage: "antenna.radiowaves.left.and.right")
+            Label("Start Local", systemImage: "desktopcomputer")
           }
           .buttonStyle(.borderedProminent)
           .disabled(!viewModel.canStartPairingSession)
+
+          Button {
+            Task { await viewModel.startPairingSession(exposureMode: .privateLan) }
+          } label: {
+            Label("Start LAN QR", systemImage: "wifi")
+          }
+          .buttonStyle(.bordered)
+          .disabled(!viewModel.canStartPairingSession)
+          .help("Start a private-LAN QR pairing server for a real phone on this network.")
 
           Button {
             viewModel.load(qrJSON: inputPayload)

--- a/apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/PairingProvisioningViewModel.swift
+++ b/apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/PairingProvisioningViewModel.swift
@@ -10,6 +10,29 @@ public enum PairingProvisioningMode: String, Sendable, Equatable {
   case unavailable
 }
 
+public enum PairingSessionExposureMode: String, Sendable, Equatable {
+  case loopback
+  case privateLan = "private_lan"
+
+  public var readyReason: String {
+    switch self {
+    case .loopback:
+      return "Short-lived loopback pairing QR is ready to scan."
+    case .privateLan:
+      return "Short-lived private-LAN pairing QR is ready to scan."
+    }
+  }
+
+  public var startingReason: String {
+    switch self {
+    case .loopback:
+      return "Starting a short-lived loopback Hub pairing session."
+    case .privateLan:
+      return "Starting a short-lived private-LAN Hub pairing session."
+    }
+  }
+}
+
 public struct PairingProvisioningState: Sendable, Equatable, CustomStringConvertible,
   CustomDebugStringConvertible
 {
@@ -62,7 +85,10 @@ public final class PairingProvisioningViewModel: ObservableObject {
     state.description
   }
 
-  public func startPairingSession(nowMs: Int64 = Int64(Date().timeIntervalSince1970 * 1000)) async {
+  public func startPairingSession(
+    exposureMode: PairingSessionExposureMode = .loopback,
+    nowMs: Int64 = Int64(Date().timeIntervalSince1970 * 1000)
+  ) async {
     guard let launcher else {
       qrPayload = ""
       state = PairingProvisioningState(
@@ -75,12 +101,16 @@ public final class PairingProvisioningViewModel: ObservableObject {
     qrPayload = ""
       state = PairingProvisioningState(
         mode: .starting,
-        reason: "Starting a short-lived Hub pairing session.",
+        reason: exposureMode.startingReason,
         projection: nil,
         manifestPath: nil)
     do {
-      let result = try await launcher.startPairingSession()
-      load(qrJSON: result.manifestJSON, nowMs: nowMs, manifestPath: result.manifestPath)
+      let result = try await launcher.startPairingSession(exposureMode: exposureMode)
+      load(
+        qrJSON: result.manifestJSON,
+        nowMs: nowMs,
+        manifestPath: result.manifestPath,
+        readyReason: exposureMode.readyReason)
     } catch {
       qrPayload = ""
       state = PairingProvisioningState(
@@ -94,7 +124,8 @@ public final class PairingProvisioningViewModel: ObservableObject {
   public func load(
     qrJSON: String,
     nowMs: Int64 = Int64(Date().timeIntervalSince1970 * 1000),
-    manifestPath: String? = nil
+    manifestPath: String? = nil,
+    readyReason: String = PairingSessionExposureMode.loopback.readyReason
   ) {
     let payload = qrJSON.trimmingCharacters(in: .whitespacesAndNewlines)
     guard !payload.isEmpty else {
@@ -109,7 +140,7 @@ public final class PairingProvisioningViewModel: ObservableObject {
       let trimmedManifestPath = manifestPath?.trimmingCharacters(in: .whitespacesAndNewlines)
       state = PairingProvisioningState(
         mode: .ready,
-        reason: "Short-lived pairing QR is ready to scan.",
+        reason: readyReason,
         projection: manifest.redactedProjection,
         manifestPath: trimmedManifestPath?.isEmpty == false ? trimmedManifestPath : nil)
     } catch {
@@ -163,7 +194,7 @@ public struct PairingSessionLaunchResult: Sendable, Equatable {
 
 @MainActor
 public protocol PairingSessionLaunching: AnyObject {
-  func startPairingSession() async throws -> PairingSessionLaunchResult
+  func startPairingSession(exposureMode: PairingSessionExposureMode) async throws -> PairingSessionLaunchResult
 }
 
 public enum PairingSessionLauncherError: Error, Equatable, CustomStringConvertible {
@@ -237,7 +268,9 @@ public final class OpsScriptPairingSessionLauncher: PairingSessionLaunching {
     return nil
   }
 
-  public func startPairingSession() async throws -> PairingSessionLaunchResult {
+  public func startPairingSession(
+    exposureMode: PairingSessionExposureMode = .loopback
+  ) async throws -> PairingSessionLaunchResult {
     guard FileManager.default.fileExists(atPath: scriptPath) else {
       throw PairingSessionLauncherError.scriptUnavailable
     }
@@ -254,6 +287,9 @@ public final class OpsScriptPairingSessionLauncher: PairingSessionLaunching {
     var env = environment
     env["FRIDAY_PAIRING_QR_JSON_OUT"] = manifestURL.path
     env["FRIDAY_PAIRING_OUT_DIR"] = outputDirectory.path
+    if exposureMode == .privateLan {
+      env["FRIDAY_PAIRING_HOST"] = "auto-lan"
+    }
     process.environment = env
 
     do {

--- a/apps/macos/FridayHubConsole/Tests/FridayHubConsoleCoreTests/PairingProvisioningViewModelTests.swift
+++ b/apps/macos/FridayHubConsole/Tests/FridayHubConsoleCoreTests/PairingProvisioningViewModelTests.swift
@@ -56,11 +56,32 @@ import Testing
   await vm.startPairingSession(nowMs: 1_780_000_000_000)
 
   #expect(launcher.startCount == 1)
+  #expect(launcher.exposureModes == [.loopback])
   #expect(vm.state.mode == .ready)
   #expect(vm.qrPayload.contains(secret))
   #expect(!vm.redactedSummary.contains(secret))
   #expect(vm.state.manifestPath == "/tmp/friday-pairing.json")
   #expect(vm.redactedSummary.contains("/tmp/friday-pairing.json"))
+  #expect(vm.canRenderQRCode)
+}
+
+@MainActor
+@Test func pairingProvisioningCanRequestPrivateLanLauncherExplicitly() async throws {
+  let secret = "friday-pairing-lan-secret" // pragma: allowlist secret
+  let launcher = FakePairingLauncher(result: PairingSessionLaunchResult(
+    manifestJSON: pairingManifestJSON(
+      secret: secret,
+      expiresAt: 1_900_000_000_000,
+      endpoint: "ws://192.168.1.44:48752"),
+    manifestPath: "/tmp/friday-pairing-lan.json"))
+  let vm = PairingProvisioningViewModel(launcher: launcher)
+
+  await vm.startPairingSession(exposureMode: .privateLan, nowMs: 1_780_000_000_000)
+
+  #expect(launcher.exposureModes == [.privateLan])
+  #expect(vm.state.mode == .ready)
+  #expect(vm.state.reason.contains("private-LAN"))
+  #expect(vm.state.projection?.transportLabels.contains("pairing") == true)
   #expect(vm.canRenderQRCode)
 }
 
@@ -107,18 +128,54 @@ import Testing
   #expect(FileManager.default.fileExists(atPath: result.manifestPath))
 }
 
+@MainActor
+@Test func opsScriptPairingLauncherPassesAutoLanOnlyForPrivateLanMode() async throws {
+  let temp = try temporaryDirectory()
+  defer { try? FileManager.default.removeItem(at: temp) }
+  let script = temp.appendingPathComponent("friday-start-pairing-session.sh")
+  let secret = "friday-pairing-script-lan-secret" // pragma: allowlist secret
+  let body = pairingManifestJSON(
+    secret: secret,
+    expiresAt: 1_900_000_000_000,
+    endpoint: "ws://192.168.1.44:48752")
+  try """
+    #!/bin/sh
+    set -eu
+    test "${FRIDAY_PAIRING_HOST:-}" = "auto-lan"
+    mkdir -p "$(dirname "$FRIDAY_PAIRING_QR_JSON_OUT")"
+    cat > "$FRIDAY_PAIRING_QR_JSON_OUT" <<'JSON'
+    \(body)
+    JSON
+    """.write(to: script, atomically: true, encoding: .utf8)
+  try FileManager.default.setAttributes(
+    [.posixPermissions: NSNumber(value: Int16(0o700))],
+    ofItemAtPath: script.path)
+
+  let launcher = OpsScriptPairingSessionLauncher(
+    scriptPath: script.path,
+    outputDirectory: temp.appendingPathComponent("out", isDirectory: true),
+    environment: [:],
+    timeoutSeconds: 2)
+  let result = try await launcher.startPairingSession(exposureMode: .privateLan)
+
+  #expect(result.manifestJSON.contains(secret))
+  #expect(FileManager.default.fileExists(atPath: result.manifestPath))
+}
+
 private final class FakePairingLauncher: PairingSessionLaunching {
   private let result: PairingSessionLaunchResult?
   private let error: PairingSessionLauncherError?
   private(set) var startCount = 0
+  private(set) var exposureModes: [PairingSessionExposureMode] = []
 
   init(result: PairingSessionLaunchResult? = nil, error: PairingSessionLauncherError? = nil) {
     self.result = result
     self.error = error
   }
 
-  func startPairingSession() async throws -> PairingSessionLaunchResult {
+  func startPairingSession(exposureMode: PairingSessionExposureMode) async throws -> PairingSessionLaunchResult {
     startCount += 1
+    exposureModes.append(exposureMode)
     if let error {
       throw error
     }
@@ -133,7 +190,11 @@ private func temporaryDirectory() throws -> URL {
   return url
 }
 
-private func pairingManifestJSON(secret: String, expiresAt: Int64) -> String {
+private func pairingManifestJSON(
+  secret: String,
+  expiresAt: Int64,
+  endpoint: String = "ws://127.0.0.1:48752"
+) -> String {
   """
   {
     "kind": "friday.pairing.qr.v1",
@@ -145,7 +206,7 @@ private func pairingManifestJSON(secret: String, expiresAt: Int64) -> String {
     "pairing_secret": "\(secret)",
     "display_name": "Friday Test Hub",
     "transport_hints": [
-      {"kind":"websocket","endpoint":"ws://127.0.0.1:48752","label":"loopback"}
+      {"kind":"websocket","endpoint":"\(endpoint)","label":"pairing"}
     ],
     "expires_at": \(expiresAt),
     "capabilities_hint": ["read", "write"]


### PR DESCRIPTION
## Summary
- add an explicit private-LAN pairing launch mode beside the existing local loopback launch
- pass FRIDAY_PAIRING_HOST=auto-lan only when the user chooses the LAN QR path
- keep the default launch loopback-only and continue surfacing pairing material as redacted truth

## Verification
- swift test --package-path apps/macos/FridayHubConsole --filter PairingProvisioningViewModelTests
- swift build --package-path apps/macos/FridayHubConsole
- git diff --check
- detect-secrets-hook --baseline .secrets.baseline apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/PairingProvisioningViewModel.swift apps/macos/FridayHubConsole/Sources/FridayHubConsole/PairingProvisioningScreen.swift apps/macos/FridayHubConsole/Tests/FridayHubConsoleCoreTests/PairingProvisioningViewModelTests.swift

Truth: T3 QR/provisioning surface improvement only. This does not mint trust_grant/context_passport, does not read operator signing keys, and does not default-enable LAN exposure.