### PR TITLE
test(ui): export T3 pairing action evidence

### DIFF
--- a/scripts/ops/friday-t3-pairing-action-evidence.mjs
+++ b/scripts/ops/friday-t3-pairing-action-evidence.mjs
@@ -1,0 +1,200 @@
+#!/usr/bin/env node
+
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, isAbsolute, resolve } from "node:path";
+
+const args = process.argv.slice(2);
+
+function usage() {
+  console.error(`usage:
+  node scripts/ops/friday-t3-pairing-action-evidence.mjs \\
+    --reconcile=/abs/db-reconcile.txt \\
+    --client-output=/abs/friday-pairing-proof.json \\
+    [--out=/abs/action-runtime-evidence.json] [--require-ready]
+
+Truth: converts one real T3 PairAck/status proof artifact into explicit
+mobile:firstLaunch action runtime evidence. It does not mint trust grants or
+context passports, does not read signing keys, and does not claim END-BAR.`);
+}
+
+function arg(name) {
+  const prefix = `--${name}=`;
+  return args.find((value) => value.startsWith(prefix))?.slice(prefix.length) || "";
+}
+
+if (args.includes("--help") || args.includes("-h")) {
+  usage();
+  process.exit(0);
+}
+
+const reconcilePath = arg("reconcile");
+const clientOutputPath = arg("client-output");
+const outPath = arg("out");
+const requireReady = args.includes("--require-ready");
+const blockers = [];
+
+function block(code, detail) {
+  blockers.push({ code, detail });
+}
+
+function abs(path) {
+  return isAbsolute(path) ? path : resolve(path);
+}
+
+function readText(path, label) {
+  if (!path) {
+    block("missing_arg", label);
+    return "";
+  }
+  try {
+    return readFileSync(abs(path), "utf8");
+  } catch {
+    block("unreadable_file", `${label}:${path}`);
+    return "";
+  }
+}
+
+function readJson(path, label) {
+  const body = readText(path, label);
+  if (!body) return null;
+  try {
+    return JSON.parse(body);
+  } catch {
+    block("invalid_json", `${label}:${path}`);
+    return null;
+  }
+}
+
+function parseKeyValue(text) {
+  const map = new Map();
+  for (const line of text.split(/\r?\n/)) {
+    const index = line.indexOf("=");
+    if (index <= 0) continue;
+    map.set(line.slice(0, index), line.slice(index + 1));
+  }
+  return map;
+}
+
+function field(map, key) {
+  const value = map.get(key) || "";
+  if (!value) block("missing_reconcile_field", key);
+  return value;
+}
+
+function numberField(map, key) {
+  const value = field(map, key);
+  if (!/^[0-9]+$/.test(value)) {
+    block("reconcile_field_not_numeric", `${key}:${value || "<missing>"}`);
+    return null;
+  }
+  return Number(value);
+}
+
+function stringJson(value, key) {
+  if (value && typeof value[key] === "string" && value[key].trim()) return value[key].trim();
+  block("client_missing_string", key);
+  return "";
+}
+
+const reconcileText = readText(reconcilePath, "reconcile");
+const reconcile = parseKeyValue(reconcileText);
+const client = readJson(clientOutputPath, "client-output");
+
+const truth = field(reconcile, "truth");
+if (truth && truth !== "friday_t3_pairing_proof_no_operator_key_no_grant_no_passport") {
+  block("reconcile_truth_unexpected", truth);
+}
+const mode = field(reconcile, "mode");
+if (mode && mode !== "status-only" && mode !== "pair") block("mode_unexpected", mode);
+const pairingId = field(reconcile, "pairing_id");
+const deviceId = field(reconcile, "device_id");
+const beforeDevice = numberField(reconcile, "trusted_device_count_before");
+const afterDevice = numberField(reconcile, "trusted_device_count_after");
+const beforeGrants = numberField(reconcile, "trust_grant_count_before");
+const afterGrants = numberField(reconcile, "trust_grant_count_after");
+const beforePassports = numberField(reconcile, "context_passport_count_before");
+const afterPassports = numberField(reconcile, "context_passport_count_after");
+
+if (beforeGrants !== null && afterGrants !== null && beforeGrants !== afterGrants) {
+  block("trust_grant_changed", `${beforeGrants}->${afterGrants}`);
+}
+if (beforePassports !== null && afterPassports !== null && beforePassports !== afterPassports) {
+  block("context_passport_changed", `${beforePassports}->${afterPassports}`);
+}
+
+let clientTruth = "";
+if (client) {
+  clientTruth = stringJson(client, "truth");
+  const clientPairingId = stringJson(client, "pairing_id");
+  if (pairingId && clientPairingId && clientPairingId !== pairingId) {
+    block("pairing_id_mismatch", `${pairingId}:${clientPairingId}`);
+  }
+}
+
+if (mode === "status-only") {
+  if (clientTruth && clientTruth !== "pairing_status_only_no_trusted_device_write") {
+    block("client_truth_unexpected", clientTruth);
+  }
+  const hubOnline = client ? stringJson(client, "hub_online") : "";
+  if (hubOnline && hubOnline !== "true") block("hub_not_online", hubOnline);
+  if (beforeDevice !== null && afterDevice !== null && beforeDevice !== afterDevice) {
+    block("trusted_device_changed_in_status_only", `${beforeDevice}->${afterDevice}`);
+  }
+}
+
+if (mode === "pair") {
+  if (clientTruth && clientTruth !== "pairing_pairack_real_sealed_ws_no_grant_no_passport_no_operator_key") {
+    block("client_truth_unexpected", clientTruth);
+  }
+  const ackAccepted = client ? stringJson(client, "ack_accepted") : "";
+  if (ackAccepted && ackAccepted !== "true") block("pairack_not_accepted", ackAccepted);
+  if (beforeDevice !== null && afterDevice !== null && afterDevice <= beforeDevice) {
+    block("trusted_device_not_created", `${beforeDevice}->${afterDevice}`);
+  }
+}
+
+const evidenceRef = clientOutputPath ? abs(clientOutputPath) : "";
+const common = {
+  surface: "mobile",
+  screen: "firstLaunch",
+  status: "pass",
+  evidence_ref: evidenceRef,
+  pairing_id: pairingId || null,
+  device_id: deviceId || null,
+  source: "t3_pairing_proof_explicit_mobile_firstlaunch_action",
+  truth_label: "pairing_action_runtime_evidence_not_grant_not_passport_not_endbar",
+};
+
+const actions = blockers.length === 0
+  ? [
+      {
+        ...common,
+        action_id: "firstlaunch_scan",
+      },
+      ...(mode === "pair" ? [{
+        ...common,
+        action_id: "firstlaunch_pairnow",
+      }] : []),
+    ]
+  : [];
+
+const output = {
+  truth: "t3_pairing_action_runtime_evidence_not_endbar",
+  status: blockers.length === 0 ? "ready" : "blocked",
+  mode: mode || null,
+  reconcile: reconcilePath ? abs(reconcilePath) : null,
+  clientOutput: clientOutputPath ? abs(clientOutputPath) : null,
+  actionCount: actions.length,
+  actions,
+  blockers,
+  caveat: "This proves explicit firstLaunch QR/PairAck actions only. It does not prove approval UX, memory confirmation, voice, cross-device continuation, adoption, END-BAR, or operator signing.",
+};
+
+if (outPath && blockers.length === 0) {
+  const out = abs(outPath);
+  mkdirSync(dirname(out), { recursive: true });
+  writeFileSync(out, `${JSON.stringify(output, null, 2)}\n`);
+}
+
+console.log(JSON.stringify(output, null, 2));
+process.exit((blockers.length === 0 || !requireReady) ? 0 : 2);

--- a/scripts/ops/friday-t3-pairing-proof.sh
+++ b/scripts/ops/friday-t3-pairing-proof.sh
@@ -14,6 +14,7 @@ REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 MODE=""
 DEVICE_ID="${FRIDAY_T3_PAIRING_DEVICE_ID:-friday-t3-pairing-proof-$(date -u +%Y%m%dT%H%M%SZ)}"
 TIMEOUT_SECONDS="${FRIDAY_T3_PAIRING_PROOF_TIMEOUT_SECONDS:-45}"
+ACTION_RUNTIME_OUT="${FRIDAY_T3_PAIRING_ACTION_RUNTIME_OUT:-}"
 
 usage() {
   cat <<'EOF'
@@ -21,6 +22,7 @@ usage:
   scripts/ops/friday-t3-pairing-proof.sh --status-only
   FRIDAY_T3_PAIRING_PROOF_ACK=operator-runs-t3-pairing-proof \
     scripts/ops/friday-t3-pairing-proof.sh --pair [--device-id <id>]
+  ... [--action-runtime-out /abs/action-runtime-evidence.json]
 
 truth:
   Starts the explicit DARK hub_pairing_server, runs the Swift FridayPairingProof client, and
@@ -44,6 +46,14 @@ while [ "$#" -gt 0 ]; do
         exit 3
       fi
       DEVICE_ID="$1"
+      ;;
+    --action-runtime-out)
+      shift
+      if [ "$#" -eq 0 ]; then
+        echo "FATAL: --action-runtime-out requires a value." >&2
+        exit 3
+      fi
+      ACTION_RUNTIME_OUT="$1"
       ;;
     -h|--help)
       usage
@@ -172,4 +182,13 @@ fi
 if [ "${before_passports}" != "sqlite3_unavailable" ] && [ "${after_passports}" != "${before_passports}" ]; then
   echo "FATAL: context_passport count changed during pairing proof; this wrapper must not mint passports." >&2
   exit 7
+fi
+
+if [ -n "${ACTION_RUNTIME_OUT}" ]; then
+  node "${SCRIPT_DIR}/friday-t3-pairing-action-evidence.mjs" \
+    --reconcile="${STATUS_QUERY_OUT}" \
+    --client-output="${CLIENT_OUT}" \
+    --out="${ACTION_RUNTIME_OUT}" \
+    --require-ready >/dev/null
+  echo "action_runtime_evidence=${ACTION_RUNTIME_OUT}"
 fi

--- a/test/unit/qa/friday-t3-pairing-action-evidence-cli.test.ts
+++ b/test/unit/qa/friday-t3-pairing-action-evidence-cli.test.ts
@@ -1,0 +1,157 @@
+import { execFileSync, spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const script = "scripts/ops/friday-t3-pairing-action-evidence.mjs";
+const checker = "scripts/ops/check-friday-design-action-runtime-evidence.mjs";
+
+function writeFile(root: string, relative: string, body: string) {
+  const target = join(root, relative);
+  mkdirSync(dirname(target), { recursive: true });
+  writeFileSync(target, body);
+  return target;
+}
+
+function reconcile(mode: "status-only" | "pair") {
+  const afterDevice = mode === "pair" ? "1" : "0";
+  return [
+    "truth=friday_t3_pairing_proof_no_operator_key_no_grant_no_passport",
+    `mode=${mode}`,
+    "device_id=ios-pair-proof-1",
+    "pairing_id=pair-proof-1",
+    "db=/tmp/rust-hub.sqlite",
+    "trusted_device_count_before=0",
+    `trusted_device_count_after=${afterDevice}`,
+    "trust_grant_count_before=7",
+    "trust_grant_count_after=7",
+    "context_passport_count_before=3",
+    "context_passport_count_after=3",
+    "client_output=/tmp/client.json",
+    "server_log=/tmp/server.log",
+    "",
+  ].join("\n");
+}
+
+function client(mode: "status-only" | "pair", overrides: Record<string, string> = {}) {
+  return {
+    truth: mode === "pair"
+      ? "pairing_pairack_real_sealed_ws_no_grant_no_passport_no_operator_key"
+      : "pairing_status_only_no_trusted_device_write",
+    hub_id: "friday-hub-test",
+    pairing_id: "pair-proof-1",
+    device_id: "ios-pair-proof-1",
+    device_pubkey_hex: "abc123",
+    hub_online: "true",
+    capabilities: "pairing,read_seam_enroll",
+    ack_accepted: mode === "pair" ? "true" : "",
+    ack_error_code: "",
+    ...overrides,
+  };
+}
+
+function contractBody() {
+  return `# Friday Action Contract
+
+**This is a wiring contract for the later Rust/native agent, NOT runtime proof.** Every row is design-proof; wired_registry ≠ runtime PASS.
+
+| Surface | Screen [state] | action_id | Label | capability_id | reg | reg_status | truth_status | result/target | Rust/Hub owner gate test expectation |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| mobile | firstLaunch | firstlaunch_scan | Scan to pair | trust_center_pairing_connected_devices | x | wired | wired_registry | result:scanning | Runtime proof required. |
+| mobile | firstLaunch [later] | firstlaunch_pairnow | Pair now | trust_center_pairing_connected_devices | x | wired | wired_registry | result:scanning | Runtime proof required. |
+`;
+}
+
+describe("friday-t3-pairing-action-evidence", () => {
+  it("exports status-only scan evidence without satisfying pair-now", () => {
+    const root = mkdtempSync(join(tmpdir(), "friday-t3-pairing-action-"));
+    try {
+      const reconcilePath = writeFile(root, "db-reconcile.txt", reconcile("status-only"));
+      const clientPath = writeFile(root, "client.json", JSON.stringify(client("status-only"), null, 2));
+      const outPath = join(root, "action-runtime-evidence.json");
+      const stdout = execFileSync("node", [
+        script,
+        `--reconcile=${reconcilePath}`,
+        `--client-output=${clientPath}`,
+        `--out=${outPath}`,
+        "--require-ready",
+      ], { cwd: process.cwd(), encoding: "utf8" });
+
+      const result = JSON.parse(stdout) as { status?: string; actionCount?: number };
+      expect(result.status).toBe("ready");
+      expect(result.actionCount).toBe(1);
+      const actionEvidence = JSON.parse(readFileSync(outPath, "utf8")) as { actions?: Array<{ action_id?: string }> };
+      expect(actionEvidence.actions?.map((row) => row.action_id)).toEqual(["firstlaunch_scan"]);
+
+      const contract = writeFile(root, "ACTION-CONTRACT.md", contractBody());
+      writeFile(root, "apps/friday-ios/Sources/FridayMobileShell/FridayHomeScreen.swift", "Button(\"Scan to pair\") {} Button(\"Pair now\") {}");
+      const check = JSON.parse(execFileSync("node", [
+        checker,
+        `--repo-root=${root}`,
+        `--contract=${contract}`,
+        `--runtime-evidence=${outPath}`,
+      ], { cwd: process.cwd(), encoding: "utf8" })) as {
+        counts?: { missingRuntimeEvidence?: number };
+        gaps?: { missingRuntimeEvidence?: Array<{ actionId?: string }> };
+      };
+      expect(check.counts?.missingRuntimeEvidence).toBe(1);
+      expect(check.gaps?.missingRuntimeEvidence).toEqual([
+        expect.objectContaining({ actionId: "firstlaunch_pairnow" }),
+      ]);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("exports scan and pair-now only after a real accepted PairAck DB delta", () => {
+    const root = mkdtempSync(join(tmpdir(), "friday-t3-pairing-action-pair-"));
+    try {
+      const reconcilePath = writeFile(root, "db-reconcile.txt", reconcile("pair"));
+      const clientPath = writeFile(root, "client.json", JSON.stringify(client("pair"), null, 2));
+      const stdout = execFileSync("node", [
+        script,
+        `--reconcile=${reconcilePath}`,
+        `--client-output=${clientPath}`,
+        "--require-ready",
+      ], { cwd: process.cwd(), encoding: "utf8" });
+
+      const result = JSON.parse(stdout) as {
+        status?: string;
+        actions?: Array<{ action_id?: string; capability_id?: string }>;
+      };
+      expect(result.status).toBe("ready");
+      expect(result.actions?.map((row) => row.action_id)).toEqual([
+        "firstlaunch_scan",
+        "firstlaunch_pairnow",
+      ]);
+      expect(result.actions?.every((row) => row.capability_id === undefined)).toBe(true);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("fails closed when PairAck is rejected or grant state changes", () => {
+    const root = mkdtempSync(join(tmpdir(), "friday-t3-pairing-action-bad-"));
+    try {
+      const badReconcile = reconcile("pair").replace("trust_grant_count_after=7", "trust_grant_count_after=8");
+      const reconcilePath = writeFile(root, "db-reconcile.txt", badReconcile);
+      const clientPath = writeFile(root, "client.json", JSON.stringify(client("pair", { ack_accepted: "false" }), null, 2));
+      const result = spawnSync("node", [
+        script,
+        `--reconcile=${reconcilePath}`,
+        `--client-output=${clientPath}`,
+        "--require-ready",
+      ], { cwd: process.cwd(), encoding: "utf8" });
+
+      expect(result.status).toBe(2);
+      const output = JSON.parse(result.stdout) as { blockers?: Array<{ code?: string }> };
+      expect(output.blockers?.map((blocker) => blocker.code)).toEqual(expect.arrayContaining([
+        "trust_grant_changed",
+        "pairack_not_accepted",
+      ]));
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add a fail-closed converter from real T3 PairAck/status proof artifacts to explicit mobile:firstLaunch action-runtime evidence
- let `friday-t3-pairing-proof.sh` write optional `--action-runtime-out` evidence after its existing DB delta guards pass
- add hermetic QA coverage proving status-only covers scan only, accepted PairAck covers scan+pair-now, and rejected PairAck/grant drift fails closed

## Verification
- `bash -n scripts/ops/friday-t3-pairing-proof.sh`
- `PATH=/Users/jarvis/Projects/Friday/node_modules/.bin:$PATH vitest run --project default test/unit/qa/friday-t3-pairing-action-evidence-cli.test.ts test/unit/qa/friday-design-action-runtime-evidence-cli.test.ts`
- real PairAck proof with `FRIDAY_T3_PAIRING_PROOF_ACK=operator-runs-t3-pairing-proof ... --pair --action-runtime-out ...` produced trusted_device 0->1 while trust_grant/context_passport stayed 1->1, then design action checker recognized `firstlaunch_scan` and `firstlaunch_pairnow` only

## Truth
This is runtime-action evidence plumbing for T3 firstLaunch QR pairing. It does not mint trust_grant/context_passport, does not read signing keys, and does not claim retry/cancel, approval UX, memory confirmation, voice, cross-device continuation, END-BAR, GO-LIVE, adoption, or operator signing completion.