### PR TITLE
Preserve UI device event provenance

### DIFF
--- a/scripts/ops/friday-ui-device-events-merge.mjs
+++ b/scripts/ops/friday-ui-device-events-merge.mjs
@@ -128,6 +128,9 @@ function normalizedEntry(entry, knownEvidenceRefs) {
   const event = typeof raw.event === "string" ? raw.event.trim() : "";
   const eventMissionId = typeof raw.mission_id === "string" ? raw.mission_id.trim() : "";
   const evidenceRef = typeof raw.evidence_ref === "string" ? raw.evidence_ref.trim() : "";
+  const truthLabel = typeof raw.truth_label === "string" ? raw.truth_label.trim() : "";
+  const source = typeof raw.source === "string" ? raw.source.trim() : "";
+  const capturedAt = typeof raw.captured_at === "string" ? raw.captured_at.trim() : "";
   if (!surface) block("event_missing_surface", label);
   if (!event) block("event_missing_event", label);
   if (!eventMissionId) block("event_missing_mission_id", label);
@@ -136,12 +139,16 @@ function normalizedEntry(entry, knownEvidenceRefs) {
   if (knownEvidenceRefs.size > 0 && evidenceRef && !knownEvidenceRefs.has(evidenceRef)) {
     block("event_evidence_ref_unknown", `${label}:${evidenceRef}`);
   }
-  return {
+  const normalized = {
     surface,
     event,
     mission_id: eventMissionId,
     evidence_ref: evidenceRef,
   };
+  if (truthLabel) normalized.truth_label = truthLabel;
+  if (source) normalized.source = source;
+  if (capturedAt) normalized.captured_at = capturedAt;
+  return normalized;
 }
 
 if (!missionId || !/^[A-Za-z0-9][A-Za-z0-9._:-]*$/.test(missionId) || !missionId.toLowerCase().includes("mission")) {

--- a/test/unit/qa/friday-ui-device-events-merge-cli.test.ts
+++ b/test/unit/qa/friday-ui-device-events-merge-cli.test.ts
@@ -28,6 +28,15 @@ function event(surface: string, name: string, evidenceRef: string, activeMission
   };
 }
 
+function diagnosticEvent(surface: string, name: string, evidenceRef: string) {
+  return {
+    ...event(surface, name, evidenceRef),
+    truth_label: "derived_from_preflighted_workbench_snapshot_not_final_proof",
+    source: "transcript_surface:desktop",
+    captured_at: "2026-06-24T20:10:00Z",
+  };
+}
+
 describe("friday-ui-device-events-merge", () => {
   it("merges repeated event inputs, validates evidence refs, and deduplicates exact rows", () => {
     const tempDir = mkdtempSync(join(tmpdir(), "friday-ui-events-merge-"));
@@ -104,6 +113,42 @@ describe("friday-ui-device-events-merge", () => {
       expect(output.status).toBe("blocked");
       expect(output.blockers?.map((blocker) => blocker.code)).toContain("event_mission_mismatch");
       expect(() => readFileSync(out, "utf8")).toThrow();
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("preserves diagnostic provenance fields from derived workbench rows", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "friday-ui-events-merge-provenance-"));
+    try {
+      const evidence = writeEvidence(tempDir);
+      const input = join(tempDir, "events.jsonl");
+      const out = join(tempDir, "merged.jsonl");
+      writeFileSync(input, `${JSON.stringify(diagnosticEvent(
+        "desktop",
+        "transcript_browser_visible",
+        evidence.desktop,
+      ))}\n`);
+
+      const stdout = execFileSync("node", [
+        "scripts/ops/friday-ui-device-events-merge.mjs",
+        `--mission-id=${missionId}`,
+        `--events=${input}`,
+        `--desktop=${evidence.desktop}`,
+        `--out=${out}`,
+        "--require-ready",
+      ], { cwd: process.cwd(), encoding: "utf8" });
+      const result = JSON.parse(stdout) as {
+        status?: string;
+        caveat?: string;
+      };
+      const rows = readFileSync(out, "utf8").trim().split("\n").map((line) => JSON.parse(line));
+
+      expect(result.status).toBe("ready");
+      expect(result.caveat).toContain("Missing observations must still be captured");
+      expect(rows).toEqual([
+        diagnosticEvent("desktop", "transcript_browser_visible", evidence.desktop),
+      ]);
     } finally {
       rmSync(tempDir, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary
- preserve optional truth_label/source/captured_at fields when merging UI/device event rows
- keep mission and evidence_ref fail-closed validation unchanged
- add CLI coverage proving diagnostic provenance survives merge without counting as proof

## Verification
- npx vitest run test/unit/qa/friday-ui-device-events-merge-cli.test.ts
- git diff --check

Truth: this strengthens evidence auditability only. It does not synthesize observations, relax UI/device proof gates, claim END-BAR, or claim runtime adoption.