### PR TITLE
Merge workbench events into UI proof readiness

### DIFF
--- a/scripts/ops/friday-ui-device-proof-readiness.sh
+++ b/scripts/ops/friday-ui-device-proof-readiness.sh
@@ -191,7 +191,7 @@ export SAME_RUN_EVENTS="${SAME_RUN_EVENTS:-}"
 export FRIDAY_WORKBENCH_SNAPSHOT_FILE="${FRIDAY_WORKBENCH_SNAPSHOT_FILE:-}"
 
 derive_workbench_events_if_possible() {
-  if [ -n "${SAME_RUN_EVENTS:-}" ] || [ -z "${FRIDAY_WORKBENCH_SNAPSHOT_FILE:-}" ]; then
+  if [ -z "${FRIDAY_WORKBENCH_SNAPSHOT_FILE:-}" ]; then
     return 0
   fi
   if [ -z "${MISSION_ID:-}" ] || [ -z "${MOBILE_EVIDENCE:-}" ] || [ -z "${DESKTOP_EVIDENCE:-}" ] || [ -z "${CHANNEL_EVIDENCE:-}" ] || [ -z "${TIMELINE_EVIDENCE:-}" ]; then
@@ -199,14 +199,19 @@ derive_workbench_events_if_possible() {
   fi
 
   local derived_out
+  local existing_events
+  local merged_out
   local stdout_out
   if [ -n "$EVIDENCE_DIR" ]; then
     derived_out="$(abs_path "$EVIDENCE_DIR")/workbench-derived-events.jsonl"
+    merged_out="$(abs_path "$EVIDENCE_DIR")/same-run-events.merged.jsonl"
   else
     derived_out="/tmp/friday-workbench-derived-events-${MISSION_ID}.jsonl"
+    merged_out="/tmp/friday-same-run-events-merged-${MISSION_ID}.jsonl"
   fi
   stdout_out="${derived_out}.stdout"
   mkdir -p "$(dirname "$derived_out")"
+  existing_events="${SAME_RUN_EVENTS:-}"
 
   if node "${REPO_ROOT}/scripts/ops/friday-workbench-snapshot-events.mjs" \
     "--mission-id=${MISSION_ID}" \
@@ -216,7 +221,13 @@ derive_workbench_events_if_possible() {
     "--channel=${CHANNEL_EVIDENCE}" \
     "--timeline=${TIMELINE_EVIDENCE}" \
     "--out=${derived_out}" >"$stdout_out"; then
-    SAME_RUN_EVENTS="$derived_out"
+    if [ -n "$existing_events" ]; then
+      awk '!seen[$0]++' "$existing_events" "$derived_out" >"$merged_out"
+      SAME_RUN_EVENTS="$merged_out"
+      notes+=("workbench_snapshot_events_merge:ready:${merged_out}")
+    else
+      SAME_RUN_EVENTS="$derived_out"
+    fi
     export SAME_RUN_EVENTS
     notes+=("workbench_snapshot_events_bridge:ready:${derived_out}")
   else

--- a/test/unit/qa/friday-ui-device-proof-readiness-cli.test.ts
+++ b/test/unit/qa/friday-ui-device-proof-readiness-cli.test.ts
@@ -477,4 +477,37 @@ describe("friday-ui-device-proof-readiness", () => {
       rmSync(tempDir, { recursive: true, force: true });
     }
   });
+
+  it("merges workbench-derived events with discovered same-run events instead of replacing them", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "friday-ui-device-readiness-merge-"));
+    try {
+      writePartialEvidenceDir(tempDir);
+      writeFileSync(join(tempDir, "workbench-snapshot.json"), JSON.stringify({ snapshot: makeWorkbenchSnapshot() }, null, 2));
+
+      const stdout = execFileSync("bash", [
+        "scripts/ops/friday-ui-device-proof-readiness.sh",
+        "--evidence-dir",
+        tempDir,
+      ], {
+        cwd: process.cwd(),
+        encoding: "utf8",
+      });
+      const result = JSON.parse(stdout.slice(stdout.indexOf("{"))) as {
+        notes?: string[];
+      };
+
+      expect(result.notes?.some((note) => note.includes("workbench_snapshot_events_bridge:ready"))).toBe(true);
+      expect(result.notes?.some((note) => note.includes("workbench_snapshot_events_merge:ready"))).toBe(true);
+      expect(result.notes?.some((note) => note.includes("resolved_SAME_RUN_EVENTS") && note.includes("same-run-events.merged.jsonl"))).toBe(true);
+
+      const rows = readFileSync(join(tempDir, "same-run-events.merged.jsonl"), "utf8")
+        .trim()
+        .split("\n")
+        .map((line) => JSON.parse(line) as { event?: string });
+      expect(rows).toContainEqual(expect.objectContaining({ event: "proof_receipt_visible_before_done" }));
+      expect(rows).toContainEqual(expect.objectContaining({ event: "mission_workbench_visible" }));
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
 });


### PR DESCRIPTION
## Summary
- Merge workbench-derived readiness events with discovered same-run events instead of replacing existing event observations.
- Preserve the merged event stream as `same-run-events.merged.jsonl` for downstream UI/device proof readiness.
- Add regression coverage for the merge path.

## Validation
- `npx vitest run test/unit/qa/friday-ui-device-proof-readiness-cli.test.ts test/unit/qa/friday-workbench-snapshot-events-cli.test.ts test/unit/qa/friday-ui-device-proof-gap-report-cli.test.ts`
- `bash -n scripts/ops/friday-ui-device-proof-readiness.sh`
- `git diff --check`
- `detect-secrets-hook --baseline .secrets.baseline $(git diff origin/main --name-only --diff-filter=ACM)`

Truth: this improves UI/device proof readiness input preservation; it does not claim END-BAR or replace live mobile/desktop click-through evidence.