### PR TITLE
test(uiux): add native linkage checker

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,6 +116,7 @@
     "check:desktop-approval-relay-contract": "node scripts/ops/check-friday-desktop-approval-relay-contract.mjs",
     "check:cross-platform-client-ship-gate": "node scripts/ops/check-friday-desktop-release-pipeline.mjs",
     "check:client-design-contract": "node scripts/ops/check-friday-client-design-contract.mjs",
+    "check:uiux-native-linkage": "node scripts/ops/check-friday-uiux-native-linkage.mjs",
     "check:uiux-action-traceability": "node scripts/ops/check-friday-uiux-action-traceability.mjs",
     "check:uiux-product-closure": "node scripts/ops/friday-uiux-product-closure-readiness.mjs",
     "check:agent-rollout:phase1": "node scripts/ops/run-agent-rollout-acceptance.mjs phase1",

--- a/scripts/ops/check-friday-uiux-native-linkage.mjs
+++ b/scripts/ops/check-friday-uiux-native-linkage.mjs
@@ -1,0 +1,326 @@
+#!/usr/bin/env node
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, isAbsolute, resolve } from "node:path";
+
+const args = process.argv.slice(2);
+
+function usage() {
+  console.error(`usage:
+  node scripts/ops/check-friday-uiux-native-linkage.mjs \\
+    [--repo-root=/abs/repo] [--design-root=/abs/friday-design-handoff-20260602] \\
+    [--out=/abs/uiux-native-linkage.json] [--require-complete]
+
+Truth: verifies that operator-selected UI/UX decisions have native Swift routes,
+drivable accessibility ids, and declared runtimeActionIds. It is not screenshot
+proof, not live tap proof, not END-BAR, and not adoption.`);
+}
+
+function arg(name) {
+  const prefix = `--${name}=`;
+  return args.find((value) => value.startsWith(prefix))?.slice(prefix.length) || "";
+}
+
+if (args.includes("--help") || args.includes("-h")) {
+  usage();
+  process.exit(0);
+}
+
+const repoRoot = resolve(arg("repo-root") || process.env.FRIDAY_REPO_ROOT || new URL("../..", import.meta.url).pathname);
+const designRoot = resolve(arg("design-root") || process.env.FRIDAY_DESIGN_HANDOFF_ROOT || `${process.env.HOME || "/Users/jarvis"}/Desktop/friday-design-handoff-20260602`);
+const outPath = arg("out") || process.env.FRIDAY_UIUX_NATIVE_LINKAGE_REPORT || "";
+const requireComplete = args.includes("--require-complete");
+
+const blockers = [];
+
+function block(code, detail) {
+  blockers.push({ code, detail });
+}
+
+function read(path, label) {
+  const resolved = isAbsolute(path) ? path : resolve(repoRoot, path);
+  if (!existsSync(resolved)) {
+    block("file_missing", `${label}:${resolved}`);
+    return "";
+  }
+  return readFileSync(resolved, "utf8");
+}
+
+function readJson(path, label) {
+  try {
+    return JSON.parse(read(path, label));
+  } catch (error) {
+    block("json_unreadable", `${label}:${path}:${error.message}`);
+    return null;
+  }
+}
+
+function selection(surface) {
+  const path = resolve(designRoot, "saved", `${surface}-selection.json`);
+  const value = readJson(path, `${surface}-selection`);
+  const issues = [];
+  if (!value) issues.push("missing_or_invalid");
+  if (value?.operatorConfirmed !== true) issues.push("not_operator_confirmed");
+  if (value?.state?.truthLabel !== "designProofOnly") issues.push("truth_label_not_designProofOnly");
+  if (issues.length > 0) block("design_selection_invalid", `${surface}:${issues.join(",")}`);
+  return {
+    surface,
+    path,
+    status: issues.length === 0 ? "operator_confirmed_design_proof_only" : "invalid",
+    state: value?.state || {},
+    locked: Array.isArray(value?.locked) ? value.locked : [],
+    issues,
+  };
+}
+
+function sourceBundle(paths) {
+  return paths.map((path) => read(path, path)).join("\n");
+}
+
+function missingStrings(source, values) {
+  return values.filter((value) => !source.includes(value));
+}
+
+function runtimeActionsFromContract(path) {
+  const source = read(path, path);
+  return [...source.matchAll(/runtimeActionIds:\s*\[([\s\S]*?)\]/g)]
+    .flatMap((match) => [...match[1].matchAll(/"([^"]+)"/g)].map((item) => item[1]));
+}
+
+function accessibilityIds(source) {
+  return [...source.matchAll(/\.accessibilityIdentifier\("([^"]+)"/g)].map((match) => match[1]);
+}
+
+function evaluateRequirement(requirement) {
+  const source = sourceBundle(requirement.paths);
+  const missing = [
+    ...missingStrings(source, requirement.requiredStrings || []).map((value) => `string:${value}`),
+  ];
+  const ids = accessibilityIds(source);
+  for (const id of requirement.requiredAccessibilityIds || []) {
+    if (!ids.includes(id)) missing.push(`accessibility:${id}`);
+  }
+  const runtimeActions = runtimeActionsFromContract(requirement.productContractPath);
+  for (const action of requirement.requiredRuntimeActionIds || []) {
+    if (!runtimeActions.includes(action)) missing.push(`runtimeActionId:${action}`);
+  }
+  return {
+    id: requirement.id,
+    surface: requirement.surface,
+    selectionKey: requirement.selectionKey,
+    expectedSelectionValue: requirement.expectedSelectionValue,
+    status: missing.length === 0 ? "linked" : "gap",
+    paths: requirement.paths,
+    requiredRuntimeActionIds: requirement.requiredRuntimeActionIds || [],
+    requiredAccessibilityIds: requirement.requiredAccessibilityIds || [],
+    missing,
+    caveat: requirement.caveat || "Native linkage only; runtime/live proof is checked elsewhere.",
+  };
+}
+
+const mobileProductContract = "apps/friday-ios/Sources/FridayMobileShellCore/MobileProductReadinessContract.swift";
+const desktopProductContract = "apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/DesktopProductReadinessContract.swift";
+
+const requirements = [
+  {
+    id: "mobile-home-status-chat",
+    surface: "mobile",
+    selectionKey: "homeLayout",
+    expectedSelectionValue: "chatStatus",
+    paths: [
+      "apps/friday-ios/Sources/FridayMobileShell/FridayApp.swift",
+      "apps/friday-ios/Sources/FridayMobileShell/FridayHomeScreen.swift",
+      "apps/friday-ios/Sources/FridayMobileShell/FridayChatScreen.swift",
+    ],
+    productContractPath: mobileProductContract,
+    requiredStrings: ["FridayHomeScreen", "FridayChatScreen", "friday.home.status-card", "friday.chat.composer"],
+    requiredAccessibilityIds: ["friday.chat.send"],
+    requiredRuntimeActionIds: ["mobile/home/refresh"],
+  },
+  {
+    id: "mobile-command-sheet-grid",
+    surface: "mobile",
+    selectionKey: "menuModel",
+    expectedSelectionValue: "commandSheet",
+    paths: [
+      "apps/friday-ios/Sources/FridayMobileShell/CommandSheet.swift",
+      mobileProductContract,
+    ],
+    productContractPath: mobileProductContract,
+    requiredStrings: ["Command Sheet", "friday.command-sheet.readiness-footer", "MobileProductDestinationID.allCases"],
+  },
+  {
+    id: "mobile-provider-workspace",
+    surface: "mobile",
+    selectionKey: "providerCardOpens",
+    expectedSelectionValue: "workspaceHome",
+    paths: [
+      "apps/friday-ios/Sources/FridayMobileShell/FridayProviderAuthScreen.swift",
+      mobileProductContract,
+    ],
+    productContractPath: mobileProductContract,
+    requiredStrings: ["Provider Workspace", "friday.provider-workspace.overview", "friday.provider-workspace.open-ledger"],
+    requiredRuntimeActionIds: ["mobile/providerAuth/check", "mobile/providerAuth/provider-workspace"],
+  },
+  {
+    id: "mobile-session-full-native-control",
+    surface: "mobile",
+    selectionKey: "sessionControlSet",
+    expectedSelectionValue: "fullNativeControl",
+    paths: [
+      "apps/friday-ios/Sources/FridayMobileShell/FridaySessionDetailScreen.swift",
+      mobileProductContract,
+    ],
+    productContractPath: mobileProductContract,
+    requiredStrings: ["friday.session.sidecar-open", "friday.session.sidecar-close", "friday.session.send-button"],
+    requiredRuntimeActionIds: ["mobile/session/sidecar/open", "mobile/session/sidecar/close", "mobile/workflow/run-control"],
+  },
+  {
+    id: "mobile-approval-summary-proof",
+    surface: "mobile",
+    selectionKey: "approvalDepth",
+    expectedSelectionValue: "summaryThenProof",
+    paths: [
+      "apps/friday-ios/Sources/FridayMobileShell/FridayChatScreen.swift",
+      mobileProductContract,
+    ],
+    productContractPath: mobileProductContract,
+    requiredStrings: ["approvalCard", "action_digest", "friday.chat.approval-card"],
+    requiredRuntimeActionIds: ["mobile/approval/check", "mobile/approval/reject"],
+  },
+  {
+    id: "mobile-voice-loop",
+    surface: "mobile",
+    selectionKey: "entrypointPattern",
+    expectedSelectionValue: "fullGridPostV1",
+    paths: [
+      "apps/friday-ios/Sources/FridayMobileShell/FridayVoiceScreen.swift",
+      "apps/friday-ios/Sources/FridayMobileShell/FridayChatScreen.swift",
+      mobileProductContract,
+    ],
+    productContractPath: mobileProductContract,
+    requiredStrings: ["Readiness plus local voice-loop truth", "friday.voice.readiness-card"],
+    requiredAccessibilityIds: ["friday.chat.voice-input", "friday.chat.voice-output", "friday.voice.open-chat-loop"],
+    requiredRuntimeActionIds: [
+      "mobile/voice/permission",
+      "mobile/fridayChat/voice-input",
+      "mobile/fridayChat/voice-output",
+      "mobile/voice/open-chat-loop",
+    ],
+  },
+  {
+    id: "mobile-passport-memory-activity",
+    surface: "mobile",
+    selectionKey: "passportPattern",
+    expectedSelectionValue: "checklistSheet",
+    paths: [
+      "apps/friday-ios/Sources/FridayMobileShell/FridayContextPassportScreen.swift",
+      "apps/friday-ios/Sources/FridayMobileShell/FridayProjectionScreens.swift",
+      "apps/friday-ios/Sources/FridayMobileShell/FridayHomeScreen.swift",
+      mobileProductContract,
+    ],
+    productContractPath: mobileProductContract,
+    requiredStrings: [
+      "friday.context-passport.checklist",
+      "friday.context-passport.send",
+      "viewModel.decideMemory",
+      "markActivityDone",
+    ],
+    requiredRuntimeActionIds: ["mobile/passport/send", "mobile/memory/confirm", "mobile/memory/reject", "mobile/activity/mark-done"],
+  },
+  {
+    id: "desktop-three-pane-proof-inspector",
+    surface: "desktop",
+    selectionKey: "layout",
+    expectedSelectionValue: "threePane",
+    paths: [
+      "apps/macos/FridayHubConsole/Sources/FridayHubConsole/HubConsoleShell.swift",
+      "apps/macos/FridayHubConsole/Sources/FridayHubConsole/ProofInspector.swift",
+      "apps/macos/FridayHubConsole/Sources/FridayHubConsole/Navigation.swift",
+      desktopProductContract,
+    ],
+    productContractPath: desktopProductContract,
+    requiredStrings: ["ProofInspector", "Navigation", "var isBuilt: Bool { contract.routeBuilt }"],
+  },
+  {
+    id: "desktop-provider-parity-channels",
+    surface: "desktop",
+    selectionKey: "providerParityView",
+    expectedSelectionValue: "capabilityMatrixAndQueues",
+    paths: [
+      "apps/macos/FridayHubConsole/Sources/FridayHubConsole/DesktopProjectionScreens.swift",
+      desktopProductContract,
+    ],
+    productContractPath: desktopProductContract,
+    requiredStrings: [
+      "friday.desktop.provider-route-decision-card",
+      "friday.desktop.provider-work-items-card",
+      "friday.desktop.channels.admin",
+      "friday.desktop.channels.surface-events",
+    ],
+    requiredRuntimeActionIds: ["desktop/channels/receipts", "desktop/channels/surface-events"],
+  },
+  {
+    id: "desktop-workflow-evidence-memory",
+    surface: "desktop",
+    selectionKey: "workflowBuilder",
+    expectedSelectionValue: "canvasInspector",
+    paths: [
+      "apps/macos/FridayHubConsole/Sources/FridayHubConsole/DesktopProjectionScreens.swift",
+      "apps/macos/FridayHubConsole/Sources/FridayHubConsole/DesktopChatScreen.swift",
+      desktopProductContract,
+    ],
+    productContractPath: desktopProductContract,
+    requiredStrings: [
+      "friday.desktop.workflow.canvas",
+      "friday.desktop.evidence.timeline-pages",
+      "friday.desktop.evidence.transcript-browser",
+      "friday.desktop.evidence.memory-review",
+    ],
+    requiredRuntimeActionIds: ["desktop/workflow/retry", "desktop/workflow/cancel", "desktop/memory/act", "desktop/memory/check"],
+  },
+];
+
+const selections = {
+  mobile: selection("mobile"),
+  desktop: selection("desktop"),
+};
+
+const evaluated = requirements.map((requirement) => {
+  const selectedValue = selections[requirement.surface]?.state?.[requirement.selectionKey];
+  const selectionMatches = selectedValue === requirement.expectedSelectionValue;
+  const result = evaluateRequirement(requirement);
+  if (!selectionMatches) result.missing.unshift(`selection:${requirement.selectionKey}:${selectedValue || "<missing>"}`);
+  result.status = result.missing.length === 0 ? "linked" : "gap";
+  result.selectedValue = selectedValue || null;
+  return result;
+});
+
+const gaps = evaluated.filter((item) => item.status !== "linked");
+const report = {
+  truth: "uiux_native_linkage_not_screenshot_not_live_tap_not_endbar",
+  status: blockers.length === 0 && gaps.length === 0 ? "linked" : "linkage_gaps_present",
+  repoRoot,
+  designRoot,
+  selections,
+  counts: {
+    requirements: evaluated.length,
+    linked: evaluated.length - gaps.length,
+    gaps: gaps.length,
+    blockers: blockers.length,
+  },
+  requirements: evaluated,
+  gaps,
+  blockers,
+  caveat:
+    "This proves selected-design native linkage only: Swift route/control/accessibility/runtimeActionId wiring. It does not prove screenshots, real GUI taps, same-run UI/device proof, release, adoption, or END-BAR.",
+};
+
+if (outPath) {
+  const resolved = isAbsolute(outPath) ? outPath : resolve(outPath);
+  mkdirSync(dirname(resolved), { recursive: true });
+  writeFileSync(resolved, `${JSON.stringify(report, null, 2)}\n`);
+}
+
+console.log(JSON.stringify(report, null, 2));
+process.exit(requireComplete && report.status !== "linked" ? 1 : 0);

--- a/scripts/ops/friday-uiux-product-closure-readiness.mjs
+++ b/scripts/ops/friday-uiux-product-closure-readiness.mjs
@@ -18,10 +18,10 @@ function usage() {
     [--require-runtime-actions] [--require-ui-device-proof]
 
 Truth: this is a product-closure readiness harness. It links the operator-confirmed
-UI/UX design handoff to current native routes, ViewModel action drivers, optional
-runtime action evidence, and optional UI/device proof evidence. It never treats
-design proof, screenshots, static Swift source, or partial live write/read bundles
-as END-BAR completion.`);
+UI/UX design handoff to selected native routes, ViewModel action drivers,
+runtimeActionIds, optional runtime action evidence, and optional UI/device proof
+evidence. It never treats design proof, screenshots, static Swift source, or
+partial live write/read bundles as END-BAR completion.`);
 }
 
 function arg(name) {
@@ -235,6 +235,12 @@ const clientDesign = runJson("client_design_contract", process.execPath, [
   `${repoRoot}/scripts/ops/check-friday-client-design-contract.mjs`,
   repoRoot,
 ]);
+const nativeLinkage = runJson("uiux_native_linkage", process.execPath, [
+  `${repoRoot}/scripts/ops/check-friday-uiux-native-linkage.mjs`,
+  `--repo-root=${repoRoot}`,
+  `--design-root=${designRoot}`,
+  "--require-complete",
+]);
 const nativeAction = runJson("native_action_closure", process.execPath, [
   `${repoRoot}/scripts/ops/check-friday-native-action-closure.mjs`,
   repoRoot,
@@ -312,12 +318,14 @@ const runtimeReport = designRuntime.parsed || {};
 const readinessReport = uiDeviceReadiness?.parsed || {};
 const traceabilityReport = uiuxTraceability.parsed || {};
 const clientPassed = clientDesign.status === "passed" && clientDesign.parsed?.status === "passed";
+const nativeLinkagePassed = nativeLinkage.status === "passed" && nativeLinkage.parsed?.status === "linked";
 const nativePassed = nativeAction.status === "passed" && nativeAction.parsed?.status === "passed";
 const traceabilityPassed = uiuxTraceability.status === "passed" && ["product_runtime_actions_traceable", "traceability_gaps_present"].includes(traceabilityReport.status);
 const runtimeCovered = runtimeReport.status === "runtime_actions_covered";
 const uiDeviceProofAssembled = readinessReport.status === "pass";
 
 if (!clientPassed) block("client_design_contract_failed", String(clientDesign.exitCode));
+if (!nativeLinkagePassed) block("uiux_native_linkage_failed", nativeLinkage.parsed?.status || String(nativeLinkage.exitCode));
 if (!nativePassed) block("native_action_closure_failed", String(nativeAction.exitCode));
 if (!traceabilityPassed) block("uiux_action_traceability_failed", traceabilityReport.status || String(uiuxTraceability.exitCode));
 if (requireRuntimeActions && !runtimeCovered) block("runtime_actions_not_covered", runtimeReport.status || "unknown");
@@ -350,6 +358,12 @@ const report = {
     clientDesignContract: {
       status: clientDesign.parsed?.status || clientDesign.status,
       truthLabel: clientDesign.parsed?.truthLabel || null,
+    },
+    uiuxNativeLinkage: {
+      status: nativeLinkage.parsed?.status || nativeLinkage.status,
+      counts: nativeLinkage.parsed?.counts || null,
+      gaps: nativeLinkage.parsed?.gaps || [],
+      caveat: nativeLinkage.parsed?.caveat || "Selected-design native linkage only; not screenshot proof, live tap proof, or END-BAR.",
     },
     nativeActionClosure: {
       status: nativeAction.parsed?.status || nativeAction.status,

--- a/test/unit/qa/friday-uiux-native-linkage-cli.test.ts
+++ b/test/unit/qa/friday-uiux-native-linkage-cli.test.ts
@@ -1,0 +1,143 @@
+import { execFileSync, spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const script = "scripts/ops/check-friday-uiux-native-linkage.mjs";
+
+function writeFile(root: string, relative: string, body: string) {
+  const target = join(root, relative);
+  mkdirSync(dirname(target), { recursive: true });
+  writeFileSync(target, body);
+  return target;
+}
+
+function writeSelections(designRoot: string, overrides: { mobile?: Record<string, string>; desktop?: Record<string, string> } = {}) {
+  writeFile(designRoot, "saved/mobile-selection.json", JSON.stringify({
+    surface: "mobile",
+    operatorConfirmed: true,
+    state: {
+      truthLabel: "designProofOnly",
+      homeLayout: "chatStatus",
+      menuModel: "commandSheet",
+      providerCardOpens: "workspaceHome",
+      sessionControlSet: "fullNativeControl",
+      approvalDepth: "summaryThenProof",
+      entrypointPattern: "fullGridPostV1",
+      passportPattern: "checklistSheet",
+      ...overrides.mobile,
+    },
+    locked: [],
+  }, null, 2));
+  writeFile(designRoot, "saved/desktop-selection.json", JSON.stringify({
+    surface: "desktop",
+    operatorConfirmed: true,
+    state: {
+      truthLabel: "designProofOnly",
+      layout: "threePane",
+      providerParityView: "capabilityMatrixAndQueues",
+      workflowBuilder: "canvasInspector",
+      ...overrides.desktop,
+    },
+    locked: [],
+  }, null, 2));
+}
+
+function writeCompleteRepo(root: string) {
+  writeFile(root, "apps/friday-ios/Sources/FridayMobileShell/FridayApp.swift", "FridayHomeScreen FridayChatScreen");
+  writeFile(root, "apps/friday-ios/Sources/FridayMobileShell/FridayHomeScreen.swift", "friday.home.status-card markActivityDone");
+  writeFile(root, "apps/friday-ios/Sources/FridayMobileShell/FridayChatScreen.swift", "friday.chat.composer .accessibilityIdentifier(\"friday.chat.send\") approvalCard action_digest friday.chat.approval-card .accessibilityIdentifier(\"friday.chat.voice-input\") .accessibilityIdentifier(\"friday.chat.voice-output\")");
+  writeFile(root, "apps/friday-ios/Sources/FridayMobileShell/CommandSheet.swift", "Command Sheet friday.command-sheet.readiness-footer MobileProductDestinationID.allCases");
+  writeFile(root, "apps/friday-ios/Sources/FridayMobileShell/FridayProviderAuthScreen.swift", "Provider Workspace friday.provider-workspace.overview friday.provider-workspace.open-ledger");
+  writeFile(root, "apps/friday-ios/Sources/FridayMobileShell/FridaySessionDetailScreen.swift", "friday.session.sidecar-open friday.session.sidecar-close friday.session.send-button");
+  writeFile(root, "apps/friday-ios/Sources/FridayMobileShell/FridayVoiceScreen.swift", "Readiness plus local voice-loop truth friday.voice.readiness-card .accessibilityIdentifier(\"friday.voice.open-chat-loop\")");
+  writeFile(root, "apps/friday-ios/Sources/FridayMobileShell/FridayContextPassportScreen.swift", "friday.context-passport.checklist friday.context-passport.send");
+  writeFile(root, "apps/friday-ios/Sources/FridayMobileShell/FridayProjectionScreens.swift", "viewModel.decideMemory");
+  writeFile(root, "apps/friday-ios/Sources/FridayMobileShellCore/MobileProductReadinessContract.swift", `
+    runtimeActionIds: ["mobile/home/refresh"]
+    runtimeActionIds: ["mobile/providerAuth/check", "mobile/providerAuth/provider-workspace"]
+    runtimeActionIds: ["mobile/session/sidecar/open", "mobile/session/sidecar/close", "mobile/workflow/run-control"]
+    runtimeActionIds: ["mobile/approval/check", "mobile/approval/reject"]
+    runtimeActionIds: ["mobile/voice/permission", "mobile/fridayChat/voice-input", "mobile/fridayChat/voice-output", "mobile/voice/open-chat-loop"]
+    runtimeActionIds: ["mobile/passport/send", "mobile/memory/confirm", "mobile/memory/reject", "mobile/activity/mark-done"]
+  `);
+
+  writeFile(root, "apps/macos/FridayHubConsole/Sources/FridayHubConsole/HubConsoleShell.swift", "ProofInspector Navigation");
+  writeFile(root, "apps/macos/FridayHubConsole/Sources/FridayHubConsole/ProofInspector.swift", "ProofInspector");
+  writeFile(root, "apps/macos/FridayHubConsole/Sources/FridayHubConsole/Navigation.swift", "Navigation var isBuilt: Bool { contract.routeBuilt }");
+  writeFile(root, "apps/macos/FridayHubConsole/Sources/FridayHubConsole/DesktopProjectionScreens.swift", "friday.desktop.provider-route-decision-card friday.desktop.provider-work-items-card friday.desktop.channels.admin friday.desktop.channels.surface-events friday.desktop.workflow.canvas friday.desktop.evidence.timeline-pages friday.desktop.evidence.transcript-browser friday.desktop.evidence.memory-review");
+  writeFile(root, "apps/macos/FridayHubConsole/Sources/FridayHubConsole/DesktopChatScreen.swift", "DesktopChatScreen");
+  writeFile(root, "apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/DesktopProductReadinessContract.swift", `
+    runtimeActionIds: ["desktop/channels/receipts", "desktop/channels/surface-events"]
+    runtimeActionIds: ["desktop/workflow/retry", "desktop/workflow/cancel", "desktop/memory/act", "desktop/memory/check"]
+  `);
+}
+
+function fixture(overrides: { mobile?: Record<string, string>; desktop?: Record<string, string> } = {}) {
+  const root = mkdtempSync(join(tmpdir(), "friday-uiux-native-linkage-"));
+  const designRoot = join(root, "design");
+  writeSelections(designRoot, overrides);
+  writeCompleteRepo(root);
+  return { root, designRoot };
+}
+
+describe("check-friday-uiux-native-linkage", () => {
+  it("passes when selected UIUX decisions have native route, accessibility, and runtime action linkage", () => {
+    const { root, designRoot } = fixture();
+    try {
+      const output = execFileSync("node", [
+        script,
+        `--repo-root=${root}`,
+        `--design-root=${designRoot}`,
+        "--require-complete",
+      ], { cwd: process.cwd(), encoding: "utf8" });
+      const report = JSON.parse(output) as { status?: string; counts?: { linked?: number; gaps?: number } };
+      expect(report.status).toBe("linked");
+      expect(report.counts?.linked).toBe(10);
+      expect(report.counts?.gaps).toBe(0);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("reports gaps without failing by default", () => {
+    const { root, designRoot } = fixture();
+    try {
+      writeFile(root, "apps/friday-ios/Sources/FridayMobileShell/FridayVoiceScreen.swift", "friday.voice.readiness-card");
+      const output = execFileSync("node", [
+        script,
+        `--repo-root=${root}`,
+        `--design-root=${designRoot}`,
+      ], { cwd: process.cwd(), encoding: "utf8" });
+      const report = JSON.parse(output) as { status?: string; gaps?: Array<{ id?: string; missing?: string[] }> };
+      expect(report.status).toBe("linkage_gaps_present");
+      expect(report.gaps).toContainEqual(expect.objectContaining({
+        id: "mobile-voice-loop",
+        missing: expect.arrayContaining(["string:Readiness plus local voice-loop truth", "accessibility:friday.voice.open-chat-loop"]),
+      }));
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("fails closed in require-complete mode", () => {
+    const { root, designRoot } = fixture({ mobile: { homeLayout: "wrong" } });
+    try {
+      const result = spawnSync("node", [
+        script,
+        `--repo-root=${root}`,
+        `--design-root=${designRoot}`,
+        "--require-complete",
+      ], { cwd: process.cwd(), encoding: "utf8" });
+      expect(result.status).toBe(1);
+      const report = JSON.parse(result.stdout) as { gaps?: Array<{ id?: string; missing?: string[] }> };
+      expect(report.gaps).toContainEqual(expect.objectContaining({
+        id: "mobile-home-status-chat",
+        missing: expect.arrayContaining(["selection:homeLayout:wrong"]),
+      }));
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add a UI/UX native linkage checker for the operator-selected mobile and desktop design decisions
- verify selected design state against native Swift route/control strings, accessibility ids, and declared runtimeActionIds
- wire the native linkage stage into `friday-uiux-product-closure-readiness.mjs` so the product closure report directly exposes `stages.uiuxNativeLinkage`
- add a unit test fixture covering linked, report-only gap, and fail-closed require-complete behavior

## Truth labels
- proves selected-design native linkage only
- does not claim screenshot proof, live GUI tap proof, same-run UI/device proof, release, adoption, or END-BAR
- product closure still requires full UI/device evidence before END-BAR can be claimed

## Validation
- node --check scripts/ops/check-friday-uiux-native-linkage.mjs
- npm run check:uiux-native-linkage -- --out=/tmp/friday-uiux-native-linkage.json --require-complete
- npx vitest run test/unit/qa/friday-uiux-native-linkage-cli.test.ts
- node --check scripts/ops/friday-uiux-product-closure-readiness.mjs
- npm run check:uiux-product-closure -- --runtime-evidence-dir=/tmp/friday-action-runtime-evidence-bundle-with-voice-approval-20260626T105126Z --runtime-evidence-dir=/tmp/friday-ui-device-shortlist-harvest-20260626T102528Z/live-write-read/bundle --out=/tmp/friday-uiux-product-closure-with-native-linkage.json
- git diff --check
