### PR TITLE
test(ui): normalize accessibility click evidence

### DIFF
--- a/package.json
+++ b/package.json
@@ -119,6 +119,7 @@
     "check:uiux-native-linkage": "node scripts/ops/check-friday-uiux-native-linkage.mjs",
     "check:uiux-action-traceability": "node scripts/ops/check-friday-uiux-action-traceability.mjs",
     "check:uiux-product-closure": "node scripts/ops/friday-uiux-product-closure-readiness.mjs",
+    "check:ui-device-accessibility-click-capture": "node scripts/ops/friday-ui-device-accessibility-click-capture.mjs",
     "check:agent-rollout:phase1": "node scripts/ops/run-agent-rollout-acceptance.mjs phase1",
     "check:native-action-closure": "node scripts/ops/check-friday-native-action-closure.mjs",
     "check:agent-rollout:phase2": "node scripts/ops/run-agent-rollout-acceptance.mjs phase2",

--- a/scripts/ops/friday-ui-device-accessibility-click-capture.mjs
+++ b/scripts/ops/friday-ui-device-accessibility-click-capture.mjs
@@ -1,0 +1,305 @@
+#!/usr/bin/env node
+
+import { existsSync, mkdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { dirname, isAbsolute, resolve } from "node:path";
+
+const args = process.argv.slice(2);
+
+const allowedSurfaces = new Set(["mobile", "desktop"]);
+const allowedCaptureMethods = new Set([
+  "ios_simulator_accessibility",
+  "ios_device_accessibility",
+  "macos_accessibility",
+]);
+const allowedInteractions = new Set(["tap", "visible", "type", "read"]);
+const allowedEvents = new Set([
+  "mission_intake_submitted",
+  "mission_intake_ready",
+  "mission_resolve_or_create_visible",
+  "duplicate_preflight_visible",
+  "mission_bound_provider_action_visible",
+  "real_provider_execution_visible",
+  "proof_receipt_visible_before_done",
+  "same_mission_projection_visible",
+  "mission_workbench_visible",
+  "transcript_browser_visible",
+  "duplicate_blocked_opens_existing",
+  "same_mission_mobile_desktop_channel_visible",
+  "provider_ack_not_done_visible",
+  "pressure_20_50_consecutive_asks_visible",
+  "invalid_key_error_visible",
+  "quota_error_visible",
+  "network_error_visible",
+  "reconnect_stale_verified",
+  "real_provider_execution_receipt_visible",
+  "stale_label_visible",
+  "offline_label_visible",
+  "error_label_visible",
+  "no_hidden_fallback_verified",
+]);
+const forbiddenTruth = /(synthetic|fixture|sample|dry[-_ ]?run|screenshot[-_ ]?only|design[-_ ]?proof|mock|placeholder)/i;
+
+function usage() {
+  console.error(`usage:
+  node scripts/ops/friday-ui-device-accessibility-click-capture.mjs \\
+    --mission-id=mission_... \\
+    --out-dir=/abs/out-dir \\
+    --capture=/abs/mobile-accessibility-capture.json [--capture=/abs/desktop-accessibility-capture.json ...] \\
+    [--require-ready]
+
+Input capture JSON shape:
+  {
+    "truth_label": "ui_device_accessibility_click_capture_real_ui_not_endbar",
+    "mission_id": "mission_...",
+    "surface": "mobile|desktop",
+    "capture_method": "ios_simulator_accessibility|ios_device_accessibility|macos_accessibility",
+    "evidence_ref": "/abs/raw-real-capture-or-log",
+    "ui_actions": [{
+      "screen": "fridayChat",
+      "runtimeActionId": "mobile/home/refresh",
+      "action_id": "optional design action id",
+      "capability_id": "optional capability id",
+      "accessibility_id": "friday.chat.send",
+      "interaction": "tap|visible|type|read",
+      "status": "pass",
+      "event": "mission_intake_submitted",
+      "evidence_ref": "/abs/specific-evidence"
+    }]
+  }
+
+Truth: normalizes already-captured real accessibility click/visible observations
+into same-run event rows and action-runtime evidence. It does not drive the UI by
+itself, does not accept synthetic/dry-run/screenshot-only evidence, and is not
+END-BAR proof.`);
+}
+
+function arg(name) {
+  const prefix = `--${name}=`;
+  return args.find((value) => value.startsWith(prefix))?.slice(prefix.length) || "";
+}
+
+function argsAll(name) {
+  const prefix = `--${name}=`;
+  const values = [];
+  for (let index = 0; index < args.length; index += 1) {
+    const value = args[index];
+    if (value.startsWith(prefix)) {
+      values.push(value.slice(prefix.length));
+    } else if (value === `--${name}` && args[index + 1]) {
+      values.push(args[index + 1]);
+      index += 1;
+    }
+  }
+  return values;
+}
+
+if (args.includes("--help") || args.includes("-h")) {
+  usage();
+  process.exit(0);
+}
+
+const missionId = arg("mission-id");
+const outDir = arg("out-dir");
+const captureInputs = argsAll("capture");
+const requireReady = args.includes("--require-ready");
+const blockers = [];
+
+function block(code, detail) {
+  blockers.push({ code, detail });
+}
+
+function abs(path) {
+  return isAbsolute(path) ? path : resolve(path);
+}
+
+function requireAbsoluteFile(label, path) {
+  if (!path) {
+    block("missing_arg", label);
+    return "";
+  }
+  if (!isAbsolute(path)) {
+    block("path_not_absolute", `${label}:${path}`);
+    return "";
+  }
+  try {
+    const stats = statSync(path);
+    if (!stats.isFile()) block("not_file", `${label}:${path}`);
+    if (stats.size <= 0) block("empty_file", `${label}:${path}`);
+  } catch {
+    block("unreadable_file", `${label}:${path}`);
+  }
+  return path;
+}
+
+function readJson(label, path) {
+  const file = requireAbsoluteFile(label, path);
+  if (!file) return null;
+  try {
+    return JSON.parse(readFileSync(file, "utf8"));
+  } catch (error) {
+    block("invalid_json", `${label}:${path}:${error.message}`);
+    return null;
+  }
+}
+
+function truthString(value) {
+  return String(value?.truth_label || value?.truthLabel || value?.truth || "");
+}
+
+function validateTruth(label, value) {
+  const truth = truthString(value);
+  if (!truth) {
+    block("truth_label_missing", label);
+  } else {
+    if (!/accessibility.*real|real.*accessibility/i.test(truth)) {
+      block("truth_label_not_real_accessibility", `${label}:${truth}`);
+    }
+    if (forbiddenTruth.test(truth)) block("truth_label_forbidden", `${label}:${truth}`);
+  }
+  return truth;
+}
+
+function validateMission(label, value) {
+  const id = String(value?.mission_id || value?.missionId || "");
+  if (id !== missionId) block("mission_id_mismatch", `${label}:${id || "<missing>"}`);
+}
+
+function evidenceRefFor(capturePath, capture, action, label) {
+  const ref = String(action?.evidence_ref || action?.evidenceRef || capture?.evidence_ref || capture?.evidenceRef || capturePath);
+  const resolved = requireAbsoluteFile(`${label}:evidence_ref`, ref);
+  return resolved || ref;
+}
+
+function normalizeCapture(capturePath, raw) {
+  const captures = Array.isArray(raw?.captures) ? raw.captures : [raw];
+  const rows = [];
+  const actions = [];
+  for (const [captureIndex, capture] of captures.entries()) {
+    const label = `${capturePath}:capture_${captureIndex + 1}`;
+    if (!capture || typeof capture !== "object" || Array.isArray(capture)) {
+      block("capture_not_object", label);
+      continue;
+    }
+    validateTruth(label, capture);
+    validateMission(label, capture);
+    const surface = String(capture.surface || "").trim();
+    const method = String(capture.capture_method || capture.captureMethod || "").trim();
+    if (!allowedSurfaces.has(surface)) block("surface_not_supported", `${label}:${surface || "<missing>"}`);
+    if (!allowedCaptureMethods.has(method)) block("capture_method_not_supported", `${label}:${method || "<missing>"}`);
+    if (forbiddenTruth.test(method)) block("capture_method_forbidden", `${label}:${method}`);
+
+    const uiActions = Array.isArray(capture.ui_actions)
+      ? capture.ui_actions
+      : Array.isArray(capture.uiActions)
+        ? capture.uiActions
+        : [];
+    if (uiActions.length === 0) block("ui_actions_missing", label);
+
+    for (const [actionIndex, action] of uiActions.entries()) {
+      const actionLabel = `${label}:ui_action_${actionIndex + 1}`;
+      if (!action || typeof action !== "object" || Array.isArray(action)) {
+        block("ui_action_not_object", actionLabel);
+        continue;
+      }
+      const actionSurface = String(action.surface || surface).trim();
+      const screen = String(action.screen || "").trim();
+      const actionId = String(action.runtimeActionId || action.runtime_action_id || action.action_id || action.actionId || "").trim();
+      const capabilityId = String(action.capability_id || action.capabilityId || "").trim();
+      const accessibilityId = String(action.accessibility_id || action.accessibilityId || "").trim();
+      const interaction = String(action.interaction || action.action || "").trim();
+      const status = String(action.status || "").trim();
+      const event = String(action.event || "").trim();
+      const evidenceRef = evidenceRefFor(capturePath, capture, action, actionLabel);
+
+      if (actionSurface !== surface) block("ui_action_surface_mismatch", `${actionLabel}:${actionSurface || "<missing>"}`);
+      if (!screen) block("screen_missing", actionLabel);
+      if (!actionId && !capabilityId) block("action_identity_missing", actionLabel);
+      if (!accessibilityId) block("accessibility_id_missing", actionLabel);
+      if (!allowedInteractions.has(interaction)) block("interaction_not_supported", `${actionLabel}:${interaction || "<missing>"}`);
+      if (status !== "pass") block("status_not_pass", `${actionLabel}:${status || "<missing>"}`);
+      if (forbiddenTruth.test(String(action.source || ""))) block("ui_action_source_forbidden", actionLabel);
+
+      if (event) {
+        if (!allowedEvents.has(event)) block("event_not_supported", `${actionLabel}:${event}`);
+        rows.push({
+          surface,
+          event,
+          mission_id: missionId,
+          evidence_ref: evidenceRef,
+          truth_label: "ui_device_accessibility_click_observation_real_ui_not_proof",
+          source: `${method}:${accessibilityId}`,
+          captured_at: String(action.captured_at || action.capturedAt || capture.captured_at || capture.capturedAt || ""),
+        });
+      }
+
+      actions.push({
+        surface,
+        screen,
+        action_id: actionId,
+        ...(capabilityId ? { capability_id: capabilityId } : {}),
+        status: "pass",
+        evidence_ref: evidenceRef,
+        mission_id: missionId,
+        source: `${method}:${accessibilityId}:${interaction}`,
+        truth_label: "accessibility_click_action_runtime_evidence_real_ui_not_endbar",
+      });
+    }
+  }
+  return { rows, actions };
+}
+
+if (!missionId || !/^[A-Za-z0-9][A-Za-z0-9._:-]*$/.test(missionId) || !missionId.toLowerCase().includes("mission")) {
+  block("mission_id_unexpected_shape", missionId || "<missing>");
+}
+if (!outDir) block("missing_arg", "out-dir");
+if (outDir && !isAbsolute(outDir)) block("path_not_absolute", `out-dir:${outDir}`);
+if (captureInputs.length === 0) block("missing_capture", "supply at least one --capture");
+
+const normalized = captureInputs
+  .map((path) => {
+    const resolved = isAbsolute(path) ? path : path;
+    const value = readJson("capture", resolved);
+    return value ? normalizeCapture(resolved, value) : { rows: [], actions: [] };
+  });
+
+const eventRows = normalized.flatMap((item) => item.rows);
+const actionRows = normalized.flatMap((item) => item.actions);
+if (eventRows.length === 0) block("no_event_rows", "at least one ui_action must include a supported proof event");
+if (actionRows.length === 0) block("no_action_runtime_rows", "at least one passed ui_action is required");
+
+const output = {
+  truth: "ui_device_accessibility_click_capture_normalized_not_proof_not_endbar",
+  status: blockers.length === 0 ? "ready" : "blocked",
+  missionId: missionId || null,
+  captures: captureInputs.map((path) => abs(path)),
+  counts: {
+    eventRows: eventRows.length,
+    actionRuntimeRows: actionRows.length,
+  },
+  outputs: outDir ? {
+    events: resolve(outDir, "accessibility-click-events.jsonl"),
+    actionRuntimeEvidence: resolve(outDir, "action-runtime-evidence.json"),
+    runtimeEvidencePaths: resolve(outDir, "runtime-evidence-paths.txt"),
+    index: resolve(outDir, "accessibility-click-capture-index.json"),
+  } : null,
+  blockers,
+  caveat: "Normalizer only. It requires already-captured real accessibility observations and does not prove END-BAR until merged with mobile, desktop, channel, timeline, manifest, stress, and negative-control evidence.",
+};
+
+if (blockers.length === 0 && outDir) {
+  mkdirSync(outDir, { recursive: true });
+  writeFileSync(output.outputs.events, `${eventRows.map((row) => JSON.stringify(row)).join("\n")}\n`);
+  writeFileSync(output.outputs.actionRuntimeEvidence, `${JSON.stringify({
+    truth: "accessibility_click_action_runtime_evidence_real_ui_not_endbar",
+    status: "ready",
+    missionId,
+    actions: actionRows,
+  }, null, 2)}\n`);
+  writeFileSync(output.outputs.runtimeEvidencePaths, `${output.outputs.actionRuntimeEvidence}\n`);
+  writeFileSync(output.outputs.index, `${JSON.stringify(output, null, 2)}\n`);
+} else if (blockers.length === 0 && outDir && !existsSync(outDir)) {
+  block("out_dir_not_created", outDir);
+}
+
+console.log(JSON.stringify(output, null, 2));
+process.exit(blockers.length === 0 || !requireReady ? 0 : 2);

--- a/scripts/ops/friday-ui-device-proof-shortlist-runner.sh
+++ b/scripts/ops/friday-ui-device-proof-shortlist-runner.sh
@@ -11,6 +11,7 @@ usage:
     [--channel-live-proof /abs/channel-live-proof.json]
     [--channel-capture /abs/channel-capture.json]
     [--timeline-capture /abs/timeline-capture.json]
+    [--accessibility-capture /abs/real-accessibility-capture.json ...]
     [--harvest-dir /abs/artifact-dir ...]
     [--same-run-events /abs/events.jsonl ...]
     [--runtime-evidence-dir /abs/evidence-dir ...]
@@ -42,6 +43,7 @@ objective_coverage="${FRIDAY_UI_DEVICE_OBJECTIVE_COVERAGE:-}"
 channel_live_proof="${FRIDAY_UI_DEVICE_CHANNEL_LIVE_PROOF:-}"
 channel_capture=""
 timeline_capture=""
+accessibility_captures=()
 harvest_dirs=()
 same_run_events=()
 runtime_evidence_dirs=()
@@ -119,6 +121,15 @@ while [ "$#" -gt 0 ]; do
       timeline_capture="${1#--timeline-capture=}"
       shift
       ;;
+    --accessibility-capture)
+      [ "$#" -ge 2 ] || die "--accessibility-capture requires a value"
+      accessibility_captures+=("$2")
+      shift 2
+      ;;
+    --accessibility-capture=*)
+      accessibility_captures+=("${1#--accessibility-capture=}")
+      shift
+      ;;
     --harvest-dir)
       [ "$#" -ge 2 ] || die "--harvest-dir requires a value"
       harvest_dirs+=("$2")
@@ -192,7 +203,7 @@ require_file_if_set() {
 }
 
 set +u
-for path in "${harvest_dirs[@]}" "${same_run_events[@]}" "${runtime_evidence_dirs[@]}" "${extra_action_runtime_evidence[@]}"; do
+for path in "${accessibility_captures[@]}" "${harvest_dirs[@]}" "${same_run_events[@]}" "${runtime_evidence_dirs[@]}" "${extra_action_runtime_evidence[@]}"; do
   require_abs_if_set "input path" "${path}"
 done
 set -u
@@ -230,6 +241,27 @@ mobile_capture="${bundle_dir}/mobile/ios-live-write-read-proof.json"
 desktop_capture="${bundle_dir}/desktop/macos-live-write-read-proof.json"
 combined_events="${bundle_dir}/mobile-desktop-live-write-read-events.jsonl"
 mission_id="$(node -e 'const fs=require("fs"); const j=JSON.parse(fs.readFileSync(process.argv[1],"utf8")); console.log(j.missionId || "")' "${bundle_index}")"
+
+accessibility_capture_status="skipped"
+set +u
+if [ "${#accessibility_captures[@]}" -gt 0 ]; then
+  accessibility_capture_dir="${out_dir}/accessibility-click-capture"
+  accessibility_args=(
+    "${repo_root}/scripts/ops/friday-ui-device-accessibility-click-capture.mjs"
+    "--mission-id=${mission_id}"
+    "--out-dir=${accessibility_capture_dir}"
+    "--require-ready"
+  )
+  for capture in "${accessibility_captures[@]}"; do
+    [ -n "${capture}" ] || continue
+    accessibility_args+=("--capture=${capture}")
+  done
+  node "${accessibility_args[@]}"
+  same_run_events+=("${accessibility_capture_dir}/accessibility-click-events.jsonl")
+  runtime_evidence_dirs+=("${accessibility_capture_dir}")
+  accessibility_capture_status="ready"
+fi
+set -u
 
 set +u
 if [ "${#harvest_dirs[@]}" -gt 0 ]; then
@@ -365,9 +397,9 @@ if [ -n "${channel_capture}" ] && [ -n "${timeline_capture}" ]; then
   gap_status="written"
 fi
 
-node - "${summary_out}" "${bundle_index}" "${product_closure_out}" "${readiness_out}" "${capture_dir_status}" "${gap_status}" <<'NODE'
+node - "${summary_out}" "${bundle_index}" "${product_closure_out}" "${readiness_out}" "${capture_dir_status}" "${gap_status}" "${accessibility_capture_status}" <<'NODE'
 const fs = require("node:fs");
-const [summaryOut, bundleIndexPath, productClosurePath, readinessPath, captureDirStatus, gapStatus] = process.argv.slice(2);
+const [summaryOut, bundleIndexPath, productClosurePath, readinessPath, captureDirStatus, gapStatus, accessibilityCaptureStatus] = process.argv.slice(2);
 function parseJsonSuffix(text) {
   const trimmed = String(text || "").trim();
   if (!trimmed) throw new Error("empty JSON input");
@@ -400,6 +432,7 @@ const summary = {
   captures: bundle.captures || {},
   captureDirStatus,
   gapStatus,
+  accessibilityCaptureStatus,
   productClosureStatus: closure.status,
   uiDeviceProofReadiness: closure.stages?.uiDeviceProofReadiness || null,
   readinessStatus: readiness.status,

--- a/test/unit/qa/friday-ui-device-accessibility-click-capture-cli.test.ts
+++ b/test/unit/qa/friday-ui-device-accessibility-click-capture-cli.test.ts
@@ -1,0 +1,180 @@
+import { execFileSync, spawnSync } from "node:child_process";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const script = "scripts/ops/friday-ui-device-accessibility-click-capture.mjs";
+const missionId = "mission_ui_device_accessibility_click_capture";
+
+function writeEvidence(root: string, name: string) {
+  const path = join(root, name);
+  writeFileSync(path, `real accessibility capture bytes for ${name}\n`);
+  return path;
+}
+
+function capture(root: string, overrides: Record<string, unknown> = {}) {
+  const mobileEvidence = writeEvidence(root, "mobile-accessibility.log");
+  const desktopEvidence = writeEvidence(root, "desktop-accessibility.log");
+  const mobile = join(root, "mobile-capture.json");
+  const desktop = join(root, "desktop-capture.json");
+  writeFileSync(mobile, JSON.stringify({
+    truth_label: "ui_device_accessibility_click_capture_real_ui_not_endbar",
+    mission_id: missionId,
+    surface: "mobile",
+    capture_method: "ios_simulator_accessibility",
+    evidence_ref: mobileEvidence,
+    ui_actions: [
+      {
+        screen: "fridayChat",
+        runtimeActionId: "mobile/home/refresh",
+        accessibility_id: "friday.chat.send",
+        interaction: "tap",
+        status: "pass",
+        event: "mission_intake_submitted",
+      },
+      {
+        screen: "fridayChat",
+        runtimeActionId: "mobile/approval/check",
+        capability_id: "security_approval_bound_principal_gate_cat10_netnew",
+        accessibility_id: "friday.chat.approval-card",
+        interaction: "visible",
+        status: "pass",
+        event: "proof_receipt_visible_before_done",
+      },
+    ],
+    ...overrides,
+  }, null, 2));
+  writeFileSync(desktop, JSON.stringify({
+    truth_label: "ui_device_accessibility_click_capture_real_ui_not_endbar",
+    mission_id: missionId,
+    surface: "desktop",
+    capture_method: "macos_accessibility",
+    evidence_ref: desktopEvidence,
+    ui_actions: [
+      {
+        screen: "operations",
+        runtimeActionId: "desktop/operations/refresh",
+        accessibility_id: "friday.desktop.refresh",
+        interaction: "tap",
+        status: "pass",
+        event: "mission_workbench_visible",
+      },
+    ],
+  }, null, 2));
+  return { mobile, desktop };
+}
+
+describe("friday-ui-device-accessibility-click-capture", () => {
+  it("normalizes real accessibility captures into same-run events and action runtime evidence", () => {
+    const root = mkdtempSync(join(tmpdir(), "friday-ui-accessibility-click-"));
+    try {
+      const outDir = join(root, "out");
+      const captures = capture(root);
+      const stdout = execFileSync("node", [
+        script,
+        `--mission-id=${missionId}`,
+        `--out-dir=${outDir}`,
+        `--capture=${captures.mobile}`,
+        `--capture=${captures.desktop}`,
+        "--require-ready",
+      ], { cwd: process.cwd(), encoding: "utf8" });
+      const result = JSON.parse(stdout) as {
+        truth?: string;
+        status?: string;
+        counts?: { eventRows?: number; actionRuntimeRows?: number };
+        outputs?: { events?: string; actionRuntimeEvidence?: string; runtimeEvidencePaths?: string };
+      };
+      expect(result.truth).toBe("ui_device_accessibility_click_capture_normalized_not_proof_not_endbar");
+      expect(result.status).toBe("ready");
+      expect(result.counts?.eventRows).toBe(3);
+      expect(result.counts?.actionRuntimeRows).toBe(3);
+
+      const events = readFileSync(result.outputs?.events || "", "utf8").trim().split("\n").map((line) => JSON.parse(line));
+      expect(events).toContainEqual(expect.objectContaining({
+        surface: "mobile",
+        event: "mission_intake_submitted",
+        mission_id: missionId,
+        source: "ios_simulator_accessibility:friday.chat.send",
+      }));
+      expect(events).toContainEqual(expect.objectContaining({
+        surface: "desktop",
+        event: "mission_workbench_visible",
+        source: "macos_accessibility:friday.desktop.refresh",
+      }));
+
+      const actionEvidence = JSON.parse(readFileSync(result.outputs?.actionRuntimeEvidence || "", "utf8")) as {
+        truth?: string;
+        actions?: Array<{ surface?: string; action_id?: string; evidence_ref?: string; truth_label?: string }>;
+      };
+      expect(actionEvidence.truth).toBe("accessibility_click_action_runtime_evidence_real_ui_not_endbar");
+      expect(actionEvidence.actions?.map((row) => row.action_id)).toEqual([
+        "mobile/home/refresh",
+        "mobile/approval/check",
+        "desktop/operations/refresh",
+      ]);
+      expect(actionEvidence.actions?.every((row) => row.truth_label === "accessibility_click_action_runtime_evidence_real_ui_not_endbar")).toBe(true);
+      expect(readFileSync(result.outputs?.runtimeEvidencePaths || "", "utf8")).toContain(result.outputs?.actionRuntimeEvidence);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("fails closed on synthetic or screenshot-only truth labels without writing outputs", () => {
+    const root = mkdtempSync(join(tmpdir(), "friday-ui-accessibility-click-blocked-"));
+    try {
+      const outDir = join(root, "out");
+      const captures = capture(root, {
+        truth_label: "synthetic_screenshot_only_accessibility_sample",
+      });
+      const result = spawnSync("node", [
+        script,
+        `--mission-id=${missionId}`,
+        `--out-dir=${outDir}`,
+        `--capture=${captures.mobile}`,
+        "--require-ready",
+      ], { cwd: process.cwd(), encoding: "utf8" });
+      expect(result.status).toBe(2);
+      const output = JSON.parse(result.stdout) as { status?: string; blockers?: Array<{ code?: string }> };
+      expect(output.status).toBe("blocked");
+      expect(output.blockers?.map((blocker) => blocker.code)).toContain("truth_label_forbidden");
+      expect(existsSync(join(outDir, "accessibility-click-events.jsonl"))).toBe(false);
+      expect(existsSync(join(outDir, "action-runtime-evidence.json"))).toBe(false);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects cross-mission captures and unsupported proof events", () => {
+    const root = mkdtempSync(join(tmpdir(), "friday-ui-accessibility-click-mismatch-"));
+    try {
+      const outDir = join(root, "out");
+      const captures = capture(root, {
+        mission_id: "mission_other",
+        ui_actions: [{
+          screen: "fridayChat",
+          runtimeActionId: "mobile/home/refresh",
+          accessibility_id: "friday.chat.send",
+          interaction: "tap",
+          status: "pass",
+          event: "unknown_visible_event",
+        }],
+      });
+      const result = spawnSync("node", [
+        script,
+        `--mission-id=${missionId}`,
+        `--out-dir=${outDir}`,
+        `--capture=${captures.mobile}`,
+        "--require-ready",
+      ], { cwd: process.cwd(), encoding: "utf8" });
+      expect(result.status).toBe(2);
+      const output = JSON.parse(result.stdout) as { blockers?: Array<{ code?: string }> };
+      expect(output.blockers?.map((blocker) => blocker.code)).toEqual(expect.arrayContaining([
+        "mission_id_mismatch",
+        "event_not_supported",
+      ]));
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/test/unit/qa/friday-ui-device-proof-shortlist-runner-contract.test.ts
+++ b/test/unit/qa/friday-ui-device-proof-shortlist-runner-contract.test.ts
@@ -1,0 +1,17 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+describe("friday-ui-device-proof-shortlist-runner contract", () => {
+  it("threads real accessibility click captures through the strict UI/device evidence chain", () => {
+    const source = readFileSync("scripts/ops/friday-ui-device-proof-shortlist-runner.sh", "utf8");
+
+    expect(source).toContain("--accessibility-capture");
+    expect(source).toContain("accessibility_captures=()");
+    expect(source).toContain("friday-ui-device-accessibility-click-capture.mjs");
+    expect(source).toContain("--mission-id=${mission_id}");
+    expect(source).toContain("accessibility-click-events.jsonl");
+    expect(source).toContain("runtime_evidence_dirs+=(\"${accessibility_capture_dir}\")");
+    expect(source).toContain("accessibilityCaptureStatus");
+    expect(source).toContain("Runner output is END-BAR only if strict UI/device readiness passes");
+  });
+});


### PR DESCRIPTION
## Summary
- add a strict UI/device accessibility click capture normalizer
- convert already-captured real accessibility observations into same-run event rows and action-runtime evidence
- fail closed on synthetic, fixture, dry-run, screenshot-only, design-proof, cross-mission, unreadable evidence, and unsupported proof events
- thread `--accessibility-capture` into the UI/device proof shortlist runner so real accessibility captures automatically join same-run events and runtime evidence inputs
- add unit/contract coverage for ready output, blocked evidence shapes, and shortlist runner wiring

## Truth labels
- normalizer only: it does not drive the UI by itself
- not screenshot proof, not live GUI tap proof by itself, not END-BAR, not adoption
- intended to feed the existing capture-dir/readiness/gate chain once real iOS/macOS accessibility drivers provide capture JSON
- shortlist runner remains partial until strict UI/device readiness passes with real mobile, desktop, channel, timeline, stress, and negative-control evidence

## Validation
- node --check scripts/ops/friday-ui-device-accessibility-click-capture.mjs
- npx vitest run test/unit/qa/friday-ui-device-accessibility-click-capture-cli.test.ts
- npx vitest run test/unit/qa/friday-ui-device-accessibility-click-capture-cli.test.ts test/unit/qa/friday-ui-device-proof-shortlist-runner-contract.test.ts
- npm run check:ui-device-accessibility-click-capture -- --mission-id=mission_ui_device_accessibility_click_capture --out-dir=/tmp/friday-ui-device-accessibility-click-capture-smoke --capture=/tmp/does-not-exist --require-ready (expected blocked smoke)
- bash -n scripts/ops/friday-ui-device-proof-shortlist-runner.sh
- shellcheck scripts/ops/friday-ui-device-proof-shortlist-runner.sh
- git diff --check
