### PR TITLE
test(endbar): accept plural search roots

### DIFF
--- a/scripts/ops/check-friday-endbar-report-inputs.mjs
+++ b/scripts/ops/check-friday-endbar-report-inputs.mjs
@@ -10,6 +10,7 @@ function usage() {
   node scripts/ops/check-friday-endbar-report-inputs.mjs \\
     [--repo-root=/abs/repo] \\
     --search-root=/abs/artifact-dir [--search-root=/abs/other-dir ...] \\
+    [--search-roots=/abs/artifact-dir,/abs/other-dir] \\
     [--max-depth=5] [--out=/abs/report-inputs.json]
 
 Truth: discovers existing END-BAR report candidates and prints the readiness
@@ -47,7 +48,10 @@ if (args.includes("--help") || args.includes("-h")) {
 }
 
 const repoRoot = resolve(arg("repo-root") || process.env.FRIDAY_REPO_ROOT || new URL("../..", import.meta.url).pathname);
-const searchRoots = allArgs("search-root").map((path) => isAbsolute(path) ? path : resolve(path));
+const searchRoots = [
+  ...allArgs("search-root"),
+  ...allArgs("search-roots").flatMap((value) => value.split(",").map((item) => item.trim()).filter(Boolean)),
+].map((path) => isAbsolute(path) ? path : resolve(path));
 const outPath = arg("out") || process.env.FRIDAY_ENDBAR_REPORT_INPUT_DISCOVERY || "";
 const maxDepth = Number.parseInt(arg("max-depth") || process.env.FRIDAY_ENDBAR_REPORT_INPUT_MAX_DEPTH || "5", 10);
 

--- a/test/unit/qa/friday-endbar-report-input-discovery.test.ts
+++ b/test/unit/qa/friday-endbar-report-input-discovery.test.ts
@@ -69,6 +69,36 @@ describe("Friday END-BAR report input discovery", () => {
     expect(report.blockers).toEqual([]);
   });
 
+  it("accepts comma-separated --search-roots as an alias for repeated search roots", () => {
+    const first = mkdtempSync(join(tmpdir(), "friday-endbar-inputs-a-"));
+    const second = mkdtempSync(join(tmpdir(), "friday-endbar-inputs-b-"));
+
+    const mechanism = writeJson(first, "mechanism-multiangle.json", {
+      truth: "mechanism_multiangle_stress_report",
+      status: "passed",
+    });
+    const ui = writeJson(second, "ui-real-use.json", { status: "strict_uiux_real_use_ready" });
+    const selected = writeJson(first, "selected-uiux.json", { status: "selected_visual_proof_ready" });
+    const provider = writeJson(second, "provider-entitlement.json", { status: "passed" });
+    const integrated = writeJson(first, "integrated-tape.json", { status: "integrated_end_to_end_tape_ready" });
+
+    const report = run([`--search-roots=${first},${second}`]);
+
+    expect(report.searchRoots).toEqual([first, second]);
+    expect(report.status).toBe("complete_candidate_set");
+    expect(report.counts.satisfiedCandidates).toBe(5);
+    expect(report.command).toEqual([
+      "node",
+      "scripts/ops/check-friday-endbar-readiness.mjs",
+      `--mechanism-report=${mechanism}`,
+      `--ui-real-use-report=${ui}`,
+      `--selected-uiux-report=${selected}`,
+      `--provider-entitlement-report=${provider}`,
+      `--integrated-tape-report=${integrated}`,
+      "--require-complete",
+    ]);
+  });
+
   it("keeps provider manifest boundary checks and deferred channel reports out of strict candidates", () => {
     const dir = mkdtempSync(join(tmpdir(), "friday-endbar-inputs-"));
     writeJson(dir, "provider-boundary.json", {


### PR DESCRIPTION
## Summary
- accept comma-separated `--search-roots=/a,/b` as an alias for repeated `--search-root` in END-BAR report input discovery
- keep the existing repeated `--search-root` API unchanged
- add focused coverage so common plural usage cannot silently produce an empty scan again

## Verification
- `ln -s /Users/jarvis/Projects/Friday/node_modules /private/tmp/friday-endbar-search-roots-alias-20260628/node_modules`
- `/Users/jarvis/Projects/Friday/node_modules/.bin/vitest run --project default --project typecheck --project llm-e2e test/unit/qa/friday-endbar-report-input-discovery.test.ts`
- `node scripts/ops/check-friday-endbar-report-inputs.mjs --repo-root=/private/tmp/friday-endbar-search-roots-alias-20260628 --search-roots=/private/tmp,/tmp --out=/private/tmp/friday-endbar-report-inputs-current-1edd9a17-searchroots-alias-20260628.json` returned nonzero as expected because current strict blockers remain deferred, and the report scanned 16976 JSON files with 3 satisfied / 2 deferred.

Truth: tooling ergonomics only. This does not create evidence, satisfy END-BAR, or count deferred channel proof.