### PR TITLE
Default simulator product launches to live loopback

### DIFF
--- a/apps/friday-ios/Sources/FridayMobileShell/FridayApp.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayApp.swift
@@ -230,6 +230,7 @@ final class FridaySession: ObservableObject {
 
   static func useDeviceKeypair(args: [String], env: [String: String]) -> Bool {
     MobileRuntimeGates.useDeviceKeypair(args: args, env: env)
+      || productLiveLoopbackDefaultRequested(args: args, env: env)
   }
 
   static func designProofSampleRequested(args: [String], env: [String: String]) -> Bool {
@@ -238,15 +239,29 @@ final class FridaySession: ObservableObject {
 
   static func defaultDeviceKeypairBackend(args: [String], env: [String: String]) -> DeviceKeypairBackend {
     #if targetEnvironment(simulator)
-    if MobileRuntimeGates.simulatorFileDeviceKeypairRequested(args: args, env: env) {
+    if MobileRuntimeGates.simulatorFileDeviceKeypairRequested(args: args, env: env)
+      || productLiveLoopbackDefaultRequested(args: args, env: env) {
       return SimulatorFileDeviceKeypairBackend()
     }
     #endif
     return KeychainDeviceKeypairBackend()
   }
 
+  static func productLiveLoopbackDefaultRequested(args: [String], env: [String: String]) -> Bool {
+    #if targetEnvironment(simulator)
+    let isSimulator = true
+    #else
+    let isSimulator = false
+    #endif
+    return MobileRuntimeGates.productLiveLoopbackDefaultRequested(
+      args: args,
+      env: env,
+      isSimulator: isSimulator)
+  }
+
   static func liveReadRequested(args: [String], env: [String: String]) -> Bool {
     MobileRuntimeGates.liveReadRequested(args: args, env: env)
+      || productLiveLoopbackDefaultRequested(args: args, env: env)
   }
 
   static func liveReadConfig(args: [String], env: [String: String]) throws -> ReadProjectionServerConfig {
@@ -266,6 +281,7 @@ final class FridaySession: ObservableObject {
 
   static func liveWriteRequested(args: [String], env: [String: String]) -> Bool {
     MobileRuntimeGates.liveWriteRequested(args: args, env: env)
+      || productLiveLoopbackDefaultRequested(args: args, env: env)
   }
 
   static func liveWriteConfig(args: [String], env: [String: String]) throws -> AgentRunServerConfig {
@@ -285,6 +301,7 @@ final class FridaySession: ObservableObject {
 
   static func livePairingRequested(args: [String], env: [String: String]) -> Bool {
     MobileRuntimeGates.livePairingRequested(args: args, env: env)
+      || productLiveLoopbackDefaultRequested(args: args, env: env)
   }
 
   static func runControlRequested(args: [String], env: [String: String]) -> Bool {

--- a/apps/friday-ios/Sources/FridayMobileShellCore/MobileRuntimeGates.swift
+++ b/apps/friday-ios/Sources/FridayMobileShellCore/MobileRuntimeGates.swift
@@ -26,6 +26,33 @@ public enum MobileRuntimeGates {
     args.contains("--design-proof-sample") || env["FRIDAY_MOBILE_DESIGN_PROOF_SAMPLE"] == "1"
   }
 
+  /// Product launch profile for local/simulator builds.
+  ///
+  /// Design/offline proof modes stay explicit negative controls. Product mode is additive: it only
+  /// selects the real loopback read/write/pairing seams; those seams still fail closed if the Hub,
+  /// peer enrollment, owner gate, or PairAck is not real.
+  public static func productLiveLoopbackDefaultRequested(
+    args: [String],
+    env: [String: String],
+    isSimulator: Bool
+  ) -> Bool {
+    if designProofSampleRequested(args: args, env: env) {
+      return false
+    }
+    if args.contains("--offline-truth") || env["FRIDAY_MOBILE_OFFLINE_TRUTH"] == "1" {
+      return false
+    }
+    if args.contains("--disable-product-live-loopback")
+      || env["FRIDAY_MOBILE_DISABLE_PRODUCT_LIVE_LOOPBACK"] == "1" {
+      return false
+    }
+    if args.contains("--product-live-loopback")
+      || env["FRIDAY_MOBILE_PRODUCT_LIVE_LOOPBACK"] == "1" {
+      return true
+    }
+    return isSimulator
+  }
+
   public static func liveReadRequested(args: [String], env: [String: String]) -> Bool {
     args.contains("--live-read") || env["FRIDAY_MOBILE_LIVE_READ"] == "1"
   }

--- a/apps/friday-ios/Tests/FridayMobileShellCoreTests/MobileRuntimeGatesTests.swift
+++ b/apps/friday-ios/Tests/FridayMobileShellCoreTests/MobileRuntimeGatesTests.swift
@@ -13,6 +13,50 @@ func mobileRuntimeGatesDefaultOff() {
 }
 
 @Test
+func mobileRuntimeProductLiveLoopbackDefaultsOnlyForProductSimulatorProfile() {
+  #expect(MobileRuntimeGates.productLiveLoopbackDefaultRequested(
+    args: [],
+    env: [:],
+    isSimulator: true))
+  #expect(!MobileRuntimeGates.productLiveLoopbackDefaultRequested(
+    args: [],
+    env: [:],
+    isSimulator: false))
+  #expect(MobileRuntimeGates.productLiveLoopbackDefaultRequested(
+    args: ["--product-live-loopback"],
+    env: [:],
+    isSimulator: false))
+  #expect(MobileRuntimeGates.productLiveLoopbackDefaultRequested(
+    args: [],
+    env: ["FRIDAY_MOBILE_PRODUCT_LIVE_LOOPBACK": "1"],
+    isSimulator: false))
+}
+
+@Test
+func mobileRuntimeProductLiveLoopbackKeepsProofAndOfflineProfilesClosed() {
+  #expect(!MobileRuntimeGates.productLiveLoopbackDefaultRequested(
+    args: ["--design-proof-sample"],
+    env: [:],
+    isSimulator: true))
+  #expect(!MobileRuntimeGates.productLiveLoopbackDefaultRequested(
+    args: ["--offline-truth"],
+    env: [:],
+    isSimulator: true))
+  #expect(!MobileRuntimeGates.productLiveLoopbackDefaultRequested(
+    args: ["--disable-product-live-loopback"],
+    env: [:],
+    isSimulator: true))
+  #expect(!MobileRuntimeGates.productLiveLoopbackDefaultRequested(
+    args: [],
+    env: ["FRIDAY_MOBILE_DISABLE_PRODUCT_LIVE_LOOPBACK": "1"],
+    isSimulator: true))
+  #expect(!MobileRuntimeGates.productLiveLoopbackDefaultRequested(
+    args: [],
+    env: ["FRIDAY_MOBILE_OFFLINE_TRUTH": "1"],
+    isSimulator: true))
+}
+
+@Test
 func mobileRuntimeGatesAcceptExplicitArgs() {
   #expect(MobileRuntimeGates.liveReadRequested(args: ["--live-read"], env: [:]))
   #expect(MobileRuntimeGates.liveWriteRequested(args: ["--live-write"], env: [:]))


### PR DESCRIPTION
## Summary
- add a product live-loopback launch profile for local/simulator iOS builds
- make simulator product launches choose real read/write/pairing seams and a persistent simulator device keypair by default
- keep design-proof/offline-truth negative controls explicit and fail-closed

## Verification
- swift test --package-path apps/friday-ios --filter MobileRuntimeGatesTests
- swift build --package-path apps/friday-ios

Truth: this does not fabricate ready state, does not enable run-control, does not sign, and does not claim END-BAR. It removes a hidden proof-mode dependency for simulator/local product launches while preserving honest failures when Hub enrollment or PairAck is missing.