### PR TITLE
fix(friday-storage): atomic content-free retention_log receipt for sweep + reaper [M3/M4]

### DIFF
--- a/rust-core/crates/friday-storage/src/lib.rs
+++ b/rust-core/crates/friday-storage/src/lib.rs
@@ -68,7 +68,10 @@ pub use provider_timeline_store::{
     persist_timeline, timeline_exists, upsert_pending, PendingActionRow, PersistEventOutcome,
     StoredPendingAction, StoredTimeline, StoredTimelineEvent, TimelineEventRow, TimelineState,
 };
-pub use retention::{sweep_retention, RetentionOutcome, RetentionWindows};
+pub use retention::{
+    insert_retention_log, insert_retention_log_in, sweep_retention, RetentionOutcome,
+    RetentionWindows,
+};
 pub use run_result::{
     get_run_answer_for_principal, get_run_result, get_run_result_ref, persist_run_result,
     persist_run_result_in, AnswerDenyReason, PersistRunResultOutcome, RunAnswerAccess, RunResult,

--- a/rust-core/crates/friday-storage/src/retention.rs
+++ b/rust-core/crates/friday-storage/src/retention.rs
@@ -58,6 +58,7 @@
 use crate::error::Result;
 use rusqlite::params;
 use rusqlite::Connection;
+use rusqlite::Transaction;
 
 // ─── Operator-approved default retention windows (ms) ───
 
@@ -258,7 +259,87 @@ pub fn sweep_retention(
         Err(_e) => out.table_errors += 1,
     }
 
+    // M3 receipt: record a CONTENT-FREE, counts-only summary of this sweep into `retention_log`
+    // (a SEPARATE table, NOT the hash-chained `audit_ledger`). Written ONLY when the sweep actually
+    // DELETED something — gated on the sum of the per-table delete counts, NOT on
+    // `RetentionOutcome::is_empty()` (which also folds in `table_errors`). An error-only tick (zero
+    // deletions, one or more per-table DELETEs failed) must NOT write a receipt: it would be an
+    // all-zero "nothing destroyed" row that hides the error, and — since `retention_log` has no
+    // sweep of its own — a persistent per-table error would reintroduce the unbounded per-tick
+    // growth this module exists to bound. The error is still surfaced to the caller via the
+    // returned `table_errors`; when a receipt IS written, `errors=` records any concurrent failures
+    // so the row stays honest. The summary carries integer counts only, never a deleted row's
+    // id/body. This is a SEPARATE write AFTER the per-table delete txns (there is no single sweep
+    // txn to join), and it must NEVER break the fail-safe contract (this fn never returns Err) — so
+    // a receipt-write failure is SWALLOWED here, exactly as the session reaper swallows its own.
+    let deleted = out.token_ledger_deleted
+        + out.surface_event_deleted
+        + out.memory_item_deleted
+        + out.work_item_deleted
+        + out.mission_deleted;
+    if deleted > 0 {
+        let summary = format!(
+            "retention.sweep:token_ledger={} surface_event={} memory_item={} work_item={} mission={} errors={}",
+            out.token_ledger_deleted,
+            out.surface_event_deleted,
+            out.memory_item_deleted,
+            out.work_item_deleted,
+            out.mission_deleted,
+            out.table_errors,
+        );
+        let _ = insert_retention_log(conn, "retention.sweep", &summary, now_ms);
+    }
+
     out
+}
+
+/// Insert ONE content-free [`retention_log`] receipt row (its own bounded busy-retry txn,
+/// mirroring [`delete_bounded`]). `summary` is a counts-only string — NEVER a deleted row's
+/// id/body. This writes the M3/M4 receipt table, which is DELIBERATELY SEPARATE from the
+/// hash-chained `audit_ledger` (gap #25): it is un-chained and never references the audit ledger.
+///
+/// `tick_kind` is the sweep that produced the row (`"retention.sweep"` for the artifact sweep,
+/// `"session.reaper"` for the lifecycle reaper). The id is generated in SQL the same way the
+/// tool-usage ledger generates its id, so the caller passes no opaque value.
+pub fn insert_retention_log(
+    conn: &Connection,
+    tick_kind: &str,
+    summary: &str,
+    now_ms: i64,
+) -> Result<()> {
+    crate::with_busy_retry(|| {
+        let tx = conn.unchecked_transaction()?;
+        insert_retention_log_in(&tx, tick_kind, summary, now_ms)?;
+        tx.commit()?;
+        Ok(())
+    })
+}
+
+/// No-BEGIN variant of [`insert_retention_log`]: writes the receipt row into a CALLER-OWNED
+/// transaction without opening (or committing) its own. SQLite forbids nested `BEGIN`, so a caller
+/// that already holds a txn — e.g. the lifecycle reaper, which must record the receipt for an
+/// IRREVERSIBLE hard-delete atomically with that delete — folds the INSERT in via this fn and lets
+/// its own `tx.commit()` seal both. The `?` propagates a write failure to the caller, which is the
+/// POINT for the M4 (irreversible) leg: a receipt failure must roll the whole sweep back so a
+/// hard-delete can NEVER commit without its receipt. This is the deliberate MIRROR of the M3
+/// (reversible) artifact sweep, where [`insert_retention_log`] is called best-effort AFTER the
+/// commit so a receipt failure can never block a reversible expiry.
+///
+/// Does NOT wrap [`crate::with_busy_retry`]: the caller's txn already carries the crate's single
+/// busy-retry policy (or, for `sweep_lifecycle`, re-runs idempotently next tick on `SQLITE_BUSY`),
+/// so wrapping here would double-apply it. `summary` is counts-only — NEVER a deleted row's id/body.
+pub fn insert_retention_log_in(
+    tx: &Transaction<'_>,
+    tick_kind: &str,
+    summary: &str,
+    now_ms: i64,
+) -> Result<()> {
+    tx.execute(
+        "INSERT INTO retention_log (retention_log_id, tick_kind, summary, created_at)
+         VALUES ('retlog:' || lower(hex(randomblob(16))), ?1, ?2, ?3)",
+        params![tick_kind, summary, now_ms],
+    )?;
+    Ok(())
 }
 
 /// Run ONE bounded DELETE inside its OWN transaction and return the deleted row count. The whole
@@ -606,6 +687,67 @@ mod tests {
             crate::audit::verify_audit_chain(db.conn()).unwrap(),
             2,
             "audit chain still clean"
+        );
+
+        // M3 receipt: a non-empty sweep writes EXACTLY ONE retention_log row whose summary
+        // carries the per-table counts (content-free; counts only). It is NOT an audit_ledger
+        // row — the audit count above is unchanged.
+        assert_eq!(
+            count(&db, "retention_log"),
+            1,
+            "one sweep ⇒ one receipt row"
+        );
+        let (tick_kind, summary): (String, String) = db
+            .conn()
+            .query_row("SELECT tick_kind, summary FROM retention_log", [], |r| {
+                Ok((r.get(0)?, r.get(1)?))
+            })
+            .unwrap();
+        assert_eq!(tick_kind, "retention.sweep");
+        assert_eq!(
+            summary,
+            "retention.sweep:token_ledger=1 surface_event=1 memory_item=1 work_item=1 mission=2 errors=0",
+            "summary records the real per-table counts + the concurrent error count"
+        );
+    }
+
+    // --- a content-free, counts-only receipt is written ONLY on a non-empty sweep ---
+
+    #[test]
+    fn empty_sweep_writes_no_retention_log_row() {
+        // The growth fix: an idle tick (nothing eligible) must NOT write a receipt — otherwise
+        // retention_log (which has no sweep of its own) would grow unbounded, the very problem
+        // this module exists to bound.
+        let db = Db::open_hub(&tmp("empty-receipt")).unwrap();
+        let now = 2_000 * 24 * 60 * 60 * 1000_i64;
+        let out = sweep_retention(db.conn(), now, RetentionWindows::default());
+        assert!(out.is_empty(), "no seeded rows ⇒ nothing deleted");
+        assert_eq!(
+            count(&db, "retention_log"),
+            0,
+            "an empty sweep writes ZERO receipt rows"
+        );
+    }
+
+    // --- an error-only sweep (a per-table DELETE failed, nothing deleted) writes NO receipt ---
+
+    #[test]
+    fn error_only_sweep_writes_no_retention_log_row() {
+        // The receipt is gated on actual DELETIONS, not on `is_empty()` (which folds in
+        // `table_errors`). Drop `mission` so its DELETE errors (table_errors += 1) while every
+        // other table is empty (0 deletions). The sweep must record NO receipt — an all-zero
+        // "nothing destroyed" row would both hide the error and, since retention_log has no sweep
+        // of its own, reintroduce unbounded per-tick growth under a persistent per-table error.
+        let db = Db::open_hub(&tmp("error-only-receipt")).unwrap();
+        let now = 2_000 * 24 * 60 * 60 * 1000_i64;
+        db.conn().execute_batch("DROP TABLE mission").unwrap();
+        let out = sweep_retention(db.conn(), now, RetentionWindows::default());
+        assert!(out.table_errors >= 1, "the dropped-table DELETE must error");
+        assert_eq!(out.mission_deleted, 0, "nothing was deleted");
+        assert_eq!(
+            count(&db, "retention_log"),
+            0,
+            "an error-only sweep (0 deletions) writes ZERO receipt rows"
         );
     }
 

--- a/rust-core/crates/friday-storage/src/schema.rs
+++ b/rust-core/crates/friday-storage/src/schema.rs
@@ -165,6 +165,14 @@ pub const HUB_ONLY_TABLES: &[&str] = &[
     // assert listed tables are PRESENT on the hub and ABSENT on the phone, and the shadow
     // names contain no forbidden secret-store word.
     "memory_fts",
+    // M3/M4 (gap #25): a CONTENT-FREE receipt for each non-empty retention/reaper sweep —
+    // tick kind + a counts-only summary (e.g. `retention.sweep:token_ledger=N ...` /
+    // `session.reaper:idled=N ... hard_deleted=N messages_deleted=N`) + timestamp. Hub-only
+    // because the sweeps it records are Hub-coordinated. DELIBERATELY SEPARATE from
+    // `audit_ledger` (whose hash-chain immutability is gap #25's own concern); this table is
+    // NOT chained and never references the audit ledger. It holds NO row id/body that was
+    // deleted — only integer counts — so it carries no secret/PII content class.
+    "retention_log",
 ];
 
 /// Tables present only on a phone (never created on the Hub).
@@ -676,6 +684,16 @@ pub fn hub_migrations() -> Vec<Migration> {
             name: "mission_body_snapshot",
             destructive: false,
             up: m0040_mission_body_snapshot,
+        },
+        // M3/M4 (gap #25): a content-free receipt table for the retention sweep + session
+        // reaper. Purely additive — CREATE TABLE + INDEX only; touches NO existing table and
+        // performs NO data migration. NOT the `audit_ledger`/hash-chain (that immutability is
+        // intentionally never referenced by the sweeps; this is a separate, un-chained log).
+        Migration {
+            version: 41,
+            name: "retention_log",
+            destructive: false,
+            up: m0041_retention_log,
         },
     ]
 }
@@ -1835,6 +1853,18 @@ CREATE TABLE mission_body_snapshot (
 CREATE INDEX idx_mission_body_snapshot_work_item
     ON mission_body_snapshot(owner_principal, work_item_id, body_ref);";
 
+// M3/M4 (gap #25): content-free receipt for each non-empty retention/reaper sweep. `summary`
+// is a counts-only string (integer counts per table, NEVER a deleted row's id/body). This is
+// NOT the hash-chained `audit_ledger` — it is a separate, un-chained log the sweeps own.
+const DDL_RETENTION_LOG: &str = "
+CREATE TABLE retention_log (
+    retention_log_id TEXT PRIMARY KEY,
+    tick_kind        TEXT NOT NULL,
+    summary          TEXT NOT NULL,
+    created_at       INTEGER NOT NULL
+);
+CREATE INDEX idx_retention_log_created ON retention_log(created_at);";
+
 const DDL_REBUILD_MISSION_LINK_WITH_ROUTE_DECISION: &str = "
 CREATE TABLE mission_link_new (
     link_id        TEXT PRIMARY KEY,
@@ -2616,4 +2646,8 @@ fn m0039_tool_usage_ledger(tx: &Transaction) -> rusqlite::Result<()> {
 
 fn m0040_mission_body_snapshot(tx: &Transaction) -> rusqlite::Result<()> {
     tx.execute_batch(DDL_MISSION_BODY_SNAPSHOT)
+}
+
+fn m0041_retention_log(tx: &Transaction) -> rusqlite::Result<()> {
+    tx.execute_batch(DDL_RETENTION_LOG)
 }

--- a/rust-core/crates/friday-storage/src/session_lifecycle.rs
+++ b/rust-core/crates/friday-storage/src/session_lifecycle.rs
@@ -167,6 +167,30 @@ pub fn sweep_lifecycle(conn: &Connection, now_ms: i64) -> Result<SweepOutcome> {
         params![hard_delete_before],
     )?;
 
+    // M4 receipt — FOLDED INTO THE SWEEP TXN, before commit, so it is ATOMIC with the irreversible
+    // hard-delete. Reversibility rationale: M4's prune leg is IRREVERSIBLE (the rows are gone), so
+    // the invariant is "a hard-delete must NEVER commit without its receipt." The receipt INSERT
+    // therefore shares this txn and its `?` propagates: a receipt-write failure rolls the WHOLE
+    // sweep back, leaving no delete-without-receipt. Rolling back is safe because the reaper is
+    // idempotent and re-runs every tick, so a transient `SQLITE_BUSY` simply retries the whole
+    // sweep next tick. This is the deliberate MIRROR of M3's artifact sweep (retention.rs), where
+    // expiry is REVERSIBLE, so there the receipt is best-effort AFTER the commit and must never
+    // block the delete (receipt-must-not-block-delete vs. delete-must-not-happen-without-receipt).
+    //
+    // Written ONLY on a non-empty sweep so an idle-only tick never grows the log (retention_log has
+    // no sweep of its own); a hard-delete is always non-empty, so a real prune is always recorded.
+    // The prune leg is today armed-but-dormant (`pruned_at = 0` fires nothing until a session ages
+    // through prune), but the receipt path is correct the moment it does.
+    let nonempty =
+        idled != 0 || archived != 0 || pruned != 0 || hard_deleted != 0 || messages_deleted != 0;
+    if nonempty {
+        let summary = format!(
+            "session.reaper:idled={} archived={} pruned={} hard_deleted={} messages_deleted={}",
+            idled, archived, pruned, hard_deleted, messages_deleted,
+        );
+        crate::insert_retention_log_in(&tx, "session.reaper", &summary, now_ms)?;
+    }
+
     tx.commit()?;
 
     Ok(SweepOutcome {
@@ -601,6 +625,130 @@ mod tests {
             )
             .unwrap();
         assert_eq!(kept, 1, "the non-expired session keeps its message");
+    }
+
+    // --- M4 receipt: the reaper records the irreversible-prune counts -----------
+
+    fn retention_log_count(db: &Db) -> i64 {
+        db.conn()
+            .query_row("SELECT COUNT(*) FROM retention_log", [], |r| r.get(0))
+            .unwrap()
+    }
+
+    #[test]
+    fn hard_delete_writes_session_reaper_receipt_with_prune_counts() {
+        // M4: the hard-delete leg is the IRREVERSIBLE prune. A non-empty sweep must leave a
+        // content-free `session.reaper` receipt in `retention_log` carrying the hard_deleted /
+        // messages_deleted counts (the audit of the prune). It is NOT an audit_ledger row.
+        let db = Db::open_hub(&tmp("reaper-receipt")).unwrap();
+        let now = 100_000_000_000_i64;
+        seed(
+            &db,
+            "gone",
+            "pruned",
+            None,
+            None,
+            Some(now - HARD_DELETE_TIMEOUT_MS - 1),
+            1,
+        );
+        append_session_message(
+            db.conn(),
+            "gone",
+            &SessionMessage::new("user", "secret", None),
+            10,
+        )
+        .unwrap();
+        append_session_message(
+            db.conn(),
+            "gone",
+            &SessionMessage::new("assistant", "reply", None),
+            11,
+        )
+        .unwrap();
+
+        let out = sweep_lifecycle(db.conn(), now).unwrap();
+        assert_eq!(out.hard_deleted, 1);
+        assert_eq!(out.messages_deleted, 2);
+
+        assert_eq!(
+            retention_log_count(&db),
+            1,
+            "one non-empty sweep ⇒ one receipt"
+        );
+        let (tick_kind, summary): (String, String) = db
+            .conn()
+            .query_row("SELECT tick_kind, summary FROM retention_log", [], |r| {
+                Ok((r.get(0)?, r.get(1)?))
+            })
+            .unwrap();
+        assert_eq!(tick_kind, "session.reaper");
+        assert_eq!(
+            summary, "session.reaper:idled=0 archived=0 pruned=0 hard_deleted=1 messages_deleted=2",
+            "receipt carries the irreversible-prune counts"
+        );
+    }
+
+    #[test]
+    fn receipt_failure_rolls_back_hard_delete() {
+        // M4 atomicity invariant: the irreversible hard-delete must NEVER commit without its
+        // receipt. The receipt INSERT is folded into the sweep txn, so if it fails the WHOLE sweep
+        // rolls back. We force a deterministic receipt failure by dropping `retention_log` before
+        // the sweep: `insert_retention_log_in` then errors, `?` propagates, and the txn unwinds.
+        // The eligible session + its messages must SURVIVE (no delete-without-receipt).
+        let db = Db::open_hub(&tmp("reaper-receipt-fail")).unwrap();
+        let now = 100_000_000_000_i64;
+        seed(
+            &db,
+            "survivor",
+            "pruned",
+            None,
+            None,
+            Some(now - HARD_DELETE_TIMEOUT_MS - 1),
+            1,
+        );
+        append_session_message(
+            db.conn(),
+            "survivor",
+            &SessionMessage::new("user", "secret", None),
+            10,
+        )
+        .unwrap();
+
+        // Remove the receipt table so the folded INSERT cannot succeed.
+        db.conn().execute_batch("DROP TABLE retention_log").unwrap();
+
+        let res = sweep_lifecycle(db.conn(), now);
+        assert!(
+            res.is_err(),
+            "a receipt-write failure must surface as an Err, not a silently-committed prune"
+        );
+        assert!(
+            exists(&db, "survivor"),
+            "hard-delete must roll back when its receipt cannot be written"
+        );
+        let msgs: i64 = db
+            .conn()
+            .query_row(
+                "SELECT COUNT(*) FROM agent_session_message WHERE agent_session_id = 'survivor'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(msgs, 1, "child messages must roll back with the parent");
+    }
+
+    #[test]
+    fn empty_reaper_sweep_writes_no_receipt() {
+        // Growth fix: an idle tick (nothing eligible) writes NO receipt — retention_log has no
+        // sweep of its own, so an all-zero row every tick would grow unbounded.
+        let db = Db::open_hub(&tmp("reaper-empty")).unwrap();
+        let out = sweep_lifecycle(db.conn(), 100_000_000_000_i64).unwrap();
+        assert!(out.is_empty(), "no seeded rows ⇒ nothing swept");
+        assert_eq!(
+            retention_log_count(&db),
+            0,
+            "empty reaper sweep ⇒ no receipt"
+        );
     }
 
     // --- idempotency: second back-to-back sweep is a no-op ---------------------

--- a/src/state/sqlite/friday-rust-hub-schema-handshake.ts
+++ b/src/state/sqlite/friday-rust-hub-schema-handshake.ts
@@ -6,7 +6,7 @@ import Database from "better-sqlite3";
 import { FridayDomainError } from "#errors";
 
 export const FRIDAY_HUB_AGENT_RUN_DB_PATH_ENV = "FRIDAY_HUB_AGENT_RUN_DB_PATH";
-export const FRIDAY_EXPECTED_RUST_HUB_SCHEMA_VERSION = 40;
+export const FRIDAY_EXPECTED_RUST_HUB_SCHEMA_VERSION = 41;
 
 export type FridayRustHubSchemaHandshakeStatus = "ok" | "skipped";
 


### PR DESCRIPTION
## What & why (audit findings M3 + M4)

Data-destruction sweeps left **no receipt**. This adds a CONTENT-FREE, counts-only `retention_log` table (deliberately SEPARATE from the hash-chained `audit_ledger` — un-chained, never references it) so a destructive sweep records *that* it happened and *how many* rows it removed — never any row id/body/PII.

Two sweeps, two **reversibility-matched** receipt disciplines:

- **M3 — artifact sweep** (`sweep_retention`, reversible/lower-stakes expiry): receipt is **best-effort**, written AFTER the per-table delete txns (`let _ = insert_retention_log(...)`). A receipt failure must **never block or fail** the delete (*receipt-must-not-block-delete*). The sweep still never returns `Err`.
- **M4 — session lifecycle reaper** (`sweep_lifecycle`, IRREVERSIBLE hard-delete): receipt is folded **INTO** the reaper's existing sweep txn via a new no-BEGIN `insert_retention_log_in(&Transaction, …)` variant, committed atomically with the delete. Its `?` propagates, so a receipt-write failure **rolls the whole sweep back** (*delete-must-not-happen-without-receipt*). Safe to roll back because the reaper is idempotent and re-runs every tick.

Storage: additive **migration v41** (`destructive:false`, CREATE TABLE + INDEX only) + `retention_log` added to `HUB_ONLY_TABLES` (present on hub, absent on phone).

## Receipt is counts-only
- M3 summary: `retention.sweep:token_ledger=N surface_event=N memory_item=N work_item=N mission=N errors=N`
- M4 summary: `session.reaper:idled=N archived=N pruned=N hard_deleted=N messages_deleted=N`

Integers + literal labels only. Id is SQL-generated (`'retlog:' || lower(hex(randomblob(16)))`). No deleted row value is ever interpolated.

## Edge-case hardening (folded in from 2 independent reviewers)
The M3 receipt is gated on **actual deletions**, NOT `is_empty()` (which also folds in `table_errors`). An error-only tick (0 deletions, a per-table DELETE failed) now writes **no** receipt — otherwise it would be a misleading all-zero row that hides the error AND, since `retention_log` has no sweep of its own, would reintroduce unbounded per-tick growth under a persistent per-table error. When a receipt IS written, `errors=` records any concurrent failures so the row stays honest.

## Tests
- `hard_delete_writes_session_reaper_receipt_with_prune_counts` — M4 receipt carries the irreversible-prune counts.
- `receipt_failure_rolls_back_hard_delete` — **atomicity proof**: drop `retention_log` → folded INSERT errors → assert the eligible session **and its child messages SURVIVE** (the hard-delete rolled back).
- `empty_reaper_sweep_writes_no_receipt` / `empty_sweep_writes_no_retention_log_row` — idle ticks write nothing.
- `error_only_sweep_writes_no_retention_log_row` — error-only sweep (0 deletions) writes nothing.

`cargo test -p friday-storage` → 140 lib + all integration binaries green; `friday-hub` builds; clippy + fmt clean.

## ⚠️ Operator note — v41 is a one-way forward version bump
The schema-version handshake is `>=`: an older binary computes a strictly lower max and **fail-closes (`SchemaTooNew`)** on a v41 disk rather than corrupting it. So a rollback-after-deploy must roll back to a binary whose code-max is still ≥ the disk's, or accept the fail-closed open. Purely additive + HUB_ONLY, so no phone-client impact.

## Status — DARK
Both sweeps ride the session-reaper tick, which is DEFAULT-OFF (`FRIDAY_RUST_SESSION_REAPER_ENABLED` / `FRIDAY_RETENTION_SWEEP`). Deploying this binary reaps/sweeps NOTHING until the operator flips the flags. The prune leg is armed-but-dormant (`pruned_at=0`) until sessions age through the full ladder. Not a v1 GO.

🤖 Generated with [Claude Code](https://claude.com/claude-code)