### PR TITLE
fix(autonomy-routes): bind requireUserId to authenticated principal [refs: A2-NEW3]

### DIFF
--- a/src/api/http/routes/friday-autonomy-routes.ts
+++ b/src/api/http/routes/friday-autonomy-routes.ts
@@ -655,11 +655,7 @@ function requireNonEmptyString(value: unknown, field: string): string {
   return value;
 }
 
-function requireUserId(principal: { userId?: string } | null, bodyOrQuery?: Record<string, unknown>): string {
-  const explicit = bodyOrQuery?.userId;
-  if (typeof explicit === "string" && explicit.trim().length > 0) {
-    return explicit.trim();
-  }
+function requireUserId(principal: { userId?: string } | null): string {
   if (!principal?.userId) {
     throw new FridayDomainError("UNAUTHORIZED", "A user-scoped autonomy principal is required", {
       httpStatus: 401,
@@ -763,7 +759,7 @@ export function createFridayAutonomyRoutes(
         }
         const query = (ctx.query ?? {}) as Record<string, unknown>;
         const goal = requireNonEmptyString(query.goal, "goal");
-        const userId = requireUserId(ctx.principal, query);
+        const userId = requireUserId(ctx.principal);
         const run = await deps.acquisitionService.plan({
           userId,
           goal,
@@ -785,7 +781,7 @@ export function createFridayAutonomyRoutes(
         }
         const body = (ctx.body ?? {}) as Record<string, unknown>;
         const goal = requireNonEmptyString(body.goal, "goal");
-        const userId = requireUserId(ctx.principal, body);
+        const userId = requireUserId(ctx.principal);
         assertCapabilityAcquisitionTestOracleAllowed(deps);
         const run = await deps.acquisitionService.startRun({
           userId,
@@ -865,7 +861,7 @@ export function createFridayAutonomyRoutes(
           throw new FridayDomainError("NOT_IMPLEMENTED", "Standing goals service is not configured", { httpStatus: 501 });
         }
         const query = (ctx.query ?? {}) as Record<string, unknown>;
-        const userId = requireUserId(ctx.principal, query);
+        const userId = requireUserId(ctx.principal);
         return {
           items: deps.standingAgendaService.listStandingGoals({
             userId,
@@ -885,7 +881,7 @@ export function createFridayAutonomyRoutes(
           throw new FridayDomainError("NOT_IMPLEMENTED", "Standing goals service is not configured", { httpStatus: 501 });
         }
         const body = (ctx.body ?? {}) as FridayCreateStandingGoalRequest;
-        const userId = requireUserId(ctx.principal, body as unknown as Record<string, unknown>);
+        const userId = requireUserId(ctx.principal);
         const objective = requireNonEmptyString(body.objective, "objective");
         assertStandingAgendaTestOracleAllowed(deps);
         const result = await deps.standingAgendaService.createStandingGoal({
@@ -922,7 +918,7 @@ export function createFridayAutonomyRoutes(
           throw new FridayDomainError("NOT_IMPLEMENTED", "Standing goals service is not configured", { httpStatus: 501 });
         }
         const query = (ctx.query ?? {}) as Record<string, unknown>;
-        const userId = requireUserId(ctx.principal, query);
+        const userId = requireUserId(ctx.principal);
         return {
           items: deps.standingAgendaService.listAgenda({
             userId,

--- a/test/unit/api/http/routes/friday-autonomy-routes.test.ts
+++ b/test/unit/api/http/routes/friday-autonomy-routes.test.ts
@@ -959,6 +959,106 @@ describe("createFridayAutonomyRoutes control route retirement", () => {
   );
 });
 
+describe("createFridayAutonomyRoutes principal user-scoping (IDOR)", () => {
+  function createUserScopedRoutes() {
+    const listStandingGoals = vi.fn(() => []);
+    const listAgenda = vi.fn(() => []);
+    const plan = vi.fn(async () => ({ id: "plan-1" }));
+    const createStandingGoal = vi.fn(async () => ({
+      goal: { id: "goal-1", userId: "user-1", objective: "Ship Friday", status: "active" },
+      agendaItem: { id: "agenda-1", userId: "user-1", goalId: "goal-1", status: "pending" },
+    }));
+    const routes = createFridayAutonomyRoutes({
+      allowTestOnlyCapabilityAcquisitionExecution: true,
+      allowTestOnlyAutonomyPolicyMutation: true,
+      allowTestOnlyStandingAgendaExecution: true,
+      listUpgradeStatus: () => ({ items: [] }),
+      acquisitionService: {
+        plan,
+        startRun: vi.fn(async () => ({ id: "run-1" })),
+        approveRun: vi.fn(async () => ({ id: "run-1" })),
+        cancelRun: vi.fn(() => ({ id: "run-1" })),
+      },
+      standingAgendaService: {
+        listStandingGoals,
+        listAgenda,
+        createStandingGoal,
+        updateStandingGoal: vi.fn(() => ({ id: "goal-1", userId: "user-1", objective: "Ship Friday", status: "active" })),
+        approveAgendaItem: vi.fn(() => ({ id: "agenda-1", userId: "user-1", status: "approved" })),
+        runAgendaItem: vi.fn(async () => ({ runId: "run-1", status: "queued" })),
+      },
+    });
+    return { routes, listStandingGoals, listAgenda, plan, createStandingGoal };
+  }
+
+  function contextWithoutUserId(input: {
+    body?: Record<string, unknown>;
+    params?: Record<string, string>;
+    query?: Record<string, unknown>;
+  } = {}) {
+    return {
+      requestId: "req-1",
+      receivedAt: "2026-05-07T18:00:00.000Z",
+      params: input.params ?? {},
+      query: input.query ?? {},
+      body: input.body ?? {},
+      headers: {},
+      principal: { ...principal, userId: undefined },
+    };
+  }
+
+  it("ignores a caller-supplied query userId and scopes standing.goals.list to the authenticated principal", async () => {
+    const { routes, listStandingGoals } = createUserScopedRoutes();
+    const route = routes.find((entry) => entry.operationId === "standing.goals.list")!;
+
+    await route.handler(makeRouteContext({ query: { userId: "admin-001" } }));
+
+    expect(listStandingGoals).toHaveBeenCalledWith(expect.objectContaining({ userId: "user-1" }));
+    expect(listStandingGoals).not.toHaveBeenCalledWith(expect.objectContaining({ userId: "admin-001" }));
+  });
+
+  it("ignores a caller-supplied query userId and scopes agenda.list to the authenticated principal", async () => {
+    const { routes, listAgenda } = createUserScopedRoutes();
+    const route = routes.find((entry) => entry.operationId === "agenda.list")!;
+
+    await route.handler(makeRouteContext({ query: { userId: "admin-001" } }));
+
+    expect(listAgenda).toHaveBeenCalledWith(expect.objectContaining({ userId: "user-1" }));
+    expect(listAgenda).not.toHaveBeenCalledWith(expect.objectContaining({ userId: "admin-001" }));
+  });
+
+  it("ignores a caller-supplied query userId and scopes capabilities.acquisition.plan to the authenticated principal", async () => {
+    const { routes, plan } = createUserScopedRoutes();
+    const route = routes.find((entry) => entry.operationId === "capabilities.acquisition.plan")!;
+
+    await route.handler(makeRouteContext({ query: { goal: "Ship Friday", userId: "admin-001" } }));
+
+    expect(plan).toHaveBeenCalledWith(expect.objectContaining({ userId: "user-1" }));
+    expect(plan).not.toHaveBeenCalledWith(expect.objectContaining({ userId: "admin-001" }));
+  });
+
+  it("ignores a caller-supplied body userId and scopes standing.goals.create to the authenticated principal", async () => {
+    const { routes, createStandingGoal } = createUserScopedRoutes();
+    const route = routes.find((entry) => entry.operationId === "standing.goals.create")!;
+
+    await route.handler(makeRouteContext({ body: { objective: "Ship Friday", userId: "admin-001" } }));
+
+    expect(createStandingGoal).toHaveBeenCalledWith(expect.objectContaining({ userId: "user-1" }));
+    expect(createStandingGoal).not.toHaveBeenCalledWith(expect.objectContaining({ userId: "admin-001" }));
+  });
+
+  it("fail-closes with 401 when the principal carries no userId, even if a userId is supplied in the query", async () => {
+    const { routes, listStandingGoals } = createUserScopedRoutes();
+    const route = routes.find((entry) => entry.operationId === "standing.goals.list")!;
+
+    await expect(
+      route.handler(contextWithoutUserId({ query: { userId: "admin-001" } })),
+    ).rejects.toMatchObject({ httpStatus: 401 });
+
+    expect(listStandingGoals).not.toHaveBeenCalled();
+  });
+});
+
 describe("createFridayAutonomyRoutes skill lifecycle approval", () => {
   it.each([
     {


### PR DESCRIPTION
Drop the caller-supplied bodyOrQuery.userId override in requireUserId that
let an unauthenticated public-route caller pass ?userId=<owner> (or a userId
body field) and read/scope to arbitrary owner data (IDOR). requireUserId now
takes only the principal and returns principal.userId, keeping the existing
401-if-absent guard. Updated the 5 vulnerable call sites
(capabilities.acquisition.plan/runs.create, standing.goals.list/create,
agenda.list) to requireUserId(ctx.principal); the other 6 sites already passed
only the principal. A bound principal still resolves to its own userId; public
callers are confined to the synthetic read-biased default public principal.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
