### PR TITLE
test(channels): add GitHub channel proof readiness gate

### DIFF
--- a/package.json
+++ b/package.json
@@ -122,6 +122,7 @@
     "check:uiux-native-linkage": "node scripts/ops/check-friday-uiux-native-linkage.mjs",
     "check:uiux-action-traceability": "node scripts/ops/check-friday-uiux-action-traceability.mjs",
     "check:uiux-product-closure": "node scripts/ops/friday-uiux-product-closure-readiness.mjs",
+    "check:github-channel-proof-readiness": "node scripts/ops/check-friday-github-channel-proof-readiness.mjs",
     "check:ui-device-accessibility-click-capture": "node scripts/ops/friday-ui-device-accessibility-click-capture.mjs",
     "check:agent-rollout:phase1": "node scripts/ops/run-agent-rollout-acceptance.mjs phase1",
     "check:native-action-closure": "node scripts/ops/check-friday-native-action-closure.mjs",

--- a/scripts/ops/check-friday-github-channel-proof-readiness.mjs
+++ b/scripts/ops/check-friday-github-channel-proof-readiness.mjs
@@ -1,0 +1,264 @@
+#!/usr/bin/env node
+
+import { execFileSync } from "node:child_process";
+import { readFileSync, writeFileSync } from "node:fs";
+import { dirname, isAbsolute, resolve } from "node:path";
+import { mkdirSync } from "node:fs";
+
+const args = process.argv.slice(2);
+
+function usage() {
+  console.error(`usage:
+  node scripts/ops/check-friday-github-channel-proof-readiness.mjs [--repo=owner/name]
+    [--environment=phase-24-live-channels]
+    [--workflow=telegram-live-proof.yml]
+    [--secrets-json=/abs/secrets.json]
+    [--variables-json=/abs/variables.json]
+    [--runs-json=/abs/runs.json]
+    [--artifacts-json=/abs/artifacts.json]
+    [--out=/abs/report.json]
+    [--require-live-artifact-metadata]
+
+Truth:
+  This check reads GitHub secret names, variable metadata, workflow run metadata,
+  and artifact metadata only. It never reads secret values and never claims
+  END-BAR or same-mission UI/device proof.`);
+}
+
+function arg(name, fallback = "") {
+  const prefix = `--${name}=`;
+  return args.find((value) => value.startsWith(prefix))?.slice(prefix.length) || fallback;
+}
+
+if (args.includes("--help") || args.includes("-h")) {
+  usage();
+  process.exit(0);
+}
+
+const repo = arg("repo", "thesongzhu/Friday");
+const environment = arg("environment", "phase-24-live-channels");
+const workflow = arg("workflow", "telegram-live-proof.yml");
+const out = arg("out");
+const requireLiveArtifactMetadata = args.includes("--require-live-artifact-metadata") || args.includes("--require-live-proof");
+
+function abs(path) {
+  return isAbsolute(path) ? path : resolve(path);
+}
+
+function readJson(path) {
+  return JSON.parse(readFileSync(abs(path), "utf8"));
+}
+
+function ghJson(commandArgs) {
+  const stdout = execFileSync("gh", commandArgs, { encoding: "utf8" });
+  return JSON.parse(stdout);
+}
+
+function ghLines(commandArgs) {
+  const stdout = execFileSync("gh", commandArgs, { encoding: "utf8" });
+  return stdout
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+}
+
+function namesFromSecretFixture(value) {
+  if (Array.isArray(value)) return value.map((entry) => typeof entry === "string" ? entry : entry?.name).filter(Boolean);
+  if (Array.isArray(value?.secrets)) return value.secrets.map((entry) => entry?.name).filter(Boolean);
+  return [];
+}
+
+function variablesFromFixture(value) {
+  if (Array.isArray(value)) {
+    return value
+      .map((entry) => typeof entry === "string" ? { name: entry, value: "" } : entry)
+      .filter((entry) => entry?.name);
+  }
+  if (Array.isArray(value?.variables)) return value.variables.filter((entry) => entry?.name);
+  return [];
+}
+
+function loadSecretNames() {
+  const fixture = arg("secrets-json");
+  if (fixture) return namesFromSecretFixture(readJson(fixture));
+  return ghLines(["secret", "list", "--env", environment, "--repo", repo])
+    .map((line) => line.split(/\s+/)[0])
+    .filter(Boolean);
+}
+
+function loadVariables() {
+  const fixture = arg("variables-json");
+  if (fixture) return variablesFromFixture(readJson(fixture));
+  return ghLines(["variable", "list", "--env", environment, "--repo", repo])
+    .map((line) => {
+      const [name, value = ""] = line.split(/\t/);
+      return { name, value };
+    })
+    .filter((entry) => entry.name);
+}
+
+function loadRuns() {
+  const fixture = arg("runs-json");
+  if (fixture) {
+    const value = readJson(fixture);
+    return Array.isArray(value) ? value : value.runs || [];
+  }
+  return ghJson([
+    "run",
+    "list",
+    "--repo",
+    repo,
+    "--workflow",
+    workflow,
+    "--limit",
+    "20",
+    "--json",
+    "databaseId,status,conclusion,event,headBranch,headSha,createdAt,displayTitle,url",
+  ]);
+}
+
+function loadArtifactsByRun() {
+  const fixture = arg("artifacts-json");
+  if (fixture) return readJson(fixture);
+  const artifactsByRun = {};
+  for (const run of runs) {
+    if (!run.databaseId) continue;
+    try {
+      const result = ghJson(["api", `repos/${repo}/actions/runs/${run.databaseId}/artifacts`]);
+      artifactsByRun[String(run.databaseId)] = result.artifacts || [];
+    } catch {
+      artifactsByRun[String(run.databaseId)] = [];
+    }
+  }
+  return artifactsByRun;
+}
+
+function hasName(collection, name) {
+  return collection.includes(name);
+}
+
+function variableValue(variables, name) {
+  const found = variables.find((entry) => entry.name === name);
+  return typeof found?.value === "string" ? found.value : "";
+}
+
+function sortedRuns(collection) {
+  return [...collection].sort((left, right) => String(right.createdAt || "").localeCompare(String(left.createdAt || "")));
+}
+
+const secretNames = loadSecretNames();
+const variables = loadVariables();
+const runs = loadRuns();
+const artifactsByRun = loadArtifactsByRun();
+
+const requiredSecrets = ["FRIDAY_TELEGRAM_BOT_TOKEN"];
+const requiredVariables = ["FRIDAY_TELEGRAM_ALLOWED_USER_ID", "FRIDAY_TELEGRAM_CHAT_ID", "FRIDAY_TELEGRAM_MODE"];
+const missingSecrets = requiredSecrets.filter((name) => !hasName(secretNames, name));
+const missingVariables = requiredVariables.filter((name) => !variables.some((entry) => entry.name === name && String(entry.value || "").trim()));
+const envReady = missingSecrets.length === 0 && missingVariables.length === 0;
+
+const readonlyRuns = sortedRuns(runs.filter((run) => run.event === "workflow_dispatch" && run.conclusion === "success"));
+const latestReadonly = readonlyRuns[0] || null;
+const listenRuns = sortedRuns(runs.filter((run) => run.event === "workflow_dispatch" && run.displayTitle === "Telegram Live Proof (Rust channels)"));
+const latestListen = listenRuns[0] || null;
+const successfulLiveRuns = sortedRuns(runs.filter((run) => {
+  if (run.event !== "workflow_dispatch" || run.conclusion !== "success") return false;
+  const artifacts = artifactsByRun[String(run.databaseId)] || [];
+  return artifacts.some((artifact) => String(artifact.name || "").startsWith("telegram-live-proof-") && artifact.expired !== true);
+}));
+const latestLiveArtifactMetadataRun = successfulLiveRuns[0] || null;
+const latestLiveArtifacts = latestLiveArtifactMetadataRun ? artifactsByRun[String(latestLiveArtifactMetadataRun.databaseId)] || [] : [];
+
+const telegramMode = variableValue(variables, "FRIDAY_TELEGRAM_MODE");
+const blockers = [];
+const notes = [];
+
+if (!envReady) {
+  for (const name of missingSecrets) blockers.push(`missing_secret_name:${name}`);
+  for (const name of missingVariables) blockers.push(`missing_variable:${name}`);
+}
+if (!latestReadonly) {
+  blockers.push("telegram_readonly_probe:not_observed");
+} else {
+  notes.push(`telegram_readonly_probe:success:${latestReadonly.databaseId}`);
+}
+if (!latestLiveArtifactMetadataRun) {
+  blockers.push("telegram_live_listen_artifact:not_observed");
+}
+if (telegramMode && telegramMode !== "polling") {
+  blockers.push(`telegram_mode:not_polling:${telegramMode}`);
+}
+
+const liveArtifactMetadataReady = envReady && latestLiveArtifactMetadataRun !== null;
+const status = liveArtifactMetadataReady
+  ? "github_channel_live_artifact_metadata_available"
+  : envReady && latestReadonly
+    ? "github_channel_credentials_ready_needs_trusted_message"
+    : "github_channel_readiness_incomplete";
+
+const report = {
+  truth: "github_channel_proof_readiness_metadata_only_no_secret_values_not_endbar",
+  status,
+  repo,
+  environment,
+  workflow,
+  credentialReadiness: {
+    status: envReady ? "ready" : "incomplete",
+    requiredSecretsPresentByNameOnly: requiredSecrets.filter((name) => hasName(secretNames, name)),
+    requiredVariablesPresent: requiredVariables.filter((name) => !missingVariables.includes(name)),
+    missingSecretsByNameOnly: missingSecrets,
+    missingVariables,
+    telegramMode: telegramMode || null,
+  },
+  readonlyProbe: latestReadonly
+    ? {
+        status: "success",
+        runId: latestReadonly.databaseId,
+        createdAt: latestReadonly.createdAt,
+        url: latestReadonly.url,
+      }
+    : { status: "missing" },
+  liveListen: {
+    latestRun: latestListen
+      ? {
+          runId: latestListen.databaseId,
+          status: latestListen.status,
+          conclusion: latestListen.conclusion || null,
+          createdAt: latestListen.createdAt,
+          url: latestListen.url,
+        }
+      : null,
+    latestArtifactMetadataRun: latestLiveArtifactMetadataRun
+      ? {
+          runId: latestLiveArtifactMetadataRun.databaseId,
+          headSha: latestLiveArtifactMetadataRun.headSha,
+          createdAt: latestLiveArtifactMetadataRun.createdAt,
+          url: latestLiveArtifactMetadataRun.url,
+          artifactSchemaValidated: false,
+          wrapperCompatible: null,
+          artifacts: latestLiveArtifacts
+            .filter((artifact) => String(artifact.name || "").startsWith("telegram-live-proof-"))
+            .map((artifact) => ({
+              id: artifact.id,
+              name: artifact.name,
+              expired: artifact.expired,
+              sizeInBytes: artifact.size_in_bytes ?? artifact.sizeInBytes ?? null,
+            })),
+        }
+      : null,
+    nextCommand: `gh workflow run ${workflow} --repo ${repo} -r main -f mode=listen`,
+    operatorAction: "send one real Telegram message to the configured bot during the listen window",
+  },
+  blockers,
+  notes,
+  caveat: "This is GitHub metadata readiness. A historical artifact is supporting channel evidence only unless separately schema-validated against the current wrapper; END-BAR still requires same-mission mobile, desktop, channel, timeline, provider, stress, and negative-control evidence.",
+};
+
+if (out) {
+  const resolved = abs(out);
+  mkdirSync(dirname(resolved), { recursive: true });
+  writeFileSync(resolved, `${JSON.stringify(report, null, 2)}\n`);
+}
+
+console.log(JSON.stringify(report, null, 2));
+process.exit(requireLiveArtifactMetadata && !liveArtifactMetadataReady ? 2 : 0);

--- a/test/unit/qa/friday-github-channel-proof-readiness-cli.test.ts
+++ b/test/unit/qa/friday-github-channel-proof-readiness-cli.test.ts
@@ -1,0 +1,161 @@
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const script = "scripts/ops/check-friday-github-channel-proof-readiness.mjs";
+
+function writeJson(root: string, name: string, value: unknown) {
+  const path = join(root, name);
+  writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`);
+  return path;
+}
+
+function writeReadyFixtures(root: string, options: { liveArtifact?: boolean; latestFailure?: boolean } = {}) {
+  const secrets = writeJson(root, "secrets.json", {
+    secrets: [
+      { name: "FRIDAY_TELEGRAM_BOT_TOKEN" },
+      { name: "FRIDAY_DISCORD_BOT_TOKEN" },
+    ],
+  });
+  const variables = writeJson(root, "variables.json", {
+    variables: [
+      { name: "FRIDAY_TELEGRAM_ALLOWED_USER_ID", value: "6757457607" },
+      { name: "FRIDAY_TELEGRAM_CHAT_ID", value: "6757457607" },
+      { name: "FRIDAY_TELEGRAM_MODE", value: "polling" },
+    ],
+  });
+  const runs = [
+    {
+      databaseId: 28246705231,
+      status: "completed",
+      conclusion: "success",
+      event: "workflow_dispatch",
+      headBranch: "main",
+      headSha: "sha-readonly",
+      createdAt: "2026-06-26T15:07:13Z",
+      displayTitle: "Telegram Live Proof (Rust channels)",
+      url: "https://example.test/runs/28246705231",
+    },
+  ];
+  if (options.latestFailure) {
+    runs.unshift({
+      databaseId: 28246893952,
+      status: "completed",
+      conclusion: "failure",
+      event: "workflow_dispatch",
+      headBranch: "main",
+      headSha: "sha-listen-failed",
+      createdAt: "2026-06-26T15:10:38Z",
+      displayTitle: "Telegram Live Proof (Rust channels)",
+      url: "https://example.test/runs/28246893952",
+    });
+  }
+  if (options.liveArtifact) {
+    runs.push({
+      databaseId: 26923313714,
+      status: "completed",
+      conclusion: "success",
+      event: "workflow_dispatch",
+      headBranch: "main",
+      headSha: "sha-live",
+      createdAt: "2026-06-04T01:03:41Z",
+      displayTitle: "Telegram Live Proof (Rust channels)",
+      url: "https://example.test/runs/26923313714",
+    });
+  }
+  const runsPath = writeJson(root, "runs.json", runs);
+  const artifacts = writeJson(root, "artifacts.json", options.liveArtifact
+    ? {
+        "26923313714": [
+          {
+            id: 7400495110,
+            name: "telegram-live-proof-26923313714",
+            expired: false,
+            size_in_bytes: 469,
+          },
+        ],
+      }
+    : {});
+  return { secrets, variables, runs: runsPath, artifacts };
+}
+
+function runChecker(root: string, fixtures: ReturnType<typeof writeReadyFixtures>, extraArgs: string[] = []) {
+  const out = join(root, "report.json");
+  const stdout = execFileSync("node", [
+    script,
+    `--secrets-json=${fixtures.secrets}`,
+    `--variables-json=${fixtures.variables}`,
+    `--runs-json=${fixtures.runs}`,
+    `--artifacts-json=${fixtures.artifacts}`,
+    `--out=${out}`,
+    ...extraArgs,
+  ], {
+    cwd: process.cwd(),
+    encoding: "utf8",
+  });
+  return {
+    stdout: JSON.parse(stdout),
+    out: JSON.parse(readFileSync(out, "utf8")),
+  };
+}
+
+describe("check-friday-github-channel-proof-readiness", () => {
+  it("reports live artifact metadata without exposing secret values or claiming wrapper validation", () => {
+    const root = mkdtempSync(join(tmpdir(), "friday-github-channel-ready-"));
+    const fixtures = writeReadyFixtures(root, { liveArtifact: true });
+    const { out } = runChecker(root, fixtures, ["--require-live-artifact-metadata"]);
+
+    expect(out.truth).toBe("github_channel_proof_readiness_metadata_only_no_secret_values_not_endbar");
+    expect(out.status).toBe("github_channel_live_artifact_metadata_available");
+    expect(out.credentialReadiness.status).toBe("ready");
+    expect(out.credentialReadiness.requiredSecretsPresentByNameOnly).toEqual(["FRIDAY_TELEGRAM_BOT_TOKEN"]);
+    expect(JSON.stringify(out)).not.toContain("bot-token");
+    expect(out.liveListen.latestArtifactMetadataRun).toMatchObject({
+      artifactSchemaValidated: false,
+      wrapperCompatible: null,
+    });
+    expect(out.liveListen.latestArtifactMetadataRun.artifacts[0]).toMatchObject({
+      name: "telegram-live-proof-26923313714",
+      expired: false,
+    });
+  });
+
+  it("keeps the state honest when credentials are ready but no live message artifact exists", () => {
+    const root = mkdtempSync(join(tmpdir(), "friday-github-channel-message-"));
+    const fixtures = writeReadyFixtures(root, { latestFailure: true });
+    const { out } = runChecker(root, fixtures);
+
+    expect(out.status).toBe("github_channel_credentials_ready_needs_trusted_message");
+    expect(out.blockers).toContain("telegram_live_listen_artifact:not_observed");
+    expect(out.liveListen.latestRun).toMatchObject({
+      runId: 28246893952,
+      conclusion: "failure",
+    });
+    expect(out.liveListen.operatorAction).toContain("send one real Telegram message");
+  });
+
+  it("fails require-live-artifact-metadata when metadata is incomplete", () => {
+    const root = mkdtempSync(join(tmpdir(), "friday-github-channel-incomplete-"));
+    mkdirSync(root, { recursive: true });
+    const fixtures = {
+      secrets: writeJson(root, "secrets.json", { secrets: [] }),
+      variables: writeJson(root, "variables.json", { variables: [] }),
+      runs: writeJson(root, "runs.json", []),
+      artifacts: writeJson(root, "artifacts.json", {}),
+    };
+
+    let failed = false;
+    try {
+      runChecker(root, fixtures, ["--require-live-artifact-metadata"]);
+    } catch (error) {
+      failed = true;
+      const stdout = JSON.parse(String((error as { stdout?: Buffer | string }).stdout ?? "{}"));
+      expect(stdout.status).toBe("github_channel_readiness_incomplete");
+      expect(stdout.blockers).toContain("missing_secret_name:FRIDAY_TELEGRAM_BOT_TOKEN");
+      expect(stdout.blockers).toContain("telegram_readonly_probe:not_observed");
+    }
+    expect(failed).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add a GitHub environment/workflow metadata checker for Telegram channel proof readiness
- expose it as `npm run check:github-channel-proof-readiness`
- cover ready, missing-message, and incomplete metadata paths without reading secret values

## Truth labels
- metadata-only check; does not read secret values
- historical live artifact metadata is supporting evidence only unless separately schema-validated against the current wrapper
- does not claim END-BAR, same-mission UI/device proof, or current live channel proof

## Verified
- `npx vitest run test/unit/qa/friday-github-channel-proof-readiness-cli.test.ts`
- `npm run check:github-channel-proof-readiness`