### PR TITLE
fix(ops): make Phase24E proof prompts deterministic

### DIFF
--- a/.github/workflows/real-green-gate.yml
+++ b/.github/workflows/real-green-gate.yml
@@ -421,6 +421,8 @@ jobs:
       FRIDAY_TELEGRAM_MODE: ${{ secrets.FRIDAY_TELEGRAM_MODE || vars.FRIDAY_TELEGRAM_MODE }}
       PHASE24E_TELEGRAM_LISTENER_TIMEOUT_MS: "1800000"
       PHASE24E_TELEGRAM_POLLING_TIMEOUT_SEC: "5"
+      PHASE24E_TELEGRAM_REJECT_CANDIDATE_ID: phase24e-reject-run-${{ github.run_id }}
+      PHASE24E_TELEGRAM_APPROVE_CANDIDATE_ID: phase24e-approve-run-${{ github.run_id }}
     steps:
       - uses: actions/checkout@v5
         with:

--- a/scripts/ops/phase24e-telegram-workflow-candidate-listener.mjs
+++ b/scripts/ops/phase24e-telegram-workflow-candidate-listener.mjs
@@ -97,6 +97,12 @@ function buildNonce(kind, explicitEnvVar) {
   return `phase24e-${kind}-run-${runId}-${sha}`;
 }
 
+function buildCandidateId(kind, explicitEnvVar) {
+  const explicit = process.env[explicitEnvVar]?.trim();
+  if (explicit) return sanitizeNoncePart(explicit, `phase24e-${kind}-explicit`);
+  return `phase24e-${kind}-${Date.now()}`;
+}
+
 function tail(value) {
   const text = typeof value === "number" ? String(value) : typeof value === "string" ? value : "";
   if (text.length === 0) return null;
@@ -198,6 +204,8 @@ function readEnvConfig() {
     githubSha: process.env.GITHUB_SHA?.trim() || null,
     rejectNonce,
     approveNonce,
+    rejectCandidateId: buildCandidateId("reject", "PHASE24E_TELEGRAM_REJECT_CANDIDATE_ID"),
+    approveCandidateId: buildCandidateId("approve", "PHASE24E_TELEGRAM_APPROVE_CANDIDATE_ID"),
   };
 }
 
@@ -414,8 +422,8 @@ async function writeReport(report, token) {
 
 function seedWorkflowCandidates(stateDir, config) {
   const candidateRepo = createFridayReflexCandidateRepository();
-  const rejectCandidateId = `phase24e-reject-${Date.now()}`;
-  const approveCandidateId = `phase24e-approve-${Date.now()}`;
+  const rejectCandidateId = config.rejectCandidateId;
+  const approveCandidateId = config.approveCandidateId;
   const generatorSessionId = `phase24e-approve-session-${Date.now()}`;
   const db = new Database(path.join(stateDir, "friday.db"));
   try {

--- a/test/unit/ops/run-real-green-gate-self-hosted.test.ts
+++ b/test/unit/ops/run-real-green-gate-self-hosted.test.ts
@@ -188,6 +188,21 @@ describe("run-real-green-gate-self-hosted", () => {
     expect(c45JobSection).not.toContain("OPENAI_API_KEY");
   });
 
+  it("makes Phase24E Telegram workflow candidate ids deterministic for manual proof prompts", () => {
+    const workflow = readFileSync(join(process.cwd(), ".github/workflows/real-green-gate.yml"), "utf8");
+    const phase24eSection = workflow.slice(
+      workflow.indexOf("phase24e-telegram-workflow-candidate:"),
+      workflow.indexOf("phase24f-discord-workflow-candidate:"),
+    );
+
+    expect(phase24eSection).toContain(
+      "PHASE24E_TELEGRAM_REJECT_CANDIDATE_ID: phase24e-reject-run-${{ github.run_id }}",
+    );
+    expect(phase24eSection).toContain(
+      "PHASE24E_TELEGRAM_APPROVE_CANDIDATE_ID: phase24e-approve-run-${{ github.run_id }}",
+    );
+  });
+
   it("passes an explicit workspace root while keeping runtime state isolated", () => {
     const paths = {
       stateDir: "/tmp/friday-rgg-runtime/state",


### PR DESCRIPTION
## Summary
- make Phase24E Telegram workflow-candidate IDs accept explicit env overrides, matching the deterministic run-id shape already used by Phase24F/G
- wire the Real Green Gate Phase24E job to set reject/approve candidate IDs from `github.run_id`
- add a workflow test so Phase24E does not regress to log-only prompt discovery

## Why
GitHub CLI does not expose in-progress job logs reliably, so Phase24E's `Date.now()` candidate IDs make the required trusted-user message unknowable during the live listener window. This preserves the same trusted-user proof bar while making the prompt computable from the run id, consistent with the Discord/Lark workflow-candidate jobs.

## Verification
- `node --check scripts/ops/phase24e-telegram-workflow-candidate-listener.mjs`
- `git diff --check`
- `npm test -- --run test/unit/ops/run-real-green-gate-self-hosted.test.ts test/unit/scripts/ops/validate-channel-proof-artifacts.test.ts`