### PR TITLE
feat(ios): continue new session into chat

### DIFF
--- a/apps/friday-ios/Sources/FridayMobileShell/FridayApp.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayApp.swift
@@ -386,7 +386,9 @@ struct RootView: View {
             chatOpen = true
           }
         case .newSession:
-          FridayNewSessionScreen(viewModel: newSessionVM)
+          FridayNewSessionScreen(viewModel: newSessionVM) {
+            chatOpen = true
+          }
         case .voice:
           FridayVoiceScreen(viewModel: voiceVM) {
             chatOpen = true

--- a/apps/friday-ios/Sources/FridayMobileShell/FridayNewSessionScreen.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayNewSessionScreen.swift
@@ -3,6 +3,7 @@ import SwiftUI
 
 struct FridayNewSessionScreen: View {
   @ObservedObject var viewModel: NewSessionViewModel
+  var onOpenFridayChat: () -> Void = {}
   @State private var intent = ""
 
   var body: some View {
@@ -101,6 +102,15 @@ struct FridayNewSessionScreen: View {
             .font(.caption2)
             .foregroundStyle(MobileTheme.textSecondary)
             .fixedSize(horizontal: false, vertical: true)
+          Button {
+            onOpenFridayChat()
+          } label: {
+            Label("Continue in Chat", systemImage: "bubble.left.and.bubble.right")
+              .frame(maxWidth: .infinity)
+          }
+          .buttonStyle(.borderedProminent)
+          .tint(MobileTheme.cyan)
+          .accessibilityIdentifier("friday.new-session.open-chat-loop")
         }
       }
     case .blocked(let reason):

--- a/apps/friday-ios/Sources/FridayMobileShellCore/MobileProductReadinessContract.swift
+++ b/apps/friday-ios/Sources/FridayMobileShellCore/MobileProductReadinessContract.swift
@@ -210,7 +210,7 @@ public enum MobileProductDestinationID: String, CaseIterable, Sendable, Equatabl
         title: "New Session",
         systemImage: "plus",
         tier: .governedActionGated,
-        runtimeActionIds: ["mobile/newSession/play"],
+        runtimeActionIds: ["mobile/newSession/play", "mobile/newSession/open-chat-loop"],
         blockers: [.init(.needsRuntimeEvidence, label: "provider result round-trip")])
     case .needsMe:
       return contract(

--- a/apps/friday-ios/Tests/FridayMobileShellCoreTests/MobileProductReadinessContractTests.swift
+++ b/apps/friday-ios/Tests/FridayMobileShellCoreTests/MobileProductReadinessContractTests.swift
@@ -107,3 +107,14 @@ func mobileProductContractTracksShareIntakeWriteAsBuiltButRuntimeBlocked() {
   #expect(share.blockers.contains { $0.kind == .needsRuntimeEvidence })
   #expect(!share.isEndBarReady)
 }
+
+@Test
+func mobileProductContractTracksNewSessionLaunchIntoChatButRuntimeBlocked() {
+  let newSession = MobileProductDestinationID.newSession.contract
+
+  #expect(newSession.tier == .governedActionGated)
+  #expect(newSession.runtimeActionIds == ["mobile/newSession/play", "mobile/newSession/open-chat-loop"])
+  #expect(!newSession.blockers.contains { $0.kind == .needsLiveWrite })
+  #expect(newSession.blockers.contains { $0.kind == .needsRuntimeEvidence })
+  #expect(!newSession.isEndBarReady)
+}


### PR DESCRIPTION
## Summary
- add a Continue in Chat action to the New Session submitted receipt
- route the action through the existing Friday Chat sheet from the app shell
- track the continuation action in the mobile product readiness contract

## Verification
- swift test --package-path apps/friday-ios --filter 'NewSessionViewModelTests|MobileProductReadinessContractTests'\n- swift build --package-path apps/friday-ios\n\nTruth: improves the selected New Session surface from refs-only mission-intake receipt into the existing Chat loop. It does not claim provider completion, readable answer proof, real user tap proof, END-BAR, GO-LIVE, or adoption.