### PR TITLE
feat(ios): route voice readiness into chat loop

### DIFF
--- a/apps/friday-ios/Sources/FridayMobileShell/FridayApp.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayApp.swift
@@ -386,7 +386,9 @@ struct RootView: View {
         case .newSession:
           FridayNewSessionScreen(viewModel: newSessionVM)
         case .voice:
-          FridayVoiceScreen(viewModel: voiceVM)
+          FridayVoiceScreen(viewModel: voiceVM) {
+            chatOpen = true
+          }
         case .pairing:
           FridayHomeScreen(viewModel: homeVM, showPairingProvisioning: true)
         case .providerAuth:

--- a/apps/friday-ios/Sources/FridayMobileShell/FridayVoiceScreen.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayVoiceScreen.swift
@@ -3,6 +3,15 @@ import SwiftUI
 
 struct FridayVoiceScreen: View {
   @ObservedObject var viewModel: VoiceReadinessViewModel
+  let onOpenVoiceChat: () -> Void
+
+  init(
+    viewModel: VoiceReadinessViewModel,
+    onOpenVoiceChat: @escaping () -> Void = {}
+  ) {
+    self.viewModel = viewModel
+    self.onOpenVoiceChat = onOpenVoiceChat
+  }
 
   var body: some View {
     ScrollView {
@@ -140,6 +149,16 @@ struct FridayVoiceScreen: View {
               }
               .buttonStyle(.bordered)
               .disabled(!row.enabled || viewModel.state == .loading)
+            } else if row.id == "open-chat-loop" {
+              Button {
+                onOpenVoiceChat()
+              } label: {
+                Text("Open")
+              }
+              .buttonStyle(.bordered)
+              .disabled(!row.enabled || viewModel.state == .loading)
+              .accessibilityLabel("Open Friday Chat voice loop")
+              .accessibilityIdentifier("friday.voice.open-chat-loop")
             }
           }
           .padding(.vertical, 3)

--- a/apps/friday-ios/Sources/FridayMobileShellCore/MobileProductReadinessContract.swift
+++ b/apps/friday-ios/Sources/FridayMobileShellCore/MobileProductReadinessContract.swift
@@ -193,6 +193,7 @@ public enum MobileProductDestinationID: String, CaseIterable, Sendable, Equatabl
           "mobile/voice/permission",
           "mobile/fridayChat/voice-input",
           "mobile/fridayChat/voice-output",
+          "mobile/voice/open-chat-loop",
         ],
         blockers: [
           .init(.needsRuntimeEvidence, label: "real microphone and speech-output tap proof"),

--- a/apps/friday-ios/Sources/FridayMobileShellCore/VoiceReadinessViewModel.swift
+++ b/apps/friday-ios/Sources/FridayMobileShellCore/VoiceReadinessViewModel.swift
@@ -150,9 +150,17 @@ public final class VoiceReadinessViewModel: ObservableObject {
         id: "realtime-loop",
         title: "Realtime voice loop",
         detail: readiness.voiceLoopReady
-          ? "Capture and TTS are both ready."
+          ? "Capture and TTS are both ready; open Friday Chat to speak with the governed loop."
           : "Disabled until capture and TTS are both ready.",
         truthLabel: readiness.voiceLoopReady ? "ready" : "blocked",
+        enabled: readiness.voiceLoopReady),
+      MobileVoiceActionRow(
+        id: "open-chat-loop",
+        title: "Open Friday Chat voice loop",
+        detail: readiness.voiceLoopReady
+          ? "Routes to Friday Chat, where mic input and speech output are wired to the live governed turn."
+          : "Blocked until voice capture and speech output are both ready.",
+        truthLabel: readiness.voiceLoopReady ? "native_voice_route_ready" : "blocked",
         enabled: readiness.voiceLoopReady),
     ]
   }

--- a/apps/friday-ios/Tests/FridayMobileShellCoreTests/MobileProductReadinessContractTests.swift
+++ b/apps/friday-ios/Tests/FridayMobileShellCoreTests/MobileProductReadinessContractTests.swift
@@ -76,6 +76,7 @@ func mobileProductContractSeparatesReadinessShellsFromProductLoops() {
     "mobile/voice/permission",
     "mobile/fridayChat/voice-input",
     "mobile/fridayChat/voice-output",
+    "mobile/voice/open-chat-loop",
   ])
   #expect(voice.blockers.contains { $0.kind == .needsRuntimeEvidence })
   #expect(workflows.tier == .navigationShell)

--- a/apps/friday-ios/Tests/FridayMobileShellCoreTests/VoiceReadinessViewModelTests.swift
+++ b/apps/friday-ios/Tests/FridayMobileShellCoreTests/VoiceReadinessViewModelTests.swift
@@ -89,13 +89,21 @@ final class VoiceReadinessViewModelTests: XCTestCase {
       speechRecognition: .notDetermined,
       ttsProviderConfigured: false)
     let initialRows = VoiceReadinessViewModel.actionRows(for: initial)
-    XCTAssertEqual(initialRows.map(\.id), ["permission", "speech-capture", "tts-output", "realtime-loop"])
+    XCTAssertEqual(initialRows.map(\.id), [
+      "permission",
+      "speech-capture",
+      "tts-output",
+      "realtime-loop",
+      "open-chat-loop",
+    ])
     XCTAssertEqual(initialRows.first { $0.id == "permission" }?.truthLabel, "native_permission_request")
     XCTAssertEqual(initialRows.first { $0.id == "permission" }?.enabled, true)
     XCTAssertEqual(initialRows.first { $0.id == "tts-output" }?.truthLabel, "NO-GO")
     XCTAssertEqual(initialRows.first { $0.id == "tts-output" }?.enabled, false)
     XCTAssertEqual(initialRows.first { $0.id == "realtime-loop" }?.truthLabel, "blocked")
     XCTAssertEqual(initialRows.first { $0.id == "realtime-loop" }?.enabled, false)
+    XCTAssertEqual(initialRows.first { $0.id == "open-chat-loop" }?.truthLabel, "blocked")
+    XCTAssertEqual(initialRows.first { $0.id == "open-chat-loop" }?.enabled, false)
 
     let captureOnly = MobileVoiceReadiness(
       microphone: .authorized,
@@ -116,5 +124,7 @@ final class VoiceReadinessViewModelTests: XCTestCase {
     XCTAssertEqual(completeRows.first { $0.id == "tts-output" }?.detail, "Local speech output provider is configured.")
     XCTAssertEqual(completeRows.first { $0.id == "realtime-loop" }?.truthLabel, "ready")
     XCTAssertEqual(completeRows.first { $0.id == "realtime-loop" }?.enabled, true)
+    XCTAssertEqual(completeRows.first { $0.id == "open-chat-loop" }?.truthLabel, "native_voice_route_ready")
+    XCTAssertEqual(completeRows.first { $0.id == "open-chat-loop" }?.enabled, true)
   }
 }


### PR DESCRIPTION
## Summary
- add a Voice screen action that opens Friday Chat when native capture + local speech output readiness are both present
- record the new `mobile/voice/open-chat-loop` runtime action in the mobile product readiness contract
- keep the action blocked until the existing voice readiness gates say the native voice loop is ready

## Verification
- `swift test --package-path apps/friday-ios --filter 'VoiceReadinessViewModelTests|MobileProductReadinessContractTests'`
- `swift build --package-path apps/friday-ios`

Truth: this improves the user path from the selected Voice surface into the existing Friday Chat voice input/output loop. It does not flip live defaults, does not bypass operator signing, does not claim END-BAR, and still requires real microphone/speech-output tap proof before voice is counted as product-complete.