### PR TITLE
Add iOS share intake surface

### DIFF
--- a/apps/friday-ios/Info.plist
+++ b/apps/friday-ios/Info.plist
@@ -12,6 +12,17 @@
     <string>6.0</string>
     <key>CFBundleName</key>
     <string>FridayShell</string>
+    <key>CFBundleURLTypes</key>
+    <array>
+        <dict>
+            <key>CFBundleURLName</key>
+            <string>com.friday.shell.share</string>
+            <key>CFBundleURLSchemes</key>
+            <array>
+                <string>friday</string>
+            </array>
+        </dict>
+    </array>
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleShortVersionString</key>

--- a/apps/friday-ios/Sources/FridayMobileShell/CommandSheet.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/CommandSheet.swift
@@ -10,6 +10,7 @@ enum MobileDestination: String, CaseIterable, Identifiable {
   case home
   case missions
   case session
+  case shareIntake
   case needsMe
   case memory
   case platform
@@ -25,6 +26,7 @@ enum MobileDestination: String, CaseIterable, Identifiable {
     case .home: return "Friday Home"
     case .missions: return "Missions"
     case .session: return "Session"
+    case .shareIntake: return "Share Intake"
     case .needsMe: return "Needs Me"
     case .memory: return "Memory"
     case .platform: return "Platform"
@@ -40,6 +42,7 @@ enum MobileDestination: String, CaseIterable, Identifiable {
     case .home: return "house"
     case .missions: return "list.bullet.rectangle"
     case .session: return "rectangle.connected.to.line.below"
+    case .shareIntake: return "square.and.arrow.down"
     case .needsMe: return "person.crop.circle.badge.exclamationmark"
     case .memory: return "brain.head.profile"
     case .platform: return "square.grid.2x2"

--- a/apps/friday-ios/Sources/FridayMobileShell/FridayApp.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayApp.swift
@@ -225,6 +225,7 @@ final class FridaySession: ObservableObject {
 struct RootView: View {
   @StateObject private var homeVM: HomeViewModel
   @StateObject private var sessionContinuationVM: SessionContinuationViewModel
+  @StateObject private var shareIntakeVM: ShareIntakeViewModel
   private let session: FridaySession
   @State private var destination: MobileDestination = .home
   @State private var commandOpen = false
@@ -242,6 +243,7 @@ struct RootView: View {
       writeClient: session.writeClient,
       signer: session.signer,
       runControlEnabled: session.runControlEnabled))
+    _shareIntakeVM = StateObject(wrappedValue: ShareIntakeViewModel(client: session.missionClient))
   }
 
   var body: some View {
@@ -252,6 +254,8 @@ struct RootView: View {
           FridayHomeScreen(viewModel: homeVM)
         case .session:
           FridaySessionDetailScreen(homeViewModel: homeVM, viewModel: sessionContinuationVM)
+        case .shareIntake:
+          FridayShareIntakeScreen(viewModel: shareIntakeVM)
         case .missions, .needsMe, .memory, .platform, .activity, .workflows, .onboarding,
              .settings:
           FridayProjectionScreen(destination: destination, viewModel: homeVM)
@@ -299,12 +303,26 @@ struct RootView: View {
     .sheet(isPresented: $commandOpen) {
       CommandSheet(destination: $destination, isOpen: $commandOpen)
     }
+    .onOpenURL { url in
+      applyShareURL(url)
+    }
     .task {
       // Initial read on launch (dark server ⇒ honest-unavailable).
       if case .idle = homeVM.state {
         await homeVM.refresh()
       }
     }
+  }
+
+  private func applyShareURL(_ url: URL) {
+    guard url.scheme == "friday", url.host == "share" else { return }
+    let components = URLComponents(url: url, resolvingAgainstBaseURL: false)
+    let text = components?.queryItems?.first(where: { $0.name == "text" })?.value
+    let rawURL = components?.queryItems?.first(where: { $0.name == "url" })?.value
+    shareIntakeVM.applyIncomingShare(
+      text: text,
+      url: rawURL.flatMap(URL.init(string:)))
+    destination = .shareIntake
   }
 }
 

--- a/apps/friday-ios/Sources/FridayMobileShell/FridayProjectionScreens.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayProjectionScreens.swift
@@ -14,7 +14,7 @@ private enum ProjectionSurface {
 
   init?(_ destination: MobileDestination) {
     switch destination {
-    case .home, .session:
+    case .home, .session, .shareIntake:
       return nil
     case .missions:
       self = .missions

--- a/apps/friday-ios/Sources/FridayMobileShell/FridayShareIntakeScreen.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayShareIntakeScreen.swift
@@ -1,0 +1,135 @@
+import FridayMobileShellCore
+import SwiftUI
+
+struct FridayShareIntakeScreen: View {
+  @ObservedObject var viewModel: ShareIntakeViewModel
+
+  var body: some View {
+    ScrollView {
+      VStack(spacing: 14) {
+        GlassPanel {
+          VStack(alignment: .leading, spacing: 12) {
+            Label("Shared Item", systemImage: "square.and.arrow.down")
+              .font(.headline)
+              .foregroundStyle(MobileTheme.textPrimary)
+
+            TextField("https://...", text: $viewModel.sharedURL)
+              .textInputAutocapitalization(.never)
+              .autocorrectionDisabled()
+              .keyboardType(.URL)
+              .padding(12)
+              .background(
+                RoundedRectangle(cornerRadius: 12, style: .continuous)
+                  .fill(Color.black.opacity(0.05)))
+              .accessibilityLabel("Shared URL")
+              .accessibilityIdentifier("friday.share.url")
+
+            TextEditor(text: $viewModel.sharedText)
+              .frame(minHeight: 150)
+              .padding(8)
+              .scrollContentBackground(.hidden)
+              .background(
+                RoundedRectangle(cornerRadius: 12, style: .continuous)
+                  .fill(Color.black.opacity(0.05)))
+              .accessibilityLabel("Shared text")
+              .accessibilityIdentifier("friday.share.text")
+
+            Button {
+              Task { await viewModel.submit() }
+            } label: {
+              Label("Send to Friday", systemImage: "paperplane.fill")
+                .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.borderedProminent)
+            .tint(MobileTheme.cyan)
+            .disabled(!canSubmit)
+            .accessibilityIdentifier("friday.share.submit")
+          }
+        }
+
+        phaseCard
+      }
+      .padding(16)
+    }
+    .background(MobileTheme.backgroundWarmOffWhite.ignoresSafeArea())
+  }
+
+  private var canSubmit: Bool {
+    !viewModel.phase.isBusy
+      && (!viewModel.sharedText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        || !viewModel.sharedURL.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+  }
+
+  @ViewBuilder private var phaseCard: some View {
+    switch viewModel.phase {
+    case .idle:
+      EmptyView()
+    case .submitting:
+      GlassPanel {
+        HStack(spacing: 8) {
+          ProgressView()
+          Text("Creating mission...")
+            .font(.headline)
+            .foregroundStyle(MobileTheme.textPrimary)
+        }
+      }
+      .accessibilityIdentifier("friday.share.submitting")
+    case .submitted(let receipt):
+      GlassPanel {
+        VStack(alignment: .leading, spacing: 10) {
+          Label("Ready", systemImage: "checkmark.seal.fill")
+            .font(.headline)
+            .foregroundStyle(MobileTheme.textPrimary)
+          RefPill(label: "mission_id", ref: receipt.missionId)
+          if let workItemId = receipt.workItemId {
+            RefPill(label: "work_item_id", ref: workItemId)
+          }
+          RefPill(label: "surface", ref: receipt.surfaceThreadId)
+          StatusChip(
+            text: receipt.createdOrReady ? "created_or_ready" : receipt.status,
+            bg: MobileTheme.chipDoneBG,
+            fg: MobileTheme.chipDoneFG)
+          Button("New share") { viewModel.reset() }
+            .font(.caption)
+            .foregroundStyle(MobileTheme.cyan)
+        }
+      }
+      .accessibilityIdentifier("friday.share.ready")
+    case .blocked(let reason):
+      messageCard(
+        title: "Needs Details",
+        systemImage: "questionmark.circle",
+        reason: reason,
+        tint: MobileTheme.coral,
+        identifier: "friday.share.blocked")
+    case .unavailable(let reason):
+      messageCard(
+        title: "Unavailable",
+        systemImage: "wifi.slash",
+        reason: reason,
+        tint: MobileTheme.coral,
+        identifier: "friday.share.unavailable")
+    }
+  }
+
+  private func messageCard(
+    title: String,
+    systemImage: String,
+    reason: String,
+    tint: Color,
+    identifier: String
+  ) -> some View {
+    GlassPanel {
+      VStack(alignment: .leading, spacing: 8) {
+        Label(title, systemImage: systemImage)
+          .font(.headline)
+          .foregroundStyle(tint)
+        Text(reason)
+          .font(.caption)
+          .foregroundStyle(MobileTheme.textSecondary)
+          .fixedSize(horizontal: false, vertical: true)
+      }
+    }
+    .accessibilityIdentifier(identifier)
+  }
+}

--- a/apps/friday-ios/Sources/FridayMobileShellCore/ShareIntakeViewModel.swift
+++ b/apps/friday-ios/Sources/FridayMobileShellCore/ShareIntakeViewModel.swift
@@ -1,0 +1,129 @@
+import Foundation
+import FridayRustClient
+
+public struct ShareIntakeReceipt: Sendable, Equatable {
+  public let missionId: String
+  public let workItemId: String?
+  public let surfaceThreadId: String
+  public let status: String
+  public let createdOrReady: Bool
+  public let clarificationQuestions: [String]
+}
+
+public enum ShareIntakePhase: Sendable, Equatable {
+  case idle
+  case submitting
+  case submitted(ShareIntakeReceipt)
+  case blocked(String)
+  case unavailable(String)
+
+  public var isBusy: Bool {
+    if case .submitting = self { return true }
+    return false
+  }
+}
+
+@MainActor
+public final class ShareIntakeViewModel: ObservableObject {
+  @Published public var sharedText: String
+  @Published public var sharedURL: String
+  @Published public private(set) var phase: ShareIntakePhase = .idle
+
+  private let client: (any FridayMissionSpineWriteClient)?
+  private let owner: String
+  private let newId: () -> String
+
+  public init(
+    client: (any FridayMissionSpineWriteClient)?,
+    owner: String = liveAgentRunOwnerPrincipal,
+    sharedText: String = "",
+    sharedURL: String = "",
+    newId: @escaping () -> String = { UUID().uuidString.lowercased().replacingOccurrences(of: "-", with: "") }
+  ) {
+    self.client = client
+    self.owner = owner
+    self.sharedText = sharedText
+    self.sharedURL = sharedURL
+    self.newId = newId
+  }
+
+  public func applyIncomingShare(text: String? = nil, url: URL? = nil) {
+    if let text {
+      sharedText = text
+    }
+    if let url {
+      sharedURL = url.absoluteString
+    }
+    phase = .idle
+  }
+
+  public func submit() async {
+    let intent = Self.intent(sharedText: sharedText, sharedURL: sharedURL)
+    guard !intent.isEmpty else {
+      phase = .blocked("Add shared text or a URL before submitting.")
+      return
+    }
+    guard let client else {
+      phase = .unavailable("Share Intake is unavailable - live mobile write is not enabled.")
+      return
+    }
+
+    phase = .submitting
+    do {
+      let result = try await client.submitMissionIntake(Self.request(
+        intent: intent,
+        owner: owner,
+        id: newId()))
+      switch result.status {
+      case "ready":
+        phase = .submitted(ShareIntakeReceipt(
+          missionId: result.missionId,
+          workItemId: result.workItemId,
+          surfaceThreadId: result.surfaceThreadId,
+          status: result.status,
+          createdOrReady: result.createdOrReady,
+          clarificationQuestions: result.clarificationQuestions))
+      case "needs_clarification":
+        let questions = result.clarificationQuestions.joined(separator: " ")
+        phase = .blocked(questions.isEmpty ? "Friday needs more detail before creating this mission." : questions)
+      default:
+        let blockers = result.blockers.joined(separator: " ")
+        phase = .blocked(blockers.isEmpty ? "Friday could not create this shared mission." : blockers)
+      }
+    } catch {
+      phase = .unavailable(FridayChatViewModel.dispatchReason(for: error))
+    }
+  }
+
+  public func reset() {
+    phase = .idle
+  }
+
+  static func intent(sharedText: String, sharedURL: String) -> String {
+    let text = sharedText.trimmingCharacters(in: .whitespacesAndNewlines)
+    let url = sharedURL.trimmingCharacters(in: .whitespacesAndNewlines)
+    var lines = ["Process this shared item for the owner."]
+    if !url.isEmpty {
+      lines.append("url: \(url)")
+    }
+    if !text.isEmpty {
+      lines.append("shared_text: \(text)")
+    }
+    return lines.count == 1 ? "" : lines.joined(separator: "\n")
+  }
+
+  static func request(intent: String, owner: String, id: String) -> MissionIntakeRequestWire {
+    MissionIntakeRequestWire(
+      fridayConversationId: "fconv_mobile_share_\(id)",
+      ownerPrincipal: owner,
+      surfaceThreadId: "surface-mobile-share-\(id)",
+      surfaceKind: "mobile",
+      deliveryRoute: "ios://friday-mobile/share/\(id)",
+      visibilityPolicy: "compact",
+      missionId: "mission-mobile-share-\(id)",
+      workItemId: "work-mobile-share-\(id)",
+      title: String(intent.prefix(72)),
+      intent: intent,
+      lane: "auto")
+  }
+}

--- a/apps/friday-ios/Tests/FridayMobileShellCoreTests/ShareIntakeViewModelTests.swift
+++ b/apps/friday-ios/Tests/FridayMobileShellCoreTests/ShareIntakeViewModelTests.swift
@@ -1,0 +1,125 @@
+import XCTest
+@testable import FridayMobileShellCore
+@testable import FridayRustClient
+
+@MainActor
+final class ShareIntakeViewModelTests: XCTestCase {
+  final class FakeMissionClient: FridayMissionSpineWriteClient, @unchecked Sendable {
+    var result: MissionIntakeResultWire
+    private(set) var requests: [MissionIntakeRequestWire] = []
+
+    init(result: MissionIntakeResultWire) {
+      self.result = result
+    }
+
+    func submitMissionIntake(_ request: MissionIntakeRequestWire) async throws -> MissionIntakeResultWire {
+      requests.append(request)
+      return result
+    }
+
+    func submitMemoryDecision(_ request: MemoryDecisionRequestWire) async throws -> MemoryDecisionResultWire {
+      MemoryDecisionResultWire(
+        memoryId: request.memoryId,
+        state: "unknown",
+        status: "blocked",
+        blocker: "unused",
+        recallable: false)
+    }
+
+    func submitRunOutcomeLearningDecision(
+      _ request: RunOutcomeLearningDecisionRequestWire
+    ) async throws -> RunOutcomeLearningDecisionResultWire {
+      RunOutcomeLearningDecisionResultWire(
+        candidateId: request.candidateId,
+        state: "unknown",
+        status: "blocked",
+        blocker: "unused")
+    }
+
+    func submitActivityMarkDone(_ request: ActivityMarkDoneRequestWire) async throws -> ActivityMarkDoneResultWire {
+      ActivityMarkDoneResultWire(
+        activityId: request.activityId,
+        state: "unknown",
+        status: "blocked",
+        blocker: "unused")
+    }
+  }
+
+  func testNoClientFailsClosedWithoutFakeMission() async {
+    let vm = ShareIntakeViewModel(client: nil, sharedText: "summarize this")
+    await vm.submit()
+
+    XCTAssertEqual(
+      vm.phase,
+      .unavailable("Share Intake is unavailable - live mobile write is not enabled."))
+  }
+
+  func testSubmitCreatesMobileShareMissionIntake() async throws {
+    let client = FakeMissionClient(result: MissionIntakeResultWire(
+      fridayConversationId: "fconv_mobile_share_fixed",
+      missionId: "mission-mobile-share-fixed",
+      workItemId: "work-mobile-share-fixed",
+      surfaceThreadId: "surface-mobile-share-fixed",
+      status: "ready",
+      createdOrReady: true))
+    let vm = ShareIntakeViewModel(
+      client: client,
+      sharedText: "Important note",
+      sharedURL: "https://example.com/a",
+      newId: { "fixed" })
+
+    await vm.submit()
+
+    XCTAssertEqual(client.requests.count, 1)
+    let request = try XCTUnwrap(client.requests.first)
+    XCTAssertEqual(request.fridayConversationId, "fconv_mobile_share_fixed")
+    XCTAssertEqual(request.ownerPrincipal, liveAgentRunOwnerPrincipal)
+    XCTAssertEqual(request.surfaceKind, "mobile")
+    XCTAssertEqual(request.deliveryRoute, "ios://friday-mobile/share/fixed")
+    XCTAssertEqual(request.visibilityPolicy, "compact")
+    XCTAssertEqual(request.missionId, "mission-mobile-share-fixed")
+    XCTAssertEqual(request.workItemId, "work-mobile-share-fixed")
+    XCTAssertEqual(request.lane, "auto")
+    XCTAssertFalse(request.includesSensitiveContext)
+    XCTAssertTrue(request.intent.contains("url: https://example.com/a"))
+    XCTAssertTrue(request.intent.contains("shared_text: Important note"))
+
+    XCTAssertEqual(vm.phase, .submitted(ShareIntakeReceipt(
+      missionId: "mission-mobile-share-fixed",
+      workItemId: "work-mobile-share-fixed",
+      surfaceThreadId: "surface-mobile-share-fixed",
+      status: "ready",
+      createdOrReady: true,
+      clarificationQuestions: [])))
+  }
+
+  func testClarificationDoesNotRenderAsSubmitted() async {
+    let client = FakeMissionClient(result: MissionIntakeResultWire(
+      fridayConversationId: "fconv",
+      missionId: "mission",
+      surfaceThreadId: "surface",
+      status: "needs_clarification",
+      createdOrReady: false,
+      clarificationQuestions: ["What should Friday do with this link?"]))
+    let vm = ShareIntakeViewModel(client: client, sharedURL: "https://example.com", newId: { "c" })
+
+    await vm.submit()
+
+    XCTAssertEqual(vm.phase, .blocked("What should Friday do with this link?"))
+  }
+
+  func testBlankInputDoesNotSubmit() async {
+    let client = FakeMissionClient(result: MissionIntakeResultWire(
+      fridayConversationId: "fconv",
+      missionId: "mission",
+      surfaceThreadId: "surface",
+      status: "ready",
+      createdOrReady: true))
+    let vm = ShareIntakeViewModel(client: client, sharedText: "   ", sharedURL: "\n")
+
+    await vm.submit()
+
+    XCTAssertTrue(client.requests.isEmpty)
+    XCTAssertEqual(vm.phase, .blocked("Add shared text or a URL before submitting."))
+  }
+}


### PR DESCRIPTION
## Summary
- add an iOS Share Intake command-sheet destination and friday://share deep-link handoff
- add a ShareIntakeViewModel that submits refs-only mobile mission-spine intake through the existing live write seam
- fail closed when live mobile write is unavailable, and preserve needs_clarification/blocked truth labels

## Verification
- swift test --package-path apps/friday-ios --filter ShareIntakeViewModelTests
- ./apps/friday-ios/build-sim.sh apps/friday-ios/.build-sim/share-intake.png
- git diff --check
- detect-secrets scan <touched files>

Truth: this is an in-app share intake/write entrypoint, not a system Share Extension or a claim that mobile live-write is flipped by default.