### PR TITLE
Harden desktop live visual proof metadata

### DIFF
--- a/scripts/ops/check-friday-uiux-selected-visual-proof.mjs
+++ b/scripts/ops/check-friday-uiux-selected-visual-proof.mjs
@@ -252,12 +252,34 @@ function evaluateDesktopCapture(path) {
     "ui_device_accessibility_click_capture_real_ui_not_endbar",
   ].includes(capture.truth_label);
   const statusOk = ["ready", "partial_capture_ready", undefined, null].includes(capture.status);
+  const declaredMode = typeof capture.mode === "string" ? capture.mode : null;
+  const liveConnection = capture.live_connection && typeof capture.live_connection === "object"
+    ? capture.live_connection
+    : null;
+  const desktopLiveModes = new Set(["live-loopback", "product-live", "same-run-live"]);
+  const desktopLiveConnected = desktopLiveModes.has(declaredMode)
+    && liveConnection?.status === "mission_bound_live_read_requested"
+    && liveConnection?.mock === false
+    && typeof liveConnection?.workbench_mission_id === "string"
+    && liveConnection.workbench_mission_id.length > 0
+    && typeof liveConnection?.read_host === "string"
+    && liveConnection.read_host.length > 0
+    && typeof liveConnection?.read_port === "string"
+    && /^[0-9]+$/.test(liveConnection.read_port);
   return {
     path,
     status: truthOk && statusOk && missing.length === 0 ? "ready" : "gap",
     truth_label: capture.truth_label || null,
     capture_status: capture.status || null,
     generated_at_utc: capture.generated_at_utc || null,
+    mode: desktopLiveConnected ? declaredMode : null,
+    declaredMode,
+    live_connection: liveConnection,
+    modeStatus: desktopLiveConnected
+      ? "live_connected_visual_proof_mode"
+      : declaredMode
+        ? "declared_mode_not_live_connected"
+        : "missing_live_mode",
     requiredDesktopDestinations,
     observedDestinations: [...observed],
     missingDestinations: missing,

--- a/scripts/ops/friday-desktop-ax-accessibility-capture.mjs
+++ b/scripts/ops/friday-desktop-ax-accessibility-capture.mjs
@@ -48,6 +48,9 @@ const treeDepth = Number(arg("tree-depth") || process.env.FRIDAY_DESKTOP_AX_TREE
 const axTraversalDepth = Number.isInteger(treeDepth) ? treeDepth : 5;
 const planOnly = args.includes("--plan-only");
 const requireObserved = args.includes("--require-observed");
+const liveReadHost = (process.env.FRIDAY_CONSOLE_LIVE_READ_HOST || "").trim();
+const liveReadPort = (process.env.FRIDAY_CONSOLE_LIVE_READ_PORT || "").trim();
+const declaredCaptureMode = (process.env.FRIDAY_DESKTOP_AX_CAPTURE_MODE || "").trim();
 const blockers = [];
 const warnings = [];
 
@@ -77,6 +80,30 @@ function read(path) {
 
 function unique(values) {
   return [...new Set(values.filter(Boolean))];
+}
+
+function liveConnectionMetadata() {
+  const readPortOk = /^[0-9]+$/.test(liveReadPort);
+  const missionBound = workbenchMissionId.length > 0;
+  const readConfigured = liveReadHost.length > 0 && readPortOk;
+  const mock = process.env.FRIDAY_CONSOLE_MOCK === "1";
+  const status = readConfigured && missionBound && !mock
+    ? "mission_bound_live_read_requested"
+    : "live_read_not_mission_bound";
+  return {
+    read_host: liveReadHost || null,
+    read_port: liveReadPort || null,
+    workbench_mission_id: workbenchMissionId || null,
+    mock,
+    status,
+  };
+}
+
+function captureModeForLiveConnection(liveConnection) {
+  if (declaredCaptureMode) return declaredCaptureMode;
+  return liveConnection.status === "mission_bound_live_read_requested"
+    ? "live-loopback"
+    : "unclassified-real-app";
 }
 
 function run(command, commandArgs, options = {}) {
@@ -630,14 +657,22 @@ if (blockers.length === 0) {
 }
 
 writeFileSync(rawPath, `${rawSnapshots.join("\n")}\n`);
+const liveConnection = liveConnectionMetadata();
+const captureMode = captureModeForLiveConnection(liveConnection);
 const capture = {
   truth_label: "ui_device_accessibility_click_capture_real_ui_not_endbar",
+  generated_at_utc: new Date().toISOString(),
+  status: blockers.length === 0 && observedActions.length > 0 ? "partial_capture_ready" : "blocked_or_empty",
   mission_id: missionId,
   workbench_mission_id: workbenchMissionId || null,
   surface: "desktop",
   capture_method: "macos_accessibility",
+  mode: captureMode,
+  live_connection: liveConnection,
   evidence_ref: rawPath,
   ui_actions: observedActions,
+  caveat:
+    "This is real macOS Accessibility inspection of FridayHubConsole with declared live-read metadata when configured; it is not END-BAR, adoption, or proof that runtime actions closed.",
 };
 jsonOut(capturePath, capture);
 
@@ -658,6 +693,8 @@ const summary = {
   capture: {
     path: capturePath,
     raw_tree: rawPath,
+    mode: captureMode,
+    live_connection: liveConnection,
     observed_count: observedActions.length,
     missing_count: missingTargets.length,
     missing_targets: missingTargets,

--- a/test/unit/qa/friday-desktop-ax-accessibility-capture-contract.test.ts
+++ b/test/unit/qa/friday-desktop-ax-accessibility-capture-contract.test.ts
@@ -51,6 +51,11 @@ describe("friday-desktop-ax-accessibility-capture contract", () => {
 
     expect(source).toContain("ui_device_accessibility_click_capture_real_ui_not_endbar");
     expect(source).toContain("macos_accessibility");
+    expect(source).toContain("live_connection");
+    expect(source).toContain("FRIDAY_CONSOLE_LIVE_READ_HOST");
+    expect(source).toContain("FRIDAY_CONSOLE_LIVE_READ_PORT");
+    expect(source).toContain("mission_bound_live_read_requested");
+    expect(source).toContain("live-loopback");
     expect(source).toContain("Only visible, safe observations are emitted");
     expect(source).toContain("does not click governed or");
     expect(source).toContain("friday-ui-device-accessibility-click-capture.mjs");

--- a/test/unit/qa/friday-uiux-selected-visual-proof-cli.test.ts
+++ b/test/unit/qa/friday-uiux-selected-visual-proof-cli.test.ts
@@ -70,6 +70,16 @@ function writeReadyEvidence(root: string, mode = "live-loopback") {
   }, null, 2));
   writeFile(evidence, "desktop-ax-accessibility-capture.json", JSON.stringify({
     truth_label: "ui_device_accessibility_click_capture_real_ui_not_endbar",
+    generated_at_utc: "2026-06-27T00:00:00.000Z",
+    status: "partial_capture_ready",
+    mode: "live-loopback",
+    live_connection: {
+      read_host: "127.0.0.1",
+      read_port: "59155",
+      workbench_mission_id: "mission_selected_visual_fixture",
+      mock: false,
+      status: "mission_bound_live_read_requested",
+    },
     ui_actions: [
       "operations",
       "chat",
@@ -154,6 +164,45 @@ describe("check-friday-uiux-selected-visual-proof", () => {
       const report = JSON.parse(output) as { status?: string; blockers?: unknown[] };
       expect(report.status).toBe("selected_visual_proof_ready");
       expect(report.blockers).toEqual([]);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("does not promote a desktop live mode declaration without live connection metadata", () => {
+    const { root, designRoot } = fixture();
+    try {
+      const evidence = writeReadyEvidence(root);
+      writeFile(evidence, "desktop-ax-accessibility-capture.json", JSON.stringify({
+        truth_label: "ui_device_accessibility_click_capture_real_ui_not_endbar",
+        status: "partial_capture_ready",
+        mode: "live-loopback",
+        ui_actions: [
+          "operations",
+          "chat",
+          "session",
+          "pairingProvisioning",
+          "providerAdmin",
+          "parity",
+          "workflow",
+          "evidence",
+        ].map((screen) => ({ screen, status: "pass", runtimeActionId: `desktop/${screen}/check` })),
+      }, null, 2));
+      const output = execFileSync("node", [
+        script,
+        `--repo-root=${root}`,
+        `--design-root=${designRoot}`,
+        `--evidence-dir=${evidence}`,
+        "--require-complete",
+      ], { cwd: process.cwd(), encoding: "utf8" });
+      const report = JSON.parse(output) as {
+        status?: string;
+        evidence?: { desktop?: Array<{ mode?: string | null; declaredMode?: string | null; modeStatus?: string }> };
+      };
+      expect(report.status).toBe("selected_visual_proof_ready");
+      expect(report.evidence?.desktop?.[0]?.declaredMode).toBe("live-loopback");
+      expect(report.evidence?.desktop?.[0]?.mode).toBeNull();
+      expect(report.evidence?.desktop?.[0]?.modeStatus).toBe("declared_mode_not_live_connected");
     } finally {
       rmSync(root, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary
- emit mission-bound live-read metadata from desktop AX captures
- only promote desktop visual evidence to live-connected when mode + live_connection are internally valid
- add contract coverage for untrusted desktop live-mode declarations

## Verification
- node --check scripts/ops/friday-desktop-ax-accessibility-capture.mjs
- node --check scripts/ops/check-friday-uiux-selected-visual-proof.mjs
- node --check scripts/ops/check-friday-uiux-product-happy-path.mjs
- npx vitest run test/unit/qa/friday-desktop-ax-accessibility-capture-contract.test.ts test/unit/qa/friday-uiux-selected-visual-proof-cli.test.ts test/unit/qa/friday-uiux-product-happy-path-cli.test.ts --reporter=dot
- selected-8 desktop live AX capture: /private/tmp/friday-desktop-ax-selected8-live-metadata-4857af9f-20260628T155722Z
- strict product gate remains not ready; residual blockers are runtime trace gaps, not desktop live metadata

Truth: this is proof-boundary hardening only; it does not claim END-BAR, release, adoption, or every-button runtime closure.