### PR TITLE
feat(mobile): batch action closure surfaces

### DIFF
--- a/apps/friday-ios/Sources/FridayMobileShell/CommandSheet.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/CommandSheet.swift
@@ -64,6 +64,7 @@ enum MobileDestination: String, CaseIterable, Identifiable {
   case shareIntake
   case voice
   case pairing
+  case newSession
   case needsMe
   case memory
   case platform
@@ -85,6 +86,7 @@ enum MobileDestination: String, CaseIterable, Identifiable {
     case .shareIntake: return "Share Intake"
     case .voice: return "Voice"
     case .pairing: return "Device Pairing"
+    case .newSession: return "New Session"
     case .needsMe: return "Needs Me"
     case .memory: return "Memory"
     case .platform: return "Platform"
@@ -106,6 +108,7 @@ enum MobileDestination: String, CaseIterable, Identifiable {
     case .shareIntake: return "square.and.arrow.down"
     case .voice: return "waveform"
     case .pairing: return "qrcode.viewfinder"
+    case .newSession: return "plus"
     case .needsMe: return "person.crop.circle.badge.exclamationmark"
     case .memory: return "brain.head.profile"
     case .platform: return "square.grid.2x2"
@@ -128,6 +131,8 @@ enum MobileDestination: String, CaseIterable, Identifiable {
     case .providerAuth:
       return .providerWorkspace
     case .shareIntake, .needsMe:
+      return .governedActionGated
+    case .newSession:
       return .governedActionGated
     case .voice, .pairing:
       return .readinessOnly

--- a/apps/friday-ios/Sources/FridayMobileShell/FridayApp.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayApp.swift
@@ -329,6 +329,7 @@ struct RootView: View {
   @StateObject private var homeVM: HomeViewModel
   @StateObject private var sessionContinuationVM: SessionContinuationViewModel
   @StateObject private var shareIntakeVM: ShareIntakeViewModel
+  @StateObject private var newSessionVM: NewSessionViewModel
   @StateObject private var voiceVM: VoiceReadinessViewModel
   private let session: FridaySession
   @State private var destination: MobileDestination = .home
@@ -360,6 +361,7 @@ struct RootView: View {
       signer: session.signer,
       runControlEnabled: session.runControlEnabled))
     _shareIntakeVM = StateObject(wrappedValue: ShareIntakeViewModel(client: session.missionClient))
+    _newSessionVM = StateObject(wrappedValue: NewSessionViewModel(client: session.missionClient))
     _voiceVM = StateObject(wrappedValue: VoiceReadinessViewModel(
       authorizer: SystemVoiceReadinessAuthorizer()))
   }
@@ -378,6 +380,8 @@ struct RootView: View {
           FridayTokenLedgerScreen(viewModel: homeVM)
         case .shareIntake:
           FridayShareIntakeScreen(viewModel: shareIntakeVM)
+        case .newSession:
+          FridayNewSessionScreen(viewModel: newSessionVM)
         case .voice:
           FridayVoiceScreen(viewModel: voiceVM)
         case .pairing:

--- a/apps/friday-ios/Sources/FridayMobileShell/FridayChatScreen.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayChatScreen.swift
@@ -47,6 +47,7 @@ struct FridayChatScreen: View {
 
           historyCard
           phaseCard
+          contextCards
         }
         .padding(16)
       }
@@ -56,6 +57,48 @@ struct FridayChatScreen: View {
     .background(MobileTheme.backgroundWarmOffWhite.ignoresSafeArea())
     .navigationTitle("Friday Chat")
     .navigationBarTitleDisplayMode(.inline)
+  }
+
+  @ViewBuilder private var contextCards: some View {
+    if !viewModel.contextCards.isEmpty {
+      GlassPanel {
+        VStack(alignment: .leading, spacing: 10) {
+          Text("Next")
+            .font(.headline)
+            .foregroundStyle(MobileTheme.textPrimary)
+          ForEach(viewModel.contextCards) { card in
+            Button {
+              viewModel.selectContextCard(card.id)
+            } label: {
+              HStack(alignment: .top, spacing: 10) {
+                Image(systemName: card.id == "handoff" ? "arrowshape.turn.up.right" : "brain.head.profile")
+                  .foregroundStyle(MobileTheme.cyan)
+                  .frame(width: 24)
+                VStack(alignment: .leading, spacing: 3) {
+                  HStack {
+                    Text(card.title)
+                      .font(.caption.weight(.semibold))
+                      .foregroundStyle(MobileTheme.textPrimary)
+                    Spacer()
+                    StatusChip(text: card.truthLabel, bg: MobileTheme.chipNeutralBG, fg: MobileTheme.chipNeutralFG)
+                  }
+                  Text(card.detail)
+                    .font(.caption2)
+                    .foregroundStyle(MobileTheme.textSecondary)
+                    .fixedSize(horizontal: false, vertical: true)
+                  RefPill(label: "evidence", ref: short(card.evidenceRef))
+                }
+              }
+              .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("\(card.title) card")
+            .accessibilityIdentifier("friday.chat.\(card.id)-card")
+          }
+        }
+      }
+      .accessibilityIdentifier("friday.chat.context-cards")
+    }
   }
 
   // MARK: - The 4-state loop, rendered

--- a/apps/friday-ios/Sources/FridayMobileShell/FridayChatScreen.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayChatScreen.swift
@@ -93,6 +93,12 @@ struct FridayChatScreen: View {
           .foregroundStyle(MobileTheme.textSecondary)
           .fixedSize(horizontal: false, vertical: true)
         RefPill(label: "evidence", ref: short(card.evidenceRef))
+        if card.id == "handoff" {
+          handoffControls
+        }
+        if card.id == "handoff", let state = viewModel.contextPassportTransferState {
+          candidateDecisionStateView(state)
+        }
         if card.id == "memory", card.memoryCandidateId != nil {
           memoryDecisionControls
         }
@@ -107,6 +113,18 @@ struct FridayChatScreen: View {
     .accessibilityElement(children: .contain)
     .accessibilityLabel("\(card.title) card")
     .accessibilityIdentifier("friday.chat.\(card.id)-card")
+  }
+
+  private var handoffControls: some View {
+    Button {
+      Task { await viewModel.submitContextPassportHandoff() }
+    } label: {
+      Label("Create handoff", systemImage: "arrowshape.turn.up.right")
+        .font(.caption.weight(.semibold))
+    }
+    .buttonStyle(.bordered)
+    .disabled(viewModel.contextPassportTransferState?.isSent == true)
+    .accessibilityIdentifier("friday.chat.handoff-card.share")
   }
 
   private var memoryDecisionControls: some View {

--- a/apps/friday-ios/Sources/FridayMobileShell/FridayChatScreen.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayChatScreen.swift
@@ -67,37 +67,89 @@ struct FridayChatScreen: View {
             .font(.headline)
             .foregroundStyle(MobileTheme.textPrimary)
           ForEach(viewModel.contextCards) { card in
-            Button {
-              viewModel.selectContextCard(card.id)
-            } label: {
-              HStack(alignment: .top, spacing: 10) {
-                Image(systemName: card.id == "handoff" ? "arrowshape.turn.up.right" : "brain.head.profile")
-                  .foregroundStyle(MobileTheme.cyan)
-                  .frame(width: 24)
-                VStack(alignment: .leading, spacing: 3) {
-                  HStack {
-                    Text(card.title)
-                      .font(.caption.weight(.semibold))
-                      .foregroundStyle(MobileTheme.textPrimary)
-                    Spacer()
-                    StatusChip(text: card.truthLabel, bg: MobileTheme.chipNeutralBG, fg: MobileTheme.chipNeutralFG)
-                  }
-                  Text(card.detail)
-                    .font(.caption2)
-                    .foregroundStyle(MobileTheme.textSecondary)
-                    .fixedSize(horizontal: false, vertical: true)
-                  RefPill(label: "evidence", ref: short(card.evidenceRef))
-                }
-              }
-              .frame(maxWidth: .infinity, alignment: .leading)
-            }
-            .buttonStyle(.plain)
-            .accessibilityLabel("\(card.title) card")
-            .accessibilityIdentifier("friday.chat.\(card.id)-card")
+            contextCardRow(card)
           }
         }
       }
       .accessibilityIdentifier("friday.chat.context-cards")
+    }
+  }
+
+  private func contextCardRow(_ card: ChatContextCard) -> some View {
+    HStack(alignment: .top, spacing: 10) {
+      Image(systemName: card.id == "handoff" ? "arrowshape.turn.up.right" : "brain.head.profile")
+        .foregroundStyle(MobileTheme.cyan)
+        .frame(width: 24)
+      VStack(alignment: .leading, spacing: 3) {
+        HStack {
+          Text(card.title)
+            .font(.caption.weight(.semibold))
+            .foregroundStyle(MobileTheme.textPrimary)
+          Spacer()
+          StatusChip(text: card.truthLabel, bg: MobileTheme.chipNeutralBG, fg: MobileTheme.chipNeutralFG)
+        }
+        Text(card.detail)
+          .font(.caption2)
+          .foregroundStyle(MobileTheme.textSecondary)
+          .fixedSize(horizontal: false, vertical: true)
+        RefPill(label: "evidence", ref: short(card.evidenceRef))
+        if card.id == "memory", card.memoryCandidateId != nil {
+          memoryDecisionControls
+        }
+        if card.id == "memory", let state = viewModel.contextMemoryDecisionState {
+          candidateDecisionStateView(state)
+        }
+      }
+    }
+    .frame(maxWidth: .infinity, alignment: .leading)
+    .contentShape(Rectangle())
+    .onTapGesture { viewModel.selectContextCard(card.id) }
+    .accessibilityElement(children: .contain)
+    .accessibilityLabel("\(card.title) card")
+    .accessibilityIdentifier("friday.chat.\(card.id)-card")
+  }
+
+  private var memoryDecisionControls: some View {
+    HStack(spacing: 8) {
+      Button {
+        Task { await viewModel.decideContextMemory(confirm: true) }
+      } label: {
+        Image(systemName: "checkmark")
+          .frame(width: 26, height: 26)
+      }
+      .buttonStyle(.borderedProminent)
+      .tint(MobileTheme.cyan)
+      .disabled(viewModel.contextMemoryDecisionState?.isSent == true)
+      .accessibilityLabel("Keep memory candidate")
+      .accessibilityIdentifier("friday.chat.memory-card.keep")
+
+      Button {
+        Task { await viewModel.decideContextMemory(confirm: false) }
+      } label: {
+        Image(systemName: "xmark")
+          .frame(width: 26, height: 26)
+      }
+      .buttonStyle(.bordered)
+      .disabled(viewModel.contextMemoryDecisionState?.isSent == true)
+      .accessibilityLabel("Reject memory candidate")
+      .accessibilityIdentifier("friday.chat.memory-card.reject")
+    }
+  }
+
+  @ViewBuilder private func candidateDecisionStateView(_ state: HomeLearningDecisionState) -> some View {
+    switch state {
+    case .sent:
+      StatusChip(text: "sending", bg: MobileTheme.chipNeutralBG, fg: MobileTheme.chipNeutralFG)
+    case .confirmed(let summary):
+      Text(summary)
+        .font(.caption2)
+        .foregroundStyle(MobileTheme.textSecondary)
+        .fixedSize(horizontal: false, vertical: true)
+    case .error(let reason):
+      Text(reason)
+        .font(.caption2)
+        .foregroundStyle(MobileTheme.chipWarnFG)
+        .fixedSize(horizontal: false, vertical: true)
     }
   }
 

--- a/apps/friday-ios/Sources/FridayMobileShell/FridayContextPassportScreen.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayContextPassportScreen.swift
@@ -37,6 +37,7 @@ struct FridayContextPassportScreen: View {
 
     if let status {
       checklistCard(status)
+      sendCard(projection)
       refsCard(status)
       truthCard(status)
     } else {
@@ -138,6 +139,44 @@ struct FridayContextPassportScreen: View {
             .fixedSize(horizontal: false, vertical: true)
         }
       }
+    }
+  }
+
+  private func sendCard(_ projection: HomeProjection) -> some View {
+    GlassPanel {
+      VStack(alignment: .leading, spacing: MobileTheme.rowSpacing) {
+        cardHeader("Send", count: 3)
+        Button {
+          Task { await viewModel.submitContextPassportTransfer(for: projection) }
+        } label: {
+          Label("Send with 3 items", systemImage: "checkmark.seal")
+            .frame(maxWidth: .infinity)
+        }
+        .buttonStyle(.borderedProminent)
+        .tint(MobileTheme.cyan)
+        .disabled(viewModel.contextPassportTransferState?.isSent == true)
+        .accessibilityIdentifier("friday.context-passport.send")
+        if let state = viewModel.contextPassportTransferState {
+          candidateDecisionStateView(state)
+        }
+      }
+    }
+  }
+
+  @ViewBuilder private func candidateDecisionStateView(_ state: HomeLearningDecisionState) -> some View {
+    switch state {
+    case .sent:
+      StatusChip(text: "sending", bg: MobileTheme.chipNeutralBG, fg: MobileTheme.chipNeutralFG)
+    case .confirmed(let summary):
+      Text(summary)
+        .font(.caption2)
+        .foregroundStyle(MobileTheme.textSecondary)
+        .fixedSize(horizontal: false, vertical: true)
+    case .error(let reason):
+      Text(reason)
+        .font(.caption2)
+        .foregroundStyle(MobileTheme.chipWarnFG)
+        .fixedSize(horizontal: false, vertical: true)
     }
   }
 

--- a/apps/friday-ios/Sources/FridayMobileShell/FridayNewSessionScreen.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayNewSessionScreen.swift
@@ -1,0 +1,126 @@
+import FridayMobileShellCore
+import SwiftUI
+
+struct FridayNewSessionScreen: View {
+  @ObservedObject var viewModel: NewSessionViewModel
+  @State private var intent = ""
+
+  var body: some View {
+    ScrollView {
+      VStack(spacing: 16) {
+        header
+        launcher
+        launchState
+      }
+      .padding(16)
+    }
+    .background(MobileTheme.backgroundWarmOffWhite.ignoresSafeArea())
+  }
+
+  private var header: some View {
+    GlassPanel {
+      HStack(spacing: 12) {
+        Image(systemName: "plus")
+          .font(.system(size: 24, weight: .semibold))
+          .foregroundStyle(MobileTheme.cyan)
+          .frame(width: 34, height: 34)
+        VStack(alignment: .leading, spacing: 4) {
+          Text("New Session")
+            .font(.headline)
+            .foregroundStyle(MobileTheme.textPrimary)
+          Text("governed mission launch")
+            .font(.caption)
+            .foregroundStyle(MobileTheme.textSecondary)
+        }
+        Spacer()
+        StatusChip(text: "action gated", bg: MobileTheme.chipPendingBG, fg: MobileTheme.chipPendingFG)
+      }
+    }
+  }
+
+  private var launcher: some View {
+    GlassPanel {
+      VStack(alignment: .leading, spacing: MobileTheme.rowSpacing) {
+        cardHeader("Launch", count: nil)
+        TextField("What should Friday do?", text: $intent, axis: .vertical)
+          .lineLimit(2...5)
+          .textInputAutocapitalization(.sentences)
+          .autocorrectionDisabled(false)
+          .font(.subheadline)
+          .padding(10)
+          .background(Color.white.opacity(0.54), in: RoundedRectangle(cornerRadius: 8))
+          .accessibilityIdentifier("friday.new-session.intent-input")
+        Button {
+          let goal = intent
+          Task { await viewModel.launch(intent: goal) }
+        } label: {
+          Label("Launch", systemImage: "play.fill")
+            .frame(maxWidth: .infinity, minHeight: 38)
+        }
+        .buttonStyle(.borderedProminent)
+        .tint(MobileTheme.cyan)
+        .disabled(intent.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || launchInFlight)
+        .accessibilityIdentifier("friday.new-session.launch-button")
+        Text("Launch submits a governed Mission Intake. It is not provider-backed until the Hub accepts it and returns refs.")
+          .font(.caption2)
+          .foregroundStyle(MobileTheme.textSecondary)
+          .fixedSize(horizontal: false, vertical: true)
+      }
+    }
+  }
+
+  @ViewBuilder
+  private var launchState: some View {
+    switch viewModel.launchState {
+    case .idle:
+      EmptyView()
+    case .launching:
+      GlassPanel {
+        HStack(spacing: 12) {
+          ProgressView()
+          Text("Submitting Mission Intake")
+            .font(.footnote)
+            .foregroundStyle(MobileTheme.textSecondary)
+        }
+      }
+    case .launched(let summary, let missionId, let workItemId):
+      GlassPanel {
+        VStack(alignment: .leading, spacing: MobileTheme.rowSpacing) {
+          cardHeader("Submitted", count: nil)
+          Text(summary)
+            .font(.caption)
+            .foregroundStyle(MobileTheme.textPrimary)
+          RefPill(label: "mission_id", ref: missionId)
+          RefPill(label: "work_item_id", ref: workItemId)
+        }
+      }
+    case .blocked(let reason):
+      GlassPanel {
+        VStack(alignment: .leading, spacing: MobileTheme.rowSpacing) {
+          cardHeader("Unavailable", count: nil)
+          Text(reason)
+            .font(.caption)
+            .foregroundStyle(MobileTheme.coral)
+            .fixedSize(horizontal: false, vertical: true)
+        }
+      }
+      .accessibilityIdentifier("friday.new-session.unavailable")
+    }
+  }
+
+  private var launchInFlight: Bool {
+    if case .launching = viewModel.launchState { return true }
+    return false
+  }
+
+  private func cardHeader(_ title: String, count: Int?) -> some View {
+    HStack {
+      Text(title)
+        .font(.headline)
+        .foregroundStyle(MobileTheme.textPrimary)
+      if let count {
+        StatusChip(text: "\(count)", bg: MobileTheme.chipNeutralBG, fg: MobileTheme.chipNeutralFG)
+      }
+    }
+  }
+}

--- a/apps/friday-ios/Sources/FridayMobileShell/FridayProjectionScreens.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayProjectionScreens.swift
@@ -14,7 +14,8 @@ private enum ProjectionSurface {
 
   init?(_ destination: MobileDestination) {
     switch destination {
-    case .home, .session, .contextPassport, .tokenLedger, .shareIntake, .voice, .pairing, .providerAuth:
+    case .home, .session, .contextPassport, .tokenLedger, .shareIntake, .voice, .pairing,
+         .newSession, .providerAuth:
       return nil
     case .missions:
       self = .missions

--- a/apps/friday-ios/Sources/FridayMobileShell/FridaySessionDetailScreen.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridaySessionDetailScreen.swift
@@ -115,6 +115,10 @@ struct FridaySessionDetailScreen: View {
       VStack(spacing: 16) {
         approvalPanel(snapshot)
         controlsCard(snapshot.controls)
+        sidecarLauncher
+        if viewModel.sidecarState.isOpen {
+          sidecarSheet
+        }
         ForEach(snapshot.sections) { section in
           sectionCard(section)
         }
@@ -242,6 +246,129 @@ struct FridaySessionDetailScreen: View {
           }
         }
       }
+    }
+  }
+
+  private var sidecarLauncher: some View {
+    Button {
+      viewModel.openSidecar()
+    } label: {
+      HStack(spacing: 8) {
+        Image(systemName: "shield.lefthalf.filled")
+        Text("Friday Sidecar - private analysis")
+          .font(.system(size: 13, weight: .semibold))
+        Spacer()
+        StatusChip(text: "private", bg: MobileTheme.chipPendingBG, fg: MobileTheme.chipPendingFG)
+      }
+      .frame(maxWidth: .infinity, minHeight: 44, alignment: .leading)
+      .padding(.horizontal, 12)
+    }
+    .buttonStyle(.bordered)
+    .accessibilityLabel("Open Friday Sidecar private analysis")
+    .accessibilityIdentifier("friday.session.sidecar-open")
+  }
+
+  private var sidecarSheet: some View {
+    GlassPanel {
+      VStack(alignment: .leading, spacing: MobileTheme.rowSpacing) {
+        HStack(alignment: .top, spacing: 10) {
+          Image(systemName: "lock.shield")
+            .font(.system(size: 22, weight: .semibold))
+            .foregroundStyle(MobileTheme.cyan)
+            .frame(width: 30, height: 30)
+          VStack(alignment: .leading, spacing: 3) {
+            Text("Friday Sidecar")
+              .font(.headline)
+              .foregroundStyle(MobileTheme.textPrimary)
+            Text("Private analysis - nothing reaches the provider unless you confirm.")
+              .font(.caption)
+              .foregroundStyle(MobileTheme.textSecondary)
+          }
+          Spacer()
+          Button {
+            viewModel.closeSidecar()
+          } label: {
+            Image(systemName: "xmark")
+              .frame(width: 26, height: 26)
+          }
+          .buttonStyle(.bordered)
+          .accessibilityLabel("Close Friday Sidecar")
+          .accessibilityIdentifier("friday.session.sidecar-close")
+        }
+
+        VStack(alignment: .leading, spacing: 8) {
+          sidecarActionButton(
+            title: "Analyze diff privately",
+            systemImage: "shield.checkered",
+            truth: "wired_registry") {
+              viewModel.analyzeSidecarPrivately()
+            }
+          sidecarActionButton(
+            title: "Insert into composer",
+            systemImage: "plus",
+            truth: "NO-GO") {
+              viewModel.blockSidecarExternalAction("Insert into composer")
+            }
+          sidecarActionButton(
+            title: "Send to provider (confirm)",
+            systemImage: "paperplane",
+            truth: "NO-GO") {
+              viewModel.blockSidecarExternalAction("Send to provider")
+            }
+          sidecarActionButton(
+            title: "Create Handoff",
+            systemImage: "square.and.arrow.up",
+            truth: "NO-GO") {
+              viewModel.blockSidecarExternalAction("Create Handoff")
+            }
+        }
+
+        sidecarStateView(viewModel.sidecarState.actionState)
+      }
+    }
+    .accessibilityIdentifier("friday.session.sidecar-sheet")
+  }
+
+  private func sidecarActionButton(
+    title: String,
+    systemImage: String,
+    truth: String,
+    action: @escaping () -> Void
+  ) -> some View {
+    Button(action: action) {
+      HStack(spacing: 8) {
+        Image(systemName: systemImage)
+          .frame(width: 20)
+        Text(title)
+          .font(.caption.weight(.semibold))
+          .foregroundStyle(MobileTheme.textPrimary)
+        Spacer()
+        StatusChip(
+          text: truth,
+          bg: truth == "NO-GO" ? MobileTheme.chipWarnBG : MobileTheme.chipPendingBG,
+          fg: truth == "NO-GO" ? MobileTheme.chipWarnFG : MobileTheme.chipPendingFG)
+      }
+      .frame(maxWidth: .infinity, minHeight: 36, alignment: .leading)
+    }
+    .buttonStyle(.bordered)
+    .accessibilityLabel("\(title) \(truth)")
+  }
+
+  @ViewBuilder
+  private func sidecarStateView(_ state: SessionSidecarActionState) -> some View {
+    switch state {
+    case .idle:
+      EmptyView()
+    case .ready(let summary):
+      Text(summary)
+        .font(.caption2)
+        .foregroundStyle(MobileTheme.textSecondary)
+        .fixedSize(horizontal: false, vertical: true)
+    case .blocked(let reason):
+      Text(reason)
+        .font(.caption2)
+        .foregroundStyle(MobileTheme.coral)
+        .fixedSize(horizontal: false, vertical: true)
     }
   }
 

--- a/apps/friday-ios/Sources/FridayMobileShellCore/FridayChatViewModel.swift
+++ b/apps/friday-ios/Sources/FridayMobileShellCore/FridayChatViewModel.swift
@@ -345,6 +345,7 @@ public final class FridayChatViewModel: ObservableObject {
   @Published public private(set) var contextCards: [ChatContextCard] = []
   @Published public private(set) var selectedContextCardId: String?
   @Published public private(set) var contextMemoryDecisionState: HomeLearningDecisionState?
+  @Published public private(set) var contextPassportTransferState: HomeLearningDecisionState?
 
   /// The package write client is `Sendable`; each dispatch/control call builds a fresh transport.
   private let writeClient: FridayRustWriteClient
@@ -624,6 +625,7 @@ public final class FridayChatViewModel: ObservableObject {
     contextCards = []
     selectedContextCardId = nil
     contextMemoryDecisionState = nil
+    contextPassportTransferState = nil
     historyStore.save(history)
   }
 
@@ -672,6 +674,70 @@ public final class FridayChatViewModel: ObservableObject {
     }
   }
 
+  public func submitContextPassportHandoff() async {
+    guard case .answered(let receipt) = phase else {
+      contextPassportTransferState = .error(reason: "No answered Chat turn is available for handoff.")
+      return
+    }
+    guard let missionId = receipt.missionId, !missionId.isEmpty else {
+      contextPassportTransferState = .error(reason: "This Chat turn is not bound to a Mission.")
+      return
+    }
+    guard let memoryDecisionClient else {
+      contextPassportTransferState = .error(reason: "Write seam not configured.")
+      return
+    }
+
+    selectedContextCardId = "handoff"
+    contextPassportTransferState = .sent
+    let workItemId = receipt.followUpWorkItemId ?? receipt.workItemId
+    let runRef = receipt.answerBodyRunId ?? receipt.followUpRunId ?? receipt.runId
+    let request = ContextPassportTransferRequestWire(
+      passportId: "mobile-chat-passport-\(missionId)",
+      missionId: missionId,
+      workItemId: workItemId,
+      destinationLane: "codex",
+      destinationTarget: "codex",
+      items: [
+        ContextPassportItemWire(
+          kind: "summary",
+          label: "Mobile Chat handoff for mission \(missionId).",
+          included: true,
+          sensitive: false),
+        ContextPassportItemWire(
+          kind: "summary",
+          label: "Answer run ref \(runRef).",
+          included: true,
+          sensitive: false),
+        ContextPassportItemWire(
+          kind: "summary",
+          label: "Work item ref \(workItemId ?? "not-attached").",
+          included: true,
+          sensitive: false),
+      ],
+      approvedSensitive: false)
+    do {
+      let result = try await memoryDecisionClient.submitContextPassportTransfer(request)
+      switch result.status {
+      case "confirmed":
+        contextPassportTransferState = .confirmed(
+          summary: "passport \(result.passportId) · items=\(result.sharedItemCount)")
+        appendHistory(
+          role: "friday",
+          text: "Context handoff created.",
+          receiptRefs: [
+            ChatReceiptRef(label: "passport_id", ref: result.passportId),
+            ChatReceiptRef(label: "mission_id", ref: result.missionId),
+            ChatReceiptRef(label: "link_id", ref: result.linkId ?? "none"),
+          ])
+      default:
+        contextPassportTransferState = .error(reason: "Context passport blocked — \(result.blocker ?? "blocked")")
+      }
+    } catch {
+      contextPassportTransferState = .error(reason: Self.memoryReason(for: error))
+    }
+  }
+
   /// Reset to a fresh composer after an answer / receipt / unavailable (start a new turn).
   public func newTurn() {
     switch phase {
@@ -680,6 +746,7 @@ public final class FridayChatViewModel: ObservableObject {
       contextCards = []
       selectedContextCardId = nil
       contextMemoryDecisionState = nil
+      contextPassportTransferState = nil
     default:
       // Do NOT abandon an in-flight dispatch or a pending approval (would drop the S6 gate).
       break

--- a/apps/friday-ios/Sources/FridayMobileShellCore/FridayChatViewModel.swift
+++ b/apps/friday-ios/Sources/FridayMobileShellCore/FridayChatViewModel.swift
@@ -262,6 +262,14 @@ public struct ChatHistoryItem: Identifiable, Codable, Sendable, Equatable {
   }
 }
 
+public struct ChatContextCard: Identifiable, Sendable, Equatable {
+  public let id: String
+  public let title: String
+  public let detail: String
+  public let truthLabel: String
+  public let evidenceRef: String
+}
+
 public protocol ChatHistoryStoring {
   func load() -> [ChatHistoryItem]
   func save(_ items: [ChatHistoryItem])
@@ -332,6 +340,8 @@ public enum ChatPhase: Sendable, Equatable {
 public final class FridayChatViewModel: ObservableObject {
   @Published public private(set) var phase: ChatPhase = .composing
   @Published public private(set) var history: [ChatHistoryItem]
+  @Published public private(set) var contextCards: [ChatContextCard] = []
+  @Published public private(set) var selectedContextCardId: String?
 
   /// The package write client is `Sendable`; each dispatch/control call builds a fresh transport.
   private let writeClient: FridayRustWriteClient
@@ -406,6 +416,7 @@ public final class FridayChatViewModel: ObservableObject {
           answerBodyRunId: answer?.runId,
           answerBodyOutcome: answer?.outcome)
         appendAnswerHistory(receipt)
+        contextCards = Self.contextCards(for: receipt)
         phase = .answered(receipt)
       case .paused(let p):
         // INV-2: a mutating run PAUSED — surface the S6 approval card. No mutation has executed.
@@ -413,6 +424,7 @@ public final class FridayChatViewModel: ObservableObject {
           role: "friday",
           text: "Approval required: \(p.ownerSealedSummary ?? "mutating action")",
           runId: p.runId)
+        contextCards = []
         phase = .pendingApproval(ApprovalCard(p))
       }
     } catch {
@@ -469,6 +481,7 @@ public final class FridayChatViewModel: ObservableObject {
         answerBodyRunId: answer?.runId,
         answerBodyOutcome: answer?.outcome)
       appendAnswerHistory(receipt)
+      contextCards = Self.contextCards(for: receipt)
       phase = .answered(receipt)
     } catch {
       phase = .unavailable(reason: Self.dispatchReason(for: error))
@@ -562,6 +575,7 @@ public final class FridayChatViewModel: ObservableObject {
         runId: receipt.runId,
         receiptRefs: surfacedReceipt.receiptRefs)
       phase = .resumed(surfacedReceipt)
+      contextCards = []
     } catch {
       phase = .unavailable(reason: Self.resumeReason(for: error))
     }
@@ -583,6 +597,7 @@ public final class FridayChatViewModel: ObservableObject {
         runId: receipt.runId,
         receiptRefs: surfacedReceipt.receiptRefs)
       phase = .resumed(surfacedReceipt)
+      contextCards = []
     } catch {
       phase = .unavailable(reason: Self.rejectReason(for: error))
     }
@@ -590,7 +605,14 @@ public final class FridayChatViewModel: ObservableObject {
 
   public func clearHistory() {
     history = []
+    contextCards = []
+    selectedContextCardId = nil
     historyStore.save(history)
+  }
+
+  public func selectContextCard(_ id: String) {
+    guard contextCards.contains(where: { $0.id == id }) else { return }
+    selectedContextCardId = id
   }
 
   /// Reset to a fresh composer after an answer / receipt / unavailable (start a new turn).
@@ -598,6 +620,8 @@ public final class FridayChatViewModel: ObservableObject {
     switch phase {
     case .answered, .resumed, .unavailable:
       phase = .composing
+      contextCards = []
+      selectedContextCardId = nil
     default:
       // Do NOT abandon an in-flight dispatch or a pending approval (would drop the S6 gate).
       break
@@ -653,6 +677,24 @@ public final class FridayChatViewModel: ObservableObject {
       text = "Friday answered (\(receipt.status)). Run \(receipt.runId)."
     }
     appendHistory(role: "friday", text: text, runId: receipt.answerBodyRunId ?? receipt.runId, receiptRefs: receipt.receiptRefs)
+  }
+
+  private static func contextCards(for receipt: ChatAnswerReceipt) -> [ChatContextCard] {
+    let runRef = receipt.answerBodyRunId ?? receipt.followUpRunId ?? receipt.runId
+    return [
+      ChatContextCard(
+        id: "handoff",
+        title: "Handoff",
+        detail: "Prepare a context passport from this answer when the passport send gate is available.",
+        truthLabel: "local",
+        evidenceRef: "swift://mobile/fridayChat/handoff-card/\(runRef)"),
+      ChatContextCard(
+        id: "memory",
+        title: "Memory",
+        detail: "Review memory candidates for this turn through the governed memory surface.",
+        truthLabel: "local",
+        evidenceRef: "swift://mobile/fridayChat/memory-card/\(runRef)"),
+    ]
   }
 
   private func appendHistory(role: String, text: String, runId: String? = nil, receiptRefs: [ChatReceiptRef] = []) {

--- a/apps/friday-ios/Sources/FridayMobileShellCore/FridayChatViewModel.swift
+++ b/apps/friday-ios/Sources/FridayMobileShellCore/FridayChatViewModel.swift
@@ -268,6 +268,8 @@ public struct ChatContextCard: Identifiable, Sendable, Equatable {
   public let detail: String
   public let truthLabel: String
   public let evidenceRef: String
+  public let memoryCandidateId: String?
+  public let memoryPreview: String?
 }
 
 public protocol ChatHistoryStoring {
@@ -342,10 +344,12 @@ public final class FridayChatViewModel: ObservableObject {
   @Published public private(set) var history: [ChatHistoryItem]
   @Published public private(set) var contextCards: [ChatContextCard] = []
   @Published public private(set) var selectedContextCardId: String?
+  @Published public private(set) var contextMemoryDecisionState: HomeLearningDecisionState?
 
   /// The package write client is `Sendable`; each dispatch/control call builds a fresh transport.
   private let writeClient: FridayRustWriteClient
   private let missionClient: (any FridayMobileMissionDispatchingWriteClient)?
+  private let memoryDecisionClient: (any FridayMissionSpineWriteClient)?
   private let readClient: FridayRustReadClient?
   private let signer: OperatorSigner
   private let newId: () -> String
@@ -362,6 +366,7 @@ public final class FridayChatViewModel: ObservableObject {
     writeClient: FridayRustWriteClient,
     signer: OperatorSigner,
     missionClient: (any FridayMobileMissionDispatchingWriteClient)? = nil,
+    memoryDecisionClient: (any FridayMissionSpineWriteClient)? = nil,
     readClient: FridayRustReadClient? = nil,
     historyStore: any ChatHistoryStoring = UserDefaultsChatHistoryStore(),
     newId: @escaping () -> String = { UUID().uuidString.lowercased().replacingOccurrences(of: "-", with: "") },
@@ -371,6 +376,7 @@ public final class FridayChatViewModel: ObservableObject {
     self.writeClient = writeClient
     self.signer = signer
     self.missionClient = missionClient
+    self.memoryDecisionClient = memoryDecisionClient ?? (writeClient as? any FridayMissionSpineWriteClient)
     self.readClient = readClient
     self.historyStore = historyStore
     self.newId = newId
@@ -416,7 +422,7 @@ public final class FridayChatViewModel: ObservableObject {
           answerBodyRunId: answer?.runId,
           answerBodyOutcome: answer?.outcome)
         appendAnswerHistory(receipt)
-        contextCards = Self.contextCards(for: receipt)
+        contextCards = Self.contextCards(for: receipt, memoryCandidate: await firstMemoryCandidate())
         phase = .answered(receipt)
       case .paused(let p):
         // INV-2: a mutating run PAUSED — surface the S6 approval card. No mutation has executed.
@@ -481,7 +487,7 @@ public final class FridayChatViewModel: ObservableObject {
         answerBodyRunId: answer?.runId,
         answerBodyOutcome: answer?.outcome)
       appendAnswerHistory(receipt)
-      contextCards = Self.contextCards(for: receipt)
+      contextCards = Self.contextCards(for: receipt, memoryCandidate: await firstMemoryCandidate())
       phase = .answered(receipt)
     } catch {
       phase = .unavailable(reason: Self.dispatchReason(for: error))
@@ -529,6 +535,16 @@ public final class FridayChatViewModel: ObservableObject {
         return nil
       }
       return (body.runId, answer, body.outcome)
+    } catch {
+      return nil
+    }
+  }
+
+  private func firstMemoryCandidate() async -> HomeMemoryCandidate? {
+    guard let readClient else { return nil }
+    do {
+      let snapshot = try await readClient.fetchWorkbench()
+      return HomeProjection(snapshot).memoryCandidates.first
     } catch {
       return nil
     }
@@ -607,12 +623,53 @@ public final class FridayChatViewModel: ObservableObject {
     history = []
     contextCards = []
     selectedContextCardId = nil
+    contextMemoryDecisionState = nil
     historyStore.save(history)
   }
 
   public func selectContextCard(_ id: String) {
     guard contextCards.contains(where: { $0.id == id }) else { return }
     selectedContextCardId = id
+  }
+
+  public func decideContextMemory(confirm: Bool) async {
+    let card = contextCards.first { $0.id == "memory" }
+    guard let memoryId = card?.memoryCandidateId, !memoryId.isEmpty else {
+      contextMemoryDecisionState = .error(reason: "No memory candidate is available for this Chat turn.")
+      return
+    }
+    guard let memoryDecisionClient else {
+      contextMemoryDecisionState = .error(reason: "Write seam not configured.")
+      return
+    }
+
+    selectedContextCardId = "memory"
+    contextMemoryDecisionState = .sent
+    let request = MemoryDecisionRequestWire(
+      memoryId: memoryId,
+      ownerPrincipal: liveAgentRunOwnerPrincipal,
+      decision: confirm ? "confirm" : "reject")
+    do {
+      let result = try await memoryDecisionClient.submitMemoryDecision(request)
+      switch result.status {
+      case "confirmed", "rejected":
+        contextMemoryDecisionState = .confirmed(
+          summary: "\(result.status) · state=\(result.state) · recallable=\(result.recallable)")
+        appendHistory(
+          role: "friday",
+          text: "Memory decision \(result.status).",
+          receiptRefs: [
+            ChatReceiptRef(label: "memory_id", ref: result.memoryId),
+            ChatReceiptRef(label: "status", ref: result.status),
+            ChatReceiptRef(label: "state", ref: result.state),
+          ])
+      default:
+        let why = result.blocker ?? "blocked"
+        contextMemoryDecisionState = .error(reason: "Memory decision blocked — \(why)")
+      }
+    } catch {
+      contextMemoryDecisionState = .error(reason: Self.memoryReason(for: error))
+    }
   }
 
   /// Reset to a fresh composer after an answer / receipt / unavailable (start a new turn).
@@ -622,6 +679,7 @@ public final class FridayChatViewModel: ObservableObject {
       phase = .composing
       contextCards = []
       selectedContextCardId = nil
+      contextMemoryDecisionState = nil
     default:
       // Do NOT abandon an in-flight dispatch or a pending approval (would drop the S6 gate).
       break
@@ -648,6 +706,11 @@ public final class FridayChatViewModel: ObservableObject {
   static func signerReason(for error: Error) -> String {
     if let e = error as? OperatorSignerError { return e.description }
     return "Approval unavailable — \(error)"
+  }
+
+  static func memoryReason(for error: Error) -> String {
+    if let e = error as? FridayWriteClientError { return writeReason(e, verb: "memory decision") }
+    return "Memory decision unavailable — \(error)"
   }
 
   private static func writeReason(_ e: FridayWriteClientError, verb: String) -> String {
@@ -679,7 +742,10 @@ public final class FridayChatViewModel: ObservableObject {
     appendHistory(role: "friday", text: text, runId: receipt.answerBodyRunId ?? receipt.runId, receiptRefs: receipt.receiptRefs)
   }
 
-  private static func contextCards(for receipt: ChatAnswerReceipt) -> [ChatContextCard] {
+  private static func contextCards(
+    for receipt: ChatAnswerReceipt,
+    memoryCandidate: HomeMemoryCandidate?
+  ) -> [ChatContextCard] {
     let runRef = receipt.answerBodyRunId ?? receipt.followUpRunId ?? receipt.runId
     return [
       ChatContextCard(
@@ -687,13 +753,17 @@ public final class FridayChatViewModel: ObservableObject {
         title: "Handoff",
         detail: "Prepare a context passport from this answer when the passport send gate is available.",
         truthLabel: "local",
-        evidenceRef: "swift://mobile/fridayChat/handoff-card/\(runRef)"),
+        evidenceRef: "swift://mobile/fridayChat/handoff-card/\(runRef)",
+        memoryCandidateId: nil,
+        memoryPreview: nil),
       ChatContextCard(
         id: "memory",
         title: "Memory",
-        detail: "Review memory candidates for this turn through the governed memory surface.",
-        truthLabel: "local",
-        evidenceRef: "swift://mobile/fridayChat/memory-card/\(runRef)"),
+        detail: memoryCandidate?.preview ?? "Review memory candidates for this turn through the governed memory surface.",
+        truthLabel: memoryCandidate == nil ? "local" : "wired",
+        evidenceRef: memoryCandidate?.evidenceRef ?? "swift://mobile/fridayChat/memory-card/\(runRef)",
+        memoryCandidateId: memoryCandidate?.id,
+        memoryPreview: memoryCandidate?.preview),
     ]
   }
 

--- a/apps/friday-ios/Sources/FridayMobileShellCore/HomeViewModel.swift
+++ b/apps/friday-ios/Sources/FridayMobileShellCore/HomeViewModel.swift
@@ -806,6 +806,7 @@ public final class HomeViewModel: ObservableObject {
   @Published public private(set) var runOutcomeLearningDecisionStates: [String: HomeLearningDecisionState] = [:]
   @Published public private(set) var activityMarkDoneStates: [String: HomeLearningDecisionState] = [:]
   @Published public private(set) var workItemStatusStates: [String: HomeLearningDecisionState] = [:]
+  @Published public private(set) var contextPassportTransferState: HomeLearningDecisionState?
   @Published public private(set) var pairingPreflight: MobilePairingPreflight = .empty
   @Published public private(set) var pairingAttempt: MobilePairingAttempt = .idle
 
@@ -889,6 +890,51 @@ public final class HomeViewModel: ObservableObject {
       }
     } catch {
       memoryDecisionStates[candidateId] = .error(reason: Self.reason(for: error))
+    }
+  }
+
+  public func submitContextPassportTransfer(for projection: HomeProjection) async {
+    guard let writeClient else {
+      contextPassportTransferState = .error(reason: "Write seam not configured.")
+      return
+    }
+    contextPassportTransferState = .sent
+    let request = ContextPassportTransferRequestWire(
+      passportId: "mobile-passport-\(projection.missionId)",
+      missionId: projection.missionId,
+      workItemId: projection.workItemIds.first,
+      destinationLane: "codex",
+      destinationTarget: "codex",
+      items: [
+        ContextPassportItemWire(
+          kind: "summary",
+          label: "Mission \(projection.missionId) context reviewed from mobile Passport surface.",
+          included: true,
+          sensitive: false),
+        ContextPassportItemWire(
+          kind: "summary",
+          label: "Workbench has \(projection.workItemIds.count) work item ref(s).",
+          included: true,
+          sensitive: false),
+        ContextPassportItemWire(
+          kind: "summary",
+          label: "Pending memory candidate count \(projection.memoryCandidates.count).",
+          included: true,
+          sensitive: false),
+      ],
+      approvedSensitive: false)
+    do {
+      let result = try await writeClient.submitContextPassportTransfer(request)
+      switch result.status {
+      case "confirmed":
+        contextPassportTransferState = .confirmed(
+          summary: "passport \(result.passportId) · items=\(result.sharedItemCount)")
+        await refresh()
+      default:
+        contextPassportTransferState = .error(reason: "Context passport blocked — \(result.blocker ?? "blocked")")
+      }
+    } catch {
+      contextPassportTransferState = .error(reason: Self.reason(for: error))
     }
   }
 

--- a/apps/friday-ios/Sources/FridayMobileShellCore/NewSessionViewModel.swift
+++ b/apps/friday-ios/Sources/FridayMobileShellCore/NewSessionViewModel.swift
@@ -1,0 +1,96 @@
+import Foundation
+import FridayRustClient
+
+public enum NewSessionLaunchState: Sendable, Equatable {
+  case idle
+  case launching
+  case launched(summary: String, missionId: String, workItemId: String)
+  case blocked(reason: String)
+}
+
+@MainActor
+public final class NewSessionViewModel: ObservableObject {
+  @Published public private(set) var launchState: NewSessionLaunchState = .idle
+
+  private let client: (any FridayMissionSpineWriteClient)?
+  private let owner: String
+  private let idFactory: () -> String
+
+  public init(
+    client: (any FridayMissionSpineWriteClient)?,
+    owner: String = "principal:owner-device",
+    idFactory: @escaping () -> String = { UUID().uuidString.lowercased() }
+  ) {
+    self.client = client
+    self.owner = owner
+    self.idFactory = idFactory
+  }
+
+  public func launch(intent: String) async {
+    let trimmed = intent.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty else {
+      launchState = .blocked(reason: "New session requires an owner-visible goal.")
+      return
+    }
+    guard let client else {
+      launchState = .blocked(reason: "Write seam not configured.")
+      return
+    }
+
+    launchState = .launching
+    do {
+      let result = try await client.submitMissionIntake(Self.request(intent: trimmed, owner: owner, id: idFactory()))
+      guard result.status == "ready" || result.status == "created" else {
+        launchState = .blocked(reason: "Mission intake not ready - \(result.status)")
+        return
+      }
+      guard let workItemId = result.workItemId, !workItemId.isEmpty else {
+        launchState = .blocked(reason: "Mission intake did not return a WorkItem ref.")
+        return
+      }
+      launchState = .launched(
+        summary: "\(result.status) · mission=\(result.missionId) · work_item=\(workItemId)",
+        missionId: result.missionId,
+        workItemId: workItemId)
+    } catch {
+      launchState = .blocked(reason: Self.reason(for: error))
+    }
+  }
+
+  public static func request(intent: String, owner: String, id: String) -> MissionIntakeRequestWire {
+    MissionIntakeRequestWire(
+      fridayConversationId: "fconv_mobile_new_session_\(id)",
+      ownerPrincipal: owner,
+      surfaceThreadId: "surface-mobile-new-session-\(id)",
+      surfaceKind: "mobile",
+      deliveryRoute: "ios://friday-mobile/new-session/\(id)",
+      visibilityPolicy: "compact",
+      missionId: "mission-mobile-new-session-\(id)",
+      workItemId: "work-mobile-new-session-\(id)",
+      title: String(intent.prefix(72)),
+      intent: intent,
+      lane: "auto")
+  }
+
+  private static func reason(for error: Error) -> String {
+    if let write = error as? FridayWriteClientError {
+      switch write {
+      case .badServerPubkey, .badSessionNonce:
+        return "Friday could not establish a trusted connection."
+      case let .serverError(code, message):
+        return "Friday is unavailable (\(code.rawValue)) - \(message)"
+      case let .unexpectedResponse(kind):
+        return "Friday returned an unexpected response (\(kind))."
+      case let .missingRef(reason):
+        return "Friday returned an incomplete launch response - \(reason)"
+      case .runControlDisabled:
+        return "Run control is not enabled for this launch."
+      case .emptySignedBlob:
+        return "Launch unavailable - unexpected empty signature state."
+      case let .transport(reason):
+        return "Friday is offline - \(reason)"
+      }
+    }
+    return "Launch failed - \(error)"
+  }
+}

--- a/apps/friday-ios/Sources/FridayMobileShellCore/SessionContinuationViewModel.swift
+++ b/apps/friday-ios/Sources/FridayMobileShellCore/SessionContinuationViewModel.swift
@@ -97,10 +97,27 @@ public enum SessionContinuationLoadState: Sendable, Equatable {
   }
 }
 
+public enum SessionSidecarActionState: Sendable, Equatable {
+  case idle
+  case ready(summary: String)
+  case blocked(reason: String)
+}
+
+public struct SessionSidecarState: Sendable, Equatable {
+  public let isOpen: Bool
+  public let actionState: SessionSidecarActionState
+
+  public init(isOpen: Bool = false, actionState: SessionSidecarActionState = .idle) {
+    self.isOpen = isOpen
+    self.actionState = actionState
+  }
+}
+
 @MainActor
 public final class SessionContinuationViewModel: ObservableObject {
   @Published public private(set) var state: SessionContinuationLoadState = .idle
   @Published public private(set) var controlStates: [String: SessionContinuationControlState] = [:]
+  @Published public private(set) var sidecarState = SessionSidecarState()
 
   private let client: FridayRustReadClient
   private let writeClient: FridayRustWriteClient?
@@ -120,6 +137,26 @@ public final class SessionContinuationViewModel: ObservableObject {
     self.makeSessionWriteClient = makeSessionWriteClient
     self.signer = signer
     self.runControlEnabled = runControlEnabled
+  }
+
+  public func openSidecar() {
+    sidecarState = SessionSidecarState(isOpen: true, actionState: sidecarState.actionState)
+  }
+
+  public func closeSidecar() {
+    sidecarState = SessionSidecarState(isOpen: false, actionState: sidecarState.actionState)
+  }
+
+  public func analyzeSidecarPrivately() {
+    sidecarState = SessionSidecarState(
+      isOpen: true,
+      actionState: .ready(summary: "Private Friday analysis ready. Nothing has been sent to the provider."))
+  }
+
+  public func blockSidecarExternalAction(_ action: String) {
+    sidecarState = SessionSidecarState(
+      isOpen: true,
+      actionState: .blocked(reason: "\(action) requires a governed confirmation path before any provider or handoff write."))
   }
 
   public func refresh(agentSessionId: String?, runId: String?) async {

--- a/apps/friday-ios/Tests/FridayMobileShellCoreTests/FridayChatViewModelTests.swift
+++ b/apps/friday-ios/Tests/FridayMobileShellCoreTests/FridayChatViewModelTests.swift
@@ -534,6 +534,11 @@ final class FridayChatViewModelTests: XCTestCase {
     guard case let .answered(answerReceipt) = sendVM.phase else {
       return XCTFail("expected answered, got \(sendVM.phase)")
     }
+    XCTAssertEqual(sendVM.contextCards.map(\.id), ["handoff", "memory"])
+    sendVM.selectContextCard("handoff")
+    XCTAssertEqual(sendVM.selectedContextCardId, "handoff")
+    sendVM.selectContextCard("memory")
+    XCTAssertEqual(sendVM.selectedContextCardId, "memory")
 
     let approveClient = FakeWriteClient(
       dispatch: .pause(makePause("run-chat-approve")),
@@ -610,9 +615,31 @@ final class FridayChatViewModelTests: XCTestCase {
           "source": "ios_chat_viewmodel_reject_runtime",
           "truth_label": "swift_viewmodel_write_client_runtime_not_live_hub_not_operator_key_not_endbar",
         ],
+        [
+          "surface": "mobile",
+          "screen": "fridayChat",
+          "action_id": "chat:handoffCard",
+          "capability_id": "ask_friday_chat",
+          "status": "pass",
+          "evidence_ref": "swift://mobile/fridayChat/handoff-card/\(answerReceipt.runId)",
+          "source": "ios_chat_viewmodel_context_card_runtime",
+          "truth_label": "swift_viewmodel_local_affordance_runtime_not_passport_send_not_endbar",
+        ],
+        [
+          "surface": "mobile",
+          "screen": "fridayChat",
+          "action_id": "chat:memoryCard",
+          "capability_id": "ask_friday_chat",
+          "status": "pass",
+          "evidence_ref": "swift://mobile/fridayChat/memory-card/\(answerReceipt.runId)",
+          "source": "ios_chat_viewmodel_context_card_runtime",
+          "truth_label": "swift_viewmodel_local_affordance_runtime_not_memory_decision_not_endbar",
+        ],
       ],
       proof: [
         "send_run_id": answerReceipt.runId,
+        "context_card_ids": sendVM.contextCards.map(\.id),
+        "selected_context_card_id": sendVM.selectedContextCardId ?? "",
         "approval_card_run_id": approvalCard.runId,
         "approval_card_digest_len": approvalCard.actionDigest.count,
         "approve_run_id": approveReceipt.runId,

--- a/apps/friday-ios/Tests/FridayMobileShellCoreTests/FridayChatViewModelTests.swift
+++ b/apps/friday-ios/Tests/FridayMobileShellCoreTests/FridayChatViewModelTests.swift
@@ -91,21 +91,33 @@ final class FridayChatViewModelTests: XCTestCase {
 
   final class FakeMissionClient: FridayMobileMissionDispatchingWriteClient, @unchecked Sendable {
     enum MemoryScript { case result(MemoryDecisionResultWire); case fail(FridayWriteClientError) }
+    enum PassportScript { case result(ContextPassportTransferResultWire); case fail(FridayWriteClientError) }
 
     private(set) var submittedIntakes: [MissionIntakeRequestWire] = []
     private(set) var missionContexts: [MissionWorkItemContextWire] = []
     private(set) var dispatchedTasks: [String] = []
     private(set) var memoryRequests: [MemoryDecisionRequestWire] = []
+    private(set) var passportRequests: [ContextPassportTransferRequestWire] = []
     let memoryScript: MemoryScript
+    let passportScript: PassportScript
 
     init(memoryScript: MemoryScript = .result(MemoryDecisionResultWire(
       memoryId: "unused",
       state: "unknown",
       status: "blocked",
       blocker: "unused",
-      recallable: false))
+      recallable: false)),
+      passportScript: PassportScript = .result(ContextPassportTransferResultWire(
+        passportId: "unused",
+        missionId: "unused",
+        destinationLane: "codex",
+        sharedItemCount: 0,
+        missionRefCount: 0,
+        status: "blocked",
+        blocker: "unused"))
     ) {
       self.memoryScript = memoryScript
+      self.passportScript = passportScript
     }
 
     func dispatchAgentRun(
@@ -143,6 +155,16 @@ final class FridayChatViewModelTests: XCTestCase {
     func submitMemoryDecision(_ request: MemoryDecisionRequestWire) async throws -> MemoryDecisionResultWire {
       memoryRequests.append(request)
       switch memoryScript {
+      case .result(let result): return result
+      case .fail(let error): throw error
+      }
+    }
+
+    func submitContextPassportTransfer(
+      _ request: ContextPassportTransferRequestWire
+    ) async throws -> ContextPassportTransferResultWire {
+      passportRequests.append(request)
+      switch passportScript {
       case .result(let result): return result
       case .fail(let error): throw error
       }
@@ -640,6 +662,40 @@ final class FridayChatViewModelTests: XCTestCase {
       rejectMemoryVM.contextMemoryDecisionState,
       .confirmed(summary: "rejected · state=rejected · recallable=false"))
 
+    let passportClient = FakeMissionClient(passportScript: .result(ContextPassportTransferResultWire(
+      passportId: "mobile-chat-passport-mission-mobile-passport",
+      missionId: "mission-mobile-passport",
+      workItemId: "work-mobile-passport",
+      destinationLane: "codex",
+      destinationTarget: "codex",
+      sharedItemCount: 3,
+      missionRefCount: 1,
+      linkId: "context-passport-mobile-chat-passport-mission-mobile-passport-1",
+      status: "confirmed")))
+    let passportRead = FakeReadClient(
+      snapshot: try WorkbenchSnapshot(
+        projectionJSON: Data("""
+        {"missionId":"mission-mobile-passport","fridayConversationId":"fconv_mobile_passport",\
+        "runtimeFeedStatus":"live_rust_hub_projection","statusLabels":[],"workItems":[]}
+        """.utf8),
+        generatedAtMs: 0),
+      answerBodies: ["run-first": "Owner-visible mission answer for a context handoff."])
+    let passportVM = FridayChatViewModel(
+      writeClient: passportClient,
+      signer: MockOperatorSigner(),
+      missionClient: passportClient,
+      readClient: passportRead,
+      newId: { "passport" })
+    await passportVM.send("create a mission answer for handoff", routePreference: .codex)
+    await passportVM.submitContextPassportHandoff()
+    XCTAssertEqual(passportClient.passportRequests.count, 1)
+    XCTAssertEqual(passportClient.passportRequests.first?.missionId, "mission-mobile-passport")
+    XCTAssertEqual(passportClient.passportRequests.first?.workItemId, "work-mobile-passport")
+    XCTAssertEqual(passportClient.passportRequests.first?.items.count, 3)
+    XCTAssertEqual(
+      passportVM.contextPassportTransferState,
+      .confirmed(summary: "passport mobile-chat-passport-mission-mobile-passport · items=3"))
+
     try writeMobileChatActionEvidenceIfRequested(
       actions: [
         [
@@ -705,6 +761,16 @@ final class FridayChatViewModelTests: XCTestCase {
         [
           "surface": "mobile",
           "screen": "fridayChat",
+          "action_id": "share",
+          "capability_id": "context_passport_transfer_checklist",
+          "status": "pass",
+          "evidence_ref": "swift://mobile/fridayChat/handoff/passport/\(passportClient.passportRequests.first?.missionId ?? "missing")",
+          "source": "ios_chat_viewmodel_context_passport_transfer_runtime",
+          "truth_label": "swift_viewmodel_context_passport_write_seam_runtime_not_live_hub_not_endbar",
+        ],
+        [
+          "surface": "mobile",
+          "screen": "fridayChat",
           "action_id": "check",
           "capability_id": "memory_review_no_silent_write_decide_candidate",
           "status": "pass",
@@ -730,6 +796,8 @@ final class FridayChatViewModelTests: XCTestCase {
         "memory_candidate_id": "cand-chat-1",
         "memory_keep_request_count": keepMemoryClient.memoryRequests.count,
         "memory_reject_request_count": rejectMemoryClient.memoryRequests.count,
+        "context_passport_request_count": passportClient.passportRequests.count,
+        "context_passport_item_count": passportClient.passportRequests.first?.items.count ?? 0,
         "approval_card_run_id": approvalCard.runId,
         "approval_card_digest_len": approvalCard.actionDigest.count,
         "approve_run_id": approveReceipt.runId,

--- a/apps/friday-ios/Tests/FridayMobileShellCoreTests/FridayChatViewModelTests.swift
+++ b/apps/friday-ios/Tests/FridayMobileShellCoreTests/FridayChatViewModelTests.swift
@@ -90,9 +90,23 @@ final class FridayChatViewModelTests: XCTestCase {
   }
 
   final class FakeMissionClient: FridayMobileMissionDispatchingWriteClient, @unchecked Sendable {
+    enum MemoryScript { case result(MemoryDecisionResultWire); case fail(FridayWriteClientError) }
+
     private(set) var submittedIntakes: [MissionIntakeRequestWire] = []
     private(set) var missionContexts: [MissionWorkItemContextWire] = []
     private(set) var dispatchedTasks: [String] = []
+    private(set) var memoryRequests: [MemoryDecisionRequestWire] = []
+    let memoryScript: MemoryScript
+
+    init(memoryScript: MemoryScript = .result(MemoryDecisionResultWire(
+      memoryId: "unused",
+      state: "unknown",
+      status: "blocked",
+      blocker: "unused",
+      recallable: false))
+    ) {
+      self.memoryScript = memoryScript
+    }
 
     func dispatchAgentRun(
       task: String,
@@ -127,12 +141,11 @@ final class FridayChatViewModelTests: XCTestCase {
     }
 
     func submitMemoryDecision(_ request: MemoryDecisionRequestWire) async throws -> MemoryDecisionResultWire {
-      MemoryDecisionResultWire(
-        memoryId: request.memoryId,
-        state: "unknown",
-        status: "blocked",
-        blocker: "unused",
-        recallable: false)
+      memoryRequests.append(request)
+      switch memoryScript {
+      case .result(let result): return result
+      case .fail(let error): throw error
+      }
     }
 
     func submitRunOutcomeLearningDecision(
@@ -239,6 +252,16 @@ final class FridayChatViewModelTests: XCTestCase {
   private func makePause(_ runId: String = "run-1") -> PausedOutcome {
     PausedOutcome(runId: runId, approvalId: "ap-nonce-\(runId)",
                   actionDigest: String(repeating: "c", count: 64), ownerSealedSummary: "write_file(notes.md)")
+  }
+
+  private func makeMemoryCandidateSnapshot(id: String = "cand-chat-1") throws -> WorkbenchSnapshot {
+    try WorkbenchSnapshot(
+      projectionJSON: Data("""
+      {"missionId":"mission-chat","fridayConversationId":"fconv-chat",\
+      "runtimeFeedStatus":"live_rust_hub_projection","statusLabels":[],"workItems":[],\
+      "memoryCandidates":[{"id":"\(id)","preview":"Remember Friday prefers batched PRs","state":"candidate_review_only","grantsMemoryAuthority":false,"evidenceRef":"proof://mobile/fridayChat/memory/\(id)"}]}
+      """.utf8),
+      generatedAtMs: 0)
   }
 
   private func writeMobileChatActionEvidenceIfRequested(
@@ -573,6 +596,50 @@ final class FridayChatViewModelTests: XCTestCase {
       return XCTFail("expected reject receipt, got \(rejectVM.phase)")
     }
 
+    let memoryRead = FakeReadClient(snapshot: try makeMemoryCandidateSnapshot())
+    let keepMemoryClient = FakeMissionClient(memoryScript: .result(MemoryDecisionResultWire(
+      memoryId: "cand-chat-1",
+      state: "confirmed",
+      status: "confirmed",
+      recallable: true)))
+    let keepMemoryVM = FridayChatViewModel(
+      writeClient: keepMemoryClient,
+      signer: MockOperatorSigner(),
+      readClient: memoryRead)
+    await keepMemoryVM.send("summarize the memory candidate")
+    XCTAssertEqual(keepMemoryVM.contextCards.first(where: { $0.id == "memory" })?.memoryCandidateId, "cand-chat-1")
+    await keepMemoryVM.decideContextMemory(confirm: true)
+    XCTAssertEqual(keepMemoryClient.memoryRequests, [
+      MemoryDecisionRequestWire(
+        memoryId: "cand-chat-1",
+        ownerPrincipal: liveAgentRunOwnerPrincipal,
+        decision: "confirm"),
+    ])
+    XCTAssertEqual(
+      keepMemoryVM.contextMemoryDecisionState,
+      .confirmed(summary: "confirmed · state=confirmed · recallable=true"))
+
+    let rejectMemoryClient = FakeMissionClient(memoryScript: .result(MemoryDecisionResultWire(
+      memoryId: "cand-chat-1",
+      state: "rejected",
+      status: "rejected",
+      recallable: false)))
+    let rejectMemoryVM = FridayChatViewModel(
+      writeClient: rejectMemoryClient,
+      signer: MockOperatorSigner(),
+      readClient: memoryRead)
+    await rejectMemoryVM.send("summarize the memory candidate")
+    await rejectMemoryVM.decideContextMemory(confirm: false)
+    XCTAssertEqual(rejectMemoryClient.memoryRequests, [
+      MemoryDecisionRequestWire(
+        memoryId: "cand-chat-1",
+        ownerPrincipal: liveAgentRunOwnerPrincipal,
+        decision: "reject"),
+    ])
+    XCTAssertEqual(
+      rejectMemoryVM.contextMemoryDecisionState,
+      .confirmed(summary: "rejected · state=rejected · recallable=false"))
+
     try writeMobileChatActionEvidenceIfRequested(
       actions: [
         [
@@ -635,11 +702,34 @@ final class FridayChatViewModelTests: XCTestCase {
           "source": "ios_chat_viewmodel_context_card_runtime",
           "truth_label": "swift_viewmodel_local_affordance_runtime_not_memory_decision_not_endbar",
         ],
+        [
+          "surface": "mobile",
+          "screen": "fridayChat",
+          "action_id": "check",
+          "capability_id": "memory_review_no_silent_write_decide_candidate",
+          "status": "pass",
+          "evidence_ref": "swift://mobile/fridayChat/memory/confirm/cand-chat-1",
+          "source": "ios_chat_viewmodel_memory_decision_runtime",
+          "truth_label": "swift_viewmodel_memory_decision_write_seam_runtime_not_live_hub_not_endbar",
+        ],
+        [
+          "surface": "mobile",
+          "screen": "fridayChat",
+          "action_id": "act",
+          "capability_id": "memory_review_no_silent_write_decide_candidate",
+          "status": "pass",
+          "evidence_ref": "swift://mobile/fridayChat/memory/reject/cand-chat-1",
+          "source": "ios_chat_viewmodel_memory_decision_runtime",
+          "truth_label": "swift_viewmodel_memory_decision_write_seam_runtime_not_live_hub_not_endbar",
+        ],
       ],
       proof: [
         "send_run_id": answerReceipt.runId,
         "context_card_ids": sendVM.contextCards.map(\.id),
         "selected_context_card_id": sendVM.selectedContextCardId ?? "",
+        "memory_candidate_id": "cand-chat-1",
+        "memory_keep_request_count": keepMemoryClient.memoryRequests.count,
+        "memory_reject_request_count": rejectMemoryClient.memoryRequests.count,
         "approval_card_run_id": approvalCard.runId,
         "approval_card_digest_len": approvalCard.actionDigest.count,
         "approve_run_id": approveReceipt.runId,

--- a/apps/friday-ios/Tests/FridayMobileShellCoreTests/FridayChatViewModelTests.swift
+++ b/apps/friday-ios/Tests/FridayMobileShellCoreTests/FridayChatViewModelTests.swift
@@ -241,6 +241,33 @@ final class FridayChatViewModelTests: XCTestCase {
                   actionDigest: String(repeating: "c", count: 64), ownerSealedSummary: "write_file(notes.md)")
   }
 
+  private func writeMobileChatActionEvidenceIfRequested(
+    actions: [[String: Any]],
+    proof: [String: Any]
+  ) throws {
+    guard let rawDir = ProcessInfo.processInfo.environment[
+      "FRIDAY_MOBILE_CHAT_ACTION_EVIDENCE_DIR"
+    ]?.trimmingCharacters(in: .whitespacesAndNewlines), !rawDir.isEmpty else {
+      return
+    }
+
+    let payload: [String: Any] = [
+      "truth": "mobile_chat_action_swift_viewmodel_runtime_not_live_hub_not_endbar",
+      "status": "ready",
+      "generated_at_utc": ISO8601DateFormatter().string(from: Date()),
+      "proof": proof,
+      "actions": actions,
+      "caveat": "Partial runtime evidence only: iOS Chat ViewModel actions delegate to the governed write/sign/reject seams and render refs-only results. This is not a simulator tap, not a live Hub audit receipt, not true operator-key approval, not END-BAR, and not adoption.",
+    ]
+
+    let dir = URL(fileURLWithPath: rawDir)
+    try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+    let out = dir.appendingPathComponent("action-runtime-evidence.json")
+    let data = try JSONSerialization.data(withJSONObject: payload, options: [.prettyPrinted, .sortedKeys])
+    try data.write(to: out, options: .atomic)
+    print("[mobile-chat-action-evidence] proofOut=\(out.path)")
+  }
+
   // MARK: 1. Compose → Send → Answer (mock)
 
   func testSend_settlesRefsOnlyAnswer() async {
@@ -498,6 +525,103 @@ final class FridayChatViewModelTests: XCTestCase {
     XCTAssertEqual(client.relayedBlobs.first, expected, "INV-1: the signer blob must ride VERBATIM")
     XCTAssertTrue(vm.history.last?.receiptRefs.contains(ChatReceiptRef(label: "audit_ref", ref: "audit://chain/run-1")) == true)
     XCTAssertTrue(vm.history.last?.receiptRefs.contains(ChatReceiptRef(label: "truth", ref: "rust_wired")) == true)
+  }
+
+  func testMobileChatActionEvidenceCoversSendApprovalCardAndControls() async throws {
+    let sendClient = FakeWriteClient(dispatch: .answer(makeAnswer("run-chat-send")))
+    let sendVM = FridayChatViewModel(writeClient: sendClient, signer: MockOperatorSigner())
+    await sendVM.send("summarize the current Friday closure status")
+    guard case let .answered(answerReceipt) = sendVM.phase else {
+      return XCTFail("expected answered, got \(sendVM.phase)")
+    }
+
+    let approveClient = FakeWriteClient(
+      dispatch: .pause(makePause("run-chat-approve")),
+      resume: .accepted(ResumeRelayResult(
+        runId: "run-chat-approve",
+        op: "resume",
+        accepted: true,
+        status: "mutation_completed",
+        auditRef: "audit://mobile-chat/approve")))
+    let approveVM = FridayChatViewModel(writeClient: approveClient, signer: MockOperatorSigner())
+    await approveVM.send("edit notes.md")
+    guard case let .pendingApproval(approvalCard) = approveVM.phase else {
+      return XCTFail("expected pending approval, got \(approveVM.phase)")
+    }
+    await approveVM.approve()
+    guard case let .resumed(approveReceipt) = approveVM.phase else {
+      return XCTFail("expected approve resume receipt, got \(approveVM.phase)")
+    }
+
+    let rejectClient = FakeWriteClient(
+      dispatch: .pause(makePause("run-chat-reject")),
+      reject: .accepted(ResumeRelayResult(
+        runId: "run-chat-reject",
+        op: "reject",
+        accepted: true,
+        status: "rejected",
+        auditRef: "audit://mobile-chat/reject")))
+    let rejectVM = FridayChatViewModel(writeClient: rejectClient, signer: MockOperatorSigner())
+    await rejectVM.send("edit notes.md")
+    await rejectVM.reject()
+    guard case let .resumed(rejectReceipt) = rejectVM.phase else {
+      return XCTFail("expected reject receipt, got \(rejectVM.phase)")
+    }
+
+    try writeMobileChatActionEvidenceIfRequested(
+      actions: [
+        [
+          "surface": "mobile",
+          "screen": "fridayChat",
+          "action_id": "chat:typing",
+          "capability_id": "ask_friday_chat",
+          "status": "pass",
+          "evidence_ref": "swift://mobile/fridayChat/send/\(answerReceipt.runId)",
+          "source": "ios_chat_viewmodel_send_runtime",
+          "truth_label": "swift_viewmodel_write_client_runtime_not_live_hub_not_operator_key_not_endbar",
+        ],
+        [
+          "surface": "mobile",
+          "screen": "fridayChat",
+          "action_id": "chat:approveCard",
+          "capability_id": "ask_friday_chat",
+          "status": "pass",
+          "evidence_ref": "swift://mobile/fridayChat/approval-card/\(approvalCard.runId)",
+          "source": "ios_chat_viewmodel_paused_approval_card_runtime",
+          "truth_label": "swift_viewmodel_write_client_runtime_not_live_hub_not_operator_key_not_endbar",
+        ],
+        [
+          "surface": "mobile",
+          "screen": "fridayChat",
+          "action_id": "check",
+          "capability_id": "security_approval_bound_principal_gate_cat10_netnew",
+          "status": "pass",
+          "evidence_ref": "swift://mobile/fridayChat/approve/\(approveReceipt.runId)",
+          "source": "ios_chat_viewmodel_approve_relay_runtime",
+          "truth_label": "swift_viewmodel_mock_operator_signer_not_true_key_not_endbar",
+        ],
+        [
+          "surface": "mobile",
+          "screen": "fridayChat",
+          "action_id": "act",
+          "capability_id": "security_approval_bound_principal_gate_cat10_netnew",
+          "status": "pass",
+          "evidence_ref": "swift://mobile/fridayChat/reject/\(rejectReceipt.runId)",
+          "source": "ios_chat_viewmodel_reject_runtime",
+          "truth_label": "swift_viewmodel_write_client_runtime_not_live_hub_not_operator_key_not_endbar",
+        ],
+      ],
+      proof: [
+        "send_run_id": answerReceipt.runId,
+        "approval_card_run_id": approvalCard.runId,
+        "approval_card_digest_len": approvalCard.actionDigest.count,
+        "approve_run_id": approveReceipt.runId,
+        "approve_status": approveReceipt.status,
+        "reject_run_id": rejectReceipt.runId,
+        "reject_status": rejectReceipt.status,
+        "approve_relay_count": approveClient.resumedRunIds.count,
+        "reject_relay_count": rejectClient.rejectedRunIds.count,
+      ])
   }
 
   /// A server REFUSAL (`accepted=false`) is a SUCCESSFUL relay of a refusal — the action did NOT

--- a/apps/friday-ios/Tests/FridayMobileShellCoreTests/HomeViewModelTests.swift
+++ b/apps/friday-ios/Tests/FridayMobileShellCoreTests/HomeViewModelTests.swift
@@ -199,23 +199,31 @@ final class HomeViewModelTests: XCTestCase {
       case result(ActivityMarkDoneResultWire)
       case fail(Error)
     }
+    enum PassportScript {
+      case result(ContextPassportTransferResultWire)
+      case fail(Error)
+    }
 
     let learningScript: LearningScript?
     let memoryScript: MemoryScript?
     let activityScript: ActivityScript?
+    let passportScript: PassportScript?
     private(set) var memoryRequests: [MemoryDecisionRequestWire] = []
     private(set) var learningRequests: [RunOutcomeLearningDecisionRequestWire] = []
     private(set) var activityMarkDoneRequests: [ActivityMarkDoneRequestWire] = []
+    private(set) var passportRequests: [ContextPassportTransferRequestWire] = []
     private(set) var workItemStatusRequests: [WorkItemStatusRequestWire] = []
 
     init(
       learningScript: LearningScript? = nil,
       memoryScript: MemoryScript? = nil,
-      activityScript: ActivityScript? = nil
+      activityScript: ActivityScript? = nil,
+      passportScript: PassportScript? = nil
     ) {
       self.learningScript = learningScript
       self.memoryScript = memoryScript
       self.activityScript = activityScript
+      self.passportScript = passportScript
     }
 
     func submitMissionIntake(_ request: MissionIntakeRequestWire) async throws -> MissionIntakeResultWire {
@@ -246,6 +254,17 @@ final class HomeViewModelTests: XCTestCase {
       activityMarkDoneRequests.append(request)
       guard let activityScript else { throw NSError(domain: "unused", code: 1) }
       switch activityScript {
+      case .result(let result): return result
+      case .fail(let error): throw error
+      }
+    }
+
+    func submitContextPassportTransfer(
+      _ request: ContextPassportTransferRequestWire
+    ) async throws -> ContextPassportTransferResultWire {
+      passportRequests.append(request)
+      guard let passportScript else { throw NSError(domain: "unused", code: 1) }
+      switch passportScript {
       case .result(let result): return result
       case .fail(let error): throw error
       }
@@ -935,6 +954,61 @@ final class HomeViewModelTests: XCTestCase {
       .error(reason: "Write seam not configured."))
   }
 
+  func testSubmitContextPassportTransferRendersConfirmedAndRefreshes() async throws {
+    let read = FakeReadClient(.snapshot(try sampleSnapshot()))
+    let write = FakeMissionWriteClient(passportScript: .result(ContextPassportTransferResultWire(
+      passportId: "mobile-passport-mission-7",
+      missionId: "mission-7",
+      workItemId: "wi-1",
+      destinationLane: "codex",
+      destinationTarget: "codex",
+      sharedItemCount: 3,
+      missionRefCount: 1,
+      linkId: "context-passport-mobile-passport-mission-7-1",
+      status: "confirmed")))
+    let vm = HomeViewModel(
+      client: read,
+      writeClient: write,
+      writeOwnerPrincipal: "owner-ios")
+    let projection = HomeProjection(try sampleSnapshot())
+
+    await vm.submitContextPassportTransfer(for: projection)
+
+    XCTAssertEqual(write.passportRequests.count, 1)
+    XCTAssertEqual(write.passportRequests.first?.passportId, "mobile-passport-mission-7")
+    XCTAssertEqual(write.passportRequests.first?.missionId, "mission-7")
+    XCTAssertEqual(write.passportRequests.first?.workItemId, "wi-1")
+    XCTAssertEqual(write.passportRequests.first?.destinationLane, "codex")
+    XCTAssertEqual(write.passportRequests.first?.destinationTarget, "codex")
+    XCTAssertEqual(write.passportRequests.first?.items.count, 3)
+    XCTAssertEqual(read.fetchWorkbenchCount, 1)
+    XCTAssertEqual(
+      vm.contextPassportTransferState,
+      .confirmed(summary: "passport mobile-passport-mission-7 · items=3"))
+    try writeMobilePassportTransferActionEvidenceIfRequested(
+      request: try XCTUnwrap(write.passportRequests.first),
+      result: ContextPassportTransferResultWire(
+        passportId: "mobile-passport-mission-7",
+        missionId: "mission-7",
+        workItemId: "wi-1",
+        destinationLane: "codex",
+        destinationTarget: "codex",
+        sharedItemCount: 3,
+        missionRefCount: 1,
+        linkId: "context-passport-mobile-passport-mission-7-1",
+        status: "confirmed"))
+  }
+
+  func testSubmitContextPassportTransferWithoutWriteClientIsUnavailable() async throws {
+    let vm = HomeViewModel(client: FakeReadClient(.snapshot(try sampleSnapshot())))
+
+    await vm.submitContextPassportTransfer(for: HomeProjection(try sampleSnapshot()))
+
+    XCTAssertEqual(
+      vm.contextPassportTransferState,
+      .error(reason: "Write seam not configured."))
+  }
+
   private func writeMobileMemoryActionEvidenceIfRequested(
     fileSuffix: String,
     screen: String,
@@ -989,6 +1063,63 @@ final class HomeViewModelTests: XCTestCase {
     let data = try JSONSerialization.data(withJSONObject: proof, options: [.prettyPrinted, .sortedKeys])
     try data.write(to: out, options: .atomic)
     print("[mobile-memory-action-evidence] proofOut=\(out.path)")
+  }
+
+  private func writeMobilePassportTransferActionEvidenceIfRequested(
+    request: ContextPassportTransferRequestWire,
+    result: ContextPassportTransferResultWire
+  ) throws {
+    guard let rawDir = ProcessInfo.processInfo.environment[
+      "FRIDAY_MOBILE_PASSPORT_TRANSFER_ACTION_EVIDENCE_DIR"
+    ]?.trimmingCharacters(in: .whitespacesAndNewlines), !rawDir.isEmpty else {
+      return
+    }
+
+    let proof: [String: Any] = [
+      "truth": "mobile_passport_transfer_swift_viewmodel_runtime_not_live_hub_not_endbar",
+      "status": "ready",
+      "generated_at_utc": ISO8601DateFormatter().string(from: Date()),
+      "request": [
+        "passport_id": request.passportId,
+        "mission_id": request.missionId,
+        "work_item_id": request.workItemId.map { $0 as Any } ?? NSNull(),
+        "destination_lane": request.destinationLane,
+        "destination_target": request.destinationTarget.map { $0 as Any } ?? NSNull(),
+        "item_count": request.items.count,
+        "approved_sensitive": request.approvedSensitive,
+      ],
+      "result": [
+        "passport_id": result.passportId,
+        "mission_id": result.missionId,
+        "work_item_id": result.workItemId.map { $0 as Any } ?? NSNull(),
+        "destination_lane": result.destinationLane,
+        "destination_target": result.destinationTarget.map { $0 as Any } ?? NSNull(),
+        "shared_item_count": result.sharedItemCount,
+        "mission_ref_count": result.missionRefCount,
+        "link_id": result.linkId.map { $0 as Any } ?? NSNull(),
+        "status": result.status,
+      ],
+      "actions": [
+        [
+          "surface": "mobile",
+          "screen": "passport",
+          "action_id": "check",
+          "capability_id": "context_passport_transfer_checklist",
+          "status": "pass",
+          "evidence_ref": "swift://mobile/passport/send/\(request.missionId)",
+          "source": "ios_home_viewmodel_context_passport_transfer_runtime",
+          "truth_label": "swift_viewmodel_context_passport_write_seam_runtime_not_live_hub_not_endbar",
+        ],
+      ],
+      "caveat": "This is Swift product ViewModel runtime evidence that the mobile Passport action delegates to the governed context-passport write seam and renders a refs-only result. It is not a live Hub audit receipt, not a simulator tap, not END-BAR, and not adoption.",
+    ]
+
+    let dir = URL(fileURLWithPath: rawDir)
+    try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+    let out = dir.appendingPathComponent("mobile-passport-transfer-action-evidence.json")
+    let data = try JSONSerialization.data(withJSONObject: proof, options: [.prettyPrinted, .sortedKeys])
+    try data.write(to: out, options: .atomic)
+    print("[mobile-passport-transfer-action-evidence] proofOut=\(out.path)")
   }
 
   private func writeHomeRefreshActionEvidenceIfRequested(

--- a/apps/friday-ios/Tests/FridayMobileShellCoreTests/HomeViewModelTests.swift
+++ b/apps/friday-ios/Tests/FridayMobileShellCoreTests/HomeViewModelTests.swift
@@ -846,6 +846,7 @@ final class HomeViewModelTests: XCTestCase {
       fileSuffix: "confirm",
       screen: "memory",
       actionId: "check",
+      additionalActionIds: ["memory_resolve"],
       evidenceRef: "proof://mobile/memory-confirm/cand-1",
       request: try XCTUnwrap(write.memoryRequests.first),
       result: MemoryDecisionResultWire(
@@ -884,6 +885,7 @@ final class HomeViewModelTests: XCTestCase {
       fileSuffix: "reject",
       screen: "memory",
       actionId: "act",
+      additionalActionIds: ["memory_resolve"],
       evidenceRef: "proof://mobile/memory-reject/cand-1",
       request: try XCTUnwrap(write.memoryRequests.first),
       result: MemoryDecisionResultWire(
@@ -937,6 +939,7 @@ final class HomeViewModelTests: XCTestCase {
     fileSuffix: String,
     screen: String,
     actionId: String,
+    additionalActionIds: [String] = [],
     evidenceRef: String,
     request: MemoryDecisionRequestWire,
     result: MemoryDecisionResultWire
@@ -945,6 +948,19 @@ final class HomeViewModelTests: XCTestCase {
       "FRIDAY_MOBILE_MEMORY_ACTION_EVIDENCE_DIR"
     ]?.trimmingCharacters(in: .whitespacesAndNewlines), !rawDir.isEmpty else {
       return
+    }
+
+    let actions: [[String: Any]] = ([actionId] + additionalActionIds).map { candidateActionId in
+      [
+        "surface": "mobile",
+        "screen": screen,
+        "action_id": candidateActionId,
+        "capability_id": "memory_review_no_silent_write_decide_candidate",
+        "status": "pass",
+        "evidence_ref": evidenceRef,
+        "source": "ios_home_viewmodel_memory_decision_runtime",
+        "truth_label": "swift_viewmodel_write_client_runtime_not_live_hub_audit_not_sim_tap",
+      ]
     }
 
     let proof: [String: Any] = [
@@ -963,18 +979,7 @@ final class HomeViewModelTests: XCTestCase {
         "blocker": result.blocker.map { $0 as Any } ?? NSNull(),
         "recallable": result.recallable,
       ],
-      "actions": [
-        [
-          "surface": "mobile",
-          "screen": screen,
-          "action_id": actionId,
-          "capability_id": "memory_review_no_silent_write_decide_candidate",
-          "status": "pass",
-          "evidence_ref": evidenceRef,
-          "source": "ios_home_viewmodel_memory_decision_runtime",
-          "truth_label": "swift_viewmodel_write_client_runtime_not_live_hub_audit_not_sim_tap",
-        ],
-      ],
+      "actions": actions,
       "caveat": "This is Swift product ViewModel runtime evidence that the mobile memory action delegates to the write seam and renders the refs-only result. It is not a live Hub memory-spine audit receipt, not a simulator tap, not END-BAR, and not adoption.",
     ]
 

--- a/apps/friday-ios/Tests/FridayMobileShellCoreTests/NewSessionViewModelTests.swift
+++ b/apps/friday-ios/Tests/FridayMobileShellCoreTests/NewSessionViewModelTests.swift
@@ -21,6 +21,21 @@ final class NewSessionViewModelTests: XCTestCase {
       MemoryDecisionResultWire(memoryId: request.memoryId, state: "unknown", status: "blocked", blocker: "unused", recallable: false)
     }
 
+    func submitContextPassportTransfer(
+      _ request: ContextPassportTransferRequestWire
+    ) async throws -> ContextPassportTransferResultWire {
+      ContextPassportTransferResultWire(
+        passportId: request.passportId,
+        missionId: request.missionId,
+        workItemId: request.workItemId,
+        destinationLane: request.destinationLane,
+        destinationTarget: request.destinationTarget,
+        sharedItemCount: 0,
+        missionRefCount: 0,
+        status: "blocked",
+        blocker: "unused")
+    }
+
     func submitRunOutcomeLearningDecision(
       _ request: RunOutcomeLearningDecisionRequestWire
     ) async throws -> RunOutcomeLearningDecisionResultWire {

--- a/apps/friday-ios/Tests/FridayMobileShellCoreTests/NewSessionViewModelTests.swift
+++ b/apps/friday-ios/Tests/FridayMobileShellCoreTests/NewSessionViewModelTests.swift
@@ -1,0 +1,119 @@
+import XCTest
+@testable import FridayMobileShellCore
+@testable import FridayRustClient
+
+@MainActor
+final class NewSessionViewModelTests: XCTestCase {
+  final class FakeMissionClient: FridayMissionSpineWriteClient, @unchecked Sendable {
+    var result: MissionIntakeResultWire
+    private(set) var requests: [MissionIntakeRequestWire] = []
+
+    init(result: MissionIntakeResultWire) {
+      self.result = result
+    }
+
+    func submitMissionIntake(_ request: MissionIntakeRequestWire) async throws -> MissionIntakeResultWire {
+      requests.append(request)
+      return result
+    }
+
+    func submitMemoryDecision(_ request: MemoryDecisionRequestWire) async throws -> MemoryDecisionResultWire {
+      MemoryDecisionResultWire(memoryId: request.memoryId, state: "unknown", status: "blocked", blocker: "unused", recallable: false)
+    }
+
+    func submitRunOutcomeLearningDecision(
+      _ request: RunOutcomeLearningDecisionRequestWire
+    ) async throws -> RunOutcomeLearningDecisionResultWire {
+      RunOutcomeLearningDecisionResultWire(candidateId: request.candidateId, state: "unknown", status: "blocked", blocker: "unused")
+    }
+
+    func submitActivityMarkDone(_ request: ActivityMarkDoneRequestWire) async throws -> ActivityMarkDoneResultWire {
+      ActivityMarkDoneResultWire(activityId: request.activityId, state: "unknown", status: "blocked", blocker: "unused")
+    }
+
+    func submitWorkItemStatus(_ request: WorkItemStatusRequestWire) async throws -> WorkItemStatusResultWire {
+      WorkItemStatusResultWire(
+        workItemId: request.workItemId,
+        missionId: "unused",
+        previousStatus: "unknown",
+        status: "blocked",
+        actorRef: request.actorRef,
+        reason: request.reason,
+        proofReceiptCount: 0,
+        updatedAtMs: 0)
+    }
+  }
+
+  func testNoWriteClientFailsClosedWithoutFakeLaunch() async {
+    let vm = NewSessionViewModel(client: nil, idFactory: { "fixed" })
+
+    await vm.launch(intent: "summarize today's Friday closure state")
+
+    XCTAssertEqual(vm.launchState, .blocked(reason: "Write seam not configured."))
+  }
+
+  func testLaunchSubmitsGovernedMissionIntake() async throws {
+    let client = FakeMissionClient(result: MissionIntakeResultWire(
+      fridayConversationId: "fconv_mobile_new_session_fixed",
+      missionId: "mission-mobile-new-session-fixed",
+      workItemId: "work-mobile-new-session-fixed",
+      surfaceThreadId: "surface-mobile-new-session-fixed",
+      status: "ready",
+      createdOrReady: true))
+    let vm = NewSessionViewModel(client: client, owner: "owner-ios", idFactory: { "fixed" })
+
+    await vm.launch(intent: "Summarize current v1 closure risk.")
+
+    XCTAssertEqual(client.requests.count, 1)
+    let request = try XCTUnwrap(client.requests.first)
+    XCTAssertEqual(request.fridayConversationId, "fconv_mobile_new_session_fixed")
+    XCTAssertEqual(request.ownerPrincipal, "owner-ios")
+    XCTAssertEqual(request.surfaceKind, "mobile")
+    XCTAssertEqual(request.deliveryRoute, "ios://friday-mobile/new-session/fixed")
+    XCTAssertEqual(request.visibilityPolicy, "compact")
+    XCTAssertEqual(request.missionId, "mission-mobile-new-session-fixed")
+    XCTAssertEqual(request.workItemId, "work-mobile-new-session-fixed")
+    XCTAssertEqual(request.title, "Summarize current v1 closure risk.")
+    XCTAssertEqual(request.intent, "Summarize current v1 closure risk.")
+    XCTAssertEqual(request.lane, "auto")
+    XCTAssertEqual(
+      vm.launchState,
+      .launched(
+        summary: "ready · mission=mission-mobile-new-session-fixed · work_item=work-mobile-new-session-fixed",
+        missionId: "mission-mobile-new-session-fixed",
+        workItemId: "work-mobile-new-session-fixed"))
+
+    try writeNewSessionActionEvidenceIfRequested()
+  }
+
+  private func writeNewSessionActionEvidenceIfRequested() throws {
+    guard let rawDir = ProcessInfo.processInfo.environment["FRIDAY_MOBILE_NEW_SESSION_ACTION_EVIDENCE_DIR"],
+          !rawDir.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+      return
+    }
+    let dir = URL(fileURLWithPath: rawDir, isDirectory: true)
+    try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+    let payload: [String: Any] = [
+      "truth": "mobile_new_session_launch_swift_viewmodel_runtime_not_live_hub_not_endbar",
+      "status": "ready",
+      "actions": [
+        [
+          "surface": "mobile",
+          "screen": "newSession",
+          "action_id": "play",
+          "capability_id": "session_control_native_set",
+          "status": "pass",
+          "evidence_ref": "swift://mobile/newSession/play/mission-mobile-new-session-fixed",
+          "proof": [
+            "mission_id": "mission-mobile-new-session-fixed",
+            "work_item_id": "work-mobile-new-session-fixed",
+            "surface_kind": "mobile",
+            "delivery_route": "ios://friday-mobile/new-session/fixed",
+          ],
+        ],
+      ],
+    ]
+    let data = try JSONSerialization.data(withJSONObject: payload, options: [.prettyPrinted, .sortedKeys])
+    try data.write(to: dir.appendingPathComponent("mobile-new-session-action-evidence.json"), options: .atomic)
+  }
+}

--- a/apps/friday-ios/Tests/FridayMobileShellCoreTests/SessionContinuationViewModelTests.swift
+++ b/apps/friday-ios/Tests/FridayMobileShellCoreTests/SessionContinuationViewModelTests.swift
@@ -682,7 +682,7 @@ final class SessionContinuationViewModelTests: XCTestCase {
     XCTAssertTrue(failed.resumedRunIds.isEmpty)
   }
 
-  func testStopUsesGovernedCancelRunAndSurfacesReceipt() async {
+  func testStopUsesGovernedCancelRunAndSurfacesReceipt() async throws {
     let client = FakeSessionReadClient()
     let write = FakeSessionWriteClient()
     let vm = SessionContinuationViewModel(
@@ -698,6 +698,11 @@ final class SessionContinuationViewModelTests: XCTestCase {
     XCTAssertEqual(
       vm.controlStates["stop"],
       .succeeded(summary: "cancel: cancelled · accepted · audit://cancel/run-1"))
+    try writeWorkflowRunControlActionEvidenceIfRequested(
+      runId: "run-1",
+      auditRef: "audit://cancel/run-1",
+      cancelledRunIds: write.cancelledRunIds,
+      cancelReasons: write.cancelReasons)
   }
 
   func testStopRefusalAndTransportFailureRenderError() async {
@@ -856,5 +861,46 @@ final class SessionContinuationViewModelTests: XCTestCase {
     ]
     let data = try JSONSerialization.data(withJSONObject: payload, options: [.prettyPrinted, .sortedKeys])
     try data.write(to: dir.appendingPathComponent("mobile-session-sidecar-action-evidence.json"), options: .atomic)
+  }
+
+  private func writeWorkflowRunControlActionEvidenceIfRequested(
+    runId: String,
+    auditRef: String,
+    cancelledRunIds: [String],
+    cancelReasons: [String?]
+  ) throws {
+    guard let rawDir = ProcessInfo.processInfo.environment["FRIDAY_MOBILE_WORKFLOW_ACTION_EVIDENCE_DIR"],
+          !rawDir.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+      return
+    }
+    let dir = URL(fileURLWithPath: rawDir, isDirectory: true)
+    try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+    let payload: [String: Any] = [
+      "truth": "mobile_workflow_action_swift_viewmodel_runtime_not_live_hub_not_endbar",
+      "status": "ready",
+      "generated_at_utc": ISO8601DateFormatter().string(from: Date()),
+      "actions": [
+        [
+          "surface": "mobile",
+          "screen": "workflow",
+          "action_id": "workflow_run_control",
+          "capability_id": "session_control_native_set",
+          "status": "pass",
+          "evidence_ref": "swift://mobile/workflow/run-control/\(runId)",
+          "source": "ios_session_continuation_viewmodel_stop_runtime",
+          "truth_label": "swift_viewmodel_write_client_runtime_not_live_hub_not_sim_tap",
+        ],
+      ],
+      "proof": [
+        "run_id": runId,
+        "op": "cancel",
+        "audit_ref": auditRef,
+        "cancelled_run_ids": cancelledRunIds,
+        "cancel_reasons": cancelReasons.map { $0 ?? "" },
+      ],
+      "caveat": "Partial runtime evidence only: iOS SessionContinuation ViewModel run-control delegates to the governed write seam and renders a refs-only receipt. This is not a live Hub audit receipt, not a simulator tap, not END-BAR, and not adoption.",
+    ]
+    let data = try JSONSerialization.data(withJSONObject: payload, options: [.prettyPrinted, .sortedKeys])
+    try data.write(to: dir.appendingPathComponent("mobile-workflow-action-evidence.json"), options: .atomic)
   }
 }

--- a/apps/friday-ios/Tests/FridayMobileShellCoreTests/SessionContinuationViewModelTests.swift
+++ b/apps/friday-ios/Tests/FridayMobileShellCoreTests/SessionContinuationViewModelTests.swift
@@ -790,4 +790,71 @@ final class SessionContinuationViewModelTests: XCTestCase {
     XCTAssertEqual(snapshot.controls.first { $0.id == "history" }?.truthLabel, "read arm")
     XCTAssertEqual(snapshot.controls.first { $0.id == "attachments" }?.truthLabel, "NO-GO")
   }
+
+  func testSessionSidecarOpenCloseKeepsProviderPrivate() throws {
+    let vm = SessionContinuationViewModel(client: FakeSessionReadClient())
+
+    XCTAssertFalse(vm.sidecarState.isOpen)
+    vm.openSidecar()
+    XCTAssertTrue(vm.sidecarState.isOpen)
+    XCTAssertEqual(vm.sidecarState.actionState, .idle)
+
+    vm.analyzeSidecarPrivately()
+    XCTAssertEqual(
+      vm.sidecarState.actionState,
+      .ready(summary: "Private Friday analysis ready. Nothing has been sent to the provider."))
+
+    vm.blockSidecarExternalAction("Send to provider")
+    guard case .blocked(let reason) = vm.sidecarState.actionState else {
+      return XCTFail("expected blocked external sidecar action")
+    }
+    XCTAssertTrue(reason.contains("governed confirmation path"))
+
+    vm.closeSidecar()
+    XCTAssertFalse(vm.sidecarState.isOpen)
+    try writeSessionSidecarActionEvidenceIfRequested()
+  }
+
+  private func writeSessionSidecarActionEvidenceIfRequested() throws {
+    guard let rawDir = ProcessInfo.processInfo.environment["FRIDAY_MOBILE_SESSION_SIDECAR_ACTION_EVIDENCE_DIR"],
+          !rawDir.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+      return
+    }
+    let dir = URL(fileURLWithPath: rawDir, isDirectory: true)
+    try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+    let payload: [String: Any] = [
+      "truth": "mobile_session_sidecar_action_swift_viewmodel_runtime_not_live_hub_not_endbar",
+      "status": "ready",
+      "actions": [
+        [
+          "surface": "mobile",
+          "screen": "session",
+          "action_id": "sidecar_open",
+          "capability_id": "friday_sidecar_private",
+          "status": "pass",
+          "evidence_ref": "swift://mobile/session/sidecar/open",
+          "proof": [
+            "sidecar_open": true,
+            "provider_sent": false,
+            "external_actions_blocked_without_confirm": true,
+          ],
+        ],
+        [
+          "surface": "mobile",
+          "screen": "session",
+          "action_id": "sidecar_close",
+          "capability_id": "friday_sidecar_private",
+          "status": "pass",
+          "evidence_ref": "swift://mobile/session/sidecar/close",
+          "proof": [
+            "sidecar_open_after_close": false,
+            "provider_sent": false,
+            "external_actions_blocked_without_confirm": true,
+          ],
+        ],
+      ],
+    ]
+    let data = try JSONSerialization.data(withJSONObject: payload, options: [.prettyPrinted, .sortedKeys])
+    try data.write(to: dir.appendingPathComponent("mobile-session-sidecar-action-evidence.json"), options: .atomic)
+  }
 }

--- a/apps/friday-ios/Tests/FridayMobileShellCoreTests/ShareIntakeViewModelTests.swift
+++ b/apps/friday-ios/Tests/FridayMobileShellCoreTests/ShareIntakeViewModelTests.swift
@@ -26,6 +26,21 @@ final class ShareIntakeViewModelTests: XCTestCase {
         recallable: false)
     }
 
+    func submitContextPassportTransfer(
+      _ request: ContextPassportTransferRequestWire
+    ) async throws -> ContextPassportTransferResultWire {
+      ContextPassportTransferResultWire(
+        passportId: request.passportId,
+        missionId: request.missionId,
+        workItemId: request.workItemId,
+        destinationLane: request.destinationLane,
+        destinationTarget: request.destinationTarget,
+        sharedItemCount: 0,
+        missionRefCount: 0,
+        status: "blocked",
+        blocker: "unused")
+    }
+
     func submitRunOutcomeLearningDecision(
       _ request: RunOutcomeLearningDecisionRequestWire
     ) async throws -> RunOutcomeLearningDecisionResultWire {

--- a/apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/RealWriteClientFactory.swift
+++ b/apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/RealWriteClientFactory.swift
@@ -142,6 +142,11 @@ struct HonestlyUnavailableWriteClient: FridayMissionSpineWriteClient, FridayMiss
   func submitMemoryDecision(_ request: MemoryDecisionRequestWire) async throws -> MemoryDecisionResultWire {
     throw FridayWriteClientError.transport("live write client unavailable: \(reason)")
   }
+  func submitContextPassportTransfer(
+    _ request: ContextPassportTransferRequestWire
+  ) async throws -> ContextPassportTransferResultWire {
+    throw FridayWriteClientError.transport("live write client unavailable: \(reason)")
+  }
   func submitRunOutcomeLearningDecision(
     _ request: RunOutcomeLearningDecisionRequestWire
   ) async throws -> RunOutcomeLearningDecisionResultWire {

--- a/apps/macos/FridayHubConsole/Tests/FridayHubConsoleCoreTests/OperationsOverviewViewModelTests.swift
+++ b/apps/macos/FridayHubConsole/Tests/FridayHubConsoleCoreTests/OperationsOverviewViewModelTests.swift
@@ -567,6 +567,7 @@ final class MockMissionSpineWriteClient: FridayMissionSpineWriteClient, FridayMi
   private let lock = NSLock()
   private var _lastIntake: MissionIntakeRequestWire?
   private var _lastDecision: MemoryDecisionRequestWire?
+  private var _lastContextPassportTransfer: ContextPassportTransferRequestWire?
   private var _lastLearningDecision: RunOutcomeLearningDecisionRequestWire?
   private var _lastActivityMarkDone: ActivityMarkDoneRequestWire?
   private var _lastWorkItemStatus: WorkItemStatusRequestWire?
@@ -582,6 +583,9 @@ final class MockMissionSpineWriteClient: FridayMissionSpineWriteClient, FridayMi
   private var _dispatchedTasks: [String] = []
   var lastIntake: MissionIntakeRequestWire? { lock.withLock { _lastIntake } }
   var lastDecision: MemoryDecisionRequestWire? { lock.withLock { _lastDecision } }
+  var lastContextPassportTransfer: ContextPassportTransferRequestWire? {
+    lock.withLock { _lastContextPassportTransfer }
+  }
   var lastLearningDecision: RunOutcomeLearningDecisionRequestWire? {
     lock.withLock { _lastLearningDecision }
   }
@@ -639,6 +643,25 @@ final class MockMissionSpineWriteClient: FridayMissionSpineWriteClient, FridayMi
         status: request.decision == "confirm" ? "confirmed" : "rejected",
         recallable: request.decision == "confirm")
     }
+  }
+
+  func submitContextPassportTransfer(
+    _ request: ContextPassportTransferRequestWire
+  ) async throws -> ContextPassportTransferResultWire {
+    lock.withLock { _lastContextPassportTransfer = request }
+    if case .throwsTransport = behavior {
+      throw FridayWriteClientError.transport("connection refused (write server dark)")
+    }
+    return ContextPassportTransferResultWire(
+      passportId: request.passportId,
+      missionId: request.missionId,
+      workItemId: request.workItemId,
+      destinationLane: request.destinationLane,
+      destinationTarget: request.destinationTarget,
+      sharedItemCount: UInt64(request.items.count),
+      missionRefCount: 1,
+      linkId: "context-passport-\(request.passportId)-1",
+      status: "confirmed")
   }
 
   func submitRunOutcomeLearningDecision(

--- a/apps/macos/FridayRustClient/Sources/FridayRustClient/PairingClient.swift
+++ b/apps/macos/FridayRustClient/Sources/FridayRustClient/PairingClient.swift
@@ -160,6 +160,8 @@ private func pairingKind(_ message: FridayMessage) -> String {
   case .missionIntakeResult: return "MissionIntakeResult"
   case .memoryDecisionRequest: return "MemoryDecisionRequest"
   case .memoryDecisionResult: return "MemoryDecisionResult"
+  case .contextPassportTransferRequest: return "ContextPassportTransferRequest"
+  case .contextPassportTransferResult: return "ContextPassportTransferResult"
   case .runOutcomeLearningDecisionRequest: return "RunOutcomeLearningDecisionRequest"
   case .runOutcomeLearningDecisionResult: return "RunOutcomeLearningDecisionResult"
   case .activityMarkDoneRequest: return "ActivityMarkDoneRequest"

--- a/apps/macos/FridayRustClient/Sources/FridayRustClient/Protocol.swift
+++ b/apps/macos/FridayRustClient/Sources/FridayRustClient/Protocol.swift
@@ -528,6 +528,10 @@ public enum FridayMessage: Equatable {
   /// hub→trusted-peer: memory decision receipt (refs-only). Mirrors
   /// `friday_protocol::Message::MemoryDecisionResult` — NESTED `{ result: … }`.
   case memoryDecisionResult(MemoryDecisionResultWire)
+  /// trusted-peer→hub: mint one governed ContextPassport for an existing Mission.
+  case contextPassportTransferRequest(ContextPassportTransferRequestWire)
+  /// hub→trusted-peer: refs-only ContextPassport mint receipt.
+  case contextPassportTransferResult(ContextPassportTransferResultWire)
   /// trusted-peer→hub: confirm/reject ONE pending A1 run-outcome learning candidate.
   /// Mirrors `friday_protocol::Message::RunOutcomeLearningDecisionRequest`.
   case runOutcomeLearningDecisionRequest(RunOutcomeLearningDecisionRequestWire)
@@ -760,6 +764,14 @@ extension FridayMessage: Codable {
     case "MemoryDecisionResult":
       let c = try decoder.container(keyedBy: ResultKey.self)
       self = .memoryDecisionResult(try c.decode(MemoryDecisionResultWire.self, forKey: .result))
+    case "ContextPassportTransferRequest":
+      let c = try decoder.container(keyedBy: RequestKey.self)
+      self = .contextPassportTransferRequest(
+        try c.decode(ContextPassportTransferRequestWire.self, forKey: .request))
+    case "ContextPassportTransferResult":
+      let c = try decoder.container(keyedBy: ResultKey.self)
+      self = .contextPassportTransferResult(
+        try c.decode(ContextPassportTransferResultWire.self, forKey: .result))
     case "RunOutcomeLearningDecisionRequest":
       let c = try decoder.container(keyedBy: RequestKey.self)
       self = .runOutcomeLearningDecisionRequest(
@@ -974,6 +986,14 @@ extension FridayMessage: Codable {
       try c.encode(r, forKey: .request)
     case .memoryDecisionResult(let r):
       try tag.encode("MemoryDecisionResult", forKey: .kind)
+      var c = encoder.container(keyedBy: ResultKey.self)
+      try c.encode(r, forKey: .result)
+    case .contextPassportTransferRequest(let r):
+      try tag.encode("ContextPassportTransferRequest", forKey: .kind)
+      var c = encoder.container(keyedBy: RequestKey.self)
+      try c.encode(r, forKey: .request)
+    case .contextPassportTransferResult(let r):
+      try tag.encode("ContextPassportTransferResult", forKey: .kind)
       var c = encoder.container(keyedBy: ResultKey.self)
       try c.encode(r, forKey: .result)
     case .runOutcomeLearningDecisionRequest(let r):

--- a/apps/macos/FridayRustClient/Sources/FridayRustClient/ReadClient.swift
+++ b/apps/macos/FridayRustClient/Sources/FridayRustClient/ReadClient.swift
@@ -250,6 +250,10 @@ public final class SealedWSReadClient: FridayRustReadClient, @unchecked Sendable
       throw FridayReadClientError.unexpectedResponse(kind: "MemoryDecisionRequest")
     case .memoryDecisionResult:
       throw FridayReadClientError.unexpectedResponse(kind: "MemoryDecisionResult")
+    case .contextPassportTransferRequest:
+      throw FridayReadClientError.unexpectedResponse(kind: "ContextPassportTransferRequest")
+    case .contextPassportTransferResult:
+      throw FridayReadClientError.unexpectedResponse(kind: "ContextPassportTransferResult")
     case .runOutcomeLearningDecisionRequest:
       throw FridayReadClientError.unexpectedResponse(kind: "RunOutcomeLearningDecisionRequest")
     case .runOutcomeLearningDecisionResult:
@@ -371,6 +375,10 @@ public final class SealedWSReadClient: FridayRustReadClient, @unchecked Sendable
       throw FridayReadClientError.unexpectedResponse(kind: "MemoryDecisionRequest")
     case .memoryDecisionResult:
       throw FridayReadClientError.unexpectedResponse(kind: "MemoryDecisionResult")
+    case .contextPassportTransferRequest:
+      throw FridayReadClientError.unexpectedResponse(kind: "ContextPassportTransferRequest")
+    case .contextPassportTransferResult:
+      throw FridayReadClientError.unexpectedResponse(kind: "ContextPassportTransferResult")
     case .runOutcomeLearningDecisionRequest:
       throw FridayReadClientError.unexpectedResponse(kind: "RunOutcomeLearningDecisionRequest")
     case .runOutcomeLearningDecisionResult:

--- a/apps/macos/FridayRustClient/Sources/FridayRustClient/WriteClient.swift
+++ b/apps/macos/FridayRustClient/Sources/FridayRustClient/WriteClient.swift
@@ -175,6 +175,10 @@ public protocol FridayMissionSpineWriteClient: Sendable {
   /// refs-only receipt (`status:"confirmed"`/`"rejected"`/`"blocked"`). `decision` MUST be
   /// `"confirm"` or `"reject"`.
   func submitMemoryDecision(_ request: MemoryDecisionRequestWire) async throws -> MemoryDecisionResultWire
+  /// Mint one governed ContextPassport for an existing Mission.
+  func submitContextPassportTransfer(
+    _ request: ContextPassportTransferRequestWire
+  ) async throws -> ContextPassportTransferResultWire
   /// Submit the owner's explicit confirm/reject for ONE pending A1 run-outcome learning candidate.
   func submitRunOutcomeLearningDecision(
     _ request: RunOutcomeLearningDecisionRequestWire
@@ -357,6 +361,7 @@ public final class SealedWSWriteClient: FridayRustWriteClient, FridayMissionSpin
          .activityNeedsMeRequest, .activityNeedsMeSnapshot,
          .missionIntakeRequest, .missionIntakeResult,
          .memoryDecisionRequest, .memoryDecisionResult,
+         .contextPassportTransferRequest, .contextPassportTransferResult,
          .runOutcomeLearningDecisionRequest, .runOutcomeLearningDecisionResult,
          .activityMarkDoneRequest, .activityMarkDoneResult,
          .workItemStatusRequest, .workItemStatusResult:
@@ -419,6 +424,33 @@ public final class SealedWSWriteClient: FridayRustWriteClient, FridayMissionSpin
     let resp = try openEnvelope(respBody, sessionKey: sessionKey)
     switch resp.message {
     case .memoryDecisionResult(let r):
+      return r
+    case .error(let code, let message):
+      throw FridayWriteClientError.serverError(code: code, message: message)
+    default:
+      throw FridayWriteClientError.unexpectedResponse(kind: dispatchKind(resp.message))
+    }
+  }
+
+  public func submitContextPassportTransfer(
+    _ request: ContextPassportTransferRequestWire
+  ) async throws -> ContextPassportTransferResultWire {
+    let transport = try makeTransport()
+    let (sessionKey, _) = try handshake(transport)
+    let msgId = "context-passport-transfer-\(request.passportId)"
+    let env = FridayEnvelope(msgId: msgId, sentAt: now(), message: .contextPassportTransferRequest(request))
+      .withCorrelation(msgId)
+    try transport.sendMessage(try sealEnvelope(env, sessionKey: sessionKey))
+    let respBody: [UInt8]
+    do {
+      respBody = try transport.recvMessage()
+    } catch {
+      throw FridayWriteClientError.transport(
+        "no context-passport-transfer result (session ended fail-closed): \(error)")
+    }
+    let resp = try openEnvelope(respBody, sessionKey: sessionKey)
+    switch resp.message {
+    case .contextPassportTransferResult(let r):
       return r
     case .error(let code, let message):
       throw FridayWriteClientError.serverError(code: code, message: message)
@@ -725,6 +757,8 @@ private func dispatchKind(_ message: FridayMessage) -> String {
   case .missionIntakeResult: return "MissionIntakeResult"
   case .memoryDecisionRequest: return "MemoryDecisionRequest"
   case .memoryDecisionResult: return "MemoryDecisionResult"
+  case .contextPassportTransferRequest: return "ContextPassportTransferRequest"
+  case .contextPassportTransferResult: return "ContextPassportTransferResult"
   case .runOutcomeLearningDecisionRequest: return "RunOutcomeLearningDecisionRequest"
   case .runOutcomeLearningDecisionResult: return "RunOutcomeLearningDecisionResult"
   case .activityMarkDoneRequest: return "ActivityMarkDoneRequest"

--- a/apps/macos/FridayRustClient/Sources/FridayRustClient/WriteProtocol.swift
+++ b/apps/macos/FridayRustClient/Sources/FridayRustClient/WriteProtocol.swift
@@ -805,3 +805,105 @@ public struct MemoryDecisionResultWire: Codable, Equatable, Sendable {
     try c.encode(recallable, forKey: .recallable)
   }
 }
+
+public struct ContextPassportItemWire: Codable, Equatable, Sendable {
+  public var kind: String
+  public var label: String
+  public var included: Bool
+  public var sensitive: Bool
+
+  public init(kind: String, label: String, included: Bool, sensitive: Bool) {
+    self.kind = kind
+    self.label = label
+    self.included = included
+    self.sensitive = sensitive
+  }
+}
+
+public struct ContextPassportTransferRequestWire: Codable, Equatable, Sendable {
+  public var passportId: String
+  public var missionId: String
+  public var workItemId: String?
+  public var destinationLane: String
+  public var destinationTarget: String?
+  public var items: [ContextPassportItemWire]
+  public var approvedSensitive: Bool
+
+  public init(
+    passportId: String,
+    missionId: String,
+    workItemId: String? = nil,
+    destinationLane: String,
+    destinationTarget: String? = nil,
+    items: [ContextPassportItemWire],
+    approvedSensitive: Bool = false
+  ) {
+    self.passportId = passportId
+    self.missionId = missionId
+    self.workItemId = workItemId
+    self.destinationLane = destinationLane
+    self.destinationTarget = destinationTarget
+    self.items = items
+    self.approvedSensitive = approvedSensitive
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case passportId = "passport_id"
+    case missionId = "mission_id"
+    case workItemId = "work_item_id"
+    case destinationLane = "destination_lane"
+    case destinationTarget = "destination_target"
+    case items
+    case approvedSensitive = "approved_sensitive"
+  }
+}
+
+public struct ContextPassportTransferResultWire: Codable, Equatable, Sendable {
+  public var passportId: String
+  public var missionId: String
+  public var workItemId: String?
+  public var destinationLane: String
+  public var destinationTarget: String?
+  public var sharedItemCount: UInt64
+  public var missionRefCount: UInt64
+  public var linkId: String?
+  public var status: String
+  public var blocker: String?
+
+  public init(
+    passportId: String,
+    missionId: String,
+    workItemId: String? = nil,
+    destinationLane: String,
+    destinationTarget: String? = nil,
+    sharedItemCount: UInt64,
+    missionRefCount: UInt64,
+    linkId: String? = nil,
+    status: String,
+    blocker: String? = nil
+  ) {
+    self.passportId = passportId
+    self.missionId = missionId
+    self.workItemId = workItemId
+    self.destinationLane = destinationLane
+    self.destinationTarget = destinationTarget
+    self.sharedItemCount = sharedItemCount
+    self.missionRefCount = missionRefCount
+    self.linkId = linkId
+    self.status = status
+    self.blocker = blocker
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case passportId = "passport_id"
+    case missionId = "mission_id"
+    case workItemId = "work_item_id"
+    case destinationLane = "destination_lane"
+    case destinationTarget = "destination_target"
+    case sharedItemCount = "shared_item_count"
+    case missionRefCount = "mission_ref_count"
+    case linkId = "link_id"
+    case status
+    case blocker
+  }
+}

--- a/apps/macos/FridayRustClient/Tests/FridayRustClientTests/MissionSpineWriteKATTests.swift
+++ b/apps/macos/FridayRustClient/Tests/FridayRustClientTests/MissionSpineWriteKATTests.swift
@@ -226,6 +226,86 @@ final class MissionSpineWriteKATTests: XCTestCase {
     XCTAssertTrue(json.contains("\"recallable\":false"))
   }
 
+  // MARK: MS4b — ContextPassportTransfer wire shape (nested + no auth_proof)
+
+  /// MS4b: a ContextPassport transfer rides as
+  /// `{"kind":"ContextPassportTransferRequest","request":{…}}` with included item rows and no
+  /// per-request auth proof. The sealed session is the channel auth, matching MissionIntake and
+  /// MemoryDecision.
+  func testMS4b_contextPassportTransferRequestNestedShapeNoAuthProof() throws {
+    let req = ContextPassportTransferRequestWire(
+      passportId: "passport-mobile-1",
+      missionId: "mission-mobile-1",
+      workItemId: "work-mobile-1",
+      destinationLane: "codex",
+      destinationTarget: "codex",
+      items: [
+        ContextPassportItemWire(
+          kind: "summary",
+          label: "Mobile Chat handoff for mission-mobile-1.",
+          included: true,
+          sensitive: false),
+        ContextPassportItemWire(
+          kind: "summary",
+          label: "Answer run ref run-1.",
+          included: true,
+          sensitive: false),
+      ],
+      approvedSensitive: false)
+    let env = FridayEnvelope(msgId: "cp-req", sentAt: 1000, message: .contextPassportTransferRequest(req))
+      .withCorrelation("c1")
+    let json = String(decoding: try env.encodeJSON(), as: UTF8.self)
+
+    XCTAssertTrue(json.contains("\"kind\":\"ContextPassportTransferRequest\""))
+    XCTAssertTrue(json.contains("\"request\":{"), "context passport transfer must NEST under request: \(json)")
+    XCTAssertTrue(json.contains("\"passport_id\":\"passport-mobile-1\""))
+    XCTAssertTrue(json.contains("\"destination_lane\":\"codex\""))
+    XCTAssertTrue(json.contains("\"approved_sensitive\":false"))
+
+    let messageObj = try messageObject(json)
+    XCTAssertEqual(Set(messageObj.keys), ["kind", "request"])
+    let request = try XCTUnwrap(messageObj["request"] as? [String: Any])
+    XCTAssertNil(request["auth_proof"], "ContextPassportTransferRequest carries NO per-request auth_proof")
+    XCTAssertNil(request["forwarded_principal"])
+    XCTAssertEqual(try FridayEnvelope.decodeJSON(Data(json.utf8)).message, .contextPassportTransferRequest(req))
+  }
+
+  /// MS4b: a confirmed ContextPassport transfer result carries only refs/counts; a blocked result
+  /// carries a blocker without fabricating a passport link.
+  func testMS4b_contextPassportTransferResultRoundTripsConfirmedAndBlocked() throws {
+    let confirmed = ContextPassportTransferResultWire(
+      passportId: "passport-mobile-1",
+      missionId: "mission-mobile-1",
+      workItemId: "work-mobile-1",
+      destinationLane: "codex",
+      destinationTarget: "codex",
+      sharedItemCount: 3,
+      missionRefCount: 1,
+      linkId: "context-passport-passport-mobile-1-1",
+      status: "confirmed")
+    let confirmedEnv = FridayEnvelope(msgId: "cp-ok", sentAt: 1, message: .contextPassportTransferResult(confirmed))
+    XCTAssertEqual(
+      try FridayEnvelope.decodeJSON(try confirmedEnv.encodeJSON()).message,
+      .contextPassportTransferResult(confirmed))
+
+    let blocked = ContextPassportTransferResultWire(
+      passportId: "passport-mobile-2",
+      missionId: "mission-mobile-2",
+      destinationLane: "codex",
+      sharedItemCount: 0,
+      missionRefCount: 0,
+      status: "blocked",
+      blocker: "mission_not_found")
+    let blockedEnv = FridayEnvelope(msgId: "cp-blocked", sentAt: 1, message: .contextPassportTransferResult(blocked))
+    let json = String(decoding: try blockedEnv.encodeJSON(), as: UTF8.self)
+    XCTAssertTrue(json.contains("\"kind\":\"ContextPassportTransferResult\""))
+    XCTAssertTrue(json.contains("\"result\":{"))
+    XCTAssertTrue(json.contains("\"blocker\":\"mission_not_found\""))
+    XCTAssertEqual(
+      try FridayEnvelope.decodeJSON(Data(json.utf8)).message,
+      .contextPassportTransferResult(blocked))
+  }
+
   // MARK: MS5 — RunOutcomeLearningDecision wire shape (nested + no auth_proof)
 
   /// MS5: an A1 run-outcome learning decision rides as

--- a/rust-core/crates/friday-ffi/src/lib.rs
+++ b/rust-core/crates/friday-ffi/src/lib.rs
@@ -1996,6 +1996,10 @@ fn message_kind_name(m: &friday_protocol::Message) -> &'static str {
         // unsupported out-of-slice envelopes carry their real truth label.
         M::ActivityMarkDoneRequest { .. } => "ActivityMarkDoneRequest",
         M::ActivityMarkDoneResult { .. } => "ActivityMarkDoneResult",
+        // ContextPassport transfer rides the sealed-WS write surface, not FFI. Keep it named so
+        // unsupported out-of-slice envelopes carry their real truth label.
+        M::ContextPassportTransferRequest { .. } => "ContextPassportTransferRequest",
+        M::ContextPassportTransferResult { .. } => "ContextPassportTransferResult",
         // WS-transport substrate (S-A..S-F) message kinds. Still DARK on the FFI
         // surface (nothing here constructs or dispatches them), but they are
         // NAMED so the truth label carries the real kind — and so this match

--- a/rust-core/crates/friday-hub/src/bin/hub_agent_run_server.rs
+++ b/rust-core/crates/friday-hub/src/bin/hub_agent_run_server.rs
@@ -534,6 +534,21 @@ fn run() -> Result<(), ServerError> {
         );
     }
 
+    let context_passport_transfer_enabled = context_passport_transfer_enabled_from(
+        env::var(CONTEXT_PASSPORT_TRANSFER_ENABLED_ENV)
+            .ok()
+            .as_deref(),
+    );
+    if context_passport_transfer_enabled {
+        eprintln!(
+            "hub_agent_run_server: CONTEXT-PASSPORT transfer ENABLED (FRIDAY_CONTEXT_PASSPORT_TRANSFER) — an inbound ContextPassportTransferRequest mints a governed ContextPassport for an existing Mission (no model call)"
+        );
+    } else {
+        eprintln!(
+            "hub_agent_run_server: CONTEXT-PASSPORT transfer DISABLED (set FRIDAY_CONTEXT_PASSPORT_TRANSFER=1 to enable) — a ContextPassportTransferRequest is a benign keepalive echo"
+        );
+    }
+
     let run_outcome_learning_confirm_enabled = run_outcome_learning_confirm_enabled_from(
         env::var(RUN_OUTCOME_LEARNING_CONFIRM_ENABLED_ENV)
             .ok()
@@ -803,6 +818,12 @@ const MEMORY_CONFIRM_ENABLED_ENV: &str = "FRIDAY_MEMORY_CONFIRM";
 /// ON only for the exact opt-in value `"1"` (trimmed), matching the program's standard flag idiom;
 /// everything else (including `"true"`) ⇒ false.
 fn memory_confirm_enabled_from(raw: Option<&str>) -> bool {
+    matches!(raw.map(str::trim), Some("1"))
+}
+
+const CONTEXT_PASSPORT_TRANSFER_ENABLED_ENV: &str = "FRIDAY_CONTEXT_PASSPORT_TRANSFER";
+
+fn context_passport_transfer_enabled_from(raw: Option<&str>) -> bool {
     matches!(raw.map(str::trim), Some("1"))
 }
 
@@ -1497,6 +1518,11 @@ fn serve_sealed_session<S: Read + Write, T: Transport>(
     let mut processed = 0usize;
     let activity_mark_done_enabled =
         activity_mark_done_enabled_from(env::var(ACTIVITY_MARK_DONE_ENABLED_ENV).ok().as_deref());
+    let context_passport_transfer_enabled = context_passport_transfer_enabled_from(
+        env::var(CONTEXT_PASSPORT_TRANSFER_ENABLED_ENV)
+            .ok()
+            .as_deref(),
+    );
     // S-E: per-session msg_id dedup. A reconnect mints a FRESH tracker (so it is not a
     // cross-connection store) — combined with the per-handshake nonce, a captured envelope is
     // useless both within a session (dedup) and across handshakes (nonce).
@@ -2185,6 +2211,23 @@ fn serve_sealed_session<S: Read + Write, T: Transport>(
                     env.msg_id
                 );
                 // The handler already correlates the reply to `msg_id`; send it sealed.
+                ws_send_envelope(ws, session_key, &result, SESSION_AAD)?;
+                processed += 1;
+            }
+            Message::ContextPassportTransferRequest { request }
+                if context_passport_transfer_enabled =>
+            {
+                let now_ms = now_ms();
+                let result = friday_hub::hub_server::context_passport_transfer_result_for_db(
+                    runtime.db(),
+                    &env.msg_id,
+                    request,
+                    now_ms,
+                );
+                eprintln!(
+                    "hub_agent_run_server_dispatch: msg_id={} leg=context_passport_transfer (context-passport transfer enabled)",
+                    env.msg_id
+                );
                 ws_send_envelope(ws, session_key, &result, SESSION_AAD)?;
                 processed += 1;
             }
@@ -4620,6 +4663,17 @@ mod tests {
             !memory_confirm_enabled_from(Some("  TRUE  ")),
             "padded TRUE ⇒ disabled (only exact 1)"
         );
+    }
+
+    #[test]
+    fn context_passport_transfer_flag_is_default_off_and_fail_closed() {
+        assert!(!context_passport_transfer_enabled_from(None));
+        assert!(!context_passport_transfer_enabled_from(Some("")));
+        assert!(!context_passport_transfer_enabled_from(Some("0")));
+        assert!(!context_passport_transfer_enabled_from(Some("true")));
+        assert!(!context_passport_transfer_enabled_from(Some("on")));
+        assert!(context_passport_transfer_enabled_from(Some("1")));
+        assert!(context_passport_transfer_enabled_from(Some(" 1 ")));
     }
 
     #[test]

--- a/rust-core/crates/friday-hub/src/hub_server.rs
+++ b/rust-core/crates/friday-hub/src/hub_server.rs
@@ -22,12 +22,13 @@
 use friday_crypto::{open, DataKey, Sealed};
 use friday_deepseek::{DeepSeekClient, Transport};
 use friday_protocol::{
-    ActivityMarkDoneRequestWire, ActivityMarkDoneResultWire, Envelope, ErrorCode,
-    MemoryDecisionRequestWire, MemoryDecisionResultWire, Message, MissionIntakeRequestWire,
-    MissionIntakeResultWire, MissionLifecycleRequestWire, MissionLifecycleResultWire,
-    MissionProjectionSnapshotWire, MissionTimelineLinkWire, MissionTimelineMissionWire,
-    MissionTimelineRequestWire, MissionTimelineSnapshotWire, MissionTimelineSurfaceEventWire,
-    MissionTimelineWorkItemWire, MissionWorkItemContextWire, ProviderWorkspaceActionRequestWire,
+    ActivityMarkDoneRequestWire, ActivityMarkDoneResultWire, ContextPassportTransferRequestWire,
+    ContextPassportTransferResultWire, Envelope, ErrorCode, MemoryDecisionRequestWire,
+    MemoryDecisionResultWire, Message, MissionIntakeRequestWire, MissionIntakeResultWire,
+    MissionLifecycleRequestWire, MissionLifecycleResultWire, MissionProjectionSnapshotWire,
+    MissionTimelineLinkWire, MissionTimelineMissionWire, MissionTimelineRequestWire,
+    MissionTimelineSnapshotWire, MissionTimelineSurfaceEventWire, MissionTimelineWorkItemWire,
+    MissionWorkItemContextWire, ProviderWorkspaceActionRequestWire,
     ProviderWorkspaceActionResultWire, RouteDecisionControlRequestWire,
     RouteDecisionControlResultWire, RouteDecisionProjectionWire,
     RunOutcomeLearningDecisionRequestWire, RunOutcomeLearningDecisionResultWire,
@@ -59,6 +60,33 @@ use crate::provider_dispatch_adapter::{
 use crate::provider_workspace::ProviderWorkspaceCatalog;
 use crate::runtime::HubRuntime;
 use crate::RecordAskError;
+
+fn parse_passport_lane(value: &str) -> Result<friday_core::WorkLane, &'static str> {
+    match value {
+        "friday_hub" => Ok(friday_core::WorkLane::FridayHub),
+        "codex" => Ok(friday_core::WorkLane::Codex),
+        "claude" => Ok(friday_core::WorkLane::Claude),
+        "deepseek" => Ok(friday_core::WorkLane::DeepSeek),
+        "workflow" => Ok(friday_core::WorkLane::Workflow),
+        "channel" => Ok(friday_core::WorkLane::Channel),
+        "human" => Ok(friday_core::WorkLane::Human),
+        "future_api" => Ok(friday_core::WorkLane::FutureApi),
+        _ => Err("unknown_destination_lane"),
+    }
+}
+
+fn parse_passport_item_kind(value: &str) -> Result<friday_core::PassportItemKind, &'static str> {
+    match value {
+        "memory_snippet" => Ok(friday_core::PassportItemKind::MemorySnippet),
+        "summary" => Ok(friday_core::PassportItemKind::Summary),
+        "file" => Ok(friday_core::PassportItemKind::File),
+        "screenshot" => Ok(friday_core::PassportItemKind::Screenshot),
+        "attachment" => Ok(friday_core::PassportItemKind::Attachment),
+        "provider_secret" => Ok(friday_core::PassportItemKind::ProviderSecret),
+        "raw_token" => Ok(friday_core::PassportItemKind::RawToken),
+        _ => Err("unknown_item_kind"),
+    }
+}
 
 /// A headless Hub runtime serving one or more trusted client sessions. Generic over the
 /// DeepSeek [`Transport`] so tests inject a scripted mock and a live build uses
@@ -163,6 +191,10 @@ impl<T: Transport> HubServer<T> {
             Message::MissionLifecycleRequest { request } => self
                 .mission_lifecycle_result(&corr, request, now_ms)
                 .with_correlation(corr),
+            // Hub-owned context-passport mint — NO provider/model call.
+            Message::ContextPassportTransferRequest { request } => {
+                context_passport_transfer_result_for_db(&self.db, &corr, request, now_ms)
+            }
             // Provider Workspace action pre-dispatch guard. No provider adapter call here.
             Message::ProviderWorkspaceActionRequest { request } => self
                 .provider_workspace_action_result(&corr, request, now_ms)
@@ -1542,6 +1574,250 @@ pub fn memory_decision_result_for_db(
                 status: status.to_string(),
                 blocker: None,
                 recallable,
+            },
+        },
+    )
+    .with_correlation(msg_id.to_string())
+}
+
+/// Mint one ContextPassport for an existing Mission through the canonical Hub gate. The reply is
+/// refs-only and fail-closed: invalid lane/kind/scope or sensitive unapproved items return
+/// `status=blocked` and do not write a partial passport.
+pub fn context_passport_transfer_result_for_db(
+    db: &Db,
+    msg_id: &str,
+    request: ContextPassportTransferRequestWire,
+    now_ms: i64,
+) -> Envelope {
+    let passport_id = request.passport_id.trim();
+    if passport_id.is_empty() {
+        return context_passport_transfer_blocked(msg_id, now_ms, &request, "passport_id_required");
+    }
+    let mission_id = request.mission_id.trim();
+    if mission_id.is_empty() {
+        return context_passport_transfer_blocked(msg_id, now_ms, &request, "mission_id_required");
+    }
+    if request.items.is_empty() {
+        return context_passport_transfer_blocked(msg_id, now_ms, &request, "items_required");
+    }
+
+    let destination_lane = match parse_passport_lane(request.destination_lane.trim()) {
+        Ok(lane) => lane,
+        Err(blocker) => {
+            return context_passport_transfer_blocked(msg_id, now_ms, &request, blocker)
+        }
+    };
+    let mut items = Vec::with_capacity(request.items.len());
+    for item in &request.items {
+        let kind = match parse_passport_item_kind(item.kind.trim()) {
+            Ok(kind) => kind,
+            Err(blocker) => {
+                return context_passport_transfer_blocked(msg_id, now_ms, &request, blocker)
+            }
+        };
+        items.push(friday_core::PassportItem {
+            kind,
+            label: item.label.clone(),
+            included: item.included,
+            sensitive: item.sensitive,
+        });
+    }
+
+    let mut mission = match db.get_mission(mission_id) {
+        Ok(Some(mission)) => mission,
+        Ok(None) => {
+            return context_passport_transfer_blocked(msg_id, now_ms, &request, "mission_not_found")
+        }
+        Err(_) => {
+            return context_passport_transfer_blocked(
+                msg_id,
+                now_ms,
+                &request,
+                "mission_read_failed",
+            )
+        }
+    };
+    if let Some(work_item_id) = request
+        .work_item_id
+        .as_ref()
+        .filter(|value| !value.trim().is_empty())
+    {
+        match db.get_work_item(work_item_id) {
+            Ok(Some(work_item)) if work_item.mission_id == mission_id => {}
+            Ok(Some(_)) => {
+                return context_passport_transfer_blocked(
+                    msg_id,
+                    now_ms,
+                    &request,
+                    "work_item_scope_mismatch",
+                )
+            }
+            Ok(None) => {
+                return context_passport_transfer_blocked(
+                    msg_id,
+                    now_ms,
+                    &request,
+                    "work_item_not_found",
+                )
+            }
+            Err(_) => {
+                return context_passport_transfer_blocked(
+                    msg_id,
+                    now_ms,
+                    &request,
+                    "work_item_read_failed",
+                )
+            }
+        }
+    }
+
+    let passport = match friday_core::build_context_passport(
+        passport_id.to_string(),
+        mission_id.to_string(),
+        request
+            .work_item_id
+            .clone()
+            .filter(|value| !value.trim().is_empty()),
+        destination_lane,
+        request
+            .destination_target
+            .clone()
+            .filter(|value| !value.trim().is_empty()),
+        items,
+        request.approved_sensitive,
+        now_ms,
+    ) {
+        Ok(passport) => passport,
+        Err(_) => {
+            return context_passport_transfer_blocked(
+                msg_id,
+                now_ms,
+                &request,
+                "context_passport_blocked",
+            )
+        }
+    };
+
+    let link_id = format!(
+        "context-passport-{}-{}",
+        passport_id
+            .chars()
+            .filter(|ch| ch.is_ascii_alphanumeric() || *ch == '-' || *ch == '_')
+            .take(48)
+            .collect::<String>(),
+        now_ms
+    );
+    let tx = match db.conn().unchecked_transaction() {
+        Ok(tx) => tx,
+        Err(_) => {
+            return context_passport_transfer_blocked(
+                msg_id,
+                now_ms,
+                &request,
+                "passport_write_failed",
+            )
+        }
+    };
+    if friday_storage::passport::upsert_context_passport_in(&tx, &passport).is_err() {
+        return context_passport_transfer_blocked(
+            msg_id,
+            now_ms,
+            &request,
+            "passport_write_failed",
+        );
+    }
+    if friday_storage::mission::upsert_mission_link(
+        &tx,
+        &friday_core::MissionLink {
+            link_id: link_id.clone(),
+            mission_id: mission_id.to_string(),
+            work_item_id: request
+                .work_item_id
+                .clone()
+                .filter(|value| !value.trim().is_empty()),
+            link_kind: friday_core::MissionLinkKind::ContextPassport,
+            target_ref: format!("friday://context-passport/{passport_id}"),
+            proof_ref: Some(passport_id.to_string()),
+            created_at_ms: now_ms,
+        },
+    )
+    .is_err()
+    {
+        return context_passport_transfer_blocked(
+            msg_id,
+            now_ms,
+            &request,
+            "mission_link_write_failed",
+        );
+    }
+    if !mission
+        .context_passport_refs
+        .iter()
+        .any(|existing| existing == passport_id)
+    {
+        mission.context_passport_refs.push(passport_id.to_string());
+    }
+    mission.updated_at_ms = now_ms;
+    if friday_storage::mission::upsert_mission(&tx, &mission).is_err() {
+        return context_passport_transfer_blocked(msg_id, now_ms, &request, "mission_write_failed");
+    }
+    if tx.commit().is_err() {
+        return context_passport_transfer_blocked(
+            msg_id,
+            now_ms,
+            &request,
+            "passport_write_failed",
+        );
+    }
+
+    Envelope::new(
+        format!("{msg_id}-context-passport-transfer"),
+        now_ms,
+        Message::ContextPassportTransferResult {
+            result: ContextPassportTransferResultWire {
+                passport_id: passport_id.to_string(),
+                mission_id: mission_id.to_string(),
+                work_item_id: request
+                    .work_item_id
+                    .clone()
+                    .filter(|value| !value.trim().is_empty()),
+                destination_lane: request.destination_lane,
+                destination_target: request.destination_target,
+                shared_item_count: passport.shared_items().len() as u64,
+                mission_ref_count: mission.context_passport_refs.len() as u64,
+                link_id: Some(link_id),
+                status: "confirmed".to_string(),
+                blocker: None,
+            },
+        },
+    )
+    .with_correlation(msg_id.to_string())
+}
+
+fn context_passport_transfer_blocked(
+    msg_id: &str,
+    now_ms: i64,
+    request: &ContextPassportTransferRequestWire,
+    blocker: &str,
+) -> Envelope {
+    Envelope::new(
+        format!("{msg_id}-context-passport-transfer"),
+        now_ms,
+        Message::ContextPassportTransferResult {
+            result: ContextPassportTransferResultWire {
+                passport_id: request.passport_id.clone(),
+                mission_id: request.mission_id.clone(),
+                work_item_id: request
+                    .work_item_id
+                    .clone()
+                    .filter(|value| !value.trim().is_empty()),
+                destination_lane: request.destination_lane.clone(),
+                destination_target: request.destination_target.clone(),
+                shared_item_count: 0,
+                mission_ref_count: 0,
+                link_id: None,
+                status: "blocked".to_string(),
+                blocker: Some(blocker.to_string()),
             },
         },
     )

--- a/rust-core/crates/friday-protocol/src/lib.rs
+++ b/rust-core/crates/friday-protocol/src/lib.rs
@@ -431,6 +431,54 @@ pub struct MemoryDecisionResultWire {
     pub recallable: bool,
 }
 
+/// One refs-only context-passport item proposed by a trusted client. Labels are operator/user
+/// reviewed summaries or refs; sensitive raw material must not ride this wire. The Hub runs the
+/// canonical context-passport gate before persisting any row.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ContextPassportItemWire {
+    pub kind: String,
+    pub label: String,
+    pub included: bool,
+    pub sensitive: bool,
+}
+
+/// Client request to mint one ContextPassport for an existing Mission. This is a Hub-owned
+/// governance mutation over the sealed peer session, never a provider/model call and never direct
+/// DB access from the client.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ContextPassportTransferRequestWire {
+    pub passport_id: String,
+    pub mission_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub work_item_id: Option<String>,
+    pub destination_lane: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub destination_target: Option<String>,
+    #[serde(default)]
+    pub items: Vec<ContextPassportItemWire>,
+    #[serde(default)]
+    pub approved_sensitive: bool,
+}
+
+/// Hub response for context-passport minting. Refs-only; never echoes item content.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ContextPassportTransferResultWire {
+    pub passport_id: String,
+    pub mission_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub work_item_id: Option<String>,
+    pub destination_lane: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub destination_target: Option<String>,
+    pub shared_item_count: u64,
+    pub mission_ref_count: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub link_id: Option<String>,
+    pub status: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub blocker: Option<String>,
+}
+
 /// Client request to apply the OWNER's explicit confirm/reject decision to ONE
 /// pending A1 run-outcome learning candidate. This is refs-only governance over a
 /// candidate row that already points at a run/session; it never carries the run
@@ -1499,6 +1547,15 @@ pub enum Message {
     /// the resulting lifecycle state, a coarse status, and whether it is now
     /// recallable. NEVER the candidate's content (the content stays Hub-side).
     MemoryDecisionResult { result: MemoryDecisionResultWire },
+    /// client->hub: mint one ContextPassport for an existing Mission through the Hub gate.
+    /// Never a provider/model call; never direct client DB writes.
+    ContextPassportTransferRequest {
+        request: ContextPassportTransferRequestWire,
+    },
+    /// hub->client: refs-only context-passport mint receipt.
+    ContextPassportTransferResult {
+        result: ContextPassportTransferResultWire,
+    },
     /// client->hub: confirm/reject ONE pending A1 run-outcome learning candidate.
     /// Owner scope is derived server-side from the candidate's bound session/run.
     /// Never a provider/model call and never carries the run answer body.

--- a/rust-core/crates/friday-storage/src/passport.rs
+++ b/rust-core/crates/friday-storage/src/passport.rs
@@ -78,7 +78,25 @@ pub fn upsert_context_passport(conn: &Connection, passport: &ContextPassport) ->
         return Err(unsupported("context_passport mission_id must not be empty"));
     }
     let tx = conn.unchecked_transaction()?;
-    tx.execute(
+    upsert_context_passport_in(&tx, passport)?;
+    tx.commit()?;
+    Ok(())
+}
+
+/// Persist a built Context Passport + item set inside the caller's existing transaction.
+///
+/// This is for multi-table Hub writes that must commit the passport, mission link, and mission
+/// ref atomically. It intentionally does not open its own transaction.
+pub fn upsert_context_passport_in(conn: &Connection, passport: &ContextPassport) -> Result<()> {
+    if passport.passport_id.trim().is_empty() {
+        return Err(unsupported(
+            "context_passport passport_id must not be empty",
+        ));
+    }
+    if passport.mission_id.trim().is_empty() {
+        return Err(unsupported("context_passport mission_id must not be empty"));
+    }
+    conn.execute(
         "INSERT INTO context_passport
             (passport_id, mission_id, work_item_id, destination_lane, destination_target,
              approved_sensitive, created_at_ms)
@@ -101,12 +119,12 @@ pub fn upsert_context_passport(conn: &Connection, passport: &ContextPassport) ->
         ],
     )?;
     // Replace the child item set wholesale (an upsert of the parent re-states all items).
-    tx.execute(
+    conn.execute(
         "DELETE FROM context_passport_item WHERE passport_id = ?1",
         params![passport.passport_id],
     )?;
     for (seq, item) in passport.items.iter().enumerate() {
-        tx.execute(
+        conn.execute(
             "INSERT INTO context_passport_item
                 (passport_id, seq, kind, label, included, sensitive)
              VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
@@ -120,7 +138,6 @@ pub fn upsert_context_passport(conn: &Connection, passport: &ContextPassport) ->
             ],
         )?;
     }
-    tx.commit()?;
     Ok(())
 }
 

--- a/scripts/ops/friday-mobile-chat-action-evidence.sh
+++ b/scripts/ops/friday-mobile-chat-action-evidence.sh
@@ -4,10 +4,11 @@
 #
 # Truth boundary:
 #   Runs iOS Swift product ViewModel tests and exports explicit action-runtime evidence for
-#   Friday Chat send, approval-card render, approve relay, and reject relay. This proves the
-#   product ViewModel delegates to governed write/sign/reject seams and renders refs-only
-#   results. It does not start or mutate prod Hub, use the operator's true signing key, prove
-#   live Hub audit receipts, drive a real simulator tap, claim END-BAR, or prove adoption.
+#   Friday Chat send, approval-card render, approve relay, reject relay, and local context-card
+#   affordances. This proves the product ViewModel delegates to governed write/sign/reject seams
+#   and renders refs-only results. It does not start or mutate prod Hub, use the operator's true
+#   signing key, prove live Hub audit receipts, drive a real simulator tap, claim END-BAR, or
+#   prove adoption.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -65,6 +66,8 @@ for (const expected of [
   ["mobile", "fridayChat", "chat:approveCard", "ask_friday_chat"],
   ["mobile", "fridayChat", "check", "security_approval_bound_principal_gate_cat10_netnew"],
   ["mobile", "fridayChat", "act", "security_approval_bound_principal_gate_cat10_netnew"],
+  ["mobile", "fridayChat", "chat:handoffCard", "ask_friday_chat"],
+  ["mobile", "fridayChat", "chat:memoryCard", "ask_friday_chat"],
 ]) {
   const found = actions.some((row) =>
     row.surface === expected[0]

--- a/scripts/ops/friday-mobile-chat-action-evidence.sh
+++ b/scripts/ops/friday-mobile-chat-action-evidence.sh
@@ -68,6 +68,8 @@ for (const expected of [
   ["mobile", "fridayChat", "act", "security_approval_bound_principal_gate_cat10_netnew"],
   ["mobile", "fridayChat", "chat:handoffCard", "ask_friday_chat"],
   ["mobile", "fridayChat", "chat:memoryCard", "ask_friday_chat"],
+  ["mobile", "fridayChat", "check", "memory_review_no_silent_write_decide_candidate"],
+  ["mobile", "fridayChat", "act", "memory_review_no_silent_write_decide_candidate"],
 ]) {
   const found = actions.some((row) =>
     row.surface === expected[0]

--- a/scripts/ops/friday-mobile-chat-action-evidence.sh
+++ b/scripts/ops/friday-mobile-chat-action-evidence.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+#
+# Mobile Friday Chat action evidence wrapper.
+#
+# Truth boundary:
+#   Runs iOS Swift product ViewModel tests and exports explicit action-runtime evidence for
+#   Friday Chat send, approval-card render, approve relay, and reject relay. This proves the
+#   product ViewModel delegates to governed write/sign/reject seams and renders refs-only
+#   results. It does not start or mutate prod Hub, use the operator's true signing key, prove
+#   live Hub audit receipts, drive a real simulator tap, claim END-BAR, or prove adoption.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+OUT_DIR="${FRIDAY_MOBILE_CHAT_ACTION_EVIDENCE_DIR:-${TMPDIR:-/tmp}/friday-mobile-chat-action-evidence}"
+ACTION_RUNTIME_OUT="${FRIDAY_MOBILE_CHAT_ACTION_RUNTIME_OUT:-${OUT_DIR}/action-runtime-evidence.json}"
+
+mkdir -p "${OUT_DIR}"
+chmod 700 "${OUT_DIR}"
+
+echo "Friday mobile Chat action evidence starting."
+echo "truth_label=mobile_chat_action_swift_viewmodel_runtime_not_live_hub_not_endbar"
+echo "out_dir=${OUT_DIR}"
+
+log="${OUT_DIR}/swift-test-mobile-chat-action-evidence.log"
+FRIDAY_MOBILE_CHAT_ACTION_EVIDENCE_DIR="${OUT_DIR}" \
+  swift test \
+    --package-path "${REPO_ROOT}/apps/friday-ios" \
+    --filter "FridayChatViewModelTests/testMobileChatActionEvidenceCoversSendApprovalCardAndControls" \
+    2>&1 | tee "${log}"
+
+if ! grep -Eq "Executed [1-9][0-9]* test|Test run with [1-9][0-9]* test" "${log}"; then
+  echo "FATAL: Swift test filter ran zero tests" >&2
+  exit 2
+fi
+
+node - "${ACTION_RUNTIME_OUT}" <<'NODE'
+const fs = require("node:fs");
+const [actionRuntimeOut] = process.argv.slice(2);
+
+if (!fs.existsSync(actionRuntimeOut)) {
+  console.error(`FATAL: missing action runtime evidence: ${actionRuntimeOut}`);
+  process.exit(2);
+}
+
+let parsed;
+try {
+  parsed = JSON.parse(fs.readFileSync(actionRuntimeOut, "utf8"));
+} catch (error) {
+  console.error(`FATAL: invalid action runtime evidence JSON: ${error.message}`);
+  process.exit(2);
+}
+
+const blockers = [];
+if (parsed.truth !== "mobile_chat_action_swift_viewmodel_runtime_not_live_hub_not_endbar") {
+  blockers.push({ code: "unexpected_truth", detail: parsed.truth || "<missing>" });
+}
+if (parsed.status !== "ready") {
+  blockers.push({ code: "evidence_not_ready", detail: parsed.status || "<missing>" });
+}
+const actions = Array.isArray(parsed.actions) ? parsed.actions : [];
+for (const expected of [
+  ["mobile", "fridayChat", "chat:typing", "ask_friday_chat"],
+  ["mobile", "fridayChat", "chat:approveCard", "ask_friday_chat"],
+  ["mobile", "fridayChat", "check", "security_approval_bound_principal_gate_cat10_netnew"],
+  ["mobile", "fridayChat", "act", "security_approval_bound_principal_gate_cat10_netnew"],
+]) {
+  const found = actions.some((row) =>
+    row.surface === expected[0]
+    && row.screen === expected[1]
+    && row.action_id === expected[2]
+    && row.capability_id === expected[3]
+    && row.status === "pass");
+  if (!found) blockers.push({ code: "missing_action_row", detail: expected.join("/") });
+}
+
+console.log(JSON.stringify({
+  status: blockers.length === 0 ? "ready" : "blocked",
+  actionCount: actions.length,
+  out: actionRuntimeOut,
+  blockers,
+}, null, 2));
+process.exit(blockers.length === 0 ? 0 : 2);
+NODE
+
+echo "Action runtime evidence: ${ACTION_RUNTIME_OUT}"
+echo "Truth: partial mobile Chat action evidence only; live Hub audit, simulator tap, and true operator signature proof remain required."

--- a/scripts/ops/friday-mobile-chat-action-evidence.sh
+++ b/scripts/ops/friday-mobile-chat-action-evidence.sh
@@ -5,10 +5,10 @@
 # Truth boundary:
 #   Runs iOS Swift product ViewModel tests and exports explicit action-runtime evidence for
 #   Friday Chat send, approval-card render, approve relay, reject relay, and local context-card
-#   affordances. This proves the product ViewModel delegates to governed write/sign/reject seams
-#   and renders refs-only results. It does not start or mutate prod Hub, use the operator's true
-#   signing key, prove live Hub audit receipts, drive a real simulator tap, claim END-BAR, or
-#   prove adoption.
+#   affordances plus the governed context-passport handoff transfer. This proves the product
+#   ViewModel delegates to governed write/sign/reject seams and renders refs-only results. It does
+#   not start or mutate prod Hub, use the operator's true signing key, prove live Hub audit
+#   receipts, drive a real simulator tap, claim END-BAR, or prove adoption.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -68,6 +68,7 @@ for (const expected of [
   ["mobile", "fridayChat", "act", "security_approval_bound_principal_gate_cat10_netnew"],
   ["mobile", "fridayChat", "chat:handoffCard", "ask_friday_chat"],
   ["mobile", "fridayChat", "chat:memoryCard", "ask_friday_chat"],
+  ["mobile", "fridayChat", "share", "context_passport_transfer_checklist"],
   ["mobile", "fridayChat", "check", "memory_review_no_silent_write_decide_candidate"],
   ["mobile", "fridayChat", "act", "memory_review_no_silent_write_decide_candidate"],
 ]) {

--- a/scripts/ops/friday-mobile-new-session-action-evidence.sh
+++ b/scripts/ops/friday-mobile-new-session-action-evidence.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+#
+# Mobile New Session Launch action evidence wrapper.
+#
+# Truth boundary:
+#   Runs iOS Swift product ViewModel tests for the New Session Launch action. This proves Launch
+#   creates a governed Mission Intake through the existing mobile write seam abstraction when a
+#   client is configured, and fails closed when it is not. It does not start or mutate prod Hub,
+#   prove a real simulator tap, claim END-BAR, or prove adoption.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+OUT_DIR="${FRIDAY_MOBILE_NEW_SESSION_ACTION_EVIDENCE_DIR:-${TMPDIR:-/tmp}/friday-mobile-new-session-action-evidence}"
+ACTION_RUNTIME_OUT="${FRIDAY_MOBILE_NEW_SESSION_ACTION_RUNTIME_OUT:-${OUT_DIR}/action-runtime-evidence.json}"
+
+mkdir -p "${OUT_DIR}"
+chmod 700 "${OUT_DIR}"
+
+echo "Friday mobile New Session action evidence starting."
+echo "truth_label=mobile_new_session_launch_swift_viewmodel_runtime_not_live_hub_not_endbar"
+echo "out_dir=${OUT_DIR}"
+
+run_swift_test() {
+  local filter="$1"
+  local log="${OUT_DIR}/swift-test-${filter}.log"
+  FRIDAY_MOBILE_NEW_SESSION_ACTION_EVIDENCE_DIR="${OUT_DIR}" \
+    swift test \
+      --package-path "${REPO_ROOT}/apps/friday-ios" \
+      --filter "${filter}" 2>&1 | tee "${log}"
+  if ! grep -Eq "Executed [1-9][0-9]* test|Test run with [1-9][0-9]* test" "${log}"; then
+    echo "FATAL: Swift test filter ran zero tests: ${filter}" >&2
+    exit 2
+  fi
+}
+
+run_swift_test testNoWriteClientFailsClosedWithoutFakeLaunch
+run_swift_test testLaunchSubmitsGovernedMissionIntake
+
+node - "${OUT_DIR}" "${ACTION_RUNTIME_OUT}" <<'NODE'
+const fs = require("node:fs");
+const path = require("node:path");
+
+const [outDir, actionRuntimeOut] = process.argv.slice(2);
+const source = path.join(outDir, "mobile-new-session-action-evidence.json");
+const blockers = [];
+let actions = [];
+
+if (!fs.existsSync(source)) {
+  blockers.push({ code: "missing_swift_evidence", detail: source });
+} else {
+  let parsed;
+  try {
+    parsed = JSON.parse(fs.readFileSync(source, "utf8"));
+  } catch {
+    blockers.push({ code: "invalid_swift_evidence_json", detail: source });
+  }
+  if (parsed) {
+    if (parsed.truth !== "mobile_new_session_launch_swift_viewmodel_runtime_not_live_hub_not_endbar") {
+      blockers.push({ code: "unexpected_truth", detail: parsed.truth || "<missing>" });
+    }
+    if (parsed.status !== "ready") {
+      blockers.push({ code: "evidence_not_ready", detail: parsed.status || "<missing>" });
+    }
+    actions = Array.isArray(parsed.actions) ? parsed.actions.map((row) => ({ ...row, source_proof: source })) : [];
+    if (actions.length !== 1) {
+      blockers.push({ code: "unexpected_action_count", detail: String(actions.length) });
+    }
+  }
+}
+
+const report = {
+  truth: "mobile_new_session_action_runtime_evidence_partial_not_live_hub_not_endbar",
+  status: blockers.length === 0 ? "ready" : "blocked",
+  actionCount: actions.length,
+  actions,
+  blockers,
+  caveat:
+    "Partial runtime evidence only: Swift product ViewModel New Session Launch semantics. Later real simulator/device tap and live Hub Mission Intake proof remain required before END-BAR coverage.",
+};
+
+fs.mkdirSync(path.dirname(actionRuntimeOut), { recursive: true });
+fs.writeFileSync(actionRuntimeOut, `${JSON.stringify(report, null, 2)}\n`);
+console.log(JSON.stringify({ status: report.status, actionCount: actions.length, out: actionRuntimeOut }, null, 2));
+process.exit(blockers.length === 0 ? 0 : 2);
+NODE
+
+echo "Action runtime evidence: ${ACTION_RUNTIME_OUT}"
+echo "Truth: partial New Session Launch action evidence only; live simulator/device and Hub proof remain required."

--- a/scripts/ops/friday-mobile-passport-transfer-action-evidence.sh
+++ b/scripts/ops/friday-mobile-passport-transfer-action-evidence.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+#
+# Mobile Context Passport transfer action evidence wrapper.
+#
+# Truth boundary:
+#   Runs the iOS Swift product Home ViewModel test for the Passport "Send with 3 items" action.
+#   This proves the product action delegates to the governed context-passport write seam and
+#   renders a refs-only result. It does not start or mutate prod Hub, prove a live Hub audit
+#   receipt, drive a real simulator tap, claim END-BAR, or prove adoption.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+OUT_DIR="${FRIDAY_MOBILE_PASSPORT_TRANSFER_ACTION_EVIDENCE_DIR:-${TMPDIR:-/tmp}/friday-mobile-passport-transfer-action-evidence}"
+ACTION_RUNTIME_OUT="${FRIDAY_MOBILE_PASSPORT_TRANSFER_ACTION_RUNTIME_OUT:-${OUT_DIR}/action-runtime-evidence.json}"
+
+mkdir -p "${OUT_DIR}"
+chmod 700 "${OUT_DIR}"
+
+echo "Friday mobile Context Passport transfer action evidence starting."
+echo "truth_label=mobile_passport_transfer_swift_viewmodel_runtime_not_live_hub_not_endbar"
+echo "out_dir=${OUT_DIR}"
+
+log="${OUT_DIR}/swift-test-mobile-passport-transfer-action-evidence.log"
+FRIDAY_MOBILE_PASSPORT_TRANSFER_ACTION_EVIDENCE_DIR="${OUT_DIR}" \
+  swift test \
+    --package-path "${REPO_ROOT}/apps/friday-ios" \
+    --filter "HomeViewModelTests/testSubmitContextPassportTransferRendersConfirmedAndRefreshes" \
+    2>&1 | tee "${log}"
+
+if ! grep -Eq "Executed [1-9][0-9]* test|Test run with [1-9][0-9]* test" "${log}"; then
+  echo "FATAL: Swift test filter ran zero tests" >&2
+  exit 2
+fi
+
+node - "${OUT_DIR}" "${ACTION_RUNTIME_OUT}" <<'NODE'
+const fs = require("node:fs");
+const path = require("node:path");
+
+const [outDir, actionRuntimeOut] = process.argv.slice(2);
+const source = path.join(outDir, "mobile-passport-transfer-action-evidence.json");
+const blockers = [];
+let actions = [];
+
+if (!fs.existsSync(source)) {
+  blockers.push({ code: "missing_swift_evidence", detail: source });
+} else {
+  let parsed;
+  try {
+    parsed = JSON.parse(fs.readFileSync(source, "utf8"));
+  } catch {
+    blockers.push({ code: "invalid_swift_evidence_json", detail: source });
+  }
+  if (parsed) {
+    if (parsed.truth !== "mobile_passport_transfer_swift_viewmodel_runtime_not_live_hub_not_endbar") {
+      blockers.push({ code: "unexpected_truth", detail: parsed.truth || "<missing>" });
+    }
+    if (parsed.status !== "ready") {
+      blockers.push({ code: "evidence_not_ready", detail: parsed.status || "<missing>" });
+    }
+    actions = Array.isArray(parsed.actions) ? parsed.actions.map((row) => ({ ...row, source_proof: source })) : [];
+    const found = actions.some((row) =>
+      row.surface === "mobile"
+      && row.screen === "passport"
+      && row.action_id === "check"
+      && row.capability_id === "context_passport_transfer_checklist"
+      && row.status === "pass");
+    if (!found) blockers.push({ code: "missing_passport_transfer_action", detail: source });
+  }
+}
+
+const report = {
+  truth: "mobile_passport_transfer_action_runtime_evidence_partial_not_live_hub_not_endbar",
+  status: blockers.length === 0 ? "ready" : "blocked",
+  actionCount: actions.length,
+  actions,
+  blockers,
+  caveat:
+    "Partial runtime evidence only: Swift product ViewModel Passport transfer delegates to the governed write seam and renders refs-only result. Later live Hub audit and simulator/device tap must land before END-BAR coverage.",
+};
+
+fs.mkdirSync(path.dirname(actionRuntimeOut), { recursive: true });
+fs.writeFileSync(actionRuntimeOut, `${JSON.stringify(report, null, 2)}\n`);
+console.log(JSON.stringify({ status: report.status, actionCount: actions.length, out: actionRuntimeOut, blockers }, null, 2));
+process.exit(blockers.length === 0 ? 0 : 2);
+NODE
+
+echo "Action runtime evidence: ${ACTION_RUNTIME_OUT}"
+echo "Truth: partial mobile Context Passport transfer action evidence only; live Hub audit and simulator/device tap remain required."

--- a/scripts/ops/friday-mobile-session-sidecar-action-evidence.sh
+++ b/scripts/ops/friday-mobile-session-sidecar-action-evidence.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+#
+# Mobile Session Sidecar open/close action evidence wrapper.
+#
+# Truth boundary:
+#   Runs iOS Swift product ViewModel tests for the Session Detail Friday Sidecar open/close
+#   actions. This proves the client keeps sidecar analysis private and blocks external actions
+#   without a governed confirmation path. It does not start or mutate prod Hub, prove a real
+#   simulator tap, claim END-BAR, or prove adoption.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+OUT_DIR="${FRIDAY_MOBILE_SESSION_SIDECAR_ACTION_EVIDENCE_DIR:-${TMPDIR:-/tmp}/friday-mobile-session-sidecar-action-evidence}"
+ACTION_RUNTIME_OUT="${FRIDAY_MOBILE_SESSION_SIDECAR_ACTION_RUNTIME_OUT:-${OUT_DIR}/action-runtime-evidence.json}"
+
+mkdir -p "${OUT_DIR}"
+chmod 700 "${OUT_DIR}"
+
+echo "Friday mobile Session Sidecar action evidence starting."
+echo "truth_label=mobile_session_sidecar_action_swift_viewmodel_runtime_not_live_hub_not_endbar"
+echo "out_dir=${OUT_DIR}"
+
+log="${OUT_DIR}/swift-test-session-sidecar.log"
+FRIDAY_MOBILE_SESSION_SIDECAR_ACTION_EVIDENCE_DIR="${OUT_DIR}" \
+  swift test \
+    --package-path "${REPO_ROOT}/apps/friday-ios" \
+    --filter testSessionSidecarOpenCloseKeepsProviderPrivate 2>&1 | tee "${log}"
+
+if ! grep -Eq "Executed [1-9][0-9]* test|Test run with [1-9][0-9]* test" "${log}"; then
+  echo "FATAL: Swift test filter ran zero tests: testSessionSidecarOpenCloseKeepsProviderPrivate" >&2
+  exit 2
+fi
+
+node - "${OUT_DIR}" "${ACTION_RUNTIME_OUT}" <<'NODE'
+const fs = require("node:fs");
+const path = require("node:path");
+
+const [outDir, actionRuntimeOut] = process.argv.slice(2);
+const source = path.join(outDir, "mobile-session-sidecar-action-evidence.json");
+const blockers = [];
+let actions = [];
+
+if (!fs.existsSync(source)) {
+  blockers.push({ code: "missing_swift_evidence", detail: source });
+} else {
+  let parsed;
+  try {
+    parsed = JSON.parse(fs.readFileSync(source, "utf8"));
+  } catch {
+    blockers.push({ code: "invalid_swift_evidence_json", detail: source });
+  }
+  if (parsed) {
+    if (parsed.truth !== "mobile_session_sidecar_action_swift_viewmodel_runtime_not_live_hub_not_endbar") {
+      blockers.push({ code: "unexpected_truth", detail: parsed.truth || "<missing>" });
+    }
+    if (parsed.status !== "ready") {
+      blockers.push({ code: "evidence_not_ready", detail: parsed.status || "<missing>" });
+    }
+    actions = Array.isArray(parsed.actions) ? parsed.actions.map((row) => ({ ...row, source_proof: source })) : [];
+    if (actions.length !== 2) {
+      blockers.push({ code: "unexpected_action_count", detail: String(actions.length) });
+    }
+  }
+}
+
+const report = {
+  truth: "mobile_session_sidecar_action_runtime_evidence_partial_not_live_hub_not_endbar",
+  status: blockers.length === 0 ? "ready" : "blocked",
+  actionCount: actions.length,
+  actions,
+  blockers,
+  caveat:
+    "Partial runtime evidence only: Swift product ViewModel/SessionDetail Sidecar open-close semantics. Later real simulator/device tap remains required before END-BAR coverage.",
+};
+
+fs.mkdirSync(path.dirname(actionRuntimeOut), { recursive: true });
+fs.writeFileSync(actionRuntimeOut, `${JSON.stringify(report, null, 2)}\n`);
+console.log(JSON.stringify({ status: report.status, actionCount: actions.length, out: actionRuntimeOut }, null, 2));
+process.exit(blockers.length === 0 ? 0 : 2);
+NODE
+
+echo "Action runtime evidence: ${ACTION_RUNTIME_OUT}"
+echo "Truth: partial Session Sidecar open/close action evidence only; live simulator/device tap remains required."

--- a/scripts/ops/friday-mobile-workflow-action-evidence.sh
+++ b/scripts/ops/friday-mobile-workflow-action-evidence.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+#
+# Mobile Workflow run-control action evidence wrapper.
+#
+# Truth boundary:
+#   Runs iOS Swift product ViewModel tests for workflow/session run-control. This proves the
+#   visible workflow run-control action delegates to the governed cancel seam and renders a
+#   refs-only receipt. It does not start or mutate prod Hub, prove a live Hub audit receipt,
+#   drive a real simulator tap, claim END-BAR, or prove adoption.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+OUT_DIR="${FRIDAY_MOBILE_WORKFLOW_ACTION_EVIDENCE_DIR:-${TMPDIR:-/tmp}/friday-mobile-workflow-action-evidence}"
+ACTION_RUNTIME_OUT="${FRIDAY_MOBILE_WORKFLOW_ACTION_RUNTIME_OUT:-${OUT_DIR}/action-runtime-evidence.json}"
+
+mkdir -p "${OUT_DIR}"
+chmod 700 "${OUT_DIR}"
+
+echo "Friday mobile Workflow action evidence starting."
+echo "truth_label=mobile_workflow_action_swift_viewmodel_runtime_not_live_hub_not_endbar"
+echo "out_dir=${OUT_DIR}"
+
+log="${OUT_DIR}/swift-test-mobile-workflow-action-evidence.log"
+FRIDAY_MOBILE_WORKFLOW_ACTION_EVIDENCE_DIR="${OUT_DIR}" \
+  swift test \
+    --package-path "${REPO_ROOT}/apps/friday-ios" \
+    --filter "SessionContinuationViewModelTests/testStopUsesGovernedCancelRunAndSurfacesReceipt" \
+    2>&1 | tee "${log}"
+
+if ! grep -Eq "Executed [1-9][0-9]* test|Test run with [1-9][0-9]* test" "${log}"; then
+  echo "FATAL: Swift test filter ran zero tests" >&2
+  exit 2
+fi
+
+node - "${OUT_DIR}" "${ACTION_RUNTIME_OUT}" <<'NODE'
+const fs = require("node:fs");
+const path = require("node:path");
+
+const [outDir, actionRuntimeOut] = process.argv.slice(2);
+const source = path.join(outDir, "mobile-workflow-action-evidence.json");
+const blockers = [];
+let actions = [];
+
+if (!fs.existsSync(source)) {
+  blockers.push({ code: "missing_swift_evidence", detail: source });
+} else {
+  let parsed;
+  try {
+    parsed = JSON.parse(fs.readFileSync(source, "utf8"));
+  } catch {
+    blockers.push({ code: "invalid_swift_evidence_json", detail: source });
+  }
+  if (parsed) {
+    if (parsed.truth !== "mobile_workflow_action_swift_viewmodel_runtime_not_live_hub_not_endbar") {
+      blockers.push({ code: "unexpected_truth", detail: parsed.truth || "<missing>" });
+    }
+    if (parsed.status !== "ready") {
+      blockers.push({ code: "evidence_not_ready", detail: parsed.status || "<missing>" });
+    }
+    actions = Array.isArray(parsed.actions) ? parsed.actions.map((row) => ({ ...row, source_proof: source })) : [];
+    const found = actions.some((row) =>
+      row.surface === "mobile"
+      && row.screen === "workflow"
+      && row.action_id === "workflow_run_control"
+      && row.capability_id === "session_control_native_set"
+      && row.status === "pass");
+    if (!found) blockers.push({ code: "missing_workflow_run_control", detail: source });
+  }
+}
+
+const report = {
+  truth: "mobile_workflow_action_runtime_evidence_partial_not_live_hub_not_endbar",
+  status: blockers.length === 0 ? "ready" : "blocked",
+  actionCount: actions.length,
+  actions,
+  blockers,
+  caveat:
+    "Partial runtime evidence only: Swift product ViewModel workflow run-control delegates to the governed write seam and renders refs-only result. Later live Hub audit and real simulator/device tap must land before END-BAR coverage.",
+};
+
+fs.mkdirSync(path.dirname(actionRuntimeOut), { recursive: true });
+fs.writeFileSync(actionRuntimeOut, `${JSON.stringify(report, null, 2)}\n`);
+console.log(JSON.stringify({ status: report.status, actionCount: actions.length, out: actionRuntimeOut, blockers }, null, 2));
+process.exit(blockers.length === 0 ? 0 : 2);
+NODE
+
+echo "Action runtime evidence: ${ACTION_RUNTIME_OUT}"
+echo "Truth: partial Workflow action evidence only; live Hub audit and simulator/device tap remain required."


### PR DESCRIPTION
## Summary
- Batch replacement for the remaining mobile action closure stack after #1224/#1234 landed on main.
- Includes session sidecar actions, new-session launch, chat action evidence, memory resolve evidence, workflow run-control evidence, chat context cards, chat memory decisions, and context-passport transfer.
- Fixes friday-ffi message-kind naming for the new context passport transfer protocol variants.

## Truth / scope
- Runtime/action evidence only; not END-BAR, not release/adoption, and not mobile approve-with-proof signed evidence.
- Does not touch schema migrations, TS schema handshake, workflow_def/workflow_exec, mission_runtime, or signer custody.
- `mobile/approval/check` remains the one unique action-runtime gap until a real operator-signed approve artifact is supplied.

## Local verification
- `vitest run --project default --project typecheck --project llm-e2e test/unit/qa/friday-mobile-approval-reject-proof-cli.test.ts test/unit/qa/friday-design-action-runtime-evidence-cli.test.ts`
- `swift test --package-path apps/friday-ios --filter 'SessionContinuationViewModelTests/testSessionSidecarOpenCloseKeepsProviderPrivate|SessionContinuationViewModelTests/testStopUsesGovernedCancelRunAndSurfacesReceipt|NewSessionViewModelTests|FridayChatViewModelTests/testMobileChatActionEvidenceCoversSendApprovalCardAndControls|HomeViewModelTests/testSubmitContextPassportTransferRendersConfirmedAndRefreshes'`
- `cargo check -p friday-ffi`
- `cargo clippy -p friday-ffi --all-targets -- -D warnings`
- `git diff --check`
