### PR TITLE
Label mobile destination closure tiers

### DIFF
--- a/apps/friday-ios/Sources/FridayMobileShell/CommandSheet.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/CommandSheet.swift
@@ -3,9 +3,54 @@ import SwiftUI
 /// The full-screen grid launcher (locked: menuModel = commandSheet) opened from the
 /// top-left of Home.
 ///
-/// The launcher surfaces all mobile read-projection destinations. Each non-Home destination
-/// consumes the same refs-only HomeProjection; none fabricates detail the read seam does not
-/// carry.
+/// The launcher surfaces all selected mobile destinations. `isBuilt` only means the route is
+/// present and openable; `closureTier` is the product truth used to avoid counting a projection
+/// or readiness shell as an END-BAR closed loop.
+enum MobileDestinationClosureTier {
+  case liveWriteRead
+  case liveReadProjection
+  case governedActionGated
+  case readinessOnly
+  case statusProjection
+  case navigationShell
+
+  var label: String {
+    switch self {
+    case .liveWriteRead: return "live write"
+    case .liveReadProjection: return "live read"
+    case .governedActionGated: return "action gated"
+    case .readinessOnly: return "readiness"
+    case .statusProjection: return "projection"
+    case .navigationShell: return "shell"
+    }
+  }
+
+  var summary: String {
+    switch self {
+    case .liveWriteRead:
+      return "Real read/write loop exists when the governed live seams are configured."
+    case .liveReadProjection:
+      return "Reads real Hub projection state; it does not create or mutate work."
+    case .governedActionGated:
+      return "Shows governed action controls; mutations require the live write seam and approval gates."
+    case .readinessOnly:
+      return "Reports device/provider readiness only; it is not a completed product loop."
+    case .statusProjection:
+      return "Shows current status from projection refs; no product action is completed here."
+    case .navigationShell:
+      return "Route exists for selected UI coverage, but closed-loop product behavior is still pending."
+    }
+  }
+
+  var isClosedLoopProductReady: Bool {
+    switch self {
+    case .liveWriteRead: return true
+    case .liveReadProjection, .governedActionGated, .readinessOnly, .statusProjection, .navigationShell:
+      return false
+    }
+  }
+}
+
 enum MobileDestination: String, CaseIterable, Identifiable {
   case home
   case missions
@@ -68,6 +113,26 @@ enum MobileDestination: String, CaseIterable, Identifiable {
     }
   }
 
+  var closureTier: MobileDestinationClosureTier {
+    switch self {
+    case .home, .session:
+      return .liveWriteRead
+    case .missions, .contextPassport, .tokenLedger, .memory, .activity:
+      return .liveReadProjection
+    case .shareIntake, .needsMe, .workflows:
+      return .governedActionGated
+    case .voice, .pairing, .providerAuth:
+      return .readinessOnly
+    case .platform, .settings:
+      return .statusProjection
+    case .onboarding:
+      return .navigationShell
+    }
+  }
+
+  var productReadinessSummary: String { closureTier.summary }
+
+  /// Route coverage only. This must not be used as a closed-loop product-completion signal.
   var isBuilt: Bool { true }
 }
 
@@ -120,15 +185,22 @@ struct CommandSheet: View {
         Spacer()
         if dest == destination {
           StatusChip(text: "open", bg: MobileTheme.chipPendingBG, fg: MobileTheme.chipPendingFG)
-        } else if !dest.isBuilt {
-          StatusChip(text: "soon", bg: MobileTheme.chipNeutralBG, fg: MobileTheme.chipNeutralFG)
         }
       }
       Text(dest.title)
         .font(.headline)
         .foregroundStyle(dest.isBuilt ? MobileTheme.textPrimary : MobileTheme.textSecondary)
+      StatusChip(
+        text: dest.closureTier.label,
+        bg: dest.closureTier.isClosedLoopProductReady ? MobileTheme.chipDoneBG : MobileTheme.chipNeutralBG,
+        fg: dest.closureTier.isClosedLoopProductReady ? MobileTheme.chipDoneFG : MobileTheme.chipNeutralFG)
+      Text(dest.productReadinessSummary)
+        .font(.caption2)
+        .foregroundStyle(MobileTheme.textSecondary)
+        .lineLimit(3)
+        .fixedSize(horizontal: false, vertical: true)
     }
-    .frame(maxWidth: .infinity, minHeight: 96, alignment: .topLeading)
+    .frame(maxWidth: .infinity, minHeight: 132, alignment: .topLeading)
     .padding(16)
     .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: MobileTheme.cornerRadius, style: .continuous))
     .overlay(

--- a/scripts/ops/check-friday-native-action-closure.mjs
+++ b/scripts/ops/check-friday-native-action-closure.mjs
@@ -119,6 +119,28 @@ const checks = [
     ],
   ),
   check(
+    "mobile-command-sheet-separates-route-coverage-from-product-closure",
+    "apps/friday-ios/Sources/FridayMobileShell/CommandSheet.swift",
+    includesAll(files.mobileCommand, [
+      "enum MobileDestinationClosureTier",
+      "var closureTier: MobileDestinationClosureTier",
+      "Route coverage only. This must not be used as a closed-loop product-completion signal.",
+      "isClosedLoopProductReady",
+      "case .liveWriteRead: return true",
+      "case .home, .session:",
+      "case .shareIntake, .needsMe, .workflows:",
+      "case .voice, .pairing, .providerAuth:",
+      "case .onboarding:",
+      "dest.closureTier.label",
+      "dest.productReadinessSummary",
+      "closed-loop product behavior is still pending",
+      "not a completed product loop",
+    ]),
+    [
+      "This keeps selected-design route coverage visible while preventing projection/readiness shells from being counted as product-complete.",
+    ],
+  ),
+  check(
     "mobile-enabled-actions-have-viewmodel-drivers",
     "apps/friday-ios/Sources/FridayMobileShellCore",
     [

--- a/test/unit/qa/friday-native-action-closure-cli.test.ts
+++ b/test/unit/qa/friday-native-action-closure-cli.test.ts
@@ -115,6 +115,35 @@ describe("friday-native-action-closure", () => {
     }
   });
 
+  it("fails closed when mobile route coverage is no longer separated from product closure", () => {
+    const root = copyFixture();
+    try {
+      replaceInFixture(
+        root,
+        "apps/friday-ios/Sources/FridayMobileShell/CommandSheet.swift",
+        "var closureTier: MobileDestinationClosureTier",
+        "var routeTier: MobileDestinationClosureTier",
+      );
+      const result = run(root);
+      expect(result.status).toBe(1);
+      const report = JSON.parse(result.stdout) as {
+        status?: string;
+        checks?: Array<{ id?: string; missing?: string[] }>;
+      };
+      expect(report.status).toBe("failed");
+      expect(report.checks).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            id: "mobile-command-sheet-separates-route-coverage-from-product-closure",
+            missing: expect.arrayContaining(["var closureTier: MobileDestinationClosureTier"]),
+          }),
+        ]),
+      );
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   it("fails closed when the package script is not exposed", () => {
     const root = copyFixture();
     try {


### PR DESCRIPTION
## Summary
- separate mobile route coverage from product closure in CommandSheet
- show closure tier chips and summaries for selected mobile destinations
- extend native action closure gate and negative test so projection/readiness shells cannot be counted as closed-loop product completion

## Verification
- npm run check:native-action-closure
- npx vitest run test/unit/qa/friday-native-action-closure-cli.test.ts
- npm run check:client-ship-gate
- bash apps/friday-ios/build-sim.sh --mode offline-truth --destination home --shot /tmp/friday-mobile-closure-tier-home.png
- git diff --check
- detect-secrets-hook --baseline .secrets.baseline apps/friday-ios/Sources/FridayMobileShell/CommandSheet.swift
scripts/ops/check-friday-native-action-closure.mjs
test/unit/qa/friday-native-action-closure-cli.test.ts

Truth: this is a product-truth/false-green prevention slice. It does not claim END-BAR, GO-LIVE, adoption, or that every selected mobile action is already runtime closed-loop.