### PR TITLE
Surface mobile token ledger facts

### DIFF
--- a/apps/friday-ios/Sources/FridayMobileShell/FridayTokenLedgerScreen.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayTokenLedgerScreen.swift
@@ -128,12 +128,20 @@ struct FridayTokenLedgerScreen: View {
     case .loaded(let detail):
       GlassPanel {
         VStack(alignment: .leading, spacing: MobileTheme.rowSpacing) {
-          cardHeader(detail.title, count: detail.refs.count)
+          cardHeader(detail.title, count: detail.facts.isEmpty ? detail.refs.count : detail.facts.count)
           Text(detail.summary)
             .font(.caption)
             .foregroundStyle(MobileTheme.textPrimary)
             .fixedSize(horizontal: false, vertical: true)
           RefPill(label: "generated", ref: generatedText(detail.generatedAtMs))
+          if !detail.facts.isEmpty {
+            VStack(spacing: 8) {
+              ForEach(detail.facts) { fact in
+                factRow(fact)
+              }
+            }
+            .accessibilityIdentifier("friday.token-ledger.facts")
+          }
           ForEach(detail.refs, id: \.self) { ref in
             RefPill(label: nil, ref: ref)
           }
@@ -151,6 +159,24 @@ struct FridayTokenLedgerScreen: View {
         }
       }
     }
+  }
+
+  private func factRow(_ fact: HomeReadDetailFact) -> some View {
+    HStack(spacing: 10) {
+      Text(fact.label)
+        .font(.caption)
+        .foregroundStyle(MobileTheme.textSecondary)
+        .frame(width: 92, alignment: .leading)
+      Text(fact.value)
+        .font(.caption.monospacedDigit())
+        .foregroundStyle(MobileTheme.textPrimary)
+        .lineLimit(2)
+        .minimumScaleFactor(0.8)
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+    .padding(.horizontal, 10)
+    .padding(.vertical, 8)
+    .background(MobileTheme.chipNeutralBG, in: RoundedRectangle(cornerRadius: 8, style: .continuous))
   }
 
   private func cardHeader(_ title: String, count: Int?) -> some View {

--- a/apps/friday-ios/Sources/FridayMobileShellCore/HomeViewModel.swift
+++ b/apps/friday-ios/Sources/FridayMobileShellCore/HomeViewModel.swift
@@ -436,6 +436,7 @@ public struct HomeReadDetail: Sendable, Equatable {
   public let generatedAtMs: Int64
   public let summary: String
   public let refs: [String]
+  public let facts: [HomeReadDetailFact]
   public let providerReadiness: HomeProviderReadinessDetail?
 
   public init(title: String, snapshot: ReadProjectionSnapshot) {
@@ -444,6 +445,7 @@ public struct HomeReadDetail: Sendable, Equatable {
     self.generatedAtMs = snapshot.generatedAtMs
     self.summary = Self.summary(from: raw)
     self.refs = Self.refs(from: raw)
+    self.facts = Self.facts(from: raw)
     self.providerReadiness = HomeProviderReadinessDetail(raw: raw)
   }
 
@@ -471,8 +473,63 @@ public struct HomeReadDetail: Sendable, Equatable {
   }
 
   private static func firstString(_ raw: [String: Any], _ keys: [String]) -> String? {
-    keys.lazy.compactMap { raw[$0] as? String }.first
+    keys.lazy.compactMap {
+      guard let value = raw[$0] as? String else { return nil }
+      let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+      return trimmed.isEmpty ? nil : trimmed
+    }.first
   }
+
+  private static func facts(from raw: [String: Any]) -> [HomeReadDetailFact] {
+    var facts: [HomeReadDetailFact] = []
+    func append(_ id: String, _ label: String, _ value: String?) {
+      guard let value, !value.isEmpty else { return }
+      facts.append(HomeReadDetailFact(id: id, label: label, value: value))
+    }
+    append("run-id", "run", firstString(raw, ["runId", "run_id"]))
+    append("state", "state", firstString(raw, ["run_state", "runState", "status"]))
+    append("loop", "loop", firstString(raw, ["loop_status_derived", "loopStatusDerived"]))
+    append("events", "events", valueText(raw, ["event_count", "eventCount"]))
+    append("db-wide-tokens", "db tokens", valueText(raw, ["db_wide_token_total", "dbWideTokenTotal"]))
+    append("prompt-tokens", "prompt", valueText(raw, ["prompt_tokens", "promptTokens"]))
+    append("completion-tokens", "completion", valueText(raw, ["completion_tokens", "completionTokens"]))
+    append("total-tokens", "total", valueText(raw, ["total_tokens", "totalTokens"]))
+    let costKeys = ["cost_usd", "costUsd", "estimated_cost_usd", "estimatedCostUsd"]
+    append("cost", "cost", firstString(raw, costKeys) ?? valueText(raw, costKeys))
+    append("audit", "audit", boolText(raw, ["audit_chain_verified", "auditChainVerified"]))
+    return facts
+  }
+
+  private static func valueText(_ raw: [String: Any], _ keys: [String]) -> String? {
+    for key in keys {
+      if let value = raw[key] as? String {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !trimmed.isEmpty { return trimmed }
+      }
+      if let value = raw[key] as? Int { return "\(value)" }
+      if let value = raw[key] as? Int64 { return "\(value)" }
+      if let value = raw[key] as? UInt64 { return "\(value)" }
+      if let value = raw[key] as? NSNumber, CFGetTypeID(value) != CFBooleanGetTypeID() {
+        return value.stringValue
+      }
+    }
+    return nil
+  }
+
+  private static func boolText(_ raw: [String: Any], _ keys: [String]) -> String? {
+    for key in keys {
+      if let value = raw[key] as? Bool {
+        return value ? "verified" : "unverified"
+      }
+    }
+    return nil
+  }
+}
+
+public struct HomeReadDetailFact: Sendable, Equatable, Identifiable {
+  public let id: String
+  public let label: String
+  public let value: String
 }
 
 public struct HomeProviderReadinessDetail: Sendable, Equatable {

--- a/apps/friday-ios/Tests/FridayMobileShellCoreTests/HomeViewModelTests.swift
+++ b/apps/friday-ios/Tests/FridayMobileShellCoreTests/HomeViewModelTests.swift
@@ -130,7 +130,22 @@ final class HomeViewModelTests: XCTestCase {
 
     func fetchRunReadback(runId: String) async throws -> ReadProjectionSnapshot {
       requestedDetails.append("run:\(runId)")
-      return try detailSnapshot(kind: "run", status: "complete", runId: runId, proofRef: "proof://run/\(runId)")
+      return try detailSnapshot(
+        kind: "run",
+        status: "complete",
+        runId: runId,
+        proofRef: "proof://run/\(runId)",
+        extra: [
+          "run_state": "complete",
+          "loop_status_derived": "complete",
+          "event_count": 7,
+          "db_wide_token_total": 321,
+          "prompt_tokens": 120,
+          "completion_tokens": 201,
+          "total_tokens": 321,
+          "cost_usd": "0.0456",
+          "audit_chain_verified": true,
+        ])
     }
 
     func fetchRunFileView(runId: String) async throws -> ReadProjectionSnapshot {
@@ -527,6 +542,22 @@ final class HomeViewModelTests: XCTestCase {
     let client = FakeReadClient(.snapshot(try sampleSnapshot()))
     let vm = HomeViewModel(client: client)
     await vm.loadDetail(.runReadback(runId: "run-1"))
+    guard case let .loaded(runDetail) = vm.detailState else {
+      return XCTFail("expected run detail .loaded, got \(vm.detailState)")
+    }
+    XCTAssertEqual(runDetail.title, "Run readback")
+    XCTAssertEqual(runDetail.facts, [
+      HomeReadDetailFact(id: "run-id", label: "run", value: "run-1"),
+      HomeReadDetailFact(id: "state", label: "state", value: "complete"),
+      HomeReadDetailFact(id: "loop", label: "loop", value: "complete"),
+      HomeReadDetailFact(id: "events", label: "events", value: "7"),
+      HomeReadDetailFact(id: "db-wide-tokens", label: "db tokens", value: "321"),
+      HomeReadDetailFact(id: "prompt-tokens", label: "prompt", value: "120"),
+      HomeReadDetailFact(id: "completion-tokens", label: "completion", value: "201"),
+      HomeReadDetailFact(id: "total-tokens", label: "total", value: "321"),
+      HomeReadDetailFact(id: "cost", label: "cost", value: "0.0456"),
+      HomeReadDetailFact(id: "audit", label: "audit", value: "verified"),
+    ])
     await vm.loadDetail(.activityNeedsMe(runId: "run-1"))
     XCTAssertEqual(client.requestedDetails, ["run:run-1", "needs-me:run-1"])
     guard case let .loaded(detail) = vm.detailState else {


### PR DESCRIPTION
## Summary
- parse run readback facts on mobile for run state, loop status, events, token totals, cost, and audit verification
- render those facts in the iOS Token Ledger surface instead of only showing refs
- align the mobile detail facts with the existing desktop readback fact pattern

## Validation
- swift test --package-path apps/friday-ios --filter HomeViewModelTests
- swift test --package-path apps/friday-ios
- npm run check:ios-t2-surface-contract
- git diff --check
- detect-secrets-hook --baseline /Users/jarvis/Projects/Friday/.secrets.baseline apps/friday-ios/Sources/FridayMobileShellCore/HomeViewModel.swift apps/friday-ios/Sources/FridayMobileShell/FridayTokenLedgerScreen.swift apps/friday-ios/Tests/FridayMobileShellCoreTests/HomeViewModelTests.swift

Truth: surfaces owner-gated run readback facts already returned by the read arm. It does not fabricate spend, does not claim END-BAR, and remains dependent on the live read projection.