### PR TITLE
fix(ops): enable Phase24 trusted inbound mirror oracle

### DIFF
--- a/scripts/ops/phase24b-discord-trusted-inbound-listener.mjs
+++ b/scripts/ops/phase24b-discord-trusted-inbound-listener.mjs
@@ -550,6 +550,11 @@ async function main() {
       skillDirs: [],
       port: 0,
       logRequests: false,
+      // Phase24B proves the live channel adapter by reading the current-runner
+      // session mirror. Production/default hubs keep TS session execution
+      // fail-closed; this disposable proof harness opts in to the same
+      // test-oracle path used by live channel E2E coverage.
+      allowTestOnlySessionExecution: true,
       channels: {
         enabled: false,
         instances: [],

--- a/scripts/ops/phase24c-telegram-trusted-inbound-listener.mjs
+++ b/scripts/ops/phase24c-telegram-trusted-inbound-listener.mjs
@@ -559,6 +559,11 @@ async function main() {
       skillDirs: [],
       port: 0,
       logRequests: false,
+      // Phase24C proves the live channel adapter by reading the current-runner
+      // session mirror. Production/default hubs keep TS session execution
+      // fail-closed; this disposable proof harness opts in to the same
+      // test-oracle path used by live channel E2E coverage.
+      allowTestOnlySessionExecution: true,
       channels: {
         enabled: false,
         instances: [],

--- a/scripts/ops/phase24d-lark-feishu-trusted-inbound-listener.mjs
+++ b/scripts/ops/phase24d-lark-feishu-trusted-inbound-listener.mjs
@@ -663,6 +663,11 @@ async function main() {
       skillDirs: [],
       port: 0,
       logRequests: false,
+      // Phase24D proves the live channel adapter by reading the current-runner
+      // session mirror. Production/default hubs keep TS session execution
+      // fail-closed; this disposable proof harness opts in to the same
+      // test-oracle path used by live channel E2E coverage.
+      allowTestOnlySessionExecution: true,
       channels: {
         enabled: false,
         instances: [],

--- a/scripts/ops/phase24e-telegram-workflow-candidate-listener.mjs
+++ b/scripts/ops/phase24e-telegram-workflow-candidate-listener.mjs
@@ -663,6 +663,11 @@ async function main() {
       skillDirs: [],
       port: 0,
       logRequests: false,
+      // Phase24E verifies candidate acks via the current-runner session mirror.
+      // Production/default hubs keep TS session execution fail-closed; this
+      // disposable proof harness opts in to the same test-oracle path used by
+      // live channel E2E coverage.
+      allowTestOnlySessionExecution: true,
       channels: {
         enabled: false,
         instances: [],

--- a/scripts/ops/phase24f-discord-workflow-candidate-listener.mjs
+++ b/scripts/ops/phase24f-discord-workflow-candidate-listener.mjs
@@ -396,6 +396,11 @@ async function main() {
       skillDirs: [],
       port: 0,
       logRequests: false,
+      // Phase24F verifies candidate acks via the current-runner session mirror.
+      // Production/default hubs keep TS session execution fail-closed; this
+      // disposable proof harness opts in to the same test-oracle path used by
+      // live channel E2E coverage.
+      allowTestOnlySessionExecution: true,
       channels: { enabled: false, instances: [] },
     });
 

--- a/scripts/ops/phase24g-lark-feishu-workflow-candidate-listener.mjs
+++ b/scripts/ops/phase24g-lark-feishu-workflow-candidate-listener.mjs
@@ -435,6 +435,11 @@ async function main() {
       skillDirs: [],
       port: 0,
       logRequests: false,
+      // Phase24G verifies candidate acks via the current-runner session mirror.
+      // Production/default hubs keep TS session execution fail-closed; this
+      // disposable proof harness opts in to the same test-oracle path used by
+      // live channel E2E coverage.
+      allowTestOnlySessionExecution: true,
       channels: { enabled: false, instances: [] },
     });
 

--- a/test/unit/scripts/ops/phase24-trusted-inbound-session-mirror-oracle.test.ts
+++ b/test/unit/scripts/ops/phase24-trusted-inbound-session-mirror-oracle.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+
+const PHASE24_LISTENERS_THAT_ASSERT_SESSION_MESSAGES = [
+  "phase24b-discord-trusted-inbound-listener.mjs",
+  "phase24c-telegram-trusted-inbound-listener.mjs",
+  "phase24d-lark-feishu-trusted-inbound-listener.mjs",
+  "phase24e-telegram-workflow-candidate-listener.mjs",
+  "phase24f-discord-workflow-candidate-listener.mjs",
+  "phase24g-lark-feishu-workflow-candidate-listener.mjs",
+];
+
+describe("Phase24 listener session-message proof oracle", () => {
+  it.each(PHASE24_LISTENERS_THAT_ASSERT_SESSION_MESSAGES)(
+    "%s opts into session mirror writes for the disposable proof harness",
+    (filename) => {
+      const scriptPath = path.resolve(__dirname, "../../../../scripts/ops", filename);
+      const source = fs.readFileSync(scriptPath, "utf8");
+
+      expect(source).toMatch(/waitForUserSessionMirror|waitForCandidateAck/u);
+      expect(source).toContain("allowTestOnlySessionExecution: true");
+      expect(source).toContain("Production/default hubs keep TS session execution");
+    },
+  );
+});


### PR DESCRIPTION
## Summary
- opt Phase24B/C/D disposable trusted-inbound proof harnesses into the session mirror test oracle they already wait on
- opt Phase24E/F/G workflow-candidate proof harnesses into the same oracle because their ack verification reads current-runner session messages
- keep production/default hub behavior fail-closed; this only affects isolated proof harness stateDirs
- add a regression test that Phase24 listeners which assert session-message proof keep the explicit oracle opt-in and truth-boundary comment

## Verification
- node --check scripts/ops/phase24b-discord-trusted-inbound-listener.mjs
- node --check scripts/ops/phase24c-telegram-trusted-inbound-listener.mjs
- node --check scripts/ops/phase24d-lark-feishu-trusted-inbound-listener.mjs
- node --check scripts/ops/phase24e-telegram-workflow-candidate-listener.mjs
- node --check scripts/ops/phase24f-discord-workflow-candidate-listener.mjs
- node --check scripts/ops/phase24g-lark-feishu-workflow-candidate-listener.mjs
- npx vitest run test/unit/scripts/ops/phase24-trusted-inbound-session-mirror-oracle.test.ts test/unit/scripts/ops/phase24d-lark-feishu-trusted-inbound.test.ts test/unit/scripts/ops/phase24f-discord-workflow-candidate.test.ts test/unit/scripts/ops/phase24g-lark-feishu-workflow-candidate.test.ts
- npx eslint --no-warn-ignored scripts/ops/phase24b-discord-trusted-inbound-listener.mjs scripts/ops/phase24c-telegram-trusted-inbound-listener.mjs scripts/ops/phase24d-lark-feishu-trusted-inbound-listener.mjs scripts/ops/phase24e-telegram-workflow-candidate-listener.mjs scripts/ops/phase24f-discord-workflow-candidate-listener.mjs scripts/ops/phase24g-lark-feishu-workflow-candidate-listener.mjs test/unit/scripts/ops/phase24-trusted-inbound-session-mirror-oracle.test.ts
- git diff --check

Truth: this does not fabricate trusted-user channel messages and does not make Phase24 pass by itself; it removes the session-message proof harness gap exposed by run 28345636569.