### PR TITLE
fix(read-projection): name older schema skew

### DIFF
--- a/rust-core/crates/friday-hub/src/bin/hub_read_projection_server.rs
+++ b/rust-core/crates/friday-hub/src/bin/hub_read_projection_server.rs
@@ -137,6 +137,12 @@ enum ServerError {
         disk: i64,
         code: i64,
     },
+    /// The on-disk hub schema is STRICTLY OLDER than this binary requires ⇒ FAIL CLOSED.
+    /// Read-only bins never migrate; the writable deployment leg must open/migrate the DB first.
+    SchemaTooOld {
+        disk: i64,
+        code: i64,
+    },
     /// The SecureStore peer-pubkey allowlist is MISSING, INVALID, or EMPTY ⇒ FAIL CLOSED. (J2: the
     /// read seam admits a NON-EMPTY MULTI-peer list, so there is no longer a multi-peer refusal —
     /// only the missing/empty/corrupt fail-closed remains.)
@@ -159,6 +165,13 @@ fn main() {
                  newer than this build understands — rebuild from the deploying commit)"
             );
         }
+        if let ServerError::SchemaTooOld { disk, code } = &err {
+            eprintln!(
+                "hub_read_projection_server: leg=open error_kind=schema_too_old \
+                 disk_version={disk} code_version={code} (stale database: run the writable \
+                 migration/deploy leg before starting this read-only projection server)"
+            );
+        }
         eprintln!(
             "hub_read_projection_server_unavailable: {}",
             boot_error_kind(&err)
@@ -176,6 +189,7 @@ fn boot_error_kind(err: &ServerError) -> &'static str {
         ServerError::Bind => "bind_failed",
         ServerError::DbUnavailable => "db_unavailable",
         ServerError::SchemaTooNew { .. } => "schema_too_new",
+        ServerError::SchemaTooOld { .. } => "schema_too_old",
         ServerError::PeerAllowlist => "peer_allowlist_unavailable",
         ServerError::MasterKeyUnavailable => "master_key_unavailable",
         ServerError::StoreUnavailable => "secure_store_unavailable",
@@ -991,6 +1005,7 @@ fn arg_value(args: &[String], name: &str) -> Option<String> {
 fn open_hub_readonly_guarded(db_path: &str) -> Result<Db, ServerError> {
     Db::open_hub_readonly(db_path).map_err(|e| match e {
         StorageError::SchemaTooNew { disk, code } => ServerError::SchemaTooNew { disk, code },
+        StorageError::SchemaTooOld { disk, code } => ServerError::SchemaTooOld { disk, code },
         _ => ServerError::DbUnavailable,
     })
 }
@@ -2751,6 +2766,38 @@ mod tests {
         assert_eq!(
             boot_error_kind(&ServerError::DbUnavailable),
             "db_unavailable"
+        );
+    }
+
+    /// NEW read server vs an older, not-yet-migrated DB: still fail-closed, but name the
+    /// deploy-order skew instead of hiding it behind the generic `db_unavailable`.
+    #[test]
+    fn older_on_disk_schema_fails_closed_with_named_skew() {
+        let path = temp_db_path("ro-too-old");
+        {
+            let db = Db::open_hub(&path).unwrap();
+            db.conn()
+                .execute(
+                    "UPDATE schema_version SET version = ?1 WHERE id = 1",
+                    [friday_storage::hub_code_max() - 1],
+                )
+                .unwrap();
+            drop(db);
+        }
+        let err = match open_hub_readonly_guarded(&path) {
+            Ok(_) => panic!("a read-only server must NOT open a pre-migration DB"),
+            Err(e) => e,
+        };
+        match err {
+            ServerError::SchemaTooOld { disk, code } => {
+                assert_eq!(disk, friday_storage::hub_code_max() - 1);
+                assert_eq!(code, friday_storage::hub_code_max());
+            }
+            other => panic!("expected SchemaTooOld naming the skew, got {other:?}"),
+        }
+        assert_eq!(
+            boot_error_kind(&ServerError::SchemaTooOld { disk: 1, code: 99 }),
+            "schema_too_old"
         );
     }
 

--- a/rust-core/crates/friday-storage/src/error.rs
+++ b/rust-core/crates/friday-storage/src/error.rs
@@ -13,6 +13,14 @@ pub enum StorageError {
     #[error("on-disk schema (v{disk}) is newer than this build (v{code}); refusing to open")]
     SchemaTooNew { disk: i64, code: i64 },
 
+    /// On-disk schema is older than this read-only build requires. Read-only
+    /// paths refuse to migrate implicitly, so deploy order must run the writable
+    /// migration leg first.
+    #[error(
+        "on-disk schema (v{disk}) is older than this build (v{code}); refusing to open read-only"
+    )]
+    SchemaTooOld { disk: i64, code: i64 },
+
     #[error("destructive-migration backup failed: {0}")]
     BackupVerify(String),
 

--- a/rust-core/crates/friday-storage/src/lib.rs
+++ b/rust-core/crates/friday-storage/src/lib.rs
@@ -473,9 +473,10 @@ impl Db {
             });
         }
         if disk_version < code_version {
-            return Err(StorageError::Unsupported(format!(
-                "database schema is older than this Friday build: disk version {disk_version}, code version {code_version}"
-            )));
+            return Err(StorageError::SchemaTooOld {
+                disk: disk_version,
+                code: code_version,
+            });
         }
         Ok(Db {
             conn,
@@ -2167,6 +2168,40 @@ mod read_only_schema_guard_tests {
                 assert_eq!(code, hub_code_max(), "the skew names the binary's code_max");
             }
             other => panic!("expected SchemaTooNew naming the skew, got {other:?}"),
+        }
+    }
+
+    /// A read-only bin built from a NEWER deploy must also fail closed when pointed at
+    /// an older Hub DB. It cannot run migrations by construction; naming this skew keeps
+    /// deploy-order mistakes diagnosable without weakening the guard.
+    #[test]
+    fn older_on_disk_version_fails_closed_with_named_skew() {
+        let path = tmp("too-old");
+        {
+            let writer = Db::open_hub(&path).unwrap();
+            writer
+                .conn()
+                .execute(
+                    "UPDATE schema_version SET version = ?1 WHERE id = 1",
+                    [hub_code_max() - 1],
+                )
+                .unwrap();
+            drop(writer);
+        }
+        let err = match Db::open_hub_readonly(&path) {
+            Ok(_) => panic!("a strictly-older on-disk schema must fail closed"),
+            Err(e) => e,
+        };
+        match err {
+            StorageError::SchemaTooOld { disk, code } => {
+                assert_eq!(
+                    disk,
+                    hub_code_max() - 1,
+                    "the skew names the on-disk version"
+                );
+                assert_eq!(code, hub_code_max(), "the skew names the binary's code_max");
+            }
+            other => panic!("expected SchemaTooOld naming the skew, got {other:?}"),
         }
     }
 }


### PR DESCRIPTION
## Summary
- add structured `SchemaTooOld` for read-only Hub DB open skew
- surface `schema_too_old` from `hub_read_projection_server` instead of collapsing pre-migration DBs into `db_unavailable`
- add storage and read-projection tests for older-schema fail-closed behavior

## Verification
- `cargo fmt --manifest-path rust-core/Cargo.toml --all -- --check`
- `cargo test --manifest-path rust-core/Cargo.toml -p friday-storage read_only_schema_guard_tests -- --nocapture`
- `cargo test --manifest-path rust-core/Cargo.toml -p friday-hub --bin hub_read_projection_server schema_fails_closed_with_named_skew -- --nocapture`
- copied live v40 DB to `/tmp`, ran new debug `hub_read_projection_server`, observed `schema_too_old disk_version=40 code_version=41` fail-closed

Truth: diagnostic-only; no migration, no prod DB write, no prod restart, no GO-LIVE/adoption claim.