### PR TITLE
fix: owner-bind activity mark-done (close WS IDOR) [M6]

### DIFF
--- a/rust-core/crates/friday-ffi/src/lib.rs
+++ b/rust-core/crates/friday-ffi/src/lib.rs
@@ -429,6 +429,8 @@ fn load_phone_activity(db_path: &str) -> friday_storage::Result<Vec<ActivityItem
             created_at: t,
             updated_at: t,
             deep_link: None,
+            // Local phone seed — owner=NULL (legacy-allow under the local FFI mark-done path).
+            owner: None,
         };
         db.insert_activity(&seed(
             "a1",
@@ -498,7 +500,10 @@ fn mark_and_list(
     let db = friday_storage::Db::open_phone(db_path)?;
     // Surface an unknown id instead of silently succeeding: `mark_activity_done`
     // returns false when no row matched (file-37 NIT #4).
-    if !db.mark_activity_done(activity_id, now)? {
+    // M6: the local single-owner phone/desktop path passes `None` — this is not the network
+    // WS attack surface, and the NULL-owner=legacy-allow arm preserves it as a no-op (phone
+    // activity rows are only ever the FFI seeds below, all owner=NULL).
+    if !db.mark_activity_done(activity_id, None, now)? {
         return Err(friday_storage::StorageError::NotFound(format!(
             "activity_id {activity_id}"
         )));
@@ -2251,6 +2256,7 @@ mod tests {
                 created_at: 99,
                 updated_at: 99,
                 deep_link: None,
+                owner: None,
             })
             .unwrap();
         }

--- a/rust-core/crates/friday-hub/src/bin/hub_agent_run_server.rs
+++ b/rust-core/crates/friday-hub/src/bin/hub_agent_run_server.rs
@@ -2255,6 +2255,10 @@ fn serve_sealed_session<S: Read + Write, T: Transport>(
                     runtime.db(),
                     &env.msg_id,
                     request,
+                    // M6: thread the run's bound principal as the authenticated owner (mirror
+                    // the memory_decision / run_outcome_learning sibling arms above) so the
+                    // mark-done is owner-scoped.
+                    runtime.policy().principal_id(),
                     now_ms,
                 );
                 eprintln!(

--- a/rust-core/crates/friday-hub/src/channel_event.rs
+++ b/rust-core/crates/friday-hub/src/channel_event.rs
@@ -220,6 +220,10 @@ pub fn ingest_channel_inbound(
         created_at: now_ms,
         updated_at: now_ms,
         deep_link: None,
+        // M6: stamp the channel's BOUND OWNER principal (NOT the sender_id) so mark-done
+        // scopes the clear to the owner who owns the binding. Shares the WS principal_id()
+        // identifier space.
+        owner: Some(redacted.bound_principal_id.clone()),
     };
     let audit = AuditEvent {
         audit_id: activity_id.clone(),
@@ -415,6 +419,66 @@ mod tests {
             0,
             "not executed in-channel"
         );
+    }
+
+    /// M6 (real-derivation, NOT a hand-set owner): a Pending ChannelInbound row produced by
+    /// the REAL ingest carries `owner = bound_principal_id` ("owner-1"), NOT the `sender_id`
+    /// ("u-1"). Marking it done with the bound OWNER ALLOWS; marking it done with the SENDER
+    /// or any other principal is BLOCKED and leaves the row Pending — so the channel binding
+    /// (not a coincidence) is the proven discriminator.
+    #[test]
+    fn m6_channel_inbound_owner_is_bound_principal_allows_owner_denies_sender_and_other() {
+        let mut db = Db::open_hub(&tmp()).unwrap();
+        let r = redacted("run the migration");
+        // RequiresApprovalElsewhere ⇒ a Pending (markable) row.
+        let receipt =
+            ingest_channel_inbound(&mut db, &r, "m-1", "run_command", true, Risk::High, &[], 1)
+                .unwrap();
+        assert_eq!(receipt.disposition, "requires_approval_elsewhere");
+        let activity_id = channel_event_id("tg:room-1", "m-1");
+
+        // The stamped owner is the BOUND principal "owner-1", NOT the sender "u-1".
+        let stored_owner: Option<String> = db
+            .conn()
+            .query_row(
+                "SELECT owner FROM activity_item WHERE activity_id = ?1",
+                [activity_id.as_str()],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(stored_owner.as_deref(), Some("owner-1"));
+        assert_ne!(
+            stored_owner.as_deref(),
+            Some("u-1"),
+            "owner must be the bound principal, never the sender_id"
+        );
+
+        let state = |db: &Db| -> String {
+            db.conn()
+                .query_row(
+                    "SELECT state FROM activity_item WHERE activity_id = ?1",
+                    [activity_id.as_str()],
+                    |row| row.get(0),
+                )
+                .unwrap()
+        };
+
+        // The SENDER ("u-1") is NOT the owner ⇒ BLOCKED, row stays Pending.
+        assert!(!db
+            .mark_activity_done(&activity_id, Some("u-1"), 200)
+            .unwrap());
+        assert_eq!(state(&db), "pending");
+        // A different principal ("bob") ⇒ BLOCKED, row stays Pending.
+        assert!(!db
+            .mark_activity_done(&activity_id, Some("bob"), 201)
+            .unwrap());
+        assert_eq!(state(&db), "pending");
+
+        // The BOUND OWNER ("owner-1") ⇒ ALLOWED.
+        assert!(db
+            .mark_activity_done(&activity_id, Some("owner-1"), 300)
+            .unwrap());
+        assert_eq!(state(&db), "done");
     }
 
     #[test]

--- a/rust-core/crates/friday-hub/src/hub_server.rs
+++ b/rust-core/crates/friday-hub/src/hub_server.rs
@@ -2056,6 +2056,7 @@ pub fn activity_mark_done_result_for_db(
     db: &Db,
     msg_id: &str,
     request: ActivityMarkDoneRequestWire,
+    authenticated_owner: Option<&str>,
     now_ms: i64,
 ) -> Envelope {
     let activity_id = request.activity_id.trim();
@@ -2063,7 +2064,27 @@ pub fn activity_mark_done_result_for_db(
         return activity_mark_done_blocked(msg_id, now_ms, "", "unknown", "activity_id_required");
     }
 
-    match db.mark_activity_done(activity_id, now_ms) {
+    // M6: the SCOPE source is the AUTHENTICATED owner (the Rust-derived principal threaded
+    // from the WS dispatch arm), NEVER a raw body field. An empty/absent owner fails closed
+    // with `owner_principal_required` (mirrors `memory_decision_result_for_db`). The WS path
+    // always passes `Some(principal)`; the local FFI path passes `None` and goes through
+    // `Db::mark_activity_done` directly (the legacy NULL-allow arm), never here.
+    let owner = authenticated_owner.unwrap_or("").trim();
+    if owner.is_empty() {
+        return activity_mark_done_blocked(
+            msg_id,
+            now_ms,
+            activity_id,
+            "unknown",
+            "owner_principal_required",
+        );
+    }
+
+    // Owner-scoped clear: a cross-owner row (a different principal's item) and an unknown id
+    // BOTH yield `Ok(false)` => both map to `unknown_activity` (no existence oracle — a
+    // cross-owner probe is indistinguishable from a missing id, which is MORE leak-resistant
+    // than the sibling get-row/check-owner idiom).
+    match db.mark_activity_done(activity_id, Some(owner), now_ms) {
         Ok(true) => Envelope::new(
             format!("{msg_id}-activity-mark-done"),
             now_ms,
@@ -7888,6 +7909,11 @@ mod tests {
     }
 
     fn seed_activity(db: &Db, activity_id: &str) {
+        seed_activity_owned(db, activity_id, Some("owner-1"));
+    }
+
+    /// Seed a Pending ApprovalRequired row owned by `owner` (None = pre-migration NULL owner).
+    fn seed_activity_owned(db: &Db, activity_id: &str, owner: Option<&str>) {
         db.insert_activity(&friday_storage::ActivityRow {
             activity_id: activity_id.to_string(),
             session_id: Some("session-activity".to_string()),
@@ -7897,6 +7923,7 @@ mod tests {
             created_at: 1_000,
             updated_at: 1_000,
             deep_link: Some("friday://activity/session-activity".to_string()),
+            owner: owner.map(str::to_string),
         })
         .unwrap();
     }
@@ -7913,6 +7940,8 @@ mod tests {
                 activity_id: "activity-mark-done-1".into(),
                 reason: Some("owner cleared it".into()),
             },
+            // The seeded row's owner — an owner-match ALLOW.
+            Some("owner-1"),
             1_200,
         );
         let result = decode_activity_mark_done(&env);
@@ -7947,6 +7976,9 @@ mod tests {
                 activity_id: "missing-activity".into(),
                 reason: None,
             },
+            // A non-empty authenticated owner so this exercises the unknown-id path, NOT the
+            // owner-empty fail-closed path.
+            Some("owner-1"),
             1_200,
         );
         let result = decode_activity_mark_done(&env);
@@ -7954,6 +7986,92 @@ mod tests {
         assert_eq!(result.state, "unknown");
         assert_eq!(result.blocker.as_deref(), Some("unknown_activity"));
         assert_eq!(db.count("activity_item").unwrap(), 0);
+    }
+
+    /// M6: the producer fails closed when no authenticated owner is threaded (None / empty /
+    /// whitespace), mirroring `memory_decision_result_for_db`. The WS arm always passes
+    /// `Some(principal)`; this is the defense-in-depth guard.
+    #[test]
+    fn activity_mark_done_empty_owner_is_blocked_owner_principal_required() {
+        let db = Db::open_hub(&tmp_db()).unwrap();
+        seed_activity(&db, "activity-mark-done-1");
+        for owner in [None, Some(""), Some("   ")] {
+            let env = activity_mark_done_result_for_db(
+                &db,
+                "msg-no-owner",
+                ActivityMarkDoneRequestWire {
+                    activity_id: "activity-mark-done-1".into(),
+                    reason: None,
+                },
+                owner,
+                1_200,
+            );
+            let result = decode_activity_mark_done(&env);
+            assert_eq!(
+                result.status, "blocked",
+                "empty owner ⇒ blocked ({owner:?})"
+            );
+            assert_eq!(result.blocker.as_deref(), Some("owner_principal_required"));
+        }
+        // The row was never touched.
+        let rows = db.list_activity().unwrap();
+        assert_eq!(rows[0].state, "pending");
+    }
+
+    /// M6: a cross-owner mark-done (the row is owned by a DIFFERENT principal) is BLOCKED and
+    /// the row is unchanged. By design the cross-owner case is indistinguishable from an
+    /// unknown id (no existence oracle), so only `status=="blocked"` is asserted — NOT a
+    /// distinct mismatch reason.
+    #[test]
+    fn activity_mark_done_cross_owner_is_blocked_and_row_unchanged() {
+        let db = Db::open_hub(&tmp_db()).unwrap();
+        seed_activity_owned(&db, "activity-mark-done-1", Some("owner-1"));
+        let env = activity_mark_done_result_for_db(
+            &db,
+            "msg-cross-owner",
+            ActivityMarkDoneRequestWire {
+                activity_id: "activity-mark-done-1".into(),
+                reason: None,
+            },
+            // A DIFFERENT authenticated principal.
+            Some("owner-2"),
+            1_200,
+        );
+        let result = decode_activity_mark_done(&env);
+        assert_eq!(result.status, "blocked", "a cross-owner clear is blocked");
+        // Row unchanged — still Pending, never cleared by a non-owner.
+        let rows = db.list_activity().unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(
+            rows[0].state, "pending",
+            "the non-owner clear changed nothing"
+        );
+    }
+
+    /// M6: a pre-migration (NULL-owner) row is legacy-allow — any authenticated principal can
+    /// clear it (a deny-NULL would strand pre-deploy rows = a degrade).
+    #[test]
+    fn activity_mark_done_null_owner_legacy_row_is_allowed_for_any_principal() {
+        let db = Db::open_hub(&tmp_db()).unwrap();
+        // A pre-migration row carries owner = NULL.
+        seed_activity_owned(&db, "activity-mark-done-1", None);
+        let env = activity_mark_done_result_for_db(
+            &db,
+            "msg-null-owner",
+            ActivityMarkDoneRequestWire {
+                activity_id: "activity-mark-done-1".into(),
+                reason: None,
+            },
+            Some("any-principal"),
+            1_200,
+        );
+        let result = decode_activity_mark_done(&env);
+        assert_eq!(
+            result.status, "done",
+            "a NULL-owner legacy row clears (legacy-allow)"
+        );
+        let rows = db.list_activity().unwrap();
+        assert_eq!(rows[0].state, "done");
     }
 
     #[test]

--- a/rust-core/crates/friday-hub/src/lib.rs
+++ b/rust-core/crates/friday-hub/src/lib.rs
@@ -2322,6 +2322,8 @@ pub fn record_friday_ask<T: friday_deepseek::Transport>(
         created_at: now_ms,
         updated_at: now_ms,
         deep_link: None,
+        // Non-markable Done receipt — never owner-scoped.
+        owner: None,
     };
     let audit = AuditEvent {
         audit_id: format!("{ledger_id}:modelcall"),
@@ -4526,6 +4528,8 @@ pub(crate) fn bill_model_call_keyed(
         created_at: now_ms,
         updated_at: now_ms,
         deep_link: None,
+        // Non-markable Done receipt — never owner-scoped.
+        owner: None,
     };
     let audit = AuditEvent {
         audit_id,
@@ -6192,6 +6196,9 @@ fn run_loop_with_policy_inner(
                         run_id,
                         &nonce,
                         &raw.action,
+                        // M6: stamp the run's bound principal so mark-done scopes to the owner
+                        // (the SAME source the WS mark-done arm threads = policy.principal_id()).
+                        policy.principal_id(),
                         now_ms,
                     );
                 }
@@ -7672,6 +7679,90 @@ mod tests {
             activity.is_empty(),
             "flag OFF ⇒ ZERO activity rows from the pause (byte-identical baseline)"
         );
+    }
+
+    /// M6 (real-derivation, NOT a hand-set owner): an ApprovalRequired row produced by a REAL
+    /// paused run carries `owner = policy.principal_id()` ("alice") — the SAME source the WS
+    /// mark-done arm threads. Marking it done with that real principal ALLOWS; a different
+    /// principal is BLOCKED and leaves the row Pending.
+    #[test]
+    fn m6_approval_required_owner_is_run_principal_allows_owner_denies_other() {
+        let root = TempDir::new("m6-approval");
+        let db = Db::open_hub(&temp_path("m6-approval")).unwrap();
+        agent_run::create_run(db.conn(), "r1", "do it", 1).unwrap();
+        let write = raw("write_file", &[("path", "out.txt"), ("content", "X")]);
+        let client = ScriptedAgentLlmClient::new(vec![AgentStep::Tool(write)]);
+        let executor = FsToolExecutor::new(&root.0);
+        // The run's bound principal is "alice" (= policy.principal_id()).
+        let policy = RunPolicy::new(Some("alice".to_string()), Vec::<String>::new(), false);
+        let out = run_loop_with_policy_flagged(
+            &client,
+            &executor,
+            db.conn(),
+            "r1",
+            "do it",
+            "",
+            None, // unprovisioned ⇒ fail-closed Pause for the mutating write
+            &no_approval(),
+            &policy,
+            5,
+            None,
+            None,
+            1000,
+            true,  // activity_needs_me ON ⇒ the ApprovalRequired row is produced
+            false, // clarification gate OFF
+            false, // subagent OFF
+            false, // rich_prompt OFF
+            false, // self_critique OFF
+            &[],   // done_criteria
+            None,  // work_item_id
+            None,  // escalation_client
+        )
+        .unwrap();
+        assert_eq!(out.status, LoopStatus::Paused, "the mutating write Pauses");
+
+        let activity = db.list_activity().unwrap();
+        assert_eq!(activity.len(), 1, "exactly one ApprovalRequired row");
+        let activity_id = activity[0].activity_id.clone();
+        assert_eq!(
+            activity[0].kind,
+            friday_core::ActivityType::ApprovalRequired.as_str()
+        );
+
+        // The stamped owner is the run's principal "alice".
+        let stored_owner: Option<String> = db
+            .conn()
+            .query_row(
+                "SELECT owner FROM activity_item WHERE activity_id = ?1",
+                [activity_id.as_str()],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(stored_owner.as_deref(), Some("alice"));
+
+        let state = |db: &Db| -> String {
+            db.conn()
+                .query_row(
+                    "SELECT state FROM activity_item WHERE activity_id = ?1",
+                    [activity_id.as_str()],
+                    |r| r.get(0),
+                )
+                .unwrap()
+        };
+
+        // A different principal ⇒ BLOCKED, row stays Pending.
+        assert!(!db
+            .mark_activity_done(&activity_id, Some("bob"), 2000)
+            .unwrap());
+        assert_eq!(state(&db), "pending");
+        // The run's REAL principal_id() (NOT a hardcoded literal) ⇒ ALLOWED. This proves the
+        // stamped owner and the WS mark-done principal share ONE identifier space (the cleared
+        // value IS what policy.principal_id() returns, not a coincidence).
+        assert_eq!(policy.principal_id(), Some("alice"));
+        assert!(db
+            .mark_activity_done(&activity_id, policy.principal_id(), 3000)
+            .unwrap());
+        assert_eq!(state(&db), "done");
     }
 
     // ── FRIDAY_CLARIFICATION_GATE: the clarification gate (loop-level, bool-injected) ──────

--- a/rust-core/crates/friday-hub/src/memory_extraction.rs
+++ b/rust-core/crates/friday-hub/src/memory_extraction.rs
@@ -447,6 +447,7 @@ pub(crate) fn memory_review_activity_row(
     state: MemoryState,
     scope: MemoryScope,
     summary: &str,
+    owner: Option<&str>,
     now_ms: i64,
 ) -> Option<ActivityRow> {
     let NeedsMeItem {
@@ -465,6 +466,10 @@ pub(crate) fn memory_review_activity_row(
         created_at: now_ms,
         updated_at: now_ms,
         deep_link: Some(destination),
+        // M6: stamp the RAW effective user_id (the session owner) so mark-done scopes to the
+        // owner. This is the raw id, NOT the composite recall `principal_id` namespace — it
+        // must share the WS `principal_id()` identifier space.
+        owner: owner.map(str::to_string),
     })
 }
 
@@ -729,6 +734,10 @@ pub fn extract_inline_flagged<T: Transport>(
             MemoryState::Candidate,
             MemoryScope::Session,
             label,
+            // M6: the RAW effective user_id (the session owner derived above) — NOT the
+            // composite `derived_namespace`/`principal_id` recall key — so the stamped owner
+            // shares the WS `principal_id()` identifier space.
+            effective_user_id.as_deref(),
             now_ms,
         ) {
             let _ = db.insert_activity(&row);
@@ -1618,12 +1627,15 @@ mod tests {
             MemoryState::Candidate,
             MemoryScope::Session,
             "preference",
+            Some("user-zed"),
             100,
         )
         .expect("a pending candidate surfaces");
         assert_eq!(row.activity_id, "memory-review-needs-me-s1:ex:100:c0");
         assert_eq!(row.kind.as_str(), "memory_review");
         assert_eq!(row.state.as_str(), "pending");
+        // M6: the stamped owner is the threaded raw user_id (not the composite namespace).
+        assert_eq!(row.owner.as_deref(), Some("user-zed"));
         assert_eq!(
             row.deep_link.as_deref(),
             Some("memory/session/s1:ex:100:c0")
@@ -1640,6 +1652,7 @@ mod tests {
                 MemoryState::Confirmed,
                 MemoryScope::Session,
                 "preference",
+                Some("user-zed"),
                 100,
             )
             .is_none(),
@@ -1650,6 +1663,7 @@ mod tests {
             MemoryState::Rejected,
             MemoryScope::Session,
             "preference",
+            Some("user-zed"),
             100,
         )
         .is_none());
@@ -1702,6 +1716,87 @@ mod tests {
         );
     }
 
+    /// M6 (real-derivation, NOT a hand-set owner): a memory_review row produced by the REAL
+    /// extraction path carries `owner = effective_user_id` (the RAW session user_id, NOT the
+    /// composite recall namespace). Marking it done with that real principal ALLOWS; marking
+    /// it done with a DIFFERENT principal is BLOCKED and leaves the row Pending — proving the
+    /// owner-binding (not a coincidence) is the discriminator.
+    #[test]
+    fn m6_memory_review_owner_is_raw_user_id_allows_owner_denies_other() {
+        let db = friday_storage::Db::open_hub(&tmp("m6-memrev")).unwrap();
+        // The session owner's RAW user_id is "alice"; the composite recall namespace is
+        // `ns_for("alice")` (a DIFFERENT string). The stamp must be the raw "alice".
+        let ids = seed_session(&db, "s1", "alice");
+        let content = json!({
+            "items": [{
+                "kind": "preference",
+                "content": "User's project codename is Falcon.",
+                "sourceMessageIds": [ids[0]]
+            }]
+        })
+        .to_string();
+        let c = client(content);
+        extract_inline_flagged(
+            &db,
+            "s1",
+            &c,
+            DEFAULT_MAX_ITEMS,
+            "s1:ex:100",
+            "led-1",
+            100,
+            true,
+        )
+        .unwrap();
+
+        let activity_id = "memory-review-needs-me-s1:ex:100:c0";
+        // The stamped owner is the RAW user_id "alice" — NOT the composite namespace.
+        let stored_owner: Option<String> = db
+            .conn()
+            .query_row(
+                "SELECT owner FROM activity_item WHERE activity_id = ?1",
+                [activity_id],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(stored_owner.as_deref(), Some("alice"));
+        assert_ne!(
+            stored_owner.as_deref(),
+            Some(ns_for("alice").as_str()),
+            "owner must be the RAW user_id, never the composite recall namespace"
+        );
+
+        // Wrong principal ("bob") => BLOCKED, row stays Pending (the cross-owner DENY).
+        assert!(!db
+            .mark_activity_done(activity_id, Some("bob"), 200)
+            .unwrap());
+        let state_after_deny: String = db
+            .conn()
+            .query_row(
+                "SELECT state FROM activity_item WHERE activity_id = ?1",
+                [activity_id],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(
+            state_after_deny, "pending",
+            "a cross-owner mark-done changes nothing"
+        );
+
+        // The real owner ("alice", = the WS principal_id() identifier space) => ALLOWED.
+        assert!(db
+            .mark_activity_done(activity_id, Some("alice"), 300)
+            .unwrap());
+        let state_after_allow: String = db
+            .conn()
+            .query_row(
+                "SELECT state FROM activity_item WHERE activity_id = ?1",
+                [activity_id],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(state_after_allow, "done");
+    }
+
     #[test]
     fn ns8_flag_on_terminal_candidate_is_not_surfaced() {
         // Drive the surfacing projection with a TERMINAL state directly (the proven producer
@@ -1710,9 +1805,14 @@ mod tests {
         // skip lives in `memory_review_activity_row` and is verified here end-to-end on the DB.
         let db = friday_storage::Db::open_hub(&tmp("ns8-terminal")).unwrap();
         for state in [MemoryState::Confirmed, MemoryState::Rejected] {
-            if let Some(row) =
-                memory_review_activity_row("m-terminal", state, MemoryScope::Session, "fact", 10)
-            {
+            if let Some(row) = memory_review_activity_row(
+                "m-terminal",
+                state,
+                MemoryScope::Session,
+                "fact",
+                Some("user-zed"),
+                10,
+            ) {
                 db.insert_activity(&row).unwrap();
             }
         }
@@ -1776,6 +1876,7 @@ mod tests {
             MemoryState::Candidate,
             MemoryScope::Session,
             "preference",
+            Some("user-zed"),
             100,
         )
         .unwrap();

--- a/rust-core/crates/friday-hub/src/run_readback_projection.rs
+++ b/rust-core/crates/friday-hub/src/run_readback_projection.rs
@@ -870,7 +870,8 @@ mod tests {
         seed_paused_run(db.conn(), run_id, owner, nonce, now);
 
         // (2) approval_required activity row — via the REAL NS-7 producer for this run + nonce.
-        insert_pending_approval_activity(db.conn(), run_id, nonce, "write_file", now).unwrap();
+        insert_pending_approval_activity(db.conn(), run_id, nonce, "write_file", Some(owner), now)
+            .unwrap();
 
         // (3) memory_review: a REAL pending candidate OWNED by `owner` (sets memory_item.principal_id),
         //     plus the NS-8 producer's exact activity row (id = "memory-review-needs-me-{memory_id}").
@@ -902,6 +903,7 @@ mod tests {
             MemoryState::Candidate,
             MemoryScope::Session,
             "a candidate fact",
+            Some(owner),
             now,
         )
         .expect("a pending candidate yields a memory_review activity row");
@@ -1001,6 +1003,7 @@ mod tests {
             created_at: now,
             updated_at: now,
             deep_link: None,
+            owner: None,
         })
         .unwrap();
         drop(db);
@@ -1044,7 +1047,8 @@ mod tests {
 
         // O's paused run + O's actionable rows.
         seed_paused_run(db.conn(), o_run, o, o_nonce, now);
-        insert_pending_approval_activity(db.conn(), o_run, o_nonce, "write_file", now).unwrap();
+        insert_pending_approval_activity(db.conn(), o_run, o_nonce, "write_file", Some(o), now)
+            .unwrap();
         record_candidate(
             db.conn(),
             &NewMemoryCandidate {
@@ -1064,6 +1068,7 @@ mod tests {
                 MemoryState::Candidate,
                 MemoryScope::Session,
                 "O's candidate",
+                Some(o),
                 now,
             )
             .expect("a pending candidate yields a memory_review activity row"),
@@ -1143,6 +1148,7 @@ mod tests {
                 MemoryState::Candidate,
                 MemoryScope::Session,
                 "unowned",
+                Some(owner),
                 now,
             )
             .expect("a pending candidate yields a memory_review activity row"),

--- a/rust-core/crates/friday-storage/src/lib.rs
+++ b/rust-core/crates/friday-storage/src/lib.rs
@@ -115,6 +115,11 @@ pub struct ActivityRow {
     pub created_at: i64,
     pub updated_at: i64,
     pub deep_link: Option<String>,
+    /// M6: the authenticated principal who OWNS this Needs-Me item, stamped by the
+    /// markable producers (MemoryReview / ChannelInbound / ApprovalRequired) so
+    /// [`Db::mark_activity_done`] can scope the clear to that owner. `None` for
+    /// non-markable (`Done`) receipts and for pre-migration rows (legacy-allow).
+    pub owner: Option<String>,
 }
 
 /// A UI-facing token/cost summary (a read projection of `token_ledger`). The
@@ -1398,12 +1403,33 @@ impl Db {
         )
     }
 
-    /// Mark an activity item `Done` (a real persisted state write). Returns
-    /// `true` if a row was updated, `false` if the id is unknown.
-    pub fn mark_activity_done(&self, activity_id: &str, now: i64) -> Result<bool> {
+    /// Mark an activity item `Done` (a real persisted state write), SCOPED to the
+    /// authenticated owner. Returns `true` if a row was updated, `false` if the id is
+    /// unknown OR the row is owned by a DIFFERENT principal (a cross-owner clear is
+    /// indistinguishable from an unknown id — no existence oracle).
+    ///
+    /// M6 owner-binding: the UPDATE matches the row's `owner` against `authenticated_owner`
+    /// OR allows a NULL-owner row. NULL-owner = legacy (pre-migration) = ALLOW: a deny-NULL
+    /// would strand pre-deploy Pending rows whose owner could no longer clear them (a
+    /// degrade). New inserts always stamp `owner`, so the NULL set is bounded to pre-migration
+    /// rows. When `authenticated_owner` is `None` (the local single-owner FFI path) the
+    /// `owner = ?4` arm matches no non-NULL row, so ONLY NULL-owner rows clear — exactly the
+    /// legacy/local semantics. The WS path always passes `Some(principal)`.
+    pub fn mark_activity_done(
+        &self,
+        activity_id: &str,
+        authenticated_owner: Option<&str>,
+        now: i64,
+    ) -> Result<bool> {
         let n = self.conn.execute(
-            "UPDATE activity_item SET state = ?1, updated_at = ?2 WHERE activity_id = ?3",
-            rusqlite::params![ActivityState::Done.as_str(), now, activity_id],
+            "UPDATE activity_item SET state = ?1, updated_at = ?2
+             WHERE activity_id = ?3 AND (owner IS NULL OR owner = ?4)",
+            rusqlite::params![
+                ActivityState::Done.as_str(),
+                now,
+                activity_id,
+                authenticated_owner
+            ],
         )?;
         Ok(n > 0)
     }
@@ -1907,8 +1933,8 @@ fn insert_tool_usage_conn(
 pub(crate) fn insert_activity_conn(conn: &Connection, a: &ActivityRow) -> rusqlite::Result<()> {
     conn.execute(
         "INSERT INTO activity_item
-            (activity_id, session_id, type, state, summary, created_at, updated_at, deep_link)
-         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+            (activity_id, session_id, type, state, summary, created_at, updated_at, deep_link, owner)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
         rusqlite::params![
             a.activity_id,
             a.session_id,
@@ -1917,7 +1943,8 @@ pub(crate) fn insert_activity_conn(conn: &Connection, a: &ActivityRow) -> rusqli
             a.summary,
             a.created_at,
             a.updated_at,
-            a.deep_link
+            a.deep_link,
+            a.owner
         ],
     )?;
     Ok(())

--- a/rust-core/crates/friday-storage/src/pending_request.rs
+++ b/rust-core/crates/friday-storage/src/pending_request.rs
@@ -150,6 +150,7 @@ pub fn insert_pending_approval_activity(
     run_id: &str,
     nonce: &str,
     action: &str,
+    owner: Option<&str>,
     now_ms: i64,
 ) -> rusqlite::Result<()> {
     let row = ActivityRow {
@@ -161,6 +162,9 @@ pub fn insert_pending_approval_activity(
         created_at: now_ms,
         updated_at: now_ms,
         deep_link: None,
+        // M6: stamp the run's bound principal so mark-done scopes to the owner. None when the
+        // paused run has no bound principal (single-owner legacy-allow).
+        owner: owner.map(str::to_string),
     };
     insert_activity_conn(conn, &row)
 }

--- a/rust-core/crates/friday-storage/src/schema.rs
+++ b/rust-core/crates/friday-storage/src/schema.rs
@@ -695,6 +695,22 @@ pub fn hub_migrations() -> Vec<Migration> {
             destructive: false,
             up: m0041_retention_log,
         },
+        // M6 (activity mark-done owner-binding): `activity_item` gains a nullable `owner`
+        // column so a markable Needs-Me row (MemoryReview / ChannelInbound / ApprovalRequired)
+        // records the authenticated principal who owns it, and `mark_activity_done` can scope
+        // the clear to that owner. Purely additive (ALTER only); touches no other table and
+        // performs NO data migration — pre-existing rows backfill to NULL `owner`, which the
+        // owner-scoped UPDATE treats as legacy-allow (a deny-NULL would strand pre-deploy rows
+        // = a degrade). `activity_item` is a SHARED table, so the SAME `up` fn also registers
+        // as phone v3 (mirrors m0013_token_ledger_run_id). The mark-done owner gate it backs
+        // is behind the DEFAULT-OFF `FRIDAY_ACTIVITY_MARK_DONE` flag, so this migration is dark
+        // on deploy.
+        Migration {
+            version: 42,
+            name: "activity_item_owner",
+            destructive: false,
+            up: m0042_activity_item_owner,
+        },
     ]
 }
 
@@ -731,6 +747,17 @@ pub fn phone_migrations() -> Vec<Migration> {
             name: "token_ledger_run_id",
             destructive: false,
             up: m0013_token_ledger_run_id,
+        },
+        // M6: `activity_item` is a SHARED table (both profiles) and the single insert
+        // chokepoint now writes an `owner` column. The phone never runs the markable Needs-Me
+        // producers (extraction / channel ingest / agent-loop pause are Hub-only), so its
+        // rows always carry `owner = NULL` — the column exists ONLY so the shared insert has
+        // the same shape on both profiles. Same additive ALTER as hub v42.
+        Migration {
+            version: 3,
+            name: "activity_item_owner",
+            destructive: false,
+            up: m0042_activity_item_owner,
         },
     ]
 }
@@ -2242,6 +2269,15 @@ fn m0013_token_ledger_run_id(tx: &Transaction) -> rusqlite::Result<()> {
         "ALTER TABLE token_ledger ADD COLUMN run_id TEXT;
          CREATE INDEX idx_ledger_run ON token_ledger(run_id);",
     )
+}
+
+// M6 (activity mark-done owner-binding): additive nullable `owner` on the SHARED
+// `activity_item` table (no default — pre-existing rows backfill to NULL, which the
+// owner-scoped mark-done treats as legacy-allow). Mirrors m0013's additive ALTER; the
+// same fn registers as hub v42 AND phone v3. No index (mark-done is PK-keyed on
+// `activity_id`), keeping the migration minimal.
+fn m0042_activity_item_owner(tx: &Transaction) -> rusqlite::Result<()> {
+    tx.execute_batch("ALTER TABLE activity_item ADD COLUMN owner TEXT;")
 }
 
 // S6b: additive Hub-only `pending_approval_request` table. `approval_id` (the single-use

--- a/rust-core/crates/friday-storage/tests/activity_list.rs
+++ b/rust-core/crates/friday-storage/tests/activity_list.rs
@@ -21,6 +21,7 @@ fn list_activity_returns_summaries_oldest_first() {
         created_at: t,
         updated_at: t,
         deep_link: None,
+        owner: None,
     };
     // Insert out of order; list must come back oldest-first.
     db.insert_activity(&row("b", 2)).unwrap();
@@ -47,12 +48,15 @@ fn mark_activity_done_persists_and_reports_unknown() {
         created_at: 1,
         updated_at: 1,
         deep_link: None,
+        // NULL owner (the FFI/local-seed shape): the local single-owner mark-done passes
+        // None and the NULL-owner row clears (legacy-allow).
+        owner: None,
     };
     {
         let db = Db::open_phone(&p).unwrap();
         db.insert_activity(&row("a")).unwrap();
-        assert!(db.mark_activity_done("a", 5).unwrap()); // updated
-        assert!(!db.mark_activity_done("ghost", 5).unwrap()); // unknown id -> false
+        assert!(db.mark_activity_done("a", None, 5).unwrap()); // NULL-owner row clears (legacy-allow)
+        assert!(!db.mark_activity_done("ghost", None, 5).unwrap()); // unknown id -> false
     }
     // Reopen a fresh handle: the state change survived on disk.
     let db = Db::open_phone(&p).unwrap();

--- a/rust-core/crates/friday-storage/tests/atomic.rs
+++ b/rust-core/crates/friday-storage/tests/atomic.rs
@@ -28,6 +28,7 @@ fn activity(id: &str) -> ActivityRow {
         created_at: 100,
         updated_at: 100,
         deep_link: None,
+        owner: None,
     }
 }
 
@@ -362,6 +363,7 @@ fn bill_turn(conn: &Connection, run_id: &str, turn: u64, now_ms: i64) -> Result<
         created_at: now_ms,
         updated_at: now_ms,
         deep_link: None,
+        owner: None,
     };
     let audit = AuditEvent {
         audit_id,

--- a/rust-core/crates/friday-storage/tests/encryption_storage.rs
+++ b/rust-core/crates/friday-storage/tests/encryption_storage.rs
@@ -110,6 +110,7 @@ fn pairing_credential_lives_in_secure_store_not_sqlite() {
         created_at: 1,
         updated_at: 1,
         deep_link: None,
+        owner: None,
     })
     .unwrap();
     let key = DataKey::generate();

--- a/rust-core/crates/friday-storage/tests/migration.rs
+++ b/rust-core/crates/friday-storage/tests/migration.rs
@@ -110,6 +110,7 @@ fn forward_migration_adds_run_id_preserving_pre_v13_ledger_rows() {
         created_at: 200,
         updated_at: 200,
         deep_link: None,
+        owner: None,
     };
     let audit = AuditEvent {
         audit_id: "au-new".into(),
@@ -121,6 +122,155 @@ fn forward_migration_adds_run_id_preserving_pre_v13_ledger_rows() {
     friday_storage::record_run_model_call(db.conn(), "run-1", &entry, &activity, &audit).unwrap();
     let mine = friday_storage::agent_run_read::run_token_totals(db.conn(), "run-1").unwrap();
     assert_eq!(mine.total, 10);
+}
+
+#[test]
+fn forward_migration_v41_to_v42_adds_activity_owner_to_null_preserving_pre_v42_rows() {
+    // M6 additive migration v42: activity_item gains a nullable `owner`. A PRE-EXISTING v41
+    // row (seeded before the column existed) must survive forward migration reading back
+    // owner = NULL (legacy-allow), and a fresh owner-stamped row must then write + read back.
+    let p = temp_db_path("activity-owner-mig");
+    {
+        let mut migs = hub_migrations();
+        migs.retain(|m| m.version <= 41);
+        let db = Db::open(&p, Profile::Hub, &migs, "v41").unwrap();
+        assert_eq!(db.version().unwrap(), 41);
+        assert!(
+            db.conn()
+                .prepare("SELECT owner FROM activity_item")
+                .is_err(),
+            "owner column must not exist before v42"
+        );
+        // Seed a pre-v42 Pending row (the markable shape) with NO owner column.
+        db.conn()
+            .execute(
+                "INSERT INTO activity_item
+                    (activity_id, session_id, type, state, summary, created_at, updated_at, deep_link)
+                 VALUES ('legacy-1', NULL, 'approval_required', 'pending', 'pre-v42', 1, 1, NULL)",
+                [],
+            )
+            .unwrap();
+    }
+    // Reopen with the full set -> forward-migrate to v42 (adds the additive owner ALTER).
+    let db = Db::open_hub(&p).unwrap();
+    assert_eq!(db.version().unwrap(), hub_max_version());
+    assert_eq!(hub_max_version(), 42, "M6 lands the hub at code_max 42");
+    assert_eq!(
+        db.count("activity_item").unwrap(),
+        1,
+        "pre-v42 row survived"
+    );
+    let owner: Option<String> = db
+        .conn()
+        .query_row(
+            "SELECT owner FROM activity_item WHERE activity_id = 'legacy-1'",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(
+        owner, None,
+        "pre-v42 row backfills to NULL owner (legacy-allow)"
+    );
+    // The NULL-owner legacy row clears under ANY principal (legacy-allow, no strand).
+    assert!(db
+        .mark_activity_done("legacy-1", Some("any-principal"), 2)
+        .unwrap());
+
+    // A fresh owner-stamped row on the migrated DB writes + reads back its owner, and is
+    // owner-scoped on mark-done.
+    db.insert_activity(&ActivityRow {
+        activity_id: "owned-1".into(),
+        session_id: None,
+        kind: ActivityType::ApprovalRequired,
+        state: ActivityState::Pending,
+        summary: "owned".into(),
+        created_at: 3,
+        updated_at: 3,
+        deep_link: None,
+        owner: Some("alice".into()),
+    })
+    .unwrap();
+    let owned: Option<String> = db
+        .conn()
+        .query_row(
+            "SELECT owner FROM activity_item WHERE activity_id = 'owned-1'",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(owned.as_deref(), Some("alice"));
+    assert!(
+        !db.mark_activity_done("owned-1", Some("bob"), 4).unwrap(),
+        "cross-owner denied"
+    );
+    assert!(
+        db.mark_activity_done("owned-1", Some("alice"), 5).unwrap(),
+        "owner allowed"
+    );
+}
+
+#[test]
+fn forward_migration_phone_v2_to_v3_adds_activity_owner_to_null_preserving_rows() {
+    // M6: activity_item is a SHARED table, so the phone profile ALSO gains the owner column
+    // at phone v3 (the same additive ALTER as hub v42). A pre-v3 phone row survives reading
+    // back owner = NULL, and the shared insert chokepoint works post-migration.
+    use friday_storage::phone_migrations;
+    let phone_max = phone_migrations().iter().map(|m| m.version).max().unwrap();
+    assert_eq!(phone_max, 3, "M6 lands the phone at version 3");
+
+    let p = temp_db_path("activity-owner-phone-mig");
+    {
+        let mut migs = phone_migrations();
+        migs.retain(|m| m.version <= 2);
+        let db = Db::open(&p, Profile::Phone, &migs, "phone-v2").unwrap();
+        assert_eq!(db.version().unwrap(), 2);
+        assert!(
+            db.conn()
+                .prepare("SELECT owner FROM activity_item")
+                .is_err(),
+            "owner column must not exist on the phone before v3"
+        );
+        db.conn()
+            .execute(
+                "INSERT INTO activity_item
+                    (activity_id, session_id, type, state, summary, created_at, updated_at, deep_link)
+                 VALUES ('phone-legacy', NULL, 'ask_status', 'done', 'pre-v3', 1, 1, NULL)",
+                [],
+            )
+            .unwrap();
+    }
+    // Reopen the phone profile -> forward-migrate to v3.
+    let db = Db::open_phone(&p).unwrap();
+    assert_eq!(db.version().unwrap(), phone_max);
+    assert_eq!(
+        db.count("activity_item").unwrap(),
+        1,
+        "pre-v3 phone row survived"
+    );
+    let owner: Option<String> = db
+        .conn()
+        .query_row(
+            "SELECT owner FROM activity_item WHERE activity_id = 'phone-legacy'",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(owner, None, "pre-v3 phone row backfills to NULL owner");
+    // The shared insert chokepoint works post-migration on the phone profile.
+    db.insert_activity(&ActivityRow {
+        activity_id: "phone-fresh".into(),
+        session_id: None,
+        kind: ActivityType::AskStatus,
+        state: ActivityState::Pending,
+        summary: "fresh".into(),
+        created_at: 2,
+        updated_at: 2,
+        deep_link: None,
+        owner: None,
+    })
+    .unwrap();
+    assert_eq!(db.count("activity_item").unwrap(), 2);
 }
 
 #[test]
@@ -734,6 +884,7 @@ fn destructive_migration_creates_verified_backup() {
             created_at: 1,
             updated_at: 1,
             deep_link: None,
+            owner: None,
         })
         .unwrap();
     }

--- a/src/state/sqlite/friday-rust-hub-schema-handshake.ts
+++ b/src/state/sqlite/friday-rust-hub-schema-handshake.ts
@@ -6,7 +6,7 @@ import Database from "better-sqlite3";
 import { FridayDomainError } from "#errors";
 
 export const FRIDAY_HUB_AGENT_RUN_DB_PATH_ENV = "FRIDAY_HUB_AGENT_RUN_DB_PATH";
-export const FRIDAY_EXPECTED_RUST_HUB_SCHEMA_VERSION = 41;
+export const FRIDAY_EXPECTED_RUST_HUB_SCHEMA_VERSION = 42;
 
 export type FridayRustHubSchemaHandshakeStatus = "ok" | "skipped";
 


### PR DESCRIPTION
## What & why (audit finding M6)

The WS `ActivityMarkDoneRequest` path called a **blind** `UPDATE activity_item SET state=done WHERE activity_id=?` with **no owner check** — any authenticated peer could mark *another* owner's Needs-Me activity done (sibling decision arms already thread the principal; this one didn't).

**Fix:** additive `owner` column on `activity_item` (migration **hub v42 + phone v3**, SHARED table), stamp the authenticated principal at the **3 markable producers**, thread `principal_id()` into the WS arm, and scope mark-done to `WHERE activity_id=? AND (owner IS NULL OR owner=?)`. All behind the existing **DEFAULT-OFF** flag `FRIDAY_ACTIVITY_MARK_DONE` — **enforcement is DARK on deploy**.

- MemoryReview → `effective_user_id` (raw user_id, NOT the composite namespace)
- ChannelInbound → `bound_principal_id` (NOT sender_id)
- ApprovalRequired → `policy.principal_id()` *(a third markable type the original finding omitted — would have failed-closed under flag-ON if missed)*

`NULL owner = legacy = allow` (pre-migration rows + local FFI path; deny-NULL would strand existing Pending rows = a degrade). New inserts always stamp owner, so the NULL set is bounded. TS `FRIDAY_EXPECTED_RUST_HUB_SCHEMA_VERSION` bumped 41→42 in lockstep (self-enforced by the handshake test).

## Verification
- 2 independent reviewers **PASS** (IDOR closed on the live path; tests are **real, not mock-green** — stamp-source asserts `raw-user-id != namespace`, `bound != sender`, + cross-principal DENY prove the binding is the discriminator; flag-OFF byte-identical; no test weakening; no secret leak; no overclaim; no scope creep; migration safe).
- friday-storage + friday-hub + friday-ffi: all tests green; clippy clean; fmt clean. Migration forward-tests v41→v42 + phone v2→v3 pass.

## ⚠️ Residuals to verify BEFORE flipping `FRIDAY_ACTIVITY_MARK_DONE` (all flag-OFF + single-owner-moot today, organic=0)
- **R1** ApprovalRequired stamps `owner=NULL` on an unowned Hub (`principal_id()`=None) → legacy-allow → multi-owner **fail-OPEN**.
- **R2** MemoryReview `owner=effective_user_id` can diverge from `principal_id()` for DM/subagent sessions (`resolve_effective_user_id` walks) → legitimate owner DENY (multi-owner **fail-CLOSED strand**, never a bypass); add a DM/subagent test before flip.
- **R3** ChannelInbound `owner=bound_principal_id`: cross-producer equality with `principal_id()` is **unproven by precedent**; confirm before flip.

## Status — DARK
Flag default-OFF; enforcement latent until the operator flips it (gated on R1–R3). Code on main ≠ running prod binary (deploy-gap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)