### PR TITLE
Make native wire gate tolerate missing rg

### DIFF
--- a/rust-core/scripts/mission-spine-native-wire-gate.sh
+++ b/rust-core/scripts/mission-spine-native-wire-gate.sh
@@ -44,6 +44,15 @@ cargo run -p friday-ffi --bin uniffi-bindgen -- \
   generate --library "$ffi_cdylib" --language kotlin --out-dir "$kotlin_out"
 
 echo "[mission-spine-native] verify native-visible Mission Spine helpers"
+contains_generated_symbol() {
+  local symbol="$1"
+  if command -v rg >/dev/null 2>&1; then
+    rg -q "$symbol" "$swift_out" "$kotlin_out"
+  else
+    grep -R -q -- "$symbol" "$swift_out" "$kotlin_out"
+  fi
+}
+
 for required in \
   sampleMissionSpineResponses \
   connectionTruthLabel \
@@ -55,7 +64,7 @@ for required in \
   missionWorkItemStatusIsTerminal \
   missionTimelineLinkGrantsConfirmedMemoryAuthority
 do
-  rg -q "$required" "$swift_out" "$kotlin_out"
+  contains_generated_symbol "$required"
 done
 
 echo "[mission-spine-native] NATIVE/WIRE CONTRACT PASSED"


### PR DESCRIPTION
## Summary
- add an rg-or-grep helper for the native wire gate symbol checks
- preserve the existing required-symbol verification while allowing GitHub Ubuntu runners without ripgrep to pass the same gate

## Verification
- `bash -n rust-core/scripts/mission-spine-native-wire-gate.sh && git diff --check`
- `cd rust-core && PATH="/opt/homebrew/opt/rustup/bin:/usr/bin:/bin:/usr/sbin:/sbin" scripts/mission-spine-native-wire-gate.sh`

Truth: this is a CI portability fix for the strict closure native/wire gate; it is not a new END-BAR proof by itself.