### PR TITLE
test(ui): prove mobile chat action evidence

### DIFF
--- a/apps/friday-ios/Tests/FridayMobileShellCoreTests/FridayChatViewModelTests.swift
+++ b/apps/friday-ios/Tests/FridayMobileShellCoreTests/FridayChatViewModelTests.swift
@@ -241,6 +241,33 @@ final class FridayChatViewModelTests: XCTestCase {
                   actionDigest: String(repeating: "c", count: 64), ownerSealedSummary: "write_file(notes.md)")
   }
 
+  private func writeMobileChatActionEvidenceIfRequested(
+    actions: [[String: Any]],
+    proof: [String: Any]
+  ) throws {
+    guard let rawDir = ProcessInfo.processInfo.environment[
+      "FRIDAY_MOBILE_CHAT_ACTION_EVIDENCE_DIR"
+    ]?.trimmingCharacters(in: .whitespacesAndNewlines), !rawDir.isEmpty else {
+      return
+    }
+
+    let payload: [String: Any] = [
+      "truth": "mobile_chat_action_swift_viewmodel_runtime_not_live_hub_not_endbar",
+      "status": "ready",
+      "generated_at_utc": ISO8601DateFormatter().string(from: Date()),
+      "proof": proof,
+      "actions": actions,
+      "caveat": "Partial runtime evidence only: iOS Chat ViewModel actions delegate to the governed write/sign/reject seams and render refs-only results. This is not a simulator tap, not a live Hub audit receipt, not true operator-key approval, not END-BAR, and not adoption.",
+    ]
+
+    let dir = URL(fileURLWithPath: rawDir)
+    try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+    let out = dir.appendingPathComponent("action-runtime-evidence.json")
+    let data = try JSONSerialization.data(withJSONObject: payload, options: [.prettyPrinted, .sortedKeys])
+    try data.write(to: out, options: .atomic)
+    print("[mobile-chat-action-evidence] proofOut=\(out.path)")
+  }
+
   // MARK: 1. Compose → Send → Answer (mock)
 
   func testSend_settlesRefsOnlyAnswer() async {
@@ -498,6 +525,103 @@ final class FridayChatViewModelTests: XCTestCase {
     XCTAssertEqual(client.relayedBlobs.first, expected, "INV-1: the signer blob must ride VERBATIM")
     XCTAssertTrue(vm.history.last?.receiptRefs.contains(ChatReceiptRef(label: "audit_ref", ref: "audit://chain/run-1")) == true)
     XCTAssertTrue(vm.history.last?.receiptRefs.contains(ChatReceiptRef(label: "truth", ref: "rust_wired")) == true)
+  }
+
+  func testMobileChatActionEvidenceCoversSendApprovalCardAndControls() async throws {
+    let sendClient = FakeWriteClient(dispatch: .answer(makeAnswer("run-chat-send")))
+    let sendVM = FridayChatViewModel(writeClient: sendClient, signer: MockOperatorSigner())
+    await sendVM.send("summarize the current Friday closure status")
+    guard case let .answered(answerReceipt) = sendVM.phase else {
+      return XCTFail("expected answered, got \(sendVM.phase)")
+    }
+
+    let approveClient = FakeWriteClient(
+      dispatch: .pause(makePause("run-chat-approve")),
+      resume: .accepted(ResumeRelayResult(
+        runId: "run-chat-approve",
+        op: "resume",
+        accepted: true,
+        status: "mutation_completed",
+        auditRef: "audit://mobile-chat/approve")))
+    let approveVM = FridayChatViewModel(writeClient: approveClient, signer: MockOperatorSigner())
+    await approveVM.send("edit notes.md")
+    guard case let .pendingApproval(approvalCard) = approveVM.phase else {
+      return XCTFail("expected pending approval, got \(approveVM.phase)")
+    }
+    await approveVM.approve()
+    guard case let .resumed(approveReceipt) = approveVM.phase else {
+      return XCTFail("expected approve resume receipt, got \(approveVM.phase)")
+    }
+
+    let rejectClient = FakeWriteClient(
+      dispatch: .pause(makePause("run-chat-reject")),
+      reject: .accepted(ResumeRelayResult(
+        runId: "run-chat-reject",
+        op: "reject",
+        accepted: true,
+        status: "rejected",
+        auditRef: "audit://mobile-chat/reject")))
+    let rejectVM = FridayChatViewModel(writeClient: rejectClient, signer: MockOperatorSigner())
+    await rejectVM.send("edit notes.md")
+    await rejectVM.reject()
+    guard case let .resumed(rejectReceipt) = rejectVM.phase else {
+      return XCTFail("expected reject receipt, got \(rejectVM.phase)")
+    }
+
+    try writeMobileChatActionEvidenceIfRequested(
+      actions: [
+        [
+          "surface": "mobile",
+          "screen": "fridayChat",
+          "action_id": "chat:typing",
+          "capability_id": "ask_friday_chat",
+          "status": "pass",
+          "evidence_ref": "swift://mobile/fridayChat/send/\(answerReceipt.runId)",
+          "source": "ios_chat_viewmodel_send_runtime",
+          "truth_label": "swift_viewmodel_write_client_runtime_not_live_hub_not_operator_key_not_endbar",
+        ],
+        [
+          "surface": "mobile",
+          "screen": "fridayChat",
+          "action_id": "chat:approveCard",
+          "capability_id": "ask_friday_chat",
+          "status": "pass",
+          "evidence_ref": "swift://mobile/fridayChat/approval-card/\(approvalCard.runId)",
+          "source": "ios_chat_viewmodel_paused_approval_card_runtime",
+          "truth_label": "swift_viewmodel_write_client_runtime_not_live_hub_not_operator_key_not_endbar",
+        ],
+        [
+          "surface": "mobile",
+          "screen": "fridayChat",
+          "action_id": "check",
+          "capability_id": "security_approval_bound_principal_gate_cat10_netnew",
+          "status": "pass",
+          "evidence_ref": "swift://mobile/fridayChat/approve/\(approveReceipt.runId)",
+          "source": "ios_chat_viewmodel_approve_relay_runtime",
+          "truth_label": "swift_viewmodel_mock_operator_signer_not_true_key_not_endbar",
+        ],
+        [
+          "surface": "mobile",
+          "screen": "fridayChat",
+          "action_id": "act",
+          "capability_id": "security_approval_bound_principal_gate_cat10_netnew",
+          "status": "pass",
+          "evidence_ref": "swift://mobile/fridayChat/reject/\(rejectReceipt.runId)",
+          "source": "ios_chat_viewmodel_reject_runtime",
+          "truth_label": "swift_viewmodel_write_client_runtime_not_live_hub_not_operator_key_not_endbar",
+        ],
+      ],
+      proof: [
+        "send_run_id": answerReceipt.runId,
+        "approval_card_run_id": approvalCard.runId,
+        "approval_card_digest_len": approvalCard.actionDigest.count,
+        "approve_run_id": approveReceipt.runId,
+        "approve_status": approveReceipt.status,
+        "reject_run_id": rejectReceipt.runId,
+        "reject_status": rejectReceipt.status,
+        "approve_relay_count": approveClient.resumedRunIds.count,
+        "reject_relay_count": rejectClient.rejectedRunIds.count,
+      ])
   }
 
   /// A server REFUSAL (`accepted=false`) is a SUCCESSFUL relay of a refusal — the action did NOT

--- a/scripts/ops/friday-mobile-chat-action-evidence.sh
+++ b/scripts/ops/friday-mobile-chat-action-evidence.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+#
+# Mobile Friday Chat action evidence wrapper.
+#
+# Truth boundary:
+#   Runs iOS Swift product ViewModel tests and exports explicit action-runtime evidence for
+#   Friday Chat send, approval-card render, approve relay, and reject relay. This proves the
+#   product ViewModel delegates to governed write/sign/reject seams and renders refs-only
+#   results. It does not start or mutate prod Hub, use the operator's true signing key, prove
+#   live Hub audit receipts, drive a real simulator tap, claim END-BAR, or prove adoption.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+OUT_DIR="${FRIDAY_MOBILE_CHAT_ACTION_EVIDENCE_DIR:-${TMPDIR:-/tmp}/friday-mobile-chat-action-evidence}"
+ACTION_RUNTIME_OUT="${FRIDAY_MOBILE_CHAT_ACTION_RUNTIME_OUT:-${OUT_DIR}/action-runtime-evidence.json}"
+
+mkdir -p "${OUT_DIR}"
+chmod 700 "${OUT_DIR}"
+
+echo "Friday mobile Chat action evidence starting."
+echo "truth_label=mobile_chat_action_swift_viewmodel_runtime_not_live_hub_not_endbar"
+echo "out_dir=${OUT_DIR}"
+
+log="${OUT_DIR}/swift-test-mobile-chat-action-evidence.log"
+FRIDAY_MOBILE_CHAT_ACTION_EVIDENCE_DIR="${OUT_DIR}" \
+  swift test \
+    --package-path "${REPO_ROOT}/apps/friday-ios" \
+    --filter "FridayChatViewModelTests/testMobileChatActionEvidenceCoversSendApprovalCardAndControls" \
+    2>&1 | tee "${log}"
+
+if ! grep -Eq "Executed [1-9][0-9]* test|Test run with [1-9][0-9]* test" "${log}"; then
+  echo "FATAL: Swift test filter ran zero tests" >&2
+  exit 2
+fi
+
+node - "${ACTION_RUNTIME_OUT}" <<'NODE'
+const fs = require("node:fs");
+const [actionRuntimeOut] = process.argv.slice(2);
+
+if (!fs.existsSync(actionRuntimeOut)) {
+  console.error(`FATAL: missing action runtime evidence: ${actionRuntimeOut}`);
+  process.exit(2);
+}
+
+let parsed;
+try {
+  parsed = JSON.parse(fs.readFileSync(actionRuntimeOut, "utf8"));
+} catch (error) {
+  console.error(`FATAL: invalid action runtime evidence JSON: ${error.message}`);
+  process.exit(2);
+}
+
+const blockers = [];
+if (parsed.truth !== "mobile_chat_action_swift_viewmodel_runtime_not_live_hub_not_endbar") {
+  blockers.push({ code: "unexpected_truth", detail: parsed.truth || "<missing>" });
+}
+if (parsed.status !== "ready") {
+  blockers.push({ code: "evidence_not_ready", detail: parsed.status || "<missing>" });
+}
+const actions = Array.isArray(parsed.actions) ? parsed.actions : [];
+for (const expected of [
+  ["mobile", "fridayChat", "chat:typing", "ask_friday_chat"],
+  ["mobile", "fridayChat", "chat:approveCard", "ask_friday_chat"],
+  ["mobile", "fridayChat", "check", "security_approval_bound_principal_gate_cat10_netnew"],
+  ["mobile", "fridayChat", "act", "security_approval_bound_principal_gate_cat10_netnew"],
+]) {
+  const found = actions.some((row) =>
+    row.surface === expected[0]
+    && row.screen === expected[1]
+    && row.action_id === expected[2]
+    && row.capability_id === expected[3]
+    && row.status === "pass");
+  if (!found) blockers.push({ code: "missing_action_row", detail: expected.join("/") });
+}
+
+console.log(JSON.stringify({
+  status: blockers.length === 0 ? "ready" : "blocked",
+  actionCount: actions.length,
+  out: actionRuntimeOut,
+  blockers,
+}, null, 2));
+process.exit(blockers.length === 0 ? 0 : 2);
+NODE
+
+echo "Action runtime evidence: ${ACTION_RUNTIME_OUT}"
+echo "Truth: partial mobile Chat action evidence only; live Hub audit, simulator tap, and true operator signature proof remain required."


### PR DESCRIPTION
## Summary
- add an iOS Friday Chat action-evidence wrapper
- export runtime evidence for send, approval-card render, approve relay, and reject relay using the existing Chat ViewModel seams
- keep truth labels strict: not live Hub audit, not true operator key, not simulator tap, not END-BAR

## Verification
- FRIDAY_MOBILE_CHAT_ACTION_EVIDENCE_DIR=/tmp/friday-mobile-chat-action-evidence-verify-20260625T133000Z scripts/ops/friday-mobile-chat-action-evidence.sh
- node scripts/ops/check-friday-design-action-runtime-evidence.mjs ... --runtime-evidence=/tmp/friday-mobile-chat-action-evidence-verify-20260625T133000Z/action-runtime-evidence.json --out=/tmp/friday-design-action-runtime-gap-after-mobile-chat-20260625T133200Z.json

Truth: partial action-evidence closure only; remaining unique runtime gaps include mobile approval true approve, firstLaunch scan/pair, chat handoff/memory/share, mobile memory resolve, passport send, and workflow pause.