### PR TITLE
feat(ios): surface token ledger receipt refs

### DIFF
--- a/apps/friday-ios/Sources/FridayMobileShell/FridayTokenLedgerScreen.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayTokenLedgerScreen.swift
@@ -35,9 +35,11 @@ struct FridayTokenLedgerScreen: View {
 
     if let runId {
       runRefCard(runId: runId, projection: projection)
+      receiptRefsCard(projection)
       detailCard
     } else {
       noRunRefCard(projection)
+      receiptRefsCard(projection)
     }
   }
 
@@ -105,7 +107,7 @@ struct FridayTokenLedgerScreen: View {
     GlassPanel {
       VStack(alignment: .leading, spacing: MobileTheme.rowSpacing) {
         cardHeader("No Run Ref", count: nil)
-        Text("The Home projection does not include a completed run ref yet, so Friday cannot show a token ledger from this app surface.")
+        Text("The Home projection does not include a completed run ref yet, so Friday cannot show per-run token totals from this app surface.")
           .font(.caption)
           .foregroundStyle(MobileTheme.textSecondary)
           .fixedSize(horizontal: false, vertical: true)
@@ -114,6 +116,29 @@ struct FridayTokenLedgerScreen: View {
       }
     }
     .accessibilityIdentifier("friday.token-ledger.no-run-ref")
+  }
+
+  @ViewBuilder
+  private func receiptRefsCard(_ projection: HomeProjection) -> some View {
+    let count = projection.providerReceiptRefs.count + projection.channelReceiptRefs.count
+    if count > 0 {
+      GlassPanel {
+        VStack(alignment: .leading, spacing: MobileTheme.rowSpacing) {
+          cardHeader("Projected Receipts", count: count)
+          Text("These are refs already projected by the Hub. They are evidence links only; Friday still needs a run ref before showing per-run token totals.")
+            .font(.caption)
+            .foregroundStyle(MobileTheme.textSecondary)
+            .fixedSize(horizontal: false, vertical: true)
+          ForEach(projection.providerReceiptRefs.prefix(5), id: \.self) { ref in
+            RefPill(label: "provider_receipt", ref: ref)
+          }
+          ForEach(projection.channelReceiptRefs.prefix(5), id: \.self) { ref in
+            RefPill(label: "channel_receipt", ref: ref)
+          }
+        }
+      }
+      .accessibilityIdentifier("friday.token-ledger.projected-receipts")
+    }
   }
 
   @ViewBuilder

--- a/apps/friday-ios/Tests/FridayMobileShellCoreTests/HomeViewModelTests.swift
+++ b/apps/friday-ios/Tests/FridayMobileShellCoreTests/HomeViewModelTests.swift
@@ -361,6 +361,25 @@ final class HomeViewModelTests: XCTestCase {
     return try WorkbenchSnapshot(projectionJSON: Data(json.utf8), generatedAtMs: 1_780_640_010_000)
   }
 
+  private func receiptOnlySnapshot() throws -> WorkbenchSnapshot {
+    let json = """
+    {
+      "missionId": "mission-receipts-only",
+      "fridayConversationId": "conv-receipts-only",
+      "runtimeFeedStatus": "live_rust_hub_projection",
+      "statusLabels": [],
+      "workItems": [],
+      "providerReceiptRefs": ["proof://provider/codex-receipt"],
+      "channelReceiptRefs": ["proof://surface/mobile-receipt"],
+      "memoryCandidates": [],
+      "runOutcomeLearningCandidates": [],
+      "capabilityStates": [],
+      "transcriptSections": []
+    }
+    """
+    return try WorkbenchSnapshot(projectionJSON: Data(json.utf8), generatedAtMs: 1_780_640_020_000)
+  }
+
   func testRefresh_loadsRefsOnlyProjection() async throws {
     let snapshot = try sampleSnapshot()
     let vm = HomeViewModel(client: FakeReadClient(.snapshot(snapshot)))
@@ -533,6 +552,16 @@ final class HomeViewModelTests: XCTestCase {
     XCTAssertNil(p.tokenLedgerRunId)
     XCTAssertTrue(vm.state.isOnline)
     XCTAssertNil(vm.state.projection?.statusLabels.first)
+  }
+
+  func testRefresh_providerReceiptsDoNotFabricateTokenLedgerRunRef() async throws {
+    let vm = HomeViewModel(client: FakeReadClient(.snapshot(try receiptOnlySnapshot())))
+    await vm.refresh()
+    guard case .loaded(let p) = vm.state else { return XCTFail("expected loaded projection, got \(vm.state)") }
+    XCTAssertEqual(p.providerReceiptRefs, ["proof://provider/codex-receipt"])
+    XCTAssertEqual(p.channelReceiptRefs, ["proof://surface/mobile-receipt"])
+    XCTAssertNil(p.tokenLedgerRunId)
+    XCTAssertFalse(p.isLoadedEmpty)
   }
 
   func testRefresh_nonEmptyProjectionIsNotLoadedEmpty() async throws {


### PR DESCRIPTION
## Summary
- Show provider/channel receipt refs on the mobile Token Ledger surface even when no completed run ref is projected.
- Keep per-run token totals gated on an actual run ref; receipt refs are labeled as evidence only.
- Add a projection test proving provider receipts do not fabricate `tokenLedgerRunId`.

## Verification
- `swift test --package-path apps/friday-ios --filter 'HomeViewModelTests|MobileProductReadinessContractTests'`
- `swift build --package-path apps/friday-ios`

## Truth label
Improves mobile Token Ledger evidence visibility from already-projected Hub refs. Does not claim per-run token totals without a run ref, provider completion, END-BAR, GO-LIVE, or adoption.