### PR TITLE
test(ui): export explicit runtime action evidence

### DIFF
--- a/scripts/ops/friday-ios-live-write-read-proof-events.mjs
+++ b/scripts/ops/friday-ios-live-write-read-proof-events.mjs
@@ -9,11 +9,14 @@ function usage() {
   console.error(`usage:
   node scripts/ops/friday-ios-live-write-read-proof-events.mjs \\
     --proof=/abs/friday-ios-mobile-roundtrip-proof.json \\
-    [--out=/abs/mobile-roundtrip-events.jsonl] [--require-ready]
+    [--out=/abs/mobile-roundtrip-events.jsonl] \\
+    [--action-runtime-out=/abs/action-runtime-evidence.json] [--require-ready]
 
 Truth: converts one real iOS live write-read roundtrip artifact into mobile
 same-run events for the UI/device capture pipeline. It is not END-BAR proof,
-does not invent desktop/channel/timeline observations, and never reads secrets.`);
+does not invent desktop/channel/timeline observations, and never reads secrets.
+Optional action runtime evidence is exported only when the proof artifact already
+contains explicit ui_actions rows from a real UI driver.`);
 }
 
 function arg(name) {
@@ -28,6 +31,7 @@ if (args.includes("--help") || args.includes("-h")) {
 
 const proofPath = arg("proof");
 const outPath = arg("out");
+const actionRuntimeOutPath = arg("action-runtime-out");
 const requireReady = args.includes("--require-ready");
 const blockers = [];
 
@@ -68,6 +72,44 @@ function arrayField(value, field, label) {
 
 function optionalArrayField(value, field) {
   return value && Array.isArray(value[field]) ? value[field] : [];
+}
+
+function explicitActionRows(value) {
+  if (!value || value.ui_actions === undefined) return [];
+  if (!Array.isArray(value.ui_actions)) {
+    block("ui_actions_not_array", "proof.ui_actions");
+    return [];
+  }
+
+  return value.ui_actions.map((row, index) => {
+    const label = `proof.ui_actions[${index}]`;
+    if (!row || typeof row !== "object") {
+      block("ui_action_not_object", label);
+      return null;
+    }
+    const surface = typeof row.surface === "string" && row.surface.trim() ? row.surface.trim() : "mobile";
+    const screen = typeof row.screen === "string" && row.screen.trim() ? row.screen.trim() : "";
+    const actionId = typeof row.action_id === "string" && row.action_id.trim() ? row.action_id.trim() : "";
+    const capabilityId = typeof row.capability_id === "string" && row.capability_id.trim() ? row.capability_id.trim() : "";
+    const status = typeof row.status === "string" && row.status.trim() ? row.status.trim() : "";
+    const evidence = typeof row.evidence_ref === "string" && row.evidence_ref.trim() ? row.evidence_ref.trim() : evidenceRef;
+    if (surface !== "mobile") block("ui_action_surface_mismatch", `${label}:${surface}`);
+    if (!screen) block("ui_action_missing_screen", label);
+    if (!actionId && !capabilityId) block("ui_action_missing_action_or_capability", label);
+    if (status !== "pass") block("ui_action_status_not_pass", `${label}:${status || "<missing>"}`);
+    return {
+      surface,
+      screen,
+      action_id: actionId,
+      capability_id: capabilityId,
+      status,
+      evidence_ref: evidence,
+      mission_id: missionId,
+      work_item_id: workItemId,
+      source: "ios_mobile_live_write_read_roundtrip_explicit_ui_actions",
+      truth_label: "explicit_ui_action_runtime_evidence_not_endbar_not_adoption",
+    };
+  }).filter(Boolean);
 }
 
 if (!proofPath) block("missing_arg", "proof");
@@ -144,11 +186,22 @@ const events = blockers.length === 0
     truth_label: "mobile_same_run_event_from_live_write_read_artifact_not_ui_device_proof",
   }))
   : [];
+const actionRows = blockers.length === 0 ? explicitActionRows(proof) : [];
 
 if (outPath && blockers.length === 0) {
   const out = abs(outPath);
   mkdirSync(dirname(out), { recursive: true });
   writeFileSync(out, `${events.map((event) => JSON.stringify(event)).join("\n")}\n`);
+}
+if (actionRuntimeOutPath && blockers.length === 0) {
+  const out = abs(actionRuntimeOutPath);
+  mkdirSync(dirname(out), { recursive: true });
+  writeFileSync(out, `${JSON.stringify({
+    truth: "action_runtime_evidence_from_explicit_ios_ui_actions_not_endbar",
+    status: actionRows.length > 0 ? "ready" : "no_explicit_ui_actions",
+    missionId: missionId || null,
+    actions: actionRows,
+  }, null, 2)}\n`);
 }
 
 const output = {
@@ -159,6 +212,11 @@ const output = {
   evidenceRef: evidenceRef || null,
   out: outPath ? abs(outPath) : null,
   eventCount: events.length,
+  actionRuntimeEvidence: {
+    out: actionRuntimeOutPath ? abs(actionRuntimeOutPath) : null,
+    count: actionRows.length,
+    status: actionRows.length > 0 ? "ready" : "no_explicit_ui_actions",
+  },
   blockers,
   caveat: "Mobile same-run events only; combine with real desktop/channel/timeline evidence before strict UI/device proof.",
 };

--- a/scripts/ops/friday-macos-live-write-read-proof-events.mjs
+++ b/scripts/ops/friday-macos-live-write-read-proof-events.mjs
@@ -9,11 +9,14 @@ function usage() {
   console.error(`usage:
   node scripts/ops/friday-macos-live-write-read-proof-events.mjs \\
     --proof=/abs/friday-macos-desktop-roundtrip-proof.json \\
-    [--out=/abs/desktop-roundtrip-events.jsonl] [--require-ready]
+    [--out=/abs/desktop-roundtrip-events.jsonl] \\
+    [--action-runtime-out=/abs/action-runtime-evidence.json] [--require-ready]
 
 Truth: converts one real macOS live write-read roundtrip artifact into desktop
 same-run events for the UI/device capture pipeline. It is not END-BAR proof,
-does not invent mobile/channel/timeline observations, and never reads secrets.`);
+does not invent mobile/channel/timeline observations, and never reads secrets.
+Optional action runtime evidence is exported only when the proof artifact already
+contains explicit ui_actions rows from a real UI driver.`);
 }
 
 function arg(name) {
@@ -28,6 +31,7 @@ if (args.includes("--help") || args.includes("-h")) {
 
 const proofPath = arg("proof");
 const outPath = arg("out");
+const actionRuntimeOutPath = arg("action-runtime-out");
 const requireReady = args.includes("--require-ready");
 const blockers = [];
 
@@ -68,6 +72,44 @@ function arrayField(value, field, label) {
 
 function optionalArrayField(value, field) {
   return value && Array.isArray(value[field]) ? value[field] : [];
+}
+
+function explicitActionRows(value) {
+  if (!value || value.ui_actions === undefined) return [];
+  if (!Array.isArray(value.ui_actions)) {
+    block("ui_actions_not_array", "proof.ui_actions");
+    return [];
+  }
+
+  return value.ui_actions.map((row, index) => {
+    const label = `proof.ui_actions[${index}]`;
+    if (!row || typeof row !== "object") {
+      block("ui_action_not_object", label);
+      return null;
+    }
+    const surface = typeof row.surface === "string" && row.surface.trim() ? row.surface.trim() : "desktop";
+    const screen = typeof row.screen === "string" && row.screen.trim() ? row.screen.trim() : "";
+    const actionId = typeof row.action_id === "string" && row.action_id.trim() ? row.action_id.trim() : "";
+    const capabilityId = typeof row.capability_id === "string" && row.capability_id.trim() ? row.capability_id.trim() : "";
+    const status = typeof row.status === "string" && row.status.trim() ? row.status.trim() : "";
+    const evidence = typeof row.evidence_ref === "string" && row.evidence_ref.trim() ? row.evidence_ref.trim() : evidenceRef;
+    if (surface !== "desktop") block("ui_action_surface_mismatch", `${label}:${surface}`);
+    if (!screen) block("ui_action_missing_screen", label);
+    if (!actionId && !capabilityId) block("ui_action_missing_action_or_capability", label);
+    if (status !== "pass") block("ui_action_status_not_pass", `${label}:${status || "<missing>"}`);
+    return {
+      surface,
+      screen,
+      action_id: actionId,
+      capability_id: capabilityId,
+      status,
+      evidence_ref: evidence,
+      mission_id: missionId,
+      work_item_id: workItemId,
+      source: "macos_desktop_live_write_read_roundtrip_explicit_ui_actions",
+      truth_label: "explicit_ui_action_runtime_evidence_not_endbar_not_adoption",
+    };
+  }).filter(Boolean);
 }
 
 if (!proofPath) block("missing_arg", "proof");
@@ -144,11 +186,22 @@ const events = blockers.length === 0
     truth_label: "desktop_same_run_event_from_live_write_read_artifact_not_ui_device_proof",
   }))
   : [];
+const actionRows = blockers.length === 0 ? explicitActionRows(proof) : [];
 
 if (outPath && blockers.length === 0) {
   const out = abs(outPath);
   mkdirSync(dirname(out), { recursive: true });
   writeFileSync(out, `${events.map((event) => JSON.stringify(event)).join("\n")}\n`);
+}
+if (actionRuntimeOutPath && blockers.length === 0) {
+  const out = abs(actionRuntimeOutPath);
+  mkdirSync(dirname(out), { recursive: true });
+  writeFileSync(out, `${JSON.stringify({
+    truth: "action_runtime_evidence_from_explicit_macos_ui_actions_not_endbar",
+    status: actionRows.length > 0 ? "ready" : "no_explicit_ui_actions",
+    missionId: missionId || null,
+    actions: actionRows,
+  }, null, 2)}\n`);
 }
 
 const output = {
@@ -159,6 +212,11 @@ const output = {
   evidenceRef: evidenceRef || null,
   out: outPath ? abs(outPath) : null,
   eventCount: events.length,
+  actionRuntimeEvidence: {
+    out: actionRuntimeOutPath ? abs(actionRuntimeOutPath) : null,
+    count: actionRows.length,
+    status: actionRows.length > 0 ? "ready" : "no_explicit_ui_actions",
+  },
   blockers,
   caveat: "Desktop same-run events only; combine with real mobile/channel/timeline evidence before strict UI/device proof.",
 };

--- a/test/unit/qa/friday-ios-live-write-read-proof-events-cli.test.ts
+++ b/test/unit/qa/friday-ios-live-write-read-proof-events-cli.test.ts
@@ -58,6 +58,7 @@ describe("friday-ios-live-write-read-proof-events", () => {
       const result = JSON.parse(stdout) as { status?: string; eventCount?: number; blockers?: unknown[] };
       expect(result.status).toBe("ready");
       expect(result.eventCount).toBe(5);
+      expect(JSON.stringify(result)).toContain("no_explicit_ui_actions");
       expect(result.blockers).toEqual([]);
 
       const rows = readFileSync(outPath, "utf8").trim().split("\n").map((line) => JSON.parse(line)) as Array<{
@@ -78,6 +79,83 @@ describe("friday-ios-live-write-read-proof-events", () => {
       expect(new Set(rows.map((row) => row.mission_id))).toEqual(new Set([missionId]));
       expect(new Set(rows.map((row) => row.work_item_id))).toEqual(new Set([workItemId]));
       expect(new Set(rows.map((row) => row.evidence_ref))).toEqual(new Set([proofPath]));
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("exports action runtime evidence only from explicit UI action rows", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "friday-ios-roundtrip-action-events-"));
+    try {
+      const proofPath = writeProof(tempDir, proof({
+        ui_actions: [
+          {
+            surface: "mobile",
+            screen: "fridayChat",
+            action_id: "chat:typing",
+            capability_id: "ask_friday_chat",
+            status: "pass",
+            evidence_ref: "proof://mobile-chat-send",
+          },
+        ],
+      }));
+      const actionOut = join(tempDir, "action-runtime-evidence.json");
+      const eventOut = join(tempDir, "events.jsonl");
+      const stdout = execFileSync("node", [
+        script,
+        `--proof=${proofPath}`,
+        `--out=${eventOut}`,
+        `--action-runtime-out=${actionOut}`,
+        "--require-ready",
+      ], { cwd: process.cwd(), encoding: "utf8" });
+
+      const result = JSON.parse(stdout) as { actionRuntimeEvidence?: { status?: string; count?: number } };
+      expect(result.actionRuntimeEvidence).toEqual(expect.objectContaining({ status: "ready", count: 1 }));
+      const actionEvidence = JSON.parse(readFileSync(actionOut, "utf8")) as {
+        truth?: string;
+        status?: string;
+        actions?: Array<{ surface?: string; screen?: string; action_id?: string; capability_id?: string; status?: string; evidence_ref?: string }>;
+      };
+      expect(actionEvidence.truth).toBe("action_runtime_evidence_from_explicit_ios_ui_actions_not_endbar");
+      expect(actionEvidence.status).toBe("ready");
+      expect(actionEvidence.actions).toEqual([
+        expect.objectContaining({
+          surface: "mobile",
+          screen: "fridayChat",
+          action_id: "chat:typing",
+          capability_id: "ask_friday_chat",
+          status: "pass",
+          evidence_ref: "proof://mobile-chat-send",
+        }),
+      ]);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("fails closed when explicit UI action rows are malformed", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "friday-ios-roundtrip-action-events-bad-"));
+    try {
+      const proofPath = writeProof(tempDir, proof({
+        ui_actions: [
+          { surface: "desktop", screen: "fridayChat", action_id: "chat:typing", status: "pass" },
+          { surface: "mobile", screen: "", action_id: "", status: "pending" },
+        ],
+      }));
+      const result = spawnSync("node", [
+        script,
+        `--proof=${proofPath}`,
+        "--require-ready",
+      ], { cwd: process.cwd(), encoding: "utf8" });
+
+      expect(result.status).toBe(2);
+      const output = JSON.parse(result.stdout) as { blockers?: Array<{ code?: string }> };
+      expect(output.blockers?.map((blocker) => blocker.code)).toEqual(expect.arrayContaining([
+        "ui_action_surface_mismatch",
+        "ui_action_missing_screen",
+        "ui_action_missing_action_or_capability",
+        "ui_action_status_not_pass",
+      ]));
     } finally {
       rmSync(tempDir, { recursive: true, force: true });
     }

--- a/test/unit/qa/friday-macos-live-write-read-proof-events-cli.test.ts
+++ b/test/unit/qa/friday-macos-live-write-read-proof-events-cli.test.ts
@@ -58,6 +58,7 @@ describe("friday-macos-live-write-read-proof-events", () => {
       const result = JSON.parse(stdout) as { status?: string; eventCount?: number; blockers?: unknown[] };
       expect(result.status).toBe("ready");
       expect(result.eventCount).toBe(5);
+      expect(JSON.stringify(result)).toContain("no_explicit_ui_actions");
       expect(result.blockers).toEqual([]);
 
       const rows = readFileSync(outPath, "utf8").trim().split("\n").map((line) => JSON.parse(line)) as Array<{
@@ -78,6 +79,83 @@ describe("friday-macos-live-write-read-proof-events", () => {
       expect(new Set(rows.map((row) => row.mission_id))).toEqual(new Set([missionId]));
       expect(new Set(rows.map((row) => row.work_item_id))).toEqual(new Set([workItemId]));
       expect(new Set(rows.map((row) => row.evidence_ref))).toEqual(new Set([proofPath]));
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("exports action runtime evidence only from explicit UI action rows", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "friday-macos-roundtrip-action-events-"));
+    try {
+      const proofPath = writeProof(tempDir, proof({
+        ui_actions: [
+          {
+            surface: "desktop",
+            screen: "fridayChat",
+            action_id: "check",
+            capability_id: "security_approval_bound_principal_gate_cat10_netnew",
+            status: "pass",
+            evidence_ref: "proof://desktop-chat-approve",
+          },
+        ],
+      }));
+      const actionOut = join(tempDir, "action-runtime-evidence.json");
+      const eventOut = join(tempDir, "events.jsonl");
+      const stdout = execFileSync("node", [
+        script,
+        `--proof=${proofPath}`,
+        `--out=${eventOut}`,
+        `--action-runtime-out=${actionOut}`,
+        "--require-ready",
+      ], { cwd: process.cwd(), encoding: "utf8" });
+
+      const result = JSON.parse(stdout) as { actionRuntimeEvidence?: { status?: string; count?: number } };
+      expect(result.actionRuntimeEvidence).toEqual(expect.objectContaining({ status: "ready", count: 1 }));
+      const actionEvidence = JSON.parse(readFileSync(actionOut, "utf8")) as {
+        truth?: string;
+        status?: string;
+        actions?: Array<{ surface?: string; screen?: string; action_id?: string; capability_id?: string; status?: string; evidence_ref?: string }>;
+      };
+      expect(actionEvidence.truth).toBe("action_runtime_evidence_from_explicit_macos_ui_actions_not_endbar");
+      expect(actionEvidence.status).toBe("ready");
+      expect(actionEvidence.actions).toEqual([
+        expect.objectContaining({
+          surface: "desktop",
+          screen: "fridayChat",
+          action_id: "check",
+          capability_id: "security_approval_bound_principal_gate_cat10_netnew",
+          status: "pass",
+          evidence_ref: "proof://desktop-chat-approve",
+        }),
+      ]);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("fails closed when explicit UI action rows are malformed", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "friday-macos-roundtrip-action-events-bad-"));
+    try {
+      const proofPath = writeProof(tempDir, proof({
+        ui_actions: [
+          { surface: "mobile", screen: "fridayChat", action_id: "check", status: "pass" },
+          { surface: "desktop", screen: "", action_id: "", status: "pending" },
+        ],
+      }));
+      const result = spawnSync("node", [
+        script,
+        `--proof=${proofPath}`,
+        "--require-ready",
+      ], { cwd: process.cwd(), encoding: "utf8" });
+
+      expect(result.status).toBe(2);
+      const output = JSON.parse(result.stdout) as { blockers?: Array<{ code?: string }> };
+      expect(output.blockers?.map((blocker) => blocker.code)).toEqual(expect.arrayContaining([
+        "ui_action_surface_mismatch",
+        "ui_action_missing_screen",
+        "ui_action_missing_action_or_capability",
+        "ui_action_status_not_pass",
+      ]));
     } finally {
       rmSync(tempDir, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary
- allow iOS/macOS live write-read proof-events drivers to export action-runtime evidence only when the proof artifact already carries explicit ui_actions rows from a real UI driver
- keep normal roundtrip evidence as no_explicit_ui_actions so write-read proof is not upgraded into button/action closure
- add fail-closed tests for malformed ui_actions on both mobile and desktop drivers

## Verification
- npx vitest run test/unit/qa/friday-ios-live-write-read-proof-events-cli.test.ts test/unit/qa/friday-macos-live-write-read-proof-events-cli.test.ts
- git diff --check

## Truth labels
- no synthetic action evidence
- not END-BAR, not GO-LIVE, not adoption
- prepares the real UI action evidence shape consumed by the design-action runtime gap report
