### PR TITLE
Merge UI device event captures

### DIFF
--- a/scripts/ops/friday-ui-device-capture-dir.mjs
+++ b/scripts/ops/friday-ui-device-capture-dir.mjs
@@ -17,17 +17,32 @@ function usage() {
     --channel=/abs/channel-capture \\
     --timeline=/abs/timeline-capture \\
     [--observations-manifest=/abs/observations-manifest.json] \\
-    [--events=/abs/same-run-events.jsonl] [--require-ready]
+    [--events=/abs/same-run-events.jsonl ...] [--events-dir=/abs/events-dir ...] [--require-ready]
 
 Truth: this indexes already-captured files into an evidence-dir shape. It is not a
 UI/device proof and never invents observations. A supplied observations manifest,
-or a manifest derived from same-run events, is validated by
+or a manifest derived from same-run events merged from real captures, is validated by
 scripts/qa/check-mission-spine-ui-proof-inputs.mjs.`);
 }
 
 function arg(name) {
   const prefix = `--${name}=`;
   return args.find((value) => value.startsWith(prefix))?.slice(prefix.length) || "";
+}
+
+function argsAll(name) {
+  const prefix = `--${name}=`;
+  const values = [];
+  for (let index = 0; index < args.length; index += 1) {
+    const value = args[index];
+    if (value.startsWith(prefix)) {
+      values.push(value.slice(prefix.length));
+    } else if (value === `--${name}` && args[index + 1]) {
+      values.push(args[index + 1]);
+      index += 1;
+    }
+  }
+  return values;
 }
 
 if (args.includes("--help") || args.includes("-h")) {
@@ -39,7 +54,8 @@ const requireReady = args.includes("--require-ready");
 const missionId = arg("mission-id");
 const outDir = arg("out-dir");
 const manifest = arg("observations-manifest");
-const events = arg("events");
+const eventInputs = argsAll("events");
+const eventDirs = argsAll("events-dir");
 const inputByRole = {
   mobile: arg("mobile"),
   desktop: arg("desktop"),
@@ -123,6 +139,7 @@ const readyToWrite = blockers.length === 0 && outDir;
 let written = [];
 let copiedManifest = "";
 let derivedEvents = "";
+let mergedEvents = "";
 let reuseSummary = null;
 if (readyToWrite) {
   const dir = abs(outDir);
@@ -150,12 +167,29 @@ if (readyToWrite) {
     } catch {
       block("observations_manifest_unreadable", manifestSource);
     }
-  } else if (events) {
+  } else if (eventInputs.length > 0 || eventDirs.length > 0) {
     const byRole = Object.fromEntries(written.map((capture) => [capture.role, capture.target]));
     const sourceToTarget = new Map(written.map((capture) => [capture.source, capture.target]));
+    mergedEvents = join(dir, "same-run-events.merged-source.jsonl");
     derivedEvents = join(dir, "same-run-events.normalized.jsonl");
     copiedManifest = join(dir, "observations-manifest.json");
-    if (normalizeEvents(events, sourceToTarget, derivedEvents)) {
+    const mergeArgs = [
+      "scripts/ops/friday-ui-device-events-merge.mjs",
+      `--mission-id=${missionId}`,
+      `--mobile=${inputByRole.mobile}`,
+      `--desktop=${inputByRole.desktop}`,
+      `--channel=${inputByRole.channel}`,
+      `--timeline=${inputByRole.timeline}`,
+      `--out=${mergedEvents}`,
+      "--require-ready",
+      ...eventInputs.map((path) => `--events=${path}`),
+      ...eventDirs.map((path) => `--events-dir=${path}`),
+    ];
+    const mergeResult = spawnSync(process.execPath, mergeArgs, { encoding: "utf8" });
+    if (mergeResult.status !== 0) {
+      copiedManifest = "";
+      block("events_merge_failed", `exit_${mergeResult.status}`);
+    } else if (normalizeEvents(mergedEvents, sourceToTarget, derivedEvents)) {
       const result = spawnSync(process.execPath, [
         "scripts/ops/friday-ui-device-observations-manifest.mjs",
         `--mission-id=${missionId}`,
@@ -200,6 +234,7 @@ if (readyToWrite) {
           reusableForPreflight: false,
           countsAsProofByItself: false,
         },
+    mergedEvents: mergedEvents || null,
     normalizedEvents: derivedEvents || null,
     nextCommand: "scripts/ops/friday-ui-device-proof-readiness.sh --evidence-dir <dir> --require-proof",
     caveat: "Reuse summary only. The strict readiness/assembler/final gate must still bind hashes and observations before proof.",
@@ -212,6 +247,7 @@ if (readyToWrite) {
     evidenceDir: dir,
     captures: written,
     observationsManifest: copiedManifest || null,
+    mergedEvents: mergedEvents || null,
     normalizedEvents: derivedEvents || null,
     reuseSummary,
     blockers,
@@ -248,6 +284,7 @@ const output = {
   evidenceDir: outDir ? abs(outDir) : null,
   captures: written,
   observationsManifest: copiedManifest || null,
+  mergedEvents: mergedEvents || null,
   normalizedEvents: derivedEvents || null,
   reuseSummary,
   preflight,

--- a/scripts/ops/friday-ui-device-events-merge.mjs
+++ b/scripts/ops/friday-ui-device-events-merge.mjs
@@ -1,0 +1,204 @@
+#!/usr/bin/env node
+
+import { mkdirSync, readFileSync, readdirSync, statSync, writeFileSync } from "node:fs";
+import { dirname, extname, isAbsolute, join, resolve } from "node:path";
+
+const args = process.argv.slice(2);
+
+function usage() {
+  console.error(`usage:
+  node scripts/ops/friday-ui-device-events-merge.mjs \\
+    --mission-id=mission_... \\
+    --events=/abs/events-a.jsonl [--events=/abs/events-b.jsonl ...] \\
+    [--events-dir=/abs/dir] \\
+    [--mobile=/abs/mobile-capture] [--desktop=/abs/desktop-capture] \\
+    [--channel=/abs/channel-capture] [--timeline=/abs/timeline-capture] \\
+    --out=/abs/same-run-events.jsonl [--require-ready]
+
+Truth: this merges already-captured same-run UI/device event rows. It validates
+mission_id and known evidence_ref values when evidence files are supplied. It
+does not invent observations, does not derive cross-surface proof rows, and is
+not a UI/device proof.`);
+}
+
+function arg(name) {
+  const prefix = `--${name}=`;
+  return args.find((value) => value.startsWith(prefix))?.slice(prefix.length) || "";
+}
+
+function argsAll(name) {
+  const prefix = `--${name}=`;
+  const values = [];
+  for (let index = 0; index < args.length; index += 1) {
+    const value = args[index];
+    if (value.startsWith(prefix)) {
+      values.push(value.slice(prefix.length));
+    } else if (value === `--${name}` && args[index + 1]) {
+      values.push(args[index + 1]);
+      index += 1;
+    }
+  }
+  return values;
+}
+
+if (args.includes("--help") || args.includes("-h")) {
+  usage();
+  process.exit(0);
+}
+
+const requireReady = args.includes("--require-ready");
+const missionId = arg("mission-id");
+const outPath = arg("out");
+const eventInputs = argsAll("events");
+const eventDirs = argsAll("events-dir");
+const evidenceArgs = {
+  mobile: arg("mobile"),
+  desktop: arg("desktop"),
+  channel: arg("channel"),
+  timeline: arg("timeline"),
+};
+const blockers = [];
+
+function block(code, detail) {
+  blockers.push({ code, detail });
+}
+
+function abs(path) {
+  return isAbsolute(path) ? path : resolve(path);
+}
+
+function readableFile(label, path) {
+  if (!path) return "";
+  const resolved = abs(path);
+  try {
+    const stats = statSync(resolved);
+    if (!stats.isFile()) block("not_file", `${label}:${resolved}`);
+    if (stats.size <= 0) block("empty_file", `${label}:${resolved}`);
+  } catch {
+    block("unreadable_file", `${label}:${resolved}`);
+  }
+  return resolved;
+}
+
+function collectEventsDir(dir) {
+  const resolved = abs(dir);
+  try {
+    const stats = statSync(resolved);
+    if (!stats.isDirectory()) {
+      block("events_dir_not_directory", resolved);
+      return [];
+    }
+    return readdirSync(resolved)
+      .filter((name) => extname(name).toLowerCase() === ".jsonl")
+      .sort()
+      .map((name) => join(resolved, name));
+  } catch {
+    block("events_dir_unreadable", resolved);
+    return [];
+  }
+}
+
+function parseJsonl(path) {
+  const resolved = readableFile("events", path);
+  if (!resolved) return [];
+  try {
+    return readFileSync(resolved, "utf8")
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter(Boolean)
+      .map((line, index) => {
+        try {
+          return { source: resolved, line: index + 1, row: JSON.parse(line) };
+        } catch {
+          block("invalid_jsonl", `${resolved}:${index + 1}`);
+          return null;
+        }
+      })
+      .filter(Boolean);
+  } catch {
+    block("events_unreadable", resolved);
+    return [];
+  }
+}
+
+function normalizedEntry(entry, knownEvidenceRefs) {
+  const label = `${entry.source}:${entry.line}`;
+  const raw = entry.row && typeof entry.row === "object" && !Array.isArray(entry.row) ? entry.row : {};
+  const surface = typeof raw.surface === "string" ? raw.surface.trim() : "";
+  const event = typeof raw.event === "string" ? raw.event.trim() : "";
+  const eventMissionId = typeof raw.mission_id === "string" ? raw.mission_id.trim() : "";
+  const evidenceRef = typeof raw.evidence_ref === "string" ? raw.evidence_ref.trim() : "";
+  if (!surface) block("event_missing_surface", label);
+  if (!event) block("event_missing_event", label);
+  if (!eventMissionId) block("event_missing_mission_id", label);
+  if (eventMissionId && eventMissionId !== missionId) block("event_mission_mismatch", `${label}:${eventMissionId}`);
+  if (!evidenceRef) block("event_missing_evidence_ref", label);
+  if (knownEvidenceRefs.size > 0 && evidenceRef && !knownEvidenceRefs.has(evidenceRef)) {
+    block("event_evidence_ref_unknown", `${label}:${evidenceRef}`);
+  }
+  return {
+    surface,
+    event,
+    mission_id: eventMissionId,
+    evidence_ref: evidenceRef,
+  };
+}
+
+if (!missionId || !/^[A-Za-z0-9][A-Za-z0-9._:-]*$/.test(missionId) || !missionId.toLowerCase().includes("mission")) {
+  block("mission_id_unexpected_shape", missionId || "<missing>");
+}
+if (!outPath) block("missing_arg", "out");
+
+const eventFiles = [
+  ...eventInputs,
+  ...eventDirs.flatMap(collectEventsDir),
+].map((path) => abs(path));
+if (eventFiles.length === 0) block("missing_events", "supply --events or --events-dir");
+
+const knownEvidenceRefs = new Set(
+  Object.entries(evidenceArgs)
+    .map(([role, path]) => readableFile(role, path))
+    .filter(Boolean),
+);
+
+const rows = eventFiles.flatMap(parseJsonl).map((entry) => normalizedEntry(entry, knownEvidenceRefs));
+const uniqueRows = [];
+const seen = new Set();
+const repeatableEvents = new Set([
+  "pressure_20_50_consecutive_asks_visible",
+]);
+for (const row of rows) {
+  const key = JSON.stringify(row);
+  if (repeatableEvents.has(row.event)) {
+    uniqueRows.push(row);
+    continue;
+  }
+  if (seen.has(key)) continue;
+  seen.add(key);
+  uniqueRows.push(row);
+}
+
+if (uniqueRows.length === 0 && blockers.length === 0) block("no_events_observed", "event inputs produced no rows");
+
+if (blockers.length === 0 && outPath) {
+  const out = abs(outPath);
+  mkdirSync(dirname(out), { recursive: true });
+  writeFileSync(out, `${uniqueRows.map((row) => JSON.stringify(row)).join("\n")}\n`);
+}
+
+const output = {
+  truth: "ui_device_events_merge_not_proof",
+  status: blockers.length === 0 ? "ready" : "blocked",
+  missionId: missionId || null,
+  inputs: eventFiles,
+  out: outPath ? abs(outPath) : null,
+  inputRows: rows.length,
+  outputRows: uniqueRows.length,
+  deduplicatedRows: Math.max(0, rows.length - uniqueRows.length),
+  knownEvidenceRefs: [...knownEvidenceRefs].sort(),
+  blockers,
+  caveat: "Merge only. Missing observations must still be captured from real same-run UI/device evidence before proof assembly.",
+};
+
+console.log(JSON.stringify(output, null, 2));
+process.exit(blockers.length === 0 || !requireReady ? 0 : 2);

--- a/test/unit/qa/friday-ui-device-capture-dir-cli.test.ts
+++ b/test/unit/qa/friday-ui-device-capture-dir-cli.test.ts
@@ -1,5 +1,5 @@
 import { execFileSync, spawnSync } from "node:child_process";
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
@@ -131,7 +131,7 @@ function writeManifest(path: string, evidenceDir: string) {
   writeFileSync(path, JSON.stringify(manifest, null, 2));
 }
 
-function writeEvents(path: string, refs: ReturnType<typeof writeEvidence>) {
+function completeEventRows(refs: ReturnType<typeof writeEvidence>) {
   const rows = [
     observation("mobile", "mission_intake_submitted", refs.mobile),
     observation("mobile", "mission_intake_ready", refs.mobile),
@@ -165,6 +165,11 @@ function writeEvents(path: string, refs: ReturnType<typeof writeEvidence>) {
   for (let index = 0; index < 20; index += 1) {
     rows.push(observation("desktop", "pressure_20_50_consecutive_asks_visible", refs.desktop));
   }
+  return rows;
+}
+
+function writeEvents(path: string, refs: ReturnType<typeof writeEvidence>) {
+  const rows = completeEventRows(refs);
   writeFileSync(path, `${rows.map((row) => JSON.stringify(row)).join("\n")}\n`);
 }
 
@@ -255,6 +260,61 @@ describe("friday-ui-device-capture-dir", () => {
       expect(result.preflight?.status).toBe(0);
       expect(result.observationsManifest).toBe(join(outDir, "observations-manifest.json"));
       expect(result.normalizedEvents).toBe(join(outDir, "same-run-events.normalized.jsonl"));
+
+      const manifest = JSON.parse(readFileSync(join(outDir, "observations-manifest.json"), "utf8")) as {
+        observations?: Array<{ evidence_ref?: string }>;
+      };
+      expect(manifest.observations?.some((row) => row.evidence_ref === captures.mobile)).toBe(false);
+      expect(manifest.observations?.some((row) => row.evidence_ref === join(outDir, "mobile.png"))).toBe(true);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("merges multiple same-run event inputs before deriving the manifest", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "friday-ui-capture-dir-multi-events-"));
+    try {
+      const captures = writeEvidence(tempDir);
+      const first = join(tempDir, "mobile-desktop-events.jsonl");
+      const eventsDir = join(tempDir, "more-events");
+      const second = join(eventsDir, "timeline-channel-events.jsonl");
+      const outDir = join(tempDir, "evidence");
+      mkdirSync(eventsDir);
+
+      const allRows = completeEventRows(captures);
+      writeFileSync(first, `${allRows.slice(0, 10).map((row) => JSON.stringify(row)).join("\n")}\n`);
+      writeFileSync(second, `${allRows.slice(10).map((row) => JSON.stringify(row)).join("\n")}\n`);
+
+      const stdout = execFileSync("node", [
+        "scripts/ops/friday-ui-device-capture-dir.mjs",
+        `--mission-id=${missionId}`,
+        `--out-dir=${outDir}`,
+        `--mobile=${captures.mobile}`,
+        `--desktop=${captures.desktop}`,
+        `--channel=${captures.channel}`,
+        `--timeline=${captures.timeline}`,
+        `--events=${first}`,
+        `--events-dir=${eventsDir}`,
+        "--require-ready",
+      ], { cwd: process.cwd(), encoding: "utf8" });
+
+      const result = JSON.parse(stdout) as {
+        status?: string;
+        mergedEvents?: string;
+        normalizedEvents?: string;
+        preflight?: { status?: number };
+      };
+      expect(result.status).toBe("ready");
+      expect(result.preflight?.status).toBe(0);
+      expect(result.mergedEvents).toBe(join(outDir, "same-run-events.merged-source.jsonl"));
+      expect(result.normalizedEvents).toBe(join(outDir, "same-run-events.normalized.jsonl"));
+
+      const mergedRows = readFileSync(join(outDir, "same-run-events.merged-source.jsonl"), "utf8")
+        .trim()
+        .split("\n")
+        .map((line) => JSON.parse(line));
+      expect(mergedRows).toContainEqual(observation("mobile", "mission_intake_submitted", captures.mobile));
+      expect(mergedRows).toContainEqual(observation("channel", "channel_replay_blocked_visible", captures.channel));
 
       const manifest = JSON.parse(readFileSync(join(outDir, "observations-manifest.json"), "utf8")) as {
         observations?: Array<{ evidence_ref?: string }>;

--- a/test/unit/qa/friday-ui-device-events-merge-cli.test.ts
+++ b/test/unit/qa/friday-ui-device-events-merge-cli.test.ts
@@ -1,0 +1,111 @@
+import { execFileSync, spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const missionId = "mission_cli_ui_device_events_merge";
+
+function writeEvidence(tempDir: string) {
+  const files = {
+    mobile: join(tempDir, "mobile.json"),
+    desktop: join(tempDir, "desktop.json"),
+    channel: join(tempDir, "channel.json"),
+    timeline: join(tempDir, "timeline.json"),
+  };
+  for (const [role, path] of Object.entries(files)) {
+    writeFileSync(path, JSON.stringify({ role, mission_id: missionId }));
+  }
+  return files;
+}
+
+function event(surface: string, name: string, evidenceRef: string, activeMissionId = missionId) {
+  return {
+    surface,
+    event: name,
+    mission_id: activeMissionId,
+    evidence_ref: evidenceRef,
+  };
+}
+
+describe("friday-ui-device-events-merge", () => {
+  it("merges repeated event inputs, validates evidence refs, and deduplicates exact rows", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "friday-ui-events-merge-"));
+    try {
+      const evidence = writeEvidence(tempDir);
+      const first = join(tempDir, "first.jsonl");
+      const eventsDir = join(tempDir, "events-dir");
+      const second = join(eventsDir, "second.jsonl");
+      const out = join(tempDir, "merged.jsonl");
+      mkdirSync(eventsDir);
+      writeFileSync(first, [
+        event("mobile", "mission_intake_submitted", evidence.mobile),
+        event("mobile", "mission_intake_submitted", evidence.mobile),
+      ].map((row) => JSON.stringify(row)).join("\n") + "\n");
+      writeFileSync(second, [
+        event("desktop", "mission_workbench_visible", evidence.desktop),
+        event("timeline", "bounded_page_1_visible", evidence.timeline),
+        event("desktop", "pressure_20_50_consecutive_asks_visible", evidence.desktop),
+        event("desktop", "pressure_20_50_consecutive_asks_visible", evidence.desktop),
+      ].map((row) => JSON.stringify(row)).join("\n") + "\n");
+
+      const stdout = execFileSync("node", [
+        "scripts/ops/friday-ui-device-events-merge.mjs",
+        `--mission-id=${missionId}`,
+        `--events=${first}`,
+        `--events-dir=${eventsDir}`,
+        `--mobile=${evidence.mobile}`,
+        `--desktop=${evidence.desktop}`,
+        `--channel=${evidence.channel}`,
+        `--timeline=${evidence.timeline}`,
+        `--out=${out}`,
+        "--require-ready",
+      ], { cwd: process.cwd(), encoding: "utf8" });
+      const result = JSON.parse(stdout) as {
+        truth?: string;
+        status?: string;
+        inputRows?: number;
+        outputRows?: number;
+        deduplicatedRows?: number;
+      };
+      const rows = readFileSync(out, "utf8").trim().split("\n").map((line) => JSON.parse(line));
+
+      expect(result.truth).toBe("ui_device_events_merge_not_proof");
+      expect(result.status).toBe("ready");
+      expect(result.inputRows).toBe(6);
+      expect(result.outputRows).toBe(5);
+      expect(result.deduplicatedRows).toBe(1);
+      expect(rows).toContainEqual(event("desktop", "mission_workbench_visible", evidence.desktop));
+      expect(rows.filter((row) => row.event === "pressure_20_50_consecutive_asks_visible")).toHaveLength(2);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("fails closed on mission mismatch and does not write merged output", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "friday-ui-events-merge-blocked-"));
+    try {
+      const evidence = writeEvidence(tempDir);
+      const input = join(tempDir, "events.jsonl");
+      const out = join(tempDir, "merged.jsonl");
+      writeFileSync(input, `${JSON.stringify(event("mobile", "mission_intake_submitted", evidence.mobile, "mission_other"))}\n`);
+
+      const result = spawnSync("node", [
+        "scripts/ops/friday-ui-device-events-merge.mjs",
+        `--mission-id=${missionId}`,
+        `--events=${input}`,
+        `--mobile=${evidence.mobile}`,
+        `--out=${out}`,
+        "--require-ready",
+      ], { cwd: process.cwd(), encoding: "utf8" });
+
+      expect(result.status).toBe(2);
+      const output = JSON.parse(result.stdout) as { status?: string; blockers?: Array<{ code?: string }> };
+      expect(output.status).toBe("blocked");
+      expect(output.blockers?.map((blocker) => blocker.code)).toContain("event_mission_mismatch");
+      expect(() => readFileSync(out, "utf8")).toThrow();
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add a same-run UI/device event merge CLI with mission/evidence validation
- preserve repeatable pressure stress rows while deduplicating ordinary duplicate rows
- let capture-dir accept multiple --events and --events-dir inputs before deriving the observations manifest

## Truth boundary
- merge/index only; this does not invent observations and does not count as UI/device proof by itself

## Verification
- npx vitest run test/unit/qa/friday-ui-device-events-merge-cli.test.ts test/unit/qa/friday-ui-device-capture-dir-cli.test.ts test/unit/qa/friday-ui-device-observations-manifest-cli.test.ts
- npm run check:client-ship-gate
- git diff --check