### PR TITLE
Default iOS selected proof to live loopback

### DIFF
--- a/apps/friday-ios/README.md
+++ b/apps/friday-ios/README.md
@@ -92,13 +92,23 @@ dependency graph for `arm64-apple-ios17.0-simulator` via `swift build --triple â
 then compiles the SwiftUI app against those sim-built modules with `swiftc`, assembles
 `FridayShell.app`, and installs/launches/screenshots it on a booted simulator.
 
-The default simulator launch is an **offline truth proof**. It deliberately keeps all
-`FRIDAY_MOBILE_LIVE_*` gates off, so the expected result is an honest-unavailable UI
-if the live seams are not explicitly enabled. That screenshot proves "no fabricated
-ready state"; it is not a product-ready live-use proof.
+The default simulator launch is the selected-product **live-loopback proof**. It turns on the
+existing simulator read/write/pairing/device-keypair gates so the app attempts the real local
+seams by default when you run the proof command. This does not flip the shipped app's
+fail-closed runtime defaults, mint trust, or hold signing keys; it only makes the local proof
+entrypoint show the product path rather than the negative-control path.
 
-For selected-design visual comparison, use the explicit sample lane instead of the
-offline truth lane:
+For explicit negative-control testing, use the offline truth lane:
+
+```sh
+apps/friday-ios/build-sim.sh --mode offline-truth --shot apps/friday-ios/.build-sim/friday-ios-offline-truth.png
+```
+
+`offline-truth` deliberately keeps all `FRIDAY_MOBILE_LIVE_*` gates off, so the expected result is
+an honest-unavailable UI if the live seams are not explicitly enabled. That screenshot proves
+"no fabricated ready state"; it is not a product-ready live-use proof.
+
+For selected-design visual comparison without live seams, use the explicit sample lane:
 
 ```sh
 apps/friday-ios/build-sim.sh --mode design-proof-sample --shot apps/friday-ios/.build-sim/friday-ios-design-proof-sample.png
@@ -108,7 +118,8 @@ apps/friday-ios/build-sim.sh --mode design-proof-sample --shot apps/friday-ios/.
 Home/destinations can be compared against the operator-selected HTML/JSON handoff.
 It is design proof only: no live Hub, no runtime PASS, no END-BAR, and no adoption.
 
-For local live-loopback dogfood, use the explicit mode:
+For local live-loopback dogfood, the default command is enough; `--mode live-loopback` is accepted
+when you want the mode to be explicit:
 
 ```sh
 apps/friday-ios/build-sim.sh --mode live-loopback --shot apps/friday-ios/.build-sim/friday-ios-live-loopback.png

--- a/apps/friday-ios/build-sim.sh
+++ b/apps/friday-ios/build-sim.sh
@@ -26,16 +26,17 @@ usage() {
   cat <<'USAGE'
 Usage:
   apps/friday-ios/build-sim.sh [screenshot-path]
-  apps/friday-ios/build-sim.sh --mode offline-truth [--destination pairing] [--shot screenshot-path]
   apps/friday-ios/build-sim.sh --mode live-loopback [--destination pairing] [--mission-id mission-id] [--shot screenshot-path]
+  apps/friday-ios/build-sim.sh --mode offline-truth [--destination pairing] [--shot screenshot-path]
   apps/friday-ios/build-sim.sh --mode design-proof-sample [--destination pairing] [--shot screenshot-path]
 
 Modes:
-  offline-truth  Default. Launches with all FRIDAY_MOBILE_LIVE_* gates OFF and proves the
+  live-loopback  Default selected-product proof mode. Launches with the existing simulator
+                 live gates ON (read/write/pairing/device-keypair) so the app attempts real
+                 loopback seams. It still does not flip shipped defaults, mint trust, or hold
+                 signing keys.
+  offline-truth  Explicit negative-control mode. Launches with all FRIDAY_MOBILE_LIVE_* gates OFF and proves the
                  shipped app renders honest-unavailable instead of fabricated ready state.
-  live-loopback  Explicit local proof mode. Launches with the existing simulator live gates ON
-                 (read/write/pairing/device-keypair) so the app attempts real loopback seams.
-                 It still does not flip shipped defaults, mint trust, or hold signing keys.
   design-proof-sample
                  Explicit visual parity mode. Launches a labeled PreviewReadClient sample for
                  operator-selected UI comparison only. It is not runtime proof or END-BAR.
@@ -45,7 +46,7 @@ USAGE
 HERE="$(cd "$(dirname "$0")" && pwd)"
 BUILD="$HERE/.build-sim"
 APP="$BUILD/FridayShell.app"
-MODE="offline-truth"
+MODE="live-loopback"
 SHOT="$BUILD/friday-ios-sim.png"
 DESTINATION=""
 MISSION_ID="${FRIDAY_MOBILE_MISSION_ID:-}"

--- a/scripts/ops/check-friday-ios-design-destination-capture-contract.mjs
+++ b/scripts/ops/check-friday-ios-design-destination-capture-contract.mjs
@@ -65,7 +65,7 @@ if (scriptExists) {
     "ios_selected_design_destination_capture_not_live_closure",
     "friday-design-handoff-20260602/saved/mobile-selection.json",
     "repo_head",
-    "design-proof-sample",
+    "mode=\"live-loopback\"",
     "`offline-truth` is a negative-control lane only",
     "not END-BAR",
     "not GO-LIVE",

--- a/scripts/ops/friday-ios-design-destination-capture.sh
+++ b/scripts/ops/friday-ios-design-destination-capture.sh
@@ -16,8 +16,9 @@ a manifest with truth labels.
 
 Truth: this is a design/device capture runner. It does not claim END-BAR,
 GO-LIVE, adoption, operator signing, or live workflow closure.
+Default mode is `live-loopback` so selected UI proof exercises the product path.
 `offline-truth` is a negative-control lane only and is rejected by selected
-visual proof gates; use `design-proof-sample` or `live-loopback` for visual proof.
+visual proof gates; use `design-proof-sample` only for visual comparison without live seams.
 EOF
 }
 
@@ -28,7 +29,7 @@ die() {
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 out_dir=""
-mode="design-proof-sample"
+mode="live-loopback"
 skip_initial_build=0
 destinations_csv="home,missions,session,contextPassport,tokenLedger,shareIntake,voice,pairing,needsMe,memory,platform,providerAuth,activity,workflows,onboarding,settings,petEditor,proofViewer,entrypoints"
 settle_seconds="${FRIDAY_IOS_DESIGN_CAPTURE_SETTLE_SECONDS:-6}"

--- a/test/unit/qa/friday-ios-design-destination-capture-contract-cli.test.ts
+++ b/test/unit/qa/friday-ios-design-destination-capture-contract-cli.test.ts
@@ -24,9 +24,9 @@ destinations_csv="home,missions,session,contextPassport,tokenLedger,shareIntake,
 truth_label="ios_selected_design_destination_capture_not_live_closure"
 design_source="friday-design-handoff-20260602/saved/mobile-selection.json"
 repo_head="$(git -C "$repo_root" rev-parse HEAD)"
-mode="design-proof-sample"
+mode="live-loopback"
 negative_control_note="\`offline-truth\` is a negative-control lane only"
-caveat="not END-BAR / not GO-LIVE; design-proof-sample is visual comparison only; enabled actions still require separate Hub/DB/ledger/proof closure"
+caveat="not END-BAR / not GO-LIVE; live-loopback is selected product proof but enabled actions still require separate Hub/DB/ledger/proof closure"
 ${extraScriptSource}
 `);
   return root;

--- a/test/unit/qa/friday-ios-design-destination-capture-runner.test.ts
+++ b/test/unit/qa/friday-ios-design-destination-capture-runner.test.ts
@@ -17,7 +17,7 @@ async function writeExecutable(filePath: string, content: string) {
 }
 
 describe("friday-ios-design-destination-capture runner", () => {
-  it("defaults selected design captures to design-proof-sample mode", async () => {
+  it("defaults selected design captures to live-loopback product proof mode", async () => {
     const root = process.cwd();
     const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "friday-ios-capture-design-default-"));
     const binDir = path.join(tempRoot, "bin");
@@ -73,12 +73,12 @@ exit 64
       caveat: string;
       relaunch_contract: string;
     };
-    expect(manifest.mode).toBe("design-proof-sample");
+    expect(manifest.mode).toBe("live-loopback");
     expect(manifest.repo_head).toMatch(/^[0-9a-f]{40}$/);
     expect(manifest.caveat).toContain("offline-truth is negative control only");
-    expect(manifest.relaunch_contract).toContain("design-proof sample");
+    expect(manifest.relaunch_contract).toContain("live-loopback read/write/pairing/device-keypair gates");
     await expect(fs.readFile(path.join(outDir, "screenshots", "session.launch.txt"), "utf8"))
-      .resolves.toContain("--design-proof-sample");
+      .resolves.toContain("--live-read");
   });
 
   it("captures multiple offline destinations with skip-initial-build under set -u", async () => {


### PR DESCRIPTION
## Summary
- default the iOS simulator selected-product proof entrypoints to live-loopback instead of negative-control offline-truth
- keep offline-truth as an explicit negative-control mode and design-proof-sample as visual comparison only
- update the static contract and unit coverage so selected UI proof exercises the product path by default

## Truth
- does not flip shipped app fail-closed runtime defaults
- does not mint trust, hold signing keys, claim END-BAR, GO-LIVE, adoption, or full product closure
- aligns local proof defaults with the operator-selected mobile UIUX/product path so offline/disabled screenshots do not masquerade as the normal selected product state

## Verification
- npm test -- --run test/unit/qa/friday-ios-design-destination-capture-runner.test.ts test/unit/qa/friday-ios-design-destination-capture-contract-cli.test.ts test/unit/qa/friday-uiux-product-happy-path-cli.test.ts test/unit/qa/friday-uiux-selected-visual-proof-cli.test.ts
- npm run typecheck:src -- --pretty false
- node scripts/ops/check-friday-ios-design-destination-capture-contract.mjs