### PR TITLE
Thread action evidence through UI proof runner

### DIFF
--- a/scripts/ops/friday-ui-device-proof-shortlist-runner.sh
+++ b/scripts/ops/friday-ui-device-proof-shortlist-runner.sh
@@ -461,6 +461,10 @@ for dir in "${runtime_evidence_dirs[@]}"; do
   [ -n "${dir}" ] || continue
   closure_args+=("--runtime-evidence-dir=${dir}")
 done
+for path in "${extra_action_runtime_evidence[@]}"; do
+  [ -n "${path}" ] || continue
+  closure_args+=("--runtime-evidence=${path}")
+done
 set -u
 if [[ "${capture_dir_status}" == ready* ]]; then
   closure_args+=("--evidence-dir=${evidence_dir}")
@@ -483,6 +487,16 @@ fi
 if [ -n "${workbench_db}" ]; then
   readiness_args+=("--workbench-db" "${workbench_db}")
 fi
+set +u
+for dir in "${runtime_evidence_dirs[@]}"; do
+  [ -n "${dir}" ] || continue
+  readiness_args+=("--design-action-runtime-evidence-dir" "${dir}")
+done
+for path in "${extra_action_runtime_evidence[@]}"; do
+  [ -n "${path}" ] || continue
+  readiness_args+=("--design-action-runtime-evidence" "${path}")
+done
+set -u
 if [ "${defer_channel_proof}" = "1" ]; then
   readiness_args+=("--defer-channel-proof")
 fi

--- a/test/unit/qa/friday-ui-device-proof-shortlist-runner-contract.test.ts
+++ b/test/unit/qa/friday-ui-device-proof-shortlist-runner-contract.test.ts
@@ -60,6 +60,14 @@ describe("friday-ui-device-proof-shortlist-runner contract", () => {
     expect(source).toContain("workbenchTimelineStatus");
   });
 
+  it("threads external action-runtime evidence into closure and readiness reports", () => {
+    const source = readFileSync("scripts/ops/friday-ui-device-proof-shortlist-runner.sh", "utf8");
+
+    expect(source).toContain("closure_args+=(\"--runtime-evidence=${path}\")");
+    expect(source).toContain("readiness_args+=(\"--design-action-runtime-evidence-dir\" \"${dir}\")");
+    expect(source).toContain("readiness_args+=(\"--design-action-runtime-evidence\" \"${path}\")");
+  });
+
   it("keeps gap reports useful when strict capture-dir assembly is blocked", () => {
     const source = readFileSync("scripts/ops/friday-ui-device-proof-shortlist-runner.sh", "utf8");
 


### PR DESCRIPTION
## Summary\n- thread external action-runtime evidence files into product closure readiness\n- thread runtime evidence dirs/files into UI device readiness design-action checks\n- add a contract test so runner summaries cannot silently drop supplied evidence\n\n## Verification\n- /Users/jarvis/Projects/Friday/node_modules/.bin/vitest run --project default test/unit/qa/friday-ui-device-proof-shortlist-runner-contract.test.ts\n- FRIDAY_UI_DEVICE_DEFER_CHANNEL_PROOF=1 bash scripts/ops/friday-ui-device-proof-shortlist-runner.sh --out-dir /private/tmp/friday-ui-device-shortlist-runner-evidence-thread-20260627T023539Z --workbench-db "/Users/jarvis/Library/Application Support/Friday/state/rust-hub.sqlite" --runtime-evidence-dir /private/tmp/friday-action-runtime-evidence-bundle-projection-actions-with-approval-verify --extra-action-runtime-evidence /private/tmp/friday-desktop-projection-action-evidence-skills-media-pr1311-recheck/action-runtime-evidence.json --defer-channel-proof\n\nTruth: still partial UI/device proof; this only preserves real supplied action-runtime evidence through reports.