### PR TITLE
fix(ios): separate home read truth from chat write loop

### DIFF
--- a/apps/friday-ios/Sources/FridayMobileShellCore/MobileProductReadinessContract.swift
+++ b/apps/friday-ios/Sources/FridayMobileShellCore/MobileProductReadinessContract.swift
@@ -140,10 +140,11 @@ public enum MobileProductDestinationID: String, CaseIterable, Sendable, Equatabl
       return contract(
         title: "Friday Home",
         systemImage: "house",
-        tier: .liveWriteRead,
+        tier: .liveReadProjection,
         runtimeActionIds: ["mobile/home/refresh"],
         blockers: [
           .init(.needsRuntimeEvidence, label: "same-run mobile+desktop user proof"),
+          .init(.needsRuntimeEvidence, id: "chat-write-action-proof", label: "Friday Chat write closes separately"),
         ])
     case .missions:
       return contract(

--- a/apps/friday-ios/Tests/FridayMobileShellCoreTests/MobileProductReadinessContractTests.swift
+++ b/apps/friday-ios/Tests/FridayMobileShellCoreTests/MobileProductReadinessContractTests.swift
@@ -35,8 +35,21 @@ func mobileProductContractDoesNotTreatRouteCoverageAsEndBar() {
   #expect(snapshot.routeCoverageCount == snapshot.totalCount)
   #expect(snapshot.endBarReadyCount == 0)
   #expect(!snapshot.hasAnyEndBarClaim)
+  #expect(snapshot.contracts.allSatisfy { $0.tier != .liveWriteRead })
   #expect(snapshot.uniqueBlockers.contains { $0.kind == .needsOperatorSignature })
   #expect(snapshot.uniqueBlockers.contains { $0.kind == .needsRuntimeEvidence })
+}
+
+@Test
+func mobileProductContractKeepsHomeReadProjectionSeparateFromChatWriteLoop() {
+  let home = MobileProductDestinationID.home.contract
+
+  #expect(home.tier == .liveReadProjection)
+  #expect(home.runtimeActionIds == ["mobile/home/refresh"])
+  #expect(home.blockers.contains { $0.id == "chat-write-action-proof" })
+  #expect(home.productReadinessSummary.contains("same-run mobile+desktop user proof"))
+  #expect(!home.productReadinessSummary.contains("Real read/write loop exists"))
+  #expect(!home.isEndBarReady)
 }
 
 @Test


### PR DESCRIPTION
## Summary
- reclassify the iOS Home selected-design destination as a live read projection instead of a live write/read loop
- add an explicit blocker showing that Friday Chat owns the write-action closure proof separately
- extend the mobile product readiness contract tests so route/UI coverage cannot inflate END-BAR truth

## Verification
- swift test --package-path apps/friday-ios --filter MobileProductReadinessContractTests

Truth: this is a truth-contract correction for selected-design readiness. It does not claim END-BAR, adoption, GUI tap proof, or live mobile action closure.