### PR TITLE
Keep iOS Home pairing explicit

### DIFF
--- a/apps/friday-ios/Sources/FridayMobileShell/CommandSheet.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/CommandSheet.swift
@@ -14,6 +14,7 @@ enum MobileDestination: String, CaseIterable, Identifiable {
   case tokenLedger
   case shareIntake
   case voice
+  case pairing
   case needsMe
   case memory
   case platform
@@ -33,6 +34,7 @@ enum MobileDestination: String, CaseIterable, Identifiable {
     case .tokenLedger: return "Token Ledger"
     case .shareIntake: return "Share Intake"
     case .voice: return "Voice"
+    case .pairing: return "Device Pairing"
     case .needsMe: return "Needs Me"
     case .memory: return "Memory"
     case .platform: return "Platform"
@@ -52,6 +54,7 @@ enum MobileDestination: String, CaseIterable, Identifiable {
     case .tokenLedger: return "chart.bar.doc.horizontal"
     case .shareIntake: return "square.and.arrow.down"
     case .voice: return "waveform"
+    case .pairing: return "qrcode.viewfinder"
     case .needsMe: return "person.crop.circle.badge.exclamationmark"
     case .memory: return "brain.head.profile"
     case .platform: return "square.grid.2x2"

--- a/apps/friday-ios/Sources/FridayMobileShell/FridayApp.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayApp.swift
@@ -362,6 +362,8 @@ struct RootView: View {
           FridayShareIntakeScreen(viewModel: shareIntakeVM)
         case .voice:
           FridayVoiceScreen(viewModel: voiceVM)
+        case .pairing:
+          FridayHomeScreen(viewModel: homeVM, showPairingProvisioning: true)
         case .missions, .needsMe, .memory, .platform, .activity, .workflows, .onboarding,
              .settings:
           FridayProjectionScreen(destination: destination, viewModel: homeVM)

--- a/apps/friday-ios/Sources/FridayMobileShell/FridayHomeScreen.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayHomeScreen.swift
@@ -15,8 +15,14 @@ import SwiftUI
 /// is Refresh (re-read) — there is NO mutating action on this surface.
 struct FridayHomeScreen: View {
   @ObservedObject var viewModel: HomeViewModel
+  let showPairingProvisioning: Bool
   @State private var pairingQRPayload = ""
   @State private var showingPairingScanner = false
+
+  init(viewModel: HomeViewModel, showPairingProvisioning: Bool = false) {
+    self.viewModel = viewModel
+    self.showPairingProvisioning = showPairingProvisioning
+  }
 
   var body: some View {
     ScrollView {
@@ -32,9 +38,17 @@ struct FridayHomeScreen: View {
           unavailableHeader
           HeroPet().padding(.top, 4)
           UnavailableView(reason: reason)
+          unavailableQueueSection(
+            title: "Needs Me",
+            emptyText: "Connect Friday to see approvals, memory candidates, and recovery items.")
+          unavailableQueueSection(
+            title: "Running",
+            emptyText: "Connect Friday to see active work and provider progress.")
         }
 
-        devicePairingCard(viewModel.devicePairing, viewModel.state.projection?.t3ProvisioningStatus)
+        if showPairingProvisioning {
+          devicePairingCard(viewModel.devicePairing, viewModel.state.projection?.t3ProvisioningStatus)
+        }
       }
       .padding(16)
     }
@@ -312,6 +326,27 @@ struct FridayHomeScreen: View {
       }
     }
     .accessibilityElement(children: .contain)
+    .accessibilityIdentifier("friday.home.\(title.lowercased().replacingOccurrences(of: " ", with: "-"))")
+  }
+
+  private func unavailableQueueSection(title: String, emptyText: String) -> some View {
+    VStack(alignment: .leading, spacing: 10) {
+      HStack(alignment: .firstTextBaseline) {
+        Text(title.uppercased())
+          .font(.caption.weight(.bold))
+          .tracking(2)
+          .foregroundStyle(MobileTheme.textSecondary.opacity(0.72))
+        Spacer()
+        StatusChip(text: "offline", bg: MobileTheme.chipWarnBG, fg: MobileTheme.chipWarnFG)
+      }
+      GlassPanel {
+        Text(emptyText)
+          .font(.footnote)
+          .foregroundStyle(MobileTheme.textSecondary)
+          .fixedSize(horizontal: false, vertical: true)
+      }
+    }
+    .accessibilityElement(children: .combine)
     .accessibilityIdentifier("friday.home.\(title.lowercased().replacingOccurrences(of: " ", with: "-"))")
   }
 

--- a/apps/friday-ios/Sources/FridayMobileShell/FridayProjectionScreens.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayProjectionScreens.swift
@@ -14,7 +14,7 @@ private enum ProjectionSurface {
 
   init?(_ destination: MobileDestination) {
     switch destination {
-    case .home, .session, .contextPassport, .tokenLedger, .shareIntake, .voice:
+    case .home, .session, .contextPassport, .tokenLedger, .shareIntake, .voice, .pairing:
       return nil
     case .missions:
       self = .missions

--- a/scripts/ops/check-friday-client-design-contract.mjs
+++ b/scripts/ops/check-friday-client-design-contract.mjs
@@ -59,6 +59,7 @@ const checks = checkSourceSet(repoRoot, [
       "tokenLedger",
       "shareIntake",
       "voice",
+      "pairing",
       "needsMe",
       "memory",
       "platform",
@@ -69,6 +70,7 @@ const checks = checkSourceSet(repoRoot, [
     requiredStrings: [
       "Command Sheet",
       "Live truth",
+      "Device Pairing",
     ],
   },
   {

--- a/scripts/ops/check-friday-ios-live-evidence-contract.mjs
+++ b/scripts/ops/check-friday-ios-live-evidence-contract.mjs
@@ -25,6 +25,7 @@ const root = repoRoot();
 const files = {
   readme: read(root, "apps/friday-ios/README.md"),
   app: read(root, "apps/friday-ios/Sources/FridayMobileShell/FridayApp.swift"),
+  home: read(root, "apps/friday-ios/Sources/FridayMobileShell/FridayHomeScreen.swift"),
   commandSheet: read(root, "apps/friday-ios/Sources/FridayMobileShell/CommandSheet.swift"),
   buildSim: read(root, "apps/friday-ios/build-sim.sh"),
   liveT3Proof: read(root, "scripts/ops/friday-ios-sim-live-t3-proof.sh"),
@@ -70,6 +71,7 @@ const checks = [
         "tokenLedger",
         "shareIntake",
         "voice",
+        "pairing",
         "needsMe",
         "memory",
         "platform",
@@ -81,6 +83,23 @@ const checks = [
       ...requireStrings(files.commandSheet, [
         "Command Sheet",
         "Live truth",
+        "Device Pairing",
+      ]),
+    ],
+  },
+  {
+    id: "mobile-selected-home-keeps-pairing-explicit",
+    target: "apps/friday-ios/Sources/FridayMobileShell/FridayApp.swift + FridayHomeScreen.swift",
+    missing: [
+      ...requireStrings(files.app, [
+        "case .pairing:",
+        "FridayHomeScreen(viewModel: homeVM, showPairingProvisioning: true)",
+      ]),
+      ...requireStrings(files.home, [
+        "showPairingProvisioning: Bool = false",
+        "if showPairingProvisioning",
+        "Connect Friday to see approvals, memory candidates, and recovery items.",
+        "Connect Friday to see active work and provider progress.",
       ]),
     ],
   },


### PR DESCRIPTION
## Summary
- keep the selected iOS Home composition focused on Friday/Home, hero pet, honest offline status, and Needs Me/Running queues
- move the full Device Pairing / Hub provisioning controls behind an explicit Command Sheet destination
- extend the selected mobile design/static evidence guards so pairing cannot drift back into the default Home surface silently

## Truth boundary
- this is presentation + static-guard hardening only
- it does not claim END-BAR, GO-LIVE, adoption, real-device use, trust minting, or operator signing
- default mobile live gates remain OFF and honest-unavailable stays honest

## Local verification
- `node scripts/ops/check-friday-client-design-contract.mjs && node scripts/ops/check-friday-ios-live-evidence-contract.mjs`
- `swift test --package-path apps/friday-ios`
- `bash apps/friday-ios/build-sim.sh --mode offline-truth --shot /tmp/friday-ios-selected-home-1782291982.png`
- `git diff --check`
- `detect-secrets-hook --baseline .secrets.baseline apps/friday-ios/Sources/FridayMobileShell/CommandSheet.swift apps/friday-ios/Sources/FridayMobileShell/FridayApp.swift apps/friday-ios/Sources/FridayMobileShell/FridayHomeScreen.swift apps/friday-ios/Sources/FridayMobileShell/FridayProjectionScreens.swift scripts/ops/check-friday-client-design-contract.mjs scripts/ops/check-friday-ios-live-evidence-contract.mjs`