### PR TITLE
fix(friday-core): flag api_token compound family in the planning save-object gate

### DIFF
--- a/rust-core/crates/friday-core/src/tool_policy.rs
+++ b/rust-core/crates/friday-core/src/tool_policy.rs
@@ -801,6 +801,18 @@ const EN_SAVE_OBJECTS: &[&str] = &[
     "api_key",
     "api-key",
     "apikey",
+    // Audit L3 — Rust-side EN-parity addition (labeled divergence from the TS oracle,
+    // same spirit as the C2 block below). `api_token`/`api-token`/`apitoken` are in
+    // SENSITIVE_WORDS / SENSITIVE_ASSIGN_KEYS but were absent here, so "save my
+    // api_token" slipped the save-object co-occurrence: word-bound bare `token`
+    // cannot match inside the underscore-joined compound (`_` is a word char). Added
+    // for parity with the `api_key` / `access_token` / `refresh_token` families. NFKC
+    // is deliberately NOT introduced one-sided (TS `normalizeText` is trim/whitespace
+    // only); only affects the planning checkpoint + risk label, never the mutating
+    // backstop (a mutating action is RequiresApproval regardless).
+    "api_token",
+    "api-token",
+    "apitoken",
     "access token",
     "access_token",
     "access-token",
@@ -1323,6 +1335,13 @@ mod tests {
         assert!(is_destructive_request("save my api key for later"));
         assert!(is_destructive_request("store the refresh token please"));
         assert!(is_destructive_request("persist the apikey to disk")); // zero-sep compound key
+
+        // Audit L3: the `api_token` compound family. The underscore and zero-sep forms
+        // previously slipped the save-object co-occurrence (word-bound bare `token`
+        // can't match inside `api_token`); the hyphen form was already caught.
+        assert!(is_destructive_request("save my api_token to disk"));
+        assert!(is_destructive_request("store the api-token now"));
+        assert!(is_destructive_request("persist the apitoken"));
         assert!(is_destructive_request(
             "disable branch protection on github"
         ));


### PR DESCRIPTION
**Audit finding L3 (LOW)** — planning-gate label parity. `EN_SAVE_OBJECTS` (the `is_destructive_request` save-verb/save-object co-occurrence, `word_bound=true`) carried the `api_key` / `access_token` / `refresh_token` families but **not** the `api_token` compound. Because `_` is a word char, bare `"token"` can't match inside `api_token`/`apitoken`, so `"save my api_token …"` slipped the planning classifier — an **EN-vs-CJK asymmetry** (the CJK clause runs `word_bound=false`, so bare `token` already substring-matches the compound).

**Fix:** add `"api_token"/"api-token"/"apitoken"` to `EN_SAVE_OBJECTS` + a labeled-divergence comment. **No NFKC** (the TS oracle `normalizeText` is trim/whitespace only — a one-sided NFKC would be a silent divergence). Affects only the **planning checkpoint + risk label** (`gate.rs:197`, `planning.rs:110/666`), never the mutating-action backstop (a mutating action is `RequiresApproval` regardless).

**Rigor:** a negative-control (strings removed) proved `"save my api_token to disk"` and `"persist the apitoken"` are `false` without the addition (non-tautological); `"store the api-token now"` was already caught by bare `token` (harmless, documented). 24 `tool_policy` tests pass; clippy + fmt clean.

Reviewed by two isolated reviewers (correctness + regression/parity): PASS/PASS (both independently probed the matcher + traced the blast radius to label/planning only).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>