### PR TITLE
Add UI device gap capture plan

### DIFF
--- a/scripts/ops/friday-ui-device-proof-gap-report.mjs
+++ b/scripts/ops/friday-ui-device-proof-gap-report.mjs
@@ -78,7 +78,11 @@ function usage() {
     --desktop=/abs/desktop-evidence \\
     --channel=/abs/channel-evidence \\
     --timeline=/abs/timeline-evidence \\
-    [--manifest=/abs/observations-manifest.json] [--out=/abs/gap-report.json] [--require-complete]
+    [--manifest=/abs/observations-manifest.json] \\
+    [--backend-live-proof=/abs/backend-proof.json] \\
+    [--channel-live-proof=/abs/channel-proof.json] \\
+    [--objective-coverage=/abs/objective-coverage.json] \\
+    [--out=/abs/gap-report.json] [--require-complete]
 
 Truth: reports missing real same-run UI/device observations. It does not derive
 or write proof, does not synthesize observations, and does not mark END-BAR.`);
@@ -99,6 +103,11 @@ const missionId = arg("mission-id");
 const eventsPath = arg("events");
 const manifestPath = arg("manifest");
 const outPath = arg("out");
+const supportingProofArgs = {
+  backendLiveProof: arg("backend-live-proof"),
+  channelLiveProof: arg("channel-live-proof"),
+  objectiveCoverage: arg("objective-coverage"),
+};
 const evidenceArgs = {
   mobile: arg("mobile"),
   desktop: arg("desktop"),
@@ -163,6 +172,60 @@ function parseManifest(path) {
   }
 }
 
+function parseOptionalJson(label, path) {
+  if (!path) return null;
+  const resolved = requireFile(label, path);
+  if (!resolved) return null;
+  try {
+    return { path: resolved, value: JSON.parse(readFileSync(resolved, "utf8")) };
+  } catch {
+    block("supporting_proof_unreadable_or_invalid_json", `${label}:${resolved}`);
+    return { path: resolved, value: null };
+  }
+}
+
+function supportingProof(label, path, validate) {
+  const parsed = parseOptionalJson(label, path);
+  if (!parsed) return null;
+  const failures = parsed.value ? validate(parsed.value) : ["invalid_json"];
+  return {
+    role: label,
+    path: parsed.path,
+    status: failures.length === 0 ? "usable_precondition_not_ui_device_evidence" : "invalid_or_incomplete",
+    countsTowardUiDeviceProof: false,
+    remainingRequirement: parsed.value?.remaining_requirement || "real UI/device observations must still pass the UI/device proof gate",
+    failures,
+  };
+}
+
+function supportingProofs() {
+  return [
+    supportingProof("backendLiveProof", supportingProofArgs.backendLiveProof, (value) => {
+      const failures = [];
+      if (value.proof !== "mission_spine_backend_api_live_pressure") failures.push("proof_mismatch");
+      if (value.status !== "passed") failures.push("status_not_passed");
+      if (!String(value.remaining_requirement || "").includes("UI/device consumption")) failures.push("remaining_requirement_missing");
+      return failures;
+    }),
+    supportingProof("channelLiveProof", supportingProofArgs.channelLiveProof, (value) => {
+      const failures = [];
+      if (value.proof !== "mission_spine_channel_live_proof") failures.push("proof_mismatch");
+      if (value.status !== "passed") failures.push("status_not_passed");
+      if (!String(value.remaining_requirement || "").includes("UI/device consumption")) failures.push("remaining_requirement_missing");
+      return failures;
+    }),
+    supportingProof("objectiveCoverage", supportingProofArgs.objectiveCoverage, (value) => {
+      const failures = [];
+      if (!String(value.remaining_requirement || "").includes("UI or device consumption")) failures.push("remaining_requirement_missing");
+      if (Array.isArray(value.requirements)) {
+        const uiRequirement = value.requirements.find((requirement) => requirement?.required_gate === "scripts/mission-spine-ui-device-proof-gate.sh");
+        if (!uiRequirement) failures.push("ui_device_required_gate_missing");
+      }
+      return failures;
+    }),
+  ].filter(Boolean);
+}
+
 function normalizeEvent(raw, index, knownEvidenceRefs) {
   const label = `event_${index + 1}`;
   const surface = typeof raw.surface === "string" ? raw.surface.trim() : "";
@@ -222,6 +285,7 @@ const knownEvidenceRefs = new Set(Object.values(evidence).filter(Boolean));
 const eventFile = requireFile("events", eventsPath);
 const observations = parseJsonl(eventFile).map((raw, index) => normalizeEvent(raw, index, knownEvidenceRefs));
 const manifest = parseManifest(manifestPath);
+const supportingProofRows = supportingProofs();
 
 const missingObservations = requiredObservations
   .filter(([surface, event]) => !hasObservation(observations, surface, event))
@@ -240,6 +304,50 @@ const timelinePageCount = observations.filter((observation) => observation.event
 const missingChecks = manifest?.checks && typeof manifest.checks === "object"
   ? requiredChecks.filter((check) => manifest.checks[check] !== true)
   : requiredChecks;
+
+function capturePlan(missingObservationRows, stressState) {
+  const bySurface = new Map();
+  const ensure = (surface) => {
+    if (!bySurface.has(surface)) {
+      bySurface.set(surface, {
+        surface,
+        events: [],
+        stress: [],
+      });
+    }
+    return bySurface.get(surface);
+  };
+
+  for (const row of missingObservationRows) {
+    ensure(row.preferredCapture).events.push(row.event);
+  }
+
+  if (!stressState.pressureAskCountOk) {
+    ensure("desktop").stress.push("pressure_20_50_consecutive_asks_visible");
+  }
+  if (!stressState.duplicateSurfaceCountOk) {
+    ensure("desktop").stress.push("duplicate_preflight_visible_on_at_least_two_surfaces");
+  }
+  if (!stressState.timelinePageCountOk) {
+    ensure("timeline").stress.push("bounded_page_1_visible_and_bounded_page_2_visible");
+  }
+
+  return [...bySurface.values()]
+    .map((entry) => ({
+      surface: entry.surface,
+      missingEvents: [...new Set(entry.events)].sort(),
+      stressRequirements: [...new Set(entry.stress)].sort(),
+      evidenceRole: entry.surface,
+      truth: "capture_real_same_run_events_only_no_synthetic_rows",
+    }))
+    .sort((a, b) => a.surface.localeCompare(b.surface));
+}
+
+const stressGaps = {
+  pressureAskCountOk: pressureAskCount >= 20 && pressureAskCount <= 50,
+  duplicateSurfaceCountOk: duplicateSurfaceCount >= 2,
+  timelinePageCountOk: timelinePageCount >= 2,
+};
 
 const gapReport = {
   truth: "ui_device_proof_gap_report_not_proof",
@@ -264,12 +372,10 @@ const gapReport = {
     missingObservations,
     missingOrderEvents,
     missingChecks,
-    stress: {
-      pressureAskCountOk: pressureAskCount >= 20 && pressureAskCount <= 50,
-      duplicateSurfaceCountOk: duplicateSurfaceCount >= 2,
-      timelinePageCountOk: timelinePageCount >= 2,
-    },
+    stress: stressGaps,
   },
+  capturePlan: capturePlan(missingObservations, stressGaps),
+  supportingProofs: supportingProofRows,
   blockers,
   caveat: "Gap report only. Capture missing observations from a real same-run mobile/desktop/channel/timeline run before assembling proof.",
 };

--- a/test/unit/qa/friday-ui-device-proof-gap-report-cli.test.ts
+++ b/test/unit/qa/friday-ui-device-proof-gap-report-cli.test.ts
@@ -97,6 +97,22 @@ function completeManifest() {
   };
 }
 
+function writeSupportingProofs(tempDir: string) {
+  const backend = join(tempDir, "backend-live-proof.json");
+  const channel = join(tempDir, "channel-live-proof.json");
+  writeFileSync(backend, JSON.stringify({
+    proof: "mission_spine_backend_api_live_pressure",
+    status: "passed",
+    remaining_requirement: "real mobile/desktop/channel UI/device consumption evidence must still pass scripts/mission-spine-ui-device-proof-gate.sh",
+  }, null, 2));
+  writeFileSync(channel, JSON.stringify({
+    proof: "mission_spine_channel_live_proof",
+    status: "passed",
+    remaining_requirement: "real mobile/desktop/channel UI/device consumption evidence must still pass scripts/mission-spine-ui-device-proof-gate.sh",
+  }, null, 2));
+  return { backend, channel };
+}
+
 function run(tempDir: string, files: ReturnType<typeof evidenceFiles>, rows: unknown[], extraArgs: string[] = []) {
   const events = join(tempDir, "events.jsonl");
   writeJsonl(events, rows);
@@ -123,6 +139,12 @@ describe("friday-ui-device-proof-gap-report", () => {
         truth?: string;
         status?: string;
         gaps?: { missingObservations?: Array<{ surface?: string; event?: string; preferredCapture?: string }> };
+        capturePlan?: Array<{
+          surface?: string;
+          missingEvents?: string[];
+          stressRequirements?: string[];
+          truth?: string;
+        }>;
       };
       expect(output.truth).toBe("ui_device_proof_gap_report_not_proof");
       expect(output.status).toBe("gaps_present");
@@ -136,6 +158,66 @@ describe("friday-ui-device-proof-gap-report", () => {
         event: "bounded_page_1_visible",
         preferredCapture: "timeline",
       });
+      expect(output.capturePlan).toContainEqual(expect.objectContaining({
+        surface: "channel",
+        missingEvents: expect.arrayContaining([
+          "same_mission_mobile_desktop_channel_visible",
+          "same_mission_projection_visible",
+        ]),
+        truth: "capture_real_same_run_events_only_no_synthetic_rows",
+      }));
+      expect(output.capturePlan).toContainEqual(expect.objectContaining({
+        surface: "desktop",
+        stressRequirements: expect.arrayContaining([
+          "duplicate_preflight_visible_on_at_least_two_surfaces",
+          "pressure_20_50_consecutive_asks_visible",
+        ]),
+      }));
+      expect(output.capturePlan).toContainEqual(expect.objectContaining({
+        surface: "timeline",
+        stressRequirements: expect.arrayContaining([
+          "bounded_page_1_visible_and_bounded_page_2_visible",
+        ]),
+      }));
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps backend and channel supporting proofs separate from UI device evidence", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "friday-ui-gap-report-supporting-"));
+    try {
+      const files = evidenceFiles(tempDir);
+      const proofs = writeSupportingProofs(tempDir);
+      const result = run(tempDir, files, partialRows(files), [
+        `--backend-live-proof=${proofs.backend}`,
+        `--channel-live-proof=${proofs.channel}`,
+      ]);
+      expect(result.status).toBe(0);
+      const output = JSON.parse(result.stdout) as {
+        status?: string;
+        supportingProofs?: Array<{
+          role?: string;
+          status?: string;
+          countsTowardUiDeviceProof?: boolean;
+          failures?: string[];
+        }>;
+        gaps?: { missingObservations?: unknown[] };
+      };
+      expect(output.status).toBe("gaps_present");
+      expect(output.gaps?.missingObservations?.length).toBeGreaterThan(0);
+      expect(output.supportingProofs).toContainEqual(expect.objectContaining({
+        role: "backendLiveProof",
+        status: "usable_precondition_not_ui_device_evidence",
+        countsTowardUiDeviceProof: false,
+        failures: [],
+      }));
+      expect(output.supportingProofs).toContainEqual(expect.objectContaining({
+        role: "channelLiveProof",
+        status: "usable_precondition_not_ui_device_evidence",
+        countsTowardUiDeviceProof: false,
+        failures: [],
+      }));
     } finally {
       rmSync(tempDir, { recursive: true, force: true });
     }
@@ -167,9 +249,14 @@ describe("friday-ui-device-proof-gap-report", () => {
         "--require-complete",
       ]);
       expect(result.status).toBe(0);
-      const output = JSON.parse(result.stdout) as { status?: string; gaps?: { missingObservations?: unknown[] } };
+      const output = JSON.parse(result.stdout) as {
+        status?: string;
+        gaps?: { missingObservations?: unknown[] };
+        capturePlan?: unknown[];
+      };
       expect(output.status).toBe("complete_inputs_observed");
       expect(output.gaps?.missingObservations).toEqual([]);
+      expect(output.capturePlan).toEqual([]);
       const written = JSON.parse(readFileSync(out, "utf8")) as { status?: string };
       expect(written.status).toBe("complete_inputs_observed");
     } finally {


### PR DESCRIPTION
## Summary
- add a capturePlan to the UI/device gap report so missing same-run observations are grouped by capture surface
- add supportingProofs for backend/channel/objective preconditions while keeping them explicitly separate from UI/device proof evidence
- keep the report truth-labeled as not proof and fail-closed for complete-input requirements

## Verification
- npx vitest run test/unit/qa/friday-ui-device-proof-gap-report-cli.test.ts test/unit/qa/friday-ui-device-proof-readiness-cli.test.ts
- npm run check:client-ship-gate
- git diff --check
- detect-secrets scan --baseline .secrets.baseline --all-files --force-use-all-plugins

Truth: this is proof-planning automation only; it does not claim END-BAR, GO-LIVE, organic adoption, or complete UI/device proof.