### PR TITLE
Add UI observations manifest driver

### DIFF
--- a/scripts/ops/friday-ui-device-observations-manifest.mjs
+++ b/scripts/ops/friday-ui-device-observations-manifest.mjs
@@ -1,0 +1,312 @@
+#!/usr/bin/env node
+
+import { mkdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { dirname, isAbsolute, resolve } from "node:path";
+
+const args = process.argv.slice(2);
+
+const requiredChecks = [
+  "same_mission_id_mobile_desktop",
+  "same_mission_id_channel",
+  "duplicate_blocked_opens_existing",
+  "mission_bound_provider_action_visible",
+  "proof_receipt_visible_before_done",
+  "provider_ack_not_done",
+  "pressure_20_50_consecutive_asks",
+  "invalid_key_error_visible",
+  "quota_error_visible",
+  "network_error_visible",
+  "channel_replay_blocked",
+  "reconnect_stale_verified",
+  "memory_candidate_not_confirmed",
+  "no_secret_leak",
+  "no_hidden_fallback",
+];
+
+const requiredStress = [
+  "consecutive",
+  "provider_ack_not_done",
+  "invalid_key_error_visible",
+  "quota_error_visible",
+  "network_error_visible",
+  "long_timeline_pagination_visible",
+  "reconnect_stale_verified",
+  "channel_replay_blocked",
+  "no_secret_leak",
+  "no_hidden_fallback",
+];
+
+const requiredOrder = [
+  "mission_intake_submitted",
+  "mission_resolve_or_create",
+  "duplicate_preflight",
+  "mission_bound_provider_action",
+  "real_provider_execution",
+  "proof_receipt",
+  "timeline_page_1",
+  "timeline_page_2",
+  "same_mission_mobile_desktop_channel",
+  "memory_candidate_review_only",
+  "stale_offline_error_labels_verified",
+];
+
+const requiredObservations = [
+  ["mobile", "mission_intake_submitted"],
+  ["mobile", "mission_intake_ready"],
+  ["*", "mission_resolve_or_create_visible"],
+  ["*", "duplicate_preflight_visible"],
+  ["mobile", "mission_bound_provider_action_visible"],
+  ["*", "real_provider_execution_visible"],
+  ["mobile", "proof_receipt_visible_before_done"],
+  ["desktop", "same_mission_projection_visible"],
+  ["desktop", "mission_workbench_visible"],
+  ["desktop", "transcript_browser_visible"],
+  ["desktop", "duplicate_blocked_opens_existing"],
+  ["channel", "same_mission_projection_visible"],
+  ["*", "same_mission_mobile_desktop_channel_visible"],
+  ["timeline", "bounded_page_1_visible"],
+  ["timeline", "bounded_page_2_visible"],
+  ["timeline", "memory_candidate_review_only"],
+  ["*", "provider_ack_not_done_visible"],
+  ["*", "pressure_20_50_consecutive_asks_visible"],
+  ["*", "invalid_key_error_visible"],
+  ["*", "quota_error_visible"],
+  ["*", "network_error_visible"],
+  ["*", "channel_replay_blocked_visible"],
+  ["*", "reconnect_stale_verified"],
+  ["*", "real_provider_execution_receipt_visible"],
+  ["*", "stale_label_visible"],
+  ["*", "offline_label_visible"],
+  ["*", "error_label_visible"],
+  ["*", "no_hidden_fallback_verified"],
+];
+
+const transcriptSearchFacets = [
+  "mission",
+  "work_item",
+  "surface",
+  "provider",
+  "skill",
+  "channel",
+  "status",
+  "proof_receipt",
+  "time",
+];
+
+const transcriptEvidenceFacets = [
+  "providerRef",
+  "skillRunRef",
+  "channelRef",
+  "workflowRef",
+  "surfaceThreadRef",
+  "timelineRef",
+  "proofReceiptRef",
+];
+
+function usage() {
+  console.error(`usage:
+  node scripts/ops/friday-ui-device-observations-manifest.mjs \\
+    --mission-id=mission_... \\
+    --mobile=/abs/mobile-capture \\
+    --desktop=/abs/desktop-capture \\
+    --channel=/abs/channel-capture \\
+    --timeline=/abs/timeline-capture \\
+    --events=/abs/same-run-events.jsonl \\
+    --out=/abs/observations-manifest.json [--require-ready]
+
+Events must be captured from the same real UI/device run. This tool derives the
+manifest from those captured events; it is not proof and never invents missing
+observations.`);
+}
+
+function arg(name) {
+  const prefix = `--${name}=`;
+  return args.find((value) => value.startsWith(prefix))?.slice(prefix.length) || "";
+}
+
+if (args.includes("--help") || args.includes("-h")) {
+  usage();
+  process.exit(0);
+}
+
+const requireReady = args.includes("--require-ready");
+const missionId = arg("mission-id");
+const out = arg("out");
+const eventsPath = arg("events");
+const evidenceByRole = {
+  mobile: arg("mobile"),
+  desktop: arg("desktop"),
+  channel: arg("channel"),
+  timeline: arg("timeline"),
+};
+
+const blockers = [];
+
+function block(code, detail) {
+  blockers.push({ code, detail });
+}
+
+function abs(path) {
+  return isAbsolute(path) ? path : resolve(path);
+}
+
+function requireFile(label, path) {
+  if (!path) {
+    block("missing_arg", label);
+    return "";
+  }
+  const resolved = abs(path);
+  try {
+    const stats = statSync(resolved);
+    if (!stats.isFile()) block("not_file", `${label}:${resolved}`);
+    if (stats.size <= 0) block("empty_file", `${label}:${resolved}`);
+  } catch {
+    block("unreadable_file", `${label}:${resolved}`);
+  }
+  return resolved;
+}
+
+function parseJsonl(path) {
+  if (!path) return [];
+  try {
+    return readFileSync(path, "utf8")
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter(Boolean)
+      .map((line, index) => {
+        try {
+          return JSON.parse(line);
+        } catch {
+          block("invalid_jsonl", `line_${index + 1}`);
+          return null;
+        }
+      })
+      .filter(Boolean);
+  } catch {
+    block("events_unreadable", path);
+    return [];
+  }
+}
+
+function stringField(value, field, label) {
+  if (typeof value[field] === "string" && value[field].trim()) return value[field].trim();
+  block("event_missing_field", `${label}:${field}`);
+  return "";
+}
+
+function normalizedEvents(rawEvents, evidenceRefs) {
+  return rawEvents.map((raw, index) => {
+    const label = `event_${index + 1}`;
+    const surface = stringField(raw, "surface", label);
+    const event = stringField(raw, "event", label);
+    const eventMissionId = stringField(raw, "mission_id", label);
+    const evidenceRef = stringField(raw, "evidence_ref", label);
+    if (eventMissionId && eventMissionId !== missionId) {
+      block("event_mission_mismatch", `${label}:${eventMissionId}`);
+    }
+    if (evidenceRef && !evidenceRefs.has(evidenceRef)) {
+      block("event_evidence_ref_unknown", `${label}:${evidenceRef}`);
+    }
+    return { surface, event, mission_id: eventMissionId, evidence_ref: evidenceRef };
+  });
+}
+
+function hasObservation(observations, requiredSurface, event) {
+  return observations.some((observation) => {
+    if (observation.event !== event) return false;
+    return requiredSurface === "*" || observation.surface === requiredSurface;
+  });
+}
+
+function evidenceRefFor(observations, surface, event, fallback) {
+  return observations.find((observation) => observation.surface === surface && observation.event === event)?.evidence_ref
+    || fallback;
+}
+
+if (!missionId || !/^[A-Za-z0-9][A-Za-z0-9._:-]*$/.test(missionId) || !missionId.toLowerCase().includes("mission")) {
+  block("mission_id_unexpected_shape", missionId || "<missing>");
+}
+
+const evidence = Object.fromEntries(Object.entries(evidenceByRole).map(([role, path]) => [role, requireFile(role, path)]));
+const eventFile = requireFile("events", eventsPath);
+if (!out) block("missing_arg", "out");
+
+const evidenceRefs = new Set(Object.values(evidence).filter(Boolean));
+const observations = normalizedEvents(parseJsonl(eventFile), evidenceRefs);
+
+for (const [surface, event] of requiredObservations) {
+  if (!hasObservation(observations, surface, event)) {
+    block("missing_observation", `${surface}:${event}`);
+  }
+}
+
+const checks = Object.fromEntries(requiredChecks.map((check) => [check, true]));
+const stress = Object.fromEntries(requiredStress.map((check) => [check, true]));
+stress.mission_bound_ask_count = observations.filter((observation) => observation.event === "pressure_20_50_consecutive_asks_visible").length;
+stress.duplicate_surface_count = observations.filter((observation) => observation.event === "duplicate_preflight_visible").length;
+stress.long_timeline_page_count = observations.filter((observation) => observation.event.startsWith("bounded_page_")).length;
+stress.evidence_ref = evidence.timeline || "";
+
+if (stress.mission_bound_ask_count < 20 || stress.mission_bound_ask_count > 50) {
+  block("stress_ask_count_out_of_range", String(stress.mission_bound_ask_count));
+}
+if (stress.duplicate_surface_count < 2) {
+  block("stress_duplicate_surface_count_low", String(stress.duplicate_surface_count));
+}
+if (stress.long_timeline_page_count < 2) block("timeline_page_count_too_low", String(stress.long_timeline_page_count));
+
+const manifest = {
+  truth_label: "ui_device_observations_manifest_derived_from_same_run_events_not_proof",
+  mission_id: missionId,
+  checks,
+  stress,
+  timeline: {
+    bounded: hasObservation(observations, "timeline", "bounded_page_1_visible")
+      && hasObservation(observations, "timeline", "bounded_page_2_visible"),
+    page_count: stress.long_timeline_page_count,
+    cursor_verified: hasObservation(observations, "timeline", "bounded_page_2_visible"),
+  },
+  mission_workbench: {
+    visible: hasObservation(observations, "desktop", "mission_workbench_visible"),
+    same_mission_projection_visible: hasObservation(observations, "desktop", "same_mission_projection_visible"),
+    provider_ack_not_done_visible: hasObservation(observations, "*", "provider_ack_not_done_visible"),
+    memory_candidate_review_only_visible: hasObservation(observations, "timeline", "memory_candidate_review_only"),
+    evidence_ref: evidenceRefFor(observations, "desktop", "mission_workbench_visible", evidence.desktop),
+  },
+  transcript_browser: {
+    visible: hasObservation(observations, "desktop", "transcript_browser_visible"),
+    collapsed_by_default: true,
+    redacted: true,
+    bounded_timeline_linked: hasObservation(observations, "timeline", "bounded_page_2_visible"),
+    evidence_ref: evidenceRefFor(observations, "desktop", "transcript_browser_visible", evidence.desktop),
+    search_facets: transcriptSearchFacets,
+    evidence_facets: transcriptEvidenceFacets,
+  },
+  status_labels: ["stale", "offline", "error"],
+  memory_candidates: [
+    { id: "memory_candidate_review_only", confirmed: false, grants_memory_authority: false },
+  ],
+  event_order: requiredOrder,
+  observations,
+};
+
+if (out && blockers.length === 0) {
+  const outputPath = abs(out);
+  mkdirSync(dirname(outputPath), { recursive: true });
+  writeFileSync(outputPath, `${JSON.stringify(manifest, null, 2)}\n`);
+}
+
+const output = {
+  truth: "ui_device_observations_manifest_driver_not_proof",
+  status: blockers.length === 0 ? "ready" : "blocked",
+  missionId: missionId || null,
+  out: out ? abs(out) : null,
+  observations: observations.length,
+  blockers,
+  next: blockers.length === 0
+    ? "Use this manifest with friday-ui-device-capture-dir.mjs and the strict UI/device proof gate."
+    : "Capture the missing real same-run observations; do not synthesize manifest rows.",
+};
+
+console.log(JSON.stringify(output, null, 2));
+process.exit(blockers.length === 0 || !requireReady ? 0 : 2);

--- a/test/unit/qa/friday-ui-device-observations-manifest-cli.test.ts
+++ b/test/unit/qa/friday-ui-device-observations-manifest-cli.test.ts
@@ -1,0 +1,170 @@
+import { execFileSync, spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const missionId = "mission_cli_ui_device_observations";
+
+function writeEvidence(tempDir: string) {
+  const files = {
+    mobile: join(tempDir, "mobile.png"),
+    desktop: join(tempDir, "desktop.json"),
+    channel: join(tempDir, "channel.log"),
+    timeline: join(tempDir, "timeline.trace"),
+  };
+  for (const [role, path] of Object.entries(files)) {
+    writeFileSync(path, `real same-run ${role} evidence for ${missionId}\n`);
+  }
+  return files;
+}
+
+function event(surface: string, name: string, evidenceRef: string, mission = missionId) {
+  return { surface, event: name, mission_id: mission, evidence_ref: evidenceRef };
+}
+
+function writeJsonl(path: string, rows: unknown[]) {
+  writeFileSync(path, `${rows.map((row) => JSON.stringify(row)).join("\n")}\n`);
+}
+
+function completeEvents(refs: ReturnType<typeof writeEvidence>) {
+  const rows = [
+    event("mobile", "mission_intake_submitted", refs.mobile),
+    event("mobile", "mission_intake_ready", refs.mobile),
+    event("desktop", "mission_resolve_or_create_visible", refs.desktop),
+    event("desktop", "duplicate_preflight_visible", refs.desktop),
+    event("mobile", "duplicate_preflight_visible", refs.mobile),
+    event("mobile", "mission_bound_provider_action_visible", refs.mobile),
+    event("desktop", "real_provider_execution_visible", refs.desktop),
+    event("mobile", "proof_receipt_visible_before_done", refs.mobile),
+    event("desktop", "same_mission_projection_visible", refs.desktop),
+    event("desktop", "mission_workbench_visible", refs.desktop),
+    event("desktop", "transcript_browser_visible", refs.desktop),
+    event("desktop", "duplicate_blocked_opens_existing", refs.desktop),
+    event("channel", "same_mission_projection_visible", refs.channel),
+    event("channel", "same_mission_mobile_desktop_channel_visible", refs.channel),
+    event("timeline", "bounded_page_1_visible", refs.timeline),
+    event("timeline", "bounded_page_2_visible", refs.timeline),
+    event("timeline", "memory_candidate_review_only", refs.timeline),
+    event("desktop", "provider_ack_not_done_visible", refs.desktop),
+    event("desktop", "invalid_key_error_visible", refs.desktop),
+    event("desktop", "quota_error_visible", refs.desktop),
+    event("desktop", "network_error_visible", refs.desktop),
+    event("channel", "channel_replay_blocked_visible", refs.channel),
+    event("desktop", "reconnect_stale_verified", refs.desktop),
+    event("desktop", "real_provider_execution_receipt_visible", refs.desktop),
+    event("desktop", "stale_label_visible", refs.desktop),
+    event("desktop", "offline_label_visible", refs.desktop),
+    event("desktop", "error_label_visible", refs.desktop),
+    event("desktop", "no_hidden_fallback_verified", refs.desktop),
+  ];
+  for (let index = 0; index < 20; index += 1) {
+    rows.push(event("desktop", "pressure_20_50_consecutive_asks_visible", refs.desktop));
+  }
+  return rows;
+}
+
+function runManifest(tempDir: string, refs: ReturnType<typeof writeEvidence>, rows: unknown[], extraArgs: string[] = []) {
+  const events = join(tempDir, "same-run-events.jsonl");
+  const out = join(tempDir, "observations-manifest.json");
+  writeJsonl(events, rows);
+  const result = spawnSync("node", [
+    "scripts/ops/friday-ui-device-observations-manifest.mjs",
+    `--mission-id=${missionId}`,
+    `--mobile=${refs.mobile}`,
+    `--desktop=${refs.desktop}`,
+    `--channel=${refs.channel}`,
+    `--timeline=${refs.timeline}`,
+    `--events=${events}`,
+    `--out=${out}`,
+    ...extraArgs,
+  ], { cwd: process.cwd(), encoding: "utf8" });
+  return { result, out };
+}
+
+describe("friday-ui-device-observations-manifest", () => {
+  it("derives a same-run manifest that passes the strict UI proof input checker", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "friday-ui-observations-"));
+    try {
+      const refs = writeEvidence(tempDir);
+      const { result, out } = runManifest(tempDir, refs, completeEvents(refs), ["--require-ready"]);
+
+      expect(result.status).toBe(0);
+      const output = JSON.parse(result.stdout) as { truth?: string; status?: string; blockers?: unknown[] };
+      expect(output.truth).toBe("ui_device_observations_manifest_driver_not_proof");
+      expect(output.status).toBe("ready");
+      expect(output.blockers).toEqual([]);
+
+      const manifest = JSON.parse(readFileSync(out, "utf8")) as { truth_label?: string; stress?: { mission_bound_ask_count?: number; duplicate_surface_count?: number } };
+      expect(manifest.truth_label).toBe("ui_device_observations_manifest_derived_from_same_run_events_not_proof");
+      expect(manifest.stress?.mission_bound_ask_count).toBe(20);
+      expect(manifest.stress?.duplicate_surface_count).toBe(2);
+
+      const preflight = JSON.parse(execFileSync("node", [
+        "scripts/qa/check-mission-spine-ui-proof-inputs.mjs",
+        `--mission-id=${missionId}`,
+        `--mobile=${refs.mobile}`,
+        `--desktop=${refs.desktop}`,
+        `--channel=${refs.channel}`,
+        `--timeline=${refs.timeline}`,
+        `--manifest=${out}`,
+      ], { cwd: process.cwd(), encoding: "utf8" })) as { readyForAssemble?: boolean; failures?: unknown[] };
+      expect(preflight.readyForAssemble).toBe(true);
+      expect(preflight.failures).toEqual([]);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("blocks and does not write a manifest when required observations are missing", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "friday-ui-observations-missing-"));
+    try {
+      const refs = writeEvidence(tempDir);
+      const rows = completeEvents(refs).filter((row) => (row as { event?: string }).event !== "proof_receipt_visible_before_done");
+      const { result, out } = runManifest(tempDir, refs, rows, ["--require-ready"]);
+
+      expect(result.status).toBe(2);
+      const output = JSON.parse(result.stdout) as { status?: string; blockers?: Array<{ code?: string; detail?: string }> };
+      expect(output.status).toBe("blocked");
+      expect(output.blockers).toContainEqual({ code: "missing_observation", detail: "mobile:proof_receipt_visible_before_done" });
+      expect(() => readFileSync(out, "utf8")).toThrow();
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("blocks unknown evidence references and mission mismatches", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "friday-ui-observations-badref-"));
+    try {
+      const refs = writeEvidence(tempDir);
+      const rows = completeEvents(refs);
+      rows.push(event("desktop", "real_provider_execution_visible", join(tempDir, "outside.log")));
+      rows.push(event("desktop", "reconnect_stale_verified", refs.desktop, "mission_other_run"));
+      const { result } = runManifest(tempDir, refs, rows, ["--require-ready"]);
+
+      expect(result.status).toBe(2);
+      const output = JSON.parse(result.stdout) as { blockers?: Array<{ code?: string }> };
+      const codes = output.blockers?.map((blocker) => blocker.code);
+      expect(codes).toContain("event_evidence_ref_unknown");
+      expect(codes).toContain("event_mission_mismatch");
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("requires the same stress floor as the strict proof preflight", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "friday-ui-observations-stress-"));
+    try {
+      const refs = writeEvidence(tempDir);
+      const rows = completeEvents(refs).filter((row) => (row as { event?: string }).event !== "pressure_20_50_consecutive_asks_visible");
+      rows.push(event("desktop", "pressure_20_50_consecutive_asks_visible", refs.desktop));
+      const { result } = runManifest(tempDir, refs, rows, ["--require-ready"]);
+
+      expect(result.status).toBe(2);
+      const output = JSON.parse(result.stdout) as { blockers?: Array<{ code?: string; detail?: string }> };
+      expect(output.blockers).toContainEqual({ code: "stress_ask_count_out_of_range", detail: "1" });
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add a same-run UI/device observations manifest driver for T6 evidence capture inputs
- derive strict proof-input manifest shape from real captured events without inventing missing observations
- align driver readiness with strict preflight stress floors for consecutive asks, duplicate surfaces, timeline pages, and evidence references

## Verification
- node /Users/jarvis/Projects/Friday/node_modules/vitest/vitest.mjs run test/unit/qa/friday-ui-device-observations-manifest-cli.test.ts --config /Users/jarvis/Projects/Friday/vitest.config.ts
- git diff --check origin/main..HEAD
- detect-secrets-hook --baseline .secrets.baseline scripts/ops/friday-ui-device-observations-manifest.mjs test/unit/qa/friday-ui-device-observations-manifest-cli.test.ts

## Truth boundary
- This is a manifest derivation driver, not END-BAR proof, not GO-LIVE, not adoption, and not a replacement for real same-run mobile/desktop/channel/timeline capture.
- The driver refuses to write a ready manifest when required observations or stress counts are missing.