### PR TITLE
fix(friday-hub): bound the per-session idempotency set with a fail-close cap

### DIFF
--- a/rust-core/crates/friday-hub/src/bin/hub_agent_run_server.rs
+++ b/rust-core/crates/friday-hub/src/bin/hub_agent_run_server.rs
@@ -160,6 +160,14 @@ const AUTH_CHALLENGE: &[u8] = b"friday:execrun:ws:s-c:authed-run:challenge:v1";
 /// through the WS layer (the underlying stream is the same socket).
 const READ_TIMEOUT: Duration = Duration::from_secs(30);
 
+/// M5 (within-session bound — defense-in-depth). The per-session [`IdempotencyTracker`] is
+/// insert-only (never evicts — eviction would reopen anti-replay). It is minted on the stack of
+/// `serve_sealed_session` and dropped on session END, so it cannot grow across sessions; this caps
+/// the DISTINCT `msg_id`s a single authenticated session may stream before it is fail-closed (an
+/// allowlisted peer streaming unbounded distinct ids = self-DoS). At the cap a NEW id ENDS the
+/// session WITHOUT being inserted; a REPLAY of an already-seen id still hits the normal Replay path.
+const MAX_SESSION_MSG_IDS: usize = 100_000;
+
 // S-F: the SecureStore allowlist id (`PEER_PUBKEY_ALLOWLIST_ID`) and the X25519 pubkey width
 // (`X25519_PUBKEY_LEN`) are NOT redefined here — they are imported from `friday_hub::key_source`
 // (the single source of truth shared with the enroll CLI). MED-1: a local copy would let a future
@@ -1500,6 +1508,12 @@ fn serve_sealed_session<S: Read + Write, T: Transport>(
             // No dispatch, no processing — fail closed.
             Err(_) => return Ok(processed),
         };
+        // M5: within-session bound (defense-in-depth). At the cap, a NEW msg_id fail-closes the
+        // session WITHOUT being recorded (no evict — eviction would reopen anti-replay). A REPLAY of
+        // an already-seen id falls through to the existing Replay check below. Same fail-close form.
+        if seen_ids.len() >= MAX_SESSION_MSG_IDS && !seen_ids.has_seen(&env.msg_id) {
+            return Ok(processed);
+        }
         // S-E: reject a REPLAYED msg_id within this session (fail-closed: END the session, no
         // echo, no dispatch). Checked BEFORE any branch so it covers dispatch AND keepalive.
         if let Seen::Replay = seen_ids.observe(&env.msg_id) {

--- a/rust-core/crates/friday-hub/src/bin/hub_read_projection_server.rs
+++ b/rust-core/crates/friday-hub/src/bin/hub_read_projection_server.rs
@@ -110,6 +110,14 @@ const AUTH_CHALLENGE: &[u8] = b"friday:ui-read-seam:ws:s-r1:read-projection:chal
 /// auth/dispatch. Set on the `TcpStream` BEFORE the cleartext preamble read.
 const READ_TIMEOUT: Duration = Duration::from_secs(30);
 
+/// M5 (within-session bound — defense-in-depth). The per-session [`IdempotencyTracker`] is
+/// insert-only (never evicts — eviction would reopen anti-replay). It is minted on the stack of
+/// `serve_read_session` and dropped on session END, so it cannot grow across sessions; this caps
+/// the DISTINCT `msg_id`s a single authenticated read session may stream before it is fail-closed
+/// (an allowlisted peer streaming unbounded distinct ids = self-DoS). At the cap a NEW id ENDS the
+/// session WITHOUT being inserted; a REPLAY of an already-seen id still hits the normal Replay path.
+const MAX_SESSION_MSG_IDS: usize = 100_000;
+
 /// A boot-time failure category. Coarse + safe — the raw detail is NOT surfaced so a storage/init
 /// error cannot leak a path or a key. Mirrors the write bin's fail-closed boot vocabulary.
 #[derive(Debug)]
@@ -336,6 +344,12 @@ fn serve_read_session<S: Read + Write>(
             // EOF / disconnect / un-openable seal → END the session. Fail closed.
             Err(_) => return Ok(processed),
         };
+        // M5: within-session bound (defense-in-depth). At the cap, a NEW msg_id fail-closes the
+        // session WITHOUT being recorded (no evict — eviction would reopen anti-replay). A REPLAY of
+        // an already-seen id falls through to the existing Replay check below. Same fail-close form.
+        if seen_ids.len() >= MAX_SESSION_MSG_IDS && !seen_ids.has_seen(&env.msg_id) {
+            return Ok(processed);
+        }
         // Reject a REPLAYED msg_id within this session (fail-closed: END the session).
         if let Seen::Replay = seen_ids.observe(&env.msg_id) {
             return Ok(processed);

--- a/rust-core/crates/friday-protocol/src/lib.rs
+++ b/rust-core/crates/friday-protocol/src/lib.rs
@@ -1926,6 +1926,18 @@ impl IdempotencyTracker {
     pub fn has_seen(&self, msg_id: &str) -> bool {
         self.seen.contains(msg_id)
     }
+
+    /// The number of DISTINCT `msg_id`s seen this session. A holder uses this to bound the
+    /// within-session set (an authenticated peer streaming unbounded distinct ids = self-DoS).
+    /// This is a pure observation — it adds NO evict/cap/LRU behavior to the dedup set (evicting
+    /// would reopen anti-replay: flushing a live id then resending it would re-`First`-execute it).
+    pub fn len(&self) -> usize {
+        self.seen.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.seen.is_empty()
+    }
 }
 
 /// A durable, resumable stream of `AskFridayStream` frames (gate §4.3). On
@@ -2872,6 +2884,79 @@ mod tests {
         assert_eq!(t.observe("cmd-1"), Seen::Replay); // reconnect resend -> skip
         assert_eq!(t.observe("cmd-2"), Seen::First);
         assert!(t.has_seen("cmd-1"));
+    }
+
+    // M5 (within-session bound — defense-in-depth). The live holders cap the per-session distinct
+    // `msg_id` set with the guard `if seen_ids.len() >= MAX && !seen_ids.has_seen(id) { fail-close }`
+    // placed IMMEDIATELY BEFORE the existing `observe()` Replay check. These tests model that guard
+    // predicate against the tracker invariants it relies on, using a SMALL local CAP (the prod const
+    // is 100_000 in each holder — untouched). The cap must NEVER evict/LRU: eviction would reopen
+    // anti-replay (flush a live id, resend it, re-`First`-execute it).
+
+    /// Models the holder guard: at the cap, observe a NEW id => the guard would fail-close WITHOUT
+    /// inserting. Asserts the predicate fires AND the tracker is NOT mutated (no flush, no execute).
+    #[test]
+    fn idempotency_cap_fails_closed_on_new_id_without_flushing() {
+        const CAP: usize = 3;
+        let mut t = IdempotencyTracker::new();
+        for i in 0..CAP {
+            assert_eq!(t.observe(&format!("id-{i}")), Seen::First);
+        }
+        assert_eq!(t.len(), CAP);
+        // A NEW id at the cap: the holder guard `len() >= CAP && !has_seen(new)` is TRUE => the
+        // session would fail-close BEFORE `observe()`, so the new id is never inserted.
+        let new_id = "id-new";
+        assert!(
+            t.len() >= CAP && !t.has_seen(new_id),
+            "guard predicate must fire"
+        );
+        // Crucially, the guard does NOT call observe(): the set is unchanged (no flush of older ids,
+        // and the new id is NOT recorded). A real holder simply ends the session here.
+        assert_eq!(t.len(), CAP, "cap branch must not grow/flush the set");
+        for i in 0..CAP {
+            assert!(t.has_seen(&format!("id-{i}")), "older ids must remain seen");
+        }
+        assert!(
+            !t.has_seen(new_id),
+            "the rejected new id must NOT be recorded"
+        );
+    }
+
+    /// The anti-replay regression tripwire: an id seen BEFORE the cap is STILL reported `Replay`
+    /// at/after the cap — it is NEVER flushed and re-`First`-ed. If anyone adds eviction/LRU, the
+    /// early id gets dropped and re-observe returns `First`, failing this test.
+    #[test]
+    fn idempotency_cap_never_re_firsts_an_id_seen_before_the_cap() {
+        const CAP: usize = 3;
+        let mut t = IdempotencyTracker::new();
+        // An id seen early, BEFORE we reach the cap.
+        let early = "early-id";
+        assert_eq!(t.observe(early), Seen::First);
+        // Fill up to (and past) the cap with DISTINCT junk ids.
+        for i in 0..CAP {
+            t.observe(&format!("junk-{i}"));
+        }
+        assert!(t.len() >= CAP);
+        // The holder guard only fires for a NEW id (`!has_seen`). A REPLAY of `early` has
+        // `has_seen == true`, so the guard FALLS THROUGH to `observe()`, which MUST return Replay.
+        assert!(t.has_seen(early));
+        assert_eq!(
+            t.observe(early),
+            Seen::Replay,
+            "an id seen before the cap must stay Replay forever — no eviction"
+        );
+    }
+
+    /// Normal under-cap behavior is unchanged: distinct ids First, resend Replay.
+    #[test]
+    fn idempotency_under_cap_behavior_unchanged() {
+        const CAP: usize = 3;
+        let mut t = IdempotencyTracker::new();
+        assert_eq!(t.observe("a"), Seen::First);
+        assert_eq!(t.observe("b"), Seen::First);
+        assert_eq!(t.observe("a"), Seen::Replay);
+        assert!(t.len() < CAP, "still under the cap — no guard involvement");
+        assert!(t.has_seen("a") && t.has_seen("b"));
     }
 
     #[test]


### PR DESCRIPTION
**Audit finding M5 (NUANCED, low-sev, defense-in-depth).** The per-session `IdempotencyTracker` (friday-protocol) is insert-only. Re-verify at HEAD **reframed the finding**: both live holders mint the tracker **per-session on the stack** (`serve_sealed_session`, `serve_read_session`), dropped on session END, fresh per reconnect — so there is **no cross-session growth**. The only residual is within one long-lived session: an authenticated/allowlisted peer streaming unbounded distinct `msg_id`s (self-DoS).

**Fix:** add a pure `len()`/`is_empty()` accessor to `IdempotencyTracker` (NO evict/cap/LRU inside the type), and at each holder add `const MAX_SESSION_MSG_IDS = 100_000` + the guard `if seen_ids.len() >= MAX && !seen_ids.has_seen(&env.msg_id) { return Ok(processed); }` placed **immediately before** the existing `observe()` Replay check, using the **same fail-close form**. A new id at the cap ends the session **without** being recorded; a replay of an already-seen id falls through to the normal Replay path.

**★Anti-replay preserved:** NEVER evict/LRU — eviction would reopen the hole (flush a live id, resend → re-`First`-execute). The invariant "an id once seen in this session stays seen for the session" holds. `provider_timeline.rs` (non-live, idempotent-resubmit) intentionally untouched.

**Tests:** 3 new in friday-protocol incl. the anti-replay tripwire `idempotency_cap_never_re_firsts_an_id_seen_before_the_cap` (fails if anyone adds eviction). `cargo test -p friday-protocol -p friday-hub` green; clippy + fmt clean.

Two isolated reviewers: PASS/PASS. Coordinator also reviewed both holder guards + the no-evict accessor directly.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>