### PR TITLE
Allow shared mission live write-read captures

### DIFF
--- a/apps/friday-ios/Tests/FridayMobileShellCoreTests/LiveWriteReadProjectionRoundTripIntegrationTests.swift
+++ b/apps/friday-ios/Tests/FridayMobileShellCoreTests/LiveWriteReadProjectionRoundTripIntegrationTests.swift
@@ -100,21 +100,40 @@ private func endpointPort(envKey: String, fallback: UInt16, label: String) throw
 }
 
 private func makeMobileRoundTripIntake() -> MissionIntakeRequestWire {
-  let id = UUID().uuidString.lowercased().replacingOccurrences(of: "-", with: "")
+  let identity = liveWriteReadMissionIdentity(defaultSurface: "mobile")
   return MissionIntakeRequestWire(
-    fridayConversationId: "fconv_mobile_live_roundtrip_\(id)",
+    fridayConversationId: "fconv_mobile_live_roundtrip_\(identity.id)",
     ownerPrincipal: liveAgentRunOwnerPrincipal,
-    surfaceThreadId: "surface-mobile-live-roundtrip-\(id)",
+    surfaceThreadId: "surface-mobile-live-roundtrip-\(identity.id)",
     surfaceKind: "mobile",
-    deliveryRoute: "ios://friday-mobile/live-write-read-roundtrip/\(id)",
+    deliveryRoute: "ios://friday-mobile/live-write-read-roundtrip/\(identity.id)",
     visibilityPolicy: "compact",
-    missionId: "mission-mobile-live-roundtrip-\(id)",
-    workItemId: "work-mobile-live-roundtrip-\(id)",
+    missionId: identity.missionId,
+    workItemId: "work-mobile-live-roundtrip-\(identity.id)",
     title: "Verify live mobile write appears in read projection",
     intent: "Create a refs-only live mobile round-trip proof item and expose it through the "
       + "Mission Workbench read projection.",
     lane: "deepseek",
     targetProviderOrAgent: "deepseek")
+}
+
+private struct LiveWriteReadMissionIdentity {
+  let id: String
+  let missionId: String
+}
+
+private func liveWriteReadMissionIdentity(defaultSurface: String) -> LiveWriteReadMissionIdentity {
+  let rawSharedId = ProcessInfo.processInfo.environment["FRIDAY_MISSION_SPINE_UI_PROOF_SHARED_ID"]?
+    .trimmingCharacters(in: .whitespacesAndNewlines)
+  if let rawSharedId, !rawSharedId.isEmpty {
+    let id = rawSharedId.hasPrefix("mission_")
+      ? String(rawSharedId.dropFirst("mission_".count))
+      : rawSharedId
+    return LiveWriteReadMissionIdentity(id: id, missionId: "mission_\(id)")
+  }
+
+  let id = UUID().uuidString.lowercased().replacingOccurrences(of: "-", with: "")
+  return LiveWriteReadMissionIdentity(id: id, missionId: "mission-\(defaultSurface)-live-roundtrip-\(id)")
 }
 
 private func pollReadProjection(

--- a/apps/macos/FridayHubConsole/Tests/FridayHubConsoleCoreTests/LiveWriteReadProjectionRoundTripIntegrationTests.swift
+++ b/apps/macos/FridayHubConsole/Tests/FridayHubConsoleCoreTests/LiveWriteReadProjectionRoundTripIntegrationTests.swift
@@ -52,21 +52,40 @@ func liveDesktopMissionWriteAppearsInReadProjection() async throws {
 }
 
 private func makeDesktopRoundTripIntake() -> MissionIntakeRequestWire {
-  let id = UUID().uuidString.lowercased().replacingOccurrences(of: "-", with: "")
+  let identity = liveWriteReadMissionIdentity(defaultSurface: "desktop")
   return MissionIntakeRequestWire(
-    fridayConversationId: "fconv_desktop_live_roundtrip_\(id)",
+    fridayConversationId: "fconv_desktop_live_roundtrip_\(identity.id)",
     ownerPrincipal: liveReadProjectionOwnerPrincipal,
-    surfaceThreadId: "surface-desktop-live-roundtrip-\(id)",
+    surfaceThreadId: "surface-desktop-live-roundtrip-\(identity.id)",
     surfaceKind: "desktop",
-    deliveryRoute: "desktop://hub-console/live-write-read-roundtrip/\(id)",
+    deliveryRoute: "desktop://hub-console/live-write-read-roundtrip/\(identity.id)",
     visibilityPolicy: "compact",
-    missionId: "mission-desktop-live-roundtrip-\(id)",
-    workItemId: "work-desktop-live-roundtrip-\(id)",
+    missionId: identity.missionId,
+    workItemId: "work-desktop-live-roundtrip-\(identity.id)",
     title: "Verify live desktop write appears in read projection",
     intent: "Create a refs-only live desktop round-trip proof item and expose it through the "
       + "Mission Workbench read projection.",
     lane: "deepseek",
     targetProviderOrAgent: "deepseek")
+}
+
+private struct LiveWriteReadMissionIdentity {
+  let id: String
+  let missionId: String
+}
+
+private func liveWriteReadMissionIdentity(defaultSurface: String) -> LiveWriteReadMissionIdentity {
+  let rawSharedId = ProcessInfo.processInfo.environment["FRIDAY_MISSION_SPINE_UI_PROOF_SHARED_ID"]?
+    .trimmingCharacters(in: .whitespacesAndNewlines)
+  if let rawSharedId, !rawSharedId.isEmpty {
+    let id = rawSharedId.hasPrefix("mission_")
+      ? String(rawSharedId.dropFirst("mission_".count))
+      : rawSharedId
+    return LiveWriteReadMissionIdentity(id: id, missionId: "mission_\(id)")
+  }
+
+  let id = UUID().uuidString.lowercased().replacingOccurrences(of: "-", with: "")
+  return LiveWriteReadMissionIdentity(id: id, missionId: "mission-\(defaultSurface)-live-roundtrip-\(id)")
 }
 
 private func pollReadProjection(

--- a/scripts/ops/friday-ios-live-write-read-capture.sh
+++ b/scripts/ops/friday-ios-live-write-read-capture.sh
@@ -7,6 +7,7 @@ usage:
   scripts/ops/friday-ios-live-write-read-capture.sh --out-dir /abs/capture-dir
     [--read-host 127.0.0.1] [--read-port 48751]
     [--write-host 127.0.0.1] [--write-port 48750]
+    [--shared-id mission_ui_device_...]
 
 Runs the env-gated iOS live write->read projection proof, converts the redacted
 artifact into mobile same-run proof events, and writes a capture index.
@@ -28,6 +29,7 @@ read_host="${FRIDAY_MOBILE_LIVE_READ_HOST:-127.0.0.1}"
 read_port="${FRIDAY_MOBILE_LIVE_READ_PORT:-48751}"
 write_host="${FRIDAY_MOBILE_LIVE_WRITE_HOST:-127.0.0.1}"
 write_port="${FRIDAY_MOBILE_LIVE_WRITE_PORT:-48750}"
+shared_id="${FRIDAY_MISSION_SPINE_UI_PROOF_SHARED_ID:-}"
 
 while [ "$#" -gt 0 ]; do
   case "$1" in
@@ -76,6 +78,15 @@ while [ "$#" -gt 0 ]; do
       write_port="${1#--write-port=}"
       shift
       ;;
+    --shared-id)
+      [ "$#" -ge 2 ] || die "--shared-id requires a value"
+      shared_id="$2"
+      shift 2
+      ;;
+    --shared-id=*)
+      shared_id="${1#--shared-id=}"
+      shift
+      ;;
     --help|-h)
       usage
       exit 0
@@ -93,6 +104,7 @@ case "${out_dir}" in
 esac
 case "${read_port}" in (*[!0-9]*|"") die "--read-port must be numeric" ;; esac
 case "${write_port}" in (*[!0-9]*|"") die "--write-port must be numeric" ;; esac
+case "${shared_id}" in (*[[:space:]]*) die "--shared-id must not contain whitespace" ;; esac
 
 mkdir -p "${out_dir}"
 proof_path="${out_dir}/ios-live-write-read-proof.json"
@@ -113,6 +125,7 @@ echo "truth=ios_live_write_read_capture_runner_not_ui_device_proof"
   FRIDAY_MOBILE_LIVE_READ_PORT="${read_port}" \
   FRIDAY_MOBILE_LIVE_WRITE_HOST="${write_host}" \
   FRIDAY_MOBILE_LIVE_WRITE_PORT="${write_port}" \
+  FRIDAY_MISSION_SPINE_UI_PROOF_SHARED_ID="${shared_id}" \
     swift test --package-path apps/friday-ios --filter LiveWriteReadProjectionRoundTrip
 )
 

--- a/scripts/ops/friday-macos-live-write-read-capture.sh
+++ b/scripts/ops/friday-macos-live-write-read-capture.sh
@@ -5,6 +5,7 @@ usage() {
   cat >&2 <<'EOF'
 usage:
   scripts/ops/friday-macos-live-write-read-capture.sh --out-dir /abs/capture-dir
+    [--shared-id mission_ui_device_...]
 
 Runs the env-gated macOS live write->read projection proof, converts the
 redacted artifact into desktop same-run proof events, and writes a capture
@@ -23,6 +24,7 @@ die() {
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 out_dir=""
+shared_id="${FRIDAY_MISSION_SPINE_UI_PROOF_SHARED_ID:-}"
 
 while [ "$#" -gt 0 ]; do
   case "$1" in
@@ -33,6 +35,15 @@ while [ "$#" -gt 0 ]; do
       ;;
     --out-dir=*)
       out_dir="${1#--out-dir=}"
+      shift
+      ;;
+    --shared-id)
+      [ "$#" -ge 2 ] || die "--shared-id requires a value"
+      shared_id="$2"
+      shift 2
+      ;;
+    --shared-id=*)
+      shared_id="${1#--shared-id=}"
       shift
       ;;
     --help|-h)
@@ -50,6 +61,7 @@ case "${out_dir}" in
   /*) ;;
   *) die "--out-dir must be absolute" ;;
 esac
+case "${shared_id}" in (*[[:space:]]*) die "--shared-id must not contain whitespace" ;; esac
 
 mkdir -p "${out_dir}"
 proof_path="${out_dir}/macos-live-write-read-proof.json"
@@ -64,6 +76,7 @@ echo "truth=macos_live_write_read_capture_runner_not_ui_device_proof"
   cd "${repo_root}"
   FRIDAY_CONSOLE_LIVE_WRITE_READ_ROUNDTRIP_TEST=1 \
   FRIDAY_DESKTOP_LIVE_WRITE_READ_ROUNDTRIP_PROOF_OUT="${proof_path}" \
+  FRIDAY_MISSION_SPINE_UI_PROOF_SHARED_ID="${shared_id}" \
     swift test --package-path apps/macos/FridayHubConsole --filter LiveWriteReadProjectionRoundTrip
 )
 

--- a/test/unit/qa/friday-ios-live-write-read-capture-cli.test.ts
+++ b/test/unit/qa/friday-ios-live-write-read-capture-cli.test.ts
@@ -7,8 +7,9 @@ import { describe, expect, it } from "vitest";
 const script = "scripts/ops/friday-ios-live-write-read-capture.sh";
 const missionId = "mission-mobile-live-roundtrip-wrapper";
 const workItemId = "work-mobile-live-roundtrip-wrapper";
+const sharedId = "mission-shared-live-write-read";
 
-function fakeSwiftScript(dir: string, proofStatus = "pass") {
+function fakeSwiftScript(dir: string, proofStatus = "pass", requiredSharedId = "") {
   const bin = join(dir, "bin");
   mkdirSync(bin, { recursive: true });
   const path = join(bin, "swift");
@@ -16,6 +17,7 @@ function fakeSwiftScript(dir: string, proofStatus = "pass") {
 set -euo pipefail
 [ "$1" = "test" ] || exit 42
 [ -n "\${FRIDAY_MOBILE_LIVE_WRITE_READ_ROUNDTRIP_PROOF_OUT:-}" ] || exit 43
+if [ -n "${requiredSharedId}" ] && [ "\${FRIDAY_MISSION_SPINE_UI_PROOF_SHARED_ID:-}" != "${requiredSharedId}" ]; then exit 44; fi
 cat >"\${FRIDAY_MOBILE_LIVE_WRITE_READ_ROUNDTRIP_PROOF_OUT}" <<'JSON'
 {
   "truth_label": "ios_mobile_live_write_read_roundtrip_proof_not_ui_device_proof",
@@ -51,8 +53,13 @@ describe("friday-ios-live-write-read-capture", () => {
     const tempDir = mkdtempSync(join(tmpdir(), "friday-ios-live-capture-"));
     try {
       const outDir = join(tempDir, "capture");
-      const fakeBin = fakeSwiftScript(tempDir);
-      const stdout = execFileSync("bash", [script, `--out-dir=${outDir}`, "--read-port=59151"], {
+      const fakeBin = fakeSwiftScript(tempDir, "pass", sharedId);
+      const stdout = execFileSync("bash", [
+        script,
+        `--out-dir=${outDir}`,
+        "--read-port=59151",
+        `--shared-id=${sharedId}`,
+      ], {
         cwd: process.cwd(),
         encoding: "utf8",
         env: {

--- a/test/unit/qa/friday-macos-live-write-read-capture-cli.test.ts
+++ b/test/unit/qa/friday-macos-live-write-read-capture-cli.test.ts
@@ -7,8 +7,9 @@ import { describe, expect, it } from "vitest";
 const script = "scripts/ops/friday-macos-live-write-read-capture.sh";
 const missionId = "mission-desktop-live-roundtrip-wrapper";
 const workItemId = "work-desktop-live-roundtrip-wrapper";
+const sharedId = "mission-shared-live-write-read";
 
-function fakeSwiftScript(dir: string, proofStatus = "pass") {
+function fakeSwiftScript(dir: string, proofStatus = "pass", requiredSharedId = "") {
   const bin = join(dir, "bin");
   mkdirSync(bin, { recursive: true });
   const path = join(bin, "swift");
@@ -16,6 +17,7 @@ function fakeSwiftScript(dir: string, proofStatus = "pass") {
 set -euo pipefail
 [ "$1" = "test" ] || exit 42
 [ -n "\${FRIDAY_DESKTOP_LIVE_WRITE_READ_ROUNDTRIP_PROOF_OUT:-}" ] || exit 43
+if [ -n "${requiredSharedId}" ] && [ "\${FRIDAY_MISSION_SPINE_UI_PROOF_SHARED_ID:-}" != "${requiredSharedId}" ]; then exit 44; fi
 cat >"\${FRIDAY_DESKTOP_LIVE_WRITE_READ_ROUNDTRIP_PROOF_OUT}" <<'JSON'
 {
   "truth_label": "macos_desktop_live_write_read_roundtrip_proof_not_ui_device_proof",
@@ -51,8 +53,8 @@ describe("friday-macos-live-write-read-capture", () => {
     const tempDir = mkdtempSync(join(tmpdir(), "friday-macos-live-capture-"));
     try {
       const outDir = join(tempDir, "capture");
-      const fakeBin = fakeSwiftScript(tempDir);
-      const stdout = execFileSync("bash", [script, `--out-dir=${outDir}`], {
+      const fakeBin = fakeSwiftScript(tempDir, "pass", sharedId);
+      const stdout = execFileSync("bash", [script, `--out-dir=${outDir}`, `--shared-id=${sharedId}`], {
         cwd: process.cwd(),
         encoding: "utf8",
         env: {


### PR DESCRIPTION
## Summary
- let iOS and macOS live write-read roundtrip tests honor FRIDAY_MISSION_SPINE_UI_PROOF_SHARED_ID
- add --shared-id to the mobile and desktop live write-read capture runners so both surfaces can capture the same mission when explicitly requested
- keep default UUID behavior unchanged and keep the capture artifacts truth-labeled as partial UI/device inputs

## Validation
- npx vitest run test/unit/qa/friday-ios-live-write-read-capture-cli.test.ts test/unit/qa/friday-macos-live-write-read-capture-cli.test.ts
- swift test --package-path apps/friday-ios --filter LiveWriteReadProjectionRoundTrip
- swift test --package-path apps/macos/FridayHubConsole --filter LiveWriteReadProjectionRoundTrip
- bash -n scripts/ops/friday-ios-live-write-read-capture.sh scripts/ops/friday-macos-live-write-read-capture.sh
- git diff --check HEAD~1..HEAD
- detect-secrets-hook --baseline .secrets.baseline apps/friday-ios/Tests/FridayMobileShellCoreTests/LiveWriteReadProjectionRoundTripIntegrationTests.swift apps/macos/FridayHubConsole/Tests/FridayHubConsoleCoreTests/LiveWriteReadProjectionRoundTripIntegrationTests.swift scripts/ops/friday-ios-live-write-read-capture.sh scripts/ops/friday-macos-live-write-read-capture.sh test/unit/qa/friday-ios-live-write-read-capture-cli.test.ts test/unit/qa/friday-macos-live-write-read-capture-cli.test.ts

Truth: this only enables same-mission mobile/desktop live write-read capture when explicitly requested. It does not run the live proof, does not create channel/timeline/stress observations, and does not claim END-BAR, GO-LIVE, adoption, or operator signing completion.