### PR TITLE
fix(http): floor anonymous reads on provider-spend + remote device/session posture

### DIFF
--- a/src/api/http/friday-sensitive-read-routes.ts
+++ b/src/api/http/friday-sensitive-read-routes.ts
@@ -32,6 +32,22 @@
  *   - /v1/grants     active grants and authorization posture
  *   - /v1/audit      runtime audit logs / forensic evidence
  *   - /v1/observability/audit  observability audit entries and detail readback
+ *   - /v1/providers/usage  provider spend/usage summary (global cost data) — gated
+ *                    2026-06-24 (operator-authorized per-handler review). Sub-path only:
+ *                    the trailing-slash boundary keeps the bare /v1/providers list/get/health/
+ *                    capability-health/doctor (accepted operator_external_adapter reads)
+ *                    anonymous.
+ *   - /v1/providers/budget  monthly budget status (GET) — gated 2026-06-24 (operator-
+ *                    authorized). Same sub-path-only boundary as /v1/providers/usage; the bare
+ *                    /v1/providers prefix stays anonymous. (PUT here is already fail-closed by
+ *                    the public-mutation floor.)
+ *   - /v1/system/remote/devices  remote device inventory / posture (GET list + GET detail) —
+ *                    gated 2026-06-24 (operator-authorized). The POST register / DELETE /
+ *                    WebAuthn auth-option routes under this prefix are mutations (unaffected by
+ *                    this GET/HEAD-only read floor).
+ *   - /v1/system/remote/sessions  remote session inventory / posture (GET list) — gated
+ *                    2026-06-24 (operator-authorized). POST create / POST heartbeat / DELETE
+ *                    under this prefix are mutations (unaffected by this read floor).
  *
  * Intentionally NOT gated here (kept anonymous): health, setup, onboarding, auth
  * bootstrap/login/refresh, version/status/capabilities, and the core no-login UX surfaces
@@ -40,9 +56,10 @@
  *
  * Known-ungated personal/posture surfaces deliberately left OUT of this targeted scope
  * (recorded so they are not silently dropped — candidates for a follow-up classification, NOT
- * closed here): /v1/uix/learned-facts, /v1/uix/user-profile, /v1/system/remote/devices,
- * /v1/providers/usage, /v1/providers/budget. Each needs
- * its own per-handler review before gating.
+ * closed here): /v1/uix/learned-facts, /v1/uix/user-profile. Each needs its own per-handler
+ * review before gating. (The provider-spend and remote-device/session posture surfaces that
+ * previously sat on this deferred list were reviewed and gated 2026-06-24 — see the prefixes
+ * above.)
  */
 export const FRIDAY_SENSITIVE_READ_ROUTE_PREFIXES: readonly string[] = [
   "/v1/memory",
@@ -55,6 +72,13 @@ export const FRIDAY_SENSITIVE_READ_ROUTE_PREFIXES: readonly string[] = [
   "/v1/grants",
   "/v1/audit",
   "/v1/observability/audit",
+  // Gated 2026-06-24 (operator-authorized per-handler review). Each is a SUB-PATH of an
+  // otherwise-anonymous prefix; the trailing-slash boundary in isFridaySensitiveReadRoute keeps
+  // the bare /v1/providers and /v1/system/... prefixes anonymous (no over-flooring).
+  "/v1/providers/usage",
+  "/v1/providers/budget",
+  "/v1/system/remote/devices",
+  "/v1/system/remote/sessions",
 ];
 
 /**

--- a/test/unit/api/http/friday-http-server-sensitive-read-gate.test.ts
+++ b/test/unit/api/http/friday-http-server-sensitive-read-gate.test.ts
@@ -78,6 +78,12 @@ describe("isFridaySensitiveReadRoute", () => {
     expect(isFridaySensitiveReadRoute("/v1/grants/active")).toBe(true);
     expect(isFridaySensitiveReadRoute("/v1/audit/logs")).toBe(true);
     expect(isFridaySensitiveReadRoute("/v1/observability/audit/:entryId")).toBe(true);
+    // Gated 2026-06-24 (operator-authorized): provider-spend + remote device/session posture.
+    expect(isFridaySensitiveReadRoute("/v1/providers/usage")).toBe(true);
+    expect(isFridaySensitiveReadRoute("/v1/providers/budget")).toBe(true);
+    expect(isFridaySensitiveReadRoute("/v1/system/remote/devices")).toBe(true);
+    expect(isFridaySensitiveReadRoute("/v1/system/remote/devices/:deviceId")).toBe(true);
+    expect(isFridaySensitiveReadRoute("/v1/system/remote/sessions")).toBe(true);
   });
 
   it("does NOT match the core no-login UX or minimal-public surfaces", () => {
@@ -95,12 +101,33 @@ describe("isFridaySensitiveReadRoute", () => {
     }
   });
 
+  it("no-degrade: the bare /v1/providers reads (accepted operator_external_adapter) stay un-gated", () => {
+    // Gating /v1/providers/usage + /v1/providers/budget must NOT over-floor the bare prefix.
+    for (const path of [
+      "/v1/providers",
+      "/v1/providers/health",
+      "/v1/providers/capability-health",
+      "/v1/providers/detect",
+      "/v1/providers/templates",
+      "/v1/providers/:providerId",
+      "/v1/providers/:providerId/doctor",
+      "/v1/providers/routing/explain",
+    ]) {
+      expect(isFridaySensitiveReadRoute(path)).toBe(false);
+    }
+  });
+
   it("respects the trailing-slash boundary (no sibling-prefix false positives)", () => {
     expect(isFridaySensitiveReadRoute("/v1/secretspolicy")).toBe(false);
     expect(isFridaySensitiveReadRoute("/v1/securityx")).toBe(false);
     expect(isFridaySensitiveReadRoute("/v1/grantsx")).toBe(false);
     expect(isFridaySensitiveReadRoute("/v1/auditx")).toBe(false);
     expect(isFridaySensitiveReadRoute("/v1/observability/auditor")).toBe(false);
+    // 2026-06-24 sub-path prefixes: a sibling that only shares the textual prefix must NOT match.
+    expect(isFridaySensitiveReadRoute("/v1/providers/usagex")).toBe(false);
+    expect(isFridaySensitiveReadRoute("/v1/providers/budgetx")).toBe(false);
+    expect(isFridaySensitiveReadRoute("/v1/system/remote/devicesx")).toBe(false);
+    expect(isFridaySensitiveReadRoute("/v1/system/remote/sessionsx")).toBe(false);
   });
 });
 
@@ -358,6 +385,103 @@ describe("FridayHttpServer sensitive-read floor", () => {
     const body = await response.json() as { ok: false; error: { code: string } };
     expect(body.error.code).toBe(ERROR_CODE_BOUND_PRINCIPAL_REQUIRED);
     expect(handlerCalls).toBe(0);
+  });
+
+  it("negative: anonymous GET on the 2026-06-24 gated spend/posture reads → 401 before handlers run", async () => {
+    const handlerCalls: Record<string, number> = {
+      usage: 0,
+      budget: 0,
+      devices: 0,
+      sessions: 0,
+    };
+    await startWith((routes) => {
+      routes.register({
+        operationId: "providers.usage.get",
+        method: "GET",
+        path: "/v1/providers/usage",
+        auth: { public: true },
+        async handler() {
+          handlerCalls.usage += 1;
+          return { summary: {} };
+        },
+      });
+      routes.register({
+        operationId: "providers.budget.get",
+        method: "GET",
+        path: "/v1/providers/budget",
+        auth: { public: true },
+        async handler() {
+          handlerCalls.budget += 1;
+          return { budget: {} };
+        },
+      });
+      routes.register({
+        operationId: "system.remote.devices.list",
+        method: "GET",
+        path: "/v1/system/remote/devices",
+        auth: { public: true },
+        async handler() {
+          handlerCalls.devices += 1;
+          return { devices: [] };
+        },
+      });
+      routes.register({
+        operationId: "system.remote.sessions.list",
+        method: "GET",
+        path: "/v1/system/remote/sessions",
+        auth: { public: true },
+        async handler() {
+          handlerCalls.sessions += 1;
+          return { sessions: [] };
+        },
+      });
+    });
+
+    for (const path of [
+      "/v1/providers/usage",
+      "/v1/providers/budget",
+      "/v1/system/remote/devices",
+      "/v1/system/remote/sessions",
+    ]) {
+      const response = await fetch(`${baseUrl}${path}`);
+      expect(response.status).toBe(401);
+      const body = (await response.json()) as { ok: false; error: { code: string } };
+      expect(body.error.code).toBe(ERROR_CODE_BOUND_PRINCIPAL_REQUIRED);
+    }
+    expect(handlerCalls).toEqual({ usage: 0, budget: 0, devices: 0, sessions: 0 });
+  });
+
+  it("no-degrade: anonymous GET on the bare /v1/providers reads stays 200 (NOT over-floored)", async () => {
+    const handlerCalls: Record<string, number> = { list: 0, health: 0 };
+    await startWith((routes) => {
+      routes.register({
+        operationId: "providers.list",
+        method: "GET",
+        path: "/v1/providers",
+        auth: { public: true },
+        async handler() {
+          handlerCalls.list += 1;
+          return { providers: [] };
+        },
+      });
+      routes.register({
+        operationId: "providers.health.list",
+        method: "GET",
+        path: "/v1/providers/health",
+        auth: { public: true },
+        async handler() {
+          handlerCalls.health += 1;
+          return { health: [] };
+        },
+      });
+    });
+
+    for (const path of ["/v1/providers", "/v1/providers/health"]) {
+      const response = await fetch(`${baseUrl}${path}`);
+      expect(response.status).toBe(200);
+    }
+    // Both accepted operator_external_adapter reads still reach their handlers anonymously.
+    expect(handlerCalls).toEqual({ list: 1, health: 1 });
   });
 
   it("regression: anonymous GET on a core no-login UX route (non-sensitive) → 200 (unaffected)", async () => {


### PR DESCRIPTION
**Audit finding A2-NEW2 + A2-NEW4** (operator-authorized 2026-06-24 to gate, per-handler review of the deferred list).

Four sensitive GET surfaces were anonymously readable network-wide (no-login-by-default → shared `default-public` principal), sitting on the "deliberately deferred / review-before-gating" list:
- `GET /v1/providers/usage` — provider spend/usage (global cost) [A2-NEW2]
- `GET /v1/providers/budget` — monthly budget status [A2-NEW2]
- `GET /v1/system/remote/devices` — remote device posture [A2-NEW4]
- `GET /v1/system/remote/sessions` — remote session posture [A2-NEW4]

**Fix:** appended the 4 sub-paths to `FRIDAY_SENSITIVE_READ_ROUTE_PREFIXES` (the single classification source consumed by the server-level sensitive-read floor in `friday-http-server.ts:762-781` → anon GET/HEAD → 401 `BOUND_PRINCIPAL_REQUIRED` before the handler runs).

**No-degrade (tested, not just reasoned):** each gated path is a sub-path of an otherwise-anonymous prefix; the trailing-slash boundary keeps bare `/v1/providers` (list/health/capability-health/`:providerId`/detect/templates/routing) anonymous (the accepted operator_external_adapter reads). Enumerated every route under both remote prefixes — the only GET routes are the two being gated; WebAuthn bootstrap is all POST → still anonymous (no onboarding break).

**Tests:** extended `friday-http-server-sensitive-read-gate.test.ts` — positives for all 4, no-over-floor `=== false` for bare `/v1/providers` reads + trailing-slash siblings, server-level anon-GET → 401 (handler count 0), server-level no-degrade anon-GET `/v1/providers` + `/health` → 200. `npx tsc --noEmit` exit 0; 24 tests pass.

Reviewed by two isolated reviewers (correctness + regression/integrity): PASS/PASS.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>