### PR TITLE
Prevent offline captures from satisfying selected UI proof

### DIFF
--- a/apps/friday-ios/README.md
+++ b/apps/friday-ios/README.md
@@ -97,6 +97,17 @@ The default simulator launch is an **offline truth proof**. It deliberately keep
 if the live seams are not explicitly enabled. That screenshot proves "no fabricated
 ready state"; it is not a product-ready live-use proof.
 
+For selected-design visual comparison, use the explicit sample lane instead of the
+offline truth lane:
+
+```sh
+apps/friday-ios/build-sim.sh --mode design-proof-sample --shot apps/friday-ios/.build-sim/friday-ios-design-proof-sample.png
+```
+
+`design-proof-sample` renders the labeled `PreviewReadClient` sample so the native
+Home/destinations can be compared against the operator-selected HTML/JSON handoff.
+It is design proof only: no live Hub, no runtime PASS, no END-BAR, and no adoption.
+
 For local live-loopback dogfood, use the explicit mode:
 
 ```sh

--- a/apps/friday-ios/Sources/FridayMobileShell/FridayApp.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayApp.swift
@@ -93,8 +93,9 @@ final class FridaySession: ObservableObject {
   init(preview: Bool = false) {
     let args = ProcessInfo.processInfo.arguments
     let env = ProcessInfo.processInfo.environment
-    self.runControlEnabled = preview ? false : Self.runControlRequested(args: args, env: env)
-    let selectedDeviceKeypairBackend: DeviceKeypairBackend = preview
+    let designProofSample = preview || Self.designProofSampleRequested(args: args, env: env)
+    self.runControlEnabled = designProofSample ? false : Self.runControlRequested(args: args, env: env)
+    let selectedDeviceKeypairBackend: DeviceKeypairBackend = designProofSample
       ? KeychainDeviceKeypairBackend()
       : Self.defaultDeviceKeypairBackend(args: args, env: env)
     self.deviceKeypairBackend = selectedDeviceKeypairBackend
@@ -109,13 +110,13 @@ final class FridaySession: ObservableObject {
     // wired here behind an OPT-IN env/arg gate (`FRIDAY_MOBILE_LIVE_READ=1` / `--live-read`,
     // mirroring the desktop `FRIDAY_CONSOLE_LIVE`). The DEFAULT (gate OFF) stays the honest-
     // unavailable client — this PR does NOT flip the shipped default (that is the slice-6 gate).
-    self.readClient = preview
+    self.readClient = designProofSample
       ? PreviewReadClient()
       : Self.defaultReadClient(deviceKeypairBackend: selectedDeviceKeypairBackend)
-    self.devicePairing = preview
+    self.devicePairing = designProofSample
       ? .evaluate(deviceKeypairRequested: false, readLiveRequested: false, writeLiveRequested: false)
       : Self.defaultDevicePairingReadiness(deviceKeypairBackend: selectedDeviceKeypairBackend)
-    self.makePairingClient = preview || !Self.livePairingRequested(args: args, env: env)
+    self.makePairingClient = designProofSample || !Self.livePairingRequested(args: args, env: env)
       ? { _ in nil }
       : Self.defaultPairingClient
 
@@ -128,7 +129,7 @@ final class FridaySession: ObservableObject {
     // A separate device-keypair live path is additive and explicitly opted in with
     // `FRIDAY_MOBILE_LIVE_DEVICE_KEYPAIR=1` / `--live-device-keypair`; the shipped default still
     // touches no keychain, opens no socket, and remains honest-unavailable.
-    if preview {
+    if designProofSample {
       self.writeClient = Self.honestUnavailableWriteClient()
       self.missionClient = nil
     } else {
@@ -225,6 +226,10 @@ final class FridaySession: ObservableObject {
 
   static func useDeviceKeypair(args: [String], env: [String: String]) -> Bool {
     MobileRuntimeGates.useDeviceKeypair(args: args, env: env)
+  }
+
+  static func designProofSampleRequested(args: [String], env: [String: String]) -> Bool {
+    MobileRuntimeGates.designProofSampleRequested(args: args, env: env)
   }
 
   static func defaultDeviceKeypairBackend(args: [String], env: [String: String]) -> DeviceKeypairBackend {

--- a/apps/friday-ios/Sources/FridayMobileShellCore/MobileRuntimeGates.swift
+++ b/apps/friday-ios/Sources/FridayMobileShellCore/MobileRuntimeGates.swift
@@ -22,6 +22,10 @@ public enum MobileRuntimeGates {
       || env["FRIDAY_MOBILE_SIMULATOR_FILE_DEVICE_KEYPAIR"] == "1"
   }
 
+  public static func designProofSampleRequested(args: [String], env: [String: String]) -> Bool {
+    args.contains("--design-proof-sample") || env["FRIDAY_MOBILE_DESIGN_PROOF_SAMPLE"] == "1"
+  }
+
   public static func liveReadRequested(args: [String], env: [String: String]) -> Bool {
     args.contains("--live-read") || env["FRIDAY_MOBILE_LIVE_READ"] == "1"
   }

--- a/apps/friday-ios/Tests/FridayMobileShellCoreTests/MobileRuntimeGatesTests.swift
+++ b/apps/friday-ios/Tests/FridayMobileShellCoreTests/MobileRuntimeGatesTests.swift
@@ -8,6 +8,7 @@ func mobileRuntimeGatesDefaultOff() {
   #expect(!MobileRuntimeGates.livePairingRequested(args: [], env: [:]))
   #expect(!MobileRuntimeGates.useDeviceKeypair(args: [], env: [:]))
   #expect(!MobileRuntimeGates.simulatorFileDeviceKeypairRequested(args: [], env: [:]))
+  #expect(!MobileRuntimeGates.designProofSampleRequested(args: [], env: [:]))
   #expect(!MobileRuntimeGates.runControlRequested(args: [], env: [:]))
 }
 
@@ -20,6 +21,7 @@ func mobileRuntimeGatesAcceptExplicitArgs() {
   #expect(MobileRuntimeGates.simulatorFileDeviceKeypairRequested(
     args: ["--simulator-file-device-keypair"],
     env: [:]))
+  #expect(MobileRuntimeGates.designProofSampleRequested(args: ["--design-proof-sample"], env: [:]))
   #expect(MobileRuntimeGates.runControlRequested(args: ["--agent-run-control-via-rust"], env: [:]))
   #expect(MobileRuntimeGates.runControlRequested(args: ["--run-control"], env: [:]))
 }
@@ -33,6 +35,9 @@ func mobileRuntimeGatesAcceptExplicitEnv() {
   #expect(MobileRuntimeGates.simulatorFileDeviceKeypairRequested(
     args: [],
     env: ["FRIDAY_MOBILE_SIMULATOR_FILE_DEVICE_KEYPAIR": "1"]))
+  #expect(MobileRuntimeGates.designProofSampleRequested(
+    args: [],
+    env: ["FRIDAY_MOBILE_DESIGN_PROOF_SAMPLE": "1"]))
   #expect(MobileRuntimeGates.runControlRequested(
     args: [],
     env: ["FRIDAY_MOBILE_AGENT_RUN_CONTROL_VIA_RUST": "1"]))
@@ -107,6 +112,9 @@ func mobileRuntimeGatesDoNotAcceptTruthyLookalikes() {
   #expect(!MobileRuntimeGates.simulatorFileDeviceKeypairRequested(
     args: [],
     env: ["FRIDAY_MOBILE_SIMULATOR_FILE_DEVICE_KEYPAIR": "true"]))
+  #expect(!MobileRuntimeGates.designProofSampleRequested(
+    args: [],
+    env: ["FRIDAY_MOBILE_DESIGN_PROOF_SAMPLE": "true"]))
   #expect(!MobileRuntimeGates.runControlRequested(
     args: [],
     env: ["FRIDAY_MOBILE_AGENT_RUN_CONTROL_VIA_RUST": "true"]))

--- a/apps/friday-ios/build-sim.sh
+++ b/apps/friday-ios/build-sim.sh
@@ -28,6 +28,7 @@ Usage:
   apps/friday-ios/build-sim.sh [screenshot-path]
   apps/friday-ios/build-sim.sh --mode offline-truth [--destination pairing] [--shot screenshot-path]
   apps/friday-ios/build-sim.sh --mode live-loopback [--destination pairing] [--shot screenshot-path]
+  apps/friday-ios/build-sim.sh --mode design-proof-sample [--destination pairing] [--shot screenshot-path]
 
 Modes:
   offline-truth  Default. Launches with all FRIDAY_MOBILE_LIVE_* gates OFF and proves the
@@ -35,6 +36,9 @@ Modes:
   live-loopback  Explicit local proof mode. Launches with the existing simulator live gates ON
                  (read/write/pairing/device-keypair) so the app attempts real loopback seams.
                  It still does not flip shipped defaults, mint trust, or hold signing keys.
+  design-proof-sample
+                 Explicit visual parity mode. Launches a labeled PreviewReadClient sample for
+                 operator-selected UI comparison only. It is not runtime proof or END-BAR.
 USAGE
 }
 
@@ -105,6 +109,9 @@ case "$MODE" in
     ;;
   live|live-loopback)
     MODE="live-loopback"
+    ;;
+  design|design-proof|design-proof-sample)
+    MODE="design-proof-sample"
     ;;
   *)
     echo "ERROR: unsupported --mode '$MODE'" >&2
@@ -207,6 +214,13 @@ case "$MODE" in
       LAUNCH_ENV+=(SIMCTL_CHILD_FRIDAY_MOBILE_LIVE_WRITE_PORT="$FRIDAY_MOBILE_LIVE_WRITE_PORT")
     fi
     ;;
+  design-proof-sample)
+    echo "launch mode: design-proof-sample (labeled selected-design sample; no live seams)"
+    LAUNCH_ARGS=(--design-proof-sample)
+    LAUNCH_ENV=(
+      SIMCTL_CHILD_FRIDAY_MOBILE_DESIGN_PROOF_SAMPLE=1
+    )
+    ;;
 esac
 LAUNCH_CMD=(xcrun simctl launch --terminate-running-process "$UDID" com.friday.shell)
 if [[ -n "$DESTINATION" ]]; then
@@ -287,7 +301,8 @@ cat > "$SHOT.metadata.json" <<JSON
   "live_write_host_override": $LIVE_WRITE_HOST_OVERRIDE_JSON,
   "live_write_port_override": $LIVE_WRITE_PORT_OVERRIDE_JSON,
   "simulator_device_pubkey": $SIMULATOR_DEVICE_PUBKEY_JSON,
-  "caveat": "offline-truth proves honest-unavailable; live-loopback attempts real local read/write/pairing seams but does not claim END-BAR, GO-LIVE, adoption, trust minting, or operator signing."
+  "design_proof_sample_requested": $([[ "$MODE" == "design-proof-sample" ]] && echo true || echo false),
+  "caveat": "offline-truth proves honest-unavailable; design-proof-sample is labeled visual comparison only; live-loopback attempts real local read/write/pairing seams and does not claim END-BAR, GO-LIVE, adoption, trust minting, or operator signing. None of these modes claims END-BAR, GO-LIVE, adoption, trust minting, or operator signing."
 }
 JSON
 echo "screenshot: $SHOT"
@@ -295,6 +310,8 @@ echo "metadata: $SHOT.metadata.json"
 echo "VERIFY: open the screenshot and confirm the 155px Hero Pet card shows the v9 DOG (not blank)."
 if [[ "$MODE" == "offline-truth" ]]; then
   echo "VERIFY: offline-truth mode should honestly show unavailable/disabled state, not a fabricated ready product."
+elif [[ "$MODE" == "design-proof-sample" ]]; then
+  echo "VERIFY: design-proof-sample mode is visual comparison only; do not count it as runtime/live product proof."
 else
   echo "VERIFY: live-loopback mode should show live read/write/pairing requests and any real seam failure AS truth."
 fi

--- a/scripts/ops/check-friday-ios-design-destination-capture-contract.mjs
+++ b/scripts/ops/check-friday-ios-design-destination-capture-contract.mjs
@@ -64,6 +64,8 @@ if (scriptExists) {
   const requiredTruthStrings = [
     "ios_selected_design_destination_capture_not_live_closure",
     "friday-design-handoff-20260602/saved/mobile-selection.json",
+    "design-proof-sample",
+    "`offline-truth` is a negative-control lane only",
     "not END-BAR",
     "not GO-LIVE",
     "enabled actions still require separate Hub/DB/ledger/proof closure",
@@ -95,7 +97,7 @@ const report = {
   status: failed.length === 0 ? "passed" : "failed",
   requiredDestinations,
   checks,
-  caveat: "This proves the selected-design capture runner and package hook remain present; it does not claim screenshots were captured, END-BAR, GO-LIVE, adoption, or live action closure.",
+  caveat: "This proves the selected-design capture runner and package hook remain present and that offline-truth is not the selected visual proof lane; it does not claim screenshots were captured, END-BAR, GO-LIVE, adoption, or live action closure.",
 };
 
 console.log(JSON.stringify(report, null, 2));

--- a/scripts/ops/check-friday-ios-live-evidence-contract.mjs
+++ b/scripts/ops/check-friday-ios-live-evidence-contract.mjs
@@ -27,6 +27,7 @@ const files = {
   app: read(root, "apps/friday-ios/Sources/FridayMobileShell/FridayApp.swift"),
   home: read(root, "apps/friday-ios/Sources/FridayMobileShell/FridayHomeScreen.swift"),
   commandSheet: read(root, "apps/friday-ios/Sources/FridayMobileShell/CommandSheet.swift"),
+  mobileProductContract: read(root, "apps/friday-ios/Sources/FridayMobileShellCore/MobileProductReadinessContract.swift"),
   buildSim: read(root, "apps/friday-ios/build-sim.sh"),
   liveT3Proof: read(root, "scripts/ops/friday-ios-sim-live-t3-proof.sh"),
   gatesTests: read(root, "apps/friday-ios/Tests/FridayMobileShellCoreTests/MobileRuntimeGatesTests.swift"),
@@ -83,6 +84,8 @@ const checks = [
       ...requireStrings(files.commandSheet, [
         "Command Sheet",
         "Route coverage is not END-BAR",
+      ]),
+      ...requireStrings(files.mobileProductContract, [
         "Device Pairing",
       ]),
     ],
@@ -115,6 +118,8 @@ const checks = [
       '"simulator_file_device_keypair_requested"',
       '"simulator_device_pubkey"',
       "does not claim END-BAR, GO-LIVE, adoption, trust minting, or operator signing",
+      "design-proof-sample is labeled visual comparison only",
+      '"design_proof_sample_requested"',
     ]),
   },
   {

--- a/scripts/ops/check-friday-uiux-selected-visual-proof.mjs
+++ b/scripts/ops/check-friday-uiux-selected-visual-proof.mjs
@@ -215,13 +215,18 @@ function evaluateIosManifest(path) {
   const missing = requiredMobileDestinations.filter((destination) => !captured.has(destination));
   const truthOk = manifest.truth_label === "ios_selected_design_destination_capture_not_live_closure";
   const statusOk = manifest.status === "ready";
+  const mode = manifest.mode || null;
+  const allowedVisualModes = ["design-proof-sample", "live-loopback"];
+  const modeOk = allowedVisualModes.includes(mode);
   return {
     path,
-    status: truthOk && statusOk && missing.length === 0 ? "ready" : "gap",
+    status: truthOk && statusOk && modeOk && missing.length === 0 ? "ready" : "gap",
     truth_label: manifest.truth_label || null,
     manifest_status: manifest.status || null,
     generated_at_utc: manifest.generated_at_utc || null,
-    mode: manifest.mode || null,
+    mode,
+    allowedVisualModes,
+    modeStatus: modeOk ? "visual_proof_mode" : mode === "offline-truth" ? "negative_control_not_visual_proof" : "missing_or_unknown_mode",
     requiredMobileDestinations,
     capturedDestinations: [...captured],
     missingDestinations: missing,
@@ -284,7 +289,7 @@ const desktopReady = desktopVisualEvidence.some((item) => item.status === "ready
 if (!iosReady) {
   block(
     "mobile_selected_visual_proof_missing",
-    "Run proof:ios:design-destinations on current HEAD and pass its ios-design-destination-capture-manifest.json",
+    "Run proof:ios:design-destinations on current HEAD in design-proof-sample or live-loopback mode and pass its ios-design-destination-capture-manifest.json; offline-truth is a negative-control lane and is not selected visual proof",
   );
 }
 if (!desktopReady) {

--- a/scripts/ops/friday-ios-design-destination-capture.sh
+++ b/scripts/ops/friday-ios-design-destination-capture.sh
@@ -5,7 +5,7 @@ usage() {
   cat >&2 <<'EOF'
 usage:
   scripts/ops/friday-ios-design-destination-capture.sh --out-dir /abs/capture-dir
-    [--mode offline-truth|live-loopback]
+    [--mode design-proof-sample|live-loopback|offline-truth]
     [--destinations home,session,...]
     [--skip-initial-build]
 
@@ -15,6 +15,8 @@ a manifest with truth labels.
 
 Truth: this is a design/device capture runner. It does not claim END-BAR,
 GO-LIVE, adoption, operator signing, or live workflow closure.
+`offline-truth` is a negative-control lane only and is rejected by selected
+visual proof gates; use `design-proof-sample` or `live-loopback` for visual proof.
 EOF
 }
 
@@ -25,7 +27,7 @@ die() {
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 out_dir=""
-mode="offline-truth"
+mode="design-proof-sample"
 skip_initial_build=0
 destinations_csv="home,missions,session,contextPassport,tokenLedger,shareIntake,voice,pairing,needsMe,memory,platform,providerAuth,activity,workflows,onboarding,settings,petEditor,proofViewer,entrypoints"
 settle_seconds="${FRIDAY_IOS_DESIGN_CAPTURE_SETTLE_SECONDS:-6}"
@@ -81,6 +83,7 @@ esac
 case "${mode}" in
   offline|offline-truth) mode="offline-truth" ;;
   live|live-loopback) mode="live-loopback" ;;
+  design|design-proof|design-proof-sample) mode="design-proof-sample" ;;
   *) die "unsupported --mode '${mode}'" ;;
 esac
 [ -n "${destinations_csv}" ] || die "--destinations must not be empty"
@@ -160,6 +163,15 @@ for destination in "${destinations[@]}"; do
       if [[ -n "${FRIDAY_MOBILE_LIVE_WRITE_PORT:-}" ]]; then
         launch_env+=(SIMCTL_CHILD_FRIDAY_MOBILE_LIVE_WRITE_PORT="${FRIDAY_MOBILE_LIVE_WRITE_PORT}")
       fi
+    elif [ "${mode}" = "design-proof-sample" ]; then
+      launch_args=(
+        --design-proof-sample
+        "${launch_args[@]}"
+      )
+      launch_env=(
+        SIMCTL_CHILD_FRIDAY_MOBILE_DESIGN_PROOF_SAMPLE=1
+        "${launch_env[@]}"
+      )
     fi
     env "${launch_env[@]}" "${launch_cmd[@]}" "${launch_args[@]}" >"${launch_log}" 2>&1
     sleep "${settle_seconds}"
@@ -244,7 +256,9 @@ const manifest = {
   required_destinations: requiredDestinations,
   relaunch_contract: mode === "live-loopback"
     ? "each non-initial destination relaunch propagates the same live-loopback read/write/pairing/device-keypair gates as the initial build launch"
-    : "each destination relaunch keeps mobile live gates off and captures honest-unavailable truth",
+    : mode === "design-proof-sample"
+      ? "each destination relaunch propagates the explicit design-proof sample gate; this is selected visual comparison only and not runtime proof"
+      : "each destination relaunch keeps mobile live gates off and captures honest-unavailable truth; this negative-control lane is not selected visual proof",
   captures,
   validation: {
     missing_captures: missingCaptures,
@@ -254,7 +268,7 @@ const manifest = {
     non_ready_captures: nonReadyCaptures,
   },
   initial_build_metadata: initialMetadata,
-  caveat: "Device screenshots prove selected destinations launch and render truth-labeled UI states only; enabled actions still require separate Hub/DB/ledger/proof closure before END-BAR.",
+  caveat: "Device screenshots prove selected destinations launch and render truth-labeled UI states only; design-proof-sample is visual comparison only, offline-truth is negative control only, and enabled actions still require separate Hub/DB/ledger/proof closure before END-BAR.",
 };
 
 writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);

--- a/test/unit/qa/friday-ios-design-destination-capture-contract-cli.test.ts
+++ b/test/unit/qa/friday-ios-design-destination-capture-contract-cli.test.ts
@@ -23,7 +23,9 @@ function createFixtureRepo(extraScriptSource = "") {
 destinations_csv="home,missions,session,contextPassport,tokenLedger,shareIntake,voice,pairing,needsMe,memory,platform,providerAuth,activity,workflows,onboarding,settings,petEditor,proofViewer,entrypoints"
 truth_label="ios_selected_design_destination_capture_not_live_closure"
 design_source="friday-design-handoff-20260602/saved/mobile-selection.json"
-caveat="not END-BAR / not GO-LIVE; enabled actions still require separate Hub/DB/ledger/proof closure"
+mode="design-proof-sample"
+negative_control_note="\`offline-truth\` is a negative-control lane only"
+caveat="not END-BAR / not GO-LIVE; design-proof-sample is visual comparison only; enabled actions still require separate Hub/DB/ledger/proof closure"
 ${extraScriptSource}
 `);
   return root;

--- a/test/unit/qa/friday-ios-design-destination-capture-runner.test.ts
+++ b/test/unit/qa/friday-ios-design-destination-capture-runner.test.ts
@@ -17,6 +17,68 @@ async function writeExecutable(filePath: string, content: string) {
 }
 
 describe("friday-ios-design-destination-capture runner", () => {
+  it("defaults selected design captures to design-proof-sample mode", async () => {
+    const root = process.cwd();
+    const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "friday-ios-capture-design-default-"));
+    const binDir = path.join(tempRoot, "bin");
+    const outDir = path.join(tempRoot, "capture");
+
+    await writeExecutable(path.join(binDir, "xcrun"), `#!/usr/bin/env bash
+set -euo pipefail
+if [ "$1" = "simctl" ] && [ "$2" = "list" ]; then
+  echo "== Devices =="
+  echo "-- iOS Test --"
+  echo "    iPhone Test (${fakeUdid}) (Booted)"
+  exit 0
+fi
+if [ "$1" = "simctl" ] && [ "$2" = "launch" ]; then
+  echo "launched $*"
+  exit 0
+fi
+if [ "$1" = "simctl" ] && [ "$2" = "io" ] && [ "$4" = "screenshot" ]; then
+  printf 'fake-png-%s\\n' "$5" > "$5"
+  exit 0
+fi
+echo "unexpected xcrun $*" >&2
+exit 64
+`);
+
+    const { stdout } = await execFileAsync(
+      "bash",
+      [
+        path.join(root, script),
+        "--out-dir",
+        outDir,
+        "--destinations",
+        "home,session",
+        "--skip-initial-build",
+      ],
+      {
+        cwd: root,
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          PATH: `${binDir}:${process.env.PATH ?? ""}`,
+          FRIDAY_IOS_DESIGN_CAPTURE_SETTLE_SECONDS: "0",
+        },
+      },
+    );
+
+    expect(stdout).toContain("PASS - selected iOS design destinations captured.");
+    const manifest = JSON.parse(
+      await fs.readFile(path.join(outDir, "ios-design-destination-capture-manifest.json"), "utf8"),
+    ) as {
+      mode: string;
+      caveat: string;
+      relaunch_contract: string;
+    };
+    expect(manifest.mode).toBe("design-proof-sample");
+    expect(manifest.caveat).toContain("offline-truth is negative control only");
+    expect(manifest.relaunch_contract).toContain("design-proof sample");
+    await expect(fs.readFile(path.join(outDir, "screenshots", "session.launch.txt"), "utf8"))
+      .resolves.toContain("--design-proof-sample");
+  });
+
   it("captures multiple offline destinations with skip-initial-build under set -u", async () => {
     const root = process.cwd();
     const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "friday-ios-capture-runner-"));

--- a/test/unit/qa/friday-uiux-selected-visual-proof-cli.test.ts
+++ b/test/unit/qa/friday-uiux-selected-visual-proof-cli.test.ts
@@ -48,13 +48,13 @@ function fixture() {
   return { root, designRoot };
 }
 
-function writeReadyEvidence(root: string) {
+function writeReadyEvidence(root: string, mode = "live-loopback") {
   const evidence = join(root, "evidence");
   writeFile(evidence, "ios-design-destination-capture-manifest.json", JSON.stringify({
     truth_label: "ios_selected_design_destination_capture_not_live_closure",
     status: "ready",
     generated_at_utc: "2026-06-27T00:00:00.000Z",
-    mode: "live-loopback",
+    mode,
     captures: [
       "home",
       "session",
@@ -135,6 +135,52 @@ describe("check-friday-uiux-selected-visual-proof", () => {
       const report = JSON.parse(output) as { status?: string; blockers?: unknown[] };
       expect(report.status).toBe("selected_visual_proof_ready");
       expect(report.blockers).toEqual([]);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("passes when current selected mobile visual evidence is a design-proof sample", () => {
+    const { root, designRoot } = fixture();
+    try {
+      const evidence = writeReadyEvidence(root, "design-proof-sample");
+      const output = execFileSync("node", [
+        script,
+        `--repo-root=${root}`,
+        `--design-root=${designRoot}`,
+        `--evidence-dir=${evidence}`,
+        "--require-complete",
+      ], { cwd: process.cwd(), encoding: "utf8" });
+      const report = JSON.parse(output) as { status?: string; blockers?: unknown[] };
+      expect(report.status).toBe("selected_visual_proof_ready");
+      expect(report.blockers).toEqual([]);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects offline-truth captures as selected mobile visual proof", () => {
+    const { root, designRoot } = fixture();
+    try {
+      const evidence = writeReadyEvidence(root, "offline-truth");
+      const result = spawnSync("node", [
+        script,
+        `--repo-root=${root}`,
+        `--design-root=${designRoot}`,
+        `--evidence-dir=${evidence}`,
+        "--require-complete",
+      ], { cwd: process.cwd(), encoding: "utf8" });
+      expect(result.status).toBe(1);
+      const report = JSON.parse(result.stdout) as {
+        status?: string;
+        blockers?: Array<{ code?: string }>;
+        evidence?: { ios?: Array<{ modeStatus?: string }> };
+      };
+      expect(report.status).toBe("selected_visual_proof_gaps_present");
+      expect(report.evidence?.ios?.[0]?.modeStatus).toBe("negative_control_not_visual_proof");
+      expect(report.blockers).toEqual(expect.arrayContaining([
+        expect.objectContaining({ code: "mobile_selected_visual_proof_missing" }),
+      ]));
     } finally {
       rmSync(root, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary
- add an explicit iOS `design-proof-sample` lane for operator-selected visual comparison
- keep `offline-truth` as a negative-control/unavailable proof lane and reject it from selected visual proof readiness
- update README, capture metadata, static guards, and regression tests so offline captures cannot be counted as selected UI proof

## Verification
- `npx vitest run test/unit/qa/friday-uiux-selected-visual-proof-cli.test.ts test/unit/qa/friday-ios-design-destination-capture-runner.test.ts test/unit/qa/friday-ios-design-destination-capture-contract-cli.test.ts --reporter=dot`
- `node scripts/ops/check-friday-ios-design-destination-capture-contract.mjs`
- `node scripts/ops/check-friday-ios-live-evidence-contract.mjs`
- `node --check scripts/ops/check-friday-uiux-selected-visual-proof.mjs`
- `bash -n scripts/ops/friday-ios-design-destination-capture.sh`
- `bash -n apps/friday-ios/build-sim.sh`
- `swift test --package-path apps/friday-ios --filter MobileRuntimeGatesTests`
- `git diff --check`

Truth: this PR fixes a proof-lane/product-claim gap. It does not claim END-BAR, GO-LIVE, adoption, runtime live closure, trust minting, or operator signing completion.