### PR TITLE
feat(ios): carry launch refs into chat

### DIFF
--- a/apps/friday-ios/Sources/FridayMobileShell/FridayApp.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayApp.swift
@@ -338,6 +338,7 @@ struct RootView: View {
   @State private var destination: MobileDestination = .home
   @State private var commandOpen = false
   @State private var chatOpen = false
+  @State private var pendingChatLaunchContext: ChatLaunchContext?
 
   init(session: FridaySession) {
     self.session = session
@@ -382,15 +383,24 @@ struct RootView: View {
         case .tokenLedger:
           FridayTokenLedgerScreen(viewModel: homeVM)
         case .shareIntake:
-          FridayShareIntakeScreen(viewModel: shareIntakeVM) {
+          FridayShareIntakeScreen(viewModel: shareIntakeVM) { receipt in
+            pendingChatLaunchContext = ChatLaunchContext(
+              source: "Share Intake",
+              missionId: receipt.missionId,
+              workItemId: receipt.workItemId,
+              surfaceThreadId: receipt.surfaceThreadId,
+              status: receipt.status,
+              createdOrReady: receipt.createdOrReady)
             chatOpen = true
           }
         case .newSession:
-          FridayNewSessionScreen(viewModel: newSessionVM) {
+          FridayNewSessionScreen(viewModel: newSessionVM) { context in
+            pendingChatLaunchContext = context
             chatOpen = true
           }
         case .voice:
           FridayVoiceScreen(viewModel: voiceVM) {
+            pendingChatLaunchContext = nil
             chatOpen = true
           }
         case .pairing:
@@ -417,6 +427,7 @@ struct RootView: View {
         // Top-BAR 💬: the Friday Chat entry (locked: the ONLY chat entry — no card).
         ToolbarItem(placement: .topBarTrailing) {
           Button {
+            pendingChatLaunchContext = nil
             chatOpen = true
           } label: {
             Image(systemName: "bubble.left.and.bubble.right").foregroundStyle(MobileTheme.cyan)
@@ -437,7 +448,7 @@ struct RootView: View {
       .navigationDestination(isPresented: $chatOpen) {
         // The Friday Chat read-WRITE / S6 surface, driven by the session's REAL write client
         // + the operator-signer relay.
-        FridayChatScreen(session: session)
+        FridayChatScreen(session: session, launchContext: pendingChatLaunchContext)
       }
     }
     .tint(MobileTheme.cyan)

--- a/apps/friday-ios/Sources/FridayMobileShell/FridayChatScreen.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayChatScreen.swift
@@ -22,17 +22,18 @@ struct FridayChatScreen: View {
   /// Whether the S6 pause/approve/resume is enabled (the run-control flag). OFF ⇒ read-only.
   private let runControlEnabled: Bool
   @State private var routePreference: MissionRoutePreference = .auto
+  @State private var draft: String
 
-  init(session: FridaySession) {
+  init(session: FridaySession, launchContext: ChatLaunchContext? = nil) {
     self.runControlEnabled = session.runControlEnabled
+    _draft = State(initialValue: launchContext?.composerPrefill ?? "")
     _viewModel = StateObject(wrappedValue: FridayChatViewModel(
       writeClient: session.writeClient,
       signer: session.signer,
       missionClient: session.missionClient,
-      readClient: session.readClient))
+      readClient: session.readClient,
+      launchContext: launchContext))
   }
-
-  @State private var draft = ""
 
   var body: some View {
     VStack(spacing: 0) {
@@ -77,7 +78,7 @@ struct FridayChatScreen: View {
 
   private func contextCardRow(_ card: ChatContextCard) -> some View {
     HStack(alignment: .top, spacing: 10) {
-      Image(systemName: card.id == "handoff" ? "arrowshape.turn.up.right" : "brain.head.profile")
+      Image(systemName: contextCardIcon(card.id))
         .foregroundStyle(MobileTheme.cyan)
         .frame(width: 24)
       VStack(alignment: .leading, spacing: 3) {
@@ -113,6 +114,14 @@ struct FridayChatScreen: View {
     .accessibilityElement(children: .contain)
     .accessibilityLabel("\(card.title) card")
     .accessibilityIdentifier("friday.chat.\(card.id)-card")
+  }
+
+  private func contextCardIcon(_ id: String) -> String {
+    switch id {
+    case "handoff": return "arrowshape.turn.up.right"
+    case "launch": return "link.badge.plus"
+    default: return "brain.head.profile"
+    }
   }
 
   private var handoffControls: some View {

--- a/apps/friday-ios/Sources/FridayMobileShell/FridayNewSessionScreen.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayNewSessionScreen.swift
@@ -3,7 +3,7 @@ import SwiftUI
 
 struct FridayNewSessionScreen: View {
   @ObservedObject var viewModel: NewSessionViewModel
-  var onOpenFridayChat: () -> Void = {}
+  var onOpenFridayChat: (ChatLaunchContext) -> Void = { _ in }
   @State private var intent = ""
 
   var body: some View {
@@ -103,7 +103,13 @@ struct FridayNewSessionScreen: View {
             .foregroundStyle(MobileTheme.textSecondary)
             .fixedSize(horizontal: false, vertical: true)
           Button {
-            onOpenFridayChat()
+            onOpenFridayChat(ChatLaunchContext(
+              source: "New Session",
+              missionId: missionId,
+              workItemId: workItemId,
+              surfaceThreadId: surfaceThreadId,
+              status: status,
+              createdOrReady: createdOrReady))
           } label: {
             Label("Continue in Chat", systemImage: "bubble.left.and.bubble.right")
               .frame(maxWidth: .infinity)

--- a/apps/friday-ios/Sources/FridayMobileShell/FridayShareIntakeScreen.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayShareIntakeScreen.swift
@@ -3,7 +3,7 @@ import SwiftUI
 
 struct FridayShareIntakeScreen: View {
   @ObservedObject var viewModel: ShareIntakeViewModel
-  var onOpenFridayChat: () -> Void = {}
+  var onOpenFridayChat: (ShareIntakeReceipt) -> Void = { _ in }
 
   var body: some View {
     ScrollView {
@@ -91,7 +91,7 @@ struct FridayShareIntakeScreen: View {
             bg: MobileTheme.chipDoneBG,
             fg: MobileTheme.chipDoneFG)
           Button {
-            onOpenFridayChat()
+            onOpenFridayChat(receipt)
           } label: {
             Label("Continue in Chat", systemImage: "bubble.left.and.bubble.right")
               .frame(maxWidth: .infinity)

--- a/apps/friday-ios/Sources/FridayMobileShellCore/FridayChatViewModel.swift
+++ b/apps/friday-ios/Sources/FridayMobileShellCore/FridayChatViewModel.swift
@@ -272,6 +272,45 @@ public struct ChatContextCard: Identifiable, Sendable, Equatable {
   public let memoryPreview: String?
 }
 
+public struct ChatLaunchContext: Sendable, Equatable {
+  public let source: String
+  public let missionId: String
+  public let workItemId: String?
+  public let surfaceThreadId: String
+  public let status: String
+  public let createdOrReady: Bool
+
+  public init(
+    source: String,
+    missionId: String,
+    workItemId: String?,
+    surfaceThreadId: String,
+    status: String,
+    createdOrReady: Bool
+  ) {
+    self.source = source
+    self.missionId = missionId
+    self.workItemId = workItemId
+    self.surfaceThreadId = surfaceThreadId
+    self.status = status
+    self.createdOrReady = createdOrReady
+  }
+
+  public var composerPrefill: String {
+    var lines = [
+      "Continue this \(source) Mission.",
+      "mission_id=\(missionId)",
+      "surface_thread_id=\(surfaceThreadId)",
+      "status=\(createdOrReady ? "created_or_ready" : status)",
+    ]
+    if let workItemId, !workItemId.isEmpty {
+      lines.append("work_item_id=\(workItemId)")
+    }
+    lines.append("Use these refs to produce the next owner-visible answer; do not fabricate missing results.")
+    return lines.joined(separator: "\n")
+  }
+}
+
 public protocol ChatHistoryStoring {
   func load() -> [ChatHistoryItem]
   func save(_ items: [ChatHistoryItem])
@@ -371,6 +410,7 @@ public final class FridayChatViewModel: ObservableObject {
     memoryDecisionClient: (any FridayMissionSpineWriteClient)? = nil,
     readClient: FridayRustReadClient? = nil,
     historyStore: any ChatHistoryStoring = UserDefaultsChatHistoryStore(),
+    launchContext: ChatLaunchContext? = nil,
     newId: @escaping () -> String = { UUID().uuidString.lowercased().replacingOccurrences(of: "-", with: "") },
     missionIdPrefix: String = "mission-mobile-",
     nowMs: @escaping () -> Int64 = { Int64(Date().timeIntervalSince1970 * 1000) }
@@ -385,6 +425,10 @@ public final class FridayChatViewModel: ObservableObject {
     self.missionIdPrefix = missionIdPrefix
     self.nowMs = nowMs
     self.history = historyStore.load()
+    if let launchContext {
+      self.contextCards = [Self.launchContextCard(launchContext)]
+      self.selectedContextCardId = "launch"
+    }
   }
 
   // MARK: 1. Compose → Send
@@ -833,6 +877,18 @@ public final class FridayChatViewModel: ObservableObject {
         memoryCandidateId: memoryCandidate?.id,
         memoryPreview: memoryCandidate?.preview),
     ]
+  }
+
+  private static func launchContextCard(_ context: ChatLaunchContext) -> ChatContextCard {
+    let workItem = context.workItemId ?? "not-attached"
+    return ChatContextCard(
+      id: "launch",
+      title: "Mission refs",
+      detail: "\(context.source) submitted \(context.missionId) / \(workItem). Send the prefilled Chat turn to continue through the governed live loop.",
+      truthLabel: context.createdOrReady ? "created_or_ready" : context.status,
+      evidenceRef: "swift://mobile/fridayChat/launch-context/\(context.missionId)",
+      memoryCandidateId: nil,
+      memoryPreview: nil)
   }
 
   private func appendHistory(role: String, text: String, runId: String? = nil, receiptRefs: [ChatReceiptRef] = []) {

--- a/apps/friday-ios/Tests/FridayMobileShellCoreTests/FridayChatViewModelTests.swift
+++ b/apps/friday-ios/Tests/FridayMobileShellCoreTests/FridayChatViewModelTests.swift
@@ -809,6 +809,31 @@ final class FridayChatViewModelTests: XCTestCase {
       ])
   }
 
+  func testLaunchContextSeedsRefsOnlyContextCardAndComposerPrefill() async {
+    let context = ChatLaunchContext(
+      source: "Share Intake",
+      missionId: "mission-mobile-share-fixed",
+      workItemId: "work-mobile-share-fixed",
+      surfaceThreadId: "surface-mobile-share-fixed",
+      status: "ready",
+      createdOrReady: true)
+    let vm = FridayChatViewModel(
+      writeClient: FakeWriteClient(dispatch: .answer(makeAnswer())),
+      signer: MockOperatorSigner(),
+      launchContext: context)
+
+    XCTAssertEqual(vm.contextCards.map(\.id), ["launch"])
+    XCTAssertEqual(vm.selectedContextCardId, "launch")
+    XCTAssertEqual(vm.contextCards.first?.truthLabel, "created_or_ready")
+    XCTAssertEqual(
+      vm.contextCards.first?.evidenceRef,
+      "swift://mobile/fridayChat/launch-context/mission-mobile-share-fixed")
+    XCTAssertTrue(context.composerPrefill.contains("mission_id=mission-mobile-share-fixed"))
+    XCTAssertTrue(context.composerPrefill.contains("work_item_id=work-mobile-share-fixed"))
+    XCTAssertTrue(context.composerPrefill.contains("surface_thread_id=surface-mobile-share-fixed"))
+    XCTAssertTrue(context.composerPrefill.contains("do not fabricate missing results"))
+  }
+
   /// A server REFUSAL (`accepted=false`) is a SUCCESSFUL relay of a refusal — the action did NOT
   /// execute, and the loop shows it honestly (not as a transport failure, not as an executed action).
   func testApprove_serverRefusal_isSurfacedAsARefusal() async {


### PR DESCRIPTION
## Summary
- Carry Share Intake and New Session refs into Friday Chat instead of opening a blank composer.
- Seed a refs-only `ChatLaunchContext` card plus composer prefill from the submitted mission/work/surface refs.
- Preserve operator-signing boundaries: this does not sign, mint, flip live flags, or fabricate provider completion.

## Verification
- `swift test --package-path apps/friday-ios --filter 'FridayChatViewModelTests|ShareIntakeViewModelTests|NewSessionViewModelTests|MobileProductReadinessContractTests'`
- `swift build --package-path apps/friday-ios`

## Truth label
Improves selected mobile UI continuation from refs-only intake receipts into the existing governed Chat loop. Does not claim provider completion, readable answer proof, real user tap proof, END-BAR, GO-LIVE, or adoption.