### PR TITLE
fix(ios): expose pairing in live evidence truth

### DIFF
--- a/apps/friday-ios/Sources/FridayMobileShell/CommandSheet.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/CommandSheet.swift
@@ -66,9 +66,10 @@ struct CommandSheet: View {
 
   private let columns = [GridItem(.flexible(), spacing: 14), GridItem(.flexible(), spacing: 14)]
   private let endBarSnapshot = MobileProductEndBarSnapshot()
-  private let selectedT2SurfaceTitles = [
+  private let selectedMobileSurfaceTitles = [
     "Session",
     "Context Passport",
+    "Device Pairing",
     "Token Ledger",
     "Share Intake",
     "Voice",
@@ -153,6 +154,6 @@ struct CommandSheet: View {
     .padding(.top, 8)
     .accessibilityIdentifier("friday.command-sheet.readiness-footer")
     .accessibilityLabel(
-      "Route coverage is not END-BAR. Selected T2 surfaces: \(selectedT2SurfaceTitles.joined(separator: ", ")).")
+      "Route coverage is not END-BAR. Selected mobile surfaces: \(selectedMobileSurfaceTitles.joined(separator: ", ")).")
   }
 }


### PR DESCRIPTION
## Summary
- include Device Pairing in the mobile live-evidence/readiness footer surface list
- rename the list from T2-specific to selected mobile surfaces so it matches the broader selected-design evidence scope
- keep the END-BAR caveat visible in accessibility truth text

## Verification
- npm run check:ios-live-evidence-contract
- npm run check:ios-t2-surface-contract
- npm run check:client-design-contract
- npm run check:native-action-closure
- swift test --package-path apps/friday-ios --filter FridayMobileShellCoreTests
- npm run check:client-ship-gate

Truth: static/live-evidence contract closure only; not END-BAR, GO-LIVE, adoption, or real-device proof.