### PR TITLE
Surface desktop chat turn receipts

### DIFF
--- a/apps/macos/FridayHubConsole/Sources/FridayHubConsole/DesktopChatScreen.swift
+++ b/apps/macos/FridayHubConsole/Sources/FridayHubConsole/DesktopChatScreen.swift
@@ -557,7 +557,10 @@ struct DesktopChatScreen: View {
     append(.user(text))
     Task {
       await viewModel.submitIntake(intent: text, routePreference: routePreference)
-      append(DesktopChatMessage.from(viewModel.intakeState))
+      append(DesktopChatMessage.from(
+        viewModel.intakeState,
+        turn: viewModel.latestChatTurn,
+        reviewState: viewModel.chatReviewState))
     }
   }
 
@@ -621,8 +624,8 @@ private struct DesktopChatBubble: View {
         .foregroundStyle(HubTheme.textPrimary)
         .fixedSize(horizontal: false, vertical: true)
         .textSelection(.enabled)
-      ForEach(message.refs, id: \.self) { ref in
-        RefPill(label: nil, ref: ref)
+      ForEach(message.refs) { ref in
+        RefPill(label: ref.label, ref: ref.ref)
       }
     }
     .padding(.horizontal, 12)
@@ -652,14 +655,24 @@ private struct DesktopChatMessage: Identifiable, Codable, Equatable, Sendable {
   let id: String
   let role: DesktopChatRole
   let text: String
-  let refs: [String]
+  let refs: [ChatReceiptRef]
   let createdAtMs: Int64
 
   static func user(_ text: String) -> Self {
     DesktopChatMessage(role: .user, text: text, refs: [])
   }
 
-  static func from(_ state: WriteActionState) -> Self {
+  static func from(
+    _ state: WriteActionState,
+    turn: ChatTurnRefs? = nil,
+    reviewState: ChatReviewState = .idle
+  ) -> Self {
+    var refs = turn?.receiptRefs ?? []
+    if case let .loaded(items) = reviewState {
+      refs.append(contentsOf: items.flatMap(\.receiptRefs))
+    }
+    refs = uniqueRefs(refs)
+
     switch state {
     case .ready:
       return DesktopChatMessage(role: .friday, text: "Ready.", refs: [])
@@ -667,18 +680,24 @@ private struct DesktopChatMessage: Identifiable, Codable, Equatable, Sendable {
       return DesktopChatMessage(role: .friday, text: "Working.", refs: [])
     case let .confirmed(summary, questions, answerBody):
       let body = answerBodyText(answerBody) ?? summary
-      return DesktopChatMessage(role: .friday, text: body, refs: questions)
+      let questionRefs = questions.map { ChatReceiptRef(label: "clarification", ref: $0) }
+      return DesktopChatMessage(role: .friday, text: body, refs: uniqueRefs(refs + questionRefs))
     case let .error(reason):
-      return DesktopChatMessage(role: .friday, text: reason, refs: [])
+      return DesktopChatMessage(role: .friday, text: reason, refs: refs)
     }
   }
 
-  init(role: DesktopChatRole, text: String, refs: [String]) {
+  init(role: DesktopChatRole, text: String, refs: [ChatReceiptRef]) {
     self.id = UUID().uuidString
     self.role = role
     self.text = text
     self.refs = refs
     self.createdAtMs = Int64(Date().timeIntervalSince1970 * 1000)
+  }
+
+  private static func uniqueRefs(_ refs: [ChatReceiptRef]) -> [ChatReceiptRef] {
+    var seen = Set<String>()
+    return refs.filter { seen.insert($0.id).inserted }
   }
 }
 

--- a/apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/OperationsOverviewViewModel.swift
+++ b/apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/OperationsOverviewViewModel.swift
@@ -238,6 +238,27 @@ public struct ChatTurnRefs: Sendable, Equatable {
     var seen = Set<String>()
     self.runIds = runIds.filter { !$0.isEmpty && seen.insert($0).inserted }
   }
+
+  public var receiptRefs: [ChatReceiptRef] {
+    var refs = [ChatReceiptRef(label: "mission_id", ref: missionId)]
+    if let workItemId, !workItemId.isEmpty {
+      refs.append(ChatReceiptRef(label: "work_item_id", ref: workItemId))
+    }
+    refs.append(contentsOf: runIds.map { ChatReceiptRef(label: "run_id", ref: $0) })
+    return refs
+  }
+}
+
+public struct ChatReceiptRef: Sendable, Codable, Equatable, Identifiable {
+  public let label: String
+  public let ref: String
+
+  public var id: String { "\(label):\(ref)" }
+
+  public init(label: String, ref: String) {
+    self.label = label
+    self.ref = ref
+  }
 }
 
 public struct ChatNeedsMeItem: Sendable, Equatable, Identifiable {
@@ -251,6 +272,31 @@ public struct ChatNeedsMeItem: Sendable, Equatable, Identifiable {
   public let signingSummary: String?
 
   public var id: String { "\(runId):\(kind):\(refId)" }
+
+  public var receiptRefs: [ChatReceiptRef] {
+    var refs = [
+      ChatReceiptRef(label: "run_id", ref: runId),
+      ChatReceiptRef(label: receiptLabel, ref: refId),
+    ]
+    if let actionDigest, !actionDigest.isEmpty {
+      refs.append(ChatReceiptRef(label: "action_digest", ref: actionDigest))
+    }
+    if let deepLink, !deepLink.isEmpty {
+      refs.append(ChatReceiptRef(label: "deep_link", ref: deepLink))
+    }
+    return refs
+  }
+
+  private var receiptLabel: String {
+    switch kind {
+    case "approval", "approval_required":
+      return "approval_ref"
+    case "memory_review":
+      return "memory_ref"
+    default:
+      return "activity_ref"
+    }
+  }
 
   public init(
     runId: String,

--- a/apps/macos/FridayHubConsole/Tests/FridayHubConsoleCoreTests/OperationsOverviewViewModelTests.swift
+++ b/apps/macos/FridayHubConsole/Tests/FridayHubConsoleCoreTests/OperationsOverviewViewModelTests.swift
@@ -1225,6 +1225,11 @@ func submitIntakeDisplaysOwnerGatedRunAnswerBodyWhenDelivered() async {
     missionId: "mission-desktop-fixed",
     workItemId: "work-desktop-fixed",
     runIds: ["run-bound-1"]))
+  #expect(vm.latestChatTurn?.receiptRefs == [
+    ChatReceiptRef(label: "mission_id", ref: "mission-desktop-fixed"),
+    ChatReceiptRef(label: "work_item_id", ref: "work-desktop-fixed"),
+    ChatReceiptRef(label: "run_id", ref: "run-bound-1"),
+  ])
   guard case let .loaded(items) = vm.chatReviewState else {
     Issue.record("expected loaded review state, got \(vm.chatReviewState)")
     return
@@ -1234,6 +1239,12 @@ func submitIntakeDisplaysOwnerGatedRunAnswerBodyWhenDelivered() async {
   let approval = items.first { $0.kind == "approval_required" }
   #expect(approval?.actionDigest == "digest-approval-nonce-1")
   #expect(approval?.signingSummary == "approval_required ready")
+  #expect(approval?.receiptRefs == [
+    ChatReceiptRef(label: "run_id", ref: "run-bound-1"),
+    ChatReceiptRef(label: "approval_ref", ref: "approval-nonce-1"),
+    ChatReceiptRef(label: "action_digest", ref: "digest-approval-nonce-1"),
+    ChatReceiptRef(label: "deep_link", ref: "run/run-bound-1/approval/approval-nonce-1"),
+  ])
 }
 
 @Test


### PR DESCRIPTION
## Summary
- add structured chat receipt refs for desktop Mission turns instead of relying on summary-string parsing
- persist mission/work-item/run refs and Needs Review refs in the desktop Chat transcript bubbles
- keep approval/signature controls operator-gated and refs-only while making same-turn receipt state visible in the UI

## Verification
- swift test --package-path apps/macos/FridayHubConsole
- npm run check:desktop-approval-relay-contract
- npm run verify:hub-console:native
- git diff --check origin/main..HEAD
- detect-secrets-hook --baseline .secrets.baseline apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/OperationsOverviewViewModel.swift apps/macos/FridayHubConsole/Sources/FridayHubConsole/DesktopChatScreen.swift apps/macos/FridayHubConsole/Tests/FridayHubConsoleCoreTests/OperationsOverviewViewModelTests.swift

## Truth boundary
- This strengthens desktop same-turn UI receipts. It does not claim END-BAR, adoption, real user load, or live operator signature completion.