### PR TITLE
Add UI device live write-read bundle driver

### DIFF
--- a/scripts/ops/friday-ui-device-live-write-read-bundle.mjs
+++ b/scripts/ops/friday-ui-device-live-write-read-bundle.mjs
@@ -1,0 +1,229 @@
+#!/usr/bin/env node
+
+import { createHash } from "node:crypto";
+import { copyFileSync, mkdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { basename, dirname, isAbsolute, join, resolve } from "node:path";
+
+const args = process.argv.slice(2);
+
+function usage() {
+  console.error(`usage:
+  node scripts/ops/friday-ui-device-live-write-read-bundle.mjs \\
+    --out-dir=/abs/bundle-dir \\
+    --mobile-capture-dir=/abs/ios-live-write-read-capture \\
+    --desktop-capture-dir=/abs/macos-live-write-read-capture \\
+    [--mission-id=mission_...] [--require-ready]
+
+Truth: this indexes existing iOS/macOS live write-read capture artifacts into a
+single partial bundle. It does not create channel/timeline/stress observations,
+does not derive a strict observations manifest, and never claims END-BAR,
+GO-LIVE, adoption, or operator signature completion.`);
+}
+
+function arg(name) {
+  const prefix = `--${name}=`;
+  return args.find((value) => value.startsWith(prefix))?.slice(prefix.length) || "";
+}
+
+if (args.includes("--help") || args.includes("-h")) {
+  usage();
+  process.exit(0);
+}
+
+const requireReady = args.includes("--require-ready");
+const outDirArg = arg("out-dir");
+const expectedMissionId = arg("mission-id");
+const captureDirs = {
+  mobile: arg("mobile-capture-dir"),
+  desktop: arg("desktop-capture-dir"),
+};
+const blockers = [];
+
+function block(code, detail) {
+  blockers.push({ code, detail });
+}
+
+function abs(path) {
+  return isAbsolute(path) ? path : resolve(path);
+}
+
+function sha256(path) {
+  return createHash("sha256").update(readFileSync(path)).digest("hex");
+}
+
+function readJson(path, label) {
+  try {
+    return JSON.parse(readFileSync(path, "utf8"));
+  } catch {
+    block("json_unreadable_or_invalid", `${label}:${path}`);
+    return null;
+  }
+}
+
+function requireFile(path, label) {
+  if (!path) {
+    block("missing_file", label);
+    return "";
+  }
+  const resolved = abs(path);
+  try {
+    const stats = statSync(resolved);
+    if (!stats.isFile()) block("not_file", `${label}:${resolved}`);
+    if (stats.size <= 0) block("empty_file", `${label}:${resolved}`);
+  } catch {
+    block("unreadable_file", `${label}:${resolved}`);
+  }
+  return resolved;
+}
+
+function requireDir(path, label) {
+  if (!path) {
+    block("missing_arg", label);
+    return "";
+  }
+  const resolved = abs(path);
+  try {
+    const stats = statSync(resolved);
+    if (!stats.isDirectory()) block("not_directory", `${label}:${resolved}`);
+  } catch {
+    block("unreadable_directory", `${label}:${resolved}`);
+  }
+  return resolved;
+}
+
+function readEvents(path, surface, missionId) {
+  try {
+    return readFileSync(path, "utf8")
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter(Boolean)
+      .map((line, index) => {
+        const event = JSON.parse(line);
+        const label = `${surface}_event_${index + 1}`;
+        if (event.surface !== surface) block("event_surface_mismatch", `${label}:${String(event.surface ?? "")}`);
+        if (event.mission_id !== missionId) block("event_mission_mismatch", `${label}:${String(event.mission_id ?? "")}`);
+        if (typeof event.event !== "string" || !event.event.trim()) block("event_missing_name", label);
+        return event;
+      });
+  } catch {
+    block("events_unreadable_or_invalid_jsonl", `${surface}:${path}`);
+    return [];
+  }
+}
+
+function capturePaths(index, role, dir) {
+  const roleIndex = index?.[role] ?? null;
+  const proof = requireFile(roleIndex?.proof || "", `${role}.proof`);
+  const events = requireFile(roleIndex?.events || "", `${role}.events`);
+  if (proof && dirname(proof) !== dir) block("capture_file_outside_dir", `${role}.proof:${proof}`);
+  if (events && dirname(events) !== dir) block("capture_file_outside_dir", `${role}.events:${events}`);
+  const eventCount = Number(roleIndex?.event_count ?? 0);
+  if (!Number.isInteger(eventCount) || eventCount <= 0) block("event_count_invalid", `${role}:${String(roleIndex?.event_count ?? "")}`);
+  return { proof, events, eventCount };
+}
+
+if (!outDirArg) block("missing_arg", "out-dir");
+if (outDirArg && !isAbsolute(outDirArg)) block("out_dir_not_absolute", outDirArg);
+if (expectedMissionId && !expectedMissionId.toLowerCase().includes("mission")) {
+  block("mission_id_unexpected_shape", expectedMissionId);
+}
+
+const outDir = outDirArg ? abs(outDirArg) : "";
+const dirs = Object.fromEntries(Object.entries(captureDirs).map(([role, value]) => [role, requireDir(value, `${role}-capture-dir`)]));
+const captures = {};
+
+for (const role of ["mobile", "desktop"]) {
+  if (!dirs[role]) continue;
+  const indexPath = requireFile(join(dirs[role], "capture-index.json"), `${role}.capture-index`);
+  const index = indexPath ? readJson(indexPath, `${role}.capture-index`) : null;
+  if (index?.status !== "ready") block("capture_index_not_ready", `${role}:${String(index?.status ?? "")}`);
+  const missionId = typeof index?.mission_id === "string" ? index.mission_id : "";
+  if (!missionId) block("capture_index_missing_mission_id", role);
+  captures[role] = {
+    role,
+    dir: dirs[role],
+    indexPath,
+    index,
+    missionId,
+    workItemId: typeof index?.work_item_id === "string" ? index.work_item_id : "",
+    ...capturePaths(index, role, dirs[role]),
+  };
+}
+
+const missionIds = [...new Set(Object.values(captures).map((capture) => capture.missionId).filter(Boolean))];
+const missionId = expectedMissionId || (missionIds.length === 1 ? missionIds[0] : "");
+if (missionIds.length > 1) block("mobile_desktop_mission_mismatch", missionIds.join(","));
+if (expectedMissionId && missionIds.some((value) => value !== expectedMissionId)) {
+  block("expected_mission_mismatch", `${expectedMissionId}:${missionIds.join(",")}`);
+}
+
+const eventsByRole = {};
+for (const [role, capture] of Object.entries(captures)) {
+  if (capture.events && capture.missionId) {
+    eventsByRole[role] = readEvents(capture.events, role, capture.missionId);
+  }
+}
+
+let written = {};
+let combinedEventsPath = null;
+let indexPath = null;
+if (outDir && blockers.filter((entry) => entry.code === "missing_arg" || entry.code === "out_dir_not_absolute").length === 0) {
+  mkdirSync(outDir, { recursive: true });
+  for (const [role, capture] of Object.entries(captures)) {
+    const roleDir = join(outDir, role);
+    mkdirSync(roleDir, { recursive: true });
+    const proofTarget = join(roleDir, basename(capture.proof));
+    const eventsTarget = join(roleDir, basename(capture.events));
+    copyFileSync(capture.proof, proofTarget);
+    copyFileSync(capture.events, eventsTarget);
+    written[role] = {
+      proof: proofTarget,
+      proof_sha256: sha256(proofTarget),
+      events: eventsTarget,
+      events_sha256: sha256(eventsTarget),
+      event_count: eventsByRole[role]?.length ?? 0,
+      mission_id: capture.missionId,
+      work_item_id: capture.workItemId,
+    };
+  }
+
+  if (missionId) {
+    combinedEventsPath = join(outDir, "mobile-desktop-live-write-read-events.jsonl");
+    const combined = ["mobile", "desktop"]
+      .flatMap((role) => eventsByRole[role] ?? [])
+      .map((event) => JSON.stringify(event));
+    writeFileSync(combinedEventsPath, combined.length ? `${combined.join("\n")}\n` : "");
+  }
+
+  indexPath = join(outDir, "live-write-read-bundle-index.json");
+}
+
+const fullProofGaps = [
+  "same_mission_mobile_desktop_channel_capture",
+  "bounded_timeline_capture",
+  "strict_observations_manifest_from_same_run_events",
+  "pressure_20_50_consecutive_asks",
+  "error_quota_network_replay_reconnect_observations",
+  "secret_leak_and_hidden_fallback_negative_controls",
+];
+
+const output = {
+  truth: "ui_device_live_write_read_bundle_not_full_proof",
+  status: blockers.length === 0 ? "partial_bundle_ready" : "blocked",
+  missionId: missionId || null,
+  outDir: outDir || null,
+  captures: written,
+  combinedEvents: combinedEventsPath,
+  blockers,
+  fullProofGaps,
+  next: blockers.length === 0
+    ? "Use the bundle as partial input only; capture real channel/timeline/stress observations before strict UI/device proof readiness can pass."
+    : "Fix blockers with real iOS/macOS same-mission captures; do not synthesize missing observations.",
+};
+
+if (indexPath) {
+  writeFileSync(indexPath, `${JSON.stringify(output, null, 2)}\n`);
+}
+
+console.log(JSON.stringify(output, null, 2));
+process.exit(blockers.length === 0 || !requireReady ? 0 : 2);

--- a/test/unit/qa/friday-ui-device-live-write-read-bundle-cli.test.ts
+++ b/test/unit/qa/friday-ui-device-live-write-read-bundle-cli.test.ts
@@ -1,0 +1,128 @@
+import { execFileSync, spawnSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const script = "scripts/ops/friday-ui-device-live-write-read-bundle.mjs";
+
+function writeCapture(root: string, role: "mobile" | "desktop", missionId: string) {
+  const dir = join(root, role);
+  mkdirSync(dir, { recursive: true });
+  const proof = join(dir, `${role}-proof.json`);
+  const events = join(dir, `${role}-events.jsonl`);
+  const workItemId = `work-${role}-${missionId}`;
+  writeFileSync(proof, JSON.stringify({
+    truth_label: `${role}_live_write_read_roundtrip_proof_not_ui_device_proof`,
+    status: "pass",
+    mission_id: missionId,
+    work_item_id: workItemId,
+    surface_kind: role,
+  }, null, 2));
+  const rows = [
+    "mission_intake_submitted",
+    "mission_intake_ready",
+    "mission_bound_provider_action_visible",
+    "proof_receipt_visible_before_done",
+    "same_mission_projection_visible",
+  ].map((event) => ({
+    surface: role,
+    event,
+    mission_id: missionId,
+    evidence_ref: proof,
+    work_item_id: workItemId,
+  }));
+  writeFileSync(events, `${rows.map((row) => JSON.stringify(row)).join("\n")}\n`);
+  writeFileSync(join(dir, "capture-index.json"), JSON.stringify({
+    truth_label: `${role}_live_write_read_capture_index_not_ui_device_proof`,
+    status: "ready",
+    mission_id: missionId,
+    work_item_id: workItemId,
+    [role]: {
+      proof,
+      events,
+      event_count: rows.length,
+    },
+    blockers: [],
+  }, null, 2));
+  return dir;
+}
+
+describe("friday-ui-device-live-write-read-bundle", () => {
+  it("indexes same-mission mobile and desktop live captures without claiming full proof", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "friday-ui-live-bundle-"));
+    try {
+      const missionId = "mission-live-write-read-bundle";
+      const mobileDir = writeCapture(tempDir, "mobile", missionId);
+      const desktopDir = writeCapture(tempDir, "desktop", missionId);
+      const outDir = join(tempDir, "bundle");
+
+      const stdout = execFileSync("node", [
+        script,
+        `--out-dir=${outDir}`,
+        `--mobile-capture-dir=${mobileDir}`,
+        `--desktop-capture-dir=${desktopDir}`,
+        "--require-ready",
+      ], { cwd: process.cwd(), encoding: "utf8" });
+
+      const result = JSON.parse(stdout) as {
+        truth?: string;
+        status?: string;
+        missionId?: string;
+        combinedEvents?: string;
+        fullProofGaps?: string[];
+      };
+      expect(result.truth).toBe("ui_device_live_write_read_bundle_not_full_proof");
+      expect(result.status).toBe("partial_bundle_ready");
+      expect(result.missionId).toBe(missionId);
+      expect(result.fullProofGaps).toContain("bounded_timeline_capture");
+
+      const combinedEvents = readFileSync(result.combinedEvents ?? "", "utf8").trim().split("\n");
+      expect(combinedEvents).toHaveLength(10);
+
+      const index = JSON.parse(readFileSync(join(outDir, "live-write-read-bundle-index.json"), "utf8")) as {
+        status?: string;
+        fullProofGaps?: string[];
+      };
+      expect(index.status).toBe("partial_bundle_ready");
+      expect(index.fullProofGaps).toContain("strict_observations_manifest_from_same_run_events");
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("fails closed when mobile and desktop captures are not the same mission", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "friday-ui-live-bundle-mismatch-"));
+    try {
+      const mobileDir = writeCapture(tempDir, "mobile", "mission-live-bundle-mobile");
+      const desktopDir = writeCapture(tempDir, "desktop", "mission-live-bundle-desktop");
+      const result = spawnSync("node", [
+        script,
+        `--out-dir=${join(tempDir, "bundle")}`,
+        `--mobile-capture-dir=${mobileDir}`,
+        `--desktop-capture-dir=${desktopDir}`,
+        "--require-ready",
+      ], { cwd: process.cwd(), encoding: "utf8" });
+
+      expect(result.status).toBe(2);
+      const output = JSON.parse(result.stdout) as { status?: string; blockers?: Array<{ code?: string }> };
+      expect(output.status).toBe("blocked");
+      expect(output.blockers?.map((blocker) => blocker.code)).toContain("mobile_desktop_mission_mismatch");
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("requires both live capture dirs and an absolute output dir", () => {
+    const result = spawnSync("node", [
+      script,
+      "--out-dir=relative",
+      "--require-ready",
+    ], { cwd: process.cwd(), encoding: "utf8" });
+
+    expect(result.status).toBe(2);
+    const output = JSON.parse(result.stdout) as { blockers?: Array<{ code?: string }> };
+    expect(output.blockers?.map((blocker) => blocker.code)).toContain("out_dir_not_absolute");
+    expect(output.blockers?.map((blocker) => blocker.code)).toContain("missing_arg");
+  });
+});


### PR DESCRIPTION
## Summary
- add a UI/device live write-read bundle driver that indexes existing iOS and macOS live capture artifacts together
- fail closed when mobile/desktop captures are missing, not ready, or not the same mission
- keep full UI/device proof gaps explicit instead of deriving channel/timeline/stress observations or a strict manifest

## Validation
- npx vitest run test/unit/qa/friday-ui-device-live-write-read-bundle-cli.test.ts test/unit/qa/friday-ios-live-write-read-capture-cli.test.ts test/unit/qa/friday-macos-live-write-read-capture-cli.test.ts
- node --check scripts/ops/friday-ui-device-live-write-read-bundle.mjs
- git diff --check
- detect-secrets-hook --baseline .secrets.baseline scripts/ops/friday-ui-device-live-write-read-bundle.mjs test/unit/qa/friday-ui-device-live-write-read-bundle-cli.test.ts

Truth: partial bundle/indexing only. This does not create channel/timeline/stress observations, does not derive strict proof, and does not claim END-BAR, GO-LIVE, adoption, or operator signing completion.