### PR TITLE
Separate unavailable from offline in selected UI truth

### DIFF
--- a/test/unit/ui/provider-truth.test.ts
+++ b/test/unit/ui/provider-truth.test.ts
@@ -151,4 +151,24 @@ describe("loadProviderTruth", () => {
     expect(truth.hasFallbackLane).toBe(false);
     expect(truth.alerts.some((alert) => alert.code === "fallback_missing")).toBe(true);
   });
+
+  it("reports missing current routing as unavailable instead of offline", async () => {
+    vi.mocked(providersApi.list).mockResolvedValue([provider] as never);
+    vi.mocked(providersApi.listHealth).mockResolvedValue([health] as never);
+    vi.mocked(providersApi.getRouting).mockResolvedValue({
+      fallbackProviderIds: [],
+    });
+    vi.mocked(providersApi.explainRouting).mockResolvedValue({
+      selectedAdjusted: false,
+      candidates: [],
+      reasonText: "no route selected",
+    } as never);
+
+    const truth = await loadProviderTruth();
+
+    expect(truth.status).toBe("unavailable");
+    expect(truth.currentStatus).toBe("unavailable");
+    expect(truth.alerts.some((alert) => alert.code === "truth_unavailable")).toBe(true);
+    expect(truth.errors).toEqual([]);
+  });
 });

--- a/test/unit/ui/system-health.test.ts
+++ b/test/unit/ui/system-health.test.ts
@@ -1,0 +1,36 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { loadSystemHealth } from "../../../ui/src/hooks/use-system-health";
+import { healthApi } from "@/lib/api/health";
+
+vi.mock("@/lib/api/health", () => ({
+  healthApi: {
+    getCapabilityHealth: vi.fn(),
+  },
+}));
+
+describe("loadSystemHealth", () => {
+  beforeEach(() => {
+    vi.mocked(healthApi.getCapabilityHealth).mockReset();
+  });
+
+  it("keeps Hub-reported unavailable separate from offline", async () => {
+    vi.mocked(healthApi.getCapabilityHealth).mockResolvedValue({
+      capabilities: {
+        system: {
+          healthStatus: "unavailable",
+        },
+      },
+    } as never);
+
+    await expect(loadSystemHealth()).resolves.toMatchObject({ status: "unavailable" });
+  });
+
+  it("reports offline only when the health request fails", async () => {
+    vi.mocked(healthApi.getCapabilityHealth).mockRejectedValue(new Error("ECONNREFUSED"));
+
+    const health = await loadSystemHealth();
+
+    expect(health.status).toBe("offline");
+    expect(health.raw).toBeInstanceOf(Error);
+  });
+});

--- a/ui/src/components/console/shell/provider-truth.tsx
+++ b/ui/src/components/console/shell/provider-truth.tsx
@@ -8,7 +8,7 @@ function statusTone(status: ProviderTruthStatus): "success" | "warning" | "dange
   if (status === "offline") {
     return "danger";
   }
-  if (status === "degraded") {
+  if (status === "degraded" || status === "unavailable") {
     return "warning";
   }
   return "success";
@@ -17,6 +17,9 @@ function statusTone(status: ProviderTruthStatus): "success" | "warning" | "dange
 function statusLabel(status: ProviderTruthStatus, locale: AppLocale): string {
   if (status === "offline") {
     return localize(locale, "离线", "Offline");
+  }
+  if (status === "unavailable") {
+    return localize(locale, "暂不可用", "Unavailable");
   }
   if (status === "degraded") {
     return localize(locale, "降级", "Degraded");
@@ -28,7 +31,7 @@ function statusDot(status: ProviderTruthStatus): string {
   if (status === "offline") {
     return "var(--rust-500)";
   }
-  if (status === "degraded") {
+  if (status === "degraded" || status === "unavailable") {
     return "var(--amber-600)";
   }
   return "var(--jade-500)";
@@ -185,7 +188,7 @@ export function ProviderTruthCard(props: {
       ?? (loading
         ? localize(locale, "正在读取当前 provider", "Reading current provider")
         : localize(locale, "当前路由不可见", "Current route unavailable")),
-    model: current?.model ?? (loading ? localize(locale, "加载中", "Loading") : localize(locale, "不可用", "Unavailable")),
+    model: current?.model ?? (loading ? localize(locale, "加载中", "Loading") : localize(locale, "未选择", "Not selected")),
     success: localize(
       locale,
       "当前真实链路已确认，provider health 与 routing explain 一致。",

--- a/ui/src/components/console/shell/right-rail-slots/channels.tsx
+++ b/ui/src/components/console/shell/right-rail-slots/channels.tsx
@@ -75,11 +75,14 @@ export function ChannelsRightRailSlot() {
 }
 
 function buildBadge(
-  status: "healthy" | "degraded" | "offline",
+  status: "healthy" | "degraded" | "unavailable" | "offline",
   locale: "zh" | "en",
 ): { label: string; color: string } {
   if (status === "offline") {
     return { label: localize(locale, "总线离线", "Bus offline"), color: "var(--rust-500)" };
+  }
+  if (status === "unavailable") {
+    return { label: localize(locale, "总线暂不可用", "Bus unavailable"), color: "var(--amber-600)" };
   }
   if (status === "degraded") {
     return { label: localize(locale, "部分降级", "Partially degraded"), color: "var(--amber-600)" };

--- a/ui/src/components/console/shell/right-rail-slots/settings-providers.tsx
+++ b/ui/src/components/console/shell/right-rail-slots/settings-providers.tsx
@@ -7,12 +7,14 @@ import { useAppLocale } from "@/providers/locale-provider";
 const STATUS_COLOR: Record<string, string> = {
   healthy: "var(--jade-500)",
   degraded: "var(--amber-600)",
+  unavailable: "var(--amber-600)",
   offline: "var(--rust-500)",
 };
 
 const STATUS_LABEL = {
   healthy: { zh: "正常", en: "Healthy" },
   degraded: { zh: "降级", en: "Degraded" },
+  unavailable: { zh: "暂不可用", en: "Unavailable" },
   offline: { zh: "不可达", en: "Offline" },
 } as const;
 

--- a/ui/src/components/console/shell/top-bar.tsx
+++ b/ui/src/components/console/shell/top-bar.tsx
@@ -16,6 +16,12 @@ function liveIndicatorParts(status: SystemHealthStatus, locale: AppLocale) {
       label: localize(locale, "离线", "Offline"),
     };
   }
+  if (status === "unavailable") {
+    return {
+      color: "var(--amber-600)",
+      label: localize(locale, "能力暂不可用", "Unavailable"),
+    };
+  }
   if (status === "degraded") {
     return {
       color: "var(--amber-600)",

--- a/ui/src/hooks/use-provider-truth.ts
+++ b/ui/src/hooks/use-provider-truth.ts
@@ -9,7 +9,7 @@ import type {
   FridayProviderRoutingExplainReport,
 } from "@/lib/api/types";
 
-export type ProviderTruthStatus = "healthy" | "degraded" | "offline";
+export type ProviderTruthStatus = "healthy" | "degraded" | "unavailable" | "offline";
 export type ProviderTruthAlertTone = "warning" | "danger";
 
 type ProviderTruthErrorSource = "providers" | "health" | "routing" | "explain";
@@ -379,14 +379,14 @@ export async function loadProviderTruth(): Promise<ProviderTruthSnapshot> {
   }
 
   const currentStatus: ProviderTruthStatus = !current
-    ? "offline"
+    ? "unavailable"
     : selectedSeverity === "healthy"
       ? "healthy"
       : "degraded";
 
   const hasWorkingRoute = Boolean(current);
   const status: ProviderTruthStatus = !hasWorkingRoute
-    ? "offline"
+    ? "unavailable"
     : alerts.length > 0 || degradedProviders.length > 0 || errors.length > 0
       ? "degraded"
       : "healthy";

--- a/ui/src/hooks/use-system-health.ts
+++ b/ui/src/hooks/use-system-health.ts
@@ -1,33 +1,36 @@
 import { useQuery } from "@tanstack/react-query";
 import { healthApi } from "@/lib/api/health";
 
-export type SystemHealthStatus = "healthy" | "degraded" | "offline";
+export type SystemHealthStatus = "healthy" | "degraded" | "unavailable" | "offline";
 
 /**
  * Collapses the full health response into a single shell indicator:
  *   healthy  — every reachable provider reports healthy
- *   degraded — at least one provider is degraded / in safe mode
- *   offline  — request failed or capability status is "unavailable"
+ *   degraded    — at least one provider is degraded / in safe mode
+ *   unavailable — the Hub responded, but the capability surface is not ready
+ *   offline     — request failed or the Hub cannot be reached
  */
+export async function loadSystemHealth(): Promise<{ status: SystemHealthStatus; raw: unknown }> {
+  try {
+    const raw = await healthApi.getCapabilityHealth();
+    const capability = (raw as { capabilities?: { system?: { healthStatus?: string } } }).capabilities;
+    const reported = capability?.system?.healthStatus;
+    if (reported === "unavailable") {
+      return { status: "unavailable", raw };
+    }
+    if (reported === "degraded" || reported === "safe_mode") {
+      return { status: "degraded", raw };
+    }
+    return { status: "healthy", raw };
+  } catch (error) {
+    return { status: "offline", raw: error };
+  }
+}
+
 export function useSystemHealthQuery() {
   return useQuery({
     queryKey: ["shell", "system-health"],
-    queryFn: async (): Promise<{ status: SystemHealthStatus; raw: unknown }> => {
-      try {
-        const raw = await healthApi.getCapabilityHealth();
-        const capability = (raw as { capabilities?: { system?: { healthStatus?: string } } }).capabilities;
-        const reported = capability?.system?.healthStatus;
-        if (reported === "unavailable") {
-          return { status: "offline", raw };
-        }
-        if (reported === "degraded" || reported === "safe_mode") {
-          return { status: "degraded", raw };
-        }
-        return { status: "healthy", raw };
-      } catch (error) {
-        return { status: "offline", raw: error };
-      }
-    },
+    queryFn: loadSystemHealth,
     refetchInterval: 30_000,
     staleTime: 15_000,
   });

--- a/ui/src/routes/home-page.tsx
+++ b/ui/src/routes/home-page.tsx
@@ -227,6 +227,12 @@ function runtimeChipParts(status: SystemHealthStatus, locale: "zh" | "en") {
       label: localize(locale, "离线", "Offline"),
     };
   }
+  if (status === "unavailable") {
+    return {
+      color: "var(--amber-600)",
+      label: localize(locale, "能力暂不可用", "Unavailable"),
+    };
+  }
   if (status === "degraded") {
     return {
       color: "var(--amber-600)",


### PR DESCRIPTION
## Summary
- keep Hub-reported capability unavailable separate from real offline request failure in the selected UI shell
- report missing provider routing as unavailable instead of offline, with matching top bar/home/right rail copy
- add focused provider/system health regressions so unavailable/offline truth cannot collapse again

## Verification
- npm test -- --run test/unit/ui/provider-truth.test.ts test/unit/ui/system-health.test.ts test/unit/qa/friday-uiux-selected-visual-proof-cli.test.ts test/unit/qa/friday-uiux-product-happy-path-cli.test.ts
- tsc -p ui/tsconfig.json --noEmit

Truth: this is not END-BAR completion; it removes a selected-UI truth downgrade and keeps normal offline reserved for unreachable Hub/request failure.