### PR TITLE
test(channels): bridge replay negative proof events

### DIFF
--- a/scripts/ops/friday-channel-proof-events.mjs
+++ b/scripts/ops/friday-channel-proof-events.mjs
@@ -84,6 +84,12 @@ if (proof) {
   if (proof.secret_policy?.artifact_contains_redacted_text_only !== true) {
     block("channel_live_proof_secret_policy_not_redacted", "artifact_contains_redacted_text_only");
   }
+  const telegram = proof.telegram_live && typeof proof.telegram_live === "object" ? proof.telegram_live : {};
+  const forgedRejected = telegram.forged_bearer_rejected === true || proof.forged_bearer_rejected === true;
+  const nonAllowlistedRejected = telegram.non_allowlisted_sender_rejected === true || proof.non_allowlisted_sender_rejected === true;
+  if (!forgedRejected || !nonAllowlistedRejected) {
+    block("channel_live_proof_replay_controls_missing", "forged_bearer_rejected_and_non_allowlisted_sender_rejected");
+  }
   if (!String(proof.remaining_requirement || "").includes("UI/device consumption evidence")) {
     block("channel_live_proof_missing_ui_device_boundary", "remaining_requirement");
   }
@@ -92,15 +98,26 @@ if (proof) {
 const capturedAt = typeof proof?.generated_at_utc === "string" && proof.generated_at_utc.trim()
   ? proof.generated_at_utc.trim()
   : new Date(0).toISOString();
-const rows = blockers.length === 0 ? [{
-  surface: "channel",
-  event: "same_mission_projection_visible",
-  mission_id: missionId,
-  evidence_ref: channelCapture,
-  truth_label: "derived_from_redacted_channel_live_proof_not_final_ui_device_proof",
-  source: "mission_spine_channel_live_proof",
-  captured_at: capturedAt,
-}] : [];
+const rows = blockers.length === 0 ? [
+  {
+    surface: "channel",
+    event: "same_mission_projection_visible",
+    mission_id: missionId,
+    evidence_ref: channelCapture,
+    truth_label: "derived_from_redacted_channel_live_proof_not_final_ui_device_proof",
+    source: "mission_spine_channel_live_proof",
+    captured_at: capturedAt,
+  },
+  {
+    surface: "channel",
+    event: "channel_replay_blocked_visible",
+    mission_id: missionId,
+    evidence_ref: channelCapture,
+    truth_label: "derived_from_redacted_channel_live_proof_negative_controls_not_final_ui_device_proof",
+    source: "mission_spine_channel_live_proof",
+    captured_at: capturedAt,
+  },
+] : [];
 
 if (blockers.length === 0 && outPath) {
   const out = abs(outPath);
@@ -118,7 +135,7 @@ const output = {
   outputRows: rows.length,
   emittedEvents: rows.map((row) => `${row.surface}:${row.event}`),
   blockers,
-  caveat: "Conservative channel event bridge only. It does not claim replay proof, timeline proof, mobile/desktop/channel convergence, END-BAR, or GO-LIVE.",
+  caveat: "Conservative channel event bridge only. Replay-blocked visibility is emitted only from passed redacted channel-wrapper negative controls; this does not claim timeline proof, mobile/desktop/channel convergence, END-BAR, or GO-LIVE.",
 };
 
 console.log(JSON.stringify(output, null, 2));

--- a/test/unit/qa/friday-channel-proof-events-cli.test.ts
+++ b/test/unit/qa/friday-channel-proof-events-cli.test.ts
@@ -31,7 +31,7 @@ function writeChannelProof(path: string, overrides: Record<string, unknown> = {}
 }
 
 describe("friday-channel-proof-events", () => {
-  it("emits only the conservative channel same-mission projection event", () => {
+  it("emits conservative channel projection and replay-blocked events from a passed wrapper", () => {
     const tempDir = mkdtempSync(join(tmpdir(), "friday-channel-proof-events-"));
     try {
       const proof = join(tempDir, "channel-live-proof.json");
@@ -60,18 +60,32 @@ describe("friday-channel-proof-events", () => {
 
       expect(result.truth).toBe("channel_proof_events_not_ui_device_proof");
       expect(result.status).toBe("ready");
-      expect(result.outputRows).toBe(1);
-      expect(result.emittedEvents).toEqual(["channel:same_mission_projection_visible"]);
-      expect(result.caveat).toContain("does not claim replay proof");
-      expect(rows).toEqual([{
-        surface: "channel",
-        event: "same_mission_projection_visible",
-        mission_id: missionId,
-        evidence_ref: channelCapture,
-        truth_label: "derived_from_redacted_channel_live_proof_not_final_ui_device_proof",
-        source: "mission_spine_channel_live_proof",
-        captured_at: "2026-06-24T23:59:00.000Z",
-      }]);
+      expect(result.outputRows).toBe(2);
+      expect(result.emittedEvents).toEqual([
+        "channel:same_mission_projection_visible",
+        "channel:channel_replay_blocked_visible",
+      ]);
+      expect(result.caveat).toContain("Replay-blocked visibility is emitted only");
+      expect(rows).toEqual([
+        {
+          surface: "channel",
+          event: "same_mission_projection_visible",
+          mission_id: missionId,
+          evidence_ref: channelCapture,
+          truth_label: "derived_from_redacted_channel_live_proof_not_final_ui_device_proof",
+          source: "mission_spine_channel_live_proof",
+          captured_at: "2026-06-24T23:59:00.000Z",
+        },
+        {
+          surface: "channel",
+          event: "channel_replay_blocked_visible",
+          mission_id: missionId,
+          evidence_ref: channelCapture,
+          truth_label: "derived_from_redacted_channel_live_proof_negative_controls_not_final_ui_device_proof",
+          source: "mission_spine_channel_live_proof",
+          captured_at: "2026-06-24T23:59:00.000Z",
+        },
+      ]);
     } finally {
       rmSync(tempDir, { recursive: true, force: true });
     }
@@ -105,6 +119,42 @@ describe("friday-channel-proof-events", () => {
         "channel_live_proof_not_passed",
         "channel_live_proof_secret_policy_not_redacted",
       ]));
+      expect(() => readFileSync(out, "utf8")).toThrow();
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("fails closed when replay negative controls are absent", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "friday-channel-proof-events-replay-"));
+    try {
+      const proof = join(tempDir, "channel-live-proof.json");
+      const channelCapture = join(tempDir, "channel-capture.json");
+      const out = join(tempDir, "channel-events.jsonl");
+      writeChannelProof(proof, {
+        telegram_live: {
+          status: "passed",
+          proof: "telegram_inbound_through_rust_channels_pipeline",
+          bot_identity_verified: true,
+          channel_binding_created: true,
+          sender_allowlisted: true,
+        },
+      });
+      writeFileSync(channelCapture, JSON.stringify({ truth: "redacted_channel_capture" }));
+
+      const result = spawnSync("node", [
+        script,
+        `--mission-id=${missionId}`,
+        `--channel-live-proof=${proof}`,
+        `--channel-capture=${channelCapture}`,
+        `--out=${out}`,
+        "--require-ready",
+      ], { cwd: process.cwd(), encoding: "utf8" });
+
+      expect(result.status).toBe(2);
+      const output = JSON.parse(result.stdout) as { status?: string; blockers?: Array<{ code?: string }> };
+      expect(output.status).toBe("blocked");
+      expect(output.blockers?.map((blocker) => blocker.code)).toContain("channel_live_proof_replay_controls_missing");
       expect(() => readFileSync(out, "utf8")).toThrow();
     } finally {
       rmSync(tempDir, { recursive: true, force: true });

--- a/test/unit/qa/friday-ui-device-proof-readiness-cli.test.ts
+++ b/test/unit/qa/friday-ui-device-proof-readiness-cli.test.ts
@@ -141,6 +141,15 @@ function writeRedactedChannelProof(tempDir: string) {
     proof: "mission_spine_channel_live_proof",
     status: "passed",
     generated_at_utc: "2026-06-05T06:10:00Z",
+    telegram_live: {
+      status: "passed",
+      proof: "telegram_inbound_through_rust_channels_pipeline",
+      bot_identity_verified: true,
+      channel_binding_created: true,
+      sender_allowlisted: true,
+      forged_bearer_rejected: true,
+      non_allowlisted_sender_rejected: true,
+    },
     secret_policy: {
       artifact_contains_redacted_text_only: true,
     },
@@ -951,6 +960,11 @@ describe("friday-ui-device-proof-readiness", () => {
       expect(rows).toContainEqual(expect.objectContaining({
         surface: "channel",
         event: "same_mission_projection_visible",
+        evidence_ref: files.channel,
+      }));
+      expect(rows).toContainEqual(expect.objectContaining({
+        surface: "channel",
+        event: "channel_replay_blocked_visible",
         evidence_ref: files.channel,
       }));
     } finally {


### PR DESCRIPTION
## Summary
- require replay negative controls in `friday-channel-proof-events.mjs` before deriving channel events
- emit `channel_replay_blocked_visible` from a passed redacted channel-wrapper proof
- add fail-closed coverage for wrappers missing forged/non-allowlisted rejection evidence

## Truth labels
- does not create or claim channel live proof
- does not claim timeline proof, mobile/desktop/channel convergence, END-BAR, or GO-LIVE
- only exposes already-present wrapper negative-control facts to the same-run event bridge

## Verified
- `npx vitest run test/unit/qa/friday-channel-proof-events-cli.test.ts`