### PR TITLE
Add desktop live roundtrip proof events

### DIFF
--- a/apps/macos/FridayHubConsole/Tests/FridayHubConsoleCoreTests/LiveWriteReadProjectionRoundTripIntegrationTests.swift
+++ b/apps/macos/FridayHubConsole/Tests/FridayHubConsoleCoreTests/LiveWriteReadProjectionRoundTripIntegrationTests.swift
@@ -20,7 +20,8 @@ private let liveWriteReadRoundTripEnabled =
 
 @Test(.enabled(if: liveWriteReadRoundTripEnabled))
 func liveDesktopMissionWriteAppearsInReadProjection() async throws {
-  let writeClient = try RealWriteClientFactory.makeLiveWrite()
+  let writeConfig = AgentRunWriteServerConfig.liveLoopback
+  let writeClient = try RealWriteClientFactory.makeLiveWrite(config: writeConfig)
   let request = makeDesktopRoundTripIntake()
 
   let result = try await writeClient.submitMissionIntake(request)
@@ -29,7 +30,8 @@ func liveDesktopMissionWriteAppearsInReadProjection() async throws {
   #expect(result.missionId == request.missionId)
   #expect(result.workItemId == request.workItemId)
 
-  let readClient = try RealReadClientFactory.makeLive(missionId: result.missionId)
+  let readConfig = ReadProjectionServerConfig.liveLoopback
+  let readClient = try RealReadClientFactory.makeLive(config: readConfig, missionId: result.missionId)
   let snapshot = try await pollReadProjection(
     client: readClient,
     missionId: result.missionId,
@@ -40,6 +42,13 @@ func liveDesktopMissionWriteAppearsInReadProjection() async throws {
       + "workItemIds=\(snapshot.workItemIds) generatedAtMs=\(snapshot.generatedAtMs)")
   #expect(snapshot.missionId == result.missionId)
   #expect(snapshot.workItemIds.contains(request.workItemId))
+
+  try writeRoundTripProofIfRequested(
+    request: request,
+    result: result,
+    snapshot: snapshot,
+    writeConfig: writeConfig,
+    readConfig: readConfig)
 }
 
 private func makeDesktopRoundTripIntake() -> MissionIntakeRequestWire {
@@ -84,4 +93,60 @@ private func pollReadProjection(
   } while Date() < deadline
 
   throw try #require(lastError)
+}
+
+private func writeRoundTripProofIfRequested(
+  request: MissionIntakeRequestWire,
+  result: MissionIntakeResultWire,
+  snapshot: FridayRustClient.WorkbenchSnapshot,
+  writeConfig: AgentRunWriteServerConfig,
+  readConfig: ReadProjectionServerConfig
+) throws {
+  guard let rawPath = ProcessInfo.processInfo.environment[
+    "FRIDAY_DESKTOP_LIVE_WRITE_READ_ROUNDTRIP_PROOF_OUT"
+  ]?.trimmingCharacters(in: .whitespacesAndNewlines), !rawPath.isEmpty else {
+    return
+  }
+  guard let workItemId = result.workItemId else {
+    throw FridayReadClientError.malformedProjection("desktop roundtrip proof missing WorkItem id")
+  }
+
+  let proof: [String: Any] = [
+    "truth_label": "macos_desktop_live_write_read_roundtrip_proof_not_ui_device_proof",
+    "status": "pass",
+    "generated_at_utc": ISO8601DateFormatter().string(from: Date()),
+    "mission_id": result.missionId,
+    "work_item_id": workItemId,
+    "surface_kind": request.surfaceKind,
+    "delivery_route": request.deliveryRoute,
+    "write": [
+      "status": result.status,
+      "created_or_ready": result.createdOrReady,
+      "mission_id": result.missionId,
+      "work_item_id": workItemId,
+      "endpoint": [
+        "host": writeConfig.host,
+        "port": Int(writeConfig.port),
+      ],
+    ],
+    "read_projection": [
+      "mission_id": snapshot.missionId,
+      "work_item_ids": snapshot.workItemIds,
+      "contains_written_work_item": snapshot.workItemIds.contains(workItemId),
+      "generated_at_ms": snapshot.generatedAtMs,
+      "endpoint": [
+        "host": readConfig.host,
+        "port": Int(readConfig.port),
+      ],
+    ],
+    "caveat": "Desktop live write-read artifact only; not END-BAR, not GO-LIVE, not UI/device proof.",
+  ]
+
+  let data = try JSONSerialization.data(withJSONObject: proof, options: [.prettyPrinted, .sortedKeys])
+  let url = URL(fileURLWithPath: rawPath)
+  try FileManager.default.createDirectory(
+    at: url.deletingLastPathComponent(),
+    withIntermediateDirectories: true)
+  try data.write(to: url, options: .atomic)
+  print("[live-write-read][desktop] proofOut=\(url.path)")
 }

--- a/scripts/ops/friday-macos-live-write-read-proof-events.mjs
+++ b/scripts/ops/friday-macos-live-write-read-proof-events.mjs
@@ -1,0 +1,156 @@
+#!/usr/bin/env node
+
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, isAbsolute, resolve } from "node:path";
+
+const args = process.argv.slice(2);
+
+function usage() {
+  console.error(`usage:
+  node scripts/ops/friday-macos-live-write-read-proof-events.mjs \\
+    --proof=/abs/friday-macos-desktop-roundtrip-proof.json \\
+    [--out=/abs/desktop-roundtrip-events.jsonl] [--require-ready]
+
+Truth: converts one real macOS live write-read roundtrip artifact into desktop
+same-run events for the UI/device capture pipeline. It is not END-BAR proof,
+does not invent mobile/channel/timeline observations, and never reads secrets.`);
+}
+
+function arg(name) {
+  const prefix = `--${name}=`;
+  return args.find((value) => value.startsWith(prefix))?.slice(prefix.length) || "";
+}
+
+if (args.includes("--help") || args.includes("-h")) {
+  usage();
+  process.exit(0);
+}
+
+const proofPath = arg("proof");
+const outPath = arg("out");
+const requireReady = args.includes("--require-ready");
+const blockers = [];
+
+function block(code, detail) {
+  blockers.push({ code, detail });
+}
+
+function abs(path) {
+  return isAbsolute(path) ? path : resolve(path);
+}
+
+function readJson(path) {
+  try {
+    return JSON.parse(readFileSync(path, "utf8"));
+  } catch {
+    block("proof_unreadable_or_invalid_json", path || "<missing>");
+    return null;
+  }
+}
+
+function stringField(value, field, label) {
+  if (value && typeof value[field] === "string" && value[field].trim()) return value[field].trim();
+  block("proof_missing_string", `${label}.${field}`);
+  return "";
+}
+
+function booleanField(value, field, label) {
+  if (value && typeof value[field] === "boolean") return value[field];
+  block("proof_missing_boolean", `${label}.${field}`);
+  return false;
+}
+
+function arrayField(value, field, label) {
+  if (value && Array.isArray(value[field])) return value[field];
+  block("proof_missing_array", `${label}.${field}`);
+  return [];
+}
+
+if (!proofPath) block("missing_arg", "proof");
+const proof = proofPath ? readJson(abs(proofPath)) : null;
+const evidenceRef = proofPath ? abs(proofPath) : "";
+
+if (proof) {
+  const serialized = JSON.stringify(proof);
+  if (/(bearer|authorization|passphrase|secret|api[_-]?key)/i.test(serialized)) {
+    block("proof_contains_sensitive_marker", "roundtrip proof must be redacted");
+  }
+}
+
+const truthLabel = proof ? stringField(proof, "truth_label", "proof") : "";
+if (truthLabel && truthLabel !== "macos_desktop_live_write_read_roundtrip_proof_not_ui_device_proof") {
+  block("proof_truth_label_unexpected", truthLabel);
+}
+
+const status = proof ? stringField(proof, "status", "proof") : "";
+if (status && status !== "pass") block("proof_status_not_pass", status);
+
+const missionId = proof ? stringField(proof, "mission_id", "proof") : "";
+const workItemId = proof ? stringField(proof, "work_item_id", "proof") : "";
+const surfaceKind = proof ? stringField(proof, "surface_kind", "proof") : "";
+if (missionId && !missionId.toLowerCase().includes("mission")) {
+  block("mission_id_unexpected_shape", missionId);
+}
+if (surfaceKind && surfaceKind !== "desktop") block("surface_kind_not_desktop", surfaceKind);
+
+const write = proof?.write ?? null;
+const writeStatus = stringField(write, "status", "proof.write");
+if (writeStatus && writeStatus !== "ready") block("write_status_not_ready", writeStatus);
+if (!booleanField(write, "created_or_ready", "proof.write")) {
+  block("write_created_or_ready_false", "proof.write.created_or_ready");
+}
+if (write && write.mission_id !== missionId) block("write_mission_mismatch", String(write.mission_id ?? ""));
+if (write && write.work_item_id !== workItemId) block("write_work_item_mismatch", String(write.work_item_id ?? ""));
+
+const readProjection = proof?.read_projection ?? null;
+if (readProjection && readProjection.mission_id !== missionId) {
+  block("read_projection_mission_mismatch", String(readProjection.mission_id ?? ""));
+}
+const projectedWorkItems = arrayField(readProjection, "work_item_ids", "proof.read_projection");
+if (!projectedWorkItems.includes(workItemId)) block("read_projection_missing_work_item", workItemId);
+if (!booleanField(readProjection, "contains_written_work_item", "proof.read_projection")) {
+  block("read_projection_contains_written_work_item_false", workItemId);
+}
+
+const eventNames = [
+  "mission_intake_submitted",
+  "mission_intake_ready",
+  "mission_bound_provider_action_visible",
+  "proof_receipt_visible_before_done",
+  "same_mission_projection_visible",
+];
+const events = blockers.length === 0
+  ? eventNames.map((event) => ({
+    surface: "desktop",
+    event,
+    mission_id: missionId,
+    evidence_ref: evidenceRef,
+    work_item_id: workItemId,
+    source: "macos_desktop_live_write_read_roundtrip_artifact",
+    truth_label: "desktop_same_run_event_from_live_write_read_artifact_not_ui_device_proof",
+  }))
+  : [];
+
+if (outPath && blockers.length === 0) {
+  const out = abs(outPath);
+  mkdirSync(dirname(out), { recursive: true });
+  writeFileSync(out, `${events.map((event) => JSON.stringify(event)).join("\n")}\n`);
+}
+
+const output = {
+  truth: "macos_desktop_live_write_read_events_driver_not_ui_device_proof",
+  status: blockers.length === 0 ? "ready" : "blocked",
+  missionId: missionId || null,
+  workItemId: workItemId || null,
+  evidenceRef: evidenceRef || null,
+  out: outPath ? abs(outPath) : null,
+  eventCount: events.length,
+  blockers,
+  caveat: "Desktop same-run events only; combine with real mobile/channel/timeline evidence before strict UI/device proof.",
+};
+
+console.log(JSON.stringify(output, null, 2));
+if (!outPath && blockers.length === 0) {
+  process.stdout.write(`${events.map((event) => JSON.stringify(event)).join("\n")}\n`);
+}
+process.exit(blockers.length === 0 || !requireReady ? 0 : 2);

--- a/test/unit/qa/friday-macos-live-write-read-proof-events-cli.test.ts
+++ b/test/unit/qa/friday-macos-live-write-read-proof-events-cli.test.ts
@@ -1,0 +1,134 @@
+import { execFileSync, spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const script = "scripts/ops/friday-macos-live-write-read-proof-events.mjs";
+const missionId = "mission-desktop-live-roundtrip-cli";
+const workItemId = "work-desktop-live-roundtrip-cli";
+
+function proof(overrides: Record<string, unknown> = {}) {
+  return {
+    truth_label: "macos_desktop_live_write_read_roundtrip_proof_not_ui_device_proof",
+    status: "pass",
+    generated_at_utc: "2026-06-24T10:00:00Z",
+    mission_id: missionId,
+    work_item_id: workItemId,
+    surface_kind: "desktop",
+    delivery_route: "desktop://hub-console/live-write-read-roundtrip/cli",
+    write: {
+      status: "ready",
+      created_or_ready: true,
+      mission_id: missionId,
+      work_item_id: workItemId,
+      endpoint: { host: "127.0.0.1", port: 48750 },
+    },
+    read_projection: {
+      mission_id: missionId,
+      work_item_ids: [workItemId],
+      contains_written_work_item: true,
+      generated_at_ms: 1782290000000,
+      endpoint: { host: "127.0.0.1", port: 48751 },
+    },
+    caveat: "Desktop live write-read artifact only; not END-BAR, not GO-LIVE, not UI/device proof.",
+    ...overrides,
+  };
+}
+
+function writeProof(tempDir: string, value = proof()) {
+  const path = join(tempDir, "desktop-roundtrip-proof.json");
+  writeFileSync(path, JSON.stringify(value, null, 2));
+  return path;
+}
+
+describe("friday-macos-live-write-read-proof-events", () => {
+  it("converts a redacted desktop write-read artifact into same-run desktop events", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "friday-macos-roundtrip-events-"));
+    try {
+      const proofPath = writeProof(tempDir);
+      const outPath = join(tempDir, "events.jsonl");
+      const stdout = execFileSync("node", [
+        script,
+        `--proof=${proofPath}`,
+        `--out=${outPath}`,
+        "--require-ready",
+      ], { cwd: process.cwd(), encoding: "utf8" });
+
+      const result = JSON.parse(stdout) as { status?: string; eventCount?: number; blockers?: unknown[] };
+      expect(result.status).toBe("ready");
+      expect(result.eventCount).toBe(5);
+      expect(result.blockers).toEqual([]);
+
+      const rows = readFileSync(outPath, "utf8").trim().split("\n").map((line) => JSON.parse(line)) as Array<{
+        surface?: string;
+        event?: string;
+        mission_id?: string;
+        evidence_ref?: string;
+        work_item_id?: string;
+      }>;
+      expect(rows.map((row) => row.event)).toEqual([
+        "mission_intake_submitted",
+        "mission_intake_ready",
+        "mission_bound_provider_action_visible",
+        "proof_receipt_visible_before_done",
+        "same_mission_projection_visible",
+      ]);
+      expect(new Set(rows.map((row) => row.surface))).toEqual(new Set(["desktop"]));
+      expect(new Set(rows.map((row) => row.mission_id))).toEqual(new Set([missionId]));
+      expect(new Set(rows.map((row) => row.work_item_id))).toEqual(new Set([workItemId]));
+      expect(new Set(rows.map((row) => row.evidence_ref))).toEqual(new Set([proofPath]));
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("blocks artifacts whose read projection does not contain the written WorkItem", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "friday-macos-roundtrip-events-blocked-"));
+    try {
+      const proofPath = writeProof(tempDir, proof({
+        read_projection: {
+          mission_id: missionId,
+          work_item_ids: ["work-other"],
+          contains_written_work_item: false,
+          generated_at_ms: 1782290000000,
+          endpoint: { host: "127.0.0.1", port: 48751 },
+        },
+      }));
+      const outPath = join(tempDir, "events.jsonl");
+      const result = spawnSync("node", [
+        script,
+        `--proof=${proofPath}`,
+        `--out=${outPath}`,
+        "--require-ready",
+      ], { cwd: process.cwd(), encoding: "utf8" });
+
+      expect(result.status).toBe(2);
+      const output = JSON.parse(result.stdout) as { status?: string; blockers?: Array<{ code?: string }> };
+      expect(output.status).toBe("blocked");
+      expect(output.blockers?.map((blocker) => blocker.code)).toContain("read_projection_missing_work_item");
+      expect(output.blockers?.map((blocker) => blocker.code)).toContain("read_projection_contains_written_work_item_false");
+      expect(() => readFileSync(outPath, "utf8")).toThrow();
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects sensitive-looking artifact payloads", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "friday-macos-roundtrip-events-sensitive-"));
+    try {
+      const proofPath = writeProof(tempDir, proof({ authorization: "Bearer nope" }));
+      const result = spawnSync("node", [
+        script,
+        `--proof=${proofPath}`,
+        "--require-ready",
+      ], { cwd: process.cwd(), encoding: "utf8" });
+
+      expect(result.status).toBe(2);
+      const output = JSON.parse(result.stdout) as { blockers?: Array<{ code?: string }> };
+      expect(output.blockers?.map((blocker) => blocker.code)).toContain("proof_contains_sensitive_marker");
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- make the env-gated macOS live write→read projection test optionally emit a redacted roundtrip proof artifact
- add a desktop proof-events CLI that converts that artifact into same-run evidence rows for the UI/device pipeline
- cover valid, missing-work-item, and sensitive-marker cases with Vitest

## Validation
- swift test --package-path apps/macos/FridayHubConsole --filter LiveWriteReadProjectionRoundTrip
- swift test --package-path apps/macos/FridayHubConsole
- npx vitest run test/unit/qa/friday-macos-live-write-read-proof-events-cli.test.ts
- git diff --check origin/main..HEAD
- detect-secrets-hook --baseline .secrets.baseline apps/macos/FridayHubConsole/Tests/FridayHubConsoleCoreTests/LiveWriteReadProjectionRoundTripIntegrationTests.swift scripts/ops/friday-macos-live-write-read-proof-events.mjs test/unit/qa/friday-macos-live-write-read-proof-events-cli.test.ts

Truth: adds a desktop same-run proof-events driver from a real macOS live write→read artifact. It does not claim UI/device proof, END-BAR, GO-LIVE, adoption, or operator signing completion.