### PR TITLE
fix(storage): pair memory-extraction billing with an audit_ledger row [refs: M1]

### DIFF
--- a/rust-core/crates/friday-hub/src/memory_extraction.rs
+++ b/rust-core/crates/friday-hub/src/memory_extraction.rs
@@ -8,7 +8,8 @@
 //!   2. builds the EXTRACT prompt ported faithfully from the TS oracle
 //!      (`friday-session-memory-extraction-llm-client.ts`),
 //!   3. calls the provider (one structured-inference [`DeepSeekClient`] call) and
-//!      ledgers the token usage ([`friday_storage::Db::insert_token_ledger`]),
+//!      ledgers the token usage + its audit event in one transaction
+//!      ([`friday_storage::Db::record_extraction_model_call`], the M1 billing-audit pair),
 //!   4. parses the candidate items (the same JSON shape + validation as the TS
 //!      `validateLlmResponse`),
 //!   5. runs the SENSITIVITY filter ported from `friday-sensitive-learning-guard.ts`
@@ -476,8 +477,8 @@ pub(crate) fn memory_review_activity_row(
 /// ## `db: &Db` (NS8-WIRE-1 — relaxed from `&mut Db`, behavior unchanged)
 /// The `db` handle is a SHARED `&Db`. This entire extraction path uses ONLY `&self` storage
 /// operations — `db.conn()` (a `&Connection`), the `&Connection`-based
-/// `unchecked_transaction`, and `db.insert_token_ledger` / `db.insert_activity` (both `&self`)
-/// — so the previous `&mut Db` receiver was gratuitous. It is relaxed to `&Db` so the live
+/// `unchecked_transaction`, and `db.record_extraction_model_call` / `db.insert_activity` (both
+/// `&self`) — so the previous `&mut Db` receiver was gratuitous. It is relaxed to `&Db` so the live
 /// sessioned run loop's `&self` runtime caller can fire this post-run (NS8-WIRE-1) WITHOUT a
 /// `&mut self` rewrite. Pre-existing `&mut db` call sites (the `hub_extract_memory` bin + the
 /// in-crate tests) reborrow `&mut Db → &Db` at the call automatically, so they are untouched
@@ -508,14 +509,15 @@ pub fn extract_inline<T: Transport>(
 }
 
 /// The flag-parameterized extraction body: derive namespace → read messages → prompt →
-/// provider call (ledgered) → parse → sensitivity-filter → persist candidates → (NS-8,
+/// provider call (ledgered + audited) → parse → sensitivity-filter → persist candidates → (NS-8,
 /// flag-gated) surface each freshly-recorded candidate on the Needs-Me surface.
 ///
 /// `client` is generic over [`Transport`] so tests inject a mock provider and the
 /// bin passes a live `DeepSeekClient::from_env()`. The call+ledger reuses
 /// [`DeepSeekClient::run_friday_ask`]; the resulting [`friday_core::LedgerEntry`]
-/// is persisted via [`friday_storage::Db::insert_token_ledger`] — the same ledger
-/// the ask path writes (`fallback = false`).
+/// is persisted via [`friday_storage::Db::record_extraction_model_call`] — the same ledger
+/// the ask path writes (`fallback = false`), now PAIRED with a hash-chained `audit_ledger`
+/// event in one transaction (M1 audit-coverage fix), mirroring the agent-loop billing.
 ///
 /// `candidate_id_prefix` namespaces the minted `memory_id`s (e.g.
 /// `"<session>:extract:<now_ms>"`). Slice-2 makes re-runs IDEMPOTENT at the source:
@@ -631,8 +633,23 @@ pub fn extract_inline_flagged<T: Transport>(
         now_ms,
     )?;
 
-    // Ledger the token usage (reuse the existing single-row insert).
-    db.insert_token_ledger(&ledger_entry)?;
+    // Ledger the token usage AND its audit event in ONE transaction (M1 audit-coverage fix).
+    // The bare `insert_token_ledger` emitted NO audit row — unlike every other billable call
+    // (ask path / agent loop), which pairs the ledger write with a hash-chained `audit_ledger`
+    // event. `record_extraction_model_call` mirrors the agent-loop billing chokepoint (ledger +
+    // audit in one busy-retried tx) so an extraction can never leave a charge with no audit
+    // trail. actor "hub-agent" matches the agent-loop sibling (`agent_loop.model_call`); the
+    // audit_id mirrors the ask path (`{ledger_id}:modelcall`) for collision-safety; payload_ref
+    // is the ledger id, which encodes the originating run (`led:{run_id}:{now_ms}`) so the audit
+    // row is run-attributable WITHOUT changing the run-unattributed (run_id = NULL) ledger row.
+    let audit = friday_storage::AuditEvent {
+        audit_id: format!("{ledger_id}:modelcall"),
+        actor: "hub-agent".to_string(),
+        action: "memory.extract.model_call".to_string(),
+        payload_ref: Some(ledger_id.to_string()),
+        created_at: now_ms,
+    };
+    db.record_extraction_model_call(&ledger_entry, &audit)?;
 
     let valid_ids: HashSet<String> = messages.iter().map(|m| m.message_id.clone()).collect();
     let items = parse_items(&outcome.content, &valid_ids)?;
@@ -653,8 +670,9 @@ pub fn extract_inline_flagged<T: Transport>(
     // `record_candidate` is a single `INSERT` (no inner transaction), and
     // `mark_messages_extracted` is a single `UPDATE`, so both compose safely inside the
     // `unchecked_transaction` (the same mechanism `record_run_model_call` already uses).
-    // The token-ledger row was written ABOVE, outside this tx (the call's cost is real
-    // regardless of whether the persist commits).
+    // The token-ledger + audit rows were written ABOVE in their OWN transaction
+    // (`record_extraction_model_call`), outside this one — the call's cost (and its audit
+    // trail) is real regardless of whether the candidate persist below commits.
     let message_ids: Vec<String> = messages.iter().map(|m| m.message_id.clone()).collect();
     let tx = db
         .conn()
@@ -876,6 +894,23 @@ mod tests {
         // The token ledger row was written (the extraction call is ledgered).
         let ledger_rows = db.count("token_ledger").unwrap();
         assert_eq!(ledger_rows, 1);
+        // M1 audit-coverage: the ledgered extraction call now ALSO appends EXACTLY one
+        // hash-chained audit row (action "memory.extract.model_call"), and the chain stays
+        // valid — billing is no longer silent. (Pre-M1 this count was 0.)
+        assert_eq!(
+            db.count("audit_ledger").unwrap(),
+            1,
+            "extraction billing must append exactly one audit row"
+        );
+        let action: String = db
+            .conn()
+            .query_row("SELECT action FROM audit_ledger LIMIT 1", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(action, "memory.extract.model_call");
+        assert_eq!(
+            friday_storage::audit::verify_audit_chain(db.conn()).unwrap(),
+            1
+        );
 
         // Existing spine: the candidate shows up as pending_review (NOT durable yet), stored
         // under the DERIVED namespace as its `principal_id` (slice-3 ownership-binding).

--- a/rust-core/crates/friday-hub/src/runtime.rs
+++ b/rust-core/crates/friday-hub/src/runtime.rs
@@ -1822,8 +1822,9 @@ impl<T: Transport> HubRuntime<T> {
     /// - **Result DISCARDED via `let _`.** The [`crate::memory_extraction::ExtractionOutcome`] (and
     ///   any [`crate::memory_extraction::ExtractionError`]) is dropped. It is never inspected, never
     ///   propagated, and never folded into the answer — so it CANNOT flip Delivered→NoAnswer.
-    /// - **Failure-isolated.** Extraction writes ONLY `token_ledger` / `memory_item` (candidate) /
-    ///   (NS-8-flag-gated) `activity` rows — NEVER the `run_result` row the answer projection reads.
+    /// - **Failure-isolated.** Extraction writes ONLY `token_ledger` / `audit_ledger` (the M1
+    ///   billing-audit pair) / `memory_item` (candidate) / (NS-8-flag-gated) `activity` rows —
+    ///   NEVER the `run_result` row the answer projection reads.
     ///   An extraction ERROR (provider failure, unresolvable namespace, parse, storage) is swallowed
     ///   by the `let _`: the run already succeeded and stays `Finished`; the answer/status/ledger of
     ///   the RUN are unchanged. The candidates it records are NON-DURABLE `Candidate` rows, gated on

--- a/rust-core/crates/friday-storage/src/lib.rs
+++ b/rust-core/crates/friday-storage/src/lib.rs
@@ -1460,6 +1460,27 @@ impl Db {
         Ok(())
     }
 
+    /// Atomic billing write for ONE background memory-extraction model call: the extraction
+    /// `token_ledger` row + its `audit_ledger` event in one transaction (M1 audit-coverage
+    /// fix). `&self` (the whole extraction path holds a shared `&Db`, NS8-WIRE-1) — it
+    /// delegates to the free [`record_extraction_model_call`] on `self.conn()`, which opens an
+    /// `unchecked_transaction`. Hub-only: fails closed on a phone (the audit insert), which the
+    /// extraction path never hits (it runs only on a Hub DB). See the free fn for the full
+    /// rationale (ledger + audit only, run_id stays NULL, busy-retry, own-tx).
+    pub fn record_extraction_model_call(
+        &self,
+        entry: &LedgerEntry,
+        audit: &AuditEvent,
+    ) -> Result<()> {
+        if self.profile != Profile::Hub {
+            return Err(StorageError::Unsupported(
+                "record_extraction_model_call requires the Hub profile (audit_ledger is Hub-only)"
+                    .into(),
+            ));
+        }
+        record_extraction_model_call(&self.conn, entry, audit)
+    }
+
     pub fn insert_tool_usage(
         &self,
         usage: &ToolUsageMeasurement,
@@ -1672,6 +1693,62 @@ pub fn record_run_model_call_with_provider_session_mirror(
         )?;
         provider_session::upsert_link(&tx, link)?;
         provider_session::append_event(&tx, event)?;
+        tx.commit()?;
+        Ok(())
+    })
+}
+
+/// Atomic billing write for ONE background memory-EXTRACTION model call — the
+/// extraction-path sibling of [`record_run_model_call`] (M1 audit-coverage fix). Writes the
+/// extraction `token_ledger` row AND a hash-chained `audit_ledger` event in ONE transaction;
+/// if either insert fails, neither persists, so an extraction can never leave a ledgered
+/// charge with no matching audit row (the gap M1 found: the bare `db.insert_token_ledger`
+/// emitted NO audit event, unlike every other billable call).
+///
+/// ## Why ledger + audit, NOT the full 3-write of `record_run_model_call`
+/// The extraction billing path has only EVER written a token_ledger row at bill time — it does
+/// not mint an `AskReceipt` activity (its only activity rows are the separate, flag-gated NS-8
+/// Memory-Review surfacing rows written AFTER the candidate commit). So this mirrors
+/// `record_run_model_call`'s txn shape (`unchecked_transaction` → ledger insert → audit append
+/// → commit, all under [`with_busy_retry`]) MINUS the activity insert — adding ONLY the missing
+/// audit row, not new activity behavior.
+///
+/// ## `run_id` stays NULL on the ledger row (intentional, no re-attribution)
+/// Extraction billing is its OWN cost dimension: the post-run extraction's tokens are NOT the
+/// run's metered turns. The token_ledger row keeps `run_id = NULL` (identical to the
+/// `insert_token_ledger` it replaces), so this fix does NOT fold extraction cost into
+/// `run_token_totals`. Run linkage for the audit row is carried by `audit.payload_ref` (the
+/// caller sets it to the `led:{run_id}:{now_ms}` ledger id), so the run is attributable through
+/// the audit chain WITHOUT changing what the run's metered total reports.
+///
+/// ## Concurrency / no-degrade
+/// Same long-lived Hub connection + same `with_busy_retry` rationale as `record_run_model_call`:
+/// the retry re-runs the WHOLE body (`append_audit` reads the prev chain hash THEN inserts, so a
+/// re-run after a rolled-back BUSY re-reads the live prev-hash and re-appends cleanly). With no
+/// contention the closure runs exactly once. Hub-only: `audit_ledger` does not exist on a phone
+/// (the extraction path runs only on a Hub DB by construction).
+///
+/// This is its OWN transaction — separate from the candidate-persist tx in `extract_inline` — so
+/// "the call's cost is real even if the candidate persist rolls back" is preserved.
+pub fn record_extraction_model_call(
+    conn: &Connection,
+    entry: &LedgerEntry,
+    audit: &AuditEvent,
+) -> Result<()> {
+    with_busy_retry(|| {
+        let tx = conn.unchecked_transaction()?;
+        // Extraction billing keeps the ledger row run-unattributed (run_id = NULL), matching
+        // the `insert_token_ledger` it replaces: extraction cost is its own dimension, not a
+        // run-metered turn.
+        insert_token_ledger_conn(&tx, entry, None)?;
+        audit::append_audit(
+            &tx,
+            &audit.audit_id,
+            &audit.actor,
+            &audit.action,
+            audit.payload_ref.as_deref(),
+            audit.created_at,
+        )?;
         tx.commit()?;
         Ok(())
     })

--- a/rust-core/crates/friday-storage/tests/atomic.rs
+++ b/rust-core/crates/friday-storage/tests/atomic.rs
@@ -221,6 +221,107 @@ fn record_event_is_hub_only() {
     assert_eq!(db.count("activity_item").unwrap(), 0);
 }
 
+// The M1 audit event a background memory-extraction billing call appends: action
+// "memory.extract.model_call", payload_ref = the ledger id (carries run attribution).
+fn extraction_audit_event(id: &str) -> AuditEvent {
+    AuditEvent {
+        audit_id: id.into(),
+        actor: "hub-agent".into(),
+        action: "memory.extract.model_call".into(),
+        payload_ref: Some("led:run-1:100".into()),
+        created_at: 100,
+    }
+}
+
+#[test]
+fn record_extraction_model_call_writes_ledger_plus_exactly_one_audit_no_activity() {
+    // M1 audit-coverage fix: extraction billing now pairs the token_ledger row with EXACTLY
+    // one hash-chained audit_ledger row (action "memory.extract.model_call") in one tx — and
+    // does NOT mint an activity row (extraction never has). The audit chain stays valid.
+    let p = temp_db_path("extract-bill-ok");
+    let db = Db::open_hub(&p).unwrap();
+    db.record_extraction_model_call(&ledger("le1"), &extraction_audit_event("le1:modelcall"))
+        .unwrap();
+
+    assert_eq!(db.count("token_ledger").unwrap(), 1);
+    assert_eq!(
+        db.count("activity_item").unwrap(),
+        0,
+        "extraction billing writes NO activity row (ledger + audit only)"
+    );
+    assert_eq!(
+        db.count("audit_ledger").unwrap(),
+        1,
+        "extraction billing appends EXACTLY one audit row"
+    );
+    // The single audit row carries the M1 action.
+    let action: String = db
+        .conn()
+        .query_row("SELECT action FROM audit_ledger LIMIT 1", [], |r| r.get(0))
+        .unwrap();
+    assert_eq!(action, "memory.extract.model_call");
+    // The hash chain remains intact after the extraction audit append.
+    assert_eq!(audit::verify_audit_chain(db.conn()).unwrap(), 1);
+
+    // Extraction is its OWN cost dimension: the ledger row stays run-unattributed (run_id =
+    // NULL), so it is excluded from any run's metered total (M1 must not re-attribute).
+    let run_id: Option<String> = db
+        .conn()
+        .query_row(
+            "SELECT run_id FROM token_ledger WHERE ledger_id = 'le1'",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(
+        run_id, None,
+        "extraction ledger row carries no run attribution"
+    );
+    let run = friday_storage::agent_run_read::run_token_totals(db.conn(), "run-1").unwrap();
+    assert_eq!(
+        run.total, 0,
+        "extraction cost is excluded from the run total"
+    );
+}
+
+#[test]
+fn record_extraction_model_call_rolls_back_both_on_failure() {
+    // Atomicity: if the audit insert collides (PK clash), the token_ledger row must NOT
+    // persist — an extraction can never leave a charge with no audit row.
+    let p = temp_db_path("extract-bill-fail");
+    let db = Db::open_hub(&p).unwrap();
+    {
+        let tx = db.conn().unchecked_transaction().unwrap();
+        audit::append_audit(&tx, "dup", "x", "seed", None, 1).unwrap();
+        tx.commit().unwrap();
+    }
+    let res = db.record_extraction_model_call(&ledger("le1"), &extraction_audit_event("dup"));
+    assert!(res.is_err(), "duplicate audit_id must fail the call");
+    assert_eq!(
+        db.count("token_ledger").unwrap(),
+        0,
+        "the billing ledger row must roll back with the failed audit append"
+    );
+    assert_eq!(
+        db.count("audit_ledger").unwrap(),
+        1,
+        "only the seed row remains"
+    );
+    assert_eq!(audit::verify_audit_chain(db.conn()).unwrap(), 1);
+}
+
+#[test]
+fn record_extraction_model_call_is_hub_only() {
+    let p = temp_db_path("extract-bill-phone");
+    let db = Db::open_phone(&p).unwrap();
+    let res =
+        db.record_extraction_model_call(&ledger("le1"), &extraction_audit_event("le1:modelcall"));
+    assert!(matches!(res, Err(StorageError::Unsupported(_))));
+    // No billing row persisted; `audit_ledger` does not exist on a phone profile at all
+    // (so it is not counted here — the guard fires before any write).
+    assert_eq!(db.count("token_ledger").unwrap(), 0);
+}
+
 // ───────────────────────────────────────────────────────────────────────────
 // CONCURRENCY: the billing busy-retry (MED bug, hardening audit).
 //


### PR DESCRIPTION
Background memory extraction ledgered its model-call token usage with a bare
`db.insert_token_ledger(&ledger_entry)?` — emitting NO audit event, unlike the
ask path (`record_model_call`) and the agent loop (`record_run_model_call`),
which each pair the token-ledger write with a hash-chained audit row in one
transaction. So extraction was the one billable path leaving a charge with no
audit trail.

Add `record_extraction_model_call` (a free fn on `&Connection` + a `&self` Db
wrapper) mirroring `record_run_model_call`'s busy-retried txn shape MINUS the
activity insert: token_ledger insert + `audit::append_audit` in one tx, all-or-
nothing. actor="hub-agent", action="memory.extract.model_call", payload_ref =
the ledger id (encodes the run as `led:{run_id}:{now_ms}`, so the audit row is
run-attributable without touching the ledger row). The token_ledger row keeps
run_id = NULL (extraction is its own cost dimension, not a run-metered turn — no
re-attribution into run_token_totals). It is its OWN tx, never folded into the
candidate-persist tx, so the cost stays real even if persist rolls back.

Route the extraction call site through the new method; refresh the now-stale
doc/comment enumerations of what extraction writes (memory_extraction.rs module
doc + extract_inline/extract_inline_flagged docs + candidate-tx comment +
runtime.rs failure-isolation doc) to include audit_ledger.

Tests (atomic.rs + the existing extract→recall e2e): a billing call appends
exactly one audit row with action "memory.extract.model_call", writes no
activity row, leaves the ledger row run-unattributed/excluded from run totals,
and verify_audit_chain stays Ok; an audit PK clash rolls back the ledger row
too; phone profile fails closed. cargo test (storage+hub) all green, clippy
-D warnings clean, fmt --check clean.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
