### PR TITLE
[codex] test channel timeout diagnostic wrapper

### DIFF
--- a/rust-core/scripts/mission-spine-channel-live-gate-self-test.sh
+++ b/rust-core/scripts/mission-spine-channel-live-gate-self-test.sh
@@ -12,6 +12,8 @@ trap cleanup EXIT
 
 raw="$tmp/raw-telegram-proof.json"
 wrapped="$tmp/channel-live-proof.json"
+failed_raw="$tmp/raw-telegram-timeout.json"
+failed_wrapped="$tmp/channel-live-timeout.json"
 fixture_token="fixture-telegram-token-not-real" # pragma: allowlist secret
 raw_text="hello from raw telegram message"
 raw_sender="987654321"
@@ -52,6 +54,52 @@ jq -e '
 if grep -q "$fixture_token\\|$raw_sender\\|$raw_text" "$wrapped"; then
   echo "BLOCKER: wrapped channel proof leaked raw Telegram secret/sender/text" >&2
   exit 2
+fi
+
+cat >"$failed_raw" <<EOF
+{
+  "proof": "telegram_inbound_through_rust_channels_pipeline",
+  "status": "failed_timeout",
+  "bot_identity_verified": true,
+  "channel_binding_created": false,
+  "sender_id_present": false,
+  "sender_allowlisted": false,
+  "bound_principal_id": "owner",
+  "bearer_auth_accepted_correct": false,
+  "forged_bearer_rejected": false,
+  "non_allowlisted_sender_rejected": false,
+  "pii_kinds_redacted": "[]",
+  "redacted_text": "",
+  "raw_text_chars": 0,
+  "failure_reason": "timed out waiting for one text message from the trusted user within the live proof window",
+  "bot_token": "$fixture_token"
+}
+EOF
+
+set +e
+TELEGRAM_PROOF_OUT="$failed_raw" \
+MISSION_SPINE_CHANNEL_LIVE_PROOF_OUT="$failed_wrapped" \
+  scripts/mission-spine-channel-live-gate.sh --wrap-existing >/tmp/friday-channel-live-timeout-self-test.out 2>&1
+status=$?
+set -e
+
+if [[ "$status" -eq 0 ]]; then
+  echo "BLOCKER: timeout diagnostic wrapper path must remain fail-closed" >&2
+  exit 3
+fi
+
+jq -e '
+  .proof == "mission_spine_channel_live_proof"
+  and .status == "failed_timeout"
+  and .capture_mode == "--wrap-existing"
+  and .telegram_live.status == "failed_timeout"
+  and .telegram_live.bot_identity_verified == true
+  and .secret_policy.artifact_contains_redacted_text_only == true
+' "$failed_wrapped" >/dev/null
+
+if grep -q "$fixture_token" "$failed_wrapped"; then
+  echo "BLOCKER: timeout diagnostic wrapper leaked fixture token" >&2
+  exit 4
 fi
 
 echo "[mission-spine-channel-self-test] PASS"

--- a/rust-core/scripts/mission-spine-channel-live-gate.sh
+++ b/rust-core/scripts/mission-spine-channel-live-gate.sh
@@ -46,11 +46,16 @@ if [[ "$mode" == "--live" ]]; then
 
   echo "[mission-spine-channel] live Telegram/channel inbound proof"
   echo "[mission-spine-channel] waiting up to ${TELEGRAM_LISTEN_SECONDS}s for one real message from the allowlisted user"
+  live_status=0
+  set +e
   cargo test -p friday-hub --test telegram_live \
     telegram_inbound_through_rust_channels_pipeline \
     -- --ignored --nocapture
+  live_status=$?
+  set -e
 else
   echo "[mission-spine-channel] wrapping existing Telegram proof artifact: ${TELEGRAM_PROOF_OUT}"
+  live_status=0
 fi
 
 if [[ ! -s "$TELEGRAM_PROOF_OUT" ]]; then
@@ -58,7 +63,7 @@ if [[ ! -s "$TELEGRAM_PROOF_OUT" ]]; then
   exit 3
 fi
 
-if ! jq -e '
+if jq -e '
   .proof == "telegram_inbound_through_rust_channels_pipeline"
   and .sender_id_present == true
   and .sender_allowlisted == true
@@ -70,16 +75,12 @@ if ! jq -e '
   and (.redacted_text | type == "string")
   and (.raw_text_chars | type == "number" and . > 0)
 ' "$TELEGRAM_PROOF_OUT" >/dev/null; then
-  echo "BLOCKER: Telegram live proof artifact failed schema validation: ${TELEGRAM_PROOF_OUT}" >&2
-  exit 4
-fi
-
-jq \
-  --arg generated_at "$generated_at" \
-  --arg worktree "$root" \
-  --arg raw_artifact "$TELEGRAM_PROOF_OUT" \
-  --arg mode "$mode" \
-  '{
+  jq \
+    --arg generated_at "$generated_at" \
+    --arg worktree "$root" \
+    --arg raw_artifact "$TELEGRAM_PROOF_OUT" \
+    --arg mode "$mode" \
+    '{
     proof: "mission_spine_channel_live_proof",
     generated_at_utc: $generated_at,
     worktree: $worktree,
@@ -106,10 +107,65 @@ jq \
 	      provider_or_channel_id_written: false,
 	      raw_sender_id_written: false,
 	      artifact_contains_redacted_text_only: true
-	    },
+    },
     remaining_requirement: "real mobile/desktop/channel UI/device consumption evidence must still pass scripts/mission-spine-ui-device-proof-gate.sh"
   }' "$TELEGRAM_PROOF_OUT" >"$channel_live_proof_out"
 
-echo "[mission-spine-channel] CHANNEL LIVE PROOF PASSED"
-echo "[mission-spine-channel] redacted proof artifact: ${TELEGRAM_PROOF_OUT}"
-echo "[mission-spine-channel] channel live proof report written: ${channel_live_proof_out}"
+  echo "[mission-spine-channel] CHANNEL LIVE PROOF PASSED"
+  echo "[mission-spine-channel] redacted proof artifact: ${TELEGRAM_PROOF_OUT}"
+  echo "[mission-spine-channel] channel live proof report written: ${channel_live_proof_out}"
+  exit "$live_status"
+fi
+
+if jq -e '
+  .proof == "telegram_inbound_through_rust_channels_pipeline"
+  and .status == "failed_timeout"
+  and .bot_identity_verified == true
+  and .sender_id_present == false
+  and .sender_allowlisted == false
+  and (.failure_reason | type == "string" and length > 0)
+' "$TELEGRAM_PROOF_OUT" >/dev/null; then
+  jq \
+    --arg generated_at "$generated_at" \
+    --arg worktree "$root" \
+    --arg raw_artifact "$TELEGRAM_PROOF_OUT" \
+    --arg mode "$mode" \
+    '{
+      proof: "mission_spine_channel_live_proof",
+      generated_at_utc: $generated_at,
+      worktree: $worktree,
+      status: "failed_timeout",
+      capture_mode: $mode,
+      scope: "diagnostic only: Telegram bot identity was verified but no trusted allowlisted text message arrived during the live proof window",
+      raw_artifact: $raw_artifact,
+      telegram_live: {
+        status: "failed_timeout",
+        proof: .proof,
+        bot_identity_verified: .bot_identity_verified,
+        channel_binding_created: .channel_binding_created,
+        sender_id_present: .sender_id_present,
+        sender_allowlisted: .sender_allowlisted,
+        bearer_auth_accepted_correct: .bearer_auth_accepted_correct,
+        forged_bearer_rejected: .forged_bearer_rejected,
+        non_allowlisted_sender_rejected: .non_allowlisted_sender_rejected,
+        pii_kinds_redacted: .pii_kinds_redacted,
+        raw_text_chars: .raw_text_chars,
+        failure_reason: .failure_reason
+      },
+      secret_policy: {
+        token_logged: false,
+        token_written_to_artifact: false,
+        provider_or_channel_id_written: false,
+        raw_sender_id_written: false,
+        artifact_contains_redacted_text_only: true
+      },
+      remaining_requirement: "real allowlisted Telegram message plus real mobile/desktop/channel UI/device consumption evidence must still pass"
+    }' "$TELEGRAM_PROOF_OUT" >"$channel_live_proof_out"
+
+  echo "BLOCKER: Telegram live proof timed out without a trusted text message" >&2
+  echo "[mission-spine-channel] timeout diagnostic wrapper written: ${channel_live_proof_out}" >&2
+  exit 4
+fi
+
+echo "BLOCKER: Telegram live proof artifact failed schema validation: ${TELEGRAM_PROOF_OUT}" >&2
+exit 4


### PR DESCRIPTION
## Summary
- make `mission-spine-channel-live-gate.sh` write a current-shape diagnostic wrapper when the Telegram live proof times out
- keep the timeout path fail-closed: the command exits non-zero and the wrapper has `status: failed_timeout`
- extend the channel live self-test to cover both passed raw proof wrapping and timeout diagnostic wrapping without leaking fixture token material

## Validation
- `bash -n rust-core/scripts/mission-spine-channel-live-gate.sh rust-core/scripts/mission-spine-channel-live-gate-self-test.sh`
- `rust-core/scripts/mission-spine-channel-live-gate-self-test.sh`
- `git diff --check`
- focused `detect-secrets-hook --baseline .secrets.baseline` on the two changed scripts
- manual timeout wrapper check: gate exits `4`, writes `status: failed_timeout`, and `friday-channel-live-artifact-ingest --require-compatible` blocks it

Truth: this is diagnostic evidence only. It does not satisfy channel live proof, END-BAR, GO-LIVE, or UI/device consumption proof.