### PR TITLE
Harden UI device evidence harvest

### DIFF
--- a/scripts/ops/friday-ui-device-proof-evidence-harvest.mjs
+++ b/scripts/ops/friday-ui-device-proof-evidence-harvest.mjs
@@ -11,7 +11,7 @@ function usage() {
   node scripts/ops/friday-ui-device-proof-evidence-harvest.mjs \\
     --mission-id=mission_... \\
     --search-dir=/abs/artifacts [--search-dir=/abs/other-artifacts ...] \\
-    [--out=/abs/harvest.json] [--require-ready] [--defer-channel-proof]
+    [--out=/abs/harvest.json] [--current-head=<git-sha>] [--require-ready] [--defer-channel-proof]
 
 Truth: scans existing artifact files and reports which ones are eligible inputs
 for the strict UI/device proof pipeline. It does not create proof rows, does not
@@ -46,6 +46,7 @@ if (args.includes("--help") || args.includes("-h")) {
 const missionId = arg("mission-id");
 const searchDirs = argsAll("search-dir");
 const out = arg("out");
+const currentHead = arg("current-head") || process.env.FRIDAY_UI_DEVICE_CURRENT_HEAD || "";
 const requireReady = args.includes("--require-ready");
 const deferChannelProof = args.includes("--defer-channel-proof") || process.env.FRIDAY_UI_DEVICE_DEFER_CHANNEL_PROOF === "1";
 const blockers = [];
@@ -83,6 +84,28 @@ function jsonMission(value) {
   return "";
 }
 
+function jsonHead(value) {
+  if (!value || typeof value !== "object") return "";
+  const candidates = [
+    value.headSha,
+    value.head_sha,
+    value.gitHead,
+    value.git_head,
+    value.commitSha,
+    value.commit_sha,
+    value.currentHead,
+    value.current_head,
+    value.repo?.headSha,
+    value.repo?.head_sha,
+    value.inputs?.headSha,
+    value.inputs?.head_sha,
+  ];
+  for (const candidate of candidates) {
+    if (typeof candidate === "string" && candidate.trim()) return candidate.trim();
+  }
+  return "";
+}
+
 function fileKind(path, json) {
   const lower = path.toLowerCase();
   const name = basename(lower);
@@ -90,7 +113,7 @@ function fileKind(path, json) {
   if (name === "observations-manifest.json") return "manifest";
   if (json?.proof === "mission_spine_backend_api_live_pressure") return "backendLiveProof";
   if (json?.proof === "mission_spine_channel_live_proof") return "channelLiveProof";
-  if (Array.isArray(json?.requirements) || String(json?.remaining_requirement || "").includes("UI or device consumption")) return "objectiveCoverage";
+  if (json?.proof === "mission_spine_objective_backend_wire_coverage") return "objectiveCoverage";
   if (name === "ios-live-write-read-proof.json" || name === "mobile.json") return "mobile";
   if (name === "macos-live-write-read-proof.json" || name === "desktop.json") return "desktop";
   if (name === "timeline-capture.json" || name === "timeline.json" || name === "timeline.trace" || name === "old-timeline-db.json") return "timeline";
@@ -102,8 +125,10 @@ function fileKind(path, json) {
 function shouldReject(path, json, kind) {
   const truth = String(json?.truth || json?.truth_label || "");
   const foundMission = jsonMission(json);
+  const foundHead = jsonHead(json);
   const reasons = [];
   if (foundMission && foundMission !== missionId) reasons.push(`mission_mismatch:${foundMission}`);
+  if (currentHead && foundHead && foundHead !== currentHead) reasons.push(`head_mismatch:${foundHead}`);
   if (truth.includes("synthetic")) reasons.push("synthetic_truth_label");
   if (truth.includes("partial_not_mission_spine_ui_device_proof") && kind !== "timeline") {
     reasons.push("explicit_partial_non_ui_device_truth_label");
@@ -131,6 +156,12 @@ function jsonlRejectReasons(path) {
   const missions = new Set(rows.map((row) => typeof row?.mission_id === "string" ? row.mission_id.trim() : "").filter(Boolean));
   if (missions.size === 0) return ["events_missing_mission_id"];
   if (missions.size !== 1 || !missions.has(missionId)) return [`events_mission_mismatch:${[...missions].sort().join(",")}`];
+  if (currentHead) {
+    const heads = new Set(rows.map((row) => jsonHead(row)).filter(Boolean));
+    if (heads.size > 0 && (heads.size !== 1 || !heads.has(currentHead))) {
+      reasons.push(`events_head_mismatch:${[...heads].sort().join(",")}`);
+    }
+  }
   return reasons;
 }
 
@@ -183,6 +214,7 @@ for (const input of searchDirs) {
       kind,
       path,
       missionId: jsonMission(json) || null,
+      headSha: jsonHead(json) || null,
       truth: typeof json?.truth === "string" ? json.truth : typeof json?.truth_label === "string" ? json.truth_label : null,
       eligible: rejectReasons.length === 0,
       rejectReasons,
@@ -261,6 +293,7 @@ const result = {
   truth: "ui_device_proof_evidence_harvest_not_proof_not_endbar",
   status,
   missionId,
+  currentHead: currentHead || null,
   searched: searchDirs.map(abs),
   selected,
   deferredInputs,

--- a/test/unit/qa/friday-ui-device-proof-evidence-harvest-cli.test.ts
+++ b/test/unit/qa/friday-ui-device-proof-evidence-harvest-cli.test.ts
@@ -32,6 +32,7 @@ function writeArtifacts(dir: string) {
     remaining_requirement: "real UI/device consumption evidence still required",
   });
   writeJson(objective, {
+    proof: "mission_spine_objective_backend_wire_coverage",
     remaining_requirement: "UI or device consumption must still pass",
     requirements: [{ required_gate: "scripts/mission-spine-ui-device-proof-gate.sh" }],
   });
@@ -150,6 +151,81 @@ describe("friday-ui-device-proof-evidence-harvest", () => {
       ], { cwd: process.cwd(), encoding: "utf8" });
       expect(strict.status).toBe(2);
       expect(JSON.parse(strict.stdout).status).toBe("non_channel_inputs_ready_channel_deferred");
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("does not classify native linkage as objective coverage just because it lists requirements", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "friday-ui-harvest-native-linkage-"));
+    try {
+      const artifacts = writeArtifacts(tempDir);
+      rmSync(artifacts.objective, { force: true });
+      writeJson(join(tempDir, "uiux-native-linkage.json"), {
+        truth: "uiux_native_linkage_not_screenshot_not_live_tap_not_endbar",
+        status: "linked",
+        requirements: [{ id: "native_route_present" }],
+        remaining_requirement: "UI or device consumption must still pass",
+      });
+
+      const output = execFileSync("node", [
+        script,
+        `--mission-id=${missionId}`,
+        `--search-dir=${tempDir}`,
+      ], { cwd: process.cwd(), encoding: "utf8" });
+      const result = JSON.parse(output) as {
+        selected?: { objectiveCoverage?: string };
+        rejected?: Array<{ path?: string }>;
+      };
+      expect(result.selected?.objectiveCoverage).toBe("");
+      expect(result.rejected?.some((candidate) => candidate.path?.endsWith("uiux-native-linkage.json"))).toBe(false);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects artifacts and events that carry a mismatched current head", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "friday-ui-harvest-current-head-"));
+    try {
+      const artifacts = writeArtifacts(tempDir);
+      writeJson(artifacts.mobile, {
+        missionId,
+        headSha: "old-head",
+        truth: "ios_mobile_live_write_read_roundtrip_proof_not_ui_device_proof",
+      });
+      writeFileSync(artifacts.events, `${JSON.stringify({
+        surface: "mobile",
+        event: "mission_intake_submitted",
+        mission_id: missionId,
+        headSha: "old-head",
+        evidence_ref: artifacts.mobile,
+      })}\n`);
+
+      const result = spawnSync("node", [
+        script,
+        `--mission-id=${missionId}`,
+        `--search-dir=${tempDir}`,
+        "--current-head=current-head",
+        "--require-ready",
+      ], { cwd: process.cwd(), encoding: "utf8" });
+      expect(result.status).toBe(2);
+      const output = JSON.parse(result.stdout) as {
+        selected?: { mobile?: string; events?: string[] };
+        rejected?: Array<{ path?: string; rejectReasons?: string[] }>;
+        blockers?: Array<{ code?: string; detail?: string }>;
+      };
+      expect(output.selected?.mobile).toBe("");
+      expect(output.selected?.events).toEqual([]);
+      expect(output.rejected).toContainEqual(expect.objectContaining({
+        path: artifacts.mobile,
+        rejectReasons: expect.arrayContaining(["head_mismatch:old-head"]),
+      }));
+      expect(output.rejected).toContainEqual(expect.objectContaining({
+        path: artifacts.events,
+        rejectReasons: expect.arrayContaining(["events_head_mismatch:old-head"]),
+      }));
+      expect(output.blockers).toContainEqual({ code: "missing_eligible_capture", detail: "mobile" });
+      expect(output.blockers).toContainEqual({ code: "missing_manifest_or_events", detail: "need observations-manifest.json or same-run event jsonl" });
     } finally {
       rmSync(tempDir, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary
- require explicit mission_spine_objective_backend_wire_coverage proof kind before classifying objective coverage artifacts
- add optional current-head filtering for proof artifacts and event rows that carry a head SHA
- cover native-linkage misclassification and stale-head rejection in harvest tests

## Verification
- npm test -- --run test/unit/qa/friday-ui-device-proof-evidence-harvest-cli.test.ts test/unit/qa/friday-uiux-product-happy-path-cli.test.ts test/unit/qa/friday-uiux-product-closure-readiness-contract.test.ts
- reran harvest against current UI/device artifacts; objectiveCoverage now resolves to the backend objective coverage proof, not uiux-native-linkage.json

Truth: fail-closed proof plumbing only; does not claim END-BAR, channel proof, product happy path, adoption, or release readiness.