### PR TITLE
test(ui-device): derive workbench snapshots from explicit DB

### DIFF
--- a/scripts/ops/friday-ui-device-proof-readiness.sh
+++ b/scripts/ops/friday-ui-device-proof-readiness.sh
@@ -18,6 +18,7 @@ EVIDENCE_DIR="${FRIDAY_UI_DEVICE_PROOF_EVIDENCE_DIR:-}"
 BACKEND_LIVE_PROOF="${FRIDAY_UI_DEVICE_BACKEND_LIVE_PROOF:-}"
 CHANNEL_LIVE_PROOF="${FRIDAY_UI_DEVICE_CHANNEL_LIVE_PROOF:-}"
 OBJECTIVE_COVERAGE="${FRIDAY_UI_DEVICE_OBJECTIVE_COVERAGE:-}"
+WORKBENCH_DB="${FRIDAY_WORKBENCH_DB_PATH:-}"
 
 usage() {
   cat <<'EOF'
@@ -26,12 +27,14 @@ usage:
     [--backend-live-proof /abs/backend-proof.json]
     [--channel-live-proof /abs/channel-proof.json]
     [--objective-coverage /abs/objective-coverage.json]
+    [--workbench-db /abs/rust-hub.sqlite]
 
 optional env for live/snapshot checks:
   FRIDAY_MISSION_WORKBENCH_URL=http://127.0.0.1:5173/mission-workbench
   MISSION_ID=mission_...
   FRIDAY_WORKBENCH_SNAPSHOT_FILE=/abs/workbench-response.json
   FRIDAY_WORKBENCH_SNAPSHOT_URL=http://127.0.0.1:3141/v1/mission-spine/workbench
+  FRIDAY_WORKBENCH_DB_PATH=/abs/rust-hub.sqlite
 
 real proof env, all required to assemble:
   MOBILE_EVIDENCE=/abs/mobile.trace
@@ -47,6 +50,7 @@ evidence-dir auto-discovery:
   FRIDAY_UI_DEVICE_BACKEND_LIVE_PROOF=/abs/backend-proof.json
   FRIDAY_UI_DEVICE_CHANNEL_LIVE_PROOF=/abs/channel-proof.json
   FRIDAY_UI_DEVICE_OBJECTIVE_COVERAGE=/abs/objective-coverage.json
+  FRIDAY_WORKBENCH_DB_PATH=/abs/rust-hub.sqlite
 
   Looks for mission-id.txt or manifest mission_id plus:
     mobile.{json,trace,log,png}
@@ -108,6 +112,15 @@ while [ "$#" -gt 0 ]; do
         exit 64
       fi
       OBJECTIVE_COVERAGE="$2"
+      shift
+      ;;
+    --workbench-db)
+      if [ "$#" -lt 2 ]; then
+        echo "FATAL: --workbench-db requires a value" >&2
+        usage >&2
+        exit 64
+      fi
+      WORKBENCH_DB="$2"
       shift
       ;;
     -h|--help)
@@ -275,6 +288,50 @@ export TIMELINE_EVIDENCE="${TIMELINE_EVIDENCE:-}"
 export OBSERVATIONS_MANIFEST="${OBSERVATIONS_MANIFEST:-}"
 export SAME_RUN_EVENTS="${SAME_RUN_EVENTS:-}"
 export FRIDAY_WORKBENCH_SNAPSHOT_FILE="${FRIDAY_WORKBENCH_SNAPSHOT_FILE:-}"
+export WORKBENCH_DB="${WORKBENCH_DB:-}"
+
+blockers=()
+notes=()
+
+derive_workbench_snapshot_if_possible() {
+  if [ -n "${FRIDAY_WORKBENCH_SNAPSHOT_FILE:-}" ] || [ -n "${FRIDAY_WORKBENCH_SNAPSHOT_URL:-}" ]; then
+    return 0
+  fi
+  if [ -z "${WORKBENCH_DB:-}" ]; then
+    return 0
+  fi
+  if [ -z "${MISSION_ID:-}" ]; then
+    blockers+=("workbench_snapshot_cli:missing_MISSION_ID")
+    return 0
+  fi
+  if [ ! -s "${WORKBENCH_DB}" ]; then
+    blockers+=("workbench_snapshot_cli:db_missing_or_empty")
+    return 0
+  fi
+
+  local snapshot_out
+  local stdout_out
+  local stderr_out
+  if [ -n "$EVIDENCE_DIR" ]; then
+    snapshot_out="$(abs_path "$EVIDENCE_DIR")/workbench-snapshot.json"
+  else
+    snapshot_out="/tmp/friday-workbench-snapshot-${MISSION_ID}.json"
+  fi
+  stdout_out="${snapshot_out}.stdout"
+  stderr_out="${snapshot_out}.stderr"
+  mkdir -p "$(dirname "$snapshot_out")"
+
+  if (cd "${REPO_ROOT}/rust-core" && cargo run -p friday-hub --bin mission_workbench_projection -- \
+    --db "$(abs_path "$WORKBENCH_DB")" \
+    --mission-id "${MISSION_ID}" >"$snapshot_out") >"$stdout_out" 2>"$stderr_out"; then
+    FRIDAY_WORKBENCH_SNAPSHOT_FILE="$snapshot_out"
+    export FRIDAY_WORKBENCH_SNAPSHOT_FILE
+    notes+=("workbench_snapshot_cli:ready:${snapshot_out}")
+  else
+    local rc=$?
+    blockers+=("workbench_snapshot_cli:exit_${rc}")
+  fi
+}
 
 derive_workbench_events_if_possible() {
   if [ -z "${FRIDAY_WORKBENCH_SNAPSHOT_FILE:-}" ]; then
@@ -322,6 +379,9 @@ derive_workbench_events_if_possible() {
   fi
 }
 
+derive_workbench_snapshot_if_possible
+derive_workbench_events_if_possible
+
 have_all_evidence=1
 for name in MISSION_ID MOBILE_EVIDENCE DESKTOP_EVIDENCE CHANNEL_EVIDENCE TIMELINE_EVIDENCE OBSERVATIONS_MANIFEST; do
   if [ -z "${!name:-}" ]; then
@@ -329,15 +389,10 @@ for name in MISSION_ID MOBILE_EVIDENCE DESKTOP_EVIDENCE CHANNEL_EVIDENCE TIMELIN
   fi
 done
 
-blockers=()
-notes=()
-
-derive_workbench_events_if_possible
-
 if [ -n "$EVIDENCE_DIR" ]; then
   notes+=("evidence_dir:$(abs_path "$EVIDENCE_DIR")")
 fi
-for name in MISSION_ID MOBILE_EVIDENCE DESKTOP_EVIDENCE CHANNEL_EVIDENCE TIMELINE_EVIDENCE OBSERVATIONS_MANIFEST FRIDAY_WORKBENCH_SNAPSHOT_FILE BACKEND_LIVE_PROOF CHANNEL_LIVE_PROOF OBJECTIVE_COVERAGE; do
+for name in MISSION_ID MOBILE_EVIDENCE DESKTOP_EVIDENCE CHANNEL_EVIDENCE TIMELINE_EVIDENCE OBSERVATIONS_MANIFEST FRIDAY_WORKBENCH_SNAPSHOT_FILE WORKBENCH_DB BACKEND_LIVE_PROOF CHANNEL_LIVE_PROOF OBJECTIVE_COVERAGE; do
   if [ -n "${!name:-}" ]; then
     notes+=("resolved_${name}:${!name}")
   fi

--- a/test/unit/qa/friday-ui-device-proof-readiness-cli.test.ts
+++ b/test/unit/qa/friday-ui-device-proof-readiness-cli.test.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from "node:child_process";
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
@@ -771,6 +771,53 @@ describe("friday-ui-device-proof-readiness", () => {
         .split("\n")
         .map((line) => JSON.parse(line) as { event?: string });
       expect(rows).toContainEqual(expect.objectContaining({ event: "proof_receipt_visible_before_done" }));
+      expect(rows).toContainEqual(expect.objectContaining({ event: "mission_workbench_visible" }));
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("can derive a workbench snapshot from an explicit read-only Rust DB path", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "friday-ui-device-readiness-workbench-db-"));
+    try {
+      writePartialEvidenceDir(tempDir);
+      const fakeBin = join(tempDir, "bin");
+      const fakeDb = join(tempDir, "rust-hub.sqlite");
+      const fakeCargo = join(fakeBin, "cargo");
+      mkdirSync(fakeBin);
+      writeFileSync(fakeDb, "not-empty");
+      writeFileSync(fakeCargo, `#!/usr/bin/env bash
+set -euo pipefail
+cat <<'JSON'
+${JSON.stringify({ snapshot: makeWorkbenchSnapshot() }, null, 2)}
+JSON
+`);
+      chmodSync(fakeCargo, 0o755);
+
+      const stdout = execFileSync("bash", [
+        "scripts/ops/friday-ui-device-proof-readiness.sh",
+        "--evidence-dir",
+        tempDir,
+        "--workbench-db",
+        fakeDb,
+      ], {
+        cwd: process.cwd(),
+        env: { ...process.env, PATH: `${fakeBin}:${process.env.PATH ?? ""}` },
+        encoding: "utf8",
+      });
+      const result = JSON.parse(stdout.slice(stdout.indexOf("{"))) as {
+        notes?: string[];
+        blockers?: string[];
+      };
+
+      expect(result.notes).toContain(`workbench_snapshot_cli:ready:${join(tempDir, "workbench-snapshot.json")}`);
+      expect(result.notes?.some((note) => note.includes("workbench_snapshot_events_merge:ready"))).toBe(true);
+      expect(result.blockers).toContain("ui_device_proof_evidence:missing_required_real_evidence_env");
+
+      const rows = readFileSync(join(tempDir, "same-run-events.merged.jsonl"), "utf8")
+        .trim()
+        .split("\n")
+        .map((line) => JSON.parse(line) as { event?: string });
       expect(rows).toContainEqual(expect.objectContaining({ event: "mission_workbench_visible" }));
     } finally {
       rmSync(tempDir, { recursive: true, force: true });


### PR DESCRIPTION
## Summary
- add an explicit `--workbench-db` / `FRIDAY_WORKBENCH_DB_PATH` path to `friday-ui-device-proof-readiness.sh`
- derive a Mission Workbench snapshot with the Rust `mission_workbench_projection` binary when no snapshot file/URL is already supplied
- keep the result as diagnostic/preflight evidence only; it does not satisfy UI-device proof or END-BAR by itself

## Verification
- `bash -n scripts/ops/friday-ui-device-proof-readiness.sh`
- readiness smoke against `/tmp/friday-ui-device-live-write-read-bundle-20260625T022852Z` copied without a snapshot, with explicit read-only DB path
- `/Users/jarvis/Projects/Friday/node_modules/.bin/vitest run test/unit/qa/friday-ui-device-proof-readiness-cli.test.ts` (via temporary node_modules symlink; removed after run)

## Truth labels
- report-only / proof-readiness helper
- no prod DB mutation
- not END-BAR / not GO-LIVE / not organic proof