### PR TITLE
test(desktop): capture initial destination AX proof

### DIFF
--- a/apps/macos/FridayHubConsole/Sources/FridayHubConsole/FridayHubConsoleApp.swift
+++ b/apps/macos/FridayHubConsole/Sources/FridayHubConsole/FridayHubConsoleApp.swift
@@ -48,6 +48,7 @@ struct FridayHubConsoleApp: App {
   var body: some Scene {
     WindowGroup("Friday Hub Console") {
       HubConsoleShell(
+        initialDestination: Self.initialDestination,
         client: Self.readClient,
         writeClient: Self.writeClient,
         missionRunClient: Self.writeClient,
@@ -65,6 +66,53 @@ struct FridayHubConsoleApp: App {
     return args.contains("--use-mock-read-client") || env["FRIDAY_CONSOLE_MOCK"] == "1"
   }
 
+  /// Proof-runner destination override. Normal user launches default to Operations.
+  /// This mirrors the iOS simulator `--initial-destination` seam and changes only
+  /// the first visible desktop route; it does not alter live/mock or trust behavior.
+  private static var initialDestination: HubDestination {
+    let args = ProcessInfo.processInfo.arguments
+    let env = ProcessInfo.processInfo.environment
+    if let envValue = env["FRIDAY_CONSOLE_INITIAL_DESTINATION"]?.trimmingCharacters(in: .whitespacesAndNewlines),
+       let destination = HubDestination(rawValue: envValue) {
+      return destination
+    }
+    for (index, arg) in args.enumerated() {
+      if arg.hasPrefix("--initial-destination=") {
+        let rawValue = String(arg.dropFirst("--initial-destination=".count))
+        if let destination = HubDestination(rawValue: rawValue) {
+          return destination
+        }
+      }
+      if arg == "--initial-destination", args.indices.contains(index + 1),
+         let destination = HubDestination(rawValue: args[index + 1]) {
+        return destination
+      }
+    }
+    return .operations
+  }
+
+  /// Optional live-read projection target for proof/user launches. Normal user launches leave this
+  /// unset, so the server keeps its existing "first active Mission" behavior.
+  private static var missionId: String? {
+    let args = ProcessInfo.processInfo.arguments
+    let env = ProcessInfo.processInfo.environment
+    if let envValue = env["FRIDAY_CONSOLE_MISSION_ID"]?.trimmingCharacters(in: .whitespacesAndNewlines),
+       !envValue.isEmpty {
+      return envValue
+    }
+    for (index, arg) in args.enumerated() {
+      if arg.hasPrefix("--mission-id=") {
+        let value = String(arg.dropFirst("--mission-id=".count)).trimmingCharacters(in: .whitespacesAndNewlines)
+        return value.isEmpty ? nil : value
+      }
+      if arg == "--mission-id", args.indices.contains(index + 1) {
+        let value = args[index + 1].trimmingCharacters(in: .whitespacesAndNewlines)
+        return value.isEmpty ? nil : value
+      }
+    }
+    return nil
+  }
+
   /// The read client the shell uses. DEFAULT = LIVE; MOCK only when explicitly opted in.
   static var readClient: FridayRustReadClient {
     // MOCK is an explicit design/demo opt-in only (re-adopting #682's `--use-mock-read-client`
@@ -77,7 +125,7 @@ struct FridayHubConsoleApp: App {
     // back to the mock, which would fabricate a ready view the live seam did not produce.
     // (The actual connect happens later in the shell's async refresh; this is non-blocking.)
     do {
-      return try RealReadClientFactory.makeLive()
+      return try RealReadClientFactory.makeLive(missionId: Self.missionId)
     } catch {
       return RealReadClientFactory.makeHonestlyUnavailable(reason: "\(error)")
     }

--- a/apps/macos/FridayHubConsole/Sources/FridayHubConsole/HubConsoleShell.swift
+++ b/apps/macos/FridayHubConsole/Sources/FridayHubConsole/HubConsoleShell.swift
@@ -7,10 +7,12 @@ import SwiftUI
 ///
 /// Default screen = Operations Overview (locked: screen = operations).
 struct HubConsoleShell: View {
-  @State private var destination: HubDestination = .operations
+  @State private var destination: HubDestination
   @StateObject private var operationsVM: OperationsOverviewViewModel
+  private let initialDestination: HubDestination
 
   init(
+    initialDestination: HubDestination = .operations,
     client: FridayRustReadClient,
     writeClient: FridayMissionSpineWriteClient? = nil,
     missionRunClient: FridayMissionBoundRunWriteClient? = nil,
@@ -24,6 +26,8 @@ struct HubConsoleShell: View {
         missionRunClient: missionRunClient,
         approvalSigner: approvalSigner,
         approvalResumeClient: approvalResumeClient))
+    _destination = State(initialValue: initialDestination)
+    self.initialDestination = initialDestination
   }
 
   var body: some View {
@@ -47,6 +51,9 @@ struct HubConsoleShell: View {
     }
     .frame(minWidth: 1080, minHeight: 680)
     .background(HubTheme.backgroundWarmOffWhite)
+    .onAppear {
+      destination = initialDestination
+    }
     .task {
       // Initial read on launch.
       if case .idle = operationsVM.state {

--- a/scripts/ops/friday-desktop-ax-accessibility-capture.mjs
+++ b/scripts/ops/friday-desktop-ax-accessibility-capture.mjs
@@ -11,6 +11,7 @@ function usage() {
   node scripts/ops/friday-desktop-ax-accessibility-capture.mjs \\
     --mission-id=mission_... --out-dir=/abs/out-dir
     [--repo-root=/abs/repo] [--app-dir=/abs/FridayHubConsole.app]
+    [--destinations=operations,chat,...] [--workbench-mission-id=mission_...]
     [--timeout-seconds=20] [--plan-only] [--require-observed]
 
 Truth:
@@ -40,6 +41,8 @@ const repoRoot = resolve(arg("repo-root") || process.env.FRIDAY_REPO_ROOT || new
 const missionId = arg("mission-id");
 const outDir = arg("out-dir");
 const appDirArg = arg("app-dir") || process.env.FRIDAY_HUB_CONSOLE_APP_DIR || "";
+const destinationsCsv = arg("destinations") || process.env.FRIDAY_DESKTOP_AX_CAPTURE_DESTINATIONS || "";
+const workbenchMissionId = arg("workbench-mission-id") || process.env.FRIDAY_DESKTOP_AX_WORKBENCH_MISSION_ID || "";
 const timeoutSeconds = Number(arg("timeout-seconds") || process.env.FRIDAY_DESKTOP_AX_CAPTURE_TIMEOUT_SECONDS || "20");
 const planOnly = args.includes("--plan-only");
 const requireObserved = args.includes("--require-observed");
@@ -113,7 +116,10 @@ const defaultActionMap = new Map([
 ]);
 
 function actionPlan() {
-  return parseDesktopDestinations().flatMap((destination) =>
+  const destinationFilter = new Set(destinationsCsv.split(",").map((value) => value.trim()).filter(Boolean));
+  return parseDesktopDestinations()
+    .filter((destination) => destinationFilter.size === 0 || destinationFilter.has(destination.destination))
+    .flatMap((destination) =>
     destination.runtimeActionIds.map((runtimeActionId) => ({
       runtimeActionId,
       destination: defaultActionMap.get(runtimeActionId)?.destination || destination.destination,
@@ -125,8 +131,7 @@ function actionPlan() {
         event: "mission_workbench_visible",
         interaction: "visible",
       }),
-    })),
-  );
+    })));
 }
 
 function jsonOut(path, value) {
@@ -146,8 +151,6 @@ function waitForWindow() {
   const deadline = Date.now() + timeoutSeconds * 1000;
   while (Date.now() < deadline) {
     const result = osascript(`
-tell application "FridayHubConsole" to activate
-delay 0.2
 tell application "System Events"
   if exists process "FridayHubConsole" then
     tell process "FridayHubConsole"
@@ -265,10 +268,9 @@ on clickMatchingElement(e, identifierValue, titleValue, depth)
     end try
   end if
 end clickMatchingElement
-tell application "FridayHubConsole" to activate
-delay 0.1
 tell application "System Events"
   tell process "FridayHubConsole"
+    set frontmost to true
     if (count of windows) = 0 then return "window_missing"
     my clickMatchingElement(window 1, ${appleString(identifier)}, ${appleString(title || destination)}, 0)
     if didClick then return "clicked"
@@ -353,35 +355,54 @@ if (appBinary && existsSync(appBinary)) {
   }
 }
 
-let appProcess = null;
-if (blockers.length === 0) {
-  appProcess = spawn(appBinary, [], {
+function quitApp() {
+  spawnSync("/usr/bin/osascript", ["-e", "tell application \"FridayHubConsole\" to quit"], { stdio: "ignore", timeout: 1500 });
+  const deadline = Date.now() + 5000;
+  while (Date.now() < deadline) {
+    const probe = spawnSync("/usr/bin/osascript", [
+      "-e",
+      "tell application \"System Events\" to if exists process \"FridayHubConsole\" then return \"running\" else return \"missing\"",
+    ], { encoding: "utf8", timeout: 1500 });
+    if (probe.stdout.trim() === "missing") return;
+    Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 200);
+  }
+}
+
+function launchApp(destination) {
+  quitApp();
+  const launchArgs = [`--initial-destination=${destination}`];
+  if (workbenchMissionId) launchArgs.push(`--mission-id=${workbenchMissionId}`);
+  const appProcess = spawn(appBinary, launchArgs, {
     cwd: repoRoot,
-    env: { ...process.env, FRIDAY_CONSOLE_MOCK: "0" },
+    env: {
+      ...process.env,
+      FRIDAY_CONSOLE_MOCK: "0",
+      FRIDAY_CONSOLE_INITIAL_DESTINATION: destination,
+      ...(workbenchMissionId ? { FRIDAY_CONSOLE_MISSION_ID: workbenchMissionId } : {}),
+    },
     detached: true,
     stdio: "ignore",
   });
   appProcess.unref();
-  if (appProcess.pid) {
-    process.on("exit", () => {
-      try {
-        spawnSync("/usr/bin/osascript", ["-e", "tell application \"FridayHubConsole\" to quit"], { stdio: "ignore" });
-      } catch {
-        // Best-effort cleanup of the app process this script launched.
-      }
-    });
-  } else {
+  if (!appProcess.pid) {
     block("app_launch_failed", "pid_missing");
+    return false;
   }
+  return waitForWindow();
 }
 
-const ready = blockers.length === 0 ? waitForWindow() : false;
-if (!ready) block("app_window_not_ready", "FridayHubConsole");
+process.on("exit", () => {
+  try {
+    quitApp();
+  } catch {
+    // Best-effort cleanup of the app process this script launched.
+  }
+});
 
 const observedActions = [];
 const rawSnapshots = [];
 const missingTargets = [];
-if (ready) {
+if (blockers.length === 0) {
   const byDestination = new Map();
   for (const target of targets) {
     const list = byDestination.get(target.destination) || [];
@@ -390,8 +411,13 @@ if (ready) {
   }
 
   for (const [destination, destinationTargets] of byDestination.entries()) {
+    const ready = launchApp(destination);
+    if (!ready) {
+      block("app_window_not_ready", `FridayHubConsole:${destination}`);
+      continue;
+    }
     const nav = clickNav(destination, destinationTargets[0]?.title || destination);
-    const navStatus = nav.status === 0 ? nav.stdout.trim() : nav.stderr.trim();
+    const navStatus = `initial_destination;${nav.status === 0 ? nav.stdout.trim() : nav.stderr.trim()}`;
     await new Promise((resolveWait) => setTimeout(resolveWait, 350));
     const raw = captureTreeRaw();
     rawSnapshots.push(`--- destination=${destination} nav=${navStatus} ---\n${raw}`);

--- a/test/unit/qa/friday-desktop-initial-destination-contract.test.ts
+++ b/test/unit/qa/friday-desktop-initial-destination-contract.test.ts
@@ -1,0 +1,23 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+describe("FridayHubConsole initial destination proof seam", () => {
+  it("mirrors the iOS initial-destination launch seam without changing live/mock mode", () => {
+    const app = readFileSync("apps/macos/FridayHubConsole/Sources/FridayHubConsole/FridayHubConsoleApp.swift", "utf8");
+    const shell = readFileSync("apps/macos/FridayHubConsole/Sources/FridayHubConsole/HubConsoleShell.swift", "utf8");
+    const capture = readFileSync("scripts/ops/friday-desktop-ax-accessibility-capture.mjs", "utf8");
+
+    expect(app).toContain("FRIDAY_CONSOLE_INITIAL_DESTINATION");
+    expect(app).toContain("--initial-destination=");
+    expect(app).toContain("FRIDAY_CONSOLE_MISSION_ID");
+    expect(app).toContain("--mission-id=");
+    expect(app).toContain("RealReadClientFactory.makeLive(missionId: Self.missionId)");
+    expect(app).toContain("return .operations");
+    expect(shell).toContain("initialDestination: HubDestination = .operations");
+    expect(shell).toContain("_destination = State(initialValue: initialDestination)");
+    expect(capture).toContain("FRIDAY_CONSOLE_INITIAL_DESTINATION: destination");
+    expect(capture).toContain("FRIDAY_CONSOLE_MISSION_ID");
+    expect(capture).toContain("--workbench-mission-id");
+    expect(capture).toContain("initial_destination");
+  });
+});


### PR DESCRIPTION
## Summary
- add FridayHubConsole proof/user launch seams for `--initial-destination` / `FRIDAY_CONSOLE_INITIAL_DESTINATION` and `--mission-id` / `FRIDAY_CONSOLE_MISSION_ID` while preserving normal defaults
- update the desktop AX capture runner to launch each destination directly, optionally target a real workbench mission, avoid LaunchServices default activation, and bound best-effort app cleanup
- add a contract test for the desktop initial-destination + mission targeting proof seam

## Local Verification
- `npx vitest run test/unit/qa/friday-desktop-initial-destination-contract.test.ts test/unit/qa/friday-desktop-ax-accessibility-capture-contract.test.ts`
- `swift build --package-path apps/macos/FridayHubConsole`
- `git diff --check`

## Real Proof
Default live desktop capture:
- `node scripts/ops/friday-desktop-ax-accessibility-capture.mjs --mission-id=mission_desktop_initial_destination_timeout --out-dir=/tmp/friday-desktop-initial-destination-smoke-timeout --timeout-seconds=30`
- `node scripts/ops/friday-ui-device-accessibility-click-capture.mjs --mission-id=mission_desktop_initial_destination_timeout --out-dir=/tmp/friday-desktop-initial-destination-normalized-timeout --capture=/tmp/friday-desktop-initial-destination-smoke-timeout/desktop-ax-accessibility-capture.json --require-ready`
- observed 10 action-runtime rows

Targeted organic mission desktop capture:
- `node scripts/ops/friday-desktop-ax-accessibility-capture.mjs --mission-id=mission_desktop_organic_target_smoke_head --workbench-mission-id=codex-organic-mission-aef06afa-543e-4cc5-9c8d-3352357ec3fd --out-dir=/tmp/friday-desktop-organic-mission-target-smoke-head --timeout-seconds=30`
- `node scripts/ops/friday-ui-device-accessibility-click-capture.mjs --mission-id=mission_desktop_organic_target_smoke_head --out-dir=/tmp/friday-desktop-organic-mission-target-normalized-head --capture=/tmp/friday-desktop-organic-mission-target-smoke-head/desktop-ax-accessibility-capture.json --require-ready`
- observed 11 action-runtime rows against commit `44587fb212b9c50e5c1c78ce87566dbfbe62f8cb`

## Truth Label
- Desktop real AX coverage now observes 11 action-runtime rows when pointed at the operator-origin organic Codex mission.
- Remaining desktop misses are true dynamic-data/scenario gaps, not claimed done: `desktop/recovery/retry`, `desktop/recovery/cancel`, `desktop/memory/act`, `desktop/memory/check`.
- This is not END-BAR, not adoption, not mobile+desktop closure, and not a replacement for strict UI/device proof.
