### PR TITLE
Clarify UIUX residual product blockers

### DIFF
--- a/scripts/ops/check-friday-uiux-action-traceability.mjs
+++ b/scripts/ops/check-friday-uiux-action-traceability.mjs
@@ -439,7 +439,7 @@ const productActionsMissingDesignRuntimeCovered = productActionsMissingDesign
 const productActionsMissingDesignRuntimeMissing = productActionsMissingDesign
   .filter((action) => !action.runtimeEvidenceMatched);
 const destinationsWithoutRuntimeActions = tracedDestinations.filter((destination) => destination.runtimeActionIds.length === 0);
-const destinationsWithBlockers = tracedDestinations.filter((destination) => destination.blockers.length > 0);
+const destinationsWithResidualEndBarBlockers = tracedDestinations.filter((destination) => destination.blockers.length > 0);
 
 if (requireRuntimeEvidence && productActionsMissingRuntime.length > 0) {
   block("product_runtime_actions_missing_evidence", String(productActionsMissingRuntime.length));
@@ -468,7 +468,10 @@ const report = {
     productActionsMissingDesignRuntimeMissing: productActionsMissingDesignRuntimeMissing.length,
     productActionsMissingRuntimeEvidence: productActionsMissingRuntime.length,
     destinationsWithoutRuntimeActions: destinationsWithoutRuntimeActions.length,
-    destinationsStillBlocked: destinationsWithBlockers.length,
+    destinationsWithResidualEndBarBlockers: destinationsWithResidualEndBarBlockers.length,
+    // Deprecated alias for older readers. These are not traceability blockers;
+    // they are product/END-BAR residuals carried by the native readiness contract.
+    destinationsStillBlocked: destinationsWithResidualEndBarBlockers.length,
   },
   designActionRuntime: {
     status: designActionRuntimeReport?.status || "not_run",
@@ -481,6 +484,8 @@ const report = {
       destinations: destinations.length,
       runtimeActionIds: destinations.reduce((sum, destination) => sum + destination.runtimeActionIds.length, 0),
       traceGaps: destinations.filter((destination) => destination.traceStatus === "trace_gaps_present").length,
+      destinationsWithResidualEndBarBlockers: destinations.filter((destination) => destination.blockers.length > 0).length,
+      // Deprecated alias for older readers.
       blockedDestinations: destinations.filter((destination) => destination.blockers.length > 0).length,
     }];
   })),
@@ -517,7 +522,15 @@ const report = {
       tier,
       blockers,
     })).slice(0, compact ? 40 : undefined),
-    destinationsStillBlocked: destinationsWithBlockers.map(({ surface, id, title, tier, blockers }) => ({
+    residualEndBarBlockers: destinationsWithResidualEndBarBlockers.map(({ surface, id, title, tier, blockers }) => ({
+      surface,
+      id,
+      title,
+      tier,
+      blockers,
+    })).slice(0, compact ? 40 : undefined),
+    // Deprecated alias for older readers.
+    destinationsStillBlocked: destinationsWithResidualEndBarBlockers.map(({ surface, id, title, tier, blockers }) => ({
       surface,
       id,
       title,

--- a/scripts/ops/friday-uiux-product-closure-readiness.mjs
+++ b/scripts/ops/friday-uiux-product-closure-readiness.mjs
@@ -386,6 +386,11 @@ if (existsSync(`${repoRoot}/scripts/ops/friday-ui-device-proof-readiness.sh`)) {
 const runtimeReport = designRuntime.parsed || {};
 const readinessReport = uiDeviceReadiness?.parsed || {};
 const traceabilityReport = uiuxTraceability.parsed || {};
+const residualEndBarBlockers = Array.isArray(traceabilityReport.gaps?.residualEndBarBlockers)
+  ? traceabilityReport.gaps.residualEndBarBlockers
+  : Array.isArray(traceabilityReport.gaps?.destinationsStillBlocked)
+    ? traceabilityReport.gaps.destinationsStillBlocked
+    : [];
 const clientPassed = clientDesign.status === "passed" && clientDesign.parsed?.status === "passed";
 const nativeLinkagePassed = nativeLinkage.status === "passed" && nativeLinkage.parsed?.status === "linked";
 const selectedVisualProofReady = selectedVisualProof.status === "passed" && selectedVisualProof.parsed?.status === "selected_visual_proof_ready";
@@ -461,6 +466,8 @@ const report = {
       counts: traceabilityReport.counts || null,
       bySurface: traceabilityReport.bySurface || null,
       gaps: traceabilityReport.gaps || null,
+      residualEndBarBlockers,
+      caveat: "Residual END-BAR blockers are product maturity/user-proof requirements, not missing runtimeActionId traceability when product_runtime_actions_traceable is reported.",
     },
     designActionRuntime: {
       status: runtimeReport.status || designRuntime.status,
@@ -496,6 +503,11 @@ const report = {
       target: "selected-visual-proof",
       action: "capture fresh current-HEAD native mobile destination screenshots and desktop visual/accessibility capture for the operator-selected baseline; static Swift linkage and old proof PNGs do not close visual parity",
       blockers: selectedVisualProof.parsed?.blockers || [],
+    }]),
+    ...(residualEndBarBlockers.length === 0 ? [] : [{
+      target: "endbar-residual-product-proof",
+      action: "close the remaining real-user/product-maturity proofs listed by residualEndBarBlockers; these do not mean runtime action wiring is missing, but they still prevent END-BAR/adoption claims",
+      blockers: residualEndBarBlockers,
     }]),
   ],
   notes,

--- a/test/unit/qa/friday-uiux-action-traceability-cli.test.ts
+++ b/test/unit/qa/friday-uiux-action-traceability-cli.test.ts
@@ -292,4 +292,122 @@ describe("check-friday-uiux-action-traceability", () => {
       rmSync(root, { recursive: true, force: true });
     }
   });
+
+  it("reports product contract blockers as END-BAR residuals, not traceability failures", () => {
+    const root = mkdtempSync(join(tmpdir(), "friday-uiux-action-traceability-residual-"));
+    try {
+      const designRoot = join(root, "design");
+      writeFile(designRoot, "ACTION-CONTRACT.md", `# Friday Action Contract — mobile + desktop
+
+**This is a wiring contract for the later Rust/native agent, NOT runtime proof.** Every row is design-proof; wired_registry ≠ runtime PASS.
+
+| Surface | Screen [state] | action_id | Label | capability_id | reg | reg_status | truth_status | result/target | Rust/Hub owner · gate · test expectation |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| mobile | home | refresh | Retry now | transport_connection_state | ✓ | wired | wired_registry | result:confirmed | Runtime test must prove gate enforcement. |
+`);
+      writeFile(
+        root,
+        "apps/friday-ios/Sources/FridayMobileShellCore/MobileProductReadinessContract.swift",
+        `enum MobileProductDestinationID {
+        case home
+        var contract: MobileProductDestinationContract {
+          switch self {
+          case .home:
+          return contract(
+            title: "Friday Home",
+            systemImage: "house",
+            tier: .liveReadProjection,
+            runtimeActionIds: ["mobile/home/refresh"],
+            blockers: [.init(.needsRuntimeEvidence, label: "same-run user proof")])
+        }
+        }
+        private func contract(
+          title: String,
+          systemImage: String,
+          tier: MobileProductLoopTier,
+          runtimeActionIds: [String],
+          blockers: [MobileProductBlocker]
+        ) -> MobileProductDestinationContract { fatalError() }
+        }
+`,
+      );
+      writeFile(
+        root,
+        "apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/DesktopProductReadinessContract.swift",
+        `enum DesktopProductDestinationID {
+        case empty
+        var contract: DesktopProductDestinationContract {
+          switch self {
+          case .empty:
+          return contract(
+            title: "Empty",
+            systemImage: "circle",
+            tier: .navigationShell,
+            runtimeActionIds: [],
+            blockers: [])
+        }
+        }
+        private func contract(
+          title: String,
+          systemImage: String,
+          tier: DesktopProductLoopTier,
+          runtimeActionIds: [String],
+          blockers: [DesktopProductBlocker]
+        ) -> DesktopProductDestinationContract { fatalError() }
+        }
+`,
+      );
+      const evidenceDir = join(root, "evidence");
+      writeFile(evidenceDir, "mobile/action-runtime-evidence.json", JSON.stringify({
+        actions: [
+          {
+            surface: "mobile",
+            screen: "home",
+            action_id: "refresh",
+            capability_id: "transport_connection_state",
+            status: "pass",
+            evidence_ref: "proof://mobile/home-refresh",
+          },
+        ],
+      }, null, 2));
+
+      const output = execFileSync("node", [
+        script,
+        `--repo-root=${root}`,
+        `--design-root=${designRoot}`,
+        "--runtime-evidence-dir",
+        evidenceDir,
+        "--compact",
+      ], { cwd: process.cwd(), encoding: "utf8" });
+      const report = JSON.parse(output) as {
+        status?: string;
+        counts?: {
+          productActionsMissingRuntimeEvidence?: number;
+          destinationsWithResidualEndBarBlockers?: number;
+          destinationsStillBlocked?: number;
+        };
+        gaps?: {
+          residualEndBarBlockers?: Array<{ id?: string; blockers?: Array<{ kind?: string; label?: string }> }>;
+          destinationsStillBlocked?: Array<unknown>;
+        };
+      };
+
+      expect(report.status).toBe("product_runtime_actions_traceable");
+      expect(report.counts?.productActionsMissingRuntimeEvidence).toBe(0);
+      expect(report.counts?.destinationsWithResidualEndBarBlockers).toBe(1);
+      expect(report.counts?.destinationsStillBlocked).toBe(1);
+      expect(report.gaps?.residualEndBarBlockers).toEqual([
+        expect.objectContaining({
+          id: "home",
+          blockers: [expect.objectContaining({
+            kind: "needsRuntimeEvidence",
+            label: "same-run user proof",
+          })],
+        }),
+      ]);
+      expect(report.gaps?.destinationsStillBlocked).toEqual(report.gaps?.residualEndBarBlockers);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
 });


### PR DESCRIPTION
## Summary
- separates product/END-BAR residual blockers from runtime action traceability gaps
- adds residualEndBarBlockers to the UIUX traceability and product closure reports while keeping deprecated aliases for existing readers
- covers the distinction with a focused CLI test

## Verification
- node --check scripts/ops/check-friday-uiux-action-traceability.mjs
- node --check scripts/ops/friday-uiux-product-closure-readiness.mjs
- npm test -- --run test/unit/qa/friday-uiux-action-traceability-cli.test.ts
- node scripts/ops/friday-uiux-product-closure-readiness.mjs --runtime-evidence-dir=/tmp/friday-main-action-runtime-evidence-bundle-with-mobile-approval-20260627T0858Z --evidence-dir=/tmp/friday-ios-design-capture-current-58061988-20260627 --evidence-dir=/tmp/friday-desktop-ax-capture-current-58061988-20260627 --evidence-dir=/private/tmp/friday-ui-device-shortlist-og9-strict-nonchannel-20260627T031937Z --require-runtime-actions --require-ui-device-proof --defer-channel-proof --out=/private/tmp/friday-uiux-product-closure-residual-check-12aeb05e-20260627.json (expected blocked on channel-deferred strict assembly)