### PR TITLE
test(ui): harvest device proof evidence

### DIFF
--- a/scripts/ops/friday-ui-device-proof-evidence-harvest.mjs
+++ b/scripts/ops/friday-ui-device-proof-evidence-harvest.mjs
@@ -1,0 +1,266 @@
+#!/usr/bin/env node
+
+import { readdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { basename, dirname, isAbsolute, join, resolve } from "node:path";
+import { mkdirSync } from "node:fs";
+
+const args = process.argv.slice(2);
+
+function usage() {
+  console.error(`usage:
+  node scripts/ops/friday-ui-device-proof-evidence-harvest.mjs \\
+    --mission-id=mission_... \\
+    --search-dir=/abs/artifacts [--search-dir=/abs/other-artifacts ...] \\
+    [--out=/abs/harvest.json] [--require-ready]
+
+Truth: scans existing artifact files and reports which ones are eligible inputs
+for the strict UI/device proof pipeline. It does not create proof rows, does not
+synthesize observations, and does not make old or cross-mission captures count.`);
+}
+
+function arg(name) {
+  const prefix = `--${name}=`;
+  return args.find((value) => value.startsWith(prefix))?.slice(prefix.length) || "";
+}
+
+function argsAll(name) {
+  const prefix = `--${name}=`;
+  const values = [];
+  for (let index = 0; index < args.length; index += 1) {
+    const value = args[index];
+    if (value.startsWith(prefix)) {
+      values.push(value.slice(prefix.length));
+    } else if (value === `--${name}` && args[index + 1]) {
+      values.push(args[index + 1]);
+      index += 1;
+    }
+  }
+  return values;
+}
+
+if (args.includes("--help") || args.includes("-h")) {
+  usage();
+  process.exit(0);
+}
+
+const missionId = arg("mission-id");
+const searchDirs = argsAll("search-dir");
+const out = arg("out");
+const requireReady = args.includes("--require-ready");
+const blockers = [];
+
+function block(code, detail) {
+  blockers.push({ code, detail });
+}
+
+function abs(path) {
+  return isAbsolute(path) ? path : resolve(path);
+}
+
+function readJson(path) {
+  try {
+    const stats = statSync(path);
+    if (!stats.isFile() || stats.size > 5 * 1024 * 1024) return null;
+    return JSON.parse(readFileSync(path, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+function jsonMission(value) {
+  if (!value || typeof value !== "object") return "";
+  const candidates = [
+    value.missionId,
+    value.mission_id,
+    value.mission?.mission_id,
+    value.mission?.id,
+    value.workItem?.mission_id,
+  ];
+  for (const candidate of candidates) {
+    if (typeof candidate === "string" && candidate.trim()) return candidate.trim();
+  }
+  return "";
+}
+
+function fileKind(path, json) {
+  const lower = path.toLowerCase();
+  const name = basename(lower);
+  if (name.endsWith(".jsonl") && (name.includes("event") || name.includes("same-run"))) return "events";
+  if (name === "observations-manifest.json") return "manifest";
+  if (json?.proof === "mission_spine_backend_api_live_pressure") return "backendLiveProof";
+  if (json?.proof === "mission_spine_channel_live_proof") return "channelLiveProof";
+  if (Array.isArray(json?.requirements) || String(json?.remaining_requirement || "").includes("UI or device consumption")) return "objectiveCoverage";
+  if (name === "ios-live-write-read-proof.json" || name === "mobile.json") return "mobile";
+  if (name === "macos-live-write-read-proof.json" || name === "desktop.json") return "desktop";
+  if (name === "timeline-capture.json" || name === "timeline.json" || name === "timeline.trace" || name === "old-timeline-db.json") return "timeline";
+  if (name === "channel-capture.json" || name === "channel.json" || name === "channel.log" || name === "channel.trace") return "channel";
+  if (name.startsWith("screenshot ") && name.endsWith(".png")) return "screenshot";
+  return "";
+}
+
+function shouldReject(path, json, kind) {
+  const truth = String(json?.truth || json?.truth_label || "");
+  const foundMission = jsonMission(json);
+  const reasons = [];
+  if (foundMission && foundMission !== missionId) reasons.push(`mission_mismatch:${foundMission}`);
+  if (truth.includes("synthetic")) reasons.push("synthetic_truth_label");
+  if (truth.includes("partial_not_mission_spine_ui_device_proof") && kind !== "timeline") {
+    reasons.push("explicit_partial_non_ui_device_truth_label");
+  }
+  if (kind === "timeline" && truth.includes("partial_not_mission_spine_ui_device_proof")) {
+    reasons.push("timeline_partial_only");
+  }
+  if (kind === "screenshot") reasons.push("screenshot_only_not_action_evidence");
+  return reasons;
+}
+
+function jsonlRejectReasons(path) {
+  const reasons = [];
+  let rows = [];
+  try {
+    rows = readFileSync(path, "utf8")
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter(Boolean)
+      .map((line) => JSON.parse(line));
+  } catch {
+    return ["events_unreadable_or_invalid_jsonl"];
+  }
+  if (rows.length === 0) return ["events_empty"];
+  const missions = new Set(rows.map((row) => typeof row?.mission_id === "string" ? row.mission_id.trim() : "").filter(Boolean));
+  if (missions.size === 0) return ["events_missing_mission_id"];
+  if (missions.size !== 1 || !missions.has(missionId)) return [`events_mission_mismatch:${[...missions].sort().join(",")}`];
+  return reasons;
+}
+
+function walk(dir, files = []) {
+  let entries = [];
+  try {
+    entries = readdirSync(dir, { withFileTypes: true });
+  } catch {
+    block("search_dir_unreadable", dir);
+    return files;
+  }
+  for (const entry of entries) {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if ([".git", "node_modules", ".build", "DerivedData"].includes(entry.name)) continue;
+      walk(path, files);
+    } else if (entry.isFile()) {
+      files.push(path);
+    }
+  }
+  return files;
+}
+
+if (!missionId || !/^[A-Za-z0-9][A-Za-z0-9._:-]*$/.test(missionId) || !missionId.toLowerCase().includes("mission")) {
+  block("mission_id_unexpected_shape", missionId || "<missing>");
+}
+if (searchDirs.length === 0) block("missing_search_dir", "supply at least one --search-dir");
+
+const candidates = [];
+for (const input of searchDirs) {
+  const dir = abs(input);
+  let stats = null;
+  try {
+    stats = statSync(dir);
+  } catch {
+    block("search_dir_missing", dir);
+    continue;
+  }
+  if (!stats.isDirectory()) {
+    block("search_dir_not_directory", dir);
+    continue;
+  }
+  for (const path of walk(dir)) {
+    const json = path.endsWith(".json") ? readJson(path) : null;
+    const kind = fileKind(path, json);
+    if (!kind) continue;
+    const rejectReasons = shouldReject(path, json, kind);
+    if (kind === "events") rejectReasons.push(...jsonlRejectReasons(path));
+    candidates.push({
+      kind,
+      path,
+      missionId: jsonMission(json) || null,
+      truth: typeof json?.truth === "string" ? json.truth : typeof json?.truth_label === "string" ? json.truth_label : null,
+      eligible: rejectReasons.length === 0,
+      rejectReasons,
+    });
+  }
+}
+
+function firstEligible(kind) {
+  return candidates.find((candidate) => candidate.kind === kind && candidate.eligible)?.path || "";
+}
+
+const selected = {
+  mobile: firstEligible("mobile"),
+  desktop: firstEligible("desktop"),
+  channel: firstEligible("channel"),
+  timeline: firstEligible("timeline"),
+  manifest: firstEligible("manifest"),
+  events: candidates.filter((candidate) => candidate.kind === "events" && candidate.eligible).map((candidate) => candidate.path),
+  backendLiveProof: firstEligible("backendLiveProof"),
+  channelLiveProof: firstEligible("channelLiveProof"),
+  objectiveCoverage: firstEligible("objectiveCoverage"),
+};
+
+for (const role of ["mobile", "desktop", "channel", "timeline"]) {
+  if (!selected[role]) block("missing_eligible_capture", role);
+}
+if (!selected.manifest && selected.events.length === 0) {
+  block("missing_manifest_or_events", "need observations-manifest.json or same-run event jsonl");
+}
+
+const captureDirCommand = selected.mobile && selected.desktop && selected.channel && selected.timeline
+  ? [
+      "node scripts/ops/friday-ui-device-capture-dir.mjs",
+      `--mission-id=${missionId}`,
+      "--out-dir=/abs/evidence-dir",
+      `--mobile=${selected.mobile}`,
+      `--desktop=${selected.desktop}`,
+      `--channel=${selected.channel}`,
+      `--timeline=${selected.timeline}`,
+      selected.manifest ? `--observations-manifest=${selected.manifest}` : "",
+      ...selected.events.map((path) => `--events=${path}`),
+      "--require-ready",
+    ].filter(Boolean).join(" \\\n  ")
+  : null;
+
+const proofRunnerCommand = [
+  "scripts/ops/friday-ui-device-proof-shortlist-runner.sh",
+  "--out-dir /abs/ui-device-proof-run",
+  selected.backendLiveProof ? `--backend-live-proof ${selected.backendLiveProof}` : "",
+  selected.objectiveCoverage ? `--objective-coverage ${selected.objectiveCoverage}` : "",
+  selected.channelLiveProof ? `--channel-live-proof ${selected.channelLiveProof}` : "",
+  selected.channel ? `--channel-capture ${selected.channel}` : "",
+  selected.timeline ? `--timeline-capture ${selected.timeline}` : "",
+  ...selected.events.map((path) => `--same-run-events ${path}`),
+].filter(Boolean).join(" \\\n  ");
+
+const result = {
+  truth: "ui_device_proof_evidence_harvest_not_proof_not_endbar",
+  status: blockers.length === 0 ? "ready_for_strict_pipeline" : "partial",
+  missionId,
+  searched: searchDirs.map(abs),
+  selected,
+  counts: {
+    candidates: candidates.length,
+    eligible: candidates.filter((candidate) => candidate.eligible).length,
+    rejected: candidates.filter((candidate) => !candidate.eligible).length,
+  },
+  rejected: candidates.filter((candidate) => !candidate.eligible),
+  captureDirCommand,
+  proofRunnerCommand,
+  blockers,
+  caveat: "Harvest only. Run the emitted strict pipeline commands and gates before claiming UI/device proof, END-BAR, or release readiness.",
+};
+
+if (out) {
+  const resolved = abs(out);
+  mkdirSync(dirname(resolved), { recursive: true });
+  writeFileSync(resolved, `${JSON.stringify(result, null, 2)}\n`);
+}
+
+console.log(JSON.stringify(result, null, 2));
+process.exit(blockers.length === 0 || !requireReady ? 0 : 2);

--- a/test/unit/qa/friday-ui-device-proof-evidence-harvest-cli.test.ts
+++ b/test/unit/qa/friday-ui-device-proof-evidence-harvest-cli.test.ts
@@ -1,0 +1,110 @@
+import { execFileSync, spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const script = "scripts/ops/friday-ui-device-proof-evidence-harvest.mjs";
+const missionId = "mission_ui_device_harvest_cli";
+
+function writeJson(path: string, value: unknown) {
+  mkdirSync(path.slice(0, path.lastIndexOf("/")), { recursive: true });
+  writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function writeArtifacts(dir: string) {
+  const mobile = join(dir, "mobile", "ios-live-write-read-proof.json");
+  const desktop = join(dir, "desktop", "macos-live-write-read-proof.json");
+  const channel = join(dir, "channel-capture.json");
+  const timeline = join(dir, "timeline-capture.json");
+  const events = join(dir, "same-run-events.jsonl");
+  const backend = join(dir, "backend-live-proof.json");
+  const objective = join(dir, "objective-coverage.json");
+  const stale = join(dir, "old-timeline-db.json");
+  writeJson(mobile, { missionId, truth: "ios_mobile_live_write_read_roundtrip_proof_not_ui_device_proof" });
+  writeJson(desktop, { missionId, truth: "macos_live_write_read_roundtrip_proof_not_ui_device_proof" });
+  writeJson(channel, { missionId, truth: "real_channel_capture_not_proof" });
+  writeJson(timeline, { missionId, truth: "real_timeline_capture_not_proof" });
+  writeFileSync(events, `${JSON.stringify({ surface: "mobile", event: "mission_intake_submitted", mission_id: missionId, evidence_ref: mobile })}\n`);
+  writeJson(backend, {
+    proof: "mission_spine_backend_api_live_pressure",
+    status: "passed",
+    remaining_requirement: "real UI/device consumption evidence still required",
+  });
+  writeJson(objective, {
+    remaining_requirement: "UI or device consumption must still pass",
+    requirements: [{ required_gate: "scripts/mission-spine-ui-device-proof-gate.sh" }],
+  });
+  writeJson(stale, {
+    missionId,
+    truth: "real_db_read_only_partial_not_mission_spine_ui_device_proof",
+  });
+  writeJson(join(dir, "other-mission-channel.json"), {
+    missionId: "mission_elsewhere",
+    truth: "real_channel_capture_not_proof",
+  });
+  writeFileSync(join(dir, "Screenshot 2026-06-26.png"), "not proof\n");
+  return { mobile, desktop, channel, timeline, events, backend, objective, stale };
+}
+
+describe("friday-ui-device-proof-evidence-harvest", () => {
+  it("selects same-mission eligible artifacts and emits strict pipeline commands", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "friday-ui-harvest-"));
+    try {
+      const artifacts = writeArtifacts(tempDir);
+      const out = join(tempDir, "harvest.json");
+      const stdout = execFileSync("node", [
+        script,
+        `--mission-id=${missionId}`,
+        `--search-dir=${tempDir}`,
+        `--out=${out}`,
+        "--require-ready",
+      ], { cwd: process.cwd(), encoding: "utf8" });
+      const result = JSON.parse(stdout) as {
+        status?: string;
+        selected?: Record<string, string | string[]>;
+        captureDirCommand?: string;
+        proofRunnerCommand?: string;
+        rejected?: Array<{ path?: string; rejectReasons?: string[] }>;
+      };
+      expect(result.status).toBe("ready_for_strict_pipeline");
+      expect(result.selected?.mobile).toBe(artifacts.mobile);
+      expect(result.selected?.desktop).toBe(artifacts.desktop);
+      expect(result.selected?.channel).toBe(artifacts.channel);
+      expect(result.selected?.timeline).toBe(artifacts.timeline);
+      expect(result.selected?.backendLiveProof).toBe(artifacts.backend);
+      expect(result.selected?.objectiveCoverage).toBe(artifacts.objective);
+      expect(result.captureDirCommand).toContain("friday-ui-device-capture-dir.mjs");
+      expect(result.captureDirCommand).toContain(`--events=${artifacts.events}`);
+      expect(result.proofRunnerCommand).toContain("friday-ui-device-proof-shortlist-runner.sh");
+      expect(result.rejected).toContainEqual(expect.objectContaining({
+        path: artifacts.stale,
+        rejectReasons: expect.arrayContaining(["timeline_partial_only"]),
+      }));
+      expect(JSON.parse(readFileSync(out, "utf8")).status).toBe("ready_for_strict_pipeline");
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("fails closed when the artifact set cannot feed the strict pipeline", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "friday-ui-harvest-blocked-"));
+    try {
+      writeJson(join(tempDir, "desktop.json"), { missionId, truth: "desktop_only" });
+      const result = spawnSync("node", [
+        script,
+        `--mission-id=${missionId}`,
+        `--search-dir=${tempDir}`,
+        "--require-ready",
+      ], { cwd: process.cwd(), encoding: "utf8" });
+      expect(result.status).toBe(2);
+      const output = JSON.parse(result.stdout) as { status?: string; blockers?: Array<{ code?: string; detail?: string }> };
+      expect(output.status).toBe("partial");
+      expect(output.blockers).toContainEqual({ code: "missing_eligible_capture", detail: "mobile" });
+      expect(output.blockers).toContainEqual({ code: "missing_eligible_capture", detail: "channel" });
+      expect(output.blockers).toContainEqual({ code: "missing_manifest_or_events", detail: "need observations-manifest.json or same-run event jsonl" });
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add a conservative UI/device proof evidence harvester for existing artifact directories
- reject cross-mission events, screenshot-only files, synthetic/partial truth labels, and stale timeline-only captures
- emit strict capture-dir and shortlist-runner commands without creating proof or END-BAR claims

## Validation
- node --check scripts/ops/friday-ui-device-proof-evidence-harvest.mjs
- git diff --check
- ./node_modules/.bin/vitest run --project default --project typecheck --project llm-e2e test/unit/qa/friday-ui-device-proof-evidence-harvest-cli.test.ts
- smoke: harvest /tmp for mission_mission-ui-device-live-write-read-20260626T093735Z-0b48ebe7-c6db-48b4-b341-32f42da4a068 -> partial, selected same-mission mobile/desktop/events/backend/objective, blocked only on channel/timeline captures

Truth: harvest output is not proof, not END-BAR, and not adoption. It only accelerates strict UI/device proof assembly.