### PR TITLE
Add UI device capture dir driver

### DIFF
--- a/scripts/ops/friday-ui-device-capture-dir.mjs
+++ b/scripts/ops/friday-ui-device-capture-dir.mjs
@@ -1,0 +1,179 @@
+#!/usr/bin/env node
+
+import { createHash } from "node:crypto";
+import { copyFileSync, mkdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { basename, extname, isAbsolute, join, resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+
+const args = process.argv.slice(2);
+
+function usage() {
+  console.error(`usage:
+  node scripts/ops/friday-ui-device-capture-dir.mjs \\
+    --mission-id=mission_... \\
+    --out-dir=/abs/evidence-dir \\
+    --mobile=/abs/mobile-capture \\
+    --desktop=/abs/desktop-capture \\
+    --channel=/abs/channel-capture \\
+    --timeline=/abs/timeline-capture \\
+    [--observations-manifest=/abs/observations-manifest.json] [--require-ready]
+
+Truth: this indexes already-captured files into an evidence-dir shape. It is not a
+UI/device proof and never invents observations. A supplied observations manifest is
+validated by scripts/qa/check-mission-spine-ui-proof-inputs.mjs.`);
+}
+
+function arg(name) {
+  const prefix = `--${name}=`;
+  return args.find((value) => value.startsWith(prefix))?.slice(prefix.length) || "";
+}
+
+if (args.includes("--help") || args.includes("-h")) {
+  usage();
+  process.exit(0);
+}
+
+const requireReady = args.includes("--require-ready");
+const missionId = arg("mission-id");
+const outDir = arg("out-dir");
+const manifest = arg("observations-manifest");
+const inputByRole = {
+  mobile: arg("mobile"),
+  desktop: arg("desktop"),
+  channel: arg("channel"),
+  timeline: arg("timeline"),
+};
+
+const blockers = [];
+
+function block(code, detail) {
+  blockers.push({ code, detail });
+}
+
+function abs(path) {
+  return isAbsolute(path) ? path : resolve(path);
+}
+
+function sha256(path) {
+  return createHash("sha256").update(readFileSync(path)).digest("hex");
+}
+
+function safeExt(path) {
+  const ext = extname(path).toLowerCase();
+  return [".json", ".trace", ".log", ".png"].includes(ext) ? ext : ".trace";
+}
+
+function checkInput(role, path) {
+  if (!path) {
+    block("missing_capture", role);
+    return null;
+  }
+  const resolved = abs(path);
+  try {
+    const stats = statSync(resolved);
+    if (!stats.isFile()) {
+      block("capture_not_file", `${role}:${resolved}`);
+      return null;
+    }
+    if (stats.size <= 0) {
+      block("capture_empty", `${role}:${resolved}`);
+    }
+    return { role, source: resolved, bytes: stats.size, sha256: sha256(resolved) };
+  } catch {
+    block("capture_unreadable", `${role}:${resolved}`);
+    return null;
+  }
+}
+
+if (!missionId || !/^[A-Za-z0-9][A-Za-z0-9._:-]*$/.test(missionId) || !missionId.toLowerCase().includes("mission")) {
+  block("mission_id_unexpected_shape", missionId || "<missing>");
+}
+if (!outDir) {
+  block("missing_out_dir", "out-dir");
+}
+
+const captures = Object.entries(inputByRole).map(([role, path]) => checkInput(role, path)).filter(Boolean);
+const readyToWrite = blockers.length === 0 && outDir;
+
+let written = [];
+let copiedManifest = "";
+if (readyToWrite) {
+  const dir = abs(outDir);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, "mission-id.txt"), `${missionId}\n`);
+
+  written = captures.map((capture) => {
+    const target = join(dir, `${capture.role}${safeExt(capture.source)}`);
+    copyFileSync(capture.source, target);
+    return {
+      ...capture,
+      target,
+      targetName: basename(target),
+      targetSha256: sha256(target),
+      truth: "copied_capture_file_not_proof",
+    };
+  });
+
+  if (manifest) {
+    const manifestSource = abs(manifest);
+    try {
+      statSync(manifestSource);
+      copiedManifest = join(dir, "observations-manifest.json");
+      copyFileSync(manifestSource, copiedManifest);
+    } catch {
+      block("observations_manifest_unreadable", manifestSource);
+    }
+  } else {
+    block("observations_manifest_missing", "supply --observations-manifest from the same real capture run");
+  }
+
+  const index = {
+    truth: "ui_device_capture_dir_index_not_proof",
+    status: blockers.length === 0 ? "ready_for_preflight" : "blocked",
+    missionId,
+    evidenceDir: dir,
+    captures: written,
+    observationsManifest: copiedManifest || null,
+    blockers,
+  };
+  writeFileSync(join(dir, "capture-index.json"), `${JSON.stringify(index, null, 2)}\n`);
+}
+
+let preflight = null;
+if (readyToWrite && copiedManifest) {
+  const byRole = Object.fromEntries(written.map((capture) => [capture.role, capture.target]));
+  const result = spawnSync(process.execPath, [
+    "scripts/qa/check-mission-spine-ui-proof-inputs.mjs",
+    `--mission-id=${missionId}`,
+    `--mobile=${byRole.mobile}`,
+    `--desktop=${byRole.desktop}`,
+    `--channel=${byRole.channel}`,
+    `--timeline=${byRole.timeline}`,
+    `--manifest=${copiedManifest}`,
+  ], { encoding: "utf8" });
+  preflight = {
+    status: result.status,
+    stdout: result.stdout.trim(),
+    stderr: result.stderr.trim(),
+  };
+  if (result.status !== 0) {
+    block("ui_proof_inputs_preflight_failed", `exit_${result.status}`);
+  }
+}
+
+const output = {
+  truth: "ui_device_capture_dir_driver_not_proof",
+  status: blockers.length === 0 ? "ready" : "blocked",
+  missionId: missionId || null,
+  evidenceDir: outDir ? abs(outDir) : null,
+  captures: written,
+  observationsManifest: copiedManifest || null,
+  preflight,
+  blockers,
+  next: blockers.length === 0
+    ? "Run scripts/ops/friday-ui-device-proof-readiness.sh --evidence-dir <dir> --require-proof after the readiness bridge is present."
+    : "Fix blockers with real same-run evidence; do not fill synthetic observations.",
+};
+
+console.log(JSON.stringify(output, null, 2));
+process.exit(blockers.length === 0 || !requireReady ? 0 : 2);

--- a/test/unit/qa/friday-ui-device-capture-dir-cli.test.ts
+++ b/test/unit/qa/friday-ui-device-capture-dir-cli.test.ts
@@ -1,0 +1,190 @@
+import { execFileSync, spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const missionId = "mission_cli_ui_device_capture_dir";
+
+function writeEvidence(tempDir: string) {
+  const files = {
+    mobile: join(tempDir, "mobile.png"),
+    desktop: join(tempDir, "desktop.json"),
+    channel: join(tempDir, "channel.log"),
+    timeline: join(tempDir, "timeline.trace"),
+  };
+  for (const [role, path] of Object.entries(files)) {
+    writeFileSync(path, `real capture shaped evidence ${role} ${missionId}\n`);
+  }
+  return files;
+}
+
+function observation(surface: string, event: string, evidenceRef: string) {
+  return { surface, event, mission_id: missionId, evidence_ref: evidenceRef };
+}
+
+function writeManifest(path: string, evidenceDir: string) {
+  const refs = {
+    mobile: join(evidenceDir, "mobile.png"),
+    desktop: join(evidenceDir, "desktop.json"),
+    channel: join(evidenceDir, "channel.log"),
+    timeline: join(evidenceDir, "timeline.trace"),
+  };
+  const checks = [
+    "same_mission_id_mobile_desktop",
+    "same_mission_id_channel",
+    "duplicate_blocked_opens_existing",
+    "mission_bound_provider_action_visible",
+    "proof_receipt_visible_before_done",
+    "provider_ack_not_done",
+    "pressure_20_50_consecutive_asks",
+    "invalid_key_error_visible",
+    "quota_error_visible",
+    "network_error_visible",
+    "channel_replay_blocked",
+    "reconnect_stale_verified",
+    "memory_candidate_not_confirmed",
+    "no_secret_leak",
+    "no_hidden_fallback",
+  ];
+  const manifest = {
+    checks: Object.fromEntries(checks.map((check) => [check, true])),
+    stress: {
+      mission_bound_ask_count: 20,
+      consecutive: true,
+      duplicate_surface_count: 2,
+      provider_ack_not_done: true,
+      invalid_key_error_visible: true,
+      quota_error_visible: true,
+      network_error_visible: true,
+      long_timeline_pagination_visible: true,
+      long_timeline_page_count: 2,
+      reconnect_stale_verified: true,
+      channel_replay_blocked: true,
+      no_secret_leak: true,
+      no_hidden_fallback: true,
+      evidence_ref: refs.timeline,
+    },
+    timeline: { bounded: true, page_count: 2, cursor_verified: true },
+    mission_workbench: {
+      visible: true,
+      same_mission_projection_visible: true,
+      provider_ack_not_done_visible: true,
+      memory_candidate_review_only_visible: true,
+      evidence_ref: refs.desktop,
+    },
+    transcript_browser: {
+      visible: true,
+      collapsed_by_default: true,
+      redacted: true,
+      bounded_timeline_linked: true,
+      evidence_ref: refs.desktop,
+      search_facets: ["mission", "work_item", "surface", "provider", "skill", "channel", "status", "proof_receipt", "time"],
+      evidence_facets: ["providerRef", "skillRunRef", "channelRef", "workflowRef", "surfaceThreadRef", "timelineRef", "proofReceiptRef"],
+    },
+    status_labels: ["stale", "offline", "error"],
+    memory_candidates: [{ id: "memory_candidate_review_only", confirmed: false, grants_memory_authority: false }],
+    event_order: [
+      "mission_intake_submitted",
+      "mission_resolve_or_create",
+      "duplicate_preflight",
+      "mission_bound_provider_action",
+      "real_provider_execution",
+      "proof_receipt",
+      "timeline_page_1",
+      "timeline_page_2",
+      "same_mission_mobile_desktop_channel",
+      "memory_candidate_review_only",
+      "stale_offline_error_labels_verified",
+    ],
+    observations: [
+      observation("mobile", "mission_intake_submitted", refs.mobile),
+      observation("mobile", "mission_intake_ready", refs.mobile),
+      observation("desktop", "mission_resolve_or_create_visible", refs.desktop),
+      observation("desktop", "duplicate_preflight_visible", refs.desktop),
+      observation("mobile", "mission_bound_provider_action_visible", refs.mobile),
+      observation("desktop", "real_provider_execution_visible", refs.desktop),
+      observation("mobile", "proof_receipt_visible_before_done", refs.mobile),
+      observation("desktop", "same_mission_projection_visible", refs.desktop),
+      observation("desktop", "mission_workbench_visible", refs.desktop),
+      observation("desktop", "transcript_browser_visible", refs.desktop),
+      observation("desktop", "duplicate_blocked_opens_existing", refs.desktop),
+      observation("channel", "same_mission_projection_visible", refs.channel),
+      observation("channel", "same_mission_mobile_desktop_channel_visible", refs.channel),
+      observation("timeline", "bounded_page_1_visible", refs.timeline),
+      observation("timeline", "bounded_page_2_visible", refs.timeline),
+      observation("timeline", "memory_candidate_review_only", refs.timeline),
+      observation("desktop", "provider_ack_not_done_visible", refs.desktop),
+      observation("desktop", "pressure_20_50_consecutive_asks_visible", refs.desktop),
+      observation("desktop", "invalid_key_error_visible", refs.desktop),
+      observation("desktop", "quota_error_visible", refs.desktop),
+      observation("desktop", "network_error_visible", refs.desktop),
+      observation("channel", "channel_replay_blocked_visible", refs.channel),
+      observation("desktop", "reconnect_stale_verified", refs.desktop),
+      observation("desktop", "real_provider_execution_receipt_visible", refs.desktop),
+      observation("desktop", "stale_label_visible", refs.desktop),
+      observation("desktop", "offline_label_visible", refs.desktop),
+      observation("desktop", "error_label_visible", refs.desktop),
+      observation("desktop", "no_hidden_fallback_verified", refs.desktop),
+    ],
+  };
+  writeFileSync(path, JSON.stringify(manifest, null, 2));
+}
+
+describe("friday-ui-device-capture-dir", () => {
+  it("indexes captures and runs the existing preflight when a real manifest is supplied", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "friday-ui-capture-dir-"));
+    try {
+      const captures = writeEvidence(tempDir);
+      const outDir = join(tempDir, "evidence");
+      const manifest = join(tempDir, "observations-source.json");
+      writeManifest(manifest, outDir);
+
+      const stdout = execFileSync("node", [
+        "scripts/ops/friday-ui-device-capture-dir.mjs",
+        `--mission-id=${missionId}`,
+        `--out-dir=${outDir}`,
+        `--mobile=${captures.mobile}`,
+        `--desktop=${captures.desktop}`,
+        `--channel=${captures.channel}`,
+        `--timeline=${captures.timeline}`,
+        `--observations-manifest=${manifest}`,
+        "--require-ready",
+      ], { cwd: process.cwd(), encoding: "utf8" });
+
+      const result = JSON.parse(stdout) as { status?: string; truth?: string; preflight?: { status?: number } };
+      expect(result.truth).toBe("ui_device_capture_dir_driver_not_proof");
+      expect(result.status).toBe("ready");
+      expect(result.preflight?.status).toBe(0);
+
+      const index = JSON.parse(readFileSync(join(outDir, "capture-index.json"), "utf8")) as { truth?: string };
+      expect(index.truth).toBe("ui_device_capture_dir_index_not_proof");
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("stays blocked without an observations manifest and does not invent one", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "friday-ui-capture-dir-missing-"));
+    try {
+      const captures = writeEvidence(tempDir);
+      const result = spawnSync("node", [
+        "scripts/ops/friday-ui-device-capture-dir.mjs",
+        `--mission-id=${missionId}`,
+        `--out-dir=${join(tempDir, "evidence")}`,
+        `--mobile=${captures.mobile}`,
+        `--desktop=${captures.desktop}`,
+        `--channel=${captures.channel}`,
+        `--timeline=${captures.timeline}`,
+        "--require-ready",
+      ], { cwd: process.cwd(), encoding: "utf8" });
+
+      expect(result.status).toBe(2);
+      const output = JSON.parse(result.stdout) as { status?: string; blockers?: Array<{ code?: string }> };
+      expect(output.status).toBe("blocked");
+      expect(output.blockers?.map((blocker) => blocker.code)).toContain("observations_manifest_missing");
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add a capture-dir driver that copies already-captured mobile/desktop/channel/timeline evidence into the standard evidence-dir shape
- write mission-id.txt and capture-index.json with hashes and explicit not-proof truth labels
- optionally copy a same-run observations manifest and run the existing UI proof inputs preflight

## Truth boundaries
- capture/indexing only; does not generate observations and does not claim UI/device proof
- missing observations manifest stays blocked, especially with --require-ready
- final END-BAR proof still requires the strict readiness/assembler/gate path with real same-run evidence

## Validation
- npx vitest run test/unit/qa/friday-ui-device-capture-dir-cli.test.ts
- git diff --check
- detect-secrets-hook --baseline .secrets.baseline scripts/ops/friday-ui-device-capture-dir.mjs test/unit/qa/friday-ui-device-capture-dir-cli.test.ts