### PR TITLE
Expose desktop unavailable status labels

### DIFF
--- a/apps/macos/FridayHubConsole/Sources/FridayHubConsole/FridayHubConsoleApp.swift
+++ b/apps/macos/FridayHubConsole/Sources/FridayHubConsole/FridayHubConsoleApp.swift
@@ -125,10 +125,30 @@ struct FridayHubConsoleApp: App {
     // back to the mock, which would fabricate a ready view the live seam did not produce.
     // (The actual connect happens later in the shell's async refresh; this is non-blocking.)
     do {
-      return try RealReadClientFactory.makeLive(missionId: Self.missionId)
+      return try RealReadClientFactory.makeLive(config: Self.liveReadConfig, missionId: Self.missionId)
     } catch {
       return RealReadClientFactory.makeHonestlyUnavailable(reason: "\(error)")
     }
+  }
+
+  /// Optional operator/proof override for the live read seam. Defaults remain the production
+  /// loopback read-projection server; this is used to prove honest fail-closed UI against an
+  /// isolated dark port without touching the real hub.
+  private static var liveReadConfig: ReadProjectionServerConfig {
+    let env = ProcessInfo.processInfo.environment
+    let base = ReadProjectionServerConfig.liveLoopback
+    let host = env["FRIDAY_CONSOLE_LIVE_READ_HOST"]?.trimmingCharacters(in: .whitespacesAndNewlines)
+    let portRaw = env["FRIDAY_CONSOLE_LIVE_READ_PORT"]?.trimmingCharacters(in: .whitespacesAndNewlines)
+    let connectRaw = env["FRIDAY_CONSOLE_LIVE_READ_CONNECT_TIMEOUT"]?.trimmingCharacters(in: .whitespacesAndNewlines)
+    let receiveRaw = env["FRIDAY_CONSOLE_LIVE_READ_RECEIVE_TIMEOUT"]?.trimmingCharacters(in: .whitespacesAndNewlines)
+    let port = portRaw.flatMap(UInt16.init) ?? base.port
+    let connectTimeout = connectRaw.flatMap(TimeInterval.init) ?? base.connectTimeout
+    let receiveTimeout = receiveRaw.flatMap(TimeInterval.init) ?? base.receiveTimeout
+    return ReadProjectionServerConfig(
+      host: host?.isEmpty == false ? host! : base.host,
+      port: port,
+      connectTimeout: connectTimeout,
+      receiveTimeout: receiveTimeout)
   }
 
   /// The mission-spine WRITE client the shell uses (Lane-D entry-point-A). Mirrors `readClient`:

--- a/apps/macos/FridayHubConsole/Sources/FridayHubConsole/OperationsOverviewScreen.swift
+++ b/apps/macos/FridayHubConsole/Sources/FridayHubConsole/OperationsOverviewScreen.swift
@@ -525,6 +525,9 @@ struct OperationsOverviewScreen: View {
 /// This is the honest "unavailable" state — never a fake-ready screen.
 struct UnavailableView: View {
   let reason: String
+  private var labels: [MissionWorkbenchStatusLabel] {
+    MissionWorkbenchStatusLabel.unavailableReasonLabels(reason)
+  }
 
   var body: some View {
     VStack(spacing: 10) {
@@ -538,13 +541,19 @@ struct UnavailableView: View {
         .font(.system(size: 12))
         .foregroundStyle(HubTheme.textSecondary)
         .multilineTextAlignment(.center)
+      HStack(spacing: 6) {
+        ForEach(labels, id: \.rawValue) { label in
+          label.chip
+            .accessibilityIdentifier("friday.desktop.status-label.\(label.rawValue)")
+        }
+      }
       Text("Showing this as truth — no cached or fabricated status is presented.")
         .font(.system(size: 10))
         .foregroundStyle(HubTheme.textSecondary)
     }
     .padding(28)
     .frame(maxWidth: .infinity, maxHeight: .infinity)
-    .accessibilityElement(children: .combine)
+    .accessibilityElement(children: .contain)
     .accessibilityLabel("Hub projection unavailable. \(reason)")
     .accessibilityIdentifier("friday.desktop.unavailable")
   }

--- a/apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/WorkbenchSnapshot.swift
+++ b/apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/WorkbenchSnapshot.swift
@@ -87,6 +87,49 @@ public enum MissionWorkbenchStatusLabel: String, Codable, Sendable, Equatable {
     let raw = try decoder.singleValueContainer().decode(String.self)
     self = MissionWorkbenchStatusLabel(rawValue: raw) ?? .unknown
   }
+
+  /// Conservative user-visible facets for an unavailable live read. A dark/offline read seam is
+  /// also a stale feed because no fresh projection can be read. These labels describe the rendered
+  /// client state only; they do not fabricate `WorkbenchSnapshot.statusLabels`.
+  public static func unavailableReasonLabels(_ reason: String) -> [MissionWorkbenchStatusLabel] {
+    let lower = reason.lowercased()
+    var labels: [MissionWorkbenchStatusLabel] = []
+    if lower.contains("stale")
+      || lower.contains("offline")
+      || lower.contains("no connection")
+      || lower.contains("connection refused")
+      || lower.contains("connect failed")
+      || lower.contains("connect waiting")
+      || lower.contains("timed out")
+      || lower.contains("no server")
+      || lower.contains("server dark")
+    {
+      labels.append(.stale)
+    }
+    if lower.contains("offline")
+      || lower.contains("no connection")
+      || lower.contains("connection refused")
+      || lower.contains("connect failed")
+      || lower.contains("connect waiting")
+      || lower.contains("timed out")
+      || lower.contains("no server")
+      || lower.contains("server dark")
+    {
+      labels.append(.offline)
+    }
+    if lower.contains("error")
+      || lower.contains("unavailable")
+      || lower.contains("503")
+      || lower.contains("invalid")
+      || lower.contains("unexpected")
+      || lower.contains("malformed")
+      || lower.contains("projection")
+      || labels.contains(.offline)
+    {
+      labels.append(.error)
+    }
+    return labels.isEmpty ? [.error] : Array(Set(labels)).sorted { $0.rawValue < $1.rawValue }
+  }
 }
 
 public enum MissionWorkbenchCapabilityKind: String, Codable, Sendable, Equatable {

--- a/apps/macos/FridayHubConsole/Tests/FridayHubConsoleCoreTests/OperationsOverviewViewModelTests.swift
+++ b/apps/macos/FridayHubConsole/Tests/FridayHubConsoleCoreTests/OperationsOverviewViewModelTests.swift
@@ -164,6 +164,13 @@ func refreshRendersUnavailableWhenOffline() async {
 }
 
 @Test
+func unavailableReasonLabelsAreClientStateOnly() {
+  #expect(MissionWorkbenchStatusLabel.unavailableReasonLabels("Hub offline — no connection") == [.error, .offline, .stale])
+  #expect(MissionWorkbenchStatusLabel.unavailableReasonLabels("Projection unavailable: stale read") == [.error, .stale])
+  #expect(MissionWorkbenchStatusLabel.unavailableReasonLabels("Hub unavailable (HTTP 503)") == [.error])
+}
+
+@Test
 func snapshotExercisesEveryHonestRenderingRule() {
   let snapshot = MockReadClient.representativeSnapshot
 

--- a/scripts/ops/friday-desktop-ax-accessibility-capture.mjs
+++ b/scripts/ops/friday-desktop-ax-accessibility-capture.mjs
@@ -514,6 +514,7 @@ process.on("exit", () => {
 const observedActions = [];
 const rawSnapshots = [];
 const missingTargets = [];
+const observedStatusEvents = new Set();
 if (blockers.length === 0) {
   const byDestination = new Map();
   for (const target of targets) {
@@ -552,6 +553,39 @@ if (blockers.length === 0) {
     const raw = captureTreeRaw();
     rawSnapshots.push(`--- destination=${destination} nav=${navStatus} ---\n${raw}`);
     const elements = parseRawTree(raw);
+    for (const [label, event] of [
+      ["stale", "stale_label_visible"],
+      ["offline", "offline_label_visible"],
+      ["error", "error_label_visible"],
+    ]) {
+      const key = `desktop:${event}`;
+      if (observedStatusEvents.has(key)) continue;
+      const identifier = `friday.desktop.status-label.${label}`;
+      const display = label.toUpperCase();
+      const matchedLabel = elements.find((element) =>
+        element.identifier.includes(identifier)
+        || element.name === display
+        || element.description === display);
+      if (!matchedLabel) continue;
+      observedStatusEvents.add(key);
+      observedActions.push({
+        screen: destination,
+        runtimeActionId: `desktop/status-label/${label}`,
+        action_id: `desktop/status-label/${label}`,
+        capability_id: `desktop/status-label/${label}`,
+        accessibility_id: identifier,
+        interaction: "visible",
+        status: "pass",
+        event,
+        evidence_ref: rawPath,
+        captured_at: new Date().toISOString(),
+        workbench_mission_id: workbenchMissionId || null,
+        matched_role: matchedLabel.role,
+        matched_name: matchedLabel.name,
+        matched_description: matchedLabel.description,
+        matched_by: matchedLabel.identifier.includes(identifier) ? "accessibility_id" : "visible_label",
+      });
+    }
     for (const target of destinationTargets) {
       let matchKind = "none";
       const matched = elements.find((element) => {

--- a/test/unit/qa/friday-desktop-ax-accessibility-capture-contract.test.ts
+++ b/test/unit/qa/friday-desktop-ax-accessibility-capture-contract.test.ts
@@ -56,4 +56,14 @@ describe("friday-desktop-ax-accessibility-capture contract", () => {
     expect(source).toContain("friday-ui-device-accessibility-click-capture.mjs");
     expect(navSource).toContain(".accessibilityIdentifier(\"friday.desktop.nav.\\(destination.rawValue)\")");
   });
+
+  it("only emits status-label events from visible accessibility labels", () => {
+    const source = readFileSync(script, "utf8");
+
+    expect(source).toContain("friday.desktop.status-label.");
+    expect(source).toContain("stale_label_visible");
+    expect(source).toContain("offline_label_visible");
+    expect(source).toContain("error_label_visible");
+    expect(source).toContain("matched_by: matchedLabel.identifier.includes(identifier) ? \"accessibility_id\" : \"visible_label\"");
+  });
 });

--- a/test/unit/qa/friday-desktop-initial-destination-contract.test.ts
+++ b/test/unit/qa/friday-desktop-initial-destination-contract.test.ts
@@ -11,7 +11,8 @@ describe("FridayHubConsole initial destination proof seam", () => {
     expect(app).toContain("--initial-destination=");
     expect(app).toContain("FRIDAY_CONSOLE_MISSION_ID");
     expect(app).toContain("--mission-id=");
-    expect(app).toContain("RealReadClientFactory.makeLive(missionId: Self.missionId)");
+    expect(app).toContain("RealReadClientFactory.makeLive(config: Self.liveReadConfig, missionId: Self.missionId)");
+    expect(app).toContain("private static var liveReadConfig: ReadProjectionServerConfig");
     expect(app).toContain("return .operations");
     expect(shell).toContain("initialDestination: HubDestination = .operations");
     expect(shell).toContain("_destination = State(initialValue: initialDestination)");


### PR DESCRIPTION
## Summary
- expose conservative OFFLINE/ERROR/STALE client-state labels for desktop honest-unavailable rendering without fabricating WorkbenchSnapshot statusLabels
- allow the desktop console live read seam to be pointed at an isolated proof port via existing FRIDAY_CONSOLE_LIVE_READ_* env vars while keeping default live loopback unchanged
- teach the real macOS AX capture bridge to emit status-label events only when those labels are actually visible in the Accessibility tree

## Verification
- node --check scripts/ops/friday-desktop-ax-accessibility-capture.mjs
- git diff --check
- npm test -- --run test/unit/qa/friday-desktop-ax-accessibility-capture-contract.test.ts
- swift test --package-path apps/macos/FridayHubConsole
- real AX fail-closed proof on isolated port 49231 produced STALE/OFFLINE/ERROR events: /private/tmp/friday-desktop-unavailable-labels-normalized-v3-a3981c31-20260627T125732Z/accessibility-click-events.jsonl
- stress producer with merged live/device/status events is ready with no status-label blockers: /private/tmp/friday-real-stress-capture-plus-all-status-labels-a3981c31-20260627T1258Z/stress-events.jsonl

Truth: not END-BAR, not GO-LIVE, not channel proof. The current non-channel readiness wrapper still reports blocked on channel-deferred strict assembly and UI gap report exit_2; this PR only closes the desktop unavailable status-label evidence gap.