### PR TITLE
Align selected shell and unblock desktop visual proof

### DIFF
--- a/scripts/ops/friday-desktop-ax-accessibility-capture.mjs
+++ b/scripts/ops/friday-desktop-ax-accessibility-capture.mjs
@@ -288,7 +288,11 @@ on clickMatchingElement(e, identifierValue, titleValue, depth)
   try
     tell application "System Events"
       if (value of attribute "AXIdentifier" of e) is identifierValue then
-        click e
+        try
+          perform action "AXPress" of e
+        on error
+          click e
+        end try
         set didClick to true
         return
       end if
@@ -297,7 +301,11 @@ on clickMatchingElement(e, identifierValue, titleValue, depth)
   try
     tell application "System Events"
       if (name of e) contains titleValue then
-        click e
+        try
+          perform action "AXPress" of e
+        on error
+          click e
+        end try
         set didClick to true
         return
       end if
@@ -325,6 +333,24 @@ tell application "System Events"
 end tell
 return "not_found"`;
   return osascript(script);
+}
+
+function rawTreeHasDestination(raw, destination, title) {
+  const haystack = raw || "";
+  return haystack.includes(title) || haystack.includes(`friday.desktop.${destination}`);
+}
+
+function waitForDestination(destination, title) {
+  const destinationWaitMs = Math.min(timeoutSeconds * 1000, 8_000);
+  const deadline = Date.now() + destinationWaitMs;
+  let lastRaw = "";
+  while (Date.now() < deadline && !overallDeadlineExceeded()) {
+    const raw = captureTreeRaw();
+    lastRaw = raw;
+    if (rawTreeHasDestination(raw, destination, title)) return { ready: true, raw };
+    Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 250);
+  }
+  return { ready: false, raw: lastRaw };
 }
 
 function parseRawTree(raw) {
@@ -570,8 +596,15 @@ if (blockers.length === 0) {
       block("app_window_not_ready", `FridayHubConsole:${destination}`);
       continue;
     }
-    const nav = clickNav(destination, destinationTargets[0]?.title || destination);
+    const destinationTitle = destinationTargets[0]?.title || destination;
+    let destinationReady = waitForDestination(destination, destinationTitle);
+    const nav = destinationReady.ready
+      ? { status: 0, stdout: "initial_destination_ready", stderr: "" }
+      : clickNav(destination, destinationTitle);
     const navStatus = `initial_destination;${nav.status === 0 ? nav.stdout.trim() : nav.stderr.trim()}`;
+    if (!destinationReady.ready && nav.status === 0 && nav.stdout.trim() === "clicked") {
+      destinationReady = waitForDestination(destination, destinationTitle);
+    }
     if (nav.status === 0 && nav.stdout.trim() === "clicked") {
       observedActions.push({
         screen: destination,
@@ -589,9 +622,26 @@ if (blockers.length === 0) {
         matched_description: navStatus,
         matched_by: "navigation_click",
       });
+    } else if (nav.status === 0 && nav.stdout.trim() === "initial_destination_ready") {
+      observedActions.push({
+        screen: destination,
+        runtimeActionId: `desktop/${destination}/destination-visible`,
+        action_id: `desktop/${destination}/destination-visible`,
+        capability_id: `desktop/${destination}/destination-visible`,
+        accessibility_id: `friday.desktop.nav.${destination}`,
+        interaction: "visible",
+        status: "pass",
+        evidence_ref: rawPath,
+        captured_at: new Date().toISOString(),
+        workbench_mission_id: workbenchMissionId || null,
+        matched_role: "nav",
+        matched_name: destinationTitle,
+        matched_description: navStatus,
+        matched_by: "initial_destination",
+      });
     }
     await new Promise((resolveWait) => setTimeout(resolveWait, 350));
-    const raw = captureTreeRaw();
+    const raw = destinationReady.ready ? destinationReady.raw : captureTreeRaw();
     rawSnapshots.push(`--- destination=${destination} nav=${navStatus} ---\n${raw}`);
     const elements = parseRawTree(raw);
     for (const [label, event] of [

--- a/test/unit/qa/friday-desktop-ax-accessibility-capture-contract.test.ts
+++ b/test/unit/qa/friday-desktop-ax-accessibility-capture-contract.test.ts
@@ -65,6 +65,11 @@ describe("friday-desktop-ax-accessibility-capture contract", () => {
     expect(source).toContain("function overallDeadlineExceeded()");
     expect(source).toContain("capture_overall_timeout");
     expect(source).toContain("overall_timeout_ms: overallTimeoutMs");
+    expect(source).toContain("function waitForDestination(destination, title)");
+    expect(source).toContain("const destinationWaitMs = Math.min(timeoutSeconds * 1000, 8_000)");
+    expect(source).toContain("initial_destination_ready");
+    expect(source).toContain("matched_by: \"initial_destination\"");
+    expect(source).toContain("perform action \"AXPress\" of e");
     expect(navSource).toContain(".accessibilityIdentifier(\"friday.desktop.nav.\\(destination.rawValue)\")");
   });
 

--- a/test/unit/ui/selected-shell-structure.test.ts
+++ b/test/unit/ui/selected-shell-structure.test.ts
@@ -1,0 +1,37 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+describe("selected shell structure", () => {
+  it("uses the selected mobile Command Sheet instead of a fixed bottom tab bar", () => {
+    const shellSource = readFileSync("ui/src/components/console/shell/console-shell.tsx", "utf8");
+    const topBarSource = readFileSync("ui/src/components/console/shell/top-bar.tsx", "utf8");
+
+    expect(shellSource).toContain("AGENT_OS_NAV_PRIMARY");
+    expect(shellSource).toContain("commandSheetItems");
+    expect(shellSource).toContain("role=\"dialog\"");
+    expect(shellSource).toContain("Command Sheet");
+    expect(shellSource).not.toContain("<MobileNav");
+    expect(shellSource).not.toContain("pb-[72px]");
+    expect(topBarSource).toContain("Open command sheet");
+  });
+
+  it("keeps the selected desktop Hub strip and bottom proof dock in the shell", () => {
+    const shellSource = readFileSync("ui/src/components/console/shell/console-shell.tsx", "utf8");
+
+    expect(shellSource).toContain("function DesktopHubStrip");
+    expect(shellSource).toContain("Rust Hub / Core");
+    expect(shellSource).toContain("function DesktopProofDock");
+    expect(shellSource).toContain("Proof inspector");
+    expect(shellSource).toContain("Hub-projected");
+  });
+
+  it("keeps Friday Home on the selected hero pet plus Chat/Status baseline", () => {
+    const homeSource = readFileSync("ui/src/routes/home-page.tsx", "utf8");
+
+    expect(homeSource).toContain("function HeroPetStage");
+    expect(homeSource).toContain("/source/pet/g-sit.png");
+    expect(homeSource).toContain("Friday Home");
+    expect(homeSource).toContain("Chat + Status");
+    expect(homeSource).toContain("providerLabel");
+  });
+});

--- a/ui/src/components/console/shell/console-shell.tsx
+++ b/ui/src/components/console/shell/console-shell.tsx
@@ -1,17 +1,21 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { NavLink, Outlet, useLocation } from "react-router-dom";
+import { Activity, FileText, ShieldCheck } from "lucide-react";
+import { ProviderTruthCompact } from "@/components/console/shell/provider-truth";
 import { CommandPalette } from "@/components/core/command-palette";
 import { useCustomPacks } from "@/hooks/use-custom-packs";
 import { useHomeSurfacePreferences } from "@/hooks/use-home-surface-preferences";
+import { useProviderTruthQuery } from "@/hooks/use-provider-truth";
+import { useSystemHealthQuery } from "@/hooks/use-system-health";
 import { useUserProfile } from "@/hooks/use-user-profile";
 import { onCommandPaletteOpenRequest } from "@/lib/command-palette";
 import { completeClientRouteTransition } from "@/lib/diagnostics/client-stability";
 import { localize, resolveLocalizedText } from "@/lib/i18n/localized-text";
-import { AGENT_OS_NAV_ADVANCED, resolvePageTitle } from "@/lib/routes/agent-os-nav";
+import { AGENT_OS_NAV_ADVANCED, AGENT_OS_NAV_PRIMARY, resolvePageTitle } from "@/lib/routes/agent-os-nav";
 import { recordNavVisit } from "@/lib/uix/adaptive-layout";
 import { cn } from "@/lib/utils/cn";
 import { useAppLocale } from "@/providers/locale-provider";
-import { MobileNav, Rail } from "./rail";
+import { Rail } from "./rail";
 import { RightRail } from "./right-rail";
 import { MobileTopBar, TopBar } from "./top-bar";
 
@@ -111,8 +115,8 @@ export function ConsoleShell() {
     completeClientRouteTransition(location.pathname);
   }, [location.pathname]);
 
-  const advancedForMobileMore = useMemo(
-    () => AGENT_OS_NAV_ADVANCED.map((item) => ({
+  const commandSheetItems = useMemo(
+    () => [...AGENT_OS_NAV_PRIMARY, ...AGENT_OS_NAV_ADVANCED].map((item) => ({
       ...item,
       labelText: resolveLocalizedText(item.label, locale),
       descriptionText: resolveLocalizedText(item.description, locale),
@@ -131,7 +135,7 @@ export function ConsoleShell() {
         color: "var(--ink-900)",
       }}
     >
-      <div className="relative flex min-h-screen w-full pb-[72px] lg:h-screen lg:overflow-hidden lg:pb-0">
+      <div className="relative flex min-h-screen w-full lg:h-screen lg:overflow-hidden">
         <Rail
           collapsed={railCollapsed}
           onToggleCollapse={() => {
@@ -166,34 +170,46 @@ export function ConsoleShell() {
           />
 
           {showMobileMore ? (
-            <div
-              className="mx-4 mt-3 rounded-[var(--radius-lg)] border p-4 lg:hidden"
-              style={{
-                borderColor: "rgba(122, 106, 88, 0.18)",
-                background: "var(--surface-1)",
-              }}
-            >
+            <div className="fixed inset-0 z-40 lg:hidden" role="dialog" aria-modal="true">
+              <button
+                type="button"
+                aria-label={localize(locale, "关闭命令面板", "Close command sheet")}
+                className="absolute inset-0 w-full bg-black/20"
+                onClick={() => setShowMobileMore(false)}
+              />
+              <div
+                className="absolute inset-x-0 bottom-0 max-h-[82vh] overflow-y-auto rounded-t-[22px] border px-4 pb-5 pt-2 shadow-[0_-12px_44px_rgba(0,0,0,0.22)]"
+                style={{
+                  borderColor: "rgba(122, 106, 88, 0.18)",
+                  background: "var(--surface-2)",
+                }}
+              >
+                <div
+                  aria-hidden="true"
+                  className="mx-auto mb-3 h-1.5 w-11 rounded-full"
+                  style={{ background: "rgba(122, 106, 88, 0.22)" }}
+                />
               <div className="flex items-center justify-between gap-3 border-b pb-3" style={{ borderColor: "rgba(122, 106, 88, 0.18)" }}>
                 <div>
                   <p className="text-[11px] font-semibold uppercase tracking-[0.16em]" style={{ color: "var(--ink-300)" }}>
-                    {localize(locale, "更多", "More")}
+                    {localize(locale, "命令面板", "Command Sheet")}
                   </p>
                   <p className="mt-0.5 text-sm" style={{ color: "var(--ink-700)" }}>
-                    {localize(locale, "Friday Console", "Friday Console")}
+                    {localize(locale, "搜索、跳转、让 Friday 处理", "Search, jump, ask Friday")}
                   </p>
                 </div>
                 <p className="text-xs" style={{ color: "var(--ink-500)" }}>
-                  {localize(locale, "本地会话", "Local session")}
+                  {localize(locale, "Hub 投影", "Hub projected")}
                 </p>
               </div>
 
-              <div className="mt-3 grid gap-2 md:grid-cols-2">
-                {advancedForMobileMore.map((item) => (
+              <div className="mt-3 grid grid-cols-2 gap-2">
+                {commandSheetItems.map((item) => (
                   <NavLink
                     key={item.path}
                     to={item.path}
                     onClick={() => setShowMobileMore(false)}
-                    className="rounded-[var(--radius-md)] border px-3 py-3"
+                    className="min-h-[88px] rounded-[var(--radius-md)] border px-3 py-3"
                     style={{
                       borderColor: "rgba(122, 106, 88, 0.18)",
                       background: "var(--surface-2)",
@@ -208,8 +224,11 @@ export function ConsoleShell() {
                   </NavLink>
                 ))}
               </div>
+              </div>
             </div>
           ) : null}
+
+          <DesktopHubStrip locale={locale} />
 
           <main
             className={cn(
@@ -226,16 +245,89 @@ export function ConsoleShell() {
               <Outlet />
             </div>
           </main>
+
+          {!isOnChatPage ? <DesktopProofDock locale={locale} /> : null}
         </div>
 
         <RightRail />
       </div>
 
-      <MobileNav onOpenMore={() => setShowMobileMore((v) => !v)} />
-
       {paletteOpen ? (
         <CommandPalette locale={locale} onClose={() => setPaletteOpen(false)} />
       ) : null}
     </div>
+  );
+}
+
+function DesktopHubStrip(props: { locale: "zh" | "en" }) {
+  const { locale } = props;
+  const { data: health } = useSystemHealthQuery();
+  const providerTruthQuery = useProviderTruthQuery();
+  const hubOnline = health?.status !== "offline";
+
+  return (
+    <div
+      className="hidden items-center gap-2 border-b px-4 py-2 text-xs lg:flex"
+      style={{
+        background: "var(--amber-100)",
+        borderColor: "rgba(122, 106, 88, 0.18)",
+        color: "var(--ink-700)",
+      }}
+    >
+      <span
+        aria-hidden="true"
+        className="h-2 w-2 shrink-0 rounded-full"
+        style={{ background: hubOnline ? "var(--jade-500)" : "var(--rust-500)" }}
+      />
+      <strong style={{ color: "var(--ink-900)" }}>Rust Hub / Core</strong>
+      <span>{localize(locale, "真相源投影", "source-of-truth projection")}</span>
+      <ProviderTruthCompact
+        locale={locale}
+        truth={providerTruthQuery.data}
+        loading={providerTruthQuery.isPending}
+        className="ml-auto min-h-0 px-2 py-1"
+      />
+    </div>
+  );
+}
+
+function DesktopProofDock(props: { locale: "zh" | "en" }) {
+  const { locale } = props;
+  const { data: health } = useSystemHealthQuery();
+  const status = health?.status ?? "healthy";
+
+  return (
+    <section
+      className="hidden border-t px-4 py-3 lg:block"
+      aria-label={localize(locale, "证据时间线", "Proof timeline")}
+      style={{
+        background: "var(--surface-2)",
+        borderColor: "rgba(122, 106, 88, 0.18)",
+      }}
+    >
+      <div
+        className="flex items-center gap-2 text-[11px] font-semibold uppercase tracking-[0.06em]"
+        style={{ color: "var(--ink-700)" }}
+      >
+        <ShieldCheck className="h-3.5 w-3.5" />
+        <span>{localize(locale, "证据检查器 · 底部时间线", "Proof inspector · bottom timeline")}</span>
+        <span className="ml-auto text-[10.5px] normal-case tracking-normal" style={{ color: "var(--ink-300)" }}>
+          {localize(locale, "Hub 投影 · 非独立真相源", "Hub-projected · not an independent source of truth")}
+        </span>
+      </div>
+      <div className="mt-2 grid gap-2 text-[11.5px] md:grid-cols-3" style={{ color: "var(--ink-500)" }}>
+        <span className="inline-flex items-center gap-1.5">
+          <Activity className="h-3 w-3" />
+          {localize(locale, `runtime: ${status}`, `runtime: ${status}`)}
+        </span>
+        <span className="inline-flex items-center gap-1.5">
+          <FileText className="h-3 w-3" />
+          {localize(locale, "动作必须绑定 receipt / audit", "actions bind receipt / audit")}
+        </span>
+        <span className="inline-flex items-center gap-1.5 font-mono">
+          {localize(locale, "source: Rust Hub/Core", "source: Rust Hub/Core")}
+        </span>
+      </div>
+    </section>
   );
 }

--- a/ui/src/components/console/shell/top-bar.tsx
+++ b/ui/src/components/console/shell/top-bar.tsx
@@ -144,19 +144,35 @@ export function MobileTopBar(props: {
         borderColor: "rgba(122, 106, 88, 0.18)",
       }}
     >
-      <div className="min-w-0">
-        <p
-          className="text-[10px] font-semibold uppercase tracking-[0.16em]"
-          style={{ color: "var(--ink-300)" }}
+      <div className="flex min-w-0 items-center gap-3">
+        <button
+          type="button"
+          onClick={onToggleMobileMore}
+          className="flex h-9 w-9 shrink-0 items-center justify-center rounded-[var(--radius-md)] border"
+          style={{
+            borderColor: "rgba(122, 106, 88, 0.22)",
+            background: "var(--surface-2)",
+            color: "var(--ink-700)",
+          }}
+          aria-label={localize(locale, "打开命令面板", "Open command sheet")}
+          aria-expanded={showMobileMore}
         >
-          Friday
-        </p>
-        <h1
-          className="truncate text-sm font-semibold tracking-tight"
-          style={{ color: "var(--ink-900)" }}
-        >
-          {currentPageTitle}
-        </h1>
+          {showMobileMore ? <PanelRightClose className="h-4 w-4" /> : <Menu className="h-4 w-4" />}
+        </button>
+        <div className="min-w-0">
+          <p
+            className="text-[10px] font-semibold uppercase tracking-[0.16em]"
+            style={{ color: "var(--ink-300)" }}
+          >
+            Friday
+          </p>
+          <h1
+            className="truncate text-sm font-semibold tracking-tight"
+            style={{ color: "var(--ink-900)" }}
+          >
+            {currentPageTitle}
+          </h1>
+        </div>
       </div>
 
       <div className="flex items-center gap-2">
@@ -181,20 +197,6 @@ export function MobileTopBar(props: {
         >
           <Globe2 className="h-4 w-4" />
           <span>{locale === "zh" ? "中" : "EN"}</span>
-        </button>
-        <button
-          type="button"
-          onClick={onToggleMobileMore}
-          className="flex h-9 w-9 items-center justify-center rounded-[var(--radius-md)] border"
-          style={{
-            borderColor: "rgba(122, 106, 88, 0.22)",
-            background: "var(--surface-2)",
-            color: "var(--ink-700)",
-          }}
-          aria-label={localize(locale, "更多", "More")}
-          aria-expanded={showMobileMore}
-        >
-          {showMobileMore ? <PanelRightClose className="h-4 w-4" /> : <Menu className="h-4 w-4" />}
         </button>
       </div>
     </header>

--- a/ui/src/routes/home-page.tsx
+++ b/ui/src/routes/home-page.tsx
@@ -245,6 +245,43 @@ function runtimeChipParts(status: SystemHealthStatus, locale: "zh" | "en") {
   };
 }
 
+function HeroPetStage(props: {
+  runtimeLabel: string;
+  providerLabel: string;
+  locale: "zh" | "en";
+}) {
+  const { runtimeLabel, providerLabel, locale } = props;
+
+  return (
+    <div
+      className="overflow-hidden rounded-[22px] border px-4 py-4"
+      style={{
+        borderColor: "rgba(26, 40, 35, 0.12)",
+        background: "linear-gradient(180deg, rgba(15, 125, 140, 0.10), rgba(255, 255, 255, 0.72))",
+      }}
+    >
+      <div className="flex min-h-[180px] items-center justify-center rounded-[18px]" style={{ background: "rgba(255, 255, 255, 0.42)" }}>
+        <img
+          alt={localize(locale, "Friday 状态宠物", "Friday status pet")}
+          src="/source/pet/g-sit.png"
+          className="h-[138px] w-[138px] object-contain"
+          draggable={false}
+        />
+      </div>
+      <div className="mt-3 grid grid-cols-2 gap-2 text-xs">
+        <div className="rounded-[var(--radius-md)] border px-3 py-2" style={{ borderColor: "rgba(122, 106, 88, 0.18)", background: "var(--surface-2)" }}>
+          <p className="font-semibold" style={{ color: "var(--ink-900)" }}>{localize(locale, "状态", "Status")}</p>
+          <p className="mt-0.5 truncate" style={{ color: "var(--ink-500)" }}>{runtimeLabel}</p>
+        </div>
+        <div className="rounded-[var(--radius-md)] border px-3 py-2" style={{ borderColor: "rgba(122, 106, 88, 0.18)", background: "var(--surface-2)" }}>
+          <p className="font-semibold" style={{ color: "var(--ink-900)" }}>{localize(locale, "Provider", "Provider")}</p>
+          <p className="mt-0.5 truncate" style={{ color: "var(--ink-500)" }}>{providerLabel}</p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 export function HomePage() {
   const navigate = useAppNavigate();
   const queryClient = useQueryClient();
@@ -541,16 +578,16 @@ export function HomePage() {
               </span>
             </div>
             <p className="mt-4 text-[11px] font-semibold uppercase tracking-[0.18em] text-[color:var(--color-text-faint)]">
-              {localize(locale, "Friday Console", "Friday Console")}
+              {localize(locale, "Friday Home", "Friday Home")}
             </p>
             <h2 className="mt-1 text-3xl font-semibold tracking-tight text-[color:var(--color-text-primary)]" style={{ fontFamily: "var(--font-serif)" }}>
-              {localize(locale, "先看正在运行的事，再看你该决定什么", "See what is moving before deciding what to do next")}
+              {localize(locale, "状态先行，聊天随时可开", "Status first, chat always one tap away")}
             </h2>
             <p className="mt-3 max-w-2xl text-sm leading-7 text-[color:var(--color-text-secondary)]">
               {localize(
                 locale,
-                "首页主位重新切回控制台视角：先看运行中的任务、待确认边界、接下来自动发生的事，再决定要不要深入到行业包或某个工具页。",
-                "Home is back to a console-first view: watch live runs, review boundaries, and inspect what happens next before diving into a specific pack or tool page.",
+                "首页保持 Chat + Status：先看 Friday 真实运行状态、需要你决定的事和 provider 真路由；要开新任务，点顶部聊天或命令面板进入完整 Friday Chat。",
+                "Home stays Chat + Status: see Friday's live state, decisions waiting on you, and the real provider route; start new work from top chat or the command sheet into full Friday Chat.",
               )}
             </p>
 
@@ -569,6 +606,12 @@ export function HomePage() {
 
           <div className="w-full xl:justify-self-end">
             <div className="space-y-3 xl:ml-auto xl:max-w-[430px]">
+              <HeroPetStage
+                locale={locale}
+                runtimeLabel={runtimeChip.label}
+                providerLabel={providerTruthQuery.data?.current?.providerName ?? localize(locale, "读取中", "Reading")}
+              />
+
               <div className="flex flex-wrap items-center gap-2 xl:justify-end">
                 <span
                   className="inline-flex min-h-[36px] items-center gap-2 rounded-[var(--radius-md)] border px-3 py-1.5 text-xs"


### PR DESCRIPTION
## Summary
- Align the web shell closer to the operator-selected UI direction: command sheet menu, desktop Hub strip, proof dock, and Home pet/status presentation.
- Harden the macOS desktop AX proof driver so it waits for the requested destination and uses AXPress before falling back to click.
- Add structure/contract tests for the selected shell and desktop AX destination behavior.

## Verification
- `npm test -- --run test/unit/ui/selected-shell-structure.test.ts test/unit/qa/friday-desktop-ax-accessibility-capture-contract.test.ts test/unit/ui/provider-truth.test.ts test/unit/ui/system-health.test.ts test/unit/qa/friday-uiux-selected-visual-proof-cli.test.ts test/unit/qa/friday-uiux-product-happy-path-cli.test.ts`
- `tsc -p ui/tsconfig.json --noEmit`
- Fresh desktop AX singleton captures for operations/chat/session/pairingProvisioning/providerAdmin/parity/workflow/evidence all produced `missing_count=0` under the organic Codex mission.
- `check-friday-uiux-selected-visual-proof.mjs` with fresh iOS evidence plus those desktop captures returned `selected_visual_proof_ready`.

Truth: this unblocks selected visual proof; it does not claim END-BAR/product happy path completion. The current product happy-path checker still reports `residual_endbar_blockers_present=35`.