### PR TITLE
Add iOS context passport checklist

### DIFF
--- a/apps/friday-ios/Sources/FridayMobileShell/CommandSheet.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/CommandSheet.swift
@@ -10,6 +10,7 @@ enum MobileDestination: String, CaseIterable, Identifiable {
   case home
   case missions
   case session
+  case contextPassport
   case shareIntake
   case voice
   case needsMe
@@ -27,6 +28,7 @@ enum MobileDestination: String, CaseIterable, Identifiable {
     case .home: return "Friday Home"
     case .missions: return "Missions"
     case .session: return "Session"
+    case .contextPassport: return "Context Passport"
     case .shareIntake: return "Share Intake"
     case .voice: return "Voice"
     case .needsMe: return "Needs Me"
@@ -44,6 +46,7 @@ enum MobileDestination: String, CaseIterable, Identifiable {
     case .home: return "house"
     case .missions: return "list.bullet.rectangle"
     case .session: return "rectangle.connected.to.line.below"
+    case .contextPassport: return "checklist.checked"
     case .shareIntake: return "square.and.arrow.down"
     case .voice: return "waveform"
     case .needsMe: return "person.crop.circle.badge.exclamationmark"
@@ -83,7 +86,7 @@ struct CommandSheet: View {
         }
         .padding(16)
 
-        Text("Read-only projection")
+        Text("Live truth")
           .font(.caption2)
           .foregroundStyle(MobileTheme.textSecondary)
           .padding(.top, 8)

--- a/apps/friday-ios/Sources/FridayMobileShell/FridayApp.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayApp.swift
@@ -354,6 +354,8 @@ struct RootView: View {
           FridayHomeScreen(viewModel: homeVM)
         case .session:
           FridaySessionDetailScreen(homeViewModel: homeVM, viewModel: sessionContinuationVM)
+        case .contextPassport:
+          FridayContextPassportScreen(viewModel: homeVM)
         case .shareIntake:
           FridayShareIntakeScreen(viewModel: shareIntakeVM)
         case .voice:

--- a/apps/friday-ios/Sources/FridayMobileShell/FridayContextPassportScreen.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayContextPassportScreen.swift
@@ -1,0 +1,166 @@
+import FridayMobileShellCore
+import SwiftUI
+
+struct FridayContextPassportScreen: View {
+  @ObservedObject var viewModel: HomeViewModel
+
+  var body: some View {
+    ScrollView {
+      VStack(spacing: 16) {
+        switch viewModel.state {
+        case .idle, .loading:
+          header(status: "loading", ready: false)
+          loadingView
+        case .unavailable(let reason):
+          header(status: "unavailable", ready: false)
+          UnavailableView(reason: reason)
+        case .loaded(let projection):
+          loadedContent(projection)
+        }
+      }
+      .padding(16)
+    }
+    .background(MobileTheme.backgroundWarmOffWhite.ignoresSafeArea())
+  }
+
+  @ViewBuilder
+  private func loadedContent(_ projection: HomeProjection) -> some View {
+    let status = projection.t3ProvisioningStatus
+    header(
+      status: status?.homeStatusLabel ?? "not loaded",
+      ready: status?.isFullyProvisioned == true)
+
+    if let status {
+      checklistCard(status)
+      refsCard(status)
+      truthCard(status)
+    } else {
+      GlassPanel {
+        VStack(alignment: .leading, spacing: MobileTheme.rowSpacing) {
+          Text("No T3 projection")
+            .font(.headline)
+            .foregroundStyle(MobileTheme.textPrimary)
+          Text("Friday did not return PairAck, trust grant, or context passport status in this Home projection.")
+            .font(.caption)
+            .foregroundStyle(MobileTheme.textSecondary)
+            .fixedSize(horizontal: false, vertical: true)
+        }
+      }
+    }
+  }
+
+  private func header(status: String, ready: Bool) -> some View {
+    GlassPanel {
+      HStack(spacing: 12) {
+        Image(systemName: "checklist.checked")
+          .font(.system(size: 24, weight: .semibold))
+          .foregroundStyle(ready ? MobileTheme.cyan : MobileTheme.coral)
+          .frame(width: 34, height: 34)
+        VStack(alignment: .leading, spacing: 4) {
+          Text("Context Passport")
+            .font(.headline)
+            .foregroundStyle(MobileTheme.textPrimary)
+          Text("governed device and shared-context readiness")
+            .font(.caption)
+            .foregroundStyle(MobileTheme.textSecondary)
+        }
+        Spacer()
+        StatusChip(
+          text: status,
+          bg: ready ? MobileTheme.chipPendingBG : MobileTheme.chipWarnBG,
+          fg: ready ? MobileTheme.chipPendingFG : MobileTheme.chipWarnFG)
+      }
+    }
+    .accessibilityIdentifier("friday.context-passport.header")
+  }
+
+  private var loadingView: some View {
+    GlassPanel {
+      HStack(spacing: 12) {
+        ProgressView()
+        Text("Reading provisioning truth")
+          .font(.footnote)
+          .foregroundStyle(MobileTheme.textSecondary)
+      }
+      .frame(maxWidth: .infinity, minHeight: 86, alignment: .leading)
+    }
+  }
+
+  private func checklistCard(_ status: HomeT3ProvisioningStatus) -> some View {
+    GlassPanel {
+      VStack(alignment: .leading, spacing: MobileTheme.rowSpacing) {
+        cardHeader("Checklist", count: status.checklistRows.filter(\.satisfied).count)
+        ForEach(status.checklistRows) { row in
+          HStack(alignment: .top, spacing: 10) {
+            Image(systemName: row.satisfied ? "checkmark.circle.fill" : "exclamationmark.triangle.fill")
+              .foregroundStyle(row.satisfied ? MobileTheme.cyan : MobileTheme.coral)
+              .frame(width: 22)
+            VStack(alignment: .leading, spacing: 3) {
+              HStack {
+                Text(row.title)
+                  .font(.caption.weight(.semibold))
+                  .foregroundStyle(MobileTheme.textPrimary)
+                Spacer()
+                StatusChip(
+                  text: row.statusText,
+                  bg: row.satisfied ? MobileTheme.chipPendingBG : MobileTheme.chipWarnBG,
+                  fg: row.satisfied ? MobileTheme.chipPendingFG : MobileTheme.chipWarnFG)
+              }
+              Text(row.detail)
+                .font(.caption2)
+                .foregroundStyle(MobileTheme.textSecondary)
+                .fixedSize(horizontal: false, vertical: true)
+            }
+          }
+        }
+      }
+    }
+    .accessibilityIdentifier("friday.context-passport.checklist")
+  }
+
+  private func refsCard(_ status: HomeT3ProvisioningStatus) -> some View {
+    GlassPanel {
+      VStack(alignment: .leading, spacing: MobileTheme.rowSpacing) {
+        cardHeader("Device", count: nil)
+        if let device = status.latestDevice {
+          RefPill(label: "device_id", ref: device.deviceId)
+          RefPill(label: "label", ref: device.label)
+          RefPill(label: "fingerprint", ref: device.pubkeyFingerprint)
+        } else {
+          Text("No trusted device ref is present in this projection.")
+            .font(.caption)
+            .foregroundStyle(MobileTheme.textSecondary)
+            .fixedSize(horizontal: false, vertical: true)
+        }
+      }
+    }
+  }
+
+  private func truthCard(_ status: HomeT3ProvisioningStatus) -> some View {
+    GlassPanel {
+      VStack(alignment: .leading, spacing: MobileTheme.rowSpacing) {
+        cardHeader("Truth", count: nil)
+        Text(status.homeSummary)
+          .font(.caption)
+          .foregroundStyle(MobileTheme.textSecondary)
+          .fixedSize(horizontal: false, vertical: true)
+        RefPill(label: "truth", ref: status.truthLabel)
+        if !status.missingOperatorSteps.isEmpty {
+          RefPill(label: "missing", ref: status.missingOperatorSteps.joined(separator: ", "))
+        }
+      }
+    }
+  }
+
+  private func cardHeader(_ title: String, count: Int?) -> some View {
+    HStack {
+      Text(title)
+        .font(.headline)
+        .foregroundStyle(MobileTheme.textPrimary)
+      Spacer()
+      if let count {
+        StatusChip(text: "\(count)/4", bg: MobileTheme.chipNeutralBG, fg: MobileTheme.chipNeutralFG)
+      }
+    }
+  }
+}

--- a/apps/friday-ios/Sources/FridayMobileShell/FridayProjectionScreens.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayProjectionScreens.swift
@@ -14,7 +14,7 @@ private enum ProjectionSurface {
 
   init?(_ destination: MobileDestination) {
     switch destination {
-    case .home, .session, .shareIntake, .voice:
+    case .home, .session, .contextPassport, .shareIntake, .voice:
       return nil
     case .missions:
       self = .missions

--- a/apps/friday-ios/Sources/FridayMobileShellCore/HomeViewModel.swift
+++ b/apps/friday-ios/Sources/FridayMobileShellCore/HomeViewModel.swift
@@ -303,11 +303,48 @@ public struct HomeT3ProvisioningStatus: Sendable, Equatable {
     return "No complete T3 device pairing in the Hub projection; missing \(missing)."
   }
 
+  public var checklistRows: [HomeT3ProvisioningStep] {
+    [
+      HomeT3ProvisioningStep(
+        id: "pairack",
+        title: "PairAck",
+        satisfied: paired,
+        statusText: paired ? "paired" : "needed",
+        detail: "\(deviceIdentityCount) device identity · \(activeTrustedDeviceCount) active trusted device"),
+      HomeT3ProvisioningStep(
+        id: "trust-grant",
+        title: "Trust grant",
+        satisfied: activeTrustGrantCount > 0,
+        statusText: activeTrustGrantCount > 0 ? "active" : "needed",
+        detail: "\(trustGrantCount) grant · \(activeTrustGrantCount) active"),
+      HomeT3ProvisioningStep(
+        id: "context-passport",
+        title: "Context passport",
+        satisfied: contextPassportCount > 0,
+        statusText: contextPassportCount > 0 ? "minted" : "needed",
+        detail: "\(contextPassportCount) passport"),
+      HomeT3ProvisioningStep(
+        id: "passport-items",
+        title: "Shared context",
+        satisfied: contextPassportItemCount > 0,
+        statusText: contextPassportItemCount > 0 ? "shared" : "needed",
+        detail: "\(contextPassportItemCount) passport items"),
+    ]
+  }
+
   private static func int(_ value: Any?) -> Int {
     if let int = value as? Int { return int }
     if let number = value as? NSNumber { return number.intValue }
     return 0
   }
+}
+
+public struct HomeT3ProvisioningStep: Sendable, Identifiable, Equatable {
+  public let id: String
+  public let title: String
+  public let satisfied: Bool
+  public let statusText: String
+  public let detail: String
 }
 
 public struct HomeTrustedDeviceSummary: Sendable, Equatable {

--- a/apps/friday-ios/Tests/FridayMobileShellCoreTests/HomeViewModelTests.swift
+++ b/apps/friday-ios/Tests/FridayMobileShellCoreTests/HomeViewModelTests.swift
@@ -386,6 +386,13 @@ final class HomeViewModelTests: XCTestCase {
       p.t3ProvisioningStatus?.homeSummary,
       "Hub projection shows 1 device identity, 1 active trusted device, 1 active trust grant, 1 context passport, and 2 passport items.")
     XCTAssertEqual(p.t3ProvisioningStatus?.missingOperatorSteps, [])
+    XCTAssertEqual(p.t3ProvisioningStatus?.checklistRows.map(\.id), [
+      "pairack", "trust-grant", "context-passport", "passport-items",
+    ])
+    XCTAssertEqual(p.t3ProvisioningStatus?.checklistRows.map(\.satisfied), [
+      true, true, true, true,
+    ])
+    XCTAssertEqual(p.t3ProvisioningStatus?.checklistRows.last?.statusText, "shared")
     XCTAssertEqual(p.transcriptEvents.first?.summary, "Mobile surface read the mission projection.")
     XCTAssertEqual(p.needsMeCount, 4)
   }
@@ -425,6 +432,12 @@ final class HomeViewModelTests: XCTestCase {
     XCTAssertEqual(
       projection.t3ProvisioningStatus?.homeSummary,
       "Paired device is visible in the Hub (1 active trusted device); missing trust grant, context passport.")
+    XCTAssertEqual(projection.t3ProvisioningStatus?.checklistRows.map(\.satisfied), [
+      true, false, false, false,
+    ])
+    XCTAssertEqual(projection.t3ProvisioningStatus?.checklistRows.map(\.statusText), [
+      "paired", "needed", "needed", "needed",
+    ])
   }
 
   func testRefresh_loadedEmptyIsConnectedEmptyNotUnavailable() async throws {

--- a/apps/friday-ios/build-sim.sh
+++ b/apps/friday-ios/build-sim.sh
@@ -189,7 +189,15 @@ case "$MODE" in
     fi
     ;;
 esac
-env "${LAUNCH_ENV[@]}" xcrun simctl launch --terminate-running-process "$UDID" com.friday.shell "${LAUNCH_ARGS[@]}"
+LAUNCH_CMD=(xcrun simctl launch --terminate-running-process "$UDID" com.friday.shell)
+if ((${#LAUNCH_ARGS[@]} > 0)); then
+  LAUNCH_CMD+=("${LAUNCH_ARGS[@]}")
+fi
+if ((${#LAUNCH_ENV[@]} > 0)); then
+  env "${LAUNCH_ENV[@]}" "${LAUNCH_CMD[@]}"
+else
+  "${LAUNCH_CMD[@]}"
+fi
 # Give the WKWebView time to load the host page over `friday-pet://`, fetch the bundled engine +
 # v9 assets, and start the canvas animation before the screenshot. Per the design CLAUDE.md hard
 # rule 5, the pet is verified by the RENDERED image (open $SHOT), not by code/bbox numbers — a


### PR DESCRIPTION
## Summary
- add a dedicated iOS Context Passport command-sheet destination backed by the existing T3 provisioning projection
- expose PairAck / trust grant / context passport / shared-context checklist rows without minting, signing, or upgrading truth
- fix the iOS simulator offline-truth launcher so empty launch env/args do not trip set -u

## Verification
- swift test --package-path apps/friday-ios --filter HomeViewModelTests
- swift test --package-path apps/friday-ios
- bash -n apps/friday-ios/build-sim.sh
- apps/friday-ios/build-sim.sh --mode offline-truth --shot apps/friday-ios/.build-sim/friday-ios-context-passport-checklist.png

Truth: product surface + proof-script fix only; no trust_grant/context_passport mint endpoint, no signing-key custody, no END-BAR/GO-LIVE claim.