### PR TITLE
Align UI proof live readiness mode

### DIFF
--- a/scripts/ops/friday-ui-device-proof-readiness.sh
+++ b/scripts/ops/friday-ui-device-proof-readiness.sh
@@ -217,6 +217,11 @@ run_note_step() {
   fi
 }
 
+EXPECT_NOT_READY_ARGS=(--expect-not-ready)
+if [ "${MODE}" = "require-proof" ]; then
+  EXPECT_NOT_READY_ARGS=()
+fi
+
 run_note_step "ui_device_gate_self_test" env \
   -u MISSION_ID \
   -u MOBILE_EVIDENCE \
@@ -229,18 +234,18 @@ run_note_step "ui_device_gate_self_test" env \
 
 if [ "${RUN_LIVE_READINESS}" = "1" ]; then
   run_step "mission_workbench_live_readiness" \
-    node "${REPO_ROOT}/scripts/qa/check-mission-workbench-live-readiness.mjs" --expect-not-ready
+    node "${REPO_ROOT}/scripts/qa/check-mission-workbench-live-readiness.mjs" "${EXPECT_NOT_READY_ARGS[@]}"
 fi
 
 if [ "${RUN_SNAPSHOT_CONTRACT}" = "1" ]; then
   if [ -n "${FRIDAY_WORKBENCH_SNAPSHOT_FILE:-}" ]; then
     run_step "mission_workbench_snapshot_contract_file" \
       node "${REPO_ROOT}/scripts/qa/check-mission-workbench-snapshot-contract.mjs" \
-        "--file=${FRIDAY_WORKBENCH_SNAPSHOT_FILE}" --expect-not-ready
+        "--file=${FRIDAY_WORKBENCH_SNAPSHOT_FILE}" "${EXPECT_NOT_READY_ARGS[@]}"
   elif [ -n "${FRIDAY_WORKBENCH_SNAPSHOT_URL:-}" ]; then
     run_step "mission_workbench_snapshot_contract_url" \
       node "${REPO_ROOT}/scripts/qa/check-mission-workbench-snapshot-contract.mjs" \
-        "--url=${FRIDAY_WORKBENCH_SNAPSHOT_URL}" --expect-not-ready
+        "--url=${FRIDAY_WORKBENCH_SNAPSHOT_URL}" "${EXPECT_NOT_READY_ARGS[@]}"
   else
     blockers+=("mission_workbench_snapshot_contract:missing_FRIDAY_WORKBENCH_SNAPSHOT_FILE_or_URL")
   fi

--- a/test/unit/qa/friday-ui-device-proof-readiness-cli.test.ts
+++ b/test/unit/qa/friday-ui-device-proof-readiness-cli.test.ts
@@ -140,6 +140,16 @@ function makeManifest(files: ReturnType<typeof writeEvidenceDir>) {
 }
 
 describe("friday-ui-device-proof-readiness", () => {
+  it("does not require final proof mode to be not-ready", () => {
+    const source = readFileSync("scripts/ops/friday-ui-device-proof-readiness.sh", "utf8");
+    expect(source).toContain("EXPECT_NOT_READY_ARGS=(--expect-not-ready)");
+    expect(source).toContain('if [ "${MODE}" = "require-proof" ]; then');
+    expect(source).toContain("EXPECT_NOT_READY_ARGS=()");
+    expect(source).toContain('check-mission-workbench-live-readiness.mjs" "${EXPECT_NOT_READY_ARGS[@]}"');
+    expect(source).toContain('check-mission-workbench-snapshot-contract.mjs"');
+    expect(source).not.toContain("check-mission-workbench-live-readiness.mjs\" --expect-not-ready");
+  });
+
   it("discovers a complete evidence dir and delegates to the strict assembler", () => {
     const tempDir = mkdtempSync(join(tmpdir(), "friday-ui-device-readiness-"));
     try {


### PR DESCRIPTION
## Summary
- keep report-only UI/device readiness checks expecting not-ready
- make --require-proof mode require live/snapshot readiness instead of carrying --expect-not-ready
- add a regression test so final proof mode cannot be blocked by report-only expectations

## Verification
- node /Users/jarvis/Projects/Friday/node_modules/vitest/vitest.mjs run test/unit/qa/friday-ui-device-proof-readiness-cli.test.ts --config /Users/jarvis/Projects/Friday/vitest.config.ts
- bash -n scripts/ops/friday-ui-device-proof-readiness.sh
- git diff --check origin/main..HEAD
- detect-secrets-hook --baseline .secrets.baseline scripts/ops/friday-ui-device-proof-readiness.sh test/unit/qa/friday-ui-device-proof-readiness-cli.test.ts

## Truth boundary
- This adjusts readiness semantics only. It does not claim END-BAR proof, GO-LIVE, adoption, real device capture, or organic traffic.