### PR TITLE
Add iOS push notification readiness surface

### DIFF
--- a/apps/friday-ios/Sources/FridayMobileShell/FridayProjectionScreens.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayProjectionScreens.swift
@@ -78,6 +78,19 @@ private enum ProjectionSurface {
 struct FridayProjectionScreen: View {
   let destination: MobileDestination
   @ObservedObject var viewModel: HomeViewModel
+  @StateObject private var pushNotifications: PushNotificationReadinessViewModel
+
+  @MainActor
+  init(
+    destination: MobileDestination,
+    viewModel: HomeViewModel,
+    pushNotifications: PushNotificationReadinessViewModel? = nil
+  ) {
+    self.destination = destination
+    self.viewModel = viewModel
+    _pushNotifications = StateObject(wrappedValue: pushNotifications
+      ?? PushNotificationReadinessViewModel(authorizer: SystemPushNotificationAuthorizer()))
+  }
 
   var body: some View {
     let surface = ProjectionSurface(destination)
@@ -577,6 +590,7 @@ struct FridayProjectionScreen: View {
     }
   }
 
+  @ViewBuilder
   private func settingsCard(_ projection: HomeProjection) -> some View {
     GlassPanel {
       VStack(alignment: .leading, spacing: MobileTheme.rowSpacing) {
@@ -605,6 +619,72 @@ struct FridayProjectionScreen: View {
         }
       }
     }
+    pushNotificationCard()
+  }
+
+  @ViewBuilder
+  private func pushNotificationCard() -> some View {
+    GlassPanel {
+      VStack(alignment: .leading, spacing: MobileTheme.rowSpacing) {
+        cardHeader("Push Notifications", count: nil)
+        switch pushNotifications.state {
+        case .idle:
+          readinessRow(title: "Permission", value: "not checked", healthy: false)
+        case .loading:
+          HStack(spacing: 12) {
+            ProgressView()
+            Text("Checking notification permission")
+              .font(.caption)
+              .foregroundStyle(MobileTheme.textSecondary)
+          }
+        case let .loaded(readiness):
+          HStack(spacing: 6) {
+            statusChip(readiness.settings.authorizationStatus.rawValue)
+            statusChip(readiness.truthLabel)
+          }
+          readinessRow(
+            title: "Local delivery",
+            value: readiness.localNotificationUsable ? "permission usable" : readiness.summary,
+            healthy: readiness.localNotificationUsable)
+          readinessRow(
+            title: "Remote APNs",
+            value: readiness.remoteDeliveryConfigured ? "configured" : "not configured in this build",
+            healthy: readiness.remoteDeliveryConfigured)
+          HStack(spacing: 6) {
+            statusChip(readiness.settings.alertSettingEnabled ? "alerts on" : "alerts off")
+            statusChip(readiness.settings.badgeSettingEnabled ? "badges on" : "badges off")
+            statusChip(readiness.settings.soundSettingEnabled ? "sounds on" : "sounds off")
+          }
+        case let .unavailable(reason):
+          readinessRow(title: "Permission", value: reason, healthy: false)
+        }
+        HStack(spacing: 8) {
+          Button {
+            Task { await pushNotifications.refresh() }
+          } label: {
+            Label("Refresh", systemImage: "arrow.clockwise")
+          }
+          .disabled(pushNotifications.state == .loading)
+
+          if pushNotifications.state.readiness?.canRequestPermission != false {
+            Button {
+              Task { await pushNotifications.requestPermission() }
+            } label: {
+              Label("Allow", systemImage: "bell.badge")
+            }
+            .buttonStyle(.borderedProminent)
+            .tint(MobileTheme.cyan)
+            .disabled(pushNotifications.state == .loading)
+          }
+        }
+      }
+    }
+    .task {
+      if pushNotifications.state == .idle {
+        await pushNotifications.refresh()
+      }
+    }
+    .accessibilityIdentifier("friday.settings.push-notifications-card")
   }
 
   private func workItemRow(_ item: HomeWorkItem) -> some View {

--- a/apps/friday-ios/Sources/FridayMobileShell/PushNotificationAuthorizer.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/PushNotificationAuthorizer.swift
@@ -1,0 +1,38 @@
+import FridayMobileShellCore
+import UserNotifications
+
+struct SystemPushNotificationAuthorizer: MobilePushNotificationAuthorizing {
+  func currentSettings() async throws -> MobilePushNotificationSettings {
+    let settings = await UNUserNotificationCenter.current().notificationSettings()
+    return MobilePushNotificationSettings(
+      authorizationStatus: Self.mapAuthorization(settings.authorizationStatus),
+      alertSettingEnabled: Self.isEnabled(settings.alertSetting),
+      badgeSettingEnabled: Self.isEnabled(settings.badgeSetting),
+      soundSettingEnabled: Self.isEnabled(settings.soundSetting))
+  }
+
+  func requestUserAuthorization() async throws -> Bool {
+    try await UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .badge, .sound])
+  }
+
+  private static func mapAuthorization(_ status: UNAuthorizationStatus) -> MobilePushAuthorizationStatus {
+    switch status {
+    case .notDetermined:
+      return .notDetermined
+    case .denied:
+      return .denied
+    case .authorized:
+      return .authorized
+    case .provisional:
+      return .provisional
+    case .ephemeral:
+      return .ephemeral
+    @unknown default:
+      return .unknown
+    }
+  }
+
+  private static func isEnabled(_ setting: UNNotificationSetting) -> Bool {
+    setting == .enabled
+  }
+}

--- a/apps/friday-ios/Sources/FridayMobileShellCore/PushNotificationReadinessViewModel.swift
+++ b/apps/friday-ios/Sources/FridayMobileShellCore/PushNotificationReadinessViewModel.swift
@@ -1,0 +1,144 @@
+import Foundation
+
+public enum MobilePushAuthorizationStatus: String, Sendable, Equatable {
+  case notDetermined = "not_determined"
+  case denied
+  case authorized
+  case provisional
+  case ephemeral
+  case unknown
+}
+
+public struct MobilePushNotificationSettings: Sendable, Equatable {
+  public let authorizationStatus: MobilePushAuthorizationStatus
+  public let alertSettingEnabled: Bool
+  public let badgeSettingEnabled: Bool
+  public let soundSettingEnabled: Bool
+
+  public init(
+    authorizationStatus: MobilePushAuthorizationStatus,
+    alertSettingEnabled: Bool,
+    badgeSettingEnabled: Bool,
+    soundSettingEnabled: Bool
+  ) {
+    self.authorizationStatus = authorizationStatus
+    self.alertSettingEnabled = alertSettingEnabled
+    self.badgeSettingEnabled = badgeSettingEnabled
+    self.soundSettingEnabled = soundSettingEnabled
+  }
+}
+
+public protocol MobilePushNotificationAuthorizing: Sendable {
+  func currentSettings() async throws -> MobilePushNotificationSettings
+  func requestUserAuthorization() async throws -> Bool
+}
+
+public struct MobilePushNotificationReadiness: Sendable, Equatable {
+  public let settings: MobilePushNotificationSettings
+  public let remoteDeliveryConfigured: Bool
+  public let truthLabel: String
+
+  public init(
+    settings: MobilePushNotificationSettings,
+    remoteDeliveryConfigured: Bool = false,
+    truthLabel: String = "mobile_push_permission_local_only"
+  ) {
+    self.settings = settings
+    self.remoteDeliveryConfigured = remoteDeliveryConfigured
+    self.truthLabel = truthLabel
+  }
+
+  public var canRequestPermission: Bool {
+    settings.authorizationStatus == .notDetermined
+  }
+
+  public var localNotificationUsable: Bool {
+    switch settings.authorizationStatus {
+    case .authorized, .provisional, .ephemeral:
+      return settings.alertSettingEnabled || settings.badgeSettingEnabled || settings.soundSettingEnabled
+    case .notDetermined, .denied, .unknown:
+      return false
+    }
+  }
+
+  public var remotePushReady: Bool {
+    localNotificationUsable && remoteDeliveryConfigured
+  }
+
+  public var summary: String {
+    if remotePushReady {
+      return "Remote push is configured and notification permission is usable."
+    }
+    if localNotificationUsable {
+      return "Notification permission is usable; remote APNs delivery is not configured in this build."
+    }
+    switch settings.authorizationStatus {
+    case .notDetermined:
+      return "Notification permission has not been requested."
+    case .denied:
+      return "Notification permission is denied in iOS Settings."
+    case .unknown:
+      return "Notification permission state is unavailable."
+    case .authorized, .provisional, .ephemeral:
+      return "Notification permission exists, but alert, badge, and sound delivery are disabled."
+    }
+  }
+}
+
+public enum MobilePushNotificationReadinessState: Sendable, Equatable {
+  case idle
+  case loading
+  case loaded(MobilePushNotificationReadiness)
+  case unavailable(String)
+
+  public var readiness: MobilePushNotificationReadiness? {
+    if case let .loaded(readiness) = self { return readiness }
+    return nil
+  }
+}
+
+@MainActor
+public final class PushNotificationReadinessViewModel: ObservableObject {
+  @Published public private(set) var state: MobilePushNotificationReadinessState = .idle
+
+  private let authorizer: any MobilePushNotificationAuthorizing
+  private let remoteDeliveryConfigured: Bool
+  private let truthLabel: String
+
+  public init(
+    authorizer: any MobilePushNotificationAuthorizing,
+    remoteDeliveryConfigured: Bool = false,
+    truthLabel: String = "mobile_push_permission_local_only"
+  ) {
+    self.authorizer = authorizer
+    self.remoteDeliveryConfigured = remoteDeliveryConfigured
+    self.truthLabel = truthLabel
+  }
+
+  public func refresh() async {
+    state = .loading
+    do {
+      let settings = try await authorizer.currentSettings()
+      state = .loaded(MobilePushNotificationReadiness(
+        settings: settings,
+        remoteDeliveryConfigured: remoteDeliveryConfigured,
+        truthLabel: truthLabel))
+    } catch {
+      state = .unavailable("\(error)")
+    }
+  }
+
+  public func requestPermission() async {
+    state = .loading
+    do {
+      _ = try await authorizer.requestUserAuthorization()
+      let settings = try await authorizer.currentSettings()
+      state = .loaded(MobilePushNotificationReadiness(
+        settings: settings,
+        remoteDeliveryConfigured: remoteDeliveryConfigured,
+        truthLabel: truthLabel))
+    } catch {
+      state = .unavailable("\(error)")
+    }
+  }
+}

--- a/apps/friday-ios/Tests/FridayMobileShellCoreTests/PushNotificationReadinessViewModelTests.swift
+++ b/apps/friday-ios/Tests/FridayMobileShellCoreTests/PushNotificationReadinessViewModelTests.swift
@@ -1,0 +1,75 @@
+import Testing
+@testable import FridayMobileShellCore
+
+@Test
+func pushReadinessDoesNotTreatLocalPermissionAsRemoteDelivery() {
+  let readiness = MobilePushNotificationReadiness(settings: MobilePushNotificationSettings(
+    authorizationStatus: .authorized,
+    alertSettingEnabled: true,
+    badgeSettingEnabled: true,
+    soundSettingEnabled: false))
+
+  #expect(readiness.localNotificationUsable)
+  #expect(!readiness.remotePushReady)
+  #expect(readiness.truthLabel == "mobile_push_permission_local_only")
+  #expect(readiness.summary.contains("remote APNs delivery is not configured"))
+}
+
+@Test
+func pushReadinessCanRequestOnlyBeforeSystemDecision() {
+  #expect(MobilePushNotificationReadiness(settings: MobilePushNotificationSettings(
+    authorizationStatus: .notDetermined,
+    alertSettingEnabled: false,
+    badgeSettingEnabled: false,
+    soundSettingEnabled: false)).canRequestPermission)
+
+  #expect(!MobilePushNotificationReadiness(settings: MobilePushNotificationSettings(
+    authorizationStatus: .denied,
+    alertSettingEnabled: false,
+    badgeSettingEnabled: false,
+    soundSettingEnabled: false)).canRequestPermission)
+}
+
+@MainActor
+@Test
+func pushReadinessViewModelRefreshesAndRequestsPermission() async {
+  let authorizer = FakePushAuthorizer(settings: MobilePushNotificationSettings(
+    authorizationStatus: .notDetermined,
+    alertSettingEnabled: false,
+    badgeSettingEnabled: false,
+    soundSettingEnabled: false))
+  let viewModel = PushNotificationReadinessViewModel(authorizer: authorizer)
+
+  await viewModel.refresh()
+  #expect(viewModel.state.readiness?.settings.authorizationStatus == .notDetermined)
+  #expect(viewModel.state.readiness?.canRequestPermission == true)
+
+  await viewModel.requestPermission()
+  #expect(authorizer.requestCount == 1)
+  #expect(viewModel.state.readiness?.settings.authorizationStatus == .authorized)
+  #expect(viewModel.state.readiness?.localNotificationUsable == true)
+  #expect(viewModel.state.readiness?.remotePushReady == false)
+}
+
+private final class FakePushAuthorizer: MobilePushNotificationAuthorizing, @unchecked Sendable {
+  private(set) var requestCount = 0
+  private var settings: MobilePushNotificationSettings
+
+  init(settings: MobilePushNotificationSettings) {
+    self.settings = settings
+  }
+
+  func currentSettings() async throws -> MobilePushNotificationSettings {
+    settings
+  }
+
+  func requestUserAuthorization() async throws -> Bool {
+    requestCount += 1
+    settings = MobilePushNotificationSettings(
+      authorizationStatus: .authorized,
+      alertSettingEnabled: true,
+      badgeSettingEnabled: true,
+      soundSettingEnabled: true)
+    return true
+  }
+}


### PR DESCRIPTION
## Summary
- add a mobile push notification readiness view model with explicit local-permission vs remote-APNs truth separation
- surface push permission status and Allow/Refresh controls in iOS Settings
- add tests proving local notification permission does not imply remote push delivery

## Truth labels
- T2 push readiness only: this does not configure APNs, register a device token, or prove remote push delivery
- default remains honest: remote delivery is labeled not configured unless a future governed backend path sets it

## Verification
- swift test --package-path apps/friday-ios --filter PushNotificationReadinessViewModelTests
- ./apps/friday-ios/build-sim.sh apps/friday-ios/.build-sim/push-readiness-rebased.png
- git diff --check origin/main...HEAD
- detect-secrets scan touched files