### PR TITLE
feat(ios): link onboarding to device pairing

### DIFF
--- a/apps/friday-ios/Sources/FridayMobileShell/FridayApp.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayApp.swift
@@ -401,8 +401,11 @@ struct RootView: View {
           FridayHomeScreen(viewModel: homeVM, showPairingProvisioning: true)
         case .providerAuth:
           FridayProviderAuthScreen(viewModel: homeVM)
-        case .missions, .needsMe, .memory, .platform, .activity, .workflows, .onboarding,
-             .settings:
+        case .onboarding:
+          FridayProjectionScreen(destination: destination, viewModel: homeVM) {
+            destination = .pairing
+          }
+        case .missions, .needsMe, .memory, .platform, .activity, .workflows, .settings:
           FridayProjectionScreen(destination: destination, viewModel: homeVM)
         }
       }

--- a/apps/friday-ios/Sources/FridayMobileShell/FridayProjectionScreens.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayProjectionScreens.swift
@@ -92,16 +92,19 @@ private enum ProjectionSurface {
 struct FridayProjectionScreen: View {
   let destination: MobileDestination
   @ObservedObject var viewModel: HomeViewModel
+  var onOpenPairing: () -> Void = {}
   @StateObject private var pushNotifications: PushNotificationReadinessViewModel
 
   @MainActor
   init(
     destination: MobileDestination,
     viewModel: HomeViewModel,
+    onOpenPairing: @escaping () -> Void = {},
     pushNotifications: PushNotificationReadinessViewModel? = nil
   ) {
     self.destination = destination
     self.viewModel = viewModel
+    self.onOpenPairing = onOpenPairing
     _pushNotifications = StateObject(wrappedValue: pushNotifications
       ?? PushNotificationReadinessViewModel(authorizer: SystemPushNotificationAuthorizer()))
   }
@@ -566,6 +569,15 @@ struct FridayProjectionScreen: View {
           value: projection.t3ProvisioningStatus?.paired == true ? "paired in Hub" : "no paired device in Hub",
           healthy: projection.t3ProvisioningStatus?.paired == true)
         t3ProvisioningRows(projection.t3ProvisioningStatus)
+        Button {
+          onOpenPairing()
+        } label: {
+          Label("Open Device Pairing", systemImage: "qrcode.viewfinder")
+        }
+        .buttonStyle(.borderedProminent)
+        .tint(MobileTheme.cyan)
+        .accessibilityIdentifier("friday.onboarding.open-device-pairing")
+        RefPill(label: "action", ref: "mobile/onboarding/open-device-pairing")
         readinessRow(
           title: "Provider auth",
           value: "read-only doctor; never stores provider secrets",

--- a/apps/friday-ios/Sources/FridayMobileShellCore/MobileProductReadinessContract.swift
+++ b/apps/friday-ios/Sources/FridayMobileShellCore/MobileProductReadinessContract.swift
@@ -258,9 +258,9 @@ public enum MobileProductDestinationID: String, CaseIterable, Sendable, Equatabl
       return contract(
         title: "Onboarding",
         systemImage: "sparkles.rectangle.stack",
-        tier: .navigationShell,
-        runtimeActionIds: [],
-        blockers: [.init(.needsNativeSurface, label: "zero-config launch flow")])
+        tier: .readinessOnly,
+        runtimeActionIds: ["mobile/onboarding/open-device-pairing"],
+        blockers: [.init(.needsRuntimeEvidence, label: "zero-config launch app proof")])
     case .settings:
       return contract(
         title: "Settings",

--- a/apps/friday-ios/Tests/FridayMobileShellCoreTests/MobileProductReadinessContractTests.swift
+++ b/apps/friday-ios/Tests/FridayMobileShellCoreTests/MobileProductReadinessContractTests.swift
@@ -69,6 +69,7 @@ func mobileProductContractKeepsApprovalSignatureVisible() {
 func mobileProductContractSeparatesReadinessShellsFromProductLoops() {
   let voice = MobileProductDestinationID.voice.contract
   let workflows = MobileProductDestinationID.workflows.contract
+  let onboarding = MobileProductDestinationID.onboarding.contract
   let provider = MobileProductDestinationID.providerAuth.contract
 
   #expect(voice.tier == .nativeDeviceLoop)
@@ -80,9 +81,14 @@ func mobileProductContractSeparatesReadinessShellsFromProductLoops() {
   ])
   #expect(voice.blockers.contains { $0.kind == .needsRuntimeEvidence })
   #expect(workflows.tier == .navigationShell)
+  #expect(onboarding.tier == .readinessOnly)
+  #expect(onboarding.runtimeActionIds == ["mobile/onboarding/open-device-pairing"])
+  #expect(onboarding.blockers.contains { $0.kind == .needsRuntimeEvidence })
+  #expect(!onboarding.blockers.contains { $0.kind == .needsNativeSurface })
   #expect(provider.tier == .providerWorkspace)
   #expect(!voice.isEndBarReady)
   #expect(!workflows.isEndBarReady)
+  #expect(!onboarding.isEndBarReady)
   #expect(!provider.isEndBarReady)
 }
 


### PR DESCRIPTION
## Summary
- Add a native Onboarding action that opens the existing Device Pairing surface from the live-read readiness card.
- Surface the action ref `mobile/onboarding/open-device-pairing` in the UI.
- Update the mobile product readiness contract so Onboarding is no longer a pure navigation shell, while still requiring runtime evidence before any END-BAR claim.

## Verification
- `swift test --package-path apps/friday-ios --filter 'MobileProductReadinessContractTests'`
- `swift build --package-path apps/friday-ios`

## Truth
This advances the mobile zero-config/onboarding path from shell toward a real native pairing entry. It does not claim PairAck live proof, true-device proof, END-BAR, GO-LIVE, or adoption.