### PR TITLE
test(ui): prove mobile memory action evidence

### DIFF
--- a/apps/friday-ios/Tests/FridayMobileShellCoreTests/HomeViewModelTests.swift
+++ b/apps/friday-ios/Tests/FridayMobileShellCoreTests/HomeViewModelTests.swift
@@ -353,6 +353,9 @@ final class HomeViewModelTests: XCTestCase {
     XCTAssertEqual(p.agentSessionId, "session-1")
     XCTAssertEqual(p.workItemIds, ["wi-1", "wi-2"])                 // refs/ids only (INV-5)
     XCTAssertTrue(vm.state.isOnline)
+    try writeHomeRefreshActionEvidenceIfRequested(
+      missionId: p.missionId,
+      evidenceRef: "proof://mobile/home-refresh/\(p.missionId)")
   }
 
   func testHomeViewModelCarriesInjectedDevicePairingReadiness() async throws {
@@ -839,6 +842,55 @@ final class HomeViewModelTests: XCTestCase {
     XCTAssertEqual(
       vm.memoryDecisionStates["cand-1"],
       .confirmed(summary: "confirmed · state=confirmed · recallable=true"))
+    try writeMobileMemoryActionEvidenceIfRequested(
+      fileSuffix: "confirm",
+      screen: "memory",
+      actionId: "check",
+      evidenceRef: "proof://mobile/memory-confirm/cand-1",
+      request: try XCTUnwrap(write.memoryRequests.first),
+      result: MemoryDecisionResultWire(
+        memoryId: "cand-1",
+        state: "confirmed",
+        status: "confirmed",
+        recallable: true))
+  }
+
+  func testDecideMemoryRejectRendersRejectedAndRefreshes() async throws {
+    let read = FakeReadClient(.snapshot(try sampleSnapshot()))
+    let write = FakeMissionWriteClient(memoryScript: .result(
+      MemoryDecisionResultWire(
+        memoryId: "cand-1",
+        state: "rejected",
+        status: "rejected",
+        recallable: false)))
+    let vm = HomeViewModel(
+      client: read,
+      writeClient: write,
+      writeOwnerPrincipal: "owner-ios")
+
+    await vm.decideMemory(candidateId: "cand-1", confirm: false)
+
+    XCTAssertEqual(write.memoryRequests, [
+      MemoryDecisionRequestWire(
+        memoryId: "cand-1",
+        ownerPrincipal: "owner-ios",
+        decision: "reject"),
+    ])
+    XCTAssertEqual(read.fetchWorkbenchCount, 1)
+    XCTAssertEqual(
+      vm.memoryDecisionStates["cand-1"],
+      .confirmed(summary: "rejected · state=rejected · recallable=false"))
+    try writeMobileMemoryActionEvidenceIfRequested(
+      fileSuffix: "reject",
+      screen: "memory",
+      actionId: "act",
+      evidenceRef: "proof://mobile/memory-reject/cand-1",
+      request: try XCTUnwrap(write.memoryRequests.first),
+      result: MemoryDecisionResultWire(
+        memoryId: "cand-1",
+        state: "rejected",
+        status: "rejected",
+        recallable: false))
   }
 
   func testDecideMemoryBlockedRendersErrorNotConfirmed() async throws {
@@ -879,6 +931,97 @@ final class HomeViewModelTests: XCTestCase {
     XCTAssertEqual(
       vm.memoryDecisionStates["cand-1"],
       .error(reason: "Write seam not configured."))
+  }
+
+  private func writeMobileMemoryActionEvidenceIfRequested(
+    fileSuffix: String,
+    screen: String,
+    actionId: String,
+    evidenceRef: String,
+    request: MemoryDecisionRequestWire,
+    result: MemoryDecisionResultWire
+  ) throws {
+    guard let rawDir = ProcessInfo.processInfo.environment[
+      "FRIDAY_MOBILE_MEMORY_ACTION_EVIDENCE_DIR"
+    ]?.trimmingCharacters(in: .whitespacesAndNewlines), !rawDir.isEmpty else {
+      return
+    }
+
+    let proof: [String: Any] = [
+      "truth": "mobile_memory_action_swift_viewmodel_runtime_not_live_hub_not_endbar",
+      "status": "ready",
+      "generated_at_utc": ISO8601DateFormatter().string(from: Date()),
+      "request": [
+        "memory_id": request.memoryId,
+        "owner_principal": request.ownerPrincipal,
+        "decision": request.decision,
+      ],
+      "result": [
+        "memory_id": result.memoryId,
+        "state": result.state,
+        "status": result.status,
+        "blocker": result.blocker.map { $0 as Any } ?? NSNull(),
+        "recallable": result.recallable,
+      ],
+      "actions": [
+        [
+          "surface": "mobile",
+          "screen": screen,
+          "action_id": actionId,
+          "capability_id": "memory_review_no_silent_write_decide_candidate",
+          "status": "pass",
+          "evidence_ref": evidenceRef,
+          "source": "ios_home_viewmodel_memory_decision_runtime",
+          "truth_label": "swift_viewmodel_write_client_runtime_not_live_hub_audit_not_sim_tap",
+        ],
+      ],
+      "caveat": "This is Swift product ViewModel runtime evidence that the mobile memory action delegates to the write seam and renders the refs-only result. It is not a live Hub memory-spine audit receipt, not a simulator tap, not END-BAR, and not adoption.",
+    ]
+
+    let dir = URL(fileURLWithPath: rawDir)
+    try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+    let out = dir.appendingPathComponent("mobile-memory-\(fileSuffix)-action-evidence.json")
+    let data = try JSONSerialization.data(withJSONObject: proof, options: [.prettyPrinted, .sortedKeys])
+    try data.write(to: out, options: .atomic)
+    print("[mobile-memory-action-evidence] proofOut=\(out.path)")
+  }
+
+  private func writeHomeRefreshActionEvidenceIfRequested(
+    missionId: String,
+    evidenceRef: String
+  ) throws {
+    guard let rawDir = ProcessInfo.processInfo.environment[
+      "FRIDAY_MOBILE_MEMORY_ACTION_EVIDENCE_DIR"
+    ]?.trimmingCharacters(in: .whitespacesAndNewlines), !rawDir.isEmpty else {
+      return
+    }
+
+    let proof: [String: Any] = [
+      "truth": "mobile_home_refresh_swift_viewmodel_runtime_not_live_hub_not_endbar",
+      "status": "ready",
+      "generated_at_utc": ISO8601DateFormatter().string(from: Date()),
+      "mission_id": missionId,
+      "actions": [
+        [
+          "surface": "mobile",
+          "screen": "home",
+          "action_id": "refresh",
+          "capability_id": "transport_connection_state",
+          "status": "pass",
+          "evidence_ref": evidenceRef,
+          "source": "ios_home_viewmodel_refresh_runtime",
+          "truth_label": "swift_viewmodel_read_refresh_runtime_not_live_hub_not_sim_tap",
+        ],
+      ],
+      "caveat": "This is Swift product ViewModel runtime evidence that Home refresh re-reads and renders the refs-only projection. It is not a live Hub read, not a simulator tap, not END-BAR, and not adoption.",
+    ]
+
+    let dir = URL(fileURLWithPath: rawDir)
+    try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+    let out = dir.appendingPathComponent("mobile-home-refresh-action-evidence.json")
+    let data = try JSONSerialization.data(withJSONObject: proof, options: [.prettyPrinted, .sortedKeys])
+    try data.write(to: out, options: .atomic)
+    print("[mobile-home-refresh-action-evidence] proofOut=\(out.path)")
   }
 }
 

--- a/scripts/ops/check-friday-design-action-runtime-evidence.mjs
+++ b/scripts/ops/check-friday-design-action-runtime-evidence.mjs
@@ -227,7 +227,10 @@ function runtimeEvidenceFor(row, runtimeRows) {
     if (candidate.status !== "pass") return false;
     if (candidate.surface && candidate.surface !== row.surface) return false;
     if (candidate.screen && candidate.screen !== row.screen) return false;
-    return candidate.actionId === row.actionId || candidate.capabilityId === row.capabilityId;
+    if (candidate.actionId && row.actionId && candidate.actionId !== row.actionId) return false;
+    if (candidate.capabilityId && row.capabilityId) return candidate.capabilityId === row.capabilityId;
+    if (candidate.actionId && row.actionId) return true;
+    return candidate.capabilityId === row.capabilityId;
   }) || null;
 }
 

--- a/scripts/ops/friday-mobile-memory-action-evidence.sh
+++ b/scripts/ops/friday-mobile-memory-action-evidence.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+#
+# Mobile Home/Memory action evidence wrapper.
+#
+# Truth boundary:
+#   Runs the iOS Swift product Home ViewModel tests and exports explicit action-runtime evidence
+#   for Home refresh plus Memory screen confirm/reject actions. This proves the product ViewModel
+#   paths delegate to their read/write seams and render refs-only results. It does not start or
+#   mutate prod Hub, seed live memory candidates, prove Hub audit receipts, run a simulator tap,
+#   claim END-BAR, or prove adoption.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+OUT_DIR="${FRIDAY_MOBILE_MEMORY_ACTION_EVIDENCE_DIR:-${TMPDIR:-/tmp}/friday-mobile-memory-action-evidence}"
+ACTION_RUNTIME_OUT="${FRIDAY_MOBILE_MEMORY_ACTION_RUNTIME_OUT:-${OUT_DIR}/action-runtime-evidence.json}"
+
+mkdir -p "${OUT_DIR}"
+chmod 700 "${OUT_DIR}"
+
+echo "Friday mobile memory action evidence starting."
+echo "truth_label=mobile_home_memory_action_swift_viewmodel_runtime_not_live_hub_not_endbar"
+echo "out_dir=${OUT_DIR}"
+
+FRIDAY_MOBILE_MEMORY_ACTION_EVIDENCE_DIR="${OUT_DIR}" \
+  swift test \
+    --package-path "${REPO_ROOT}/apps/friday-ios" \
+    --filter HomeViewModelTests/testRefresh_loadsRefsOnlyProjection
+
+FRIDAY_MOBILE_MEMORY_ACTION_EVIDENCE_DIR="${OUT_DIR}" \
+  swift test \
+    --package-path "${REPO_ROOT}/apps/friday-ios" \
+    --filter HomeViewModelTests/testDecideMemoryConfirmRendersConfirmedAndRefreshes
+
+FRIDAY_MOBILE_MEMORY_ACTION_EVIDENCE_DIR="${OUT_DIR}" \
+  swift test \
+    --package-path "${REPO_ROOT}/apps/friday-ios" \
+    --filter HomeViewModelTests/testDecideMemoryRejectRendersRejectedAndRefreshes
+
+node - "${OUT_DIR}" "${ACTION_RUNTIME_OUT}" <<'NODE'
+const fs = require("node:fs");
+const path = require("node:path");
+
+const [outDir, actionRuntimeOut] = process.argv.slice(2);
+const files = [
+  path.join(outDir, "mobile-home-refresh-action-evidence.json"),
+  path.join(outDir, "mobile-memory-confirm-action-evidence.json"),
+  path.join(outDir, "mobile-memory-reject-action-evidence.json"),
+];
+const blockers = [];
+const actions = [];
+
+for (const file of files) {
+  if (!fs.existsSync(file)) {
+    blockers.push({ code: "missing_swift_evidence", detail: file });
+    continue;
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(fs.readFileSync(file, "utf8"));
+  } catch {
+    blockers.push({ code: "invalid_swift_evidence_json", detail: file });
+    continue;
+  }
+  const allowedTruth = new Set([
+    "mobile_home_refresh_swift_viewmodel_runtime_not_live_hub_not_endbar",
+    "mobile_memory_action_swift_viewmodel_runtime_not_live_hub_not_endbar",
+  ]);
+  if (!allowedTruth.has(parsed.truth)) {
+    blockers.push({ code: "unexpected_truth", detail: `${file}:${parsed.truth || "<missing>"}` });
+  }
+  if (parsed.status !== "ready") {
+    blockers.push({ code: "evidence_not_ready", detail: `${file}:${parsed.status || "<missing>"}` });
+  }
+  const rows = Array.isArray(parsed.actions) ? parsed.actions : [];
+  if (rows.length === 0) blockers.push({ code: "missing_actions", detail: file });
+  for (const row of rows) {
+    actions.push({ ...row, source_proof: file });
+  }
+}
+
+const report = {
+  truth: "mobile_home_memory_action_runtime_evidence_partial_not_live_hub_not_endbar",
+  status: blockers.length === 0 ? "ready" : "blocked",
+  actionCount: actions.length,
+  actions,
+  blockers,
+  caveat:
+    "Partial runtime evidence only: Swift product ViewModel Home refresh re-reads refs and Memory confirm/reject delegates to the write seam and renders refs-only results. Later live Hub read/write and memory-spine audit/recall proof must land before this counts as full END-BAR coverage.",
+};
+
+fs.mkdirSync(path.dirname(actionRuntimeOut), { recursive: true });
+fs.writeFileSync(actionRuntimeOut, `${JSON.stringify(report, null, 2)}\n`);
+console.log(JSON.stringify({ status: report.status, actionCount: actions.length, out: actionRuntimeOut }, null, 2));
+process.exit(blockers.length === 0 ? 0 : 2);
+NODE
+
+echo "Action runtime evidence: ${ACTION_RUNTIME_OUT}"
+echo "Truth: partial mobile Home/Memory action evidence only; live Hub read/write plus memory-spine audit/recall proof is still required."

--- a/test/unit/qa/friday-design-action-runtime-evidence-cli.test.ts
+++ b/test/unit/qa/friday-design-action-runtime-evidence-cli.test.ts
@@ -36,6 +36,30 @@ function fixtureRepo() {
   return { root, contract };
 }
 
+function sameCapabilityContractBody() {
+  return `# Friday Action Contract — mobile + desktop
+
+**This is a wiring contract for the later Rust/native agent, NOT runtime proof.** Every row is design-proof; wired_registry ≠ runtime PASS.
+
+| Surface | Screen [state] | action_id | Label | capability_id | reg | reg_status | truth_status | result/target | Rust/Hub owner · gate · test expectation |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| mobile | memory | check | Confirm | memory_review_no_silent_write_decide_candidate | ✓ | wired | wired_registry | result:confirmed | Runtime test must prove gate enforcement. |
+| mobile | memory | memory_resolve | Keep old | memory_review_no_silent_write_decide_candidate | ✓ | wired | wired_registry | result:confirmed | Runtime test must prove gate enforcement. |
+`;
+}
+
+function sameActionDifferentCapabilityContractBody() {
+  return `# Friday Action Contract — mobile + desktop
+
+**This is a wiring contract for the later Rust/native agent, NOT runtime proof.** Every row is design-proof; wired_registry ≠ runtime PASS.
+
+| Surface | Screen [state] | action_id | Label | capability_id | reg | reg_status | truth_status | result/target | Rust/Hub owner · gate · test expectation |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| desktop | fridayChat | check | Approve | security_approval_bound_principal_gate_cat10_netnew | ✓ | wired | wired_registry | result:confirmed | Runtime test must prove gate enforcement. |
+| desktop | fridayChat | check | Keep | memory_review_no_silent_write_decide_candidate | ✓ | wired | wired_registry | result:confirmed | Runtime test must prove gate enforcement. |
+`;
+}
+
 describe("check-friday-design-action-runtime-evidence", () => {
   it("reports design action runtime gaps without counting static Swift hints as proof", () => {
     const { root, contract } = fixtureRepo();
@@ -151,6 +175,84 @@ describe("check-friday-design-action-runtime-evidence", () => {
       expect(report.counts?.runtimeEvidenceRows).toBe(2);
       expect(report.counts?.missingRuntimeEvidence).toBe(0);
       expect(report.counts?.missingUniqueRuntimeEvidence).toBe(0);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("does not let one capability row satisfy a different explicit action on the same screen", () => {
+    const root = mkdtempSync(join(tmpdir(), "friday-design-action-runtime-same-cap-"));
+    try {
+      writeFile(root, "apps/friday-ios/Sources/FridayMobileShell/FridayProjectionScreens.swift", "Button(\"Confirm\") {}; Button(\"Keep old\") {}");
+      writeFile(root, "apps/friday-ios/Sources/FridayMobileShellCore/HomeViewModel.swift", "func decideMemory() {}");
+      const contract = writeFile(root, "ACTION-CONTRACT.md", sameCapabilityContractBody());
+      const runtime = writeFile(root, "action-runtime-evidence.json", JSON.stringify({
+        actions: [
+          {
+            surface: "mobile",
+            screen: "memory",
+            action_id: "check",
+            capability_id: "memory_review_no_silent_write_decide_candidate",
+            status: "pass",
+            evidence_ref: "proof://mobile/memory-confirm",
+          },
+        ],
+      }, null, 2));
+      const output = execFileSync("node", [
+        script,
+        `--repo-root=${root}`,
+        `--contract=${contract}`,
+        `--runtime-evidence=${runtime}`,
+      ], { cwd: process.cwd(), encoding: "utf8" });
+      const report = JSON.parse(output) as {
+        status?: string;
+        counts?: { missingUniqueRuntimeEvidence?: number };
+        gaps?: { missingUniqueRuntimeEvidence?: Array<{ actionId?: string }> };
+      };
+      expect(report.status).toBe("gaps_present");
+      expect(report.counts?.missingUniqueRuntimeEvidence).toBe(1);
+      expect(report.gaps?.missingUniqueRuntimeEvidence).toEqual([
+        expect.objectContaining({ actionId: "memory_resolve" }),
+      ]);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("does not let one explicit action satisfy a different capability on the same screen", () => {
+    const root = mkdtempSync(join(tmpdir(), "friday-design-action-runtime-same-action-"));
+    try {
+      writeFile(root, "apps/macos/FridayHubConsole/Sources/FridayHubConsole/DesktopChatScreen.swift", "Button(\"Approve\") {}; Button(\"Keep\") {}");
+      writeFile(root, "apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/OperationsOverviewViewModel.swift", "func approveNeedsMeItem() {}; func decideMemory() {}");
+      const contract = writeFile(root, "ACTION-CONTRACT.md", sameActionDifferentCapabilityContractBody());
+      const runtime = writeFile(root, "action-runtime-evidence.json", JSON.stringify({
+        actions: [
+          {
+            surface: "desktop",
+            screen: "fridayChat",
+            action_id: "check",
+            capability_id: "security_approval_bound_principal_gate_cat10_netnew",
+            status: "pass",
+            evidence_ref: "proof://desktop/approval-approve",
+          },
+        ],
+      }, null, 2));
+      const output = execFileSync("node", [
+        script,
+        `--repo-root=${root}`,
+        `--contract=${contract}`,
+        `--runtime-evidence=${runtime}`,
+      ], { cwd: process.cwd(), encoding: "utf8" });
+      const report = JSON.parse(output) as {
+        status?: string;
+        counts?: { missingUniqueRuntimeEvidence?: number };
+        gaps?: { missingUniqueRuntimeEvidence?: Array<{ capabilityId?: string }> };
+      };
+      expect(report.status).toBe("gaps_present");
+      expect(report.counts?.missingUniqueRuntimeEvidence).toBe(1);
+      expect(report.gaps?.missingUniqueRuntimeEvidence).toEqual([
+        expect.objectContaining({ capabilityId: "memory_review_no_silent_write_decide_candidate" }),
+      ]);
     } finally {
       rmSync(root, { recursive: true, force: true });
     }

--- a/test/unit/qa/friday-mobile-approval-reject-proof-cli.test.ts
+++ b/test/unit/qa/friday-mobile-approval-reject-proof-cli.test.ts
@@ -107,8 +107,10 @@ describe("friday-mobile-approval-reject-proof", () => {
         gaps?: { missingRuntimeEvidence?: Array<{ actionId?: string }> };
       };
 
-      expect(report.counts?.missingRuntimeEvidence).toBe(0);
-      expect(report.gaps?.missingRuntimeEvidence).toEqual([]);
+      expect(report.counts?.missingRuntimeEvidence).toBe(1);
+      expect(report.gaps?.missingRuntimeEvidence).toEqual([
+        expect.objectContaining({ actionId: "check" }),
+      ]);
     } finally {
       rmSync(root, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary
- export partial mobile Home refresh plus Memory confirm/reject action-runtime evidence from Swift Home ViewModel paths
- add a wrapper that runs the targeted Swift tests and writes combined action-runtime evidence
- tighten design action runtime matching so one capability row cannot satisfy a different explicit action on the same screen

## Truth boundary
- This is partial runtime evidence only: Swift product ViewModel paths delegate to read/write seams and render refs-only results.
- It does not prove live Hub memory-spine audit/recall, simulator tap, END-BAR, release, adoption, or GO-LIVE.
- The matcher fix is intentionally conservative and reveals more honest missing action evidence than the previous capability-level OR match.

## Verification
- `FRIDAY_MOBILE_MEMORY_ACTION_EVIDENCE_DIR=/tmp/friday-mobile-home-memory-action-evidence-verify-20260625T124210Z scripts/ops/friday-mobile-memory-action-evidence.sh`
- `./node_modules/.bin/vitest run --project default test/unit/qa/friday-design-action-runtime-evidence-cli.test.ts`
- strict design action gap recomputed with bundle + T3 + Home/Memory evidence: 7 runtime rows, 23 unique runtime gaps remain
