### PR TITLE
Add iOS voice readiness surface

### DIFF
--- a/apps/friday-ios/Sources/FridayMobileShell/CommandSheet.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/CommandSheet.swift
@@ -11,6 +11,7 @@ enum MobileDestination: String, CaseIterable, Identifiable {
   case missions
   case session
   case shareIntake
+  case voice
   case needsMe
   case memory
   case platform
@@ -27,6 +28,7 @@ enum MobileDestination: String, CaseIterable, Identifiable {
     case .missions: return "Missions"
     case .session: return "Session"
     case .shareIntake: return "Share Intake"
+    case .voice: return "Voice"
     case .needsMe: return "Needs Me"
     case .memory: return "Memory"
     case .platform: return "Platform"
@@ -43,6 +45,7 @@ enum MobileDestination: String, CaseIterable, Identifiable {
     case .missions: return "list.bullet.rectangle"
     case .session: return "rectangle.connected.to.line.below"
     case .shareIntake: return "square.and.arrow.down"
+    case .voice: return "waveform"
     case .needsMe: return "person.crop.circle.badge.exclamationmark"
     case .memory: return "brain.head.profile"
     case .platform: return "square.grid.2x2"

--- a/apps/friday-ios/Sources/FridayMobileShell/FridayApp.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayApp.swift
@@ -226,6 +226,7 @@ struct RootView: View {
   @StateObject private var homeVM: HomeViewModel
   @StateObject private var sessionContinuationVM: SessionContinuationViewModel
   @StateObject private var shareIntakeVM: ShareIntakeViewModel
+  @StateObject private var voiceVM: VoiceReadinessViewModel
   private let session: FridaySession
   @State private var destination: MobileDestination = .home
   @State private var commandOpen = false
@@ -244,6 +245,8 @@ struct RootView: View {
       signer: session.signer,
       runControlEnabled: session.runControlEnabled))
     _shareIntakeVM = StateObject(wrappedValue: ShareIntakeViewModel(client: session.missionClient))
+    _voiceVM = StateObject(wrappedValue: VoiceReadinessViewModel(
+      authorizer: SystemVoiceReadinessAuthorizer()))
   }
 
   var body: some View {
@@ -256,6 +259,8 @@ struct RootView: View {
           FridaySessionDetailScreen(homeViewModel: homeVM, viewModel: sessionContinuationVM)
         case .shareIntake:
           FridayShareIntakeScreen(viewModel: shareIntakeVM)
+        case .voice:
+          FridayVoiceScreen(viewModel: voiceVM)
         case .missions, .needsMe, .memory, .platform, .activity, .workflows, .onboarding,
              .settings:
           FridayProjectionScreen(destination: destination, viewModel: homeVM)

--- a/apps/friday-ios/Sources/FridayMobileShell/FridayProjectionScreens.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayProjectionScreens.swift
@@ -14,7 +14,7 @@ private enum ProjectionSurface {
 
   init?(_ destination: MobileDestination) {
     switch destination {
-    case .home, .session, .shareIntake:
+    case .home, .session, .shareIntake, .voice:
       return nil
     case .missions:
       self = .missions

--- a/apps/friday-ios/Sources/FridayMobileShell/FridayVoiceScreen.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayVoiceScreen.swift
@@ -1,0 +1,156 @@
+import FridayMobileShellCore
+import SwiftUI
+
+struct FridayVoiceScreen: View {
+  @ObservedObject var viewModel: VoiceReadinessViewModel
+
+  var body: some View {
+    ScrollView {
+      VStack(spacing: 16) {
+        header
+        stateContent
+      }
+      .padding(16)
+    }
+    .background(MobileTheme.backgroundWarmOffWhite.ignoresSafeArea())
+    .task {
+      if case .idle = viewModel.state {
+        await viewModel.refresh()
+      }
+    }
+  }
+
+  private var header: some View {
+    GlassPanel {
+      HStack(spacing: 12) {
+        Image(systemName: "waveform")
+          .font(.system(size: 24, weight: .semibold))
+          .foregroundStyle(MobileTheme.cyan)
+          .frame(width: 34, height: 34)
+        VStack(alignment: .leading, spacing: 4) {
+          Text("Voice")
+            .font(.headline)
+            .foregroundStyle(MobileTheme.textPrimary)
+          Text("input and speech output readiness")
+            .font(.caption)
+            .foregroundStyle(MobileTheme.textSecondary)
+        }
+        Spacer()
+      }
+    }
+  }
+
+  @ViewBuilder
+  private var stateContent: some View {
+    switch viewModel.state {
+    case .idle, .loading:
+      GlassPanel {
+        HStack(spacing: 12) {
+          ProgressView()
+          Text("Checking voice readiness")
+            .font(.footnote)
+            .foregroundStyle(MobileTheme.textSecondary)
+        }
+        .frame(maxWidth: .infinity, minHeight: 86, alignment: .leading)
+      }
+    case let .unavailable(reason):
+      UnavailableView(reason: reason)
+    case let .loaded(readiness):
+      readinessCard(readiness)
+      gatesCard(readiness)
+    }
+  }
+
+  private func readinessCard(_ readiness: MobileVoiceReadiness) -> some View {
+    GlassPanel {
+      VStack(alignment: .leading, spacing: MobileTheme.rowSpacing) {
+        HStack(spacing: 8) {
+          StatusChip(
+            text: readiness.voiceLoopReady ? "voice ready" : "not ready",
+            bg: readiness.voiceLoopReady ? MobileTheme.chipPendingBG : MobileTheme.chipWarnBG,
+            fg: readiness.voiceLoopReady ? MobileTheme.chipPendingFG : MobileTheme.chipWarnFG)
+          StatusChip(text: readiness.truthLabel, bg: MobileTheme.chipNeutralBG, fg: MobileTheme.chipNeutralFG)
+        }
+        Text(readiness.summary)
+          .font(.callout.weight(.medium))
+          .foregroundStyle(MobileTheme.textPrimary)
+          .fixedSize(horizontal: false, vertical: true)
+        Text("Readiness only; realtime voice starts after capture and TTS gates are ready.")
+          .font(.caption)
+          .foregroundStyle(MobileTheme.textSecondary)
+          .fixedSize(horizontal: false, vertical: true)
+        if readiness.canRequestPermission {
+          Button {
+            Task { await viewModel.requestPermission() }
+          } label: {
+            Label("Allow Voice", systemImage: "mic.badge.plus")
+          }
+          .buttonStyle(.borderedProminent)
+          .tint(MobileTheme.cyan)
+          .disabled(viewModel.state == .loading)
+        } else {
+          Button {
+            Task { await viewModel.refresh() }
+          } label: {
+            Label("Refresh", systemImage: "arrow.clockwise")
+          }
+          .disabled(viewModel.state == .loading)
+        }
+      }
+    }
+    .accessibilityIdentifier("friday.voice.readiness-card")
+  }
+
+  private func gatesCard(_ readiness: MobileVoiceReadiness) -> some View {
+    GlassPanel {
+      VStack(alignment: .leading, spacing: MobileTheme.rowSpacing) {
+        cardHeader("Voice Gates", count: nil)
+        readinessRow(
+          title: "Microphone",
+          value: readiness.microphone.rawValue,
+          healthy: readiness.microphone == .authorized)
+        readinessRow(
+          title: "Speech recognition",
+          value: readiness.speechRecognition.rawValue,
+          healthy: readiness.speechRecognition == .authorized)
+        readinessRow(
+          title: "TTS provider",
+          value: readiness.ttsProviderConfigured ? "configured" : "not configured in this build",
+          healthy: readiness.ttsProviderConfigured)
+        readinessRow(
+          title: "Realtime loop",
+          value: readiness.voiceLoopReady ? "ready" : "blocked until capture and TTS are ready",
+          healthy: readiness.voiceLoopReady)
+      }
+    }
+  }
+
+  private func cardHeader(_ title: String, count: Int?) -> some View {
+    HStack {
+      Text(title)
+        .font(.headline)
+        .foregroundStyle(MobileTheme.textPrimary)
+      Spacer()
+      if let count {
+        StatusChip(text: "\(count)", bg: MobileTheme.chipNeutralBG, fg: MobileTheme.chipNeutralFG)
+      }
+    }
+  }
+
+  private func readinessRow(title: String, value: String, healthy: Bool) -> some View {
+    HStack(alignment: .top, spacing: 10) {
+      Image(systemName: healthy ? "checkmark.circle" : "exclamationmark.triangle")
+        .foregroundStyle(healthy ? MobileTheme.cyan : MobileTheme.coral)
+      VStack(alignment: .leading, spacing: 3) {
+        Text(title)
+          .font(.caption.weight(.semibold))
+          .foregroundStyle(MobileTheme.textPrimary)
+        Text(value)
+          .font(.caption2)
+          .foregroundStyle(MobileTheme.textSecondary)
+          .fixedSize(horizontal: false, vertical: true)
+      }
+      Spacer()
+    }
+  }
+}

--- a/apps/friday-ios/Sources/FridayMobileShell/SystemVoiceReadinessAuthorizer.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/SystemVoiceReadinessAuthorizer.swift
@@ -1,0 +1,78 @@
+import AVFoundation
+import FridayMobileShellCore
+import Speech
+
+struct SystemVoiceReadinessAuthorizer: MobileVoiceReadinessAuthorizing {
+  private let ttsProviderConfigured: Bool
+
+  init(ttsProviderConfigured: Bool = false) {
+    self.ttsProviderConfigured = ttsProviderConfigured
+  }
+
+  func currentReadiness() async throws -> MobileVoiceReadiness {
+    MobileVoiceReadiness(
+      microphone: Self.microphoneStatus(AVAudioApplication.shared.recordPermission),
+      speechRecognition: Self.speechStatus(SFSpeechRecognizer.authorizationStatus()),
+      ttsProviderConfigured: ttsProviderConfigured)
+  }
+
+  func requestVoiceAuthorization() async throws -> MobileVoiceReadiness {
+    let microphone = await requestMicrophoneStatus()
+    let speech = await requestSpeechStatus()
+    return MobileVoiceReadiness(
+      microphone: microphone,
+      speechRecognition: speech,
+      ttsProviderConfigured: ttsProviderConfigured)
+  }
+
+  private func requestMicrophoneStatus() async -> MobileVoiceAuthorizationStatus {
+    await withCheckedContinuation { continuation in
+      AVAudioApplication.requestRecordPermission { granted in
+        let status = granted
+          ? MobileVoiceAuthorizationStatus.authorized
+          : Self.microphoneStatus(AVAudioApplication.shared.recordPermission)
+        continuation.resume(returning: status)
+      }
+    }
+  }
+
+  private func requestSpeechStatus() async -> MobileVoiceAuthorizationStatus {
+    await withCheckedContinuation { continuation in
+      SFSpeechRecognizer.requestAuthorization { status in
+        continuation.resume(returning: Self.speechStatus(status))
+      }
+    }
+  }
+
+  private static func microphoneStatus(
+    _ status: AVAudioApplication.recordPermission
+  ) -> MobileVoiceAuthorizationStatus {
+    switch status {
+    case .undetermined:
+      return .notDetermined
+    case .denied:
+      return .denied
+    case .granted:
+      return .authorized
+    @unknown default:
+      return .unknown
+    }
+  }
+
+  private static func speechStatus(
+    _ status: SFSpeechRecognizerAuthorizationStatus
+  ) -> MobileVoiceAuthorizationStatus {
+    switch status {
+    case .notDetermined:
+      return .notDetermined
+    case .denied:
+      return .denied
+    case .restricted:
+      return .restricted
+    case .authorized:
+      return .authorized
+    @unknown default:
+      return .unknown
+    }
+  }
+}

--- a/apps/friday-ios/Sources/FridayMobileShellCore/VoiceReadinessViewModel.swift
+++ b/apps/friday-ios/Sources/FridayMobileShellCore/VoiceReadinessViewModel.swift
@@ -1,0 +1,106 @@
+import Foundation
+
+public enum MobileVoiceAuthorizationStatus: String, Sendable, Equatable {
+  case notDetermined = "not_determined"
+  case denied
+  case restricted
+  case authorized
+  case unavailable
+  case unknown
+}
+
+public struct MobileVoiceReadiness: Sendable, Equatable {
+  public let microphone: MobileVoiceAuthorizationStatus
+  public let speechRecognition: MobileVoiceAuthorizationStatus
+  public let ttsProviderConfigured: Bool
+  public let truthLabel: String
+
+  public init(
+    microphone: MobileVoiceAuthorizationStatus,
+    speechRecognition: MobileVoiceAuthorizationStatus,
+    ttsProviderConfigured: Bool = false,
+    truthLabel: String = "mobile_voice_readiness_local_only"
+  ) {
+    self.microphone = microphone
+    self.speechRecognition = speechRecognition
+    self.ttsProviderConfigured = ttsProviderConfigured
+    self.truthLabel = truthLabel
+  }
+
+  public var canRequestPermission: Bool {
+    microphone == .notDetermined || speechRecognition == .notDetermined
+  }
+
+  public var speechCaptureReady: Bool {
+    microphone == .authorized && speechRecognition == .authorized
+  }
+
+  public var voiceLoopReady: Bool {
+    speechCaptureReady && ttsProviderConfigured
+  }
+
+  public var summary: String {
+    if voiceLoopReady {
+      return "Voice capture and TTS provider readiness are both present."
+    }
+    if speechCaptureReady {
+      return "Voice capture is allowed; TTS provider output is not configured in this build."
+    }
+    if microphone == .notDetermined || speechRecognition == .notDetermined {
+      return "Voice permissions have not both been requested."
+    }
+    if microphone == .denied || speechRecognition == .denied {
+      return "Voice input is denied in system settings."
+    }
+    if microphone == .restricted || speechRecognition == .restricted {
+      return "Voice input is restricted by the device policy."
+    }
+    return "Voice readiness is unavailable."
+  }
+}
+
+public protocol MobileVoiceReadinessAuthorizing: Sendable {
+  func currentReadiness() async throws -> MobileVoiceReadiness
+  func requestVoiceAuthorization() async throws -> MobileVoiceReadiness
+}
+
+public enum MobileVoiceReadinessState: Sendable, Equatable {
+  case idle
+  case loading
+  case loaded(MobileVoiceReadiness)
+  case unavailable(String)
+
+  public var readiness: MobileVoiceReadiness? {
+    if case let .loaded(readiness) = self { return readiness }
+    return nil
+  }
+}
+
+@MainActor
+public final class VoiceReadinessViewModel: ObservableObject {
+  @Published public private(set) var state: MobileVoiceReadinessState = .idle
+
+  private let authorizer: any MobileVoiceReadinessAuthorizing
+
+  public init(authorizer: any MobileVoiceReadinessAuthorizing) {
+    self.authorizer = authorizer
+  }
+
+  public func refresh() async {
+    state = .loading
+    do {
+      state = .loaded(try await authorizer.currentReadiness())
+    } catch {
+      state = .unavailable("\(error)")
+    }
+  }
+
+  public func requestPermission() async {
+    state = .loading
+    do {
+      state = .loaded(try await authorizer.requestVoiceAuthorization())
+    } catch {
+      state = .unavailable("\(error)")
+    }
+  }
+}

--- a/apps/friday-ios/Tests/FridayMobileShellCoreTests/VoiceReadinessViewModelTests.swift
+++ b/apps/friday-ios/Tests/FridayMobileShellCoreTests/VoiceReadinessViewModelTests.swift
@@ -1,0 +1,85 @@
+import XCTest
+@testable import FridayMobileShellCore
+
+@MainActor
+final class VoiceReadinessViewModelTests: XCTestCase {
+  struct FakeVoiceAuthorizer: MobileVoiceReadinessAuthorizing {
+    let current: MobileVoiceReadiness
+    let requested: MobileVoiceReadiness
+
+    func currentReadiness() async throws -> MobileVoiceReadiness {
+      current
+    }
+
+    func requestVoiceAuthorization() async throws -> MobileVoiceReadiness {
+      requested
+    }
+  }
+
+  func testVoiceLoopReadyRequiresCaptureAndTtsProvider() {
+    let captureOnly = MobileVoiceReadiness(
+      microphone: .authorized,
+      speechRecognition: .authorized,
+      ttsProviderConfigured: false)
+    XCTAssertTrue(captureOnly.speechCaptureReady)
+    XCTAssertFalse(captureOnly.voiceLoopReady)
+    XCTAssertEqual(
+      captureOnly.summary,
+      "Voice capture is allowed; TTS provider output is not configured in this build.")
+
+    let complete = MobileVoiceReadiness(
+      microphone: .authorized,
+      speechRecognition: .authorized,
+      ttsProviderConfigured: true)
+    XCTAssertTrue(complete.voiceLoopReady)
+    XCTAssertEqual(
+      complete.summary,
+      "Voice capture and TTS provider readiness are both present.")
+  }
+
+  func testDeniedOrRestrictedPermissionsNeverClaimVoiceReady() {
+    let denied = MobileVoiceReadiness(
+      microphone: .denied,
+      speechRecognition: .authorized,
+      ttsProviderConfigured: true)
+    XCTAssertFalse(denied.speechCaptureReady)
+    XCTAssertFalse(denied.voiceLoopReady)
+    XCTAssertEqual(denied.summary, "Voice input is denied in system settings.")
+
+    let restricted = MobileVoiceReadiness(
+      microphone: .authorized,
+      speechRecognition: .restricted,
+      ttsProviderConfigured: true)
+    XCTAssertFalse(restricted.speechCaptureReady)
+    XCTAssertFalse(restricted.voiceLoopReady)
+    XCTAssertEqual(restricted.summary, "Voice input is restricted by the device policy.")
+  }
+
+  func testRefreshAndRequestPermissionUseAuthoritativeAuthorizerState() async {
+    let vm = VoiceReadinessViewModel(authorizer: FakeVoiceAuthorizer(
+      current: MobileVoiceReadiness(
+        microphone: .notDetermined,
+        speechRecognition: .notDetermined,
+        ttsProviderConfigured: false),
+      requested: MobileVoiceReadiness(
+        microphone: .authorized,
+        speechRecognition: .authorized,
+        ttsProviderConfigured: false)))
+
+    await vm.refresh()
+    guard case .loaded(let initial) = vm.state else {
+      return XCTFail("expected loaded initial state, got \(vm.state)")
+    }
+    XCTAssertTrue(initial.canRequestPermission)
+    XCTAssertFalse(initial.voiceLoopReady)
+
+    await vm.requestPermission()
+    guard case .loaded(let requested) = vm.state else {
+      return XCTFail("expected loaded requested state, got \(vm.state)")
+    }
+    XCTAssertTrue(requested.speechCaptureReady)
+    XCTAssertFalse(
+      requested.voiceLoopReady,
+      "requesting OS capture permissions must not fabricate TTS provider readiness")
+  }
+}


### PR DESCRIPTION
## Summary
- add a Voice destination to the iOS command sheet and route it to a native readiness screen
- add a core VoiceReadinessViewModel that only reports microphone, speech recognition, and TTS-provider readiness
- add an iOS system authorizer using AVAudioApplication + SFSpeechRecognizer without starting model calls or holding signing material

Truth label: this is a T2 voice readiness/product surface. It does not claim a completed realtime voice I/O loop; voice loop readiness stays false until capture and TTS-provider gates are both ready.

## Verification
- swift test --package-path apps/friday-ios --filter VoiceReadinessViewModelTests
- swift test --package-path apps/friday-ios
- ./apps/friday-ios/build-sim.sh apps/friday-ios/.build-sim/t2-voice-readiness.png
- git diff --check
- detect-secrets scan apps/friday-ios/Sources apps/friday-ios/Tests

Screenshot proof: apps/friday-ios/.build-sim/t2-voice-readiness.png (sim app launched, Home rendered nonblank with pet).