### PR TITLE
fix(ui): count native readiness contracts as action hints

### DIFF
--- a/scripts/ops/check-friday-design-action-runtime-evidence.mjs
+++ b/scripts/ops/check-friday-design-action-runtime-evidence.mjs
@@ -40,6 +40,28 @@ function argsAll(name) {
   return values;
 }
 
+function positionalRuntimeEvidenceArgs() {
+  const valueFlags = new Set([
+    "--contract",
+    "--evidence-dir",
+    "--out",
+    "--repo-root",
+    "--runtime-evidence",
+  ]);
+  const values = [];
+  for (let index = 0; index < args.length; index += 1) {
+    const value = args[index];
+    if (value.startsWith("--")) {
+      if (!value.includes("=") && valueFlags.has(value) && args[index + 1]) {
+        index += 1;
+      }
+      continue;
+    }
+    values.push(value);
+  }
+  return values;
+}
+
 if (args.includes("--help") || args.includes("-h")) {
   usage();
   process.exit(0);
@@ -50,7 +72,7 @@ const repoRoot = resolve(arg("repo-root") || process.env.FRIDAY_REPO_ROOT || new
 const defaultContract = `${process.env.HOME || "/Users/jarvis"}/Desktop/friday-design-handoff-20260602/ACTION-CONTRACT.md`;
 const contractPath = resolve(arg("contract") || process.env.FRIDAY_DESIGN_ACTION_CONTRACT || defaultContract);
 const evidenceDir = arg("evidence-dir") || process.env.FRIDAY_UI_DEVICE_PROOF_EVIDENCE_DIR || "";
-const runtimeEvidenceArgs = argsAll("runtime-evidence");
+const runtimeEvidenceArgs = [...argsAll("runtime-evidence"), ...positionalRuntimeEvidenceArgs()];
 const runtimeEvidenceEnv = process.env.FRIDAY_DESIGN_ACTION_RUNTIME_EVIDENCE
   ? process.env.FRIDAY_DESIGN_ACTION_RUNTIME_EVIDENCE.split(/[:\n]/).map((value) => value.trim()).filter(Boolean)
   : [];
@@ -164,6 +186,7 @@ const nativeSources = {
     "apps/friday-ios/Sources/FridayMobileShell/FridayProjectionScreens.swift",
     "apps/friday-ios/Sources/FridayMobileShellCore/HomeViewModel.swift",
     "apps/friday-ios/Sources/FridayMobileShellCore/FridayChatViewModel.swift",
+    "apps/friday-ios/Sources/FridayMobileShellCore/MobileProductReadinessContract.swift",
     "apps/friday-ios/Sources/FridayMobileShellCore/SessionContinuationViewModel.swift",
     "apps/friday-ios/Sources/FridayMobileShellCore/ShareIntakeViewModel.swift",
     "apps/friday-ios/Sources/FridayMobileShellCore/VoiceReadinessViewModel.swift",
@@ -174,6 +197,7 @@ const nativeSources = {
     "apps/macos/FridayHubConsole/Sources/FridayHubConsole/DesktopChatScreen.swift",
     "apps/macos/FridayHubConsole/Sources/FridayHubConsole/DesktopProjectionScreens.swift",
     "apps/macos/FridayHubConsole/Sources/FridayHubConsole/PairingProvisioningScreen.swift",
+    "apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/DesktopProductReadinessContract.swift",
     "apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/OperationsOverviewViewModel.swift",
   ]),
 };

--- a/test/unit/qa/friday-design-action-runtime-evidence-cli.test.ts
+++ b/test/unit/qa/friday-design-action-runtime-evidence-cli.test.ts
@@ -97,6 +97,52 @@ describe("check-friday-design-action-runtime-evidence", () => {
     }
   });
 
+  it("counts native readiness contracts as source hints without counting them as runtime proof", () => {
+    const root = mkdtempSync(join(tmpdir(), "friday-design-action-runtime-native-contract-"));
+    try {
+      const contract = writeFile(root, "ACTION-CONTRACT.md", `# Friday Action Contract — mobile + desktop
+
+**This is a wiring contract for the later Rust/native agent, NOT runtime proof.** Every row is design-proof; wired_registry ≠ runtime PASS.
+
+| Surface | Screen [state] | action_id | Label | capability_id | reg | reg_status | truth_status | result/target | Rust/Hub owner · gate · test expectation |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| mobile | firstLaunch | firstlaunch_scan | Scan to pair | trust_center_pairing_connected_devices | ✓ | wired | wired_registry | result:scanning | Runtime test must prove gate enforcement. |
+`);
+      writeFile(
+        root,
+        "apps/friday-ios/Sources/FridayMobileShellCore/MobileProductReadinessContract.swift",
+        `enum FridayMobileProductDestination {
+          case pairing
+          var runtimeActionIds: [String] { ["mobile/firstlaunch/scan"] }
+          var title: String { "Device Pairing" }
+          var label: String { "Scan to pair" }
+        }`,
+      );
+      const output = execFileSync("node", [
+        script,
+        `--repo-root=${root}`,
+        `--contract=${contract}`,
+      ], { cwd: process.cwd(), encoding: "utf8" });
+      const report = JSON.parse(output) as {
+        status?: string;
+        counts?: { missingRuntimeEvidence?: number; missingNativeHints?: number };
+        gaps?: {
+          missingRuntimeEvidence?: Array<{ actionId?: string }>;
+          missingNativeHints?: Array<{ actionId?: string }>;
+        };
+      };
+      expect(report.status).toBe("gaps_present");
+      expect(report.counts?.missingNativeHints).toBe(0);
+      expect(report.gaps?.missingNativeHints).toEqual([]);
+      expect(report.counts?.missingRuntimeEvidence).toBe(1);
+      expect(report.gaps?.missingRuntimeEvidence).toEqual([
+        expect.objectContaining({ actionId: "firstlaunch_scan" }),
+      ]);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   it("accepts explicit runtime action evidence but still requires real evidence for every actionable row", () => {
     const { root, contract } = fixtureRepo();
     try {
@@ -175,6 +221,47 @@ describe("check-friday-design-action-runtime-evidence", () => {
       expect(report.counts?.runtimeEvidenceRows).toBe(2);
       expect(report.counts?.missingRuntimeEvidence).toBe(0);
       expect(report.counts?.missingUniqueRuntimeEvidence).toBe(0);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("accepts positional runtime action evidence paths to avoid silent false gaps", () => {
+    const { root, contract } = fixtureRepo();
+    try {
+      const runtime = writeFile(root, "action-runtime-evidence.json", JSON.stringify({
+        actions: [
+          {
+            surface: "mobile",
+            screen: "fridayChat",
+            action_id: "act",
+            status: "pass",
+            evidence_ref: "proof://mobile/send",
+          },
+          {
+            surface: "desktop",
+            screen: "fridayChat",
+            action_id: "check",
+            status: "pass",
+            evidence_ref: "proof://desktop/approve",
+          },
+        ],
+      }, null, 2));
+      const output = execFileSync("node", [
+        script,
+        `--repo-root=${root}`,
+        `--contract=${contract}`,
+        runtime,
+      ], { cwd: process.cwd(), encoding: "utf8" });
+      const report = JSON.parse(output) as {
+        status?: string;
+        runtimeEvidenceInputs?: string[];
+        counts?: { runtimeEvidenceRows?: number; missingRuntimeEvidence?: number };
+      };
+      expect(report.status).toBe("runtime_actions_covered");
+      expect(report.runtimeEvidenceInputs).toEqual([runtime]);
+      expect(report.counts?.runtimeEvidenceRows).toBe(2);
+      expect(report.counts?.missingRuntimeEvidence).toBe(0);
     } finally {
       rmSync(root, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary
- Include the iOS and macOS product readiness contract files in design-action native source hint scanning.
- Add a regression test proving native readiness hints do not count as runtime proof.
- Verified current runtime evidence now has `missingNativeHints=0` while still honestly retaining the remaining `mobile/approval/check` runtime gap.

## Verification
- `npx vitest run --project default test/unit/qa/friday-design-action-runtime-evidence-cli.test.ts`
- `npm run check:client-ship-gate`
- `node scripts/ops/check-friday-design-action-runtime-evidence.mjs --json --runtime-evidence=...` over existing runtime evidence files -> `missingNativeHints=0`, `missingUniqueRuntimeEvidence=1`

Truth: this is a source-hint/gate accuracy fix only. It does not claim END-BAR, adoption, GO-LIVE, or runtime completion.