### PR TITLE
Correct desktop governed workbench label

### DIFF
--- a/apps/macos/FridayHubConsole/Sources/FridayHubConsole/FridayHubConsoleApp.swift
+++ b/apps/macos/FridayHubConsole/Sources/FridayHubConsole/FridayHubConsoleApp.swift
@@ -4,7 +4,7 @@ import SwiftUI
 
 /// Friday Hub Console — the v1 desktop UI shell (D-PR1).
 ///
-/// A read-only operator workbench over Rust Hub Mission truth.
+/// A governed operator workbench over Rust Hub Mission truth.
 ///
 /// LAUNCH MODES (LIVE is the DEFAULT — the slice-6 J2/I3/I4 flip):
 ///   - DEFAULT (LIVE) — the REAL `SealedWSReadClient` (the `FridayRustClient` package) over the

--- a/apps/macos/FridayHubConsole/Sources/FridayHubConsole/HubConsoleShell.swift
+++ b/apps/macos/FridayHubConsole/Sources/FridayHubConsole/HubConsoleShell.swift
@@ -97,10 +97,17 @@ struct NavRail: View {
 
       Spacer()
 
-      Text("Read-only workbench")
-        .font(.system(size: 10))
-        .foregroundStyle(HubTheme.textSecondary)
-        .padding(14)
+      VStack(alignment: .leading, spacing: 3) {
+        Text("Governed workbench")
+          .font(.system(size: 10, weight: .semibold))
+          .foregroundStyle(HubTheme.textPrimary)
+        Text("Live read + gated writes")
+          .font(.system(size: 10))
+          .foregroundStyle(HubTheme.textSecondary)
+      }
+      .padding(14)
+      .accessibilityElement(children: .combine)
+      .accessibilityLabel("Governed workbench. Live read plus gated writes.")
     }
     .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
     .background(HubTheme.navRailBackground)


### PR DESCRIPTION
## Summary
- update the desktop nav footer and app comment from stale read-only wording to governed-workbench truth
- keep the label explicit that live reads and gated writes exist without changing any signing or write behavior

## Verification
- swift test --package-path apps/macos/FridayHubConsole
- rg -n "Read-only workbench|read-only operator workbench" apps/macos/FridayHubConsole -S || true

Truth: UI wording only; no GO-LIVE, END-BAR, signature custody, or mint endpoint claim.