### PR TITLE
Discover desktop live capture evidence

### DIFF
--- a/scripts/ops/friday-ui-device-proof-readiness.sh
+++ b/scripts/ops/friday-ui-device-proof-readiness.sh
@@ -120,9 +120,15 @@ infer_mission_id_from_manifest() {
   ' "$manifest" 2>/dev/null || true
 }
 
+infer_mission_id_from_capture_index() {
+  local index="$1"
+  jq -r '.mission_id // .missionId // empty' "$index" 2>/dev/null || true
+}
+
 discover_evidence_dir() {
   local dir="$1"
   local manifest
+  local capture_index
   if [ -z "$dir" ]; then
     return 0
   fi
@@ -145,14 +151,35 @@ discover_evidence_dir() {
       MISSION_ID="$(tr -d '[:space:]' <"$dir/mission-id.txt")"
     elif [ -n "$manifest" ] && [ -s "$manifest" ]; then
       MISSION_ID="$(infer_mission_id_from_manifest "$manifest")"
+    else
+      capture_index="$(first_existing \
+        "$dir/capture-index.json" \
+        "$dir/bundle/live-write-read-bundle-index.json" \
+        "$dir/desktop/capture-index.json" \
+        "$dir/mobile/capture-index.json" || true)"
+      if [ -n "$capture_index" ]; then
+        MISSION_ID="$(infer_mission_id_from_capture_index "$capture_index")"
+      fi
     fi
   fi
 
   if [ -z "${MOBILE_EVIDENCE:-}" ]; then
-    MOBILE_EVIDENCE="$(first_existing "$dir/mobile.json" "$dir/mobile.trace" "$dir/mobile.log" "$dir/mobile.png" || true)"
+    MOBILE_EVIDENCE="$(first_existing \
+      "$dir/mobile.json" \
+      "$dir/mobile.trace" \
+      "$dir/mobile.log" \
+      "$dir/mobile.png" \
+      "$dir/ios-live-write-read-proof.json" \
+      "$dir/mobile/ios-live-write-read-proof.json" || true)"
   fi
   if [ -z "${DESKTOP_EVIDENCE:-}" ]; then
-    DESKTOP_EVIDENCE="$(first_existing "$dir/desktop.json" "$dir/desktop.trace" "$dir/desktop.log" "$dir/desktop.png" || true)"
+    DESKTOP_EVIDENCE="$(first_existing \
+      "$dir/desktop.json" \
+      "$dir/desktop.trace" \
+      "$dir/desktop.log" \
+      "$dir/desktop.png" \
+      "$dir/macos-live-write-read-proof.json" \
+      "$dir/desktop/macos-live-write-read-proof.json" || true)"
   fi
   if [ -z "${CHANNEL_EVIDENCE:-}" ]; then
     CHANNEL_EVIDENCE="$(first_existing "$dir/channel.json" "$dir/channel.trace" "$dir/channel.log" "$dir/channel.png" || true)"
@@ -164,7 +191,12 @@ discover_evidence_dir() {
     SAME_RUN_EVENTS="$(first_existing \
       "$dir/same-run-events.normalized.jsonl" \
       "$dir/same-run-events.jsonl" \
-      "$dir/events.jsonl" || true)"
+      "$dir/events.jsonl" \
+      "$dir/bundle/mobile-desktop-live-write-read-events.jsonl" \
+      "$dir/ios-live-write-read-events.jsonl" \
+      "$dir/macos-live-write-read-events.jsonl" \
+      "$dir/mobile/ios-live-write-read-events.jsonl" \
+      "$dir/desktop/macos-live-write-read-events.jsonl" || true)"
   fi
   if [ -z "${FRIDAY_WORKBENCH_SNAPSHOT_FILE:-}" ]; then
     FRIDAY_WORKBENCH_SNAPSHOT_FILE="$(first_existing \

--- a/test/unit/qa/friday-ui-device-proof-readiness-cli.test.ts
+++ b/test/unit/qa/friday-ui-device-proof-readiness-cli.test.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from "node:child_process";
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
@@ -77,6 +77,75 @@ function writeWorkbenchSnapshotEvidenceDir(tempDir: string) {
     writeFileSync(filePath, JSON.stringify({ role, mission_id: missionId, capture: "redacted snapshot-derived qa input" }));
   }
   writeFileSync(files.snapshot, JSON.stringify({ snapshot: makeWorkbenchSnapshot() }, null, 2));
+  return files;
+}
+
+function writeDesktopLiveCaptureDir(tempDir: string) {
+  const files = {
+    proof: join(tempDir, "macos-live-write-read-proof.json"),
+    events: join(tempDir, "macos-live-write-read-events.jsonl"),
+    index: join(tempDir, "capture-index.json"),
+  };
+
+  writeFileSync(files.proof, JSON.stringify({
+    truth_label: "macos_desktop_live_write_read_roundtrip_proof_not_ui_device_proof",
+    status: "pass",
+    mission_id: missionId,
+    work_item_id: "work_desktop_live_capture",
+    surface_kind: "desktop",
+    write: { status: "ready", created_or_ready: true },
+    read_projection: { contains_written_work_item: true },
+  }, null, 2));
+  writeFileSync(files.events, `${[
+    observation("desktop", "mission_intake_submitted", files.proof),
+    observation("desktop", "mission_intake_ready", files.proof),
+    observation("desktop", "same_mission_projection_visible", files.proof),
+  ].map((row) => JSON.stringify(row)).join("\n")}\n`);
+  writeFileSync(files.index, JSON.stringify({
+    truth_label: "macos_live_write_read_capture_index_not_ui_device_proof",
+    status: "ready",
+    mission_id: missionId,
+    desktop: {
+      proof: files.proof,
+      events: files.events,
+      event_count: 3,
+    },
+    caveat: "Desktop same-run capture only; still requires mobile/channel/timeline evidence before strict UI/device proof.",
+  }, null, 2));
+  return files;
+}
+
+function writeLiveWriteReadBundleDir(tempDir: string) {
+  const files = {
+    mobile: join(tempDir, "mobile", "ios-live-write-read-proof.json"),
+    desktop: join(tempDir, "desktop", "macos-live-write-read-proof.json"),
+    mobileEvents: join(tempDir, "mobile", "ios-live-write-read-events.jsonl"),
+    desktopEvents: join(tempDir, "desktop", "macos-live-write-read-events.jsonl"),
+    combinedEvents: join(tempDir, "bundle", "mobile-desktop-live-write-read-events.jsonl"),
+    index: join(tempDir, "bundle", "live-write-read-bundle-index.json"),
+  };
+
+  mkdirSync(join(tempDir, "mobile"), { recursive: true });
+  mkdirSync(join(tempDir, "desktop"), { recursive: true });
+  mkdirSync(join(tempDir, "bundle"), { recursive: true });
+  writeFileSync(files.mobile, JSON.stringify({ role: "mobile", mission_id: missionId, status: "pass" }));
+  writeFileSync(files.desktop, JSON.stringify({ role: "desktop", mission_id: missionId, status: "pass" }));
+  writeFileSync(files.mobileEvents, `${JSON.stringify(observation("mobile", "mission_intake_ready", files.mobile))}\n`);
+  writeFileSync(files.desktopEvents, `${JSON.stringify(observation("desktop", "same_mission_projection_visible", files.desktop))}\n`);
+  writeFileSync(files.combinedEvents, `${[
+    observation("mobile", "mission_intake_ready", files.mobile),
+    observation("desktop", "same_mission_projection_visible", files.desktop),
+  ].map((row) => JSON.stringify(row)).join("\n")}\n`);
+  writeFileSync(files.index, JSON.stringify({
+    truth: "ui_device_live_write_read_bundle_not_full_proof",
+    status: "partial_bundle_ready",
+    missionId,
+    captures: {
+      mobile: { proof: files.mobile, events: files.mobileEvents },
+      desktop: { proof: files.desktop, events: files.desktopEvents },
+    },
+    combinedEvents: files.combinedEvents,
+  }, null, 2));
   return files;
 }
 
@@ -388,6 +457,69 @@ describe("friday-ui-device-proof-readiness", () => {
 
       expect(result.truth).toBe("report_only_not_ui_device_proof");
       expect(result.status).toBe("blocked");
+      expect(result.blockers).toContain("ui_device_proof_evidence:missing_required_real_evidence_env");
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("discovers desktop live write-read capture artifacts without hand-written evidence aliases", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "friday-ui-device-readiness-desktop-live-"));
+    try {
+      const files = writeDesktopLiveCaptureDir(tempDir);
+
+      const stdout = execFileSync("bash", [
+        "scripts/ops/friday-ui-device-proof-readiness.sh",
+        "--evidence-dir",
+        tempDir,
+      ], {
+        cwd: process.cwd(),
+        encoding: "utf8",
+      });
+      const result = JSON.parse(stdout.slice(stdout.indexOf("{"))) as {
+        truth?: string;
+        status?: string;
+        notes?: string[];
+        blockers?: string[];
+      };
+
+      expect(result.truth).toBe("report_only_not_ui_device_proof");
+      expect(result.status).toBe("blocked");
+      expect(result.notes).toContain(`resolved_MISSION_ID:${missionId}`);
+      expect(result.notes).toContain(`resolved_DESKTOP_EVIDENCE:${files.proof}`);
+      expect(result.notes).toContain(`resolved_SAME_RUN_EVENTS:${files.events}`);
+      expect(result.blockers).toContain("ui_device_proof_evidence:missing_required_real_evidence_env");
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("discovers live write-read bundle missionId and prefers combined same-run events", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "friday-ui-device-readiness-bundle-"));
+    try {
+      const files = writeLiveWriteReadBundleDir(tempDir);
+
+      const stdout = execFileSync("bash", [
+        "scripts/ops/friday-ui-device-proof-readiness.sh",
+        "--evidence-dir",
+        tempDir,
+      ], {
+        cwd: process.cwd(),
+        encoding: "utf8",
+      });
+      const result = JSON.parse(stdout.slice(stdout.indexOf("{"))) as {
+        truth?: string;
+        status?: string;
+        notes?: string[];
+        blockers?: string[];
+      };
+
+      expect(result.truth).toBe("report_only_not_ui_device_proof");
+      expect(result.status).toBe("blocked");
+      expect(result.notes).toContain(`resolved_MISSION_ID:${missionId}`);
+      expect(result.notes).toContain(`resolved_MOBILE_EVIDENCE:${files.mobile}`);
+      expect(result.notes).toContain(`resolved_DESKTOP_EVIDENCE:${files.desktop}`);
+      expect(result.notes).toContain(`resolved_SAME_RUN_EVENTS:${files.combinedEvents}`);
       expect(result.blockers).toContain("ui_device_proof_evidence:missing_required_real_evidence_env");
     } finally {
       rmSync(tempDir, { recursive: true, force: true });


### PR DESCRIPTION
## Summary
- teach UI/device proof readiness to auto-discover macOS live write-read capture artifacts
- support standard mobile/desktop live write-read proof and event filenames in evidence-dir discovery
- add a negative/full-proof-safe test proving desktop-only capture is consumed but still blocked from final proof assembly when mobile/channel/timeline evidence is missing

## Verification
- npx vitest run test/unit/qa/friday-ui-device-proof-readiness-cli.test.ts
- bash scripts/ops/friday-macos-live-write-read-capture.sh --out-dir /tmp/friday-desktop-live-write-read-20260624
- bash scripts/ops/friday-ui-device-proof-readiness.sh --evidence-dir /tmp/friday-desktop-live-write-read-20260624
- npm run check:client-ship-gate
- git diff --check
- detect-secrets-hook --baseline .secrets.baseline scripts/ops/friday-ui-device-proof-readiness.sh
test/unit/qa/friday-ui-device-proof-readiness-cli.test.ts

Truth: this speeds evidence plumbing for real desktop capture. Desktop-only evidence remains partial and does not claim END-BAR, GO-LIVE, adoption, organic usage, or full UI/device proof.