### PR TITLE
feat(desktop): anchor product readiness contract

### DIFF
--- a/apps/macos/FridayHubConsole/Sources/FridayHubConsole/HubConsoleShell.swift
+++ b/apps/macos/FridayHubConsole/Sources/FridayHubConsole/HubConsoleShell.swift
@@ -101,7 +101,7 @@ struct NavRail: View {
         Text("Governed workbench")
           .font(.system(size: 10, weight: .semibold))
           .foregroundStyle(HubTheme.textPrimary)
-        Text("Live read + gated writes")
+        Text(readinessFooterText)
           .font(.system(size: 10))
           .foregroundStyle(HubTheme.textSecondary)
       }
@@ -111,6 +111,11 @@ struct NavRail: View {
     }
     .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
     .background(HubTheme.navRailBackground)
+  }
+
+  private var readinessFooterText: String {
+    let snapshot = DesktopProductEndBarSnapshot()
+    return "\(snapshot.routeCoverageCount)/\(snapshot.totalCount) routes · \(snapshot.endBarReadyCount)/\(snapshot.totalCount) END-BAR"
   }
 }
 
@@ -131,6 +136,13 @@ struct NavRailItem: View {
         Spacer()
         if !destination.isBuilt {
           Text("soon")
+            .font(.system(size: 9, weight: .medium))
+            .foregroundStyle(HubTheme.textSecondary)
+            .padding(.horizontal, 5)
+            .padding(.vertical, 1)
+            .background(Capsule().fill(Color.black.opacity(0.05)))
+        } else if !destination.contract.blockers.isEmpty {
+          Text(destination.contract.tier.label)
             .font(.system(size: 9, weight: .medium))
             .foregroundStyle(HubTheme.textSecondary)
             .padding(.horizontal, 5)

--- a/apps/macos/FridayHubConsole/Sources/FridayHubConsole/Navigation.swift
+++ b/apps/macos/FridayHubConsole/Sources/FridayHubConsole/Navigation.swift
@@ -1,3 +1,4 @@
+import FridayHubConsoleCore
 import SwiftUI
 
 /// The nav-rail destinations of the Hub Console.
@@ -22,46 +23,29 @@ enum HubDestination: String, CaseIterable, Identifiable {
 
   var id: String { rawValue }
 
+  var contract: DesktopProductDestinationContract {
+    DesktopProductDestinationID(rawValue: rawValue)?.contract
+      ?? DesktopProductDestinationContract(
+        id: rawValue,
+        title: rawValue,
+        systemImage: "questionmark.square.dashed",
+        tier: .navigationShell,
+        routeBuilt: false,
+        selectedDesignLocked: false,
+        runtimeActionIds: [],
+        blockers: [
+          DesktopProductBlocker(.needsNativeSurface, label: "missing desktop route contract"),
+        ])
+  }
+
   var title: String {
-    switch self {
-    case .operations: return "Operations Overview"
-    case .chat: return "Friday Chat"
-    case .providerAdmin: return "Provider Admin"
-    case .parity: return "Provider Parity"
-    case .pairingProvisioning: return "Pairing"
-    case .workflow: return "Workflow Builder"
-    case .channels: return "Channels"
-    case .diagnostics: return "Diagnostics"
-    case .recovery: return "Recovery"
-    case .memory: return "Memory"
-    case .tokenLedger: return "Token Ledger"
-    case .skills: return "Skills / Tools"
-    case .media: return "Media / Link"
-    case .settings: return "Settings"
-    case .evidence: return "Evidence Search"
-    }
+    contract.title
   }
 
   var systemImage: String {
-    switch self {
-    case .operations: return "gauge.with.dots.needle.bottom.50percent"
-    case .chat: return "bubble.left.and.bubble.right"
-    case .providerAdmin: return "person.badge.key"
-    case .parity: return "square.grid.3x3"
-    case .pairingProvisioning: return "qrcode.viewfinder"
-    case .workflow: return "point.3.connected.trianglepath.dotted"
-    case .channels: return "antenna.radiowaves.left.and.right"
-    case .diagnostics: return "stethoscope"
-    case .recovery: return "arrow.counterclockwise.circle"
-    case .memory: return "brain.head.profile"
-    case .tokenLedger: return "chart.bar.doc.horizontal"
-    case .skills: return "wrench.and.screwdriver"
-    case .media: return "link.badge.plus"
-    case .settings: return "gearshape"
-    case .evidence: return "doc.text.magnifyingglass"
-    }
+    contract.systemImage
   }
 
   /// Whether this destination is implemented by the desktop shell.
-  var isBuilt: Bool { true }
+  var isBuilt: Bool { contract.routeBuilt }
 }

--- a/apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/DesktopProductReadinessContract.swift
+++ b/apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/DesktopProductReadinessContract.swift
@@ -1,0 +1,291 @@
+import Foundation
+
+public enum DesktopProductLoopTier: String, CaseIterable, Sendable, Equatable {
+  case liveWorkbench
+  case liveChatWorkbench
+  case providerAdmin
+  case liveReadProjection
+  case governedActionGated
+  case readinessOnly
+  case navigationShell
+
+  public var label: String {
+    switch self {
+    case .liveWorkbench: return "workbench"
+    case .liveChatWorkbench: return "chat"
+    case .providerAdmin: return "provider admin"
+    case .liveReadProjection: return "live read"
+    case .governedActionGated: return "action gated"
+    case .readinessOnly: return "readiness"
+    case .navigationShell: return "shell"
+    }
+  }
+
+  public var summary: String {
+    switch self {
+    case .liveWorkbench:
+      return "Reads the real Hub workbench projection and proof refs when the live read seam is configured."
+    case .liveChatWorkbench:
+      return "Surfaces chat, approvals, memory, and proof refs through governed read/write seams."
+    case .providerAdmin:
+      return "Shows provider auth, route readiness, and failover truth from Hub read arms."
+    case .liveReadProjection:
+      return "Reads real Hub projection details; it does not complete a product action by itself."
+    case .governedActionGated:
+      return "Shows governed action controls; mutations still require live write and approval gates."
+    case .readinessOnly:
+      return "Reports setup/readiness truth only."
+    case .navigationShell:
+      return "Navigation exists for selected UI coverage; closed-loop product behavior is still pending."
+    }
+  }
+}
+
+public enum DesktopProductBlockerKind: String, CaseIterable, Sendable, Equatable {
+  case needsLiveWrite
+  case needsOperatorSignature
+  case needsProviderCredential
+  case needsRuntimeEvidence
+  case needsNativeSurface
+  case needsLongRunSoak
+}
+
+public struct DesktopProductBlocker: Sendable, Equatable, Identifiable {
+  public let id: String
+  public let kind: DesktopProductBlockerKind
+  public let label: String
+
+  public init(_ kind: DesktopProductBlockerKind, id: String? = nil, label: String) {
+    self.kind = kind
+    self.id = id ?? kind.rawValue
+    self.label = label
+  }
+}
+
+public struct DesktopProductDestinationContract: Sendable, Equatable, Identifiable {
+  public let id: String
+  public let title: String
+  public let systemImage: String
+  public let tier: DesktopProductLoopTier
+  public let routeBuilt: Bool
+  public let selectedDesignLocked: Bool
+  public let runtimeActionIds: [String]
+  public let blockers: [DesktopProductBlocker]
+
+  public init(
+    id: String,
+    title: String,
+    systemImage: String,
+    tier: DesktopProductLoopTier,
+    routeBuilt: Bool,
+    selectedDesignLocked: Bool,
+    runtimeActionIds: [String],
+    blockers: [DesktopProductBlocker]
+  ) {
+    self.id = id
+    self.title = title
+    self.systemImage = systemImage
+    self.tier = tier
+    self.routeBuilt = routeBuilt
+    self.selectedDesignLocked = selectedDesignLocked
+    self.runtimeActionIds = runtimeActionIds
+    self.blockers = blockers
+  }
+
+  public var isEndBarReady: Bool {
+    routeBuilt && selectedDesignLocked && blockers.isEmpty && tier == .liveWorkbench
+  }
+
+  public var productReadinessSummary: String {
+    if blockers.isEmpty {
+      return tier.summary
+    }
+    let first = blockers.prefix(2).map(\.label).joined(separator: " · ")
+    if blockers.count <= 2 {
+      return first
+    }
+    return "\(first) · +\(blockers.count - 2)"
+  }
+}
+
+public enum DesktopProductDestinationID: String, CaseIterable, Sendable, Equatable, Identifiable {
+  case operations
+  case chat
+  case providerAdmin
+  case parity
+  case pairingProvisioning
+  case workflow
+  case channels
+  case diagnostics
+  case recovery
+  case memory
+  case tokenLedger
+  case skills
+  case media
+  case settings
+  case evidence
+
+  public var id: String { rawValue }
+
+  public var contract: DesktopProductDestinationContract {
+    switch self {
+    case .operations:
+      return contract(
+        title: "Operations Overview",
+        systemImage: "gauge.with.dots.needle.bottom.50percent",
+        tier: .liveWorkbench,
+        runtimeActionIds: ["desktop/operations/refresh"],
+        blockers: [.init(.needsRuntimeEvidence, label: "same-run user proof")])
+    case .chat:
+      return contract(
+        title: "Friday Chat",
+        systemImage: "bubble.left.and.bubble.right",
+        tier: .liveChatWorkbench,
+        runtimeActionIds: [
+          "desktop/fridayChat/act",
+          "desktop/fridayChat/check",
+        ],
+        blockers: [.init(.needsRuntimeEvidence, label: "full desktop tap proof")])
+    case .providerAdmin:
+      return contract(
+        title: "Provider Admin",
+        systemImage: "person.badge.key",
+        tier: .providerAdmin,
+        runtimeActionIds: [],
+        blockers: [.init(.needsProviderCredential, label: "all selected provider routes")])
+    case .parity:
+      return contract(
+        title: "Provider Parity",
+        systemImage: "square.grid.3x3",
+        tier: .liveReadProjection,
+        runtimeActionIds: [],
+        blockers: [.init(.needsRuntimeEvidence, label: "multi-provider route proof")])
+    case .pairingProvisioning:
+      return contract(
+        title: "Pairing",
+        systemImage: "qrcode.viewfinder",
+        tier: .readinessOnly,
+        runtimeActionIds: ["desktop/pairing/manifest"],
+        blockers: [.init(.needsRuntimeEvidence, label: "desktop+mobile pair proof")])
+    case .workflow:
+      return contract(
+        title: "Workflow Builder",
+        systemImage: "point.3.connected.trianglepath.dotted",
+        tier: .navigationShell,
+        runtimeActionIds: [],
+        blockers: [.init(.needsNativeSurface, label: "canvas+inspector product surface")])
+    case .channels:
+      return contract(
+        title: "Channels",
+        systemImage: "antenna.radiowaves.left.and.right",
+        tier: .navigationShell,
+        runtimeActionIds: [],
+        blockers: [.init(.needsNativeSurface, label: "channel admin product surface")])
+    case .diagnostics:
+      return contract(
+        title: "Diagnostics",
+        systemImage: "stethoscope",
+        tier: .liveReadProjection,
+        runtimeActionIds: [],
+        blockers: [.init(.needsRuntimeEvidence, label: "doctor action proof")])
+    case .recovery:
+      return contract(
+        title: "Recovery",
+        systemImage: "arrow.counterclockwise.circle",
+        tier: .governedActionGated,
+        runtimeActionIds: ["desktop/recovery/retry", "desktop/recovery/cancel"],
+        blockers: [.init(.needsLiveWrite, label: "owner-bound recovery writes")])
+    case .memory:
+      return contract(
+        title: "Memory",
+        systemImage: "brain.head.profile",
+        tier: .governedActionGated,
+        runtimeActionIds: ["desktop/memory/act", "desktop/memory/check"],
+        blockers: [.init(.needsRuntimeEvidence, label: "confirmed memory behavior delta")])
+    case .tokenLedger:
+      return contract(
+        title: "Token Ledger",
+        systemImage: "chart.bar.doc.horizontal",
+        tier: .liveReadProjection,
+        runtimeActionIds: [],
+        blockers: [.init(.needsRuntimeEvidence, label: "run-backed ledger proof")])
+    case .skills:
+      return contract(
+        title: "Skills / Tools",
+        systemImage: "wrench.and.screwdriver",
+        tier: .navigationShell,
+        runtimeActionIds: [],
+        blockers: [.init(.needsNativeSurface, label: "tool install/run controls")])
+    case .media:
+      return contract(
+        title: "Media / Link",
+        systemImage: "link.badge.plus",
+        tier: .navigationShell,
+        runtimeActionIds: [],
+        blockers: [.init(.needsNativeSurface, label: "media/link product surface")])
+    case .settings:
+      return contract(
+        title: "Settings",
+        systemImage: "gearshape",
+        tier: .navigationShell,
+        runtimeActionIds: [],
+        blockers: [.init(.needsRuntimeEvidence, label: "settings mutation proof")])
+    case .evidence:
+      return contract(
+        title: "Evidence Search",
+        systemImage: "doc.text.magnifyingglass",
+        tier: .liveReadProjection,
+        runtimeActionIds: [],
+        blockers: [.init(.needsRuntimeEvidence, label: "search result proof")])
+    }
+  }
+
+  private func contract(
+    title: String,
+    systemImage: String,
+    tier: DesktopProductLoopTier,
+    runtimeActionIds: [String],
+    blockers: [DesktopProductBlocker]
+  ) -> DesktopProductDestinationContract {
+    DesktopProductDestinationContract(
+      id: rawValue,
+      title: title,
+      systemImage: systemImage,
+      tier: tier,
+      routeBuilt: true,
+      selectedDesignLocked: true,
+      runtimeActionIds: runtimeActionIds,
+      blockers: blockers)
+  }
+}
+
+public struct DesktopProductEndBarSnapshot: Sendable, Equatable {
+  public let contracts: [DesktopProductDestinationContract]
+
+  public init(contracts: [DesktopProductDestinationContract] = DesktopProductDestinationID.allCases.map(\.contract)) {
+    self.contracts = contracts
+  }
+
+  public var routeCoverageCount: Int {
+    contracts.filter(\.routeBuilt).count
+  }
+
+  public var endBarReadyCount: Int {
+    contracts.filter(\.isEndBarReady).count
+  }
+
+  public var totalCount: Int {
+    contracts.count
+  }
+
+  public var hasAnyEndBarClaim: Bool {
+    endBarReadyCount > 0
+  }
+
+  public var uniqueBlockers: [DesktopProductBlocker] {
+    var seen = Set<String>()
+    return contracts
+      .flatMap(\.blockers)
+      .filter { seen.insert($0.id).inserted }
+  }
+}

--- a/apps/macos/FridayHubConsole/Tests/FridayHubConsoleCoreTests/DesktopProductReadinessContractTests.swift
+++ b/apps/macos/FridayHubConsole/Tests/FridayHubConsoleCoreTests/DesktopProductReadinessContractTests.swift
@@ -1,0 +1,68 @@
+import Testing
+@testable import FridayHubConsoleCore
+
+@Test
+func desktopProductContractCoversSelectedHubConsoleDestinations() {
+  let ids = DesktopProductDestinationID.allCases.map(\.rawValue)
+
+  #expect(ids == [
+    "operations",
+    "chat",
+    "providerAdmin",
+    "parity",
+    "pairingProvisioning",
+    "workflow",
+    "channels",
+    "diagnostics",
+    "recovery",
+    "memory",
+    "tokenLedger",
+    "skills",
+    "media",
+    "settings",
+    "evidence",
+  ])
+  #expect(DesktopProductDestinationID.allCases.allSatisfy { $0.contract.routeBuilt })
+  #expect(DesktopProductDestinationID.allCases.allSatisfy { $0.contract.selectedDesignLocked })
+}
+
+@Test
+func desktopProductContractDoesNotTreatNavCoverageAsEndBar() {
+  let snapshot = DesktopProductEndBarSnapshot()
+
+  #expect(snapshot.routeCoverageCount == snapshot.totalCount)
+  #expect(snapshot.endBarReadyCount == 0)
+  #expect(!snapshot.hasAnyEndBarClaim)
+  #expect(snapshot.uniqueBlockers.contains { $0.kind == .needsRuntimeEvidence })
+  #expect(snapshot.uniqueBlockers.contains { $0.kind == .needsLiveWrite })
+}
+
+@Test
+func desktopProductContractKeepsChatAndMemoryEvidenceVisible() {
+  let chat = DesktopProductDestinationID.chat.contract
+  let memory = DesktopProductDestinationID.memory.contract
+
+  #expect(chat.runtimeActionIds.contains("desktop/fridayChat/check"))
+  #expect(chat.runtimeActionIds.contains("desktop/fridayChat/act"))
+  #expect(memory.runtimeActionIds.contains("desktop/memory/check"))
+  #expect(memory.runtimeActionIds.contains("desktop/memory/act"))
+  #expect(!chat.isEndBarReady)
+  #expect(!memory.isEndBarReady)
+}
+
+@Test
+func desktopProductContractSeparatesShellsFromWorkbenchLoops() {
+  let operations = DesktopProductDestinationID.operations.contract
+  let workflow = DesktopProductDestinationID.workflow.contract
+  let channels = DesktopProductDestinationID.channels.contract
+  let provider = DesktopProductDestinationID.providerAdmin.contract
+
+  #expect(operations.tier == .liveWorkbench)
+  #expect(workflow.tier == .navigationShell)
+  #expect(channels.tier == .navigationShell)
+  #expect(provider.tier == .providerAdmin)
+  #expect(!operations.isEndBarReady)
+  #expect(!workflow.isEndBarReady)
+  #expect(!channels.isEndBarReady)
+  #expect(!provider.isEndBarReady)
+}

--- a/scripts/ops/check-friday-client-design-contract.mjs
+++ b/scripts/ops/check-friday-client-design-contract.mjs
@@ -80,7 +80,10 @@ const checks = checkSourceSet(repoRoot, [
   },
   {
     label: "macOS nav rail covers selected desktop Hub Console destinations",
-    path: "apps/macos/FridayHubConsole/Sources/FridayHubConsole/Navigation.swift",
+    paths: [
+      "apps/macos/FridayHubConsole/Sources/FridayHubConsole/Navigation.swift",
+      "apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/DesktopProductReadinessContract.swift",
+    ],
     requiredCases: [
       "operations",
       "chat",
@@ -113,6 +116,7 @@ const checks = checkSourceSet(repoRoot, [
       "Media / Link",
       "Settings",
       "Evidence Search",
+      "var isBuilt: Bool { contract.routeBuilt }",
     ],
   },
   {

--- a/scripts/ops/check-friday-native-action-closure.mjs
+++ b/scripts/ops/check-friday-native-action-closure.mjs
@@ -63,6 +63,7 @@ const files = {
   desktopProjection: read(root, "apps/macos/FridayHubConsole/Sources/FridayHubConsole/DesktopProjectionScreens.swift"),
   desktopChat: read(root, "apps/macos/FridayHubConsole/Sources/FridayHubConsole/DesktopChatScreen.swift"),
   desktopVM: read(root, "apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/OperationsOverviewViewModel.swift"),
+  desktopProductContract: read(root, "apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/DesktopProductReadinessContract.swift"),
   desktopTests: read(root, "apps/macos/FridayHubConsole/Tests/FridayHubConsoleCoreTests/OperationsOverviewViewModelTests.swift"),
   packageJson: read(root, "package.json"),
 };
@@ -98,6 +99,10 @@ const desktopUi = [
   files.desktopOps,
   files.desktopProjection,
   files.desktopChat,
+].join("\n");
+const desktopNavContract = [
+  files.desktopNav,
+  files.desktopProductContract,
 ].join("\n");
 const desktopTests = files.desktopTests;
 
@@ -240,8 +245,8 @@ const checks = [
   ),
   check(
     "desktop-nav-does-not-hide-workbench-destinations",
-    "apps/macos/FridayHubConsole/Sources/FridayHubConsole/Navigation.swift",
-    includesAll(files.desktopNav, [
+    "apps/macos/FridayHubConsole/Sources/FridayHubConsole/Navigation.swift + apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/DesktopProductReadinessContract.swift",
+    includesAll(desktopNavContract, [
       "case operations",
       "case chat",
       "case providerAdmin",
@@ -257,7 +262,7 @@ const checks = [
       "case media",
       "case settings",
       "case evidence",
-      "var isBuilt: Bool { true }",
+      "var isBuilt: Bool { contract.routeBuilt }",
     ]),
   ),
   check(

--- a/test/unit/qa/friday-native-action-closure-cli.test.ts
+++ b/test/unit/qa/friday-native-action-closure-cli.test.ts
@@ -42,6 +42,7 @@ const requiredFixtureFiles = [
   "apps/macos/FridayHubConsole/Sources/FridayHubConsole/DesktopProjectionScreens.swift",
   "apps/macos/FridayHubConsole/Sources/FridayHubConsole/DesktopChatScreen.swift",
   "apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/OperationsOverviewViewModel.swift",
+  "apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/DesktopProductReadinessContract.swift",
   "apps/macos/FridayHubConsole/Tests/FridayHubConsoleCoreTests/OperationsOverviewViewModelTests.swift",
 ];
 


### PR DESCRIPTION
## Summary
- add a UI-free desktop product readiness contract for the operator-selected Hub Console destinations
- make the nav rail consume the shared contract and show route vs END-BAR truth
- add tests proving nav coverage is not desktop END-BAR and shell routes stay visible

## Verification
- swift test --package-path apps/macos/FridayHubConsole --filter DesktopProductReadinessContractTests
- swift build --package-path apps/macos/FridayHubConsole

Truth: this is product-truth plumbing for desktop UI accountability. It does not claim END-BAR, GO-LIVE, adoption, or full desktop live dogfood.