### PR TITLE
test(closure): report backend proof artifact status

### DIFF
--- a/rust-core/scripts/mission-spine-closure-audit-gate.sh
+++ b/rust-core/scripts/mission-spine-closure-audit-gate.sh
@@ -123,6 +123,10 @@ if [[ -s "$backend_live_proof_out" ]] \
   backend_live_proof_generated_at="$(jq -r '.generated_at_utc // ""' "$backend_live_proof_out")"
 fi
 
+if [[ "$mode" == "--report" && "$backend_live_proof_status" == "passed" && "$deepseek_status" != "passed" ]]; then
+  deepseek_status="satisfied_by_last_backend_live_proof"
+fi
+
 if [[ -s "$channel_live_proof_out" ]] \
   && jq -e '.proof == "mission_spine_channel_live_proof" and .status == "passed"' "$channel_live_proof_out" >/dev/null; then
   channel_live_proof_available="true"
@@ -221,7 +225,8 @@ cat > "$report_out" <<EOF
   "report_semantics": {
     "report_mode_runs_live_positive_gates": false,
     "strict_mode_runs_live_positive_gates": true,
-    "missing_env_in_report_mode_is_not_a_regression_of_prior_strict_live_proof": true
+    "missing_env_in_report_mode_is_not_a_regression_of_prior_strict_live_proof": true,
+    "report_mode_can_satisfy_deepseek_from_last_backend_live_proof": true
   },
   "full_goal_complete": $full_goal_complete
 }

--- a/test/unit/qa/mission-spine-closure-audit-gate-contract.test.ts
+++ b/test/unit/qa/mission-spine-closure-audit-gate-contract.test.ts
@@ -1,0 +1,14 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const script = readFileSync("rust-core/scripts/mission-spine-closure-audit-gate.sh", "utf8");
+
+describe("mission-spine closure audit gate contract", () => {
+  it("reports fresh backend live proof without weakening strict closure", () => {
+    expect(script).toContain("deepseek_status=\"satisfied_by_last_backend_live_proof\"");
+    expect(script).toContain("[[ \"$mode\" == \"--report\" && \"$backend_live_proof_status\" == \"passed\" && \"$deepseek_status\" != \"passed\" ]]");
+    expect(script).toContain("\"report_mode_can_satisfy_deepseek_from_last_backend_live_proof\": true");
+    expect(script).toContain("&& \"$deepseek_status\" == \"passed\" \\");
+    expect(script).toContain("strict_mode_runs_live_positive_gates\": true");
+  });
+});


### PR DESCRIPTION
## Summary
- Teach the mission-spine closure report to surface a passed backend live proof artifact as `satisfied_by_last_backend_live_proof` in report mode, instead of continuing to show a misleading missing-key blocker.
- Keep strict closure unchanged: `--strict` still requires live gates/env, and full closure still requires `deepseek_status=passed` plus channel/UI-device proof.
- Add a contract test pinning the report-mode status and strict-mode non-bypass behavior.

## Verification
- `bash -n rust-core/scripts/mission-spine-closure-audit-gate.sh`
- `npx vitest run test/unit/qa/mission-spine-closure-audit-gate-contract.test.ts`
- `git diff --check`
- `MISSION_SPINE_CLOSURE_REPORT_OUT=/tmp/friday-closure-report-status-pr-20260627.json MISSION_SPINE_BACKEND_LIVE_PROOF_OUT=/tmp/friday-mission-spine-backend-live-proof.json rust-core/scripts/mission-spine-closure-audit-gate.sh --report` (long output redirected locally); report showed `deepseek_live_api_pressure.status=satisfied_by_last_backend_live_proof` and `full_goal_complete=false`.

Truth: report readability/truth-label fix only; not END-BAR, not GO-LIVE, not channel proof, not strict UI/device proof.
