### PR TITLE
Harden product happy-path satisfaction truth labels

### DIFF
--- a/scripts/ops/check-friday-uiux-product-happy-path.mjs
+++ b/scripts/ops/check-friday-uiux-product-happy-path.mjs
@@ -310,7 +310,7 @@ const allowedSatisfactionClasses = new Set([
   "channel_live_product_proof",
   "human_release_acceptance",
 ]);
-const forbiddenSatisfactionTruth = /(partial|not[-_ ]?endbar|not[-_ ]?proof|design[-_ ]?proof|screenshot|mock|fixture|sample|dry[-_ ]?run|offline|unavailable|placeholder)/i;
+const forbiddenSatisfactionTruth = /(partial|not[-_ ]?(?:endbar|proof|full[-_ ]?proof|product[-_ ]?proof|ui[-_ ]?device[-_ ]?proof)|design[-_ ]?proof|screenshot|mock|fixture|sample|dry[-_ ]?run|offline|unavailable|placeholder)/i;
 
 function satisfactionRows(report) {
   if (!report) return [];

--- a/test/unit/qa/friday-uiux-product-happy-path-cli.test.ts
+++ b/test/unit/qa/friday-uiux-product-happy-path-cli.test.ts
@@ -230,6 +230,49 @@ describe("check-friday-uiux-product-happy-path", () => {
     }
   });
 
+  it("rejects blocker satisfaction backed by not-ui-device proof labels", () => {
+    const root = mkdtempSync(join(tmpdir(), "friday-happy-path-not-ui-device-satisfaction-"));
+    try {
+      const visual = writeJson(root, "visual.json", selectedVisual("live-loopback"));
+      const trace = writeJson(root, "trace.json", traceability({
+        counts: {
+          runtimeEvidenceInputs: 2,
+          productActionsMissingRuntimeEvidence: 0,
+          destinationsWithResidualEndBarBlockers: 1,
+          destinationsStillBlocked: 1,
+        },
+        gaps: {
+          residualEndBarBlockers: [{
+            surface: "mobile",
+            id: "home",
+            blockers: [{ kind: "needsRuntimeEvidence", label: "same-run user proof" }],
+          }],
+        },
+      }));
+      const blockerSatisfaction = satisfaction(root, [satisfiedHomeRow({
+        evidenceClass: "live_write_read_projection_proof",
+        evidenceTruthLabels: ["mobile_same_run_event_from_live_write_read_artifact_not_ui_device_proof"],
+      })]);
+      const result = spawnSync("node", [
+        script,
+        `--repo-root=${process.cwd()}`,
+        `--selected-visual-report=${visual}`,
+        `--action-traceability-report=${trace}`,
+        `--blocker-satisfaction-report=${blockerSatisfaction}`,
+        "--require-complete",
+      ], { cwd: process.cwd(), encoding: "utf8" });
+      expect(result.status).toBe(1);
+      const report = JSON.parse(result.stdout) as { blockers?: Array<{ code?: string; detail?: string }> };
+      expect(report.blockers).toEqual(expect.arrayContaining([
+        expect.objectContaining({ code: "blocker_satisfaction_report_invalid" }),
+        expect.objectContaining({ code: "residual_endbar_blockers_present" }),
+      ]));
+      expect(JSON.stringify(report.blockers)).toContain("satisfaction_evidence_truth_forbidden");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   it("rejects negative status labels on the connected happy path", () => {
     const root = mkdtempSync(join(tmpdir(), "friday-happy-path-negative-labels-"));
     try {


### PR DESCRIPTION
## Summary
- tighten product happy-path blocker satisfaction truth-label rejection for not-full/not-product/not-ui-device proof labels
- add a regression test proving live write/read projection artifacts cannot satisfy full UI/device product blockers

## Verification
- npm test -- --run test/unit/qa/friday-uiux-product-happy-path-cli.test.ts

Truth: this is gate hardening against false-positive END-BAR claims. It does not close UI/device product blockers by itself.