### PR TITLE
[codex] report design-annex traceability gaps

### DIFF
--- a/scripts/ops/check-friday-uiux-action-traceability.mjs
+++ b/scripts/ops/check-friday-uiux-action-traceability.mjs
@@ -422,6 +422,10 @@ const productActions = tracedDestinations.flatMap((destination) => destination.a
 })));
 const productActionsMissingDesign = productActions.filter((action) => !action.designContractMatched);
 const productActionsMissingRuntime = productActions.filter((action) => !action.runtimeEvidenceMatched);
+const productActionsMissingDesignRuntimeCovered = productActionsMissingDesign
+  .filter((action) => action.runtimeEvidenceMatched);
+const productActionsMissingDesignRuntimeMissing = productActionsMissingDesign
+  .filter((action) => !action.runtimeEvidenceMatched);
 const destinationsWithoutRuntimeActions = tracedDestinations.filter((destination) => destination.runtimeActionIds.length === 0);
 const destinationsWithBlockers = tracedDestinations.filter((destination) => destination.blockers.length > 0);
 
@@ -448,6 +452,8 @@ const report = {
     runtimeEvidenceInputs: runtimeEvidencePaths.length,
     runtimeEvidenceActionRows: evidenceActions.length,
     productActionsMissingDesign: productActionsMissingDesign.length,
+    productActionsMissingDesignRuntimeCovered: productActionsMissingDesignRuntimeCovered.length,
+    productActionsMissingDesignRuntimeMissing: productActionsMissingDesignRuntimeMissing.length,
     productActionsMissingRuntimeEvidence: productActionsMissingRuntime.length,
     destinationsWithoutRuntimeActions: destinationsWithoutRuntimeActions.length,
     destinationsStillBlocked: destinationsWithBlockers.length,
@@ -467,11 +473,23 @@ const report = {
     }];
   })),
   gaps: {
-    productActionsMissingDesign: productActionsMissingDesign.map(({ surface, destination, runtimeActionId, tier }) => ({
+    productActionsMissingDesign: productActionsMissingDesign.map(({
       surface,
       destination,
       runtimeActionId,
       tier,
+      runtimeEvidenceMatched,
+      evidenceRefs,
+    }) => ({
+      surface,
+      destination,
+      runtimeActionId,
+      tier,
+      runtimeEvidenceMatched,
+      evidenceRefs,
+      recommendedNext: runtimeEvidenceMatched
+        ? "add or reconcile a design contract annex row; runtime action evidence is already present"
+        : "capture runtime action evidence and reconcile the design contract row",
     })).slice(0, compact ? 40 : undefined),
     productActionsMissingRuntimeEvidence: productActionsMissingRuntime.map(({ surface, destination, runtimeActionId, tier, designContractMatched }) => ({
       surface,

--- a/test/unit/qa/friday-uiux-action-traceability-cli.test.ts
+++ b/test/unit/qa/friday-uiux-action-traceability-cli.test.ts
@@ -168,4 +168,128 @@ describe("check-friday-uiux-action-traceability", () => {
       rmSync(root, { recursive: true, force: true });
     }
   });
+
+  it("separates design-annex gaps from missing runtime evidence", () => {
+    const root = mkdtempSync(join(tmpdir(), "friday-uiux-action-traceability-annex-"));
+    try {
+      const designRoot = join(root, "design");
+      writeFile(designRoot, "ACTION-CONTRACT.md", `# Friday Action Contract — mobile + desktop
+
+**This is a wiring contract for the later Rust/native agent, NOT runtime proof.** Every row is design-proof; wired_registry ≠ runtime PASS.
+
+| Surface | Screen [state] | action_id | Label | capability_id | reg | reg_status | truth_status | result/target | Rust/Hub owner · gate · test expectation |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| mobile | home | refresh | Retry now | transport_connection_state | ✓ | wired | wired_registry | result:confirmed | Runtime test must prove gate enforcement. |
+`);
+      writeFile(
+        root,
+        "apps/friday-ios/Sources/FridayMobileShellCore/MobileProductReadinessContract.swift",
+        `enum MobileProductDestinationID {
+        case shareIntake
+        var contract: MobileProductDestinationContract {
+          switch self {
+          case .shareIntake:
+          return contract(
+            title: "Share Intake",
+            systemImage: "square.and.arrow.down",
+            tier: .governedActionGated,
+            runtimeActionIds: ["mobile/share/send"],
+            blockers: [])
+        }
+        }
+        private func contract(
+          title: String,
+          systemImage: String,
+          tier: MobileProductLoopTier,
+          runtimeActionIds: [String],
+          blockers: [MobileProductBlocker]
+        ) -> MobileProductDestinationContract { fatalError() }
+        }
+`,
+      );
+      writeFile(
+        root,
+        "apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/DesktopProductReadinessContract.swift",
+        `enum DesktopProductDestinationID {
+        case empty
+        var contract: DesktopProductDestinationContract {
+          switch self {
+          case .empty:
+          return contract(
+            title: "Empty",
+            systemImage: "circle",
+            tier: .navigationShell,
+            runtimeActionIds: [],
+            blockers: [])
+        }
+        }
+        private func contract(
+          title: String,
+          systemImage: String,
+          tier: DesktopProductLoopTier,
+          runtimeActionIds: [String],
+          blockers: [DesktopProductBlocker]
+        ) -> DesktopProductDestinationContract { fatalError() }
+        }
+`,
+      );
+      const evidenceDir = join(root, "evidence");
+      writeFile(evidenceDir, "mobile/action-runtime-evidence.json", JSON.stringify({
+        actions: [
+          {
+            surface: "mobile",
+            screen: "share",
+            action_id: "send",
+            capability_id: "share_intake_governed_send",
+            status: "pass",
+            evidence_ref: "proof://mobile/share-send",
+          },
+        ],
+      }, null, 2));
+
+      const output = execFileSync("node", [
+        script,
+        `--repo-root=${root}`,
+        `--design-root=${designRoot}`,
+        "--runtime-evidence-dir",
+        evidenceDir,
+        "--compact",
+      ], { cwd: process.cwd(), encoding: "utf8" });
+      const report = JSON.parse(output) as {
+        status?: string;
+        counts?: {
+          productActionsMissingDesign?: number;
+          productActionsMissingDesignRuntimeCovered?: number;
+          productActionsMissingDesignRuntimeMissing?: number;
+          productActionsMissingRuntimeEvidence?: number;
+        };
+        gaps?: {
+          productActionsMissingDesign?: Array<{
+            runtimeActionId?: string;
+            runtimeEvidenceMatched?: boolean;
+            evidenceRefs?: string[];
+            recommendedNext?: string;
+          }>;
+          productActionsMissingRuntimeEvidence?: Array<unknown>;
+        };
+      };
+
+      expect(report.status).toBe("traceability_gaps_present");
+      expect(report.counts?.productActionsMissingDesign).toBe(1);
+      expect(report.counts?.productActionsMissingDesignRuntimeCovered).toBe(1);
+      expect(report.counts?.productActionsMissingDesignRuntimeMissing).toBe(0);
+      expect(report.counts?.productActionsMissingRuntimeEvidence).toBe(0);
+      expect(report.gaps?.productActionsMissingRuntimeEvidence).toEqual([]);
+      expect(report.gaps?.productActionsMissingDesign).toEqual([
+        expect.objectContaining({
+          runtimeActionId: "mobile/share/send",
+          runtimeEvidenceMatched: true,
+          evidenceRefs: ["proof://mobile/share-send"],
+          recommendedNext: "add or reconcile a design contract annex row; runtime action evidence is already present",
+        }),
+      ]);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
 });


### PR DESCRIPTION
## Summary
- split product action traceability gaps into runtime-missing vs design-annex-missing-but-runtime-covered buckets
- keep the readiness gate strict while making UI/UX closure reporting distinguish stale design contract coverage from missing runtime proof
- add CLI regression coverage for both the runtime-missing and runtime-covered design-annex paths

## Verification
- node --check scripts/ops/check-friday-uiux-action-traceability.mjs
- npx vitest run test/unit/qa/friday-uiux-action-traceability-cli.test.ts
- git diff --check

Truth: this is reporting precision only. It does not count deferred channel proof as complete and does not move END-BAR by itself.