### PR TITLE
Cover desktop pairing in render proofs

### DIFF
--- a/apps/macos/FridayHubConsole/Sources/FridayHubConsole/PairingProvisioningScreen.swift
+++ b/apps/macos/FridayHubConsole/Sources/FridayHubConsole/PairingProvisioningScreen.swift
@@ -12,12 +12,7 @@ struct PairingProvisioningScreen: View {
 
   var body: some View {
     ScrollView {
-      VStack(alignment: .leading, spacing: 16) {
-        header
-        inputPanel
-        qrPanel
-        operatorPanel
-      }
+      renderProofContent
       .padding(20)
       .frame(maxWidth: .infinity, alignment: .topLeading)
     }
@@ -27,6 +22,15 @@ struct PairingProvisioningScreen: View {
       allowedContentTypes: [.json, .plainText],
       allowsMultipleSelection: false,
       onCompletion: importManifest)
+  }
+
+  var renderProofContent: some View {
+    VStack(alignment: .leading, spacing: 16) {
+      header
+      inputPanel
+      qrPanel
+      operatorPanel
+    }
   }
 
   private var header: some View {

--- a/apps/macos/FridayHubConsole/Sources/FridayHubConsole/StateRenderProof.swift
+++ b/apps/macos/FridayHubConsole/Sources/FridayHubConsole/StateRenderProof.swift
@@ -39,6 +39,7 @@ enum StateRenderProof {
       ("chat-loaded-mock", .chat, .loaded),
       ("provider-admin-loaded-mock", .providerAdmin, .loaded),
       ("provider-parity-loaded-mock", .parity, .loaded),
+      ("pairing-provisioning-honest-empty", .pairingProvisioning, .loaded),
       ("workflow-loaded-mock", .workflow, .loaded),
       ("channels-loaded-mock", .channels, .loaded),
       ("diagnostics-loaded-mock", .diagnostics, .loaded),
@@ -66,6 +67,20 @@ enum StateRenderProof {
         let vm = OperationsOverviewViewModel(client: MockReadClient(behavior: behavior))
         await vm.refresh()  // mock is instant → materialize the target state.
         let outPath = "\(outputDir)/\(name).png"
+        if destination == .pairingProvisioning {
+          let content = AnyView(
+            PairingProvisioningScreen()
+              .frame(width: 760, height: 720, alignment: .topLeading)
+              .background(HubTheme.backgroundWarmOffWhite))
+          if writeHostedPNG(content, width: 760, height: 720, to: outPath) {
+            FileHandle.standardOutput.write(Data("[state-proof] OK — \(outPath)\n".utf8))
+          } else {
+            FileHandle.standardError.write(
+              Data("[state-proof] FAILED — could not render \(name)\n".utf8))
+            failures += 1
+          }
+          continue
+        }
         // For the LOADED state, rasterize the card stack directly (not inside the screen's
         // `ScrollView`, which `ImageRenderer` leaves blank). The unavailable states have no
         // scroll content, so the whole screen rasterizes faithfully.
@@ -114,6 +129,17 @@ enum StateRenderProof {
       let png = rep.representation(using: .png, properties: [:])
     else { return false }
     return (try? png.write(to: URL(fileURLWithPath: path))) != nil
+  }
+
+  private static func writeHostedPNG(_ content: AnyView, width: CGFloat, height: CGFloat, to path: String) -> Bool {
+    let view = NSHostingView(rootView: content)
+    view.frame = CGRect(x: 0, y: 0, width: width, height: height)
+    view.layoutSubtreeIfNeeded()
+    guard let rep = view.bitmapImageRepForCachingDisplay(in: view.bounds) else { return false }
+    view.cacheDisplay(in: view.bounds, to: rep)
+    let image = NSImage(size: view.bounds.size)
+    image.addRepresentation(rep)
+    return writePNG(image, to: path)
   }
 }
 #endif

--- a/scripts/ops/check-friday-client-design-contract.mjs
+++ b/scripts/ops/check-friday-client-design-contract.mjs
@@ -138,6 +138,7 @@ const checks = checkSourceSet(repoRoot, [
       "recovery-loaded-mock",
       "memory-loaded-mock",
       "token-ledger-loaded-mock",
+      "pairing-provisioning-honest-empty",
       "skills-loaded-mock",
       "media-loaded-mock",
       "settings-loaded-mock",


### PR DESCRIPTION
## Summary\n- include the desktop Pairing Provisioning surface in the Hub Console state render proof matrix\n- reuse the Pairing screen content for render-proof capture while keeping normal app rendering unchanged\n- pin the selected-design static gate so Pairing proof coverage cannot silently drop\n\n## Verification\n- npm run check:client-design-contract\n- git diff --check\n- swift test --package-path apps/macos/FridayHubConsole --filter PairingProvisioningViewModelTests\n- swift run --package-path apps/macos/FridayHubConsole FridayHubConsole --state-render-proof /tmp/friday-desktop-state-proof-20260624-rebase\n\nTruth: render proof coverage only; not END-BAR, adoption, GO-LIVE, or real user device closure.