### PR TITLE
Support role-scoped UI device evidence sets

### DIFF
--- a/scripts/ops/friday-ui-device-capture-dir.mjs
+++ b/scripts/ops/friday-ui-device-capture-dir.mjs
@@ -16,6 +16,9 @@ function usage() {
     --desktop=/abs/desktop-capture \\
     --channel=/abs/channel-capture \\
     --timeline=/abs/timeline-capture \\
+    [--mobile-extra-evidence=/abs/file ...] [--desktop-extra-evidence=/abs/file ...] \\
+    [--channel-extra-evidence=/abs/file ...] [--timeline-extra-evidence=/abs/file ...] \\
+    [--shared-extra-evidence=/abs/file ...] \\
     [--observations-manifest=/abs/observations-manifest.json] \\
     [--events=/abs/same-run-events.jsonl ...] [--events-dir=/abs/events-dir ...] \\
     [--defer-channel-proof] [--require-ready]
@@ -64,6 +67,13 @@ const inputByRole = {
   desktop: arg("desktop"),
   channel: arg("channel"),
   timeline: arg("timeline"),
+};
+const extraInputByRole = {
+  mobile: argsAll("mobile-extra-evidence"),
+  desktop: argsAll("desktop-extra-evidence"),
+  channel: argsAll("channel-extra-evidence"),
+  timeline: argsAll("timeline-extra-evidence"),
+  shared: argsAll("shared-extra-evidence"),
 };
 
 const blockers = [];
@@ -140,9 +150,13 @@ if (!outDir) {
 }
 
 const captures = Object.entries(inputByRole).map(([role, path]) => checkInput(role, path)).filter(Boolean);
+const extraCaptures = Object.entries(extraInputByRole)
+  .flatMap(([role, paths]) => paths.map((path, index) => checkInput(`${role}-extra-${index + 1}`, path)))
+  .filter(Boolean);
 const readyToWrite = blockers.length === 0 && outDir;
 
 let written = [];
+let writtenExtra = [];
 let copiedManifest = "";
 let derivedEvents = "";
 let mergedEvents = "";
@@ -163,6 +177,17 @@ if (readyToWrite) {
       truth: "copied_capture_file_not_proof",
     };
   });
+  writtenExtra = extraCaptures.map((capture) => {
+    const target = join(dir, `${capture.role}${safeExt(capture.source)}`);
+    copyFileSync(capture.source, target);
+    return {
+      ...capture,
+      target,
+      targetName: basename(target),
+      targetSha256: sha256(target),
+      truth: "copied_role_extra_evidence_file_not_proof",
+    };
+  });
 
   if (manifest) {
     const manifestSource = abs(manifest);
@@ -175,7 +200,7 @@ if (readyToWrite) {
     }
   } else if (eventInputs.length > 0 || eventDirs.length > 0) {
     const byRole = Object.fromEntries(written.map((capture) => [capture.role, capture.target]));
-    const sourceToTarget = new Map(written.map((capture) => [capture.source, capture.target]));
+    const sourceToTarget = new Map([...written, ...writtenExtra].map((capture) => [capture.source, capture.target]));
     mergedEvents = join(dir, "same-run-events.merged-source.jsonl");
     derivedEvents = join(dir, "same-run-events.normalized.jsonl");
     copiedManifest = join(dir, "observations-manifest.json");
@@ -189,6 +214,7 @@ if (readyToWrite) {
       "--require-ready",
       ...eventInputs.map((path) => `--events=${path}`),
       ...eventDirs.map((path) => `--events-dir=${path}`),
+      ...extraCaptures.map((capture) => `--extra-evidence-ref=${capture.source}`),
     ];
     if (inputByRole.channel) {
       mergeArgs.splice(4, 0, `--channel=${inputByRole.channel}`);
@@ -208,6 +234,7 @@ if (readyToWrite) {
         `--out=${copiedManifest}`,
         ...(byRole.channel ? [`--channel=${byRole.channel}`] : []),
         ...(deferChannelProof ? ["--defer-channel-proof"] : []),
+        ...writtenExtra.map((capture) => `--extra-evidence-ref=${capture.target}`),
         "--require-ready",
       ], { encoding: "utf8" });
       if (result.status !== 0) {
@@ -228,6 +255,14 @@ if (readyToWrite) {
       sha256: capture.targetSha256,
       bytes: statSync(capture.target).size,
       reusableAsUiDeviceEvidenceInput: true,
+      countsAsProofByItself: false,
+    })),
+    extraCaptures: writtenExtra.map((capture) => ({
+      role: capture.role,
+      path: capture.target,
+      sha256: capture.targetSha256,
+      bytes: statSync(capture.target).size,
+      reusableAsRoleScopedUiDeviceEvidenceInput: true,
       countsAsProofByItself: false,
     })),
     observationsManifest: copiedManifest
@@ -261,6 +296,7 @@ if (readyToWrite) {
     missionId,
     evidenceDir: dir,
     captures: written,
+    extraCaptures: writtenExtra,
     observationsManifest: copiedManifest || null,
     mergedEvents: mergedEvents || null,
     normalizedEvents: derivedEvents || null,
@@ -283,6 +319,10 @@ if (readyToWrite && copiedManifest) {
       caveat: "Strict UI proof input preflight requires channel evidence and was intentionally not claimed.",
     };
   } else {
+    const extraPreflightArgs = writtenExtra.map((capture) => {
+      if (capture.role.startsWith("shared-extra-")) return `--shared-extra-evidence=${capture.target}`;
+      return `--${capture.role.replace(/-extra-\d+$/, "")}-extra-evidence=${capture.target}`;
+    });
     const result = spawnSync(process.execPath, [
       "scripts/qa/check-mission-spine-ui-proof-inputs.mjs",
       `--mission-id=${missionId}`,
@@ -291,6 +331,7 @@ if (readyToWrite && copiedManifest) {
       `--channel=${byRole.channel}`,
       `--timeline=${byRole.timeline}`,
       `--manifest=${copiedManifest}`,
+      ...extraPreflightArgs,
     ], { encoding: "utf8" });
     preflight = {
       status: result.status,
@@ -309,6 +350,7 @@ const output = {
   missionId: missionId || null,
   evidenceDir: outDir ? abs(outDir) : null,
   captures: written,
+  extraCaptures: writtenExtra,
   observationsManifest: copiedManifest || null,
   mergedEvents: mergedEvents || null,
   normalizedEvents: derivedEvents || null,

--- a/scripts/qa/check-mission-spine-ui-proof-inputs.mjs
+++ b/scripts/qa/check-mission-spine-ui-proof-inputs.mjs
@@ -135,6 +135,9 @@ function usage() {
     --desktop=/abs/desktop-evidence \\
     --channel=/abs/channel-evidence \\
     --timeline=/abs/timeline-evidence \\
+    [--mobile-extra-evidence=/abs/file ...] [--desktop-extra-evidence=/abs/file ...] \\
+    [--channel-extra-evidence=/abs/file ...] [--timeline-extra-evidence=/abs/file ...] \\
+    [--shared-extra-evidence=/abs/file ...] \\
     --manifest=/abs/observations-manifest.json
 
 This is a pre-assemble readiness check only. It does not write a
@@ -147,6 +150,23 @@ function argValue(name, envName) {
   const arg = args.find((value) => value.startsWith(prefix));
   if (arg) return arg.slice(prefix.length);
   return process.env[envName] || "";
+}
+
+function argValues(name, envName) {
+  const prefix = `--${name}=`;
+  const values = [];
+  for (let index = 0; index < args.length; index += 1) {
+    const value = args[index];
+    if (value.startsWith(prefix)) {
+      values.push(value.slice(prefix.length));
+    } else if (value === `--${name}` && args[index + 1]) {
+      values.push(args[index + 1]);
+      index += 1;
+    }
+  }
+  const envValue = process.env[envName] || "";
+  if (envValue) values.push(...envValue.split(":").map((value) => value.trim()).filter(Boolean));
+  return values;
 }
 
 function sha256(textOrBuffer) {
@@ -165,6 +185,10 @@ function pathFor(name, envName) {
   const value = argValue(name, envName);
   if (!value) return "";
   return isAbsolute(value) ? value : resolve(value);
+}
+
+function pathsFor(name, envName) {
+  return argValues(name, envName).map((value) => (isAbsolute(value) ? value : resolve(value)));
 }
 
 function evidenceKey(path) {
@@ -273,21 +297,30 @@ function validateKnownEvidenceRef(value, knownEvidenceRefs, failures, code, deta
   }
 }
 
-function expectedEvidenceRefForSurface(surface, evidenceByRole) {
-  if (surface === "mobile") return evidenceByRole.mobile?.path || "";
-  if (surface === "desktop") return evidenceByRole.desktop?.path || "";
-  if (surface === "channel") return evidenceByRole.channel?.path || "";
-  if (surface === "timeline") return evidenceByRole.timeline?.path || "";
-  return "";
+function evidenceRefsForRole(role, evidenceByRole, extraEvidenceByRole) {
+  return [
+    evidenceByRole[role]?.path,
+    ...(extraEvidenceByRole.shared || []).map((entry) => entry.path),
+    ...(extraEvidenceByRole[role] || []).map((entry) => entry.path),
+  ].filter(Boolean);
+}
+
+function expectedEvidenceRefsForSurface(surface, evidenceByRole, extraEvidenceByRole) {
+  if (surface === "mobile") return evidenceRefsForRole("mobile", evidenceByRole, extraEvidenceByRole);
+  if (surface === "desktop") return evidenceRefsForRole("desktop", evidenceByRole, extraEvidenceByRole);
+  if (surface === "channel") return evidenceRefsForRole("channel", evidenceByRole, extraEvidenceByRole);
+  if (surface === "timeline") return evidenceRefsForRole("timeline", evidenceByRole, extraEvidenceByRole);
+  return [];
 }
 
 function validateEvidenceRoleRef(value, expectedValue, failures, code, detail) {
-  if (evidenceKey(value) !== evidenceKey(expectedValue)) {
+  const expectedValues = Array.isArray(expectedValue) ? expectedValue : [expectedValue].filter(Boolean);
+  if (expectedValues.length > 0 && !expectedValues.map(evidenceKey).includes(evidenceKey(value))) {
     recordFailure(failures, code, detail);
   }
 }
 
-function validateMissionWorkbenchManifest(manifest, evidenceByRole, knownEvidenceRefs, failures) {
+function validateMissionWorkbenchManifest(manifest, evidenceByRole, extraEvidenceByRole, knownEvidenceRefs, failures) {
   const workbench = asObject(manifest.mission_workbench);
   if (!workbench) {
     recordFailure(failures, "manifest_missing_mission_workbench", "mission_workbench");
@@ -315,14 +348,14 @@ function validateMissionWorkbenchManifest(manifest, evidenceByRole, knownEvidenc
   );
   validateEvidenceRoleRef(
     workbench.evidence_ref,
-    evidenceByRole.desktop?.path,
+    evidenceRefsForRole("desktop", evidenceByRole, extraEvidenceByRole),
     failures,
     "mission_workbench_evidence_ref_not_desktop",
     String(workbench.evidence_ref || ""),
   );
 }
 
-function validateTranscriptBrowserManifest(manifest, evidenceByRole, knownEvidenceRefs, failures) {
+function validateTranscriptBrowserManifest(manifest, evidenceByRole, extraEvidenceByRole, knownEvidenceRefs, failures) {
   const browser = asObject(manifest.transcript_browser);
   if (!browser) {
     recordFailure(failures, "manifest_missing_transcript_browser", "transcript_browser");
@@ -350,7 +383,7 @@ function validateTranscriptBrowserManifest(manifest, evidenceByRole, knownEviden
   );
   validateEvidenceRoleRef(
     browser.evidence_ref,
-    evidenceByRole.desktop?.path,
+    evidenceRefsForRole("desktop", evidenceByRole, extraEvidenceByRole),
     failures,
     "transcript_browser_evidence_ref_not_desktop",
     String(browser.evidence_ref || ""),
@@ -371,7 +404,7 @@ function validateTranscriptBrowserManifest(manifest, evidenceByRole, knownEviden
   }
 }
 
-function validateManifest(manifestPath, missionId, evidenceByRole, knownEvidenceRefs, failures) {
+function validateManifest(manifestPath, missionId, evidenceByRole, extraEvidenceByRole, knownEvidenceRefs, failures) {
   if (!manifestPath) {
     recordFailure(failures, "missing_manifest_arg", "manifest");
     return null;
@@ -396,8 +429,8 @@ function validateManifest(manifestPath, missionId, evidenceByRole, knownEvidence
     recordFailure(failures, "manifest_marked_non_real", manifestPath);
   }
 
-  validateMissionWorkbenchManifest(manifest, evidenceByRole, knownEvidenceRefs, failures);
-  validateTranscriptBrowserManifest(manifest, evidenceByRole, knownEvidenceRefs, failures);
+  validateMissionWorkbenchManifest(manifest, evidenceByRole, extraEvidenceByRole, knownEvidenceRefs, failures);
+  validateTranscriptBrowserManifest(manifest, evidenceByRole, extraEvidenceByRole, knownEvidenceRefs, failures);
 
   if (!manifest.checks || typeof manifest.checks !== "object") {
     recordFailure(failures, "manifest_missing_checks", manifestPath);
@@ -429,7 +462,7 @@ function validateManifest(manifestPath, missionId, evidenceByRole, knownEvidence
     }
     validateEvidenceRoleRef(
       manifest.stress.evidence_ref,
-      evidenceByRole.timeline?.path,
+      evidenceRefsForRole("timeline", evidenceByRole, extraEvidenceByRole),
       failures,
       "stress_evidence_ref_not_timeline",
       String(manifest.stress.evidence_ref || ""),
@@ -489,11 +522,11 @@ function validateManifest(manifestPath, missionId, evidenceByRole, knownEvidence
     if (!knownEvidenceRefs.has(evidenceKey(observation.evidence_ref))) {
       recordFailure(failures, "observation_evidence_ref_unknown", String(observation.event || "unknown"));
     }
-    const expectedEvidenceRef = expectedEvidenceRefForSurface(observation.surface, evidenceByRole);
-    if (expectedEvidenceRef) {
+    const expectedEvidenceRefs = expectedEvidenceRefsForSurface(observation.surface, evidenceByRole, extraEvidenceByRole);
+    if (expectedEvidenceRefs.length > 0) {
       validateEvidenceRoleRef(
         observation.evidence_ref,
-        expectedEvidenceRef,
+        expectedEvidenceRefs,
         failures,
         "observation_evidence_ref_role_mismatch",
         `${String(observation.event || "unknown")}:${String(observation.surface || "unknown")}`,
@@ -531,14 +564,28 @@ const evidenceArgs = {
   channel: pathFor("channel", "CHANNEL_EVIDENCE"),
   timeline: pathFor("timeline", "TIMELINE_EVIDENCE"),
 };
+const extraEvidenceArgs = {
+  mobile: pathsFor("mobile-extra-evidence", "MOBILE_EXTRA_EVIDENCE"),
+  desktop: pathsFor("desktop-extra-evidence", "DESKTOP_EXTRA_EVIDENCE"),
+  channel: pathsFor("channel-extra-evidence", "CHANNEL_EXTRA_EVIDENCE"),
+  timeline: pathsFor("timeline-extra-evidence", "TIMELINE_EXTRA_EVIDENCE"),
+  shared: pathsFor("shared-extra-evidence", "SHARED_EXTRA_EVIDENCE"),
+};
 const manifestPath = pathFor("manifest", "OBSERVATIONS_MANIFEST");
 
 const evidence = Object.entries(evidenceArgs)
   .map(([role, path]) => validateEvidence(role, path, failures))
   .filter(Boolean);
 const evidenceByRole = Object.fromEntries(evidence.map((entry) => [entry.role, entry]));
-const knownEvidenceRefs = new Set(evidence.map((entry) => evidenceKey(entry.path)));
-validateManifest(manifestPath, missionId, evidenceByRole, knownEvidenceRefs, failures);
+const extraEvidence = Object.entries(extraEvidenceArgs)
+  .flatMap(([role, paths]) => paths.map((path, index) => validateEvidence(`${role}-extra-${index + 1}`, path, failures)))
+  .filter(Boolean);
+const extraEvidenceByRole = Object.fromEntries(Object.keys(extraEvidenceArgs).map((role) => [
+  role,
+  extraEvidence.filter((entry) => entry.role.startsWith(`${role}-extra-`) || entry.role.startsWith(`${role}-shared-extra-`)),
+]));
+const knownEvidenceRefs = new Set([...evidence, ...extraEvidence].map((entry) => evidenceKey(entry.path)));
+validateManifest(manifestPath, missionId, evidenceByRole, extraEvidenceByRole, knownEvidenceRefs, failures);
 
 const readyForAssemble = failures.length === 0;
 const result = {
@@ -546,7 +593,7 @@ const result = {
   proof_source: "pre_assemble_readiness_only_not_ui_device_proof",
   readyForAssemble,
   missionId: missionId || null,
-  evidence,
+  evidence: [...evidence, ...extraEvidence],
   manifestPath: manifestPath || null,
   failures,
 };

--- a/test/unit/qa/friday-ui-device-capture-dir-cli.test.ts
+++ b/test/unit/qa/friday-ui-device-capture-dir-cli.test.ts
@@ -340,6 +340,116 @@ describe("friday-ui-device-capture-dir", () => {
     }
   });
 
+  it("copies role-scoped extra evidence and remaps same-run event refs before preflight", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "friday-ui-capture-dir-extra-evidence-"));
+    try {
+      const captures = writeEvidence(tempDir);
+      const desktopAx = join(tempDir, "desktop-ax-tree.txt");
+      const events = join(tempDir, "same-run-events.jsonl");
+      const outDir = join(tempDir, "evidence");
+      writeFileSync(desktopAx, "real desktop accessibility tree bytes\n");
+      const rows = completeEventRows(captures).map((row) => (
+        row.event === "mission_resolve_or_create_visible"
+          ? observation("desktop", "mission_resolve_or_create_visible", desktopAx)
+          : row
+      ));
+      writeFileSync(events, `${rows.map((row) => JSON.stringify(row)).join("\n")}\n`);
+
+      const stdout = execFileSync("node", [
+        "scripts/ops/friday-ui-device-capture-dir.mjs",
+        `--mission-id=${missionId}`,
+        `--out-dir=${outDir}`,
+        `--mobile=${captures.mobile}`,
+        `--desktop=${captures.desktop}`,
+        `--channel=${captures.channel}`,
+        `--timeline=${captures.timeline}`,
+        `--desktop-extra-evidence=${desktopAx}`,
+        `--events=${events}`,
+        "--require-ready",
+      ], { cwd: process.cwd(), encoding: "utf8" });
+
+      const result = JSON.parse(stdout) as {
+        status?: string;
+        extraCaptures?: Array<{ role?: string; path?: string }>;
+        preflight?: { status?: number };
+      };
+      const copiedAx = join(outDir, "desktop-extra-1.trace");
+      expect(result.status).toBe("ready");
+      expect(result.preflight?.status).toBe(0);
+      expect(result.extraCaptures).toContainEqual(expect.objectContaining({
+        role: "desktop-extra-1",
+        target: copiedAx,
+      }));
+
+      const manifest = JSON.parse(readFileSync(join(outDir, "observations-manifest.json"), "utf8")) as {
+        observations?: Array<{ event?: string; evidence_ref?: string }>;
+      };
+      expect(manifest.observations).toContainEqual(expect.objectContaining({
+        event: "mission_resolve_or_create_visible",
+        evidence_ref: copiedAx,
+      }));
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("copies shared extra evidence for cross-surface stress rows before preflight", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "friday-ui-capture-dir-shared-extra-evidence-"));
+    try {
+      const captures = writeEvidence(tempDir);
+      const stressReport = join(tempDir, "real-stress-source-report.json");
+      const events = join(tempDir, "same-run-events.jsonl");
+      const outDir = join(tempDir, "evidence");
+      writeFileSync(stressReport, "real same-run stress report bytes\n");
+      const rows = completeEventRows(captures).map((row) => (
+        row.event === "pressure_20_50_consecutive_asks_visible" || row.event === "no_hidden_fallback_verified"
+          ? { ...row, evidence_ref: stressReport }
+          : row
+      ));
+      writeFileSync(events, `${rows.map((row) => JSON.stringify(row)).join("\n")}\n`);
+
+      const stdout = execFileSync("node", [
+        "scripts/ops/friday-ui-device-capture-dir.mjs",
+        `--mission-id=${missionId}`,
+        `--out-dir=${outDir}`,
+        `--mobile=${captures.mobile}`,
+        `--desktop=${captures.desktop}`,
+        `--channel=${captures.channel}`,
+        `--timeline=${captures.timeline}`,
+        `--shared-extra-evidence=${stressReport}`,
+        `--events=${events}`,
+        "--require-ready",
+      ], { cwd: process.cwd(), encoding: "utf8" });
+
+      const result = JSON.parse(stdout) as {
+        status?: string;
+        extraCaptures?: Array<{ role?: string; path?: string }>;
+        preflight?: { status?: number };
+      };
+      const copiedStress = join(outDir, "shared-extra-1.json");
+      expect(result.status).toBe("ready");
+      expect(result.preflight?.status).toBe(0);
+      expect(result.extraCaptures).toContainEqual(expect.objectContaining({
+        role: "shared-extra-1",
+        target: copiedStress,
+      }));
+
+      const manifest = JSON.parse(readFileSync(join(outDir, "observations-manifest.json"), "utf8")) as {
+        observations?: Array<{ event?: string; evidence_ref?: string }>;
+      };
+      expect(manifest.observations).toContainEqual(expect.objectContaining({
+        event: "pressure_20_50_consecutive_asks_visible",
+        evidence_ref: copiedStress,
+      }));
+      expect(manifest.observations).toContainEqual(expect.objectContaining({
+        event: "no_hidden_fallback_verified",
+        evidence_ref: copiedStress,
+      }));
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
   it("merges multiple same-run event inputs before deriving the manifest", () => {
     const tempDir = mkdtempSync(join(tmpdir(), "friday-ui-capture-dir-multi-events-"));
     try {

--- a/test/unit/qa/mission-spine-ui-proof-inputs-cli.test.ts
+++ b/test/unit/qa/mission-spine-ui-proof-inputs-cli.test.ts
@@ -254,6 +254,68 @@ describe("check-mission-spine-ui-proof-inputs CLI", () => {
     }
   });
 
+  it("accepts additional role-scoped evidence for the same surface without weakening role checks", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "friday-ui-proof-inputs-extra-role-evidence-"));
+    try {
+      const files = writeEvidenceFiles(tempDir);
+      const desktopAx = join(tempDir, "desktop-ax-tree.txt");
+      writeFileSync(desktopAx, "real desktop accessibility tree bytes\n");
+      const baseManifest = makeManifest(files);
+      const manifest = makeManifest(files, {
+        observations: baseManifest.observations.map((observation) => (
+          observation.event === "mission_resolve_or_create_visible"
+            ? { ...observation, evidence_ref: desktopAx }
+            : observation
+        )),
+      });
+      const manifestPath = join(tempDir, "observations-manifest-extra-role-evidence.json");
+      writeFileSync(manifestPath, JSON.stringify(manifest, null, 2));
+
+      const result = runInputsCli(files, manifestPath, [`--desktop-extra-evidence=${desktopAx}`]);
+
+      expect(result.readyForAssemble).toBe(true);
+      expect(result.failures).toEqual([]);
+      expect(result.evidence.map((entry) => entry.role)).toContain("desktop-extra-1");
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("accepts explicit shared extra evidence for cross-surface stress observations", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "friday-ui-proof-inputs-shared-extra-evidence-"));
+    try {
+      const files = writeEvidenceFiles(tempDir);
+      const stressReport = join(tempDir, "real-stress-source-report.json");
+      writeFileSync(stressReport, "real same-run stress report bytes\n");
+      const baseManifest = makeManifest(files);
+      const manifest = makeManifest(files, {
+        stress: {
+          ...baseManifest.stress,
+          evidence_ref: stressReport,
+        },
+        observations: baseManifest.observations.map((observation) => {
+          if (
+            observation.event === "pressure_20_50_consecutive_asks_visible"
+            || observation.event === "no_hidden_fallback_verified"
+          ) {
+            return { ...observation, evidence_ref: stressReport };
+          }
+          return observation;
+        }),
+      });
+      const manifestPath = join(tempDir, "observations-manifest-shared-extra-evidence.json");
+      writeFileSync(manifestPath, JSON.stringify(manifest, null, 2));
+
+      const result = runInputsCli(files, manifestPath, [`--shared-extra-evidence=${stressReport}`]);
+
+      expect(result.readyForAssemble).toBe(true);
+      expect(result.failures).toEqual([]);
+      expect(result.evidence.map((entry) => entry.role)).toContain("shared-extra-1");
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
   it("fails closed for template or weak manifest inputs in expect-not-ready mode", () => {
     const tempDir = mkdtempSync(join(tmpdir(), "friday-ui-proof-inputs-invalid-"));
     try {


### PR DESCRIPTION
## Summary
- allow strict UI/device preflight to accept role-scoped extra evidence without treating unknown refs as valid
- add explicit shared-extra evidence for real cross-surface stress reports
- copy/remap extra evidence through capture-dir so manifests point at evidence-dir-owned files

## Verification
- node --check scripts/ops/friday-ui-device-capture-dir.mjs
- node --check scripts/qa/check-mission-spine-ui-proof-inputs.mjs
- npx vitest run test/unit/qa/mission-spine-ui-proof-inputs-cli.test.ts test/unit/qa/friday-ui-device-capture-dir-cli.test.ts
- real non-channel rerun: /private/tmp/friday-role-evidence-preflight-shared-20260627T000016Z status=ready, blockers=[]; channel remains deferred and does not count toward END-BAR

## Truth
This is strict evidence plumbing only. It does not claim END-BAR, adoption, GO-LIVE, or channel proof.