### PR TITLE
test(closure): define END-BAR acceptance manifest

### DIFF
--- a/docs/ops/friday-endbar-acceptance-manifest.json
+++ b/docs/ops/friday-endbar-acceptance-manifest.json
@@ -1,0 +1,163 @@
+{
+  "schemaVersion": 1,
+  "truthLabel": "endbar_acceptance_manifest_not_evidence_not_release",
+  "status": "acceptance_defined_not_satisfied",
+  "caveat": "This manifest defines the END-BAR acceptance standard. It is not proof that the standard has passed.",
+  "operatorSources": [
+    {
+      "id": "multiangle-mechanism-stress",
+      "path": "~/Desktop/FRIDAY_MULTIANGLE_STRESS_SPEC_20260618.md",
+      "requiredForEndBar": true,
+      "role": "mechanism stress matrix"
+    },
+    {
+      "id": "ui-real-use-stress",
+      "path": "~/Desktop/FRIDAY_UI_REALUSE_STRESS_SPEC_20260619.md",
+      "requiredForEndBar": true,
+      "role": "mobile and desktop user-use stress matrix"
+    },
+    {
+      "id": "full-product-marching-order",
+      "path": "~/Desktop/FRIDAY_FULL_PRODUCT_MARCHING_ORDER_20260622.md",
+      "requiredForEndBar": true,
+      "role": "T1 through T6 product bar"
+    },
+    {
+      "id": "selected-uiux-design",
+      "path": "~/Desktop/friday-design-handoff-20260602",
+      "requiredForEndBar": true,
+      "role": "operator-selected mobile and desktop UI/UX source"
+    },
+    {
+      "id": "provider-auth-policy",
+      "path": "~/Desktop/FRIDAY_PROVIDER_AUTH_POLICY_20260625.md",
+      "requiredForEndBar": true,
+      "role": "provider entitlement and subscription boundary policy"
+    }
+  ],
+  "acceptanceGroups": [
+    {
+      "id": "mechanism_multiangle_stress",
+      "requiredForEndBar": true,
+      "repoEvidencePaths": [
+        "rust-core/scripts/mission-spine-closure-audit-gate.sh",
+        "rust-core/scripts/mission-spine-proof-gate.sh",
+        "scripts/ops/friday-codex-mission-proof-of-life-keychain.sh",
+        "scripts/ops/friday-claude-mission-proof-of-life-keychain.sh"
+      ],
+      "passBar": [
+        "real provider spend is windowed and joined to run proof",
+        "provider usage receipt is reconciled with token ledger for real-spend cases",
+        "failure-injection paths prove fail-closed behavior without synthetic inserts",
+        "agent-driven stress is not counted as organic adoption or GO-LIVE"
+      ]
+    },
+    {
+      "id": "ui_real_use_mobile_desktop",
+      "requiredForEndBar": true,
+      "repoEvidencePaths": [
+        "scripts/ops/friday-uiux-real-use-proof-driver.sh",
+        "scripts/ops/friday-ui-device-proof-readiness.sh",
+        "scripts/ops/friday-ui-device-proof-shortlist-runner.sh",
+        "scripts/ops/friday-uiux-product-closure-readiness.mjs"
+      ],
+      "passBar": [
+        "mobile and desktop are driven as real app surfaces, not DB-only proof",
+        "rendered pixels, app accessibility tree, DB rows, provider receipts, and git HEAD are linked in one manifest",
+        "honest-unavailable, owner-gate, timeout, leak, accessibility, and cross-surface truth controls are exercised",
+        "simulator evidence remains labeled as simulator evidence and does not substitute for real-device release proof"
+      ]
+    },
+    {
+      "id": "selected_uiux_conformance",
+      "requiredForEndBar": true,
+      "repoEvidencePaths": [
+        "scripts/ops/check-friday-client-design-contract.mjs",
+        "scripts/ops/check-friday-uiux-native-linkage.mjs",
+        "scripts/ops/check-friday-uiux-selected-visual-proof.mjs",
+        "docs/friday-uiux-product-runtime-action-annex.md"
+      ],
+      "passBar": [
+        "operator-selected mobile and desktop design destinations are represented in native code",
+        "runtime action evidence is attached to product actions before action closure is counted",
+        "visual proof is current-HEAD native proof, not static design proof",
+        "residual product blockers remain blockers even when runtime action traceability is complete"
+      ]
+    },
+    {
+      "id": "provider_entitlement_matrix",
+      "requiredForEndBar": true,
+      "repoEvidencePaths": [
+        "test/e2e/live/friday-provider-routing-c3c4-live.e2e.test.ts",
+        "scripts/ops/check-friday-provider-entitlement-manifest.mjs",
+        "docs/ops/friday-endbar-acceptance-manifest.json"
+      ],
+      "passBar": [
+        "DeepSeek API route is tested as a supported BYOK or configured-key provider",
+        "OpenAI API route is tested as a supported API-key provider when an API key is present",
+        "Claude API route is tested as a supported API-key provider when an API key is present",
+        "Codex CLI and Claude CLI are labeled advanced local first-party CLI delegation, not native API or channel proof",
+        "a free ChatGPT web account is explicitly unsupported as an autonomous Friday workflow backend"
+      ]
+    },
+    {
+      "id": "integrated_end_to_end_tape",
+      "requiredForEndBar": true,
+      "repoEvidencePaths": [
+        "scripts/ops/friday-ui-device-live-write-read-capture-bundle.sh",
+        "scripts/ops/friday-product-auto-followup-proof.sh",
+        "scripts/ops/friday-ui-device-observations-manifest.mjs"
+      ],
+      "passBar": [
+        "one linked tape covers goal capture, governed execution, approval or honest pause, result readback, memory confirmation or honest candidate state, and recall",
+        "mobile and desktop consume the same mission truth without stale or fabricated state",
+        "negative controls are included for offline, owner mismatch, reconnect, channel replay, no hidden fallback, and secret redaction",
+        "channel proof is either current and linked or explicitly deferred and therefore not END-BAR"
+      ]
+    }
+  ],
+  "providerEntitlementMatrix": [
+    {
+      "id": "deepseek_api",
+      "status": "supported_api_key_route",
+      "mustPassBeforeEndBar": true,
+      "proof": "real /v1/agent/runs or mission-spine run with fallback=0, usage ledger, and configured DeepSeek key"
+    },
+    {
+      "id": "openai_api",
+      "status": "supported_api_key_route",
+      "mustPassBeforeEndBar": true,
+      "proof": "real provider routing run with OPENAI_API_KEY or FRIDAY_OPENAI_API_KEY present"
+    },
+    {
+      "id": "anthropic_api",
+      "status": "supported_api_key_route",
+      "mustPassBeforeEndBar": true,
+      "proof": "real provider routing run with ANTHROPIC_API_KEY or FRIDAY_ANTHROPIC_API_KEY present"
+    },
+    {
+      "id": "codex_cli",
+      "status": "advanced_local_first_party_cli_delegation",
+      "mustPassBeforeEndBar": false,
+      "proof": "local logged-in Codex CLI route may be tested as Codex route only; it is not OpenAI API proof and not a free ChatGPT backend"
+    },
+    {
+      "id": "claude_cli",
+      "status": "advanced_local_first_party_cli_delegation",
+      "mustPassBeforeEndBar": false,
+      "proof": "local logged-in Claude CLI route may be tested as Claude route only; it is not Anthropic API proof and not channel proof"
+    },
+    {
+      "id": "free_chatgpt_web_account",
+      "status": "unsupported_as_friday_autonomous_backend",
+      "mustPassBeforeEndBar": false,
+      "proof": "negative/boundary check only: do not count browser automation, scraping, subscription replay, or free ChatGPT web access as Friday provider proof"
+    }
+  ],
+  "completionRules": [
+    "END-BAR requires real user-use mobile and desktop product closure, not report coverage alone.",
+    "A green manifest check is only a standard-definition check; it is not runtime evidence.",
+    "Report-mode closure, non-channel closure, simulator-only proof, and agent dogfood never satisfy strict UI/device proof by themselves.",
+    "No synthetic INSERT, no fake organic, no secret echo, no production hub kill, and no gate weakening may be used to satisfy any group."
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -124,6 +124,7 @@
     "check:uiux-selected-visual-proof": "node scripts/ops/check-friday-uiux-selected-visual-proof.mjs",
     "check:uiux-action-traceability": "node scripts/ops/check-friday-uiux-action-traceability.mjs",
     "check:uiux-product-closure": "node scripts/ops/friday-uiux-product-closure-readiness.mjs",
+    "check:endbar-acceptance-manifest": "node scripts/ops/check-friday-provider-entitlement-manifest.mjs",
     "check:github-channel-proof-readiness": "node scripts/ops/check-friday-github-channel-proof-readiness.mjs",
     "check:ui-device-accessibility-click-capture": "node scripts/ops/friday-ui-device-accessibility-click-capture.mjs",
     "check:agent-rollout:phase1": "node scripts/ops/run-agent-rollout-acceptance.mjs phase1",

--- a/scripts/ops/check-friday-provider-entitlement-manifest.mjs
+++ b/scripts/ops/check-friday-provider-entitlement-manifest.mjs
@@ -1,0 +1,194 @@
+#!/usr/bin/env node
+
+import { existsSync, readFileSync } from "node:fs";
+import { isAbsolute, resolve } from "node:path";
+
+const args = process.argv.slice(2);
+
+function arg(name) {
+  const prefix = `--${name}=`;
+  for (let index = 0; index < args.length; index += 1) {
+    const value = args[index];
+    if (value.startsWith(prefix)) return value.slice(prefix.length);
+    if (value === `--${name}` && args[index + 1]) return args[index + 1];
+  }
+  return "";
+}
+
+function usage() {
+  console.error(`usage:
+  node scripts/ops/check-friday-provider-entitlement-manifest.mjs \\
+    [--repo-root=/abs/repo] \\
+    [--manifest=/abs/or/repo-relative/friday-endbar-acceptance-manifest.json]
+
+Truth: validates the END-BAR acceptance manifest shape and provider entitlement
+boundaries. It does not execute providers, prove runtime closure, mark GO-LIVE,
+or claim adoption.`);
+}
+
+if (args.includes("--help") || args.includes("-h")) {
+  usage();
+  process.exit(0);
+}
+
+const repoRoot = resolve(arg("repo-root") || process.env.FRIDAY_REPO_ROOT || new URL("../..", import.meta.url).pathname);
+const manifestPathInput = arg("manifest") || process.env.FRIDAY_ENDBAR_ACCEPTANCE_MANIFEST || "docs/ops/friday-endbar-acceptance-manifest.json";
+const manifestPath = isAbsolute(manifestPathInput) ? manifestPathInput : resolve(repoRoot, manifestPathInput);
+const requireExternalSources = process.env.FRIDAY_ENDBAR_REQUIRE_EXTERNAL_SOURCES === "1";
+
+const blockers = [];
+const notes = [];
+
+function block(code, detail) {
+  blockers.push({ code, detail });
+}
+
+function readJson(path, label) {
+  try {
+    return JSON.parse(readFileSync(path, "utf8"));
+  } catch (error) {
+    block("json_unreadable", `${label}:${path}:${error.message}`);
+    return null;
+  }
+}
+
+function expandHome(path) {
+  if (path === "~") return process.env.HOME || "";
+  if (path.startsWith("~/")) return resolve(process.env.HOME || "", path.slice(2));
+  return path;
+}
+
+function repoPathExists(relativePath) {
+  return existsSync(resolve(repoRoot, relativePath));
+}
+
+function asArray(value) {
+  return Array.isArray(value) ? value : [];
+}
+
+function field(value, name) {
+  return value && typeof value === "object" ? value[name] : undefined;
+}
+
+function ids(rows) {
+  return new Set(asArray(rows).map((row) => field(row, "id")).filter((id) => typeof id === "string" && id));
+}
+
+function requiredIdsPresent(sectionName, rows, required) {
+  const present = ids(rows);
+  for (const id of required) {
+    if (!present.has(id)) block(`${sectionName}_missing_required_id`, id);
+  }
+}
+
+function containsUnsupportedFreeChatGpt(matrix) {
+  return asArray(matrix).some((row) => {
+    return field(row, "id") === "free_chatgpt_web_account"
+      && field(row, "status") === "unsupported_as_friday_autonomous_backend";
+  });
+}
+
+function hasDangerousFreeChatGptSupport(matrix) {
+  return asArray(matrix).some((row) => {
+    const id = String(field(row, "id") || "").toLowerCase();
+    const status = String(field(row, "status") || "").toLowerCase();
+    return id.includes("free_chatgpt") && /^supported(?:_|$)/.test(status);
+  });
+}
+
+if (!existsSync(manifestPath)) {
+  block("manifest_missing", manifestPath);
+}
+
+const manifest = existsSync(manifestPath) ? readJson(manifestPath, "endbar-acceptance-manifest") : null;
+
+if (manifest) {
+  if (manifest.schemaVersion !== 1) block("schema_version_not_1", String(manifest.schemaVersion));
+  if (manifest.truthLabel !== "endbar_acceptance_manifest_not_evidence_not_release") {
+    block("truth_label_unexpected", String(manifest.truthLabel || ""));
+  }
+  if (manifest.status !== "acceptance_defined_not_satisfied") {
+    block("status_must_not_claim_satisfied", String(manifest.status || ""));
+  }
+  if (!String(manifest.caveat || "").includes("not proof")) {
+    block("manifest_caveat_missing_not_proof", String(manifest.caveat || ""));
+  }
+
+  requiredIdsPresent("acceptance_group", manifest.acceptanceGroups, [
+    "mechanism_multiangle_stress",
+    "ui_real_use_mobile_desktop",
+    "selected_uiux_conformance",
+    "provider_entitlement_matrix",
+    "integrated_end_to_end_tape",
+  ]);
+  requiredIdsPresent("provider_matrix", manifest.providerEntitlementMatrix, [
+    "deepseek_api",
+    "openai_api",
+    "anthropic_api",
+    "codex_cli",
+    "claude_cli",
+    "free_chatgpt_web_account",
+  ]);
+
+  for (const group of asArray(manifest.acceptanceGroups)) {
+    if (field(group, "requiredForEndBar") !== true) {
+      block("acceptance_group_not_required", String(field(group, "id") || ""));
+    }
+    const passBar = asArray(field(group, "passBar"));
+    if (passBar.length === 0) block("acceptance_group_missing_pass_bar", String(field(group, "id") || ""));
+    for (const relativePath of asArray(field(group, "repoEvidencePaths"))) {
+      if (typeof relativePath !== "string" || !relativePath.trim()) {
+        block("repo_evidence_path_invalid", String(field(group, "id") || ""));
+      } else if (!repoPathExists(relativePath)) {
+        block("repo_evidence_path_missing", relativePath);
+      }
+    }
+  }
+
+  for (const source of asArray(manifest.operatorSources)) {
+    const sourcePath = field(source, "path");
+    if (typeof sourcePath !== "string" || !sourcePath.trim()) {
+      block("operator_source_path_invalid", String(field(source, "id") || ""));
+      continue;
+    }
+    if (requireExternalSources && !existsSync(expandHome(sourcePath))) {
+      block("operator_source_missing", sourcePath);
+    }
+  }
+  if (!requireExternalSources) {
+    notes.push("external operator sources listed but not required in default CI mode");
+  }
+
+  if (!containsUnsupportedFreeChatGpt(manifest.providerEntitlementMatrix)) {
+    block("free_chatgpt_boundary_missing", "free_chatgpt_web_account must be unsupported_as_friday_autonomous_backend");
+  }
+  if (hasDangerousFreeChatGptSupport(manifest.providerEntitlementMatrix)) {
+    block("free_chatgpt_incorrectly_supported", "free ChatGPT web account cannot count as a Friday autonomous backend");
+  }
+
+  const rules = asArray(manifest.completionRules).join("\n");
+  for (const phrase of [
+    "real user-use mobile and desktop",
+    "not runtime evidence",
+    "No synthetic INSERT",
+    "no fake organic",
+    "no production hub kill",
+    "no gate weakening",
+  ]) {
+    if (!rules.includes(phrase)) block("completion_rule_phrase_missing", phrase);
+  }
+}
+
+const report = {
+  truth: "endbar_acceptance_manifest_check_not_runtime_proof",
+  status: blockers.length === 0 ? "passed" : "failed",
+  repoRoot,
+  manifestPath,
+  externalSourceMode: requireExternalSources ? "required" : "listed_only",
+  notes,
+  blockers,
+  caveat: "This checker validates the standard and provider boundary only. END-BAR still requires real mobile+desktop user-use proof, provider runs, UI/device evidence, and closure gates.",
+};
+
+console.log(JSON.stringify(report, null, 2));
+process.exit(blockers.length === 0 ? 0 : 1);

--- a/test/unit/qa/friday-endbar-acceptance-manifest-contract.test.ts
+++ b/test/unit/qa/friday-endbar-acceptance-manifest-contract.test.ts
@@ -1,0 +1,54 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const manifest = JSON.parse(readFileSync("docs/ops/friday-endbar-acceptance-manifest.json", "utf8"));
+const checker = readFileSync("scripts/ops/check-friday-provider-entitlement-manifest.mjs", "utf8");
+
+describe("Friday END-BAR acceptance manifest contract", () => {
+  it("keeps the manifest as an acceptance standard, not proof of completion", () => {
+    expect(manifest.truthLabel).toBe("endbar_acceptance_manifest_not_evidence_not_release");
+    expect(manifest.status).toBe("acceptance_defined_not_satisfied");
+    expect(manifest.caveat).toContain("not proof");
+  });
+
+  it("requires mechanism, UI, selected-design, provider, and integrated tape groups", () => {
+    const ids = new Set(manifest.acceptanceGroups.map((group: { id: string }) => group.id));
+
+    expect([...ids]).toEqual(expect.arrayContaining([
+      "mechanism_multiangle_stress",
+      "ui_real_use_mobile_desktop",
+      "selected_uiux_conformance",
+      "provider_entitlement_matrix",
+      "integrated_end_to_end_tape",
+    ]));
+    expect(manifest.acceptanceGroups.every((group: { requiredForEndBar: boolean }) => group.requiredForEndBar)).toBe(true);
+  });
+
+  it("does not allow a free ChatGPT web account to count as a Friday autonomous backend", () => {
+    const freeChatGpt = manifest.providerEntitlementMatrix.find((row: { id: string }) => row.id === "free_chatgpt_web_account");
+    const codexCli = manifest.providerEntitlementMatrix.find((row: { id: string }) => row.id === "codex_cli");
+
+    expect(freeChatGpt.status).toBe("unsupported_as_friday_autonomous_backend");
+    expect(freeChatGpt.proof).toContain("negative/boundary check only");
+    expect(codexCli.status).toBe("advanced_local_first_party_cli_delegation");
+    expect(codexCli.proof).toContain("not a free ChatGPT backend");
+  });
+
+  it("pins completion rules against fake closure and gate weakening", () => {
+    const rules = manifest.completionRules.join("\n");
+
+    expect(rules).toContain("real user-use mobile and desktop");
+    expect(rules).toContain("not runtime evidence");
+    expect(rules).toContain("No synthetic INSERT");
+    expect(rules).toContain("no fake organic");
+    expect(rules).toContain("no production hub kill");
+    expect(rules).toContain("no gate weakening");
+  });
+
+  it("checker preserves external source portability and the free-account boundary", () => {
+    expect(checker).toContain("FRIDAY_ENDBAR_REQUIRE_EXTERNAL_SOURCES");
+    expect(checker).toContain("external operator sources listed but not required in default CI mode");
+    expect(checker).toContain("free ChatGPT web account cannot count as a Friday autonomous backend");
+    expect(checker).toContain("This checker validates the standard and provider boundary only");
+  });
+});


### PR DESCRIPTION
## Summary
- Add a machine-readable END-BAR acceptance manifest that consolidates the confirmed 5-group closure standard: mechanism stress, UI real-use, selected UI/UX conformance, provider entitlement, and integrated E2E tape.
- Add a manifest checker that validates the standard without claiming runtime proof, and keeps the free ChatGPT web-account boundary explicit: unsupported as a Friday autonomous backend.
- Add focused contract tests and an npm check script.

## Verification
- `npm run check:endbar-acceptance-manifest`
- `FRIDAY_ENDBAR_REQUIRE_EXTERNAL_SOURCES=1 npm run check:endbar-acceptance-manifest`
- `npx vitest run test/unit/qa/friday-endbar-acceptance-manifest-contract.test.ts --reporter=dot`
- `node --check scripts/ops/check-friday-provider-entitlement-manifest.mjs`
- JSON parse check for `docs/ops/friday-endbar-acceptance-manifest.json`
- `git diff --check`

## Truth
This defines and guards the acceptance standard only. It is not runtime evidence, not END-BAR, not GO-LIVE, and not adoption proof.