### PR TITLE
Add iOS live-loopback read seam proof

### DIFF
--- a/apps/friday-ios/README.md
+++ b/apps/friday-ios/README.md
@@ -113,6 +113,28 @@ passports, hold signing keys, or claim END-BAR/GO-LIVE. The adjacent `.metadata.
 records which proof mode produced the screenshot and, in live-loopback mode, the public
 simulator device key needed for read-seam enrollment.
 
+To turn that simulator public key into an auditable read-seam proof, use:
+
+```sh
+scripts/ops/friday-ios-sim-live-loopback-read-seam.sh
+```
+
+By default this rebuilds/runs the simulator in `live-loopback` mode, validates the
+metadata, and dry-runs `hub_read_seam_enroll --pubkey <simulator-public-key> --add`.
+It writes no SecureStore state. To actually enroll the simulator read peer for local
+loopback dogfood, use the explicit write mode:
+
+```sh
+FRIDAY_IOS_SIM_READ_SEAM_ENROLL_ACK=operator-approves-ios-sim-read-seam-enroll \
+  scripts/ops/friday-ios-sim-live-loopback-read-seam.sh --enroll-read-seam
+```
+
+That enrollment is read-only seam access for the simulator public peer. It does not
+restart services, grant write access, mint trust grants/context passports, hold signing
+keys, or claim END-BAR/GO-LIVE/adoption. The read-projection server loads its
+allowlist at boot, so an already-running `:48751` process may need a separate safe
+reload before the newly-enrolled peer is admitted.
+
 **Device/simulator screenshot proof is operator-gated** (it needs Xcode + a booted
 simulator or a physical device); it is a deferred acceptance criterion. The
 load-bearing local checks are host `swift build` + `swift test` (the truth rules + the

--- a/scripts/ops/friday-ios-sim-live-loopback-read-seam.sh
+++ b/scripts/ops/friday-ios-sim-live-loopback-read-seam.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+#
+# One-command iOS simulator live-loopback proof + read-seam peer reconciliation.
+#
+# Truth boundary:
+#   Default mode builds/runs the simulator app in explicit live-loopback mode, validates the
+#   generated metadata, and dry-runs hub_read_seam_enroll. It writes no SecureStore state.
+#   --enroll-read-seam performs the same proof and then enrolls the simulator public read peer,
+#   gated by FRIDAY_IOS_SIM_READ_SEAM_ENROLL_ACK. It still does not restart services, grant
+#   write access, mint trust_grant/context_passport, sign, or claim END-BAR/GO-LIVE.
+#   The read-projection server loads the allowlist at boot; an already-running :48751 process may
+#   need a separate safe reload before newly-enrolled peers are admitted.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+SHOT="${FRIDAY_IOS_SIM_LIVE_LOOPBACK_SHOT:-${REPO_ROOT}/apps/friday-ios/.build-sim/friday-ios-live-loopback-read-seam.png}"
+METADATA=""
+ENROLL=0
+SKIP_BUILD=0
+
+usage() {
+  cat <<'EOF'
+usage:
+  scripts/ops/friday-ios-sim-live-loopback-read-seam.sh [--shot <png>] [--metadata <shot.metadata.json>] [--enroll-read-seam]
+
+truth:
+  Without --enroll-read-seam this is a dry-run proof and writes no SecureStore state.
+  --metadata skips the simulator build and validates an existing live-loopback metadata file.
+  The read-projection server loads the allowlist at boot; this wrapper never restarts it.
+  --enroll-read-seam requires:
+    FRIDAY_IOS_SIM_READ_SEAM_ENROLL_ACK=operator-approves-ios-sim-read-seam-enroll
+EOF
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --shot)
+      shift
+      if [ "$#" -eq 0 ]; then
+        echo "FATAL: --shot requires a value." >&2
+        exit 3
+      fi
+      SHOT="$1"
+      ;;
+    --metadata)
+      shift
+      if [ "$#" -eq 0 ]; then
+        echo "FATAL: --metadata requires a value." >&2
+        exit 3
+      fi
+      METADATA="$1"
+      SKIP_BUILD=1
+      ;;
+    --enroll-read-seam)
+      ENROLL=1
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "FATAL: unknown argument: $1" >&2
+      usage >&2
+      exit 3
+      ;;
+  esac
+  shift
+done
+
+if [ "${SKIP_BUILD}" = "0" ]; then
+  bash "${REPO_ROOT}/apps/friday-ios/build-sim.sh" --mode live-loopback --shot "${SHOT}"
+  METADATA="${SHOT}.metadata.json"
+fi
+
+if [ -z "${METADATA}" ]; then
+  echo "FATAL: metadata path was not resolved." >&2
+  exit 3
+fi
+
+args=(--metadata "${METADATA}")
+if [ "${ENROLL}" = "1" ]; then
+  args+=(--enroll)
+fi
+
+node "${SCRIPT_DIR}/friday-ios-sim-read-seam-enroll.mjs" "${args[@]}"

--- a/scripts/ops/friday-ios-sim-read-seam-enroll.mjs
+++ b/scripts/ops/friday-ios-sim-read-seam-enroll.mjs
@@ -1,0 +1,136 @@
+#!/usr/bin/env node
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawnSync } from "node:child_process";
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(scriptDir, "../..");
+
+function usage() {
+  console.log(`usage:
+  scripts/ops/friday-ios-sim-read-seam-enroll.mjs --metadata <shot.metadata.json> [--store-dir <dir>] [--enroll]
+
+truth:
+  Validates iOS simulator live-loopback metadata and runs hub_read_seam_enroll.
+  Default is dry-run and writes no SecureStore state. --enroll requires
+  FRIDAY_IOS_SIM_READ_SEAM_ENROLL_ACK=operator-approves-ios-sim-read-seam-enroll.
+  This enrolls only the simulator public read-seam peer; it does not restart services,
+  grant write access, mint trust grants/context passports, sign, or claim END-BAR/GO-LIVE.`);
+}
+
+function fail(message, code = 2) {
+  console.error(`FATAL: ${message}`);
+  process.exit(code);
+}
+
+function takeArg(args, name) {
+  const index = args.indexOf(name);
+  if (index === -1) return null;
+  if (index === args.length - 1) fail(`${name} requires a value`);
+  const value = args[index + 1];
+  args.splice(index, 2);
+  return value;
+}
+
+const args = process.argv.slice(2);
+if (args.includes("-h") || args.includes("--help")) {
+  usage();
+  process.exit(0);
+}
+
+const metadataPath = takeArg(args, "--metadata");
+const storeDir =
+  takeArg(args, "--store-dir") ||
+  process.env.FRIDAY_READ_SEAM_STORE_DIR ||
+  resolve(homedir(), ".friday/agent-run-securestore");
+const enroll = args.includes("--enroll");
+if (enroll) args.splice(args.indexOf("--enroll"), 1);
+if (args.length > 0) fail(`unknown argument(s): ${args.join(" ")}`);
+if (!metadataPath) {
+  usage();
+  fail("--metadata is required");
+}
+if (
+  enroll &&
+  process.env.FRIDAY_IOS_SIM_READ_SEAM_ENROLL_ACK !==
+    "operator-approves-ios-sim-read-seam-enroll"
+) {
+  fail("--enroll writes read-seam allowlist state; set FRIDAY_IOS_SIM_READ_SEAM_ENROLL_ACK=operator-approves-ios-sim-read-seam-enroll", 4);
+}
+
+const absoluteMetadata = resolve(metadataPath);
+if (!existsSync(absoluteMetadata)) fail(`metadata file not found: ${absoluteMetadata}`);
+
+let metadata;
+try {
+  metadata = JSON.parse(readFileSync(absoluteMetadata, "utf8"));
+} catch (error) {
+  fail(`invalid metadata JSON: ${error.message}`);
+}
+
+const expectedTruth = "friday_ios_simulator_live-loopback_proof";
+if (metadata.truth_label !== expectedTruth) fail(`truth_label must be ${expectedTruth}`);
+if (metadata.mode !== "live-loopback") fail("mode must be live-loopback");
+for (const key of [
+  "live_read_requested",
+  "live_write_requested",
+  "live_pairing_requested",
+  "device_keypair_requested",
+  "simulator_file_device_keypair_requested",
+]) {
+  if (metadata[key] !== true) fail(`${key} must be true`);
+}
+
+const pubkey = String(metadata.simulator_device_pubkey || "");
+if (!/^[0-9a-f]{64}$/.test(pubkey)) {
+  fail("simulator_device_pubkey must be a lowercase 64-hex X25519 public key");
+}
+
+const enrollBin = resolve(repoRoot, "rust-core/target/release/hub_read_seam_enroll");
+if (!existsSync(enrollBin)) {
+  console.error("hub_read_seam_enroll release binary missing; building only that bin...");
+  const build = spawnSync(
+    "cargo",
+    ["build", "--release", "--manifest-path", "rust-core/Cargo.toml", "--bin", "hub_read_seam_enroll"],
+    {
+      cwd: repoRoot,
+      encoding: "utf8",
+      stdio: "inherit",
+    },
+  );
+  if (build.status !== 0) {
+    fail(`failed to build ${enrollBin}`, build.status || 5);
+  }
+}
+
+const enrollArgs = ["--store-dir", storeDir, "--pubkey", pubkey, "--add"];
+if (!enroll) enrollArgs.push("--dry-run");
+
+const result = spawnSync(enrollBin, enrollArgs, {
+  cwd: repoRoot,
+  encoding: "utf8",
+});
+
+const stdout = (result.stdout || "").trim();
+const stderr = (result.stderr || "").trim();
+if (stdout) console.log(stdout);
+if (stderr) console.error(stderr);
+if (result.status !== 0) {
+  fail(`hub_read_seam_enroll exited ${result.status ?? "without status"}`, result.status || 6);
+}
+
+const proof = {
+  truth_label: enroll
+    ? "friday_ios_simulator_live_loopback_read_seam_enrolled"
+    : "friday_ios_simulator_live_loopback_read_seam_dry_run",
+  status: "pass",
+  mode: enroll ? "enroll" : "dry-run",
+  metadata: absoluteMetadata,
+  store_dir: storeDir,
+  simulator_device_pubkey: pubkey,
+  caveat:
+    "Read-seam peer validation/enrollment only. The read-projection server loads the allowlist at boot, so an already-running :48751 process may need a separate safe reload before this peer is admitted. No service restart, no write-seam grant, no trust grant/context passport mint, no signing, no END-BAR/GO-LIVE/adoption claim.",
+};
+console.log(JSON.stringify(proof, null, 2));


### PR DESCRIPTION
## Summary
- add a simulator live-loopback read-seam proof wrapper
- validate live-loopback metadata before using the simulator public read peer
- default to dry-run read-seam enrollment, with explicit ACK for write mode and boot-time allowlist caveats

## Verification
- bash -n scripts/ops/friday-ios-sim-live-loopback-read-seam.sh
- node scripts/ops/friday-ios-sim-read-seam-enroll.mjs --help
- scripts/ops/friday-ios-sim-live-loopback-read-seam.sh --metadata /Users/jarvis/Projects/Friday/apps/friday-ios/.build-sim/friday-ios-main-live-loopback.png.metadata.json
- scripts/ops/friday-ios-sim-live-loopback-read-seam.sh --shot apps/friday-ios/.build-sim/friday-ios-wrapper-live-loopback.png
- no-ACK negative: --enroll-read-seam exits rc=4 before writing SecureStore