### PR TITLE
[codex] canonicalize UI-device evidence refs

### DIFF
--- a/scripts/ops/friday-ui-device-events-merge.mjs
+++ b/scripts/ops/friday-ui-device-events-merge.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { mkdirSync, readFileSync, readdirSync, statSync, writeFileSync } from "node:fs";
+import { mkdirSync, readFileSync, readdirSync, realpathSync, statSync, writeFileSync } from "node:fs";
 import { dirname, extname, isAbsolute, join, resolve } from "node:path";
 
 const args = process.argv.slice(2);
@@ -65,6 +65,16 @@ function block(code, detail) {
 
 function abs(path) {
   return isAbsolute(path) ? path : resolve(path);
+}
+
+function evidenceKey(path) {
+  if (!path) return "";
+  const resolved = abs(path);
+  try {
+    return realpathSync.native(resolved);
+  } catch {
+    return resolved;
+  }
 }
 
 function readableFile(label, path) {
@@ -136,7 +146,7 @@ function normalizedEntry(entry, knownEvidenceRefs) {
   if (!eventMissionId) block("event_missing_mission_id", label);
   if (eventMissionId && eventMissionId !== missionId) block("event_mission_mismatch", `${label}:${eventMissionId}`);
   if (!evidenceRef) block("event_missing_evidence_ref", label);
-  if (knownEvidenceRefs.size > 0 && evidenceRef && !knownEvidenceRefs.has(evidenceRef)) {
+  if (knownEvidenceRefs.size > 0 && evidenceRef && !knownEvidenceRefs.has(evidenceKey(evidenceRef))) {
     block("event_evidence_ref_unknown", `${label}:${evidenceRef}`);
   }
   const normalized = {
@@ -165,7 +175,8 @@ if (eventFiles.length === 0) block("missing_events", "supply --events or --event
 const knownEvidenceRefs = new Set(
   Object.entries(evidenceArgs)
     .map(([role, path]) => readableFile(role, path))
-    .filter(Boolean),
+    .filter(Boolean)
+    .map(evidenceKey),
 );
 
 const rows = eventFiles.flatMap(parseJsonl).map((entry) => normalizedEntry(entry, knownEvidenceRefs));

--- a/scripts/ops/friday-ui-device-observations-manifest.mjs
+++ b/scripts/ops/friday-ui-device-observations-manifest.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { mkdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { mkdirSync, readFileSync, realpathSync, statSync, writeFileSync } from "node:fs";
 import { dirname, isAbsolute, resolve } from "node:path";
 
 const args = process.argv.slice(2);
@@ -150,6 +150,16 @@ function abs(path) {
   return isAbsolute(path) ? path : resolve(path);
 }
 
+function evidenceKey(path) {
+  if (!path) return "";
+  const resolved = abs(path);
+  try {
+    return realpathSync.native(resolved);
+  } catch {
+    return resolved;
+  }
+}
+
 function requireFile(label, path) {
   if (!path) {
     block("missing_arg", label);
@@ -204,7 +214,7 @@ function normalizedEvents(rawEvents, evidenceRefs) {
     if (eventMissionId && eventMissionId !== missionId) {
       block("event_mission_mismatch", `${label}:${eventMissionId}`);
     }
-    if (evidenceRef && !evidenceRefs.has(evidenceRef)) {
+    if (evidenceRef && !evidenceRefs.has(evidenceKey(evidenceRef))) {
       block("event_evidence_ref_unknown", `${label}:${evidenceRef}`);
     }
     return { surface, event, mission_id: eventMissionId, evidence_ref: evidenceRef };
@@ -231,7 +241,7 @@ const evidence = Object.fromEntries(Object.entries(evidenceByRole).map(([role, p
 const eventFile = requireFile("events", eventsPath);
 if (!out) block("missing_arg", "out");
 
-const evidenceRefs = new Set(Object.values(evidence).filter(Boolean));
+const evidenceRefs = new Set(Object.values(evidence).filter(Boolean).map(evidenceKey));
 const observations = normalizedEvents(parseJsonl(eventFile), evidenceRefs);
 
 for (const [surface, event] of requiredObservations) {

--- a/scripts/ops/friday-ui-device-proof-gap-report.mjs
+++ b/scripts/ops/friday-ui-device-proof-gap-report.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { readFileSync, statSync, writeFileSync } from "node:fs";
+import { readFileSync, realpathSync, statSync, writeFileSync } from "node:fs";
 import { dirname, isAbsolute, resolve } from "node:path";
 import { mkdirSync } from "node:fs";
 
@@ -126,6 +126,16 @@ function abs(path) {
   return isAbsolute(path) ? path : resolve(path);
 }
 
+function evidenceKey(path) {
+  if (!path) return "";
+  const resolved = abs(path);
+  try {
+    return realpathSync.native(resolved);
+  } catch {
+    return resolved;
+  }
+}
+
 function requireFile(label, path) {
   if (label === "channel" && deferChannelProof && !path) {
     return "";
@@ -240,7 +250,7 @@ function normalizeEvent(raw, index, knownEvidenceRefs) {
   if (!surface) block("event_missing_surface", label);
   if (!event) block("event_missing_name", label);
   if (eventMissionId !== missionId) block("event_mission_mismatch", `${label}:${eventMissionId}`);
-  if (!knownEvidenceRefs.has(evidenceRef)) block("event_evidence_ref_unknown", `${label}:${evidenceRef}`);
+  if (!knownEvidenceRefs.has(evidenceKey(evidenceRef))) block("event_evidence_ref_unknown", `${label}:${evidenceRef}`);
   return { surface, event, mission_id: eventMissionId, evidence_ref: evidenceRef };
 }
 
@@ -286,7 +296,7 @@ if (!missionId || !/^[A-Za-z0-9][A-Za-z0-9._:-]*$/.test(missionId) || !missionId
 const evidence = Object.fromEntries(
   Object.entries(evidenceArgs).map(([role, path]) => [role, requireFile(role, path)]),
 );
-const knownEvidenceRefs = new Set(Object.values(evidence).filter(Boolean));
+const knownEvidenceRefs = new Set(Object.values(evidence).filter(Boolean).map(evidenceKey));
 const eventFile = requireFile("events", eventsPath);
 const observations = parseJsonl(eventFile).map((raw, index) => normalizeEvent(raw, index, knownEvidenceRefs));
 const manifest = parseManifest(manifestPath);

--- a/scripts/qa/check-mission-spine-ui-proof-inputs.mjs
+++ b/scripts/qa/check-mission-spine-ui-proof-inputs.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import { createHash } from "node:crypto";
-import { readFileSync, statSync } from "node:fs";
+import { readFileSync, realpathSync, statSync } from "node:fs";
 import { isAbsolute, resolve } from "node:path";
 
 const args = process.argv.slice(2);
@@ -167,6 +167,16 @@ function pathFor(name, envName) {
   return isAbsolute(value) ? value : resolve(value);
 }
 
+function evidenceKey(path) {
+  if (!path) return "";
+  const resolved = isAbsolute(path) ? path : resolve(path);
+  try {
+    return realpathSync.native(resolved);
+  } catch {
+    return resolved;
+  }
+}
+
 function recordFailure(failures, code, detail) {
   failures.push({ code, detail });
 }
@@ -244,7 +254,7 @@ function observationExists(observations, requiredSurface, eventName, missionId, 
   return observations.some((observation) => {
     if (observation.event !== eventName) return false;
     if (requiredSurface !== "*" && observation.surface !== requiredSurface) return false;
-    return observation.mission_id === missionId && knownEvidenceRefs.has(observation.evidence_ref);
+    return observation.mission_id === missionId && knownEvidenceRefs.has(evidenceKey(observation.evidence_ref));
   });
 }
 
@@ -258,7 +268,7 @@ function isMissionIdProofEligible(value) {
 }
 
 function validateKnownEvidenceRef(value, knownEvidenceRefs, failures, code, detail) {
-  if (!knownEvidenceRefs.has(value)) {
+  if (!knownEvidenceRefs.has(evidenceKey(value))) {
     recordFailure(failures, code, detail);
   }
 }
@@ -272,7 +282,7 @@ function expectedEvidenceRefForSurface(surface, evidenceByRole) {
 }
 
 function validateEvidenceRoleRef(value, expectedValue, failures, code, detail) {
-  if (value !== expectedValue) {
+  if (evidenceKey(value) !== evidenceKey(expectedValue)) {
     recordFailure(failures, code, detail);
   }
 }
@@ -414,7 +424,7 @@ function validateManifest(manifestPath, missionId, evidenceByRole, knownEvidence
     if (pageCount < 2) {
       recordFailure(failures, "stress_timeline_page_count_low", String(pageCount));
     }
-    if (!knownEvidenceRefs.has(manifest.stress.evidence_ref)) {
+    if (!knownEvidenceRefs.has(evidenceKey(manifest.stress.evidence_ref))) {
       recordFailure(failures, "stress_evidence_ref_unknown", String(manifest.stress.evidence_ref || ""));
     }
     validateEvidenceRoleRef(
@@ -476,7 +486,7 @@ function validateManifest(manifestPath, missionId, evidenceByRole, knownEvidence
     if (observation.mission_id !== missionId) {
       recordFailure(failures, "observation_mission_mismatch", String(observation.event || "unknown"));
     }
-    if (!knownEvidenceRefs.has(observation.evidence_ref)) {
+    if (!knownEvidenceRefs.has(evidenceKey(observation.evidence_ref))) {
       recordFailure(failures, "observation_evidence_ref_unknown", String(observation.event || "unknown"));
     }
     const expectedEvidenceRef = expectedEvidenceRefForSurface(observation.surface, evidenceByRole);
@@ -527,7 +537,7 @@ const evidence = Object.entries(evidenceArgs)
   .map(([role, path]) => validateEvidence(role, path, failures))
   .filter(Boolean);
 const evidenceByRole = Object.fromEntries(evidence.map((entry) => [entry.role, entry]));
-const knownEvidenceRefs = new Set(evidence.map((entry) => entry.path));
+const knownEvidenceRefs = new Set(evidence.map((entry) => evidenceKey(entry.path)));
 validateManifest(manifestPath, missionId, evidenceByRole, knownEvidenceRefs, failures);
 
 const readyForAssemble = failures.length === 0;

--- a/test/unit/qa/friday-ui-device-events-merge-cli.test.ts
+++ b/test/unit/qa/friday-ui-device-events-merge-cli.test.ts
@@ -1,5 +1,5 @@
 import { execFileSync, spawnSync } from "node:child_process";
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
@@ -86,6 +86,34 @@ describe("friday-ui-device-events-merge", () => {
       expect(result.deduplicatedRows).toBe(1);
       expect(rows).toContainEqual(event("desktop", "mission_workbench_visible", evidence.desktop));
       expect(rows.filter((row) => row.event === "pressure_20_50_consecutive_asks_visible")).toHaveLength(2);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("accepts evidence refs that resolve to the same file through a symlink", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "friday-ui-events-merge-realpath-"));
+    try {
+      const evidence = writeEvidence(tempDir);
+      const alias = join(tempDir, "mobile-alias.json");
+      symlinkSync(evidence.mobile, alias);
+      const input = join(tempDir, "events.jsonl");
+      const out = join(tempDir, "merged.jsonl");
+      writeFileSync(input, `${JSON.stringify(event("mobile", "mission_intake_submitted", alias))}\n`);
+
+      const stdout = execFileSync("node", [
+        "scripts/ops/friday-ui-device-events-merge.mjs",
+        `--mission-id=${missionId}`,
+        `--events=${input}`,
+        `--mobile=${evidence.mobile}`,
+        `--out=${out}`,
+        "--require-ready",
+      ], { cwd: process.cwd(), encoding: "utf8" });
+      const result = JSON.parse(stdout) as { status?: string; blockers?: unknown[] };
+
+      expect(result.status).toBe("ready");
+      expect(result.blockers).toEqual([]);
+      expect(readFileSync(out, "utf8")).toContain(alias);
     } finally {
       rmSync(tempDir, { recursive: true, force: true });
     }

--- a/test/unit/qa/friday-ui-device-observations-manifest-cli.test.ts
+++ b/test/unit/qa/friday-ui-device-observations-manifest-cli.test.ts
@@ -1,5 +1,5 @@
 import { execFileSync, spawnSync } from "node:child_process";
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
@@ -111,6 +111,26 @@ describe("friday-ui-device-observations-manifest", () => {
       ], { cwd: process.cwd(), encoding: "utf8" })) as { readyForAssemble?: boolean; failures?: unknown[] };
       expect(preflight.readyForAssemble).toBe(true);
       expect(preflight.failures).toEqual([]);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("accepts evidence refs that resolve to the same file through a symlink", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "friday-ui-observations-realpath-"));
+    try {
+      const refs = writeEvidence(tempDir);
+      const alias = join(tempDir, "desktop-alias.json");
+      symlinkSync(refs.desktop, alias);
+      const rows = completeEvents({ ...refs, desktop: alias });
+      const { result, out } = runManifest(tempDir, refs, rows, ["--require-ready"]);
+
+      expect(result.status).toBe(0);
+      const output = JSON.parse(result.stdout) as { status?: string; blockers?: unknown[] };
+      expect(output.status).toBe("ready");
+      expect(output.blockers).toEqual([]);
+      const manifest = JSON.parse(readFileSync(out, "utf8")) as { transcript_browser?: { evidence_ref?: string } };
+      expect(manifest.transcript_browser?.evidence_ref).toBe(alias);
     } finally {
       rmSync(tempDir, { recursive: true, force: true });
     }

--- a/test/unit/qa/friday-ui-device-proof-gap-report-cli.test.ts
+++ b/test/unit/qa/friday-ui-device-proof-gap-report-cli.test.ts
@@ -1,5 +1,5 @@
 import { execFileSync, spawnSync } from "node:child_process";
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
@@ -218,6 +218,29 @@ describe("friday-ui-device-proof-gap-report", () => {
         countsTowardUiDeviceProof: false,
         failures: [],
       }));
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("accepts evidence refs that resolve to the same file through a symlink", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "friday-ui-gap-report-realpath-"));
+    try {
+      const files = evidenceFiles(tempDir);
+      const alias = join(tempDir, "desktop-alias.json");
+      symlinkSync(files.desktop, alias);
+      const rows = completeRows({ ...files, desktop: alias });
+      const manifest = join(tempDir, "manifest.json");
+      writeFileSync(manifest, JSON.stringify(completeManifest(), null, 2));
+
+      const result = run(tempDir, files, rows, [
+        `--manifest=${manifest}`,
+        "--require-complete",
+      ]);
+      expect(result.status).toBe(0);
+      const output = JSON.parse(result.stdout) as { status?: string; blockers?: unknown[] };
+      expect(output.status).toBe("complete_inputs_observed");
+      expect(output.blockers).toEqual([]);
     } finally {
       rmSync(tempDir, { recursive: true, force: true });
     }

--- a/test/unit/qa/mission-spine-ui-proof-inputs-cli.test.ts
+++ b/test/unit/qa/mission-spine-ui-proof-inputs-cli.test.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from "node:child_process";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
@@ -206,6 +206,32 @@ describe("check-mission-spine-ui-proof-inputs CLI", () => {
       });
       expect(result.evidence.map((entry) => entry.role)).toEqual(["mobile", "desktop", "channel", "timeline"]);
       expect(result.evidence.every((entry) => /^[a-f0-9]{64}$/.test(entry.sha256) && entry.bytes > 0)).toBe(true);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("accepts complete inputs when manifest evidence refs resolve to the same files through symlinks", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "friday-ui-proof-inputs-realpath-"));
+    try {
+      const files = writeEvidenceFiles(tempDir);
+      const aliases = {
+        mobile: join(tempDir, "mobile-link.json"),
+        desktop: join(tempDir, "desktop-link.json"),
+        channel: join(tempDir, "channel-link.json"),
+        timeline: join(tempDir, "timeline-link.json"),
+      };
+      symlinkSync(files.mobile, aliases.mobile);
+      symlinkSync(files.desktop, aliases.desktop);
+      symlinkSync(files.channel, aliases.channel);
+      symlinkSync(files.timeline, aliases.timeline);
+      const manifestPath = join(tempDir, "observations-manifest-realpath.json");
+      writeFileSync(manifestPath, JSON.stringify(makeManifest(aliases), null, 2));
+
+      const result = runInputsCli(files, manifestPath);
+
+      expect(result.readyForAssemble).toBe(true);
+      expect(result.failures).toEqual([]);
     } finally {
       rmSync(tempDir, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary
- canonicalize UI/device evidence paths before comparing captured event `evidence_ref` values
- remove false blockers caused by equivalent paths such as symlinked tmp directories while preserving the original provenance fields in outputs
- cover gap-report, events-merge, and observations-manifest CLIs with symlink-realpath regressions

## Verification
- node --check scripts/ops/friday-ui-device-proof-gap-report.mjs
- node --check scripts/ops/friday-ui-device-events-merge.mjs
- node --check scripts/ops/friday-ui-device-observations-manifest.mjs
- npx vitest run test/unit/qa/friday-ui-device-proof-gap-report-cli.test.ts test/unit/qa/friday-ui-device-events-merge-cli.test.ts test/unit/qa/friday-ui-device-observations-manifest-cli.test.ts
- git diff --check

Truth: strict evidence membership remains required. This only avoids false negatives when two paths resolve to the same existing evidence file; it does not synthesize observations or satisfy deferred channel proof.