### PR TITLE
Harden current-head UI proof capture

### DIFF
--- a/scripts/ops/check-friday-ios-design-destination-capture-contract.mjs
+++ b/scripts/ops/check-friday-ios-design-destination-capture-contract.mjs
@@ -64,6 +64,7 @@ if (scriptExists) {
   const requiredTruthStrings = [
     "ios_selected_design_destination_capture_not_live_closure",
     "friday-design-handoff-20260602/saved/mobile-selection.json",
+    "repo_head",
     "design-proof-sample",
     "`offline-truth` is a negative-control lane only",
     "not END-BAR",

--- a/scripts/ops/friday-desktop-ax-accessibility-capture.mjs
+++ b/scripts/ops/friday-desktop-ax-accessibility-capture.mjs
@@ -46,6 +46,8 @@ const workbenchMissionId = arg("workbench-mission-id") || process.env.FRIDAY_DES
 const timeoutSeconds = Number(arg("timeout-seconds") || process.env.FRIDAY_DESKTOP_AX_CAPTURE_TIMEOUT_SECONDS || "20");
 const treeDepth = Number(arg("tree-depth") || process.env.FRIDAY_DESKTOP_AX_TREE_DEPTH || "5");
 const axTraversalDepth = Number.isInteger(treeDepth) ? treeDepth : 5;
+const overallStartedAtMs = Date.now();
+const overallTimeoutMs = Math.max(timeoutSeconds * 1000 * 4, 30_000);
 const planOnly = args.includes("--plan-only");
 const requireObserved = args.includes("--require-observed");
 const liveReadHost = (process.env.FRIDAY_CONSOLE_LIVE_READ_HOST || "").trim();
@@ -190,12 +192,19 @@ function appleString(value) {
 }
 
 function osascript(script) {
-  return run("/usr/bin/osascript", ["-e", script], { timeout: timeoutSeconds * 1000 });
+  return run("/usr/bin/osascript", ["-e", script], {
+    killSignal: "SIGKILL",
+    timeout: timeoutSeconds * 1000,
+  });
+}
+
+function overallDeadlineExceeded() {
+  return Date.now() - overallStartedAtMs > overallTimeoutMs;
 }
 
 function waitForWindow() {
   const deadline = Date.now() + timeoutSeconds * 1000;
-  while (Date.now() < deadline) {
+  while (Date.now() < deadline && !overallDeadlineExceeded()) {
     const result = osascript(`
 tell application "System Events"
   if exists process "FridayHubConsole" then
@@ -552,6 +561,10 @@ if (blockers.length === 0) {
   }
 
   for (const [destination, destinationTargets] of byDestination.entries()) {
+    if (overallDeadlineExceeded()) {
+      block("capture_overall_timeout", `stopped before destination:${destination}`);
+      break;
+    }
     const ready = launchApp(destination);
     if (!ready) {
       block("app_window_not_ready", `FridayHubConsole:${destination}`);
@@ -615,6 +628,10 @@ if (blockers.length === 0) {
       });
     }
     for (const target of destinationTargets) {
+      if (overallDeadlineExceeded()) {
+        block("capture_overall_timeout", `stopped before target:${target.runtimeActionId}`);
+        break;
+      }
       let matchKind = "none";
       const matched = elements.find((element) => {
         const result = targetMatches(element, target);
@@ -695,6 +712,7 @@ const summary = {
     raw_tree: rawPath,
     mode: captureMode,
     live_connection: liveConnection,
+    overall_timeout_ms: overallTimeoutMs,
     observed_count: observedActions.length,
     missing_count: missingTargets.length,
     missing_targets: missingTargets,

--- a/scripts/ops/friday-ios-design-destination-capture.sh
+++ b/scripts/ops/friday-ios-design-destination-capture.sh
@@ -114,6 +114,7 @@ fi
 
 mkdir -p "${out_dir}/screenshots"
 manifest_path="${out_dir}/ios-design-destination-capture-manifest.json"
+repo_head="$(git -C "${repo_root}" rev-parse HEAD 2>/dev/null || true)"
 initial_destination="${destinations[0]}"
 initial_shot="${out_dir}/screenshots/${initial_destination}.png"
 initial_metadata="${initial_shot}.metadata.json"
@@ -211,11 +212,11 @@ for destination in "${destinations[@]}"; do
   capture_rows+=("${destination}|${shot}|${launch_log}|${screenshot_log}")
 done
 
-node - "${manifest_path}" "${mode}" "${destinations_csv}" "${udid}" "${initial_metadata}" "${mission_id}" "${capture_rows[@]}" <<'NODE'
+node - "${manifest_path}" "${mode}" "${destinations_csv}" "${udid}" "${initial_metadata}" "${mission_id}" "${repo_head}" "${capture_rows[@]}" <<'NODE'
 const { createHash } = require("node:crypto");
 const { existsSync, readFileSync, writeFileSync } = require("node:fs");
 
-const [manifestPath, mode, destinationsCsv, simulatorUdid, initialMetadataPath, missionIdOverride, ...rows] = process.argv.slice(2);
+const [manifestPath, mode, destinationsCsv, simulatorUdid, initialMetadataPath, missionIdOverride, repoHead, ...rows] = process.argv.slice(2);
 const sha256 = (target) => createHash("sha256").update(readFileSync(target)).digest("hex");
 const captures = rows.map((row) => {
   const [destination, screenshot, launchLog, screenshotLog] = row.split("|");
@@ -264,6 +265,7 @@ const manifest = {
   truth_label: "ios_selected_design_destination_capture_not_live_closure",
   status: validationErrors.length === 0 ? "ready" : "failed",
   generated_at_utc: new Date().toISOString(),
+  repo_head: repoHead || null,
   mode,
   bundle_id: "com.friday.shell",
   simulator_udid: simulatorUdid,

--- a/test/unit/qa/friday-desktop-ax-accessibility-capture-contract.test.ts
+++ b/test/unit/qa/friday-desktop-ax-accessibility-capture-contract.test.ts
@@ -59,6 +59,12 @@ describe("friday-desktop-ax-accessibility-capture contract", () => {
     expect(source).toContain("Only visible, safe observations are emitted");
     expect(source).toContain("does not click governed or");
     expect(source).toContain("friday-ui-device-accessibility-click-capture.mjs");
+    expect(source).toContain("killSignal: \"SIGKILL\"");
+    expect(source).toContain("timeout: timeoutSeconds * 1000");
+    expect(source).toContain("const overallTimeoutMs = Math.max(timeoutSeconds * 1000 * 4, 30_000)");
+    expect(source).toContain("function overallDeadlineExceeded()");
+    expect(source).toContain("capture_overall_timeout");
+    expect(source).toContain("overall_timeout_ms: overallTimeoutMs");
     expect(navSource).toContain(".accessibilityIdentifier(\"friday.desktop.nav.\\(destination.rawValue)\")");
   });
 

--- a/test/unit/qa/friday-ios-design-destination-capture-contract-cli.test.ts
+++ b/test/unit/qa/friday-ios-design-destination-capture-contract-cli.test.ts
@@ -23,6 +23,7 @@ function createFixtureRepo(extraScriptSource = "") {
 destinations_csv="home,missions,session,contextPassport,tokenLedger,shareIntake,voice,pairing,needsMe,memory,platform,providerAuth,activity,workflows,onboarding,settings,petEditor,proofViewer,entrypoints"
 truth_label="ios_selected_design_destination_capture_not_live_closure"
 design_source="friday-design-handoff-20260602/saved/mobile-selection.json"
+repo_head="$(git -C "$repo_root" rev-parse HEAD)"
 mode="design-proof-sample"
 negative_control_note="\`offline-truth\` is a negative-control lane only"
 caveat="not END-BAR / not GO-LIVE; design-proof-sample is visual comparison only; enabled actions still require separate Hub/DB/ledger/proof closure"

--- a/test/unit/qa/friday-ios-design-destination-capture-runner.test.ts
+++ b/test/unit/qa/friday-ios-design-destination-capture-runner.test.ts
@@ -69,10 +69,12 @@ exit 64
       await fs.readFile(path.join(outDir, "ios-design-destination-capture-manifest.json"), "utf8"),
     ) as {
       mode: string;
+      repo_head: string | null;
       caveat: string;
       relaunch_contract: string;
     };
     expect(manifest.mode).toBe("design-proof-sample");
+    expect(manifest.repo_head).toMatch(/^[0-9a-f]{40}$/);
     expect(manifest.caveat).toContain("offline-truth is negative control only");
     expect(manifest.relaunch_contract).toContain("design-proof sample");
     await expect(fs.readFile(path.join(outDir, "screenshots", "session.launch.txt"), "utf8"))
@@ -133,6 +135,7 @@ exit 64
       await fs.readFile(path.join(outDir, "ios-design-destination-capture-manifest.json"), "utf8"),
     ) as {
       status: string;
+      repo_head: string | null;
       mode: string;
       captures: Array<{ destination: string; status: string; screenshot: string }>;
       validation: {
@@ -145,6 +148,7 @@ exit 64
     };
 
     expect(manifest.status).toBe("ready");
+    expect(manifest.repo_head).toMatch(/^[0-9a-f]{40}$/);
     expect(manifest.mode).toBe("offline-truth");
     expect(manifest.captures.map((capture) => capture.destination)).toEqual(["home", "session"]);
     expect(manifest.validation).toEqual({


### PR DESCRIPTION
## Summary
- bind iOS selected-design capture manifests to the exact repo HEAD used for proof generation
- require the iOS capture contract to preserve repo-head metadata
- make desktop AX osascript captures bounded with SIGKILL on timeout so proof collection cannot hang indefinitely

## Local verification
- `node --check scripts/ops/friday-desktop-ax-accessibility-capture.mjs`
- `node --check scripts/ops/check-friday-ios-design-destination-capture-contract.mjs`
- `bash -n scripts/ops/friday-ios-design-destination-capture.sh`
- `git diff --check`
- `/Users/jarvis/Projects/Friday/node_modules/.bin/vitest run test/unit/qa/friday-desktop-ax-accessibility-capture-contract.test.ts test/unit/qa/friday-ios-design-destination-capture-runner.test.ts test/unit/qa/friday-ios-design-destination-capture-contract-cli.test.ts`

Truth: proof hygiene only. This does not claim END-BAR, selected UI completion, adoption, release, or product happy-path readiness.