### PR TITLE
feat(mobile): wire new session launch action

### DIFF
--- a/apps/friday-ios/Sources/FridayMobileShell/CommandSheet.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/CommandSheet.swift
@@ -64,6 +64,7 @@ enum MobileDestination: String, CaseIterable, Identifiable {
   case shareIntake
   case voice
   case pairing
+  case newSession
   case needsMe
   case memory
   case platform
@@ -85,6 +86,7 @@ enum MobileDestination: String, CaseIterable, Identifiable {
     case .shareIntake: return "Share Intake"
     case .voice: return "Voice"
     case .pairing: return "Device Pairing"
+    case .newSession: return "New Session"
     case .needsMe: return "Needs Me"
     case .memory: return "Memory"
     case .platform: return "Platform"
@@ -106,6 +108,7 @@ enum MobileDestination: String, CaseIterable, Identifiable {
     case .shareIntake: return "square.and.arrow.down"
     case .voice: return "waveform"
     case .pairing: return "qrcode.viewfinder"
+    case .newSession: return "plus"
     case .needsMe: return "person.crop.circle.badge.exclamationmark"
     case .memory: return "brain.head.profile"
     case .platform: return "square.grid.2x2"
@@ -128,6 +131,8 @@ enum MobileDestination: String, CaseIterable, Identifiable {
     case .providerAuth:
       return .providerWorkspace
     case .shareIntake, .needsMe:
+      return .governedActionGated
+    case .newSession:
       return .governedActionGated
     case .voice, .pairing:
       return .readinessOnly

--- a/apps/friday-ios/Sources/FridayMobileShell/FridayApp.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayApp.swift
@@ -329,6 +329,7 @@ struct RootView: View {
   @StateObject private var homeVM: HomeViewModel
   @StateObject private var sessionContinuationVM: SessionContinuationViewModel
   @StateObject private var shareIntakeVM: ShareIntakeViewModel
+  @StateObject private var newSessionVM: NewSessionViewModel
   @StateObject private var voiceVM: VoiceReadinessViewModel
   private let session: FridaySession
   @State private var destination: MobileDestination = .home
@@ -360,6 +361,7 @@ struct RootView: View {
       signer: session.signer,
       runControlEnabled: session.runControlEnabled))
     _shareIntakeVM = StateObject(wrappedValue: ShareIntakeViewModel(client: session.missionClient))
+    _newSessionVM = StateObject(wrappedValue: NewSessionViewModel(client: session.missionClient))
     _voiceVM = StateObject(wrappedValue: VoiceReadinessViewModel(
       authorizer: SystemVoiceReadinessAuthorizer()))
   }
@@ -378,6 +380,8 @@ struct RootView: View {
           FridayTokenLedgerScreen(viewModel: homeVM)
         case .shareIntake:
           FridayShareIntakeScreen(viewModel: shareIntakeVM)
+        case .newSession:
+          FridayNewSessionScreen(viewModel: newSessionVM)
         case .voice:
           FridayVoiceScreen(viewModel: voiceVM)
         case .pairing:

--- a/apps/friday-ios/Sources/FridayMobileShell/FridayNewSessionScreen.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayNewSessionScreen.swift
@@ -1,0 +1,126 @@
+import FridayMobileShellCore
+import SwiftUI
+
+struct FridayNewSessionScreen: View {
+  @ObservedObject var viewModel: NewSessionViewModel
+  @State private var intent = ""
+
+  var body: some View {
+    ScrollView {
+      VStack(spacing: 16) {
+        header
+        launcher
+        launchState
+      }
+      .padding(16)
+    }
+    .background(MobileTheme.backgroundWarmOffWhite.ignoresSafeArea())
+  }
+
+  private var header: some View {
+    GlassPanel {
+      HStack(spacing: 12) {
+        Image(systemName: "plus")
+          .font(.system(size: 24, weight: .semibold))
+          .foregroundStyle(MobileTheme.cyan)
+          .frame(width: 34, height: 34)
+        VStack(alignment: .leading, spacing: 4) {
+          Text("New Session")
+            .font(.headline)
+            .foregroundStyle(MobileTheme.textPrimary)
+          Text("governed mission launch")
+            .font(.caption)
+            .foregroundStyle(MobileTheme.textSecondary)
+        }
+        Spacer()
+        StatusChip(text: "action gated", bg: MobileTheme.chipPendingBG, fg: MobileTheme.chipPendingFG)
+      }
+    }
+  }
+
+  private var launcher: some View {
+    GlassPanel {
+      VStack(alignment: .leading, spacing: MobileTheme.rowSpacing) {
+        cardHeader("Launch", count: nil)
+        TextField("What should Friday do?", text: $intent, axis: .vertical)
+          .lineLimit(2...5)
+          .textInputAutocapitalization(.sentences)
+          .autocorrectionDisabled(false)
+          .font(.subheadline)
+          .padding(10)
+          .background(Color.white.opacity(0.54), in: RoundedRectangle(cornerRadius: 8))
+          .accessibilityIdentifier("friday.new-session.intent-input")
+        Button {
+          let goal = intent
+          Task { await viewModel.launch(intent: goal) }
+        } label: {
+          Label("Launch", systemImage: "play.fill")
+            .frame(maxWidth: .infinity, minHeight: 38)
+        }
+        .buttonStyle(.borderedProminent)
+        .tint(MobileTheme.cyan)
+        .disabled(intent.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || launchInFlight)
+        .accessibilityIdentifier("friday.new-session.launch-button")
+        Text("Launch submits a governed Mission Intake. It is not provider-backed until the Hub accepts it and returns refs.")
+          .font(.caption2)
+          .foregroundStyle(MobileTheme.textSecondary)
+          .fixedSize(horizontal: false, vertical: true)
+      }
+    }
+  }
+
+  @ViewBuilder
+  private var launchState: some View {
+    switch viewModel.launchState {
+    case .idle:
+      EmptyView()
+    case .launching:
+      GlassPanel {
+        HStack(spacing: 12) {
+          ProgressView()
+          Text("Submitting Mission Intake")
+            .font(.footnote)
+            .foregroundStyle(MobileTheme.textSecondary)
+        }
+      }
+    case .launched(let summary, let missionId, let workItemId):
+      GlassPanel {
+        VStack(alignment: .leading, spacing: MobileTheme.rowSpacing) {
+          cardHeader("Submitted", count: nil)
+          Text(summary)
+            .font(.caption)
+            .foregroundStyle(MobileTheme.textPrimary)
+          RefPill(label: "mission_id", ref: missionId)
+          RefPill(label: "work_item_id", ref: workItemId)
+        }
+      }
+    case .blocked(let reason):
+      GlassPanel {
+        VStack(alignment: .leading, spacing: MobileTheme.rowSpacing) {
+          cardHeader("Unavailable", count: nil)
+          Text(reason)
+            .font(.caption)
+            .foregroundStyle(MobileTheme.coral)
+            .fixedSize(horizontal: false, vertical: true)
+        }
+      }
+      .accessibilityIdentifier("friday.new-session.unavailable")
+    }
+  }
+
+  private var launchInFlight: Bool {
+    if case .launching = viewModel.launchState { return true }
+    return false
+  }
+
+  private func cardHeader(_ title: String, count: Int?) -> some View {
+    HStack {
+      Text(title)
+        .font(.headline)
+        .foregroundStyle(MobileTheme.textPrimary)
+      if let count {
+        StatusChip(text: "\(count)", bg: MobileTheme.chipNeutralBG, fg: MobileTheme.chipNeutralFG)
+      }
+    }
+  }
+}

--- a/apps/friday-ios/Sources/FridayMobileShell/FridayProjectionScreens.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayProjectionScreens.swift
@@ -14,7 +14,8 @@ private enum ProjectionSurface {
 
   init?(_ destination: MobileDestination) {
     switch destination {
-    case .home, .session, .contextPassport, .tokenLedger, .shareIntake, .voice, .pairing, .providerAuth:
+    case .home, .session, .contextPassport, .tokenLedger, .shareIntake, .voice, .pairing,
+         .newSession, .providerAuth:
       return nil
     case .missions:
       self = .missions

--- a/apps/friday-ios/Sources/FridayMobileShellCore/NewSessionViewModel.swift
+++ b/apps/friday-ios/Sources/FridayMobileShellCore/NewSessionViewModel.swift
@@ -1,0 +1,96 @@
+import Foundation
+import FridayRustClient
+
+public enum NewSessionLaunchState: Sendable, Equatable {
+  case idle
+  case launching
+  case launched(summary: String, missionId: String, workItemId: String)
+  case blocked(reason: String)
+}
+
+@MainActor
+public final class NewSessionViewModel: ObservableObject {
+  @Published public private(set) var launchState: NewSessionLaunchState = .idle
+
+  private let client: (any FridayMissionSpineWriteClient)?
+  private let owner: String
+  private let idFactory: () -> String
+
+  public init(
+    client: (any FridayMissionSpineWriteClient)?,
+    owner: String = "principal:owner-device",
+    idFactory: @escaping () -> String = { UUID().uuidString.lowercased() }
+  ) {
+    self.client = client
+    self.owner = owner
+    self.idFactory = idFactory
+  }
+
+  public func launch(intent: String) async {
+    let trimmed = intent.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty else {
+      launchState = .blocked(reason: "New session requires an owner-visible goal.")
+      return
+    }
+    guard let client else {
+      launchState = .blocked(reason: "Write seam not configured.")
+      return
+    }
+
+    launchState = .launching
+    do {
+      let result = try await client.submitMissionIntake(Self.request(intent: trimmed, owner: owner, id: idFactory()))
+      guard result.status == "ready" || result.status == "created" else {
+        launchState = .blocked(reason: "Mission intake not ready - \(result.status)")
+        return
+      }
+      guard let workItemId = result.workItemId, !workItemId.isEmpty else {
+        launchState = .blocked(reason: "Mission intake did not return a WorkItem ref.")
+        return
+      }
+      launchState = .launched(
+        summary: "\(result.status) · mission=\(result.missionId) · work_item=\(workItemId)",
+        missionId: result.missionId,
+        workItemId: workItemId)
+    } catch {
+      launchState = .blocked(reason: Self.reason(for: error))
+    }
+  }
+
+  public static func request(intent: String, owner: String, id: String) -> MissionIntakeRequestWire {
+    MissionIntakeRequestWire(
+      fridayConversationId: "fconv_mobile_new_session_\(id)",
+      ownerPrincipal: owner,
+      surfaceThreadId: "surface-mobile-new-session-\(id)",
+      surfaceKind: "mobile",
+      deliveryRoute: "ios://friday-mobile/new-session/\(id)",
+      visibilityPolicy: "compact",
+      missionId: "mission-mobile-new-session-\(id)",
+      workItemId: "work-mobile-new-session-\(id)",
+      title: String(intent.prefix(72)),
+      intent: intent,
+      lane: "auto")
+  }
+
+  private static func reason(for error: Error) -> String {
+    if let write = error as? FridayWriteClientError {
+      switch write {
+      case .badServerPubkey, .badSessionNonce:
+        return "Friday could not establish a trusted connection."
+      case let .serverError(code, message):
+        return "Friday is unavailable (\(code.rawValue)) - \(message)"
+      case let .unexpectedResponse(kind):
+        return "Friday returned an unexpected response (\(kind))."
+      case let .missingRef(reason):
+        return "Friday returned an incomplete launch response - \(reason)"
+      case .runControlDisabled:
+        return "Run control is not enabled for this launch."
+      case .emptySignedBlob:
+        return "Launch unavailable - unexpected empty signature state."
+      case let .transport(reason):
+        return "Friday is offline - \(reason)"
+      }
+    }
+    return "Launch failed - \(error)"
+  }
+}

--- a/apps/friday-ios/Tests/FridayMobileShellCoreTests/NewSessionViewModelTests.swift
+++ b/apps/friday-ios/Tests/FridayMobileShellCoreTests/NewSessionViewModelTests.swift
@@ -1,0 +1,119 @@
+import XCTest
+@testable import FridayMobileShellCore
+@testable import FridayRustClient
+
+@MainActor
+final class NewSessionViewModelTests: XCTestCase {
+  final class FakeMissionClient: FridayMissionSpineWriteClient, @unchecked Sendable {
+    var result: MissionIntakeResultWire
+    private(set) var requests: [MissionIntakeRequestWire] = []
+
+    init(result: MissionIntakeResultWire) {
+      self.result = result
+    }
+
+    func submitMissionIntake(_ request: MissionIntakeRequestWire) async throws -> MissionIntakeResultWire {
+      requests.append(request)
+      return result
+    }
+
+    func submitMemoryDecision(_ request: MemoryDecisionRequestWire) async throws -> MemoryDecisionResultWire {
+      MemoryDecisionResultWire(memoryId: request.memoryId, state: "unknown", status: "blocked", blocker: "unused", recallable: false)
+    }
+
+    func submitRunOutcomeLearningDecision(
+      _ request: RunOutcomeLearningDecisionRequestWire
+    ) async throws -> RunOutcomeLearningDecisionResultWire {
+      RunOutcomeLearningDecisionResultWire(candidateId: request.candidateId, state: "unknown", status: "blocked", blocker: "unused")
+    }
+
+    func submitActivityMarkDone(_ request: ActivityMarkDoneRequestWire) async throws -> ActivityMarkDoneResultWire {
+      ActivityMarkDoneResultWire(activityId: request.activityId, state: "unknown", status: "blocked", blocker: "unused")
+    }
+
+    func submitWorkItemStatus(_ request: WorkItemStatusRequestWire) async throws -> WorkItemStatusResultWire {
+      WorkItemStatusResultWire(
+        workItemId: request.workItemId,
+        missionId: "unused",
+        previousStatus: "unknown",
+        status: "blocked",
+        actorRef: request.actorRef,
+        reason: request.reason,
+        proofReceiptCount: 0,
+        updatedAtMs: 0)
+    }
+  }
+
+  func testNoWriteClientFailsClosedWithoutFakeLaunch() async {
+    let vm = NewSessionViewModel(client: nil, idFactory: { "fixed" })
+
+    await vm.launch(intent: "summarize today's Friday closure state")
+
+    XCTAssertEqual(vm.launchState, .blocked(reason: "Write seam not configured."))
+  }
+
+  func testLaunchSubmitsGovernedMissionIntake() async throws {
+    let client = FakeMissionClient(result: MissionIntakeResultWire(
+      fridayConversationId: "fconv_mobile_new_session_fixed",
+      missionId: "mission-mobile-new-session-fixed",
+      workItemId: "work-mobile-new-session-fixed",
+      surfaceThreadId: "surface-mobile-new-session-fixed",
+      status: "ready",
+      createdOrReady: true))
+    let vm = NewSessionViewModel(client: client, owner: "owner-ios", idFactory: { "fixed" })
+
+    await vm.launch(intent: "Summarize current v1 closure risk.")
+
+    XCTAssertEqual(client.requests.count, 1)
+    let request = try XCTUnwrap(client.requests.first)
+    XCTAssertEqual(request.fridayConversationId, "fconv_mobile_new_session_fixed")
+    XCTAssertEqual(request.ownerPrincipal, "owner-ios")
+    XCTAssertEqual(request.surfaceKind, "mobile")
+    XCTAssertEqual(request.deliveryRoute, "ios://friday-mobile/new-session/fixed")
+    XCTAssertEqual(request.visibilityPolicy, "compact")
+    XCTAssertEqual(request.missionId, "mission-mobile-new-session-fixed")
+    XCTAssertEqual(request.workItemId, "work-mobile-new-session-fixed")
+    XCTAssertEqual(request.title, "Summarize current v1 closure risk.")
+    XCTAssertEqual(request.intent, "Summarize current v1 closure risk.")
+    XCTAssertEqual(request.lane, "auto")
+    XCTAssertEqual(
+      vm.launchState,
+      .launched(
+        summary: "ready · mission=mission-mobile-new-session-fixed · work_item=work-mobile-new-session-fixed",
+        missionId: "mission-mobile-new-session-fixed",
+        workItemId: "work-mobile-new-session-fixed"))
+
+    try writeNewSessionActionEvidenceIfRequested()
+  }
+
+  private func writeNewSessionActionEvidenceIfRequested() throws {
+    guard let rawDir = ProcessInfo.processInfo.environment["FRIDAY_MOBILE_NEW_SESSION_ACTION_EVIDENCE_DIR"],
+          !rawDir.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+      return
+    }
+    let dir = URL(fileURLWithPath: rawDir, isDirectory: true)
+    try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+    let payload: [String: Any] = [
+      "truth": "mobile_new_session_launch_swift_viewmodel_runtime_not_live_hub_not_endbar",
+      "status": "ready",
+      "actions": [
+        [
+          "surface": "mobile",
+          "screen": "newSession",
+          "action_id": "play",
+          "capability_id": "session_control_native_set",
+          "status": "pass",
+          "evidence_ref": "swift://mobile/newSession/play/mission-mobile-new-session-fixed",
+          "proof": [
+            "mission_id": "mission-mobile-new-session-fixed",
+            "work_item_id": "work-mobile-new-session-fixed",
+            "surface_kind": "mobile",
+            "delivery_route": "ios://friday-mobile/new-session/fixed",
+          ],
+        ],
+      ],
+    ]
+    let data = try JSONSerialization.data(withJSONObject: payload, options: [.prettyPrinted, .sortedKeys])
+    try data.write(to: dir.appendingPathComponent("mobile-new-session-action-evidence.json"), options: .atomic)
+  }
+}

--- a/scripts/ops/friday-mobile-new-session-action-evidence.sh
+++ b/scripts/ops/friday-mobile-new-session-action-evidence.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+#
+# Mobile New Session Launch action evidence wrapper.
+#
+# Truth boundary:
+#   Runs iOS Swift product ViewModel tests for the New Session Launch action. This proves Launch
+#   creates a governed Mission Intake through the existing mobile write seam abstraction when a
+#   client is configured, and fails closed when it is not. It does not start or mutate prod Hub,
+#   prove a real simulator tap, claim END-BAR, or prove adoption.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+OUT_DIR="${FRIDAY_MOBILE_NEW_SESSION_ACTION_EVIDENCE_DIR:-${TMPDIR:-/tmp}/friday-mobile-new-session-action-evidence}"
+ACTION_RUNTIME_OUT="${FRIDAY_MOBILE_NEW_SESSION_ACTION_RUNTIME_OUT:-${OUT_DIR}/action-runtime-evidence.json}"
+
+mkdir -p "${OUT_DIR}"
+chmod 700 "${OUT_DIR}"
+
+echo "Friday mobile New Session action evidence starting."
+echo "truth_label=mobile_new_session_launch_swift_viewmodel_runtime_not_live_hub_not_endbar"
+echo "out_dir=${OUT_DIR}"
+
+run_swift_test() {
+  local filter="$1"
+  local log="${OUT_DIR}/swift-test-${filter}.log"
+  FRIDAY_MOBILE_NEW_SESSION_ACTION_EVIDENCE_DIR="${OUT_DIR}" \
+    swift test \
+      --package-path "${REPO_ROOT}/apps/friday-ios" \
+      --filter "${filter}" 2>&1 | tee "${log}"
+  if ! grep -Eq "Executed [1-9][0-9]* test|Test run with [1-9][0-9]* test" "${log}"; then
+    echo "FATAL: Swift test filter ran zero tests: ${filter}" >&2
+    exit 2
+  fi
+}
+
+run_swift_test testNoWriteClientFailsClosedWithoutFakeLaunch
+run_swift_test testLaunchSubmitsGovernedMissionIntake
+
+node - "${OUT_DIR}" "${ACTION_RUNTIME_OUT}" <<'NODE'
+const fs = require("node:fs");
+const path = require("node:path");
+
+const [outDir, actionRuntimeOut] = process.argv.slice(2);
+const source = path.join(outDir, "mobile-new-session-action-evidence.json");
+const blockers = [];
+let actions = [];
+
+if (!fs.existsSync(source)) {
+  blockers.push({ code: "missing_swift_evidence", detail: source });
+} else {
+  let parsed;
+  try {
+    parsed = JSON.parse(fs.readFileSync(source, "utf8"));
+  } catch {
+    blockers.push({ code: "invalid_swift_evidence_json", detail: source });
+  }
+  if (parsed) {
+    if (parsed.truth !== "mobile_new_session_launch_swift_viewmodel_runtime_not_live_hub_not_endbar") {
+      blockers.push({ code: "unexpected_truth", detail: parsed.truth || "<missing>" });
+    }
+    if (parsed.status !== "ready") {
+      blockers.push({ code: "evidence_not_ready", detail: parsed.status || "<missing>" });
+    }
+    actions = Array.isArray(parsed.actions) ? parsed.actions.map((row) => ({ ...row, source_proof: source })) : [];
+    if (actions.length !== 1) {
+      blockers.push({ code: "unexpected_action_count", detail: String(actions.length) });
+    }
+  }
+}
+
+const report = {
+  truth: "mobile_new_session_action_runtime_evidence_partial_not_live_hub_not_endbar",
+  status: blockers.length === 0 ? "ready" : "blocked",
+  actionCount: actions.length,
+  actions,
+  blockers,
+  caveat:
+    "Partial runtime evidence only: Swift product ViewModel New Session Launch semantics. Later real simulator/device tap and live Hub Mission Intake proof remain required before END-BAR coverage.",
+};
+
+fs.mkdirSync(path.dirname(actionRuntimeOut), { recursive: true });
+fs.writeFileSync(actionRuntimeOut, `${JSON.stringify(report, null, 2)}\n`);
+console.log(JSON.stringify({ status: report.status, actionCount: actions.length, out: actionRuntimeOut }, null, 2));
+process.exit(blockers.length === 0 ? 0 : 2);
+NODE
+
+echo "Action runtime evidence: ${ACTION_RUNTIME_OUT}"
+echo "Truth: partial New Session Launch action evidence only; live simulator/device and Hub proof remain required."


### PR DESCRIPTION
## Summary
- add the mobile New Session route and SwiftUI screen wired to governed Mission Spine intake
- add fail-closed NewSessionViewModel behavior for missing write seams and non-ready intake results
- add runtime action evidence for mobile/newSession/play without claiming live Hub, END-BAR, or adoption

## Verification
- FRIDAY_MOBILE_NEW_SESSION_ACTION_EVIDENCE_DIR=/tmp/friday-mobile-new-session-action-evidence-verify-20260625T131300Z scripts/ops/friday-mobile-new-session-action-evidence.sh
- apps/friday-ios/build-sim.sh --mode offline-truth --destination newSession --shot /tmp/friday-mobile-new-session-sim-20260625T131400Z.png
- node scripts/ops/check-friday-design-action-runtime-evidence.mjs --runtime-evidence=/tmp/friday-mobile-memory-action-evidence-verify-20260625T130200Z/action-runtime-evidence.json --runtime-evidence=/tmp/friday-desktop-chat-memory-action-evidence-verify-20260625T124956Z/action-runtime-evidence.json --runtime-evidence=/tmp/friday-mobile-approval-reject-live-20260625T125127Z/action-runtime-evidence.json --runtime-evidence=/tmp/friday-mobile-firstlaunch-action-evidence-verify-20260625T125435Z/action-runtime-evidence.json --runtime-evidence=/tmp/friday-mobile-session-sidecar-action-evidence-verify-20260625T130000Z/action-runtime-evidence.json --runtime-evidence=/tmp/friday-mobile-new-session-action-evidence-verify-20260625T131300Z/action-runtime-evidence.json --out=/tmp/friday-design-action-runtime-gap-after-new-session-20260625T131500Z.json

Truth: partial action-evidence closure only; offline simulator proof is not END-BAR and not live Hub adoption.