### PR TITLE
Surface mobile home recovery controls

### DIFF
--- a/apps/friday-ios/Sources/FridayMobileShell/FridayHomeScreen.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayHomeScreen.swift
@@ -11,8 +11,8 @@ import SwiftUI
 ///
 /// Truth rules: the projection is refs-only (counts/labels/ids — never a body); the
 /// `runtimeFeedStatus` + `statusLabels` ride AS-IS (never upgraded); a 503 / offline / dark
-/// server renders AS truth (honest-unavailable), never a fabricated ready Home. The only action
-/// is Refresh (re-read) — there is NO mutating action on this surface.
+/// server renders AS truth (honest-unavailable), never a fabricated ready Home. Governed recovery
+/// actions only appear when the live projection exposes WorkItem retry/cancel affordances.
 struct FridayHomeScreen: View {
   @ObservedObject var viewModel: HomeViewModel
   let showPairingProvisioning: Bool
@@ -222,6 +222,7 @@ struct FridayHomeScreen: View {
     let subtitle: String
     let chip: String
     let urgent: Bool
+    let workItem: HomeWorkItem?
   }
 
   private func needsRows(_ projection: HomeProjection) -> [QueueRow] {
@@ -236,7 +237,8 @@ struct FridayHomeScreen: View {
           title: item.title,
           subtitle: item.blockingReason.isEmpty ? "state: \(item.state)" : item.blockingReason,
           chip: item.canRetry ? "needs" : item.state,
-          urgent: item.canRetry || item.state == "stale" || item.state == "blocked")
+          urgent: item.canRetry || item.state == "stale" || item.state == "blocked",
+          workItem: item)
       }
     rows.append(contentsOf: projection.memoryCandidates.prefix(2).map { candidate in
       QueueRow(
@@ -246,7 +248,8 @@ struct FridayHomeScreen: View {
         title: "Review memory candidate",
         subtitle: candidate.preview,
         chip: candidate.grantsMemoryAuthority ? "authority" : "review",
-        urgent: false)
+        urgent: false,
+        workItem: nil)
     })
     rows.append(contentsOf: projection.runOutcomeLearningCandidates.prefix(2).map { candidate in
       QueueRow(
@@ -256,7 +259,8 @@ struct FridayHomeScreen: View {
         title: candidate.summary,
         subtitle: "candidate: \(candidate.kind) · \(candidate.state)",
         chip: "confirm",
-        urgent: false)
+        urgent: false,
+        workItem: nil)
     })
     return Array(rows.prefix(6))
   }
@@ -273,7 +277,8 @@ struct FridayHomeScreen: View {
           title: item.title,
           subtitle: "owner: \(item.owner)",
           chip: item.state,
-          urgent: false)
+          urgent: false,
+          workItem: nil)
       }
     if let route = projection.routeSelected {
       rows.append(QueueRow(
@@ -285,7 +290,8 @@ struct FridayHomeScreen: View {
           ? "selected by route advisor"
           : "alternatives: \(projection.routeAlternatives.joined(separator: ", "))",
         chip: "ok",
-        urgent: false))
+        urgent: false,
+        workItem: nil))
     }
     rows.append(contentsOf: projection.transcriptEvents.prefix(3).map { event in
       QueueRow(
@@ -295,7 +301,8 @@ struct FridayHomeScreen: View {
         title: event.summary,
         subtitle: "\(event.sectionTitle) · \(event.truthLabel)",
         chip: event.status,
-        urgent: false)
+        urgent: false,
+        workItem: nil)
     })
     return Array(rows.prefix(6))
   }
@@ -351,38 +358,100 @@ struct FridayHomeScreen: View {
   }
 
   private func commandQueueRow(_ row: QueueRow) -> some View {
-    GlassPanel {
-      HStack(spacing: 13) {
-        ZStack {
-          RoundedRectangle(cornerRadius: 12, style: .continuous)
-            .fill(row.iconBg)
-          Image(systemName: row.icon)
-            .font(.system(size: 18, weight: .semibold))
-            .foregroundStyle(row.urgent ? MobileTheme.coral : MobileTheme.cyan)
+    let recoveryState = row.workItem.flatMap { viewModel.workItemStatusStates[$0.id] }
+    return GlassPanel {
+      VStack(alignment: .leading, spacing: 8) {
+        HStack(spacing: 13) {
+          ZStack {
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+              .fill(row.iconBg)
+            Image(systemName: row.icon)
+              .font(.system(size: 18, weight: .semibold))
+              .foregroundStyle(row.urgent ? MobileTheme.coral : MobileTheme.cyan)
+          }
+          .frame(width: 44, height: 44)
+          VStack(alignment: .leading, spacing: 4) {
+            Text(row.title)
+              .font(.headline)
+              .foregroundStyle(MobileTheme.textPrimary)
+              .lineLimit(2)
+            Text(row.subtitle)
+              .font(.subheadline)
+              .foregroundStyle(MobileTheme.textSecondary)
+              .lineLimit(2)
+          }
+          Spacer(minLength: 8)
+          StatusChip(
+            text: row.chip,
+            bg: row.urgent ? MobileTheme.chipWarnBG : MobileTheme.chipNeutralBG,
+            fg: row.urgent ? MobileTheme.chipWarnFG : MobileTheme.chipNeutralFG)
+          Image(systemName: "chevron.right")
+            .font(.footnote.weight(.semibold))
+            .foregroundStyle(MobileTheme.textSecondary.opacity(0.55))
         }
-        .frame(width: 44, height: 44)
-        VStack(alignment: .leading, spacing: 4) {
-          Text(row.title)
-            .font(.headline)
-            .foregroundStyle(MobileTheme.textPrimary)
-            .lineLimit(2)
-          Text(row.subtitle)
-            .font(.subheadline)
-            .foregroundStyle(MobileTheme.textSecondary)
-            .lineLimit(2)
+        if let item = row.workItem, item.canRetry || item.canCancel {
+          workItemRecoveryControls(item, state: recoveryState)
         }
-        Spacer(minLength: 8)
-        StatusChip(
-          text: row.chip,
-          bg: row.urgent ? MobileTheme.chipWarnBG : MobileTheme.chipNeutralBG,
-          fg: row.urgent ? MobileTheme.chipWarnFG : MobileTheme.chipNeutralFG)
-        Image(systemName: "chevron.right")
-          .font(.footnote.weight(.semibold))
-          .foregroundStyle(MobileTheme.textSecondary.opacity(0.55))
       }
     }
     .accessibilityElement(children: .combine)
     .accessibilityLabel("\(row.title). \(row.subtitle). \(row.chip)")
+  }
+
+  @ViewBuilder
+  private func workItemRecoveryControls(_ item: HomeWorkItem, state: HomeLearningDecisionState?) -> some View {
+    HStack(spacing: 8) {
+      if item.canRetry {
+        Button {
+          Task { await viewModel.retryWorkItem(item) }
+        } label: {
+          Image(systemName: "arrow.clockwise")
+            .frame(width: 26, height: 26)
+        }
+        .buttonStyle(.bordered)
+        .disabled(candidateDecisionControlsDisabled(state))
+        .accessibilityLabel("Retry WorkItem")
+        .accessibilityIdentifier("friday.home.retry-work-item")
+      }
+      if item.canCancel {
+        Button {
+          Task { await viewModel.cancelWorkItem(item) }
+        } label: {
+          Image(systemName: "stop.circle")
+            .frame(width: 26, height: 26)
+        }
+        .buttonStyle(.bordered)
+        .disabled(candidateDecisionControlsDisabled(state))
+        .accessibilityLabel("Cancel WorkItem")
+        .accessibilityIdentifier("friday.home.cancel-work-item")
+      }
+    }
+    candidateDecisionStateView(state, pendingText: "Updating WorkItem...")
+  }
+
+  private func candidateDecisionControlsDisabled(_ state: HomeLearningDecisionState?) -> Bool {
+    guard let state else { return false }
+    return state.isSent || state.isTerminal
+  }
+
+  @ViewBuilder
+  private func candidateDecisionStateView(_ state: HomeLearningDecisionState?, pendingText: String) -> some View {
+    switch state {
+    case .sent:
+      Text(pendingText)
+        .font(.caption2)
+        .foregroundStyle(MobileTheme.textSecondary)
+    case .confirmed(let summary):
+      Text(summary)
+        .font(.caption2)
+        .foregroundStyle(MobileTheme.textSecondary)
+    case .error(let reason):
+      Text(reason)
+        .font(.caption2)
+        .foregroundStyle(MobileTheme.coral)
+    case nil:
+      EmptyView()
+    }
   }
 
   private func statusCard(_ projection: HomeProjection) -> some View {

--- a/apps/friday-ios/Tests/FridayMobileShellCoreTests/HomeViewModelTests.swift
+++ b/apps/friday-ios/Tests/FridayMobileShellCoreTests/HomeViewModelTests.swift
@@ -696,6 +696,43 @@ final class HomeViewModelTests: XCTestCase {
       .confirmed(summary: "cancelled · work_item_id=wi-2 · previous=unknown"))
   }
 
+  func testRetryWorkItemGuardDoesNotWriteWhenProjectionSaysNotRetryable() async throws {
+    let read = FakeReadClient(.snapshot(try sampleSnapshot()))
+    let write = FakeMissionWriteClient()
+    let vm = HomeViewModel(client: read, writeClient: write, writeOwnerPrincipal: "owner-ios")
+    let item = try XCTUnwrap(HomeProjection(try sampleSnapshot()).workItems.first)
+
+    await vm.retryWorkItem(item)
+
+    XCTAssertTrue(write.workItemStatusRequests.isEmpty)
+    XCTAssertEqual(read.fetchWorkbenchCount, 0)
+    XCTAssertEqual(vm.workItemStatusStates["wi-1"], .error(reason: "This WorkItem is not retryable."))
+  }
+
+  func testCancelWorkItemGuardDoesNotWriteWhenProjectionSaysNotCancellable() async throws {
+    let read = FakeReadClient(.snapshot(try sampleSnapshot()))
+    let write = FakeMissionWriteClient()
+    let vm = HomeViewModel(client: read, writeClient: write, writeOwnerPrincipal: "owner-ios")
+    var item = try XCTUnwrap(HomeProjection(try sampleSnapshot()).workItems.last)
+    item = HomeWorkItem(
+      id: item.id,
+      title: item.title,
+      state: item.state,
+      owner: item.owner,
+      proofRef: item.proofRef,
+      done: item.done,
+      blockingReason: item.blockingReason,
+      recoveryKind: item.recoveryKind,
+      canRetry: item.canRetry,
+      canCancel: false)
+
+    await vm.cancelWorkItem(item)
+
+    XCTAssertTrue(write.workItemStatusRequests.isEmpty)
+    XCTAssertEqual(read.fetchWorkbenchCount, 0)
+    XCTAssertEqual(vm.workItemStatusStates["wi-2"], .error(reason: "This WorkItem is not cancellable."))
+  }
+
   func testDecideMemoryConfirmRendersConfirmedAndRefreshes() async throws {
     let read = FakeReadClient(.snapshot(try sampleSnapshot()))
     let write = FakeMissionWriteClient(memoryScript: .result(

--- a/rust-core/crates/friday-hub/src/workbench_projection.rs
+++ b/rust-core/crates/friday-hub/src/workbench_projection.rs
@@ -1282,6 +1282,47 @@ mod tests {
     }
 
     #[test]
+    fn real_failed_retryable_work_item_projects_stale_retry_affordance() {
+        let db = Db::open_hub(&tmp()).unwrap();
+        let mission_id = seed_real_producer_mission(&db);
+        let mut item = db.get_work_item("autodisp-1781492033").unwrap().unwrap();
+        item.status = WorkItemStatus::FailedRetryable;
+        item.blocking_reason = Some(
+            "failed retryable; operator may retry by returning the WorkItem to ready_to_dispatch"
+                .into(),
+        );
+        db.upsert_work_item(&item).unwrap();
+
+        let snapshot = project_workbench(&db, Some(&mission_id)).unwrap();
+        let items = snapshot
+            .get("workItems")
+            .and_then(Value::as_array)
+            .expect("workItems array");
+        let projected = items
+            .iter()
+            .find(|row| row.get("id").and_then(Value::as_str) == Some("autodisp-1781492033"))
+            .expect("real producer work item projection");
+
+        assert_eq!(
+            projected.get("state").and_then(Value::as_str),
+            Some("stale")
+        );
+        assert_eq!(
+            projected.get("recoveryKind").and_then(Value::as_str),
+            Some("retryable")
+        );
+        assert_eq!(
+            projected.get("canRetry").and_then(Value::as_bool),
+            Some(true)
+        );
+        assert_eq!(
+            projected.get("canCancel").and_then(Value::as_bool),
+            Some(true)
+        );
+        assert_eq!(projected.get("done").and_then(Value::as_bool), Some(false));
+    }
+
+    #[test]
     fn memory_candidates_project_durable_memory_id_once() {
         let db = Db::open_hub(&tmp()).unwrap();
         let mission_id = seed_real_producer_mission(&db);

--- a/test/unit/api/routes/friday-mission-spine-routes.test.ts
+++ b/test/unit/api/routes/friday-mission-spine-routes.test.ts
@@ -338,6 +338,40 @@ describe("createFridayMissionSpineRoutes", () => {
     expect(JSON.stringify(response)).not.toContain("prep fallback");
   });
 
+  it("accepts stale WorkItems only when the retry recovery affordance is exposed", async () => {
+    const staleSnapshot = cloneSnapshot({
+      workItems: snapshot.workItems.map((item, index) => (
+        index === 0
+          ? {
+            ...item,
+            state: "stale",
+            done: false,
+            blockingReason: "failed retryable; operator may retry by returning the WorkItem to ready_to_dispatch",
+            recoveryKind: "retryable",
+            canRetry: true,
+            canCancel: true,
+          }
+          : item
+      )),
+    });
+    const routes = createFridayMissionSpineRoutes({
+      workbench: { getSnapshot: vi.fn(async () => staleSnapshot) },
+      disabledReason: null,
+    });
+    const route = findRoute(routes);
+
+    const response = await route.handler(makeCtx() as never);
+
+    expect(response).toEqual({ snapshot: staleSnapshot });
+    expect(response.snapshot.workItems[0]).toMatchObject({
+      state: "stale",
+      recoveryKind: "retryable",
+      canRetry: true,
+      canCancel: true,
+      done: false,
+    });
+  });
+
   it("accepts real Rust producer hyphen mission ids without weakening exact-match checks", async () => {
     const missionId = "mission-autodisp-1781492033";
     const hyphenSnapshot = cloneSnapshot({


### PR DESCRIPTION
## Summary
- surface existing WorkItem retry/cancel recovery controls directly in the mobile Home Needs Me queue
- keep recovery governed by projection affordances and the existing mission-spine write seam
- add Swift guard coverage plus TS/Rust proof that stale retryable WorkItems expose retry affordances

## Validation
- swift test --package-path apps/friday-ios
- bash apps/friday-ios/build-sim.sh
- cargo fmt --manifest-path rust-core/Cargo.toml -p friday-hub --check
- cargo test -p friday-hub workbench_projection::tests::real_failed_retryable_work_item_projects_stale_retry_affordance --manifest-path rust-core/Cargo.toml
- node /Users/jarvis/Projects/Friday/node_modules/vitest/vitest.mjs run test/unit/api/routes/friday-mission-spine-routes.test.ts --config /Users/jarvis/Projects/Friday/vitest.config.ts -t "accepts stale WorkItems only when the retry recovery affordance is exposed"
- git diff --check
- detect-secrets-hook --baseline /Users/jarvis/Projects/Friday/.secrets.baseline apps/friday-ios/Sources/FridayMobileShell/FridayHomeScreen.swift apps/friday-ios/Tests/FridayMobileShellCoreTests/HomeViewModelTests.swift rust-core/crates/friday-hub/src/workbench_projection.rs test/unit/api/routes/friday-mission-spine-routes.test.ts

Truth: enables first-screen mobile recovery actions for WorkItems that the live projection already marks retryable/cancellable; not END-BAR, not GO-LIVE by itself.