### PR TITLE
test(ui): add device proof shortlist runner

### DIFF
--- a/scripts/ops/friday-ui-device-proof-shortlist-runner.sh
+++ b/scripts/ops/friday-ui-device-proof-shortlist-runner.sh
@@ -1,0 +1,375 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat >&2 <<'EOF'
+usage:
+  scripts/ops/friday-ui-device-proof-shortlist-runner.sh --out-dir /abs/run-dir
+    [--shared-id mission_ui_device_...]
+    [--backend-live-proof /abs/backend-proof.json]
+    [--objective-coverage /abs/objective-coverage.json]
+    [--channel-live-proof /abs/channel-live-proof.json]
+    [--channel-capture /abs/channel-capture.json]
+    [--timeline-capture /abs/timeline-capture.json]
+    [--same-run-events /abs/events.jsonl ...]
+    [--runtime-evidence-dir /abs/evidence-dir ...]
+    [--extra-action-runtime-evidence /abs/action-runtime-evidence.json ...]
+
+Runs the already-proven mobile+desktop live write/read capture bundle, then
+assembles the strongest honest UI/device readiness report possible from supplied
+real evidence. It never invents channel, timeline, stress, or negative-control
+observations.
+
+Truth:
+  - mobile+desktop live write/read capture is real same-mission runtime evidence.
+  - channel/timeline/stress proof is only counted when explicit real artifacts
+    are supplied.
+  - without the full evidence set, output remains partial and not END-BAR.
+EOF
+}
+
+die() {
+  echo "FATAL: $*" >&2
+  exit 2
+}
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+out_dir=""
+shared_id="${FRIDAY_MISSION_SPINE_UI_PROOF_SHARED_ID:-}"
+backend_live_proof="${FRIDAY_UI_DEVICE_BACKEND_LIVE_PROOF:-}"
+objective_coverage="${FRIDAY_UI_DEVICE_OBJECTIVE_COVERAGE:-}"
+channel_live_proof="${FRIDAY_UI_DEVICE_CHANNEL_LIVE_PROOF:-}"
+channel_capture=""
+timeline_capture=""
+same_run_events=()
+runtime_evidence_dirs=()
+extra_action_runtime_evidence=()
+
+if [ -n "${FRIDAY_DESIGN_ACTION_RUNTIME_EVIDENCE_DIRS:-}" ]; then
+  IFS=':' read -r -a runtime_evidence_dirs <<<"${FRIDAY_DESIGN_ACTION_RUNTIME_EVIDENCE_DIRS}"
+fi
+if [ -n "${FRIDAY_EXTRA_ACTION_RUNTIME_EVIDENCE:-}" ]; then
+  IFS=':' read -r -a extra_action_runtime_evidence <<<"${FRIDAY_EXTRA_ACTION_RUNTIME_EVIDENCE}"
+fi
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --out-dir)
+      [ "$#" -ge 2 ] || die "--out-dir requires a value"
+      out_dir="$2"
+      shift 2
+      ;;
+    --out-dir=*)
+      out_dir="${1#--out-dir=}"
+      shift
+      ;;
+    --shared-id)
+      [ "$#" -ge 2 ] || die "--shared-id requires a value"
+      shared_id="$2"
+      shift 2
+      ;;
+    --shared-id=*)
+      shared_id="${1#--shared-id=}"
+      shift
+      ;;
+    --backend-live-proof)
+      [ "$#" -ge 2 ] || die "--backend-live-proof requires a value"
+      backend_live_proof="$2"
+      shift 2
+      ;;
+    --backend-live-proof=*)
+      backend_live_proof="${1#--backend-live-proof=}"
+      shift
+      ;;
+    --objective-coverage)
+      [ "$#" -ge 2 ] || die "--objective-coverage requires a value"
+      objective_coverage="$2"
+      shift 2
+      ;;
+    --objective-coverage=*)
+      objective_coverage="${1#--objective-coverage=}"
+      shift
+      ;;
+    --channel-live-proof)
+      [ "$#" -ge 2 ] || die "--channel-live-proof requires a value"
+      channel_live_proof="$2"
+      shift 2
+      ;;
+    --channel-live-proof=*)
+      channel_live_proof="${1#--channel-live-proof=}"
+      shift
+      ;;
+    --channel-capture)
+      [ "$#" -ge 2 ] || die "--channel-capture requires a value"
+      channel_capture="$2"
+      shift 2
+      ;;
+    --channel-capture=*)
+      channel_capture="${1#--channel-capture=}"
+      shift
+      ;;
+    --timeline-capture)
+      [ "$#" -ge 2 ] || die "--timeline-capture requires a value"
+      timeline_capture="$2"
+      shift 2
+      ;;
+    --timeline-capture=*)
+      timeline_capture="${1#--timeline-capture=}"
+      shift
+      ;;
+    --same-run-events)
+      [ "$#" -ge 2 ] || die "--same-run-events requires a value"
+      same_run_events+=("$2")
+      shift 2
+      ;;
+    --same-run-events=*)
+      same_run_events+=("${1#--same-run-events=}")
+      shift
+      ;;
+    --runtime-evidence-dir)
+      [ "$#" -ge 2 ] || die "--runtime-evidence-dir requires a value"
+      runtime_evidence_dirs+=("$2")
+      shift 2
+      ;;
+    --runtime-evidence-dir=*)
+      runtime_evidence_dirs+=("${1#--runtime-evidence-dir=}")
+      shift
+      ;;
+    --extra-action-runtime-evidence)
+      [ "$#" -ge 2 ] || die "--extra-action-runtime-evidence requires a value"
+      extra_action_runtime_evidence+=("$2")
+      shift 2
+      ;;
+    --extra-action-runtime-evidence=*)
+      extra_action_runtime_evidence+=("${1#--extra-action-runtime-evidence=}")
+      shift
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      die "unknown argument: $1"
+      ;;
+  esac
+done
+
+[ -n "${out_dir}" ] || die "missing --out-dir"
+case "${out_dir}" in
+  /*) ;;
+  *) die "--out-dir must be absolute" ;;
+esac
+
+require_abs_if_set() {
+  local label="$1"
+  local value="$2"
+  if [ -n "${value}" ]; then
+    case "${value}" in
+      /*) ;;
+      *) die "${label} must be absolute: ${value}" ;;
+    esac
+  fi
+}
+
+require_file_if_set() {
+  local label="$1"
+  local value="$2"
+  require_abs_if_set "${label}" "${value}"
+  if [ -n "${value}" ] && [ ! -s "${value}" ]; then
+    die "${label} missing or empty: ${value}"
+  fi
+}
+
+require_file_if_set "--backend-live-proof" "${backend_live_proof}"
+require_file_if_set "--objective-coverage" "${objective_coverage}"
+require_file_if_set "--channel-live-proof" "${channel_live_proof}"
+require_file_if_set "--channel-capture" "${channel_capture}"
+require_file_if_set "--timeline-capture" "${timeline_capture}"
+set +u
+for path in "${same_run_events[@]}" "${runtime_evidence_dirs[@]}" "${extra_action_runtime_evidence[@]}"; do
+  require_abs_if_set "input path" "${path}"
+done
+set -u
+
+mkdir -p "${out_dir}"
+capture_root="${out_dir}/live-write-read"
+evidence_dir="${out_dir}/evidence"
+summary_out="${out_dir}/ui-device-shortlist-summary.json"
+product_closure_out="${out_dir}/product-closure-readiness.json"
+readiness_out="${out_dir}/ui-device-proof-readiness.json"
+gap_out="${out_dir}/ui-device-proof-gap-report.json"
+
+capture_args=(
+  "${repo_root}/scripts/ops/friday-ui-device-live-write-read-capture-bundle.sh"
+  "--out-dir" "${capture_root}"
+)
+if [ -n "${shared_id}" ]; then
+  capture_args+=("--shared-id" "${shared_id}")
+fi
+set +u
+for path in "${extra_action_runtime_evidence[@]}"; do
+  [ -n "${path}" ] || continue
+  capture_args+=("--extra-action-runtime-evidence" "${path}")
+done
+set -u
+
+echo "Friday UI/device proof shortlist runner starting."
+echo "out_dir=${out_dir}"
+echo "truth=ui_device_shortlist_runner_partial_until_full_real_evidence"
+bash "${capture_args[@]}"
+
+bundle_dir="${capture_root}/bundle"
+bundle_index="${bundle_dir}/live-write-read-bundle-index.json"
+mobile_capture="${bundle_dir}/mobile/ios-live-write-read-proof.json"
+desktop_capture="${bundle_dir}/desktop/macos-live-write-read-proof.json"
+combined_events="${bundle_dir}/mobile-desktop-live-write-read-events.jsonl"
+
+event_inputs=("${combined_events}")
+channel_events=""
+if [ -n "${channel_live_proof}" ] || [ -n "${channel_capture}" ]; then
+  [ -n "${channel_live_proof}" ] || die "--channel-live-proof is required with --channel-capture"
+  [ -n "${channel_capture}" ] || die "--channel-capture is required with --channel-live-proof"
+  mission_id="$(node -e 'const fs=require("fs"); const j=JSON.parse(fs.readFileSync(process.argv[1],"utf8")); console.log(j.missionId || "")' "${bundle_index}")"
+  channel_events="${out_dir}/channel-events.jsonl"
+  node "${repo_root}/scripts/ops/friday-channel-proof-events.mjs" \
+    "--mission-id=${mission_id}" \
+    "--channel-live-proof=${channel_live_proof}" \
+    "--channel-capture=${channel_capture}" \
+    "--out=${channel_events}" \
+    --require-ready
+  event_inputs+=("${channel_events}")
+fi
+set +u
+for path in "${same_run_events[@]}"; do
+  [ -n "${path}" ] || continue
+  event_inputs+=("${path}")
+done
+set -u
+
+capture_dir_status="skipped_missing_channel_or_timeline"
+if [ -n "${channel_capture}" ] && [ -n "${timeline_capture}" ]; then
+  mission_id="$(node -e 'const fs=require("fs"); const j=JSON.parse(fs.readFileSync(process.argv[1],"utf8")); console.log(j.missionId || "")' "${bundle_index}")"
+  capture_dir_args=(
+    "${repo_root}/scripts/ops/friday-ui-device-capture-dir.mjs"
+    "--mission-id=${mission_id}"
+    "--out-dir=${evidence_dir}"
+    "--mobile=${mobile_capture}"
+    "--desktop=${desktop_capture}"
+    "--channel=${channel_capture}"
+    "--timeline=${timeline_capture}"
+    "--require-ready"
+  )
+  for path in "${event_inputs[@]}"; do
+    capture_dir_args+=("--events=${path}")
+  done
+  node "${capture_dir_args[@]}"
+  capture_dir_status="ready"
+else
+  echo "capture_dir=skipped_missing_channel_or_timeline"
+fi
+
+closure_args=(
+  "${repo_root}/scripts/ops/friday-uiux-product-closure-readiness.mjs"
+  "--runtime-evidence-dir=${bundle_dir}"
+  "--out=${product_closure_out}"
+)
+set +u
+for dir in "${runtime_evidence_dirs[@]}"; do
+  [ -n "${dir}" ] || continue
+  closure_args+=("--runtime-evidence-dir=${dir}")
+done
+set -u
+if [ "${capture_dir_status}" = "ready" ]; then
+  closure_args+=("--evidence-dir=${evidence_dir}")
+fi
+node "${closure_args[@]}"
+
+readiness_args=("${repo_root}/scripts/ops/friday-ui-device-proof-readiness.sh")
+if [ "${capture_dir_status}" = "ready" ]; then
+  readiness_args+=("--evidence-dir" "${evidence_dir}")
+fi
+if [ -n "${backend_live_proof}" ]; then
+  readiness_args+=("--backend-live-proof" "${backend_live_proof}")
+fi
+if [ -n "${channel_live_proof}" ]; then
+  readiness_args+=("--channel-live-proof" "${channel_live_proof}")
+fi
+if [ -n "${objective_coverage}" ]; then
+  readiness_args+=("--objective-coverage" "${objective_coverage}")
+fi
+FRIDAY_DESIGN_ACTION_RUNTIME_EVIDENCE_DIRS="${bundle_dir}" bash "${readiness_args[@]}" >"${readiness_out}"
+
+gap_status="skipped_missing_channel_or_timeline"
+if [ -n "${channel_capture}" ] && [ -n "${timeline_capture}" ]; then
+  mission_id="$(node -e 'const fs=require("fs"); const j=JSON.parse(fs.readFileSync(process.argv[1],"utf8")); console.log(j.missionId || "")' "${bundle_index}")"
+  gap_args=(
+    "${repo_root}/scripts/ops/friday-ui-device-proof-gap-report.mjs"
+    "--mission-id=${mission_id}"
+    "--events=${evidence_dir}/same-run-events.normalized.jsonl"
+    "--mobile=${evidence_dir}/mobile.json"
+    "--desktop=${evidence_dir}/desktop.json"
+    "--channel=${evidence_dir}/channel.json"
+    "--timeline=${evidence_dir}/timeline.json"
+    "--manifest=${evidence_dir}/observations-manifest.json"
+    "--out=${gap_out}"
+  )
+  if [ -n "${backend_live_proof}" ]; then
+    gap_args+=("--backend-live-proof=${backend_live_proof}")
+  fi
+  if [ -n "${channel_live_proof}" ]; then
+    gap_args+=("--channel-live-proof=${channel_live_proof}")
+  fi
+  if [ -n "${objective_coverage}" ]; then
+    gap_args+=("--objective-coverage=${objective_coverage}")
+  fi
+  node "${gap_args[@]}" || true
+  gap_status="written"
+fi
+
+node - "${summary_out}" "${bundle_index}" "${product_closure_out}" "${readiness_out}" "${capture_dir_status}" "${gap_status}" <<'NODE'
+const fs = require("node:fs");
+const [summaryOut, bundleIndexPath, productClosurePath, readinessPath, captureDirStatus, gapStatus] = process.argv.slice(2);
+function parseJsonSuffix(text) {
+  const trimmed = String(text || "").trim();
+  if (!trimmed) throw new Error("empty JSON input");
+  try {
+    return JSON.parse(trimmed);
+  } catch {
+    // The readiness wrapper prints self-test lines before its final JSON object.
+  }
+  const starts = [];
+  for (let index = 0; index < trimmed.length; index += 1) {
+    if (trimmed[index] === "{") starts.push(index);
+  }
+  for (const start of starts.reverse()) {
+    try {
+      return JSON.parse(trimmed.slice(start));
+    } catch {
+      // Try the next earlier object start.
+    }
+  }
+  throw new Error("no parseable JSON object suffix");
+}
+const readJson = (path) => parseJsonSuffix(fs.readFileSync(path, "utf8"));
+const bundle = readJson(bundleIndexPath);
+const closure = readJson(productClosurePath);
+const readiness = readJson(readinessPath);
+const summary = {
+  truth: "ui_device_shortlist_runner_summary_not_endbar_not_adoption",
+  status: readiness.status === "pass" ? "strict_ui_device_ready" : "partial_ready",
+  missionId: bundle.missionId || null,
+  captures: bundle.captures || {},
+  captureDirStatus,
+  gapStatus,
+  productClosureStatus: closure.status,
+  uiDeviceProofReadiness: closure.stages?.uiDeviceProofReadiness || null,
+  readinessStatus: readiness.status,
+  readinessBlockers: readiness.blockers || [],
+  fullProofGaps: bundle.fullProofGaps || [],
+  caveat: "Runner output is END-BAR only if strict UI/device readiness passes with real channel, timeline, stress, and negative-control evidence. Partial mobile+desktop live write/read capture is not enough.",
+};
+fs.writeFileSync(summaryOut, `${JSON.stringify(summary, null, 2)}\n`);
+console.log(JSON.stringify(summary, null, 2));
+NODE
+
+echo "summary=${summary_out}"


### PR DESCRIPTION
## Summary
- Add a one-command UI/device proof shortlist runner that reuses existing mobile+desktop live write/read capture, product-closure readiness, UI/device readiness, channel event bridge, capture-dir, and gap-report tooling.
- The runner produces a structured summary and remains partial unless real channel, timeline, stress, and negative-control evidence are supplied.
- It does not synthesize observations or claim END-BAR/adoption from mobile+desktop capture alone.

## Validation
- `bash -n scripts/ops/friday-ui-device-proof-shortlist-runner.sh`
- `shellcheck scripts/ops/friday-ui-device-proof-shortlist-runner.sh`
- `git diff --check`
- Ran the runner with existing backend/objective proof and action evidence inputs. It produced `partial_ready` with same-mission mobile+desktop live write/read captures and the expected blocker: missing channel/timeline/stress/negative-control UI/device evidence.

## Truth
- This is an orchestration/testing utility only.
- Output is END-BAR only when strict UI/device readiness passes with real evidence inputs.
- Current autonomous run remains `partial_ready`, not product complete.