### PR TITLE
Add UIUX product happy path gate

### DIFF
--- a/package.json
+++ b/package.json
@@ -123,6 +123,7 @@
     "check:uiux-native-linkage": "node scripts/ops/check-friday-uiux-native-linkage.mjs",
     "check:uiux-selected-visual-proof": "node scripts/ops/check-friday-uiux-selected-visual-proof.mjs",
     "check:uiux-action-traceability": "node scripts/ops/check-friday-uiux-action-traceability.mjs",
+    "check:uiux-product-happy-path": "node scripts/ops/check-friday-uiux-product-happy-path.mjs",
     "check:uiux-product-closure": "node scripts/ops/friday-uiux-product-closure-readiness.mjs",
     "check:endbar-acceptance-manifest": "node scripts/ops/check-friday-provider-entitlement-manifest.mjs",
     "check:endbar-readiness": "node scripts/ops/check-friday-endbar-readiness.mjs",

--- a/scripts/ops/check-friday-uiux-product-happy-path.mjs
+++ b/scripts/ops/check-friday-uiux-product-happy-path.mjs
@@ -1,0 +1,346 @@
+#!/usr/bin/env node
+
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, isAbsolute, resolve } from "node:path";
+
+const args = process.argv.slice(2);
+
+function usage() {
+  console.error(`usage:
+  node scripts/ops/check-friday-uiux-product-happy-path.mjs \\
+    [--repo-root=/abs/repo] [--design-root=/abs/friday-design-handoff-20260602] \\
+    [--selected-visual-report=/abs/selected-visual-proof.json] \\
+    [--action-traceability-report=/abs/uiux-action-traceability.json] \\
+    [--evidence-dir=/abs/evidence ...] [--runtime-evidence-dir=/abs/runtime-evidence ...] \\
+    [--runtime-evidence=/abs/action-runtime-evidence.json ...] [--out=/abs/report.json] \\
+    [--require-complete]
+
+Truth: verifies whether current evidence is strong enough to call the selected
+mobile+desktop UI a normal connected product happy path. It is intentionally
+stricter than selected visual proof or action traceability. Design-only samples,
+offline negative controls, AX-only visibility, missing runtime evidence, and
+residual ProductReadinessContract blockers cannot satisfy this gate.`);
+}
+
+function arg(name) {
+  const prefix = `--${name}=`;
+  for (let index = 0; index < args.length; index += 1) {
+    const value = args[index];
+    if (value.startsWith(prefix)) return value.slice(prefix.length);
+    if (value === `--${name}` && args[index + 1]) return args[index + 1];
+  }
+  return "";
+}
+
+function argsAll(name) {
+  const prefix = `--${name}=`;
+  const values = [];
+  for (let index = 0; index < args.length; index += 1) {
+    const value = args[index];
+    if (value.startsWith(prefix)) {
+      values.push(value.slice(prefix.length));
+    } else if (value === `--${name}` && args[index + 1]) {
+      values.push(args[index + 1]);
+      index += 1;
+    }
+  }
+  return values;
+}
+
+if (args.includes("--help") || args.includes("-h")) {
+  usage();
+  process.exit(0);
+}
+
+const repoRoot = resolve(arg("repo-root") || process.env.FRIDAY_REPO_ROOT || new URL("../..", import.meta.url).pathname);
+const designRoot = resolve(
+  arg("design-root") ||
+  process.env.FRIDAY_DESIGN_HANDOFF_ROOT ||
+  `${process.env.HOME || process.env.USERPROFILE || "."}/Desktop/friday-design-handoff-20260602`,
+);
+const outPath = arg("out") || process.env.FRIDAY_UIUX_PRODUCT_HAPPY_PATH_REPORT || "";
+const requireComplete = args.includes("--require-complete");
+const selectedVisualReportPath = arg("selected-visual-report") || process.env.FRIDAY_UIUX_SELECTED_VISUAL_PROOF_REPORT || "";
+const actionTraceabilityReportPath = arg("action-traceability-report") || process.env.FRIDAY_UIUX_ACTION_TRACEABILITY_REPORT || "";
+const evidenceDirs = [
+  ...argsAll("evidence-dir"),
+  ...(process.env.FRIDAY_UIUX_HAPPY_PATH_EVIDENCE_DIRS
+    ? process.env.FRIDAY_UIUX_HAPPY_PATH_EVIDENCE_DIRS.split(/[:\n]/).filter(Boolean)
+    : []),
+];
+const runtimeEvidenceDirs = [
+  ...argsAll("runtime-evidence-dir"),
+  ...(process.env.FRIDAY_DESIGN_ACTION_RUNTIME_EVIDENCE_DIRS
+    ? process.env.FRIDAY_DESIGN_ACTION_RUNTIME_EVIDENCE_DIRS.split(/[:\n]/).filter(Boolean)
+    : []),
+];
+const runtimeEvidence = [
+  ...argsAll("runtime-evidence"),
+  ...(process.env.FRIDAY_DESIGN_ACTION_RUNTIME_EVIDENCE
+    ? process.env.FRIDAY_DESIGN_ACTION_RUNTIME_EVIDENCE.split(/[:\n]/).filter(Boolean)
+    : []),
+];
+
+const blockers = [];
+const notes = [];
+
+function abs(path) {
+  return isAbsolute(path) ? path : resolve(path);
+}
+
+function block(code, detail) {
+  blockers.push({ code, detail });
+}
+
+function note(code, detail) {
+  notes.push({ code, detail });
+}
+
+function readJson(path, label) {
+  const resolved = abs(path);
+  try {
+    return JSON.parse(readFileSync(resolved, "utf8"));
+  } catch (error) {
+    block("json_unreadable", `${label}:${resolved}:${error.message}`);
+    return null;
+  }
+}
+
+function parseJsonFromOutput(text, label) {
+  const trimmed = (text || "").trim();
+  if (!trimmed) return null;
+  try {
+    return JSON.parse(trimmed);
+  } catch {
+    block(`${label}_invalid_json`, "stdout did not contain a parseable JSON object");
+    return null;
+  }
+}
+
+function runJson(label, commandArgs) {
+  const result = spawnSync(process.execPath, commandArgs, {
+    cwd: repoRoot,
+    encoding: "utf8",
+  });
+  const parsed = parseJsonFromOutput(result.stdout, label);
+  if ((result.status ?? 1) !== 0) {
+    block(`${label}_failed`, String(result.status ?? 1));
+  }
+  return {
+    label,
+    exitCode: result.status ?? 1,
+    parsed,
+    stderr: (result.stderr || "").trim(),
+  };
+}
+
+function selectedVisualReport() {
+  if (selectedVisualReportPath) {
+    return {
+      source: abs(selectedVisualReportPath),
+      parsed: readJson(selectedVisualReportPath, "selected-visual-report"),
+      exitCode: 0,
+    };
+  }
+  const commandArgs = [
+    resolve(repoRoot, "scripts/ops/check-friday-uiux-selected-visual-proof.mjs"),
+    `--repo-root=${repoRoot}`,
+    `--design-root=${designRoot}`,
+  ];
+  for (const dir of evidenceDirs) commandArgs.push(`--evidence-dir=${abs(dir)}`);
+  return { source: "generated", ...runJson("selected_visual_proof", commandArgs) };
+}
+
+function actionTraceabilityReport() {
+  if (actionTraceabilityReportPath) {
+    return {
+      source: abs(actionTraceabilityReportPath),
+      parsed: readJson(actionTraceabilityReportPath, "action-traceability-report"),
+      exitCode: 0,
+    };
+  }
+  const commandArgs = [
+    resolve(repoRoot, "scripts/ops/check-friday-uiux-action-traceability.mjs"),
+    `--repo-root=${repoRoot}`,
+    `--design-root=${designRoot}`,
+    "--compact",
+  ];
+  for (const dir of evidenceDirs) commandArgs.push(`--evidence-dir=${abs(dir)}`);
+  for (const dir of runtimeEvidenceDirs) commandArgs.push(`--runtime-evidence-dir=${abs(dir)}`);
+  for (const evidence of runtimeEvidence) commandArgs.push(`--runtime-evidence=${abs(evidence)}`);
+  return { source: "generated", ...runJson("action_traceability", commandArgs) };
+}
+
+function numberAt(value, path, fallback = 0) {
+  let current = value;
+  for (const key of path) current = current?.[key];
+  return typeof current === "number" ? current : fallback;
+}
+
+function arrayAt(value, path) {
+  let current = value;
+  for (const key of path) current = current?.[key];
+  return Array.isArray(current) ? current : [];
+}
+
+const liveConnectedVisualModes = new Set([
+  "live-loopback",
+  "real-device-live",
+  "product-live",
+  "same-run-live",
+]);
+
+function liveEvidenceForSurface(report, surface) {
+  const entries = arrayAt(report, ["evidence", surface]);
+  return entries.filter((item) => item?.status === "ready" && liveConnectedVisualModes.has(String(item?.mode || "")));
+}
+
+function visualModesForSurface(report, surface) {
+  return arrayAt(report, ["evidence", surface])
+    .map((item) => String(item?.mode || ""))
+    .filter(Boolean);
+}
+
+const negativeLabelValues = new Set(["offline", "stale", "error", "unavailable", "disabled"]);
+const labelKeys = new Set([
+  "statusLabels",
+  "status_labels",
+  "visibleLabels",
+  "visible_labels",
+  "labels",
+  "badges",
+  "chips",
+]);
+
+function collectNegativeLabels(value, path = []) {
+  const found = [];
+  if (Array.isArray(value)) {
+    for (let index = 0; index < value.length; index += 1) {
+      found.push(...collectNegativeLabels(value[index], [...path, String(index)]));
+    }
+    return found;
+  }
+  if (!value || typeof value !== "object") return found;
+  for (const [key, child] of Object.entries(value)) {
+    const nextPath = [...path, key];
+    if (labelKeys.has(key) && Array.isArray(child)) {
+      for (const label of child) {
+        const normalized = String(label || "").toLowerCase();
+        if (negativeLabelValues.has(normalized)) {
+          found.push({ path: nextPath.join("."), label: normalized });
+        }
+      }
+    }
+    found.push(...collectNegativeLabels(child, nextPath));
+  }
+  return found;
+}
+
+function summarizeTrace(report) {
+  const missingRuntime = numberAt(report, ["counts", "productActionsMissingRuntimeEvidence"]);
+  const residualBlockers = numberAt(report, ["counts", "destinationsWithResidualEndBarBlockers"],
+    numberAt(report, ["counts", "destinationsStillBlocked"]));
+  const runtimeEvidenceInputs = numberAt(report, ["counts", "runtimeEvidenceInputs"]);
+  const status = String(report?.status || "missing");
+  return {
+    status,
+    runtimeEvidenceInputs,
+    productActionsMissingRuntimeEvidence: missingRuntime,
+    destinationsWithResidualEndBarBlockers: residualBlockers,
+    bySurface: report?.bySurface || null,
+  };
+}
+
+const selected = selectedVisualReport();
+const trace = actionTraceabilityReport();
+const selectedReport = selected.parsed || {};
+const traceReport = trace.parsed || {};
+const traceSummary = summarizeTrace(traceReport);
+const liveIos = liveEvidenceForSurface(selectedReport, "ios");
+const liveDesktop = liveEvidenceForSurface(selectedReport, "desktop");
+const mobileModes = visualModesForSurface(selectedReport, "ios");
+const desktopModes = visualModesForSurface(selectedReport, "desktop");
+const negativeLabels = collectNegativeLabels({
+  selectedVisualEvidence: selectedReport?.evidence,
+  actionTraceabilityEvidence: traceReport?.residualEndBarEvidence,
+});
+
+if (selectedReport.status !== "selected_visual_proof_ready") {
+  block("selected_visual_proof_not_ready", selectedReport.status || "missing");
+}
+if (liveIos.length === 0) {
+  block("mobile_visual_not_live_connected", mobileModes.length > 0
+    ? `modes=${mobileModes.join(",")}`
+    : "no iOS visual evidence modes found");
+}
+if (liveDesktop.length === 0) {
+  block("desktop_visual_not_live_connected", desktopModes.length > 0
+    ? `modes=${desktopModes.join(",")}`
+    : "no desktop visual evidence modes found");
+}
+if (mobileModes.includes("offline-truth")) {
+  block("offline_truth_negative_control_present", "offline-truth is valid negative control but cannot count toward product happy path");
+}
+if (mobileModes.length > 0 && mobileModes.every((mode) => mode === "design-proof-sample")) {
+  block("design_proof_sample_only", "design-proof-sample is selected visual comparison only, not live connected product proof");
+}
+if (traceSummary.status !== "product_runtime_actions_traceable") {
+  block("product_runtime_actions_not_traceable", traceSummary.status);
+}
+if (traceSummary.runtimeEvidenceInputs === 0) {
+  block("runtime_evidence_inputs_missing", "same-run action runtime evidence is required for product happy path");
+}
+if (traceSummary.productActionsMissingRuntimeEvidence > 0) {
+  block("product_runtime_actions_missing_evidence", String(traceSummary.productActionsMissingRuntimeEvidence));
+}
+if (traceSummary.destinationsWithResidualEndBarBlockers > 0) {
+  block("residual_endbar_blockers_present", String(traceSummary.destinationsWithResidualEndBarBlockers));
+}
+if (negativeLabels.length > 0) {
+  block("negative_happy_path_labels_present", JSON.stringify(negativeLabels.slice(0, 20)));
+}
+
+if (selectedReport.status === "selected_visual_proof_ready" && (liveIos.length === 0 || liveDesktop.length === 0)) {
+  note("selected_visual_ready_but_not_product_live", "visual proof is ready, but live connected mobile+desktop evidence was not supplied");
+}
+if (traceSummary.status === "traceability_gaps_present") {
+  note("traceability_gaps_are_product_gaps", "do not report selected UI/product maturity as done until runtime evidence and residual blockers are closed");
+}
+
+const report = {
+  truth: "uiux_product_happy_path_gate_not_design_only_not_offline_not_endbar_until_runtime_closure",
+  status: blockers.length === 0 ? "product_happy_path_ready" : "product_happy_path_not_ready",
+  repoRoot,
+  designRoot,
+  inputs: {
+    selectedVisualReport: selected.source,
+    actionTraceabilityReport: trace.source,
+    evidenceDirs: evidenceDirs.map(abs),
+    runtimeEvidenceDirs: runtimeEvidenceDirs.map(abs),
+    runtimeEvidence: runtimeEvidence.map(abs),
+  },
+  selectedVisual: {
+    status: selectedReport.status || "missing",
+    mobileModes,
+    desktopModes,
+    liveConnectedMobileEvidenceCount: liveIos.length,
+    liveConnectedDesktopEvidenceCount: liveDesktop.length,
+    caveat: "Selected visual proof is necessary but insufficient; product happy path requires live connected mobile+desktop evidence, not design-proof-sample, offline-truth, or static AX-only proof.",
+  },
+  actionTraceability: traceSummary,
+  negativeHappyPathLabels: negativeLabels,
+  blockers,
+  notes,
+  caveat:
+    "This gate intentionally fails current design-only/offline/partial-runtime states. Passing it still does not prove adoption or public release; it only proves the supplied evidence is strong enough to call the selected UI a normal connected product happy path.",
+};
+
+if (outPath) {
+  const out = abs(outPath);
+  mkdirSync(dirname(out), { recursive: true });
+  writeFileSync(out, `${JSON.stringify(report, null, 2)}\n`);
+}
+
+console.log(JSON.stringify(report, null, 2));
+process.exit(requireComplete && blockers.length > 0 ? 1 : 0);

--- a/test/unit/qa/friday-uiux-product-happy-path-cli.test.ts
+++ b/test/unit/qa/friday-uiux-product-happy-path-cli.test.ts
@@ -1,0 +1,203 @@
+import { execFileSync, spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const script = "scripts/ops/check-friday-uiux-product-happy-path.mjs";
+
+function writeJson(root: string, relative: string, value: unknown) {
+  const target = join(root, relative);
+  mkdirSync(dirname(target), { recursive: true });
+  writeFileSync(target, `${JSON.stringify(value, null, 2)}\n`);
+  return target;
+}
+
+function selectedVisual(
+  mode: string,
+  extra: Record<string, unknown> = {},
+  desktopExtra: Record<string, unknown> = {},
+) {
+  return {
+    truth: "selected_uiux_visual_proof_not_static_linkage_not_action_runtime_not_endbar",
+    status: "selected_visual_proof_ready",
+    evidence: {
+      ios: [
+        {
+          status: "ready",
+          mode,
+          missingDestinations: [],
+          ...extra,
+        },
+      ],
+      desktop: [
+        {
+          status: "ready",
+          mode,
+          missingDestinations: [],
+          ...desktopExtra,
+        },
+      ],
+    },
+  };
+}
+
+function traceability(overrides: Record<string, unknown> = {}) {
+  return {
+    truth: "uiux_action_traceability_not_endbar_not_adoption_not_gui_proof",
+    status: "product_runtime_actions_traceable",
+    counts: {
+      runtimeEvidenceInputs: 2,
+      productActionsMissingRuntimeEvidence: 0,
+      destinationsWithResidualEndBarBlockers: 0,
+      destinationsStillBlocked: 0,
+    },
+    bySurface: {
+      mobile: { destinations: 1, runtimeActionIds: 1, traceGaps: 0, destinationsWithResidualEndBarBlockers: 0 },
+      desktop: { destinations: 1, runtimeActionIds: 1, traceGaps: 0, destinationsWithResidualEndBarBlockers: 0 },
+    },
+    ...overrides,
+  };
+}
+
+describe("check-friday-uiux-product-happy-path", () => {
+  it("rejects design-proof-sample as product happy path", () => {
+    const root = mkdtempSync(join(tmpdir(), "friday-happy-path-design-only-"));
+    try {
+      const visual = writeJson(root, "visual.json", selectedVisual("design-proof-sample"));
+      const trace = writeJson(root, "trace.json", traceability());
+      const result = spawnSync("node", [
+        script,
+        `--repo-root=${process.cwd()}`,
+        `--selected-visual-report=${visual}`,
+        `--action-traceability-report=${trace}`,
+        "--require-complete",
+      ], { cwd: process.cwd(), encoding: "utf8" });
+      expect(result.status).toBe(1);
+      const report = JSON.parse(result.stdout) as {
+        status?: string;
+        blockers?: Array<{ code?: string; detail?: string }>;
+      };
+      expect(report.status).toBe("product_happy_path_not_ready");
+      expect(report.blockers).toContainEqual(expect.objectContaining({
+        code: "mobile_visual_not_live_connected",
+        detail: "modes=design-proof-sample",
+      }));
+      expect(report.blockers).toContainEqual(expect.objectContaining({
+        code: "design_proof_sample_only",
+      }));
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects residual END-BAR blockers even when action evidence is attached", () => {
+    const root = mkdtempSync(join(tmpdir(), "friday-happy-path-residual-"));
+    try {
+      const visual = writeJson(root, "visual.json", selectedVisual("live-loopback"));
+      const trace = writeJson(root, "trace.json", traceability({
+        counts: {
+          runtimeEvidenceInputs: 2,
+          productActionsMissingRuntimeEvidence: 0,
+          destinationsWithResidualEndBarBlockers: 3,
+          destinationsStillBlocked: 3,
+        },
+      }));
+      const result = spawnSync("node", [
+        script,
+        `--repo-root=${process.cwd()}`,
+        `--selected-visual-report=${visual}`,
+        `--action-traceability-report=${trace}`,
+        "--require-complete",
+      ], { cwd: process.cwd(), encoding: "utf8" });
+      expect(result.status).toBe(1);
+      const report = JSON.parse(result.stdout) as { blockers?: Array<{ code?: string; detail?: string }> };
+      expect(report.blockers).toContainEqual(expect.objectContaining({
+        code: "residual_endbar_blockers_present",
+        detail: "3",
+      }));
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects negative status labels on the connected happy path", () => {
+    const root = mkdtempSync(join(tmpdir(), "friday-happy-path-negative-labels-"));
+    try {
+      const visual = writeJson(root, "visual.json", selectedVisual("live-loopback", {
+        statusLabels: ["online", "offline"],
+      }));
+      const trace = writeJson(root, "trace.json", traceability());
+      const result = spawnSync("node", [
+        script,
+        `--repo-root=${process.cwd()}`,
+        `--selected-visual-report=${visual}`,
+        `--action-traceability-report=${trace}`,
+        "--require-complete",
+      ], { cwd: process.cwd(), encoding: "utf8" });
+      expect(result.status).toBe(1);
+      const report = JSON.parse(result.stdout) as { blockers?: Array<{ code?: string }> };
+      expect(report.blockers).toContainEqual(expect.objectContaining({
+        code: "negative_happy_path_labels_present",
+      }));
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects static desktop visual proof as product happy path", () => {
+    const root = mkdtempSync(join(tmpdir(), "friday-happy-path-static-desktop-"));
+    try {
+      const visual = writeJson(root, "visual.json", selectedVisual("live-loopback", {}, {
+        mode: "static-ax",
+      }));
+      const trace = writeJson(root, "trace.json", traceability());
+      const result = spawnSync("node", [
+        script,
+        `--repo-root=${process.cwd()}`,
+        `--selected-visual-report=${visual}`,
+        `--action-traceability-report=${trace}`,
+        "--require-complete",
+      ], { cwd: process.cwd(), encoding: "utf8" });
+      expect(result.status).toBe(1);
+      const report = JSON.parse(result.stdout) as { blockers?: Array<{ code?: string; detail?: string }> };
+      expect(report.blockers).toContainEqual(expect.objectContaining({
+        code: "desktop_visual_not_live_connected",
+        detail: "modes=static-ax",
+      }));
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("passes only when visual proof is live-connected and runtime/product blockers are closed", () => {
+    const root = mkdtempSync(join(tmpdir(), "friday-happy-path-ready-"));
+    try {
+      const visual = writeJson(root, "visual.json", selectedVisual("live-loopback", {
+        statusLabels: ["online"],
+      }));
+      const trace = writeJson(root, "trace.json", traceability());
+      const out = join(root, "happy-path.json");
+      const output = execFileSync("node", [
+        script,
+        `--repo-root=${process.cwd()}`,
+        `--selected-visual-report=${visual}`,
+        `--action-traceability-report=${trace}`,
+        "--require-complete",
+        `--out=${out}`,
+      ], { cwd: process.cwd(), encoding: "utf8" });
+      const report = JSON.parse(output) as {
+        status?: string;
+        selectedVisual?: { liveConnectedMobileEvidenceCount?: number };
+        blockers?: unknown[];
+      };
+      const persisted = JSON.parse(readFileSync(out, "utf8")) as typeof report;
+      expect(report.status).toBe("product_happy_path_ready");
+      expect(report.selectedVisual?.liveConnectedMobileEvidenceCount).toBe(1);
+      expect(report.blockers).toEqual([]);
+      expect(persisted.status).toBe("product_happy_path_ready");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add `check-friday-uiux-product-happy-path.mjs`, a stricter report/gate for normal connected product happy-path evidence
- reject design-only `design-proof-sample`, `offline-truth` negative controls, static/AX-only desktop proof, missing runtime evidence, residual ProductReadinessContract blockers, and negative happy-path labels as product-ready proof
- add focused CLI tests and npm script `check:uiux-product-happy-path`

## Truth boundary
This PR does not claim END-BAR, product maturity, release, adoption, or every-button runtime closure. It prevents those claims unless supplied evidence is live-connected on both mobile and desktop, and runtime/product blockers are actually closed.

## Local verification
- `node --check scripts/ops/check-friday-uiux-product-happy-path.mjs`
- `npx vitest run test/unit/qa/friday-uiux-product-happy-path-cli.test.ts --reporter=dot` (5 tests PASS)
- `npx vitest run test/unit/qa/friday-uiux-product-happy-path-cli.test.ts test/unit/qa/friday-uiux-selected-visual-proof-cli.test.ts test/unit/qa/friday-uiux-action-traceability-cli.test.ts --reporter=dot` (13 tests PASS)
- `node scripts/ops/check-friday-uiux-product-happy-path.mjs --evidence-dir=/tmp/friday-ios-design-destination-capture-current-37d88441-20260628T1401Z --evidence-dir=/tmp/friday-desktop-ax-capture-current-37d88441-20260628T1404Z --runtime-evidence-dir=/private/tmp/friday-uiux-real-use-driver-main-28fb4b47-clean-nonchannel-20260627T141349Z/action-runtime-bundle --runtime-evidence=/tmp/friday-mobile-projection-action-evidence-current-check/action-runtime-evidence.json --require-complete --json` correctly exits 1 and reports current product happy path not ready: design-proof-only mobile, no live-connected desktop visual evidence, and 36 residual blockers
- `git diff --check`

## Current truth from fresh evidence
- Fresh mobile projection action evidence covers `petEditor`, `proofViewer`, and `entrypoints`, so product action traceability can reach 60/60 runtime action IDs with fresh inputs.
- The product happy-path gate still fails by design until mobile and desktop both have live-connected selected-design evidence and all 36 residual ProductReadinessContract blockers are cleared.
