### PR TITLE
Honor segmented desktop visual proof in product happy path

### DIFF
--- a/scripts/ops/check-friday-uiux-product-happy-path.mjs
+++ b/scripts/ops/check-friday-uiux-product-happy-path.mjs
@@ -193,13 +193,22 @@ const liveConnectedVisualModes = new Set([
   "same-run-live",
 ]);
 
-function liveEvidenceForSurface(report, surface) {
+function visualEvidenceEntriesForSurface(report, surface) {
   const entries = arrayAt(report, ["evidence", surface]);
+  if (surface !== "desktop") return entries;
+  return [
+    ...entries,
+    ...arrayAt(report, ["evidence", "desktopAggregates"]),
+  ];
+}
+
+function liveEvidenceForSurface(report, surface) {
+  const entries = visualEvidenceEntriesForSurface(report, surface);
   return entries.filter((item) => item?.status === "ready" && liveConnectedVisualModes.has(String(item?.mode || "")));
 }
 
 function visualModesForSurface(report, surface) {
-  return arrayAt(report, ["evidence", surface])
+  return visualEvidenceEntriesForSurface(report, surface)
     .map((item) => String(item?.mode || ""))
     .filter(Boolean);
 }
@@ -258,6 +267,26 @@ function residualBlockers(report) {
   return arrayAt(report, ["gaps", "residualEndBarBlockers"]);
 }
 
+function residualBlockerRows(report) {
+  const rows = [];
+  for (const destination of residualBlockers(report)) {
+    for (const blocker of arrayAt(destination, ["blockers"])) {
+      const row = {
+        surface: String(destination.surface || ""),
+        id: String(destination.id || destination.destination || ""),
+        title: String(destination.title || ""),
+        kind: String(blocker.kind || ""),
+        label: String(blocker.label || ""),
+      };
+      rows.push({
+        ...row,
+        key: blockerKey(row),
+      });
+    }
+  }
+  return rows;
+}
+
 function blockerKey(blocker) {
   return [
     String(blocker?.surface || ""),
@@ -268,18 +297,7 @@ function blockerKey(blocker) {
 }
 
 function residualBlockerKeys(report) {
-  const keys = [];
-  for (const destination of residualBlockers(report)) {
-    for (const blocker of arrayAt(destination, ["blockers"])) {
-      keys.push(blockerKey({
-        surface: destination.surface,
-        id: destination.id || destination.destination,
-        kind: blocker.kind,
-        label: blocker.label,
-      }));
-    }
-  }
-  return keys;
+  return residualBlockerRows(report).map((row) => row.key);
 }
 
 const allowedSatisfactionClasses = new Set([
@@ -368,8 +386,10 @@ const satisfaction = blockerSatisfactionReport();
 const selectedReport = selected.parsed || {};
 const traceReport = trace.parsed || {};
 const traceSummary = summarizeTrace(traceReport);
+const residualRows = residualBlockerRows(traceReport);
 const residualKeys = residualBlockerKeys(traceReport);
 const unsatisfiedResidualKeys = residualKeys.filter((key) => !satisfaction.satisfiedKeys.has(key));
+const unsatisfiedResidualRows = residualRows.filter((row) => !satisfaction.satisfiedKeys.has(row.key));
 const residualBlockerCount = Math.max(traceSummary.destinationsWithResidualEndBarBlockers, residualKeys.length);
 const unsatisfiedResidualBlockerCount = residualKeys.length > 0
   ? unsatisfiedResidualKeys.length
@@ -456,6 +476,7 @@ const report = {
     residualBlockerCount,
     satisfiedResidualBlockerCount: residualBlockerCount - unsatisfiedResidualBlockerCount,
     unsatisfiedResidualBlockerCount,
+    unsatisfiedResidualBlockers: unsatisfiedResidualRows.map(({ key, ...row }) => row),
     invalid: satisfaction.invalid,
     caveat:
       "Blocker satisfaction does not weaken the native ProductReadinessContract. It only lets this gate distinguish residual blockers that have explicit same-run/current-head/live-connected satisfaction evidence from blockers still lacking proof.",

--- a/test/unit/qa/friday-uiux-product-happy-path-cli.test.ts
+++ b/test/unit/qa/friday-uiux-product-happy-path-cli.test.ts
@@ -309,4 +309,45 @@ describe("check-friday-uiux-product-happy-path", () => {
       rmSync(root, { recursive: true, force: true });
     }
   });
+
+  it("accepts a live desktop aggregate from segmented selected visual proof", () => {
+    const root = mkdtempSync(join(tmpdir(), "friday-happy-path-desktop-aggregate-"));
+    try {
+      const visualValue = selectedVisual("live-loopback", {}, {
+        status: "gap",
+        missingDestinations: ["evidence"],
+      }) as {
+        evidence: {
+          desktopAggregates?: Array<Record<string, unknown>>;
+        };
+      };
+      visualValue.evidence.desktopAggregates = [{
+        status: "ready",
+        mode: "live-loopback",
+        capture_status: "segmented_aggregate",
+        segmentCount: 3,
+        missingDestinations: [],
+      }];
+      const visual = writeJson(root, "visual.json", visualValue);
+      const trace = writeJson(root, "trace.json", traceability());
+      const output = execFileSync("node", [
+        script,
+        `--repo-root=${process.cwd()}`,
+        `--selected-visual-report=${visual}`,
+        `--action-traceability-report=${trace}`,
+        "--require-complete",
+      ], { cwd: process.cwd(), encoding: "utf8" });
+      const report = JSON.parse(output) as {
+        status?: string;
+        selectedVisual?: { liveConnectedDesktopEvidenceCount?: number; desktopModes?: string[] };
+        blockers?: unknown[];
+      };
+      expect(report.status).toBe("product_happy_path_ready");
+      expect(report.selectedVisual?.liveConnectedDesktopEvidenceCount).toBe(1);
+      expect(report.selectedVisual?.desktopModes).toEqual(["live-loopback", "live-loopback"]);
+      expect(report.blockers).toEqual([]);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
 });


### PR DESCRIPTION
## Summary
- let the product happy-path gate consider `evidence.desktopAggregates` from segmented desktop AX selected-visual proof
- keep mobile unchanged and preserve fail-closed residual END-BAR blocker behavior
- add a focused regression proving a segmented live desktop aggregate can satisfy the desktop visual leg without weakening blockers

## Verification
- `npm test -- --run test/unit/qa/friday-uiux-product-happy-path-cli.test.ts`
- `node --check scripts/ops/check-friday-uiux-product-happy-path.mjs`
- `git diff --check`
- real replay: `/private/tmp/friday-uiux-current-product-gates-c219cdfd-product-aggregate-20260628T194200Z/product-happy-path.json` now has mobile+desktop live-connected visual evidence and remains blocked only by `residual_endbar_blockers_present=35`

Truth: this is gate recognition for current live proof hygiene. It does not claim END-BAR, release, adoption, or that residual product blockers are cleared.