### PR TITLE
Enable mobile session continuation send

### DIFF
--- a/apps/friday-ios/Sources/FridayMobileShell/FridayApp.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayApp.swift
@@ -183,14 +183,15 @@ final class FridaySession: ObservableObject {
   /// over the real `SealedWSWriteClient` (`RealWriteClientFactory.makeLive`). If the host master key
   /// is unavailable (e.g. a real phone — the J2 pairing problem), fall back to the throwing default
   /// (honest unavailable) — NEVER fabricate a ready chat surface the live seam did not produce.
-  static func defaultWriteClient(runControlEnabled: Bool) -> FridayRustWriteClient {
-    defaultLiveWriteClient(runControlEnabled: runControlEnabled)
-      ?? honestUnavailableWriteClient(runControlEnabled: runControlEnabled)
+  static func defaultWriteClient(runControlEnabled: Bool, sessionId: String? = nil) -> FridayRustWriteClient {
+    defaultLiveWriteClient(runControlEnabled: runControlEnabled, sessionId: sessionId)
+      ?? honestUnavailableWriteClient(runControlEnabled: runControlEnabled, sessionId: sessionId)
   }
 
   static func defaultLiveWriteClient(
     runControlEnabled: Bool,
-    deviceKeypairBackend: DeviceKeypairBackend = KeychainDeviceKeypairBackend()
+    deviceKeypairBackend: DeviceKeypairBackend = KeychainDeviceKeypairBackend(),
+    sessionId: String? = nil
   ) -> FridayMobileMissionDispatchingWriteClient? {
     let args = ProcessInfo.processInfo.arguments
     let env = ProcessInfo.processInfo.environment
@@ -205,10 +206,12 @@ final class FridaySession: ObservableObject {
         return RealWriteClientFactory.makeLive(
           deviceKeypair: device,
           config: config,
+          sessionId: sessionId,
           agentRunControlViaRust: runControlEnabled)
       }
       return try RealWriteClientFactory.makeLive(
         config: config,
+        sessionId: sessionId,
         agentRunControlViaRust: runControlEnabled)
     } catch {
       // Master/device key unavailable or corrupt: no mission-capable client. The caller falls back
@@ -302,10 +305,14 @@ final class FridaySession: ObservableObject {
   /// The honest-unavailable WRITE client: the shared `FridayClientFactory.makeWriteClient` with its
   /// DEFAULT throwing `liveTransportNotWired` transport + an ephemeral session keypair that opens no
   /// socket. This is the SHIPPED default and the preview/no-master-key fallback.
-  static func honestUnavailableWriteClient(runControlEnabled: Bool = false) -> FridayRustWriteClient {
+  static func honestUnavailableWriteClient(
+    runControlEnabled: Bool = false,
+    sessionId: String? = nil
+  ) -> FridayRustWriteClient {
     let writeKeypair = FridayCrypto.DeviceKeypair()
     let endpoint = FridayClientFactory.Endpoint(
       forwardedPrincipal: "principal:owner-device",
+      sessionId: sessionId,
       agentRunControlViaRust: runControlEnabled)
     return FridayClientFactory.makeWriteClient(keypair: writeKeypair, endpoint: endpoint)
   }
@@ -339,6 +346,15 @@ struct RootView: View {
     _sessionContinuationVM = StateObject(wrappedValue: SessionContinuationViewModel(
       client: session.readClient,
       writeClient: session.writeClient,
+      makeSessionWriteClient: { sessionId in
+        FridaySession.defaultLiveWriteClient(
+          runControlEnabled: session.runControlEnabled,
+          deviceKeypairBackend: session.deviceKeypairBackend,
+          sessionId: sessionId)
+          ?? FridaySession.honestUnavailableWriteClient(
+            runControlEnabled: session.runControlEnabled,
+            sessionId: sessionId)
+      },
       signer: session.signer,
       runControlEnabled: session.runControlEnabled))
     _shareIntakeVM = StateObject(wrappedValue: ShareIntakeViewModel(client: session.missionClient))

--- a/apps/friday-ios/Sources/FridayMobileShell/FridaySessionDetailScreen.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridaySessionDetailScreen.swift
@@ -4,6 +4,7 @@ import SwiftUI
 struct FridaySessionDetailScreen: View {
   @ObservedObject var homeViewModel: HomeViewModel
   @ObservedObject var viewModel: SessionContinuationViewModel
+  @State private var sessionSendText = ""
 
   var body: some View {
     ScrollView {
@@ -198,8 +199,11 @@ struct FridaySessionDetailScreen: View {
     GlassPanel {
       VStack(alignment: .leading, spacing: MobileTheme.rowSpacing) {
         cardHeader("Controls", count: nil)
+        if let send = controls.first(where: { $0.id == "send" }) {
+          sessionSendComposer(send)
+        }
         LazyVGrid(columns: [GridItem(.flexible()), GridItem(.flexible())], spacing: 10) {
-          ForEach(controls) { control in
+          ForEach(controls.filter { $0.id != "send" }) { control in
             let controlState = viewModel.controlStates[control.id]
             Button {
               if control.id == "stop" {
@@ -233,6 +237,42 @@ struct FridaySessionDetailScreen: View {
           }
         }
       }
+    }
+  }
+
+  private func sessionSendComposer(_ control: SessionContinuationControl) -> some View {
+    let state = viewModel.controlStates[control.id]
+    return VStack(alignment: .leading, spacing: 8) {
+      HStack(spacing: 8) {
+        TextField("Continue this session", text: $sessionSendText, axis: .vertical)
+          .lineLimit(1...4)
+          .textInputAutocapitalization(.sentences)
+          .autocorrectionDisabled(false)
+          .font(.subheadline)
+          .padding(10)
+          .background(Color.white.opacity(0.54), in: RoundedRectangle(cornerRadius: 8))
+          .accessibilityIdentifier("friday.session.send-input")
+        Button {
+          let text = sessionSendText
+          sessionSendText = ""
+          Task { await viewModel.send(text) }
+        } label: {
+          Image(systemName: control.systemImage)
+            .frame(width: 28, height: 28)
+        }
+        .buttonStyle(.borderedProminent)
+        .tint(MobileTheme.cyan)
+        .disabled(!control.isEnabled
+          || sessionSendText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+          || controlStateDisablesButton(state))
+        .accessibilityLabel("Send session continuation")
+        .accessibilityIdentifier("friday.session.send-button")
+      }
+      Text(control.reason)
+        .font(.caption2)
+        .foregroundStyle(MobileTheme.textSecondary)
+        .fixedSize(horizontal: false, vertical: true)
+      controlStateView(state)
     }
   }
 

--- a/apps/friday-ios/Sources/FridayMobileShellCore/SessionContinuationViewModel.swift
+++ b/apps/friday-ios/Sources/FridayMobileShellCore/SessionContinuationViewModel.swift
@@ -104,17 +104,20 @@ public final class SessionContinuationViewModel: ObservableObject {
 
   private let client: FridayRustReadClient
   private let writeClient: FridayRustWriteClient?
+  private let makeSessionWriteClient: ((String) -> FridayRustWriteClient)?
   private let signer: OperatorSigner?
   private let runControlEnabled: Bool
 
   public init(
     client: FridayRustReadClient,
     writeClient: FridayRustWriteClient? = nil,
+    makeSessionWriteClient: ((String) -> FridayRustWriteClient)? = nil,
     signer: OperatorSigner? = nil,
     runControlEnabled: Bool = false
   ) {
     self.client = client
     self.writeClient = writeClient
+    self.makeSessionWriteClient = makeSessionWriteClient
     self.signer = signer
     self.runControlEnabled = runControlEnabled
   }
@@ -175,9 +178,39 @@ public final class SessionContinuationViewModel: ObservableObject {
         runId: resolvedRunId,
         hasPendingApproval: pendingApproval != nil,
         hasWriteClient: writeClient != nil,
+        hasSessionWriteClient: makeSessionWriteClient != nil,
         hasSigner: signer != nil,
         runControlEnabled: runControlEnabled),
       pendingApproval: pendingApproval))
+  }
+
+  public func send(_ task: String) async {
+    guard case .loaded(let snapshot) = state else { return }
+    let trimmed = task.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty else { return }
+    guard let makeSessionWriteClient else {
+      controlStates["send"] = .error(reason: "Send requires the session-bound write seam.")
+      return
+    }
+
+    controlStates["send"] = .sending
+    let sessionClient = makeSessionWriteClient(snapshot.agentSessionId)
+    do {
+      let outcome = try await sessionClient.dispatchAgentRun(
+        task: trimmed,
+        constraints: AgentRunConstraintsWire(readOnly: true))
+      switch outcome {
+      case .result(let result):
+        controlStates["send"] = .succeeded(summary: Self.dispatchSummary(for: result))
+        await refresh(agentSessionId: snapshot.agentSessionId, runId: result.runId)
+        controlStates["send"] = .succeeded(summary: Self.dispatchSummary(for: result))
+      case .paused(let pause):
+        controlStates["send"] = .error(
+          reason: "Send paused for approval — run_id=\(pause.runId) approval_id=\(pause.approvalId)")
+      }
+    } catch {
+      controlStates["send"] = .error(reason: Self.writeReason(for: error, verb: "send"))
+    }
   }
 
   public func stop() async {
@@ -398,12 +431,20 @@ public final class SessionContinuationViewModel: ObservableObject {
     runId: String?,
     hasPendingApproval: Bool,
     hasWriteClient: Bool,
+    hasSessionWriteClient: Bool,
     hasSigner: Bool,
     runControlEnabled: Bool
   ) -> [SessionContinuationControl] {
+    let sendReady = hasSessionWriteClient
     let stopReady = runId != nil && hasWriteClient && runControlEnabled
     let resumeReady = hasPendingApproval && hasWriteClient && hasSigner && runControlEnabled
     let rejectReady = hasPendingApproval && hasWriteClient && runControlEnabled
+    let sendReason: String
+    if sendReady {
+      sendReason = "Session-bound read-only send is wired through the governed write seam."
+    } else {
+      sendReason = "Send requires the session-bound write seam."
+    }
     let stopReason: String
     if stopReady {
       stopReason = "Owner-authenticated cancel is wired through the governed write seam."
@@ -441,9 +482,9 @@ public final class SessionContinuationViewModel: ObservableObject {
         id: "send",
         title: "Send",
         systemImage: "paperplane",
-        truthLabel: "NO-GO",
-        reason: "Session send mutation is not built on mobile.",
-        isEnabled: false),
+        truthLabel: sendReady ? "guarded" : "NO-GO",
+        reason: sendReason,
+        isEnabled: sendReady),
       SessionContinuationControl(
         id: "stop",
         title: "Stop",
@@ -480,6 +521,17 @@ public final class SessionContinuationViewModel: ObservableObject {
     parts.append(result.accepted ? "accepted" : "refused")
     if let auditRef = result.auditRef, !auditRef.isEmpty {
       parts.append(auditRef)
+    }
+    return parts.joined(separator: " · ")
+  }
+
+  private nonisolated static func dispatchSummary(for result: AgentRunResultWire) -> String {
+    var parts = ["run: \(result.status)", "run_id=\(result.runId)"]
+    if let answerSha256 = result.answerSha256, !answerSha256.isEmpty {
+      parts.append("answer_sha=\(answerSha256)")
+    }
+    if let prompt = result.promptTokens, let completion = result.completionTokens {
+      parts.append("tokens=\(prompt + completion)")
     }
     return parts.joined(separator: " · ")
   }

--- a/apps/friday-ios/Tests/FridayMobileShellCoreTests/SessionContinuationViewModelTests.swift
+++ b/apps/friday-ios/Tests/FridayMobileShellCoreTests/SessionContinuationViewModelTests.swift
@@ -132,8 +132,15 @@ final class SessionContinuationViewModelTests: XCTestCase {
       case refused(ResumeRelayResult)
       case fail(FridayWriteClientError)
     }
+    enum DispatchScript {
+      case result(AgentRunDispatchOutcome)
+      case fail(FridayWriteClientError)
+    }
 
     let script: Script
+    let dispatchScript: DispatchScript?
+    private(set) var dispatchedTasks: [String] = []
+    private(set) var dispatchedConstraints: [AgentRunConstraintsWire?] = []
     private(set) var cancelledRunIds: [String] = []
     private(set) var cancelReasons: [String?] = []
     private(set) var resumedRunIds: [String] = []
@@ -141,20 +148,30 @@ final class SessionContinuationViewModelTests: XCTestCase {
     private(set) var rejectedRunIds: [String] = []
     private(set) var rejectedApprovalIds: [String] = []
 
-    init(_ script: Script = .accepted(ResumeRelayResult(
-      runId: "run-1",
-      op: "cancel",
-      accepted: true,
-      status: "cancelled",
-      auditRef: "audit://cancel/run-1"))) {
+    init(
+      _ script: Script = .accepted(ResumeRelayResult(
+        runId: "run-1",
+        op: "cancel",
+        accepted: true,
+        status: "cancelled",
+        auditRef: "audit://cancel/run-1")),
+      dispatchScript: DispatchScript? = nil
+    ) {
       self.script = script
+      self.dispatchScript = dispatchScript
     }
 
     func dispatchAgentRun(
       task: String,
       constraints: AgentRunConstraintsWire?
     ) async throws -> AgentRunDispatchOutcome {
-      throw FridayWriteClientError.transport("unused")
+      dispatchedTasks.append(task)
+      dispatchedConstraints.append(constraints)
+      guard let dispatchScript else { throw FridayWriteClientError.transport("unused") }
+      switch dispatchScript {
+      case .result(let outcome): return outcome
+      case .fail(let error): throw error
+      }
     }
 
     func resumeWithApproval(runId: String, opaqueSignedBlob: [UInt8]) async throws -> ResumeRelayResult {
@@ -188,6 +205,23 @@ final class SessionContinuationViewModelTests: XCTestCase {
       case .fail(let error):
         throw error
       }
+    }
+  }
+
+  final class SessionIdRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var values: [String] = []
+
+    func append(_ value: String) {
+      lock.lock()
+      values.append(value)
+      lock.unlock()
+    }
+
+    var recorded: [String] {
+      lock.lock()
+      defer { lock.unlock() }
+      return values
     }
   }
 
@@ -257,6 +291,90 @@ final class SessionContinuationViewModelTests: XCTestCase {
     XCTAssertEqual(stop?.truthLabel, "guarded")
     XCTAssertEqual(stop?.isEnabled, true)
     XCTAssertTrue(stop?.reason.contains("cancel") == true)
+  }
+
+  func testRefreshWithSessionWriteFactoryEnablesGuardedSend() async {
+    let client = FakeSessionReadClient()
+    let vm = SessionContinuationViewModel(
+      client: client,
+      makeSessionWriteClient: { _ in FakeSessionWriteClient() })
+
+    await vm.refresh(agentSessionId: "session-1", runId: "run-1")
+
+    guard case .loaded(let snapshot) = vm.state else {
+      return XCTFail("expected loaded session continuation, got \(vm.state)")
+    }
+    let send = snapshot.controls.first { $0.id == "send" }
+    XCTAssertEqual(send?.truthLabel, "guarded")
+    XCTAssertEqual(send?.isEnabled, true)
+    XCTAssertTrue(send?.reason.contains("Session-bound") == true)
+  }
+
+  func testSendDispatchesReadOnlySessionTurnAndRefreshesToReturnedRun() async {
+    let client = FakeSessionReadClient()
+    let write = FakeSessionWriteClient(dispatchScript: .result(.result(AgentRunResultWire(
+      runId: "run-2",
+      status: "completed",
+      answerSha256: "abc123",
+      promptTokens: 3,
+      completionTokens: 4))))
+    let requestedSessionIds = SessionIdRecorder()
+    let vm = SessionContinuationViewModel(
+      client: client,
+      makeSessionWriteClient: { sessionId in
+        requestedSessionIds.append(sessionId)
+        return write
+      })
+
+    await vm.refresh(agentSessionId: "session-1", runId: "run-1")
+    await vm.send(" continue the analysis ")
+
+    XCTAssertEqual(requestedSessionIds.recorded, ["session-1"])
+    XCTAssertEqual(write.dispatchedTasks, ["continue the analysis"])
+    XCTAssertEqual(write.dispatchedConstraints.map { $0?.readOnly }, [true])
+    XCTAssertTrue(client.requests.contains("run-readback:run-2"))
+    XCTAssertTrue(client.requests.contains("run-files:run-2"))
+    XCTAssertTrue(client.requests.contains("needs-me:run-2"))
+    XCTAssertEqual(
+      vm.controlStates["send"],
+      .succeeded(summary: "run: completed · run_id=run-2 · answer_sha=abc123 · tokens=7"))
+  }
+
+  func testSendBlankOrMissingSessionWriteSeamDoesNotDispatch() async {
+    let client = FakeSessionReadClient()
+    let write = FakeSessionWriteClient(dispatchScript: .result(.result(AgentRunResultWire(
+      runId: "run-blank",
+      status: "completed"))))
+    let blankVM = SessionContinuationViewModel(
+      client: client,
+      makeSessionWriteClient: { _ in write })
+    await blankVM.refresh(agentSessionId: "session-1", runId: "run-1")
+    await blankVM.send("   \n")
+    XCTAssertTrue(write.dispatchedTasks.isEmpty)
+    XCTAssertNil(blankVM.controlStates["send"])
+
+    let missingVM = SessionContinuationViewModel(client: client)
+    await missingVM.refresh(agentSessionId: "session-1", runId: "run-1")
+    await missingVM.send("continue")
+    XCTAssertEqual(
+      missingVM.controlStates["send"],
+      .error(reason: "Send requires the session-bound write seam."))
+  }
+
+  func testSendTransportFailureIsHonestUnavailable() async {
+    let write = FakeSessionWriteClient(dispatchScript: .fail(.transport("server dark")))
+    let vm = SessionContinuationViewModel(
+      client: FakeSessionReadClient(),
+      makeSessionWriteClient: { _ in write })
+
+    await vm.refresh(agentSessionId: "session-1", runId: "run-1")
+    await vm.send("continue")
+
+    XCTAssertEqual(write.dispatchedTasks, ["continue"])
+    guard case .error(let reason) = vm.controlStates["send"] else {
+      return XCTFail("expected send transport error, got \(String(describing: vm.controlStates["send"]))")
+    }
+    XCTAssertTrue(reason.contains("offline"), "reason: \(reason)")
   }
 
   func testRefreshParsesNeedsMeApprovalAndEnablesOperatorGatedResume() async {


### PR DESCRIPTION
## Summary
- add a session-bound Send composer to mobile Session Detail
- dispatch continuation turns through a write client built with the current agentSessionId as sessionId
- keep sends read-only by default and preserve honest-unavailable behavior when live write is gated off/dark

## Validation
- swift test --package-path apps/friday-ios
- bash apps/friday-ios/build-sim.sh
- git diff --check
- detect-secrets-hook --baseline /Users/jarvis/Projects/Friday/.secrets.baseline apps/friday-ios/Sources/FridayMobileShellCore/SessionContinuationViewModel.swift apps/friday-ios/Sources/FridayMobileShell/FridayApp.swift apps/friday-ios/Sources/FridayMobileShell/FridaySessionDetailScreen.swift apps/friday-ios/Tests/FridayMobileShellCoreTests/SessionContinuationViewModelTests.swift

Truth: enables a real session-bound read-only continuation send path in the mobile Session Detail surface; not END-BAR, not GO-LIVE by itself, and still fails honestly when the live write seam is not enabled.