### PR TITLE
[codex] report deferred channel proof gaps

### DIFF
--- a/scripts/ops/friday-ui-device-proof-gap-report.mjs
+++ b/scripts/ops/friday-ui-device-proof-gap-report.mjs
@@ -80,7 +80,7 @@ function usage() {
     --timeline=/abs/timeline-evidence \\
     [--manifest=/abs/observations-manifest.json] \\
     [--backend-live-proof=/abs/backend-proof.json] \\
-    [--channel-live-proof=/abs/channel-proof.json] \\
+    [--channel-live-proof=/abs/channel-proof.json] [--defer-channel-proof] \\
     [--objective-coverage=/abs/objective-coverage.json] \\
     [--out=/abs/gap-report.json] [--require-complete]
 
@@ -99,6 +99,8 @@ if (args.includes("--help") || args.includes("-h")) {
 }
 
 const requireComplete = args.includes("--require-complete");
+const deferChannelProof = args.includes("--defer-channel-proof")
+  || process.env.FRIDAY_UI_DEVICE_DEFER_CHANNEL_PROOF === "1";
 const missionId = arg("mission-id");
 const eventsPath = arg("events");
 const manifestPath = arg("manifest");
@@ -125,6 +127,9 @@ function abs(path) {
 }
 
 function requireFile(label, path) {
+  if (label === "channel" && deferChannelProof && !path) {
+    return "";
+  }
   if (!path) {
     block("missing_arg", label);
     return "";
@@ -338,6 +343,7 @@ function capturePlan(missingObservationRows, stressState) {
       missingEvents: [...new Set(entry.events)].sort(),
       stressRequirements: [...new Set(entry.stress)].sort(),
       evidenceRole: entry.surface,
+      deferred: entry.surface === "channel" && deferChannelProof,
       truth: "capture_real_same_run_events_only_no_synthetic_rows",
     }))
     .sort((a, b) => a.surface.localeCompare(b.surface));
@@ -376,8 +382,14 @@ const gapReport = {
   },
   capturePlan: capturePlan(missingObservations, stressGaps),
   supportingProofs: supportingProofRows,
+  deferredInputs: deferChannelProof ? [{
+    role: "channel",
+    status: "deferred_by_operator",
+    countsTowardUiDeviceProof: false,
+    caveat: "Channel live proof is deferred for this report-only run. This does not satisfy channel observations or END-BAR UI/device proof.",
+  }] : [],
   blockers,
-  caveat: "Gap report only. Capture missing observations from a real same-run mobile/desktop/channel/timeline run before assembling proof.",
+  caveat: "Gap report only. Capture missing observations from a real same-run mobile/desktop/channel/timeline run before assembling proof. Deferred inputs are never counted as proof.",
 };
 
 if (outPath) {

--- a/scripts/ops/friday-ui-device-proof-readiness.sh
+++ b/scripts/ops/friday-ui-device-proof-readiness.sh
@@ -21,6 +21,7 @@ OBJECTIVE_COVERAGE="${FRIDAY_UI_DEVICE_OBJECTIVE_COVERAGE:-}"
 WORKBENCH_DB="${FRIDAY_WORKBENCH_DB_PATH:-}"
 DESIGN_ACTION_CONTRACT="${FRIDAY_DESIGN_ACTION_CONTRACT:-}"
 DESIGN_ACTION_RUNTIME_EVIDENCE="${FRIDAY_DESIGN_ACTION_RUNTIME_EVIDENCE:-}"
+DEFER_CHANNEL_PROOF="${FRIDAY_UI_DEVICE_DEFER_CHANNEL_PROOF:-0}"
 DESIGN_ACTION_RUNTIME_EVIDENCE_DIRS=()
 if [ -n "${FRIDAY_DESIGN_ACTION_RUNTIME_EVIDENCE_DIRS:-}" ]; then
   IFS=':' read -r -a DESIGN_ACTION_RUNTIME_EVIDENCE_DIRS <<<"${FRIDAY_DESIGN_ACTION_RUNTIME_EVIDENCE_DIRS}"
@@ -33,6 +34,7 @@ usage:
     [--backend-live-proof /abs/backend-proof.json]
     [--channel-live-proof /abs/channel-proof.json]
     [--objective-coverage /abs/objective-coverage.json]
+    [--defer-channel-proof]
     [--workbench-db /abs/rust-hub.sqlite]
     [--design-action-contract /abs/ACTION-CONTRACT.md]
     [--design-action-runtime-evidence /abs/action-runtime-evidence.json]
@@ -59,6 +61,7 @@ evidence-dir auto-discovery:
   FRIDAY_UI_DEVICE_BACKEND_LIVE_PROOF=/abs/backend-proof.json
   FRIDAY_UI_DEVICE_CHANNEL_LIVE_PROOF=/abs/channel-proof.json
   FRIDAY_UI_DEVICE_OBJECTIVE_COVERAGE=/abs/objective-coverage.json
+  FRIDAY_UI_DEVICE_DEFER_CHANNEL_PROOF=1
   FRIDAY_WORKBENCH_DB_PATH=/abs/rust-hub.sqlite
   FRIDAY_DESIGN_ACTION_CONTRACT=/abs/ACTION-CONTRACT.md
   FRIDAY_DESIGN_ACTION_RUNTIME_EVIDENCE=/abs/action-runtime-evidence.json
@@ -128,6 +131,9 @@ while [ "$#" -gt 0 ]; do
       fi
       OBJECTIVE_COVERAGE="$2"
       shift
+      ;;
+    --defer-channel-proof)
+      DEFER_CHANNEL_PROOF=1
       ;;
     --workbench-db)
       if [ "$#" -lt 2 ]; then
@@ -642,7 +648,10 @@ run_note_step() {
 }
 
 run_gap_report_if_possible() {
-  if [ -z "${MISSION_ID:-}" ] || [ -z "${MOBILE_EVIDENCE:-}" ] || [ -z "${DESKTOP_EVIDENCE:-}" ] || [ -z "${CHANNEL_EVIDENCE:-}" ] || [ -z "${TIMELINE_EVIDENCE:-}" ] || [ -z "${SAME_RUN_EVENTS:-}" ]; then
+  if [ -z "${MISSION_ID:-}" ] || [ -z "${MOBILE_EVIDENCE:-}" ] || [ -z "${DESKTOP_EVIDENCE:-}" ] || [ -z "${TIMELINE_EVIDENCE:-}" ] || [ -z "${SAME_RUN_EVENTS:-}" ]; then
+    return 0
+  fi
+  if [ -z "${CHANNEL_EVIDENCE:-}" ] && [ "${DEFER_CHANNEL_PROOF}" != "1" ]; then
     return 0
   fi
 
@@ -662,10 +671,15 @@ run_gap_report_if_possible() {
     "--events=${SAME_RUN_EVENTS}"
     "--mobile=${MOBILE_EVIDENCE}"
     "--desktop=${DESKTOP_EVIDENCE}"
-    "--channel=${CHANNEL_EVIDENCE}"
     "--timeline=${TIMELINE_EVIDENCE}"
     "--out=${gap_out}"
   )
+  if [ -n "${CHANNEL_EVIDENCE:-}" ]; then
+    args+=("--channel=${CHANNEL_EVIDENCE}")
+  fi
+  if [ "${DEFER_CHANNEL_PROOF}" = "1" ]; then
+    args+=("--defer-channel-proof")
+  fi
   if [ -n "${OBSERVATIONS_MANIFEST:-}" ]; then
     args+=("--manifest=${OBSERVATIONS_MANIFEST}")
   fi

--- a/test/unit/qa/friday-ui-device-proof-readiness-cli.test.ts
+++ b/test/unit/qa/friday-ui-device-proof-readiness-cli.test.ts
@@ -737,6 +737,53 @@ describe("friday-ui-device-proof-readiness", () => {
     }
   });
 
+  it("can defer channel proof in report-only mode without satisfying UI proof", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "friday-ui-device-readiness-defer-channel-"));
+    try {
+      const files = writePartialEvidenceDir(tempDir);
+      rmSync(files.channel, { force: true });
+
+      const stdout = execFileSync("bash", [
+        "scripts/ops/friday-ui-device-proof-readiness.sh",
+        "--evidence-dir",
+        tempDir,
+        "--defer-channel-proof",
+      ], {
+        cwd: process.cwd(),
+        encoding: "utf8",
+      });
+      const result = JSON.parse(stdout.slice(stdout.indexOf("{"))) as {
+        truth?: string;
+        status?: string;
+        notes?: string[];
+        blockers?: string[];
+      };
+
+      expect(result.truth).toBe("report_only_not_ui_device_proof");
+      expect(result.status).toBe("blocked");
+      expect(result.blockers).toContain("ui_device_proof_evidence:missing_required_real_evidence_env");
+      expect(result.notes?.some((note) => note.includes("ui_device_gap_report:gaps_present"))).toBe(true);
+
+      const gapReport = JSON.parse(readFileSync(join(tempDir, "gap-report.json"), "utf8")) as {
+        status?: string;
+        deferredInputs?: Array<{ role?: string; status?: string; countsTowardUiDeviceProof?: boolean }>;
+        capturePlan?: Array<{ surface?: string; deferred?: boolean }>;
+      };
+      expect(gapReport.status).toBe("gaps_present");
+      expect(gapReport.deferredInputs).toContainEqual(expect.objectContaining({
+        role: "channel",
+        status: "deferred_by_operator",
+        countsTowardUiDeviceProof: false,
+      }));
+      expect(gapReport.capturePlan).toContainEqual(expect.objectContaining({
+        surface: "channel",
+        deferred: true,
+      }));
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
   it("discovers indexed channel and timeline evidence without satisfying UI proof", () => {
     const tempDir = mkdtempSync(join(tmpdir(), "friday-ui-device-readiness-indexed-roles-"));
     try {


### PR DESCRIPTION
## Summary
- add report-only deferred channel proof mode to the UI/device gap reporter
- pass the mode through the UI/device proof readiness wrapper
- keep strict proof blocked: deferred channel inputs never count as UI/device proof or END-BAR completion

## Verification
- bash -n scripts/ops/friday-ui-device-proof-readiness.sh
- node --check scripts/ops/friday-ui-device-proof-gap-report.mjs
- npx vitest run test/unit/qa/friday-ui-device-proof-readiness-cli.test.ts
- git diff --check
- real-ish deferred report smoke with current mobile/desktop live-write-read evidence (channel absent, gap report remains gaps_present)