### PR TITLE
fix(ops): record Phase24 workflow ack delivery

### DIFF
--- a/scripts/ops/lib/workflow-candidate-proof-harness.mjs
+++ b/scripts/ops/lib/workflow-candidate-proof-harness.mjs
@@ -258,6 +258,72 @@ async function waitForCandidateAck(baseUrl, channelKind, chatId, candidateId, ex
   return null;
 }
 
+function observeChannelOutboundAcks(hub, report, persistReport) {
+  const originalSend = hub.channelRegistry.send.bind(hub.channelRegistry);
+  const deliveries = [];
+
+  hub.channelRegistry.send = async (kind, options) => {
+    const text = typeof options?.text === "string" ? options.text : "";
+    const startedAt = new Date().toISOString();
+    try {
+      const delivery = await originalSend(kind, options);
+      const entry = {
+        kind,
+        chatIdTail: tail(options?.chatId),
+        replyToMessageIdTail: tail(options?.replyTo),
+        messageIdTail: tail(delivery?.messageId),
+        deliveredAt: new Date().toISOString(),
+        startedAt,
+        reflexCandidateAck: text.includes("Reflex candidate ") && text.includes(" 已更新为 "),
+        text,
+      };
+      deliveries.push(entry);
+      report.diagnostics.channelOutboundDeliveries = deliveries;
+      await persistReport?.("channel_outbound_delivery").catch(() => {});
+      return delivery;
+    } catch (error) {
+      const entry = {
+        kind,
+        chatIdTail: tail(options?.chatId),
+        replyToMessageIdTail: tail(options?.replyTo),
+        deliveredAt: null,
+        startedAt,
+        error: error instanceof Error ? `${error.name}: ${error.message}` : String(error),
+        reflexCandidateAck: text.includes("Reflex candidate ") && text.includes(" 已更新为 "),
+        text,
+      };
+      deliveries.push(entry);
+      report.diagnostics.channelOutboundDeliveries = deliveries;
+      await persistReport?.("channel_outbound_delivery_failed").catch(() => {});
+      throw error;
+    }
+  };
+
+  return {
+    deliveries,
+    restore() {
+      hub.channelRegistry.send = originalSend;
+    },
+  };
+}
+
+async function waitForObservedChannelAck(observer, candidateId, expectedStatusWord, timeoutMs) {
+  const deadline = Date.now() + timeoutMs;
+  const needle = `Reflex candidate ${candidateId} 已更新为 ${expectedStatusWord}`;
+  while (Date.now() < deadline) {
+    const found = observer.deliveries.find((entry) =>
+      entry?.reflexCandidateAck === true
+      && typeof entry?.text === "string"
+      && entry.text.includes(needle)
+      && typeof entry?.messageIdTail === "string"
+      && entry.messageIdTail.length > 0
+    );
+    if (found) return found;
+    await delay(1000);
+  }
+  return null;
+}
+
 async function waitForCandidateStatus(stateDir, candidateId, expectedStatus, timeoutMs) {
   const deadline = Date.now() + timeoutMs;
   let lastSeen = null;
@@ -290,9 +356,11 @@ export {
   getSessionMessages,
   installWorkflowApprovalStub,
   listWorkflowsByTag,
+  observeChannelOutboundAcks,
   seedWorkflowCandidates,
   tail,
   withTimeout,
   waitForCandidateAck,
+  waitForObservedChannelAck,
   waitForCandidateStatus,
 };

--- a/scripts/ops/phase24f-discord-workflow-candidate-listener.mjs
+++ b/scripts/ops/phase24f-discord-workflow-candidate-listener.mjs
@@ -28,10 +28,12 @@ import {
   findFreePort,
   installWorkflowApprovalStub,
   listWorkflowsByTag,
+  observeChannelOutboundAcks,
   seedWorkflowCandidates,
   tail,
   withTimeout,
   waitForCandidateAck,
+  waitForObservedChannelAck,
   waitForCandidateStatus,
 } from "./lib/workflow-candidate-proof-harness.mjs";
 import {
@@ -236,13 +238,18 @@ function createInstrumentedDiscordGatewayService(config, report, observedEventsB
         onEvent(event);
       }, (status) => {
         const connected = status === "connected" || gateway.isConnected();
-        report.criteria.gatewayConnected = connected;
+        report.criteria.gatewayConnected = report.criteria.gatewayConnected || connected;
         report.diagnostics.discordHubAdapter.gatewayConnected = connected;
+        report.diagnostics.discordHubAdapter.gatewayEverConnected =
+          report.diagnostics.discordHubAdapter.gatewayEverConnected || connected;
         void persistReport("discord_gateway_status").catch(() => {});
         if (onStatusChange) onStatusChange(status);
       });
-      report.criteria.gatewayConnected = gateway.isConnected();
-      report.diagnostics.discordHubAdapter.gatewayConnected = gateway.isConnected();
+      const connected = gateway.isConnected();
+      report.criteria.gatewayConnected = report.criteria.gatewayConnected || connected;
+      report.diagnostics.discordHubAdapter.gatewayConnected = connected;
+      report.diagnostics.discordHubAdapter.gatewayEverConnected =
+        report.diagnostics.discordHubAdapter.gatewayEverConnected || connected;
     },
     async disconnect() {
       await gateway.disconnect();
@@ -300,10 +307,12 @@ function initialReport(config, reportPath) {
       rejectCandidateSeeded: false,
       approveCandidateSeeded: false,
       rejectInboundObserved: false,
+      rejectOutboundAckDelivered: false,
       rejectAckDelivered: false,
       rejectCandidateStatusRejected: false,
       rejectDidNotSaveWorkflow: false,
       approveInboundObserved: false,
+      approveOutboundAckDelivered: false,
       approveAckDelivered: false,
       approveCandidateStatusApproved: false,
       approveSavedWorkflow: false,
@@ -314,6 +323,7 @@ function initialReport(config, reportPath) {
       proofSource: "instrumented_hub_discord_gateway_plus_seeded_reflex_candidates",
       discordHubAdapter: {
         gatewayConnected: false,
+        gatewayEverConnected: false,
         messageCreateCount: 0,
         messageEventCount: 0,
         staleMessageEventCount: 0,
@@ -321,6 +331,7 @@ function initialReport(config, reportPath) {
         lastMessageCreate: null,
         matchedMessageCreate: null,
       },
+      channelOutboundDeliveries: [],
       cleanupFailures: [],
       llmBridgeBoundary: "stubbed_to_bypass_live_llm_workflow_save_via_real_crud_only",
     },
@@ -328,12 +339,16 @@ function initialReport(config, reportPath) {
     rejectFlow: {
       candidateIdTail: null,
       candidateStatusReached: null,
+      outboundAckDelivered: false,
+      outboundAckMessageIdTail: null,
       ackDelivered: false,
       workflowSavedAfter: false,
     },
     approveFlow: {
       candidateIdTail: null,
       candidateStatusReached: null,
+      outboundAckDelivered: false,
+      outboundAckMessageIdTail: null,
       ackDelivered: false,
       workflowSaved: false,
       workflowIdTail: null,
@@ -375,6 +390,7 @@ async function main() {
   let stateDir = "";
   const observedEventsByMessageId = new Map();
   const approvedSlot = { workflowId: null, workflowVersionId: null };
+  let channelSendObserver = null;
 
   try {
     const missingEnv = missingRequiredEnv(config);
@@ -423,12 +439,16 @@ async function main() {
       allowedUsers: [config.setupUserId],
       allowedChats: [config.channelId],
     });
+    channelSendObserver = observeChannelOutboundAcks(hub, report, persistReport);
     await hub.start();
 
     const discordView = hub.channelRegistry.describe("discord");
     report.criteria.fridayHubChannelConnected = discordView?.status === "connected" && discordView?.running === true;
-    report.criteria.gatewayConnected = instrumentedGateway.isConnected();
-    report.diagnostics.discordHubAdapter.gatewayConnected = instrumentedGateway.isConnected();
+    const gatewayConnected = instrumentedGateway.isConnected();
+    report.criteria.gatewayConnected = report.criteria.gatewayConnected || gatewayConnected;
+    report.diagnostics.discordHubAdapter.gatewayConnected = gatewayConnected;
+    report.diagnostics.discordHubAdapter.gatewayEverConnected =
+      report.diagnostics.discordHubAdapter.gatewayEverConnected || gatewayConnected;
     const allowlistSummary = discordView?.allowlist;
     report.criteria.channelAllowListEnforced =
       allowlistSummary?.hasAllowedUsers === true
@@ -478,11 +498,24 @@ async function main() {
     console.log(approveText);
 
     const perFlowTimeout = Math.max(60_000, Math.floor(config.timeoutMs / 2));
-    const rejectAck = await waitForCandidateAck(baseUrl, "discord", config.channelId, rejectCandidateId, "rejected", perFlowTimeout);
+    const rejectOutboundAck = await waitForObservedChannelAck(channelSendObserver, rejectCandidateId, "rejected", perFlowTimeout);
+    if (!rejectOutboundAck) {
+      report.status = "blocked";
+      report.blocker = "PHASE24F_WAITING_FOR_REJECT_OUTBOUND_ACK";
+      report.failures.push(`Reject outbound ack for candidate ${tail(rejectCandidateId)} not delivered within ${perFlowTimeout}ms`);
+      await writeReport(report, config.botToken);
+      process.exitCode = 2;
+      return;
+    }
+    report.criteria.rejectOutboundAckDelivered = true;
+    report.rejectFlow.outboundAckDelivered = true;
+    report.rejectFlow.outboundAckMessageIdTail = rejectOutboundAck.messageIdTail;
+
+    const rejectAck = await waitForCandidateAck(baseUrl, "discord", config.channelId, rejectCandidateId, "rejected", Math.min(60_000, perFlowTimeout));
     if (!rejectAck) {
       report.status = "blocked";
-      report.blocker = "PHASE24F_WAITING_FOR_REJECT_ACK";
-      report.failures.push(`Reject ack for candidate ${tail(rejectCandidateId)} not observed within ${perFlowTimeout}ms`);
+      report.blocker = "PHASE24F_REJECT_ACK_SESSION_MIRROR_MISSING";
+      report.failures.push(`Reject ack for candidate ${tail(rejectCandidateId)} reached real Discord outbound but was not mirrored into the session oracle`);
       await writeReport(report, config.botToken);
       process.exitCode = 2;
       return;
@@ -513,11 +546,24 @@ async function main() {
       return;
     }
 
-    const approveAck = await waitForCandidateAck(baseUrl, "discord", config.channelId, approveCandidateId, "approved", perFlowTimeout);
+    const approveOutboundAck = await waitForObservedChannelAck(channelSendObserver, approveCandidateId, "approved", perFlowTimeout);
+    if (!approveOutboundAck) {
+      report.status = "blocked";
+      report.blocker = "PHASE24F_WAITING_FOR_APPROVE_OUTBOUND_ACK";
+      report.failures.push(`Approve outbound ack for candidate ${tail(approveCandidateId)} not delivered within ${perFlowTimeout}ms`);
+      await writeReport(report, config.botToken);
+      process.exitCode = 2;
+      return;
+    }
+    report.criteria.approveOutboundAckDelivered = true;
+    report.approveFlow.outboundAckDelivered = true;
+    report.approveFlow.outboundAckMessageIdTail = approveOutboundAck.messageIdTail;
+
+    const approveAck = await waitForCandidateAck(baseUrl, "discord", config.channelId, approveCandidateId, "approved", Math.min(60_000, perFlowTimeout));
     if (!approveAck) {
       report.status = "blocked";
-      report.blocker = "PHASE24F_WAITING_FOR_APPROVE_ACK";
-      report.failures.push(`Approve ack for candidate ${tail(approveCandidateId)} not observed within ${perFlowTimeout}ms`);
+      report.blocker = "PHASE24F_APPROVE_ACK_SESSION_MIRROR_MISSING";
+      report.failures.push(`Approve ack for candidate ${tail(approveCandidateId)} reached real Discord outbound but was not mirrored into the session oracle`);
       await writeReport(report, config.botToken);
       process.exitCode = 2;
       return;
@@ -546,10 +592,12 @@ async function main() {
       "rejectCandidateSeeded",
       "approveCandidateSeeded",
       "rejectInboundObserved",
+      "rejectOutboundAckDelivered",
       "rejectAckDelivered",
       "rejectCandidateStatusRejected",
       "rejectDidNotSaveWorkflow",
       "approveInboundObserved",
+      "approveOutboundAckDelivered",
       "approveAckDelivered",
       "approveCandidateStatusApproved",
       "approveSavedWorkflow",
@@ -572,6 +620,7 @@ async function main() {
     process.exitCode = 1;
   } finally {
     const cleanupFailures = [];
+    channelSendObserver?.restore();
     if (server) {
       await withTimeout(server.close(), 5_000, "http_server_close").catch((error) => {
         cleanupFailures.push(safeError(error, config?.botToken ?? ""));

--- a/scripts/ops/phase24g-lark-feishu-workflow-candidate-listener.mjs
+++ b/scripts/ops/phase24g-lark-feishu-workflow-candidate-listener.mjs
@@ -22,10 +22,12 @@ import {
   findFreePort,
   installWorkflowApprovalStub,
   listWorkflowsByTag,
+  observeChannelOutboundAcks,
   seedWorkflowCandidates,
   tail,
   withTimeout,
   waitForCandidateAck,
+  waitForObservedChannelAck,
   waitForCandidateStatus,
 } from "./lib/workflow-candidate-proof-harness.mjs";
 import {
@@ -274,6 +276,7 @@ function instrumentLarkFeishuPlugin(plugin, config, report, observedEventsByMess
       await originalLifecycle.connect(wrappedOnEvent);
       report.criteria.wsClientConnected = true;
       report.diagnostics.larkFeishuHubAdapter.wsClientConnected = true;
+      report.diagnostics.larkFeishuHubAdapter.wsClientEverConnected = true;
     },
     async disconnect() {
       await originalLifecycle.disconnect();
@@ -341,10 +344,12 @@ function initialReport(config, reportPath) {
       rejectCandidateSeeded: false,
       approveCandidateSeeded: false,
       rejectInboundObserved: false,
+      rejectOutboundAckDelivered: false,
       rejectAckDelivered: false,
       rejectCandidateStatusRejected: false,
       rejectDidNotSaveWorkflow: false,
       approveInboundObserved: false,
+      approveOutboundAckDelivered: false,
       approveAckDelivered: false,
       approveCandidateStatusApproved: false,
       approveSavedWorkflow: false,
@@ -358,6 +363,7 @@ function initialReport(config, reportPath) {
       larkFeishuHubAdapter: {
         platformBrand: config.platformBrand,
         wsClientConnected: false,
+        wsClientEverConnected: false,
         eventCount: 0,
         messageEventCount: 0,
         staleMessageEventCount: 0,
@@ -365,6 +371,7 @@ function initialReport(config, reportPath) {
         lastEvent: null,
         matchedEvent: null,
       },
+      channelOutboundDeliveries: [],
       cleanupFailures: [],
       llmBridgeBoundary: "stubbed_to_bypass_live_llm_workflow_save_via_real_crud_only",
     },
@@ -372,12 +379,16 @@ function initialReport(config, reportPath) {
     rejectFlow: {
       candidateIdTail: null,
       candidateStatusReached: null,
+      outboundAckDelivered: false,
+      outboundAckMessageIdTail: null,
       ackDelivered: false,
       workflowSavedAfter: false,
     },
     approveFlow: {
       candidateIdTail: null,
       candidateStatusReached: null,
+      outboundAckDelivered: false,
+      outboundAckMessageIdTail: null,
       ackDelivered: false,
       workflowSaved: false,
       workflowIdTail: null,
@@ -406,6 +417,12 @@ async function main() {
   let stateDir = "";
   const observedEventsByMessageId = new Map();
   const approvedSlot = { workflowId: null, workflowVersionId: null };
+  let channelSendObserver = null;
+  const persistReport = async (reason) => {
+    report.diagnostics.lastReportUpdateReason = reason;
+    report.diagnostics.lastReportUpdatedAt = new Date().toISOString();
+    await writeReport(report, config.appSecret);
+  };
 
   try {
     const missingEnv = missingRequiredEnv(config);
@@ -459,6 +476,7 @@ async function main() {
       allowedUsers: [config.allowedUserId],
       allowedChats: [config.chatId],
     });
+    channelSendObserver = observeChannelOutboundAcks(hub, report, persistReport);
     await hub.start();
 
     const larkView = hub.channelRegistry.describe(config.platformBrand);
@@ -512,11 +530,24 @@ async function main() {
     console.log(approveText);
 
     const perFlowTimeout = Math.max(60_000, Math.floor(config.timeoutMs / 2));
-    const rejectAck = await waitForCandidateAck(baseUrl, config.platformBrand, config.chatId, rejectCandidateId, "rejected", perFlowTimeout);
+    const rejectOutboundAck = await waitForObservedChannelAck(channelSendObserver, rejectCandidateId, "rejected", perFlowTimeout);
+    if (!rejectOutboundAck) {
+      report.status = "blocked";
+      report.blocker = "PHASE24G_WAITING_FOR_REJECT_OUTBOUND_ACK";
+      report.failures.push(`Reject outbound ack for candidate ${tail(rejectCandidateId)} not delivered within ${perFlowTimeout}ms`);
+      await writeReport(report, config.appSecret);
+      process.exitCode = 2;
+      return;
+    }
+    report.criteria.rejectOutboundAckDelivered = true;
+    report.rejectFlow.outboundAckDelivered = true;
+    report.rejectFlow.outboundAckMessageIdTail = rejectOutboundAck.messageIdTail;
+
+    const rejectAck = await waitForCandidateAck(baseUrl, config.platformBrand, config.chatId, rejectCandidateId, "rejected", Math.min(60_000, perFlowTimeout));
     if (!rejectAck) {
       report.status = "blocked";
-      report.blocker = "PHASE24G_WAITING_FOR_REJECT_ACK";
-      report.failures.push(`Reject ack for candidate ${tail(rejectCandidateId)} not observed within ${perFlowTimeout}ms`);
+      report.blocker = "PHASE24G_REJECT_ACK_SESSION_MIRROR_MISSING";
+      report.failures.push(`Reject ack for candidate ${tail(rejectCandidateId)} reached real ${config.platformDisplayName} outbound but was not mirrored into the session oracle`);
       await writeReport(report, config.appSecret);
       process.exitCode = 2;
       return;
@@ -543,11 +574,24 @@ async function main() {
       return;
     }
 
-    const approveAck = await waitForCandidateAck(baseUrl, config.platformBrand, config.chatId, approveCandidateId, "approved", perFlowTimeout);
+    const approveOutboundAck = await waitForObservedChannelAck(channelSendObserver, approveCandidateId, "approved", perFlowTimeout);
+    if (!approveOutboundAck) {
+      report.status = "blocked";
+      report.blocker = "PHASE24G_WAITING_FOR_APPROVE_OUTBOUND_ACK";
+      report.failures.push(`Approve outbound ack for candidate ${tail(approveCandidateId)} not delivered within ${perFlowTimeout}ms`);
+      await writeReport(report, config.appSecret);
+      process.exitCode = 2;
+      return;
+    }
+    report.criteria.approveOutboundAckDelivered = true;
+    report.approveFlow.outboundAckDelivered = true;
+    report.approveFlow.outboundAckMessageIdTail = approveOutboundAck.messageIdTail;
+
+    const approveAck = await waitForCandidateAck(baseUrl, config.platformBrand, config.chatId, approveCandidateId, "approved", Math.min(60_000, perFlowTimeout));
     if (!approveAck) {
       report.status = "blocked";
-      report.blocker = "PHASE24G_WAITING_FOR_APPROVE_ACK";
-      report.failures.push(`Approve ack for candidate ${tail(approveCandidateId)} not observed within ${perFlowTimeout}ms`);
+      report.blocker = "PHASE24G_APPROVE_ACK_SESSION_MIRROR_MISSING";
+      report.failures.push(`Approve ack for candidate ${tail(approveCandidateId)} reached real ${config.platformDisplayName} outbound but was not mirrored into the session oracle`);
       await writeReport(report, config.appSecret);
       process.exitCode = 2;
       return;
@@ -575,10 +619,12 @@ async function main() {
       "rejectCandidateSeeded",
       "approveCandidateSeeded",
       "rejectInboundObserved",
+      "rejectOutboundAckDelivered",
       "rejectAckDelivered",
       "rejectCandidateStatusRejected",
       "rejectDidNotSaveWorkflow",
       "approveInboundObserved",
+      "approveOutboundAckDelivered",
       "approveAckDelivered",
       "approveCandidateStatusApproved",
       "approveSavedWorkflow",
@@ -601,6 +647,7 @@ async function main() {
     process.exitCode = 1;
   } finally {
     const cleanupFailures = [];
+    channelSendObserver?.restore();
     if (server) {
       await withTimeout(server.close(), 5_000, "http_server_close").catch((error) => {
         cleanupFailures.push(safeError(error, config?.appSecret ?? ""));

--- a/test/unit/scripts/ops/lib/workflow-candidate-proof-harness.test.ts
+++ b/test/unit/scripts/ops/lib/workflow-candidate-proof-harness.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import * as path from "node:path";
+import { pathToFileURL } from "node:url";
+
+type WorkflowHarnessModule = typeof import("../../../../../scripts/ops/lib/workflow-candidate-proof-harness.mjs");
+
+const harnessUrl = pathToFileURL(
+  path.resolve(__dirname, "../../../../../scripts/ops/lib/workflow-candidate-proof-harness.mjs"),
+).href;
+
+async function loadHarness(): Promise<WorkflowHarnessModule> {
+  return (await import(harnessUrl)) as WorkflowHarnessModule;
+}
+
+describe("workflow-candidate proof harness outbound ack observer", () => {
+  it("records real channelRegistry.send delivery evidence for candidate acks", async () => {
+    const { observeChannelOutboundAcks, waitForObservedChannelAck } = await loadHarness();
+    const report = { diagnostics: {} as Record<string, unknown> };
+    const persisted: string[] = [];
+    const hub = {
+      channelRegistry: {
+        async send(kind: string, options: { chatId: string; text: string; replyTo?: string }) {
+          return { messageId: `msg-${kind}-${options.chatId}` };
+        },
+      },
+    };
+
+    const observer = observeChannelOutboundAcks(hub, report, async (reason: string) => {
+      persisted.push(reason);
+    });
+
+    await hub.channelRegistry.send("discord", {
+      chatId: "chat-abcdef12",
+      replyTo: "source-12345678",
+      text: "Reflex candidate candidate-123 已更新为 approved。",
+    });
+
+    const ack = await waitForObservedChannelAck(observer, "candidate-123", "approved", 100);
+
+    expect(ack).toMatchObject({
+      kind: "discord",
+      chatIdTail: "abcdef12",
+      replyToMessageIdTail: "12345678",
+      messageIdTail: "abcdef12",
+      reflexCandidateAck: true,
+    });
+    expect(report.diagnostics.channelOutboundDeliveries).toEqual([ack]);
+    expect(persisted).toEqual(["channel_outbound_delivery"]);
+
+    observer.restore();
+    await hub.channelRegistry.send("discord", {
+      chatId: "chat-second",
+      text: "Reflex candidate candidate-456 已更新为 rejected。",
+    });
+    expect(observer.deliveries).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary\n- add a Phase24 workflow-candidate harness observer for real channelRegistry outbound ack deliveries\n- require Discord and Lark/Feishu workflow candidate proof artifacts to distinguish real outbound ack delivery from TS session mirror ack\n- latch gateway/ws connection criteria so cleanup disconnects do not rewrite terminal proof criteria\n- add a focused unit test for the outbound ack observer\n\n## Verification\n- node --check scripts/ops/lib/workflow-candidate-proof-harness.mjs\n- node --check scripts/ops/phase24f-discord-workflow-candidate-listener.mjs\n- node --check scripts/ops/phase24g-lark-feishu-workflow-candidate-listener.mjs\n- npm run build:api\n- npx vitest run test/unit/scripts/ops/lib/workflow-candidate-proof-harness.test.ts test/unit/hub/friday-hub-bootstrap.test.ts -t "workflow-candidate proof harness outbound ack observer|workflow Reflex candidates"\n\n## Truth label\nThis does not mark Phase24 F/G passed. It improves the proof harness so the next live run reports whether the real channel outbound ack, session mirror ack, candidate state, or workflow CRUD leg is the failing link.