### PR TITLE
feat(ios): surface chat handoff receipts

### DIFF
--- a/apps/friday-ios/Sources/FridayMobileShell/FridayApp.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayApp.swift
@@ -384,13 +384,7 @@ struct RootView: View {
           FridayTokenLedgerScreen(viewModel: homeVM)
         case .shareIntake:
           FridayShareIntakeScreen(viewModel: shareIntakeVM) { receipt in
-            pendingChatLaunchContext = ChatLaunchContext(
-              source: "Share Intake",
-              missionId: receipt.missionId,
-              workItemId: receipt.workItemId,
-              surfaceThreadId: receipt.surfaceThreadId,
-              status: receipt.status,
-              createdOrReady: receipt.createdOrReady)
+            pendingChatLaunchContext = receipt.chatLaunchContext
             chatOpen = true
           }
         case .newSession:

--- a/apps/friday-ios/Sources/FridayMobileShell/FridayNewSessionScreen.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayNewSessionScreen.swift
@@ -85,6 +85,13 @@ struct FridayNewSessionScreen: View {
         }
       }
     case .launched(let summary, let missionId, let workItemId, let surfaceThreadId, let status, let createdOrReady):
+      let context = ChatLaunchContext(
+        source: "New Session",
+        missionId: missionId,
+        workItemId: workItemId,
+        surfaceThreadId: surfaceThreadId,
+        status: status,
+        createdOrReady: createdOrReady)
       GlassPanel {
         VStack(alignment: .leading, spacing: MobileTheme.rowSpacing) {
           cardHeader("Submitted", count: nil)
@@ -102,16 +109,27 @@ struct FridayNewSessionScreen: View {
             .font(.caption2)
             .foregroundStyle(MobileTheme.textSecondary)
             .fixedSize(horizontal: false, vertical: true)
+          Divider().opacity(0.5)
+          HStack(alignment: .top, spacing: 10) {
+            Image(systemName: "arrowshape.turn.up.right.circle")
+              .foregroundStyle(MobileTheme.cyan)
+              .frame(width: 22)
+            VStack(alignment: .leading, spacing: 6) {
+              Text("Friday Chat handoff is armed")
+                .font(.subheadline.weight(.semibold))
+                .foregroundStyle(MobileTheme.textPrimary)
+              Text("The next tap carries these mission refs into Chat as a prefilled governed turn. It still cannot invent missing provider results.")
+                .font(.caption2)
+                .foregroundStyle(MobileTheme.textSecondary)
+                .fixedSize(horizontal: false, vertical: true)
+              RefPill(label: "handoff", ref: context.evidenceRef)
+              RefPill(label: "action", ref: "mobile/newSession/open-chat-loop")
+            }
+          }
           Button {
-            onOpenFridayChat(ChatLaunchContext(
-              source: "New Session",
-              missionId: missionId,
-              workItemId: workItemId,
-              surfaceThreadId: surfaceThreadId,
-              status: status,
-              createdOrReady: createdOrReady))
+            onOpenFridayChat(context)
           } label: {
-            Label("Continue in Chat", systemImage: "bubble.left.and.bubble.right")
+            Label("Continue in Friday Chat", systemImage: "bubble.left.and.bubble.right")
               .frame(maxWidth: .infinity)
           }
           .buttonStyle(.borderedProminent)

--- a/apps/friday-ios/Sources/FridayMobileShell/FridayShareIntakeScreen.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayShareIntakeScreen.swift
@@ -90,10 +90,27 @@ struct FridayShareIntakeScreen: View {
             text: receipt.createdOrReady ? "created_or_ready" : receipt.status,
             bg: MobileTheme.chipDoneBG,
             fg: MobileTheme.chipDoneFG)
+          Divider().opacity(0.5)
+          HStack(alignment: .top, spacing: 10) {
+            Image(systemName: "arrowshape.turn.up.right.circle")
+              .foregroundStyle(MobileTheme.cyan)
+              .frame(width: 22)
+            VStack(alignment: .leading, spacing: 6) {
+              Text("Friday Chat handoff is armed")
+                .font(.subheadline.weight(.semibold))
+                .foregroundStyle(MobileTheme.textPrimary)
+              Text("The next tap carries these share refs into Chat as a prefilled governed turn. Provider results remain unavailable until the live loop returns them.")
+                .font(.caption2)
+                .foregroundStyle(MobileTheme.textSecondary)
+                .fixedSize(horizontal: false, vertical: true)
+              RefPill(label: "handoff", ref: receipt.chatLaunchContext.evidenceRef)
+              RefPill(label: "action", ref: "mobile/share/open-chat-loop")
+            }
+          }
           Button {
             onOpenFridayChat(receipt)
           } label: {
-            Label("Continue in Chat", systemImage: "bubble.left.and.bubble.right")
+            Label("Continue in Friday Chat", systemImage: "bubble.left.and.bubble.right")
               .frame(maxWidth: .infinity)
           }
           .buttonStyle(.borderedProminent)

--- a/apps/friday-ios/Sources/FridayMobileShellCore/FridayChatViewModel.swift
+++ b/apps/friday-ios/Sources/FridayMobileShellCore/FridayChatViewModel.swift
@@ -309,6 +309,10 @@ public struct ChatLaunchContext: Sendable, Equatable {
     lines.append("Use these refs to produce the next owner-visible answer; do not fabricate missing results.")
     return lines.joined(separator: "\n")
   }
+
+  public var evidenceRef: String {
+    "swift://mobile/fridayChat/launch-context/\(missionId)"
+  }
 }
 
 public protocol ChatHistoryStoring {
@@ -886,7 +890,7 @@ public final class FridayChatViewModel: ObservableObject {
       title: "Mission refs",
       detail: "\(context.source) submitted \(context.missionId) / \(workItem). Send the prefilled Chat turn to continue through the governed live loop.",
       truthLabel: context.createdOrReady ? "created_or_ready" : context.status,
-      evidenceRef: "swift://mobile/fridayChat/launch-context/\(context.missionId)",
+      evidenceRef: context.evidenceRef,
       memoryCandidateId: nil,
       memoryPreview: nil)
   }

--- a/apps/friday-ios/Sources/FridayMobileShellCore/ShareIntakeViewModel.swift
+++ b/apps/friday-ios/Sources/FridayMobileShellCore/ShareIntakeViewModel.swift
@@ -8,6 +8,16 @@ public struct ShareIntakeReceipt: Sendable, Equatable {
   public let status: String
   public let createdOrReady: Bool
   public let clarificationQuestions: [String]
+
+  public var chatLaunchContext: ChatLaunchContext {
+    ChatLaunchContext(
+      source: "Share Intake",
+      missionId: missionId,
+      workItemId: workItemId,
+      surfaceThreadId: surfaceThreadId,
+      status: status,
+      createdOrReady: createdOrReady)
+  }
 }
 
 public enum ShareIntakePhase: Sendable, Equatable {

--- a/apps/friday-ios/Tests/FridayMobileShellCoreTests/FridayChatViewModelTests.swift
+++ b/apps/friday-ios/Tests/FridayMobileShellCoreTests/FridayChatViewModelTests.swift
@@ -828,6 +828,9 @@ final class FridayChatViewModelTests: XCTestCase {
     XCTAssertEqual(
       vm.contextCards.first?.evidenceRef,
       "swift://mobile/fridayChat/launch-context/mission-mobile-share-fixed")
+    XCTAssertEqual(
+      context.evidenceRef,
+      "swift://mobile/fridayChat/launch-context/mission-mobile-share-fixed")
     XCTAssertTrue(context.composerPrefill.contains("mission_id=mission-mobile-share-fixed"))
     XCTAssertTrue(context.composerPrefill.contains("work_item_id=work-mobile-share-fixed"))
     XCTAssertTrue(context.composerPrefill.contains("surface_thread_id=surface-mobile-share-fixed"))

--- a/apps/friday-ios/Tests/FridayMobileShellCoreTests/ShareIntakeViewModelTests.swift
+++ b/apps/friday-ios/Tests/FridayMobileShellCoreTests/ShareIntakeViewModelTests.swift
@@ -118,6 +118,19 @@ final class ShareIntakeViewModelTests: XCTestCase {
       status: "ready",
       createdOrReady: true,
       clarificationQuestions: [])))
+    guard case .submitted(let receipt) = vm.phase else {
+      return XCTFail("expected submitted receipt")
+    }
+    XCTAssertEqual(receipt.chatLaunchContext, ChatLaunchContext(
+      source: "Share Intake",
+      missionId: "mission-mobile-share-fixed",
+      workItemId: "work-mobile-share-fixed",
+      surfaceThreadId: "surface-mobile-share-fixed",
+      status: "ready",
+      createdOrReady: true))
+    XCTAssertEqual(
+      receipt.chatLaunchContext.evidenceRef,
+      "swift://mobile/fridayChat/launch-context/mission-mobile-share-fixed")
 
     try writeShareIntakeActionEvidenceIfRequested(request: request)
   }


### PR DESCRIPTION
## Summary
- Surface an explicit Friday Chat handoff block on the New Session and Share Intake success cards.
- Reuse a shared `ChatLaunchContext.evidenceRef` so the source receipt, Chat context card, and UI handoff point at the same refs-only evidence.
- Route Share Intake through the receipt-owned launch context to avoid duplicated field assembly.

## Verification
- `swift test --package-path apps/friday-ios --filter 'ShareIntakeViewModelTests|FridayChatViewModelTests|MobileProductReadinessContractTests'`
- `swift build --package-path apps/friday-ios`

## Truth
This improves the mobile T2 write-receipt -> Friday Chat handoff product loop. It does not claim provider result completion, END-BAR, GO-LIVE, adoption, or real-user device proof.