### PR TITLE
test(mobile): align product readiness actions

### DIFF
--- a/apps/friday-ios/Sources/FridayMobileShellCore/MobileProductReadinessContract.swift
+++ b/apps/friday-ios/Sources/FridayMobileShellCore/MobileProductReadinessContract.swift
@@ -168,14 +168,20 @@ public enum MobileProductDestinationID: String, CaseIterable, Sendable, Equatabl
         title: "Context Passport",
         systemImage: "checklist.checked",
         tier: .liveReadProjection,
-        runtimeActionIds: ["mobile/passport/send"],
+        runtimeActionIds: [
+          "mobile/passport/checklist",
+          "mobile/passport/send",
+        ],
         blockers: [.init(.needsRuntimeEvidence, label: "real app transfer proof")])
     case .tokenLedger:
       return contract(
         title: "Token Ledger",
         systemImage: "chart.bar.doc.horizontal",
         tier: .liveReadProjection,
-        runtimeActionIds: [],
+        runtimeActionIds: [
+          "mobile/tokenLedger/refresh",
+          "mobile/tokenLedger/run-readback",
+        ],
         blockers: [.init(.needsRuntimeEvidence, label: "run-backed ledger proof")])
     case .shareIntake:
       return contract(
@@ -238,8 +244,14 @@ public enum MobileProductDestinationID: String, CaseIterable, Sendable, Equatabl
         title: "Provider Workspace",
         systemImage: "person.badge.key",
         tier: .providerWorkspace,
-        runtimeActionIds: [],
-        blockers: [.init(.needsProviderCredential, label: "all selected provider routes")])
+        runtimeActionIds: [
+          "mobile/providerAuth/check",
+          "mobile/providerAuth/provider-workspace",
+        ],
+        blockers: [
+          .init(.needsProviderCredential, label: "all selected provider routes"),
+          .init(.needsRuntimeEvidence, label: "provider doctor app proof"),
+        ])
     case .activity:
       return contract(
         title: "Activity",

--- a/apps/friday-ios/Tests/FridayMobileShellCoreTests/MobileProductReadinessContractTests.swift
+++ b/apps/friday-ios/Tests/FridayMobileShellCoreTests/MobileProductReadinessContractTests.swift
@@ -66,6 +66,31 @@ func mobileProductContractKeepsApprovalSignatureVisible() {
 }
 
 @Test
+func mobileProductContractSurfacesBuiltReadOnlyProductActions() {
+  let passport = MobileProductDestinationID.contextPassport.contract
+  let tokenLedger = MobileProductDestinationID.tokenLedger.contract
+  let provider = MobileProductDestinationID.providerAuth.contract
+
+  #expect(passport.runtimeActionIds == [
+    "mobile/passport/checklist",
+    "mobile/passport/send",
+  ])
+  #expect(tokenLedger.runtimeActionIds == [
+    "mobile/tokenLedger/refresh",
+    "mobile/tokenLedger/run-readback",
+  ])
+  #expect(provider.runtimeActionIds == [
+    "mobile/providerAuth/check",
+    "mobile/providerAuth/provider-workspace",
+  ])
+  #expect(provider.blockers.contains { $0.kind == .needsProviderCredential })
+  #expect(provider.blockers.contains { $0.kind == .needsRuntimeEvidence })
+  #expect(!passport.isEndBarReady)
+  #expect(!tokenLedger.isEndBarReady)
+  #expect(!provider.isEndBarReady)
+}
+
+@Test
 func mobileProductContractSeparatesReadinessShellsFromProductLoops() {
   let voice = MobileProductDestinationID.voice.contract
   let workflows = MobileProductDestinationID.workflows.contract


### PR DESCRIPTION
## Summary\n- align MobileProductReadinessContract with already-built mobile product actions for Context Passport, Token Ledger, and Provider Workspace\n- keep runtime evidence and provider credential blockers visible so these surfaces are not counted as END-BAR ready\n- add contract coverage for the built action IDs to prevent future drift\n\n## Verification\n- swift test --package-path apps/friday-ios --filter 'MobileProductReadinessContractTests|HomeViewModelTests'\n- swift build --package-path apps/friday-ios\n- git diff --check\n\n## Truth\n- This is readiness/action contract alignment for existing mobile surfaces.\n- It does not claim runtime tap proof, END-BAR, release, adoption, or operator signature/mint custody.