### PR TITLE
Stamp live write-read proof events with head metadata

### DIFF
--- a/scripts/ops/friday-ios-live-write-read-capture.sh
+++ b/scripts/ops/friday-ios-live-write-read-capture.sh
@@ -25,6 +25,7 @@ die() {
 }
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+repo_head="$(git -C "${repo_root}" rev-parse HEAD 2>/dev/null || true)"
 out_dir=""
 read_host="${FRIDAY_MOBILE_LIVE_READ_HOST:-127.0.0.1}"
 read_port="${FRIDAY_MOBILE_LIVE_READ_PORT:-48751}"
@@ -155,16 +156,17 @@ node "${repo_root}/scripts/ops/friday-ios-live-write-read-proof-events.mjs" \
   --proof="${proof_path}" \
   --out="${events_path}" \
   --action-runtime-out="${action_runtime_path}" \
+  ${repo_head:+--head-sha="${repo_head}"} \
   --require-ready >/tmp/friday-ios-live-write-read-proof-events.$$.json
 
 [ -s "${events_path}" ] || die "proof-events driver did not create ${events_path}"
 [ -s "${action_runtime_path}" ] || die "proof-events driver did not create ${action_runtime_path}"
 
-node - "${proof_path}" "${events_path}" "${action_runtime_path}" "${index_path}" <<'NODE'
+node - "${proof_path}" "${events_path}" "${action_runtime_path}" "${index_path}" "${repo_head}" <<'NODE'
 const { readFileSync, writeFileSync } = require("node:fs");
 const { createHash } = require("node:crypto");
 
-const [proofPath, eventsPath, actionRuntimePath, indexPath] = process.argv.slice(2);
+const [proofPath, eventsPath, actionRuntimePath, indexPath, repoHead] = process.argv.slice(2);
 const proof = JSON.parse(readFileSync(proofPath, "utf8"));
 const events = readFileSync(eventsPath, "utf8")
   .trim()
@@ -177,6 +179,7 @@ const index = {
   truth_label: "ios_live_write_read_capture_index_not_ui_device_proof",
   status: "ready",
   generated_at_utc: new Date().toISOString(),
+  headSha: repoHead || null,
   mission_id: proof.mission_id,
   work_item_id: proof.work_item_id,
   mobile: {

--- a/scripts/ops/friday-ios-live-write-read-proof-events.mjs
+++ b/scripts/ops/friday-ios-live-write-read-proof-events.mjs
@@ -10,7 +10,7 @@ function usage() {
   node scripts/ops/friday-ios-live-write-read-proof-events.mjs \\
     --proof=/abs/friday-ios-mobile-roundtrip-proof.json \\
     [--out=/abs/mobile-roundtrip-events.jsonl] \\
-    [--action-runtime-out=/abs/action-runtime-evidence.json] [--require-ready]
+    [--action-runtime-out=/abs/action-runtime-evidence.json] [--head-sha=<git-sha>] [--require-ready]
 
 Truth: converts one real iOS live write-read roundtrip artifact into mobile
 same-run events for the UI/device capture pipeline. It is not END-BAR proof,
@@ -32,6 +32,7 @@ if (args.includes("--help") || args.includes("-h")) {
 const proofPath = arg("proof");
 const outPath = arg("out");
 const actionRuntimeOutPath = arg("action-runtime-out");
+const headSha = arg("head-sha");
 const requireReady = args.includes("--require-ready");
 const blockers = [];
 
@@ -113,6 +114,7 @@ function explicitActionRows(value) {
       evidence_ref: evidence,
       mission_id: missionId,
       work_item_id: workItemId,
+      ...(headSha ? { headSha } : {}),
       source: "ios_mobile_live_write_read_roundtrip_explicit_ui_actions",
       truth_label: "explicit_ui_action_runtime_evidence_not_endbar_not_adoption",
     };
@@ -145,6 +147,7 @@ if (missionId && !missionId.toLowerCase().includes("mission")) {
   block("mission_id_unexpected_shape", missionId);
 }
 if (surfaceKind && surfaceKind !== "mobile") block("surface_kind_not_mobile", surfaceKind);
+if (headSha && !/^[a-f0-9]{7,40}$/i.test(headSha)) block("head_sha_unexpected_shape", headSha);
 
 const write = proof?.write ?? null;
 const writeStatus = stringField(write, "status", "proof.write");
@@ -189,6 +192,7 @@ const events = blockers.length === 0
     mission_id: missionId,
     evidence_ref: evidenceRef,
     work_item_id: workItemId,
+    ...(headSha ? { headSha } : {}),
     source: "ios_mobile_live_write_read_roundtrip_artifact",
     truth_label: "mobile_same_run_event_from_live_write_read_artifact_not_ui_device_proof",
   }))
@@ -207,6 +211,7 @@ if (actionRuntimeOutPath && blockers.length === 0) {
     truth: "action_runtime_evidence_from_explicit_ios_ui_actions_not_endbar",
     status: actionRows.length > 0 ? "ready" : "no_explicit_ui_actions",
     missionId: missionId || null,
+    headSha: headSha || null,
     actions: actionRows,
   }, null, 2)}\n`);
 }
@@ -216,6 +221,7 @@ const output = {
   status: blockers.length === 0 ? "ready" : "blocked",
   missionId: missionId || null,
   workItemId: workItemId || null,
+  headSha: headSha || null,
   evidenceRef: evidenceRef || null,
   out: outPath ? abs(outPath) : null,
   eventCount: events.length,

--- a/scripts/ops/friday-macos-live-write-read-capture.sh
+++ b/scripts/ops/friday-macos-live-write-read-capture.sh
@@ -24,6 +24,7 @@ die() {
 }
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+repo_head="$(git -C "${repo_root}" rev-parse HEAD 2>/dev/null || true)"
 out_dir=""
 shared_id="${FRIDAY_MISSION_SPINE_UI_PROOF_SHARED_ID:-}"
 mission_id="${FRIDAY_MISSION_SPINE_UI_PROOF_MISSION_ID:-}"
@@ -106,16 +107,17 @@ node "${repo_root}/scripts/ops/friday-macos-live-write-read-proof-events.mjs" \
   --proof="${proof_path}" \
   --out="${events_path}" \
   --action-runtime-out="${action_runtime_path}" \
+  ${repo_head:+--head-sha="${repo_head}"} \
   --require-ready >/tmp/friday-macos-live-write-read-proof-events.$$.json
 
 [ -s "${events_path}" ] || die "proof-events driver did not create ${events_path}"
 [ -s "${action_runtime_path}" ] || die "proof-events driver did not create ${action_runtime_path}"
 
-node - "${proof_path}" "${events_path}" "${action_runtime_path}" "${index_path}" <<'NODE'
+node - "${proof_path}" "${events_path}" "${action_runtime_path}" "${index_path}" "${repo_head}" <<'NODE'
 const { readFileSync, writeFileSync } = require("node:fs");
 const { createHash } = require("node:crypto");
 
-const [proofPath, eventsPath, actionRuntimePath, indexPath] = process.argv.slice(2);
+const [proofPath, eventsPath, actionRuntimePath, indexPath, repoHead] = process.argv.slice(2);
 const proof = JSON.parse(readFileSync(proofPath, "utf8"));
 const events = readFileSync(eventsPath, "utf8")
   .trim()
@@ -128,6 +130,7 @@ const index = {
   truth_label: "macos_live_write_read_capture_index_not_ui_device_proof",
   status: "ready",
   generated_at_utc: new Date().toISOString(),
+  headSha: repoHead || null,
   mission_id: proof.mission_id,
   work_item_id: proof.work_item_id,
   desktop: {

--- a/scripts/ops/friday-macos-live-write-read-proof-events.mjs
+++ b/scripts/ops/friday-macos-live-write-read-proof-events.mjs
@@ -10,7 +10,7 @@ function usage() {
   node scripts/ops/friday-macos-live-write-read-proof-events.mjs \\
     --proof=/abs/friday-macos-desktop-roundtrip-proof.json \\
     [--out=/abs/desktop-roundtrip-events.jsonl] \\
-    [--action-runtime-out=/abs/action-runtime-evidence.json] [--require-ready]
+    [--action-runtime-out=/abs/action-runtime-evidence.json] [--head-sha=<git-sha>] [--require-ready]
 
 Truth: converts one real macOS live write-read roundtrip artifact into desktop
 same-run events for the UI/device capture pipeline. It is not END-BAR proof,
@@ -32,6 +32,7 @@ if (args.includes("--help") || args.includes("-h")) {
 const proofPath = arg("proof");
 const outPath = arg("out");
 const actionRuntimeOutPath = arg("action-runtime-out");
+const headSha = arg("head-sha");
 const requireReady = args.includes("--require-ready");
 const blockers = [];
 
@@ -113,6 +114,7 @@ function explicitActionRows(value) {
       evidence_ref: evidence,
       mission_id: missionId,
       work_item_id: workItemId,
+      ...(headSha ? { headSha } : {}),
       source: "macos_desktop_live_write_read_roundtrip_explicit_ui_actions",
       truth_label: "explicit_ui_action_runtime_evidence_not_endbar_not_adoption",
     };
@@ -145,6 +147,7 @@ if (missionId && !missionId.toLowerCase().includes("mission")) {
   block("mission_id_unexpected_shape", missionId);
 }
 if (surfaceKind && surfaceKind !== "desktop") block("surface_kind_not_desktop", surfaceKind);
+if (headSha && !/^[a-f0-9]{7,40}$/i.test(headSha)) block("head_sha_unexpected_shape", headSha);
 
 const write = proof?.write ?? null;
 const writeStatus = stringField(write, "status", "proof.write");
@@ -189,6 +192,7 @@ const events = blockers.length === 0
     mission_id: missionId,
     evidence_ref: evidenceRef,
     work_item_id: workItemId,
+    ...(headSha ? { headSha } : {}),
     source: "macos_desktop_live_write_read_roundtrip_artifact",
     truth_label: "desktop_same_run_event_from_live_write_read_artifact_not_ui_device_proof",
   }))
@@ -207,6 +211,7 @@ if (actionRuntimeOutPath && blockers.length === 0) {
     truth: "action_runtime_evidence_from_explicit_macos_ui_actions_not_endbar",
     status: actionRows.length > 0 ? "ready" : "no_explicit_ui_actions",
     missionId: missionId || null,
+    headSha: headSha || null,
     actions: actionRows,
   }, null, 2)}\n`);
 }
@@ -216,6 +221,7 @@ const output = {
   status: blockers.length === 0 ? "ready" : "blocked",
   missionId: missionId || null,
   workItemId: workItemId || null,
+  headSha: headSha || null,
   evidenceRef: evidenceRef || null,
   out: outPath ? abs(outPath) : null,
   eventCount: events.length,

--- a/test/unit/qa/friday-ios-live-write-read-capture-cli.test.ts
+++ b/test/unit/qa/friday-ios-live-write-read-capture-cli.test.ts
@@ -79,17 +79,20 @@ describe("friday-ios-live-write-read-capture", () => {
       const events = readFileSync(join(outDir, "ios-live-write-read-events.jsonl"), "utf8")
         .trim()
         .split("\n")
-        .map((line) => JSON.parse(line)) as Array<{ surface?: string; mission_id?: string }>;
+        .map((line) => JSON.parse(line)) as Array<{ surface?: string; mission_id?: string; headSha?: string }>;
       expect(events).toHaveLength(5);
       expect(new Set(events.map((event) => event.surface))).toEqual(new Set(["mobile"]));
       expect(new Set(events.map((event) => event.mission_id))).toEqual(new Set([missionId]));
 
       const index = JSON.parse(readFileSync(join(outDir, "capture-index.json"), "utf8")) as {
         status?: string;
+        headSha?: string;
         mobile?: { event_count?: number };
         caveat?: string;
       };
       expect(index.status).toBe("ready");
+      expect(index.headSha).toMatch(/^[a-f0-9]{40}$/);
+      expect(new Set(events.map((event) => event.headSha))).toEqual(new Set([index.headSha]));
       expect(index.mobile?.event_count).toBe(5);
       expect(index.caveat).toContain("Mobile same-run capture only");
     } finally {

--- a/test/unit/qa/friday-ios-live-write-read-proof-events-cli.test.ts
+++ b/test/unit/qa/friday-ios-live-write-read-proof-events-cli.test.ts
@@ -7,6 +7,7 @@ import { describe, expect, it } from "vitest";
 const script = "scripts/ops/friday-ios-live-write-read-proof-events.mjs";
 const missionId = "mission-mobile-live-roundtrip-cli";
 const workItemId = "work-mobile-live-roundtrip-cli";
+const headSha = "abcdef12".repeat(5);
 
 function proof(overrides: Record<string, unknown> = {}) {
   return {
@@ -52,12 +53,14 @@ describe("friday-ios-live-write-read-proof-events", () => {
         script,
         `--proof=${proofPath}`,
         `--out=${outPath}`,
+        `--head-sha=${headSha}`,
         "--require-ready",
       ], { cwd: process.cwd(), encoding: "utf8" });
 
-      const result = JSON.parse(stdout) as { status?: string; eventCount?: number; blockers?: unknown[] };
+      const result = JSON.parse(stdout) as { status?: string; eventCount?: number; headSha?: string; blockers?: unknown[] };
       expect(result.status).toBe("ready");
       expect(result.eventCount).toBe(5);
+      expect(result.headSha).toBe(headSha);
       expect(JSON.stringify(result)).toContain("no_explicit_ui_actions");
       expect(result.blockers).toEqual([]);
 
@@ -66,6 +69,7 @@ describe("friday-ios-live-write-read-proof-events", () => {
         event?: string;
         mission_id?: string;
         evidence_ref?: string;
+        headSha?: string;
         work_item_id?: string;
       }>;
       expect(rows.map((row) => row.event)).toEqual([
@@ -79,6 +83,7 @@ describe("friday-ios-live-write-read-proof-events", () => {
       expect(new Set(rows.map((row) => row.mission_id))).toEqual(new Set([missionId]));
       expect(new Set(rows.map((row) => row.work_item_id))).toEqual(new Set([workItemId]));
       expect(new Set(rows.map((row) => row.evidence_ref))).toEqual(new Set([proofPath]));
+      expect(new Set(rows.map((row) => row.headSha))).toEqual(new Set([headSha]));
     } finally {
       rmSync(tempDir, { recursive: true, force: true });
     }
@@ -107,6 +112,7 @@ describe("friday-ios-live-write-read-proof-events", () => {
         `--proof=${proofPath}`,
         `--out=${eventOut}`,
         `--action-runtime-out=${actionOut}`,
+        `--head-sha=${headSha}`,
         "--require-ready",
       ], { cwd: process.cwd(), encoding: "utf8" });
 
@@ -115,10 +121,12 @@ describe("friday-ios-live-write-read-proof-events", () => {
       const actionEvidence = JSON.parse(readFileSync(actionOut, "utf8")) as {
         truth?: string;
         status?: string;
-        actions?: Array<{ surface?: string; screen?: string; action_id?: string; capability_id?: string; status?: string; evidence_ref?: string }>;
+        headSha?: string;
+        actions?: Array<{ surface?: string; screen?: string; action_id?: string; capability_id?: string; status?: string; evidence_ref?: string; headSha?: string }>;
       };
       expect(actionEvidence.truth).toBe("action_runtime_evidence_from_explicit_ios_ui_actions_not_endbar");
       expect(actionEvidence.status).toBe("ready");
+      expect(actionEvidence.headSha).toBe(headSha);
       expect(actionEvidence.actions).toEqual([
         expect.objectContaining({
           surface: "mobile",
@@ -128,6 +136,7 @@ describe("friday-ios-live-write-read-proof-events", () => {
           capability_id: "ask_friday_chat",
           status: "pass",
           evidence_ref: "proof://mobile-chat-send",
+          headSha,
         }),
       ]);
     } finally {
@@ -252,6 +261,25 @@ describe("friday-ios-live-write-read-proof-events", () => {
       expect(result.status).toBe(2);
       const output = JSON.parse(result.stdout) as { blockers?: Array<{ code?: string }> };
       expect(output.blockers?.map((blocker) => blocker.code)).toContain("proof_contains_sensitive_marker");
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects malformed head sha metadata", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "friday-ios-roundtrip-events-head-"));
+    try {
+      const proofPath = writeProof(tempDir);
+      const result = spawnSync("node", [
+        script,
+        `--proof=${proofPath}`,
+        "--head-sha=not a sha",
+        "--require-ready",
+      ], { cwd: process.cwd(), encoding: "utf8" });
+
+      expect(result.status).toBe(2);
+      const output = JSON.parse(result.stdout) as { blockers?: Array<{ code?: string }> };
+      expect(output.blockers?.map((blocker) => blocker.code)).toContain("head_sha_unexpected_shape");
     } finally {
       rmSync(tempDir, { recursive: true, force: true });
     }

--- a/test/unit/qa/friday-macos-live-write-read-capture-cli.test.ts
+++ b/test/unit/qa/friday-macos-live-write-read-capture-cli.test.ts
@@ -74,17 +74,20 @@ describe("friday-macos-live-write-read-capture", () => {
       const events = readFileSync(join(outDir, "macos-live-write-read-events.jsonl"), "utf8")
         .trim()
         .split("\n")
-        .map((line) => JSON.parse(line)) as Array<{ surface?: string; mission_id?: string }>;
+        .map((line) => JSON.parse(line)) as Array<{ surface?: string; mission_id?: string; headSha?: string }>;
       expect(events).toHaveLength(5);
       expect(new Set(events.map((event) => event.surface))).toEqual(new Set(["desktop"]));
       expect(new Set(events.map((event) => event.mission_id))).toEqual(new Set([missionId]));
 
       const index = JSON.parse(readFileSync(join(outDir, "capture-index.json"), "utf8")) as {
         status?: string;
+        headSha?: string;
         desktop?: { event_count?: number };
         caveat?: string;
       };
       expect(index.status).toBe("ready");
+      expect(index.headSha).toMatch(/^[a-f0-9]{40}$/);
+      expect(new Set(events.map((event) => event.headSha))).toEqual(new Set([index.headSha]));
       expect(index.desktop?.event_count).toBe(5);
       expect(index.caveat).toContain("Desktop same-run capture only");
     } finally {

--- a/test/unit/qa/friday-macos-live-write-read-proof-events-cli.test.ts
+++ b/test/unit/qa/friday-macos-live-write-read-proof-events-cli.test.ts
@@ -7,6 +7,7 @@ import { describe, expect, it } from "vitest";
 const script = "scripts/ops/friday-macos-live-write-read-proof-events.mjs";
 const missionId = "mission-desktop-live-roundtrip-cli";
 const workItemId = "work-desktop-live-roundtrip-cli";
+const headSha = "abcdef12".repeat(5);
 
 function proof(overrides: Record<string, unknown> = {}) {
   return {
@@ -52,12 +53,14 @@ describe("friday-macos-live-write-read-proof-events", () => {
         script,
         `--proof=${proofPath}`,
         `--out=${outPath}`,
+        `--head-sha=${headSha}`,
         "--require-ready",
       ], { cwd: process.cwd(), encoding: "utf8" });
 
-      const result = JSON.parse(stdout) as { status?: string; eventCount?: number; blockers?: unknown[] };
+      const result = JSON.parse(stdout) as { status?: string; eventCount?: number; headSha?: string; blockers?: unknown[] };
       expect(result.status).toBe("ready");
       expect(result.eventCount).toBe(5);
+      expect(result.headSha).toBe(headSha);
       expect(JSON.stringify(result)).toContain("no_explicit_ui_actions");
       expect(result.blockers).toEqual([]);
 
@@ -66,6 +69,7 @@ describe("friday-macos-live-write-read-proof-events", () => {
         event?: string;
         mission_id?: string;
         evidence_ref?: string;
+        headSha?: string;
         work_item_id?: string;
       }>;
       expect(rows.map((row) => row.event)).toEqual([
@@ -79,6 +83,7 @@ describe("friday-macos-live-write-read-proof-events", () => {
       expect(new Set(rows.map((row) => row.mission_id))).toEqual(new Set([missionId]));
       expect(new Set(rows.map((row) => row.work_item_id))).toEqual(new Set([workItemId]));
       expect(new Set(rows.map((row) => row.evidence_ref))).toEqual(new Set([proofPath]));
+      expect(new Set(rows.map((row) => row.headSha))).toEqual(new Set([headSha]));
     } finally {
       rmSync(tempDir, { recursive: true, force: true });
     }
@@ -107,6 +112,7 @@ describe("friday-macos-live-write-read-proof-events", () => {
         `--proof=${proofPath}`,
         `--out=${eventOut}`,
         `--action-runtime-out=${actionOut}`,
+        `--head-sha=${headSha}`,
         "--require-ready",
       ], { cwd: process.cwd(), encoding: "utf8" });
 
@@ -115,10 +121,12 @@ describe("friday-macos-live-write-read-proof-events", () => {
       const actionEvidence = JSON.parse(readFileSync(actionOut, "utf8")) as {
         truth?: string;
         status?: string;
-        actions?: Array<{ surface?: string; screen?: string; action_id?: string; capability_id?: string; status?: string; evidence_ref?: string }>;
+        headSha?: string;
+        actions?: Array<{ surface?: string; screen?: string; action_id?: string; capability_id?: string; status?: string; evidence_ref?: string; headSha?: string }>;
       };
       expect(actionEvidence.truth).toBe("action_runtime_evidence_from_explicit_macos_ui_actions_not_endbar");
       expect(actionEvidence.status).toBe("ready");
+      expect(actionEvidence.headSha).toBe(headSha);
       expect(actionEvidence.actions).toEqual([
         expect.objectContaining({
           surface: "desktop",
@@ -128,6 +136,7 @@ describe("friday-macos-live-write-read-proof-events", () => {
           capability_id: "security_approval_bound_principal_gate_cat10_netnew",
           status: "pass",
           evidence_ref: "proof://desktop-chat-approve",
+          headSha,
         }),
       ]);
     } finally {
@@ -252,6 +261,25 @@ describe("friday-macos-live-write-read-proof-events", () => {
       expect(result.status).toBe(2);
       const output = JSON.parse(result.stdout) as { blockers?: Array<{ code?: string }> };
       expect(output.blockers?.map((blocker) => blocker.code)).toContain("proof_contains_sensitive_marker");
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects malformed head sha metadata", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "friday-macos-roundtrip-events-head-"));
+    try {
+      const proofPath = writeProof(tempDir);
+      const result = spawnSync("node", [
+        script,
+        `--proof=${proofPath}`,
+        "--head-sha=not a sha",
+        "--require-ready",
+      ], { cwd: process.cwd(), encoding: "utf8" });
+
+      expect(result.status).toBe(2);
+      const output = JSON.parse(result.stdout) as { blockers?: Array<{ code?: string }> };
+      expect(output.blockers?.map((blocker) => blocker.code)).toContain("head_sha_unexpected_shape");
     } finally {
       rmSync(tempDir, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary
- add optional head SHA stamping to iOS and macOS live write/read proof event converters
- propagate the current repo HEAD from capture wrappers into event rows, action runtime rows, and capture indexes
- add fail-closed tests so same-SHA harvest gates can reject stale evidence instead of mixing old runs

## Verification
- npm test -- --run test/unit/qa/friday-ios-live-write-read-proof-events-cli.test.ts test/unit/qa/friday-macos-live-write-read-proof-events-cli.test.ts test/unit/qa/friday-ios-live-write-read-capture-cli.test.ts test/unit/qa/friday-macos-live-write-read-capture-cli.test.ts test/unit/qa/friday-ui-device-proof-evidence-harvest-cli.test.ts

Truth: this is proof hygiene for same-SHA UI/device evidence. It does not claim END-BAR, GO-LIVE, release, or full product maturity.