### PR TITLE
fix(ui): aggregate runtime evidence for closure gates

### DIFF
--- a/scripts/ops/friday-ui-device-proof-readiness.sh
+++ b/scripts/ops/friday-ui-device-proof-readiness.sh
@@ -22,6 +22,10 @@ WORKBENCH_DB="${FRIDAY_WORKBENCH_DB_PATH:-}"
 DESIGN_ACTION_CONTRACT="${FRIDAY_DESIGN_ACTION_CONTRACT:-}"
 DESIGN_ACTION_RUNTIME_EVIDENCE="${FRIDAY_DESIGN_ACTION_RUNTIME_EVIDENCE:-}"
 DEFER_CHANNEL_PROOF="${FRIDAY_UI_DEVICE_DEFER_CHANNEL_PROOF:-0}"
+DESIGN_ACTION_RUNTIME_EVIDENCE_PATHS=()
+if [ -n "${DESIGN_ACTION_RUNTIME_EVIDENCE:-}" ]; then
+  IFS=':' read -r -a DESIGN_ACTION_RUNTIME_EVIDENCE_PATHS <<<"${DESIGN_ACTION_RUNTIME_EVIDENCE}"
+fi
 DESIGN_ACTION_RUNTIME_EVIDENCE_DIRS=()
 if [ -n "${FRIDAY_DESIGN_ACTION_RUNTIME_EVIDENCE_DIRS:-}" ]; then
   IFS=':' read -r -a DESIGN_ACTION_RUNTIME_EVIDENCE_DIRS <<<"${FRIDAY_DESIGN_ACTION_RUNTIME_EVIDENCE_DIRS}"
@@ -159,7 +163,7 @@ while [ "$#" -gt 0 ]; do
         usage >&2
         exit 64
       fi
-      DESIGN_ACTION_RUNTIME_EVIDENCE="$2"
+      DESIGN_ACTION_RUNTIME_EVIDENCE_PATHS+=("$2")
       shift
       ;;
     --design-action-runtime-evidence-dir)
@@ -206,6 +210,22 @@ first_existing() {
     fi
   done
   return 1
+}
+
+sync_design_action_runtime_evidence_env() {
+  local joined=""
+  local candidate
+  set +u
+  for candidate in "${DESIGN_ACTION_RUNTIME_EVIDENCE_PATHS[@]}"; do
+    [ -n "$candidate" ] || continue
+    if [ -z "$joined" ]; then
+      joined="$candidate"
+    else
+      joined="${joined}:$candidate"
+    fi
+  done
+  set -u
+  DESIGN_ACTION_RUNTIME_EVIDENCE="$joined"
 }
 
 discover_action_runtime_evidence_paths() {
@@ -261,6 +281,34 @@ function pathsFromIndex(indexPath) {
     .map((candidate) => path.isAbsolute(candidate) ? candidate : path.resolve(indexDir, candidate));
 }
 
+function walkRuntimeEvidence(root) {
+  const found = [];
+  const seen = new Set();
+  const stack = [{ dir: root, depth: 0 }];
+  const maxDepth = 8;
+  const ignored = new Set([".git", "node_modules", "target", ".build", "DerivedData"]);
+  while (stack.length > 0) {
+    const item = stack.pop();
+    if (!item || seen.has(item.dir) || item.depth > maxDepth) continue;
+    seen.add(item.dir);
+    let entries = [];
+    try {
+      entries = fs.readdirSync(item.dir, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const entry of entries) {
+      const candidate = path.join(item.dir, entry.name);
+      if (entry.isDirectory()) {
+        if (!ignored.has(entry.name)) stack.push({ dir: candidate, depth: item.depth + 1 });
+      } else if (entry.isFile() && ["action-runtime-evidence.json", "design-action-runtime-evidence.json"].includes(entry.name)) {
+        found.push(candidate);
+      }
+    }
+  }
+  return found;
+}
+
 const found = [];
 for (const rawDir of process.argv.slice(2)) {
   if (!rawDir) continue;
@@ -278,6 +326,7 @@ for (const rawDir of process.argv.slice(2)) {
     ...pathsFromIndex(path.join(dir, "capture-index.json")),
     ...pathsFromIndex(path.join(dir, "desktop", "capture-index.json")),
     ...pathsFromIndex(path.join(dir, "mobile", "capture-index.json")),
+    ...walkRuntimeEvidence(dir),
   );
 }
 
@@ -433,12 +482,19 @@ discover_evidence_dir() {
       "$dir/mission-spine-objective-coverage.json" \
       "$dir/mission-spine-objective-coverage-gate.json" || true)"
   fi
-  if [ -z "${DESIGN_ACTION_RUNTIME_EVIDENCE:-}" ]; then
-    DESIGN_ACTION_RUNTIME_EVIDENCE="$(first_existing \
+  set +u
+  local runtime_evidence_path_count="${#DESIGN_ACTION_RUNTIME_EVIDENCE_PATHS[@]}"
+  set -u
+  if [ "$runtime_evidence_path_count" -eq 0 ]; then
+    local discovered_runtime_evidence
+    discovered_runtime_evidence="$(first_existing \
       "$dir/action-runtime-evidence.json" \
       "$dir/design-action-runtime-evidence.json" \
       "$dir/bundle/action-runtime-evidence.json" \
       "$dir/bundle/design-action-runtime-evidence.json" || true)"
+    if [ -n "${discovered_runtime_evidence:-}" ]; then
+      DESIGN_ACTION_RUNTIME_EVIDENCE_PATHS+=("$discovered_runtime_evidence")
+    fi
   fi
 }
 
@@ -468,6 +524,7 @@ emit_blocked_report() {
 }
 
 discover_evidence_dir "$EVIDENCE_DIR"
+sync_design_action_runtime_evidence_env
 export MISSION_ID="${MISSION_ID:-}"
 export MOBILE_EVIDENCE="${MOBILE_EVIDENCE:-}"
 export DESKTOP_EVIDENCE="${DESKTOP_EVIDENCE:-}"
@@ -789,9 +846,9 @@ run_design_action_gap_if_possible() {
   if [ -n "${EVIDENCE_DIR:-}" ]; then
     args+=("--evidence-dir=$(abs_path "$EVIDENCE_DIR")")
   fi
-  if [ -n "${DESIGN_ACTION_RUNTIME_EVIDENCE:-}" ]; then
-    IFS=':' read -r -a runtime_evidence_paths <<<"${DESIGN_ACTION_RUNTIME_EVIDENCE}"
-  fi
+  set +u
+  runtime_evidence_paths+=("${DESIGN_ACTION_RUNTIME_EVIDENCE_PATHS[@]}")
+  set -u
   set +u
   local -a discovery_dirs=()
   if [ -n "${EVIDENCE_DIR:-}" ]; then

--- a/scripts/ops/friday-uiux-product-closure-readiness.mjs
+++ b/scripts/ops/friday-uiux-product-closure-readiness.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import { spawnSync } from "node:child_process";
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, isAbsolute, resolve } from "node:path";
 
 const args = process.argv.slice(2);
@@ -244,7 +244,37 @@ function runtimeEvidenceFromDir(dir) {
     ...runtimeEvidenceFromIndex(`${resolved}/live-write-read-bundle-index.json`),
     ...runtimeEvidenceFromIndex(`${resolved}/bundle/live-write-read-bundle-index.json`),
     ...runtimeEvidenceFromIndex(`${resolved}/capture-index.json`),
+    ...recursiveRuntimeEvidenceFromDir(resolved),
   ].filter((candidate, index, values) => existsSync(candidate) && values.indexOf(candidate) === index);
+}
+
+function recursiveRuntimeEvidenceFromDir(root) {
+  if (!root || !existsSync(root)) return [];
+  const found = [];
+  const stack = [{ dir: root, depth: 0 }];
+  const seen = new Set();
+  const ignored = new Set([".git", "node_modules", "target", ".build", "DerivedData"]);
+  const maxDepth = 8;
+  while (stack.length > 0) {
+    const item = stack.pop();
+    if (!item || seen.has(item.dir) || item.depth > maxDepth) continue;
+    seen.add(item.dir);
+    let entries = [];
+    try {
+      entries = readdirSync(item.dir, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const entry of entries) {
+      const candidate = resolve(item.dir, entry.name);
+      if (entry.isDirectory()) {
+        if (!ignored.has(entry.name)) stack.push({ dir: candidate, depth: item.depth + 1 });
+      } else if (entry.isFile() && ["action-runtime-evidence.json", "design-action-runtime-evidence.json"].includes(entry.name)) {
+        found.push(candidate);
+      }
+    }
+  }
+  return found;
 }
 
 function unique(values) {

--- a/test/unit/qa/friday-ui-device-proof-readiness-cli.test.ts
+++ b/test/unit/qa/friday-ui-device-proof-readiness-cli.test.ts
@@ -888,6 +888,59 @@ describe("friday-ui-device-proof-readiness", () => {
     }
   });
 
+  it("accumulates repeated explicit design action runtime evidence paths", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "friday-ui-device-readiness-action-explicit-"));
+    try {
+      writePartialEvidenceDir(tempDir);
+      const contract = writeDesignActionContract(tempDir);
+      const bundle = writeDesignActionRuntimeBundleDir(tempDir);
+
+      const stdout = execFileSync("bash", [
+        "scripts/ops/friday-ui-device-proof-readiness.sh",
+        "--evidence-dir",
+        tempDir,
+        "--design-action-contract",
+        contract,
+        "--design-action-runtime-evidence",
+        bundle.mobileRuntime,
+        "--design-action-runtime-evidence",
+        bundle.desktopRuntime,
+      ], {
+        cwd: process.cwd(),
+        encoding: "utf8",
+      });
+      const result = JSON.parse(stdout.slice(stdout.indexOf("{"))) as {
+        truth?: string;
+        status?: string;
+        notes?: string[];
+        blockers?: string[];
+      };
+
+      expect(result.truth).toBe("report_only_not_ui_device_proof");
+      expect(result.status).toBe("blocked");
+      expect(result.blockers).toContain("ui_device_proof_evidence:missing_required_real_evidence_env");
+      expect(result.notes?.some((note) => note.includes("design_action_runtime_gap:runtime_actions_covered"))).toBe(true);
+
+      const actionReport = JSON.parse(readFileSync(join(tempDir, "design-action-runtime-gap.json"), "utf8")) as {
+        status?: string;
+        runtimeEvidenceInputs?: string[];
+        counts?: {
+          missingRuntimeEvidence?: number;
+          missingUniqueRuntimeEvidence?: number;
+        };
+      };
+      expect(actionReport.status).toBe("runtime_actions_covered");
+      expect(actionReport.runtimeEvidenceInputs).toEqual(expect.arrayContaining([
+        bundle.mobileRuntime,
+        bundle.desktopRuntime,
+      ]));
+      expect(actionReport.counts?.missingRuntimeEvidence).toBe(0);
+      expect(actionReport.counts?.missingUniqueRuntimeEvidence).toBe(0);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
   it("passes supporting proofs into the gap report without satisfying UI device proof", () => {
     const tempDir = mkdtempSync(join(tmpdir(), "friday-ui-device-readiness-supporting-"));
     try {

--- a/test/unit/qa/friday-uiux-product-closure-readiness-contract.test.ts
+++ b/test/unit/qa/friday-uiux-product-closure-readiness-contract.test.ts
@@ -49,4 +49,12 @@ describe("friday-uiux-product-closure-readiness contract", () => {
     expect(source).toContain("evidence set only lists inputs; each referenced artifact is still revalidated");
     expect(source).toContain("evidenceSets,");
   });
+
+  it("discovers nested runtime action evidence instead of requiring hand-built flat lists", () => {
+    const source = readFileSync("scripts/ops/friday-uiux-product-closure-readiness.mjs", "utf8");
+
+    expect(source).toContain("function recursiveRuntimeEvidenceFromDir");
+    expect(source).toContain('["action-runtime-evidence.json", "design-action-runtime-evidence.json"].includes(entry.name)');
+    expect(source).toContain("...recursiveRuntimeEvidenceFromDir(resolved)");
+  });
 });


### PR DESCRIPTION
## Summary
- accumulate repeated design action runtime evidence inputs in the UI/device readiness wrapper
- discover nested action-runtime evidence files from closure evidence directories
- keep channel-deferred and missing-proof states blocked while removing false runtime-action gaps

## Verification
- PATH=/Users/jarvis/Projects/Friday/node_modules/.bin:/opt/homebrew/opt/rustup/bin:/opt/homebrew/Cellar/openjdk@21/21.0.11/libexec/openjdk.jdk/Contents/Home/bin:/Users/jarvis/Library/Android/sdk/emulator:/Users/jarvis/Library/Android/sdk/platform-tools:/Users/jarvis/Library/Android/sdk/cmdline-tools/latest/bin:/Users/jarvis/.cargo/bin:/Users/jarvis/.local/bin:/Users/jarvis/.nvm/versions/node/v22.22.0/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pkg/env/active/bin:/opt/pmk/env/global/bin:/Library/Apple/usr/bin:/Users/jarvis/.codex/packages/standalone/releases/0.140.0-aarch64-apple-darwin/codex-path:/Users/jarvis/.codex/tmp/arg0/codex-arg0cmUNHd:/opt/homebrew/opt/rustup/bin:/Users/jarvis/.cargo/bin:/opt/homebrew/Cellar/openjdk@21/21.0.11/libexec/openjdk.jdk/Contents/Home/bin:/Users/jarvis/Library/Android/sdk/emulator:/Users/jarvis/Library/Android/sdk/platform-tools:/Users/jarvis/Library/Android/sdk/cmdline-tools/latest/bin:/Users/jarvis/.local/bin:/Users/jarvis/.bun/bin:/Users/jarvis/.nvm/versions/node/v22.22.0/bin npm test -- test/unit/qa/friday-ui-device-proof-readiness-cli.test.ts test/unit/qa/friday-uiux-product-closure-readiness-contract.test.ts
- node --check scripts/ops/friday-uiux-product-closure-readiness.mjs
- bash -n scripts/ops/friday-ui-device-proof-readiness.sh
- git diff --check
- patched product closure rerun: designActionRuntime=runtime_actions_covered, uiDevice blocker remains channel_deferred_strict_assembly_blocked