### PR TITLE
Separate healthy workbench status from negative controls

### DIFF
--- a/src/api/http/routes/friday-mission-spine-routes.ts
+++ b/src/api/http/routes/friday-mission-spine-routes.ts
@@ -81,7 +81,7 @@ export interface FridayMissionSpineRouteDecisionControlResponse {
 const DEFAULT_DISABLED_MESSAGE =
   "Mission Spine workbench projection is unavailable in this runtime; the Rust Hub projection service has not been wired.";
 
-const REQUIRED_STATUS_LABELS = ["stale", "offline", "error"] as const;
+const ALLOWED_STATUS_LABELS = new Set(["stale", "offline", "error"] as const);
 const REQUIRED_TRANSCRIPT_SURFACES = ["mobile", "desktop", "telegram", "timeline"] as const;
 const SURFACE_KINDS = new Set(REQUIRED_TRANSCRIPT_SURFACES);
 const TRANSCRIPT_GROUP_KINDS = new Set(["mission", "work_item", "provider_session", "skill_run", "channel_task", "workflow", "surface", "status", "time"]);
@@ -478,9 +478,15 @@ function validateSnapshotHeader(
   }
   pushIfInvalid(failures, hasText(snapshot.fridayConversationId), "conversation_id_missing");
   pushIfInvalid(failures, snapshot.runtimeFeedStatus === "live_rust_hub_projection", "runtime_feed_not_live");
-
-  for (const label of REQUIRED_STATUS_LABELS) {
-    pushIfInvalid(failures, snapshot.statusLabels.includes(label), `status_label_missing:${label}`);
+  pushIfInvalid(failures, Array.isArray(snapshot.statusLabels), "status_labels_not_array");
+  if (Array.isArray(snapshot.statusLabels)) {
+    for (const [index, label] of snapshot.statusLabels.entries()) {
+      pushIfInvalid(
+        failures,
+        typeof label === "string" && ALLOWED_STATUS_LABELS.has(label as "stale" | "offline" | "error"),
+        `status_label_invalid:${index}:${String(label)}`,
+      );
+    }
   }
 
   pushIfInvalid(failures, snapshot.duplicatePreflight.status === "opens_existing_mission", "duplicate_preflight_not_open_existing");

--- a/test/unit/api/routes/friday-mission-spine-routes.test.ts
+++ b/test/unit/api/routes/friday-mission-spine-routes.test.ts
@@ -338,6 +338,44 @@ describe("createFridayMissionSpineRoutes", () => {
     expect(JSON.stringify(response)).not.toContain("prep fallback");
   });
 
+  it("allows healthy live projections to omit negative status labels", async () => {
+    const healthySnapshot = cloneSnapshot({ statusLabels: [] });
+    const routes = createFridayMissionSpineRoutes({
+      workbench: { getSnapshot: vi.fn(async () => healthySnapshot) },
+      disabledReason: null,
+    });
+    const route = findRoute(routes);
+
+    const response = await route.handler(makeCtx({
+      query: { missionId: "mission_live_projection_test" },
+    }) as never);
+
+    expect(response).toEqual({ snapshot: healthySnapshot });
+  });
+
+  it("fails closed on unknown status labels without requiring negative labels on healthy projections", async () => {
+    const invalidSnapshot = cloneSnapshot({
+      statusLabels: ["online" as never],
+    });
+    const routes = createFridayMissionSpineRoutes({
+      workbench: { getSnapshot: vi.fn(async () => invalidSnapshot) },
+      disabledReason: null,
+    });
+    const route = findRoute(routes);
+
+    let thrown: unknown = null;
+    try {
+      await route.handler(makeCtx() as never);
+    } catch (err) {
+      thrown = err;
+    }
+
+    expect(thrown).toBeInstanceOf(FridayDomainError);
+    const error = thrown as FridayDomainError;
+    expect(error.code).toBe("MISSION_SPINE_WORKBENCH_SNAPSHOT_INVALID");
+    expect(JSON.stringify(error.details)).toContain("status_label_invalid:0:online");
+  });
+
   it("accepts stale WorkItems only when the retry recovery affordance is exposed", async () => {
     const staleSnapshot = cloneSnapshot({
       workItems: snapshot.workItems.map((item, index) => (


### PR DESCRIPTION
## Summary\n- stop requiring stale/offline/error labels on otherwise healthy live Mission Spine workbench projections\n- keep fail-closed validation for malformed or unknown status labels\n- add route tests for healthy empty labels and invalid label rejection\n\n## Tests\n- npm test -- --run test/unit/api/routes/friday-mission-spine-routes.test.ts\n- npm test -- --run test/unit/qa/friday-ui-device-proof-readiness-cli.test.ts test/unit/qa/friday-uiux-product-happy-path-cli.test.ts\n\n## Truth\nThis does not weaken negative-control proof. Stress/gap-report still owns stale/offline/error proof; normal product happy path is no longer forced to render those labels.