### PR TITLE
[codex] Surface selected mobile design destinations

### DIFF
--- a/apps/friday-ios/Sources/FridayMobileShell/CommandSheet.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/CommandSheet.swift
@@ -25,6 +25,9 @@ enum MobileDestination: String, CaseIterable, Identifiable {
   case workflows
   case onboarding
   case settings
+  case petEditor
+  case proofViewer
+  case entrypoints
 
   var id: String { rawValue }
 
@@ -66,35 +69,43 @@ struct CommandSheet: View {
 
   private let columns = [GridItem(.flexible(), spacing: 14), GridItem(.flexible(), spacing: 14)]
   private let endBarSnapshot = MobileProductEndBarSnapshot()
-  private let selectedMobileSurfaceTitles = [
-    "Session",
-    "Context Passport",
-    "Device Pairing",
-    "Token Ledger",
-    "Share Intake",
-    "Voice",
-    "Needs Me",
+  private let sections: [(String, [MobileDestination])] = [
+    ("Command", [.home, .newSession, .voice, .shareIntake]),
+    ("Work", [.missions, .needsMe, .activity, .workflows]),
+    ("Providers", [.platform, .providerAuth, .session]),
+    ("Trust", [.contextPassport, .memory, .tokenLedger, .proofViewer]),
+    ("Setup", [.pairing, .onboarding, .settings, .petEditor, .entrypoints]),
   ]
 
   var body: some View {
     NavigationStack {
       ScrollView {
-        LazyVGrid(columns: columns, spacing: 14) {
-          ForEach(MobileDestination.allCases) { dest in
-            Button {
-              if dest.isBuilt { destination = dest }
-              isOpen = false
-            } label: {
-              tile(dest)
+        VStack(alignment: .leading, spacing: 18) {
+          ForEach(sections, id: \.0) { section in
+            VStack(alignment: .leading, spacing: 10) {
+              Text(section.0.uppercased())
+                .font(.caption.weight(.bold))
+                .foregroundStyle(MobileTheme.textSecondary)
+                .tracking(3)
+                .accessibilityHidden(true)
+              LazyVGrid(columns: columns, spacing: 14) {
+                ForEach(section.1) { dest in
+                  Button {
+                    if dest.isBuilt { destination = dest }
+                    isOpen = false
+                  } label: {
+                    tile(dest)
+                  }
+                  .buttonStyle(.plain)
+                  .disabled(!dest.isBuilt)
+                  .accessibilityIdentifier("friday.command-sheet.destination.\(dest.rawValue)")
+                }
+              }
             }
-            .buttonStyle(.plain)
-            .disabled(!dest.isBuilt)
-            .accessibilityIdentifier("friday.command-sheet.destination.\(dest.rawValue)")
           }
+          readinessFooter
         }
         .padding(16)
-
-        readinessFooter
       }
       .background(MobileTheme.backgroundWarmOffWhite.ignoresSafeArea())
       .navigationTitle("Friday")
@@ -157,6 +168,6 @@ struct CommandSheet: View {
     .padding(.top, 8)
     .accessibilityIdentifier("friday.command-sheet.readiness-footer")
     .accessibilityLabel(
-      "Route coverage is not END-BAR. Selected mobile surfaces: \(selectedMobileSurfaceTitles.joined(separator: ", ")).")
+      "Route coverage is not END-BAR. Selected mobile surfaces: \(MobileDestination.allCases.map(\.title).joined(separator: ", ")).")
   }
 }

--- a/apps/friday-ios/Sources/FridayMobileShell/FridayApp.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayApp.swift
@@ -405,7 +405,8 @@ struct RootView: View {
           FridayProjectionScreen(destination: destination, viewModel: homeVM) {
             destination = .pairing
           }
-        case .missions, .needsMe, .memory, .platform, .activity, .workflows, .settings:
+        case .missions, .needsMe, .memory, .platform, .activity, .workflows, .settings,
+             .petEditor, .proofViewer, .entrypoints:
           FridayProjectionScreen(destination: destination, viewModel: homeVM)
         }
       }

--- a/apps/friday-ios/Sources/FridayMobileShell/FridayProjectionScreens.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayProjectionScreens.swift
@@ -11,6 +11,9 @@ private enum ProjectionSurface {
   case workflows
   case onboarding
   case settings
+  case petEditor
+  case proofViewer
+  case entrypoints
 
   init?(_ destination: MobileDestination) {
     switch destination {
@@ -33,6 +36,12 @@ private enum ProjectionSurface {
       self = .onboarding
     case .settings:
       self = .settings
+    case .petEditor:
+      self = .petEditor
+    case .proofViewer:
+      self = .proofViewer
+    case .entrypoints:
+      self = .entrypoints
     }
   }
 
@@ -46,6 +55,9 @@ private enum ProjectionSurface {
     case .workflows: return "arrow.triangle.branch"
     case .onboarding: return "sparkles.rectangle.stack"
     case .settings: return "gearshape"
+    case .petEditor: return "paintpalette"
+    case .proofViewer: return "doc.text.magnifyingglass"
+    case .entrypoints: return "rectangle.stack.badge.plus"
     }
   }
 
@@ -59,6 +71,9 @@ private enum ProjectionSurface {
     case .workflows: return "Workflows"
     case .onboarding: return "Onboarding"
     case .settings: return "Settings"
+    case .petEditor: return "Pet Editor"
+    case .proofViewer: return "Proof Viewer"
+    case .entrypoints: return "iOS Entrypoints"
     }
   }
 
@@ -72,6 +87,9 @@ private enum ProjectionSurface {
     case .workflows: return "workflows"
     case .onboarding: return "onboarding"
     case .settings: return "settings"
+    case .petEditor: return "pet-editor"
+    case .proofViewer: return "proof-viewer"
+    case .entrypoints: return "entrypoints"
     }
   }
 
@@ -85,6 +103,9 @@ private enum ProjectionSurface {
     case .workflows: return "routing and work"
     case .onboarding: return "local readiness"
     case .settings: return "read seam"
+    case .petEditor: return "companion state"
+    case .proofViewer: return "receipt truth"
+    case .entrypoints: return "native launchers"
     }
   }
 }
@@ -205,6 +226,12 @@ struct FridayProjectionScreen: View {
         onboardingCard(projection)
       case .settings:
         settingsCard(projection)
+      case .petEditor:
+        petEditorCard(projection)
+      case .proofViewer:
+        proofViewerCard(projection)
+      case .entrypoints:
+        entrypointsCard(projection)
       }
     }
   }
@@ -673,6 +700,74 @@ struct FridayProjectionScreen: View {
       }
     }
     pushNotificationCard()
+  }
+
+  private func petEditorCard(_ projection: HomeProjection) -> some View {
+    GlassPanel {
+      VStack(alignment: .leading, spacing: MobileTheme.rowSpacing) {
+        cardHeader("Companion State", count: nil)
+        Text("The selected mobile design keeps the companion visible, but pet editing is not allowed to invent live state. This screen exposes the current state mapping gap until a real pet-state proof exists.")
+          .font(.caption)
+          .foregroundStyle(MobileTheme.textSecondary)
+          .fixedSize(horizontal: false, vertical: true)
+        readinessRow(
+          title: "Hero pet",
+          value: "rendered locally from bundled v9 assets",
+          healthy: true)
+        readinessRow(
+          title: "Live state mapping",
+          value: projection.runtimeFeedStatus.isEmpty ? "not in projection" : projection.runtimeFeedStatus,
+          healthy: false)
+        RefPill(label: "action", ref: "mobile/pet/state-mapping")
+        RefPill(label: "mission_id", ref: projection.missionId)
+      }
+    }
+    .accessibilityIdentifier("friday.pet-editor.readiness")
+  }
+
+  private func proofViewerCard(_ projection: HomeProjection) -> some View {
+    GlassPanel {
+      VStack(alignment: .leading, spacing: MobileTheme.rowSpacing) {
+        cardHeader(
+          "Proof Receipts",
+          count: projection.providerReceiptRefs.count + projection.channelReceiptRefs.count)
+        Text("Proof Viewer shows only receipt refs emitted by the live projection. Opening and replaying receipt contents still requires same-run app evidence before END-BAR.")
+          .font(.caption)
+          .foregroundStyle(MobileTheme.textSecondary)
+          .fixedSize(horizontal: false, vertical: true)
+        if projection.providerReceiptRefs.isEmpty && projection.channelReceiptRefs.isEmpty {
+          emptyText("No proof receipt refs in this projection.")
+        } else {
+          ForEach(projection.providerReceiptRefs, id: \.self) {
+            RefPill(label: "provider", ref: $0)
+          }
+          ForEach(projection.channelReceiptRefs, id: \.self) {
+            RefPill(label: "channel", ref: $0)
+          }
+        }
+        RefPill(label: "action", ref: "mobile/proof/viewer-open")
+      }
+    }
+    .accessibilityIdentifier("friday.proof-viewer.receipts")
+  }
+
+  private func entrypointsCard(_ projection: HomeProjection) -> some View {
+    GlassPanel {
+      VStack(alignment: .leading, spacing: MobileTheme.rowSpacing) {
+        cardHeader("Native Entrypoints", count: nil)
+        Text("Widgets, controls, push entry, share intake, and deep links are tracked here as selected-design launch paths. This is readiness evidence, not proof of a completed user loop.")
+          .font(.caption)
+          .foregroundStyle(MobileTheme.textSecondary)
+          .fixedSize(horizontal: false, vertical: true)
+        readinessRow(title: "Share intake", value: "friday://share deep link wired", healthy: true)
+        readinessRow(title: "Command sheet", value: "top-left launcher routes selected surfaces", healthy: true)
+        readinessRow(title: "Push entry", value: "local permission surface wired; APNs delivery still unproven", healthy: false)
+        readinessRow(title: "Widget/control", value: "native launcher proof still required", healthy: false)
+        RefPill(label: "action", ref: "mobile/entrypoints/readiness")
+        RefPill(label: "conversation", ref: projection.fridayConversationId)
+      }
+    }
+    .accessibilityIdentifier("friday.entrypoints.readiness")
   }
 
   @ViewBuilder

--- a/apps/friday-ios/Sources/FridayMobileShellCore/MobileProductReadinessContract.swift
+++ b/apps/friday-ios/Sources/FridayMobileShellCore/MobileProductReadinessContract.swift
@@ -131,6 +131,9 @@ public enum MobileProductDestinationID: String, CaseIterable, Sendable, Equatabl
   case workflows
   case onboarding
   case settings
+  case petEditor
+  case proofViewer
+  case entrypoints
 
   public var id: String { rawValue }
 
@@ -280,6 +283,27 @@ public enum MobileProductDestinationID: String, CaseIterable, Sendable, Equatabl
         tier: .statusProjection,
         runtimeActionIds: ["mobile/settings/push-permission"],
         blockers: [.init(.needsRuntimeEvidence, label: "settings mutation proof")])
+    case .petEditor:
+      return contract(
+        title: "Pet Editor",
+        systemImage: "paintpalette",
+        tier: .readinessOnly,
+        runtimeActionIds: ["mobile/pet/state-mapping"],
+        blockers: [.init(.needsRuntimeEvidence, label: "pet state mapping proof")])
+    case .proofViewer:
+      return contract(
+        title: "Proof Viewer",
+        systemImage: "doc.text.magnifyingglass",
+        tier: .liveReadProjection,
+        runtimeActionIds: ["mobile/proof/viewer-open"],
+        blockers: [.init(.needsRuntimeEvidence, label: "proof receipt open proof")])
+    case .entrypoints:
+      return contract(
+        title: "iOS Entrypoints",
+        systemImage: "rectangle.stack.badge.plus",
+        tier: .readinessOnly,
+        runtimeActionIds: ["mobile/entrypoints/readiness"],
+        blockers: [.init(.needsRuntimeEvidence, label: "widget/control/app-intent proof")])
     }
   }
 

--- a/apps/friday-ios/Tests/FridayMobileShellCoreTests/MobileProductReadinessContractTests.swift
+++ b/apps/friday-ios/Tests/FridayMobileShellCoreTests/MobileProductReadinessContractTests.swift
@@ -23,6 +23,9 @@ func mobileProductContractCoversOperatorSelectedDestinations() {
     "workflows",
     "onboarding",
     "settings",
+    "petEditor",
+    "proofViewer",
+    "entrypoints",
   ])
   #expect(MobileProductDestinationID.allCases.allSatisfy { $0.contract.routeBuilt })
   #expect(MobileProductDestinationID.allCases.allSatisfy { $0.contract.selectedDesignLocked })
@@ -166,4 +169,30 @@ func mobileProductContractTracksNewSessionLaunchIntoChatButRuntimeBlocked() {
   #expect(!newSession.blockers.contains { $0.kind == .needsLiveWrite })
   #expect(newSession.blockers.contains { $0.kind == .needsRuntimeEvidence })
   #expect(!newSession.isEndBarReady)
+}
+
+@Test
+func mobileProductContractTracksSelectedDesignCompanionProofAndEntrypoints() {
+  let petEditor = MobileProductDestinationID.petEditor.contract
+  let proofViewer = MobileProductDestinationID.proofViewer.contract
+  let entrypoints = MobileProductDestinationID.entrypoints.contract
+
+  #expect(petEditor.title == "Pet Editor")
+  #expect(petEditor.tier == .readinessOnly)
+  #expect(petEditor.runtimeActionIds == ["mobile/pet/state-mapping"])
+  #expect(petEditor.blockers.contains { $0.label == "pet state mapping proof" })
+
+  #expect(proofViewer.title == "Proof Viewer")
+  #expect(proofViewer.tier == .liveReadProjection)
+  #expect(proofViewer.runtimeActionIds == ["mobile/proof/viewer-open"])
+  #expect(proofViewer.blockers.contains { $0.label == "proof receipt open proof" })
+
+  #expect(entrypoints.title == "iOS Entrypoints")
+  #expect(entrypoints.tier == .readinessOnly)
+  #expect(entrypoints.runtimeActionIds == ["mobile/entrypoints/readiness"])
+  #expect(entrypoints.blockers.contains { $0.label == "widget/control/app-intent proof" })
+
+  #expect(!petEditor.isEndBarReady)
+  #expect(!proofViewer.isEndBarReady)
+  #expect(!entrypoints.isEndBarReady)
 }

--- a/scripts/ops/friday-ios-sim-accessibility-capture.mjs
+++ b/scripts/ops/friday-ios-sim-accessibility-capture.mjs
@@ -69,6 +69,9 @@ const ACTION_MAP = {
   "mobile/onboarding/open-device-pairing": { screen: "onboarding", accessibilityIds: ["friday.onboarding.open-device-pairing"], event: "mission_workbench_visible", interaction: "visible" },
   "mobile/platform/capability-matrix": { screen: "platform", accessibilityIds: ["friday.platform.capability-matrix"], event: "same_mission_projection_visible", interaction: "visible" },
   "mobile/settings/push-permission": { screen: "settings", accessibilityIds: ["friday.settings.push-permission"], event: "mission_workbench_visible", interaction: "visible" },
+  "mobile/pet/state-mapping": { screen: "petEditor", accessibilityIds: ["friday.pet-editor.readiness"], event: "same_mission_projection_visible", interaction: "visible" },
+  "mobile/proof/viewer-open": { screen: "proofViewer", accessibilityIds: ["friday.proof-viewer.receipts"], event: "proof_receipt_visible_before_done", interaction: "visible" },
+  "mobile/entrypoints/readiness": { screen: "entrypoints", accessibilityIds: ["friday.entrypoints.readiness"], event: "mission_workbench_visible", interaction: "visible" },
 };
 
 function usage() {

--- a/test/unit/qa/friday-ios-sim-accessibility-capture-cli.test.ts
+++ b/test/unit/qa/friday-ios-sim-accessibility-capture-cli.test.ts
@@ -101,6 +101,18 @@ describe("friday-ios-sim-accessibility-capture", () => {
         runtimeActionId: "mobile/home/refresh",
         accessibilityIds: expect.arrayContaining(["friday.mobile.toolbar.refresh"]),
       }));
+      expect(summary.targets).toContainEqual(expect.objectContaining({
+        runtimeActionId: "mobile/pet/state-mapping",
+        accessibilityIds: expect.arrayContaining(["friday.pet-editor.readiness"]),
+      }));
+      expect(summary.targets).toContainEqual(expect.objectContaining({
+        runtimeActionId: "mobile/proof/viewer-open",
+        accessibilityIds: expect.arrayContaining(["friday.proof-viewer.receipts"]),
+      }));
+      expect(summary.targets).toContainEqual(expect.objectContaining({
+        runtimeActionId: "mobile/entrypoints/readiness",
+        accessibilityIds: expect.arrayContaining(["friday.entrypoints.readiness"]),
+      }));
     } finally {
       rmSync(outDir, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary
- Adds the selected mobile design destinations for Pet Editor, Proof Viewer, and iOS Entrypoints to the mobile product readiness contract and command sheet.
- Wires those destinations through the SwiftUI root router and projection surface so every selected route opens to a truth-preserving screen.
- Adds contract coverage proving these destinations are route-visible while still blocked from END-BAR until runtime proof exists.

## Truth label
This is selected UI/UX route and readiness coverage only. It does not claim END-BAR, adoption, GO-LIVE, or a completed real-user closed loop.

## Validation
- `git diff --check`
- `swift test --package-path apps/friday-ios --filter MobileProductReadinessContractTests`
- `swift test --package-path apps/friday-ios`