### PR TITLE
Add iOS live write-read capture runner

### DIFF
--- a/scripts/ops/friday-ios-live-write-read-capture.sh
+++ b/scripts/ops/friday-ios-live-write-read-capture.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat >&2 <<'EOF'
+usage:
+  scripts/ops/friday-ios-live-write-read-capture.sh --out-dir /abs/capture-dir
+    [--read-host 127.0.0.1] [--read-port 48751]
+    [--write-host 127.0.0.1] [--write-port 48750]
+
+Runs the env-gated iOS live write->read projection proof, converts the redacted
+artifact into mobile same-run proof events, and writes a capture index.
+
+Truth: this writes a real mobile live write-read proof only when the Swift live
+test succeeds. It does not claim desktop/channel/timeline proof, END-BAR,
+GO-LIVE, adoption, or operator signing completion.
+EOF
+}
+
+die() {
+  echo "FATAL: $*" >&2
+  exit 2
+}
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+out_dir=""
+read_host="${FRIDAY_MOBILE_LIVE_READ_HOST:-127.0.0.1}"
+read_port="${FRIDAY_MOBILE_LIVE_READ_PORT:-48751}"
+write_host="${FRIDAY_MOBILE_LIVE_WRITE_HOST:-127.0.0.1}"
+write_port="${FRIDAY_MOBILE_LIVE_WRITE_PORT:-48750}"
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --out-dir)
+      [ "$#" -ge 2 ] || die "--out-dir requires a value"
+      out_dir="$2"
+      shift 2
+      ;;
+    --out-dir=*)
+      out_dir="${1#--out-dir=}"
+      shift
+      ;;
+    --read-host)
+      [ "$#" -ge 2 ] || die "--read-host requires a value"
+      read_host="$2"
+      shift 2
+      ;;
+    --read-host=*)
+      read_host="${1#--read-host=}"
+      shift
+      ;;
+    --read-port)
+      [ "$#" -ge 2 ] || die "--read-port requires a value"
+      read_port="$2"
+      shift 2
+      ;;
+    --read-port=*)
+      read_port="${1#--read-port=}"
+      shift
+      ;;
+    --write-host)
+      [ "$#" -ge 2 ] || die "--write-host requires a value"
+      write_host="$2"
+      shift 2
+      ;;
+    --write-host=*)
+      write_host="${1#--write-host=}"
+      shift
+      ;;
+    --write-port)
+      [ "$#" -ge 2 ] || die "--write-port requires a value"
+      write_port="$2"
+      shift 2
+      ;;
+    --write-port=*)
+      write_port="${1#--write-port=}"
+      shift
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      die "unknown argument: $1"
+      ;;
+  esac
+done
+
+[ -n "${out_dir}" ] || die "missing --out-dir"
+case "${out_dir}" in
+  /*) ;;
+  *) die "--out-dir must be absolute" ;;
+esac
+case "${read_port}" in (*[!0-9]*|"") die "--read-port must be numeric" ;; esac
+case "${write_port}" in (*[!0-9]*|"") die "--write-port must be numeric" ;; esac
+
+mkdir -p "${out_dir}"
+proof_path="${out_dir}/ios-live-write-read-proof.json"
+events_path="${out_dir}/ios-live-write-read-events.jsonl"
+index_path="${out_dir}/capture-index.json"
+
+echo "Friday iOS live write-read capture starting."
+echo "out_dir=${out_dir}"
+echo "read=${read_host}:${read_port}"
+echo "write=${write_host}:${write_port}"
+echo "truth=ios_live_write_read_capture_runner_not_ui_device_proof"
+
+(
+  cd "${repo_root}"
+  FRIDAY_MOBILE_LIVE_WRITE_READ_ROUNDTRIP_TEST=1 \
+  FRIDAY_MOBILE_LIVE_WRITE_READ_ROUNDTRIP_PROOF_OUT="${proof_path}" \
+  FRIDAY_MOBILE_LIVE_READ_HOST="${read_host}" \
+  FRIDAY_MOBILE_LIVE_READ_PORT="${read_port}" \
+  FRIDAY_MOBILE_LIVE_WRITE_HOST="${write_host}" \
+  FRIDAY_MOBILE_LIVE_WRITE_PORT="${write_port}" \
+    swift test --package-path apps/friday-ios --filter LiveWriteReadProjectionRoundTrip
+)
+
+[ -s "${proof_path}" ] || die "Swift live write-read proof did not create ${proof_path}"
+
+node "${repo_root}/scripts/ops/friday-ios-live-write-read-proof-events.mjs" \
+  --proof="${proof_path}" \
+  --out="${events_path}" \
+  --require-ready >/tmp/friday-ios-live-write-read-proof-events.$$.json
+
+[ -s "${events_path}" ] || die "proof-events driver did not create ${events_path}"
+
+node - "${proof_path}" "${events_path}" "${index_path}" <<'NODE'
+const { readFileSync, writeFileSync } = require("node:fs");
+const { createHash } = require("node:crypto");
+
+const [proofPath, eventsPath, indexPath] = process.argv.slice(2);
+const proof = JSON.parse(readFileSync(proofPath, "utf8"));
+const events = readFileSync(eventsPath, "utf8")
+  .trim()
+  .split("\n")
+  .filter(Boolean)
+  .map((line) => JSON.parse(line));
+const sha256 = (path) => createHash("sha256").update(readFileSync(path)).digest("hex");
+
+const index = {
+  truth_label: "ios_live_write_read_capture_index_not_ui_device_proof",
+  status: "ready",
+  generated_at_utc: new Date().toISOString(),
+  mission_id: proof.mission_id,
+  work_item_id: proof.work_item_id,
+  mobile: {
+    proof: proofPath,
+    proof_sha256: sha256(proofPath),
+    events: eventsPath,
+    events_sha256: sha256(eventsPath),
+    event_count: events.length,
+  },
+  blockers: [],
+  caveat: "Mobile same-run capture only; still requires desktop/channel/timeline evidence before strict UI/device proof.",
+};
+
+writeFileSync(indexPath, `${JSON.stringify(index, null, 2)}\n`);
+NODE
+
+echo "PASS - mobile live write-read proof, same-run events, and capture index written."
+echo "proof=${proof_path}"
+echo "events=${events_path}"
+echo "index=${index_path}"
+echo "Truth: mobile-only proof input; not END-BAR / not GO-LIVE / not adoption."

--- a/test/unit/qa/friday-ios-live-write-read-capture-cli.test.ts
+++ b/test/unit/qa/friday-ios-live-write-read-capture-cli.test.ts
@@ -1,0 +1,120 @@
+import { execFileSync, spawnSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const script = "scripts/ops/friday-ios-live-write-read-capture.sh";
+const missionId = "mission-mobile-live-roundtrip-wrapper";
+const workItemId = "work-mobile-live-roundtrip-wrapper";
+
+function fakeSwiftScript(dir: string, proofStatus = "pass") {
+  const bin = join(dir, "bin");
+  mkdirSync(bin, { recursive: true });
+  const path = join(bin, "swift");
+  writeFileSync(path, `#!/usr/bin/env bash
+set -euo pipefail
+[ "$1" = "test" ] || exit 42
+[ -n "\${FRIDAY_MOBILE_LIVE_WRITE_READ_ROUNDTRIP_PROOF_OUT:-}" ] || exit 43
+cat >"\${FRIDAY_MOBILE_LIVE_WRITE_READ_ROUNDTRIP_PROOF_OUT}" <<'JSON'
+{
+  "truth_label": "ios_mobile_live_write_read_roundtrip_proof_not_ui_device_proof",
+  "status": "${proofStatus}",
+  "generated_at_utc": "2026-06-24T12:00:00Z",
+  "mission_id": "${missionId}",
+  "work_item_id": "${workItemId}",
+  "surface_kind": "mobile",
+  "delivery_route": "ios://friday-mobile/live-write-read-roundtrip/wrapper",
+  "write": {
+    "status": "ready",
+    "created_or_ready": true,
+    "mission_id": "${missionId}",
+    "work_item_id": "${workItemId}",
+    "endpoint": { "host": "127.0.0.1", "port": 48750 }
+  },
+  "read_projection": {
+    "mission_id": "${missionId}",
+    "work_item_ids": ["${workItemId}"],
+    "contains_written_work_item": true,
+    "generated_at_ms": 1782290000000,
+    "endpoint": { "host": "127.0.0.1", "port": 59151 }
+  },
+  "caveat": "Mobile live write-read artifact only; not END-BAR, not GO-LIVE, not UI/device proof."
+}
+JSON
+`, { mode: 0o755 });
+  return bin;
+}
+
+describe("friday-ios-live-write-read-capture", () => {
+  it("runs the live proof command, derives mobile events, and writes a capture index", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "friday-ios-live-capture-"));
+    try {
+      const outDir = join(tempDir, "capture");
+      const fakeBin = fakeSwiftScript(tempDir);
+      const stdout = execFileSync("bash", [script, `--out-dir=${outDir}`, "--read-port=59151"], {
+        cwd: process.cwd(),
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          PATH: `${fakeBin}:${process.env.PATH ?? ""}`,
+        },
+      });
+
+      expect(stdout).toContain("PASS - mobile live write-read proof");
+      const proof = JSON.parse(readFileSync(join(outDir, "ios-live-write-read-proof.json"), "utf8")) as {
+        mission_id?: string;
+      };
+      expect(proof.mission_id).toBe(missionId);
+
+      const events = readFileSync(join(outDir, "ios-live-write-read-events.jsonl"), "utf8")
+        .trim()
+        .split("\n")
+        .map((line) => JSON.parse(line)) as Array<{ surface?: string; mission_id?: string }>;
+      expect(events).toHaveLength(5);
+      expect(new Set(events.map((event) => event.surface))).toEqual(new Set(["mobile"]));
+      expect(new Set(events.map((event) => event.mission_id))).toEqual(new Set([missionId]));
+
+      const index = JSON.parse(readFileSync(join(outDir, "capture-index.json"), "utf8")) as {
+        status?: string;
+        mobile?: { event_count?: number };
+        caveat?: string;
+      };
+      expect(index.status).toBe("ready");
+      expect(index.mobile?.event_count).toBe(5);
+      expect(index.caveat).toContain("Mobile same-run capture only");
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("fails closed when the proof-events driver refuses the artifact", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "friday-ios-live-capture-blocked-"));
+    try {
+      const outDir = join(tempDir, "capture");
+      const fakeBin = fakeSwiftScript(tempDir, "blocked");
+      const result = spawnSync("bash", [script, `--out-dir=${outDir}`], {
+        cwd: process.cwd(),
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          PATH: `${fakeBin}:${process.env.PATH ?? ""}`,
+        },
+      });
+
+      expect(result.status).not.toBe(0);
+      expect(result.stderr + result.stdout).not.toContain("PASS - mobile live write-read proof");
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("requires an absolute output directory", () => {
+    const result = spawnSync("bash", [script, "--out-dir=relative"], {
+      cwd: process.cwd(),
+      encoding: "utf8",
+    });
+    expect(result.status).toBe(2);
+    expect(result.stderr).toContain("--out-dir must be absolute");
+  });
+});


### PR DESCRIPTION
## Summary
- add a governed iOS live write→read capture runner that executes the env-gated Swift proof and writes a redacted artifact
- convert that artifact into mobile same-run proof events and a capture index for the UI/device evidence pipeline
- cover success, fail-closed artifact refusal, and absolute output directory enforcement with Vitest

## Validation
- bash -n scripts/ops/friday-ios-live-write-read-capture.sh
- npx vitest run test/unit/qa/friday-ios-live-write-read-capture-cli.test.ts
- git diff --check origin/main..HEAD
- detect-secrets-hook --baseline .secrets.baseline scripts/ops/friday-ios-live-write-read-capture.sh test/unit/qa/friday-ios-live-write-read-capture-cli.test.ts

Truth: mobile same-run capture runner only. It does not create desktop/channel/timeline evidence and does not claim END-BAR, GO-LIVE, adoption, or operator signing completion.