### PR TITLE
[codex] Add END-BAR UI real-use report validator

### DIFF
--- a/package.json
+++ b/package.json
@@ -129,6 +129,7 @@
     "check:endbar-report-inputs": "node scripts/ops/check-friday-endbar-report-inputs.mjs",
     "check:integrated-end-to-end-tape": "node scripts/ops/check-friday-integrated-end-to-end-tape-report.mjs",
     "check:mechanism-multiangle-stress": "node scripts/ops/check-friday-mechanism-multiangle-stress-report.mjs",
+    "check:ui-real-use-mobile-desktop": "node scripts/ops/check-friday-ui-real-use-mobile-desktop-report.mjs",
     "check:provider-entitlement-readiness": "node scripts/ops/check-friday-provider-entitlement-readiness.mjs",
     "check:github-channel-proof-readiness": "node scripts/ops/check-friday-github-channel-proof-readiness.mjs",
     "check:ui-device-accessibility-click-capture": "node scripts/ops/friday-ui-device-accessibility-click-capture.mjs",

--- a/scripts/ops/check-friday-endbar-report-inputs.mjs
+++ b/scripts/ops/check-friday-endbar-report-inputs.mjs
@@ -198,6 +198,8 @@ function looksRelevant(path, report) {
   const body = `${statusText(report)}\n${truthText(report)}`.toLowerCase();
   return name.includes("endbar")
     || name.includes("uiux")
+    || name.includes("ui-real-use")
+    || name.includes("ui_real_use")
     || name.includes("ui-device")
     || name.includes("provider")
     || name.includes("integrated")
@@ -211,6 +213,7 @@ function looksRelevant(path, report) {
     || body.includes("mechanism_multiangle")
     || body.includes("mechanism-stress")
     || body.includes("ui_device")
+    || body.includes("ui_real_use_mobile_desktop")
     || body.includes("uiux")
     || body.includes("provider")
     || body.includes("integrated_end_to_end_tape")

--- a/scripts/ops/check-friday-ui-real-use-mobile-desktop-report.mjs
+++ b/scripts/ops/check-friday-ui-real-use-mobile-desktop-report.mjs
@@ -1,0 +1,175 @@
+#!/usr/bin/env node
+
+import { existsSync, mkdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { dirname, isAbsolute, resolve } from "node:path";
+
+const args = process.argv.slice(2);
+
+function usage() {
+  console.error(`usage:
+  node scripts/ops/check-friday-ui-real-use-mobile-desktop-report.mjs \\
+    --ui-device-summary=/abs/ui-device-shortlist-summary.json \\
+    [--out=/abs/ui-real-use-mobile-desktop-report.json] [--require-ready]
+
+Truth: validates an already-captured UI/device real-use summary for the
+ui_real_use_mobile_desktop END-BAR group. It does not run apps, create
+evidence, write DB rows, call providers, mark GO-LIVE, or claim adoption.`);
+}
+
+function arg(name) {
+  const prefix = `--${name}=`;
+  for (let index = 0; index < args.length; index += 1) {
+    const value = args[index];
+    if (value.startsWith(prefix)) return value.slice(prefix.length);
+    if (value === `--${name}` && args[index + 1]) return args[index + 1];
+  }
+  return "";
+}
+
+if (args.includes("--help") || args.includes("-h")) {
+  usage();
+  process.exit(0);
+}
+
+const summaryPath = arg("ui-device-summary");
+const outPath = arg("out") || "";
+const requireReady = args.includes("--require-ready");
+const blockers = [];
+const checks = [];
+
+function block(code, detail) {
+  blockers.push({ code, detail });
+}
+
+function check(id, passed, detail = "") {
+  checks.push({ id, status: passed ? "passed" : "blocked", detail });
+  if (!passed) block(id, detail);
+}
+
+function abs(path) {
+  return isAbsolute(path) ? path : resolve(path);
+}
+
+function requireFile(label, path) {
+  if (!path) {
+    block("missing_arg", label);
+    return "";
+  }
+  if (!isAbsolute(path)) {
+    block("path_not_absolute", `${label}:${path}`);
+    return "";
+  }
+  try {
+    const stats = statSync(path);
+    if (!stats.isFile()) block("not_file", `${label}:${path}`);
+    if (stats.size <= 0) block("empty_file", `${label}:${path}`);
+  } catch {
+    block("unreadable_file", `${label}:${path}`);
+  }
+  return path;
+}
+
+function readJson(label, path) {
+  const file = requireFile(label, path);
+  if (!file) return null;
+  try {
+    return JSON.parse(readFileSync(file, "utf8"));
+  } catch (error) {
+    block("invalid_json", `${label}:${error.message}`);
+    return null;
+  }
+}
+
+function array(value) {
+  return Array.isArray(value) ? value : [];
+}
+
+function string(value) {
+  return value == null ? "" : String(value);
+}
+
+function fileExists(path) {
+  return typeof path === "string" && path.length > 0 && existsSync(path);
+}
+
+function deferredSignals(summary) {
+  const blockers = [
+    ...array(summary?.readinessBlockers),
+    ...array(summary?.uiDeviceProofReadiness?.blockers),
+    ...array(summary?.deferredInputs),
+    ...array(summary?.deferred_inputs),
+  ].map(String);
+  const haystack = [
+    string(summary?.status),
+    string(summary?.truth),
+    string(summary?.captureDirStatus),
+    string(summary?.readinessStatus),
+    ...blockers,
+  ].join("\n").toLowerCase();
+  return haystack.includes("defer") || haystack.includes("channel_deferred") ? blockers.length > 0 ? blockers : ["deferred signal present"] : [];
+}
+
+function hasCapture(capture, missionId) {
+  if (!capture || typeof capture !== "object" || Array.isArray(capture)) return false;
+  if (capture.mission_id !== missionId) return false;
+  if (!fileExists(capture.proof)) return false;
+  if (!fileExists(capture.events)) return false;
+  if (!fileExists(capture.action_runtime_evidence)) return false;
+  return Number(capture.event_count || 0) > 0 && Number(capture.action_count || 0) > 0;
+}
+
+const summary = readJson("ui-device-summary", summaryPath);
+
+if (summary && typeof summary === "object" && !Array.isArray(summary)) {
+  const missionId = string(summary.missionId || summary.mission_id);
+  const captures = summary.captures || {};
+  const mobile = captures.mobile;
+  const desktop = captures.desktop;
+  const uiReadiness = summary.uiDeviceProofReadiness || {};
+  const deferred = deferredSignals(summary);
+
+  check("summary_truth_shape", string(summary.truth).includes("ui_device_shortlist_runner_summary") || string(summary.truth).includes("uiux_real_use"), string(summary.truth));
+  check("mission_id_present", missionId.toLowerCase().includes("mission"), missionId);
+  check("mobile_real_surface_capture", hasCapture(mobile, missionId), mobile?.proof || "<missing>");
+  check("desktop_real_surface_capture", hasCapture(desktop, missionId), desktop?.proof || "<missing>");
+  check("action_runtime_traceability", ["runtime_actions_covered", "written"].includes(string(summary.gapStatus)) || ["runtime_actions_covered"].includes(string(summary.designActionRuntimeStatus)), string(summary.gapStatus || summary.designActionRuntimeStatus || ""));
+  check("accessibility_capture_ready", ["ready", "passed"].includes(string(summary.accessibilityCaptureStatus)), string(summary.accessibilityCaptureStatus));
+  check("stress_capture_ready", ["ready", "passed"].includes(string(summary.stressCaptureStatus)), string(summary.stressCaptureStatus));
+  check("workbench_timeline_ready", ["snapshot_ready_events_ready", "ready"].includes(string(summary.workbenchTimelineStatus)), string(summary.workbenchTimelineStatus));
+  check("product_closure_runtime_capture_ready", ["ready_for_runtime_capture", "ready", "passed"].includes(string(summary.productClosureStatus)), string(summary.productClosureStatus));
+  check("strict_ui_device_readiness_passed", string(uiReadiness.status) === "pass" || string(uiReadiness.status) === "strict_ui_device_ready", string(uiReadiness.status));
+  check("no_deferred_channel_or_external_input", deferred.length === 0, deferred.join(","));
+} else if (summary) {
+  block("summary_not_object", summaryPath);
+}
+
+const ready = blockers.length === 0;
+const deferred = summary && typeof summary === "object" && !Array.isArray(summary) && deferredSignals(summary).length > 0;
+const report = {
+  truth: "ui_real_use_mobile_desktop_report",
+  status: ready ? "strict_uiux_real_use_ready" : deferred ? "deferred" : "blocked",
+  generated_at_utc: new Date().toISOString(),
+  inputs: {
+    ui_device_summary: summaryPath || null,
+  },
+  passBar: {
+    mobile_and_desktop_real_app_surfaces: checks.some((row) => row.id === "mobile_real_surface_capture" && row.status === "passed")
+      && checks.some((row) => row.id === "desktop_real_surface_capture" && row.status === "passed"),
+    pixels_accessibility_db_provider_head_linked: checks.some((row) => row.id === "accessibility_capture_ready" && row.status === "passed")
+      && checks.some((row) => row.id === "workbench_timeline_ready" && row.status === "passed"),
+    negative_controls_exercised: checks.some((row) => row.id === "stress_capture_ready" && row.status === "passed"),
+    simulator_labeled_not_real_device_release: true,
+  },
+  checks,
+  blockers,
+  caveat: "This is a UI real-use report over supplied artifacts only. Deferred channel proof or strict UI/device blockers keep it out of strict END-BAR; simulator evidence remains simulator evidence.",
+};
+
+if (outPath) {
+  const out = abs(outPath);
+  mkdirSync(dirname(out), { recursive: true });
+  writeFileSync(out, `${JSON.stringify(report, null, 2)}\n`);
+}
+
+console.log(JSON.stringify(report, null, 2));
+process.exit(ready || !requireReady ? 0 : 2);

--- a/test/unit/qa/friday-endbar-report-input-discovery.test.ts
+++ b/test/unit/qa/friday-endbar-report-input-discovery.test.ts
@@ -136,4 +136,31 @@ describe("Friday END-BAR report input discovery", () => {
       detail: "mechanism_multiangle_stress",
     });
   });
+
+  it("discovers strict UI real-use reports and keeps deferred ones non-satisfied", () => {
+    const dir = mkdtempSync(join(tmpdir(), "friday-endbar-inputs-"));
+    const strict = writeJson(dir, "ui-real-use-strict.json", {
+      truth: "ui_real_use_mobile_desktop_report",
+      status: "strict_uiux_real_use_ready",
+    });
+    writeJson(dir, "ui-real-use-deferred.json", {
+      truth: "ui_real_use_mobile_desktop_report",
+      status: "deferred",
+      blockers: [{ code: "no_deferred_channel_or_external_input" }],
+    });
+
+    const report = run([`--search-root=${dir}`], true);
+    const group = report.groups.find((row: { id: string }) => row.id === "ui_real_use_mobile_desktop");
+
+    expect(group.selectedCandidate).toEqual(expect.objectContaining({
+      path: strict,
+      classification: "satisfied",
+    }));
+    expect(group.candidates).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        path: expect.stringContaining("ui-real-use-deferred.json"),
+        classification: "deferred",
+      }),
+    ]));
+  });
 });

--- a/test/unit/qa/friday-ui-real-use-mobile-desktop-report-cli.test.ts
+++ b/test/unit/qa/friday-ui-real-use-mobile-desktop-report-cli.test.ts
@@ -1,0 +1,123 @@
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const script = "scripts/ops/check-friday-ui-real-use-mobile-desktop-report.mjs";
+
+function writeJson(dir: string, name: string, value: unknown) {
+  const path = join(dir, name);
+  writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`);
+  return path;
+}
+
+function touch(dir: string, name: string) {
+  const path = join(dir, name);
+  writeFileSync(path, "{}\n");
+  return path;
+}
+
+function summary(dir: string, overrides: Record<string, unknown> = {}) {
+  const missionId = "mission_ui_real_use_cli";
+  mkdirSync(join(dir, "mobile"), { recursive: true });
+  mkdirSync(join(dir, "desktop"), { recursive: true });
+  return {
+    truth: "ui_device_shortlist_runner_summary_not_endbar_not_adoption",
+    status: "partial_ready",
+    missionId,
+    captures: {
+      mobile: {
+        mission_id: missionId,
+        proof: touch(join(dir, "mobile"), "proof.json"),
+        events: touch(join(dir, "mobile"), "events.jsonl"),
+        action_runtime_evidence: touch(join(dir, "mobile"), "action.json"),
+        event_count: 5,
+        action_count: 1,
+      },
+      desktop: {
+        mission_id: missionId,
+        proof: touch(join(dir, "desktop"), "proof.json"),
+        events: touch(join(dir, "desktop"), "events.jsonl"),
+        action_runtime_evidence: touch(join(dir, "desktop"), "action.json"),
+        event_count: 5,
+        action_count: 1,
+      },
+    },
+    gapStatus: "written",
+    accessibilityCaptureStatus: "ready",
+    stressCaptureStatus: "ready",
+    workbenchTimelineStatus: "snapshot_ready_events_ready",
+    productClosureStatus: "ready_for_runtime_capture",
+    readinessStatus: "pass",
+    readinessBlockers: [],
+    uiDeviceProofReadiness: {
+      status: "pass",
+      blockers: [],
+    },
+    ...overrides,
+  };
+}
+
+function run(args: string[], expectFailure = false) {
+  try {
+    const stdout = execFileSync(process.execPath, [script, ...args], {
+      cwd: process.cwd(),
+      encoding: "utf8",
+    });
+    return JSON.parse(stdout);
+  } catch (error) {
+    if (!expectFailure) throw error;
+    const stdout = (error as { stdout?: Buffer | string }).stdout?.toString() || "";
+    return JSON.parse(stdout);
+  }
+}
+
+describe("Friday UI real-use mobile/desktop report", () => {
+  it("passes only when strict UI/device readiness is present with mobile and desktop captures", () => {
+    const dir = mkdtempSync(join(tmpdir(), "friday-ui-real-use-"));
+    const summaryPath = writeJson(dir, "summary.json", summary(dir));
+
+    const report = run([`--ui-device-summary=${summaryPath}`, "--require-ready"]);
+
+    expect(report.truth).toBe("ui_real_use_mobile_desktop_report");
+    expect(report.status).toBe("strict_uiux_real_use_ready");
+    expect(report.passBar.mobile_and_desktop_real_app_surfaces).toBe(true);
+    expect(report.blockers).toEqual([]);
+  });
+
+  it("marks channel-deferred summaries as deferred, not strict-ready", () => {
+    const dir = mkdtempSync(join(tmpdir(), "friday-ui-real-use-"));
+    const summaryPath = writeJson(dir, "summary.json", summary(dir, {
+      readinessStatus: "blocked",
+      readinessBlockers: ["ui_device_proof_evidence:channel_deferred_strict_assembly_blocked"],
+      uiDeviceProofReadiness: {
+        status: "blocked",
+        blockers: ["ui_device_proof_evidence:channel_deferred_strict_assembly_blocked"],
+      },
+    }));
+
+    const report = run([`--ui-device-summary=${summaryPath}`, "--require-ready"], true);
+
+    expect(report.status).toBe("deferred");
+    expect(report.blockers).toEqual(expect.arrayContaining([
+      expect.objectContaining({ code: "strict_ui_device_readiness_passed" }),
+      expect.objectContaining({ code: "no_deferred_channel_or_external_input" }),
+    ]));
+  });
+
+  it("blocks missing same-mission desktop evidence", () => {
+    const dir = mkdtempSync(join(tmpdir(), "friday-ui-real-use-"));
+    const value = summary(dir);
+    value.captures.desktop.mission_id = "mission_other";
+    value.captures.desktop.events = join(dir, "desktop", "missing.jsonl");
+    const summaryPath = writeJson(dir, "summary.json", value);
+
+    const report = run([`--ui-device-summary=${summaryPath}`]);
+
+    expect(report.status).toBe("blocked");
+    expect(report.blockers).toEqual(expect.arrayContaining([
+      expect.objectContaining({ code: "desktop_real_surface_capture" }),
+    ]));
+  });
+});


### PR DESCRIPTION
## Summary\n- add a ui_real_use_mobile_desktop group validator that consumes an existing UI/device shortlist summary\n- classify current channel-deferred evidence as deferred rather than strict END-BAR ready\n- teach END-BAR input discovery to recognize UI real-use group reports\n- expose npm check:ui-real-use-mobile-desktop\n\n## Verification\n- npx vitest run test/unit/qa/friday-ui-real-use-mobile-desktop-report-cli.test.ts test/unit/qa/friday-endbar-report-input-discovery.test.ts --reporter=dot\n- npm run --silent check:ui-real-use-mobile-desktop -- --ui-device-summary=/private/tmp/friday-ui-device-shortlist-og9-with-stress-status-28fb4b47-20260627T1510Z/ui-device-shortlist-summary.json --out=/tmp/friday-ui-real-use-mobile-desktop-current.json || true\n- git diff --check\n\nTruth: report validator only; no app launch, provider call, DB write, synthetic evidence, GO-LIVE, release, or adoption claim. Current real-use report remains deferred because strict channel/UI-device evidence is deferred.