### PR TITLE
Thread workbench timeline evidence through UI device runner

### DIFF
--- a/scripts/ops/friday-ui-device-proof-readiness.sh
+++ b/scripts/ops/friday-ui-device-proof-readiness.sh
@@ -508,7 +508,10 @@ derive_workbench_events_if_possible() {
   if [ -z "${FRIDAY_WORKBENCH_SNAPSHOT_FILE:-}" ]; then
     return 0
   fi
-  if [ -z "${MISSION_ID:-}" ] || [ -z "${MOBILE_EVIDENCE:-}" ] || [ -z "${DESKTOP_EVIDENCE:-}" ] || [ -z "${CHANNEL_EVIDENCE:-}" ] || [ -z "${TIMELINE_EVIDENCE:-}" ]; then
+  if [ -z "${MISSION_ID:-}" ] || [ -z "${MOBILE_EVIDENCE:-}" ] || [ -z "${DESKTOP_EVIDENCE:-}" ] || [ -z "${TIMELINE_EVIDENCE:-}" ]; then
+    return 0
+  fi
+  if [ -z "${CHANNEL_EVIDENCE:-}" ] && [ "${DEFER_CHANNEL_PROOF}" != "1" ]; then
     return 0
   fi
 
@@ -527,14 +530,23 @@ derive_workbench_events_if_possible() {
   mkdir -p "$(dirname "$derived_out")"
   existing_events="${SAME_RUN_EVENTS:-}"
 
-  if node "${REPO_ROOT}/scripts/ops/friday-workbench-snapshot-events.mjs" \
-    "--mission-id=${MISSION_ID}" \
-    "--file=${FRIDAY_WORKBENCH_SNAPSHOT_FILE}" \
-    "--mobile=${MOBILE_EVIDENCE}" \
-    "--desktop=${DESKTOP_EVIDENCE}" \
-    "--channel=${CHANNEL_EVIDENCE}" \
-    "--timeline=${TIMELINE_EVIDENCE}" \
-    "--out=${derived_out}" >"$stdout_out"; then
+  local args=(
+    "${REPO_ROOT}/scripts/ops/friday-workbench-snapshot-events.mjs"
+    "--mission-id=${MISSION_ID}"
+    "--file=${FRIDAY_WORKBENCH_SNAPSHOT_FILE}"
+    "--mobile=${MOBILE_EVIDENCE}"
+    "--desktop=${DESKTOP_EVIDENCE}"
+    "--timeline=${TIMELINE_EVIDENCE}"
+    "--out=${derived_out}"
+  )
+  if [ -n "${CHANNEL_EVIDENCE:-}" ]; then
+    args+=("--channel=${CHANNEL_EVIDENCE}")
+  fi
+  if [ "${DEFER_CHANNEL_PROOF}" = "1" ]; then
+    args+=("--defer-channel-proof")
+  fi
+
+  if node "${args[@]}" >"$stdout_out"; then
     if [ -n "$existing_events" ]; then
       awk '!seen[$0]++' "$existing_events" "$derived_out" >"$merged_out"
       SAME_RUN_EVENTS="$merged_out"

--- a/scripts/ops/friday-ui-device-proof-shortlist-runner.sh
+++ b/scripts/ops/friday-ui-device-proof-shortlist-runner.sh
@@ -11,6 +11,7 @@ usage:
     [--channel-live-proof /abs/channel-live-proof.json]
     [--channel-capture /abs/channel-capture.json]
     [--timeline-capture /abs/timeline-capture.json]
+    [--workbench-db /abs/rust-hub.sqlite]
     [--accessibility-capture /abs/real-accessibility-capture.json ...]
     [--stress-capture /abs/real-same-run-stress-capture.json ...]
     [--harvest-dir /abs/artifact-dir ...]
@@ -45,6 +46,7 @@ objective_coverage="${FRIDAY_UI_DEVICE_OBJECTIVE_COVERAGE:-}"
 channel_live_proof="${FRIDAY_UI_DEVICE_CHANNEL_LIVE_PROOF:-}"
 channel_capture=""
 timeline_capture=""
+workbench_db="${FRIDAY_WORKBENCH_DB_PATH:-}"
 defer_channel_proof="${FRIDAY_UI_DEVICE_DEFER_CHANNEL_PROOF:-0}"
 accessibility_captures=()
 stress_captures=()
@@ -123,6 +125,15 @@ while [ "$#" -gt 0 ]; do
       ;;
     --timeline-capture=*)
       timeline_capture="${1#--timeline-capture=}"
+      shift
+      ;;
+    --workbench-db)
+      [ "$#" -ge 2 ] || die "--workbench-db requires a value"
+      workbench_db="$2"
+      shift 2
+      ;;
+    --workbench-db=*)
+      workbench_db="${1#--workbench-db=}"
       shift
       ;;
     --accessibility-capture)
@@ -338,8 +349,55 @@ require_file_if_set "--objective-coverage" "${objective_coverage}"
 require_file_if_set "--channel-live-proof" "${channel_live_proof}"
 require_file_if_set "--channel-capture" "${channel_capture}"
 require_file_if_set "--timeline-capture" "${timeline_capture}"
+require_file_if_set "--workbench-db" "${workbench_db}"
 
 event_inputs=("${combined_events}")
+workbench_timeline_status="skipped"
+if [ -z "${timeline_capture}" ] && [ -n "${workbench_db}" ]; then
+  workbench_snapshot="${out_dir}/workbench-timeline-capture.json"
+  workbench_snapshot_stdout="${workbench_snapshot}.stdout"
+  workbench_snapshot_stderr="${workbench_snapshot}.stderr"
+  if (cd "${repo_root}/rust-core" && cargo run -p friday-hub --bin mission_workbench_projection -- \
+    --db "${workbench_db}" \
+    --mission-id "${mission_id}" >"${workbench_snapshot}") >"${workbench_snapshot_stdout}" 2>"${workbench_snapshot_stderr}"; then
+    timeline_capture="${workbench_snapshot}"
+    workbench_timeline_status="snapshot_ready"
+  else
+    workbench_timeline_status="snapshot_failed"
+  fi
+fi
+if [ -n "${timeline_capture}" ] && [ "${workbench_timeline_status}" != "snapshot_failed" ]; then
+  workbench_events="${out_dir}/workbench-derived-events.jsonl"
+  workbench_events_args=(
+    "${repo_root}/scripts/ops/friday-workbench-snapshot-events.mjs"
+    "--mission-id=${mission_id}"
+    "--file=${timeline_capture}"
+    "--mobile=${mobile_capture}"
+    "--desktop=${desktop_capture}"
+    "--timeline=${timeline_capture}"
+    "--out=${workbench_events}"
+  )
+  if [ -n "${channel_capture}" ]; then
+    workbench_events_args+=("--channel=${channel_capture}")
+  fi
+  if [ "${defer_channel_proof}" = "1" ]; then
+    workbench_events_args+=("--defer-channel-proof")
+  fi
+  if node "${workbench_events_args[@]}" --require-ready >"${workbench_events}.stdout"; then
+    same_run_events+=("${workbench_events}")
+    if [ "${workbench_timeline_status}" = "skipped" ]; then
+      workbench_timeline_status="events_ready"
+    else
+      workbench_timeline_status="${workbench_timeline_status}_events_ready"
+    fi
+  else
+    if [ "${workbench_timeline_status}" = "skipped" ]; then
+      workbench_timeline_status="events_failed"
+    else
+      workbench_timeline_status="${workbench_timeline_status}_events_failed"
+    fi
+  fi
+fi
 channel_events=""
 if [ -n "${channel_live_proof}" ] || [ -n "${channel_capture}" ]; then
   [ -n "${channel_live_proof}" ] || die "--channel-live-proof is required with --channel-capture"
@@ -380,11 +438,14 @@ if [ -n "${timeline_capture}" ] && { [ -n "${channel_capture}" ] || [ "${defer_c
   for path in "${event_inputs[@]}"; do
     capture_dir_args+=("--events=${path}")
   done
-  node "${capture_dir_args[@]}"
-  if [ "${defer_channel_proof}" = "1" ]; then
-    capture_dir_status="ready_channel_deferred_non_strict"
+  if node "${capture_dir_args[@]}"; then
+    if [ "${defer_channel_proof}" = "1" ]; then
+      capture_dir_status="ready_channel_deferred_non_strict"
+    else
+      capture_dir_status="ready"
+    fi
   else
-    capture_dir_status="ready"
+    capture_dir_status="blocked"
   fi
 else
   echo "capture_dir=skipped_missing_channel_or_timeline"
@@ -419,10 +480,13 @@ fi
 if [ -n "${objective_coverage}" ]; then
   readiness_args+=("--objective-coverage" "${objective_coverage}")
 fi
+if [ -n "${workbench_db}" ]; then
+  readiness_args+=("--workbench-db" "${workbench_db}")
+fi
 if [ "${defer_channel_proof}" = "1" ]; then
   readiness_args+=("--defer-channel-proof")
 fi
-FRIDAY_DESIGN_ACTION_RUNTIME_EVIDENCE_DIRS="${bundle_dir}" bash "${readiness_args[@]}" >"${readiness_out}"
+MISSION_ID="${mission_id}" FRIDAY_DESIGN_ACTION_RUNTIME_EVIDENCE_DIRS="${bundle_dir}" bash "${readiness_args[@]}" >"${readiness_out}"
 
 gap_status="skipped_missing_channel_or_timeline"
 if [ -n "${timeline_capture}" ] && { [ -n "${channel_capture}" ] || [ "${defer_channel_proof}" = "1" ]; }; then
@@ -455,9 +519,9 @@ if [ -n "${timeline_capture}" ] && { [ -n "${channel_capture}" ] || [ "${defer_c
   gap_status="written"
 fi
 
-node - "${summary_out}" "${bundle_index}" "${product_closure_out}" "${readiness_out}" "${capture_dir_status}" "${gap_status}" "${accessibility_capture_status}" "${stress_capture_status}" <<'NODE'
+node - "${summary_out}" "${bundle_index}" "${product_closure_out}" "${readiness_out}" "${capture_dir_status}" "${gap_status}" "${accessibility_capture_status}" "${stress_capture_status}" "${workbench_timeline_status}" <<'NODE'
 const fs = require("node:fs");
-const [summaryOut, bundleIndexPath, productClosurePath, readinessPath, captureDirStatus, gapStatus, accessibilityCaptureStatus, stressCaptureStatus] = process.argv.slice(2);
+const [summaryOut, bundleIndexPath, productClosurePath, readinessPath, captureDirStatus, gapStatus, accessibilityCaptureStatus, stressCaptureStatus, workbenchTimelineStatus] = process.argv.slice(2);
 function parseJsonSuffix(text) {
   const trimmed = String(text || "").trim();
   if (!trimmed) throw new Error("empty JSON input");
@@ -492,6 +556,7 @@ const summary = {
   gapStatus,
   accessibilityCaptureStatus,
   stressCaptureStatus,
+  workbenchTimelineStatus,
   productClosureStatus: closure.status,
   uiDeviceProofReadiness: closure.stages?.uiDeviceProofReadiness || null,
   readinessStatus: readiness.status,

--- a/test/unit/qa/friday-ui-device-proof-shortlist-runner-contract.test.ts
+++ b/test/unit/qa/friday-ui-device-proof-shortlist-runner-contract.test.ts
@@ -23,6 +23,8 @@ describe("friday-ui-device-proof-shortlist-runner contract", () => {
     expect(source).toContain("harvest_args+=(\"--defer-channel-proof\")");
     expect(source).toContain("readiness_args+=(\"--defer-channel-proof\")");
     expect(source).toContain("[ -n \"${timeline_capture}\" ] && { [ -n \"${channel_capture}\" ] || [ \"${defer_channel_proof}\" = \"1\" ]; }");
+    expect(source).toContain("if node \"${capture_dir_args[@]}\"; then");
+    expect(source).toContain("capture_dir_status=\"blocked\"");
     expect(source).toContain("capture_dir_args+=(\"--defer-channel-proof\")");
     expect(source).toContain("capture_dir_status=\"ready_channel_deferred_non_strict\"");
     expect(source).toContain("[[ \"${capture_dir_status}\" == ready* ]]");
@@ -42,5 +44,27 @@ describe("friday-ui-device-proof-shortlist-runner contract", () => {
     expect(source).toContain("--require-ready");
     expect(source).toContain("same_run_events+=(\"${stress_events}\")");
     expect(source).toContain("stressCaptureStatus");
+  });
+
+  it("can derive non-channel workbench timeline inputs from the Rust Hub DB", () => {
+    const source = readFileSync("scripts/ops/friday-ui-device-proof-shortlist-runner.sh", "utf8");
+
+    expect(source).toContain("--workbench-db");
+    expect(source).toContain("workbench_db=\"${FRIDAY_WORKBENCH_DB_PATH:-}\"");
+    expect(source).toContain("cargo run -p friday-hub --bin mission_workbench_projection");
+    expect(source).toContain("workbench-timeline-capture.json");
+    expect(source).toContain("friday-workbench-snapshot-events.mjs");
+    expect(source).toContain("same_run_events+=(\"${workbench_events}\")");
+    expect(source).toContain("readiness_args+=(\"--workbench-db\" \"${workbench_db}\")");
+    expect(source).toContain("MISSION_ID=\"${mission_id}\" FRIDAY_DESIGN_ACTION_RUNTIME_EVIDENCE_DIRS");
+    expect(source).toContain("workbenchTimelineStatus");
+  });
+
+  it("lets readiness derive workbench events while channel proof is deferred", () => {
+    const source = readFileSync("scripts/ops/friday-ui-device-proof-readiness.sh", "utf8");
+
+    expect(source).toContain("[ -z \"${CHANNEL_EVIDENCE:-}\" ] && [ \"${DEFER_CHANNEL_PROOF}\" != \"1\" ]");
+    expect(source).toContain("args+=(\"--defer-channel-proof\")");
+    expect(source).toContain("node \"${args[@]}\" >\"$stdout_out\"");
   });
 });


### PR DESCRIPTION
## Summary
- add a `--workbench-db` path to the UI/device proof shortlist runner so it can derive same-mission workbench timeline captures from the read-only Rust Hub DB
- allow workbench-derived event bridging while channel proof is explicitly deferred, without counting channel evidence as proof
- keep partial capture-dir failures reportable so the runner still writes summary/gap status instead of stopping before the actionable gap report

## Truth boundary
- This does not claim END-BAR, GO-LIVE, adoption, or channel completion.
- Deferred channel rows remain deferred and do not count toward strict UI/device proof.
- Workbench/timeline rows are diagnostic same-mission evidence; stress, negative controls, action runtime coverage, and channel remain separately gated.

## Verification
- `bash -n scripts/ops/friday-ui-device-proof-shortlist-runner.sh scripts/ops/friday-ui-device-proof-readiness.sh`
- `npx vitest run test/unit/qa/friday-ui-device-proof-shortlist-runner-contract.test.ts test/unit/qa/friday-ui-device-proof-readiness-cli.test.ts`
- real runner smoke with read-only Rust DB: `workbenchTimelineStatus=snapshot_ready_events_ready`, `gapStatus=written`, `readinessBlockers=[ui_device_proof_evidence:missing_required_real_evidence_env]`