### PR TITLE
[codex] Report provider entitlement readiness

### DIFF
--- a/package.json
+++ b/package.json
@@ -127,6 +127,7 @@
     "check:endbar-acceptance-manifest": "node scripts/ops/check-friday-provider-entitlement-manifest.mjs",
     "check:endbar-readiness": "node scripts/ops/check-friday-endbar-readiness.mjs",
     "check:endbar-report-inputs": "node scripts/ops/check-friday-endbar-report-inputs.mjs",
+    "check:provider-entitlement-readiness": "node scripts/ops/check-friday-provider-entitlement-readiness.mjs",
     "check:github-channel-proof-readiness": "node scripts/ops/check-friday-github-channel-proof-readiness.mjs",
     "check:ui-device-accessibility-click-capture": "node scripts/ops/friday-ui-device-accessibility-click-capture.mjs",
     "check:agent-rollout:phase1": "node scripts/ops/run-agent-rollout-acceptance.mjs phase1",

--- a/scripts/ops/check-friday-provider-entitlement-readiness.mjs
+++ b/scripts/ops/check-friday-provider-entitlement-readiness.mjs
@@ -1,0 +1,220 @@
+#!/usr/bin/env node
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, isAbsolute, resolve } from "node:path";
+
+const args = process.argv.slice(2);
+
+function usage() {
+  console.error(`usage:
+  node scripts/ops/check-friday-provider-entitlement-readiness.mjs \\
+    [--repo-root=/abs/repo] [--manifest=/abs/or/repo-relative/manifest.json] \\
+    [--deepseek-proof=/abs/proof.json] \\
+    [--openai-proof=/abs/proof.json] \\
+    [--anthropic-proof=/abs/proof.json] \\
+    [--out=/abs/provider-entitlement-readiness.json]
+
+Truth: evaluates supplied provider entitlement runtime proofs against the
+END-BAR manifest. It never calls providers, reads secrets, automates free
+ChatGPT web, mints credentials, writes DB rows, or claims release.`);
+}
+
+function arg(name) {
+  const prefix = `--${name}=`;
+  for (let index = 0; index < args.length; index += 1) {
+    const value = args[index];
+    if (value.startsWith(prefix)) return value.slice(prefix.length);
+    if (value === `--${name}` && args[index + 1]) return args[index + 1];
+  }
+  return "";
+}
+
+if (args.includes("--help") || args.includes("-h")) {
+  usage();
+  process.exit(0);
+}
+
+const repoRoot = resolve(arg("repo-root") || process.env.FRIDAY_REPO_ROOT || new URL("../..", import.meta.url).pathname);
+const manifestPathInput = arg("manifest") || process.env.FRIDAY_ENDBAR_ACCEPTANCE_MANIFEST || "docs/ops/friday-endbar-acceptance-manifest.json";
+const manifestPath = isAbsolute(manifestPathInput) ? manifestPathInput : resolve(repoRoot, manifestPathInput);
+const outPath = arg("out") || process.env.FRIDAY_PROVIDER_ENTITLEMENT_READINESS_REPORT || "";
+
+const proofInputs = {
+  deepseek_api: arg("deepseek-proof") || process.env.FRIDAY_PROVIDER_ENTITLEMENT_DEEPSEEK_PROOF || "",
+  openai_api: arg("openai-proof") || process.env.FRIDAY_PROVIDER_ENTITLEMENT_OPENAI_PROOF || "",
+  anthropic_api: arg("anthropic-proof") || process.env.FRIDAY_PROVIDER_ENTITLEMENT_ANTHROPIC_PROOF || "",
+};
+
+const blockers = [];
+const notes = [];
+
+function block(code, detail) {
+  blockers.push({ code, detail });
+}
+
+function readJson(path, label) {
+  try {
+    return JSON.parse(readFileSync(path, "utf8"));
+  } catch (error) {
+    block("json_unreadable", `${label}:${path}:${error.message}`);
+    return null;
+  }
+}
+
+function asArray(value) {
+  return Array.isArray(value) ? value : [];
+}
+
+function field(value, name) {
+  return value && typeof value === "object" ? value[name] : undefined;
+}
+
+function text(value) {
+  if (value == null) return "";
+  if (typeof value === "string") return value;
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
+function statusText(value) {
+  return String(field(value, "status") || field(value, "result") || field(value, "proof") || "");
+}
+
+function passLike(value) {
+  return ["pass", "passed", "ready", "complete"].includes(statusText(value));
+}
+
+function resolveInput(path) {
+  if (!path) return "";
+  return isAbsolute(path) ? path : resolve(path);
+}
+
+function providerSignal(providerId, report) {
+  const haystack = text(report).toLowerCase();
+  if (providerId === "deepseek_api") {
+    return haystack.includes("deepseek") && !haystack.includes("free_chatgpt");
+  }
+  if (providerId === "openai_api") {
+    return haystack.includes("openai") && !haystack.includes("openai-codex") && !haystack.includes("codex_cli") && !haystack.includes("free_chatgpt");
+  }
+  if (providerId === "anthropic_api") {
+    return haystack.includes("anthropic") && !haystack.includes("claude_cli") && !haystack.includes("free_chatgpt");
+  }
+  return false;
+}
+
+function validateProviderProof(providerId, proofPath) {
+  if (!proofPath) {
+    return {
+      providerId,
+      status: "missing",
+      proofPath: null,
+      proofStatus: null,
+      blockers: [{ code: "provider_runtime_proof_missing", detail: providerId }],
+    };
+  }
+  const resolved = resolveInput(proofPath);
+  if (!existsSync(resolved)) {
+    return {
+      providerId,
+      status: "missing",
+      proofPath: resolved,
+      proofStatus: null,
+      blockers: [{ code: "provider_runtime_proof_file_missing", detail: `${providerId}:${resolved}` }],
+    };
+  }
+  const proof = readJson(resolved, providerId);
+  const rowBlockers = [];
+  if (!proof) {
+    rowBlockers.push({ code: "provider_runtime_proof_unreadable", detail: providerId });
+  } else {
+    if (!passLike(proof)) {
+      rowBlockers.push({ code: "provider_runtime_proof_not_passed", detail: `${providerId}:${statusText(proof) || "<missing-status>"}` });
+    }
+    if (!providerSignal(providerId, proof)) {
+      rowBlockers.push({ code: "provider_runtime_proof_wrong_provider", detail: providerId });
+    }
+    if (providerId === "deepseek_api") {
+      const deepseekPressure = field(proof, "deepseek_live_api_pressure");
+      if (deepseekPressure && field(deepseekPressure, "real_external_api") !== true) {
+        rowBlockers.push({ code: "deepseek_runtime_proof_not_external_api", detail: resolved });
+      }
+    }
+  }
+  return {
+    providerId,
+    status: rowBlockers.length === 0 ? "satisfied" : "blocked",
+    proofPath: resolved,
+    proofStatus: proof ? statusText(proof) || null : null,
+    blockers: rowBlockers,
+  };
+}
+
+if (!existsSync(manifestPath)) {
+  block("manifest_missing", manifestPath);
+}
+const manifest = existsSync(manifestPath) ? readJson(manifestPath, "endbar-acceptance-manifest") : null;
+const matrix = asArray(field(manifest, "providerEntitlementMatrix"));
+
+const expectedRequired = ["deepseek_api", "openai_api", "anthropic_api"];
+for (const providerId of expectedRequired) {
+  const row = matrix.find((item) => field(item, "id") === providerId);
+  if (!row) {
+    block("provider_matrix_required_row_missing", providerId);
+    continue;
+  }
+  if (field(row, "mustPassBeforeEndBar") !== true) {
+    block("provider_matrix_required_row_not_must_pass", providerId);
+  }
+  const status = String(field(row, "status") || "");
+  if (status !== "supported_api_key_route") {
+    block("provider_matrix_required_row_status_unexpected", `${providerId}:${status}`);
+  }
+}
+
+const freeChatGpt = matrix.find((item) => field(item, "id") === "free_chatgpt_web_account");
+if (!freeChatGpt) {
+  block("free_chatgpt_boundary_missing", "free_chatgpt_web_account");
+} else if (field(freeChatGpt, "status") !== "unsupported_as_friday_autonomous_backend" || field(freeChatGpt, "mustPassBeforeEndBar") !== false) {
+  block("free_chatgpt_boundary_unsafe", text(freeChatGpt));
+}
+
+const providers = expectedRequired.map((providerId) => validateProviderProof(providerId, proofInputs[providerId]));
+for (const provider of providers) {
+  for (const providerBlocker of provider.blockers) block(providerBlocker.code, providerBlocker.detail);
+}
+
+if (providers.some((provider) => provider.status === "missing")) {
+  notes.push("missing provider runtime proofs are expected in offline/report-only mode; they keep END-BAR blocked");
+}
+
+const report = {
+  truth: "provider_entitlement_readiness_not_runtime_generator_not_release",
+  status: blockers.length === 0 ? "passed" : "blocked",
+  repoRoot,
+  manifestPath,
+  providers,
+  freeChatGptBoundary: freeChatGpt ? {
+    status: field(freeChatGpt, "status"),
+    mustPassBeforeEndBar: field(freeChatGpt, "mustPassBeforeEndBar"),
+  } : null,
+  counts: {
+    requiredProviders: expectedRequired.length,
+    satisfiedProviders: providers.filter((provider) => provider.status === "satisfied").length,
+  },
+  notes,
+  blockers,
+  caveat: "This report validates supplied runtime proof artifacts only. It does not call providers, cannot prove absent API credentials, and never treats CLI or free ChatGPT web access as API-provider proof.",
+};
+
+if (outPath) {
+  const resolved = resolveInput(outPath);
+  mkdirSync(dirname(resolved), { recursive: true });
+  writeFileSync(resolved, `${JSON.stringify(report, null, 2)}\n`);
+}
+
+console.log(JSON.stringify(report, null, 2));
+process.exit(blockers.length === 0 ? 0 : 2);

--- a/test/unit/qa/friday-provider-entitlement-readiness.test.ts
+++ b/test/unit/qa/friday-provider-entitlement-readiness.test.ts
@@ -1,0 +1,111 @@
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const script = "scripts/ops/check-friday-provider-entitlement-readiness.mjs";
+
+function run(args: string[] = [], expectFailure = false) {
+  try {
+    const stdout = execFileSync(process.execPath, [script, ...args], {
+      cwd: process.cwd(),
+      encoding: "utf8",
+    });
+    return JSON.parse(stdout);
+  } catch (error) {
+    if (!expectFailure) throw error;
+    const stdout = (error as { stdout?: Buffer | string }).stdout?.toString() || "";
+    return JSON.parse(stdout);
+  }
+}
+
+function writeJson(dir: string, name: string, value: unknown) {
+  const path = join(dir, name);
+  writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`);
+  return path;
+}
+
+function proof(provider: "deepseek" | "openai" | "anthropic") {
+  if (provider === "deepseek") {
+    return {
+      proof: "mission_spine_backend_api_live_pressure",
+      status: "passed",
+      provider_kind: "deepseek",
+      deepseek_live_api_pressure: {
+        status: "passed",
+        real_external_api: true,
+      },
+    };
+  }
+  return {
+    proof: "provider_entitlement_runtime_api_proof",
+    status: "passed",
+    provider_kind: provider,
+    real_external_api: true,
+  };
+}
+
+describe("Friday provider entitlement readiness", () => {
+  it("blocks without runtime API proofs and keeps free ChatGPT unsupported", () => {
+    const report = run([], true);
+
+    expect(report.truth).toBe("provider_entitlement_readiness_not_runtime_generator_not_release");
+    expect(report.status).toBe("blocked");
+    expect(report.freeChatGptBoundary).toEqual({
+      status: "unsupported_as_friday_autonomous_backend",
+      mustPassBeforeEndBar: false,
+    });
+    expect(report.counts.satisfiedProviders).toBe(0);
+    expect(report.blockers).toEqual(expect.arrayContaining([
+      { code: "provider_runtime_proof_missing", detail: "deepseek_api" },
+      { code: "provider_runtime_proof_missing", detail: "openai_api" },
+      { code: "provider_runtime_proof_missing", detail: "anthropic_api" },
+    ]));
+  });
+
+  it("counts DeepSeek proof only for DeepSeek and keeps the matrix blocked until OpenAI and Anthropic proofs are supplied", () => {
+    const dir = mkdtempSync(join(tmpdir(), "friday-provider-entitlement-"));
+    const deepseek = writeJson(dir, "deepseek.json", proof("deepseek"));
+
+    const report = run([`--deepseek-proof=${deepseek}`], true);
+
+    expect(report.status).toBe("blocked");
+    expect(report.counts.satisfiedProviders).toBe(1);
+    expect(report.providers.find((provider: { providerId: string }) => provider.providerId === "deepseek_api").status).toBe("satisfied");
+    expect(report.blockers).toEqual(expect.arrayContaining([
+      { code: "provider_runtime_proof_missing", detail: "openai_api" },
+      { code: "provider_runtime_proof_missing", detail: "anthropic_api" },
+    ]));
+  });
+
+  it("passes only when all required API provider proofs match their provider kind", () => {
+    const dir = mkdtempSync(join(tmpdir(), "friday-provider-entitlement-"));
+    const deepseek = writeJson(dir, "deepseek.json", proof("deepseek"));
+    const openai = writeJson(dir, "openai.json", proof("openai"));
+    const anthropic = writeJson(dir, "anthropic.json", proof("anthropic"));
+
+    const report = run([
+      `--deepseek-proof=${deepseek}`,
+      `--openai-proof=${openai}`,
+      `--anthropic-proof=${anthropic}`,
+    ]);
+
+    expect(report.status).toBe("passed");
+    expect(report.counts.satisfiedProviders).toBe(3);
+    expect(report.blockers).toEqual([]);
+  });
+
+  it("rejects using one provider proof for a different provider", () => {
+    const dir = mkdtempSync(join(tmpdir(), "friday-provider-entitlement-"));
+    const deepseek = writeJson(dir, "deepseek.json", proof("deepseek"));
+
+    const report = run([`--openai-proof=${deepseek}`], true);
+
+    expect(report.status).toBe("blocked");
+    expect(report.providers.find((provider: { providerId: string }) => provider.providerId === "openai_api").blockers).toContainEqual({
+      code: "provider_runtime_proof_wrong_provider",
+      detail: "openai_api",
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add a provider entitlement readiness report for the END-BAR provider matrix group
- require DeepSeek, OpenAI, and Anthropic API runtime proof artifacts before the group can pass
- keep free ChatGPT web access unsupported and prevent CLI/other-provider proof from satisfying API-provider proof

## Verification
- npx vitest run test/unit/qa/friday-provider-entitlement-readiness.test.ts --reporter=dot
- npm run --silent check:provider-entitlement-readiness -- --deepseek-proof=/tmp/friday-mission-spine-backend-live-proof.json --out=/tmp/friday-provider-entitlement-readiness-current.json
- git diff --check

Truth: this is report-mode only. It does not call providers, read secrets, write DB rows, mint credentials, or claim END-BAR/provider completion without supplied runtime proofs.