### PR TITLE
[codex] Discover END-BAR readiness report inputs

### DIFF
--- a/package.json
+++ b/package.json
@@ -126,6 +126,7 @@
     "check:uiux-product-closure": "node scripts/ops/friday-uiux-product-closure-readiness.mjs",
     "check:endbar-acceptance-manifest": "node scripts/ops/check-friday-provider-entitlement-manifest.mjs",
     "check:endbar-readiness": "node scripts/ops/check-friday-endbar-readiness.mjs",
+    "check:endbar-report-inputs": "node scripts/ops/check-friday-endbar-report-inputs.mjs",
     "check:github-channel-proof-readiness": "node scripts/ops/check-friday-github-channel-proof-readiness.mjs",
     "check:ui-device-accessibility-click-capture": "node scripts/ops/friday-ui-device-accessibility-click-capture.mjs",
     "check:agent-rollout:phase1": "node scripts/ops/run-agent-rollout-acceptance.mjs phase1",

--- a/scripts/ops/check-friday-endbar-report-inputs.mjs
+++ b/scripts/ops/check-friday-endbar-report-inputs.mjs
@@ -1,0 +1,363 @@
+#!/usr/bin/env node
+
+import { existsSync, mkdirSync, readdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { dirname, isAbsolute, join, resolve } from "node:path";
+
+const args = process.argv.slice(2);
+
+function usage() {
+  console.error(`usage:
+  node scripts/ops/check-friday-endbar-report-inputs.mjs \\
+    [--repo-root=/abs/repo] \\
+    --search-root=/abs/artifact-dir [--search-root=/abs/other-dir ...] \\
+    [--max-depth=5] [--out=/abs/report-inputs.json]
+
+Truth: discovers existing END-BAR report candidates and prints the readiness
+aggregator command. It does not run providers, create evidence, write DB rows,
+mark GO-LIVE, count deferred channel proof as strict END-BAR, or claim release.`);
+}
+
+function arg(name) {
+  const prefix = `--${name}=`;
+  for (let index = 0; index < args.length; index += 1) {
+    const value = args[index];
+    if (value.startsWith(prefix)) return value.slice(prefix.length);
+    if (value === `--${name}` && args[index + 1]) return args[index + 1];
+  }
+  return "";
+}
+
+function allArgs(name) {
+  const prefix = `--${name}=`;
+  const values = [];
+  for (let index = 0; index < args.length; index += 1) {
+    const value = args[index];
+    if (value.startsWith(prefix)) values.push(value.slice(prefix.length));
+    if (value === `--${name}` && args[index + 1]) {
+      values.push(args[index + 1]);
+      index += 1;
+    }
+  }
+  return values;
+}
+
+if (args.includes("--help") || args.includes("-h")) {
+  usage();
+  process.exit(0);
+}
+
+const repoRoot = resolve(arg("repo-root") || process.env.FRIDAY_REPO_ROOT || new URL("../..", import.meta.url).pathname);
+const searchRoots = allArgs("search-root").map((path) => isAbsolute(path) ? path : resolve(path));
+const outPath = arg("out") || process.env.FRIDAY_ENDBAR_REPORT_INPUT_DISCOVERY || "";
+const maxDepth = Number.parseInt(arg("max-depth") || process.env.FRIDAY_ENDBAR_REPORT_INPUT_MAX_DEPTH || "5", 10);
+
+const groupOrder = [
+  "mechanism_multiangle_stress",
+  "ui_real_use_mobile_desktop",
+  "selected_uiux_conformance",
+  "provider_entitlement_matrix",
+  "integrated_end_to_end_tape",
+];
+
+const optionByGroup = {
+  mechanism_multiangle_stress: "--mechanism-report",
+  ui_real_use_mobile_desktop: "--ui-real-use-report",
+  selected_uiux_conformance: "--selected-uiux-report",
+  provider_entitlement_matrix: "--provider-entitlement-report",
+  integrated_end_to_end_tape: "--integrated-tape-report",
+};
+
+const blockers = [];
+const notes = [];
+
+function block(code, detail) {
+  blockers.push({ code, detail });
+}
+
+function asArray(value) {
+  return Array.isArray(value) ? value : [];
+}
+
+function text(value) {
+  if (value == null) return "";
+  if (typeof value === "string") return value;
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
+function statusText(report) {
+  return text(report?.status || report?.result || report?.proof || "");
+}
+
+function truthText(report) {
+  return text(report?.truth || report?.truth_label || report?.truthLabel || "");
+}
+
+function hasDeferredSignal(report) {
+  const haystack = [
+    statusText(report),
+    truthText(report),
+    text(report?.blockers),
+    text(report?.readinessBlockers),
+    text(report?.deferredInputs),
+    text(report?.deferred_inputs),
+  ].join("\n").toLowerCase();
+  return haystack.includes("defer") || haystack.includes("channel_deferred");
+}
+
+function hasBlockers(report) {
+  return asArray(report?.blockers).length > 0 || asArray(report?.readinessBlockers).length > 0;
+}
+
+function hasAnySignal(value, signals) {
+  const lower = value.toLowerCase();
+  return signals.some((signal) => lower.includes(signal));
+}
+
+function classifyForGroup(groupId, report, path) {
+  const status = statusText(report);
+  const truth = truthText(report);
+  const pathAndTruth = `${path}\n${truth}`.toLowerCase();
+  const deferred = hasDeferredSignal(report);
+  if (deferred) {
+    return { classification: "deferred", score: 55, reason: "report contains deferred/channel-deferred signal" };
+  }
+
+  if (groupId === "provider_entitlement_matrix") {
+    if (status === "passed" && truth.includes("endbar_acceptance_manifest_check")) {
+      return { classification: "boundary_only", score: 35, reason: "provider boundary checker passed but is not runtime provider proof" };
+    }
+    if (status === "passed") return { classification: "satisfied", score: 90, reason: "provider entitlement report status is passed" };
+    return { classification: "candidate", score: 20, reason: `status=${status || "<missing>"}` };
+  }
+
+  if (groupId === "selected_uiux_conformance") {
+    const accepted = new Set([
+      "uiux_product_closure_evidence_ready",
+      "selected_visual_proof_ready",
+      "product_runtime_actions_traceable",
+      "runtime_actions_covered",
+      "passed",
+    ]);
+    if (accepted.has(status) && !hasBlockers(report)) {
+      return { classification: "satisfied", score: status === "uiux_product_closure_evidence_ready" ? 95 : 85, reason: `selected UI/UX accepted status ${status}` };
+    }
+    if (accepted.has(status)) {
+      return { classification: "candidate_with_blockers", score: 45, reason: `accepted status ${status} but blockers are present` };
+    }
+    return { classification: "candidate", score: 20, reason: `status=${status || "<missing>"}` };
+  }
+
+  if (groupId === "ui_real_use_mobile_desktop") {
+    if (status === "strict_uiux_real_use_ready" || status === "strict_ui_device_ready" || status === "pass" || status === "passed") {
+      if (status === "strict_uiux_real_use_ready" || status === "strict_ui_device_ready") {
+        return { classification: "satisfied", score: 95, reason: `strict UI/device status ${status}` };
+      }
+      if (hasAnySignal(pathAndTruth, ["ui-real-use-report", "ui_real_use_mobile_desktop", "uiux_real_use"])) {
+        return { classification: "satisfied", score: 90, reason: `group-level UI real-use report status ${status}` };
+      }
+      return { classification: "partial", score: 45, reason: `single proof is pass-like but not a strict/group UI real-use report (${truth || path})` };
+    }
+    if (status === "partial_ready" || status === "ready_for_runtime_capture") {
+      return { classification: "partial", score: 50, reason: `non-strict UI/device status ${status}` };
+    }
+    return { classification: "candidate", score: 20, reason: `status=${status || "<missing>"}` };
+  }
+
+  if (groupId === "integrated_end_to_end_tape") {
+    if (status === "integrated_end_to_end_tape_ready") {
+      return { classification: "satisfied", score: 95, reason: "integrated tape ready status" };
+    }
+    if (status === "partial_ready" || status === "ready_for_runtime_capture") {
+      return { classification: "partial", score: 40, reason: `not an integrated tape report (${status})` };
+    }
+    return { classification: "candidate", score: 20, reason: `status=${status || "<missing>"}` };
+  }
+
+  if (groupId === "mechanism_multiangle_stress") {
+    if (["pass", "passed", "ready", "complete", "complete_inputs_observed"].includes(status)) {
+      if (hasAnySignal(pathAndTruth, ["mechanism_multiangle", "multiangle", "mission_spine_closure", "mission-spine-closure", "mechanism-stress"])) {
+        return { classification: "satisfied", score: 90, reason: `group-level mechanism report status ${status}` };
+      }
+      return { classification: "partial", score: 35, reason: `pass-like report is not identifiable as mechanism multiangle stress (${truth || path})` };
+    }
+    return { classification: "candidate", score: 20, reason: `status=${status || "<missing>"}` };
+  }
+
+  if (["pass", "passed", "ready", "complete", "complete_inputs_observed"].includes(status)) {
+    return { classification: "satisfied", score: 90, reason: `pass-like status ${status}` };
+  }
+  return { classification: "candidate", score: 20, reason: `status=${status || "<missing>"}` };
+}
+
+function looksRelevant(path, report) {
+  const name = path.toLowerCase();
+  const body = `${statusText(report)}\n${truthText(report)}`.toLowerCase();
+  return name.includes("endbar")
+    || name.includes("uiux")
+    || name.includes("ui-device")
+    || name.includes("provider")
+    || name.includes("mission-spine")
+    || name.includes("objective")
+    || name.includes("backend-live")
+    || body.includes("endbar")
+    || body.includes("ui_device")
+    || body.includes("uiux")
+    || body.includes("provider")
+    || body.includes("mission_spine");
+}
+
+function appliesToGroup(groupId, path, report) {
+  const haystack = `${path}\n${statusText(report)}\n${truthText(report)}`.toLowerCase();
+  if (groupId === "mechanism_multiangle_stress") {
+    return hasAnySignal(haystack, ["mechanism_multiangle", "multiangle", "mechanism-stress", "mission_spine_closure", "mission-spine-closure", "mission-spine-proof", "backend-live-proof"]);
+  }
+  if (groupId === "ui_real_use_mobile_desktop") {
+    return hasAnySignal(haystack, ["ui_real_use_mobile_desktop", "ui-real-use", "uiux_real_use", "ui-device", "ui_device", "mobile_desktop"]);
+  }
+  if (groupId === "selected_uiux_conformance") {
+    return hasAnySignal(haystack, ["selected_uiux", "selected-uiux", "selected_visual", "selected-visual", "design-action", "action-traceability", "runtime-action", "native-linkage", "product-closure"]);
+  }
+  if (groupId === "provider_entitlement_matrix") {
+    return hasAnySignal(haystack, ["provider_entitlement", "provider-entitlement", "provider-routing", "provider entitlement", "endbar_acceptance_manifest_check"]);
+  }
+  if (groupId === "integrated_end_to_end_tape") {
+    return hasAnySignal(haystack, ["integrated_end_to_end_tape", "integrated-tape", "end-to-end-tape", "product-auto-followup", "auto-followup"]);
+  }
+  return false;
+}
+
+function walkJsonFiles(root, depth = 0, out = []) {
+  if (depth > maxDepth) return out;
+  let entries = [];
+  try {
+    entries = readdirSync(root, { withFileTypes: true });
+  } catch {
+    return out;
+  }
+  for (const entry of entries) {
+    const path = join(root, entry.name);
+    if (entry.isDirectory()) {
+      walkJsonFiles(path, depth + 1, out);
+    } else if (entry.isFile() && entry.name.endsWith(".json")) {
+      out.push(path);
+    }
+  }
+  return out;
+}
+
+function readJson(path) {
+  try {
+    return JSON.parse(readFileSync(path, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+if (!Number.isFinite(maxDepth) || maxDepth < 0 || maxDepth > 12) {
+  block("invalid_max_depth", String(maxDepth));
+}
+
+if (searchRoots.length === 0) {
+  block("search_root_missing", "provide at least one --search-root");
+}
+
+const files = [];
+for (const root of searchRoots) {
+  if (!existsSync(root)) {
+    block("search_root_missing", root);
+    continue;
+  }
+  let stats = null;
+  try {
+    stats = statSync(root);
+  } catch {
+    block("search_root_unreadable", root);
+    continue;
+  }
+  if (stats.isFile() && root.endsWith(".json")) {
+    files.push(root);
+  } else if (stats.isDirectory()) {
+    files.push(...walkJsonFiles(root));
+  }
+}
+
+const byGroup = Object.fromEntries(groupOrder.map((groupId) => [groupId, []]));
+for (const path of files) {
+  const report = readJson(path);
+  if (!report || !looksRelevant(path, report)) continue;
+  for (const groupId of groupOrder) {
+    if (!appliesToGroup(groupId, path, report)) continue;
+    const classification = classifyForGroup(groupId, report, path);
+    if (classification.score < 35) continue;
+    byGroup[groupId].push({
+      path,
+      status: statusText(report) || null,
+      truth: truthText(report) || null,
+      classification: classification.classification,
+      score: classification.score,
+      reason: classification.reason,
+    });
+  }
+}
+
+const groups = groupOrder.map((groupId) => {
+  const candidates = byGroup[groupId]
+    .sort((left, right) => right.score - left.score || left.path.localeCompare(right.path))
+    .slice(0, 8);
+  const selected = candidates.find((candidate) => candidate.classification === "satisfied") || candidates[0] || null;
+  if (!selected) block("report_candidate_missing", groupId);
+  if (selected && selected.classification !== "satisfied") {
+    block("report_candidate_not_satisfied", `${groupId}:${selected.classification}`);
+  }
+  return {
+    id: groupId,
+    selectedCandidate: selected,
+    candidates,
+  };
+});
+
+const selectedByGroup = Object.fromEntries(groups.map((group) => [group.id, group.selectedCandidate?.path || ""]));
+const allSatisfied = groups.every((group) => group.selectedCandidate?.classification === "satisfied");
+const command = allSatisfied
+  ? [
+      "node",
+      "scripts/ops/check-friday-endbar-readiness.mjs",
+      ...groupOrder.map((groupId) => `${optionByGroup[groupId]}=${selectedByGroup[groupId]}`),
+      "--require-complete",
+    ]
+  : null;
+
+if (searchRoots.some((root) => root === "/tmp" || root === "/private/tmp")) {
+  notes.push("large tmp roots can contain stale evidence; prefer a run-specific artifact directory when possible");
+}
+
+const report = {
+  truth: "endbar_report_input_discovery_not_runtime_proof_not_release",
+  status: allSatisfied && blockers.length === 0 ? "complete_candidate_set" : "partial_candidate_set",
+  repoRoot,
+  searchRoots,
+  maxDepth,
+  counts: {
+    jsonFilesScanned: files.length,
+    groups: groupOrder.length,
+    satisfiedCandidates: groups.filter((group) => group.selectedCandidate?.classification === "satisfied").length,
+  },
+  groups,
+  command,
+  notes,
+  blockers,
+  caveat: "Candidate discovery is not evidence generation and not release approval. Run the printed readiness command and inspect each source report before any END-BAR claim.",
+};
+
+if (outPath) {
+  const resolved = isAbsolute(outPath) ? outPath : resolve(outPath);
+  mkdirSync(dirname(resolved), { recursive: true });
+  writeFileSync(resolved, `${JSON.stringify(report, null, 2)}\n`);
+}
+
+console.log(JSON.stringify(report, null, 2));
+process.exit(blockers.length === 0 ? 0 : 2);

--- a/test/unit/qa/friday-endbar-report-input-discovery.test.ts
+++ b/test/unit/qa/friday-endbar-report-input-discovery.test.ts
@@ -1,0 +1,99 @@
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const script = "scripts/ops/check-friday-endbar-report-inputs.mjs";
+
+function run(args: string[] = [], expectFailure = false) {
+  try {
+    const stdout = execFileSync(process.execPath, [script, ...args], {
+      cwd: process.cwd(),
+      encoding: "utf8",
+    });
+    return JSON.parse(stdout);
+  } catch (error) {
+    if (!expectFailure) throw error;
+    const stdout = (error as { stdout?: Buffer | string }).stdout?.toString() || "";
+    return JSON.parse(stdout);
+  }
+}
+
+function writeJson(dir: string, name: string, value: unknown) {
+  const path = join(dir, name);
+  writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`);
+  return path;
+}
+
+describe("Friday END-BAR report input discovery", () => {
+  it("requires an explicit search root and never claims readiness from nothing", () => {
+    const report = run([], true);
+
+    expect(report.truth).toBe("endbar_report_input_discovery_not_runtime_proof_not_release");
+    expect(report.status).toBe("partial_candidate_set");
+    expect(report.blockers).toContainEqual({
+      code: "search_root_missing",
+      detail: "provide at least one --search-root",
+    });
+  });
+
+  it("discovers a complete satisfying report set and prints the aggregator command", () => {
+    const dir = mkdtempSync(join(tmpdir(), "friday-endbar-inputs-"));
+    const nested = join(dir, "nested");
+    mkdirSync(nested);
+
+    const mechanism = writeJson(dir, "mechanism-multiangle.json", {
+      truth: "mechanism_multiangle_stress_report",
+      status: "passed",
+    });
+    const ui = writeJson(nested, "ui-real-use.json", { status: "strict_uiux_real_use_ready" });
+    const selected = writeJson(dir, "selected-uiux.json", { status: "uiux_product_closure_evidence_ready" });
+    const provider = writeJson(dir, "provider-entitlement.json", { status: "passed" });
+    const integrated = writeJson(dir, "integrated-tape.json", { status: "integrated_end_to_end_tape_ready" });
+
+    const report = run([`--search-root=${dir}`]);
+
+    expect(report.status).toBe("complete_candidate_set");
+    expect(report.counts.satisfiedCandidates).toBe(5);
+    expect(report.command).toEqual([
+      "node",
+      "scripts/ops/check-friday-endbar-readiness.mjs",
+      `--mechanism-report=${mechanism}`,
+      `--ui-real-use-report=${ui}`,
+      `--selected-uiux-report=${selected}`,
+      `--provider-entitlement-report=${provider}`,
+      `--integrated-tape-report=${integrated}`,
+      "--require-complete",
+    ]);
+    expect(report.blockers).toEqual([]);
+  });
+
+  it("keeps provider manifest boundary checks and deferred channel reports out of strict candidates", () => {
+    const dir = mkdtempSync(join(tmpdir(), "friday-endbar-inputs-"));
+    writeJson(dir, "provider-boundary.json", {
+      truth: "endbar_acceptance_manifest_check_not_runtime_proof",
+      status: "passed",
+    });
+    writeJson(dir, "ui-device-deferred.json", {
+      status: "partial_ready",
+      readinessBlockers: ["ui_device_proof_evidence:channel_deferred_strict_assembly_blocked"],
+    });
+
+    const report = run([`--search-root=${dir}`], true);
+    const provider = report.groups.find((group: { id: string }) => group.id === "provider_entitlement_matrix");
+    const ui = report.groups.find((group: { id: string }) => group.id === "ui_real_use_mobile_desktop");
+
+    expect(provider.selectedCandidate.classification).toBe("boundary_only");
+    expect(ui.selectedCandidate.classification).toBe("deferred");
+    expect(report.blockers).toContainEqual({
+      code: "report_candidate_not_satisfied",
+      detail: "provider_entitlement_matrix:boundary_only",
+    });
+    expect(report.blockers).toContainEqual({
+      code: "report_candidate_not_satisfied",
+      detail: "ui_real_use_mobile_desktop:deferred",
+    });
+    expect(report.command).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- add a report-input discovery diagnostic for the five END-BAR acceptance groups
- print the exact readiness aggregator command only when all selected candidates are strict-satisfied
- keep deferred channel proof, provider boundary-only checks, and unrelated pass-like artifacts out of strict END-BAR candidates

## Verification
- npx vitest run test/unit/qa/friday-endbar-report-input-discovery.test.ts test/unit/qa/friday-endbar-readiness-aggregator.test.ts --reporter=dot
- npm run --silent check:endbar-report-inputs -- --search-root=/private/tmp/friday-ui-device-shortlist-og9-with-stress-status-28fb4b47-20260627T1510Z --max-depth=4
- git diff --check

Truth: this is a diagnostic/report wiring tool only. It does not generate evidence, run providers, write DB rows, mark GO-LIVE, or turn channel-deferred non-channel evidence into strict END-BAR.