### PR TITLE
Aggregate segmented desktop visual proof

### DIFF
--- a/scripts/ops/check-friday-uiux-selected-visual-proof.mjs
+++ b/scripts/ops/check-friday-uiux-selected-visual-proof.mjs
@@ -268,6 +268,15 @@ function evaluateDesktopCapture(path) {
     && /^[0-9]+$/.test(liveConnection.read_port);
   return {
     path,
+    eligibleForAggregate: truthOk && statusOk && desktopLiveConnected,
+    aggregate_key: desktopLiveConnected
+      ? [
+        declaredMode,
+        liveConnection.read_host,
+        liveConnection.read_port,
+        liveConnection.workbench_mission_id,
+      ].join("\u001f")
+      : null,
     status: truthOk && statusOk && missing.length === 0 ? "ready" : "gap",
     truth_label: capture.truth_label || null,
     capture_status: capture.status || null,
@@ -285,6 +294,40 @@ function evaluateDesktopCapture(path) {
     missingDestinations: missing,
     caveat: capture.caveat || null,
   };
+}
+
+function aggregateDesktopCaptures(items) {
+  const groups = new Map();
+  for (const item of items) {
+    if (item.aggregate_key === null || item.eligibleForAggregate !== true) continue;
+    const group = groups.get(item.aggregate_key) || [];
+    group.push(item);
+    groups.set(item.aggregate_key, group);
+  }
+
+  return [...groups.values()]
+    .filter((group) => group.length > 1)
+    .map((group) => {
+      const observed = new Set(group.flatMap((item) => item.observedDestinations || []));
+      const missing = requiredDesktopDestinations.filter((destination) => !observed.has(destination));
+      const first = group[0];
+      return {
+        status: missing.length === 0 ? "ready" : "gap",
+        truth_label: "segmented_desktop_visual_capture_aggregate_not_endbar",
+        capture_status: "segmented_aggregate",
+        generated_at_utc: new Date().toISOString(),
+        mode: first.mode,
+        declaredMode: first.declaredMode,
+        live_connection: first.live_connection,
+        modeStatus: first.modeStatus,
+        requiredDesktopDestinations,
+        observedDestinations: [...observed],
+        missingDestinations: missing,
+        segmentCount: group.length,
+        segmentPaths: group.map((item) => item.path),
+        caveat: "Aggregates same-mission live desktop AX capture segments for selected visual proof only; not END-BAR, adoption, or runtime action closure.",
+      };
+    });
 }
 
 const mobileSelection = selection("mobile");
@@ -305,8 +348,10 @@ if (staleRepoProof.length > 0) {
 
 const iosVisualEvidence = unique(iosManifests).map(evaluateIosManifest);
 const desktopVisualEvidence = unique(desktopCaptures).map(evaluateDesktopCapture);
+const desktopAggregateEvidence = aggregateDesktopCaptures(desktopVisualEvidence);
 const iosReady = iosVisualEvidence.some((item) => item.status === "ready");
-const desktopReady = desktopVisualEvidence.some((item) => item.status === "ready");
+const desktopReady = desktopVisualEvidence.some((item) => item.status === "ready")
+  || desktopAggregateEvidence.some((item) => item.status === "ready");
 
 if (!iosReady) {
   block(
@@ -343,6 +388,7 @@ const report = {
   evidence: {
     ios: iosVisualEvidence,
     desktop: desktopVisualEvidence,
+    desktopAggregates: desktopAggregateEvidence,
     committedProofFreshness: repoProofFreshness,
   },
   notes,

--- a/test/unit/qa/friday-uiux-selected-visual-proof-cli.test.ts
+++ b/test/unit/qa/friday-uiux-selected-visual-proof-cli.test.ts
@@ -94,6 +94,25 @@ function writeReadyEvidence(root: string, mode = "live-loopback") {
   return evidence;
 }
 
+function writeDesktopCapture(root: string, relative: string, screens: string[], mission = "mission_selected_visual_fixture") {
+  const evidence = join(root, relative);
+  writeFile(evidence, "desktop-ax-accessibility-capture.json", JSON.stringify({
+    truth_label: "ui_device_accessibility_click_capture_real_ui_not_endbar",
+    generated_at_utc: "2026-06-27T00:00:00.000Z",
+    status: "partial_capture_ready",
+    mode: "live-loopback",
+    live_connection: {
+      read_host: "127.0.0.1",
+      read_port: "59155",
+      workbench_mission_id: mission,
+      mock: false,
+      status: "mission_bound_live_read_requested",
+    },
+    ui_actions: screens.map((screen) => ({ screen, status: "pass", runtimeActionId: `desktop/${screen}/check` })),
+  }, null, 2));
+  return evidence;
+}
+
 describe("check-friday-uiux-selected-visual-proof", () => {
   it("reports missing selected visual proof without failing default mode", () => {
     const { root, designRoot } = fixture();
@@ -164,6 +183,89 @@ describe("check-friday-uiux-selected-visual-proof", () => {
       const report = JSON.parse(output) as { status?: string; blockers?: unknown[] };
       expect(report.status).toBe("selected_visual_proof_ready");
       expect(report.blockers).toEqual([]);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("passes when same-mission desktop visual evidence is split across live segments", () => {
+    const { root, designRoot } = fixture();
+    try {
+      const evidence = writeReadyEvidence(root);
+      writeFile(evidence, "desktop-ax-accessibility-capture.json", JSON.stringify({
+        truth_label: "ui_device_accessibility_click_capture_real_ui_not_endbar",
+        status: "partial_capture_ready",
+        mode: "live-loopback",
+        live_connection: {
+          read_host: "127.0.0.1",
+          read_port: "59155",
+          workbench_mission_id: "mission_selected_visual_fixture",
+          mock: false,
+          status: "mission_bound_live_read_requested",
+        },
+        ui_actions: ["operations", "chat", "session"].map((screen) => ({ screen, status: "pass", runtimeActionId: `desktop/${screen}/check` })),
+      }, null, 2));
+      const segmentB = writeDesktopCapture(root, "segment-b", ["pairingProvisioning", "providerAdmin", "parity"]);
+      const segmentC = writeDesktopCapture(root, "segment-c", ["workflow", "evidence"]);
+      const output = execFileSync("node", [
+        script,
+        `--repo-root=${root}`,
+        `--design-root=${designRoot}`,
+        `--evidence-dir=${evidence}`,
+        `--evidence-dir=${segmentB}`,
+        `--evidence-dir=${segmentC}`,
+        "--require-complete",
+      ], { cwd: process.cwd(), encoding: "utf8" });
+      const report = JSON.parse(output) as {
+        status?: string;
+        blockers?: unknown[];
+        evidence?: { desktopAggregates?: Array<{ status?: string; segmentCount?: number; missingDestinations?: string[] }> };
+      };
+      expect(report.status).toBe("selected_visual_proof_ready");
+      expect(report.blockers).toEqual([]);
+      expect(report.evidence?.desktopAggregates?.[0]).toMatchObject({
+        status: "ready",
+        segmentCount: 3,
+        missingDestinations: [],
+      });
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("does not aggregate desktop segments with an invalid proof truth label", () => {
+    const { root, designRoot } = fixture();
+    try {
+      const evidence = writeReadyEvidence(root);
+      writeFile(evidence, "desktop-ax-accessibility-capture.json", JSON.stringify({
+        truth_label: "bad_truth",
+        status: "partial_capture_ready",
+        mode: "live-loopback",
+        live_connection: {
+          read_host: "127.0.0.1",
+          read_port: "59155",
+          workbench_mission_id: "mission_selected_visual_fixture",
+          mock: false,
+          status: "mission_bound_live_read_requested",
+        },
+        ui_actions: ["operations", "chat", "session", "pairingProvisioning", "providerAdmin", "parity", "workflow", "evidence"]
+          .map((screen) => ({ screen, status: "pass", runtimeActionId: `desktop/${screen}/check` })),
+      }, null, 2));
+      const result = spawnSync("node", [
+        script,
+        `--repo-root=${root}`,
+        `--design-root=${designRoot}`,
+        `--evidence-dir=${evidence}`,
+        "--require-complete",
+      ], { cwd: process.cwd(), encoding: "utf8" });
+      expect(result.status).toBe(1);
+      const report = JSON.parse(result.stdout) as {
+        status?: string;
+        evidence?: { desktop?: Array<{ eligibleForAggregate?: boolean }>; desktopAggregates?: unknown[] };
+      };
+      expect(report.status).toBe("selected_visual_proof_gaps_present");
+      expect(report.evidence?.desktop?.[0]?.eligibleForAggregate).toBe(false);
+      expect(report.evidence?.desktopAggregates).toEqual([]);
     } finally {
       rmSync(root, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary
- allow selected visual proof to aggregate same-mission live desktop AX capture segments
- require each segment to keep valid truth/status/live connection metadata before aggregation
- add positive segmented proof coverage and a bad-truth negative control

## Local verification
- `node --check scripts/ops/check-friday-uiux-selected-visual-proof.mjs`
- `git diff --check`
- `npm test -- --run test/unit/qa/friday-uiux-selected-visual-proof-cli.test.ts`
- real current-head proof replay with iOS live-loopback + 4 segmented desktop AX captures returned `selected_visual_proof_ready`

Truth: selected visual proof aggregation only. This does not claim END-BAR, runtime action closure, release, adoption, or product happy-path readiness.