### PR TITLE
feat(mobile): wire firstlaunch retry cancel actions

### DIFF
--- a/apps/friday-ios/Sources/FridayMobileShell/FridayHomeScreen.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayHomeScreen.swift
@@ -18,6 +18,7 @@ struct FridayHomeScreen: View {
   let showPairingProvisioning: Bool
   @State private var pairingQRPayload = ""
   @State private var showingPairingScanner = false
+  @State private var pairingTask: Task<Void, Never>?
 
   init(viewModel: HomeViewModel, showPairingProvisioning: Bool = false) {
     self.viewModel = viewModel
@@ -615,7 +616,7 @@ struct FridayHomeScreen: View {
         .accessibilityIdentifier("friday.home.pairing-preflight-button")
 
         Button {
-          Task { await viewModel.pairScannedQR(pairingQRPayload) }
+          startPairing()
         } label: {
           Label("Pair", systemImage: "link.badge.plus")
         }
@@ -623,6 +624,27 @@ struct FridayHomeScreen: View {
         .disabled(pairingQRPayload.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
           || viewModel.pairingAttempt.mode == .sending)
         .accessibilityIdentifier("friday.home.pair-button")
+
+        if viewModel.pairingAttempt.mode == .unavailable || viewModel.pairingAttempt.mode == .denied {
+          Button {
+            startPairing()
+          } label: {
+            Label("Retry", systemImage: "arrow.clockwise")
+          }
+          .buttonStyle(.bordered)
+          .disabled(pairingQRPayload.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+          .accessibilityIdentifier("friday.home.pairing-retry-button")
+        }
+
+        if viewModel.pairingAttempt.mode == .sending {
+          Button {
+            cancelPairing()
+          } label: {
+            Label("Cancel", systemImage: "xmark")
+          }
+          .buttonStyle(.bordered)
+          .accessibilityIdentifier("friday.home.pairing-cancel-button")
+        }
 
         Button {
           showingPairingScanner = true
@@ -644,6 +666,22 @@ struct FridayHomeScreen: View {
       }
       .font(.caption)
     }
+  }
+
+  private func startPairing() {
+    pairingTask?.cancel()
+    pairingTask = Task {
+      await viewModel.pairScannedQR(pairingQRPayload)
+      await MainActor.run {
+        pairingTask = nil
+      }
+    }
+  }
+
+  private func cancelPairing() {
+    pairingTask?.cancel()
+    pairingTask = nil
+    viewModel.cancelPairingAttempt()
   }
 
   @ViewBuilder

--- a/apps/friday-ios/Sources/FridayMobileShellCore/HomeViewModel.swift
+++ b/apps/friday-ios/Sources/FridayMobileShellCore/HomeViewModel.swift
@@ -717,6 +717,7 @@ public enum MobilePairingAttemptMode: String, Sendable, Equatable {
   case accepted
   case denied
   case unavailable
+  case cancelled
 }
 
 public struct MobilePairingAttempt: Sendable, Equatable {
@@ -781,6 +782,19 @@ public struct MobilePairingAttempt: Sendable, Equatable {
       deviceId: deviceId,
       errorCode: nil,
       reason: reason)
+  }
+
+  public static func cancelled(
+    _ projection: FridayPairingManifestProjection?,
+    deviceId: String? = nil
+  ) -> MobilePairingAttempt {
+    MobilePairingAttempt(
+      mode: .cancelled,
+      pairingId: projection?.pairingId,
+      hubId: projection?.hubId,
+      deviceId: deviceId,
+      errorCode: nil,
+      reason: "Pair request cancelled before PairAck.")
   }
 }
 
@@ -985,6 +999,13 @@ public final class HomeViewModel: ObservableObject {
     pairingAttempt = .idle
   }
 
+  public func cancelPairingAttempt() {
+    guard pairingAttempt.mode == .sending else {
+      return
+    }
+    pairingAttempt = .cancelled(pairingPreflight.projection, deviceId: pairingAttempt.deviceId)
+  }
+
   public func pairScannedQR(
     _ qrPayload: String,
     deviceId: String = "",
@@ -1051,6 +1072,10 @@ public final class HomeViewModel: ObservableObject {
     pairingAttempt = .sending(manifest.redactedProjection, deviceId: finalDeviceId)
     do {
       let ack = try await pairingClient.pairDevice(manifest: manifest, deviceId: finalDeviceId)
+      guard !Task.isCancelled else {
+        pairingAttempt = .cancelled(manifest.redactedProjection, deviceId: finalDeviceId)
+        return
+      }
       if ack.accepted {
         pairingAttempt = .accepted(manifest.redactedProjection, deviceId: finalDeviceId)
         await refresh()
@@ -1058,6 +1083,10 @@ public final class HomeViewModel: ObservableObject {
         pairingAttempt = .denied(manifest.redactedProjection, code: ack.errorCode, deviceId: finalDeviceId)
       }
     } catch {
+      if Task.isCancelled || error is CancellationError {
+        pairingAttempt = .cancelled(manifest.redactedProjection, deviceId: finalDeviceId)
+        return
+      }
       pairingAttempt = .unavailable(
         manifest.redactedProjection,
         reason: Self.pairingReason(for: error),

--- a/apps/friday-ios/Tests/FridayMobileShellCoreTests/PairingPreflightTests.swift
+++ b/apps/friday-ios/Tests/FridayMobileShellCoreTests/PairingPreflightTests.swift
@@ -26,11 +26,13 @@ private final class InMemoryPairingKeypairBackend: DeviceKeypairBackend, @unchec
 
 private final class FakePairingClient: FridayPairingClient, @unchecked Sendable {
   var ack: PairingPairAckWire
+  var delayNanoseconds: UInt64
   private(set) var pairedDeviceIds: [String] = []
   private(set) var sawRawSecret = false
 
-  init(ack: PairingPairAckWire) {
+  init(ack: PairingPairAckWire, delayNanoseconds: UInt64 = 0) {
     self.ack = ack
+    self.delayNanoseconds = delayNanoseconds
   }
 
   func fetchHubStatus(manifest: FridayPairingManifest) async throws -> PairingHubStatusWire {
@@ -42,6 +44,9 @@ private final class FakePairingClient: FridayPairingClient, @unchecked Sendable 
   }
 
   func pairDevice(manifest: FridayPairingManifest, deviceId: String) async throws -> PairingPairAckWire {
+    if delayNanoseconds > 0 {
+      try await Task.sleep(nanoseconds: delayNanoseconds)
+    }
     pairedDeviceIds.append(deviceId)
     sawRawSecret = String(describing: self).contains(manifest.pairingSecret)
     return ack
@@ -131,6 +136,16 @@ func homeViewModelCarriesPairingPreflightStateAndCanClearIt() async throws {
 
   #expect(vm.pairingPreflight.mode == .ready)
   #expect(vm.pairingPreflight.projection?.displayName == "Friday Local Hub")
+  try writeFirstLaunchActionEvidenceIfRequested(
+    fileSuffix: "scan",
+    actionId: "firstlaunch_scan",
+    evidenceRef: "swift://mobile/firstlaunch/scan/pair-123",
+    proof: [
+      "preflight_mode": String(describing: vm.pairingPreflight.mode),
+      "proof_ready": vm.pairingPreflight.proofReady,
+      "pairing_id": vm.pairingPreflight.projection?.pairingId ?? "",
+      "hub_id": vm.pairingPreflight.projection?.hubId ?? "",
+    ])
 
   vm.clearPairingPreflight()
 
@@ -162,6 +177,17 @@ func homeViewModelPairScannedQrDrivesPairAckAcceptedWithoutLeakingSecret() async
   #expect(!String(describing: vm.pairingPreflight).contains(secret))
   #expect(!String(describing: vm.pairingAttempt).contains(secret))
   #expect(!fake.sawRawSecret)
+  try writeFirstLaunchActionEvidenceIfRequested(
+    fileSuffix: "pairnow",
+    actionId: "firstlaunch_pairnow",
+    evidenceRef: "swift://mobile/firstlaunch/pairnow/\(vm.pairingAttempt.deviceId ?? "unknown")",
+    proof: [
+      "attempt": "accepted",
+      "device_id": vm.pairingAttempt.deviceId ?? "",
+      "pairing_id": vm.pairingAttempt.pairingId ?? "",
+      "hub_id": vm.pairingAttempt.hubId ?? "",
+      "raw_secret_leaked": fake.sawRawSecret,
+    ])
 }
 
 @MainActor
@@ -203,6 +229,90 @@ func homeViewModelPairScannedQrFailsClosedWhenPairingChannelNotConfigured() asyn
   #expect(vm.pairingAttempt.deviceId?.hasPrefix("ios-") == true)
 }
 
+@MainActor
+@Test
+func homeViewModelRetryAfterUnavailableRunsPairingFlowAgain() async throws {
+  let backend = InMemoryPairingKeypairBackend()
+  var fake: FakePairingClient?
+  let vm = HomeViewModel(
+    client: HonestlyUnavailableReadClient(),
+    makePairingClient: { _ in fake })
+  let payload = try pairingManifest(expiresAt: 1_900_000_000_000)
+
+  await vm.pairScannedQR(
+    payload,
+    deviceId: "phone-retry",
+    nowMs: 1_780_640_000_000,
+    backend: backend)
+
+  #expect(vm.pairingAttempt.mode == .unavailable)
+  #expect(vm.pairingAttempt.deviceId == "phone-retry")
+
+  let retryClient = FakePairingClient(ack: PairingPairAckWire(accepted: true))
+  fake = retryClient
+  await vm.pairScannedQR(
+    payload,
+    deviceId: "phone-retry",
+    nowMs: 1_780_640_000_000,
+    backend: backend)
+
+  #expect(vm.pairingAttempt.mode == .accepted)
+  #expect(vm.pairingAttempt.deviceId == "phone-retry")
+  #expect(retryClient.pairedDeviceIds == ["phone-retry"])
+  try writeFirstLaunchActionEvidenceIfRequested(
+    fileSuffix: "retry",
+    actionId: "firstlaunch_retry",
+    evidenceRef: "swift://mobile/firstlaunch/retry/phone-retry",
+    proof: [
+      "first_attempt": "unavailable",
+      "retry_attempt": "accepted",
+      "device_id": "phone-retry",
+      "pairing_id": vm.pairingAttempt.pairingId ?? "",
+    ])
+}
+
+@MainActor
+@Test
+func homeViewModelCancelPairingAttemptPreventsLatePairAckFromWinning() async throws {
+  let backend = InMemoryPairingKeypairBackend()
+  let fake = FakePairingClient(
+    ack: PairingPairAckWire(accepted: true),
+    delayNanoseconds: 200_000_000)
+  let vm = HomeViewModel(
+    client: HonestlyUnavailableReadClient(),
+    makePairingClient: { _ in fake })
+  let payload = try pairingManifest(expiresAt: 1_900_000_000_000)
+
+  let task = Task {
+    await vm.pairScannedQR(
+      payload,
+      deviceId: "phone-cancel",
+      nowMs: 1_780_640_000_000,
+      backend: backend)
+  }
+  while vm.pairingAttempt.mode != .sending {
+    try await Task.sleep(nanoseconds: 1_000_000)
+  }
+
+  vm.cancelPairingAttempt()
+  task.cancel()
+  await task.value
+
+  #expect(vm.pairingAttempt.mode == .cancelled)
+  #expect(vm.pairingAttempt.deviceId == "phone-cancel")
+  #expect(fake.pairedDeviceIds.isEmpty)
+  try writeFirstLaunchActionEvidenceIfRequested(
+    fileSuffix: "cancel",
+    actionId: "firstlaunch_cancel",
+    evidenceRef: "swift://mobile/firstlaunch/cancel/phone-cancel",
+    proof: [
+      "attempt": "cancelled",
+      "late_pairack_won": false,
+      "device_id": "phone-cancel",
+      "pairing_id": vm.pairingAttempt.pairingId ?? "",
+    ])
+}
+
 @Test
 func pairingServerConfigAllowsLoopbackAndPrivateLanOnly() throws {
   #expect(try PairingServerConfig(manifest: manifest(endpoint: "ws://127.0.0.1:49152")).host == "127.0.0.1")
@@ -228,6 +338,46 @@ func pairingServerConfigAllowsLoopbackAndPrivateLanOnly() throws {
   #expect(throws: PairingServerConfigError.missingPort("ws://127.0.0.1:0")) {
     try PairingServerConfig(manifest: manifest(endpoint: "ws://127.0.0.1:0"))
   }
+}
+
+private func writeFirstLaunchActionEvidenceIfRequested(
+  fileSuffix: String,
+  actionId: String,
+  evidenceRef: String,
+  proof: [String: Any]
+) throws {
+  guard let rawDir = ProcessInfo.processInfo.environment[
+    "FRIDAY_MOBILE_FIRSTLAUNCH_ACTION_EVIDENCE_DIR"
+  ]?.trimmingCharacters(in: .whitespacesAndNewlines), !rawDir.isEmpty else {
+    return
+  }
+
+  let payload: [String: Any] = [
+    "truth": "mobile_firstlaunch_pairing_action_swift_viewmodel_runtime_not_live_hub_not_endbar",
+    "status": "ready",
+    "generated_at_utc": ISO8601DateFormatter().string(from: Date()),
+    "proof": proof,
+    "actions": [
+      [
+        "surface": "mobile",
+        "screen": "firstLaunch",
+        "action_id": actionId,
+        "capability_id": "trust_center_pairing_connected_devices",
+        "status": "pass",
+        "evidence_ref": evidenceRef,
+        "source": "ios_home_viewmodel_firstlaunch_pairing_action_runtime",
+        "truth_label": "swift_viewmodel_pairing_action_runtime_not_live_hub_not_sim_tap",
+      ],
+    ],
+    "caveat": "Partial runtime evidence only: Swift product ViewModel and Home wiring cover firstLaunch Retry/Cancel semantics. This is not a real simulator tap, not a live Hub PairAck proof, not END-BAR, and not adoption.",
+  ]
+
+  let dir = URL(fileURLWithPath: rawDir)
+  try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+  let out = dir.appendingPathComponent("mobile-firstlaunch-\(fileSuffix)-action-evidence.json")
+  let data = try JSONSerialization.data(withJSONObject: payload, options: [.prettyPrinted, .sortedKeys])
+  try data.write(to: out, options: .atomic)
+  print("[mobile-firstlaunch-action-evidence] proofOut=\(out.path)")
 }
 
 private func pairingManifest(

--- a/apps/macos/FridayHubConsole/Tests/FridayHubConsoleCoreTests/OperationsOverviewViewModelTests.swift
+++ b/apps/macos/FridayHubConsole/Tests/FridayHubConsoleCoreTests/OperationsOverviewViewModelTests.swift
@@ -220,6 +220,49 @@ private func temporaryHome() throws -> URL {
   return url
 }
 
+private func writeDesktopActionEvidenceIfRequested(
+  fileSuffix: String,
+  screen: String,
+  actionId: String,
+  capabilityId: String,
+  evidenceRef: String,
+  source: String,
+  proof: [String: Any]
+) throws {
+  guard let rawDir = ProcessInfo.processInfo.environment[
+    "FRIDAY_DESKTOP_CHAT_MEMORY_ACTION_EVIDENCE_DIR"
+  ]?.trimmingCharacters(in: .whitespacesAndNewlines), !rawDir.isEmpty else {
+    return
+  }
+
+  let payload: [String: Any] = [
+    "truth": "desktop_chat_memory_action_swift_viewmodel_runtime_not_live_hub_not_endbar",
+    "status": "ready",
+    "generated_at_utc": ISO8601DateFormatter().string(from: Date()),
+    "proof": proof,
+    "actions": [
+      [
+        "surface": "desktop",
+        "screen": screen,
+        "action_id": actionId,
+        "capability_id": capabilityId,
+        "status": "pass",
+        "evidence_ref": evidenceRef,
+        "source": source,
+        "truth_label": "swift_viewmodel_write_client_runtime_not_live_hub_not_operator_key_not_endbar",
+      ],
+    ],
+    "caveat": "Partial runtime evidence only: macOS product ViewModel action delegates to the read/write seam and renders refs-only results. This is not a live Hub audit receipt, not a user tap, not operator true-key approval, not END-BAR, and not adoption.",
+  ]
+
+  let dir = URL(fileURLWithPath: rawDir)
+  try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+  let out = dir.appendingPathComponent("desktop-\(fileSuffix)-action-evidence.json")
+  let data = try JSONSerialization.data(withJSONObject: payload, options: [.prettyPrinted, .sortedKeys])
+  try data.write(to: out, options: .atomic)
+  print("[desktop-chat-memory-action-evidence] proofOut=\(out.path)")
+}
+
 @Test
 @MainActor
 func inspectorReturnsRefsOnlyForSelection() async {
@@ -1285,7 +1328,7 @@ func chatNeedsMeItemsParsesApprovalSigningRefsFromActionableRows() throws {
 
 @Test
 @MainActor
-func approveNeedsMeItemSignsRefsAndRelaysOpaqueBlob() async {
+func approveNeedsMeItemSignsRefsAndRelaysOpaqueBlob() async throws {
   let signer = MockOperatorApprovalSigner()
   signer.blob = Array("{\"decision\":\"approved\"}".utf8)
   let write = MockMissionSpineWriteClient(behavior: .intakeReady)
@@ -1321,6 +1364,20 @@ func approveNeedsMeItemSignsRefsAndRelaysOpaqueBlob() async {
   }
   #expect(summary.contains("mutation_completed"))
   #expect(summary.contains("audit://resume/1"))
+  try writeDesktopActionEvidenceIfRequested(
+    fileSuffix: "approval-approve",
+    screen: "fridayChat",
+    actionId: "check",
+    capabilityId: "security_approval_bound_principal_gate_cat10_netnew",
+    evidenceRef: "swift://desktop/approval/approve/run-paused/approval-nonce-9",
+    source: "macos_operations_viewmodel_approval_approve_runtime",
+    proof: [
+      "run_id": item.runId,
+      "approval_id": item.refId,
+      "action_digest": item.actionDigest ?? "",
+      "signed_blob_bytes": write.lastResumeBlob?.count ?? 0,
+      "audit_ref": "audit://resume/1",
+    ])
 }
 
 @Test
@@ -1352,7 +1409,7 @@ func approveNeedsMeItemWithoutSignerFailsClosedWithoutResume() async {
 
 @Test
 @MainActor
-func rejectNeedsMeApprovalUsesRunControlWithoutSigner() async {
+func rejectNeedsMeApprovalUsesRunControlWithoutSigner() async throws {
   let write = MockMissionSpineWriteClient(behavior: .intakeReady)
   let item = ChatNeedsMeItem(
     runId: "run-paused",
@@ -1378,6 +1435,20 @@ func rejectNeedsMeApprovalUsesRunControlWithoutSigner() async {
   }
   #expect(summary.contains("reject"))
   #expect(summary.contains("audit://reject/1"))
+  try writeDesktopActionEvidenceIfRequested(
+    fileSuffix: "approval-reject",
+    screen: "fridayChat",
+    actionId: "act",
+    capabilityId: "security_approval_bound_principal_gate_cat10_netnew",
+    evidenceRef: "swift://desktop/approval/reject/run-paused/approval-nonce-10",
+    source: "macos_operations_viewmodel_approval_reject_runtime",
+    proof: [
+      "run_id": item.runId,
+      "approval_id": item.refId,
+      "rejected_run_id": write.lastRejectRunId ?? "",
+      "rejected_approval_id": write.lastRejectApprovalId ?? "",
+      "audit_ref": "audit://reject/1",
+    ])
 }
 
 @Test
@@ -1683,7 +1754,7 @@ func submitIntakeTransportFailureRendersHonestUnavailable() async {
 
 @Test
 @MainActor
-func decideMemoryConfirmRendersConfirmedRecallable() async {
+func decideMemoryConfirmRendersConfirmedRecallable() async throws {
   let write = MockMissionSpineWriteClient(behavior: .memoryConfirmed)
   let vm = OperationsOverviewViewModel(
     client: MockReadClient(behavior: .loaded), writeClient: write, writeOwnerPrincipal: "admin-001")
@@ -1696,6 +1767,53 @@ func decideMemoryConfirmRendersConfirmedRecallable() async {
   #expect(summary.contains("recallable=true"))
   #expect(write.lastDecision?.decision == "confirm")
   #expect(write.lastDecision?.ownerPrincipal == "admin-001")
+  try writeDesktopActionEvidenceIfRequested(
+    fileSuffix: "memory-confirm",
+    screen: "memory",
+    actionId: "check",
+    capabilityId: "memory_review_no_silent_write_decide_candidate",
+    evidenceRef: "swift://desktop/memory/confirm/cand-1/mem-1",
+    source: "macos_operations_viewmodel_memory_confirm_runtime",
+    proof: [
+      "candidate_id": "cand-1",
+      "memory_id": write.lastDecision?.memoryId ?? "",
+      "owner_principal": write.lastDecision?.ownerPrincipal ?? "",
+      "decision": write.lastDecision?.decision ?? "",
+      "status": "confirmed",
+      "recallable": true,
+    ])
+}
+
+@Test
+@MainActor
+func decideMemoryRejectRendersRejectedNotRecallable() async throws {
+  let write = MockMissionSpineWriteClient(behavior: .memoryConfirmed)
+  let vm = OperationsOverviewViewModel(
+    client: MockReadClient(behavior: .loaded), writeClient: write, writeOwnerPrincipal: "admin-001")
+  await vm.decideMemory(candidateId: "cand-2", memoryId: "mem-2", confirm: false)
+  guard case let .confirmed(summary, _, _) = vm.memoryDecisionStates["cand-2"] else {
+    Issue.record("expected .confirmed, got \(String(describing: vm.memoryDecisionStates["cand-2"]))")
+    return
+  }
+  #expect(summary.contains("rejected"))
+  #expect(summary.contains("recallable=false"))
+  #expect(write.lastDecision?.decision == "reject")
+  #expect(write.lastDecision?.ownerPrincipal == "admin-001")
+  try writeDesktopActionEvidenceIfRequested(
+    fileSuffix: "memory-reject",
+    screen: "memory",
+    actionId: "act",
+    capabilityId: "memory_review_no_silent_write_decide_candidate",
+    evidenceRef: "swift://desktop/memory/reject/cand-2/mem-2",
+    source: "macos_operations_viewmodel_memory_reject_runtime",
+    proof: [
+      "candidate_id": "cand-2",
+      "memory_id": write.lastDecision?.memoryId ?? "",
+      "owner_principal": write.lastDecision?.ownerPrincipal ?? "",
+      "decision": write.lastDecision?.decision ?? "",
+      "status": "rejected",
+      "recallable": false,
+    ])
 }
 
 @Test

--- a/scripts/ops/friday-desktop-chat-memory-action-evidence.sh
+++ b/scripts/ops/friday-desktop-chat-memory-action-evidence.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+#
+# Desktop Chat/Memory action evidence wrapper.
+#
+# Truth boundary:
+#   Runs macOS Swift product ViewModel tests and exports explicit action-runtime evidence for
+#   desktop Chat approval approve/reject plus desktop Memory confirm/reject actions. This proves
+#   the product ViewModel delegates to its signer/write seams and renders refs-only results. It
+#   does not start or mutate prod Hub, use the operator's true signing key, prove live Hub audit
+#   receipts, drive a real GUI tap, claim END-BAR, or prove adoption.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+OUT_DIR="${FRIDAY_DESKTOP_CHAT_MEMORY_ACTION_EVIDENCE_DIR:-${TMPDIR:-/tmp}/friday-desktop-chat-memory-action-evidence}"
+ACTION_RUNTIME_OUT="${FRIDAY_DESKTOP_CHAT_MEMORY_ACTION_RUNTIME_OUT:-${OUT_DIR}/action-runtime-evidence.json}"
+
+mkdir -p "${OUT_DIR}"
+chmod 700 "${OUT_DIR}"
+
+echo "Friday desktop Chat/Memory action evidence starting."
+echo "truth_label=desktop_chat_memory_action_swift_viewmodel_runtime_not_live_hub_not_endbar"
+echo "out_dir=${OUT_DIR}"
+
+run_swift_test() {
+  local filter="$1"
+  local log="${OUT_DIR}/swift-test-${filter}.log"
+  FRIDAY_DESKTOP_CHAT_MEMORY_ACTION_EVIDENCE_DIR="${OUT_DIR}" \
+    swift test \
+      --package-path "${REPO_ROOT}/apps/macos/FridayHubConsole" \
+      --filter "${filter}" 2>&1 | tee "${log}"
+  if ! grep -Eq "Test run with [1-9][0-9]* test" "${log}"; then
+    echo "FATAL: Swift test filter ran zero tests: ${filter}" >&2
+    exit 2
+  fi
+}
+
+run_swift_test approveNeedsMeItemSignsRefsAndRelaysOpaqueBlob
+run_swift_test rejectNeedsMeApprovalUsesRunControlWithoutSigner
+run_swift_test decideMemoryConfirmRendersConfirmedRecallable
+run_swift_test decideMemoryRejectRendersRejectedNotRecallable
+
+node - "${OUT_DIR}" "${ACTION_RUNTIME_OUT}" <<'NODE'
+const fs = require("node:fs");
+const path = require("node:path");
+
+const [outDir, actionRuntimeOut] = process.argv.slice(2);
+const files = [
+  path.join(outDir, "desktop-approval-approve-action-evidence.json"),
+  path.join(outDir, "desktop-approval-reject-action-evidence.json"),
+  path.join(outDir, "desktop-memory-confirm-action-evidence.json"),
+  path.join(outDir, "desktop-memory-reject-action-evidence.json"),
+];
+const blockers = [];
+const actions = [];
+
+for (const file of files) {
+  if (!fs.existsSync(file)) {
+    blockers.push({ code: "missing_swift_evidence", detail: file });
+    continue;
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(fs.readFileSync(file, "utf8"));
+  } catch {
+    blockers.push({ code: "invalid_swift_evidence_json", detail: file });
+    continue;
+  }
+  if (parsed.truth !== "desktop_chat_memory_action_swift_viewmodel_runtime_not_live_hub_not_endbar") {
+    blockers.push({ code: "unexpected_truth", detail: `${file}:${parsed.truth || "<missing>"}` });
+  }
+  if (parsed.status !== "ready") {
+    blockers.push({ code: "evidence_not_ready", detail: `${file}:${parsed.status || "<missing>"}` });
+  }
+  const rows = Array.isArray(parsed.actions) ? parsed.actions : [];
+  if (rows.length === 0) blockers.push({ code: "missing_actions", detail: file });
+  for (const row of rows) {
+    actions.push({ ...row, source_proof: file });
+  }
+}
+
+const report = {
+  truth: "desktop_chat_memory_action_runtime_evidence_partial_not_live_hub_not_endbar",
+  status: blockers.length === 0 ? "ready" : "blocked",
+  actionCount: actions.length,
+  actions,
+  blockers,
+  caveat:
+    "Partial runtime evidence only: macOS product ViewModel actions delegate to signer/write seams and render refs-only results. Later live Hub audit, true operator signature, GUI tap, and adoption proof must land before END-BAR coverage.",
+};
+
+fs.mkdirSync(path.dirname(actionRuntimeOut), { recursive: true });
+fs.writeFileSync(actionRuntimeOut, `${JSON.stringify(report, null, 2)}\n`);
+console.log(JSON.stringify({ status: report.status, actionCount: actions.length, out: actionRuntimeOut }, null, 2));
+process.exit(blockers.length === 0 ? 0 : 2);
+NODE
+
+echo "Action runtime evidence: ${ACTION_RUNTIME_OUT}"
+echo "Truth: partial desktop Chat/Memory action evidence only; live Hub audit, GUI tap, and true operator signature proof remain required."

--- a/scripts/ops/friday-mobile-firstlaunch-action-evidence.sh
+++ b/scripts/ops/friday-mobile-firstlaunch-action-evidence.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+#
+# Mobile firstLaunch Scan/Pair/Retry/Cancel action evidence wrapper.
+#
+# Truth boundary:
+#   Runs iOS Swift product ViewModel tests for firstLaunch pairing Scan, Pair now, Retry, and
+#   Cancel actions. This proves QR preflight, accepted PairAck, retry after unavailable, and
+#   cancellation before late PairAck. It does not start or mutate prod Hub, prove a real
+#   simulator tap, claim END-BAR, or prove adoption.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+OUT_DIR="${FRIDAY_MOBILE_FIRSTLAUNCH_ACTION_EVIDENCE_DIR:-${TMPDIR:-/tmp}/friday-mobile-firstlaunch-action-evidence}"
+ACTION_RUNTIME_OUT="${FRIDAY_MOBILE_FIRSTLAUNCH_ACTION_RUNTIME_OUT:-${OUT_DIR}/action-runtime-evidence.json}"
+
+mkdir -p "${OUT_DIR}"
+chmod 700 "${OUT_DIR}"
+
+echo "Friday mobile firstLaunch action evidence starting."
+echo "truth_label=mobile_firstlaunch_pairing_action_swift_viewmodel_runtime_not_live_hub_not_endbar"
+echo "out_dir=${OUT_DIR}"
+
+run_swift_test() {
+  local filter="$1"
+  local log="${OUT_DIR}/swift-test-${filter}.log"
+  FRIDAY_MOBILE_FIRSTLAUNCH_ACTION_EVIDENCE_DIR="${OUT_DIR}" \
+    swift test \
+      --package-path "${REPO_ROOT}/apps/friday-ios" \
+      --filter "${filter}" 2>&1 | tee "${log}"
+  if ! grep -Eq "Executed [1-9][0-9]* test|Test run with [1-9][0-9]* test" "${log}"; then
+    echo "FATAL: Swift test filter ran zero tests: ${filter}" >&2
+    exit 2
+  fi
+}
+
+run_swift_test homeViewModelCarriesPairingPreflightStateAndCanClearIt
+run_swift_test homeViewModelPairScannedQrDrivesPairAckAcceptedWithoutLeakingSecret
+run_swift_test homeViewModelRetryAfterUnavailableRunsPairingFlowAgain
+run_swift_test homeViewModelCancelPairingAttemptPreventsLatePairAckFromWinning
+
+node - "${OUT_DIR}" "${ACTION_RUNTIME_OUT}" <<'NODE'
+const fs = require("node:fs");
+const path = require("node:path");
+
+const [outDir, actionRuntimeOut] = process.argv.slice(2);
+const files = [
+  path.join(outDir, "mobile-firstlaunch-scan-action-evidence.json"),
+  path.join(outDir, "mobile-firstlaunch-pairnow-action-evidence.json"),
+  path.join(outDir, "mobile-firstlaunch-retry-action-evidence.json"),
+  path.join(outDir, "mobile-firstlaunch-cancel-action-evidence.json"),
+];
+const blockers = [];
+const actions = [];
+
+for (const file of files) {
+  if (!fs.existsSync(file)) {
+    blockers.push({ code: "missing_swift_evidence", detail: file });
+    continue;
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(fs.readFileSync(file, "utf8"));
+  } catch {
+    blockers.push({ code: "invalid_swift_evidence_json", detail: file });
+    continue;
+  }
+  if (parsed.truth !== "mobile_firstlaunch_pairing_action_swift_viewmodel_runtime_not_live_hub_not_endbar") {
+    blockers.push({ code: "unexpected_truth", detail: `${file}:${parsed.truth || "<missing>"}` });
+  }
+  if (parsed.status !== "ready") {
+    blockers.push({ code: "evidence_not_ready", detail: `${file}:${parsed.status || "<missing>"}` });
+  }
+  const rows = Array.isArray(parsed.actions) ? parsed.actions : [];
+  if (rows.length === 0) blockers.push({ code: "missing_actions", detail: file });
+  for (const row of rows) {
+    actions.push({ ...row, source_proof: file });
+  }
+}
+
+const report = {
+  truth: "mobile_firstlaunch_action_runtime_evidence_partial_not_live_hub_not_endbar",
+  status: blockers.length === 0 ? "ready" : "blocked",
+  actionCount: actions.length,
+  actions,
+  blockers,
+  caveat:
+    "Partial runtime evidence only: Swift product ViewModel/Home firstLaunch Scan, Pair now, Retry, and Cancel semantics. Later real simulator/device tap plus live Hub PairAck proof must land before END-BAR coverage.",
+};
+
+fs.mkdirSync(path.dirname(actionRuntimeOut), { recursive: true });
+fs.writeFileSync(actionRuntimeOut, `${JSON.stringify(report, null, 2)}\n`);
+console.log(JSON.stringify({ status: report.status, actionCount: actions.length, out: actionRuntimeOut }, null, 2));
+process.exit(blockers.length === 0 ? 0 : 2);
+NODE
+
+echo "Action runtime evidence: ${ACTION_RUNTIME_OUT}"
+echo "Truth: partial firstLaunch Scan/Pair/Retry/Cancel action evidence only; live simulator/device and Hub proof remain required."


### PR DESCRIPTION
## Summary
- wire firstLaunch Device Pairing Retry/Cancel actions in the iOS Home UI
- add ViewModel cancellation state so a late PairAck cannot overwrite a cancelled pairing attempt
- add a mobile firstLaunch action evidence wrapper for Retry/Cancel runtime evidence

## Truth label
Partial product action coverage only. This proves Swift product ViewModel/Home semantics for firstLaunch Retry and Cancel. It does not start prod Hub, claim a real user tap, claim END-BAR, claim organic, or claim real device PairAck live coverage.

## Verification
- `FRIDAY_MOBILE_FIRSTLAUNCH_ACTION_EVIDENCE_DIR=/tmp/friday-mobile-firstlaunch-action-evidence-verify-20260625T125435Z scripts/ops/friday-mobile-firstlaunch-action-evidence.sh`
- `node /private/tmp/friday-mobile-memory-action-evidence-20260625/scripts/ops/check-friday-design-action-runtime-evidence.mjs --repo-root=/private/tmp/friday-mobile-firstlaunch-retry-cancel-20260625 --runtime-evidence=/tmp/friday-mobile-memory-action-evidence-verify-20260625T124838Z/action-runtime-evidence.json --runtime-evidence=/tmp/friday-desktop-chat-memory-action-evidence-verify-20260625T124956Z/action-runtime-evidence.json --runtime-evidence=/tmp/friday-mobile-approval-reject-live-20260625T125127Z/action-runtime-evidence.json --runtime-evidence=/tmp/friday-mobile-firstlaunch-action-evidence-verify-20260625T125435Z/action-runtime-evidence.json --json-out=/tmp/friday-mobile-firstlaunch-action-evidence-verify-20260625T125435Z/design-action-runtime-gap-after-firstlaunch.json`
- `apps/friday-ios/build-sim.sh --mode offline-truth --destination pairing --shot /tmp/friday-mobile-firstlaunch-retry-cancel-sim-20260625T125538Z.png`
- `git diff --check`

Strict design-action gap after this local evidence: `missingUniqueRuntimeEvidence=15`. This is intentionally conservative and still not END-BAR.
