### PR TITLE
chore(release): normalize npm publish metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/thesongzhu/Friday.git"
+    "url": "git+https://github.com/thesongzhu/Friday.git"
   },
   "keywords": [
     "ai",
@@ -55,7 +55,7 @@
     "LICENSE"
   ],
   "bin": {
-    "friday": "./dist/cli/friday-cli.js"
+    "friday": "dist/cli/friday-cli.js"
   },
   "scripts": {
     "typecheck": "npm run typecheck:src && npm run typecheck:contracts",


### PR DESCRIPTION
## Summary
- normalize the npm repository URL to the canonical git+https form
- remove the leading ./ from the friday bin target so npm publish dry-run no longer auto-corrects package metadata

## Verification
- npm run build
- npm run release:check
- npm run check:public-source-hygiene
- npm publish --dry-run --ignore-scripts --access public (exit 0; no auto-correct/bin warnings)

Truth: metadata-only release hygiene fix; no publish/tag/release performed.