### PR TITLE
fix(proof): bridge channel proof events into UI readiness

### DIFF
--- a/scripts/ops/friday-ui-device-proof-readiness.sh
+++ b/scripts/ops/friday-ui-device-proof-readiness.sh
@@ -520,7 +520,52 @@ derive_workbench_events_if_possible() {
   fi
 }
 
+derive_channel_events_if_possible() {
+  if [ -z "${CHANNEL_LIVE_PROOF:-}" ] || [ -z "${CHANNEL_EVIDENCE:-}" ] || [ -z "${MISSION_ID:-}" ]; then
+    return 0
+  fi
+
+  local derived_out
+  local existing_events
+  local merged_out
+  local stdout_out
+  if [ -n "$EVIDENCE_DIR" ]; then
+    derived_out="$(abs_path "$EVIDENCE_DIR")/channel-derived-events.jsonl"
+    merged_out="$(abs_path "$EVIDENCE_DIR")/same-run-events.with-channel.jsonl"
+  else
+    derived_out="/tmp/friday-channel-derived-events-${MISSION_ID}.jsonl"
+    merged_out="/tmp/friday-same-run-events-with-channel-${MISSION_ID}.jsonl"
+  fi
+  stdout_out="${derived_out}.stdout"
+  mkdir -p "$(dirname "$derived_out")"
+  existing_events="${SAME_RUN_EVENTS:-}"
+
+  if node "${REPO_ROOT}/scripts/ops/friday-channel-proof-events.mjs" \
+    "--mission-id=${MISSION_ID}" \
+    "--channel-live-proof=${CHANNEL_LIVE_PROOF}" \
+    "--channel-capture=${CHANNEL_EVIDENCE}" \
+    "--out=${derived_out}" >"$stdout_out"; then
+    if [ ! -s "$derived_out" ]; then
+      notes+=("channel_proof_events_bridge:no_events")
+      return 0
+    fi
+    if [ -n "$existing_events" ]; then
+      awk '!seen[$0]++' "$existing_events" "$derived_out" >"$merged_out"
+      SAME_RUN_EVENTS="$merged_out"
+      notes+=("channel_proof_events_merge:ready:${merged_out}")
+    else
+      SAME_RUN_EVENTS="$derived_out"
+    fi
+    export SAME_RUN_EVENTS
+    notes+=("channel_proof_events_bridge:ready:${derived_out}")
+  else
+    local rc=$?
+    notes+=("channel_proof_events_bridge:exit_${rc}")
+  fi
+}
+
 derive_workbench_snapshot_if_possible
+derive_channel_events_if_possible
 derive_workbench_events_if_possible
 
 have_all_evidence=1

--- a/test/unit/qa/friday-ui-device-proof-readiness-cli.test.ts
+++ b/test/unit/qa/friday-ui-device-proof-readiness-cli.test.ts
@@ -135,6 +135,20 @@ function writeSupportingProofs(tempDir: string) {
   return files;
 }
 
+function writeRedactedChannelProof(tempDir: string) {
+  const proof = join(tempDir, "channel-live-proof.json");
+  writeFileSync(proof, JSON.stringify({
+    proof: "mission_spine_channel_live_proof",
+    status: "passed",
+    generated_at_utc: "2026-06-05T06:10:00Z",
+    secret_policy: {
+      artifact_contains_redacted_text_only: true,
+    },
+    remaining_requirement: "real mobile/desktop/channel UI/device consumption evidence must still pass scripts/mission-spine-ui-device-proof-gate.sh",
+  }, null, 2));
+  return proof;
+}
+
 function writeWorkbenchSnapshotEvidenceDir(tempDir: string) {
   const files = {
     mobile: join(tempDir, "mobile.json"),
@@ -827,6 +841,49 @@ describe("friday-ui-device-proof-readiness", () => {
         role: "objectiveCoverage",
         status: "usable_precondition_not_ui_device_evidence",
         countsTowardUiDeviceProof: false,
+      }));
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("bridges redacted channel proof into same-run events without treating it as UI proof", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "friday-ui-device-readiness-channel-bridge-"));
+    try {
+      const files = writePartialEvidenceDir(tempDir);
+      const channelProof = writeRedactedChannelProof(tempDir);
+
+      const stdout = execFileSync("bash", [
+        "scripts/ops/friday-ui-device-proof-readiness.sh",
+        "--evidence-dir",
+        tempDir,
+      ], {
+        cwd: process.cwd(),
+        encoding: "utf8",
+      });
+      const result = JSON.parse(stdout.slice(stdout.indexOf("{"))) as {
+        truth?: string;
+        status?: string;
+        notes?: string[];
+        blockers?: string[];
+      };
+
+      expect(result.truth).toBe("report_only_not_ui_device_proof");
+      expect(result.status).toBe("blocked");
+      expect(result.notes).toContain(`resolved_CHANNEL_LIVE_PROOF:${channelProof}`);
+      expect(result.notes?.some((note) => note.includes("channel_proof_events_bridge:ready"))).toBe(true);
+      expect(result.notes?.some((note) => note.includes("channel_proof_events_merge:ready"))).toBe(true);
+      expect(result.notes?.some((note) => note.includes("resolved_SAME_RUN_EVENTS") && note.includes("same-run-events.with-channel.jsonl"))).toBe(true);
+      expect(result.blockers).toContain("ui_device_proof_evidence:missing_required_real_evidence_env");
+
+      const rows = readFileSync(join(tempDir, "same-run-events.with-channel.jsonl"), "utf8")
+        .trim()
+        .split("\n")
+        .map((line) => JSON.parse(line) as { surface?: string; event?: string; evidence_ref?: string });
+      expect(rows).toContainEqual(expect.objectContaining({
+        surface: "channel",
+        event: "same_mission_projection_visible",
+        evidence_ref: files.channel,
       }));
     } finally {
       rmSync(tempDir, { recursive: true, force: true });


### PR DESCRIPTION
## Summary
- derive redacted channel proof events for UI/device readiness when a real channel proof, channel evidence, and mission id are present
- merge those derived events with existing same-run events without replacing mobile/desktop evidence
- add regression coverage proving channel-derived support stays diagnostic and does not satisfy UI/device proof by itself

## Verification
- bash -n scripts/ops/friday-ui-device-proof-readiness.sh
- /Users/jarvis/Projects/Friday/node_modules/.bin/vitest run --project default --run test/unit/qa/friday-ui-device-proof-readiness-cli.test.ts

Truth: this is a diagnostic evidence bridge only. It does not synthesize UI/device proof, does not make channel evidence count as mobile/desktop GUI evidence, and does not claim END-BAR, live adoption, or GUI tap closure.