### PR TITLE
test(ui): report design action runtime evidence gaps

### DIFF
--- a/scripts/ops/check-friday-design-action-runtime-evidence.mjs
+++ b/scripts/ops/check-friday-design-action-runtime-evidence.mjs
@@ -1,0 +1,287 @@
+#!/usr/bin/env node
+
+import { existsSync, mkdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { dirname, isAbsolute, resolve } from "node:path";
+
+const args = process.argv.slice(2);
+
+function usage() {
+  console.error(`usage:
+  node scripts/ops/check-friday-design-action-runtime-evidence.mjs \\
+    [--repo-root=/abs/repo] \\
+    [--contract=/abs/ACTION-CONTRACT.md] \\
+    [--runtime-evidence=/abs/action-runtime-evidence.json] \\
+    [--evidence-dir=/abs/ui-device-evidence] \\
+    [--out=/abs/design-action-runtime-gap.json] \\
+    [--require-complete]
+
+Truth: compares the operator-confirmed design action contract with current native
+source and optional runtime action evidence. It never treats design-proof rows,
+static Swift bindings, or UI/device capture bundles as END-BAR completion.`);
+}
+
+function arg(name) {
+  const prefix = `--${name}=`;
+  return args.find((value) => value.startsWith(prefix))?.slice(prefix.length) || "";
+}
+
+if (args.includes("--help") || args.includes("-h")) {
+  usage();
+  process.exit(0);
+}
+
+const requireComplete = args.includes("--require-complete");
+const repoRoot = resolve(arg("repo-root") || process.env.FRIDAY_REPO_ROOT || new URL("../..", import.meta.url).pathname);
+const defaultContract = `${process.env.HOME || "/Users/jarvis"}/Desktop/friday-design-handoff-20260602/ACTION-CONTRACT.md`;
+const contractPath = resolve(arg("contract") || process.env.FRIDAY_DESIGN_ACTION_CONTRACT || defaultContract);
+const evidenceDir = arg("evidence-dir") || process.env.FRIDAY_UI_DEVICE_PROOF_EVIDENCE_DIR || "";
+const runtimeEvidenceArg = arg("runtime-evidence")
+  || process.env.FRIDAY_DESIGN_ACTION_RUNTIME_EVIDENCE
+  || (evidenceDir ? `${evidenceDir}/action-runtime-evidence.json` : "");
+const runtimeEvidencePath = runtimeEvidenceArg ? resolve(runtimeEvidenceArg) : "";
+const outPath = arg("out") || process.env.FRIDAY_DESIGN_ACTION_RUNTIME_REPORT || "";
+const blockers = [];
+
+function block(code, detail) {
+  blockers.push({ code, detail });
+}
+
+function readOptional(path) {
+  if (!path || !existsSync(path)) return "";
+  return readFileSync(path, "utf8");
+}
+
+function requireFile(path, label) {
+  if (!path) {
+    block("missing_file", label);
+    return "";
+  }
+  if (!isAbsolute(path)) {
+    block("path_not_absolute", `${label}:${path}`);
+    return "";
+  }
+  try {
+    const stats = statSync(path);
+    if (!stats.isFile()) block("not_file", `${label}:${path}`);
+    if (stats.size <= 0) block("empty_file", `${label}:${path}`);
+  } catch {
+    block("unreadable_file", `${label}:${path}`);
+  }
+  return path;
+}
+
+function splitMarkdownRow(line) {
+  const trimmed = line.trim();
+  if (!trimmed.startsWith("|") || !trimmed.endsWith("|")) return [];
+  return trimmed
+    .slice(1, -1)
+    .split("|")
+    .map((cell) => cell.trim().replace(/`/g, ""));
+}
+
+function parseActionContract(path) {
+  const contractFile = requireFile(path, "action-contract");
+  if (!contractFile) return [];
+  const source = readFileSync(contractFile, "utf8");
+  if (!source.includes("design-proof") || !source.includes("wired_registry ≠ runtime PASS")) {
+    block("contract_missing_truth_boundary", path);
+  }
+  const rows = [];
+  for (const line of source.split(/\r?\n/)) {
+    if (!line.startsWith("|")) continue;
+    const cells = splitMarkdownRow(line);
+    if (cells.length < 9) continue;
+    if (cells[0] === "---" || cells[0] === "Surface") continue;
+    const [surface, rawScreen, actionId, label, capabilityId, , regStatus, truthStatus, resultTarget, ownerGateTest] = cells;
+    if (!surface || !rawScreen || !actionId) continue;
+    const screen = rawScreen.replace(/\s+\[.*\]$/, "");
+    rows.push({
+      surface,
+      screen,
+      screenState: rawScreen,
+      actionId,
+      label,
+      capabilityId,
+      regStatus,
+      truthStatus,
+      resultTarget,
+      ownerGateTest,
+      actionable: isActionable({ surface, actionId, capabilityId, truthStatus, resultTarget }),
+    });
+  }
+  return rows;
+}
+
+function isActionable(row) {
+  if (!["mobile", "desktop"].includes(row.surface)) return false;
+  if (["disabled", "caprow"].includes(row.actionId)) return false;
+  if (["action_local", "navigation_local"].includes(row.capabilityId)) return false;
+  if (row.truthStatus === "historical" || row.truthStatus === "release_only") return false;
+  if (String(row.resultTarget || "").startsWith("result:disabled")) return false;
+  return true;
+}
+
+function readSources(paths) {
+  return paths.map((relative) => readOptional(resolve(repoRoot, relative))).join("\n");
+}
+
+const nativeSources = {
+  mobile: readSources([
+    "apps/friday-ios/Sources/FridayMobileShell/CommandSheet.swift",
+    "apps/friday-ios/Sources/FridayMobileShell/FridayApp.swift",
+    "apps/friday-ios/Sources/FridayMobileShell/FridayHomeScreen.swift",
+    "apps/friday-ios/Sources/FridayMobileShell/FridayChatScreen.swift",
+    "apps/friday-ios/Sources/FridayMobileShell/FridaySessionDetailScreen.swift",
+    "apps/friday-ios/Sources/FridayMobileShell/FridayContextPassportScreen.swift",
+    "apps/friday-ios/Sources/FridayMobileShell/FridayProviderAuthScreen.swift",
+    "apps/friday-ios/Sources/FridayMobileShell/FridayShareIntakeScreen.swift",
+    "apps/friday-ios/Sources/FridayMobileShell/FridayTokenLedgerScreen.swift",
+    "apps/friday-ios/Sources/FridayMobileShell/FridayVoiceScreen.swift",
+    "apps/friday-ios/Sources/FridayMobileShell/FridayProjectionScreens.swift",
+    "apps/friday-ios/Sources/FridayMobileShellCore/HomeViewModel.swift",
+    "apps/friday-ios/Sources/FridayMobileShellCore/FridayChatViewModel.swift",
+    "apps/friday-ios/Sources/FridayMobileShellCore/SessionContinuationViewModel.swift",
+    "apps/friday-ios/Sources/FridayMobileShellCore/ShareIntakeViewModel.swift",
+    "apps/friday-ios/Sources/FridayMobileShellCore/VoiceReadinessViewModel.swift",
+  ]),
+  desktop: readSources([
+    "apps/macos/FridayHubConsole/Sources/FridayHubConsole/Navigation.swift",
+    "apps/macos/FridayHubConsole/Sources/FridayHubConsole/OperationsOverviewScreen.swift",
+    "apps/macos/FridayHubConsole/Sources/FridayHubConsole/DesktopChatScreen.swift",
+    "apps/macos/FridayHubConsole/Sources/FridayHubConsole/DesktopProjectionScreens.swift",
+    "apps/macos/FridayHubConsole/Sources/FridayHubConsole/PairingProvisioningScreen.swift",
+    "apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/OperationsOverviewViewModel.swift",
+  ]),
+};
+
+function normalizedWords(value) {
+  return String(value || "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, " ")
+    .split(/\s+/)
+    .filter((word) => word.length >= 3);
+}
+
+function nativeHint(row) {
+  const source = nativeSources[row.surface] || "";
+  if (!source) return "source_missing";
+  const lower = source.toLowerCase();
+  const screenWords = normalizedWords(row.screen);
+  const labelWords = normalizedWords(row.label);
+  const capabilityWords = normalizedWords(row.capabilityId.replace(/_/g, " "));
+  const screenHit = screenWords.length === 0 || screenWords.some((word) => lower.includes(word));
+  const labelHit = labelWords.length === 0 || labelWords.some((word) => lower.includes(word));
+  const capabilityHit = capabilityWords.slice(0, 2).some((word) => lower.includes(word));
+  if (screenHit && (labelHit || capabilityHit)) return "native_source_hint_present_not_runtime_proof";
+  if (screenHit) return "screen_hint_present_action_unproven";
+  return "native_hint_missing";
+}
+
+function readRuntimeEvidence(path) {
+  if (!path || !existsSync(path)) return [];
+  try {
+    const value = JSON.parse(readFileSync(path, "utf8"));
+    const rows = Array.isArray(value) ? value : Array.isArray(value.actions) ? value.actions : [];
+    return rows
+      .filter((row) => row && typeof row === "object")
+      .map((row) => ({
+        surface: String(row.surface || ""),
+        screen: String(row.screen || ""),
+        actionId: String(row.action_id || row.actionId || ""),
+        capabilityId: String(row.capability_id || row.capabilityId || ""),
+        status: String(row.status || ""),
+        evidenceRef: String(row.evidence_ref || row.evidenceRef || ""),
+      }));
+  } catch {
+    block("runtime_evidence_invalid_json", path);
+    return [];
+  }
+}
+
+function runtimeEvidenceFor(row, runtimeRows) {
+  return runtimeRows.find((candidate) => {
+    if (candidate.status !== "pass") return false;
+    if (candidate.surface && candidate.surface !== row.surface) return false;
+    if (candidate.screen && candidate.screen !== row.screen) return false;
+    return candidate.actionId === row.actionId || candidate.capabilityId === row.capabilityId;
+  }) || null;
+}
+
+function summarizeBy(rows, key) {
+  const counts = new Map();
+  for (const row of rows) {
+    const value = row[key] || "unknown";
+    counts.set(value, (counts.get(value) || 0) + 1);
+  }
+  return Object.fromEntries([...counts.entries()].sort((a, b) => String(a[0]).localeCompare(String(b[0]))));
+}
+
+const contractRows = parseActionContract(contractPath);
+const runtimeRows = readRuntimeEvidence(runtimeEvidencePath);
+const actionableRows = contractRows.filter((row) => row.actionable);
+const evidenceRows = actionableRows.map((row) => {
+  const runtime = runtimeEvidenceFor(row, runtimeRows);
+  return {
+    surface: row.surface,
+    screen: row.screen,
+    screenState: row.screenState,
+    actionId: row.actionId,
+    label: row.label,
+    capabilityId: row.capabilityId,
+    truthStatus: row.truthStatus,
+    nativeStatus: nativeHint(row),
+    runtimeStatus: runtime ? "runtime_action_evidence_pass" : "runtime_action_evidence_missing",
+    evidenceRef: runtime?.evidenceRef || null,
+  };
+});
+
+const missingRuntime = evidenceRows.filter((row) => row.runtimeStatus !== "runtime_action_evidence_pass");
+const missingNative = evidenceRows.filter((row) => row.nativeStatus === "native_hint_missing" || row.nativeStatus === "source_missing");
+const topMissing = missingRuntime.slice(0, 40).map((row) => ({
+  surface: row.surface,
+  screen: row.screen,
+  actionId: row.actionId,
+  label: row.label,
+  capabilityId: row.capabilityId,
+  preferredEvidence: `${row.surface}/${row.screen}/${row.actionId}`,
+}));
+
+const report = {
+  truth: "design_action_runtime_gap_report_not_endbar_not_runtime_adoption",
+  status: blockers.length === 0 && missingRuntime.length === 0 ? "runtime_actions_covered" : "gaps_present",
+  repoRoot,
+  contract: contractPath,
+  runtimeEvidence: existsSync(runtimeEvidencePath) ? runtimeEvidencePath : null,
+  counts: {
+    contractRows: contractRows.length,
+    actionableRows: actionableRows.length,
+    runtimeEvidenceRows: runtimeRows.length,
+    missingRuntimeEvidence: missingRuntime.length,
+    missingNativeHints: missingNative.length,
+  },
+  bySurface: summarizeBy(actionableRows, "surface"),
+  byTruthStatus: summarizeBy(actionableRows, "truthStatus"),
+  gaps: {
+    missingRuntimeEvidence: topMissing,
+    missingNativeHints: missingNative.slice(0, 40),
+  },
+  capturePlan: [
+    ...new Set(topMissing.map((row) => `${row.surface}:${row.screen}`)),
+  ].slice(0, 24).map((target) => ({
+    target,
+    required: "capture a real same-run UI action observation with surface, screen, action_id/capability_id, status=pass, and evidence_ref",
+    truth: "real_runtime_action_evidence_only_no_design_proof_upgrade",
+  })),
+  blockers,
+  caveat: "Design action rows and native source hints are not runtime proof. Missing runtime evidence means the action cannot be counted toward END-BAR even when design and Swift bindings exist.",
+};
+
+if (outPath) {
+  const out = isAbsolute(outPath) ? outPath : resolve(outPath);
+  mkdirSync(dirname(out), { recursive: true });
+  writeFileSync(out, `${JSON.stringify(report, null, 2)}\n`);
+}
+
+console.log(JSON.stringify(report, null, 2));
+const complete = report.status === "runtime_actions_covered";
+process.exit((complete || !requireComplete) && blockers.length === 0 ? 0 : 2);

--- a/scripts/ops/friday-ui-device-proof-readiness.sh
+++ b/scripts/ops/friday-ui-device-proof-readiness.sh
@@ -19,6 +19,8 @@ BACKEND_LIVE_PROOF="${FRIDAY_UI_DEVICE_BACKEND_LIVE_PROOF:-}"
 CHANNEL_LIVE_PROOF="${FRIDAY_UI_DEVICE_CHANNEL_LIVE_PROOF:-}"
 OBJECTIVE_COVERAGE="${FRIDAY_UI_DEVICE_OBJECTIVE_COVERAGE:-}"
 WORKBENCH_DB="${FRIDAY_WORKBENCH_DB_PATH:-}"
+DESIGN_ACTION_CONTRACT="${FRIDAY_DESIGN_ACTION_CONTRACT:-}"
+DESIGN_ACTION_RUNTIME_EVIDENCE="${FRIDAY_DESIGN_ACTION_RUNTIME_EVIDENCE:-}"
 
 usage() {
   cat <<'EOF'
@@ -28,6 +30,8 @@ usage:
     [--channel-live-proof /abs/channel-proof.json]
     [--objective-coverage /abs/objective-coverage.json]
     [--workbench-db /abs/rust-hub.sqlite]
+    [--design-action-contract /abs/ACTION-CONTRACT.md]
+    [--design-action-runtime-evidence /abs/action-runtime-evidence.json]
 
 optional env for live/snapshot checks:
   FRIDAY_MISSION_WORKBENCH_URL=http://127.0.0.1:5173/mission-workbench
@@ -51,6 +55,8 @@ evidence-dir auto-discovery:
   FRIDAY_UI_DEVICE_CHANNEL_LIVE_PROOF=/abs/channel-proof.json
   FRIDAY_UI_DEVICE_OBJECTIVE_COVERAGE=/abs/objective-coverage.json
   FRIDAY_WORKBENCH_DB_PATH=/abs/rust-hub.sqlite
+  FRIDAY_DESIGN_ACTION_CONTRACT=/abs/ACTION-CONTRACT.md
+  FRIDAY_DESIGN_ACTION_RUNTIME_EVIDENCE=/abs/action-runtime-evidence.json
 
   Looks for mission-id.txt or manifest mission_id plus:
     mobile.{json,trace,log,png}
@@ -121,6 +127,24 @@ while [ "$#" -gt 0 ]; do
         exit 64
       fi
       WORKBENCH_DB="$2"
+      shift
+      ;;
+    --design-action-contract)
+      if [ "$#" -lt 2 ]; then
+        echo "FATAL: --design-action-contract requires a value" >&2
+        usage >&2
+        exit 64
+      fi
+      DESIGN_ACTION_CONTRACT="$2"
+      shift
+      ;;
+    --design-action-runtime-evidence)
+      if [ "$#" -lt 2 ]; then
+        echo "FATAL: --design-action-runtime-evidence requires a value" >&2
+        usage >&2
+        exit 64
+      fi
+      DESIGN_ACTION_RUNTIME_EVIDENCE="$2"
       shift
       ;;
     -h|--help)
@@ -271,6 +295,11 @@ discover_evidence_dir() {
       "$dir/mission-spine-objective-coverage.json" \
       "$dir/mission-spine-objective-coverage-gate.json" || true)"
   fi
+  if [ -z "${DESIGN_ACTION_RUNTIME_EVIDENCE:-}" ]; then
+    DESIGN_ACTION_RUNTIME_EVIDENCE="$(first_existing \
+      "$dir/action-runtime-evidence.json" \
+      "$dir/design-action-runtime-evidence.json" || true)"
+  fi
 }
 
 json_escape() {
@@ -289,6 +318,8 @@ export OBSERVATIONS_MANIFEST="${OBSERVATIONS_MANIFEST:-}"
 export SAME_RUN_EVENTS="${SAME_RUN_EVENTS:-}"
 export FRIDAY_WORKBENCH_SNAPSHOT_FILE="${FRIDAY_WORKBENCH_SNAPSHOT_FILE:-}"
 export WORKBENCH_DB="${WORKBENCH_DB:-}"
+export DESIGN_ACTION_CONTRACT="${DESIGN_ACTION_CONTRACT:-}"
+export DESIGN_ACTION_RUNTIME_EVIDENCE="${DESIGN_ACTION_RUNTIME_EVIDENCE:-}"
 
 blockers=()
 notes=()
@@ -400,6 +431,12 @@ done
 if [ -n "${SAME_RUN_EVENTS:-}" ]; then
   notes+=("resolved_SAME_RUN_EVENTS:${SAME_RUN_EVENTS}")
 fi
+if [ -n "${DESIGN_ACTION_CONTRACT:-}" ]; then
+  notes+=("resolved_DESIGN_ACTION_CONTRACT:${DESIGN_ACTION_CONTRACT}")
+fi
+if [ -n "${DESIGN_ACTION_RUNTIME_EVIDENCE:-}" ]; then
+  notes+=("resolved_DESIGN_ACTION_RUNTIME_EVIDENCE:${DESIGN_ACTION_RUNTIME_EVIDENCE}")
+fi
 
 run_step() {
   local label="$1"
@@ -476,6 +513,51 @@ run_gap_report_if_possible() {
   fi
 }
 
+run_design_action_gap_if_possible() {
+  local contract="${DESIGN_ACTION_CONTRACT:-}"
+  if [ -z "$contract" ] && [ -s "$HOME/Desktop/friday-design-handoff-20260602/ACTION-CONTRACT.md" ]; then
+    contract="$HOME/Desktop/friday-design-handoff-20260602/ACTION-CONTRACT.md"
+  fi
+  if [ -z "$contract" ]; then
+    return 0
+  fi
+
+  local design_gap_out
+  local stdout_out
+  local status
+  if [ -n "$EVIDENCE_DIR" ]; then
+    design_gap_out="$(abs_path "$EVIDENCE_DIR")/design-action-runtime-gap.json"
+  else
+    design_gap_out="/tmp/friday-design-action-runtime-gap.json"
+  fi
+  stdout_out="${design_gap_out}.stdout"
+
+  local args=(
+    "${REPO_ROOT}/scripts/ops/check-friday-design-action-runtime-evidence.mjs"
+    "--repo-root=${REPO_ROOT}"
+    "--contract=$(abs_path "$contract")"
+    "--out=${design_gap_out}"
+  )
+  if [ -n "${EVIDENCE_DIR:-}" ]; then
+    args+=("--evidence-dir=$(abs_path "$EVIDENCE_DIR")")
+  fi
+  if [ -n "${DESIGN_ACTION_RUNTIME_EVIDENCE:-}" ]; then
+    args+=("--runtime-evidence=$(abs_path "$DESIGN_ACTION_RUNTIME_EVIDENCE")")
+  fi
+
+  mkdir -p "$(dirname "$design_gap_out")"
+  if node "${args[@]}" >"$stdout_out"; then
+    status="$(jq -r '.status // "unknown"' "$design_gap_out" 2>/dev/null || printf 'unknown')"
+    notes+=("design_action_runtime_gap:${status}:${design_gap_out}")
+    if [ "$status" != "runtime_actions_covered" ] && [ "${MODE}" = "require-proof" ]; then
+      blockers+=("design_action_runtime_gap:${status}")
+    fi
+  else
+    local rc=$?
+    blockers+=("design_action_runtime_gap:exit_${rc}")
+  fi
+}
+
 EXPECT_NOT_READY_ARGS=(--expect-not-ready)
 if [ "${MODE}" = "require-proof" ]; then
   EXPECT_NOT_READY_ARGS=()
@@ -529,6 +611,7 @@ else
 fi
 
 run_gap_report_if_possible
+run_design_action_gap_if_possible
 
 if [ "${MODE}" = "require-proof" ]; then
   printf 'FATAL: UI/device proof not assembled. blockers=%s\n' "${blockers[*]}" >&2

--- a/test/unit/qa/friday-design-action-runtime-evidence-cli.test.ts
+++ b/test/unit/qa/friday-design-action-runtime-evidence-cli.test.ts
@@ -1,0 +1,120 @@
+import { execFileSync, spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const script = "scripts/ops/check-friday-design-action-runtime-evidence.mjs";
+
+function writeFile(root: string, relative: string, body: string) {
+  const target = join(root, relative);
+  mkdirSync(dirname(target), { recursive: true });
+  writeFileSync(target, body);
+  return target;
+}
+
+function contractBody() {
+  return `# Friday Action Contract — mobile + desktop
+
+**This is a wiring contract for the later Rust/native agent, NOT runtime proof.** Every row is design-proof; wired_registry ≠ runtime PASS.
+
+| Surface | Screen [state] | action_id | Label | capability_id | reg | reg_status | truth_status | result/target | Rust/Hub owner · gate · test expectation |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| mobile | fridayChat | act | Send to Friday | ask_friday_chat_compose_send | ✓ | wired | wired_registry | result:submitted | Runtime test must prove gate enforcement. |
+| desktop | fridayChat | check | Approve | security_approval_bound_principal_gate_cat10_netnew | ✓ | wired | wired_registry | result:confirmed | Runtime test must prove gate enforcement. |
+| mobile | voice | disabled | Voice backend unavailable | action_local | · | local | design_proof | result:disabled:reference | Local affordance only. |
+`;
+}
+
+function fixtureRepo() {
+  const root = mkdtempSync(join(tmpdir(), "friday-design-action-runtime-"));
+  writeFile(root, "apps/friday-ios/Sources/FridayMobileShell/FridayChatScreen.swift", "struct FridayChatScreen { Button(\"Send to Friday\") {} }");
+  writeFile(root, "apps/friday-ios/Sources/FridayMobileShellCore/FridayChatViewModel.swift", "func send() {}");
+  writeFile(root, "apps/macos/FridayHubConsole/Sources/FridayHubConsole/DesktopChatScreen.swift", "struct DesktopChatScreen { Button(\"Approve\") {} }");
+  writeFile(root, "apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/OperationsOverviewViewModel.swift", "func approveNeedsMeItem() {}");
+  const contract = writeFile(root, "ACTION-CONTRACT.md", contractBody());
+  return { root, contract };
+}
+
+describe("check-friday-design-action-runtime-evidence", () => {
+  it("reports design action runtime gaps without counting static Swift hints as proof", () => {
+    const { root, contract } = fixtureRepo();
+    try {
+      const output = execFileSync("node", [
+        script,
+        `--repo-root=${root}`,
+        `--contract=${contract}`,
+      ], { cwd: process.cwd(), encoding: "utf8" });
+      const report = JSON.parse(output) as {
+        truth?: string;
+        status?: string;
+        counts?: { actionableRows?: number; missingRuntimeEvidence?: number };
+        gaps?: { missingRuntimeEvidence?: Array<{ actionId?: string }> };
+      };
+      expect(report.truth).toBe("design_action_runtime_gap_report_not_endbar_not_runtime_adoption");
+      expect(report.status).toBe("gaps_present");
+      expect(report.counts?.actionableRows).toBe(2);
+      expect(report.counts?.missingRuntimeEvidence).toBe(2);
+      expect(report.gaps?.missingRuntimeEvidence).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ actionId: "act" }),
+          expect.objectContaining({ actionId: "check" }),
+        ]),
+      );
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("accepts explicit runtime action evidence but still requires real evidence for every actionable row", () => {
+    const { root, contract } = fixtureRepo();
+    try {
+      const runtime = writeFile(root, "action-runtime-evidence.json", JSON.stringify({
+        actions: [
+          {
+            surface: "mobile",
+            screen: "fridayChat",
+            action_id: "act",
+            status: "pass",
+            evidence_ref: "proof://mobile/send",
+          },
+        ],
+      }, null, 2));
+      const output = execFileSync("node", [
+        script,
+        `--repo-root=${root}`,
+        `--contract=${contract}`,
+        `--runtime-evidence=${runtime}`,
+      ], { cwd: process.cwd(), encoding: "utf8" });
+      const report = JSON.parse(output) as {
+        status?: string;
+        counts?: { missingRuntimeEvidence?: number };
+        gaps?: { missingRuntimeEvidence?: Array<{ surface?: string; actionId?: string }> };
+      };
+      expect(report.status).toBe("gaps_present");
+      expect(report.counts?.missingRuntimeEvidence).toBe(1);
+      expect(report.gaps?.missingRuntimeEvidence).toEqual([
+        expect.objectContaining({ surface: "desktop", actionId: "check" }),
+      ]);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("fails closed in require-complete mode while runtime evidence is incomplete", () => {
+    const { root, contract } = fixtureRepo();
+    try {
+      const result = spawnSync("node", [
+        script,
+        `--repo-root=${root}`,
+        `--contract=${contract}`,
+        "--require-complete",
+      ], { cwd: process.cwd(), encoding: "utf8" });
+      expect(result.status).toBe(2);
+      const report = JSON.parse(result.stdout) as { status?: string };
+      expect(report.status).toBe("gaps_present");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add a report-only checker that compares the operator-confirmed ACTION-CONTRACT rows against current native source hints and explicit runtime action evidence
- integrate the design-action gap report into the UI/device proof readiness wrapper without upgrading design-proof or static Swift bindings into END-BAR proof
- add focused CLI coverage for missing runtime evidence, partial explicit evidence, and require-complete fail-closed behavior

## Verification
- node scripts/ops/check-friday-design-action-runtime-evidence.mjs --repo-root=/private/tmp/friday-ui-evidence-closure-20260624 --contract=/Users/jarvis/Desktop/friday-design-handoff-20260602/ACTION-CONTRACT.md --out=/tmp/friday-design-action-runtime-gap-current.json
- npx vitest run test/unit/qa/friday-design-action-runtime-evidence-cli.test.ts test/unit/qa/friday-ui-device-proof-readiness-cli.test.ts

## Truth labels
- report-only; not END-BAR, not GO-LIVE, not adoption
- current real ACTION-CONTRACT read reports 935 contract rows, 78 actionable rows, and 78 missing runtime action evidence rows until real same-run action evidence is captured
