### PR TITLE
Clarify UI device proof readiness blockers

### DIFF
--- a/scripts/ops/friday-ui-device-proof-readiness.sh
+++ b/scripts/ops/friday-ui-device-proof-readiness.sh
@@ -448,6 +448,25 @@ json_escape() {
   }
 }
 
+emit_blocked_report() {
+  printf '{\n'
+  printf '  "truth": "report_only_not_ui_device_proof",\n'
+  printf '  "status": "blocked",\n'
+  printf '  "notes": ['
+  for i in "${!notes[@]}"; do
+    [ "$i" -gt 0 ] && printf ', '
+    printf '%s' "$(printf '%s' "${notes[$i]}" | json_escape)"
+  done
+  printf '],\n'
+  printf '  "blockers": ['
+  for i in "${!blockers[@]}"; do
+    [ "$i" -gt 0 ] && printf ', '
+    printf '%s' "$(printf '%s' "${blockers[$i]}" | json_escape)"
+  done
+  printf ']\n'
+  printf '}\n'
+}
+
 discover_evidence_dir "$EVIDENCE_DIR"
 export MISSION_ID="${MISSION_ID:-}"
 export MOBILE_EVIDENCE="${MOBILE_EVIDENCE:-}"
@@ -711,7 +730,25 @@ run_gap_report_if_possible() {
   if node "${args[@]}" >"$stdout_out"; then
     status="$(jq -r '.status // "unknown"' "$gap_out" 2>/dev/null || printf 'unknown')"
     notes+=("ui_device_gap_report:${status}:${gap_out}")
-    if [ "$status" != "complete_inputs_observed" ] && [ "${MODE}" = "require-proof" ]; then
+    local channel_deferred_only=0
+    if [ "${DEFER_CHANNEL_PROOF}" = "1" ]; then
+      channel_deferred_only="$(jq -r '
+        (.blockers // []) as $blockers |
+        (.gaps // {}) as $gaps |
+        if
+          ($blockers | length) == 0 and
+          (($gaps.missingObservations // []) | length) == 0 and
+          (($gaps.missingOrderEvents // []) | length) == 0 and
+          (($gaps.missingChecks // []) | length) == 0 and
+          (
+            (($gaps.deferredObservations // []) | length) +
+            (($gaps.deferredOrderEvents // []) | length) +
+            (($gaps.deferredChecks // []) | length)
+          ) > 0
+        then 1 else 0 end
+      ' "$gap_out" 2>/dev/null || printf '0')"
+    fi
+    if [ "$status" != "complete_inputs_observed" ] && [ "${MODE}" = "require-proof" ] && [ "$channel_deferred_only" != "1" ]; then
       blockers+=("ui_device_gap_report:${status}")
     fi
   else
@@ -848,22 +885,8 @@ run_design_action_gap_if_possible
 
 if [ "${MODE}" = "require-proof" ]; then
   printf 'FATAL: UI/device proof not assembled. blockers=%s\n' "${blockers[*]}" >&2
+  emit_blocked_report
   exit 2
 fi
 
-printf '{\n'
-printf '  "truth": "report_only_not_ui_device_proof",\n'
-printf '  "status": "blocked",\n'
-printf '  "notes": ['
-for i in "${!notes[@]}"; do
-  [ "$i" -gt 0 ] && printf ', '
-  printf '%s' "$(printf '%s' "${notes[$i]}" | json_escape)"
-done
-printf '],\n'
-printf '  "blockers": ['
-for i in "${!blockers[@]}"; do
-  [ "$i" -gt 0 ] && printf ', '
-  printf '%s' "$(printf '%s' "${blockers[$i]}" | json_escape)"
-done
-printf ']\n'
-printf '}\n'
+emit_blocked_report

--- a/scripts/ops/friday-uiux-product-closure-readiness.mjs
+++ b/scripts/ops/friday-uiux-product-closure-readiness.mjs
@@ -393,6 +393,10 @@ const nativePassed = nativeAction.status === "passed" && nativeAction.parsed?.st
 const traceabilityPassed = uiuxTraceability.status === "passed" && ["product_runtime_actions_traceable", "traceability_gaps_present"].includes(traceabilityReport.status);
 const runtimeCovered = runtimeReport.status === "runtime_actions_covered";
 const uiDeviceProofAssembled = readinessReport.status === "pass";
+const readinessBlockers = Array.isArray(readinessReport.blockers) ? readinessReport.blockers : [];
+const readinessBlockerDetail = readinessBlockers.length > 0
+  ? readinessBlockers.join(",")
+  : readinessReport.status || "unknown";
 
 if (!clientPassed) block("client_design_contract_failed", String(clientDesign.exitCode));
 if (!nativeLinkagePassed) block("uiux_native_linkage_failed", nativeLinkage.parsed?.status || String(nativeLinkage.exitCode));
@@ -400,7 +404,7 @@ if (requireUiDeviceProof && !selectedVisualProofReady) block("selected_visual_pr
 if (!nativePassed) block("native_action_closure_failed", String(nativeAction.exitCode));
 if (!traceabilityPassed) block("uiux_action_traceability_failed", traceabilityReport.status || String(uiuxTraceability.exitCode));
 if (requireRuntimeActions && !runtimeCovered) block("runtime_actions_not_covered", runtimeReport.status || "unknown");
-if (requireUiDeviceProof && !uiDeviceProofAssembled) block("ui_device_proof_not_assembled", readinessReport.status || "unknown");
+if (requireUiDeviceProof && !uiDeviceProofAssembled) block("ui_device_proof_not_assembled", readinessBlockerDetail);
 
 if (!runtimeCovered) {
   notes.push("runtime_action_evidence_gap_present");


### PR DESCRIPTION
## Summary\n- emit structured readiness JSON even when --require-proof fails\n- avoid treating channel-deferred-only gap reports as an extra strict blocker\n- surface concrete UI/device proof blockers in the product-closure report\n\n## Verification\n- bash -n scripts/ops/friday-ui-device-proof-readiness.sh\n- node --check scripts/ops/friday-uiux-product-closure-readiness.mjs\n- bash scripts/ops/friday-ui-device-proof-readiness.sh --evidence-dir /private/tmp/friday-ui-device-shortlist-og9-strict-nonchannel-20260627T031937Z/evidence --design-action-runtime-evidence-dir /tmp/friday-main-action-runtime-evidence-bundle-with-mobile-approval-20260627T0858Z --defer-channel-proof --require-proof\n- node scripts/ops/friday-uiux-product-closure-readiness.mjs --runtime-evidence-dir=/tmp/friday-main-action-runtime-evidence-bundle-with-mobile-approval-20260627T0858Z --evidence-dir=/tmp/friday-ios-design-capture-current-58061988-20260627 --evidence-dir=/tmp/friday-desktop-ax-capture-current-58061988-20260627 --evidence-dir=/private/tmp/friday-ui-device-shortlist-og9-strict-nonchannel-20260627T031937Z --require-runtime-actions --require-ui-device-proof --defer-channel-proof --out=/tmp/friday-uiux-product-closure-after-topdetail-fix-58061988-20260627.json\n- git diff --check