### PR TITLE
Bridge channel proof into UI device events

### DIFF
--- a/scripts/ops/friday-channel-proof-events.mjs
+++ b/scripts/ops/friday-channel-proof-events.mjs
@@ -1,0 +1,125 @@
+#!/usr/bin/env node
+
+import { mkdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { dirname, isAbsolute, resolve } from "node:path";
+
+const args = process.argv.slice(2);
+
+function usage() {
+  console.error(`usage:
+  node scripts/ops/friday-channel-proof-events.mjs \\
+    --mission-id=mission_... \\
+    --channel-live-proof=/abs/channel-live-proof.json \\
+    --channel-capture=/abs/channel-capture.json \\
+    --out=/abs/channel-events.jsonl [--require-ready]
+
+Truth: converts a redacted channel live proof wrapper into conservative
+same-run UI/device event rows. It does not synthesize replay, timeline,
+mobile/desktop/channel convergence, END-BAR, GO-LIVE, or adoption proof.`);
+}
+
+function arg(name) {
+  const prefix = `--${name}=`;
+  return args.find((value) => value.startsWith(prefix))?.slice(prefix.length) || "";
+}
+
+if (args.includes("--help") || args.includes("-h")) {
+  usage();
+  process.exit(0);
+}
+
+const requireReady = args.includes("--require-ready");
+const missionId = arg("mission-id");
+const channelLiveProofPath = arg("channel-live-proof");
+const channelCapturePath = arg("channel-capture");
+const outPath = arg("out");
+const blockers = [];
+
+function block(code, detail) {
+  blockers.push({ code, detail });
+}
+
+function abs(path) {
+  return isAbsolute(path) ? path : resolve(path);
+}
+
+function requireFile(label, path) {
+  if (!path) {
+    block("missing_arg", label);
+    return "";
+  }
+  const resolved = abs(path);
+  try {
+    const stats = statSync(resolved);
+    if (!stats.isFile()) block("not_file", `${label}:${resolved}`);
+    if (stats.size <= 0) block("empty_file", `${label}:${resolved}`);
+  } catch {
+    block("unreadable_file", `${label}:${resolved}`);
+  }
+  return resolved;
+}
+
+function readJson(path, label) {
+  if (!path) return null;
+  try {
+    return JSON.parse(readFileSync(path, "utf8"));
+  } catch {
+    block("invalid_json", label);
+    return null;
+  }
+}
+
+if (!missionId || !/^[A-Za-z0-9][A-Za-z0-9._:-]*$/.test(missionId) || !missionId.toLowerCase().includes("mission")) {
+  block("mission_id_unexpected_shape", missionId || "<missing>");
+}
+if (!outPath) block("missing_arg", "out");
+
+const channelLiveProof = requireFile("channel-live-proof", channelLiveProofPath);
+const channelCapture = requireFile("channel-capture", channelCapturePath);
+const proof = readJson(channelLiveProof, "channel-live-proof");
+
+if (proof) {
+  if (proof.proof !== "mission_spine_channel_live_proof") block("channel_live_proof_mismatch", String(proof.proof ?? ""));
+  if (proof.status !== "passed") block("channel_live_proof_not_passed", String(proof.status ?? ""));
+  if (proof.secret_policy?.artifact_contains_redacted_text_only !== true) {
+    block("channel_live_proof_secret_policy_not_redacted", "artifact_contains_redacted_text_only");
+  }
+  if (!String(proof.remaining_requirement || "").includes("UI/device consumption evidence")) {
+    block("channel_live_proof_missing_ui_device_boundary", "remaining_requirement");
+  }
+}
+
+const capturedAt = typeof proof?.generated_at_utc === "string" && proof.generated_at_utc.trim()
+  ? proof.generated_at_utc.trim()
+  : new Date(0).toISOString();
+const rows = blockers.length === 0 ? [{
+  surface: "channel",
+  event: "same_mission_projection_visible",
+  mission_id: missionId,
+  evidence_ref: channelCapture,
+  truth_label: "derived_from_redacted_channel_live_proof_not_final_ui_device_proof",
+  source: "mission_spine_channel_live_proof",
+  captured_at: capturedAt,
+}] : [];
+
+if (blockers.length === 0 && outPath) {
+  const out = abs(outPath);
+  mkdirSync(dirname(out), { recursive: true });
+  writeFileSync(out, `${rows.map((row) => JSON.stringify(row)).join("\n")}\n`);
+}
+
+const output = {
+  truth: "channel_proof_events_not_ui_device_proof",
+  status: blockers.length === 0 ? "ready" : "blocked",
+  missionId: missionId || null,
+  channelLiveProof: channelLiveProof || null,
+  channelCapture: channelCapture || null,
+  out: outPath ? abs(outPath) : null,
+  outputRows: rows.length,
+  emittedEvents: rows.map((row) => `${row.surface}:${row.event}`),
+  blockers,
+  caveat: "Conservative channel event bridge only. It does not claim replay proof, timeline proof, mobile/desktop/channel convergence, END-BAR, or GO-LIVE.",
+};
+
+console.log(JSON.stringify(output, null, 2));
+process.exit(blockers.length === 0 || !requireReady ? 0 : 2);

--- a/test/unit/qa/friday-channel-proof-events-cli.test.ts
+++ b/test/unit/qa/friday-channel-proof-events-cli.test.ts
@@ -1,0 +1,113 @@
+import { execFileSync, spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const script = "scripts/ops/friday-channel-proof-events.mjs";
+const missionId = "mission_cli_channel_proof_events";
+
+function writeChannelProof(path: string, overrides: Record<string, unknown> = {}) {
+  writeFileSync(path, JSON.stringify({
+    proof: "mission_spine_channel_live_proof",
+    generated_at_utc: "2026-06-24T23:59:00.000Z",
+    status: "passed",
+    scope: "real Telegram/channel inbound proof through Rust channel auth and redaction pipeline; not real UI/device consumption proof",
+    telegram_live: {
+      status: "passed",
+      proof: "telegram_inbound_through_rust_channels_pipeline",
+      bot_identity_verified: true,
+      channel_binding_created: true,
+      sender_allowlisted: true,
+      forged_bearer_rejected: true,
+      non_allowlisted_sender_rejected: true,
+    },
+    secret_policy: {
+      artifact_contains_redacted_text_only: true,
+    },
+    remaining_requirement: "real mobile/desktop/channel UI/device consumption evidence must still pass scripts/mission-spine-ui-device-proof-gate.sh",
+    ...overrides,
+  }, null, 2));
+}
+
+describe("friday-channel-proof-events", () => {
+  it("emits only the conservative channel same-mission projection event", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "friday-channel-proof-events-"));
+    try {
+      const proof = join(tempDir, "channel-live-proof.json");
+      const channelCapture = join(tempDir, "channel-capture.json");
+      const out = join(tempDir, "channel-events.jsonl");
+      writeChannelProof(proof);
+      writeFileSync(channelCapture, JSON.stringify({ truth: "redacted_channel_capture" }));
+
+      const stdout = execFileSync("node", [
+        script,
+        `--mission-id=${missionId}`,
+        `--channel-live-proof=${proof}`,
+        `--channel-capture=${channelCapture}`,
+        `--out=${out}`,
+        "--require-ready",
+      ], { cwd: process.cwd(), encoding: "utf8" });
+
+      const result = JSON.parse(stdout) as {
+        truth?: string;
+        status?: string;
+        outputRows?: number;
+        emittedEvents?: string[];
+        caveat?: string;
+      };
+      const rows = readFileSync(out, "utf8").trim().split("\n").map((line) => JSON.parse(line));
+
+      expect(result.truth).toBe("channel_proof_events_not_ui_device_proof");
+      expect(result.status).toBe("ready");
+      expect(result.outputRows).toBe(1);
+      expect(result.emittedEvents).toEqual(["channel:same_mission_projection_visible"]);
+      expect(result.caveat).toContain("does not claim replay proof");
+      expect(rows).toEqual([{
+        surface: "channel",
+        event: "same_mission_projection_visible",
+        mission_id: missionId,
+        evidence_ref: channelCapture,
+        truth_label: "derived_from_redacted_channel_live_proof_not_final_ui_device_proof",
+        source: "mission_spine_channel_live_proof",
+        captured_at: "2026-06-24T23:59:00.000Z",
+      }]);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("fails closed when the channel proof wrapper is not passed or redacted", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "friday-channel-proof-events-blocked-"));
+    try {
+      const proof = join(tempDir, "channel-live-proof.json");
+      const channelCapture = join(tempDir, "channel-capture.json");
+      const out = join(tempDir, "channel-events.jsonl");
+      writeChannelProof(proof, {
+        status: "blocked",
+        secret_policy: { artifact_contains_redacted_text_only: false },
+      });
+      writeFileSync(channelCapture, JSON.stringify({ truth: "redacted_channel_capture" }));
+
+      const result = spawnSync("node", [
+        script,
+        `--mission-id=${missionId}`,
+        `--channel-live-proof=${proof}`,
+        `--channel-capture=${channelCapture}`,
+        `--out=${out}`,
+        "--require-ready",
+      ], { cwd: process.cwd(), encoding: "utf8" });
+
+      expect(result.status).toBe(2);
+      const output = JSON.parse(result.stdout) as { status?: string; blockers?: Array<{ code?: string }> };
+      expect(output.status).toBe("blocked");
+      expect(output.blockers?.map((blocker) => blocker.code)).toEqual(expect.arrayContaining([
+        "channel_live_proof_not_passed",
+        "channel_live_proof_secret_policy_not_redacted",
+      ]));
+      expect(() => readFileSync(out, "utf8")).toThrow();
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add a conservative channel-live-proof to UI/device event bridge
- emit only `channel:same_mission_projection_visible` from a redacted `mission_spine_channel_live_proof` wrapper
- fail closed when the wrapper is not passed/redacted or when inputs are missing

## Verification
- npm test -- --run test/unit/qa/friday-channel-proof-events-cli.test.ts

Truth: this is an event bridge for already-captured channel proof. It does not synthesize replay, timeline, mobile/desktop/channel convergence, END-BAR, GO-LIVE, or adoption proof.