### PR TITLE
[codex] Aggregate END-BAR readiness reports

### DIFF
--- a/package.json
+++ b/package.json
@@ -125,6 +125,7 @@
     "check:uiux-action-traceability": "node scripts/ops/check-friday-uiux-action-traceability.mjs",
     "check:uiux-product-closure": "node scripts/ops/friday-uiux-product-closure-readiness.mjs",
     "check:endbar-acceptance-manifest": "node scripts/ops/check-friday-provider-entitlement-manifest.mjs",
+    "check:endbar-readiness": "node scripts/ops/check-friday-endbar-readiness.mjs",
     "check:github-channel-proof-readiness": "node scripts/ops/check-friday-github-channel-proof-readiness.mjs",
     "check:ui-device-accessibility-click-capture": "node scripts/ops/friday-ui-device-accessibility-click-capture.mjs",
     "check:agent-rollout:phase1": "node scripts/ops/run-agent-rollout-acceptance.mjs phase1",

--- a/scripts/ops/check-friday-endbar-readiness.mjs
+++ b/scripts/ops/check-friday-endbar-readiness.mjs
@@ -1,0 +1,223 @@
+#!/usr/bin/env node
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, isAbsolute, resolve } from "node:path";
+
+const args = process.argv.slice(2);
+
+function usage() {
+  console.error(`usage:
+  node scripts/ops/check-friday-endbar-readiness.mjs \\
+    [--repo-root=/abs/repo] \\
+    [--manifest=/abs/or/repo-relative/friday-endbar-acceptance-manifest.json] \\
+    [--mechanism-report=/abs/report.json] \\
+    [--ui-real-use-report=/abs/report.json] \\
+    [--selected-uiux-report=/abs/report.json] \\
+    [--provider-entitlement-report=/abs/report.json] \\
+    [--integrated-tape-report=/abs/report.json] \\
+    [--out=/abs/endbar-readiness.json] [--require-complete]
+
+Truth: aggregates already-captured reports against the five END-BAR acceptance
+groups. It does not run providers, synthesize evidence, insert DB rows, mark
+GO-LIVE, or claim adoption.`);
+}
+
+function arg(name) {
+  const prefix = `--${name}=`;
+  for (let index = 0; index < args.length; index += 1) {
+    const value = args[index];
+    if (value.startsWith(prefix)) return value.slice(prefix.length);
+    if (value === `--${name}` && args[index + 1]) return args[index + 1];
+  }
+  return "";
+}
+
+if (args.includes("--help") || args.includes("-h")) {
+  usage();
+  process.exit(0);
+}
+
+const requireComplete = args.includes("--require-complete");
+const repoRoot = resolve(arg("repo-root") || process.env.FRIDAY_REPO_ROOT || new URL("../..", import.meta.url).pathname);
+const manifestPathInput = arg("manifest") || process.env.FRIDAY_ENDBAR_ACCEPTANCE_MANIFEST || "docs/ops/friday-endbar-acceptance-manifest.json";
+const manifestPath = isAbsolute(manifestPathInput) ? manifestPathInput : resolve(repoRoot, manifestPathInput);
+const outPath = arg("out") || process.env.FRIDAY_ENDBAR_READINESS_REPORT || "";
+
+const reportInputs = {
+  mechanism_multiangle_stress: arg("mechanism-report") || process.env.FRIDAY_ENDBAR_MECHANISM_REPORT || "",
+  ui_real_use_mobile_desktop: arg("ui-real-use-report") || process.env.FRIDAY_ENDBAR_UI_REAL_USE_REPORT || "",
+  selected_uiux_conformance: arg("selected-uiux-report") || process.env.FRIDAY_ENDBAR_SELECTED_UIUX_REPORT || "",
+  provider_entitlement_matrix: arg("provider-entitlement-report") || process.env.FRIDAY_ENDBAR_PROVIDER_ENTITLEMENT_REPORT || "",
+  integrated_end_to_end_tape: arg("integrated-tape-report") || process.env.FRIDAY_ENDBAR_INTEGRATED_TAPE_REPORT || "",
+};
+
+const blockers = [];
+
+function block(code, detail) {
+  blockers.push({ code, detail });
+}
+
+function readJson(path, label) {
+  try {
+    return JSON.parse(readFileSync(path, "utf8"));
+  } catch (error) {
+    block("json_unreadable", `${label}:${path}:${error.message}`);
+    return null;
+  }
+}
+
+function abs(path) {
+  return isAbsolute(path) ? path : resolve(path);
+}
+
+function asArray(value) {
+  return Array.isArray(value) ? value : [];
+}
+
+function field(value, name) {
+  return value && typeof value === "object" ? value[name] : undefined;
+}
+
+function statusText(value) {
+  return String(field(value, "status") || field(value, "result") || field(value, "proof") || "");
+}
+
+function hasDeferredSignal(value) {
+  const status = statusText(value).toLowerCase();
+  if (status.includes("defer")) return true;
+  if (asArray(field(value, "deferredInputs")).length > 0) return true;
+  if (asArray(field(value, "deferred_inputs")).length > 0) return true;
+  const blockers = asArray(field(value, "blockers")).join("\n").toLowerCase();
+  return blockers.includes("defer") || blockers.includes("channel_deferred");
+}
+
+function isPassLike(value) {
+  const status = statusText(value);
+  return [
+    "pass",
+    "passed",
+    "ready",
+    "complete",
+    "complete_inputs_observed",
+    "uiux_product_closure_evidence_ready",
+    "selected_visual_proof_ready",
+    "product_runtime_actions_traceable",
+    "runtime_actions_covered",
+    "integrated_end_to_end_tape_ready",
+  ].includes(status);
+}
+
+function expectedStatusForGroup(groupId, report) {
+  if (!report) return { status: "missing_report", blocker: "report not supplied" };
+  if (hasDeferredSignal(report)) {
+    return {
+      status: "deferred",
+      blocker: "deferred input remains outside strict END-BAR",
+    };
+  }
+  if (groupId === "provider_entitlement_matrix") {
+    return report.status === "passed"
+      ? { status: "satisfied" }
+      : { status: "blocked", blocker: statusText(report) || "provider entitlement report not passed" };
+  }
+  if (groupId === "selected_uiux_conformance") {
+    const accepted = [
+      "uiux_product_closure_evidence_ready",
+      "selected_visual_proof_ready",
+      "product_runtime_actions_traceable",
+      "runtime_actions_covered",
+      "passed",
+    ];
+    return accepted.includes(statusText(report))
+      ? { status: "satisfied" }
+      : { status: "blocked", blocker: statusText(report) || "selected UI/UX report not complete" };
+  }
+  return isPassLike(report)
+    ? { status: "satisfied" }
+    : { status: "blocked", blocker: statusText(report) || "report not pass-like" };
+}
+
+function readReport(groupId, inputPath) {
+  if (!inputPath) return null;
+  const resolved = abs(inputPath);
+  if (!existsSync(resolved)) {
+    block("report_missing", `${groupId}:${resolved}`);
+    return null;
+  }
+  return {
+    path: resolved,
+    value: readJson(resolved, groupId),
+  };
+}
+
+if (!existsSync(manifestPath)) {
+  block("manifest_missing", manifestPath);
+}
+
+const manifest = existsSync(manifestPath) ? readJson(manifestPath, "endbar-acceptance-manifest") : null;
+const groups = asArray(field(manifest, "acceptanceGroups"));
+const requiredGroups = groups.filter((group) => field(group, "requiredForEndBar") === true);
+
+for (const requiredId of [
+  "mechanism_multiangle_stress",
+  "ui_real_use_mobile_desktop",
+  "selected_uiux_conformance",
+  "provider_entitlement_matrix",
+  "integrated_end_to_end_tape",
+]) {
+  if (!requiredGroups.some((group) => field(group, "id") === requiredId)) {
+    block("acceptance_group_missing", requiredId);
+  }
+}
+
+const rows = requiredGroups.map((group) => {
+  const id = field(group, "id");
+  const loaded = readReport(id, reportInputs[id] || "");
+  const evaluation = expectedStatusForGroup(id, loaded?.value || null);
+  return {
+    id,
+    requiredForEndBar: true,
+    status: evaluation.status,
+    reportPath: loaded?.path || null,
+    reportStatus: loaded?.value ? statusText(loaded.value) || null : null,
+    blocker: evaluation.blocker || null,
+    passBar: asArray(field(group, "passBar")),
+  };
+});
+
+for (const row of rows) {
+  if (row.status !== "satisfied") {
+    block("acceptance_group_not_satisfied", `${row.id}:${row.status}`);
+  }
+}
+
+const satisfiedCount = rows.filter((row) => row.status === "satisfied").length;
+const deferredCount = rows.filter((row) => row.status === "deferred").length;
+const missingReportCount = rows.filter((row) => row.status === "missing_report").length;
+const strictEndBarReady = rows.length > 0 && satisfiedCount === rows.length && blockers.length === 0;
+
+const report = {
+  truth: "endbar_readiness_aggregator_not_runtime_proof_not_release",
+  status: strictEndBarReady ? "strict_endbar_inputs_satisfied" : "blocked",
+  repoRoot,
+  manifestPath,
+  counts: {
+    requiredGroups: rows.length,
+    satisfied: satisfiedCount,
+    deferred: deferredCount,
+    missingReport: missingReportCount,
+  },
+  groups: rows,
+  blockers,
+  strictEndBarReady,
+  caveat: "This report aggregates supplied evidence reports only. It never creates evidence, never counts deferred channel proof as strict END-BAR, and never turns report coverage into adoption.",
+};
+
+if (outPath) {
+  const out = abs(outPath);
+  mkdirSync(dirname(out), { recursive: true });
+  writeFileSync(out, `${JSON.stringify(report, null, 2)}\n`);
+}
+
+console.log(JSON.stringify(report, null, 2));
+process.exit(strictEndBarReady || !requireComplete ? 0 : 2);

--- a/test/unit/qa/friday-endbar-readiness-aggregator.test.ts
+++ b/test/unit/qa/friday-endbar-readiness-aggregator.test.ts
@@ -1,0 +1,81 @@
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const script = "scripts/ops/check-friday-endbar-readiness.mjs";
+
+function run(args: string[] = []) {
+  const stdout = execFileSync(process.execPath, [script, ...args], {
+    cwd: process.cwd(),
+    encoding: "utf8",
+  });
+  return JSON.parse(stdout);
+}
+
+function writeJson(dir: string, name: string, value: unknown) {
+  const path = join(dir, name);
+  writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`);
+  return path;
+}
+
+describe("Friday END-BAR readiness aggregator", () => {
+  it("reports missing evidence reports without claiming END-BAR", () => {
+    const report = run();
+
+    expect(report.truth).toBe("endbar_readiness_aggregator_not_runtime_proof_not_release");
+    expect(report.status).toBe("blocked");
+    expect(report.strictEndBarReady).toBe(false);
+    expect(report.counts.requiredGroups).toBe(5);
+    expect(report.counts.missingReport).toBe(5);
+    expect(report.blockers).toContainEqual({
+      code: "acceptance_group_not_satisfied",
+      detail: "mechanism_multiangle_stress:missing_report",
+    });
+  });
+
+  it("keeps deferred channel proof outside strict END-BAR", () => {
+    const dir = mkdtempSync(join(tmpdir(), "friday-endbar-readiness-"));
+    const pass = writeJson(dir, "pass.json", { status: "passed" });
+    const deferred = writeJson(dir, "deferred.json", {
+      status: "blocked",
+      deferredInputs: [{ role: "channel", status: "deferred_by_operator" }],
+    });
+
+    const report = run([
+      `--mechanism-report=${pass}`,
+      `--ui-real-use-report=${deferred}`,
+      `--selected-uiux-report=${pass}`,
+      `--provider-entitlement-report=${pass}`,
+      `--integrated-tape-report=${pass}`,
+    ]);
+
+    expect(report.status).toBe("blocked");
+    expect(report.strictEndBarReady).toBe(false);
+    expect(report.counts.satisfied).toBe(4);
+    expect(report.counts.deferred).toBe(1);
+    expect(report.groups.find((group: { id: string }) => group.id === "ui_real_use_mobile_desktop").status).toBe("deferred");
+  });
+
+  it("marks strict ready only when every required group has a supplied pass report", () => {
+    const dir = mkdtempSync(join(tmpdir(), "friday-endbar-readiness-"));
+    const pass = writeJson(dir, "pass.json", { status: "passed" });
+    const selected = writeJson(dir, "selected.json", { status: "uiux_product_closure_evidence_ready" });
+    const integrated = writeJson(dir, "integrated.json", { status: "integrated_end_to_end_tape_ready" });
+
+    const report = run([
+      `--mechanism-report=${pass}`,
+      `--ui-real-use-report=${pass}`,
+      `--selected-uiux-report=${selected}`,
+      `--provider-entitlement-report=${pass}`,
+      `--integrated-tape-report=${integrated}`,
+      "--require-complete",
+    ]);
+
+    expect(report.status).toBe("strict_endbar_inputs_satisfied");
+    expect(report.strictEndBarReady).toBe(true);
+    expect(report.counts.satisfied).toBe(5);
+    expect(report.blockers).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary\n- add a read-only END-BAR readiness aggregator over the 5 accepted validation groups\n- require real report artifacts instead of treating manifest coverage as proof\n- keep strict END-BAR blocked when any group is missing, failed, deferred, or channel-deferred\n\n## Validation\n- node --check scripts/ops/check-friday-endbar-readiness.mjs\n- npx vitest run test/unit/qa/friday-endbar-readiness-aggregator.test.ts --reporter=dot\n- git diff --check\n\nTruth: readiness aggregation only; not END-BAR, adoption, GO-LIVE, or generated proof evidence.