### PR TITLE
fix(ios): fail-close default operator signer

### DIFF
--- a/apps/friday-ios/Sources/FridayMobileShell/FridayApp.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayApp.swift
@@ -10,7 +10,8 @@
 // This shell now consumes the PACKAGE's real sealed-WS clients (`FridayRustClient`): the
 // Home reads the refs-only Mission Workbench projection over `SealedWSReadClient`; the
 // Friday Chat surface drives the read-WRITE / S6 loop over `SealedWSWriteClient` + the
-// `OperatorSigner` relay (mock now; the real desktop signer / PR #671 is the slice-6 gate).
+// `OperatorSigner` relay seam. The shipped default signer fail-closes until the real desktop
+// signer relay is configured; tests/previews may inject the mock signer explicitly.
 // The live `NWConnection` transport is the DEFERRED slice-6 AC, so every surface renders
 // honest-unavailable while the Rust servers are DARK — the EXPECTED state. Truth rules
 // (refs-only, truth labels never upgraded, 503/stale/offline AS truth, no key on the app,
@@ -64,7 +65,7 @@ private struct SimulatorFileDeviceKeypairBackend: DeviceKeypairBackend {
 /// INV-1: the device keypair is the X25519 SESSION keypair (transport identity) — it is NOT a
 /// signing key and CANNOT mint an approval. The operator's Ed25519 signing key lives ONLY in
 /// the desktop signer's isolated SecureStore (PR #671); on the phone the signer is an injected
-/// relay (`MockOperatorSigner` today — NOT a real signature).
+/// relay seam. The shipped default is `UnavailableOperatorSigner`, which returns no signature.
 ///
 /// The live network transport (a `NWConnection`-backed `SealedWSTransport`) is the DEFERRED
 /// slice-6 AC; until it is wired the default factory transport throws and every surface renders
@@ -81,8 +82,8 @@ final class FridaySession: ObservableObject {
   let devicePairing: DevicePairingReadiness
   let deviceKeypairBackend: DeviceKeypairBackend
   let makePairingClient: (DeviceKeypair) -> FridayPairingClient?
-  /// The operator-signing RELAY. Mock today (NOT a real signature); the real desktop signer
-  /// (PR #671) is the slice-6 / operator-key gate. The phone holds NO signing key (INV-1).
+  /// The operator-signing RELAY. The shipped default fail-closes until the real desktop signer
+  /// (PR #671) is reachable. The phone holds NO signing key (INV-1).
   let signer: OperatorSigner
 
   /// - Parameter preview: when `true`, the Home read client is the labeled `PreviewReadClient`
@@ -137,7 +138,9 @@ final class FridaySession: ObservableObject {
       self.writeClient = liveWrite ?? Self.honestUnavailableWriteClient(runControlEnabled: runControlEnabled)
       self.missionClient = liveWrite
     }
-    self.signer = MockOperatorSigner()
+    self.signer = preview
+      ? MockOperatorSigner()
+      : UnavailableOperatorSigner(error: .signerUnavailable)
   }
 
   /// The DEFAULT (non-preview) Home read client. DEFAULT = the no-key honest-unavailable client;

--- a/apps/friday-ios/Sources/FridayMobileShellCore/FridayChatViewModel.swift
+++ b/apps/friday-ios/Sources/FridayMobileShellCore/FridayChatViewModel.swift
@@ -361,8 +361,9 @@ public final class FridayChatViewModel: ObservableObject {
   /// - Parameters:
   ///   - writeClient: the real `SealedWSWriteClient` (or a mock in tests/preview). DEFAULT
   ///     read-only / no-grant dispatch; the run-control flag lives on the client.
-  ///   - signer: the operator-signing RELAY seam (INV-1). Mock now (`MockOperatorSigner`); the
-  ///     real desktop signer (PR #671) is the slice-6 / operator-key gate.
+  ///   - signer: the operator-signing RELAY seam (INV-1). The shipped app default is
+  ///     `UnavailableOperatorSigner`; tests may inject `MockOperatorSigner` explicitly, and the
+  ///     real desktop signer (PR #671) remains the slice-6 / operator-key gate.
   public init(
     writeClient: FridayRustWriteClient,
     signer: OperatorSigner,

--- a/apps/friday-ios/Sources/FridayMobileShellCore/OperatorSigner.swift
+++ b/apps/friday-ios/Sources/FridayMobileShellCore/OperatorSigner.swift
@@ -16,12 +16,14 @@ import Foundation
 /// verify time (`canonical_approval_signature_bytes`). That blob is what rides
 /// `AgentRunResume.signed_blob`.
 ///
-/// On the phone, `OperatorSigner` is therefore an INJECTED protocol whose ONLY concrete
-/// implementation shipped today is a clearly-labeled TEST/DEV mock (`MockOperatorSigner`).
-/// The REAL on-device integration — relaying to the desktop signer (or a future Secure
-/// Enclave-backed operator path) over the local trust channel — is a DEFERRED acceptance
-/// criterion gated on slice-6 + the operator key. The protocol shape is fixed NOW so the
-/// chat loop is real and the only thing that swaps at slice-6 is the signer impl.
+/// On the phone, `OperatorSigner` is therefore an INJECTED protocol. The shipped app default is
+/// `UnavailableOperatorSigner`, which fail-closes approval until a real signer relay is wired.
+/// Tests and previews may explicitly inject the clearly-labeled TEST/DEV mock
+/// (`MockOperatorSigner`) to exercise the relay shape. The REAL on-device integration — relaying
+/// to the desktop signer (or a future Secure Enclave-backed operator path) over the local trust
+/// channel — is a DEFERRED acceptance criterion gated on slice-6 + the operator key. The protocol
+/// shape is fixed NOW so the chat loop is real and the only thing that swaps at slice-6 is the
+/// signer impl.
 ///
 /// INV-1 is structural: the protocol can ONLY return an opaque `[UInt8]` blob. It exposes NO
 /// key material, NO "sign these bytes with this key" primitive — the app has nothing to mint
@@ -39,6 +41,26 @@ public protocol OperatorSigner: Sendable {
   ///   means NO resume is relayed — the mutation stays paused (INV-2 holds: no approval ⇒ no
   ///   mutation).
   func signApproval(_ request: ApprovalSigningRequest) async throws -> [UInt8]
+}
+
+/// The production/default signer before a real operator-signing relay is configured.
+///
+/// This is deliberately a real `OperatorSigner` implementation rather than `nil`: approval UI can
+/// keep the same code path, but the result is an honest unavailable state and no resume blob is
+/// ever relayed. Reject still goes through the write client because rejection does not execute the
+/// paused mutation.
+public struct UnavailableOperatorSigner: OperatorSigner {
+  public static let truthLabel = "operator_signer_unavailable_no_signature_relay"
+
+  private let error: OperatorSignerError
+
+  public init(error: OperatorSignerError = .signerUnavailable) {
+    self.error = error
+  }
+
+  public func signApproval(_ request: ApprovalSigningRequest) async throws -> [UInt8] {
+    throw error
+  }
 }
 
 /// The REFS-ONLY request handed to the operator signer. It carries ONLY what the pause frame

--- a/apps/friday-ios/Tests/FridayMobileShellCoreTests/FridayChatViewModelTests.swift
+++ b/apps/friday-ios/Tests/FridayMobileShellCoreTests/FridayChatViewModelTests.swift
@@ -904,6 +904,18 @@ final class FridayChatViewModelTests: XCTestCase {
     XCTAssertTrue(client.resumedRunIds.isEmpty)
   }
 
+  func testApprove_unavailableProductionSignerRelaysNoResume() async {
+    let client = FakeWriteClient(
+      dispatch: .pause(makePause()),
+      resume: .accepted(ResumeRelayResult(runId: "run-1", op: "resume", accepted: true, status: "x", auditRef: nil)))
+    let vm = FridayChatViewModel(writeClient: client, signer: UnavailableOperatorSigner())
+    await vm.send("edit notes.md")
+    await vm.approve()
+    guard case .unavailable(let reason) = vm.phase else { return XCTFail("expected .unavailable") }
+    XCTAssertTrue(reason.lowercased().contains("signer unavailable"), "reason: \(reason)")
+    XCTAssertTrue(client.resumedRunIds.isEmpty, "production unavailable signer must not relay resume")
+  }
+
   // MARK: Honest-unavailable on a connection failure (the dark-server default)
 
   func testSend_transportFailure_rendersHonestUnavailable() async {

--- a/apps/friday-ios/build-sim.sh
+++ b/apps/friday-ios/build-sim.sh
@@ -3,7 +3,8 @@
 # This is the v1 mobile UI shell wired to the REAL Rust clients: Home (Status + top-bar 💬
 # chat-entry + heroPet) reading the refs-only Mission Workbench projection over the package's
 # `SealedWSReadClient`, + the full-screen pet-centered Friday Chat read-WRITE / S6 surface over
-# `SealedWSWriteClient` + the `OperatorSigner` relay, + the Command Sheet launcher.
+# `SealedWSWriteClient` + the `OperatorSigner` seam. The shipped default signer fail-closes until
+# a real operator signer relay is configured; tests/previews inject the mock explicitly.
 #
 # The shell now depends on the `FridayRustClient` SPM package, which depends on swift-sodium
 # (libsodium via the vendored `Clibsodium.xcframework`). So — unlike the prior mock-only shell —


### PR DESCRIPTION
## Summary
- add a production/default unavailable operator signer that never emits a resume blob
- wire the shipped iOS session to fail-close approval until a real signer relay is configured, while keeping mock signer explicit for previews/tests
- add view-model coverage proving unavailable signing relays no resume and leaves the mutation unexecuted

## Verification
- swift test --package-path apps/friday-ios --filter FridayChatViewModelTests
- bash -n apps/friday-ios/build-sim.sh
- apps/friday-ios/build-sim.sh --mode offline-truth --destination chat --shot /tmp/friday-ios-signer-truth-offline-chat.png

Truth: this is signer truth hardening. It does not add a real signer relay, does not claim END-BAR, and does not make mobile approval live.