### PR TITLE
Surface iOS T3 provisioning counts

### DIFF
--- a/apps/friday-ios/Sources/FridayMobileShell/FridayHomeScreen.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayHomeScreen.swift
@@ -297,9 +297,16 @@ struct FridayHomeScreen: View {
         RefPill(label: "missing", ref: status.missingOperatorSteps.joined(separator: ", "))
       }
       if let device = status.latestDevice {
-        RefPill(label: "trusted_device", ref: device.deviceId)
+        RefPill(label: "latest_device", ref: device.deviceId)
         RefPill(label: "device_fingerprint", ref: device.pubkeyFingerprint)
       }
+      RefPill(label: "device_identity_count", ref: String(status.deviceIdentityCount))
+      RefPill(label: "trusted_device_count", ref: String(status.trustedDeviceCount))
+      RefPill(label: "active_trusted_device_count", ref: String(status.activeTrustedDeviceCount))
+      RefPill(label: "trust_grant_count", ref: String(status.trustGrantCount))
+      RefPill(label: "active_trust_grant_count", ref: String(status.activeTrustGrantCount))
+      RefPill(label: "context_passport_count", ref: String(status.contextPassportCount))
+      RefPill(label: "context_passport_item_count", ref: String(status.contextPassportItemCount))
       RefPill(label: "truth", ref: status.truthLabel)
     } else {
       Text("Open a loaded Hub projection to see PairAck, trust grant, and context passport status.")

--- a/apps/friday-ios/Sources/FridayMobileShellCore/HomeViewModel.swift
+++ b/apps/friday-ios/Sources/FridayMobileShellCore/HomeViewModel.swift
@@ -294,11 +294,11 @@ public struct HomeT3ProvisioningStatus: Sendable, Equatable {
 
   public var homeSummary: String {
     if isFullyProvisioned {
-      return "Hub projection shows paired device, active trust grant, and context passport rows."
+      return "Hub projection shows \(deviceIdentityCount) device identity, \(activeTrustedDeviceCount) active trusted device, \(activeTrustGrantCount) active trust grant, \(contextPassportCount) context passport, and \(contextPassportItemCount) passport items."
     }
     let missing = missingOperatorSteps.joined(separator: ", ")
     if paired {
-      return "Paired device is visible in the Hub; missing \(missing)."
+      return "Paired device is visible in the Hub (\(activeTrustedDeviceCount) active trusted device); missing \(missing)."
     }
     return "No complete T3 device pairing in the Hub projection; missing \(missing)."
   }

--- a/apps/friday-ios/Tests/FridayMobileShellCoreTests/HomeViewModelTests.swift
+++ b/apps/friday-ios/Tests/FridayMobileShellCoreTests/HomeViewModelTests.swift
@@ -382,6 +382,9 @@ final class HomeViewModelTests: XCTestCase {
     XCTAssertEqual(p.t3ProvisioningStatus?.latestDevice?.pubkeyFingerprint, "abcd1234:dcba4321")
     XCTAssertEqual(p.t3ProvisioningStatus?.isFullyProvisioned, true)
     XCTAssertEqual(p.t3ProvisioningStatus?.homeStatusLabel, "fully provisioned")
+    XCTAssertEqual(
+      p.t3ProvisioningStatus?.homeSummary,
+      "Hub projection shows 1 device identity, 1 active trusted device, 1 active trust grant, 1 context passport, and 2 passport items.")
     XCTAssertEqual(p.t3ProvisioningStatus?.missingOperatorSteps, [])
     XCTAssertEqual(p.transcriptEvents.first?.summary, "Mobile surface read the mission projection.")
     XCTAssertEqual(p.needsMeCount, 4)
@@ -421,7 +424,7 @@ final class HomeViewModelTests: XCTestCase {
     XCTAssertEqual(projection.t3ProvisioningStatus?.missingOperatorSteps, ["trust grant", "context passport"])
     XCTAssertEqual(
       projection.t3ProvisioningStatus?.homeSummary,
-      "Paired device is visible in the Hub; missing trust grant, context passport.")
+      "Paired device is visible in the Hub (1 active trusted device); missing trust grant, context passport.")
   }
 
   func testRefresh_loadedEmptyIsConnectedEmptyNotUnavailable() async throws {


### PR DESCRIPTION
## Summary
- surface refs-only T3 provisioning counts in the iOS Home summary once operator grant/passport rows exist
- include active trusted device, active grant, context passport, and passport item counts in the mobile provisioning rows
- keep missing-state copy honest: counts are projection evidence, not END-BAR/GO-LIVE/adoption claims

## Verification
- swift test --package-path apps/friday-ios --filter HomeViewModelTests
