### PR TITLE
Derive readiness events from workbench snapshots

### DIFF
--- a/scripts/ops/friday-ui-device-proof-readiness.sh
+++ b/scripts/ops/friday-ui-device-proof-readiness.sh
@@ -46,6 +46,7 @@ evidence-dir auto-discovery:
     timeline.{json,trace,log,png}
     observations-manifest.json or ui-observations-manifest.json
     same-run-events.normalized.jsonl or same-run-events.jsonl for gap reporting
+    workbench-snapshot.json or mission-workbench-snapshot.json for diagnostic event bridging
 
 truth:
   Default report-only mode never writes MISSION_SPINE_UI_DEVICE_PROOF and is not END-BAR proof.
@@ -165,6 +166,12 @@ discover_evidence_dir() {
       "$dir/same-run-events.jsonl" \
       "$dir/events.jsonl" || true)"
   fi
+  if [ -z "${FRIDAY_WORKBENCH_SNAPSHOT_FILE:-}" ]; then
+    FRIDAY_WORKBENCH_SNAPSHOT_FILE="$(first_existing \
+      "$dir/workbench-snapshot.json" \
+      "$dir/mission-workbench-snapshot.json" \
+      "$dir/workbench-response.json" || true)"
+  fi
 }
 
 json_escape() {
@@ -181,6 +188,42 @@ export CHANNEL_EVIDENCE="${CHANNEL_EVIDENCE:-}"
 export TIMELINE_EVIDENCE="${TIMELINE_EVIDENCE:-}"
 export OBSERVATIONS_MANIFEST="${OBSERVATIONS_MANIFEST:-}"
 export SAME_RUN_EVENTS="${SAME_RUN_EVENTS:-}"
+export FRIDAY_WORKBENCH_SNAPSHOT_FILE="${FRIDAY_WORKBENCH_SNAPSHOT_FILE:-}"
+
+derive_workbench_events_if_possible() {
+  if [ -n "${SAME_RUN_EVENTS:-}" ] || [ -z "${FRIDAY_WORKBENCH_SNAPSHOT_FILE:-}" ]; then
+    return 0
+  fi
+  if [ -z "${MISSION_ID:-}" ] || [ -z "${MOBILE_EVIDENCE:-}" ] || [ -z "${DESKTOP_EVIDENCE:-}" ] || [ -z "${CHANNEL_EVIDENCE:-}" ] || [ -z "${TIMELINE_EVIDENCE:-}" ]; then
+    return 0
+  fi
+
+  local derived_out
+  local stdout_out
+  if [ -n "$EVIDENCE_DIR" ]; then
+    derived_out="$(abs_path "$EVIDENCE_DIR")/workbench-derived-events.jsonl"
+  else
+    derived_out="/tmp/friday-workbench-derived-events-${MISSION_ID}.jsonl"
+  fi
+  stdout_out="${derived_out}.stdout"
+  mkdir -p "$(dirname "$derived_out")"
+
+  if node "${REPO_ROOT}/scripts/ops/friday-workbench-snapshot-events.mjs" \
+    "--mission-id=${MISSION_ID}" \
+    "--file=${FRIDAY_WORKBENCH_SNAPSHOT_FILE}" \
+    "--mobile=${MOBILE_EVIDENCE}" \
+    "--desktop=${DESKTOP_EVIDENCE}" \
+    "--channel=${CHANNEL_EVIDENCE}" \
+    "--timeline=${TIMELINE_EVIDENCE}" \
+    "--out=${derived_out}" >"$stdout_out"; then
+    SAME_RUN_EVENTS="$derived_out"
+    export SAME_RUN_EVENTS
+    notes+=("workbench_snapshot_events_bridge:ready:${derived_out}")
+  else
+    local rc=$?
+    blockers+=("workbench_snapshot_events_bridge:exit_${rc}")
+  fi
+}
 
 have_all_evidence=1
 for name in MISSION_ID MOBILE_EVIDENCE DESKTOP_EVIDENCE CHANNEL_EVIDENCE TIMELINE_EVIDENCE OBSERVATIONS_MANIFEST; do
@@ -192,10 +235,12 @@ done
 blockers=()
 notes=()
 
+derive_workbench_events_if_possible
+
 if [ -n "$EVIDENCE_DIR" ]; then
   notes+=("evidence_dir:$(abs_path "$EVIDENCE_DIR")")
 fi
-for name in MISSION_ID MOBILE_EVIDENCE DESKTOP_EVIDENCE CHANNEL_EVIDENCE TIMELINE_EVIDENCE OBSERVATIONS_MANIFEST; do
+for name in MISSION_ID MOBILE_EVIDENCE DESKTOP_EVIDENCE CHANNEL_EVIDENCE TIMELINE_EVIDENCE OBSERVATIONS_MANIFEST FRIDAY_WORKBENCH_SNAPSHOT_FILE; do
   if [ -n "${!name:-}" ]; then
     notes+=("resolved_${name}:${!name}")
   fi

--- a/test/unit/qa/friday-ui-device-proof-readiness-cli.test.ts
+++ b/test/unit/qa/friday-ui-device-proof-readiness-cli.test.ts
@@ -58,8 +58,167 @@ function writePartialEvidenceDir(tempDir: string) {
   return files;
 }
 
+function writeWorkbenchSnapshotEvidenceDir(tempDir: string) {
+  const files = {
+    mobile: join(tempDir, "mobile.json"),
+    desktop: join(tempDir, "desktop.json"),
+    channel: join(tempDir, "channel.json"),
+    timeline: join(tempDir, "timeline.json"),
+    snapshot: join(tempDir, "workbench-snapshot.json"),
+  };
+
+  writeFileSync(join(tempDir, "mission-id.txt"), `${missionId}\n`);
+  for (const [role, filePath] of Object.entries({
+    mobile: files.mobile,
+    desktop: files.desktop,
+    channel: files.channel,
+    timeline: files.timeline,
+  })) {
+    writeFileSync(filePath, JSON.stringify({ role, mission_id: missionId, capture: "redacted snapshot-derived qa input" }));
+  }
+  writeFileSync(files.snapshot, JSON.stringify({ snapshot: makeWorkbenchSnapshot() }, null, 2));
+  return files;
+}
+
 function observation(surface: string, event: string, evidenceRef: string) {
   return { surface, event, mission_id: missionId, evidence_ref: evidenceRef };
+}
+
+function transcriptEvent(
+  id: string,
+  surface: string,
+  status: string,
+  evidenceRefs: Record<string, string>,
+  workItemId?: string,
+) {
+  return {
+    id,
+    missionId,
+    workItemId,
+    surface,
+    status,
+    truthLabel: surface === "telegram" ? "observed_only" : "friday_owned",
+    summary: `${surface} ${status}`,
+    proofRef: "proof://redacted",
+    evidenceRefs,
+    capturedAt: "2026-06-05T06:10:00Z",
+  };
+}
+
+function makeWorkbenchSnapshot() {
+  return {
+    missionId,
+    fridayConversationId: "conversation_cli_ui_device_readiness",
+    runtimeFeedStatus: "live_rust_hub_projection",
+    statusLabels: ["stale", "offline", "error"],
+    duplicatePreflight: {
+      status: "opens_existing_mission",
+      duplicateMissionId: missionId,
+      duplicateWorkItemId: "work_provider",
+    },
+    routeDecision: {
+      advisorSummary: "Rust Hub route decision projection.",
+      selectedRoute: "route_decision_ref",
+      controlRef: `friday://route-decision-projection/${missionId}/work_provider/1700000000000`,
+      workItemId: "work_provider",
+      alternatives: ["alternate_ref"],
+      actionItems: [
+        {
+          description: "Implement Mission Spine domain types",
+          targetKind: "file",
+          targetRef: "rust-core/crates/friday-core/src/lib.rs",
+          reversibility: "operator_gate_required",
+          assignedLane: "codex",
+          assignedProviderOrAgent: "codex",
+          routeReason: "Rust Hub must own product truth before UI wiring",
+        },
+      ],
+      truthLabel: "friday_owned",
+    },
+    providerReceiptRefs: ["proof://provider/receipt/redacted"],
+    channelReceiptRefs: ["proof://channel/receipt/redacted"],
+    workItems: [
+      {
+        id: "work_provider",
+        title: "Mission-bound provider action",
+        state: "provider_ack",
+        owner: "friday_owned",
+        proofRef: "proof://provider/ack/not-completion",
+        done: false,
+        blockingReason: "provider or hub execution is still in flight; cancel is the only exposed recovery action",
+        recoveryKind: "in_flight",
+        canRetry: false,
+        canCancel: true,
+      },
+      {
+        id: "work_timeline",
+        title: "Bounded timeline read",
+        state: "timeline_read",
+        owner: "friday_owned",
+        proofRef: "proof://timeline/page-2/cursor",
+        done: false,
+        blockingReason: "bounded timeline read only; no WorkItem recovery action applies",
+        recoveryKind: "none",
+        canRetry: false,
+        canCancel: false,
+      },
+      {
+        id: "work_completed",
+        title: "Completed only after proof receipt",
+        state: "completed_with_proof",
+        owner: "friday_owned",
+        proofRef: "proof://provider/receipt/redacted",
+        done: true,
+        blockingReason: "terminal or archived WorkItem; no recovery action applies",
+        recoveryKind: "none",
+        canRetry: false,
+        canCancel: false,
+      },
+    ],
+    timelinePages: [
+      { page: 1, cursor: "cursor_1", nextCursor: "cursor_2", eventRefs: ["event_mobile_intake", "event_provider_ack"] },
+      { page: 2, cursor: "cursor_2", eventRefs: ["event_channel_receipt", "event_timeline_read", "event_memory_candidate", "event_completed_with_proof"] },
+    ],
+    memoryCandidates: [
+      {
+        id: "memory_candidate_review_only",
+        preview: "Review-only candidate.",
+        state: "candidate_review_only",
+        grantsMemoryAuthority: false,
+        evidenceRef: "proof://memory/review-only",
+      },
+    ],
+    capabilityStates: [
+      {
+        id: "capability_mission_advisor",
+        label: "Mission advisor",
+        kind: "advisor",
+        truthLabel: "friday_owned",
+        approvalState: "not_required",
+        dispatchAllowed: false,
+        summary: "Advisor state is a Rust Hub projection.",
+        proofRef: "proof://advisor/route-decision/redacted",
+      },
+    ],
+    transcriptSections: [
+      {
+        id: "section_cli_ui_device_readiness",
+        title: "Mission projection",
+        groupKind: "mission",
+        missionId,
+        truthLabel: "friday_owned",
+        status: "waiting",
+        events: [
+          transcriptEvent("event_mobile_intake", "mobile", "ready", { surfaceThreadRef: "surface://mobile/thread", workflowRef: "workflow://mission/intake", timelineRef: "timeline://mission/page-1/event-mobile-intake" }),
+          transcriptEvent("event_provider_ack", "desktop", "provider_ack", { providerRef: "provider://session", proofReceiptRef: "proof://provider/ack", surfaceThreadRef: "surface://desktop/thread", timelineRef: "timeline://mission/page-1/event-provider-ack" }, "work_provider"),
+          transcriptEvent("event_channel_receipt", "telegram", "queued", { channelRef: "channel://telegram/redacted", proofReceiptRef: "proof://channel/receipt", timelineRef: "timeline://mission/page-2/event-channel-receipt" }),
+          transcriptEvent("event_timeline_read", "timeline", "timeline_read", { workflowRef: "workflow://mission/timeline", timelineRef: "timeline://mission/page-2/cursor" }, "work_timeline"),
+          transcriptEvent("event_memory_candidate", "timeline", "waiting", { skillRunRef: "skill://candidate/review-only", workflowRef: "workflow://memory/review", timelineRef: "timeline://mission/page-2/event-memory-candidate" }),
+          transcriptEvent("event_completed_with_proof", "desktop", "completed_with_proof", { providerRef: "provider://session/receipt", proofReceiptRef: "proof://provider/receipt", surfaceThreadRef: "surface://desktop/thread", timelineRef: "timeline://mission/page-2/event-completed-with-proof" }, "work_completed"),
+        ],
+      },
+    ],
+  };
 }
 
 function makeManifest(files: ReturnType<typeof writeEvidenceDir>) {
@@ -272,6 +431,48 @@ describe("friday-ui-device-proof-readiness", () => {
         event: "same_mission_projection_visible",
         preferredCapture: "channel",
       });
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("derives diagnostic events from a preflighted workbench snapshot without assembling proof", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "friday-ui-device-readiness-workbench-"));
+    try {
+      writeWorkbenchSnapshotEvidenceDir(tempDir);
+
+      const stdout = execFileSync("bash", [
+        "scripts/ops/friday-ui-device-proof-readiness.sh",
+        "--evidence-dir",
+        tempDir,
+      ], {
+        cwd: process.cwd(),
+        encoding: "utf8",
+      });
+      const result = JSON.parse(stdout.slice(stdout.indexOf("{"))) as {
+        truth?: string;
+        status?: string;
+        notes?: string[];
+        blockers?: string[];
+      };
+
+      expect(result.truth).toBe("report_only_not_ui_device_proof");
+      expect(result.status).toBe("blocked");
+      expect(result.blockers).toContain("ui_device_proof_evidence:missing_required_real_evidence_env");
+      expect(result.notes?.some((note) => note.includes("workbench_snapshot_events_bridge:ready"))).toBe(true);
+      expect(result.notes?.some((note) => note.includes("ui_device_gap_report:gaps_present"))).toBe(true);
+
+      const rows = readFileSync(join(tempDir, "workbench-derived-events.jsonl"), "utf8")
+        .trim()
+        .split("\n")
+        .map((line) => JSON.parse(line) as { surface?: string; event?: string });
+      expect(rows).toContainEqual(expect.objectContaining({
+        surface: "desktop",
+        event: "mission_workbench_visible",
+      }));
+      expect(rows).not.toContainEqual(expect.objectContaining({
+        event: "pressure_20_50_consecutive_asks_visible",
+      }));
     } finally {
       rmSync(tempDir, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary
- auto-discover Workbench snapshot captures in UI/device proof evidence dirs
- derive diagnostic same-run event rows through the preflighted Workbench snapshot bridge when explicit events are absent
- keep final proof assembly blocked unless the strict evidence and manifest gate is complete

## Validation
- npx vitest run test/unit/qa/friday-ui-device-proof-readiness-cli.test.ts test/unit/qa/friday-workbench-snapshot-events-cli.test.ts test/unit/qa/mission-workbench-snapshot-contract-cli.test.ts
- bash -n scripts/ops/friday-ui-device-proof-readiness.sh
- git diff --check origin/main..HEAD -- scripts/ops/friday-ui-device-proof-readiness.sh test/unit/qa/friday-ui-device-proof-readiness-cli.test.ts
- detect-secrets-hook --baseline .secrets.baseline scripts/ops/friday-ui-device-proof-readiness.sh test/unit/qa/friday-ui-device-proof-readiness-cli.test.ts

Truth: readiness diagnostics only. This does not assemble proof from Workbench snapshots, does not synthesize missing stress/security/network observations, and does not claim END-BAR, GO-LIVE, adoption, or operator signing completion.