### PR TITLE
feat(ios): show complete new session receipt refs

### DIFF
--- a/apps/friday-ios/Sources/FridayMobileShell/FridayNewSessionScreen.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayNewSessionScreen.swift
@@ -83,7 +83,7 @@ struct FridayNewSessionScreen: View {
             .foregroundStyle(MobileTheme.textSecondary)
         }
       }
-    case .launched(let summary, let missionId, let workItemId):
+    case .launched(let summary, let missionId, let workItemId, let surfaceThreadId, let status, let createdOrReady):
       GlassPanel {
         VStack(alignment: .leading, spacing: MobileTheme.rowSpacing) {
           cardHeader("Submitted", count: nil)
@@ -92,6 +92,15 @@ struct FridayNewSessionScreen: View {
             .foregroundStyle(MobileTheme.textPrimary)
           RefPill(label: "mission_id", ref: missionId)
           RefPill(label: "work_item_id", ref: workItemId)
+          RefPill(label: "surface", ref: surfaceThreadId)
+          StatusChip(
+            text: createdOrReady ? "created_or_ready" : status,
+            bg: MobileTheme.chipDoneBG,
+            fg: MobileTheme.chipDoneFG)
+          Text("Refs-only receipt. Provider execution and readable results still require the governed live loop to finish.")
+            .font(.caption2)
+            .foregroundStyle(MobileTheme.textSecondary)
+            .fixedSize(horizontal: false, vertical: true)
         }
       }
     case .blocked(let reason):

--- a/apps/friday-ios/Sources/FridayMobileShellCore/NewSessionViewModel.swift
+++ b/apps/friday-ios/Sources/FridayMobileShellCore/NewSessionViewModel.swift
@@ -4,7 +4,13 @@ import FridayRustClient
 public enum NewSessionLaunchState: Sendable, Equatable {
   case idle
   case launching
-  case launched(summary: String, missionId: String, workItemId: String)
+  case launched(
+    summary: String,
+    missionId: String,
+    workItemId: String,
+    surfaceThreadId: String,
+    status: String,
+    createdOrReady: Bool)
   case blocked(reason: String)
 }
 
@@ -51,7 +57,10 @@ public final class NewSessionViewModel: ObservableObject {
       launchState = .launched(
         summary: "\(result.status) · mission=\(result.missionId) · work_item=\(workItemId)",
         missionId: result.missionId,
-        workItemId: workItemId)
+        workItemId: workItemId,
+        surfaceThreadId: result.surfaceThreadId,
+        status: result.status,
+        createdOrReady: result.createdOrReady)
     } catch {
       launchState = .blocked(reason: Self.reason(for: error))
     }

--- a/apps/friday-ios/Tests/FridayMobileShellCoreTests/NewSessionViewModelTests.swift
+++ b/apps/friday-ios/Tests/FridayMobileShellCoreTests/NewSessionViewModelTests.swift
@@ -96,7 +96,10 @@ final class NewSessionViewModelTests: XCTestCase {
       .launched(
         summary: "ready · mission=mission-mobile-new-session-fixed · work_item=work-mobile-new-session-fixed",
         missionId: "mission-mobile-new-session-fixed",
-        workItemId: "work-mobile-new-session-fixed"))
+        workItemId: "work-mobile-new-session-fixed",
+        surfaceThreadId: "surface-mobile-new-session-fixed",
+        status: "ready",
+        createdOrReady: true))
 
     try writeNewSessionActionEvidenceIfRequested()
   }
@@ -122,6 +125,9 @@ final class NewSessionViewModelTests: XCTestCase {
           "proof": [
             "mission_id": "mission-mobile-new-session-fixed",
             "work_item_id": "work-mobile-new-session-fixed",
+            "surface_thread_id": "surface-mobile-new-session-fixed",
+            "status": "ready",
+            "created_or_ready": true,
             "surface_kind": "mobile",
             "delivery_route": "ios://friday-mobile/new-session/fixed",
           ],


### PR DESCRIPTION
## Summary
- include `surfaceThreadId`, `status`, and `createdOrReady` in the New Session launched state
- show the surface ref and created/ready chip in the iOS New Session receipt
- extend New Session evidence coverage so the receipt proves the same refs the UI renders

## Verification
- `swift test --package-path apps/friday-ios --filter NewSessionViewModelTests`
- `swift build --package-path apps/friday-ios`

Truth: this makes the user-visible New Session receipt more complete and refs-only after a governed mission-intake launch. It does not claim provider execution, readable result completion, END-BAR, GO-LIVE, or adoption.