### PR TITLE
feat(mobile): surface chat context cards

### DIFF
--- a/apps/friday-ios/Sources/FridayMobileShell/FridayChatScreen.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayChatScreen.swift
@@ -47,6 +47,7 @@ struct FridayChatScreen: View {
 
           historyCard
           phaseCard
+          contextCards
         }
         .padding(16)
       }
@@ -56,6 +57,48 @@ struct FridayChatScreen: View {
     .background(MobileTheme.backgroundWarmOffWhite.ignoresSafeArea())
     .navigationTitle("Friday Chat")
     .navigationBarTitleDisplayMode(.inline)
+  }
+
+  @ViewBuilder private var contextCards: some View {
+    if !viewModel.contextCards.isEmpty {
+      GlassPanel {
+        VStack(alignment: .leading, spacing: 10) {
+          Text("Next")
+            .font(.headline)
+            .foregroundStyle(MobileTheme.textPrimary)
+          ForEach(viewModel.contextCards) { card in
+            Button {
+              viewModel.selectContextCard(card.id)
+            } label: {
+              HStack(alignment: .top, spacing: 10) {
+                Image(systemName: card.id == "handoff" ? "arrowshape.turn.up.right" : "brain.head.profile")
+                  .foregroundStyle(MobileTheme.cyan)
+                  .frame(width: 24)
+                VStack(alignment: .leading, spacing: 3) {
+                  HStack {
+                    Text(card.title)
+                      .font(.caption.weight(.semibold))
+                      .foregroundStyle(MobileTheme.textPrimary)
+                    Spacer()
+                    StatusChip(text: card.truthLabel, bg: MobileTheme.chipNeutralBG, fg: MobileTheme.chipNeutralFG)
+                  }
+                  Text(card.detail)
+                    .font(.caption2)
+                    .foregroundStyle(MobileTheme.textSecondary)
+                    .fixedSize(horizontal: false, vertical: true)
+                  RefPill(label: "evidence", ref: short(card.evidenceRef))
+                }
+              }
+              .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("\(card.title) card")
+            .accessibilityIdentifier("friday.chat.\(card.id)-card")
+          }
+        }
+      }
+      .accessibilityIdentifier("friday.chat.context-cards")
+    }
   }
 
   // MARK: - The 4-state loop, rendered

--- a/apps/friday-ios/Sources/FridayMobileShellCore/FridayChatViewModel.swift
+++ b/apps/friday-ios/Sources/FridayMobileShellCore/FridayChatViewModel.swift
@@ -262,6 +262,14 @@ public struct ChatHistoryItem: Identifiable, Codable, Sendable, Equatable {
   }
 }
 
+public struct ChatContextCard: Identifiable, Sendable, Equatable {
+  public let id: String
+  public let title: String
+  public let detail: String
+  public let truthLabel: String
+  public let evidenceRef: String
+}
+
 public protocol ChatHistoryStoring {
   func load() -> [ChatHistoryItem]
   func save(_ items: [ChatHistoryItem])
@@ -332,6 +340,8 @@ public enum ChatPhase: Sendable, Equatable {
 public final class FridayChatViewModel: ObservableObject {
   @Published public private(set) var phase: ChatPhase = .composing
   @Published public private(set) var history: [ChatHistoryItem]
+  @Published public private(set) var contextCards: [ChatContextCard] = []
+  @Published public private(set) var selectedContextCardId: String?
 
   /// The package write client is `Sendable`; each dispatch/control call builds a fresh transport.
   private let writeClient: FridayRustWriteClient
@@ -406,6 +416,7 @@ public final class FridayChatViewModel: ObservableObject {
           answerBodyRunId: answer?.runId,
           answerBodyOutcome: answer?.outcome)
         appendAnswerHistory(receipt)
+        contextCards = Self.contextCards(for: receipt)
         phase = .answered(receipt)
       case .paused(let p):
         // INV-2: a mutating run PAUSED — surface the S6 approval card. No mutation has executed.
@@ -413,6 +424,7 @@ public final class FridayChatViewModel: ObservableObject {
           role: "friday",
           text: "Approval required: \(p.ownerSealedSummary ?? "mutating action")",
           runId: p.runId)
+        contextCards = []
         phase = .pendingApproval(ApprovalCard(p))
       }
     } catch {
@@ -469,6 +481,7 @@ public final class FridayChatViewModel: ObservableObject {
         answerBodyRunId: answer?.runId,
         answerBodyOutcome: answer?.outcome)
       appendAnswerHistory(receipt)
+      contextCards = Self.contextCards(for: receipt)
       phase = .answered(receipt)
     } catch {
       phase = .unavailable(reason: Self.dispatchReason(for: error))
@@ -562,6 +575,7 @@ public final class FridayChatViewModel: ObservableObject {
         runId: receipt.runId,
         receiptRefs: surfacedReceipt.receiptRefs)
       phase = .resumed(surfacedReceipt)
+      contextCards = []
     } catch {
       phase = .unavailable(reason: Self.resumeReason(for: error))
     }
@@ -583,6 +597,7 @@ public final class FridayChatViewModel: ObservableObject {
         runId: receipt.runId,
         receiptRefs: surfacedReceipt.receiptRefs)
       phase = .resumed(surfacedReceipt)
+      contextCards = []
     } catch {
       phase = .unavailable(reason: Self.rejectReason(for: error))
     }
@@ -590,7 +605,14 @@ public final class FridayChatViewModel: ObservableObject {
 
   public func clearHistory() {
     history = []
+    contextCards = []
+    selectedContextCardId = nil
     historyStore.save(history)
+  }
+
+  public func selectContextCard(_ id: String) {
+    guard contextCards.contains(where: { $0.id == id }) else { return }
+    selectedContextCardId = id
   }
 
   /// Reset to a fresh composer after an answer / receipt / unavailable (start a new turn).
@@ -598,6 +620,8 @@ public final class FridayChatViewModel: ObservableObject {
     switch phase {
     case .answered, .resumed, .unavailable:
       phase = .composing
+      contextCards = []
+      selectedContextCardId = nil
     default:
       // Do NOT abandon an in-flight dispatch or a pending approval (would drop the S6 gate).
       break
@@ -653,6 +677,24 @@ public final class FridayChatViewModel: ObservableObject {
       text = "Friday answered (\(receipt.status)). Run \(receipt.runId)."
     }
     appendHistory(role: "friday", text: text, runId: receipt.answerBodyRunId ?? receipt.runId, receiptRefs: receipt.receiptRefs)
+  }
+
+  private static func contextCards(for receipt: ChatAnswerReceipt) -> [ChatContextCard] {
+    let runRef = receipt.answerBodyRunId ?? receipt.followUpRunId ?? receipt.runId
+    return [
+      ChatContextCard(
+        id: "handoff",
+        title: "Handoff",
+        detail: "Prepare a context passport from this answer when the passport send gate is available.",
+        truthLabel: "local",
+        evidenceRef: "swift://mobile/fridayChat/handoff-card/\(runRef)"),
+      ChatContextCard(
+        id: "memory",
+        title: "Memory",
+        detail: "Review memory candidates for this turn through the governed memory surface.",
+        truthLabel: "local",
+        evidenceRef: "swift://mobile/fridayChat/memory-card/\(runRef)"),
+    ]
   }
 
   private func appendHistory(role: String, text: String, runId: String? = nil, receiptRefs: [ChatReceiptRef] = []) {

--- a/apps/friday-ios/Tests/FridayMobileShellCoreTests/FridayChatViewModelTests.swift
+++ b/apps/friday-ios/Tests/FridayMobileShellCoreTests/FridayChatViewModelTests.swift
@@ -534,6 +534,11 @@ final class FridayChatViewModelTests: XCTestCase {
     guard case let .answered(answerReceipt) = sendVM.phase else {
       return XCTFail("expected answered, got \(sendVM.phase)")
     }
+    XCTAssertEqual(sendVM.contextCards.map(\.id), ["handoff", "memory"])
+    sendVM.selectContextCard("handoff")
+    XCTAssertEqual(sendVM.selectedContextCardId, "handoff")
+    sendVM.selectContextCard("memory")
+    XCTAssertEqual(sendVM.selectedContextCardId, "memory")
 
     let approveClient = FakeWriteClient(
       dispatch: .pause(makePause("run-chat-approve")),
@@ -610,9 +615,31 @@ final class FridayChatViewModelTests: XCTestCase {
           "source": "ios_chat_viewmodel_reject_runtime",
           "truth_label": "swift_viewmodel_write_client_runtime_not_live_hub_not_operator_key_not_endbar",
         ],
+        [
+          "surface": "mobile",
+          "screen": "fridayChat",
+          "action_id": "chat:handoffCard",
+          "capability_id": "ask_friday_chat",
+          "status": "pass",
+          "evidence_ref": "swift://mobile/fridayChat/handoff-card/\(answerReceipt.runId)",
+          "source": "ios_chat_viewmodel_context_card_runtime",
+          "truth_label": "swift_viewmodel_local_affordance_runtime_not_passport_send_not_endbar",
+        ],
+        [
+          "surface": "mobile",
+          "screen": "fridayChat",
+          "action_id": "chat:memoryCard",
+          "capability_id": "ask_friday_chat",
+          "status": "pass",
+          "evidence_ref": "swift://mobile/fridayChat/memory-card/\(answerReceipt.runId)",
+          "source": "ios_chat_viewmodel_context_card_runtime",
+          "truth_label": "swift_viewmodel_local_affordance_runtime_not_memory_decision_not_endbar",
+        ],
       ],
       proof: [
         "send_run_id": answerReceipt.runId,
+        "context_card_ids": sendVM.contextCards.map(\.id),
+        "selected_context_card_id": sendVM.selectedContextCardId ?? "",
         "approval_card_run_id": approvalCard.runId,
         "approval_card_digest_len": approvalCard.actionDigest.count,
         "approve_run_id": approveReceipt.runId,

--- a/scripts/ops/friday-mobile-chat-action-evidence.sh
+++ b/scripts/ops/friday-mobile-chat-action-evidence.sh
@@ -4,10 +4,11 @@
 #
 # Truth boundary:
 #   Runs iOS Swift product ViewModel tests and exports explicit action-runtime evidence for
-#   Friday Chat send, approval-card render, approve relay, and reject relay. This proves the
-#   product ViewModel delegates to governed write/sign/reject seams and renders refs-only
-#   results. It does not start or mutate prod Hub, use the operator's true signing key, prove
-#   live Hub audit receipts, drive a real simulator tap, claim END-BAR, or prove adoption.
+#   Friday Chat send, approval-card render, approve relay, reject relay, and local context-card
+#   affordances. This proves the product ViewModel delegates to governed write/sign/reject seams
+#   and renders refs-only results. It does not start or mutate prod Hub, use the operator's true
+#   signing key, prove live Hub audit receipts, drive a real simulator tap, claim END-BAR, or
+#   prove adoption.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -65,6 +66,8 @@ for (const expected of [
   ["mobile", "fridayChat", "chat:approveCard", "ask_friday_chat"],
   ["mobile", "fridayChat", "check", "security_approval_bound_principal_gate_cat10_netnew"],
   ["mobile", "fridayChat", "act", "security_approval_bound_principal_gate_cat10_netnew"],
+  ["mobile", "fridayChat", "chat:handoffCard", "ask_friday_chat"],
+  ["mobile", "fridayChat", "chat:memoryCard", "ask_friday_chat"],
 ]) {
   const found = actions.some((row) =>
     row.surface === expected[0]


### PR DESCRIPTION
## Summary
- add refs-only handoff and memory context cards after Friday Chat answers
- wire local card selection state into the mobile Chat UI
- extend the mobile chat action evidence wrapper to fail-close on both context-card affordances

## Verification
- `FRIDAY_MOBILE_CHAT_ACTION_EVIDENCE_DIR=/tmp/friday-mobile-chat-context-cards-evidence-verify-20260625T140500Z scripts/ops/friday-mobile-chat-action-evidence.sh`
- `apps/friday-ios/build-sim.sh --mode offline-truth --destination chat --shot /tmp/friday-mobile-chat-context-cards-sim-20260625T140900Z.png`
- `node scripts/ops/check-friday-design-action-runtime-evidence.mjs --repo-root=/private/tmp/friday-mobile-chat-context-cards-20260625 --contract=/Users/jarvis/Desktop/friday-design-handoff-20260602/ACTION-CONTRACT.md --runtime-evidence=/tmp/friday-mobile-memory-resolve-action-evidence-verify-20260625T134800Z/action-runtime-evidence.json --runtime-evidence=/tmp/friday-desktop-chat-memory-action-evidence-verify-20260625T132400Z/action-runtime-evidence.json --runtime-evidence=/tmp/friday-mobile-approval-reject-live-20260625T125127Z/action-runtime-evidence.json --runtime-evidence=/tmp/friday-mobile-firstlaunch-action-evidence-verify-20260625T134000Z/action-runtime-evidence.json --runtime-evidence=/tmp/friday-mobile-session-sidecar-action-evidence-verify-20260625T130000Z/action-runtime-evidence.json --runtime-evidence=/tmp/friday-mobile-new-session-action-evidence-verify-20260625T131300Z/action-runtime-evidence.json --runtime-evidence=/tmp/friday-mobile-chat-context-cards-evidence-verify-20260625T140500Z/action-runtime-evidence.json --runtime-evidence=/tmp/friday-mobile-workflow-action-evidence-verify-20260625T135500Z/action-runtime-evidence.json --out=/tmp/friday-design-action-runtime-gap-20260625T140700Z.json`

## Truth label
- partial mobile Chat context-card affordance evidence only
- does not prove passport send, memory keep/reject decision, live Hub audit, simulator tap on this screen, END-BAR, or adoption
- combined design-action checker still reports 5 unique runtime gaps`