### PR TITLE
Assert desktop live read T3 projection

### DIFF
--- a/apps/macos/FridayHubConsole/Tests/FridayHubConsoleCoreTests/LiveReadProjectionIntegrationTests.swift
+++ b/apps/macos/FridayHubConsole/Tests/FridayHubConsoleCoreTests/LiveReadProjectionIntegrationTests.swift
@@ -16,6 +16,12 @@ import Testing
 //   FRIDAY_CONSOLE_LIVE_TEST=1 swift test --package-path apps/macos/FridayHubConsole \
 //     --filter Live
 //
+// Optional scratch-port + T3 assertion:
+//   FRIDAY_CONSOLE_LIVE_TEST=1 \
+//   FRIDAY_CONSOLE_LIVE_READ_PORT=59152 \
+//   FRIDAY_CONSOLE_EXPECT_T3_READY=1 \
+//   swift test --package-path apps/macos/FridayHubConsole --filter LiveReadProjection
+//
 // PROOF CEILING (honest): the live read-projection DB may have NO active mission, in which case
 // the server returns a TYPED `Error(HUB_OFFLINE, "no active mission found")` rather than a
 // snapshot. That typed response is itself the end-to-end proof: it is owner-sealed under the
@@ -27,6 +33,7 @@ import Testing
 // never the master key or any derived secret.
 
 private let liveTestEnabled = ProcessInfo.processInfo.environment["FRIDAY_CONSOLE_LIVE_TEST"] == "1"
+private let expectT3Ready = ProcessInfo.processInfo.environment["FRIDAY_CONSOLE_EXPECT_T3_READY"] == "1"
 
 @Test(.enabled(if: liveTestEnabled))
 func liveReadProjectionSealedRoundTripWithMasterDerivedPeer() async throws {
@@ -37,8 +44,12 @@ func liveReadProjectionSealedRoundTripWithMasterDerivedPeer() async throws {
   print("[live] master-derived peer pubkey (PUBLIC) = \(Hex.encode(keypair.publicKey))")
 
   // Use the EXACT path the app launches under FRIDAY_CONSOLE_LIVE=1: `makeLive()` derives the
-  // master-derived peer, targets 48751, and authenticates as `admin-001` (the LaunchAgent owner).
-  let client = try RealReadClientFactory.makeLive()
+  // master-derived peer and authenticates as `admin-001` (the LaunchAgent owner). Tests may
+  // target a scratch read-projection server by setting FRIDAY_CONSOLE_LIVE_READ_HOST/PORT; this
+  // keeps the product default on 48751 while allowing no-prod-kill live proofs.
+  let config = liveReadConfigFromEnvironment()
+  let client = try RealReadClientFactory.makeLive(config: config)
+  print("[live] desktop read target = \(config.host):\(config.port)")
 
   // Drive the full handshake → owner-authed request → open the owner-sealed reply.
   do {
@@ -50,10 +61,28 @@ func liveReadProjectionSealedRoundTripWithMasterDerivedPeer() async throws {
         + "statusLabels=\(snapshot.statusLabels) workItemIds=\(snapshot.workItemIds) "
         + "generatedAtMs=\(snapshot.generatedAtMs)")
     #expect(!snapshot.missionId.isEmpty)
+    if expectT3Ready {
+      let displaySnapshot = try WorkbenchSnapshotAdapter.display(from: snapshot)
+      let t3 = try #require(displaySnapshot.t3ProvisioningStatus)
+      #expect(t3.isFullyProvisioned)
+      #expect(t3.activeTrustedDeviceCount > 0)
+      #expect(t3.activeTrustGrantCount > 0)
+      #expect(t3.contextPassportCount > 0)
+      #expect(t3.contextPassportItemCount > 0)
+      print(
+        "[live] T3 READY desktop projection decoded: "
+          + "activeTrustedDeviceCount=\(t3.activeTrustedDeviceCount) "
+          + "activeTrustGrantCount=\(t3.activeTrustGrantCount) "
+          + "contextPassportCount=\(t3.contextPassportCount) "
+          + "contextPassportItemCount=\(t3.contextPassportItemCount)")
+    }
   } catch let FridayReadClientError.serverError(code, message) {
     // The EXPECTED ceiling against an empty live DB: a typed, owner-sealed Error we could only
     // open because the full handshake + peer-auth + owner-auth round-trip SUCCEEDED.
     print("[live] AUTHENTICATED ROUND-TRIP OK — typed server response: code=\(code) message=\(message)")
+    if expectT3Ready {
+      Issue.record("expected a T3-ready desktop snapshot, got typed server response: \(code) \(message)")
+    }
     #expect(code == .hubOffline || code == .internal)
   }
   // Any OTHER error (transport/handshake/badServerPubkey/...) propagates and FAILS the test —
@@ -72,7 +101,7 @@ func liveReadProjectionRefusesFreshEphemeralPeer() async throws {
   let client = SealedWSReadClient(
     keypair: ephemeral,
     forwardedPrincipal: liveReadProjectionOwnerPrincipal,
-    makeTransport: { try LoopbackSealedWSTransport(config: .liveLoopback) })
+    makeTransport: { try LoopbackSealedWSTransport(config: liveReadConfigFromEnvironment()) })
 
   do {
     _ = try await client.fetchWorkbench()
@@ -83,4 +112,12 @@ func liveReadProjectionRefusesFreshEphemeralPeer() async throws {
     // The expected outcome: refused / session-ended / transport failure. Print it as evidence.
     print("[live] ephemeral peer REFUSED (fail-closed) as expected: \(error)")
   }
+}
+
+private func liveReadConfigFromEnvironment() -> ReadProjectionServerConfig {
+  let env = ProcessInfo.processInfo.environment
+  let host = env["FRIDAY_CONSOLE_LIVE_READ_HOST"] ?? ReadProjectionServerConfig.liveLoopback.host
+  let port = env["FRIDAY_CONSOLE_LIVE_READ_PORT"].flatMap(UInt16.init)
+    ?? ReadProjectionServerConfig.liveLoopback.port
+  return ReadProjectionServerConfig(host: host, port: port)
 }


### PR DESCRIPTION
## Summary
- let the desktop live-read integration test target a scratch read-projection server through `FRIDAY_CONSOLE_LIVE_READ_HOST/PORT`
- add optional `FRIDAY_CONSOLE_EXPECT_T3_READY=1` assertions that adapt the wire snapshot through `WorkbenchSnapshotAdapter` and verify T3 readiness
- keep CI behavior unchanged: live tests still skip unless `FRIDAY_CONSOLE_LIVE_TEST=1`

## Tests
- `swift test --package-path apps/macos/FridayHubConsole --filter LiveReadProjection`
- Scratch live proof against `hub_read_projection_server` on `127.0.0.1:59152`:
  - `FRIDAY_CONSOLE_LIVE_TEST=1 FRIDAY_CONSOLE_LIVE_READ_PORT=59152 FRIDAY_CONSOLE_EXPECT_T3_READY=1 swift test --package-path apps/macos/FridayHubConsole --filter LiveReadProjection`
  - decoded live snapshot from master-derived peer
  - verified T3 ready projection: activeTrustedDeviceCount=1, activeTrustGrantCount=1, contextPassportCount=1, contextPassportItemCount=3
  - negative-control ephemeral peer was refused fail-closed

## Truth / Caveat
This proves desktop sealed-read can decode a T3-ready live projection from a scratch read server. It does not restart/kill prod hub, prove real-device use, prove release/adoption, or claim END-BAR/GO-LIVE.
