### PR TITLE
Add native client action closure gate

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,6 +108,7 @@
     "check:cross-platform-client-ship-gate": "node scripts/ops/check-friday-desktop-release-pipeline.mjs",
     "check:client-design-contract": "node scripts/ops/check-friday-client-design-contract.mjs",
     "check:agent-rollout:phase1": "node scripts/ops/run-agent-rollout-acceptance.mjs phase1",
+    "check:native-action-closure": "node scripts/ops/check-friday-native-action-closure.mjs",
     "check:agent-rollout:phase2": "node scripts/ops/run-agent-rollout-acceptance.mjs phase2",
     "check:agent-rollout:phase3": "node scripts/ops/run-agent-rollout-acceptance.mjs phase3",
     "check:agent-rollout:full": "node scripts/ops/run-agent-rollout-acceptance.mjs full",

--- a/scripts/ops/check-friday-desktop-release-pipeline.mjs
+++ b/scripts/ops/check-friday-desktop-release-pipeline.mjs
@@ -247,6 +247,36 @@ function runDesignContractCheck(repoRoot) {
   };
 }
 
+function runNativeActionClosureCheck(repoRoot) {
+  const scriptPath = path.join(repoRoot, "scripts", "ops", "check-friday-native-action-closure.mjs");
+  if (!fs.existsSync(scriptPath)) {
+    return {
+      kind: "command",
+      label: "Native action closure check",
+      target: "scripts/ops/check-friday-native-action-closure.mjs",
+      status: "failed",
+      exitCode: 1,
+      stderr: "native action closure script is missing",
+    };
+  }
+
+  const result = spawnSync(process.execPath, [scriptPath, repoRoot], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    env: process.env,
+  });
+
+  return {
+    kind: "command",
+    label: "Native action closure check",
+    target: "scripts/ops/check-friday-native-action-closure.mjs",
+    status: result.status === 0 ? "passed" : "failed",
+    exitCode: result.status ?? 1,
+    stdout: (result.stdout ?? "").trim(),
+    stderr: (result.stderr ?? "").trim(),
+  };
+}
+
 const repoRoot = resolveRepoRoot();
 const pkg = readPackageJson(repoRoot);
 
@@ -260,6 +290,7 @@ const checks = [
     ["scripts/ops/build-friday-hub-console-app.sh", "Hub Console app bundle build script"],
     ["scripts/ops/verify-friday-hub-console-app.sh", "Hub Console app bundle verify script"],
     ["scripts/ops/check-friday-client-design-contract.mjs", "Client design contract check"],
+    ["scripts/ops/check-friday-native-action-closure.mjs", "Native action closure check"],
     ["scripts/ops/check-friday-ios-t2-surface-contract.mjs", "iOS T2 surface contract check"],
     ["scripts/ops/check-friday-product-auto-followup-contract.mjs", "Product auto-followup contract check"],
     ["scripts/ops/friday-product-auto-followup-proof.sh", "Product auto-followup live proof script"],
@@ -286,6 +317,7 @@ const checks = [
     "check:client-ship-gate",
     "check:cross-platform-client-ship-gate",
     "check:client-design-contract",
+    "check:native-action-closure",
     "check:ios-t2-surface-contract",
     "check:product-auto-followup-contract",
     "proof:product:auto-followup",
@@ -305,6 +337,7 @@ const checks = [
   ].map((name) => scriptCheck(pkg, name)),
   runEnvCheck(repoRoot),
   runDesignContractCheck(repoRoot),
+  runNativeActionClosureCheck(repoRoot),
   ...artifactFreshnessChecks(repoRoot),
 ];
 

--- a/scripts/ops/check-friday-native-action-closure.mjs
+++ b/scripts/ops/check-friday-native-action-closure.mjs
@@ -1,0 +1,318 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+
+function resolveRepoRoot() {
+  const explicit = process.argv[2]?.trim() || process.env.FRIDAY_REPO_ROOT?.trim();
+  if (explicit) return path.resolve(explicit);
+  return path.resolve(path.dirname(new URL(import.meta.url).pathname), "../..");
+}
+
+function read(root, relativePath) {
+  return fs.readFileSync(path.join(root, relativePath), "utf8");
+}
+
+function includesAll(source, values) {
+  return values.filter((value) => !source.includes(value));
+}
+
+function hasMethod(source, name) {
+  return new RegExp(`\\bfunc\\s+${name}\\s*\\(`).test(source);
+}
+
+function methodMissing(source, names) {
+  return names.filter((name) => !hasMethod(source, name));
+}
+
+function check(id, target, missing, notes = []) {
+  return {
+    id,
+    target,
+    status: missing.length === 0 ? "passed" : "failed",
+    missing,
+    notes,
+  };
+}
+
+const root = resolveRepoRoot();
+const files = {
+  mobileCommand: read(root, "apps/friday-ios/Sources/FridayMobileShell/CommandSheet.swift"),
+  mobileApp: read(root, "apps/friday-ios/Sources/FridayMobileShell/FridayApp.swift"),
+  mobileHome: read(root, "apps/friday-ios/Sources/FridayMobileShell/FridayHomeScreen.swift"),
+  mobileProjection: read(root, "apps/friday-ios/Sources/FridayMobileShell/FridayProjectionScreens.swift"),
+  mobileSession: read(root, "apps/friday-ios/Sources/FridayMobileShell/FridaySessionDetailScreen.swift"),
+  mobileChat: read(root, "apps/friday-ios/Sources/FridayMobileShell/FridayChatScreen.swift"),
+  mobileShare: read(root, "apps/friday-ios/Sources/FridayMobileShell/FridayShareIntakeScreen.swift"),
+  mobileVoice: read(root, "apps/friday-ios/Sources/FridayMobileShell/FridayVoiceScreen.swift"),
+  mobileToken: read(root, "apps/friday-ios/Sources/FridayMobileShell/FridayTokenLedgerScreen.swift"),
+  mobileHomeVM: read(root, "apps/friday-ios/Sources/FridayMobileShellCore/HomeViewModel.swift"),
+  mobileSessionVM: read(root, "apps/friday-ios/Sources/FridayMobileShellCore/SessionContinuationViewModel.swift"),
+  mobileChatVM: read(root, "apps/friday-ios/Sources/FridayMobileShellCore/FridayChatViewModel.swift"),
+  mobileShareVM: read(root, "apps/friday-ios/Sources/FridayMobileShellCore/ShareIntakeViewModel.swift"),
+  mobileVoiceVM: read(root, "apps/friday-ios/Sources/FridayMobileShellCore/VoiceReadinessViewModel.swift"),
+  mobileHomeTests: read(root, "apps/friday-ios/Tests/FridayMobileShellCoreTests/HomeViewModelTests.swift"),
+  mobileSessionTests: read(root, "apps/friday-ios/Tests/FridayMobileShellCoreTests/SessionContinuationViewModelTests.swift"),
+  mobileChatTests: read(root, "apps/friday-ios/Tests/FridayMobileShellCoreTests/FridayChatViewModelTests.swift"),
+  mobileShareTests: read(root, "apps/friday-ios/Tests/FridayMobileShellCoreTests/ShareIntakeViewModelTests.swift"),
+  mobileVoiceTests: read(root, "apps/friday-ios/Tests/FridayMobileShellCoreTests/VoiceReadinessViewModelTests.swift"),
+  desktopNav: read(root, "apps/macos/FridayHubConsole/Sources/FridayHubConsole/Navigation.swift"),
+  desktopShell: read(root, "apps/macos/FridayHubConsole/Sources/FridayHubConsole/HubConsoleShell.swift"),
+  desktopOps: read(root, "apps/macos/FridayHubConsole/Sources/FridayHubConsole/OperationsOverviewScreen.swift"),
+  desktopProjection: read(root, "apps/macos/FridayHubConsole/Sources/FridayHubConsole/DesktopProjectionScreens.swift"),
+  desktopChat: read(root, "apps/macos/FridayHubConsole/Sources/FridayHubConsole/DesktopChatScreen.swift"),
+  desktopVM: read(root, "apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/OperationsOverviewViewModel.swift"),
+  desktopTests: read(root, "apps/macos/FridayHubConsole/Tests/FridayHubConsoleCoreTests/OperationsOverviewViewModelTests.swift"),
+  packageJson: read(root, "package.json"),
+};
+
+const mobileUi = [
+  files.mobileHome,
+  files.mobileProjection,
+  files.mobileSession,
+  files.mobileChat,
+  files.mobileShare,
+  files.mobileVoice,
+  files.mobileToken,
+].join("\n");
+const mobileVM = [
+  files.mobileHomeVM,
+  files.mobileSessionVM,
+  files.mobileChatVM,
+  files.mobileShareVM,
+  files.mobileVoiceVM,
+].join("\n");
+const mobileTests = [
+  files.mobileHomeTests,
+  files.mobileSessionTests,
+  files.mobileChatTests,
+  files.mobileShareTests,
+  files.mobileVoiceTests,
+].join("\n");
+const desktopUi = [
+  files.desktopOps,
+  files.desktopProjection,
+  files.desktopChat,
+].join("\n");
+const desktopTests = files.desktopTests;
+
+const checks = [
+  check(
+    "mobile-command-sheet-does-not-hide-product-destinations",
+    "apps/friday-ios/Sources/FridayMobileShell/CommandSheet.swift",
+    includesAll(files.mobileCommand, [
+      "case session",
+      "case contextPassport",
+      "case tokenLedger",
+      "case shareIntake",
+      "case voice",
+      "case needsMe",
+      "case memory",
+      "case platform",
+      "case activity",
+      "case workflows",
+      "case settings",
+      "var isBuilt: Bool { true }",
+    ]),
+    [
+      "This is destination coverage, not END-BAR. Action closure is checked by the rows below.",
+    ],
+  ),
+  check(
+    "mobile-enabled-actions-have-viewmodel-drivers",
+    "apps/friday-ios/Sources/FridayMobileShellCore",
+    [
+      ...methodMissing(files.mobileHomeVM, [
+        "refresh",
+        "loadDetail",
+        "decideMemory",
+        "decideRunOutcomeLearning",
+        "markActivityDone",
+        "retryWorkItem",
+        "cancelWorkItem",
+        "preflightPairingQR",
+        "pairScannedQR",
+      ]),
+      ...methodMissing(files.mobileSessionVM, [
+        "refresh",
+        "send",
+        "stop",
+        "resume",
+        "reject",
+      ]),
+      ...methodMissing(files.mobileChatVM, [
+        "send",
+        "approve",
+        "reject",
+      ]),
+      ...methodMissing(files.mobileShareVM, ["submit"]),
+      ...methodMissing(files.mobileVoiceVM, ["refresh"]),
+    ],
+  ),
+  check(
+    "mobile-enabled-actions-are-bound-to-ui-controls",
+    "apps/friday-ios/Sources/FridayMobileShell",
+    includesAll(mobileUi, [
+      "viewModel.loadDetail(",
+      "viewModel.retryWorkItem",
+      "viewModel.cancelWorkItem",
+      "viewModel.decideMemory",
+      "viewModel.decideRunOutcomeLearning",
+      "viewModel.markActivityDone",
+      "viewModel.preflightPairingQR",
+      "viewModel.pairScannedQR",
+      "viewModel.send(",
+      "viewModel.stop()",
+      "viewModel.resume()",
+      "viewModel.reject()",
+      "viewModel.submit()",
+      "viewModel.refresh()",
+      ".disabled(",
+      "accessibilityIdentifier",
+    ]),
+  ),
+  check(
+    "mobile-actions-fail-closed-and-surface-truth",
+    "apps/friday-ios/Sources/FridayMobileShell + FridayMobileShellCore",
+    includesAll(`${mobileUi}\n${mobileVM}`, [
+      "Write seam not configured",
+      "honest-unavailable",
+      "requires the governed write client",
+      "requires the session-bound write seam",
+      "requires a pending approval ref",
+      "Add shared text or a URL before submitting.",
+      "Share Intake is unavailable",
+      "Readiness only",
+      "No cost data is fabricated",
+    ]),
+  ),
+  check(
+    "mobile-action-behavior-tests-cover-enabled-writes",
+    "apps/friday-ios/Tests/FridayMobileShellCoreTests",
+    includesAll(mobileTests, [
+      "testRetryWorkItemSendsLifecycleWriteAndRefreshes",
+      "testCancelWorkItemSendsLifecycleWriteAndRefreshes",
+      "testDecideMemoryConfirmRendersConfirmedAndRefreshes",
+      "testDecideRunOutcomeLearningConfirmRendersConfirmedAndRefreshes",
+      "testMarkActivityDoneRendersConfirmedAndRefreshes",
+      "testResumeRelaysSignerBlobVerbatimAndSurfacesReceipt",
+      "testRejectRelaysApprovalRefWithoutResumingMutation",
+      "testStopUsesGovernedCancelRunAndSurfacesReceipt",
+      "testSendDispatchesReadOnlySessionTurnAndRefreshesToReturnedRun",
+      "testSubmitCreatesMobileShareMissionIntake",
+      "testNoClientFailsClosedWithoutFakeMission",
+      "testVoiceLoopReadyRequiresCaptureAndTtsProvider",
+    ]),
+  ),
+  check(
+    "desktop-nav-does-not-hide-workbench-destinations",
+    "apps/macos/FridayHubConsole/Sources/FridayHubConsole/Navigation.swift",
+    includesAll(files.desktopNav, [
+      "case operations",
+      "case chat",
+      "case providerAdmin",
+      "case parity",
+      "case pairingProvisioning",
+      "case workflow",
+      "case channels",
+      "case diagnostics",
+      "case recovery",
+      "case memory",
+      "case tokenLedger",
+      "case skills",
+      "case media",
+      "case settings",
+      "case evidence",
+      "var isBuilt: Bool { true }",
+    ]),
+  ),
+  check(
+    "desktop-enabled-actions-have-viewmodel-drivers",
+    "apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/OperationsOverviewViewModel.swift",
+    methodMissing(files.desktopVM, [
+      "refresh",
+      "loadDetail",
+      "submitIntake",
+      "approveNeedsMeItem",
+      "rejectNeedsMeApproval",
+      "cancelNeedsMeRun",
+      "markNeedsMeItemDone",
+      "retryWorkItem",
+      "cancelWorkItem",
+      "decideMemory",
+      "decideRunOutcomeLearning",
+    ]),
+  ),
+  check(
+    "desktop-enabled-actions-are-bound-to-ui-controls",
+    "apps/macos/FridayHubConsole/Sources/FridayHubConsole",
+    includesAll(desktopUi, [
+      "viewModel.refresh()",
+      "viewModel.loadDetail(",
+      "viewModel.submitIntake",
+      "viewModel.approveNeedsMeItem",
+      "viewModel.rejectNeedsMeApproval",
+      "viewModel.cancelNeedsMeRun",
+      "viewModel.markNeedsMeItemDone",
+      "viewModel.retryWorkItem",
+      "viewModel.cancelWorkItem",
+      "viewModel.decideMemory",
+      "viewModel.decideRunOutcomeLearning",
+      ".disabled(",
+      "accessibilityIdentifier",
+    ]),
+  ),
+  check(
+    "desktop-actions-fail-closed-and-surface-truth",
+    "apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/OperationsOverviewViewModel.swift",
+    includesAll(files.desktopVM, [
+      "Write seam not configured",
+      "Operator signer relay not configured",
+      "Run-control write seam not configured",
+      "cannot sign",
+      "This WorkItem is not retryable",
+      "This WorkItem is not cancellable",
+      "blocked",
+    ]),
+  ),
+  check(
+    "desktop-action-behavior-tests-cover-enabled-writes",
+    "apps/macos/FridayHubConsole/Tests/FridayHubConsoleCoreTests/OperationsOverviewViewModelTests.swift",
+    includesAll(desktopTests, [
+      "submitIntakeReadyRendersConfirmedAndWiresOwnerAdmin001",
+      "submitIntakeReadyDispatchesMissionBoundModelTurnWhenRunClientConfigured",
+      "approveNeedsMeItemSignsRefsAndRelaysOpaqueBlob",
+      "rejectNeedsMeApprovalUsesRunControlWithoutSigner",
+      "cancelNeedsMeRunUsesRunControlReason",
+      "markNeedsMeItemDoneUsesRefIdAndRefreshesReview",
+      "retryWorkItemSendsLifecycleWriteAndRefreshes",
+      "cancelWorkItemSendsLifecycleWriteAndRefreshes",
+      "decideMemoryConfirmRendersConfirmedRecallable",
+      "decideRunOutcomeLearningConfirmRendersConfirmedAndWiresCandidate",
+    ]),
+  ),
+  check(
+    "package-exposes-native-action-closure-gate",
+    "package.json",
+    includesAll(files.packageJson, [
+      "\"check:native-action-closure\"",
+    ]),
+  ),
+];
+
+const failed = checks.filter((row) => row.status === "failed");
+const report = {
+  generatedAt: new Date().toISOString(),
+  repoRoot: root,
+  truthLabel: "native_action_closure_static_behavior_guard_not_endbar_not_runtime_adoption",
+  status: failed.length === 0 ? "passed" : "failed",
+  summary: {
+    passed: checks.filter((row) => row.status === "passed").length,
+    failed: failed.length,
+  },
+  checks,
+  caveat: "This gate prevents enabled native controls from being counted as complete without UI bindings, ViewModel drivers, fail-closed truth states, and behavior tests. It is still not a substitute for simulator/desktop screenshots, real live loop evidence, real-device adoption, or END-BAR.",
+};
+
+console.log(JSON.stringify(report, null, 2));
+process.exit(failed.length === 0 ? 0 : 1);

--- a/test/integration/system/friday-desktop-release-pipeline.integration.test.ts
+++ b/test/integration/system/friday-desktop-release-pipeline.integration.test.ts
@@ -35,6 +35,7 @@ async function createFixtureRepo(): Promise<string> {
       "check:client-ship-gate": "node scripts/ops/check-friday-desktop-release-pipeline.mjs",
       "check:cross-platform-client-ship-gate": "node scripts/ops/check-friday-desktop-release-pipeline.mjs",
       "check:client-design-contract": "node scripts/ops/check-friday-client-design-contract.mjs",
+      "check:native-action-closure": "node scripts/ops/check-friday-native-action-closure.mjs",
       "check:ios-t2-surface-contract": "node scripts/ops/check-friday-ios-t2-surface-contract.mjs",
       "check:product-auto-followup-contract": "node scripts/ops/check-friday-product-auto-followup-contract.mjs",
       "proof:product:auto-followup": "bash scripts/ops/friday-product-auto-followup-proof.sh",
@@ -63,6 +64,7 @@ async function createFixtureRepo(): Promise<string> {
     "scripts/ops/build-friday-hub-console-app.sh",
     "scripts/ops/verify-friday-hub-console-app.sh",
     "scripts/ops/check-friday-client-design-contract.mjs",
+    "scripts/ops/check-friday-native-action-closure.mjs",
     "scripts/ops/check-friday-ios-t2-surface-contract.mjs",
     "scripts/ops/check-friday-product-auto-followup-contract.mjs",
     "scripts/ops/friday-product-auto-followup-proof.sh",
@@ -95,6 +97,11 @@ async function createFixtureRepo(): Promise<string> {
     root,
     "scripts/ops/check-friday-client-design-contract.mjs",
     "#!/usr/bin/env node\nconsole.log(JSON.stringify({status:\"passed\", truthLabel:\"fixture_design_contract\"}));\n",
+  );
+  await writeFileWithParents(
+    root,
+    "scripts/ops/check-friday-native-action-closure.mjs",
+    "#!/usr/bin/env node\nconsole.log(JSON.stringify({status:\"passed\", truthLabel:\"fixture_native_action_closure\"}));\n",
   );
   await writeFileWithParents(
     root,
@@ -164,6 +171,14 @@ describe("client ship gate pipeline check", () => {
         }),
         expect.objectContaining({
           target: "check:client-design-contract",
+          status: "passed",
+        }),
+        expect.objectContaining({
+          target: "scripts/ops/check-friday-native-action-closure.mjs",
+          status: "passed",
+        }),
+        expect.objectContaining({
+          target: "check:native-action-closure",
           status: "passed",
         }),
         expect.objectContaining({

--- a/test/unit/qa/friday-native-action-closure-cli.test.ts
+++ b/test/unit/qa/friday-native-action-closure-cli.test.ts
@@ -1,0 +1,144 @@
+import { spawnSync } from "node:child_process";
+import {
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const script = "scripts/ops/check-friday-native-action-closure.mjs";
+
+const requiredFixtureFiles = [
+  "package.json",
+  "apps/friday-ios/Sources/FridayMobileShell/CommandSheet.swift",
+  "apps/friday-ios/Sources/FridayMobileShell/FridayApp.swift",
+  "apps/friday-ios/Sources/FridayMobileShell/FridayHomeScreen.swift",
+  "apps/friday-ios/Sources/FridayMobileShell/FridayProjectionScreens.swift",
+  "apps/friday-ios/Sources/FridayMobileShell/FridaySessionDetailScreen.swift",
+  "apps/friday-ios/Sources/FridayMobileShell/FridayChatScreen.swift",
+  "apps/friday-ios/Sources/FridayMobileShell/FridayShareIntakeScreen.swift",
+  "apps/friday-ios/Sources/FridayMobileShell/FridayVoiceScreen.swift",
+  "apps/friday-ios/Sources/FridayMobileShell/FridayTokenLedgerScreen.swift",
+  "apps/friday-ios/Sources/FridayMobileShellCore/HomeViewModel.swift",
+  "apps/friday-ios/Sources/FridayMobileShellCore/SessionContinuationViewModel.swift",
+  "apps/friday-ios/Sources/FridayMobileShellCore/FridayChatViewModel.swift",
+  "apps/friday-ios/Sources/FridayMobileShellCore/ShareIntakeViewModel.swift",
+  "apps/friday-ios/Sources/FridayMobileShellCore/VoiceReadinessViewModel.swift",
+  "apps/friday-ios/Tests/FridayMobileShellCoreTests/HomeViewModelTests.swift",
+  "apps/friday-ios/Tests/FridayMobileShellCoreTests/SessionContinuationViewModelTests.swift",
+  "apps/friday-ios/Tests/FridayMobileShellCoreTests/FridayChatViewModelTests.swift",
+  "apps/friday-ios/Tests/FridayMobileShellCoreTests/ShareIntakeViewModelTests.swift",
+  "apps/friday-ios/Tests/FridayMobileShellCoreTests/VoiceReadinessViewModelTests.swift",
+  "apps/macos/FridayHubConsole/Sources/FridayHubConsole/Navigation.swift",
+  "apps/macos/FridayHubConsole/Sources/FridayHubConsole/HubConsoleShell.swift",
+  "apps/macos/FridayHubConsole/Sources/FridayHubConsole/OperationsOverviewScreen.swift",
+  "apps/macos/FridayHubConsole/Sources/FridayHubConsole/DesktopProjectionScreens.swift",
+  "apps/macos/FridayHubConsole/Sources/FridayHubConsole/DesktopChatScreen.swift",
+  "apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/OperationsOverviewViewModel.swift",
+  "apps/macos/FridayHubConsole/Tests/FridayHubConsoleCoreTests/OperationsOverviewViewModelTests.swift",
+];
+
+function run(repoRoot = process.cwd()) {
+  return spawnSync("node", [script, repoRoot], {
+    cwd: process.cwd(),
+    encoding: "utf8",
+  });
+}
+
+function copyFixture() {
+  const root = mkdtempSync(join(tmpdir(), "friday-native-action-closure-"));
+  for (const relativePath of requiredFixtureFiles) {
+    const source = join(process.cwd(), relativePath);
+    const target = join(root, relativePath);
+    mkdirSync(dirname(target), { recursive: true });
+    copyFileSync(source, target);
+  }
+  return root;
+}
+
+function replaceInFixture(root: string, relativePath: string, from: string, to: string) {
+  const target = join(root, relativePath);
+  const source = readFileSync(target, "utf8");
+  expect(source).toContain(from);
+  writeFileSync(target, source.replace(from, to));
+}
+
+describe("friday-native-action-closure", () => {
+  it("passes on the current native mobile and desktop closure surface", () => {
+    expect(existsSync(script)).toBe(true);
+    const result = run();
+    expect(result.status).toBe(0);
+    const report = JSON.parse(result.stdout) as {
+      status?: string;
+      truthLabel?: string;
+      summary?: { failed?: number };
+      caveat?: string;
+    };
+    expect(report.status).toBe("passed");
+    expect(report.truthLabel).toBe("native_action_closure_static_behavior_guard_not_endbar_not_runtime_adoption");
+    expect(report.summary?.failed).toBe(0);
+    expect(report.caveat).toContain("not a substitute for simulator/desktop screenshots");
+  });
+
+  it("fails closed when an enabled mobile action loses its ViewModel driver", () => {
+    const root = copyFixture();
+    try {
+      replaceInFixture(
+        root,
+        "apps/friday-ios/Sources/FridayMobileShellCore/HomeViewModel.swift",
+        "public func retryWorkItem(",
+        "public func retryWorkItemMissing(",
+      );
+      const result = run(root);
+      expect(result.status).toBe(1);
+      const report = JSON.parse(result.stdout) as {
+        status?: string;
+        checks?: Array<{ id?: string; missing?: string[] }>;
+      };
+      expect(report.status).toBe("failed");
+      expect(report.checks).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            id: "mobile-enabled-actions-have-viewmodel-drivers",
+            missing: expect.arrayContaining(["retryWorkItem"]),
+          }),
+        ]),
+      );
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("fails closed when the package script is not exposed", () => {
+    const root = copyFixture();
+    try {
+      replaceInFixture(
+        root,
+        "package.json",
+        "\"check:native-action-closure\": \"node scripts/ops/check-friday-native-action-closure.mjs\",",
+        "",
+      );
+      const result = run(root);
+      expect(result.status).toBe(1);
+      const report = JSON.parse(result.stdout) as {
+        checks?: Array<{ id?: string; missing?: string[] }>;
+      };
+      expect(report.checks).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            id: "package-exposes-native-action-closure-gate",
+            missing: expect.arrayContaining(["\"check:native-action-closure\""]),
+          }),
+        ]),
+      );
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Add a native action closure guard for iOS/macOS client surfaces so enabled controls must have UI bindings, ViewModel drivers, fail-closed truth states, and behavior tests before they can count as closed.
- Wire the guard into the client ship gate and package scripts.
- Add CLI/unit coverage plus release pipeline fixture coverage.

## Validation
- `npm run check:native-action-closure`
- `npm run check:client-ship-gate`
- `npx vitest run test/unit/qa/friday-native-action-closure-cli.test.ts test/integration/system/friday-desktop-release-pipeline.integration.test.ts`
- `git diff --check`
- `detect-secrets-hook --baseline .secrets.baseline $(git diff origin/main --name-only --diff-filter=ACM)`

Truth: this is a static/behavioral guard, not END-BAR, not runtime adoption, and not a substitute for simulator/desktop screenshots or real live loop evidence.