### PR TITLE
Align selected mobile UI proof

### DIFF
--- a/apps/friday-ios/Sources/FridayMobileShell/FridayApp.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayApp.swift
@@ -409,7 +409,7 @@ struct RootView: View {
           FridayProjectionScreen(destination: destination, viewModel: homeVM)
         }
       }
-      .navigationTitle(destination.title)
+      .navigationTitle(destination == .home ? "Friday" : destination.title)
       .navigationBarTitleDisplayMode(.inline)
       .toolbar {
         // Top-LEFT: the Command Sheet launcher (locked: commandSheet from top-left).

--- a/apps/friday-ios/Sources/FridayMobileShell/FridayHomeScreen.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayHomeScreen.swift
@@ -30,14 +30,22 @@ struct FridayHomeScreen: View {
       VStack(spacing: 16) {
         switch viewModel.state {
         case .idle, .loading:
-          loadingHeader
-          HeroPet().padding(.top, 4)
+          designIntro(
+            title: greetingTitle,
+            subtitle: "Reading Friday's live projection.")
+          selectedHomeHero
           loadingView
         case .loaded(let projection):
           loadedContent(projection)
         case let .unavailable(reason):
-          unavailableHeader
-          offlineCommandCenter(reason: reason)
+          designIntro(
+            title: greetingTitle,
+            subtitle: "Friday will not show cached or fabricated status.")
+          selectedHomeHero
+          UnavailableView(
+            reason: reason,
+            title: "Hub offline",
+            detail: "Live connection is not set up yet.")
           unavailableQueueSection(
             title: "Needs Me",
             emptyText: "Connect Friday to see approvals, memory candidates, and recovery items.")
@@ -67,22 +75,6 @@ struct FridayHomeScreen: View {
     }
   }
 
-  private var loadingHeader: some View {
-    homeHeader(
-      hubLabel: "Hub loading",
-      hubOnline: false,
-      title: greetingTitle,
-      subtitle: "Reading Friday's live projection.")
-  }
-
-  private var unavailableHeader: some View {
-    homeHeader(
-      hubLabel: "Hub offline",
-      hubOnline: false,
-      title: greetingTitle,
-      subtitle: "Friday will not show cached or fabricated status.")
-  }
-
   private var loadingView: some View {
     VStack(spacing: 12) {
       ProgressView()
@@ -97,18 +89,16 @@ struct FridayHomeScreen: View {
   /// truth labels ride AS-IS; never a fabricated ready view.
   @ViewBuilder
   private func loadedContent(_ projection: HomeProjection) -> some View {
-    homeHeader(
-      hubLabel: projection.statusLabels.isEmpty ? "Hub live" : "Hub flagged",
-      hubOnline: projection.statusLabels.isEmpty,
+    designIntro(
       title: greetingTitle,
       subtitle: "Here is what Friday is watching for you.")
+    selectedHomeHero
 
     // Honest status banner — any stale/offline/error label rides AS truth.
     if !projection.statusLabels.isEmpty {
       StatusBanner(labels: projection.statusLabels)
     }
 
-    attentionHero(projection)
     commandQueueSection(title: "Needs Me", rows: needsRows(projection), emptyText: "No approval, memory, or recovery items need action.")
     commandQueueSection(title: "Running", rows: runningRows(projection), emptyText: "No active Friday work is visible in this projection.")
     if projection.isLoadedEmpty {
@@ -118,6 +108,29 @@ struct FridayHomeScreen: View {
     refsCard(projection)
   }
 
+  /// The selected mobile home starts with a quiet greeting, then the bare Hero Pet stage.
+  /// It must not become an engineering diagnostic header; proof/truth details live below.
+  private func designIntro(title: String, subtitle: String) -> some View {
+    VStack(alignment: .leading, spacing: 6) {
+      Text(title)
+        .font(.system(size: 30, weight: .bold))
+        .foregroundStyle(MobileTheme.textPrimary)
+      Text(subtitle)
+        .font(.callout)
+        .foregroundStyle(MobileTheme.textSecondary)
+        .fixedSize(horizontal: false, vertical: true)
+    }
+    .frame(maxWidth: .infinity, alignment: .leading)
+    .accessibilityElement(children: .combine)
+    .accessibilityLabel("\(title). \(subtitle)")
+    .accessibilityIdentifier("friday.home.selected-design-intro")
+  }
+
+  private var selectedHomeHero: some View {
+    HeroPet()
+      .accessibilityIdentifier("friday.home.selected-hero-pet")
+  }
+
   private var greetingTitle: String {
     let hour = Calendar.current.component(.hour, from: Date())
     switch hour {
@@ -125,123 +138,6 @@ struct FridayHomeScreen: View {
     case 12..<18: return "Good afternoon"
     default: return "Good evening"
     }
-  }
-
-  private func homeHeader(
-    hubLabel: String,
-    hubOnline: Bool,
-    title: String,
-    subtitle: String
-  ) -> some View {
-    VStack(alignment: .leading, spacing: 12) {
-      HStack(alignment: .firstTextBaseline) {
-        VStack(alignment: .leading, spacing: 2) {
-          Text("Friday")
-            .font(.title3.weight(.bold))
-            .foregroundStyle(MobileTheme.textPrimary)
-          Text("Private command center")
-            .font(.subheadline)
-            .foregroundStyle(MobileTheme.textSecondary)
-        }
-        Spacer()
-        StatusChip(
-          text: hubLabel,
-          bg: hubOnline ? MobileTheme.chipDoneBG : MobileTheme.chipWarnBG,
-          fg: hubOnline ? MobileTheme.chipDoneFG : MobileTheme.chipWarnFG)
-      }
-      VStack(alignment: .leading, spacing: 6) {
-        Text(title)
-          .font(.system(size: 30, weight: .bold))
-          .foregroundStyle(MobileTheme.textPrimary)
-        Text(subtitle)
-          .font(.callout)
-          .foregroundStyle(MobileTheme.textSecondary)
-      }
-    }
-    .frame(maxWidth: .infinity, alignment: .leading)
-    .accessibilityElement(children: .combine)
-    .accessibilityLabel("\(hubLabel). \(title). \(subtitle)")
-    .accessibilityIdentifier("friday.home.command-center-header")
-  }
-
-  private func attentionHero(_ projection: HomeProjection) -> some View {
-    GlassPanel {
-      HStack(spacing: 14) {
-        HeroPet()
-          .frame(width: 155, height: 155)
-          .scaleEffect(0.67)
-          .frame(width: 112, height: 104)
-          .clipped()
-        VStack(alignment: .leading, spacing: 10) {
-          Text(primaryAttentionTitle(projection))
-            .font(.title3.weight(.bold))
-            .foregroundStyle(MobileTheme.textPrimary)
-            .fixedSize(horizontal: false, vertical: true)
-          HStack(spacing: 8) {
-            StatusChip(
-              text: projection.statusLabels.isEmpty ? "verified projection" : "truth flagged",
-              bg: projection.statusLabels.isEmpty ? MobileTheme.chipDoneBG : MobileTheme.chipWarnBG,
-              fg: projection.statusLabels.isEmpty ? MobileTheme.chipDoneFG : MobileTheme.chipWarnFG)
-            StatusChip(
-              text: "no hidden calls",
-              bg: MobileTheme.chipPendingBG,
-              fg: MobileTheme.chipPendingFG)
-          }
-          if let summary = projection.routeDecisionSummary {
-            Text(summary)
-              .font(.caption)
-              .foregroundStyle(MobileTheme.textSecondary)
-              .lineLimit(2)
-          }
-        }
-      }
-    }
-    .accessibilityElement(children: .combine)
-    .accessibilityLabel(primaryAttentionTitle(projection))
-    .accessibilityIdentifier("friday.home.attention-hero")
-  }
-
-  private func offlineCommandCenter(reason: String) -> some View {
-    GlassPanel {
-      HStack(spacing: 14) {
-        HeroPet()
-          .frame(width: 155, height: 155)
-          .scaleEffect(0.67)
-          .frame(width: 112, height: 104)
-          .clipped()
-        VStack(alignment: .leading, spacing: 10) {
-          Text("Friday is offline.")
-            .font(.title3.weight(.bold))
-            .foregroundStyle(MobileTheme.textPrimary)
-            .fixedSize(horizontal: false, vertical: true)
-          HStack(spacing: 8) {
-            StatusChip(text: "offline", bg: MobileTheme.chipWarnBG, fg: MobileTheme.chipWarnFG)
-            StatusChip(text: "no cached status", bg: MobileTheme.chipNeutralBG, fg: MobileTheme.chipNeutralFG)
-          }
-          Text(reason)
-            .font(.caption)
-            .foregroundStyle(MobileTheme.textSecondary)
-            .lineLimit(3)
-            .fixedSize(horizontal: false, vertical: true)
-        }
-      }
-    }
-    .accessibilityElement(children: .combine)
-    .accessibilityLabel("Friday is offline. \(reason). No cached or fabricated status is shown.")
-    .accessibilityIdentifier("friday.home.offline-command-center")
-  }
-
-  private func primaryAttentionTitle(_ projection: HomeProjection) -> String {
-    if projection.needsMeCount > 0 {
-      return "Friday needs your attention."
-    }
-    if projection.workItems.contains(where: { !$0.done }) {
-      return "Friday is working."
-    }
-    if projection.isLoadedEmpty {
-      return "Friday is connected."
-    }
-    return "Friday is caught up."
   }
 
   private struct QueueRow: Identifiable, Equatable {

--- a/rust-core/crates/friday-hub/src/bin/hub_seed_recovery_projection.rs
+++ b/rust-core/crates/friday-hub/src/bin/hub_seed_recovery_projection.rs
@@ -223,6 +223,9 @@ fn now_ms() -> i64 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    static TMP_DB_COUNTER: AtomicU64 = AtomicU64::new(0);
 
     #[test]
     fn refuses_non_controlled_mission_id() {
@@ -253,9 +256,11 @@ mod tests {
 
     fn tmp_db() -> String {
         let mut path = std::env::temp_dir();
+        let counter = TMP_DB_COUNTER.fetch_add(1, Ordering::Relaxed);
         path.push(format!(
-            "friday-seed-recovery-projection-{}-{}.sqlite",
+            "friday-seed-recovery-projection-{}-{}-{}.sqlite",
             std::process::id(),
+            counter,
             now_ms()
         ));
         path.to_string_lossy().to_string()

--- a/scripts/ops/check-friday-client-design-contract.mjs
+++ b/scripts/ops/check-friday-client-design-contract.mjs
@@ -54,6 +54,8 @@ const checks = checkSourceSet(repoRoot, [
     label: "iOS command sheet covers selected mobile destinations",
     paths: [
       "apps/friday-ios/Sources/FridayMobileShell/CommandSheet.swift",
+      "apps/friday-ios/Sources/FridayMobileShell/FridayApp.swift",
+      "apps/friday-ios/Sources/FridayMobileShell/FridayHomeScreen.swift",
       "apps/friday-ios/Sources/FridayMobileShellCore/MobileProductReadinessContract.swift",
     ],
     requiredCases: [
@@ -76,6 +78,9 @@ const checks = checkSourceSet(repoRoot, [
       "Route coverage only",
       "Provider Workspace",
       "Device Pairing",
+      "destination == .home ? \"Friday\" : destination.title",
+      "friday.home.selected-design-intro",
+      "friday.home.selected-hero-pet",
     ],
   },
   {

--- a/scripts/ops/friday-desktop-ax-accessibility-capture.mjs
+++ b/scripts/ops/friday-desktop-ax-accessibility-capture.mjs
@@ -47,9 +47,14 @@ const timeoutSeconds = Number(arg("timeout-seconds") || process.env.FRIDAY_DESKT
 const planOnly = args.includes("--plan-only");
 const requireObserved = args.includes("--require-observed");
 const blockers = [];
+const warnings = [];
 
 function block(code, detail) {
   blockers.push({ code, detail });
+}
+
+function warn(code, detail) {
+  warnings.push({ code, detail });
 }
 
 function requireAbsoluteDir(label, value) {
@@ -226,7 +231,7 @@ set AppleScript's text item delimiters to linefeed
 return outputLines as text`;
   const result = osascript(script);
   if (result.status !== 0) {
-    block("ax_tree_capture_failed", result.stderr.trim() || result.stdout.trim() || String(result.status));
+    warn("ax_tree_capture_failed", result.stderr.trim() || result.stdout.trim() || String(result.status));
     return "";
   }
   return result.stdout;
@@ -428,6 +433,25 @@ if (blockers.length === 0) {
     }
     const nav = clickNav(destination, destinationTargets[0]?.title || destination);
     const navStatus = `initial_destination;${nav.status === 0 ? nav.stdout.trim() : nav.stderr.trim()}`;
+    if (nav.status === 0 && nav.stdout.trim() === "clicked") {
+      observedActions.push({
+        screen: destination,
+        runtimeActionId: `desktop/${destination}/destination-visible`,
+        action_id: `desktop/${destination}/destination-visible`,
+        capability_id: `desktop/${destination}/destination-visible`,
+        accessibility_id: `friday.desktop.nav.${destination}`,
+        interaction: "visible",
+        status: "pass",
+        event: "desktop_destination_visible",
+        evidence_ref: rawPath,
+        captured_at: new Date().toISOString(),
+        workbench_mission_id: workbenchMissionId || null,
+        matched_role: "nav",
+        matched_name: destinationTargets[0]?.title || destination,
+        matched_description: navStatus,
+        matched_by: "navigation_click",
+      });
+    }
     await new Promise((resolveWait) => setTimeout(resolveWait, 350));
     const raw = captureTreeRaw();
     rawSnapshots.push(`--- destination=${destination} nav=${navStatus} ---\n${raw}`);
@@ -503,6 +527,7 @@ const summary = {
     missing_targets: missingTargets,
   },
   blockers,
+  warnings,
   caveats: [
     "This is real macOS Accessibility inspection of FridayHubConsole, not screenshot proof.",
     "Only visible, safe observations are emitted; governed/destructive actions are not auto-clicked.",

--- a/scripts/ops/friday-uiux-product-closure-readiness.mjs
+++ b/scripts/ops/friday-uiux-product-closure-readiness.mjs
@@ -11,7 +11,7 @@ function usage() {
   node scripts/ops/friday-uiux-product-closure-readiness.mjs \\
     [--repo-root=/abs/repo] \\
     [--design-root=/abs/friday-design-handoff-20260602] \\
-    [--evidence-dir=/abs/ui-device-evidence] \\
+    [--evidence-dir=/abs/ui-device-evidence ...] \\
     [--runtime-evidence=/abs/action-runtime-evidence.json ...] \\
     [--runtime-evidence-dir=/abs/evidence-dir ...] \\
     [--out=/abs/uiux-product-closure-readiness.json] \\
@@ -53,7 +53,15 @@ const requireRuntimeActions = args.includes("--require-runtime-actions");
 const requireUiDeviceProof = args.includes("--require-ui-device-proof");
 const repoRoot = resolve(arg("repo-root") || process.env.FRIDAY_REPO_ROOT || new URL("../..", import.meta.url).pathname);
 const designRoot = resolve(arg("design-root") || process.env.FRIDAY_DESIGN_HANDOFF_ROOT || `${process.env.HOME || "/Users/jarvis"}/Desktop/friday-design-handoff-20260602`);
-const evidenceDir = arg("evidence-dir") || process.env.FRIDAY_UI_DEVICE_PROOF_EVIDENCE_DIR || "";
+const evidenceDirs = [
+  ...argsAll("evidence-dir"),
+  ...(process.env.FRIDAY_UI_DEVICE_PROOF_EVIDENCE_DIR
+    ? [process.env.FRIDAY_UI_DEVICE_PROOF_EVIDENCE_DIR]
+    : []),
+  ...(process.env.FRIDAY_UI_DEVICE_PROOF_EVIDENCE_DIRS
+    ? process.env.FRIDAY_UI_DEVICE_PROOF_EVIDENCE_DIRS.split(/[:\n]/).filter(Boolean)
+    : []),
+];
 const runtimeEvidence = [
   ...argsAll("runtime-evidence"),
   ...(process.env.FRIDAY_DESIGN_ACTION_RUNTIME_EVIDENCE
@@ -246,7 +254,9 @@ const selectedVisualProofArgs = [
   `--repo-root=${repoRoot}`,
   `--design-root=${designRoot}`,
 ];
-if (evidenceDir) selectedVisualProofArgs.push(`--evidence-dir=${abs(evidenceDir)}`);
+for (const dir of evidenceDirs) {
+  selectedVisualProofArgs.push(`--evidence-dir=${abs(dir)}`);
+}
 if (requireUiDeviceProof) selectedVisualProofArgs.push("--require-complete");
 const selectedVisualProof = runJson("selected_visual_proof", process.execPath, selectedVisualProofArgs);
 const nativeAction = runJson("native_action_closure", process.execPath, [
@@ -269,7 +279,9 @@ for (const dir of runtimeEvidenceDirs) {
   const resolved = abs(dir);
   if (existsSync(resolved)) traceabilityArgs.push(`--evidence-dir=${resolved}`);
 }
-if (evidenceDir && existsSync(abs(evidenceDir))) traceabilityArgs.push(`--evidence-dir=${abs(evidenceDir)}`);
+for (const dir of evidenceDirs) {
+  if (existsSync(abs(dir))) traceabilityArgs.push(`--evidence-dir=${abs(dir)}`);
+}
 const uiuxTraceability = runJson("uiux_action_traceability", process.execPath, traceabilityArgs);
 
 const designRuntimeArgs = [
@@ -292,8 +304,8 @@ for (const dir of runtimeEvidenceDirs) {
     }
   }
 }
-if (evidenceDir) {
-  const resolved = abs(evidenceDir);
+for (const dir of evidenceDirs) {
+  const resolved = abs(dir);
   if (!existsSync(resolved)) {
     block("evidence_dir_missing", resolved);
   } else {
@@ -308,7 +320,9 @@ const designRuntime = runJson("design_action_runtime", process.execPath, designR
 let uiDeviceReadiness = null;
 if (existsSync(`${repoRoot}/scripts/ops/friday-ui-device-proof-readiness.sh`)) {
   const readinessArgs = [`${repoRoot}/scripts/ops/friday-ui-device-proof-readiness.sh`];
-  if (evidenceDir) readinessArgs.push("--evidence-dir", abs(evidenceDir));
+  for (const dir of evidenceDirs) {
+    readinessArgs.push("--evidence-dir", abs(dir));
+  }
   if (designContractPath) readinessArgs.push("--design-action-contract", designContractPath);
   for (const evidence of runtimeEvidence) {
     if (existsSync(abs(evidence))) readinessArgs.push("--design-action-runtime-evidence", abs(evidence));


### PR DESCRIPTION
## Summary
- Align the iOS Home shell with the operator-selected mobile handoff: lightweight `Friday` app title, greeting, bare Hero Pet stage, and Needs Me / Running queues before proof/status details.
- Harden selected-design guards so Home cannot drift back to a diagnostic header while still rendering honest offline truth.
- Split desktop AX capture into destination-visible proof vs action-control proof, and let UIUX product-closure readiness consume multiple evidence directories.
- Fix the `hub_seed_recovery_projection` test DB name race that made main Rust Core fail post-#1315.

## Verification
- `bash apps/friday-ios/build-sim.sh --mode offline-truth --destination home --shot /tmp/friday-ui-selected-parity-20260627-rerun/ios-home-selected-parity.png`
- `npm run proof:ios:design-destinations -- --destinations home,session,contextPassport,tokenLedger,shareIntake,voice,pairing,providerAuth,activity,workflows`
- `npm run proof:desktop:ax-capture` with `FRIDAY_DESKTOP_AX_CAPTURE_DESTINATIONS=operations,chat,session,pairingProvisioning,providerAdmin,parity,workflow,evidence`
- `node scripts/ops/check-friday-uiux-selected-visual-proof.mjs ... --require-complete` -> `selected_visual_proof_ready`
- `node scripts/ops/friday-uiux-product-closure-readiness.mjs ...` -> selected visual proof ready; runtime action / full UI-device proof still honest gaps
- `cargo test -p friday-hub --bin hub_seed_recovery_projection`
- `cargo fmt --all --check`
- `node --check scripts/ops/friday-desktop-ax-accessibility-capture.mjs && node --check scripts/ops/friday-uiux-product-closure-readiness.mjs && node --check scripts/ops/check-friday-client-design-contract.mjs`
- `vitest run --project default test/unit/qa/friday-uiux-selected-visual-proof-cli.test.ts test/unit/qa/friday-uiux-action-traceability-cli.test.ts test/unit/qa/friday-uiux-native-linkage-cli.test.ts`

## Truth Labels
- Selected visual proof ready is not END-BAR, not adoption, not live action closure.
- Remaining UIUX gaps are runtime action evidence and full same-run UI/device proof assembly.
- Desktop AX still honestly records action-level misses where live/offline state cannot expose loaded-only controls.
