### PR TITLE
Add workbench snapshot event bridge

### DIFF
--- a/scripts/ops/friday-workbench-snapshot-events.mjs
+++ b/scripts/ops/friday-workbench-snapshot-events.mjs
@@ -1,0 +1,280 @@
+#!/usr/bin/env node
+
+import { spawnSync } from "node:child_process";
+import { mkdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { dirname, isAbsolute, resolve } from "node:path";
+
+const args = process.argv.slice(2);
+
+function usage() {
+  console.error(`usage:
+  node scripts/ops/friday-workbench-snapshot-events.mjs \\
+    --mission-id=mission_... \\
+    --file=/abs/workbench-snapshot.json \\
+    --mobile=/abs/mobile-capture \\
+    --desktop=/abs/desktop-capture \\
+    --channel=/abs/channel-capture \\
+    --timeline=/abs/timeline-capture \\
+    --out=/abs/workbench-derived-events.jsonl
+
+Options:
+  --url=http://127.0.0.1:3141/v1/mission-spine/workbench
+  --require-ready
+
+Truth: this bridges a preflight-passing Mission Workbench snapshot into
+diagnostic UI/device event rows. It does not write proof, does not synthesize
+missing stress/security/network observations, and does not mark END-BAR.`);
+}
+
+function arg(name) {
+  const prefix = `--${name}=`;
+  return args.find((value) => value.startsWith(prefix))?.slice(prefix.length) || "";
+}
+
+if (args.includes("--help") || args.includes("-h")) {
+  usage();
+  process.exit(0);
+}
+
+const requireReady = args.includes("--require-ready");
+const missionId = arg("mission-id") || process.env.MISSION_ID || "";
+const sourceFile = arg("file") || process.env.MISSION_WORKBENCH_SNAPSHOT_FILE || "";
+const sourceUrl = arg("url") || process.env.MISSION_WORKBENCH_SNAPSHOT_URL || "";
+const outPath = arg("out");
+const evidenceArgs = {
+  mobile: arg("mobile"),
+  desktop: arg("desktop"),
+  channel: arg("channel"),
+  timeline: arg("timeline"),
+};
+const blockers = [];
+
+function block(code, detail) {
+  blockers.push({ code, detail });
+}
+
+function abs(path) {
+  return isAbsolute(path) ? path : resolve(path);
+}
+
+function requireFile(label, path) {
+  if (!path) {
+    block("missing_arg", label);
+    return "";
+  }
+  const resolved = abs(path);
+  try {
+    const stats = statSync(resolved);
+    if (!stats.isFile()) block("not_file", `${label}:${resolved}`);
+    if (stats.size <= 0) block("empty_file", `${label}:${resolved}`);
+  } catch {
+    block("unreadable_file", `${label}:${resolved}`);
+  }
+  return resolved;
+}
+
+function readJson(path) {
+  try {
+    return JSON.parse(readFileSync(abs(path), "utf8"));
+  } catch {
+    block("source_unreadable_or_invalid_json", abs(path));
+    return null;
+  }
+}
+
+async function readJsonFromUrl(url) {
+  const headers = {};
+  if (process.env.FRIDAY_API_BEARER) {
+    headers.Authorization = `Bearer ${process.env.FRIDAY_API_BEARER}`;
+  }
+  let response;
+  try {
+    response = await fetch(url, { headers });
+  } catch {
+    block("source_url_fetch_failed", url);
+    return null;
+  }
+  const text = await response.text();
+  if (!response.ok) {
+    block("source_url_response_not_ok", String(response.status));
+    return null;
+  }
+  try {
+    return JSON.parse(text);
+  } catch {
+    block("source_url_invalid_json", url);
+    return null;
+  }
+}
+
+function object(value) {
+  return value && typeof value === "object" && !Array.isArray(value) ? value : {};
+}
+
+function array(value) {
+  return Array.isArray(value) ? value : [];
+}
+
+function unwrapSnapshot(payload) {
+  const root = object(payload);
+  const data = object(root.data);
+  return object(data.snapshot || root.snapshot || root);
+}
+
+function runPreflight() {
+  if (sourceFile && sourceUrl) {
+    block("multiple_sources", "choose --file or --url, not both");
+    return null;
+  }
+  if (!sourceFile && !sourceUrl) {
+    block("missing_source", "--file or --url");
+    return null;
+  }
+  const preflightArgs = [
+    "scripts/qa/check-mission-workbench-snapshot-contract.mjs",
+    sourceFile ? `--file=${sourceFile}` : `--url=${sourceUrl}`,
+  ];
+  if (missionId) preflightArgs.push(`--mission-id=${missionId}`);
+  const result = spawnSync(process.execPath, preflightArgs, {
+    cwd: process.cwd(),
+    encoding: "utf8",
+  });
+  let parsed = null;
+  try {
+    parsed = JSON.parse(result.stdout || "{}");
+  } catch {
+    block("preflight_output_invalid_json", result.stderr || "no stdout");
+  }
+  if (result.status !== 0 || parsed?.readyForLiveCaptureInput !== true) {
+    block("snapshot_preflight_not_ready", JSON.stringify(parsed?.failures || []));
+  }
+  return parsed;
+}
+
+function collectTranscriptEvents(snapshot) {
+  return array(snapshot.transcriptSections)
+    .flatMap((section) => array(object(section).events).map((event) => object(event)));
+}
+
+function hasTranscriptSurface(events, surface) {
+  return events.some((event) => event.surface === surface);
+}
+
+function hasWorkItem(snapshot, state, done) {
+  return array(snapshot.workItems).some((item) => {
+    const workItem = object(item);
+    return workItem.state === state && workItem.done === done;
+  });
+}
+
+function hasCompletedProof(snapshot) {
+  return array(snapshot.workItems).some((item) => {
+    const workItem = object(item);
+    return workItem.state === "completed_with_proof" && workItem.done === true && typeof workItem.proofRef === "string";
+  });
+}
+
+function firstCapturedAt(events) {
+  return events.find((event) => typeof event.capturedAt === "string" && event.capturedAt.trim())?.capturedAt
+    || new Date().toISOString();
+}
+
+function makeRows(snapshot, evidence) {
+  const rows = [];
+  const transcriptEvents = collectTranscriptEvents(snapshot);
+  const capturedAt = firstCapturedAt(transcriptEvents);
+  const add = (surface, event, evidenceRef, source) => {
+    rows.push({
+      surface,
+      event,
+      mission_id: missionId,
+      evidence_ref: evidenceRef,
+      truth_label: "derived_from_preflighted_workbench_snapshot_not_final_proof",
+      source,
+      captured_at: capturedAt,
+    });
+  };
+
+  if (hasTranscriptSurface(transcriptEvents, "mobile")) {
+    add("mobile", "mission_intake_submitted", evidence.mobile, "transcript_surface:mobile");
+    add("mobile", "mission_intake_ready", evidence.mobile, "transcript_surface:mobile");
+  }
+  if (object(snapshot.duplicatePreflight).status === "opens_existing_mission") {
+    add("mobile", "duplicate_preflight_visible", evidence.mobile, "duplicate_preflight");
+    add("desktop", "duplicate_preflight_visible", evidence.desktop, "duplicate_preflight");
+    add("desktop", "duplicate_blocked_opens_existing", evidence.desktop, "duplicate_preflight");
+  }
+  if (hasWorkItem(snapshot, "provider_ack", false)) {
+    add("mobile", "mission_bound_provider_action_visible", evidence.mobile, "work_item:provider_ack");
+    add("desktop", "provider_ack_not_done_visible", evidence.desktop, "work_item:provider_ack");
+  }
+  if (hasCompletedProof(snapshot)) {
+    add("desktop", "real_provider_execution_visible", evidence.desktop, "work_item:completed_with_proof");
+    add("desktop", "real_provider_execution_receipt_visible", evidence.desktop, "work_item:completed_with_proof");
+    add("mobile", "proof_receipt_visible_before_done", evidence.mobile, "work_item:completed_with_proof");
+  }
+  if (hasTranscriptSurface(transcriptEvents, "desktop")) {
+    add("desktop", "same_mission_projection_visible", evidence.desktop, "transcript_surface:desktop");
+    add("desktop", "mission_workbench_visible", evidence.desktop, "transcript_surface:desktop");
+    add("desktop", "transcript_browser_visible", evidence.desktop, "transcript_surface:desktop");
+  }
+  if (hasTranscriptSurface(transcriptEvents, "telegram") || array(snapshot.channelReceiptRefs).length > 0) {
+    add("channel", "same_mission_projection_visible", evidence.channel, "channel_receipt_refs");
+  }
+  if (array(snapshot.timelinePages).some((page) => object(page).page === 1)) {
+    add("timeline", "bounded_page_1_visible", evidence.timeline, "timeline_page:1");
+  }
+  if (array(snapshot.timelinePages).some((page) => object(page).page === 2)) {
+    add("timeline", "bounded_page_2_visible", evidence.timeline, "timeline_page:2");
+  }
+  if (array(snapshot.memoryCandidates).some((candidate) => object(candidate).state === "candidate_review_only")) {
+    add("timeline", "memory_candidate_review_only", evidence.timeline, "memory_candidate:review_only");
+  }
+  const statusLabels = new Set(array(snapshot.statusLabels));
+  if (statusLabels.has("stale")) add("desktop", "stale_label_visible", evidence.desktop, "status_label:stale");
+  if (statusLabels.has("offline")) add("desktop", "offline_label_visible", evidence.desktop, "status_label:offline");
+  if (statusLabels.has("error")) add("desktop", "error_label_visible", evidence.desktop, "status_label:error");
+  if (
+    hasTranscriptSurface(transcriptEvents, "mobile")
+    && hasTranscriptSurface(transcriptEvents, "desktop")
+    && (hasTranscriptSurface(transcriptEvents, "telegram") || array(snapshot.channelReceiptRefs).length > 0)
+  ) {
+    add("*", "same_mission_mobile_desktop_channel_visible", evidence.desktop, "transcript_surfaces:mobile_desktop_channel");
+  }
+  return rows;
+}
+
+if (!missionId || !/^[A-Za-z0-9][A-Za-z0-9._:-]*$/.test(missionId) || !missionId.toLowerCase().includes("mission")) {
+  block("mission_id_unexpected_shape", missionId || "<missing>");
+}
+if (!outPath) block("missing_arg", "out");
+
+const evidence = Object.fromEntries(
+  Object.entries(evidenceArgs).map(([role, path]) => [role, requireFile(role, path)]),
+);
+const preflight = runPreflight();
+const payload = sourceFile ? readJson(sourceFile) : sourceUrl ? await readJsonFromUrl(sourceUrl) : null;
+const snapshot = payload ? unwrapSnapshot(payload) : {};
+
+const rows = blockers.length === 0 ? makeRows(snapshot, evidence) : [];
+if (rows.length === 0 && blockers.length === 0) block("no_derivable_events", "snapshot produced no diagnostic rows");
+
+if (blockers.length === 0) {
+  const out = abs(outPath);
+  mkdirSync(dirname(out), { recursive: true });
+  writeFileSync(out, `${rows.map((row) => JSON.stringify(row)).join("\n")}\n`);
+}
+
+const output = {
+  truth: "workbench_snapshot_events_bridge_diagnostic_not_proof",
+  status: blockers.length === 0 ? "ready" : "blocked",
+  missionId: missionId || null,
+  out: outPath ? abs(outPath) : null,
+  derivedEvents: rows.length,
+  preflightReady: preflight?.readyForLiveCaptureInput === true,
+  blockers,
+  caveat: "Diagnostic bridge only. Stress/security/network/device observations still require real same-run capture before final proof.",
+};
+
+console.log(JSON.stringify(output, null, 2));
+process.exit(blockers.length === 0 || !requireReady ? 0 : 2);

--- a/test/unit/qa/friday-workbench-snapshot-events-cli.test.ts
+++ b/test/unit/qa/friday-workbench-snapshot-events-cli.test.ts
@@ -1,0 +1,220 @@
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+function makeSnapshot(overrides: Record<string, unknown> = {}) {
+  const missionId = "mission_workbench_events_bridge";
+  return {
+    missionId,
+    fridayConversationId: "conversation_workbench_events_bridge",
+    runtimeFeedStatus: "live_rust_hub_projection",
+    statusLabels: ["stale", "offline", "error"],
+    duplicatePreflight: {
+      status: "opens_existing_mission",
+      duplicateMissionId: missionId,
+      duplicateWorkItemId: "work_provider",
+    },
+    routeDecision: {
+      advisorSummary: "Rust Hub route decision projection.",
+      selectedRoute: "route_decision_ref",
+      controlRef: `friday://route-decision-projection/${missionId}/work_provider/1700000000000`,
+      workItemId: "work_provider",
+      alternatives: ["alternate_ref"],
+      actionItems: [
+        {
+          description: "Implement Mission Spine domain types",
+          targetKind: "file",
+          targetRef: "rust-core/crates/friday-core/src/lib.rs",
+          reversibility: "operator_gate_required",
+          assignedLane: "codex",
+          assignedProviderOrAgent: "codex",
+          routeReason: "Rust Hub must own product truth before UI wiring",
+        },
+      ],
+      truthLabel: "friday_owned",
+    },
+    providerReceiptRefs: ["proof://provider/receipt/redacted"],
+    channelReceiptRefs: ["proof://channel/receipt/redacted"],
+    workItems: [
+      {
+        id: "work_provider",
+        title: "Mission-bound provider action",
+        state: "provider_ack",
+        owner: "friday_owned",
+        proofRef: "proof://provider/ack/not-completion",
+        done: false,
+        blockingReason: "provider or hub execution is still in flight; cancel is the only exposed recovery action",
+        recoveryKind: "in_flight",
+        canRetry: false,
+        canCancel: true,
+      },
+      {
+        id: "work_timeline",
+        title: "Bounded timeline read",
+        state: "timeline_read",
+        owner: "friday_owned",
+        proofRef: "proof://timeline/page-2/cursor",
+        done: false,
+        blockingReason: "bounded timeline read only; no WorkItem recovery action applies",
+        recoveryKind: "none",
+        canRetry: false,
+        canCancel: false,
+      },
+      {
+        id: "work_completed",
+        title: "Completed only after proof receipt",
+        state: "completed_with_proof",
+        owner: "friday_owned",
+        proofRef: "proof://provider/receipt/redacted",
+        done: true,
+        blockingReason: "terminal or archived WorkItem; no recovery action applies",
+        recoveryKind: "none",
+        canRetry: false,
+        canCancel: false,
+      },
+    ],
+    timelinePages: [
+      { page: 1, cursor: "cursor_1", nextCursor: "cursor_2", eventRefs: ["event_mobile_intake", "event_provider_ack"] },
+      { page: 2, cursor: "cursor_2", eventRefs: ["event_channel_receipt", "event_timeline_read", "event_memory_candidate", "event_completed_with_proof"] },
+    ],
+    memoryCandidates: [
+      {
+        id: "memory_candidate_review_only",
+        preview: "Review-only candidate.",
+        state: "candidate_review_only",
+        grantsMemoryAuthority: false,
+        evidenceRef: "proof://memory/review-only",
+      },
+    ],
+    capabilityStates: [
+      {
+        id: "capability_mission_advisor",
+        label: "Mission advisor",
+        kind: "advisor",
+        truthLabel: "friday_owned",
+        approvalState: "not_required",
+        dispatchAllowed: false,
+        summary: "Advisor state is a Rust Hub projection.",
+        proofRef: "proof://advisor/route-decision/redacted",
+      },
+    ],
+    transcriptSections: [
+      {
+        id: "section_workbench_events_bridge",
+        title: "Mission projection",
+        groupKind: "mission",
+        missionId,
+        truthLabel: "friday_owned",
+        status: "waiting",
+        events: [
+          transcriptEvent("event_mobile_intake", "mobile", "ready", { surfaceThreadRef: "surface://mobile/thread", workflowRef: "workflow://mission/intake", timelineRef: "timeline://mission/page-1/event-mobile-intake" }),
+          transcriptEvent("event_provider_ack", "desktop", "provider_ack", { providerRef: "provider://session", proofReceiptRef: "proof://provider/ack", surfaceThreadRef: "surface://desktop/thread", timelineRef: "timeline://mission/page-1/event-provider-ack" }, "work_provider"),
+          transcriptEvent("event_channel_receipt", "telegram", "queued", { channelRef: "channel://telegram/redacted", proofReceiptRef: "proof://channel/receipt", timelineRef: "timeline://mission/page-2/event-channel-receipt" }),
+          transcriptEvent("event_timeline_read", "timeline", "timeline_read", { workflowRef: "workflow://mission/timeline", timelineRef: "timeline://mission/page-2/cursor" }, "work_timeline"),
+          transcriptEvent("event_memory_candidate", "timeline", "waiting", { skillRunRef: "skill://candidate/review-only", workflowRef: "workflow://memory/review", timelineRef: "timeline://mission/page-2/event-memory-candidate" }),
+          transcriptEvent("event_completed_with_proof", "desktop", "completed_with_proof", { providerRef: "provider://session/receipt", proofReceiptRef: "proof://provider/receipt", surfaceThreadRef: "surface://desktop/thread", timelineRef: "timeline://mission/page-2/event-completed-with-proof" }, "work_completed"),
+        ],
+      },
+    ],
+    ...overrides,
+  };
+}
+
+function transcriptEvent(
+  id: string,
+  surface: string,
+  status: string,
+  evidenceRefs: Record<string, string>,
+  workItemId?: string,
+) {
+  return {
+    id,
+    missionId: "mission_workbench_events_bridge",
+    workItemId,
+    surface,
+    status,
+    truthLabel: surface === "telegram" ? "observed_only" : "friday_owned",
+    summary: `${surface} ${status}`,
+    proofRef: "proof://redacted",
+    evidenceRefs,
+    capturedAt: "2026-06-05T06:10:00Z",
+  };
+}
+
+function writeEvidence(tempDir: string) {
+  const files = {
+    mobile: join(tempDir, "mobile.txt"),
+    desktop: join(tempDir, "desktop.txt"),
+    channel: join(tempDir, "channel.txt"),
+    timeline: join(tempDir, "timeline.txt"),
+  };
+  for (const [role, path] of Object.entries(files)) {
+    writeFileSync(path, `${role} evidence\n`);
+  }
+  return files;
+}
+
+function runBridge(tempDir: string, snapshot: Record<string, unknown>, extraArgs: string[] = []) {
+  const snapshotPath = join(tempDir, "snapshot.json");
+  const out = join(tempDir, "workbench-derived-events.jsonl");
+  const files = writeEvidence(tempDir);
+  writeFileSync(snapshotPath, JSON.stringify({ snapshot }, null, 2));
+  const stdout = execFileSync(process.execPath, [
+    "scripts/ops/friday-workbench-snapshot-events.mjs",
+    "--mission-id=mission_workbench_events_bridge",
+    `--file=${snapshotPath}`,
+    `--mobile=${files.mobile}`,
+    `--desktop=${files.desktop}`,
+    `--channel=${files.channel}`,
+    `--timeline=${files.timeline}`,
+    `--out=${out}`,
+    ...extraArgs,
+  ], {
+    cwd: process.cwd(),
+    encoding: "utf8",
+  });
+  return { result: JSON.parse(stdout), out };
+}
+
+describe("friday-workbench-snapshot-events CLI", () => {
+  it("bridges a preflight-passing workbench snapshot into diagnostic events only", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "friday-workbench-events-"));
+    try {
+      const { result, out } = runBridge(tempDir, makeSnapshot(), ["--require-ready"]);
+      const rows = readFileSync(out, "utf8").trim().split("\n").map((line) => JSON.parse(line));
+      const keys = rows.map((row) => `${row.surface}:${row.event}`);
+
+      expect(result).toMatchObject({
+        truth: "workbench_snapshot_events_bridge_diagnostic_not_proof",
+        status: "ready",
+        preflightReady: true,
+      });
+      expect(keys).toContain("desktop:mission_workbench_visible");
+      expect(keys).toContain("desktop:transcript_browser_visible");
+      expect(keys).toContain("channel:same_mission_projection_visible");
+      expect(keys).toContain("timeline:bounded_page_2_visible");
+      expect(keys).not.toContain("*:pressure_20_50_consecutive_asks_visible");
+      expect(new Set(rows.map((row) => row.truth_label))).toEqual(new Set([
+        "derived_from_preflighted_workbench_snapshot_not_final_proof",
+      ]));
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("fails closed and writes no events when the snapshot contract is not ready", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "friday-workbench-events-blocked-"));
+    try {
+      const invalid = makeSnapshot({ runtimeFeedStatus: "prep_contract_fallback" });
+      const { result, out } = runBridge(tempDir, invalid);
+
+      expect(result.status).toBe("blocked");
+      expect(result.blockers.map((blocker: { code: string }) => blocker.code)).toContain("snapshot_preflight_not_ready");
+      expect(() => readFileSync(out, "utf8")).toThrow();
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add a fail-closed Workbench snapshot to UI/device diagnostic event bridge
- require the existing Mission Workbench snapshot contract before writing any derived event rows
- cover ready and blocked paths with CLI tests, including the rule that stress/security/network observations are not synthesized

## Validation
- npx vitest run test/unit/qa/friday-workbench-snapshot-events-cli.test.ts test/unit/qa/mission-workbench-snapshot-contract-cli.test.ts
- node --check scripts/ops/friday-workbench-snapshot-events.mjs
- git diff --check origin/main..HEAD -- scripts/ops/friday-workbench-snapshot-events.mjs test/unit/qa/friday-workbench-snapshot-events-cli.test.ts
- detect-secrets-hook --baseline .secrets.baseline scripts/ops/friday-workbench-snapshot-events.mjs test/unit/qa/friday-workbench-snapshot-events-cli.test.ts

Truth: diagnostic bridge only. It does not write proof, does not synthesize missing stress/security/network/device observations, and does not claim END-BAR, GO-LIVE, adoption, or operator signing completion.