### PR TITLE
Polish iOS unavailable truth surfaces

### DIFF
--- a/apps/friday-ios/Sources/FridayMobileShell/FridayContextPassportScreen.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayContextPassportScreen.swift
@@ -13,7 +13,12 @@ struct FridayContextPassportScreen: View {
           loadingView
         case .unavailable(let reason):
           header(status: "unavailable", ready: false)
-          UnavailableView(reason: reason)
+          UnavailableView(
+            reason: reason,
+            title: "Context Passport unavailable",
+            detail: "PairAck, trust grant, and context passport truth are read from the Hub projection.",
+            systemImage: "checklist.checked",
+            identifier: "friday.context-passport.unavailable")
         case .loaded(let projection):
           loadedContent(projection)
         }

--- a/apps/friday-ios/Sources/FridayMobileShell/FridayHomeScreen.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayHomeScreen.swift
@@ -833,24 +833,43 @@ struct StatusBanner: View {
 /// The honest "unavailable" state — never a fake-ready Home.
 struct UnavailableView: View {
   let reason: String
+  var title = "Friday is offline"
+  var detail = "Live Hub projection is required before this surface can show current state."
+  var systemImage = "exclamationmark.triangle"
+  var identifier = "friday.home.unavailable"
 
   var body: some View {
-    VStack(spacing: 10) {
-      Image(systemName: "exclamationmark.triangle")
-        .font(.system(size: 28)).foregroundStyle(MobileTheme.coral)
-      Text("Friday is offline")
-        .font(.headline).foregroundStyle(MobileTheme.textPrimary)
-      Text(reason)
-        .font(.footnote).foregroundStyle(MobileTheme.textSecondary)
-        .multilineTextAlignment(.center)
-      Text("No cached or fabricated status is shown.")
-        .font(.caption2).foregroundStyle(MobileTheme.textSecondary)
-        .multilineTextAlignment(.center)
+    GlassPanel {
+      VStack(alignment: .leading, spacing: MobileTheme.rowSpacing) {
+        HStack(spacing: 12) {
+          Image(systemName: systemImage)
+            .font(.system(size: 24, weight: .semibold))
+            .foregroundStyle(MobileTheme.coral)
+            .frame(width: 34, height: 34)
+          VStack(alignment: .leading, spacing: 4) {
+            Text(title)
+              .font(.headline)
+              .foregroundStyle(MobileTheme.textPrimary)
+            Text(detail)
+              .font(.caption)
+              .foregroundStyle(MobileTheme.textSecondary)
+              .fixedSize(horizontal: false, vertical: true)
+          }
+          Spacer()
+          StatusChip(text: "offline", bg: MobileTheme.chipWarnBG, fg: MobileTheme.chipWarnFG)
+        }
+        Text(reason)
+          .font(.footnote)
+          .foregroundStyle(MobileTheme.textSecondary)
+          .fixedSize(horizontal: false, vertical: true)
+        HStack(spacing: 8) {
+          StatusChip(text: "no cache", bg: MobileTheme.chipNeutralBG, fg: MobileTheme.chipNeutralFG)
+          StatusChip(text: "no fabricated status", bg: MobileTheme.chipNeutralBG, fg: MobileTheme.chipNeutralFG)
+        }
+      }
     }
-    .padding(28)
-    .frame(maxWidth: .infinity, minHeight: 200)
     .accessibilityElement(children: .combine)
-    .accessibilityLabel("Friday is offline. \(reason). No cached or fabricated status is shown.")
-    .accessibilityIdentifier("friday.home.unavailable")
+    .accessibilityLabel("\(title). \(detail). \(reason). No cached or fabricated status is shown.")
+    .accessibilityIdentifier(identifier)
   }
 }

--- a/apps/friday-ios/Sources/FridayMobileShell/FridayProjectionScreens.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayProjectionScreens.swift
@@ -61,6 +61,19 @@ private enum ProjectionSurface {
     }
   }
 
+  var identifierSlug: String {
+    switch self {
+    case .missions: return "missions"
+    case .needsMe: return "needs-me"
+    case .memory: return "memory"
+    case .platform: return "platform"
+    case .activity: return "activity"
+    case .workflows: return "workflows"
+    case .onboarding: return "onboarding"
+    case .settings: return "settings"
+    }
+  }
+
   var statusLabel: String {
     switch self {
     case .missions: return "mission truth"
@@ -114,7 +127,12 @@ struct FridayProjectionScreen: View {
     case .loaded(let projection):
       loadedContent(surface, projection)
     case .unavailable(let reason):
-      UnavailableView(reason: reason)
+      UnavailableView(
+        reason: reason,
+        title: "\(surface.title) unavailable",
+        detail: "This destination renders only live Hub projection state and will not invent cached readiness.",
+        systemImage: surface.icon,
+        identifier: "friday.\(surface.identifierSlug).unavailable")
     }
   }
 

--- a/apps/friday-ios/Sources/FridayMobileShell/FridaySessionDetailScreen.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridaySessionDetailScreen.swift
@@ -13,7 +13,12 @@ struct FridaySessionDetailScreen: View {
         case .idle, .loading:
           loadingView
         case .unavailable(let reason):
-          UnavailableView(reason: reason)
+          UnavailableView(
+            reason: reason,
+            title: "Session detail unavailable",
+            detail: "Transcript, proof receipts, and continuation controls appear after a live session projection is readable.",
+            systemImage: "rectangle.connected.to.line.below",
+            identifier: "friday.session-detail.unavailable")
         case .loaded(let projection):
           loadedContent(projection)
         }

--- a/apps/friday-ios/Sources/FridayMobileShell/FridayTokenLedgerScreen.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayTokenLedgerScreen.swift
@@ -13,7 +13,12 @@ struct FridayTokenLedgerScreen: View {
           loadingView
         case .unavailable(let reason):
           header(status: "unavailable", ready: false)
-          UnavailableView(reason: reason)
+          UnavailableView(
+            reason: reason,
+            title: "Token ledger unavailable",
+            detail: "Cost and provider usage stay hidden until a run reference is projected by the Hub.",
+            systemImage: "chart.bar.doc.horizontal",
+            identifier: "friday.token-ledger.unavailable")
         case .loaded(let projection):
           loadedContent(projection)
         }

--- a/apps/friday-ios/Sources/FridayMobileShell/FridayVoiceScreen.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayVoiceScreen.swift
@@ -54,7 +54,12 @@ struct FridayVoiceScreen: View {
         .frame(maxWidth: .infinity, minHeight: 86, alignment: .leading)
       }
     case let .unavailable(reason):
-      UnavailableView(reason: reason)
+      UnavailableView(
+        reason: reason,
+        title: "Voice readiness unavailable",
+        detail: "Microphone, speech, and playback gates stay local until the live voice readiness arm is available.",
+        systemImage: "waveform",
+        identifier: "friday.voice.unavailable")
     case let .loaded(readiness):
       readinessCard(readiness)
       actionsCard(readiness)


### PR DESCRIPTION
## Summary
- replace the generic centered iOS unavailable placeholder with a glass-native truth card
- add surface-specific unavailable copy/icons/identifiers for session, context passport, token ledger, voice, and projection destinations
- keep all states fail-closed: no cached status, no fabricated readiness, no live flag changes

## Verification
- swift test (apps/friday-ios)
- node scripts/ops/check-friday-ios-t2-surface-contract.mjs
- node scripts/ops/check-friday-client-design-contract.mjs
- node scripts/ops/check-friday-native-action-closure.mjs
- bash scripts/ops/friday-ios-design-destination-capture.sh --out-dir /private/tmp/friday-ios-design-capture-t2-polish-20260624 --mode offline-truth

Truth: simulator screenshot capture proves selected destinations render truth-labeled UI states only; not END-BAR, not GO-LIVE, not adoption.