### PR TITLE
Surface desktop provider workspace guard receipt

### DIFF
--- a/apps/friday-ios/Tests/FridayMobileShellCoreTests/MissionSpineWriteClientTestDefaults.swift
+++ b/apps/friday-ios/Tests/FridayMobileShellCoreTests/MissionSpineWriteClientTestDefaults.swift
@@ -1,0 +1,20 @@
+import Foundation
+@testable import FridayRustClient
+
+extension FridayMissionSpineWriteClient {
+  func submitProviderWorkspaceAction(
+    _ request: ProviderWorkspaceActionRequestWire
+  ) async throws -> ProviderWorkspaceActionResultWire {
+    ProviderWorkspaceActionResultWire(
+      requestId: request.requestId,
+      fridaySessionId: request.fridaySessionId,
+      provider: request.provider,
+      action: request.action,
+      accepted: false,
+      routed: false,
+      status: "blocked",
+      truthLabel: "ios_test_provider_workspace_action_default_blocked",
+      blocker: "test fake does not exercise provider workspace action",
+      missionContext: request.missionContext)
+  }
+}

--- a/apps/macos/FridayHubConsole/Sources/FridayHubConsole/DesktopProjectionScreens.swift
+++ b/apps/macos/FridayHubConsole/Sources/FridayHubConsole/DesktopProjectionScreens.swift
@@ -358,6 +358,7 @@ struct DesktopProjectionScreen: View {
             .foregroundStyle(HubTheme.textSecondary)
         }
       }
+      providerWorkspaceActionCard(snapshot)
       GlassPanel {
         VStack(alignment: .leading, spacing: HubTheme.rowSpacing) {
           cardTitle("Provider State")
@@ -397,6 +398,76 @@ struct DesktopProjectionScreen: View {
       providerRouteDecisionCard(snapshot)
       providerWorkItemsCard(snapshot)
       refsCard(title: "Provider Receipt Refs", refs: snapshot.providerReceiptRefs)
+    }
+  }
+
+  private func providerWorkspaceActionCard(_ snapshot: WorkbenchSnapshot) -> some View {
+    let key = OperationsOverviewViewModel.providerWorkspaceListSessionsKey
+    let state = viewModel.providerWorkspaceActionStates[key] ?? .ready
+    return GlassPanel {
+      VStack(alignment: .leading, spacing: HubTheme.rowSpacing) {
+        HStack {
+          cardTitle("Provider Workspace Guard")
+          Spacer()
+          StatusChip(
+            text: snapshot.agentSessionId == nil ? "needs session ref" : "guarded write",
+            bg: snapshot.agentSessionId == nil ? HubTheme.chipWarnBG : HubTheme.chipPendingBG,
+            fg: snapshot.agentSessionId == nil ? HubTheme.chipWarnFG : HubTheme.chipPendingFG)
+        }
+        Text("Requests a Codex list-sessions guard receipt through the sealed WRITE seam. The Hub validates session, capability, and Mission context; blocked receipts render as truth.")
+          .font(.system(size: 11))
+          .foregroundStyle(HubTheme.textSecondary)
+          .fixedSize(horizontal: false, vertical: true)
+        HStack(spacing: 8) {
+          Button {
+            Task { await viewModel.requestProviderWorkspaceListSessions(snapshot) }
+          } label: {
+            Label("List Sessions", systemImage: "list.bullet.rectangle")
+          }
+          .buttonStyle(.bordered)
+          .disabled(state.isSent)
+          .accessibilityLabel("Request Provider Workspace list sessions guard receipt")
+          .accessibilityIdentifier("friday.desktop.provider-workspace.list-sessions")
+
+          WriteActionStateView(state: state, pendingText: "Requesting Provider Workspace guard…")
+        }
+        RefPill(label: "capability", ref: "provider.codex.list_sessions")
+        if let agentSessionId = snapshot.agentSessionId {
+          RefPill(label: "friday_session_id", ref: agentSessionId)
+        }
+        if let receipt = viewModel.latestProviderWorkspaceActionReceipt {
+          providerWorkspaceReceipt(receipt)
+        }
+      }
+    }
+    .accessibilityIdentifier("friday.desktop.provider-workspace.guard")
+  }
+
+  private func providerWorkspaceReceipt(_ receipt: ProviderWorkspaceActionReceipt) -> some View {
+    VStack(alignment: .leading, spacing: 6) {
+      HStack(spacing: 6) {
+        StatusChip(
+          text: receipt.accepted ? "accepted" : "blocked",
+          bg: receipt.accepted ? HubTheme.chipDoneBG : HubTheme.chipWarnBG,
+          fg: receipt.accepted ? HubTheme.chipDoneFG : HubTheme.chipWarnFG)
+        StatusChip(
+          text: receipt.routed ? "routed" : "not routed",
+          bg: receipt.routed ? HubTheme.chipPendingBG : HubTheme.chipNeutralBG,
+          fg: receipt.routed ? HubTheme.chipPendingFG : HubTheme.chipNeutralFG)
+        StatusChip(text: receipt.status, bg: HubTheme.chipNeutralBG, fg: HubTheme.chipNeutralFG)
+      }
+      Text(receipt.summary)
+        .font(.system(size: 11))
+        .foregroundStyle(HubTheme.textSecondary)
+        .textSelection(.enabled)
+      RefPill(label: "request_id", ref: receipt.requestId)
+      RefPill(label: "capability", ref: receipt.capabilityId)
+      if let proofRef = receipt.proofRef {
+        RefPill(label: "proof", ref: proofRef)
+      }
+      if let dispatchRef = receipt.dispatchRef {
+        RefPill(label: "dispatch", ref: dispatchRef)
+      }
     }
   }
 

--- a/apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/OperationsOverviewViewModel.swift
+++ b/apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/OperationsOverviewViewModel.swift
@@ -261,6 +261,48 @@ public struct ChatReceiptRef: Sendable, Codable, Equatable, Identifiable {
   }
 }
 
+public struct ProviderWorkspaceActionReceipt: Sendable, Equatable {
+  public let requestId: String
+  public let fridaySessionId: String
+  public let provider: String
+  public let action: String
+  public let capabilityId: String
+  public let accepted: Bool
+  public let routed: Bool
+  public let status: String
+  public let truthLabel: String
+  public let blocker: String?
+  public let proofRef: String?
+  public let dispatchRef: String?
+
+  public init(_ result: ProviderWorkspaceActionResultWire) {
+    self.requestId = result.requestId
+    self.fridaySessionId = result.fridaySessionId
+    self.provider = result.provider
+    self.action = result.action
+    self.capabilityId = "provider.\(result.provider).\(result.action)"
+    self.accepted = result.accepted
+    self.routed = result.routed
+    self.status = result.status
+    self.truthLabel = result.truthLabel
+    self.blocker = result.blocker
+    self.proofRef = result.proofRef
+    self.dispatchRef = result.dispatchRef
+  }
+
+  public var summary: String {
+    var parts = [
+      "\(provider).\(action)",
+      "accepted=\(accepted)",
+      "routed=\(routed)",
+      "status=\(status)",
+      "truth=\(truthLabel)",
+    ]
+    if let blocker, !blocker.isEmpty { parts.append("blocker=\(blocker)") }
+    return parts.joined(separator: " · ")
+  }
+}
+
 public struct ChatNeedsMeItem: Sendable, Equatable, Identifiable {
   public let runId: String
   public let kind: String
@@ -397,6 +439,10 @@ public final class OperationsOverviewViewModel: ObservableObject {
   @Published public private(set) var activityMarkDoneStates: [String: WriteActionState] = [:]
   /// Per WorkItem lifecycle recovery state, keyed by WorkItem id.
   @Published public private(set) var workItemStatusStates: [String: WriteActionState] = [:]
+  /// Provider Workspace guarded action state, keyed by capability/action id.
+  @Published public private(set) var providerWorkspaceActionStates: [String: WriteActionState] = [:]
+  /// Last Provider Workspace guard receipt surfaced to the desktop Provider Admin UI.
+  @Published public private(set) var latestProviderWorkspaceActionReceipt: ProviderWorkspaceActionReceipt?
   /// Structured refs for the latest desktop Chat turn. This avoids parsing status prose in the UI.
   @Published public private(set) var latestChatTurn: ChatTurnRefs?
   /// Refs-only Needs-Me rows for the latest Chat turn's runs.
@@ -825,6 +871,69 @@ public final class OperationsOverviewViewModel: ObservableObject {
     } catch {
       workItemStatusStates[workItemId] = .error(reason: Self.writeReason(for: error))
     }
+  }
+
+  /// Request the safest Provider Workspace guard receipt: Codex `list_sessions`.
+  ///
+  /// This is not raw provider execution. The Hub validates the exact capability id, session link,
+  /// and Mission context before returning a refs-only guard receipt. If the provider dispatch flag
+  /// is off or the capability is gated, the UI renders that blocked receipt as truth.
+  public func requestProviderWorkspaceListSessions(_ snapshot: WorkbenchSnapshot) async {
+    let key = Self.providerWorkspaceListSessionsKey
+    guard let fridaySessionId = snapshot.agentSessionId?.trimmingCharacters(in: .whitespacesAndNewlines),
+      !fridaySessionId.isEmpty
+    else {
+      providerWorkspaceActionStates[key] = .error(
+        reason: "Provider Workspace action requires an agent session ref.")
+      return
+    }
+    guard let workItemId = Self.providerWorkspaceWorkItemId(snapshot) else {
+      providerWorkspaceActionStates[key] = .error(
+        reason: "Provider Workspace action requires a provider-linked WorkItem ref.")
+      return
+    }
+    guard let writeClient else {
+      providerWorkspaceActionStates[key] = .error(reason: "Write seam not configured.")
+      return
+    }
+
+    providerWorkspaceActionStates[key] = .sent
+    let request = ProviderWorkspaceActionRequestWire(
+      requestId: "desktop-provider-workspace-\(newId())",
+      fridaySessionId: fridaySessionId,
+      provider: "codex",
+      action: "list_sessions",
+      capabilityId: "provider.codex.list_sessions",
+      payloadRef: nil,
+      missionContext: ProviderWorkspaceMissionContextWire(
+        fridayConversationId: snapshot.fridayConversationId,
+        missionId: snapshot.missionId,
+        workItemId: workItemId))
+    do {
+      let result = try await writeClient.submitProviderWorkspaceAction(request)
+      let receipt = ProviderWorkspaceActionReceipt(result)
+      latestProviderWorkspaceActionReceipt = receipt
+      if result.accepted {
+        providerWorkspaceActionStates[key] = .confirmed(summary: receipt.summary)
+      } else {
+        providerWorkspaceActionStates[key] = .error(reason: receipt.summary)
+      }
+      await refresh()
+    } catch {
+      providerWorkspaceActionStates[key] = .error(reason: Self.writeReason(for: error))
+    }
+  }
+
+  public static let providerWorkspaceListSessionsKey = "provider.codex.list_sessions:list_sessions"
+
+  private static func providerWorkspaceWorkItemId(_ snapshot: WorkbenchSnapshot) -> String? {
+    let candidate = snapshot.workItems.first { item in
+      item.state == .providerAck
+        || item.proofRef?.localizedCaseInsensitiveContains("provider") == true
+        || item.title.localizedCaseInsensitiveContains("provider")
+    } ?? snapshot.workItems.first
+    let trimmed = candidate?.id.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+    return trimmed.isEmpty ? nil : trimmed
   }
 
   private static func resumeSummary(for result: ResumeRelayResult) -> String {

--- a/apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/RealWriteClientFactory.swift
+++ b/apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/RealWriteClientFactory.swift
@@ -158,6 +158,11 @@ struct HonestlyUnavailableWriteClient: FridayMissionSpineWriteClient, FridayMiss
   func submitWorkItemStatus(_ request: WorkItemStatusRequestWire) async throws -> WorkItemStatusResultWire {
     throw FridayWriteClientError.transport("live write client unavailable: \(reason)")
   }
+  func submitProviderWorkspaceAction(
+    _ request: ProviderWorkspaceActionRequestWire
+  ) async throws -> ProviderWorkspaceActionResultWire {
+    throw FridayWriteClientError.transport("live write client unavailable: \(reason)")
+  }
   func dispatchMissionBoundAgentRun(
     task: String,
     missionContext: MissionWorkItemContextWire,

--- a/apps/macos/FridayHubConsole/Tests/FridayHubConsoleCoreTests/OperationsOverviewViewModelTests.swift
+++ b/apps/macos/FridayHubConsole/Tests/FridayHubConsoleCoreTests/OperationsOverviewViewModelTests.swift
@@ -689,6 +689,7 @@ final class MockMissionSpineWriteClient: FridayMissionSpineWriteClient, FridayMi
   private var _lastLearningDecision: RunOutcomeLearningDecisionRequestWire?
   private var _lastActivityMarkDone: ActivityMarkDoneRequestWire?
   private var _lastWorkItemStatus: WorkItemStatusRequestWire?
+  private var _lastProviderWorkspaceAction: ProviderWorkspaceActionRequestWire?
   private var _lastMissionContext: MissionWorkItemContextWire?
   private var _lastMissionRunConstraints: AgentRunConstraintsWire?
   private var _lastResumeRunId: String?
@@ -709,6 +710,9 @@ final class MockMissionSpineWriteClient: FridayMissionSpineWriteClient, FridayMi
   }
   var lastActivityMarkDone: ActivityMarkDoneRequestWire? { lock.withLock { _lastActivityMarkDone } }
   var lastWorkItemStatus: WorkItemStatusRequestWire? { lock.withLock { _lastWorkItemStatus } }
+  var lastProviderWorkspaceAction: ProviderWorkspaceActionRequestWire? {
+    lock.withLock { _lastProviderWorkspaceAction }
+  }
   var lastMissionContext: MissionWorkItemContextWire? { lock.withLock { _lastMissionContext } }
   var lastMissionRunConstraints: AgentRunConstraintsWire? { lock.withLock { _lastMissionRunConstraints } }
   var lastResumeRunId: String? { lock.withLock { _lastResumeRunId } }
@@ -831,6 +835,27 @@ final class MockMissionSpineWriteClient: FridayMissionSpineWriteClient, FridayMi
       reason: request.reason,
       proofReceiptCount: request.proofReceipt == nil ? 0 : 1,
       updatedAtMs: 1_780_640_000_123)
+  }
+
+  func submitProviderWorkspaceAction(
+    _ request: ProviderWorkspaceActionRequestWire
+  ) async throws -> ProviderWorkspaceActionResultWire {
+    lock.withLock { _lastProviderWorkspaceAction = request }
+    if case .throwsTransport = behavior {
+      throw FridayWriteClientError.transport("connection refused (write server dark)")
+    }
+    return ProviderWorkspaceActionResultWire(
+      requestId: request.requestId,
+      fridaySessionId: request.fridaySessionId,
+      provider: request.provider,
+      action: request.action,
+      accepted: true,
+      routed: true,
+      status: "verified",
+      truthLabel: "provider_workspace_guarded",
+      proofRef: "proof://provider-workspace/list-sessions",
+      dispatchRef: "dispatch://provider-workspace/list-sessions",
+      missionContext: request.missionContext)
   }
 
   func dispatchMissionBoundAgentRun(
@@ -1851,6 +1876,88 @@ func cancelWorkItemSendsLifecycleWriteAndRefreshes() async {
     proof: [
       "work_item_id": write.lastWorkItemStatus?.workItemId ?? "",
       "target_status": write.lastWorkItemStatus?.targetStatus ?? "",
+    ])
+}
+
+@Test
+@MainActor
+func providerWorkspaceListSessionsSendsGuardedRequestAndRefreshes() async {
+  let write = MockMissionSpineWriteClient(behavior: .intakeReady)
+  let snapshot = FridayHubConsoleCore.WorkbenchSnapshot(
+    missionId: "mission-provider-workspace",
+    fridayConversationId: "fconv_provider_workspace",
+    agentSessionId: "friday-session-1",
+    runtimeFeedStatus: .liveRustHubProjection,
+    statusLabels: [],
+    duplicatePreflight: MissionWorkbenchDuplicatePreflight(
+      status: "none", duplicateMissionId: "", duplicateWorkItemId: ""),
+    routeDecision: MissionWorkbenchRouteDecision(
+      advisorSummary: "Codex owns Provider Workspace list sessions.",
+      selectedRoute: "codex",
+      alternatives: ["claude"],
+      truthLabel: .fridayOwned),
+    providerReceiptRefs: [],
+    channelReceiptRefs: [],
+    workItems: [
+      MissionWorkbenchWorkItem(
+        id: "work-provider-workspace",
+        title: "Provider Workspace list sessions",
+        state: .providerAck,
+        owner: .fridayOwned,
+        proofRef: "proof://provider-workspace/seed",
+        done: false)
+    ],
+    timelinePages: [],
+    memoryCandidates: [],
+    capabilityStates: [],
+    transcriptSections: [])
+  let vm = OperationsOverviewViewModel(
+    client: StaticWorkbenchReadClient(snapshot: snapshot),
+    writeClient: write,
+    newId: { "guard-1" })
+
+  await vm.requestProviderWorkspaceListSessions(snapshot)
+
+  #expect(write.lastProviderWorkspaceAction == ProviderWorkspaceActionRequestWire(
+    requestId: "desktop-provider-workspace-guard-1",
+    fridaySessionId: "friday-session-1",
+    provider: "codex",
+    action: "list_sessions",
+    capabilityId: "provider.codex.list_sessions",
+    payloadRef: nil,
+    missionContext: ProviderWorkspaceMissionContextWire(
+      fridayConversationId: "fconv_provider_workspace",
+      missionId: "mission-provider-workspace",
+      workItemId: "work-provider-workspace")))
+  let key = OperationsOverviewViewModel.providerWorkspaceListSessionsKey
+  guard case .confirmed(let summary, _, _) = vm.providerWorkspaceActionStates[key] else {
+    Issue.record(
+      "expected provider workspace .confirmed, got \(String(describing: vm.providerWorkspaceActionStates[key]))")
+    return
+  }
+  #expect(summary.contains("codex.list_sessions"))
+  #expect(summary.contains("routed=true"))
+  #expect(vm.latestProviderWorkspaceActionReceipt?.proofRef == "proof://provider-workspace/list-sessions")
+  try? writeDesktopActionEvidenceIfRequested(
+    fileSuffix: "provider-workspace-list-sessions",
+    screen: "providerAdmin",
+    actionId: "desktop/providerAdmin/provider-workspace-list-sessions",
+    capabilityId: "provider.codex.list_sessions",
+    evidenceRef: "swift://desktop/providerAdmin/provider-workspace/list-sessions",
+    source: "macos_operations_viewmodel_provider_workspace_action_runtime",
+    proof: [
+      "request_id": write.lastProviderWorkspaceAction?.requestId ?? "",
+      "friday_session_id": write.lastProviderWorkspaceAction?.fridaySessionId ?? "",
+      "provider": write.lastProviderWorkspaceAction?.provider ?? "",
+      "action": write.lastProviderWorkspaceAction?.action ?? "",
+      "capability_id": write.lastProviderWorkspaceAction?.capabilityId ?? "",
+      "mission_id": write.lastProviderWorkspaceAction?.missionContext?.missionId ?? "",
+      "work_item_id": write.lastProviderWorkspaceAction?.missionContext?.workItemId ?? "",
+      "accepted": vm.latestProviderWorkspaceActionReceipt?.accepted ?? false,
+      "routed": vm.latestProviderWorkspaceActionReceipt?.routed ?? false,
+      "truth_label": vm.latestProviderWorkspaceActionReceipt?.truthLabel ?? "",
+      "proof_ref": vm.latestProviderWorkspaceActionReceipt?.proofRef ?? "",
+      "dispatch_ref": vm.latestProviderWorkspaceActionReceipt?.dispatchRef ?? "",
     ])
 }
 

--- a/scripts/ops/friday-desktop-projection-action-evidence.sh
+++ b/scripts/ops/friday-desktop-projection-action-evidence.sh
@@ -37,6 +37,7 @@ run_swift_test() {
 run_swift_test refreshLoadsRepresentativeSnapshot
 run_swift_test loadDetailCallsProviderDoctorReadArm
 run_swift_test loadDetailCallsRunAndNeedsMeReadArms
+run_swift_test providerWorkspaceListSessionsSendsGuardedRequestAndRefreshes
 
 node - "${OUT_DIR}" "${ACTION_RUNTIME_OUT}" <<'NODE'
 const fs = require("node:fs");
@@ -50,11 +51,13 @@ const files = [
   path.join(outDir, "desktop-skills-capability-matrix-action-evidence.json"),
   path.join(outDir, "desktop-media-evidence-refs-action-evidence.json"),
   path.join(outDir, "desktop-provider-admin-check-action-evidence.json"),
+  path.join(outDir, "desktop-provider-workspace-list-sessions-action-evidence.json"),
   path.join(outDir, "desktop-parity-route-readiness-action-evidence.json"),
   path.join(outDir, "desktop-token-ledger-run-readback-action-evidence.json"),
 ];
 const requiredActions = [
   "desktop/providerAdmin/check",
+  "desktop/providerAdmin/provider-workspace-list-sessions",
   "desktop/parity/route-readiness",
   "desktop/diagnostics/proof-refs",
   "desktop/tokenLedger/run-readback",


### PR DESCRIPTION
## Summary
- add a desktop Provider Workspace Guard card that requests the safest Codex list-sessions guard receipt through the sealed WRITE seam
- render accepted/routed/status/blocker/proof/dispatch refs as truth without exposing provider secrets or raw provider execution
- extend the desktop projection action evidence wrapper to include the new provider workspace action proof

## Truth / Safety
- no flag flip, no signing key custody, no provider turn/send_turn action, no prod DB mutation by tests
- the UI requests a guarded Hub receipt only; blocked/accepted false receipts render as truth
- still partial runtime evidence only: not GUI tap proof, not END-BAR, not adoption

## Verification
- git diff --check
- swift test --package-path apps/macos/FridayHubConsole --filter OperationsOverviewViewModelTests
- swift test --package-path apps/macos/FridayHubConsole
- bash scripts/ops/friday-desktop-projection-action-evidence.sh