### PR TITLE
Allow deferred channel proof harvest reporting

### DIFF
--- a/scripts/ops/friday-ui-device-proof-evidence-harvest.mjs
+++ b/scripts/ops/friday-ui-device-proof-evidence-harvest.mjs
@@ -11,7 +11,7 @@ function usage() {
   node scripts/ops/friday-ui-device-proof-evidence-harvest.mjs \\
     --mission-id=mission_... \\
     --search-dir=/abs/artifacts [--search-dir=/abs/other-artifacts ...] \\
-    [--out=/abs/harvest.json] [--require-ready]
+    [--out=/abs/harvest.json] [--require-ready] [--defer-channel-proof]
 
 Truth: scans existing artifact files and reports which ones are eligible inputs
 for the strict UI/device proof pipeline. It does not create proof rows, does not
@@ -47,6 +47,7 @@ const missionId = arg("mission-id");
 const searchDirs = argsAll("search-dir");
 const out = arg("out");
 const requireReady = args.includes("--require-ready");
+const deferChannelProof = args.includes("--defer-channel-proof") || process.env.FRIDAY_UI_DEVICE_DEFER_CHANNEL_PROOF === "1";
 const blockers = [];
 
 function block(code, detail) {
@@ -206,6 +207,7 @@ const selected = {
 };
 
 for (const role of ["mobile", "desktop", "channel", "timeline"]) {
+  if (role === "channel" && deferChannelProof) continue;
   if (!selected[role]) block("missing_eligible_capture", role);
 }
 if (!selected.manifest && selected.events.length === 0) {
@@ -238,12 +240,30 @@ const proofRunnerCommand = [
   ...selected.events.map((path) => `--same-run-events ${path}`),
 ].filter(Boolean).join(" \\\n  ");
 
+const deferredInputs = [];
+if (deferChannelProof && !selected.channel) {
+  deferredInputs.push({
+    role: "channel",
+    status: "deferred_by_operator",
+    countsTowardUiDeviceProof: false,
+    caveat: "Channel live proof is intentionally deferred; this harvest can unblock non-channel evidence work but cannot satisfy strict UI/device proof or END-BAR.",
+  });
+}
+
+const pipelineReady = blockers.length === 0 && deferredInputs.length === 0;
+const status = pipelineReady
+  ? "ready_for_strict_pipeline"
+  : blockers.length === 0 && deferredInputs.length > 0
+    ? "non_channel_inputs_ready_channel_deferred"
+    : "partial";
+
 const result = {
   truth: "ui_device_proof_evidence_harvest_not_proof_not_endbar",
-  status: blockers.length === 0 ? "ready_for_strict_pipeline" : "partial",
+  status,
   missionId,
   searched: searchDirs.map(abs),
   selected,
+  deferredInputs,
   counts: {
     candidates: candidates.length,
     eligible: candidates.filter((candidate) => candidate.eligible).length,
@@ -263,4 +283,4 @@ if (out) {
 }
 
 console.log(JSON.stringify(result, null, 2));
-process.exit(blockers.length === 0 || !requireReady ? 0 : 2);
+process.exit(pipelineReady || !requireReady ? 0 : 2);

--- a/scripts/ops/friday-ui-device-proof-shortlist-runner.sh
+++ b/scripts/ops/friday-ui-device-proof-shortlist-runner.sh
@@ -16,6 +16,7 @@ usage:
     [--same-run-events /abs/events.jsonl ...]
     [--runtime-evidence-dir /abs/evidence-dir ...]
     [--extra-action-runtime-evidence /abs/action-runtime-evidence.json ...]
+    [--defer-channel-proof]
 
 Runs the already-proven mobile+desktop live write/read capture bundle, then
 assembles the strongest honest UI/device readiness report possible from supplied
@@ -43,6 +44,7 @@ objective_coverage="${FRIDAY_UI_DEVICE_OBJECTIVE_COVERAGE:-}"
 channel_live_proof="${FRIDAY_UI_DEVICE_CHANNEL_LIVE_PROOF:-}"
 channel_capture=""
 timeline_capture=""
+defer_channel_proof="${FRIDAY_UI_DEVICE_DEFER_CHANNEL_PROOF:-0}"
 accessibility_captures=()
 harvest_dirs=()
 same_run_events=()
@@ -166,6 +168,10 @@ while [ "$#" -gt 0 ]; do
       extra_action_runtime_evidence+=("${1#--extra-action-runtime-evidence=}")
       shift
       ;;
+    --defer-channel-proof)
+      defer_channel_proof=1
+      shift
+      ;;
     --help|-h)
       usage
       exit 0
@@ -275,6 +281,9 @@ if [ "${#harvest_dirs[@]}" -gt 0 ]; then
     [ -n "${dir}" ] || continue
     harvest_args+=("--search-dir=${dir}")
   done
+  if [ "${defer_channel_proof}" = "1" ]; then
+    harvest_args+=("--defer-channel-proof")
+  fi
   node "${harvest_args[@]}"
   fill_from_harvest() {
     local field="$1"
@@ -369,6 +378,9 @@ fi
 if [ -n "${objective_coverage}" ]; then
   readiness_args+=("--objective-coverage" "${objective_coverage}")
 fi
+if [ "${defer_channel_proof}" = "1" ]; then
+  readiness_args+=("--defer-channel-proof")
+fi
 FRIDAY_DESIGN_ACTION_RUNTIME_EVIDENCE_DIRS="${bundle_dir}" bash "${readiness_args[@]}" >"${readiness_out}"
 
 gap_status="skipped_missing_channel_or_timeline"
@@ -392,6 +404,9 @@ if [ -n "${channel_capture}" ] && [ -n "${timeline_capture}" ]; then
   fi
   if [ -n "${objective_coverage}" ]; then
     gap_args+=("--objective-coverage=${objective_coverage}")
+  fi
+  if [ "${defer_channel_proof}" = "1" ]; then
+    gap_args+=("--defer-channel-proof")
   fi
   node "${gap_args[@]}" || true
   gap_status="written"

--- a/scripts/ops/friday-workbench-snapshot-events.mjs
+++ b/scripts/ops/friday-workbench-snapshot-events.mjs
@@ -19,6 +19,7 @@ function usage() {
 
 Options:
   --url=http://127.0.0.1:3141/v1/mission-spine/workbench
+  --defer-channel-proof
   --require-ready
 
 Truth: this bridges a preflight-passing Mission Workbench snapshot into
@@ -37,6 +38,7 @@ if (args.includes("--help") || args.includes("-h")) {
 }
 
 const requireReady = args.includes("--require-ready");
+const deferChannelProof = args.includes("--defer-channel-proof") || process.env.FRIDAY_UI_DEVICE_DEFER_CHANNEL_PROOF === "1";
 const missionId = arg("mission-id") || process.env.MISSION_ID || "";
 const sourceFile = arg("file") || process.env.MISSION_WORKBENCH_SNAPSHOT_FILE || "";
 const sourceUrl = arg("url") || process.env.MISSION_WORKBENCH_SNAPSHOT_URL || "";
@@ -218,7 +220,7 @@ function makeRows(snapshot, evidence) {
     add("desktop", "mission_workbench_visible", evidence.desktop, "transcript_surface:desktop");
     add("desktop", "transcript_browser_visible", evidence.desktop, "transcript_surface:desktop");
   }
-  if (hasTranscriptSurface(transcriptEvents, "telegram") || array(snapshot.channelReceiptRefs).length > 0) {
+  if (evidence.channel && (hasTranscriptSurface(transcriptEvents, "telegram") || array(snapshot.channelReceiptRefs).length > 0)) {
     add("channel", "same_mission_projection_visible", evidence.channel, "channel_receipt_refs");
   }
   if (array(snapshot.timelinePages).some((page) => object(page).page === 1)) {
@@ -237,6 +239,7 @@ function makeRows(snapshot, evidence) {
   if (
     hasTranscriptSurface(transcriptEvents, "mobile")
     && hasTranscriptSurface(transcriptEvents, "desktop")
+    && evidence.channel
     && (hasTranscriptSurface(transcriptEvents, "telegram") || array(snapshot.channelReceiptRefs).length > 0)
   ) {
     add("*", "same_mission_mobile_desktop_channel_visible", evidence.desktop, "transcript_surfaces:mobile_desktop_channel");
@@ -249,9 +252,14 @@ if (!missionId || !/^[A-Za-z0-9][A-Za-z0-9._:-]*$/.test(missionId) || !missionId
 }
 if (!outPath) block("missing_arg", "out");
 
-const evidence = Object.fromEntries(
-  Object.entries(evidenceArgs).map(([role, path]) => [role, requireFile(role, path)]),
-);
+const evidence = {};
+for (const [role, path] of Object.entries(evidenceArgs)) {
+  if (role === "channel" && deferChannelProof && !path) {
+    evidence[role] = "";
+  } else {
+    evidence[role] = requireFile(role, path);
+  }
+}
 const preflight = runPreflight();
 const payload = sourceFile ? readJson(sourceFile) : sourceUrl ? await readJsonFromUrl(sourceUrl) : null;
 const snapshot = payload ? unwrapSnapshot(payload) : {};
@@ -272,6 +280,12 @@ const output = {
   out: outPath ? abs(outPath) : null,
   derivedEvents: rows.length,
   preflightReady: preflight?.readyForLiveCaptureInput === true,
+  deferredInputs: deferChannelProof ? [{
+    role: "channel",
+    status: "deferred_by_operator",
+    countsTowardUiDeviceProof: false,
+    caveat: "Channel evidence is deferred; this bridge emits only diagnostic non-channel rows and never counts as channel proof.",
+  }] : [],
   blockers,
   caveat: "Diagnostic bridge only. Stress/security/network/device observations still require real same-run capture before final proof.",
 };

--- a/test/unit/qa/friday-ui-device-proof-evidence-harvest-cli.test.ts
+++ b/test/unit/qa/friday-ui-device-proof-evidence-harvest-cli.test.ts
@@ -107,4 +107,51 @@ describe("friday-ui-device-proof-evidence-harvest", () => {
       rmSync(tempDir, { recursive: true, force: true });
     }
   });
+
+  it("can report non-channel inputs while channel proof is explicitly deferred", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "friday-ui-harvest-channel-deferred-"));
+    try {
+      const artifacts = writeArtifacts(tempDir);
+      rmSync(artifacts.channel, { force: true });
+
+      const reportOnly = spawnSync("node", [
+        script,
+        `--mission-id=${missionId}`,
+        `--search-dir=${tempDir}`,
+        "--defer-channel-proof",
+      ], { cwd: process.cwd(), encoding: "utf8" });
+      expect(reportOnly.status).toBe(0);
+      const output = JSON.parse(reportOnly.stdout) as {
+        status?: string;
+        selected?: { channel?: string };
+        deferredInputs?: Array<{ role?: string; countsTowardUiDeviceProof?: boolean }>;
+        blockers?: Array<{ code?: string; detail?: string }>;
+        captureDirCommand?: string | null;
+        proofRunnerCommand?: string;
+      };
+      expect(output.status).toBe("non_channel_inputs_ready_channel_deferred");
+      expect(output.selected?.channel).toBe("");
+      expect(output.deferredInputs).toContainEqual({
+        role: "channel",
+        status: "deferred_by_operator",
+        countsTowardUiDeviceProof: false,
+        caveat: "Channel live proof is intentionally deferred; this harvest can unblock non-channel evidence work but cannot satisfy strict UI/device proof or END-BAR.",
+      });
+      expect(output.blockers).toEqual([]);
+      expect(output.captureDirCommand).toBeNull();
+      expect(output.proofRunnerCommand).not.toContain("--channel-capture");
+
+      const strict = spawnSync("node", [
+        script,
+        `--mission-id=${missionId}`,
+        `--search-dir=${tempDir}`,
+        "--defer-channel-proof",
+        "--require-ready",
+      ], { cwd: process.cwd(), encoding: "utf8" });
+      expect(strict.status).toBe(2);
+      expect(JSON.parse(strict.stdout).status).toBe("non_channel_inputs_ready_channel_deferred");
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
 });

--- a/test/unit/qa/friday-ui-device-proof-shortlist-runner-contract.test.ts
+++ b/test/unit/qa/friday-ui-device-proof-shortlist-runner-contract.test.ts
@@ -14,4 +14,15 @@ describe("friday-ui-device-proof-shortlist-runner contract", () => {
     expect(source).toContain("accessibilityCaptureStatus");
     expect(source).toContain("Runner output is END-BAR only if strict UI/device readiness passes");
   });
+
+  it("threads channel deferral through harvest, readiness, and gap report without counting it as proof", () => {
+    const source = readFileSync("scripts/ops/friday-ui-device-proof-shortlist-runner.sh", "utf8");
+
+    expect(source).toContain("--defer-channel-proof");
+    expect(source).toContain("defer_channel_proof=\"${FRIDAY_UI_DEVICE_DEFER_CHANNEL_PROOF:-0}\"");
+    expect(source).toContain("harvest_args+=(\"--defer-channel-proof\")");
+    expect(source).toContain("readiness_args+=(\"--defer-channel-proof\")");
+    expect(source).toContain("gap_args+=(\"--defer-channel-proof\")");
+    expect(source).toContain("real channel, timeline, stress, and negative-control evidence");
+  });
 });

--- a/test/unit/qa/friday-workbench-snapshot-events-cli.test.ts
+++ b/test/unit/qa/friday-workbench-snapshot-events-cli.test.ts
@@ -217,4 +217,46 @@ describe("friday-workbench-snapshot-events CLI", () => {
       rmSync(tempDir, { recursive: true, force: true });
     }
   });
+
+  it("can derive non-channel diagnostic rows when channel evidence is deferred", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "friday-workbench-events-channel-deferred-"));
+    try {
+      const snapshotPath = join(tempDir, "snapshot.json");
+      const out = join(tempDir, "workbench-derived-events.jsonl");
+      const files = writeEvidence(tempDir);
+      writeFileSync(snapshotPath, JSON.stringify({ snapshot: makeSnapshot() }, null, 2));
+
+      const stdout = execFileSync(process.execPath, [
+        "scripts/ops/friday-workbench-snapshot-events.mjs",
+        "--mission-id=mission_workbench_events_bridge",
+        `--file=${snapshotPath}`,
+        `--mobile=${files.mobile}`,
+        `--desktop=${files.desktop}`,
+        `--timeline=${files.timeline}`,
+        `--out=${out}`,
+        "--defer-channel-proof",
+        "--require-ready",
+      ], {
+        cwd: process.cwd(),
+        encoding: "utf8",
+      });
+      const result = JSON.parse(stdout) as {
+        status?: string;
+        deferredInputs?: Array<{ role?: string; countsTowardUiDeviceProof?: boolean }>;
+      };
+      const rows = readFileSync(out, "utf8").trim().split("\n").map((line) => JSON.parse(line));
+      const keys = rows.map((row) => `${row.surface}:${row.event}`);
+
+      expect(result.status).toBe("ready");
+      expect(result.deferredInputs).toContainEqual(expect.objectContaining({
+        role: "channel",
+        countsTowardUiDeviceProof: false,
+      }));
+      expect(keys).toContain("timeline:bounded_page_2_visible");
+      expect(keys).not.toContain("channel:same_mission_projection_visible");
+      expect(keys).not.toContain("*:same_mission_mobile_desktop_channel_visible");
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
 });


### PR DESCRIPTION
## Summary
- add a report-only channel deferral mode to the UI/device proof evidence harvest CLI
- thread the same deferral through the shortlist runner into harvest/readiness/gap report
- allow the workbench snapshot event bridge to derive non-channel diagnostic rows when channel evidence is deferred
- keep deferred channel inputs from counting as strict UI/device proof or END-BAR
- add coverage that report-only mode can proceed while --require-ready still fails closed where strict proof would be implied

## Verification
- node --check scripts/ops/friday-ui-device-proof-evidence-harvest.mjs
- node --check scripts/ops/friday-workbench-snapshot-events.mjs
- bash -n scripts/ops/friday-ui-device-proof-shortlist-runner.sh
- npx vitest run test/unit/qa/friday-workbench-snapshot-events-cli.test.ts test/unit/qa/friday-ui-device-proof-evidence-harvest-cli.test.ts test/unit/qa/friday-ui-device-proof-shortlist-runner-contract.test.ts
- git diff --check

Truth: channel live proof is deferred by operator/user instruction; this PR does not claim channel proof, strict UI/device proof, END-BAR, release readiness, or organic adoption.