### PR TITLE
Surface T3 operator ceremony command

### DIFF
--- a/apps/macos/FridayHubConsole/Sources/FridayHubConsole/PairingProvisioningScreen.swift
+++ b/apps/macos/FridayHubConsole/Sources/FridayHubConsole/PairingProvisioningScreen.swift
@@ -8,6 +8,7 @@ struct PairingProvisioningScreen: View {
   @StateObject private var viewModel = PairingProvisioningViewModel()
   @State private var inputPayload = ""
   @State private var showImporter = false
+  private let operatorCommand = PairingProvisioningViewModel.operatorProvisioningCommand()
 
   var body: some View {
     ScrollView {
@@ -15,6 +16,7 @@ struct PairingProvisioningScreen: View {
         header
         inputPanel
         qrPanel
+        operatorPanel
       }
       .padding(20)
       .frame(maxWidth: .infinity, alignment: .topLeading)
@@ -163,6 +165,38 @@ struct PairingProvisioningScreen: View {
     }
   }
 
+  private var operatorPanel: some View {
+    GlassPanel {
+      VStack(alignment: .leading, spacing: 12) {
+        HStack {
+          Text("Operator Ceremony")
+            .font(.system(size: 13, weight: .semibold))
+            .foregroundStyle(HubTheme.textPrimary)
+          Spacer()
+          Button {
+            copyOperatorCommand()
+          } label: {
+            Label("Copy", systemImage: "doc.on.doc")
+          }
+          .buttonStyle(.bordered)
+        }
+        Text("Trust grants and context passports stay operator CLI ceremonies; this app only stages the exact command shape.")
+          .font(.system(size: 11))
+          .foregroundStyle(HubTheme.textSecondary)
+          .fixedSize(horizontal: false, vertical: true)
+        ScrollView(.horizontal) {
+          Text(operatorCommand)
+            .font(.system(size: 11, design: .monospaced))
+            .foregroundStyle(HubTheme.textPrimary)
+            .textSelection(.enabled)
+            .padding(10)
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .background(Color.white.opacity(0.62), in: RoundedRectangle(cornerRadius: 8))
+      }
+    }
+  }
+
   private func importManifest(_ result: Result<[URL], Error>) {
     do {
       guard let url = try result.get().first else { return }
@@ -184,6 +218,11 @@ struct PairingProvisioningScreen: View {
     guard viewModel.canRenderQRCode else { return }
     NSPasteboard.general.clearContents()
     NSPasteboard.general.setString(viewModel.qrPayload, forType: .string)
+  }
+
+  private func copyOperatorCommand() {
+    NSPasteboard.general.clearContents()
+    NSPasteboard.general.setString(operatorCommand, forType: .string)
   }
 
   private func statusChip(_ text: String) -> some View {

--- a/apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/PairingProvisioningViewModel.swift
+++ b/apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/PairingProvisioningViewModel.swift
@@ -85,6 +85,25 @@ public final class PairingProvisioningViewModel: ObservableObject {
     state.description
   }
 
+  public static func operatorProvisioningCommand(repoRoot: String = "$FRIDAY_REPO_ROOT") -> String {
+    """
+    cd \(repoRoot)
+    FRIDAY_T3_OPERATOR_PROVISION_ACK=operator-runs-t3-provisioning \\
+    FRIDAY_T3_STEP=both \\
+    FRIDAY_T3_GRANT_ID=<grant-id> \\
+    FRIDAY_T3_AGENT_ID=<agent-or-device-principal> \\
+    FRIDAY_T3_RISK_CEILING=<low|medium|high> \\
+    FRIDAY_T3_WORKSPACE=<absolute-workspace-path> \\
+    FRIDAY_T3_PROVIDERS=<provider-list> \\
+    FRIDAY_T3_TOOLS=<tool-list> \\
+    FRIDAY_T3_PASSPORT_ID=<passport-id> \\
+    FRIDAY_T3_MISSION_ID=<mission-id> \\
+    FRIDAY_T3_DESTINATION_LANE=<codex|claude|deepseek> \\
+    FRIDAY_T3_ITEMS_JSON=<approved-context-items-json> \\
+    scripts/ops/friday-t3-operator-provision.sh
+    """
+  }
+
   public func startPairingSession(
     exposureMode: PairingSessionExposureMode = .loopback,
     nowMs: Int64 = Int64(Date().timeIntervalSince1970 * 1000)
@@ -99,11 +118,11 @@ public final class PairingProvisioningViewModel: ObservableObject {
       return
     }
     qrPayload = ""
-      state = PairingProvisioningState(
-        mode: .starting,
-        reason: exposureMode.startingReason,
-        projection: nil,
-        manifestPath: nil)
+    state = PairingProvisioningState(
+      mode: .starting,
+      reason: exposureMode.startingReason,
+      projection: nil,
+      manifestPath: nil)
     do {
       let result = try await launcher.startPairingSession(exposureMode: exposureMode)
       load(

--- a/apps/macos/FridayHubConsole/Tests/FridayHubConsoleCoreTests/PairingProvisioningViewModelTests.swift
+++ b/apps/macos/FridayHubConsole/Tests/FridayHubConsoleCoreTests/PairingProvisioningViewModelTests.swift
@@ -3,6 +3,18 @@ import Testing
 @testable import FridayHubConsoleCore
 
 @MainActor
+@Test func operatorProvisioningCommandStaysOperatorOnlyAndPlaceholderBased() async throws {
+  let command = PairingProvisioningViewModel.operatorProvisioningCommand(repoRoot: "/repo")
+
+  #expect(command.contains("cd /repo"))
+  #expect(command.contains("FRIDAY_T3_OPERATOR_PROVISION_ACK=operator-runs-t3-provisioning")) // pragma: allowlist secret
+  #expect(command.contains("scripts/ops/friday-t3-operator-provision.sh"))
+  #expect(command.contains("<grant-id>"))
+  #expect(!command.contains("operator-approve.key"))
+  #expect(!command.contains("operator-signer.key"))
+}
+
+@MainActor
 @Test func pairingProvisioningAcceptsValidManifestWithoutDisplayingSecret() async throws {
   let secret = "friday-pairing-secret-for-test" // pragma: allowlist secret
   let payload = pairingManifestJSON(secret: secret, expiresAt: 1_900_000_000_000)


### PR DESCRIPTION
## Summary
- Adds a desktop Pairing Provisioning panel with the operator-only T3 trust grant/context passport ceremony command skeleton.
- Keeps trust grant and context passport minting as CLI/operator ceremony only; the app only displays and copies placeholders.
- Adds a regression test that the command routes through `scripts/ops/friday-t3-operator-provision.sh` and does not surface operator private-key paths.

Truth label: T3 operator-ceremony UX surface. This does not mint trust grants/context passports and does not claim T3 fully provisioned.

## Validation
- `swift test --package-path apps/macos/FridayHubConsole --filter PairingProvisioningViewModelTests`
- `swift build --package-path apps/macos/FridayHubConsole`
- `git diff --check`
- `detect-secrets scan apps/macos/FridayHubConsole/Sources apps/macos/FridayHubConsole/Tests`