### PR TITLE
Surface desktop T3 provisioning gaps

### DIFF
--- a/apps/macos/FridayHubConsole/Sources/FridayHubConsole/OperationsOverviewScreen.swift
+++ b/apps/macos/FridayHubConsole/Sources/FridayHubConsole/OperationsOverviewScreen.swift
@@ -170,7 +170,7 @@ struct OperationsOverviewScreen: View {
           cardTitle("T3 Provisioning")
           Spacer()
           StatusChip(
-            text: status?.isFullyProvisioned == true ? "fully provisioned" : "operator gated",
+            text: status?.desktopStatusLabel ?? "not projected",
             bg: status?.isFullyProvisioned == true ? HubTheme.chipPendingBG : HubTheme.chipWarnBG,
             fg: status?.isFullyProvisioned == true ? HubTheme.chipPendingFG : HubTheme.chipWarnFG)
         }
@@ -211,6 +211,11 @@ struct OperationsOverviewScreen: View {
               .font(.system(size: 12))
               .foregroundStyle(HubTheme.textSecondary)
           }
+
+          Text(status.desktopSummary)
+            .font(.system(size: 12, weight: .semibold))
+            .foregroundStyle(status.isFullyProvisioned ? HubTheme.textSecondary : HubTheme.coral)
+            .fixedSize(horizontal: false, vertical: true)
 
           Text("Read-only status from Hub DB; trust grant and context passport minting remain operator CLI ceremonies.")
             .font(.system(size: 10))

--- a/apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/WorkbenchSnapshot.swift
+++ b/apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/WorkbenchSnapshot.swift
@@ -603,6 +603,37 @@ public struct MissionWorkbenchT3ProvisioningStatus: Codable, Sendable, Equatable
   public var isFullyProvisioned: Bool {
     paired && activeTrustGrantCount > 0 && contextPassportCount > 0 && contextPassportItemCount > 0
   }
+
+  public var missingOperatorSteps: [String] {
+    var steps: [String] = []
+    if !paired {
+      steps.append("paired device")
+    }
+    if activeTrustGrantCount == 0 {
+      steps.append("trust grant")
+    }
+    if contextPassportCount == 0 || contextPassportItemCount == 0 {
+      steps.append("context passport")
+    }
+    return steps
+  }
+
+  public var desktopStatusLabel: String {
+    if isFullyProvisioned {
+      return "fully provisioned"
+    }
+    return paired ? "operator action needed" : "pairing needed"
+  }
+
+  public var desktopSummary: String {
+    if isFullyProvisioned {
+      return "Hub projection shows paired device, active trust grant, and context passport rows."
+    }
+    if missingOperatorSteps.isEmpty {
+      return "Hub projection is incomplete."
+    }
+    return "Missing \(missingOperatorSteps.joined(separator: ", "))."
+  }
 }
 
 public struct MissionWorkbenchTrustedDeviceSummary: Codable, Sendable, Equatable {

--- a/apps/macos/FridayHubConsole/Tests/FridayHubConsoleCoreTests/OperationsOverviewViewModelTests.swift
+++ b/apps/macos/FridayHubConsole/Tests/FridayHubConsoleCoreTests/OperationsOverviewViewModelTests.swift
@@ -94,6 +94,8 @@ func snapshotExercisesEveryHonestRenderingRule() {
   #expect(snapshot.runOutcomeLearningCandidates.first?.evidenceRef.hasPrefix("proof://") == true)
   #expect(snapshot.t3ProvisioningStatus?.truthLabel == "rust_hub_t3_provisioning_read_only_no_mint")
   #expect(snapshot.t3ProvisioningStatus?.isFullyProvisioned == true)
+  #expect(snapshot.t3ProvisioningStatus?.desktopStatusLabel == "fully provisioned")
+  #expect(snapshot.t3ProvisioningStatus?.missingOperatorSteps == [])
   #expect(snapshot.t3ProvisioningStatus?.latestDevice?.deviceId.hasPrefix("proof://device/") == true)
   #expect(snapshot.t3ProvisioningStatus?.latestDevice?.pubkeyFingerprint == "abcd1234:dcba4321")
 }
@@ -348,7 +350,32 @@ func decodesRustProjectionShapedJSON() throws {
   #expect(snapshot.t3ProvisioningStatus?.paired == true)
   #expect(snapshot.t3ProvisioningStatus?.latestDevice?.deviceId == "proof://device/paired-desktop-1")
   #expect(snapshot.t3ProvisioningStatus?.latestDevice?.pubkeyFingerprint == "abcd1234:dcba4321")
+  #expect(snapshot.t3ProvisioningStatus?.missingOperatorSteps == [])
   #expect(snapshot.transcriptSections.first?.events.first?.evidenceRefs.timelineRef != nil)
+}
+
+@Test
+func desktopT3ProvisioningStatusNamesOperatorGapsWithoutClaimingReady() throws {
+  let status = MissionWorkbenchT3ProvisioningStatus(
+    truthLabel: "rust_hub_t3_provisioning_read_only_no_mint",
+    paired: true,
+    deviceIdentityCount: 1,
+    trustedDeviceCount: 1,
+    activeTrustedDeviceCount: 1,
+    trustGrantCount: 0,
+    activeTrustGrantCount: 0,
+    contextPassportCount: 0,
+    contextPassportItemCount: 0,
+    latestDevice: MissionWorkbenchTrustedDeviceSummary(
+      deviceId: "proof://device/friday-iphone",
+      label: "Friday iPhone",
+      pairedAt: 1782208748151,
+      pubkeyFingerprint: "f2ccff9e:69f7de33"))
+
+  #expect(status.isFullyProvisioned == false)
+  #expect(status.desktopStatusLabel == "operator action needed")
+  #expect(status.missingOperatorSteps == ["trust grant", "context passport"])
+  #expect(status.desktopSummary == "Missing trust grant, context passport.")
 }
 
 // MARK: - Real FridayRustClient integration (wire → display reconciliation)


### PR DESCRIPTION
## Summary
- add desktop-derived T3 operator gap labels for paired-device / trust-grant / context-passport status
- show the gap summary in the desktop T3 provisioning card without changing wire schema
- cover paired-but-unprovisioned state in desktop core tests

## Truth boundary
- Read/display only: no trust_grant or context_passport minting, no DB writes, no signatures, no app/agent mint endpoint.
- This reduces operator friction but does not claim T3 ready until real operator ceremony rows exist.

## Tests
- swift test --package-path apps/macos/FridayHubConsole --filter OperationsOverviewViewModelTests
- swift test --package-path apps/macos/FridayHubConsole
- git diff --check