### PR TITLE
Preserve mobile chat proof receipts

### DIFF
--- a/apps/friday-ios/Sources/FridayMobileShell/FridayChatScreen.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayChatScreen.swift
@@ -83,8 +83,10 @@ struct FridayChatScreen: View {
                 .font(.caption)
                 .foregroundStyle(MobileTheme.textPrimary)
                 .lineLimit(4)
-              if let runId = item.runId {
+              if item.receiptRefs.isEmpty, let runId = item.runId {
                 RefPill(label: "run_id", ref: short(runId))
+              } else if !item.receiptRefs.isEmpty {
+                receiptRefs(item.receiptRefs, limit: 4)
               }
             }
             .frame(maxWidth: .infinity, alignment: .leading)
@@ -270,22 +272,7 @@ struct FridayChatScreen: View {
           Text("Answer body is not available from the owner-gated readback yet.")
             .font(.caption2).foregroundStyle(MobileTheme.textSecondary)
         }
-        if let sha = r.answerSha256 { RefPill(label: "answer_sha256", ref: short(sha)) }
-        if let missionId = r.missionId { RefPill(label: "mission_id", ref: missionId) }
-        if let workItemId = r.workItemId { RefPill(label: "work_item_id", ref: workItemId) }
-        if let followUpWorkItemId = r.followUpWorkItemId {
-          RefPill(label: "follow_up_work_item_id", ref: followUpWorkItemId)
-        }
-        if let followUpRunId = r.followUpRunId { RefPill(label: "follow_up_run_id", ref: followUpRunId) }
-        if let len = r.answerLen { RefPill(label: "answer_len", ref: "\(len)") }
-        if let outcome = r.answerBodyOutcome { RefPill(label: "answer_body", ref: outcome) }
-        if let turns = r.turns { RefPill(label: "turns", ref: "\(turns)") }
-        if let tools = r.executedTools { RefPill(label: "executed_tools", ref: "\(tools)") }
-        if let prompt = r.promptTokens { RefPill(label: "prompt_tokens", ref: "\(prompt)") }
-        if let completion = r.completionTokens { RefPill(label: "completion_tokens", ref: "\(completion)") }
-        if let total = tokenTotal(prompt: r.promptTokens, completion: r.completionTokens) {
-          RefPill(label: "total_tokens", ref: "\(total)")
-        }
+        receiptRefs(r.receiptRefs)
       }
     }
     .accessibilityElement(children: .contain)
@@ -352,9 +339,7 @@ struct FridayChatScreen: View {
         }
         Text(r.title)
           .font(.headline).foregroundStyle(MobileTheme.textPrimary)
-        RefPill(label: "op", ref: r.op)
-        RefPill(label: "status", ref: r.status)
-        if let audit = r.auditRef { RefPill(label: "audit_ref", ref: audit) }
+        receiptRefs(r.receiptRefs)
         Text(r.detail)
           .font(.caption2).foregroundStyle(MobileTheme.textSecondary)
       }
@@ -384,10 +369,17 @@ struct FridayChatScreen: View {
     return trimmed
   }
 
-  private func tokenTotal(prompt: UInt64?, completion: UInt64?) -> UInt64? {
-    guard let prompt, let completion else { return nil }
-    let sum = prompt.addingReportingOverflow(completion)
-    return sum.overflow ? nil : sum.partialValue
+  private func receiptRefs(_ refs: [ChatReceiptRef], limit: Int? = nil) -> some View {
+    let visibleRefs = limit.map { Array(refs.prefix($0)) } ?? refs
+    return VStack(alignment: .leading, spacing: 4) {
+      ForEach(visibleRefs) { ref in
+        RefPill(label: ref.label, ref: short(ref.ref))
+      }
+      if let limit, refs.count > limit {
+        RefPill(label: "more_refs", ref: "+\(refs.count - limit)")
+      }
+    }
+    .accessibilityIdentifier("friday.chat.receipt-refs")
   }
 }
 

--- a/apps/friday-ios/Sources/FridayMobileShellCore/FridayChatViewModel.swift
+++ b/apps/friday-ios/Sources/FridayMobileShellCore/FridayChatViewModel.swift
@@ -36,6 +36,17 @@ import FridayRustClient
 
 // MARK: - Surfaced models
 
+public struct ChatReceiptRef: Codable, Sendable, Equatable, Identifiable {
+  public var id: String { "\(label):\(ref)" }
+  public let label: String
+  public let ref: String
+
+  public init(label: String, ref: String) {
+    self.label = label
+    self.ref = ref
+  }
+}
+
 /// The ANSWER receipt the chat shows on a non-paused settle. The write receipt remains refs-only
 /// (status/fingerprint/counts). `answerBody` is populated only by the separate owner-gated readback.
 public struct ChatAnswerReceipt: Sendable, Equatable {
@@ -80,6 +91,26 @@ public struct ChatAnswerReceipt: Sendable, Equatable {
     self.answerBody = answerBody
     self.answerBodyRunId = answerBodyRunId
     self.answerBodyOutcome = answerBodyOutcome
+  }
+
+  public var receiptRefs: [ChatReceiptRef] {
+    var refs = [ChatReceiptRef(label: "run_id", ref: runId)]
+    appendReceiptRef("mission_id", missionId, to: &refs)
+    appendReceiptRef("work_item_id", workItemId, to: &refs)
+    appendReceiptRef("follow_up_work_item_id", followUpWorkItemId, to: &refs)
+    appendReceiptRef("follow_up_run_id", followUpRunId, to: &refs)
+    appendReceiptRef("answer_body_run_id", answerBodyRunId, to: &refs)
+    appendReceiptRef("answer_sha256", answerSha256, to: &refs)
+    appendReceiptRef("answer_len", answerLen.map(String.init), to: &refs)
+    appendReceiptRef("answer_body", answerBodyOutcome, to: &refs)
+    appendReceiptRef("turns", turns.map(String.init), to: &refs)
+    appendReceiptRef("executed_tools", executedTools.map(String.init), to: &refs)
+    appendReceiptRef("prompt_tokens", promptTokens.map(String.init), to: &refs)
+    appendReceiptRef("completion_tokens", completionTokens.map(String.init), to: &refs)
+    if let total = tokenTotal(prompt: promptTokens, completion: completionTokens) {
+      refs.append(ChatReceiptRef(label: "total_tokens", ref: String(total)))
+    }
+    return refs
   }
 }
 
@@ -174,6 +205,17 @@ public struct ChatResumeReceipt: Sendable, Equatable {
     default: return "control receipt is refs-only — no body"
     }
   }
+
+  public var receiptRefs: [ChatReceiptRef] {
+    var refs = [
+      ChatReceiptRef(label: "run_id", ref: runId),
+      ChatReceiptRef(label: "op", ref: op),
+      ChatReceiptRef(label: "status", ref: status),
+    ]
+    appendReceiptRef("audit_ref", auditRef, to: &refs)
+    appendReceiptRef("truth", truthLabel, to: &refs)
+    return refs
+  }
 }
 
 public struct ChatHistoryItem: Identifiable, Codable, Sendable, Equatable {
@@ -181,6 +223,7 @@ public struct ChatHistoryItem: Identifiable, Codable, Sendable, Equatable {
   public let role: String
   public let text: String
   public let runId: String?
+  public let receiptRefs: [ChatReceiptRef]
   public let createdAtMs: Int64
 
   public init(
@@ -188,13 +231,34 @@ public struct ChatHistoryItem: Identifiable, Codable, Sendable, Equatable {
     role: String,
     text: String,
     runId: String? = nil,
+    receiptRefs: [ChatReceiptRef] = [],
     createdAtMs: Int64
   ) {
     self.id = id
     self.role = role
     self.text = text
     self.runId = runId
+    self.receiptRefs = receiptRefs
     self.createdAtMs = createdAtMs
+  }
+
+  private enum CodingKeys: String, CodingKey {
+    case id
+    case role
+    case text
+    case runId
+    case receiptRefs
+    case createdAtMs
+  }
+
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    self.id = try container.decode(String.self, forKey: .id)
+    self.role = try container.decode(String.self, forKey: .role)
+    self.text = try container.decode(String.self, forKey: .text)
+    self.runId = try container.decodeIfPresent(String.self, forKey: .runId)
+    self.receiptRefs = try container.decodeIfPresent([ChatReceiptRef].self, forKey: .receiptRefs) ?? []
+    self.createdAtMs = try container.decode(Int64.self, forKey: .createdAtMs)
   }
 }
 
@@ -336,12 +400,13 @@ public final class FridayChatViewModel: ObservableObject {
       switch outcome {
       case .result(let r):
         let answer = await fetchDeliveredAnswerBody(for: r.runId)
-        appendAnswerHistory(runId: r.runId, status: r.status, answerBody: answer?.body)
-        phase = .answered(ChatAnswerReceipt(
+        let receipt = ChatAnswerReceipt(
           r,
           answerBody: answer?.body,
           answerBodyRunId: answer?.runId,
-          answerBodyOutcome: answer?.outcome))
+          answerBodyOutcome: answer?.outcome)
+        appendAnswerHistory(receipt)
+        phase = .answered(receipt)
       case .paused(let p):
         // INV-2: a mutating run PAUSED — surface the S6 approval card. No mutation has executed.
         appendHistory(
@@ -394,8 +459,7 @@ public final class FridayChatViewModel: ObservableObject {
         missionClient: missionClient)
       let bodyRunId = followUp?.runId ?? firstReceipt.runId
       let answer = await fetchDeliveredAnswerBody(for: bodyRunId)
-      appendAnswerHistory(runId: bodyRunId, status: firstReceipt.status, answerBody: answer?.body)
-      phase = .answered(ChatAnswerReceipt(
+      let receipt = ChatAnswerReceipt(
         firstReceipt,
         missionId: result.missionId,
         workItemId: workItemId,
@@ -403,7 +467,9 @@ public final class FridayChatViewModel: ObservableObject {
         followUpRunId: followUp?.runId,
         answerBody: answer?.body,
         answerBodyRunId: answer?.runId,
-        answerBodyOutcome: answer?.outcome))
+        answerBodyOutcome: answer?.outcome)
+      appendAnswerHistory(receipt)
+      phase = .answered(receipt)
     } catch {
       phase = .unavailable(reason: Self.dispatchReason(for: error))
     }
@@ -489,11 +555,13 @@ public final class FridayChatViewModel: ObservableObject {
     do {
       // INV-1: relay the OPAQUE blob VERBATIM. The view model inspects/derives nothing in it.
       let receipt = try await writeClient.resumeWithApproval(runId: card.runId, opaqueSignedBlob: blob)
+      let surfacedReceipt = ChatResumeReceipt(receipt)
       appendHistory(
         role: "friday",
         text: receipt.accepted ? "Approved action executed." : "Action refused.",
-        runId: receipt.runId)
-      phase = .resumed(ChatResumeReceipt(receipt))
+        runId: receipt.runId,
+        receiptRefs: surfacedReceipt.receiptRefs)
+      phase = .resumed(surfacedReceipt)
     } catch {
       phase = .unavailable(reason: Self.resumeReason(for: error))
     }
@@ -508,11 +576,13 @@ public final class FridayChatViewModel: ObservableObject {
     phase = .rejecting(card)
     do {
       let receipt = try await writeClient.rejectApproval(runId: card.runId, approvalId: card.approvalId)
+      let surfacedReceipt = ChatResumeReceipt(receipt)
       appendHistory(
         role: "friday",
         text: receipt.accepted ? "Approval rejected." : "Approval rejection refused.",
-        runId: receipt.runId)
-      phase = .resumed(ChatResumeReceipt(receipt))
+        runId: receipt.runId,
+        receiptRefs: surfacedReceipt.receiptRefs)
+      phase = .resumed(surfacedReceipt)
     } catch {
       phase = .unavailable(reason: Self.rejectReason(for: error))
     }
@@ -575,22 +645,23 @@ public final class FridayChatViewModel: ObservableObject {
     }
   }
 
-  private func appendAnswerHistory(runId: String, status: String, answerBody: String?) {
+  private func appendAnswerHistory(_ receipt: ChatAnswerReceipt) {
     let text: String
-    if let body = answerBody?.trimmingCharacters(in: .whitespacesAndNewlines), !body.isEmpty {
+    if let body = receipt.answerBody?.trimmingCharacters(in: .whitespacesAndNewlines), !body.isEmpty {
       text = body
     } else {
-      text = "Friday answered (\(status)). Run \(runId)."
+      text = "Friday answered (\(receipt.status)). Run \(receipt.runId)."
     }
-    appendHistory(role: "friday", text: text, runId: runId)
+    appendHistory(role: "friday", text: text, runId: receipt.answerBodyRunId ?? receipt.runId, receiptRefs: receipt.receiptRefs)
   }
 
-  private func appendHistory(role: String, text: String, runId: String? = nil) {
+  private func appendHistory(role: String, text: String, runId: String? = nil, receiptRefs: [ChatReceiptRef] = []) {
     let item = ChatHistoryItem(
       id: newId(),
       role: role,
       text: text,
       runId: runId,
+      receiptRefs: receiptRefs,
       createdAtMs: nowMs())
     history.append(item)
     if history.count > 100 {
@@ -674,4 +745,17 @@ public final class FridayChatViewModel: ObservableObject {
     }
     return String(excerpt.suffix(800))
   }
+}
+
+private func appendReceiptRef(_ label: String, _ value: String?, to refs: inout [ChatReceiptRef]) {
+  guard let value = value?.trimmingCharacters(in: .whitespacesAndNewlines), !value.isEmpty else {
+    return
+  }
+  refs.append(ChatReceiptRef(label: label, ref: value))
+}
+
+private func tokenTotal(prompt: UInt64?, completion: UInt64?) -> UInt64? {
+  guard let prompt, let completion else { return nil }
+  let sum = prompt.addingReportingOverflow(completion)
+  return sum.overflow ? nil : sum.partialValue
 }

--- a/apps/friday-ios/Tests/FridayMobileShellCoreTests/FridayChatViewModelTests.swift
+++ b/apps/friday-ios/Tests/FridayMobileShellCoreTests/FridayChatViewModelTests.swift
@@ -311,6 +311,9 @@ final class FridayChatViewModelTests: XCTestCase {
     ])
     XCTAssertEqual(vm.history.last?.runId, "run-readable")
     XCTAssertEqual(vm.history.last?.createdAtMs, 42)
+    XCTAssertTrue(vm.history.last?.receiptRefs.contains(ChatReceiptRef(label: "run_id", ref: "run-readable")) == true)
+    XCTAssertTrue(vm.history.last?.receiptRefs.contains(ChatReceiptRef(label: "answer_body_run_id", ref: "run-readable")) == true)
+    XCTAssertTrue(vm.history.last?.receiptRefs.contains(ChatReceiptRef(label: "answer_body", ref: "delivered")) == true)
     XCTAssertEqual(store.items, vm.history)
   }
 
@@ -328,6 +331,19 @@ final class FridayChatViewModelTests: XCTestCase {
     vm.clearHistory()
     XCTAssertTrue(vm.history.isEmpty)
     XCTAssertEqual(store.items, [])
+  }
+
+  func testHistory_decodesLegacyRowsWithoutReceiptRefs() throws {
+    let data = Data("""
+    [{"id":"h1","role":"friday","text":"legacy answer","runId":"run-old","createdAtMs":7}]
+    """.utf8)
+
+    let rows = try JSONDecoder().decode([ChatHistoryItem].self, from: data)
+
+    XCTAssertEqual(rows, [
+      ChatHistoryItem(id: "h1", role: "friday", text: "legacy answer", runId: "run-old", createdAtMs: 7)
+    ])
+    XCTAssertEqual(rows.first?.receiptRefs, [])
   }
 
   func testBuildMissionIntakeRequest_usesMobileAutoRoute() {
@@ -424,6 +440,11 @@ final class FridayChatViewModelTests: XCTestCase {
     XCTAssertEqual(receipt.followUpRunId, "run-followup")
     XCTAssertEqual(receipt.answerBodyRunId, "run-followup")
     XCTAssertEqual(receipt.answerBody, "Claude follow-up body visible to the owner.")
+    XCTAssertTrue(receipt.receiptRefs.contains(ChatReceiptRef(label: "mission_id", ref: "mission-mobile-fixed")))
+    XCTAssertTrue(receipt.receiptRefs.contains(ChatReceiptRef(label: "work_item_id", ref: "work-mobile-fixed")))
+    XCTAssertTrue(receipt.receiptRefs.contains(ChatReceiptRef(label: "follow_up_work_item_id", ref: "work-mobile-fixed-claude-followup")))
+    XCTAssertTrue(receipt.receiptRefs.contains(ChatReceiptRef(label: "follow_up_run_id", ref: "run-followup")))
+    XCTAssertEqual(vm.history.last?.receiptRefs, receipt.receiptRefs)
   }
 
   func testSend_blankTask_isNoOp() async {
@@ -475,6 +496,8 @@ final class FridayChatViewModelTests: XCTestCase {
     XCTAssertEqual(client.resumedRunIds, ["run-1"])
     XCTAssertEqual(client.relayedBlobs.count, 1)
     XCTAssertEqual(client.relayedBlobs.first, expected, "INV-1: the signer blob must ride VERBATIM")
+    XCTAssertTrue(vm.history.last?.receiptRefs.contains(ChatReceiptRef(label: "audit_ref", ref: "audit://chain/run-1")) == true)
+    XCTAssertTrue(vm.history.last?.receiptRefs.contains(ChatReceiptRef(label: "truth", ref: "rust_wired")) == true)
   }
 
   /// A server REFUSAL (`accepted=false`) is a SUCCESSFUL relay of a refusal — the action did NOT


### PR DESCRIPTION
## Summary
- add structured mobile Chat receipt refs for answer/resume receipts
- persist proof refs in local chat history with legacy decode compatibility
- render transcript proof refs in mobile Chat history, answer, and control receipt cards

## Validation
- swift test --package-path apps/friday-ios
- bash apps/friday-ios/build-sim.sh
- git diff --check
- detect-secrets-hook --baseline /Users/jarvis/Projects/Friday/.secrets.baseline apps/friday-ios/Sources/FridayMobileShellCore/FridayChatViewModel.swift apps/friday-ios/Sources/FridayMobileShell/FridayChatScreen.swift apps/friday-ios/Tests/FridayMobileShellCoreTests/FridayChatViewModelTests.swift

Truth: improves mobile Transcript + Proof Receipts surface; not END-BAR, not adoption, not GO-LIVE by itself.