### PR TITLE
Expose desktop resolve/create AX proof target

### DIFF
--- a/apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/DesktopProductReadinessContract.swift
+++ b/apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/DesktopProductReadinessContract.swift
@@ -135,7 +135,10 @@ public enum DesktopProductDestinationID: String, CaseIterable, Sendable, Equatab
         title: "Operations Overview",
         systemImage: "gauge.with.dots.needle.bottom.50percent",
         tier: .liveWorkbench,
-        runtimeActionIds: ["desktop/operations/refresh"],
+        runtimeActionIds: [
+          "desktop/operations/refresh",
+          "desktop/operations/mission-resolve-or-create",
+        ],
         blockers: [.init(.needsRuntimeEvidence, label: "same-run user proof")])
     case .chat:
       return contract(

--- a/scripts/ops/friday-desktop-ax-accessibility-capture.mjs
+++ b/scripts/ops/friday-desktop-ax-accessibility-capture.mjs
@@ -99,6 +99,7 @@ function parseDesktopDestinations() {
 
 const defaultActionMap = new Map([
   ["desktop/operations/refresh", { destination: "operations", screen: "operations", accessibility_id: "friday.desktop.refresh", event: "mission_workbench_visible", interaction: "visible" }],
+  ["desktop/operations/mission-resolve-or-create", { destination: "operations", screen: "operations", accessibility_id: "friday.desktop.mission-card", event: "mission_resolve_or_create_visible", interaction: "visible" }],
   ["desktop/fridayChat/act", { destination: "chat", screen: "fridayChat", accessibility_id: "friday.desktop.chat.send", event: "mission_bound_provider_action_visible", interaction: "visible" }],
   ["desktop/fridayChat/check", { destination: "chat", screen: "fridayChat", accessibility_id: "friday.desktop.chat.review", event: "mission_bound_provider_action_visible", interaction: "visible" }],
   ["desktop/session/list", { destination: "session", screen: "session", accessibility_id: "friday.desktop.session-detail", event: "transcript_browser_visible", interaction: "visible" }],

--- a/test/unit/qa/friday-desktop-ax-accessibility-capture-contract.test.ts
+++ b/test/unit/qa/friday-desktop-ax-accessibility-capture-contract.test.ts
@@ -34,6 +34,12 @@ describe("friday-desktop-ax-accessibility-capture contract", () => {
         accessibility_id: "friday.desktop.refresh",
         interaction: "visible",
       }));
+      expect(summary.targets).toContainEqual(expect.objectContaining({
+        runtimeActionId: "desktop/operations/mission-resolve-or-create",
+        accessibility_id: "friday.desktop.mission-card",
+        event: "mission_resolve_or_create_visible",
+        interaction: "visible",
+      }));
     } finally {
       rmSync(outDir, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary
- expose the operations mission card as a desktop runtime action for resolve/create visibility
- map that real macOS Accessibility target to mission_resolve_or_create_visible
- assert the plan-only AX capture includes the new target

## Verification
- node --check scripts/ops/friday-desktop-ax-accessibility-capture.mjs
- npx vitest run test/unit/qa/friday-desktop-ax-accessibility-capture-contract.test.ts
- real macOS AX smoke against exact organic mission codex-organic-mission-aef06afa-543e-4cc5-9c8d-3352357ec3fd: partial_capture_ready, observed_count=2, missing_count=0; normalized event rows include mission_resolve_or_create_visible from friday.desktop.mission-card

Truth: real AX target/capture support only; not END-BAR, not adoption, and channel proof remains deferred by operator instruction.