### PR TITLE
Summarize reusable UI device captures

### DIFF
--- a/scripts/ops/friday-ui-device-capture-dir.mjs
+++ b/scripts/ops/friday-ui-device-capture-dir.mjs
@@ -123,6 +123,7 @@ const readyToWrite = blockers.length === 0 && outDir;
 let written = [];
 let copiedManifest = "";
 let derivedEvents = "";
+let reuseSummary = null;
 if (readyToWrite) {
   const dir = abs(outDir);
   mkdirSync(dir, { recursive: true });
@@ -175,6 +176,35 @@ if (readyToWrite) {
     block("observations_manifest_missing", "supply --observations-manifest or --events from the same real capture run");
   }
 
+  reuseSummary = {
+    truth: "ui_device_capture_dir_reuse_summary_not_proof",
+    evidenceDir: dir,
+    captures: written.map((capture) => ({
+      role: capture.role,
+      path: capture.target,
+      sha256: capture.targetSha256,
+      bytes: statSync(capture.target).size,
+      reusableAsUiDeviceEvidenceInput: true,
+      countsAsProofByItself: false,
+    })),
+    observationsManifest: copiedManifest
+      ? {
+          path: copiedManifest,
+          present: true,
+          reusableForPreflight: true,
+          countsAsProofByItself: false,
+        }
+      : {
+          path: null,
+          present: false,
+          reusableForPreflight: false,
+          countsAsProofByItself: false,
+        },
+    normalizedEvents: derivedEvents || null,
+    nextCommand: "scripts/ops/friday-ui-device-proof-readiness.sh --evidence-dir <dir> --require-proof",
+    caveat: "Reuse summary only. The strict readiness/assembler/final gate must still bind hashes and observations before proof.",
+  };
+
   const index = {
     truth: "ui_device_capture_dir_index_not_proof",
     status: blockers.length === 0 ? "ready_for_preflight" : "blocked",
@@ -183,6 +213,7 @@ if (readyToWrite) {
     captures: written,
     observationsManifest: copiedManifest || null,
     normalizedEvents: derivedEvents || null,
+    reuseSummary,
     blockers,
   };
   writeFileSync(join(dir, "capture-index.json"), `${JSON.stringify(index, null, 2)}\n`);
@@ -218,6 +249,7 @@ const output = {
   captures: written,
   observationsManifest: copiedManifest || null,
   normalizedEvents: derivedEvents || null,
+  reuseSummary,
   preflight,
   blockers,
   next: blockers.length === 0

--- a/test/unit/qa/friday-ui-device-capture-dir-cli.test.ts
+++ b/test/unit/qa/friday-ui-device-capture-dir-cli.test.ts
@@ -189,13 +189,37 @@ describe("friday-ui-device-capture-dir", () => {
         "--require-ready",
       ], { cwd: process.cwd(), encoding: "utf8" });
 
-      const result = JSON.parse(stdout) as { status?: string; truth?: string; preflight?: { status?: number } };
+      const result = JSON.parse(stdout) as {
+        status?: string;
+        truth?: string;
+        preflight?: { status?: number };
+        reuseSummary?: {
+          truth?: string;
+          captures?: Array<{ role?: string; reusableAsUiDeviceEvidenceInput?: boolean; countsAsProofByItself?: boolean }>;
+          observationsManifest?: { present?: boolean; reusableForPreflight?: boolean; countsAsProofByItself?: boolean };
+        };
+      };
       expect(result.truth).toBe("ui_device_capture_dir_driver_not_proof");
       expect(result.status).toBe("ready");
       expect(result.preflight?.status).toBe(0);
+      expect(result.reuseSummary?.truth).toBe("ui_device_capture_dir_reuse_summary_not_proof");
+      expect(result.reuseSummary?.captures).toContainEqual(expect.objectContaining({
+        role: "mobile",
+        reusableAsUiDeviceEvidenceInput: true,
+        countsAsProofByItself: false,
+      }));
+      expect(result.reuseSummary?.observationsManifest).toEqual(expect.objectContaining({
+        present: true,
+        reusableForPreflight: true,
+        countsAsProofByItself: false,
+      }));
 
-      const index = JSON.parse(readFileSync(join(outDir, "capture-index.json"), "utf8")) as { truth?: string };
+      const index = JSON.parse(readFileSync(join(outDir, "capture-index.json"), "utf8")) as {
+        truth?: string;
+        reuseSummary?: { nextCommand?: string };
+      };
       expect(index.truth).toBe("ui_device_capture_dir_index_not_proof");
+      expect(index.reuseSummary?.nextCommand).toBe("scripts/ops/friday-ui-device-proof-readiness.sh --evidence-dir <dir> --require-proof");
     } finally {
       rmSync(tempDir, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary
- add a reuseSummary to the UI/device capture-dir index and stdout
- show copied evidence paths, hashes, byte counts, and whether each file can be reused as a UI/device evidence input
- keep every row truth-labeled as not proof and require the existing readiness/assembler/final gate for proof

## Verification
- npx vitest run test/unit/qa/friday-ui-device-capture-dir-cli.test.ts test/unit/qa/friday-ui-device-proof-gap-report-cli.test.ts test/unit/qa/friday-ui-device-proof-readiness-cli.test.ts
- npm run check:client-ship-gate
- git diff --check
- detect-secrets scan --baseline .secrets.baseline --all-files --force-use-all-plugins

Truth: this is capture-dir reuse/reporting automation only; it does not claim END-BAR, GO-LIVE, organic adoption, or complete UI/device proof.