### PR TITLE
test(ui): report design action coverage from live bundle

### DIFF
--- a/scripts/ops/check-friday-design-action-runtime-evidence.mjs
+++ b/scripts/ops/check-friday-design-action-runtime-evidence.mjs
@@ -216,6 +216,24 @@ function summarizeBy(rows, key) {
   return Object.fromEntries([...counts.entries()].sort((a, b) => String(a[0]).localeCompare(String(b[0]))));
 }
 
+function actionKey(row) {
+  return [
+    row.surface,
+    row.screen,
+    row.actionId,
+    row.capabilityId,
+  ].join("|");
+}
+
+function uniqueRows(rows) {
+  const byKey = new Map();
+  for (const row of rows) {
+    const key = actionKey(row);
+    if (!byKey.has(key)) byKey.set(key, row);
+  }
+  return [...byKey.values()];
+}
+
 const contractRows = parseActionContract(contractPath);
 const runtimeRows = readRuntimeEvidence(runtimeEvidencePath);
 const actionableRows = contractRows.filter((row) => row.actionable);
@@ -237,6 +255,9 @@ const evidenceRows = actionableRows.map((row) => {
 
 const missingRuntime = evidenceRows.filter((row) => row.runtimeStatus !== "runtime_action_evidence_pass");
 const missingNative = evidenceRows.filter((row) => row.nativeStatus === "native_hint_missing" || row.nativeStatus === "source_missing");
+const uniqueActionableRows = uniqueRows(actionableRows);
+const uniqueEvidenceRows = uniqueRows(evidenceRows);
+const missingUniqueRuntime = uniqueRows(uniqueEvidenceRows.filter((row) => row.runtimeStatus !== "runtime_action_evidence_pass"));
 const topMissing = missingRuntime.slice(0, 40).map((row) => ({
   surface: row.surface,
   screen: row.screen,
@@ -255,14 +276,24 @@ const report = {
   counts: {
     contractRows: contractRows.length,
     actionableRows: actionableRows.length,
+    uniqueActionableRows: uniqueActionableRows.length,
     runtimeEvidenceRows: runtimeRows.length,
     missingRuntimeEvidence: missingRuntime.length,
+    missingUniqueRuntimeEvidence: missingUniqueRuntime.length,
     missingNativeHints: missingNative.length,
   },
   bySurface: summarizeBy(actionableRows, "surface"),
   byTruthStatus: summarizeBy(actionableRows, "truthStatus"),
   gaps: {
     missingRuntimeEvidence: topMissing,
+    missingUniqueRuntimeEvidence: missingUniqueRuntime.slice(0, 40).map((row) => ({
+      surface: row.surface,
+      screen: row.screen,
+      actionId: row.actionId,
+      label: row.label,
+      capabilityId: row.capabilityId,
+      preferredEvidence: `${row.surface}/${row.screen}/${row.actionId}`,
+    })),
     missingNativeHints: missingNative.slice(0, 40),
   },
   capturePlan: [

--- a/scripts/ops/friday-ui-device-live-write-read-capture-bundle.sh
+++ b/scripts/ops/friday-ui-device-live-write-read-capture-bundle.sh
@@ -12,6 +12,7 @@ usage:
     [--timeline-capture /abs/timeline-capture]
     [--same-run-events /abs/same-run-events.jsonl]
     [--evidence-dir /abs/evidence-dir]
+    [--design-action-contract /abs/ACTION-CONTRACT.md]
 
 Runs the mobile and desktop live write-read capture runners with one shared
 mission id, then indexes the resulting artifacts into a partial bundle.
@@ -42,6 +43,7 @@ channel_capture=""
 timeline_capture=""
 same_run_events=""
 evidence_dir=""
+design_action_contract="${FRIDAY_DESIGN_ACTION_CONTRACT:-}"
 
 while [ "$#" -gt 0 ]; do
   case "$1" in
@@ -135,6 +137,15 @@ while [ "$#" -gt 0 ]; do
       evidence_dir="${1#--evidence-dir=}"
       shift
       ;;
+    --design-action-contract)
+      [ "$#" -ge 2 ] || die "--design-action-contract requires a value"
+      design_action_contract="$2"
+      shift 2
+      ;;
+    --design-action-contract=*)
+      design_action_contract="${1#--design-action-contract=}"
+      shift
+      ;;
     --help|-h)
       usage
       exit 0
@@ -160,6 +171,12 @@ for optional_path in "${channel_capture}" "${timeline_capture}" "${same_run_even
     esac
   fi
 done
+if [ -n "${design_action_contract}" ]; then
+  case "${design_action_contract}" in
+    /*) ;;
+    *) die "--design-action-contract must be absolute: ${design_action_contract}" ;;
+  esac
+fi
 
 if [ -z "${shared_id}" ]; then
   shared_id="mission-ui-device-live-write-read-$(date -u +%Y%m%dT%H%M%SZ)-$(uuidgen | tr '[:upper:]' '[:lower:]')"
@@ -203,6 +220,21 @@ node "${repo_root}/scripts/ops/friday-ui-device-live-write-read-bundle.mjs" \
   --desktop-capture-dir="${desktop_dir}" \
   --mission-id="${canonical_shared_mission_id}" \
   --require-ready
+
+action_runtime_evidence="${bundle_dir}/action-runtime-evidence.json"
+design_action_report="${bundle_dir}/design-action-runtime-gap.json"
+if [ -z "${design_action_contract}" ] && [ -s "${HOME}/Desktop/friday-design-handoff-20260602/ACTION-CONTRACT.md" ]; then
+  design_action_contract="${HOME}/Desktop/friday-design-handoff-20260602/ACTION-CONTRACT.md"
+fi
+if [ -n "${design_action_contract}" ] && [ -s "${design_action_contract}" ] && [ -s "${action_runtime_evidence}" ]; then
+  node "${repo_root}/scripts/ops/check-friday-design-action-runtime-evidence.mjs" \
+    --contract="${design_action_contract}" \
+    --runtime-evidence="${action_runtime_evidence}" \
+    --out="${design_action_report}" >/tmp/friday-ui-device-live-write-read-design-action.$$.json
+  echo "design_action_runtime=${design_action_report}"
+else
+  echo "design_action_runtime=skipped(no contract or action runtime evidence)"
+fi
 
 if [ -n "${channel_capture}${timeline_capture}${same_run_events}" ]; then
   [ -n "${channel_capture}" ] || die "--channel-capture is required when building an evidence dir"

--- a/test/unit/qa/friday-design-action-runtime-evidence-cli.test.ts
+++ b/test/unit/qa/friday-design-action-runtime-evidence-cli.test.ts
@@ -48,13 +48,20 @@ describe("check-friday-design-action-runtime-evidence", () => {
       const report = JSON.parse(output) as {
         truth?: string;
         status?: string;
-        counts?: { actionableRows?: number; missingRuntimeEvidence?: number };
+        counts?: {
+          actionableRows?: number;
+          uniqueActionableRows?: number;
+          missingRuntimeEvidence?: number;
+          missingUniqueRuntimeEvidence?: number;
+        };
         gaps?: { missingRuntimeEvidence?: Array<{ actionId?: string }> };
       };
       expect(report.truth).toBe("design_action_runtime_gap_report_not_endbar_not_runtime_adoption");
       expect(report.status).toBe("gaps_present");
       expect(report.counts?.actionableRows).toBe(2);
+      expect(report.counts?.uniqueActionableRows).toBe(2);
       expect(report.counts?.missingRuntimeEvidence).toBe(2);
+      expect(report.counts?.missingUniqueRuntimeEvidence).toBe(2);
       expect(report.gaps?.missingRuntimeEvidence).toEqual(
         expect.arrayContaining([
           expect.objectContaining({ actionId: "act" }),
@@ -88,11 +95,12 @@ describe("check-friday-design-action-runtime-evidence", () => {
       ], { cwd: process.cwd(), encoding: "utf8" });
       const report = JSON.parse(output) as {
         status?: string;
-        counts?: { missingRuntimeEvidence?: number };
+        counts?: { missingRuntimeEvidence?: number; missingUniqueRuntimeEvidence?: number };
         gaps?: { missingRuntimeEvidence?: Array<{ surface?: string; actionId?: string }> };
       };
       expect(report.status).toBe("gaps_present");
       expect(report.counts?.missingRuntimeEvidence).toBe(1);
+      expect(report.counts?.missingUniqueRuntimeEvidence).toBe(1);
       expect(report.gaps?.missingRuntimeEvidence).toEqual([
         expect.objectContaining({ surface: "desktop", actionId: "check" }),
       ]);

--- a/test/unit/qa/friday-ui-device-live-write-read-capture-bundle-cli.test.ts
+++ b/test/unit/qa/friday-ui-device-live-write-read-capture-bundle-cli.test.ts
@@ -100,18 +100,33 @@ function writeCompleteSameRunEvents(path: string, refs: { mobile: string; deskto
   writeFileSync(path, `${rows.map((row) => JSON.stringify(row)).join("\n")}\n`);
 }
 
+function writeDesignActionContract(path: string) {
+  writeFileSync(path, `# Friday Action Contract — test
+
+Every row is design-proof; wired_registry ≠ runtime PASS.
+
+| Surface | Screen [state] | action_id | Label | capability_id | reg | reg_status | truth_status | result/target | Rust/Hub owner · gate · test expectation |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| mobile | fridayChat [typing] | chat:typing | Ask | ask_friday_chat | ✓ | wired | design_proof | — | Runtime test must prove action. |
+| desktop | fridayChat | caprow | Ask row | ask_friday_chat_compose_send | ✓ | wired | design_proof | — | Capability row only. |
+`);
+}
+
 describe("friday-ui-device-live-write-read-capture-bundle", () => {
   it("runs mobile and desktop captures with the same mission id, then writes a partial bundle", () => {
     const tempDir = mkdtempSync(join(tmpdir(), "friday-ui-device-orchestrator-"));
     try {
       const outDir = join(tempDir, "capture");
+      const contract = join(tempDir, "ACTION-CONTRACT.md");
       const fakeBin = fakeSwiftScript(tempDir);
+      writeDesignActionContract(contract);
 
       const stdout = execFile("bash", [
         script,
         `--out-dir=${outDir}`,
         `--shared-id=${sharedId}`,
         "--read-port=59151",
+        `--design-action-contract=${contract}`,
       ], {
         cwd: process.cwd(),
         encoding: "utf8",
@@ -122,6 +137,7 @@ describe("friday-ui-device-live-write-read-capture-bundle", () => {
       });
 
       expect(stdout).toContain("PASS - same-mission mobile+desktop live write-read capture bundle written");
+      expect(stdout).toContain(`design_action_runtime=${join(outDir, "bundle", "design-action-runtime-gap.json")}`);
       const index = JSON.parse(readFileSync(join(outDir, "bundle", "live-write-read-bundle-index.json"), "utf8")) as {
         status?: string;
         missionId?: string;
@@ -133,6 +149,11 @@ describe("friday-ui-device-live-write-read-capture-bundle", () => {
       expect(index.captures?.mobile?.event_count).toBe(5);
       expect(index.captures?.desktop?.event_count).toBe(5);
       expect(index.fullProofGaps).toContain("bounded_timeline_capture");
+      const designReport = JSON.parse(readFileSync(join(outDir, "bundle", "design-action-runtime-gap.json"), "utf8")) as {
+        counts?: { uniqueActionableRows?: number; missingUniqueRuntimeEvidence?: number };
+      };
+      expect(designReport.counts?.uniqueActionableRows).toBe(1);
+      expect(designReport.counts?.missingUniqueRuntimeEvidence).toBe(1);
     } finally {
       rmSync(tempDir, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary
- add unique-action coverage counts to the design action runtime evidence report without relaxing `status` or `--require-complete`
- have the mobile+desktop live write/read bundle automatically emit a design-action runtime gap report when an operator-confirmed action contract is available
- cover the new reporting path in QA tests

## Verification
- `bash -n scripts/ops/friday-ui-device-live-write-read-capture-bundle.sh`
- `PATH=/Users/jarvis/Projects/Friday/node_modules/.bin:$PATH vitest run --project default test/unit/qa/friday-design-action-runtime-evidence-cli.test.ts test/unit/qa/friday-ui-device-live-write-read-capture-bundle-cli.test.ts test/unit/qa/friday-ui-device-live-write-read-bundle-cli.test.ts`
- real live bundle with patched script: `scripts/ops/friday-ui-device-live-write-read-capture-bundle.sh --out-dir /tmp/friday-ui-live-write-read-bundle-autogap-20260625T095442Z`
- autogap report from that live run: `actionableRows=78`, `uniqueActionableRows=29`, `runtimeEvidenceRows=2`, `missingRuntimeEvidence=58`, `missingUniqueRuntimeEvidence=25`

Truth: reporting/automation only. This does not mark END-BAR, GO-LIVE, adoption, or any remaining approval/memory/firstLaunch action closed.
