### PR TITLE
fix(ios): mark share intake runtime blocked

### DIFF
--- a/apps/friday-ios/Sources/FridayMobileShellCore/MobileProductReadinessContract.swift
+++ b/apps/friday-ios/Sources/FridayMobileShellCore/MobileProductReadinessContract.swift
@@ -182,7 +182,7 @@ public enum MobileProductDestinationID: String, CaseIterable, Sendable, Equatabl
         systemImage: "square.and.arrow.down",
         tier: .governedActionGated,
         runtimeActionIds: ["mobile/share/send"],
-        blockers: [.init(.needsLiveWrite, label: "mission-spine write seam")])
+        blockers: [.init(.needsRuntimeEvidence, label: "share mission-intake app proof")])
     case .voice:
       return contract(
         title: "Voice",

--- a/apps/friday-ios/Tests/FridayMobileShellCoreTests/MobileProductReadinessContractTests.swift
+++ b/apps/friday-ios/Tests/FridayMobileShellCoreTests/MobileProductReadinessContractTests.swift
@@ -82,3 +82,14 @@ func mobileProductContractTracksActivityMarkDoneAsBuiltButRuntimeBlocked() {
   #expect(activity.blockers.contains { $0.kind == .needsRuntimeEvidence })
   #expect(!activity.isEndBarReady)
 }
+
+@Test
+func mobileProductContractTracksShareIntakeWriteAsBuiltButRuntimeBlocked() {
+  let share = MobileProductDestinationID.shareIntake.contract
+
+  #expect(share.tier == .governedActionGated)
+  #expect(share.runtimeActionIds == ["mobile/share/send"])
+  #expect(!share.blockers.contains { $0.kind == .needsLiveWrite })
+  #expect(share.blockers.contains { $0.kind == .needsRuntimeEvidence })
+  #expect(!share.isEndBarReady)
+}


### PR DESCRIPTION
## Summary
- update the iOS Share Intake readiness contract after verifying the mission-intake write seam is present
- keep Share Intake blocked on real app runtime proof instead of claiming END-BAR readiness
- add a contract test pinning mobile/share/send as built but runtime-blocked

## Verification
- `swift test --package-path apps/friday-ios --filter MobileProductReadinessContractTests`
- `npm run check:native-action-closure`
- `npm run check:client-design-contract`
- `npm run check:client-ship-gate`

Truth: contract/runtime blocker alignment only; no END-BAR, release, adoption, or real share runtime proof claim.