### PR TITLE
test(closure): surface UI proof evidence anchor

### DIFF
--- a/rust-core/scripts/mission-spine-closure-audit-gate.sh
+++ b/rust-core/scripts/mission-spine-closure-audit-gate.sh
@@ -51,6 +51,11 @@ uiux_non_channel_inputs_resolved="false"
 uiux_channel_deferred_strict_assembly="false"
 uiux_report_notes_json="[]"
 uiux_report_blockers_json="[]"
+uiux_selected_evidence_dir_json="null"
+uiux_selected_score_json="null"
+uiux_readiness_notes_json="[]"
+uiux_readiness_blockers_json="[]"
+uiux_readiness_candidate_runs_json="[]"
 
 echo "[mission-spine-closure] local backend + native/wire proof"
 scripts/mission-spine-proof-gate.sh --local
@@ -148,6 +153,11 @@ if [[ -n "$uiux_closure_report_in" ]]; then
     uiux_channel_deferred_strict_assembly="$(jq -r 'if .stages.nonChannelClosure.channelDeferredStrictAssembly == true then "true" else "false" end' "$uiux_closure_report_in")"
     uiux_report_notes_json="$(jq -c '(.notes // [])' "$uiux_closure_report_in")"
     uiux_report_blockers_json="$(jq -c '(.blockers // [])' "$uiux_closure_report_in")"
+    uiux_selected_evidence_dir_json="$(jq -c '(.stages.uiDeviceProofReadiness.selectedEvidenceDir // null)' "$uiux_closure_report_in")"
+    uiux_selected_score_json="$(jq -c '(.stages.uiDeviceProofReadiness.selectedScore // null)' "$uiux_closure_report_in")"
+    uiux_readiness_notes_json="$(jq -c '(.stages.uiDeviceProofReadiness.notes // [])' "$uiux_closure_report_in")"
+    uiux_readiness_blockers_json="$(jq -c '(.stages.uiDeviceProofReadiness.blockers // [])' "$uiux_closure_report_in")"
+    uiux_readiness_candidate_runs_json="$(jq -c '(.stages.uiDeviceProofReadiness.candidateRuns // []) | map({evidenceDir, score, status, blockers})' "$uiux_closure_report_in")"
   fi
 fi
 
@@ -246,6 +256,11 @@ cat > "$report_out" <<EOF
     "non_channel_status": "$uiux_non_channel_status",
     "non_channel_inputs_resolved": $uiux_non_channel_inputs_resolved,
     "channel_deferred_strict_assembly": $uiux_channel_deferred_strict_assembly,
+    "selected_ui_device_evidence_dir": $uiux_selected_evidence_dir_json,
+    "selected_ui_device_evidence_score": $uiux_selected_score_json,
+    "ui_device_readiness_notes": $uiux_readiness_notes_json,
+    "ui_device_readiness_blockers": $uiux_readiness_blockers_json,
+    "ui_device_readiness_candidate_runs": $uiux_readiness_candidate_runs_json,
     "notes": $uiux_report_notes_json,
     "blockers": $uiux_report_blockers_json,
     "scope": "Optional report-mode bridge to scripts/ops/friday-uiux-product-closure-readiness.mjs output; never satisfies strict MISSION_SPINE_UI_DEVICE_PROOF or full END-BAR while channel proof is deferred"

--- a/test/unit/qa/mission-spine-closure-audit-gate-contract.test.ts
+++ b/test/unit/qa/mission-spine-closure-audit-gate-contract.test.ts
@@ -16,6 +16,8 @@ describe("mission-spine closure audit gate contract", () => {
     expect(script).toContain("uiux_closure_report_in=\"${MISSION_SPINE_UIUX_CLOSURE_REPORT:-}\"");
     expect(script).toContain("\"uiux_product_closure_report\": {");
     expect(script).toContain("\"non_channel_status\": \"$uiux_non_channel_status\"");
+    expect(script).toContain("\"selected_ui_device_evidence_dir\": $uiux_selected_evidence_dir_json");
+    expect(script).toContain("\"ui_device_readiness_candidate_runs\": $uiux_readiness_candidate_runs_json");
     expect(script).toContain("\"uiux_non_channel_report_never_satisfies_strict_ui_device_proof\": true");
     expect(script).toContain("&& \"$ui_device_status\" == \"passed\"");
   });


### PR DESCRIPTION
## Summary
- surface the selected UI/device evidence dir, score, readiness notes/blockers, and candidate runs from the optional UIUX closure report
- keep report mode truth-only: this does not satisfy strict MISSION_SPINE_UI_DEVICE_PROOF or full END-BAR
- add contract coverage for the surfaced fields

## Verification
- bash -n rust-core/scripts/mission-spine-closure-audit-gate.sh
- git diff --check
- npx vitest run test/unit/qa/mission-spine-closure-audit-gate-contract.test.ts
- report-mode closure audit with MISSION_SPINE_UIUX_CLOSURE_REPORT=/private/tmp/friday-uiux-product-closure-origin-main-28291d52-nonchannel-evidence-set-verified-20260627.json; full_goal_complete=false, selected evidence dir surfaced, channel-deferred blocker preserved

## Truth
Report-only evidence anchoring. Not END-BAR, not GO-LIVE, not adoption, not strict UI/device proof.