### PR TITLE
Derive UI capture manifests from events

### DIFF
--- a/scripts/ops/friday-ui-device-capture-dir.mjs
+++ b/scripts/ops/friday-ui-device-capture-dir.mjs
@@ -16,11 +16,13 @@ function usage() {
     --desktop=/abs/desktop-capture \\
     --channel=/abs/channel-capture \\
     --timeline=/abs/timeline-capture \\
-    [--observations-manifest=/abs/observations-manifest.json] [--require-ready]
+    [--observations-manifest=/abs/observations-manifest.json] \\
+    [--events=/abs/same-run-events.jsonl] [--require-ready]
 
 Truth: this indexes already-captured files into an evidence-dir shape. It is not a
-UI/device proof and never invents observations. A supplied observations manifest is
-validated by scripts/qa/check-mission-spine-ui-proof-inputs.mjs.`);
+UI/device proof and never invents observations. A supplied observations manifest,
+or a manifest derived from same-run events, is validated by
+scripts/qa/check-mission-spine-ui-proof-inputs.mjs.`);
 }
 
 function arg(name) {
@@ -37,6 +39,7 @@ const requireReady = args.includes("--require-ready");
 const missionId = arg("mission-id");
 const outDir = arg("out-dir");
 const manifest = arg("observations-manifest");
+const events = arg("events");
 const inputByRole = {
   mobile: arg("mobile"),
   desktop: arg("desktop"),
@@ -85,6 +88,28 @@ function checkInput(role, path) {
   }
 }
 
+function normalizeEvents(sourcePath, replacements, targetPath) {
+  const source = abs(sourcePath);
+  try {
+    const lines = readFileSync(source, "utf8")
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter(Boolean);
+    const normalized = lines.map((line) => {
+      const row = JSON.parse(line);
+      if (typeof row.evidence_ref === "string" && replacements.has(row.evidence_ref)) {
+        row.evidence_ref = replacements.get(row.evidence_ref);
+      }
+      return JSON.stringify(row);
+    });
+    writeFileSync(targetPath, `${normalized.join("\n")}\n`);
+    return true;
+  } catch {
+    block("events_unreadable_or_invalid_jsonl", source);
+    return false;
+  }
+}
+
 if (!missionId || !/^[A-Za-z0-9][A-Za-z0-9._:-]*$/.test(missionId) || !missionId.toLowerCase().includes("mission")) {
   block("mission_id_unexpected_shape", missionId || "<missing>");
 }
@@ -97,6 +122,7 @@ const readyToWrite = blockers.length === 0 && outDir;
 
 let written = [];
 let copiedManifest = "";
+let derivedEvents = "";
 if (readyToWrite) {
   const dir = abs(outDir);
   mkdirSync(dir, { recursive: true });
@@ -123,8 +149,30 @@ if (readyToWrite) {
     } catch {
       block("observations_manifest_unreadable", manifestSource);
     }
+  } else if (events) {
+    const byRole = Object.fromEntries(written.map((capture) => [capture.role, capture.target]));
+    const sourceToTarget = new Map(written.map((capture) => [capture.source, capture.target]));
+    derivedEvents = join(dir, "same-run-events.normalized.jsonl");
+    copiedManifest = join(dir, "observations-manifest.json");
+    if (normalizeEvents(events, sourceToTarget, derivedEvents)) {
+      const result = spawnSync(process.execPath, [
+        "scripts/ops/friday-ui-device-observations-manifest.mjs",
+        `--mission-id=${missionId}`,
+        `--mobile=${byRole.mobile}`,
+        `--desktop=${byRole.desktop}`,
+        `--channel=${byRole.channel}`,
+        `--timeline=${byRole.timeline}`,
+        `--events=${derivedEvents}`,
+        `--out=${copiedManifest}`,
+        "--require-ready",
+      ], { encoding: "utf8" });
+      if (result.status !== 0) {
+        copiedManifest = "";
+        block("observations_manifest_derivation_failed", `exit_${result.status}`);
+      }
+    }
   } else {
-    block("observations_manifest_missing", "supply --observations-manifest from the same real capture run");
+    block("observations_manifest_missing", "supply --observations-manifest or --events from the same real capture run");
   }
 
   const index = {
@@ -134,6 +182,7 @@ if (readyToWrite) {
     evidenceDir: dir,
     captures: written,
     observationsManifest: copiedManifest || null,
+    normalizedEvents: derivedEvents || null,
     blockers,
   };
   writeFileSync(join(dir, "capture-index.json"), `${JSON.stringify(index, null, 2)}\n`);
@@ -168,6 +217,7 @@ const output = {
   evidenceDir: outDir ? abs(outDir) : null,
   captures: written,
   observationsManifest: copiedManifest || null,
+  normalizedEvents: derivedEvents || null,
   preflight,
   blockers,
   next: blockers.length === 0

--- a/test/unit/qa/friday-ui-device-capture-dir-cli.test.ts
+++ b/test/unit/qa/friday-ui-device-capture-dir-cli.test.ts
@@ -131,6 +131,43 @@ function writeManifest(path: string, evidenceDir: string) {
   writeFileSync(path, JSON.stringify(manifest, null, 2));
 }
 
+function writeEvents(path: string, refs: ReturnType<typeof writeEvidence>) {
+  const rows = [
+    observation("mobile", "mission_intake_submitted", refs.mobile),
+    observation("mobile", "mission_intake_ready", refs.mobile),
+    observation("desktop", "mission_resolve_or_create_visible", refs.desktop),
+    observation("desktop", "duplicate_preflight_visible", refs.desktop),
+    observation("mobile", "duplicate_preflight_visible", refs.mobile),
+    observation("mobile", "mission_bound_provider_action_visible", refs.mobile),
+    observation("desktop", "real_provider_execution_visible", refs.desktop),
+    observation("mobile", "proof_receipt_visible_before_done", refs.mobile),
+    observation("desktop", "same_mission_projection_visible", refs.desktop),
+    observation("desktop", "mission_workbench_visible", refs.desktop),
+    observation("desktop", "transcript_browser_visible", refs.desktop),
+    observation("desktop", "duplicate_blocked_opens_existing", refs.desktop),
+    observation("channel", "same_mission_projection_visible", refs.channel),
+    observation("channel", "same_mission_mobile_desktop_channel_visible", refs.channel),
+    observation("timeline", "bounded_page_1_visible", refs.timeline),
+    observation("timeline", "bounded_page_2_visible", refs.timeline),
+    observation("timeline", "memory_candidate_review_only", refs.timeline),
+    observation("desktop", "provider_ack_not_done_visible", refs.desktop),
+    observation("desktop", "invalid_key_error_visible", refs.desktop),
+    observation("desktop", "quota_error_visible", refs.desktop),
+    observation("desktop", "network_error_visible", refs.desktop),
+    observation("channel", "channel_replay_blocked_visible", refs.channel),
+    observation("desktop", "reconnect_stale_verified", refs.desktop),
+    observation("desktop", "real_provider_execution_receipt_visible", refs.desktop),
+    observation("desktop", "stale_label_visible", refs.desktop),
+    observation("desktop", "offline_label_visible", refs.desktop),
+    observation("desktop", "error_label_visible", refs.desktop),
+    observation("desktop", "no_hidden_fallback_verified", refs.desktop),
+  ];
+  for (let index = 0; index < 20; index += 1) {
+    rows.push(observation("desktop", "pressure_20_50_consecutive_asks_visible", refs.desktop));
+  }
+  writeFileSync(path, `${rows.map((row) => JSON.stringify(row)).join("\n")}\n`);
+}
+
 describe("friday-ui-device-capture-dir", () => {
   it("indexes captures and runs the existing preflight when a real manifest is supplied", () => {
     const tempDir = mkdtempSync(join(tmpdir(), "friday-ui-capture-dir-"));
@@ -159,6 +196,47 @@ describe("friday-ui-device-capture-dir", () => {
 
       const index = JSON.parse(readFileSync(join(outDir, "capture-index.json"), "utf8")) as { truth?: string };
       expect(index.truth).toBe("ui_device_capture_dir_index_not_proof");
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("derives a manifest from same-run events and remaps capture refs into the evidence dir", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "friday-ui-capture-dir-events-"));
+    try {
+      const captures = writeEvidence(tempDir);
+      const events = join(tempDir, "same-run-events.jsonl");
+      const outDir = join(tempDir, "evidence");
+      writeEvents(events, captures);
+
+      const stdout = execFileSync("node", [
+        "scripts/ops/friday-ui-device-capture-dir.mjs",
+        `--mission-id=${missionId}`,
+        `--out-dir=${outDir}`,
+        `--mobile=${captures.mobile}`,
+        `--desktop=${captures.desktop}`,
+        `--channel=${captures.channel}`,
+        `--timeline=${captures.timeline}`,
+        `--events=${events}`,
+        "--require-ready",
+      ], { cwd: process.cwd(), encoding: "utf8" });
+
+      const result = JSON.parse(stdout) as {
+        status?: string;
+        observationsManifest?: string;
+        normalizedEvents?: string;
+        preflight?: { status?: number };
+      };
+      expect(result.status).toBe("ready");
+      expect(result.preflight?.status).toBe(0);
+      expect(result.observationsManifest).toBe(join(outDir, "observations-manifest.json"));
+      expect(result.normalizedEvents).toBe(join(outDir, "same-run-events.normalized.jsonl"));
+
+      const manifest = JSON.parse(readFileSync(join(outDir, "observations-manifest.json"), "utf8")) as {
+        observations?: Array<{ evidence_ref?: string }>;
+      };
+      expect(manifest.observations?.some((row) => row.evidence_ref === captures.mobile)).toBe(false);
+      expect(manifest.observations?.some((row) => row.evidence_ref === join(outDir, "mobile.png"))).toBe(true);
     } finally {
       rmSync(tempDir, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary
- let the UI/device capture-dir driver accept same-run events JSONL when an observations manifest has not already been produced
- normalize captured event evidence refs from source captures into the evidence-dir copied files before manifest derivation
- run the same strict proof-input preflight after derived manifest creation, preserving the no-synthetic-observations boundary

## Verification
- node /Users/jarvis/Projects/Friday/node_modules/vitest/vitest.mjs run test/unit/qa/friday-ui-device-capture-dir-cli.test.ts --config /Users/jarvis/Projects/Friday/vitest.config.ts
- git diff --check origin/main..HEAD
- detect-secrets-hook --baseline .secrets.baseline scripts/ops/friday-ui-device-capture-dir.mjs test/unit/qa/friday-ui-device-capture-dir-cli.test.ts

## Truth boundary
- This indexes already-captured same-run evidence and derives manifest inputs; it is not END-BAR proof, not GO-LIVE, not adoption, and does not invent observations.