### PR TITLE
test(ui): prove mobile workflow run-control evidence

### DIFF
--- a/apps/friday-ios/Tests/FridayMobileShellCoreTests/SessionContinuationViewModelTests.swift
+++ b/apps/friday-ios/Tests/FridayMobileShellCoreTests/SessionContinuationViewModelTests.swift
@@ -682,7 +682,7 @@ final class SessionContinuationViewModelTests: XCTestCase {
     XCTAssertTrue(failed.resumedRunIds.isEmpty)
   }
 
-  func testStopUsesGovernedCancelRunAndSurfacesReceipt() async {
+  func testStopUsesGovernedCancelRunAndSurfacesReceipt() async throws {
     let client = FakeSessionReadClient()
     let write = FakeSessionWriteClient()
     let vm = SessionContinuationViewModel(
@@ -698,6 +698,11 @@ final class SessionContinuationViewModelTests: XCTestCase {
     XCTAssertEqual(
       vm.controlStates["stop"],
       .succeeded(summary: "cancel: cancelled · accepted · audit://cancel/run-1"))
+    try writeWorkflowRunControlActionEvidenceIfRequested(
+      runId: "run-1",
+      auditRef: "audit://cancel/run-1",
+      cancelledRunIds: write.cancelledRunIds,
+      cancelReasons: write.cancelReasons)
   }
 
   func testStopRefusalAndTransportFailureRenderError() async {
@@ -856,5 +861,46 @@ final class SessionContinuationViewModelTests: XCTestCase {
     ]
     let data = try JSONSerialization.data(withJSONObject: payload, options: [.prettyPrinted, .sortedKeys])
     try data.write(to: dir.appendingPathComponent("mobile-session-sidecar-action-evidence.json"), options: .atomic)
+  }
+
+  private func writeWorkflowRunControlActionEvidenceIfRequested(
+    runId: String,
+    auditRef: String,
+    cancelledRunIds: [String],
+    cancelReasons: [String?]
+  ) throws {
+    guard let rawDir = ProcessInfo.processInfo.environment["FRIDAY_MOBILE_WORKFLOW_ACTION_EVIDENCE_DIR"],
+          !rawDir.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+      return
+    }
+    let dir = URL(fileURLWithPath: rawDir, isDirectory: true)
+    try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+    let payload: [String: Any] = [
+      "truth": "mobile_workflow_action_swift_viewmodel_runtime_not_live_hub_not_endbar",
+      "status": "ready",
+      "generated_at_utc": ISO8601DateFormatter().string(from: Date()),
+      "actions": [
+        [
+          "surface": "mobile",
+          "screen": "workflow",
+          "action_id": "workflow_run_control",
+          "capability_id": "session_control_native_set",
+          "status": "pass",
+          "evidence_ref": "swift://mobile/workflow/run-control/\(runId)",
+          "source": "ios_session_continuation_viewmodel_stop_runtime",
+          "truth_label": "swift_viewmodel_write_client_runtime_not_live_hub_not_sim_tap",
+        ],
+      ],
+      "proof": [
+        "run_id": runId,
+        "op": "cancel",
+        "audit_ref": auditRef,
+        "cancelled_run_ids": cancelledRunIds,
+        "cancel_reasons": cancelReasons.map { $0 ?? "" },
+      ],
+      "caveat": "Partial runtime evidence only: iOS SessionContinuation ViewModel run-control delegates to the governed write seam and renders a refs-only receipt. This is not a live Hub audit receipt, not a simulator tap, not END-BAR, and not adoption.",
+    ]
+    let data = try JSONSerialization.data(withJSONObject: payload, options: [.prettyPrinted, .sortedKeys])
+    try data.write(to: dir.appendingPathComponent("mobile-workflow-action-evidence.json"), options: .atomic)
   }
 }

--- a/scripts/ops/friday-mobile-workflow-action-evidence.sh
+++ b/scripts/ops/friday-mobile-workflow-action-evidence.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+#
+# Mobile Workflow run-control action evidence wrapper.
+#
+# Truth boundary:
+#   Runs iOS Swift product ViewModel tests for workflow/session run-control. This proves the
+#   visible workflow run-control action delegates to the governed cancel seam and renders a
+#   refs-only receipt. It does not start or mutate prod Hub, prove a live Hub audit receipt,
+#   drive a real simulator tap, claim END-BAR, or prove adoption.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+OUT_DIR="${FRIDAY_MOBILE_WORKFLOW_ACTION_EVIDENCE_DIR:-${TMPDIR:-/tmp}/friday-mobile-workflow-action-evidence}"
+ACTION_RUNTIME_OUT="${FRIDAY_MOBILE_WORKFLOW_ACTION_RUNTIME_OUT:-${OUT_DIR}/action-runtime-evidence.json}"
+
+mkdir -p "${OUT_DIR}"
+chmod 700 "${OUT_DIR}"
+
+echo "Friday mobile Workflow action evidence starting."
+echo "truth_label=mobile_workflow_action_swift_viewmodel_runtime_not_live_hub_not_endbar"
+echo "out_dir=${OUT_DIR}"
+
+log="${OUT_DIR}/swift-test-mobile-workflow-action-evidence.log"
+FRIDAY_MOBILE_WORKFLOW_ACTION_EVIDENCE_DIR="${OUT_DIR}" \
+  swift test \
+    --package-path "${REPO_ROOT}/apps/friday-ios" \
+    --filter "SessionContinuationViewModelTests/testStopUsesGovernedCancelRunAndSurfacesReceipt" \
+    2>&1 | tee "${log}"
+
+if ! grep -Eq "Executed [1-9][0-9]* test|Test run with [1-9][0-9]* test" "${log}"; then
+  echo "FATAL: Swift test filter ran zero tests" >&2
+  exit 2
+fi
+
+node - "${OUT_DIR}" "${ACTION_RUNTIME_OUT}" <<'NODE'
+const fs = require("node:fs");
+const path = require("node:path");
+
+const [outDir, actionRuntimeOut] = process.argv.slice(2);
+const source = path.join(outDir, "mobile-workflow-action-evidence.json");
+const blockers = [];
+let actions = [];
+
+if (!fs.existsSync(source)) {
+  blockers.push({ code: "missing_swift_evidence", detail: source });
+} else {
+  let parsed;
+  try {
+    parsed = JSON.parse(fs.readFileSync(source, "utf8"));
+  } catch {
+    blockers.push({ code: "invalid_swift_evidence_json", detail: source });
+  }
+  if (parsed) {
+    if (parsed.truth !== "mobile_workflow_action_swift_viewmodel_runtime_not_live_hub_not_endbar") {
+      blockers.push({ code: "unexpected_truth", detail: parsed.truth || "<missing>" });
+    }
+    if (parsed.status !== "ready") {
+      blockers.push({ code: "evidence_not_ready", detail: parsed.status || "<missing>" });
+    }
+    actions = Array.isArray(parsed.actions) ? parsed.actions.map((row) => ({ ...row, source_proof: source })) : [];
+    const found = actions.some((row) =>
+      row.surface === "mobile"
+      && row.screen === "workflow"
+      && row.action_id === "workflow_run_control"
+      && row.capability_id === "session_control_native_set"
+      && row.status === "pass");
+    if (!found) blockers.push({ code: "missing_workflow_run_control", detail: source });
+  }
+}
+
+const report = {
+  truth: "mobile_workflow_action_runtime_evidence_partial_not_live_hub_not_endbar",
+  status: blockers.length === 0 ? "ready" : "blocked",
+  actionCount: actions.length,
+  actions,
+  blockers,
+  caveat:
+    "Partial runtime evidence only: Swift product ViewModel workflow run-control delegates to the governed write seam and renders refs-only result. Later live Hub audit and real simulator/device tap must land before END-BAR coverage.",
+};
+
+fs.mkdirSync(path.dirname(actionRuntimeOut), { recursive: true });
+fs.writeFileSync(actionRuntimeOut, `${JSON.stringify(report, null, 2)}\n`);
+console.log(JSON.stringify({ status: report.status, actionCount: actions.length, out: actionRuntimeOut, blockers }, null, 2));
+process.exit(blockers.length === 0 ? 0 : 2);
+NODE
+
+echo "Action runtime evidence: ${ACTION_RUNTIME_OUT}"
+echo "Truth: partial Workflow action evidence only; live Hub audit and simulator/device tap remain required."


### PR DESCRIPTION
## Summary
- add mobile Workflow run-control action evidence for the governed cancel seam
- export contract row mobile/workflow/workflow_run_control with session_control_native_set
- leave passport send unclaimed because the current passport screen is read-only projection, not a send mutation

## Verification
- FRIDAY_MOBILE_WORKFLOW_ACTION_EVIDENCE_DIR=/tmp/friday-mobile-workflow-action-evidence-verify-20260625T135500Z scripts/ops/friday-mobile-workflow-action-evidence.sh
- node scripts/ops/check-friday-design-action-runtime-evidence.mjs ... --runtime-evidence=/tmp/friday-mobile-workflow-action-evidence-verify-20260625T135500Z/action-runtime-evidence.json --out=/tmp/friday-design-action-runtime-gap-after-workflow-20260625T135800Z.json

Truth: partial action-evidence closure only; not live Hub audit, not simulator/device tap, not END-BAR.