### PR TITLE
Allow deferred-channel UI evidence dirs

### DIFF
--- a/scripts/ops/friday-ui-device-capture-dir.mjs
+++ b/scripts/ops/friday-ui-device-capture-dir.mjs
@@ -17,7 +17,8 @@ function usage() {
     --channel=/abs/channel-capture \\
     --timeline=/abs/timeline-capture \\
     [--observations-manifest=/abs/observations-manifest.json] \\
-    [--events=/abs/same-run-events.jsonl ...] [--events-dir=/abs/events-dir ...] [--require-ready]
+    [--events=/abs/same-run-events.jsonl ...] [--events-dir=/abs/events-dir ...] \\
+    [--defer-channel-proof] [--require-ready]
 
 Truth: this indexes already-captured files into an evidence-dir shape. It is not a
 UI/device proof and never invents observations. A supplied observations manifest,
@@ -51,6 +52,8 @@ if (args.includes("--help") || args.includes("-h")) {
 }
 
 const requireReady = args.includes("--require-ready");
+const deferChannelProof = args.includes("--defer-channel-proof")
+  || process.env.FRIDAY_UI_DEVICE_DEFER_CHANNEL_PROOF === "1";
 const missionId = arg("mission-id");
 const outDir = arg("out-dir");
 const manifest = arg("observations-manifest");
@@ -83,6 +86,9 @@ function safeExt(path) {
 }
 
 function checkInput(role, path) {
+  if (role === "channel" && deferChannelProof && !path) {
+    return null;
+  }
   if (!path) {
     block("missing_capture", role);
     return null;
@@ -178,13 +184,15 @@ if (readyToWrite) {
       `--mission-id=${missionId}`,
       `--mobile=${inputByRole.mobile}`,
       `--desktop=${inputByRole.desktop}`,
-      `--channel=${inputByRole.channel}`,
       `--timeline=${inputByRole.timeline}`,
       `--out=${mergedEvents}`,
       "--require-ready",
       ...eventInputs.map((path) => `--events=${path}`),
       ...eventDirs.map((path) => `--events-dir=${path}`),
     ];
+    if (inputByRole.channel) {
+      mergeArgs.splice(4, 0, `--channel=${inputByRole.channel}`);
+    }
     const mergeResult = spawnSync(process.execPath, mergeArgs, { encoding: "utf8" });
     if (mergeResult.status !== 0) {
       copiedManifest = "";
@@ -195,10 +203,11 @@ if (readyToWrite) {
         `--mission-id=${missionId}`,
         `--mobile=${byRole.mobile}`,
         `--desktop=${byRole.desktop}`,
-        `--channel=${byRole.channel}`,
         `--timeline=${byRole.timeline}`,
         `--events=${derivedEvents}`,
         `--out=${copiedManifest}`,
+        ...(byRole.channel ? [`--channel=${byRole.channel}`] : []),
+        ...(deferChannelProof ? ["--defer-channel-proof"] : []),
         "--require-ready",
       ], { encoding: "utf8" });
       if (result.status !== 0) {
@@ -236,6 +245,12 @@ if (readyToWrite) {
         },
     mergedEvents: mergedEvents || null,
     normalizedEvents: derivedEvents || null,
+    deferredInputs: deferChannelProof ? [{
+      role: "channel",
+      status: "deferred_by_operator",
+      countsTowardUiDeviceProof: false,
+      caveat: "Channel proof is deferred. This evidence dir can support non-channel evidence work but cannot satisfy strict UI/device proof or END-BAR.",
+    }] : [],
     nextCommand: "scripts/ops/friday-ui-device-proof-readiness.sh --evidence-dir <dir> --require-proof",
     caveat: "Reuse summary only. The strict readiness/assembler/final gate must still bind hashes and observations before proof.",
   };
@@ -250,6 +265,7 @@ if (readyToWrite) {
     mergedEvents: mergedEvents || null,
     normalizedEvents: derivedEvents || null,
     reuseSummary,
+    deferredInputs: reuseSummary.deferredInputs,
     blockers,
   };
   writeFileSync(join(dir, "capture-index.json"), `${JSON.stringify(index, null, 2)}\n`);
@@ -258,22 +274,32 @@ if (readyToWrite) {
 let preflight = null;
 if (readyToWrite && copiedManifest) {
   const byRole = Object.fromEntries(written.map((capture) => [capture.role, capture.target]));
-  const result = spawnSync(process.execPath, [
-    "scripts/qa/check-mission-spine-ui-proof-inputs.mjs",
-    `--mission-id=${missionId}`,
-    `--mobile=${byRole.mobile}`,
-    `--desktop=${byRole.desktop}`,
-    `--channel=${byRole.channel}`,
-    `--timeline=${byRole.timeline}`,
-    `--manifest=${copiedManifest}`,
-  ], { encoding: "utf8" });
-  preflight = {
-    status: result.status,
-    stdout: result.stdout.trim(),
-    stderr: result.stderr.trim(),
-  };
-  if (result.status !== 0) {
-    block("ui_proof_inputs_preflight_failed", `exit_${result.status}`);
+  if (deferChannelProof) {
+    preflight = {
+      status: null,
+      skipped: true,
+      reason: "channel_deferred",
+      countsTowardUiDeviceProof: false,
+      caveat: "Strict UI proof input preflight requires channel evidence and was intentionally not claimed.",
+    };
+  } else {
+    const result = spawnSync(process.execPath, [
+      "scripts/qa/check-mission-spine-ui-proof-inputs.mjs",
+      `--mission-id=${missionId}`,
+      `--mobile=${byRole.mobile}`,
+      `--desktop=${byRole.desktop}`,
+      `--channel=${byRole.channel}`,
+      `--timeline=${byRole.timeline}`,
+      `--manifest=${copiedManifest}`,
+    ], { encoding: "utf8" });
+    preflight = {
+      status: result.status,
+      stdout: result.stdout.trim(),
+      stderr: result.stderr.trim(),
+    };
+    if (result.status !== 0) {
+      block("ui_proof_inputs_preflight_failed", `exit_${result.status}`);
+    }
   }
 }
 
@@ -288,6 +314,12 @@ const output = {
   normalizedEvents: derivedEvents || null,
   reuseSummary,
   preflight,
+  deferredInputs: deferChannelProof ? [{
+    role: "channel",
+    status: "deferred_by_operator",
+    countsTowardUiDeviceProof: false,
+    caveat: "Channel proof is deferred. This run is not strict UI/device proof or END-BAR.",
+  }] : [],
   blockers,
   next: blockers.length === 0
     ? "Run scripts/ops/friday-ui-device-proof-readiness.sh --evidence-dir <dir> --require-proof after the readiness bridge is present."

--- a/scripts/ops/friday-ui-device-observations-manifest.mjs
+++ b/scripts/ops/friday-ui-device-observations-manifest.mjs
@@ -112,7 +112,7 @@ function usage() {
     --channel=/abs/channel-capture \\
     --timeline=/abs/timeline-capture \\
     --events=/abs/same-run-events.jsonl \\
-    --out=/abs/observations-manifest.json [--require-ready]
+    --out=/abs/observations-manifest.json [--defer-channel-proof] [--require-ready]
 
 Events must be captured from the same real UI/device run. This tool derives the
 manifest from those captured events; it is not proof and never invents missing
@@ -130,6 +130,8 @@ if (args.includes("--help") || args.includes("-h")) {
 }
 
 const requireReady = args.includes("--require-ready");
+const deferChannelProof = args.includes("--defer-channel-proof")
+  || process.env.FRIDAY_UI_DEVICE_DEFER_CHANNEL_PROOF === "1";
 const missionId = arg("mission-id");
 const out = arg("out");
 const eventsPath = arg("events");
@@ -161,6 +163,9 @@ function evidenceKey(path) {
 }
 
 function requireFile(label, path) {
+  if (label === "channel" && deferChannelProof && !path) {
+    return "";
+  }
   if (!path) {
     block("missing_arg", label);
     return "";
@@ -243,15 +248,27 @@ if (!out) block("missing_arg", "out");
 
 const evidenceRefs = new Set(Object.values(evidence).filter(Boolean).map(evidenceKey));
 const observations = normalizedEvents(parseJsonl(eventFile), evidenceRefs);
+const activeRequiredObservations = deferChannelProof
+  ? requiredObservations.filter(([surface, event]) => surface !== "channel" && !event.includes("channel"))
+  : requiredObservations;
 
-for (const [surface, event] of requiredObservations) {
+for (const [surface, event] of activeRequiredObservations) {
   if (!hasObservation(observations, surface, event)) {
     block("missing_observation", `${surface}:${event}`);
   }
 }
 
-const checks = Object.fromEntries(requiredChecks.map((check) => [check, true]));
-const stress = Object.fromEntries(requiredStress.map((check) => [check, true]));
+const activeRequiredChecks = deferChannelProof
+  ? requiredChecks.filter((check) => !check.includes("channel"))
+  : requiredChecks;
+const activeRequiredStress = deferChannelProof
+  ? requiredStress.filter((check) => !check.includes("channel"))
+  : requiredStress;
+const activeRequiredOrder = deferChannelProof
+  ? requiredOrder.filter((event) => !event.includes("channel"))
+  : requiredOrder;
+const checks = Object.fromEntries(activeRequiredChecks.map((check) => [check, true]));
+const stress = Object.fromEntries(activeRequiredStress.map((check) => [check, true]));
 stress.mission_bound_ask_count = observations.filter((observation) => observation.event === "pressure_20_50_consecutive_asks_visible").length;
 stress.duplicate_surface_count = observations.filter((observation) => observation.event === "duplicate_preflight_visible").length;
 stress.long_timeline_page_count = observations.filter((observation) => observation.event.startsWith("bounded_page_")).length;
@@ -296,8 +313,14 @@ const manifest = {
   memory_candidates: [
     { id: "memory_candidate_review_only", confirmed: false, grants_memory_authority: false },
   ],
-  event_order: requiredOrder,
+  event_order: activeRequiredOrder,
   observations,
+  deferred_inputs: deferChannelProof ? [{
+    role: "channel",
+    status: "deferred_by_operator",
+    countsTowardUiDeviceProof: false,
+    caveat: "Channel proof is deferred. This manifest can support non-channel evidence work but cannot satisfy strict UI/device proof or END-BAR.",
+  }] : [],
 };
 
 if (out && blockers.length === 0) {
@@ -312,6 +335,7 @@ const output = {
   missionId: missionId || null,
   out: out ? abs(out) : null,
   observations: observations.length,
+  deferredInputs: manifest.deferred_inputs,
   blockers,
   next: blockers.length === 0
     ? "Use this manifest with friday-ui-device-capture-dir.mjs and the strict UI/device proof gate."

--- a/scripts/ops/friday-ui-device-proof-gap-report.mjs
+++ b/scripts/ops/friday-ui-device-proof-gap-report.mjs
@@ -289,6 +289,18 @@ function preferredSurface(surface, event) {
   return "desktop";
 }
 
+function isChannelObservationRequirement([surface, event]) {
+  return surface === "channel" || event.includes("channel");
+}
+
+function isChannelOrderEvent(event) {
+  return event.includes("channel");
+}
+
+function isChannelCheck(check) {
+  return check.includes("channel");
+}
+
 if (!missionId || !/^[A-Za-z0-9][A-Za-z0-9._:-]*$/.test(missionId) || !missionId.toLowerCase().includes("mission")) {
   block("mission_id_unexpected_shape", missionId || "<missing>");
 }
@@ -302,23 +314,53 @@ const observations = parseJsonl(eventFile).map((raw, index) => normalizeEvent(ra
 const manifest = parseManifest(manifestPath);
 const supportingProofRows = supportingProofs();
 
-const missingObservations = requiredObservations
+const activeRequiredObservations = deferChannelProof
+  ? requiredObservations.filter((requirement) => !isChannelObservationRequirement(requirement))
+  : requiredObservations;
+const deferredObservationRequirements = deferChannelProof
+  ? requiredObservations.filter(isChannelObservationRequirement)
+  : [];
+
+const missingObservations = activeRequiredObservations
   .filter(([surface, event]) => !hasObservation(observations, surface, event))
   .map(([surface, event]) => ({
     surface,
     event,
     preferredCapture: preferredSurface(surface, event),
   }));
+const deferredObservations = deferredObservationRequirements
+  .filter(([surface, event]) => !hasObservation(observations, surface, event))
+  .map(([surface, event]) => ({
+    surface,
+    event,
+    preferredCapture: preferredSurface(surface, event),
+    deferred: true,
+  }));
 
 const observedEvents = new Set(observations.map((observation) => observation.event));
-const missingOrderEvents = requiredOrder.filter((event) => !orderEventObserved(observedEvents, event));
+const activeRequiredOrder = deferChannelProof
+  ? requiredOrder.filter((event) => !isChannelOrderEvent(event))
+  : requiredOrder;
+const deferredOrderEvents = deferChannelProof
+  ? requiredOrder.filter((event) => isChannelOrderEvent(event) && !orderEventObserved(observedEvents, event))
+  : [];
+const missingOrderEvents = activeRequiredOrder.filter((event) => !orderEventObserved(observedEvents, event));
 const pressureAskCount = observations.filter((observation) => observation.event === "pressure_20_50_consecutive_asks_visible").length;
 const duplicateSurfaceCount = observations.filter((observation) => observation.event === "duplicate_preflight_visible").length;
 const timelinePageCount = observations.filter((observation) => observation.event.startsWith("bounded_page_")).length;
 
-const missingChecks = manifest?.checks && typeof manifest.checks === "object"
-  ? requiredChecks.filter((check) => manifest.checks[check] !== true)
+const activeRequiredChecks = deferChannelProof
+  ? requiredChecks.filter((check) => !isChannelCheck(check))
   : requiredChecks;
+const deferredChecks = deferChannelProof
+  ? requiredChecks.filter((check) => {
+      if (!isChannelCheck(check)) return false;
+      return !(manifest?.checks && typeof manifest.checks === "object" && manifest.checks[check] === true);
+    })
+  : [];
+const missingChecks = manifest?.checks && typeof manifest.checks === "object"
+  ? activeRequiredChecks.filter((check) => manifest.checks[check] !== true)
+  : activeRequiredChecks;
 
 function capturePlan(missingObservationRows, stressState) {
   const bySurface = new Map();
@@ -386,8 +428,11 @@ const gapReport = {
   },
   gaps: {
     missingObservations,
+    deferredObservations,
     missingOrderEvents,
+    deferredOrderEvents,
     missingChecks,
+    deferredChecks,
     stress: stressGaps,
   },
   capturePlan: capturePlan(missingObservations, stressGaps),
@@ -397,6 +442,9 @@ const gapReport = {
     status: "deferred_by_operator",
     countsTowardUiDeviceProof: false,
     caveat: "Channel live proof is deferred for this report-only run. This does not satisfy channel observations or END-BAR UI/device proof.",
+    missingObservations: deferredObservations,
+    missingOrderEvents: deferredOrderEvents,
+    missingChecks: deferredChecks,
   }] : [],
   blockers,
   caveat: "Gap report only. Capture missing observations from a real same-run mobile/desktop/channel/timeline run before assembling proof. Deferred inputs are never counted as proof.",

--- a/scripts/ops/friday-ui-device-proof-shortlist-runner.sh
+++ b/scripts/ops/friday-ui-device-proof-shortlist-runner.sh
@@ -329,22 +329,31 @@ done
 set -u
 
 capture_dir_status="skipped_missing_channel_or_timeline"
-if [ -n "${channel_capture}" ] && [ -n "${timeline_capture}" ]; then
+if [ -n "${timeline_capture}" ] && { [ -n "${channel_capture}" ] || [ "${defer_channel_proof}" = "1" ]; }; then
   capture_dir_args=(
     "${repo_root}/scripts/ops/friday-ui-device-capture-dir.mjs"
     "--mission-id=${mission_id}"
     "--out-dir=${evidence_dir}"
     "--mobile=${mobile_capture}"
     "--desktop=${desktop_capture}"
-    "--channel=${channel_capture}"
     "--timeline=${timeline_capture}"
     "--require-ready"
   )
+  if [ -n "${channel_capture}" ]; then
+    capture_dir_args+=("--channel=${channel_capture}")
+  fi
+  if [ "${defer_channel_proof}" = "1" ]; then
+    capture_dir_args+=("--defer-channel-proof")
+  fi
   for path in "${event_inputs[@]}"; do
     capture_dir_args+=("--events=${path}")
   done
   node "${capture_dir_args[@]}"
-  capture_dir_status="ready"
+  if [ "${defer_channel_proof}" = "1" ]; then
+    capture_dir_status="ready_channel_deferred_non_strict"
+  else
+    capture_dir_status="ready"
+  fi
 else
   echo "capture_dir=skipped_missing_channel_or_timeline"
 fi
@@ -360,13 +369,13 @@ for dir in "${runtime_evidence_dirs[@]}"; do
   closure_args+=("--runtime-evidence-dir=${dir}")
 done
 set -u
-if [ "${capture_dir_status}" = "ready" ]; then
+if [[ "${capture_dir_status}" == ready* ]]; then
   closure_args+=("--evidence-dir=${evidence_dir}")
 fi
 node "${closure_args[@]}"
 
 readiness_args=("${repo_root}/scripts/ops/friday-ui-device-proof-readiness.sh")
-if [ "${capture_dir_status}" = "ready" ]; then
+if [[ "${capture_dir_status}" == ready* ]]; then
   readiness_args+=("--evidence-dir" "${evidence_dir}")
 fi
 if [ -n "${backend_live_proof}" ]; then
@@ -384,18 +393,20 @@ fi
 FRIDAY_DESIGN_ACTION_RUNTIME_EVIDENCE_DIRS="${bundle_dir}" bash "${readiness_args[@]}" >"${readiness_out}"
 
 gap_status="skipped_missing_channel_or_timeline"
-if [ -n "${channel_capture}" ] && [ -n "${timeline_capture}" ]; then
+if [ -n "${timeline_capture}" ] && { [ -n "${channel_capture}" ] || [ "${defer_channel_proof}" = "1" ]; }; then
   gap_args=(
     "${repo_root}/scripts/ops/friday-ui-device-proof-gap-report.mjs"
     "--mission-id=${mission_id}"
     "--events=${evidence_dir}/same-run-events.normalized.jsonl"
     "--mobile=${evidence_dir}/mobile.json"
     "--desktop=${evidence_dir}/desktop.json"
-    "--channel=${evidence_dir}/channel.json"
     "--timeline=${evidence_dir}/timeline.json"
     "--manifest=${evidence_dir}/observations-manifest.json"
     "--out=${gap_out}"
   )
+  if [ -n "${channel_capture}" ]; then
+    gap_args+=("--channel=${evidence_dir}/channel.json")
+  fi
   if [ -n "${backend_live_proof}" ]; then
     gap_args+=("--backend-live-proof=${backend_live_proof}")
   fi

--- a/test/unit/qa/friday-ui-device-capture-dir-cli.test.ts
+++ b/test/unit/qa/friday-ui-device-capture-dir-cli.test.ts
@@ -168,8 +168,20 @@ function completeEventRows(refs: ReturnType<typeof writeEvidence>) {
   return rows;
 }
 
+function nonChannelEventRows(refs: ReturnType<typeof writeEvidence>) {
+  return completeEventRows(refs).filter((row) => {
+    const eventRow = row as { surface?: string; event?: string };
+    return eventRow.surface !== "channel" && !String(eventRow.event || "").includes("channel");
+  });
+}
+
 function writeEvents(path: string, refs: ReturnType<typeof writeEvidence>) {
   const rows = completeEventRows(refs);
+  writeFileSync(path, `${rows.map((row) => JSON.stringify(row)).join("\n")}\n`);
+}
+
+function writeNonChannelEvents(path: string, refs: ReturnType<typeof writeEvidence>) {
+  const rows = nonChannelEventRows(refs);
   writeFileSync(path, `${rows.map((row) => JSON.stringify(row)).join("\n")}\n`);
 }
 
@@ -266,6 +278,63 @@ describe("friday-ui-device-capture-dir", () => {
       };
       expect(manifest.observations?.some((row) => row.evidence_ref === captures.mobile)).toBe(false);
       expect(manifest.observations?.some((row) => row.evidence_ref === join(outDir, "mobile.png"))).toBe(true);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("indexes non-channel captures when channel proof is explicitly deferred without claiming strict preflight", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "friday-ui-capture-dir-channel-deferred-"));
+    try {
+      const captures = writeEvidence(tempDir);
+      const events = join(tempDir, "same-run-events.jsonl");
+      const outDir = join(tempDir, "evidence");
+      writeNonChannelEvents(events, captures);
+
+      const stdout = execFileSync("node", [
+        "scripts/ops/friday-ui-device-capture-dir.mjs",
+        `--mission-id=${missionId}`,
+        `--out-dir=${outDir}`,
+        `--mobile=${captures.mobile}`,
+        `--desktop=${captures.desktop}`,
+        `--timeline=${captures.timeline}`,
+        `--events=${events}`,
+        "--defer-channel-proof",
+        "--require-ready",
+      ], { cwd: process.cwd(), encoding: "utf8" });
+
+      const result = JSON.parse(stdout) as {
+        status?: string;
+        captures?: Array<{ role?: string }>;
+        preflight?: { skipped?: boolean; reason?: string; countsTowardUiDeviceProof?: boolean };
+        deferredInputs?: Array<{ role?: string; countsTowardUiDeviceProof?: boolean }>;
+        reuseSummary?: { deferredInputs?: Array<{ role?: string; countsTowardUiDeviceProof?: boolean }> };
+      };
+      expect(result.status).toBe("ready");
+      expect(result.captures?.map((capture) => capture.role).sort()).toEqual(["desktop", "mobile", "timeline"]);
+      expect(result.preflight).toEqual(expect.objectContaining({
+        skipped: true,
+        reason: "channel_deferred",
+        countsTowardUiDeviceProof: false,
+      }));
+      expect(result.deferredInputs).toContainEqual(expect.objectContaining({
+        role: "channel",
+        countsTowardUiDeviceProof: false,
+      }));
+      expect(result.reuseSummary?.deferredInputs).toContainEqual(expect.objectContaining({
+        role: "channel",
+        countsTowardUiDeviceProof: false,
+      }));
+
+      const manifest = JSON.parse(readFileSync(join(outDir, "observations-manifest.json"), "utf8")) as {
+        checks?: Record<string, boolean>;
+        deferred_inputs?: Array<{ role?: string; countsTowardUiDeviceProof?: boolean }>;
+      };
+      expect(manifest.checks?.same_mission_id_channel).toBeUndefined();
+      expect(manifest.deferred_inputs).toContainEqual(expect.objectContaining({
+        role: "channel",
+        countsTowardUiDeviceProof: false,
+      }));
     } finally {
       rmSync(tempDir, { recursive: true, force: true });
     }

--- a/test/unit/qa/friday-ui-device-observations-manifest-cli.test.ts
+++ b/test/unit/qa/friday-ui-device-observations-manifest-cli.test.ts
@@ -64,6 +64,13 @@ function completeEvents(refs: ReturnType<typeof writeEvidence>) {
   return rows;
 }
 
+function nonChannelEvents(refs: ReturnType<typeof writeEvidence>) {
+  return completeEvents(refs).filter((row) => {
+    const eventRow = row as { surface?: string; event?: string };
+    return eventRow.surface !== "channel" && !String(eventRow.event || "").includes("channel");
+  });
+}
+
 function runManifest(tempDir: string, refs: ReturnType<typeof writeEvidence>, rows: unknown[], extraArgs: string[] = []) {
   const events = join(tempDir, "same-run-events.jsonl");
   const out = join(tempDir, "observations-manifest.json");
@@ -131,6 +138,56 @@ describe("friday-ui-device-observations-manifest", () => {
       expect(output.blockers).toEqual([]);
       const manifest = JSON.parse(readFileSync(out, "utf8")) as { transcript_browser?: { evidence_ref?: string } };
       expect(manifest.transcript_browser?.evidence_ref).toBe(alias);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("derives non-channel manifest inputs when channel proof is explicitly deferred", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "friday-ui-observations-channel-deferred-"));
+    try {
+      const refs = writeEvidence(tempDir);
+      const events = join(tempDir, "same-run-events.jsonl");
+      const out = join(tempDir, "observations-manifest.json");
+      writeJsonl(events, nonChannelEvents(refs));
+
+      const result = spawnSync("node", [
+        "scripts/ops/friday-ui-device-observations-manifest.mjs",
+        `--mission-id=${missionId}`,
+        `--mobile=${refs.mobile}`,
+        `--desktop=${refs.desktop}`,
+        `--timeline=${refs.timeline}`,
+        `--events=${events}`,
+        `--out=${out}`,
+        "--defer-channel-proof",
+        "--require-ready",
+      ], { cwd: process.cwd(), encoding: "utf8" });
+
+      expect(result.status).toBe(0);
+      const output = JSON.parse(result.stdout) as {
+        status?: string;
+        deferredInputs?: Array<{ role?: string; countsTowardUiDeviceProof?: boolean }>;
+      };
+      expect(output.status).toBe("ready");
+      expect(output.deferredInputs).toContainEqual(expect.objectContaining({
+        role: "channel",
+        countsTowardUiDeviceProof: false,
+      }));
+
+      const manifest = JSON.parse(readFileSync(out, "utf8")) as {
+        checks?: Record<string, boolean>;
+        event_order?: string[];
+        deferred_inputs?: Array<{ role?: string; countsTowardUiDeviceProof?: boolean }>;
+        observations?: Array<{ surface?: string; event?: string }>;
+      };
+      expect(manifest.checks?.same_mission_id_channel).toBeUndefined();
+      expect(manifest.checks?.channel_replay_blocked).toBeUndefined();
+      expect(manifest.event_order).not.toContain("same_mission_mobile_desktop_channel");
+      expect(manifest.observations?.some((row) => row.surface === "channel" || String(row.event).includes("channel"))).toBe(false);
+      expect(manifest.deferred_inputs).toContainEqual(expect.objectContaining({
+        role: "channel",
+        countsTowardUiDeviceProof: false,
+      }));
     } finally {
       rmSync(tempDir, { recursive: true, force: true });
     }

--- a/test/unit/qa/friday-ui-device-proof-gap-report-cli.test.ts
+++ b/test/unit/qa/friday-ui-device-proof-gap-report-cli.test.ts
@@ -223,6 +223,82 @@ describe("friday-ui-device-proof-gap-report", () => {
     }
   });
 
+  it("moves channel gaps into deferred buckets when channel proof is deferred", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "friday-ui-gap-report-defer-channel-"));
+    try {
+      const files = evidenceFiles(tempDir);
+      const events = join(tempDir, "events.jsonl");
+      const rows = completeRows(files)
+        .filter((row) => {
+          const eventName = (row as { event?: string }).event ?? "";
+          const surface = (row as { surface?: string }).surface ?? "";
+          return surface !== "channel" && !eventName.includes("channel");
+        });
+      writeJsonl(events, rows);
+      const manifest = join(tempDir, "manifest.json");
+      const checks = completeManifest().checks;
+      delete checks.same_mission_id_channel;
+      delete checks.channel_replay_blocked;
+      writeFileSync(manifest, JSON.stringify({ checks }, null, 2));
+
+      const result = spawnSync("node", [
+        script,
+        `--mission-id=${missionId}`,
+        `--events=${events}`,
+        `--mobile=${files.mobile}`,
+        `--desktop=${files.desktop}`,
+        `--timeline=${files.timeline}`,
+        `--manifest=${manifest}`,
+        "--defer-channel-proof",
+        "--require-complete",
+      ], { cwd: process.cwd(), encoding: "utf8" });
+      expect(result.status).toBe(0);
+      const output = JSON.parse(result.stdout) as {
+        status?: string;
+        gaps?: {
+          missingObservations?: Array<{ event?: string; surface?: string }>;
+          deferredObservations?: Array<{ event?: string; surface?: string; deferred?: boolean }>;
+          missingOrderEvents?: string[];
+          deferredOrderEvents?: string[];
+          missingChecks?: string[];
+          deferredChecks?: string[];
+        };
+        capturePlan?: Array<{ surface?: string }>;
+        deferredInputs?: Array<{
+          role?: string;
+          countsTowardUiDeviceProof?: boolean;
+          missingObservations?: unknown[];
+          missingOrderEvents?: unknown[];
+          missingChecks?: unknown[];
+        }>;
+      };
+      expect(output.status).toBe("complete_inputs_observed");
+      expect(output.gaps?.missingObservations).toEqual([]);
+      expect(output.gaps?.missingOrderEvents).toEqual([]);
+      expect(output.gaps?.missingChecks).toEqual([]);
+      expect(output.capturePlan?.some((entry) => entry.surface === "channel")).toBe(false);
+      expect(output.gaps?.deferredObservations).toEqual(expect.arrayContaining([
+        expect.objectContaining({ surface: "channel", event: "same_mission_projection_visible", deferred: true }),
+        expect.objectContaining({ surface: "*", event: "same_mission_mobile_desktop_channel_visible", deferred: true }),
+        expect.objectContaining({ surface: "*", event: "channel_replay_blocked_visible", deferred: true }),
+      ]));
+      expect(output.gaps?.deferredOrderEvents).toEqual(["same_mission_mobile_desktop_channel"]);
+      expect(output.gaps?.deferredChecks).toEqual(expect.arrayContaining([
+        "same_mission_id_channel",
+        "channel_replay_blocked",
+      ]));
+      expect(output.deferredInputs).toContainEqual(expect.objectContaining({
+        role: "channel",
+        countsTowardUiDeviceProof: false,
+        missingObservations: output.gaps?.deferredObservations,
+        missingOrderEvents: output.gaps?.deferredOrderEvents,
+        missingChecks: output.gaps?.deferredChecks,
+      }));
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
   it("accepts evidence refs that resolve to the same file through a symlink", () => {
     const tempDir = mkdtempSync(join(tmpdir(), "friday-ui-gap-report-realpath-"));
     try {

--- a/test/unit/qa/friday-ui-device-proof-readiness-cli.test.ts
+++ b/test/unit/qa/friday-ui-device-proof-readiness-cli.test.ts
@@ -766,19 +766,34 @@ describe("friday-ui-device-proof-readiness", () => {
 
       const gapReport = JSON.parse(readFileSync(join(tempDir, "gap-report.json"), "utf8")) as {
         status?: string;
-        deferredInputs?: Array<{ role?: string; status?: string; countsTowardUiDeviceProof?: boolean }>;
+        gaps?: { deferredObservations?: Array<{ surface?: string; event?: string; deferred?: boolean }> };
+        deferredInputs?: Array<{
+          role?: string;
+          status?: string;
+          countsTowardUiDeviceProof?: boolean;
+          missingObservations?: Array<{ surface?: string; event?: string; deferred?: boolean }>;
+        }>;
         capturePlan?: Array<{ surface?: string; deferred?: boolean }>;
       };
       expect(gapReport.status).toBe("gaps_present");
+      expect(gapReport.gaps?.deferredObservations).toContainEqual(expect.objectContaining({
+        surface: "channel",
+        event: "same_mission_projection_visible",
+        deferred: true,
+      }));
       expect(gapReport.deferredInputs).toContainEqual(expect.objectContaining({
         role: "channel",
         status: "deferred_by_operator",
         countsTowardUiDeviceProof: false,
+        missingObservations: expect.arrayContaining([
+          expect.objectContaining({
+            surface: "channel",
+            event: "same_mission_projection_visible",
+            deferred: true,
+          }),
+        ]),
       }));
-      expect(gapReport.capturePlan).toContainEqual(expect.objectContaining({
-        surface: "channel",
-        deferred: true,
-      }));
+      expect(gapReport.capturePlan?.some((entry) => entry.surface === "channel")).toBe(false);
     } finally {
       rmSync(tempDir, { recursive: true, force: true });
     }

--- a/test/unit/qa/friday-ui-device-proof-shortlist-runner-contract.test.ts
+++ b/test/unit/qa/friday-ui-device-proof-shortlist-runner-contract.test.ts
@@ -22,6 +22,10 @@ describe("friday-ui-device-proof-shortlist-runner contract", () => {
     expect(source).toContain("defer_channel_proof=\"${FRIDAY_UI_DEVICE_DEFER_CHANNEL_PROOF:-0}\"");
     expect(source).toContain("harvest_args+=(\"--defer-channel-proof\")");
     expect(source).toContain("readiness_args+=(\"--defer-channel-proof\")");
+    expect(source).toContain("[ -n \"${timeline_capture}\" ] && { [ -n \"${channel_capture}\" ] || [ \"${defer_channel_proof}\" = \"1\" ]; }");
+    expect(source).toContain("capture_dir_args+=(\"--defer-channel-proof\")");
+    expect(source).toContain("capture_dir_status=\"ready_channel_deferred_non_strict\"");
+    expect(source).toContain("[[ \"${capture_dir_status}\" == ready* ]]");
     expect(source).toContain("gap_args+=(\"--defer-channel-proof\")");
     expect(source).toContain("real channel, timeline, stress, and negative-control evidence");
   });


### PR DESCRIPTION
## Summary
- allow UI/device observations manifests to derive non-channel evidence when channel proof is explicitly deferred
- let capture-dir index mobile, desktop, and timeline evidence without claiming strict preflight when channel is deferred
- thread deferred-channel evidence dirs through the shortlist runner so non-channel timeline/stress evidence can keep flowing

## Truth labels
- channel proof remains deferred and countsTowardUiDeviceProof=false
- strict UI/device proof and END-BAR are not satisfied by deferred-channel evidence dirs

## Test
- node --check scripts/ops/friday-ui-device-observations-manifest.mjs
- node --check scripts/ops/friday-ui-device-capture-dir.mjs
- bash -n scripts/ops/friday-ui-device-proof-shortlist-runner.sh
- npx vitest run test/unit/qa/friday-ui-device-observations-manifest-cli.test.ts test/unit/qa/friday-ui-device-capture-dir-cli.test.ts test/unit/qa/friday-ui-device-proof-shortlist-runner-contract.test.ts
- git diff --check