### PR TITLE
ci: install detect-secrets in strict closure audit

### DIFF
--- a/.github/workflows/mission-spine-closure-audit.yml
+++ b/.github/workflows/mission-spine-closure-audit.yml
@@ -35,6 +35,9 @@ jobs:
       - name: Toolchain
         run: rustup show && cargo --version
 
+      - name: Install detect-secrets
+        run: pip install detect-secrets==1.5.0
+
       - name: Decode UI/device proof bundle
         working-directory: .
         env:


### PR DESCRIPTION
## Summary
- install `detect-secrets==1.5.0` in the Mission Spine strict closure workflow before running the existing closure gate
- matches the existing CI secrets tooling so `mission-spine-secret-scan-gate.sh` can remain fail-closed

## Verification
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/mission-spine-closure-audit.yml"); puts "yaml_ok"'`

Truth: this does not bypass or weaken the secret scan; it supplies the missing tool in the GitHub runner.