### PR TITLE
Add client work-item recovery actions

### DIFF
--- a/apps/friday-ios/Sources/FridayMobileShell/FridayProjectionScreens.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayProjectionScreens.swift
@@ -688,7 +688,8 @@ struct FridayProjectionScreen: View {
   }
 
   private func workItemRow(_ item: HomeWorkItem) -> some View {
-    VStack(alignment: .leading, spacing: 6) {
+    let recoveryState = viewModel.workItemStatusStates[item.id]
+    return VStack(alignment: .leading, spacing: 6) {
       HStack {
         Text(item.title)
           .font(.system(size: 13, weight: .medium))
@@ -711,14 +712,31 @@ struct FridayProjectionScreen: View {
           .fixedSize(horizontal: false, vertical: true)
       }
       if item.canRetry || item.canCancel {
-        HStack(spacing: 6) {
+        HStack(spacing: 8) {
           if item.canRetry {
-            statusChip("retry available")
+            Button {
+              Task { await viewModel.retryWorkItem(item) }
+            } label: {
+              Image(systemName: "arrow.clockwise")
+                .frame(width: 26, height: 26)
+            }
+            .buttonStyle(.bordered)
+            .disabled(candidateDecisionControlsDisabled(recoveryState))
+            .accessibilityLabel("Retry WorkItem")
           }
           if item.canCancel {
-            statusChip("cancel available")
+            Button {
+              Task { await viewModel.cancelWorkItem(item) }
+            } label: {
+              Image(systemName: "stop.circle")
+                .frame(width: 26, height: 26)
+            }
+            .buttonStyle(.bordered)
+            .disabled(candidateDecisionControlsDisabled(recoveryState))
+            .accessibilityLabel("Cancel WorkItem")
           }
         }
+        candidateDecisionStateView(recoveryState, pendingText: "Updating WorkItem...")
       }
       if let proofRef = item.proofRef {
         RefPill(label: "proofRef", ref: proofRef)

--- a/apps/friday-ios/Sources/FridayMobileShellCore/HomeViewModel.swift
+++ b/apps/friday-ios/Sources/FridayMobileShellCore/HomeViewModel.swift
@@ -659,6 +659,7 @@ public final class HomeViewModel: ObservableObject {
   @Published public private(set) var memoryDecisionStates: [String: HomeLearningDecisionState] = [:]
   @Published public private(set) var runOutcomeLearningDecisionStates: [String: HomeLearningDecisionState] = [:]
   @Published public private(set) var activityMarkDoneStates: [String: HomeLearningDecisionState] = [:]
+  @Published public private(set) var workItemStatusStates: [String: HomeLearningDecisionState] = [:]
   @Published public private(set) var pairingPreflight: MobilePairingPreflight = .empty
   @Published public private(set) var pairingAttempt: MobilePairingAttempt = .idle
 
@@ -787,6 +788,48 @@ public final class HomeViewModel: ObservableObject {
       }
     } catch {
       activityMarkDoneStates[activityId] = .error(reason: Self.reason(for: error))
+    }
+  }
+
+  public func retryWorkItem(_ item: HomeWorkItem) async {
+    guard item.canRetry else {
+      workItemStatusStates[item.id] = .error(reason: "This WorkItem is not retryable.")
+      return
+    }
+    await submitWorkItemStatus(
+      workItemId: item.id,
+      targetStatus: "ready_to_dispatch",
+      reason: "operator retries WorkItem from mobile recovery surface")
+  }
+
+  public func cancelWorkItem(_ item: HomeWorkItem) async {
+    guard item.canCancel else {
+      workItemStatusStates[item.id] = .error(reason: "This WorkItem is not cancellable.")
+      return
+    }
+    await submitWorkItemStatus(
+      workItemId: item.id,
+      targetStatus: "cancelled",
+      reason: "operator cancels WorkItem from mobile recovery surface")
+  }
+
+  private func submitWorkItemStatus(workItemId: String, targetStatus: String, reason: String) async {
+    guard let writeClient else {
+      workItemStatusStates[workItemId] = .error(reason: "Write seam not configured.")
+      return
+    }
+    workItemStatusStates[workItemId] = .sent
+    do {
+      let result = try await writeClient.submitWorkItemStatus(WorkItemStatusRequestWire(
+        workItemId: workItemId,
+        targetStatus: targetStatus,
+        actorRef: "mobile:\(writeOwnerPrincipal)",
+        reason: reason))
+      workItemStatusStates[workItemId] = .confirmed(
+        summary: "\(result.status) · work_item_id=\(result.workItemId) · previous=\(result.previousStatus)")
+      await refresh()
+    } catch {
+      workItemStatusStates[workItemId] = .error(reason: Self.reason(for: error))
     }
   }
 

--- a/apps/friday-ios/Tests/FridayMobileShellCoreTests/FridayChatViewModelTests.swift
+++ b/apps/friday-ios/Tests/FridayMobileShellCoreTests/FridayChatViewModelTests.swift
@@ -153,6 +153,18 @@ final class FridayChatViewModelTests: XCTestCase {
         blocker: "unused")
     }
 
+    func submitWorkItemStatus(_ request: WorkItemStatusRequestWire) async throws -> WorkItemStatusResultWire {
+      WorkItemStatusResultWire(
+        workItemId: request.workItemId,
+        missionId: "unused",
+        previousStatus: "unknown",
+        status: "blocked",
+        actorRef: request.actorRef,
+        reason: request.reason,
+        proofReceiptCount: 0,
+        updatedAtMs: 0)
+    }
+
     func dispatchMissionBoundAgentRun(
       task: String,
       missionContext: MissionWorkItemContextWire,

--- a/apps/friday-ios/Tests/FridayMobileShellCoreTests/HomeViewModelTests.swift
+++ b/apps/friday-ios/Tests/FridayMobileShellCoreTests/HomeViewModelTests.swift
@@ -191,6 +191,7 @@ final class HomeViewModelTests: XCTestCase {
     private(set) var memoryRequests: [MemoryDecisionRequestWire] = []
     private(set) var learningRequests: [RunOutcomeLearningDecisionRequestWire] = []
     private(set) var activityMarkDoneRequests: [ActivityMarkDoneRequestWire] = []
+    private(set) var workItemStatusRequests: [WorkItemStatusRequestWire] = []
 
     init(
       learningScript: LearningScript? = nil,
@@ -233,6 +234,19 @@ final class HomeViewModelTests: XCTestCase {
       case .result(let result): return result
       case .fail(let error): throw error
       }
+    }
+
+    func submitWorkItemStatus(_ request: WorkItemStatusRequestWire) async throws -> WorkItemStatusResultWire {
+      workItemStatusRequests.append(request)
+      return WorkItemStatusResultWire(
+        workItemId: request.workItemId,
+        missionId: "unused",
+        previousStatus: "unknown",
+        status: request.targetStatus,
+        actorRef: request.actorRef,
+        reason: request.reason,
+        proofReceiptCount: request.proofReceipt == nil ? 0 : 1,
+        updatedAtMs: 0)
     }
   }
 
@@ -620,6 +634,48 @@ final class HomeViewModelTests: XCTestCase {
     XCTAssertEqual(
       vm.activityMarkDoneStates["missing-activity"],
       .error(reason: "Activity mark done blocked — unknown_activity"))
+  }
+
+  func testRetryWorkItemSendsLifecycleWriteAndRefreshes() async throws {
+    let read = FakeReadClient(.snapshot(try sampleSnapshot()))
+    let write = FakeMissionWriteClient()
+    let vm = HomeViewModel(client: read, writeClient: write, writeOwnerPrincipal: "owner-ios")
+    let item = try XCTUnwrap(HomeProjection(try sampleSnapshot()).workItems.last)
+
+    await vm.retryWorkItem(item)
+
+    XCTAssertEqual(write.workItemStatusRequests, [
+      WorkItemStatusRequestWire(
+        workItemId: "wi-2",
+        targetStatus: "ready_to_dispatch",
+        actorRef: "mobile:owner-ios",
+        reason: "operator retries WorkItem from mobile recovery surface"),
+    ])
+    XCTAssertEqual(read.fetchWorkbenchCount, 1)
+    XCTAssertEqual(
+      vm.workItemStatusStates["wi-2"],
+      .confirmed(summary: "ready_to_dispatch · work_item_id=wi-2 · previous=unknown"))
+  }
+
+  func testCancelWorkItemSendsLifecycleWriteAndRefreshes() async throws {
+    let read = FakeReadClient(.snapshot(try sampleSnapshot()))
+    let write = FakeMissionWriteClient()
+    let vm = HomeViewModel(client: read, writeClient: write, writeOwnerPrincipal: "owner-ios")
+    let item = try XCTUnwrap(HomeProjection(try sampleSnapshot()).workItems.last)
+
+    await vm.cancelWorkItem(item)
+
+    XCTAssertEqual(write.workItemStatusRequests, [
+      WorkItemStatusRequestWire(
+        workItemId: "wi-2",
+        targetStatus: "cancelled",
+        actorRef: "mobile:owner-ios",
+        reason: "operator cancels WorkItem from mobile recovery surface"),
+    ])
+    XCTAssertEqual(read.fetchWorkbenchCount, 1)
+    XCTAssertEqual(
+      vm.workItemStatusStates["wi-2"],
+      .confirmed(summary: "cancelled · work_item_id=wi-2 · previous=unknown"))
   }
 
   func testDecideMemoryConfirmRendersConfirmedAndRefreshes() async throws {

--- a/apps/friday-ios/Tests/FridayMobileShellCoreTests/ShareIntakeViewModelTests.swift
+++ b/apps/friday-ios/Tests/FridayMobileShellCoreTests/ShareIntakeViewModelTests.swift
@@ -43,6 +43,18 @@ final class ShareIntakeViewModelTests: XCTestCase {
         status: "blocked",
         blocker: "unused")
     }
+
+    func submitWorkItemStatus(_ request: WorkItemStatusRequestWire) async throws -> WorkItemStatusResultWire {
+      WorkItemStatusResultWire(
+        workItemId: request.workItemId,
+        missionId: "unused",
+        previousStatus: "unknown",
+        status: "blocked",
+        actorRef: request.actorRef,
+        reason: request.reason,
+        proofReceiptCount: 0,
+        updatedAtMs: 0)
+    }
   }
 
   func testNoClientFailsClosedWithoutFakeMission() async {

--- a/apps/macos/FridayHubConsole/Sources/FridayHubConsole/OperationsOverviewScreen.swift
+++ b/apps/macos/FridayHubConsole/Sources/FridayHubConsole/OperationsOverviewScreen.swift
@@ -374,7 +374,10 @@ struct OperationsOverviewScreen: View {
         ForEach(snapshot.workItems) { item in
           WorkItemRow(
             item: item,
-            isSelected: viewModel.selection == .workItem(id: item.id)
+            isSelected: viewModel.selection == .workItem(id: item.id),
+            recoveryState: viewModel.workItemStatusStates[item.id] ?? .ready,
+            onRetry: { Task { await viewModel.retryWorkItem(item) } },
+            onCancel: { Task { await viewModel.cancelWorkItem(item) } }
           ) {
             viewModel.select(.workItem(id: item.id))
           }
@@ -760,56 +763,93 @@ struct SelectableCard<Content: View>: View {
 struct WorkItemRow: View {
   let item: MissionWorkbenchWorkItem
   let isSelected: Bool
+  let recoveryState: WriteActionState
+  let onRetry: () -> Void
+  let onCancel: () -> Void
   let onSelect: () -> Void
 
   var body: some View {
-    Button(action: onSelect) {
-      VStack(alignment: .leading, spacing: 6) {
-        HStack {
-          Text(item.title)
-            .font(.system(size: 13, weight: .medium))
-            .foregroundStyle(HubTheme.textPrimary)
-          Spacer()
-          // `done` strictly from the projection's done field — provider_ack/linked
-          // items are explicitly NOT done.
-          if item.done {
-            StatusChip(text: "done", bg: HubTheme.chipDoneBG, fg: HubTheme.chipDoneFG)
-          } else {
-            StatusChip(text: "not done", bg: HubTheme.chipNeutralBG, fg: HubTheme.chipNeutralFG)
-          }
-        }
-        HStack(spacing: 6) {
-          item.state.chip
-          item.owner.chip
-          if item.recoveryKind != "none" {
-            StatusChip(text: item.recoveryKind, bg: HubTheme.chipNeutralBG, fg: HubTheme.chipNeutralFG)
-          }
-        }
-        if !item.blockingReason.isEmpty {
-          Text(item.blockingReason)
-            .font(.system(size: 10))
-            .foregroundStyle(HubTheme.textSecondary)
-            .fixedSize(horizontal: false, vertical: true)
-        }
-        if item.canRetry || item.canCancel {
-          HStack(spacing: 6) {
-            if item.canRetry {
-              StatusChip(text: "retry available", bg: HubTheme.chipWarnBG, fg: HubTheme.chipWarnFG)
+    VStack(alignment: .leading, spacing: 8) {
+      Button(action: onSelect) {
+        content
+          .frame(maxWidth: .infinity, alignment: .leading)
+      }
+      .buttonStyle(.plain)
+
+      if item.canRetry || item.canCancel {
+        HStack(spacing: 8) {
+          if item.canRetry {
+            Button(action: onRetry) {
+              Label("Retry", systemImage: "arrow.clockwise")
             }
-            if item.canCancel {
-              StatusChip(text: "cancel available", bg: HubTheme.chipNeutralBG, fg: HubTheme.chipNeutralFG)
+            .buttonStyle(.bordered)
+            .disabled(recoveryControlsDisabled)
+            .accessibilityLabel("Retry WorkItem")
+            .accessibilityIdentifier("friday.desktop.workItem.retry.\(item.id)")
+          }
+          if item.canCancel {
+            Button(action: onCancel) {
+              Label("Cancel", systemImage: "stop.circle")
             }
+            .buttonStyle(.bordered)
+            .disabled(recoveryControlsDisabled)
+            .accessibilityLabel("Cancel WorkItem")
+            .accessibilityIdentifier("friday.desktop.workItem.cancel.\(item.id)")
           }
         }
-        if let proof = item.proofRef {
-          RefPill(label: "proofRef", ref: proof)
+        WriteActionStateView(state: recoveryState, pendingText: "Updating WorkItem...")
+      }
+    }
+    .padding(10)
+    .background(rowBackground)
+  }
+
+  private var content: some View {
+    VStack(alignment: .leading, spacing: 6) {
+      HStack {
+        Text(item.title)
+          .font(.system(size: 13, weight: .medium))
+          .foregroundStyle(HubTheme.textPrimary)
+        Spacer()
+        // `done` strictly from the projection's done field — provider_ack/linked
+        // items are explicitly NOT done.
+        if item.done {
+          StatusChip(text: "done", bg: HubTheme.chipDoneBG, fg: HubTheme.chipDoneFG)
+        } else {
+          StatusChip(text: "not done", bg: HubTheme.chipNeutralBG, fg: HubTheme.chipNeutralFG)
         }
       }
-      .frame(maxWidth: .infinity, alignment: .leading)
-      .padding(10)
-      .background(rowBackground)
+      HStack(spacing: 6) {
+        item.state.chip
+        item.owner.chip
+        if item.recoveryKind != "none" {
+          StatusChip(text: item.recoveryKind, bg: HubTheme.chipNeutralBG, fg: HubTheme.chipNeutralFG)
+        }
+      }
+      if !item.blockingReason.isEmpty {
+        Text(item.blockingReason)
+          .font(.system(size: 10))
+          .foregroundStyle(HubTheme.textSecondary)
+          .fixedSize(horizontal: false, vertical: true)
+      }
+      if item.canRetry || item.canCancel {
+        HStack(spacing: 6) {
+          if item.canRetry {
+            StatusChip(text: "retry available", bg: HubTheme.chipWarnBG, fg: HubTheme.chipWarnFG)
+          }
+          if item.canCancel {
+            StatusChip(text: "cancel available", bg: HubTheme.chipNeutralBG, fg: HubTheme.chipNeutralFG)
+          }
+        }
+      }
+      if let proof = item.proofRef {
+        RefPill(label: "proofRef", ref: proof)
+      }
     }
-    .buttonStyle(.plain)
+  }
+
+  private var recoveryControlsDisabled: Bool {
+    recoveryState.isSent || recoveryState.isTerminal
   }
 
   private var rowBackground: some View {

--- a/apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/OperationsOverviewViewModel.swift
+++ b/apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/OperationsOverviewViewModel.swift
@@ -329,6 +329,8 @@ public enum WriteActionState: Sendable, Equatable {
 ///  - `decideMemory(...)`      — drive ONE owner confirm/reject of a memory candidate.
 ///  - `approve/reject/cancelNeedsMe...` — relay operator choices for a paused run; signing stays
 ///    external and the app never holds the operator key.
+///  - `retry/cancelWorkItem...` — advance ONE existing WorkItem lifecycle row through the Hub's
+///    owner-bound state machine.
 /// The write drivers are gated: with no `writeClient` (or an honest-unavailable one) they render the
 /// truth, never a fabricated confirm. No provider-admin / arbitrary-mutation method is exposed.
 @MainActor
@@ -347,6 +349,8 @@ public final class OperationsOverviewViewModel: ObservableObject {
   @Published public private(set) var approvalRelayStates: [String: WriteActionState] = [:]
   /// Per Activity / Needs-Me mark-done state, keyed by the Needs-Me item id.
   @Published public private(set) var activityMarkDoneStates: [String: WriteActionState] = [:]
+  /// Per WorkItem lifecycle recovery state, keyed by WorkItem id.
+  @Published public private(set) var workItemStatusStates: [String: WriteActionState] = [:]
   /// Structured refs for the latest desktop Chat turn. This avoids parsing status prose in the UI.
   @Published public private(set) var latestChatTurn: ChatTurnRefs?
   /// Refs-only Needs-Me rows for the latest Chat turn's runs.
@@ -732,6 +736,48 @@ public final class OperationsOverviewViewModel: ObservableObject {
       }
     } catch {
       activityMarkDoneStates[key] = .error(reason: Self.writeReason(for: error))
+    }
+  }
+
+  public func retryWorkItem(_ item: MissionWorkbenchWorkItem) async {
+    guard item.canRetry else {
+      workItemStatusStates[item.id] = .error(reason: "This WorkItem is not retryable.")
+      return
+    }
+    await submitWorkItemStatus(
+      workItemId: item.id,
+      targetStatus: "ready_to_dispatch",
+      reason: "operator retries WorkItem from desktop recovery surface")
+  }
+
+  public func cancelWorkItem(_ item: MissionWorkbenchWorkItem) async {
+    guard item.canCancel else {
+      workItemStatusStates[item.id] = .error(reason: "This WorkItem is not cancellable.")
+      return
+    }
+    await submitWorkItemStatus(
+      workItemId: item.id,
+      targetStatus: "cancelled",
+      reason: "operator cancels WorkItem from desktop recovery surface")
+  }
+
+  private func submitWorkItemStatus(workItemId: String, targetStatus: String, reason: String) async {
+    guard let writeClient else {
+      workItemStatusStates[workItemId] = .error(reason: "Write seam not configured.")
+      return
+    }
+    workItemStatusStates[workItemId] = .sent
+    do {
+      let result = try await writeClient.submitWorkItemStatus(WorkItemStatusRequestWire(
+        workItemId: workItemId,
+        targetStatus: targetStatus,
+        actorRef: "desktop:\(writeOwnerPrincipal)",
+        reason: reason))
+      workItemStatusStates[workItemId] = .confirmed(
+        summary: "\(result.status) · work_item_id=\(result.workItemId) · previous=\(result.previousStatus)")
+      await refresh()
+    } catch {
+      workItemStatusStates[workItemId] = .error(reason: Self.writeReason(for: error))
     }
   }
 

--- a/apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/RealWriteClientFactory.swift
+++ b/apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/RealWriteClientFactory.swift
@@ -150,6 +150,9 @@ struct HonestlyUnavailableWriteClient: FridayMissionSpineWriteClient, FridayMiss
   func submitActivityMarkDone(_ request: ActivityMarkDoneRequestWire) async throws -> ActivityMarkDoneResultWire {
     throw FridayWriteClientError.transport("live write client unavailable: \(reason)")
   }
+  func submitWorkItemStatus(_ request: WorkItemStatusRequestWire) async throws -> WorkItemStatusResultWire {
+    throw FridayWriteClientError.transport("live write client unavailable: \(reason)")
+  }
   func dispatchMissionBoundAgentRun(
     task: String,
     missionContext: MissionWorkItemContextWire,

--- a/apps/macos/FridayHubConsole/Tests/FridayHubConsoleCoreTests/OperationsOverviewViewModelTests.swift
+++ b/apps/macos/FridayHubConsole/Tests/FridayHubConsoleCoreTests/OperationsOverviewViewModelTests.swift
@@ -496,6 +496,7 @@ final class MockMissionSpineWriteClient: FridayMissionSpineWriteClient, FridayMi
   private var _lastDecision: MemoryDecisionRequestWire?
   private var _lastLearningDecision: RunOutcomeLearningDecisionRequestWire?
   private var _lastActivityMarkDone: ActivityMarkDoneRequestWire?
+  private var _lastWorkItemStatus: WorkItemStatusRequestWire?
   private var _lastMissionContext: MissionWorkItemContextWire?
   private var _lastMissionRunConstraints: AgentRunConstraintsWire?
   private var _lastResumeRunId: String?
@@ -512,6 +513,7 @@ final class MockMissionSpineWriteClient: FridayMissionSpineWriteClient, FridayMi
     lock.withLock { _lastLearningDecision }
   }
   var lastActivityMarkDone: ActivityMarkDoneRequestWire? { lock.withLock { _lastActivityMarkDone } }
+  var lastWorkItemStatus: WorkItemStatusRequestWire? { lock.withLock { _lastWorkItemStatus } }
   var lastMissionContext: MissionWorkItemContextWire? { lock.withLock { _lastMissionContext } }
   var lastMissionRunConstraints: AgentRunConstraintsWire? { lock.withLock { _lastMissionRunConstraints } }
   var lastResumeRunId: String? { lock.withLock { _lastResumeRunId } }
@@ -599,6 +601,22 @@ final class MockMissionSpineWriteClient: FridayMissionSpineWriteClient, FridayMi
     default:
       return ActivityMarkDoneResultWire(activityId: request.activityId, state: "done", status: "done")
     }
+  }
+
+  func submitWorkItemStatus(_ request: WorkItemStatusRequestWire) async throws -> WorkItemStatusResultWire {
+    lock.withLock { _lastWorkItemStatus = request }
+    if case .throwsTransport = behavior {
+      throw FridayWriteClientError.transport("connection refused (write server dark)")
+    }
+    return WorkItemStatusResultWire(
+      workItemId: request.workItemId,
+      missionId: "mission-\(request.workItemId)",
+      previousStatus: request.targetStatus == "ready_to_dispatch" ? "failed_retryable" : "ready_to_dispatch",
+      status: request.targetStatus,
+      actorRef: request.actorRef,
+      reason: request.reason,
+      proofReceiptCount: request.proofReceipt == nil ? 0 : 1,
+      updatedAtMs: 1_780_640_000_123)
   }
 
   func dispatchMissionBoundAgentRun(
@@ -1403,6 +1421,75 @@ func markNeedsMeItemDoneUsesRefIdAndRefreshesReview() async {
   }
   #expect(summary.contains("done"))
   #expect(summary.contains("activity-review-1"))
+}
+
+@Test
+@MainActor
+func retryWorkItemSendsLifecycleWriteAndRefreshes() async {
+  let write = MockMissionSpineWriteClient(behavior: .intakeReady)
+  let item = MissionWorkbenchWorkItem(
+    id: "work-stale-1",
+    title: "Retry stale provider turn",
+    state: .stale,
+    owner: .fridayOwned,
+    proofRef: nil,
+    done: false,
+    blockingReason: "failed retryable",
+    recoveryKind: "retryable",
+    canRetry: true,
+    canCancel: true)
+  let vm = OperationsOverviewViewModel(
+    client: MockReadClient(behavior: .loaded),
+    writeClient: write,
+    writeOwnerPrincipal: "owner-desktop")
+
+  await vm.retryWorkItem(item)
+
+  #expect(write.lastWorkItemStatus == WorkItemStatusRequestWire(
+    workItemId: "work-stale-1",
+    targetStatus: "ready_to_dispatch",
+    actorRef: "desktop:owner-desktop",
+    reason: "operator retries WorkItem from desktop recovery surface"))
+  guard case .confirmed(let summary, _, _) = vm.workItemStatusStates[item.id] else {
+    Issue.record("expected retry .confirmed, got \(String(describing: vm.workItemStatusStates[item.id]))")
+    return
+  }
+  #expect(summary.contains("ready_to_dispatch"))
+  #expect(summary.contains("previous=failed_retryable"))
+}
+
+@Test
+@MainActor
+func cancelWorkItemSendsLifecycleWriteAndRefreshes() async {
+  let write = MockMissionSpineWriteClient(behavior: .intakeReady)
+  let item = MissionWorkbenchWorkItem(
+    id: "work-inflight-1",
+    title: "Cancel in-flight provider turn",
+    state: .providerAck,
+    owner: .fridayOwned,
+    proofRef: nil,
+    done: false,
+    blockingReason: "provider acknowledged",
+    recoveryKind: "in_flight",
+    canRetry: false,
+    canCancel: true)
+  let vm = OperationsOverviewViewModel(
+    client: MockReadClient(behavior: .loaded),
+    writeClient: write,
+    writeOwnerPrincipal: "owner-desktop")
+
+  await vm.cancelWorkItem(item)
+
+  #expect(write.lastWorkItemStatus == WorkItemStatusRequestWire(
+    workItemId: "work-inflight-1",
+    targetStatus: "cancelled",
+    actorRef: "desktop:owner-desktop",
+    reason: "operator cancels WorkItem from desktop recovery surface"))
+  guard case .confirmed(let summary, _, _) = vm.workItemStatusStates[item.id] else {
+    Issue.record("expected cancel .confirmed, got \(String(describing: vm.workItemStatusStates[item.id]))")
+    return
+  }
+  #expect(summary.contains("cancelled"))
 }
 
 @Test

--- a/apps/macos/FridayRustClient/Sources/FridayRustClient/PairingClient.swift
+++ b/apps/macos/FridayRustClient/Sources/FridayRustClient/PairingClient.swift
@@ -164,6 +164,8 @@ private func pairingKind(_ message: FridayMessage) -> String {
   case .runOutcomeLearningDecisionResult: return "RunOutcomeLearningDecisionResult"
   case .activityMarkDoneRequest: return "ActivityMarkDoneRequest"
   case .activityMarkDoneResult: return "ActivityMarkDoneResult"
+  case .workItemStatusRequest: return "WorkItemStatusRequest"
+  case .workItemStatusResult: return "WorkItemStatusResult"
   case .runAnswerBodyRequest: return "RunAnswerBodyRequest"
   case .runAnswerBodySnapshot: return "RunAnswerBodySnapshot"
   }

--- a/apps/macos/FridayRustClient/Sources/FridayRustClient/Protocol.swift
+++ b/apps/macos/FridayRustClient/Sources/FridayRustClient/Protocol.swift
@@ -538,6 +538,10 @@ public enum FridayMessage: Equatable {
   case activityMarkDoneRequest(ActivityMarkDoneRequestWire)
   /// hub→trusted-peer: refs-only receipt for Activity / Needs-Me mark-done.
   case activityMarkDoneResult(ActivityMarkDoneResultWire)
+  /// trusted-peer→hub: advance ONE WorkItem lifecycle status through the Hub state machine.
+  case workItemStatusRequest(WorkItemStatusRequestWire)
+  /// hub→trusted-peer: refs-only receipt for a WorkItem lifecycle transition.
+  case workItemStatusResult(WorkItemStatusResultWire)
   /// client→read-server: owner-gated run answer body readback. Kept separate from
   /// RunReadback so refs-only projections stay refs-only.
   case runAnswerBodyRequest(RunAnswerBodyRequestWire)
@@ -770,6 +774,12 @@ extension FridayMessage: Codable {
     case "ActivityMarkDoneResult":
       let c = try decoder.container(keyedBy: ResultKey.self)
       self = .activityMarkDoneResult(try c.decode(ActivityMarkDoneResultWire.self, forKey: .result))
+    case "WorkItemStatusRequest":
+      let c = try decoder.container(keyedBy: RequestKey.self)
+      self = .workItemStatusRequest(try c.decode(WorkItemStatusRequestWire.self, forKey: .request))
+    case "WorkItemStatusResult":
+      let c = try decoder.container(keyedBy: ResultKey.self)
+      self = .workItemStatusResult(try c.decode(WorkItemStatusResultWire.self, forKey: .result))
     case "RunAnswerBodyRequest":
       let c = try decoder.container(keyedBy: RequestKey.self)
       self = .runAnswerBodyRequest(try c.decode(RunAnswerBodyRequestWire.self, forKey: .request))
@@ -980,6 +990,14 @@ extension FridayMessage: Codable {
       try c.encode(r, forKey: .request)
     case .activityMarkDoneResult(let r):
       try tag.encode("ActivityMarkDoneResult", forKey: .kind)
+      var c = encoder.container(keyedBy: ResultKey.self)
+      try c.encode(r, forKey: .result)
+    case .workItemStatusRequest(let r):
+      try tag.encode("WorkItemStatusRequest", forKey: .kind)
+      var c = encoder.container(keyedBy: RequestKey.self)
+      try c.encode(r, forKey: .request)
+    case .workItemStatusResult(let r):
+      try tag.encode("WorkItemStatusResult", forKey: .kind)
       var c = encoder.container(keyedBy: ResultKey.self)
       try c.encode(r, forKey: .result)
     case .runAnswerBodyRequest(let r):

--- a/apps/macos/FridayRustClient/Sources/FridayRustClient/ReadClient.swift
+++ b/apps/macos/FridayRustClient/Sources/FridayRustClient/ReadClient.swift
@@ -258,6 +258,10 @@ public final class SealedWSReadClient: FridayRustReadClient, @unchecked Sendable
       throw FridayReadClientError.unexpectedResponse(kind: "ActivityMarkDoneRequest")
     case .activityMarkDoneResult:
       throw FridayReadClientError.unexpectedResponse(kind: "ActivityMarkDoneResult")
+    case .workItemStatusRequest:
+      throw FridayReadClientError.unexpectedResponse(kind: "WorkItemStatusRequest")
+    case .workItemStatusResult:
+      throw FridayReadClientError.unexpectedResponse(kind: "WorkItemStatusResult")
     case .runAnswerBodyRequest:
       throw FridayReadClientError.unexpectedResponse(kind: "RunAnswerBodyRequest")
     case .runAnswerBodySnapshot:
@@ -375,6 +379,10 @@ public final class SealedWSReadClient: FridayRustReadClient, @unchecked Sendable
       throw FridayReadClientError.unexpectedResponse(kind: "ActivityMarkDoneRequest")
     case .activityMarkDoneResult:
       throw FridayReadClientError.unexpectedResponse(kind: "ActivityMarkDoneResult")
+    case .workItemStatusRequest:
+      throw FridayReadClientError.unexpectedResponse(kind: "WorkItemStatusRequest")
+    case .workItemStatusResult:
+      throw FridayReadClientError.unexpectedResponse(kind: "WorkItemStatusResult")
     case .runReadbackRequest:
       throw FridayReadClientError.unexpectedResponse(kind: "RunReadbackRequest")
     case .runReadbackSnapshot:

--- a/apps/macos/FridayRustClient/Sources/FridayRustClient/WriteClient.swift
+++ b/apps/macos/FridayRustClient/Sources/FridayRustClient/WriteClient.swift
@@ -181,6 +181,10 @@ public protocol FridayMissionSpineWriteClient: Sendable {
   ) async throws -> RunOutcomeLearningDecisionResultWire
   /// Mark one existing Activity / Needs-Me row done. This is refs-only and never completes a WorkItem.
   func submitActivityMarkDone(_ request: ActivityMarkDoneRequestWire) async throws -> ActivityMarkDoneResultWire
+  /// Advance one existing WorkItem lifecycle status through the Hub state machine. This is refs-only
+  /// recovery/lifecycle control; the Hub enforces owner binding, legal transitions, audit, and
+  /// proof-on-completion.
+  func submitWorkItemStatus(_ request: WorkItemStatusRequestWire) async throws -> WorkItemStatusResultWire
 }
 
 /// Product-facing bridge for MissionIntakeResult -> mission-bound AgentRunRequest. This is the
@@ -354,7 +358,8 @@ public final class SealedWSWriteClient: FridayRustWriteClient, FridayMissionSpin
          .missionIntakeRequest, .missionIntakeResult,
          .memoryDecisionRequest, .memoryDecisionResult,
          .runOutcomeLearningDecisionRequest, .runOutcomeLearningDecisionResult,
-         .activityMarkDoneRequest, .activityMarkDoneResult:
+         .activityMarkDoneRequest, .activityMarkDoneResult,
+         .workItemStatusRequest, .workItemStatusResult:
       throw FridayWriteClientError.unexpectedResponse(kind: dispatchKind(message))
     case .unsupported(let kind):
       throw FridayWriteClientError.unexpectedResponse(kind: kind)
@@ -471,6 +476,33 @@ public final class SealedWSWriteClient: FridayRustWriteClient, FridayMissionSpin
     let resp = try openEnvelope(respBody, sessionKey: sessionKey)
     switch resp.message {
     case .activityMarkDoneResult(let r):
+      return r
+    case .error(let code, let message):
+      throw FridayWriteClientError.serverError(code: code, message: message)
+    default:
+      throw FridayWriteClientError.unexpectedResponse(kind: dispatchKind(resp.message))
+    }
+  }
+
+  /// Advance one WorkItem's lifecycle through the Rust Hub WorkItem state machine over the sealed
+  /// WRITE session. Like mission intake / memory decisions, the sealed peer session is the channel
+  /// auth; the server binds the write to its authenticated owner and rejects illegal transitions.
+  public func submitWorkItemStatus(_ request: WorkItemStatusRequestWire) async throws -> WorkItemStatusResultWire {
+    let transport = try makeTransport()
+    let (sessionKey, _) = try handshake(transport)
+    let msgId = "work-item-status-\(request.workItemId)"
+    let env = FridayEnvelope(msgId: msgId, sentAt: now(), message: .workItemStatusRequest(request))
+      .withCorrelation(msgId)
+    try transport.sendMessage(try sealEnvelope(env, sessionKey: sessionKey))
+    let respBody: [UInt8]
+    do {
+      respBody = try transport.recvMessage()
+    } catch {
+      throw FridayWriteClientError.transport("no work-item-status result (session ended fail-closed): \(error)")
+    }
+    let resp = try openEnvelope(respBody, sessionKey: sessionKey)
+    switch resp.message {
+    case .workItemStatusResult(let r):
       return r
     case .error(let code, let message):
       throw FridayWriteClientError.serverError(code: code, message: message)
@@ -697,6 +729,8 @@ private func dispatchKind(_ message: FridayMessage) -> String {
   case .runOutcomeLearningDecisionResult: return "RunOutcomeLearningDecisionResult"
   case .activityMarkDoneRequest: return "ActivityMarkDoneRequest"
   case .activityMarkDoneResult: return "ActivityMarkDoneResult"
+  case .workItemStatusRequest: return "WorkItemStatusRequest"
+  case .workItemStatusResult: return "WorkItemStatusResult"
   case .unsupported(let kind): return kind
   }
 }

--- a/apps/macos/FridayRustClient/Sources/FridayRustClient/WriteProtocol.swift
+++ b/apps/macos/FridayRustClient/Sources/FridayRustClient/WriteProtocol.swift
@@ -246,6 +246,98 @@ public struct ActivityMarkDoneResultWire: Codable, Equatable, Sendable {
   }
 }
 
+/// Client→hub WorkItem lifecycle command. Mirrors
+/// `friday_protocol::WorkItemStatusRequestWire`.
+///
+/// This is a Hub-owned state-machine mutation over an existing WorkItem, not a provider/model call.
+/// `targetStatus` must be one of the Rust WorkItem lifecycle labels. `proofReceipt` is required only
+/// for `completed_with_proof`; the Hub rejects proofless completion and rejects receipts on every
+/// other target.
+public struct WorkItemStatusRequestWire: Codable, Equatable, Sendable {
+  public var workItemId: String
+  public var targetStatus: String
+  public var actorRef: String
+  public var reason: String
+  public var proofReceipt: String?
+
+  public init(
+    workItemId: String,
+    targetStatus: String,
+    actorRef: String,
+    reason: String,
+    proofReceipt: String? = nil
+  ) {
+    self.workItemId = workItemId
+    self.targetStatus = targetStatus
+    self.actorRef = actorRef
+    self.reason = reason
+    self.proofReceipt = proofReceipt
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case workItemId = "work_item_id"
+    case targetStatus = "target_status"
+    case actorRef = "actor_ref"
+    case reason
+    case proofReceipt = "proof_receipt"
+  }
+
+  public func encode(to encoder: Encoder) throws {
+    var c = encoder.container(keyedBy: CodingKeys.self)
+    try c.encode(workItemId, forKey: .workItemId)
+    try c.encode(targetStatus, forKey: .targetStatus)
+    try c.encode(actorRef, forKey: .actorRef)
+    try c.encode(reason, forKey: .reason)
+    if let proofReceipt {
+      try c.encode(proofReceipt, forKey: .proofReceipt)
+    }
+  }
+}
+
+/// Hub→client WorkItem lifecycle receipt. Refs-only: previous/current status, actor/reason, proof
+/// receipt count, and timestamp. It never carries raw proof refs or provider bodies.
+public struct WorkItemStatusResultWire: Codable, Equatable, Sendable {
+  public var workItemId: String
+  public var missionId: String
+  public var previousStatus: String
+  public var status: String
+  public var actorRef: String
+  public var reason: String
+  public var proofReceiptCount: UInt64
+  public var updatedAtMs: Int64
+
+  public init(
+    workItemId: String,
+    missionId: String,
+    previousStatus: String,
+    status: String,
+    actorRef: String,
+    reason: String,
+    proofReceiptCount: UInt64,
+    updatedAtMs: Int64
+  ) {
+    self.workItemId = workItemId
+    self.missionId = missionId
+    self.previousStatus = previousStatus
+    self.status = status
+    self.actorRef = actorRef
+    self.reason = reason
+    self.proofReceiptCount = proofReceiptCount
+    self.updatedAtMs = updatedAtMs
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case workItemId = "work_item_id"
+    case missionId = "mission_id"
+    case previousStatus = "previous_status"
+    case status
+    case actorRef = "actor_ref"
+    case reason
+    case proofReceiptCount = "proof_receipt_count"
+    case updatedAtMs = "updated_at_ms"
+  }
+}
+
 /// Client→read-server owner-gated answer-body request. This is a READ-seam message, but the shared
 /// wire types live beside the other protocol structs so `FridayMessage` can encode/decode it.
 public struct RunAnswerBodyRequestWire: Codable, Equatable, Sendable {

--- a/apps/macos/FridayRustClient/Tests/FridayRustClientTests/WriteClientWiringTests.swift
+++ b/apps/macos/FridayRustClient/Tests/FridayRustClientTests/WriteClientWiringTests.swift
@@ -25,6 +25,7 @@ final class WriteClientWiringTests: XCTestCase {
     case resumeRefused       // resume → AgentRunControlResult(accepted=false, denied)
     case rejectAccepted      // reject → AgentRunControlResult(accepted, rejected)
     case cancelAccepted      // cancel → AgentRunControlResult(accepted, cancelled)
+    case workItemStatusAccepted // work item lifecycle → WorkItemStatusResult
   }
 
   /// An in-memory transport playing the Rust agent-run WRITE server's half, in the byte sequence
@@ -52,6 +53,7 @@ final class WriteClientWiringTests: XCTestCase {
     private(set) var receivedConstraints: AgentRunConstraintsWire?
     private(set) var receivedSessionId: String?
     private(set) var receivedMissionContext: MissionWorkItemContextWire?
+    private(set) var receivedWorkItemStatusRequest: WorkItemStatusRequestWire?
 
     init(serverKeypair: FridayCrypto.DeviceKeypair, sessionNonce: [UInt8],
          peerAllowlist: [[UInt8]], ownerAllowlist: [String], mode: ServerMode) {
@@ -123,6 +125,8 @@ final class WriteClientWiringTests: XCTestCase {
             self.receivedCancelReason = reason
             self.cancelled += 1
           })
+      case .workItemStatusRequest(let req):
+        try handleWorkItemStatus(req, sessionKey: sessionKey, correlation: env.msgId)
       default:
         throw FridayWriteClientError.transport("unexpected inbound on the write session: \(env.msgId)")
       }
@@ -222,6 +226,29 @@ final class WriteClientWiringTests: XCTestCase {
         msgId: "agent-run-control-result-\(runId)",
         sentAt: 1_780_640_000_000,
         message: .agentRunControlResult(result)).withCorrelation(correlation)
+      queuedFromServer.append(try FridayCrypto.encodeSealed(FridayCrypto.seal(
+        key: sessionKey, plaintext: [UInt8](resp.encodeJSON()), aad: writeSessionAad)))
+    }
+
+    private func handleWorkItemStatus(
+      _ req: WorkItemStatusRequestWire,
+      sessionKey: [UInt8],
+      correlation: String
+    ) throws {
+      receivedWorkItemStatusRequest = req
+      let result = WorkItemStatusResultWire(
+        workItemId: req.workItemId,
+        missionId: "mission-\(req.workItemId)",
+        previousStatus: "failed_retryable",
+        status: req.targetStatus,
+        actorRef: req.actorRef,
+        reason: req.reason,
+        proofReceiptCount: req.proofReceipt == nil ? 0 : 1,
+        updatedAtMs: 1_780_640_000_123)
+      let resp = FridayEnvelope(
+        msgId: "work-item-status-result-\(req.workItemId)",
+        sentAt: 1_780_640_000_000,
+        message: .workItemStatusResult(result)).withCorrelation(correlation)
       queuedFromServer.append(try FridayCrypto.encodeSealed(FridayCrypto.seal(
         key: sessionKey, plaintext: [UInt8](resp.encodeJSON()), aad: writeSessionAad)))
     }
@@ -466,5 +493,27 @@ final class WriteClientWiringTests: XCTestCase {
       XCTAssertEqual(transport.cancelled, 0)
       XCTAssertNil(transport.receivedCancelReason)
     }
+  }
+
+  // MARK: work-item lifecycle status (T4 recovery write leg)
+
+  func testWorkItemStatus_sendsLifecycleRequestAndParsesRefsOnlyReceipt() async throws {
+    let (client, transport) = try makeClient(mode: .workItemStatusAccepted, controlEnabled: false)
+    let request = WorkItemStatusRequestWire(
+      workItemId: "work-stale-1",
+      targetStatus: "ready_to_dispatch",
+      actorRef: "desktop:operator",
+      reason: "operator retries stale WorkItem from recovery surface")
+
+    let result = try await client.submitWorkItemStatus(request)
+
+    XCTAssertEqual(transport.receivedWorkItemStatusRequest, request)
+    XCTAssertEqual(result.workItemId, "work-stale-1")
+    XCTAssertEqual(result.missionId, "mission-work-stale-1")
+    XCTAssertEqual(result.previousStatus, "failed_retryable")
+    XCTAssertEqual(result.status, "ready_to_dispatch")
+    XCTAssertEqual(result.actorRef, "desktop:operator")
+    XCTAssertEqual(result.reason, "operator retries stale WorkItem from recovery surface")
+    XCTAssertEqual(result.proofReceiptCount, 0)
   }
 }


### PR DESCRIPTION
## Summary
- Adds a sealed work-item lifecycle write arm to the Swift Rust client for retry/cancel status updates.
- Wires desktop Operations and iOS Home WorkItem recovery controls to the write seam with refs-only receipts and refresh behavior.
- Extends focused client tests across RustClient, desktop, and iOS fakes.

Truth label: T4 product-action residue. This makes retry/cancel actionable from clients; it does not claim full T4, L1, or END-BAR completion.

## Validation
- `swift test --package-path apps/macos/FridayRustClient`
- `swift test --package-path apps/macos/FridayHubConsole --filter OperationsOverviewViewModelTests`
- `swift test --package-path apps/friday-ios --filter HomeViewModelTests`
- `swift test --package-path apps/friday-ios --filter FridayChatViewModelTests`
- `swift test --package-path apps/friday-ios --filter ShareIntakeViewModelTests`
- `swift build --package-path apps/macos/FridayHubConsole`
- `git diff --check`
- `detect-secrets scan apps/friday-ios/Sources apps/friday-ios/Tests apps/macos/FridayHubConsole/Sources apps/macos/FridayHubConsole/Tests apps/macos/FridayRustClient/Sources apps/macos/FridayRustClient/Tests`
- `./apps/friday-ios/build-sim.sh apps/friday-ios/.build-sim/t4-recovery-actions-postrebase.png`