### PR TITLE
Clarify deferred channel UI proof blocker

### DIFF
--- a/apps/macos/FridayHubConsole/Tests/FridayHubConsoleCoreTests/OperationsOverviewViewModelTests.swift
+++ b/apps/macos/FridayHubConsole/Tests/FridayHubConsoleCoreTests/OperationsOverviewViewModelTests.swift
@@ -39,6 +39,19 @@ func refreshLoadsRepresentativeSnapshot() async {
       "provider_receipt_refs": snapshot?.providerReceiptRefs ?? [],
     ])
   try? writeDesktopActionEvidenceIfRequested(
+    fileSuffix: "operations-mission-resolve-or-create",
+    screen: "operations",
+    actionId: "desktop/operations/mission-resolve-or-create",
+    capabilityId: "desktop_operations_mission_resolve_or_create_projection",
+    evidenceRef: "swift://desktop/operations/mission-resolve-or-create/mission_workbench_probe_20260605",
+    source: "macos_operations_viewmodel_refresh_runtime",
+    proof: [
+      "mission_id": snapshot?.missionId ?? "",
+      "duplicate_preflight_status": snapshot?.duplicatePreflight.status ?? "",
+      "duplicate_mission_id": snapshot?.duplicatePreflight.duplicateMissionId ?? "",
+      "duplicate_work_item_id": snapshot?.duplicatePreflight.duplicateWorkItemId ?? "",
+    ])
+  try? writeDesktopActionEvidenceIfRequested(
     fileSuffix: "channels-receipts",
     screen: "channels",
     actionId: "desktop/channels/receipts",

--- a/scripts/ops/friday-desktop-chat-memory-action-evidence.sh
+++ b/scripts/ops/friday-desktop-chat-memory-action-evidence.sh
@@ -56,6 +56,7 @@ const files = [
   path.join(outDir, "desktop-memory-confirm-action-evidence.json"),
   path.join(outDir, "desktop-memory-reject-action-evidence.json"),
   path.join(outDir, "desktop-operations-refresh-action-evidence.json"),
+  path.join(outDir, "desktop-operations-mission-resolve-or-create-action-evidence.json"),
   path.join(outDir, "desktop-channels-receipts-action-evidence.json"),
   path.join(outDir, "desktop-channels-surface-events-action-evidence.json"),
   path.join(outDir, "desktop-session-list-action-evidence.json"),
@@ -96,6 +97,7 @@ for (const file of files) {
 
 for (const actionId of [
   "desktop/operations/refresh",
+  "desktop/operations/mission-resolve-or-create",
   "desktop/session/list",
   "desktop/session/open",
   "desktop/session/link",

--- a/scripts/ops/friday-ui-device-proof-readiness.sh
+++ b/scripts/ops/friday-ui-device-proof-readiness.sh
@@ -611,9 +611,11 @@ derive_channel_events_if_possible
 derive_workbench_events_if_possible
 
 have_all_evidence=1
+missing_evidence_env=()
 for name in MISSION_ID MOBILE_EVIDENCE DESKTOP_EVIDENCE CHANNEL_EVIDENCE TIMELINE_EVIDENCE OBSERVATIONS_MANIFEST; do
   if [ -z "${!name:-}" ]; then
     have_all_evidence=0
+    missing_evidence_env+=("$name")
   fi
 done
 
@@ -834,7 +836,11 @@ if [ "${have_all_evidence}" = "1" ]; then
     exit 0
   fi
 else
-  blockers+=("ui_device_proof_evidence:missing_required_real_evidence_env")
+  if [ "${DEFER_CHANNEL_PROOF}" = "1" ] && [ "${#missing_evidence_env[@]}" -eq 1 ] && [ "${missing_evidence_env[0]}" = "CHANNEL_EVIDENCE" ]; then
+    blockers+=("ui_device_proof_evidence:channel_deferred_strict_assembly_blocked")
+  else
+    blockers+=("ui_device_proof_evidence:missing_required_real_evidence_env")
+  fi
 fi
 
 run_gap_report_if_possible

--- a/test/unit/qa/friday-ui-device-proof-readiness-cli.test.ts
+++ b/test/unit/qa/friday-ui-device-proof-readiness-cli.test.ts
@@ -741,6 +741,12 @@ describe("friday-ui-device-proof-readiness", () => {
     const tempDir = mkdtempSync(join(tmpdir(), "friday-ui-device-readiness-defer-channel-"));
     try {
       const files = writePartialEvidenceDir(tempDir);
+      const manifest = join(tempDir, "observations-manifest.json");
+      writeFileSync(manifest, JSON.stringify(makeManifest({
+        ...files,
+        manifest,
+        out: join(tempDir, "assembled-proof.json"),
+      }), null, 2));
       rmSync(files.channel, { force: true });
 
       const stdout = execFileSync("bash", [
@@ -761,7 +767,7 @@ describe("friday-ui-device-proof-readiness", () => {
 
       expect(result.truth).toBe("report_only_not_ui_device_proof");
       expect(result.status).toBe("blocked");
-      expect(result.blockers).toContain("ui_device_proof_evidence:missing_required_real_evidence_env");
+      expect(result.blockers).toContain("ui_device_proof_evidence:channel_deferred_strict_assembly_blocked");
       expect(result.notes?.some((note) => note.includes("ui_device_gap_report:gaps_present"))).toBe(true);
 
       const gapReport = JSON.parse(readFileSync(join(tempDir, "gap-report.json"), "utf8")) as {


### PR DESCRIPTION
## Summary
- clarify strict UI-device proof readiness when the only missing required real evidence is the operator-deferred channel proof
- keep ordinary incomplete evidence on the generic missing-real-evidence blocker
- add desktop operations mission resolve-or-create runtime action evidence to the desktop Chat/Memory action evidence producer

## Verification
- bash -n scripts/ops/friday-ui-device-proof-readiness.sh
- npx vitest run test/unit/qa/friday-ui-device-proof-readiness-cli.test.ts
- FRIDAY_DESKTOP_CHAT_MEMORY_ACTION_EVIDENCE_DIR=/private/tmp/friday-desktop-chat-memory-action-evidence-post1309-verify2 FRIDAY_DESKTOP_CHAT_MEMORY_ACTION_RUNTIME_OUT=/private/tmp/friday-desktop-chat-memory-action-evidence-post1309-verify2/action-runtime-evidence.json bash scripts/ops/friday-desktop-chat-memory-action-evidence.sh
- Product closure recheck with the new action evidence reports productActionsMissingRuntimeEvidence=0 and productActionsMissingDesignRuntimeMissing=0.

## Truth
- This does not complete channel proof; channel remains explicitly deferred by operator instruction.
- This does not claim END-BAR, adoption, release, or a full GUI/device proof.