### PR TITLE
test(ios): validate design capture manifest

### DIFF
--- a/scripts/ops/friday-ios-design-destination-capture.sh
+++ b/scripts/ops/friday-ios-design-destination-capture.sh
@@ -187,6 +187,33 @@ const captures = rows.map((row) => {
     status: "captured",
   };
 });
+const requiredDestinations = destinationsCsv.split(",").filter(Boolean);
+const seenDestinations = new Set();
+const duplicateDestinations = [];
+for (const destination of requiredDestinations) {
+  if (seenDestinations.has(destination)) {
+    duplicateDestinations.push(destination);
+  }
+  seenDestinations.add(destination);
+}
+const capturedDestinations = new Set(captures.map((capture) => capture.destination));
+const missingCaptures = requiredDestinations.filter((destination) => !capturedDestinations.has(destination));
+const extraCaptures = captures
+  .map((capture) => capture.destination)
+  .filter((destination) => !requiredDestinations.includes(destination));
+const emptyScreenshots = captures
+  .filter((capture) => !existsSync(capture.screenshot) || readFileSync(capture.screenshot).length === 0)
+  .map((capture) => capture.destination);
+const nonReadyCaptures = captures
+  .filter((capture) => capture.status !== "captured")
+  .map((capture) => capture.destination);
+const validationErrors = [
+  ...duplicateDestinations.map((destination) => `duplicate destination: ${destination}`),
+  ...missingCaptures.map((destination) => `missing capture: ${destination}`),
+  ...extraCaptures.map((destination) => `unexpected capture: ${destination}`),
+  ...emptyScreenshots.map((destination) => `empty screenshot: ${destination}`),
+  ...nonReadyCaptures.map((destination) => `non-ready capture: ${destination}`),
+];
 
 const initialMetadata = existsSync(initialMetadataPath)
   ? JSON.parse(readFileSync(initialMetadataPath, "utf8"))
@@ -194,7 +221,7 @@ const initialMetadata = existsSync(initialMetadataPath)
 
 const manifest = {
   truth_label: "ios_selected_design_destination_capture_not_live_closure",
-  status: captures.length > 0 && captures.every((capture) => capture.status === "captured") ? "ready" : "failed",
+  status: validationErrors.length === 0 ? "ready" : "failed",
   generated_at_utc: new Date().toISOString(),
   mode,
   bundle_id: "com.friday.shell",
@@ -214,16 +241,27 @@ const manifest = {
     capability_truth: "matrixTruth",
     session_control_set: "fullNativeControl",
   },
-  required_destinations: destinationsCsv.split(",").filter(Boolean),
+  required_destinations: requiredDestinations,
   relaunch_contract: mode === "live-loopback"
     ? "each non-initial destination relaunch propagates the same live-loopback read/write/pairing/device-keypair gates as the initial build launch"
     : "each destination relaunch keeps mobile live gates off and captures honest-unavailable truth",
   captures,
+  validation: {
+    missing_captures: missingCaptures,
+    extra_captures: extraCaptures,
+    duplicate_destinations: duplicateDestinations,
+    empty_screenshots: emptyScreenshots,
+    non_ready_captures: nonReadyCaptures,
+  },
   initial_build_metadata: initialMetadata,
   caveat: "Device screenshots prove selected destinations launch and render truth-labeled UI states only; enabled actions still require separate Hub/DB/ledger/proof closure before END-BAR.",
 };
 
 writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+if (validationErrors.length > 0) {
+  console.error(`iOS destination capture manifest validation failed: ${validationErrors.join("; ")}`);
+  process.exit(2);
+}
 NODE
 
 echo "PASS - selected iOS design destinations captured."

--- a/test/unit/qa/friday-ios-design-destination-capture-runner.test.ts
+++ b/test/unit/qa/friday-ios-design-destination-capture-runner.test.ts
@@ -73,12 +73,90 @@ exit 64
       status: string;
       mode: string;
       captures: Array<{ destination: string; status: string; screenshot: string }>;
+      validation: {
+        missing_captures: string[];
+        extra_captures: string[];
+        duplicate_destinations: string[];
+        empty_screenshots: string[];
+        non_ready_captures: string[];
+      };
     };
 
     expect(manifest.status).toBe("ready");
     expect(manifest.mode).toBe("offline-truth");
     expect(manifest.captures.map((capture) => capture.destination)).toEqual(["home", "session"]);
+    expect(manifest.validation).toEqual({
+      missing_captures: [],
+      extra_captures: [],
+      duplicate_destinations: [],
+      empty_screenshots: [],
+      non_ready_captures: [],
+    });
     await expect(fs.stat(path.join(outDir, "screenshots", "home.png"))).resolves.toBeTruthy();
     await expect(fs.stat(path.join(outDir, "screenshots", "session.png"))).resolves.toBeTruthy();
+  });
+
+  it("fails the manifest instead of accepting duplicate destination captures", async () => {
+    const root = process.cwd();
+    const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "friday-ios-capture-duplicate-"));
+    const binDir = path.join(tempRoot, "bin");
+    const outDir = path.join(tempRoot, "capture");
+
+    await writeExecutable(path.join(binDir, "xcrun"), `#!/usr/bin/env bash
+set -euo pipefail
+if [ "$1" = "simctl" ] && [ "$2" = "list" ]; then
+  echo "== Devices =="
+  echo "    iPhone Test (${fakeUdid}) (Booted)"
+  exit 0
+fi
+if [ "$1" = "simctl" ] && [ "$2" = "launch" ]; then
+  echo "launched $*"
+  exit 0
+fi
+if [ "$1" = "simctl" ] && [ "$2" = "io" ] && [ "$4" = "screenshot" ]; then
+  printf 'fake-png-%s\\n' "$5" > "$5"
+  exit 0
+fi
+echo "unexpected xcrun $*" >&2
+exit 64
+`);
+
+    const error = await execFileAsync(
+      "bash",
+      [
+        path.join(root, script),
+        "--out-dir",
+        outDir,
+        "--mode",
+        "offline-truth",
+        "--destinations",
+        "home,home",
+        "--skip-initial-build",
+      ],
+      {
+        cwd: root,
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          PATH: `${binDir}:${process.env.PATH ?? ""}`,
+          FRIDAY_IOS_DESIGN_CAPTURE_SETTLE_SECONDS: "0",
+        },
+      },
+    ).then(
+      () => null,
+      (failure) => failure as Error & { code?: number; stdout?: string; stderr?: string },
+    );
+
+    expect(error).not.toBeNull();
+    expect(error?.code).toBe(2);
+    expect(error?.stderr).toContain("duplicate destination: home");
+    const manifest = JSON.parse(
+      await fs.readFile(path.join(outDir, "ios-design-destination-capture-manifest.json"), "utf8"),
+    ) as {
+      status: string;
+      validation: { duplicate_destinations: string[] };
+    };
+    expect(manifest.status).toBe("failed");
+    expect(manifest.validation.duplicate_destinations).toEqual(["home"]);
   });
 });


### PR DESCRIPTION
## Summary
- make the iOS selected-design capture runner validate the generated manifest instead of treating manifest creation as enough
- fail closed on duplicate destinations, missing captures, unexpected captures, empty screenshots, or non-ready capture rows
- add unit coverage for the ready path and duplicate-destination negative control

## Verification
- bash -n scripts/ops/friday-ios-design-destination-capture.sh
- /Users/jarvis/Projects/Friday/node_modules/.bin/vitest run --project default --project typecheck --project llm-e2e --run test/unit/qa/friday-ios-design-destination-capture-runner.test.ts

Truth: this strengthens screenshot manifest proof only. It is not END-BAR, not adoption, not mobile tap proof, and not live action closure.