### PR TITLE
feat(clients): surface workflow controls

### DIFF
--- a/apps/friday-ios/Sources/FridayMobileShell/FridayProjectionScreens.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayProjectionScreens.swift
@@ -510,22 +510,41 @@ struct FridayProjectionScreen: View {
   private func workflowCard(_ projection: HomeProjection) -> some View {
     GlassPanel {
       VStack(alignment: .leading, spacing: MobileTheme.rowSpacing) {
-        cardHeader("Workflow", count: nil)
+        cardHeader("Workflow Control", count: projection.workItems.count)
+        Text("Route refs and WorkItem lifecycle controls are rendered from the live Hub projection. Retry/cancel use the governed write seam; this surface still needs real app proof before END-BAR.")
+          .font(.caption)
+          .foregroundStyle(MobileTheme.textSecondary)
+          .fixedSize(horizontal: false, vertical: true)
         if let selected = projection.routeSelected {
           RefPill(label: "selectedRoute", ref: selected)
         }
-        ForEach(projection.routeAlternatives, id: \.self) { alternative in
-          RefPill(label: "alternative", ref: alternative)
+        if !projection.routeAlternatives.isEmpty {
+          VStack(alignment: .leading, spacing: 6) {
+            Text("Route Alternatives")
+              .font(.caption.weight(.semibold))
+              .foregroundStyle(MobileTheme.textSecondary)
+            ForEach(projection.routeAlternatives, id: \.self) { alternative in
+              RefPill(label: "alternative", ref: alternative)
+            }
+          }
+        }
+        HStack(spacing: 6) {
+          RefPill(label: "action", ref: "mobile/workflow/retry")
+          RefPill(label: "action", ref: "mobile/workflow/cancel")
         }
         if projection.workItems.isEmpty {
           emptyText("No workflow work-item refs.")
         } else {
-          ForEach(projection.workItems) { item in
-            workItemRow(item)
+          VStack(alignment: .leading, spacing: 8) {
+            ForEach(projection.workItems) { item in
+              workItemRow(item)
+                .accessibilityIdentifier("friday.workflow.work-item.\(item.id)")
+            }
           }
         }
       }
     }
+    .accessibilityIdentifier("friday.workflow.control-surface")
   }
 
   private func receiptRefsCard(_ projection: HomeProjection) -> some View {

--- a/apps/friday-ios/Sources/FridayMobileShellCore/MobileProductReadinessContract.swift
+++ b/apps/friday-ios/Sources/FridayMobileShellCore/MobileProductReadinessContract.swift
@@ -251,9 +251,9 @@ public enum MobileProductDestinationID: String, CaseIterable, Sendable, Equatabl
       return contract(
         title: "Workflows",
         systemImage: "arrow.triangle.branch",
-        tier: .navigationShell,
-        runtimeActionIds: [],
-        blockers: [.init(.needsNativeSurface, label: "workflow builder surface")])
+        tier: .governedActionGated,
+        runtimeActionIds: ["mobile/workflow/retry", "mobile/workflow/cancel"],
+        blockers: [.init(.needsRuntimeEvidence, label: "workflow retry/cancel app proof")])
     case .onboarding:
       return contract(
         title: "Onboarding",

--- a/apps/friday-ios/Tests/FridayMobileShellCoreTests/MobileProductReadinessContractTests.swift
+++ b/apps/friday-ios/Tests/FridayMobileShellCoreTests/MobileProductReadinessContractTests.swift
@@ -80,7 +80,13 @@ func mobileProductContractSeparatesReadinessShellsFromProductLoops() {
     "mobile/voice/open-chat-loop",
   ])
   #expect(voice.blockers.contains { $0.kind == .needsRuntimeEvidence })
-  #expect(workflows.tier == .navigationShell)
+  #expect(workflows.tier == .governedActionGated)
+  #expect(workflows.runtimeActionIds == [
+    "mobile/workflow/retry",
+    "mobile/workflow/cancel",
+  ])
+  #expect(!workflows.blockers.contains { $0.kind == .needsNativeSurface })
+  #expect(workflows.blockers.contains { $0.kind == .needsRuntimeEvidence })
   #expect(onboarding.tier == .readinessOnly)
   #expect(onboarding.runtimeActionIds == ["mobile/onboarding/open-device-pairing"])
   #expect(onboarding.blockers.contains { $0.kind == .needsRuntimeEvidence })

--- a/apps/macos/FridayHubConsole/Sources/FridayHubConsole/DesktopProjectionScreens.swift
+++ b/apps/macos/FridayHubConsole/Sources/FridayHubConsole/DesktopProjectionScreens.swift
@@ -516,51 +516,74 @@ struct DesktopProjectionScreen: View {
   }
 
   private func workflowStatus(_ snapshot: WorkbenchSnapshot) -> some View {
-    GlassPanel {
-      VStack(alignment: .leading, spacing: HubTheme.rowSpacing) {
-        cardTitle("Workflow Work Items")
-        ForEach(snapshot.workItems) { item in
-          VStack(alignment: .leading, spacing: 6) {
-            HStack {
-              Text(item.title)
-                .font(.system(size: 13, weight: .medium))
-                .foregroundStyle(HubTheme.textPrimary)
-              Spacer()
-              StatusChip(
-                text: item.done ? "done" : "not done",
-                bg: item.done ? HubTheme.chipDoneBG : HubTheme.chipNeutralBG,
-                fg: item.done ? HubTheme.chipDoneFG : HubTheme.chipNeutralFG)
-            }
-            HStack(spacing: 6) {
-              item.state.chip
-              item.owner.chip
-              if item.recoveryKind != "none" {
-                StatusChip(text: item.recoveryKind, bg: HubTheme.chipNeutralBG, fg: HubTheme.chipNeutralFG)
-              }
-            }
-            if !item.blockingReason.isEmpty {
-              Text(item.blockingReason)
-                .font(.system(size: 11))
-                .foregroundStyle(HubTheme.textSecondary)
-                .fixedSize(horizontal: false, vertical: true)
-            }
-            if item.canRetry || item.canCancel {
-              HStack(spacing: 6) {
-                if item.canRetry {
-                  StatusChip(text: "retry available", bg: HubTheme.chipWarnBG, fg: HubTheme.chipWarnFG)
-                }
-                if item.canCancel {
-                  StatusChip(text: "cancel available", bg: HubTheme.chipNeutralBG, fg: HubTheme.chipNeutralFG)
-                }
-              }
-            }
-            if let proofRef = item.proofRef {
-              RefPill(label: "proofRef", ref: proofRef)
-            }
+    VStack(alignment: .leading, spacing: 16) {
+      GlassPanel {
+        VStack(alignment: .leading, spacing: HubTheme.rowSpacing) {
+          HStack {
+            cardTitle("Workflow Canvas")
+            Spacer()
+            snapshot.routeDecision.truthLabel.chip
           }
-          .padding(.vertical, 4)
+          Text("Canvas + inspector view over the live mission route and WorkItem graph. Controls use the governed WorkItem lifecycle write seam; runtime tap proof is still required before END-BAR.")
+            .font(.system(size: 11))
+            .foregroundStyle(HubTheme.textSecondary)
+            .fixedSize(horizontal: false, vertical: true)
+          HStack(alignment: .top, spacing: 12) {
+            VStack(alignment: .leading, spacing: 6) {
+              Text("Route")
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundStyle(HubTheme.textSecondary)
+              RefPill(label: "selectedRoute", ref: snapshot.routeDecision.selectedRoute)
+              ForEach(snapshot.routeDecision.alternatives, id: \.self) { alternative in
+                RefPill(label: "alternative", ref: alternative)
+              }
+            }
+            .frame(maxWidth: .infinity, alignment: .topLeading)
+
+            VStack(alignment: .leading, spacing: 6) {
+              Text("Inspector")
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundStyle(HubTheme.textSecondary)
+              StatusChip(
+                text: "\(snapshot.workItems.count) work items",
+                bg: HubTheme.chipNeutralBG,
+                fg: HubTheme.chipNeutralFG)
+              StatusChip(
+                text: "\(snapshot.attentionWorkItems.count) need attention",
+                bg: snapshot.attentionWorkItems.isEmpty ? HubTheme.chipNeutralBG : HubTheme.chipWarnBG,
+                fg: snapshot.attentionWorkItems.isEmpty ? HubTheme.chipNeutralFG : HubTheme.chipWarnFG)
+              RefPill(label: "action", ref: "desktop/workflow/retry")
+              RefPill(label: "action", ref: "desktop/workflow/cancel")
+            }
+            .frame(maxWidth: .infinity, alignment: .topLeading)
+          }
         }
       }
+      .accessibilityIdentifier("friday.desktop.workflow.canvas")
+
+      GlassPanel {
+        VStack(alignment: .leading, spacing: HubTheme.rowSpacing) {
+          cardTitle("Workflow Work Items")
+          if snapshot.workItems.isEmpty {
+            Text("No workflow work-item refs in this projection.")
+              .font(.system(size: 12))
+              .foregroundStyle(HubTheme.textSecondary)
+          } else {
+            ForEach(snapshot.workItems) { item in
+              WorkItemRow(
+                item: item,
+                isSelected: false,
+                recoveryState: viewModel.workItemStatusStates[item.id] ?? .ready,
+                onRetry: { Task { await viewModel.retryWorkItem(item) } },
+                onCancel: { Task { await viewModel.cancelWorkItem(item) } }
+              ) {
+                viewModel.select(.workItem(id: item.id))
+              }
+            }
+          }
+        }
+      }
+      .accessibilityIdentifier("friday.desktop.workflow.work-items")
     }
   }
 

--- a/apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/DesktopProductReadinessContract.swift
+++ b/apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/DesktopProductReadinessContract.swift
@@ -183,9 +183,9 @@ public enum DesktopProductDestinationID: String, CaseIterable, Sendable, Equatab
       return contract(
         title: "Workflow Builder",
         systemImage: "point.3.connected.trianglepath.dotted",
-        tier: .navigationShell,
-        runtimeActionIds: [],
-        blockers: [.init(.needsNativeSurface, label: "canvas+inspector product surface")])
+        tier: .governedActionGated,
+        runtimeActionIds: ["desktop/workflow/retry", "desktop/workflow/cancel"],
+        blockers: [.init(.needsRuntimeEvidence, label: "workflow canvas retry/cancel proof")])
     case .channels:
       return contract(
         title: "Channels",

--- a/apps/macos/FridayHubConsole/Tests/FridayHubConsoleCoreTests/DesktopProductReadinessContractTests.swift
+++ b/apps/macos/FridayHubConsole/Tests/FridayHubConsoleCoreTests/DesktopProductReadinessContractTests.swift
@@ -63,7 +63,13 @@ func desktopProductContractSeparatesShellsFromWorkbenchLoops() {
   let provider = DesktopProductDestinationID.providerAdmin.contract
 
   #expect(operations.tier == .liveWorkbench)
-  #expect(workflow.tier == .navigationShell)
+  #expect(workflow.tier == .governedActionGated)
+  #expect(workflow.runtimeActionIds == [
+    "desktop/workflow/retry",
+    "desktop/workflow/cancel",
+  ])
+  #expect(!workflow.blockers.contains { $0.kind == .needsNativeSurface })
+  #expect(workflow.blockers.contains { $0.kind == .needsRuntimeEvidence })
   #expect(channels.tier == .navigationShell)
   #expect(provider.tier == .providerAdmin)
   #expect(!operations.isEndBarReady)


### PR DESCRIPTION
## Summary\n- turn mobile Workflows into a governed workflow-control surface with route refs, WorkItem lifecycle action refs, and WorkItem retry/cancel rows\n- turn desktop Workflow Builder into a canvas + inspector projection with governed WorkItem retry/cancel controls\n- update mobile/desktop readiness contracts so workflow is no longer a missing native surface, while keeping runtime-evidence blockers and no END-BAR claim\n\n## Verification\n- swift test --package-path apps/friday-ios --filter 'MobileProductReadinessContractTests|HomeViewModelTests'\n- swift test --package-path apps/macos/FridayHubConsole --filter 'DesktopProductReadinessContractTests|OperationsOverviewViewModelTests'\n- swift build --package-path apps/friday-ios\n- swift build --package-path apps/macos/FridayHubConsole\n\nTruth: this builds product workflow controls over existing governed WorkItem lifecycle seams. It does not claim runtime tap proof, END-BAR, release, adoption, or signature/mint custody.