### PR TITLE
fix(ios): expose T2 command sheet truth

### DIFF
--- a/apps/friday-ios/Sources/FridayMobileShell/CommandSheet.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/CommandSheet.swift
@@ -66,6 +66,14 @@ struct CommandSheet: View {
 
   private let columns = [GridItem(.flexible(), spacing: 14), GridItem(.flexible(), spacing: 14)]
   private let endBarSnapshot = MobileProductEndBarSnapshot()
+  private let selectedT2SurfaceTitles = [
+    "Session",
+    "Context Passport",
+    "Token Ledger",
+    "Share Intake",
+    "Voice",
+    "Needs Me",
+  ]
 
   var body: some View {
     NavigationStack {
@@ -144,5 +152,7 @@ struct CommandSheet: View {
     .frame(maxWidth: .infinity)
     .padding(.top, 8)
     .accessibilityIdentifier("friday.command-sheet.readiness-footer")
+    .accessibilityLabel(
+      "Route coverage is not END-BAR. Selected T2 surfaces: \(selectedT2SurfaceTitles.joined(separator: ", ")).")
   }
 }


### PR DESCRIPTION
## Summary
- expose the selected iOS T2 surfaces in the CommandSheet readiness footer accessibility semantics
- keep the route-coverage-vs-END-BAR truth boundary explicit for static and accessibility checks
- do not change routes, flags, live behavior, signing, or product readiness claims

## Truth boundary
- this is selected-surface visibility and truth-label wiring only
- it does not claim real-device adoption, live GUI tap evidence, complete voice I/O, operator signing completion, END-BAR, GO-LIVE, or release

## Local verification
- `npm run check:ios-t2-surface-contract`
- `npm run check:client-design-contract`
- `npm run check:native-action-closure`
- `swift test --package-path apps/friday-ios --filter FridayMobileShellCoreTests`
- `npm run check:client-ship-gate`