### PR TITLE
Surface mobile provider auth doctor

### DIFF
--- a/apps/friday-ios/Sources/FridayMobileShell/CommandSheet.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/CommandSheet.swift
@@ -18,6 +18,7 @@ enum MobileDestination: String, CaseIterable, Identifiable {
   case needsMe
   case memory
   case platform
+  case providerAuth
   case activity
   case workflows
   case onboarding
@@ -38,6 +39,7 @@ enum MobileDestination: String, CaseIterable, Identifiable {
     case .needsMe: return "Needs Me"
     case .memory: return "Memory"
     case .platform: return "Platform"
+    case .providerAuth: return "Provider/Auth"
     case .activity: return "Activity"
     case .workflows: return "Workflows"
     case .onboarding: return "Onboarding"
@@ -58,6 +60,7 @@ enum MobileDestination: String, CaseIterable, Identifiable {
     case .needsMe: return "person.crop.circle.badge.exclamationmark"
     case .memory: return "brain.head.profile"
     case .platform: return "square.grid.2x2"
+    case .providerAuth: return "person.badge.key"
     case .activity: return "bell.badge"
     case .workflows: return "arrow.triangle.branch"
     case .onboarding: return "sparkles.rectangle.stack"

--- a/apps/friday-ios/Sources/FridayMobileShell/FridayApp.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayApp.swift
@@ -364,6 +364,8 @@ struct RootView: View {
           FridayVoiceScreen(viewModel: voiceVM)
         case .pairing:
           FridayHomeScreen(viewModel: homeVM, showPairingProvisioning: true)
+        case .providerAuth:
+          FridayProviderAuthScreen(viewModel: homeVM)
         case .missions, .needsMe, .memory, .platform, .activity, .workflows, .onboarding,
              .settings:
           FridayProjectionScreen(destination: destination, viewModel: homeVM)

--- a/apps/friday-ios/Sources/FridayMobileShell/FridayProjectionScreens.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayProjectionScreens.swift
@@ -14,7 +14,7 @@ private enum ProjectionSurface {
 
   init?(_ destination: MobileDestination) {
     switch destination {
-    case .home, .session, .contextPassport, .tokenLedger, .shareIntake, .voice, .pairing:
+    case .home, .session, .contextPassport, .tokenLedger, .shareIntake, .voice, .pairing, .providerAuth:
       return nil
     case .missions:
       self = .missions
@@ -281,7 +281,7 @@ struct FridayProjectionScreen: View {
             .foregroundStyle(MobileTheme.textPrimary)
           RefPill(label: "generated", ref: generatedText(detail.generatedAtMs))
           if let providerReadiness = detail.providerReadiness {
-            providerReadinessRows(providerReadiness)
+            ProviderReadinessPanel(detail: providerReadiness)
           }
           ForEach(detail.refs, id: \.self) { ref in
             RefPill(label: nil, ref: ref)
@@ -884,114 +884,6 @@ struct FridayProjectionScreen: View {
           .foregroundStyle(MobileTheme.textSecondary)
       }
       Spacer()
-    }
-  }
-
-  @ViewBuilder
-  private func providerReadinessRows(_ detail: HomeProviderReadinessDetail) -> some View {
-    VStack(alignment: .leading, spacing: 8) {
-      HStack(spacing: 6) {
-        statusChip(detail.truthLabel)
-        statusChip(detail.proofOnly ? "proof only" : "not proof only")
-        StatusChip(
-          text: detail.ok ? "doctor ok" : "doctor not ok",
-          bg: detail.ok ? MobileTheme.chipPendingBG : MobileTheme.chipWarnBG,
-          fg: detail.ok ? MobileTheme.chipPendingFG : MobileTheme.chipWarnFG)
-      }
-      HStack(spacing: 6) {
-        statusChip(detail.anyAuthenticated ? "some auth" : "none auth")
-        statusChip(detail.allAuthenticated ? "all auth" : "partial auth")
-      }
-      if !detail.readyProviders.isEmpty {
-        Text("ready: \(detail.readyProviders.joined(separator: ", "))")
-          .font(.caption)
-          .foregroundStyle(MobileTheme.textSecondary)
-          .fixedSize(horizontal: false, vertical: true)
-      }
-      if let suggestedTextRoute = detail.suggestedTextRoute {
-        Text("text route: \(suggestedTextRoute)")
-          .font(.caption)
-          .foregroundStyle(MobileTheme.textSecondary)
-          .fixedSize(horizontal: false, vertical: true)
-      }
-      if let suggestedStrongRoute = detail.suggestedStrongRoute {
-        Text("strong route: \(suggestedStrongRoute)")
-          .font(.caption)
-          .foregroundStyle(MobileTheme.textSecondary)
-          .fixedSize(horizontal: false, vertical: true)
-      }
-      if let keyValidationProbed = detail.keyValidationProbed {
-        statusChip(keyValidationProbed ? "keys probed" : "keys not probed")
-      }
-      ForEach(detail.detected) { provider in
-        VStack(alignment: .leading, spacing: 5) {
-          HStack {
-            Text(provider.provider)
-              .font(.system(size: 13, weight: .medium))
-              .foregroundStyle(MobileTheme.textPrimary)
-            Spacer()
-            StatusChip(
-              text: provider.authenticated ? "authenticated" : "not authenticated",
-              bg: provider.authenticated ? MobileTheme.chipPendingBG : MobileTheme.chipWarnBG,
-              fg: provider.authenticated ? MobileTheme.chipPendingFG : MobileTheme.chipWarnFG)
-          }
-          Text(provider.detail)
-            .font(.caption)
-            .foregroundStyle(MobileTheme.textSecondary)
-            .fixedSize(horizontal: false, vertical: true)
-          HStack(spacing: 6) {
-            statusChip(provider.installed ? "installed" : "not installed")
-            statusChip(provider.truthLabel)
-          }
-        }
-        .padding(.vertical, 3)
-      }
-      ForEach(detail.routes) { route in
-        VStack(alignment: .leading, spacing: 5) {
-          HStack {
-            Text(route.providerId)
-              .font(.system(size: 13, weight: .medium))
-              .foregroundStyle(MobileTheme.textPrimary)
-            Spacer()
-            StatusChip(
-              text: route.dispatchable ? "dispatchable" : "blocked",
-              bg: route.dispatchable ? MobileTheme.chipPendingBG : MobileTheme.chipWarnBG,
-              fg: route.dispatchable ? MobileTheme.chipPendingFG : MobileTheme.chipWarnFG)
-          }
-          Text("\(route.model) - \(route.modelSize) - \(route.strength)")
-            .font(.caption)
-            .foregroundStyle(MobileTheme.textSecondary)
-            .fixedSize(horizontal: false, vertical: true)
-          if !route.blockers.isEmpty {
-            Text("blockers: \(route.blockers.joined(separator: ", "))")
-              .font(.caption2)
-              .foregroundStyle(MobileTheme.textSecondary)
-              .fixedSize(horizontal: false, vertical: true)
-          }
-        }
-        .padding(.vertical, 3)
-      }
-      ForEach(detail.failovers) { failover in
-        VStack(alignment: .leading, spacing: 5) {
-          HStack {
-            Text(failover.direction)
-              .font(.system(size: 13, weight: .medium))
-              .foregroundStyle(MobileTheme.textPrimary)
-            Spacer()
-            StatusChip(
-              text: failover.flagEnabled ? "armed" : "off",
-              bg: failover.flagEnabled ? MobileTheme.chipPendingBG : MobileTheme.chipNeutralBG,
-              fg: failover.flagEnabled ? MobileTheme.chipPendingFG : MobileTheme.chipNeutralFG)
-          }
-          HStack(spacing: 6) {
-            statusChip(failover.canEnable ? "can enable" : "blocked")
-            if !failover.blockers.isEmpty {
-              statusChip("blockers \(failover.blockers.count)")
-            }
-          }
-        }
-        .padding(.vertical, 3)
-      }
     }
   }
 

--- a/apps/friday-ios/Sources/FridayMobileShell/FridayProviderAuthScreen.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayProviderAuthScreen.swift
@@ -1,0 +1,127 @@
+import FridayMobileShellCore
+import SwiftUI
+
+struct FridayProviderAuthScreen: View {
+  @ObservedObject var viewModel: HomeViewModel
+
+  var body: some View {
+    ScrollView {
+      VStack(spacing: 16) {
+        header
+        doctorActionCard
+        detailCard
+      }
+      .padding(16)
+    }
+    .background(MobileTheme.backgroundWarmOffWhite.ignoresSafeArea())
+    .task {
+      if case .idle = viewModel.detailState {
+        await viewModel.loadDetail(.providersDoctor(probe: nil))
+      }
+    }
+  }
+
+  private var header: some View {
+    GlassPanel {
+      HStack(spacing: 12) {
+        Image(systemName: "person.badge.key")
+          .font(.system(size: 24, weight: .semibold))
+          .foregroundStyle(MobileTheme.cyan)
+          .frame(width: 34, height: 34)
+        VStack(alignment: .leading, spacing: 4) {
+          Text("Provider/Auth")
+            .font(.headline)
+            .foregroundStyle(MobileTheme.textPrimary)
+          Text("read-only provider doctor; no secrets are stored here")
+            .font(.caption)
+            .foregroundStyle(MobileTheme.textSecondary)
+        }
+        Spacer()
+      }
+    }
+    .accessibilityIdentifier("friday.provider-auth.header")
+  }
+
+  private var doctorActionCard: some View {
+    GlassPanel {
+      VStack(alignment: .leading, spacing: MobileTheme.rowSpacing) {
+        Text("Provider Doctor")
+          .font(.headline)
+          .foregroundStyle(MobileTheme.textPrimary)
+        Text("Checks provider CLI/auth/route readiness through the Hub read arm. This surface never asks for, stores, or displays provider secrets.")
+          .font(.caption)
+          .foregroundStyle(MobileTheme.textSecondary)
+          .fixedSize(horizontal: false, vertical: true)
+        Button {
+          Task { await viewModel.loadDetail(.providersDoctor(probe: nil)) }
+        } label: {
+          Label("Check Provider Auth", systemImage: "stethoscope")
+            .frame(maxWidth: .infinity)
+        }
+        .buttonStyle(.borderedProminent)
+        .tint(MobileTheme.cyan)
+        .disabled(viewModel.detailState.isLoading)
+        .accessibilityIdentifier("friday.provider-auth.check")
+      }
+    }
+  }
+
+  @ViewBuilder
+  private var detailCard: some View {
+    switch viewModel.detailState {
+    case .idle:
+      EmptyView()
+    case .loading:
+      GlassPanel {
+        HStack(spacing: 12) {
+          ProgressView()
+          Text("Reading provider doctor")
+            .font(.caption)
+            .foregroundStyle(MobileTheme.textSecondary)
+        }
+      }
+    case .loaded(let detail):
+      GlassPanel {
+        VStack(alignment: .leading, spacing: MobileTheme.rowSpacing) {
+          HStack {
+            Text(detail.title)
+              .font(.headline)
+              .foregroundStyle(MobileTheme.textPrimary)
+            Spacer()
+            StatusChip(
+              text: detail.providerReadiness == nil ? "not provider doctor" : "read",
+              bg: detail.providerReadiness == nil ? MobileTheme.chipWarnBG : MobileTheme.chipPendingBG,
+              fg: detail.providerReadiness == nil ? MobileTheme.chipWarnFG : MobileTheme.chipPendingFG)
+          }
+          Text(detail.summary)
+            .font(.caption)
+            .foregroundStyle(MobileTheme.textPrimary)
+            .fixedSize(horizontal: false, vertical: true)
+          if let providerReadiness = detail.providerReadiness {
+            ProviderReadinessPanel(detail: providerReadiness)
+          } else {
+            Text("The latest read result is not a provider doctor projection.")
+              .font(.caption)
+              .foregroundStyle(MobileTheme.textSecondary)
+          }
+          ForEach(detail.refs, id: \.self) { ref in
+            RefPill(label: "proof", ref: ref)
+          }
+        }
+      }
+      .accessibilityIdentifier("friday.provider-auth.detail")
+    case .unavailable(let title, let reason):
+      GlassPanel {
+        VStack(alignment: .leading, spacing: MobileTheme.rowSpacing) {
+          Text(title)
+            .font(.headline)
+            .foregroundStyle(MobileTheme.textPrimary)
+          Text(reason)
+            .font(.caption)
+            .foregroundStyle(MobileTheme.textSecondary)
+            .fixedSize(horizontal: false, vertical: true)
+        }
+      }
+    }
+  }
+}

--- a/apps/friday-ios/Sources/FridayMobileShell/ProviderReadinessPanel.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/ProviderReadinessPanel.swift
@@ -1,0 +1,129 @@
+import FridayMobileShellCore
+import SwiftUI
+
+struct ProviderReadinessPanel: View {
+  let detail: HomeProviderReadinessDetail
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 8) {
+      HStack(spacing: 6) {
+        statusChip(detail.truthLabel)
+        statusChip(detail.proofOnly ? "proof only" : "not proof only")
+        StatusChip(
+          text: detail.ok ? "doctor ok" : "doctor not ok",
+          bg: detail.ok ? MobileTheme.chipPendingBG : MobileTheme.chipWarnBG,
+          fg: detail.ok ? MobileTheme.chipPendingFG : MobileTheme.chipWarnFG)
+      }
+      HStack(spacing: 6) {
+        statusChip(detail.anyAuthenticated ? "some auth" : "none auth")
+        statusChip(detail.allAuthenticated ? "all auth" : "partial auth")
+      }
+      if !detail.readyProviders.isEmpty {
+        Text("ready: \(detail.readyProviders.joined(separator: ", "))")
+          .font(.caption)
+          .foregroundStyle(MobileTheme.textSecondary)
+          .fixedSize(horizontal: false, vertical: true)
+      }
+      if let suggestedTextRoute = detail.suggestedTextRoute {
+        Text("text route: \(suggestedTextRoute)")
+          .font(.caption)
+          .foregroundStyle(MobileTheme.textSecondary)
+          .fixedSize(horizontal: false, vertical: true)
+      }
+      if let suggestedStrongRoute = detail.suggestedStrongRoute {
+        Text("strong route: \(suggestedStrongRoute)")
+          .font(.caption)
+          .foregroundStyle(MobileTheme.textSecondary)
+          .fixedSize(horizontal: false, vertical: true)
+      }
+      if let keyValidationProbed = detail.keyValidationProbed {
+        statusChip(keyValidationProbed ? "keys probed" : "keys not probed")
+      }
+      providerRows
+      routeRows
+      failoverRows
+    }
+  }
+
+  private var providerRows: some View {
+    ForEach(detail.detected) { provider in
+      VStack(alignment: .leading, spacing: 5) {
+        HStack {
+          Text(provider.provider)
+            .font(.system(size: 13, weight: .medium))
+            .foregroundStyle(MobileTheme.textPrimary)
+          Spacer()
+          StatusChip(
+            text: provider.authenticated ? "authenticated" : "not authenticated",
+            bg: provider.authenticated ? MobileTheme.chipPendingBG : MobileTheme.chipWarnBG,
+            fg: provider.authenticated ? MobileTheme.chipPendingFG : MobileTheme.chipWarnFG)
+        }
+        Text(provider.detail)
+          .font(.caption)
+          .foregroundStyle(MobileTheme.textSecondary)
+          .fixedSize(horizontal: false, vertical: true)
+        HStack(spacing: 6) {
+          statusChip(provider.installed ? "installed" : "not installed")
+          statusChip(provider.truthLabel)
+        }
+      }
+      .padding(.vertical, 3)
+    }
+  }
+
+  private var routeRows: some View {
+    ForEach(detail.routes) { route in
+      VStack(alignment: .leading, spacing: 5) {
+        HStack {
+          Text(route.providerId)
+            .font(.system(size: 13, weight: .medium))
+            .foregroundStyle(MobileTheme.textPrimary)
+          Spacer()
+          StatusChip(
+            text: route.dispatchable ? "dispatchable" : "blocked",
+            bg: route.dispatchable ? MobileTheme.chipPendingBG : MobileTheme.chipWarnBG,
+            fg: route.dispatchable ? MobileTheme.chipPendingFG : MobileTheme.chipWarnFG)
+        }
+        Text("\(route.model) - \(route.modelSize) - \(route.strength)")
+          .font(.caption)
+          .foregroundStyle(MobileTheme.textSecondary)
+          .fixedSize(horizontal: false, vertical: true)
+        if !route.blockers.isEmpty {
+          Text("blockers: \(route.blockers.joined(separator: ", "))")
+            .font(.caption2)
+            .foregroundStyle(MobileTheme.textSecondary)
+            .fixedSize(horizontal: false, vertical: true)
+        }
+      }
+      .padding(.vertical, 3)
+    }
+  }
+
+  private var failoverRows: some View {
+    ForEach(detail.failovers) { failover in
+      VStack(alignment: .leading, spacing: 5) {
+        HStack {
+          Text(failover.direction)
+            .font(.system(size: 13, weight: .medium))
+            .foregroundStyle(MobileTheme.textPrimary)
+          Spacer()
+          StatusChip(
+            text: failover.flagEnabled ? "armed" : "off",
+            bg: failover.flagEnabled ? MobileTheme.chipPendingBG : MobileTheme.chipNeutralBG,
+            fg: failover.flagEnabled ? MobileTheme.chipPendingFG : MobileTheme.chipNeutralFG)
+        }
+        HStack(spacing: 6) {
+          statusChip(failover.canEnable ? "can enable" : "blocked")
+          if !failover.blockers.isEmpty {
+            statusChip("blockers \(failover.blockers.count)")
+          }
+        }
+      }
+      .padding(.vertical, 3)
+    }
+  }
+
+  private func statusChip(_ text: String) -> some View {
+    StatusChip(text: text, bg: MobileTheme.chipNeutralBG, fg: MobileTheme.chipNeutralFG)
+  }
+}


### PR DESCRIPTION
## Summary
- add a first-class mobile Provider/Auth destination backed by the existing provider doctor read arm
- factor provider readiness rows into a shared ProviderReadinessPanel
- keep Provider/Auth read-only: no provider secrets are stored, requested, or displayed

## Validation
- swift test --package-path apps/friday-ios
- bash apps/friday-ios/build-sim.sh
- git diff --check
- detect-secrets-hook --baseline /Users/jarvis/Projects/Friday/.secrets.baseline apps/friday-ios/Sources/FridayMobileShell/CommandSheet.swift apps/friday-ios/Sources/FridayMobileShell/FridayApp.swift apps/friday-ios/Sources/FridayMobileShell/FridayProjectionScreens.swift apps/friday-ios/Sources/FridayMobileShell/FridayProviderAuthScreen.swift apps/friday-ios/Sources/FridayMobileShell/ProviderReadinessPanel.swift

Truth: surfaces provider doctor readiness in-app; not END-BAR, not provider-secret custody, not GO-LIVE by itself.