### PR TITLE
Add iOS sim initial destination proof hook

### DIFF
--- a/apps/friday-ios/Sources/FridayMobileShell/FridayApp.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayApp.swift
@@ -337,6 +337,8 @@ struct RootView: View {
 
   init(session: FridaySession) {
     self.session = session
+    let initialDestination = Self.initialDestinationFromLaunch()
+    _destination = State(initialValue: initialDestination)
     _homeVM = StateObject(wrappedValue: HomeViewModel(
       client: session.readClient,
       writeClient: session.missionClient,
@@ -438,6 +440,33 @@ struct RootView: View {
         await homeVM.refresh()
       }
     }
+  }
+
+  private static func initialDestinationFromLaunch(
+    args: [String] = ProcessInfo.processInfo.arguments,
+    env: [String: String] = ProcessInfo.processInfo.environment
+  ) -> MobileDestination {
+    let envValue = env["FRIDAY_MOBILE_INITIAL_DESTINATION"]?.trimmingCharacters(in: .whitespacesAndNewlines)
+    if let envValue, let destination = MobileDestination(rawValue: envValue) {
+      return destination
+    }
+
+    for (index, arg) in args.enumerated() {
+      if arg.hasPrefix("--initial-destination=") {
+        let rawValue = String(arg.dropFirst("--initial-destination=".count))
+        if let destination = MobileDestination(rawValue: rawValue) {
+          return destination
+        }
+      }
+      if arg == "--initial-destination", args.indices.contains(index + 1) {
+        let rawValue = args[index + 1]
+        if let destination = MobileDestination(rawValue: rawValue) {
+          return destination
+        }
+      }
+    }
+
+    return .home
   }
 
   private func applyShareURL(_ url: URL) {

--- a/apps/friday-ios/build-sim.sh
+++ b/apps/friday-ios/build-sim.sh
@@ -25,8 +25,8 @@ usage() {
   cat <<'USAGE'
 Usage:
   apps/friday-ios/build-sim.sh [screenshot-path]
-  apps/friday-ios/build-sim.sh --mode offline-truth [--shot screenshot-path]
-  apps/friday-ios/build-sim.sh --mode live-loopback [--shot screenshot-path]
+  apps/friday-ios/build-sim.sh --mode offline-truth [--destination pairing] [--shot screenshot-path]
+  apps/friday-ios/build-sim.sh --mode live-loopback [--destination pairing] [--shot screenshot-path]
 
 Modes:
   offline-truth  Default. Launches with all FRIDAY_MOBILE_LIVE_* gates OFF and proves the
@@ -42,6 +42,7 @@ BUILD="$HERE/.build-sim"
 APP="$BUILD/FridayShell.app"
 MODE="offline-truth"
 SHOT="$BUILD/friday-ios-sim.png"
+DESTINATION=""
 IOS_VERSION="17.0"
 TRIPLE="arm64-apple-ios${IOS_VERSION}-simulator"   # Apple-Silicon host (arm64 sim slice)
 
@@ -66,6 +67,19 @@ while [[ $# -gt 0 ]]; do
       fi
       SHOT="$2"
       shift 2
+      ;;
+    --destination)
+      if [[ $# -lt 2 ]]; then
+        echo "ERROR: --destination requires a value" >&2
+        usage >&2
+        exit 2
+      fi
+      DESTINATION="$2"
+      shift 2
+      ;;
+    --destination=*)
+      DESTINATION="${1#--destination=}"
+      shift
       ;;
     -h|--help)
       usage
@@ -97,6 +111,10 @@ case "$MODE" in
     exit 2
     ;;
 esac
+if [[ -n "$DESTINATION" && ! "$DESTINATION" =~ ^[A-Za-z][A-Za-z0-9]*$ ]]; then
+  echo "ERROR: --destination must be a MobileDestination raw value such as pairing or providerAuth" >&2
+  exit 2
+fi
 
 rm -rf "$BUILD"; mkdir -p "$BUILD" "$APP"
 
@@ -190,6 +208,10 @@ case "$MODE" in
     ;;
 esac
 LAUNCH_CMD=(xcrun simctl launch --terminate-running-process "$UDID" com.friday.shell)
+if [[ -n "$DESTINATION" ]]; then
+  LAUNCH_ARGS+=("--initial-destination=$DESTINATION")
+  LAUNCH_ENV+=(SIMCTL_CHILD_FRIDAY_MOBILE_INITIAL_DESTINATION="$DESTINATION")
+fi
 if ((${#LAUNCH_ARGS[@]} > 0)); then
   LAUNCH_CMD+=("${LAUNCH_ARGS[@]}")
 fi


### PR DESCRIPTION
## Summary
- allow the iOS simulator launch helper to open a specific MobileDestination via --destination
- pass the selected destination through both launch arguments and SIMCTL_CHILD_FRIDAY_MOBILE_INITIAL_DESTINATION
- keep the default Home launch behavior unchanged for existing screenshots and smoke runs

## Validation
- swift test --package-path apps/friday-ios --filter HomeViewModelTests
- bash apps/friday-ios/build-sim.sh --mode offline-truth --destination pairing --shot apps/friday-ios/.build-sim/friday-ios-pairing-destination.png
- visually inspected the generated screenshot: Device Pairing opens directly and shows QR available copy from current main
- git diff --check HEAD~1..HEAD
- detect-secrets-hook --baseline .secrets.baseline apps/friday-ios/Sources/FridayMobileShell/FridayApp.swift apps/friday-ios/build-sim.sh

Truth: simulator proof hook only. This does not enable live pairing, does not mint trust, does not claim END-BAR, GO-LIVE, adoption, or operator signing completion.