### PR TITLE
Make mission spine native wire gate portable

### DIFF
--- a/rust-core/scripts/mission-spine-native-wire-gate.sh
+++ b/rust-core/scripts/mission-spine-native-wire-gate.sh
@@ -6,6 +6,21 @@ cd "$root"
 
 swift_out="${SWIFT_BINDGEN_OUT:-/tmp/friday-ffi-bindgen-swift}"
 kotlin_out="${KOTLIN_BINDGEN_OUT:-/tmp/friday-ffi-bindgen-kotlin}"
+case "$(uname -s)" in
+  Darwin)
+    ffi_cdylib="target/debug/libfriday_ffi.dylib"
+    ;;
+  Linux)
+    ffi_cdylib="target/debug/libfriday_ffi.so"
+    ;;
+  MINGW*|MSYS*|CYGWIN*)
+    ffi_cdylib="target/debug/friday_ffi.dll"
+    ;;
+  *)
+    echo "Unsupported host OS for friday-ffi bindgen: $(uname -s)" >&2
+    exit 2
+    ;;
+esac
 
 echo "[mission-spine-native] fmt check"
 cargo fmt --all -- --check
@@ -20,13 +35,13 @@ echo "[mission-spine-native] generate Swift bindings"
 rm -rf "$swift_out"
 mkdir -p "$swift_out"
 cargo run -p friday-ffi --bin uniffi-bindgen -- \
-  generate --library target/debug/libfriday_ffi.dylib --language swift --out-dir "$swift_out"
+  generate --library "$ffi_cdylib" --language swift --out-dir "$swift_out"
 
 echo "[mission-spine-native] generate Kotlin bindings"
 rm -rf "$kotlin_out"
 mkdir -p "$kotlin_out"
 cargo run -p friday-ffi --bin uniffi-bindgen -- \
-  generate --library target/debug/libfriday_ffi.dylib --language kotlin --out-dir "$kotlin_out"
+  generate --library "$ffi_cdylib" --language kotlin --out-dir "$kotlin_out"
 
 echo "[mission-spine-native] verify native-visible Mission Spine helpers"
 for required in \


### PR DESCRIPTION
## Summary
- Resolve the friday-ffi cdylib path by host OS instead of hard-coding the macOS `.dylib` path.
- Keeps the strict mission-spine closure audit runnable on Ubuntu GitHub runners while preserving macOS local behavior.

## Verification
- `bash -n rust-core/scripts/mission-spine-native-wire-gate.sh`
- `git diff --check`
- `cd rust-core && cargo build -p friday-ffi`
- `cd rust-core && scripts/mission-spine-native-wire-gate.sh`

Truth: this fixes a CI/gate portability blocker only; it is not a product/END-BAR proof by itself.