### PR TITLE
Clarify iOS simulator proof modes

### DIFF
--- a/apps/friday-ios/README.md
+++ b/apps/friday-ios/README.md
@@ -80,7 +80,9 @@ side with `nonisolated(unsafe) let` clients (the package is never edited).
 ## Build + screenshot (simulator)
 
 ```sh
-apps/friday-ios/build-sim.sh   # -> .build-sim/friday-ios-sim.png
+apps/friday-ios/build-sim.sh
+# -> .build-sim/friday-ios-sim.png
+# -> .build-sim/friday-ios-sim.png.metadata.json
 ```
 
 Because the core now depends on `FridayRustClient` â†’ swift-sodium (libsodium via the
@@ -89,6 +91,27 @@ dependency graph for `arm64-apple-ios17.0-simulator` via `swift build --triple â
 (resolving swift-sodium + linking the xcframework's ios-simulator libsodium slice),
 then compiles the SwiftUI app against those sim-built modules with `swiftc`, assembles
 `FridayShell.app`, and installs/launches/screenshots it on a booted simulator.
+
+The default simulator launch is an **offline truth proof**. It deliberately keeps all
+`FRIDAY_MOBILE_LIVE_*` gates off, so the expected result is an honest-unavailable UI
+if the live seams are not explicitly enabled. That screenshot proves "no fabricated
+ready state"; it is not a product-ready live-use proof.
+
+For local live-loopback dogfood, use the explicit mode:
+
+```sh
+apps/friday-ios/build-sim.sh --mode live-loopback --shot apps/friday-ios/.build-sim/friday-ios-live-loopback.png
+```
+
+`live-loopback` passes the existing `--live-read`, `--live-write`, `--live-pairing`,
+and `--live-device-keypair` launch gates via simulator args/env so the app attempts
+the real local read/write/pairing seams. Because the hand-built simulator shell is not
+signed with an iOS development Keychain entitlement, this mode also uses an explicit
+simulator-only file-backed device keypair gate. Real devices still use the Keychain
+backend. It still does **not** flip shipped defaults, mint trust grants/context
+passports, hold signing keys, or claim END-BAR/GO-LIVE. The adjacent `.metadata.json`
+records which proof mode produced the screenshot and, in live-loopback mode, the public
+simulator device key needed for read-seam enrollment.
 
 **Device/simulator screenshot proof is operator-gated** (it needs Xcode + a booted
 simulator or a physical device); it is a deferred acceptance criterion. The

--- a/apps/friday-ios/Sources/FridayMobileShell/FridayApp.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayApp.swift
@@ -18,7 +18,44 @@
 
 import FridayMobileShellCore
 import FridayRustClient
+import Foundation
 import SwiftUI
+
+#if targetEnvironment(simulator)
+private struct SimulatorFileDeviceKeypairBackend: DeviceKeypairBackend {
+  private let url: URL
+  private let publicKeyURL: URL
+
+  init(fileManager: FileManager = .default) {
+    let base = fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
+      ?? fileManager.temporaryDirectory
+    let directory = base.appendingPathComponent("FridayShellSimulatorProof", isDirectory: true)
+    try? fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
+    self.url = directory.appendingPathComponent("device-keypair-v1.bin")
+    self.publicKeyURL = directory.appendingPathComponent("device-pubkey-v1.txt")
+  }
+
+  func loadSecret() throws -> [UInt8]? {
+    guard FileManager.default.fileExists(atPath: url.path) else { return nil }
+    let secret = [UInt8](try Data(contentsOf: url))
+    writePublicKeySidecar(for: secret)
+    return secret
+  }
+
+  func storeSecret(_ secret: [UInt8]) throws {
+    try FileManager.default.createDirectory(
+      at: url.deletingLastPathComponent(),
+      withIntermediateDirectories: true)
+    try Data(secret).write(to: url, options: [.atomic])
+    writePublicKeySidecar(for: secret)
+  }
+
+  private func writePublicKeySidecar(for secret: [UInt8]) {
+    guard let keypair = try? FridayCrypto.DeviceKeypair(secretBytes: secret) else { return }
+    try? Hex.encode(keypair.publicKey).write(to: publicKeyURL, atomically: true, encoding: .utf8)
+  }
+}
+#endif
 
 /// The app's real-client wiring: the device X25519 transport keypair + the REAL sealed-WS
 /// read/write clients (built via `FridayClientFactory`) + the operator-signer RELAY seam.
@@ -42,6 +79,7 @@ final class FridaySession: ObservableObject {
   let writeClient: FridayRustWriteClient
   let missionClient: FridayMobileMissionDispatchingWriteClient?
   let devicePairing: DevicePairingReadiness
+  let deviceKeypairBackend: DeviceKeypairBackend
   let makePairingClient: (DeviceKeypair) -> FridayPairingClient?
   /// The operator-signing RELAY. Mock today (NOT a real signature); the real desktop signer
   /// (PR #671) is the slice-6 / operator-key gate. The phone holds NO signing key (INV-1).
@@ -55,6 +93,10 @@ final class FridaySession: ObservableObject {
     let args = ProcessInfo.processInfo.arguments
     let env = ProcessInfo.processInfo.environment
     self.runControlEnabled = preview ? false : Self.runControlRequested(args: args, env: env)
+    let selectedDeviceKeypairBackend: DeviceKeypairBackend = preview
+      ? KeychainDeviceKeypairBackend()
+      : Self.defaultDeviceKeypairBackend(args: args, env: env)
+    self.deviceKeypairBackend = selectedDeviceKeypairBackend
 
     // SINGLE-PEER-TRAP SAFETY: the DEFAULT read client mints NO X25519 keypair, opens NO socket,
     // and touches NO SecureStore — it is the no-key `HonestlyUnavailableReadClient`, which always
@@ -66,10 +108,12 @@ final class FridaySession: ObservableObject {
     // wired here behind an OPT-IN env/arg gate (`FRIDAY_MOBILE_LIVE_READ=1` / `--live-read`,
     // mirroring the desktop `FRIDAY_CONSOLE_LIVE`). The DEFAULT (gate OFF) stays the honest-
     // unavailable client — this PR does NOT flip the shipped default (that is the slice-6 gate).
-    self.readClient = preview ? PreviewReadClient() : Self.defaultReadClient()
+    self.readClient = preview
+      ? PreviewReadClient()
+      : Self.defaultReadClient(deviceKeypairBackend: selectedDeviceKeypairBackend)
     self.devicePairing = preview
       ? .evaluate(deviceKeypairRequested: false, readLiveRequested: false, writeLiveRequested: false)
-      : Self.defaultDevicePairingReadiness()
+      : Self.defaultDevicePairingReadiness(deviceKeypairBackend: selectedDeviceKeypairBackend)
     self.makePairingClient = preview || !Self.livePairingRequested(args: args, env: env)
       ? { _ in nil }
       : Self.defaultPairingClient
@@ -87,7 +131,9 @@ final class FridaySession: ObservableObject {
       self.writeClient = Self.honestUnavailableWriteClient()
       self.missionClient = nil
     } else {
-      let liveWrite = Self.defaultLiveWriteClient(runControlEnabled: runControlEnabled)
+      let liveWrite = Self.defaultLiveWriteClient(
+        runControlEnabled: runControlEnabled,
+        deviceKeypairBackend: selectedDeviceKeypairBackend)
       self.writeClient = liveWrite ?? Self.honestUnavailableWriteClient(runControlEnabled: runControlEnabled)
       self.missionClient = liveWrite
     }
@@ -104,7 +150,9 @@ final class FridaySession: ObservableObject {
   /// master key is unavailable (e.g. a real phone — the J2 pairing problem), surface the TRUTH
   /// (honest unavailable) — NEVER fall back to the preview sample, which would fabricate a ready
   /// view the live seam did not produce.
-  static func defaultReadClient() -> FridayRustReadClient {
+  static func defaultReadClient(
+    deviceKeypairBackend: DeviceKeypairBackend = KeychainDeviceKeypairBackend()
+  ) -> FridayRustReadClient {
     let args = ProcessInfo.processInfo.arguments
     let env = ProcessInfo.processInfo.environment
     let useLive = liveReadRequested(args: args, env: env)
@@ -114,7 +162,7 @@ final class FridaySession: ObservableObject {
     }
     do {
       if useDeviceKeypair(args: args, env: env) {
-        let device = try DeviceKeypairStore.loadOrGenerate()
+        let device = try DeviceKeypairStore.loadOrGenerate(backend: deviceKeypairBackend)
         return RealReadClientFactory.makeLive(deviceKeypair: device)
       }
       return try RealReadClientFactory.makeLive()
@@ -140,7 +188,8 @@ final class FridaySession: ObservableObject {
   }
 
   static func defaultLiveWriteClient(
-    runControlEnabled: Bool
+    runControlEnabled: Bool,
+    deviceKeypairBackend: DeviceKeypairBackend = KeychainDeviceKeypairBackend()
   ) -> FridayMobileMissionDispatchingWriteClient? {
     let args = ProcessInfo.processInfo.arguments
     let env = ProcessInfo.processInfo.environment
@@ -150,7 +199,7 @@ final class FridaySession: ObservableObject {
     }
     do {
       if useDeviceKeypair(args: args, env: env) {
-        let device = try DeviceKeypairStore.loadOrGenerate()
+        let device = try DeviceKeypairStore.loadOrGenerate(backend: deviceKeypairBackend)
         return RealWriteClientFactory.makeLive(
           deviceKeypair: device,
           agentRunControlViaRust: runControlEnabled)
@@ -165,6 +214,15 @@ final class FridaySession: ObservableObject {
 
   static func useDeviceKeypair(args: [String], env: [String: String]) -> Bool {
     MobileRuntimeGates.useDeviceKeypair(args: args, env: env)
+  }
+
+  static func defaultDeviceKeypairBackend(args: [String], env: [String: String]) -> DeviceKeypairBackend {
+    #if targetEnvironment(simulator)
+    if MobileRuntimeGates.simulatorFileDeviceKeypairRequested(args: args, env: env) {
+      return SimulatorFileDeviceKeypairBackend()
+    }
+    #endif
+    return KeychainDeviceKeypairBackend()
   }
 
   static func liveReadRequested(args: [String], env: [String: String]) -> Bool {
@@ -194,13 +252,16 @@ final class FridaySession: ObservableObject {
     return RealPairingClientFactory.makeLive(deviceKeypair: deviceKeypair)
   }
 
-  static func defaultDevicePairingReadiness() -> DevicePairingReadiness {
+  static func defaultDevicePairingReadiness(
+    deviceKeypairBackend: DeviceKeypairBackend = KeychainDeviceKeypairBackend()
+  ) -> DevicePairingReadiness {
     let args = ProcessInfo.processInfo.arguments
     let env = ProcessInfo.processInfo.environment
     return DevicePairingReadiness.evaluate(
       deviceKeypairRequested: useDeviceKeypair(args: args, env: env),
       readLiveRequested: liveReadRequested(args: args, env: env),
-      writeLiveRequested: liveWriteRequested(args: args, env: env))
+      writeLiveRequested: liveWriteRequested(args: args, env: env),
+      backend: deviceKeypairBackend)
   }
 
   /// The honest-unavailable WRITE client: the shared `FridayClientFactory.makeWriteClient` with its
@@ -238,6 +299,7 @@ struct RootView: View {
       client: session.readClient,
       writeClient: session.missionClient,
       devicePairing: session.devicePairing,
+      deviceKeypairBackend: session.deviceKeypairBackend,
       makePairingClient: session.makePairingClient))
     _sessionContinuationVM = StateObject(wrappedValue: SessionContinuationViewModel(
       client: session.readClient,

--- a/apps/friday-ios/Sources/FridayMobileShellCore/HomeViewModel.swift
+++ b/apps/friday-ios/Sources/FridayMobileShellCore/HomeViewModel.swift
@@ -670,6 +670,7 @@ public final class HomeViewModel: ObservableObject {
   private let client: FridayRustReadClient
   private let writeClient: FridayMissionSpineWriteClient?
   private let writeOwnerPrincipal: String
+  private let deviceKeypairBackend: DeviceKeypairBackend
   private let makePairingClient: (DeviceKeypair) -> FridayPairingClient?
 
   /// - Parameter client: the read client. In production this is the real `SealedWSReadClient`
@@ -682,12 +683,14 @@ public final class HomeViewModel: ObservableObject {
       deviceKeypairRequested: false,
       readLiveRequested: false,
       writeLiveRequested: false),
+    deviceKeypairBackend: DeviceKeypairBackend = KeychainDeviceKeypairBackend(),
     makePairingClient: @escaping (DeviceKeypair) -> FridayPairingClient? = { _ in nil }
   ) {
     self.client = client
     self.writeClient = writeClient
     self.writeOwnerPrincipal = writeOwnerPrincipal
     self.devicePairing = devicePairing
+    self.deviceKeypairBackend = deviceKeypairBackend
     self.makePairingClient = makePairingClient
   }
 
@@ -836,12 +839,13 @@ public final class HomeViewModel: ObservableObject {
   public func preflightPairingQR(
     _ qrPayload: String,
     nowMs: Int64 = Int64(Date().timeIntervalSince1970 * 1000),
-    backend: DeviceKeypairBackend = KeychainDeviceKeypairBackend()
+    backend: DeviceKeypairBackend? = nil
   ) {
+    let selectedBackend = backend ?? deviceKeypairBackend
     pairingPreflight = MobilePairingPreflight.evaluate(
       qrPayload: qrPayload,
       nowMs: nowMs,
-      backend: backend)
+      backend: selectedBackend)
   }
 
   public func clearPairingPreflight() {
@@ -853,8 +857,9 @@ public final class HomeViewModel: ObservableObject {
     _ qrPayload: String,
     deviceId: String = "",
     nowMs: Int64 = Int64(Date().timeIntervalSince1970 * 1000),
-    backend: DeviceKeypairBackend = KeychainDeviceKeypairBackend()
+    backend: DeviceKeypairBackend? = nil
   ) async {
+    let selectedBackend = backend ?? deviceKeypairBackend
     let payload = qrPayload.trimmingCharacters(in: .whitespacesAndNewlines)
     guard !payload.isEmpty else {
       pairingPreflight = .empty
@@ -870,20 +875,20 @@ public final class HomeViewModel: ObservableObject {
       pairingPreflight = MobilePairingPreflight.evaluate(
         qrPayload: payload,
         nowMs: nowMs,
-        backend: backend)
+        backend: selectedBackend)
       pairingAttempt = .unavailable(pairingPreflight.projection, reason: Self.pairingReason(for: error))
       return
     }
 
     let device: DeviceKeypair
     do {
-      device = try DeviceKeypairStore.loadOrGenerate(backend: backend)
+      device = try DeviceKeypairStore.loadOrGenerate(backend: selectedBackend)
       _ = try manifest.pairingProof(forDevicePublicKey: device.keypair.publicKey)
     } catch {
       pairingPreflight = MobilePairingPreflight.evaluate(
         qrPayload: payload,
         nowMs: nowMs,
-        backend: backend)
+        backend: selectedBackend)
       pairingAttempt = .unavailable(
         manifest.redactedProjection,
         reason: "Device keypair store is unavailable.")

--- a/apps/friday-ios/Sources/FridayMobileShellCore/MobileRuntimeGates.swift
+++ b/apps/friday-ios/Sources/FridayMobileShellCore/MobileRuntimeGates.swift
@@ -5,6 +5,11 @@ public enum MobileRuntimeGates {
     args.contains("--live-device-keypair") || env["FRIDAY_MOBILE_LIVE_DEVICE_KEYPAIR"] == "1"
   }
 
+  public static func simulatorFileDeviceKeypairRequested(args: [String], env: [String: String]) -> Bool {
+    args.contains("--simulator-file-device-keypair")
+      || env["FRIDAY_MOBILE_SIMULATOR_FILE_DEVICE_KEYPAIR"] == "1"
+  }
+
   public static func liveReadRequested(args: [String], env: [String: String]) -> Bool {
     args.contains("--live-read") || env["FRIDAY_MOBILE_LIVE_READ"] == "1"
   }

--- a/apps/friday-ios/Tests/FridayMobileShellCoreTests/MobileRuntimeGatesTests.swift
+++ b/apps/friday-ios/Tests/FridayMobileShellCoreTests/MobileRuntimeGatesTests.swift
@@ -7,6 +7,7 @@ func mobileRuntimeGatesDefaultOff() {
   #expect(!MobileRuntimeGates.liveWriteRequested(args: [], env: [:]))
   #expect(!MobileRuntimeGates.livePairingRequested(args: [], env: [:]))
   #expect(!MobileRuntimeGates.useDeviceKeypair(args: [], env: [:]))
+  #expect(!MobileRuntimeGates.simulatorFileDeviceKeypairRequested(args: [], env: [:]))
   #expect(!MobileRuntimeGates.runControlRequested(args: [], env: [:]))
 }
 
@@ -16,6 +17,9 @@ func mobileRuntimeGatesAcceptExplicitArgs() {
   #expect(MobileRuntimeGates.liveWriteRequested(args: ["--live-write"], env: [:]))
   #expect(MobileRuntimeGates.livePairingRequested(args: ["--live-pairing"], env: [:]))
   #expect(MobileRuntimeGates.useDeviceKeypair(args: ["--live-device-keypair"], env: [:]))
+  #expect(MobileRuntimeGates.simulatorFileDeviceKeypairRequested(
+    args: ["--simulator-file-device-keypair"],
+    env: [:]))
   #expect(MobileRuntimeGates.runControlRequested(args: ["--agent-run-control-via-rust"], env: [:]))
   #expect(MobileRuntimeGates.runControlRequested(args: ["--run-control"], env: [:]))
 }
@@ -26,6 +30,9 @@ func mobileRuntimeGatesAcceptExplicitEnv() {
   #expect(MobileRuntimeGates.liveWriteRequested(args: [], env: ["FRIDAY_MOBILE_LIVE_WRITE": "1"]))
   #expect(MobileRuntimeGates.livePairingRequested(args: [], env: ["FRIDAY_MOBILE_LIVE_PAIRING": "1"]))
   #expect(MobileRuntimeGates.useDeviceKeypair(args: [], env: ["FRIDAY_MOBILE_LIVE_DEVICE_KEYPAIR": "1"]))
+  #expect(MobileRuntimeGates.simulatorFileDeviceKeypairRequested(
+    args: [],
+    env: ["FRIDAY_MOBILE_SIMULATOR_FILE_DEVICE_KEYPAIR": "1"]))
   #expect(MobileRuntimeGates.runControlRequested(
     args: [],
     env: ["FRIDAY_MOBILE_AGENT_RUN_CONTROL_VIA_RUST": "1"]))
@@ -37,6 +44,9 @@ func mobileRuntimeGatesDoNotAcceptTruthyLookalikes() {
   #expect(!MobileRuntimeGates.liveReadRequested(args: [], env: ["FRIDAY_MOBILE_LIVE_READ": "true"]))
   #expect(!MobileRuntimeGates.liveWriteRequested(args: [], env: ["FRIDAY_MOBILE_LIVE_WRITE": "yes"]))
   #expect(!MobileRuntimeGates.livePairingRequested(args: [], env: ["FRIDAY_MOBILE_LIVE_PAIRING": "TRUE"]))
+  #expect(!MobileRuntimeGates.simulatorFileDeviceKeypairRequested(
+    args: [],
+    env: ["FRIDAY_MOBILE_SIMULATOR_FILE_DEVICE_KEYPAIR": "true"]))
   #expect(!MobileRuntimeGates.runControlRequested(
     args: [],
     env: ["FRIDAY_MOBILE_AGENT_RUN_CONTROL_VIA_RUST": "true"]))

--- a/apps/friday-ios/build-sim.sh
+++ b/apps/friday-ios/build-sim.sh
@@ -21,14 +21,82 @@
 # physical device); this script is a LOCAL proof, not a CI step.
 set -euo pipefail
 
+usage() {
+  cat <<'USAGE'
+Usage:
+  apps/friday-ios/build-sim.sh [screenshot-path]
+  apps/friday-ios/build-sim.sh --mode offline-truth [--shot screenshot-path]
+  apps/friday-ios/build-sim.sh --mode live-loopback [--shot screenshot-path]
+
+Modes:
+  offline-truth  Default. Launches with all FRIDAY_MOBILE_LIVE_* gates OFF and proves the
+                 shipped app renders honest-unavailable instead of fabricated ready state.
+  live-loopback  Explicit local proof mode. Launches with the existing simulator live gates ON
+                 (read/write/pairing/device-keypair) so the app attempts real loopback seams.
+                 It still does not flip shipped defaults, mint trust, or hold signing keys.
+USAGE
+}
+
 HERE="$(cd "$(dirname "$0")" && pwd)"
 BUILD="$HERE/.build-sim"
 APP="$BUILD/FridayShell.app"
-SHOT="${1:-$BUILD/friday-ios-sim.png}"
+MODE="offline-truth"
+SHOT="$BUILD/friday-ios-sim.png"
 IOS_VERSION="17.0"
 TRIPLE="arm64-apple-ios${IOS_VERSION}-simulator"   # Apple-Silicon host (arm64 sim slice)
 
 APPSRC="$HERE/Sources/FridayMobileShell"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --mode)
+      if [[ $# -lt 2 ]]; then
+        echo "ERROR: --mode requires a value" >&2
+        usage >&2
+        exit 2
+      fi
+      MODE="$2"
+      shift 2
+      ;;
+    --shot)
+      if [[ $# -lt 2 ]]; then
+        echo "ERROR: --shot requires a path" >&2
+        usage >&2
+        exit 2
+      fi
+      SHOT="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    --*)
+      echo "ERROR: unknown option $1" >&2
+      usage >&2
+      exit 2
+      ;;
+    *)
+      # Backward-compatible positional screenshot path.
+      SHOT="$1"
+      shift
+      ;;
+  esac
+done
+
+case "$MODE" in
+  offline|offline-truth)
+    MODE="offline-truth"
+    ;;
+  live|live-loopback)
+    MODE="live-loopback"
+    ;;
+  *)
+    echo "ERROR: unsupported --mode '$MODE'" >&2
+    usage >&2
+    exit 2
+    ;;
+esac
 
 rm -rf "$BUILD"; mkdir -p "$BUILD" "$APP"
 
@@ -90,12 +158,64 @@ open -a Simulator || true
 
 echo "== 4. install + launch + screenshot =="
 xcrun simctl install "$UDID" "$APP"
-xcrun simctl launch "$UDID" com.friday.shell
+LAUNCH_ARGS=()
+LAUNCH_ENV=()
+case "$MODE" in
+  offline-truth)
+    echo "launch mode: offline-truth (all mobile live gates OFF)"
+    ;;
+  live-loopback)
+    echo "launch mode: live-loopback (explicit FRIDAY_MOBILE_LIVE_* gates ON)"
+    LAUNCH_ARGS=(--live-read --live-write --live-pairing --live-device-keypair)
+    LAUNCH_ARGS+=(--simulator-file-device-keypair)
+    LAUNCH_ENV=(
+      SIMCTL_CHILD_FRIDAY_MOBILE_LIVE_READ=1
+      SIMCTL_CHILD_FRIDAY_MOBILE_LIVE_WRITE=1
+      SIMCTL_CHILD_FRIDAY_MOBILE_LIVE_PAIRING=1
+      SIMCTL_CHILD_FRIDAY_MOBILE_LIVE_DEVICE_KEYPAIR=1
+      SIMCTL_CHILD_FRIDAY_MOBILE_SIMULATOR_FILE_DEVICE_KEYPAIR=1
+    )
+    ;;
+esac
+env "${LAUNCH_ENV[@]}" xcrun simctl launch --terminate-running-process "$UDID" com.friday.shell "${LAUNCH_ARGS[@]}"
 # Give the WKWebView time to load the host page over `friday-pet://`, fetch the bundled engine +
 # v9 assets, and start the canvas animation before the screenshot. Per the design CLAUDE.md hard
 # rule 5, the pet is verified by the RENDERED image (open $SHOT), not by code/bbox numbers — a
 # scheme/fetch bug yields a BLANK card (the host page sets window.__petError), so inspect the shot.
 sleep 6
 xcrun simctl io "$UDID" screenshot "$SHOT"
+SIMULATOR_DEVICE_PUBKEY_JSON=null
+if [[ "$MODE" == "live-loopback" ]]; then
+  DATA_CONTAINER="$(xcrun simctl get_app_container "$UDID" com.friday.shell data 2>/dev/null || true)"
+  PUBKEY_FILE="$DATA_CONTAINER/Library/Application Support/FridayShellSimulatorProof/device-pubkey-v1.txt"
+  if [[ -n "$DATA_CONTAINER" && -f "$PUBKEY_FILE" ]]; then
+    PUBKEY_HEX="$(tr -d '\r\n' < "$PUBKEY_FILE")"
+    if [[ "$PUBKEY_HEX" =~ ^[0-9a-fA-F]{64}$ ]]; then
+      PUBKEY_HEX_LOWER="$(printf '%s' "$PUBKEY_HEX" | tr '[:upper:]' '[:lower:]')"
+      SIMULATOR_DEVICE_PUBKEY_JSON="\"$PUBKEY_HEX_LOWER\""
+    fi
+  fi
+fi
+cat > "$SHOT.metadata.json" <<JSON
+{
+  "truth_label": "friday_ios_simulator_${MODE}_proof",
+  "mode": "$MODE",
+  "bundle_id": "com.friday.shell",
+  "screenshot": "$SHOT",
+  "live_read_requested": $([[ "$MODE" == "live-loopback" ]] && echo true || echo false),
+  "live_write_requested": $([[ "$MODE" == "live-loopback" ]] && echo true || echo false),
+  "live_pairing_requested": $([[ "$MODE" == "live-loopback" ]] && echo true || echo false),
+  "device_keypair_requested": $([[ "$MODE" == "live-loopback" ]] && echo true || echo false),
+  "simulator_file_device_keypair_requested": $([[ "$MODE" == "live-loopback" ]] && echo true || echo false),
+  "simulator_device_pubkey": $SIMULATOR_DEVICE_PUBKEY_JSON,
+  "caveat": "offline-truth proves honest-unavailable; live-loopback attempts real local read/write/pairing seams but does not claim END-BAR, GO-LIVE, adoption, trust minting, or operator signing."
+}
+JSON
 echo "screenshot: $SHOT"
+echo "metadata: $SHOT.metadata.json"
 echo "VERIFY: open the screenshot and confirm the 155px Hero Pet card shows the v9 DOG (not blank)."
+if [[ "$MODE" == "offline-truth" ]]; then
+  echo "VERIFY: offline-truth mode should honestly show unavailable/disabled state, not a fabricated ready product."
+else
+  echo "VERIFY: live-loopback mode should show live read/write/pairing requests and any real seam failure AS truth."
+fi


### PR DESCRIPTION
## Summary
- Add explicit offline-truth and live-loopback modes to the iOS simulator build/screenshot script.
- Keep shipped simulator defaults safe/offline unless live-loopback is explicitly requested.
- Emit adjacent screenshot metadata so UI proofs record whether live read/write/pairing/device-keypair gates were requested.
- Add an explicit simulator-only file-backed device keypair gate for local live-loopback proofs, because this hand-built simulator shell has no iOS development Keychain entitlement. Real devices still use the Keychain backend.
- Inject the selected device-keypair backend through Home pairing preflight/pair flows so readiness and PairAck use the same identity source.
- Write a simulator-only public-key sidecar and include the full public key in screenshot metadata; no secret is printed or exported.

## Tests
- bash -n apps/friday-ios/build-sim.sh
- bash apps/friday-ios/build-sim.sh --help
- swift test --package-path apps/friday-ios --filter MobileRuntimeGatesTests
- swift test --package-path apps/friday-ios --filter 'MobileRuntimeGatesTests|DeviceKeypairStoreTests|PairingPreflightTests|HomeViewModelTests'\n- bash apps/friday-ios/build-sim.sh --mode live-loopback --shot apps/friday-ios/.build-sim/friday-ios-live-loopback-filekey-pubkey.png\n\n## Local proof\n- live-loopback screenshot rendered the selected Friday Home shell with live read/write requested.\n- Device pairing advanced from Keychain OSStatus -34018 to ready with a public simulator device key in metadata.\n- Read/write still reported real unavailable state: connection closed / server dark, which is truth and not fabricated readiness.\n\n## Truth label\nThis clarifies proof modes and enables simulator-only local dogfood. It does not flip shipped defaults, mint trust grants/context passports, hold signing keys, export device secrets, or claim END-BAR/GO-LIVE.