### PR TITLE
test(desktop): prove approval reject action

### DIFF
--- a/scripts/diagnostics/friday-s6-transport-a-driver.mjs
+++ b/scripts/diagnostics/friday-s6-transport-a-driver.mjs
@@ -52,6 +52,11 @@
 //       accepted===true ⇒ "MUTATION RESUMED — verify the proof-file + a fresh token_ledger row".
 //       accepted===false ⇒ "REFUSED (fail-closed)".
 //
+//   --mode reject --run-id <id> --approval-id <id>
+//       Owner-authed reject of ONE pending approval. This does NOT sign, does NOT resume, and does
+//       NOT execute the mutation. It calls rejectApproval({ runId, approvalId, forwardedPrincipal })
+//       over the shipped sealed client and expects accepted===true/status==="rejected".
+//
 //   --mode resume-negative --run-id <id> --kind <empty|wrongkey> [--approval <wrongkey-signed.json>]
 //       Adversarial: prove an ABSENT or FORGED signature does NOT execute.
 //         empty    : pass an EMPTY Uint8Array. The shipped client guards length===0 and REJECTS
@@ -536,6 +541,52 @@ async function modeResume(args, createFactory, resolverMod) {
   }
 }
 
+// ─── MODE 2b: reject (owner-auth refusal — no signature, no mutation execution) ───
+async function modeReject(args, createFactory, resolverMod) {
+  const runId = typeof args["run-id"] === "string" ? args["run-id"] : undefined;
+  const approvalId = typeof args["approval-id"] === "string" ? args["approval-id"] : undefined;
+  if (!runId) die("usage", "--run-id <id> is required for reject");
+  if (!approvalId) die("usage", "--approval-id <id> is required for reject");
+
+  const secret = resolveClientSecretOrDie(resolverMod);
+  const client = makeClient(createFactory, secret);
+
+  console.log(
+    `[reject] sealed-WS → ${DEFAULT_HOST}:${DEFAULT_PORT} runId=${runId} approvalId=${approvalId} ` +
+      `principal=${FORWARDED_PRINCIPAL} (owner-auth, no operator signature, no resume)`,
+  );
+
+  let result;
+  try {
+    result = await client.rejectApproval({
+      runId,
+      approvalId,
+      forwardedPrincipal: FORWARDED_PRINCIPAL,
+    });
+  } catch (err) {
+    die(
+      "network",
+      `rejectApproval failed to settle: ${err?.message ?? String(err)}. A close-before-result is ` +
+        "the fail-closed path (unprovisioned peer, owner mismatch, or a non-paused/cancelled run).",
+    );
+  }
+
+  console.log(
+    `[reject] op=${result.op} accepted=${result.accepted} status=${result.status}` +
+      (result.auditRef !== undefined ? ` auditRef=${result.auditRef}` : ""),
+  );
+  if (
+    result.accepted === true &&
+    (result.status === "rejected" || result.status === "already_rejected")
+  ) {
+    console.log("[reject] PASS — pending approval rejected; the paused mutation did NOT execute.");
+    return;
+  }
+  console.log(
+    "[reject] REFUSED (fail-closed): the server did not accept this reject request. No mutation executed.",
+  );
+}
+
 // ─── MODE 3: resume-negative (adversarial — absent / forged signature MUST NOT execute) ───
 async function modeResumeNegative(args, createFactory, resolverMod) {
   const runId = typeof args["run-id"] === "string" ? args["run-id"] : undefined;
@@ -625,6 +676,7 @@ async function main() {
         "  --mode dispatch-mutating [--artifact-dir <dir>] [--proof-file <path>]\n" +
         "                            [--pending-request-file <path>] [--signed-approval-file <path>]\n" +
         "  --mode resume            --run-id <id> --approval <signed-approval.json>\n" +
+        "  --mode reject            --run-id <id> --approval-id <id>\n" +
         "  --mode resume-negative   --run-id <id> --kind <empty|wrongkey> [--approval <wrongkey-signed.json>]\n" +
         "env: FRIDAY_MASTER_KEY (exported by the caller, sourced from the hub plist — the secret\n" +
         "       resolver's getMasterKey reads it; this script NEVER handles it directly),\n" +
@@ -642,6 +694,8 @@ async function main() {
     await modeDispatchMutating(args, createFactory, resolverMod);
   } else if (mode === "resume") {
     await modeResume(args, createFactory, resolverMod);
+  } else if (mode === "reject") {
+    await modeReject(args, createFactory, resolverMod);
   } else if (mode === "resume-negative") {
     await modeResumeNegative(args, createFactory, resolverMod);
   } else {

--- a/scripts/ops/friday-desktop-approval-relay-proof.sh
+++ b/scripts/ops/friday-desktop-approval-relay-proof.sh
@@ -6,7 +6,8 @@
 #   This wraps the existing S6 sealed-WS driver into a desktop-product proof entrypoint. It does not read signing keys,
 #   mint signatures, kill/restart prod Hub, flip flags, or fabricate organic traffic. `dispatch`
 #   creates a real paused mutating run and a signable pending-request artifact;
-#   `resume` relays an operator-signed JSON artifact verbatim through the shipped write seam.
+#   `resume` relays an operator-signed JSON artifact verbatim through the shipped write seam;
+#   `reject` owner-auth rejects the pending approval without signing or executing the mutation.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -18,6 +19,8 @@ ARTIFACT_DIR="${FRIDAY_DESKTOP_APPROVAL_RELAY_ARTIFACT_DIR:-${TMPDIR:-/tmp}/frid
 PROOF_FILE="${FRIDAY_DESKTOP_APPROVAL_RELAY_PROOF_FILE:-desktop-approval-relay-proof.txt}"
 SIGNED_APPROVAL="${FRIDAY_DESKTOP_APPROVAL_SIGNED_APPROVAL:-}"
 RUN_ID="${FRIDAY_DESKTOP_APPROVAL_RUN_ID:-}"
+APPROVAL_ID="${FRIDAY_DESKTOP_APPROVAL_APPROVAL_ID:-}"
+ACTION_RUNTIME_OUT="${FRIDAY_DESKTOP_APPROVAL_ACTION_RUNTIME_OUT:-}"
 
 fail() {
   echo "FATAL: $*" >&2
@@ -49,9 +52,9 @@ metadata_path() {
 save_metadata() {
   local log_file="$1"
   local run_id approval_id action_digest pending_request signed_default
-  run_id="$(awk -F'= ' '/runId[[:space:]]*=/{gsub(/[[:space:]]/, "", $2); print $2; exit}' "${log_file}")"
-  approval_id="$(awk -F'= ' '/approvalId[[:space:]]*=/{gsub(/[[:space:]]/, "", $2); print $2; exit}' "${log_file}")"
-  action_digest="$(awk -F'= ' '/actionDigest[[:space:]]*=/{gsub(/[[:space:]]/, "", $2); print $2; exit}' "${log_file}")"
+  run_id="$(awk -F'= ' '/^[[:space:]]+runId[[:space:]]*=/{gsub(/[[:space:]]/, "", $2); print $2; exit}' "${log_file}")"
+  approval_id="$(awk -F'= ' '/^[[:space:]]+approvalId[[:space:]]*=/{gsub(/[[:space:]]/, "", $2); print $2; exit}' "${log_file}")"
+  action_digest="$(awk -F'= ' '/^[[:space:]]+actionDigest[[:space:]]*=/{gsub(/[[:space:]]/, "", $2); print $2; exit}' "${log_file}")"
   pending_request="${ARTIFACT_DIR}/pending-request.json"
   signed_default="${ARTIFACT_DIR}/signed-approval.json"
   if [[ -z "${run_id}" || -z "${approval_id}" || -z "${action_digest}" ]]; then
@@ -82,6 +85,55 @@ load_run_id() {
     fail "${meta} does not contain FRIDAY_DESKTOP_APPROVAL_RUN_ID."
   fi
   echo "${FRIDAY_DESKTOP_APPROVAL_RUN_ID}"
+}
+
+load_approval_id() {
+  if [[ -n "${APPROVAL_ID}" ]]; then
+    echo "${APPROVAL_ID}"
+    return
+  fi
+  local meta
+  meta="$(metadata_path)"
+  if [[ ! -f "${meta}" ]]; then
+    fail "FRIDAY_DESKTOP_APPROVAL_APPROVAL_ID is required when ${meta} is absent."
+  fi
+  # shellcheck disable=SC1090
+  source "${meta}"
+  if [[ -z "${FRIDAY_DESKTOP_APPROVAL_APPROVAL_ID:-}" ]]; then
+    fail "${meta} does not contain FRIDAY_DESKTOP_APPROVAL_APPROVAL_ID."
+  fi
+  echo "${FRIDAY_DESKTOP_APPROVAL_APPROVAL_ID}"
+}
+
+write_action_runtime_evidence() {
+  local out="$1"
+  local run_id="$2"
+  local approval_id="$3"
+  if [[ -z "${out}" ]]; then
+    return
+  fi
+  mkdir -p "$(dirname "${out}")"
+  node - "${out}" "${run_id}" "${approval_id}" <<'NODE'
+const fs = require("node:fs");
+const [out, runId, approvalId] = process.argv.slice(2);
+const evidence = {
+  truth: "desktop_approval_reject_action_runtime_evidence_not_endbar_not_signature",
+  status: "ready",
+  actions: [
+    {
+      surface: "desktop",
+      screen: "fridayChat",
+      action_id: "act",
+      status: "pass",
+      evidence_ref: `proof://desktop/approval-reject/${runId}`,
+      run_id: runId,
+      approval_id: approvalId,
+    },
+  ],
+  caveat: "Reject action evidence only: owner-auth refusal of a paused mutation. It does not prove operator-signed approve, END-BAR, release, or adoption.",
+};
+fs.writeFileSync(out, `${JSON.stringify(evidence, null, 2)}\n`);
+NODE
 }
 
 run_dispatch() {
@@ -117,10 +169,32 @@ run_resume() {
   echo "Truth: resume relayed the supplied signed artifact; inspect the driver output for accepted/status."
 }
 
+run_reject() {
+  need_live
+  local run_id approval_id log_file
+  run_id="$(load_run_id)"
+  approval_id="$(load_approval_id)"
+  log_file="${ARTIFACT_DIR}/reject.log"
+  echo "Friday desktop approval relay proof: reject"
+  echo "truth_label=desktop_approval_relay_reject_owner_authed_no_signature_no_mutation"
+  echo "run_id=${run_id}"
+  echo "approval_id=${approval_id}"
+  driver --mode reject --run-id "${run_id}" --approval-id "${approval_id}" | tee "${log_file}"
+  if ! grep -q "\\[reject\\] PASS" "${log_file}"; then
+    fail "reject proof did not report PASS."
+  fi
+  write_action_runtime_evidence "${ACTION_RUNTIME_OUT}" "${run_id}" "${approval_id}"
+  if [[ -n "${ACTION_RUNTIME_OUT}" ]]; then
+    echo "Action runtime evidence: ${ACTION_RUNTIME_OUT}"
+  fi
+  echo "Truth: reject refused the pending approval through run-control; it did not sign, resume, release, GO, or prove adoption."
+}
+
 case "${STEP}" in
   dispatch) run_dispatch ;;
   resume) run_resume ;;
+  reject) run_reject ;;
   *)
-    fail "FRIDAY_DESKTOP_APPROVAL_RELAY_STEP must be dispatch or resume."
+    fail "FRIDAY_DESKTOP_APPROVAL_RELAY_STEP must be dispatch, resume, or reject."
     ;;
 esac

--- a/src/api/mission-spine/friday-rust-hub-agent-run-ws-sealed-client.ts
+++ b/src/api/mission-spine/friday-rust-hub-agent-run-ws-sealed-client.ts
@@ -373,6 +373,16 @@ export interface FridayRustHubAgentRunSealedClient {
     request: FridayRustHubAgentRunResumeRequest,
   ): Promise<FridayRustHubAgentRunResumeResult>;
   /**
+   * (A1 run-controls) OWNER-auth reject of ONE pending tool approval on a paused run —
+   * `Message::AgentRunReject`. Unlike `resumeWithApproval`, this does not carry an operator
+   * signature blob; it carries the same sealed-session possession proof as dispatch/cancel and the
+   * server checks the forwarded principal against the pending approval owner before writing
+   * `pending_approval_request.status='rejected'`.
+   */
+  rejectApproval(
+    request: FridayRustHubAgentRunRejectRequest,
+  ): Promise<FridayRustHubAgentRunResumeResult>;
+  /**
    * (Lane B) Resolve/create a Mission from one surface input over a sealed session —
    * `Message::MissionIntakeRequest`. PURE Hub mutation (no model/provider call). Opens a fresh
    * sealed session (the channel auth), sends the intake envelope, and awaits the FIRST
@@ -441,6 +451,16 @@ export interface FridayRustHubAgentRunResumeRequest {
    * courier — relayed VERBATIM as the wire `signed_blob`; TS inspects/derives/authors NOTHING.
    */
   readonly opaqueSignedBlob: Uint8Array;
+}
+
+/** (A1 run-controls) Reject ONE pending approval by owner-auth, without signing or resuming it. */
+export interface FridayRustHubAgentRunRejectRequest {
+  /** The paused run carrying the pending approval. */
+  readonly runId: string;
+  /** The pending approval nonce to reject (`AgentRunPaused.nonce` / `approval_id`). */
+  readonly approvalId: string;
+  /** The TS-token-resolved principal the trusted peer forwards; server verifies ownership. */
+  readonly forwardedPrincipal: string;
 }
 
 // ─── (Lane B) Mission-spine organic mutation requests/results ───────────────
@@ -952,6 +972,33 @@ export function buildResumeEnvelope(
       run_id: runId,
       // serde `Vec<u8>` ⇒ a JSON ARRAY of byte numbers (NOT base64/hex). VERBATIM relay (INV-1).
       signed_blob: Array.from(opaqueSignedBlob),
+    },
+  };
+}
+
+/**
+ * (A1 run-controls) Build the `AgentRunReject` envelope. This is owner-authed, not
+ * operator-signed: the auth proof is the sealed-session possession proof bound to
+ * `(forwardedPrincipal, runId)`, and the server verifies that owner against the pending approval row.
+ * The wire is refs-only: no body, no signature material, no tool args.
+ */
+export function buildRejectEnvelope(
+  runId: string,
+  approvalId: string,
+  forwardedPrincipal: string,
+  authProof: Uint8Array,
+): Record<string, unknown> {
+  return {
+    schema_version: SCHEMA_VERSION,
+    msg_id: `agent-run-reject-${runId}-${approvalId}`,
+    correlation_id: `agent-run-reject-${runId}-${approvalId}`,
+    sent_at: Date.now(),
+    message: {
+      kind: "AgentRunReject",
+      run_id: runId,
+      approval_id: approvalId,
+      forwarded_principal: forwardedPrincipal,
+      auth_proof: Array.from(authProof),
     },
   };
 }
@@ -1701,6 +1748,163 @@ interface MissionRoundTripParams<TResult> {
   readonly leg: string;
 }
 
+interface AgentRunOwnerControlRoundTripParams {
+  readonly host: string;
+  readonly port: number;
+  readonly timeoutMs: number;
+  readonly keypair: { readonly publicKey: Uint8Array; readonly secret: Uint8Array };
+  readonly runId: string;
+  readonly forwardedPrincipal: string;
+  readonly leg: string;
+  readonly buildEnvelope: (authProof: Uint8Array) => Record<string, unknown>;
+}
+
+/**
+ * (A1 run-controls) Run one owner-authed agent-run control round-trip
+ * (`AgentRunReject`, later reusable for cancel if TS needs it). This mirrors dispatch's sealed
+ * possession proof and resume's strict `AgentRunControlResult` settle, without reading or minting
+ * operator signatures.
+ */
+function runAgentRunOwnerControlRoundTrip(
+  params: AgentRunOwnerControlRoundTripParams,
+): Promise<FridayRustHubAgentRunResumeResult> {
+  const { host, port, timeoutMs, keypair, runId, forwardedPrincipal, leg, buildEnvelope } = params;
+  return new Promise<FridayRustHubAgentRunResumeResult>((resolve, reject) => {
+    let settled = false;
+    let socket: Socket | null = null;
+    let receiver: WsReceiver | null = null;
+    let sessionKey: Uint8Array = new Uint8Array(0);
+
+    const timer = setTimeout(() => {
+      fail(unavailable(`Sealed agent-run client ${leg} timed out awaiting a control result.`));
+    }, timeoutMs);
+    if (typeof timer.unref === "function") timer.unref();
+
+    function teardown(): void {
+      clearTimeout(timer);
+      if (receiver) {
+        receiver.removeAllListeners();
+      }
+      if (socket) {
+        socket.removeAllListeners();
+        socket.on("error", () => {});
+        try {
+          socket.destroy();
+        } catch {
+          // best-effort; the result is already decided.
+        }
+      }
+    }
+    function succeed(result: FridayRustHubAgentRunResumeResult): void {
+      if (settled) return;
+      settled = true;
+      teardown();
+      resolve(result);
+    }
+    function fail(error: FridayDomainError): void {
+      if (settled) return;
+      settled = true;
+      teardown();
+      reject(error);
+    }
+    function onClose(): void {
+      fail(unavailable(`Sealed agent-run client ${leg} connection closed before a control result.`));
+    }
+    function onInbound(payload: Buffer): void {
+      let inbound: InboundEnvelope;
+      try {
+        inbound = openInbound(sessionKey, payload);
+      } catch {
+        fail(unavailable(`Sealed agent-run client ${leg} could not open an inbound envelope.`));
+        return;
+      }
+      if (inbound.kind !== "AgentRunControlResult") {
+        fail(unavailable(`Sealed agent-run client ${leg} received an unknown message shape.`));
+        return;
+      }
+      const parsed = parseControlResult(inbound.fields);
+      if (!parsed) {
+        fail(unavailable(`Sealed agent-run client ${leg} result is missing a required ref.`));
+        return;
+      }
+      succeed(parsed);
+    }
+
+    void (async () => {
+      let connected: Socket;
+      try {
+        connected = await new Promise<Socket>((res, rej) => {
+          const s = connect({ host, port }, () => res(s));
+          socket = s;
+          s.once("error", rej);
+        });
+      } catch {
+        fail(unavailable(`Sealed agent-run client ${leg} could not open a connection.`));
+        return;
+      }
+      socket = connected;
+      socket.setNoDelay(true);
+
+      const reader = createPreambleReader(socket);
+      try {
+        socket.write(frameBytes(keypair.publicKey));
+        const serverPub = await reader.readFrame();
+        if (serverPub.length !== X25519_PUBKEY_LEN) {
+          throw new Error("server pubkey wrong width");
+        }
+        const sessionNonce = await reader.readFrame();
+        if (sessionNonce.length !== SESSION_NONCE_LEN) {
+          throw new Error("session nonce wrong width");
+        }
+
+        sessionKey = agree(keypair.secret, serverPub);
+        const { socket: sock, leftover: preambleLeftover } = reader.takeover();
+        if (preambleLeftover.length > 0) {
+          throw new Error("unexpected buffered bytes before ws upgrade");
+        }
+        const leftover = await wsClientUpgrade(sock, host, port);
+
+        const sender = new wsRuntime.Sender(sock, undefined, () => randomBytes(4));
+        const recv = new wsRuntime.Receiver({ isServer: false, binaryType: "nodebuffer", skipUTF8Validation: true });
+        receiver = recv;
+
+        recv.on("message", (data: Buffer, isBinary: boolean) => {
+          if (!isBinary) {
+            fail(unavailable(`Sealed agent-run client ${leg} received a non-binary frame.`));
+            return;
+          }
+          onInbound(data);
+        });
+        recv.on("conclude", onClose);
+        recv.on("error", () => {
+          fail(unavailable(`Sealed agent-run client ${leg} received a malformed WS frame.`));
+        });
+
+        sock.on("data", (chunk: Buffer) => recv.write(chunk));
+        sock.on("error", () => {
+          fail(unavailable(`Sealed agent-run client ${leg} connection error.`));
+        });
+        sock.on("close", onClose);
+        if (leftover.length > 0) {
+          recv.write(leftover);
+        }
+
+        const authProof = buildAuthProof({
+          sessionKey,
+          sessionNonce,
+          sessionAad: SESSION_AAD,
+          authChallenge: AUTH_CHALLENGE,
+          forwardedPrincipal,
+          runId,
+        });
+        sealAndSend(sender, sessionKey, buildEnvelope(authProof));
+      } catch {
+        fail(unavailable(`Sealed agent-run client ${leg} handshake failed.`));
+      }
+    })();
+  });
+}
+
 /**
  * (Lane B) Run ONE sealed request→response round-trip for a mission-spine mutation. Mirrors the
  * `resumeWithApproval` handshake EXACTLY (connect → length-prefixed preamble → X25519+HKDF session
@@ -2245,6 +2449,43 @@ export function createFridayRustHubAgentRunSealedClient(
             fail(unavailable("Sealed agent-run client resume handshake failed."));
           }
         })();
+      });
+    },
+
+    rejectApproval(
+      request: FridayRustHubAgentRunRejectRequest,
+    ): Promise<FridayRustHubAgentRunResumeResult> {
+      if (!controlEnabled) {
+        return Promise.reject(
+          unavailable("Sealed agent-run client run-control is disabled (reject refused)."),
+        );
+      }
+      if (!request.runId) {
+        return Promise.reject(unavailable("Sealed agent-run client reject requires a run id."));
+      }
+      if (!request.approvalId) {
+        return Promise.reject(unavailable("Sealed agent-run client reject requires an approval id."));
+      }
+      if (!request.forwardedPrincipal) {
+        return Promise.reject(
+          unavailable("Sealed agent-run client reject requires a forwarded principal."),
+        );
+      }
+      return runAgentRunOwnerControlRoundTrip({
+        host,
+        port,
+        timeoutMs,
+        keypair,
+        runId: request.runId,
+        forwardedPrincipal: request.forwardedPrincipal,
+        leg: "reject",
+        buildEnvelope: (authProof) =>
+          buildRejectEnvelope(
+            request.runId,
+            request.approvalId,
+            request.forwardedPrincipal,
+            authProof,
+          ),
       });
     },
 

--- a/test/unit/api/mission-spine/friday-rust-hub-agent-run-ws-sealed-client.test.ts
+++ b/test/unit/api/mission-spine/friday-rust-hub-agent-run-ws-sealed-client.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import { FridayDomainError } from "../../../../src/errors/friday-domain-error.js";
 import {
+  buildRejectEnvelope,
   buildResumeEnvelope,
   createFridayRustHubAgentRunSealedClient,
   handlePaused,
@@ -389,6 +390,34 @@ describe("friday-rust-hub-agent-run-ws-sealed-client A3 courier (pause/resume, d
     expect(envelope.correlation_id).toBe("agent-run-resume-run-9");
   });
 
+  it("(b0) buildRejectEnvelope produces the EXACT owner-authed AgentRunReject refs-only wire", () => {
+    const authProof = new Uint8Array([9, 8, 7]);
+    const envelope = buildRejectEnvelope("run-9", "approval-abc", "admin-001", authProof) as {
+      schema_version: number;
+      msg_id: string;
+      correlation_id: string;
+      message: Record<string, unknown>;
+    };
+
+    expect(envelope.schema_version).toBe(12);
+    expect(envelope.msg_id).toBe("agent-run-reject-run-9-approval-abc");
+    expect(envelope.correlation_id).toBe("agent-run-reject-run-9-approval-abc");
+    expect(envelope.message).toEqual({
+      kind: "AgentRunReject",
+      run_id: "run-9",
+      approval_id: "approval-abc",
+      forwarded_principal: "admin-001",
+      auth_proof: [9, 8, 7],
+    });
+    expect(Object.keys(envelope.message).sort()).toEqual([
+      "approval_id",
+      "auth_proof",
+      "forwarded_principal",
+      "kind",
+      "run_id",
+    ]);
+  });
+
   // ── parseControlResult: the resume reply parse (the OTHER half of test b) ─────────────────────
   it("(b) parseControlResult maps an ACCEPTED AgentRunControlResult to a refs-only resume result", () => {
     const parsed = parseControlResult({
@@ -460,6 +489,49 @@ describe("friday-rust-hub-agent-run-ws-sealed-client A3 courier (pause/resume, d
     });
     await expect(
       client.resumeWithApproval({ runId: "", opaqueSignedBlob: new Uint8Array([1, 2, 3]) }),
+    ).rejects.toMatchObject({ httpStatus: 503 });
+  });
+
+  it("(b'''''') rejectApproval is FAIL-CLOSED when the run-control flag is OFF (relays nothing)", async () => {
+    const client = createFridayRustHubAgentRunSealedClient({
+      port: 1,
+      clientSecret: new Uint8Array(32).fill(7),
+    });
+    await expect(
+      client.rejectApproval({
+        runId: "run-9",
+        approvalId: "approval-abc",
+        forwardedPrincipal: "admin-001",
+      }),
+    ).rejects.toMatchObject({ httpStatus: 503 });
+  });
+
+  it("(b''''''') rejectApproval (flag ON) rejects missing refs before opening a socket", async () => {
+    const client = createFridayRustHubAgentRunSealedClient({
+      port: 1,
+      clientSecret: new Uint8Array(32).fill(7),
+      agentRunControlViaRust: true,
+    });
+    await expect(
+      client.rejectApproval({
+        runId: "",
+        approvalId: "approval-abc",
+        forwardedPrincipal: "admin-001",
+      }),
+    ).rejects.toMatchObject({ httpStatus: 503 });
+    await expect(
+      client.rejectApproval({
+        runId: "run-9",
+        approvalId: "",
+        forwardedPrincipal: "admin-001",
+      }),
+    ).rejects.toMatchObject({ httpStatus: 503 });
+    await expect(
+      client.rejectApproval({
+        runId: "run-9",
+        approvalId: "approval-abc",
+        forwardedPrincipal: "",
+      }),
     ).rejects.toMatchObject({ httpStatus: 503 });
   });
 });


### PR DESCRIPTION
## Summary
- add the missing TS sealed-client AgentRunReject courier method using the existing owner-auth sealed-session proof
- extend the S6 desktop approval relay proof with a reject step and scoped action-runtime evidence for desktop fridayChat Reject
- cover the new reject wire shape and fail-closed guards in unit tests

## Verification
- PATH=/private/tmp/friday-desktop-approval-reject-evidence-20260625/node_modules/.bin:/Users/jarvis/Projects/Friday/node_modules/.bin:/opt/homebrew/opt/rustup/bin:/opt/homebrew/Cellar/openjdk@21/21.0.11/libexec/openjdk.jdk/Contents/Home/bin:/Users/jarvis/Library/Android/sdk/emulator:/Users/jarvis/Library/Android/sdk/platform-tools:/Users/jarvis/Library/Android/sdk/cmdline-tools/latest/bin:/Users/jarvis/.cargo/bin:/Users/jarvis/.local/bin:/Users/jarvis/.nvm/versions/node/v22.22.0/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pkg/env/active/bin:/opt/pmk/env/global/bin:/Library/Apple/usr/bin:/Users/jarvis/.codex/packages/standalone/releases/0.140.0-aarch64-apple-darwin/codex-path:/Users/jarvis/.codex/tmp/arg0/codex-arg0cmUNHd:/opt/homebrew/opt/rustup/bin:/Users/jarvis/.cargo/bin:/opt/homebrew/Cellar/openjdk@21/21.0.11/libexec/openjdk.jdk/Contents/Home/bin:/Users/jarvis/Library/Android/sdk/emulator:/Users/jarvis/Library/Android/sdk/platform-tools:/Users/jarvis/Library/Android/sdk/cmdline-tools/latest/bin:/Users/jarvis/.local/bin:/Users/jarvis/.bun/bin:/Users/jarvis/.nvm/versions/node/v22.22.0/bin vitest run --project default test/unit/api/mission-spine/friday-rust-hub-agent-run-ws-sealed-client.test.ts test/unit/qa/friday-design-action-runtime-evidence-cli.test.ts
- bash -n scripts/ops/friday-desktop-approval-relay-proof.sh
- node scripts/ops/check-friday-desktop-approval-relay-contract.mjs .
- live proof: /tmp/friday-desktop-approval-reject-evidence-20260625T102038Z (paused write_file run, reject accepted/already_rejected, pending_approval_request.status=rejected, proof file absent)

## Truth boundary
This proves owner-auth Reject action evidence only. It does not sign, does not resume, does not execute the mutation, does not read operator signing keys, and does not claim END-BAR, GO-LIVE, release, or adoption.