### PR TITLE
test(desktop): prove dynamic Workbench projections

### DIFF
--- a/apps/macos/FridayHubConsole/Sources/FridayHubConsole/DesktopProjectionScreens.swift
+++ b/apps/macos/FridayHubConsole/Sources/FridayHubConsole/DesktopProjectionScreens.swift
@@ -822,6 +822,7 @@ struct DesktopProjectionScreen: View {
       VStack(alignment: .leading, spacing: HubTheme.rowSpacing) {
         HStack {
           cardTitle("Memory Review Evidence")
+            .accessibilityIdentifier("friday.desktop.evidence.memory-review")
           Spacer()
           StatusChip(
             text: "\(snapshot.memoryCandidates.count)",
@@ -843,6 +844,7 @@ struct DesktopProjectionScreen: View {
                 .font(.system(size: 12))
                 .foregroundStyle(HubTheme.textPrimary)
                 .lineLimit(2)
+                .accessibilityIdentifier("friday.desktop.evidence.memory-candidate")
               HStack(spacing: 6) {
                 StatusChip(
                   text: candidate.state,

--- a/rust-core/crates/friday-hub/src/bin/hub_attach_memory_candidate.rs
+++ b/rust-core/crates/friday-hub/src/bin/hub_attach_memory_candidate.rs
@@ -1,0 +1,308 @@
+//! Attach an existing pending memory candidate to a Mission for refs-only Workbench proof.
+//!
+//! This is an ops/proof driver. It does not create a memory item, does not read or print
+//! candidate content, and does not confirm/reject/grant memory authority. The only write is the
+//! existing governed [`friday_hub::mission_preflight::attach_memory_candidate_ref`] path.
+
+use std::env;
+use std::path::Path;
+
+use friday_hub::mission_preflight::{attach_memory_candidate_ref, MissionAttachmentOutcome};
+use friday_hub::workbench_projection::project_workbench;
+use friday_storage::{Db, StorageError};
+use serde_json::{json, Value};
+
+const ACK: &str = "operator-approved-existing-candidate-mission-attach";
+
+fn main() {
+    match run() {
+        Ok(rendered) => println!("{rendered}"),
+        Err(err) => {
+            let payload = json!({
+                "truth_label": "hub_attach_memory_candidate_refs_only",
+                "ok": false,
+                "error_kind": err,
+            });
+            println!("{}", payload);
+            eprintln!("hub_attach_memory_candidate_unavailable: {err}");
+            std::process::exit(2);
+        }
+    }
+}
+
+fn run() -> Result<String, &'static str> {
+    let args: Vec<String> = env::args().collect();
+    let db_path = arg_value(&args, "--db").ok_or("bad_args")?;
+    let mission_id = arg_value(&args, "--mission-id").ok_or("bad_args")?;
+    let memory_id = arg_value(&args, "--memory-id").ok_or("bad_args")?;
+    let ack = arg_value(&args, "--ack")
+        .or_else(|| env::var("FRIDAY_ATTACH_MEMORY_CANDIDATE_ACK").ok())
+        .ok_or("ack_required")?;
+    if ack != ACK {
+        return Err("ack_mismatch");
+    }
+    if !Path::new(&db_path).is_file() {
+        return Err("db_not_found");
+    }
+
+    render_attach(&db_path, &mission_id, &memory_id, now_ms())
+}
+
+fn render_attach(
+    db_path: &str,
+    mission_id: &str,
+    memory_id: &str,
+    now_ms: i64,
+) -> Result<String, &'static str> {
+    let db = Db::open_hub(db_path).map_err(map_open_error)?;
+    let outcome = attach_memory_candidate_ref(&db, mission_id, memory_id, now_ms)
+        .map_err(|_| "attach_failed")?;
+    let (status, link_id, blockers) = outcome_fields(&outcome);
+    let snapshot = project_workbench(&db, Some(mission_id)).map_err(|_| "project_failed")?;
+    let visible = snapshot
+        .get("memoryCandidates")
+        .and_then(Value::as_array)
+        .map(|rows| {
+            rows.iter()
+                .any(|row| row.get("id").and_then(Value::as_str) == Some(memory_id))
+        })
+        .unwrap_or(false);
+
+    let payload = json!({
+        "truth_label": "hub_attach_memory_candidate_refs_only",
+        "proof_only": true,
+        "ok": matches!(outcome, MissionAttachmentOutcome::Attached { .. } | MissionAttachmentOutcome::MissionLinked { .. }) && visible,
+        "mission_id": mission_id,
+        "memory_id": memory_id,
+        "status": status,
+        "link_id": link_id,
+        "blockers": blockers,
+        "workbench_memory_candidate_visible": visible,
+        "authority_granted": false,
+        "candidate_content_emitted": false,
+    });
+    let rendered = serde_json::to_string_pretty(&payload).map_err(|_| "serialize_failed")?;
+    reject_forbidden_output(&rendered)?;
+    Ok(rendered)
+}
+
+fn outcome_fields(outcome: &MissionAttachmentOutcome) -> (&'static str, Option<&str>, Vec<String>) {
+    match outcome {
+        MissionAttachmentOutcome::Attached { link_id, .. } => {
+            ("attached", Some(link_id.as_str()), Vec::new())
+        }
+        MissionAttachmentOutcome::MissionLinked { link_id } => {
+            ("mission_linked", Some(link_id.as_str()), Vec::new())
+        }
+        MissionAttachmentOutcome::Blocked { blockers } => ("blocked", None, blockers.clone()),
+    }
+}
+
+fn map_open_error(err: StorageError) -> &'static str {
+    match err {
+        StorageError::SchemaTooNew { .. } => "schema_too_new",
+        _ => "open_failed",
+    }
+}
+
+fn reject_forbidden_output(rendered: &str) -> Result<(), &'static str> {
+    friday_hub::refs_guard::reject_forbidden_output(
+        rendered,
+        &["\"content\"", "\"candidate_content\""],
+    )
+    .map_err(|_| "output_guard")
+}
+
+fn arg_value(args: &[String], name: &str) -> Option<String> {
+    args.windows(2)
+        .find_map(|pair| (pair[0] == name).then(|| pair[1].clone()))
+        .or_else(|| {
+            let prefix = format!("{name}=");
+            args.iter()
+                .find_map(|arg| arg.strip_prefix(&prefix).map(str::to_string))
+        })
+}
+
+fn now_ms() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as i64)
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use friday_core::{
+        ApprovalState, FridayConversation, HandoffJudgmentMemory, MemoryScope, Mission,
+        MissionStatus, RouteDecisionCard, TruthStatus, WorkItem, WorkItemStatus, WorkLane,
+    };
+    use friday_storage::memory::{record_candidate, NewMemoryCandidate};
+
+    #[test]
+    fn arg_value_supports_space_and_equals_forms() {
+        let args = vec![
+            "bin".to_string(),
+            "--db=/tmp/hub.sqlite".to_string(),
+            "--mission-id".to_string(),
+            "mission-1".to_string(),
+            "--memory-id".to_string(),
+            "mem-1".to_string(),
+        ];
+        assert_eq!(arg_value(&args, "--db").as_deref(), Some("/tmp/hub.sqlite"));
+        assert_eq!(
+            arg_value(&args, "--mission-id").as_deref(),
+            Some("mission-1")
+        );
+        assert_eq!(arg_value(&args, "--memory-id").as_deref(), Some("mem-1"));
+    }
+
+    #[test]
+    fn existing_candidate_attach_surfaces_workbench_memory_candidate_without_content() {
+        let path = tmp_db();
+        let db = Db::open_hub(&path).unwrap();
+        db.upsert_friday_conversation(&FridayConversation {
+            friday_conversation_id: "fconv_memory_attach".into(),
+            owner_principal: "admin-001".into(),
+            title: "Memory attach proof".into(),
+            current_focus_summary: "refs-only candidate attach".into(),
+            active_mission_ids: vec!["mission_memory_attach".into()],
+            surface_thread_ids: Vec::new(),
+            memory_scope_ref: None,
+            truth_status: TruthStatus::Proven,
+            proof_refs: Vec::new(),
+            created_at_ms: 10,
+            updated_at_ms: 10,
+        })
+        .unwrap();
+        db.upsert_mission(&Mission {
+            mission_id: "mission_memory_attach".into(),
+            friday_conversation_id: "fconv_memory_attach".into(),
+            title: "Memory attach proof".into(),
+            intent: "surface review-only memory candidate".into(),
+            status: MissionStatus::Active,
+            why_now: "desktop evidence needs real memory projection".into(),
+            decision_path_summary: "existing candidate attach".into(),
+            considered_options: Vec::new(),
+            deferred_options: vec!["final mobile+desktop UI proof".into()],
+            known_pitfalls: Vec::new(),
+            handoff_inheritance: Vec::new(),
+            work_item_ids: vec!["work_memory_attach".into()],
+            memory_candidate_refs: Vec::new(),
+            context_passport_refs: Vec::new(),
+            proof_refs: Vec::new(),
+            created_at_ms: 10,
+            updated_at_ms: 10,
+        })
+        .unwrap();
+        let work_item = WorkItem {
+            work_item_id: "work_memory_attach".into(),
+            mission_id: "mission_memory_attach".into(),
+            lane: WorkLane::DeepSeek,
+            target_provider_or_agent: Some("deepseek".into()),
+            status: WorkItemStatus::ReadyToDispatch,
+            owner_claim_ids: Vec::new(),
+            workspace_refs: Vec::new(),
+            capability_id: Some("memory.review".into()),
+            risk_level: friday_core::Risk::Low,
+            approval_state: ApprovalState::NotRequired,
+            blocking_reason: None,
+            input_refs: vec!["body://redacted/memory-review".into()],
+            output_refs: Vec::new(),
+            proof_requirements: vec!["refs-only memory candidate projection".into()],
+            proof_receipts: Vec::new(),
+            judgment_memory: judgment(),
+            created_at_ms: 10,
+            updated_at_ms: 10,
+        };
+        db.upsert_work_item(&work_item).unwrap();
+        db.upsert_route_decision(&RouteDecisionCard::from_work_item(
+            "route_memory_attach".into(),
+            &work_item,
+            vec!["trace://redacted/memory-route".into()],
+            11,
+            None,
+        ))
+        .unwrap();
+        record_candidate(
+            db.conn(),
+            &NewMemoryCandidate {
+                memory_id: "mem-existing-candidate",
+                scope: MemoryScope::Session,
+                content_ref: Some("friday://memory-candidate/existing"),
+                content: Some("Candidate content must never be emitted by this proof bin."),
+                principal_id: Some("tenant.default.channel.unknown.user.admin-001.shared"),
+                sensitive: false,
+                created_at: 11,
+            },
+        )
+        .unwrap();
+
+        let rendered = run_with_args(vec![
+            "bin",
+            "--db",
+            &path,
+            "--mission-id",
+            "mission_memory_attach",
+            "--memory-id",
+            "mem-existing-candidate",
+            "--ack",
+            ACK,
+        ])
+        .unwrap();
+        let parsed: Value = serde_json::from_str(&rendered).unwrap();
+        assert_eq!(parsed["ok"], true);
+        assert_eq!(parsed["workbench_memory_candidate_visible"], true);
+        assert_eq!(parsed["authority_granted"], false);
+        assert!(reject_forbidden_output(&rendered).is_ok());
+        assert!(!rendered.contains("Candidate content must never"));
+    }
+
+    fn run_with_args(raw: Vec<&str>) -> Result<String, &'static str> {
+        let args = raw.into_iter().map(str::to_string).collect::<Vec<_>>();
+        run_from_args(args)
+    }
+
+    fn run_from_args(args: Vec<String>) -> Result<String, &'static str> {
+        let db_path = arg_value(&args, "--db").ok_or("bad_args")?;
+        let mission_id = arg_value(&args, "--mission-id").ok_or("bad_args")?;
+        let memory_id = arg_value(&args, "--memory-id").ok_or("bad_args")?;
+        let ack = arg_value(&args, "--ack").ok_or("ack_required")?;
+        if ack != ACK {
+            return Err("ack_mismatch");
+        }
+        render_attach(&db_path, &mission_id, &memory_id, 12)
+    }
+
+    fn tmp_db() -> String {
+        let mut path = std::env::temp_dir();
+        path.push(format!(
+            "friday-attach-memory-candidate-{}-{}.sqlite",
+            std::process::id(),
+            now_ms()
+        ));
+        path.to_string_lossy().to_string()
+    }
+
+    fn judgment() -> HandoffJudgmentMemory {
+        HandoffJudgmentMemory {
+            task: "Memory candidate Workbench projection".into(),
+            current_blocker: None,
+            target_lane_thread_agent_provider: "deepseek".into(),
+            read_first_files: Vec::new(),
+            required_output: "refs-only candidate projection".into(),
+            done_criteria: vec!["memory candidate is visible without content".into()],
+            red_lines: vec![
+                "do not confirm memory".into(),
+                "do not emit candidate content".into(),
+            ],
+            why_this_route: "Workbench consumes mission refs owned by Rust Hub.".into(),
+            considered_options: vec!["direct SQL".into(), "governed attach path".into()],
+            deferred_options: vec!["final UI/device capture".into()],
+            previous_pitfalls: vec!["visible UI is not memory authority".into()],
+            inheritable_context: vec!["memory candidate remains review-only".into()],
+            proof_requirements: vec!["refs-only output guard".into()],
+            ownership_claim_ids: Vec::new(),
+        }
+    }
+}

--- a/rust-core/crates/friday-hub/src/bin/hub_seed_recovery_projection.rs
+++ b/rust-core/crates/friday-hub/src/bin/hub_seed_recovery_projection.rs
@@ -1,0 +1,263 @@
+//! Seed a controlled recovery Workbench scenario for real desktop Accessibility proof.
+//!
+//! This proof driver writes a new Mission + one `FailedRetryable` WorkItem through typed storage
+//! APIs. It does not touch existing user/organic missions, does not dispatch a provider, and does
+//! not claim adoption or END-BAR. The seeded row exists only so the desktop recovery surface can
+//! prove its retry/cancel affordances against real Rust Hub projection data.
+
+use std::env;
+use std::path::Path;
+
+use friday_core::{
+    ApprovalState, FridayConversation, HandoffJudgmentMemory, Mission, MissionStatus,
+    RouteDecisionCard, TruthStatus, WorkItem, WorkItemStatus, WorkLane,
+};
+use friday_storage::{Db, StorageError};
+use serde_json::json;
+
+const ACK: &str = "operator-approved-controlled-recovery-projection";
+
+fn main() {
+    match run() {
+        Ok(rendered) => println!("{rendered}"),
+        Err(err) => {
+            let payload = json!({
+                "truth_label": "hub_seed_recovery_projection_controlled_not_organic",
+                "ok": false,
+                "error_kind": err,
+            });
+            println!("{}", payload);
+            eprintln!("hub_seed_recovery_projection_unavailable: {err}");
+            std::process::exit(2);
+        }
+    }
+}
+
+fn run() -> Result<String, &'static str> {
+    let args: Vec<String> = env::args().collect();
+    let db_path = arg_value(&args, "--db").ok_or("bad_args")?;
+    let mission_id = arg_value(&args, "--mission-id").ok_or("bad_args")?;
+    let ack = arg_value(&args, "--ack")
+        .or_else(|| env::var("FRIDAY_SEED_RECOVERY_PROJECTION_ACK").ok())
+        .ok_or("ack_required")?;
+    if ack != ACK {
+        return Err("ack_mismatch");
+    }
+    if !Path::new(&db_path).is_file() {
+        return Err("db_not_found");
+    }
+
+    seed_recovery_projection(&db_path, &mission_id, now_ms())
+}
+
+fn seed_recovery_projection(
+    db_path: &str,
+    mission_id: &str,
+    now_ms: i64,
+) -> Result<String, &'static str> {
+    if !mission_id.starts_with("mission_desktop_recovery_") {
+        return Err("mission_id_not_controlled_recovery");
+    }
+    let db = Db::open_hub(db_path).map_err(map_open_error)?;
+    let conversation_id = format!("fconv_{mission_id}");
+    let work_item_id = format!("work_{mission_id}");
+    let route_id = format!("route_{mission_id}");
+
+    db.upsert_friday_conversation(&FridayConversation {
+        friday_conversation_id: conversation_id.clone(),
+        owner_principal: "admin-001".into(),
+        title: "Desktop recovery projection proof".into(),
+        current_focus_summary:
+            "controlled refs-only recovery scenario for desktop Accessibility proof".into(),
+        active_mission_ids: vec![mission_id.into()],
+        surface_thread_ids: Vec::new(),
+        memory_scope_ref: None,
+        truth_status: TruthStatus::Proven,
+        proof_refs: vec!["proof://desktop/recovery/projection-controlled".into()],
+        created_at_ms: now_ms,
+        updated_at_ms: now_ms,
+    })
+    .map_err(|_| "conversation_write_failed")?;
+
+    db.upsert_mission(&Mission {
+        mission_id: mission_id.into(),
+        friday_conversation_id: conversation_id,
+        title: "Prove desktop recovery queue".into(),
+        intent: "show retry/cancel affordances only when Rust Hub projects a retryable WorkItem"
+            .into(),
+        status: MissionStatus::Active,
+        why_now: "desktop AX runtime coverage needs a real recoverable WorkItem".into(),
+        decision_path_summary:
+            "controlled proof mission; not organic traffic and not provider execution".into(),
+        considered_options: vec![
+            "fake UI button".into(),
+            "controlled typed Rust Hub WorkItem projection".into(),
+        ],
+        deferred_options: vec!["organic recovery occurrence".into()],
+        known_pitfalls: vec!["do not count this as organic or adoption".into()],
+        handoff_inheritance: vec!["refs-only recovery proof".into()],
+        work_item_ids: vec![work_item_id.clone()],
+        memory_candidate_refs: Vec::new(),
+        context_passport_refs: Vec::new(),
+        proof_refs: vec!["proof://desktop/recovery/projection-controlled".into()],
+        created_at_ms: now_ms,
+        updated_at_ms: now_ms,
+    })
+    .map_err(|_| "mission_write_failed")?;
+
+    let work_item = WorkItem {
+        work_item_id: work_item_id.clone(),
+        mission_id: mission_id.into(),
+        lane: WorkLane::DeepSeek,
+        target_provider_or_agent: Some("deepseek".into()),
+        status: WorkItemStatus::FailedRetryable,
+        owner_claim_ids: Vec::new(),
+        workspace_refs: Vec::new(),
+        capability_id: Some("desktop.recovery.proof".into()),
+        risk_level: friday_core::Risk::Low,
+        approval_state: ApprovalState::NotRequired,
+        blocking_reason: Some(
+            "controlled retryable proof row; no provider dispatch occurred".into(),
+        ),
+        input_refs: vec!["body://redacted/desktop-recovery-proof".into()],
+        output_refs: Vec::new(),
+        proof_requirements: vec!["desktop recovery retry/cancel visible in real AX tree".into()],
+        proof_receipts: Vec::new(),
+        judgment_memory: judgment(),
+        created_at_ms: now_ms,
+        updated_at_ms: now_ms,
+    };
+    db.upsert_work_item(&work_item)
+        .map_err(|_| "work_item_write_failed")?;
+    db.upsert_route_decision(&RouteDecisionCard::from_work_item(
+        route_id,
+        &work_item,
+        vec!["trace://redacted/desktop-recovery-proof".into()],
+        now_ms,
+        None,
+    ))
+    .map_err(|_| "route_decision_write_failed")?;
+
+    let snapshot = friday_hub::workbench_projection::project_workbench(&db, Some(mission_id))
+        .map_err(|_| "project_failed")?;
+    let work_items = snapshot
+        .get("workItems")
+        .and_then(|rows| rows.as_array())
+        .ok_or("projection_missing_work_items")?;
+    let retry_visible = work_items.iter().any(|row| {
+        row.get("id").and_then(|id| id.as_str()) == Some(work_item_id.as_str())
+            && row.get("canRetry").and_then(|value| value.as_bool()) == Some(true)
+    });
+    let cancel_visible = work_items.iter().any(|row| {
+        row.get("id").and_then(|id| id.as_str()) == Some(work_item_id.as_str())
+            && row.get("canCancel").and_then(|value| value.as_bool()) == Some(true)
+    });
+
+    let payload = json!({
+        "truth_label": "hub_seed_recovery_projection_controlled_not_organic",
+        "ok": retry_visible && cancel_visible,
+        "mission_id": mission_id,
+        "work_item_id": work_item_id,
+        "status": "failed_retryable",
+        "retry_visible": retry_visible,
+        "cancel_visible": cancel_visible,
+        "organic": false,
+        "provider_dispatched": false,
+        "endbar": false,
+    });
+    serde_json::to_string_pretty(&payload).map_err(|_| "serialize_failed")
+}
+
+fn judgment() -> HandoffJudgmentMemory {
+    HandoffJudgmentMemory {
+        task: "Desktop recovery retry/cancel projection".into(),
+        current_blocker: Some("controlled retryable row for AX proof".into()),
+        target_lane_thread_agent_provider: "deepseek".into(),
+        read_first_files: vec![
+            "rust-core/crates/friday-hub/src/workbench_projection.rs".into(),
+            "apps/macos/FridayHubConsole/Sources/FridayHubConsole/DesktopProjectionScreens.swift"
+                .into(),
+        ],
+        required_output: "real desktop AX tree shows retry and cancel affordances".into(),
+        done_criteria: vec!["retry available".into(), "cancel available".into()],
+        red_lines: vec![
+            "do not count as organic".into(),
+            "do not dispatch provider".into(),
+            "do not claim END-BAR".into(),
+        ],
+        why_this_route:
+            "Recovery UI must be proven against Rust-owned WorkItem lifecycle projection.".into(),
+        considered_options: vec!["fake UI target".into(), "typed projection proof row".into()],
+        deferred_options: vec!["organic recovery occurrence".into()],
+        previous_pitfalls: vec!["empty recovery queue looked like missing UI".into()],
+        inheritable_context: vec!["controlled proof only".into()],
+        proof_requirements: vec!["desktop Accessibility capture".into()],
+        ownership_claim_ids: Vec::new(),
+    }
+}
+
+fn map_open_error(err: StorageError) -> &'static str {
+    match err {
+        StorageError::SchemaTooNew { .. } => "schema_too_new",
+        _ => "open_failed",
+    }
+}
+
+fn arg_value(args: &[String], name: &str) -> Option<String> {
+    args.windows(2)
+        .find_map(|pair| (pair[0] == name).then(|| pair[1].clone()))
+        .or_else(|| {
+            let prefix = format!("{name}=");
+            args.iter()
+                .find_map(|arg| arg.strip_prefix(&prefix).map(str::to_string))
+        })
+}
+
+fn now_ms() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as i64)
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn refuses_non_controlled_mission_id() {
+        let path = tmp_db();
+        let db = Db::open_hub(&path).unwrap();
+        drop(db);
+
+        let err = seed_recovery_projection(&path, "codex-organic-mission-real", 10).unwrap_err();
+        assert_eq!(err, "mission_id_not_controlled_recovery");
+    }
+
+    #[test]
+    fn seeds_retryable_projection_without_provider_dispatch_or_organic_claim() {
+        let path = tmp_db();
+        let db = Db::open_hub(&path).unwrap();
+        drop(db);
+
+        let rendered =
+            seed_recovery_projection(&path, "mission_desktop_recovery_contract", 10).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&rendered).unwrap();
+        assert_eq!(parsed["ok"], true);
+        assert_eq!(parsed["retry_visible"], true);
+        assert_eq!(parsed["cancel_visible"], true);
+        assert_eq!(parsed["organic"], false);
+        assert_eq!(parsed["provider_dispatched"], false);
+        assert_eq!(parsed["endbar"], false);
+    }
+
+    fn tmp_db() -> String {
+        let mut path = std::env::temp_dir();
+        path.push(format!(
+            "friday-seed-recovery-projection-{}-{}.sqlite",
+            std::process::id(),
+            now_ms()
+        ));
+        path.to_string_lossy().to_string()
+    }
+}

--- a/scripts/ops/check-friday-uiux-native-linkage.mjs
+++ b/scripts/ops/check-friday-uiux-native-linkage.mjs
@@ -276,6 +276,7 @@ const requirements = [
       "friday.desktop.evidence.timeline-pages",
       "friday.desktop.evidence.transcript-browser",
       "friday.desktop.evidence.memory-review",
+      "friday.desktop.evidence.memory-candidate",
     ],
     requiredRuntimeActionIds: ["desktop/workflow/retry", "desktop/workflow/cancel", "desktop/memory/act", "desktop/memory/check"],
   },

--- a/scripts/ops/friday-desktop-ax-accessibility-capture.mjs
+++ b/scripts/ops/friday-desktop-ax-accessibility-capture.mjs
@@ -109,10 +109,10 @@ const defaultActionMap = new Map([
   ["desktop/workflow/cancel", { destination: "workflow", screen: "workflow", accessibility_id: "friday.desktop.workflow.canvas", event: "mission_workbench_visible", interaction: "visible" }],
   ["desktop/channels/receipts", { destination: "channels", screen: "channels", accessibility_id: "friday.desktop.channels.admin", event: "same_mission_mobile_desktop_channel_visible", interaction: "visible" }],
   ["desktop/channels/surface-events", { destination: "channels", screen: "channels", accessibility_id: "friday.desktop.channels.surface-events", event: "same_mission_mobile_desktop_channel_visible", interaction: "visible" }],
-  ["desktop/recovery/retry", { destination: "recovery", screen: "recovery", accessibility_id: "friday.desktop.workflow.work-items", event: "reconnect_stale_verified", interaction: "visible" }],
-  ["desktop/recovery/cancel", { destination: "recovery", screen: "recovery", accessibility_id: "friday.desktop.workflow.work-items", event: "reconnect_stale_verified", interaction: "visible" }],
-  ["desktop/memory/act", { destination: "memory", screen: "memory", accessibility_id: "friday.desktop.evidence.memory-review", event: "same_mission_projection_visible", interaction: "visible" }],
-  ["desktop/memory/check", { destination: "memory", screen: "memory", accessibility_id: "friday.desktop.evidence.memory-review", event: "same_mission_projection_visible", interaction: "visible" }],
+  ["desktop/recovery/retry", { destination: "recovery", screen: "recovery", accessibility_id: "friday.desktop.recovery.retry-available", visible_text: "retry available", event: "reconnect_stale_verified", interaction: "visible" }],
+  ["desktop/recovery/cancel", { destination: "recovery", screen: "recovery", accessibility_id: "friday.desktop.recovery.cancel-available", visible_text: "cancel available", event: "reconnect_stale_verified", interaction: "visible" }],
+  ["desktop/memory/act", { destination: "memory", screen: "memory", accessibility_id: "friday.desktop.evidence.memory-candidate", visible_text: "Review-only memory candidate attached to this Mission.", event: "same_mission_projection_visible", interaction: "visible" }],
+  ["desktop/memory/check", { destination: "memory", screen: "memory", accessibility_id: "friday.desktop.evidence.memory-candidate", visible_text: "Review-only memory candidate attached to this Mission.", event: "same_mission_projection_visible", interaction: "visible" }],
 ]);
 
 function actionPlan() {
@@ -295,6 +295,15 @@ function elementMatches(element, accessibilityId) {
   return haystack.includes(accessibilityId);
 }
 
+function targetMatches(element, target) {
+  if (elementMatches(element, target.accessibility_id)) return { ok: true, match: "accessibility_id" };
+  if (target.visible_text) {
+    const haystack = [element.name, element.description].join("\n");
+    if (haystack.includes(target.visible_text)) return { ok: true, match: "visible_text" };
+  }
+  return { ok: false, match: "none" };
+}
+
 const targets = actionPlan();
 const summaryPath = outDir ? resolve(outDir, "desktop-ax-accessibility-capture-summary.json") : "";
 const capturePath = outDir ? resolve(outDir, "desktop-ax-accessibility-capture.json") : "";
@@ -423,12 +432,18 @@ if (blockers.length === 0) {
     rawSnapshots.push(`--- destination=${destination} nav=${navStatus} ---\n${raw}`);
     const elements = parseRawTree(raw);
     for (const target of destinationTargets) {
-      const matched = elements.find((element) => elementMatches(element, target.accessibility_id));
+      let matchKind = "none";
+      const matched = elements.find((element) => {
+        const result = targetMatches(element, target);
+        if (result.ok) matchKind = result.match;
+        return result.ok;
+      });
       if (!matched) {
         missingTargets.push({
           runtimeActionId: target.runtimeActionId,
           destination: target.destination,
           accessibility_id: target.accessibility_id,
+          visible_text: target.visible_text || null,
         });
         continue;
       }
@@ -443,9 +458,11 @@ if (blockers.length === 0) {
         event: target.event,
         evidence_ref: rawPath,
         captured_at: new Date().toISOString(),
+        workbench_mission_id: workbenchMissionId || null,
         matched_role: matched.role,
         matched_name: matched.name,
         matched_description: matched.description,
+        matched_by: matchKind,
       });
     }
   }
@@ -455,6 +472,7 @@ writeFileSync(rawPath, `${rawSnapshots.join("\n")}\n`);
 const capture = {
   truth_label: "ui_device_accessibility_click_capture_real_ui_not_endbar",
   mission_id: missionId,
+  workbench_mission_id: workbenchMissionId || null,
   surface: "desktop",
   capture_method: "macos_accessibility",
   evidence_ref: rawPath,

--- a/test/unit/qa/friday-uiux-native-linkage-cli.test.ts
+++ b/test/unit/qa/friday-uiux-native-linkage-cli.test.ts
@@ -66,7 +66,7 @@ function writeCompleteRepo(root: string) {
   writeFile(root, "apps/macos/FridayHubConsole/Sources/FridayHubConsole/HubConsoleShell.swift", "ProofInspector Navigation");
   writeFile(root, "apps/macos/FridayHubConsole/Sources/FridayHubConsole/ProofInspector.swift", "ProofInspector");
   writeFile(root, "apps/macos/FridayHubConsole/Sources/FridayHubConsole/Navigation.swift", "Navigation var isBuilt: Bool { contract.routeBuilt }");
-  writeFile(root, "apps/macos/FridayHubConsole/Sources/FridayHubConsole/DesktopProjectionScreens.swift", "friday.desktop.provider-route-decision-card friday.desktop.provider-work-items-card friday.desktop.channels.admin friday.desktop.channels.surface-events friday.desktop.workflow.canvas friday.desktop.evidence.timeline-pages friday.desktop.evidence.transcript-browser friday.desktop.evidence.memory-review");
+  writeFile(root, "apps/macos/FridayHubConsole/Sources/FridayHubConsole/DesktopProjectionScreens.swift", "friday.desktop.provider-route-decision-card friday.desktop.provider-work-items-card friday.desktop.channels.admin friday.desktop.channels.surface-events friday.desktop.workflow.canvas friday.desktop.evidence.timeline-pages friday.desktop.evidence.transcript-browser friday.desktop.evidence.memory-review friday.desktop.evidence.memory-candidate");
   writeFile(root, "apps/macos/FridayHubConsole/Sources/FridayHubConsole/DesktopChatScreen.swift", "DesktopChatScreen");
   writeFile(root, "apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/DesktopProductReadinessContract.swift", `
     runtimeActionIds: ["desktop/channels/receipts", "desktop/channels/surface-events"]


### PR DESCRIPTION
## Summary
- add refs-only Rust proof drivers for two real Workbench projection scenarios: existing organic memory candidate attachment and controlled recovery retry/cancel visibility
- expose desktop memory candidate evidence as a stable UI proof target without granting memory authority or emitting candidate content
- extend the real macOS Accessibility capture runner to record the Workbench mission it read and to match visible AX text when SwiftUI does not expose static-text identifiers

## Verification
- cargo fmt --check
- cargo test -p friday-hub --bin hub_attach_memory_candidate
- cargo test -p friday-hub --bin hub_seed_recovery_projection
- swift build --package-path apps/macos/FridayHubConsole
- npx vitest run test/unit/qa/friday-uiux-native-linkage-cli.test.ts test/unit/qa/friday-desktop-initial-destination-contract.test.ts test/unit/qa/friday-desktop-ax-accessibility-capture-contract.test.ts
- real macOS AX capture, organic Workbench mission codex-organic-mission-aef06afa-543e-4cc5-9c8d-3352357ec3fd: 13/13 targeted desktop rows observed for organic-memory destinations
- real macOS AX capture, controlled recovery Workbench mission mission_desktop_recovery_20260626T141220Z: 2/2 recovery rows observed
- combined normalizer: 15 action-runtime rows, 15 event rows, no blockers

Truth: this is real app/accessibility proof wiring and controlled recovery projection proof. It is not END-BAR, not adoption, and the controlled recovery scenario is not organic traffic.