### PR TITLE
feat(mobile): anchor product readiness contract

### DIFF
--- a/apps/friday-ios/Sources/FridayMobileShell/CommandSheet.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/CommandSheet.swift
@@ -1,3 +1,4 @@
+import FridayMobileShellCore
 import SwiftUI
 
 /// The full-screen grid launcher (locked: menuModel = commandSheet) opened from the
@@ -6,55 +7,6 @@ import SwiftUI
 /// The launcher surfaces all selected mobile destinations. `isBuilt` only means the route is
 /// present and openable; `closureTier` is the product truth used to avoid counting a projection
 /// or readiness shell as an END-BAR closed loop.
-enum MobileDestinationClosureTier {
-  case liveWriteRead
-  case liveReadProjection
-  case providerWorkspace
-  case governedActionGated
-  case readinessOnly
-  case statusProjection
-  case navigationShell
-
-  var label: String {
-    switch self {
-    case .liveWriteRead: return "live write"
-    case .liveReadProjection: return "live read"
-    case .providerWorkspace: return "workspace"
-    case .governedActionGated: return "action gated"
-    case .readinessOnly: return "readiness"
-    case .statusProjection: return "projection"
-    case .navigationShell: return "shell"
-    }
-  }
-
-  var summary: String {
-    switch self {
-    case .liveWriteRead:
-      return "Real read/write loop exists when the governed live seams are configured."
-    case .liveReadProjection:
-      return "Reads real Hub projection state; it does not create or mutate work."
-    case .providerWorkspace:
-      return "Opens provider readiness, route/session refs, and native-control truth; read-only pieces are labeled."
-    case .governedActionGated:
-      return "Shows governed action controls; mutations require the live write seam and approval gates."
-    case .readinessOnly:
-      return "Reports device/provider readiness only; it is not a completed product loop."
-    case .statusProjection:
-      return "Shows current status from projection refs; no product action is completed here."
-    case .navigationShell:
-      return "Route exists for selected UI coverage, but closed-loop product behavior is still pending."
-    }
-  }
-
-  var isClosedLoopProductReady: Bool {
-    switch self {
-    case .liveWriteRead: return true
-    case .liveReadProjection, .providerWorkspace, .governedActionGated, .readinessOnly, .statusProjection, .navigationShell:
-      return false
-    }
-  }
-}
-
 enum MobileDestination: String, CaseIterable, Identifiable {
   case home
   case missions
@@ -76,77 +28,35 @@ enum MobileDestination: String, CaseIterable, Identifiable {
 
   var id: String { rawValue }
 
+  var contract: MobileProductDestinationContract {
+    MobileProductDestinationID(rawValue: rawValue)?.contract
+      ?? MobileProductDestinationContract(
+        id: rawValue,
+        title: rawValue,
+        systemImage: "questionmark.square.dashed",
+        tier: .navigationShell,
+        routeBuilt: false,
+        selectedDesignLocked: false,
+        runtimeActionIds: [],
+        blockers: [
+          MobileProductBlocker(.needsNativeSurface, label: "missing native route contract"),
+        ])
+  }
+
   var title: String {
-    switch self {
-    case .home: return "Friday Home"
-    case .missions: return "Missions"
-    case .session: return "Session"
-    case .contextPassport: return "Context Passport"
-    case .tokenLedger: return "Token Ledger"
-    case .shareIntake: return "Share Intake"
-    case .voice: return "Voice"
-    case .pairing: return "Device Pairing"
-    case .newSession: return "New Session"
-    case .needsMe: return "Needs Me"
-    case .memory: return "Memory"
-    case .platform: return "Platform"
-    case .providerAuth: return "Provider Workspace"
-    case .activity: return "Activity"
-    case .workflows: return "Workflows"
-    case .onboarding: return "Onboarding"
-    case .settings: return "Settings"
-    }
+    contract.title
   }
 
   var systemImage: String {
-    switch self {
-    case .home: return "house"
-    case .missions: return "list.bullet.rectangle"
-    case .session: return "rectangle.connected.to.line.below"
-    case .contextPassport: return "checklist.checked"
-    case .tokenLedger: return "chart.bar.doc.horizontal"
-    case .shareIntake: return "square.and.arrow.down"
-    case .voice: return "waveform"
-    case .pairing: return "qrcode.viewfinder"
-    case .newSession: return "plus"
-    case .needsMe: return "person.crop.circle.badge.exclamationmark"
-    case .memory: return "brain.head.profile"
-    case .platform: return "square.grid.2x2"
-    case .providerAuth: return "person.badge.key"
-    case .activity: return "bell.badge"
-    case .workflows: return "arrow.triangle.branch"
-    case .onboarding: return "sparkles.rectangle.stack"
-    case .settings: return "gearshape"
-    }
+    contract.systemImage
   }
 
-  var closureTier: MobileDestinationClosureTier {
-    switch self {
-    case .home:
-      return .liveWriteRead
-    case .session:
-      return .governedActionGated
-    case .missions, .contextPassport, .tokenLedger, .memory, .activity:
-      return .liveReadProjection
-    case .providerAuth:
-      return .providerWorkspace
-    case .shareIntake, .needsMe:
-      return .governedActionGated
-    case .newSession:
-      return .governedActionGated
-    case .voice, .pairing:
-      return .readinessOnly
-    case .platform, .settings:
-      return .statusProjection
-    case .workflows, .onboarding:
-      return .navigationShell
-    }
-  }
+  var closureTier: MobileProductLoopTier { contract.tier }
 
-  var productReadinessSummary: String { closureTier.summary }
+  var productReadinessSummary: String { contract.productReadinessSummary }
 
   /// Route coverage only. This must not be used as a closed-loop product-completion signal.
-  var isBuilt: Bool { true }
+  var isBuilt: Bool { contract.routeBuilt }
 }
 
 /// The Command Sheet: a full-screen 2-column grid launcher.
@@ -155,6 +65,7 @@ struct CommandSheet: View {
   @Binding var isOpen: Bool
 
   private let columns = [GridItem(.flexible(), spacing: 14), GridItem(.flexible(), spacing: 14)]
+  private let endBarSnapshot = MobileProductEndBarSnapshot()
 
   var body: some View {
     NavigationStack {
@@ -173,10 +84,7 @@ struct CommandSheet: View {
         }
         .padding(16)
 
-        Text("Route coverage is not END-BAR. Each tile shows the current runtime contract.")
-          .font(.caption2)
-          .foregroundStyle(MobileTheme.textSecondary)
-          .padding(.top, 8)
+        readinessFooter
       }
       .background(MobileTheme.backgroundWarmOffWhite.ignoresSafeArea())
       .navigationTitle("Friday")
@@ -190,9 +98,10 @@ struct CommandSheet: View {
   }
 
   private func tile(_ dest: MobileDestination) -> some View {
-    VStack(alignment: .leading, spacing: 10) {
+    let contract = dest.contract
+    return VStack(alignment: .leading, spacing: 10) {
       HStack {
-        Image(systemName: dest.systemImage)
+        Image(systemName: contract.systemImage)
           .font(.system(size: 26))
           .foregroundStyle(dest.isBuilt ? MobileTheme.cyan : MobileTheme.textSecondary)
         Spacer()
@@ -200,14 +109,14 @@ struct CommandSheet: View {
           StatusChip(text: "open", bg: MobileTheme.chipPendingBG, fg: MobileTheme.chipPendingFG)
         }
       }
-      Text(dest.title)
+      Text(contract.title)
         .font(.headline)
         .foregroundStyle(dest.isBuilt ? MobileTheme.textPrimary : MobileTheme.textSecondary)
       StatusChip(
-        text: dest.closureTier.label,
-        bg: dest.closureTier.isClosedLoopProductReady ? MobileTheme.chipDoneBG : MobileTheme.chipNeutralBG,
-        fg: dest.closureTier.isClosedLoopProductReady ? MobileTheme.chipDoneFG : MobileTheme.chipNeutralFG)
-      Text(dest.productReadinessSummary)
+        text: contract.tier.label,
+        bg: contract.isEndBarReady ? MobileTheme.chipDoneBG : MobileTheme.chipNeutralBG,
+        fg: contract.isEndBarReady ? MobileTheme.chipDoneFG : MobileTheme.chipNeutralFG)
+      Text(contract.productReadinessSummary)
         .font(.caption2)
         .foregroundStyle(MobileTheme.textSecondary)
         .lineLimit(3)
@@ -219,5 +128,21 @@ struct CommandSheet: View {
     .overlay(
       RoundedRectangle(cornerRadius: MobileTheme.cornerRadius, style: .continuous)
         .strokeBorder(MobileTheme.glassPanelBorder, lineWidth: 1))
+  }
+
+  private var readinessFooter: some View {
+    VStack(spacing: 6) {
+      StatusChip(
+        text: "\(endBarSnapshot.routeCoverageCount)/\(endBarSnapshot.totalCount) routes",
+        bg: MobileTheme.chipPendingBG,
+        fg: MobileTheme.chipPendingFG)
+      StatusChip(
+        text: "\(endBarSnapshot.endBarReadyCount)/\(endBarSnapshot.totalCount) END-BAR",
+        bg: endBarSnapshot.hasAnyEndBarClaim ? MobileTheme.chipDoneBG : MobileTheme.chipWarnBG,
+        fg: endBarSnapshot.hasAnyEndBarClaim ? MobileTheme.chipDoneFG : MobileTheme.chipWarnFG)
+    }
+    .frame(maxWidth: .infinity)
+    .padding(.top, 8)
+    .accessibilityIdentifier("friday.command-sheet.readiness-footer")
   }
 }

--- a/apps/friday-ios/Sources/FridayMobileShellCore/MobileProductReadinessContract.swift
+++ b/apps/friday-ios/Sources/FridayMobileShellCore/MobileProductReadinessContract.swift
@@ -1,0 +1,313 @@
+import Foundation
+
+public enum MobileProductLoopTier: String, CaseIterable, Sendable, Equatable {
+  case liveWriteRead
+  case liveReadProjection
+  case providerWorkspace
+  case governedActionGated
+  case readinessOnly
+  case statusProjection
+  case navigationShell
+
+  public var label: String {
+    switch self {
+    case .liveWriteRead: return "live write"
+    case .liveReadProjection: return "live read"
+    case .providerWorkspace: return "workspace"
+    case .governedActionGated: return "action gated"
+    case .readinessOnly: return "readiness"
+    case .statusProjection: return "projection"
+    case .navigationShell: return "shell"
+    }
+  }
+
+  public var summary: String {
+    switch self {
+    case .liveWriteRead:
+      return "Real read/write loop exists when the governed live seams are configured."
+    case .liveReadProjection:
+      return "Reads real Hub projection state; it does not create or mutate work."
+    case .providerWorkspace:
+      return "Opens provider readiness, route/session refs, and native-control truth; read-only pieces are labeled."
+    case .governedActionGated:
+      return "Shows governed action controls; mutations require the live write seam and approval gates."
+    case .readinessOnly:
+      return "Reports device/provider readiness only; it is not a completed product loop."
+    case .statusProjection:
+      return "Shows current status from projection refs; no product action is completed here."
+    case .navigationShell:
+      return "Route exists for selected UI coverage, but closed-loop product behavior is still pending."
+    }
+  }
+}
+
+public enum MobileProductBlockerKind: String, CaseIterable, Sendable, Equatable {
+  case needsLiveWrite
+  case needsLiveRead
+  case needsOperatorSignature
+  case needsDevicePairing
+  case needsProviderCredential
+  case needsRuntimeEvidence
+  case needsNativeSurface
+}
+
+public struct MobileProductBlocker: Sendable, Equatable, Identifiable {
+  public let id: String
+  public let kind: MobileProductBlockerKind
+  public let label: String
+
+  public init(_ kind: MobileProductBlockerKind, id: String? = nil, label: String) {
+    self.kind = kind
+    self.id = id ?? kind.rawValue
+    self.label = label
+  }
+}
+
+public struct MobileProductDestinationContract: Sendable, Equatable, Identifiable {
+  public let id: String
+  public let title: String
+  public let systemImage: String
+  public let tier: MobileProductLoopTier
+  public let routeBuilt: Bool
+  public let selectedDesignLocked: Bool
+  public let runtimeActionIds: [String]
+  public let blockers: [MobileProductBlocker]
+
+  public init(
+    id: String,
+    title: String,
+    systemImage: String,
+    tier: MobileProductLoopTier,
+    routeBuilt: Bool,
+    selectedDesignLocked: Bool,
+    runtimeActionIds: [String],
+    blockers: [MobileProductBlocker]
+  ) {
+    self.id = id
+    self.title = title
+    self.systemImage = systemImage
+    self.tier = tier
+    self.routeBuilt = routeBuilt
+    self.selectedDesignLocked = selectedDesignLocked
+    self.runtimeActionIds = runtimeActionIds
+    self.blockers = blockers
+  }
+
+  public var isEndBarReady: Bool {
+    routeBuilt && selectedDesignLocked && blockers.isEmpty && tier == .liveWriteRead
+  }
+
+  public var productReadinessSummary: String {
+    if blockers.isEmpty {
+      return tier.summary
+    }
+    let first = blockers.prefix(2).map(\.label).joined(separator: " · ")
+    if blockers.count <= 2 {
+      return first
+    }
+    return "\(first) · +\(blockers.count - 2)"
+  }
+}
+
+public enum MobileProductDestinationID: String, CaseIterable, Sendable, Equatable, Identifiable {
+  case home
+  case missions
+  case session
+  case contextPassport
+  case tokenLedger
+  case shareIntake
+  case voice
+  case pairing
+  case newSession
+  case needsMe
+  case memory
+  case platform
+  case providerAuth
+  case activity
+  case workflows
+  case onboarding
+  case settings
+
+  public var id: String { rawValue }
+
+  public var contract: MobileProductDestinationContract {
+    switch self {
+    case .home:
+      return contract(
+        title: "Friday Home",
+        systemImage: "house",
+        tier: .liveWriteRead,
+        runtimeActionIds: ["mobile/home/refresh"],
+        blockers: [
+          .init(.needsRuntimeEvidence, label: "same-run mobile+desktop user proof"),
+        ])
+    case .missions:
+      return contract(
+        title: "Missions",
+        systemImage: "list.bullet.rectangle",
+        tier: .liveReadProjection,
+        runtimeActionIds: [],
+        blockers: [.init(.needsLiveWrite, label: "dispatch/action controls")])
+    case .session:
+      return contract(
+        title: "Session",
+        systemImage: "rectangle.connected.to.line.below",
+        tier: .governedActionGated,
+        runtimeActionIds: ["mobile/session/sidecar/open", "mobile/session/sidecar/close", "mobile/workflow/run-control"],
+        blockers: [
+          .init(.needsOperatorSignature, label: "approve-with-proof signature"),
+          .init(.needsRuntimeEvidence, label: "real user tap proof"),
+        ])
+    case .contextPassport:
+      return contract(
+        title: "Context Passport",
+        systemImage: "checklist.checked",
+        tier: .liveReadProjection,
+        runtimeActionIds: ["mobile/passport/send"],
+        blockers: [.init(.needsRuntimeEvidence, label: "real app transfer proof")])
+    case .tokenLedger:
+      return contract(
+        title: "Token Ledger",
+        systemImage: "chart.bar.doc.horizontal",
+        tier: .liveReadProjection,
+        runtimeActionIds: [],
+        blockers: [.init(.needsRuntimeEvidence, label: "run-backed ledger proof")])
+    case .shareIntake:
+      return contract(
+        title: "Share Intake",
+        systemImage: "square.and.arrow.down",
+        tier: .governedActionGated,
+        runtimeActionIds: ["mobile/share/send"],
+        blockers: [.init(.needsLiveWrite, label: "mission-spine write seam")])
+    case .voice:
+      return contract(
+        title: "Voice",
+        systemImage: "waveform",
+        tier: .readinessOnly,
+        runtimeActionIds: [],
+        blockers: [
+          .init(.needsNativeSurface, label: "speech loop UI"),
+          .init(.needsProviderCredential, label: "TTS/provider readiness"),
+        ])
+    case .pairing:
+      return contract(
+        title: "Device Pairing",
+        systemImage: "qrcode.viewfinder",
+        tier: .readinessOnly,
+        runtimeActionIds: ["mobile/firstlaunch/scan", "mobile/firstlaunch/pairnow", "mobile/firstlaunch/retry", "mobile/firstlaunch/cancel"],
+        blockers: [.init(.needsRuntimeEvidence, label: "real device pair proof")])
+    case .newSession:
+      return contract(
+        title: "New Session",
+        systemImage: "plus",
+        tier: .governedActionGated,
+        runtimeActionIds: ["mobile/newSession/play"],
+        blockers: [.init(.needsRuntimeEvidence, label: "provider result round-trip")])
+    case .needsMe:
+      return contract(
+        title: "Needs Me",
+        systemImage: "person.crop.circle.badge.exclamationmark",
+        tier: .governedActionGated,
+        runtimeActionIds: ["mobile/approval/check", "mobile/approval/reject"],
+        blockers: [.init(.needsOperatorSignature, label: "approve-with-proof signature")])
+    case .memory:
+      return contract(
+        title: "Memory",
+        systemImage: "brain.head.profile",
+        tier: .liveReadProjection,
+        runtimeActionIds: ["mobile/memory/confirm", "mobile/memory/reject"],
+        blockers: [.init(.needsRuntimeEvidence, label: "confirmed learning behavior delta")])
+    case .platform:
+      return contract(
+        title: "Platform",
+        systemImage: "square.grid.2x2",
+        tier: .statusProjection,
+        runtimeActionIds: [],
+        blockers: [.init(.needsRuntimeEvidence, label: "capability matrix live proof")])
+    case .providerAuth:
+      return contract(
+        title: "Provider Workspace",
+        systemImage: "person.badge.key",
+        tier: .providerWorkspace,
+        runtimeActionIds: [],
+        blockers: [.init(.needsProviderCredential, label: "all selected provider routes")])
+    case .activity:
+      return contract(
+        title: "Activity",
+        systemImage: "bell.badge",
+        tier: .liveReadProjection,
+        runtimeActionIds: ["mobile/activity/mark-done"],
+        blockers: [.init(.needsLiveWrite, label: "owner-bound mark-done")])
+    case .workflows:
+      return contract(
+        title: "Workflows",
+        systemImage: "arrow.triangle.branch",
+        tier: .navigationShell,
+        runtimeActionIds: [],
+        blockers: [.init(.needsNativeSurface, label: "workflow builder surface")])
+    case .onboarding:
+      return contract(
+        title: "Onboarding",
+        systemImage: "sparkles.rectangle.stack",
+        tier: .navigationShell,
+        runtimeActionIds: [],
+        blockers: [.init(.needsNativeSurface, label: "zero-config launch flow")])
+    case .settings:
+      return contract(
+        title: "Settings",
+        systemImage: "gearshape",
+        tier: .statusProjection,
+        runtimeActionIds: [],
+        blockers: [.init(.needsRuntimeEvidence, label: "settings mutation proof")])
+    }
+  }
+
+  private func contract(
+    title: String,
+    systemImage: String,
+    tier: MobileProductLoopTier,
+    runtimeActionIds: [String],
+    blockers: [MobileProductBlocker]
+  ) -> MobileProductDestinationContract {
+    MobileProductDestinationContract(
+      id: rawValue,
+      title: title,
+      systemImage: systemImage,
+      tier: tier,
+      routeBuilt: true,
+      selectedDesignLocked: true,
+      runtimeActionIds: runtimeActionIds,
+      blockers: blockers)
+  }
+}
+
+public struct MobileProductEndBarSnapshot: Sendable, Equatable {
+  public let contracts: [MobileProductDestinationContract]
+
+  public init(contracts: [MobileProductDestinationContract] = MobileProductDestinationID.allCases.map(\.contract)) {
+    self.contracts = contracts
+  }
+
+  public var routeCoverageCount: Int {
+    contracts.filter(\.routeBuilt).count
+  }
+
+  public var endBarReadyCount: Int {
+    contracts.filter(\.isEndBarReady).count
+  }
+
+  public var totalCount: Int {
+    contracts.count
+  }
+
+  public var hasAnyEndBarClaim: Bool {
+    endBarReadyCount > 0
+  }
+
+  public var uniqueBlockers: [MobileProductBlocker] {
+    var seen = Set<String>()
+    return contracts
+      .flatMap(\.blockers)
+      .filter { seen.insert($0.id).inserted }
+  }
+}

--- a/apps/friday-ios/Tests/FridayMobileShellCoreTests/MobileProductReadinessContractTests.swift
+++ b/apps/friday-ios/Tests/FridayMobileShellCoreTests/MobileProductReadinessContractTests.swift
@@ -1,0 +1,67 @@
+import Testing
+@testable import FridayMobileShellCore
+
+@Test
+func mobileProductContractCoversOperatorSelectedDestinations() {
+  let ids = MobileProductDestinationID.allCases.map(\.rawValue)
+
+  #expect(ids == [
+    "home",
+    "missions",
+    "session",
+    "contextPassport",
+    "tokenLedger",
+    "shareIntake",
+    "voice",
+    "pairing",
+    "newSession",
+    "needsMe",
+    "memory",
+    "platform",
+    "providerAuth",
+    "activity",
+    "workflows",
+    "onboarding",
+    "settings",
+  ])
+  #expect(MobileProductDestinationID.allCases.allSatisfy { $0.contract.routeBuilt })
+  #expect(MobileProductDestinationID.allCases.allSatisfy { $0.contract.selectedDesignLocked })
+}
+
+@Test
+func mobileProductContractDoesNotTreatRouteCoverageAsEndBar() {
+  let snapshot = MobileProductEndBarSnapshot()
+
+  #expect(snapshot.routeCoverageCount == snapshot.totalCount)
+  #expect(snapshot.endBarReadyCount == 0)
+  #expect(!snapshot.hasAnyEndBarClaim)
+  #expect(snapshot.uniqueBlockers.contains { $0.kind == .needsOperatorSignature })
+  #expect(snapshot.uniqueBlockers.contains { $0.kind == .needsRuntimeEvidence })
+}
+
+@Test
+func mobileProductContractKeepsApprovalSignatureVisible() {
+  let needsMe = MobileProductDestinationID.needsMe.contract
+  let session = MobileProductDestinationID.session.contract
+
+  #expect(needsMe.runtimeActionIds.contains("mobile/approval/check"))
+  #expect(needsMe.runtimeActionIds.contains("mobile/approval/reject"))
+  #expect(needsMe.blockers.contains { $0.kind == .needsOperatorSignature })
+  #expect(session.blockers.contains { $0.kind == .needsOperatorSignature })
+  #expect(!needsMe.isEndBarReady)
+  #expect(!session.isEndBarReady)
+}
+
+@Test
+func mobileProductContractSeparatesReadinessShellsFromProductLoops() {
+  let voice = MobileProductDestinationID.voice.contract
+  let workflows = MobileProductDestinationID.workflows.contract
+  let provider = MobileProductDestinationID.providerAuth.contract
+
+  #expect(voice.tier == .readinessOnly)
+  #expect(workflows.tier == .navigationShell)
+  #expect(provider.tier == .providerWorkspace)
+  #expect(!voice.isEndBarReady)
+  #expect(!workflows.isEndBarReady)
+  #expect(!provider.isEndBarReady)
+}

--- a/scripts/ops/check-friday-client-design-contract.mjs
+++ b/scripts/ops/check-friday-client-design-contract.mjs
@@ -23,7 +23,8 @@ function hasString(source, value) {
 
 function checkSourceSet(repoRoot, checks) {
   return checks.map((check) => {
-    const source = readText(repoRoot, check.path);
+    const paths = check.paths ?? [check.path];
+    const source = paths.map((target) => readText(repoRoot, target)).join("\n");
     const missing = [];
     for (const item of check.requiredCases ?? []) {
       if (!hasCase(source, item)) missing.push(`case ${item}`);
@@ -33,7 +34,7 @@ function checkSourceSet(repoRoot, checks) {
     }
     return {
       label: check.label,
-      target: check.path,
+      target: paths.join(" + "),
       status: missing.length === 0 ? "passed" : "failed",
       missing,
     };
@@ -51,7 +52,10 @@ const repoRoot = resolveRepoRoot();
 const checks = checkSourceSet(repoRoot, [
   {
     label: "iOS command sheet covers selected mobile destinations",
-    path: "apps/friday-ios/Sources/FridayMobileShell/CommandSheet.swift",
+    paths: [
+      "apps/friday-ios/Sources/FridayMobileShell/CommandSheet.swift",
+      "apps/friday-ios/Sources/FridayMobileShellCore/MobileProductReadinessContract.swift",
+    ],
     requiredCases: [
       "home",
       "session",
@@ -69,7 +73,7 @@ const checks = checkSourceSet(repoRoot, [
     ],
     requiredStrings: [
       "Command Sheet",
-      "Route coverage is not END-BAR",
+      "Route coverage only",
       "Provider Workspace",
       "Device Pairing",
     ],

--- a/scripts/ops/check-friday-native-action-closure.mjs
+++ b/scripts/ops/check-friday-native-action-closure.mjs
@@ -51,6 +51,7 @@ const files = {
   mobileChatVM: read(root, "apps/friday-ios/Sources/FridayMobileShellCore/FridayChatViewModel.swift"),
   mobileShareVM: read(root, "apps/friday-ios/Sources/FridayMobileShellCore/ShareIntakeViewModel.swift"),
   mobileVoiceVM: read(root, "apps/friday-ios/Sources/FridayMobileShellCore/VoiceReadinessViewModel.swift"),
+  mobileProductContract: read(root, "apps/friday-ios/Sources/FridayMobileShellCore/MobileProductReadinessContract.swift"),
   mobileHomeTests: read(root, "apps/friday-ios/Tests/FridayMobileShellCoreTests/HomeViewModelTests.swift"),
   mobileSessionTests: read(root, "apps/friday-ios/Tests/FridayMobileShellCoreTests/SessionContinuationViewModelTests.swift"),
   mobileChatTests: read(root, "apps/friday-ios/Tests/FridayMobileShellCoreTests/FridayChatViewModelTests.swift"),
@@ -74,6 +75,10 @@ const mobileUi = [
   files.mobileShare,
   files.mobileVoice,
   files.mobileToken,
+].join("\n");
+const mobileCommandContract = [
+  files.mobileCommand,
+  files.mobileProductContract,
 ].join("\n");
 const mobileVM = [
   files.mobileHomeVM,
@@ -99,8 +104,8 @@ const desktopTests = files.desktopTests;
 const checks = [
   check(
     "mobile-command-sheet-does-not-hide-product-destinations",
-    "apps/friday-ios/Sources/FridayMobileShell/CommandSheet.swift",
-    includesAll(files.mobileCommand, [
+    "apps/friday-ios/Sources/FridayMobileShell/CommandSheet.swift + apps/friday-ios/Sources/FridayMobileShellCore/MobileProductReadinessContract.swift",
+    includesAll(mobileCommandContract, [
       "case session",
       "case contextPassport",
       "case tokenLedger",
@@ -112,7 +117,7 @@ const checks = [
       "case activity",
       "case workflows",
       "case settings",
-      "var isBuilt: Bool { true }",
+      "var isBuilt: Bool { contract.routeBuilt }",
     ]),
     [
       "This is destination coverage, not END-BAR. Action closure is checked by the rows below.",
@@ -120,22 +125,25 @@ const checks = [
   ),
   check(
     "mobile-command-sheet-separates-route-coverage-from-product-closure",
-    "apps/friday-ios/Sources/FridayMobileShell/CommandSheet.swift",
-    includesAll(files.mobileCommand, [
-      "enum MobileDestinationClosureTier",
-      "var closureTier: MobileDestinationClosureTier",
+    "apps/friday-ios/Sources/FridayMobileShell/CommandSheet.swift + apps/friday-ios/Sources/FridayMobileShellCore/MobileProductReadinessContract.swift",
+    includesAll(mobileCommandContract, [
+      "enum MobileProductLoopTier",
+      "var closureTier: MobileProductLoopTier",
       "Route coverage only. This must not be used as a closed-loop product-completion signal.",
-      "isClosedLoopProductReady",
-      "case .liveWriteRead: return true",
+      "isEndBarReady",
+      "tier == .liveWriteRead",
       "case .home:",
       "case .session:",
       "case .providerAuth:",
-      "case .shareIntake, .needsMe:",
-      "case .voice, .pairing:",
-      "case .workflows, .onboarding:",
+      "case .shareIntake:",
+      "case .needsMe:",
+      "case .voice:",
+      "case .pairing:",
+      "case .workflows:",
+      "case .onboarding:",
       "case .providerWorkspace:",
-      "dest.closureTier.label",
-      "dest.productReadinessSummary",
+      "contract.tier.label",
+      "contract.productReadinessSummary",
       "closed-loop product behavior is still pending",
       "not a completed product loop",
       "Provider Workspace",

--- a/test/unit/qa/friday-native-action-closure-cli.test.ts
+++ b/test/unit/qa/friday-native-action-closure-cli.test.ts
@@ -30,6 +30,7 @@ const requiredFixtureFiles = [
   "apps/friday-ios/Sources/FridayMobileShellCore/FridayChatViewModel.swift",
   "apps/friday-ios/Sources/FridayMobileShellCore/ShareIntakeViewModel.swift",
   "apps/friday-ios/Sources/FridayMobileShellCore/VoiceReadinessViewModel.swift",
+  "apps/friday-ios/Sources/FridayMobileShellCore/MobileProductReadinessContract.swift",
   "apps/friday-ios/Tests/FridayMobileShellCoreTests/HomeViewModelTests.swift",
   "apps/friday-ios/Tests/FridayMobileShellCoreTests/SessionContinuationViewModelTests.swift",
   "apps/friday-ios/Tests/FridayMobileShellCoreTests/FridayChatViewModelTests.swift",
@@ -121,8 +122,8 @@ describe("friday-native-action-closure", () => {
       replaceInFixture(
         root,
         "apps/friday-ios/Sources/FridayMobileShell/CommandSheet.swift",
-        "var closureTier: MobileDestinationClosureTier",
-        "var routeTier: MobileDestinationClosureTier",
+        "var closureTier: MobileProductLoopTier",
+        "var routeTier: MobileProductLoopTier",
       );
       const result = run(root);
       expect(result.status).toBe(1);
@@ -135,7 +136,7 @@ describe("friday-native-action-closure", () => {
         expect.arrayContaining([
           expect.objectContaining({
             id: "mobile-command-sheet-separates-route-coverage-from-product-closure",
-            missing: expect.arrayContaining(["var closureTier: MobileDestinationClosureTier"]),
+            missing: expect.arrayContaining(["var closureTier: MobileProductLoopTier"]),
           }),
         ]),
       );


### PR DESCRIPTION
## Summary
- move the selected mobile destination readiness truth into a UI-free core contract
- make Command Sheet consume the shared contract instead of a local duplicate table
- add tests proving route coverage is not END-BAR and the approve-with-proof gap stays visible

## Verification
- swift test --package-path apps/friday-ios --filter MobileProductReadinessContractTests
- apps/friday-ios/build-sim.sh --mode offline-truth --destination home --shot /tmp/friday-ios-product-contract-home-20260625T145000Z.png
- node scripts/ops/check-friday-design-action-runtime-evidence.mjs ... => missingUniqueRuntimeEvidence=1 (mobile/approval/check)

Truth: this PR is product-truth plumbing and UI accountability. It does not claim END-BAR, GO-LIVE, adoption, or operator-signed mobile approval.