### PR TITLE
Surface iOS provider-linked WorkItem truth

### DIFF
--- a/apps/friday-ios/Sources/FridayMobileShell/FridayProviderAuthScreen.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayProviderAuthScreen.swift
@@ -131,31 +131,67 @@ struct FridayProviderAuthScreen: View {
         .font(.caption2)
         .foregroundStyle(MobileTheme.textSecondary)
         .fixedSize(horizontal: false, vertical: true)
-      if projection.workItems.isEmpty {
-        Text("No provider work-item refs in the current projection.")
+      let providerItems = projection.providerWorkItems
+      if providerItems.isEmpty {
+        Text("No provider-linked WorkItem refs in the current projection.")
           .font(.caption2)
           .foregroundStyle(MobileTheme.textSecondary)
       } else {
-        ForEach(projection.workItems.prefix(3)) { item in
-          HStack(spacing: 8) {
-            Image(systemName: item.needsAttention ? "exclamationmark.triangle" : "circle.dashed")
-              .foregroundStyle(item.needsAttention ? MobileTheme.coral : MobileTheme.textSecondary)
-              .frame(width: 18)
-            VStack(alignment: .leading, spacing: 2) {
-              Text(item.title)
-                .font(.caption.weight(.semibold))
-                .foregroundStyle(MobileTheme.textPrimary)
-                .lineLimit(1)
-              Text("\(item.owner) · \(item.state)")
-                .font(.caption2)
-                .foregroundStyle(MobileTheme.textSecondary)
-                .lineLimit(1)
-            }
-            Spacer()
+        Text("Provider-linked WorkItems")
+          .font(.caption.weight(.semibold))
+          .foregroundStyle(MobileTheme.textPrimary)
+        ForEach(providerItems.prefix(3)) { item in
+          providerWorkItemRow(item)
+        }
+      }
+    }
+    .accessibilityIdentifier("friday.provider-workspace.provider-work-items")
+  }
+
+  private func providerWorkItemRow(_ item: HomeWorkItem) -> some View {
+    VStack(alignment: .leading, spacing: 6) {
+      HStack(spacing: 8) {
+        Image(systemName: item.needsAttention ? "exclamationmark.triangle" : "circle.dashed")
+          .foregroundStyle(item.needsAttention ? MobileTheme.coral : MobileTheme.textSecondary)
+          .frame(width: 18)
+        VStack(alignment: .leading, spacing: 2) {
+          Text(item.title)
+            .font(.caption.weight(.semibold))
+            .foregroundStyle(MobileTheme.textPrimary)
+            .lineLimit(1)
+          Text("\(item.owner) · \(item.state)")
+            .font(.caption2)
+            .foregroundStyle(MobileTheme.textSecondary)
+            .lineLimit(1)
+        }
+        Spacer()
+        StatusChip(
+          text: item.done ? "done" : (item.needsAttention ? "needs action" : "visible"),
+          bg: item.done ? MobileTheme.chipDoneBG : (item.needsAttention ? MobileTheme.chipWarnBG : MobileTheme.chipNeutralBG),
+          fg: item.done ? MobileTheme.chipDoneFG : (item.needsAttention ? MobileTheme.chipWarnFG : MobileTheme.chipNeutralFG))
+      }
+      if !item.blockingReason.isEmpty {
+        Text(item.blockingReason)
+          .font(.caption2)
+          .foregroundStyle(MobileTheme.textSecondary)
+          .fixedSize(horizontal: false, vertical: true)
+      }
+      if let proofRef = item.proofRef, !proofRef.isEmpty {
+        RefPill(label: "work_item_proof", ref: proofRef)
+      }
+      if item.canRetry || item.canCancel {
+        HStack(spacing: 8) {
+          if item.canRetry {
+            StatusChip(text: "retry exposed on Home", bg: MobileTheme.chipPendingBG, fg: MobileTheme.chipPendingFG)
+          }
+          if item.canCancel {
+            StatusChip(text: "cancel exposed on Home", bg: MobileTheme.chipPendingBG, fg: MobileTheme.chipPendingFG)
           }
         }
       }
     }
+    .padding(10)
+    .background(MobileTheme.chipNeutralBG, in: RoundedRectangle(cornerRadius: 10, style: .continuous))
   }
 
   private func routeDecisionCard(_ projection: HomeProjection) -> some View {

--- a/apps/friday-ios/Sources/FridayMobileShellCore/HomeViewModel.swift
+++ b/apps/friday-ios/Sources/FridayMobileShellCore/HomeViewModel.swift
@@ -88,6 +88,10 @@ public struct HomeProjection: Sendable, Equatable {
       + runOutcomeLearningCandidates.count
   }
 
+  public var providerWorkItems: [HomeWorkItem] {
+    workItems.filter(\.isProviderLinked)
+  }
+
   public var isLoadedEmpty: Bool {
     workItemIds.isEmpty
       && providerReceiptRefs.isEmpty
@@ -210,6 +214,18 @@ public struct HomeWorkItem: Sendable, Identifiable, Equatable {
 
   public var needsAttention: Bool {
     !done && (["blocked", "waiting", "error", "stale"].contains(state) || canRetry || canCancel)
+  }
+
+  public var isProviderLinked: Bool {
+    let haystack = [
+      title,
+      state,
+      owner,
+      proofRef ?? "",
+      blockingReason,
+      recoveryKind,
+    ].joined(separator: " ").lowercased()
+    return ["provider", "codex", "claude", "deepseek", "anthropic"].contains { haystack.contains($0) }
   }
 }
 

--- a/apps/friday-ios/Tests/FridayMobileShellCoreTests/HomeViewModelTests.swift
+++ b/apps/friday-ios/Tests/FridayMobileShellCoreTests/HomeViewModelTests.swift
@@ -384,6 +384,7 @@ final class HomeViewModelTests: XCTestCase {
     XCTAssertEqual(p.providerReceiptRefs, ["proof://provider/1"])
     XCTAssertEqual(p.channelReceiptRefs, ["proof://surface/mobile/1"])
     XCTAssertEqual(p.workItems.map(\.title), ["Draft mission", "Needs approval"])
+    XCTAssertEqual(p.providerWorkItems, [])
     XCTAssertEqual(p.workItems.filter(\.needsAttention).map(\.id), ["wi-1", "wi-2"])
     XCTAssertEqual(p.workItems.last?.recoveryKind, "retryable")
     XCTAssertEqual(p.workItems.last?.canRetry, true)
@@ -411,6 +412,51 @@ final class HomeViewModelTests: XCTestCase {
     XCTAssertEqual(p.t3ProvisioningStatus?.checklistRows.last?.statusText, "shared")
     XCTAssertEqual(p.transcriptEvents.first?.summary, "Mobile surface read the mission projection.")
     XCTAssertEqual(p.needsMeCount, 4)
+  }
+
+  func testProviderWorkItemsOnlyIncludesProviderLinkedRows() throws {
+    let data = Data("""
+    {
+      "missionId": "mission-provider-work",
+      "fridayConversationId": "conv-provider-work",
+      "runtimeFeedStatus": "live_rust_hub_projection",
+      "statusLabels": [],
+      "workItems": [
+        {
+          "workItemId": "wi-general",
+          "title": "Draft owner note",
+          "state": "waiting",
+          "owner": "friday_owned",
+          "proofRef": "proof://wi/general",
+          "done": false,
+          "blockingReason": "waiting on operator review",
+          "recoveryKind": "needs_operator",
+          "canRetry": false,
+          "canCancel": true
+        },
+        {
+          "workItemId": "wi-provider",
+          "title": "Codex provider run needs receipt",
+          "state": "blocked",
+          "owner": "provider:codex",
+          "proofRef": "proof://provider/codex-run",
+          "done": false,
+          "blockingReason": "provider receipt not reconciled",
+          "recoveryKind": "provider_retryable",
+          "canRetry": true,
+          "canCancel": true
+        }
+      ]
+    }
+    """.utf8)
+
+    let snapshot = try WorkbenchSnapshot(projectionJSON: data, generatedAtMs: 1_780_640_000_000)
+    let projection = HomeProjection(snapshot)
+
+    XCTAssertEqual(projection.workItems.map(\.id), ["wi-general", "wi-provider"])
+    XCTAssertEqual(projection.providerWorkItems.map(\.id), ["wi-provider"])
+    XCTAssertFalse(try XCTUnwrap(projection.workItems.first).isProviderLinked)
+    XCTAssertTrue(try XCTUnwrap(projection.workItems.last).isProviderLinked)
   }
 
   func testT3ProvisioningHomeSummarySurfacesOperatorGapsWithoutClaimingReady() throws {


### PR DESCRIPTION
## Summary
- Classify provider-linked WorkItems in the iOS HomeProjection.
- Make Provider Workspace show only provider-linked WorkItems instead of implying every work item is provider queue state.
- Surface proof refs, blocker text, and Home-exposed retry/cancel truth without adding new write actions.

## Verification
- `swift test` in `apps/friday-ios`
- `node scripts/ops/check-friday-native-action-closure.mjs`
- `node scripts/ops/check-friday-ios-t2-surface-contract.mjs`
- `bash apps/friday-ios/build-sim.sh` and screenshot inspection

## Truth
This aligns mobile Provider Workspace truth with the desktop Provider/Admin projection. It does not claim live provider control, END-BAR, GO-LIVE, adoption, or complete mobile+desktop product closure.