### PR TITLE
fix(storage): chain mission lifecycle transitions into the audit ledger [M2]

### DIFF
--- a/rust-core/crates/friday-hub/src/mission_preflight.rs
+++ b/rust-core/crates/friday-hub/src/mission_preflight.rs
@@ -2218,8 +2218,8 @@ mod tests {
         assert_eq!(lifecycle_audit_rows(&db), 5);
         assert_eq!(
             verify_audit_chain(db.conn()).unwrap(),
-            5,
-            "the WI-1 lifecycle rows are the only audit rows and the chain must verify"
+            6,
+            "5 WorkItem lifecycle rows + 1 mission auto-close row (M2: the active->done auto-close now also chains its own receipt); the whole chain verifies"
         );
         // The MissionLink still binds the run (unchanged from the inline path).
         let links = db.list_mission_links("mission-wi1-on").unwrap();

--- a/rust-core/crates/friday-hub/src/mission_runtime.rs
+++ b/rust-core/crates/friday-hub/src/mission_runtime.rs
@@ -1825,8 +1825,8 @@ mod tests {
         assert_eq!(lifecycle_audit_rows(&db), 5);
         assert_eq!(
             verify_audit_chain(db.conn()).unwrap(),
-            5,
-            "the WI-1 lifecycle rows are the only audit rows and the chain must verify"
+            6,
+            "5 WorkItem lifecycle rows + 1 mission auto-close row (M2: the active->done auto-close now also chains its own receipt); the whole chain verifies"
         );
     }
 

--- a/rust-core/crates/friday-storage/src/mission.rs
+++ b/rust-core/crates/friday-storage/src/mission.rs
@@ -16,7 +16,7 @@ use friday_core::{
     RouteDecisionProjection, SurfaceEvent, SurfaceEventKind, SurfaceKind, SurfaceThread,
     TruthStatus, VisibilityPolicy, WorkItem, WorkItemStatus, WorkLane,
 };
-use rusqlite::{params, Connection, OptionalExtension};
+use rusqlite::{params, Connection, OptionalExtension, Transaction};
 use sha2::{Digest, Sha256};
 
 fn unsupported(message: impl Into<String>) -> StorageError {
@@ -879,6 +879,29 @@ pub fn transition_mission_status(
         }
         mission.decision_path_summary =
             append_lifecycle_summary(&mission.decision_path_summary, &lifecycle_entry);
+
+        // M2 (audit-coverage hardening): record the Mission status hop in the hash-chained audit
+        // ledger inside the SAME txn as the state write — the WorkItem sibling
+        // (`transition_work_item_status_inner`, audit row at the `work_item.lifecycle:` action)
+        // already chains its hop, but a Mission's transition was recorded ONLY in the mutable,
+        // free-text `decision_path_summary` (above), which is not tamper-evident. The summary entry
+        // is preserved (no-degrade); this ADDS the append-only, verifiable receipt so a mission
+        // lifecycle transition can never be silently rewritten. The audit read+insert and the
+        // upserts share this one txn, so a `with_busy_retry` re-run rolls back ALL of it first and
+        // re-appends from the live prev-hash — never a double-append or a forked chain.
+        crate::audit::append_audit(
+            &tx,
+            &format!("mission_lifecycle:{}:{now_ms}", mission.mission_id),
+            actor_ref,
+            &format!(
+                "mission.lifecycle:{}->{}:{}",
+                previous_status.as_str(),
+                mission.status.as_str(),
+                reason
+            ),
+            Some(mission.mission_id.as_str()),
+            now_ms,
+        )?;
         upsert_mission(&tx, &mission)?;
 
         let mut conversation = get_conversation(&tx, friday_conversation_id)?.ok_or_else(|| {
@@ -1148,7 +1171,7 @@ fn transition_work_item_status_inner(
 }
 
 fn maybe_close_mission_after_work_item_completion(
-    conn: &Connection,
+    tx: &Transaction<'_>,
     item: &WorkItem,
     previous_status: WorkItemStatus,
     work_item_audit_id: &str,
@@ -1162,14 +1185,14 @@ fn maybe_close_mission_after_work_item_completion(
         return Ok(());
     }
 
-    let Some(mut mission) = get_mission(conn, &item.mission_id)? else {
+    let Some(mut mission) = get_mission(tx, &item.mission_id)? else {
         return Ok(());
     };
     if !mission.status.can_transition_to(MissionStatus::Done) {
         return Ok(());
     }
 
-    let work_items = list_work_items_for_mission(conn, &item.mission_id)?;
+    let work_items = list_work_items_for_mission(tx, &item.mission_id)?;
     if work_items.is_empty()
         || !work_items
             .iter()
@@ -1177,11 +1200,12 @@ fn maybe_close_mission_after_work_item_completion(
     {
         return Ok(());
     }
-    if has_unmaterialized_deferred_follow_up(conn, &item.mission_id, &work_items)? {
+    if has_unmaterialized_deferred_follow_up(tx, &item.mission_id, &work_items)? {
         return Ok(());
     }
 
     let proof_ref = format!("audit://{work_item_audit_id}");
+    let previous_mission_status = mission.status;
     mission.status = mission
         .status
         .try_transition(MissionStatus::Done)
@@ -1196,10 +1220,31 @@ fn maybe_close_mission_after_work_item_completion(
     );
     mission.decision_path_summary =
         append_lifecycle_summary(&mission.decision_path_summary, &lifecycle_entry);
-    upsert_mission(conn, &mission)?;
+
+    // M2 (audit-coverage hardening): the auto-close is a Mission status hop (active->Done) exactly
+    // like an explicit `transition_mission_status`, so it gets the SAME hash-chained receipt — the
+    // caller (`transition_work_item_status_inner`) passes its OPEN `tx`, so this audit row + the
+    // mission/conversation upserts below land atomically with the triggering WorkItem completion.
+    // A distinct `mission_autoclose:` audit_id prefix guarantees no collision with an explicit
+    // `mission_lifecycle:` row at the same `now_ms`. `decision_path_summary` is preserved
+    // (no-degrade); this ADDS the tamper-evident record the close previously lacked.
+    crate::audit::append_audit(
+        tx,
+        &format!("mission_autoclose:{}:{now_ms}", mission.mission_id),
+        actor_ref,
+        &format!(
+            "mission.lifecycle:{}->{}:auto_close_after_work_item:{}",
+            previous_mission_status.as_str(),
+            mission.status.as_str(),
+            item.work_item_id
+        ),
+        Some(mission.mission_id.as_str()),
+        now_ms,
+    )?;
+    upsert_mission(tx, &mission)?;
 
     let mut conversation =
-        get_conversation(conn, &mission.friday_conversation_id)?.ok_or_else(|| {
+        get_conversation(tx, &mission.friday_conversation_id)?.ok_or_else(|| {
             unsupported(format!(
                 "mission_auto_close conversation '{}' not found",
                 mission.friday_conversation_id
@@ -1209,7 +1254,7 @@ fn maybe_close_mission_after_work_item_completion(
         .active_mission_ids
         .retain(|id| id != &mission.mission_id);
     conversation.updated_at_ms = now_ms;
-    upsert_conversation(conn, &conversation)?;
+    upsert_conversation(tx, &conversation)?;
 
     Ok(())
 }

--- a/rust-core/crates/friday-storage/tests/mission_spine.rs
+++ b/rust-core/crates/friday-storage/tests/mission_spine.rs
@@ -342,6 +342,81 @@ fn mission_lifecycle_transition_updates_status_and_active_mission_list() {
 }
 
 #[test]
+fn mission_lifecycle_transition_is_recorded_in_hash_chained_audit() {
+    // M2 (audit-coverage hardening): a Mission status hop must leave a tamper-evident,
+    // hash-chained audit receipt — the WorkItem sibling already does, but a Mission transition
+    // used to live ONLY in the mutable free-text decision_path_summary. Assert the chained row is
+    // appended per transition AND the chain still verifies, WITHOUT losing the summary (no-degrade).
+    let db = Db::open_hub(&temp_db_path("mission-spine-lifecycle-audit")).unwrap();
+    db.upsert_friday_conversation(&conversation()).unwrap();
+    db.upsert_mission(&mission(
+        "mission-spine",
+        MissionStatus::Active,
+        "mission-spine-audit",
+    ))
+    .unwrap();
+
+    db.transition_mission_status(
+        "fconv_20260604_global",
+        "mission-spine",
+        MissionStatus::Paused,
+        "operator:jarvis",
+        "pause for review",
+        Some("audit://mission-lifecycle/pause"),
+        None,
+        40,
+    )
+    .unwrap();
+    db.transition_mission_status(
+        "fconv_20260604_global",
+        "mission-spine",
+        MissionStatus::Active,
+        "operator:jarvis",
+        "resume",
+        None,
+        None,
+        50,
+    )
+    .unwrap();
+
+    // One chained row per transition, carrying the from->to:reason action.
+    let rows: i64 = db
+        .conn()
+        .query_row(
+            "SELECT COUNT(*) FROM audit_ledger WHERE audit_id LIKE 'mission_lifecycle:mission-spine:%'",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(
+        rows, 2,
+        "each mission transition appends exactly one chained audit row"
+    );
+
+    let paused_action: String = db
+        .conn()
+        .query_row(
+            "SELECT action FROM audit_ledger WHERE audit_id = 'mission_lifecycle:mission-spine:40'",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(
+        paused_action,
+        "mission.lifecycle:active->paused:pause for review"
+    );
+
+    // The new rows participate in the hash chain — it verifies end-to-end.
+    assert!(friday_storage::audit::verify_audit_chain(db.conn()).is_ok());
+
+    // No-degrade: the free-text decision_path_summary entry is still written alongside the chain.
+    let stored = db.get_mission("mission-spine").unwrap().unwrap();
+    assert!(stored
+        .decision_path_summary
+        .contains("lifecycle:mission-spine:active->paused"));
+}
+
+#[test]
 fn mission_lifecycle_blocks_fake_done_and_bad_merge_targets() {
     let db = Db::open_hub(&temp_db_path("mission-spine-lifecycle-blocks")).unwrap();
     let mut convo = conversation();

--- a/rust-core/crates/friday-storage/tests/work_item_lifecycle.rs
+++ b/rust-core/crates/friday-storage/tests/work_item_lifecycle.rs
@@ -309,6 +309,26 @@ fn final_completed_work_item_closes_active_mission_with_audit_proof() {
         .decision_path_summary
         .contains("auto-close after WorkItem 'work-wi' completed_with_proof"));
 
+    // M2 (audit-coverage hardening): the auto-close is itself a Mission status hop (active->done),
+    // so it leaves its OWN hash-chained receipt (distinct `mission_autoclose:` id) inside the SAME
+    // txn as the triggering WorkItem completion — not only the WorkItem's `workitem_lifecycle:` row.
+    let autoclose_action: String = db
+        .conn()
+        .query_row(
+            "SELECT action FROM audit_ledger WHERE audit_id = 'mission_autoclose:mission-wi:10'",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(
+        autoclose_action,
+        "mission.lifecycle:active->done:auto_close_after_work_item:work-wi"
+    );
+    assert!(
+        friday_storage::audit::verify_audit_chain(db.conn()).is_ok(),
+        "WorkItem lifecycle row + auto-close mission row both verify in the chain"
+    );
+
     let conversation = db
         .get_friday_conversation("fconv_wi_lifecycle")
         .unwrap()


### PR DESCRIPTION
## What
Audit-coverage hardening **M2**: chain Mission lifecycle status transitions into the hash-chained \`audit_ledger\`, inside the same transaction as the state write — mirroring the WorkItem sibling that already does this. Closes the gap where a mission status change left only a mutable free-text \`decision_path_summary\` entry (not tamper-evident).

## How
- \`friday-storage/src/mission.rs\`: add \`append_audit\` inside the existing \`with_busy_retry\`/\`unchecked_transaction\` for BOTH mission status-transition paths:
  - explicit \`transition_mission_status\` (id \`mission_lifecycle:{id}:{now_ms}\`)
  - auto-close \`maybe_close_mission_after_work_item_completion\` — threaded the caller's open \`&Transaction\` through (\`&Connection\`→\`&Transaction<'_>\`) so the mission receipt is atomic with the triggering WorkItem completion (id \`mission_autoclose:{id}:{now_ms}\`, distinct prefix → no same-\`now_ms\` collision).
- \`decision_path_summary\` preserved in both paths (no-degrade).

## Tests / verification
- New \`mission_spine\` audit-chain test (explicit path) + extended \`work_item_lifecycle\` auto-close assertion.
- Corrected two stale hub count assertions (\`mission_preflight.rs\`, \`mission_runtime.rs\`) 5→6 for the added auto-close receipt.
- \`cargo test -p friday-storage\` 21/21; \`-p friday-hub\` all green; \`cargo fmt --check\` + \`cargo clippy -D warnings\` clean.

## Review
Two isolated read-only reviewers (correctness + regression) + a re-confirm pass; Reviewer B caught the two stale counts (fixed). Final state PASS on all three.

Closes: FINDING-M2 (read-only adversarial audit 2026-06-24).

🤖 Generated with [Claude Code](https://claude.com/claude-code)