### PR TITLE
Surface mission timeline evidence on mobile home

### DIFF
--- a/apps/friday-ios/Sources/FridayMobileShell/FridayHomeScreen.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayHomeScreen.swift
@@ -101,6 +101,7 @@ struct FridayHomeScreen: View {
 
     commandQueueSection(title: "Needs Me", rows: needsRows(projection), emptyText: "No approval, memory, or recovery items need action.")
     commandQueueSection(title: "Running", rows: runningRows(projection), emptyText: "No active Friday work is visible in this projection.")
+    evidenceFlowCard(projection)
     if projection.isLoadedEmpty {
       loadedEmptyCard(projection)
     }
@@ -409,6 +410,69 @@ struct FridayHomeScreen: View {
     .accessibilityElement(children: .combine)
     .accessibilityLabel(viewModel.isOnline ? "Friday status online" : "Friday status offline or stale")
     .accessibilityIdentifier("friday.home.status-card")
+  }
+
+  private func evidenceFlowCard(_ projection: HomeProjection) -> some View {
+    GlassPanel {
+      VStack(alignment: .leading, spacing: MobileTheme.rowSpacing) {
+        HStack(alignment: .firstTextBaseline) {
+          Text("Evidence flow")
+            .font(.headline)
+            .foregroundStyle(MobileTheme.textPrimary)
+          Spacer()
+          StatusChip(
+            text: projection.timelinePages.isEmpty ? "waiting" : "\(projection.timelinePages.count) pages",
+            bg: projection.timelinePages.isEmpty ? MobileTheme.chipNeutralBG : MobileTheme.chipPendingBG,
+            fg: projection.timelinePages.isEmpty ? MobileTheme.chipNeutralFG : MobileTheme.chipPendingFG)
+        }
+
+        if projection.timelinePages.isEmpty {
+          Text("No bounded mission timeline page is projected yet.")
+            .font(.footnote)
+            .foregroundStyle(MobileTheme.textSecondary)
+            .fixedSize(horizontal: false, vertical: true)
+        } else {
+          ForEach(projection.timelinePages.prefix(3)) { page in
+            VStack(alignment: .leading, spacing: 6) {
+              HStack(spacing: 8) {
+                Image(systemName: "point.topleft.down.curvedto.point.bottomright.up")
+                  .font(.system(size: 15, weight: .semibold))
+                  .foregroundStyle(MobileTheme.cyan)
+                  .accessibilityHidden(true)
+                Text(page.title)
+                  .font(.subheadline.weight(.semibold))
+                  .foregroundStyle(MobileTheme.textPrimary)
+                  .lineLimit(1)
+                Spacer(minLength: 8)
+                StatusChip(text: page.statusText, bg: MobileTheme.chipNeutralBG, fg: MobileTheme.chipNeutralFG)
+              }
+              if !page.summary.isEmpty {
+                Text(page.summary)
+                  .font(.caption)
+                  .foregroundStyle(MobileTheme.textSecondary)
+                  .lineLimit(2)
+              }
+              HStack(spacing: 8) {
+                RefPill(label: "cursor", ref: page.cursor ?? "start")
+                if let next = page.nextCursor {
+                  RefPill(label: "next", ref: next)
+                }
+                if page.refsCount > 0 {
+                  RefPill(label: "refs", ref: "\(page.refsCount)")
+                }
+              }
+            }
+            .padding(.vertical, 2)
+          }
+        }
+      }
+    }
+    .accessibilityElement(children: .combine)
+    .accessibilityLabel(
+      projection.timelinePages.isEmpty
+        ? "Evidence flow waiting for bounded mission timeline pages"
+        : "Evidence flow shows \(projection.timelinePages.count) bounded mission timeline pages")
+    .accessibilityIdentifier("friday.home.evidence-flow")
   }
 
   private func devicePairingCard(

--- a/apps/friday-ios/Sources/FridayMobileShellCore/HomeViewModel.swift
+++ b/apps/friday-ios/Sources/FridayMobileShellCore/HomeViewModel.swift
@@ -53,6 +53,7 @@ public struct HomeProjection: Sendable, Equatable {
   public let runOutcomeLearningCandidates: [HomeRunOutcomeLearningCandidate]
   public let capabilityStates: [HomeCapabilityState]
   public let t3ProvisioningStatus: HomeT3ProvisioningStatus?
+  public let timelinePages: [HomeTimelinePage]
   public let transcriptEvents: [HomeTranscriptEvent]
   /// The Hub epoch-millis the snapshot was generated (lets the UI flag staleness).
   public let generatedAtMs: Int64
@@ -81,6 +82,7 @@ public struct HomeProjection: Sendable, Equatable {
       raw["runOutcomeLearningCandidates"])
     self.capabilityStates = Self.parseCapabilityStates(raw["capabilityStates"])
     self.t3ProvisioningStatus = HomeT3ProvisioningStatus(raw: raw["t3ProvisioningStatus"])
+    self.timelinePages = Self.parseTimelinePages(raw["timelinePages"])
     self.transcriptEvents = Self.parseTranscriptEvents(raw["transcriptSections"])
     self.generatedAtMs = snapshot.generatedAtMs
   }
@@ -103,6 +105,7 @@ public struct HomeProjection: Sendable, Equatable {
       && runOutcomeLearningCandidates.isEmpty
       && capabilityStates.isEmpty
       && t3ProvisioningStatus == nil
+      && timelinePages.isEmpty
       && transcriptEvents.isEmpty
   }
 
@@ -193,6 +196,23 @@ public struct HomeProjection: Sendable, Equatable {
     }
   }
 
+  private static func parseTimelinePages(_ value: Any?) -> [HomeTimelinePage] {
+    guard let rows = value as? [[String: Any]] else { return [] }
+    return rows.enumerated().map { index, row in
+      HomeTimelinePage(
+        id: (row["id"] as? String) ?? "timeline-page-\(index)",
+        title: (row["title"] as? String) ?? "Timeline page",
+        cursor: row["cursor"] as? String,
+        nextCursor: row["nextCursor"] as? String,
+        retainedFrom: int(row["retainedFrom"]),
+        bounded: row["bounded"] as? Bool ?? false,
+        hasMore: row["hasMore"] as? Bool ?? false,
+        eventRefs: firstStringArray(row, ["eventRefs", "event_refs"]),
+        proofRefs: firstStringArray(row, ["proofRefs", "proof_refs"]),
+        summary: (row["summary"] as? String) ?? "")
+    }
+  }
+
   private static func firstString(_ raw: [String: Any], _ keys: [String]) -> String? {
     keys.lazy.compactMap { raw[$0] as? String }
       .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
@@ -201,6 +221,12 @@ public struct HomeProjection: Sendable, Equatable {
 
   private static func firstStringArray(_ raw: [String: Any], _ keys: [String]) -> [String] {
     keys.lazy.compactMap { raw[$0] as? [String] }.first ?? []
+  }
+
+  private static func int(_ value: Any?) -> Int {
+    if let int = value as? Int { return int }
+    if let number = value as? NSNumber { return number.intValue }
+    return 0
   }
 }
 
@@ -390,6 +416,29 @@ public struct HomeTrustedDeviceSummary: Sendable, Equatable {
     if let int = value as? Int { return Int64(int) }
     if let number = value as? NSNumber { return number.int64Value }
     return 0
+  }
+}
+
+public struct HomeTimelinePage: Sendable, Identifiable, Equatable {
+  public let id: String
+  public let title: String
+  public let cursor: String?
+  public let nextCursor: String?
+  public let retainedFrom: Int
+  public let bounded: Bool
+  public let hasMore: Bool
+  public let eventRefs: [String]
+  public let proofRefs: [String]
+  public let summary: String
+
+  public var statusText: String {
+    if hasMore { return "more" }
+    if bounded { return "bounded" }
+    return "read"
+  }
+
+  public var refsCount: Int {
+    eventRefs.count + proofRefs.count
   }
 }
 

--- a/apps/friday-ios/Tests/FridayMobileShellCoreTests/HomeViewModelTests.swift
+++ b/apps/friday-ios/Tests/FridayMobileShellCoreTests/HomeViewModelTests.swift
@@ -314,6 +314,20 @@ final class HomeViewModelTests: XCTestCase {
       "capabilityStates": [
         { "id": "cap-route", "label": "Route advisor", "kind": "advisor", "truthLabel": "friday_owned", "approvalState": "not_required", "dispatchAllowed": true, "summary": "Routes are advisory.", "proofRef": "proof://cap/1" }
       ],
+      "timelinePages": [
+        {
+          "id": "page-1",
+          "title": "Mission timeline",
+          "cursor": "start",
+          "nextCursor": "offset:12",
+          "retainedFrom": 0,
+          "bounded": true,
+          "hasMore": true,
+          "eventRefs": ["event://surface/mobile/1"],
+          "proofRefs": ["proof://timeline/1"],
+          "summary": "Bounded timeline window for the mobile projection."
+        }
+      ],
       "t3ProvisioningStatus": {
         "truthLabel": "rust_hub_t3_provisioning_read_only_no_mint",
         "paired": true,
@@ -452,6 +466,9 @@ final class HomeViewModelTests: XCTestCase {
       true, true, true, true,
     ])
     XCTAssertEqual(p.t3ProvisioningStatus?.checklistRows.last?.statusText, "shared")
+    XCTAssertEqual(p.timelinePages.first?.title, "Mission timeline")
+    XCTAssertEqual(p.timelinePages.first?.statusText, "more")
+    XCTAssertEqual(p.timelinePages.first?.refsCount, 2)
     XCTAssertEqual(p.transcriptEvents.first?.summary, "Mobile surface read the mission projection.")
     XCTAssertEqual(p.needsMeCount, 4)
     try writeMobileTokenLedgerActionEvidenceIfRequested(
@@ -1530,6 +1547,9 @@ final class ReadClientFactoryTests: XCTestCase {
     XCTAssertEqual(p.memoryCandidates.first?.grantsMemoryAuthority, false)
     XCTAssertEqual(p.runOutcomeLearningCandidates.first?.evidenceRef, "proof://learning/emulated")
     XCTAssertEqual(p.capabilityStates.first?.dispatchAllowed, false)
+    XCTAssertEqual(p.timelinePages.first?.title, "Live mission timeline")
+    XCTAssertEqual(p.timelinePages.first?.statusText, "bounded")
+    XCTAssertEqual(p.timelinePages.first?.refsCount, 2)
     XCTAssertEqual(p.transcriptEvents.first?.summary, "Mobile UI consumed the owner-gated projection.")
     XCTAssertEqual(p.needsMeCount, 3)
   }
@@ -1664,6 +1684,10 @@ final class EmulatedReadServerTransport: SealedWSTransport {
     "capabilityStates":[{"id":"cap-route","label":"Route advisor","kind":"advisor",\
     "truthLabel":"friday_owned","approvalState":"not_required","dispatchAllowed":false,\
     "summary":"Advisory only","proofRef":"proof://cap/route"}],\
+    "timelinePages":[{"id":"page-emulated","title":"Live mission timeline",\
+    "cursor":"start","nextCursor":null,"retainedFrom":0,"bounded":true,"hasMore":false,\
+    "eventRefs":["event://mobile/a"],"proofRefs":["proof://timeline/a"],\
+    "summary":"Owner-gated bounded timeline page was projected."}],\
     "transcriptSections":[{"id":"sec-a","title":"Mission","groupKind":"mission",\
     "missionId":"mission-emulated","truthLabel":"friday_owned","status":"waiting",\
     "events":[{"id":"evt-a","missionId":"mission-emulated","surface":"mobile",\


### PR DESCRIPTION
## Summary
- parse refs-only `timelinePages` into the iOS `HomeProjection`
- add a selected-design Home `Evidence flow` card that shows bounded mission timeline pages without claiming completion
- extend mobile read-projection tests and the emulated read-server fixture to cover timeline page consumption

## Truth label
- Mobile UI read/projection consumption only.
- No DB writes, no signing, no flag flip, no provider/model call, no END-BAR/adoption claim.
- Bounded timeline pages remain read-only evidence windows, not completion proof.

## Tests
- `swift test --package-path apps/friday-ios --filter HomeViewModelTests`
- `swift test --package-path apps/friday-ios`
