### PR TITLE
fix(ios): classify voice as native device loop

### DIFF
--- a/apps/friday-ios/Sources/FridayMobileShellCore/MobileProductReadinessContract.swift
+++ b/apps/friday-ios/Sources/FridayMobileShellCore/MobileProductReadinessContract.swift
@@ -3,6 +3,7 @@ import Foundation
 public enum MobileProductLoopTier: String, CaseIterable, Sendable, Equatable {
   case liveWriteRead
   case liveReadProjection
+  case nativeDeviceLoop
   case providerWorkspace
   case governedActionGated
   case readinessOnly
@@ -13,6 +14,7 @@ public enum MobileProductLoopTier: String, CaseIterable, Sendable, Equatable {
     switch self {
     case .liveWriteRead: return "live write"
     case .liveReadProjection: return "live read"
+    case .nativeDeviceLoop: return "device loop"
     case .providerWorkspace: return "workspace"
     case .governedActionGated: return "action gated"
     case .readinessOnly: return "readiness"
@@ -27,6 +29,8 @@ public enum MobileProductLoopTier: String, CaseIterable, Sendable, Equatable {
       return "Real read/write loop exists when the governed live seams are configured."
     case .liveReadProjection:
       return "Reads real Hub projection state; it does not create or mutate work."
+    case .nativeDeviceLoop:
+      return "Runs local device I/O from the native app; product completion still needs runtime proof."
     case .providerWorkspace:
       return "Opens provider readiness, route/session refs, and native-control truth; read-only pieces are labeled."
     case .governedActionGated:
@@ -183,11 +187,14 @@ public enum MobileProductDestinationID: String, CaseIterable, Sendable, Equatabl
       return contract(
         title: "Voice",
         systemImage: "waveform",
-        tier: .readinessOnly,
-        runtimeActionIds: [],
+        tier: .nativeDeviceLoop,
+        runtimeActionIds: [
+          "mobile/voice/permission",
+          "mobile/fridayChat/voice-input",
+          "mobile/fridayChat/voice-output",
+        ],
         blockers: [
-          .init(.needsNativeSurface, label: "speech loop UI"),
-          .init(.needsProviderCredential, label: "TTS/provider readiness"),
+          .init(.needsRuntimeEvidence, label: "real microphone and speech-output tap proof"),
         ])
     case .pairing:
       return contract(

--- a/apps/friday-ios/Tests/FridayMobileShellCoreTests/MobileProductReadinessContractTests.swift
+++ b/apps/friday-ios/Tests/FridayMobileShellCoreTests/MobileProductReadinessContractTests.swift
@@ -58,7 +58,13 @@ func mobileProductContractSeparatesReadinessShellsFromProductLoops() {
   let workflows = MobileProductDestinationID.workflows.contract
   let provider = MobileProductDestinationID.providerAuth.contract
 
-  #expect(voice.tier == .readinessOnly)
+  #expect(voice.tier == .nativeDeviceLoop)
+  #expect(voice.runtimeActionIds == [
+    "mobile/voice/permission",
+    "mobile/fridayChat/voice-input",
+    "mobile/fridayChat/voice-output",
+  ])
+  #expect(voice.blockers.contains { $0.kind == .needsRuntimeEvidence })
   #expect(workflows.tier == .navigationShell)
   #expect(provider.tier == .providerWorkspace)
   #expect(!voice.isEndBarReady)


### PR DESCRIPTION
## Summary
- classify the iOS Voice destination as a native device I/O loop instead of a readiness-only shell
- expose existing local voice action ids for permission, speech input, and speech output
- keep END-BAR truth intact by leaving runtime tap proof as the blocker and avoiding any claim of remote realtime voice, adoption, or release

## Verification
- `swift test --package-path apps/friday-ios --filter MobileProductReadinessContractTests`
- `swift test --package-path apps/friday-ios --filter VoiceReadinessViewModelTests`
- `npm run check:client-design-contract`
- `npm run check:native-action-closure`
- `npm run check:client-ship-gate`

Truth: this updates product readiness accounting for existing native Speech/AVSpeechSynthesizer wiring. It does not claim END-BAR, GO-LIVE, real-device adoption, or remote realtime voice completion.