### PR TITLE
Trace canonical UI runtime action evidence

### DIFF
--- a/apps/macos/FridayHubConsole/Tests/FridayHubConsoleCoreTests/LiveWriteReadProjectionRoundTripIntegrationTests.swift
+++ b/apps/macos/FridayHubConsole/Tests/FridayHubConsoleCoreTests/LiveWriteReadProjectionRoundTripIntegrationTests.swift
@@ -202,6 +202,7 @@ private func writeRoundTripProofIfRequested(
         "surface": "desktop",
         "screen": "fridayChat",
         "action_id": "caprow",
+        "runtime_action_id": "desktop/fridayChat/act",
         "capability_id": "ask_friday_chat_compose_send",
         "status": "pass",
         "evidence_ref": rawPath,

--- a/scripts/ops/check-friday-design-action-runtime-evidence.mjs
+++ b/scripts/ops/check-friday-design-action-runtime-evidence.mjs
@@ -338,7 +338,7 @@ function readRuntimeEvidence(path) {
       .map((row) => ({
         surface: String(row.surface || ""),
         screen: String(row.screen || ""),
-        actionId: String(row.action_id || row.actionId || ""),
+        actionId: String(row.runtime_action_id || row.runtimeActionId || row.action_id || row.actionId || ""),
         capabilityId: String(row.capability_id || row.capabilityId || ""),
         status: String(row.status || ""),
         evidenceRef: String(row.evidence_ref || row.evidenceRef || ""),
@@ -354,11 +354,53 @@ function runtimeEvidenceFor(row, runtimeRows) {
     if (candidate.status !== "pass") return false;
     if (candidate.surface && candidate.surface !== row.surface) return false;
     if (candidate.screen && candidate.screen !== row.screen) return false;
-    if (candidate.actionId && row.actionId && candidate.actionId !== row.actionId) return false;
+    const actionMatches = candidate.actionId && row.actionId
+      ? actionIdentity(candidate.surface || row.surface, candidate.screen || row.screen, candidate.actionId)
+        === actionIdentity(row.surface, row.screen, row.actionId)
+      : false;
+    if (candidate.actionId && row.actionId && !actionMatches) return false;
     if (candidate.capabilityId && row.capabilityId) return candidate.capabilityId === row.capabilityId;
-    if (candidate.actionId && row.actionId) return true;
+    if (actionMatches) return true;
     return candidate.capabilityId === row.capabilityId;
   }) || null;
+}
+
+function normalizedToken(value) {
+  return String(value || "").toLowerCase().replace(/[^a-z0-9]/g, "");
+}
+
+function canonicalScreen(screen) {
+  return normalizedToken(screen).replace(/^firstlaunch$/, "firstlaunch");
+}
+
+function canonicalAction(screen, action) {
+  const screenToken = canonicalScreen(screen);
+  let token = normalizedToken(action);
+  if (screenToken && token.startsWith(screenToken)) token = token.slice(screenToken.length);
+  const synonyms = new Map([
+    ["reject", "act"],
+    ["approve", "check"],
+    ["confirm", "check"],
+    ["keep", "check"],
+    ["pairnow", "pairnow"],
+    ["runcontrol", "workflowruncontrol"],
+    ["open", "sidecaropen"],
+    ["close", "sidecarclose"],
+    ["send", "check"],
+    ["checklist", "check"],
+  ]);
+  return synonyms.get(token) || token;
+}
+
+function actionIdentity(surface, screen, action) {
+  if (/^(mobile|desktop)\//i.test(String(action || ""))) return productActionIdentity(action);
+  return `${normalizedToken(surface)}/${canonicalScreen(screen)}/${canonicalAction(screen, action)}`;
+}
+
+function productActionIdentity(actionId) {
+  const parts = String(actionId || "").split("/");
+  const [surface = "", screen = "", ...rest] = parts;
+  return actionIdentity(surface, screen, rest.join("/"));
 }
 
 function summarizeBy(rows, key) {

--- a/scripts/ops/check-friday-uiux-action-traceability.mjs
+++ b/scripts/ops/check-friday-uiux-action-traceability.mjs
@@ -288,7 +288,7 @@ function runtimeActions(paths) {
         path,
         surface: String(row.surface || ""),
         screen: String(row.screen || ""),
-        actionId: String(row.action_id || row.actionId || ""),
+        actionId: String(row.runtime_action_id || row.runtimeActionId || row.action_id || row.actionId || ""),
         capabilityId: String(row.capability_id || row.capabilityId || ""),
         status: String(row.status || ""),
         evidenceRef: String(row.evidence_ref || row.evidenceRef || ""),

--- a/scripts/ops/friday-ios-live-write-read-proof-events.mjs
+++ b/scripts/ops/friday-ios-live-write-read-proof-events.mjs
@@ -89,7 +89,13 @@ function explicitActionRows(value) {
     }
     const surface = typeof row.surface === "string" && row.surface.trim() ? row.surface.trim() : "mobile";
     const screen = typeof row.screen === "string" && row.screen.trim() ? row.screen.trim() : "";
-    const actionId = typeof row.action_id === "string" && row.action_id.trim() ? row.action_id.trim() : "";
+    const rawActionId = typeof row.action_id === "string" && row.action_id.trim() ? row.action_id.trim() : "";
+    const runtimeActionId = typeof row.runtime_action_id === "string" && row.runtime_action_id.trim()
+      ? row.runtime_action_id.trim()
+      : typeof row.runtimeActionId === "string" && row.runtimeActionId.trim()
+        ? row.runtimeActionId.trim()
+        : "";
+    const actionId = runtimeActionId || rawActionId;
     const capabilityId = typeof row.capability_id === "string" && row.capability_id.trim() ? row.capability_id.trim() : "";
     const status = typeof row.status === "string" && row.status.trim() ? row.status.trim() : "";
     const evidence = typeof row.evidence_ref === "string" && row.evidence_ref.trim() ? row.evidence_ref.trim() : evidenceRef;
@@ -101,6 +107,7 @@ function explicitActionRows(value) {
       surface,
       screen,
       action_id: actionId,
+      ...(runtimeActionId && rawActionId && runtimeActionId !== rawActionId ? { source_action_id: rawActionId } : {}),
       capability_id: capabilityId,
       status,
       evidence_ref: evidence,

--- a/scripts/ops/friday-macos-live-write-read-proof-events.mjs
+++ b/scripts/ops/friday-macos-live-write-read-proof-events.mjs
@@ -89,7 +89,13 @@ function explicitActionRows(value) {
     }
     const surface = typeof row.surface === "string" && row.surface.trim() ? row.surface.trim() : "desktop";
     const screen = typeof row.screen === "string" && row.screen.trim() ? row.screen.trim() : "";
-    const actionId = typeof row.action_id === "string" && row.action_id.trim() ? row.action_id.trim() : "";
+    const rawActionId = typeof row.action_id === "string" && row.action_id.trim() ? row.action_id.trim() : "";
+    const runtimeActionId = typeof row.runtime_action_id === "string" && row.runtime_action_id.trim()
+      ? row.runtime_action_id.trim()
+      : typeof row.runtimeActionId === "string" && row.runtimeActionId.trim()
+        ? row.runtimeActionId.trim()
+        : "";
+    const actionId = runtimeActionId || rawActionId;
     const capabilityId = typeof row.capability_id === "string" && row.capability_id.trim() ? row.capability_id.trim() : "";
     const status = typeof row.status === "string" && row.status.trim() ? row.status.trim() : "";
     const evidence = typeof row.evidence_ref === "string" && row.evidence_ref.trim() ? row.evidence_ref.trim() : evidenceRef;
@@ -101,6 +107,7 @@ function explicitActionRows(value) {
       surface,
       screen,
       action_id: actionId,
+      ...(runtimeActionId && rawActionId && runtimeActionId !== rawActionId ? { source_action_id: rawActionId } : {}),
       capability_id: capabilityId,
       status,
       evidence_ref: evidence,

--- a/test/unit/qa/friday-design-action-runtime-evidence-cli.test.ts
+++ b/test/unit/qa/friday-design-action-runtime-evidence-cli.test.ts
@@ -198,7 +198,7 @@ describe("check-friday-design-action-runtime-evidence", () => {
           {
             surface: "desktop",
             screen: "fridayChat",
-            action_id: "check",
+            runtime_action_id: "desktop/fridayChat/check",
             status: "pass",
             evidence_ref: "proof://desktop/approve",
           },

--- a/test/unit/qa/friday-ios-live-write-read-proof-events-cli.test.ts
+++ b/test/unit/qa/friday-ios-live-write-read-proof-events-cli.test.ts
@@ -93,6 +93,7 @@ describe("friday-ios-live-write-read-proof-events", () => {
             surface: "mobile",
             screen: "fridayChat",
             action_id: "chat:typing",
+            runtimeActionId: "mobile/fridayChat/act",
             capability_id: "ask_friday_chat",
             status: "pass",
             evidence_ref: "proof://mobile-chat-send",
@@ -122,7 +123,8 @@ describe("friday-ios-live-write-read-proof-events", () => {
         expect.objectContaining({
           surface: "mobile",
           screen: "fridayChat",
-          action_id: "chat:typing",
+          action_id: "mobile/fridayChat/act",
+          source_action_id: "chat:typing",
           capability_id: "ask_friday_chat",
           status: "pass",
           evidence_ref: "proof://mobile-chat-send",

--- a/test/unit/qa/friday-macos-live-write-read-proof-events-cli.test.ts
+++ b/test/unit/qa/friday-macos-live-write-read-proof-events-cli.test.ts
@@ -92,7 +92,8 @@ describe("friday-macos-live-write-read-proof-events", () => {
           {
             surface: "desktop",
             screen: "fridayChat",
-            action_id: "check",
+            action_id: "caprow",
+            runtime_action_id: "desktop/fridayChat/act",
             capability_id: "security_approval_bound_principal_gate_cat10_netnew",
             status: "pass",
             evidence_ref: "proof://desktop-chat-approve",
@@ -122,7 +123,8 @@ describe("friday-macos-live-write-read-proof-events", () => {
         expect.objectContaining({
           surface: "desktop",
           screen: "fridayChat",
-          action_id: "check",
+          action_id: "desktop/fridayChat/act",
+          source_action_id: "caprow",
           capability_id: "security_approval_bound_principal_gate_cat10_netnew",
           status: "pass",
           evidence_ref: "proof://desktop-chat-approve",

--- a/test/unit/qa/friday-uiux-action-traceability-cli.test.ts
+++ b/test/unit/qa/friday-uiux-action-traceability-cli.test.ts
@@ -125,7 +125,7 @@ describe("check-friday-uiux-action-traceability", () => {
           {
             surface: "mobile",
             screen: "home",
-            action_id: "refresh",
+            runtimeActionId: "mobile/home/refresh",
             capability_id: "transport_connection_state",
             status: "pass",
             evidence_ref: "proof://mobile/home-refresh",


### PR DESCRIPTION
## Summary
- accept canonical runtimeActionId/runtime_action_id in UI runtime evidence readers
- preserve source control action IDs while emitting canonical action IDs from live write/read converters
- add regression coverage so canonical product action IDs satisfy traceability without weakening capability matching

## Verification
- node --check scripts/ops/friday-ios-live-write-read-proof-events.mjs scripts/ops/friday-macos-live-write-read-proof-events.mjs scripts/ops/check-friday-uiux-action-traceability.mjs scripts/ops/check-friday-design-action-runtime-evidence.mjs
- ln -s /Users/jarvis/Projects/Friday/node_modules node_modules && ./node_modules/.bin/vitest run --project default test/unit/qa/friday-ios-live-write-read-proof-events-cli.test.ts test/unit/qa/friday-macos-live-write-read-proof-events-cli.test.ts test/unit/qa/friday-uiux-action-traceability-cli.test.ts test/unit/qa/friday-design-action-runtime-evidence-cli.test.ts; rm node_modules
- old evidence still leaves 57 missing product actions; synthetic canonical desktop/fridayChat/act removes only that product action gap

Truth: this does not claim END-BAR, adoption, channel proof, or old artifact retroactive closure. Existing old evidence remains unchanged and still reports current gaps until a fresh real capture emits canonical runtime action IDs.