### PR TITLE
Preserve same-run events when workbench bridge is empty

### DIFF
--- a/scripts/ops/friday-ui-device-proof-readiness.sh
+++ b/scripts/ops/friday-ui-device-proof-readiness.sh
@@ -566,15 +566,18 @@ derive_workbench_events_if_possible() {
   fi
 
   if node "${args[@]}" >"$stdout_out"; then
-    if [ -n "$existing_events" ]; then
+    if [ -s "$derived_out" ] && [ -n "$existing_events" ]; then
       awk '!seen[$0]++' "$existing_events" "$derived_out" >"$merged_out"
       SAME_RUN_EVENTS="$merged_out"
       notes+=("workbench_snapshot_events_merge:ready:${merged_out}")
-    else
+      notes+=("workbench_snapshot_events_bridge:ready:${derived_out}")
+    elif [ -s "$derived_out" ]; then
       SAME_RUN_EVENTS="$derived_out"
+      notes+=("workbench_snapshot_events_bridge:ready:${derived_out}")
+    else
+      notes+=("workbench_snapshot_events_bridge:no_derived_events:${stdout_out}")
     fi
     export SAME_RUN_EVENTS
-    notes+=("workbench_snapshot_events_bridge:ready:${derived_out}")
   else
     local rc=$?
     blockers+=("workbench_snapshot_events_bridge:exit_${rc}")

--- a/test/unit/qa/friday-ui-device-proof-readiness-cli.test.ts
+++ b/test/unit/qa/friday-ui-device-proof-readiness-cli.test.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from "node:child_process";
-import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
@@ -1110,6 +1110,48 @@ describe("friday-ui-device-proof-readiness", () => {
         .map((line) => JSON.parse(line) as { event?: string });
       expect(rows).toContainEqual(expect.objectContaining({ event: "proof_receipt_visible_before_done" }));
       expect(rows).toContainEqual(expect.objectContaining({ event: "mission_workbench_visible" }));
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps discovered same-run events when the workbench diagnostic bridge emits no derived events", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "friday-ui-device-readiness-empty-workbench-"));
+    try {
+      const files = writePartialEvidenceDir(tempDir);
+      writeFileSync(join(tempDir, "workbench-snapshot.json"), JSON.stringify({
+        snapshot: {
+          missionId,
+          fridayConversationId: "conversation_cli_ui_device_readiness",
+          runtimeFeedStatus: "live_rust_hub_projection",
+          statusLabels: [],
+          workItems: [],
+        },
+      }, null, 2));
+
+      const stdout = execFileSync("bash", [
+        "scripts/ops/friday-ui-device-proof-readiness.sh",
+        "--evidence-dir",
+        tempDir,
+      ], {
+        cwd: process.cwd(),
+        encoding: "utf8",
+      });
+      const result = JSON.parse(stdout.slice(stdout.indexOf("{"))) as {
+        notes?: string[];
+        blockers?: string[];
+      };
+
+      expect(result.notes?.some((note) => note.includes("workbench_snapshot_events_bridge:no_derived_events"))).toBe(true);
+      expect(result.notes?.some((note) => note.includes(`resolved_SAME_RUN_EVENTS:${files.events}`))).toBe(true);
+      expect(result.blockers).toContain("ui_device_proof_evidence:missing_required_real_evidence_env");
+      expect(result.blockers ?? []).not.toContain("ui_device_gap_report:exit_2");
+      expect(existsSync(join(tempDir, "same-run-events.merged.jsonl"))).toBe(false);
+
+      const gapReport = JSON.parse(readFileSync(join(tempDir, "gap-report.json"), "utf8")) as {
+        blockers?: Array<{ code?: string }>;
+      };
+      expect(gapReport.blockers?.some((blocker) => blocker.code === "events_unreadable")).toBe(false);
     } finally {
       rmSync(tempDir, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary
- keep an existing SAME_RUN_EVENTS input when the workbench diagnostic bridge exits successfully but emits no derived events
- record a no_derived_events note instead of pointing readiness/gap-report at a missing workbench-derived-events.jsonl
- add regression coverage for the empty diagnostic bridge path

## Verification
- bash -n scripts/ops/friday-ui-device-proof-readiness.sh
- npm test -- --run test/unit/qa/friday-ui-device-proof-readiness-cli.test.ts
- git diff --check
- real current non-channel readiness with explicit same-run events + action runtime bundle: /private/tmp/friday-nonchannel-readiness-fixed-event-bridge-9be4f0f1-20260627T131227Z/readiness.stdout

Truth: not END-BAR, not GO-LIVE, not channel proof. This removes a false unreadable-events blocker; current remaining non-channel design-action gap is mobile approval approve/reject runtime evidence.