### PR TITLE
Expose UIUX residual evidence overlays

### DIFF
--- a/scripts/ops/check-friday-uiux-action-traceability.mjs
+++ b/scripts/ops/check-friday-uiux-action-traceability.mjs
@@ -441,6 +441,26 @@ const productActionsMissingDesignRuntimeMissing = productActionsMissingDesign
 const destinationsWithoutRuntimeActions = tracedDestinations.filter((destination) => destination.runtimeActionIds.length === 0);
 const destinationsWithResidualEndBarBlockers = tracedDestinations.filter((destination) => destination.blockers.length > 0);
 
+function residualEvidenceOverlay(destination) {
+  const actions = destination.actionTrace || [];
+  const covered = actions.filter((action) => action.runtimeEvidenceMatched);
+  return {
+    status: actions.length === 0
+      ? "no_runtime_actions_declared"
+      : covered.length === actions.length
+        ? "runtime_action_evidence_attached_not_endbar"
+        : covered.length > 0
+          ? "partial_runtime_action_evidence_attached_not_endbar"
+          : "no_runtime_action_evidence_attached",
+    runtimeActionCount: actions.length,
+    runtimeActionsCovered: covered.length,
+    runtimeActionsMissing: actions.length - covered.length,
+    evidenceRefs: unique(covered.flatMap((action) => action.evidenceRefs || [])),
+    evidenceTruthLabels: unique(covered.flatMap((action) => action.evidenceTruthLabels || [])),
+    caveat: "Runtime evidence attached here does not clear ProductReadinessContract blockers or prove END-BAR; strict UI/device proof and product-maturity checks remain required.",
+  };
+}
+
 if (requireRuntimeEvidence && productActionsMissingRuntime.length > 0) {
   block("product_runtime_actions_missing_evidence", String(productActionsMissingRuntime.length));
 }
@@ -522,21 +542,43 @@ const report = {
       tier,
       blockers,
     })).slice(0, compact ? 40 : undefined),
-    residualEndBarBlockers: destinationsWithResidualEndBarBlockers.map(({ surface, id, title, tier, blockers }) => ({
-      surface,
-      id,
-      title,
-      tier,
-      blockers,
+    residualEndBarBlockers: destinationsWithResidualEndBarBlockers.map((destination) => ({
+      surface: destination.surface,
+      id: destination.id,
+      title: destination.title,
+      tier: destination.tier,
+      blockers: destination.blockers,
+      evidenceOverlay: residualEvidenceOverlay(destination),
     })).slice(0, compact ? 40 : undefined),
     // Deprecated alias for older readers.
-    destinationsStillBlocked: destinationsWithResidualEndBarBlockers.map(({ surface, id, title, tier, blockers }) => ({
-      surface,
-      id,
-      title,
-      tier,
-      blockers,
+    destinationsStillBlocked: destinationsWithResidualEndBarBlockers.map((destination) => ({
+      surface: destination.surface,
+      id: destination.id,
+      title: destination.title,
+      tier: destination.tier,
+      blockers: destination.blockers,
+      evidenceOverlay: residualEvidenceOverlay(destination),
     })).slice(0, compact ? 40 : undefined),
+  },
+  residualEndBarEvidence: {
+    truth: "runtime_action_evidence_overlay_not_endbar_not_strict_ui_device_proof",
+    destinationsWithResidualBlockers: destinationsWithResidualEndBarBlockers.length,
+    destinationsWithAllRuntimeActionsCovered: destinationsWithResidualEndBarBlockers
+      .filter((destination) => {
+        const overlay = residualEvidenceOverlay(destination);
+        return overlay.status === "runtime_action_evidence_attached_not_endbar";
+      }).length,
+    destinationsWithPartialRuntimeActionsCovered: destinationsWithResidualEndBarBlockers
+      .filter((destination) => {
+        const overlay = residualEvidenceOverlay(destination);
+        return overlay.status === "partial_runtime_action_evidence_attached_not_endbar";
+      }).length,
+    destinationsWithNoRuntimeActionEvidence: destinationsWithResidualEndBarBlockers
+      .filter((destination) => {
+        const overlay = residualEvidenceOverlay(destination);
+        return overlay.status === "no_runtime_action_evidence_attached";
+      }).length,
+    caveat: "These counts summarize evidence attached beside residual blockers only. They never remove native product blockers, satisfy deferred channel proof, or mark END-BAR ready.",
   },
   destinations: compact ? undefined : tracedDestinations,
   blockers,

--- a/scripts/ops/friday-uiux-product-closure-readiness.mjs
+++ b/scripts/ops/friday-uiux-product-closure-readiness.mjs
@@ -391,6 +391,11 @@ const residualEndBarBlockers = Array.isArray(traceabilityReport.gaps?.residualEn
   : Array.isArray(traceabilityReport.gaps?.destinationsStillBlocked)
     ? traceabilityReport.gaps.destinationsStillBlocked
     : [];
+const residualEndBarEvidence = traceabilityReport.residualEndBarEvidence || {
+  truth: "runtime_action_evidence_overlay_not_available_not_endbar",
+  destinationsWithResidualBlockers: residualEndBarBlockers.length,
+  caveat: "No residual evidence overlay was emitted by the traceability report; residual blockers remain product maturity/user-proof requirements.",
+};
 const clientPassed = clientDesign.status === "passed" && clientDesign.parsed?.status === "passed";
 const nativeLinkagePassed = nativeLinkage.status === "passed" && nativeLinkage.parsed?.status === "linked";
 const selectedVisualProofReady = selectedVisualProof.status === "passed" && selectedVisualProof.parsed?.status === "selected_visual_proof_ready";
@@ -467,6 +472,7 @@ const report = {
       bySurface: traceabilityReport.bySurface || null,
       gaps: traceabilityReport.gaps || null,
       residualEndBarBlockers,
+      residualEndBarEvidence,
       caveat: "Residual END-BAR blockers are product maturity/user-proof requirements, not missing runtimeActionId traceability when product_runtime_actions_traceable is reported.",
     },
     designActionRuntime: {
@@ -506,8 +512,9 @@ const report = {
     }]),
     ...(residualEndBarBlockers.length === 0 ? [] : [{
       target: "endbar-residual-product-proof",
-      action: "close the remaining real-user/product-maturity proofs listed by residualEndBarBlockers; these do not mean runtime action wiring is missing, but they still prevent END-BAR/adoption claims",
+      action: "close the remaining real-user/product-maturity proofs listed by residualEndBarBlockers; residualEndBarEvidence may show attached runtime evidence, but that evidence does not clear product blockers or satisfy END-BAR by itself",
       blockers: residualEndBarBlockers,
+      evidence: residualEndBarEvidence,
     }]),
   ],
   notes,

--- a/test/unit/qa/friday-uiux-action-traceability-cli.test.ts
+++ b/test/unit/qa/friday-uiux-action-traceability-cli.test.ts
@@ -387,8 +387,23 @@ describe("check-friday-uiux-action-traceability", () => {
           destinationsStillBlocked?: number;
         };
         gaps?: {
-          residualEndBarBlockers?: Array<{ id?: string; blockers?: Array<{ kind?: string; label?: string }> }>;
+          residualEndBarBlockers?: Array<{
+            id?: string;
+            blockers?: Array<{ kind?: string; label?: string }>;
+            evidenceOverlay?: {
+              status?: string;
+              runtimeActionCount?: number;
+              runtimeActionsCovered?: number;
+              runtimeActionsMissing?: number;
+              evidenceRefs?: string[];
+            };
+          }>;
           destinationsStillBlocked?: Array<unknown>;
+        };
+        residualEndBarEvidence?: {
+          destinationsWithResidualBlockers?: number;
+          destinationsWithAllRuntimeActionsCovered?: number;
+          destinationsWithNoRuntimeActionEvidence?: number;
         };
       };
 
@@ -403,8 +418,20 @@ describe("check-friday-uiux-action-traceability", () => {
             kind: "needsRuntimeEvidence",
             label: "same-run user proof",
           })],
+          evidenceOverlay: expect.objectContaining({
+            status: "runtime_action_evidence_attached_not_endbar",
+            runtimeActionCount: 1,
+            runtimeActionsCovered: 1,
+            runtimeActionsMissing: 0,
+            evidenceRefs: ["proof://mobile/home-refresh"],
+          }),
         }),
       ]);
+      expect(report.residualEndBarEvidence).toEqual(expect.objectContaining({
+        destinationsWithResidualBlockers: 1,
+        destinationsWithAllRuntimeActionsCovered: 1,
+        destinationsWithNoRuntimeActionEvidence: 0,
+      }));
       expect(report.gaps?.destinationsStillBlocked).toEqual(report.gaps?.residualEndBarBlockers);
     } finally {
       rmSync(root, { recursive: true, force: true });

--- a/test/unit/qa/friday-uiux-product-closure-readiness-contract.test.ts
+++ b/test/unit/qa/friday-uiux-product-closure-readiness-contract.test.ts
@@ -20,4 +20,12 @@ describe("friday-uiux-product-closure-readiness contract", () => {
     expect(source).toContain("channel_deferred_strict_assembly_blocked");
     expect(source).not.toContain('report.status === "blocked" && deferChannelProof');
   });
+
+  it("surfaces residual evidence overlays without clearing END-BAR blockers", () => {
+    const source = readFileSync("scripts/ops/friday-uiux-product-closure-readiness.mjs", "utf8");
+
+    expect(source).toContain("residualEndBarEvidence");
+    expect(source).toContain("does not clear product blockers or satisfy END-BAR by itself");
+    expect(source).toContain("residualEndBarBlockers");
+  });
 });


### PR DESCRIPTION
## Summary\n- add an evidence overlay beside UIUX residual END-BAR blockers without clearing those blockers\n- pass the overlay through product closure readiness and recommended next actions\n- cover the distinction with QA tests so runtime evidence cannot be mistaken for END-BAR proof\n\n## Verification\n- node --check scripts/ops/check-friday-uiux-action-traceability.mjs\n- node --check scripts/ops/friday-uiux-product-closure-readiness.mjs\n- git diff --check\n- npm test -- --run test/unit/qa/friday-uiux-action-traceability-cli.test.ts test/unit/qa/friday-uiux-product-closure-readiness-contract.test.ts\n- product closure overlay check stayed blocked on ui_device_proof_not_assembled\n\nTruth: reporting-only; does not satisfy strict UI/device proof, channel proof, END-BAR, adoption, organic load, or operator signing.