### PR TITLE
Add Swift provider workspace action client

### DIFF
--- a/apps/macos/FridayRustClient/Sources/FridayRustClient/PairingClient.swift
+++ b/apps/macos/FridayRustClient/Sources/FridayRustClient/PairingClient.swift
@@ -168,6 +168,8 @@ private func pairingKind(_ message: FridayMessage) -> String {
   case .activityMarkDoneResult: return "ActivityMarkDoneResult"
   case .workItemStatusRequest: return "WorkItemStatusRequest"
   case .workItemStatusResult: return "WorkItemStatusResult"
+  case .providerWorkspaceActionRequest: return "ProviderWorkspaceActionRequest"
+  case .providerWorkspaceActionResult: return "ProviderWorkspaceActionResult"
   case .runAnswerBodyRequest: return "RunAnswerBodyRequest"
   case .runAnswerBodySnapshot: return "RunAnswerBodySnapshot"
   }

--- a/apps/macos/FridayRustClient/Sources/FridayRustClient/Protocol.swift
+++ b/apps/macos/FridayRustClient/Sources/FridayRustClient/Protocol.swift
@@ -546,6 +546,11 @@ public enum FridayMessage: Equatable {
   case workItemStatusRequest(WorkItemStatusRequestWire)
   /// hub→trusted-peer: refs-only receipt for a WorkItem lifecycle transition.
   case workItemStatusResult(WorkItemStatusResultWire)
+  /// trusted-peer→hub: request one guarded Provider Workspace action. The Hub validates capability
+  /// + mission context before any provider adapter dispatch.
+  case providerWorkspaceActionRequest(ProviderWorkspaceActionRequestWire)
+  /// hub→trusted-peer: refs-only guard/dispatch receipt for a Provider Workspace action.
+  case providerWorkspaceActionResult(ProviderWorkspaceActionResultWire)
   /// client→read-server: owner-gated run answer body readback. Kept separate from
   /// RunReadback so refs-only projections stay refs-only.
   case runAnswerBodyRequest(RunAnswerBodyRequestWire)
@@ -792,6 +797,13 @@ extension FridayMessage: Codable {
     case "WorkItemStatusResult":
       let c = try decoder.container(keyedBy: ResultKey.self)
       self = .workItemStatusResult(try c.decode(WorkItemStatusResultWire.self, forKey: .result))
+    case "ProviderWorkspaceActionRequest":
+      let c = try decoder.container(keyedBy: RequestKey.self)
+      self = .providerWorkspaceActionRequest(
+        try c.decode(ProviderWorkspaceActionRequestWire.self, forKey: .request))
+    case "ProviderWorkspaceActionResult":
+      let c = try decoder.container(keyedBy: ResultKey.self)
+      self = .providerWorkspaceActionResult(try c.decode(ProviderWorkspaceActionResultWire.self, forKey: .result))
     case "RunAnswerBodyRequest":
       let c = try decoder.container(keyedBy: RequestKey.self)
       self = .runAnswerBodyRequest(try c.decode(RunAnswerBodyRequestWire.self, forKey: .request))
@@ -1018,6 +1030,14 @@ extension FridayMessage: Codable {
       try c.encode(r, forKey: .request)
     case .workItemStatusResult(let r):
       try tag.encode("WorkItemStatusResult", forKey: .kind)
+      var c = encoder.container(keyedBy: ResultKey.self)
+      try c.encode(r, forKey: .result)
+    case .providerWorkspaceActionRequest(let r):
+      try tag.encode("ProviderWorkspaceActionRequest", forKey: .kind)
+      var c = encoder.container(keyedBy: RequestKey.self)
+      try c.encode(r, forKey: .request)
+    case .providerWorkspaceActionResult(let r):
+      try tag.encode("ProviderWorkspaceActionResult", forKey: .kind)
       var c = encoder.container(keyedBy: ResultKey.self)
       try c.encode(r, forKey: .result)
     case .runAnswerBodyRequest(let r):

--- a/apps/macos/FridayRustClient/Sources/FridayRustClient/ReadClient.swift
+++ b/apps/macos/FridayRustClient/Sources/FridayRustClient/ReadClient.swift
@@ -266,6 +266,10 @@ public final class SealedWSReadClient: FridayRustReadClient, @unchecked Sendable
       throw FridayReadClientError.unexpectedResponse(kind: "WorkItemStatusRequest")
     case .workItemStatusResult:
       throw FridayReadClientError.unexpectedResponse(kind: "WorkItemStatusResult")
+    case .providerWorkspaceActionRequest:
+      throw FridayReadClientError.unexpectedResponse(kind: "ProviderWorkspaceActionRequest")
+    case .providerWorkspaceActionResult:
+      throw FridayReadClientError.unexpectedResponse(kind: "ProviderWorkspaceActionResult")
     case .runAnswerBodyRequest:
       throw FridayReadClientError.unexpectedResponse(kind: "RunAnswerBodyRequest")
     case .runAnswerBodySnapshot:
@@ -391,6 +395,10 @@ public final class SealedWSReadClient: FridayRustReadClient, @unchecked Sendable
       throw FridayReadClientError.unexpectedResponse(kind: "WorkItemStatusRequest")
     case .workItemStatusResult:
       throw FridayReadClientError.unexpectedResponse(kind: "WorkItemStatusResult")
+    case .providerWorkspaceActionRequest:
+      throw FridayReadClientError.unexpectedResponse(kind: "ProviderWorkspaceActionRequest")
+    case .providerWorkspaceActionResult:
+      throw FridayReadClientError.unexpectedResponse(kind: "ProviderWorkspaceActionResult")
     case .runReadbackRequest:
       throw FridayReadClientError.unexpectedResponse(kind: "RunReadbackRequest")
     case .runReadbackSnapshot:

--- a/apps/macos/FridayRustClient/Sources/FridayRustClient/WriteClient.swift
+++ b/apps/macos/FridayRustClient/Sources/FridayRustClient/WriteClient.swift
@@ -189,6 +189,11 @@ public protocol FridayMissionSpineWriteClient: Sendable {
   /// recovery/lifecycle control; the Hub enforces owner binding, legal transitions, audit, and
   /// proof-on-completion.
   func submitWorkItemStatus(_ request: WorkItemStatusRequestWire) async throws -> WorkItemStatusResultWire
+  /// Request one guarded Provider Workspace action. The Hub returns a refs-only guard receipt; an
+  /// `accepted:false` / `routed:false` receipt is returned to the caller as truth, not thrown.
+  func submitProviderWorkspaceAction(
+    _ request: ProviderWorkspaceActionRequestWire
+  ) async throws -> ProviderWorkspaceActionResultWire
 }
 
 /// Product-facing bridge for MissionIntakeResult -> mission-bound AgentRunRequest. This is the
@@ -364,7 +369,8 @@ public final class SealedWSWriteClient: FridayRustWriteClient, FridayMissionSpin
          .contextPassportTransferRequest, .contextPassportTransferResult,
          .runOutcomeLearningDecisionRequest, .runOutcomeLearningDecisionResult,
          .activityMarkDoneRequest, .activityMarkDoneResult,
-         .workItemStatusRequest, .workItemStatusResult:
+         .workItemStatusRequest, .workItemStatusResult,
+         .providerWorkspaceActionRequest, .providerWorkspaceActionResult:
       throw FridayWriteClientError.unexpectedResponse(kind: dispatchKind(message))
     case .unsupported(let kind):
       throw FridayWriteClientError.unexpectedResponse(kind: kind)
@@ -535,6 +541,36 @@ public final class SealedWSWriteClient: FridayRustWriteClient, FridayMissionSpin
     let resp = try openEnvelope(respBody, sessionKey: sessionKey)
     switch resp.message {
     case .workItemStatusResult(let r):
+      return r
+    case .error(let code, let message):
+      throw FridayWriteClientError.serverError(code: code, message: message)
+    default:
+      throw FridayWriteClientError.unexpectedResponse(kind: dispatchKind(resp.message))
+    }
+  }
+
+  /// Submit one Provider Workspace action over the sealed WRITE session. The request carries no
+  /// per-request `auth_proof`; the authenticated sealed peer is the channel auth, and the Hub still
+  /// validates capability + Mission context before any provider adapter can run.
+  public func submitProviderWorkspaceAction(
+    _ request: ProviderWorkspaceActionRequestWire
+  ) async throws -> ProviderWorkspaceActionResultWire {
+    let transport = try makeTransport()
+    let (sessionKey, _) = try handshake(transport)
+    let msgId = "provider-workspace-action-\(request.requestId)"
+    let env = FridayEnvelope(msgId: msgId, sentAt: now(), message: .providerWorkspaceActionRequest(request))
+      .withCorrelation(msgId)
+    try transport.sendMessage(try sealEnvelope(env, sessionKey: sessionKey))
+    let respBody: [UInt8]
+    do {
+      respBody = try transport.recvMessage()
+    } catch {
+      throw FridayWriteClientError.transport(
+        "no provider-workspace-action result (session ended fail-closed): \(error)")
+    }
+    let resp = try openEnvelope(respBody, sessionKey: sessionKey)
+    switch resp.message {
+    case .providerWorkspaceActionResult(let r):
       return r
     case .error(let code, let message):
       throw FridayWriteClientError.serverError(code: code, message: message)
@@ -765,6 +801,8 @@ private func dispatchKind(_ message: FridayMessage) -> String {
   case .activityMarkDoneResult: return "ActivityMarkDoneResult"
   case .workItemStatusRequest: return "WorkItemStatusRequest"
   case .workItemStatusResult: return "WorkItemStatusResult"
+  case .providerWorkspaceActionRequest: return "ProviderWorkspaceActionRequest"
+  case .providerWorkspaceActionResult: return "ProviderWorkspaceActionResult"
   case .unsupported(let kind): return kind
   }
 }

--- a/apps/macos/FridayRustClient/Sources/FridayRustClient/WriteProtocol.swift
+++ b/apps/macos/FridayRustClient/Sources/FridayRustClient/WriteProtocol.swift
@@ -338,6 +338,138 @@ public struct WorkItemStatusResultWire: Codable, Equatable, Sendable {
   }
 }
 
+/// Canonical Mission context for a Provider Workspace action. Mirrors
+/// `friday_protocol::ProviderWorkspaceMissionContextWire`.
+public struct ProviderWorkspaceMissionContextWire: Codable, Equatable, Sendable {
+  public var fridayConversationId: String
+  public var missionId: String
+  public var workItemId: String
+
+  public init(fridayConversationId: String, missionId: String, workItemId: String) {
+    self.fridayConversationId = fridayConversationId
+    self.missionId = missionId
+    self.workItemId = workItemId
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case fridayConversationId = "friday_conversation_id"
+    case missionId = "mission_id"
+    case workItemId = "work_item_id"
+  }
+}
+
+/// Client→hub Provider Workspace action request. This is a governed action selector over an
+/// existing provider workspace session, not raw provider control; Hub validates `capabilityId`
+/// before any adapter dispatch.
+public struct ProviderWorkspaceActionRequestWire: Codable, Equatable, Sendable {
+  public var requestId: String
+  public var fridaySessionId: String
+  public var provider: String
+  public var action: String
+  public var capabilityId: String
+  public var payloadRef: String?
+  public var missionContext: ProviderWorkspaceMissionContextWire?
+
+  public init(
+    requestId: String,
+    fridaySessionId: String,
+    provider: String,
+    action: String,
+    capabilityId: String,
+    payloadRef: String? = nil,
+    missionContext: ProviderWorkspaceMissionContextWire? = nil
+  ) {
+    self.requestId = requestId
+    self.fridaySessionId = fridaySessionId
+    self.provider = provider
+    self.action = action
+    self.capabilityId = capabilityId
+    self.payloadRef = payloadRef
+    self.missionContext = missionContext
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case requestId = "request_id"
+    case fridaySessionId = "friday_session_id"
+    case provider
+    case action
+    case capabilityId = "capability_id"
+    case payloadRef = "payload_ref"
+    case missionContext = "mission_context"
+  }
+
+  public func encode(to encoder: Encoder) throws {
+    var c = encoder.container(keyedBy: CodingKeys.self)
+    try c.encode(requestId, forKey: .requestId)
+    try c.encode(fridaySessionId, forKey: .fridaySessionId)
+    try c.encode(provider, forKey: .provider)
+    try c.encode(action, forKey: .action)
+    try c.encode(capabilityId, forKey: .capabilityId)
+    if let payloadRef { try c.encode(payloadRef, forKey: .payloadRef) }
+    if let missionContext { try c.encode(missionContext, forKey: .missionContext) }
+  }
+}
+
+/// Hub→client Provider Workspace action result. `accepted/routed=false` is a valid guard receipt the
+/// UI must render honestly, not a transport failure.
+public struct ProviderWorkspaceActionResultWire: Codable, Equatable, Sendable {
+  public var requestId: String
+  public var fridaySessionId: String
+  public var provider: String
+  public var action: String
+  public var accepted: Bool
+  public var routed: Bool
+  public var status: String
+  public var truthLabel: String
+  public var blocker: String?
+  public var proofRef: String?
+  public var dispatchRef: String?
+  public var missionContext: ProviderWorkspaceMissionContextWire?
+
+  public init(
+    requestId: String,
+    fridaySessionId: String,
+    provider: String,
+    action: String,
+    accepted: Bool,
+    routed: Bool,
+    status: String,
+    truthLabel: String,
+    blocker: String? = nil,
+    proofRef: String? = nil,
+    dispatchRef: String? = nil,
+    missionContext: ProviderWorkspaceMissionContextWire? = nil
+  ) {
+    self.requestId = requestId
+    self.fridaySessionId = fridaySessionId
+    self.provider = provider
+    self.action = action
+    self.accepted = accepted
+    self.routed = routed
+    self.status = status
+    self.truthLabel = truthLabel
+    self.blocker = blocker
+    self.proofRef = proofRef
+    self.dispatchRef = dispatchRef
+    self.missionContext = missionContext
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case requestId = "request_id"
+    case fridaySessionId = "friday_session_id"
+    case provider
+    case action
+    case accepted
+    case routed
+    case status
+    case truthLabel = "truth_label"
+    case blocker
+    case proofRef = "proof_ref"
+    case dispatchRef = "dispatch_ref"
+    case missionContext = "mission_context"
+  }
+}
+
 /// Client→read-server owner-gated answer-body request. This is a READ-seam message, but the shared
 /// wire types live beside the other protocol structs so `FridayMessage` can encode/decode it.
 public struct RunAnswerBodyRequestWire: Codable, Equatable, Sendable {

--- a/apps/macos/FridayRustClient/Tests/FridayRustClientTests/MissionSpineWriteKATTests.swift
+++ b/apps/macos/FridayRustClient/Tests/FridayRustClientTests/MissionSpineWriteKATTests.swift
@@ -409,4 +409,63 @@ final class MissionSpineWriteKATTests: XCTestCase {
     XCTAssertTrue(json.contains("\"result\":{"))
     XCTAssertTrue(json.contains("\"blocker\":\"unknown_activity\""))
   }
+
+  // MARK: MS8 — ProviderWorkspaceAction wire shape (nested + refs-only guard receipt)
+
+  func testMS8_providerWorkspaceActionRequestNestedShapeNoAuthProof() throws {
+    let ctx = ProviderWorkspaceMissionContextWire(
+      fridayConversationId: "fconv_provider_workspace",
+      missionId: "mission-provider-workspace",
+      workItemId: "work-provider-workspace")
+    let req = ProviderWorkspaceActionRequestWire(
+      requestId: "provider-action-1",
+      fridaySessionId: "friday-codex-1",
+      provider: "codex",
+      action: "send_turn",
+      capabilityId: "provider.codex.send_turn",
+      payloadRef: "friday://body/user-message/1",
+      missionContext: ctx)
+    let env = FridayEnvelope(msgId: "provider-action", sentAt: 1000, message: .providerWorkspaceActionRequest(req))
+      .withCorrelation("c1")
+    let json = String(decoding: try env.encodeJSON(), as: UTF8.self)
+
+    XCTAssertTrue(json.contains("\"kind\":\"ProviderWorkspaceActionRequest\""))
+    XCTAssertTrue(json.contains("\"request\":{"), "provider action must NEST under request: \(json)")
+    XCTAssertTrue(json.contains("\"capability_id\":\"provider.codex.send_turn\""))
+    XCTAssertTrue(json.contains("\"mission_id\":\"mission-provider-workspace\""))
+    XCTAssertFalse(json.contains("auth_proof"))
+    XCTAssertFalse(json.contains("forwarded_principal"))
+    XCTAssertFalse(json.contains("raw user prompt"))
+
+    let messageObj = try messageObject(json)
+    XCTAssertEqual(Set(messageObj.keys), ["kind", "request"])
+    let request = try XCTUnwrap(messageObj["request"] as? [String: Any])
+    XCTAssertNil(request["auth_proof"], "ProviderWorkspaceActionRequest carries NO per-request auth_proof")
+    XCTAssertEqual(try FridayEnvelope.decodeJSON(Data(json.utf8)).message, .providerWorkspaceActionRequest(req))
+  }
+
+  func testMS8_providerWorkspaceActionResultBlockedCarriesGuardTruth() throws {
+    let ctx = ProviderWorkspaceMissionContextWire(
+      fridayConversationId: "fconv_provider_workspace",
+      missionId: "mission-provider-workspace",
+      workItemId: "work-provider-workspace")
+    let result = ProviderWorkspaceActionResultWire(
+      requestId: "provider-action-1",
+      fridaySessionId: "friday-codex-1",
+      provider: "codex",
+      action: "send_turn",
+      accepted: false,
+      routed: false,
+      status: "blocked",
+      truthLabel: "provider_workspace_action_guard_blocked",
+      blocker: "capability_not_verified",
+      missionContext: ctx)
+    let env = FridayEnvelope(msgId: "provider-result", sentAt: 1, message: .providerWorkspaceActionResult(result))
+    XCTAssertEqual(try FridayEnvelope.decodeJSON(try env.encodeJSON()).message, .providerWorkspaceActionResult(result))
+    let json = String(decoding: try env.encodeJSON(), as: UTF8.self)
+    XCTAssertTrue(json.contains("\"result\":{"))
+    XCTAssertTrue(json.contains("\"accepted\":false"))
+    XCTAssertTrue(json.contains("\"routed\":false"))
+    XCTAssertTrue(json.contains("\"blocker\":\"capability_not_verified\""))
+  }
 }

--- a/apps/macos/FridayRustClient/Tests/FridayRustClientTests/MissionSpineWriteWiringTests.swift
+++ b/apps/macos/FridayRustClient/Tests/FridayRustClientTests/MissionSpineWriteWiringTests.swift
@@ -26,6 +26,8 @@ final class MissionSpineWriteWiringTests: XCTestCase {
     case learningBlocked
     case activityDone
     case activityBlocked
+    case providerActionAccepted
+    case providerActionBlocked
     case serverError           // a typed Error frame
   }
 
@@ -47,6 +49,7 @@ final class MissionSpineWriteWiringTests: XCTestCase {
     private(set) var receivedDecision: MemoryDecisionRequestWire?
     private(set) var receivedLearningDecision: RunOutcomeLearningDecisionRequestWire?
     private(set) var receivedActivityMarkDone: ActivityMarkDoneRequestWire?
+    private(set) var receivedProviderWorkspaceAction: ProviderWorkspaceActionRequestWire?
     /// Proves the inbound message object carried NO `auth_proof` (sealed session is the channel auth).
     private(set) var sawAuthProof = false
 
@@ -158,6 +161,36 @@ final class MissionSpineWriteWiringTests: XCTestCase {
           reply = .activityMarkDoneResult(ActivityMarkDoneResultWire(
             activityId: req.activityId, state: "done", status: "done"))
         }
+      case .providerWorkspaceActionRequest(let req):
+        receivedProviderWorkspaceAction = req
+        switch mode {
+        case .serverError:
+          reply = .error(code: .internal, message: "provider workspace action failed")
+        case .providerActionBlocked:
+          reply = .providerWorkspaceActionResult(ProviderWorkspaceActionResultWire(
+            requestId: req.requestId,
+            fridaySessionId: req.fridaySessionId,
+            provider: req.provider,
+            action: req.action,
+            accepted: false,
+            routed: false,
+            status: "blocked",
+            truthLabel: "provider_workspace_action_guard_blocked",
+            blocker: "capability_not_verified",
+            missionContext: req.missionContext))
+        default:
+          reply = .providerWorkspaceActionResult(ProviderWorkspaceActionResultWire(
+            requestId: req.requestId,
+            fridaySessionId: req.fridaySessionId,
+            provider: req.provider,
+            action: req.action,
+            accepted: true,
+            routed: true,
+            status: "accepted",
+            truthLabel: "provider_workspace_action_guard_accepted",
+            dispatchRef: "provider-dispatch-1",
+            missionContext: req.missionContext))
+        }
       default:
         throw FridayWriteClientError.transport("unexpected inbound on the spine session: \(env.msgId)")
       }
@@ -197,6 +230,20 @@ final class MissionSpineWriteWiringTests: XCTestCase {
       missionId: "mission-desktop-1", workItemId: "work-desktop-1",
       title: "Coordinate Friday work", intent: "keep one Mission across every surface",
       lane: "deepseek")
+  }
+
+  private func sampleProviderWorkspaceAction() -> ProviderWorkspaceActionRequestWire {
+    ProviderWorkspaceActionRequestWire(
+      requestId: "provider-action-1",
+      fridaySessionId: "friday-codex-1",
+      provider: "codex",
+      action: "send_turn",
+      capabilityId: "provider.codex.send_turn",
+      payloadRef: "friday://body/user-message/1",
+      missionContext: ProviderWorkspaceMissionContextWire(
+        fridayConversationId: "fconv_desktop_1",
+        missionId: "mission-desktop-1",
+        workItemId: "work-desktop-1"))
   }
 
   // MARK: submitMissionIntake
@@ -337,6 +384,43 @@ final class MissionSpineWriteWiringTests: XCTestCase {
     let (client, _) = try makeClient(mode: .serverError)
     do {
       _ = try await client.submitActivityMarkDone(ActivityMarkDoneRequestWire(activityId: "activity-1"))
+      XCTFail("a typed Error frame must throw")
+    } catch let err as FridayWriteClientError {
+      guard case .serverError = err else { return XCTFail("expected serverError, got \(err)") }
+    }
+  }
+
+  // MARK: submitProviderWorkspaceAction
+
+  func testSubmitProviderWorkspaceAction_acceptedReturnsGuardReceiptNoAuthProof() async throws {
+    let (client, transport) = try makeClient(mode: .providerActionAccepted)
+    let result = try await client.submitProviderWorkspaceAction(sampleProviderWorkspaceAction())
+    XCTAssertEqual(result.requestId, "provider-action-1")
+    XCTAssertEqual(result.fridaySessionId, "friday-codex-1")
+    XCTAssertEqual(result.provider, "codex")
+    XCTAssertEqual(result.action, "send_turn")
+    XCTAssertTrue(result.accepted)
+    XCTAssertTrue(result.routed)
+    XCTAssertEqual(result.status, "accepted")
+    XCTAssertEqual(result.dispatchRef, "provider-dispatch-1")
+    XCTAssertEqual(transport.receivedProviderWorkspaceAction?.capabilityId, "provider.codex.send_turn")
+    XCTAssertEqual(transport.receivedProviderWorkspaceAction?.missionContext?.missionId, "mission-desktop-1")
+    XCTAssertFalse(transport.sawAuthProof, "the provider workspace action request must carry NO auth_proof")
+  }
+
+  func testSubmitProviderWorkspaceAction_blockedIsReturnedReceiptNotThrow() async throws {
+    let (client, _) = try makeClient(mode: .providerActionBlocked)
+    let result = try await client.submitProviderWorkspaceAction(sampleProviderWorkspaceAction())
+    XCTAssertFalse(result.accepted)
+    XCTAssertFalse(result.routed)
+    XCTAssertEqual(result.status, "blocked")
+    XCTAssertEqual(result.blocker, "capability_not_verified")
+  }
+
+  func testSubmitProviderWorkspaceAction_serverError_throwsServerError() async throws {
+    let (client, _) = try makeClient(mode: .serverError)
+    do {
+      _ = try await client.submitProviderWorkspaceAction(sampleProviderWorkspaceAction())
       XCTFail("a typed Error frame must throw")
     } catch let err as FridayWriteClientError {
       guard case .serverError = err else { return XCTFail("expected serverError, got \(err)") }


### PR DESCRIPTION
## Summary
- add Swift wire structs and FridayMessage encode/decode support for ProviderWorkspaceActionRequest/Result
- add SealedWSWriteClient.submitProviderWorkspaceAction over the existing sealed WRITE session
- add KAT + in-memory sealed wiring tests proving nested request/result shape, no per-request auth_proof, and blocked guard receipts returned as truth

## Truth label
- Client action leg only. No flag flip, no provider dispatch live claim, no operator signature/minting change. The Hub still gates provider dispatch behind existing capability/mission-context checks and FRIDAY_PROVIDER_WORKSPACE_DISPATCH.

## Verification
- git diff --check
- swift test --package-path apps/macos/FridayRustClient --filter MissionSpineWrite
- swift test --package-path apps/macos/FridayRustClient