### PR TITLE
Add product blocker satisfaction builder

### DIFF
--- a/scripts/ops/build-friday-uiux-product-blocker-satisfaction.mjs
+++ b/scripts/ops/build-friday-uiux-product-blocker-satisfaction.mjs
@@ -1,0 +1,214 @@
+#!/usr/bin/env node
+
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, isAbsolute, resolve } from "node:path";
+
+const args = process.argv.slice(2);
+
+function arg(name) {
+  const prefix = `--${name}=`;
+  for (let index = 0; index < args.length; index += 1) {
+    const value = args[index];
+    if (value.startsWith(prefix)) return value.slice(prefix.length);
+    if (value === `--${name}` && args[index + 1]) return args[index + 1];
+  }
+  return "";
+}
+
+function argsAll(name) {
+  const prefix = `--${name}=`;
+  const values = [];
+  for (let index = 0; index < args.length; index += 1) {
+    const value = args[index];
+    if (value.startsWith(prefix)) {
+      values.push(value.slice(prefix.length));
+    } else if (value === `--${name}` && args[index + 1]) {
+      values.push(args[index + 1]);
+      index += 1;
+    }
+  }
+  return values;
+}
+
+function usage() {
+  console.error(`usage:
+  node scripts/ops/build-friday-uiux-product-blocker-satisfaction.mjs \\
+    --head=<current-main-sha> --satisfaction-report=/abs/report.json [...] \\
+    [--out=/abs/product-blocker-satisfaction.json] [--require-ready]
+
+Truth: merges already-produced product blocker satisfaction manifests only when
+they are ready, same-head, live-connected, current-head, and backed by allowed
+evidence classes. This builder does not create product proof from partial
+write/read artifacts, screenshots, offline evidence, fixtures, or stale reports.`);
+}
+
+if (args.includes("--help") || args.includes("-h")) {
+  usage();
+  process.exit(0);
+}
+
+const currentHead = arg("head") || process.env.FRIDAY_UIUX_PRODUCT_SATISFACTION_HEAD || "";
+const outPath = arg("out") || process.env.FRIDAY_UIUX_PRODUCT_SATISFACTION_OUT || "";
+const requireReady = args.includes("--require-ready");
+const inputReports = [
+  ...argsAll("satisfaction-report"),
+  ...(process.env.FRIDAY_UIUX_PRODUCT_SATISFACTION_REPORTS
+    ? process.env.FRIDAY_UIUX_PRODUCT_SATISFACTION_REPORTS.split(/[:\n]/).filter(Boolean)
+    : []),
+];
+
+const blockers = [];
+const notes = [];
+
+function abs(path) {
+  return isAbsolute(path) ? path : resolve(path);
+}
+
+function block(code, detail) {
+  blockers.push({ code, detail });
+}
+
+function note(code, detail) {
+  notes.push({ code, detail });
+}
+
+function readJson(path) {
+  const resolved = abs(path);
+  try {
+    return JSON.parse(readFileSync(resolved, "utf8"));
+  } catch (error) {
+    block("input_unreadable", `${resolved}:${error.message}`);
+    return null;
+  }
+}
+
+function rowKey(row) {
+  return [
+    String(row?.surface || ""),
+    String(row?.id || row?.destination || ""),
+    String(row?.kind || row?.blockerKind || row?.blocker_kind || ""),
+    String(row?.label || row?.blockerLabel || row?.blocker_label || ""),
+  ].join("\u001f");
+}
+
+const allowedEvidenceClasses = new Set([
+  "same_run_ui_device_product_proof",
+  "operator_signed_approval_proof",
+  "provider_credential_live_proof",
+  "device_pairing_live_proof",
+  "live_write_read_projection_proof",
+  "memory_behavior_delta_proof",
+  "channel_live_product_proof",
+  "human_release_acceptance",
+]);
+
+const forbiddenTruth = /(partial|not[-_ ]?(?:endbar|proof|full[-_ ]?proof|product[-_ ]?proof|ui[-_ ]?device[-_ ]?proof)|design[-_ ]?proof|screenshot|mock|fixture|sample|dry[-_ ]?run|offline|unavailable|placeholder)/i;
+
+function validateReport(report, source) {
+  if (!report) return [];
+  const rows = Array.isArray(report.satisfactions) ? report.satisfactions : [];
+  const truth = String(report.truth || report.truth_label || report.truthLabel || "");
+  if (!/blocker.*satisfaction/i.test(truth)) {
+    block("input_truth_unexpected", `${source}:${truth || "missing"}`);
+    return [];
+  }
+  if (report.status !== "ready") {
+    block("input_not_ready", `${source}:${String(report.status || "missing")}`);
+    return [];
+  }
+  if (!currentHead) {
+    block("current_head_missing", source);
+    return [];
+  }
+  if (String(report.head || "") !== currentHead) {
+    block("input_head_mismatch", `${source}:${String(report.head || "missing")}`);
+    return [];
+  }
+  if (rows.length === 0) {
+    note("input_has_no_satisfactions", source);
+  }
+  return rows;
+}
+
+function validateRow(row, source, index) {
+  const label = `${source}:satisfactions[${index}]`;
+  const invalid = [];
+  const evidenceClass = String(row?.evidenceClass || row?.evidence_class || "");
+  const evidenceRefs = Array.isArray(row?.evidenceRefs)
+    ? row.evidenceRefs
+    : Array.isArray(row?.evidence_refs)
+      ? row.evidence_refs
+      : [];
+  const truthLabels = Array.isArray(row?.evidenceTruthLabels)
+    ? row.evidenceTruthLabels
+    : Array.isArray(row?.evidence_truth_labels)
+      ? row.evidence_truth_labels
+      : [];
+  if (row?.status !== "satisfied") invalid.push(`status=${String(row?.status || "missing")}`);
+  if (!row?.surface) invalid.push("surface=missing");
+  if (!row?.id && !row?.destination) invalid.push("id=missing");
+  if (!row?.kind && !row?.blockerKind && !row?.blocker_kind) invalid.push("kind=missing");
+  if (!row?.label && !row?.blockerLabel && !row?.blocker_label) invalid.push("label=missing");
+  if (!allowedEvidenceClasses.has(evidenceClass)) invalid.push(`evidenceClass=${evidenceClass || "missing"}`);
+  if (evidenceRefs.length === 0) invalid.push("evidenceRefs=missing");
+  if (truthLabels.length === 0) invalid.push("evidenceTruthLabels=missing");
+  for (const truthLabel of truthLabels) {
+    if (forbiddenTruth.test(String(truthLabel || ""))) invalid.push(`forbiddenTruth=${truthLabel}`);
+  }
+  if (row?.sameRun !== true && row?.same_run !== true) invalid.push("sameRun=false");
+  if (row?.liveConnected !== true && row?.live_connected !== true) invalid.push("liveConnected=false");
+  if (row?.currentHead !== true && row?.current_head !== true) invalid.push("currentHead=false");
+  if (invalid.length > 0) {
+    block("row_invalid", `${label}:${invalid.join(",")}`);
+    return null;
+  }
+  return row;
+}
+
+if (inputReports.length === 0) {
+  block("input_reports_missing", "provide at least one --satisfaction-report");
+}
+
+const byKey = new Map();
+const sources = [];
+for (const input of inputReports) {
+  const source = abs(input);
+  sources.push(source);
+  const report = readJson(source);
+  const rows = validateReport(report, source);
+  rows.forEach((row, index) => {
+    const valid = validateRow(row, source, index);
+    if (!valid) return;
+    const key = rowKey(valid);
+    if (!byKey.has(key)) byKey.set(key, valid);
+  });
+}
+
+if (byKey.size === 0) {
+  block("no_valid_satisfactions", "no rows survived validation");
+}
+
+const output = {
+  truth: "uiux_product_blocker_satisfaction_manifest",
+  status: blockers.length === 0 ? "ready" : "not_ready",
+  head: currentHead,
+  sources,
+  counts: {
+    inputReports: sources.length,
+    satisfactions: byKey.size,
+  },
+  satisfactions: [...byKey.values()],
+  blockers,
+  notes,
+  caveat:
+    "Builder output only merges same-head, ready blocker-satisfaction rows. It does not weaken END-BAR, mint proof, or convert partial evidence into product UI/device proof.",
+};
+
+if (outPath) {
+  const out = abs(outPath);
+  mkdirSync(dirname(out), { recursive: true });
+  writeFileSync(out, `${JSON.stringify(output, null, 2)}\n`);
+}
+
+console.log(JSON.stringify(output, null, 2));
+process.exit(requireReady && blockers.length > 0 ? 1 : 0);

--- a/test/unit/qa/friday-uiux-product-blocker-satisfaction-builder-cli.test.ts
+++ b/test/unit/qa/friday-uiux-product-blocker-satisfaction-builder-cli.test.ts
@@ -1,0 +1,124 @@
+import { execFileSync, spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const script = "scripts/ops/build-friday-uiux-product-blocker-satisfaction.mjs";
+const head = "abc1234";
+
+function writeJson(root: string, relative: string, value: unknown) {
+  const target = join(root, relative);
+  mkdirSync(dirname(target), { recursive: true });
+  writeFileSync(target, `${JSON.stringify(value, null, 2)}\n`);
+  return target;
+}
+
+function row(overrides: Record<string, unknown> = {}) {
+  return {
+    surface: "mobile",
+    id: "home",
+    kind: "needsRuntimeEvidence",
+    label: "same-run user proof",
+    status: "satisfied",
+    evidenceClass: "same_run_ui_device_product_proof",
+    evidenceRefs: ["proof://same-run/mobile-home"],
+    evidenceTruthLabels: ["same_run_ui_device_product_proof"],
+    sameRun: true,
+    liveConnected: true,
+    currentHead: true,
+    ...overrides,
+  };
+}
+
+function manifest(root: string, rows: Array<Record<string, unknown>>, overrides: Record<string, unknown> = {}) {
+  return writeJson(root, `manifest-${Math.random().toString(16).slice(2)}.json`, {
+    truth: "uiux_product_blocker_satisfaction_manifest",
+    status: "ready",
+    head,
+    satisfactions: rows,
+    ...overrides,
+  });
+}
+
+describe("build-friday-uiux-product-blocker-satisfaction", () => {
+  it("merges same-head satisfaction manifests and deduplicates rows", () => {
+    const root = mkdtempSync(join(tmpdir(), "friday-satisfaction-builder-ready-"));
+    try {
+      const first = manifest(root, [row()]);
+      const second = manifest(root, [row(), row({
+        surface: "desktop",
+        id: "chat",
+        label: "full desktop tap proof",
+        evidenceRefs: ["proof://same-run/desktop-chat"],
+      })]);
+      const output = execFileSync("node", [
+        script,
+        `--head=${head}`,
+        `--satisfaction-report=${first}`,
+        `--satisfaction-report=${second}`,
+        "--require-ready",
+      ], { cwd: process.cwd(), encoding: "utf8" });
+      const report = JSON.parse(output) as {
+        status?: string;
+        counts?: { satisfactions?: number };
+        satisfactions?: Array<{ surface?: string; id?: string }>;
+        blockers?: unknown[];
+      };
+      expect(report.status).toBe("ready");
+      expect(report.counts?.satisfactions).toBe(2);
+      expect(report.satisfactions?.map((item) => `${item.surface}:${item.id}`)).toEqual([
+        "mobile:home",
+        "desktop:chat",
+      ]);
+      expect(report.blockers).toEqual([]);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects stale-head satisfaction manifests", () => {
+    const root = mkdtempSync(join(tmpdir(), "friday-satisfaction-builder-stale-"));
+    try {
+      const stale = manifest(root, [row()], { head: "old1234" });
+      const result = spawnSync("node", [
+        script,
+        `--head=${head}`,
+        `--satisfaction-report=${stale}`,
+        "--require-ready",
+      ], { cwd: process.cwd(), encoding: "utf8" });
+      expect(result.status).toBe(1);
+      const report = JSON.parse(result.stdout) as { blockers?: Array<{ code?: string; detail?: string }> };
+      expect(report.blockers).toEqual(expect.arrayContaining([
+        expect.objectContaining({ code: "input_head_mismatch" }),
+        expect.objectContaining({ code: "no_valid_satisfactions" }),
+      ]));
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects partial or not-ui-device truth labels", () => {
+    const root = mkdtempSync(join(tmpdir(), "friday-satisfaction-builder-partial-"));
+    try {
+      const partial = manifest(root, [row({
+        evidenceTruthLabels: ["mobile_same_run_event_from_live_write_read_artifact_not_ui_device_proof"],
+      })]);
+      const result = spawnSync("node", [
+        script,
+        `--head=${head}`,
+        `--satisfaction-report=${partial}`,
+        "--require-ready",
+      ], { cwd: process.cwd(), encoding: "utf8" });
+      expect(result.status).toBe(1);
+      const report = JSON.parse(result.stdout) as { blockers?: Array<{ code?: string; detail?: string }> };
+      expect(report.blockers).toEqual(expect.arrayContaining([
+        expect.objectContaining({ code: "row_invalid" }),
+        expect.objectContaining({ code: "no_valid_satisfactions" }),
+      ]));
+      expect(JSON.stringify(report.blockers)).toContain("forbiddenTruth");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add a same-head product blocker satisfaction manifest builder
- reject stale reports, non-ready manifests, missing evidence refs, and partial/not-ui-device/offline/mock truth labels
- add regression coverage for dedupe, stale-head rejection, and partial proof rejection

## Verification
- npm test -- --run test/unit/qa/friday-uiux-product-blocker-satisfaction-builder-cli.test.ts test/unit/qa/friday-uiux-product-happy-path-cli.test.ts

Truth: this automates proof-manifest hygiene only. It does not close END-BAR or convert partial evidence into product proof.