### PR TITLE
Allow iOS live write endpoint overrides

### DIFF
--- a/apps/friday-ios/README.md
+++ b/apps/friday-ios/README.md
@@ -114,15 +114,28 @@ records which proof mode produced the screenshot and, in live-loopback mode, the
 simulator device key needed for read-seam enrollment.
 
 For isolated read-server proofs that must not touch the production `:48751` process,
-set an explicit simulator child read endpoint before launching:
+set an explicit simulator child read endpoint before launching. The write endpoint still
+defaults to the live agent-run server on `127.0.0.1:48750`; set
+`FRIDAY_MOBILE_LIVE_WRITE_HOST` / `FRIDAY_MOBILE_LIVE_WRITE_PORT` only when intentionally
+targeting an isolated write server.
 
 ```sh
 FRIDAY_MOBILE_LIVE_READ_PORT=59151 \
   apps/friday-ios/build-sim.sh --mode live-loopback --shot apps/friday-ios/.build-sim/friday-ios-live-scratch-read.png
 ```
 
-The shipped default remains `127.0.0.1:48751`; invalid explicit ports fail closed as
-honest unavailable instead of silently falling back.
+The shipped defaults remain `127.0.0.1:48751` for read and `127.0.0.1:48750` for write;
+invalid explicit ports fail closed as honest unavailable instead of silently falling back.
+
+The env-gated live write→read projection proof accepts the same endpoint overrides, so a
+safe local proof can write through live `:48750` and read back through an isolated read server
+that loaded the current simulator allowlist:
+
+```sh
+FRIDAY_MOBILE_LIVE_WRITE_READ_ROUNDTRIP_TEST=1 \
+FRIDAY_MOBILE_LIVE_READ_PORT=59151 \
+  swift test --package-path apps/friday-ios --filter LiveWriteReadProjectionRoundTrip
+```
 
 To turn that simulator public key into an auditable read-seam proof, use:
 

--- a/apps/friday-ios/Sources/FridayMobileShell/FridayApp.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayApp.swift
@@ -199,13 +199,17 @@ final class FridaySession: ObservableObject {
       return nil
     }
     do {
+      let config = try liveWriteConfig(args: args, env: env)
       if useDeviceKeypair(args: args, env: env) {
         let device = try DeviceKeypairStore.loadOrGenerate(backend: deviceKeypairBackend)
         return RealWriteClientFactory.makeLive(
           deviceKeypair: device,
+          config: config,
           agentRunControlViaRust: runControlEnabled)
       }
-      return try RealWriteClientFactory.makeLive(agentRunControlViaRust: runControlEnabled)
+      return try RealWriteClientFactory.makeLive(
+        config: config,
+        agentRunControlViaRust: runControlEnabled)
     } catch {
       // Master/device key unavailable or corrupt: no mission-capable client. The caller falls back
       // to the throwing honest-unavailable write client; never fabricate a ready chat surface.
@@ -247,6 +251,21 @@ final class FridaySession: ObservableObject {
 
   static func liveWriteRequested(args: [String], env: [String: String]) -> Bool {
     MobileRuntimeGates.liveWriteRequested(args: args, env: env)
+  }
+
+  static func liveWriteConfig(args: [String], env: [String: String]) throws -> AgentRunServerConfig {
+    let host = MobileRuntimeGates.liveWriteHostOverride(args: args, env: env)
+      ?? AgentRunServerConfig.liveLoopback.host
+    switch MobileRuntimeGates.liveWritePortOverride(args: args, env: env) {
+    case .absent:
+      return AgentRunServerConfig(
+        host: host,
+        port: AgentRunServerConfig.liveLoopback.port)
+    case let .value(port):
+      return AgentRunServerConfig(host: host, port: port)
+    case let .invalid(raw):
+      throw FridayReadClientError.transport("invalid live write port override \(raw)")
+    }
   }
 
   static func livePairingRequested(args: [String], env: [String: String]) -> Bool {

--- a/apps/friday-ios/Sources/FridayMobileShellCore/MobileRuntimeGates.swift
+++ b/apps/friday-ios/Sources/FridayMobileShellCore/MobileRuntimeGates.swift
@@ -7,6 +7,12 @@ public enum MobileRuntimeGates {
     case invalid(String)
   }
 
+  public enum LiveWritePortOverride: Equatable, Sendable {
+    case absent
+    case value(UInt16)
+    case invalid(String)
+  }
+
   public static func useDeviceKeypair(args: [String], env: [String: String]) -> Bool {
     args.contains("--live-device-keypair") || env["FRIDAY_MOBILE_LIVE_DEVICE_KEYPAIR"] == "1"
   }
@@ -42,6 +48,26 @@ public enum MobileRuntimeGates {
 
   public static func liveWriteRequested(args: [String], env: [String: String]) -> Bool {
     args.contains("--live-write") || env["FRIDAY_MOBILE_LIVE_WRITE"] == "1"
+  }
+
+  public static func liveWriteHostOverride(args: [String], env: [String: String]) -> String? {
+    if let arg = value(after: "--live-write-host", in: args), !arg.isEmpty {
+      return arg
+    }
+    let envValue = env["FRIDAY_MOBILE_LIVE_WRITE_HOST"]?.trimmingCharacters(in: .whitespacesAndNewlines)
+    return envValue?.isEmpty == false ? envValue : nil
+  }
+
+  public static func liveWritePortOverride(args: [String], env: [String: String]) -> LiveWritePortOverride {
+    guard let raw = value(after: "--live-write-port", in: args)
+      ?? env["FRIDAY_MOBILE_LIVE_WRITE_PORT"]?.trimmingCharacters(in: .whitespacesAndNewlines)
+    else {
+      return .absent
+    }
+    guard let port = UInt16(raw), port > 0 else {
+      return .invalid(raw)
+    }
+    return .value(port)
   }
 
   public static func livePairingRequested(args: [String], env: [String: String]) -> Bool {

--- a/apps/friday-ios/Tests/FridayMobileShellCoreTests/LiveMissionSpineWriteDispatchIntegrationTests.swift
+++ b/apps/friday-ios/Tests/FridayMobileShellCoreTests/LiveMissionSpineWriteDispatchIntegrationTests.swift
@@ -75,8 +75,10 @@ func liveMobileMissionSpineWriteDispatchCanStartMissionBoundRun() async throws {
 @MainActor
 func liveMobileChatSendAutoDispatchesHybridClaudeFollowUp() async throws {
   let identity = liveUiProofMissionIdentity(defaultSurface: "mobile")
-  let writeClient = try RealWriteClientFactory.makeLive(config: mobileProductAutoFollowUpWriteConfig())
-  let readClient = try RealReadClientFactory.makeLive(missionId: identity.missionId)
+  let writeClient = try RealWriteClientFactory.makeLive(config: try mobileProductAutoFollowUpWriteConfig())
+  let readClient = try RealReadClientFactory.makeLive(
+    config: try mobileProductAutoFollowUpReadConfig(),
+    missionId: identity.missionId)
   let vm = FridayChatViewModel(
     writeClient: writeClient,
     signer: MockOperatorSigner(),
@@ -173,14 +175,27 @@ private func pollLiveRunOutcomeLearningCandidates(
   return []
 }
 
-private func mobileProductAutoFollowUpWriteConfig() -> AgentRunServerConfig {
-  guard
-    let rawPort = ProcessInfo.processInfo.environment["FRIDAY_MOBILE_LIVE_PRODUCT_AUTO_FOLLOWUP_WRITE_PORT"],
-    let port = UInt16(rawPort)
-  else {
+private func mobileProductAutoFollowUpWriteConfig() throws -> AgentRunServerConfig {
+  guard let rawPort = ProcessInfo.processInfo.environment["FRIDAY_MOBILE_LIVE_PRODUCT_AUTO_FOLLOWUP_WRITE_PORT"] else {
     return .liveLoopback
   }
+  guard let port = UInt16(rawPort), port > 0 else {
+    throw FridayReadClientError.transport("invalid live product auto-followup write port override \(rawPort)")
+  }
   return AgentRunServerConfig(host: "127.0.0.1", port: port)
+}
+
+private func mobileProductAutoFollowUpReadConfig() throws -> ReadProjectionServerConfig {
+  let env = ProcessInfo.processInfo.environment
+  let rawPort = env["FRIDAY_MOBILE_LIVE_PRODUCT_AUTO_FOLLOWUP_READ_PORT"]
+    ?? env["FRIDAY_MOBILE_LIVE_READ_PORT"]
+  guard let rawPort else {
+    return .liveLoopback
+  }
+  guard let port = UInt16(rawPort), port > 0 else {
+    throw FridayReadClientError.transport("invalid live product auto-followup read port override \(rawPort)")
+  }
+  return ReadProjectionServerConfig(host: "127.0.0.1", port: port)
 }
 
 private func makeLiveMobileIntake(

--- a/apps/friday-ios/Tests/FridayMobileShellCoreTests/LiveWriteReadProjectionRoundTripIntegrationTests.swift
+++ b/apps/friday-ios/Tests/FridayMobileShellCoreTests/LiveWriteReadProjectionRoundTripIntegrationTests.swift
@@ -14,13 +14,18 @@ import Testing
 //   FRIDAY_MOBILE_LIVE_WRITE_READ_ROUNDTRIP_TEST=1 swift test \
 //     --package-path apps/friday-ios \
 //     --filter LiveWriteReadProjectionRoundTrip
+//
+// Optional isolated read/write endpoint overrides:
+//   FRIDAY_MOBILE_LIVE_WRITE_PORT=48750 \
+//   FRIDAY_MOBILE_LIVE_READ_PORT=59151 \
+//   FRIDAY_MOBILE_LIVE_WRITE_READ_ROUNDTRIP_TEST=1 swift test ...
 
 private let liveWriteReadRoundTripEnabled =
   ProcessInfo.processInfo.environment["FRIDAY_MOBILE_LIVE_WRITE_READ_ROUNDTRIP_TEST"] == "1"
 
 @Test(.enabled(if: liveWriteReadRoundTripEnabled))
 func liveMobileMissionWriteAppearsInReadProjection() async throws {
-  let writeClient = try RealWriteClientFactory.makeLive()
+  let writeClient = try RealWriteClientFactory.makeLive(config: liveRoundTripWriteConfig())
   let request = makeMobileRoundTripIntake()
 
   let result = try await writeClient.submitMissionIntake(request)
@@ -29,7 +34,9 @@ func liveMobileMissionWriteAppearsInReadProjection() async throws {
   #expect(result.missionId == request.missionId)
   #expect(result.workItemId == request.workItemId)
 
-  let readClient = try RealReadClientFactory.makeLive(missionId: result.missionId)
+  let readClient = try RealReadClientFactory.makeLive(
+    config: liveRoundTripReadConfig(),
+    missionId: result.missionId)
   let snapshot = try await pollReadProjection(
     client: readClient,
     missionId: result.missionId,
@@ -40,6 +47,49 @@ func liveMobileMissionWriteAppearsInReadProjection() async throws {
       + "workItemIds=\(snapshot.workItemIds) generatedAtMs=\(snapshot.generatedAtMs)")
   #expect(snapshot.missionId == result.missionId)
   #expect(snapshot.workItemIds.contains(request.workItemId))
+}
+
+private func liveRoundTripWriteConfig() throws -> AgentRunServerConfig {
+  let host = endpointHost(
+    envKey: "FRIDAY_MOBILE_LIVE_WRITE_HOST",
+    fallback: AgentRunServerConfig.liveLoopback.host)
+  let port = try endpointPort(
+    envKey: "FRIDAY_MOBILE_LIVE_WRITE_PORT",
+    fallback: AgentRunServerConfig.liveLoopback.port,
+    label: "write")
+  return AgentRunServerConfig(host: host, port: port)
+}
+
+private func liveRoundTripReadConfig() throws -> ReadProjectionServerConfig {
+  let host = endpointHost(
+    envKey: "FRIDAY_MOBILE_LIVE_READ_HOST",
+    fallback: ReadProjectionServerConfig.liveLoopback.host)
+  let port = try endpointPort(
+    envKey: "FRIDAY_MOBILE_LIVE_READ_PORT",
+    fallback: ReadProjectionServerConfig.liveLoopback.port,
+    label: "read")
+  return ReadProjectionServerConfig(host: host, port: port)
+}
+
+private func endpointHost(envKey: String, fallback: String) -> String {
+  if let value = ProcessInfo.processInfo.environment[envKey]?.trimmingCharacters(in: .whitespacesAndNewlines),
+    !value.isEmpty
+  {
+    return value
+  }
+  return fallback
+}
+
+private func endpointPort(envKey: String, fallback: UInt16, label: String) throws -> UInt16 {
+  guard let raw = ProcessInfo.processInfo.environment[envKey]?.trimmingCharacters(in: .whitespacesAndNewlines),
+    !raw.isEmpty
+  else {
+    return fallback
+  }
+  guard let port = UInt16(raw), port > 0 else {
+    throw FridayReadClientError.transport("invalid live \(label) port override \(raw)")
+  }
+  return port
 }
 
 private func makeMobileRoundTripIntake() -> MissionIntakeRequestWire {

--- a/apps/friday-ios/Tests/FridayMobileShellCoreTests/MobileRuntimeGatesTests.swift
+++ b/apps/friday-ios/Tests/FridayMobileShellCoreTests/MobileRuntimeGatesTests.swift
@@ -60,6 +60,26 @@ func mobileRuntimeGatesReadEndpointOverridesAreExplicit() {
 }
 
 @Test
+func mobileRuntimeGatesWriteEndpointOverridesAreExplicit() {
+  #expect(MobileRuntimeGates.liveWriteHostOverride(args: [], env: [:]) == nil)
+  #expect(MobileRuntimeGates.liveWritePortOverride(args: [], env: [:]) == .absent)
+
+  #expect(MobileRuntimeGates.liveWriteHostOverride(
+    args: ["--live-write-host", "127.0.0.1"],
+    env: [:]) == "127.0.0.1")
+  #expect(MobileRuntimeGates.liveWriteHostOverride(
+    args: [],
+    env: ["FRIDAY_MOBILE_LIVE_WRITE_HOST": "localhost"]) == "localhost")
+
+  #expect(MobileRuntimeGates.liveWritePortOverride(
+    args: ["--live-write-port", "59150"],
+    env: [:]) == .value(59150))
+  #expect(MobileRuntimeGates.liveWritePortOverride(
+    args: [],
+    env: ["FRIDAY_MOBILE_LIVE_WRITE_PORT": "59153"]) == .value(59153))
+}
+
+@Test
 func mobileRuntimeGatesReadPortOverrideRejectsBadValues() {
   #expect(MobileRuntimeGates.liveReadPortOverride(
     args: ["--live-read-port", "0"],
@@ -67,6 +87,16 @@ func mobileRuntimeGatesReadPortOverrideRejectsBadValues() {
   #expect(MobileRuntimeGates.liveReadPortOverride(
     args: [],
     env: ["FRIDAY_MOBILE_LIVE_READ_PORT": "nope"]) == .invalid("nope"))
+}
+
+@Test
+func mobileRuntimeGatesWritePortOverrideRejectsBadValues() {
+  #expect(MobileRuntimeGates.liveWritePortOverride(
+    args: ["--live-write-port", "0"],
+    env: [:]) == .invalid("0"))
+  #expect(MobileRuntimeGates.liveWritePortOverride(
+    args: [],
+    env: ["FRIDAY_MOBILE_LIVE_WRITE_PORT": "nope"]) == .invalid("nope"))
 }
 
 @Test

--- a/apps/friday-ios/build-sim.sh
+++ b/apps/friday-ios/build-sim.sh
@@ -181,6 +181,12 @@ case "$MODE" in
     if [[ -n "${FRIDAY_MOBILE_LIVE_READ_PORT:-}" ]]; then
       LAUNCH_ENV+=(SIMCTL_CHILD_FRIDAY_MOBILE_LIVE_READ_PORT="$FRIDAY_MOBILE_LIVE_READ_PORT")
     fi
+    if [[ -n "${FRIDAY_MOBILE_LIVE_WRITE_HOST:-}" ]]; then
+      LAUNCH_ENV+=(SIMCTL_CHILD_FRIDAY_MOBILE_LIVE_WRITE_HOST="$FRIDAY_MOBILE_LIVE_WRITE_HOST")
+    fi
+    if [[ -n "${FRIDAY_MOBILE_LIVE_WRITE_PORT:-}" ]]; then
+      LAUNCH_ENV+=(SIMCTL_CHILD_FRIDAY_MOBILE_LIVE_WRITE_PORT="$FRIDAY_MOBILE_LIVE_WRITE_PORT")
+    fi
     ;;
 esac
 env "${LAUNCH_ENV[@]}" xcrun simctl launch --terminate-running-process "$UDID" com.friday.shell "${LAUNCH_ARGS[@]}"
@@ -193,12 +199,20 @@ xcrun simctl io "$UDID" screenshot "$SHOT"
 SIMULATOR_DEVICE_PUBKEY_JSON=null
 LIVE_READ_HOST_OVERRIDE_JSON=null
 LIVE_READ_PORT_OVERRIDE_JSON=null
+LIVE_WRITE_HOST_OVERRIDE_JSON=null
+LIVE_WRITE_PORT_OVERRIDE_JSON=null
 if [[ "$MODE" == "live-loopback" ]]; then
   if [[ -n "${FRIDAY_MOBILE_LIVE_READ_HOST:-}" && "$FRIDAY_MOBILE_LIVE_READ_HOST" =~ ^[A-Za-z0-9._:-]+$ ]]; then
     LIVE_READ_HOST_OVERRIDE_JSON="\"$FRIDAY_MOBILE_LIVE_READ_HOST\""
   fi
   if [[ -n "${FRIDAY_MOBILE_LIVE_READ_PORT:-}" && "$FRIDAY_MOBILE_LIVE_READ_PORT" =~ ^[0-9]+$ ]]; then
     LIVE_READ_PORT_OVERRIDE_JSON="\"$FRIDAY_MOBILE_LIVE_READ_PORT\""
+  fi
+  if [[ -n "${FRIDAY_MOBILE_LIVE_WRITE_HOST:-}" && "$FRIDAY_MOBILE_LIVE_WRITE_HOST" =~ ^[A-Za-z0-9._:-]+$ ]]; then
+    LIVE_WRITE_HOST_OVERRIDE_JSON="\"$FRIDAY_MOBILE_LIVE_WRITE_HOST\""
+  fi
+  if [[ -n "${FRIDAY_MOBILE_LIVE_WRITE_PORT:-}" && "$FRIDAY_MOBILE_LIVE_WRITE_PORT" =~ ^[0-9]+$ ]]; then
+    LIVE_WRITE_PORT_OVERRIDE_JSON="\"$FRIDAY_MOBILE_LIVE_WRITE_PORT\""
   fi
   DATA_CONTAINER="$(xcrun simctl get_app_container "$UDID" com.friday.shell data 2>/dev/null || true)"
   PUBKEY_FILE="$DATA_CONTAINER/Library/Application Support/FridayShellSimulatorProof/device-pubkey-v1.txt"
@@ -223,6 +237,8 @@ cat > "$SHOT.metadata.json" <<JSON
   "simulator_file_device_keypair_requested": $([[ "$MODE" == "live-loopback" ]] && echo true || echo false),
   "live_read_host_override": $LIVE_READ_HOST_OVERRIDE_JSON,
   "live_read_port_override": $LIVE_READ_PORT_OVERRIDE_JSON,
+  "live_write_host_override": $LIVE_WRITE_HOST_OVERRIDE_JSON,
+  "live_write_port_override": $LIVE_WRITE_PORT_OVERRIDE_JSON,
   "simulator_device_pubkey": $SIMULATOR_DEVICE_PUBKEY_JSON,
   "caveat": "offline-truth proves honest-unavailable; live-loopback attempts real local read/write/pairing seams but does not claim END-BAR, GO-LIVE, adoption, trust minting, or operator signing."
 }


### PR DESCRIPTION
## Summary
- add explicit iOS live write host/port overrides mirroring the read override path
- let the env-gated mobile write->read projection proof target explicit read/write endpoints
- pass write endpoint overrides through the simulator live-loopback launcher and record them in metadata

## Verification
- bash -n apps/friday-ios/build-sim.sh
- swift test --package-path apps/friday-ios
- FRIDAY_MOBILE_LIVE_WRITE_READ_ROUNDTRIP_TEST=1 FRIDAY_MOBILE_LIVE_READ_PORT=59151 swift test --package-path apps/friday-ios --filter LiveWriteReadProjectionRoundTrip
- FRIDAY_MOBILE_LIVE_READ_PORT=59151 FRIDAY_MOBILE_LIVE_WRITE_PORT=48750 apps/friday-ios/build-sim.sh --mode live-loopback --shot apps/friday-ios/.build-sim/friday-ios-live-write-read-overrides.png

## Truth labels
- The live roundtrip wrote a real mobile refs-only mission through prod write :48750 and read it back through scratch read :59151.
- This is v1-works evidence only: not END-BAR, not GO-LIVE, not adoption, not trust minting, and not operator signing.