### PR TITLE
fix(desktop): mark recovery writes runtime blocked

### DIFF
--- a/apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/DesktopProductReadinessContract.swift
+++ b/apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/DesktopProductReadinessContract.swift
@@ -206,7 +206,7 @@ public enum DesktopProductDestinationID: String, CaseIterable, Sendable, Equatab
         systemImage: "arrow.counterclockwise.circle",
         tier: .governedActionGated,
         runtimeActionIds: ["desktop/recovery/retry", "desktop/recovery/cancel"],
-        blockers: [.init(.needsLiveWrite, label: "owner-bound recovery writes")])
+        blockers: [.init(.needsRuntimeEvidence, label: "owner-bound recovery desktop proof")])
     case .memory:
       return contract(
         title: "Memory",

--- a/apps/macos/FridayHubConsole/Tests/FridayHubConsoleCoreTests/DesktopProductReadinessContractTests.swift
+++ b/apps/macos/FridayHubConsole/Tests/FridayHubConsoleCoreTests/DesktopProductReadinessContractTests.swift
@@ -35,7 +35,6 @@ func desktopProductContractDoesNotTreatNavCoverageAsEndBar() {
   #expect(snapshot.endBarReadyCount == 0)
   #expect(!snapshot.hasAnyEndBarClaim)
   #expect(snapshot.uniqueBlockers.contains { $0.kind == .needsRuntimeEvidence })
-  #expect(snapshot.uniqueBlockers.contains { $0.kind == .needsLiveWrite })
 }
 
 @Test
@@ -71,4 +70,18 @@ func desktopProductContractSeparatesShellsFromWorkbenchLoops() {
   #expect(!workflow.isEndBarReady)
   #expect(!channels.isEndBarReady)
   #expect(!provider.isEndBarReady)
+}
+
+@Test
+func desktopProductContractTracksRecoveryWritesAsBuiltButRuntimeBlocked() {
+  let recovery = DesktopProductDestinationID.recovery.contract
+
+  #expect(recovery.tier == .governedActionGated)
+  #expect(recovery.runtimeActionIds == [
+    "desktop/recovery/retry",
+    "desktop/recovery/cancel",
+  ])
+  #expect(!recovery.blockers.contains { $0.kind == .needsLiveWrite })
+  #expect(recovery.blockers.contains { $0.kind == .needsRuntimeEvidence })
+  #expect(!recovery.isEndBarReady)
 }


### PR DESCRIPTION
## Summary
- update the desktop Recovery readiness contract after the owner-bound mission lifecycle write path is present
- keep Recovery blocked on real desktop runtime proof instead of claiming END-BAR readiness
- add a contract test pinning retry/cancel as built but runtime-blocked

## Verification
- `swift test --package-path apps/macos/FridayHubConsole --filter DesktopProductReadinessContractTests`
- `npm run check:native-action-closure`
- `npm run check:client-design-contract`
- `npm run check:client-ship-gate`

Truth: contract/runtime blocker alignment only; no END-BAR, release, adoption, or real desktop runtime proof claim.