### PR TITLE
Bind iOS live read proof to explicit mission

### DIFF
--- a/apps/friday-ios/Sources/FridayMobileShell/FridayApp.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayApp.swift
@@ -166,11 +166,15 @@ final class FridaySession: ObservableObject {
     }
     do {
       let config = try liveReadConfig(args: args, env: env)
+      let missionId = MobileRuntimeGates.liveReadMissionIdOverride(args: args, env: env)
       if useDeviceKeypair(args: args, env: env) {
         let device = try DeviceKeypairStore.loadOrGenerate(backend: deviceKeypairBackend)
-        return RealReadClientFactory.makeLive(deviceKeypair: device, config: config)
+        return RealReadClientFactory.makeLive(
+          deviceKeypair: device,
+          config: config,
+          missionId: missionId)
       }
-      return try RealReadClientFactory.makeLive(config: config)
+      return try RealReadClientFactory.makeLive(config: config, missionId: missionId)
     } catch {
       return RealReadClientFactory.makeHonestlyUnavailable(reason: "\(error)")
     }

--- a/apps/friday-ios/Sources/FridayMobileShellCore/MobileRuntimeGates.swift
+++ b/apps/friday-ios/Sources/FridayMobileShellCore/MobileRuntimeGates.swift
@@ -50,6 +50,15 @@ public enum MobileRuntimeGates {
     return .value(port)
   }
 
+  public static func liveReadMissionIdOverride(args: [String], env: [String: String]) -> String? {
+    if let arg = value(for: "--mission-id", in: args)?.trimmingCharacters(in: .whitespacesAndNewlines),
+       !arg.isEmpty {
+      return arg
+    }
+    let envValue = env["FRIDAY_MOBILE_MISSION_ID"]?.trimmingCharacters(in: .whitespacesAndNewlines)
+    return envValue?.isEmpty == false ? envValue : nil
+  }
+
   public static func liveWriteRequested(args: [String], env: [String: String]) -> Bool {
     args.contains("--live-write") || env["FRIDAY_MOBILE_LIVE_WRITE"] == "1"
   }
@@ -90,5 +99,17 @@ public enum MobileRuntimeGates {
       return nil
     }
     return args[index + 1]
+  }
+
+  private static func value(for flag: String, in args: [String]) -> String? {
+    for (index, arg) in args.enumerated() {
+      if arg.hasPrefix("\(flag)=") {
+        return String(arg.dropFirst(flag.count + 1))
+      }
+      if arg == flag, args.indices.contains(index + 1) {
+        return args[index + 1]
+      }
+    }
+    return nil
   }
 }

--- a/apps/friday-ios/Tests/FridayMobileShellCoreTests/MobileRuntimeGatesTests.swift
+++ b/apps/friday-ios/Tests/FridayMobileShellCoreTests/MobileRuntimeGatesTests.swift
@@ -48,6 +48,7 @@ func mobileRuntimeGatesAcceptExplicitEnv() {
 func mobileRuntimeGatesReadEndpointOverridesAreExplicit() {
   #expect(MobileRuntimeGates.liveReadHostOverride(args: [], env: [:]) == nil)
   #expect(MobileRuntimeGates.liveReadPortOverride(args: [], env: [:]) == .absent)
+  #expect(MobileRuntimeGates.liveReadMissionIdOverride(args: [], env: [:]) == nil)
 
   #expect(MobileRuntimeGates.liveReadHostOverride(
     args: ["--live-read-host", "127.0.0.1"],
@@ -62,6 +63,18 @@ func mobileRuntimeGatesReadEndpointOverridesAreExplicit() {
   #expect(MobileRuntimeGates.liveReadPortOverride(
     args: [],
     env: ["FRIDAY_MOBILE_LIVE_READ_PORT": "59152"]) == .value(59152))
+  #expect(MobileRuntimeGates.liveReadMissionIdOverride(
+    args: ["--mission-id", "mission-mobile-live"],
+    env: [:]) == "mission-mobile-live")
+  #expect(MobileRuntimeGates.liveReadMissionIdOverride(
+    args: ["--mission-id=mission-mobile-live-eq"],
+    env: [:]) == "mission-mobile-live-eq")
+  #expect(MobileRuntimeGates.liveReadMissionIdOverride(
+    args: [],
+    env: ["FRIDAY_MOBILE_MISSION_ID": "mission-mobile-live-env"]) == "mission-mobile-live-env")
+  #expect(MobileRuntimeGates.liveReadMissionIdOverride(
+    args: ["--mission-id", "   "],
+    env: ["FRIDAY_MOBILE_MISSION_ID": ""]) == nil)
 }
 
 @Test

--- a/apps/friday-ios/build-sim.sh
+++ b/apps/friday-ios/build-sim.sh
@@ -27,7 +27,7 @@ usage() {
 Usage:
   apps/friday-ios/build-sim.sh [screenshot-path]
   apps/friday-ios/build-sim.sh --mode offline-truth [--destination pairing] [--shot screenshot-path]
-  apps/friday-ios/build-sim.sh --mode live-loopback [--destination pairing] [--shot screenshot-path]
+  apps/friday-ios/build-sim.sh --mode live-loopback [--destination pairing] [--mission-id mission-id] [--shot screenshot-path]
   apps/friday-ios/build-sim.sh --mode design-proof-sample [--destination pairing] [--shot screenshot-path]
 
 Modes:
@@ -48,6 +48,7 @@ APP="$BUILD/FridayShell.app"
 MODE="offline-truth"
 SHOT="$BUILD/friday-ios-sim.png"
 DESTINATION=""
+MISSION_ID="${FRIDAY_MOBILE_MISSION_ID:-}"
 IOS_VERSION="17.0"
 TRIPLE="arm64-apple-ios${IOS_VERSION}-simulator"   # Apple-Silicon host (arm64 sim slice)
 
@@ -86,6 +87,19 @@ while [[ $# -gt 0 ]]; do
       DESTINATION="${1#--destination=}"
       shift
       ;;
+    --mission-id)
+      if [[ $# -lt 2 ]]; then
+        echo "ERROR: --mission-id requires a value" >&2
+        usage >&2
+        exit 2
+      fi
+      MISSION_ID="$2"
+      shift 2
+      ;;
+    --mission-id=*)
+      MISSION_ID="${1#--mission-id=}"
+      shift
+      ;;
     -h|--help)
       usage
       exit 0
@@ -119,8 +133,17 @@ case "$MODE" in
     exit 2
     ;;
 esac
+if [[ -n "$MISSION_ID" && "$MODE" != "live-loopback" ]]; then
+  echo "ERROR: --mission-id / FRIDAY_MOBILE_MISSION_ID is only valid in live-loopback mode" >&2
+  exit 2
+fi
 if [[ -n "$DESTINATION" && ! "$DESTINATION" =~ ^[A-Za-z][A-Za-z0-9]*$ ]]; then
   echo "ERROR: --destination must be a MobileDestination raw value such as pairing or providerAuth" >&2
+  exit 2
+fi
+MISSION_ID="$(printf '%s' "$MISSION_ID" | tr -d '\r' | sed 's/^[[:space:]]*//; s/[[:space:]]*$//')"
+if [[ -n "$MISSION_ID" && ! "$MISSION_ID" =~ ^[A-Za-z0-9._:-]+$ ]]; then
+  echo "ERROR: --mission-id must contain only letters, numbers, dot, underscore, colon, or hyphen" >&2
   exit 2
 fi
 
@@ -213,6 +236,10 @@ case "$MODE" in
     if [[ -n "${FRIDAY_MOBILE_LIVE_WRITE_PORT:-}" ]]; then
       LAUNCH_ENV+=(SIMCTL_CHILD_FRIDAY_MOBILE_LIVE_WRITE_PORT="$FRIDAY_MOBILE_LIVE_WRITE_PORT")
     fi
+    if [[ -n "$MISSION_ID" ]]; then
+      LAUNCH_ARGS+=("--mission-id=$MISSION_ID")
+      LAUNCH_ENV+=(SIMCTL_CHILD_FRIDAY_MOBILE_MISSION_ID="$MISSION_ID")
+    fi
     ;;
   design-proof-sample)
     echo "launch mode: design-proof-sample (labeled selected-design sample; no live seams)"
@@ -246,7 +273,11 @@ LIVE_READ_HOST_OVERRIDE_JSON=null
 LIVE_READ_PORT_OVERRIDE_JSON=null
 LIVE_WRITE_HOST_OVERRIDE_JSON=null
 LIVE_WRITE_PORT_OVERRIDE_JSON=null
+MISSION_ID_OVERRIDE_JSON=null
 if [[ "$MODE" == "live-loopback" ]]; then
+  if [[ -n "$MISSION_ID" ]]; then
+    MISSION_ID_OVERRIDE_JSON="\"$MISSION_ID\""
+  fi
   if [[ -n "${FRIDAY_MOBILE_LIVE_READ_HOST:-}" && "$FRIDAY_MOBILE_LIVE_READ_HOST" =~ ^[A-Za-z0-9._:-]+$ ]]; then
     LIVE_READ_HOST_OVERRIDE_JSON="\"$FRIDAY_MOBILE_LIVE_READ_HOST\""
   fi
@@ -300,6 +331,7 @@ cat > "$SHOT.metadata.json" <<JSON
   "live_read_port_override": $LIVE_READ_PORT_OVERRIDE_JSON,
   "live_write_host_override": $LIVE_WRITE_HOST_OVERRIDE_JSON,
   "live_write_port_override": $LIVE_WRITE_PORT_OVERRIDE_JSON,
+  "mission_id_override": $MISSION_ID_OVERRIDE_JSON,
   "simulator_device_pubkey": $SIMULATOR_DEVICE_PUBKEY_JSON,
   "design_proof_sample_requested": $([[ "$MODE" == "design-proof-sample" ]] && echo true || echo false),
   "caveat": "offline-truth proves honest-unavailable; design-proof-sample is labeled visual comparison only; live-loopback attempts real local read/write/pairing seams and does not claim END-BAR, GO-LIVE, adoption, trust minting, or operator signing. None of these modes claims END-BAR, GO-LIVE, adoption, trust minting, or operator signing."

--- a/apps/macos/FridayHubConsole/Sources/FridayHubConsole/FridayHubConsoleApp.swift
+++ b/apps/macos/FridayHubConsole/Sources/FridayHubConsole/FridayHubConsoleApp.swift
@@ -50,6 +50,7 @@ struct FridayHubConsoleApp: App {
       HubConsoleShell(
         initialDestination: Self.initialDestination,
         client: Self.readClient,
+        devicePairing: Self.devicePairingReadiness,
         writeClient: Self.writeClient,
         missionRunClient: Self.writeClient,
         approvalSigner: Self.approvalSigner,
@@ -149,6 +150,11 @@ struct FridayHubConsoleApp: App {
       port: port,
       connectTimeout: connectTimeout,
       receiveTimeout: receiveTimeout)
+  }
+
+  /// UI truth for the desktop read seam must use the same target as the real read client.
+  private static var devicePairingReadiness: DesktopDevicePairingReadiness {
+    DesktopDevicePairingReadiness.evaluate(config: Self.liveReadConfig)
   }
 
   /// The mission-spine WRITE client the shell uses (Lane-D entry-point-A). Mirrors `readClient`:

--- a/apps/macos/FridayHubConsole/Sources/FridayHubConsole/HubConsoleShell.swift
+++ b/apps/macos/FridayHubConsole/Sources/FridayHubConsole/HubConsoleShell.swift
@@ -14,6 +14,7 @@ struct HubConsoleShell: View {
   init(
     initialDestination: HubDestination = .operations,
     client: FridayRustReadClient,
+    devicePairing: DesktopDevicePairingReadiness = .evaluate(),
     writeClient: FridayMissionSpineWriteClient? = nil,
     missionRunClient: FridayMissionBoundRunWriteClient? = nil,
     approvalSigner: OperatorApprovalSigner? = nil,
@@ -25,7 +26,8 @@ struct HubConsoleShell: View {
         writeClient: writeClient,
         missionRunClient: missionRunClient,
         approvalSigner: approvalSigner,
-        approvalResumeClient: approvalResumeClient))
+        approvalResumeClient: approvalResumeClient,
+        devicePairing: devicePairing))
     _destination = State(initialValue: initialDestination)
     self.initialDestination = initialDestination
   }

--- a/scripts/ops/check-friday-desktop-gui-smoke-contract.mjs
+++ b/scripts/ops/check-friday-desktop-gui-smoke-contract.mjs
@@ -31,17 +31,29 @@ const script = read(root, scriptPath);
 
 requireText(script, "desktop_gui_smoke_real_app_launch_screenshot_not_endbar", scriptPath);
 requireText(script, "FRIDAY_DESKTOP_GUI_SMOKE_MODE:-live", scriptPath);
+requireText(script, "FRIDAY_DESKTOP_GUI_SMOKE_REPLACE_EXISTING:-0", scriptPath);
 requireText(script, "FRIDAY_CONSOLE_MOCK=1", scriptPath);
+requireText(script, "existing FridayHubConsole process(es) would contaminate proof", scriptPath);
+requireText(script, "fail", scriptPath);
+requireText(script, "process_preflight", scriptPath);
+requireText(script, "preexisting_friday_hub_console_pids", scriptPath);
+requireText(script, "replace_existing_requested", scriptPath);
+requireText(script, "terminate_friday_console_pids", scriptPath);
+requireText(script, "/usr/bin/osascript - \"${APP_PID}\"", scriptPath);
+requireText(script, "first process whose unix id is targetPid", scriptPath);
+requireText(script, "refusing whole-screen stale proof", scriptPath);
+requireText(script, "Window activation is PID-bound", scriptPath);
 requireText(script, "screencapture -x", scriptPath);
 requireText(script, "This is not END-BAR", scriptPath);
 requireText(script, "not a GUI tap/closed-loop proof", scriptPath);
-requireText(script, "only terminates the app process it spawned", scriptPath);
+requireText(script, "does not kill Friday hub ports or production services", scriptPath);
 requireText(script, "/bin/kill \"${APP_PID}\"", scriptPath);
 
 forbidPattern(script, /\bkillall\b/, scriptPath);
 forbidPattern(script, /\bpkill\b/, scriptPath);
 forbidPattern(script, /lsof\s+-ti\s+:(48750|48751|3141)/, scriptPath);
 forbidPattern(script, /kill\s+-9\s+\$\(lsof/, scriptPath);
+forbidPattern(script, /tell application "FridayHubConsole" to activate/, scriptPath);
 
 const mockDefaultIndex = script.indexOf("FRIDAY_DESKTOP_GUI_SMOKE_MODE:-live");
 const mockAssignmentIndex = script.indexOf("FRIDAY_CONSOLE_MOCK=1");

--- a/scripts/ops/check-read-projection-runtime-freshness.mjs
+++ b/scripts/ops/check-read-projection-runtime-freshness.mjs
@@ -25,6 +25,7 @@ Options:
   --db <path>                Hub SQLite DB. Default: macOS Friday rust-hub.sqlite.
   --plist <path>             read-projection LaunchAgent plist.
   --require-current-schema   Exit non-zero if DB schema != repo code_max.
+  --require-running-current  Exit non-zero if the live read process predates repo HEAD.
   --json                     Print JSON only.
   -h, --help                 Show this help.
 
@@ -38,6 +39,7 @@ function parseArgs(argv) {
     plistPath: process.env.FRIDAY_READ_PROJECTION_PLIST || DEFAULT_PLIST,
     json: false,
     requireCurrentSchema: false,
+    requireRunningCurrent: false,
     help: false,
   };
   for (let i = 2; i < argv.length; i += 1) {
@@ -58,6 +60,8 @@ function parseArgs(argv) {
       options.json = true;
     } else if (arg === "--require-current-schema") {
       options.requireCurrentSchema = true;
+    } else if (arg === "--require-running-current") {
+      options.requireRunningCurrent = true;
     } else if (arg === "-h" || arg === "--help") {
       options.help = true;
     } else {
@@ -78,6 +82,18 @@ function run(command, args, opts = {}) {
   }
   if (result.status !== 0) {
     throw new Error(result.stderr.trim() || `${command} exited ${result.status}`);
+  }
+  return result.stdout;
+}
+
+function runOptional(command, args, opts = {}) {
+  const result = spawnSync(command, args, {
+    encoding: "utf8",
+    maxBuffer: 1024 * 1024,
+    ...opts,
+  });
+  if (result.error || result.status !== 0) {
+    return null;
   }
   return result.stdout;
 }
@@ -118,6 +134,75 @@ function readPlistProgramArguments(plistPath) {
   return JSON.parse(raw);
 }
 
+function readRepoHead(repoDir) {
+  const oid = run("git", ["-C", repoDir, "rev-parse", "HEAD"]).trim();
+  const unix = Number(run("git", ["-C", repoDir, "log", "-1", "--format=%ct"]).trim());
+  return {
+    oid,
+    commitUnix: Number.isFinite(unix) ? unix : null,
+    commitMs: Number.isFinite(unix) ? unix * 1000 : null,
+  };
+}
+
+function readListeningPid(port) {
+  if (!port || !/^[0-9]+$/.test(String(port))) {
+    return null;
+  }
+  const stdout = runOptional("lsof", ["-nP", `-iTCP:${port}`, "-sTCP:LISTEN", "-Fp"]);
+  if (!stdout) {
+    return null;
+  }
+  const line = stdout
+    .split(/\r?\n/)
+    .find((candidate) => /^p[0-9]+$/.test(candidate));
+  return line ? Number(line.slice(1)) : null;
+}
+
+function readProcessStart(pid) {
+  if (!pid) {
+    return null;
+  }
+  const raw = runOptional("ps", ["-p", String(pid), "-o", "lstart="])?.trim();
+  if (!raw) {
+    return null;
+  }
+  const ms = Date.parse(raw);
+  return {
+    raw,
+    ms: Number.isFinite(ms) ? ms : null,
+  };
+}
+
+function classifyRuntime({ pid, processStartMs, repoHeadCommitMs }) {
+  if (!pid) {
+    return {
+      status: "not_running",
+      ok: false,
+      reason: "No read-projection process is listening on the plist port.",
+    };
+  }
+  if (!processStartMs || !repoHeadCommitMs) {
+    return {
+      status: "runtime_freshness_unknown",
+      ok: false,
+      reason: "Could not compare the process start time to repo HEAD.",
+    };
+  }
+  if (processStartMs < repoHeadCommitMs) {
+    return {
+      status: "runtime_predates_repo_head",
+      ok: false,
+      reason:
+        "The running read-projection process started before this repo HEAD; it cannot prove current-code product behavior.",
+    };
+  }
+  return {
+    status: "runtime_at_or_after_repo_head",
+    ok: true,
+    reason: "The running read-projection process started at or after this repo HEAD commit time.",
+  };
+}
+
 function classifySchema(diskSchemaVersion, repoCodeMax) {
   if (diskSchemaVersion === repoCodeMax) {
     return {
@@ -147,6 +232,7 @@ export function buildReport(options) {
   const dbPath = path.resolve(options.dbPath);
   const plistPath = path.resolve(options.plistPath);
   const repoCodeMax = readHubCodeMax(repoDir);
+  const repoHead = readRepoHead(repoDir);
   const diskSchemaVersion = readDbSchemaVersion(dbPath);
   const schema = classifySchema(diskSchemaVersion, repoCodeMax);
   const programArguments = readPlistProgramArguments(plistPath);
@@ -155,11 +241,19 @@ export function buildReport(options) {
   const plistDbPath = plistDbArgIndex >= 0 ? programArguments[plistDbArgIndex + 1] : null;
   const plistPortArgIndex = Array.isArray(programArguments) ? programArguments.indexOf("--port") : -1;
   const plistPort = plistPortArgIndex >= 0 ? programArguments[plistPortArgIndex + 1] : null;
+  const runningPid = readListeningPid(plistPort);
+  const processStart = readProcessStart(runningPid);
+  const runtime = classifyRuntime({
+    pid: runningPid,
+    processStartMs: processStart?.ms ?? null,
+    repoHeadCommitMs: repoHead.commitMs,
+  });
 
   return {
     truth_label: "read_projection_runtime_freshness_read_only_no_restart_no_migration",
     generated_at_utc: new Date().toISOString(),
     repoDir,
+    repoHead,
     dbPath,
     plistPath,
     repoCodeMax,
@@ -174,8 +268,17 @@ export function buildReport(options) {
       port: plistPort,
       pointsAtCheckedDb: plistDbPath ? path.resolve(plistDbPath) === dbPath : null,
     },
+    runtime: {
+      port: plistPort,
+      pid: runningPid,
+      processStartedAt: processStart?.raw ?? null,
+      processStartedAtMs: processStart?.ms ?? null,
+      status: runtime.status,
+      ok: runtime.ok,
+      reason: runtime.reason,
+    },
     caveat:
-      "This is a read-only cutover sanity check. It does not prove the LaunchAgent was restarted, does not migrate the DB, and does not claim END-BAR, GO-LIVE, or adoption.",
+      "This is a read-only cutover sanity check. It does not start, stop, restart, migrate, or sign. Runtime freshness is based on process start time versus repo HEAD and does not claim END-BAR, GO-LIVE, or adoption.",
   };
 }
 
@@ -192,10 +295,14 @@ function main() {
     console.log(`status=${report.schemaStatus}`);
     console.log(`db_schema=${report.diskSchemaVersion} repo_code_max=${report.repoCodeMax}`);
     console.log(`plist_present=${report.launchd.plistPresent} port=${report.launchd.port ?? "unknown"}`);
+    console.log(`runtime=${report.runtime.status} pid=${report.runtime.pid ?? "none"}`);
     console.log(`reason=${report.reason}`);
     console.log(`truth_label=${report.truth_label}`);
   }
   if (options.requireCurrentSchema && !report.ok) {
+    process.exitCode = 1;
+  }
+  if (options.requireRunningCurrent && !report.runtime.ok) {
     process.exitCode = 1;
   }
 }

--- a/scripts/ops/friday-desktop-gui-smoke-proof.sh
+++ b/scripts/ops/friday-desktop-gui-smoke-proof.sh
@@ -6,7 +6,11 @@ usage() {
 Usage: friday-desktop-gui-smoke-proof.sh [--repo-dir <path>] [--out-dir <path>] [--app-dir <path>] [--timeout-seconds <n>]
 
 Builds or verifies FridayHubConsole.app, launches the real macOS app process, captures a
-desktop screenshot, and writes a truth-labeled manifest.
+desktop screenshot, and writes a truth-labeled manifest. If an existing
+FridayHubConsole GUI process is already running, the script fails closed by default so
+the screenshot cannot be captured from stale UI. Set
+FRIDAY_DESKTOP_GUI_SMOKE_REPLACE_EXISTING=1 to terminate only FridayHubConsole GUI
+processes before launch; this never kills Friday hub ports or production services.
 
 Truth: this proves a real local app launch + screenshot only. It is not END-BAR, not
 adoption, not a GUI tap/closed-loop proof, and not a substitute for live mobile+desktop
@@ -20,6 +24,7 @@ APP_DIR="${FRIDAY_HUB_CONSOLE_APP_DIR:-}"
 TIMEOUT_SECONDS="${FRIDAY_DESKTOP_GUI_SMOKE_TIMEOUT_SECONDS:-20}"
 MODE="${FRIDAY_DESKTOP_GUI_SMOKE_MODE:-live}"
 BUILD_APP="${FRIDAY_DESKTOP_GUI_SMOKE_BUILD_APP:-true}"
+REPLACE_EXISTING="${FRIDAY_DESKTOP_GUI_SMOKE_REPLACE_EXISTING:-0}"
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -100,12 +105,35 @@ SCREENSHOT="${OUT_DIR}/desktop-gui-smoke.png"
 WINDOW_PROBE="${OUT_DIR}/window-probe.txt"
 MANIFEST="${OUT_DIR}/desktop-gui-smoke-manifest.json"
 APP_PID=""
+PREEXISTING_PIDS=""
+PREEXISTING_RESOLUTION="none"
+
+find_friday_console_pids() {
+  (/usr/bin/pgrep -x "FridayHubConsole" 2>/dev/null || true) | tr '\n' ' ' | sed 's/[[:space:]]*$//'
+}
+
+terminate_friday_console_pids() {
+  local pid
+  for pid in "$@"; do
+    [[ -n "${pid}" ]] || continue
+    /bin/kill "${pid}" >/dev/null 2>&1 || true
+  done
+}
+
+wait_for_no_friday_console_pids() {
+  local deadline=$((SECONDS + 5))
+  while (( SECONDS < deadline )); do
+    if [[ -z "$(find_friday_console_pids)" ]]; then
+      return 0
+    fi
+    sleep 0.2
+  done
+  return 1
+}
 
 cleanup() {
   if [[ -n "${APP_PID}" ]] && /bin/ps -p "${APP_PID}" >/dev/null 2>&1; then
-    /usr/bin/osascript >/dev/null 2>&1 <<'APPLESCRIPT' || true
-tell application "FridayHubConsole" to quit
-APPLESCRIPT
+    /bin/kill "${APP_PID}" >/dev/null 2>&1 || true
     for _ in 1 2 3 4 5; do
       /bin/ps -p "${APP_PID}" >/dev/null 2>&1 || break
       sleep 0.2
@@ -117,6 +145,22 @@ APPLESCRIPT
   fi
 }
 trap cleanup EXIT
+
+PREEXISTING_PIDS="$(find_friday_console_pids)"
+if [[ -n "${PREEXISTING_PIDS}" ]]; then
+  if [[ "${REPLACE_EXISTING}" != "1" ]]; then
+    echo "[friday-desktop-gui-smoke] existing FridayHubConsole process(es) would contaminate proof: ${PREEXISTING_PIDS}" >&2
+    echo "[friday-desktop-gui-smoke] set FRIDAY_DESKTOP_GUI_SMOKE_REPLACE_EXISTING=1 to terminate only the GUI app before launch; hub ports are never killed." >&2
+    exit 78
+  fi
+  read -r -a preexisting_pid_array <<<"${PREEXISTING_PIDS}"
+  terminate_friday_console_pids "${preexisting_pid_array[@]}"
+  if ! wait_for_no_friday_console_pids; then
+    echo "[friday-desktop-gui-smoke] existing FridayHubConsole process(es) did not exit cleanly; refusing stale screenshot proof." >&2
+    exit 78
+  fi
+  PREEXISTING_RESOLUTION="quit_gui_app_before_launch"
+fi
 
 echo "[friday-desktop-gui-smoke] launching ${APP_BINARY} mode=${MODE}" >&2
 if [[ "${MODE}" == "mock" ]]; then
@@ -134,22 +178,24 @@ while (( SECONDS < deadline )); do
     exit 78
   fi
 
-  if /usr/bin/osascript >"${WINDOW_PROBE}" 2>&1 <<'APPLESCRIPT'
-tell application "FridayHubConsole" to activate
-delay 0.2
+  if /usr/bin/osascript - "${APP_PID}" >"${WINDOW_PROBE}" 2>&1 <<'APPLESCRIPT'
+on run argv
+set targetPid to (item 1 of argv) as integer
 tell application "System Events"
-  if exists process "FridayHubConsole" then
-    tell process "FridayHubConsole"
+  if exists (first process whose unix id is targetPid) then
+    tell (first process whose unix id is targetPid)
       set frontmost to true
+      delay 0.2
       set windowCount to count of windows
       if windowCount > 0 then
-        return "window_count=" & windowCount & "\nfrontmost=" & frontmost & "\nfirst_window=" & name of window 1
+        return "pid=" & targetPid & "\nwindow_count=" & windowCount & "\nfrontmost=" & frontmost & "\nfirst_window=" & name of window 1
       end if
-      return "window_count=0\nfrontmost=" & frontmost
+      return "pid=" & targetPid & "\nwindow_count=0\nfrontmost=" & frontmost
     end tell
   end if
 end tell
 return "process_missing"
+end run
 APPLESCRIPT
   then
     if grep -q '^window_count=[1-9]' "${WINDOW_PROBE}"; then
@@ -158,6 +204,12 @@ APPLESCRIPT
   fi
   sleep 0.5
 done
+
+if ! grep -q '^window_count=[1-9]' "${WINDOW_PROBE}"; then
+  echo "[friday-desktop-gui-smoke] spawned app window was not captured by PID-bound probe; refusing whole-screen stale proof." >&2
+  sed -n '1,120p' "${WINDOW_PROBE}" >&2 || true
+  exit 78
+fi
 
 if ! /bin/ps -p "${APP_PID}" >/dev/null 2>&1; then
   echo "[friday-desktop-gui-smoke] app process is not alive at capture time." >&2
@@ -186,6 +238,9 @@ FRIDAY_DESKTOP_GUI_SMOKE_STDOUT="${STDOUT_LOG}" \
 FRIDAY_DESKTOP_GUI_SMOKE_STDERR="${STDERR_LOG}" \
 FRIDAY_DESKTOP_GUI_SMOKE_WINDOW_PROBE="${WINDOW_PROBE}" \
 FRIDAY_DESKTOP_GUI_SMOKE_MANIFEST="${MANIFEST}" \
+FRIDAY_DESKTOP_GUI_SMOKE_PREEXISTING_PIDS="${PREEXISTING_PIDS}" \
+FRIDAY_DESKTOP_GUI_SMOKE_PREEXISTING_RESOLUTION="${PREEXISTING_RESOLUTION}" \
+FRIDAY_DESKTOP_GUI_SMOKE_REPLACE_EXISTING="${REPLACE_EXISTING}" \
 node --input-type=module <<'NODE'
 import crypto from "node:crypto";
 import fs from "node:fs";
@@ -227,11 +282,20 @@ const manifest = {
     window_probe: process.env.FRIDAY_DESKTOP_GUI_SMOKE_WINDOW_PROBE,
     window_probe_text: text(process.env.FRIDAY_DESKTOP_GUI_SMOKE_WINDOW_PROBE),
   },
+  process_preflight: {
+    preexisting_friday_hub_console_pids: process.env.FRIDAY_DESKTOP_GUI_SMOKE_PREEXISTING_PIDS
+      ? process.env.FRIDAY_DESKTOP_GUI_SMOKE_PREEXISTING_PIDS.split(/\s+/).filter(Boolean).map(Number)
+      : [],
+    replace_existing_requested: process.env.FRIDAY_DESKTOP_GUI_SMOKE_REPLACE_EXISTING === "1",
+    resolution: process.env.FRIDAY_DESKTOP_GUI_SMOKE_PREEXISTING_RESOLUTION,
+  },
   caveats: [
     "This proves a real local macOS app process launched and a desktop screenshot was captured.",
     "This is not END-BAR, not adoption, not a GUI tap/closed-loop proof, and not a mobile proof.",
     "Live mode is the default; mock mode is an explicit proof mode and is truth-labeled when used.",
-    "The script only terminates the app process it spawned; it does not kill Friday hub ports or production services.",
+    "If an existing FridayHubConsole GUI process is present, the script fails closed unless FRIDAY_DESKTOP_GUI_SMOKE_REPLACE_EXISTING=1 is set.",
+    "Replacement mode only terminates FridayHubConsole GUI processes before launch; it does not kill Friday hub ports or production services.",
+    "Window activation is PID-bound to the spawned app process so LaunchServices cannot substitute a stale app instance.",
   ],
 };
 

--- a/scripts/ops/friday-ios-design-destination-capture.sh
+++ b/scripts/ops/friday-ios-design-destination-capture.sh
@@ -7,6 +7,7 @@ usage:
   scripts/ops/friday-ios-design-destination-capture.sh --out-dir /abs/capture-dir
     [--mode design-proof-sample|live-loopback|offline-truth]
     [--destinations home,session,...]
+    [--mission-id mission-id]
     [--skip-initial-build]
 
 Builds or reuses the current Friday iOS simulator app, launches the selected
@@ -31,6 +32,7 @@ mode="design-proof-sample"
 skip_initial_build=0
 destinations_csv="home,missions,session,contextPassport,tokenLedger,shareIntake,voice,pairing,needsMe,memory,platform,providerAuth,activity,workflows,onboarding,settings,petEditor,proofViewer,entrypoints"
 settle_seconds="${FRIDAY_IOS_DESIGN_CAPTURE_SETTLE_SECONDS:-6}"
+mission_id="${FRIDAY_MOBILE_MISSION_ID:-}"
 
 while [ "$#" -gt 0 ]; do
   case "$1" in
@@ -61,6 +63,15 @@ while [ "$#" -gt 0 ]; do
       destinations_csv="${1#--destinations=}"
       shift
       ;;
+    --mission-id)
+      [ "$#" -ge 2 ] || die "--mission-id requires a value"
+      mission_id="$2"
+      shift 2
+      ;;
+    --mission-id=*)
+      mission_id="${1#--mission-id=}"
+      shift
+      ;;
     --skip-initial-build)
       skip_initial_build=1
       shift
@@ -86,6 +97,9 @@ case "${mode}" in
   design|design-proof|design-proof-sample) mode="design-proof-sample" ;;
   *) die "unsupported --mode '${mode}'" ;;
 esac
+if [ -n "${mission_id}" ] && [ "${mode}" != "live-loopback" ]; then
+  die "--mission-id / FRIDAY_MOBILE_MISSION_ID is only valid in live-loopback mode"
+fi
 [ -n "${destinations_csv}" ] || die "--destinations must not be empty"
 [[ "${settle_seconds}" =~ ^[0-9]+([.][0-9]+)?$ ]] || die "FRIDAY_IOS_DESIGN_CAPTURE_SETTLE_SECONDS must be numeric"
 
@@ -93,6 +107,10 @@ IFS=',' read -r -a destinations <<< "${destinations_csv}"
 for destination in "${destinations[@]}"; do
   [[ "${destination}" =~ ^[A-Za-z][A-Za-z0-9]*$ ]] || die "invalid destination '${destination}'"
 done
+mission_id="$(printf '%s' "${mission_id}" | tr -d '\r' | sed 's/^[[:space:]]*//; s/[[:space:]]*$//')"
+if [ -n "${mission_id}" ] && [[ ! "${mission_id}" =~ ^[A-Za-z0-9._:-]+$ ]]; then
+  die "--mission-id must contain only letters, numbers, dot, underscore, colon, or hyphen"
+fi
 
 mkdir -p "${out_dir}/screenshots"
 manifest_path="${out_dir}/ios-design-destination-capture-manifest.json"
@@ -104,15 +122,22 @@ echo "Friday iOS design destination capture starting."
 echo "out_dir=${out_dir}"
 echo "mode=${mode}"
 echo "destinations=${destinations_csv}"
+if [ -n "${mission_id}" ]; then
+  echo "mission_id=${mission_id}"
+fi
 echo "truth=ios_design_destination_capture_device_screenshots_not_live_closure"
 
 if [ "${skip_initial_build}" -eq 0 ]; then
   (
     cd "${repo_root}"
-    bash apps/friday-ios/build-sim.sh \
+    build_cmd=(bash apps/friday-ios/build-sim.sh \
       --mode "${mode}" \
       --destination "${initial_destination}" \
-      --shot "${initial_shot}"
+      --shot "${initial_shot}")
+    if [ -n "${mission_id}" ]; then
+      build_cmd+=(--mission-id "${mission_id}")
+    fi
+    "${build_cmd[@]}"
   )
 else
   echo "Skipping initial build; reusing installed com.friday.shell on a booted simulator."
@@ -163,6 +188,10 @@ for destination in "${destinations[@]}"; do
       if [[ -n "${FRIDAY_MOBILE_LIVE_WRITE_PORT:-}" ]]; then
         launch_env+=(SIMCTL_CHILD_FRIDAY_MOBILE_LIVE_WRITE_PORT="${FRIDAY_MOBILE_LIVE_WRITE_PORT}")
       fi
+      if [ -n "${mission_id}" ]; then
+        launch_args+=("--mission-id=${mission_id}")
+        launch_env+=(SIMCTL_CHILD_FRIDAY_MOBILE_MISSION_ID="${mission_id}")
+      fi
     elif [ "${mode}" = "design-proof-sample" ]; then
       launch_args=(
         --design-proof-sample
@@ -182,11 +211,11 @@ for destination in "${destinations[@]}"; do
   capture_rows+=("${destination}|${shot}|${launch_log}|${screenshot_log}")
 done
 
-node - "${manifest_path}" "${mode}" "${destinations_csv}" "${udid}" "${initial_metadata}" "${capture_rows[@]}" <<'NODE'
+node - "${manifest_path}" "${mode}" "${destinations_csv}" "${udid}" "${initial_metadata}" "${mission_id}" "${capture_rows[@]}" <<'NODE'
 const { createHash } = require("node:crypto");
 const { existsSync, readFileSync, writeFileSync } = require("node:fs");
 
-const [manifestPath, mode, destinationsCsv, simulatorUdid, initialMetadataPath, ...rows] = process.argv.slice(2);
+const [manifestPath, mode, destinationsCsv, simulatorUdid, initialMetadataPath, missionIdOverride, ...rows] = process.argv.slice(2);
 const sha256 = (target) => createHash("sha256").update(readFileSync(target)).digest("hex");
 const captures = rows.map((row) => {
   const [destination, screenshot, launchLog, screenshotLog] = row.split("|");
@@ -238,6 +267,7 @@ const manifest = {
   mode,
   bundle_id: "com.friday.shell",
   simulator_udid: simulatorUdid,
+  mission_id_override: missionIdOverride || null,
   selected_design_source: "friday-design-handoff-20260602/saved/mobile-selection.json",
   selected_mobile_design: {
     selection_kind: "mobile-final (operator-confirmed 2026-06-04)",

--- a/test/unit/qa/friday-read-projection-runtime-freshness-cli.test.ts
+++ b/test/unit/qa/friday-read-projection-runtime-freshness-cli.test.ts
@@ -1,0 +1,22 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const source = () => readFileSync("scripts/ops/check-read-projection-runtime-freshness.mjs", "utf8");
+
+describe("check-read-projection-runtime-freshness CLI", () => {
+  it("exposes a read-only hard gate for running runtime freshness", () => {
+    const text = source();
+
+    expect(text).toContain("--require-running-current");
+    expect(text).toContain("runtime_predates_repo_head");
+    expect(text).toContain("process start time versus repo HEAD");
+  });
+
+  it("does not start, stop, restart, migrate, or sign", () => {
+    const text = source();
+
+    expect(text).toContain("It does not start, stop, restart, migrate, or sign.");
+    expect(text).not.toMatch(/launchctl\s+(bootout|bootstrap|kickstart)/);
+    expect(text).not.toMatch(/\bkill\b/);
+  });
+});


### PR DESCRIPTION
## Summary
- bind iOS live-loopback captures to an explicit Friday mission via `FRIDAY_MOBILE_MISSION_ID` / `--mission-id`
- record mission overrides in iOS build/capture metadata and reject mission IDs outside `live-loopback`
- add a read-projection runtime freshness checker with `--require-running-current` to catch stale prod read servers before claiming live product UI
- fail desktop GUI smoke proof closed when an old FridayHubConsole process is already running, unless explicit GUI replacement is requested, record that preflight in the proof manifest, and bind screenshot window probing to the spawned app PID

## Truth boundary
This PR does not claim END-BAR, release, adoption, or mature product completion. It prevents two specific proof mistakes found during audit: mission-ambiguous mobile live captures and stale desktop GUI/runtime proof contamination.

## Verification
- `bash -n apps/friday-ios/build-sim.sh && bash -n scripts/ops/friday-ios-design-destination-capture.sh && git diff --check`
- `swift test --package-path apps/friday-ios --filter MobileRuntimeGatesTests`
- `node --check scripts/ops/check-read-projection-runtime-freshness.mjs`
- `node scripts/ops/check-read-projection-runtime-freshness.mjs --require-running-current` fails as expected against stale prod read runtime
- `bash -n scripts/ops/friday-desktop-gui-smoke-proof.sh && node --check scripts/ops/check-friday-desktop-gui-smoke-contract.mjs && node scripts/ops/check-friday-desktop-gui-smoke-contract.mjs`
- `npx vitest run test/integration/system/friday-desktop-release-pipeline.integration.test.ts --reporter=dot`
- `node scripts/ops/check-friday-desktop-release-pipeline.mjs "$PWD"`
- iOS same-mission live-loopback capture against current scratch read server clears stale/offline/error banner; prod `:48751` remains stale until read runtime is safely cut over
- desktop same-mission live smoke against current scratch read server is PID-bound, displays `read_seam 127.0.0.1:59155`, and has no red stale/offline/error banner
