### PR TITLE
Expose UI device proof assembly gaps

### DIFF
--- a/scripts/ops/friday-ui-device-capture-dir.mjs
+++ b/scripts/ops/friday-ui-device-capture-dir.mjs
@@ -161,6 +161,8 @@ let copiedManifest = "";
 let derivedEvents = "";
 let mergedEvents = "";
 let reuseSummary = null;
+let derivedManifestProbe = null;
+let mergeProbe = null;
 if (readyToWrite) {
   const dir = abs(outDir);
   mkdirSync(dir, { recursive: true });
@@ -220,6 +222,13 @@ if (readyToWrite) {
       mergeArgs.splice(4, 0, `--channel=${inputByRole.channel}`);
     }
     const mergeResult = spawnSync(process.execPath, mergeArgs, { encoding: "utf8" });
+    mergeProbe = {
+      status: mergeResult.status,
+      stdoutPath: join(dir, "events-merge.stdout.json"),
+      stderrPath: join(dir, "events-merge.stderr.txt"),
+    };
+    writeFileSync(mergeProbe.stdoutPath, mergeResult.stdout || "");
+    writeFileSync(mergeProbe.stderrPath, mergeResult.stderr || "");
     if (mergeResult.status !== 0) {
       copiedManifest = "";
       block("events_merge_failed", `exit_${mergeResult.status}`);
@@ -237,9 +246,29 @@ if (readyToWrite) {
         ...writtenExtra.map((capture) => `--extra-evidence-ref=${capture.target}`),
         "--require-ready",
       ], { encoding: "utf8" });
+      derivedManifestProbe = {
+        status: result.status,
+        stdoutPath: join(dir, "observations-manifest.stdout.json"),
+        stderrPath: join(dir, "observations-manifest.stderr.txt"),
+        parsed: null,
+      };
+      writeFileSync(derivedManifestProbe.stdoutPath, result.stdout || "");
+      writeFileSync(derivedManifestProbe.stderrPath, result.stderr || "");
+      try {
+        derivedManifestProbe.parsed = JSON.parse(result.stdout || "{}");
+      } catch {
+        derivedManifestProbe.parsed = null;
+      }
       if (result.status !== 0) {
         copiedManifest = "";
         block("observations_manifest_derivation_failed", `exit_${result.status}`);
+        if (Array.isArray(derivedManifestProbe.parsed?.blockers)) {
+          for (const blocker of derivedManifestProbe.parsed.blockers) {
+            if (blocker && typeof blocker.code === "string") {
+              block(`observations_manifest:${blocker.code}`, String(blocker.detail || ""));
+            }
+          }
+        }
       }
     }
   } else {
@@ -300,6 +329,8 @@ if (readyToWrite) {
     observationsManifest: copiedManifest || null,
     mergedEvents: mergedEvents || null,
     normalizedEvents: derivedEvents || null,
+    mergeProbe,
+    derivedManifestProbe,
     reuseSummary,
     deferredInputs: reuseSummary.deferredInputs,
     blockers,
@@ -354,6 +385,8 @@ const output = {
   observationsManifest: copiedManifest || null,
   mergedEvents: mergedEvents || null,
   normalizedEvents: derivedEvents || null,
+  mergeProbe,
+  derivedManifestProbe,
   reuseSummary,
   preflight,
   deferredInputs: deferChannelProof ? [{

--- a/scripts/ops/friday-ui-device-proof-shortlist-runner.sh
+++ b/scripts/ops/friday-ui-device-proof-shortlist-runner.sh
@@ -311,6 +311,40 @@ if [ "${#accessibility_captures[@]}" -gt 0 ]; then
   node "${accessibility_args[@]}"
   same_run_events+=("${accessibility_capture_dir}/accessibility-click-events.jsonl")
   runtime_evidence_dirs+=("${accessibility_capture_dir}")
+  while IFS= read -r accessibility_evidence_ref; do
+    [ -n "${accessibility_evidence_ref}" ] || continue
+    require_file_if_set "accessibility evidence_ref" "${accessibility_evidence_ref}"
+    shared_extra_evidence+=("${accessibility_evidence_ref}")
+  done < <(node - "${accessibility_captures[@]}" <<'NODE'
+const fs = require("node:fs");
+const seen = new Set();
+for (const path of process.argv.slice(2)) {
+  const raw = JSON.parse(fs.readFileSync(path, "utf8"));
+  const captures = Array.isArray(raw?.captures) ? raw.captures : [raw];
+  for (const capture of captures) {
+    const refs = [
+      capture?.evidence_ref,
+      capture?.evidenceRef,
+      ...(Array.isArray(capture?.ui_actions) ? capture.ui_actions : []),
+      ...(Array.isArray(capture?.uiActions) ? capture.uiActions : []),
+    ];
+    for (const value of refs) {
+      const ref = typeof value === "string"
+        ? value
+        : typeof value?.evidence_ref === "string"
+          ? value.evidence_ref
+          : typeof value?.evidenceRef === "string"
+            ? value.evidenceRef
+            : "";
+      if (ref && !seen.has(ref)) {
+        seen.add(ref);
+        console.log(ref);
+      }
+    }
+  }
+}
+NODE
+)
   accessibility_capture_status="ready"
 fi
 set -u

--- a/test/unit/qa/friday-ui-device-capture-dir-cli.test.ts
+++ b/test/unit/qa/friday-ui-device-capture-dir-cli.test.ts
@@ -340,6 +340,51 @@ describe("friday-ui-device-capture-dir", () => {
     }
   });
 
+  it("surfaces manifest derivation blockers when same-run observations are incomplete", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "friday-ui-capture-dir-incomplete-events-"));
+    try {
+      const captures = writeEvidence(tempDir);
+      const events = join(tempDir, "same-run-events.jsonl");
+      const outDir = join(tempDir, "evidence");
+      const incompleteRows = nonChannelEventRows(captures).filter((row) => (
+        row.event !== "pressure_20_50_consecutive_asks_visible"
+      ));
+      writeFileSync(events, `${incompleteRows.map((row) => JSON.stringify(row)).join("\n")}\n`);
+
+      const result = spawnSync("node", [
+        "scripts/ops/friday-ui-device-capture-dir.mjs",
+        `--mission-id=${missionId}`,
+        `--out-dir=${outDir}`,
+        `--mobile=${captures.mobile}`,
+        `--desktop=${captures.desktop}`,
+        `--timeline=${captures.timeline}`,
+        `--events=${events}`,
+        "--defer-channel-proof",
+        "--require-ready",
+      ], { cwd: process.cwd(), encoding: "utf8" });
+
+      expect(result.status).toBe(2);
+      const output = JSON.parse(result.stdout) as {
+        status?: string;
+        derivedManifestProbe?: { status?: number; parsed?: { blockers?: Array<{ code?: string; detail?: string }> } };
+        blockers?: Array<{ code?: string; detail?: string }>;
+      };
+      expect(output.status).toBe("blocked");
+      expect(output.derivedManifestProbe?.status).toBe(2);
+      expect(output.derivedManifestProbe?.parsed?.blockers).toContainEqual(expect.objectContaining({
+        code: "missing_observation",
+        detail: "*:pressure_20_50_consecutive_asks_visible",
+      }));
+      expect(output.blockers).toContainEqual(expect.objectContaining({
+        code: "observations_manifest:missing_observation",
+        detail: "*:pressure_20_50_consecutive_asks_visible",
+      }));
+      expect(readFileSync(join(outDir, "observations-manifest.stdout.json"), "utf8")).toContain("pressure_20_50_consecutive_asks_visible");
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
   it("copies role-scoped extra evidence and remaps same-run event refs before preflight", () => {
     const tempDir = mkdtempSync(join(tmpdir(), "friday-ui-capture-dir-extra-evidence-"));
     try {

--- a/test/unit/qa/friday-ui-device-proof-shortlist-runner-contract.test.ts
+++ b/test/unit/qa/friday-ui-device-proof-shortlist-runner-contract.test.ts
@@ -11,6 +11,8 @@ describe("friday-ui-device-proof-shortlist-runner contract", () => {
     expect(source).toContain("--mission-id=${mission_id}");
     expect(source).toContain("accessibility-click-events.jsonl");
     expect(source).toContain("runtime_evidence_dirs+=(\"${accessibility_capture_dir}\")");
+    expect(source).toContain("require_file_if_set \"accessibility evidence_ref\" \"${accessibility_evidence_ref}\"");
+    expect(source).toContain("shared_extra_evidence+=(\"${accessibility_evidence_ref}\")");
     expect(source).toContain("accessibilityCaptureStatus");
     expect(source).toContain("Runner output is END-BAR only if strict UI/device readiness passes");
   });


### PR DESCRIPTION
## Summary
- carry accessibility capture evidence refs into shared UI/device proof evidence
- persist merge/manifest probe stdout+stderr from capture-dir assembly
- surface concrete observations-manifest blockers instead of opaque exit_2

## Verification
- pnpm vitest run test/unit/qa/friday-ui-device-proof-shortlist-runner-contract.test.ts test/unit/qa/friday-ui-device-capture-dir-cli.test.ts test/unit/qa/friday-ui-device-observations-manifest-cli.test.ts test/unit/qa/friday-ui-device-events-merge-cli.test.ts
- real OG9 non-channel capture-dir rerun: blockers now enumerate missing provider_ack/stress/error/label/no-hidden-fallback observations; no synthetic rows or proof-bar relaxation

Truth: this is proof-orchestration/diagnostics only. It does not claim END-BAR, channel proof, adoption, or strict UI/device readiness.