### PR TITLE
Wire UI device gap report into readiness

### DIFF
--- a/scripts/ops/friday-ui-device-proof-readiness.sh
+++ b/scripts/ops/friday-ui-device-proof-readiness.sh
@@ -45,6 +45,7 @@ evidence-dir auto-discovery:
     channel.{json,trace,log,png}
     timeline.{json,trace,log,png}
     observations-manifest.json or ui-observations-manifest.json
+    same-run-events.normalized.jsonl or same-run-events.jsonl for gap reporting
 
 truth:
   Default report-only mode never writes MISSION_SPINE_UI_DEVICE_PROOF and is not END-BAR proof.
@@ -158,6 +159,12 @@ discover_evidence_dir() {
   if [ -z "${TIMELINE_EVIDENCE:-}" ]; then
     TIMELINE_EVIDENCE="$(first_existing "$dir/timeline.json" "$dir/timeline.trace" "$dir/timeline.log" "$dir/timeline.png" || true)"
   fi
+  if [ -z "${SAME_RUN_EVENTS:-}" ]; then
+    SAME_RUN_EVENTS="$(first_existing \
+      "$dir/same-run-events.normalized.jsonl" \
+      "$dir/same-run-events.jsonl" \
+      "$dir/events.jsonl" || true)"
+  fi
 }
 
 json_escape() {
@@ -173,6 +180,7 @@ export DESKTOP_EVIDENCE="${DESKTOP_EVIDENCE:-}"
 export CHANNEL_EVIDENCE="${CHANNEL_EVIDENCE:-}"
 export TIMELINE_EVIDENCE="${TIMELINE_EVIDENCE:-}"
 export OBSERVATIONS_MANIFEST="${OBSERVATIONS_MANIFEST:-}"
+export SAME_RUN_EVENTS="${SAME_RUN_EVENTS:-}"
 
 have_all_evidence=1
 for name in MISSION_ID MOBILE_EVIDENCE DESKTOP_EVIDENCE CHANNEL_EVIDENCE TIMELINE_EVIDENCE OBSERVATIONS_MANIFEST; do
@@ -192,6 +200,9 @@ for name in MISSION_ID MOBILE_EVIDENCE DESKTOP_EVIDENCE CHANNEL_EVIDENCE TIMELIN
     notes+=("resolved_${name}:${!name}")
   fi
 done
+if [ -n "${SAME_RUN_EVENTS:-}" ]; then
+  notes+=("resolved_SAME_RUN_EVENTS:${SAME_RUN_EVENTS}")
+fi
 
 run_step() {
   local label="$1"
@@ -214,6 +225,48 @@ run_note_step() {
     local rc=$?
     notes+=("${label}:exit_${rc}")
     return 0
+  fi
+}
+
+run_gap_report_if_possible() {
+  if [ -z "${MISSION_ID:-}" ] || [ -z "${MOBILE_EVIDENCE:-}" ] || [ -z "${DESKTOP_EVIDENCE:-}" ] || [ -z "${CHANNEL_EVIDENCE:-}" ] || [ -z "${TIMELINE_EVIDENCE:-}" ] || [ -z "${SAME_RUN_EVENTS:-}" ]; then
+    return 0
+  fi
+
+  local gap_out
+  local stdout_out
+  local status
+  if [ -n "$EVIDENCE_DIR" ]; then
+    gap_out="$(abs_path "$EVIDENCE_DIR")/gap-report.json"
+  else
+    gap_out="/tmp/friday-ui-device-proof-gap-report-${MISSION_ID}.json"
+  fi
+  stdout_out="${gap_out}.stdout"
+
+  local args=(
+    "${REPO_ROOT}/scripts/ops/friday-ui-device-proof-gap-report.mjs"
+    "--mission-id=${MISSION_ID}"
+    "--events=${SAME_RUN_EVENTS}"
+    "--mobile=${MOBILE_EVIDENCE}"
+    "--desktop=${DESKTOP_EVIDENCE}"
+    "--channel=${CHANNEL_EVIDENCE}"
+    "--timeline=${TIMELINE_EVIDENCE}"
+    "--out=${gap_out}"
+  )
+  if [ -n "${OBSERVATIONS_MANIFEST:-}" ]; then
+    args+=("--manifest=${OBSERVATIONS_MANIFEST}")
+  fi
+
+  mkdir -p "$(dirname "$gap_out")"
+  if node "${args[@]}" >"$stdout_out"; then
+    status="$(jq -r '.status // "unknown"' "$gap_out" 2>/dev/null || printf 'unknown')"
+    notes+=("ui_device_gap_report:${status}:${gap_out}")
+    if [ "$status" != "complete_inputs_observed" ] && [ "${MODE}" = "require-proof" ]; then
+      blockers+=("ui_device_gap_report:${status}")
+    fi
+  else
+    local rc=$?
+    blockers+=("ui_device_gap_report:exit_${rc}")
   fi
 }
 
@@ -268,6 +321,8 @@ if [ "${have_all_evidence}" = "1" ]; then
 else
   blockers+=("ui_device_proof_evidence:missing_required_real_evidence_env")
 fi
+
+run_gap_report_if_possible
 
 if [ "${MODE}" = "require-proof" ]; then
   printf 'FATAL: UI/device proof not assembled. blockers=%s\n' "${blockers[*]}" >&2

--- a/test/unit/qa/friday-ui-device-proof-readiness-cli.test.ts
+++ b/test/unit/qa/friday-ui-device-proof-readiness-cli.test.ts
@@ -29,6 +29,35 @@ function writeEvidenceDir(tempDir: string) {
   return files;
 }
 
+function writePartialEvidenceDir(tempDir: string) {
+  const files = {
+    mobile: join(tempDir, "mobile.json"),
+    desktop: join(tempDir, "desktop.json"),
+    channel: join(tempDir, "channel.json"),
+    timeline: join(tempDir, "timeline.json"),
+    events: join(tempDir, "same-run-events.jsonl"),
+  };
+
+  writeFileSync(join(tempDir, "mission-id.txt"), `${missionId}\n`);
+  for (const [role, filePath] of Object.entries({
+    mobile: files.mobile,
+    desktop: files.desktop,
+    channel: files.channel,
+    timeline: files.timeline,
+  })) {
+    writeFileSync(filePath, JSON.stringify({ role, mission_id: missionId, capture: "redacted partial qa input" }));
+  }
+  const rows = [
+    observation("mobile", "mission_intake_submitted", files.mobile),
+    observation("mobile", "mission_intake_ready", files.mobile),
+    observation("mobile", "mission_bound_provider_action_visible", files.mobile),
+    observation("mobile", "proof_receipt_visible_before_done", files.mobile),
+    observation("desktop", "same_mission_projection_visible", files.desktop),
+  ];
+  writeFileSync(files.events, `${rows.map((row) => JSON.stringify(row)).join("\n")}\n`);
+  return files;
+}
+
 function observation(surface: string, event: string, evidenceRef: string) {
   return { surface, event, mission_id: missionId, evidence_ref: evidenceRef };
 }
@@ -201,6 +230,48 @@ describe("friday-ui-device-proof-readiness", () => {
       expect(result.truth).toBe("report_only_not_ui_device_proof");
       expect(result.status).toBe("blocked");
       expect(result.blockers).toContain("ui_device_proof_evidence:missing_required_real_evidence_env");
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("writes a gap report from discovered same-run events without treating it as proof", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "friday-ui-device-readiness-gap-"));
+    try {
+      writePartialEvidenceDir(tempDir);
+
+      const stdout = execFileSync("bash", [
+        "scripts/ops/friday-ui-device-proof-readiness.sh",
+        "--evidence-dir",
+        tempDir,
+      ], {
+        cwd: process.cwd(),
+        encoding: "utf8",
+      });
+      const result = JSON.parse(stdout.slice(stdout.indexOf("{"))) as {
+        truth?: string;
+        status?: string;
+        notes?: string[];
+        blockers?: string[];
+      };
+
+      expect(result.truth).toBe("report_only_not_ui_device_proof");
+      expect(result.status).toBe("blocked");
+      expect(result.blockers).toContain("ui_device_proof_evidence:missing_required_real_evidence_env");
+      expect(result.notes?.some((note) => note.includes("ui_device_gap_report:gaps_present"))).toBe(true);
+
+      const gapReport = JSON.parse(readFileSync(join(tempDir, "gap-report.json"), "utf8")) as {
+        truth?: string;
+        status?: string;
+        gaps?: { missingObservations?: Array<{ surface?: string; event?: string }> };
+      };
+      expect(gapReport.truth).toBe("ui_device_proof_gap_report_not_proof");
+      expect(gapReport.status).toBe("gaps_present");
+      expect(gapReport.gaps?.missingObservations).toContainEqual({
+        surface: "channel",
+        event: "same_mission_projection_visible",
+        preferredCapture: "channel",
+      });
     } finally {
       rmSync(tempDir, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary
- auto-discover same-run events from UI/device evidence directories
- run the UI/device proof gap report from the readiness wrapper when enough partial evidence exists
- keep gap output diagnostic only: proof assembly still requires the existing strict evidence + manifest gate

## Validation
- bash -n scripts/ops/friday-ui-device-proof-readiness.sh
- npx vitest run test/unit/qa/friday-ui-device-proof-readiness-cli.test.ts test/unit/qa/friday-ui-device-proof-gap-report-cli.test.ts
- git diff --check origin/main..HEAD
- detect-secrets-hook --baseline .secrets.baseline scripts/ops/friday-ui-device-proof-readiness.sh test/unit/qa/friday-ui-device-proof-readiness-cli.test.ts

Truth: readiness diagnostics only. This does not assemble proof from gaps, does not synthesize observations, and does not claim END-BAR, GO-LIVE, adoption, or operator signing completion.