### PR TITLE
Add diagnostic timeline snapshot bridge

### DIFF
--- a/scripts/ops/friday-workbench-snapshot-events.mjs
+++ b/scripts/ops/friday-workbench-snapshot-events.mjs
@@ -137,6 +137,7 @@ function runPreflight() {
     sourceFile ? `--file=${sourceFile}` : `--url=${sourceUrl}`,
   ];
   if (missionId) preflightArgs.push(`--mission-id=${missionId}`);
+  if (deferChannelProof) preflightArgs.push("--diagnostic-timeline-only");
   const result = spawnSync(process.execPath, preflightArgs, {
     cwd: process.cwd(),
     encoding: "utf8",
@@ -147,7 +148,9 @@ function runPreflight() {
   } catch {
     block("preflight_output_invalid_json", result.stderr || "no stdout");
   }
-  if (result.status !== 0 || parsed?.readyForLiveCaptureInput !== true) {
+  const ready = parsed?.readyForLiveCaptureInput === true
+    || (deferChannelProof && parsed?.readyForDiagnosticTimelineInput === true);
+  if (result.status !== 0 || ready !== true) {
     block("snapshot_preflight_not_ready", JSON.stringify(parsed?.failures || []));
   }
   return parsed;
@@ -181,7 +184,7 @@ function firstCapturedAt(events) {
     || new Date().toISOString();
 }
 
-function makeRows(snapshot, evidence) {
+function makeRows(snapshot, evidence, truthLabel) {
   const rows = [];
   const transcriptEvents = collectTranscriptEvents(snapshot);
   const capturedAt = firstCapturedAt(transcriptEvents);
@@ -191,7 +194,7 @@ function makeRows(snapshot, evidence) {
       event,
       mission_id: missionId,
       evidence_ref: evidenceRef,
-      truth_label: "derived_from_preflighted_workbench_snapshot_not_final_proof",
+      truth_label: truthLabel,
       source,
       captured_at: capturedAt,
     });
@@ -264,7 +267,10 @@ const preflight = runPreflight();
 const payload = sourceFile ? readJson(sourceFile) : sourceUrl ? await readJsonFromUrl(sourceUrl) : null;
 const snapshot = payload ? unwrapSnapshot(payload) : {};
 
-const rows = blockers.length === 0 ? makeRows(snapshot, evidence) : [];
+const rowTruthLabel = preflight?.readyForLiveCaptureInput === true
+  ? "derived_from_preflighted_workbench_snapshot_not_final_proof"
+  : "derived_from_diagnostic_workbench_snapshot_not_final_proof";
+const rows = blockers.length === 0 ? makeRows(snapshot, evidence, rowTruthLabel) : [];
 if (rows.length === 0 && blockers.length === 0) block("no_derivable_events", "snapshot produced no diagnostic rows");
 
 if (blockers.length === 0) {
@@ -280,6 +286,7 @@ const output = {
   out: outPath ? abs(outPath) : null,
   derivedEvents: rows.length,
   preflightReady: preflight?.readyForLiveCaptureInput === true,
+  diagnosticTimelineReady: preflight?.readyForDiagnosticTimelineInput === true,
   deferredInputs: deferChannelProof ? [{
     role: "channel",
     status: "deferred_by_operator",

--- a/scripts/qa/check-mission-workbench-snapshot-contract.mjs
+++ b/scripts/qa/check-mission-workbench-snapshot-contract.mjs
@@ -4,6 +4,7 @@ import { readFileSync } from "node:fs";
 
 const args = process.argv.slice(2);
 const expectNotReady = args.includes("--expect-not-ready");
+const diagnosticTimelineOnly = args.includes("--diagnostic-timeline-only");
 const helpRequested = args.includes("--help") || args.includes("-h");
 
 const placeholderMarkers = [
@@ -91,6 +92,8 @@ function usage() {
 Options:
   --mission-id=mission_...     Require the live snapshot to use this Mission id.
   --expect-not-ready           Exit 0 only when the snapshot is not final-capture ready.
+  --diagnostic-timeline-only   Also report whether bounded timeline rows can be
+                               derived for diagnostic, non-proof use.
 
 This is a live snapshot contract preflight only. It does not write a
 MISSION_SPINE_UI_DEVICE_PROOF artifact, does not set env, does not capture
@@ -106,6 +109,24 @@ function argValue(name, envName) {
 
 function recordFailure(failures, code, detail) {
   failures.push({ code, detail });
+}
+
+function isDiagnosticTimelineIgnorableFailure(failure) {
+  if (!failure || typeof failure !== "object") return false;
+  if (failure.code === "provider_receipt_refs_missing") return true;
+  if (failure.code === "channel_receipt_refs_missing") return true;
+  if (failure.code === "provider_ack_not_done_missing") return true;
+  if (failure.code === "completed_with_proof_ref_missing") return true;
+  if (failure.code === "memory_candidates_missing") return true;
+  if (failure.code === "transcript_events_too_few") return true;
+  if (failure.code === "transcript_surface_missing" && failure.detail === "telegram") return true;
+  if (
+    failure.code === "transcript_evidence_facet_missing"
+    && ["channelRef", "providerRef", "proofReceiptRef", "skillRunRef"].includes(failure.detail)
+  ) {
+    return true;
+  }
+  return false;
 }
 
 function asObject(value) {
@@ -536,6 +557,12 @@ if (filePath && !url) {
 const snapshot = payload ? unwrapSnapshot(payload, failures) : null;
 const summary = validateSnapshot(snapshot, expectedMissionId, failures);
 const readyForLiveCaptureInput = failures.length === 0;
+const diagnosticTimelineFailures = diagnosticTimelineOnly
+  ? failures.filter((failure) => !isDiagnosticTimelineIgnorableFailure(failure))
+  : [];
+const readyForDiagnosticTimelineInput = diagnosticTimelineOnly
+  ? diagnosticTimelineFailures.length === 0
+  : null;
 
 const result = {
   proof: "mission_workbench_snapshot_contract_preflight",
@@ -543,6 +570,8 @@ const result = {
   source: filePath ? { kind: "file", path: filePath } : url ? { kind: "url", url } : null,
   expectedMissionId: expectedMissionId || null,
   readyForLiveCaptureInput,
+  readyForDiagnosticTimelineInput,
+  diagnosticTimelineFailures,
   summary,
   failures,
 };
@@ -553,4 +582,4 @@ if (expectNotReady) {
   process.exit(readyForLiveCaptureInput ? 1 : 0);
 }
 
-process.exit(readyForLiveCaptureInput ? 0 : 1);
+process.exit(readyForLiveCaptureInput || readyForDiagnosticTimelineInput ? 0 : 1);

--- a/test/unit/qa/friday-workbench-snapshot-events-cli.test.ts
+++ b/test/unit/qa/friday-workbench-snapshot-events-cli.test.ts
@@ -259,4 +259,83 @@ describe("friday-workbench-snapshot-events CLI", () => {
       rmSync(tempDir, { recursive: true, force: true });
     }
   });
+
+  it("can derive diagnostic timeline rows from a partial non-channel snapshot", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "friday-workbench-events-diagnostic-timeline-"));
+    try {
+      const missionId = "mission_workbench_events_bridge";
+      const snapshotPath = join(tempDir, "snapshot.json");
+      const out = join(tempDir, "workbench-derived-events.jsonl");
+      const files = writeEvidence(tempDir);
+      const partial = makeSnapshot({
+        providerReceiptRefs: [],
+        channelReceiptRefs: [],
+        memoryCandidates: [],
+        workItems: [
+          {
+            id: "work_timeline",
+            title: "Bounded timeline read",
+            state: "timeline_read",
+            owner: "friday_owned",
+            proofRef: "proof://timeline/page-2/cursor",
+            done: false,
+            blockingReason: "bounded timeline read only; no WorkItem recovery action applies",
+            recoveryKind: "none",
+            canRetry: false,
+            canCancel: false,
+          },
+        ],
+        timelinePages: [
+          { page: 1, cursor: "cursor_1", nextCursor: "cursor_2", eventRefs: ["event_mobile_intake", "event_desktop_projection"] },
+          { page: 2, cursor: "cursor_2", eventRefs: ["event_timeline_read"] },
+        ],
+        transcriptSections: [
+          {
+            id: "section_workbench_events_bridge",
+            title: "Mission projection",
+            groupKind: "mission",
+            missionId,
+            truthLabel: "friday_owned",
+            status: "waiting",
+            events: [
+              transcriptEvent("event_mobile_intake", "mobile", "ready", { surfaceThreadRef: "surface://mobile/thread", workflowRef: "workflow://mission/intake", timelineRef: "timeline://mission/page-1/event-mobile-intake" }),
+              transcriptEvent("event_desktop_projection", "desktop", "waiting", { surfaceThreadRef: "surface://desktop/thread", timelineRef: "timeline://mission/page-1/event-desktop-projection" }),
+              transcriptEvent("event_timeline_read", "timeline", "timeline_read", { workflowRef: "workflow://mission/timeline", timelineRef: "timeline://mission/page-2/cursor" }, "work_timeline"),
+            ],
+          },
+        ],
+      });
+      writeFileSync(snapshotPath, JSON.stringify({ snapshot: partial }, null, 2));
+
+      const stdout = execFileSync(process.execPath, [
+        "scripts/ops/friday-workbench-snapshot-events.mjs",
+        "--mission-id=mission_workbench_events_bridge",
+        `--file=${snapshotPath}`,
+        `--mobile=${files.mobile}`,
+        `--desktop=${files.desktop}`,
+        `--timeline=${files.timeline}`,
+        `--out=${out}`,
+        "--defer-channel-proof",
+        "--require-ready",
+      ], {
+        cwd: process.cwd(),
+        encoding: "utf8",
+      });
+      const result = JSON.parse(stdout) as { status?: string; preflightReady?: boolean; diagnosticTimelineReady?: boolean };
+      const rows = readFileSync(out, "utf8").trim().split("\n").map((line) => JSON.parse(line));
+      const keys = rows.map((row) => `${row.surface}:${row.event}`);
+
+      expect(result.status).toBe("ready");
+      expect(result.preflightReady).toBe(false);
+      expect(result.diagnosticTimelineReady).toBe(true);
+      expect(keys).toContain("timeline:bounded_page_1_visible");
+      expect(keys).toContain("timeline:bounded_page_2_visible");
+      expect(keys).not.toContain("channel:same_mission_projection_visible");
+      expect(new Set(rows.map((row) => row.truth_label))).toEqual(new Set([
+        "derived_from_diagnostic_workbench_snapshot_not_final_proof",
+      ]));
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
 });

--- a/test/unit/qa/mission-workbench-snapshot-contract-cli.test.ts
+++ b/test/unit/qa/mission-workbench-snapshot-contract-cli.test.ts
@@ -245,6 +245,8 @@ function runSnapshotContract(
     proof: string;
     proof_source: string;
     readyForLiveCaptureInput: boolean;
+    readyForDiagnosticTimelineInput: boolean | null;
+    diagnosticTimelineFailures: Array<{ code: string; detail: string }>;
     failures: Array<{ code: string; detail: string }>;
     summary: {
       transcriptSurfaces?: string[];
@@ -295,6 +297,106 @@ describe("check-mission-workbench-snapshot-contract CLI", () => {
       expect(result.readyForLiveCaptureInput).toBe(true);
       expect(result.failures).toEqual([]);
       expect(result.summary?.transcriptSurfaces).toEqual(["desktop", "mobile", "telegram", "timeline"]);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("can report diagnostic timeline readiness without relaxing strict live-capture readiness", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "friday-workbench-contract-diagnostic-timeline-"));
+    try {
+      const missionId = "mission_cli_snapshot_contract";
+      const partial = makeSnapshot({
+        providerReceiptRefs: [],
+        channelReceiptRefs: [],
+        memoryCandidates: [],
+        workItems: [
+          {
+            id: "work_timeline",
+            title: "Bounded timeline read",
+            state: "timeline_read",
+            owner: "friday_owned",
+            proofRef: "proof://timeline/page-2/cursor",
+            done: false,
+            blockingReason: "bounded timeline read only; no WorkItem recovery action applies",
+            recoveryKind: "none",
+            canRetry: false,
+            canCancel: false,
+          },
+        ],
+        timelinePages: [
+          { page: 1, cursor: "cursor_1", nextCursor: "cursor_2", eventRefs: ["event_mobile_intake", "event_desktop_projection"] },
+          { page: 2, cursor: "cursor_2", eventRefs: ["event_timeline_read"] },
+        ],
+        transcriptSections: [
+          {
+            id: "section_cli_snapshot_contract",
+            title: "Mission projection",
+            groupKind: "mission",
+            missionId,
+            truthLabel: "friday_owned",
+            status: "waiting",
+            events: [
+              {
+                id: "event_mobile_intake",
+                missionId,
+                surface: "mobile",
+                status: "ready",
+                truthLabel: "friday_owned",
+                summary: "Mobile Mission intake is attached to the same Mission.",
+                proofRef: "proof://surface/mobile/intake",
+                evidenceRefs: {
+                  surfaceThreadRef: "surface://mobile/thread/redacted",
+                  workflowRef: "workflow://mission/intake",
+                  timelineRef: "timeline://mission/page-1/event-mobile-intake",
+                },
+                capturedAt: "2026-06-05T06:10:00Z",
+              },
+              {
+                id: "event_desktop_projection",
+                missionId,
+                surface: "desktop",
+                status: "waiting",
+                truthLabel: "friday_owned",
+                summary: "Desktop projection is visible for the same Mission.",
+                proofRef: "proof://surface/desktop/projection",
+                evidenceRefs: {
+                  surfaceThreadRef: "surface://desktop/thread/redacted",
+                  timelineRef: "timeline://mission/page-1/event-desktop-projection",
+                },
+                capturedAt: "2026-06-05T06:10:01Z",
+              },
+              {
+                id: "event_timeline_read",
+                missionId,
+                workItemId: "work_timeline",
+                surface: "timeline",
+                status: "timeline_read",
+                truthLabel: "friday_owned",
+                summary: "Timeline read is bounded and not completion.",
+                proofRef: "proof://timeline/page-2/cursor",
+                evidenceRefs: {
+                  workflowRef: "workflow://mission/bounded-timeline-read",
+                  timelineRef: "timeline://mission/page-2/cursor",
+                },
+                capturedAt: "2026-06-05T06:10:02Z",
+              },
+            ],
+          },
+        ],
+      });
+      const filePath = join(tempDir, "snapshot.json");
+      writeFileSync(filePath, JSON.stringify({ snapshot: partial }, null, 2));
+
+      const result = runSnapshotContract(filePath, ["--diagnostic-timeline-only"]);
+      const failureCodes = result.failures.map((failure) => failure.code);
+
+      expect(result.readyForLiveCaptureInput).toBe(false);
+      expect(result.readyForDiagnosticTimelineInput).toBe(true);
+      expect(result.diagnosticTimelineFailures).toEqual([]);
+      expect(failureCodes).toContain("channel_receipt_refs_missing");
+      expect(failureCodes).toContain("completed_with_proof_ref_missing");
+      expect(result.summary?.transcriptSurfaces).toEqual(["desktop", "mobile", "timeline"]);
     } finally {
       rmSync(tempDir, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary
- add a diagnostic timeline-only readiness mode to the Mission Workbench snapshot contract
- let the workbench snapshot event bridge derive non-channel diagnostic rows when channel proof is deferred
- keep strict live-capture readiness unchanged and label diagnostic rows as non-final proof

## Real diagnostic run
- /private/tmp/friday-workbench-derived-diagnostic-timeline-20260626T203947Z/workbench-derived-events.jsonl
- Derived 13 rows from the real 2026-06-26 workbench snapshot, including timeline page 1/2 rows.

## Verification
- node --check scripts/qa/check-mission-workbench-snapshot-contract.mjs
- node --check scripts/ops/friday-workbench-snapshot-events.mjs
- npx vitest run test/unit/qa/mission-workbench-snapshot-contract-cli.test.ts test/unit/qa/friday-workbench-snapshot-events-cli.test.ts
- git diff --check origin/main...HEAD

Truth: diagnostic rows are not strict UI/device proof, channel proof, END-BAR, release readiness, or organic adoption.