### PR TITLE
Report non-channel UI closure status

### DIFF
--- a/scripts/ops/friday-uiux-product-closure-readiness.mjs
+++ b/scripts/ops/friday-uiux-product-closure-readiness.mjs
@@ -407,6 +407,27 @@ const readinessBlockers = Array.isArray(readinessReport.blockers) ? readinessRep
 const readinessBlockerDetail = readinessBlockers.length > 0
   ? readinessBlockers.join(",")
   : readinessReport.status || "unknown";
+const channelDeferredStrictAssembly = readinessBlockers.includes("ui_device_proof_evidence:channel_deferred_strict_assembly_blocked");
+const readinessNotes = Array.isArray(readinessReport.notes) ? readinessReport.notes : [];
+const nonChannelInputsResolved = [
+  "resolved_MOBILE_EVIDENCE:",
+  "resolved_DESKTOP_EVIDENCE:",
+  "resolved_TIMELINE_EVIDENCE:",
+  "resolved_OBSERVATIONS_MANIFEST:",
+  "resolved_SAME_RUN_EVENTS:",
+].every((prefix) => readinessNotes.some((note) => String(note).startsWith(prefix)));
+const nonChannelUiDeviceClosureReady = !uiDeviceProofAssembled
+  && channelDeferredStrictAssembly
+  && readinessReport.status === "blocked"
+  && nonChannelInputsResolved;
+const nonChannelProductClosureReady = blockers.length === 0
+  && clientPassed
+  && nativeLinkagePassed
+  && selectedVisualProofReady
+  && nativePassed
+  && traceabilityPassed
+  && runtimeCovered
+  && nonChannelUiDeviceClosureReady;
 
 if (!clientPassed) block("client_design_contract_failed", String(clientDesign.exitCode));
 if (!nativeLinkagePassed) block("uiux_native_linkage_failed", nativeLinkage.parsed?.status || String(nativeLinkage.exitCode));
@@ -424,6 +445,9 @@ if (!uiDeviceProofAssembled) {
 }
 if (!selectedVisualProofReady) {
   notes.push("selected_visual_proof_gap_present");
+}
+if (nonChannelProductClosureReady) {
+  notes.push("non_channel_uiux_closure_ready_channel_deferred");
 }
 
 const report = {
@@ -493,6 +517,27 @@ const report = {
       })),
       notes: readinessReport.notes || [],
       blockers: readinessReport.blockers || [],
+    },
+    nonChannelClosure: {
+      status: nonChannelProductClosureReady
+        ? "non_channel_uiux_closure_ready_channel_deferred"
+        : uiDeviceProofAssembled
+          ? "superseded_by_full_ui_device_proof"
+          : "not_ready",
+      channelDeferredStrictAssembly,
+      nonChannelInputsResolved,
+      blockers: nonChannelProductClosureReady ? [
+        "ui_device_proof_evidence:channel_deferred_strict_assembly_blocked",
+      ] : [
+        ...(!clientPassed ? ["client_design_contract_failed"] : []),
+        ...(!nativeLinkagePassed ? ["uiux_native_linkage_failed"] : []),
+        ...(!selectedVisualProofReady ? ["selected_visual_proof_not_ready"] : []),
+        ...(!nativePassed ? ["native_action_closure_failed"] : []),
+        ...(!traceabilityPassed ? ["uiux_action_traceability_failed"] : []),
+        ...(!runtimeCovered ? ["runtime_actions_not_covered"] : []),
+        ...(!nonChannelUiDeviceClosureReady ? ["non_channel_ui_device_inputs_not_ready"] : []),
+      ],
+      caveat: "Non-channel closure is not END-BAR, not GO-LIVE, not adoption, and never satisfies strict UI/device proof while channel proof is deferred.",
     },
   },
   recommendedNextActions: [

--- a/test/unit/qa/friday-uiux-product-closure-readiness-contract.test.ts
+++ b/test/unit/qa/friday-uiux-product-closure-readiness-contract.test.ts
@@ -21,6 +21,16 @@ describe("friday-uiux-product-closure-readiness contract", () => {
     expect(source).not.toContain('report.status === "blocked" && deferChannelProof');
   });
 
+  it("reports non-channel closure without upgrading channel-deferred runs to END-BAR", () => {
+    const source = readFileSync("scripts/ops/friday-uiux-product-closure-readiness.mjs", "utf8");
+
+    expect(source).toContain("nonChannelProductClosureReady");
+    expect(source).toContain("nonChannelClosure:");
+    expect(source).toContain("non_channel_uiux_closure_ready_channel_deferred");
+    expect(source).toContain("Non-channel closure is not END-BAR");
+    expect(source).toContain("never satisfies strict UI/device proof while channel proof is deferred");
+  });
+
   it("surfaces residual evidence overlays without clearing END-BAR blockers", () => {
     const source = readFileSync("scripts/ops/friday-uiux-product-closure-readiness.mjs", "utf8");
 


### PR DESCRIPTION
## Summary
- add a machine-readable non-channel UI/product closure stage when all non-channel evidence is resolved and the only strict UI/device blocker is deferred channel proof
- keep full UI/device proof blocked on channel-deferred strict assembly
- add contract coverage so channel-deferred runs are not upgraded to END-BAR

## Verification
- npx vitest run test/unit/qa/friday-uiux-product-closure-readiness-contract.test.ts
- npx vitest run test/unit/qa/friday-uiux-product-closure-readiness-contract.test.ts test/unit/qa/friday-ui-device-proof-shortlist-runner-contract.test.ts test/unit/qa/friday-ui-device-capture-dir-cli.test.ts
- FRIDAY_UI_DEVICE_DEFER_CHANNEL_PROOF=1 node scripts/ops/friday-uiux-product-closure-readiness.mjs ... --defer-channel-proof --out=/private/tmp/friday-uiux-product-closure-nonchannel-status-f9dfa714-20260627.json

Truth: this does not claim END-BAR, GO-LIVE, adoption, or strict UI/device proof while channel proof is deferred.