### PR TITLE
Add desktop live write-read capture runner

### DIFF
--- a/scripts/ops/friday-macos-live-write-read-capture.sh
+++ b/scripts/ops/friday-macos-live-write-read-capture.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat >&2 <<'EOF'
+usage:
+  scripts/ops/friday-macos-live-write-read-capture.sh --out-dir /abs/capture-dir
+
+Runs the env-gated macOS live write->read projection proof, converts the
+redacted artifact into desktop same-run proof events, and writes a capture
+index.
+
+Truth: this writes a real desktop live write-read proof only when the Swift live
+test succeeds. It does not claim mobile/channel/timeline proof, END-BAR,
+GO-LIVE, adoption, or operator signing completion.
+EOF
+}
+
+die() {
+  echo "FATAL: $*" >&2
+  exit 2
+}
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+out_dir=""
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --out-dir)
+      [ "$#" -ge 2 ] || die "--out-dir requires a value"
+      out_dir="$2"
+      shift 2
+      ;;
+    --out-dir=*)
+      out_dir="${1#--out-dir=}"
+      shift
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      die "unknown argument: $1"
+      ;;
+  esac
+done
+
+[ -n "${out_dir}" ] || die "missing --out-dir"
+case "${out_dir}" in
+  /*) ;;
+  *) die "--out-dir must be absolute" ;;
+esac
+
+mkdir -p "${out_dir}"
+proof_path="${out_dir}/macos-live-write-read-proof.json"
+events_path="${out_dir}/macos-live-write-read-events.jsonl"
+index_path="${out_dir}/capture-index.json"
+
+echo "Friday macOS live write-read capture starting."
+echo "out_dir=${out_dir}"
+echo "truth=macos_live_write_read_capture_runner_not_ui_device_proof"
+
+(
+  cd "${repo_root}"
+  FRIDAY_CONSOLE_LIVE_WRITE_READ_ROUNDTRIP_TEST=1 \
+  FRIDAY_DESKTOP_LIVE_WRITE_READ_ROUNDTRIP_PROOF_OUT="${proof_path}" \
+    swift test --package-path apps/macos/FridayHubConsole --filter LiveWriteReadProjectionRoundTrip
+)
+
+[ -s "${proof_path}" ] || die "Swift live write-read proof did not create ${proof_path}"
+
+node "${repo_root}/scripts/ops/friday-macos-live-write-read-proof-events.mjs" \
+  --proof="${proof_path}" \
+  --out="${events_path}" \
+  --require-ready >/tmp/friday-macos-live-write-read-proof-events.$$.json
+
+[ -s "${events_path}" ] || die "proof-events driver did not create ${events_path}"
+
+node - "${proof_path}" "${events_path}" "${index_path}" <<'NODE'
+const { readFileSync, writeFileSync } = require("node:fs");
+const { createHash } = require("node:crypto");
+
+const [proofPath, eventsPath, indexPath] = process.argv.slice(2);
+const proof = JSON.parse(readFileSync(proofPath, "utf8"));
+const events = readFileSync(eventsPath, "utf8")
+  .trim()
+  .split("\n")
+  .filter(Boolean)
+  .map((line) => JSON.parse(line));
+const sha256 = (path) => createHash("sha256").update(readFileSync(path)).digest("hex");
+
+const index = {
+  truth_label: "macos_live_write_read_capture_index_not_ui_device_proof",
+  status: "ready",
+  generated_at_utc: new Date().toISOString(),
+  mission_id: proof.mission_id,
+  work_item_id: proof.work_item_id,
+  desktop: {
+    proof: proofPath,
+    proof_sha256: sha256(proofPath),
+    events: eventsPath,
+    events_sha256: sha256(eventsPath),
+    event_count: events.length,
+  },
+  blockers: [],
+  caveat: "Desktop same-run capture only; still requires mobile/channel/timeline evidence before strict UI/device proof.",
+};
+
+writeFileSync(indexPath, `${JSON.stringify(index, null, 2)}\n`);
+NODE
+
+echo "PASS - desktop live write-read proof, same-run events, and capture index written."
+echo "proof=${proof_path}"
+echo "events=${events_path}"
+echo "index=${index_path}"
+echo "Truth: desktop-only proof input; not END-BAR / not GO-LIVE / not adoption."

--- a/test/unit/qa/friday-macos-live-write-read-capture-cli.test.ts
+++ b/test/unit/qa/friday-macos-live-write-read-capture-cli.test.ts
@@ -1,0 +1,120 @@
+import { execFileSync, spawnSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const script = "scripts/ops/friday-macos-live-write-read-capture.sh";
+const missionId = "mission-desktop-live-roundtrip-wrapper";
+const workItemId = "work-desktop-live-roundtrip-wrapper";
+
+function fakeSwiftScript(dir: string, proofStatus = "pass") {
+  const bin = join(dir, "bin");
+  mkdirSync(bin, { recursive: true });
+  const path = join(bin, "swift");
+  writeFileSync(path, `#!/usr/bin/env bash
+set -euo pipefail
+[ "$1" = "test" ] || exit 42
+[ -n "\${FRIDAY_DESKTOP_LIVE_WRITE_READ_ROUNDTRIP_PROOF_OUT:-}" ] || exit 43
+cat >"\${FRIDAY_DESKTOP_LIVE_WRITE_READ_ROUNDTRIP_PROOF_OUT}" <<'JSON'
+{
+  "truth_label": "macos_desktop_live_write_read_roundtrip_proof_not_ui_device_proof",
+  "status": "${proofStatus}",
+  "generated_at_utc": "2026-06-24T12:00:00Z",
+  "mission_id": "${missionId}",
+  "work_item_id": "${workItemId}",
+  "surface_kind": "desktop",
+  "delivery_route": "desktop://hub-console/live-write-read-roundtrip/wrapper",
+  "write": {
+    "status": "ready",
+    "created_or_ready": true,
+    "mission_id": "${missionId}",
+    "work_item_id": "${workItemId}",
+    "endpoint": { "host": "127.0.0.1", "port": 48750 }
+  },
+  "read_projection": {
+    "mission_id": "${missionId}",
+    "work_item_ids": ["${workItemId}"],
+    "contains_written_work_item": true,
+    "generated_at_ms": 1782290000000,
+    "endpoint": { "host": "127.0.0.1", "port": 48751 }
+  },
+  "caveat": "Desktop live write-read artifact only; not END-BAR, not GO-LIVE, not UI/device proof."
+}
+JSON
+`, { mode: 0o755 });
+  return bin;
+}
+
+describe("friday-macos-live-write-read-capture", () => {
+  it("runs the live proof command, derives desktop events, and writes a capture index", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "friday-macos-live-capture-"));
+    try {
+      const outDir = join(tempDir, "capture");
+      const fakeBin = fakeSwiftScript(tempDir);
+      const stdout = execFileSync("bash", [script, `--out-dir=${outDir}`], {
+        cwd: process.cwd(),
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          PATH: `${fakeBin}:${process.env.PATH ?? ""}`,
+        },
+      });
+
+      expect(stdout).toContain("PASS - desktop live write-read proof");
+      const proof = JSON.parse(readFileSync(join(outDir, "macos-live-write-read-proof.json"), "utf8")) as {
+        mission_id?: string;
+      };
+      expect(proof.mission_id).toBe(missionId);
+
+      const events = readFileSync(join(outDir, "macos-live-write-read-events.jsonl"), "utf8")
+        .trim()
+        .split("\n")
+        .map((line) => JSON.parse(line)) as Array<{ surface?: string; mission_id?: string }>;
+      expect(events).toHaveLength(5);
+      expect(new Set(events.map((event) => event.surface))).toEqual(new Set(["desktop"]));
+      expect(new Set(events.map((event) => event.mission_id))).toEqual(new Set([missionId]));
+
+      const index = JSON.parse(readFileSync(join(outDir, "capture-index.json"), "utf8")) as {
+        status?: string;
+        desktop?: { event_count?: number };
+        caveat?: string;
+      };
+      expect(index.status).toBe("ready");
+      expect(index.desktop?.event_count).toBe(5);
+      expect(index.caveat).toContain("Desktop same-run capture only");
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("fails closed when the proof-events driver refuses the artifact", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "friday-macos-live-capture-blocked-"));
+    try {
+      const outDir = join(tempDir, "capture");
+      const fakeBin = fakeSwiftScript(tempDir, "blocked");
+      const result = spawnSync("bash", [script, `--out-dir=${outDir}`], {
+        cwd: process.cwd(),
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          PATH: `${fakeBin}:${process.env.PATH ?? ""}`,
+        },
+      });
+
+      expect(result.status).not.toBe(0);
+      expect(result.stderr + result.stdout).not.toContain("PASS - desktop live write-read proof");
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("requires an absolute output directory", () => {
+    const result = spawnSync("bash", [script, "--out-dir=relative"], {
+      cwd: process.cwd(),
+      encoding: "utf8",
+    });
+    expect(result.status).toBe(2);
+    expect(result.stderr).toContain("--out-dir must be absolute");
+  });
+});


### PR DESCRIPTION
## Summary
- add a governed macOS live write→read capture runner that executes the env-gated Swift proof and writes a redacted artifact
- convert that artifact into desktop same-run proof events and a capture index for the UI/device evidence pipeline
- cover success, fail-closed artifact refusal, and absolute output directory enforcement with Vitest

## Validation
- bash -n scripts/ops/friday-macos-live-write-read-capture.sh
- npx vitest run test/unit/qa/friday-macos-live-write-read-capture-cli.test.ts
- git diff --check origin/main..HEAD
- detect-secrets-hook --baseline .secrets.baseline scripts/ops/friday-macos-live-write-read-capture.sh test/unit/qa/friday-macos-live-write-read-capture-cli.test.ts

Truth: desktop same-run capture runner only. It does not create mobile/channel/timeline evidence and does not claim END-BAR, GO-LIVE, adoption, or operator signing completion.