### PR TITLE
Surface chat route preference

### DIFF
--- a/apps/friday-ios/Sources/FridayMobileShell/FridayChatScreen.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayChatScreen.swift
@@ -1,5 +1,6 @@
 import FridayMobileShellCore
 import AVFoundation
+import FridayRustClient
 @preconcurrency import Speech
 import SwiftUI
 
@@ -20,6 +21,7 @@ struct FridayChatScreen: View {
   @StateObject private var voice = MobileVoiceController()
   /// Whether the S6 pause/approve/resume is enabled (the run-control flag). OFF ⇒ read-only.
   private let runControlEnabled: Bool
+  @State private var routePreference: MissionRoutePreference = .auto
 
   init(session: FridaySession) {
     self.runControlEnabled = session.runControlEnabled
@@ -155,6 +157,16 @@ struct FridayChatScreen: View {
 
   private var composer: some View {
     VStack(alignment: .leading, spacing: 6) {
+      Picker("Route", selection: $routePreference) {
+        ForEach(MissionRoutePreference.allCases) { preference in
+          Text(preference.title).tag(preference)
+        }
+      }
+      .pickerStyle(.segmented)
+      .disabled(viewModel.phase.isBusy || viewModel.phase.isAwaitingApproval)
+      .accessibilityLabel("Route preference")
+      .accessibilityIdentifier("friday.chat.route-preference")
+
       HStack(spacing: 10) {
         Button {
           voice.toggleRecording { transcript in
@@ -187,7 +199,7 @@ struct FridayChatScreen: View {
           voice.stopRecording()
           let task = draft
           draft = ""
-          Task { await viewModel.send(task) }
+          Task { await viewModel.send(task, routePreference: routePreference) }
         } label: {
           Image(systemName: "arrow.up.circle.fill")
             .font(.system(size: 30))

--- a/apps/friday-ios/Sources/FridayMobileShellCore/FridayChatViewModel.swift
+++ b/apps/friday-ios/Sources/FridayMobileShellCore/FridayChatViewModel.swift
@@ -315,12 +315,20 @@ public final class FridayChatViewModel: ObservableObject {
   /// to TIGHTEN the run; the grant/gate admission hints never reach the wire (the mutation is
   /// operator-gated downstream + at the resume).
   public func send(_ task: String, constraints: AgentRunConstraintsWire? = nil) async {
+    await send(task, routePreference: .auto, constraints: constraints)
+  }
+
+  public func send(
+    _ task: String,
+    routePreference: MissionRoutePreference,
+    constraints: AgentRunConstraintsWire? = nil
+  ) async {
     let trimmed = task.trimmingCharacters(in: .whitespacesAndNewlines)
     guard !trimmed.isEmpty else { return }
     appendHistory(role: "you", text: trimmed)
     phase = .dispatching(task: trimmed)
     if let missionClient {
-      await sendMission(trimmed, missionClient: missionClient)
+      await sendMission(trimmed, routePreference: routePreference, missionClient: missionClient)
       return
     }
     do {
@@ -349,6 +357,7 @@ public final class FridayChatViewModel: ObservableObject {
 
   private func sendMission(
     _ task: String,
+    routePreference: MissionRoutePreference,
     missionClient: any FridayMobileMissionDispatchingWriteClient
   ) async {
     do {
@@ -356,7 +365,8 @@ public final class FridayChatViewModel: ObservableObject {
         intent: task,
         owner: liveAgentRunOwnerPrincipal,
         idFactory: newId,
-        missionIdPrefix: missionIdPrefix)
+        missionIdPrefix: missionIdPrefix,
+        routePreference: routePreference)
       let result = try await missionClient.submitMissionIntake(request)
       guard result.status == "ready", let workItemId = result.workItemId else {
         phase = .unavailable(reason: "Mission intake not ready — \(result.status)")
@@ -593,7 +603,8 @@ public final class FridayChatViewModel: ObservableObject {
     intent: String,
     owner: String,
     idFactory: () -> String,
-    missionIdPrefix: String = "mission-mobile-"
+    missionIdPrefix: String = "mission-mobile-",
+    routePreference: MissionRoutePreference = .auto
   ) -> MissionIntakeRequestWire {
     let id = idFactory()
     return MissionIntakeRequestWire(
@@ -607,7 +618,8 @@ public final class FridayChatViewModel: ObservableObject {
       workItemId: "work-mobile-\(id)",
       title: String(intent.prefix(72)),
       intent: intent,
-      lane: "auto")
+      lane: routePreference.lane,
+      targetProviderOrAgent: routePreference.targetProviderOrAgent)
   }
 
   private static let claudeFollowUpTaskHeader =

--- a/apps/friday-ios/Tests/FridayMobileShellCoreTests/FridayChatViewModelTests.swift
+++ b/apps/friday-ios/Tests/FridayMobileShellCoreTests/FridayChatViewModelTests.swift
@@ -332,6 +332,16 @@ final class FridayChatViewModelTests: XCTestCase {
     XCTAssertNil(request.targetProviderOrAgent)
   }
 
+  func testBuildMissionIntakeRequest_carriesRoutePreference() {
+    let request = FridayChatViewModel.buildMissionIntakeRequest(
+      intent: "use Claude for this synthesis",
+      owner: "admin-001",
+      idFactory: { "fixed" },
+      routePreference: .claude)
+    XCTAssertEqual(request.lane, "claude")
+    XCTAssertEqual(request.targetProviderOrAgent, "claude")
+  }
+
   func testBuildMissionIntakeRequest_acceptsSharedMissionPrefixForUiProofCapture() {
     let request = FridayChatViewModel.buildMissionIntakeRequest(
       intent: "route through Codex first and Claude follow-up",
@@ -373,9 +383,10 @@ final class FridayChatViewModelTests: XCTestCase {
       readClient: read,
       newId: { "fixed" })
 
-    await vm.send("route through Codex first and Claude follow-up")
+    await vm.send("route through Codex first and Claude follow-up", routePreference: .codex)
 
-    XCTAssertEqual(mission.submittedIntakes.map(\.lane), ["auto"])
+    XCTAssertEqual(mission.submittedIntakes.map(\.lane), ["codex"])
+    XCTAssertEqual(mission.submittedIntakes.first?.targetProviderOrAgent, "codex")
     XCTAssertEqual(mission.submittedIntakes.map(\.surfaceKind), ["mobile"])
     XCTAssertEqual(mission.missionContexts.map(\.workItemId), [
       "work-mobile-fixed",

--- a/apps/macos/FridayHubConsole/Sources/FridayHubConsole/DesktopChatScreen.swift
+++ b/apps/macos/FridayHubConsole/Sources/FridayHubConsole/DesktopChatScreen.swift
@@ -7,6 +7,7 @@ struct DesktopChatScreen: View {
   @ObservedObject var viewModel: OperationsOverviewViewModel
   @StateObject private var voice = DesktopVoiceController()
   @State private var draft = ""
+  @State private var routePreference: MissionRoutePreference = .auto
   @State private var history: [DesktopChatMessage]
 
   private let historyStore: DesktopChatHistoryStore
@@ -481,6 +482,16 @@ struct DesktopChatScreen: View {
 
   private var composer: some View {
     VStack(alignment: .leading, spacing: 6) {
+      Picker("Route", selection: $routePreference) {
+        ForEach(MissionRoutePreference.allCases) { preference in
+          Text(preference.title).tag(preference)
+        }
+      }
+      .pickerStyle(.segmented)
+      .disabled(viewModel.intakeState.isSent)
+      .accessibilityLabel("Route preference")
+      .accessibilityIdentifier("friday.desktop.chat.route-preference")
+
       HStack(spacing: 10) {
         Button {
           voice.toggleRecording { transcript in
@@ -545,7 +556,7 @@ struct DesktopChatScreen: View {
     draft = ""
     append(.user(text))
     Task {
-      await viewModel.submitIntake(intent: text)
+      await viewModel.submitIntake(intent: text, routePreference: routePreference)
       append(DesktopChatMessage.from(viewModel.intakeState))
     }
   }

--- a/apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/OperationsOverviewViewModel.swift
+++ b/apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/OperationsOverviewViewModel.swift
@@ -1,6 +1,8 @@
 import Foundation
 import FridayRustClient
 
+public typealias MissionRoutePreference = FridayRustClient.MissionRoutePreference
+
 /// What the right-docked proof inspector is currently focused on.
 /// Each case carries only refs/labels — never a body to load.
 public enum InspectorSelection: Sendable, Equatable {
@@ -476,7 +478,10 @@ public final class OperationsOverviewViewModel: ObservableObject {
   ///  - `blocked`             ⇒ `.error` (the blockers),
   ///  - a transport/honest-unavailable throw ⇒ `.error` (the truth).
   /// On any SUCCESS path it then `await refresh()`s so the new Mission appears in the read projection.
-  public func submitIntake(intent: String) async {
+  public func submitIntake(
+    intent: String,
+    routePreference: MissionRoutePreference = .auto
+  ) async {
     let trimmed = intent.trimmingCharacters(in: .whitespacesAndNewlines)
     guard !trimmed.isEmpty else {
       intakeState = .error(reason: "Enter an intent before submitting.")
@@ -493,7 +498,8 @@ public final class OperationsOverviewViewModel: ObservableObject {
     chatReviewState = .idle
     let request = Self.buildIntakeRequest(
       intent: trimmed, owner: writeOwnerPrincipal, idFactory: newId,
-      missionIdPrefix: missionIdPrefix)
+      missionIdPrefix: missionIdPrefix,
+      routePreference: routePreference)
     do {
       let result = try await writeClient.submitMissionIntake(request)
       switch result.status {
@@ -823,7 +829,8 @@ public final class OperationsOverviewViewModel: ObservableObject {
   /// equal the server `--owner` (FIX-Q3b). The title is a short prefix of the intent.
   static func buildIntakeRequest(
     intent: String, owner: String, idFactory: () -> String,
-    missionIdPrefix: String = "mission-desktop-"
+    missionIdPrefix: String = "mission-desktop-",
+    routePreference: MissionRoutePreference = .auto
   ) -> MissionIntakeRequestWire {
     let title = String(intent.prefix(72))
     let id = idFactory()
@@ -838,7 +845,8 @@ public final class OperationsOverviewViewModel: ObservableObject {
       workItemId: "work-desktop-\(id)",
       title: title,
       intent: intent,
-      lane: "auto")
+      lane: routePreference.lane,
+      targetProviderOrAgent: routePreference.targetProviderOrAgent)
   }
 
   /// Map a write-client error to an honest unavailable reason (mirrors `reason(for:)`'s tone).

--- a/apps/macos/FridayHubConsole/Tests/FridayHubConsoleCoreTests/OperationsOverviewViewModelTests.swift
+++ b/apps/macos/FridayHubConsole/Tests/FridayHubConsoleCoreTests/OperationsOverviewViewModelTests.swift
@@ -1053,6 +1053,7 @@ func submitIntakeReadyRendersConfirmedAndWiresOwnerAdmin001() async {
   #expect(write.lastIntake?.ownerPrincipal == "admin-001")
   #expect(write.lastIntake?.surfaceKind == "desktop")
   #expect(write.lastIntake?.lane == "auto")
+  #expect(write.lastIntake?.targetProviderOrAgent == nil)
 }
 
 @Test
@@ -1068,6 +1069,19 @@ func buildIntakeRequestAcceptsSharedMissionPrefixForUiProofCapture() {
   #expect(request.workItemId == "work-desktop-ui_proof_fixed")
   #expect(request.surfaceKind == "desktop")
   #expect(request.deliveryRoute == "desktop://hub-console/operations/ui_proof_fixed")
+}
+
+@Test
+@MainActor
+func buildIntakeRequestCarriesRoutePreference() {
+  let request = OperationsOverviewViewModel.buildIntakeRequest(
+    intent: "use DeepSeek for the cheap first pass",
+    owner: "admin-001",
+    idFactory: { "fixed" },
+    routePreference: .deepseek)
+
+  #expect(request.lane == "deepseek")
+  #expect(request.targetProviderOrAgent == "deepseek")
 }
 
 @Test

--- a/apps/macos/FridayRustClient/Sources/FridayRustClient/WriteProtocol.swift
+++ b/apps/macos/FridayRustClient/Sources/FridayRustClient/WriteProtocol.swift
@@ -12,6 +12,40 @@ import Foundation
 /// path: the WRITE session AAD/challenge (`friday:execrun:ws:s-c:…`) and the agent-run dispatch +
 /// courier pause/resume + S6 approval relay flow (not a single read projection).
 
+public enum MissionRoutePreference: String, CaseIterable, Identifiable, Sendable, Equatable, Hashable {
+  case auto
+  case codex
+  case claude
+  case deepseek
+
+  public var id: String { rawValue }
+
+  public var title: String {
+    switch self {
+    case .auto: return "Auto"
+    case .codex: return "Codex"
+    case .claude: return "Claude"
+    case .deepseek: return "DeepSeek"
+    }
+  }
+
+  public var lane: String {
+    switch self {
+    case .auto: return "auto"
+    case .codex: return "codex"
+    case .claude: return "claude"
+    case .deepseek: return "deepseek"
+    }
+  }
+
+  public var targetProviderOrAgent: String? {
+    switch self {
+    case .auto: return nil
+    case .codex, .claude, .deepseek: return rawValue
+    }
+  }
+}
+
 // MARK: - AgentRunConstraintsWire (per-run restrictions — NEVER a grant)
 
 /// Per-run CONSTRAINTS carried on an `AgentRunRequest`. Mirrors


### PR DESCRIPTION
## Summary
- add a shared MissionRoutePreference for auto/Codex/Claude/DeepSeek mission intake routing hints
- surface route preference pickers in mobile and desktop chat composers
- carry the selected preference into refs-only mission-spine intake as lane/target_provider_or_agent while leaving server-side routing/admission in control

## Verification
- swift test --package-path apps/friday-ios --filter FridayChatViewModelTests
- swift test --package-path apps/macos/FridayHubConsole --filter OperationsOverviewViewModelTests
- swift build --package-path apps/macos/FridayHubConsole
- ./apps/friday-ios/build-sim.sh apps/friday-ios/.build-sim/chat-route-preference.png
- git diff --check
- detect-secrets scan <touched files>

Truth: this is a user route preference surfaced through existing mission intake fields; it does not bypass governance, force provider availability, or flip live defaults.