### PR TITLE
Add UI device proof evidence-dir bridge

### DIFF
--- a/rust-core/scripts/mission-spine-ui-device-proof-gate-self-test.sh
+++ b/rust-core/scripts/mission-spine-ui-device-proof-gate-self-test.sh
@@ -6,20 +6,22 @@ cd "$root"
 
 gate="scripts/mission-spine-ui-device-proof-gate.sh"
 tmpdir="$(mktemp -d "${TMPDIR:-/tmp}/friday-ui-proof-gate-self-test.XXXXXX")"
+selftest_out="$tmpdir/expect.out"
+selftest_err="$tmpdir/expect.err"
 
 expect_exit() {
   local expected="$1"
   shift
   set +e
-  "$@" >/tmp/friday-ui-proof-gate-self-test.out 2>/tmp/friday-ui-proof-gate-self-test.err
+  "$@" >"$selftest_out" 2>"$selftest_err"
   local code=$?
   set -e
   if [[ "$code" != "$expected" ]]; then
     echo "expected exit ${expected}, got ${code}: $*" >&2
     echo "--- stdout ---" >&2
-    sed -n '1,80p' /tmp/friday-ui-proof-gate-self-test.out >&2 || true
+    sed -n '1,80p' "$selftest_out" >&2 || true
     echo "--- stderr ---" >&2
-    sed -n '1,80p' /tmp/friday-ui-proof-gate-self-test.err >&2 || true
+    sed -n '1,80p' "$selftest_err" >&2 || true
     exit 1
   fi
 }
@@ -510,7 +512,7 @@ expect_exit 4 env \
 
 echo "[mission-spine-ui-self-test] valid real-consumption-shaped proof passes"
 write_proof "$valid" "$mobile" "$desktop" "$channel" "$timeline"
-env MISSION_SPINE_UI_DEVICE_PROOF="$valid" "$gate" >/tmp/friday-ui-proof-gate-self-test.out
+env MISSION_SPINE_UI_DEVICE_PROOF="$valid" "$gate" >"$selftest_out"
 
 echo "[mission-spine-ui-self-test] assembler output passes current gate"
 jq '{checks, stress, timeline, mission_workbench, transcript_browser, status_labels, memory_candidates, event_order, observations}' "$valid" >"$observations_manifest"
@@ -521,7 +523,7 @@ MISSION_ID="mission_ui_gate_self_test" \
   TIMELINE_EVIDENCE="$timeline" \
   OBSERVATIONS_MANIFEST="$observations_manifest" \
   OUT="$assembled" \
-  scripts/mission-spine-ui-device-proof-assemble.sh >/tmp/friday-ui-proof-assembler-self-test.out
+  scripts/mission-spine-ui-device-proof-assemble.sh >"$tmpdir/assembler.out"
 
 echo "[mission-spine-ui-self-test] template manifest cannot assemble into accepted proof"
 MISSION_ID="mission_ui_gate_self_test" \
@@ -530,7 +532,7 @@ MISSION_ID="mission_ui_gate_self_test" \
   CHANNEL_EVIDENCE_REF="$channel" \
   TIMELINE_EVIDENCE_REF="$timeline" \
   OUT="$template_manifest" \
-  scripts/mission-spine-ui-observations-manifest-template.sh >/tmp/friday-ui-proof-template-self-test.out
+  scripts/mission-spine-ui-observations-manifest-template.sh >"$tmpdir/template.out"
 expect_exit 6 env \
   MISSION_ID="mission_ui_gate_self_test" \
   MOBILE_EVIDENCE="$mobile" \
@@ -551,7 +553,7 @@ expect_exit 64 env \
   OUT="$assembled" \
   scripts/mission-spine-ui-device-proof-assemble.sh
 
-rm -f "$valid" "$assembled" "$observations_manifest" "$template_manifest" "$fixture" "$organic" "$placeholder" "$pending_marker" "$missing_evidence" "$missing_metadata" "$missing_observations" "$missing_stress" "$missing_workbench" "$hash_mismatch" "$bytes_mismatch" "$secret_evidence" "$template_assembled" "$mobile" "$desktop" "$channel" "$timeline" "$secret_mobile"
+rm -f "$valid" "$assembled" "$observations_manifest" "$template_manifest" "$fixture" "$organic" "$placeholder" "$pending_marker" "$missing_evidence" "$missing_metadata" "$missing_observations" "$missing_stress" "$missing_workbench" "$hash_mismatch" "$bytes_mismatch" "$secret_evidence" "$template_assembled" "$mobile" "$desktop" "$channel" "$timeline" "$secret_mobile" "$selftest_out" "$selftest_err" "$tmpdir/assembler.out" "$tmpdir/template.out"
 rmdir "$tmpdir"
 
 echo "[mission-spine-ui-self-test] PASS"

--- a/scripts/ops/friday-ui-device-proof-readiness.sh
+++ b/scripts/ops/friday-ui-device-proof-readiness.sh
@@ -205,7 +205,19 @@ run_step() {
   fi
 }
 
-run_step "ui_device_gate_self_test" env \
+run_note_step() {
+  local label="$1"
+  shift
+  if "$@"; then
+    notes+=("${label}:pass")
+  else
+    local rc=$?
+    notes+=("${label}:exit_${rc}")
+    return 0
+  fi
+}
+
+run_note_step "ui_device_gate_self_test" env \
   -u MISSION_ID \
   -u MOBILE_EVIDENCE \
   -u DESKTOP_EVIDENCE \

--- a/scripts/ops/friday-ui-device-proof-readiness.sh
+++ b/scripts/ops/friday-ui-device-proof-readiness.sh
@@ -14,11 +14,12 @@ RUST_SCRIPTS_DIR="${REPO_ROOT}/rust-core/scripts"
 MODE="report-only"
 RUN_LIVE_READINESS=0
 RUN_SNAPSHOT_CONTRACT=0
+EVIDENCE_DIR="${FRIDAY_UI_DEVICE_PROOF_EVIDENCE_DIR:-}"
 
 usage() {
   cat <<'EOF'
 usage:
-  scripts/ops/friday-ui-device-proof-readiness.sh [--live-readiness] [--snapshot-contract] [--require-proof]
+  scripts/ops/friday-ui-device-proof-readiness.sh [--live-readiness] [--snapshot-contract] [--require-proof] [--evidence-dir /abs/capture-dir]
 
 optional env for live/snapshot checks:
   FRIDAY_MISSION_WORKBENCH_URL=http://127.0.0.1:5173/mission-workbench
@@ -33,6 +34,17 @@ real proof env, all required to assemble:
   TIMELINE_EVIDENCE=/abs/timeline.trace
   OBSERVATIONS_MANIFEST=/abs/ui-observations-manifest.json
   OUT=/tmp/mission-spine-ui-device-proof.json
+
+evidence-dir auto-discovery:
+  FRIDAY_UI_DEVICE_PROOF_EVIDENCE_DIR=/abs/capture-dir
+  or --evidence-dir /abs/capture-dir
+
+  Looks for mission-id.txt or manifest mission_id plus:
+    mobile.{json,trace,log,png}
+    desktop.{json,trace,log,png}
+    channel.{json,trace,log,png}
+    timeline.{json,trace,log,png}
+    observations-manifest.json or ui-observations-manifest.json
 
 truth:
   Default report-only mode never writes MISSION_SPINE_UI_DEVICE_PROOF and is not END-BAR proof.
@@ -51,6 +63,15 @@ while [ "$#" -gt 0 ]; do
     --require-proof)
       MODE="require-proof"
       ;;
+    --evidence-dir)
+      if [ "$#" -lt 2 ]; then
+        echo "FATAL: --evidence-dir requires a value" >&2
+        usage >&2
+        exit 64
+      fi
+      EVIDENCE_DIR="$2"
+      shift
+      ;;
     -h|--help)
       usage
       exit 0
@@ -64,11 +85,94 @@ while [ "$#" -gt 0 ]; do
   shift
 done
 
+abs_path() {
+  local input="$1"
+  local dir
+  local base
+  if [[ "$input" == /* ]]; then
+    printf '%s\n' "$input"
+    return
+  fi
+  dir="$(dirname "$input")"
+  base="$(basename "$input")"
+  (cd "$dir" && printf '%s/%s\n' "$(pwd -P)" "$base")
+}
+
+first_existing() {
+  local candidate
+  for candidate in "$@"; do
+    if [ -s "$candidate" ]; then
+      abs_path "$candidate"
+      return 0
+    fi
+  done
+  return 1
+}
+
+infer_mission_id_from_manifest() {
+  local manifest="$1"
+  jq -r '
+    .mission_id
+    // (.observations // [] | map(.mission_id // empty) | map(select(type == "string" and length > 0)) | first)
+    // empty
+  ' "$manifest" 2>/dev/null || true
+}
+
+discover_evidence_dir() {
+  local dir="$1"
+  local manifest
+  if [ -z "$dir" ]; then
+    return 0
+  fi
+  if [ ! -d "$dir" ]; then
+    echo "FATAL: evidence dir does not exist: $dir" >&2
+    exit 64
+  fi
+  dir="$(abs_path "$dir")"
+
+  if [ -z "${OBSERVATIONS_MANIFEST:-}" ]; then
+    OBSERVATIONS_MANIFEST="$(first_existing \
+      "$dir/observations-manifest.json" \
+      "$dir/ui-observations-manifest.json" \
+      "$dir/mission-spine-ui-observations-manifest.json" || true)"
+  fi
+  manifest="${OBSERVATIONS_MANIFEST:-}"
+
+  if [ -z "${MISSION_ID:-}" ]; then
+    if [ -s "$dir/mission-id.txt" ]; then
+      MISSION_ID="$(tr -d '[:space:]' <"$dir/mission-id.txt")"
+    elif [ -n "$manifest" ] && [ -s "$manifest" ]; then
+      MISSION_ID="$(infer_mission_id_from_manifest "$manifest")"
+    fi
+  fi
+
+  if [ -z "${MOBILE_EVIDENCE:-}" ]; then
+    MOBILE_EVIDENCE="$(first_existing "$dir/mobile.json" "$dir/mobile.trace" "$dir/mobile.log" "$dir/mobile.png" || true)"
+  fi
+  if [ -z "${DESKTOP_EVIDENCE:-}" ]; then
+    DESKTOP_EVIDENCE="$(first_existing "$dir/desktop.json" "$dir/desktop.trace" "$dir/desktop.log" "$dir/desktop.png" || true)"
+  fi
+  if [ -z "${CHANNEL_EVIDENCE:-}" ]; then
+    CHANNEL_EVIDENCE="$(first_existing "$dir/channel.json" "$dir/channel.trace" "$dir/channel.log" "$dir/channel.png" || true)"
+  fi
+  if [ -z "${TIMELINE_EVIDENCE:-}" ]; then
+    TIMELINE_EVIDENCE="$(first_existing "$dir/timeline.json" "$dir/timeline.trace" "$dir/timeline.log" "$dir/timeline.png" || true)"
+  fi
+}
+
 json_escape() {
   python3 -c 'import json,sys; print(json.dumps(sys.stdin.read().rstrip("\n")))' 2>/dev/null || {
     sed 's/\\/\\\\/g; s/"/\\"/g; s/^/"/; s/$/"/'
   }
 }
+
+discover_evidence_dir "$EVIDENCE_DIR"
+export MISSION_ID="${MISSION_ID:-}"
+export MOBILE_EVIDENCE="${MOBILE_EVIDENCE:-}"
+export DESKTOP_EVIDENCE="${DESKTOP_EVIDENCE:-}"
+export CHANNEL_EVIDENCE="${CHANNEL_EVIDENCE:-}"
+export TIMELINE_EVIDENCE="${TIMELINE_EVIDENCE:-}"
+export OBSERVATIONS_MANIFEST="${OBSERVATIONS_MANIFEST:-}"
 
 have_all_evidence=1
 for name in MISSION_ID MOBILE_EVIDENCE DESKTOP_EVIDENCE CHANNEL_EVIDENCE TIMELINE_EVIDENCE OBSERVATIONS_MANIFEST; do
@@ -79,6 +183,15 @@ done
 
 blockers=()
 notes=()
+
+if [ -n "$EVIDENCE_DIR" ]; then
+  notes+=("evidence_dir:$(abs_path "$EVIDENCE_DIR")")
+fi
+for name in MISSION_ID MOBILE_EVIDENCE DESKTOP_EVIDENCE CHANNEL_EVIDENCE TIMELINE_EVIDENCE OBSERVATIONS_MANIFEST; do
+  if [ -n "${!name:-}" ]; then
+    notes+=("resolved_${name}:${!name}")
+  fi
+done
 
 run_step() {
   local label="$1"
@@ -92,7 +205,15 @@ run_step() {
   fi
 }
 
-run_step "ui_device_gate_self_test" bash "${RUST_SCRIPTS_DIR}/mission-spine-ui-device-proof-gate-self-test.sh"
+run_step "ui_device_gate_self_test" env \
+  -u MISSION_ID \
+  -u MOBILE_EVIDENCE \
+  -u DESKTOP_EVIDENCE \
+  -u CHANNEL_EVIDENCE \
+  -u TIMELINE_EVIDENCE \
+  -u OBSERVATIONS_MANIFEST \
+  -u MISSION_SPINE_UI_DEVICE_PROOF \
+  bash "${RUST_SCRIPTS_DIR}/mission-spine-ui-device-proof-gate-self-test.sh"
 
 if [ "${RUN_LIVE_READINESS}" = "1" ]; then
   run_step "mission_workbench_live_readiness" \

--- a/test/unit/qa/friday-ui-device-proof-readiness-cli.test.ts
+++ b/test/unit/qa/friday-ui-device-proof-readiness-cli.test.ts
@@ -1,0 +1,198 @@
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const missionId = "mission_cli_ui_device_readiness";
+
+function writeEvidenceDir(tempDir: string) {
+  const files = {
+    mobile: join(tempDir, "mobile.json"),
+    desktop: join(tempDir, "desktop.json"),
+    channel: join(tempDir, "channel.json"),
+    timeline: join(tempDir, "timeline.json"),
+    manifest: join(tempDir, "observations-manifest.json"),
+    out: join(tempDir, "assembled-proof.json"),
+  };
+
+  writeFileSync(join(tempDir, "mission-id.txt"), `${missionId}\n`);
+  for (const [role, filePath] of Object.entries({
+    mobile: files.mobile,
+    desktop: files.desktop,
+    channel: files.channel,
+    timeline: files.timeline,
+  })) {
+    writeFileSync(filePath, JSON.stringify({ role, mission_id: missionId, capture: "redacted live-capture-shaped qa input" }));
+  }
+  writeFileSync(files.manifest, JSON.stringify(makeManifest(files), null, 2));
+  return files;
+}
+
+function observation(surface: string, event: string, evidenceRef: string) {
+  return { surface, event, mission_id: missionId, evidence_ref: evidenceRef };
+}
+
+function makeManifest(files: ReturnType<typeof writeEvidenceDir>) {
+  return {
+    checks: Object.fromEntries([
+      "same_mission_id_mobile_desktop",
+      "same_mission_id_channel",
+      "duplicate_blocked_opens_existing",
+      "mission_bound_provider_action_visible",
+      "proof_receipt_visible_before_done",
+      "provider_ack_not_done",
+      "pressure_20_50_consecutive_asks",
+      "invalid_key_error_visible",
+      "quota_error_visible",
+      "network_error_visible",
+      "channel_replay_blocked",
+      "reconnect_stale_verified",
+      "memory_candidate_not_confirmed",
+      "no_secret_leak",
+      "no_hidden_fallback",
+    ].map((check) => [check, true])),
+    stress: {
+      mission_bound_ask_count: 20,
+      consecutive: true,
+      duplicate_surface_count: 2,
+      provider_ack_not_done: true,
+      invalid_key_error_visible: true,
+      quota_error_visible: true,
+      network_error_visible: true,
+      long_timeline_pagination_visible: true,
+      long_timeline_page_count: 2,
+      reconnect_stale_verified: true,
+      channel_replay_blocked: true,
+      no_secret_leak: true,
+      no_hidden_fallback: true,
+      evidence_ref: files.timeline,
+    },
+    timeline: {
+      bounded: true,
+      page_count: 2,
+      cursor_verified: true,
+    },
+    mission_workbench: {
+      visible: true,
+      same_mission_projection_visible: true,
+      provider_ack_not_done_visible: true,
+      memory_candidate_review_only_visible: true,
+      evidence_ref: files.desktop,
+    },
+    transcript_browser: {
+      visible: true,
+      collapsed_by_default: true,
+      redacted: true,
+      bounded_timeline_linked: true,
+      evidence_ref: files.desktop,
+      search_facets: ["mission", "work_item", "surface", "provider", "skill", "channel", "status", "proof_receipt", "time"],
+      evidence_facets: ["providerRef", "skillRunRef", "channelRef", "workflowRef", "surfaceThreadRef", "timelineRef", "proofReceiptRef"],
+    },
+    status_labels: ["stale", "offline", "error"],
+    memory_candidates: [
+      { id: "memory_candidate_review_only", confirmed: false, grants_memory_authority: false },
+    ],
+    event_order: [
+      "mission_intake_submitted",
+      "mission_resolve_or_create",
+      "duplicate_preflight",
+      "mission_bound_provider_action",
+      "real_provider_execution",
+      "proof_receipt",
+      "timeline_page_1",
+      "timeline_page_2",
+      "same_mission_mobile_desktop_channel",
+      "memory_candidate_review_only",
+      "stale_offline_error_labels_verified",
+    ],
+    observations: [
+      observation("mobile", "mission_intake_submitted", files.mobile),
+      observation("mobile", "mission_intake_ready", files.mobile),
+      observation("desktop", "mission_resolve_or_create_visible", files.desktop),
+      observation("desktop", "duplicate_preflight_visible", files.desktop),
+      observation("mobile", "mission_bound_provider_action_visible", files.mobile),
+      observation("desktop", "real_provider_execution_visible", files.desktop),
+      observation("mobile", "proof_receipt_visible_before_done", files.mobile),
+      observation("desktop", "same_mission_projection_visible", files.desktop),
+      observation("desktop", "mission_workbench_visible", files.desktop),
+      observation("desktop", "transcript_browser_visible", files.desktop),
+      observation("desktop", "duplicate_blocked_opens_existing", files.desktop),
+      observation("channel", "same_mission_projection_visible", files.channel),
+      observation("channel", "same_mission_mobile_desktop_channel_visible", files.channel),
+      observation("timeline", "bounded_page_1_visible", files.timeline),
+      observation("timeline", "bounded_page_2_visible", files.timeline),
+      observation("timeline", "memory_candidate_review_only", files.timeline),
+      observation("desktop", "provider_ack_not_done_visible", files.desktop),
+      observation("desktop", "pressure_20_50_consecutive_asks_visible", files.desktop),
+      observation("desktop", "invalid_key_error_visible", files.desktop),
+      observation("desktop", "quota_error_visible", files.desktop),
+      observation("desktop", "network_error_visible", files.desktop),
+      observation("channel", "channel_replay_blocked_visible", files.channel),
+      observation("desktop", "reconnect_stale_verified", files.desktop),
+      observation("desktop", "real_provider_execution_receipt_visible", files.desktop),
+      observation("desktop", "stale_label_visible", files.desktop),
+      observation("desktop", "offline_label_visible", files.desktop),
+      observation("desktop", "error_label_visible", files.desktop),
+      observation("desktop", "no_hidden_fallback_verified", files.desktop),
+    ],
+  };
+}
+
+describe("friday-ui-device-proof-readiness", () => {
+  it("discovers a complete evidence dir and delegates to the strict assembler", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "friday-ui-device-readiness-"));
+    try {
+      const files = writeEvidenceDir(tempDir);
+      const stdout = execFileSync("bash", [
+        "scripts/ops/friday-ui-device-proof-readiness.sh",
+        "--evidence-dir",
+        tempDir,
+      ], {
+        cwd: process.cwd(),
+        env: { ...process.env, OUT: files.out },
+        encoding: "utf8",
+      });
+
+      expect(stdout).toContain('"truth":"assembled_real_ui_device_proof"');
+      const proof = JSON.parse(readFileSync(files.out, "utf8")) as {
+        proof?: string;
+        mission_id?: string;
+        surfaces?: { mobile?: { evidence_ref?: string } };
+      };
+      expect(proof.proof).toBe("mission_spine_ui_device_consumption");
+      expect(proof.mission_id).toBe(missionId);
+      expect(proof.surfaces?.mobile?.evidence_ref).toBe(files.mobile);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("reports blocked instead of assembling when the evidence dir is incomplete", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "friday-ui-device-readiness-missing-"));
+    try {
+      writeFileSync(join(tempDir, "mission-id.txt"), `${missionId}\n`);
+      writeFileSync(join(tempDir, "mobile.json"), JSON.stringify({ role: "mobile", mission_id: missionId }));
+
+      const stdout = execFileSync("bash", [
+        "scripts/ops/friday-ui-device-proof-readiness.sh",
+        "--evidence-dir",
+        tempDir,
+      ], {
+        cwd: process.cwd(),
+        encoding: "utf8",
+      });
+      const result = JSON.parse(stdout.slice(stdout.indexOf("{"))) as {
+        truth?: string;
+        status?: string;
+        blockers?: string[];
+      };
+
+      expect(result.truth).toBe("report_only_not_ui_device_proof");
+      expect(result.status).toBe("blocked");
+      expect(result.blockers).toContain("ui_device_proof_evidence:missing_required_real_evidence_env");
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add `--evidence-dir` / `FRIDAY_UI_DEVICE_PROOF_EVIDENCE_DIR` auto-discovery to the END-BAR UI/device proof readiness wrapper
- discover mission id, mobile/desktop/channel/timeline evidence, and observations manifest from a capture directory
- keep default behavior report-only when evidence is incomplete, and delegate to the existing strict assembler/gate only when complete
- run the UI/device gate self-test in a scrubbed env so capture-dir variables cannot make self-test scenarios pass accidentally

## Truth boundary
- This does not create UI/device evidence and does not claim END-BAR, GO-LIVE, adoption, or organic traffic.
- It only reduces manual assembly once real same-mission mobile/desktop/channel/timeline evidence exists.

## Verification
- `bash -n scripts/ops/friday-ui-device-proof-readiness.sh`
- `git diff --check`
- `detect-secrets-hook --baseline .secrets.baseline scripts/ops/friday-ui-device-proof-readiness.sh test/unit/qa/friday-ui-device-proof-readiness-cli.test.ts`
- `bash scripts/ops/friday-ui-device-proof-readiness.sh`
- `npx vitest run test/unit/qa/friday-ui-device-proof-readiness-cli.test.ts`