### PR TITLE
test(mobile): prove approval reject action

### DIFF
--- a/apps/friday-ios/Tests/FridayMobileShellCoreTests/LiveApprovalRejectIntegrationTests.swift
+++ b/apps/friday-ios/Tests/FridayMobileShellCoreTests/LiveApprovalRejectIntegrationTests.swift
@@ -1,0 +1,267 @@
+import Foundation
+import Testing
+
+@testable import FridayMobileShellCore
+@testable import FridayRustClient
+
+// MARK: - LIVE mobile approval reject integration (MANUAL / env-gated)
+//
+// Drives the real mobile Swift write client against the live agent-run WRITE server. The paused
+// approval is created by the governed S6 diagnostic driver; this test proves the mobile product
+// write seam can reject that exact pending approval over owner-authed sealed WS without relaying an
+// operator signature or executing the paused mutation.
+//
+// HONEST CEILING: this is mobile Swift write-client runtime evidence paired with existing
+// view-model reject unit coverage. It is not a simulator tap, not END-BAR, not release/adoption,
+// and not an operator-signed approve.
+
+private let liveMobileApprovalRejectEnabled =
+  ProcessInfo.processInfo.environment["FRIDAY_MOBILE_LIVE_APPROVAL_REJECT_TEST"] == "1"
+
+@MainActor
+@Test(.enabled(if: liveMobileApprovalRejectEnabled))
+func liveMobileApprovalRejectUsesOwnerAuthedWriteClientWithoutResume() async throws {
+  let env = ProcessInfo.processInfo.environment
+  let runId = try requiredMobileApprovalRejectEnv("FRIDAY_MOBILE_APPROVAL_REJECT_RUN_ID", env: env)
+  let approvalId = try requiredMobileApprovalRejectEnv("FRIDAY_MOBILE_APPROVAL_REJECT_APPROVAL_ID", env: env)
+  let writeConfig = try mobileApprovalRejectWriteConfig(env: env)
+  let client = try RealWriteClientFactory.makeLive(
+    config: writeConfig,
+    agentRunControlViaRust: true)
+
+  let result = try await client.rejectApproval(runId: runId, approvalId: approvalId)
+
+  print(
+    "[live-mobile-approval-reject] runId=\(result.runId) op=\(result.op) "
+      + "accepted=\(result.accepted) status=\(result.status) "
+      + "auditRef=\(result.auditRef ?? "<nil>")")
+
+  #expect(result.runId == runId)
+  #expect(result.op == "reject")
+  #expect(result.accepted)
+  #expect(result.status == "rejected" || result.status == "already_rejected")
+
+  try writeMobileApprovalRejectProofIfRequested(
+    result: result,
+    approvalId: approvalId,
+    writeConfig: writeConfig)
+
+  try await proveFridayChatViewModelRejectDelegatesToLiveWriteClientWithoutResume(
+    runId: runId,
+    approvalId: approvalId,
+    actionDigest: env["FRIDAY_MOBILE_APPROVAL_REJECT_ACTION_DIGEST"],
+    liveClient: client)
+}
+
+private func requiredMobileApprovalRejectEnv(_ key: String, env: [String: String]) throws -> String {
+  guard let value = env[key]?.trimmingCharacters(in: .whitespacesAndNewlines), !value.isEmpty else {
+    throw FridayWriteClientError.transport("missing required env \(key)")
+  }
+  return value
+}
+
+private func mobileApprovalRejectWriteConfig(env: [String: String]) throws -> AgentRunServerConfig {
+  let host = env["FRIDAY_MOBILE_APPROVAL_REJECT_WRITE_HOST"]?
+    .trimmingCharacters(in: .whitespacesAndNewlines)
+  let rawPort = env["FRIDAY_MOBILE_APPROVAL_REJECT_WRITE_PORT"]?
+    .trimmingCharacters(in: .whitespacesAndNewlines)
+  guard let rawPort, !rawPort.isEmpty else {
+    return AgentRunServerConfig(
+      host: host.flatMap { $0.isEmpty ? nil : $0 } ?? AgentRunServerConfig.liveLoopback.host,
+      port: AgentRunServerConfig.liveLoopback.port)
+  }
+  guard let port = UInt16(rawPort), port > 0 else {
+    throw FridayWriteClientError.transport("invalid FRIDAY_MOBILE_APPROVAL_REJECT_WRITE_PORT=\(rawPort)")
+  }
+  return AgentRunServerConfig(
+    host: host.flatMap { $0.isEmpty ? nil : $0 } ?? AgentRunServerConfig.liveLoopback.host,
+    port: port)
+}
+
+private func writeMobileApprovalRejectProofIfRequested(
+  result: ResumeRelayResult,
+  approvalId: String,
+  writeConfig: AgentRunServerConfig
+) throws {
+  guard let rawPath = ProcessInfo.processInfo.environment[
+    "FRIDAY_MOBILE_APPROVAL_REJECT_PROOF_OUT"
+  ]?.trimmingCharacters(in: .whitespacesAndNewlines), !rawPath.isEmpty else {
+    return
+  }
+
+  let proof: [String: Any] = [
+    "truth_label": "ios_mobile_live_approval_reject_write_client_proof_not_sim_tap_not_endbar",
+    "status": "pass",
+    "generated_at_utc": ISO8601DateFormatter().string(from: Date()),
+    "run_id": result.runId,
+    "approval_id": approvalId,
+    "reject": [
+      "op": result.op,
+      "accepted": result.accepted,
+      "status": result.status,
+      "audit_ref": result.auditRef.map { $0 as Any } ?? NSNull(),
+      "endpoint": [
+        "host": writeConfig.host,
+        "port": Int(writeConfig.port),
+      ],
+    ],
+    "ui_actions": [
+      [
+        "surface": "mobile",
+        "screen": "approval",
+        "action_id": "act",
+        "capability_id": "security_approval_bound_principal_gate_cat10_netnew",
+        "status": "pass",
+        "evidence_ref": "proof://mobile/approval-reject/\(result.runId)",
+        "truth_label": "explicit_mobile_approval_reject_runtime_evidence_from_live_swift_write_client",
+      ],
+    ],
+      "caveat": "Mobile Swift write-client reject proof only, paired with view-model unit tests; not a simulator tap, not END-BAR, not GO-LIVE, not operator-signed approve.",
+  ]
+
+  let data = try JSONSerialization.data(withJSONObject: proof, options: [.prettyPrinted, .sortedKeys])
+  let url = URL(fileURLWithPath: rawPath)
+  try FileManager.default.createDirectory(
+    at: url.deletingLastPathComponent(),
+    withIntermediateDirectories: true)
+  try data.write(to: url, options: .atomic)
+  print("[live-mobile-approval-reject] proofOut=\(url.path)")
+}
+
+@MainActor
+private func proveFridayChatViewModelRejectDelegatesToLiveWriteClientWithoutResume(
+  runId: String,
+  approvalId: String,
+  actionDigest rawActionDigest: String?,
+  liveClient: FridayRustWriteClient
+) async throws {
+  let actionDigest = rawActionDigest?
+    .trimmingCharacters(in: .whitespacesAndNewlines)
+  let client = FridayChatLiveRejectHarnessWriteClient(
+    pending: PausedOutcome(
+      runId: runId,
+      approvalId: approvalId,
+      actionDigest: actionDigest.flatMap { $0.isEmpty ? nil : $0 } ?? String(repeating: "0", count: 64),
+      ownerSealedSummary: "write_file(mobile-approval-reject-proof.txt)"),
+    liveClient: liveClient)
+  let vm = FridayChatViewModel(
+    writeClient: client,
+    signer: MockOperatorSigner(),
+    historyStore: LiveApprovalRejectInMemoryHistoryStore())
+
+  await vm.send("reject this already-paused mobile approval")
+  guard case .pendingApproval = vm.phase else {
+    Issue.record("expected .pendingApproval before reject, got \(String(describing: vm.phase))")
+    return
+  }
+
+  await vm.reject()
+
+  #expect(client.dispatchedTasks == ["reject this already-paused mobile approval"])
+  #expect(client.rejectedRunIds == [runId])
+  #expect(client.rejectedApprovalIds == [approvalId])
+  #expect(client.resumedRunIds.isEmpty)
+  guard case .resumed(let receipt) = vm.phase else {
+    Issue.record("expected .resumed reject receipt, got \(String(describing: vm.phase))")
+    return
+  }
+  #expect(receipt.runId == runId)
+  #expect(receipt.op == "reject")
+  #expect(receipt.accepted)
+  #expect(receipt.status == "rejected" || receipt.status == "already_rejected")
+
+  try appendMobileFridayChatRejectEvidenceIfRequested(
+    result: ResumeRelayResult(
+      runId: receipt.runId,
+      op: receipt.op,
+      accepted: receipt.accepted,
+      status: receipt.status,
+      auditRef: receipt.auditRef),
+    approvalId: approvalId)
+}
+
+private final class FridayChatLiveRejectHarnessWriteClient: FridayRustWriteClient, @unchecked Sendable {
+  let pending: PausedOutcome
+  let liveClient: FridayRustWriteClient
+
+  private(set) var dispatchedTasks: [String] = []
+  private(set) var resumedRunIds: [String] = []
+  private(set) var rejectedRunIds: [String] = []
+  private(set) var rejectedApprovalIds: [String] = []
+
+  init(pending: PausedOutcome, liveClient: FridayRustWriteClient) {
+    self.pending = pending
+    self.liveClient = liveClient
+  }
+
+  func dispatchAgentRun(task: String, constraints: AgentRunConstraintsWire?) async throws -> AgentRunDispatchOutcome {
+    dispatchedTasks.append(task)
+    return .paused(pending)
+  }
+
+  func resumeWithApproval(runId: String, opaqueSignedBlob: [UInt8]) async throws -> ResumeRelayResult {
+    resumedRunIds.append(runId)
+    throw FridayWriteClientError.transport("test harness must not resume")
+  }
+
+  func rejectApproval(runId: String, approvalId: String) async throws -> ResumeRelayResult {
+    rejectedRunIds.append(runId)
+    rejectedApprovalIds.append(approvalId)
+    return try await liveClient.rejectApproval(runId: runId, approvalId: approvalId)
+  }
+
+  func cancelRun(runId: String, reason: String?) async throws -> ResumeRelayResult {
+    throw FridayWriteClientError.transport("test harness must not cancel")
+  }
+}
+
+private final class LiveApprovalRejectInMemoryHistoryStore: ChatHistoryStoring, @unchecked Sendable {
+  private var items: [ChatHistoryItem] = []
+
+  func load() -> [ChatHistoryItem] {
+    items
+  }
+
+  func save(_ items: [ChatHistoryItem]) {
+    self.items = items
+  }
+}
+
+private func appendMobileFridayChatRejectEvidenceIfRequested(
+  result: ResumeRelayResult,
+  approvalId: String
+) throws {
+  guard let rawPath = ProcessInfo.processInfo.environment[
+    "FRIDAY_MOBILE_APPROVAL_REJECT_PROOF_OUT"
+  ]?.trimmingCharacters(in: .whitespacesAndNewlines), !rawPath.isEmpty else {
+    return
+  }
+
+  let url = URL(fileURLWithPath: rawPath)
+  let original = try Data(contentsOf: url)
+  guard var proof = try JSONSerialization.jsonObject(with: original) as? [String: Any] else {
+    throw FridayWriteClientError.transport("invalid mobile approval reject proof JSON at \(rawPath)")
+  }
+  var actions = proof["ui_actions"] as? [[String: Any]] ?? []
+  actions.append([
+    "surface": "mobile",
+    "screen": "fridayChat",
+    "action_id": "act",
+    "capability_id": "security_approval_bound_principal_gate_cat10_netnew",
+    "status": "pass",
+    "evidence_ref": "proof://mobile/fridaychat-approval-reject/\(result.runId)",
+    "truth_label": "explicit_mobile_fridaychat_reject_runtime_evidence_from_view_model_delegating_to_live_swift_write_client",
+  ])
+  proof["ui_actions"] = actions
+  proof["friday_chat_reject"] = [
+    "op": result.op,
+    "accepted": result.accepted,
+    "status": result.status,
+    "run_id": result.runId,
+    "approval_id": approvalId,
+    "audit_ref": result.auditRef.map { $0 as Any } ?? NSNull(),
+  ]
+  let updated = try JSONSerialization.data(withJSONObject: proof, options: [.prettyPrinted, .sortedKeys])
+  try updated.write(to: url, options: .atomic)
+  print("[live-mobile-fridaychat-approval-reject] appendedProofOut=\(url.path)")
+}

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "proof:ui-device:live-write-read-bundle": "bash scripts/ops/friday-ui-device-live-write-read-capture-bundle.sh --out-dir \"${FRIDAY_UI_DEVICE_LIVE_WRITE_READ_BUNDLE_OUT:-/tmp/friday-ui-device-live-write-read-bundle}\"",
     "proof:product:auto-followup": "bash scripts/ops/friday-product-auto-followup-proof.sh",
     "proof:desktop:approval-relay": "bash scripts/ops/friday-desktop-approval-relay-proof.sh",
+    "proof:mobile:approval-reject": "bash scripts/ops/friday-mobile-approval-reject-proof.sh",
     "build:android:emu": "bash apps/friday-android/build-emu.sh",
     "build:release:source": "bash scripts/ops/build-friday-source-distribution.sh",
     "build:friday-static:prod": "node scripts/qa/build-friday-static-prod.mjs",

--- a/scripts/ops/friday-mobile-approval-reject-proof.sh
+++ b/scripts/ops/friday-mobile-approval-reject-proof.sh
@@ -1,0 +1,197 @@
+#!/usr/bin/env bash
+#
+# Mobile approval reject live proof wrapper.
+#
+# Truth boundary:
+#   `dispatch` creates a real paused mutating run through the existing governed S6 diagnostic
+#   driver. `reject` then runs the mobile Swift live write-client test against that exact pending
+#   approval. This does not read signing keys, mint signatures, resume the mutation, kill/restart
+#   prod Hub, flip flags, or fabricate organic traffic. It is mobile Swift write-client evidence,
+#   not a simulator tap, not END-BAR, and not release/adoption.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+STEP="${FRIDAY_MOBILE_APPROVAL_REJECT_STEP:-both}"
+LIVE="${FRIDAY_MOBILE_APPROVAL_REJECT_LIVE:-0}"
+ARTIFACT_DIR="${FRIDAY_MOBILE_APPROVAL_REJECT_ARTIFACT_DIR:-${TMPDIR:-/tmp}/friday-mobile-approval-reject}"
+PROOF_FILE="${FRIDAY_MOBILE_APPROVAL_REJECT_DRIVER_PROOF_FILE:-mobile-approval-reject-proof.txt}"
+RUN_ID="${FRIDAY_MOBILE_APPROVAL_REJECT_RUN_ID:-}"
+APPROVAL_ID="${FRIDAY_MOBILE_APPROVAL_REJECT_APPROVAL_ID:-}"
+ACTION_DIGEST="${FRIDAY_MOBILE_APPROVAL_REJECT_ACTION_DIGEST:-}"
+SWIFT_PROOF_OUT="${FRIDAY_MOBILE_APPROVAL_REJECT_SWIFT_PROOF_OUT:-${ARTIFACT_DIR}/mobile-approval-reject-proof.json}"
+ACTION_RUNTIME_OUT="${FRIDAY_MOBILE_APPROVAL_REJECT_ACTION_RUNTIME_OUT:-${ARTIFACT_DIR}/action-runtime-evidence.json}"
+
+fail() {
+  echo "FATAL: $*" >&2
+  exit 3
+}
+
+need_live() {
+  if [[ "${LIVE}" != "1" ]]; then
+    fail "set FRIDAY_MOBILE_APPROVAL_REJECT_LIVE=1 to run this live proof."
+  fi
+}
+
+driver() {
+  node "${REPO_ROOT}/scripts/diagnostics/friday-s6-transport-a-driver.mjs" "$@"
+}
+
+metadata_path() {
+  echo "${ARTIFACT_DIR}/mobile-approval-reject-metadata.env"
+}
+
+save_metadata() {
+  local log_file="$1"
+  local run_id approval_id action_digest
+  run_id="$(awk -F'= ' '/^[[:space:]]+runId[[:space:]]*=/{gsub(/[[:space:]]/, "", $2); print $2; exit}' "${log_file}")"
+  approval_id="$(awk -F'= ' '/^[[:space:]]+approvalId[[:space:]]*=/{gsub(/[[:space:]]/, "", $2); print $2; exit}' "${log_file}")"
+  action_digest="$(awk -F'= ' '/^[[:space:]]+actionDigest[[:space:]]*=/{gsub(/[[:space:]]/, "", $2); print $2; exit}' "${log_file}")"
+  if [[ -z "${run_id}" || -z "${approval_id}" || -z "${action_digest}" ]]; then
+    fail "could not parse runId/approvalId/actionDigest from ${log_file}."
+  fi
+  cat >"$(metadata_path)" <<EOF
+FRIDAY_MOBILE_APPROVAL_REJECT_RUN_ID=${run_id}
+FRIDAY_MOBILE_APPROVAL_REJECT_APPROVAL_ID=${approval_id}
+FRIDAY_MOBILE_APPROVAL_REJECT_ACTION_DIGEST=${action_digest}
+EOF
+}
+
+load_run_id() {
+  if [[ -n "${RUN_ID}" ]]; then
+    echo "${RUN_ID}"
+    return
+  fi
+  local meta
+  meta="$(metadata_path)"
+  if [[ ! -f "${meta}" ]]; then
+    fail "FRIDAY_MOBILE_APPROVAL_REJECT_RUN_ID is required when ${meta} is absent."
+  fi
+  # shellcheck disable=SC1090
+  source "${meta}"
+  if [[ -z "${FRIDAY_MOBILE_APPROVAL_REJECT_RUN_ID:-}" ]]; then
+    fail "${meta} does not contain FRIDAY_MOBILE_APPROVAL_REJECT_RUN_ID."
+  fi
+  echo "${FRIDAY_MOBILE_APPROVAL_REJECT_RUN_ID}"
+}
+
+load_approval_id() {
+  if [[ -n "${APPROVAL_ID}" ]]; then
+    echo "${APPROVAL_ID}"
+    return
+  fi
+  local meta
+  meta="$(metadata_path)"
+  if [[ ! -f "${meta}" ]]; then
+    fail "FRIDAY_MOBILE_APPROVAL_REJECT_APPROVAL_ID is required when ${meta} is absent."
+  fi
+  # shellcheck disable=SC1090
+  source "${meta}"
+  if [[ -z "${FRIDAY_MOBILE_APPROVAL_REJECT_APPROVAL_ID:-}" ]]; then
+    fail "${meta} does not contain FRIDAY_MOBILE_APPROVAL_REJECT_APPROVAL_ID."
+  fi
+  echo "${FRIDAY_MOBILE_APPROVAL_REJECT_APPROVAL_ID}"
+}
+
+load_action_digest() {
+  if [[ -n "${ACTION_DIGEST}" ]]; then
+    echo "${ACTION_DIGEST}"
+    return
+  fi
+  local meta
+  meta="$(metadata_path)"
+  if [[ ! -f "${meta}" ]]; then
+    echo ""
+    return
+  fi
+  # shellcheck disable=SC1090
+  source "${meta}"
+  echo "${FRIDAY_MOBILE_APPROVAL_REJECT_ACTION_DIGEST:-}"
+}
+
+write_action_runtime_evidence() {
+  local swift_proof="$1"
+  local out="$2"
+  if [[ -z "${out}" ]]; then
+    return
+  fi
+  node - "${swift_proof}" "${out}" <<'NODE'
+const fs = require("node:fs");
+const path = require("node:path");
+const [swiftProofPath, outPath] = process.argv.slice(2);
+const swiftProof = JSON.parse(fs.readFileSync(swiftProofPath, "utf8"));
+const actionRows = Array.isArray(swiftProof.ui_actions) ? swiftProof.ui_actions : [];
+const evidence = {
+  truth: "mobile_approval_reject_action_runtime_evidence_not_sim_tap_not_endbar_not_signature",
+  status: actionRows.length > 0 ? "ready" : "blocked",
+  actions: actionRows,
+  source_proof: swiftProofPath,
+  run_id: swiftProof.run_id,
+  approval_id: swiftProof.approval_id,
+  caveat:
+    "Reject action evidence only: mobile Swift write-client owner-auth refusal of a paused mutation. It does not prove simulator tap, operator-signed approve, END-BAR, release, or adoption.",
+};
+fs.mkdirSync(path.dirname(outPath), { recursive: true });
+fs.writeFileSync(outPath, `${JSON.stringify(evidence, null, 2)}\n`);
+console.log(JSON.stringify({ status: evidence.status, actionCount: evidence.actions.length, out: outPath }, null, 2));
+NODE
+}
+
+run_dispatch() {
+  need_live
+  mkdir -p "${ARTIFACT_DIR}"
+  chmod 700 "${ARTIFACT_DIR}"
+  local log_file="${ARTIFACT_DIR}/dispatch.log"
+  echo "Friday mobile approval reject proof: dispatch"
+  echo "truth_label=mobile_approval_reject_dispatch_paused_real_run_not_signature_not_go"
+  echo "artifact_dir=${ARTIFACT_DIR}"
+  driver \
+    --mode dispatch-mutating \
+    --artifact-dir "${ARTIFACT_DIR}" \
+    --proof-file "${PROOF_FILE}" | tee "${log_file}"
+  save_metadata "${log_file}"
+  echo
+  echo "Metadata written: $(metadata_path)"
+  echo "Truth: dispatch paused a real mutating run; it did not sign, resume, release, GO, or prove adoption."
+}
+
+run_reject() {
+  need_live
+  local run_id approval_id action_digest
+  run_id="$(load_run_id)"
+  approval_id="$(load_approval_id)"
+  action_digest="$(load_action_digest)"
+  mkdir -p "${ARTIFACT_DIR}"
+  echo "Friday mobile approval reject proof: reject"
+  echo "truth_label=mobile_approval_reject_swift_live_write_client_no_signature_no_mutation"
+  echo "run_id=${run_id}"
+  echo "approval_id=${approval_id}"
+  FRIDAY_MOBILE_LIVE_APPROVAL_REJECT_TEST=1 \
+  FRIDAY_MOBILE_APPROVAL_REJECT_RUN_ID="${run_id}" \
+  FRIDAY_MOBILE_APPROVAL_REJECT_APPROVAL_ID="${approval_id}" \
+  FRIDAY_MOBILE_APPROVAL_REJECT_ACTION_DIGEST="${action_digest}" \
+  FRIDAY_MOBILE_APPROVAL_REJECT_PROOF_OUT="${SWIFT_PROOF_OUT}" \
+    swift test \
+      --package-path "${REPO_ROOT}/apps/friday-ios" \
+      --filter liveMobile
+  if [[ ! -s "${SWIFT_PROOF_OUT}" ]]; then
+    fail "Swift live proof did not write ${SWIFT_PROOF_OUT}."
+  fi
+  write_action_runtime_evidence "${SWIFT_PROOF_OUT}" "${ACTION_RUNTIME_OUT}"
+  echo "Swift proof: ${SWIFT_PROOF_OUT}"
+  echo "Action runtime evidence: ${ACTION_RUNTIME_OUT}"
+  echo "Truth: mobile reject refused the pending approval through run-control; it did not sign, resume, release, GO, or prove adoption."
+}
+
+case "${STEP}" in
+  dispatch) run_dispatch ;;
+  reject) run_reject ;;
+  both)
+    run_dispatch
+    run_reject
+    ;;
+  *)
+    fail "FRIDAY_MOBILE_APPROVAL_REJECT_STEP must be dispatch, reject, or both."
+    ;;
+esac

--- a/test/unit/qa/friday-mobile-approval-reject-proof-cli.test.ts
+++ b/test/unit/qa/friday-mobile-approval-reject-proof-cli.test.ts
@@ -1,0 +1,116 @@
+import { execFileSync, spawnSync } from "node:child_process";
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const wrapper = "scripts/ops/friday-mobile-approval-reject-proof.sh";
+const checker = "scripts/ops/check-friday-design-action-runtime-evidence.mjs";
+
+function writeFile(root: string, relative: string, body: string) {
+  const target = join(root, relative);
+  mkdirSync(dirname(target), { recursive: true });
+  writeFileSync(target, body);
+  return target;
+}
+
+function contractBody() {
+  return `# Friday Action Contract
+
+**This is a wiring contract for the later Rust/native agent, NOT runtime proof.** Every row is design-proof; wired_registry ≠ runtime PASS.
+
+| Surface | Screen [state] | action_id | Label | capability_id | reg | reg_status | truth_status | result/target | Rust/Hub owner gate test expectation |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| mobile | approval | act | Reject | security_approval_bound_principal_gate_cat10_netnew | x | wired | wired_registry | result:rejected | Runtime proof required. |
+| mobile | approval | check | Approve with proof | security_approval_bound_principal_gate_cat10_netnew | x | wired | wired_registry | result:confirmed | Runtime proof required. |
+`;
+}
+
+describe("friday-mobile-approval-reject-proof", () => {
+  it("fails closed unless explicitly live-enabled", () => {
+    const result = spawnSync("bash", [wrapper], {
+      cwd: process.cwd(),
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        FRIDAY_MOBILE_APPROVAL_REJECT_LIVE: "0",
+      },
+    });
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("FRIDAY_MOBILE_APPROVAL_REJECT_LIVE=1");
+  });
+
+  it("converts a Swift reject proof into mobile approval action evidence", () => {
+    const root = mkdtempSync(join(tmpdir(), "friday-mobile-approval-reject-"));
+    try {
+      const swiftProof = writeFile(root, "mobile-approval-reject-proof.json", JSON.stringify({
+        truth_label: "ios_mobile_live_approval_reject_write_client_proof_not_sim_tap_not_endbar",
+        status: "pass",
+        run_id: "run-paused-1",
+        approval_id: "approval-1",
+        ui_actions: [
+          {
+            surface: "mobile",
+            screen: "approval",
+            action_id: "act",
+            capability_id: "security_approval_bound_principal_gate_cat10_netnew",
+            status: "pass",
+            evidence_ref: "proof://mobile/approval-reject/run-paused-1",
+          },
+        ],
+      }, null, 2));
+      const swift = writeFile(root, "swift", "#!/usr/bin/env bash\nexit 0\n");
+      chmodSync(swift, 0o755);
+      const out = join(root, "action-runtime-evidence.json");
+
+      const stdout = execFileSync("bash", [
+        wrapper,
+      ], {
+        cwd: process.cwd(),
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          FRIDAY_MOBILE_APPROVAL_REJECT_LIVE: "1",
+          FRIDAY_MOBILE_APPROVAL_REJECT_STEP: "reject",
+          FRIDAY_MOBILE_APPROVAL_REJECT_RUN_ID: "run-paused-1",
+          FRIDAY_MOBILE_APPROVAL_REJECT_APPROVAL_ID: "approval-1",
+          FRIDAY_MOBILE_APPROVAL_REJECT_SWIFT_PROOF_OUT: swiftProof,
+          FRIDAY_MOBILE_APPROVAL_REJECT_ACTION_RUNTIME_OUT: out,
+          PATH: `${root}:${process.env.PATH ?? ""}`,
+        },
+      });
+
+      expect(stdout).toContain("Action runtime evidence:");
+      const actionEvidence = JSON.parse(readFileSync(out, "utf8")) as {
+        actions?: Array<{ surface?: string; screen?: string; action_id?: string; status?: string }>;
+      };
+      expect(actionEvidence.actions).toEqual([
+        expect.objectContaining({
+          surface: "mobile",
+          screen: "approval",
+          action_id: "act",
+          status: "pass",
+        }),
+      ]);
+
+      const contract = writeFile(root, "ACTION-CONTRACT.md", contractBody());
+      writeFile(root, "apps/friday-ios/Sources/FridayMobileShell/FridayChatScreen.swift", "Button(\"Reject\") {}");
+      writeFile(root, "apps/friday-ios/Sources/FridayMobileShellCore/FridayChatViewModel.swift", "func reject() {}");
+      const report = JSON.parse(execFileSync("node", [
+        checker,
+        `--repo-root=${root}`,
+        `--contract=${contract}`,
+        `--runtime-evidence=${out}`,
+      ], { cwd: process.cwd(), encoding: "utf8" })) as {
+        counts?: { missingRuntimeEvidence?: number };
+        gaps?: { missingRuntimeEvidence?: Array<{ actionId?: string }> };
+      };
+
+      expect(report.counts?.missingRuntimeEvidence).toBe(0);
+      expect(report.gaps?.missingRuntimeEvidence).toEqual([]);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add an env-gated iOS Swift live integration test for owner-auth mobile approval reject
- add `proof:mobile:approval-reject` wrapper to dispatch a real paused mutation, reject it through the mobile Swift write client, and export design action runtime evidence
- extend the live proof through `FridayChatViewModel.reject()` so the mobile chat approve-card Reject action delegates to the same live owner-auth write seam without resuming
- add CLI coverage for fail-closed live gating and evidence conversion

## Truth boundary
- proves mobile Swift write-client reject of a real paused approval over sealed WS
- proves FridayChat view-model Reject delegates to the live write client and does not call resume
- not a simulator tap, not operator-signed approve, not END-BAR, not release/adoption, not GO-LIVE

## Live proof run
- artifact dir: `/tmp/friday-mobile-approval-reject-20260625T112516Z`
- run: `ec224d2a-cec3-4853-b70a-be4db0433423`
- approval: `3e0e839343f103a7ec05fa63cee82ebf04780f74fa710263aeaea1dee853512e`
- result: `op=reject accepted=true status=rejected`
- audit ref: `ec224d2a-cec3-4853-b70a-be4db0433423:control:reject:2a401627f6ddb2bdf832cb71656f31f9a300863666e7f8cc904c8e2a0512e28d:receipt`
- action runtime evidence rows: `2` (`mobile approval/act`, `mobile fridayChat/act`)
- design action checker: `missingMobileApprovalAndChatRejectRows=0`, `missingUnique=24`, `missingRuntime=65`
- mutation proof file absent after reject: `/Users/jarvis/.friday/agent-run-workspace/mobile-approval-reject-proof.txt`

## Tests
- `bash -n scripts/ops/friday-mobile-approval-reject-proof.sh`
- `PATH="/Users/jarvis/Projects/Friday/node_modules/.bin:$PATH" npm exec --no -- vitest run --project default test/unit/qa/friday-mobile-approval-reject-proof-cli.test.ts`
- `swift test --package-path apps/friday-ios --filter liveMobileApprovalRejectUsesOwnerAuthedWriteClientWithoutResume`
- `swift test --package-path apps/friday-ios --filter FridayChatViewModelTests/testReject`
- `FRIDAY_MOBILE_APPROVAL_REJECT_LIVE=1 FRIDAY_MOBILE_APPROVAL_REJECT_ARTIFACT_DIR=/tmp/friday-mobile-approval-reject-20260625T112516Z bash scripts/ops/friday-mobile-approval-reject-proof.sh`
- `node scripts/ops/check-friday-design-action-runtime-evidence.mjs --repo-root=/private/tmp/friday-mobile-approval-reject-evidence-20260625 --contract=/Users/jarvis/Desktop/friday-design-handoff-20260602/ACTION-CONTRACT.md --runtime-evidence=/tmp/friday-mobile-approval-reject-20260625T112516Z/action-runtime-evidence.json --out=/tmp/friday-mobile-approval-reject-20260625T112516Z/design-action-runtime-gap.json`
