### PR TITLE
test(closure): surface UI action traceability

### DIFF
--- a/rust-core/scripts/mission-spine-closure-audit-gate.sh
+++ b/rust-core/scripts/mission-spine-closure-audit-gate.sh
@@ -56,6 +56,13 @@ uiux_selected_score_json="null"
 uiux_readiness_notes_json="[]"
 uiux_readiness_blockers_json="[]"
 uiux_readiness_candidate_runs_json="[]"
+uiux_action_traceability_status="not_provided"
+uiux_product_runtime_action_ids_json="null"
+uiux_product_actions_missing_runtime_evidence_json="null"
+uiux_runtime_evidence_inputs_json="null"
+uiux_runtime_evidence_action_rows_json="null"
+uiux_residual_destinations_with_blockers_json="null"
+uiux_residual_destinations_all_runtime_actions_covered_json="null"
 
 echo "[mission-spine-closure] local backend + native/wire proof"
 scripts/mission-spine-proof-gate.sh --local
@@ -158,6 +165,13 @@ if [[ -n "$uiux_closure_report_in" ]]; then
     uiux_readiness_notes_json="$(jq -c '(.stages.uiDeviceProofReadiness.notes // [])' "$uiux_closure_report_in")"
     uiux_readiness_blockers_json="$(jq -c '(.stages.uiDeviceProofReadiness.blockers // [])' "$uiux_closure_report_in")"
     uiux_readiness_candidate_runs_json="$(jq -c '(.stages.uiDeviceProofReadiness.candidateRuns // []) | map({evidenceDir, score, status, blockers})' "$uiux_closure_report_in")"
+    uiux_action_traceability_status="$(jq -r '.stages.uiuxActionTraceability.status // "missing"' "$uiux_closure_report_in")"
+    uiux_product_runtime_action_ids_json="$(jq -c '(.stages.uiuxActionTraceability.counts.productRuntimeActionIds // null)' "$uiux_closure_report_in")"
+    uiux_product_actions_missing_runtime_evidence_json="$(jq -c '(.stages.uiuxActionTraceability.counts.productActionsMissingRuntimeEvidence // null)' "$uiux_closure_report_in")"
+    uiux_runtime_evidence_inputs_json="$(jq -c '(.stages.uiuxActionTraceability.counts.runtimeEvidenceInputs // null)' "$uiux_closure_report_in")"
+    uiux_runtime_evidence_action_rows_json="$(jq -c '(.stages.uiuxActionTraceability.counts.runtimeEvidenceActionRows // null)' "$uiux_closure_report_in")"
+    uiux_residual_destinations_with_blockers_json="$(jq -c '(.stages.uiuxActionTraceability.residualEndBarEvidence.destinationsWithResidualBlockers // null)' "$uiux_closure_report_in")"
+    uiux_residual_destinations_all_runtime_actions_covered_json="$(jq -c '(.stages.uiuxActionTraceability.residualEndBarEvidence.destinationsWithAllRuntimeActionsCovered // null)' "$uiux_closure_report_in")"
   fi
 fi
 
@@ -261,6 +275,16 @@ cat > "$report_out" <<EOF
     "ui_device_readiness_notes": $uiux_readiness_notes_json,
     "ui_device_readiness_blockers": $uiux_readiness_blockers_json,
     "ui_device_readiness_candidate_runs": $uiux_readiness_candidate_runs_json,
+    "action_traceability": {
+      "status": "$uiux_action_traceability_status",
+      "product_runtime_action_ids": $uiux_product_runtime_action_ids_json,
+      "product_actions_missing_runtime_evidence": $uiux_product_actions_missing_runtime_evidence_json,
+      "runtime_evidence_inputs": $uiux_runtime_evidence_inputs_json,
+      "runtime_evidence_action_rows": $uiux_runtime_evidence_action_rows_json,
+      "residual_destinations_with_blockers": $uiux_residual_destinations_with_blockers_json,
+      "residual_destinations_all_runtime_actions_covered": $uiux_residual_destinations_all_runtime_actions_covered_json,
+      "scope": "Traceability counts from the UIUX product-closure report; these counts never clear residual product blockers or satisfy strict UI/device proof by themselves"
+    },
     "notes": $uiux_report_notes_json,
     "blockers": $uiux_report_blockers_json,
     "scope": "Optional report-mode bridge to scripts/ops/friday-uiux-product-closure-readiness.mjs output; never satisfies strict MISSION_SPINE_UI_DEVICE_PROOF or full END-BAR while channel proof is deferred"

--- a/test/unit/qa/mission-spine-closure-audit-gate-contract.test.ts
+++ b/test/unit/qa/mission-spine-closure-audit-gate-contract.test.ts
@@ -18,6 +18,10 @@ describe("mission-spine closure audit gate contract", () => {
     expect(script).toContain("\"non_channel_status\": \"$uiux_non_channel_status\"");
     expect(script).toContain("\"selected_ui_device_evidence_dir\": $uiux_selected_evidence_dir_json");
     expect(script).toContain("\"ui_device_readiness_candidate_runs\": $uiux_readiness_candidate_runs_json");
+    expect(script).toContain("\"action_traceability\": {");
+    expect(script).toContain("\"product_runtime_action_ids\": $uiux_product_runtime_action_ids_json");
+    expect(script).toContain("\"product_actions_missing_runtime_evidence\": $uiux_product_actions_missing_runtime_evidence_json");
+    expect(script).toContain("\"residual_destinations_with_blockers\": $uiux_residual_destinations_with_blockers_json");
     expect(script).toContain("\"uiux_non_channel_report_never_satisfies_strict_ui_device_proof\": true");
     expect(script).toContain("&& \"$ui_device_status\" == \"passed\"");
   });


### PR DESCRIPTION
## Summary
- surface UIUX action traceability counts in the mission-spine closure report
- expose product runtime action totals, missing runtime evidence, runtime evidence input/action row counts, and residual product blocker counts
- keep strict closure semantics unchanged: these counts do not satisfy UI/device proof or END-BAR

## Verification
- bash -n rust-core/scripts/mission-spine-closure-audit-gate.sh
- git diff --check
- npx vitest run test/unit/qa/mission-spine-closure-audit-gate-contract.test.ts
- report-mode closure run with verified UIUX evidence-set showed traceability status product_runtime_actions_traceable, 57 runtimeActionIds, 0 missing runtime evidence, 44 runtime evidence inputs, 181 rows, 33 residual blockers

Truth: report-only visibility; not strict UI/device proof, not END-BAR, not GO-LIVE, not adoption.