### PR TITLE
test(friday-core): cover trust provider/channel/skill_family deny sites

### DIFF
--- a/rust-core/crates/friday-core/src/trust.rs
+++ b/rust-core/crates/friday-core/src/trust.rs
@@ -322,6 +322,61 @@ mod tests {
     }
 
     #[test]
+    fn provider_not_in_allowlist_denies_but_allowed_provider_passes() {
+        // allowed_providers is ["deepseek"]. A non-allowed provider DENIES with the
+        // exact reason; the allowed provider exercises the allow path (allowed() ==
+        // true), which within_boundaries_allows does not cover (it carries no provider).
+        let mut deny_c = check();
+        deny_c.provider = Some("openai".into());
+        let (d, r) = check_grant(&grant(), &deny_c);
+        assert_eq!(d, GateDecision::Deny);
+        assert_eq!(r, "trust_grant_provider_not_allowed");
+
+        let mut allow_c = check();
+        allow_c.provider = Some("deepseek".into());
+        let (d2, r2) = check_grant(&grant(), &allow_c);
+        assert_eq!(d2, GateDecision::Allow);
+        assert_eq!(r2, "trust_grant_within_boundaries");
+    }
+
+    #[test]
+    fn channel_not_in_allowlist_denies_but_allowed_channel_passes() {
+        // allowed_channels is ["telegram"]. A non-allowed channel DENIES with the exact
+        // reason; the allowed channel exercises the allow path (allowed() == true).
+        let mut deny_c = check();
+        deny_c.channel = Some("slack".into());
+        let (d, r) = check_grant(&grant(), &deny_c);
+        assert_eq!(d, GateDecision::Deny);
+        assert_eq!(r, "trust_grant_channel_not_allowed");
+
+        let mut allow_c = check();
+        allow_c.channel = Some("telegram".into());
+        let (d2, r2) = check_grant(&grant(), &allow_c);
+        assert_eq!(d2, GateDecision::Allow);
+        assert_eq!(r2, "trust_grant_within_boundaries");
+    }
+
+    #[test]
+    fn skill_family_not_in_allowlist_denies_but_allowed_family_passes() {
+        // The fixture's allowed_skill_families is EMPTY (deny-all): any skill-family
+        // action denies with the exact reason. Populating the allowlist exercises the
+        // allow path (allowed() == true) for a matching family.
+        let mut deny_c = check();
+        deny_c.skill_family = Some("research".into());
+        let (d, r) = check_grant(&grant(), &deny_c);
+        assert_eq!(d, GateDecision::Deny);
+        assert_eq!(r, "trust_grant_skill_family_not_allowed");
+
+        let mut g = grant();
+        g.boundaries.allowed_skill_families = vec!["research".into()];
+        let mut allow_c = check();
+        allow_c.skill_family = Some("research".into());
+        let (d2, r2) = check_grant(&g, &allow_c);
+        assert_eq!(d2, GateDecision::Allow);
+        assert_eq!(r2, "trust_grant_within_boundaries");
+    }
+
+    #[test]
     fn empty_allowlist_is_deny_all_for_a_checked_dimension() {
         // allowed_workflow_families is empty -> ANY workflow-family action denies.
         let mut c = check();


### PR DESCRIPTION
**Audit finding testblind** — mutation/coverage gap (NOT a live fail-open; the code is correct).

`friday-core trust.rs::check_grant` has 5 per-dimension deny sites; only the `tool` branch had a unit test. The `provider` (:136), `channel` (:141), and `skill_family` (:151) deny sites had zero direct coverage (`workflow_family` was already covered by `empty_allowlist_is_deny_all_...`). The provider/channel ALLOW-via-allowlist path was also exercised nowhere.

**Change — ADD-TESTS ONLY (zero behavior change):** three new `#[cfg(test)]` tests mirroring the tool-branch test + the fire-when-Some / inert-when-None dimension semantics. Each asserts BOTH deny (exact reason string) AND allow (matching allowlist value → within_boundaries). Each deny test sets only its own dimension to a bad value so the in-order short-circuit can't mask the asserted reason.

**Hard constraints honored:** `trust.rs:109` risk-ceiling `>` comparator UNTOUCHED (the `>=` off-by-one hypothesis was refuted); `gate.rs` untouched; diff is pure additions inside `mod tests` (single file, +55 −0).

**Verify:** `cargo test -p friday-core` 193 passed / 0 failed incl. the 3 new tests; `cargo clippy -- -D warnings` clean; `cargo fmt --check` clean.

Reviewed by two isolated reviewers (correctness + regression/integrity): PASS/PASS.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>