### PR TITLE
Add UI device live write-read capture orchestrator

### DIFF
--- a/apps/friday-ios/Tests/FridayMobileShellCoreTests/LiveWriteReadProjectionRoundTripIntegrationTests.swift
+++ b/apps/friday-ios/Tests/FridayMobileShellCoreTests/LiveWriteReadProjectionRoundTripIntegrationTests.swift
@@ -30,28 +30,27 @@ func liveMobileMissionWriteAppearsInReadProjection() async throws {
   let request = makeMobileRoundTripIntake()
 
   let result = try await writeClient.submitMissionIntake(request)
-  #expect(result.status == "ready")
-  #expect(result.createdOrReady)
   #expect(result.missionId == request.missionId)
-  #expect(result.workItemId == request.workItemId)
+  let acceptedWorkItemId = try acceptedRoundTripWorkItemId(result: result, request: request)
 
   let readConfig = try liveRoundTripReadConfig()
   let readClient = try RealReadClientFactory.makeLive(config: readConfig, missionId: result.missionId)
   let snapshot = try await pollReadProjection(
     client: readClient,
     missionId: result.missionId,
-    workItemId: try #require(result.workItemId))
+    workItemId: acceptedWorkItemId)
 
   print(
     "[live-write-read][mobile] missionId=\(snapshot.missionId) "
       + "workItemIds=\(snapshot.workItemIds) generatedAtMs=\(snapshot.generatedAtMs)")
   #expect(snapshot.missionId == result.missionId)
-  #expect(snapshot.workItemIds.contains(request.workItemId))
+  #expect(snapshot.workItemIds.contains(acceptedWorkItemId))
 
   try writeRoundTripProofIfRequested(
     request: request,
     result: result,
     snapshot: snapshot,
+    acceptedWorkItemId: acceptedWorkItemId,
     writeConfig: writeConfig,
     readConfig: readConfig)
 }
@@ -101,18 +100,30 @@ private func endpointPort(envKey: String, fallback: UInt16, label: String) throw
 
 private func makeMobileRoundTripIntake() -> MissionIntakeRequestWire {
   let identity = liveWriteReadMissionIdentity(defaultSurface: "mobile")
+  let workItemId = identity.usesSharedId
+    ? "work-live-roundtrip-\(identity.id)"
+    : "work-mobile-live-roundtrip-\(identity.id)"
+  let conversationId = identity.usesSharedId
+    ? "fconv_live_roundtrip_\(identity.id)"
+    : "fconv_mobile_live_roundtrip_\(identity.id)"
+  let title = identity.usesSharedId
+    ? "Verify live UI device write appears in read projection"
+    : "Verify live mobile write appears in read projection"
+  let intent = identity.usesSharedId
+    ? "Create a refs-only live UI device round-trip proof item and expose it through the Mission Workbench read projection."
+    : "Create a refs-only live mobile round-trip proof item and expose it through the "
+      + "Mission Workbench read projection."
   return MissionIntakeRequestWire(
-    fridayConversationId: "fconv_mobile_live_roundtrip_\(identity.id)",
+    fridayConversationId: conversationId,
     ownerPrincipal: liveAgentRunOwnerPrincipal,
     surfaceThreadId: "surface-mobile-live-roundtrip-\(identity.id)",
     surfaceKind: "mobile",
     deliveryRoute: "ios://friday-mobile/live-write-read-roundtrip/\(identity.id)",
     visibilityPolicy: "compact",
     missionId: identity.missionId,
-    workItemId: "work-mobile-live-roundtrip-\(identity.id)",
-    title: "Verify live mobile write appears in read projection",
-    intent: "Create a refs-only live mobile round-trip proof item and expose it through the "
-      + "Mission Workbench read projection.",
+    workItemId: workItemId,
+    title: title,
+    intent: intent,
     lane: "deepseek",
     targetProviderOrAgent: "deepseek")
 }
@@ -120,6 +131,7 @@ private func makeMobileRoundTripIntake() -> MissionIntakeRequestWire {
 private struct LiveWriteReadMissionIdentity {
   let id: String
   let missionId: String
+  let usesSharedId: Bool
 }
 
 private func liveWriteReadMissionIdentity(defaultSurface: String) -> LiveWriteReadMissionIdentity {
@@ -129,11 +141,32 @@ private func liveWriteReadMissionIdentity(defaultSurface: String) -> LiveWriteRe
     let id = rawSharedId.hasPrefix("mission_")
       ? String(rawSharedId.dropFirst("mission_".count))
       : rawSharedId
-    return LiveWriteReadMissionIdentity(id: id, missionId: "mission_\(id)")
+    return LiveWriteReadMissionIdentity(id: id, missionId: "mission_\(id)", usesSharedId: true)
   }
 
   let id = UUID().uuidString.lowercased().replacingOccurrences(of: "-", with: "")
-  return LiveWriteReadMissionIdentity(id: id, missionId: "mission-\(defaultSurface)-live-roundtrip-\(id)")
+  return LiveWriteReadMissionIdentity(id: id, missionId: "mission-\(defaultSurface)-live-roundtrip-\(id)", usesSharedId: false)
+}
+
+private func acceptedRoundTripWorkItemId(
+  result: MissionIntakeResultWire,
+  request: MissionIntakeRequestWire
+) throws -> String {
+  let ready = result.status == "ready"
+    && result.createdOrReady
+    && result.workItemId == request.workItemId
+  let duplicateExisting = result.status == "blocked"
+    && !result.createdOrReady
+    && result.blockers.contains("duplicate_active_work_item_before_dispatch")
+    && result.duplicateWorkItemId == request.workItemId
+
+  if ready || duplicateExisting {
+    return request.workItemId
+  }
+
+  throw FridayReadClientError.malformedProjection(
+    "unexpected live write-read intake status=\(result.status) workItemId=\(String(describing: result.workItemId)) "
+      + "duplicateWorkItemId=\(String(describing: result.duplicateWorkItemId)) blockers=\(result.blockers)")
 }
 
 private func pollReadProjection(
@@ -166,6 +199,7 @@ private func writeRoundTripProofIfRequested(
   request: MissionIntakeRequestWire,
   result: MissionIntakeResultWire,
   snapshot: FridayRustClient.WorkbenchSnapshot,
+  acceptedWorkItemId: String,
   writeConfig: AgentRunServerConfig,
   readConfig: ReadProjectionServerConfig
 ) throws {
@@ -174,23 +208,22 @@ private func writeRoundTripProofIfRequested(
   ]?.trimmingCharacters(in: .whitespacesAndNewlines), !rawPath.isEmpty else {
     return
   }
-  guard let workItemId = result.workItemId else {
-    throw FridayReadClientError.malformedProjection("roundtrip proof missing WorkItem id")
-  }
-
   let proof: [String: Any] = [
     "truth_label": "ios_mobile_live_write_read_roundtrip_proof_not_ui_device_proof",
     "status": "pass",
     "generated_at_utc": ISO8601DateFormatter().string(from: Date()),
     "mission_id": result.missionId,
-    "work_item_id": workItemId,
+    "work_item_id": acceptedWorkItemId,
     "surface_kind": request.surfaceKind,
     "delivery_route": request.deliveryRoute,
     "write": [
       "status": result.status,
       "created_or_ready": result.createdOrReady,
       "mission_id": result.missionId,
-      "work_item_id": workItemId,
+      "work_item_id": acceptedWorkItemId,
+      "blockers": result.blockers,
+      "duplicate_work_item_id": result.duplicateWorkItemId.map { $0 as Any } ?? NSNull(),
+      "accepted_existing_work_item": result.duplicateWorkItemId == acceptedWorkItemId && !result.createdOrReady,
       "endpoint": [
         "host": writeConfig.host,
         "port": Int(writeConfig.port),
@@ -199,7 +232,7 @@ private func writeRoundTripProofIfRequested(
     "read_projection": [
       "mission_id": snapshot.missionId,
       "work_item_ids": snapshot.workItemIds,
-      "contains_written_work_item": snapshot.workItemIds.contains(workItemId),
+      "contains_written_work_item": snapshot.workItemIds.contains(acceptedWorkItemId),
       "generated_at_ms": snapshot.generatedAtMs,
       "endpoint": [
         "host": readConfig.host,

--- a/apps/macos/FridayHubConsole/Tests/FridayHubConsoleCoreTests/LiveWriteReadProjectionRoundTripIntegrationTests.swift
+++ b/apps/macos/FridayHubConsole/Tests/FridayHubConsoleCoreTests/LiveWriteReadProjectionRoundTripIntegrationTests.swift
@@ -25,46 +25,57 @@ func liveDesktopMissionWriteAppearsInReadProjection() async throws {
   let request = makeDesktopRoundTripIntake()
 
   let result = try await writeClient.submitMissionIntake(request)
-  #expect(result.status == "ready")
-  #expect(result.createdOrReady)
   #expect(result.missionId == request.missionId)
-  #expect(result.workItemId == request.workItemId)
+  let acceptedWorkItemId = try acceptedRoundTripWorkItemId(result: result, request: request)
 
   let readConfig = ReadProjectionServerConfig.liveLoopback
   let readClient = try RealReadClientFactory.makeLive(config: readConfig, missionId: result.missionId)
   let snapshot = try await pollReadProjection(
     client: readClient,
     missionId: result.missionId,
-    workItemId: try #require(result.workItemId))
+    workItemId: acceptedWorkItemId)
 
   print(
     "[live-write-read][desktop] missionId=\(snapshot.missionId) "
       + "workItemIds=\(snapshot.workItemIds) generatedAtMs=\(snapshot.generatedAtMs)")
   #expect(snapshot.missionId == result.missionId)
-  #expect(snapshot.workItemIds.contains(request.workItemId))
+  #expect(snapshot.workItemIds.contains(acceptedWorkItemId))
 
   try writeRoundTripProofIfRequested(
     request: request,
     result: result,
     snapshot: snapshot,
+    acceptedWorkItemId: acceptedWorkItemId,
     writeConfig: writeConfig,
     readConfig: readConfig)
 }
 
 private func makeDesktopRoundTripIntake() -> MissionIntakeRequestWire {
   let identity = liveWriteReadMissionIdentity(defaultSurface: "desktop")
+  let workItemId = identity.usesSharedId
+    ? "work-live-roundtrip-\(identity.id)"
+    : "work-desktop-live-roundtrip-\(identity.id)"
+  let conversationId = identity.usesSharedId
+    ? "fconv_live_roundtrip_\(identity.id)"
+    : "fconv_desktop_live_roundtrip_\(identity.id)"
+  let title = identity.usesSharedId
+    ? "Verify live UI device write appears in read projection"
+    : "Verify live desktop write appears in read projection"
+  let intent = identity.usesSharedId
+    ? "Create a refs-only live UI device round-trip proof item and expose it through the Mission Workbench read projection."
+    : "Create a refs-only live desktop round-trip proof item and expose it through the "
+      + "Mission Workbench read projection."
   return MissionIntakeRequestWire(
-    fridayConversationId: "fconv_desktop_live_roundtrip_\(identity.id)",
+    fridayConversationId: conversationId,
     ownerPrincipal: liveReadProjectionOwnerPrincipal,
     surfaceThreadId: "surface-desktop-live-roundtrip-\(identity.id)",
     surfaceKind: "desktop",
     deliveryRoute: "desktop://hub-console/live-write-read-roundtrip/\(identity.id)",
     visibilityPolicy: "compact",
     missionId: identity.missionId,
-    workItemId: "work-desktop-live-roundtrip-\(identity.id)",
-    title: "Verify live desktop write appears in read projection",
-    intent: "Create a refs-only live desktop round-trip proof item and expose it through the "
-      + "Mission Workbench read projection.",
+    workItemId: workItemId,
+    title: title,
+    intent: intent,
     lane: "deepseek",
     targetProviderOrAgent: "deepseek")
 }
@@ -72,6 +83,7 @@ private func makeDesktopRoundTripIntake() -> MissionIntakeRequestWire {
 private struct LiveWriteReadMissionIdentity {
   let id: String
   let missionId: String
+  let usesSharedId: Bool
 }
 
 private func liveWriteReadMissionIdentity(defaultSurface: String) -> LiveWriteReadMissionIdentity {
@@ -81,11 +93,32 @@ private func liveWriteReadMissionIdentity(defaultSurface: String) -> LiveWriteRe
     let id = rawSharedId.hasPrefix("mission_")
       ? String(rawSharedId.dropFirst("mission_".count))
       : rawSharedId
-    return LiveWriteReadMissionIdentity(id: id, missionId: "mission_\(id)")
+    return LiveWriteReadMissionIdentity(id: id, missionId: "mission_\(id)", usesSharedId: true)
   }
 
   let id = UUID().uuidString.lowercased().replacingOccurrences(of: "-", with: "")
-  return LiveWriteReadMissionIdentity(id: id, missionId: "mission-\(defaultSurface)-live-roundtrip-\(id)")
+  return LiveWriteReadMissionIdentity(id: id, missionId: "mission-\(defaultSurface)-live-roundtrip-\(id)", usesSharedId: false)
+}
+
+private func acceptedRoundTripWorkItemId(
+  result: MissionIntakeResultWire,
+  request: MissionIntakeRequestWire
+) throws -> String {
+  let ready = result.status == "ready"
+    && result.createdOrReady
+    && result.workItemId == request.workItemId
+  let duplicateExisting = result.status == "blocked"
+    && !result.createdOrReady
+    && result.blockers.contains("duplicate_active_work_item_before_dispatch")
+    && result.duplicateWorkItemId == request.workItemId
+
+  if ready || duplicateExisting {
+    return request.workItemId
+  }
+
+  throw FridayReadClientError.malformedProjection(
+    "unexpected live write-read intake status=\(result.status) workItemId=\(String(describing: result.workItemId)) "
+      + "duplicateWorkItemId=\(String(describing: result.duplicateWorkItemId)) blockers=\(result.blockers)")
 }
 
 private func pollReadProjection(
@@ -118,6 +151,7 @@ private func writeRoundTripProofIfRequested(
   request: MissionIntakeRequestWire,
   result: MissionIntakeResultWire,
   snapshot: FridayRustClient.WorkbenchSnapshot,
+  acceptedWorkItemId: String,
   writeConfig: AgentRunWriteServerConfig,
   readConfig: ReadProjectionServerConfig
 ) throws {
@@ -126,23 +160,22 @@ private func writeRoundTripProofIfRequested(
   ]?.trimmingCharacters(in: .whitespacesAndNewlines), !rawPath.isEmpty else {
     return
   }
-  guard let workItemId = result.workItemId else {
-    throw FridayReadClientError.malformedProjection("desktop roundtrip proof missing WorkItem id")
-  }
-
   let proof: [String: Any] = [
     "truth_label": "macos_desktop_live_write_read_roundtrip_proof_not_ui_device_proof",
     "status": "pass",
     "generated_at_utc": ISO8601DateFormatter().string(from: Date()),
     "mission_id": result.missionId,
-    "work_item_id": workItemId,
+    "work_item_id": acceptedWorkItemId,
     "surface_kind": request.surfaceKind,
     "delivery_route": request.deliveryRoute,
     "write": [
       "status": result.status,
       "created_or_ready": result.createdOrReady,
       "mission_id": result.missionId,
-      "work_item_id": workItemId,
+      "work_item_id": acceptedWorkItemId,
+      "blockers": result.blockers,
+      "duplicate_work_item_id": result.duplicateWorkItemId.map { $0 as Any } ?? NSNull(),
+      "accepted_existing_work_item": result.duplicateWorkItemId == acceptedWorkItemId && !result.createdOrReady,
       "endpoint": [
         "host": writeConfig.host,
         "port": Int(writeConfig.port),
@@ -151,7 +184,7 @@ private func writeRoundTripProofIfRequested(
     "read_projection": [
       "mission_id": snapshot.missionId,
       "work_item_ids": snapshot.workItemIds,
-      "contains_written_work_item": snapshot.workItemIds.contains(workItemId),
+      "contains_written_work_item": snapshot.workItemIds.contains(acceptedWorkItemId),
       "generated_at_ms": snapshot.generatedAtMs,
       "endpoint": [
         "host": readConfig.host,

--- a/scripts/ops/friday-ios-live-write-read-proof-events.mjs
+++ b/scripts/ops/friday-ios-live-write-read-proof-events.mjs
@@ -66,6 +66,10 @@ function arrayField(value, field, label) {
   return [];
 }
 
+function optionalArrayField(value, field) {
+  return value && Array.isArray(value[field]) ? value[field] : [];
+}
+
 if (!proofPath) block("missing_arg", "proof");
 const proof = proofPath ? readJson(abs(proofPath)) : null;
 const evidenceRef = proofPath ? abs(proofPath) : "";
@@ -95,8 +99,16 @@ if (surfaceKind && surfaceKind !== "mobile") block("surface_kind_not_mobile", su
 
 const write = proof?.write ?? null;
 const writeStatus = stringField(write, "status", "proof.write");
-if (writeStatus && writeStatus !== "ready") block("write_status_not_ready", writeStatus);
-if (!booleanField(write, "created_or_ready", "proof.write")) {
+const writeBlockers = optionalArrayField(write, "blockers").filter((value) => typeof value === "string");
+const duplicateWorkItemId = typeof write?.duplicate_work_item_id === "string" ? write.duplicate_work_item_id : "";
+const acceptedExistingWorkItem = write?.accepted_existing_work_item === true;
+const duplicateExisting = writeStatus === "blocked"
+  && !write?.created_or_ready
+  && acceptedExistingWorkItem
+  && duplicateWorkItemId === workItemId
+  && writeBlockers.includes("duplicate_active_work_item_before_dispatch");
+if (writeStatus && writeStatus !== "ready" && !duplicateExisting) block("write_status_not_ready", writeStatus);
+if (!booleanField(write, "created_or_ready", "proof.write") && !duplicateExisting) {
   block("write_created_or_ready_false", "proof.write.created_or_ready");
 }
 if (write && write.mission_id !== missionId) block("write_mission_mismatch", String(write.mission_id ?? ""));
@@ -120,7 +132,9 @@ const eventNames = [
   "same_mission_projection_visible",
 ];
 const events = blockers.length === 0
-  ? eventNames.map((event) => ({
+  ? eventNames.map((event) => event === "mission_intake_ready" && duplicateExisting
+    ? "duplicate_preflight_visible"
+    : event).map((event) => ({
     surface: "mobile",
     event,
     mission_id: missionId,

--- a/scripts/ops/friday-macos-live-write-read-proof-events.mjs
+++ b/scripts/ops/friday-macos-live-write-read-proof-events.mjs
@@ -66,6 +66,10 @@ function arrayField(value, field, label) {
   return [];
 }
 
+function optionalArrayField(value, field) {
+  return value && Array.isArray(value[field]) ? value[field] : [];
+}
+
 if (!proofPath) block("missing_arg", "proof");
 const proof = proofPath ? readJson(abs(proofPath)) : null;
 const evidenceRef = proofPath ? abs(proofPath) : "";
@@ -95,8 +99,16 @@ if (surfaceKind && surfaceKind !== "desktop") block("surface_kind_not_desktop", 
 
 const write = proof?.write ?? null;
 const writeStatus = stringField(write, "status", "proof.write");
-if (writeStatus && writeStatus !== "ready") block("write_status_not_ready", writeStatus);
-if (!booleanField(write, "created_or_ready", "proof.write")) {
+const writeBlockers = optionalArrayField(write, "blockers").filter((value) => typeof value === "string");
+const duplicateWorkItemId = typeof write?.duplicate_work_item_id === "string" ? write.duplicate_work_item_id : "";
+const acceptedExistingWorkItem = write?.accepted_existing_work_item === true;
+const duplicateExisting = writeStatus === "blocked"
+  && !write?.created_or_ready
+  && acceptedExistingWorkItem
+  && duplicateWorkItemId === workItemId
+  && writeBlockers.includes("duplicate_active_work_item_before_dispatch");
+if (writeStatus && writeStatus !== "ready" && !duplicateExisting) block("write_status_not_ready", writeStatus);
+if (!booleanField(write, "created_or_ready", "proof.write") && !duplicateExisting) {
   block("write_created_or_ready_false", "proof.write.created_or_ready");
 }
 if (write && write.mission_id !== missionId) block("write_mission_mismatch", String(write.mission_id ?? ""));
@@ -120,7 +132,9 @@ const eventNames = [
   "same_mission_projection_visible",
 ];
 const events = blockers.length === 0
-  ? eventNames.map((event) => ({
+  ? eventNames.map((event) => event === "mission_intake_ready" && duplicateExisting
+    ? "duplicate_preflight_visible"
+    : event).map((event) => ({
     surface: "desktop",
     event,
     mission_id: missionId,

--- a/scripts/ops/friday-ui-device-live-write-read-bundle.mjs
+++ b/scripts/ops/friday-ui-device-live-write-read-bundle.mjs
@@ -32,7 +32,7 @@ if (args.includes("--help") || args.includes("-h")) {
 
 const requireReady = args.includes("--require-ready");
 const outDirArg = arg("out-dir");
-const expectedMissionId = arg("mission-id");
+const rawExpectedMissionId = arg("mission-id");
 const captureDirs = {
   mobile: arg("mobile-capture-dir"),
   desktop: arg("desktop-capture-dir"),
@@ -49,6 +49,11 @@ function abs(path) {
 
 function sha256(path) {
   return createHash("sha256").update(readFileSync(path)).digest("hex");
+}
+
+function canonicalMissionId(value) {
+  if (!value) return "";
+  return value.startsWith("mission_") ? value : `mission_${value}`;
 }
 
 function readJson(path, label) {
@@ -124,9 +129,10 @@ function capturePaths(index, role, dir) {
 
 if (!outDirArg) block("missing_arg", "out-dir");
 if (outDirArg && !isAbsolute(outDirArg)) block("out_dir_not_absolute", outDirArg);
-if (expectedMissionId && !expectedMissionId.toLowerCase().includes("mission")) {
-  block("mission_id_unexpected_shape", expectedMissionId);
+if (rawExpectedMissionId && !rawExpectedMissionId.toLowerCase().includes("mission")) {
+  block("mission_id_unexpected_shape", rawExpectedMissionId);
 }
+const expectedMissionId = canonicalMissionId(rawExpectedMissionId);
 
 const outDir = outDirArg ? abs(outDirArg) : "";
 const dirs = Object.fromEntries(Object.entries(captureDirs).map(([role, value]) => [role, requireDir(value, `${role}-capture-dir`)]));

--- a/scripts/ops/friday-ui-device-live-write-read-capture-bundle.sh
+++ b/scripts/ops/friday-ui-device-live-write-read-capture-bundle.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat >&2 <<'EOF'
+usage:
+  scripts/ops/friday-ui-device-live-write-read-capture-bundle.sh --out-dir /abs/capture-root
+    [--shared-id mission_ui_device_...]
+    [--read-host 127.0.0.1] [--read-port 48751]
+    [--write-host 127.0.0.1] [--write-port 48750]
+
+Runs the mobile and desktop live write-read capture runners with one shared
+mission id, then indexes the resulting artifacts into a partial bundle.
+
+Truth: this orchestrates real capture runners only. It does not synthesize
+proof rows, does not create channel/timeline/stress observations, and does not
+claim END-BAR, GO-LIVE, adoption, or operator signing completion.
+EOF
+}
+
+die() {
+  echo "FATAL: $*" >&2
+  exit 2
+}
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+out_dir=""
+read_host="${FRIDAY_MOBILE_LIVE_READ_HOST:-127.0.0.1}"
+read_port="${FRIDAY_MOBILE_LIVE_READ_PORT:-48751}"
+write_host="${FRIDAY_MOBILE_LIVE_WRITE_HOST:-127.0.0.1}"
+write_port="${FRIDAY_MOBILE_LIVE_WRITE_PORT:-48750}"
+shared_id="${FRIDAY_MISSION_SPINE_UI_PROOF_SHARED_ID:-}"
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --out-dir)
+      [ "$#" -ge 2 ] || die "--out-dir requires a value"
+      out_dir="$2"
+      shift 2
+      ;;
+    --out-dir=*)
+      out_dir="${1#--out-dir=}"
+      shift
+      ;;
+    --shared-id)
+      [ "$#" -ge 2 ] || die "--shared-id requires a value"
+      shared_id="$2"
+      shift 2
+      ;;
+    --shared-id=*)
+      shared_id="${1#--shared-id=}"
+      shift
+      ;;
+    --read-host)
+      [ "$#" -ge 2 ] || die "--read-host requires a value"
+      read_host="$2"
+      shift 2
+      ;;
+    --read-host=*)
+      read_host="${1#--read-host=}"
+      shift
+      ;;
+    --read-port)
+      [ "$#" -ge 2 ] || die "--read-port requires a value"
+      read_port="$2"
+      shift 2
+      ;;
+    --read-port=*)
+      read_port="${1#--read-port=}"
+      shift
+      ;;
+    --write-host)
+      [ "$#" -ge 2 ] || die "--write-host requires a value"
+      write_host="$2"
+      shift 2
+      ;;
+    --write-host=*)
+      write_host="${1#--write-host=}"
+      shift
+      ;;
+    --write-port)
+      [ "$#" -ge 2 ] || die "--write-port requires a value"
+      write_port="$2"
+      shift 2
+      ;;
+    --write-port=*)
+      write_port="${1#--write-port=}"
+      shift
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      die "unknown argument: $1"
+      ;;
+  esac
+done
+
+[ -n "${out_dir}" ] || die "missing --out-dir"
+case "${out_dir}" in
+  /*) ;;
+  *) die "--out-dir must be absolute" ;;
+esac
+case "${read_port}" in (*[!0-9]*|"") die "--read-port must be numeric" ;; esac
+case "${write_port}" in (*[!0-9]*|"") die "--write-port must be numeric" ;; esac
+
+if [ -z "${shared_id}" ]; then
+  shared_id="mission-ui-device-live-write-read-$(date -u +%Y%m%dT%H%M%SZ)-$(uuidgen | tr '[:upper:]' '[:lower:]')"
+fi
+case "${shared_id}" in (*[[:space:]]*) die "--shared-id must not contain whitespace" ;; esac
+case "${shared_id}" in (*mission*) ;; *) die "--shared-id must contain mission" ;; esac
+
+mobile_dir="${out_dir}/mobile"
+desktop_dir="${out_dir}/desktop"
+bundle_dir="${out_dir}/bundle"
+
+mkdir -p "${out_dir}"
+
+echo "Friday UI/device live write-read capture bundle starting."
+echo "out_dir=${out_dir}"
+echo "shared_id=${shared_id}"
+echo "truth=ui_device_live_write_read_capture_bundle_orchestrator_not_full_proof"
+
+bash "${repo_root}/scripts/ops/friday-ios-live-write-read-capture.sh" \
+  --out-dir "${mobile_dir}" \
+  --read-host "${read_host}" \
+  --read-port "${read_port}" \
+  --write-host "${write_host}" \
+  --write-port "${write_port}" \
+  --shared-id "${shared_id}"
+
+bash "${repo_root}/scripts/ops/friday-macos-live-write-read-capture.sh" \
+  --out-dir "${desktop_dir}" \
+  --shared-id "${shared_id}"
+
+node "${repo_root}/scripts/ops/friday-ui-device-live-write-read-bundle.mjs" \
+  --out-dir="${bundle_dir}" \
+  --mobile-capture-dir="${mobile_dir}" \
+  --desktop-capture-dir="${desktop_dir}" \
+  --mission-id="${shared_id}" \
+  --require-ready
+
+echo "PASS - same-mission mobile+desktop live write-read capture bundle written."
+echo "bundle=${bundle_dir}/live-write-read-bundle-index.json"
+echo "Truth: partial UI/device live write-read bundle only; not END-BAR / not GO-LIVE / not adoption."

--- a/scripts/ops/friday-ui-device-live-write-read-capture-bundle.sh
+++ b/scripts/ops/friday-ui-device-live-write-read-capture-bundle.sh
@@ -166,6 +166,10 @@ if [ -z "${shared_id}" ]; then
 fi
 case "${shared_id}" in (*[[:space:]]*) die "--shared-id must not contain whitespace" ;; esac
 case "${shared_id}" in (*mission*) ;; *) die "--shared-id must contain mission" ;; esac
+case "${shared_id}" in
+  mission_*) canonical_shared_mission_id="${shared_id}" ;;
+  *) canonical_shared_mission_id="mission_${shared_id}" ;;
+esac
 
 mobile_dir="${out_dir}/mobile"
 desktop_dir="${out_dir}/desktop"
@@ -197,7 +201,7 @@ node "${repo_root}/scripts/ops/friday-ui-device-live-write-read-bundle.mjs" \
   --out-dir="${bundle_dir}" \
   --mobile-capture-dir="${mobile_dir}" \
   --desktop-capture-dir="${desktop_dir}" \
-  --mission-id="${shared_id}" \
+  --mission-id="${canonical_shared_mission_id}" \
   --require-ready
 
 if [ -n "${channel_capture}${timeline_capture}${same_run_events}" ]; then
@@ -206,7 +210,7 @@ if [ -n "${channel_capture}${timeline_capture}${same_run_events}" ]; then
   [ -n "${same_run_events}" ] || die "--same-run-events is required when building an evidence dir"
 
   node "${repo_root}/scripts/ops/friday-ui-device-capture-dir.mjs" \
-    --mission-id="${shared_id}" \
+    --mission-id="${canonical_shared_mission_id}" \
     --out-dir="${evidence_dir}" \
     --mobile="${mobile_dir}/ios-live-write-read-proof.json" \
     --desktop="${desktop_dir}/macos-live-write-read-proof.json" \

--- a/scripts/ops/friday-ui-device-live-write-read-capture-bundle.sh
+++ b/scripts/ops/friday-ui-device-live-write-read-capture-bundle.sh
@@ -8,6 +8,10 @@ usage:
     [--shared-id mission_ui_device_...]
     [--read-host 127.0.0.1] [--read-port 48751]
     [--write-host 127.0.0.1] [--write-port 48750]
+    [--channel-capture /abs/channel-capture]
+    [--timeline-capture /abs/timeline-capture]
+    [--same-run-events /abs/same-run-events.jsonl]
+    [--evidence-dir /abs/evidence-dir]
 
 Runs the mobile and desktop live write-read capture runners with one shared
 mission id, then indexes the resulting artifacts into a partial bundle.
@@ -15,6 +19,10 @@ mission id, then indexes the resulting artifacts into a partial bundle.
 Truth: this orchestrates real capture runners only. It does not synthesize
 proof rows, does not create channel/timeline/stress observations, and does not
 claim END-BAR, GO-LIVE, adoption, or operator signing completion.
+
+When channel/timeline captures and same-run events are supplied, the script also
+delegates to the existing capture-dir/preflight driver. It still never invents
+missing channel, timeline, stress, or negative-control observations.
 EOF
 }
 
@@ -30,6 +38,10 @@ read_port="${FRIDAY_MOBILE_LIVE_READ_PORT:-48751}"
 write_host="${FRIDAY_MOBILE_LIVE_WRITE_HOST:-127.0.0.1}"
 write_port="${FRIDAY_MOBILE_LIVE_WRITE_PORT:-48750}"
 shared_id="${FRIDAY_MISSION_SPINE_UI_PROOF_SHARED_ID:-}"
+channel_capture=""
+timeline_capture=""
+same_run_events=""
+evidence_dir=""
 
 while [ "$#" -gt 0 ]; do
   case "$1" in
@@ -87,6 +99,42 @@ while [ "$#" -gt 0 ]; do
       write_port="${1#--write-port=}"
       shift
       ;;
+    --channel-capture)
+      [ "$#" -ge 2 ] || die "--channel-capture requires a value"
+      channel_capture="$2"
+      shift 2
+      ;;
+    --channel-capture=*)
+      channel_capture="${1#--channel-capture=}"
+      shift
+      ;;
+    --timeline-capture)
+      [ "$#" -ge 2 ] || die "--timeline-capture requires a value"
+      timeline_capture="$2"
+      shift 2
+      ;;
+    --timeline-capture=*)
+      timeline_capture="${1#--timeline-capture=}"
+      shift
+      ;;
+    --same-run-events)
+      [ "$#" -ge 2 ] || die "--same-run-events requires a value"
+      same_run_events="$2"
+      shift 2
+      ;;
+    --same-run-events=*)
+      same_run_events="${1#--same-run-events=}"
+      shift
+      ;;
+    --evidence-dir)
+      [ "$#" -ge 2 ] || die "--evidence-dir requires a value"
+      evidence_dir="$2"
+      shift 2
+      ;;
+    --evidence-dir=*)
+      evidence_dir="${1#--evidence-dir=}"
+      shift
+      ;;
     --help|-h)
       usage
       exit 0
@@ -104,6 +152,14 @@ case "${out_dir}" in
 esac
 case "${read_port}" in (*[!0-9]*|"") die "--read-port must be numeric" ;; esac
 case "${write_port}" in (*[!0-9]*|"") die "--write-port must be numeric" ;; esac
+for optional_path in "${channel_capture}" "${timeline_capture}" "${same_run_events}" "${evidence_dir}"; do
+  if [ -n "${optional_path}" ]; then
+    case "${optional_path}" in
+      /*) ;;
+      *) die "optional capture/evidence paths must be absolute: ${optional_path}" ;;
+    esac
+  fi
+done
 
 if [ -z "${shared_id}" ]; then
   shared_id="mission-ui-device-live-write-read-$(date -u +%Y%m%dT%H%M%SZ)-$(uuidgen | tr '[:upper:]' '[:lower:]')"
@@ -114,6 +170,9 @@ case "${shared_id}" in (*mission*) ;; *) die "--shared-id must contain mission" 
 mobile_dir="${out_dir}/mobile"
 desktop_dir="${out_dir}/desktop"
 bundle_dir="${out_dir}/bundle"
+if [ -z "${evidence_dir}" ]; then
+  evidence_dir="${out_dir}/evidence"
+fi
 
 mkdir -p "${out_dir}"
 
@@ -140,6 +199,24 @@ node "${repo_root}/scripts/ops/friday-ui-device-live-write-read-bundle.mjs" \
   --desktop-capture-dir="${desktop_dir}" \
   --mission-id="${shared_id}" \
   --require-ready
+
+if [ -n "${channel_capture}${timeline_capture}${same_run_events}" ]; then
+  [ -n "${channel_capture}" ] || die "--channel-capture is required when building an evidence dir"
+  [ -n "${timeline_capture}" ] || die "--timeline-capture is required when building an evidence dir"
+  [ -n "${same_run_events}" ] || die "--same-run-events is required when building an evidence dir"
+
+  node "${repo_root}/scripts/ops/friday-ui-device-capture-dir.mjs" \
+    --mission-id="${shared_id}" \
+    --out-dir="${evidence_dir}" \
+    --mobile="${mobile_dir}/ios-live-write-read-proof.json" \
+    --desktop="${desktop_dir}/macos-live-write-read-proof.json" \
+    --channel="${channel_capture}" \
+    --timeline="${timeline_capture}" \
+    --events="${same_run_events}" \
+    --require-ready
+
+  echo "evidence=${evidence_dir}/capture-index.json"
+fi
 
 echo "PASS - same-mission mobile+desktop live write-read capture bundle written."
 echo "bundle=${bundle_dir}/live-write-read-bundle-index.json"

--- a/test/unit/qa/friday-ios-live-write-read-proof-events-cli.test.ts
+++ b/test/unit/qa/friday-ios-live-write-read-proof-events-cli.test.ts
@@ -83,6 +83,51 @@ describe("friday-ios-live-write-read-proof-events", () => {
     }
   });
 
+  it("accepts shared-mission duplicate-existing preflight when the same WorkItem is visible", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "friday-ios-roundtrip-events-duplicate-"));
+    try {
+      const proofPath = writeProof(tempDir, proof({
+        write: {
+          status: "blocked",
+          created_or_ready: false,
+          mission_id: missionId,
+          work_item_id: workItemId,
+          blockers: ["duplicate_active_work_item_before_dispatch"],
+          duplicate_work_item_id: workItemId,
+          accepted_existing_work_item: true,
+          endpoint: { host: "127.0.0.1", port: 48750 },
+        },
+      }));
+      const outPath = join(tempDir, "events.jsonl");
+      const stdout = execFileSync("node", [
+        script,
+        `--proof=${proofPath}`,
+        `--out=${outPath}`,
+        "--require-ready",
+      ], { cwd: process.cwd(), encoding: "utf8" });
+
+      const result = JSON.parse(stdout) as { status?: string; eventCount?: number; blockers?: unknown[] };
+      expect(result.status).toBe("ready");
+      expect(result.eventCount).toBe(5);
+      expect(result.blockers).toEqual([]);
+
+      const rows = readFileSync(outPath, "utf8").trim().split("\n").map((line) => JSON.parse(line)) as Array<{
+        event?: string;
+        work_item_id?: string;
+      }>;
+      expect(rows.map((row) => row.event)).toEqual([
+        "mission_intake_submitted",
+        "duplicate_preflight_visible",
+        "mission_bound_provider_action_visible",
+        "proof_receipt_visible_before_done",
+        "same_mission_projection_visible",
+      ]);
+      expect(new Set(rows.map((row) => row.work_item_id))).toEqual(new Set([workItemId]));
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
   it("blocks artifacts whose read projection does not contain the written WorkItem", () => {
     const tempDir = mkdtempSync(join(tmpdir(), "friday-ios-roundtrip-events-blocked-"));
     try {

--- a/test/unit/qa/friday-macos-live-write-read-proof-events-cli.test.ts
+++ b/test/unit/qa/friday-macos-live-write-read-proof-events-cli.test.ts
@@ -83,6 +83,51 @@ describe("friday-macos-live-write-read-proof-events", () => {
     }
   });
 
+  it("accepts shared-mission duplicate-existing preflight when the same WorkItem is visible", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "friday-macos-roundtrip-events-duplicate-"));
+    try {
+      const proofPath = writeProof(tempDir, proof({
+        write: {
+          status: "blocked",
+          created_or_ready: false,
+          mission_id: missionId,
+          work_item_id: workItemId,
+          blockers: ["duplicate_active_work_item_before_dispatch"],
+          duplicate_work_item_id: workItemId,
+          accepted_existing_work_item: true,
+          endpoint: { host: "127.0.0.1", port: 48750 },
+        },
+      }));
+      const outPath = join(tempDir, "events.jsonl");
+      const stdout = execFileSync("node", [
+        script,
+        `--proof=${proofPath}`,
+        `--out=${outPath}`,
+        "--require-ready",
+      ], { cwd: process.cwd(), encoding: "utf8" });
+
+      const result = JSON.parse(stdout) as { status?: string; eventCount?: number; blockers?: unknown[] };
+      expect(result.status).toBe("ready");
+      expect(result.eventCount).toBe(5);
+      expect(result.blockers).toEqual([]);
+
+      const rows = readFileSync(outPath, "utf8").trim().split("\n").map((line) => JSON.parse(line)) as Array<{
+        event?: string;
+        work_item_id?: string;
+      }>;
+      expect(rows.map((row) => row.event)).toEqual([
+        "mission_intake_submitted",
+        "duplicate_preflight_visible",
+        "mission_bound_provider_action_visible",
+        "proof_receipt_visible_before_done",
+        "same_mission_projection_visible",
+      ]);
+      expect(new Set(rows.map((row) => row.work_item_id))).toEqual(new Set([workItemId]));
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
   it("blocks artifacts whose read projection does not contain the written WorkItem", () => {
     const tempDir = mkdtempSync(join(tmpdir(), "friday-macos-roundtrip-events-blocked-"));
     try {

--- a/test/unit/qa/friday-ui-device-live-write-read-bundle-cli.test.ts
+++ b/test/unit/qa/friday-ui-device-live-write-read-bundle-cli.test.ts
@@ -91,6 +91,33 @@ describe("friday-ui-device-live-write-read-bundle", () => {
     }
   });
 
+  it("canonicalizes raw shared mission ids the same way as the live capture clients", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "friday-ui-live-bundle-canonical-"));
+    try {
+      const rawSharedId = "mission-live-write-read-canonical";
+      const canonicalMissionId = `mission_${rawSharedId}`;
+      const mobileDir = writeCapture(tempDir, "mobile", canonicalMissionId);
+      const desktopDir = writeCapture(tempDir, "desktop", canonicalMissionId);
+      const outDir = join(tempDir, "bundle");
+
+      const stdout = execFileSync("node", [
+        script,
+        `--out-dir=${outDir}`,
+        `--mobile-capture-dir=${mobileDir}`,
+        `--desktop-capture-dir=${desktopDir}`,
+        `--mission-id=${rawSharedId}`,
+        "--require-ready",
+      ], { cwd: process.cwd(), encoding: "utf8" });
+
+      const result = JSON.parse(stdout) as { status?: string; missionId?: string; blockers?: unknown[] };
+      expect(result.status).toBe("partial_bundle_ready");
+      expect(result.missionId).toBe(canonicalMissionId);
+      expect(result.blockers).toEqual([]);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
   it("fails closed when mobile and desktop captures are not the same mission", () => {
     const tempDir = mkdtempSync(join(tmpdir(), "friday-ui-live-bundle-mismatch-"));
     try {

--- a/test/unit/qa/friday-ui-device-live-write-read-capture-bundle-cli.test.ts
+++ b/test/unit/qa/friday-ui-device-live-write-read-capture-bundle-cli.test.ts
@@ -1,0 +1,114 @@
+import { execFileSync as execFile, spawnSync as spawn } from "node:child_process";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const script = "scripts/ops/friday-ui-device-live-write-read-capture-bundle.sh";
+const sharedId = "mission-ui-device-live-write-read-test";
+const workItemId = "work-ui-device-live-write-read-test";
+
+function fakeSwiftScript(dir: string, expectedSharedId = sharedId) {
+  const bin = join(dir, "bin");
+  mkdirSync(bin, { recursive: true });
+  const path = join(bin, "swift");
+  writeFileSync(path, `#!/usr/bin/env bash
+set -euo pipefail
+[ "$1" = "test" ] || exit 42
+[ "\${FRIDAY_MISSION_SPINE_UI_PROOF_SHARED_ID:-}" = "${expectedSharedId}" ] || exit 44
+if [ -n "\${FRIDAY_MOBILE_LIVE_WRITE_READ_ROUNDTRIP_PROOF_OUT:-}" ]; then
+  surface_kind="mobile"
+  truth_label="ios_mobile_live_write_read_roundtrip_proof_not_ui_device_proof"
+  route="ios://friday-mobile/live-write-read-roundtrip/wrapper"
+  proof_out="\${FRIDAY_MOBILE_LIVE_WRITE_READ_ROUNDTRIP_PROOF_OUT}"
+else
+  [ -n "\${FRIDAY_DESKTOP_LIVE_WRITE_READ_ROUNDTRIP_PROOF_OUT:-}" ] || exit 43
+  surface_kind="desktop"
+  truth_label="macos_desktop_live_write_read_roundtrip_proof_not_ui_device_proof"
+  route="desktop://hub-console/live-write-read-roundtrip/wrapper"
+  proof_out="\${FRIDAY_DESKTOP_LIVE_WRITE_READ_ROUNDTRIP_PROOF_OUT}"
+fi
+cat >"\${proof_out}" <<JSON
+{
+  "truth_label": "\${truth_label}",
+  "status": "pass",
+  "generated_at_utc": "2026-06-24T12:00:00Z",
+  "mission_id": "${expectedSharedId}",
+  "work_item_id": "${workItemId}",
+  "surface_kind": "\${surface_kind}",
+  "delivery_route": "\${route}",
+  "write": {
+    "status": "ready",
+    "created_or_ready": true,
+    "mission_id": "${expectedSharedId}",
+    "work_item_id": "${workItemId}",
+    "endpoint": { "host": "127.0.0.1", "port": 48750 }
+  },
+  "read_projection": {
+    "mission_id": "${expectedSharedId}",
+    "work_item_ids": ["${workItemId}"],
+    "contains_written_work_item": true,
+    "generated_at_ms": 1782290000000,
+    "endpoint": { "host": "127.0.0.1", "port": 48751 }
+  },
+  "caveat": "Live write-read artifact only; not END-BAR, not GO-LIVE, not UI/device proof."
+}
+JSON
+`, { mode: 0o755 });
+  return bin;
+}
+
+describe("friday-ui-device-live-write-read-capture-bundle", () => {
+  it("runs mobile and desktop captures with the same mission id, then writes a partial bundle", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "friday-ui-device-orchestrator-"));
+    try {
+      const outDir = join(tempDir, "capture");
+      const fakeBin = fakeSwiftScript(tempDir);
+
+      const stdout = execFile("bash", [
+        script,
+        `--out-dir=${outDir}`,
+        `--shared-id=${sharedId}`,
+        "--read-port=59151",
+      ], {
+        cwd: process.cwd(),
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          PATH: `${fakeBin}:${process.env.PATH ?? ""}`,
+        },
+      });
+
+      expect(stdout).toContain("PASS - same-mission mobile+desktop live write-read capture bundle written");
+      const index = JSON.parse(readFileSync(join(outDir, "bundle", "live-write-read-bundle-index.json"), "utf8")) as {
+        status?: string;
+        missionId?: string;
+        captures?: Record<string, { event_count?: number }>;
+        fullProofGaps?: string[];
+      };
+      expect(index.status).toBe("partial_bundle_ready");
+      expect(index.missionId).toBe(sharedId);
+      expect(index.captures?.mobile?.event_count).toBe(5);
+      expect(index.captures?.desktop?.event_count).toBe(5);
+      expect(index.fullProofGaps).toContain("bounded_timeline_capture");
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects relative output directories and malformed shared ids before running captures", () => {
+    const relative = spawn("bash", [script, "--out-dir=relative"], {
+      cwd: process.cwd(),
+      encoding: "utf8",
+    });
+    expect(relative.status).toBe(2);
+    expect(relative.stderr).toContain("--out-dir must be absolute");
+
+    const malformed = spawn("bash", [script, `--out-dir=${tmpdir()}`, "--shared-id=not-a-valid-id"], {
+      cwd: process.cwd(),
+      encoding: "utf8",
+    });
+    expect(malformed.status).toBe(2);
+    expect(malformed.stderr).toContain("--shared-id must contain mission");
+  });
+});

--- a/test/unit/qa/friday-ui-device-live-write-read-capture-bundle-cli.test.ts
+++ b/test/unit/qa/friday-ui-device-live-write-read-capture-bundle-cli.test.ts
@@ -58,6 +58,47 @@ JSON
   return bin;
 }
 
+function event(surface: string, name: string, evidenceRef: string) {
+  return { surface, event: name, mission_id: sharedId, evidence_ref: evidenceRef };
+}
+
+function writeCompleteSameRunEvents(path: string, refs: { mobile: string; desktop: string; channel: string; timeline: string }) {
+  const rows = [
+    event("mobile", "mission_intake_submitted", refs.mobile),
+    event("mobile", "mission_intake_ready", refs.mobile),
+    event("desktop", "mission_resolve_or_create_visible", refs.desktop),
+    event("desktop", "duplicate_preflight_visible", refs.desktop),
+    event("mobile", "duplicate_preflight_visible", refs.mobile),
+    event("mobile", "mission_bound_provider_action_visible", refs.mobile),
+    event("desktop", "real_provider_execution_visible", refs.desktop),
+    event("mobile", "proof_receipt_visible_before_done", refs.mobile),
+    event("desktop", "same_mission_projection_visible", refs.desktop),
+    event("desktop", "mission_workbench_visible", refs.desktop),
+    event("desktop", "transcript_browser_visible", refs.desktop),
+    event("desktop", "duplicate_blocked_opens_existing", refs.desktop),
+    event("channel", "same_mission_projection_visible", refs.channel),
+    event("channel", "same_mission_mobile_desktop_channel_visible", refs.channel),
+    event("timeline", "bounded_page_1_visible", refs.timeline),
+    event("timeline", "bounded_page_2_visible", refs.timeline),
+    event("timeline", "memory_candidate_review_only", refs.timeline),
+    event("desktop", "provider_ack_not_done_visible", refs.desktop),
+    event("desktop", "invalid_key_error_visible", refs.desktop),
+    event("desktop", "quota_error_visible", refs.desktop),
+    event("desktop", "network_error_visible", refs.desktop),
+    event("channel", "channel_replay_blocked_visible", refs.channel),
+    event("desktop", "reconnect_stale_verified", refs.desktop),
+    event("desktop", "real_provider_execution_receipt_visible", refs.desktop),
+    event("desktop", "stale_label_visible", refs.desktop),
+    event("desktop", "offline_label_visible", refs.desktop),
+    event("desktop", "error_label_visible", refs.desktop),
+    event("desktop", "no_hidden_fallback_verified", refs.desktop),
+  ];
+  for (let index = 0; index < 20; index += 1) {
+    rows.push(event("desktop", "pressure_20_50_consecutive_asks_visible", refs.desktop));
+  }
+  writeFileSync(path, `${rows.map((row) => JSON.stringify(row)).join("\n")}\n`);
+}
+
 describe("friday-ui-device-live-write-read-capture-bundle", () => {
   it("runs mobile and desktop captures with the same mission id, then writes a partial bundle", () => {
     const tempDir = mkdtempSync(join(tmpdir(), "friday-ui-device-orchestrator-"));
@@ -91,6 +132,51 @@ describe("friday-ui-device-live-write-read-capture-bundle", () => {
       expect(index.captures?.mobile?.event_count).toBe(5);
       expect(index.captures?.desktop?.event_count).toBe(5);
       expect(index.fullProofGaps).toContain("bounded_timeline_capture");
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("delegates to the capture-dir preflight when real channel and timeline inputs are supplied", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "friday-ui-device-orchestrator-full-"));
+    try {
+      const outDir = join(tempDir, "capture");
+      const channel = join(tempDir, "channel.log");
+      const timeline = join(tempDir, "timeline.trace");
+      const events = join(tempDir, "same-run-events.jsonl");
+      const fakeBin = fakeSwiftScript(tempDir);
+      writeFileSync(channel, "real channel capture\n");
+      writeFileSync(timeline, "real timeline capture\n");
+      writeCompleteSameRunEvents(events, {
+        mobile: join(outDir, "mobile", "ios-live-write-read-proof.json"),
+        desktop: join(outDir, "desktop", "macos-live-write-read-proof.json"),
+        channel,
+        timeline,
+      });
+
+      const stdout = execFile("bash", [
+        script,
+        `--out-dir=${outDir}`,
+        `--shared-id=${sharedId}`,
+        `--channel-capture=${channel}`,
+        `--timeline-capture=${timeline}`,
+        `--same-run-events=${events}`,
+      ], {
+        cwd: process.cwd(),
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          PATH: `${fakeBin}:${process.env.PATH ?? ""}`,
+        },
+      });
+
+      expect(stdout).toContain("evidence=");
+      const captureIndex = JSON.parse(readFileSync(join(outDir, "evidence", "capture-index.json"), "utf8")) as {
+        status?: string;
+        observationsManifest?: string;
+      };
+      expect(captureIndex.status).toBe("ready_for_preflight");
+      expect(captureIndex.observationsManifest).toContain("observations-manifest.json");
     } finally {
       rmSync(tempDir, { recursive: true, force: true });
     }

--- a/test/unit/qa/friday-ui-device-live-write-read-capture-bundle-cli.test.ts
+++ b/test/unit/qa/friday-ui-device-live-write-read-capture-bundle-cli.test.ts
@@ -6,6 +6,7 @@ import { describe, expect, it } from "vitest";
 
 const script = "scripts/ops/friday-ui-device-live-write-read-capture-bundle.sh";
 const sharedId = "mission-ui-device-live-write-read-test";
+const canonicalMissionId = `mission_${sharedId}`;
 const workItemId = "work-ui-device-live-write-read-test";
 
 function fakeSwiftScript(dir: string, expectedSharedId = sharedId) {
@@ -33,19 +34,19 @@ cat >"\${proof_out}" <<JSON
   "truth_label": "\${truth_label}",
   "status": "pass",
   "generated_at_utc": "2026-06-24T12:00:00Z",
-  "mission_id": "${expectedSharedId}",
+  "mission_id": "${canonicalMissionId}",
   "work_item_id": "${workItemId}",
   "surface_kind": "\${surface_kind}",
   "delivery_route": "\${route}",
   "write": {
     "status": "ready",
     "created_or_ready": true,
-    "mission_id": "${expectedSharedId}",
+    "mission_id": "${canonicalMissionId}",
     "work_item_id": "${workItemId}",
     "endpoint": { "host": "127.0.0.1", "port": 48750 }
   },
   "read_projection": {
-    "mission_id": "${expectedSharedId}",
+    "mission_id": "${canonicalMissionId}",
     "work_item_ids": ["${workItemId}"],
     "contains_written_work_item": true,
     "generated_at_ms": 1782290000000,
@@ -59,7 +60,7 @@ JSON
 }
 
 function event(surface: string, name: string, evidenceRef: string) {
-  return { surface, event: name, mission_id: sharedId, evidence_ref: evidenceRef };
+  return { surface, event: name, mission_id: canonicalMissionId, evidence_ref: evidenceRef };
 }
 
 function writeCompleteSameRunEvents(path: string, refs: { mobile: string; desktop: string; channel: string; timeline: string }) {
@@ -128,7 +129,7 @@ describe("friday-ui-device-live-write-read-capture-bundle", () => {
         fullProofGaps?: string[];
       };
       expect(index.status).toBe("partial_bundle_ready");
-      expect(index.missionId).toBe(sharedId);
+      expect(index.missionId).toBe(canonicalMissionId);
       expect(index.captures?.mobile?.event_count).toBe(5);
       expect(index.captures?.desktop?.event_count).toBe(5);
       expect(index.fullProofGaps).toContain("bounded_timeline_capture");


### PR DESCRIPTION
## Summary
- add a one-command UI/device live write-read capture bundle orchestrator
- run the existing iOS and macOS capture runners with one shared mission id, then index their artifacts with the existing bundle driver
- when real channel/timeline captures and same-run events are supplied, delegate to the existing capture-dir/preflight driver to write an evidence-dir
- accept shared live captures as one canonical mission/work item across mobile and desktop without relaxing mission-spine body snapshot invariants
- keep the truth boundary explicit: missing channel/timeline/stress/negative-control observations are never invented

## Validation
- npx vitest run test/unit/qa/friday-ios-live-write-read-proof-events-cli.test.ts test/unit/qa/friday-macos-live-write-read-proof-events-cli.test.ts test/unit/qa/friday-ios-live-write-read-capture-cli.test.ts test/unit/qa/friday-macos-live-write-read-capture-cli.test.ts test/unit/qa/friday-ui-device-live-write-read-capture-bundle-cli.test.ts test/unit/qa/friday-ui-device-live-write-read-bundle-cli.test.ts test/unit/qa/friday-ui-device-capture-dir-cli.test.ts
- swift test --package-path apps/friday-ios --filter LiveWriteReadProjectionRoundTrip
- swift test --package-path apps/macos/FridayHubConsole --filter LiveWriteReadProjectionRoundTrip
- bash -n scripts/ops/friday-ui-device-live-write-read-capture-bundle.sh scripts/ops/friday-ios-live-write-read-capture.sh scripts/ops/friday-macos-live-write-read-capture.sh
- git diff --check
- detect-secrets-hook --baseline .secrets.baseline apps/friday-ios/Tests/FridayMobileShellCoreTests/LiveWriteReadProjectionRoundTripIntegrationTests.swift apps/macos/FridayHubConsole/Tests/FridayHubConsoleCoreTests/LiveWriteReadProjectionRoundTripIntegrationTests.swift scripts/ops/friday-ios-live-write-read-proof-events.mjs scripts/ops/friday-macos-live-write-read-proof-events.mjs scripts/ops/friday-ui-device-live-write-read-bundle.mjs scripts/ops/friday-ui-device-live-write-read-capture-bundle.sh test/unit/qa/friday-ios-live-write-read-proof-events-cli.test.ts test/unit/qa/friday-macos-live-write-read-proof-events-cli.test.ts test/unit/qa/friday-ui-device-live-write-read-bundle-cli.test.ts test/unit/qa/friday-ui-device-live-write-read-capture-bundle-cli.test.ts
- real live bundle: `bash scripts/ops/friday-ui-device-live-write-read-capture-bundle.sh --out-dir /tmp/friday-ui-device-live-write-read-20260624T161208Z --shared-id mission-ui-device-live-write-read-agent-20260624T161208Z`
  - result: `partial_bundle_ready`
  - canonical mission: `mission_mission-ui-device-live-write-read-agent-20260624T161208Z`
  - mobile+desktop both observed `work-live-roundtrip-mission-ui-device-live-write-read-agent-20260624T161208Z`

Truth: orchestrates real capture runners and optional real captured channel/timeline inputs only. It does not synthesize proof rows, does not create missing stress or negative-control observations, and does not claim END-BAR, GO-LIVE, adoption, or operator signing completion.
