### PR TITLE
Pass supporting proofs into UI readiness gaps

### DIFF
--- a/scripts/ops/friday-ui-device-proof-readiness.sh
+++ b/scripts/ops/friday-ui-device-proof-readiness.sh
@@ -15,11 +15,17 @@ MODE="report-only"
 RUN_LIVE_READINESS=0
 RUN_SNAPSHOT_CONTRACT=0
 EVIDENCE_DIR="${FRIDAY_UI_DEVICE_PROOF_EVIDENCE_DIR:-}"
+BACKEND_LIVE_PROOF="${FRIDAY_UI_DEVICE_BACKEND_LIVE_PROOF:-}"
+CHANNEL_LIVE_PROOF="${FRIDAY_UI_DEVICE_CHANNEL_LIVE_PROOF:-}"
+OBJECTIVE_COVERAGE="${FRIDAY_UI_DEVICE_OBJECTIVE_COVERAGE:-}"
 
 usage() {
   cat <<'EOF'
 usage:
   scripts/ops/friday-ui-device-proof-readiness.sh [--live-readiness] [--snapshot-contract] [--require-proof] [--evidence-dir /abs/capture-dir]
+    [--backend-live-proof /abs/backend-proof.json]
+    [--channel-live-proof /abs/channel-proof.json]
+    [--objective-coverage /abs/objective-coverage.json]
 
 optional env for live/snapshot checks:
   FRIDAY_MISSION_WORKBENCH_URL=http://127.0.0.1:5173/mission-workbench
@@ -38,6 +44,9 @@ real proof env, all required to assemble:
 evidence-dir auto-discovery:
   FRIDAY_UI_DEVICE_PROOF_EVIDENCE_DIR=/abs/capture-dir
   or --evidence-dir /abs/capture-dir
+  FRIDAY_UI_DEVICE_BACKEND_LIVE_PROOF=/abs/backend-proof.json
+  FRIDAY_UI_DEVICE_CHANNEL_LIVE_PROOF=/abs/channel-proof.json
+  FRIDAY_UI_DEVICE_OBJECTIVE_COVERAGE=/abs/objective-coverage.json
 
   Looks for mission-id.txt or manifest mission_id plus:
     mobile.{json,trace,log,png}
@@ -72,6 +81,33 @@ while [ "$#" -gt 0 ]; do
         exit 64
       fi
       EVIDENCE_DIR="$2"
+      shift
+      ;;
+    --backend-live-proof)
+      if [ "$#" -lt 2 ]; then
+        echo "FATAL: --backend-live-proof requires a value" >&2
+        usage >&2
+        exit 64
+      fi
+      BACKEND_LIVE_PROOF="$2"
+      shift
+      ;;
+    --channel-live-proof)
+      if [ "$#" -lt 2 ]; then
+        echo "FATAL: --channel-live-proof requires a value" >&2
+        usage >&2
+        exit 64
+      fi
+      CHANNEL_LIVE_PROOF="$2"
+      shift
+      ;;
+    --objective-coverage)
+      if [ "$#" -lt 2 ]; then
+        echo "FATAL: --objective-coverage requires a value" >&2
+        usage >&2
+        exit 64
+      fi
+      OBJECTIVE_COVERAGE="$2"
       shift
       ;;
     -h|--help)
@@ -283,7 +319,7 @@ derive_workbench_events_if_possible
 if [ -n "$EVIDENCE_DIR" ]; then
   notes+=("evidence_dir:$(abs_path "$EVIDENCE_DIR")")
 fi
-for name in MISSION_ID MOBILE_EVIDENCE DESKTOP_EVIDENCE CHANNEL_EVIDENCE TIMELINE_EVIDENCE OBSERVATIONS_MANIFEST FRIDAY_WORKBENCH_SNAPSHOT_FILE; do
+for name in MISSION_ID MOBILE_EVIDENCE DESKTOP_EVIDENCE CHANNEL_EVIDENCE TIMELINE_EVIDENCE OBSERVATIONS_MANIFEST FRIDAY_WORKBENCH_SNAPSHOT_FILE BACKEND_LIVE_PROOF CHANNEL_LIVE_PROOF OBJECTIVE_COVERAGE; do
   if [ -n "${!name:-}" ]; then
     notes+=("resolved_${name}:${!name}")
   fi
@@ -343,6 +379,15 @@ run_gap_report_if_possible() {
   )
   if [ -n "${OBSERVATIONS_MANIFEST:-}" ]; then
     args+=("--manifest=${OBSERVATIONS_MANIFEST}")
+  fi
+  if [ -n "${BACKEND_LIVE_PROOF:-}" ]; then
+    args+=("--backend-live-proof=$(abs_path "$BACKEND_LIVE_PROOF")")
+  fi
+  if [ -n "${CHANNEL_LIVE_PROOF:-}" ]; then
+    args+=("--channel-live-proof=$(abs_path "$CHANNEL_LIVE_PROOF")")
+  fi
+  if [ -n "${OBJECTIVE_COVERAGE:-}" ]; then
+    args+=("--objective-coverage=$(abs_path "$OBJECTIVE_COVERAGE")")
   fi
 
   mkdir -p "$(dirname "$gap_out")"

--- a/test/unit/qa/friday-ui-device-proof-readiness-cli.test.ts
+++ b/test/unit/qa/friday-ui-device-proof-readiness-cli.test.ts
@@ -58,6 +58,24 @@ function writePartialEvidenceDir(tempDir: string) {
   return files;
 }
 
+function writeSupportingProofs(tempDir: string) {
+  const files = {
+    backend: join(tempDir, "backend-live-proof.json"),
+    channel: join(tempDir, "channel-live-proof.json"),
+  };
+  writeFileSync(files.backend, JSON.stringify({
+    proof: "mission_spine_backend_api_live_pressure",
+    status: "passed",
+    remaining_requirement: "real mobile/desktop/channel UI/device consumption evidence must still pass scripts/mission-spine-ui-device-proof-gate.sh",
+  }, null, 2));
+  writeFileSync(files.channel, JSON.stringify({
+    proof: "mission_spine_channel_live_proof",
+    status: "passed",
+    remaining_requirement: "real mobile/desktop/channel UI/device consumption evidence must still pass scripts/mission-spine-ui-device-proof-gate.sh",
+  }, null, 2));
+  return files;
+}
+
 function writeWorkbenchSnapshotEvidenceDir(tempDir: string) {
   const files = {
     mobile: join(tempDir, "mobile.json"),
@@ -563,6 +581,57 @@ describe("friday-ui-device-proof-readiness", () => {
         event: "same_mission_projection_visible",
         preferredCapture: "channel",
       });
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("passes supporting proofs into the gap report without satisfying UI device proof", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "friday-ui-device-readiness-supporting-"));
+    try {
+      writePartialEvidenceDir(tempDir);
+      const proofs = writeSupportingProofs(tempDir);
+
+      const stdout = execFileSync("bash", [
+        "scripts/ops/friday-ui-device-proof-readiness.sh",
+        "--evidence-dir",
+        tempDir,
+        "--backend-live-proof",
+        proofs.backend,
+        "--channel-live-proof",
+        proofs.channel,
+      ], {
+        cwd: process.cwd(),
+        encoding: "utf8",
+      });
+      const result = JSON.parse(stdout.slice(stdout.indexOf("{"))) as {
+        truth?: string;
+        status?: string;
+        notes?: string[];
+        blockers?: string[];
+      };
+
+      expect(result.truth).toBe("report_only_not_ui_device_proof");
+      expect(result.status).toBe("blocked");
+      expect(result.notes).toContain(`resolved_BACKEND_LIVE_PROOF:${proofs.backend}`);
+      expect(result.notes).toContain(`resolved_CHANNEL_LIVE_PROOF:${proofs.channel}`);
+      expect(result.blockers).toContain("ui_device_proof_evidence:missing_required_real_evidence_env");
+
+      const gapReport = JSON.parse(readFileSync(join(tempDir, "gap-report.json"), "utf8")) as {
+        status?: string;
+        supportingProofs?: Array<{ role?: string; status?: string; countsTowardUiDeviceProof?: boolean }>;
+      };
+      expect(gapReport.status).toBe("gaps_present");
+      expect(gapReport.supportingProofs).toContainEqual(expect.objectContaining({
+        role: "backendLiveProof",
+        status: "usable_precondition_not_ui_device_evidence",
+        countsTowardUiDeviceProof: false,
+      }));
+      expect(gapReport.supportingProofs).toContainEqual(expect.objectContaining({
+        role: "channelLiveProof",
+        status: "usable_precondition_not_ui_device_evidence",
+        countsTowardUiDeviceProof: false,
+      }));
     } finally {
       rmSync(tempDir, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary
- add readiness wrapper flags/env for backend live proof, channel live proof, and objective coverage artifacts
- pass those artifacts through to the UI/device gap report as supportingProofs
- keep supporting proofs separate from UI/device evidence so they never satisfy proof/END-BAR by themselves

## Verification
- npx vitest run test/unit/qa/friday-ui-device-proof-readiness-cli.test.ts test/unit/qa/friday-ui-device-proof-gap-report-cli.test.ts
- npm run check:client-ship-gate
- git diff --check
- detect-secrets scan --baseline .secrets.baseline --all-files --force-use-all-plugins

Truth: this is readiness reporting/planning automation only; it does not claim END-BAR, GO-LIVE, organic adoption, or complete UI/device proof.