### PR TITLE
fix(ops): snapshot Phase24 reject invariants before mirror

### DIFF
--- a/scripts/ops/phase24f-discord-workflow-candidate-listener.mjs
+++ b/scripts/ops/phase24f-discord-workflow-candidate-listener.mjs
@@ -511,19 +511,6 @@ async function main() {
     report.rejectFlow.outboundAckDelivered = true;
     report.rejectFlow.outboundAckMessageIdTail = rejectOutboundAck.messageIdTail;
 
-    const rejectAck = await waitForCandidateAck(baseUrl, "discord", config.channelId, rejectCandidateId, "rejected", Math.min(60_000, perFlowTimeout));
-    if (rejectAck) {
-      report.criteria.rejectAckDelivered = true;
-      report.rejectFlow.ackDelivered = true;
-    } else {
-      report.rejectFlow.ackDelivered = false;
-      report.diagnostics.sessionMirrorWarnings = [
-        ...(report.diagnostics.sessionMirrorWarnings ?? []),
-        `Reject ack for candidate ${tail(rejectCandidateId)} reached real Discord outbound but was not mirrored into the session oracle`,
-      ];
-      await persistReport("reject_ack_session_mirror_missing_non_blocking");
-    }
-
     const rejectCandidate = await waitForCandidateStatus(stateDir, rejectCandidateId, "rejected", 30_000);
     report.rejectFlow.candidateStatusReached = rejectCandidate?.status ?? null;
     report.criteria.rejectCandidateStatusRejected = rejectCandidate?.status === "rejected";
@@ -536,7 +523,7 @@ async function main() {
     report.criteria.requireMentionSatisfied = !config.requireMention || Boolean(
       [...observedEventsByMessageId.values()].find((entry) => entry?.inspection?.mentionMatched),
     );
-    await persistReport("reject_flow_verified");
+    await persistReport("reject_flow_invariants_snapshotted");
 
     if (!report.criteria.rejectCandidateStatusRejected || !report.criteria.rejectDidNotSaveWorkflow) {
       report.status = "failed";
@@ -545,6 +532,19 @@ async function main() {
       await writeReport(report, config.botToken);
       process.exitCode = 1;
       return;
+    }
+
+    const rejectAck = await waitForCandidateAck(baseUrl, "discord", config.channelId, rejectCandidateId, "rejected", Math.min(60_000, perFlowTimeout));
+    if (rejectAck) {
+      report.criteria.rejectAckDelivered = true;
+      report.rejectFlow.ackDelivered = true;
+    } else {
+      report.rejectFlow.ackDelivered = false;
+      report.diagnostics.sessionMirrorWarnings = [
+        ...(report.diagnostics.sessionMirrorWarnings ?? []),
+        `Reject ack for candidate ${tail(rejectCandidateId)} reached real Discord outbound but was not mirrored into the session oracle`,
+      ];
+      await persistReport("reject_ack_session_mirror_missing_non_blocking");
     }
 
     const approveOutboundAck = await waitForObservedChannelAck(channelSendObserver, approveCandidateId, "approved", perFlowTimeout);

--- a/scripts/ops/phase24g-lark-feishu-workflow-candidate-listener.mjs
+++ b/scripts/ops/phase24g-lark-feishu-workflow-candidate-listener.mjs
@@ -543,6 +543,26 @@ async function main() {
     report.rejectFlow.outboundAckDelivered = true;
     report.rejectFlow.outboundAckMessageIdTail = rejectOutboundAck.messageIdTail;
 
+    const rejectCandidate = await waitForCandidateStatus(stateDir, rejectCandidateId, "rejected", 30_000);
+    report.rejectFlow.candidateStatusReached = rejectCandidate?.status ?? null;
+    report.criteria.rejectCandidateStatusRejected = rejectCandidate?.status === "rejected";
+    const workflowsAfterReject = listWorkflowsByTag(hub, WORKFLOW_TAG);
+    report.criteria.rejectDidNotSaveWorkflow = workflowsAfterReject.length === 0;
+    report.rejectFlow.workflowSavedAfter = workflowsAfterReject.length > 0;
+    report.criteria.rejectInboundObserved = Boolean(
+      [...observedEventsByMessageId.values()].find((entry) => entry?.inspection?.containsRejectCommand),
+    );
+    await persistReport("reject_flow_invariants_snapshotted");
+
+    if (!report.criteria.rejectCandidateStatusRejected || !report.criteria.rejectDidNotSaveWorkflow) {
+      report.status = "failed";
+      report.blocker = "PHASE24G_REJECT_PATH_INVARIANTS_BROKEN";
+      report.failures.push("Reject path did not satisfy invariants (status=rejected AND no workflow saved)");
+      await writeReport(report, config.appSecret);
+      process.exitCode = 1;
+      return;
+    }
+
     const rejectAck = await waitForCandidateAck(baseUrl, config.platformBrand, config.chatId, rejectCandidateId, "rejected", Math.min(60_000, perFlowTimeout));
     if (rejectAck) {
       report.criteria.rejectAckDelivered = true;
@@ -554,25 +574,6 @@ async function main() {
         `Reject ack for candidate ${tail(rejectCandidateId)} reached real ${config.platformDisplayName} outbound but was not mirrored into the session oracle`,
       ];
       await persistReport("reject_ack_session_mirror_missing_non_blocking");
-    }
-
-    const rejectCandidate = await waitForCandidateStatus(stateDir, rejectCandidateId, "rejected", 30_000);
-    report.rejectFlow.candidateStatusReached = rejectCandidate?.status ?? null;
-    report.criteria.rejectCandidateStatusRejected = rejectCandidate?.status === "rejected";
-    const workflowsAfterReject = listWorkflowsByTag(hub, WORKFLOW_TAG);
-    report.criteria.rejectDidNotSaveWorkflow = workflowsAfterReject.length === 0;
-    report.rejectFlow.workflowSavedAfter = workflowsAfterReject.length > 0;
-    report.criteria.rejectInboundObserved = Boolean(
-      [...observedEventsByMessageId.values()].find((entry) => entry?.inspection?.containsRejectCommand),
-    );
-
-    if (!report.criteria.rejectCandidateStatusRejected || !report.criteria.rejectDidNotSaveWorkflow) {
-      report.status = "failed";
-      report.blocker = "PHASE24G_REJECT_PATH_INVARIANTS_BROKEN";
-      report.failures.push("Reject path did not satisfy invariants (status=rejected AND no workflow saved)");
-      await writeReport(report, config.appSecret);
-      process.exitCode = 1;
-      return;
     }
 
     const approveOutboundAck = await waitForObservedChannelAck(channelSendObserver, approveCandidateId, "approved", perFlowTimeout);

--- a/test/unit/scripts/ops/phase24f-discord-workflow-candidate.test.ts
+++ b/test/unit/scripts/ops/phase24f-discord-workflow-candidate.test.ts
@@ -193,6 +193,9 @@ describe("phase24f Discord workflow-candidate listener exports", () => {
     expect(source).not.toContain("PHASE24F_REJECT_ACK_SESSION_MIRROR_MISSING");
     expect(source).not.toContain("PHASE24F_APPROVE_ACK_SESSION_MIRROR_MISSING");
     expect(source).toContain("sessionMirrorWarnings");
+    expect(source.indexOf("const workflowsAfterReject = listWorkflowsByTag")).toBeLessThan(
+      source.indexOf("const rejectAck = await waitForCandidateAck"),
+    );
 
     const requiredCriteria = source.slice(
       source.indexOf("const requiredCriteria = ["),

--- a/test/unit/scripts/ops/phase24g-lark-feishu-workflow-candidate.test.ts
+++ b/test/unit/scripts/ops/phase24g-lark-feishu-workflow-candidate.test.ts
@@ -199,6 +199,9 @@ describe("phase24g Lark/Feishu workflow-candidate listener exports", () => {
     expect(source).not.toContain("PHASE24G_REJECT_ACK_SESSION_MIRROR_MISSING");
     expect(source).not.toContain("PHASE24G_APPROVE_ACK_SESSION_MIRROR_MISSING");
     expect(source).toContain("sessionMirrorWarnings");
+    expect(source.indexOf("const workflowsAfterReject = listWorkflowsByTag")).toBeLessThan(
+      source.indexOf("const rejectAck = await waitForCandidateAck"),
+    );
 
     const requiredCriteria = source.slice(
       source.indexOf("const requiredCriteria = ["),


### PR DESCRIPTION
## Summary\n- snapshot Phase24 F/G reject candidate status and no-save invariant immediately after real reject outbound ack\n- keep TS session mirror as diagnostic-only after that invariant snapshot\n- add source-order guard tests so fast approve messages cannot poison reject no-save proof\n\n## Verification\n- node --check scripts/ops/phase24f-discord-workflow-candidate-listener.mjs\n- node --check scripts/ops/phase24g-lark-feishu-workflow-candidate-listener.mjs\n- npx vitest run test/unit/scripts/ops/phase24f-discord-workflow-candidate.test.ts test/unit/scripts/ops/phase24g-lark-feishu-workflow-candidate.test.ts\n- npm run build:api\n\nTruth: this does not weaken Phase24 gates. Real trusted inbound, real outbound ack, candidate state, reject no-save, approve CRUD save, and token-free artifact remain required.