### PR TITLE
feat(ios): continue share intake into chat

### DIFF
--- a/apps/friday-ios/Sources/FridayMobileShell/FridayApp.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayApp.swift
@@ -382,7 +382,9 @@ struct RootView: View {
         case .tokenLedger:
           FridayTokenLedgerScreen(viewModel: homeVM)
         case .shareIntake:
-          FridayShareIntakeScreen(viewModel: shareIntakeVM)
+          FridayShareIntakeScreen(viewModel: shareIntakeVM) {
+            chatOpen = true
+          }
         case .newSession:
           FridayNewSessionScreen(viewModel: newSessionVM)
         case .voice:

--- a/apps/friday-ios/Sources/FridayMobileShell/FridayShareIntakeScreen.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayShareIntakeScreen.swift
@@ -3,6 +3,7 @@ import SwiftUI
 
 struct FridayShareIntakeScreen: View {
   @ObservedObject var viewModel: ShareIntakeViewModel
+  var onOpenFridayChat: () -> Void = {}
 
   var body: some View {
     ScrollView {
@@ -89,6 +90,15 @@ struct FridayShareIntakeScreen: View {
             text: receipt.createdOrReady ? "created_or_ready" : receipt.status,
             bg: MobileTheme.chipDoneBG,
             fg: MobileTheme.chipDoneFG)
+          Button {
+            onOpenFridayChat()
+          } label: {
+            Label("Continue in Chat", systemImage: "bubble.left.and.bubble.right")
+              .frame(maxWidth: .infinity)
+          }
+          .buttonStyle(.borderedProminent)
+          .tint(MobileTheme.cyan)
+          .accessibilityIdentifier("friday.share.open-chat-loop")
           Button("New share") { viewModel.reset() }
             .font(.caption)
             .foregroundStyle(MobileTheme.cyan)

--- a/apps/friday-ios/Sources/FridayMobileShellCore/MobileProductReadinessContract.swift
+++ b/apps/friday-ios/Sources/FridayMobileShellCore/MobileProductReadinessContract.swift
@@ -182,7 +182,7 @@ public enum MobileProductDestinationID: String, CaseIterable, Sendable, Equatabl
         title: "Share Intake",
         systemImage: "square.and.arrow.down",
         tier: .governedActionGated,
-        runtimeActionIds: ["mobile/share/send"],
+        runtimeActionIds: ["mobile/share/send", "mobile/share/open-chat-loop"],
         blockers: [.init(.needsRuntimeEvidence, label: "share mission-intake app proof")])
     case .voice:
       return contract(

--- a/apps/friday-ios/Tests/FridayMobileShellCoreTests/MobileProductReadinessContractTests.swift
+++ b/apps/friday-ios/Tests/FridayMobileShellCoreTests/MobileProductReadinessContractTests.swift
@@ -102,7 +102,7 @@ func mobileProductContractTracksShareIntakeWriteAsBuiltButRuntimeBlocked() {
   let share = MobileProductDestinationID.shareIntake.contract
 
   #expect(share.tier == .governedActionGated)
-  #expect(share.runtimeActionIds == ["mobile/share/send"])
+  #expect(share.runtimeActionIds == ["mobile/share/send", "mobile/share/open-chat-loop"])
   #expect(!share.blockers.contains { $0.kind == .needsLiveWrite })
   #expect(share.blockers.contains { $0.kind == .needsRuntimeEvidence })
   #expect(!share.isEndBarReady)


### PR DESCRIPTION
## Summary
- add a Continue in Chat action to the Share Intake ready receipt
- route the action through the existing Friday Chat sheet from the app shell
- record the continuation as a mobile product runtime action in the readiness contract

## Verification
- swift test --package-path apps/friday-ios --filter 'ShareIntakeViewModelTests|MobileProductReadinessContractTests'\n- swift build --package-path apps/friday-ios\n\nTruth: improves the selected Share Intake surface from refs-only mission-intake receipt into the existing Chat loop. It does not claim provider completion, readable answer proof, real user tap proof, END-BAR, GO-LIVE, or adoption.