### PR TITLE
test(ios): add simulator accessibility capture bridge

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "build:ios:sim": "bash apps/friday-ios/build-sim.sh",
     "proof:ios:live-t3": "bash scripts/ops/friday-ios-sim-live-t3-proof.sh",
     "proof:ios:design-destinations": "bash scripts/ops/friday-ios-design-destination-capture.sh --out-dir \"${FRIDAY_IOS_DESIGN_CAPTURE_OUT:-/tmp/friday-ios-design-destination-capture}\"",
+    "proof:ios:ax-capture": "node scripts/ops/friday-ios-sim-accessibility-capture.mjs --out-dir \"${FRIDAY_IOS_AX_CAPTURE_OUT:-/tmp/friday-ios-sim-accessibility-capture}\" --mission-id \"${FRIDAY_IOS_AX_CAPTURE_MISSION_ID:-mission_ios_sim_ax_capture}\"",
     "proof:action-runtime:evidence-bundle": "bash scripts/ops/friday-action-runtime-evidence-bundle.sh --out-dir \"${FRIDAY_ACTION_RUNTIME_EVIDENCE_BUNDLE_OUT:-/tmp/friday-action-runtime-evidence-bundle}\"",
     "proof:desktop:gui-smoke": "bash scripts/ops/friday-desktop-gui-smoke-proof.sh --out-dir \"${FRIDAY_DESKTOP_GUI_SMOKE_OUT_DIR:-/tmp/friday-desktop-gui-smoke-proof}\"",
     "proof:desktop:ax-capture": "node scripts/ops/friday-desktop-ax-accessibility-capture.mjs --out-dir \"${FRIDAY_DESKTOP_AX_CAPTURE_OUT:-/tmp/friday-desktop-ax-accessibility-capture}\" --mission-id \"${FRIDAY_DESKTOP_AX_CAPTURE_MISSION_ID:-mission_desktop_ax_capture}\"",

--- a/scripts/ops/friday-ios-sim-accessibility-capture.mjs
+++ b/scripts/ops/friday-ios-sim-accessibility-capture.mjs
@@ -1,0 +1,480 @@
+#!/usr/bin/env node
+
+import { existsSync, mkdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { dirname, isAbsolute, resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+
+const args = process.argv.slice(2);
+const forbiddenTruth = /(synthetic|fixture|sample|dry[-_ ]?run|screenshot[-_ ]?only|design[-_ ]?proof|mock|placeholder)/i;
+const imageEvidence = /\.(png|jpe?g|heic|gif|webp|tiff?)$/i;
+const allowedEvidenceTypes = new Set(["accessibility_tree", "accessibility_observation", "xctest_accessibility"]);
+const allowedInteractions = new Set(["tap", "visible", "type", "read"]);
+const allowedEvents = new Set([
+  "mission_intake_submitted",
+  "mission_intake_ready",
+  "mission_resolve_or_create_visible",
+  "duplicate_preflight_visible",
+  "mission_bound_provider_action_visible",
+  "real_provider_execution_visible",
+  "proof_receipt_visible_before_done",
+  "same_mission_projection_visible",
+  "mission_workbench_visible",
+  "transcript_browser_visible",
+  "duplicate_blocked_opens_existing",
+  "same_mission_mobile_desktop_channel_visible",
+  "provider_ack_not_done_visible",
+  "pressure_20_50_consecutive_asks_visible",
+  "invalid_key_error_visible",
+  "quota_error_visible",
+  "network_error_visible",
+  "reconnect_stale_verified",
+  "real_provider_execution_receipt_visible",
+  "stale_label_visible",
+  "offline_label_visible",
+  "error_label_visible",
+  "no_hidden_fallback_verified",
+]);
+
+const ACTION_MAP = {
+  "mobile/home/refresh": { screen: "home", accessibilityIds: ["friday.mobile.toolbar.refresh"], event: "mission_workbench_visible", interaction: "visible" },
+  "mobile/session/sidecar/open": { screen: "session", accessibilityIds: ["friday.session.sidecar-open"], event: "mission_workbench_visible", interaction: "visible" },
+  "mobile/session/sidecar/close": { screen: "session", accessibilityIds: ["friday.session.sidecar-close"], event: "mission_workbench_visible", interaction: "visible" },
+  "mobile/workflow/run-control": { screen: "session", accessibilityIds: ["friday.session.control.resume", "friday.session.control.reject"], event: "provider_ack_not_done_visible", interaction: "visible" },
+  "mobile/passport/checklist": { screen: "contextPassport", accessibilityIds: ["friday.context-passport.checklist"], event: "same_mission_projection_visible", interaction: "visible" },
+  "mobile/passport/send": { screen: "contextPassport", accessibilityIds: ["friday.context-passport.send"], event: "mission_bound_provider_action_visible", interaction: "visible" },
+  "mobile/tokenLedger/refresh": { screen: "tokenLedger", accessibilityIds: ["friday.token-ledger.refresh"], event: "same_mission_projection_visible", interaction: "visible" },
+  "mobile/tokenLedger/run-readback": { screen: "tokenLedger", accessibilityIds: ["friday.token-ledger.detail"], event: "same_mission_projection_visible", interaction: "read" },
+  "mobile/share/send": { screen: "shareIntake", accessibilityIds: ["friday.share.submit"], event: "mission_intake_submitted", interaction: "visible" },
+  "mobile/share/open-chat-loop": { screen: "shareIntake", accessibilityIds: ["friday.share.open-chat-loop"], event: "mission_intake_ready", interaction: "visible" },
+  "mobile/voice/permission": { screen: "voice", accessibilityIds: ["friday.voice.permission"], event: "mission_workbench_visible", interaction: "visible" },
+  "mobile/fridayChat/voice-input": { screen: "fridayChat", accessibilityIds: ["friday.chat.voice-input"], event: "mission_bound_provider_action_visible", interaction: "visible" },
+  "mobile/fridayChat/voice-output": { screen: "fridayChat", accessibilityIds: ["friday.chat.voice-output"], event: "real_provider_execution_receipt_visible", interaction: "visible" },
+  "mobile/voice/open-chat-loop": { screen: "voice", accessibilityIds: ["friday.voice.open-chat-loop"], event: "mission_intake_ready", interaction: "visible" },
+  "mobile/firstlaunch/scan": { screen: "pairing", accessibilityIds: ["friday.home.pairing-scan-button"], event: "mission_workbench_visible", interaction: "visible" },
+  "mobile/firstlaunch/pairnow": { screen: "pairing", accessibilityIds: ["friday.home.pair-button"], event: "mission_workbench_visible", interaction: "visible" },
+  "mobile/firstlaunch/retry": { screen: "pairing", accessibilityIds: ["friday.home.pairing-retry-button"], event: "reconnect_stale_verified", interaction: "visible" },
+  "mobile/firstlaunch/cancel": { screen: "pairing", accessibilityIds: ["friday.home.pairing-cancel-button"], event: "reconnect_stale_verified", interaction: "visible" },
+  "mobile/newSession/play": { screen: "newSession", accessibilityIds: ["friday.new-session.launch-button"], event: "mission_intake_submitted", interaction: "visible" },
+  "mobile/newSession/open-chat-loop": { screen: "newSession", accessibilityIds: ["friday.new-session.open-chat-loop"], event: "mission_intake_ready", interaction: "visible" },
+  "mobile/approval/check": { screen: "fridayChat", accessibilityIds: ["friday.chat.approval.approve", "friday.session.control.resume"], event: "proof_receipt_visible_before_done", interaction: "visible" },
+  "mobile/approval/reject": { screen: "fridayChat", accessibilityIds: ["friday.chat.approval.reject", "friday.session.control.reject"], event: "provider_ack_not_done_visible", interaction: "visible" },
+  "mobile/memory/confirm": { screen: "memory", accessibilityIds: ["friday.memory.confirm-candidate", "friday.chat.memory-card.keep"], event: "same_mission_projection_visible", interaction: "visible" },
+  "mobile/memory/reject": { screen: "memory", accessibilityIds: ["friday.memory.reject-candidate", "friday.chat.memory-card.reject"], event: "same_mission_projection_visible", interaction: "visible" },
+  "mobile/providerAuth/check": { screen: "providerAuth", accessibilityIds: ["friday.provider-auth.check"], event: "mission_bound_provider_action_visible", interaction: "visible" },
+  "mobile/providerAuth/provider-workspace": { screen: "providerAuth", accessibilityIds: ["friday.provider-workspace.overview"], event: "real_provider_execution_visible", interaction: "visible" },
+  "mobile/activity/mark-done": { screen: "activity", accessibilityIds: ["friday.activity.mark-done"], event: "same_mission_projection_visible", interaction: "visible" },
+  "mobile/workflow/retry": { screen: "workflows", accessibilityIds: ["friday.workflow.retry-work-item", "friday.home.retry-work-item"], event: "reconnect_stale_verified", interaction: "visible" },
+  "mobile/workflow/cancel": { screen: "workflows", accessibilityIds: ["friday.workflow.cancel-work-item", "friday.home.cancel-work-item"], event: "reconnect_stale_verified", interaction: "visible" },
+  "mobile/onboarding/open-device-pairing": { screen: "onboarding", accessibilityIds: ["friday.onboarding.open-device-pairing"], event: "mission_workbench_visible", interaction: "visible" },
+};
+
+function usage() {
+  console.error(`usage:
+  node scripts/ops/friday-ios-sim-accessibility-capture.mjs \\
+    --mission-id=mission_... --out-dir=/abs/out-dir
+    [--repo-root=/abs/repo] [--bundle-id=com.friday.shell] [--udid=SIM_UDID]
+    [--destinations=home,needsMe,...] [--plan-only]
+    [--real --observation=/abs/real-ios-accessibility-observation.json]
+    [--normalize] [--normalizer-out-dir=/abs/out-dir] [--require-observed]
+
+Observation input shape for --real:
+  {
+    "truth_label": "ios_simulator_accessibility_observation_real_ui",
+    "mission_id": "mission_...",
+    "capture_method": "ios_simulator_accessibility",
+    "evidence_type": "accessibility_tree|accessibility_observation|xctest_accessibility",
+    "evidence_ref": "/abs/raw-ax-tree-or-xctest-log.txt",
+    "observations": [{
+      "runtimeActionId": "mobile/home/refresh",
+      "accessibility_id": "friday.mobile.toolbar.refresh",
+      "interaction": "visible",
+      "status": "pass",
+      "event": "mission_workbench_visible"
+    }]
+  }
+
+Truth:
+  Default mode is plan-only and does not inspect Simulator/app state. Real mode
+  requires Simulator state from simctl, an installed/launched app, and real
+  accessibility observations. It refuses screenshot-only, synthetic, mock, or
+  placeholder evidence and is not END-BAR/adoption proof.`);
+}
+
+function arg(name) {
+  const prefix = `--${name}=`;
+  for (let index = 0; index < args.length; index += 1) {
+    const value = args[index];
+    if (value.startsWith(prefix)) return value.slice(prefix.length);
+    if (value === `--${name}` && args[index + 1]) return args[index + 1];
+  }
+  return "";
+}
+
+if (args.includes("--help") || args.includes("-h")) {
+  usage();
+  process.exit(0);
+}
+
+const repoRoot = resolve(arg("repo-root") || process.env.FRIDAY_REPO_ROOT || new URL("../..", import.meta.url).pathname);
+const missionId = arg("mission-id");
+const outDir = arg("out-dir");
+const bundleId = arg("bundle-id") || process.env.FRIDAY_IOS_SIM_BUNDLE_ID || "com.friday.shell";
+const udidArg = arg("udid") || process.env.FRIDAY_IOS_SIM_UDID || "";
+const observationPath = arg("observation");
+const destinationsCsv = arg("destinations") || process.env.FRIDAY_IOS_SIM_AX_DESTINATIONS || "";
+const normalize = args.includes("--normalize");
+const normalizerOutDir = arg("normalizer-out-dir") || (outDir ? resolve(outDir, "normalized") : "");
+const requireObserved = args.includes("--require-observed");
+const realMode = args.includes("--real") || Boolean(observationPath);
+const planOnly = args.includes("--plan-only") || !realMode;
+const blockers = [];
+
+function block(code, detail) {
+  blockers.push({ code, detail });
+}
+
+function run(command, commandArgs, options = {}) {
+  return spawnSync(command, commandArgs, {
+    cwd: repoRoot,
+    encoding: "utf8",
+    ...options,
+  });
+}
+
+function jsonOut(path, value) {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function requireAbsoluteFile(label, path) {
+  if (!path) {
+    block("missing_arg", label);
+    return "";
+  }
+  if (!isAbsolute(path)) {
+    block("path_not_absolute", `${label}:${path}`);
+    return "";
+  }
+  try {
+    const stats = statSync(path);
+    if (!stats.isFile()) block("not_file", `${label}:${path}`);
+    if (stats.size <= 0) block("empty_file", `${label}:${path}`);
+  } catch {
+    block("unreadable_file", `${label}:${path}`);
+  }
+  return path;
+}
+
+function readJson(label, path) {
+  const file = requireAbsoluteFile(label, path);
+  if (!file) return null;
+  try {
+    return JSON.parse(readFileSync(file, "utf8"));
+  } catch (error) {
+    block("invalid_json", `${label}:${path}:${error.message}`);
+    return null;
+  }
+}
+
+function parseMobileDestinations() {
+  const contractPath = resolve(repoRoot, "apps/friday-ios/Sources/FridayMobileShellCore/MobileProductReadinessContract.swift");
+  if (!existsSync(contractPath)) {
+    block("mobile_contract_missing", contractPath);
+    return [];
+  }
+  const source = readFileSync(contractPath, "utf8");
+  const rows = [];
+  const caseMatches = [...source.matchAll(/case \.([A-Za-z0-9_]+):\s*return contract\(([\s\S]*?)(?=\n\s*case \.|^\s*\}\n\s*private func contract)/gm)];
+  for (const match of caseMatches) {
+    const destination = match[1];
+    const body = match[2];
+    const title = body.match(/title:\s*"([^"]+)"/)?.[1] || destination;
+    const tier = body.match(/tier:\s*\.([A-Za-z0-9_]+)/)?.[1] || "";
+    const actionBlock = body.match(/runtimeActionIds:\s*\[([\s\S]*?)\]/)?.[1] || "";
+    const runtimeActionIds = [...actionBlock.matchAll(/"([^"]+)"/g)].map((item) => item[1]);
+    rows.push({ destination, title, tier, runtimeActionIds });
+  }
+  return rows;
+}
+
+function plannedTargets() {
+  const destinationFilter = new Set(destinationsCsv.split(",").map((value) => value.trim()).filter(Boolean));
+  return parseMobileDestinations()
+    .filter((destination) => destinationFilter.size === 0 || destinationFilter.has(destination.destination))
+    .flatMap((destination) =>
+      destination.runtimeActionIds.map((runtimeActionId) => {
+        const mapped = ACTION_MAP[runtimeActionId];
+        return {
+          destination: destination.destination,
+          title: destination.title,
+          tier: destination.tier,
+          runtimeActionId,
+          screen: mapped?.screen || destination.destination,
+          accessibilityIds: mapped?.accessibilityIds || [],
+          interaction: mapped?.interaction || "visible",
+          event: mapped?.event || "mission_workbench_visible",
+          status: mapped ? "planned" : "unmapped",
+        };
+      }));
+}
+
+function validateTruth(label, value) {
+  const truth = String(value?.truth_label || value?.truthLabel || value?.truth || "");
+  if (!truth) block("truth_label_missing", label);
+  if (truth && !/accessibility.*real|real.*accessibility/i.test(truth)) block("truth_label_not_real_accessibility", `${label}:${truth}`);
+  if (truth && forbiddenTruth.test(truth)) block("truth_label_forbidden", `${label}:${truth}`);
+  return truth;
+}
+
+function validateEvidenceRef(label, evidenceRef) {
+  const ref = requireAbsoluteFile(`${label}:evidence_ref`, String(evidenceRef || ""));
+  if (ref && imageEvidence.test(ref)) block("screenshot_only_evidence_forbidden", `${label}:${ref}`);
+  return ref;
+}
+
+function resolveSimulator() {
+  const list = run("xcrun", ["simctl", "list", "devices", "--json"]);
+  if (list.status !== 0) {
+    block("simctl_list_failed", list.stderr.trim() || list.stdout.trim() || String(list.status));
+    return null;
+  }
+  let parsed = null;
+  try {
+    parsed = JSON.parse(list.stdout);
+  } catch (error) {
+    block("simctl_list_invalid_json", error.message);
+    return null;
+  }
+  const devices = Object.values(parsed.devices || {}).flat();
+  const available = devices.filter((device) => device && device.isAvailable !== false);
+  const selected = udidArg
+    ? available.find((device) => device.udid === udidArg)
+    : available.find((device) => device.state === "Booted" && /iPhone|iPad/i.test(String(device.name || "")));
+  if (!selected) {
+    block("ios_simulator_not_available", udidArg || "booted iPhone/iPad");
+    return null;
+  }
+  if (selected.state !== "Booted") block("ios_simulator_not_booted", `${selected.name || "<unnamed>"}:${selected.udid}`);
+  return {
+    name: selected.name || "",
+    udid: selected.udid,
+    state: selected.state || "",
+  };
+}
+
+function observeAppState(simulator) {
+  if (!simulator?.udid) return null;
+  const container = run("xcrun", ["simctl", "get_app_container", simulator.udid, bundleId, "data"]);
+  if (container.status !== 0) {
+    block("app_container_unavailable", container.stderr.trim() || container.stdout.trim() || `${bundleId}:${simulator.udid}`);
+    return null;
+  }
+  const dataContainer = container.stdout.trim().split(/\r?\n/).at(-1) || "";
+  if (!isAbsolute(dataContainer)) block("app_container_not_absolute", dataContainer || "<missing>");
+
+  const launch = run("xcrun", ["simctl", "launch", simulator.udid, bundleId]);
+  if (launch.status !== 0) {
+    block("app_launch_failed", launch.stderr.trim() || launch.stdout.trim() || `${bundleId}:${simulator.udid}`);
+  }
+  return {
+    bundle_id: bundleId,
+    data_container: dataContainer,
+    launch_stdout: launch.stdout.trim(),
+  };
+}
+
+function normalizeObservation(raw, targets, captureEvidenceRef) {
+  const rawActions = Array.isArray(raw?.observations)
+    ? raw.observations
+    : Array.isArray(raw?.ui_actions)
+      ? raw.ui_actions
+      : [];
+  if (rawActions.length === 0) block("observations_missing", "observation input must include observations or ui_actions");
+
+  const byRuntimeAction = new Map(targets.map((target) => [target.runtimeActionId, target]));
+  const actions = [];
+  for (const [index, action] of rawActions.entries()) {
+    const label = `observation:ui_action_${index + 1}`;
+    if (!action || typeof action !== "object" || Array.isArray(action)) {
+      block("ui_action_not_object", label);
+      continue;
+    }
+    const runtimeActionId = String(action.runtimeActionId || action.runtime_action_id || action.action_id || action.actionId || "").trim();
+    const target = byRuntimeAction.get(runtimeActionId);
+    const accessibilityId = String(action.accessibility_id || action.accessibilityId || target?.accessibilityIds?.[0] || "").trim();
+    const interaction = String(action.interaction || action.action || target?.interaction || "").trim();
+    const event = String(action.event || target?.event || "").trim();
+    const status = String(action.status || "").trim();
+    const actionEvidenceType = String(action.evidence_type || action.evidenceType || raw.evidence_type || raw.evidenceType || "").trim();
+    const evidenceRef = validateEvidenceRef(label, action.evidence_ref || action.evidenceRef || captureEvidenceRef);
+
+    if (!runtimeActionId) block("runtime_action_id_missing", label);
+    if (!target) block("runtime_action_not_planned", `${label}:${runtimeActionId || "<missing>"}`);
+    if (!accessibilityId) block("accessibility_id_missing", label);
+    if (target && !target.accessibilityIds.includes(accessibilityId)) {
+      block("accessibility_id_not_planned", `${label}:${runtimeActionId}:${accessibilityId}`);
+    }
+    if (!allowedInteractions.has(interaction)) block("interaction_not_supported", `${label}:${interaction || "<missing>"}`);
+    if (status !== "pass") block("status_not_pass", `${label}:${status || "<missing>"}`);
+    if (!allowedEvents.has(event)) block("event_not_supported", `${label}:${event || "<missing>"}`);
+    if (!allowedEvidenceTypes.has(actionEvidenceType)) block("evidence_type_not_accessibility", `${label}:${actionEvidenceType || "<missing>"}`);
+    if (forbiddenTruth.test(String(action.source || ""))) block("ui_action_source_forbidden", label);
+    if (forbiddenTruth.test(actionEvidenceType)) block("evidence_type_forbidden", `${label}:${actionEvidenceType}`);
+
+    actions.push({
+      screen: String(action.screen || target?.screen || "").trim(),
+      runtimeActionId,
+      action_id: runtimeActionId,
+      capability_id: String(action.capability_id || action.capabilityId || runtimeActionId),
+      accessibility_id: accessibilityId,
+      interaction,
+      status: "pass",
+      event,
+      evidence_ref: evidenceRef,
+      captured_at: String(action.captured_at || action.capturedAt || raw.captured_at || raw.capturedAt || new Date().toISOString()),
+      matched_by: String(action.matched_by || action.matchedBy || "external_real_accessibility_observation"),
+    });
+  }
+  return actions;
+}
+
+const targets = plannedTargets();
+const summaryPath = outDir ? resolve(outDir, "ios-sim-accessibility-capture-summary.json") : "";
+const capturePath = outDir ? resolve(outDir, "ios-sim-accessibility-capture.json") : "";
+
+if (!missionId || !/^[A-Za-z0-9][A-Za-z0-9._:-]*$/.test(missionId) || !missionId.toLowerCase().includes("mission")) {
+  block("mission_id_unexpected_shape", missionId || "<missing>");
+}
+if (!outDir) block("missing_arg", "out-dir");
+if (outDir && !isAbsolute(outDir)) block("path_not_absolute", `out-dir:${outDir}`);
+if (targets.some((target) => target.status === "unmapped")) {
+  for (const target of targets.filter((item) => item.status === "unmapped")) {
+    block("runtime_action_unmapped", target.runtimeActionId);
+  }
+}
+
+if (planOnly) {
+  const summary = {
+    generated_at_utc: new Date().toISOString(),
+    truth: "ios_sim_accessibility_capture_plan_only_not_runtime_proof",
+    status: blockers.length === 0 ? "plan_ready" : "blocked",
+    missionId: missionId || null,
+    targetCount: targets.length,
+    targets,
+    outputs: {
+      summary: summaryPath || null,
+      capture: null,
+      normalized: null,
+    },
+    blockers,
+    caveat: "Default plan-only mode reads static iOS action/accessibility targets only. It does not launch Simulator, inspect app state, emit real capture JSON, or claim UI/device proof.",
+  };
+  if (summaryPath) jsonOut(summaryPath, summary);
+  console.log(JSON.stringify(summary, null, 2));
+  process.exit(blockers.length > 0 ? 2 : 0);
+}
+
+if (!observationPath) block("real_accessibility_observation_required", "supply --observation=/abs/real-ios-accessibility-observation.json");
+
+let simulator = null;
+let appState = null;
+let capture = null;
+let observedActions = [];
+if (blockers.length === 0) {
+  simulator = resolveSimulator();
+}
+if (blockers.length === 0) {
+  appState = observeAppState(simulator);
+}
+if (blockers.length === 0) {
+  const raw = readJson("observation", observationPath);
+  if (raw) {
+    validateTruth("observation", raw);
+    const rawMissionId = String(raw.mission_id || raw.missionId || "");
+    if (rawMissionId !== missionId) block("mission_id_mismatch", rawMissionId || "<missing>");
+    const method = String(raw.capture_method || raw.captureMethod || "");
+    if (method !== "ios_simulator_accessibility") block("capture_method_not_supported", method || "<missing>");
+    if (forbiddenTruth.test(method)) block("capture_method_forbidden", method);
+    const evidenceType = String(raw.evidence_type || raw.evidenceType || "");
+    if (!allowedEvidenceTypes.has(evidenceType)) block("evidence_type_not_accessibility", evidenceType || "<missing>");
+    if (forbiddenTruth.test(evidenceType)) block("evidence_type_forbidden", evidenceType);
+    const evidenceRef = validateEvidenceRef("observation", raw.evidence_ref || raw.evidenceRef);
+    if (forbiddenTruth.test(String(raw.source || ""))) block("observation_source_forbidden", String(raw.source));
+    const rawUdid = String(raw.udid || raw.simulator_udid || raw.simulatorUdid || "");
+    if (rawUdid && simulator?.udid && rawUdid !== simulator.udid) block("simulator_udid_mismatch", `${rawUdid}:${simulator.udid}`);
+    const rawBundle = String(raw.bundle_id || raw.bundleId || "");
+    if (rawBundle && rawBundle !== bundleId) block("bundle_id_mismatch", `${rawBundle}:${bundleId}`);
+
+    observedActions = normalizeObservation(raw, targets, evidenceRef);
+    if (requireObserved && observedActions.length === 0) block("observed_actions_missing", "no passed real accessibility observations");
+
+    capture = {
+      truth_label: "ui_device_accessibility_click_capture_real_ui_not_endbar",
+      mission_id: missionId,
+      surface: "mobile",
+      capture_method: "ios_simulator_accessibility",
+      evidence_ref: evidenceRef,
+      bundle_id: bundleId,
+      simulator: {
+        udid: simulator?.udid || null,
+        name: simulator?.name || null,
+        state: simulator?.state || null,
+      },
+      app_state: appState,
+      ui_actions: observedActions,
+    };
+  }
+}
+
+let normalizer = null;
+if (blockers.length === 0 && capture) {
+  mkdirSync(outDir, { recursive: true });
+  jsonOut(capturePath, capture);
+  if (normalize) {
+    if (!isAbsolute(normalizerOutDir)) {
+      block("path_not_absolute", `normalizer-out-dir:${normalizerOutDir}`);
+    } else {
+      const result = run("node", [
+        resolve(repoRoot, "scripts/ops/friday-ui-device-accessibility-click-capture.mjs"),
+        `--mission-id=${missionId}`,
+        `--out-dir=${normalizerOutDir}`,
+        `--capture=${capturePath}`,
+        "--require-ready",
+      ]);
+      normalizer = {
+        status: result.status,
+        stdout: result.stdout.trim(),
+        stderr: result.stderr.trim(),
+      };
+      if (result.status !== 0) block("normalizer_failed", result.stderr.trim() || result.stdout.trim() || String(result.status));
+    }
+  }
+}
+
+const summary = {
+  generated_at_utc: new Date().toISOString(),
+  truth: blockers.length === 0 && observedActions.length > 0
+    ? "ios_sim_accessibility_capture_real_simulator_accessibility_not_endbar"
+    : "ios_sim_accessibility_capture_blocked_not_runtime_proof",
+  status: blockers.length === 0 && observedActions.length > 0 ? "capture_ready" : "blocked",
+  missionId: missionId || null,
+  simulator,
+  app_state: appState,
+  capture: blockers.length === 0 && capture ? {
+    path: capturePath,
+    observed_count: observedActions.length,
+  } : null,
+  normalized: normalize ? {
+    out_dir: normalizerOutDir || null,
+    status: normalizer?.status ?? null,
+  } : null,
+  blockers,
+  caveats: [
+    "Real mode requires simctl Simulator/app state plus non-screenshot accessibility observations.",
+    "The produced capture JSON is a normalizer input, not END-BAR proof by itself.",
+    "This script does not infer accessibility truth from screenshots or static Swift declarations.",
+  ],
+};
+if (summaryPath) jsonOut(summaryPath, summary);
+console.log(JSON.stringify(summary, null, 2));
+process.exit(blockers.length > 0 || (requireObserved && observedActions.length === 0) ? 2 : 0);

--- a/test/unit/qa/friday-ios-sim-accessibility-capture-cli.test.ts
+++ b/test/unit/qa/friday-ios-sim-accessibility-capture-cli.test.ts
@@ -1,0 +1,200 @@
+import { execFileSync, spawnSync } from "node:child_process";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { chmod, mkdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const script = "scripts/ops/friday-ios-sim-accessibility-capture.mjs";
+const missionId = "mission_ios_sim_accessibility_capture_contract";
+const fakeUdid = "11111111-2222-3333-4444-555555555555";
+
+async function writeFakeXcrun(binDir: string) {
+  await mkdir(binDir, { recursive: true });
+  const file = join(binDir, "xcrun");
+  writeFileSync(file, `#!/usr/bin/env bash
+set -euo pipefail
+if [ "$1" = "simctl" ] && [ "$2" = "list" ]; then
+  cat <<'JSON'
+{"devices":{"iOS Test":[{"name":"iPhone Test","udid":"${fakeUdid}","state":"Booted","isAvailable":true}]}}
+JSON
+  exit 0
+fi
+if [ "$1" = "simctl" ] && [ "$2" = "get_app_container" ]; then
+  echo "/tmp/friday-ios-sim-data-container"
+  exit 0
+fi
+if [ "$1" = "simctl" ] && [ "$2" = "launch" ]; then
+  echo "com.friday.shell: 12345"
+  exit 0
+fi
+echo "unexpected xcrun $*" >&2
+exit 64
+`);
+  await chmod(file, 0o755);
+}
+
+function writeObservation(root: string, overrides: Record<string, unknown> = {}) {
+  const evidence = join(root, "ios-accessibility-tree.txt");
+  writeFileSync(evidence, "real iOS accessibility tree bytes from XCTest or AX probe\n");
+  const observation = join(root, "ios-accessibility-observation.json");
+  writeFileSync(observation, JSON.stringify({
+    truth_label: "ios_simulator_accessibility_observation_real_ui",
+    mission_id: missionId,
+    bundle_id: "com.friday.shell",
+    udid: fakeUdid,
+    capture_method: "ios_simulator_accessibility",
+    evidence_type: "accessibility_tree",
+    evidence_ref: evidence,
+    observations: [
+      {
+        screen: "home",
+        runtimeActionId: "mobile/home/refresh",
+        accessibility_id: "friday.mobile.toolbar.refresh",
+        interaction: "visible",
+        status: "pass",
+        event: "mission_workbench_visible",
+      },
+    ],
+    ...overrides,
+  }, null, 2));
+  return { observation, evidence };
+}
+
+describe("friday-ios-sim-accessibility-capture", () => {
+  it("is exposed as the iOS AX proof script without claiming END-BAR", () => {
+    const pkg = JSON.parse(readFileSync("package.json", "utf8")) as {
+      scripts?: Record<string, string>;
+    };
+    expect(pkg.scripts?.["proof:ios:ax-capture"]).toContain(script);
+    expect(readFileSync(script, "utf8")).toContain("not END-BAR/adoption proof");
+  });
+
+  it("defaults to plan-only without writing capture JSON or claiming runtime proof", () => {
+    const outDir = mkdtempSync(join(tmpdir(), "friday-ios-sim-ax-plan-"));
+    try {
+      const stdout = execFileSync("node", [
+        script,
+        `--mission-id=${missionId}`,
+        `--out-dir=${outDir}`,
+      ], { cwd: process.cwd(), encoding: "utf8" });
+      const output = JSON.parse(stdout) as {
+        truth?: string;
+        status?: string;
+        targetCount?: number;
+        outputs?: { capture?: string | null };
+        caveat?: string;
+      };
+      expect(output.truth).toBe("ios_sim_accessibility_capture_plan_only_not_runtime_proof");
+      expect(output.status).toBe("plan_ready");
+      expect(output.targetCount).toBeGreaterThan(0);
+      expect(output.outputs?.capture).toBeNull();
+      expect(output.caveat).toContain("does not launch Simulator");
+      expect(existsSync(join(outDir, "ios-sim-accessibility-capture.json"))).toBe(false);
+
+      const summary = JSON.parse(readFileSync(join(outDir, "ios-sim-accessibility-capture-summary.json"), "utf8")) as {
+        truth?: string;
+        targets?: Array<{ runtimeActionId?: string; accessibilityIds?: string[] }>;
+      };
+      expect(summary.truth).toBe("ios_sim_accessibility_capture_plan_only_not_runtime_proof");
+      expect(summary.targets).toContainEqual(expect.objectContaining({
+        runtimeActionId: "mobile/home/refresh",
+        accessibilityIds: expect.arrayContaining(["friday.mobile.toolbar.refresh"]),
+      }));
+    } finally {
+      rmSync(outDir, { recursive: true, force: true });
+    }
+  });
+
+  it("blocks screenshot-only or mock evidence before writing capture JSON", async () => {
+    const root = mkdtempSync(join(tmpdir(), "friday-ios-sim-ax-blocked-"));
+    try {
+      const binDir = join(root, "bin");
+      const outDir = join(root, "out");
+      await writeFakeXcrun(binDir);
+      const screenshot = join(root, "screenshot.png");
+      writeFileSync(screenshot, "not accessibility evidence\n");
+      const { observation } = writeObservation(root, {
+        truth_label: "ios_simulator_accessibility_observation_real_ui_screenshot_only",
+        source: "mock screenshot-only harness",
+        evidence_type: "screenshot_only",
+        evidence_ref: screenshot,
+      });
+      const result = spawnSync("node", [
+        script,
+        "--real",
+        "--require-observed",
+        `--mission-id=${missionId}`,
+        `--out-dir=${outDir}`,
+        `--observation=${observation}`,
+      ], {
+        cwd: process.cwd(),
+        encoding: "utf8",
+        env: { ...process.env, PATH: `${binDir}:${process.env.PATH ?? ""}` },
+      });
+      expect(result.status).toBe(2);
+      const output = JSON.parse(result.stdout) as { status?: string; blockers?: Array<{ code?: string }> };
+      expect(output.status).toBe("blocked");
+      expect(output.blockers?.map((blocker) => blocker.code)).toEqual(expect.arrayContaining([
+        "truth_label_forbidden",
+        "evidence_type_not_accessibility",
+        "screenshot_only_evidence_forbidden",
+        "observation_source_forbidden",
+      ]));
+      expect(existsSync(join(outDir, "ios-sim-accessibility-capture.json"))).toBe(false);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("emits normalizer-accepted capture JSON only after simulator/app and accessibility observation checks pass", async () => {
+    const root = mkdtempSync(join(tmpdir(), "friday-ios-sim-ax-real-"));
+    try {
+      const binDir = join(root, "bin");
+      const outDir = join(root, "out");
+      const normalizedOut = join(root, "normalized");
+      await writeFakeXcrun(binDir);
+      const { observation } = writeObservation(root);
+      const stdout = execFileSync("node", [
+        script,
+        "--real",
+        "--normalize",
+        "--require-observed",
+        `--mission-id=${missionId}`,
+        `--out-dir=${outDir}`,
+        `--normalizer-out-dir=${normalizedOut}`,
+        `--observation=${observation}`,
+      ], {
+        cwd: process.cwd(),
+        encoding: "utf8",
+        env: { ...process.env, PATH: `${binDir}:${process.env.PATH ?? ""}` },
+      });
+      const output = JSON.parse(stdout) as {
+        truth?: string;
+        status?: string;
+        simulator?: { udid?: string };
+        capture?: { path?: string; observed_count?: number };
+      };
+      expect(output.truth).toBe("ios_sim_accessibility_capture_real_simulator_accessibility_not_endbar");
+      expect(output.status).toBe("capture_ready");
+      expect(output.simulator?.udid).toBe(fakeUdid);
+      expect(output.capture?.observed_count).toBe(1);
+
+      const capture = JSON.parse(readFileSync(output.capture?.path || "", "utf8")) as {
+        truth_label?: string;
+        capture_method?: string;
+        ui_actions?: Array<{ runtimeActionId?: string; accessibility_id?: string }>;
+      };
+      expect(capture.truth_label).toBe("ui_device_accessibility_click_capture_real_ui_not_endbar");
+      expect(capture.capture_method).toBe("ios_simulator_accessibility");
+      expect(capture.ui_actions).toContainEqual(expect.objectContaining({
+        runtimeActionId: "mobile/home/refresh",
+        accessibility_id: "friday.mobile.toolbar.refresh",
+      }));
+      expect(existsSync(join(normalizedOut, "accessibility-click-events.jsonl"))).toBe(true);
+      expect(existsSync(join(normalizedOut, "action-runtime-evidence.json"))).toBe(true);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add a fail-closed iOS Simulator accessibility capture bridge for real AX/XCTest observations
- expose `proof:ios:ax-capture` alongside the existing desktop AX capture script
- add QA coverage for plan-only boundaries, fake/screenshot-only rejection, and normalizer integration

## Truth Boundary
- default mode is plan-only and does not claim runtime proof
- real mode requires simctl state, app container/launch, and a supplied real accessibility observation artifact
- output remains normalizer input only: not END-BAR, not GO-LIVE, not adoption

## Local Verification
- `npm run proof:ios:ax-capture -- --plan-only`
- `npx vitest run test/unit/qa/friday-ios-sim-accessibility-capture-cli.test.ts test/unit/qa/friday-ui-device-accessibility-click-capture-cli.test.ts`