### PR TITLE
Bind UI device proof capture to exact organic missions

### DIFF
--- a/apps/friday-ios/Tests/FridayMobileShellCoreTests/LiveWriteReadProjectionRoundTripIntegrationTests.swift
+++ b/apps/friday-ios/Tests/FridayMobileShellCoreTests/LiveWriteReadProjectionRoundTripIntegrationTests.swift
@@ -135,6 +135,12 @@ private struct LiveWriteReadMissionIdentity {
 }
 
 private func liveWriteReadMissionIdentity(defaultSurface: String) -> LiveWriteReadMissionIdentity {
+  let rawMissionId = ProcessInfo.processInfo.environment["FRIDAY_MISSION_SPINE_UI_PROOF_MISSION_ID"]?
+    .trimmingCharacters(in: .whitespacesAndNewlines)
+  if let rawMissionId, !rawMissionId.isEmpty {
+    return LiveWriteReadMissionIdentity(id: rawMissionId, missionId: rawMissionId, usesSharedId: true)
+  }
+
   let rawSharedId = ProcessInfo.processInfo.environment["FRIDAY_MISSION_SPINE_UI_PROOF_SHARED_ID"]?
     .trimmingCharacters(in: .whitespacesAndNewlines)
   if let rawSharedId, !rawSharedId.isEmpty {

--- a/apps/macos/FridayHubConsole/Tests/FridayHubConsoleCoreTests/LiveWriteReadProjectionRoundTripIntegrationTests.swift
+++ b/apps/macos/FridayHubConsole/Tests/FridayHubConsoleCoreTests/LiveWriteReadProjectionRoundTripIntegrationTests.swift
@@ -87,6 +87,12 @@ private struct LiveWriteReadMissionIdentity {
 }
 
 private func liveWriteReadMissionIdentity(defaultSurface: String) -> LiveWriteReadMissionIdentity {
+  let rawMissionId = ProcessInfo.processInfo.environment["FRIDAY_MISSION_SPINE_UI_PROOF_MISSION_ID"]?
+    .trimmingCharacters(in: .whitespacesAndNewlines)
+  if let rawMissionId, !rawMissionId.isEmpty {
+    return LiveWriteReadMissionIdentity(id: rawMissionId, missionId: rawMissionId, usesSharedId: true)
+  }
+
   let rawSharedId = ProcessInfo.processInfo.environment["FRIDAY_MISSION_SPINE_UI_PROOF_SHARED_ID"]?
     .trimmingCharacters(in: .whitespacesAndNewlines)
   if let rawSharedId, !rawSharedId.isEmpty {

--- a/scripts/ops/friday-ios-live-write-read-capture.sh
+++ b/scripts/ops/friday-ios-live-write-read-capture.sh
@@ -7,6 +7,7 @@ usage:
   scripts/ops/friday-ios-live-write-read-capture.sh --out-dir /abs/capture-dir
     [--read-host 127.0.0.1] [--read-port 48751]
     [--write-host 127.0.0.1] [--write-port 48750]
+    [--mission-id codex-organic-mission-...]
     [--shared-id mission_ui_device_...]
 
 Runs the env-gated iOS live write->read projection proof, converts the redacted
@@ -30,6 +31,7 @@ read_port="${FRIDAY_MOBILE_LIVE_READ_PORT:-48751}"
 write_host="${FRIDAY_MOBILE_LIVE_WRITE_HOST:-127.0.0.1}"
 write_port="${FRIDAY_MOBILE_LIVE_WRITE_PORT:-48750}"
 shared_id="${FRIDAY_MISSION_SPINE_UI_PROOF_SHARED_ID:-}"
+mission_id="${FRIDAY_MISSION_SPINE_UI_PROOF_MISSION_ID:-}"
 
 while [ "$#" -gt 0 ]; do
   case "$1" in
@@ -87,6 +89,15 @@ while [ "$#" -gt 0 ]; do
       shared_id="${1#--shared-id=}"
       shift
       ;;
+    --mission-id)
+      [ "$#" -ge 2 ] || die "--mission-id requires a value"
+      mission_id="$2"
+      shift 2
+      ;;
+    --mission-id=*)
+      mission_id="${1#--mission-id=}"
+      shift
+      ;;
     --help|-h)
       usage
       exit 0
@@ -105,6 +116,13 @@ esac
 case "${read_port}" in (*[!0-9]*|"") die "--read-port must be numeric" ;; esac
 case "${write_port}" in (*[!0-9]*|"") die "--write-port must be numeric" ;; esac
 case "${shared_id}" in (*[[:space:]]*) die "--shared-id must not contain whitespace" ;; esac
+case "${mission_id}" in (*[[:space:]]*) die "--mission-id must not contain whitespace" ;; esac
+if [ -n "${shared_id}" ] && [ -n "${mission_id}" ]; then
+  die "--mission-id and --shared-id are mutually exclusive"
+fi
+if [ -n "${mission_id}" ]; then
+  case "${mission_id}" in (*mission*) ;; *) die "--mission-id must contain mission" ;; esac
+fi
 
 mkdir -p "${out_dir}"
 proof_path="${out_dir}/ios-live-write-read-proof.json"
@@ -127,6 +145,7 @@ echo "truth=ios_live_write_read_capture_runner_not_ui_device_proof"
   FRIDAY_MOBILE_LIVE_WRITE_HOST="${write_host}" \
   FRIDAY_MOBILE_LIVE_WRITE_PORT="${write_port}" \
   FRIDAY_MISSION_SPINE_UI_PROOF_SHARED_ID="${shared_id}" \
+  FRIDAY_MISSION_SPINE_UI_PROOF_MISSION_ID="${mission_id}" \
     swift test --package-path apps/friday-ios --filter LiveWriteReadProjectionRoundTrip
 )
 

--- a/scripts/ops/friday-macos-live-write-read-capture.sh
+++ b/scripts/ops/friday-macos-live-write-read-capture.sh
@@ -5,6 +5,7 @@ usage() {
   cat >&2 <<'EOF'
 usage:
   scripts/ops/friday-macos-live-write-read-capture.sh --out-dir /abs/capture-dir
+    [--mission-id codex-organic-mission-...]
     [--shared-id mission_ui_device_...]
 
 Runs the env-gated macOS live write->read projection proof, converts the
@@ -25,6 +26,7 @@ die() {
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 out_dir=""
 shared_id="${FRIDAY_MISSION_SPINE_UI_PROOF_SHARED_ID:-}"
+mission_id="${FRIDAY_MISSION_SPINE_UI_PROOF_MISSION_ID:-}"
 
 while [ "$#" -gt 0 ]; do
   case "$1" in
@@ -46,6 +48,15 @@ while [ "$#" -gt 0 ]; do
       shared_id="${1#--shared-id=}"
       shift
       ;;
+    --mission-id)
+      [ "$#" -ge 2 ] || die "--mission-id requires a value"
+      mission_id="$2"
+      shift 2
+      ;;
+    --mission-id=*)
+      mission_id="${1#--mission-id=}"
+      shift
+      ;;
     --help|-h)
       usage
       exit 0
@@ -62,6 +73,13 @@ case "${out_dir}" in
   *) die "--out-dir must be absolute" ;;
 esac
 case "${shared_id}" in (*[[:space:]]*) die "--shared-id must not contain whitespace" ;; esac
+case "${mission_id}" in (*[[:space:]]*) die "--mission-id must not contain whitespace" ;; esac
+if [ -n "${shared_id}" ] && [ -n "${mission_id}" ]; then
+  die "--mission-id and --shared-id are mutually exclusive"
+fi
+if [ -n "${mission_id}" ]; then
+  case "${mission_id}" in (*mission*) ;; *) die "--mission-id must contain mission" ;; esac
+fi
 
 mkdir -p "${out_dir}"
 proof_path="${out_dir}/macos-live-write-read-proof.json"
@@ -78,6 +96,7 @@ echo "truth=macos_live_write_read_capture_runner_not_ui_device_proof"
   FRIDAY_CONSOLE_LIVE_WRITE_READ_ROUNDTRIP_TEST=1 \
   FRIDAY_DESKTOP_LIVE_WRITE_READ_ROUNDTRIP_PROOF_OUT="${proof_path}" \
   FRIDAY_MISSION_SPINE_UI_PROOF_SHARED_ID="${shared_id}" \
+  FRIDAY_MISSION_SPINE_UI_PROOF_MISSION_ID="${mission_id}" \
     swift test --package-path apps/macos/FridayHubConsole --filter LiveWriteReadProjectionRoundTrip
 )
 

--- a/scripts/ops/friday-ui-device-live-write-read-bundle.mjs
+++ b/scripts/ops/friday-ui-device-live-write-read-bundle.mjs
@@ -12,7 +12,7 @@ function usage() {
     --out-dir=/abs/bundle-dir \\
     --mobile-capture-dir=/abs/ios-live-write-read-capture \\
     --desktop-capture-dir=/abs/macos-live-write-read-capture \\
-    [--mission-id=mission_...] [--require-ready]
+    [--mission-id=mission_...] [--exact-mission-id=codex-organic-mission-...] [--require-ready]
 
 Truth: this indexes existing iOS/macOS live write-read capture artifacts into a
 single partial bundle. It does not create channel/timeline/stress observations,
@@ -32,7 +32,8 @@ if (args.includes("--help") || args.includes("-h")) {
 
 const requireReady = args.includes("--require-ready");
 const outDirArg = arg("out-dir");
-const rawExpectedMissionId = arg("mission-id");
+const rawExactExpectedMissionId = arg("exact-mission-id");
+const rawExpectedMissionId = rawExactExpectedMissionId || arg("mission-id");
 const captureDirs = {
   mobile: arg("mobile-capture-dir"),
   desktop: arg("desktop-capture-dir"),
@@ -51,8 +52,9 @@ function sha256(path) {
   return createHash("sha256").update(readFileSync(path)).digest("hex");
 }
 
-function canonicalMissionId(value) {
+function canonicalMissionId(value, exact = false) {
   if (!value) return "";
+  if (exact) return value;
   return value.startsWith("mission_") ? value : `mission_${value}`;
 }
 
@@ -157,7 +159,7 @@ if (outDirArg && !isAbsolute(outDirArg)) block("out_dir_not_absolute", outDirArg
 if (rawExpectedMissionId && !rawExpectedMissionId.toLowerCase().includes("mission")) {
   block("mission_id_unexpected_shape", rawExpectedMissionId);
 }
-const expectedMissionId = canonicalMissionId(rawExpectedMissionId);
+const expectedMissionId = canonicalMissionId(rawExpectedMissionId, Boolean(rawExactExpectedMissionId));
 
 const outDir = outDirArg ? abs(outDirArg) : "";
 const dirs = Object.fromEntries(Object.entries(captureDirs).map(([role, value]) => [role, requireDir(value, `${role}-capture-dir`)]));

--- a/scripts/ops/friday-ui-device-live-write-read-capture-bundle.sh
+++ b/scripts/ops/friday-ui-device-live-write-read-capture-bundle.sh
@@ -5,6 +5,7 @@ usage() {
   cat >&2 <<'EOF'
 usage:
   scripts/ops/friday-ui-device-live-write-read-capture-bundle.sh --out-dir /abs/capture-root
+    [--mission-id codex-organic-mission-...]
     [--shared-id mission_ui_device_...]
     [--read-host 127.0.0.1] [--read-port 48751]
     [--write-host 127.0.0.1] [--write-port 48750]
@@ -40,6 +41,7 @@ read_port="${FRIDAY_MOBILE_LIVE_READ_PORT:-48751}"
 write_host="${FRIDAY_MOBILE_LIVE_WRITE_HOST:-127.0.0.1}"
 write_port="${FRIDAY_MOBILE_LIVE_WRITE_PORT:-48750}"
 shared_id="${FRIDAY_MISSION_SPINE_UI_PROOF_SHARED_ID:-}"
+mission_id="${FRIDAY_MISSION_SPINE_UI_PROOF_MISSION_ID:-}"
 channel_capture=""
 timeline_capture=""
 same_run_events=""
@@ -68,6 +70,15 @@ while [ "$#" -gt 0 ]; do
       ;;
     --shared-id=*)
       shared_id="${1#--shared-id=}"
+      shift
+      ;;
+    --mission-id)
+      [ "$#" -ge 2 ] || die "--mission-id requires a value"
+      mission_id="$2"
+      shift 2
+      ;;
+    --mission-id=*)
+      mission_id="${1#--mission-id=}"
       shift
       ;;
     --read-host)
@@ -202,14 +213,25 @@ done
 set -u
 
 if [ -z "${shared_id}" ]; then
-  shared_id="mission-ui-device-live-write-read-$(date -u +%Y%m%dT%H%M%SZ)-$(uuidgen | tr '[:upper:]' '[:lower:]')"
+  if [ -z "${mission_id}" ]; then
+    shared_id="mission-ui-device-live-write-read-$(date -u +%Y%m%dT%H%M%SZ)-$(uuidgen | tr '[:upper:]' '[:lower:]')"
+  fi
 fi
 case "${shared_id}" in (*[[:space:]]*) die "--shared-id must not contain whitespace" ;; esac
-case "${shared_id}" in (*mission*) ;; *) die "--shared-id must contain mission" ;; esac
-case "${shared_id}" in
-  mission_*) canonical_shared_mission_id="${shared_id}" ;;
-  *) canonical_shared_mission_id="mission_${shared_id}" ;;
-esac
+case "${mission_id}" in (*[[:space:]]*) die "--mission-id must not contain whitespace" ;; esac
+if [ -n "${shared_id}" ] && [ -n "${mission_id}" ]; then
+  die "--mission-id and --shared-id are mutually exclusive"
+fi
+if [ -n "${mission_id}" ]; then
+  case "${mission_id}" in (*mission*) ;; *) die "--mission-id must contain mission" ;; esac
+  canonical_shared_mission_id="${mission_id}"
+else
+  case "${shared_id}" in (*mission*) ;; *) die "--shared-id must contain mission" ;; esac
+  case "${shared_id}" in
+    mission_*) canonical_shared_mission_id="${shared_id}" ;;
+    *) canonical_shared_mission_id="mission_${shared_id}" ;;
+  esac
+fi
 
 mobile_dir="${out_dir}/mobile"
 desktop_dir="${out_dir}/desktop"
@@ -223,7 +245,15 @@ mkdir -p "${out_dir}"
 echo "Friday UI/device live write-read capture bundle starting."
 echo "out_dir=${out_dir}"
 echo "shared_id=${shared_id}"
+echo "mission_id=${mission_id}"
 echo "truth=ui_device_live_write_read_capture_bundle_orchestrator_not_full_proof"
+
+runner_identity_args=()
+if [ -n "${mission_id}" ]; then
+  runner_identity_args+=(--mission-id "${mission_id}")
+else
+  runner_identity_args+=(--shared-id "${shared_id}")
+fi
 
 bash "${repo_root}/scripts/ops/friday-ios-live-write-read-capture.sh" \
   --out-dir "${mobile_dir}" \
@@ -231,18 +261,25 @@ bash "${repo_root}/scripts/ops/friday-ios-live-write-read-capture.sh" \
   --read-port "${read_port}" \
   --write-host "${write_host}" \
   --write-port "${write_port}" \
-  --shared-id "${shared_id}"
+  "${runner_identity_args[@]}"
 
 bash "${repo_root}/scripts/ops/friday-macos-live-write-read-capture.sh" \
   --out-dir "${desktop_dir}" \
-  --shared-id "${shared_id}"
+  "${runner_identity_args[@]}"
 
-node "${repo_root}/scripts/ops/friday-ui-device-live-write-read-bundle.mjs" \
-  --out-dir="${bundle_dir}" \
-  --mobile-capture-dir="${mobile_dir}" \
-  --desktop-capture-dir="${desktop_dir}" \
-  --mission-id="${canonical_shared_mission_id}" \
-  --require-ready
+bundle_args=(
+  "${repo_root}/scripts/ops/friday-ui-device-live-write-read-bundle.mjs"
+  "--out-dir=${bundle_dir}"
+  "--mobile-capture-dir=${mobile_dir}"
+  "--desktop-capture-dir=${desktop_dir}"
+  "--require-ready"
+)
+if [ -n "${mission_id}" ]; then
+  bundle_args+=("--exact-mission-id=${canonical_shared_mission_id}")
+else
+  bundle_args+=("--mission-id=${canonical_shared_mission_id}")
+fi
+node "${bundle_args[@]}"
 
 action_runtime_evidence="${bundle_dir}/action-runtime-evidence.json"
 design_action_report="${bundle_dir}/design-action-runtime-gap.json"

--- a/test/unit/qa/friday-ios-live-write-read-capture-cli.test.ts
+++ b/test/unit/qa/friday-ios-live-write-read-capture-cli.test.ts
@@ -8,8 +8,9 @@ const script = "scripts/ops/friday-ios-live-write-read-capture.sh";
 const missionId = "mission-mobile-live-roundtrip-wrapper";
 const workItemId = "work-mobile-live-roundtrip-wrapper";
 const sharedId = "mission-shared-live-write-read";
+const exactMissionId = "codex-organic-mission-ios-contract";
 
-function fakeSwiftScript(dir: string, proofStatus = "pass", requiredSharedId = "") {
+function fakeSwiftScript(dir: string, proofStatus = "pass", requiredSharedId = "", requiredMissionId = "") {
   const bin = join(dir, "bin");
   mkdirSync(bin, { recursive: true });
   const path = join(bin, "swift");
@@ -18,6 +19,7 @@ set -euo pipefail
 [ "$1" = "test" ] || exit 42
 [ -n "\${FRIDAY_MOBILE_LIVE_WRITE_READ_ROUNDTRIP_PROOF_OUT:-}" ] || exit 43
 if [ -n "${requiredSharedId}" ] && [ "\${FRIDAY_MISSION_SPINE_UI_PROOF_SHARED_ID:-}" != "${requiredSharedId}" ]; then exit 44; fi
+if [ -n "${requiredMissionId}" ] && [ "\${FRIDAY_MISSION_SPINE_UI_PROOF_MISSION_ID:-}" != "${requiredMissionId}" ]; then exit 45; fi
 cat >"\${FRIDAY_MOBILE_LIVE_WRITE_READ_ROUNDTRIP_PROOF_OUT}" <<'JSON'
 {
   "truth_label": "ios_mobile_live_write_read_roundtrip_proof_not_ui_device_proof",
@@ -95,6 +97,30 @@ describe("friday-ios-live-write-read-capture", () => {
     }
   });
 
+  it("passes an exact mission id to the live Swift proof", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "friday-ios-live-capture-exact-mission-"));
+    try {
+      const outDir = join(tempDir, "capture");
+      const fakeBin = fakeSwiftScript(tempDir, "pass", "", exactMissionId);
+      const stdout = execFileSync("bash", [
+        script,
+        `--out-dir=${outDir}`,
+        `--mission-id=${exactMissionId}`,
+      ], {
+        cwd: process.cwd(),
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          PATH: `${fakeBin}:${process.env.PATH ?? ""}`,
+        },
+      });
+
+      expect(stdout).toContain("PASS - mobile live write-read proof");
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
   it("fails closed when the proof-events driver refuses the artifact", () => {
     const tempDir = mkdtempSync(join(tmpdir(), "friday-ios-live-capture-blocked-"));
     try {
@@ -123,5 +149,19 @@ describe("friday-ios-live-write-read-capture", () => {
     });
     expect(result.status).toBe(2);
     expect(result.stderr).toContain("--out-dir must be absolute");
+  });
+
+  it("rejects ambiguous shared and exact mission identity", () => {
+    const result = spawnSync("bash", [
+      script,
+      `--out-dir=${tmpdir()}`,
+      `--shared-id=${sharedId}`,
+      `--mission-id=${exactMissionId}`,
+    ], {
+      cwd: process.cwd(),
+      encoding: "utf8",
+    });
+    expect(result.status).toBe(2);
+    expect(result.stderr).toContain("--mission-id and --shared-id are mutually exclusive");
   });
 });

--- a/test/unit/qa/friday-macos-live-write-read-capture-cli.test.ts
+++ b/test/unit/qa/friday-macos-live-write-read-capture-cli.test.ts
@@ -8,8 +8,9 @@ const script = "scripts/ops/friday-macos-live-write-read-capture.sh";
 const missionId = "mission-desktop-live-roundtrip-wrapper";
 const workItemId = "work-desktop-live-roundtrip-wrapper";
 const sharedId = "mission-shared-live-write-read";
+const exactMissionId = "codex-organic-mission-macos-contract";
 
-function fakeSwiftScript(dir: string, proofStatus = "pass", requiredSharedId = "") {
+function fakeSwiftScript(dir: string, proofStatus = "pass", requiredSharedId = "", requiredMissionId = "") {
   const bin = join(dir, "bin");
   mkdirSync(bin, { recursive: true });
   const path = join(bin, "swift");
@@ -18,6 +19,7 @@ set -euo pipefail
 [ "$1" = "test" ] || exit 42
 [ -n "\${FRIDAY_DESKTOP_LIVE_WRITE_READ_ROUNDTRIP_PROOF_OUT:-}" ] || exit 43
 if [ -n "${requiredSharedId}" ] && [ "\${FRIDAY_MISSION_SPINE_UI_PROOF_SHARED_ID:-}" != "${requiredSharedId}" ]; then exit 44; fi
+if [ -n "${requiredMissionId}" ] && [ "\${FRIDAY_MISSION_SPINE_UI_PROOF_MISSION_ID:-}" != "${requiredMissionId}" ]; then exit 45; fi
 cat >"\${FRIDAY_DESKTOP_LIVE_WRITE_READ_ROUNDTRIP_PROOF_OUT}" <<'JSON'
 {
   "truth_label": "macos_desktop_live_write_read_roundtrip_proof_not_ui_device_proof",
@@ -90,6 +92,30 @@ describe("friday-macos-live-write-read-capture", () => {
     }
   });
 
+  it("passes an exact mission id to the live Swift proof", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "friday-macos-live-capture-exact-mission-"));
+    try {
+      const outDir = join(tempDir, "capture");
+      const fakeBin = fakeSwiftScript(tempDir, "pass", "", exactMissionId);
+      const stdout = execFileSync("bash", [
+        script,
+        `--out-dir=${outDir}`,
+        `--mission-id=${exactMissionId}`,
+      ], {
+        cwd: process.cwd(),
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          PATH: `${fakeBin}:${process.env.PATH ?? ""}`,
+        },
+      });
+
+      expect(stdout).toContain("PASS - desktop live write-read proof");
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
   it("fails closed when the proof-events driver refuses the artifact", () => {
     const tempDir = mkdtempSync(join(tmpdir(), "friday-macos-live-capture-blocked-"));
     try {
@@ -118,5 +144,19 @@ describe("friday-macos-live-write-read-capture", () => {
     });
     expect(result.status).toBe(2);
     expect(result.stderr).toContain("--out-dir must be absolute");
+  });
+
+  it("rejects ambiguous shared and exact mission identity", () => {
+    const result = spawnSync("bash", [
+      script,
+      `--out-dir=${tmpdir()}`,
+      `--shared-id=${sharedId}`,
+      `--mission-id=${exactMissionId}`,
+    ], {
+      cwd: process.cwd(),
+      encoding: "utf8",
+    });
+    expect(result.status).toBe(2);
+    expect(result.stderr).toContain("--mission-id and --shared-id are mutually exclusive");
   });
 });

--- a/test/unit/qa/friday-ui-device-live-write-read-capture-bundle-cli.test.ts
+++ b/test/unit/qa/friday-ui-device-live-write-read-capture-bundle-cli.test.ts
@@ -7,16 +7,23 @@ import { describe, expect, it } from "vitest";
 const script = "scripts/ops/friday-ui-device-live-write-read-capture-bundle.sh";
 const sharedId = "mission-ui-device-live-write-read-test";
 const canonicalMissionId = `mission_${sharedId}`;
+const exactMissionId = "codex-organic-mission-contract";
 const workItemId = "work-ui-device-live-write-read-test";
 
-function fakeSwiftScript(dir: string, expectedSharedId = sharedId) {
+function fakeSwiftScript(
+  dir: string,
+  expectedSharedId = sharedId,
+  expectedMissionId = "",
+  emittedMissionId = canonicalMissionId,
+) {
   const bin = join(dir, "bin");
   mkdirSync(bin, { recursive: true });
   const path = join(bin, "swift");
   writeFileSync(path, `#!/usr/bin/env bash
 set -euo pipefail
 [ "$1" = "test" ] || exit 42
-[ "\${FRIDAY_MISSION_SPINE_UI_PROOF_SHARED_ID:-}" = "${expectedSharedId}" ] || exit 44
+if [ -n "${expectedSharedId}" ] && [ "\${FRIDAY_MISSION_SPINE_UI_PROOF_SHARED_ID:-}" != "${expectedSharedId}" ]; then exit 44; fi
+if [ -n "${expectedMissionId}" ] && [ "\${FRIDAY_MISSION_SPINE_UI_PROOF_MISSION_ID:-}" != "${expectedMissionId}" ]; then exit 45; fi
 if [ -n "\${FRIDAY_MOBILE_LIVE_WRITE_READ_ROUNDTRIP_PROOF_OUT:-}" ]; then
   surface_kind="mobile"
   truth_label="ios_mobile_live_write_read_roundtrip_proof_not_ui_device_proof"
@@ -34,19 +41,19 @@ cat >"\${proof_out}" <<JSON
   "truth_label": "\${truth_label}",
   "status": "pass",
   "generated_at_utc": "2026-06-24T12:00:00Z",
-  "mission_id": "${canonicalMissionId}",
+  "mission_id": "${emittedMissionId}",
   "work_item_id": "${workItemId}",
   "surface_kind": "\${surface_kind}",
   "delivery_route": "\${route}",
   "write": {
     "status": "ready",
     "created_or_ready": true,
-    "mission_id": "${canonicalMissionId}",
+    "mission_id": "${emittedMissionId}",
     "work_item_id": "${workItemId}",
     "endpoint": { "host": "127.0.0.1", "port": 48750 }
   },
   "read_projection": {
-    "mission_id": "${canonicalMissionId}",
+    "mission_id": "${emittedMissionId}",
     "work_item_ids": ["${workItemId}"],
     "contains_written_work_item": true,
     "generated_at_ms": 1782290000000,
@@ -229,6 +236,43 @@ describe("friday-ui-device-live-write-read-capture-bundle", () => {
     }
   });
 
+  it("binds mobile and desktop captures to an exact existing mission id", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "friday-ui-device-orchestrator-exact-mission-"));
+    try {
+      const outDir = join(tempDir, "capture");
+      const fakeBin = fakeSwiftScript(tempDir, "", exactMissionId, exactMissionId);
+
+      const stdout = execFile("bash", [
+        script,
+        `--out-dir=${outDir}`,
+        `--mission-id=${exactMissionId}`,
+      ], {
+        cwd: process.cwd(),
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          PATH: `${fakeBin}:${process.env.PATH ?? ""}`,
+        },
+      });
+
+      expect(stdout).toContain("PASS - same-mission mobile+desktop live write-read capture bundle written");
+      const index = JSON.parse(readFileSync(join(outDir, "bundle", "live-write-read-bundle-index.json"), "utf8")) as {
+        missionId?: string;
+      };
+      expect(index.missionId).toBe(exactMissionId);
+      const mobileProof = JSON.parse(readFileSync(join(outDir, "mobile", "ios-live-write-read-proof.json"), "utf8")) as {
+        mission_id?: string;
+      };
+      const desktopProof = JSON.parse(readFileSync(join(outDir, "desktop", "macos-live-write-read-proof.json"), "utf8")) as {
+        mission_id?: string;
+      };
+      expect(mobileProof.mission_id).toBe(exactMissionId);
+      expect(desktopProof.mission_id).toBe(exactMissionId);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
   it("rejects relative output directories and malformed shared ids before running captures", () => {
     const relative = spawn("bash", [script, "--out-dir=relative"], {
       cwd: process.cwd(),
@@ -243,5 +287,17 @@ describe("friday-ui-device-live-write-read-capture-bundle", () => {
     });
     expect(malformed.status).toBe(2);
     expect(malformed.stderr).toContain("--shared-id must contain mission");
+
+    const ambiguous = spawn("bash", [
+      script,
+      `--out-dir=${tmpdir()}`,
+      `--shared-id=${sharedId}`,
+      `--mission-id=${exactMissionId}`,
+    ], {
+      cwd: process.cwd(),
+      encoding: "utf8",
+    });
+    expect(ambiguous.status).toBe(2);
+    expect(ambiguous.stderr).toContain("--mission-id and --shared-id are mutually exclusive");
   });
 });


### PR DESCRIPTION
## Summary
- add exact `--mission-id` support to the mobile, desktop, and bundled live write-read capture runners
- keep legacy shared-id canonicalization intact while adding an explicit `--exact-mission-id` path for the bundle indexer
- let iOS/macOS live write-read tests bind to an existing mission id without adding a `mission_` prefix

## Truth labels
- This is a partial UI/device proof input only.
- It does not claim END-BAR, GO-LIVE, adoption, channel proof, timeline proof, stress proof, or negative-control completion.
- Channel live proof remains deferred by operator instruction.

## Verification
- `bash -n scripts/ops/friday-ui-device-live-write-read-capture-bundle.sh scripts/ops/friday-ios-live-write-read-capture.sh scripts/ops/friday-macos-live-write-read-capture.sh`
- `npx vitest run test/unit/qa/friday-ui-device-live-write-read-capture-bundle-cli.test.ts test/unit/qa/friday-ui-device-live-write-read-bundle-cli.test.ts test/unit/qa/friday-ios-live-write-read-capture-cli.test.ts test/unit/qa/friday-macos-live-write-read-capture-cli.test.ts`
- `swift test --package-path apps/friday-ios --filter LiveWriteReadProjectionRoundTrip`
- `swift test --package-path apps/macos/FridayHubConsole --filter LiveWriteReadProjectionRoundTrip`
- Real exact-organic smoke:
  - mission: `codex-organic-mission-aef06afa-543e-4cc5-9c8d-3352357ec3fd`
  - output: `/private/tmp/friday-ui-device-exact-organic-bundle-20260626T231318Z`
  - result: `partial_bundle_ready`, blockers `[]`, mobile+desktop action evidence count `2`
  - remaining gaps: channel/timeline/stress/error negative-controls/hidden fallback checks
