### PR TITLE
fix(ios): capture multiple design destinations

### DIFF
--- a/scripts/ops/friday-ios-design-destination-capture.sh
+++ b/scripts/ops/friday-ios-design-destination-capture.sh
@@ -28,6 +28,7 @@ out_dir=""
 mode="offline-truth"
 skip_initial_build=0
 destinations_csv="home,missions,session,contextPassport,tokenLedger,shareIntake,voice,pairing,needsMe,memory,platform,providerAuth,activity,workflows,onboarding,settings"
+settle_seconds="${FRIDAY_IOS_DESIGN_CAPTURE_SETTLE_SECONDS:-6}"
 
 while [ "$#" -gt 0 ]; do
   case "$1" in
@@ -83,6 +84,7 @@ case "${mode}" in
   *) die "unsupported --mode '${mode}'" ;;
 esac
 [ -n "${destinations_csv}" ] || die "--destinations must not be empty"
+[[ "${settle_seconds}" =~ ^[0-9]+([.][0-9]+)?$ ]] || die "FRIDAY_IOS_DESIGN_CAPTURE_SETTLE_SECONDS must be numeric"
 
 IFS=',' read -r -a destinations <<< "${destinations_csv}"
 for destination in "${destinations[@]}"; do
@@ -116,31 +118,6 @@ fi
 udid="$(xcrun simctl list devices available | grep -Eo '\(([0-9A-F-]{36})\) \(Booted\)' | grep -Eo '[0-9A-F-]{36}' | head -1 || true)"
 [ -n "${udid}" ] || die "no booted simulator after build/reuse"
 
-live_loopback_launch_args=()
-live_loopback_launch_env=()
-if [ "${mode}" = "live-loopback" ]; then
-  live_loopback_launch_args=(--live-read --live-write --live-pairing --live-device-keypair --simulator-file-device-keypair)
-  live_loopback_launch_env=(
-    SIMCTL_CHILD_FRIDAY_MOBILE_LIVE_READ=1
-    SIMCTL_CHILD_FRIDAY_MOBILE_LIVE_WRITE=1
-    SIMCTL_CHILD_FRIDAY_MOBILE_LIVE_PAIRING=1
-    SIMCTL_CHILD_FRIDAY_MOBILE_LIVE_DEVICE_KEYPAIR=1
-    SIMCTL_CHILD_FRIDAY_MOBILE_SIMULATOR_FILE_DEVICE_KEYPAIR=1
-  )
-  if [[ -n "${FRIDAY_MOBILE_LIVE_READ_HOST:-}" ]]; then
-    live_loopback_launch_env+=(SIMCTL_CHILD_FRIDAY_MOBILE_LIVE_READ_HOST="${FRIDAY_MOBILE_LIVE_READ_HOST}")
-  fi
-  if [[ -n "${FRIDAY_MOBILE_LIVE_READ_PORT:-}" ]]; then
-    live_loopback_launch_env+=(SIMCTL_CHILD_FRIDAY_MOBILE_LIVE_READ_PORT="${FRIDAY_MOBILE_LIVE_READ_PORT}")
-  fi
-  if [[ -n "${FRIDAY_MOBILE_LIVE_WRITE_HOST:-}" ]]; then
-    live_loopback_launch_env+=(SIMCTL_CHILD_FRIDAY_MOBILE_LIVE_WRITE_HOST="${FRIDAY_MOBILE_LIVE_WRITE_HOST}")
-  fi
-  if [[ -n "${FRIDAY_MOBILE_LIVE_WRITE_PORT:-}" ]]; then
-    live_loopback_launch_env+=(SIMCTL_CHILD_FRIDAY_MOBILE_LIVE_WRITE_PORT="${FRIDAY_MOBILE_LIVE_WRITE_PORT}")
-  fi
-fi
-
 capture_rows=()
 for destination in "${destinations[@]}"; do
   shot="${out_dir}/screenshots/${destination}.png"
@@ -152,14 +129,40 @@ for destination in "${destinations[@]}"; do
     printf 'reused initial build screenshot\n' > "${screenshot_log}"
   else
     launch_cmd=(xcrun simctl launch --terminate-running-process "${udid}" com.friday.shell)
-    launch_args=("${live_loopback_launch_args[@]}" "--initial-destination=${destination}")
-    launch_env=("${live_loopback_launch_env[@]}" "SIMCTL_CHILD_FRIDAY_MOBILE_INITIAL_DESTINATION=${destination}")
-    if [ "${#launch_env[@]}" -gt 0 ]; then
-      env "${launch_env[@]}" "${launch_cmd[@]}" "${launch_args[@]}" >"${launch_log}" 2>&1
-    else
-      "${launch_cmd[@]}" "${launch_args[@]}" >"${launch_log}" 2>&1
+    launch_args=("--initial-destination=${destination}")
+    launch_env=("SIMCTL_CHILD_FRIDAY_MOBILE_INITIAL_DESTINATION=${destination}")
+    if [ "${mode}" = "live-loopback" ]; then
+      launch_args=(
+        --live-read
+        --live-write
+        --live-pairing
+        --live-device-keypair
+        --simulator-file-device-keypair
+        "${launch_args[@]}"
+      )
+      launch_env=(
+        SIMCTL_CHILD_FRIDAY_MOBILE_LIVE_READ=1
+        SIMCTL_CHILD_FRIDAY_MOBILE_LIVE_WRITE=1
+        SIMCTL_CHILD_FRIDAY_MOBILE_LIVE_PAIRING=1
+        SIMCTL_CHILD_FRIDAY_MOBILE_LIVE_DEVICE_KEYPAIR=1
+        SIMCTL_CHILD_FRIDAY_MOBILE_SIMULATOR_FILE_DEVICE_KEYPAIR=1
+        "${launch_env[@]}"
+      )
+      if [[ -n "${FRIDAY_MOBILE_LIVE_READ_HOST:-}" ]]; then
+        launch_env+=(SIMCTL_CHILD_FRIDAY_MOBILE_LIVE_READ_HOST="${FRIDAY_MOBILE_LIVE_READ_HOST}")
+      fi
+      if [[ -n "${FRIDAY_MOBILE_LIVE_READ_PORT:-}" ]]; then
+        launch_env+=(SIMCTL_CHILD_FRIDAY_MOBILE_LIVE_READ_PORT="${FRIDAY_MOBILE_LIVE_READ_PORT}")
+      fi
+      if [[ -n "${FRIDAY_MOBILE_LIVE_WRITE_HOST:-}" ]]; then
+        launch_env+=(SIMCTL_CHILD_FRIDAY_MOBILE_LIVE_WRITE_HOST="${FRIDAY_MOBILE_LIVE_WRITE_HOST}")
+      fi
+      if [[ -n "${FRIDAY_MOBILE_LIVE_WRITE_PORT:-}" ]]; then
+        launch_env+=(SIMCTL_CHILD_FRIDAY_MOBILE_LIVE_WRITE_PORT="${FRIDAY_MOBILE_LIVE_WRITE_PORT}")
+      fi
     fi
-    sleep 6
+    env "${launch_env[@]}" "${launch_cmd[@]}" "${launch_args[@]}" >"${launch_log}" 2>&1
+    sleep "${settle_seconds}"
     xcrun simctl io "${udid}" screenshot "${shot}" >"${screenshot_log}" 2>&1
   fi
 

--- a/test/unit/qa/friday-ios-design-destination-capture-runner.test.ts
+++ b/test/unit/qa/friday-ios-design-destination-capture-runner.test.ts
@@ -1,0 +1,84 @@
+import { execFile } from "node:child_process";
+import * as fs from "node:fs/promises";
+import os from "node:os";
+import * as path from "node:path";
+import { promisify } from "node:util";
+
+import { describe, expect, it } from "vitest";
+
+const execFileAsync = promisify(execFile);
+const script = "scripts/ops/friday-ios-design-destination-capture.sh";
+const fakeUdid = "11111111-2222-3333-4444-555555555555";
+
+async function writeExecutable(filePath: string, content: string) {
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  await fs.writeFile(filePath, content, { encoding: "utf8", mode: 0o755 });
+  await fs.chmod(filePath, 0o755);
+}
+
+describe("friday-ios-design-destination-capture runner", () => {
+  it("captures multiple offline destinations with skip-initial-build under set -u", async () => {
+    const root = process.cwd();
+    const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "friday-ios-capture-runner-"));
+    const binDir = path.join(tempRoot, "bin");
+    const outDir = path.join(tempRoot, "capture");
+
+    await writeExecutable(path.join(binDir, "xcrun"), `#!/usr/bin/env bash
+set -euo pipefail
+if [ "$1" = "simctl" ] && [ "$2" = "list" ]; then
+  echo "== Devices =="
+  echo "-- iOS Test --"
+  echo "    iPhone Test (${fakeUdid}) (Booted)"
+  exit 0
+fi
+if [ "$1" = "simctl" ] && [ "$2" = "launch" ]; then
+  echo "launched $*"
+  exit 0
+fi
+if [ "$1" = "simctl" ] && [ "$2" = "io" ] && [ "$4" = "screenshot" ]; then
+  printf 'fake-png-%s\\n' "$5" > "$5"
+  exit 0
+fi
+echo "unexpected xcrun $*" >&2
+exit 64
+`);
+
+    const { stdout } = await execFileAsync(
+      "bash",
+      [
+        path.join(root, script),
+        "--out-dir",
+        outDir,
+        "--mode",
+        "offline-truth",
+        "--destinations",
+        "home,session",
+        "--skip-initial-build",
+      ],
+      {
+        cwd: root,
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          PATH: `${binDir}:${process.env.PATH ?? ""}`,
+          FRIDAY_IOS_DESIGN_CAPTURE_SETTLE_SECONDS: "0",
+        },
+      },
+    );
+
+    expect(stdout).toContain("PASS - selected iOS design destinations captured.");
+    const manifest = JSON.parse(
+      await fs.readFile(path.join(outDir, "ios-design-destination-capture-manifest.json"), "utf8"),
+    ) as {
+      status: string;
+      mode: string;
+      captures: Array<{ destination: string; status: string; screenshot: string }>;
+    };
+
+    expect(manifest.status).toBe("ready");
+    expect(manifest.mode).toBe("offline-truth");
+    expect(manifest.captures.map((capture) => capture.destination)).toEqual(["home", "session"]);
+    await expect(fs.stat(path.join(outDir, "screenshots", "home.png"))).resolves.toBeTruthy();
+    await expect(fs.stat(path.join(outDir, "screenshots", "session.png"))).resolves.toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary

- Fix the iOS selected-design capture runner so offline-truth relaunches do not expand an empty live-loopback array under `set -u`.
- Preserve live-loopback launch flags only when that mode is explicitly requested.
- Add a fake-xcrun regression test proving `--skip-initial-build --mode offline-truth --destinations home,session` captures both destinations and writes a ready manifest.

## Verification

- `npx vitest run --project default test/unit/qa/friday-ios-design-destination-capture-runner.test.ts test/unit/qa/friday-ios-design-destination-capture-contract-cli.test.ts`
- `bash -n scripts/ops/friday-ios-design-destination-capture.sh`
- `npm run check:client-ship-gate`
- Real simulator smoke: `scripts/ops/friday-ios-design-destination-capture.sh --out-dir /private/tmp/friday-ios-design-capture-patched-20260625T163255Z --mode offline-truth --destinations home,session,voice,pairing,needsMe,providerAuth,activity,settings --skip-initial-build` produced a ready manifest with 8 PNG screenshots.

Truth: this is device screenshot capture reliability only; it is not END-BAR, GO-LIVE, adoption, or live action closure.