### PR TITLE
feat(mobile): wire chat memory decisions

### DIFF
--- a/apps/friday-ios/Sources/FridayMobileShell/FridayChatScreen.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayChatScreen.swift
@@ -67,37 +67,89 @@ struct FridayChatScreen: View {
             .font(.headline)
             .foregroundStyle(MobileTheme.textPrimary)
           ForEach(viewModel.contextCards) { card in
-            Button {
-              viewModel.selectContextCard(card.id)
-            } label: {
-              HStack(alignment: .top, spacing: 10) {
-                Image(systemName: card.id == "handoff" ? "arrowshape.turn.up.right" : "brain.head.profile")
-                  .foregroundStyle(MobileTheme.cyan)
-                  .frame(width: 24)
-                VStack(alignment: .leading, spacing: 3) {
-                  HStack {
-                    Text(card.title)
-                      .font(.caption.weight(.semibold))
-                      .foregroundStyle(MobileTheme.textPrimary)
-                    Spacer()
-                    StatusChip(text: card.truthLabel, bg: MobileTheme.chipNeutralBG, fg: MobileTheme.chipNeutralFG)
-                  }
-                  Text(card.detail)
-                    .font(.caption2)
-                    .foregroundStyle(MobileTheme.textSecondary)
-                    .fixedSize(horizontal: false, vertical: true)
-                  RefPill(label: "evidence", ref: short(card.evidenceRef))
-                }
-              }
-              .frame(maxWidth: .infinity, alignment: .leading)
-            }
-            .buttonStyle(.plain)
-            .accessibilityLabel("\(card.title) card")
-            .accessibilityIdentifier("friday.chat.\(card.id)-card")
+            contextCardRow(card)
           }
         }
       }
       .accessibilityIdentifier("friday.chat.context-cards")
+    }
+  }
+
+  private func contextCardRow(_ card: ChatContextCard) -> some View {
+    HStack(alignment: .top, spacing: 10) {
+      Image(systemName: card.id == "handoff" ? "arrowshape.turn.up.right" : "brain.head.profile")
+        .foregroundStyle(MobileTheme.cyan)
+        .frame(width: 24)
+      VStack(alignment: .leading, spacing: 3) {
+        HStack {
+          Text(card.title)
+            .font(.caption.weight(.semibold))
+            .foregroundStyle(MobileTheme.textPrimary)
+          Spacer()
+          StatusChip(text: card.truthLabel, bg: MobileTheme.chipNeutralBG, fg: MobileTheme.chipNeutralFG)
+        }
+        Text(card.detail)
+          .font(.caption2)
+          .foregroundStyle(MobileTheme.textSecondary)
+          .fixedSize(horizontal: false, vertical: true)
+        RefPill(label: "evidence", ref: short(card.evidenceRef))
+        if card.id == "memory", card.memoryCandidateId != nil {
+          memoryDecisionControls
+        }
+        if card.id == "memory", let state = viewModel.contextMemoryDecisionState {
+          candidateDecisionStateView(state)
+        }
+      }
+    }
+    .frame(maxWidth: .infinity, alignment: .leading)
+    .contentShape(Rectangle())
+    .onTapGesture { viewModel.selectContextCard(card.id) }
+    .accessibilityElement(children: .contain)
+    .accessibilityLabel("\(card.title) card")
+    .accessibilityIdentifier("friday.chat.\(card.id)-card")
+  }
+
+  private var memoryDecisionControls: some View {
+    HStack(spacing: 8) {
+      Button {
+        Task { await viewModel.decideContextMemory(confirm: true) }
+      } label: {
+        Image(systemName: "checkmark")
+          .frame(width: 26, height: 26)
+      }
+      .buttonStyle(.borderedProminent)
+      .tint(MobileTheme.cyan)
+      .disabled(viewModel.contextMemoryDecisionState?.isSent == true)
+      .accessibilityLabel("Keep memory candidate")
+      .accessibilityIdentifier("friday.chat.memory-card.keep")
+
+      Button {
+        Task { await viewModel.decideContextMemory(confirm: false) }
+      } label: {
+        Image(systemName: "xmark")
+          .frame(width: 26, height: 26)
+      }
+      .buttonStyle(.bordered)
+      .disabled(viewModel.contextMemoryDecisionState?.isSent == true)
+      .accessibilityLabel("Reject memory candidate")
+      .accessibilityIdentifier("friday.chat.memory-card.reject")
+    }
+  }
+
+  @ViewBuilder private func candidateDecisionStateView(_ state: HomeLearningDecisionState) -> some View {
+    switch state {
+    case .sent:
+      StatusChip(text: "sending", bg: MobileTheme.chipNeutralBG, fg: MobileTheme.chipNeutralFG)
+    case .confirmed(let summary):
+      Text(summary)
+        .font(.caption2)
+        .foregroundStyle(MobileTheme.textSecondary)
+        .fixedSize(horizontal: false, vertical: true)
+    case .error(let reason):
+      Text(reason)
+        .font(.caption2)
+        .foregroundStyle(MobileTheme.chipWarnFG)
+        .fixedSize(horizontal: false, vertical: true)
     }
   }
 

--- a/apps/friday-ios/Sources/FridayMobileShellCore/FridayChatViewModel.swift
+++ b/apps/friday-ios/Sources/FridayMobileShellCore/FridayChatViewModel.swift
@@ -268,6 +268,8 @@ public struct ChatContextCard: Identifiable, Sendable, Equatable {
   public let detail: String
   public let truthLabel: String
   public let evidenceRef: String
+  public let memoryCandidateId: String?
+  public let memoryPreview: String?
 }
 
 public protocol ChatHistoryStoring {
@@ -342,10 +344,12 @@ public final class FridayChatViewModel: ObservableObject {
   @Published public private(set) var history: [ChatHistoryItem]
   @Published public private(set) var contextCards: [ChatContextCard] = []
   @Published public private(set) var selectedContextCardId: String?
+  @Published public private(set) var contextMemoryDecisionState: HomeLearningDecisionState?
 
   /// The package write client is `Sendable`; each dispatch/control call builds a fresh transport.
   private let writeClient: FridayRustWriteClient
   private let missionClient: (any FridayMobileMissionDispatchingWriteClient)?
+  private let memoryDecisionClient: (any FridayMissionSpineWriteClient)?
   private let readClient: FridayRustReadClient?
   private let signer: OperatorSigner
   private let newId: () -> String
@@ -362,6 +366,7 @@ public final class FridayChatViewModel: ObservableObject {
     writeClient: FridayRustWriteClient,
     signer: OperatorSigner,
     missionClient: (any FridayMobileMissionDispatchingWriteClient)? = nil,
+    memoryDecisionClient: (any FridayMissionSpineWriteClient)? = nil,
     readClient: FridayRustReadClient? = nil,
     historyStore: any ChatHistoryStoring = UserDefaultsChatHistoryStore(),
     newId: @escaping () -> String = { UUID().uuidString.lowercased().replacingOccurrences(of: "-", with: "") },
@@ -371,6 +376,7 @@ public final class FridayChatViewModel: ObservableObject {
     self.writeClient = writeClient
     self.signer = signer
     self.missionClient = missionClient
+    self.memoryDecisionClient = memoryDecisionClient ?? (writeClient as? any FridayMissionSpineWriteClient)
     self.readClient = readClient
     self.historyStore = historyStore
     self.newId = newId
@@ -416,7 +422,7 @@ public final class FridayChatViewModel: ObservableObject {
           answerBodyRunId: answer?.runId,
           answerBodyOutcome: answer?.outcome)
         appendAnswerHistory(receipt)
-        contextCards = Self.contextCards(for: receipt)
+        contextCards = Self.contextCards(for: receipt, memoryCandidate: await firstMemoryCandidate())
         phase = .answered(receipt)
       case .paused(let p):
         // INV-2: a mutating run PAUSED — surface the S6 approval card. No mutation has executed.
@@ -481,7 +487,7 @@ public final class FridayChatViewModel: ObservableObject {
         answerBodyRunId: answer?.runId,
         answerBodyOutcome: answer?.outcome)
       appendAnswerHistory(receipt)
-      contextCards = Self.contextCards(for: receipt)
+      contextCards = Self.contextCards(for: receipt, memoryCandidate: await firstMemoryCandidate())
       phase = .answered(receipt)
     } catch {
       phase = .unavailable(reason: Self.dispatchReason(for: error))
@@ -529,6 +535,16 @@ public final class FridayChatViewModel: ObservableObject {
         return nil
       }
       return (body.runId, answer, body.outcome)
+    } catch {
+      return nil
+    }
+  }
+
+  private func firstMemoryCandidate() async -> HomeMemoryCandidate? {
+    guard let readClient else { return nil }
+    do {
+      let snapshot = try await readClient.fetchWorkbench()
+      return HomeProjection(snapshot).memoryCandidates.first
     } catch {
       return nil
     }
@@ -607,12 +623,53 @@ public final class FridayChatViewModel: ObservableObject {
     history = []
     contextCards = []
     selectedContextCardId = nil
+    contextMemoryDecisionState = nil
     historyStore.save(history)
   }
 
   public func selectContextCard(_ id: String) {
     guard contextCards.contains(where: { $0.id == id }) else { return }
     selectedContextCardId = id
+  }
+
+  public func decideContextMemory(confirm: Bool) async {
+    let card = contextCards.first { $0.id == "memory" }
+    guard let memoryId = card?.memoryCandidateId, !memoryId.isEmpty else {
+      contextMemoryDecisionState = .error(reason: "No memory candidate is available for this Chat turn.")
+      return
+    }
+    guard let memoryDecisionClient else {
+      contextMemoryDecisionState = .error(reason: "Write seam not configured.")
+      return
+    }
+
+    selectedContextCardId = "memory"
+    contextMemoryDecisionState = .sent
+    let request = MemoryDecisionRequestWire(
+      memoryId: memoryId,
+      ownerPrincipal: liveAgentRunOwnerPrincipal,
+      decision: confirm ? "confirm" : "reject")
+    do {
+      let result = try await memoryDecisionClient.submitMemoryDecision(request)
+      switch result.status {
+      case "confirmed", "rejected":
+        contextMemoryDecisionState = .confirmed(
+          summary: "\(result.status) · state=\(result.state) · recallable=\(result.recallable)")
+        appendHistory(
+          role: "friday",
+          text: "Memory decision \(result.status).",
+          receiptRefs: [
+            ChatReceiptRef(label: "memory_id", ref: result.memoryId),
+            ChatReceiptRef(label: "status", ref: result.status),
+            ChatReceiptRef(label: "state", ref: result.state),
+          ])
+      default:
+        let why = result.blocker ?? "blocked"
+        contextMemoryDecisionState = .error(reason: "Memory decision blocked — \(why)")
+      }
+    } catch {
+      contextMemoryDecisionState = .error(reason: Self.memoryReason(for: error))
+    }
   }
 
   /// Reset to a fresh composer after an answer / receipt / unavailable (start a new turn).
@@ -622,6 +679,7 @@ public final class FridayChatViewModel: ObservableObject {
       phase = .composing
       contextCards = []
       selectedContextCardId = nil
+      contextMemoryDecisionState = nil
     default:
       // Do NOT abandon an in-flight dispatch or a pending approval (would drop the S6 gate).
       break
@@ -648,6 +706,11 @@ public final class FridayChatViewModel: ObservableObject {
   static func signerReason(for error: Error) -> String {
     if let e = error as? OperatorSignerError { return e.description }
     return "Approval unavailable — \(error)"
+  }
+
+  static func memoryReason(for error: Error) -> String {
+    if let e = error as? FridayWriteClientError { return writeReason(e, verb: "memory decision") }
+    return "Memory decision unavailable — \(error)"
   }
 
   private static func writeReason(_ e: FridayWriteClientError, verb: String) -> String {
@@ -679,7 +742,10 @@ public final class FridayChatViewModel: ObservableObject {
     appendHistory(role: "friday", text: text, runId: receipt.answerBodyRunId ?? receipt.runId, receiptRefs: receipt.receiptRefs)
   }
 
-  private static func contextCards(for receipt: ChatAnswerReceipt) -> [ChatContextCard] {
+  private static func contextCards(
+    for receipt: ChatAnswerReceipt,
+    memoryCandidate: HomeMemoryCandidate?
+  ) -> [ChatContextCard] {
     let runRef = receipt.answerBodyRunId ?? receipt.followUpRunId ?? receipt.runId
     return [
       ChatContextCard(
@@ -687,13 +753,17 @@ public final class FridayChatViewModel: ObservableObject {
         title: "Handoff",
         detail: "Prepare a context passport from this answer when the passport send gate is available.",
         truthLabel: "local",
-        evidenceRef: "swift://mobile/fridayChat/handoff-card/\(runRef)"),
+        evidenceRef: "swift://mobile/fridayChat/handoff-card/\(runRef)",
+        memoryCandidateId: nil,
+        memoryPreview: nil),
       ChatContextCard(
         id: "memory",
         title: "Memory",
-        detail: "Review memory candidates for this turn through the governed memory surface.",
-        truthLabel: "local",
-        evidenceRef: "swift://mobile/fridayChat/memory-card/\(runRef)"),
+        detail: memoryCandidate?.preview ?? "Review memory candidates for this turn through the governed memory surface.",
+        truthLabel: memoryCandidate == nil ? "local" : "wired",
+        evidenceRef: memoryCandidate?.evidenceRef ?? "swift://mobile/fridayChat/memory-card/\(runRef)",
+        memoryCandidateId: memoryCandidate?.id,
+        memoryPreview: memoryCandidate?.preview),
     ]
   }
 

--- a/apps/friday-ios/Tests/FridayMobileShellCoreTests/FridayChatViewModelTests.swift
+++ b/apps/friday-ios/Tests/FridayMobileShellCoreTests/FridayChatViewModelTests.swift
@@ -90,9 +90,23 @@ final class FridayChatViewModelTests: XCTestCase {
   }
 
   final class FakeMissionClient: FridayMobileMissionDispatchingWriteClient, @unchecked Sendable {
+    enum MemoryScript { case result(MemoryDecisionResultWire); case fail(FridayWriteClientError) }
+
     private(set) var submittedIntakes: [MissionIntakeRequestWire] = []
     private(set) var missionContexts: [MissionWorkItemContextWire] = []
     private(set) var dispatchedTasks: [String] = []
+    private(set) var memoryRequests: [MemoryDecisionRequestWire] = []
+    let memoryScript: MemoryScript
+
+    init(memoryScript: MemoryScript = .result(MemoryDecisionResultWire(
+      memoryId: "unused",
+      state: "unknown",
+      status: "blocked",
+      blocker: "unused",
+      recallable: false))
+    ) {
+      self.memoryScript = memoryScript
+    }
 
     func dispatchAgentRun(
       task: String,
@@ -127,12 +141,11 @@ final class FridayChatViewModelTests: XCTestCase {
     }
 
     func submitMemoryDecision(_ request: MemoryDecisionRequestWire) async throws -> MemoryDecisionResultWire {
-      MemoryDecisionResultWire(
-        memoryId: request.memoryId,
-        state: "unknown",
-        status: "blocked",
-        blocker: "unused",
-        recallable: false)
+      memoryRequests.append(request)
+      switch memoryScript {
+      case .result(let result): return result
+      case .fail(let error): throw error
+      }
     }
 
     func submitRunOutcomeLearningDecision(
@@ -239,6 +252,16 @@ final class FridayChatViewModelTests: XCTestCase {
   private func makePause(_ runId: String = "run-1") -> PausedOutcome {
     PausedOutcome(runId: runId, approvalId: "ap-nonce-\(runId)",
                   actionDigest: String(repeating: "c", count: 64), ownerSealedSummary: "write_file(notes.md)")
+  }
+
+  private func makeMemoryCandidateSnapshot(id: String = "cand-chat-1") throws -> WorkbenchSnapshot {
+    try WorkbenchSnapshot(
+      projectionJSON: Data("""
+      {"missionId":"mission-chat","fridayConversationId":"fconv-chat",\
+      "runtimeFeedStatus":"live_rust_hub_projection","statusLabels":[],"workItems":[],\
+      "memoryCandidates":[{"id":"\(id)","preview":"Remember Friday prefers batched PRs","state":"candidate_review_only","grantsMemoryAuthority":false,"evidenceRef":"proof://mobile/fridayChat/memory/\(id)"}]}
+      """.utf8),
+      generatedAtMs: 0)
   }
 
   private func writeMobileChatActionEvidenceIfRequested(
@@ -573,6 +596,50 @@ final class FridayChatViewModelTests: XCTestCase {
       return XCTFail("expected reject receipt, got \(rejectVM.phase)")
     }
 
+    let memoryRead = FakeReadClient(snapshot: try makeMemoryCandidateSnapshot())
+    let keepMemoryClient = FakeMissionClient(memoryScript: .result(MemoryDecisionResultWire(
+      memoryId: "cand-chat-1",
+      state: "confirmed",
+      status: "confirmed",
+      recallable: true)))
+    let keepMemoryVM = FridayChatViewModel(
+      writeClient: keepMemoryClient,
+      signer: MockOperatorSigner(),
+      readClient: memoryRead)
+    await keepMemoryVM.send("summarize the memory candidate")
+    XCTAssertEqual(keepMemoryVM.contextCards.first(where: { $0.id == "memory" })?.memoryCandidateId, "cand-chat-1")
+    await keepMemoryVM.decideContextMemory(confirm: true)
+    XCTAssertEqual(keepMemoryClient.memoryRequests, [
+      MemoryDecisionRequestWire(
+        memoryId: "cand-chat-1",
+        ownerPrincipal: liveAgentRunOwnerPrincipal,
+        decision: "confirm"),
+    ])
+    XCTAssertEqual(
+      keepMemoryVM.contextMemoryDecisionState,
+      .confirmed(summary: "confirmed · state=confirmed · recallable=true"))
+
+    let rejectMemoryClient = FakeMissionClient(memoryScript: .result(MemoryDecisionResultWire(
+      memoryId: "cand-chat-1",
+      state: "rejected",
+      status: "rejected",
+      recallable: false)))
+    let rejectMemoryVM = FridayChatViewModel(
+      writeClient: rejectMemoryClient,
+      signer: MockOperatorSigner(),
+      readClient: memoryRead)
+    await rejectMemoryVM.send("summarize the memory candidate")
+    await rejectMemoryVM.decideContextMemory(confirm: false)
+    XCTAssertEqual(rejectMemoryClient.memoryRequests, [
+      MemoryDecisionRequestWire(
+        memoryId: "cand-chat-1",
+        ownerPrincipal: liveAgentRunOwnerPrincipal,
+        decision: "reject"),
+    ])
+    XCTAssertEqual(
+      rejectMemoryVM.contextMemoryDecisionState,
+      .confirmed(summary: "rejected · state=rejected · recallable=false"))
+
     try writeMobileChatActionEvidenceIfRequested(
       actions: [
         [
@@ -635,11 +702,34 @@ final class FridayChatViewModelTests: XCTestCase {
           "source": "ios_chat_viewmodel_context_card_runtime",
           "truth_label": "swift_viewmodel_local_affordance_runtime_not_memory_decision_not_endbar",
         ],
+        [
+          "surface": "mobile",
+          "screen": "fridayChat",
+          "action_id": "check",
+          "capability_id": "memory_review_no_silent_write_decide_candidate",
+          "status": "pass",
+          "evidence_ref": "swift://mobile/fridayChat/memory/confirm/cand-chat-1",
+          "source": "ios_chat_viewmodel_memory_decision_runtime",
+          "truth_label": "swift_viewmodel_memory_decision_write_seam_runtime_not_live_hub_not_endbar",
+        ],
+        [
+          "surface": "mobile",
+          "screen": "fridayChat",
+          "action_id": "act",
+          "capability_id": "memory_review_no_silent_write_decide_candidate",
+          "status": "pass",
+          "evidence_ref": "swift://mobile/fridayChat/memory/reject/cand-chat-1",
+          "source": "ios_chat_viewmodel_memory_decision_runtime",
+          "truth_label": "swift_viewmodel_memory_decision_write_seam_runtime_not_live_hub_not_endbar",
+        ],
       ],
       proof: [
         "send_run_id": answerReceipt.runId,
         "context_card_ids": sendVM.contextCards.map(\.id),
         "selected_context_card_id": sendVM.selectedContextCardId ?? "",
+        "memory_candidate_id": "cand-chat-1",
+        "memory_keep_request_count": keepMemoryClient.memoryRequests.count,
+        "memory_reject_request_count": rejectMemoryClient.memoryRequests.count,
         "approval_card_run_id": approvalCard.runId,
         "approval_card_digest_len": approvalCard.actionDigest.count,
         "approve_run_id": approveReceipt.runId,

--- a/scripts/ops/friday-mobile-chat-action-evidence.sh
+++ b/scripts/ops/friday-mobile-chat-action-evidence.sh
@@ -68,6 +68,8 @@ for (const expected of [
   ["mobile", "fridayChat", "act", "security_approval_bound_principal_gate_cat10_netnew"],
   ["mobile", "fridayChat", "chat:handoffCard", "ask_friday_chat"],
   ["mobile", "fridayChat", "chat:memoryCard", "ask_friday_chat"],
+  ["mobile", "fridayChat", "check", "memory_review_no_silent_write_decide_candidate"],
+  ["mobile", "fridayChat", "act", "memory_review_no_silent_write_decide_candidate"],
 ]) {
   const found = actions.some((row) =>
     row.surface === expected[0]


### PR DESCRIPTION
## Summary
- attach pending memory-candidate context to Friday Chat memory cards when the read projection exposes one
- route Chat memory keep/reject through the existing sealed `submitMemoryDecision` write seam
- extend the mobile chat action evidence wrapper to fail-close on memory-review keep/reject rows

## Verification
- `FRIDAY_MOBILE_CHAT_ACTION_EVIDENCE_DIR=/tmp/friday-mobile-chat-memory-decisions-evidence-verify-20260625T142000Z scripts/ops/friday-mobile-chat-action-evidence.sh`
- `apps/friday-ios/build-sim.sh --mode offline-truth --destination chat --shot /tmp/friday-mobile-chat-memory-decisions-sim-20260625T142300Z.png`
- `node scripts/ops/check-friday-design-action-runtime-evidence.mjs --repo-root=/private/tmp/friday-mobile-chat-memory-decisions-20260625 --contract=/Users/jarvis/Desktop/friday-design-handoff-20260602/ACTION-CONTRACT.md --runtime-evidence=/tmp/friday-mobile-memory-resolve-action-evidence-verify-20260625T134800Z/action-runtime-evidence.json --runtime-evidence=/tmp/friday-desktop-chat-memory-action-evidence-verify-20260625T132400Z/action-runtime-evidence.json --runtime-evidence=/tmp/friday-mobile-approval-reject-live-20260625T125127Z/action-runtime-evidence.json --runtime-evidence=/tmp/friday-mobile-firstlaunch-action-evidence-verify-20260625T134000Z/action-runtime-evidence.json --runtime-evidence=/tmp/friday-mobile-session-sidecar-action-evidence-verify-20260625T130000Z/action-runtime-evidence.json --runtime-evidence=/tmp/friday-mobile-new-session-action-evidence-verify-20260625T131300Z/action-runtime-evidence.json --runtime-evidence=/tmp/friday-mobile-chat-memory-decisions-evidence-verify-20260625T142000Z/action-runtime-evidence.json --runtime-evidence=/tmp/friday-mobile-workflow-action-evidence-verify-20260625T135500Z/action-runtime-evidence.json --out=/tmp/friday-design-action-runtime-gap-20260625T142100Z.json`

## Truth label
- uses the existing memory-decision write seam from the Chat surface
- does not create a new memory backend, does not prove live Hub audit/adoption/END-BAR
- combined design-action checker still reports 3 unique runtime gaps: mobile approval approve, chat handoff share, passport send`