### PR TITLE
Discover UI readiness supporting proofs

### DIFF
--- a/scripts/ops/friday-ui-device-proof-readiness.sh
+++ b/scripts/ops/friday-ui-device-proof-readiness.sh
@@ -240,6 +240,24 @@ discover_evidence_dir() {
       "$dir/mission-workbench-snapshot.json" \
       "$dir/workbench-response.json" || true)"
   fi
+  if [ -z "${BACKEND_LIVE_PROOF:-}" ]; then
+    BACKEND_LIVE_PROOF="$(first_existing \
+      "$dir/backend-live-proof.json" \
+      "$dir/backend-proof.json" \
+      "$dir/mission-spine-backend-live-proof.json" || true)"
+  fi
+  if [ -z "${CHANNEL_LIVE_PROOF:-}" ]; then
+    CHANNEL_LIVE_PROOF="$(first_existing \
+      "$dir/channel-live-proof.json" \
+      "$dir/channel-proof.json" \
+      "$dir/mission-spine-channel-live-proof.json" || true)"
+  fi
+  if [ -z "${OBJECTIVE_COVERAGE:-}" ]; then
+    OBJECTIVE_COVERAGE="$(first_existing \
+      "$dir/objective-coverage.json" \
+      "$dir/mission-spine-objective-coverage.json" \
+      "$dir/mission-spine-objective-coverage-gate.json" || true)"
+  fi
 }
 
 json_escape() {

--- a/test/unit/qa/friday-ui-device-proof-readiness-cli.test.ts
+++ b/test/unit/qa/friday-ui-device-proof-readiness-cli.test.ts
@@ -62,6 +62,7 @@ function writeSupportingProofs(tempDir: string) {
   const files = {
     backend: join(tempDir, "backend-live-proof.json"),
     channel: join(tempDir, "channel-live-proof.json"),
+    objective: join(tempDir, "objective-coverage.json"),
   };
   writeFileSync(files.backend, JSON.stringify({
     proof: "mission_spine_backend_api_live_pressure",
@@ -72,6 +73,17 @@ function writeSupportingProofs(tempDir: string) {
     proof: "mission_spine_channel_live_proof",
     status: "passed",
     remaining_requirement: "real mobile/desktop/channel UI/device consumption evidence must still pass scripts/mission-spine-ui-device-proof-gate.sh",
+  }, null, 2));
+  writeFileSync(files.objective, JSON.stringify({
+    proof: "mission_spine_objective_coverage",
+    status: "passed",
+    remaining_requirement: "real mobile/desktop/channel UI or device consumption evidence must still pass scripts/mission-spine-ui-device-proof-gate.sh",
+    requirements: [
+      {
+        requirement: "real mobile/desktop/channel UI or device consumption",
+        required_gate: "scripts/mission-spine-ui-device-proof-gate.sh",
+      },
+    ],
   }, null, 2));
   return files;
 }
@@ -629,6 +641,59 @@ describe("friday-ui-device-proof-readiness", () => {
       }));
       expect(gapReport.supportingProofs).toContainEqual(expect.objectContaining({
         role: "channelLiveProof",
+        status: "usable_precondition_not_ui_device_evidence",
+        countsTowardUiDeviceProof: false,
+      }));
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("auto-discovers supporting proof artifacts from the evidence dir without counting them as UI proof", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "friday-ui-device-readiness-supporting-auto-"));
+    try {
+      writePartialEvidenceDir(tempDir);
+      const proofs = writeSupportingProofs(tempDir);
+
+      const stdout = execFileSync("bash", [
+        "scripts/ops/friday-ui-device-proof-readiness.sh",
+        "--evidence-dir",
+        tempDir,
+      ], {
+        cwd: process.cwd(),
+        encoding: "utf8",
+      });
+      const result = JSON.parse(stdout.slice(stdout.indexOf("{"))) as {
+        truth?: string;
+        status?: string;
+        notes?: string[];
+        blockers?: string[];
+      };
+
+      expect(result.truth).toBe("report_only_not_ui_device_proof");
+      expect(result.status).toBe("blocked");
+      expect(result.notes).toContain(`resolved_BACKEND_LIVE_PROOF:${proofs.backend}`);
+      expect(result.notes).toContain(`resolved_CHANNEL_LIVE_PROOF:${proofs.channel}`);
+      expect(result.notes).toContain(`resolved_OBJECTIVE_COVERAGE:${proofs.objective}`);
+      expect(result.blockers).toContain("ui_device_proof_evidence:missing_required_real_evidence_env");
+
+      const gapReport = JSON.parse(readFileSync(join(tempDir, "gap-report.json"), "utf8")) as {
+        status?: string;
+        supportingProofs?: Array<{ role?: string; status?: string; countsTowardUiDeviceProof?: boolean }>;
+      };
+      expect(gapReport.status).toBe("gaps_present");
+      expect(gapReport.supportingProofs).toContainEqual(expect.objectContaining({
+        role: "backendLiveProof",
+        status: "usable_precondition_not_ui_device_evidence",
+        countsTowardUiDeviceProof: false,
+      }));
+      expect(gapReport.supportingProofs).toContainEqual(expect.objectContaining({
+        role: "channelLiveProof",
+        status: "usable_precondition_not_ui_device_evidence",
+        countsTowardUiDeviceProof: false,
+      }));
+      expect(gapReport.supportingProofs).toContainEqual(expect.objectContaining({
+        role: "objectiveCoverage",
         status: "usable_precondition_not_ui_device_evidence",
         countsTowardUiDeviceProof: false,
       }));


### PR DESCRIPTION
## Summary
- auto-discover backend/channel/objective supporting proof artifacts from a UI/device evidence dir
- keep supporting proofs as preconditions only; they still countTowardUiDeviceProof=false
- cover auto-discovery in the readiness CLI test

## Verification
- npx vitest run test/unit/qa/friday-ui-device-proof-readiness-cli.test.ts test/unit/qa/friday-ui-device-proof-gap-report-cli.test.ts
- npm run check:client-ship-gate
- git diff --check