### PR TITLE
Require external desktop approval artifacts

### DIFF
--- a/apps/macos/FridayHubConsole/Sources/FridayHubConsole/FridayHubConsoleApp.swift
+++ b/apps/macos/FridayHubConsole/Sources/FridayHubConsole/FridayHubConsoleApp.swift
@@ -174,9 +174,9 @@ struct FridayHubConsoleApp: App {
     }
   }
 
-  /// Operator approval signer bridge. It invokes the external operator CLI only after the operator
-  /// clicks Approve; startup never reads or signs with the private key.
+  /// Operator approval relay. It never receives a key path or invokes signing from the app; the
+  /// operator supplies an already-signed artifact from an external custody boundary.
   static var approvalSigner: OperatorApprovalSigner? {
-    useMock ? nil : OperatorApprovalCLISigner()
+    useMock ? nil : OperatorApprovalExternalArtifactSigner()
   }
 }

--- a/apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/OperatorApprovalSigner.swift
+++ b/apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/OperatorApprovalSigner.swift
@@ -38,6 +38,7 @@ public enum OperatorApprovalSignerError: Error, Sendable, Equatable, CustomStrin
   case keyUnprovisioned
   case invalidRequest(String)
   case signerFailed(String)
+  case signedApprovalUnavailable(String)
 
   public var description: String {
     switch self {
@@ -47,33 +48,41 @@ public enum OperatorApprovalSignerError: Error, Sendable, Equatable, CustomStrin
       return "Invalid approval request: \(reason)"
     case let .signerFailed(reason):
       return "Operator signer failed: \(reason)"
+    case let .signedApprovalUnavailable(reason):
+      return "Operator signed approval unavailable: \(reason)"
     }
   }
 }
 
-/// Desktop bridge to `friday-operator-approve sign`. It reads no key bytes itself; the external
-/// operator CLI owns key custody and emits only public signed-approval JSON on stdout.
-public struct OperatorApprovalCLISigner: OperatorApprovalSigner {
-  private let executablePath: String
-  private let keyPath: String?
+/// Desktop relay for an operator-supplied `SignedApproval` artifact.
+///
+/// The app is not a signer. It writes a refs-only pending request the operator can sign outside
+/// the app, and if a signed artifact path is configured it relays those opaque bytes after checking
+/// the public refs match this pause frame. No key path is accepted and no signing command is run.
+public struct OperatorApprovalExternalArtifactSigner: OperatorApprovalSigner {
+  private let signedApprovalPath: String?
   private let tempDirectory: URL
 
   public init(
-    executablePath: String? = ProcessInfo.processInfo.environment["FRIDAY_OPERATOR_APPROVE_BIN"],
-    keyPath: String? = ProcessInfo.processInfo.environment["FRIDAY_OPERATOR_APPROVE_KEY_PATH"],
+    signedApprovalPath: String? = ProcessInfo.processInfo.environment[
+      "FRIDAY_OPERATOR_APPROVE_SIGNED_APPROVAL_PATH"],
     tempDirectory: URL = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
   ) {
-    self.executablePath = executablePath?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
-      ?? "friday-operator-approve"
-    self.keyPath = keyPath?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
+    self.signedApprovalPath = signedApprovalPath?.trimmingCharacters(in: .whitespacesAndNewlines)
+      .nilIfEmpty
     self.tempDirectory = tempDirectory
   }
 
   public func signApproval(_ request: OperatorApprovalSigningRequest) async throws -> [UInt8] {
-    guard let keyPath else { throw OperatorApprovalSignerError.keyUnprovisioned }
     let requestFile = try writePendingRequest(request)
-    defer { try? FileManager.default.removeItem(at: requestFile) }
-    return try await runSigner(keyPath: keyPath, requestFile: requestFile)
+    guard let signedApprovalPath else {
+      throw OperatorApprovalSignerError.signedApprovalUnavailable(
+        "refs-only request written to \(requestFile.path); sign it outside the app and set FRIDAY_OPERATOR_APPROVE_SIGNED_APPROVAL_PATH")
+    }
+    let signedApprovalFile = URL(fileURLWithPath: signedApprovalPath)
+    let data = try Data(contentsOf: signedApprovalFile)
+    try validateSignedApproval(data, matches: request)
+    return Array(data)
   }
 
   private func writePendingRequest(_ request: OperatorApprovalSigningRequest) throws -> URL {
@@ -108,41 +117,25 @@ public struct OperatorApprovalCLISigner: OperatorApprovalSigner {
     return file
   }
 
-  private func runSigner(keyPath: String, requestFile: URL) async throws -> [UInt8] {
-    try await withCheckedThrowingContinuation { continuation in
-      let process = Process()
-      let stdout = Pipe()
-      let stderr = Pipe()
-      process.standardOutput = stdout
-      process.standardError = stderr
-
-      if executablePath.contains("/") {
-        process.executableURL = URL(fileURLWithPath: executablePath)
-        process.arguments = ["sign", "--key", keyPath, "--request", requestFile.path]
-      } else {
-        process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
-        process.arguments = [executablePath, "sign", "--key", keyPath, "--request", requestFile.path]
-      }
-
-      process.terminationHandler = { completed in
-        let out = stdout.fileHandleForReading.readDataToEndOfFile()
-        let err = stderr.fileHandleForReading.readDataToEndOfFile()
-        if completed.terminationStatus == 0, !out.isEmpty {
-          continuation.resume(returning: Array(out))
-        } else {
-          let stderrText = String(data: err, encoding: .utf8)?
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-          continuation.resume(
-            throwing: OperatorApprovalSignerError.signerFailed(
-              stderrText?.nilIfEmpty ?? "exit \(completed.terminationStatus)"))
-        }
-      }
-
-      do {
-        try process.run()
-      } catch {
-        continuation.resume(throwing: OperatorApprovalSignerError.signerFailed(error.localizedDescription))
-      }
+  private func validateSignedApproval(
+    _ data: Data,
+    matches request: OperatorApprovalSigningRequest
+  ) throws {
+    let approval = try JSONDecoder().decode(SignedApprovalFile.self, from: data)
+    guard approval.approvalId == request.approvalId else {
+      throw OperatorApprovalSignerError.invalidRequest("signed approval_id does not match pause frame")
+    }
+    guard approval.actionDigest == request.actionDigest else {
+      throw OperatorApprovalSignerError.invalidRequest("signed action_digest does not match pause frame")
+    }
+    guard approval.decision == request.decision else {
+      throw OperatorApprovalSignerError.invalidRequest("signed decision does not match requested decision")
+    }
+    guard approval.expiresAt > 0 else {
+      throw OperatorApprovalSignerError.invalidRequest("signed expires_at must be positive")
+    }
+    guard !approval.signature.isEmpty else {
+      throw OperatorApprovalSignerError.invalidRequest("signed approval is missing signature")
     }
   }
 }
@@ -160,6 +153,21 @@ private struct PendingApprovalRequestFile: Encodable {
     case actionDigest = "action_digest"
     case expiresAt = "expires_at"
     case decision, surface, summary
+  }
+}
+
+private struct SignedApprovalFile: Decodable {
+  let approvalId: String
+  let actionDigest: String
+  let expiresAt: Int64
+  let decision: String
+  let signature: String
+
+  enum CodingKeys: String, CodingKey {
+    case approvalId = "approval_id"
+    case actionDigest = "action_digest"
+    case expiresAt = "expires_at"
+    case decision, signature
   }
 }
 

--- a/apps/macos/FridayHubConsole/Tests/FridayHubConsoleCoreTests/OperationsOverviewViewModelTests.swift
+++ b/apps/macos/FridayHubConsole/Tests/FridayHubConsoleCoreTests/OperationsOverviewViewModelTests.swift
@@ -1969,8 +1969,8 @@ func providerWorkspaceListSessionsSendsGuardedRequestAndRefreshes() async {
 }
 
 @Test
-func operatorApprovalCLISignerRejectsMalformedDigestBeforeInvokingSigner() async {
-  let signer = OperatorApprovalCLISigner(keyPath: "/tmp/not-read-in-this-test")
+func operatorApprovalExternalArtifactSignerRejectsMalformedDigestBeforeReadingArtifact() async {
+  let signer = OperatorApprovalExternalArtifactSigner(signedApprovalPath: "/tmp/not-read-in-this-test")
   do {
     _ = try await signer.signApproval(OperatorApprovalSigningRequest(
       runId: "run-x",
@@ -1987,36 +1987,26 @@ func operatorApprovalCLISignerRejectsMalformedDigestBeforeInvokingSigner() async
 }
 
 @Test
-func operatorApprovalCLISignerWritesRefsOnlyRequestAndRelaysOpaqueStdout() async throws {
+func operatorApprovalExternalArtifactSignerWritesRefsOnlyRequestAndRelaysMatchingSignedArtifact() async throws {
   let temp = try temporaryHome()
   defer { try? FileManager.default.removeItem(at: temp) }
 
-  let capturedArgs = temp.appendingPathComponent("args.txt")
-  let capturedRequest = temp.appendingPathComponent("request.json")
-  let fakeSigner = temp.appendingPathComponent("friday-operator-approve")
-  let fakeKey = temp.appendingPathComponent("operator-test.key")
-  try Data("not-a-real-key\n".utf8).write(to: fakeKey)
-  let signedApproval = #"{"truth_label":"fake_cli_signed_approval","signature":"opaque"}"#
-  let script = """
-    #!/bin/sh
-    set -eu
-    printf '%s\\n' "$@" > '\(capturedArgs.path)'
-    test "$1" = "sign"
-    test "$2" = "--key"
-    test "$3" = "\(fakeKey.path)"
-    test "$4" = "--request"
-    test -f "$5"
-    cat "$5" > '\(capturedRequest.path)'
-    printf '%s' '\(signedApproval)'
+  let signedApproval = """
+    {
+      "scheme": "ed25519",
+      "decision": "approved",
+      "approval_id": "approval-bridge-1",
+      "action_digest": "\(String(repeating: "b", count: 64))",
+      "expires_at": 1900000000000,
+      "issuer": "friday_canonical_gate",
+      "signature": "\(String(repeating: "c", count: 128))"
+    }
     """
-  try script.write(to: fakeSigner, atomically: true, encoding: .utf8)
-  try FileManager.default.setAttributes(
-    [.posixPermissions: NSNumber(value: Int16(0o700))],
-    ofItemAtPath: fakeSigner.path)
+  let signedApprovalFile = temp.appendingPathComponent("signed-approval.json")
+  try Data(signedApproval.utf8).write(to: signedApprovalFile)
 
-  let signer = OperatorApprovalCLISigner(
-    executablePath: fakeSigner.path,
-    keyPath: fakeKey.path,
+  let signer = OperatorApprovalExternalArtifactSigner(
+    signedApprovalPath: signedApprovalFile.path,
     tempDirectory: temp)
   let blob = try await signer.signApproval(OperatorApprovalSigningRequest(
     runId: "run-paused-bridge",
@@ -2027,7 +2017,11 @@ func operatorApprovalCLISignerWritesRefsOnlyRequestAndRelaysOpaqueStdout() async
 
   #expect(String(decoding: blob, as: UTF8.self) == signedApproval)
 
-  let requestData = try Data(contentsOf: capturedRequest)
+  let requestFiles = try FileManager.default.contentsOfDirectory(
+    at: temp, includingPropertiesForKeys: nil)
+    .filter { $0.lastPathComponent.hasPrefix("friday-approval-") }
+  #expect(requestFiles.count == 1)
+  let requestData = try Data(contentsOf: requestFiles[0])
   let requestText = String(decoding: requestData, as: UTF8.self)
   let request = try JSONDecoder().decode(ApprovalRequestFileMirror.self, from: requestData)
   #expect(request.approvalId == "approval-bridge-1")
@@ -2039,16 +2033,39 @@ func operatorApprovalCLISignerWritesRefsOnlyRequestAndRelaysOpaqueStdout() async
   #expect(!requestText.contains("run-paused-bridge"))
   #expect(!requestText.contains("private"))
   #expect(!requestText.contains("body"))
+}
 
-  let args = try String(contentsOf: capturedArgs, encoding: .utf8)
-    .split(separator: "\n")
-    .map(String.init)
-  #expect(args.count == 5)
-  #expect(args[0] == "sign")
-  #expect(args[1] == "--key")
-  #expect(args[2] == fakeKey.path)
-  #expect(args[3] == "--request")
-  #expect(!FileManager.default.fileExists(atPath: args[4]))
+@Test
+func operatorApprovalExternalArtifactSignerRejectsMismatchedSignedArtifact() async throws {
+  let temp = try temporaryHome()
+  defer { try? FileManager.default.removeItem(at: temp) }
+  let signedApprovalFile = temp.appendingPathComponent("signed-approval.json")
+  try Data("""
+    {
+      "decision": "approved",
+      "approval_id": "wrong-approval",
+      "action_digest": "\(String(repeating: "b", count: 64))",
+      "expires_at": 1900000000000,
+      "signature": "\(String(repeating: "c", count: 128))"
+    }
+    """.utf8).write(to: signedApprovalFile)
+
+  let signer = OperatorApprovalExternalArtifactSigner(
+    signedApprovalPath: signedApprovalFile.path,
+    tempDirectory: temp)
+  do {
+    _ = try await signer.signApproval(OperatorApprovalSigningRequest(
+      runId: "run-paused-bridge",
+      approvalId: "approval-bridge-1",
+      actionDigest: String(repeating: "b", count: 64),
+      summary: "write_file paused",
+      expiresAtMs: 1_900_000_000_000))
+    Issue.record("mismatched signed artifact must fail closed")
+  } catch let error as OperatorApprovalSignerError {
+    #expect(error.description.contains("approval_id"))
+  } catch {
+    Issue.record("unexpected error \(error)")
+  }
 }
 
 @Test

--- a/scripts/ops/check-friday-desktop-approval-relay-contract.mjs
+++ b/scripts/ops/check-friday-desktop-approval-relay-contract.mjs
@@ -47,8 +47,8 @@ const checks = [
     missing: missingStrings(files.app, [
       "approvalSigner: Self.approvalSigner",
       "approvalResumeClient: Self.writeClient",
-      "OperatorApprovalCLISigner()",
-      "startup never reads or signs with the private key",
+      "OperatorApprovalExternalArtifactSigner()",
+      "never receives a key path or invokes signing from the app",
     ]),
   },
   {
@@ -69,8 +69,9 @@ const checks = [
     missing: missingStrings(files.tests, [
       "approveNeedsMeItemSignsRefsAndRelaysOpaqueBlob",
       "approveNeedsMeItemWithoutSignerFailsClosedWithoutResume",
-      "operatorApprovalCLISignerWritesRefsOnlyRequestAndRelaysOpaqueStdout",
-      "operatorApprovalCLISignerRejectsMalformedDigestBeforeInvokingSigner",
+      "operatorApprovalExternalArtifactSignerWritesRefsOnlyRequestAndRelaysMatchingSignedArtifact",
+      "operatorApprovalExternalArtifactSignerRejectsMalformedDigestBeforeReadingArtifact",
+      "operatorApprovalExternalArtifactSignerRejectsMismatchedSignedArtifact",
       "rejectNeedsMeApprovalUsesRunControlWithoutSigner",
       "cancelNeedsMeRunUsesRunControlReason",
     ]),


### PR DESCRIPTION
## Summary
- Remove the desktop app-callable `sign --key` approval bridge.
- Replace it with an external signed-approval artifact relay: the app writes refs-only pending requests and only relays a supplied `SignedApproval` JSON after public ref validation.
- Update static guard/tests so key-path based signing cannot silently return.

## Verification
- `node scripts/ops/check-friday-desktop-approval-relay-contract.mjs $(pwd)`
- `swift test --package-path apps/macos/FridayHubConsole --filter operatorApprovalExternalArtifactSigner`
- `git diff --check`
- `rg -n "OperatorApprovalCLISigner|FRIDAY_OPERATOR_APPROVE_KEY_PATH|sign --key|--key" apps/macos scripts/ops/check-friday-desktop-approval-relay-contract.mjs` returns no matches

## Truth label
Security/vision boundary fix only. This does not claim END-BAR, product maturity, adoption, or operator signature completion; it prevents the desktop app from invoking operator-key signing.
