### PR TITLE
Surface full mobile session control truth

### DIFF
--- a/apps/friday-ios/Sources/FridayMobileShell/FridaySessionDetailScreen.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridaySessionDetailScreen.swift
@@ -220,7 +220,7 @@ struct FridaySessionDetailScreen: View {
                   Text(control.title)
                     .font(.system(size: 13, weight: .semibold))
                   Spacer()
-                  StatusChip(text: control.truthLabel, bg: MobileTheme.chipWarnBG, fg: MobileTheme.chipWarnFG)
+                  controlTruthChip(control)
                 }
                 Text(control.reason)
                   .font(.caption2)
@@ -485,6 +485,16 @@ struct FridaySessionDetailScreen: View {
 
   private func statusChip(_ text: String) -> some View {
     StatusChip(text: text, bg: MobileTheme.chipNeutralBG, fg: MobileTheme.chipNeutralFG)
+  }
+
+  private func controlTruthChip(_ control: SessionContinuationControl) -> some View {
+    if control.isEnabled {
+      return StatusChip(text: control.truthLabel, bg: MobileTheme.chipPendingBG, fg: MobileTheme.chipPendingFG)
+    }
+    if control.truthLabel == "read arm" {
+      return StatusChip(text: control.truthLabel, bg: MobileTheme.chipNeutralBG, fg: MobileTheme.chipNeutralFG)
+    }
+    return StatusChip(text: control.truthLabel, bg: MobileTheme.chipWarnBG, fg: MobileTheme.chipWarnFG)
   }
 
   private func short(_ s: String) -> String {

--- a/apps/friday-ios/Sources/FridayMobileShellCore/SessionContinuationViewModel.swift
+++ b/apps/friday-ios/Sources/FridayMobileShellCore/SessionContinuationViewModel.swift
@@ -513,6 +513,62 @@ public final class SessionContinuationViewModel: ObservableObject {
         truthLabel: "NO-GO",
         reason: "Fork is not a built mobile mutation.",
         isEnabled: false),
+      SessionContinuationControl(
+        id: "steer",
+        title: "Steer",
+        systemImage: "slider.horizontal.3",
+        truthLabel: "NO-GO",
+        reason: "Steering controls are visible for the selected design, but no governed mobile steer mutation is built.",
+        isEnabled: false),
+      SessionContinuationControl(
+        id: "archive",
+        title: "Archive",
+        systemImage: "archivebox",
+        truthLabel: "NO-GO",
+        reason: "Archive is not a built mobile mutation.",
+        isEnabled: false),
+      SessionContinuationControl(
+        id: "slash-actions",
+        title: "Slash / Actions",
+        systemImage: "command",
+        truthLabel: "NO-GO",
+        reason: "Slash/action palette is not a built mobile mutation surface.",
+        isEnabled: false),
+      SessionContinuationControl(
+        id: "tools",
+        title: "Tools",
+        systemImage: "wrench.and.screwdriver",
+        truthLabel: "NO-GO",
+        reason: "Tool execution is not exposed from mobile session controls.",
+        isEnabled: false),
+      SessionContinuationControl(
+        id: "files",
+        title: "Files",
+        systemImage: "folder",
+        truthLabel: "read arm",
+        reason: "Run files are shown through the read-only Run Files section when a run ref exists.",
+        isEnabled: false),
+      SessionContinuationControl(
+        id: "diffs",
+        title: "Diffs",
+        systemImage: "doc.text.magnifyingglass",
+        truthLabel: "NO-GO",
+        reason: "Diff rendering is not a built mobile session surface.",
+        isEnabled: false),
+      SessionContinuationControl(
+        id: "attachments",
+        title: "Attachments",
+        systemImage: "paperclip",
+        truthLabel: "NO-GO",
+        reason: "Attachments are not a built mobile session mutation surface.",
+        isEnabled: false),
+      SessionContinuationControl(
+        id: "history",
+        title: "History",
+        systemImage: "clock.arrow.circlepath",
+        truthLabel: "read arm",
+        reason: "Session history is represented by read-only session sections and local chat history, not a separate native history mutation.",
+        isEnabled: false),
     ]
   }
 

--- a/apps/friday-ios/Tests/FridayMobileShellCoreTests/SessionContinuationViewModelTests.swift
+++ b/apps/friday-ios/Tests/FridayMobileShellCoreTests/SessionContinuationViewModelTests.swift
@@ -269,8 +269,25 @@ final class SessionContinuationViewModelTests: XCTestCase {
       SessionContinuationFact(id: "audit", label: "audit", value: "verified"),
     ])
     XCTAssertEqual(snapshot.sections.first?.generatedAtMs, 1_780_640_000_123)
-    XCTAssertEqual(snapshot.controls.map(\.title), ["Send", "Stop", "Resume", "Reject", "Fork"])
-    XCTAssertTrue(snapshot.controls.allSatisfy { !$0.isEnabled && $0.truthLabel == "NO-GO" })
+    XCTAssertEqual(snapshot.controls.map(\.title), [
+      "Send",
+      "Stop",
+      "Resume",
+      "Reject",
+      "Fork",
+      "Steer",
+      "Archive",
+      "Slash / Actions",
+      "Tools",
+      "Files",
+      "Diffs",
+      "Attachments",
+      "History",
+    ])
+    XCTAssertTrue(snapshot.controls.allSatisfy { !$0.isEnabled })
+    XCTAssertEqual(snapshot.controls.first { $0.id == "files" }?.truthLabel, "read arm")
+    XCTAssertEqual(snapshot.controls.first { $0.id == "history" }?.truthLabel, "read arm")
+    XCTAssertEqual(snapshot.controls.first { $0.id == "steer" }?.truthLabel, "NO-GO")
     XCTAssertNil(snapshot.pendingApproval)
   }
 
@@ -768,6 +785,9 @@ final class SessionContinuationViewModelTests: XCTestCase {
       }
       return false
     })
-    XCTAssertTrue(snapshot.controls.allSatisfy { !$0.isEnabled && $0.truthLabel == "NO-GO" })
+    XCTAssertTrue(snapshot.controls.allSatisfy { !$0.isEnabled })
+    XCTAssertEqual(snapshot.controls.first { $0.id == "files" }?.truthLabel, "read arm")
+    XCTAssertEqual(snapshot.controls.first { $0.id == "history" }?.truthLabel, "read arm")
+    XCTAssertEqual(snapshot.controls.first { $0.id == "attachments" }?.truthLabel, "NO-GO")
   }
 }


### PR DESCRIPTION
## Summary
- surface the selected-design session control set in mobile Session Detail instead of hiding unbuilt controls
- distinguish read-arm controls from mutation NO-GO controls, while keeping all unbuilt actions disabled
- improve control truth chips so guarded/read-arm/NO-GO states do not collapse into one warning style

## Verification
- swift test --filter SessionContinuationViewModelTests in apps/friday-ios
- apps/friday-ios/build-sim.sh --mode offline-truth

Truth: this increases mobile session-control truth coverage. It does not claim steer/archive/tools/diffs/attachments are executable, GO-LIVE, adoption, or END-BAR.