### PR TITLE
test(endbar): report shared deferred blockers

### DIFF
--- a/scripts/ops/check-friday-endbar-readiness.mjs
+++ b/scripts/ops/check-friday-endbar-readiness.mjs
@@ -116,6 +116,27 @@ function hasDeferredSignal(value) {
   return blockers.includes("defer") || blockers.includes("channel_deferred");
 }
 
+function deferredBlockerKey(value) {
+  if (!hasDeferredSignal(value)) return null;
+  const body = [
+    statusText(value),
+    truthText(value),
+    text(field(value, "blockers")),
+    text(field(value, "readinessBlockers")),
+    text(field(value, "deferredInputs")),
+    text(field(value, "deferred_inputs")),
+    text(field(value, "fullProofGaps")),
+  ].join("\n").toLowerCase();
+  if (
+    body.includes("channel")
+    || body.includes("same_mission_mobile_desktop_channel")
+    || body.includes("channel_deferred")
+  ) {
+    return "channel_current_linked_proof_deferred";
+  }
+  return "deferred_external_input";
+}
+
 function isPassLike(value) {
   const status = statusText(value);
   return [
@@ -137,6 +158,7 @@ function expectedStatusForGroup(groupId, report, reportPath = "") {
     return {
       status: "deferred",
       blocker: "deferred input remains outside strict END-BAR",
+      sharedBlockerKey: deferredBlockerKey(report),
     };
   }
   if (groupId === "provider_entitlement_matrix") {
@@ -227,6 +249,7 @@ const rows = requiredGroups.map((group) => {
     reportPath: loaded?.path || null,
     reportStatus: loaded?.value ? statusText(loaded.value) || null : null,
     blocker: evaluation.blocker || null,
+    sharedBlockerKey: evaluation.sharedBlockerKey || null,
     passBar: asArray(field(group, "passBar")),
   };
 });
@@ -240,6 +263,19 @@ for (const row of rows) {
 const satisfiedCount = rows.filter((row) => row.status === "satisfied").length;
 const deferredCount = rows.filter((row) => row.status === "deferred").length;
 const missingReportCount = rows.filter((row) => row.status === "missing_report").length;
+const sharedBlockers = Object.values(rows.reduce((acc, row) => {
+  if (!row.sharedBlockerKey || row.status === "satisfied") return acc;
+  acc[row.sharedBlockerKey] ||= {
+    key: row.sharedBlockerKey,
+    status: row.status,
+    affectedGroups: [],
+    description: row.sharedBlockerKey === "channel_current_linked_proof_deferred"
+      ? "Channel/current-linked proof is deferred, so all affected groups remain outside strict END-BAR."
+      : "A deferred external input keeps all affected groups outside strict END-BAR.",
+  };
+  acc[row.sharedBlockerKey].affectedGroups.push(row.id);
+  return acc;
+}, {}));
 const strictEndBarReady = rows.length > 0 && satisfiedCount === rows.length && blockers.length === 0;
 
 const report = {
@@ -255,6 +291,7 @@ const report = {
   },
   groups: rows,
   blockers,
+  sharedBlockers,
   strictEndBarReady,
   caveat: "This report aggregates supplied evidence reports only. It never creates evidence, never counts deferred channel proof as strict END-BAR, and never turns report coverage into adoption.",
 };

--- a/test/unit/qa/friday-endbar-readiness-aggregator.test.ts
+++ b/test/unit/qa/friday-endbar-readiness-aggregator.test.ts
@@ -67,6 +67,52 @@ describe("Friday END-BAR readiness aggregator", () => {
     expect(report.groups.find((group: { id: string }) => group.id === "ui_real_use_mobile_desktop").status).toBe("deferred");
   });
 
+  it("surfaces shared channel-current blocker across deferred UI and integrated groups", () => {
+    const dir = mkdtempSync(join(tmpdir(), "friday-endbar-readiness-"));
+    const mechanism = writeJson(dir, "mechanism-multiangle.json", {
+      truth: "mechanism_multiangle_stress_report",
+      status: "complete_inputs_observed",
+    });
+    const provider = writeJson(dir, "provider-entitlement.json", {
+      truth: "provider_entitlement_readiness_report",
+      status: "passed",
+    });
+    const selected = writeJson(dir, "selected-uiux.json", { status: "selected_visual_proof_ready" });
+    const ui = writeJson(dir, "ui-real-use.json", {
+      truth: "ui_real_use_mobile_desktop_report",
+      status: "deferred",
+      deferredInputs: [{ role: "channel", status: "deferred_by_operator" }],
+    });
+    const integrated = writeJson(dir, "integrated-tape.json", {
+      truth: "integrated_end_to_end_tape_report",
+      status: "blocked",
+      blockers: [{
+        code: "no_channel_deferred_signal",
+        detail: "ui_device_proof_evidence:channel_deferred_strict_assembly_blocked",
+      }],
+      fullProofGaps: ["same_mission_mobile_desktop_channel_capture"],
+    });
+
+    const report = run([
+      `--mechanism-report=${mechanism}`,
+      `--ui-real-use-report=${ui}`,
+      `--selected-uiux-report=${selected}`,
+      `--provider-entitlement-report=${provider}`,
+      `--integrated-tape-report=${integrated}`,
+    ]);
+
+    expect(report.status).toBe("blocked");
+    expect(report.strictEndBarReady).toBe(false);
+    expect(report.counts.satisfied).toBe(3);
+    expect(report.counts.deferred).toBe(2);
+    expect(report.sharedBlockers).toContainEqual({
+      key: "channel_current_linked_proof_deferred",
+      status: "deferred",
+      affectedGroups: ["ui_real_use_mobile_desktop", "integrated_end_to_end_tape"],
+      description: "Channel/current-linked proof is deferred, so all affected groups remain outside strict END-BAR.",
+    });
+  });
+
   it("marks strict ready only when every required group has a supplied pass report", () => {
     const dir = mkdtempSync(join(tmpdir(), "friday-endbar-readiness-"));
     const mechanism = writeJson(dir, "mechanism-multiangle.json", {


### PR DESCRIPTION
## Summary
- add `sharedBlockerKey` rows and top-level `sharedBlockers` to END-BAR readiness aggregation
- classify deferred channel/current-linked proof as one shared blocker across UI real-use and integrated tape groups
- keep strict END-BAR blocked/deferred semantics unchanged

## Verification
- `ln -s /Users/jarvis/Projects/Friday/node_modules /private/tmp/friday-endbar-shared-blocker-diagnostics-20260628/node_modules`
- `/Users/jarvis/Projects/Friday/node_modules/.bin/vitest run --project default --project typecheck --project llm-e2e test/unit/qa/friday-endbar-readiness-aggregator.test.ts`
- `node scripts/ops/check-friday-endbar-readiness.mjs --repo-root=/private/tmp/friday-endbar-shared-blocker-diagnostics-20260628 --mechanism-report=/private/tmp/friday-mechanism-multiangle-stress-report-current.json --ui-real-use-report=/private/tmp/friday-ui-real-use-mobile-desktop-current-21c0dca5-20260628.json --selected-uiux-report=/tmp/friday-selected-visual-proof-current-21c0dca5-20260628T0351Z.json --provider-entitlement-report=/private/tmp/friday-provider-entitlement-all-runtime-20260628T0312Z/summary.json --integrated-tape-report=/private/tmp/friday-integrated-end-to-end-tape-current-21c0dca5-20260628.json --out=/private/tmp/friday-endbar-readiness-current-21c0dca5-sharedblocker-20260628.json`

Truth: diagnostic/reporting improvement only. This does not satisfy END-BAR, does not count deferred channel proof, and does not claim adoption or release.