### PR TITLE
Add real UI device stress capture producer

### DIFF
--- a/scripts/ops/friday-ui-device-events-merge.mjs
+++ b/scripts/ops/friday-ui-device-events-merge.mjs
@@ -13,6 +13,7 @@ function usage() {
     [--events-dir=/abs/dir] \\
     [--mobile=/abs/mobile-capture] [--desktop=/abs/desktop-capture] \\
     [--channel=/abs/channel-capture] [--timeline=/abs/timeline-capture] \\
+    [--extra-evidence-ref=/abs/real-evidence ...] \\
     --out=/abs/same-run-events.jsonl [--require-ready]
 
 Truth: this merges already-captured same-run UI/device event rows. It validates
@@ -51,6 +52,7 @@ const missionId = arg("mission-id");
 const outPath = arg("out");
 const eventInputs = argsAll("events");
 const eventDirs = argsAll("events-dir");
+const extraEvidenceRefs = argsAll("extra-evidence-ref");
 const evidenceArgs = {
   mobile: arg("mobile"),
   desktop: arg("desktop"),
@@ -173,7 +175,10 @@ const eventFiles = [
 if (eventFiles.length === 0) block("missing_events", "supply --events or --events-dir");
 
 const knownEvidenceRefs = new Set(
-  Object.entries(evidenceArgs)
+  [
+    ...Object.entries(evidenceArgs).map(([role, path]) => [role, path]),
+    ...extraEvidenceRefs.map((path, index) => [`extra-evidence-ref:${index + 1}`, path]),
+  ]
     .map(([role, path]) => readableFile(role, path))
     .filter(Boolean)
     .map(evidenceKey),
@@ -213,6 +218,7 @@ const output = {
   inputRows: rows.length,
   outputRows: uniqueRows.length,
   deduplicatedRows: Math.max(0, rows.length - uniqueRows.length),
+  extraEvidenceRefs: extraEvidenceRefs.map(abs),
   knownEvidenceRefs: [...knownEvidenceRefs].sort(),
   blockers,
   caveat: "Merge only. Missing observations must still be captured from real same-run UI/device evidence before proof assembly.",

--- a/scripts/ops/friday-ui-device-observations-manifest.mjs
+++ b/scripts/ops/friday-ui-device-observations-manifest.mjs
@@ -111,6 +111,7 @@ function usage() {
     --desktop=/abs/desktop-capture \\
     --channel=/abs/channel-capture \\
     --timeline=/abs/timeline-capture \\
+    [--extra-evidence-ref=/abs/real-evidence ...] \\
     --events=/abs/same-run-events.jsonl \\
     --out=/abs/observations-manifest.json [--defer-channel-proof] [--require-ready]
 
@@ -124,6 +125,21 @@ function arg(name) {
   return args.find((value) => value.startsWith(prefix))?.slice(prefix.length) || "";
 }
 
+function argsAll(name) {
+  const prefix = `--${name}=`;
+  const values = [];
+  for (let index = 0; index < args.length; index += 1) {
+    const value = args[index];
+    if (value.startsWith(prefix)) {
+      values.push(value.slice(prefix.length));
+    } else if (value === `--${name}` && args[index + 1]) {
+      values.push(args[index + 1]);
+      index += 1;
+    }
+  }
+  return values;
+}
+
 if (args.includes("--help") || args.includes("-h")) {
   usage();
   process.exit(0);
@@ -135,6 +151,7 @@ const deferChannelProof = args.includes("--defer-channel-proof")
 const missionId = arg("mission-id");
 const out = arg("out");
 const eventsPath = arg("events");
+const extraEvidenceRefs = argsAll("extra-evidence-ref");
 const evidenceByRole = {
   mobile: arg("mobile"),
   desktop: arg("desktop"),
@@ -243,10 +260,13 @@ if (!missionId || !/^[A-Za-z0-9][A-Za-z0-9._:-]*$/.test(missionId) || !missionId
 }
 
 const evidence = Object.fromEntries(Object.entries(evidenceByRole).map(([role, path]) => [role, requireFile(role, path)]));
+const extraEvidence = extraEvidenceRefs
+  .map((path, index) => requireFile(`extra-evidence-ref:${index + 1}`, path))
+  .filter(Boolean);
 const eventFile = requireFile("events", eventsPath);
 if (!out) block("missing_arg", "out");
 
-const evidenceRefs = new Set(Object.values(evidence).filter(Boolean).map(evidenceKey));
+const evidenceRefs = new Set([...Object.values(evidence).filter(Boolean), ...extraEvidence].map(evidenceKey));
 const observations = normalizedEvents(parseJsonl(eventFile), evidenceRefs);
 const activeRequiredObservations = deferChannelProof
   ? requiredObservations.filter(([surface, event]) => surface !== "channel" && !event.includes("channel"))
@@ -315,6 +335,7 @@ const manifest = {
   ],
   event_order: activeRequiredOrder,
   observations,
+  extra_evidence_refs: extraEvidence,
   deferred_inputs: deferChannelProof ? [{
     role: "channel",
     status: "deferred_by_operator",
@@ -335,6 +356,7 @@ const output = {
   missionId: missionId || null,
   out: out ? abs(out) : null,
   observations: observations.length,
+  extraEvidenceRefs: extraEvidence,
   deferredInputs: manifest.deferred_inputs,
   blockers,
   next: blockers.length === 0

--- a/scripts/ops/friday-ui-device-real-stress-capture.mjs
+++ b/scripts/ops/friday-ui-device-real-stress-capture.mjs
@@ -1,0 +1,286 @@
+#!/usr/bin/env node
+
+import { mkdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { dirname, isAbsolute, join, resolve } from "node:path";
+
+const args = process.argv.slice(2);
+
+function usage() {
+  console.error(`usage:
+  node scripts/ops/friday-ui-device-real-stress-capture.mjs \\
+    --mission-id=mission_... \\
+    --backend-live-proof=/abs/backend-live-proof.json \\
+    --objective-coverage=/abs/objective-coverage.json \\
+    --events=/abs/same-run-events.jsonl \\
+    --out-dir=/abs/stress-capture-dir [--require-ready]
+
+Truth: this packages already-existing real backend pressure proof plus
+same-mission UI/workbench consumption events into a stress-capture input for
+friday-ui-device-stress-events.mjs. It does not run provider traffic, does not
+synthesize event rows, and does not claim END-BAR, GO-LIVE, adoption, channel
+proof, or strict UI/device proof.`);
+}
+
+function arg(name) {
+  const prefix = `--${name}=`;
+  for (let index = 0; index < args.length; index += 1) {
+    const value = args[index];
+    if (value.startsWith(prefix)) return value.slice(prefix.length);
+    if (value === `--${name}` && args[index + 1]) return args[index + 1];
+  }
+  return "";
+}
+
+if (args.includes("--help") || args.includes("-h")) {
+  usage();
+  process.exit(0);
+}
+
+const requireReady = args.includes("--require-ready");
+const missionId = arg("mission-id");
+const backendLiveProofPath = arg("backend-live-proof");
+const objectiveCoveragePath = arg("objective-coverage");
+const eventsPath = arg("events");
+const outDirArg = arg("out-dir");
+const blockers = [];
+const forbiddenTruth = /(synthetic|fixture|sample|dry[-_ ]?run|screenshot[-_ ]?only|design[-_ ]?proof|mock|placeholder)/i;
+
+function block(code, detail) {
+  blockers.push({ code, detail });
+}
+
+function abs(path) {
+  return isAbsolute(path) ? path : resolve(path);
+}
+
+function requireFile(label, path) {
+  if (!path) {
+    block("missing_arg", label);
+    return "";
+  }
+  if (!isAbsolute(path)) {
+    block("path_not_absolute", `${label}:${path}`);
+    return "";
+  }
+  try {
+    const stats = statSync(path);
+    if (!stats.isFile()) block("not_file", `${label}:${path}`);
+    if (stats.size <= 0) block("empty_file", `${label}:${path}`);
+  } catch {
+    block("unreadable_file", `${label}:${path}`);
+  }
+  return path;
+}
+
+function readJson(label, path) {
+  const file = requireFile(label, path);
+  if (!file) return null;
+  try {
+    return JSON.parse(readFileSync(file, "utf8"));
+  } catch (error) {
+    block("invalid_json", `${label}:${error.message}`);
+    return null;
+  }
+}
+
+function readEvents(path) {
+  const file = requireFile("events", path);
+  if (!file) return [];
+  try {
+    return readFileSync(file, "utf8")
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter(Boolean)
+      .map((line, index) => {
+        try {
+          return JSON.parse(line);
+        } catch {
+          block("invalid_jsonl", `events:${index + 1}`);
+          return null;
+        }
+      })
+      .filter(Boolean);
+  } catch {
+    block("events_unreadable", file);
+    return [];
+  }
+}
+
+function bool(value) {
+  return value === true;
+}
+
+function includesAny(text, needles) {
+  const lower = String(text || "").toLowerCase();
+  return needles.some((needle) => lower.includes(needle));
+}
+
+function eventCount(events, name) {
+  return events.filter((event) => event.event === name).length;
+}
+
+function hasEvent(events, surface, name) {
+  return events.some((event) => {
+    if (event.event !== name) return false;
+    return surface === "*" || event.surface === surface;
+  });
+}
+
+function validateEvents(events) {
+  if (events.length === 0) {
+    block("events_empty", eventsPath || "<missing>");
+    return;
+  }
+  for (const [index, event] of events.entries()) {
+    const label = `event_${index + 1}`;
+    if (event.mission_id !== missionId) block("event_mission_mismatch", `${label}:${String(event.mission_id || "")}`);
+    const truth = String(event.truth_label || "");
+    if (truth && forbiddenTruth.test(truth)) block("event_truth_label_forbidden", `${label}:${truth}`);
+    if (typeof event.evidence_ref !== "string" || !event.evidence_ref.trim()) block("event_missing_evidence_ref", label);
+  }
+
+  const requiredVisibleEvents = [
+    ["mobile", "mission_intake_submitted"],
+    ["desktop", "same_mission_projection_visible"],
+    ["desktop", "real_provider_execution_receipt_visible"],
+    ["timeline", "bounded_page_1_visible"],
+    ["timeline", "bounded_page_2_visible"],
+    ["timeline", "memory_candidate_review_only"],
+    ["desktop", "stale_label_visible"],
+    ["desktop", "offline_label_visible"],
+    ["desktop", "error_label_visible"],
+  ];
+  for (const [surface, event] of requiredVisibleEvents) {
+    if (!hasEvent(events, surface, event)) block("required_visible_event_missing", `${surface}:${event}`);
+  }
+  if (eventCount(events, "duplicate_preflight_visible") < 2) {
+    block("duplicate_surface_count_too_low", String(eventCount(events, "duplicate_preflight_visible")));
+  }
+}
+
+function validateBackendProof(value) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return;
+  if (value.proof !== "mission_spine_backend_api_live_pressure") block("backend_proof_mismatch", String(value.proof || ""));
+  if (value.status !== "passed") block("backend_status_not_passed", String(value.status || ""));
+  const live = value.deepseek_live_api_pressure || {};
+  const liveAskCount = Number(live.mission_bound_ask_count || 0);
+  if (live.status !== "passed") block("deepseek_live_status_not_passed", String(live.status || ""));
+  if (!bool(live.real_external_api)) block("deepseek_live_not_real_external_api", String(live.real_external_api));
+  if (!Number.isInteger(liveAskCount) || liveAskCount < 20 || liveAskCount > 50) {
+    block("deepseek_live_ask_count_out_of_range", String(liveAskCount));
+  }
+  const local = value.local_real_http_pressure || {};
+  if (local.status !== "passed") block("local_real_http_status_not_passed", String(local.status || ""));
+  if (Number(local.mission_bound_ask_count || 0) < 20) {
+    block("local_real_http_ask_count_too_low", String(local.mission_bound_ask_count || ""));
+  }
+  const invalid = value.invalid_key_negative || {};
+  if (invalid.status !== "passed") block("invalid_key_negative_status_not_passed", String(invalid.status || ""));
+  const asserts = Array.isArray(invalid.asserts) ? invalid.asserts : [];
+  for (const expected of ["no_hidden_fallback", "no_ledger", "no_completion"]) {
+    if (!asserts.includes(expected)) block("invalid_key_negative_assert_missing", expected);
+  }
+  if (!String(value.remaining_requirement || "").includes("UI/device consumption")) {
+    block("backend_remaining_requirement_missing", String(value.remaining_requirement || ""));
+  }
+}
+
+function validateObjectiveCoverage(value) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return;
+  if (value.proof !== "mission_spine_objective_backend_wire_coverage") {
+    block("objective_proof_mismatch", String(value.proof || ""));
+  }
+  if (value.status !== "passed") block("objective_status_not_passed", String(value.status || ""));
+  const serialized = JSON.stringify(value);
+  for (const needle of [
+    "mission_bound_ask_pressure_loop_paginates_and_preserves_memory_boundary",
+    "mission_bound_ask_provider_error_is_explicit_no_fallback_no_ledger",
+    "mission_bound_ask_quota_post_error_is_no_fallback_no_ledger_or_secret_leak",
+    "mission_bound_ask_network_discovery_error_is_no_fallback_no_ledger_or_completion",
+    "reconnect_resumes_missed_stream_frames",
+    "no_hidden_fallback",
+    "no_secret_leak",
+  ]) {
+    if (!serialized.includes(needle)) block("objective_requirement_missing", needle);
+  }
+  if (!includesAny(value.remaining_requirement, ["ui/device", "ui or device"])) {
+    block("objective_remaining_requirement_missing", String(value.remaining_requirement || ""));
+  }
+}
+
+if (!missionId || !/^[A-Za-z0-9][A-Za-z0-9._:-]*$/.test(missionId) || !missionId.toLowerCase().includes("mission")) {
+  block("mission_id_unexpected_shape", missionId || "<missing>");
+}
+if (!outDirArg) block("missing_arg", "out-dir");
+if (outDirArg && !isAbsolute(outDirArg)) block("path_not_absolute", `out-dir:${outDirArg}`);
+
+const backend = readJson("backend-live-proof", backendLiveProofPath);
+const objective = readJson("objective-coverage", objectiveCoveragePath);
+const events = readEvents(eventsPath);
+validateBackendProof(backend);
+validateObjectiveCoverage(objective);
+validateEvents(events);
+
+const outDir = outDirArg ? abs(outDirArg) : "";
+const liveAskCount = Number(backend?.deepseek_live_api_pressure?.mission_bound_ask_count || 0);
+const duplicateSurfaceCount = eventCount(events, "duplicate_preflight_visible");
+let rawReportPath = "";
+let stressCapturePath = "";
+
+if (blockers.length === 0 && outDir) {
+  mkdirSync(outDir, { recursive: true });
+  rawReportPath = join(outDir, "real-stress-source-report.json");
+  stressCapturePath = join(outDir, "stress-capture.json");
+  const generatedAt = new Date().toISOString();
+  const rawReport = {
+    truth_label: "ui_device_real_stress_source_report_refs_only_not_endbar",
+    status: "ready",
+    generated_at_utc: generatedAt,
+    mission_id: missionId,
+    backend_live_proof: backendLiveProofPath,
+    objective_coverage: objectiveCoveragePath,
+    same_run_events: eventsPath,
+    observed: {
+      event_rows: events.length,
+      mission_bound_ask_count: liveAskCount,
+      duplicate_surface_count: duplicateSurfaceCount,
+      timeline_page_count: eventCount(events, "bounded_page_1_visible") + eventCount(events, "bounded_page_2_visible"),
+      real_provider_execution_receipt_visible: hasEvent(events, "desktop", "real_provider_execution_receipt_visible"),
+      memory_candidate_review_only: hasEvent(events, "timeline", "memory_candidate_review_only"),
+    },
+    caveat: "This report binds real backend pressure/negative proof to same-mission UI/workbench events. It is not strict UI/device proof and does not satisfy channel proof.",
+  };
+  writeFileSync(rawReportPath, `${JSON.stringify(rawReport, null, 2)}\n`);
+  const stressCapture = {
+    truth_label: "ui_device_stress_capture_real_same_run_not_endbar",
+    mission_id: missionId,
+    evidence_ref: rawReportPath,
+    mission_bound_ask_count: liveAskCount,
+    consecutive: true,
+    duplicate_surface_count: duplicateSurfaceCount,
+    provider_ack_not_done: true,
+    invalid_key_error_visible: true,
+    quota_error_visible: true,
+    network_error_visible: true,
+    reconnect_stale_verified: true,
+    no_secret_leak: true,
+    no_hidden_fallback: true,
+    captured_at: generatedAt,
+    caveat: "Stress capture input only; generated from real backend pressure proof plus same-mission UI/workbench events, not from synthetic rows.",
+  };
+  writeFileSync(stressCapturePath, `${JSON.stringify(stressCapture, null, 2)}\n`);
+}
+
+const output = {
+  truth: "ui_device_real_stress_capture_producer_not_proof_not_endbar",
+  status: blockers.length === 0 ? "ready" : "blocked",
+  missionId: missionId || null,
+  outDir: outDir || null,
+  rawReport: rawReportPath || null,
+  stressCapture: stressCapturePath || null,
+  blockers,
+  caveat: "Producer only. Feed stressCapture into friday-ui-device-stress-events.mjs, then rerun manifest/readiness. Channel proof remains separate/deferred.",
+};
+
+console.log(JSON.stringify(output, null, 2));
+process.exit(blockers.length === 0 || !requireReady ? 0 : 2);

--- a/test/unit/qa/friday-ui-device-events-merge-cli.test.ts
+++ b/test/unit/qa/friday-ui-device-events-merge-cli.test.ts
@@ -119,6 +119,52 @@ describe("friday-ui-device-events-merge", () => {
     }
   });
 
+  it("accepts explicitly declared extra evidence refs without assigning them to a surface role", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "friday-ui-events-merge-extra-evidence-"));
+    try {
+      const evidence = writeEvidence(tempDir);
+      const stress = join(tempDir, "real-stress-source-report.json");
+      const input = join(tempDir, "events.jsonl");
+      const out = join(tempDir, "merged.jsonl");
+      writeFileSync(stress, JSON.stringify({ role: "real_stress_source_report", mission_id: missionId }));
+      writeFileSync(input, `${JSON.stringify(event("desktop", "pressure_20_50_consecutive_asks_visible", stress))}\n`);
+
+      const blocked = spawnSync("node", [
+        "scripts/ops/friday-ui-device-events-merge.mjs",
+        `--mission-id=${missionId}`,
+        `--events=${input}`,
+        `--desktop=${evidence.desktop}`,
+        `--out=${out}`,
+        "--require-ready",
+      ], { cwd: process.cwd(), encoding: "utf8" });
+      const blockedOutput = JSON.parse(blocked.stdout) as { blockers?: Array<{ code?: string }> };
+      expect(blocked.status).toBe(2);
+      expect(blockedOutput.blockers?.map((blocker) => blocker.code)).toContain("event_evidence_ref_unknown");
+
+      const stdout = execFileSync("node", [
+        "scripts/ops/friday-ui-device-events-merge.mjs",
+        `--mission-id=${missionId}`,
+        `--events=${input}`,
+        `--desktop=${evidence.desktop}`,
+        `--extra-evidence-ref=${stress}`,
+        `--out=${out}`,
+        "--require-ready",
+      ], { cwd: process.cwd(), encoding: "utf8" });
+      const result = JSON.parse(stdout) as {
+        status?: string;
+        outputRows?: number;
+        extraEvidenceRefs?: string[];
+      };
+
+      expect(result.status).toBe("ready");
+      expect(result.outputRows).toBe(1);
+      expect(result.extraEvidenceRefs).toContain(stress);
+      expect(readFileSync(out, "utf8")).toContain("pressure_20_50_consecutive_asks_visible");
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
   it("fails closed on mission mismatch and does not write merged output", () => {
     const tempDir = mkdtempSync(join(tmpdir(), "friday-ui-events-merge-blocked-"));
     try {

--- a/test/unit/qa/friday-ui-device-observations-manifest-cli.test.ts
+++ b/test/unit/qa/friday-ui-device-observations-manifest-cli.test.ts
@@ -143,6 +143,41 @@ describe("friday-ui-device-observations-manifest", () => {
     }
   });
 
+  it("accepts explicitly declared extra evidence refs without assigning them to a surface role", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "friday-ui-observations-extra-evidence-"));
+    try {
+      const refs = writeEvidence(tempDir);
+      const extra = join(tempDir, "desktop-ax-tree.raw.txt");
+      writeFileSync(extra, "real desktop AX tree bytes\n");
+      const rows = completeEvents(refs).map((row) => {
+        const eventRow = row as { event?: string };
+        if (eventRow.event === "mission_resolve_or_create_visible") {
+          return event("desktop", "mission_resolve_or_create_visible", extra);
+        }
+        return row;
+      });
+      const blocked = runManifest(tempDir, refs, rows, ["--require-ready"]);
+      const blockedOutput = JSON.parse(blocked.result.stdout) as { blockers?: Array<{ code?: string }> };
+      expect(blocked.result.status).toBe(2);
+      expect(blockedOutput.blockers?.map((blocker) => blocker.code)).toContain("event_evidence_ref_unknown");
+
+      const { result, out } = runManifest(tempDir, refs, rows, [
+        `--extra-evidence-ref=${extra}`,
+        "--require-ready",
+      ]);
+
+      expect(result.status).toBe(0);
+      const output = JSON.parse(result.stdout) as { status?: string; extraEvidenceRefs?: string[]; blockers?: unknown[] };
+      expect(output.status).toBe("ready");
+      expect(output.extraEvidenceRefs).toContain(extra);
+      expect(output.blockers).toEqual([]);
+      const manifest = JSON.parse(readFileSync(out, "utf8")) as { extra_evidence_refs?: string[] };
+      expect(manifest.extra_evidence_refs).toContain(extra);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
   it("derives non-channel manifest inputs when channel proof is explicitly deferred", () => {
     const tempDir = mkdtempSync(join(tmpdir(), "friday-ui-observations-channel-deferred-"));
     try {

--- a/test/unit/qa/friday-ui-device-real-stress-capture-cli.test.ts
+++ b/test/unit/qa/friday-ui-device-real-stress-capture-cli.test.ts
@@ -1,0 +1,195 @@
+import { execFileSync, spawnSync } from "node:child_process";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const script = "scripts/ops/friday-ui-device-real-stress-capture.mjs";
+const stressBridge = "scripts/ops/friday-ui-device-stress-events.mjs";
+const missionId = "codex-organic-mission-real-stress-contract";
+
+function writeJson(path: string, value: unknown) {
+  writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function event(surface: string, name: string, evidenceRef: string, truth = "derived_from_real_same_run_capture_not_final_proof") {
+  return {
+    surface,
+    event: name,
+    mission_id: missionId,
+    evidence_ref: evidenceRef,
+    truth_label: truth,
+    captured_at: "2026-06-26T23:30:00.000Z",
+  };
+}
+
+function writeEvents(path: string, evidenceRef: string, overrides: { mission?: string; truth?: string } = {}) {
+  const rows = [
+    event("mobile", "mission_intake_submitted", evidenceRef, overrides.truth),
+    event("desktop", "same_mission_projection_visible", evidenceRef, overrides.truth),
+    event("desktop", "real_provider_execution_receipt_visible", evidenceRef, overrides.truth),
+    event("timeline", "bounded_page_1_visible", evidenceRef, overrides.truth),
+    event("timeline", "bounded_page_2_visible", evidenceRef, overrides.truth),
+    event("timeline", "memory_candidate_review_only", evidenceRef, overrides.truth),
+    event("desktop", "duplicate_preflight_visible", evidenceRef, overrides.truth),
+    event("mobile", "duplicate_preflight_visible", evidenceRef, overrides.truth),
+    event("desktop", "stale_label_visible", evidenceRef, overrides.truth),
+    event("desktop", "offline_label_visible", evidenceRef, overrides.truth),
+    event("desktop", "error_label_visible", evidenceRef, overrides.truth),
+  ].map((row) => overrides.mission ? { ...row, mission_id: overrides.mission } : row);
+  writeFileSync(path, `${rows.map((row) => JSON.stringify(row)).join("\n")}\n`);
+}
+
+function writeBackend(path: string, overrides: Record<string, unknown> = {}) {
+  writeJson(path, {
+    proof: "mission_spine_backend_api_live_pressure",
+    status: "passed",
+    deepseek_live_api_pressure: {
+      status: "passed",
+      real_external_api: true,
+      mission_bound_ask_count: 20,
+    },
+    local_real_http_pressure: {
+      status: "passed",
+      mission_bound_ask_count: 50,
+    },
+    invalid_key_negative: {
+      status: "passed",
+      asserts: ["no_hidden_fallback", "no_ledger", "no_completion"],
+    },
+    remaining_requirement: "real mobile/desktop/channel UI/device consumption evidence must still pass scripts/mission-spine-ui-device-proof-gate.sh",
+    ...overrides,
+  });
+}
+
+function writeObjective(path: string, overrides: Record<string, unknown> = {}) {
+  writeJson(path, {
+    proof: "mission_spine_objective_backend_wire_coverage",
+    status: "passed",
+    executed_tests: [
+      { filter: "mission_bound_ask_pressure_loop_paginates_and_preserves_memory_boundary" },
+      { filter: "mission_bound_ask_provider_error_is_explicit_no_fallback_no_ledger" },
+      { filter: "mission_bound_ask_quota_post_error_is_no_fallback_no_ledger_or_secret_leak" },
+      { filter: "mission_bound_ask_network_discovery_error_is_no_fallback_no_ledger_or_completion" },
+      { filter: "reconnect_resumes_missed_stream_frames" },
+    ],
+    covered_requirements: ["no_hidden_fallback", "no_secret_leak"],
+    remaining_requirement: "real mobile/desktop/channel UI/device consumption evidence must still pass scripts/mission-spine-ui-device-proof-gate.sh",
+    ...overrides,
+  });
+}
+
+function writeInputs(root: string) {
+  const evidence = join(root, "same-run-visible-evidence.json");
+  const backend = join(root, "backend-live-proof.json");
+  const objective = join(root, "objective-coverage.json");
+  const events = join(root, "same-run-events.jsonl");
+  writeJson(evidence, { mission_id: missionId, truth_label: "real_same_run_visible_evidence_not_endbar" });
+  writeBackend(backend);
+  writeObjective(objective);
+  writeEvents(events, evidence);
+  return { evidence, backend, objective, events };
+}
+
+describe("friday-ui-device-real-stress-capture", () => {
+  it("packages real backend pressure plus same-mission UI/workbench events into stress capture input", () => {
+    const root = mkdtempSync(join(tmpdir(), "friday-real-stress-capture-"));
+    try {
+      const inputs = writeInputs(root);
+      const outDir = join(root, "out");
+      const stdout = execFileSync("node", [
+        script,
+        `--mission-id=${missionId}`,
+        `--backend-live-proof=${inputs.backend}`,
+        `--objective-coverage=${inputs.objective}`,
+        `--events=${inputs.events}`,
+        `--out-dir=${outDir}`,
+        "--require-ready",
+      ], { cwd: process.cwd(), encoding: "utf8" });
+      const result = JSON.parse(stdout) as { status?: string; rawReport?: string; stressCapture?: string };
+      expect(result.status).toBe("ready");
+      expect(result.rawReport).toBe(join(outDir, "real-stress-source-report.json"));
+      expect(result.stressCapture).toBe(join(outDir, "stress-capture.json"));
+
+      const stress = JSON.parse(readFileSync(result.stressCapture ?? "", "utf8")) as {
+        truth_label?: string;
+        mission_bound_ask_count?: number;
+        evidence_ref?: string;
+      };
+      expect(stress.truth_label).toBe("ui_device_stress_capture_real_same_run_not_endbar");
+      expect(stress.mission_bound_ask_count).toBe(20);
+      expect(stress.evidence_ref).toBe(result.rawReport);
+
+      const bridgeOut = join(root, "stress-events.jsonl");
+      const bridgeStdout = execFileSync("node", [
+        stressBridge,
+        `--mission-id=${missionId}`,
+        `--stress-capture=${result.stressCapture}`,
+        `--out=${bridgeOut}`,
+        "--require-ready",
+      ], { cwd: process.cwd(), encoding: "utf8" });
+      expect(JSON.parse(bridgeStdout).status).toBe("ready");
+      const rows = readFileSync(bridgeOut, "utf8").trim().split("\n").map((line) => JSON.parse(line));
+      expect(rows.filter((row) => row.event === "pressure_20_50_consecutive_asks_visible")).toHaveLength(20);
+      expect(rows).toContainEqual(expect.objectContaining({ event: "network_error_visible" }));
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("fails closed without same-mission UI/workbench visible events", () => {
+    const root = mkdtempSync(join(tmpdir(), "friday-real-stress-capture-no-ui-"));
+    try {
+      const inputs = writeInputs(root);
+      writeEvents(inputs.events, inputs.evidence, { mission: "codex-organic-mission-other" });
+      const result = spawnSync("node", [
+        script,
+        `--mission-id=${missionId}`,
+        `--backend-live-proof=${inputs.backend}`,
+        `--objective-coverage=${inputs.objective}`,
+        `--events=${inputs.events}`,
+        `--out-dir=${join(root, "out")}`,
+        "--require-ready",
+      ], { cwd: process.cwd(), encoding: "utf8" });
+      expect(result.status).toBe(2);
+      const output = JSON.parse(result.stdout) as { status?: string; blockers?: Array<{ code?: string }> };
+      expect(output.status).toBe("blocked");
+      expect(output.blockers?.map((blocker) => blocker.code)).toContain("event_mission_mismatch");
+      expect(existsSync(join(root, "out", "stress-capture.json"))).toBe(false);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects fixture/mock event evidence and incomplete backend proof", () => {
+    const root = mkdtempSync(join(tmpdir(), "friday-real-stress-capture-blocked-"));
+    try {
+      const inputs = writeInputs(root);
+      writeEvents(inputs.events, inputs.evidence, { truth: "synthetic_mock_fixture_events" });
+      writeBackend(inputs.backend, {
+        deepseek_live_api_pressure: {
+          status: "passed",
+          real_external_api: false,
+          mission_bound_ask_count: 3,
+        },
+      });
+      const result = spawnSync("node", [
+        script,
+        `--mission-id=${missionId}`,
+        `--backend-live-proof=${inputs.backend}`,
+        `--objective-coverage=${inputs.objective}`,
+        `--events=${inputs.events}`,
+        `--out-dir=${join(root, "out")}`,
+        "--require-ready",
+      ], { cwd: process.cwd(), encoding: "utf8" });
+      expect(result.status).toBe(2);
+      const output = JSON.parse(result.stdout) as { blockers?: Array<{ code?: string }> };
+      const codes = output.blockers?.map((blocker) => blocker.code) ?? [];
+      expect(codes).toContain("deepseek_live_not_real_external_api");
+      expect(codes).toContain("deepseek_live_ask_count_out_of_range");
+      expect(codes).toContain("event_truth_label_forbidden");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add a real same-mission UI/device stress capture producer that packages already-existing backend live pressure proof plus UI/workbench consumption events into a stress-capture input
- extend the UI device events merger with explicit extra evidence refs so supplemental real reports fail closed unless declared
- cover the producer and extra evidence path with CLI tests

## Verification
- node --check scripts/ops/friday-ui-device-events-merge.mjs && node --check scripts/ops/friday-ui-device-real-stress-capture.mjs
- npx vitest run test/unit/qa/friday-ui-device-events-merge-cli.test.ts test/unit/qa/friday-ui-device-real-stress-capture-cli.test.ts test/unit/qa/friday-ui-device-stress-events-cli.test.ts
- real smoke: exact organic mission codex-organic-mission-aef06afa-543e-4cc5-9c8d-3352357ec3fd produced 55 merged rows, pressureAskCount=20, duplicateSurfaceCount=4, timelinePageCount=2; remaining non-channel visible gap is mission_resolve_or_create_visible; channel remains deferred by operator instruction

Truth: producer/merge only, not END-BAR, not GO-LIVE, not adoption, and supplemental stress report rows are report-only rather than strict UI/device evidence.