### PR TITLE
test(ui): expand action runtime evidence bundle

### DIFF
--- a/scripts/ops/friday-action-runtime-evidence-bundle.sh
+++ b/scripts/ops/friday-action-runtime-evidence-bundle.sh
@@ -272,11 +272,39 @@ run_wrapper \
   "mobile-share-intake"
 
 run_wrapper \
+  "mobile token ledger" \
+  "scripts/ops/friday-mobile-token-ledger-action-evidence.sh" \
+  "FRIDAY_MOBILE_TOKEN_LEDGER_ACTION_EVIDENCE_DIR" \
+  "FRIDAY_MOBILE_TOKEN_LEDGER_ACTION_RUNTIME_OUT" \
+  "mobile-token-ledger"
+
+run_wrapper \
+  "mobile provider auth" \
+  "scripts/ops/friday-mobile-provider-auth-action-evidence.sh" \
+  "FRIDAY_MOBILE_PROVIDER_AUTH_ACTION_EVIDENCE_DIR" \
+  "FRIDAY_MOBILE_PROVIDER_AUTH_ACTION_RUNTIME_OUT" \
+  "mobile-provider-auth"
+
+run_wrapper \
+  "mobile activity" \
+  "scripts/ops/friday-mobile-activity-action-evidence.sh" \
+  "FRIDAY_MOBILE_ACTIVITY_ACTION_EVIDENCE_DIR" \
+  "FRIDAY_MOBILE_ACTIVITY_ACTION_RUNTIME_OUT" \
+  "mobile-activity"
+
+run_wrapper \
   "desktop chat/memory" \
   "scripts/ops/friday-desktop-chat-memory-action-evidence.sh" \
   "FRIDAY_DESKTOP_CHAT_MEMORY_ACTION_EVIDENCE_DIR" \
   "FRIDAY_DESKTOP_CHAT_MEMORY_ACTION_RUNTIME_OUT" \
   "desktop-chat-memory"
+
+run_wrapper \
+  "desktop pairing" \
+  "scripts/ops/friday-desktop-pairing-action-evidence.sh" \
+  "FRIDAY_DESKTOP_PAIRING_ACTION_EVIDENCE_DIR" \
+  "FRIDAY_DESKTOP_PAIRING_ACTION_RUNTIME_OUT" \
+  "desktop-pairing"
 
 set +u
 for extra in "${EXTRA_ACTION_EVIDENCE[@]}"; do

--- a/scripts/ops/friday-action-runtime-evidence-bundle.sh
+++ b/scripts/ops/friday-action-runtime-evidence-bundle.sh
@@ -272,6 +272,13 @@ run_wrapper \
   "mobile-share-intake"
 
 run_wrapper \
+  "mobile voice" \
+  "scripts/ops/friday-mobile-voice-action-evidence.sh" \
+  "FRIDAY_MOBILE_VOICE_ACTION_EVIDENCE_DIR" \
+  "FRIDAY_MOBILE_VOICE_ACTION_RUNTIME_OUT" \
+  "mobile-voice"
+
+run_wrapper \
   "mobile token ledger" \
   "scripts/ops/friday-mobile-token-ledger-action-evidence.sh" \
   "FRIDAY_MOBILE_TOKEN_LEDGER_ACTION_EVIDENCE_DIR" \


### PR DESCRIPTION
## Summary
- expands the UI action-runtime evidence bundle with token ledger, provider auth, activity, desktop pairing, and mobile voice wrappers
- keeps the bundle truth-labeled as partial evidence only: no prod Hub mutation, no signing-key custody, no GUI tap claim, no END-BAR claim
- preserves support for operator/live approval artifacts through `--extra-action-runtime-evidence-dir`

## Local Validation
- `bash -n scripts/ops/friday-action-runtime-evidence-bundle.sh`
- `shellcheck scripts/ops/friday-action-runtime-evidence-bundle.sh`
- `git diff --check`
- Bundle without approval extras:
  - `runtimeEvidenceActionRows=61`
  - `productActionsMissingRuntimeEvidence=2` (`mobile/approval/check`, `mobile/approval/reject`)
- Bundle with existing signed mobile approval evidence dirs:
  - `/private/tmp/friday-mobile-approval-approve-live-20260625T162459Z`
  - `/private/tmp/friday-mobile-approval-reject-live-20260625T125127Z`
  - `designActionRuntime.status=runtime_actions_covered`
  - `productActionsMissingRuntimeEvidence=0`

## Truth Boundary
This PR improves action traceability only. Remaining END-BAR gaps still include strict same-run UI/device/channel/timeline/stress/negative-control proof, product destinations without runtime action ids, design-contract rows for newly surfaced runtime actions, and real user mobile+desktop closure.
