### PR TITLE
Wire desktop AX capture into UI real-use driver

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,6 +121,7 @@
     "check:cross-platform-client-ship-gate": "node scripts/ops/check-friday-desktop-release-pipeline.mjs",
     "check:client-design-contract": "node scripts/ops/check-friday-client-design-contract.mjs",
     "check:uiux-native-linkage": "node scripts/ops/check-friday-uiux-native-linkage.mjs",
+    "check:uiux-selected-visual-proof": "node scripts/ops/check-friday-uiux-selected-visual-proof.mjs",
     "check:uiux-action-traceability": "node scripts/ops/check-friday-uiux-action-traceability.mjs",
     "check:uiux-product-closure": "node scripts/ops/friday-uiux-product-closure-readiness.mjs",
     "check:github-channel-proof-readiness": "node scripts/ops/check-friday-github-channel-proof-readiness.mjs",

--- a/scripts/ops/check-friday-uiux-selected-visual-proof.mjs
+++ b/scripts/ops/check-friday-uiux-selected-visual-proof.mjs
@@ -1,0 +1,334 @@
+#!/usr/bin/env node
+
+import { execFileSync } from "node:child_process";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, isAbsolute, resolve } from "node:path";
+
+const args = process.argv.slice(2);
+
+function usage() {
+  console.error(`usage:
+  node scripts/ops/check-friday-uiux-selected-visual-proof.mjs \\
+    [--repo-root=/abs/repo] [--design-root=/abs/friday-design-handoff-20260602] \\
+    [--evidence-dir=/abs/evidence] [--ios-manifest=/abs/ios-design-destination-capture-manifest.json] \\
+    [--desktop-capture=/abs/desktop-ax-accessibility-capture.json] [--out=/abs/report.json] \\
+    [--require-complete]
+
+Truth: checks whether the operator-selected mobile+desktop visual baseline has
+fresh native screenshot/capture evidence. It does not treat static Swift source,
+old proof PNGs, accessibility rows, or action-runtime evidence as visual parity.`);
+}
+
+function arg(name) {
+  const prefix = `--${name}=`;
+  return args.find((value) => value.startsWith(prefix))?.slice(prefix.length) || "";
+}
+
+function argsAll(name) {
+  const prefix = `--${name}=`;
+  const values = [];
+  for (let index = 0; index < args.length; index += 1) {
+    const value = args[index];
+    if (value.startsWith(prefix)) {
+      values.push(value.slice(prefix.length));
+    } else if (value === `--${name}` && args[index + 1]) {
+      values.push(args[index + 1]);
+      index += 1;
+    }
+  }
+  return values;
+}
+
+if (args.includes("--help") || args.includes("-h")) {
+  usage();
+  process.exit(0);
+}
+
+const repoRoot = resolve(arg("repo-root") || process.env.FRIDAY_REPO_ROOT || new URL("../..", import.meta.url).pathname);
+const designRoot = resolve(
+  arg("design-root") ||
+  process.env.FRIDAY_DESIGN_HANDOFF_ROOT ||
+  `${process.env.HOME || "/Users/jarvis"}/Desktop/friday-design-handoff-20260602`,
+);
+const evidenceDirs = [
+  ...argsAll("evidence-dir"),
+  ...(process.env.FRIDAY_UIUX_VISUAL_PROOF_EVIDENCE_DIRS
+    ? process.env.FRIDAY_UIUX_VISUAL_PROOF_EVIDENCE_DIRS.split(/[:\n]/).filter(Boolean)
+    : []),
+].map(abs);
+const iosManifests = [
+  ...argsAll("ios-manifest"),
+  ...(process.env.FRIDAY_UIUX_IOS_VISUAL_MANIFEST
+    ? process.env.FRIDAY_UIUX_IOS_VISUAL_MANIFEST.split(/[:\n]/).filter(Boolean)
+    : []),
+].map(abs);
+const desktopCaptures = [
+  ...argsAll("desktop-capture"),
+  ...(process.env.FRIDAY_UIUX_DESKTOP_VISUAL_CAPTURE
+    ? process.env.FRIDAY_UIUX_DESKTOP_VISUAL_CAPTURE.split(/[:\n]/).filter(Boolean)
+    : []),
+].map(abs);
+const outPath = arg("out") || process.env.FRIDAY_UIUX_SELECTED_VISUAL_PROOF_REPORT || "";
+const requireComplete = args.includes("--require-complete");
+
+const blockers = [];
+const notes = [];
+
+function abs(path) {
+  return isAbsolute(path) ? path : resolve(path);
+}
+
+function block(code, detail) {
+  blockers.push({ code, detail });
+}
+
+function note(code, detail) {
+  notes.push({ code, detail });
+}
+
+function readJson(path, label) {
+  try {
+    return JSON.parse(readFileSync(path, "utf8"));
+  } catch (error) {
+    block("json_unreadable", `${label}:${path}:${error.message}`);
+    return null;
+  }
+}
+
+function selection(surface) {
+  const path = resolve(designRoot, "saved", `${surface}-selection.json`);
+  if (!existsSync(path)) {
+    block("design_selection_missing", path);
+    return { surface, path, status: "missing" };
+  }
+  const value = readJson(path, `${surface}-selection`);
+  const state = value?.state || {};
+  const issues = [];
+  if (value?.operatorConfirmed !== true) issues.push("not_operator_confirmed");
+  if (state.truthLabel !== "designProofOnly") issues.push("truth_label_not_designProofOnly");
+  return {
+    surface,
+    path,
+    status: issues.length === 0 ? "operator_confirmed_design_proof_only" : "invalid",
+    selectionKind: value?.selectionKind || null,
+    state,
+    locked: Array.isArray(value?.locked) ? value.locked : [],
+    issues,
+  };
+}
+
+function currentHead() {
+  try {
+    return execFileSync("git", ["-C", repoRoot, "rev-parse", "HEAD"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+  } catch {
+    note("git_head_unavailable", repoRoot);
+    return null;
+  }
+}
+
+function currentHeadTimeMs() {
+  try {
+    return Date.parse(execFileSync("git", ["-C", repoRoot, "log", "-1", "--format=%cI"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim());
+  } catch {
+    note("git_head_time_unavailable", repoRoot);
+    return null;
+  }
+}
+
+function fileFreshness(paths, headTimeMs) {
+  return paths.map((path) => {
+    if (!existsSync(path)) {
+      return { path, status: "missing" };
+    }
+    const stat = statSync(path);
+    const newerThanHead = typeof headTimeMs === "number" ? stat.mtimeMs >= headTimeMs : null;
+    return {
+      path,
+      status: newerThanHead === false ? "stale_before_head" : "present",
+      mtime: stat.mtime.toISOString(),
+      size: stat.size,
+      newerThanHead,
+    };
+  });
+}
+
+function addEvidenceDir(dir) {
+  if (!existsSync(dir)) return;
+  const ios = resolve(dir, "ios-design-destination-capture-manifest.json");
+  const iosNested = resolve(dir, "ios-design-destination-capture", "ios-design-destination-capture-manifest.json");
+  const desktop = resolve(dir, "desktop-ax-accessibility-capture.json");
+  const desktopNested = resolve(dir, "desktop-ax", "desktop-ax-accessibility-capture.json");
+  const desktopAccessibilityNested = resolve(dir, "desktop-ax-accessibility", "desktop-ax-accessibility-capture.json");
+  if (existsSync(ios)) iosManifests.push(ios);
+  if (existsSync(iosNested)) iosManifests.push(iosNested);
+  if (existsSync(desktop)) desktopCaptures.push(desktop);
+  if (existsSync(desktopNested)) desktopCaptures.push(desktopNested);
+  if (existsSync(desktopAccessibilityNested)) desktopCaptures.push(desktopAccessibilityNested);
+}
+
+for (const dir of evidenceDirs) addEvidenceDir(dir);
+
+function unique(values) {
+  return [...new Set(values)];
+}
+
+const requiredMobileDestinations = [
+  "home",
+  "session",
+  "contextPassport",
+  "tokenLedger",
+  "shareIntake",
+  "voice",
+  "pairing",
+  "providerAuth",
+  "activity",
+  "workflows",
+];
+const requiredDesktopDestinations = [
+  "operations",
+  "chat",
+  "session",
+  "pairingProvisioning",
+  "providerAdmin",
+  "parity",
+  "workflow",
+  "evidence",
+];
+
+function evaluateIosManifest(path) {
+  if (!existsSync(path)) return { path, status: "missing" };
+  const manifest = readJson(path, "ios-manifest");
+  if (!manifest) return { path, status: "invalid" };
+  const captured = new Set((manifest.captures || []).map((capture) => capture.destination));
+  const missing = requiredMobileDestinations.filter((destination) => !captured.has(destination));
+  const truthOk = manifest.truth_label === "ios_selected_design_destination_capture_not_live_closure";
+  const statusOk = manifest.status === "ready";
+  return {
+    path,
+    status: truthOk && statusOk && missing.length === 0 ? "ready" : "gap",
+    truth_label: manifest.truth_label || null,
+    manifest_status: manifest.status || null,
+    generated_at_utc: manifest.generated_at_utc || null,
+    mode: manifest.mode || null,
+    requiredMobileDestinations,
+    capturedDestinations: [...captured],
+    missingDestinations: missing,
+    caveat: manifest.caveat || null,
+  };
+}
+
+function evaluateDesktopCapture(path) {
+  if (!existsSync(path)) return { path, status: "missing" };
+  const capture = readJson(path, "desktop-capture");
+  if (!capture) return { path, status: "invalid" };
+  const normalizeDestination = (value) => value === "fridayChat" ? "chat" : value;
+  const observed = new Set(
+    [
+      ...(capture.observed || []).map((row) => row.destination),
+      ...(capture.ui_actions || []).map((row) => row.screen),
+      ...(capture.destinations || []).filter((value) => typeof value === "string"),
+    ].filter(Boolean).map(normalizeDestination),
+  );
+  const missing = requiredDesktopDestinations.filter((destination) => !observed.has(destination));
+  const truthOk = [
+    "desktop_ax_accessibility_capture_not_screenshot_not_endbar",
+    "ui_device_accessibility_click_capture_real_ui_not_endbar",
+  ].includes(capture.truth_label);
+  const statusOk = ["ready", "partial_capture_ready", undefined, null].includes(capture.status);
+  return {
+    path,
+    status: truthOk && statusOk && missing.length === 0 ? "ready" : "gap",
+    truth_label: capture.truth_label || null,
+    capture_status: capture.status || null,
+    generated_at_utc: capture.generated_at_utc || null,
+    requiredDesktopDestinations,
+    observedDestinations: [...observed],
+    missingDestinations: missing,
+    caveat: capture.caveat || null,
+  };
+}
+
+const mobileSelection = selection("mobile");
+const desktopSelection = selection("desktop");
+const head = currentHead();
+const headTimeMs = currentHeadTimeMs();
+const repoProofFiles = [
+  resolve(repoRoot, "apps/friday-ios/proof/friday-ios-home-honest-unavailable.png"),
+  resolve(repoRoot, "apps/macos/FridayHubConsole/proof/operations-loaded-mock.png"),
+  resolve(repoRoot, "apps/macos/FridayHubConsole/proof/operations-offline.png"),
+  resolve(repoRoot, "apps/macos/FridayHubConsole/proof/operations-unavailable-503.png"),
+];
+const repoProofFreshness = fileFreshness(repoProofFiles, headTimeMs);
+const staleRepoProof = repoProofFreshness.filter((item) => item.status === "missing" || item.status === "stale_before_head");
+if (staleRepoProof.length > 0) {
+  note("repo_committed_screenshot_proofs_not_current_head_visual_pass", `${staleRepoProof.length}/${repoProofFreshness.length}`);
+}
+
+const iosVisualEvidence = unique(iosManifests).map(evaluateIosManifest);
+const desktopVisualEvidence = unique(desktopCaptures).map(evaluateDesktopCapture);
+const iosReady = iosVisualEvidence.some((item) => item.status === "ready");
+const desktopReady = desktopVisualEvidence.some((item) => item.status === "ready");
+
+if (!iosReady) {
+  block(
+    "mobile_selected_visual_proof_missing",
+    "Run proof:ios:design-destinations on current HEAD and pass its ios-design-destination-capture-manifest.json",
+  );
+}
+if (!desktopReady) {
+  block(
+    "desktop_selected_visual_proof_missing",
+    "Run desktop GUI/AX capture on current HEAD with selected desktop destinations and pass desktop-ax-accessibility-capture.json",
+  );
+}
+
+const report = {
+  truth: "selected_uiux_visual_proof_not_static_linkage_not_action_runtime_not_endbar",
+  status: blockers.length === 0 ? "selected_visual_proof_ready" : "selected_visual_proof_gaps_present",
+  repoRoot,
+  designRoot,
+  head,
+  selections: {
+    mobile: mobileSelection,
+    desktop: desktopSelection,
+  },
+  requiredVisualEvidence: {
+    mobile: requiredMobileDestinations,
+    desktop: requiredDesktopDestinations,
+  },
+  evidenceInputs: {
+    evidenceDirs: unique(evidenceDirs),
+    iosManifests: unique(iosManifests),
+    desktopCaptures: unique(desktopCaptures),
+  },
+  evidence: {
+    ios: iosVisualEvidence,
+    desktop: desktopVisualEvidence,
+    committedProofFreshness: repoProofFreshness,
+  },
+  notes,
+  blockers,
+  caveat:
+    "This is the visual-proof gate for the operator-selected UI baseline. It does not claim pixel-perfect parity, live action closure, release, adoption, or END-BAR; it prevents old screenshots/static linkage from being counted as visual PASS.",
+};
+
+if (outPath) {
+  const out = abs(outPath);
+  mkdirSync(dirname(out), { recursive: true });
+  writeFileSync(out, `${JSON.stringify(report, null, 2)}\n`);
+}
+
+console.log(JSON.stringify(report, null, 2));
+process.exit(requireComplete && blockers.length > 0 ? 1 : 0);

--- a/scripts/ops/friday-uiux-product-closure-readiness.mjs
+++ b/scripts/ops/friday-uiux-product-closure-readiness.mjs
@@ -241,6 +241,14 @@ const nativeLinkage = runJson("uiux_native_linkage", process.execPath, [
   `--design-root=${designRoot}`,
   "--require-complete",
 ]);
+const selectedVisualProofArgs = [
+  `${repoRoot}/scripts/ops/check-friday-uiux-selected-visual-proof.mjs`,
+  `--repo-root=${repoRoot}`,
+  `--design-root=${designRoot}`,
+];
+if (evidenceDir) selectedVisualProofArgs.push(`--evidence-dir=${abs(evidenceDir)}`);
+if (requireUiDeviceProof) selectedVisualProofArgs.push("--require-complete");
+const selectedVisualProof = runJson("selected_visual_proof", process.execPath, selectedVisualProofArgs);
 const nativeAction = runJson("native_action_closure", process.execPath, [
   `${repoRoot}/scripts/ops/check-friday-native-action-closure.mjs`,
   repoRoot,
@@ -319,6 +327,7 @@ const readinessReport = uiDeviceReadiness?.parsed || {};
 const traceabilityReport = uiuxTraceability.parsed || {};
 const clientPassed = clientDesign.status === "passed" && clientDesign.parsed?.status === "passed";
 const nativeLinkagePassed = nativeLinkage.status === "passed" && nativeLinkage.parsed?.status === "linked";
+const selectedVisualProofReady = selectedVisualProof.status === "passed" && selectedVisualProof.parsed?.status === "selected_visual_proof_ready";
 const nativePassed = nativeAction.status === "passed" && nativeAction.parsed?.status === "passed";
 const traceabilityPassed = uiuxTraceability.status === "passed" && ["product_runtime_actions_traceable", "traceability_gaps_present"].includes(traceabilityReport.status);
 const runtimeCovered = runtimeReport.status === "runtime_actions_covered";
@@ -326,6 +335,7 @@ const uiDeviceProofAssembled = readinessReport.status === "pass";
 
 if (!clientPassed) block("client_design_contract_failed", String(clientDesign.exitCode));
 if (!nativeLinkagePassed) block("uiux_native_linkage_failed", nativeLinkage.parsed?.status || String(nativeLinkage.exitCode));
+if (requireUiDeviceProof && !selectedVisualProofReady) block("selected_visual_proof_not_ready", selectedVisualProof.parsed?.status || String(selectedVisualProof.exitCode));
 if (!nativePassed) block("native_action_closure_failed", String(nativeAction.exitCode));
 if (!traceabilityPassed) block("uiux_action_traceability_failed", traceabilityReport.status || String(uiuxTraceability.exitCode));
 if (requireRuntimeActions && !runtimeCovered) block("runtime_actions_not_covered", runtimeReport.status || "unknown");
@@ -336,6 +346,9 @@ if (!runtimeCovered) {
 }
 if (!uiDeviceProofAssembled) {
   notes.push("ui_device_full_proof_not_assembled");
+}
+if (!selectedVisualProofReady) {
+  notes.push("selected_visual_proof_gap_present");
 }
 
 const report = {
@@ -364,6 +377,13 @@ const report = {
       counts: nativeLinkage.parsed?.counts || null,
       gaps: nativeLinkage.parsed?.gaps || [],
       caveat: nativeLinkage.parsed?.caveat || "Selected-design native linkage only; not screenshot proof, live tap proof, or END-BAR.",
+    },
+    selectedVisualProof: {
+      status: selectedVisualProof.parsed?.status || selectedVisualProof.status,
+      blockers: selectedVisualProof.parsed?.blockers || [],
+      notes: selectedVisualProof.parsed?.notes || [],
+      evidenceInputs: selectedVisualProof.parsed?.evidenceInputs || null,
+      caveat: selectedVisualProof.parsed?.caveat || "Selected visual proof only; not live action closure, release, adoption, or END-BAR.",
     },
     nativeActionClosure: {
       status: nativeAction.parsed?.status || nativeAction.status,
@@ -398,6 +418,11 @@ const report = {
     ...(uiDeviceProofAssembled ? [] : [{
       target: "ui-device-proof",
       action: "supply same-run mobile, desktop, channel, timeline, observations manifest, and stress/negative-control evidence to friday-ui-device-proof-readiness.sh",
+    }]),
+    ...(selectedVisualProofReady ? [] : [{
+      target: "selected-visual-proof",
+      action: "capture fresh current-HEAD native mobile destination screenshots and desktop visual/accessibility capture for the operator-selected baseline; static Swift linkage and old proof PNGs do not close visual parity",
+      blockers: selectedVisualProof.parsed?.blockers || [],
     }]),
   ],
   notes,

--- a/scripts/ops/friday-uiux-real-use-proof-driver.sh
+++ b/scripts/ops/friday-uiux-real-use-proof-driver.sh
@@ -6,12 +6,19 @@ usage() {
 usage:
   scripts/ops/friday-uiux-real-use-proof-driver.sh --out-dir /abs/run-dir
     [--shared-id mission_ui_device_...]
+    [--mission-id mission_...]
     [--accessibility-capture /abs/real-accessibility-capture.json ...]
+    [--run-desktop-ax-capture]
+    [--desktop-ax-destinations operations,chat,...]
+    [--desktop-ax-app-dir /abs/FridayHubConsole.app]
+    [--desktop-ax-workbench-mission-id mission_...]
+    [--desktop-ax-timeout-seconds 20]
     [--backend-live-proof /abs/backend-proof.json]
     [--objective-coverage /abs/objective-coverage.json]
     [--channel-live-proof /abs/channel-live-proof.json]
     [--channel-capture /abs/channel-capture.json]
     [--timeline-capture /abs/timeline-capture.json]
+    [--workbench-db /abs/rust-hub.sqlite]
     [--harvest-dir /abs/artifact-dir ...]
     [--same-run-events /abs/events.jsonl ...]
     [--runtime-evidence-dir /abs/evidence-dir ...]
@@ -24,7 +31,7 @@ Runs the current fastest honest UI/UX real-use proof chain:
   1. selected-design native linkage gate
   2. optional action-runtime evidence bundle
   3. mobile+desktop live write/read capture bundle
-  4. optional real accessibility click capture normalization
+  4. optional real desktop Accessibility capture and real accessibility click capture normalization
   5. strict UI/device readiness and product-closure reports
 
 Truth:
@@ -41,12 +48,19 @@ die() {
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 out_dir=""
 shared_id="${FRIDAY_MISSION_SPINE_UI_PROOF_SHARED_ID:-}"
+mission_id_arg="${FRIDAY_MISSION_SPINE_UI_PROOF_MISSION_ID:-}"
 backend_live_proof="${FRIDAY_UI_DEVICE_BACKEND_LIVE_PROOF:-}"
 objective_coverage="${FRIDAY_UI_DEVICE_OBJECTIVE_COVERAGE:-}"
 channel_live_proof="${FRIDAY_UI_DEVICE_CHANNEL_LIVE_PROOF:-}"
 channel_capture="${FRIDAY_UI_DEVICE_CHANNEL_CAPTURE:-}"
 timeline_capture="${FRIDAY_UI_DEVICE_TIMELINE_CAPTURE:-}"
+workbench_db="${FRIDAY_WORKBENCH_DB_PATH:-}"
 defer_channel_proof="${FRIDAY_UI_DEVICE_DEFER_CHANNEL_PROOF:-0}"
+run_desktop_ax_capture="${FRIDAY_UIUX_RUN_DESKTOP_AX_CAPTURE:-0}"
+desktop_ax_destinations="${FRIDAY_DESKTOP_AX_CAPTURE_DESTINATIONS:-}"
+desktop_ax_app_dir="${FRIDAY_DESKTOP_AX_APP_DIR:-}"
+desktop_ax_workbench_mission_id="${FRIDAY_DESKTOP_AX_WORKBENCH_MISSION_ID:-}"
+desktop_ax_timeout_seconds="${FRIDAY_DESKTOP_AX_CAPTURE_TIMEOUT_SECONDS:-20}"
 plan_only=0
 skip_action_bundle=0
 accessibility_captures=()
@@ -79,6 +93,15 @@ while [ "$#" -gt 0 ]; do
       shared_id="${1#--shared-id=}"
       shift
       ;;
+    --mission-id)
+      [ "$#" -ge 2 ] || die "--mission-id requires a value"
+      mission_id_arg="$2"
+      shift 2
+      ;;
+    --mission-id=*)
+      mission_id_arg="${1#--mission-id=}"
+      shift
+      ;;
     --accessibility-capture)
       [ "$#" -ge 2 ] || die "--accessibility-capture requires a value"
       accessibility_captures+=("$2")
@@ -86,6 +109,46 @@ while [ "$#" -gt 0 ]; do
       ;;
     --accessibility-capture=*)
       accessibility_captures+=("${1#--accessibility-capture=}")
+      shift
+      ;;
+    --run-desktop-ax-capture)
+      run_desktop_ax_capture=1
+      shift
+      ;;
+    --desktop-ax-destinations)
+      [ "$#" -ge 2 ] || die "--desktop-ax-destinations requires a value"
+      desktop_ax_destinations="$2"
+      shift 2
+      ;;
+    --desktop-ax-destinations=*)
+      desktop_ax_destinations="${1#--desktop-ax-destinations=}"
+      shift
+      ;;
+    --desktop-ax-app-dir)
+      [ "$#" -ge 2 ] || die "--desktop-ax-app-dir requires a value"
+      desktop_ax_app_dir="$2"
+      shift 2
+      ;;
+    --desktop-ax-app-dir=*)
+      desktop_ax_app_dir="${1#--desktop-ax-app-dir=}"
+      shift
+      ;;
+    --desktop-ax-workbench-mission-id)
+      [ "$#" -ge 2 ] || die "--desktop-ax-workbench-mission-id requires a value"
+      desktop_ax_workbench_mission_id="$2"
+      shift 2
+      ;;
+    --desktop-ax-workbench-mission-id=*)
+      desktop_ax_workbench_mission_id="${1#--desktop-ax-workbench-mission-id=}"
+      shift
+      ;;
+    --desktop-ax-timeout-seconds)
+      [ "$#" -ge 2 ] || die "--desktop-ax-timeout-seconds requires a value"
+      desktop_ax_timeout_seconds="$2"
+      shift 2
+      ;;
+    --desktop-ax-timeout-seconds=*)
+      desktop_ax_timeout_seconds="${1#--desktop-ax-timeout-seconds=}"
       shift
       ;;
     --backend-live-proof)
@@ -131,6 +194,15 @@ while [ "$#" -gt 0 ]; do
       ;;
     --timeline-capture=*)
       timeline_capture="${1#--timeline-capture=}"
+      shift
+      ;;
+    --workbench-db)
+      [ "$#" -ge 2 ] || die "--workbench-db requires a value"
+      workbench_db="$2"
+      shift 2
+      ;;
+    --workbench-db=*)
+      workbench_db="${1#--workbench-db=}"
       shift
       ;;
     --harvest-dir)
@@ -197,6 +269,20 @@ case "${out_dir}" in
   *) die "--out-dir must be absolute" ;;
 esac
 case "${shared_id}" in (*[[:space:]]*) die "--shared-id must not contain whitespace" ;; esac
+case "${mission_id_arg}" in (*[[:space:]]*) die "--mission-id must not contain whitespace" ;; esac
+if [ -n "${shared_id}" ] && [ -n "${mission_id_arg}" ]; then
+  die "--shared-id and --mission-id are mutually exclusive"
+fi
+if [ -n "${mission_id_arg}" ]; then
+  case "${mission_id_arg}" in (*mission*) ;; *) die "--mission-id must contain mission" ;; esac
+fi
+case "${run_desktop_ax_capture}" in
+  0|1|false|true) ;;
+  *) die "FRIDAY_UIUX_RUN_DESKTOP_AX_CAPTURE must be 0/1/false/true" ;;
+esac
+if ! [[ "${desktop_ax_timeout_seconds}" =~ ^[0-9]+$ ]] || [[ "${desktop_ax_timeout_seconds}" -lt 5 ]]; then
+  die "--desktop-ax-timeout-seconds must be an integer >= 5"
+fi
 
 require_abs_if_set() {
   local label="$1"
@@ -228,10 +314,28 @@ require_file_if_set "--objective-coverage" "${objective_coverage}"
 require_file_if_set "--channel-live-proof" "${channel_live_proof}"
 require_file_if_set "--channel-capture" "${channel_capture}"
 require_file_if_set "--timeline-capture" "${timeline_capture}"
+require_file_if_set "--workbench-db" "${workbench_db}"
+if [ -n "${desktop_ax_app_dir}" ]; then
+  require_abs_if_set "--desktop-ax-app-dir" "${desktop_ax_app_dir}"
+fi
+
+if [ -z "${shared_id}" ] && [ -z "${mission_id_arg}" ]; then
+  shared_id="mission-uiux-real-use-$(date -u +%Y%m%dT%H%M%SZ)-$(uuidgen | tr '[:upper:]' '[:lower:]')"
+fi
+if [ -n "${mission_id_arg}" ]; then
+  canonical_mission_id="${mission_id_arg}"
+else
+  case "${shared_id}" in
+    mission_*) canonical_mission_id="${shared_id}" ;;
+    *) canonical_mission_id="mission_${shared_id}" ;;
+  esac
+fi
 
 mkdir -p "${out_dir}"
 native_linkage_out="${out_dir}/uiux-native-linkage.json"
 action_bundle_dir="${out_dir}/action-runtime-bundle"
+desktop_ax_dir="${out_dir}/desktop-ax-accessibility"
+desktop_ax_capture_out="${desktop_ax_dir}/desktop-ax-accessibility-capture.json"
 shortlist_dir="${out_dir}/ui-device-shortlist"
 driver_summary="${out_dir}/uiux-real-use-proof-driver-summary.json"
 
@@ -281,12 +385,38 @@ if [ "${skip_action_bundle}" -eq 0 ]; then
   runtime_evidence_dirs+=("${action_bundle_dir}")
 fi
 
+case "${run_desktop_ax_capture}" in
+  1|true)
+    desktop_ax_args=(
+      "${repo_root}/scripts/ops/friday-desktop-ax-accessibility-capture.mjs"
+      "--mission-id=${canonical_mission_id}"
+      "--out-dir=${desktop_ax_dir}"
+      "--timeout-seconds=${desktop_ax_timeout_seconds}"
+      "--require-observed"
+    )
+    if [ -n "${desktop_ax_destinations}" ]; then
+      desktop_ax_args+=("--destinations=${desktop_ax_destinations}")
+    fi
+    if [ -n "${desktop_ax_app_dir}" ]; then
+      desktop_ax_args+=("--app-dir=${desktop_ax_app_dir}")
+    fi
+    if [ -n "${desktop_ax_workbench_mission_id}" ]; then
+      desktop_ax_args+=("--workbench-mission-id=${desktop_ax_workbench_mission_id}")
+    fi
+    node "${desktop_ax_args[@]}"
+    accessibility_captures+=("${desktop_ax_capture_out}")
+    ;;
+esac
+
 shortlist_args=(
   "${repo_root}/scripts/ops/friday-ui-device-proof-shortlist-runner.sh"
   "--out-dir" "${shortlist_dir}"
 )
 if [ -n "${shared_id}" ]; then
   shortlist_args+=("--shared-id" "${shared_id}")
+fi
+if [ -n "${mission_id_arg}" ]; then
+  shortlist_args+=("--mission-id" "${mission_id_arg}")
 fi
 if [ -n "${backend_live_proof}" ]; then
   shortlist_args+=("--backend-live-proof" "${backend_live_proof}")
@@ -302,6 +432,9 @@ if [ -n "${channel_capture}" ]; then
 fi
 if [ -n "${timeline_capture}" ]; then
   shortlist_args+=("--timeline-capture" "${timeline_capture}")
+fi
+if [ -n "${workbench_db}" ]; then
+  shortlist_args+=("--workbench-db" "${workbench_db}")
 fi
 if [ "${defer_channel_proof}" = "1" ]; then
   shortlist_args+=("--defer-channel-proof")
@@ -331,9 +464,9 @@ set -u
 
 bash "${shortlist_args[@]}"
 
-node - "${driver_summary}" "${native_linkage_out}" "${shortlist_dir}/ui-device-shortlist-summary.json" "${action_bundle_dir}/action-runtime-evidence-bundle-index.json" <<'NODE'
+node - "${driver_summary}" "${native_linkage_out}" "${shortlist_dir}/ui-device-shortlist-summary.json" "${action_bundle_dir}/action-runtime-evidence-bundle-index.json" "${desktop_ax_capture_out}" <<'NODE'
 const fs = require("node:fs");
-const [summaryPath, nativePath, shortlistPath, actionBundlePath] = process.argv.slice(2);
+const [summaryPath, nativePath, shortlistPath, actionBundlePath, desktopAxCapturePath] = process.argv.slice(2);
 function readJson(path) {
   try {
     return JSON.parse(fs.readFileSync(path, "utf8"));
@@ -356,6 +489,7 @@ const summary = {
   outputs: {
     nativeLinkage: nativePath,
     actionRuntimeBundle: fs.existsSync(actionBundlePath) ? actionBundlePath : null,
+    desktopAccessibilityCapture: fs.existsSync(desktopAxCapturePath) ? desktopAxCapturePath : null,
     uiDeviceShortlist: shortlistPath,
   },
   caveat: "END-BAR requires strict UI/device readiness with real mobile, desktop, channel, timeline, stress, and negative-control evidence. This driver does not fabricate missing evidence or claim adoption.",

--- a/test/unit/qa/friday-uiux-real-use-proof-driver-contract.test.ts
+++ b/test/unit/qa/friday-uiux-real-use-proof-driver-contract.test.ts
@@ -41,7 +41,16 @@ describe("friday-uiux-real-use-proof-driver contract", () => {
 
     expect(source).toContain("check-friday-uiux-native-linkage.mjs");
     expect(source).toContain("friday-action-runtime-evidence-bundle.sh");
+    expect(source).toContain("friday-desktop-ax-accessibility-capture.mjs");
     expect(source).toContain("friday-ui-device-proof-shortlist-runner.sh");
+    expect(source).toContain("--run-desktop-ax-capture");
+    expect(source).toContain("FRIDAY_UIUX_RUN_DESKTOP_AX_CAPTURE:-0");
+    expect(source).toContain("workbench_db=\"${FRIDAY_WORKBENCH_DB_PATH:-}\"");
+    expect(source).toContain("shortlist_args+=(\"--workbench-db\" \"${workbench_db}\")");
+    expect(source).toContain("--mission-id=${canonical_mission_id}");
+    expect(source).toContain("desktop_ax_capture_out=\"${desktop_ax_dir}/desktop-ax-accessibility-capture.json\"");
+    expect(source).toContain("accessibility_captures+=(\"${desktop_ax_capture_out}\")");
+    expect(source).toContain("desktopAccessibilityCapture");
     expect(source).toContain("--accessibility-capture");
     expect(source).toContain("--defer-channel-proof");
     expect(source).toContain("defer_channel_proof=\"${FRIDAY_UI_DEVICE_DEFER_CHANNEL_PROOF:-0}\"");

--- a/test/unit/qa/friday-uiux-selected-visual-proof-cli.test.ts
+++ b/test/unit/qa/friday-uiux-selected-visual-proof-cli.test.ts
@@ -1,0 +1,142 @@
+import { execFileSync, spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const script = "scripts/ops/check-friday-uiux-selected-visual-proof.mjs";
+
+function writeFile(root: string, relative: string, body: string) {
+  const target = join(root, relative);
+  mkdirSync(dirname(target), { recursive: true });
+  writeFileSync(target, body);
+  return target;
+}
+
+function writeSelections(designRoot: string) {
+  writeFile(designRoot, "saved/mobile-selection.json", JSON.stringify({
+    surface: "mobile",
+    selectionKind: "mobile-final (operator-confirmed 2026-06-04)",
+    operatorConfirmed: true,
+    state: {
+      truthLabel: "designProofOnly",
+      palette: "cyanCoral",
+      form: "glassNative",
+      petStyle: "retroLcd",
+      homeLayout: "chatStatus",
+    },
+    locked: ["Chat + Status home"],
+  }, null, 2));
+  writeFile(designRoot, "saved/desktop-selection.json", JSON.stringify({
+    surface: "desktop",
+    selectionKind: "desktop-final (operator-confirmed 2026-06-09)",
+    operatorConfirmed: true,
+    state: {
+      truthLabel: "designProofOnly",
+      palette: "cyanCoral",
+      form: "glassNative",
+      layout: "threePane",
+    },
+    locked: ["Desktop localhost remains Hub Console"],
+  }, null, 2));
+}
+
+function fixture() {
+  const root = mkdtempSync(join(tmpdir(), "friday-uiux-selected-visual-proof-"));
+  const designRoot = join(root, "design");
+  writeSelections(designRoot);
+  return { root, designRoot };
+}
+
+function writeReadyEvidence(root: string) {
+  const evidence = join(root, "evidence");
+  writeFile(evidence, "ios-design-destination-capture-manifest.json", JSON.stringify({
+    truth_label: "ios_selected_design_destination_capture_not_live_closure",
+    status: "ready",
+    generated_at_utc: "2026-06-27T00:00:00.000Z",
+    mode: "live-loopback",
+    captures: [
+      "home",
+      "session",
+      "contextPassport",
+      "tokenLedger",
+      "shareIntake",
+      "voice",
+      "pairing",
+      "providerAuth",
+      "activity",
+      "workflows",
+    ].map((destination) => ({ destination, status: "captured", screenshot: `${destination}.png` })),
+  }, null, 2));
+  writeFile(evidence, "desktop-ax-accessibility-capture.json", JSON.stringify({
+    truth_label: "ui_device_accessibility_click_capture_real_ui_not_endbar",
+    ui_actions: [
+      "operations",
+      "chat",
+      "session",
+      "pairingProvisioning",
+      "providerAdmin",
+      "parity",
+      "workflow",
+      "evidence",
+    ].map((screen) => ({ screen, status: "pass", runtimeActionId: `desktop/${screen}/check` })),
+  }, null, 2));
+  return evidence;
+}
+
+describe("check-friday-uiux-selected-visual-proof", () => {
+  it("reports missing selected visual proof without failing default mode", () => {
+    const { root, designRoot } = fixture();
+    try {
+      const output = execFileSync("node", [
+        script,
+        `--repo-root=${root}`,
+        `--design-root=${designRoot}`,
+      ], { cwd: process.cwd(), encoding: "utf8" });
+      const report = JSON.parse(output) as { status?: string; blockers?: Array<{ code?: string }> };
+      expect(report.status).toBe("selected_visual_proof_gaps_present");
+      expect(report.blockers).toEqual(expect.arrayContaining([
+        expect.objectContaining({ code: "mobile_selected_visual_proof_missing" }),
+        expect.objectContaining({ code: "desktop_selected_visual_proof_missing" }),
+      ]));
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("fails closed in require-complete mode when visual proof is missing", () => {
+    const { root, designRoot } = fixture();
+    try {
+      const result = spawnSync("node", [
+        script,
+        `--repo-root=${root}`,
+        `--design-root=${designRoot}`,
+        "--require-complete",
+      ], { cwd: process.cwd(), encoding: "utf8" });
+      expect(result.status).toBe(1);
+      const report = JSON.parse(result.stdout) as { status?: string };
+      expect(report.status).toBe("selected_visual_proof_gaps_present");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("passes when current selected mobile and desktop visual evidence is present", () => {
+    const { root, designRoot } = fixture();
+    try {
+      const evidence = writeReadyEvidence(root);
+      const output = execFileSync("node", [
+        script,
+        `--repo-root=${root}`,
+        `--design-root=${designRoot}`,
+        `--evidence-dir=${evidence}`,
+        "--require-complete",
+      ], { cwd: process.cwd(), encoding: "utf8" });
+      const report = JSON.parse(output) as { status?: string; blockers?: unknown[] };
+      expect(report.status).toBe("selected_visual_proof_ready");
+      expect(report.blockers).toEqual([]);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add optional `--run-desktop-ax-capture` support to the UI/UX real-use proof driver
- pass explicit mission IDs and workbench DB through the driver so desktop AX, live write/read, timeline, and shortlist evidence bind to the same run
- surface the desktop AX artifact path in the driver summary
- add `check-friday-uiux-selected-visual-proof.mjs` and wire it into product-closure readiness so selected mobile/desktop visual parity cannot be inferred from static Swift linkage, old proof PNGs, accessibility rows, or action-runtime evidence

## Verification
- `bash -n scripts/ops/friday-uiux-real-use-proof-driver.sh`
- `./node_modules/.bin/vitest run --project default test/unit/qa/friday-uiux-real-use-proof-driver-contract.test.ts test/unit/qa/friday-desktop-ax-accessibility-capture-contract.test.ts`
- `./node_modules/.bin/vitest run --project default test/unit/qa/friday-uiux-selected-visual-proof-cli.test.ts test/unit/qa/friday-uiux-real-use-proof-driver-contract.test.ts test/unit/qa/friday-uiux-native-linkage-cli.test.ts`
- `npm run check:uiux-selected-visual-proof -- --repo-root=/private/tmp/friday-endbar-current-20260627 --design-root=/Users/jarvis/Desktop/friday-design-handoff-20260602` reports the expected current gaps: missing mobile current-HEAD design-destination manifest and incomplete desktop selected visual capture
- real smoke: `friday-uiux-real-use-proof-driver.sh --skip-action-bundle --run-desktop-ax-capture --desktop-ax-destinations operations,chat --defer-channel-proof --workbench-db ...` produced 4 real desktop AX observations and partial same-mission mobile+desktop live write/read evidence

Truth: this improves real GUI/AX proof orchestration and prevents visual-parity overclaiming. It does not claim selected-design visual parity is done, strict UI/device proof, END-BAR, adoption, or channel proof.
