### PR TITLE
Allow iOS live read endpoint overrides

### DIFF
--- a/apps/friday-ios/README.md
+++ b/apps/friday-ios/README.md
@@ -113,6 +113,17 @@ passports, hold signing keys, or claim END-BAR/GO-LIVE. The adjacent `.metadata.
 records which proof mode produced the screenshot and, in live-loopback mode, the public
 simulator device key needed for read-seam enrollment.
 
+For isolated read-server proofs that must not touch the production `:48751` process,
+set an explicit simulator child read endpoint before launching:
+
+```sh
+FRIDAY_MOBILE_LIVE_READ_PORT=59151 \
+  apps/friday-ios/build-sim.sh --mode live-loopback --shot apps/friday-ios/.build-sim/friday-ios-live-scratch-read.png
+```
+
+The shipped default remains `127.0.0.1:48751`; invalid explicit ports fail closed as
+honest unavailable instead of silently falling back.
+
 To turn that simulator public key into an auditable read-seam proof, use:
 
 ```sh

--- a/apps/friday-ios/Sources/FridayMobileShell/FridayApp.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayApp.swift
@@ -161,11 +161,12 @@ final class FridaySession: ObservableObject {
       return HonestlyUnavailableReadClient()
     }
     do {
+      let config = try liveReadConfig(args: args, env: env)
       if useDeviceKeypair(args: args, env: env) {
         let device = try DeviceKeypairStore.loadOrGenerate(backend: deviceKeypairBackend)
-        return RealReadClientFactory.makeLive(deviceKeypair: device)
+        return RealReadClientFactory.makeLive(deviceKeypair: device, config: config)
       }
-      return try RealReadClientFactory.makeLive()
+      return try RealReadClientFactory.makeLive(config: config)
     } catch {
       return RealReadClientFactory.makeHonestlyUnavailable(reason: "\(error)")
     }
@@ -227,6 +228,21 @@ final class FridaySession: ObservableObject {
 
   static func liveReadRequested(args: [String], env: [String: String]) -> Bool {
     MobileRuntimeGates.liveReadRequested(args: args, env: env)
+  }
+
+  static func liveReadConfig(args: [String], env: [String: String]) throws -> ReadProjectionServerConfig {
+    let host = MobileRuntimeGates.liveReadHostOverride(args: args, env: env)
+      ?? ReadProjectionServerConfig.liveLoopback.host
+    switch MobileRuntimeGates.liveReadPortOverride(args: args, env: env) {
+    case .absent:
+      return ReadProjectionServerConfig(
+        host: host,
+        port: ReadProjectionServerConfig.liveLoopback.port)
+    case let .value(port):
+      return ReadProjectionServerConfig(host: host, port: port)
+    case let .invalid(raw):
+      throw FridayReadClientError.transport("invalid live read port override \(raw)")
+    }
   }
 
   static func liveWriteRequested(args: [String], env: [String: String]) -> Bool {

--- a/apps/friday-ios/Sources/FridayMobileShellCore/MobileRuntimeGates.swift
+++ b/apps/friday-ios/Sources/FridayMobileShellCore/MobileRuntimeGates.swift
@@ -1,6 +1,12 @@
 import Foundation
 
 public enum MobileRuntimeGates {
+  public enum LiveReadPortOverride: Equatable, Sendable {
+    case absent
+    case value(UInt16)
+    case invalid(String)
+  }
+
   public static func useDeviceKeypair(args: [String], env: [String: String]) -> Bool {
     args.contains("--live-device-keypair") || env["FRIDAY_MOBILE_LIVE_DEVICE_KEYPAIR"] == "1"
   }
@@ -12,6 +18,26 @@ public enum MobileRuntimeGates {
 
   public static func liveReadRequested(args: [String], env: [String: String]) -> Bool {
     args.contains("--live-read") || env["FRIDAY_MOBILE_LIVE_READ"] == "1"
+  }
+
+  public static func liveReadHostOverride(args: [String], env: [String: String]) -> String? {
+    if let arg = value(after: "--live-read-host", in: args), !arg.isEmpty {
+      return arg
+    }
+    let envValue = env["FRIDAY_MOBILE_LIVE_READ_HOST"]?.trimmingCharacters(in: .whitespacesAndNewlines)
+    return envValue?.isEmpty == false ? envValue : nil
+  }
+
+  public static func liveReadPortOverride(args: [String], env: [String: String]) -> LiveReadPortOverride {
+    guard let raw = value(after: "--live-read-port", in: args)
+      ?? env["FRIDAY_MOBILE_LIVE_READ_PORT"]?.trimmingCharacters(in: .whitespacesAndNewlines)
+    else {
+      return .absent
+    }
+    guard let port = UInt16(raw), port > 0 else {
+      return .invalid(raw)
+    }
+    return .value(port)
   }
 
   public static func liveWriteRequested(args: [String], env: [String: String]) -> Bool {
@@ -27,5 +53,12 @@ public enum MobileRuntimeGates {
       || args.contains("--run-control")
       || env["FRIDAY_MOBILE_AGENT_RUN_CONTROL_VIA_RUST"] == "1"
       || env["FRIDAY_AGENT_RUN_CONTROL_VIA_RUST"] == "1"
+  }
+
+  private static func value(after flag: String, in args: [String]) -> String? {
+    guard let index = args.firstIndex(of: flag), args.indices.contains(index + 1) else {
+      return nil
+    }
+    return args[index + 1]
   }
 }

--- a/apps/friday-ios/Tests/FridayMobileShellCoreTests/MobileRuntimeGatesTests.swift
+++ b/apps/friday-ios/Tests/FridayMobileShellCoreTests/MobileRuntimeGatesTests.swift
@@ -40,6 +40,36 @@ func mobileRuntimeGatesAcceptExplicitEnv() {
 }
 
 @Test
+func mobileRuntimeGatesReadEndpointOverridesAreExplicit() {
+  #expect(MobileRuntimeGates.liveReadHostOverride(args: [], env: [:]) == nil)
+  #expect(MobileRuntimeGates.liveReadPortOverride(args: [], env: [:]) == .absent)
+
+  #expect(MobileRuntimeGates.liveReadHostOverride(
+    args: ["--live-read-host", "127.0.0.1"],
+    env: [:]) == "127.0.0.1")
+  #expect(MobileRuntimeGates.liveReadHostOverride(
+    args: [],
+    env: ["FRIDAY_MOBILE_LIVE_READ_HOST": "localhost"]) == "localhost")
+
+  #expect(MobileRuntimeGates.liveReadPortOverride(
+    args: ["--live-read-port", "59151"],
+    env: [:]) == .value(59151))
+  #expect(MobileRuntimeGates.liveReadPortOverride(
+    args: [],
+    env: ["FRIDAY_MOBILE_LIVE_READ_PORT": "59152"]) == .value(59152))
+}
+
+@Test
+func mobileRuntimeGatesReadPortOverrideRejectsBadValues() {
+  #expect(MobileRuntimeGates.liveReadPortOverride(
+    args: ["--live-read-port", "0"],
+    env: [:]) == .invalid("0"))
+  #expect(MobileRuntimeGates.liveReadPortOverride(
+    args: [],
+    env: ["FRIDAY_MOBILE_LIVE_READ_PORT": "nope"]) == .invalid("nope"))
+}
+
+@Test
 func mobileRuntimeGatesDoNotAcceptTruthyLookalikes() {
   #expect(!MobileRuntimeGates.liveReadRequested(args: [], env: ["FRIDAY_MOBILE_LIVE_READ": "true"]))
   #expect(!MobileRuntimeGates.liveWriteRequested(args: [], env: ["FRIDAY_MOBILE_LIVE_WRITE": "yes"]))

--- a/apps/friday-ios/build-sim.sh
+++ b/apps/friday-ios/build-sim.sh
@@ -175,6 +175,12 @@ case "$MODE" in
       SIMCTL_CHILD_FRIDAY_MOBILE_LIVE_DEVICE_KEYPAIR=1
       SIMCTL_CHILD_FRIDAY_MOBILE_SIMULATOR_FILE_DEVICE_KEYPAIR=1
     )
+    if [[ -n "${FRIDAY_MOBILE_LIVE_READ_HOST:-}" ]]; then
+      LAUNCH_ENV+=(SIMCTL_CHILD_FRIDAY_MOBILE_LIVE_READ_HOST="$FRIDAY_MOBILE_LIVE_READ_HOST")
+    fi
+    if [[ -n "${FRIDAY_MOBILE_LIVE_READ_PORT:-}" ]]; then
+      LAUNCH_ENV+=(SIMCTL_CHILD_FRIDAY_MOBILE_LIVE_READ_PORT="$FRIDAY_MOBILE_LIVE_READ_PORT")
+    fi
     ;;
 esac
 env "${LAUNCH_ENV[@]}" xcrun simctl launch --terminate-running-process "$UDID" com.friday.shell "${LAUNCH_ARGS[@]}"
@@ -185,7 +191,15 @@ env "${LAUNCH_ENV[@]}" xcrun simctl launch --terminate-running-process "$UDID" c
 sleep 6
 xcrun simctl io "$UDID" screenshot "$SHOT"
 SIMULATOR_DEVICE_PUBKEY_JSON=null
+LIVE_READ_HOST_OVERRIDE_JSON=null
+LIVE_READ_PORT_OVERRIDE_JSON=null
 if [[ "$MODE" == "live-loopback" ]]; then
+  if [[ -n "${FRIDAY_MOBILE_LIVE_READ_HOST:-}" && "$FRIDAY_MOBILE_LIVE_READ_HOST" =~ ^[A-Za-z0-9._:-]+$ ]]; then
+    LIVE_READ_HOST_OVERRIDE_JSON="\"$FRIDAY_MOBILE_LIVE_READ_HOST\""
+  fi
+  if [[ -n "${FRIDAY_MOBILE_LIVE_READ_PORT:-}" && "$FRIDAY_MOBILE_LIVE_READ_PORT" =~ ^[0-9]+$ ]]; then
+    LIVE_READ_PORT_OVERRIDE_JSON="\"$FRIDAY_MOBILE_LIVE_READ_PORT\""
+  fi
   DATA_CONTAINER="$(xcrun simctl get_app_container "$UDID" com.friday.shell data 2>/dev/null || true)"
   PUBKEY_FILE="$DATA_CONTAINER/Library/Application Support/FridayShellSimulatorProof/device-pubkey-v1.txt"
   if [[ -n "$DATA_CONTAINER" && -f "$PUBKEY_FILE" ]]; then
@@ -207,6 +221,8 @@ cat > "$SHOT.metadata.json" <<JSON
   "live_pairing_requested": $([[ "$MODE" == "live-loopback" ]] && echo true || echo false),
   "device_keypair_requested": $([[ "$MODE" == "live-loopback" ]] && echo true || echo false),
   "simulator_file_device_keypair_requested": $([[ "$MODE" == "live-loopback" ]] && echo true || echo false),
+  "live_read_host_override": $LIVE_READ_HOST_OVERRIDE_JSON,
+  "live_read_port_override": $LIVE_READ_PORT_OVERRIDE_JSON,
   "simulator_device_pubkey": $SIMULATOR_DEVICE_PUBKEY_JSON,
   "caveat": "offline-truth proves honest-unavailable; live-loopback attempts real local read/write/pairing seams but does not claim END-BAR, GO-LIVE, adoption, trust minting, or operator signing."
 }


### PR DESCRIPTION
## Summary
- add explicit iOS live-read host/port overrides for simulator/local proof runs
- keep shipped default at 127.0.0.1:48751 and fail closed on invalid explicit ports
- pass read endpoint overrides through build-sim live-loopback child env and record them in metadata

## Verification
- bash -n apps/friday-ios/build-sim.sh
- swift test --package-path apps/friday-ios --filter MobileRuntimeGatesTests
- FRIDAY_MOBILE_LIVE_READ_PORT=59151 apps/friday-ios/build-sim.sh --mode live-loopback --shot apps/friday-ios/.build-sim/friday-ios-live-read-port-override-post-rebase.png
- metadata JSON shows truth_label=friday_ios_simulator_live-loopback_proof and live_read_port_override=59151
- scratch read server proof: hub_read_projection_server on 127.0.0.1:59151 loaded 3-peer allowlist; iOS simulator screenshot apps/friday-ios/.build-sim/friday-ios-scratch-read-live.png rendered online feed=live_rust_hub_projection with work item refs; server log delivered request_id=req-CE93DDC9-4912-4BBA-8EB7-34B1EC2C6049

## Caveat
- scratch proof does not restart or mutate production :48751; it proves the simulator can read a live Rust projection through an isolated read server using the enrolled simulator peer.