### PR TITLE
Add iOS token ledger surface

### DIFF
--- a/apps/friday-ios/Sources/FridayMobileShell/CommandSheet.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/CommandSheet.swift
@@ -11,6 +11,7 @@ enum MobileDestination: String, CaseIterable, Identifiable {
   case missions
   case session
   case contextPassport
+  case tokenLedger
   case shareIntake
   case voice
   case needsMe
@@ -29,6 +30,7 @@ enum MobileDestination: String, CaseIterable, Identifiable {
     case .missions: return "Missions"
     case .session: return "Session"
     case .contextPassport: return "Context Passport"
+    case .tokenLedger: return "Token Ledger"
     case .shareIntake: return "Share Intake"
     case .voice: return "Voice"
     case .needsMe: return "Needs Me"
@@ -47,6 +49,7 @@ enum MobileDestination: String, CaseIterable, Identifiable {
     case .missions: return "list.bullet.rectangle"
     case .session: return "rectangle.connected.to.line.below"
     case .contextPassport: return "checklist.checked"
+    case .tokenLedger: return "chart.bar.doc.horizontal"
     case .shareIntake: return "square.and.arrow.down"
     case .voice: return "waveform"
     case .needsMe: return "person.crop.circle.badge.exclamationmark"

--- a/apps/friday-ios/Sources/FridayMobileShell/FridayApp.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayApp.swift
@@ -356,6 +356,8 @@ struct RootView: View {
           FridaySessionDetailScreen(homeViewModel: homeVM, viewModel: sessionContinuationVM)
         case .contextPassport:
           FridayContextPassportScreen(viewModel: homeVM)
+        case .tokenLedger:
+          FridayTokenLedgerScreen(viewModel: homeVM)
         case .shareIntake:
           FridayShareIntakeScreen(viewModel: shareIntakeVM)
         case .voice:

--- a/apps/friday-ios/Sources/FridayMobileShell/FridayProjectionScreens.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayProjectionScreens.swift
@@ -14,7 +14,7 @@ private enum ProjectionSurface {
 
   init?(_ destination: MobileDestination) {
     switch destination {
-    case .home, .session, .contextPassport, .shareIntake, .voice:
+    case .home, .session, .contextPassport, .tokenLedger, .shareIntake, .voice:
       return nil
     case .missions:
       self = .missions

--- a/apps/friday-ios/Sources/FridayMobileShell/FridayTokenLedgerScreen.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayTokenLedgerScreen.swift
@@ -1,0 +1,173 @@
+import FridayMobileShellCore
+import SwiftUI
+
+struct FridayTokenLedgerScreen: View {
+  @ObservedObject var viewModel: HomeViewModel
+
+  var body: some View {
+    ScrollView {
+      VStack(spacing: 16) {
+        switch viewModel.state {
+        case .idle, .loading:
+          header(status: "loading", ready: false)
+          loadingView
+        case .unavailable(let reason):
+          header(status: "unavailable", ready: false)
+          UnavailableView(reason: reason)
+        case .loaded(let projection):
+          loadedContent(projection)
+        }
+      }
+      .padding(16)
+    }
+    .background(MobileTheme.backgroundWarmOffWhite.ignoresSafeArea())
+  }
+
+  @ViewBuilder
+  private func loadedContent(_ projection: HomeProjection) -> some View {
+    let runId = projection.tokenLedgerRunId
+    header(status: runId == nil ? "no run ref" : "readable", ready: runId != nil)
+
+    if let runId {
+      runRefCard(runId: runId, projection: projection)
+      detailCard
+    } else {
+      noRunRefCard(projection)
+    }
+  }
+
+  private func header(status: String, ready: Bool) -> some View {
+    GlassPanel {
+      HStack(spacing: 12) {
+        Image(systemName: "chart.bar.doc.horizontal")
+          .font(.system(size: 24, weight: .semibold))
+          .foregroundStyle(ready ? MobileTheme.cyan : MobileTheme.coral)
+          .frame(width: 34, height: 34)
+        VStack(alignment: .leading, spacing: 4) {
+          Text("Token Ledger")
+            .font(.headline)
+            .foregroundStyle(MobileTheme.textPrimary)
+          Text("refs-only provider usage readback")
+            .font(.caption)
+            .foregroundStyle(MobileTheme.textSecondary)
+        }
+        Spacer()
+        StatusChip(
+          text: status,
+          bg: ready ? MobileTheme.chipPendingBG : MobileTheme.chipWarnBG,
+          fg: ready ? MobileTheme.chipPendingFG : MobileTheme.chipWarnFG)
+      }
+    }
+    .accessibilityIdentifier("friday.token-ledger.header")
+  }
+
+  private var loadingView: some View {
+    GlassPanel {
+      HStack(spacing: 12) {
+        ProgressView()
+        Text("Reading token ledger truth")
+          .font(.footnote)
+          .foregroundStyle(MobileTheme.textSecondary)
+      }
+      .frame(maxWidth: .infinity, minHeight: 86, alignment: .leading)
+    }
+  }
+
+  private func runRefCard(runId: String, projection: HomeProjection) -> some View {
+    GlassPanel {
+      VStack(alignment: .leading, spacing: MobileTheme.rowSpacing) {
+        cardHeader("Selected Run", count: nil)
+        Text("Friday will read the run readback arm for this run. No cost data is fabricated when the read arm is empty or unavailable.")
+          .font(.caption)
+          .foregroundStyle(MobileTheme.textSecondary)
+          .fixedSize(horizontal: false, vertical: true)
+        RefPill(label: "run_id", ref: runId)
+        RefPill(label: "mission_id", ref: projection.missionId)
+        Button {
+          Task { await viewModel.loadDetail(.runReadback(runId: runId)) }
+        } label: {
+          Label("Refresh Ledger", systemImage: "arrow.clockwise")
+        }
+        .disabled(viewModel.detailState.isLoading)
+      }
+    }
+    .task(id: runId) {
+      await viewModel.loadDetail(.runReadback(runId: runId))
+    }
+  }
+
+  private func noRunRefCard(_ projection: HomeProjection) -> some View {
+    GlassPanel {
+      VStack(alignment: .leading, spacing: MobileTheme.rowSpacing) {
+        cardHeader("No Run Ref", count: nil)
+        Text("The Home projection does not include a completed run ref yet, so Friday cannot show a token ledger from this app surface.")
+          .font(.caption)
+          .foregroundStyle(MobileTheme.textSecondary)
+          .fixedSize(horizontal: false, vertical: true)
+        RefPill(label: "mission_id", ref: projection.missionId)
+        RefPill(label: "feed", ref: projection.runtimeFeedStatus)
+      }
+    }
+    .accessibilityIdentifier("friday.token-ledger.no-run-ref")
+  }
+
+  @ViewBuilder
+  private var detailCard: some View {
+    switch viewModel.detailState {
+    case .idle:
+      EmptyView()
+    case .loading:
+      GlassPanel {
+        HStack(spacing: 12) {
+          ProgressView()
+          Text("Reading run ledger")
+            .font(.caption)
+            .foregroundStyle(MobileTheme.textSecondary)
+        }
+      }
+    case .loaded(let detail):
+      GlassPanel {
+        VStack(alignment: .leading, spacing: MobileTheme.rowSpacing) {
+          cardHeader(detail.title, count: detail.refs.count)
+          Text(detail.summary)
+            .font(.caption)
+            .foregroundStyle(MobileTheme.textPrimary)
+            .fixedSize(horizontal: false, vertical: true)
+          RefPill(label: "generated", ref: generatedText(detail.generatedAtMs))
+          ForEach(detail.refs, id: \.self) { ref in
+            RefPill(label: nil, ref: ref)
+          }
+        }
+      }
+      .accessibilityIdentifier("friday.token-ledger.detail")
+    case .unavailable(let title, let reason):
+      GlassPanel {
+        VStack(alignment: .leading, spacing: MobileTheme.rowSpacing) {
+          cardHeader(title, count: nil)
+          Text(reason)
+            .font(.caption)
+            .foregroundStyle(MobileTheme.textSecondary)
+            .fixedSize(horizontal: false, vertical: true)
+        }
+      }
+    }
+  }
+
+  private func cardHeader(_ title: String, count: Int?) -> some View {
+    HStack {
+      Text(title)
+        .font(.headline)
+        .foregroundStyle(MobileTheme.textPrimary)
+      Spacer()
+      if let count {
+        StatusChip(text: "\(count)", bg: MobileTheme.chipNeutralBG, fg: MobileTheme.chipNeutralFG)
+      }
+    }
+  }
+
+  private func generatedText(_ generatedAtMs: Int64) -> String {
+    guard generatedAtMs > 0 else { return "unknown" }
+    let date = Date(timeIntervalSince1970: Double(generatedAtMs) / 1000.0)
+    return date.formatted(date: .abbreviated, time: .shortened)
+  }
+}

--- a/apps/friday-ios/Sources/FridayMobileShellCore/HomeViewModel.swift
+++ b/apps/friday-ios/Sources/FridayMobileShellCore/HomeViewModel.swift
@@ -99,6 +99,10 @@ public struct HomeProjection: Sendable, Equatable {
       && transcriptEvents.isEmpty
   }
 
+  public var tokenLedgerRunId: String? {
+    runOutcomeLearningCandidates.lazy.map(\.runId).first { !$0.isEmpty }
+  }
+
   private static func parseWorkItems(_ value: Any?) -> [HomeWorkItem] {
     guard let rows = value as? [[String: Any]] else { return [] }
     return rows.compactMap { row in

--- a/apps/friday-ios/Tests/FridayMobileShellCoreTests/HomeViewModelTests.swift
+++ b/apps/friday-ios/Tests/FridayMobileShellCoreTests/HomeViewModelTests.swift
@@ -375,6 +375,7 @@ final class HomeViewModelTests: XCTestCase {
     XCTAssertEqual(p.workItems.last?.blockingReason, "failed retryable; operator may retry by returning the WorkItem to ready_to_dispatch")
     XCTAssertEqual(p.memoryCandidates.first?.grantsMemoryAuthority, false)
     XCTAssertEqual(p.runOutcomeLearningCandidates.first?.runId, "run-1")
+    XCTAssertEqual(p.tokenLedgerRunId, "run-1")
     XCTAssertEqual(p.capabilityStates.first?.dispatchAllowed, true)
     XCTAssertEqual(p.t3ProvisioningStatus?.truthLabel, "rust_hub_t3_provisioning_read_only_no_mint")
     XCTAssertEqual(p.t3ProvisioningStatus?.paired, true)
@@ -446,6 +447,7 @@ final class HomeViewModelTests: XCTestCase {
     guard case .loaded(let p) = vm.state else { return XCTFail("expected loaded empty projection, got \(vm.state)") }
     XCTAssertEqual(p.missionId, "mission-empty")
     XCTAssertTrue(p.isLoadedEmpty)
+    XCTAssertNil(p.tokenLedgerRunId)
     XCTAssertTrue(vm.state.isOnline)
     XCTAssertNil(vm.state.projection?.statusLabels.first)
   }


### PR DESCRIPTION
## Summary
- add Token Ledger as a first-class iOS command-sheet destination
- render an honest refs-only run ledger screen using the existing run readback arm
- surface no-run-ref as unavailable instead of fabricating usage/cost data

## Verification
- swift test --package-path apps/friday-ios --filter HomeViewModelTests
- swift test --package-path apps/friday-ios
- apps/friday-ios/build-sim.sh --mode offline-truth --shot apps/friday-ios/.build-sim/friday-ios-token-ledger-surface.png

Truth: read-only mobile surface; no backend mint/signing path, no fabricated token/cost values, no GO-LIVE or END-BAR claim.