### PR TITLE
Use T3 operator action helper from desktop

### DIFF
--- a/apps/macos/FridayHubConsole/Sources/FridayHubConsole/PairingProvisioningScreen.swift
+++ b/apps/macos/FridayHubConsole/Sources/FridayHubConsole/PairingProvisioningScreen.swift
@@ -180,7 +180,7 @@ struct PairingProvisioningScreen: View {
           }
           .buttonStyle(.bordered)
         }
-        Text("Trust grants and context passports stay operator CLI ceremonies; this app only stages the exact command shape.")
+        Text("Trust grants and context passports stay operator CLI ceremonies; this app opens the read-only action helper so the current DB state chooses the exact command.")
           .font(.system(size: 11))
           .foregroundStyle(HubTheme.textSecondary)
           .fixedSize(horizontal: false, vertical: true)

--- a/apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/PairingProvisioningViewModel.swift
+++ b/apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/PairingProvisioningViewModel.swift
@@ -88,19 +88,7 @@ public final class PairingProvisioningViewModel: ObservableObject {
   public static func operatorProvisioningCommand(repoRoot: String = "$FRIDAY_REPO_ROOT") -> String {
     """
     cd \(repoRoot)
-    FRIDAY_T3_OPERATOR_PROVISION_ACK=operator-runs-t3-provisioning \\
-    FRIDAY_T3_STEP=both \\
-    FRIDAY_T3_GRANT_ID=<grant-id> \\
-    FRIDAY_T3_AGENT_ID=<agent-or-device-principal> \\
-    FRIDAY_T3_RISK_CEILING=<low|medium|high> \\
-    FRIDAY_T3_WORKSPACE=<absolute-workspace-path> \\
-    FRIDAY_T3_PROVIDERS=<provider-list> \\
-    FRIDAY_T3_TOOLS=<tool-list> \\
-    FRIDAY_T3_PASSPORT_ID=<passport-id> \\
-    FRIDAY_T3_MISSION_ID=<mission-id> \\
-    FRIDAY_T3_DESTINATION_LANE=<codex|claude|deepseek> \\
-    FRIDAY_T3_ITEMS_JSON=<approved-context-items-json> \\
-    scripts/ops/friday-t3-operator-provision.sh
+    node scripts/ops/friday-t3-provisioning-status.mjs --operator-action
     """
   }
 

--- a/apps/macos/FridayHubConsole/Tests/FridayHubConsoleCoreTests/PairingProvisioningViewModelTests.swift
+++ b/apps/macos/FridayHubConsole/Tests/FridayHubConsoleCoreTests/PairingProvisioningViewModelTests.swift
@@ -3,13 +3,16 @@ import Testing
 @testable import FridayHubConsoleCore
 
 @MainActor
-@Test func operatorProvisioningCommandStaysOperatorOnlyAndPlaceholderBased() async throws {
+@Test func operatorProvisioningCommandUsesReadOnlyActionHelper() async throws {
   let command = PairingProvisioningViewModel.operatorProvisioningCommand(repoRoot: "/repo")
 
   #expect(command.contains("cd /repo"))
-  #expect(command.contains("FRIDAY_T3_OPERATOR_PROVISION_ACK=operator-runs-t3-provisioning")) // pragma: allowlist secret
-  #expect(command.contains("scripts/ops/friday-t3-operator-provision.sh"))
-  #expect(command.contains("<grant-id>"))
+  #expect(command.contains("node scripts/ops/friday-t3-provisioning-status.mjs --operator-action"))
+  #expect(!command.contains("FRIDAY_T3_OPERATOR_PROVISION_ACK=operator-runs-t3-provisioning")) // pragma: allowlist secret
+  #expect(!command.contains("scripts/ops/friday-t3-operator-provision.sh"))
+  #expect(!command.contains("<grant-id>"))
+  #expect(!command.contains("FRIDAY_T3_ITEMS_JSON"))
+  #expect(!command.contains("<<"))
   #expect(!command.contains("operator-approve.key"))
   #expect(!command.contains("operator-signer.key"))
 }


### PR DESCRIPTION
Summary:
- Point the desktop pairing/provisioning copy action at the read-only T3 operator action helper.
- Remove the stale giant placeholder ceremony command from the app surface.
- Keep the app boundary honest: no minting rows, no signing-key access, no flag flips, and no app/agent approval endpoint.

Verification:
- swift test --package-path apps/macos/FridayHubConsole --filter PairingProvisioningViewModelTests

Truth boundary:
- This makes the desktop surface safer and easier to use after T3 provisioning status changes.
- It does not claim END-BAR, GO-LIVE, adoption, or operator signature completion.
