### PR TITLE
Add automation session target evidence

### DIFF
--- a/src/agent/runtime/friday-agent-runtime.types.ts
+++ b/src/agent/runtime/friday-agent-runtime.types.ts
@@ -41,6 +41,12 @@ export interface FridayAgentExecutionContext {
   interactive?: boolean;
   browserPresentationMode?: "auto" | "headless" | "host_chrome_visible";
   packId?: string;
+  /** Automation run evidence for replay/oracle checks. */
+  automationId?: string;
+  automationSessionTargetType?: "isolated" | "named" | "current";
+  automationSessionTargetSource?: "saved" | "run_override";
+  automationSessionKey?: string;
+  automationSourceRunId?: string;
   /** Channel kind when the run enters through a connected chat channel. */
   channelKind?: string;
   /** Channel chat shape for private-memory defaults. */

--- a/src/agent/services/friday-agent-automation-service.ts
+++ b/src/agent/services/friday-agent-automation-service.ts
@@ -126,6 +126,29 @@ export function createFridayAgentAutomationService(
     return sessionTarget.sessionKey;
   }
 
+  function buildAutomationTargetEvidence(input: {
+    automation: FridayAgentAutomationRecord;
+    sessionTarget: FridayAgentAutomationSessionTarget;
+    source: "saved" | "run_override";
+  }): {
+    automationId: string;
+    automationSessionTargetType: FridayAgentAutomationSessionTarget["type"];
+    automationSessionTargetSource: "saved" | "run_override";
+    automationSessionKey?: string;
+    automationSourceRunId?: string;
+  } {
+    const sessionKey = input.sessionTarget.type === "isolated"
+      ? undefined
+      : input.sessionTarget.sessionKey;
+    return {
+      automationId: input.automation.id,
+      automationSessionTargetType: input.sessionTarget.type,
+      automationSessionTargetSource: input.source,
+      ...(sessionKey ? { automationSessionKey: sessionKey } : {}),
+      ...(input.automation.sourceRunId ? { automationSourceRunId: input.automation.sourceRunId } : {}),
+    };
+  }
+
   return {
     attachSchedulerBridge(bridge) {
       schedulerBridge = bridge;
@@ -288,6 +311,7 @@ export function createFridayAgentAutomationService(
       }
 
       const task = input?.taskOverride ?? automation.taskTemplate;
+      const sessionTargetSource = input?.sessionTarget ? "run_override" : "saved";
       const sessionTarget = input?.sessionTarget
         ? resolveSessionTarget({
             sessionTarget: input.sessionTarget,
@@ -297,6 +321,11 @@ export function createFridayAgentAutomationService(
             sessionTarget: automation.sessionTarget,
             sourceRunId: automation.sourceRunId,
           });
+      const targetEvidence = buildAutomationTargetEvidence({
+        automation,
+        sessionTarget,
+        source: sessionTargetSource,
+      });
 
       const result = await startRun({
         task,
@@ -308,6 +337,7 @@ export function createFridayAgentAutomationService(
         executionContext: {
           surface: "agent.automation",
           interactive: false,
+          ...targetEvidence,
         },
       });
 
@@ -339,6 +369,7 @@ export function createFridayAgentAutomationService(
             sourceAutomationId: automationId,
             sourceRunId: automation.sourceRunId ?? null,
             resultRunId: result.runId,
+            ...targetEvidence,
             previousPromotionState: automation.promotionState,
             promotionState: nextInsights.promotionState,
             reuseCount: nextInsights.reuseCount,
@@ -350,9 +381,9 @@ export function createFridayAgentAutomationService(
       writeLearningEvent({
         kind: "automation_reused",
         payload: {
-          automationId,
           sourceRunId: automation.sourceRunId ?? null,
           resultRunId: result.runId,
+          ...targetEvidence,
           reuseCount: nextInsights.reuseCount,
           lastOutcomeScore: nextInsights.lastOutcomeScore,
           success: result.status === "completed",
@@ -362,8 +393,8 @@ export function createFridayAgentAutomationService(
         writeLearningEvent({
           kind: "outcome_confirmed",
           payload: {
-            automationId,
             resultRunId: result.runId,
+            ...targetEvidence,
             outcomeScore: computeAutomationOutcomeScore(result),
             estimatedTimeSavedMinutes: nextInsights.estimatedTimeSavedMinutes,
           },

--- a/test/unit/agent/services/friday-agent-automation-service.test.ts
+++ b/test/unit/agent/services/friday-agent-automation-service.test.ts
@@ -7,6 +7,7 @@ import {
 } from "#agent";
 import type { FridayLearningEventAppendInput } from "#ledger";
 import type {
+  FridayAgentExecutionContext,
   FridayAgentAutomationSchedulerBridge,
   FridayAgentAutomationService,
   FridayAgentRuntimeResult,
@@ -25,10 +26,7 @@ describe("FridayAgentAutomationService", () => {
     model?: string;
     timezone?: string;
     timeoutMs?: number;
-    executionContext?: {
-      surface?: string;
-      interactive?: boolean;
-    };
+    executionContext?: FridayAgentExecutionContext;
   }) => Promise<FridayAgentRuntimeResult>>>;
   const NOW = "2026-02-19T10:00:00.000Z";
 
@@ -43,10 +41,7 @@ describe("FridayAgentAutomationService", () => {
       model?: string;
       timezone?: string;
       timeoutMs?: number;
-      executionContext?: {
-        surface?: string;
-        interactive?: boolean;
-      };
+      executionContext?: FridayAgentExecutionContext;
     }) => Promise<FridayAgentRuntimeResult>>().mockResolvedValue({
       runId: "run-result-001",
       status: "completed",
@@ -350,6 +345,9 @@ describe("FridayAgentAutomationService", () => {
         executionContext: {
           surface: "agent.automation",
           interactive: false,
+          automationId: created.id,
+          automationSessionTargetType: "isolated",
+          automationSessionTargetSource: "saved",
         },
       });
       expect(result.runId).toBe("run-result-001");
@@ -370,6 +368,9 @@ describe("FridayAgentAutomationService", () => {
           executionContext: {
             surface: "agent.automation",
             interactive: false,
+            automationId: created.id,
+            automationSessionTargetType: "isolated",
+            automationSessionTargetSource: "saved",
           },
         }),
       );
@@ -397,6 +398,9 @@ describe("FridayAgentAutomationService", () => {
         executionContext: {
           surface: "agent.automation",
           interactive: false,
+          automationId: created.id,
+          automationSessionTargetType: "isolated",
+          automationSessionTargetSource: "saved",
         },
       });
     });
@@ -413,6 +417,12 @@ describe("FridayAgentAutomationService", () => {
       expect(mockStartRun).toHaveBeenCalledWith(expect.objectContaining({
         task: "task",
         sessionKey: "named-session-1",
+        executionContext: expect.objectContaining({
+          automationId: created.id,
+          automationSessionTargetType: "named",
+          automationSessionTargetSource: "saved",
+          automationSessionKey: "named-session-1",
+        }),
       }));
     });
 
@@ -429,7 +439,50 @@ describe("FridayAgentAutomationService", () => {
       expect(mockStartRun).toHaveBeenCalledWith(expect.objectContaining({
         task: "task",
         sessionKey: "override-session",
+        executionContext: expect.objectContaining({
+          automationId: created.id,
+          automationSessionTargetType: "named",
+          automationSessionTargetSource: "run_override",
+          automationSessionKey: "override-session",
+        }),
       }));
+    });
+
+    it("records current-source session target evidence for run oracles", async () => {
+      db.withWriteTransaction((writer) => {
+        writer.prepare(
+          `INSERT INTO friday_agent_runs (id, task, status, session_key, attempt, max_attempts, created_at)
+           VALUES ('run-123', 'seed task', 'completed', 'session-from-source', 0, 3, ?)`,
+        ).run(NOW);
+      });
+
+      const created = service.save({
+        name: "Current Session Evidence",
+        sourceRunId: "run-123",
+        taskTemplate: "continue",
+        sessionTarget: { type: "current" },
+      });
+
+      await service.run(created.id);
+
+      expect(mockStartRun).toHaveBeenCalledWith(expect.objectContaining({
+        sessionKey: "session-from-source",
+        executionContext: expect.objectContaining({
+          automationId: created.id,
+          automationSessionTargetType: "current",
+          automationSessionTargetSource: "saved",
+          automationSessionKey: "session-from-source",
+          automationSourceRunId: "run-123",
+        }),
+      }));
+      expect(learningEvents.find((event) => event.kind === "automation_reused")?.payload)
+        .toMatchObject({
+          automationId: created.id,
+          automationSessionTargetType: "current",
+          automationSessionTargetSource: "saved",
+          automationSessionKey: "session-from-source",
+          automationSourceRunId: "run-123",
+        });
     });
 
     it("updates last run info after execution", async () => {


### PR DESCRIPTION
## Summary
- add automation session target/source evidence to Friday agent execution context
- include the resolved automation target evidence in run learning event payloads
- cover saved/current/run-override session target cases in the automation service tests

## Verification
- `npm exec -- vitest run test/unit/agent/services/friday-agent-automation-service.test.ts`
- `npm run typecheck:src`

## Truth boundary
Evidence/oracle improvement only. This does not claim END-BAR, GO-LIVE, adoption, operator signature completion, or any routing behavior change.
