### PR TITLE
Surface mobile pairing controls first

### DIFF
--- a/apps/friday-ios/Sources/FridayMobileShell/FridayHomeScreen.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayHomeScreen.swift
@@ -28,6 +28,10 @@ struct FridayHomeScreen: View {
   var body: some View {
     ScrollView {
       VStack(spacing: 16) {
+        if showPairingProvisioning {
+          devicePairingCard(viewModel.devicePairing, viewModel.state.projection?.t3ProvisioningStatus)
+        }
+
         switch viewModel.state {
         case .idle, .loading:
           designIntro(
@@ -52,10 +56,6 @@ struct FridayHomeScreen: View {
           unavailableQueueSection(
             title: "Running",
             emptyText: "Connect Friday to see active work and provider progress.")
-        }
-
-        if showPairingProvisioning {
-          devicePairingCard(viewModel.devicePairing, viewModel.state.projection?.t3ProvisioningStatus)
         }
       }
       .padding(16)


### PR DESCRIPTION
## Summary
- place the Device Pairing card first when the app is opened directly to the pairing destination
- keep ordinary Home ordering unchanged
- preserve honest live/pairing/provisioning truth labels and gated controls

## Verification
- git diff --check
- swift test --package-path apps/friday-ios --filter HomeViewModelTests
- apps/friday-ios/build-sim.sh --mode live-loopback --destination pairing --shot /tmp/friday-ios-live-loopback-pairing-first-20260627.png

Truth: this improves the zero-config/QR pairing surface discoverability only. It does not claim real-device pairing adoption, END-BAR, or channel closure.