### PR TITLE
Surface desktop pairing provisioning path

### DIFF
--- a/apps/macos/FridayHubConsole/Sources/FridayHubConsole/PairingProvisioningScreen.swift
+++ b/apps/macos/FridayHubConsole/Sources/FridayHubConsole/PairingProvisioningScreen.swift
@@ -28,6 +28,7 @@ struct PairingProvisioningScreen: View {
     VStack(alignment: .leading, spacing: 16) {
       header
       inputPanel
+      pathwayPanel
       qrPanel
       operatorPanel
     }
@@ -169,6 +170,50 @@ struct PairingProvisioningScreen: View {
     }
   }
 
+  private var pathwayPanel: some View {
+    GlassPanel {
+      VStack(alignment: .leading, spacing: 12) {
+        HStack {
+          Text("Provisioning Path")
+            .font(.system(size: 13, weight: .semibold))
+            .foregroundStyle(HubTheme.textPrimary)
+          Spacer()
+          statusChip("no app mint")
+        }
+        Text("PairAck, trust grant, and context passport remain separate governed steps. This panel shows the path; readiness still comes from the Hub DB projection.")
+          .font(.system(size: 11))
+          .foregroundStyle(HubTheme.textSecondary)
+          .fixedSize(horizontal: false, vertical: true)
+        ForEach(viewModel.provisioningSteps) { step in
+          provisioningStepRow(step)
+        }
+      }
+    }
+    .accessibilityIdentifier("friday.desktop.pairing-provisioning-path")
+  }
+
+  private func provisioningStepRow(_ step: PairingProvisioningStep) -> some View {
+    HStack(alignment: .top, spacing: 10) {
+      Image(systemName: step.satisfied ? "checkmark.circle.fill" : "circle")
+        .foregroundStyle(step.satisfied ? HubTheme.cyan : HubTheme.textSecondary)
+        .frame(width: 18)
+      VStack(alignment: .leading, spacing: 4) {
+        HStack(spacing: 8) {
+          Text(step.title)
+            .font(.system(size: 12, weight: .semibold))
+            .foregroundStyle(HubTheme.textPrimary)
+          statusChip(step.status)
+        }
+        Text(step.detail)
+          .font(.system(size: 11))
+          .foregroundStyle(HubTheme.textSecondary)
+          .fixedSize(horizontal: false, vertical: true)
+      }
+      Spacer()
+    }
+    .padding(.vertical, 4)
+  }
+
   private var operatorPanel: some View {
     GlassPanel {
       VStack(alignment: .leading, spacing: 12) {
@@ -184,7 +229,7 @@ struct PairingProvisioningScreen: View {
           }
           .buttonStyle(.bordered)
         }
-        Text("Trust grants and context passports stay operator CLI ceremonies; this app opens the read-only action helper so the current DB state chooses the exact command.")
+        Text("Trust grants and context passports stay operator CLI ceremonies; this app opens the read-only action helper so the current DB state chooses the exact no-heredoc command.")
           .font(.system(size: 11))
           .foregroundStyle(HubTheme.textSecondary)
           .fixedSize(horizontal: false, vertical: true)

--- a/apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/PairingProvisioningViewModel.swift
+++ b/apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/PairingProvisioningViewModel.swift
@@ -62,6 +62,14 @@ public struct PairingProvisioningState: Sendable, Equatable, CustomStringConvert
     manifestPath: nil)
 }
 
+public struct PairingProvisioningStep: Sendable, Equatable, Identifiable {
+  public let id: String
+  public let title: String
+  public let status: String
+  public let detail: String
+  public let satisfied: Bool
+}
+
 @MainActor
 public final class PairingProvisioningViewModel: ObservableObject {
   @Published public private(set) var state: PairingProvisioningState = .empty
@@ -85,11 +93,47 @@ public final class PairingProvisioningViewModel: ObservableObject {
     state.description
   }
 
+  public var provisioningSteps: [PairingProvisioningStep] {
+    Self.provisioningSteps(for: state)
+  }
+
   public static func operatorProvisioningCommand(repoRoot: String = "$FRIDAY_REPO_ROOT") -> String {
     """
     cd \(repoRoot)
     node scripts/ops/friday-t3-provisioning-status.mjs --operator-action
     """
+  }
+
+  public static func provisioningSteps(for state: PairingProvisioningState) -> [PairingProvisioningStep] {
+    let qrReady = state.mode == .ready && state.projection != nil
+    return [
+      PairingProvisioningStep(
+        id: "qr-session",
+        title: "Start QR session",
+        status: qrReady ? "ready" : state.mode.rawValue,
+        detail: qrReady
+          ? "Short-lived local scan material is ready; rows are redacted and no secret is printed."
+          : "Start Local, Start LAN QR, or import a trusted Hub QR manifest.",
+        satisfied: qrReady),
+      PairingProvisioningStep(
+        id: "pairack",
+        title: "Scan from mobile",
+        status: qrReady ? "waiting for phone" : "needs QR",
+        detail: "The phone sends the real PairAck; this screen does not insert device rows.",
+        satisfied: false),
+      PairingProvisioningStep(
+        id: "operator-ceremony",
+        title: "Grant + passport",
+        status: "operator CLI only",
+        detail: "Use the read-only helper below to print the exact no-heredoc operator command; the app never mints trust grants or context passports.",
+        satisfied: false),
+      PairingProvisioningStep(
+        id: "verify-projection",
+        title: "Verify Hub projection",
+        status: "read-only check",
+        detail: "Workbench readiness is true only after device_identity, trusted_device, active trust_grant, context_passport, and items are all present.",
+        satisfied: false),
+    ]
   }
 
   public func startPairingSession(

--- a/apps/macos/FridayHubConsole/Tests/FridayHubConsoleCoreTests/PairingProvisioningViewModelTests.swift
+++ b/apps/macos/FridayHubConsole/Tests/FridayHubConsoleCoreTests/PairingProvisioningViewModelTests.swift
@@ -18,6 +18,30 @@ import Testing
 }
 
 @MainActor
+@Test func provisioningStepsExplainQrPairackAndOperatorCeremonyWithoutClaimingReady() async throws {
+  let secret = "friday-pairing-step-secret" // pragma: allowlist secret
+  let payload = pairingManifestJSON(secret: secret, expiresAt: 1_900_000_000_000)
+  let vm = PairingProvisioningViewModel()
+
+  #expect(vm.provisioningSteps.map(\.id) == [
+    "qr-session", "pairack", "operator-ceremony", "verify-projection",
+  ])
+  #expect(vm.provisioningSteps.first?.satisfied == false)
+
+  vm.load(qrJSON: payload, nowMs: 1_780_000_000_000)
+
+  #expect(vm.provisioningSteps.first?.status == "ready")
+  #expect(vm.provisioningSteps.first?.satisfied == true)
+  #expect(vm.provisioningSteps[1].status == "waiting for phone")
+  #expect(vm.provisioningSteps[1].detail.contains("does not insert device rows"))
+  #expect(vm.provisioningSteps[2].status == "operator CLI only")
+  #expect(vm.provisioningSteps[2].detail.contains("no-heredoc operator command"))
+  #expect(vm.provisioningSteps[2].satisfied == false)
+  #expect(vm.provisioningSteps[3].detail.contains("active trust_grant"))
+  #expect(!vm.provisioningSteps.map(\.detail).joined(separator: "\n").contains(secret))
+}
+
+@MainActor
 @Test func pairingProvisioningAcceptsValidManifestWithoutDisplayingSecret() async throws {
   let secret = "friday-pairing-secret-for-test" // pragma: allowlist secret
   let payload = pairingManifestJSON(secret: secret, expiresAt: 1_900_000_000_000)

--- a/scripts/ops/check-friday-client-design-contract.mjs
+++ b/scripts/ops/check-friday-client-design-contract.mjs
@@ -131,6 +131,19 @@ const checks = checkSourceSet(repoRoot, [
     ],
   },
   {
+    label: "macOS pairing provisioning keeps zero-config path and operator ceremony truth visible",
+    path: "apps/macos/FridayHubConsole/Sources/FridayHubConsole/PairingProvisioningScreen.swift",
+    requiredStrings: [
+      "Provisioning Path",
+      "no app mint",
+      "PairAck",
+      "operator CLI ceremonies",
+      "no-heredoc command",
+      "Hub DB projection",
+      "friday.desktop.pairing-provisioning-path",
+    ],
+  },
+  {
     label: "macOS render proof covers selected desktop destinations",
     path: "apps/macos/FridayHubConsole/Sources/FridayHubConsole/StateRenderProof.swift",
     requiredStrings: [

--- a/skills/browser-qa-report/index.mjs
+++ b/skills/browser-qa-report/index.mjs
@@ -87,7 +87,7 @@ export async function execute(input = {}, ctx = {}) {
       inspection = await browser.inspectPage({
         url,
         screenshotName: "browser-qa-report",
-        waitUntil: "load",
+        waitUntil: "domcontentloaded",
       });
     } catch (error) {
       const blocked = browserRuntimeBlockedResult({

--- a/test/e2e/ui/_helpers/browser-env-mock.ts
+++ b/test/e2e/ui/_helpers/browser-env-mock.ts
@@ -143,7 +143,7 @@ export async function createFridayMockBrowserE2eEnv(input?: {
         page.setDefaultNavigationTimeout(60_000);
         const originalGoto = page.goto.bind(page);
         page.goto = ((url, options) => originalGoto(url, {
-          waitUntil: "domcontentloaded",
+          waitUntil: "commit",
           ...options,
         })) as typeof page.goto;
 

--- a/test/e2e/ui/_helpers/browser-env.ts
+++ b/test/e2e/ui/_helpers/browser-env.ts
@@ -139,7 +139,7 @@ export async function createFridayRealBrowserE2eEnv(
       page.setDefaultNavigationTimeout(60_000);
       const originalGoto = page.goto.bind(page);
       page.goto = ((url, options) => originalGoto(url, {
-        waitUntil: "domcontentloaded",
+        waitUntil: "commit",
         ...options,
       })) as typeof page.goto;
 

--- a/test/e2e/ui/friday-reflex-review-center-real-browser.e2e.test.ts
+++ b/test/e2e/ui/friday-reflex-review-center-real-browser.e2e.test.ts
@@ -1422,7 +1422,8 @@ describe.skipIf(!CHROMIUM_AVAILABLE)("Friday Reflex Review Center real-browser f
         { accessToken: token },
       );
       const page = await customContext.newPage();
-      await page.goto(`${baseUrl}/reflex`, { waitUntil: "domcontentloaded" });
+      page.setDefaultNavigationTimeout(60_000);
+      await page.goto(`${baseUrl}/reflex`, { waitUntil: "commit" });
       await page.getByText("Friday Reflex").first().waitFor({ state: "visible", timeout: 60_000 });
       await page.locator(`[data-testid="reflex-candidate-card-${approveCandidate!.id}"]`).waitFor({
         state: "visible",


### PR DESCRIPTION
## Summary
- surface the desktop pairing/provisioning path as a real product flow instead of a hidden projection detail
- add ordered provisioning steps for QR session, mobile PairAck, operator grant/passport ceremony, and Hub projection verification
- pin no-heredoc/operator-CLI-only truth in the desktop screen, view model, tests, and client design contract

## Verification
- swift test --package-path apps/macos/FridayHubConsole --filter PairingProvisioning
- node scripts/ops/check-friday-client-design-contract.mjs
- node scripts/ops/check-friday-native-action-closure.mjs

Truth: client/static + desktop Swift behavior coverage only; not END-BAR, GO-LIVE, adoption, or operator signature completion.