### PR TITLE
Recognize local iOS speech output provider

### DIFF
--- a/apps/friday-ios/Sources/FridayMobileShell/FridayVoiceScreen.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayVoiceScreen.swift
@@ -162,12 +162,12 @@ struct FridayVoiceScreen: View {
           value: readiness.speechRecognition.rawValue,
           healthy: readiness.speechRecognition == .authorized)
         readinessRow(
-          title: "TTS provider",
+          title: "Speech output provider",
           value: readiness.ttsProviderConfigured ? "configured" : "not configured in this build",
           healthy: readiness.ttsProviderConfigured)
         readinessRow(
           title: "Realtime loop",
-          value: readiness.voiceLoopReady ? "ready" : "blocked until capture and TTS are ready",
+          value: readiness.voiceLoopReady ? "ready" : "blocked until capture and speech output are ready",
           healthy: readiness.voiceLoopReady)
       }
     }

--- a/apps/friday-ios/Sources/FridayMobileShell/SystemVoiceReadinessAuthorizer.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/SystemVoiceReadinessAuthorizer.swift
@@ -5,7 +5,9 @@ import Speech
 struct SystemVoiceReadinessAuthorizer: MobileVoiceReadinessAuthorizing {
   private let ttsProviderConfigured: Bool
 
-  init(ttsProviderConfigured: Bool = false) {
+  /// The app already speaks answers through AVSpeechSynthesizer in FridayChatScreen. That is a
+  /// local, on-device speech-output provider; it does not imply remote realtime voice or STT.
+  init(ttsProviderConfigured: Bool = true) {
     self.ttsProviderConfigured = ttsProviderConfigured
   }
 

--- a/apps/friday-ios/Sources/FridayMobileShellCore/VoiceReadinessViewModel.swift
+++ b/apps/friday-ios/Sources/FridayMobileShellCore/VoiceReadinessViewModel.swift
@@ -44,7 +44,7 @@ public struct MobileVoiceReadiness: Sendable, Equatable {
       return "Voice capture and TTS provider readiness are both present."
     }
     if speechCaptureReady {
-      return "Voice capture is allowed; TTS provider output is not configured in this build."
+      return "Voice capture is allowed; speech output provider is not configured in this build."
     }
     if microphone == .notDetermined || speechRecognition == .notDetermined {
       return "Voice permissions have not both been requested."
@@ -140,10 +140,10 @@ public final class VoiceReadinessViewModel: ObservableObject {
         enabled: readiness.speechCaptureReady),
       MobileVoiceActionRow(
         id: "tts-output",
-        title: "TTS output",
+        title: "Speech output",
         detail: readiness.ttsProviderConfigured
-          ? "TTS provider is configured for speech output."
-          : "No TTS provider is configured in this build.",
+          ? "Speech output provider is configured."
+          : "No speech output provider is configured in this build.",
         truthLabel: readiness.ttsProviderConfigured ? "provider_configured" : "NO-GO",
         enabled: readiness.ttsProviderConfigured),
       MobileVoiceActionRow(

--- a/apps/friday-ios/Tests/FridayMobileShellCoreTests/VoiceReadinessViewModelTests.swift
+++ b/apps/friday-ios/Tests/FridayMobileShellCoreTests/VoiceReadinessViewModelTests.swift
@@ -25,7 +25,7 @@ final class VoiceReadinessViewModelTests: XCTestCase {
     XCTAssertFalse(captureOnly.voiceLoopReady)
     XCTAssertEqual(
       captureOnly.summary,
-      "Voice capture is allowed; TTS provider output is not configured in this build.")
+      "Voice capture is allowed; speech output provider is not configured in this build.")
 
     let complete = MobileVoiceReadiness(
       microphone: .authorized,


### PR DESCRIPTION
## Summary
- Treat the existing AVSpeechSynthesizer path as the local on-device speech-output provider for iOS voice readiness.
- Keep the truth boundary explicit: this does not claim remote realtime voice, Whisper/STT model integration, or external TTS provider setup.

## Verification
- `swift test` in `apps/friday-ios`
- `bash apps/friday-ios/build-sim.sh`

## Truth
This corrects the Voice readiness surface to match the app code that already speaks Friday answers locally. It does not satisfy complete Voice I/O END-BAR by itself.