### PR TITLE
Bound desktop AX capture traversal depth

### DIFF
--- a/scripts/ops/friday-desktop-ax-accessibility-capture.mjs
+++ b/scripts/ops/friday-desktop-ax-accessibility-capture.mjs
@@ -45,6 +45,7 @@ const destinationsCsv = arg("destinations") || process.env.FRIDAY_DESKTOP_AX_CAP
 const workbenchMissionId = arg("workbench-mission-id") || process.env.FRIDAY_DESKTOP_AX_WORKBENCH_MISSION_ID || "";
 const timeoutSeconds = Number(arg("timeout-seconds") || process.env.FRIDAY_DESKTOP_AX_CAPTURE_TIMEOUT_SECONDS || "20");
 const treeDepth = Number(arg("tree-depth") || process.env.FRIDAY_DESKTOP_AX_TREE_DEPTH || "5");
+const axTraversalDepth = Number.isInteger(treeDepth) ? treeDepth : 5;
 const planOnly = args.includes("--plan-only");
 const requireObserved = args.includes("--require-observed");
 const blockers = [];
@@ -214,7 +215,7 @@ on appendElement(e, depth)
     end tell
   end try
   set end of outputLines to ((depth as text) & tab & roleValue & tab & identifierValue & tab & nameValue & tab & "" & tab & "")
-  if depth < ${Number.isInteger(treeDepth) ? treeDepth : 5} then
+  if depth < ${axTraversalDepth} then
     try
       tell application "System Events"
         set childElements to UI elements of e
@@ -266,7 +267,7 @@ on clickMatchingElement(e, identifierValue, titleValue, depth)
       end if
     end tell
   end try
-  if depth < 8 then
+  if depth < ${axTraversalDepth} then
     try
       tell application "System Events"
         set childElements to UI elements of e
@@ -374,7 +375,7 @@ on inspectElement(e, identifierNeedles, textNeedle, depth)
       return
     end if
   end if
-  if depth < 8 then
+  if depth < ${axTraversalDepth} then
     try
       tell application "System Events"
         set childElements to UI elements of e

--- a/test/unit/qa/friday-desktop-ax-accessibility-capture-contract.test.ts
+++ b/test/unit/qa/friday-desktop-ax-accessibility-capture-contract.test.ts
@@ -57,6 +57,14 @@ describe("friday-desktop-ax-accessibility-capture contract", () => {
     expect(navSource).toContain(".accessibilityIdentifier(\"friday.desktop.nav.\\(destination.rawValue)\")");
   });
 
+  it("applies the configured AX tree depth to navigation and targeted probes", () => {
+    const source = readFileSync(script, "utf8");
+
+    expect(source).toContain("const axTraversalDepth = Number.isInteger(treeDepth) ? treeDepth : 5");
+    expect(source).toContain("if depth < ${axTraversalDepth} then");
+    expect(source).not.toContain("if depth < 8 then");
+  });
+
   it("only emits status-label events from visible accessibility labels", () => {
     const source = readFileSync(script, "utf8");
 


### PR DESCRIPTION
## Summary
- Route desktop AX navigation and targeted probes through the configured `--tree-depth` instead of hard-coded depth 8.
- Add a contract test so `--tree-depth` remains effective for navigation and targeted probes.

## Verification
- `PATH=/private/tmp/friday-desktop-ax-timeout-fix-20260628/node_modules/.bin:$PATH vitest run --project default test/unit/qa/friday-desktop-ax-accessibility-capture-contract.test.ts`
- `node scripts/ops/friday-desktop-ax-accessibility-capture.mjs --plan-only --mission-id=mission_desktop_ax_capture_plan --out-dir=/tmp/friday-desktop-ax-plan-depth-fix-20260628`
- Real current-HEAD proof after fix: `node scripts/ops/friday-desktop-ax-accessibility-capture.mjs --out-dir=/tmp/friday-desktop-ax-capture-required-b6f80331-depthfix-20260628T0323Z --app-dir=/Users/jarvis/Projects/Friday/dist/macos/FridayHubConsole.app --mission-id=mission_desktop_ax_capture_required_b6f80331_depthfix_20260628 --tree-depth=2 --timeout-seconds=8 --destinations=operations,chat,session,pairingProvisioning,providerAdmin,parity,workflow,evidence`
- Current selected visual proof refreshed: `/tmp/friday-selected-visual-proof-current-b6f80331-20260628T0325Z.json` (`selected_visual_proof_ready`).

Truth: this improves proof-tool runtime behavior only; it does not claim END-BAR, adoption, or live action closure.
