### PR TITLE
fix(friday-hub): fold mission resume-completion writes into one tx (crash-window atomicity)

### DIFF
--- a/rust-core/crates/friday-hub/src/agent_run_control.rs
+++ b/rust-core/crates/friday-hub/src/agent_run_control.rs
@@ -75,7 +75,7 @@ use rusqlite::Connection;
 
 use friday_protocol::AgentRunConstraintsWire;
 
-use crate::resume::{resume_with_approval, ResumeError};
+use crate::resume::{resume_with_approval_hooked, ResumeCompletionHook, ResumeError};
 use crate::{RunPolicy, ToolExecutor};
 
 /// Map a run's bound owner + the wire-asserted per-run [`AgentRunConstraintsWire`] onto an
@@ -410,6 +410,35 @@ pub fn resume(
     signed_blob: &[u8],
     now_ms: i64,
 ) -> Result<ControlOutcome, StorageError> {
+    resume_hooked(
+        conn,
+        executor,
+        operator_vk,
+        run_id,
+        signed_blob,
+        now_ms,
+        None,
+    )
+}
+
+/// [`resume`] with an OPTIONAL post-execute completion hook threaded through to the S6 spine.
+///
+/// Identical pre-checks (malformed-blob, cancel/reject coupling, wire-run binding) and identical
+/// outcome mapping as [`resume`]; the ONLY addition is `on_executed`, which the mission
+/// resume-completion leg ([`crate::mission_runtime::resume_agent_loop_for_mission`]) uses to fold
+/// its bound-WorkItem advance into the SAME transaction the spine commits the `run_result` in (H3
+/// crash-window atomicity — see [`resume_with_approval_hooked`]). `on_executed = None` is
+/// byte-identical to [`resume`]. The pre-checks run UNCHANGED and the abort predicate is NOT
+/// broadened — the hook only runs AFTER the spine has executed and inside the success transaction.
+pub fn resume_hooked(
+    conn: &Connection,
+    executor: &dyn ToolExecutor,
+    operator_vk: &OperatorVerifyingKey,
+    run_id: &str,
+    signed_blob: &[u8],
+    now_ms: i64,
+    on_executed: Option<ResumeCompletionHook<'_>>,
+) -> Result<ControlOutcome, StorageError> {
     // (1) Decode the courier blob (JSON of a SignedApproval). Malformed ⇒ fail-closed.
     let signed: SignedApprovalIn = match std::str::from_utf8(signed_blob)
         .ok()
@@ -462,8 +491,8 @@ pub fn resume(
         }
     }
 
-    // (3) Delegate VERBATIM to the S6 spine.
-    match resume_with_approval(conn, executor, operator_vk, &approval, now_ms) {
+    // (3) Delegate VERBATIM to the S6 spine (with the optional completion hook threaded through).
+    match resume_with_approval_hooked(conn, executor, operator_vk, &approval, now_ms, on_executed) {
         Ok(outcome) => Ok(ControlOutcome {
             op: "resume",
             // The spine PROCESSED it; `executed` reflects whether the mutation ran. A gate Deny

--- a/rust-core/crates/friday-hub/src/mission_preflight.rs
+++ b/rust-core/crates/friday-hub/src/mission_preflight.rs
@@ -12,7 +12,8 @@ use friday_core::{
     outcome_checked_proof_enabled, requires_context_passport, ApprovalState, FridayConversation,
     Mission, MissionLink, MissionLinkKind, SurfaceThread, WorkItem, WorkItemStatus, WorkspaceClaim,
 };
-use friday_storage::{memory, workflow, Db, MissionBodySnapshot, StorageError};
+use friday_storage::{memory, mission, workflow, Db, MissionBodySnapshot, StorageError};
+use rusqlite::Connection;
 
 use crate::channel_event::ChannelInboundReceipt;
 use crate::provider_timeline::PendingState;
@@ -696,6 +697,117 @@ pub(crate) fn attach_provider_timeline_state_guarded_with_completion_receipt(
         proof_ref: attachment.proof_ref,
         created_at_ms: attachment.now_ms,
     })?;
+    Ok(MissionAttachmentOutcome::Attached {
+        link_id,
+        work_item_status: next_status,
+    })
+}
+
+/// (H3 crash-window atomicity) The OFF-path (`guarded = false`) provider-timeline attachment,
+/// run against a CALLER-SUPPLIED [`Connection`] — which is a live [`rusqlite::Transaction`] at
+/// the resume-completion fold site, so this WorkItem advance commits in the SAME transaction as
+/// the run's `run_result`. A crash therefore lands BOTH rows or NEITHER (no `run_result=completed`
+/// + WorkItem-still-`ProviderRouted` UNDER-claim from a partial commit).
+///
+/// This is BEHAVIORALLY IDENTICAL to the `else` (OFF) branch of
+/// [`attach_provider_timeline_state_guarded_with_completion_receipt`] — same blocker strings, same
+/// legal-hop pre-check, same write set (`upsert_work_item[_clearing_executing]` + `upsert_mission` +
+/// `upsert_mission_link`), same outcome-checked-proof guard, same `MissionAttachmentOutcome`. The
+/// ONLY difference is that the writes use the [`mission`] free functions on the supplied connection
+/// (no inner `BEGIN`, since SQLite forbids a nested transaction) instead of the `&Db` wrappers. It
+/// is intentionally OFF-path-only: the resume-completion binding always passes `guarded = false`
+/// ([`crate::mission_runtime::resume_agent_loop_for_mission`]), so the guarded primitive's own-tx
+/// path is never reached here. The `&Db` wrappers' `Profile::Hub` assertion is unreachable as a
+/// real guard on this path (provider-timeline links + WorkItems are Hub-only data, so any caller
+/// already holds a Hub `Db`); the free functions are equivalent for a Hub connection.
+///
+/// Keep this in lock-step with the `else` branch above: any change to one must change the other.
+pub(crate) fn attach_provider_timeline_state_off_path_in(
+    conn: &Connection,
+    attachment: ProviderTimelineAttachment,
+    clear_executing: bool,
+    completion_proof_receipt: Option<&str>,
+) -> Result<MissionAttachmentOutcome, StorageError> {
+    let Some(mut mission) = mission::get_mission(conn, &attachment.mission_id)? else {
+        return Ok(MissionAttachmentOutcome::blocked("unknown_mission"));
+    };
+    let Some(mut work_item) = mission::get_work_item(conn, &attachment.work_item_id)? else {
+        return Ok(MissionAttachmentOutcome::blocked("unknown_work_item"));
+    };
+    if work_item.mission_id != attachment.mission_id {
+        return Ok(MissionAttachmentOutcome::blocked(
+            "work_item_mission_mismatch",
+        ));
+    }
+    let Some(next_status) =
+        work_item_status_for_provider_state(attachment.state, attachment.proof_ref.as_deref())
+    else {
+        return Ok(MissionAttachmentOutcome::blocked(provider_state_blocker(
+            attachment.state,
+            attachment.proof_ref.as_deref(),
+        )));
+    };
+    // SHARED legal-hop pre-check (identical to the guarded function). An illegal hop is a
+    // non-advancing Ok(Blocked), never an Err — so a same-status/idempotent replay is a no-op.
+    if work_item.status != next_status && !work_item.status.can_transition_to(next_status) {
+        return Ok(MissionAttachmentOutcome::blocked(format!(
+            "illegal_work_item_transition:{}->{}",
+            work_item.status.as_str(),
+            next_status.as_str()
+        )));
+    }
+
+    // OFF path (and same-status no-op): the pre-WI-1 inline write, verbatim.
+    work_item.status = next_status;
+    work_item.updated_at_ms = attachment.now_ms;
+    if next_status == WorkItemStatus::CompletedWithProof {
+        if let Some(proof_receipt) = completion_proof_receipt.or(attachment.proof_ref.as_deref()) {
+            push_unique(&mut work_item.proof_receipts, proof_receipt.to_string());
+        }
+        if let Some(proof_ref) = attachment.proof_ref.as_ref() {
+            push_unique(&mut mission.proof_refs, proof_ref.clone());
+            mission.updated_at_ms = attachment.now_ms;
+        }
+        if outcome_checked_proof_enabled()
+            && work_item.has_outcome_proof_requirements()
+            && !work_item.completion_outcome_is_proven()
+        {
+            return Err(StorageError::Unsupported(
+                "provider_timeline outcome-checked completion requires a typed outcome proof receipt matching an outcome proof requirement".into(),
+            ));
+        }
+    }
+    // (#24b degrade-3) On the binding's final resting-state hop, clear `executing = 0` in the
+    // SAME tx as this status upsert; otherwise the plain upsert. Both run on the caller's tx.
+    if clear_executing {
+        mission::upsert_work_item_clearing_executing_in(conn, &work_item)?;
+    } else {
+        mission::upsert_work_item(conn, &work_item)?;
+    }
+    mission::upsert_mission(conn, &mission)?;
+
+    let target_ref = format!(
+        "friday://provider-timeline/{}#{}",
+        attachment.friday_session_id, attachment.request_id
+    );
+    let link_id = stable_link_id(
+        "mlink_provider",
+        &attachment.mission_id,
+        &attachment.work_item_id,
+        &format!("{}_{}", attachment.friday_session_id, attachment.request_id),
+    );
+    mission::upsert_mission_link(
+        conn,
+        &MissionLink {
+            link_id: link_id.clone(),
+            mission_id: attachment.mission_id,
+            work_item_id: Some(attachment.work_item_id),
+            link_kind: MissionLinkKind::ProviderTimeline,
+            target_ref,
+            proof_ref: attachment.proof_ref,
+            created_at_ms: attachment.now_ms,
+        },
+    )?;
     Ok(MissionAttachmentOutcome::Attached {
         link_id,
         work_item_status: next_status,

--- a/rust-core/crates/friday-hub/src/mission_runtime.rs
+++ b/rust-core/crates/friday-hub/src/mission_runtime.rs
@@ -14,7 +14,7 @@ use friday_deepseek::{DeepSeekClient, Transport};
 use friday_storage::channel::get_channel;
 use friday_storage::{Db, StorageError};
 
-use crate::agent_run_control::{resume as agent_run_control_resume, ControlOutcome};
+use crate::agent_run_control::{resume_hooked as agent_run_control_resume_hooked, ControlOutcome};
 use crate::channel_event::{channel_event_id, ingest_channel_inbound, ChannelInboundReceipt};
 use crate::channels::{redact_inbound, resolve_and_verify, InboundRejection, RedactedInbound};
 use crate::mission_context::{
@@ -22,9 +22,9 @@ use crate::mission_context::{
     MissionContextResolution, ResolvedMissionContext,
 };
 use crate::mission_preflight::{
-    attach_channel_inbound_receipt, attach_provider_timeline_state_guarded,
-    attach_provider_timeline_state_guarded_with_completion_receipt, attach_workflow_run_ref,
-    MissionAttachmentOutcome, ProviderTimelineAttachment,
+    attach_channel_inbound_receipt, attach_provider_timeline_state_guarded_with_completion_receipt,
+    attach_provider_timeline_state_off_path_in, attach_workflow_run_ref, MissionAttachmentOutcome,
+    ProviderTimelineAttachment,
 };
 use crate::planner::WorkflowDefinition;
 use crate::provider_timeline::PendingState;
@@ -771,11 +771,18 @@ fn drive_provider_states(
 /// `accepted` outcome (the mutation DID run). The advance is a pure side-effect; it never alters
 /// the returned [`ControlOutcome`].
 ///
-/// **Known boundary (dark PR):** the spine's mutation (its own transaction) and this WorkItem
-/// advance (separate transactions) are not atomic. A crash between them leaves
-/// `run_result=mutation_completed` with the WorkItem still at `ProviderRouted`/`ProviderWaiting` —
-/// an UNDER-claim, never a false proof; the next resume is `executed==false` (nonce consumed) so it
-/// cannot re-advance. Acceptable for this dark, default-off seam.
+/// **Crash-window atomicity (H3 fix).** The spine's `run_result=mutation_completed` write AND this
+/// WorkItem advance now commit in ONE transaction: the advance runs as the spine's `on_executed`
+/// hook INSIDE the success transaction (`resume_with_approval_hooked`), so a crash leaves BOTH the
+/// run_result and the WorkItem hop, or NEITHER. The earlier non-atomic boundary — which could leave
+/// `run_result=mutation_completed` with the WorkItem stuck at `ProviderRouted`/`ProviderWaiting` (an
+/// UNDER-claim) — is closed. The residual under-claim is ONLY the executor-side one: the executor's
+/// file write is the irreducible non-rollbackable side effect committed OUTSIDE the transaction, so
+/// a crash after the file write but before the fold commits degrades to `executed==false` (nonce
+/// consumed, run_result + WorkItem both absent) on the next resume — never a false proof, never a
+/// re-advance (the consumed nonce replay-refuses). The abort predicate is UNCHANGED: the advance
+/// still runs ONLY when the spine returned an `accepted` (executed) outcome under a fresh Ed25519
+/// verify.
 ///
 /// Returns `Result<ControlOutcome, StorageError>` — a drop-in for the bare
 /// `agent_run_control::resume` at the wire seam (same `send_control_result` / `storage_failed`
@@ -788,81 +795,97 @@ pub fn resume_agent_loop_for_mission(
     signed_blob: &[u8],
     now_ms: i64,
 ) -> Result<ControlOutcome, StorageError> {
-    // (a) Delegate to the EXISTING resume spine UNCHANGED. This verifies the Ed25519 signature,
-    //     enforces single-use (nonce consume), runs the reject/cancel + wire-run-binding
-    //     pre-checks, and executes the ONE approved mutation. We add no verification/execution.
-    let outcome = agent_run_control_resume(
+    // (a) Resolve the bound WorkItem from the run's OWN pause-time provider_timeline link ONLY
+    //     (never a wire-supplied id) — a READ on the pre-pause binding, done BEFORE the spine runs
+    //     (the resume never mutates this link). No own-link (non-mission run / foreign nonce), a
+    //     non-provider_timeline kind, or no bound WorkItem ⇒ NO advance hook: the resume runs
+    //     byte-identically to a bare `agent_run_control::resume` on a non-mission run.
+    let advance_binding = match db.find_provider_timeline_link_by_run_id(run_id)? {
+        Some(link)
+            if link.link_kind == MissionLinkKind::ProviderTimeline
+                && link.work_item_id.is_some() =>
+        {
+            // The pause-time link's target_ref is `friday://provider-timeline/{session}#{run_id}`.
+            // Parse the session BACK out so the completion reuses the SAME link_id
+            // (mission_id+work_item+session+run) and UPSERTS the existing link instead of minting a
+            // second one (which would make a future run_id resolution ambiguous → fail-closed). The
+            // run_id segment was matched EXACTLY by the resolver, so the session is everything
+            // between the `provider-timeline/` prefix and the `#`.
+            let session_id =
+                provider_timeline_session_from_target(&link.target_ref).unwrap_or_default();
+            Some((
+                link.mission_id.clone(),
+                link.work_item_id.clone().expect("work_item_id is some"),
+                session_id,
+            ))
+        }
+        // Defense-in-depth: the storage query already filters to provider_timeline.
+        _ => None,
+    };
+
+    // (b) The completion hook: drive ONLY the remaining legal hops WaitingProvider →
+    //     ProviderCompleted with the run as proof. It runs INSIDE the spine's success transaction
+    //     (so the WorkItem advance and the `run_result` commit atomically), ONLY when the spine
+    //     executed the mutation (gate Allow + executor Ok) — `resume_with_approval_hooked` invokes
+    //     it solely on the executed-`Ok` arm, AFTER the nonce is consumed and the executor ran. A
+    //     non-advancing attachment outcome (e.g. an already-completed run ⇒ illegal/duplicate
+    //     transition) is NON-FATAL: the mutation DID run, so we stop driving hops but never error
+    //     the resume (the advance is a side-effect that never changes the returned ControlOutcome).
+    let proof_ref = format!("friday://agent-run/{run_id}");
+    let mut advance_hook =
+        advance_binding
+            .as_ref()
+            .map(|(mission_id, work_item_id, session_id)| {
+                move |tx: &rusqlite::Transaction<'_>| -> Result<(), StorageError> {
+                    for state in [
+                        PendingState::WaitingProvider,
+                        PendingState::ProviderCompleted,
+                    ] {
+                        let attachment = attach_provider_timeline_state_off_path_in(
+                            tx,
+                            ProviderTimelineAttachment {
+                                mission_id: mission_id.clone(),
+                                work_item_id: work_item_id.clone(),
+                                friday_session_id: session_id.clone(),
+                                request_id: run_id.to_string(),
+                                state,
+                                proof_ref: (state == PendingState::ProviderCompleted)
+                                    .then(|| proof_ref.clone()),
+                                now_ms,
+                            },
+                            // (#24b degrade-3) Clear `executing` on the resume completion hop too: a
+                            // resumed run that reaches `CompletedWithProof` must not leave a stale
+                            // marker (terminal rows are already never reconciled by PASS-2, but clearing
+                            // keeps the marker truthful for observability). Lands in the SAME fold tx.
+                            /* clear_executing = */
+                            state == PendingState::ProviderCompleted,
+                            // No separate completion-proof receipt: the proof_ref above is supplied.
+                            None,
+                        )?;
+                        if matches!(attachment, MissionAttachmentOutcome::Blocked { .. }) {
+                            break;
+                        }
+                    }
+                    Ok(())
+                }
+            });
+
+    // (c) Delegate to the EXISTING resume spine. This verifies the Ed25519 signature, enforces
+    //     single-use (nonce consume), runs the reject/cancel + wire-run-binding pre-checks, and
+    //     executes the ONE approved mutation. We add no verification/execution — the only addition
+    //     is the post-execute completion hook, folded into the spine's success transaction.
+    let hook = advance_hook
+        .as_mut()
+        .map(|h| h as crate::resume::ResumeCompletionHook<'_>);
+    agent_run_control_resume_hooked(
         db.conn(),
         executor,
         operator_vk,
         run_id,
         signed_blob,
         now_ms,
-    )?;
-
-    // (b) THE LOOPHOLE GATE. `outcome.accepted == outcome.executed` (agent_run_control.rs:472):
-    //     true IFF gate Allow AND executor Ok. Any refusal / exec-failure is `accepted:false` ⇒
-    //     return the spine outcome UNMODIFIED, WorkItem untouched (stays ProviderRouted). No proof.
-    if !outcome.accepted {
-        return Ok(outcome);
-    }
-
-    // (c) Resolve the bound WorkItem from the run's OWN pause-time provider_timeline link ONLY
-    //     (never a wire-supplied id). No own-link (non-mission run / foreign nonce) ⇒ no advance:
-    //     return the spine outcome unchanged (byte-identical to a bare resume on a non-mission run).
-    let Some(link) = db.find_provider_timeline_link_by_run_id(run_id)? else {
-        return Ok(outcome);
-    };
-    if link.link_kind != MissionLinkKind::ProviderTimeline {
-        // Defense-in-depth: the storage query already filters to provider_timeline.
-        return Ok(outcome);
-    }
-    let Some(work_item_id) = link.work_item_id.clone() else {
-        // A provider_timeline link with no bound WorkItem cannot be completed — leave it.
-        return Ok(outcome);
-    };
-    // The pause-time link's target_ref is `friday://provider-timeline/{session}#{run_id}`. Parse the
-    // session BACK out so the completion reuses the SAME link_id (mission_id+work_item+session+run)
-    // and UPSERTS the existing link instead of minting a second one (which would make a future
-    // run_id resolution ambiguous → fail-closed). The run_id segment was matched EXACTLY by the
-    // resolver, so the session is everything between the `provider-timeline/` prefix and the `#`.
-    let session_id = provider_timeline_session_from_target(&link.target_ref).unwrap_or_default();
-
-    // (d) Drive ONLY the remaining legal hops RoutedToProvider → WaitingProvider →
-    //     ProviderCompleted with the run as proof. `guarded=false` = the inline write (no extra
-    //     audit row, no PK risk); the proof_ref is always supplied so the completion is well-formed.
-    let proof_ref = format!("friday://agent-run/{run_id}");
-    for state in [
-        PendingState::WaitingProvider,
-        PendingState::ProviderCompleted,
-    ] {
-        let attachment = attach_provider_timeline_state_guarded(
-            db,
-            ProviderTimelineAttachment {
-                mission_id: link.mission_id.clone(),
-                work_item_id: work_item_id.clone(),
-                friday_session_id: session_id.clone(),
-                request_id: run_id.to_string(),
-                state,
-                proof_ref: (state == PendingState::ProviderCompleted).then(|| proof_ref.clone()),
-                now_ms,
-            },
-            /* guarded = */ false,
-            // (#24b degrade-3) Clear `executing` on the resume completion hop too: a resumed run that
-            // reaches `CompletedWithProof` must not leave a stale marker (terminal rows are already
-            // never reconciled by PASS-2, but clearing keeps the marker truthful for observability).
-            /* clear_executing = */
-            state == PendingState::ProviderCompleted,
-        )?;
-        // A non-advancing outcome (e.g. an already-completed run ⇒ illegal/duplicate transition) is
-        // NON-FATAL: the mutation DID run (the spine returned accepted), so we still report it. The
-        // advance is a best-effort side-effect that never changes the returned ControlOutcome.
-        if matches!(attachment, MissionAttachmentOutcome::Blocked { .. }) {
-            break;
-        }
-    }
-
-    Ok(outcome)
+        hook,
+    )
 }
 
 /// Parse the `{session}` out of a provider-timeline `target_ref`

--- a/rust-core/crates/friday-hub/src/resume.rs
+++ b/rust-core/crates/friday-hub/src/resume.rs
@@ -26,11 +26,17 @@ use friday_core::gate::{canonical_action_bytes, CanonicalApproval, GateDecision}
 use friday_crypto::OperatorVerifyingKey;
 use friday_storage::{
     audit, authorize_mutating_action_ed25519, get_pending_request, persist_run_result,
-    set_pending_status, PendingApprovalRequest, RunResult, StorageError,
+    persist_run_result_in, set_pending_status, PendingApprovalRequest, RunResult, StorageError,
 };
-use rusqlite::Connection;
+use rusqlite::{Connection, Transaction};
 
 use crate::{build_request_with_policy, RawToolCall, RunPolicy, ToolError, ToolExecutor};
+
+/// A post-execute completion hook run INSIDE the resume success transaction (H3 crash-window
+/// atomicity). It receives the live [`Transaction`] so any write it performs (e.g. the mission
+/// resume-completion leg's WorkItem advance) commits atomically with the spine's `run_result`. An
+/// `Err` rolls back the WHOLE fold (both-or-neither). See [`resume_with_approval_hooked`].
+pub type ResumeCompletionHook<'a> = &'a mut dyn FnMut(&Transaction<'_>) -> Result<(), StorageError>;
 
 /// The result of an ingest+resume attempt. Refs-friendly: it carries the gate decision,
 /// a coarse status, whether the one mutation executed, and a soft link to the audit
@@ -123,6 +129,43 @@ pub fn resume_with_approval(
     approval: &CanonicalApproval,
     now_ms: i64,
 ) -> Result<ResumeOutcome, ResumeError> {
+    resume_with_approval_hooked(conn, executor, operator_vk, approval, now_ms, None)
+}
+
+/// [`resume_with_approval`] with an OPTIONAL post-execute completion hook that runs INSIDE the
+/// success transaction (H3 crash-window atomicity).
+///
+/// The hook is the seam that lets the mission resume-completion leg
+/// ([`crate::mission_runtime::resume_agent_loop_for_mission`]) fold its bound-WorkItem advance into
+/// the SAME transaction that commits the run's `run_result`. On the executed-Ok path the spine now
+/// opens ONE transaction, writes the receipt + consumes the pending status + persists the
+/// `run_result`, then — STILL inside that transaction — calls `on_executed(&tx)` (the WorkItem
+/// advance), and only then commits. A crash therefore leaves BOTH the run_result and the WorkItem
+/// hop, or NEITHER; it can never leave `run_result=mutation_completed` with the WorkItem stuck at
+/// `ProviderRouted` (the previous partial-commit UNDER-claim).
+///
+/// CRITICALLY, the transaction opens ONLY in the executed-`Ok` arm — strictly AFTER
+/// `authorize_mutating_action_ed25519` has already CONSUMED the nonce (the `consumed_approval`
+/// INSERT commits in its own autocommit transaction, UPSTREAM of and OUTSIDE this fold). So a crash
+/// that rolls back the fold still leaves the nonce consumed: a replay re-enters
+/// `authorize_mutating_action_ed25519` and is Denied by the `consumed_approval` PRIMARY-KEY
+/// collision, INDEPENDENT of the (rolled-back, still-`pending`) `pending_approval_request.status`.
+/// The abort predicate is NOT broadened: the gate still verifies Ed25519 + expiry + digest exactly
+/// as before. The [`ToolExecutor`] file write stays OUTSIDE the transaction (its irreducible
+/// non-rollbackable side effect) — so the executor-side under-claim (file written, DB rolled back)
+/// still degrades to `executed == false`, never a worse leak.
+///
+/// `on_executed = None` is byte-identical to the pre-fold spine for every non-mission caller (the
+/// wire path, the bins, the tests): the same three writes, now in one transaction with one commit
+/// instead of three. The refused-arm and exec-failed-arm writes are unchanged.
+pub fn resume_with_approval_hooked(
+    conn: &Connection,
+    executor: &dyn ToolExecutor,
+    operator_vk: &OperatorVerifyingKey,
+    approval: &CanonicalApproval,
+    now_ms: i64,
+    on_executed: Option<ResumeCompletionHook<'_>>,
+) -> Result<ResumeOutcome, ResumeError> {
     // (1) Look up the pending request by the approval's NONCE. An unknown nonce is a hard
     //     refusal — there is no paused action this approval applies to.
     let pending =
@@ -186,11 +229,24 @@ pub fn resume_with_approval(
     //     second ingest of this approval is replay-refused regardless of what happens here.
     match executor.execute(&raw.action, &raw.params) {
         Ok(receipt) => {
+            // (H3 crash-window atomicity) Fold the post-execute writes — the receipt, the
+            // pending-status consume, the `run_result`, AND (for the mission leg) the bound
+            // WorkItem advance via `on_executed` — into ONE transaction. The executor already ran
+            // (its file write is the irreducible side effect, committed above and OUTSIDE this tx),
+            // and the nonce is already consumed by `authorize_mutating_action_ed25519` (its own
+            // autocommit, UPSTREAM). So this tx contains ONLY rollback-safe bookkeeping: a crash
+            // before commit leaves NONE of these rows (the executor under-claim, `executed==false`
+            // on the replay-refused next resume), and a clean commit lands ALL of them together —
+            // never `run_result=mutation_completed` with the WorkItem stuck at `ProviderRouted`.
             let summary = format!("resume.executed:{}", receipt.summary);
-            write_receipt(conn, &event_id, &receipt_id, &run_id, &summary, now_ms)?;
-            set_pending_status(conn, &approval.approval_id, "consumed")?;
-            persist_run_result(
-                conn,
+            let tx = conn
+                .unchecked_transaction()
+                .map_err(StorageError::from)
+                .map_err(ResumeError::Storage)?;
+            write_receipt_in(&tx, &event_id, &receipt_id, &run_id, &summary, now_ms)?;
+            set_pending_status(&tx, &approval.approval_id, "consumed")?;
+            persist_run_result_in(
+                &tx,
                 &run_id,
                 &with_owner(
                     RunResult::new(
@@ -202,6 +258,12 @@ pub fn resume_with_approval(
                 ),
                 now_ms,
             )?;
+            if let Some(hook) = on_executed {
+                hook(&tx)?;
+            }
+            tx.commit()
+                .map_err(StorageError::from)
+                .map_err(ResumeError::Storage)?;
             Ok(ResumeOutcome {
                 run_id,
                 approval_id: approval.approval_id.clone(),
@@ -264,7 +326,8 @@ fn with_owner(result: RunResult, principal_id: Option<&str>) -> RunResult {
 
 /// Write the event-log line + the hash-chained audit receipt in ONE transaction (so the
 /// event log can never get ahead of the ledger on a partial commit) — the same coupling
-/// the loop uses for an executed tool.
+/// the loop uses for an executed tool. Used by the refused / exec-failed arms, which are NOT
+/// folded with any downstream write.
 fn write_receipt(
     conn: &Connection,
     event_id: &str,
@@ -274,15 +337,32 @@ fn write_receipt(
     now_ms: i64,
 ) -> Result<(), StorageError> {
     let tx = conn.unchecked_transaction()?;
-    friday_storage::agent_run::record_event(&tx, event_id, run_id, summary, now_ms)?;
+    write_receipt_in(&tx, event_id, receipt_id, run_id, summary, now_ms)?;
+    tx.commit()?;
+    Ok(())
+}
+
+/// [`write_receipt`] WITHOUT opening/committing its own transaction — the caller supplies the
+/// [`Transaction`] and owns the surrounding `BEGIN`/`COMMIT`. This is the variant the executed-Ok
+/// arm uses so the receipt joins the SAME fold transaction as the `run_result` + WorkItem advance
+/// (H3 crash-window atomicity); SQLite forbids a nested `BEGIN`. The event/ledger coupling is
+/// identical — both rows land or neither, now as part of the larger fold.
+fn write_receipt_in(
+    tx: &Transaction<'_>,
+    event_id: &str,
+    receipt_id: &str,
+    run_id: &str,
+    summary: &str,
+    now_ms: i64,
+) -> Result<(), StorageError> {
+    friday_storage::agent_run::record_event(tx, event_id, run_id, summary, now_ms)?;
     audit::append_audit(
-        &tx,
+        tx,
         receipt_id,
         "operator-resume",
         summary,
         Some(run_id),
         now_ms,
     )?;
-    tx.commit()?;
     Ok(())
 }

--- a/rust-core/crates/friday-hub/tests/resume_mission_workitem_completion.rs
+++ b/rust-core/crates/friday-hub/tests/resume_mission_workitem_completion.rs
@@ -33,12 +33,15 @@ use friday_hub::mission_preflight::{
 };
 use friday_hub::mission_runtime::resume_agent_loop_for_mission;
 use friday_hub::provider_timeline::PendingState;
+use friday_hub::resume::resume_with_approval_hooked;
 use friday_hub::{
     build_request_with_policy, run_loop_with_policy, AgentError, AgentLlmClient, AgentStep,
     ExecError, FsToolExecutor, LoopStatus, RawToolCall, RunPolicy, ToolExecutor, ToolReceipt,
     TurnTrace,
 };
-use friday_storage::{agent_run, list_pending_requests_for_run, Db};
+use friday_storage::{
+    agent_run, get_run_result_ref, list_pending_requests_for_run, Db, StorageError,
+};
 
 static C: AtomicU64 = AtomicU64::new(0);
 
@@ -669,5 +672,124 @@ fn no_double_advance_on_already_completed_run() {
     assert_eq!(
         item_after_first.updated_at_ms,
         item_after_second.updated_at_ms
+    );
+}
+
+// ─────────────────────────── crash-window atomicity (H3 fix) ───────────────────────────
+
+/// THE H3 CANARY: the spine's `run_result` write and the bound-WorkItem advance commit in ONE
+/// transaction, so a crash leaves BOTH-or-NEITHER — never the partial `run_result=mutation_completed`
+/// + WorkItem-still-`ProviderRouted` UNDER-claim.
+///
+/// We simulate a crash BETWEEN the (formerly two) writes by passing `resume_with_approval_hooked` an
+/// `on_executed` hook that FAILS after the spine has already written the `run_result` inside the
+/// fold transaction. Because the advance hook and the `run_result` share ONE transaction, the hook's
+/// `Err` rolls back the WHOLE fold: the `run_result` row is ABSENT (the partial commit is gone) AND
+/// the WorkItem is UNCHANGED at `ProviderRouted` (its advance rolled back too).
+///
+/// The executor file write (the irreducible non-rollbackable side effect) DID happen, committed
+/// OUTSIDE the transaction, and the nonce was consumed UPSTREAM (so a replay would replay-refuse).
+/// That is exactly the residual executor-only under-claim: `executed`-then-crash degrades to
+/// `run_result` absent on the next resume, never a false proof. BEFORE this fix the `run_result` row
+/// would survive the failed advance (the bug); after it, both rows vanish together.
+#[test]
+fn fold_rolls_back_run_result_when_advance_hook_fails() {
+    let (sk, vk) = operator();
+    let db = Db::open_hub(&temp_db("foldfail")).unwrap();
+    let ws = Workspace::new("foldfail");
+    let owner = "owner:alice";
+    let run_id = "run-foldfail";
+    seed_mission(&db, "foldfail", owner);
+    bind_to_provider_routed(&db, "foldfail", "friday-session-foldfail", run_id);
+    let (nonce, request) = pause_run(&db, &ws, run_id, owner, &vk, "out-foldfail.txt");
+    let exec = FsToolExecutor::new(&ws.0);
+    let approval = ed_approval(&request, &sk, &nonce, Some(FUTURE));
+
+    // A hook that simulates a crash AFTER the spine wrote run_result, inside the fold tx.
+    let mut hook = |_tx: &rusqlite::Transaction<'_>| -> Result<(), StorageError> {
+        Err(StorageError::Unsupported("simulated mid-fold crash".into()))
+    };
+    let result =
+        resume_with_approval_hooked(db.conn(), &exec, &vk, &approval, NOW, Some(&mut hook));
+
+    // The hook's Err propagates out of the spine (the fold tx never committed).
+    assert!(
+        result.is_err(),
+        "the hook failure must surface (the fold tx is rolled back, not silently committed)"
+    );
+
+    // BOTH-OR-NEITHER: the run_result is ABSENT (rolled back with the failed advance) — NOT a
+    // partial `run_result=mutation_completed`-only under-claim.
+    let rr = get_run_result_ref(db.conn(), run_id).unwrap();
+    assert!(
+        rr.is_none(),
+        "run_result must roll back with the failed WorkItem advance (no partial commit): {rr:?}"
+    );
+
+    // The WorkItem is unchanged at ProviderRouted (its advance rolled back too — no false proof).
+    assert_eq!(
+        work_status(&db, "foldfail"),
+        WorkItemStatus::ProviderRouted,
+        "the WorkItem advance must roll back with the run_result"
+    );
+
+    // The executor file write is the irreducible side effect: it DID run (outside the tx). This is
+    // the residual executor-only under-claim — file present, DB rolled back.
+    assert_eq!(
+        std::fs::read_to_string(ws.join("out-foldfail.txt")).unwrap(),
+        "RESUMED",
+        "the executor file write stays OUTSIDE the fold tx (irreducible side effect)"
+    );
+
+    // The nonce was consumed UPSTREAM (its own autocommit), so a replay replay-refuses — proving the
+    // rolled-back fold did NOT un-consume the nonce (no re-execute path opens).
+    let approval2 = ed_approval(&request, &sk, &nonce, Some(FUTURE));
+    let replay =
+        resume_agent_loop_for_mission(&db, &exec, &vk, run_id, &signed_blob(&approval2), NOW + 1)
+            .unwrap();
+    assert!(
+        !replay.accepted,
+        "the consumed nonce must replay-refuse even after the fold rolled back"
+    );
+    // Still no run_result, still ProviderRouted (the replay-refusal never advances).
+    assert!(get_run_result_ref(db.conn(), run_id).unwrap().is_none());
+    assert_eq!(work_status(&db, "foldfail"), WorkItemStatus::ProviderRouted);
+}
+
+/// The COMMIT side of the both-or-neither coupling: a successful executed resume commits the
+/// `run_result` AND the bound-WorkItem advance TOGETHER (one transaction). Asserts the `run_result`
+/// row is present (`mutation_completed`) exactly when the WorkItem reached `CompletedWithProof` —
+/// the two are never observed apart.
+#[test]
+fn fold_commits_run_result_and_work_item_together() {
+    let (sk, vk) = operator();
+    let db = Db::open_hub(&temp_db("foldok")).unwrap();
+    let ws = Workspace::new("foldok");
+    let owner = "owner:alice";
+    let run_id = "run-foldok";
+    seed_mission(&db, "foldok", owner);
+    bind_to_provider_routed(&db, "foldok", "friday-session-foldok", run_id);
+    let (nonce, request) = pause_run(&db, &ws, run_id, owner, &vk, "out-foldok.txt");
+    let exec = FsToolExecutor::new(&ws.0);
+    let approval = ed_approval(&request, &sk, &nonce, Some(FUTURE));
+
+    // BEFORE: no run_result yet (the paused run defers it to the resume-completion leg).
+    assert!(get_run_result_ref(db.conn(), run_id).unwrap().is_none());
+
+    let outcome =
+        resume_agent_loop_for_mission(&db, &exec, &vk, run_id, &signed_blob(&approval), NOW)
+            .unwrap();
+    assert!(outcome.accepted);
+
+    // AFTER: the run_result is present (mutation_completed) AND the WorkItem is CompletedWithProof —
+    // both committed together by the single fold transaction.
+    let rr = get_run_result_ref(db.conn(), run_id)
+        .unwrap()
+        .expect("run_result committed with the advance");
+    assert_eq!(rr.status, "mutation_completed");
+    assert_eq!(
+        work_status(&db, "foldok"),
+        WorkItemStatus::CompletedWithProof,
+        "the WorkItem advance commits in the SAME tx as the run_result"
     );
 }

--- a/rust-core/crates/friday-storage/src/lib.rs
+++ b/rust-core/crates/friday-storage/src/lib.rs
@@ -71,8 +71,8 @@ pub use provider_timeline_store::{
 pub use retention::{sweep_retention, RetentionOutcome, RetentionWindows};
 pub use run_result::{
     get_run_answer_for_principal, get_run_result, get_run_result_ref, persist_run_result,
-    AnswerDenyReason, PersistRunResultOutcome, RunAnswerAccess, RunResult, RunResultRef,
-    StoredRunResult,
+    persist_run_result_in, AnswerDenyReason, PersistRunResultOutcome, RunAnswerAccess, RunResult,
+    RunResultRef, StoredRunResult,
 };
 pub use schema::{
     hub_code_max, hub_migrations, phone_migrations, HUB_ONLY_TABLES, PHONE_ONLY_TABLES,

--- a/rust-core/crates/friday-storage/src/mission.rs
+++ b/rust-core/crates/friday-storage/src/mission.rs
@@ -2032,12 +2032,24 @@ pub fn get_mission_body_snapshot(
 /// only acts on `executing == 1` rows).
 pub fn upsert_work_item_clearing_executing(conn: &Connection, item: &WorkItem) -> Result<()> {
     let tx = conn.unchecked_transaction()?;
-    upsert_work_item(&tx, item)?;
-    tx.execute(
+    upsert_work_item_clearing_executing_in(&tx, item)?;
+    tx.commit()?;
+    Ok(())
+}
+
+/// [`upsert_work_item_clearing_executing`] WITHOUT opening/committing its own transaction —
+/// the caller supplies the connection (a [`rusqlite::Transaction`] derefs to [`Connection`])
+/// and owns the surrounding `BEGIN`/`COMMIT`. Both statements still land together because
+/// the caller's transaction is the atomic boundary. This is the seam the resume-completion
+/// fold (H3 crash-window atomicity) uses to advance the WorkItem to its resting state inside
+/// the SAME transaction that commits the run's `run_result`; SQLite forbids a nested `BEGIN`,
+/// so a caller already inside a transaction MUST use this variant.
+pub fn upsert_work_item_clearing_executing_in(conn: &Connection, item: &WorkItem) -> Result<()> {
+    upsert_work_item(conn, item)?;
+    conn.execute(
         "UPDATE work_item SET executing = 0 WHERE work_item_id = ?1",
         params![item.work_item_id],
     )?;
-    tx.commit()?;
     Ok(())
 }
 

--- a/rust-core/crates/friday-storage/src/run_result.rs
+++ b/rust-core/crates/friday-storage/src/run_result.rs
@@ -54,7 +54,7 @@
 
 use crate::error::{Result, StorageError};
 use friday_core::gate::{is_anonymous_principal, Actor, ActorKind};
-use rusqlite::{params, Connection, OptionalExtension};
+use rusqlite::{params, Connection, OptionalExtension, Transaction};
 use sha2::{Digest, Sha256};
 
 /// The result of a run, as supplied to [`persist_run_result`]. Deliberately lean:
@@ -270,11 +270,32 @@ pub fn persist_run_result(
     result: &RunResult,
     now_ms: i64,
 ) -> Result<PersistRunResultOutcome> {
+    let tx = conn.unchecked_transaction()?;
+    let outcome = persist_run_result_in(&tx, run_id, result, now_ms)?;
+    tx.commit()?;
+    Ok(outcome)
+}
+
+/// [`persist_run_result`] WITHOUT opening/committing its own transaction — the caller
+/// supplies the [`Transaction`] and is responsible for the surrounding `BEGIN`/`COMMIT`.
+///
+/// This is the seam the resume-completion fold uses (H3 crash-window atomicity): the
+/// resume path commits the `run_result` row AND the bound WorkItem's status advance in ONE
+/// transaction, so a crash leaves BOTH rows or NEITHER — never the intermediate
+/// `run_result=mutation_completed` + WorkItem-still-`ProviderRouted` UNDER-claim. The
+/// check-then-insert + lifecycle-state coherence semantics are byte-identical to the
+/// tx-opening [`persist_run_result`] (which now delegates here); SQLite forbids a nested
+/// `BEGIN`, so a caller already inside a transaction MUST use this variant.
+pub fn persist_run_result_in(
+    tx: &Transaction<'_>,
+    run_id: &str,
+    result: &RunResult,
+    now_ms: i64,
+) -> Result<PersistRunResultOutcome> {
     let answer_bytes = result.answer.as_bytes();
     let answer_sha256 = sha256_hex(answer_bytes);
     let answer_len = answer_bytes.len() as i64;
 
-    let tx = conn.unchecked_transaction()?;
     let existing: Option<String> = tx
         .query_row(
             "SELECT answer_sha256 FROM run_result WHERE run_id = ?1",
@@ -318,8 +339,7 @@ pub fn persist_run_result(
     // clobbers a `cancelled` run, and is harmless when no `agent_run` row exists or on
     // an idempotent re-persist (re-writes the same terminal value). See
     // [`crate::agent_run::mark_run_terminal_state`] for the full no-degrade contract.
-    crate::agent_run::mark_run_terminal_state(&tx, run_id, &result.status, now_ms)?;
-    tx.commit()?;
+    crate::agent_run::mark_run_terminal_state(tx, run_id, &result.status, now_ms)?;
     Ok(outcome)
 }
 


### PR DESCRIPTION
**Audit finding H3 (NUANCED, flag default-OFF/dark).** `resume_agent_loop_for_mission` wrote the spine's `run_result=mutation_completed` (its own tx) and the bound-WorkItem advance (separate txs) **non-atomically** — a crash between them left `run_result=mutation_completed` with the WorkItem stuck at `ProviderRouted` (an UNDER-claim).

**Fix (smallest complete fold):** a post-execute completion hook (`ResumeCompletionHook`) threaded through `resume_with_approval_hooked`. On the executed-`Ok` arm the spine opens ONE tx — `write_receipt_in` + `set_pending_status` + `persist_run_result_in` + `on_executed(&tx)` (the WorkItem advance) — then commits. A crash leaves **both rows or neither**. `resume_with_approval`/`resume` keep their public API (delegate with `None`); non-mission callers are byte-identical (same writes, one commit instead of three). SQLite forbids nested BEGIN, so the self-tx'ing writes got `&Transaction` no-BEGIN `_in` variants.

**★Guardrails (each verified in the diff):**
- **Abort predicate UNCHANGED** — the hook runs ONLY on the executed-Ok arm (fresh Ed25519 verify + executor Ok); `accepted == executed` untouched.
- **Nonce-consume stays UPSTREAM & OUTSIDE the fold** (`consumed_approval` INSERT autocommits in `authorize_mutating_action_ed25519`); a rolled-back fold still leaves the nonce consumed → replay Denied by PK collision (test-asserted).
- **Executor file write stays OUTSIDE the tx** (irreducible side effect) → residual under-claim degrades to `executed==false`, never a worse leak.
- **Benign non-advance is non-fatal** — an already-completed/illegal WorkItem transition (`MissionAttachmentOutcome::Blocked`) `break`s → `Ok(())` → run_result still commits; only a genuine `StorageError` rolls back the fold.
- **Busy-resilience parity** — old `persist_run_result` was also a raw `unchecked_transaction` (no `with_busy_retry`); the fold uses the same connection `busy_timeout`. **crash_recovery.rs untouched. Flag stays default-OFF** (OFF-path helper hardcoded).

**Tests:** replay-guard `false_proof_guard_replayed_nonce_does_not_re_advance` + all 7 pre-existing resume-mission tests kept green; 2 new — `fold_rolls_back_run_result_when_advance_hook_fails` (both-or-neither on hook Err) + `fold_commits_run_result_and_work_item_together`. `cargo test -p friday-hub -p friday-storage` green; clippy + fmt clean; `cargo build --workspace` clean.

Two isolated reviewers: PASS/PASS. Coordinator also reviewed the fold + hook Ok/Err mapping + busy parity + advisor-vetted.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>