### PR TITLE
Keep UI device gap reports visible when strict evidence blocks

### DIFF
--- a/scripts/ops/friday-ui-device-proof-gap-report.mjs
+++ b/scripts/ops/friday-ui-device-proof-gap-report.mjs
@@ -117,6 +117,7 @@ const evidenceArgs = {
   timeline: arg("timeline"),
 };
 const blockers = [];
+const supplementalEvidenceRefs = [];
 
 function block(code, detail) {
   blockers.push({ code, detail });
@@ -250,7 +251,20 @@ function normalizeEvent(raw, index, knownEvidenceRefs) {
   if (!surface) block("event_missing_surface", label);
   if (!event) block("event_missing_name", label);
   if (eventMissionId !== missionId) block("event_mission_mismatch", `${label}:${eventMissionId}`);
-  if (!knownEvidenceRefs.has(evidenceKey(evidenceRef))) block("event_evidence_ref_unknown", `${label}:${evidenceRef}`);
+  const knownEvidenceRef = knownEvidenceRefs.has(evidenceKey(evidenceRef));
+  if (!knownEvidenceRef) {
+    const detail = `${label}:${evidenceRef}`;
+    if (requireComplete) {
+      block("event_evidence_ref_unknown", detail);
+    } else {
+      supplementalEvidenceRefs.push({
+        event: label,
+        evidenceRef,
+        countsTowardStrictProof: false,
+        caveat: "Report-only supplemental event evidence. Strict proof still requires evidence_ref to resolve to the mobile/desktop/channel/timeline capture manifest.",
+      });
+    }
+  }
   return { surface, event, mission_id: eventMissionId, evidence_ref: evidenceRef };
 }
 
@@ -410,6 +424,7 @@ const stressGaps = {
 const gapReport = {
   truth: "ui_device_proof_gap_report_not_proof",
   status: blockers.length === 0 && missingObservations.length === 0 && missingOrderEvents.length === 0 && missingChecks.length === 0
+    && supplementalEvidenceRefs.length === 0
     && pressureAskCount >= 20 && pressureAskCount <= 50 && duplicateSurfaceCount >= 2 && timelinePageCount >= 2
     ? "complete_inputs_observed"
     : "gaps_present",
@@ -437,6 +452,7 @@ const gapReport = {
   },
   capturePlan: capturePlan(missingObservations, stressGaps),
   supportingProofs: supportingProofRows,
+  supplementalEvidenceRefs,
   deferredInputs: deferChannelProof ? [{
     role: "channel",
     status: "deferred_by_operator",

--- a/scripts/ops/friday-ui-device-proof-shortlist-runner.sh
+++ b/scripts/ops/friday-ui-device-proof-shortlist-runner.sh
@@ -489,19 +489,53 @@ fi
 MISSION_ID="${mission_id}" FRIDAY_DESIGN_ACTION_RUNTIME_EVIDENCE_DIRS="${bundle_dir}" bash "${readiness_args[@]}" >"${readiness_out}"
 
 gap_status="skipped_missing_channel_or_timeline"
+gap_event_status="skipped"
 if [ -n "${timeline_capture}" ] && { [ -n "${channel_capture}" ] || [ "${defer_channel_proof}" = "1" ]; }; then
+  gap_events="${evidence_dir}/same-run-events.normalized.jsonl"
+  gap_mobile="${mobile_capture}"
+  gap_desktop="${desktop_capture}"
+  gap_timeline="${timeline_capture}"
+  gap_manifest="${evidence_dir}/observations-manifest.json"
+  if [ ! -s "${gap_events}" ]; then
+    gap_events="${out_dir}/gap-report-events.jsonl"
+    gap_merge_args=(
+      "${repo_root}/scripts/ops/friday-ui-device-events-merge.mjs"
+      "--mission-id=${mission_id}"
+      "--out=${gap_events}"
+      "--require-ready"
+    )
+    for path in "${event_inputs[@]}"; do
+      gap_merge_args+=("--events=${path}")
+    done
+    if node "${gap_merge_args[@]}" >"${gap_events}.stdout"; then
+      gap_event_status="report_only_events_ready"
+    else
+      gap_event_status="report_only_events_blocked"
+    fi
+  else
+    gap_event_status="strict_capture_dir_events_ready"
+    gap_mobile="${evidence_dir}/mobile.json"
+    gap_desktop="${evidence_dir}/desktop.json"
+    gap_timeline="${evidence_dir}/timeline.json"
+  fi
   gap_args=(
     "${repo_root}/scripts/ops/friday-ui-device-proof-gap-report.mjs"
     "--mission-id=${mission_id}"
-    "--events=${evidence_dir}/same-run-events.normalized.jsonl"
-    "--mobile=${evidence_dir}/mobile.json"
-    "--desktop=${evidence_dir}/desktop.json"
-    "--timeline=${evidence_dir}/timeline.json"
-    "--manifest=${evidence_dir}/observations-manifest.json"
+    "--events=${gap_events}"
+    "--mobile=${gap_mobile}"
+    "--desktop=${gap_desktop}"
+    "--timeline=${gap_timeline}"
     "--out=${gap_out}"
   )
   if [ -n "${channel_capture}" ]; then
-    gap_args+=("--channel=${evidence_dir}/channel.json")
+    gap_channel="${evidence_dir}/channel.json"
+    if [ ! -s "${gap_channel}" ]; then
+      gap_channel="${channel_capture}"
+    fi
+    gap_args+=("--channel=${gap_channel}")
+  fi
+  if [ -s "${gap_manifest}" ]; then
+    gap_args+=("--manifest=${gap_manifest}")
   fi
   if [ -n "${backend_live_proof}" ]; then
     gap_args+=("--backend-live-proof=${backend_live_proof}")
@@ -519,9 +553,9 @@ if [ -n "${timeline_capture}" ] && { [ -n "${channel_capture}" ] || [ "${defer_c
   gap_status="written"
 fi
 
-node - "${summary_out}" "${bundle_index}" "${product_closure_out}" "${readiness_out}" "${capture_dir_status}" "${gap_status}" "${accessibility_capture_status}" "${stress_capture_status}" "${workbench_timeline_status}" <<'NODE'
+node - "${summary_out}" "${bundle_index}" "${product_closure_out}" "${readiness_out}" "${capture_dir_status}" "${gap_status}" "${gap_event_status}" "${accessibility_capture_status}" "${stress_capture_status}" "${workbench_timeline_status}" <<'NODE'
 const fs = require("node:fs");
-const [summaryOut, bundleIndexPath, productClosurePath, readinessPath, captureDirStatus, gapStatus, accessibilityCaptureStatus, stressCaptureStatus, workbenchTimelineStatus] = process.argv.slice(2);
+const [summaryOut, bundleIndexPath, productClosurePath, readinessPath, captureDirStatus, gapStatus, gapEventStatus, accessibilityCaptureStatus, stressCaptureStatus, workbenchTimelineStatus] = process.argv.slice(2);
 function parseJsonSuffix(text) {
   const trimmed = String(text || "").trim();
   if (!trimmed) throw new Error("empty JSON input");
@@ -554,6 +588,7 @@ const summary = {
   captures: bundle.captures || {},
   captureDirStatus,
   gapStatus,
+  gapEventStatus,
   accessibilityCaptureStatus,
   stressCaptureStatus,
   workbenchTimelineStatus,

--- a/test/unit/qa/friday-ui-device-proof-gap-report-cli.test.ts
+++ b/test/unit/qa/friday-ui-device-proof-gap-report-cli.test.ts
@@ -335,6 +335,40 @@ describe("friday-ui-device-proof-gap-report", () => {
     }
   });
 
+  it("reports supplemental accessibility evidence refs without treating them as strict proof in report-only mode", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "friday-ui-gap-report-supplemental-"));
+    try {
+      const files = evidenceFiles(tempDir);
+      const axTree = join(tempDir, "desktop-ax-tree.raw.txt");
+      writeFileSync(axTree, "real macOS accessibility tree captured from the app\n");
+      const rows = [
+        event("desktop", "mission_workbench_visible", axTree),
+        event("desktop", "same_mission_projection_visible", files.desktop),
+      ];
+      const result = run(tempDir, files, rows);
+      expect(result.status).toBe(0);
+      const output = JSON.parse(result.stdout) as {
+        status?: string;
+        observed?: { eventRows?: number; surfaces?: string[] };
+        blockers?: Array<{ code?: string }>;
+        supplementalEvidenceRefs?: Array<{
+          evidenceRef?: string;
+          countsTowardStrictProof?: boolean;
+        }>;
+      };
+      expect(output.status).toBe("gaps_present");
+      expect(output.observed?.eventRows).toBe(2);
+      expect(output.observed?.surfaces).toContain("desktop");
+      expect(output.blockers?.map((blocker) => blocker.code)).not.toContain("event_evidence_ref_unknown");
+      expect(output.supplementalEvidenceRefs).toContainEqual(expect.objectContaining({
+        evidenceRef: axTree,
+        countsTowardStrictProof: false,
+      }));
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
   it("marks complete only when required observations and manifest checks are present", () => {
     const tempDir = mkdtempSync(join(tmpdir(), "friday-ui-gap-report-complete-"));
     try {

--- a/test/unit/qa/friday-ui-device-proof-shortlist-runner-contract.test.ts
+++ b/test/unit/qa/friday-ui-device-proof-shortlist-runner-contract.test.ts
@@ -60,6 +60,17 @@ describe("friday-ui-device-proof-shortlist-runner contract", () => {
     expect(source).toContain("workbenchTimelineStatus");
   });
 
+  it("keeps gap reports useful when strict capture-dir assembly is blocked", () => {
+    const source = readFileSync("scripts/ops/friday-ui-device-proof-shortlist-runner.sh", "utf8");
+
+    expect(source).toContain("gap-report-events.jsonl");
+    expect(source).toContain("friday-ui-device-events-merge.mjs");
+    expect(source).toContain("gap_event_status=\"report_only_events_ready\"");
+    expect(source).toContain("gapEventStatus");
+    expect(source).toContain("gap_mobile=\"${mobile_capture}\"");
+    expect(source).toContain("if [ -s \"${gap_manifest}\" ]; then");
+  });
+
   it("lets readiness derive workbench events while channel proof is deferred", () => {
     const source = readFileSync("scripts/ops/friday-ui-device-proof-readiness.sh", "utf8");
 


### PR DESCRIPTION
## Summary
- Let report-only UI/device gap reports retain real same-run events whose evidence refs are supplemental rather than strict manifest refs.
- Add runner fallback event merging when strict capture-dir assembly blocks, while keeping strict readiness blocked.
- Surface `gapEventStatus` in the shortlist summary for truth labeling.

## Verification
- `bash -n scripts/ops/friday-ui-device-proof-shortlist-runner.sh scripts/ops/friday-ui-device-proof-readiness.sh`
- `npx vitest run test/unit/qa/friday-ui-device-proof-gap-report-cli.test.ts test/unit/qa/friday-ui-device-proof-shortlist-runner-contract.test.ts`
- Real non-channel smoke with desktop AX capture + workbench DB: observed 27 mobile/desktop/timeline rows, blockers=0 in gap report, `captureDirStatus=blocked`, `gapEventStatus=report_only_events_ready`, `readinessStatus=blocked`.

Truth: this is diagnostic/reporting plumbing only. It does not claim END-BAR, GO, adoption, strict UI/device proof, or deferred channel proof.