### PR TITLE
test(ui): bundle explicit runtime action evidence

### DIFF
--- a/scripts/ops/friday-ios-live-write-read-capture.sh
+++ b/scripts/ops/friday-ios-live-write-read-capture.sh
@@ -109,6 +109,7 @@ case "${shared_id}" in (*[[:space:]]*) die "--shared-id must not contain whitesp
 mkdir -p "${out_dir}"
 proof_path="${out_dir}/ios-live-write-read-proof.json"
 events_path="${out_dir}/ios-live-write-read-events.jsonl"
+action_runtime_path="${out_dir}/action-runtime-evidence.json"
 index_path="${out_dir}/capture-index.json"
 
 echo "Friday iOS live write-read capture starting."
@@ -134,15 +135,17 @@ echo "truth=ios_live_write_read_capture_runner_not_ui_device_proof"
 node "${repo_root}/scripts/ops/friday-ios-live-write-read-proof-events.mjs" \
   --proof="${proof_path}" \
   --out="${events_path}" \
+  --action-runtime-out="${action_runtime_path}" \
   --require-ready >/tmp/friday-ios-live-write-read-proof-events.$$.json
 
 [ -s "${events_path}" ] || die "proof-events driver did not create ${events_path}"
+[ -s "${action_runtime_path}" ] || die "proof-events driver did not create ${action_runtime_path}"
 
-node - "${proof_path}" "${events_path}" "${index_path}" <<'NODE'
+node - "${proof_path}" "${events_path}" "${action_runtime_path}" "${index_path}" <<'NODE'
 const { readFileSync, writeFileSync } = require("node:fs");
 const { createHash } = require("node:crypto");
 
-const [proofPath, eventsPath, indexPath] = process.argv.slice(2);
+const [proofPath, eventsPath, actionRuntimePath, indexPath] = process.argv.slice(2);
 const proof = JSON.parse(readFileSync(proofPath, "utf8"));
 const events = readFileSync(eventsPath, "utf8")
   .trim()
@@ -162,6 +165,8 @@ const index = {
     proof_sha256: sha256(proofPath),
     events: eventsPath,
     events_sha256: sha256(eventsPath),
+    action_runtime_evidence: actionRuntimePath,
+    action_runtime_evidence_sha256: sha256(actionRuntimePath),
     event_count: events.length,
   },
   blockers: [],

--- a/scripts/ops/friday-macos-live-write-read-capture.sh
+++ b/scripts/ops/friday-macos-live-write-read-capture.sh
@@ -66,6 +66,7 @@ case "${shared_id}" in (*[[:space:]]*) die "--shared-id must not contain whitesp
 mkdir -p "${out_dir}"
 proof_path="${out_dir}/macos-live-write-read-proof.json"
 events_path="${out_dir}/macos-live-write-read-events.jsonl"
+action_runtime_path="${out_dir}/action-runtime-evidence.json"
 index_path="${out_dir}/capture-index.json"
 
 echo "Friday macOS live write-read capture starting."
@@ -85,15 +86,17 @@ echo "truth=macos_live_write_read_capture_runner_not_ui_device_proof"
 node "${repo_root}/scripts/ops/friday-macos-live-write-read-proof-events.mjs" \
   --proof="${proof_path}" \
   --out="${events_path}" \
+  --action-runtime-out="${action_runtime_path}" \
   --require-ready >/tmp/friday-macos-live-write-read-proof-events.$$.json
 
 [ -s "${events_path}" ] || die "proof-events driver did not create ${events_path}"
+[ -s "${action_runtime_path}" ] || die "proof-events driver did not create ${action_runtime_path}"
 
-node - "${proof_path}" "${events_path}" "${index_path}" <<'NODE'
+node - "${proof_path}" "${events_path}" "${action_runtime_path}" "${index_path}" <<'NODE'
 const { readFileSync, writeFileSync } = require("node:fs");
 const { createHash } = require("node:crypto");
 
-const [proofPath, eventsPath, indexPath] = process.argv.slice(2);
+const [proofPath, eventsPath, actionRuntimePath, indexPath] = process.argv.slice(2);
 const proof = JSON.parse(readFileSync(proofPath, "utf8"));
 const events = readFileSync(eventsPath, "utf8")
   .trim()
@@ -113,6 +116,8 @@ const index = {
     proof_sha256: sha256(proofPath),
     events: eventsPath,
     events_sha256: sha256(eventsPath),
+    action_runtime_evidence: actionRuntimePath,
+    action_runtime_evidence_sha256: sha256(actionRuntimePath),
     event_count: events.length,
   },
   blockers: [],

--- a/scripts/ops/friday-ui-device-live-write-read-bundle.mjs
+++ b/scripts/ops/friday-ui-device-live-write-read-bundle.mjs
@@ -81,6 +81,10 @@ function requireFile(path, label) {
   return resolved;
 }
 
+function optionalFile(path, label) {
+  return path ? requireFile(path, label) : "";
+}
+
 function requireDir(path, label) {
   if (!path) {
     block("missing_arg", label);
@@ -116,15 +120,36 @@ function readEvents(path, surface, missionId) {
   }
 }
 
+function readActionEvidence(path, surface, missionId) {
+  if (!path) return [];
+  const value = readJson(path, `${surface}.action-runtime-evidence`);
+  const actions = Array.isArray(value?.actions) ? value.actions : [];
+  return actions.map((action, index) => {
+    const label = `${surface}_action_${index + 1}`;
+    if (action.surface !== surface) block("action_surface_mismatch", `${label}:${String(action.surface ?? "")}`);
+    if (action.mission_id !== missionId) block("action_mission_mismatch", `${label}:${String(action.mission_id ?? "")}`);
+    if (action.status !== "pass") block("action_status_not_pass", `${label}:${String(action.status ?? "")}`);
+    if (typeof action.screen !== "string" || !action.screen.trim()) block("action_missing_screen", label);
+    if (!String(action.action_id || "").trim() && !String(action.capability_id || "").trim()) {
+      block("action_missing_action_or_capability", label);
+    }
+    return action;
+  });
+}
+
 function capturePaths(index, role, dir) {
   const roleIndex = index?.[role] ?? null;
   const proof = requireFile(roleIndex?.proof || "", `${role}.proof`);
   const events = requireFile(roleIndex?.events || "", `${role}.events`);
+  const actionRuntimeEvidence = optionalFile(roleIndex?.action_runtime_evidence || "", `${role}.action_runtime_evidence`);
   if (proof && dirname(proof) !== dir) block("capture_file_outside_dir", `${role}.proof:${proof}`);
   if (events && dirname(events) !== dir) block("capture_file_outside_dir", `${role}.events:${events}`);
+  if (actionRuntimeEvidence && dirname(actionRuntimeEvidence) !== dir) {
+    block("capture_file_outside_dir", `${role}.action_runtime_evidence:${actionRuntimeEvidence}`);
+  }
   const eventCount = Number(roleIndex?.event_count ?? 0);
   if (!Number.isInteger(eventCount) || eventCount <= 0) block("event_count_invalid", `${role}:${String(roleIndex?.event_count ?? "")}`);
-  return { proof, events, eventCount };
+  return { proof, events, actionRuntimeEvidence, eventCount };
 }
 
 if (!outDirArg) block("missing_arg", "out-dir");
@@ -164,14 +189,19 @@ if (expectedMissionId && missionIds.some((value) => value !== expectedMissionId)
 }
 
 const eventsByRole = {};
+const actionsByRole = {};
 for (const [role, capture] of Object.entries(captures)) {
   if (capture.events && capture.missionId) {
     eventsByRole[role] = readEvents(capture.events, role, capture.missionId);
+  }
+  if (capture.actionRuntimeEvidence && capture.missionId) {
+    actionsByRole[role] = readActionEvidence(capture.actionRuntimeEvidence, role, capture.missionId);
   }
 }
 
 let written = {};
 let combinedEventsPath = null;
+let combinedActionEvidencePath = null;
 let indexPath = null;
 if (outDir && blockers.filter((entry) => entry.code === "missing_arg" || entry.code === "out_dir_not_absolute").length === 0) {
   mkdirSync(outDir, { recursive: true });
@@ -182,12 +212,20 @@ if (outDir && blockers.filter((entry) => entry.code === "missing_arg" || entry.c
     const eventsTarget = join(roleDir, basename(capture.events));
     copyFileSync(capture.proof, proofTarget);
     copyFileSync(capture.events, eventsTarget);
+    let actionRuntimeEvidenceTarget = null;
+    if (capture.actionRuntimeEvidence) {
+      actionRuntimeEvidenceTarget = join(roleDir, basename(capture.actionRuntimeEvidence));
+      copyFileSync(capture.actionRuntimeEvidence, actionRuntimeEvidenceTarget);
+    }
     written[role] = {
       proof: proofTarget,
       proof_sha256: sha256(proofTarget),
       events: eventsTarget,
       events_sha256: sha256(eventsTarget),
+      action_runtime_evidence: actionRuntimeEvidenceTarget,
+      action_runtime_evidence_sha256: actionRuntimeEvidenceTarget ? sha256(actionRuntimeEvidenceTarget) : null,
       event_count: eventsByRole[role]?.length ?? 0,
+      action_count: actionsByRole[role]?.length ?? 0,
       mission_id: capture.missionId,
       work_item_id: capture.workItemId,
     };
@@ -199,6 +237,15 @@ if (outDir && blockers.filter((entry) => entry.code === "missing_arg" || entry.c
       .flatMap((role) => eventsByRole[role] ?? [])
       .map((event) => JSON.stringify(event));
     writeFileSync(combinedEventsPath, combined.length ? `${combined.join("\n")}\n` : "");
+
+    const combinedActions = ["mobile", "desktop"].flatMap((role) => actionsByRole[role] ?? []);
+    combinedActionEvidencePath = join(outDir, "action-runtime-evidence.json");
+    writeFileSync(combinedActionEvidencePath, `${JSON.stringify({
+      truth: "combined_mobile_desktop_action_runtime_evidence_not_endbar",
+      status: combinedActions.length > 0 ? "ready" : "no_explicit_ui_actions",
+      missionId,
+      actions: combinedActions,
+    }, null, 2)}\n`);
   }
 
   indexPath = join(outDir, "live-write-read-bundle-index.json");
@@ -220,6 +267,8 @@ const output = {
   outDir: outDir || null,
   captures: written,
   combinedEvents: combinedEventsPath,
+  actionRuntimeEvidence: combinedActionEvidencePath,
+  actionRuntimeEvidenceCount: ["mobile", "desktop"].reduce((sum, role) => sum + (actionsByRole[role]?.length ?? 0), 0),
   blockers,
   fullProofGaps,
   next: blockers.length === 0

--- a/test/unit/qa/friday-ui-device-live-write-read-bundle-cli.test.ts
+++ b/test/unit/qa/friday-ui-device-live-write-read-bundle-cli.test.ts
@@ -11,6 +11,7 @@ function writeCapture(root: string, role: "mobile" | "desktop", missionId: strin
   mkdirSync(dir, { recursive: true });
   const proof = join(dir, `${role}-proof.json`);
   const events = join(dir, `${role}-events.jsonl`);
+  const actionRuntimeEvidence = join(dir, "action-runtime-evidence.json");
   const workItemId = `work-${role}-${missionId}`;
   writeFileSync(proof, JSON.stringify({
     truth_label: `${role}_live_write_read_roundtrip_proof_not_ui_device_proof`,
@@ -33,6 +34,21 @@ function writeCapture(root: string, role: "mobile" | "desktop", missionId: strin
     work_item_id: workItemId,
   }));
   writeFileSync(events, `${rows.map((row) => JSON.stringify(row)).join("\n")}\n`);
+  writeFileSync(actionRuntimeEvidence, JSON.stringify({
+    truth: `action_runtime_evidence_from_explicit_${role}_ui_actions_not_endbar`,
+    status: "ready",
+    missionId,
+    actions: [{
+      surface: role,
+      screen: role === "mobile" ? "fridayChat" : "desktopChat",
+      action_id: "chat:typing",
+      capability_id: "ask_friday_chat",
+      status: "pass",
+      evidence_ref: `proof://${role}/chat-send`,
+      mission_id: missionId,
+      work_item_id: workItemId,
+    }],
+  }, null, 2));
   writeFileSync(join(dir, "capture-index.json"), JSON.stringify({
     truth_label: `${role}_live_write_read_capture_index_not_ui_device_proof`,
     status: "ready",
@@ -41,6 +57,7 @@ function writeCapture(root: string, role: "mobile" | "desktop", missionId: strin
     [role]: {
       proof,
       events,
+      action_runtime_evidence: actionRuntimeEvidence,
       event_count: rows.length,
     },
     blockers: [],
@@ -70,6 +87,8 @@ describe("friday-ui-device-live-write-read-bundle", () => {
         status?: string;
         missionId?: string;
         combinedEvents?: string;
+        actionRuntimeEvidence?: string;
+        actionRuntimeEvidenceCount?: number;
         fullProofGaps?: string[];
       };
       expect(result.truth).toBe("ui_device_live_write_read_bundle_not_full_proof");
@@ -79,12 +98,21 @@ describe("friday-ui-device-live-write-read-bundle", () => {
 
       const combinedEvents = readFileSync(result.combinedEvents ?? "", "utf8").trim().split("\n");
       expect(combinedEvents).toHaveLength(10);
+      expect(result.actionRuntimeEvidenceCount).toBe(2);
+      const actionEvidence = JSON.parse(readFileSync(result.actionRuntimeEvidence ?? "", "utf8")) as {
+        status?: string;
+        actions?: unknown[];
+      };
+      expect(actionEvidence.status).toBe("ready");
+      expect(actionEvidence.actions).toHaveLength(2);
 
       const index = JSON.parse(readFileSync(join(outDir, "live-write-read-bundle-index.json"), "utf8")) as {
         status?: string;
+        actionRuntimeEvidenceCount?: number;
         fullProofGaps?: string[];
       };
       expect(index.status).toBe("partial_bundle_ready");
+      expect(index.actionRuntimeEvidenceCount).toBe(2);
       expect(index.fullProofGaps).toContain("strict_observations_manifest_from_same_run_events");
     } finally {
       rmSync(tempDir, { recursive: true, force: true });


### PR DESCRIPTION
## Summary
- export action-runtime evidence paths from iOS/macOS live write-read capture indexes
- combine mobile+desktop explicit action rows into bundle/action-runtime-evidence.json
- keep truth labels explicit: this is runtime evidence plumbing only, not END-BAR, GO-LIVE, adoption, or synthetic completion

## Verification
- npx vitest run test/unit/qa/friday-ui-device-live-write-read-bundle-cli.test.ts test/unit/qa/friday-ios-live-write-read-capture-cli.test.ts test/unit/qa/friday-macos-live-write-read-capture-cli.test.ts

## Truth
This only carries explicit ui_actions rows that already exist in real capture artifacts. Empty/missing action rows remain no_explicit_ui_actions and do not satisfy the design runtime coverage gate.