### PR TITLE
Align iOS voice readiness truth wording

### DIFF
--- a/apps/friday-ios/Sources/FridayMobileShell/FridayVoiceScreen.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayVoiceScreen.swift
@@ -81,7 +81,7 @@ struct FridayVoiceScreen: View {
           .font(.callout.weight(.medium))
           .foregroundStyle(MobileTheme.textPrimary)
           .fixedSize(horizontal: false, vertical: true)
-        Text("Readiness only; realtime voice starts after capture and TTS gates are ready.")
+        Text("Readiness plus local voice-loop truth: capture and speech output run from Friday Chat when these gates are ready.")
           .font(.caption)
           .foregroundStyle(MobileTheme.textSecondary)
           .fixedSize(horizontal: false, vertical: true)
@@ -167,7 +167,7 @@ struct FridayVoiceScreen: View {
           healthy: readiness.ttsProviderConfigured)
         readinessRow(
           title: "Realtime loop",
-          value: readiness.voiceLoopReady ? "ready" : "blocked until capture and speech output are ready",
+          value: readiness.voiceLoopReady ? "ready in Friday Chat" : "blocked until capture and speech output are ready",
           healthy: readiness.voiceLoopReady)
       }
     }

--- a/apps/friday-ios/Sources/FridayMobileShellCore/VoiceReadinessViewModel.swift
+++ b/apps/friday-ios/Sources/FridayMobileShellCore/VoiceReadinessViewModel.swift
@@ -41,7 +41,7 @@ public struct MobileVoiceReadiness: Sendable, Equatable {
 
   public var summary: String {
     if voiceLoopReady {
-      return "Voice capture and TTS provider readiness are both present."
+      return "Voice capture and local speech output provider readiness are both present."
     }
     if speechCaptureReady {
       return "Voice capture is allowed; speech output provider is not configured in this build."
@@ -142,7 +142,7 @@ public final class VoiceReadinessViewModel: ObservableObject {
         id: "tts-output",
         title: "Speech output",
         detail: readiness.ttsProviderConfigured
-          ? "Speech output provider is configured."
+          ? "Local speech output provider is configured."
           : "No speech output provider is configured in this build.",
         truthLabel: readiness.ttsProviderConfigured ? "provider_configured" : "NO-GO",
         enabled: readiness.ttsProviderConfigured),

--- a/apps/friday-ios/Tests/FridayMobileShellCoreTests/VoiceReadinessViewModelTests.swift
+++ b/apps/friday-ios/Tests/FridayMobileShellCoreTests/VoiceReadinessViewModelTests.swift
@@ -34,7 +34,7 @@ final class VoiceReadinessViewModelTests: XCTestCase {
     XCTAssertTrue(complete.voiceLoopReady)
     XCTAssertEqual(
       complete.summary,
-      "Voice capture and TTS provider readiness are both present.")
+      "Voice capture and local speech output provider readiness are both present.")
   }
 
   func testDeniedOrRestrictedPermissionsNeverClaimVoiceReady() {
@@ -113,6 +113,7 @@ final class VoiceReadinessViewModelTests: XCTestCase {
       ttsProviderConfigured: true)
     let completeRows = VoiceReadinessViewModel.actionRows(for: complete)
     XCTAssertEqual(completeRows.first { $0.id == "tts-output" }?.truthLabel, "provider_configured")
+    XCTAssertEqual(completeRows.first { $0.id == "tts-output" }?.detail, "Local speech output provider is configured.")
     XCTAssertEqual(completeRows.first { $0.id == "realtime-loop" }?.truthLabel, "ready")
     XCTAssertEqual(completeRows.first { $0.id == "realtime-loop" }?.enabled, true)
   }

--- a/scripts/ops/check-friday-ios-t2-surface-contract.mjs
+++ b/scripts/ops/check-friday-ios-t2-surface-contract.mjs
@@ -133,8 +133,8 @@ const checks = [
       "Voice Gates",
       "MobileVoiceReadiness",
       "NO-GO",
-      "TTS provider output is not configured in this build",
-      "Readiness only",
+      "speech output provider",
+      "Readiness plus local voice-loop truth",
     ]),
   },
   {

--- a/scripts/ops/check-friday-native-action-closure.mjs
+++ b/scripts/ops/check-friday-native-action-closure.mjs
@@ -208,7 +208,7 @@ const checks = [
       "requires a pending approval ref",
       "Add shared text or a URL before submitting.",
       "Share Intake is unavailable",
-      "Readiness only",
+      "Readiness plus local voice-loop truth",
       "No cost data is fabricated",
     ]),
   ),


### PR DESCRIPTION
## Summary
- align the iOS Voice readiness screen and ViewModel copy with the current truth: local capture + local speech output provider readiness, not complete realtime Voice I/O
- update the iOS T2/static native-action guards so stale "readiness only" wording cannot drift back
- preserve the caveat that this is not END-BAR, not complete voice I/O, and not adoption proof

## Verification
- `swift test` in `apps/friday-ios` (78 XCTest + 45 Swift Testing passed; live tests skipped)
- `node scripts/ops/check-friday-ios-t2-surface-contract.mjs`
- `node scripts/ops/check-friday-native-action-closure.mjs`

## Truth
This is a truth-label/copy guard PR. It does not claim complete Voice I/O, real-device adoption, END-BAR, GO-LIVE, or operator signature completion.