### PR TITLE
fix(ios): mark activity write seam runtime blocked

### DIFF
--- a/apps/friday-ios/Sources/FridayMobileShellCore/MobileProductReadinessContract.swift
+++ b/apps/friday-ios/Sources/FridayMobileShellCore/MobileProductReadinessContract.swift
@@ -244,7 +244,7 @@ public enum MobileProductDestinationID: String, CaseIterable, Sendable, Equatabl
         systemImage: "bell.badge",
         tier: .liveReadProjection,
         runtimeActionIds: ["mobile/activity/mark-done"],
-        blockers: [.init(.needsLiveWrite, label: "owner-bound mark-done")])
+        blockers: [.init(.needsRuntimeEvidence, label: "owner-bound mark-done app proof")])
     case .workflows:
       return contract(
         title: "Workflows",

--- a/apps/friday-ios/Tests/FridayMobileShellCoreTests/MobileProductReadinessContractTests.swift
+++ b/apps/friday-ios/Tests/FridayMobileShellCoreTests/MobileProductReadinessContractTests.swift
@@ -71,3 +71,14 @@ func mobileProductContractSeparatesReadinessShellsFromProductLoops() {
   #expect(!workflows.isEndBarReady)
   #expect(!provider.isEndBarReady)
 }
+
+@Test
+func mobileProductContractTracksActivityMarkDoneAsBuiltButRuntimeBlocked() {
+  let activity = MobileProductDestinationID.activity.contract
+
+  #expect(activity.tier == .liveReadProjection)
+  #expect(activity.runtimeActionIds == ["mobile/activity/mark-done"])
+  #expect(!activity.blockers.contains { $0.kind == .needsLiveWrite })
+  #expect(activity.blockers.contains { $0.kind == .needsRuntimeEvidence })
+  #expect(!activity.isEndBarReady)
+}


### PR DESCRIPTION
## Summary
- update the iOS Activity readiness contract after M6 owner-bound mark-done landed
- keep Activity blocked on real app runtime proof instead of claiming END-BAR readiness
- add a contract test that pins mark-done as built but runtime-blocked

## Verification
- `swift test --package-path apps/friday-ios --filter MobileProductReadinessContractTests`
- `npm run check:native-action-closure`
- `npm run check:client-design-contract`
- `npm run check:client-ship-gate`

Truth: contract/runtime blocker alignment only; no END-BAR, release, adoption, or real-device runtime proof claim.